### PR TITLE
Improve modularity of some core CMake files

### DIFF
--- a/build/build-win19.sh
+++ b/build/build-win19.sh
@@ -7,7 +7,7 @@
 set -e
 
 BUILDDIR=$(readlink -f $(dirname ${BASH_SOURCE[0]}))
-CORE=7
+CORE=`grep -c ^processor /proc/cpuinfo`
 
 CMAKE="/mnt/c/Program Files/CMake/bin/cmake.exe"
 XRT=/mnt/c/Xilinx/xrt
@@ -27,6 +27,7 @@ usage()
     echo "[-xrt]                     XRT root directory (default: $XRT)"
     echo "[-boost]                   BOOST libaries root directory (default: $BOOST)"
     echo "[-nocmake]                 Do not rerun cmake generation, just build"
+    echo "[-noabi]                   Do compile with ABI version check"
     echo "[-mcdm]                    Build mcdm subset"
     echo "[-j <n>]                   Compile parallel (default: system cores)"
     echo "[-dbg]                     Build debug library (default: optimized)"
@@ -38,6 +39,7 @@ usage()
 clean=0
 jcore=$CORE
 nocmake=0
+noabi=0
 dbg=0
 release=1
 cmake_flags="-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
@@ -86,6 +88,10 @@ while [ $# -gt 0 ]; do
             ;;
         -nocmake)
             nocmake=1
+            shift
+            ;;
+        -noabi)
+            cmake_flags+=" -DDISABLE_ABI_CHECK=1"
             shift
             ;;
         *)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2018-2022 Xilinx, Inc. All rights reserved.
+# Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
 cmake_minimum_required(VERSION 3.5.0)
 project(XRT)
 set(PROJECT_DESCRIPTION "https://github.com/Xilinx/XRT")
@@ -55,6 +56,10 @@ if (DEFINED ENV{XRT_CLANGTIDY_REVIEW})
   set(XRT_CLANGTIDY_REVIEW "yes")
   set(XRT_AIE_BUILD "yes")
   add_compile_options("-DXRT_ENABLE_AIE")
+endif()
+
+if (DISABLE_ABI_CHECK)
+  add_compile_options("-DDISABLE_ABI_CHECK")
 endif()
 
 if (NOT CMAKE_BUILD_TYPE)

--- a/src/runtime_src/core/common/CMakeLists.txt
+++ b/src/runtime_src/core/common/CMakeLists.txt
@@ -1,59 +1,71 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2019-2022 Xilinx, Inc. All rights reserved.
+# Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+add_subdirectory(api)
 
