### PR TITLE
xbflash2 tool commands update.

### DIFF
--- a/src/runtime_src/core/tools/xbflash2/OO_Program_Qspips.cpp
+++ b/src/runtime_src/core/tools/xbflash2/OO_Program_Qspips.cpp
@@ -119,6 +119,7 @@ OO_Program_Qspips::OO_Program_Qspips( const std::string &_longName, bool _isHidd
       ("flash-part,p", po::value<std::string>(), "qspips-flash-type, default is qspi_ps_x2_single.\n")
       ("bar,b", po::value<std::string>(), "BAR-index, default is 0.\n")
       ("bar-offset,s", po::value<std::string>(), "BAR-offset-for-QSPIPS, default is 0x40000.\n")
+      ("length,l", po::value<std::string>(), "length-to-erase, default is 96MB.\n")
       ("image,i", po::value<std::vector<std::string>>(), "Specifies MCS or BOOT.BIN image path to update the persistent device.\n")
       ("erase,e", "Erase flash on the device.\n")
       ("help", boost::program_options::bool_switch(&m_help), "Help to use this sub-command")

--- a/src/runtime_src/core/tools/xbflash2/XBFMain.cpp
+++ b/src/runtime_src/core/tools/xbflash2/XBFMain.cpp
@@ -44,7 +44,6 @@ void  main_(int argc, char** argv,
   bool bBatchMode = false;
   bool bShowHidden = false;
   bool bForce = false;
-  bool bVersion = false;
   std::string sDevice;
 
   // Build Options
@@ -58,7 +57,6 @@ void  main_(int argc, char** argv,
   po::options_description globalOptions("Global Options");
   globalOptions.add_options()
     ("help",    boost::program_options::bool_switch(&bHelp), "Help to use this application")
-    ("version", boost::program_options::bool_switch(&bVersion), "Report the version of XRT and its drivers")
   ;
   globalOptions.add(globalSubCmdOptions);
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
xbflash2 ui changes : identified small issues during documentation of this feature. 
-  XRT version not needed for this tool
- Length option added for qspips sub-command 

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
n/a
#### How problem was solved, alternative solutions (if any) and why they were rejected

- Removed version option from help menu
- Added length option to program --qspips command

#### Risks (if any) associated the changes in the commit
Low
#### What has been tested and how, request additional testing if necessary
Tested locally this tool with the changes.
#### Documentation impact (if any)
yes, already submitted another PR #6526 