### PR TITLE
CR-1126325 Parsing device_process.log and displaying end_of_simulation message

### DIFF
--- a/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/shim.h
@@ -160,6 +160,8 @@ namespace xclcpuemhal2 {
       int xclOpenContext(uint32_t slot, const uuid_t xclbinId, const char* cuname, bool shared) const;
       int xclExecWait(int timeoutMilliSec);
       int xclExecBuf(unsigned int cmdBO);
+      std::vector<std::string> parsedMsgs;
+      int parseLog();
       int xclCloseContext(const uuid_t xclbinId, unsigned int ipIndex) const;
       //Get CU index from IP_LAYOUT section for corresponding kernel name
       int xclIPName2Index(const char *name);
@@ -325,6 +327,7 @@ namespace xclcpuemhal2 {
       uint32_t getPerfMonByteScaleFactor(xclPerfMonType type);
       uint8_t  getPerfMonShowIDS(xclPerfMonType type);
       uint8_t  getPerfMonShowLEN(xclPerfMonType type);
+      void closemMessengerThread();
       size_t resetFifos(xclPerfMonType type);
       uint32_t bin2dec(std::string str, int start, int number);
       uint32_t bin2dec(const char * str, int start, int number);
@@ -341,6 +344,8 @@ namespace xclcpuemhal2 {
       std::vector<std::string> mTempdlopenfilenames;
       std::string deviceName;
       std::string deviceDirectory;
+      std::thread mMessengerThread;
+      bool mMessengerThreadStarted;
       std::list<xclemulation::DDRBank> mDdrBanks;
       std::map<uint64_t,std::pair<std::string,unsigned int>> kernelArgsInfo;
       xclDeviceInfo2 mDeviceInfo;

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
@@ -1274,7 +1274,7 @@ namespace xclcpuemhal2 {
             if(std::find(parsedMsgs.begin(), parsedMsgs.end(), line) == parsedMsgs.end()) {
               parsedMsgs.push_back(line);
               std::cout << "Received request to end simulation from connected initiator. Press Cntrl+C to exit the application. " << std::endl; 
-			  //xclClose(); TO-DO : final solution is to call xclclose
+	      //xclClose(); TO-DO : final solution is to call xclclose
             }
           }
         }
@@ -1358,7 +1358,7 @@ namespace xclcpuemhal2 {
 
   CpuemShim::~CpuemShim()
   {
-	parsedMsgs.clear();
+    parsedMsgs.clear();
     if (mIsKdsSwEmu && mSWSch && mCore)
     {
       mSWSch->fini_scheduler_thread();
@@ -1385,7 +1385,7 @@ namespace xclcpuemhal2 {
     {
       mLogStream.close();
     }
-	closemMessengerThread();
+    closemMessengerThread();
   }
 
   /**********************************************HAL2 API's START HERE **********************************************/

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.h
@@ -174,7 +174,8 @@ namespace xclcpuemhal2 {
       int xclRegRW(bool rd, uint32_t cu_index, uint32_t offset, uint32_t *datap);
       int xclRegRead(uint32_t cu_index, uint32_t offset, uint32_t *datap);
       int xclRegWrite(uint32_t cu_index, uint32_t offset, uint32_t data);
-
+      int parseLog();
+      std::vector<std::string> parsedMsgs;
       bool isImported(unsigned int _bo)
       {
         if (mImportedBOs.find(_bo) != mImportedBOs.end())
@@ -410,7 +411,7 @@ namespace xclcpuemhal2 {
       // */
       // int
       //   xrtGraphReadRTP(void * gh, const char *hierPathPort, char *buffer, size_t size);
-
+    
     private:
       std::shared_ptr<xrt_core::device> mCoreDevice;
       std::mutex mMemManagerMutex;
@@ -433,6 +434,7 @@ namespace xclcpuemhal2 {
       std::string dec2bin(uint32_t n);
       std::string dec2bin(uint32_t n, unsigned bits);
 
+      void closemMessengerThread();
       std::mutex mtx;
       unsigned int message_size;
       bool simulator_started;
@@ -443,6 +445,8 @@ namespace xclcpuemhal2 {
       std::vector<std::string> mTempdlopenfilenames;
       std::string deviceName;
       std::string deviceDirectory;
+      std::thread mMessengerThread;
+      bool mMessengerThreadStarted;
       std::list<xclemulation::DDRBank> mDdrBanks;
       std::map<uint64_t,std::pair<std::string,unsigned int>> kernelArgsInfo;
       xclDeviceInfo2 mDeviceInfo;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit : Currently the external IO design hang for DC platforms . When end_of_simulation is given from test_master.py, we are capturing it in device_process.log generated from sim_ipc_master. For 2022.1, When this message is seen, we are giving a message “Received request to end simulation from connected initiator. Press Cntrl+C to exit the application.”
For HEAD, we will be calling xclclose.


#### Bug / issue (if any) fixed : 1126325

#### Risks (if any) associated the changes in the commit : No

#### Testing : Canary run. Results are clean.

#### Documentation impact (if any) : No
