### PR TITLE
Fix calculation of frequency value in setting aie clock frequency

### DIFF
--- a/src/runtime_src/core/tools/common/ReportBOStats.cpp
+++ b/src/runtime_src/core/tools/common/ReportBOStats.cpp
@@ -95,7 +95,7 @@ ReportBOStats::getPropertyTree20202( const xrt_core::device * pDevice,
     } else {
       std::string mem_used(bo_info[1]);
       mem_used.pop_back();
-      auto mem_used_bytes = XBUtilities::string_to_bytes(mem_used);
+      auto mem_used_bytes = XBUtilities::string_to_base_units(mem_used, XBUtilities::unit::bytes);
       mem_used.pop_back();
       bo_pt.put("buffer_type", bo_info[0].substr(1, bo_info[0].length()-2));
       bo_pt.put("buffer_count", bo_info[2].substr(0, bo_info[2].length()-3));

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -510,7 +510,7 @@ XBUtilities::string_to_base_units(std::string str, const unit& conversion_unit)
     case unit::bytes :
       factor = 1024;
       break;
-    case unit::hertz :
+    case unit::Hertz :
       factor = 1000;
       break;
     default :

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -498,12 +498,24 @@ XBUtilities::parse_clock_id(const std::string& id)
 }
 
 uint64_t
-XBUtilities::string_to_bytes(std::string str)
+XBUtilities::string_to_base_units(std::string str, const unit& conversion_unit)
 {
   boost::algorithm::trim(str);
 
   if(str.empty())
     throw xrt_core::error(std::errc::invalid_argument);
+
+  int factor;
+  switch(conversion_unit) {
+    case unit::bytes :
+      factor = 1024;
+      break;
+    case unit::hertz :
+      factor = 1000;
+      break;
+    default :
+      throw xrt_core::error(std::errc::invalid_argument);
+  }
 
   std::string units = "B";
   if(std::isalpha(str.back())) {
@@ -511,16 +523,16 @@ XBUtilities::string_to_bytes(std::string str)
     str.pop_back();
   }
 
-  uint64_t unit_bytes = 0;
+  uint64_t unit_value = 0;
   boost::to_upper(units);
   if(units.compare("B") == 0)
-    unit_bytes = 1;
+    unit_value = 1;
   else if(units.compare("K") == 0)
-    unit_bytes = 1024;
+    unit_value = factor;
   else if(units.compare("M") == 0)
-    unit_bytes = 1024*1024;
+    unit_value = factor * factor;
   else if(units.compare("G") == 0)
-    unit_bytes = 1024*1024*1024;
+    unit_value = factor * factor * factor;
   else
     throw xrt_core::error(std::errc::invalid_argument);
 
@@ -534,7 +546,7 @@ XBUtilities::string_to_bytes(std::string str)
     throw xrt_core::error(std::errc::invalid_argument);
   }
 
-  size *= unit_bytes;
+  size *= unit_value;
   return size;
 }
 

--- a/src/runtime_src/core/tools/common/XBUtilities.h
+++ b/src/runtime_src/core/tools/common/XBUtilities.h
@@ -90,7 +90,7 @@ namespace XBUtilities {
   enum class unit
   {
     bytes,
-    hertz
+    Hertz
   };
   uint64_t
   string_to_base_units(std::string str, const unit& conversion_unit);

--- a/src/runtime_src/core/tools/common/XBUtilities.h
+++ b/src/runtime_src/core/tools/common/XBUtilities.h
@@ -87,8 +87,13 @@ namespace XBUtilities {
   std::string
   string_to_UUID(std::string str);
 
-  uint64_t 
-  string_to_bytes(std::string str);
+  enum class unit
+  {
+    bytes,
+    hertz
+  };
+  uint64_t
+  string_to_base_units(std::string str, const unit& conversion_unit);
 
   inline bool 
   is_power_of_2(const uint64_t x)

--- a/src/runtime_src/core/tools/xbutil2/OO_AieClockFreq.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_AieClockFreq.cpp
@@ -65,7 +65,7 @@ set_aie_part_freq(const std::shared_ptr<xrt_core::device>& device, uint32_t part
   uint64_t freq = 0;
   try {
     //convert freq to hertz(Hz)
-    freq = XBUtilities::string_to_base_units(setFreq, XBUtilities::unit::hertz);
+    freq = XBUtilities::string_to_base_units(setFreq, XBUtilities::unit::Hertz);
   }
   catch(const xrt_core::error&) {
     std::cerr << "Freq value provided with 'set' option is invalid. Please specify proper units and rerun" << std::endl;

--- a/src/runtime_src/core/tools/xbutil2/OO_AieClockFreq.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_AieClockFreq.cpp
@@ -65,7 +65,7 @@ set_aie_part_freq(const std::shared_ptr<xrt_core::device>& device, uint32_t part
   uint64_t freq = 0;
   try {
     //convert freq to hertz(Hz)
-    freq = XBUtilities::string_to_bytes(setFreq);
+    freq = XBUtilities::string_to_base_units(setFreq, XBUtilities::unit::hertz);
   }
   catch(const xrt_core::error&) {
     std::cerr << "Freq value provided with 'set' option is invalid. Please specify proper units and rerun" << std::endl;

--- a/src/runtime_src/core/tools/xbutil2/OO_HostMem.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_HostMem.cpp
@@ -103,7 +103,7 @@ OO_HostMem::execute(const SubCmdOptions& _options) const
   uint64_t size = 0;
   try {
     if(!m_size.empty())
-      size = XBUtilities::string_to_bytes(m_size);
+      size = XBUtilities::string_to_base_units(m_size, XBUtilities::unit::bytes);
   } 
   catch(const xrt_core::error&) {
     std::cerr << "Value supplied to --size option is invalid. Please specify a memory size between 4M and 1G." << std::endl;

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -999,7 +999,7 @@ dmaTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree::ptr
     if (xrt_core::device_query<xrt_core::query::pcie_vendor>(_dev) == ARISTA_ID)
       totalSize = 0x20000000; // 512 MB 
     else
-      totalSize = std::min((mem.m_size * 1024), XBU::string_to_bytes("2G")); // minimum of mem size in bytes and 2 GB
+      totalSize = std::min((mem.m_size * 1024), XBU::string_to_base_units("2G", XBUtilities::unit::bytes)); // minimum of mem size in bytes and 2 GB
 
     xcldev::DMARunner runner(_dev->get_device_handle(), block_size, static_cast<unsigned int>(midx), totalSize);
     try {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
When aie clock freq is set using xbutil we pass a string value (eg: 100M), earlier string_to_bytes is used for calculation which uses 1024 as conversion factor. Modified string_to_bytes function to convert frequency as well.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://github.com/Xilinx/XRT/pull/6272 introduced this bug

#### How problem was solved, alternative solutions (if any) and why they were rejected
Fixed frequency calculation by using correct conversion factor

#### Risks (if any) associated the changes in the commit
NA

#### What has been tested and how, request additional testing if necessary
Tested setting aie clock frequency on vck190 board and behavior is as expected

#### Documentation impact (if any)
NA