### PR TITLE
Cherry-pick:Parsing device_process.log to check for end_of_simulation

### DIFF
--- a/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/shim.h
@@ -161,6 +161,8 @@ namespace xclcpuemhal2 {
       int xclOpenContext(const uuid_t xclbinId, unsigned int ipIndex, bool shared) const;
       int xclExecWait(int timeoutMilliSec);
       int xclExecBuf(unsigned int cmdBO);
+      std::vector<std::string> parsedMsgs;
+      int parseLog();
       int xclCloseContext(const uuid_t xclbinId, unsigned int ipIndex) const;
       //Get CU index from IP_LAYOUT section for corresponding kernel name
       int xclIPName2Index(const char *name);
@@ -326,6 +328,7 @@ namespace xclcpuemhal2 {
       uint32_t getPerfMonByteScaleFactor(xclPerfMonType type);
       uint8_t  getPerfMonShowIDS(xclPerfMonType type);
       uint8_t  getPerfMonShowLEN(xclPerfMonType type);
+      void closemMessengerThread();
       size_t resetFifos(xclPerfMonType type);
       uint32_t bin2dec(std::string str, int start, int number);
       uint32_t bin2dec(const char * str, int start, int number);
@@ -342,6 +345,8 @@ namespace xclcpuemhal2 {
       std::vector<std::string> mTempdlopenfilenames;
       std::string deviceName;
       std::string deviceDirectory;
+      std::thread mMessengerThread;
+      bool mMessengerThreadStarted;
       std::list<xclemulation::DDRBank> mDdrBanks;
       std::map<uint64_t,std::pair<std::string,unsigned int>> kernelArgsInfo;
       xclDeviceInfo2 mDeviceInfo;

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
@@ -44,7 +44,7 @@ namespace xclcpuemhal2 {
   const unsigned CpuemShim::CONTROL_AP_IDLE  = 4;
   const unsigned CpuemShim::CONTROL_AP_CONTINUE = 0x10;
   std::map<std::string, std::string> CpuemShim::mEnvironmentNameValueMap(xclemulation::getEnvironmentByReadingIni());
-
+  void messagesThread(xclcpuemhal2::CpuemShim* inst);
   namespace bf = boost::filesystem;
 #define PRINTENDFUNC if (mLogStream.is_open()) mLogStream << __func__ << " ended " << std::endl;
 
@@ -105,6 +105,7 @@ namespace xclcpuemhal2 {
     {
       message_size = 0x800000;
     }
+    mMessengerThreadStarted = false;
     mCloseAll = false;
     bUnified = _unified;
     bXPR = _xpr;
@@ -562,6 +563,11 @@ namespace xclcpuemhal2 {
     bool isVersal = false;
     std::string binaryDirectory("");
     launchDeviceProcess(debuggable,binaryDirectory);
+    //Check if device_process.log already exists. Remove if exists.
+    std::string extIoTxtFile = deviceDirectory + "/../../../device_process.log";
+    FILE* fp = fopen(extIoTxtFile.c_str(), "rb");
+    if (fp != NULL)
+      systemUtil::makeSystemCall(extIoTxtFile, systemUtil::systemOperation::REMOVE); 
 
     if(header)
     {
@@ -762,7 +768,11 @@ namespace xclcpuemhal2 {
         aiesim_sock = new unix_socket("AIESIM_SOCKETID");
       }
     }
-
+    //Thread to fetch messages from Device to display on host
+    if(mMessengerThreadStarted == false) {
+      mMessengerThread = std::thread(xclcpuemhal2::messagesThread,this);
+      mMessengerThreadStarted = true;
+    }
     return 0;
   }
 
@@ -1223,9 +1233,61 @@ namespace xclcpuemhal2 {
       xclClose_RPC_CALL(xclClose,this);
 #endif
     }
+   closemMessengerThread();
    saveDeviceProcessOutput();
   }
 
+  void CpuemShim::closemMessengerThread()
+  {
+    if (mMessengerThreadStarted) {
+      mMessengerThread.join();
+      mMessengerThreadStarted = false;
+    }
+  }
+
+  void messagesThread(xclcpuemhal2::CpuemShim *inst)
+  {  
+    static auto start_time = std::chrono::high_resolution_clock::now();
+    unsigned int timeCheck = 0;
+    unsigned int parseCount = 0;
+    while (inst)
+    {
+      sleep(50);
+      auto end_time = std::chrono::high_resolution_clock::now();
+      if (std::chrono::duration<double>(end_time - start_time).count() > timeCheck) {
+        start_time = std::chrono::high_resolution_clock::now();
+        inst->parseLog();
+        parseCount++;
+        if (parseCount%5 == 0 && timeCheck < 300) {
+          timeCheck += 10;
+        }
+      }
+    }
+  }
+  
+  int CpuemShim::parseLog()
+  {
+    std::vector<std::string> myvector = {"received request to end simulation from connected initiator"};
+    std::ifstream ifs(deviceDirectory + "/../../../device_process.log");
+    std::string logparse = deviceDirectory + "/../../../device_process.log";
+    if (ifs.is_open()) {
+      std::string line;
+      while (std::getline(ifs, line)) {
+        for (auto matchString : myvector) {
+          std::string::size_type index = line.find(matchString);
+          if (index != std::string::npos) {
+            if(std::find(parsedMsgs.begin(), parsedMsgs.end(), line) == parsedMsgs.end()) {
+              parsedMsgs.push_back(line);
+              std::cout << "Received request to end simulation from connected initiator. Press Cntrl+C to exit the application. " << std::endl; 
+	      //xclClose(); TO-DO : final solution is to call xclclose
+            }
+          }
+        }
+      }
+    }
+    return 0;
+  }
+  
   void CpuemShim::xclClose()
   {
     std::lock_guard<std::mutex> lk(mApiMtx);
@@ -1301,6 +1363,7 @@ namespace xclcpuemhal2 {
 
   CpuemShim::~CpuemShim()
   {
+    parsedMsgs.clear();
     if (mIsKdsSwEmu && mSWSch && mCore)
     {
       mSWSch->fini_scheduler_thread();
@@ -1327,6 +1390,7 @@ namespace xclcpuemhal2 {
     {
       mLogStream.close();
     }
+    closemMessengerThread();
   }
 
   /**********************************************HAL2 API's START HERE **********************************************/

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.h
@@ -175,7 +175,10 @@ namespace xclcpuemhal2 {
       int xclRegRW(bool rd, uint32_t cu_index, uint32_t offset, uint32_t *datap);
       int xclRegRead(uint32_t cu_index, uint32_t offset, uint32_t *datap);
       int xclRegWrite(uint32_t cu_index, uint32_t offset, uint32_t data);
-      
+
+      int parseLog();
+      std::vector<std::string> parsedMsgs;
+
       bool isImported(unsigned int _bo)
       {
         if (mImportedBOs.find(_bo) != mImportedBOs.end())
@@ -411,7 +414,7 @@ namespace xclcpuemhal2 {
       // */
       // int
       //   xrtGraphReadRTP(void * gh, const char *hierPathPort, char *buffer, size_t size);
-
+    
     private:
       std::shared_ptr<xrt_core::device> mCoreDevice;
       std::mutex mMemManagerMutex;
@@ -434,6 +437,7 @@ namespace xclcpuemhal2 {
       std::string dec2bin(uint32_t n);
       std::string dec2bin(uint32_t n, unsigned bits);
 
+      void closemMessengerThread();
       std::mutex mtx;
       unsigned int message_size;
       bool simulator_started;
@@ -444,6 +448,8 @@ namespace xclcpuemhal2 {
       std::vector<std::string> mTempdlopenfilenames;
       std::string deviceName;
       std::string deviceDirectory;
+      std::thread mMessengerThread;
+      bool mMessengerThreadStarted;
       std::list<xclemulation::DDRBank> mDdrBanks;
       std::map<uint64_t,std::pair<std::string,unsigned int>> kernelArgsInfo;
       xclDeviceInfo2 mDeviceInfo;


### PR DESCRIPTION
Problem solved by the commit : Currently the external IO design hang for DC platforms . When end_of_simulation is given from test_master.py, we are capturing it in device_process.log generated from sim_ipc_master. For 2022.1, When this message is seen, we are giving a message “Received request to end simulation from connected initiator. Press Cntrl+C to exit the application.”
For HEAD, we will be calling xclclose.
Bug / issue (if any) fixed : 1126325
Risks (if any) associated the changes in the commit : No
Testing : Canary run. Results are clean.
Documentation impact (if any) : No