### PR TITLE
CR-1127568: Updated description for aie_profile_interface_metrics

### DIFF
--- a/src/runtime_src/xdp/profile/writer/vp_base/ini_parameters.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/ini_parameters.cpp
@@ -99,7 +99,7 @@ namespace xdp {
                  "Metric set for AI Engine memory modules");
     addParameter("aie_profile_interface_metrics",
                  xrt_core::config::get_aie_profile_interface_metrics(),
-                 "Metric set for AI Engine interface modules");             
+                 "Metric set for AI Engine interface tiles");             
     addParameter("aie_status", xrt_core::config::get_aie_status(),
                  "Generation of AI Engine debug/status");
     addParameter("aie_status_interval_us",


### PR DESCRIPTION
Fixed naming from "AI Engine interface modules" to "AI Engine interface tiles".