### PR TITLE
Update build-win19.sh for building of MCDM shim

### DIFF
--- a/build/build-win19.sh
+++ b/build/build-win19.sh
@@ -71,7 +71,7 @@ while [ $# -gt 0 ]; do
             shift
             ;;
         -mcdm)
-            cmake_flags+=" -DMCDM=1"
+            cmake_flags+=" -DMCDM=1 -DMCDM_IN_XRT=1"
             shift
             ;;
 	-boost)


### PR DESCRIPTION
#### Problem solved by the commit
Simply script change to support building of MCDM shim local to XRT.

#### How problem was solved, alternative solutions (if any) and why they were rejected
The MCDM shim layer is developed in an internal repo that use rest of
XRT as a sub-module. By default XRT doesn't build inband MCDM unless
explicitly requested.
