### PR TITLE
Cherry-pick : Fix SOM multiple bitstream programming for full PL DFx shells (#6537)

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/cu.c
+++ b/src/runtime_src/core/edge/drm/zocl/cu.c
@@ -291,7 +291,8 @@ static int cu_remove(struct platform_device *pdev)
 		free_irq(zcu->irq, zcu);
 
 	zdev = zocl_get_zdev();
-	zocl_kds_del_cu(zdev, &zcu->base);
+	if(zdev)
+		zocl_kds_del_cu(zdev, &zcu->base);
 
 	if (zcu->base.res)
 		vfree(zcu->base.res);

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
@@ -287,7 +287,10 @@ struct platform_device *zocl_find_pdev(char *name);
 static inline struct drm_zocl_dev *
 zocl_get_zdev(void)
 {
-	return platform_get_drvdata(zocl_find_pdev("zyxclmm_drm"));
+	struct platform_device *pdev = zocl_find_pdev("zyxclmm_drm");
+	if(!pdev)
+		return NULL;
+	return platform_get_drvdata(pdev);
 }
 int get_apt_index_by_addr(struct drm_zocl_dev *zdev, phys_addr_t addr);
 int get_apt_index_by_cu_idx(struct drm_zocl_dev *zdev, int cu_idx);

--- a/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
@@ -845,6 +845,12 @@ void zocl_destroy_client(void *client_hdl)
 	struct drm_zocl_slot *slot = NULL;
 	int pid = pid_nr(client->pid);
 
+	if (!zdev) {
+		zocl_info(client->dev, "client exits pid(%d)\n", pid);
+		kfree(client);
+		return;
+	}
+
 	kds = &zdev->kds;
 
 	/* kds_fini_client should released resources hold by the client.

--- a/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
@@ -605,10 +605,10 @@ zocl_create_cu(struct drm_zocl_dev *zdev, struct drm_zocl_slot *slot)
 			cu_info[i].args = (struct xrt_cu_arg *)&krnl_info->args[i];
 			cu_info[i].num_args = krnl_info->anums;
 			cu_info[i].size = krnl_info->range;
-		}
 
-		if (krnl_info->features & KRNL_SW_RESET)
-			cu_info[i].sw_reset = true;
+			if (krnl_info->features & KRNL_SW_RESET)
+				cu_info[i].sw_reset = true;
+		}
 
 		/* CU sub device is a virtual device, which means there is no
 		 * device tree nodes
@@ -1705,10 +1705,12 @@ zocl_xclbin_set_dtbo_path(struct drm_zocl_slot *slot, char *dtbo_path)
         }
 
 	if(dtbo_path) {
-		path = vmalloc(strlen(dtbo_path) + 1);
+		uint32_t len = strlen(dtbo_path);
+		path = vmalloc(len + 1);
 		if (!path)
 			return -ENOMEM;
-		copy_from_user(path, dtbo_path, strlen(dtbo_path));
+		copy_from_user(path, dtbo_path, len);
+		path[len] = '\0';
 	}
 
         slot->slot_xclbin->zx_dtbo_path = path;


### PR DESCRIPTION
**Cherry picked the change from master**

Problem solved by the commit
In SOM we have added a new feature to program multiple xclbins for full PL DFx shells by using device tree overlay, when new xclbin with OVERLAY section is loaded overlay that is already applied is removed. zocl node (zyxclmm_drm) is part of Overlay for this kind of platforms, so zocl node is removed and zocl module is unloaded which causes kernel crash. This PR fixes this kernel crash by checking zyxclmm_drm is present before accessing it.

Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
When loading different xclbins with overlay sections it was discovered that during driver unload we are accessing zyxclmm_drm device tree node without checking for its presence.

How problem was solved, alternative solutions (if any) and why they were rejected
Added check for NULL pointer

Risks (if any) associated the changes in the commit
None as we are just checking for NULL pointer

What has been tested and how, request additional testing if necessary
Tested on SOM board by loading different xclbins in a loop for 200 times, it did not cause any crash

Documentation impact (if any)
NA