### PR TITLE
CR-1126396 xbtop python crash

### DIFF
--- a/src/runtime_src/core/tools/xbtop/XBUtil.py
+++ b/src/runtime_src/core/tools/xbtop/XBUtil.py
@@ -141,7 +141,7 @@ def get_percentage(usage, size):
 
     percent = usage * 100 / size
 
-    return "%.2f %" % percent
+    return "%.2f %%" % percent
 
 def convert_size(size_bytes):
     if size_bytes == 0:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
xbtop throws a python exception when displaying the memory data due to a format exception.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Introduced in https://github.com/Xilinx/XRT/pull/6501 due to python version issues.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Problem was fixed by using a format that is acceptable across all python versions. IE adding a % character

#### Risks (if any) associated the changes in the commit
None. This is a fix for an issue.

#### What has been tested and how, request additional testing if necessary
Using Python 3.8:
![image](https://user-images.githubusercontent.com/94083344/162081227-0d8c2cba-0ab5-4adc-ba27-ec41b035712c.png)

#### Documentation impact (if any)
None