### PR TITLE
CR-1127448 Backport - Unable to flash SC firmware on u50 platform

### DIFF
--- a/src/runtime_src/core/tools/xbmgmt2/flash/firmware_image.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/firmware_image.cpp
@@ -753,7 +753,7 @@ firmwareImage::firmwareImage(const std::string& file, imageType type) :
     }
     else
     {
-        if (type != MCS_FIRMWARE_PRIMARY)
+        if ((type != BMC_FIRMWARE) && (type != MCS_FIRMWARE_PRIMARY))
         {
             this->setstate(failbit);
             std::cout << "non-dsabin supports only primary bitstream: " << file << std::endl;


### PR DESCRIPTION
* CR-1127448 Add BMC firmware as valid image type for firmware flashing

* Add brackets around conditionals

(cherry picked from commit 8580baf66e3460410b4ed6cf618193a4ff3a189e)
Original PR: https://github.com/Xilinx/XRT/pull/6566
