### PR TITLE
CR-1126396 xbtop output does not look correct

### DIFF
--- a/src/runtime_src/core/common/info_memory.cpp
+++ b/src/runtime_src/core/common/info_memory.cpp
@@ -468,7 +468,7 @@ scheduler_update_stat(const xrt_core::device *device)
     // lock xclbin
     std::string xclbin_uuid = xrt_core::device_query<xq::xclbin_uuid>(dev);
     // dont open a context if xclbin_uuid is empty
-    if(xclbin_uuid.empty())
+    if(xq::xclbin_uuid::is_empty(xclbin_uuid))
       return;
     auto uuid = xrt::uuid(xclbin_uuid);
     dev->open_context(uuid.get(), std::numeric_limits<unsigned int>::max(), true);

--- a/src/runtime_src/core/common/info_memory.cpp
+++ b/src/runtime_src/core/common/info_memory.cpp
@@ -467,8 +467,8 @@ scheduler_update_stat(const xrt_core::device *device)
   try {
     // lock xclbin
     std::string xclbin_uuid = xrt_core::device_query<xq::xclbin_uuid>(dev);
-    // dont open a context if xclbin_uuid is empty
-    if(xq::xclbin_uuid::is_empty(xclbin_uuid))
+    // dont open a context if xclbin_uuid is empty or is all zeros
+    if (xclbin_uuid.empty() || !xrt::uuid(xclbin_uuid))
       return;
     auto uuid = xrt::uuid(xclbin_uuid);
     dev->open_context(uuid.get(), std::numeric_limits<unsigned int>::max(), true);

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -29,6 +29,7 @@
 #include <stdexcept>
 #include <boost/any.hpp>
 #include <boost/format.hpp>
+#include <boost/algorithm/string.hpp>
 
 struct debug_ip_data;
 
@@ -698,6 +699,12 @@ struct xclbin_uuid : request
 
   virtual boost::any
   get(const device*) const = 0;
+  
+  static bool
+  is_empty(const std::string& uuid) 
+  {
+    return (boost::equals(uuid, "00000000-0000-0000-0000-000000000000") || boost::equals(uuid, ""));
+  }
 };
 
 // dtbo_path is unique path used by libdfx library to load bitstream and device tree

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -699,12 +699,6 @@ struct xclbin_uuid : request
 
   virtual boost::any
   get(const device*) const = 0;
-  
-  static bool
-  is_empty(const std::string& uuid) 
-  {
-    return (boost::equals(uuid, "00000000-0000-0000-0000-000000000000") || boost::equals(uuid, ""));
-  }
 };
 
 // dtbo_path is unique path used by libdfx library to load bitstream and device tree

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -29,7 +29,6 @@
 #include <stdexcept>
 #include <boost/any.hpp>
 #include <boost/format.hpp>
-#include <boost/algorithm/string.hpp>
 
 struct debug_ip_data;
 

--- a/src/runtime_src/core/tools/xbtop/ReportDynamicRegions.py
+++ b/src/runtime_src/core/tools/xbtop/ReportDynamicRegions.py
@@ -15,19 +15,17 @@ import pyxrt
 
 
 class ReportDynamicRegions:
-    def __init__(self, max_report_length):
-        self.report_page_length = max_report_length
-
     def report_name(self):
         return "Dynamic Region"
 
-    def update(self, dev):
+    def update(self, dev, report_length):
+        self.report_length = report_length
         #get cu info
         cu_json = dev.get_info(pyxrt.xrt_info_device.dynamic_regions)
         cu_raw = json.loads(cu_json) #read into a dictionary
 
         # Round up the division to leave an extra page for the last batch of data
-        page_count_temp = math.ceil(len(cu_raw) / self.report_page_length)
+        page_count_temp = math.ceil(len(cu_raw) / self.report_length)
         # We must ensure that we always have at least one page
         self.page_count = max(page_count_temp, 1)
 
@@ -58,10 +56,10 @@ class ReportDynamicRegions:
             return table_offset + 1
 
         # Each page should display however many items a report page can hold
