### PR TITLE
CR-1128494: Update postinst script of xrt package to use correct dkms remove command for CentOS/RHEL (#6604)

### DIFF
--- a/src/CMake/config/postinst.in
+++ b/src/CMake/config/postinst.in
@@ -60,7 +60,16 @@ fi
 echo "Unloading old XRT Linux kernel modules"
 rmmod xocl
 rmmod xclmgmt
-XRT_VERSION_STRING_OLD=`dkms status -m xrt | awk -F, '{print $2}'`
+
+# Dkms status o/p differs with different versions
+# So we need different way of parsing old xrt version string.
+dkms_major=`dkms --version | tr -d " "[a-z-:] | awk -F. '{print $1}'`
+if [ $dkms_major -ge 3 ]; then
+    XRT_VERSION_STRING_OLD=`dkms status -m xrt | awk -F, '{print $1}' | awk -F/ '{print $2}'`
+else
+    XRT_VERSION_STRING_OLD=`dkms status -m xrt | awk -F, '{print $2}'`
+fi
+
 for OLD in $XRT_VERSION_STRING_OLD; do
     echo "Unregistering old XRT Linux kernel module sources $OLD from dkms"
     dkms remove -m xrt -v $OLD --all


### PR DESCRIPTION
* Update postinst script of xrt package to use correct dkms remove command for CentOS/RHEL

* Add comment

* Address comments

dkms o/p differs with different versions, so added checks based on dkms major versions
(cherry picked from commit d68f7b4f5b12b3c297e1dbd6777925963a620787)
