### PR TITLE
CR-1127445 Flash secondary flash image also if available

### DIFF
--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -429,8 +429,7 @@ update_shell(unsigned int boardIdx, DSAInfo& candidate, Flasher::E_FlasherType f
   boost::format programFmt("[%s] : %s...\n");
   std::cout << programFmt % flasher.sGetDBDF() % "Updating base (e.g., shell) flash image";
   std::map<std::string, std::string> validated_image = {{"primary", candidate.file}};
-  std::unique_ptr<firmwareImage> sec;
-  sec = std::make_unique<firmwareImage>(candidate.file, MCS_FIRMWARE_SECONDARY);
+  std::unique_ptr<firmwareImage> sec = std::make_unique<firmwareImage>(candidate.file, MCS_FIRMWARE_SECONDARY);
   if (sec->good())
     validated_image["secondary"] = candidate.file;
 

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -429,6 +429,11 @@ update_shell(unsigned int boardIdx, DSAInfo& candidate, Flasher::E_FlasherType f
   boost::format programFmt("[%s] : %s...\n");
   std::cout << programFmt % flasher.sGetDBDF() % "Updating base (e.g., shell) flash image";
   std::map<std::string, std::string> validated_image = {{"primary", candidate.file}};
+  std::unique_ptr<firmwareImage> sec;
+  sec = std::make_unique<firmwareImage>(candidate.file, MCS_FIRMWARE_SECONDARY);
+  if (sec->good())
+    validated_image["secondary"] = candidate.file;
+
   update_shell(boardIdx, validated_image, flash_type);
   return true;
 }


### PR DESCRIPTION
Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
U.2 card has two flashes whereas all other Alveo has only one flash. But, xbmgmt program is flashing only one flash on U2, hence the issue.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1127445 will be fixed with this PR.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added changes in XRT to consider secondary flash image also if available.

#### Risks (if any) associated the changes in the commit
NA
#### What has been tested and how, request additional testing if necessary
Flashing on u2 and u250

#### Documentation impact (if any)
NA