-        for i in range(self.report_page_length):
+        for i in range(self.report_length):
             line = []
             # The current element to be parsed depends on what page has been requested
-            index = i + (page * self.report_page_length)
+            index = i + (page * self.report_length)
             # Ensure that our index does not exceed the input data size. This may happen on the last page
             if(index < len(cus)):
                 line.append(str(index))

--- a/src/runtime_src/core/tools/xbtop/ReportMemory.py
+++ b/src/runtime_src/core/tools/xbtop/ReportMemory.py
@@ -123,7 +123,7 @@ class ReportMemory:
                 
                 size = int(memory['range_bytes'], 16)
                 if size == 0 or memory['enabled'] == "false":
-                    line.append("N/A")
+                    line.append("--  ")
                 else:
                     usage = int(memory['extended_info']['usage']['allocated_bytes'], 0)
                     line.append(XBUtil.get_percentage(usage, size))

--- a/src/runtime_src/core/tools/xbtop/ReportMemory.py
+++ b/src/runtime_src/core/tools/xbtop/ReportMemory.py
@@ -48,19 +48,19 @@ class ReportMemory:
 
     def _print_memory_usage(self, term, lock, start_x, start_y, page):
         XBUtil.print_section_heading(term, lock, "Device Memory Usage", start_y)
-        table_offset = 1
+        offset = 1
 
         if self._df == None:
-            XBUtil.print_warning(term, lock, start_y + table_offset, "Data unavailable. Acceleration image not loaded")
-            return table_offset + 1
+            XBUtil.print_warning(term, lock, start_y + offset, "Data unavailable. Acceleration image not loaded")
+            return offset + 1
 
         data = []
         memories = []
         try:
             memories = self._df['board']['memory']['memories']
         except:
-            XBUtil.print_warning(term, lock, start_y + table_offset, "Data unavailable. Acceleration image not loaded")
-            return table_offset + 1
+            XBUtil.print_warning(term, lock, start_y + offset, "Data unavailable. Acceleration image not loaded")
+            return offset + 1
 
         for i in range(self.report_length):
             # The current element to be parsed depends on what page has been requested
@@ -78,31 +78,34 @@ class ReportMemory:
             # last page
             else:
                 break
-        
 
-        XBUtil.indented_print(term, lock, data, 3, start_y + table_offset)
-        table_offset += len(data)
-        return table_offset
+        if (not data):
+            XBUtil.print_warning(term, lock, start_y + offset, "Data unavailable")
+            return offset + 1
+
+        XBUtil.indented_print(term, lock, data, 3, start_y + offset)
+        offset += len(data)
+        return offset
 
     def _print_mem_topology(self, term, lock, start_x, start_y, page):
         XBUtil.print_section_heading(term, lock, "Memory Topology", start_y)
-        table_offset = 1
+        offset = 1
 
         if self._df == None:
-            print_warning(term, lock, start_y + table_offset, "Data unavailable. Acceleration image not loaded")
-            return table_offset + 1
-
-        try:
-            memories = self._df['board']['memory']['memories']
-        except:
-            XBUtil.print_warning(term, lock, start_y + table_offset, "Data unavailable. Acceleration image not loaded")
-            return table_offset + 1
+            print_warning(term, lock, start_y + offset, "Data unavailable. Acceleration image not loaded")
+            return offset + 1
 
         header = [     "",  "Tag", "Type", "Temp (C)",  "Size", "Mem Usage", "BO Count"]
         format = ["right", "left", "left",    "right", "right",     "right",    "right"]
         data = []
 
-        memories = self._df['board']['memory']['memories']
+        memories = []
+        try:
+            memories = self._df['board']['memory']['memories']
+        except:
+            XBUtil.print_warning(term, lock, start_y + offset, "Data unavailable. Acceleration image not loaded")
+            return offset + 1
+
         for i in range(self.report_length):
             line = []
             # The current data element to be parsed depends on what page has been requested
@@ -123,20 +126,24 @@ class ReportMemory:
             else:
                 break
 
+        if (not data):
+            XBUtil.print_warning(term, lock, start_y + offset, "Data unavailable")
+            return offset + 1
+
         table = XBUtil.Table(header, data, format)
         ascii_table = table.create_table()
 
