### PR TITLE
Updating petalinux to 2022.1_stable_latest

### DIFF
--- a/build/petalinux.build
+++ b/build/petalinux.build
@@ -1,4 +1,3 @@
 # When updating Petalinux build please file a SH ticket to retain the build
 # https://jira.xilinx.com/secure/CreateIssue!default.jspa
-# Current ticket - https://jira.xilinx.com/browse/SH-1819
-PETALINUX="/proj/petalinux/2022.1/petalinux-v2022.1_03180759/tool/petalinux-v2022.1-final"
+PETALINUX="/proj/petalinux/2022.1/petalinux-v2022.1_stable_latest/tool/petalinux-v2022.1-final"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Updating petalinux version to 2022.1_stable_latest as 0318 build has been removed.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
PR#6535 had updated to 0318 petalinux, but that build was not kept

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
