### PR TITLE
CR-1127707 xbmgmt dump -d 0000:41:00.0 -f does not work for u25

### DIFF
--- a/src/runtime_src/core/pcie/tools/xbflash.qspi/xqspips.cpp
+++ b/src/runtime_src/core/pcie/tools/xbflash.qspi/xqspips.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2018 Xilinx, Inc
+ * Copyright (C) 2016-2022 Xilinx, Inc
  * Author(s) : Min Ma
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/src/runtime_src/core/pcie/tools/xbflash.qspi/xqspips.cpp
+++ b/src/runtime_src/core/pcie/tools/xbflash.qspi/xqspips.cpp
@@ -499,6 +499,24 @@ int XQSPIPS_Flasher::xclReadBack(std::string output, unsigned base, unsigned tot
     unsigned size = 0;
     int beatCount = 0;
 
+    initQSpiPS();
+
+    uint32_t StatusReg = XQSpiPS_GetStatusReg();
+
+    if (StatusReg == 0xFFFFFFFF) {
+        std::cout << "[ERROR]: Read PCIe device return -1. Cannot get QSPI status." << std::endl;
+        exit(-EOPNOTSUPP);
+    }
+
+    /* Make sure it is ready to receive commands. */
+    resetQSpiPS();
+    XQSpiPS_Enable_GQSPI();
+
+    if (!getFlashID()) {
+        std::cout << "[ERROR]: Could not get Flash ID" << std::endl;
+        exit(-EOPNOTSUPP);
+    }
+
     std::ofstream of_flash;
     of_flash.open(output, std::ofstream::out);
     if (!of_flash.is_open()) {

--- a/src/runtime_src/core/tools/xbmgmt2/flash/xqspips.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/xqspips.cpp
@@ -482,6 +482,24 @@ unsigned int XQSPIPS_Flasher::getFlashSize()
 
 void XQSPIPS_Flasher::readBack(const std::string& output, unsigned int base)
 {
+    initQSpiPS();
+
+    uint32_t StatusReg = XQSpiPS_GetStatusReg();
+
+    if (StatusReg == 0xFFFFFFFF) {
+        std::cout << "[ERROR]: Read PCIe device return -1. Cannot get QSPI status." << std::endl;
+        return;
+    }
+
+    /* Make sure it is ready to receive commands. */
+    resetQSpiPS();
+    XQSpiPS_Enable_GQSPI();
+
+    if (!getFlashID()) {
+        std::cout << "[ERROR]: Could not get Flash ID" << std::endl;
+        return;
+    }
+
     std::ofstream of_flash;
     of_flash.open(output, std::ofstream::out);
     if (!of_flash.is_open()) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
xbmgmt dump -f gets stuck for u25
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1127707 filed by DSV
#### How problem was solved, alternative solutions (if any) and why they were rejected
If read flash is the very first cmd to access flash, some required initialization is not done
#### Risks (if any) associated the changes in the commit
risk is low. qspips flash/erase work as expected, the change just fix the issue that read is the first cmd to access flash
#### What has been tested and how, request additional testing if necessary
both xbmgmt and xbflash have the same issue.
#### Documentation impact (if any)
N/A