### PR TITLE
CR-1127440 : Vitis execution environment on CentOX 7.x has older version of readelf

### DIFF
--- a/src/runtime_src/tools/xclbinutil/ElfUtilities.cxx
+++ b/src/runtime_src/tools/xclbinutil/ElfUtilities.cxx
@@ -23,6 +23,7 @@
 #include <boost/algorithm/string/split.hpp>
 #include <boost/format.hpp>
 #include <boost/version.hpp>
+#include <cstdlib>
 
 #if (BOOST_VERSION >= 106400)
   #include <boost/process/search_path.hpp>
@@ -30,6 +31,60 @@
 
 
 namespace XUtil = XclBinUtilities;
+
+static
+auto findExecutablePath(const std::string &executable)
+{
+  boost::filesystem::path executablePath;
+
+#if 0                       // Only enabled for the Vitis version of xclbinutil
+  // -- Check to see if XILINX_VITIS has been set
+  const auto xilinxVitisEnv = std::getenv("XILINX_VITIS");
+  
+  if (xilinxVitisEnv != nullptr) {
+    executablePath = xilinxVitisEnv;
+    executablePath = executablePath / "aietools" / "tps" / "lnx64" / "gcc" / "bin" / executable;
+    XUtil::TRACE("Step 1: Looking for executable at: '" + executablePath.string() + "'");
+    if (!boost::filesystem::exists(executablePath)) {
+      executablePath = "";           // Executable doesn't exist
+      XUtil::TRACE("Not found");
+    }
+  }
+#endif
+
+#if (BOOST_VERSION >= 106400)
+  // -- Check the path
+  if (executablePath.string().empty()) {
+    XUtil::TRACE("Step 2: Looking for executable path");
+    executablePath = boost::process::search_path(executable);
+    if (!boost::filesystem::exists(executablePath)) 
+      XUtil::TRACE("Not found");
+
+  }
+#endif
+ 
+  // -- Check /usr/bin
+  if (executablePath.string().empty()) {
+    executablePath = boost::filesystem::path("usr") / "bin" / executable;
+    XUtil::TRACE("Step 3: Looking for executable at: '" + executablePath.string() + "'");
+    if (!boost::filesystem::exists(executablePath)) {
+      executablePath = "";           // Executable doesn't exist
+      XUtil::TRACE("Not found");
+    }
+  }
+
+  if (executablePath.string().empty()) {
+    auto errMsg = boost::format("Error: Could not find the helper executable: '%s'\n"
+                                "       In either the path or '/usr/bin'\n. ")
+                                % executablePath.string();
+    throw std::runtime_error(errMsg.str());
+  }
+
+  XUtil::TRACE("Found executable: '" + executablePath.string() + "'");
+  
+  
+  return executablePath;
+}
 
 static std::vector<std::string>
 dataMineExportedFunctionsObjdump(const std::string& elfLibrary)
