### PR TITLE
xclbinutil : Refactored how sections are registered.

### DIFF
--- a/src/runtime_src/tools/xclbinutil/Section.cxx
+++ b/src/runtime_src/tools/xclbinutil/Section.cxx
@@ -17,6 +17,7 @@
 #include "Section.h"
 
 #include "XclBinUtilities.h"
+#include <algorithm>
 #include <boost/algorithm/string.hpp>
 #include <boost/format.hpp>
 #include <boost/property_tree/json_parser.hpp>
@@ -31,15 +32,81 @@ namespace XUtil = XclBinUtilities;
 #endif
 
 
+Section::SectionInfo::SectionInfo( enum axlf_section_kind eKind,
+                                   const std::string & sectionName,
+                                   Section_factory sectionCtor)
+  : m_eKind(eKind)
+  , m_sectionName(sectionName)
+  , m_sectionCtor(sectionCtor)
+  , m_nodeName("")
+  , m_bSupportsSubSections(false)
+  , m_bSupportsIndexing(false)
+{
+  // Empty
+}
 
-// Static Variables Initialization
-std::map<enum axlf_section_kind, std::string> Section::m_mapIdToName;
-std::map<std::string, enum axlf_section_kind> Section::m_mapNameToId;
-std::map<enum axlf_section_kind, Section::Section_factory> Section::m_mapIdToCtor;
-std::map<std::string, enum axlf_section_kind> Section::m_mapJSONNameToKind;
-std::map<enum axlf_section_kind, std::string> Section::m_mapKindToJSONName;
-std::map<enum axlf_section_kind, bool> Section::m_mapIdToSubSectionSupport;
-std::map<enum axlf_section_kind, bool> Section::m_mapIdToSectionIndexSupport;
+void 
+Section::SectionInfo::setNodeName(const std::string& sNodeName)
+{
+  m_nodeName = sNodeName;
+}
+
+void 
+Section::SectionInfo::setSupportsSubSections(bool bValue)
+{
+  m_bSupportsSubSections = bValue;
+}
+
+void 
+Section::SectionInfo::setSupportsIndexing(bool bValue)
+{
+  m_bSupportsIndexing = bValue;
+}
+
+enum axlf_section_kind 
+  Section::SectionInfo::getType() const
+{
+  return m_eKind;
+}
+
+const std::string &
+Section::SectionInfo::getSectionName() const
+{
+  return m_sectionName;
+}
+
+Section::Section_factory
+Section::SectionInfo::getCtor() const
+{
+  return m_sectionCtor;
+}
+
+
+const std::string &
+Section::SectionInfo::getNodeName() const
+{
+  return m_nodeName;
+}
+
+bool 
+Section::SectionInfo::getSupportsSubSections() const
+{
+  return m_bSupportsSubSections;
+}
+
+bool 
+Section::SectionInfo::getSupportsIndexing() const
+{
+  return m_bSupportsIndexing;
+}
+
+
+// Singleton collection of sections 
+std::vector<std::unique_ptr<Section::SectionInfo>> &
+Section::getSectionTypes() {
+  static std::vector<std::unique_ptr<SectionInfo>> sections;
+  return sections;
+}
 
 Section::Section()
     : m_eKind(BITSTREAM)
@@ -73,85 +140,108 @@ Section::setName(const std::string &_sSectionName)
 
 void
 Section::getKinds(std::vector< std::string > & kinds) {
-  for (auto & item : m_mapNameToId) {
-    kinds.push_back(item.first);
-  }
+  for (auto & item : getSectionTypes()) 
+    kinds.push_back(item->getSectionName());
 }
 
+
+// Next phase: This method will be refactor such that the underlying 
+// section class will initialize its own section data.
 void
