### PR TITLE
VITIS-3524 - AIE Partition support for xclbin containers and xclbinutil

### DIFF
--- a/src/runtime_src/core/include/xclbin.h
+++ b/src/runtime_src/core/include/xclbin.h
@@ -97,6 +97,7 @@
     enum { XLCBIN_ASSERT_CONCAT(assert_line_, __LINE__) = 1/(int)(!!(e)) }
 #endif
 
+// *** Helper macro ***
 // Reports a size of structure via an error
 #define SIZE_OF_STRUCT(s) \
    char (*__fail)[sizeof(struct s)] = 1
@@ -175,6 +176,7 @@ extern "C" {
         AIE_RESOURCES          = 29,
         OVERLAY                = 30,
         VENDER_METADATA        = 31,
+        AIE_PARTITION          = 32,
     };
 
     enum MEM_TYPE {
@@ -516,6 +518,25 @@ extern "C" {
         uint8_t padding[36];       // Reserved for future use
     };
     XCLBIN_STATIC_ASSERT(sizeof(struct vender_metadata) == 48, "vender metadata kernel structure no longer is 48 bytes in size");
+
+    struct partition_info {
+        uint16_t column_width;         // Width of the partition
+        uint8_t padding[6];              //   Byte alignment
+        uint32_t start_columns_count;    // The number of elements in the start_columns array
+        uint32_t mpo_auint16_start_columns;  // Offset pointer to an array uint16_t values
+        uint8_t reserved[72];            //   Resevered
+    };
+    XCLBIN_STATIC_ASSERT(sizeof(struct partition_info) == 88, "partition_info structure no longer is 88 bytes in size");
+    
+    struct aie_partition {
+        uint8_t schema_version;          // Group schema version (default 0)
+        uint8_t padding0[3];             //   Byte alignment          
+        uint32_t mpo_name;               // Name of the aie_partition 
+        struct partition_info info;      // Partition information
+        uint8_t reserved[64];            //   Reservered
+    };
+    XCLBIN_STATIC_ASSERT(sizeof(struct aie_partition) == 160, "aie_partition structure no longer is 160 bytes in size");
+
 
     /**** END : Xilinx internal section *****/
 

--- a/src/runtime_src/tools/xclbinutil/CMakeLists.txt
+++ b/src/runtime_src/tools/xclbinutil/CMakeLists.txt
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (C) 2019-2021 Xilinx, Inc. All rights reserved.
+# Copyright (C) 2019-2022 Xilinx, Inc. All rights reserved.
 #
 # Signing xclbin images are currently only support on Linux
 
@@ -126,9 +126,13 @@ if(NOT WIN32)
   set(TEST_OPTIONS " --resource-dir ${CMAKE_CURRENT_SOURCE_DIR}/unittests/BinaryImages")
   xrt_add_test("binary-images" "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/unittests/BinaryImages/BinaryImages.py ${TEST_OPTIONS}")
 
-  # -- Binary Images
+  # -- Single Subsection
   set(TEST_OPTIONS " --resource-dir ${CMAKE_CURRENT_SOURCE_DIR}/unittests/SingleSubsection")
   xrt_add_test("single-subsection" "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/unittests/SingleSubsection/SingleSubsection.py ${TEST_OPTIONS}")
+
+  # -- AIE Partition
+  set(TEST_OPTIONS " --resource-dir ${CMAKE_CURRENT_SOURCE_DIR}/unittests/AIEPartition")
+  xrt_add_test("aie-partition" "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/unittests/AIEPartition/AIEPartition.py ${TEST_OPTIONS}")
 
 endif()
 

--- a/src/runtime_src/tools/xclbinutil/Section.cxx
+++ b/src/runtime_src/tools/xclbinutil/Section.cxx
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 - 2021 Xilinx, Inc
+ * Copyright (C) 2018 - 2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -258,7 +258,7 @@ Section::writeXclBinSectionBuffer(std::ostream& _ostream) const
 }
 
 void