@@ -48,18 +103,7 @@ dataMineExportedFunctionsObjdump(const std::string& elfLibrary)
 {
 
   // Call objdump to get the collection of functions
-  boost::filesystem::path objdumpPath = "/usr/bin/objdump";    // Assume it is in a known location
-
-#if (BOOST_VERSION >= 106400)
-  objdumpPath = boost::process::search_path("objdump");
-
-  const std::string expectedObjdumpPath = "/usr/bin/objdump";
-
-  if (objdumpPath.string() != expectedObjdumpPath)
-    std::cout << boost::format("Warning: Unexpected objdump path.\n"
-                               "         Expected: %s\n"
-                               "           Actual: %s\n") % expectedObjdumpPath % objdumpPath.string();
-#endif
+  const auto objdumpPath = findExecutablePath("objdump");
 
   const std::vector<std::string> cmdOptions = { "--wide", "--section=.text", "-T", "-C", elfLibrary };
   std::ostringstream os_stdout;
@@ -199,6 +243,7 @@ enum_DW_TAG_to_string(enum DW_TAG eTag)
 static std::string
 get_DW_AT_value(const std::string& entry, const std::string& tag)
 //    <434>   DW_AT_name        : (indirect string, offset: 0xa7): nullptr_t
+//    <c8d>   DW_AT_name        : (strp) (offset: 0x3e4): kernel0_fini
 {
   // If the tag is not found return an empty string
   if (entry.find(tag) == std::string::npos)
@@ -218,16 +263,81 @@ get_DW_AT_value(const std::string& entry, const std::string& tag)
 }
 
 static void 
-if_exist_add_DW_AT(const std::string& entry,
-                   const std::string& tag,
-                   boost::property_tree::ptree& pt)
+if_exist_add_DW_AT_byte_size(const std::string& entry,
+                             boost::property_tree::ptree& pt)
+//    <6f9>   DW_AT_byte_size   : 8
+//    <d51>   DW_AT_byte_size   : (data1) 8
 {
+  const auto tag = "DW_AT_byte_size";
   const auto& tagValue = get_DW_AT_value(entry, tag);
   if (tagValue.empty())
     return;
 
-  pt.put(tag, tagValue);
+  // Find the byte size value
+  auto byteSizeValue  = tagValue;
+  size_t valueIndex = tagValue.find_last_of(" ");
+  if (valueIndex != std::string::npos) 
+    byteSizeValue = tagValue.substr(valueIndex);
+
+  boost::algorithm::trim(byteSizeValue);
+  pt.put(tag, byteSizeValue);
 }
+
+static void 
+if_exist_add_DW_AT_type(const std::string& entry,
+                        boost::property_tree::ptree& pt)
+//    <cbf>   DW_AT_type        : <0xc73>
+//    <d52>   DW_AT_type        : (ref4) <0x55f>, float
+{
+  const auto tag = "DW_AT_type";
+  const auto& tagValue = get_DW_AT_value(entry, tag);
+  if (tagValue.empty())
+    return;
+
+  // Find the byte size value
+  size_t startIndex = tagValue.find("<");
+  size_t endIndex = tagValue.find(">");
+  size_t copyLength = (1 + endIndex) - startIndex;  // Include the end index character
+
+  auto typeValue = tagValue.substr(startIndex, copyLength);
+  boost::algorithm::trim(typeValue);
+
+  pt.put(tag, typeValue);
+}
+
+static void
+remove_helper_comment(std::string & tagValue) {
+  size_t startIndex = tagValue.find("(");
+  size_t endIndex = tagValue.find(")");
+  if ((startIndex != std::string::npos) && (endIndex != std::string::npos)) {
+    size_t eraseLength = (sizeof(")") + endIndex) - startIndex;
+    tagValue.erase(startIndex, eraseLength);
+  }
+}
+
+static void 
+if_exist_add_DW_AT_name(const std::string& entry,
+                        boost::property_tree::ptree& pt)
+//    <cc4>   DW_AT_name        : (indirect string, offset: 0x5ee): kernel0
+//    <cc4>   DW_AT_name        : (strp) (offset: 0x5ee): kernel0
+{
+  const auto tag = "DW_AT_name";
+  const auto& tagValue = get_DW_AT_value(entry, tag);
+  if (tagValue.empty())
+    return;
+
+  // Get the last value after the colon
+  const std::string searchString = ":";
+  size_t valueIndex = entry.find_last_of(searchString);
+  auto nameValue = entry.substr(valueIndex + searchString.size());
+
+  // Post clean-up
+  remove_helper_comment(nameValue);
+  boost::algorithm::trim(nameValue);
+
+  pt.put(tag, nameValue);
+}
+
 
 static unsigned long 
 get_tag_offset(const std::string& entry)
@@ -250,6 +360,10 @@ add_DWTAG_pointerType(size_t& index,
 // <1><6f8>: Abbrev Number: 37 (DW_TAG_pointer_type)
 //    <6f9>   DW_AT_byte_size   : 8
 //    <6fa>   DW_AT_type        : <0x6db>
+
+// <1><d50>: Abbrev Number: 37 (DW_TAG_pointer_type)
+//    <d51>   DW_AT_byte_size   : (data1) 8
+//    <d52>   DW_AT_type        : (ref4) <0x55f>, float
 {
   const auto offset = get_tag_offset(dwarfEntries[index]);
 
@@ -260,8 +374,8 @@ add_DWTAG_pointerType(size_t& index,
   while ((++index < dwarfEntries.size()) &&
          (!isTag(dwarfEntries[index]))) {
     const auto& entry = dwarfEntries[index];
-    if_exist_add_DW_AT(entry, "DW_AT_byte_size", ptDWTAG);
-    if_exist_add_DW_AT(entry, "DW_AT_type", ptDWTAG);
+    if_exist_add_DW_AT_byte_size(entry, ptDWTAG);
+    if_exist_add_DW_AT_type(entry, ptDWTAG);
   }
   argTags.emplace_back(offset, ptDWTAG);
 }
@@ -283,8 +397,8 @@ add_DWTAG_referenceType(size_t& index,
   while ((++index < dwarfEntries.size()) &&
          (!isTag(dwarfEntries[index]))) {
     const auto& entry = dwarfEntries[index];
-    if_exist_add_DW_AT(entry, "DW_AT_byte_size", ptDWTAG);
-    if_exist_add_DW_AT(entry, "DW_AT_type", ptDWTAG);
+    if_exist_add_DW_AT_byte_size(entry, ptDWTAG);
+    if_exist_add_DW_AT_type(entry, ptDWTAG);
   }
   argTags.emplace_back(offset, ptDWTAG);
 }
@@ -308,8 +422,8 @@ add_DWTAG_typedef(size_t& index,
   while ((++index < dwarfEntries.size()) &&
          (!isTag(dwarfEntries[index]))) {
     const auto& entry = dwarfEntries[index];
-    if_exist_add_DW_AT(entry, "DW_AT_name", ptDWTAG);
-    if_exist_add_DW_AT(entry, "DW_AT_type", ptDWTAG);
+    if_exist_add_DW_AT_name(entry, ptDWTAG);
+    if_exist_add_DW_AT_type(entry, ptDWTAG);
   }
   argTags.emplace_back(offset, ptDWTAG);
 }
@@ -332,9 +446,10 @@ add_DWTAG_base_type(size_t& index,
   while ((++index < dwarfEntries.size()) &&
          (!isTag(dwarfEntries[index]))) {
     const auto& entry = dwarfEntries[index];
-    if_exist_add_DW_AT(entry, "DW_AT_name", ptDWTAG);
-    if_exist_add_DW_AT(entry, "DW_AT_byte_size", ptDWTAG);
+    if_exist_add_DW_AT_name(entry, ptDWTAG);
+    if_exist_add_DW_AT_byte_size(entry, ptDWTAG);
   }
+
   argTags.emplace_back(offset, ptDWTAG);
 }
 
@@ -357,7 +472,7 @@ add_DWTAG_class_type(size_t& index,
   while ((++index < dwarfEntries.size()) &&
          (!isTag(dwarfEntries[index]))) {
     const auto& entry = dwarfEntries[index];
-    if_exist_add_DW_AT(entry, "DW_AT_name", ptDWTAG);
+    if_exist_add_DW_AT_name(entry, ptDWTAG);
   }
   argTags.emplace_back(offset, ptDWTAG);
 }
@@ -380,7 +495,7 @@ add_DWTAG_const_type(size_t& index,
   // Examine the DWTAG entries up either the end of the list or the next DWTAG
   while ((++index < dwarfEntries.size()) &&
          (!isTag(dwarfEntries[index]))) {
-    if_exist_add_DW_AT(dwarfEntries[index], "DW_AT_type", ptDWTAG);
+    if_exist_add_DW_AT_type(dwarfEntries[index], ptDWTAG);
   }
   argTags.emplace_back(offset, ptDWTAG);
 }
@@ -406,7 +521,7 @@ add_DWTAG_structure_type(size_t& index,
   while ((++index < dwarfEntries.size()) &&
          (!isTag(dwarfEntries[index]))) {
     const auto& entry = dwarfEntries[index];
-    if_exist_add_DW_AT(entry, "DW_AT_name", ptDWTAG);
+    if_exist_add_DW_AT_name(entry, ptDWTAG);
   }
   argTags.emplace_back(offset, ptDWTAG);
 }
@@ -416,16 +531,26 @@ static const boost::property_tree::ptree&
 get_dw_type(const std::string& typeOffset, 
             const AbbrevCollection& argTags)
 // <0xcc3>
+// (ref4) <0xcbd>, xrtHandles
 {
-  size_t posOffset = typeOffset.find("<0x") == std::string::npos ? 0 : 3;
-  unsigned long offset = readHexString(typeOffset, posOffset);
+  // -- Get the hex string
+  size_t startIndex = typeOffset.find("<");
+  size_t endIndex = typeOffset.find(">");
+  size_t copyLength = (1 + endIndex) - startIndex;  // Include the end index character
+
+  auto offsetValue = typeOffset.substr(startIndex, copyLength);
+  boost::algorithm::trim(offsetValue);
+
+  // -- Parse the hex string
+  size_t posOffset = offsetValue.find("<0x") == std::string::npos ? 0 : 3;
+  unsigned long offset = readHexString(offsetValue, posOffset);
 
   auto it = std::find_if(argTags.begin(), argTags.end(),
                          [&offset](const std::pair<unsigned long, boost::property_tree::ptree>& element) {return element.first == offset;});
 
   const static boost::property_tree::ptree ptEmpty;
   if (it == argTags.end()) {
-    XUtil::TRACE("Argument tag not found for: '" + typeOffset + "'");
+    XUtil::TRACE("Argument tag offset '" + offsetValue + "' not found for: '" + typeOffset + "'");
     return ptEmpty;
   }
 
@@ -502,8 +627,12 @@ add_formal_parameter(size_t& index,
          (!isTag(dwarfEntries[index]))) {
     const auto& entry = dwarfEntries[index];
 
-    if (entry.find("DW_AT_name") != std::string::npos)
-      ptArgument.put("name", get_DW_AT_value(entry, "DW_AT_name"));
+    if (entry.find("DW_AT_name") != std::string::npos) {
+      auto nameValue = get_DW_AT_value(entry, "DW_AT_name");
+      remove_helper_comment(nameValue);
+      boost::algorithm::trim(nameValue);
+      ptArgument.put("name", nameValue);
+    }
 
     if (entry.find("DW_AT_type") != std::string::npos)
       evaluate_DW_TAG_type(get_DW_AT_value(entry, "DW_AT_type"), argTags, ptArgument);
@@ -552,6 +681,24 @@ add_DWTAG_subprogram(size_t& index,
 //    <cb9>   DW_AT_decl_line   : 26
 //    <cba>   DW_AT_type        : <0xcc3>
 //    <cbe>   DW_AT_location    : 0x0 (location list)
+
+// <1><cc3>: Abbrev Number: 64 (DW_TAG_subprogram)
+//    <cc4>   DW_AT_external    : (flag_present) 1
+//    <cc4>   DW_AT_name        : (strp) (offset: 0x5ee): kernel0
+//    <cc8>   DW_AT_decl_file   : (data1) 1
+//    <cc9>   DW_AT_decl_line   : (data1) 20
+//    <cca>   DW_AT_type        : (ref4) <0x592>, int
+//    <cce>   DW_AT_low_pc      : (addr) 0x788
+//    <cd6>   DW_AT_high_pc     : (data8) 0x8
+//    <cde>   DW_AT_frame_base  : (exprloc) 1 byte block: 9c 	(DW_OP_call_frame_cfa)
+//    <ce0>   DW_AT_GNU_all_call_sites: (flag_present) 1
+//    <ce0>   DW_AT_sibling     : (ref4) <0xd50>
+// <2><ce4>: Abbrev Number: 66 (DW_TAG_formal_parameter)
+//    <ce5>   DW_AT_name        : (string) inA
+//    <ce9>   DW_AT_decl_file   : (data1) 1
+//    <cea>   DW_AT_decl_line   : (data1) 20
+//    <ceb>   DW_AT_type        : (ref4) <0xd50>, float
+
 {
   // -- Get function metadata
   boost::property_tree::ptree ptFunction;
@@ -702,18 +849,7 @@ dataMineExportedFunctionsReadElf(const std::string& elfLibrary,
                                  std::vector<std::string>& dwarfEntries)
 {
   // Call readelf to get the collection of functions
-  boost::filesystem::path readElfPath = "/usr/bin/readelf";    // Assume it is in a known location
-
-#if (BOOST_VERSION >= 106400)
-  readElfPath = boost::process::search_path("readelf");
-
-  const std::string expectedReadElfPath = "/usr/bin/readelf";
-
-  if (readElfPath.string() != expectedReadElfPath)
-    std::cout << boost::format("Warning: Unexpected readelf path.\n"
-                               "         Expected: %s\n"
-                               "           Actual: %s\n") % expectedReadElfPath % readElfPath.string();
-#endif
+  const auto readElfPath = findExecutablePath("readelf"); 
 
   const std::vector<std::string> cmdOptions = { "--wide", "-wi", elfLibrary };
   std::ostringstream os_stdout;

--- a/src/runtime_src/tools/xclbinutil/unittests/PSKernel/PSKernel.py
+++ b/src/runtime_src/tools/xclbinutil/unittests/PSKernel/PSKernel.py
@@ -145,7 +145,8 @@ def main():
                      "--dump-section", "CONNECTIVITY:JSON:" + outputPSKConnectivity,
                      "--dump-section", "MEM_TOPOLOGY:JSON:" + outputPSKMemTopology,
                      "--output", outputOnlyPSKernelXclbin, 
-                     "--force"]
+                     "--force"
+                     ]
 
   execCmd(step, cmd)
 


### PR DESCRIPTION
#### Problem solved by the commit
Update xclbinutil to:
1. Use an alternate version of readelf.
2. Support more verbose readelf dumps.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
This issue has always been around.  The root issue is that Vitis delievers all of its own libraries and applications, where XRT uses the OS packager for installation of depended packages.

#### How problem was solved, alternative solutions (if any) and why they were rejected
The algorithm to discover the readelf application was updated to search in XILINX_VITIS home for the version of xclbinutil that is build for Vitis.

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
Manual and unit tests.
#### Documentation impact (if any)