-Section::registerSectionCtor(enum axlf_section_kind _eKind,
-                             const std::string& _sKindStr,
-                             const std::string& _sHeaderJSONName,
-                             bool _bSupportsSubSections,
-                             bool _bSupportsIndexing,
-                             Section_factory _Section_factory) {
+Section::registerSectionCtor(enum axlf_section_kind eKind,
+                             const std::string& cmdName,
+                             const std::string& nodeName,
+                             bool bSupportsSubSections,
+                             bool bSupportsIndexing,
+                             Section_factory sectionCtor) {
+
   // Some error checking
-  if (_sKindStr.empty()) {
-    auto errMsg = boost::format("ERROR: Kind (%d) pretty print name is missing.") % (unsigned int) _eKind;
+  if (cmdName.empty()) {
+    auto errMsg = boost::format("ERROR: CMD name for the section kind (%d) is empty. This needs to be defined.") % eKind;
     throw std::runtime_error(errMsg.str());
   }
 
-  if (m_mapIdToName.find(_eKind) != m_mapIdToName.end()) {
+  // Get the collection of sections
+  auto & sections = getSectionTypes();
+
+  // Is the enumeration type already registered
+  if (std::any_of(sections.begin(), sections.end(), [&](const auto &entry) { return entry->getType() ==eKind; })) {
     auto errMsg = boost::format("ERROR: Attempting to register (%d : %s). Constructor enum of kind (%d) already registered.")
-                                % (unsigned int)_eKind % _sKindStr % (unsigned int)_eKind;
+                                % eKind % cmdName % eKind;
     throw std::runtime_error(errMsg.str());
   }
 
-  if (m_mapNameToId.find(_sKindStr) != m_mapNameToId.end()) {
-    auto errMsg = boost::format("ERROR: Attempting to register: (%d : %s). Constructor name '%s' already registered to eKind (%d).")
-                                % (unsigned int)_eKind % _sKindStr
-                                % _sKindStr % (unsigned int)m_mapNameToId[_sKindStr];
-    throw std::runtime_error(errMsg.str());
-  }
-
-  if (!_sHeaderJSONName.empty()) {
-    if (m_mapJSONNameToKind.find(_sHeaderJSONName) != m_mapJSONNameToKind.end()) {
-      auto errMsg = boost::format("ERROR: Attempting to register: (%d : %s). JSON mapping name '%s' already registered to eKind (%d).")
-                                  % (unsigned int) _eKind % _sKindStr.c_str()
-                                  % _sHeaderJSONName % (unsigned int) m_mapJSONNameToKind[_sHeaderJSONName];
+  // Is the cmd name already registered
+  {
+    auto iter = std::find_if(sections.begin(), sections.end(), [&](const auto &entry) { return entry->getSectionName() == cmdName; });
+    if (iter != sections.end()) {
+      auto errMsg = boost::format("ERROR: Attempting to register: (%d : %s). Constructor name '%s' already registered to eKind (%d).")
+                                  % eKind % cmdName
+                                  % cmdName % iter->get()->getType();
       throw std::runtime_error(errMsg.str());
     }
-    m_mapJSONNameToKind[_sHeaderJSONName] = _eKind;
   }
 
-  
-  // At this point we know we are good, lets initialize the arrays
-  // TODO: These mappings are no longer scalable. 
-  //       Please refactor to a cleaner solution at the next earliest possibility.
-  m_mapKindToJSONName[_eKind] = _sHeaderJSONName;
-  m_mapIdToName[_eKind] = _sKindStr;
-  m_mapNameToId[_sKindStr] = _eKind;
-  m_mapIdToCtor[_eKind] = _Section_factory;
-  m_mapIdToSubSectionSupport[_eKind] = _bSupportsSubSections;
-  m_mapIdToSectionIndexSupport[_eKind] = _bSupportsIndexing;
+  // Is the header name already registered
+  if (!nodeName.empty()) {
+    auto iter = std::find_if(sections.begin(), sections.end(), [&](const auto &entry) { return entry->getNodeName() == nodeName; });
+    if (iter != sections.end()) {
+      auto errMsg = boost::format("ERROR: Attempting to register: (%d : %s). JSON mapping name '%s' already registered to eKind (%d).")
+                                    % eKind % cmdName
+                                    % nodeName % iter->get()->getType();
+        throw std::runtime_error(errMsg.str());
+    }
+  }
+
+  auto sectionInfo = std::make_unique<SectionInfo>(eKind, cmdName, sectionCtor);
+  sectionInfo->setNodeName(nodeName);
+  sectionInfo->setSupportsSubSections(bSupportsSubSections);
+  sectionInfo->setSupportsIndexing(bSupportsIndexing);
+
+  sections.push_back(std::move(sectionInfo));
 }
 
 void
-Section::translateSectionKindStrToKind(const std::string & sKind, enum axlf_section_kind & eKind)
+Section::translateSectionKindStrToKind(const std::string & sectionName, 
+                                       enum axlf_section_kind & eKind)
 {
-  if (m_mapNameToId.find(sKind) == m_mapNameToId.end()) {
-    auto errMsg = boost::format("ERROR: Section '%s' isn't a valid section name.") % sKind;
+  auto & sections = getSectionTypes();
+  auto iter = std::find_if(sections.begin(), sections.end(), [&](const auto &entry) { return entry->getSectionName() == sectionName; });
+  if (iter == sections.end()) {
+    auto errMsg = boost::format("ERROR: Section '%s' isn't a valid section name.") % sectionName;
     throw std::runtime_error(errMsg.str());
   }
-  eKind = m_mapNameToId[sKind];
+  eKind = iter->get()->getType();
 }
 
 bool
-Section::supportsSubSections(enum axlf_section_kind &_eKind)
+Section::supportsSubSections(enum axlf_section_kind &eKind)
 {
-  if (m_mapIdToSubSectionSupport.find(_eKind) == m_mapIdToSubSectionSupport.end()) {
-    return false;   
+  auto &sections = getSectionTypes();
+
+  auto iter = std::find_if(sections.begin(), sections.end(), [&](const auto &entry) { return entry->getType() == eKind; });
+
+  if (iter == sections.end()) {
+    auto errMsg = boost::format("ERROR: The section kind value '%d' does not exist.") % eKind;
+    throw std::runtime_error(errMsg.str());
   }
-  return m_mapIdToSubSectionSupport[_eKind];
+
+  return iter->get()->getSupportsSubSections();
 }
 
 bool
-Section::supportsSectionIndex(enum axlf_section_kind &_eKind)
+Section::supportsSectionIndex(enum axlf_section_kind &eKind)
 {
-  if (m_mapIdToSectionIndexSupport.find(_eKind) == m_mapIdToSectionIndexSupport.end()) {
-    return false;   
+  auto & sections = getSectionTypes();
+
+  auto iter = std::find_if(sections.begin(), sections.end(), [&](const auto &entry) { return entry->getType() == eKind; });
+
+  if (iter == sections.end()) {
+    auto errMsg = boost::format("ERROR: The section kind value '%d' does not exist.") % eKind;
+    throw std::runtime_error(errMsg.str());
   }
-  return m_mapIdToSectionIndexSupport[_eKind];
+
+  return iter->get()->getSupportsIndexing();
 }
 
 // -------------------------------------------------------------------------
@@ -178,40 +268,53 @@ Section::getFormatType(const std::string _sFormatType)
   return FT_UNKNOWN;
 }
 
-bool 
-Section::getKindOfJSON(const std::string &_sJSONStr, enum axlf_section_kind &_eKind) {
-  if (_sJSONStr.empty() ||
-     (m_mapJSONNameToKind.find(_sJSONStr) == m_mapJSONNameToKind.end()) ) {
-    return false;
-  }
+enum axlf_section_kind 
+Section::getKindOfJSON(const std::string &nodeName) {
+  auto & sections = getSectionTypes();
+  auto iter = std::find_if(sections.begin(), sections.end(), [&](const auto &entry) { return entry->getNodeName() == nodeName; });
 
-  _eKind = m_mapJSONNameToKind[_sJSONStr];
-  return true;
-}
-
-std::string
-Section::getJSONOfKind(enum axlf_section_kind _eKind) {
-  return m_mapKindToJSONName[_eKind];
-}
-
-Section*
-Section::createSectionObjectOfKind( enum axlf_section_kind _eKind, 
-                                    const std::string _sIndexName) {
-  Section* pSection = nullptr;
-
-  if (m_mapIdToCtor.find(_eKind) == m_mapIdToCtor.end()) {
-    auto errMsg = boost::format("ERROR: Section constructor for the archive section ID '%d' does not exist.  This error is most likely the result of examining a newer version of an archive image than this version of software supports.") % (unsigned int)_eKind;
+  if (iter == sections.end()) {
+    auto errMsg = boost::format("ERROR: Node name '%s' does not map to a given section type.") % nodeName;
     throw std::runtime_error(errMsg.str());
   }
 
-  pSection = m_mapIdToCtor[_eKind]();
-  pSection->m_eKind = _eKind;
-  pSection->m_sKindName = m_mapIdToName[_eKind];
-  pSection->m_sIndexName = _sIndexName;
+  return iter->get()->getType();
+}
+
+std::string
+Section::getJSONOfKind(enum axlf_section_kind eKind) {
+  auto & sections = getSectionTypes();
+  auto iter = std::find_if(sections.begin(), sections.end(), [&](const auto &entry) { return entry->getType() == eKind; });
+
+  if (iter == sections.end()) {
+    auto errMsg = boost::format("ERROR: The given enum kind (%d) does not exist.") % eKind;
+    throw std::runtime_error(errMsg.str());
+  }
+
+  return iter->get()->getNodeName();
+}
+
+Section*
+Section::createSectionObjectOfKind( enum axlf_section_kind eKind, 
+                                    const std::string sIndexName) {
+  Section* pSection = nullptr;
+
+  auto & sections = getSectionTypes();
+  auto iter = std::find_if(sections.begin(), sections.end(), [&](const auto &entry) { return entry->getType() == eKind; });
+
+  if (iter == sections.end()) {
+    auto errMsg = boost::format("ERROR: Section constructor for the archive section ID '%d' does not exist.  This error is most likely the result of examining a newer version of an archive image than this version of software supports.") % eKind;
+    throw std::runtime_error(errMsg.str());
+  }
+
+  pSection = iter->get()->getCtor()();
+  pSection->m_eKind = eKind;
+  pSection->m_sKindName = iter->get()->getSectionName();
+  pSection->m_sIndexName = sIndexName;
 
   XUtil::TRACE(boost::format("Created segment: %s (%d), index: '%s'")
                              % pSection->getSectionKindAsString()
-                             % (unsigned int) pSection->getSectionKind()
+                             % pSection->getSectionKind()
                              % pSection->getSectionIndexName());
   return pSection;
 }

--- a/src/runtime_src/tools/xclbinutil/Section.h
+++ b/src/runtime_src/tools/xclbinutil/Section.h
@@ -39,25 +39,15 @@ class Section {
     SectionInfo() = delete;
 
    public:
-    SectionInfo(enum axlf_section_kind eKind, const std::string & secondName, Section_factory sectionCtor);   
-    void setNodeName(const std::string& sNodeName);
-    void setSupportsSubSections(bool bValue);
-    void setSupportsIndexing(bool bValue);
+    SectionInfo(enum axlf_section_kind eKind, std::string sectionName, Section_factory sectionCtor);   
 
-    enum axlf_section_kind getType() const;
-    const std::string &getSectionName() const;
-    Section_factory getCtor() const;
-    const std::string &getNodeName() const;
-    bool getSupportsSubSections() const;
-    bool getSupportsIndexing() const;
-
-   private:
-    enum axlf_section_kind m_eKind;       // The section enumeration value
-    std::string m_sectionName;            // Name of the section 
-    Section_factory m_sectionCtor;        // Section constructor
-    std::string m_nodeName;               // JSON node name
-    bool m_bSupportsSubSections;          // Support subsections
-    bool m_bSupportsIndexing;             // Supports indexing
+   public:
+    enum axlf_section_kind eKind;       // The section enumeration value
+    std::string name;                   // Name of the section 
+    Section_factory sectionCtor;        // Section constructor
+    std::string nodeName;               // JSON node name
+    bool supportsSubSections;           // Support subsections
+    bool supportsIndexing;              // Supports indexing
   };
 
  public:
@@ -77,7 +67,7 @@ class Section {
   static std::vector<std::unique_ptr<SectionInfo>> & getSectionTypes();
 
  public:
-  static void getKinds(std::vector< std::string > & kinds);
+  static std::vector<std::string> getSupportedKinds();
   static Section* createSectionObjectOfKind(enum axlf_section_kind _eKind, const std::string _sIndexName = "");
   static void translateSectionKindStrToKind(const std::string & sKind, enum axlf_section_kind & eKind);
   static axlf_section_kind getKindOfJSON(const std::string & nodeName);

--- a/src/runtime_src/tools/xclbinutil/XclBinClass.cxx
+++ b/src/runtime_src/tools/xclbinutil/XclBinClass.cxx
@@ -1128,11 +1128,7 @@ XclBin::addSections(ParameterSectionData& _PSD)
 
     XUtil::TRACE("Processing: '" + sectionName + "'");
 
-    enum axlf_section_kind eKind;
-    if (Section::getKindOfJSON(sectionName, eKind) == false) {
-      auto errMsg = boost::format("ERROR: Unknown JSON section '%s' in file: %s") % sectionName % sJSONFileName;
-      throw std::runtime_error(errMsg.str());
-    }
+    auto eKind = Section::getKindOfJSON(sectionName);    // Can throw
 
     Section* pSection = findSection(eKind);
     if (pSection != nullptr) {
@@ -1204,11 +1200,7 @@ XclBin::appendSections(ParameterSectionData& _PSD)
 
     XUtil::TRACE("Processing: '" + sectionName + "'");
 
-    enum axlf_section_kind eKind;
-    if (Section::getKindOfJSON(sectionName, eKind) == false) {
-      auto errMsg = boost::format("ERROR: Unknown JSON section '%s' in file: %s") % sectionName % sJSONFileName;
-      throw std::runtime_error(errMsg.str());
-    }
+    auto eKind = Section::getKindOfJSON(sectionName);  // Can throw
 
     Section* pSection = findSection(eKind);
 

--- a/src/runtime_src/tools/xclbinutil/XclBinUtilities.cxx
+++ b/src/runtime_src/tools/xclbinutil/XclBinUtilities.cxx
@@ -380,11 +380,10 @@ XclBinUtilities::stringToUInt64(const std::string& _sInteger, bool _bForceHex) {
 
 void
 XclBinUtilities::printKinds() {
-  std::vector< std::string > kinds;
-  Section::getKinds(kinds);
+  auto supportedKinds = Section::getSupportedKinds();
   std::cout << "All supported section names supported by this tool:\n";
-  for (auto & kind : kinds) {
-    std::cout << "  " << kind << "\n";
+  for (auto & entry : supportedKinds) {
+    std::cout << "  " << entry << "\n";
   }
 }
 


### PR DESCRIPTION
#### Problem solved by the commit
Note: This pull request is 1 of 2.  

- The first being cleaning up the how sections are added and used in the underlying section collection.  
- The second being updating the sections to use a helper class to register itself.

What was done:
+ Replaced multiple mapping collections with 1 vector collection of the registered sections.
+ Move the singleton collection into a get method that has it declared as a static.
+ Refactored the searching code to use C++11 syntax (e.g., find_if with lamndas)
+ Cleaned up some methods to no longer return back execution status.  In other words, exceptions are thrown.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
n/a

#### How problem was solved, alternative solutions (if any) and why they were rejected
n/a

#### Risks (if any) associated the changes in the commit
Risks low

#### What has been tested and how, request additional testing if necessary
Unit and manual testing

#### Documentation impact (if any)
n/a