### PR TITLE
CR-1127448 Unable to flash SC firmware on u50 platform

### DIFF
--- a/src/runtime_src/core/tools/xbmgmt2/flash/firmware_image.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/firmware_image.cpp
@@ -753,7 +753,7 @@ firmwareImage::firmwareImage(const std::string& file, imageType type) :
     }
     else
     {
-        if (type != BMC_FIRMWARE && type != MCS_FIRMWARE_PRIMARY)
+        if ((type != BMC_FIRMWARE) && (type != MCS_FIRMWARE_PRIMARY))
         {
             this->setstate(failbit);
             std::cout << "non-dsabin supports only primary bitstream: " << file << std::endl;

--- a/src/runtime_src/core/tools/xbmgmt2/flash/firmware_image.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/firmware_image.cpp
@@ -753,7 +753,7 @@ firmwareImage::firmwareImage(const std::string& file, imageType type) :
     }
     else
     {
-        if (type != MCS_FIRMWARE_PRIMARY)
+        if (type != BMC_FIRMWARE && type != MCS_FIRMWARE_PRIMARY)
         {
             this->setstate(failbit);
             std::cout << "non-dsabin supports only primary bitstream: " << file << std::endl;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Original issue states we are not able to flash SC firmware on u50. However this extends to all cards when flashing the SC with a non valid file format.

Ex. A u200 flashing failure
```
root@xsjsagarw50:~# xbmgmt program -d b3:00 -b sc --image /tmp/sc-fw/opt/xilinx/firmware/sc-fw/u200-u250/sc-fw-u200-u250-4.6.20-8ccda94e4c34f21bb5eba0b9b7ef9ef0.txt
Warning: Non-xsabin file detected. Development usage, this may damage the card
Are you sure you wish to proceed? [Y/n]: y
Stopping user function...
non-dsabin supports only primary bitstream: /tmp/sc-fw/opt/xilinx/firmware/sc-fw/u200-u250/sc-fw-u200-u250-4.6.20-8ccda94e4c34f21bb5eba0b9b7ef9ef0.txt
XRT build version: 2.13.446
Build hash: 02a676c5f58a941f61751a0986f6337e78ea8632
Build date: 2022-03-28 14:03:20
Git branch: 2022.1
PID: 188966
UID: 0
[Tue Apr  5 17:52:48 2022 GMT]
HOST: xsjsagarw50
EXE: /opt/xilinx/xrt/bin/unwrapped/xbmgmt2
[xbmgmt] ERROR: Failed to read /tmp/sc-fw/opt/xilinx/firmware/sc-fw/u200-u250/sc-fw-u200-u250-4.6.20-8ccda94e4c34f21bb5eba0b9b7ef9ef0.txt: Invalid argument
root@xsjsagarw50:~# echo $?
1
```

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Looks like BMC_FIRMWARE was not added as a valid firmware option. This was possible int he previous xbmgmt version so this was just an oversight.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Add BMC firmware as valid image type for firmware flashing.

#### Risks (if any) associated the changes in the commit
None, this change is to mirror older xbmgmt functionality.

#### What has been tested and how, request additional testing if necessary
On u200:
```
root@xsjsagarw50:/tmp/sc-fw/opt/xilinx/firmware/sc-fw/u200-u250# xbmgmt program -d b3:00 -b sc --image /tmp/sc-fw/opt/xilinx/firmware/sc-fw/u200-u250/sc-fw-u200-u250-4.6.20-8ccda94e4c34f21bb5eba0b9b7ef9ef0.txt
Warning: Non-xsabin file detected. Development usage, this may damage the card
Are you sure you wish to proceed? [Y/n]: y
Stopping user function...
INFO     : found 5 sections
[PASSED] : SC successfully updated < 44s >
INFO     : Loading new firmware on SC
.
root@xsjsagarw50:/tmp/sc-fw/opt/xilinx/firmware/sc-fw/u200-u250# echo $?
0
```

#### Documentation impact (if any)
None