### PR TITLE
Disable MCDM shim

### DIFF
--- a/src/runtime_src/core/pcie/windows/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/windows/CMakeLists.txt
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2019-2022 Xilinx, Inc. All rights reserved.
 #
-if (MCDM)
+if (MCDM_IN_XRT)
   add_subdirectory(mcdm)
-else()
+elseif (NOT MCDM)
   add_subdirectory(alveo)
 endif()


### PR DESCRIPTION
Development of MCMD shim moves to internal repo for convenience.
This makes XRT less of a moving target for the MCDM repo and simplifies
managing of the XRT git submodule.

At some point the MCMD shim layer can be moved back to mainstream XRT.