-        XBUtil.indented_print(term, lock, ascii_table, 3, start_y + table_offset)
-        table_offset += len(ascii_table)
-        return table_offset
+        XBUtil.indented_print(term, lock, ascii_table, 3, start_y + offset)
+        offset += len(ascii_table)
+        return offset
 
     def _print_dma_transfer_metrics(self, term, lock, start_x, start_y, page):
         XBUtil.print_section_heading(term, lock, "DMA Transfer Metrics", start_y)
-        table_offset = 1
+        offset = 1
 
         if self._df == None:
-            print_warning(term, lock, start_y + table_offset, "Data unavailable. Acceleration image not loaded")
-            return table_offset + 1
+            print_warning(term, lock, start_y + offset, "Data unavailable. Acceleration image not loaded")
+            return offset + 1
 
         header = [     "", "Channel", "Host-to-Card", "Card-to-Host"]
         format = ["right",   "right",        "right",        "right"]
@@ -146,8 +153,8 @@ class ReportMemory:
         try:
             dma_metrics = self._df['board']['direct_memory_accesses']['metrics']
         except:
-            XBUtil.print_warning(term, lock, start_y + table_offset, "Data unavailable. Acceleration image not loaded")
-            return table_offset + 1
+            XBUtil.print_warning(term, lock, start_y + offset, "Data unavailable. Acceleration image not loaded")
+            return offset + 1
 
         for i in range(self.report_length):
             line = []
@@ -166,12 +173,16 @@ class ReportMemory:
             else:
                 break
 
+        if (not data):
+            XBUtil.print_warning(term, lock, start_y + offset, "Data unavailable")
+            return offset + 1
+
         table = XBUtil.Table(header, data, format)
         ascii_table = table.create_table()
 
-        XBUtil.indented_print(term, lock, ascii_table, 3, start_y + table_offset)
-        table_offset += len(ascii_table)
-        return table_offset
+        XBUtil.indented_print(term, lock, ascii_table, 3, start_y + offset)
+        offset += len(ascii_table)
+        return offset
 
     def print_report(self, term, lock, start_x, start_y, page):
         offset = 0
@@ -191,6 +202,6 @@ class ReportMemory:
         elif (page < self.usage_page_count + self.topology_page_count + self.dma_page_count):
             offset = 1 + self._print_dma_transfer_metrics(term, lock, start_x, start_y + offset, page - (self.usage_page_count + self.topology_page_count))
         else:
-            XBUtil.print_warning(term, lock, start_y + table_offset, "Something went wrong! Please report this issue and its conditions.")
+            XBUtil.print_warning(term, lock, start_y + offset, "Something went wrong! Please report this issue and its conditions.")
         return offset
 

--- a/src/runtime_src/core/tools/xbtop/ReportMemory.py
+++ b/src/runtime_src/core/tools/xbtop/ReportMemory.py
@@ -15,6 +15,9 @@ import pyxrt
 
 
 class ReportMemory:
+    # Python value used as second parameter for int() to convert hexadecimal strings into ints
+    hexadecimal_converion = 16
+
     def report_name(self):
         return "Memory"
 
@@ -69,7 +72,7 @@ class ReportMemory:
             # Ensure that our index does not exceed the input data size. This may happen on the last page
             if (index < len(memories)):
                 memory = memories[index]
-                size = int(memory['range_bytes'], 16)
+                size = int(memory['range_bytes'], self.hexadecimal_converion)
                 if size == 0 or memory['enabled'] == "false":
                     continue
                 name = memory['tag']
@@ -118,10 +121,10 @@ class ReportMemory:
                 line.append(memory['tag'])
                 line.append(memory['type'])
                 line.append(memory['extended_info']['temperature_C'] if 'temperature_C' in memory['extended_info'] else "--")
-                line.append(XBUtil.convert_size(int(memory['range_bytes'],16)))
+                line.append(XBUtil.convert_size(int(memory['range_bytes'], self.hexadecimal_converion)))
                 line.append(XBUtil.convert_size(int(memory['extended_info']['usage']['buffer_objects_count'],0)))
                 
