### PR TITLE
xclmgmt: reload hwmon_sdm sensors list during reset sequence

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-utils.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-utils.c
@@ -1,5 +1,5 @@
 /**
- *  Copyright (C) 2017 Xilinx, Inc. All rights reserved.
+ *  Copyright (C) 2017-2022 Xilinx, Inc. All rights reserved.
  *
  *  Utility Functions for sysmon, axi firewall and other peripherals.
  *  Author: Umang Parekh
@@ -370,6 +370,8 @@ long xclmgmt_hot_reset(struct xclmgmt_dev *lro, bool force)
 			"Please warm reboot");
 		return -EIO;
 	}
+
+	(void) xocl_hwmon_sdm_get_sensors_list(lro, true);
 
 	/* Workaround for some DSAs. Flush axilite busses */
 	if (dev_info->flags & XOCL_DSAFLAG_AXILITE_FLUSH)


### PR DESCRIPTION
Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
xbutil examine reports null values after reset. With this PR, able to see expected values after reset.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Sensor readings after reset.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added changes in XRT driver

#### Risks (if any) associated the changes in the commit
NA
#### What has been tested and how, request additional testing if necessary
xbutil & xbmgmt examine reports before and after reset.

#### Documentation impact (if any)
NA