### PR TITLE
CR-1127762 Download of xclbin causes crash on the Ubuntu 18.04 VM

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -2106,6 +2106,9 @@ void xocl_kds_unregister_cus(struct xocl_dev *xdev, int slot_hdl)
 		return;
 	}
 
+	if (!xocl_ert_ctrl_is_version(xdev, 1, 0))
+		return;
+
 	// Work-around to unconfigure PS kernel
 	// Will be removed once unconfigure command is there
 	ret = xocl_kds_xgq_cfg_start(xdev, XDEV(xdev)->kds_cfg, 0, 0);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Host crash during download xclbin

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1127762 reports this

#### How problem was solved, alternative solutions (if any) and why they were rejected
When host XRT supports XGQ but ERT firmware doesn't support it, this issue can be reproduced.
Just add a check in unregister CU to avoid construct XGQ command for a non XGQ based ERT firmware.

#### Risks (if any) associated the changes in the commit
low

#### What has been tested and how, request additional testing if necessary
U30 shell with non XGQ based ERT.

#### Documentation impact (if any)
No