### PR TITLE
CR-1123001:Resolved system_error issue on CentOs for sw_emu

### DIFF
--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
@@ -1312,9 +1312,12 @@ namespace xclcpuemhal2 {
 
     for (auto& it: mFdToFileNameMap) {
       int fd = it.first;
-      uint64_t sSize = std::get<1>(it.second);
-      void* addr = std::get<2>(it.second);
-      munmap(addr,sSize);
+      // CR-1123001 munmap() call is not required while exiting the application
+      // OS will take care of cleaning once file descriptor close call is performed.
+      
+      //uint64_t sSize = std::get<1>(it.second);
+      //void* addr = std::get<2>(it.second);
+      //munmap(addr,sSize);
       close(fd);
     }
     mFdToFileNameMap.clear();

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/swscheduler.cxx
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/swscheduler.cxx
@@ -1098,7 +1098,10 @@ namespace xclcpuemhal2 {
     
     //int retval = pthread_join(mScheduler->scheduler_thread,NULL);
     int retval = 0;
-    mScheduler->scheduler_thread.join();
+    
+    if (mScheduler->scheduler_thread.joinable())
+      mScheduler->scheduler_thread.join();
+   
     pending_cmds.clear();
     mScheduler->command_queue.clear();
     free_cmds.clear();


### PR DESCRIPTION

As per the CR-1123001, the below changes are peformed.
commented out munmap() calls on addresses which already unmapped earlier.
As the application exiting with xclclose() call and all the file descriptor are getting closed with close() api. The OS will take care of cleaning/unmapping automatically.