### PR TITLE
CR-1126286 Inform of caveats in advance of SC flashing

### DIFF
--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -720,10 +720,10 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
     ("device,d", boost::program_options::value<decltype(device)>(&device)->multitoken(), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest.")
     ("shell,s", boost::program_options::value<decltype(plp)>(&plp), "The partition to be loaded.  Valid values:\n"
                                                                       "  Name (and path) of the partition.")
-    ("base,b", boost::program_options::value<decltype(update)>(&update)->implicit_value("all"), "Update the persistent images and/or the Satellite controller (SC) firmware image.  Value values:\n"
+    ("base,b", boost::program_options::value<decltype(update)>(&update)->implicit_value("all"), "Update the persistent images and/or the Satellite controller (SC) firmware image.  Valid values:\n"
                                                                          "  ALL   - All images will be updated\n"
                                                                          "  SHELL - Platform image\n"
-                                                                         "  SC    - Satellite controller\n"
+                                                                         "  SC    - Satellite controller (Warning: Damage could occur to the device)\n"
                                                                          "  NO-BACKUP   - Backup boot remains unchanged")
     ("user,u", boost::program_options::value<decltype(xclbin)>(&xclbin), "The xclbin to be loaded.  Valid values:\n"
                                                                       "  Name (and path) of the xclbin.")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1126286
While the SC is being flashed a warning message is displayed and seeing this for the first time while the command is running will make a user nervous.

This is a stop-gap PR to add additional information to the help menu while the fix for the xball issue described in the CR will be fixed for 2022.2

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added new text to help menus

#### Risks (if any) associated the changes in the commit
None, just adding text

#### What has been tested and how, request additional testing if necessary
Help Menu
```
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbmgmt program --help

DESCRIPTION: Updates the image(s) for a given device.

USAGE: xbmgmt program [--revert-to-golden] [--help] [-d arg] [-s arg] [-b arg] [-u arg] [--image arg]

OPTIONS:
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest.
  -s, --shell        - The partition to be loaded.  Valid values:
                         Name (and path) of the partition.
  -b, --base         - Update the persistent images and/or the Satellite controller (SC) firmware
                       image.  Valid values:
                         ALL   - All images will be updated
                         SHELL - Platform image
                         SC    - Satellite controller (Warning: Damage could occur to the device)
                         NO-BACKUP   - Backup boot remains unchanged
  -u, --user         - The xclbin to be loaded.  Valid values:
                         Name (and path) of the xclbin.
  --image            - Specifies an image to use used to update the persistent device.  Valid
                       values:
                         Name (and path) to the mcs image on disk
                         Name (and path) to the xsabin image on disk
  --revert-to-golden - Resets the FPGA PROM back to the factory image. Note: The Satellite
                       Controller will not be reverted for a golden image does not exist.
  --help             - Help to use this sub-command


GLOBAL OPTIONS:
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
```

#### Documentation impact (if any)
We could add the `sc` or `shell` options to the documentation. Not sure if that is the direction we would like to go with as those options are used in house more often than not (from what I understand). Please let me know your thoughts!