### PR TITLE
CR-1128494: Update postinst script of xrt package to use correct dkms remove command for CentOS/RHEL

### DIFF
--- a/src/CMake/config/postinst.in
+++ b/src/CMake/config/postinst.in
@@ -61,13 +61,13 @@ echo "Unloading old XRT Linux kernel modules"
 rmmod xocl
 rmmod xclmgmt
 
-# Dkms status o/p differs in Ubuntu and CentOS/RHEL
+# Dkms status o/p differs with different versions
 # So we need different way of parsing old xrt version string.
-. /etc/os-release
-if [ $ID = "ubuntu" ] || [ $ID = "debian" ]; then
-    XRT_VERSION_STRING_OLD=`dkms status -m xrt | awk -F, '{print $2}'`
-else
+dkms_major=`dkms --version | tr -d " "[a-z-:] | awk -F. '{print $1}'`
+if [ $dkms_major -ge 3 ]; then
     XRT_VERSION_STRING_OLD=`dkms status -m xrt | awk -F, '{print $1}' | awk -F/ '{print $2}'`
+else
+    XRT_VERSION_STRING_OLD=`dkms status -m xrt | awk -F, '{print $2}'`
 fi
 
 for OLD in $XRT_VERSION_STRING_OLD; do

--- a/src/CMake/config/postinst.in
+++ b/src/CMake/config/postinst.in
@@ -60,6 +60,9 @@ fi
 echo "Unloading old XRT Linux kernel modules"
 rmmod xocl
 rmmod xclmgmt
+
+# Dkms status o/p differs in Ubuntu and CentOS/RHEL
+# So we need different way of parsing old xrt version string.
 . /etc/os-release
 if [ $ID = "ubuntu" ] || [ $ID = "debian" ]; then
     XRT_VERSION_STRING_OLD=`dkms status -m xrt | awk -F, '{print $2}'`

--- a/src/CMake/config/postinst.in
+++ b/src/CMake/config/postinst.in
@@ -60,7 +60,13 @@ fi
 echo "Unloading old XRT Linux kernel modules"
 rmmod xocl
 rmmod xclmgmt
-XRT_VERSION_STRING_OLD=`dkms status -m xrt | awk -F, '{print $2}'`
+. /etc/os-release
+if [ $ID = "ubuntu" ] || [ $ID = "debian" ]; then
+    XRT_VERSION_STRING_OLD=`dkms status -m xrt | awk -F, '{print $2}'`
+else
+    XRT_VERSION_STRING_OLD=`dkms status -m xrt | awk -F, '{print $1}' | awk -F/ '{print $2}'`
+fi
+
 for OLD in $XRT_VERSION_STRING_OLD; do
     echo "Unregistering old XRT Linux kernel module sources $OLD from dkms"
     dkms remove -m xrt -v $OLD --all


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
When xrt package is installed and its postinst script is run we are getting - **Error! Could not locate dkms.conf file.** on centos and rhel machines. This is because dkms status command returns different o/p in ubuntu and centos, this o/p is parsed to get xrt version string which is improper w.r.to centos/rhel. Fixed this issue.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
dkms cleans old xrt kernel sources properly with this fix. It was discovered in clean room testing on centos machine

#### How problem was solved, alternative solutions (if any) and why they were rejected
Updated parsing dkms status o/p to get correct xrt version string

#### Risks (if any) associated the changes in the commit
none

#### What has been tested and how, request additional testing if necessary
Tested on centos 7.9, 8.1 and rhel 8.5, ubuntu 18.04 machines, no errors are found

#### Documentation impact (if any)
NA