### PR TITLE
hwmon_sdm: maintain separate cache timer for each SDR type

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/hwmon_sdm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/hwmon_sdm.c
@@ -71,7 +71,7 @@ struct xocl_hwmon_sdm {
 
 	struct mutex            sdm_lock;
 	u64                     cache_expire_secs;
-	ktime_t                 cache_expires;
+	ktime_t                 cache_expires[SDR_TYPE_MAX];
 };
 
 #define SDM_BUF_IDX_INCR(buf_index, len, buf_len) \
@@ -180,10 +180,10 @@ static int get_sdr_type(enum xcl_group_kind kind)
 	return type;
 }
 
-static void update_cache_expiry_time(struct xocl_hwmon_sdm *sdm)
+static void update_cache_expiry_time(struct xocl_hwmon_sdm *sdm, uint8_t repo_id)
 {
-	sdm->cache_expires = ktime_add(ktime_get_boottime(),
-                                   ktime_set(sdm->cache_expire_secs, 0));
+	sdm->cache_expires[repo_id] = ktime_add(ktime_get_boottime(),
+                                      ktime_set(sdm->cache_expire_secs, 0));
 }
 
 /*
@@ -246,7 +246,7 @@ static int get_sensors_data(struct platform_device *pdev, uint8_t repo_id)
 	struct xocl_hwmon_sdm *sdm = platform_get_drvdata(pdev);
 	ktime_t now = ktime_get_boottime();
 
-	if (ktime_compare(now, sdm->cache_expires) > 0)
+	if (ktime_compare(now, sdm->cache_expires[repo_id]) > 0)
 		return hwmon_sdm_update_sensors(pdev, repo_id);
 
 	return 0;
@@ -1046,7 +1046,7 @@ static int hwmon_sdm_update_sensors(struct platform_device *pdev, uint8_t repo_i
 		ret = hwmon_sdm_read_from_peer(pdev, repo_type);
 
 	if (!ret)
-		update_cache_expiry_time(sdm);
+		update_cache_expiry_time(sdm, repo_id);
 
 	return ret;
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/hwmon_sdm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/hwmon_sdm.c
@@ -293,6 +293,11 @@ static ssize_t hwmon_sensor_show(struct device *dev,
 	uint32_t uval = 0;
 	ssize_t sz = 0;
 
+	if (repo_id >= SDR_TYPE_MAX) {
+		xocl_dbg(&sdm->pdev->dev, "repo_id: 0x%x is corrupted or not supported\n", repo_id);
+		return sprintf(buf, "%d\n", 0);
+	}
+
 	mutex_lock(&sdm->sdm_lock);
 	get_sensors_data(sdm->pdev, repo_id);
 


### PR DESCRIPTION
Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
At present, hwmon_sdm driver is having single cache timer for all SDR types. It will not work for below case.
1. repo_id = 0x2 is received in get_sensors_data() function
2. It checks if the cache timer is expired. If yes, it will update the sensor list for repo_id = 0x2 and reset cache timer.
3. Within cache timer limits, a new repo_id say 0x3 is received in get_sensors_data() function
4. Since, timer is not expired, it returns 0 without updating sensor list for repo_id 0x3. This is an Issue.

This PR will fixes this scenario by adding cache timer for each SDR type.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added changes in hwmon_sdm driver.

#### Risks (if any) associated the changes in the commit
NA
#### What has been tested and how, request additional testing if necessary
xbutil & xbmgmt examine reports and able to see all SDR types sensors are getting updated if cache timer expired.

#### Documentation impact (if any)
NA