### PR TITLE
Fix trace buffer allocation in multi-slr case

### DIFF
--- a/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.cpp
+++ b/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.cpp
@@ -59,7 +59,7 @@ AIETraceOffload::AIETraceOffload(void* handle, uint64_t id,
                  offloadStatus(AIEOffloadThreadStatus::IDLE)
 {
   bufAllocSz = (totalSz / numStream) & TRACE_BUFFER_4K_MASK;
-  if (bufAllocSz == 0)
+  if (bufAllocSz < TS2MM_MIN_BUF_SIZE)
     bufAllocSz = TS2MM_MIN_BUF_SIZE;
 }
 

--- a/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.cpp
+++ b/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.cpp
@@ -58,7 +58,9 @@ AIETraceOffload::AIETraceOffload(void* handle, uint64_t id,
                  bufferInitialized(false),
                  offloadStatus(AIEOffloadThreadStatus::IDLE)
 {
-  bufAllocSz = (totalSz / numStream) & 0xfffffffffffff000;
+  bufAllocSz = (totalSz / numStream) & TRACE_BUFFER_4K_MASK;
+  if (bufAllocSz == 0)
+    bufAllocSz = TS2MM_MIN_BUF_SIZE;
 }
 
 AIETraceOffload::~AIETraceOffload()

--- a/src/runtime_src/xdp/profile/device/tracedefs.h
+++ b/src/runtime_src/xdp/profile/device/tracedefs.h
@@ -21,6 +21,8 @@
 // Device timestamp is 45 bits so it can never be this value
 #define INVALID_DEVICE_TIMESTAMP 0xffffffffffffffff
 
+#define TRACE_BUFFER_4K_MASK  0xfffffffffffff000
+
 // Property bit masks
 #define XCL_PERF_MON_TRACE_MASK 0x1
 #define TS2MM_AIE_TRACE_MASK    0x1

--- a/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
@@ -188,7 +188,7 @@ namespace xdp {
 
       trace_buffer_size = GetTS2MMBufSize();
 
-      uint64_t each_buffer_size = (1 == num_ts2mm) ? trace_buffer_size : ((trace_buffer_size / num_ts2mm) % 0xfffffffffffff000);
+      uint64_t each_buffer_size = (1 == num_ts2mm) ? trace_buffer_size : ((trace_buffer_size / num_ts2mm) & 0xfffffffffffff000);
       buf_sizes.resize(num_ts2mm, each_buffer_size);
       for(size_t i = 0; i < num_ts2mm; i++) {
         Memory* memory = (db->getStaticInfo()).getMemory(deviceId, devInterface->getTS2MmMemIndex(i));

--- a/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
@@ -190,7 +190,7 @@ namespace xdp {
       trace_buffer_size = GetTS2MMBufSize();
 
       uint64_t each_buffer_size = (num_ts2mm == 1) ? trace_buffer_size : ((trace_buffer_size / num_ts2mm) & TRACE_BUFFER_4K_MASK);
-      if (each_buffer_size == 0)
+      if (each_buffer_size < TS2MM_MIN_BUF_SIZE)
         each_buffer_size = TS2MM_MIN_BUF_SIZE;
 
       buf_sizes.resize(num_ts2mm, each_buffer_size);

--- a/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
@@ -29,6 +29,7 @@
 #include "xdp/profile/plugin/vp_base/info.h"
 #include "xdp/profile/writer/device_trace/device_trace_writer.h"
 #include "xdp/profile/device/device_trace_logger.h"
+#include "xdp/profile/device/tracedefs.h"
 
 #include "core/common/config_reader.h"
 #include "core/common/message.h"
@@ -188,7 +189,10 @@ namespace xdp {
 
       trace_buffer_size = GetTS2MMBufSize();
 
-      uint64_t each_buffer_size = (1 == num_ts2mm) ? trace_buffer_size : ((trace_buffer_size / num_ts2mm) & 0xfffffffffffff000);
+      uint64_t each_buffer_size = (num_ts2mm == 1) ? trace_buffer_size : ((trace_buffer_size / num_ts2mm) & TRACE_BUFFER_4K_MASK);
+      if (each_buffer_size == 0)
+        each_buffer_size = TS2MM_MIN_BUF_SIZE;
+
       buf_sizes.resize(num_ts2mm, each_buffer_size);
       for(size_t i = 0; i < num_ts2mm; i++) {
         Memory* memory = (db->getStaticInfo()).getMemory(deviceId, devInterface->getTS2MmMemIndex(i));


### PR DESCRIPTION
Issue: trace buffer size limited to 4k per datamover if there are more than 1 PL datamovers
Fix: Correction in trace buffer logic. The trace buffers should be aligned to 4k and not limited to 4k
If trace buffer size calculation returns 0, we use the minimum size which is 8K