### PR TITLE
CR-1125969 U55C program from recovery image attempts SC update

### DIFF
--- a/src/runtime_src/core/tools/xbmgmt2/ReportPlatform.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/ReportPlatform.cpp
@@ -282,6 +282,7 @@ ReportPlatform::getPropertyTree20202( const xrt_core::device * device,
               pt_current_shell.get<std::string>("id", ""), installedDSA));
     pt_status.put("sc", same_sc( pt_current_shell.get<std::string>("sc_version", ""), installedDSA));
     pt_status.put("is_factory", xrt_core::device_query<xrt_core::query::is_mfg>(device));
+    pt_status.put("is_recovery", xrt_core::device_query<xrt_core::query::is_recovery>(device));
     pt_platform.add_child("status", pt_status);
 
     pt_available_shells.push_back( std::make_pair("", pt_available_shell) );

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -305,7 +305,7 @@ report_status(const std::string& vbnv, boost::property_tree::ptree& pt_device)
   if (!pt_device.get<bool>("platform.status.shell"))
     action_list << boost::format("  [%s] : Program base (FLASH) image\n") % pt_device.get<std::string>("platform.bdf");
 
-  if (!pt_device.get<bool>("platform.status.sc") && !pt_device.get<bool>("platform.status.is_factory"))
+  if (!pt_device.get<bool>("platform.status.sc") && !pt_device.get<bool>("platform.status.is_factory") && !pt_device.get<bool>("platform.status.is_recovery"))
     action_list << boost::format("  [%s] : Program Satellite Controller (SC) image\n") % pt_device.get<std::string>("platform.bdf");
   
   if (!action_list.str().empty()) {

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -538,8 +538,8 @@ auto_flash(std::shared_ptr<xrt_core::device> & working_device, Flasher::E_Flashe
     try {
       std::cout << std::endl;
       // 1) Flash the Satellite Controller image
-      if (xrt_core::device_query<xrt_core::query::is_mfg>(working_device.get()))
-        report_stream << boost::format("  [%s] : Factory image detected. Reflash the device after the reboot to update the SC firmware.\n") % getBDF(p.first);
+      if (xrt_core::device_query<xrt_core::query::is_mfg>(working_device.get()) || xrt_core::device_query<xrt_core::query::is_recovery>(working_device.get()))
+        report_stream << boost::format("  [%s] : Factory or Recovery image detected. Reflash the device after the reboot to update the SC firmware.\n") % getBDF(p.first);
       else {
         if (update_sc(p.first, p.second) == true)  {
           report_stream << boost::format("  [%s] : Successfully flashed the Satellite Controller (SC) image\n") % getBDF(p.first);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1125969
In today's 2022.1 daily latest XRT (2.13.424) when flashing the platform onto the U55C from the recovery image, XRT attempts to program the SC controller. This should not happen!

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Introduced in https://github.com/Xilinx/XRT/pull/6321. The extra condition for the recovery image was not added at that time.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added a recovery image check onto the SC flashing code block

#### Risks (if any) associated the changes in the commit
None, this is the intended functionality.

#### What has been tested and how, request additional testing if necessary
On u55c with a recovery image:
```
root@xsjpranjal01:~# xbmgmt program -b -d 02:00
----------------------------------------------------
Device : [0000:02:00.0]

Current Configuration
  Platform             : xilinx_u55c_recovery
  SC Version           : INACTIVE
  Platform ID          : 0x0


Incoming Configuration
  Deployment File      : partition.xsabin
  Deployment Directory : /lib/firmware/xilinx/97088961feaeda9152a21d9dfd63ccef
  Size                 : 128,554,724 bytes
  Timestamp            : Mon Apr  4 15:57:43 2022

  Platform             : xilinx_u55c_gen3x16_xdma_base_3
  SC Version           : 7.1.17
  Platform UUID        : 97088961-FEAE-DA91-52A2-1D9DFD63CCEF
----------------------------------------------------
Actions to perform:
  [0000:02:00.0] : Program base (FLASH) image
----------------------------------------------------
Are you sure you wish to proceed? [Y/n]: Y

[0000:02:00.0] : Updating base (e.g., shell) flash image...
Bitstream guard installed on flash @0x1002000
Persisted 594140 bytes of meta data to flash 0 @0x7f6eef8
Extracting bitstream from MCS data:
.............................................
Extracted 46526952 bytes from bitstream @0x1002000
Writing bitstream to flash 0:
.............................................
Bitstream guard removed from flash
INFO     : Base flash image has been programmed successfully.
----------------------------------------------------
Report
  [0000:02:00.0] : Factory or Recovery image detected. Reflash the device after the reboot to update the SC firmware.
  [0000:02:00.0] : Successfully flashed the base (e.g., shell) image

Device flashed successfully.
****************************************************
Cold reboot machine to load the new image on device.
****************************************************
```

#### Documentation impact (if any)
None