### PR TITLE
CR-1127564 Azure: bypass unattested xclbin check for internal testing (#6564)

### DIFF
--- a/src/runtime_src/core/pcie/tools/cloud-daemon/azure/azure.cpp
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/azure/azure.cpp
@@ -1,5 +1,5 @@
 /*
- * Partial Copyright (C) 2019-2021 Xilinx, Inc
+ * Partial Copyright (C) 2019-2022 Xilinx, Inc
  *
  * Microsoft provides sample code how RESTful APIs are being called
  *
@@ -225,6 +225,7 @@ static size_t WriteCallback(void *contents, size_t size, size_t nmemb, void *use
 int AzureDev::azureLoadXclBin(const xclBin *buffer)
 {
     char *xclbininmemory = reinterpret_cast<char*> (const_cast<xclBin*> (buffer));
+
     if (memcmp(xclbininmemory, "xclbin2", 8) != 0)
         return -1;
     std::string fpgaSerialNumber;
@@ -234,8 +235,14 @@ int AzureDev::azureLoadXclBin(const xclBin *buffer)
         return -E_EMPTY_SN;
     std::cout << "LoadXclBin FPGA serial No: " << fpgaSerialNumber << std::endl;
 
+    bool allow_unattested_xclbin = false;
+    char* env = getenv("ALLOW_UNATTESTED_XCLBIN");
+    if (env && !strcmp(env, "true"))
+        allow_unattested_xclbin = true;
+
     // check if the xclbin is valid
-    if (xclbin::get_axlf_section(buffer, BITSTREAM) != nullptr) {
+    if (!allow_unattested_xclbin &&
+        (xclbin::get_axlf_section(buffer, BITSTREAM) != nullptr)) {
         std::cout << "xclbin is invalid, please provide azure xclbin" << std::endl;
         return -E_INVALID_XCLBIN;
     }


### PR DESCRIPTION
* CR-1127564 Azure: bypass unattested xclbin check for internal testing

Since the standalone ZT servers does not have the same infrastructure of Azure,
this change facilitates verifying xclbin download without recompiling XRT.

User has to add the environment settings in following way

1. Run command "systemctl edit mpd"
2. add below lines in file opened
  [Service]
  Environment="AZURE_UNATTESTED_XCLBIN=true"
3. save the file
4. restart mpd service using command "systemctl restart mpd"

Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>

* Fix review comments

Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>
(cherry picked from commit 7bf400e9c83517832239d279c77171eccd731539)