-if (NOT WIN32)
-include_directories(${DRM_INCLUDE_DIRS})
-
-endif (NOT WIN32)
-
-file(GLOB XRT_CORE_COMMON_SRC_SHARED
-  "config_reader.cpp"
-  "debug.cpp"
-  "debug_ip.cpp"
-  "device.cpp"
-  "error.cpp"
-  "info_*.cpp"
-  "message.cpp"
-  "module_loader.cpp"
-  "query_requests.cpp"
-  "sensor.cpp"
-  "system.cpp"
-  "thread.cpp"
-  "time.cpp"
-  "utils.cpp"
-  "xclbin_parser.cpp"
-  "xclbin_swemu.cpp"
-  "api/*.cpp"
+add_library(core_common_library_objects OBJECT
+  config_reader.cpp
+  debug.cpp
+  debug_ip.cpp
+  device.cpp
+  error.cpp
+  info_aie.cpp
+  info_memory.cpp
+  info_platform.cpp
+  info_vmr.cpp
+  message.cpp
+  module_loader.cpp
+  query_requests.cpp
+  sensor.cpp
+  system.cpp
+  thread.cpp
+  time.cpp
+  utils.cpp
+  xclbin_parser.cpp
+  xclbin_swemu.cpp
   )
 
-if (DEFINED XRT_AIE_BUILD)
-  message("-- enabling api aie build")
-  list(APPEND XRT_CORE_COMMON_SRC_SHARED "api/aie/xrt_graph.cpp")
-endif()
-
-# The static library files may not contain dependencies on dwarf/elf/ffi
-# so can't include ps kernel sources
-set(XRT_CORE_COMMON_SRC_STATIC ${XRT_CORE_COMMON_SRC_SHARED})
-
-# Files to include in object list
-file(GLOB XRT_CORE_COMMON_SRC_OBJ
-  "scheduler.cpp"
+target_include_directories(core_common_library_objects
+  PRIVATE
+  ${XRT_SOURCE_DIR}/runtime_src
   )
 
-add_compile_options("-DXRT_VERSION_MAJOR=\"${XRT_VERSION_MAJOR}\"")
+target_compile_definitions(core_common_library_objects
+  PRIVATE
+  XRT_VERSION_MAJOR="${XRT_VERSION_MAJOR}"
+  )
 
-add_library(xrt_coreutil SHARED ${XRT_CORE_COMMON_SRC_SHARED})
-add_library(xrt_coreutil_static STATIC ${XRT_CORE_COMMON_SRC_STATIC})
+# The scheduler object files are for auto config of scheduler. These
+# files reference xrt_core symbols, hence are excluded from
+# xrt_corecommon shared library and instead linked explicitly into
+# client (core) libraries
+add_library(core_common_objects OBJECT scheduler.cpp)
+target_include_directories(core_common_objects
+  PRIVATE
+  ${XRT_SOURCE_DIR}/runtime_src
+  )
+
+add_library(xrt_coreutil SHARED
+  $<TARGET_OBJECTS:core_common_library_objects>
+  $<TARGET_OBJECTS:core_common_api_library_objects>
+  )
+
+add_library(xrt_coreutil_static STATIC
+  $<TARGET_OBJECTS:core_common_library_objects>
+  $<TARGET_OBJECTS:core_common_api_library_objects>
+  )
 
 set_target_properties(xrt_coreutil PROPERTIES
   VERSION ${XRT_VERSION_STRING}
-  SOVERSION ${XRT_SOVERSION})
+  SOVERSION ${XRT_SOVERSION}
+  )
 
 # Private dependencies for fully resolved dynamic xrt_coreutil
 target_link_libraries(xrt_coreutil
   PRIVATE
   ${Boost_FILESYSTEM_LIBRARY}
-  ${Boost_SYSTEM_LIBRARY})
+  ${Boost_SYSTEM_LIBRARY}
+  )
 
 # Targets linking with xrt_coreutil_static must also link with boost
 # libraries used by coreutil.  These type of link dependencies are
@@ -63,7 +75,8 @@ target_link_libraries(xrt_coreutil
 target_link_libraries(xrt_coreutil_static
   INTERFACE
   boost_filesystem
-  boost_system)
+  boost_system
+  )
 
 if (NOT WIN32)
   # Additional link dependencies for xrt_coreutil
@@ -73,7 +86,6 @@ if (NOT WIN32)
   # Targets of xrt_coreutil_static must link with these additional
   # system libraries
   target_link_libraries(xrt_coreutil_static INTERFACE uuid dl rt pthread)
