### PR TITLE
xclbinutil: Header code cleanup 

### DIFF
--- a/src/runtime_src/tools/xclbinutil/DTC.h
+++ b/src/runtime_src/tools/xclbinutil/DTC.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019 Xilinx, Inc
+ * Copyright (C) 2019, 2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -18,19 +18,15 @@
 #define __DTC_h_
 
 // ----------------------- I N C L U D E S -----------------------------------
-
-// #includes here - please keep these to a bare minimum!
 #include "DTCStringsBlock.h"
 #include "FDTNode.h"
-
 #include <boost/property_tree/ptree.hpp>
 
-// ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
-// Forward declarations - use these instead whenever possible...
-
-// ------------------- C L A S S :   S e c t i o n ---------------------------
+// ------------------- C L A S S :   D T C -----------------------------------
 
 class DTC {
+ private:
+  DTC();
 
  public:
   DTC(const char* _pBuffer, const unsigned int _size, const FDTProperty::PropertyNameFormat & _propertyNameFormat);
@@ -44,12 +40,6 @@ class DTC {
  protected:
   void marshalFromDTCImage( const char* _pBuffer, const unsigned int _size, const FDTProperty::PropertyNameFormat & _propertyNameFormat);
   void marshalFromJSON(const boost::property_tree::ptree &_ptDTC, const FDTProperty::PropertyNameFormat & _propertyNameFormat);
-
- private:
-  // Purposefully private and undefined ctors...
-  DTC();
-  DTC(const DTC& obj);
-  DTC& operator=(const DTC& obj);
 
  private:
   DTCStringsBlock m_DTCStringsBlock;    // Block of property strings

--- a/src/runtime_src/tools/xclbinutil/DTCStringsBlock.h
+++ b/src/runtime_src/tools/xclbinutil/DTCStringsBlock.h
@@ -18,21 +18,16 @@
 #define __DTCStringsBlock_h_
 
 // ----------------------- I N C L U D E S -----------------------------------
-
-// #includes here - please keep these to a bare minimum!
-#include <string>
 #include <sstream>
+#include <string>
 
-// ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
-// Forward declarations - use these instead whenever possible...
-
-// ------------------- C L A S S :   S e c t i o n ---------------------------
+// ----------- C L A S S :   D T C S t r i n g s B l o c k -------------------
 
 class DTCStringsBlock {
 
  public:
   DTCStringsBlock();
-  virtual ~DTCStringsBlock();
+  ~DTCStringsBlock();
 
  public:
   uint32_t addString(const std::string _dtcString);
@@ -40,11 +35,6 @@ class DTCStringsBlock {
 
   void parseDTCStringsBlock(const char* _pBuffer, const unsigned int _size);
   void marshalToDTC(std::ostream& _buf) const;
-
- private:
-  // Purposefully private and undefined ctors...
-  DTCStringsBlock(const DTCStringsBlock& obj);
-  DTCStringsBlock& operator=(const DTCStringsBlock& obj);
 
  private:
    std::ostringstream * m_pDTCStringBlock;

--- a/src/runtime_src/tools/xclbinutil/FDTNode.h
+++ b/src/runtime_src/tools/xclbinutil/FDTNode.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019 Xilinx, Inc
+ * Copyright (C) 2019,2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -18,45 +18,37 @@
 #define __FDTNode_h_
 
 // ----------------------- I N C L U D E S -----------------------------------
-
-// #includes here - please keep these to a bare minimum!
 #include "FDTProperty.h"
-
+#include <boost/property_tree/ptree.hpp>
 #include <string>
 #include <vector>
-#include <boost/property_tree/ptree.hpp>
 
 // ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
-// Forward declarations - use these instead whenever possible...
 class DTCStringsBlock;
 
-// ------------------- C L A S S :   S e c t i o n ---------------------------
+// ------------------- C L A S S :   F D T N o d e ---------------------------
 
 class FDTNode {
 
  private:
+  FDTNode();
   FDTNode(const char* _pBuffer, const unsigned int _size, const DTCStringsBlock& _dtcStringsBlock, unsigned int& _bytesExamined, const FDTProperty::PropertyNameFormat & _propertyNameFormat);
   FDTNode(const boost::property_tree::ptree& _ptDTC, std::string & _nodeName, const FDTProperty::PropertyNameFormat & _propertyNameFormat);
 
  public:
-  virtual ~FDTNode();
+  ~FDTNode();
 
  public:
   static FDTNode* marshalFromDTC(const char* _pBuffer, const unsigned int _size, const DTCStringsBlock& _dtcStringsBlock, const FDTProperty::PropertyNameFormat & _propertyNameFormat);
   static FDTNode* marshalFromJSON(const boost::property_tree::ptree& _ptDTC, const FDTProperty::PropertyNameFormat & _propertyNameFormat);
 
+ public:
   void marshalToJSON(boost::property_tree::ptree& _dtcTree, const FDTProperty::PropertyNameFormat & _propertyNameFormat) const;
   void marshalToDTC(DTCStringsBlock& _dtcStringsBlock, std::ostream& _buf) const;
 
  protected:
   void marshalSubNodeToJSON(boost::property_tree::ptree& _ptTree, const FDTProperty::PropertyNameFormat & _propertyNameFormat) const;
   static void runningBufferCheck(const unsigned int _bytesExamined, const unsigned int _size);
-
- private:
-  // Purposefully private and undefined ctors...
-  FDTNode();
-  FDTNode(const FDTNode& obj);
-  FDTNode& operator=(const FDTNode& obj);
 
  private:
   std::string m_name;                      // Name of the node

--- a/src/runtime_src/tools/xclbinutil/FDTProperty.h
+++ b/src/runtime_src/tools/xclbinutil/FDTProperty.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019 Xilinx, Inc
+ * Copyright (C) 2019,2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -18,17 +18,14 @@
 #define __FDTProperty_h_
 
 // ----------------------- I N C L U D E S -----------------------------------
-
-// #includes here - please keep these to a bare minimum!
-#include <string>
-#include <map>
 #include <boost/property_tree/ptree.hpp>
+#include <map>
+#include <string>
 
 // ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
-// Forward declarations - use these instead whenever possible...
 class DTCStringsBlock;
 
-// ------------------- C L A S S :   S e c t i o n ---------------------------
+// -------------- C L A S S :   F D T P r o p e r t y ------------------------
 
 class FDTProperty {
  public: 
@@ -48,6 +45,9 @@ class FDTProperty {
 
  public:
   typedef std::map<const std::string, DataFormat> PropertyNameFormat;
+
+ private:
+  FDTProperty();
 
  public:
   FDTProperty(const char* _pBuffer, const unsigned int _size, const DTCStringsBlock & _dtcStringsBlock, unsigned int & _bytesExamined, const PropertyNameFormat & _propertyNameFormat);
@@ -82,12 +82,6 @@ class FDTProperty {
   const std::string & getDataFormatPrettyName(DataFormat _eDataFormat) const;
   unsigned int getWordLength(DataFormat _eDataFormat) const;
   bool isDataFormatArray(DataFormat _eDataFormat) const;
-
- private:
-  // Purposefully private and undefined ctors...
-  FDTProperty();
-  FDTProperty(const FDTProperty& obj);
-  FDTProperty& operator=(const FDTProperty& obj);
 
  private:
   uint32_t m_dataLength;      // The length of the data buffer

--- a/src/runtime_src/tools/xclbinutil/ParameterSectionData.h
+++ b/src/runtime_src/tools/xclbinutil/ParameterSectionData.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Xilinx, Inc
+ * Copyright (C) 2018, 2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -18,26 +18,19 @@
 #define __ParameterSectionData_h_
 
 // ----------------------- I N C L U D E S -----------------------------------
-
-// #includes here - please keep these to a bare minimum!
-#include <string>
 #include "Section.h"
 #include "xclbin.h"
+#include <string>
 
-// ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
-// Forward declarations - use these instead whenever possible...
-
-// ------------------- C L A S S :   S e c t i o n ---------------------------
-
-/**
- *    This class represents the base class for a given Section in the xclbin
- *    archive.  
-*/
+// ---------- C L A S S :   P a r a m e t e r S e c t i o n D a t a ---------
 
 class ParameterSectionData {
+ private:
+  ParameterSectionData();
+
  public:
   ParameterSectionData(const std::string &_formattedString);
-  virtual ~ParameterSectionData();
+  ~ParameterSectionData();
 
  public:
   const std::string &getFile();
@@ -49,6 +42,9 @@ class ParameterSectionData {
   enum axlf_section_kind &getSectionKind();
   const std::string &getOriginalFormattedString();
 
+  protected:
+   void transformFormattedString(const std::string _formattedString);
+
  protected:
    enum Section::FormatType m_formatType;
    std::string m_formatTypeStr;
@@ -58,17 +54,6 @@ class ParameterSectionData {
    std::string m_sectionIndex;
    enum axlf_section_kind m_eKind;
    std::string m_originalString;
-
- protected:
-   void transformFormattedString(const std::string _formattedString);
-
- private:
-  ParameterSectionData();
-  // Purposefully private and undefined ctors...
-  ParameterSectionData(const ParameterSectionData& obj);
-  ParameterSectionData& operator=(const ParameterSectionData& obj);
-
- private:
 };
 
 #endif

--- a/src/runtime_src/tools/xclbinutil/SectionAIEMetadata.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionAIEMetadata.cxx
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Xilinx, Inc
+ * Copyright (C) 2020, 2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -16,13 +16,20 @@
 
 #include "SectionAIEMetadata.h"
 
+#include "XclBinUtilities.h"
+#include <boost/functional/factory.hpp>
 #include <boost/property_tree/json_parser.hpp>
 
-#include "XclBinUtilities.h"
 namespace XUtil = XclBinUtilities;
 
 // Static Variables / Classes
-SectionAIEMetadata::_init SectionAIEMetadata::_initializer;
+// ----------------------------------------------------------------------------
+SectionAIEMetadata::init SectionAIEMetadata::initializer;
+
+SectionAIEMetadata::init::init() {
+  registerSectionCtor(AIE_METADATA, "AIE_METADATA", "", false, false, boost::factory<SectionAIEMetadata*>()); 
+}
+// ----------------------------------------------------------------------------
 
 void 
 SectionAIEMetadata::marshalToJSON( char* _pDataSection, 

--- a/src/runtime_src/tools/xclbinutil/SectionAIEMetadata.h
+++ b/src/runtime_src/tools/xclbinutil/SectionAIEMetadata.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Xilinx, Inc
+ * Copyright (C) 2020, 2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -18,32 +18,25 @@
 #define __SectionAIEMetadata_h_
 
 // ----------------------- I N C L U D E S -----------------------------------
-
-// #includes here - please keep these to a bare minimum!
 #include "Section.h"
-#include <boost/functional/factory.hpp>
 
-// ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
-// Forward declarations - use these instead whenever possible...
-
-// ------ C L A S S :   S e c t i o n C l e a r B i t s t r e a m ------------
-
+// ------ C L A S S :   S e c t i o n A I E M e t a d a t a ------------------
 class SectionAIEMetadata : public Section {
 
 public:
-  virtual bool doesSupportAddFormatType(FormatType _eFormatType) const;
-  virtual bool doesSupportDumpFormatType(FormatType _eFormatType) const;
+  bool doesSupportAddFormatType(FormatType _eFormatType) const override;
+  bool doesSupportDumpFormatType(FormatType _eFormatType) const override;
 
  protected:
-  virtual void marshalToJSON(char* _pDataSection, unsigned int _sectionSize, boost::property_tree::ptree& _ptree) const;
-  virtual void marshalFromJSON(const boost::property_tree::ptree& _ptSection, std::ostringstream& _buf) const;
+  void marshalToJSON(char* _pDataSection, unsigned int _sectionSize, boost::property_tree::ptree& _ptree) const override;
+  void marshalFromJSON(const boost::property_tree::ptree& _ptSection, std::ostringstream& _buf) const override;
 
  private:
   // Static initializer helper class
-  static class _init {
+  static class init {
    public:
-    _init() { registerSectionCtor(AIE_METADATA, "AIE_METADATA", "", false, false, boost::factory<SectionAIEMetadata*>()); }
-  } _initializer;
+    init();
+  } initializer;
 };
 
 #endif

--- a/src/runtime_src/tools/xclbinutil/SectionAIEPartition.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionAIEPartition.cxx
@@ -17,8 +17,10 @@
 #include "SectionAIEPartition.h"
 
 #include "XclBinUtilities.h"
-namespace XUtil = XclBinUtilities;
+#include <boost/functional/factory.hpp>
 #include <iostream>
+
+namespace XUtil = XclBinUtilities;
 
 // Static Variables / Classes
 SectionAIEPartition::init SectionAIEPartition::initializer;

--- a/src/runtime_src/tools/xclbinutil/SectionAIEPartition.h
+++ b/src/runtime_src/tools/xclbinutil/SectionAIEPartition.h
@@ -18,13 +18,9 @@
 #define __SectionAIEPartitions_h_
 
 // ----------------------- I N C L U D E S -----------------------------------
-
-// #includes here - please keep these to a bare minimum!
 #include "Section.h"
-#include <boost/functional/factory.hpp>
 
 // -------- C L A S S :   S e c t i o n A I E P a r t i t i o n --------------
-
 class SectionAIEPartition : public Section {
  public:
   bool doesSupportAddFormatType(FormatType _eFormatType) const override;

--- a/src/runtime_src/tools/xclbinutil/SectionAIEResources.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionAIEResources.cxx
@@ -16,7 +16,14 @@
 
 #include "SectionAIEResources.h"
 
+#include <boost/functional/factory.hpp>
+
 // Static Variables / Classes
-SectionAIEResources::_init SectionAIEResources::_initializer;
+SectionAIEResources::init SectionAIEResources::initializer;
+
+SectionAIEResources::init::init() 
+{ 
+  registerSectionCtor(AIE_RESOURCES, "AIE_RESOURCES", "", false, false, boost::factory<SectionAIEResources*>()); 
+}
 
 

--- a/src/runtime_src/tools/xclbinutil/SectionAIEResources.h
+++ b/src/runtime_src/tools/xclbinutil/SectionAIEResources.h
@@ -18,24 +18,16 @@
 #define __SectionAIEResources_h_
 
 // ----------------------- I N C L U D E S -----------------------------------
-
-// #includes here - please keep these to a bare minimum!
 #include "Section.h"
-#include <boost/functional/factory.hpp>
 
-// ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
-// Forward declarations - use these instead whenever possible...
-
-// --------------- C L A S S :   S e c t i o n P D I -------------------------
-
+// --------- C L A S S :  S e c t i o n A I E R e s o u r c e s --------------
 class SectionAIEResources : public Section {
- 
  private:
   // Static initializer helper class
-  static class _init {
+  static class init {
    public:
-    _init() { registerSectionCtor(AIE_RESOURCES, "AIE_RESOURCES", "", false, false, boost::factory<SectionAIEResources*>()); }
-  } _initializer;
+    init();
+  } initializer;
 };
 
 #endif

--- a/src/runtime_src/tools/xclbinutil/SectionBMC.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionBMC.cxx
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018, 2020-2021 Xilinx, Inc
+ * Copyright (C) 2018, 2020-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -20,6 +20,7 @@
 namespace XUtil = XclBinUtilities;
 
 #include <boost/algorithm/string.hpp>
+#include <boost/functional/factory.hpp>
 #include <boost/property_tree/json_parser.hpp>
 
 // Disable windows compiler warnings
@@ -28,20 +29,12 @@ namespace XUtil = XclBinUtilities;
 #endif
 
 // Static Variables / Classes
-SectionBMC::_init SectionBMC::_initializer;
+SectionBMC::init SectionBMC::initializer;
 
-// -------------------------------------------------------------------------
-
-SectionBMC::SectionBMC() {
-  // Empty
+SectionBMC::init::init() 
+{
+  registerSectionCtor(BMC, "BMC", "", true, false, boost::factory<SectionBMC*>()); 
 }
-
-// -------------------------------------------------------------------------
-
-SectionBMC::~SectionBMC() {
-  // Empty
-}
-
 // -------------------------------------------------------------------------
 
 bool 

--- a/src/runtime_src/tools/xclbinutil/SectionBMC.h
+++ b/src/runtime_src/tools/xclbinutil/SectionBMC.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 - 2021 Xilinx, Inc
+ * Copyright (C) 2018 - 2021, 2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -18,22 +18,11 @@
 #define __SectionBMC_h_
 
 // ----------------------- I N C L U D E S -----------------------------------
-
-// #includes here - please keep these to a bare minimum!
 #include "Section.h"
-#include <boost/functional/factory.hpp>
-
-// ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
-// Forward declarations - use these instead whenever possible...
 
 // --------------- C L A S S :   S e c t i o n B M C -------------------------
-
 class SectionBMC : public Section {
  public:
-  SectionBMC();
-  virtual ~SectionBMC();
-
-public:
   enum SubSection{
     SS_UNKNOWN,
     SS_FW,
@@ -41,32 +30,27 @@ public:
   };
 
  public:
-  virtual bool doesSupportAddFormatType(FormatType _eFormatType) const;
-  virtual bool supportsSubSection(const std::string &_sSubSectionName) const;
-  virtual bool subSectionExists(const std::string &_sSubSectionName) const;
+  bool doesSupportAddFormatType(FormatType _eFormatType) const override;
+  bool supportsSubSection(const std::string &_sSubSectionName) const override;
+  bool subSectionExists(const std::string &_sSubSectionName) const override;
 
  protected:
-  virtual void readSubPayload(const char* _pOrigDataSection, unsigned int _origSectionSize,  std::istream& _istream, const std::string & _sSubSection, enum Section::FormatType _eFormatType, std::ostringstream &_buffer) const;
+  void readSubPayload(const char* _pOrigDataSection, unsigned int _origSectionSize,  std::istream& _istream, const std::string & _sSubSection, enum Section::FormatType _eFormatType, std::ostringstream &_buffer) const override;
+  void writeSubPayload(const std::string & _sSubSectionName, FormatType _eFormatType, std::fstream&  _oStream) const override;
 
  protected:
    enum SubSection getSubSectionEnum(const std::string _sSubSectionName) const;
    void copyBufferUpdateMetadata(const char* _pOrigDataSection, unsigned int _origSectionSize,  std::istream& _istream, std::ostringstream &_buffer) const;
    void createDefaultFWImage(std::istream & _istream, std::ostringstream &_buffer) const;
-   virtual void writeSubPayload(const std::string & _sSubSectionName, FormatType _eFormatType, std::fstream&  _oStream) const;
    void writeFWImage(std::ostream& _oStream) const;
    void writeMetadata(std::ostream& _oStream) const;
 
  private:
-  // Purposefully private and undefined ctors...
-  SectionBMC(const SectionBMC& obj);
-  SectionBMC& operator=(const SectionBMC& obj);
-
- private:
   // Static initializer helper class
-  static class _init {
+  static class init {
    public:
-    _init() { registerSectionCtor(BMC, "BMC", "", true, false, boost::factory<SectionBMC*>()); }
-  } _initializer;
+    init();
+  } initializer;
 };
 
 #endif

--- a/src/runtime_src/tools/xclbinutil/SectionBitstream.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionBitstream.cxx
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Xilinx, Inc
+ * Copyright (C) 2018, 2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -17,17 +17,16 @@
 #include "SectionBitstream.h"
 
 #include "XclBinUtilities.h"
+#include <boost/functional/factory.hpp>
+
 namespace XUtil = XclBinUtilities;
 
 // Static Variables / Classes
-SectionBitstream::_init SectionBitstream::_initializer;
+SectionBitstream::init SectionBitstream::initializer;
 
-SectionBitstream::SectionBitstream() {
-  // Empty
-}
-
-SectionBitstream::~SectionBitstream() {
-  // Empty
+SectionBitstream::init::init() 
+{ 
+  registerSectionCtor(BITSTREAM, "BITSTREAM", "", false, false, boost::factory<SectionBitstream*>()); 
 }
 
 std::string

--- a/src/runtime_src/tools/xclbinutil/SectionBitstream.h
+++ b/src/runtime_src/tools/xclbinutil/SectionBitstream.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 - 2019 Xilinx, Inc
+ * Copyright (C) 2018 - 2019, 2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -18,35 +18,19 @@
 #define __SectionBitstream_h_
 
 // ----------------------- I N C L U D E S -----------------------------------
-
-// #includes here - please keep these to a bare minimum!
 #include "Section.h"
-#include <boost/functional/factory.hpp>
-
-// ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
-// Forward declarations - use these instead whenever possible...
 
 // --------- C L A S S :   S e c t i o n B i t s t r e a m -------------------
-
 class SectionBitstream : public Section {
- public:
-  SectionBitstream();
-  virtual ~SectionBitstream();
-
  public:
   std::string getContentTypeAsString();
 
  private:
-  // Purposefully private and undefined ctors...
-  SectionBitstream(const SectionBitstream& obj);
-  SectionBitstream& operator=(const SectionBitstream& obj);
-
- private:
   // Static initializer helper class
-  static class _init {
+  static class init {
    public:
-    _init() { registerSectionCtor(BITSTREAM, "BITSTREAM", "", false, false, boost::factory<SectionBitstream*>()); }
-  } _initializer;
+    init();
+  } initializer;
 };
 
 #endif

--- a/src/runtime_src/tools/xclbinutil/SectionBitstreamPartialPDI.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionBitstreamPartialPDI.cxx
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Xilinx, Inc
+ * Copyright (C) 2018, 2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -16,19 +16,16 @@
 
 #include "SectionBitstreamPartialPDI.h"
 
-#include "XclBinUtilities.h"
-namespace XUtil = XclBinUtilities;
+#include <boost/functional/factory.hpp>
 
 // Static Variables / Classes
-SectionBitstreamPartialPDI::_init SectionBitstreamPartialPDI::_initializer;
+SectionBitstreamPartialPDI::init SectionBitstreamPartialPDI::initializer;
 
-SectionBitstreamPartialPDI::SectionBitstreamPartialPDI() {
-  // Empty
+SectionBitstreamPartialPDI::init::init() 
+{ 
+  registerSectionCtor(BITSTREAM_PARTIAL_PDI, "BITSTREAM_PARTIAL_PDI", "", false, false, boost::factory<SectionBitstreamPartialPDI*>()); 
 }
 
-SectionBitstreamPartialPDI::~SectionBitstreamPartialPDI() {
-  // Empty
-}
 
 
 

--- a/src/runtime_src/tools/xclbinutil/SectionBitstreamPartialPDI.h
+++ b/src/runtime_src/tools/xclbinutil/SectionBitstreamPartialPDI.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 - 2019 Xilinx, Inc
+ * Copyright (C) 2018 - 2019, 2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -18,32 +18,16 @@
 #define __SectionBitstreamPartialPDI_h_
 
 // ----------------------- I N C L U D E S -----------------------------------
-
-// #includes here - please keep these to a bare minimum!
 #include "Section.h"
-#include <boost/functional/factory.hpp>
-
-// ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
-// Forward declarations - use these instead whenever possible...
 
 // ---- C L A S S :   S e c t i o n B i t s t r e a m P a r t i a l P D I ----
-
 class SectionBitstreamPartialPDI : public Section {
- public:
-  SectionBitstreamPartialPDI();
-  virtual ~SectionBitstreamPartialPDI();
-
- private:
-  // Purposefully private and undefined ctors...
-  SectionBitstreamPartialPDI(const SectionBitstreamPartialPDI& obj);
-  SectionBitstreamPartialPDI& operator=(const SectionBitstreamPartialPDI& obj);
-
  private:
   // Static initializer helper class
-  static class _init {
+  static class init {
    public:
-    _init() { registerSectionCtor(BITSTREAM_PARTIAL_PDI, "BITSTREAM_PARTIAL_PDI", "", false, false, boost::factory<SectionBitstreamPartialPDI*>()); }
-  } _initializer;
+    init();
+  } initializer;
 };
 
 #endif

--- a/src/runtime_src/tools/xclbinutil/SectionBuildMetadata.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionBuildMetadata.cxx
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018, 2020 Xilinx, Inc
+ * Copyright (C) 2018, 2020, 2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -16,23 +16,19 @@
 
 #include "SectionBuildMetadata.h"
 
-#include <boost/property_tree/json_parser.hpp>
-
-#include "XclBinUtilities.h"
-
 #include "version.h" // Globally included from main
+#include "XclBinUtilities.h"
+#include <boost/functional/factory.hpp>
+#include <boost/property_tree/json_parser.hpp>
 
 namespace XUtil = XclBinUtilities;
 
 // Static Variables / Classes
-SectionBuildMetadata::_init SectionBuildMetadata::_initializer;
+SectionBuildMetadata::init SectionBuildMetadata::initializer;
 
-SectionBuildMetadata::SectionBuildMetadata() {
-  // Empty
-}
-
-SectionBuildMetadata::~SectionBuildMetadata() {
-  // Empty
+SectionBuildMetadata::init::init() 
+{ 
+  registerSectionCtor(BUILD_METADATA, "BUILD_METADATA", "build_metadata", false, false, boost::factory<SectionBuildMetadata*>()); 
 }
 
 void 

--- a/src/runtime_src/tools/xclbinutil/SectionBuildMetadata.h
+++ b/src/runtime_src/tools/xclbinutil/SectionBuildMetadata.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 - 2019 Xilinx, Inc
+ * Copyright (C) 2018 - 2019, 2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -18,41 +18,24 @@
 #define __SectionBuildMetadata_h_
 
 // ----------------------- I N C L U D E S -----------------------------------
-
-// #includes here - please keep these to a bare minimum!
 #include "Section.h"
-#include <boost/functional/factory.hpp>
-#include <boost/property_tree/ptree.hpp>
-
-// ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
-// Forward declarations - use these instead whenever possible...
 
 // ----- C L A S S :   S e c t i o n B u i l d M e t a d a t a ---------------
-
 class SectionBuildMetadata : public Section {
  public:
-  SectionBuildMetadata();
-  virtual ~SectionBuildMetadata();
-
- public:
-  virtual bool doesSupportAddFormatType(FormatType _eFormatType) const;
-  virtual bool doesSupportDumpFormatType(FormatType _eFormatType) const;
+  bool doesSupportAddFormatType(FormatType _eFormatType) const override;
+  bool doesSupportDumpFormatType(FormatType _eFormatType) const override;
 
  protected:
-  virtual void marshalToJSON(char* _pDataSection, unsigned int _sectionSize, boost::property_tree::ptree& _ptree) const;
-  virtual void marshalFromJSON(const boost::property_tree::ptree& _ptSection, std::ostringstream& _buf) const;
-
- private:
-  // Purposefully private and undefined ctors...
-  SectionBuildMetadata(const SectionBuildMetadata& obj);
-  SectionBuildMetadata& operator=(const SectionBuildMetadata& obj);
+  void marshalToJSON(char* _pDataSection, unsigned int _sectionSize, boost::property_tree::ptree& _ptree) const override;
+  void marshalFromJSON(const boost::property_tree::ptree& _ptSection, std::ostringstream& _buf) const override;
 
  private:
   // Static initializer helper class
-  static class _init {
+  static class init {
    public:
-    _init() { registerSectionCtor(BUILD_METADATA, "BUILD_METADATA", "build_metadata", false, false, boost::factory<SectionBuildMetadata*>()); }
-  } _initializer;
+    init();
+  } initializer;
 };
 
 #endif

--- a/src/runtime_src/tools/xclbinutil/SectionClearBitstream.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionClearBitstream.cxx
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Xilinx, Inc
+ * Copyright (C) 2018, 2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -16,19 +16,14 @@
 
 #include "SectionClearBitstream.h"
 
-#include "XclBinUtilities.h"
-namespace XUtil = XclBinUtilities;
+#include <boost/functional/factory.hpp>
 
 // Static Variables / Classes
-SectionClearBitstream::_init SectionClearBitstream::_initializer;
+SectionClearBitstream::init SectionClearBitstream::initializer;
 
-SectionClearBitstream::SectionClearBitstream() {
-  // Empty
+SectionClearBitstream::init::init() 
+{ 
+  registerSectionCtor(CLEARING_BITSTREAM, "CLEARING_BITSTREAM", "", false, false, boost::factory<SectionClearBitstream*>()); 
 }
-
-SectionClearBitstream::~SectionClearBitstream() {
-  // Empty
-}
-
 
 

--- a/src/runtime_src/tools/xclbinutil/SectionClearBitstream.h
+++ b/src/runtime_src/tools/xclbinutil/SectionClearBitstream.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 - 2019 Xilinx, Inc
+ * Copyright (C) 2018 - 2019, 2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -18,32 +18,16 @@
 #define __SectionClearBitstream_h_
 
 // ----------------------- I N C L U D E S -----------------------------------
-
-// #includes here - please keep these to a bare minimum!
 #include "Section.h"
-#include <boost/functional/factory.hpp>
-
-// ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
-// Forward declarations - use these instead whenever possible...
 
 // ------ C L A S S :   S e c t i o n C l e a r B i t s t r e a m ------------
-
 class SectionClearBitstream : public Section {
- public:
-  SectionClearBitstream();
-  virtual ~SectionClearBitstream();
-
- private:
-  // Purposefully private and undefined ctors...
-  SectionClearBitstream(const SectionClearBitstream& obj);
-  SectionClearBitstream& operator=(const SectionClearBitstream& obj);
-
  private:
   // Static initializer helper class
-  static class _init {
+  static class init {
    public:
-    _init() { registerSectionCtor(CLEARING_BITSTREAM, "CLEARING_BITSTREAM", "", false, false, boost::factory<SectionClearBitstream*>()); }
-  } _initializer;
+    init();
+  } initializer;
 };
 
 #endif

--- a/src/runtime_src/tools/xclbinutil/SectionClockFrequencyTopology.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionClockFrequencyTopology.cxx
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Xilinx, Inc
+ * Copyright (C) 2018, 2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -17,19 +17,18 @@
 #include "SectionClockFrequencyTopology.h"
 
 #include "XclBinUtilities.h"
-namespace XUtil = XclBinUtilities;
+#include <boost/functional/factory.hpp>
 #include <iostream>
 #include <stdint.h>
 
+namespace XUtil = XclBinUtilities;
+
 // Static Variables / Classes
-SectionClockFrequencyTopology::_init SectionClockFrequencyTopology::_initializer;
+SectionClockFrequencyTopology::init SectionClockFrequencyTopology::initializer;
 
-SectionClockFrequencyTopology::SectionClockFrequencyTopology() {
-  // Empty
-}
-
-SectionClockFrequencyTopology::~SectionClockFrequencyTopology() {
-  // Empty
+SectionClockFrequencyTopology::init::init() 
+{ 
+  registerSectionCtor(CLOCK_FREQ_TOPOLOGY, "CLOCK_FREQ_TOPOLOGY", "clock_freq_topology", false, false, boost::factory<SectionClockFrequencyTopology*>()); 
 }
 
 const std::string

--- a/src/runtime_src/tools/xclbinutil/SectionClockFrequencyTopology.h
+++ b/src/runtime_src/tools/xclbinutil/SectionClockFrequencyTopology.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 - 2019 Xilinx, Inc
+ * Copyright (C) 2018 - 2019, 2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -18,45 +18,28 @@
 #define __SectionClockFrequencyTopology_h_
 
 // ----------------------- I N C L U D E S -----------------------------------
-
-// #includes here - please keep these to a bare minimum!
 #include "Section.h"
-#include <boost/functional/factory.hpp>
-
-// ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
-// Forward declarations - use these instead whenever possible...
 
 // - C L A S S :   S e c t i o n C l o c k F r e q u e n c y T o p o l o g y -
-
-
 class SectionClockFrequencyTopology : public Section {
  public:
-  SectionClockFrequencyTopology();
-  virtual ~SectionClockFrequencyTopology();
-
- public:
-  virtual bool doesSupportAddFormatType(FormatType _eFormatType) const;
-  virtual bool doesSupportDumpFormatType(FormatType _eFormatType) const;
+  bool doesSupportAddFormatType(FormatType _eFormatType) const override;
+  bool doesSupportDumpFormatType(FormatType _eFormatType) const override;
 
  protected:
-  virtual void marshalToJSON(char* _pDataSection, unsigned int _sectionSize, boost::property_tree::ptree& _ptree) const;
-  virtual void marshalFromJSON(const boost::property_tree::ptree& _ptSection, std::ostringstream& _buf) const;
+  void marshalToJSON(char* _pDataSection, unsigned int _sectionSize, boost::property_tree::ptree& _ptree) const override;
+  void marshalFromJSON(const boost::property_tree::ptree& _ptSection, std::ostringstream& _buf) const override;
 
  protected:
   const std::string getClockTypeStr(enum CLOCK_TYPE _clockType) const;
   enum CLOCK_TYPE getClockType(std::string& _sClockType) const;
 
  private:
-  // Purposefully private and undefined ctors...
-  SectionClockFrequencyTopology(const SectionClockFrequencyTopology& obj);
-  SectionClockFrequencyTopology& operator=(const SectionClockFrequencyTopology& obj);
-
- private:
   // Static initializer helper class
-  static class _init {
+  static class init {
    public:
-    _init() { registerSectionCtor(CLOCK_FREQ_TOPOLOGY, "CLOCK_FREQ_TOPOLOGY", "clock_freq_topology", false, false, boost::factory<SectionClockFrequencyTopology*>()); }
-  } _initializer;
+    init();
+  } initializer;
 };
 
 #endif

--- a/src/runtime_src/tools/xclbinutil/SectionConnectivity.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionConnectivity.cxx
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018, 2020 Xilinx, Inc
+ * Copyright (C) 2018, 2020, 2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -17,18 +17,17 @@
 #include "SectionConnectivity.h"
 
 #include "XclBinUtilities.h"
-namespace XUtil = XclBinUtilities;
+#include <boost/functional/factory.hpp>
 #include <iostream>
 
+namespace XUtil = XclBinUtilities;
+
 // Static Variables / Classes
-SectionConnectivity::_init SectionConnectivity::_initializer;
+SectionConnectivity::init SectionConnectivity::initializer;
 
-SectionConnectivity::SectionConnectivity() {
-  // Empty
-}
-
-SectionConnectivity::~SectionConnectivity() {
-  // Empty
+SectionConnectivity::init::init() 
+{ 
+  registerSectionCtor(CONNECTIVITY, "CONNECTIVITY", "connectivity", false, false, boost::factory<SectionConnectivity*>()); 
 }
 
 void

--- a/src/runtime_src/tools/xclbinutil/SectionConnectivity.h
+++ b/src/runtime_src/tools/xclbinutil/SectionConnectivity.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 - 2019 Xilinx, Inc
+ * Copyright (C) 2018 - 2019, 2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -18,43 +18,24 @@
 #define __SectionConnectivity_h_
 
 // ----------------------- I N C L U D E S -----------------------------------
-
-// #includes here - please keep these to a bare minimum!
 #include "Section.h"
-#include <boost/functional/factory.hpp>
-
-// ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
-// Forward declarations - use these instead whenever possible...
 
 // ------ C L A S S :   S e c t i o n C o n n e c t i v i t y ----------------
-
 class SectionConnectivity : public Section {
  public:
-  SectionConnectivity();
-  virtual ~SectionConnectivity();
-
-public:
-  virtual bool doesSupportAddFormatType(FormatType _eFormatType) const;
-  virtual bool doesSupportDumpFormatType(FormatType _eFormatType) const;
-
-
- private:
-  // Purposefully private and undefined ctors...
-  SectionConnectivity(const SectionConnectivity& obj);
-  SectionConnectivity& operator=(const SectionConnectivity& obj);
+  bool doesSupportAddFormatType(FormatType _eFormatType) const override;
+  bool doesSupportDumpFormatType(FormatType _eFormatType) const override;
 
  protected:
-  virtual void marshalToJSON(char* _DataSection, unsigned int _sectionSize, boost::property_tree::ptree& _ptree) const;
-  virtual void marshalFromJSON(const boost::property_tree::ptree& _ptSection, std::ostringstream& _buf) const;
-
- protected:
+  void marshalToJSON(char* _DataSection, unsigned int _sectionSize, boost::property_tree::ptree& _ptree) const override;
+  void marshalFromJSON(const boost::property_tree::ptree& _ptSection, std::ostringstream& _buf) const override;
 
  private:
   // Static initializer helper class
-  static class _init {
+  static class init {
    public:
-    _init() { registerSectionCtor(CONNECTIVITY, "CONNECTIVITY", "connectivity", false, false, boost::factory<SectionConnectivity*>()); }
-  } _initializer;
+    init();
+  } initializer;
 };
 
 #endif

--- a/src/runtime_src/tools/xclbinutil/SectionDNACertificate.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionDNACertificate.cxx
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Xilinx, Inc
+ * Copyright (C) 2018, 2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -15,20 +15,19 @@
  */
 
 #include "SectionDNACertificate.h"
-#include <string>
 
 #include "XclBinUtilities.h"
+#include <boost/functional/factory.hpp>
+#include <string>
+
 namespace XUtil = XclBinUtilities;
 
 // Static Variables / Classes
-SectionDNACertificate::_init SectionDNACertificate::_initializer;
+SectionDNACertificate::init SectionDNACertificate::initializer;
 
-SectionDNACertificate::SectionDNACertificate() {
-  // Empty
-}
-
-SectionDNACertificate::~SectionDNACertificate() {
-  // Empty
+SectionDNACertificate::init::init() 
+{ 
+  registerSectionCtor(DNA_CERTIFICATE, "DNA_CERTIFICATE", "", false, false, boost::factory<SectionDNACertificate*>()); 
 }
 
 #define signatureSizeBytes 512

--- a/src/runtime_src/tools/xclbinutil/SectionDNACertificate.h
+++ b/src/runtime_src/tools/xclbinutil/SectionDNACertificate.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 - 2019 Xilinx, Inc
+ * Copyright (C) 2018 - 2019, 2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -18,38 +18,22 @@
 #define __SectionDNACertificate_h_
 
 // ----------------------- I N C L U D E S -----------------------------------
-
-// #includes here - please keep these to a bare minimum!
 #include "Section.h"
-#include <boost/functional/factory.hpp>
-
-// ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
-// Forward declarations - use these instead whenever possible...
 
 // ----- C L A S S :   S e c t i o n D N A C e r t i f i c a t e -------------
-
 class SectionDNACertificate : public Section {
  public:
-  SectionDNACertificate();
-  virtual ~SectionDNACertificate();
-
- public:
-  virtual bool doesSupportDumpFormatType(FormatType _eFormatType) const;
+  bool doesSupportDumpFormatType(FormatType _eFormatType) const override;
 
  protected:
-  virtual void marshalToJSON(char* _pDataSection, unsigned int _sectionSize, boost::property_tree::ptree& _ptree) const;
-
- private:
-  // Purposefully private and undefined ctors...
-  SectionDNACertificate(const SectionDNACertificate& obj);
-  SectionDNACertificate& operator=(const SectionDNACertificate& obj);
+  void marshalToJSON(char* _pDataSection, unsigned int _sectionSize, boost::property_tree::ptree& _ptree) const override;
 
  private:
   // Static initializer helper class
-  static class _init {
+  static class init {
    public:
-    _init() { registerSectionCtor(DNA_CERTIFICATE, "DNA_CERTIFICATE", "", false, false, boost::factory<SectionDNACertificate*>()); }
-  } _initializer;
+    init();
+  } initializer;
 };
 
 #endif

--- a/src/runtime_src/tools/xclbinutil/SectionDebugData.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionDebugData.cxx
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Xilinx, Inc
+ * Copyright (C) 2018, 2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -16,19 +16,14 @@
 
 #include "SectionDebugData.h"
 
-#include "XclBinUtilities.h"
-namespace XUtil = XclBinUtilities;
+#include <boost/functional/factory.hpp>
 
 // Static Variables / Classes
-SectionDebugData::_init SectionDebugData::_initializer;
+SectionDebugData::init SectionDebugData::initializer;
 
-SectionDebugData::SectionDebugData() {
-  // Empty
+SectionDebugData::init::init() 
+{ 
+  registerSectionCtor(DEBUG_DATA, "DEBUG_DATA", "", false, false, boost::factory<SectionDebugData*>());
 }
-
-SectionDebugData::~SectionDebugData() {
-  // Empty
-}
-
 
 

--- a/src/runtime_src/tools/xclbinutil/SectionDebugData.h
+++ b/src/runtime_src/tools/xclbinutil/SectionDebugData.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 - 2019 Xilinx, Inc
+ * Copyright (C) 2018 - 2019, 2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -18,32 +18,16 @@
 #define __SectionDebugData_h_
 
 // ----------------------- I N C L U D E S -----------------------------------
-
-// #includes here - please keep these to a bare minimum!
 #include "Section.h"
-#include <boost/functional/factory.hpp>
-
-// ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
-// Forward declarations - use these instead whenever possible...
 
 // -------- C L A S S :   S e c t i o n D e b u g D a t a --------------------
-
 class SectionDebugData : public Section {
- public:
-  SectionDebugData();
-  virtual ~SectionDebugData();
-
- private:
-  // Purposefully private and undefined ctors...
-  SectionDebugData(const SectionDebugData& obj);
-  SectionDebugData& operator=(const SectionDebugData& obj);
-
  private:
   // Static initializer helper class
-  static class _init {
+  static class init {
    public:
-    _init() { registerSectionCtor(DEBUG_DATA, "DEBUG_DATA", "", false, false, boost::factory<SectionDebugData*>()); }
-  } _initializer;
+    init();
+  } initializer;
 };
 
 #endif

--- a/src/runtime_src/tools/xclbinutil/SectionDebugIPLayout.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionDebugIPLayout.cxx
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018, 2021 Xilinx, Inc
+ * Copyright (C) 2018, 2021 - 2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -17,19 +17,17 @@
 #include "SectionDebugIPLayout.h"
 
 #include "XclBinUtilities.h"
-namespace XUtil = XclBinUtilities;
-
+#include <boost/functional/factory.hpp>
 #include <iostream>
 
+namespace XUtil = XclBinUtilities;
+
 // Static Variables / Classes
-SectionDebugIPLayout::_init SectionDebugIPLayout::_initializer;
+SectionDebugIPLayout::init SectionDebugIPLayout::initializer;
 
-SectionDebugIPLayout::SectionDebugIPLayout() {
-  // Empty
-}
-
-SectionDebugIPLayout::~SectionDebugIPLayout() {
-  // Empty
+SectionDebugIPLayout::init::init() 
+{ 
+  registerSectionCtor(DEBUG_IP_LAYOUT, "DEBUG_IP_LAYOUT", "debug_ip_layout", false, false, boost::factory<SectionDebugIPLayout*>()); 
 }
 
 const std::string

--- a/src/runtime_src/tools/xclbinutil/SectionDebugIPLayout.h
+++ b/src/runtime_src/tools/xclbinutil/SectionDebugIPLayout.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 - 2019 Xilinx, Inc
+ * Copyright (C) 2018 - 2019, 2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -18,44 +18,28 @@
 #define __SectionDebugIPLayout_h_
 
 // ----------------------- I N C L U D E S -----------------------------------
-
-// #includes here - please keep these to a bare minimum!
 #include "Section.h"
-#include <boost/functional/factory.hpp>
-
-// ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
-// Forward declarations - use these instead whenever possible...
 
 // ------ C L A S S :   S e c t i o n D e b u g I P L a y o u t --------------
-
 class SectionDebugIPLayout : public Section {
- private:
-  // Purposefully private and undefined ctors...
-  SectionDebugIPLayout(const SectionDebugIPLayout& obj);
-  SectionDebugIPLayout& operator=(const SectionDebugIPLayout& obj);
-
  public:
-  virtual bool doesSupportAddFormatType(FormatType _eFormatType) const;
-  virtual bool doesSupportDumpFormatType(FormatType _eFormatType) const;
+  bool doesSupportAddFormatType(FormatType _eFormatType) const override;
+  bool doesSupportDumpFormatType(FormatType _eFormatType) const override;
 
  protected:
-  virtual void marshalToJSON(char* _pDataSection, unsigned int _sectionSize, boost::property_tree::ptree& _ptree) const;
-  virtual void marshalFromJSON(const boost::property_tree::ptree& _ptSection, std::ostringstream& _buf) const;
+  void marshalToJSON(char* _pDataSection, unsigned int _sectionSize, boost::property_tree::ptree& _ptree) const override;
+  void marshalFromJSON(const boost::property_tree::ptree& _ptSection, std::ostringstream& _buf) const override;
 
  protected:
   const std::string getDebugIPTypeStr(enum DEBUG_IP_TYPE _debugIpType) const;
   enum DEBUG_IP_TYPE getDebugIPType(std::string& _sDebugIPType) const;
 
- public:
-  SectionDebugIPLayout();
-  virtual ~SectionDebugIPLayout();
-
  private:
   // Static initializer helper class
-  static class _init {
+  static class init {
    public:
-    _init() { registerSectionCtor(DEBUG_IP_LAYOUT, "DEBUG_IP_LAYOUT", "debug_ip_layout", false, false, boost::factory<SectionDebugIPLayout*>()); }
-  } _initializer;
+    init();
+  } initializer;
 };
 
 #endif

--- a/src/runtime_src/tools/xclbinutil/SectionDesignCheckPoint.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionDesignCheckPoint.cxx
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Xilinx, Inc
+ * Copyright (C) 2018, 2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -16,18 +16,14 @@
 
 #include "SectionDesignCheckPoint.h"
 
-#include "XclBinUtilities.h"
-namespace XUtil = XclBinUtilities;
+#include <boost/functional/factory.hpp>
 
 // Static Variables / Classes
-SectionDesignCheckPoint::_init SectionDesignCheckPoint::_initializer;
+SectionDesignCheckPoint::init SectionDesignCheckPoint::initializer;
 
-SectionDesignCheckPoint::SectionDesignCheckPoint() {
-  // Empty
-}
-
-SectionDesignCheckPoint::~SectionDesignCheckPoint() {
-  // Empty
+SectionDesignCheckPoint::init::init() 
+{ 
+  registerSectionCtor(DESIGN_CHECK_POINT, "DESIGN_CHECKPOINT", "", false, false, boost::factory<SectionDesignCheckPoint*>()); 
 }
 
 

--- a/src/runtime_src/tools/xclbinutil/SectionDesignCheckPoint.h
+++ b/src/runtime_src/tools/xclbinutil/SectionDesignCheckPoint.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 - 2019 Xilinx, Inc
+ * Copyright (C) 2018 - 2019, 2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -18,32 +18,16 @@
 #define __SectionDesignCheckPoint_h_
 
 // ----------------------- I N C L U D E S -----------------------------------
-
-// #includes here - please keep these to a bare minimum!
 #include "Section.h"
-#include <boost/functional/factory.hpp>
-
-// ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
-// Forward declarations - use these instead whenever possible...
 
 // ------ C L A S S :   S e c t i o n D e s i g n C h e c k P o i n t --------
-
 class SectionDesignCheckPoint : public Section {
- public:
-  SectionDesignCheckPoint();
-  virtual ~SectionDesignCheckPoint();
-
- private:
-  // Purposefully private and undefined ctors...
-  SectionDesignCheckPoint(const SectionDesignCheckPoint& obj);
-  SectionDesignCheckPoint& operator=(const SectionDesignCheckPoint& obj);
-
  private:
   // Static initializer helper class
-  static class _init {
+  static class init {
    public:
-    _init() { registerSectionCtor(DESIGN_CHECK_POINT, "DESIGN_CHECKPOINT", "", false, false, boost::factory<SectionDesignCheckPoint*>()); }
-  } _initializer;
+    init();
+  } initializer;
 };
 
 #endif

--- a/src/runtime_src/tools/xclbinutil/SectionEmbeddedMetadata.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionEmbeddedMetadata.cxx
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 - 2021 Xilinx, Inc
+ * Copyright (C) 2018 - 2021, 2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -17,19 +17,17 @@
 #include "SectionEmbeddedMetadata.h"
 
 #include "XclBinUtilities.h"
-namespace XUtil = XclBinUtilities;
-
+#include <boost/functional/factory.hpp>
 #include <boost/property_tree/xml_parser.hpp>
 
+namespace XUtil = XclBinUtilities;
+
 // Static Variables / Classes
-SectionEmbeddedMetadata::_init SectionEmbeddedMetadata::_initializer;
+SectionEmbeddedMetadata::init SectionEmbeddedMetadata::initializer;
 
-SectionEmbeddedMetadata::SectionEmbeddedMetadata() {
-  // Empty
-}
-
-SectionEmbeddedMetadata::~SectionEmbeddedMetadata() {
-  // Empty
+SectionEmbeddedMetadata::init::init() 
+{ 
+  registerSectionCtor(EMBEDDED_METADATA, "EMBEDDED_METADATA", "", false, false, boost::factory<SectionEmbeddedMetadata*>()); 
 }
 
 void

--- a/src/runtime_src/tools/xclbinutil/SectionEmbeddedMetadata.h
+++ b/src/runtime_src/tools/xclbinutil/SectionEmbeddedMetadata.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 - 2021 Xilinx, Inc
+ * Copyright (C) 2018 - 2021, 2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -18,36 +18,20 @@
 #define __SectionEmbeddedMetadata_h_
 
 // ----------------------- I N C L U D E S -----------------------------------
-
-// #includes here - please keep these to a bare minimum!
 #include "Section.h"
-#include <boost/functional/factory.hpp>
-
-// ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
-// Forward declarations - use these instead whenever possible...
 
 // ----- C L A S S :   S e c t i o n E m b e d d e d M e t a d a t a ---------
-
 class SectionEmbeddedMetadata : public Section {
- public:
-  SectionEmbeddedMetadata();
-  virtual ~SectionEmbeddedMetadata();
-
-  protected:
-     virtual void marshalToJSON(char* _DataSection, unsigned int _sectionSize, boost::property_tree::ptree& _ptree) const;
-     virtual void marshalFromJSON(const boost::property_tree::ptree& _ptSection, std::ostringstream& _buf) const;
-
-  private:
-  // Purposefully private and undefined ctors...
-  SectionEmbeddedMetadata(const SectionEmbeddedMetadata& obj);
-  SectionEmbeddedMetadata& operator=(const SectionEmbeddedMetadata& obj);
+ protected:
+  void marshalToJSON(char* _DataSection, unsigned int _sectionSize, boost::property_tree::ptree& _ptree) const override;
+  void marshalFromJSON(const boost::property_tree::ptree& _ptSection, std::ostringstream& _buf) const override;
 
  private:
   // Static initializer helper class
-  static class _init {
+  static class init {
    public:
-    _init() { registerSectionCtor(EMBEDDED_METADATA, "EMBEDDED_METADATA", "", false, false, boost::factory<SectionEmbeddedMetadata*>()); }
-  } _initializer;
+    init();
+  } initializer;
 };
 
 #endif

--- a/src/runtime_src/tools/xclbinutil/SectionEmulationData.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionEmulationData.cxx
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Xilinx, Inc
+ * Copyright (C) 2018, 2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -16,18 +16,14 @@
 
 #include "SectionEmulationData.h"
 
-#include "XclBinUtilities.h"
-namespace XUtil = XclBinUtilities;
+#include <boost/functional/factory.hpp>
 
 // Static Variables / Classes
-SectionEmulationData::_init SectionEmulationData::_initializer;
+SectionEmulationData::init SectionEmulationData::initializer;
 
-SectionEmulationData::SectionEmulationData() {
-  // Empty
-}
-
-SectionEmulationData::~SectionEmulationData() {
-  // Empty
+SectionEmulationData::init::init() 
+{ 
+  registerSectionCtor(EMULATION_DATA, "EMULATION_DATA", "", false, false, boost::factory<SectionEmulationData*>()); 
 }
 
 

--- a/src/runtime_src/tools/xclbinutil/SectionEmulationData.h
+++ b/src/runtime_src/tools/xclbinutil/SectionEmulationData.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019 Xilinx, Inc
+ * Copyright (C) 2019, 2022 - 2023 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -18,32 +18,16 @@
 #define __SectionEmulationData_h_
 
 // ----------------------- I N C L U D E S -----------------------------------
-
-// #includes here - please keep these to a bare minimum!
 #include "Section.h"
-#include <boost/functional/factory.hpp>
 
-// ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
-// Forward declarations - use these instead whenever possible...
-
-// --------------- C L A S S :   S e c t i o n P D I -------------------------
-
+// --------- C L A S S :   S e c t i o n E m u l a t i o n D a t a -----------
 class SectionEmulationData : public Section {
- public:
-  SectionEmulationData();
-  virtual ~SectionEmulationData();
-
- private:
-  // Purposefully private and undefined ctors...
-  SectionEmulationData(const SectionEmulationData& obj);
-  SectionEmulationData& operator=(const SectionEmulationData& obj);
-
  private:
   // Static initializer helper class
-  static class _init {
+  static class init {
    public:
-    _init() { registerSectionCtor(EMULATION_DATA, "EMULATION_DATA", "", false, false, boost::factory<SectionEmulationData*>()); }
-  } _initializer;
+    init();
+  } initializer;
 };
 
 #endif

--- a/src/runtime_src/tools/xclbinutil/SectionFlash.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionFlash.cxx
@@ -17,11 +17,12 @@
 #include "SectionFlash.h"
 
 #include "XclBinUtilities.h"
-namespace XUtil = XclBinUtilities;
-
 #include <boost/algorithm/string.hpp>
-#include <boost/property_tree/json_parser.hpp>
 #include <boost/format.hpp>
+#include <boost/functional/factory.hpp>
+#include <boost/property_tree/json_parser.hpp>
+
+namespace XUtil = XclBinUtilities;
 
 // Disable windows compiler warnings
 #ifdef _WIN32
@@ -29,18 +30,11 @@ namespace XUtil = XclBinUtilities;
 #endif
 
 // Static Variables / Classes
-SectionFlash::_init SectionFlash::_initializer;
+SectionFlash::init SectionFlash::initializer;
 
-// -------------------------------------------------------------------------
-
-SectionFlash::SectionFlash() {
-  // Empty
-}
-
-// -------------------------------------------------------------------------
-
-SectionFlash::~SectionFlash() {
-  // Empty
+SectionFlash::init::init() 
+{ 
+  registerSectionCtor(ASK_FLASH, "FLASH", "", true, true, boost::factory<SectionFlash*>()); 
 }
 
 // -------------------------------------------------------------------------

--- a/src/runtime_src/tools/xclbinutil/SectionFlash.h
+++ b/src/runtime_src/tools/xclbinutil/SectionFlash.h
@@ -18,22 +18,11 @@
 #define __SectionFlash_h_
 
 // ----------------------- I N C L U D E S -----------------------------------
-
-// #includes here - please keep these to a bare minimum!
 #include "Section.h"
-#include <boost/functional/factory.hpp>
 
-// ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
-// Forward declarations - use these instead whenever possible...
-
-// --------------- C L A S S :   S e c t i o n B M C -------------------------
-
+// ----------- C L A S S :   S e c t i o n F l a s h -------------------------
 class SectionFlash : public Section {
  public:
-  SectionFlash();
-  virtual ~SectionFlash();
-
-public:
   enum SubSection{
     SS_UNKNOWN,
     SS_DATA,
@@ -58,15 +47,11 @@ public:
    void writeMetadata(std::ostream& _oStream) const;
 
  private:
-  SectionFlash(const SectionFlash& obj) = delete;
-  SectionFlash& operator=(const SectionFlash& obj) = delete;
-
- private:
   // Static initializer helper class
-  static class _init {
+  static class init {
    public:
-    _init() { registerSectionCtor(ASK_FLASH, "FLASH", "", true, true, boost::factory<SectionFlash*>()); }
-  } _initializer;
+    init();
+  } initializer;
 };
 
 #endif

--- a/src/runtime_src/tools/xclbinutil/SectionGroupConnectivity.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionGroupConnectivity.cxx
@@ -17,11 +17,18 @@
 #include "SectionGroupConnectivity.h"
 
 #include "XclBinUtilities.h"
-namespace XUtil = XclBinUtilities;
+#include <boost/functional/factory.hpp>
 #include <iostream>
 
+namespace XUtil = XclBinUtilities;
+
 // Static Variables / Classes
-SectionGroupConnectivity::_init SectionGroupConnectivity::_initializer;
+SectionGroupConnectivity::init SectionGroupConnectivity::initializer;
+
+SectionGroupConnectivity::init::init() 
+{ 
+  registerSectionCtor(ASK_GROUP_CONNECTIVITY, "GROUP_CONNECTIVITY", "group_connectivity", false, false, boost::factory<SectionGroupConnectivity*>()); 
+}
 
 void
 SectionGroupConnectivity::marshalToJSON(char* _pDataSection,

--- a/src/runtime_src/tools/xclbinutil/SectionGroupConnectivity.h
+++ b/src/runtime_src/tools/xclbinutil/SectionGroupConnectivity.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Xilinx, Inc
+ * Copyright (C) 2020, 2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -18,43 +18,24 @@
 #define __SectionGroupConnectivity_h_
 
 // ----------------------- I N C L U D E S -----------------------------------
-
-// #includes here - please keep these to a bare minimum!
 #include "Section.h"
-#include <boost/functional/factory.hpp>
-
-// ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
-// Forward declarations - use these instead whenever possible...
 
 // --- C L A S S :   S e c t i o n G r o u p C o n n e c t i v i t y ---------
-
 class SectionGroupConnectivity : public Section {
  public:
-  SectionGroupConnectivity() {};
-  virtual ~SectionGroupConnectivity() {};
-
-public:
-  virtual bool doesSupportAddFormatType(FormatType _eFormatType) const;
-  virtual bool doesSupportDumpFormatType(FormatType _eFormatType) const;
-
-
- private:
-  // Purposefully private and undefined ctors...
-  SectionGroupConnectivity(const SectionGroupConnectivity& obj);
-  SectionGroupConnectivity& operator=(const SectionGroupConnectivity& obj);
+  bool doesSupportAddFormatType(FormatType _eFormatType) const override;
+  bool doesSupportDumpFormatType(FormatType _eFormatType) const override;
 
  protected:
-  virtual void marshalToJSON(char* _DataSection, unsigned int _sectionSize, boost::property_tree::ptree& _ptree) const;
-  virtual void marshalFromJSON(const boost::property_tree::ptree& _ptSection, std::ostringstream& _buf) const;
-
- protected:
+  void marshalToJSON(char* _DataSection, unsigned int _sectionSize, boost::property_tree::ptree& _ptree) const override;
+  void marshalFromJSON(const boost::property_tree::ptree& _ptSection, std::ostringstream& _buf) const override;
 
  private:
   // Static initializer helper class
-  static class _init {
+  static class init {
    public:
-    _init() { registerSectionCtor(ASK_GROUP_CONNECTIVITY, "GROUP_CONNECTIVITY", "group_connectivity", false, false, boost::factory<SectionGroupConnectivity*>()); }
-  } _initializer;
+    init();
+  } initializer; 
 };
 
 #endif

--- a/src/runtime_src/tools/xclbinutil/SectionGroupTopology.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionGroupTopology.cxx
@@ -17,12 +17,18 @@
 #include "SectionGroupTopology.h"
 
 #include "XclBinUtilities.h"
-namespace XUtil = XclBinUtilities;
+#include <boost/functional/factory.hpp>
 #include <iostream>
 
-// Static Variables / Classes
-SectionGroupTopology::_init SectionGroupTopology::_initializer;
+namespace XUtil = XclBinUtilities;
 
+// Static Variables / Classes
+SectionGroupTopology::init SectionGroupTopology::initializer;
+
+SectionGroupTopology::init::init() 
+{ 
+  registerSectionCtor(ASK_GROUP_TOPOLOGY, "GROUP_TOPOLOGY", "group_topology", false, false, boost::factory<SectionGroupTopology*>()); 
+}
 
 const std::string
 SectionGroupTopology::getMemTypeStr(enum MEM_TYPE _memType) const {

--- a/src/runtime_src/tools/xclbinutil/SectionGroupTopology.h
+++ b/src/runtime_src/tools/xclbinutil/SectionGroupTopology.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Xilinx, Inc
+ * Copyright (C) 2020, 2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -21,41 +21,27 @@
 
 // #includes here - please keep these to a bare minimum!
 #include "Section.h"
-#include <boost/functional/factory.hpp>
-
-// ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
-// Forward declarations - use these instead whenever possible...
 
 // ----- C L A S S :   S e c t i o n G r o u p T o p o l o g y ---------------
-
 class SectionGroupTopology : public Section {
  public:
-  SectionGroupTopology() {};
-  virtual ~SectionGroupTopology() {};
-
- public:
-  virtual bool doesSupportAddFormatType(FormatType _eFormatType) const;
-  virtual bool doesSupportDumpFormatType(FormatType _eFormatType) const;
+  bool doesSupportAddFormatType(FormatType _eFormatType) const override;
+  bool doesSupportDumpFormatType(FormatType _eFormatType) const override;
 
  protected:
-  virtual void marshalToJSON(char* _pDataSection, unsigned int _sectionSize, boost::property_tree::ptree& _ptree) const;
-  virtual void marshalFromJSON(const boost::property_tree::ptree& _ptSection, std::ostringstream& _buf) const;
+  void marshalToJSON(char* _pDataSection, unsigned int _sectionSize, boost::property_tree::ptree& _ptree) const override;
+  void marshalFromJSON(const boost::property_tree::ptree& _ptSection, std::ostringstream& _buf) const override;
 
  protected:
   const std::string getMemTypeStr(enum MEM_TYPE _memType) const;
   enum MEM_TYPE getMemType(std::string& _sMemType) const;
 
  private:
-  // Purposefully private and undefined ctors...
-  SectionGroupTopology(const SectionGroupTopology& obj);
-  SectionGroupTopology& operator=(const SectionGroupTopology& obj);
-
- private:
   // Static initializer helper class
-  static class _init {
+  static class init {
    public:
-    _init() { registerSectionCtor(ASK_GROUP_TOPOLOGY, "GROUP_TOPOLOGY", "group_topology", false, false, boost::factory<SectionGroupTopology*>()); }
-  } _initializer;
+    init();
+  } initializer; 
 };
 
 #endif

--- a/src/runtime_src/tools/xclbinutil/SectionHeader.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionHeader.cxx
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Xilinx, Inc
+ * Copyright (C) 2018, 2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -26,9 +26,6 @@ SectionHeader::SectionHeader()
   // Empty
 }
 
-SectionHeader::~SectionHeader() {
-  // Empty
-}
 
 void
 SectionHeader::readXclBinBinarySection(std::fstream& _istream, unsigned int _section) {

--- a/src/runtime_src/tools/xclbinutil/SectionHeader.h
+++ b/src/runtime_src/tools/xclbinutil/SectionHeader.h
@@ -33,7 +33,6 @@
 class SectionHeader {
  public:
   SectionHeader();
-  virtual ~SectionHeader();
 
  public:
   void readXclBinBinarySection(std::fstream& _istream, unsigned int _section);
@@ -41,11 +40,6 @@ class SectionHeader {
  private:
   enum axlf_section_kind m_eType;  /* Type of section */
   std::string m_name;              /* Name of section (not really used in the xclbin anymore */
-
- private:
-  // Purposefully private and undefined ctors...
-  SectionHeader(const SectionHeader& obj);
-  SectionHeader& operator=(const SectionHeader& obj);
 };
 
 

--- a/src/runtime_src/tools/xclbinutil/SectionIPLayout.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionIPLayout.cxx
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018, 2020 Xilinx, Inc
+ * Copyright (C) 2018, 2020, 2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -17,19 +17,17 @@
 #include "SectionIPLayout.h"
 
 #include "XclBinUtilities.h"
-namespace XUtil = XclBinUtilities;
-
+#include <boost/functional/factory.hpp>
 #include <iostream>
 
+namespace XUtil = XclBinUtilities;
+
 // Static Variables / Classes
-SectionIPLayout::_init SectionIPLayout::_initializer;
+SectionIPLayout::init SectionIPLayout::initializer;
 
-SectionIPLayout::SectionIPLayout() {
-  // Empty
-}
-
-SectionIPLayout::~SectionIPLayout() {
-  // Empty
+SectionIPLayout::init::init() 
+{ 
+  registerSectionCtor(IP_LAYOUT, "IP_LAYOUT", "ip_layout", false, false, boost::factory<SectionIPLayout*>()); 
 }
 
 

--- a/src/runtime_src/tools/xclbinutil/SectionIPLayout.h
+++ b/src/runtime_src/tools/xclbinutil/SectionIPLayout.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 -2019 Xilinx, Inc
+ * Copyright (C) 2018-2019, 2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -18,29 +18,18 @@
 #define __SectionIPLayout_h_
 
 // ----------------------- I N C L U D E S -----------------------------------
-
-// #includes here - please keep these to a bare minimum!
 #include "Section.h"
-#include <boost/functional/factory.hpp>
-
-// ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
-// Forward declarations - use these instead whenever possible...
 
 // --------- C L A S S :   S e c t i o n I P L a y o u t ---------------------
-
 class SectionIPLayout : public Section {
  public:
-  SectionIPLayout();
-  virtual ~SectionIPLayout();
-
-public:
-  virtual bool doesSupportAddFormatType(FormatType _eFormatType) const;
-  virtual bool doesSupportDumpFormatType(FormatType _eFormatType) const;
-  virtual void appendToSectionMetadata(const boost::property_tree::ptree& _ptAppendData, boost::property_tree::ptree& _ptToAppendTo);
+  bool doesSupportAddFormatType(FormatType _eFormatType) const override;
+  bool doesSupportDumpFormatType(FormatType _eFormatType) const override;
+  void appendToSectionMetadata(const boost::property_tree::ptree& _ptAppendData, boost::property_tree::ptree& _ptToAppendTo) override;
 
  protected:
-  virtual void marshalToJSON(char* _pDataSection, unsigned int _sectionSize, boost::property_tree::ptree& _ptree) const;
-  virtual void marshalFromJSON(const boost::property_tree::ptree& _ptSection, std::ostringstream& _buf) const;
+  void marshalToJSON(char* _pDataSection, unsigned int _sectionSize, boost::property_tree::ptree& _ptree) const override;
+  void marshalFromJSON(const boost::property_tree::ptree& _ptSection, std::ostringstream& _buf) const override;
 
  protected:
   const std::string getIPTypeStr(enum IP_TYPE _ipType) const;
@@ -49,16 +38,11 @@ public:
   enum IP_CONTROL getIPControlType(std::string& _sIPControlType) const;
 
  private:
-  // Purposefully private and undefined ctors...
-  SectionIPLayout(const SectionIPLayout& obj);
-  SectionIPLayout& operator=(const SectionIPLayout& obj);
-
- private:
   // Static initializer helper class
-  static class _init {
+  static class init {
    public:
-    _init() { registerSectionCtor(IP_LAYOUT, "IP_LAYOUT", "ip_layout", false, false, boost::factory<SectionIPLayout*>()); }
-  } _initializer;
+    init();
+  } initializer;
 };
 
 #endif

--- a/src/runtime_src/tools/xclbinutil/SectionKeyValueMetadata.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionKeyValueMetadata.cxx
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Xilinx, Inc
+ * Copyright (C) 2018, 2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -16,20 +16,18 @@
 
 #include "SectionKeyValueMetadata.h"
 
+#include "XclBinUtilities.h"
+#include <boost/functional/factory.hpp>
 #include <boost/property_tree/json_parser.hpp>
 
-#include "XclBinUtilities.h"
 namespace XUtil = XclBinUtilities;
 
 // Static Variables / Classes
-SectionKeyValueMetadata::_init SectionKeyValueMetadata::_initializer;
+SectionKeyValueMetadata::init SectionKeyValueMetadata::initializer;
 
-SectionKeyValueMetadata::SectionKeyValueMetadata() {
-  // Empty
-}
-
-SectionKeyValueMetadata::~SectionKeyValueMetadata() {
-  // Empty
+SectionKeyValueMetadata::init::init() 
+{ 
+  registerSectionCtor(KEYVALUE_METADATA, "KEYVALUE_METADATA", "keyvalue_metadata", false, false, boost::factory<SectionKeyValueMetadata*>()); 
 }
 
 void 

--- a/src/runtime_src/tools/xclbinutil/SectionKeyValueMetadata.h
+++ b/src/runtime_src/tools/xclbinutil/SectionKeyValueMetadata.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 - 2019 Xilinx, Inc
+ * Copyright (C) 2018 - 2019, 2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -18,40 +18,24 @@
 #define __SectionKeyValueMetadata_h_
 
 // ----------------------- I N C L U D E S -----------------------------------
-
-// #includes here - please keep these to a bare minimum!
 #include "Section.h"
-#include <boost/functional/factory.hpp>
-
-// ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
-// Forward declarations - use these instead whenever possible...
 
 // ----- C L A S S :   S e c t i o n K e y V a l u e M e t a d a t a ---------
-
 class SectionKeyValueMetadata : public Section {
  public:
-  SectionKeyValueMetadata();
-  virtual ~SectionKeyValueMetadata();
-
- public:
-  virtual bool doesSupportAddFormatType(FormatType _eFormatType) const;
-  virtual bool doesSupportDumpFormatType(FormatType _eFormatType) const;
+  bool doesSupportAddFormatType(FormatType _eFormatType) const override;
+  bool doesSupportDumpFormatType(FormatType _eFormatType) const override;
 
  protected:
-  virtual void marshalToJSON(char* _pDataSection, unsigned int _sectionSize, boost::property_tree::ptree& _ptree) const;
-  virtual void marshalFromJSON(const boost::property_tree::ptree& _ptSection, std::ostringstream& _buf) const;
-
- private:
-  // Purposefully private and undefined ctors...
-  SectionKeyValueMetadata(const SectionKeyValueMetadata& obj);
-  SectionKeyValueMetadata& operator=(const SectionKeyValueMetadata& obj);
+  void marshalToJSON(char* _pDataSection, unsigned int _sectionSize, boost::property_tree::ptree& _ptree) const override;
+  void marshalFromJSON(const boost::property_tree::ptree& _ptSection, std::ostringstream& _buf) const override;
 
  private:
   // Static initializer helper class
-  static class _init {
+  static class init {
    public:
-    _init() { registerSectionCtor(KEYVALUE_METADATA, "KEYVALUE_METADATA", "keyvalue_metadata", false, false, boost::factory<SectionKeyValueMetadata*>()); }
-  } _initializer;
+    init();
+  } initializer;
 };
 
 #endif

--- a/src/runtime_src/tools/xclbinutil/SectionMCS.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionMCS.cxx
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2021 Xilinx, Inc
+ * Copyright (C) 2018-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -18,6 +18,7 @@
 
 #include "XclBinUtilities.h"
 #include <boost/algorithm/string.hpp>
+#include <boost/functional/factory.hpp>
 
 // Disable windows compiler warnings
 #ifdef _WIN32
@@ -28,18 +29,11 @@
 namespace XUtil = XclBinUtilities;
 
 // Static Variables / Classes
-SectionMCS::_init SectionMCS::_initializer;
+SectionMCS::init SectionMCS::initializer;
 
-// --------------------------------------------------------------------------
-
-SectionMCS::SectionMCS() {
-  // Empty
-}
-
-// --------------------------------------------------------------------------
-
-SectionMCS::~SectionMCS() {
-  // Empty
+SectionMCS::init::init() 
+{ 
+  registerSectionCtor(MCS, "MCS", "", true, false, boost::factory<SectionMCS*>()); 
 }
 
 // --------------------------------------------------------------------------

--- a/src/runtime_src/tools/xclbinutil/SectionMCS.h
+++ b/src/runtime_src/tools/xclbinutil/SectionMCS.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2021 Xilinx, Inc
+ * Copyright (C) 2018-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -18,26 +18,19 @@
 #define __SectionMCS_h_
 
 // ----------------------- I N C L U D E S -----------------------------------
-
-// #includes here - please keep these to a bare minimum!
 #include "Section.h"
-#include <boost/functional/factory.hpp>
-
-// ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
-// Forward declarations - use these instead whenever possible...
 
 // --------------- C L A S S :   S e c t i o n M C S -------------------------
-
 class SectionMCS : public Section {
  public:
-  virtual bool supportsSubSection(const std::string &_sSubSectionName) const;
-  virtual bool subSectionExists(const std::string &_sSubSectionName) const;
+  bool supportsSubSection(const std::string &_sSubSectionName) const override;
+  bool subSectionExists(const std::string &_sSubSectionName) const override;
 
  protected:
-  virtual void getSubPayload(char* _pDataSection, unsigned int _sectionSize, std::ostringstream &_buf, const std::string &_sSubSectionName, enum Section::FormatType _eFormatType) const;
-  virtual void marshalToJSON(char* _buffer, unsigned int _pDataSegment, boost::property_tree::ptree& _ptree) const;
-  virtual void readSubPayload(const char* _pOrigDataSection, unsigned int _origSectionSize,  std::istream& _istream, const std::string & _sSubSection, enum Section::FormatType _eFormatType, std::ostringstream &_buffer) const;
-  virtual void writeSubPayload(const std::string & _sSubSectionName, FormatType _eFormatType, std::fstream&  _oStream) const;
+  void getSubPayload(char* _pDataSection, unsigned int _sectionSize, std::ostringstream &_buf, const std::string &_sSubSectionName, enum Section::FormatType _eFormatType) const override;
+  void marshalToJSON(char* _buffer, unsigned int _pDataSegment, boost::property_tree::ptree& _ptree) const override;
+  void readSubPayload(const char* _pOrigDataSection, unsigned int _origSectionSize,  std::istream& _istream, const std::string & _sSubSection, enum Section::FormatType _eFormatType, std::ostringstream &_buffer) const override;
+  void writeSubPayload(const std::string & _sSubSectionName, FormatType _eFormatType, std::fstream&  _oStream) const override;
 
  protected:
   enum MCS_TYPE getMCSTypeEnum(const std::string & _sSubSectionType) const;
@@ -47,21 +40,12 @@ class SectionMCS : public Section {
   void extractBuffers(const char* _pDataSection, unsigned int _sectionSize, std::vector<mcsBufferPair> &_mcsBuffers) const;
   void buildBuffer(const std::vector<mcsBufferPair> &_mcsBuffers, std::ostringstream &_buffer) const;
 
- public:
-  SectionMCS();
-  virtual ~SectionMCS();
-
- private:
-  // Purposefully private and undefined ctors...
-  SectionMCS(const SectionMCS& obj);
-  SectionMCS& operator=(const SectionMCS& obj);
-
  private:
   // Static initializer helper class
-  static class _init {
+  static class init {
    public:
-    _init() { registerSectionCtor(MCS, "MCS", "", true, false, boost::factory<SectionMCS*>()); }
-  } _initializer;
+    init();
+  } initializer; 
 };
 
 #endif

--- a/src/runtime_src/tools/xclbinutil/SectionManagementFW.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionManagementFW.cxx
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Xilinx, Inc
+ * Copyright (C) 2018, 2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -16,19 +16,14 @@
 
 #include "SectionManagementFW.h"
 
-#include "XclBinUtilities.h"
-namespace XUtil = XclBinUtilities;
+#include <boost/functional/factory.hpp>
 
 // Static Variables / Classes
-SectionManagementFW::_init SectionManagementFW::_initializer;
+SectionManagementFW::init SectionManagementFW::initializer;
 
-SectionManagementFW::SectionManagementFW() {
-  // Empty
+SectionManagementFW::init::init() 
+{ 
+  registerSectionCtor(FIRMWARE, "FIRMWARE", "", false, false, boost::factory<SectionManagementFW*>()); 
 }
-
-SectionManagementFW::~SectionManagementFW() {
-  // Empty
-}
-
 
 

--- a/src/runtime_src/tools/xclbinutil/SectionManagementFW.h
+++ b/src/runtime_src/tools/xclbinutil/SectionManagementFW.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 - 2019 Xilinx, Inc
+ * Copyright (C) 2018 - 2019, 2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -18,32 +18,16 @@
 #define __SectionManagementFW_h_
 
 // ----------------------- I N C L U D E S -----------------------------------
-
-// #includes here - please keep these to a bare minimum!
 #include "Section.h"
-#include <boost/functional/factory.hpp>
-
-// ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
-// Forward declarations - use these instead whenever possible...
 
 // ------- C L A S S :   S e c t i o n M a n a g e m e n t F W ---------------
-
 class SectionManagementFW : public Section {
- public:
-  SectionManagementFW();
-  virtual ~SectionManagementFW();
-
- private:
-  // Purposefully private and undefined ctors...
-  SectionManagementFW(const SectionManagementFW& obj);
-  SectionManagementFW& operator=(const SectionManagementFW& obj);
-
  private:
   // Static initializer helper class
-  static class _init {
+  static class init {
    public:
-    _init() { registerSectionCtor(FIRMWARE, "FIRMWARE", "", false, false, boost::factory<SectionManagementFW*>()); }
-  } _initializer;
+    init();
+  } initializer;
 };
 
 #endif

--- a/src/runtime_src/tools/xclbinutil/SectionMemTopology.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionMemTopology.cxx
@@ -17,21 +17,18 @@
 #include "SectionMemTopology.h"
 
 #include "XclBinUtilities.h"
-
-namespace XUtil = XclBinUtilities;
+#include <boost/functional/factory.hpp>
 #include <iostream>
 
+namespace XUtil = XclBinUtilities;
+
 // Static Variables / Classes
-SectionMemTopology::_init SectionMemTopology::_initializer;
+SectionMemTopology::init SectionMemTopology::initializer;
 
-SectionMemTopology::SectionMemTopology() {
-  // Empty
+SectionMemTopology::init::init() 
+{ 
+  registerSectionCtor(MEM_TOPOLOGY, "MEM_TOPOLOGY", "mem_topology", false, false, boost::factory<SectionMemTopology*>()); 
 }
-
-SectionMemTopology::~SectionMemTopology() {
-  // Empty
-}
-
 
 const std::string
 SectionMemTopology::getMemTypeStr(enum MEM_TYPE _memType) const {

--- a/src/runtime_src/tools/xclbinutil/SectionMemTopology.h
+++ b/src/runtime_src/tools/xclbinutil/SectionMemTopology.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 - 2019 Xilinx, Inc
+ * Copyright (C) 2018 - 2019, 2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -18,44 +18,28 @@
 #define __SectionMemTopology_h_
 
 // ----------------------- I N C L U D E S -----------------------------------
-
-// #includes here - please keep these to a bare minimum!
 #include "Section.h"
-#include <boost/functional/factory.hpp>
-
-// ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
-// Forward declarations - use these instead whenever possible...
 
 // ------- C L A S S :   S e c t i o n M e m T o p o l o g y -----------------
-
 class SectionMemTopology : public Section {
  public:
-  SectionMemTopology();
-  virtual ~SectionMemTopology();
-
- public:
-  virtual bool doesSupportAddFormatType(FormatType _eFormatType) const;
-  virtual bool doesSupportDumpFormatType(FormatType _eFormatType) const;
+  bool doesSupportAddFormatType(FormatType _eFormatType) const override;
+  bool doesSupportDumpFormatType(FormatType _eFormatType) const override;
 
  protected:
-  virtual void marshalToJSON(char* _pDataSection, unsigned int _sectionSize, boost::property_tree::ptree& _ptree) const;
-  virtual void marshalFromJSON(const boost::property_tree::ptree& _ptSection, std::ostringstream& _buf) const;
+  void marshalToJSON(char* _pDataSection, unsigned int _sectionSize, boost::property_tree::ptree& _ptree) const override;
+  void marshalFromJSON(const boost::property_tree::ptree& _ptSection, std::ostringstream& _buf) const override;
 
  protected:
   const std::string getMemTypeStr(enum MEM_TYPE _memType) const;
   enum MEM_TYPE getMemType(std::string& _sMemType) const;
 
  private:
-  // Purposefully private and undefined ctors...
-  SectionMemTopology(const SectionMemTopology& obj);
-  SectionMemTopology& operator=(const SectionMemTopology& obj);
-
- private:
   // Static initializer helper class
-  static class _init {
+  static class init {
    public:
-    _init() { registerSectionCtor(MEM_TOPOLOGY, "MEM_TOPOLOGY", "mem_topology", false, false, boost::factory<SectionMemTopology*>()); }
-  } _initializer;
+    init();
+  } initializer;
 };
 
 #endif

--- a/src/runtime_src/tools/xclbinutil/SectionOverlay.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionOverlay.cxx
@@ -16,19 +16,13 @@
 
 #include "SectionOverlay.h"
 
-#include "XclBinUtilities.h"
-namespace XUtil = XclBinUtilities;
+#include <boost/functional/factory.hpp>
 
 // Static Variables / Classes
-SectionOverlay::_init SectionOverlay::_initializer;
+SectionOverlay::init SectionOverlay::initializer;
 
-SectionOverlay::SectionOverlay() {
-  // Empty
+SectionOverlay::init::init() 
+{ 
+  registerSectionCtor(OVERLAY, "OVERLAY", "", false, false, boost::factory<SectionOverlay*>()); 
 }
-
-SectionOverlay::~SectionOverlay() {
-  // Empty
-}
-
-
 

--- a/src/runtime_src/tools/xclbinutil/SectionOverlay.h
+++ b/src/runtime_src/tools/xclbinutil/SectionOverlay.h
@@ -18,27 +18,16 @@
 #define __SectionOverlay_h_
 
 // ----------------------- I N C L U D E S -----------------------------------
-
-// #includes here - please keep these to a bare minimum!
 #include "Section.h"
-#include <boost/functional/factory.hpp>
 
-// ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
-// Forward declarations - use these instead whenever possible...
-
-// --------------- C L A S S :   S e c t i o n P D I -------------------------
-
+// --------------- C L A S S :   S e c t i o n O v e r l a y -----------------
 class SectionOverlay : public Section {
- public:
-  SectionOverlay();
-  virtual ~SectionOverlay();
-
  private:
   // Static initializer helper class
-  static class _init {
+  static class init {
    public:
-    _init() { registerSectionCtor(OVERLAY, "OVERLAY", "", false, false, boost::factory<SectionOverlay*>()); }
-  } _initializer;
+    init();
+  } initializer; 
 };
 
 #endif

--- a/src/runtime_src/tools/xclbinutil/SectionPDI.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionPDI.cxx
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Xilinx, Inc
+ * Copyright (C) 2018, 2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -16,19 +16,14 @@
 
 #include "SectionPDI.h"
 
-#include "XclBinUtilities.h"
-namespace XUtil = XclBinUtilities;
+#include <boost/functional/factory.hpp>
 
 // Static Variables / Classes
-SectionPDI::_init SectionPDI::_initializer;
+SectionPDI::init SectionPDI::initializer;
 
-SectionPDI::SectionPDI() {
-  // Empty
+SectionPDI::init::init() 
+{ 
+  registerSectionCtor(PDI, "PDI", "", false, false, boost::factory<SectionPDI*>()); 
 }
-
-SectionPDI::~SectionPDI() {
-  // Empty
-}
-
 
 

--- a/src/runtime_src/tools/xclbinutil/SectionPDI.h
+++ b/src/runtime_src/tools/xclbinutil/SectionPDI.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 -2019 Xilinx, Inc
+ * Copyright (C) 2018 -2019, 2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -18,32 +18,16 @@
 #define __SectionPDI_h_
 
 // ----------------------- I N C L U D E S -----------------------------------
-
-// #includes here - please keep these to a bare minimum!
 #include "Section.h"
-#include <boost/functional/factory.hpp>
-
-// ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
-// Forward declarations - use these instead whenever possible...
 
 // --------------- C L A S S :   S e c t i o n P D I -------------------------
-
 class SectionPDI : public Section {
- public:
-  SectionPDI();
-  virtual ~SectionPDI();
-
- private:
-  // Purposefully private and undefined ctors...
-  SectionPDI(const SectionPDI& obj);
-  SectionPDI& operator=(const SectionPDI& obj);
-
  private:
   // Static initializer helper class
-  static class _init {
+  static class init {
    public:
-    _init() { registerSectionCtor(PDI, "PDI", "", false, false, boost::factory<SectionPDI*>()); }
-  } _initializer;
+    init();
+  } initializer;
 };
 
 #endif

--- a/src/runtime_src/tools/xclbinutil/SectionPartitionMetadata.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionPartitionMetadata.cxx
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 - 2021 Xilinx, Inc
+ * Copyright (C) 2018 - 2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -15,12 +15,14 @@
  */
 
 #include "SectionPartitionMetadata.h"
+
 #include "DTC.h"
+#include "XclBinUtilities.h"
 #include <algorithm>
 #include <boost/algorithm/string/replace.hpp>
+#include <boost/functional/factory.hpp>
 #include <boost/property_tree/json_parser.hpp>
 
-#include "XclBinUtilities.h"
 namespace XUtil = XclBinUtilities;
 
 template <typename T>
@@ -34,8 +36,12 @@ std::vector<T> as_vector(boost::property_tree::ptree const& pt,
 }
 
 // Static Variables / Classes
-SectionPartitionMetadata::_init SectionPartitionMetadata::_initializer;
+SectionPartitionMetadata::init SectionPartitionMetadata::initializer;
 
+SectionPartitionMetadata::init::init() 
+{ 
+  registerSectionCtor(PARTITION_METADATA, "PARTITION_METADATA", "partition_metadata", false, false, boost::factory<SectionPartitionMetadata *>()); 
+}
 
 // Variable name to data size mapping table
 const FDTProperty::PropertyNameFormat SectionPartitionMetadata::m_propertyNameFormat = {
@@ -770,16 +776,6 @@ SchemaTransformToPM_root( const boost::property_tree::ptree & _ptOriginal,
   SchemaTransform_subNode( "partition_info", false /*required*/, 
                            SchemaTransformToPM_partition_info,
                            _ptOriginal, _ptTransformed);
-}
-
-
-
-SectionPartitionMetadata::SectionPartitionMetadata() {
-  // Empty
-}
-
-SectionPartitionMetadata::~SectionPartitionMetadata() {
-  // Empty
 }
 
 bool 

--- a/src/runtime_src/tools/xclbinutil/SectionPartitionMetadata.h
+++ b/src/runtime_src/tools/xclbinutil/SectionPartitionMetadata.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 - 2019 Xilinx, Inc
+ * Copyright (C) 2018 - 2019, 2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -18,46 +18,29 @@
 #define __SectionPartitionMetadata_h_
 
 // ----------------------- I N C L U D E S -----------------------------------
-
-// #includes here - please keep these to a bare minimum!
 #include "Section.h"
 #include "FDTProperty.h"
-#include <boost/functional/factory.hpp>
 
-// ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
-// Forward declarations - use these instead whenever possible...
-
-// ------------- C L A S S :   S e c t i o n D T C ---------------------------
-
+// --- C L A S S :   S e c t i o n P a r t i t i o n M e t a d a t a ---------
 class SectionPartitionMetadata : public Section {
  public:
-  SectionPartitionMetadata();
-  virtual ~SectionPartitionMetadata();
-
- public:
-  virtual bool doesSupportAddFormatType(FormatType _eFormatType) const;
-  virtual bool doesSupportDumpFormatType(FormatType _eFormatType) const;
-  virtual void appendToSectionMetadata(const boost::property_tree::ptree& _ptAppendData, boost::property_tree::ptree& _ptToAppendTo);
+  bool doesSupportAddFormatType(FormatType _eFormatType) const override;
+  bool doesSupportDumpFormatType(FormatType _eFormatType) const override;
+  void appendToSectionMetadata(const boost::property_tree::ptree& _ptAppendData, boost::property_tree::ptree& _ptToAppendTo) override;
 
  protected:
-  virtual void marshalToJSON(char* _pDataSection, unsigned int _sectionSize, boost::property_tree::ptree& _ptree) const;
-  virtual void marshalFromJSON(const boost::property_tree::ptree& _ptSection, std::ostringstream& _buf) const;
+  void marshalToJSON(char* _pDataSection, unsigned int _sectionSize, boost::property_tree::ptree& _ptree) const override;
+  void marshalFromJSON(const boost::property_tree::ptree& _ptSection, std::ostringstream& _buf) const override;
 
  protected:
    static const FDTProperty::PropertyNameFormat m_propertyNameFormat;
 
-
- private:
-  // Purposefully private and undefined ctors...
-  SectionPartitionMetadata(const SectionPartitionMetadata& obj);
-  SectionPartitionMetadata& operator=(const SectionPartitionMetadata& obj);
-
  private:
   // Static initializer helper class
-  static class _init {
+  static class init {
    public:
-      _init() { registerSectionCtor(PARTITION_METADATA, "PARTITION_METADATA", "partition_metadata", false, false, boost::factory<SectionPartitionMetadata *>()); }
-  } _initializer;
+    init();
+  } initializer;
 };
 
 #endif

--- a/src/runtime_src/tools/xclbinutil/SectionSchedulerFW.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionSchedulerFW.cxx
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Xilinx, Inc
+ * Copyright (C) 2018, 2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -16,19 +16,16 @@
 
 #include "SectionSchedulerFW.h"
 
-#include "XclBinUtilities.h"
-namespace XUtil = XclBinUtilities;
+#include <boost/functional/factory.hpp>
 
 // Static Variables / Classes
-SectionSchedulerFW::_init SectionSchedulerFW::_initializer;
+SectionSchedulerFW::init SectionSchedulerFW::initializer;
 
-SectionSchedulerFW::SectionSchedulerFW() {
-  // Empty
+SectionSchedulerFW::init::init() 
+{ 
+  registerSectionCtor(SCHED_FIRMWARE, "SCHED_FIRMWARE", "", false, false, boost::factory<SectionSchedulerFW*>()); 
 }
 
-SectionSchedulerFW::~SectionSchedulerFW() {
-  // Empty
-}
 
 
 

--- a/src/runtime_src/tools/xclbinutil/SectionSchedulerFW.h
+++ b/src/runtime_src/tools/xclbinutil/SectionSchedulerFW.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 - 2019 Xilinx, Inc
+ * Copyright (C) 2018 - 2019, 2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -18,32 +18,16 @@
 #define __SectionSchedulerFW_h_
 
 // ----------------------- I N C L U D E S -----------------------------------
-
-// #includes here - please keep these to a bare minimum!
 #include "Section.h"
-#include <boost/functional/factory.hpp>
-
-// ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
-// Forward declarations - use these instead whenever possible...
 
 // ------ C L A S S :   S e c t i o n S c h e d u l e r F W ------------------
-
 class SectionSchedulerFW : public Section {
- public:
-  SectionSchedulerFW();
-  virtual ~SectionSchedulerFW();
-
- private:
-  // Purposefully private and undefined ctors...
-  SectionSchedulerFW(const SectionSchedulerFW& obj);
-  SectionSchedulerFW& operator=(const SectionSchedulerFW& obj);
-
  private:
   // Static initializer helper class
-  static class _init {
+  static class init {
    public:
-    _init() { registerSectionCtor(SCHED_FIRMWARE, "SCHED_FIRMWARE", "", false, false, boost::factory<SectionSchedulerFW*>()); }
-  } _initializer;
+    init();
+  } initializer;
 };
 
 #endif

--- a/src/runtime_src/tools/xclbinutil/SectionSmartNic.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionSmartNic.cxx
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2021 Xilinx, Inc
+ * Copyright (C) 2021, 2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -20,26 +20,28 @@
 
 #include "SectionSmartNic.h"
 
-#include "XclBinUtilities.h"
 #include "CBOR.h"
 #include "RapidJsonUtilities.h"
 #include "ResourcesSmartNic.h"
-
-namespace XUtil = XclBinUtilities;
-
-#include <boost/property_tree/json_parser.hpp>
+#include "XclBinUtilities.h"
 #include <boost/algorithm/hex.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/format.hpp>
-
-// Need to convert between boost property trees and rapid json
+#include <boost/functional/factory.hpp>
+#include <boost/property_tree/json_parser.hpp>
+#include <fstream>
 #include <rapidjson/stringbuffer.h>
 #include <rapidjson/writer.h>
 
-#include <fstream>
+namespace XUtil = XclBinUtilities;
 
 // Static Variables / Classes
-SectionSmartNic::_init SectionSmartNic::_initializer;
+SectionSmartNic::init SectionSmartNic::initializer;
+
+SectionSmartNic::init::init() 
+{ 
+  registerSectionCtor(SMARTNIC, "SMARTNIC", "smartnic", false, false, boost::factory<SectionSmartNic*>()); 
+}
 
 
 bool

--- a/src/runtime_src/tools/xclbinutil/SectionSmartNic.h
+++ b/src/runtime_src/tools/xclbinutil/SectionSmartNic.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2021 Xilinx, Inc
+ * Copyright (C) 2021 - 2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -21,41 +21,25 @@
 #define __SectionSmartNic_h_
 
 // ----------------------- I N C L U D E S -----------------------------------
-
-// #includes here - please keep these to a bare minimum!
 #include "Section.h"
-#include <boost/functional/factory.hpp>
-
-// ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
-// Forward declarations - use these instead whenever possible...
 
 // ------------- C L A S S :   S e c t i o n S m a r t N i c -----------------
-
 class SectionSmartNic : public Section {
  public:
-  SectionSmartNic() = default;
-  virtual ~SectionSmartNic() = default;
-
- public:
-  virtual bool doesSupportAddFormatType(FormatType _eFormatType) const;
-  virtual bool doesSupportDumpFormatType(FormatType _eFormatType) const;
-  virtual void appendToSectionMetadata(const boost::property_tree::ptree& _ptAppendData, boost::property_tree::ptree& _ptToAppendTo);
+  bool doesSupportAddFormatType(FormatType _eFormatType) const override;
+  bool doesSupportDumpFormatType(FormatType _eFormatType) const override;
+  void appendToSectionMetadata(const boost::property_tree::ptree& _ptAppendData, boost::property_tree::ptree& _ptToAppendTo) override;
 
  protected:
-  virtual void marshalToJSON(char* _pDataSection, unsigned int _sectionSize, boost::property_tree::ptree& _ptree) const;
-  virtual void marshalFromJSON(const boost::property_tree::ptree& _ptSection, std::ostringstream& _buf) const;
-
- private:
-  // Purposefully private and undefined ctors...
-  SectionSmartNic(const SectionSmartNic& obj);
-  SectionSmartNic& operator=(const SectionSmartNic& obj);
+  void marshalToJSON(char* _pDataSection, unsigned int _sectionSize, boost::property_tree::ptree& _ptree) const override;
+  void marshalFromJSON(const boost::property_tree::ptree& _ptSection, std::ostringstream& _buf) const override;
 
  private:
   // Static initializer helper class
-  static class _init {
+  static class init {
    public:
-    _init() { registerSectionCtor(SMARTNIC, "SMARTNIC", "smartnic", false, false, boost::factory<SectionSmartNic*>()); }
-  } _initializer;
+    init();
+  } initializer; 
 };
 
 #endif

--- a/src/runtime_src/tools/xclbinutil/SectionSoftKernel.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionSoftKernel.cxx
@@ -17,11 +17,12 @@
 #include "SectionSoftKernel.h"
 
 #include "XclBinUtilities.h"
-namespace XUtil = XclBinUtilities;
-
 #include <boost/algorithm/string.hpp>
 #include <boost/format.hpp>
+#include <boost/functional/factory.hpp>
 #include <boost/property_tree/json_parser.hpp>
+
+namespace XUtil = XclBinUtilities;
 
 // Disable windows compiler warnings
 #ifdef _WIN32
@@ -29,18 +30,11 @@ namespace XUtil = XclBinUtilities;
 #endif
 
 // Static Variables / Classes
-SectionSoftKernel::_init SectionSoftKernel::_initializer;
+SectionSoftKernel::init SectionSoftKernel::initializer;
 
-// -------------------------------------------------------------------------
-
-SectionSoftKernel::SectionSoftKernel() {
-  // Empty
-}
-
-// -------------------------------------------------------------------------
-
-SectionSoftKernel::~SectionSoftKernel() {
-  // Empty
+SectionSoftKernel::init::init() 
+{ 
+  registerSectionCtor(SOFT_KERNEL, "SOFT_KERNEL", "", true, true, boost::factory<SectionSoftKernel*>()); 
 }
 
 // -------------------------------------------------------------------------

--- a/src/runtime_src/tools/xclbinutil/SectionSoftKernel.h
+++ b/src/runtime_src/tools/xclbinutil/SectionSoftKernel.h
@@ -18,22 +18,11 @@
 #define __SectionSoftKernel_h_
 
 // ----------------------- I N C L U D E S -----------------------------------
-
-// #includes here - please keep these to a bare minimum!
 #include "Section.h"
-#include <boost/functional/factory.hpp>
 
-// ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
-// Forward declarations - use these instead whenever possible...
-
-// --------------- C L A S S :   S e c t i o n B M C -------------------------
-
+// ---------- C L A S S :   S e c t i o n S o f t K e r n e l ----------------
 class SectionSoftKernel : public Section {
  public:
-  SectionSoftKernel();
-  virtual ~SectionSoftKernel();
-
-public:
   enum SubSection{
     SS_UNKNOWN,
     SS_OBJ,
@@ -45,7 +34,6 @@ public:
   bool supportsSubSection(const std::string &_sSubSectionName) const override;
   bool subSectionExists(const std::string &_sSubSectionName) const override;
   void readXclBinBinary(std::istream& _istream, const struct axlf_section_header& _sectionHeader) override;
-
 
  protected:
   void readSubPayload(const char* _pOrigDataSection, unsigned int _origSectionSize,  std::istream& _istream, const std::string & _sSubSection, enum Section::FormatType _eFormatType, std::ostringstream &_buffer) const override;
@@ -59,16 +47,11 @@ public:
    void writeMetadata(std::ostream& _oStream) const;
 
  private:
-  // Purposefully private and undefined ctors...
-  SectionSoftKernel(const SectionSoftKernel& obj);
-  SectionSoftKernel& operator=(const SectionSoftKernel& obj);
-
- private:
   // Static initializer helper class
-  static class _init {
+  static class init {
    public:
-    _init() { registerSectionCtor(SOFT_KERNEL, "SOFT_KERNEL", "", true, true, boost::factory<SectionSoftKernel*>()); }
-  } _initializer;
+    init();
+  } initializer;
 };
 
 #endif

--- a/src/runtime_src/tools/xclbinutil/SectionSystemMetadata.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionSystemMetadata.cxx
@@ -16,23 +16,20 @@
 
 #include "SectionSystemMetadata.h"
 
-#include <boost/property_tree/json_parser.hpp>
-#include <boost/format.hpp>
-
 #include "XclBinUtilities.h"
+#include <boost/format.hpp>
+#include <boost/functional/factory.hpp>
+#include <boost/property_tree/json_parser.hpp>
+
 namespace XUtil = XclBinUtilities;
 
 // Static Variables / Classes
-SectionSystemMetadata::_init SectionSystemMetadata::_initializer;
+SectionSystemMetadata::init SectionSystemMetadata::initializer;
 
-SectionSystemMetadata::SectionSystemMetadata() {
-  // Empty
+SectionSystemMetadata::init::init() 
+{ 
+    registerSectionCtor(SYSTEM_METADATA, "SYSTEM_METADATA", "", false, false, boost::factory<SectionSystemMetadata*>()); 
 }
-
-SectionSystemMetadata::~SectionSystemMetadata() {
-  // Empty
-}
-
 
 void
 SectionSystemMetadata::marshalToJSON(char* _pDataSection,

--- a/src/runtime_src/tools/xclbinutil/SectionSystemMetadata.h
+++ b/src/runtime_src/tools/xclbinutil/SectionSystemMetadata.h
@@ -18,36 +18,20 @@
 #define __SectionSystemMetadata_h_
 
 // ----------------------- I N C L U D E S -----------------------------------
-
-// #includes here - please keep these to a bare minimum!
 #include "Section.h"
-#include <boost/functional/factory.hpp>
-
-// ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
-// Forward declarations - use these instead whenever possible...
 
 // ------ C L A S S :   S e c t i o n C l e a r B i t s t r e a m ------------
-
 class SectionSystemMetadata : public Section {
- public:
-  SectionSystemMetadata();
-  virtual ~SectionSystemMetadata();
-
  protected:
-  virtual void marshalToJSON(char* _DataSection, unsigned int _sectionSize, boost::property_tree::ptree& _ptree) const;
-  virtual void marshalFromJSON(const boost::property_tree::ptree& _ptSection, std::ostringstream& _buf) const;
-
- private:
-  // Purposefully private and undefined ctors...
-  SectionSystemMetadata(const SectionSystemMetadata& obj);
-  SectionSystemMetadata& operator=(const SectionSystemMetadata& obj);
+  void marshalToJSON(char* _DataSection, unsigned int _sectionSize, boost::property_tree::ptree& _ptree) const override;
+  void marshalFromJSON(const boost::property_tree::ptree& _ptSection, std::ostringstream& _buf) const override;
 
  private:
   // Static initializer helper class
-  static class _init {
+  static class init {
    public:
-    _init() { registerSectionCtor(SYSTEM_METADATA, "SYSTEM_METADATA", "", false, false, boost::factory<SectionSystemMetadata*>()); }
-  } _initializer;
+    init();
+  } initializer;
 };
 
 #endif

--- a/src/runtime_src/tools/xclbinutil/SectionUserMetadata.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionUserMetadata.cxx
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Xilinx, Inc
+ * Copyright (C) 2018, 2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -16,19 +16,14 @@
 
 #include "SectionUserMetadata.h"
 
-#include "XclBinUtilities.h"
-namespace XUtil = XclBinUtilities;
+#include <boost/functional/factory.hpp>
 
 // Static Variables / Classes
-SectionUserMetadata::_init SectionUserMetadata::_initializer;
+SectionUserMetadata::init SectionUserMetadata::initializer;
 
-SectionUserMetadata::SectionUserMetadata() {
-  // Empty
+SectionUserMetadata::init::init() 
+{ 
+  registerSectionCtor(USER_METADATA, "USER_METADATA", "", false, false, boost::factory<SectionUserMetadata*>()); 
 }
-
-SectionUserMetadata::~SectionUserMetadata() {
-  // Empty
-}
-
 
 

--- a/src/runtime_src/tools/xclbinutil/SectionUserMetadata.h
+++ b/src/runtime_src/tools/xclbinutil/SectionUserMetadata.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 - 2019 Xilinx, Inc
+ * Copyright (C) 2018 - 2019, 2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -18,32 +18,16 @@
 #define __SectionUserMetadata_h_
 
 // ----------------------- I N C L U D E S -----------------------------------
-
-// #includes here - please keep these to a bare minimum!
 #include "Section.h"
-#include <boost/functional/factory.hpp>
-
-// ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
-// Forward declarations - use these instead whenever possible...
 
 // ------ C L A S S :   S e c t i o n U s e r M e t a d a t a ----------------
-
 class SectionUserMetadata : public Section {
- public:
-  SectionUserMetadata();
-  virtual ~SectionUserMetadata();
-
- private:
-  // Purposefully private and undefined ctors...
-  SectionUserMetadata(const SectionUserMetadata& obj);
-  SectionUserMetadata& operator=(const SectionUserMetadata& obj);
-
  private:
   // Static initializer helper class
-  static class _init {
+  static class init {
    public:
-    _init() { registerSectionCtor(USER_METADATA, "USER_METADATA", "", false, false, boost::factory<SectionUserMetadata*>()); }
-  } _initializer;
+    init();
+  } initializer;
 };
 
 #endif

--- a/src/runtime_src/tools/xclbinutil/SectionVenderMetadata.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionVenderMetadata.cxx
@@ -17,11 +17,12 @@
 #include "SectionVenderMetadata.h"
 
 #include "XclBinUtilities.h"
-namespace XUtil = XclBinUtilities;
-
 #include <boost/algorithm/string.hpp>
 #include <boost/format.hpp>
+#include <boost/functional/factory.hpp>
 #include <boost/property_tree/json_parser.hpp>
+
+namespace XUtil = XclBinUtilities;
 
 // Disable windows compiler warnings
 #ifdef _WIN32
@@ -29,20 +30,11 @@ namespace XUtil = XclBinUtilities;
 #endif
 
 // Static Variables / Classes
-SectionVenderMetadata::_init SectionVenderMetadata::_initializer;
+SectionVenderMetadata::init SectionVenderMetadata::initializer;
 
-// -------------------------------------------------------------------------
-
-SectionVenderMetadata::SectionVenderMetadata()
-{
-  // Empty
-}
-
-// -------------------------------------------------------------------------
-
-SectionVenderMetadata::~SectionVenderMetadata()
-{
-  // Empty
+SectionVenderMetadata::init::init() 
+{ 
+  registerSectionCtor(VENDER_METADATA, "VENDER_METADATA", "", true, true, boost::factory<SectionVenderMetadata*>()); 
 }
 
 // -------------------------------------------------------------------------

--- a/src/runtime_src/tools/xclbinutil/SectionVenderMetadata.h
+++ b/src/runtime_src/tools/xclbinutil/SectionVenderMetadata.h
@@ -17,17 +17,11 @@
 #ifndef __SectionVenderMetadata_h_
 #define __SectionVenderMetadata_h_
 
-// #includes here - please keep these to a bare minimum!
+// ----------------------- I N C L U D E S -----------------------------------
 #include "Section.h"
-#include <boost/functional/factory.hpp>
 
-
-
+// -------- C L A S S :   S e c t i o n V e n d e r M e t a d a t a ----------
 class SectionVenderMetadata : public Section {
- public:
-  SectionVenderMetadata();
-  virtual ~SectionVenderMetadata();
-
  public:
   bool doesSupportAddFormatType(FormatType _eFormatType) const override;
   bool supportsSubSection(const std::string& _sSubSectionName) const override;
@@ -45,15 +39,11 @@ class SectionVenderMetadata : public Section {
   void writeMetadata(std::ostream& _oStream) const;
 
  private:
-  SectionVenderMetadata(const SectionVenderMetadata& obj) = delete;
-  SectionVenderMetadata& operator=(const SectionVenderMetadata& obj) = delete;
-
- private:
   // Static initializer helper class
-  static class _init {
+  static class init {
    public:
-    _init() { registerSectionCtor(VENDER_METADATA, "VENDER_METADATA", "", true, true, boost::factory<SectionVenderMetadata*>()); }
-  } _initializer;
+    init();
+  } initializer; 
 };
 
 #endif

--- a/src/runtime_src/tools/xclbinutil/XclBinClass.h
+++ b/src/runtime_src/tools/xclbinutil/XclBinClass.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2021 Xilinx, Inc
+ * Copyright (C) 2018-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -37,7 +37,7 @@ class XclBin {
 
  public:
   XclBin();
-  virtual ~XclBin();
+  ~XclBin();
 
  public:
   void reportInfo(std::ostream &_ostream, const std::string & _sInputFile, bool _bVerbose) const;
@@ -107,12 +107,6 @@ class XclBin {
 
  protected:
   SchemaVersion m_SchemaVersionMirrorWrite;
-
-
- private:
-  // Purposefully private and undefined ctors...
-  XclBin(const XclBin& obj);
-  XclBin& operator=(const XclBin& obj);
 };
 
 

--- a/src/runtime_src/tools/xclbinutil/XclBinUtilities.h
+++ b/src/runtime_src/tools/xclbinutil/XclBinUtilities.h
@@ -112,7 +112,7 @@ public:
     }
 
     // Use are version of what() and not runtime_error's
-    virtual const char* what() const noexcept {
+    const char* what() const noexcept override{
       return m_msg.c_str();
     }
 


### PR DESCRIPTION
#### Problem solved by the commit
To better prepare refactoring the xclbinutil code to better support registering section classes, the existing code is being refactored to meet the XRT coding standards.  Part of this work is to upgrade the C++ classes to use the newer C++ version (e.g., 11 & 17).

This PR focued on the the headers where:

1. virtual child methods were refactore to use the `override `keyword.
2. The helper intializer init() body was moved from the header to the c++ source.
3. Unneeded constructors were removed (e.g., default, copy, etc.)
4. Unnessary included files were removed
5. Comments were added / removed

Note: No functionality was added or removed. 

#### Testing Performed
Unit tests and manual testing