### PR TITLE
CR-1125007 hwmon_sdm: add changes to report sensor status

### DIFF
--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -911,6 +911,7 @@ struct sdm_sensor_info : request
     uint32_t max {};
     uint32_t average {};
     uint32_t highest {};
+    std::string status;
   };
   using result_type = std::vector<sensor_data>;
   using req_type = sdr_req_type;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/hwmon_sdm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/hwmon_sdm.c
@@ -35,12 +35,19 @@
 //TODO: fix it by issuing sensor size request to vmr.
 #define RESP_LEN 4096
 
+enum sensor_data_status {
+	SD_NOT_PRESENT		= 0,
+	SD_PRESENT		= 0x01,
+	SD_DATA_NOT_AVAILABLE	= 0x02,
+	SD_DEFAULT_VALUE	= 0x7F
+};
+
 enum sysfs_sdr_field_ids {
-    SYSFS_SDR_NAME,
-    SYSFS_SDR_INS_VAL,
-    SYSFS_SDR_MAX_VAL,
-    SYSFS_SDR_AVG_VAL,
-    SYSFS_SDR_STATUS_VAL,
+	SYSFS_SDR_NAME		= 0,
+	SYSFS_SDR_INS_VAL	= 1,
+	SYSFS_SDR_MAX_VAL	= 2,
+	SYSFS_SDR_AVG_VAL	= 3,
+	SYSFS_SDR_STATUS_VAL	= 4,
 };
 
 struct xocl_sdr_bdinfo {
@@ -322,16 +329,16 @@ static ssize_t hwmon_sensor_show(struct device *dev,
 	} else if (field_id == SYSFS_SDR_STATUS_VAL) {
 		memcpy(&uval, &sdm->sensor_data[repo_id][buf_index], buf_len);
 		switch(uval) {
-		case 0x00:
+		case SD_NOT_PRESENT:
 			sz = sprintf(buf, "%s\n", "Sensor Not Present");
 			break;
-		case 0x01:
+		case SD_PRESENT:
 			sz = sprintf(buf, "%s\n", "Sensor Present and Valid");
 			break;
-		case 0x02:
+		case SD_DATA_NOT_AVAILABLE:
 			sz = sprintf(buf, "%s\n", "Data Not Available");
 			break;
-		case 0x7F:
+		case SD_DEFAULT_VALUE:
 			sz = sprintf(buf, "%s\n", "Not Applicable or Default Value");
 			break;
 		default:
@@ -625,44 +632,44 @@ static int parse_sdr_info(char *in_buf, struct xocl_hwmon_sdm *sdm, bool create_
 				case SDR_TYPE_TEMP:
 					memcpy(sensor_name, &in_buf[name_index], name_length);
 					if (strstr(sensor_name, "fan")) {
-						sprintf(sysfs_name[4], "fan%d_status", fan_index);
-						sprintf(sysfs_name[1], "fan%d_input", fan_index);
-						sprintf(sysfs_name[0], "fan%d_label", fan_index);
+						sprintf(sysfs_name[SYSFS_SDR_STATUS_VAL], "fan%d_status", fan_index);
+						sprintf(sysfs_name[SYSFS_SDR_INS_VAL], "fan%d_input", fan_index);
+						sprintf(sysfs_name[SYSFS_SDR_NAME], "fan%d_label", fan_index);
 						fan_index++;
 					} else {
-						sprintf(sysfs_name[4], "temp%d_status", sys_index);
-						sprintf(sysfs_name[3], "temp%d_average", sys_index);
-						sprintf(sysfs_name[2], "temp%d_max", sys_index);
-						sprintf(sysfs_name[1], "temp%d_input", sys_index);
-						sprintf(sysfs_name[0], "temp%d_label", sys_index);
+						sprintf(sysfs_name[SYSFS_SDR_STATUS_VAL], "temp%d_status", sys_index);
+						sprintf(sysfs_name[SYSFS_SDR_AVG_VAL], "temp%d_average", sys_index);
+						sprintf(sysfs_name[SYSFS_SDR_MAX_VAL], "temp%d_max", sys_index);
+						sprintf(sysfs_name[SYSFS_SDR_INS_VAL], "temp%d_input", sys_index);
+						sprintf(sysfs_name[SYSFS_SDR_NAME], "temp%d_label", sys_index);
 						sys_index++;
 					}
 					create = true;
 					break;
 				case SDR_TYPE_VOLTAGE:
-					sprintf(sysfs_name[4], "in%d_status", sys_index);
-					sprintf(sysfs_name[3], "in%d_average", sys_index);
-					sprintf(sysfs_name[2], "in%d_max", sys_index);
-					sprintf(sysfs_name[1], "in%d_input", sys_index);
-					sprintf(sysfs_name[0], "in%d_label", sys_index);
+					sprintf(sysfs_name[SYSFS_SDR_STATUS_VAL], "in%d_status", sys_index);
+					sprintf(sysfs_name[SYSFS_SDR_AVG_VAL], "in%d_average", sys_index);
+					sprintf(sysfs_name[SYSFS_SDR_MAX_VAL], "in%d_max", sys_index);
+					sprintf(sysfs_name[SYSFS_SDR_INS_VAL], "in%d_input", sys_index);
+					sprintf(sysfs_name[SYSFS_SDR_NAME], "in%d_label", sys_index);
 					sys_index++;
 					create = true;
 					break;
 				case SDR_TYPE_CURRENT:
-					sprintf(sysfs_name[4], "curr%d_status", sys_index);
-					sprintf(sysfs_name[3], "curr%d_average", sys_index);
-					sprintf(sysfs_name[2], "curr%d_max", sys_index);
-					sprintf(sysfs_name[1], "curr%d_input", sys_index);
-					sprintf(sysfs_name[0], "curr%d_label", sys_index);
+					sprintf(sysfs_name[SYSFS_SDR_STATUS_VAL], "curr%d_status", sys_index);
+					sprintf(sysfs_name[SYSFS_SDR_AVG_VAL], "curr%d_average", sys_index);
+					sprintf(sysfs_name[SYSFS_SDR_MAX_VAL], "curr%d_max", sys_index);
+					sprintf(sysfs_name[SYSFS_SDR_INS_VAL], "curr%d_input", sys_index);
+					sprintf(sysfs_name[SYSFS_SDR_NAME], "curr%d_label", sys_index);
 					sys_index++;
 					create = true;
 					break;
 				case SDR_TYPE_POWER:
-					sprintf(sysfs_name[4], "power%d_status", sys_index);
-					sprintf(sysfs_name[3], "power%d_average", sys_index);
-					sprintf(sysfs_name[2], "power%d_max", sys_index);
-					sprintf(sysfs_name[1], "power%d_input", sys_index);
-					sprintf(sysfs_name[0], "power%d_label", sys_index);
+					sprintf(sysfs_name[SYSFS_SDR_STATUS_VAL], "power%d_status", sys_index);
+					sprintf(sysfs_name[SYSFS_SDR_AVG_VAL], "power%d_average", sys_index);
+					sprintf(sysfs_name[SYSFS_SDR_MAX_VAL], "power%d_max", sys_index);
+					sprintf(sysfs_name[SYSFS_SDR_INS_VAL], "power%d_input", sys_index);
+					sprintf(sysfs_name[SYSFS_SDR_NAME], "power%d_label", sys_index);
 					sys_index++;
 					create = true;
 					break;
@@ -678,47 +685,47 @@ static int parse_sdr_info(char *in_buf, struct xocl_hwmon_sdm *sdm, bool create_
 			}
 			if (create) {
 				//Create *_label sysfs node
-				if(strlen(sysfs_name[0]) != 0) {
-					err = hwmon_sysfs_create(sdm, sysfs_name[0], repo_id,
+				if(strlen(sysfs_name[SYSFS_SDR_NAME]) != 0) {
+					err = hwmon_sysfs_create(sdm, sysfs_name[SYSFS_SDR_NAME], repo_id,
                                           SYSFS_SDR_NAME, name_index, name_length);
 					if (err) {
 						xocl_err(&sdm->pdev->dev, "Unable to create sysfs node (%s), err: %d\n",
-								 sysfs_name[0], err);
+								 sysfs_name[SYSFS_SDR_NAME], err);
 					}
 				}
 
 				//Create *_ins sysfs node
-				if(strlen(sysfs_name[1]) != 0) {
-					err = hwmon_sysfs_create(sdm, sysfs_name[1], repo_id,
+				if(strlen(sysfs_name[SYSFS_SDR_INS_VAL]) != 0) {
+					err = hwmon_sysfs_create(sdm, sysfs_name[SYSFS_SDR_INS_VAL], repo_id,
 											 SYSFS_SDR_INS_VAL, ins_index, val_len);
 					if (err) {
-						xocl_err(&sdm->pdev->dev, "Unable to create sysfs node (%s), err: %d\n", sysfs_name[1], err);
+						xocl_err(&sdm->pdev->dev, "Unable to create sysfs node (%s), err: %d\n", sysfs_name[SYSFS_SDR_INS_VAL], err);
 					}
 				}
 
 				//Create *_max sysfs node
-				if(strlen(sysfs_name[2]) != 0) {
-					err = hwmon_sysfs_create(sdm, sysfs_name[2], repo_id,
+				if(strlen(sysfs_name[SYSFS_SDR_MAX_VAL]) != 0) {
+					err = hwmon_sysfs_create(sdm, sysfs_name[SYSFS_SDR_MAX_VAL], repo_id,
 											SYSFS_SDR_MAX_VAL, max_index, val_len);
 					if (err) {
-						xocl_err(&sdm->pdev->dev, "Unable to create sysfs node (%s), err: %d\n", sysfs_name[2], err);
+						xocl_err(&sdm->pdev->dev, "Unable to create sysfs node (%s), err: %d\n", sysfs_name[SYSFS_SDR_MAX_VAL], err);
 					}
 				}
 
 				//Create *_avg sysfs node
-				if(strlen(sysfs_name[3]) != 0) {
-					err = hwmon_sysfs_create(sdm, sysfs_name[3], repo_id,
+				if(strlen(sysfs_name[SYSFS_SDR_AVG_VAL]) != 0) {
+					err = hwmon_sysfs_create(sdm, sysfs_name[SYSFS_SDR_AVG_VAL], repo_id,
 											SYSFS_SDR_AVG_VAL, avg_index, val_len);
 					if (err) {
-						xocl_err(&sdm->pdev->dev, "Unable to create sysfs node (%s), err: %d\n", sysfs_name[3], err);
+						xocl_err(&sdm->pdev->dev, "Unable to create sysfs node (%s), err: %d\n", sysfs_name[SYSFS_SDR_AVG_VAL], err);
 					}
 				}
 
 				//Create *_status sysfs node
-				if(strlen(sysfs_name[4]) != 0) {
-					err = hwmon_sysfs_create(sdm, sysfs_name[4], repo_id, SYSFS_SDR_STATUS_VAL, status_index, 1);
+				if(strlen(sysfs_name[SYSFS_SDR_STATUS_VAL]) != 0) {
+					err = hwmon_sysfs_create(sdm, sysfs_name[SYSFS_SDR_STATUS_VAL], repo_id, SYSFS_SDR_STATUS_VAL, status_index, 1);
 					if (err) {
-						xocl_err(&sdm->pdev->dev, "Unable to create sysfs node (%s), err: %d\n", sysfs_name[4], err);
+						xocl_err(&sdm->pdev->dev, "Unable to create sysfs node (%s), err: %d\n", sysfs_name[SYSFS_SDR_STATUS_VAL], err);
 					}
 				}
 			}

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -160,7 +160,7 @@ struct sdm_sensor_info
       {
       case 0:
         // read sysfs node <tpath>label
-        pdev->sysfs_get("", target_snode, errmsg, str_output);
+        pdev->sysfs_get("", target_snode, errmsg, str_op);
         if (!errmsg.empty())
         {
           //<tpath>label sysfs node is not found, so try next sysfs node.
@@ -168,7 +168,7 @@ struct sdm_sensor_info
           end_id = max_end_types;
         }
         else {
-          data.label = str_output;
+          data.label = str_op;
         }
         break;
       case 1:

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -139,17 +139,72 @@ struct sdm_sensor_info
   using data_type = query::sdm_sensor_info::data_type;
   using sdr_req_type = query::sdm_sensor_info::sdr_req_type;
 
+  static data_type
+  parse_sysfs_nodes(const xrt_core::device* device,
+                    std::string tpath,
+                    bool *next_id)
+  {
+    auto pdev = get_pcidev(device);
+    //sensors are stored in hwmon sysfs dir with name ends with as follows.
+    std::array<std::string, 6> sname_end = {"label", "input", "max", "average", "highest", "status"};
+    int max_end_types = sname_end.size();
+    data_type data;
+
+    for (int end_id = 0; end_id < max_end_types; end_id++)
+    {
+      std::string target_snode = tpath + sname_end[end_id];
+      if (end_id == 0)
+      {
+        std::string errmsg;
+        std::string label;
+        pdev->sysfs_get("", target_snode, errmsg, label);
+        if (!errmsg.empty())
+        {
+          //go and read next sysfs node
+          *next_id = true;
+          end_id = max_end_types;
+          continue;
+        }
+        data.label = label;
+      }
+      else if (end_id == 5)
+      {
+        std::string errmsg;
+        std::string status;
+        pdev->sysfs_get("", target_snode, errmsg, status);
+        if (!errmsg.empty())
+          continue;
+        data.status = status;
+      }
+      else
+      {
+        std::string errmsg;
+        uint32_t input = 0;
+        pdev->sysfs_get<uint32_t>("", target_snode, errmsg, input, EINVAL);
+        if (!errmsg.empty())
+          continue;
+
+        if (end_id == 1)
+          data.input = input;
+        else if (end_id == 2)
+          data.max = input;
+        else if (end_id == 3)
+          data.average = input;
+        else
+          data.highest = input;
+      }
+    }
+    return data;
+  }
+
   static result_type
   get_sdm_sensors(const xrt_core::device* device,
                   const sdr_req_type& req_type,
                   const std::string& path)
   {
-    auto pdev = get_pcidev(device);
     result_type output;
-    //sensors are stored in hwmon sysfs dir with name starts & ends with as follows.
+    //sensors are stored in hwmon sysfs dir with name starts with as follows.
     std::array<std::string, 5> sname_start = {"curr", "in", "power", "temp", "fan"};
-    std::array<std::string, 6> sname_end = {"label", "input", "max", "average", "highest", "status"};
-    int max_end_types = sname_end.size();
     bool next_id = false;
     //All sensor sysfs nodes starts with 1 as starting index.
     int start_id = 1;
@@ -165,63 +220,15 @@ struct sdm_sensor_info
       const auto slash = "/";
       const auto underscore = "_";
       /*
-       * Forming sysfs node as /<start>[start_id]_.
-       * Example: /in0_ or /curr1_ or /power1_ or /temp1_ in 1st iteration.
+       * Forming sysfs node as <path>/<start>[start_id]_. Here, path is "hwmon/hwmon*"
+       * Example: <path>/in0_ or <path>/curr1_ or <path>/power1_ or <path>/temp1_ in 1st iteration.
        * start_id will be incremented till next_id become true.
-       * So, next iteration will be /in1_ or /curr2_ or /power2_ or /temp2_.
+       * So, next iteration will be <path>/in1_ or <path>/curr2_ or <path>/power2_ or <path>/temp2_.
        * Similarly, end string of sysfs node name will be retrieved using end[].
        */
-      std::string tmp = slash + type + std::to_string(start_id) + underscore;
-      for (int end_id = 0; end_id < max_end_types; end_id++)
-      {
-        if (end_id == 0)
-        {
-          std::string errmsg;
-          std::string label;
-          pdev->sysfs_get("", path + tmp + sname_end[end_id], errmsg, label);
-          if (!errmsg.empty())
-          {
-            //go and read next sysfs node
-            data.label = "N/A";
-            next_id = true;
-            end_id = max_end_types;
-            continue;
-          }
-          data.label = label;
-        }
-        else if (end_id == 5)
-        {
-          std::string errmsg;
-          std::string status;
-          pdev->sysfs_get("", path + tmp + sname_end[end_id], errmsg, status);
-          if (!errmsg.empty())
-          {
-            data.status = "";
-            continue;
-          }
-          data.status= status;
-        }
-        else
-        {
-          std::string errmsg;
-          uint32_t input = 0;
-          pdev->sysfs_get<uint32_t>("", path + tmp + sname_end[end_id], errmsg, input, EINVAL);
-          if (!errmsg.empty())
-            continue;
-
-          if (end_id == 1)
-            data.input = input;
-          else if (end_id == 2)
-            data.max = input;
-          else if (end_id == 3)
-            data.average = input;
-          else
-            data.highest = input;
-        }
-      } // for (end_id =0; end_id < max ...)
-
-      if (data.label.compare("N/A"))
-        output.push_back(data);
+      std::string tpath = path + slash + type + std::to_string(start_id) + underscore;
+      data = parse_sysfs_nodes(device, tpath, &next_id);
+      output.push_back(data);
 
       start_id++;
     } //while (!next_id)

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -148,7 +148,7 @@ struct sdm_sensor_info
     result_type output;
     //sensors are stored in hwmon sysfs dir with name starts & ends with as follows.
     std::array<std::string, 5> sname_start = {"curr", "in", "power", "temp", "fan"};
-    std::array<std::string, 5> sname_end = {"label", "input", "max", "average", "highest"};
+    std::array<std::string, 6> sname_end = {"label", "input", "max", "average", "highest", "status"};
     int max_end_types = sname_end.size();
     bool next_id = false;
     //All sensor sysfs nodes starts with 1 as starting index.
@@ -188,6 +188,18 @@ struct sdm_sensor_info
             continue;
           }
           data.label = label;
+        }
+        else if (end_id == 5)
+        {
+          std::string errmsg;
+          std::string status;
+          pdev->sysfs_get("", path + tmp + sname_end[end_id], errmsg, status);
+          if (!errmsg.empty())
+          {
+            data.status = "";
+            continue;
+          }
+          data.status= status;
         }
         else
         {

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -148,52 +148,60 @@ struct sdm_sensor_info
     //sensors are stored in hwmon sysfs dir with name ends with as follows.
     std::array<std::string, 6> sname_end = {"label", "input", "max", "average", "highest", "status"};
     int max_end_types = sname_end.size();
+    std::string errmsg, str_op, target_snode;
     data_type data = { 0 };
+    uint32_t uint_op = 0;
 
+    //Starting from index 0 in sname_end array, read and store all the sysfs nodes information
     for (int end_id = 0; end_id < max_end_types; end_id++)
     {
-      std::string target_snode = tpath + sname_end[end_id];
-      if (end_id == 0)
+      target_snode = tpath + sname_end[end_id];
+      switch(end_id)
       {
-        std::string errmsg;
-        std::string label;
-        pdev->sysfs_get("", target_snode, errmsg, label);
+      case 0:
+        // read sysfs node <tpath>label
+        pdev->sysfs_get("", target_snode, errmsg, str_output);
         if (!errmsg.empty())
         {
-          //go and read next sysfs node
+          //<tpath>label sysfs node is not found, so try next sysfs node.
           *next_id = true;
           end_id = max_end_types;
         }
         else {
-          data.label = label;
+          data.label = str_output;
         }
-        continue;
-      }
-
-      if (end_id == 5)
-      {
-        std::string errmsg;
-        std::string status;
-        pdev->sysfs_get("", target_snode, errmsg, status);
+        break;
+      case 1:
+        // read sysfs node <tpath>input
+        pdev->sysfs_get<uint32_t>("", target_snode, errmsg, uint_op, EINVAL);
         if (errmsg.empty())
-          data.status = status;
-        continue;
+          data.input = uint_op;
+        break;
+      case 2:
+        // read sysfs node <tpath>max
+        pdev->sysfs_get<uint32_t>("", target_snode, errmsg, uint_op, EINVAL);
+        if (errmsg.empty())
+          data.max = uint_op;
+        break;
+      case 3:
+        // read sysfs node <tpath>average
+        pdev->sysfs_get<uint32_t>("", target_snode, errmsg, uint_op, EINVAL);
+        if (errmsg.empty())
+          data.average = uint_op;
+        break;
+      case 4:
+        // read sysfs node <tpath>highest
+        pdev->sysfs_get<uint32_t>("", target_snode, errmsg, uint_op, EINVAL);
+        if (errmsg.empty())
+          data.highest = uint_op;
+        break;
+      case 5:
+        // read sysfs node <tpath>status
+        pdev->sysfs_get("", target_snode, errmsg, str_op);
+        if (errmsg.empty())
+          data.status = str_op;
+        break;
       }
-
-      std::string errmsg;
-      uint32_t input = 0;
-      pdev->sysfs_get<uint32_t>("", target_snode, errmsg, input, EINVAL);
-      if (!errmsg.empty())
-        continue;
-
-      if (end_id == 1)
-        data.input = input;
-      else if (end_id == 2)
-        data.max = input;
-      else if (end_id == 3)
-        data.average = input;
-      else
-        data.highest = input;
     }
     return data;
   }
@@ -218,8 +226,6 @@ struct sdm_sensor_info
     while (!next_id)
     {
       data_type data;
-      const auto slash = "/";
-      const auto underscore = "_";
       /*
        * Forming sysfs node as <path>/<start>[start_id]_. Here, path is "hwmon/hwmon*"
        * Example: <path>/in0_ or <path>/curr1_ or <path>/power1_ or <path>/temp1_ in 1st iteration.
@@ -227,7 +233,7 @@ struct sdm_sensor_info
        * So, next iteration will be <path>/in1_ or <path>/curr2_ or <path>/power2_ or <path>/temp2_.
        * Similarly, end string of sysfs node name will be retrieved using end[].
        */
-      std::string tpath = path + slash + type + std::to_string(start_id) + underscore;
+      std::string tpath = path + "/" + type + std::to_string(start_id) + "_";
       data = parse_sysfs_nodes(device, tpath, &next_id);
       output.push_back(data);
 

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -148,7 +148,7 @@ struct sdm_sensor_info
     //sensors are stored in hwmon sysfs dir with name ends with as follows.
     std::array<std::string, 6> sname_end = {"label", "input", "max", "average", "highest", "status"};
     int max_end_types = sname_end.size();
-    data_type data;
+    data_type data = { 0 };
 
     for (int end_id = 0; end_id < max_end_types; end_id++)
     {
@@ -163,36 +163,37 @@ struct sdm_sensor_info
           //go and read next sysfs node
           *next_id = true;
           end_id = max_end_types;
-          continue;
         }
-        data.label = label;
+        else {
+          data.label = label;
+        }
+        continue;
       }
-      else if (end_id == 5)
+
+      if (end_id == 5)
       {
         std::string errmsg;
         std::string status;
         pdev->sysfs_get("", target_snode, errmsg, status);
-        if (!errmsg.empty())
-          continue;
-        data.status = status;
+        if (errmsg.empty())
+          data.status = status;
+        continue;
       }
-      else
-      {
-        std::string errmsg;
-        uint32_t input = 0;
-        pdev->sysfs_get<uint32_t>("", target_snode, errmsg, input, EINVAL);
-        if (!errmsg.empty())
-          continue;
 
-        if (end_id == 1)
-          data.input = input;
-        else if (end_id == 2)
-          data.max = input;
-        else if (end_id == 3)
-          data.average = input;
-        else
-          data.highest = input;
-      }
+      std::string errmsg;
+      uint32_t input = 0;
+      pdev->sysfs_get<uint32_t>("", target_snode, errmsg, input, EINVAL);
+      if (!errmsg.empty())
+        continue;
+
+      if (end_id == 1)
+        data.input = input;
+      else if (end_id == 2)
+        data.max = input;
+      else if (end_id == 3)
+        data.average = input;
+      else
+        data.highest = input;
     }
     return data;
   }


### PR DESCRIPTION
Added changes to report the sensor status as part of hwmon sysfs nodes named "*_status".
Followed doc https://confluence.xilinx.com/display/DCG/Versal+In-band+sensor+data+reporting for reporting the sensor status as per their value.

Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
VMR sends sensor status for each sensor. hwmon_sdm driver should read this value and store it as part of hwmon sysfs nodes.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1125007
#### How problem was solved, alternative solutions (if any) and why they were rejected
Added changes in hwmon_sdm driver and relevant shim layer of XRT
#### Risks (if any) associated the changes in the commit
NA
#### What has been tested and how, request additional testing if necessary
hwmon sysfs access of these newly added sensor status
#### Documentation impact (if any)
NA