### PR TITLE
CR-1126325 Parsing device_process.log and displaying end_of_simulatio…

### DIFF
--- a/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/shim.h
@@ -161,6 +161,8 @@ namespace xclcpuemhal2 {
       int xclOpenContext(const uuid_t xclbinId, unsigned int ipIndex, bool shared) const;
       int xclExecWait(int timeoutMilliSec);
       int xclExecBuf(unsigned int cmdBO);
+      std::vector<std::string> parsedMsgs;
+      int parseLog();
       int xclCloseContext(const uuid_t xclbinId, unsigned int ipIndex) const;
       //Get CU index from IP_LAYOUT section for corresponding kernel name
       int xclIPName2Index(const char *name);
@@ -326,6 +328,7 @@ namespace xclcpuemhal2 {
       uint32_t getPerfMonByteScaleFactor(xclPerfMonType type);
       uint8_t  getPerfMonShowIDS(xclPerfMonType type);
       uint8_t  getPerfMonShowLEN(xclPerfMonType type);
+      void closemMessengerThread();
       size_t resetFifos(xclPerfMonType type);
       uint32_t bin2dec(std::string str, int start, int number);
       uint32_t bin2dec(const char * str, int start, int number);
@@ -342,6 +345,8 @@ namespace xclcpuemhal2 {
       std::vector<std::string> mTempdlopenfilenames;
       std::string deviceName;
       std::string deviceDirectory;
+      std::thread mMessengerThread;
+      bool mMessengerThreadStarted;
       std::list<xclemulation::DDRBank> mDdrBanks;
       std::map<uint64_t,std::pair<std::string,unsigned int>> kernelArgsInfo;
       xclDeviceInfo2 mDeviceInfo;

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
@@ -44,7 +44,7 @@ namespace xclcpuemhal2 {
   const unsigned CpuemShim::CONTROL_AP_IDLE  = 4;
   const unsigned CpuemShim::CONTROL_AP_CONTINUE = 0x10;
   std::map<std::string, std::string> CpuemShim::mEnvironmentNameValueMap(xclemulation::getEnvironmentByReadingIni());
-
+  void messagesThread(xclcpuemhal2::CpuemShim* inst);
   namespace bf = boost::filesystem;
 #define PRINTENDFUNC if (mLogStream.is_open()) mLogStream << __func__ << " ended " << std::endl;
 
@@ -105,6 +105,7 @@ namespace xclcpuemhal2 {
     {
       message_size = 0x800000;
     }
+    mMessengerThreadStarted = false;
     mCloseAll = false;
     bUnified = _unified;
     bXPR = _xpr;
@@ -562,6 +563,11 @@ namespace xclcpuemhal2 {
     bool isVersal = false;
     std::string binaryDirectory("");
     launchDeviceProcess(debuggable,binaryDirectory);
+    //Check if device_process.log already exists. Remove if exists.
+    std::string extIoTxtFile = deviceDirectory + "/../../../device_process.log";
+    FILE* fp = fopen(extIoTxtFile.c_str(), "rb");
+    if (fp != NULL)
+      systemUtil::makeSystemCall(extIoTxtFile, systemUtil::systemOperation::REMOVE); 
 
     if(header)
     {
@@ -762,7 +768,11 @@ namespace xclcpuemhal2 {
         aiesim_sock = new unix_socket("AIESIM_SOCKETID");
       }
     }
-
+    //Thread to fetch messages from Device to display on host
+    if(mMessengerThreadStarted == false) {
+      mMessengerThread = std::thread(xclcpuemhal2::messagesThread,this);
+      mMessengerThreadStarted = true;
+    }
     return 0;
   }
 
@@ -1223,9 +1233,61 @@ namespace xclcpuemhal2 {
       xclClose_RPC_CALL(xclClose,this);
 #endif
     }
+   closemMessengerThread();
    saveDeviceProcessOutput();
   }
 
+  void CpuemShim::closemMessengerThread()
+  {
+    if (mMessengerThreadStarted) {
+      mMessengerThread.join();
+      mMessengerThreadStarted = false;
+    }
+  }
+
+  void messagesThread(xclcpuemhal2::CpuemShim *inst)
+  {  
+    static auto start_time = std::chrono::high_resolution_clock::now();
+    unsigned int timeCheck = 0;
+    unsigned int parseCount = 0;
+    while (inst)
+    {
+      sleep(50);
+      auto end_time = std::chrono::high_resolution_clock::now();
+      if (std::chrono::duration<double>(end_time - start_time).count() > timeCheck) {
+        start_time = std::chrono::high_resolution_clock::now();
+        inst->parseLog();
+        parseCount++;
+        if (parseCount%5 == 0 && timeCheck < 300) {
+          timeCheck += 10;
+        }
+      }
+    }
+  }
+  
+  int CpuemShim::parseLog()
+  {
+    std::vector<std::string> myvector = {"received request to end simulation from connected initiator"};
+    std::ifstream ifs(deviceDirectory + "/../../../device_process.log");
+    std::string logparse = deviceDirectory + "/../../../device_process.log";
+    if (ifs.is_open()) {
+      std::string line;
+      while (std::getline(ifs, line)) {
+        for (auto matchString : myvector) {
+          std::string::size_type index = line.find(matchString);
+          if (index != std::string::npos) {
+            if(std::find(parsedMsgs.begin(), parsedMsgs.end(), line) == parsedMsgs.end()) {
+              parsedMsgs.push_back(line);
+              std::cout << "Received request to end simulation from connected initiator. Press Cntrl+C to exit the application. " << std::endl; 
+	      //xclClose(); TO-DO : final solution is to call xclclose
+            }
+          }
+        }
+      }
+    }
+    return 0;
+  }
+  
   void CpuemShim::xclClose()
   {
     std::lock_guard<std::mutex> lk(mApiMtx);
@@ -1301,6 +1363,7 @@ namespace xclcpuemhal2 {
 
   CpuemShim::~CpuemShim()
   {
+    parsedMsgs.clear();
     if (mIsKdsSwEmu && mSWSch && mCore)
     {
       mSWSch->fini_scheduler_thread();
@@ -1327,6 +1390,7 @@ namespace xclcpuemhal2 {
     {
       mLogStream.close();
     }
+    closemMessengerThread();
   }
 
   /**********************************************HAL2 API's START HERE **********************************************/

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.h
@@ -1,6 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Xilinx, Inc
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2016-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -14,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 #ifndef _SW_EMU_SHIM_H_
 #define _SW_EMU_SHIM_H_
 
@@ -147,7 +145,7 @@ namespace xclcpuemhal2 {
 
 
       ~CpuemShim();
-      CpuemShim(unsigned int deviceIndex, xclDeviceInfo2 &info, std::list<xclemulation::DDRBank>& DDRBankList, bool bUnified, 
+      CpuemShim(unsigned int deviceIndex, xclDeviceInfo2 &info, std::list<xclemulation::DDRBank>& DDRBankList, bool bUnified,
         bool bXPR, FeatureRomHeader &featureRom, const boost::property_tree::ptree & platformData);
 
       static CpuemShim *handleCheck(void *handle);
@@ -163,6 +161,7 @@ namespace xclcpuemhal2 {
       ssize_t xclReadQueue(uint64_t q_hdl, xclQueueRequest *wr);
       int xclPollCompletion(int min_compl, int max_compl, xclReqCompletion *comps, int* actual, int timeout);
       int xclOpenContext(const uuid_t xclbinId, unsigned int ipIndex, bool shared) const;
+      int xclOpenContextByName(uint32_t slot, const uuid_t xclbinId, const char* cuname, bool shared) const;
       int xclExecWait(int timeoutMilliSec);
       int xclExecBuf(unsigned int cmdBO);
       int xclCloseContext(const uuid_t xclbinId, unsigned int ipIndex) const;
@@ -175,7 +174,8 @@ namespace xclcpuemhal2 {
       int xclRegRW(bool rd, uint32_t cu_index, uint32_t offset, uint32_t *datap);
       int xclRegRead(uint32_t cu_index, uint32_t offset, uint32_t *datap);
       int xclRegWrite(uint32_t cu_index, uint32_t offset, uint32_t data);
-      
+      int parseLog();
+      std::vector<std::string> parsedMsgs;
       bool isImported(unsigned int _bo)
       {
         if (mImportedBOs.find(_bo) != mImportedBOs.end())
@@ -191,7 +191,7 @@ namespace xclcpuemhal2 {
 
       //******************************* XRT Graph API's **************************************************//
       /**
-      * xrtGraphInit() - Initialize graph 
+      * xrtGraphInit() - Initialize graph
       *
       * @gh:             Handle to graph previously opened with xrtGraphOpen.
       * Return:          0 on success, -1 on error
@@ -200,7 +200,7 @@ namespace xclcpuemhal2 {
       */
       int
         xrtGraphInit(void * gh);
-      
+
       /**
       * xrtGraphRun() - Start a graph execution
       *
@@ -227,7 +227,7 @@ namespace xclcpuemhal2 {
       * forever or graph that has multi-rate core(s).
       */
       int
-        xrtGraphWait(void * gh);          
+        xrtGraphWait(void * gh);
 
       /**
       * xrtGraphEnd() - Wait a given AIE cycle since the last xrtGraphRun and
@@ -235,7 +235,7 @@ namespace xclcpuemhal2 {
       *                 is done before end the graph. If graph already run more
       *                 than the given cycle, stop the graph immediately and end it.
       *
-      * @gh:              Handle to graph previously opened with xrtGraphOpen.      
+      * @gh:              Handle to graph previously opened with xrtGraphOpen.
       *
       * Return:          0 on success, -1 on timeout.
       *
@@ -329,7 +329,7 @@ namespace xclcpuemhal2 {
 
       // //******************************* XRT Graph API's **************************************************//
       // /**
-      // * xrtGraphInit() - Initialize graph 
+      // * xrtGraphInit() - Initialize graph
       // *
       // * @gh:             Handle to graph previously opened with xrtGraphOpen.
       // * Return:          0 on success, -1 on error
@@ -338,7 +338,7 @@ namespace xclcpuemhal2 {
       // */
       // int
       //   xrtGraphInit(void * gh);
-      // 
+      //
       // /**
       // * xrtGraphRun() - Start a graph execution
       // *
@@ -350,7 +350,7 @@ namespace xclcpuemhal2 {
       // */
       // int
       //   xrtGraphRun(void * gh, uint32_t iterations);
-      // 
+      //
       // /**
       // * xrtGraphWait() -  Wait a given AIE cycle since the last xrtGraphRun and
       // *                   then stop the graph. If cycle is 0, busy wait until graph
@@ -365,15 +365,15 @@ namespace xclcpuemhal2 {
       // * forever or graph that has multi-rate core(s).
       // */
       // int
-      //   xrtGraphWait(void * gh);          
-      // 
+      //   xrtGraphWait(void * gh);
+      //
       // /**
       // * xrtGraphEnd() - Wait a given AIE cycle since the last xrtGraphRun and
       // *                 then end the graph. busy wait until graph
       // *                 is done before end the graph. If graph already run more
       // *                 than the given cycle, stop the graph immediately and end it.
       // *
-      // * @gh:              Handle to graph previously opened with xrtGraphOpen.      
+      // * @gh:              Handle to graph previously opened with xrtGraphOpen.
       // *
       // * Return:          0 on success, -1 on timeout.
       // *
@@ -382,7 +382,7 @@ namespace xclcpuemhal2 {
       // */
       // int
       //   xrtGraphEnd(void * gh);
-      // 
+      //
       // /**
       // * xrtGraphUpdateRTP() - Update RTP value of port with hierarchical name
       // *
@@ -395,7 +395,7 @@ namespace xclcpuemhal2 {
       // */
       // int
       //   xrtGraphUpdateRTP(void * gh, const char *hierPathPort, const char *buffer, size_t size);
-      // 
+      //
       // /**
       // * xrtGraphUpdateRTP() - Read RTP value of port with hierarchical name
       // *
@@ -434,6 +434,7 @@ namespace xclcpuemhal2 {
       std::string dec2bin(uint32_t n);
       std::string dec2bin(uint32_t n, unsigned bits);
 
+      void closemMessengerThread();
       std::mutex mtx;
       unsigned int message_size;
       bool simulator_started;
@@ -444,6 +445,8 @@ namespace xclcpuemhal2 {
       std::vector<std::string> mTempdlopenfilenames;
       std::string deviceName;
       std::string deviceDirectory;
+      std::thread mMessengerThread;
+      bool mMessengerThreadStarted;
       std::list<xclemulation::DDRBank> mDdrBanks;
       std::map<uint64_t,std::pair<std::string,unsigned int>> kernelArgsInfo;
       xclDeviceInfo2 mDeviceInfo;
@@ -514,7 +517,7 @@ namespace xclcpuemhal2 {
     xclcpuemhal2::CpuemShim*  getDeviceHandle() {  return _deviceHandle;  }
     const char*  getGraphName() { return _graph; }
     unsigned int  getGraphHandle() { return graphHandle; }
-  private: 
+  private:
     xclcpuemhal2::CpuemShim*  _deviceHandle;
     //const uuid_t _xclbin_uuid;
     const char* _graph;
@@ -529,7 +532,7 @@ namespace xclcpuemhal2 {
     };
     graph_state _state;
     std::string _name;
-    uint64_t _startTime;  
+    uint64_t _startTime;
     /* This is the collections of rtps that are used. */
     std::vector<std::string> rtps;
     static unsigned int mGraphHandle;


### PR DESCRIPTION
…n message (#6519)

* Parsing device_process.log generated from sim_ipc_master and display a message to exit on end_of_simulation

* Parsing device_process.log to check for end_of_simulation messages
(cherry picked from commit 38ad053493c5691d19a61cd404d72a950cc83061)

Conflicts:
	src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.h

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
