### PR TITLE
BACKPORT CR-1125022 Host crash when releasing exported buffer used in P2P on u250

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libxdma.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libxdma.c
@@ -838,7 +838,6 @@ static void xdma_request_release(struct xdma_dev *xdev,
 	if (!req->dma_mapped) {
 		pci_unmap_sg(xdev->pdev, sgt->sgl, sgt->orig_nents,
 			     req->dir);
-		sgt->nents = 0;
 	}
 
 	xdma_request_free(req);
@@ -3354,7 +3353,6 @@ ssize_t xdma_xfer_fastpath(void *dev_hndl, int channel, bool write, u64 ep_addr,
 	if (!dma_mapped) {
                 pci_unmap_sg(xdev->pdev, sgt->sgl, sgt->orig_nents,
                              engine->dir);
-                sgt->nents = 0;
         }
 
 	if (ret < 0)


### PR DESCRIPTION
…250 (#6528)

(cherry picked from commit 239e0b729516f85e60bb5712385e3a351b446ac0)

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
