### PR TITLE
CR-1125022 Host crash when releasing exported buffer used in P2P on u250

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libxdma.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libxdma.c
@@ -838,7 +838,6 @@ static void xdma_request_release(struct xdma_dev *xdev,
 	if (!req->dma_mapped) {
 		pci_unmap_sg(xdev->pdev, sgt->sgl, sgt->orig_nents,
 			     req->dir);
-		sgt->nents = 0;
 	}
 
 	xdma_request_free(req);
@@ -3354,7 +3353,6 @@ ssize_t xdma_xfer_fastpath(void *dev_hndl, int channel, bool write, u64 ep_addr,
 	if (!dma_mapped) {
                 pci_unmap_sg(xdev->pdev, sgt->sgl, sgt->orig_nents,
                              engine->dir);
-                sgt->nents = 0;
         }
 
 	if (ret < 0)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
kernel panic when running 2 cards P2P with intel iommu on
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
intel iommu linux kernel code does not check zero length sgt. We should not set the sgt length to 0 in our driver.
#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
test p2p with both IOMMU on and off on the aster test machine.
#### Documentation impact (if any)
