### PR TITLE
CR-1127240 ASTeR Basic Sanity - vck5000 - cannot program the base 2 

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
@@ -1102,13 +1102,14 @@ static int vmr_info_query_op(struct platform_device *pdev,
 			XGQ_WARN(xgq, "info size is zero");
 			ret = -EINVAL;
 		} else {
-			char *info_data = vmalloc(info_size);
+			char *info_data = vmalloc(info_size + 1);
 			if (info_data == NULL) {
 				XGQ_ERR(xgq, "vmalloc failed");
 				ret = -ENOMEM;
 				goto done;
 			}
 			memcpy_from_device(xgq, address, info_data, info_size);
+			info_data[info_size] = '\0'; /* terminate the string */
 			*cnt += sprintf(buf, "%s", info_data);
 			vfree(info_data);
 		}


### PR DESCRIPTION
shell with the latest 2022.1 XRT

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
observed that VMR returns size as 397, but after sprintf(buf, "%s", info_data) the return value can sometimes become to larger number on centos only.

[19744.193677] info_size 397                                                                                     
[19744.194491] after snprintf size 408 

When use gdb, it shows some garbage data attached onto the last vector.
```
(gdb) p vmr_version
$1 = std::vector of length 14, capacity 14 = {"Build flags: default full build", "vitis version: 2022.1",
  "git hash: 8d589a2c17d0cf27ef2268dc14fc338707deeb18", "git branch: 2022.1",
  "git hash date: Thu, 24 Mar 2022 21:09:01 -0700", "is PS ready: 1", "default image offset: 0x48000",
  "default image size: 0x6f0710", "default image capacity: 0x5fb8000", "backup image offset: 0x6008000",
  "backup image size: 0x6fec60", "backup image capacity: 0x5fb8000", "SC firmware size: 0x630f0",
  "\337\377\377@\327I>L\337\377\377\200\251\205=L\337\377\377\300\251\205=L\337\377\377\200\242I?L\337\377\377\300\242I?L\337\377\377\200.B=L\337\377\377\300.B=L\337\377\377"}
```



#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

explicitly set buf size to info_size. Avoid reading additional garage info from sprintf.

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
tested on centos and ubuntu

#### Documentation impact (if any)
