### PR TITLE
fixed typo in the example command line (#6500)

### DIFF
--- a/src/runtime_src/doc/toc/xrt_native_apis.rst
+++ b/src/runtime_src/doc/toc/xrt_native_apis.rst
@@ -17,7 +17,7 @@ Example g++ command
 
 .. code-block:: shell
 
-    g++ -g -std=c++14 -I$XILINX_XRT/include -L$XILINX_XRT/lib -o host.exe host.cpp -lxrt_coreutil -pthread
+    g++ -g -std=c++17 -I$XILINX_XRT/include -L$XILINX_XRT/lib -o host.exe host.cpp -lxrt_coreutil -pthread
 
 
 The XRT native API supports both the C and C++ flavor of APIs. For general host code development, C++-based APIs are recommended, hence this document only describes the C++-based API interfaces. The full Doxygen generated C and C++ API documentation can be found in :doc: `xrt_native.main`.


### PR DESCRIPTION
fixed typo in the example command line, cpp14 --> cpp17

(cherry picked from commit 6fcd904e14af072b8899d801c72343f941132391)

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
