### PR TITLE
CR-1127564 Azure: bypass unattested xclbin check for internal testing

### DIFF
--- a/src/runtime_src/core/pcie/tools/cloud-daemon/azure/azure.cpp
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/azure/azure.cpp
@@ -1,5 +1,5 @@
 /*
- * Partial Copyright (C) 2019-2021 Xilinx, Inc
+ * Partial Copyright (C) 2019-2022 Xilinx, Inc
  *
  * Microsoft provides sample code how RESTful APIs are being called
  *
@@ -225,6 +225,8 @@ static size_t WriteCallback(void *contents, size_t size, size_t nmemb, void *use
 int AzureDev::azureLoadXclBin(const xclBin *buffer)
 {
     char *xclbininmemory = reinterpret_cast<char*> (const_cast<xclBin*> (buffer));
+    bool allow_unattested_xclbin = false;
+
     if (memcmp(xclbininmemory, "xclbin2", 8) != 0)
         return -1;
     std::string fpgaSerialNumber;
@@ -234,8 +236,13 @@ int AzureDev::azureLoadXclBin(const xclBin *buffer)
         return -E_EMPTY_SN;
     std::cout << "LoadXclBin FPGA serial No: " << fpgaSerialNumber << std::endl;
 
+    char* env = getenv("AZURE_UNATTESTED_XCLBIN");
+    if (env && !strcmp(env, "true"))
+        allow_unattested_xclbin = true;
+
     // check if the xclbin is valid
-    if (xclbin::get_axlf_section(buffer, BITSTREAM) != nullptr) {
+    if (!allow_unattested_xclbin &&
+        (xclbin::get_axlf_section(buffer, BITSTREAM) != nullptr)) {
         std::cout << "xclbin is invalid, please provide azure xclbin" << std::endl;
         return -E_INVALID_XCLBIN;
     }

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/azure/azure.cpp
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/azure/azure.cpp
@@ -225,7 +225,6 @@ static size_t WriteCallback(void *contents, size_t size, size_t nmemb, void *use
 int AzureDev::azureLoadXclBin(const xclBin *buffer)
 {
     char *xclbininmemory = reinterpret_cast<char*> (const_cast<xclBin*> (buffer));
-    bool allow_unattested_xclbin = false;
 
     if (memcmp(xclbininmemory, "xclbin2", 8) != 0)
         return -1;
@@ -236,7 +235,8 @@ int AzureDev::azureLoadXclBin(const xclBin *buffer)
         return -E_EMPTY_SN;
     std::cout << "LoadXclBin FPGA serial No: " << fpgaSerialNumber << std::endl;
 
-    char* env = getenv("AZURE_UNATTESTED_XCLBIN");
+    bool allow_unattested_xclbin = false;
+    char* env = getenv("ALLOW_UNATTESTED_XCLBIN");
     if (env && !strcmp(env, "true"))
         allow_unattested_xclbin = true;
 


### PR DESCRIPTION
Since the standalone ZT servers does not have the same infrastructure of Azure,
this change facilitates verifying xclbin download without recompiling XRT.

User has to add the environment settings in following way in Guess machine

1. Run command "systemctl edit mpd"
2. add below lines in file opened
  [Service]
  Environment="ALLOW_UNATTESTED_XCLBIN=true"
3. save the file
4. restart mpd service using command "systemctl restart mpd"

Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Allow unattested xclbin in internal testing since the internal servers doesn't have same infra like Azure

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added change in Azure driver

#### Risks (if any) associated the changes in the commit
NA
#### What has been tested and how, request additional testing if necessary
xclbin download in Azure setup

#### Documentation impact (if any)
NA