### PR TITLE
CR 1127444 : If xclbin has monitors enabled for counter only, facilit…

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
@@ -229,9 +229,17 @@ namespace xdp {
         if (devInterface->hasTs2mm()) {
           xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", TS2MM_WARN_MSG_ALLOC_FAIL) ;
         }
-        delete offloader ;
-        delete logger ;
-        return ;
+        if (xrt_core::config::get_device_counters()) {
+          /* As device_counters is enabled, the offloader object is required for reading counters.
+           * So do not delete offlader and logger.
+           * As trace infrastructure could not be initialized, disable device_trace to avoid further issue.
+           */
+          device_trace = false;
+        } else {
+          delete offloader ;
+          delete logger ;
+          return ;
+        }
       }
     }
 


### PR DESCRIPTION
…ate read of counters even if trace infrastructure cannot be initialized. (#6525)

Xclbin reported in CR 1127444 contains profile monitors enabled with counters only. When device_trace and device_counters are enabled for such a design, trace infrastructure cannot be initialized as the xclbin does not have any TS2MM or FIFO for trace offload. However, reading of counters should be facilitated. Hence keep offloader object in valid state.