### PR TITLE
CR-1120194:application does not throw segfault if xsim is not running

### DIFF
--- a/src/runtime_src/core/include/xcl_api_macros.h
+++ b/src/runtime_src/core/include/xcl_api_macros.h
@@ -26,7 +26,8 @@ mtx.lock(); \
 mtx.unlock();
 
 #define RPC_PROLOGUE(func_name) \
-    unix_socket* _s_inst = sock; \
+    /*unix_socket* _s_inst = sock; */ \
+    auto _s_inst = sock;  \
     func_name##_call c_msg; \
     func_name##_response r_msg; \
     AQUIRE_MUTEX()

--- a/src/runtime_src/core/include/xcl_api_macros.h
+++ b/src/runtime_src/core/include/xcl_api_macros.h
@@ -26,7 +26,6 @@ mtx.lock(); \
 mtx.unlock();
 
 #define RPC_PROLOGUE(func_name) \
-    /*unix_socket* _s_inst = sock; */ \
     auto _s_inst = sock;  \
     func_name##_call c_msg; \
     func_name##_response r_msg; \

--- a/src/runtime_src/core/pcie/emulation/common_em/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/emulation/common_em/CMakeLists.txt
@@ -48,7 +48,6 @@ target_link_libraries(common_em
   xrt_coreutil
   dl
   pthread
-  stdc++fs
   crypt
   rt
   )

--- a/src/runtime_src/core/pcie/emulation/common_em/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/emulation/common_em/CMakeLists.txt
@@ -48,6 +48,7 @@ target_link_libraries(common_em
   xrt_coreutil
   dl
   pthread
+  stdc++fs
   crypt
   rt
   )

