### PR TITLE
CR-1127668 hwmon_sdm: print 6 bytes of MAC information

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/hwmon_sdm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/hwmon_sdm.c
@@ -833,10 +833,9 @@ mac_addr0_show(struct device *dev, struct device_attribute *attr, char *buf)
 {
 	struct xocl_hwmon_sdm *sdm = dev_get_drvdata(dev);
 
-	return sprintf(buf, "%02hhX:%02hhX:%02hhX:%02hhX:%02hhX:%02hhX:%02hhX:%02hhX\n",
+	return sprintf(buf, "%02hhX:%02hhX:%02hhX:%02hhX:%02hhX:%02hhX\n",
 				   sdm->bdinfo.mac_addr0[0], sdm->bdinfo.mac_addr0[1], sdm->bdinfo.mac_addr0[2],
-				   sdm->bdinfo.mac_addr0[3], sdm->bdinfo.mac_addr0[4], sdm->bdinfo.mac_addr0[5],
-				   sdm->bdinfo.mac_addr0[6], sdm->bdinfo.mac_addr0[7]);
+				   sdm->bdinfo.mac_addr0[3], sdm->bdinfo.mac_addr0[4], sdm->bdinfo.mac_addr0[5]);
 };
 static DEVICE_ATTR_RO(mac_addr0);
 
@@ -845,10 +844,9 @@ mac_addr1_show(struct device *dev, struct device_attribute *attr, char *buf)
 {
 	struct xocl_hwmon_sdm *sdm = dev_get_drvdata(dev);
 
-	return sprintf(buf, "%02hhX:%02hhX:%02hhX:%02hhX:%02hhX:%02hhX:%02hhX:%02hhX\n",
+	return sprintf(buf, "%02hhX:%02hhX:%02hhX:%02hhX:%02hhX:%02hhX\n",
 				   sdm->bdinfo.mac_addr1[0], sdm->bdinfo.mac_addr1[1], sdm->bdinfo.mac_addr1[2],
-				   sdm->bdinfo.mac_addr1[3], sdm->bdinfo.mac_addr1[4], sdm->bdinfo.mac_addr1[5],
-				   sdm->bdinfo.mac_addr1[6], sdm->bdinfo.mac_addr1[7]);
+				   sdm->bdinfo.mac_addr1[3], sdm->bdinfo.mac_addr1[4], sdm->bdinfo.mac_addr1[5]);
 };
 static DEVICE_ATTR_RO(mac_addr1);
 


### PR DESCRIPTION
Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
XRT is displaying wrong size of MAC information. So, fixed this issue by adding changes in XRT hwmon_sdm driver.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1127668

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added changes in hwmon_sdm driver to print correct length of MAC data

#### Risks (if any) associated the changes in the commit
NA

#### What has been tested and how, request additional testing if necessary
xbutil & xbmgmt examine reports. Reports shows MAC address in 6 bytes long length

 Mac Addresses            : 00:0A:35:0C:F6:3C
                                     : 00:0A:35:0C:F6:3D
 

#### Documentation impact (if any)
NA