### PR TITLE
CR-1128706 XRT failure on kvm systems

### DIFF
--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdConfigure.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdConfigure.cpp
@@ -298,8 +298,7 @@ update_daemon_config(const std::string& host = "")
   if (!cfile)
     throw xrt_core::system_error(std::errc::invalid_argument, "Missing '" + std::string(config_file) + "'.  Cannot update");
 
-  if(host.empty())
-    cfg.host = host;
+  cfg.host = host;
   // update the configuration file
   cfile << boost::str(boost::format("%s\n") % cfg);
   std::cout << boost::format("Successfully updated the Daemon configuration.\n");

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdConfigure.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdConfigure.cpp
@@ -298,7 +298,8 @@ update_daemon_config(const std::string& host = "")
   if (!cfile)
     throw xrt_core::system_error(std::errc::invalid_argument, "Missing '" + std::string(config_file) + "'.  Cannot update");
 
-  cfg.host = host;
+  if (!host.empty())
+    cfg.host = host;
   // update the configuration file
   cfile << boost::str(boost::format("%s\n") % cfg);
   std::cout << boost::format("Successfully updated the Daemon configuration.\n");


### PR DESCRIPTION
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
The postinst script calls xbmgmt configure to start daemons for kvm. However, there is a small bug in the implementation. The host name is not updated in the configuration

#### How problem was solved, alternative solutions (if any) and why they were rejected
I removed the check which prevents this from happening.

#### Risks (if any) associated the changes in the commit
low to none

#### What has been tested and how, request additional testing if necessary
Manual testing on KVM and bare metal and pipeline testing

#### Documentation impact (if any)