-                size = int(memory['range_bytes'], 16)
+                size = int(memory['range_bytes'], self.hexadecimal_converion)
                 if size == 0 or memory['enabled'] == "false":
                     line.append("--  ")
                 else:
@@ -175,8 +178,8 @@ class ReportMemory:
                 dma_metric = dma_metrics[index]
                 line.append(str(i))
                 line.append(dma_metric['channel_id'])
-                line.append(XBUtil.convert_size(int(dma_metric['host_to_card_bytes'], 16)))
-                line.append(XBUtil.convert_size(int(dma_metric['card_to_host_bytes'], 16)))
+                line.append(XBUtil.convert_size(int(dma_metric['host_to_card_bytes'], self.hexadecimal_converion)))
+                line.append(XBUtil.convert_size(int(dma_metric['card_to_host_bytes'], self.hexadecimal_converion)))
                 data.append(line)
             # If the index exceeds the input data size leave the for loop as everything is populated on the
             # last page

--- a/src/runtime_src/core/tools/xbtop/ReportPower.py
+++ b/src/runtime_src/core/tools/xbtop/ReportPower.py
@@ -7,12 +7,16 @@
 #
 
 import json
+import math
 import XBUtil
 
 # found in PYTHONPATH
 import pyxrt
 
 class ReportPower:
+    def __init__(self, max_report_length):
+        self.report_length = max_report_length
+
     def report_name(self):
         return "Power"
 
@@ -24,7 +28,8 @@ class ReportPower:
         # check if xclbin is loaded
         if not electrical_raw:
             self._df.clear()
-            return
+            self.page_count = 0
+            return self.page_count
 
         # dict with all power entries
         power_status = {}
@@ -33,14 +38,20 @@ class ReportPower:
         power_status['Warning'] = electrical_raw['power_consumption_warning']
 
         self._df = power_status
+        self.page_count = 1
+        return self.page_count
 
-    def print_report(self, term, lock, start_x, start_y):
+    def print_report(self, term, lock, start_x, start_y, page):
         XBUtil.print_section_heading(term, lock, self.report_name(), start_y)
         offset = 1
 
         if len(self._df) == 0:
             print_warning(term, lock, start_y + offset, "Data unavailable. Acceleration image not loaded")
-            return offset
+            return offset + 1
+
+        if (self.page_count == 0):
+            XBUtil.print_warning(term, lock, start_y + table_offset, "Data unavailable. Acceleration image not loaded")
+            return table_offset + 1
 
         power_buf=[
             'Power     : %s Watts' % self._df['Power'],

--- a/src/runtime_src/core/tools/xbtop/ReportPower.py
+++ b/src/runtime_src/core/tools/xbtop/ReportPower.py
@@ -14,13 +14,12 @@ import XBUtil
 import pyxrt
 
 class ReportPower:
-    def __init__(self, max_report_length):
-        self.report_page_length = max_report_length
 
     def report_name(self):
         return "Power"
 
-    def update(self, dev):
+    def update(self, dev, report_length):
+        self.report_length = report_length
         #get power info
         electrical_json = dev.get_info(pyxrt.xrt_info_device.electrical)
         electrical_raw = json.loads(electrical_json) #read into a dictionary
@@ -40,7 +39,7 @@ class ReportPower:
 
         self._df = power_status
         # Round up the division to leave an extra page for the last batch of data
-        page_count_temp = math.ceil(len(power_status) / self.report_page_length)
+        page_count_temp = math.ceil(len(power_status) / self.report_length)
         # We must ensure that we always have at least one page
         self.page_count = max(page_count_temp, 1)
         return self.page_count
@@ -65,9 +64,9 @@ class ReportPower:
             ]
 
         # Extract the data elements to be displayed on the requested page
-        page_offset = page * self.report_page_length
+        page_offset = page * self.report_length
         # The upper offset is bounded by the size of the full power buffer
