### PR TITLE
Adjust xrt::bo::get_bo_properties for MCDM

### DIFF
--- a/src/runtime_src/core/common/api/CMakeLists.txt
+++ b/src/runtime_src/core/common/api/CMakeLists.txt
@@ -28,6 +28,9 @@ if (DEFINED XRT_AIE_BUILD)
     aie/xrt_graph.cpp)
 endif()
 
+if (MCDM)
+  target_compile_definitions(core_common_api_library_objects PRIVATE MCDM)
+endif()
 
 target_include_directories(core_common_api_library_objects
   PRIVATE

--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -155,7 +155,8 @@ private:
     grpid = prop.flags & XRT_BO_FLAGS_MEMIDX_MASK;
     flags = static_cast<bo::flags>(prop.flags & ~XRT_BO_FLAGS_MEMIDX_MASK);
 
-#ifdef _WIN32 // All shims minus windows return proper flags
+#if defined(_WIN32) && !defined(MCDM)
+    // All shims minus windows return proper flags
     // Remove when driver returns the flags that were used to ctor the bo
     auto mem_topo = device->get_axlf_section<const ::mem_topology*>(ASK_GROUP_TOPOLOGY);
     grpid = xrt_core::xclbin::address_to_memidx(mem_topo, addr);


### PR DESCRIPTION
#### Problem solved by the commit
Conditional code for computing group index on windows must be removed
for MCDM where the proper BO flags are returned.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Debugging encountered wrong flags.

#### How problem was solved, alternative solutions (if any) and why they were rejected
MCMD is already a CMake variable, use it to set a target_compile_defintion.