-Section::readXclBinBinary(std::fstream& _istream, const axlf_section_header& _sectionHeader) {
+Section::readXclBinBinary(std::istream& _istream, const axlf_section_header& _sectionHeader) {
   // Some error checking
   if ((enum axlf_section_kind)_sectionHeader.m_sectionKind != getSectionKind()) {
     std::string errMsg = XUtil::format("ERROR: Unexpected section kind.  Expected: %d, Read: %d", getSectionKind(), _sectionHeader.m_sectionKind);
@@ -319,7 +319,7 @@ Section::readJSONSectionImage(const boost::property_tree::ptree& _ptSection)
 }
 
 void
-Section::readXclBinBinary(std::fstream& _istream,
+Section::readXclBinBinary(std::istream& _istream,
                           const boost::property_tree::ptree& _ptSection) {
   // Some error checking
   enum axlf_section_kind eKind = (enum axlf_section_kind)_ptSection.get<unsigned int>("Kind");
@@ -416,7 +416,7 @@ Section::getPathAndName() const
 
 
 void 
-Section::readPayload(std::fstream& _istream, enum FormatType _eFormatType)
+Section::readPayload(std::istream& _istream, enum FormatType _eFormatType)
 {
     switch (_eFormatType) {
     case FT_RAW:

--- a/src/runtime_src/tools/xclbinutil/Section.h
+++ b/src/runtime_src/tools/xclbinutil/Section.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 - 2021 Xilinx, Inc
+ * Copyright (C) 2018 - 2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -74,10 +74,10 @@ class Section {
 
  public:
   // Xclbin Binary helper methods - child classes can override them if they choose
-  virtual void readXclBinBinary(std::fstream& _istream, const struct axlf_section_header& _sectionHeader);
-  virtual void readXclBinBinary(std::fstream& _istream, const boost::property_tree::ptree& _ptSection);
+  virtual void readXclBinBinary(std::istream& _istream, const struct axlf_section_header& _sectionHeader);
+  virtual void readXclBinBinary(std::istream& _istream, const boost::property_tree::ptree& _ptSection);
   void readJSONSectionImage(const boost::property_tree::ptree& _ptSection);
-  void readPayload(std::fstream& _istream, enum FormatType _eFormatType);
+  void readPayload(std::istream& _istream, enum FormatType _eFormatType);
   void printHeader(std::ostream &_ostream) const;
   bool getSubPayload(std::ostringstream &_buf, const std::string _sSubSection, enum Section::FormatType _eFormatType) const;
   void readSubPayload(std::istream& _istream, const std::string & _sSubSection, enum Section::FormatType _eFormatType);

--- a/src/runtime_src/tools/xclbinutil/SectionAIEPartition.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionAIEPartition.cxx
@@ -109,24 +109,24 @@ SectionAIEPartition::marshalFromJSON(const boost::property_tree::ptree& _ptSecti
   // -- Start Column
   const uint32_t startColumnsOffset = sizeof(aie_partition);
   std::vector<uint16_t> startColumns = XUtil::as_vector_simple<uint16_t>(ptAIEPartition, "partition_info.start_columns");
-  size_t startColumnsRawSize = sizeof(uint16_t) * startColumns.size();
+  uint32_t startColumnsRawSize = static_cast<uint32_t>(sizeof(uint16_t) * startColumns.size());
   XUtil::TRACE(boost::format("start_column_offset: 0x%x, raw size: 0x%x, aligned_size: 0x%x")
                % startColumnsOffset % startColumnsRawSize
                % (startColumnsRawSize + XUtil::bytesToAlign(startColumnsRawSize)));
 
   // -- String Block
-  const uint32_t stringBlockOffset = startColumnsOffset + startColumnsRawSize + XUtil::bytesToAlign(startColumnsRawSize);
+  const uint32_t stringBlockOffset = static_cast<uint32_t>(startColumnsOffset + startColumnsRawSize + XUtil::bytesToAlign(startColumnsRawSize));
   XUtil::TRACE(boost::format("staring_block_offset: 0x%x") % stringBlockOffset);
 
   // -- Name
   auto partitionName = ptAIEPartition.get<std::string>("name");
-  aie_partitionHdr.mpo_name = stringBlockOffset + stringBlock.tellp();
+  aie_partitionHdr.mpo_name = static_cast<uint32_t>(stringBlockOffset + stringBlock.tellp());
   stringBlock << partitionName << '\0';
 
   // -- Partition Info
   const boost::property_tree::ptree& ptParitionInfo = ptAIEPartition.get_child("partition_info");
   aie_partitionHdr.info.column_width = ptParitionInfo.get<uint16_t>("column_width");
-  aie_partitionHdr.info.start_columns_count = startColumns.size();
+  aie_partitionHdr.info.start_columns_count = static_cast<uint32_t>(startColumns.size());
   if (startColumns.size())
     aie_partitionHdr.info.mpo_auint16_start_columns = startColumnsOffset;
 

--- a/src/runtime_src/tools/xclbinutil/SectionAIEPartition.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionAIEPartition.cxx
@@ -1,0 +1,172 @@
+/**
+ * Copyright (C) 2022 Advanced Micro Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "SectionAIEPartition.h"
+
+#include "XclBinUtilities.h"
+namespace XUtil = XclBinUtilities;
+#include <iostream>
+
+// Static Variables / Classes
+SectionAIEPartition::_init SectionAIEPartition::_initializer;
+
+SectionAIEPartition::SectionAIEPartition()
+{
+  // Empty
+}
+
+SectionAIEPartition::~SectionAIEPartition()
+{
+  // Empty
+}
+
+void
+SectionAIEPartition::marshalToJSON(char* _pDataSection,
+                                   unsigned int _sectionSize,
+                                   boost::property_tree::ptree& _ptree) const
+{
+  XUtil::TRACE("");
+  XUtil::TRACE("Extracting: AIE_PARTITION");
+  XUtil::TRACE_BUF("Section Buffer", reinterpret_cast<const char*>(_pDataSection), _sectionSize);
+
+  // Do we have enough room to overlay the header structure
+  if (_sectionSize < sizeof(aie_partition)) {
+    auto errMsg = boost::format("ERROR: Section size (%d) is smaller than the size of the aie_partition structure (%d)")
+                                 % _sectionSize % sizeof(aie_partition);
+    throw std::runtime_error(errMsg.str());
+  }
+
+  aie_partition* pHdr = (aie_partition*)_pDataSection;
+  boost::property_tree::ptree ptAIEPartition;
+
+  // -- schema version
+  XUtil::TRACE(boost::format("schema_version: %d") % static_cast<uint32_t>(pHdr->schema_version));
+  ptAIEPartition.put("schema_version", std::to_string(pHdr->schema_version));
+
+  // -- mpo_name
+  XUtil::TRACE(boost::format("mpo_name (0x%lx): '%s'") % pHdr->mpo_name % (reinterpret_cast<const char*>(pHdr) + pHdr->mpo_name));
+  ptAIEPartition.put("name", reinterpret_cast<char*>(pHdr) + pHdr->mpo_name);
+
+  // -- partition_info
+  boost::property_tree::ptree ptPartitionInfo;
+  {
+    // -- column width
+    XUtil::TRACE(boost::format("column_width: %d") % pHdr->info.column_width);
+    ptPartitionInfo.put("column_width", std::to_string(pHdr->info.column_width));
+
+    // -- start_column array
+    XUtil::TRACE(boost::format("columns count: %d, offset: 0x%0x")
+                               % pHdr->info.start_columns_count
+                               % pHdr->info.mpo_auint16_start_columns);
+
+    if (pHdr->info.start_columns_count) {
+      const uint16_t* startColumns = reinterpret_cast<const uint16_t*>(reinterpret_cast<const uint8_t*>(pHdr) + pHdr->info.mpo_auint16_start_columns);
+
+      boost::property_tree::ptree ptArray;
+      for (size_t index = 0; index < pHdr->info.start_columns_count; index++) {
+        boost::property_tree::ptree ptEntry;
+        ptEntry.put("", std::to_string(startColumns[index]));
+        ptArray.push_back(std::make_pair("", ptEntry));   // Used to make an array of objects
+      }
+      ptPartitionInfo.add_child("start_columns", ptArray);
+    }
+  }
+  ptAIEPartition.add_child("partition_info", ptPartitionInfo);
+
+  _ptree.add_child("aie_partition", ptAIEPartition);
+  XUtil::TRACE("-----------------------------");
+}
+
+void
+SectionAIEPartition::marshalFromJSON(const boost::property_tree::ptree& _ptSection,
+                                     std::ostringstream& _buf) const
+{
+  const boost::property_tree::ptree ptEmpty;
+  std::ostringstream stringBlock;              // Contains variable length strings
+
+  const boost::property_tree::ptree& ptAIEPartition = _ptSection.get_child("aie_partition");
+  XUtil::TRACE_PrintTree("AIE_PARTITION", ptAIEPartition);
+  aie_partition aie_partitionHdr = aie_partition{0};
+
+  // -- Schema Version
+  aie_partitionHdr.schema_version = ptAIEPartition.get<uint8_t>("schema_version");
+  XUtil::TRACE(boost::format("schema_version: %d") % static_cast<uint32_t>(aie_partitionHdr.schema_version));
+
+  // -- Offsets
+  // -- Start Column
+  const uint32_t startColumnsOffset = sizeof(aie_partition);
+  std::vector<uint16_t> startColumns = XUtil::as_vector_simple<uint16_t>(ptAIEPartition, "partition_info.start_columns");
+  size_t startColumnsRawSize = sizeof(uint16_t) * startColumns.size();
+  XUtil::TRACE(boost::format("start_column_offset: 0x%x, raw size: 0x%x, aligned_size: 0x%x")
+               % startColumnsOffset % startColumnsRawSize
+               % (startColumnsRawSize + XUtil::bytesToAlign(startColumnsRawSize)));
+
+  // -- String Block
+  const uint32_t stringBlockOffset = startColumnsOffset + startColumnsRawSize + XUtil::bytesToAlign(startColumnsRawSize);
+  XUtil::TRACE(boost::format("staring_block_offset: 0x%x") % stringBlockOffset);
+
+  // -- Name
+  auto partitionName = ptAIEPartition.get<std::string>("name");
+  aie_partitionHdr.mpo_name = stringBlockOffset + stringBlock.tellp();
+  stringBlock << partitionName << '\0';
+
+  // -- Partition Info
+  const boost::property_tree::ptree& ptParitionInfo = ptAIEPartition.get_child("partition_info");
+  aie_partitionHdr.info.column_width = ptParitionInfo.get<uint16_t>("column_width");
+  aie_partitionHdr.info.start_columns_count = startColumns.size();
+  if (startColumns.size())
+    aie_partitionHdr.info.mpo_auint16_start_columns = startColumnsOffset;
+
+  // -- Copy the output to the output buffer.
+  // Header
+  _buf.write(reinterpret_cast<const char*>(&aie_partitionHdr), sizeof(aie_partitionHdr));
+
+  // Start columns
+  auto bufferSize = sizeof(uint16_t) * startColumns.size();
+  if (bufferSize) {
+    _buf.write(reinterpret_cast<const char*>(startColumns.data()), bufferSize);
+
+    // Align the buffer on the 64 bit boundary
+    auto numAlignBytes = XUtil::alignBytes(_buf, sizeof(uint64_t));
+    if (numAlignBytes != XUtil::bytesToAlign(startColumnsRawSize))
+      throw std::runtime_error("ERROR: Buffer alignment mismatch. Number of padding bytes written does not match expectation");
+  }
+
+  // String block
+  std::string sStringBlock = stringBlock.str();
+  _buf.write(sStringBlock.c_str(), sStringBlock.size());
+}
+
+bool
+SectionAIEPartition::doesSupportAddFormatType(FormatType _eFormatType) const
+{
+  if (_eFormatType == FT_JSON) {
+    return true;
+  }
+  return false;
+}
+
+bool
+SectionAIEPartition::doesSupportDumpFormatType(FormatType _eFormatType) const
+{
+  if ((_eFormatType == FT_JSON) ||
+      (_eFormatType == FT_HTML) ||
+      (_eFormatType == FT_RAW)) {
+    return true;
+  }
+
+  return false;
+}

--- a/src/runtime_src/tools/xclbinutil/SectionAIEPartition.h
+++ b/src/runtime_src/tools/xclbinutil/SectionAIEPartition.h
@@ -1,0 +1,49 @@
+/**
+ * Copyright (C) 2022 Advanced Micro Devices, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef __SectionAIEPartitions_h_
+#define __SectionAIEPartitions_h_
+
+// ----------------------- I N C L U D E S -----------------------------------
+
+// #includes here - please keep these to a bare minimum!
+#include "Section.h"
+#include <boost/functional/factory.hpp>
+
+// -------- C L A S S :   S e c t i o n A I E P a r t i t i o n --------------
+
+class SectionAIEPartition : public Section {
+ public:
+  SectionAIEPartition();
+  virtual ~SectionAIEPartition();
+
+ public:
+  virtual bool doesSupportAddFormatType(FormatType _eFormatType) const;
+  virtual bool doesSupportDumpFormatType(FormatType _eFormatType) const;
+
+ protected:
+  virtual void marshalToJSON(char* _pDataSection, unsigned int _sectionSize, boost::property_tree::ptree& _ptree) const;
+  virtual void marshalFromJSON(const boost::property_tree::ptree& _ptSection, std::ostringstream& _buf) const;
+
+ private:
+  // Static initializer helper class
+  static class _init {
+   public:
+    _init() { registerSectionCtor(AIE_PARTITION, "AIE_PARTITION", "aie_partition", false, false, boost::factory<SectionAIEPartition*>()); }
+  } _initializer;
+};
+
+#endif

--- a/src/runtime_src/tools/xclbinutil/SectionAIEPartition.h
+++ b/src/runtime_src/tools/xclbinutil/SectionAIEPartition.h
@@ -27,23 +27,19 @@
 
 class SectionAIEPartition : public Section {
  public:
-  SectionAIEPartition();
-  virtual ~SectionAIEPartition();
-
- public:
-  virtual bool doesSupportAddFormatType(FormatType _eFormatType) const;
-  virtual bool doesSupportDumpFormatType(FormatType _eFormatType) const;
+  bool doesSupportAddFormatType(FormatType _eFormatType) const override;
+  bool doesSupportDumpFormatType(FormatType _eFormatType) const override;
 
  protected:
-  virtual void marshalToJSON(char* _pDataSection, unsigned int _sectionSize, boost::property_tree::ptree& _ptree) const;
-  virtual void marshalFromJSON(const boost::property_tree::ptree& _ptSection, std::ostringstream& _buf) const;
+  void marshalToJSON(char* pDataSection, unsigned int sectionSize, boost::property_tree::ptree& ptReturn) const override;
+  void marshalFromJSON(const boost::property_tree::ptree& ptSection, std::ostringstream& buf) const override;
 
  private:
   // Static initializer helper class
-  static class _init {
+  static class init {
    public:
-    _init() { registerSectionCtor(AIE_PARTITION, "AIE_PARTITION", "aie_partition", false, false, boost::factory<SectionAIEPartition*>()); }
-  } _initializer;
+    init();
+  } initializer;
 };
 
 #endif

--- a/src/runtime_src/tools/xclbinutil/SectionFlash.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionFlash.cxx
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019 - 2021 Xilinx, Inc
+ * Copyright (C) 2019 - 2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -498,7 +498,7 @@ SectionFlash::writeSubPayload(const std::string& _sSubSectionName,
 }
 
 void
-SectionFlash::readXclBinBinary(std::fstream& _istream, const axlf_section_header& _sectionHeader) {
+SectionFlash::readXclBinBinary(std::istream& _istream, const axlf_section_header& _sectionHeader) {
   Section::readXclBinBinary(_istream, _sectionHeader);
 
   // Extract the binary data as a JSON string

--- a/src/runtime_src/tools/xclbinutil/SectionFlash.h
+++ b/src/runtime_src/tools/xclbinutil/SectionFlash.h
@@ -41,19 +41,19 @@ public:
   };
 
  public:
-  virtual bool doesSupportAddFormatType(FormatType _eFormatType) const;
-  virtual bool supportsSubSection(const std::string &_sSubSectionName) const;
-  virtual bool subSectionExists(const std::string &_sSubSectionName) const;
-  virtual void readXclBinBinary(std::istream& _istream, const struct axlf_section_header& _sectionHeader);
+  bool doesSupportAddFormatType(FormatType _eFormatType) const override;
+  bool supportsSubSection(const std::string &_sSubSectionName) const override;
+  bool subSectionExists(const std::string &_sSubSectionName) const override;
+  void readXclBinBinary(std::istream& _istream, const struct axlf_section_header& _sectionHeader) override;
 
  protected:
-  virtual void readSubPayload(const char* _pOrigDataSection, unsigned int _origSectionSize,  std::istream& _istream, const std::string & _sSubSection, enum Section::FormatType _eFormatType, std::ostringstream &_buffer) const;
+  void readSubPayload(const char* _pOrigDataSection, unsigned int _origSectionSize,  std::istream& _istream, const std::string & _sSubSection, enum Section::FormatType _eFormatType, std::ostringstream &_buffer) const override;
+  void writeSubPayload(const std::string & _sSubSectionName, FormatType _eFormatType, std::fstream&  _oStream) const override;
 
  protected:
    enum SubSection getSubSectionEnum(const std::string _sSubSectionName) const;
    void copyBufferUpdateMetadata(const char* _pOrigDataSection, unsigned int _origSectionSize,  std::istream& _istream, std::ostringstream &_buffer) const;
    void createDefaultImage(std::istream & _istream, std::ostringstream &_buffer) const;
-   virtual void writeSubPayload(const std::string & _sSubSectionName, FormatType _eFormatType, std::fstream&  _oStream) const;
    void writeObjImage(std::ostream& _oStream) const;
    void writeMetadata(std::ostream& _oStream) const;
 

--- a/src/runtime_src/tools/xclbinutil/SectionFlash.h
+++ b/src/runtime_src/tools/xclbinutil/SectionFlash.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 - 2021 Xilinx, Inc
+ * Copyright (C) 2018 - 2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -44,7 +44,7 @@ public:
   virtual bool doesSupportAddFormatType(FormatType _eFormatType) const;
   virtual bool supportsSubSection(const std::string &_sSubSectionName) const;
   virtual bool subSectionExists(const std::string &_sSubSectionName) const;
-  virtual void readXclBinBinary(std::fstream& _istream, const struct axlf_section_header& _sectionHeader);
+  virtual void readXclBinBinary(std::istream& _istream, const struct axlf_section_header& _sectionHeader);
 
  protected:
   virtual void readSubPayload(const char* _pOrigDataSection, unsigned int _origSectionSize,  std::istream& _istream, const std::string & _sSubSection, enum Section::FormatType _eFormatType, std::ostringstream &_buffer) const;

--- a/src/runtime_src/tools/xclbinutil/SectionSoftKernel.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionSoftKernel.cxx
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019-2021 Xilinx, Inc
+ * Copyright (C) 2019-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -486,7 +486,7 @@ SectionSoftKernel::writeSubPayload(const std::string& _sSubSectionName,
 }
 
 void
-SectionSoftKernel::readXclBinBinary(std::fstream& _istream, const axlf_section_header& _sectionHeader) {
+SectionSoftKernel::readXclBinBinary(std::istream& _istream, const axlf_section_header& _sectionHeader) {
   Section::readXclBinBinary(_istream, _sectionHeader);
 
   // Extract the binary data as a JSON string

--- a/src/runtime_src/tools/xclbinutil/SectionSoftKernel.h
+++ b/src/runtime_src/tools/xclbinutil/SectionSoftKernel.h
@@ -41,20 +41,20 @@ public:
   };
 
  public:
-  virtual bool doesSupportAddFormatType(FormatType _eFormatType) const;
-  virtual bool supportsSubSection(const std::string &_sSubSectionName) const;
-  virtual bool subSectionExists(const std::string &_sSubSectionName) const;
-  virtual void readXclBinBinary(std::istream& _istream, const struct axlf_section_header& _sectionHeader);
+  bool doesSupportAddFormatType(FormatType _eFormatType) const override;
+  bool supportsSubSection(const std::string &_sSubSectionName) const override;
+  bool subSectionExists(const std::string &_sSubSectionName) const override;
+  void readXclBinBinary(std::istream& _istream, const struct axlf_section_header& _sectionHeader) override;
 
 
  protected:
-  virtual void readSubPayload(const char* _pOrigDataSection, unsigned int _origSectionSize,  std::istream& _istream, const std::string & _sSubSection, enum Section::FormatType _eFormatType, std::ostringstream &_buffer) const;
+  void readSubPayload(const char* _pOrigDataSection, unsigned int _origSectionSize,  std::istream& _istream, const std::string & _sSubSection, enum Section::FormatType _eFormatType, std::ostringstream &_buffer) const override;
+  void writeSubPayload(const std::string & _sSubSectionName, FormatType _eFormatType, std::fstream&  _oStream) const override;
 
  protected:
    enum SubSection getSubSectionEnum(const std::string _sSubSectionName) const;
    void copyBufferUpdateMetadata(const char* _pOrigDataSection, unsigned int _origSectionSize,  std::istream& _istream, std::ostringstream &_buffer) const;
    void createDefaultImage(std::istream & _istream, std::ostringstream &_buffer) const;
-   virtual void writeSubPayload(const std::string & _sSubSectionName, FormatType _eFormatType, std::fstream&  _oStream) const;
    void writeObjImage(std::ostream& _oStream) const;
    void writeMetadata(std::ostream& _oStream) const;
 

--- a/src/runtime_src/tools/xclbinutil/SectionSoftKernel.h
+++ b/src/runtime_src/tools/xclbinutil/SectionSoftKernel.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 - 2021 Xilinx, Inc
+ * Copyright (C) 2018 - 2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -44,7 +44,7 @@ public:
   virtual bool doesSupportAddFormatType(FormatType _eFormatType) const;
   virtual bool supportsSubSection(const std::string &_sSubSectionName) const;
   virtual bool subSectionExists(const std::string &_sSubSectionName) const;
-  virtual void readXclBinBinary(std::fstream& _istream, const struct axlf_section_header& _sectionHeader);
+  virtual void readXclBinBinary(std::istream& _istream, const struct axlf_section_header& _sectionHeader);
 
 
  protected:

--- a/src/runtime_src/tools/xclbinutil/SectionVenderMetadata.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionVenderMetadata.cxx
@@ -325,7 +325,7 @@ SectionVenderMetadata::writeSubPayload(const std::string& _sSubSectionName,
 }
 
 void
-SectionVenderMetadata::readXclBinBinary(std::fstream& _istream, const axlf_section_header& _sectionHeader)
+SectionVenderMetadata::readXclBinBinary(std::istream& _istream, const axlf_section_header& _sectionHeader)
 {
   Section::readXclBinBinary(_istream, _sectionHeader);
 

--- a/src/runtime_src/tools/xclbinutil/SectionVenderMetadata.h
+++ b/src/runtime_src/tools/xclbinutil/SectionVenderMetadata.h
@@ -32,7 +32,7 @@ class SectionVenderMetadata : public Section {
   virtual bool doesSupportAddFormatType(FormatType _eFormatType) const;
   virtual bool supportsSubSection(const std::string& _sSubSectionName) const;
   virtual bool subSectionExists(const std::string& _sSubSectionName) const;
-  virtual void readXclBinBinary(std::fstream& _istream, const struct axlf_section_header& _sectionHeader);
+  virtual void readXclBinBinary(std::istream& _istream, const struct axlf_section_header& _sectionHeader);
 
  protected:
   virtual void readSubPayload(const char* _pOrigDataSection, unsigned int _origSectionSize,  std::istream& _istream, const std::string& _sSubSection, enum Section::FormatType _eFormatType, std::ostringstream& _buffer) const;

--- a/src/runtime_src/tools/xclbinutil/SectionVenderMetadata.h
+++ b/src/runtime_src/tools/xclbinutil/SectionVenderMetadata.h
@@ -29,14 +29,14 @@ class SectionVenderMetadata : public Section {
   virtual ~SectionVenderMetadata();
 
  public:
-  virtual bool doesSupportAddFormatType(FormatType _eFormatType) const;
-  virtual bool supportsSubSection(const std::string& _sSubSectionName) const;
-  virtual bool subSectionExists(const std::string& _sSubSectionName) const;
-  virtual void readXclBinBinary(std::istream& _istream, const struct axlf_section_header& _sectionHeader);
+  bool doesSupportAddFormatType(FormatType _eFormatType) const override;
+  bool supportsSubSection(const std::string& _sSubSectionName) const override;
+  bool subSectionExists(const std::string& _sSubSectionName) const override;
+  void readXclBinBinary(std::istream& _istream, const struct axlf_section_header& _sectionHeader)  override;
 
  protected:
-  virtual void readSubPayload(const char* _pOrigDataSection, unsigned int _origSectionSize,  std::istream& _istream, const std::string& _sSubSection, enum Section::FormatType _eFormatType, std::ostringstream& _buffer) const;
-  virtual void writeSubPayload(const std::string& _sSubSectionName, FormatType _eFormatType, std::fstream&  _oStream) const;
+  void readSubPayload(const char* _pOrigDataSection, unsigned int _origSectionSize,  std::istream& _istream, const std::string& _sSubSection, enum Section::FormatType _eFormatType, std::ostringstream& _buffer) const override;
+  void writeSubPayload(const std::string& _sSubSectionName, FormatType _eFormatType, std::fstream&  _oStream) const override;
 
  protected:
   void copyBufferUpdateMetadata(const char* _pOrigDataSection, unsigned int _origSectionSize,  std::istream& _istream, std::ostringstream& _buffer) const;

--- a/src/runtime_src/tools/xclbinutil/XclBinUtilMain.cxx
+++ b/src/runtime_src/tools/xclbinutil/XclBinUtilMain.cxx
@@ -196,6 +196,7 @@ int main_(int argc, const char** argv) {
   bool bResetBankGrouping = false;
   bool bSignatureDebug = false;
   bool bSkipBankGrouping = false;
+  bool bSkipAIEPartitionInsertion = false;
   bool bSkipUUIDInsertion = false;
   bool bTrace = false;
   boost::program_options::options_description hidden("Hidden options");
@@ -211,6 +212,7 @@ int main_(int argc, const char** argv) {
     ("dump-signature", boost::program_options::value<decltype(sSignatureOutputFile)>(&sSignatureOutputFile), "Dumps a sign xclbin image's signature.")
     ("reset-bank-grouping", boost::program_options::bool_switch(&bResetBankGrouping), "Resets the memory bank grouping section(s).")
     ("signature-debug", boost::program_options::bool_switch(&bSignatureDebug), "Dump section debug data.")
+    ("skip-aie-partition-insertion", boost::program_options::bool_switch(&bSkipAIEPartitionInsertion), "Disables creating an AIE partition section.")
     ("skip-bank-grouping", boost::program_options::bool_switch(&bSkipBankGrouping), "Disables creating the memory bank grouping section(s).")
     ("skip-uuid-insertion", boost::program_options::bool_switch(&bSkipUUIDInsertion), "Do not update the xclbin's UUID")
     ("trace,t", boost::program_options::bool_switch(&bTrace), "Trace")
@@ -524,6 +526,11 @@ int main_(int argc, const char** argv) {
       (xclBin.findSection(ASK_GROUP_CONNECTIVITY) == nullptr) &&
       (xclBin.findSection(MEM_TOPOLOGY) != nullptr))
     XUtil::createMemoryBankGrouping(xclBin);
+
+  if ((bSkipAIEPartitionInsertion == false) && 
+      (xclBin.findSection(AIE_METADATA) != nullptr) &&
+      (xclBin.findSection(AIE_PARTITION) == nullptr)) 
+    XUtil::createAIEPartition(xclBin);
 
   // -- Remove Keys --
   for (const auto &key : keysToRemove) 

--- a/src/runtime_src/tools/xclbinutil/XclBinUtilities.cxx
+++ b/src/runtime_src/tools/xclbinutil/XclBinUtilities.cxx
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018, 2020-2021 Xilinx, Inc
+ * Copyright (C) 2018, 2020-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -96,6 +96,11 @@ XclBinUtilities::TRACE(const std::string& _msg, bool _endl) {
 
   if (_endl)
     std::cout << std::endl << std::flush;
+}
+
+void 
+XclBinUtilities::TRACE(const boost::format &fmt, bool endl) {
+  TRACE(boost::str(fmt), endl);
 }
 
 
@@ -1033,6 +1038,76 @@ XclBinUtilities::createMemoryBankGrouping(XclBin & xclbin)
   }
 }
 
+
+void 
+XclBinUtilities::createAIEPartition(XclBin & xclbin)
+{
+  const boost::property_tree::ptree ptEmpty;
+
+  // -- DRC checks
+  const auto pAIEMetadataSection = xclbin.findSection(AIE_METADATA);
+  if (pAIEMetadataSection == nullptr)
+    throw std::runtime_error("ERROR: AIE_METADATA section does not exist.  Unable to auto create the AIE Partition.");
+
+  if (xclbin.findSection(AIE_PARTITION))
+    throw std::runtime_error("ERROR: AIE_PARTITION section arleady exist.  Unable to auto create the AIE Partition from the AIE_METADATA.");
+
+  // -- Get and examine the AIE metadata
+  boost::property_tree::ptree ptAIEMetadata;
+  pAIEMetadataSection->getPayload(ptAIEMetadata);
+
+  XUtil::TRACE_PrintTree("AIE_METADATA", ptAIEMetadata);
+  const auto & ptDriverConfig = ptAIEMetadata.get_child("aie_metadata.driver_config", ptEmpty);
+
+  // The AIE partition information in the in driver_config node.
+  if (ptDriverConfig.empty()) {
+    XUtil::TRACE("aie_partition section not created: driver_config node not found aie_metadata");
+    return;
+  }
+    
+  // Check to see if this data is present
+  auto numColumns = ptDriverConfig.get<uint32_t>("partition_num_cols", 0);
+  auto & ptPartitionStartColumns = ptDriverConfig.get_child("partition_overlay_start_cols", ptEmpty);
+  if ((numColumns == 0 ) || (ptPartitionStartColumns.empty())) {
+      XUtil::TRACE("aie_partition section not created: No overlay start columns.");
+      return;
+  }
+
+  // Build the AIE PARTITION JSON
+  XUtil::TRACE("Creating AIE_PARTITION property tree");
+  
+  boost::property_tree::ptree ptAIEPartition;
+  ptAIEPartition.put("schema_version", 0);
+  ptAIEPartition.put("name", "xclbinutil-generated");
+
+  boost::property_tree::ptree ptPartitionInfo;
+  ptPartitionInfo.put("column_width", std::to_string(numColumns));
+  ptPartitionInfo.add_child("start_columns", ptPartitionStartColumns);
+
+  ptAIEPartition.add_child("partition_info", ptPartitionInfo);
+  
+  boost::property_tree::ptree ptRoot;
+  ptRoot.add_child("aie_partition", ptAIEPartition);
+
+  XUtil::TRACE_PrintTree("AIE_PARTITION to be added", ptRoot);
+
+  // Create and add the section
+  XUtil::TRACE("Creating AIE_PARTITION section");
+  auto pSection = Section::createSectionObjectOfKind(AIE_PARTITION);
+
+  std::ostringstream buffer;
+  boost::property_tree::write_json(buffer, ptRoot);
+  std::istringstream iSectionMetadata(buffer.str());
+  pSection->readPayload(iSectionMetadata, Section::FT_JSON);
+
+  // -- Now add the section to the collection and report our successful status
+  XUtil::TRACE("Adding AIE_PARTITION section to xclbin");
+  xclbin.addSection(pSection);
+  std::string sSectionAddedName = pSection->getSectionKindAsString();
+
+  XUtil::QUIET("");
+  XUtil::QUIET("Section: AIE_PARTITION was successfully added.");
+}
 
 
 #if (BOOST_VERSION >= 106400)

--- a/src/runtime_src/tools/xclbinutil/XclBinUtilities.cxx
+++ b/src/runtime_src/tools/xclbinutil/XclBinUtilities.cxx
@@ -1046,7 +1046,7 @@ XclBinUtilities::createAIEPartition(XclBin & xclbin)
 
   // -- DRC checks
   const auto pAIEMetadataSection = xclbin.findSection(AIE_METADATA);
-  if (pAIEMetadataSection == nullptr)
+  if (!pAIEMetadataSection)
     throw std::runtime_error("ERROR: AIE_METADATA section does not exist.  Unable to auto create the AIE Partition.");
 
   if (xclbin.findSection(AIE_PARTITION))

--- a/src/runtime_src/tools/xclbinutil/XclBinUtilities.h
+++ b/src/runtime_src/tools/xclbinutil/XclBinUtilities.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018, 2020-2021 Xilinx, Inc
+ * Copyright (C) 2018, 2020-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -21,6 +21,7 @@
 #include "xclbin.h"
 
 #include <boost/filesystem.hpp>
+#include <boost/format.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <fstream>
 #include <iostream>
@@ -65,6 +66,19 @@ std::vector<T> as_vector(boost::property_tree::ptree const& pt,
         r.push_back(item.second);
       }
     }
+    return r;
+}
+
+// This template will eventually replace "as_vector"
+// The issue is that the code needs to be refactored to use this new template
+template <typename T>
+std::vector<T> as_vector_simple(const boost::property_tree::ptree& pt, 
+                                const boost::property_tree::ptree::key_type& key)
+{
+    std::vector<T> r;
+
+    for (auto& item : pt.get_child(key))
+        r.push_back(item.second.get_value<T>());
     return r;
 }
 
@@ -142,6 +156,7 @@ bool isQuiet();
 
 void QUIET(const std::string& _msg);
 void TRACE(const std::string& _msg, bool _endl = true);
+void TRACE(const boost::format & fmt, bool _endl = true);
 void TRACE_PrintTree(const std::string& _msg, const boost::property_tree::ptree& _pt);
 void TRACE_BUF(const std::string& _msg, const char* _pData, uint64_t _size);
 
@@ -159,6 +174,7 @@ int exec(const boost::filesystem::path &cmd, const std::vector<std::string> &arg
 void write_htonl(std::ostream & _buf, uint32_t _word32);
 
 void createMemoryBankGrouping(XclBin & xclbin);
+void createAIEPartition(XclBin & xclbin);
 };
 
 #endif

--- a/src/runtime_src/tools/xclbinutil/unittests/AIEPartition/AIEPartition.py
+++ b/src/runtime_src/tools/xclbinutil/unittests/AIEPartition/AIEPartition.py
@@ -1,0 +1,161 @@
+import subprocess
+import os
+import argparse
+from argparse import RawDescriptionHelpFormatter
+import filecmp
+import json
+import binascii
+
+# Start of our unit test
+# -- main() -------------------------------------------------------------------
+#
+# The entry point to this script.
+#
+# Note: It is called at the end of this script so that the other functions
+#       and classes have been defined and the syntax validated
+def main():
+  # -- Configure the argument parser
+  parser = argparse.ArgumentParser(formatter_class=RawDescriptionHelpFormatter, description='description:\n  Unit test wrapper for the adding AIE Partitions')
+  parser.add_argument('--resource-dir', nargs='?', default=".", help='directory containing data to be used by this unit test')
+  args = parser.parse_args()
+
+  # Validate that the resource directory is valid
+  if not os.path.exists(args.resource_dir):
+      raise Exception("Error: The resource-dir '" + args.resource_dir +"' does not exist")
+
+  if not os.path.isdir(args.resource_dir):
+      raise Exception("Error: The resource-dir '" + args.resource_dir +"' is not a directory")
+
+  # Prepare for testing
+  xclbinutil = "xclbinutil"
+
+  # Start the tests
+  print ("Starting test")
+
+  # ---------------------------------------------------------------------------
+
+  step = "1) Add and validate adding / dumping an AIE_PARTITION"
+
+  aiePartition = os.path.join(args.resource_dir, "aie_partition.json")
+  aiePartitionOutput = "aie_partition_output.json"
+
+  cmd = [xclbinutil, "--add-section", "AIE_PARTITION:JSON:" + aiePartition,
+                     "--dump-section", "AIE_PARTITION:JSON:" + aiePartitionOutput,
+                     "--force"
+                     ]
+  execCmd(step, cmd)
+  jsonFileCompare(aiePartition, aiePartitionOutput)
+
+  # ---------------------------------------------------------------------------
+
+  step = "2) Create an xclbin image with an AIE Parition"
+
+  aieMetadata = os.path.join(args.resource_dir, "aie_metadata.json")
+  aiePartitionExpected2 = os.path.join(args.resource_dir, "aie_partition_expected2.json")
+  aiePartitionOutput2 = "aie_partition_output2.json"
+
+  cmd = [xclbinutil, "--add-section", "AIE_METADATA:JSON:" + aieMetadata,
+                     "--dump-section", "AIE_PARTITION:JSON:" + aiePartitionOutput2,
+                     "--force"
+                     ]
+  execCmd(step, cmd)
+  jsonFileCompare(aiePartitionExpected2, aiePartitionOutput2)
+
+  # ---------------------------------------------------------------------------
+
+  # If the code gets this far, all is good.
+  return False
+
+def jsonFileCompare(file1, file2):
+  if not os.path.isfile(file1):
+    raise Exception("Error: The following json file does not exist: '" + file1 +"'")
+
+  with open(file1) as f:
+    data1 = json.dumps(json.load(f), indent=2)
+
+  if not os.path.isfile(file2):
+    raise Exception("Error: The following json file does not exist: '" + file2 +"'")
+
+  with open(file2) as f:
+    data2 = json.dumps(json.load(f), indent=2)
+
+  if data1 != data2:
+      # Print out the contents of file 1
+      print ("\nFile1 : "+ file1)
+      print ("vvvvv")
+      print (data1)
+      print ("^^^^^")
+
+      # Print out the contents of file 1
+      print ("\nFile2 : "+ file2)
+      print ("vvvvv")
+      print (data2)
+      print ("^^^^^")
+
+      raise Exception("Error: The given files are not the same")
+
+def textFileCompare(file1, file2):
+    if not os.path.isfile(file1):
+      raise Exception("Error: The following file does not exist: '" + file1 +"'")
+
+    with open(file1) as f:
+      data1 = f.read()
+
+    if not os.path.isfile(file2):
+      raise Exception("Error: The following file does not exist: '" + file2 +"'")
+
+    with open(file2) as f:
+      data2 = f.read()
+
+    if data1 != data2:
+        # Print out the contents of file 1
+        print ("\nFile1 : "+ file1)
+        print ("vvvvv")
+        print (data1)
+        print ("^^^^^")
+
+        # Print out the contents of file 1
+        print ("\nFile2 : "+ file2)
+        print ("vvvvv")
+        print (data2)
+        print ("^^^^^")
+
+        raise Exception("Error: The given files are not the same")
+
+
+def testDivider():
+  print("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
+
+
+def execCmd(pretty_name, cmd):
+  testDivider()
+  print(pretty_name)
+  testDivider()
+  cmdLine = ' '.join(cmd)
+  print(cmdLine)
+  proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+  o, e = proc.communicate()
+  print(o.decode('ascii'))
+  print(e.decode('ascii'))
+  errorCode = proc.returncode
+
+  if errorCode != 0:
+    raise Exception("Operation failed with the return code: " + str(errorCode))
+
+# -- Start executing the script functions
+if __name__ == '__main__':
+  try:
+    if main() == True:
+      print ("\nError(s) occurred.")
+      print("Test Status: FAILED")
+      exit(1)
+  except Exception as error:
+    print(repr(error))
+    print("Test Status: FAILED")
+    exit(1)
+
+
+# If the code get this far then no errors occured
+print("Test Status: PASSED")
+exit(0)
+

--- a/src/runtime_src/tools/xclbinutil/unittests/AIEPartition/aie_metadata.json
+++ b/src/runtime_src/tools/xclbinutil/unittests/AIEPartition/aie_metadata.json
@@ -1,0 +1,173 @@
+{
+    "schema_version": {
+        "major": "1",
+        "minor": "0",
+        "patch": "0"
+    },
+    "aie_metadata": {
+        "driver_config": {
+            "hw_gen": 2,
+            "base_address": 2199023255552,
+            "npi_address": 0,
+            "column_shift": 25,
+            "row_shift": 20,
+            "num_rows": 6,
+            "num_columns": 5,
+            "shim_row": 0,
+            "reserved_row_start": 1,
+            "reserved_num_rows": 1,
+            "aie_tile_row_start": 2,
+            "aie_tile_num_rows": 4,
+            "partition_num_cols": 1,
+            "partition_overlay_start_cols": [
+                1,
+                2,
+                3,
+                4
+            ]
+        },
+        "aiecompiler_options": {
+            "broadcast_enable_core": false
+        },
+        "graphs": {
+            "graph0": {
+                "id": 0,
+                "name": "ipu_inst",
+                "core_columns": [
+                    0,
+                    0,
+                    0,
+                    0
+                ],
+                "core_rows": [
+                    0,
+                    1,
+                    2,
+                    3
+                ],
+                "iteration_memory_columns": [
+                    0,
+                    0,
+                    0,
+                    0
+                ],
+                "iteration_memory_rows": [
+                    0,
+                    1,
+                    2,
+                    2
+                ],
+                "iteration_memory_addresses": [
+                    26628,
+                    26628,
+                    26628,
+                    49220
+                ],
+                "multirate_triggers": [
+                    false,
+                    false,
+                    false,
+                    false
+                ],
+                "pl_kernel_instance_names": [],
+                "pl_axi_lite_modes": []
+            }
+        },
+        "RTPs": {},
+        "GMIOs": {
+            "gmio0": {
+                "id": 0,
+                "name": "ipu_inst.aPr_slice_c0",
+                "logical_name": "IFM_MT0",
+                "type": 0,
+                "shim_column": 0,
+                "channel_number": 2,
+                "stream_id": 3,
+                "burst_length_in_16byte": 16,
+                "pl_kernel_instance_name": "",
+                "pl_parameter_index": -1
+            },
+            "gmio1": {
+                "id": 1,
+                "name": "ipu_inst.bPr_slice_c0",
+                "logical_name": "WGT_MT0",
+                "type": 0,
+                "shim_column": 0,
+                "channel_number": 3,
+                "stream_id": 7,
+                "burst_length_in_16byte": 16,
+                "pl_kernel_instance_name": "",
+                "pl_parameter_index": -1
+            },
+            "gmio2": {
+                "id": 2,
+                "name": "ipu_inst.cPr_slice_c0",
+                "logical_name": "OFM_MT0",
+                "type": 1,
+                "shim_column": 0,
+                "channel_number": 0,
+                "stream_id": 2,
+                "burst_length_in_16byte": 16,
+                "pl_kernel_instance_name": "",
+                "pl_parameter_index": -1
+            }
+        },
+        "PLIOs": {
+            "plio0": {
+                "id": 0,
+                "name": "ipu_inst.tct0",
+                "logical_name": "TCT",
+                "shim_column": 0,
+                "slaveOrMaster": 1,
+                "stream_id": 0
+            }
+        },
+        "EventGraphs": {
+            "graph0": {
+                "id": 0,
+                "name": "ipu_inst",
+                "core_columns": [
+                    0,
+                    0,
+                    0,
+                    0
+                ],
+                "core_rows": [
+                    0,
+                    1,
+                    2,
+                    3
+                ],
+                "dma_columns": [
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0
+                ],
+                "dma_rows": [
+                    0,
+                    1,
+                    1,
+                    2,
+                    2,
+                    3,
+                    0,
+                    1,
+                    2,
+                    3
+                ]
+            }
+        },
+        "DeviceData": {
+            "AIEBaseAddress": "0x20000000000",
+            "AIEFrequency": 1000
+        },
+        "TraceGMIOs": {}
+    }
+}

--- a/src/runtime_src/tools/xclbinutil/unittests/AIEPartition/aie_partition.json
+++ b/src/runtime_src/tools/xclbinutil/unittests/AIEPartition/aie_partition.json
@@ -1,0 +1,14 @@
+{
+    "aie_partition": {
+        "schema_version": "0",
+        "name": "acme",
+        "partition_info": {
+            "column_width": "1",
+            "start_columns": [
+                "1",
+                "2",
+                "5"
+            ]
+        }
+    }
+}

--- a/src/runtime_src/tools/xclbinutil/unittests/AIEPartition/aie_partition_expected2.json
+++ b/src/runtime_src/tools/xclbinutil/unittests/AIEPartition/aie_partition_expected2.json
@@ -1,0 +1,15 @@
+{
+    "aie_partition": {
+        "schema_version": "0",
+        "name": "xclbinutil-generated",
+        "partition_info": {
+            "column_width": "1",
+            "start_columns": [
+                "1",
+                "2",
+                "3",
+                "4"
+            ]
+        }
+    }
+}


### PR DESCRIPTION
#### Problem solved by the commit
Enhanced xclbin containers and xclbinutil to support AIE Partition metadata.

Work Done
------------
+ Refactored readXclBinBinar() and readPayload() to use std::istream classe instead of std::fstream
+ Created new section AIE_PARTITION and its supporting functions
+ Updated flow to auto create AIE_PARTITION section if AIT_METADATA contains AIE Partition information
+ Update XclBinUtilities::TRACE to accept boost::format types
+ Added --skip-aie-partition-insertion option to skip automatically added the AIE_PARTITION section if one isn't found
+ Created unit-tests to add / dump AIE_PARTITIONS
+ Created unit-tests to automatically extract AIE_PARTITION metadata from AIE_METADATA

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
N/A

#### How problem was solved, alternative solutions (if any) and why they were rejected
N/A

#### Risks (if any) associated the changes in the commit
none - incremental addition

#### What has been tested and how, request additional testing if necessary
+ Several unit-tests have been added for this new functionality
+ Manual testing

#### Documentation impact (if any)
N/A