### PR TITLE
Fixed PS kernel BO list not cleaned up issue

### DIFF
--- a/src/runtime_src/core/edge/skd/xrt_skd.cpp
+++ b/src/runtime_src/core/edge/skd/xrt_skd.cpp
@@ -220,6 +220,8 @@ namespace xrt {
 	munmap(bos[i],boSize[i]);
 	xclFreeBO(devHdl,boHandles[i]);
       }
+      bo_list.clear();
+
     }
 
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
The BO list maintained by PS kernel daemon was not cleared after each run.
Therefore as runs start to accumulate, BO free operation takes longer and longer.
This fix clears the BO list after each run.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Discovered with ps iops test

#### How problem was solved, alternative solutions (if any) and why they were rejected
Clear the BO list

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
vck5000 ps iops test

#### Documentation impact (if any)
None
