### PR TITLE
hwmon_sdm: maintain separate cache timer for each SDR type (#6542)

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/hwmon_sdm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/hwmon_sdm.c
@@ -71,7 +71,7 @@ struct xocl_hwmon_sdm {
 
 	struct mutex            sdm_lock;
 	u64                     cache_expire_secs;
-	ktime_t                 cache_expires;
+	ktime_t                 cache_expires[SDR_TYPE_MAX];
 };
 
 #define SDM_BUF_IDX_INCR(buf_index, len, buf_len) \
@@ -180,10 +180,10 @@ static int get_sdr_type(enum xcl_group_kind kind)
 	return type;
 }
 
-static void update_cache_expiry_time(struct xocl_hwmon_sdm *sdm)
+static void update_cache_expiry_time(struct xocl_hwmon_sdm *sdm, uint8_t repo_id)
 {
-	sdm->cache_expires = ktime_add(ktime_get_boottime(),
-                                   ktime_set(sdm->cache_expire_secs, 0));
+	sdm->cache_expires[repo_id] = ktime_add(ktime_get_boottime(),
+                                      ktime_set(sdm->cache_expire_secs, 0));
 }
 
 /*
@@ -246,7 +246,7 @@ static int get_sensors_data(struct platform_device *pdev, uint8_t repo_id)
 	struct xocl_hwmon_sdm *sdm = platform_get_drvdata(pdev);
 	ktime_t now = ktime_get_boottime();
 
-	if (ktime_compare(now, sdm->cache_expires) > 0)
+	if (ktime_compare(now, sdm->cache_expires[repo_id]) > 0)
 		return hwmon_sdm_update_sensors(pdev, repo_id);
 
 	return 0;
@@ -292,6 +292,11 @@ static ssize_t hwmon_sensor_show(struct device *dev,
 	char output[64];
 	uint32_t uval = 0;
 	ssize_t sz = 0;
+
+	if (repo_id >= SDR_TYPE_MAX) {
+		xocl_dbg(&sdm->pdev->dev, "repo_id: 0x%x is corrupted or not supported\n", repo_id);
+		return sprintf(buf, "%d\n", 0);
+	}
 
 	mutex_lock(&sdm->sdm_lock);
 	get_sensors_data(sdm->pdev, repo_id);
@@ -1048,7 +1053,7 @@ static int hwmon_sdm_update_sensors(struct platform_device *pdev, uint8_t repo_i
 		ret = hwmon_sdm_read_from_peer(pdev, repo_type);
 
 	if (!ret)
-		update_cache_expiry_time(sdm);
+		update_cache_expiry_time(sdm, repo_id);
 
 	return ret;
 }


### PR DESCRIPTION
* hwmon_sdm: maintain seperate cache timer for each SDR type

Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>

* hwmon_sdm: check if repo_id is in valid range

Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>
(cherry picked from commit 4f75f3e4eb707ee29475a7f3fbdb45acb7dae156)
