### PR TITLE
Don't use __GNUC__ to imply Linux

### DIFF
--- a/src/runtime_src/core/common/config_reader.cpp
+++ b/src/runtime_src/core/common/config_reader.cpp
@@ -30,7 +30,7 @@
 #include <boost/filesystem/operations.hpp>
 #include <boost/format.hpp>
 
-#ifdef __GNUC__
+#ifdef __linux__
 # include <linux/limits.h>
 # include <sys/stat.h>
 #endif
@@ -215,7 +215,7 @@ get_string_value(const char* key, const std::string& default_value)
     if (!val.empty() && (val.front() == '"') && (val.back() == '"')) {
       val.erase(0, 1);
       val.erase(val.size()-1);
-    } 
+    }
   }
   catch( std::exception const&) {
     // eat the exception, probably bad path

--- a/src/runtime_src/core/common/memalign.h
+++ b/src/runtime_src/core/common/memalign.h
@@ -24,7 +24,7 @@ namespace xrt_core {
 inline int
 posix_memalign(void **memptr, size_t alignment, size_t size)
 {
-#if defined(__GNUC__)
+#if defined(__linux__)
   return ::posix_memalign(memptr,alignment,size);
 #elif defined(_WINDOWS)
   // this is not good, _aligned_malloc requires _aligned_free

--- a/src/runtime_src/core/common/message.cpp
+++ b/src/runtime_src/core/common/message.cpp
@@ -29,7 +29,7 @@
 #include <algorithm>
 #include <cstdarg>
 #include <climits>
-#ifdef __GNUC__
+#ifdef __linux__
 # include <syslog.h>
 # include <linux/limits.h>
 # include <sys/stat.h>
@@ -66,7 +66,7 @@ get_userid()
 static std::string
 get_exe_path()
 {
-#ifdef __GNUC__
+#ifdef __linux__
   char buf[PATH_MAX] = {0};
   auto len = ::readlink("/proc/self/exe", buf, PATH_MAX);
   return std::string(buf, (len>0) ? len : 0);
@@ -273,9 +273,9 @@ void
 sendv(severity_level l, const char* tag, const char* format, va_list args)
 {
   static auto verbosity = xrt_core::config::get_verbosity();
-  if (l > (xrt_core::message::severity_level)verbosity) 
+  if (l > (xrt_core::message::severity_level)verbosity)
     return;
-  
+
   va_list args_bak;
   // vsnprintf will mutate va_list so back it up
   va_copy(args_bak, args);
@@ -293,5 +293,5 @@ sendv(severity_level l, const char* tag, const char* format, va_list args)
   std::vsnprintf(buf.data(), len, format, args);
   send(l, tag, buf.data());
 }
-  
+
 }} // message,xrt

--- a/src/runtime_src/core/common/scheduler.cpp
+++ b/src/runtime_src/core/common/scheduler.cpp
@@ -29,7 +29,7 @@
 #include <cstring>
 #include <iostream>
 
-#ifdef __GNUC__
+#ifdef __linux__
 #include <sys/mman.h>
 #endif
 

--- a/src/runtime_src/core/common/thread.cpp
+++ b/src/runtime_src/core/common/thread.cpp
@@ -25,7 +25,7 @@
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/tokenizer.hpp>
 
-#ifdef __GNUC__
+#ifdef __linux__
 # include <pthread.h>
 # include <sched.h>
 #endif
@@ -34,7 +34,7 @@ namespace {
 
 namespace platform_specific {
 
-#ifdef __GNUC__
+#ifdef __linux__
 
 static void
 debug_thread_policy(const std::string& str, int policy, int priority)

--- a/src/runtime_src/core/include/ert.h
+++ b/src/runtime_src/core/include/ert.h
@@ -858,7 +858,7 @@ ert_valid_opcode(struct ert_packet *pkt)
     break;
   case ERT_CLK_CALIB:
   case ERT_MB_VALIDATE:
-  case ERT_ACCESS_TEST_C:  
+  case ERT_ACCESS_TEST_C:
   case ERT_CU_STAT: /* TODO: Rules to validate? */
   case ERT_EXIT:
   case ERT_ABORT:
@@ -872,7 +872,7 @@ ert_valid_opcode(struct ert_packet *pkt)
   return valid;
 }
 
-#ifdef __GNUC__
+#ifdef __linux__
 #define P2ROUNDUP(x, align)     (-(-(x) & -(align)))
 static inline struct cu_cmd_state_timestamps *
 ert_start_kernel_timestamps(struct ert_start_kernel_cmd *pkt)

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -1,7 +1,7 @@
 /**
  * Copyright (C) 2020,2021,2022 Xilinx, Inc
  * Copyright (C) 2022 Advanced Micro Devices, Inc.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
  * License is located at
@@ -36,7 +36,7 @@ namespace XBU = XBUtilities;
 #include "flash/flasher.h"
 #include "core/common/info_vmr.h"
 // Remove linux specific code
-#ifdef __GNUC__
+#ifdef __linux__
 #include "core/pcie/linux/scan.cpp"
 #endif
 
@@ -76,13 +76,13 @@ namespace {
 
 /**
  * @brief Update shell on the board for manual flash
- * 
+ *
  * @param[in] index The index of the board to be flashed
  * @param[in] image_paths The images to flash onto the board
- * @param[in] flash_type The format in which the board will be flashed. Leave 
+ * @param[in] flash_type The format in which the board will be flashed. Leave
  *                       blank to use the boards default flashing mode
  */
-static void 
+static void
 update_shell(unsigned int index, std::map<std::string, std::string>& image_paths, Flasher::E_FlasherType flash_type)
 {
   Flasher flasher(index);
@@ -107,14 +107,14 @@ update_shell(unsigned int index, std::map<std::string, std::string>& image_paths
     if (sec->fail())
       throw xrt_core::error(boost::str(boost::format("Failed to read %s") % image_paths["secondary"]));
   }
-  
+
   if (flasher.upgradeFirmware(flash_type, pri.get(), sec.get(), stripped.get()) != 0)
     throw xrt_core::error("Failed to update base");
-  
+
   std::cout << boost::format("%-8s : %s \n") % "INFO" % "Base flash image has been programmed successfully.";
 }
 
-static std::string 
+static std::string
 getBDF(unsigned int index)
 {
   auto dev = xrt_core::get_mgmtpf_device(index);
@@ -138,7 +138,7 @@ is_SC_fixed(unsigned int index)
 }
 
 // Update SC firmware on the board
-static void 
+static void
 update_SC(unsigned int  index, const std::string& file)
 {
   Flasher flasher(index);
@@ -154,11 +154,11 @@ update_SC(unsigned int  index, const std::string& file)
     xrt_core::device_update<xrt_core::query::program_sc>(dev.get(), val);
     return;
   }
-  catch (const xrt_core::query::exception&) { 
+  catch (const xrt_core::query::exception&) {
     // this flow is not supported on the device
     // continue with the other flow
   }
-  
+
   //if factory image, update SC
   auto is_mfg = xrt_core::device_query<xrt_core::query::is_mfg>(dev);
   if (is_mfg) {
@@ -172,13 +172,13 @@ update_SC(unsigned int  index, const std::string& file)
   }
 
   // If SC is fixed, stop flashing immediately
-  if (is_SC_fixed(index)) 
+  if (is_SC_fixed(index))
     throw xrt_core::error("SC is fixed, unable to flash image.");
 
 // To be replaced with a cleaner fix
 // Mgmt pf needs to shutdown so that the board doesn't brick
 // Hack: added linux specific code to shutdown mgmt pf
-#ifdef __GNUC__
+#ifdef __linux__
   auto mgmt_dev = pcidev::get_dev(index, false);
   auto peer_dev = mgmt_dev->lookup_peer_dev();
   if (pcidev::shutdown(mgmt_dev))
@@ -195,12 +195,12 @@ update_SC(unsigned int  index, const std::string& file)
 
 // To be replaced with a cleaner fix
 // Hack: added linux specific code to bring back mgmt pf
-#ifdef __GNUC__
+#ifdef __linux__
   std::string errmsg;
   peer_dev->sysfs_put("", "shutdown", errmsg, "0\n");
   if (!errmsg.empty())
     throw xrt_core::error("Userpf is not online. Please warm reboot.");
-  
+
   const static int dev_timeout = 60;
   int wait = 0;
   do {
@@ -213,15 +213,15 @@ update_SC(unsigned int  index, const std::string& file)
   } while (++wait < dev_timeout);
   if (wait == dev_timeout)
     throw xrt_core::error("User function is not back online. Please warm reboot.");
-#endif 
+#endif
 }
 
 // Helper function for header info
-static std::string 
-file_size(const std::string & _file) 
+static std::string
+file_size(const std::string & _file)
 {
   std::ifstream in(_file.c_str(), std::ifstream::ate | std::ifstream::binary);
-  auto total_size = std::to_string(in.tellg()); 
+  auto total_size = std::to_string(in.tellg());
   int strSize = static_cast<int>(total_size.size());
 
   //if file size is > 3 digits, insert commas after every 3 digits
@@ -230,12 +230,12 @@ file_size(const std::string & _file)
    for (int i = (strSize - COMMA_SPACING);  i > 0;  i -= COMMA_SPACING)
      total_size.insert(static_cast<size_t>(i), 1, ',');
   }
-  
+
   return total_size + std::string(" bytes");
 }
 
 // Helper function for header info
-static std::pair<std::string, std::string> 
+static std::pair<std::string, std::string>
 deployment_path_and_filename(std::string file)
 {
   using tokenizer = boost::tokenizer< boost::char_separator<char> >;
@@ -243,7 +243,7 @@ deployment_path_and_filename(std::string file)
   tokenizer tokens(file, sep);
   std::string dsafile = "";
   for (auto tok_iter = tokens.begin(); tok_iter != tokens.end(); ++tok_iter) {
-  	if ((std::string(*tok_iter).find(XSABIN_FILE_SUFFIX) != std::string::npos) 
+  	if ((std::string(*tok_iter).find(XSABIN_FILE_SUFFIX) != std::string::npos)
           || (std::string(*tok_iter).find(DSABIN_FILE_SUFFIX) != std::string::npos))
           dsafile = *tok_iter;
   }
@@ -254,8 +254,8 @@ deployment_path_and_filename(std::string file)
 }
 
 // Helper function for header info
-static std::string 
-get_file_timestamp(const std::string & _file) 
+static std::string
+get_file_timestamp(const std::string & _file)
 {
   boost::filesystem::path p(_file);
 	if (!boost::filesystem::exists(p)) {
@@ -305,7 +305,7 @@ pretty_print_platform_info(const boost::property_tree::ptree& _ptDevice, const s
 }
 
 static void
-report_status(const std::string& vbnv, boost::property_tree::ptree& pt_device) 
+report_status(const std::string& vbnv, boost::property_tree::ptree& pt_device)
 {
   std::cout << "----------------------------------------------------\n";
   pretty_print_platform_info(pt_device, vbnv);
@@ -318,7 +318,7 @@ report_status(const std::string& vbnv, boost::property_tree::ptree& pt_device)
 
   if (!pt_device.get<bool>("platform.status.sc") && !pt_device.get<bool>("platform.status.is_factory") && !pt_device.get<bool>("platform.status.is_recovery"))
     action_list << boost::format("  [%s] : Program Satellite Controller (SC) image\n") % pt_device.get<std::string>("platform.bdf");
-  
+
   if (!action_list.str().empty()) {
     std::cout << "Actions to perform:\n" << action_list.str();
     std::cout << "----------------------------------------------------\n";
@@ -346,7 +346,7 @@ are_scs_equal(const DSAInfo& candidate, const DSAInfo& current)
           (candidate.bmc_ver() == current.bmc_ver()));
 }
 
-static bool 
+static bool
 update_sc(unsigned int boardIdx, DSAInfo& candidate)
 {
   Flasher flasher(boardIdx);
@@ -354,7 +354,7 @@ update_sc(unsigned int boardIdx, DSAInfo& candidate)
   // Determine if the SC images are the same
   bool same_bmc = false;
   DSAInfo current = flasher.getOnBoardDSA();
-  if (!current.dsaname().empty()) 
+  if (!current.dsaname().empty())
     same_bmc = are_scs_equal(candidate, current);
 
   // -- Some DRCs (Design Rule Checks) --
@@ -363,13 +363,13 @@ update_sc(unsigned int boardIdx, DSAInfo& candidate)
      std::cout << "INFO: Satellite controller is not present.\n";
      return false;
   }
-  
-  // Can the SC be programmed  
+
+  // Can the SC be programmed
   if (is_SC_fixed(boardIdx)) {
     std::cout << "INFO: Fixed Satellite Controller.\n";
     return false;
   }
-   
+
   // Check to see if force is being used
   if ((same_bmc == true) && (XBU::getForce() == true)) {
     std::cout << "INFO: Forcing flashing of the Satellite Controller (SC) image (Force flag is set).\n";
@@ -395,7 +395,7 @@ update_sc(unsigned int boardIdx, DSAInfo& candidate)
 
 // Flash shell and sc firmware
 // Helper method for auto_flash
-static bool  
+static bool
 update_shell(unsigned int boardIdx, DSAInfo& candidate, Flasher::E_FlasherType flash_type)
 {
   Flasher flasher(boardIdx);
@@ -403,7 +403,7 @@ update_shell(unsigned int boardIdx, DSAInfo& candidate, Flasher::E_FlasherType f
   // Determine if the shells are the same
   bool same_dsa = false;
   DSAInfo current = flasher.getOnBoardDSA();
-  if (!current.dsaname().empty()) 
+  if (!current.dsaname().empty())
     same_dsa = are_shells_equal(candidate, current);
 
   // -- Some DRCs (Design Rule Checks) --
@@ -454,19 +454,19 @@ update_default_only(xrt_core::device* device, bool value)
         break;
       }
     }
-      
+
     uint32_t val = xrt_core::query::flush_default_only::value_type(value);
     xrt_core::device_update<xrt_core::query::flush_default_only>(device, val);
   }
-  catch (const xrt_core::query::exception&) { 
+  catch (const xrt_core::query::exception&) {
     // only available for versal devices
   }
 }
 
-// Update shell and sc firmware on the device automatically 
-// Refactor code to support only 1 device. 
-static void 
-auto_flash(std::shared_ptr<xrt_core::device> & working_device, Flasher::E_FlasherType flashType, const std::string& image = "") 
+// Update shell and sc firmware on the device automatically
+// Refactor code to support only 1 device.
+static void
+auto_flash(std::shared_ptr<xrt_core::device> & working_device, Flasher::E_FlasherType flashType, const std::string& image = "")
 {
   // Get platform information
   boost::property_tree::ptree pt;
@@ -503,9 +503,9 @@ auto_flash(std::shared_ptr<xrt_core::device> & working_device, Flasher::E_Flashe
   boost::property_tree::ptree& pt_dev = pt.get_child(std::to_string(working_device->get_device_id()));
   bool same_shell = (dsa.name == pt_dev.get<std::string>("platform.current_shell.vbnv", ""))
                       && (dsa.matchId(pt_dev.get<std::string>("platform.current_shell.id", "")));
-  
+
   auto sc = pt_dev.get<std::string>("platform.current_shell.sc_version", "");
-  bool same_sc = ((sc.empty()) || (dsa.bmcVer.empty()) || 
+  bool same_sc = ((sc.empty()) || (dsa.bmcVer.empty()) ||
                   (dsa.bmcVer == sc) || (sc.find("FIXED") != std::string::npos));
 
   // Always update Arista devices
@@ -524,7 +524,7 @@ auto_flash(std::shared_ptr<xrt_core::device> & working_device, Flasher::E_Flashe
 
     boardsToUpdate.push_back(std::make_pair(working_device->get_device_id(), dsa));
   }
-  
+
   // Is there anything to flash
   if (boardsToUpdate.empty() == true) {
     std::cout << "\nDevice is up-to-date.  No flashing to performed.\n";
@@ -580,7 +580,7 @@ auto_flash(std::shared_ptr<xrt_core::device> & working_device, Flasher::E_Flashe
 
 
   if (error_stream.str().empty()) {
-    std::cout << "\nDevice flashed successfully.\n"; 
+    std::cout << "\nDevice flashed successfully.\n";
   } else {
     std::cout << "\nDevice flashing encountered errors:\n";
     std::cerr << error_stream.str();
@@ -616,7 +616,7 @@ program_plp(const xrt_core::device* dev, const std::string& partition)
 
   try {
     xrt_core::program_plp(dev, buffer, XBU::getForce());
-  } 
+  }
   catch (xrt_core::error& e) {
     std::cout << "ERROR: " << e.what() << std::endl;
     throw xrt_core::error(std::errc::operation_canceled);
@@ -630,7 +630,7 @@ find_flash_image_paths(const std::vector<std::string>& image_list)
 {
   std::vector<std::string> path_list;
   auto installedShells = firmwareImage::getIntalledDSAs();
-  
+
   for(const auto& img : image_list) {
     // Check if the passed in image is absolute path
     if (boost::filesystem::is_regular_file(img)){
@@ -680,7 +680,7 @@ switch_partition(xrt_core::device* device, int boot)
     device->reset(hot_reset);
     std::cout << "Rebooted successfully" << std::endl;
   }
-  catch (const xrt_core::query::exception& ex) { 
+  catch (const xrt_core::query::exception& ex) {
     std::cout << "ERROR: " << ex.what() << std::endl;
     throw xrt_core::error(std::errc::operation_canceled);
     // only available for versal devices
@@ -693,7 +693,7 @@ switch_partition(xrt_core::device* device, int boot)
 // ----- C L A S S   M E T H O D S -------------------------------------------
 
 SubCmdProgram::SubCmdProgram(bool _isHidden, bool _isDepricated, bool _isPreliminary)
-    : SubCmd("program", 
+    : SubCmd("program",
              "Update image(s) for a given device")
 {
   const std::string longDescription = "Updates the image(s) for a given device.";
@@ -730,7 +730,7 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
   bool revertToGolden = false;
   bool help = false;
 
-  po::options_description commonOptions("Common Options");  
+  po::options_description commonOptions("Common Options");
   commonOptions.add_options()
     ("device,d", boost::program_options::value<decltype(device)>(&device)->multitoken(), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest.")
     ("shell,s", boost::program_options::value<decltype(plp)>(&plp), "The partition to be loaded.  Valid values:\n"
@@ -749,19 +749,19 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
     ("help", boost::program_options::bool_switch(&help), "Help to use this sub-command")
   ;
 
-  po::options_description hiddenOptions("Hidden Options");  
+  po::options_description hiddenOptions("Hidden Options");
   hiddenOptions.add_options()
     ("flash-type", boost::program_options::value<decltype(flashType)>(&flashType),
       "Overrides the flash mode. Use with caution.  Valid values:\n"
       "  ospi\n"
       "  ospi_versal")
-    ("boot", boost::program_options::value<decltype(boot)>(&boot)->implicit_value("default"), 
+    ("boot", boost::program_options::value<decltype(boot)>(&boot)->implicit_value("default"),
     "RPU and/or APU will be booted to either partition A or partition B.  Valid values:\n"
     "  DEFAULT - Reboot RPU to partition A\n"
     "  BACKUP  - Reboot RPU to partition B\n")
   ;
 
-  po::options_description allOptions("All Options");  
+  po::options_description allOptions("All Options");
 
   allOptions.add(commonOptions);
   allOptions.add(hiddenOptions);
@@ -807,7 +807,7 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
   std::set<std::string> deviceNames;
 
   xrt_core::device_collection deviceCollection;
-  for (const auto & deviceName : device) 
+  for (const auto & deviceName : device)
     deviceNames.insert(boost::algorithm::to_lower_copy(deviceName));
 
   XBU::collect_devices(deviceNames, false /*inUserDomain*/, deviceCollection);
@@ -840,9 +840,9 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
 
   // Populate flash type. Uses board's default when passing an empty input string.
   if (!flashType.empty()) {
-      xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", 
+      xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT",
         "Overriding flash mode is not recommended.\nYou may damage your device with this option.");
-  } 
+  }
   Flasher working_flasher(working_device->get_device_id());
   auto flash_type = working_flasher.getFlashType(flashType);
 
@@ -915,7 +915,7 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
 
     return;
   }
-  
+
   // -- process "revert-to-golden" option ---------------------------------------
   if (revertToGolden) {
     XBU::verbose("Sub command: --revert-to-golden");
@@ -929,17 +929,17 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
         xrt_core::error(boost::str(boost::format("%d is an invalid index") % dev->get_device_id()));
         continue;
       }
-      std::cout << boost::format("%-8s : %s %s %s \n") % "INFO" % "Resetting device [" 
+      std::cout << boost::format("%-8s : %s %s %s \n") % "INFO" % "Resetting device ["
         % flasher.sGetDBDF() % "] back to factory mode.";
       flasher_list.push_back(flasher);
     }
-    
+
     XBUtilities::sudo_or_throw("Root privileges are required to revert the device to its golden flash image");
 
     //ask user's permission
     if (!XBU::can_proceed(XBU::getForce()))
       throw xrt_core::error(std::errc::operation_canceled);
-    
+
     for (auto& f : flasher_list) {
       if (!f.upgradeFirmware(flash_type, nullptr, nullptr, nullptr)) {
         std::cout << boost::format("%-8s : %s %s %s\n") % "INFO" % "Shell on [" % f.sGetDBDF() % "]"
@@ -983,7 +983,7 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
     //TO_DO: add a report for plp before asking permission to proceed. Replace following 2 lines
     std::cout << "Programming shell on device [" << flasher.sGetDBDF() << "]..." << std::endl;
     std::cout << "Partition file: " << dsa.file << std::endl;
-    
+
     for (const auto& uuid : dsa.uuids) {
 
       //check if plp is compatible with the installed blp
@@ -1017,7 +1017,7 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
 
     std::vector<char> xclbin_buffer(size);
     stream.read(xclbin_buffer.data(), size);
-    
+
     auto bdf = xrt_core::query::pcie_bdf::to_string(xrt_core::device_query<xrt_core::query::pcie_bdf>(dev));
     std::cout << "Downloading xclbin on device [" << bdf << "]..." << std::endl;
     try {
@@ -1037,8 +1037,8 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
     else if (boost::iequals(boot, "BACKUP"))
       switch_partition(working_device.get(), 1);
     else {
-      std::cout << "ERROR: Invalid value.\n" 
-                << "Usage: xbmgmt program --device='0000:00:00.0' --boot [default|backup]" 
+      std::cout << "ERROR: Invalid value.\n"
+                << "Usage: xbmgmt program --device='0000:00:00.0' --boot [default|backup]"
                 << std::endl;
       throw xrt_core::error(std::errc::operation_canceled);
     }

--- a/src/runtime_src/core/tools/xbmgmt2/flash/firmware_image.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/firmware_image.cpp
@@ -308,7 +308,7 @@ DSAInfo::DSAInfo(const std::string& filename, uint64_t ts, const std::string& id
         }
         // For 2RP platform, only UUIDs are provided
         //timestamp = ap->m_header.m_featureRomTimeStamp;
-        hasFlashImage = (xclbin::get_axlf_section(ap, MCS) != nullptr) || (xclbin::get_axlf_section(ap, PDI) != nullptr) || 
+        hasFlashImage = (xclbin::get_axlf_section(ap, MCS) != nullptr) || (xclbin::get_axlf_section(ap, PDI) != nullptr) ||
                             (xclbin::get_axlf_section(ap, ASK_FLASH) != nullptr);
 
         // Find out BMC version
@@ -361,7 +361,7 @@ normalize_uuid(std::string id)
     return uuid;
 }
 
-bool DSAInfo::matchId(const std::string &id) const 
+bool DSAInfo::matchId(const std::string &id) const
 {
     uint64_t ts = strtoull(id.c_str(), nullptr, 0);
     if (ts != 0 && ts != ULLONG_MAX && ts == timestamp)
@@ -384,12 +384,12 @@ bool DSAInfo::matchIntId(std::string &id) const
 
     if (uuids.size() > 1) {
         for(unsigned int j = 1; j < uuids.size(); j++) {
-            
+
             //Check 1: check if passed in id matches UUID
             if (!strncmp(uuids[j].c_str(), uuid.c_str(), uuid.length()))
                 return true;
-            
-            //Check 2: check if passed in ID macthes the timestamp 
+
+            //Check 2: check if passed in ID macthes the timestamp
             uint64_t int_ts = 0;
             uuid2ts(uuids[j], int_ts);
 	        if (int_ts == ts)
@@ -412,7 +412,7 @@ bool DSAInfo::matchId(const DSAInfo& dsa) const
     return false;
 }
 
-bool DSAInfo::bmcVerIsFixed() const 
+bool DSAInfo::bmcVerIsFixed() const
 {
 	return (bmcVer.find("FIXED") != std::string::npos);
 }
@@ -429,7 +429,7 @@ std::vector<DSAInfo> firmwareImage::getIntalledDSAs()
       catch (const std::exception&) {
         // directory cannot be checked, maybe relative and
         // insufficient CWD permissions
-        continue; 
+        continue;
       }
 
       boost::filesystem::recursive_directory_iterator end_iter;
@@ -441,7 +441,7 @@ std::vector<DSAInfo> firmwareImage::getIntalledDSAs()
         }
       }
     }
-    
+
     return installedDSA;
 }
 
@@ -460,7 +460,7 @@ std::ostream& operator<<(std::ostream& stream, const DSAInfo& dsa)
     return stream;
 }
 
-static void 
+static void
 remove_xsabin_mirror(void * xsabin_buffer)
 {
   static const std::string mirror_data_start = "XCLBIN_MIRROR_DATA_START";
@@ -490,14 +490,14 @@ remove_xsabin_mirror(void * xsabin_buffer)
 
   // Compress the image
   uint64_t bytesToCopy = bufferSize - end_offset;
-  if (bytesToCopy != 0) 
+  if (bytesToCopy != 0)
     std::memcpy(reinterpret_cast<unsigned char *>(xsabin_buffer) + start_offset, reinterpret_cast<unsigned char *>(xsabin_buffer) + end_offset, bytesToCopy);
 
   // Update length of the buffer
   axlf_header->m_header.m_length = bufferSize - bytesRemoved;
 }
 
-static void 
+static void
 remove_xsabin_section(void * xsabin_buffer, enum axlf_section_kind section_to_remove)
 {
   // Simple DRC check
@@ -505,7 +505,7 @@ remove_xsabin_section(void * xsabin_buffer, enum axlf_section_kind section_to_re
     throw std::runtime_error("ERROR: Buffer pointer is a nullptr.");
   axlf *axlf_header = reinterpret_cast<struct axlf *>(xsabin_buffer);
 
-  // This loop does need to re-evaluate the m_numSections for it will be 
+  // This loop does need to re-evaluate the m_numSections for it will be
   // reduced as sections are removed.  In addition, we need to start again from
   // the start for there could be multiple sections of the same type that
   // need to be removed.
@@ -526,7 +526,7 @@ remove_xsabin_section(void * xsabin_buffer, enum axlf_section_kind section_to_re
     uint64_t bytesRemoved = startFromOffset - startToOffset;
 
     if (bytesToCopy != 0) {
-      std::memcpy(reinterpret_cast<unsigned char *>(xsabin_buffer) + startToOffset, 
+      std::memcpy(reinterpret_cast<unsigned char *>(xsabin_buffer) + startToOffset,
                     reinterpret_cast<unsigned char *>(xsabin_buffer) + startFromOffset, bytesToCopy);
     }
     // -- Now do some incremental clean up of the data structures
@@ -546,7 +546,7 @@ remove_xsabin_section(void * xsabin_buffer, enum axlf_section_kind section_to_re
     // Remove the array entry
     void * ptrStartTo = &sectionHeaderArray[index];
     void * ptrStartFrom = &sectionHeaderArray[index+1];
-    uint64_t bytesToShift = axlf_header->m_header.m_length - 
+    uint64_t bytesToShift = axlf_header->m_header.m_length -
                             (reinterpret_cast<unsigned char *>(ptrStartFrom) - reinterpret_cast<unsigned char *>(xsabin_buffer));
     std::memcpy(reinterpret_cast<unsigned char *>(ptrStartTo), reinterpret_cast<unsigned char *>(ptrStartFrom), bytesToShift);
 
@@ -699,7 +699,7 @@ firmwareImage::firmwareImage(const std::string& file, imageType type) :
                 }
 
                 /*
-                 * By default, we load entire xsabin. 
+                 * By default, we load entire xsabin.
 		 * For legacy ospiversal type, the Flasher class will trim to PDI.
 		 * For new ospi_xgq type, the Flasher will take entire xsabin.
                  */
@@ -749,7 +749,7 @@ firmwareImage::firmwareImage(const std::string& file, imageType type) :
                 in_file.read(mBuf, bufsize);
             }
         }
-            
+
     }
     else
     {
@@ -766,7 +766,7 @@ firmwareImage::firmwareImage(const std::string& file, imageType type) :
     }
 
 // rdbuf doesn't work on windows and str() doesn't work for ospi_versal on linux
-#ifdef __GNUC__
+#ifdef __linux__
     this->rdbuf()->pubsetbuf(mBuf, bufsize);
 #endif
 #ifdef _WIN32

--- a/src/runtime_src/core/tools/xbmgmt2/flash/xgq_vmr.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/xgq_vmr.cpp
@@ -40,7 +40,7 @@ int XGQ_VMR_Flasher::xclUpgradeFirmware(std::istream& binStream)
     binStream.read(buffer.data(), total_size);
     ssize_t ret = total_size;
 
-#ifdef __GNUC__
+#ifdef __linux__
     auto fd = m_device->file_open("xgq_vmr", O_RDWR);
     ret = write(fd.get(), buffer.data(), total_size);
 #endif

--- a/src/runtime_src/core/tools/xbmgmt2/flash/xospiversal.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/xospiversal.cpp
@@ -47,7 +47,7 @@ int XOSPIVER_Flasher::xclUpgradeFirmware(std::istream& binStream)
 
     std::cout << "INFO: ***PDI has " << size << " bytes" << std::endl;
 
-#ifdef __GNUC__
+#ifdef __linux__
     auto data = reinterpret_cast<const char*>(reinterpret_cast<const char*>(top) +
         hdr->m_sectionOffset);
     auto fd = m_device->file_open("xfer_versal", O_RDWR);

--- a/src/runtime_src/core/tools/xbmgmt2/flash/xspi.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/xspi.cpp
@@ -322,7 +322,7 @@ XSPI_Flasher::XSPI_Flasher(std::shared_ptr<xrt_core::device> dev)
         flash_base = FLASH_BASE;
 
     mFlashDev = nullptr;
-#ifdef __GNUC__
+#ifdef __linux__
     if (std::getenv("FLASH_VIA_USER") == NULL) {
         int fd = mDev->open("flash", O_RDWR);
         if (fd >= 0)
@@ -1853,7 +1853,7 @@ static int writeToFlash(std::FILE *flashDev, int secondary,
     return ret;
 }
 
-static int 
+static int
 readFromFlash(std::FILE *flashDev, int secondary,
   const unsigned int address, unsigned char *buf, size_t len)
 {
@@ -2215,7 +2215,7 @@ int XSPI_Flasher::upgradeFirmware1Drv(std::istream& mcsStream, std::istream& str
     ret = installBitstreamGuard(mDev.get(), mFlashDev, bsGuardAddr);
     if (ret)
         return ret;
-    
+
     // Persist non-bitstream part of firmware, should happen before we
     // start writing bitstream, so that we don't corrupt bitstream.
     if (stripped) {
@@ -2257,7 +2257,7 @@ int XSPI_Flasher::upgradeFirmware2Drv(std::istream& mcsStream0,
     ret = installBitstreamGuard(mDev.get(), mFlashDev, bsGuardAddr);
     if (ret)
         return ret;
-    
+
     // Persist non-bitstream part of firmware, should happen before we
     // start writing bitstream, so that we don't corrupt bitstream.
     if (stripped) {
@@ -2295,7 +2295,7 @@ struct flash_data_header {
     struct flash_data_ident fdh_id_end;
 };
 
-static inline uint32_t 
+static inline uint32_t
 flash_xrt_data_get_parity32(const unsigned char *buf, size_t n)
 {
 	uint32_t parity = 0;
@@ -2392,14 +2392,14 @@ xclReadData(std::vector<unsigned char>& data)
         std::cout << boost::format("ERROR: Failed to read header from flash: %d\n") %ret;
         return ret;
     }
-    
+
     // Sanity check header
     flash_data_ident ident = header.fdh_id_end;
     const size_t magiclen = sizeof(ident.fdi_magic);
     if (std::memcmp(ident.fdi_magic, magic.c_str(), magiclen)) {
         char tmp[sizeof(ident.fdi_magic) + 1] = { 0 };
         std::memcpy(tmp, ident.fdi_magic, magiclen);
-        std::cout << boost::format("ERROR: corrupted meta data detected on flash, bad header magic: %s. Expected header magic: %s\n") 
+        std::cout << boost::format("ERROR: corrupted meta data detected on flash, bad header magic: %s. Expected header magic: %s\n")
                     % tmp % magic;
         return -EINVAL;
     } else if (ident.fdi_version != 0) {

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -46,7 +46,7 @@ namespace po = boost::program_options;
 #include <sstream>
 #include <thread>
 #include <regex>
-#ifdef __GNUC__
+#ifdef __linux__
 #include <sys/mman.h> //munmap
 #endif
 
@@ -244,7 +244,7 @@ runTestCase( const std::shared_ptr<xrt_core::device>& _dev, const std::string& p
   }
   else if(!logic_uuid.empty()) {
     xclbinPath = searchSSV2Xclbin(logic_uuid.front(), xclbin, _ptTest);
-  } 
+  }
   else {
     auto vendor = xrt_core::device_query<xrt_core::query::pcie_vendor>(_dev);
     xclbinPath = searchLegacyXclbin(vendor, name, xclbin, _ptTest);
@@ -402,7 +402,7 @@ runTestCase( const std::shared_ptr<xrt_core::device>& _dev, const std::string& p
 static void
 free_unmap_bo(xclDeviceHandle handle, xclBufferHandle boh, void * boptr, size_t bo_size)
 {
-#ifdef __GNUC__
+#ifdef __linux__
   if(boptr != nullptr)
     munmap(boptr, bo_size);
 #endif
@@ -465,14 +465,14 @@ p2ptest_chunk(xclDeviceHandle handle, char *boptr, uint64_t dev_addr, uint64_t s
   return true;
 }
 
-//Since no DMA platforms don't have a DMA engine, we copy p2p buffer 
+//Since no DMA platforms don't have a DMA engine, we copy p2p buffer
 //to host only buffer and run the test through m2m
 
 static bool
 p2ptest_chunk_no_dma(xclDeviceHandle handle, xclBufferHandle bop2p, size_t bo_size, int bank)
 {
    // testing p2p write flow host -> device
-	
+
   xclBufferHandle boh = xclAllocBO(handle, bo_size, 0, XCL_BO_FLAGS_HOST_ONLY|bank);
   if (boh == NULLBO) {
     return false;
@@ -544,7 +544,7 @@ p2ptest_bank(xclDeviceHandle handle, boost::property_tree::ptree& _ptTest, std::
              unsigned int mem_idx, uint64_t addr, uint64_t bo_size, uint32_t no_dma)
 {
   const size_t chunk_size = 16 * 1024 * 1024; //16 MB
-  const size_t mem_size = 256 * 1024 * 1024 ; //256 MB 
+  const size_t mem_size = 256 * 1024 * 1024 ; //256 MB
 
   xclBufferHandle boh = xclAllocBO(handle, bo_size, 0, XCL_BO_FLAGS_P2P | mem_idx);
   if (boh == NULLBO) {
@@ -576,7 +576,7 @@ p2ptest_bank(xclDeviceHandle handle, boost::property_tree::ptree& _ptTest, std::
         return false;
       }
     }
-  } 
+  }
   free_unmap_bo(handle, boh, boptr, bo_size);
   _ptTest.put("status", test_token_passed);
   return true;
@@ -859,7 +859,7 @@ auxConnectionTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property
     max_power = xrt_core::device_query<xrt_core::query::max_power_level>(_dev);
   }
   catch (const xrt_core::query::exception&) { }
-  
+
   //check if device has aux power connector
   bool auxDevice = false;
   for (auto bd : auxPwrRequiredDevice) {
@@ -982,7 +982,7 @@ dmaTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree::ptr
       }
       catch(const std::invalid_argument&) {
         std::cerr << boost::format(
-          "ERROR: The parameter '%s' value '%s' is invalid for the test '%s'. Please specify and integer byte block-size.'\n") 
+          "ERROR: The parameter '%s' value '%s' is invalid for the test '%s'. Please specify and integer byte block-size.'\n")
           % "block-size" % str_block_size % "dma" ;
         throw xrt_core::error(std::errc::operation_canceled);
       }
@@ -997,7 +997,7 @@ dmaTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree::ptr
 
     size_t totalSize = 0;
     if (xrt_core::device_query<xrt_core::query::pcie_vendor>(_dev) == ARISTA_ID)
-      totalSize = 0x20000000; // 512 MB 
+      totalSize = 0x20000000; // 512 MB
     else
       totalSize = std::min((mem.m_size * 1024), XBU::string_to_base_units("2G", XBUtilities::unit::bytes)); // minimum of mem size in bytes and 2 GB
 
@@ -1104,8 +1104,8 @@ p2pTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree::ptr
     }
   }
   run_test.finish(true, "");
- 
-  if (XBU::is_escape_codes_disabled() == true) 
+
+  if (XBU::is_escape_codes_disabled() == true)
     std::cout << EscapeCodes::cursor().prev_line() << EscapeCodes::cursor().clear_line();
 }
 
@@ -1444,7 +1444,7 @@ get_platform_info(const std::shared_ptr<xrt_core::device>& device,
   const boost::property_tree::ptree empty_ptree;
   auto report = std::make_shared<ReportPlatforms>();
   report->getPropertyTreeInternal(device.get(), platform_report);
-  
+
   const boost::property_tree::ptree& platforms = platform_report.get_child("platforms", empty_ptree);
   if(platforms.size() > 1)
     throw xrt_core::error(std::errc::operation_canceled);
@@ -1535,7 +1535,7 @@ run_tests_on_devices( xrt_core::device_collection &deviceCollection,
 
   // -- Run the various tests and collect the test data
   boost::property_tree::ptree ptDeviceTested;
-  for(auto const& dev : deviceCollection) 
+  for(auto const& dev : deviceCollection)
     has_failures |= (run_test_suite_device(dev, schemaVersion, testObjectsToRun, ptDeviceTested) == test_status::failed);
 
   ptDevCollectionTestSuite.put_child("logical_devices", ptDeviceTested);
@@ -1744,7 +1744,7 @@ SubCmdValidate::execute(const SubCmdOptions& _options) const
       doesTestExist(param[0], testNameDescription);
 
       //check parameter name
-      auto iter = std::find_if( extendedKeysCollection.begin(), extendedKeysCollection.end(), 
+      auto iter = std::find_if( extendedKeysCollection.begin(), extendedKeysCollection.end(),
           [&param](const ExtendedKeysStruct& collection){ return collection.param_name == param[1];} );
       if (iter == extendedKeysCollection.end())
         throw xrt_core::error((boost::format("Unsupported parameter name '%s' for validation test '%s'") % param[1] % param[2]).str());
@@ -1847,6 +1847,6 @@ SubCmdValidate::execute(const SubCmdOptions& _options) const
     std::cout << boost::format("Successfully wrote the %s file: %s") % sFormat % sOutput << std::endl;
   }
 
-  if (has_failures == true) 
+  if (has_failures == true)
     throw xrt_core::error(std::errc::operation_canceled);
 }


### PR DESCRIPTION
#### Problem solved by the commit
Use __linux__ in place of __GNUC__ where Linux is the differentiator.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Addresses issue #6574.  There are still instance of __GNUC__ left, but primarily for GCC specific attributes.
