### PR TITLE
CR-1128307 : Fix dangling pointer dereference issue while deleting kds client context in embedded platforms

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
@@ -842,6 +842,7 @@ void zocl_destroy_client(void *client_hdl)
 	struct kds_client *client = (struct kds_client *)client_hdl;
 	struct kds_sched  *kds = NULL;
 	struct kds_client_ctx *curr = NULL;
+	struct kds_client_ctx *tmp = NULL;
 	struct drm_zocl_slot *slot = NULL;
 	int pid = pid_nr(client->pid);
 
@@ -862,7 +863,7 @@ void zocl_destroy_client(void *client_hdl)
 	/* Delete all the existing context associated to this device for this
 	 * client.
 	 */
-	list_for_each_entry(curr, &client->ctx_list, link) {
+	list_for_each_entry_safe(curr, tmp, &client->ctx_list, link) {
 		/* Get the corresponding slot for this xclbin */
 		slot = zocl_get_slot(zdev, curr->xclbin_id);
 		if (!slot)
@@ -871,6 +872,7 @@ void zocl_destroy_client(void *client_hdl)
 		/* Unlock this slot specific xclbin */
 		zocl_unlock_bitstream(slot, curr->xclbin_id);
 		vfree(curr->xclbin_id);
+		list_del(&curr->link);
 		vfree(curr);
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Fix null pointer dereference which causes kernel crash in embedded platforms when kds client contexts are removed

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
PR- https://github.com/Xilinx/XRT/pull/6160 introduced this bug, it was discovered using sprite test case - uram_ecc_global_int

#### How problem was solved, alternative solutions (if any) and why they were rejected
we are freeing client but not deleting linked list node, added changes to delete node

#### Risks (if any) associated the changes in the commit
no

#### What has been tested and how, request additional testing if necessary
Ran application 1000 times, no issue is found

#### Documentation impact (if any)
NA