### PR TITLE
CR-1126268: Fix seg fault in profiling summary generation

### DIFF
--- a/src/runtime_src/xdp/profile/writer/vp_base/summary_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/summary_writer.cpp
@@ -924,10 +924,9 @@ namespace xdp {
         // In both these cases we print out "N/A"
         printNA ? (fout << "N/A,") : (fout << stats.totalTime/one_million << ",");
         printNA ? (fout << "N/A,\n") : (fout << stats.averageTime / one_million << ",\n");
-
-        // Move on from READ to WRITE
-        ++i;
       }
+      // Move on from READ to WRITE
+      ++i;
     }
   }
 


### PR DESCRIPTION
(cherry picked from commit ac5840899cb350aa0db7575547b49e0fdc24cb97)

#### Problem solved by the commit
Writing a table in the profile summary could cause a segmentation fault when designs have multiple buffer reads and writes from the host to the device.  This was due to a misplaced increment in the loop structure.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
A malformed loop increment was causing accesses beyond the bounds of the array.