--- a/src/runtime_src/core/pcie/emulation/common_em/config.h
+++ b/src/runtime_src/core/pcie/emulation/common_em/config.h
@@ -31,7 +31,7 @@
 #include <vector>
 
 namespace xclemulation{
-
+  
   // KB
   const uint64_t MEMSIZE_1K   =   0x0000000000000400;
   const uint64_t MEMSIZE_4K   =   0x0000000000001000;
@@ -78,7 +78,7 @@ namespace xclemulation{
   const uint64_t MEMSIZE_128T =   0x0000800000000000;
   const uint64_t MEMSIZE_256T =   0x0001000000000000;
   const uint64_t MEMSIZE_512T =   0x0002000000000000;
-  
+
   //For Profiling Offsets
   const uint64_t FIFO_INFO_MESSAGES     = 0x0000000000100000;
   const uint64_t FIFO_WARNING_MESSAGES  = 0x0000000000200000;
@@ -86,7 +86,7 @@ namespace xclemulation{
   const uint64_t FIFO_CTRL_INFO_SIZE    = 0x64;
   const uint64_t FIFO_CTRL_WARNING_SIZE = 0x68;
   const uint64_t FIFO_CTRL_ERROR_SIZE   = 0x6C;
- 
+
   const int VIVADO_MIN_VERSION = 2000;
   const int VIVADO_MAX_VERSION = 2100;
 
@@ -103,7 +103,7 @@ struct sParseLog
   std::atomic_bool mFileExists;
   std::vector<std::string> mMatchedStrings;
   eEmulationType mEmuType;
-
+  
   sParseLog(const std::string& iDeviceLog, eEmulationType iType, const std::vector<std::string>& iMatchedStrings)
       : mFileName(iDeviceLog)
       , mFileExists{false}
@@ -112,7 +112,10 @@ struct sParseLog
   {
 
   }
-
+  /* The function displays user actionable message by calling print_user_msg(),
+  *  if any user list of strings found in mFileName otherwise the content of 
+  *  mFileName will be displayed.
+  */
   void check_simulator_status()
   {
     std::string line;
@@ -126,7 +129,7 @@ struct sParseLog
             print_user_msg();
           else if (eEmulationType::eHw_Emu == mEmuType)
           {
-            if (!StringData.compare("Exiting xsim") || !StringData.compare("FATAL_ERROR"))
+            if (StringData == "Exiting xsim" || StringData == "FATAL_ERROR")
               print_user_msg();
             else
               std::cout << line << '\n';
@@ -156,6 +159,7 @@ struct sParseLog
    * */
   void parseLog()
   {
+    // mFileName might be created/updated by xsim, check its existence always.
     if (not mFileExists.load())
     {
       if (boost::filesystem::exists(mFileName))
@@ -165,11 +169,10 @@ struct sParseLog
           mFileExists.store(true);
       }
     }
-
+    // Now, check for user list of strings, display actionable message incase matched.
     if (mFileExists.load())
-    {
       check_simulator_status();
-    }
+    
   }
 };
 

--- a/src/runtime_src/core/pcie/emulation/common_em/config.h
+++ b/src/runtime_src/core/pcie/emulation/common_em/config.h
@@ -10,7 +10,6 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <atomic>
-//#include <filesystem>
 
 #ifdef _MSC_VER
 #include <boost/config/compiler/visualc.hpp>

--- a/src/runtime_src/core/pcie/emulation/common_em/config.h
+++ b/src/runtime_src/core/pcie/emulation/common_em/config.h
@@ -10,7 +10,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <atomic>
-#include <filesystem>
+//#include <filesystem>
 
 #ifdef _MSC_VER
 #include <boost/config/compiler/visualc.hpp>
@@ -90,6 +90,14 @@ namespace xclemulation{
  
   const int VIVADO_MIN_VERSION = 2000;
   const int VIVADO_MAX_VERSION = 2100;
+
+inline bool file_exists(const std::string& fnm)
+{
+  struct stat statBuf;
+  return stat(fnm.c_str(), &statBuf) == 0;
+}
+
+
 //sparse log utility
 enum class eEmulationType{
   eSw_Emu,
@@ -123,11 +131,11 @@ struct sParseLog
         if (line.find(StringData) != std::string::npos)
         {
           if (eEmulationType::eSw_Emu == mEmuType)
-            print();
+            printMsg();
           else if (eEmulationType::eHw_Emu == mEmuType)
           {
             if (!StringData.compare("Exiting xsim") || !StringData.compare("FATAL_ERROR"))
-              print();
+              printMsg();
             else
               std::cout << line << std::endl;
           }
@@ -135,7 +143,7 @@ struct sParseLog
       }
     }
   }
-  void print()
+  void printMsg()
   {
     switch (mEmuType)
     {
@@ -151,7 +159,7 @@ struct sParseLog
   {
     if (not mFileExists.load())
     {
-      if (std::filesystem::exists(mFileName))
+      if (file_exists(mFileName))
       {
         file.open(mFileName);
         if (file.is_open())

--- a/src/runtime_src/core/pcie/emulation/common_em/config.h
+++ b/src/runtime_src/core/pcie/emulation/common_em/config.h
@@ -100,7 +100,7 @@ struct sParseLog
 {
   std::ifstream mFileStream;
   std::string mFileName;
-  std::atomic_bool mFileExists;
+  std::atomic<bool> mFileExists;
   std::vector<std::string> mMatchedStrings;
   eEmulationType mEmuType;
   
@@ -138,7 +138,14 @@ struct sParseLog
       }
     }
   }
-
+  /* print_user_msg prints an actionable item to the user so that one can perform
+  * for a cleaner exit. Hence Device Process, XSim exits neatly. ShimPtr->xclClose() achieves this.
+  * But unable to get those Shim pointers intelligently except by making them as composite classes.
+  * The proper clean up activity from XRT will be performed as part of future CR
+  * The current design has some limitations to apply this feature to both
+  * SwEmShim & HwEmShim classes.
+  * */
+  
   void print_user_msg()
   {
     switch (mEmuType) {

--- a/src/runtime_src/core/pcie/emulation/common_em/unix_socket.cxx
+++ b/src/runtime_src/core/pcie/emulation/common_em/unix_socket.cxx
@@ -113,7 +113,7 @@ ssize_t unix_socket::sk_write(const void *wbuf, size_t count)
   }
   ssize_t r;
   ssize_t wlen = 0;
-  auto *buf = reinterpret_cast<const unsigned char*>(wbuf);
+  auto buf = reinterpret_cast<const unsigned char*>(wbuf);
   do {
     if ((r = write(fd, buf + wlen, count - wlen)) < 0) {
       if (errno == EINTR || errno == EAGAIN) {
@@ -139,7 +139,7 @@ ssize_t unix_socket::sk_read(void *rbuf, size_t count)
   }
   ssize_t r;
   ssize_t rlen = 0;
-  auto *buf = reinterpret_cast<unsigned char*>(rbuf);
+  auto buf = reinterpret_cast<unsigned char*>(rbuf);
 
   do {
     if ((r = read(fd, buf + rlen, count - rlen)) < 0) {

--- a/src/runtime_src/core/pcie/emulation/common_em/unix_socket.cxx
+++ b/src/runtime_src/core/pcie/emulation/common_em/unix_socket.cxx
@@ -119,6 +119,11 @@ ssize_t unix_socket::sk_write(const void *wbuf, size_t count)
       if (errno == EINTR || errno == EAGAIN) {
         continue;
       }
+      if (EBADF == errno){
+        std::cout<<"\n file descriptor pointing to invalid file.\n";
+        break;
+      }
+       
       return -1;
     }
     wlen += r;

--- a/src/runtime_src/core/pcie/emulation/common_em/unix_socket.cxx
+++ b/src/runtime_src/core/pcie/emulation/common_em/unix_socket.cxx
@@ -113,7 +113,7 @@ ssize_t unix_socket::sk_write(const void *wbuf, size_t count)
   }
   ssize_t r;
   ssize_t wlen = 0;
-  const unsigned char *buf = (const unsigned char*)(wbuf);
+  auto *buf = reinterpret_cast<const unsigned char*>(wbuf);
   do {
     if ((r = write(fd, buf + wlen, count - wlen)) < 0) {
       if (errno == EINTR || errno == EAGAIN) {
@@ -139,7 +139,7 @@ ssize_t unix_socket::sk_read(void *rbuf, size_t count)
   }
   ssize_t r;
   ssize_t rlen = 0;
-  unsigned char *buf = (unsigned char*)(rbuf);
+  auto *buf = reinterpret_cast<unsigned char*>(rbuf);
 
   do {
     if ((r = read(fd, buf + rlen, count - rlen)) < 0) {

--- a/src/runtime_src/core/pcie/emulation/common_em/unix_socket.cxx
+++ b/src/runtime_src/core/pcie/emulation/common_em/unix_socket.cxx
@@ -22,7 +22,7 @@
 unix_socket::unix_socket(const std::string& env, const std::string& sock_id, double timeout_insec, bool fatal_error)
 {
   std::string socket = sock_id;
-  server_started = false;
+  server_started.store(false);
   fd = -1;
   char* cUser = getenv("USER");
 
@@ -63,7 +63,8 @@ void unix_socket::start_server(double timeout_insec, bool fatal_error)
   strncpy(server.sun_path, name.c_str(),STR_MAX_LEN);
   if (connect(sock, (struct sockaddr*)&server, sizeof(server)) >= 0){
     fd = sock;
-    server_started = true;
+    std::cout<<"\n server socket name is\t"<<name<<"\n";
+    server_started.store(true);
     return;
   }
   unlink(server.sun_path);
@@ -99,13 +100,17 @@ void unix_socket::start_server(double timeout_insec, bool fatal_error)
     perror("socket acceptance failed");
     exit(1);
   } else {
-    server_started = true;
+    server_started.store(true);
   }
   return;
 }
 
 ssize_t unix_socket::sk_write(const void *wbuf, size_t count)
 {
+  if (not server_started) {
+    std::cout<<"\n unix_socket::sk_write failed, no socket connection established.\n";
+    return -1;
+  }
   ssize_t r;
   ssize_t wlen = 0;
   const unsigned char *buf = (const unsigned char*)(wbuf);
@@ -123,6 +128,10 @@ ssize_t unix_socket::sk_write(const void *wbuf, size_t count)
 
 ssize_t unix_socket::sk_read(void *rbuf, size_t count)
 {
+  if (not server_started) {
+    std::cout<<"\n unix_socket::sk_read failed, no socket connection established.\n";
+    return -1;
+  }
   ssize_t r;
   ssize_t rlen = 0;
   unsigned char *buf = (unsigned char*)(rbuf);

--- a/src/runtime_src/core/pcie/emulation/common_em/unix_socket.cxx
+++ b/src/runtime_src/core/pcie/emulation/common_em/unix_socket.cxx
@@ -108,7 +108,7 @@ void unix_socket::start_server(double timeout_insec, bool fatal_error)
 ssize_t unix_socket::sk_write(const void *wbuf, size_t count)
 {
   if (not server_started) {
-    std::cout<<"\n unix_socket::sk_write failed, no socket connection established.\n";
+    std::cout<< "\n unix_socket::sk_write failed, no socket connection established.\n";
     return -1;
   }
   ssize_t r;
@@ -120,7 +120,7 @@ ssize_t unix_socket::sk_write(const void *wbuf, size_t count)
         continue;
       }
       if (EBADF == errno){
-        std::cout<<"\n file descriptor pointing to invalid file.\n";
+        std::cout<< "\n file descriptor pointing to invalid file.\n";
         break;
       }
        
@@ -134,7 +134,7 @@ ssize_t unix_socket::sk_write(const void *wbuf, size_t count)
 ssize_t unix_socket::sk_read(void *rbuf, size_t count)
 {
   if (not server_started) {
-    std::cout<<"\n unix_socket::sk_read failed, no socket connection established.\n";
+    std::cout<< "\n unix_socket::sk_read failed, no socket connection established.\n";
     return -1;
   }
   ssize_t r;

--- a/src/runtime_src/core/pcie/emulation/common_em/unix_socket.h
+++ b/src/runtime_src/core/pcie/emulation/common_em/unix_socket.h
@@ -18,15 +18,18 @@
 
 #ifndef __XCLHOST_UNIXSOCKET__
 #define __XCLHOST_UNIXSOCKET__
+// Local/XRT headers
+#include "em_defines.h"
+#include "system_utils.h"
+#include "xclhal2.h"
+// c-style system headers
 #include <sys/socket.h>
-#include <sys/un.h>
 #include <sys/stat.h>
+#include <sys/un.h>
+// C++ headers
+#include <atomic>
 #include <boost/algorithm/string.hpp>
 #include <iostream>
-#include <atomic>
-#include "system_utils.h"
-#include "em_defines.h"
-#include "xclhal2.h"
 
 class unix_socket {
   private:

--- a/src/runtime_src/core/pcie/emulation/common_em/unix_socket.h
+++ b/src/runtime_src/core/pcie/emulation/common_em/unix_socket.h
@@ -36,7 +36,7 @@ public:
     std::atomic_bool server_started;
     void set_name(const std::string &sock_name) { name = sock_name;}
     std::string get_name() { return name;}
-    unix_socket(const std::string& env = "EMULATION_SOCKETID", const std::string& sock_id="xcl_sock",double timeout_insec=100,bool fatal_error=true);
+    unix_socket(const std::string& env = "EMULATION_SOCKETID", const std::string& sock_id="xcl_sock",double timeout_insec=300,bool fatal_error=true);
     ~unix_socket()
     {
        server_started = false;

--- a/src/runtime_src/core/pcie/emulation/common_em/unix_socket.h
+++ b/src/runtime_src/core/pcie/emulation/common_em/unix_socket.h
@@ -23,7 +23,7 @@
 #include <sys/stat.h>
 #include <boost/algorithm/string.hpp>
 #include <iostream>
-
+#include <atomic>
 #include "system_utils.h"
 #include "em_defines.h"
 #include "xclhal2.h"
@@ -33,10 +33,10 @@ class unix_socket {
     int fd;
     std::string name;
 public:
-    bool server_started;
+    std::atomic_bool server_started;
     void set_name(const std::string &sock_name) { name = sock_name;}
     std::string get_name() { return name;}
-    unix_socket(const std::string& env = "EMULATION_SOCKETID", const std::string& sock_id="xcl_sock",double timeout_insec=300,bool fatal_error=true);
+    unix_socket(const std::string& env = "EMULATION_SOCKETID", const std::string& sock_id="xcl_sock",double timeout_insec=100,bool fatal_error=true);
     ~unix_socket()
     {
        server_started = false;

--- a/src/runtime_src/core/pcie/emulation/common_em/unix_socket.h
+++ b/src/runtime_src/core/pcie/emulation/common_em/unix_socket.h
@@ -36,7 +36,7 @@ class unix_socket {
     int fd;
     std::string name;
 public:
-    std::atomic_bool server_started;
+    std::atomic<bool> server_started;
     void set_name(const std::string &sock_name) { name = sock_name;}
     std::string get_name() { return name;}
     unix_socket(const std::string& env = "EMULATION_SOCKETID", const std::string& sock_id="xcl_sock",double timeout_insec=300,bool fatal_error=true);

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/debug.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/debug.cxx
@@ -67,7 +67,7 @@ namespace xclhwemhal2
                                               "HLS_PRINT",
                                               "Exiting xsim",
                                               "FATAL_ERROR"};
-  const auto kMaxTimeToConnectSimulator = 300;  // in seconds
+  constexpr auto kMaxTimeToConnectSimulator = 300;  // in seconds
 
   void HwEmShim::readDebugIpLayout(const std::string debugFileName)
   {

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/debug.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/debug.cxx
@@ -32,21 +32,22 @@
  * under the License.
  */
 
+// Local/XRT headers
+#include "config.h"
 #include "shim.h"
 #include "xclbin.h"
 #include "xcl_perfmon_parameters.h"
-#include "config.h"
-
-#include <iostream>
+// C++ headers
+#include <algorithm>
+#include <cassert>
+#include <chrono>
 #include <cstdio>
 #include <cstring>
-#include <cassert>
-#include <algorithm>
+#include <ctime>
+#include <iostream>
+#include <string>
 #include <thread>
 #include <vector>
-#include <ctime>
-#include <string>
-#include <chrono>
 
 #ifndef _WINDOWS
 // TODO: Windows build support
@@ -61,6 +62,13 @@
 
 namespace xclhwemhal2
 {
+  const std::vector<std::string> kSimProcessStatus = {"SIM-IPC's external process can be connected to instance",
+                                              "SystemC TLM functional mode",
+                                              "HLS_PRINT",
+                                              "Exiting xsim",
+                                              "FATAL_ERROR"};
+  const auto kMaxTimeToConnectSimulator = 300;  // in seconds
+
   void HwEmShim::readDebugIpLayout(const std::string debugFileName)
   {
     //
@@ -253,26 +261,25 @@ namespace xclhwemhal2
   }
 
   /*
-   * messagesThread()
+   * messagesThread(): This thread Prints several messages on to console with a conditional 
+   * sleep time.
+   * Task 1:
+   *  Calls parseLog() with a sleep time of 10,20,30...etc if elapsed time is falls < 300 seconds
+   * Task 2: 
+   *  Otherwise parseSimulateLog,fetchAndPrintMessages called continuously.
    */
   void HwEmShim::messagesThread()
   {
-
- //..........................................   
     if (xclemulation::config::getInstance()->isSystemDPAEnabled() == false)
     {
       return;
     }
-    static auto l_time = std::chrono::high_resolution_clock::now();
-    static auto start_time = std::chrono::high_resolution_clock::now();
+    auto l_time = std::chrono::high_resolution_clock::now();
+    auto start_time = std::chrono::high_resolution_clock::now();
 
     unsigned int parseCount = 0;
-    std::vector<std::string> lMatchedStrings = {"SIM-IPC's external process can be connected to instance",
-                                      "SystemC TLM functional mode",
-                                      "HLS_PRINT",
-                                      "Exiting xsim",
-                                      "FATAL_ERROR"};
-    xclemulation::sParseLog lParseLog(std::string(getSimPath() + "/simulate.log"), xclemulation::eEmulationType::eHw_Emu, lMatchedStrings);
+
+    xclemulation::sParseLog lParseLog(std::string(getSimPath() + "/simulate.log"), xclemulation::eEmulationType::eHw_Emu, kSimProcessStatus);
     while (get_simulator_started())
     {
       sleep(10);
@@ -280,27 +287,29 @@ namespace xclhwemhal2
        break;
 
       auto l_time_end = std::chrono::high_resolution_clock::now();
-      if (std::chrono::duration_cast<std::chrono::seconds>(l_time_end - l_time).count() > 300) {
+      // My wait time > 300 seconds, Let's fetch the exact details behind late connection with Simulator.
+      if (std::chrono::duration_cast<std::chrono::seconds>(l_time_end - l_time).count() > kMaxTimeToConnectSimulator) {
        
         std::lock_guard<std::mutex> guard(mPrintMessagesLock);
         if (get_simulator_started() == false)
           return;
-        
+        // Possibility of deadlock detection?
         parseSimulateLog();
         fetchAndPrintMessages();
       }
 
       auto end_time = std::chrono::high_resolution_clock::now();
-      if (std::chrono::duration_cast<std::chrono::seconds>(end_time - start_time).count() <= 300) {
+      if (std::chrono::duration_cast<std::chrono::seconds>(end_time - start_time).count() <= kMaxTimeToConnectSimulator) {
 
         std::lock_guard<std::mutex> guard(mPrintMessagesLock);
 
         if (get_simulator_started() == false) 
           return;
-
-        lParseLog.parseLog();
+        // Any status message found in parse log file?
+        lParseLog.parseLog();         
         parseCount++;
         if (parseCount%5 == 0) {
+            // Sleep for 10, 20, 30 ...etc
             std::this_thread::sleep_for(std::chrono::seconds(10*(parseCount/5)));
         }
       }

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/debug.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/debug.cxx
@@ -266,7 +266,6 @@ namespace xclhwemhal2
     static auto l_time = std::chrono::high_resolution_clock::now();
     static auto start_time = std::chrono::high_resolution_clock::now();
 
-    //unsigned int timeCheck = 0;
     unsigned int parseCount = 0;
     std::vector<std::string> lMatchedStrings = {"SIM-IPC's external process can be connected to instance",
                                       "SystemC TLM functional mode",
@@ -282,7 +281,7 @@ namespace xclhwemhal2
 
       auto l_time_end = std::chrono::high_resolution_clock::now();
       if (std::chrono::duration_cast<std::chrono::seconds>(l_time_end - l_time).count() > 300) {
-       // l_time = std::chrono::high_resolution_clock::now();
+       
         std::lock_guard<std::mutex> guard(mPrintMessagesLock);
         if (get_simulator_started() == false)
           return;

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
@@ -61,9 +61,9 @@ namespace xclhwemhal2 {
         private:
         std::unique_ptr<call_packet_info> header;
         std::unique_ptr<response_packet_info> response_header;
-	    size_t  i_len;
-	    size_t  ri_len;
-        std::shared_ptr<unix_socket> Q2h_sock;
+        size_t  i_len;
+        size_t  ri_len;
+        std::unique_ptr<unix_socket> Q2h_sock;
         xclhwemhal2::HwEmShim* inst;
 
         public:
@@ -988,7 +988,7 @@ namespace xclhwemhal2 {
       mEnvironmentNameValueMap["enable_pr"] = "false";
     }
     
-    sock.reset(new unix_socket);
+    sock = std::make_shared<unix_socket>();
     set_simulator_started(true);
     //Thread to fetch messages from Device to display on host
     if (mMessengerThreadStarted == false) {
@@ -3922,7 +3922,7 @@ bool Q2H_helper::connect_sock() {
       sock_name = "D2X_unix_sock";
     }
     if (Q2h_sock == nullptr) {
-      Q2h_sock = std::make_shared<unix_socket>("EMULATION_SOCKETID", sock_name, 5, false);
+      Q2h_sock = std::make_unique<unix_socket>("EMULATION_SOCKETID", sock_name, 5, false);
     }
     else if (!Q2h_sock->server_started) {
       Q2h_sock->start_server(5,false);

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
@@ -1799,12 +1799,12 @@ uint32_t HwEmShim::getAddressSpace (uint32_t topology)
     }
 
     xclGetDebugMessages(true);
-    try{
+    try {
       std::lock_guard<std::mutex> guard(mPrintMessagesLock);
       fetchAndPrintMessages();
       simulator_started = false;
     }
-    catch(std::exception& ex){
+    catch (std::exception& ex) {
       if (mLogStream.is_open()) 
         mLogStream << __func__ << ", unable to get lock:: " <<ex.what()<< std::endl;
       
@@ -3639,14 +3639,12 @@ void HwEmShim::closeMessengerThread()
 {
   // set_simulator_started has to be false in order to see proper exit of joinable thread.
   //set_simulator_started(false);
-  if (mMessengerThread.joinable())
-  {
+  if (mMessengerThread.joinable()) {
     mMessengerThreadStarted = false;
     mMessengerThread.join();
   }
 
-  if (mHostMemAccessThread.joinable())
-  {
+  if (mHostMemAccessThread.joinable()) {
     mHostMemAccessThreadStarted = false;
     mHostMemAccessThread.join();
   }
@@ -3935,7 +3933,7 @@ void HwEmShim::hostMemAccessThread() {
     auto mq2h_helper_ptr = std::make_unique<Q2H_helper>(this);
     bool sock_ret = false;
     int count = 0;
-    while(mHostMemAccessThreadStarted && !sock_ret && count < 71){
+    while (mHostMemAccessThreadStarted && !sock_ret && count < 71) {
         sock_ret = mq2h_helper_ptr->connect_sock();
         count++;
     }
@@ -3943,7 +3941,7 @@ void HwEmShim::hostMemAccessThread() {
       std::cout<<"\n unable to get a reliable socket connection, ideally should exit here. select call took care. \n";
     }
     int r =0;
-    while(mHostMemAccessThreadStarted && r >= 0){
+    while (mHostMemAccessThreadStarted && r >= 0) {
         try {
             if (not get_simulator_started())
                 return;

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
@@ -52,7 +52,6 @@
 
 namespace xclhwemhal2 {
     //Thread for which pooling for transaction from SIM_QDMA
-   // void hostMemAccessThread(xclhwemhal2::HwEmShim* inst);
 
     /**
       * helper class for transactions from SIM_QDMA to XRT
@@ -64,7 +63,6 @@ namespace xclhwemhal2 {
         std::unique_ptr<response_packet_info> response_header;
 	    size_t  i_len;
 	    size_t  ri_len;
-        //unix_socket* Q2h_sock;
         std::shared_ptr<unix_socket> Q2h_sock;
         xclhwemhal2::HwEmShim* inst;
 
@@ -96,8 +94,7 @@ namespace xclhwemhal2 {
   const unsigned HwEmShim::REG_BUFF_SIZE = 0x4;
   const unsigned HwEmShim::M2M_KERNEL_ARGS_SIZE = 36;
 
-  //void messagesThread(xclhwemhal2::HwEmShim* inst);
-
+  
   // Maintain a list of all currently open device handles.
   //
   // xclClose removes a handle from the list.  At static destruction
@@ -616,18 +613,7 @@ namespace xclhwemhal2 {
 
     //CR-1116870 Changes End
 
-    //set_simulator_started(true);
-
-    //Thread to fetch messages from Device to display on host
-    /*
-    if(mMessengerThreadStarted == false) {
-      mMessengerThread = std::thread(xclhwemhal2::messagesThread,this);
-      mMessengerThreadStarted = true;
-    }
     
-    if (mLogStream.is_open())
-       mLogStream << __func__ << " mMessengerThreadStarted " << std::endl;
-*/
     bool simDontRun = xclemulation::config::getInstance()->isDontRun();
     std::string launcherArgs = xclemulation::config::getInstance()->getLauncherArgs();
     std::string wdbFileName("");
@@ -840,7 +826,7 @@ namespace xclhwemhal2 {
     }
 
     if(mHostMemAccessThreadStarted == false) {
-      mHostMemAccessThread = std::thread([this](){hostMemAccessThread();});
+      mHostMemAccessThread = std::thread([this]() { hostMemAccessThread(); } );
     }
 
     if (deviceDirectory.empty() == false)
@@ -1001,12 +987,12 @@ namespace xclhwemhal2 {
       mEnvironmentNameValueMap["enable_pr"] = "false";
     }
     
-    //sock = new unix_socket;
     sock.reset(new unix_socket);
     set_simulator_started(true);
+    //Thread to fetch messages from Device to display on host
     if (mMessengerThreadStarted == false) {
       std::cout<<"\n messages Thread is created\n";
-      mMessengerThread = std::thread([this](){messagesThread();});
+      mMessengerThread = std::thread([this]() { messagesThread(); } );
       mMessengerThreadStarted = true;
     }
 
@@ -1824,12 +1810,6 @@ uint32_t HwEmShim::getAddressSpace (uint32_t topology)
       std::cout<<"\n unable to get lock::"<<ex.what();
     }
     
-    /*
-    mPrintMessagesLock.lock();
-    fetchAndPrintMessages();
-    simulator_started = false;
-    mPrintMessagesLock.unlock();
-    */
     std::string socketName = sock->get_name();
     if(socketName.empty() == false)// device is active if socketName is non-empty
     {
@@ -1866,8 +1846,7 @@ uint32_t HwEmShim::getAddressSpace (uint32_t topology)
       saveWaveDataBase();
     }
     //ProfilerStop();
-    //delete sock;
-    //sock = NULL;
+    
     sock.reset();
 
     PRINTENDFUNC;
@@ -3747,8 +3726,6 @@ int HwEmShim::xclIPName2Index(const char *name)
 }
 
 
-//volatile bool HwEmShim::get_mHostMemAccessThreadStarted() { return mHostMemAccessThreadStarted; }
-//volatile void HwEmShim::set_mHostMemAccessThreadStarted(bool val) { mHostMemAccessThreadStarted = val; }
 /********************************************** QDMA APIs IMPLEMENTATION END**********************************************/
 /**********************************************HAL2 API's END HERE **********************************************/
 
@@ -3865,10 +3842,7 @@ Q2H_helper :: Q2H_helper(xclhwemhal2::HwEmShim* _inst) {
     ri_len          = response_header->ByteSizeLong();
 #endif
 }
-Q2H_helper::~Q2H_helper() {
-    //delete Q2h_sock;
-    //Q2h_sock = 0;
-}
+Q2H_helper::~Q2H_helper() = default;
 
 /**
  * Pooling on socket for any memory or interrupt requests from SIM_QDMA
@@ -3946,8 +3920,7 @@ bool Q2H_helper::connect_sock() {
     } else {
       sock_name = "D2X_unix_sock";
     }
-    if(Q2h_sock == nullptr) {
-      //Q2h_sock = new unix_socket("EMULATION_SOCKETID", sock_name, 5, false);
+    if (Q2h_sock == nullptr) {
       Q2h_sock = std::make_shared<unix_socket>("EMULATION_SOCKETID", sock_name, 5, false);
     }
     else if (!Q2h_sock->server_started) {

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
@@ -846,7 +846,6 @@ namespace xclhwemhal2 {
     }
 
     if(mHostMemAccessThreadStarted == false) {
-  	  //mHostMemAccessThread = std::thread(xclhwemhal2::hostMemAccessThread,this);
       mHostMemAccessThread = std::thread([this](){hostMemAccessThread();});
     }
 
@@ -1843,7 +1842,7 @@ uint32_t HwEmShim::getAddressSpace (uint32_t topology)
 #ifndef _WINDOWS
       xclClose_RPC_CALL(xclClose,this);
 #endif
-      closemMessengerThread();
+      closeMessengerThread();
       //clean up directories which are created inside the driver
       systemUtil::makeSystemCall(socketName, systemUtil::systemOperation::REMOVE, "", std::to_string(__LINE__));
     }
@@ -1956,7 +1955,7 @@ uint32_t HwEmShim::getAddressSpace (uint32_t topology)
       delete mDataSpace;
       mDataSpace = NULL;
     }
-    closemMessengerThread();
+    closeMessengerThread();
   }
 
   void HwEmShim::initMemoryManager(std::list<xclemulation::DDRBank>& DDRBankList)
@@ -3662,19 +3661,20 @@ int HwEmShim::xclLogMsg(xrtLogMsgLevel level, const char* tag, const char* forma
     return 0;
 }
 
-void HwEmShim::closemMessengerThread()
+void HwEmShim::closeMessengerThread()
 {
-  //set_simulator_started has to be false in order to see proper exit of joinable thread.
-  if (mMessengerThread.joinable()) {
+  // set_simulator_started has to be false in order to see proper exit of joinable thread.
+  //set_simulator_started(false);
+  if (mMessengerThread.joinable())
+  {
     mMessengerThreadStarted = false;
     mMessengerThread.join();
   }
 
-  if (mHostMemAccessThreadStarted) {
+  if (mHostMemAccessThread.joinable())
+  {
     mHostMemAccessThreadStarted = false;
-    if (mHostMemAccessThread.joinable()) {
-      mHostMemAccessThread.join();
-    }
+    mHostMemAccessThread.join();
   }
 }
 

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
@@ -968,7 +968,8 @@ namespace xclhwemhal2 {
         if (!launcherArgs.empty())
           simMode = launcherArgs.c_str();
 
-        if (!xclemulation::file_exists(sim_file))
+        //if (!xclemulation::file_exists(sim_file))
+        if (!boost::filesystem::exists(sim_file))
           sim_file = "simulate.sh";
 
         int r = execl(sim_file.c_str(), sim_file.c_str(), simMode, NULL);

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
@@ -58,7 +58,7 @@ file_exists(const std::string& fnm)
 
 namespace xclhwemhal2 {
     //Thread for which pooling for transaction from SIM_QDMA
-    void hostMemAccessThread(xclhwemhal2::HwEmShim* inst);
+   // void hostMemAccessThread(xclhwemhal2::HwEmShim* inst);
 
     /**
       * helper class for transactions from SIM_QDMA to XRT
@@ -70,7 +70,8 @@ namespace xclhwemhal2 {
         std::unique_ptr<response_packet_info> response_header;
 	    size_t  i_len;
 	    size_t  ri_len;
-        unix_socket* Q2h_sock;
+        //unix_socket* Q2h_sock;
+        std::shared_ptr<unix_socket> Q2h_sock;
         xclhwemhal2::HwEmShim* inst;
 
         public:
@@ -101,7 +102,7 @@ namespace xclhwemhal2 {
   const unsigned HwEmShim::REG_BUFF_SIZE = 0x4;
   const unsigned HwEmShim::M2M_KERNEL_ARGS_SIZE = 36;
 
-  void messagesThread(xclhwemhal2::HwEmShim* inst);
+  //void messagesThread(xclhwemhal2::HwEmShim* inst);
 
   // Maintain a list of all currently open device handles.
   //
@@ -621,17 +622,18 @@ namespace xclhwemhal2 {
 
     //CR-1116870 Changes End
 
-    set_simulator_started(true);
+    //set_simulator_started(true);
 
     //Thread to fetch messages from Device to display on host
+    /*
     if(mMessengerThreadStarted == false) {
       mMessengerThread = std::thread(xclhwemhal2::messagesThread,this);
       mMessengerThreadStarted = true;
     }
-
+    
     if (mLogStream.is_open())
        mLogStream << __func__ << " mMessengerThreadStarted " << std::endl;
-
+*/
     bool simDontRun = xclemulation::config::getInstance()->isDontRun();
     std::string launcherArgs = xclemulation::config::getInstance()->getLauncherArgs();
     std::string wdbFileName("");
@@ -844,7 +846,8 @@ namespace xclhwemhal2 {
     }
 
     if(mHostMemAccessThreadStarted == false) {
-  	  mHostMemAccessThread = std::thread(xclhwemhal2::hostMemAccessThread,this);
+  	  //mHostMemAccessThread = std::thread(xclhwemhal2::hostMemAccessThread,this);
+      mHostMemAccessThread = std::thread([this](){hostMemAccessThread();});
     }
 
     if (deviceDirectory.empty() == false)
@@ -1004,8 +1007,18 @@ namespace xclhwemhal2 {
     {
       mEnvironmentNameValueMap["enable_pr"] = "false";
     }
+    
+    //sock = new unix_socket;
+    sock.reset(new unix_socket);
+    set_simulator_started(true);
+    if (mMessengerThreadStarted == false) {
+      std::cout<<"\n messages Thread is created\n";
+      mMessengerThread = std::thread([this](){messagesThread();});
+      mMessengerThreadStarted = true;
+    }
 
-    sock = new unix_socket;
+    if (mLogStream.is_open())
+      mLogStream << __func__ << " mMessengerThreadStarted " << std::endl;
 
     if (mLogStream.is_open())
       mLogStream << __func__ << " Created the Unix socket." << std::endl;
@@ -1806,10 +1819,24 @@ uint32_t HwEmShim::getAddressSpace (uint32_t topology)
     }
 
     xclGetDebugMessages(true);
+    try{
+      std::lock_guard<std::mutex> guard(mPrintMessagesLock);
+      fetchAndPrintMessages();
+      simulator_started = false;
+    }
+    catch(std::exception& ex){
+      if (mLogStream.is_open()) 
+        mLogStream << __func__ << ", unable to get lock:: " <<ex.what()<< std::endl;
+      
+      std::cout<<"\n unable to get lock::"<<ex.what();
+    }
+    
+    /*
     mPrintMessagesLock.lock();
     fetchAndPrintMessages();
     simulator_started = false;
     mPrintMessagesLock.unlock();
+    */
     std::string socketName = sock->get_name();
     if(socketName.empty() == false)// device is active if socketName is non-empty
     {
@@ -1846,8 +1873,10 @@ uint32_t HwEmShim::getAddressSpace (uint32_t topology)
       saveWaveDataBase();
     }
     //ProfilerStop();
-    delete sock;
-    sock = NULL;
+    //delete sock;
+    //sock = NULL;
+    sock.reset();
+
     PRINTENDFUNC;
     if(mMBSch && mCore)
     {
@@ -3635,9 +3664,10 @@ int HwEmShim::xclLogMsg(xrtLogMsgLevel level, const char* tag, const char* forma
 
 void HwEmShim::closemMessengerThread()
 {
-  if (mMessengerThreadStarted) {
-    mMessengerThread.join();
+  //set_simulator_started has to be false in order to see proper exit of joinable thread.
+  if (mMessengerThread.joinable()) {
     mMessengerThreadStarted = false;
+    mMessengerThread.join();
   }
 
   if (mHostMemAccessThreadStarted) {
@@ -3723,8 +3753,8 @@ int HwEmShim::xclIPName2Index(const char *name)
 }
 
 
-volatile bool HwEmShim::get_mHostMemAccessThreadStarted() { return mHostMemAccessThreadStarted; }
-volatile void HwEmShim::set_mHostMemAccessThreadStarted(bool val) { mHostMemAccessThreadStarted = val; }
+//volatile bool HwEmShim::get_mHostMemAccessThreadStarted() { return mHostMemAccessThreadStarted; }
+//volatile void HwEmShim::set_mHostMemAccessThreadStarted(bool val) { mHostMemAccessThreadStarted = val; }
 /********************************************** QDMA APIs IMPLEMENTATION END**********************************************/
 /**********************************************HAL2 API's END HERE **********************************************/
 
@@ -3828,7 +3858,7 @@ Q2H_helper :: Q2H_helper(xclhwemhal2::HwEmShim* _inst) {
     header          = std::make_unique<call_packet_info>();
     response_header = std::make_unique<response_packet_info>();
     inst = _inst;
-    Q2h_sock        = NULL;
+    Q2h_sock        = nullptr;
     header->set_size(0);
     header->set_xcl_api(0);
     response_header->set_size(0);
@@ -3842,8 +3872,8 @@ Q2H_helper :: Q2H_helper(xclhwemhal2::HwEmShim* _inst) {
 #endif
 }
 Q2H_helper::~Q2H_helper() {
-    delete Q2h_sock;
-    Q2h_sock = 0;
+    //delete Q2h_sock;
+    //Q2h_sock = 0;
 }
 
 /**
@@ -3922,8 +3952,9 @@ bool Q2H_helper::connect_sock() {
     } else {
       sock_name = "D2X_unix_sock";
     }
-    if(Q2h_sock == NULL) {
-      Q2h_sock = new unix_socket("EMULATION_SOCKETID", sock_name, 5, false);
+    if(Q2h_sock == nullptr) {
+      //Q2h_sock = new unix_socket("EMULATION_SOCKETID", sock_name, 5, false);
+      Q2h_sock = std::make_shared<unix_socket>("EMULATION_SOCKETID", sock_name, 5, false);
     }
     else if (!Q2h_sock->server_started) {
       Q2h_sock->start_server(5,false);
@@ -3931,19 +3962,22 @@ bool Q2H_helper::connect_sock() {
     return Q2h_sock->server_started;
 }
 
-void hostMemAccessThread(xclhwemhal2::HwEmShim* inst) {
-	inst->set_mHostMemAccessThreadStarted(true);
-    auto mq2h_helper_ptr = std::make_unique<Q2H_helper>(inst);
+void HwEmShim::hostMemAccessThread() {
+    mHostMemAccessThreadStarted.store(true);
+    auto mq2h_helper_ptr = std::make_unique<Q2H_helper>(this);
     bool sock_ret = false;
     int count = 0;
-    while(inst->get_mHostMemAccessThreadStarted() && !sock_ret && count < 71){
+    while(mHostMemAccessThreadStarted && !sock_ret && count < 71){
         sock_ret = mq2h_helper_ptr->connect_sock();
         count++;
     }
+    if (not sock_ret) {
+      std::cout<<"\n unable to get a reliable socket connection, ideally should exit here. select call took care. \n";
+    }
     int r =0;
-    while(inst->get_mHostMemAccessThreadStarted() && r >= 0){
+    while(mHostMemAccessThreadStarted && r >= 0){
         try {
-            if (!inst->get_simulator_started())
+            if (not get_simulator_started())
                 return;
             r = mq2h_helper_ptr->poolingon_Qdma();
         } catch(int e) {

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
@@ -14,24 +14,27 @@
  * under the License.
  */
 
+#include "core/common/AlignedAllocator.h"
+#include "core/common/xclbin_parser.h"
+#include "plugin/xdp/device_offload.h"
 #include "shim.h"
 #include "system_hwemu.h"
 #include "xclbin.h"
-#include "core/common/xclbin_parser.h"
-#include "core/common/AlignedAllocator.h"
 #include "xcl_perfmon_parameters.h"
-#include <fstream>
-#include <boost/property_tree/xml_parser.hpp>
+
 #include <unistd.h>
+
+#include <boost/property_tree/xml_parser.hpp>
 #include <array>
 #include <cctype>
 #include <cerrno>
 #include <cstring>
+#include <fstream>
 #include <mutex>
 #include <set>
 #include <vector>
 
-#include "plugin/xdp/device_offload.h"
+
 
 #define SEND_RESP2QDMA() \
     { \
@@ -45,16 +48,7 @@
     }
 
 
-namespace {
 
-inline bool
-file_exists(const std::string& fnm)
-{
-  struct stat statBuf;
-  return stat(fnm.c_str(), &statBuf) == 0;
-}
-
-}
 
 namespace xclhwemhal2 {
     //Thread for which pooling for transaction from SIM_QDMA
@@ -988,7 +982,7 @@ namespace xclhwemhal2 {
         if (!launcherArgs.empty())
           simMode = launcherArgs.c_str();
 
-        if (!file_exists(sim_file))
+        if (!xclemulation::file_exists(sim_file))
           sim_file = "simulate.sh";
 
         int r = execl(sim_file.c_str(), sim_file.c_str(), simMode, NULL);

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.h
@@ -104,49 +104,6 @@ using addr_type = uint64_t;
    unsigned int size;
  } KernelArg;
 
- struct sParseLog
- {
-   std::ifstream file;
-   std::string mFileName;
-   std::atomic_bool mFileExists;
-
-   sParseLog(const std::string &iDeviceLog) : mFileName(iDeviceLog) {
-     mFileExists.store(false);
-   }
-
-   ~sParseLog() = default;
-   //******************************* XRT Graph API's **************************************************//
-   /**
-    * SearchString(std::string&) - Searches for a string
-    *
-    * @gh:             Handle to graph previously opened with xrtGraphOpen.
-    * Return:          0 on success, -1 on error
-    *
-    * Note: Run by enable tiles and disable tile reset
-    */
-   void SearchString(std::string &matchString) {
-     std::string line;
-     while (std::getline(file, line)) {
-       if (line.find(matchString) != std::string::npos)
-         std::cout << "Received request to end the application. Press Cntrl+C to exit the application." << std::endl;
-     }
-   }
-
-   void parseLog() {
-     if (not mFileExists.load()) {
-       if (std::filesystem::exists(mFileName)) {
-         file.open(mFileName);
-         if (file.is_open())
-           mFileExists.store(true);
-       }
-     }
-
-     if (mFileExists.load()) {
-       std::string matchString = "received request to end simulation from connected initiator";
-       SearchString(matchString);
-     }
-   }
- };
 
   class HwEmShim {
 

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.h
@@ -304,8 +304,8 @@ using addr_type = uint64_t;
     private:
       std::thread mMessengerThread;
       std::thread mHostMemAccessThread;
-      std::atomic_bool mMessengerThreadStarted;
-      std::atomic_bool mHostMemAccessThreadStarted;
+      std::atomic<bool> mMessengerThreadStarted;
+      std::atomic<bool> mHostMemAccessThreadStarted;
       void messagesThread(); 
       void hostMemAccessThread();
 

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.h
@@ -275,8 +275,7 @@ using addr_type = uint64_t;
       // Restricted read/write on IP register space
       int xclRegWrite(uint32_t cu_index, uint32_t offset, uint32_t data);
       int xclRegRead(uint32_t cu_index, uint32_t offset, uint32_t *datap);
-      //volatile bool get_mHostMemAccessThreadStarted();
-      //volatile void set_mHostMemAccessThreadStarted(bool val);
+      
       bool device2xrt_rd_trans_cb(unsigned long int addr, void* const data_ptr,unsigned long int size);
       bool device2xrt_wr_trans_cb(unsigned long int addr, void const* data_ptr,unsigned long int size);
       bool device2xrt_irq_trans_cb(uint32_t,unsigned long int);
@@ -352,7 +351,7 @@ using addr_type = uint64_t;
       static std::ofstream mDebugLogStream;
       static bool mFirstBinary;
       unsigned int binaryCounter;
-      //unix_socket* sock;
+
       std::shared_ptr<unix_socket> sock;
       std::string deviceName;
       xclDeviceInfo2 mDeviceInfo;

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.h
@@ -18,41 +18,41 @@
 #define _HW_EM_SHIM_H_
 
 #ifndef _WINDOWS
-#include "unix_socket.h"
 #include "config.h"
+#include "core/common/api/xclbin_int.h"
+#include "core/common/device.h"
+#include "core/common/message.h"
+#include "core/common/query_requests.h"
+#include "core/common/scheduler.h"
+#include "core/common/xrt_profiling.h"
+#include "core/include/experimental/xrt_xclbin.h"
 #include "em_defines.h"
+#include "mbscheduler.h"
 #include "memorymanager.h"
+#include "mbscheduler_hwemu.h"
+#include "mem_model.h"
 #include "rpc_messages.pb.h"
-
+#include "xgq_hwemu.h"
+#include "xclbin.h"
 #include "xclperf.h"
 #include "xcl_api_macros.h"
 #include "xcl_macros.h"
-#include "xclbin.h"
-#include "core/common/device.h"
-#include "core/common/scheduler.h"
-#include "core/common/message.h"
-#include "core/common/xrt_profiling.h"
-#include "core/common/query_requests.h"
-#include "core/common/api/xclbin_int.h"
-#include "core/include/experimental/xrt_xclbin.h"
+#include "unix_socket.h"
 
-#include "mem_model.h"
-#include "mbscheduler.h"
-#include "mbscheduler_hwemu.h"
-#include "xgq_hwemu.h"
 #endif
 
-#include <sys/param.h>
-#include <sys/wait.h>
-#include <thread>
+#include <fcntl.h>
 #include <signal.h>
 #include <sys/mman.h>
-#include <sys/types.h>
+#include <sys/param.h>
 #include <sys/stat.h>
-#include <fcntl.h>
-#include <tuple>
+#include <sys/types.h>
+#include <sys/wait.h>
+
 #include <cstdarg>
-#include <filesystem>
+#include <thread>
+#include <tuple>
+
 #ifdef _WINDOWS
 #define strtoll _strtoi64
 #endif

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.h
@@ -403,7 +403,7 @@ using addr_type = uint64_t;
       bool     mVersalPlatform;
       //For Emulation specific messages on host from Device
 
-      void closemMessengerThread();
+      void closeMessengerThread();
       bool mIsTraceHubAvailable;
       uint32_t mCuIndx;
       std::map<std::string, uint64_t> mCURangeMap;


### PR DESCRIPTION

Fix : Currently hw_emu looks for an active socket connection with xsim, it should exit after numerous retries within default 300 seconds time period. But it is crashing because unix_socket pointer was trying to used by dispatched messagesThread where unix_socket pointer is not a valid memory location.

Risk : very Low. 

Tests :  Canary tun. Results are clean.

Reviewer : venkatp