-
 endif()
 
 install(TARGETS xrt_coreutil
@@ -87,9 +99,3 @@ install(TARGETS xrt_coreutil xrt_coreutil_static
   ARCHIVE DESTINATION ${XRT_INSTALL_LIB_DIR} COMPONENT ${XRT_DEV_COMPONENT}
   LIBRARY DESTINATION ${XRT_INSTALL_LIB_DIR} COMPONENT ${XRT_DEV_COMPONENT} ${XRT_NAMELINK_ONLY}
 )
-
-# The scheduler object files are for auto config of scheduler. These
-# files reference xrt_core symbols, hence are excluded from
-# xrt_corecommon shared library and instead linked explicitly into
-# client (core) libraries
-add_library(core_common_objects OBJECT ${XRT_CORE_COMMON_SRC_OBJ})

--- a/src/runtime_src/core/common/api/CMakeLists.txt
+++ b/src/runtime_src/core/common/api/CMakeLists.txt
@@ -19,8 +19,15 @@ add_library(core_common_api_library_objects OBJECT
   xrt_queue.cpp
   xrt_system.cpp
   xrt_xclbin.cpp
-  aie/xrt_graph.cpp
   )
+
+if (DEFINED XRT_AIE_BUILD)
+  message("-- enabling api aie build")
+  target_sources(core_common_api_library_objects
+    PRIVATE
+    aie/xrt_graph.cpp)
+endif()
+
 
 target_include_directories(core_common_api_library_objects
   PRIVATE

--- a/src/runtime_src/core/common/api/CMakeLists.txt
+++ b/src/runtime_src/core/common/api/CMakeLists.txt
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+add_library(core_common_api_library_objects OBJECT
+  context_mgr.cpp
+  exec.cpp
+  kds.cpp
+  native_profile.cpp
+  sws.cpp
+  xrt_bo.cpp
+  xrt_device.cpp
+  xrt_enqueue.cpp
+  xrt_error.cpp
+  xrt_ini.cpp
+  xrt_ip.cpp
+  xrt_kernel.cpp
+  xrt_message.cpp
+  xrt_pipeline.cpp
+  xrt_profile.cpp
+  xrt_queue.cpp
+  xrt_system.cpp
+  xrt_xclbin.cpp
+  aie/xrt_graph.cpp
+  )
+
+target_include_directories(core_common_api_library_objects
+  PRIVATE
+  ${XRT_SOURCE_DIR}/runtime_src
+  )

--- a/src/runtime_src/core/common/api/xrt_queue.cpp
+++ b/src/runtime_src/core/common/api/xrt_queue.cpp
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2022 Xilinx, Inc. All rights reserved.
+// Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
 
 // This file implements XRT xclbin APIs as declared in
 // core/include/experimental/xrt_queue.h
-#define XCL_DRIVER_DLL_EXPORT  // exporting xrt_queue.h
+#define XRT_API_SOURCE         // exporting xrt_queue.h
 #define XRT_CORE_COMMON_SOURCE // in same dll as core_common
 #include "core/include/experimental/xrt_queue.h"
 

--- a/src/runtime_src/core/common/scheduler.h
+++ b/src/runtime_src/core/common/scheduler.h
@@ -17,8 +17,8 @@
 #ifndef core_common_scheduler_h_
 #define core_common_scheduler_h_
 
-#include "xrt.h"
-#include "xclbin.h"
+#include "core/include/xrt.h"
+#include "core/include/xclbin.h"
 
 // This is interim, must be consolidated with runtime_src/xrt/scheduler
 // when XRT C++ code is refactored.

--- a/src/runtime_src/core/include/experimental/xrt_queue.h
+++ b/src/runtime_src/core/include/experimental/xrt_queue.h
@@ -1,22 +1,10 @@
-/*
- * Copyright (C) 2022, Xilinx Inc - All rights reserved
- * Xilinx Runtime (XRT) Experimental APIs
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2022 Xilinx, Inc. All rights reserved.
+// Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
 #ifndef XRT_QUEUE_H_
 #define XRT_QUEUE_H_
+
+#include "xrt/detail/config.h"
 
 #ifdef __cplusplus
 # include <algorithm>
@@ -177,6 +165,7 @@ public:
 
 private:
   // Add task to queue
+  XRT_API_EXPORT
   void
   add_task(task&& ev);
 
@@ -186,6 +175,7 @@ public:
    *
    * The queue is constructed with one consumer thread.
    */
+  XRT_API_EXPORT
   queue();
 
   /**

--- a/src/runtime_src/core/include/xrt/CMakeLists.txt
+++ b/src/runtime_src/core/include/xrt/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2019-2021 Xilinx, Inc. All rights reserved.
-#
+# Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
 set(XRT_XRT_HEADER_SRC
   xrt_aie.h
   xrt_bo.h
@@ -15,6 +15,7 @@ install (FILES ${XRT_XRT_HEADER_SRC} DESTINATION ${XRT_INSTALL_INCLUDE_DIR}/xrt 
 set(XRT_XRT_DETAIL_HEADER_SRC
   detail/abi.h
   detail/any.h
+  detail/config.h
   detail/param_traits.h
   detail/pimpl.h)
 

--- a/src/runtime_src/core/include/xrt/detail/config.h
+++ b/src/runtime_src/core/include/xrt/detail/config.h
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+#ifndef XRT_DETAIL_CONFIG_H
+#define XRT_DETAIL_CONFIG_H
+
+//------------------Enable dynamic linking on windows-------------------------//
+
+#ifdef _WIN32
+# ifdef XRT_API_SOURCE
+#  define XRT_API_EXPORT __declspec(dllexport)
+# else
+#  define XRT_API_EXPORT __declspec(dllimport)
+# endif
+#endif
+#ifdef __GNUC__
+# ifdef XRT_API_SOURCE
+#  define XRT_API_EXPORT __attribute__ ((visibility("default")))
+# else
+#  define XRT_API_EXPORT
+# endif
+#endif
+
+#ifndef XRT_API_EXPORT
+# define XRT_API_EXPORT
+#endif
+
+#endif

--- a/src/runtime_src/core/pcie/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/CMakeLists.txt
@@ -1,14 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2019-2021 Xilinx, Inc. All rights reserved.
-#
+# Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
 include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}
   )
 
+add_subdirectory(common)
+add_subdirectory(tools)
+
 if(NOT WIN32)
-  add_subdirectory(common)
   add_subdirectory(linux)
-  add_subdirectory(tools)
   add_subdirectory(driver)
   if (${CMAKE_SYSTEM_PROCESSOR} STREQUAL "x86_64")
     # Emulation flow only works on x86_64
@@ -17,5 +18,4 @@ if(NOT WIN32)
   endif()
 else()
   add_subdirectory(windows)
-  add_subdirectory(tools)
 endif(NOT WIN32)

--- a/src/runtime_src/core/pcie/common/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/common/CMakeLists.txt
@@ -1,34 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (C) 2019-2021 Xilinx, Inc. All rights reserved.
-#
-include_directories(
-  ${CMAKE_CURRENT_SOURCE_DIR}
-  ${DRM_INCLUDE_DIRS}
+# Copyright (C) 2019-2022 Xilinx, Inc. All rights reserved.
+add_library(core_pciecommon_objects OBJECT
+  aie_stubs.cpp
+  device_pcie.cpp
+  system_pcie.cpp
   )
 
-file(GLOB XRT_CORE_PCIE_COMMON_FILES
-  "*.h"
-  "*.cpp"
+target_include_directories(core_pciecommon_objects
+  PRIVATE
+  ${XRT_SOURCE_DIR}/runtime_src
+  ${XRT_BINARY_DIR}/gen
   )
-
-# The class device_pcie should be in the pcie/common folder.  Unfortunately,
-# windows doesn't use the core_pciecommon_objects due to build issues.  So
-# for now exclude these files.
-#
-# Note: These files are linked in directly via the pcie/linux and
-#       pcie/windows CMakeList.txt.
-# Note: Would have preferrred to use list(FILTER ... to remove these files, but
-#       Ubunutu 16.04 version of cmake doesn't support this, for example:
-#          list(FILTER XRT_CORE_PCIE_COMMON_FILES EXCLUDE REGEX ".*device_pcie.cpp$|.*device_pcie.h$")
-get_filename_component(full_path_device_pcie_cpp ${CMAKE_CURRENT_SOURCE_DIR}/device_pcie.cpp ABSOLUTE)
-list(REMOVE_ITEM XRT_CORE_PCIE_COMMON_FILES "${full_path_device_pcie_cpp}")
-get_filename_component(full_path_device_pcie_h ${CMAKE_CURRENT_SOURCE_DIR}/device_pcie.h ABSOLUTE)
-list(REMOVE_ITEM XRT_CORE_PCIE_COMMON_FILES "${full_path_device_pcie_h}")
-get_filename_component(full_path_system_pcie_cpp ${CMAKE_CURRENT_SOURCE_DIR}/system_pcie.cpp ABSOLUTE)
-list(REMOVE_ITEM XRT_CORE_PCIE_COMMON_FILES "${full_path_system_pcie_cpp}")
-get_filename_component(full_path_system_pcie_h ${CMAKE_CURRENT_SOURCE_DIR}/system_pcie.h ABSOLUTE)
-list(REMOVE_ITEM XRT_CORE_PCIE_COMMON_FILES "${full_path_system_pcie_h}")
-get_filename_component(full_path_aie_stubs_cpp ${CMAKE_CURRENT_SOURCE_DIR}/aie_stubs.cpp ABSOLUTE)
-list(REMOVE_ITEM XRT_CORE_PCIE_COMMON_FILES "${full_path_aie_stubs_cpp}")
-
-add_library(core_pciecommon_objects OBJECT ${XRT_CORE_PCIE_COMMON_FILES})

--- a/src/runtime_src/core/pcie/linux/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/linux/CMakeLists.txt
@@ -1,40 +1,36 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (C) 2019-2021 Xilinx, Inc. All rights reserved.
-#
-include_directories(
-  ${CMAKE_CURRENT_SOURCE_DIR}
-  ${DRM_INCLUDE_DIRS}
-  ${CURSES_INCLUDE_DIRS}
-  ${CMAKE_BINARY_DIR}
+# Copyright (C) 2019-2022 Xilinx, Inc. All rights reserved.
+add_subdirectory(plugin/xdp)
+
+add_library(core_pcielinux_objects OBJECT
+  debug.cpp
+  device_linux.cpp
+  scan.cpp
+  shim.cpp
+  system_linux.cpp
   )
 
-file(GLOB XRT_PCIE_LINUX_PLUGIN_XDP_FILES
-  "plugin/xdp/*.h"
-  "plugin/xdp/*.cpp"
+target_compile_definitions(core_pcielinux_objects
+  PRIVATE
+  XCLHAL_MAJOR_VER=2
+  XCLHAL_MINOR_VER=1
   )
 
-file(GLOB XRT_PCIE_LINUX_FILES
-  "*.h"
-  "*.cpp"
-  "../common/aie_stubs.cpp"
-  "../common/system_pcie.cpp"
-  "../common/device_pcie.cpp"
+target_include_directories(core_pcielinux_objects
+  PRIVATE
+  ${XRT_SOURCE_DIR}/runtime_src
+  ${XRT_BINARY_DIR}/gen
   )
 
-set(CMAKE_CXX_FLAGS "-DXCLHAL_MAJOR_VER=2 ${CMAKE_CXX_FLAGS}")
-set(CMAKE_CXX_FLAGS "-DXCLHAL_MINOR_VER=1 ${CMAKE_CXX_FLAGS}")
 
-add_library(core_pcielinux_plugin_xdp_objects OBJECT ${XRT_PCIE_LINUX_PLUGIN_XDP_FILES})
-add_library(core_pcielinux_objects OBJECT ${XRT_PCIE_LINUX_FILES})
-
-add_library(xrt_core SHARED ""
+add_library(xrt_core SHARED
   $<TARGET_OBJECTS:core_pcielinux_plugin_xdp_objects>
   $<TARGET_OBJECTS:core_pcielinux_objects>
   $<TARGET_OBJECTS:core_pciecommon_objects>
   $<TARGET_OBJECTS:core_common_objects>
   )
 
-add_library(xrt_core_static STATIC ""
+add_library(xrt_core_static STATIC
   $<TARGET_OBJECTS:core_pcielinux_plugin_xdp_objects>
   $<TARGET_OBJECTS:core_pcielinux_objects>
   $<TARGET_OBJECTS:core_pciecommon_objects>

--- a/src/runtime_src/core/pcie/linux/plugin/xdp/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/linux/plugin/xdp/CMakeLists.txt
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+
+file(GLOB XRT_PCIE_LINUX_PLUGIN_XDP_FILES *.cpp)
+
+add_library(core_pcielinux_plugin_xdp_objects OBJECT
+  ${XRT_PCIE_LINUX_PLUGIN_XDP_FILES}
+  )
+
+target_include_directories(core_pcielinux_plugin_xdp_objects
+  PRIVATE
+  ${XRT_SOURCE_DIR}/runtime_src
+  ${XRT_SOURCE_DIR}/runtime_src/core/pcie/linux
+  )

--- a/src/runtime_src/core/pcie/noop/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/noop/CMakeLists.txt
@@ -1,44 +1,33 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (C) 2019-2021 Xilinx, Inc. All rights reserved.
-#
-include_directories(
-  ${CMAKE_CURRENT_SOURCE_DIR}
-  ${Boost_INCLUDE_DIRS}
-  ${CMAKE_BINARY_DIR}
-  )
-
-file(GLOB XRT_PCIE_NOOP_FILES
-  "*.h"
-  "*.cpp"
-  "../common/system_pcie.cpp"
-  "../common/device_pcie.cpp"
-  )
-
-file(GLOB XRT_PCIE_NOOP_SHARED_FILES
-  "shim.cpp"
-  "system_noop.cpp"
-  "../common/aie_stubs.cpp"
-  "../common/system_pcie.cpp"
-  "device_noop.cpp"
-  "../common/device_pcie.cpp"
-  )
-
-set(CMAKE_CXX_FLAGS "-DXCLHAL_MAJOR_VER=2 ${CMAKE_CXX_FLAGS}")
-set(CMAKE_CXX_FLAGS "-DXCLHAL_MINOR_VER=1 ${CMAKE_CXX_FLAGS}")
-
+# Copyright (C) 2019-2022 Xilinx, Inc. All rights reserved.
 add_library(xrt_noop SHARED
-  ${XRT_PCIE_NOOP_SHARED_FILES}
+  device_noop.cpp
+  shim.cpp
+  system_noop.cpp
+  $<TARGET_OBJECTS:core_pciecommon_objects>
   $<TARGET_OBJECTS:core_common_objects>
   )
 
-set_target_properties(xrt_noop PROPERTIES VERSION ${XRT_VERSION_STRING}
-  SOVERSION ${XRT_SOVERSION})
+target_include_directories(xrt_noop
+  PRIVATE
+  ${XRT_SOURCE_DIR}/runtime_src
+  )
+
+target_compile_definitions(xrt_noop
+  PRIVATE
+  XCLHAL_MAJOR_VER=2
+  XCLHAL_MINOR_VER=1
+  )
 
 target_link_libraries(xrt_noop
   PRIVATE
   xrt_coreutil
   pthread
   )
+
+set_target_properties(xrt_noop PROPERTIES
+  VERSION ${XRT_VERSION_STRING}
+  SOVERSION ${XRT_SOVERSION})
 
 install(TARGETS xrt_noop
   EXPORT xrt-targets

--- a/src/runtime_src/core/pcie/tools/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/tools/CMakeLists.txt
@@ -5,4 +5,3 @@ if(NOT WIN32)
   add_subdirectory(cloud-daemon)
   add_subdirectory(xbflash.qspi)
 endif(NOT WIN32)
-

--- a/src/runtime_src/core/pcie/windows/alveo/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/windows/alveo/CMakeLists.txt
@@ -1,45 +1,34 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2019-2021 Xilinx, Inc. All rights reserved.
-#
-include_directories(
-  ${CMAKE_CURRENT_SOURCE_DIR}
-  ${Boost_INCLUDE_DIRS}
-  ${CMAKE_BINARY_DIR}
+# Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+add_library(core_pciewindows_alveo_objects OBJECT
+  device_windows.cpp
+  mgmt.cpp
+  perf.cpp
+  shim.cpp
+  system_windows.cpp
   )
 
-file(GLOB XRT_PCIE_WINDOWS_FILES
-  "*.cpp"
-  "../../common/aie_stubs.cpp"
-  "../../common/system_pcie.cpp"
-  "../../common/device_pcie.cpp"
+target_compile_definitions(core_pciewindows_alveo_objects
+  PRIVATE
+  XCLHAL_MAJOR_VER=2
+  XCLHAL_MINOR_VER=1
   )
 
-file(GLOB XRT_PCIE_WINDOWS_STATIC_FILES
-  "device_windows.cpp"
-  "../../common/aie_stubs.cpp"
-  "../../common/system_pcie.cpp"
-  "../../common/device_pcie.cpp"
+target_include_directories(core_pciewindows_alveo_objects
+  PRIVATE
+  ${XRT_SOURCE_DIR}/runtime_src
+  ${XRT_BINARY_DIR}
   )
-
-file(GLOB XRT_PCIE_WINDOWS_SHARED_FILES
-  "shim.cpp"
-  "mgmt.cpp"
-  "perf.cpp"
-  "device_windows.cpp"
-  "system_windows.cpp"
-  "../../common/aie_stubs.cpp"
-  "../../common/system_pcie.cpp"
-  "../../common/device_pcie.cpp"
-  )
-
-set(CMAKE_CXX_FLAGS "-DXCLHAL_MAJOR_VER=2 ${CMAKE_CXX_FLAGS}")
-set(CMAKE_CXX_FLAGS "-DXCLHAL_MINOR_VER=1 ${CMAKE_CXX_FLAGS}")
 
 add_library(xrt_core SHARED
-  ${XRT_PCIE_WINDOWS_SHARED_FILES}
+  $<TARGET_OBJECTS:core_pciewindows_alveo_objects>
+  $<TARGET_OBJECTS:core_pciecommon_objects>
   )
+
 add_library(xrt_core_static STATIC
-  ${XRT_PCIE_WINDOWS_STATIC_FILES}
+  $<TARGET_OBJECTS:core_pciewindows_alveo_objects>
+  $<TARGET_OBJECTS:core_pciecommon_objects>
   )
 
 target_link_libraries(xrt_core

--- a/src/runtime_src/core/pcie/windows/mcdm/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/windows/mcdm/CMakeLists.txt
@@ -1,40 +1,32 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2022 Xilinx, Inc. All rights reserved.
-#
-include_directories(
-  ${CMAKE_CURRENT_SOURCE_DIR}
-  ${CMAKE_BINARY_DIR}
+# Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+add_library(core_pciewindows_mcdm_objects OBJECT
+  device_mcdm.cpp
+  shim.cpp
+  system_mcdm.cpp
   )
 
-file(GLOB XRT_PCIE_MCDM_FILES
-  "*.cpp"
-  "../../common/aie_stubs.cpp"
-  "../../common/system_pcie.cpp"
-  "../../common/device_pcie.cpp"
+target_compile_definitions(core_pciewindows_mcdm_objects
+  PRIVATE
+  XCLHAL_MAJOR_VER=2
+  XCLHAL_MINOR_VER=1
   )
 
-file(GLOB XRT_PCIE_MCDM_STATIC_FILES
-  "device_mcdm.cpp"
-  "../../common/aie_stubs.cpp"
-  "../../common/system_pcie.cpp"
-  "../../common/device_pcie.cpp"
-  )
-
-file(GLOB XRT_PCIE_MCDM_SHARED_FILES
-  "shim.cpp"
-  "mgmt.cpp"
-  "device_mcdm.cpp"
-  "system_mcdm.cpp"
-  "../../common/aie_stubs.cpp"
-  "../../common/system_pcie.cpp"
-  "../../common/device_pcie.cpp"
+target_include_directories(core_pciewindows_mcdm_objects
+  PRIVATE
+  ${XRT_SOURCE_DIR}/runtime_src
+  ${XRT_BINARY_DIR}
   )
 
 add_library(xrt_core SHARED
-  ${XRT_PCIE_MCDM_SHARED_FILES}
+  $<TARGET_OBJECTS:core_pciewindows_mcdm_objects>
+  $<TARGET_OBJECTS:core_pciecommon_objects>
   )
+
 add_library(xrt_core_static STATIC
-  ${XRT_PCIE_MCDM_STATIC_FILES}
+  $<TARGET_OBJECTS:core_pciewindows_mcdm_objects>
+  $<TARGET_OBJECTS:core_pciecommon_objects>
   )
 
 target_link_libraries(xrt_core

--- a/tests/xrt/enqueue/CMakeLists.txt
+++ b/tests/xrt/enqueue/CMakeLists.txt
@@ -1,13 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2021-2022 Xilinx, Inc. All rights reserved.
-#
+# Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
 CMAKE_MINIMUM_REQUIRED(VERSION 3.0.0)
 PROJECT(enqueue)
 set(TESTNAME "enqueue")
 
 include(../../CMake/utils.cmake)
 
-add_executable(enqueue enqueue.cpp)
+add_executable(enqueue enqueue2.cpp)
 target_link_libraries(enqueue PRIVATE ${xrt_coreutil_LIBRARY})
 
 if (NOT WIN32)

--- a/tests/xrt/enqueue/enqueue.cpp
+++ b/tests/xrt/enqueue/enqueue.cpp
@@ -1,8 +1,6 @@
-/**
- * Copyright (C) 2021 Xilinx, Inc
- * SPDX-License-Identifier: Apache-2.0
- */
-
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2021-2022 Xilinx, Inc. All rights reserved.
+// Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
 /****************************************************************
 Enqueue example illustrating use of xrt::enqueue APIs
 
@@ -28,8 +26,8 @@ event dependencies controlling the execution order.
          r[5]         r[6]
           |            |
          o[5]         o[6]
- 
-a[0..5]: 
+
+a[0..5]:
 xrt::bo objects that are synced to device and used as input to
 xrt::run objects.  Event dependencies ensure that no sync operation
 takes place before the receiving kernel is done with prior execution.
@@ -41,7 +39,7 @@ a[3] : r[2]
 a[4] : r[3], r[4]
 a[5] : r[6]
 
-r[0..6]: 
+r[0..6]:
 xrt::run objects from same xrt::kernel object.  Event dependencies
 ensure that run objects wait for (1) input to be synced and (2)
 receiving kernel is done with prior execution.
@@ -54,7 +52,7 @@ r[4] : a[4], r[1], r[6]
 r[5] : r[2], r[3], o[5]
 r[6] : r[4], r[5], o[6]
 
-o[o..6]: 
+o[o..6]:
 xrt::bo objects for kernel run outputs.  The outputs o[0..4] are used
 as input to following run objects. o[5] and o[6] are synced from
 device.
@@ -66,19 +64,20 @@ o[6] : r[6]
 
 
 #include "xrt.h"
-#include "xrt/xrt_kernel.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
+#include "xrt/xrt_kernel.h"
 #include "experimental/xrt_enqueue.h"
 #include "xclbin.h"
 
+#include <array>
+#include <atomic>
+#include <cstdlib>
 #include <fstream>
+#include <iostream>
 #include <list>
 #include <thread>
-#include <atomic>
-#include <iostream>
 #include <vector>
-#include <cstdlib>
 
 #ifdef _WIN32
 # pragma warning ( disable : 4267 )
@@ -173,7 +172,7 @@ struct job_type
 
     for (int i = 0; i < 6; ++i)
       a[i] = xrt::bo(device, data_size * sizeof(unsigned long), grpid0);
-    
+
     for (int i = 0; i < 7; ++i)
       o[i] = xrt::bo(device, data_size * sizeof(unsigned long), grpid1);
   }
@@ -228,7 +227,7 @@ struct job_type
 
     // sync a5 when r6 is done
     ea[5] = queue.enqueue_with_waitlist(sync, {er[6]}, a[5], XCL_BO_SYNC_BO_TO_DEVICE);
-    
+
     // run r0 when a0, a1, r2  are done
     er[0] = queue.enqueue_with_waitlist(r[0], {ea[0], ea[1], er[2]}, a[0], a[1], o[0], ELEMENTS);
 
@@ -252,7 +251,7 @@ struct job_type
 
     // sync o5 when r5 is done
     eo[5] = queue.enqueue_with_waitlist(sync, {er[5]}, o[5], XCL_BO_SYNC_BO_FROM_DEVICE);
-    
+
     // sync o6 when r6 is done
     eo[6] = queue.enqueue_with_waitlist(sync, {er[6]}, o[6], XCL_BO_SYNC_BO_FROM_DEVICE);
   }

--- a/tests/xrt/enqueue/enqueue2.cpp
+++ b/tests/xrt/enqueue/enqueue2.cpp
@@ -1,8 +1,6 @@
-/**
- * Copyright (C) 2022 Xilinx, Inc
- * SPDX-License-Identifier: Apache-2.0
- */
-
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2022 Xilinx, Inc. All rights reserved.
+// Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
 /****************************************************************
 Enqueue example illustrating use of xrt::queue APIs
 
@@ -114,6 +112,7 @@ q5: (r[6]) a[5]
 
 #include "experimental/xrt_queue.h"
 
+#include <array>
 #include <atomic>
 #include <cstdlib>
 #include <fstream>


### PR DESCRIPTION
#### Problem solved by the commit
Small step towards better structured makefiles using more modern CMake
design.  Use library targets and properties with targets; avoid
variables.

