### PR TITLE
CR-1127863 VMR easy of use - debug mode - task management

### DIFF
--- a/src/runtime_src/core/include/xgq_cmd_vmr.h
+++ b/src/runtime_src/core/include/xgq_cmd_vmr.h
@@ -87,6 +87,7 @@ enum xgq_cmd_vmr_control_type {
 	XGQ_CMD_BOOT_DEFAULT	= 0x1,
 	XGQ_CMD_BOOT_BACKUP	= 0x2,
 	XGQ_CMD_PROGRAM_SC	= 0x3,
+	XGQ_CMD_VMR_DEBUG	= 0x4,
 };
 
 /**
@@ -184,6 +185,12 @@ enum xgq_cmd_flash_type {
 	XGQ_CMD_FLASH_TO_LEGACY		= 0x2,
 };
 
+enum xgq_cmd_debug_type {
+	XGQ_CMD_DBG_CLEAR		= 0x0,
+	XGQ_CMD_DBG_RMGMT		= 0x1,
+	XGQ_CMD_DBG_VMC			= 0x2,
+};
+
 /**
  * struct xgq_cmd_vmr_control_payload: vmr controlling ops
  *
@@ -192,7 +199,8 @@ enum xgq_cmd_flash_type {
 struct xgq_cmd_vmr_control_payload {
 	uint32_t req_type:8;
 	uint32_t debug_level:3;
-	uint32_t rsvd:21;
+	uint32_t debug_type:5;
+	uint32_t rsvd:16;
 };
 
 /**


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

Update 04/15:
- simplify the rmgmt tasks with no timeout value, just a flag to indicate this task can be started or not.
- add ospi_flash_safe_write, which can safely write data size smaller than sector size by caching existing data and write it back.
- xgq will only init basic service (vmr_control) and then allow either rmgmt or vmc not to provide service but host driver can still talk to xgq for minimum service. Thus xgq service will keep alive.

A new shell flash will automatically set all values to 0 so not affect on regular production shell. 

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

CR-1127863

#### How problem was solved, alternative solutions (if any) and why they were rejected

<img width="1175" alt="image" src="https://user-images.githubusercontent.com/50243230/162668835-65047440-b30a-481d-ae2d-d87abed46d97.png">

#### Risks (if any) associated the changes in the commit

N/A

#### What has been tested and how, request additional testing if necessary

Tested on 0328 shell. 
See debug value, after hot reset check log the value is taking effect.
Reset back to 0, everything becomes back to normal mode.

Rerun xbutil validate passed without any issue.

04/15 Update:
simplify it again with no delay value needed. only a flag which can disable the task.
more code changed in VMR side, but seems cleaner than having 2 delay value hard-coded for rmgmt and vmc.

#### Documentation impact (if any)

https://confluence.xilinx.com/pages/viewpage.action?pageId=302345261#XGQ1.0CommandandQueueSpecification(WIP)-GetLogPage