-        upper_page_offset = min(self.report_page_length + page_offset, len(all_data))
+        upper_page_offset = min(self.report_length + page_offset, len(all_data))
         data=all_data[page_offset:upper_page_offset]
 
         if (not data):

--- a/src/runtime_src/core/tools/xbtop/ReportPower.py
+++ b/src/runtime_src/core/tools/xbtop/ReportPower.py
@@ -58,7 +58,7 @@ class ReportPower:
             return offset + 1
 
         # Create the complete power buffer
-        power_buf_total=[
+        all_data=[
             'Power     : %s Watts' % self._df['Power'],
             'Max Power : %s Watts' % self._df['Max Power'],
             'Warning   : %s' % self._df['Warning']
@@ -67,9 +67,13 @@ class ReportPower:
         # Extract the data elements to be displayed on the requested page
         page_offset = page * self.report_page_length
         # The upper offset is bounded by the size of the full power buffer
-        upper_page_offset = min(self.report_page_length + page_offset, len(power_buf_total))
-        power_buf=power_buf_total[page_offset:upper_page_offset]
+        upper_page_offset = min(self.report_page_length + page_offset, len(all_data))
+        data=all_data[page_offset:upper_page_offset]
 
-        XBUtil.indented_print(term, lock, power_buf, 3, start_y + offset)
-        offset += len(power_buf)
+        if (not data):
+            XBUtil.print_warning(term, lock, start_y + offset, "Data unavailable")
+            return offset + 1
+
+        XBUtil.indented_print(term, lock, data, 3, start_y + offset)
+        offset += len(data)
         return offset

--- a/src/runtime_src/core/tools/xbtop/XBUtil.py
+++ b/src/runtime_src/core/tools/xbtop/XBUtil.py
@@ -135,6 +135,14 @@ def pad_string(padded_string, padding_width, alignment):
 
     return padded_string
 
+def get_percentage(usage, size):
+    if usage == 0:
+        return "0 %"
+
+    percent = usage * 100 / size
+
+    return "%.2f %" % percent
+
 def convert_size(size_bytes):
     if size_bytes == 0:
         return "0  B"

--- a/src/runtime_src/core/tools/xbtop/xbtop.py
+++ b/src/runtime_src/core/tools/xbtop/xbtop.py
@@ -97,10 +97,11 @@ def print_header(term, lock, dev, report_header, page_header, len_x):
     page_header = XBUtil.pad_string(page_header, padding_width, "center")
 
     with lock:
-        center_align = int((len_x - len(page_header)) / 2)
-
+        center_align = int((len_x - len(report_header)) / 2)
         term.location(center_align, 2)
         print(XBUtil.fg.blue + XBUtil.fx.bold + XBUtil.fx.italic + report_header + XBUtil.fx.reset)
+
+        center_align = int((len_x - len(page_header)) / 2)
         term.location(center_align, 3)
         print(XBUtil.fg.blue + XBUtil.fx.bold + XBUtil.fx.italic + page_header + XBUtil.fx.reset)
 
@@ -114,7 +115,7 @@ def running_reports(term, lock, dev, x_len, y_len):
 
     report_length = 0
     report_start_row = 10
-    report_end_row = 10 # From bottom
+    report_end_row = 10 # Number of lines above bottom of terminal. Must leave room for footer!
     num_lines_printed = 0
     current_report = -1
     current_page = -1

--- a/src/runtime_src/core/tools/xbtop/xbtop.py
+++ b/src/runtime_src/core/tools/xbtop/xbtop.py
@@ -35,11 +35,11 @@ from ReportPower import ReportPower
 from ReportMemory import ReportMemory
 from ReportDynamicRegions import ReportDynamicRegions
 
-MAX_REPORT_NUMBER = 10
+MAX_REPORT_PAGE_LENGTH = 10
 g_reports = []
-g_reports.append(ReportMemory(MAX_REPORT_NUMBER))
-g_reports.append(ReportDynamicRegions(MAX_REPORT_NUMBER))
-g_reports.append(ReportPower(MAX_REPORT_NUMBER))
+g_reports.append(ReportMemory(MAX_REPORT_PAGE_LENGTH))
+g_reports.append(ReportDynamicRegions(MAX_REPORT_PAGE_LENGTH))
+g_reports.append(ReportPower(MAX_REPORT_PAGE_LENGTH))
 
 
 # Running clock thread (upper left corner)

--- a/src/runtime_src/core/tools/xbtop/xbtop.py
+++ b/src/runtime_src/core/tools/xbtop/xbtop.py
@@ -68,7 +68,7 @@ def running_counter(term, lock, len_x):
 def print_footer(term, lock, y_len):
     footer_buf = [
         XBUtil.fg.yellow + "'p'/'n' - Previous/Next Report" + XBUtil.fg.reset,
-        XBUtil.fg.yellow + "'<'/'>' - Previous/Next Report Page" + XBUtil.fg.reset,
+        XBUtil.fg.yellow + "'<'/'>' - Dec/Inc Page" + XBUtil.fg.reset,
         XBUtil.fg.yellow + "    'q' - Quit" + XBUtil.fg.reset
     ]
     XBUtil.indented_print(term, lock, footer_buf, 5, y_len - len(footer_buf))

--- a/src/runtime_src/core/tools/xbtop/xbtop.py
+++ b/src/runtime_src/core/tools/xbtop/xbtop.py
@@ -156,7 +156,7 @@ def running_reports(term, lock, dev, x_len, y_len):
             print_header(term, lock, dev, report_header, page_header, x_len)
         # Just update the report if no changes have occurred
         else:
-            page_count = g_reports[current_report].update(dev)
+            page_count = g_reports[current_report].update(dev, report_length)
 
         # Clear the previous reports
         XBUtil.clear_rows(term, lock, report_start_row, num_lines_printed)
@@ -228,7 +228,7 @@ def main():
         t1.start()
 
         # Running reports
-        t2 = threading.Thread(target=running_reports, args=(term, lock, dev, x_len))
+        t2 = threading.Thread(target=running_reports, args=(term, lock, dev, x_len, y_len))
         t2.daemon = True
         t2.start()
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1126396
When xbtop is running for a u55c board, the output looks keep rolling and most data is not visible

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Discovered on cards that have a large memory bank to display after running a validation test

#### How problem was solved, alternative solutions (if any) and why they were rejected
The problem was solved by splitting up the data displays onto multiple pages the users can go through. The memory report was consolidated into two internal reports rather than three.

#### Risks (if any) associated the changes in the commit
Risk of data not being presented properly using xbtop if an unexpected case appears. Possible crashes in these scenarios as well. Resizing the window does not dynamically reprint data, the program must be stopped and restarted.

#### What has been tested and how, request additional testing if necessary
Remory report pages:
![image](https://user-images.githubusercontent.com/94083344/160451033-e5e27be0-591a-4cea-8fcb-16a10c42b74f.png)
![image](https://user-images.githubusercontent.com/94083344/160451089-e05dc516-11c1-49bc-abdd-c27c74f34c75.png)
![image](https://user-images.githubusercontent.com/94083344/160451125-87b9b89a-f6cc-42b2-8cd2-c6b8990245c1.png)
Resized terminal window:
![image](https://user-images.githubusercontent.com/94083344/160451237-64f31bd4-90b1-4eb9-a80b-fdfcb886b4df.png)
Report with single page:
![image](https://user-images.githubusercontent.com/94083344/160451728-7816f39f-9320-4297-8532-91f19ab18954.png)
Report with no xclbin loaded:
![image](https://user-images.githubusercontent.com/94083344/160693926-bc24e636-ed5f-4407-ae8b-27b340de0efb.png)
![image](https://user-images.githubusercontent.com/94083344/160693974-990acd1c-276e-4c1b-bea3-f4f7b9df93f4.png)
![image](https://user-images.githubusercontent.com/94083344/160694018-22b28dd9-5446-4b56-a070-e5223e84635d.png)
Updated memory utilization to have percentages:
![image](https://user-images.githubusercontent.com/94083344/160695084-90ac27d9-e2fa-49aa-98b1-19a7cc8aeb4c.png)

#### Documentation impact (if any)
None, unless we would like to document the paging feature.