### PR TITLE
xclbinutil : Phase 2 regarding how sections are registered

### DIFF
--- a/src/runtime_src/tools/xclbinutil/ParameterSectionData.cxx
+++ b/src/runtime_src/tools/xclbinutil/ParameterSectionData.cxx
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Xilinx, Inc
+ * Copyright (C) 2018, 2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -23,7 +23,7 @@
 namespace XUtil = XclBinUtilities;
 
 ParameterSectionData::ParameterSectionData(const std::string &_formattedString)
-  : m_formatType(Section::FT_UNKNOWN)
+  : m_formatType(Section::FormatType::UNKNOWN)
   , m_formatTypeStr("")
   , m_file("")
   , m_section("")
@@ -98,7 +98,7 @@ ParameterSectionData::transformFormattedString(const std::string _formattedStrin
   // -- Retrieve the section --
   std::string sSection = tokens[0];
   
-  if ( sSection.empty() && (m_formatType != Section::FT_JSON)) {
+  if ( sSection.empty() && (m_formatType != Section::FormatType::JSON)) {
     std::string errMsg = "Error: Empty sections names are only permitted with JSON format files.";
     throw std::runtime_error(errMsg);
   }

--- a/src/runtime_src/tools/xclbinutil/Section.h
+++ b/src/runtime_src/tools/xclbinutil/Section.h
@@ -34,6 +34,16 @@
 class Section {
  typedef std::function<Section*()> Section_factory;
 
+ public:
+  enum class FormatType{
+    UNDEFINED,
+    UNKNOWN,
+    RAW,
+    JSON,
+    HTML,
+    TXT
+  };
+
  protected:
   class SectionInfo {
     SectionInfo() = delete;
@@ -48,16 +58,8 @@ class Section {
     std::string nodeName;               // JSON node name
     bool supportsSubSections;           // Support subsections
     bool supportsIndexing;              // Supports indexing
-  };
-
- public:
-  enum FormatType{
-    FT_UNDEFINED,
-    FT_UNKNOWN,
-    FT_RAW,
-    FT_JSON,
-    FT_HTML,
-    FT_TXT
+    std::vector<FormatType> supportedAddFormats;  // Supported add format
+    std::vector<FormatType> supportedDumpFormats; // Supported dump formats
   };
 
  public:
@@ -66,13 +68,16 @@ class Section {
  private:
   static std::vector<std::unique_ptr<SectionInfo>> & getSectionTypes();
 
+ protected:
+  static void addSectionType(std::unique_ptr<SectionInfo> sectionInfo);
+
  public:
   static std::vector<std::string> getSupportedKinds();
   static Section* createSectionObjectOfKind(enum axlf_section_kind _eKind, const std::string _sIndexName = "");
   static void translateSectionKindStrToKind(const std::string & sKind, enum axlf_section_kind & eKind);
   static axlf_section_kind getKindOfJSON(const std::string & nodeName);
   static std::string getJSONOfKind(enum axlf_section_kind _eKind);
-  static enum FormatType getFormatType(const std::string _sFormatType);
+  static enum FormatType getFormatType(const std::string & sFormatType);
   static bool supportsSubSections(enum axlf_section_kind &_eKind);
   static bool supportsSectionIndex(enum axlf_section_kind &_eKind);
 
@@ -121,9 +126,6 @@ class Section {
 
  protected:
   Section();
-
- protected:
-  static void registerSectionCtor(enum axlf_section_kind _eKind, const std::string& _sKindStr, const std::string& _sHeaderJSONName, bool _bSupportsSubSections, bool _bSupportsIndexing, Section_factory _Section_factory);
 
  protected:
   enum axlf_section_kind m_eKind;

--- a/src/runtime_src/tools/xclbinutil/SectionAIEMetadata.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionAIEMetadata.cxx
@@ -26,8 +26,11 @@ namespace XUtil = XclBinUtilities;
 // ----------------------------------------------------------------------------
 SectionAIEMetadata::init SectionAIEMetadata::initializer;
 
-SectionAIEMetadata::init::init() {
-  registerSectionCtor(AIE_METADATA, "AIE_METADATA", "", false, false, boost::factory<SectionAIEMetadata*>()); 
+SectionAIEMetadata::init::init() 
+{
+  auto sectionInfo = std::make_unique<SectionInfo>(AIE_METADATA, "AIE_METADATA", boost::factory<SectionAIEMetadata*>());
+
+  addSectionType(std::move(sectionInfo));
 }
 // ----------------------------------------------------------------------------
 
@@ -72,8 +75,8 @@ SectionAIEMetadata::marshalFromJSON( const boost::property_tree::ptree& _ptSecti
 bool 
 SectionAIEMetadata::doesSupportAddFormatType(FormatType _eFormatType) const
 {
-  if ((_eFormatType == FT_JSON) ||
-      (_eFormatType == FT_RAW)) {
+  if ((_eFormatType == FormatType::JSON) ||
+      (_eFormatType == FormatType::RAW)) {
     return true;
   }
   return false;
@@ -82,12 +85,10 @@ SectionAIEMetadata::doesSupportAddFormatType(FormatType _eFormatType) const
 bool 
 SectionAIEMetadata::doesSupportDumpFormatType(FormatType _eFormatType) const
 {
-    if ((_eFormatType == FT_JSON) ||
-        (_eFormatType == FT_HTML)) {
+    if ((_eFormatType == FormatType::JSON) ||
+        (_eFormatType == FormatType::HTML)) {
       return true;
     }
     return false;
 }
-
-
 

--- a/src/runtime_src/tools/xclbinutil/SectionAIEPartition.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionAIEPartition.cxx
@@ -25,8 +25,12 @@ namespace XUtil = XclBinUtilities;
 // Static Variables / Classes
 SectionAIEPartition::init SectionAIEPartition::initializer;
 
-SectionAIEPartition::init::init() {
-  registerSectionCtor(AIE_PARTITION, "AIE_PARTITION", "aie_partition", false, false, boost::factory<SectionAIEPartition*>()); 
+SectionAIEPartition::init::init() 
+{
+  auto sectionInfo = std::make_unique<SectionInfo>(AIE_PARTITION, "AIE_PARTITION", boost::factory<SectionAIEPartition*>());
+  sectionInfo->nodeName = "aie_partition";
+
+  addSectionType(std::move(sectionInfo));
 }
 
 void
@@ -149,13 +153,13 @@ SectionAIEPartition::marshalFromJSON(const boost::property_tree::ptree& ptSectio
 bool
 SectionAIEPartition::doesSupportAddFormatType(FormatType eFormatType) const
 {
-  return (eFormatType == FT_JSON); 
+  return (eFormatType == FormatType::JSON); 
 }
 
 bool
 SectionAIEPartition::doesSupportDumpFormatType(FormatType eFormatType) const
 {
-  return ((eFormatType == FT_JSON) ||
-          (eFormatType == FT_HTML) ||
-          (eFormatType == FT_RAW));
+  return ((eFormatType == FormatType::JSON) ||
+          (eFormatType == FormatType::HTML) ||
+          (eFormatType == FormatType::RAW));
 }

--- a/src/runtime_src/tools/xclbinutil/SectionAIEResources.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionAIEResources.cxx
@@ -23,7 +23,8 @@ SectionAIEResources::init SectionAIEResources::initializer;
 
 SectionAIEResources::init::init() 
 { 
-  registerSectionCtor(AIE_RESOURCES, "AIE_RESOURCES", "", false, false, boost::factory<SectionAIEResources*>()); 
+  auto sectionInfo = std::make_unique<SectionInfo>(AIE_RESOURCES, "AIE_RESOURCES", boost::factory<SectionAIEResources*>());
+  addSectionType(std::move(sectionInfo));
 }
 
 

--- a/src/runtime_src/tools/xclbinutil/SectionBMC.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionBMC.cxx
@@ -34,14 +34,17 @@ SectionBMC::init SectionBMC::initializer;
 
 SectionBMC::init::init() 
 {
-  registerSectionCtor(BMC, "BMC", "", true, false, boost::factory<SectionBMC*>()); 
+  auto sectionInfo = std::make_unique<SectionInfo>(BMC, "BMC", boost::factory<SectionBMC*>()); 
+  sectionInfo->supportsSubSections = true;
+
+  addSectionType(std::move(sectionInfo));
 }
 // -------------------------------------------------------------------------
 
 bool 
 SectionBMC::doesSupportAddFormatType(FormatType _eFormatType) const
 {
-  // The BMC top-level section does support any add syntax.  
+  // The BMC top-level section doesn't support any add syntax.  
   // Must use sub-sections
   return false;
 }
@@ -288,7 +291,7 @@ SectionBMC::readSubPayload(const char* _pOrigDataSection,
         throw std::runtime_error(errMsg);
       }
 
-      if (_eFormatType != Section::FT_RAW) {
+      if (_eFormatType != Section::FormatType::RAW) {
         std::string errMsg = "ERROR: BMC-FW only supports the RAW format.";
         throw std::runtime_error(errMsg);
       }
@@ -304,7 +307,7 @@ SectionBMC::readSubPayload(const char* _pOrigDataSection,
           throw std::runtime_error(errMsg);
         }
 
-        if (_eFormatType != Section::FT_JSON) {
+        if (_eFormatType != Section::FormatType::JSON) {
           std::string errMsg = "ERROR: BMC-METADATA only supports the JSON format.";
           throw std::runtime_error(errMsg);
         }
@@ -390,7 +393,7 @@ SectionBMC::writeSubPayload(const std::string & _sSubSectionName,
   switch (eSubSection) {
     case SS_FW:
       // Some basic DRC checks
-      if (_eFormatType != Section::FT_RAW) {
+      if (_eFormatType != Section::FormatType::RAW) {
         std::string errMsg = "ERROR: BMC-FW only supports the RAW format.";
         throw std::runtime_error(errMsg);
       }
@@ -400,7 +403,7 @@ SectionBMC::writeSubPayload(const std::string & _sSubSectionName,
 
     case SS_METADATA:
       {
-        if (_eFormatType != Section::FT_JSON) {
+        if (_eFormatType != Section::FormatType::JSON) {
           std::string errMsg = "ERROR: BMC-METADATA only supports the JSON format.";
           throw std::runtime_error(errMsg);
         }

--- a/src/runtime_src/tools/xclbinutil/SectionBitstream.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionBitstream.cxx
@@ -26,7 +26,9 @@ SectionBitstream::init SectionBitstream::initializer;
 
 SectionBitstream::init::init() 
 { 
-  registerSectionCtor(BITSTREAM, "BITSTREAM", "", false, false, boost::factory<SectionBitstream*>()); 
+  auto sectionInfo = std::make_unique<SectionInfo>(BITSTREAM, "BITSTREAM", boost::factory<SectionBitstream*>());
+
+  addSectionType(std::move(sectionInfo));
 }
 
 std::string

--- a/src/runtime_src/tools/xclbinutil/SectionBitstreamPartialPDI.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionBitstreamPartialPDI.cxx
@@ -23,7 +23,9 @@ SectionBitstreamPartialPDI::init SectionBitstreamPartialPDI::initializer;
 
 SectionBitstreamPartialPDI::init::init() 
 { 
-  registerSectionCtor(BITSTREAM_PARTIAL_PDI, "BITSTREAM_PARTIAL_PDI", "", false, false, boost::factory<SectionBitstreamPartialPDI*>()); 
+  auto sectionInfo = std::make_unique<SectionInfo>(BITSTREAM_PARTIAL_PDI, "BITSTREAM_PARTIAL_PDI", boost::factory<SectionBitstreamPartialPDI*>()); 
+
+  addSectionType(std::move(sectionInfo));
 }
 
 

--- a/src/runtime_src/tools/xclbinutil/SectionBuildMetadata.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionBuildMetadata.cxx
@@ -28,7 +28,10 @@ SectionBuildMetadata::init SectionBuildMetadata::initializer;
 
 SectionBuildMetadata::init::init() 
 { 
-  registerSectionCtor(BUILD_METADATA, "BUILD_METADATA", "build_metadata", false, false, boost::factory<SectionBuildMetadata*>()); 
+  auto sectionInfo = std::make_unique<SectionInfo>(BUILD_METADATA, "BUILD_METADATA", boost::factory<SectionBuildMetadata*>()); 
+  sectionInfo->nodeName = "build_metadata";
+
+  addSectionType(std::move(sectionInfo));
 }
 
 void 
@@ -75,8 +78,8 @@ SectionBuildMetadata::marshalFromJSON(const boost::property_tree::ptree& _ptSect
 bool 
 SectionBuildMetadata::doesSupportAddFormatType(FormatType _eFormatType) const
 {
-  if ((_eFormatType == FT_JSON) ||
-      (_eFormatType == FT_RAW)){
+  if ((_eFormatType == FormatType::JSON) ||
+      (_eFormatType == FormatType::RAW)){
     return true;
   }
   return false;
@@ -85,8 +88,8 @@ SectionBuildMetadata::doesSupportAddFormatType(FormatType _eFormatType) const
 bool 
 SectionBuildMetadata::doesSupportDumpFormatType(FormatType _eFormatType) const
 {
-    if ((_eFormatType == FT_JSON) ||
-        (_eFormatType == FT_HTML))
+    if ((_eFormatType == FormatType::JSON) ||
+        (_eFormatType == FormatType::HTML))
     {
       return true;
     }

--- a/src/runtime_src/tools/xclbinutil/SectionClearBitstream.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionClearBitstream.cxx
@@ -23,7 +23,9 @@ SectionClearBitstream::init SectionClearBitstream::initializer;
 
 SectionClearBitstream::init::init() 
 { 
-  registerSectionCtor(CLEARING_BITSTREAM, "CLEARING_BITSTREAM", "", false, false, boost::factory<SectionClearBitstream*>()); 
+  auto sectionInfo = std::make_unique<SectionInfo>(CLEARING_BITSTREAM, "CLEARING_BITSTREAM", boost::factory<SectionClearBitstream*>()); 
+
+  addSectionType(std::move(sectionInfo));
 }
 
 

--- a/src/runtime_src/tools/xclbinutil/SectionClockFrequencyTopology.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionClockFrequencyTopology.cxx
@@ -29,7 +29,10 @@ SectionClockFrequencyTopology::init SectionClockFrequencyTopology::initializer;
 
 SectionClockFrequencyTopology::init::init() 
 { 
-  registerSectionCtor(CLOCK_FREQ_TOPOLOGY, "CLOCK_FREQ_TOPOLOGY", "clock_freq_topology", false, false, boost::factory<SectionClockFrequencyTopology*>()); 
+  auto sectionInfo = std::make_unique<SectionInfo>(CLOCK_FREQ_TOPOLOGY, "CLOCK_FREQ_TOPOLOGY", boost::factory<SectionClockFrequencyTopology*>()); 
+  sectionInfo->nodeName = "clock_freq_topology"; 
+
+  addSectionType(std::move(sectionInfo));
 }
 
 const std::string
@@ -198,7 +201,7 @@ SectionClockFrequencyTopology::marshalFromJSON(const boost::property_tree::ptree
 bool 
 SectionClockFrequencyTopology::doesSupportAddFormatType(FormatType _eFormatType) const
 {
-  if (_eFormatType == FT_JSON) {
+  if (_eFormatType == FormatType::JSON) {
     return true;
   }
   return false;
@@ -207,9 +210,9 @@ SectionClockFrequencyTopology::doesSupportAddFormatType(FormatType _eFormatType)
 bool 
 SectionClockFrequencyTopology::doesSupportDumpFormatType(FormatType _eFormatType) const
 {
-    if ((_eFormatType == FT_JSON) ||
-        (_eFormatType == FT_HTML) ||
-        (_eFormatType == FT_RAW))
+    if ((_eFormatType == FormatType::JSON) ||
+        (_eFormatType == FormatType::HTML) ||
+        (_eFormatType == FormatType::RAW))
     {
       return true;
     }

--- a/src/runtime_src/tools/xclbinutil/SectionConnectivity.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionConnectivity.cxx
@@ -28,7 +28,10 @@ SectionConnectivity::init SectionConnectivity::initializer;
 
 SectionConnectivity::init::init() 
 { 
-  registerSectionCtor(CONNECTIVITY, "CONNECTIVITY", "connectivity", false, false, boost::factory<SectionConnectivity*>()); 
+  auto sectionInfo = std::make_unique<SectionInfo>(CONNECTIVITY, "CONNECTIVITY", boost::factory<SectionConnectivity*>());  
+  sectionInfo->nodeName = "connectivity";
+
+  addSectionType(std::move(sectionInfo));
 }
 
 void
@@ -156,7 +159,7 @@ SectionConnectivity::marshalFromJSON(const boost::property_tree::ptree& _ptSecti
 bool 
 SectionConnectivity::doesSupportAddFormatType(FormatType _eFormatType) const
 {
-  if (_eFormatType == FT_JSON) {
+  if (_eFormatType == FormatType::JSON) {
     return true;
   }
   return false;
@@ -165,9 +168,9 @@ SectionConnectivity::doesSupportAddFormatType(FormatType _eFormatType) const
 bool 
 SectionConnectivity::doesSupportDumpFormatType(FormatType _eFormatType) const
 {
-    if ((_eFormatType == FT_JSON) ||
-        (_eFormatType == FT_HTML) ||
-        (_eFormatType == FT_RAW))
+    if ((_eFormatType == FormatType::JSON) ||
+        (_eFormatType == FormatType::HTML) ||
+        (_eFormatType == FormatType::RAW))
     {
       return true;
     }

--- a/src/runtime_src/tools/xclbinutil/SectionDNACertificate.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionDNACertificate.cxx
@@ -28,7 +28,9 @@ SectionDNACertificate::init SectionDNACertificate::initializer;
 
 SectionDNACertificate::init::init() 
 { 
-  registerSectionCtor(DNA_CERTIFICATE, "DNA_CERTIFICATE", "", false, false, boost::factory<SectionDNACertificate*>()); 
+  auto sectionInfo = std::make_unique<SectionInfo>(DNA_CERTIFICATE, "DNA_CERTIFICATE", boost::factory<SectionDNACertificate*>()); 
+
+  addSectionType(std::move(sectionInfo));
 }
 
 #define signatureSizeBytes 512
@@ -124,9 +126,9 @@ SectionDNACertificate::marshalToJSON(char* _pDataSection,
 bool 
 SectionDNACertificate::doesSupportDumpFormatType(FormatType _eFormatType) const
 {
-    if ((_eFormatType == FT_JSON) ||
-        (_eFormatType == FT_HTML) ||
-        (_eFormatType == FT_RAW))
+    if ((_eFormatType == FormatType::JSON) ||
+        (_eFormatType == FormatType::HTML) ||
+        (_eFormatType == FormatType::RAW))
     {
       return true;
     }

--- a/src/runtime_src/tools/xclbinutil/SectionDebugData.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionDebugData.cxx
@@ -23,7 +23,9 @@ SectionDebugData::init SectionDebugData::initializer;
 
 SectionDebugData::init::init() 
 { 
-  registerSectionCtor(DEBUG_DATA, "DEBUG_DATA", "", false, false, boost::factory<SectionDebugData*>());
+  auto sectionInfo = std::make_unique<SectionInfo>(DEBUG_DATA, "DEBUG_DATA", boost::factory<SectionDebugData*>());
+
+  addSectionType(std::move(sectionInfo));
 }
 
 

--- a/src/runtime_src/tools/xclbinutil/SectionDebugIPLayout.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionDebugIPLayout.cxx
@@ -28,7 +28,10 @@ SectionDebugIPLayout::init SectionDebugIPLayout::initializer;
 
 SectionDebugIPLayout::init::init() 
 { 
-  registerSectionCtor(DEBUG_IP_LAYOUT, "DEBUG_IP_LAYOUT", "debug_ip_layout", false, false, boost::factory<SectionDebugIPLayout*>()); 
+  auto sectionInfo = std::make_unique<SectionInfo>(DEBUG_IP_LAYOUT, "DEBUG_IP_LAYOUT", boost::factory<SectionDebugIPLayout*>()); 
+  sectionInfo->nodeName = "debug_ip_layout";
+
+  addSectionType(std::move(sectionInfo));
 }
 
 const std::string
@@ -303,7 +306,7 @@ SectionDebugIPLayout::marshalFromJSON(const boost::property_tree::ptree& _ptSect
 bool 
 SectionDebugIPLayout::doesSupportAddFormatType(FormatType _eFormatType) const
 {
-  if (_eFormatType == FT_JSON) {
+  if (_eFormatType == FormatType::JSON) {
     return true;
   }
   return false;
@@ -312,9 +315,9 @@ SectionDebugIPLayout::doesSupportAddFormatType(FormatType _eFormatType) const
 bool 
 SectionDebugIPLayout::doesSupportDumpFormatType(FormatType _eFormatType) const
 {
-    if ((_eFormatType == FT_JSON) ||
-        (_eFormatType == FT_HTML) ||
-        (_eFormatType == FT_RAW))
+    if ((_eFormatType == FormatType::JSON) ||
+        (_eFormatType == FormatType::HTML) ||
+        (_eFormatType == FormatType::RAW))
     {
       return true;
     }

--- a/src/runtime_src/tools/xclbinutil/SectionDesignCheckPoint.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionDesignCheckPoint.cxx
@@ -23,7 +23,9 @@ SectionDesignCheckPoint::init SectionDesignCheckPoint::initializer;
 
 SectionDesignCheckPoint::init::init() 
 { 
-  registerSectionCtor(DESIGN_CHECK_POINT, "DESIGN_CHECKPOINT", "", false, false, boost::factory<SectionDesignCheckPoint*>()); 
+  auto sectionInfo = std::make_unique<SectionInfo>(DESIGN_CHECK_POINT, "DESIGN_CHECKPOINT", boost::factory<SectionDesignCheckPoint*>()); 
+
+  addSectionType(std::move(sectionInfo));
 }
 
 

--- a/src/runtime_src/tools/xclbinutil/SectionEmbeddedMetadata.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionEmbeddedMetadata.cxx
@@ -27,7 +27,9 @@ SectionEmbeddedMetadata::init SectionEmbeddedMetadata::initializer;
 
 SectionEmbeddedMetadata::init::init() 
 { 
-  registerSectionCtor(EMBEDDED_METADATA, "EMBEDDED_METADATA", "", false, false, boost::factory<SectionEmbeddedMetadata*>()); 
+  auto sectionInfo = std::make_unique<SectionInfo>(EMBEDDED_METADATA, "EMBEDDED_METADATA", boost::factory<SectionEmbeddedMetadata*>()); 
+
+  addSectionType(std::move(sectionInfo));
 }
 
 void

--- a/src/runtime_src/tools/xclbinutil/SectionEmulationData.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionEmulationData.cxx
@@ -23,7 +23,9 @@ SectionEmulationData::init SectionEmulationData::initializer;
 
 SectionEmulationData::init::init() 
 { 
-  registerSectionCtor(EMULATION_DATA, "EMULATION_DATA", "", false, false, boost::factory<SectionEmulationData*>()); 
+  auto sectionInfo = std::make_unique<SectionInfo>(EMULATION_DATA, "EMULATION_DATA", boost::factory<SectionEmulationData*>()); 
+
+  addSectionType(std::move(sectionInfo));
 }
 
 

--- a/src/runtime_src/tools/xclbinutil/SectionFlash.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionFlash.cxx
@@ -34,14 +34,18 @@ SectionFlash::init SectionFlash::initializer;
 
 SectionFlash::init::init() 
 { 
-  registerSectionCtor(ASK_FLASH, "FLASH", "", true, true, boost::factory<SectionFlash*>()); 
+  auto sectionInfo = std::make_unique<SectionInfo>(ASK_FLASH, "FLASH", boost::factory<SectionFlash*>()); 
+  sectionInfo->supportsSubSections = true;
+  sectionInfo->supportsIndexing = true;
+
+  addSectionType(std::move(sectionInfo));
 }
 
 // -------------------------------------------------------------------------
 
 bool
 SectionFlash::doesSupportAddFormatType(FormatType _eFormatType) const {
-  // The FLASH top-level section does support any add syntax.
+  // The FLASH top-level section doesn't support any add syntax.
   // Must use sub-sections
   return false;
 }
@@ -352,7 +356,7 @@ SectionFlash::readSubPayload(const char* _pOrigDataSection,
         throw std::runtime_error(errMsg);
       }
 
-      if (_eFormatType != Section::FT_RAW) {
+      if (_eFormatType != Section::FormatType::RAW) {
         std::string errMsg = "ERROR: Flash DATA image only supports the RAW format.";
         throw std::runtime_error(errMsg);
       }
@@ -367,7 +371,7 @@ SectionFlash::readSubPayload(const char* _pOrigDataSection,
           throw std::runtime_error(errMsg);
         }
 
-        if (_eFormatType != Section::FT_JSON) {
+        if (_eFormatType != Section::FormatType::JSON) {
           std::string errMsg = "ERROR: FLASH[]-METADATA only supports the JSON format.";
           throw std::runtime_error(errMsg);
         }
@@ -464,7 +468,7 @@ SectionFlash::writeSubPayload(const std::string& _sSubSectionName,
   switch (eSubSection) {
     case SS_DATA:
       // Some basic DRC checks
-      if (_eFormatType != Section::FT_RAW) {
+      if (_eFormatType != Section::FormatType::RAW) {
         std::string errMsg = "ERROR: FLASH[]-DATA only supports the RAW format.";
         throw std::runtime_error(errMsg);
       }
@@ -473,7 +477,7 @@ SectionFlash::writeSubPayload(const std::string& _sSubSectionName,
       break;
 
     case SS_METADATA: {
-        if (_eFormatType != Section::FT_JSON) {
+        if (_eFormatType != Section::FormatType::JSON) {
           std::string errMsg = "ERROR: FLASH[]-METADATA only supports the JSON format.";
           throw std::runtime_error(errMsg);
         }

--- a/src/runtime_src/tools/xclbinutil/SectionGroupConnectivity.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionGroupConnectivity.cxx
@@ -28,7 +28,10 @@ SectionGroupConnectivity::init SectionGroupConnectivity::initializer;
 
 SectionGroupConnectivity::init::init() 
 { 
-  registerSectionCtor(ASK_GROUP_CONNECTIVITY, "GROUP_CONNECTIVITY", "group_connectivity", false, false, boost::factory<SectionGroupConnectivity*>()); 
+  auto sectionInfo = std::make_unique<SectionInfo>(ASK_GROUP_CONNECTIVITY, "GROUP_CONNECTIVITY", boost::factory<SectionGroupConnectivity*>()); 
+  sectionInfo->nodeName = "group_connectivity";
+
+  addSectionType(std::move(sectionInfo));
 }
 
 void
@@ -154,7 +157,7 @@ SectionGroupConnectivity::marshalFromJSON(const boost::property_tree::ptree& _pt
 bool 
 SectionGroupConnectivity::doesSupportAddFormatType(FormatType _eFormatType) const
 {
-  if (_eFormatType == FT_JSON) {
+  if (_eFormatType == FormatType::JSON) {
     return true;
   }
   return false;
@@ -163,9 +166,9 @@ SectionGroupConnectivity::doesSupportAddFormatType(FormatType _eFormatType) cons
 bool 
 SectionGroupConnectivity::doesSupportDumpFormatType(FormatType _eFormatType) const
 {
-    if ((_eFormatType == FT_JSON) ||
-        (_eFormatType == FT_HTML) ||
-        (_eFormatType == FT_RAW))
+    if ((_eFormatType == FormatType::JSON) ||
+        (_eFormatType == FormatType::HTML) ||
+        (_eFormatType == FormatType::RAW))
     {
       return true;
     }

--- a/src/runtime_src/tools/xclbinutil/SectionGroupTopology.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionGroupTopology.cxx
@@ -28,7 +28,10 @@ SectionGroupTopology::init SectionGroupTopology::initializer;
 
 SectionGroupTopology::init::init() 
 { 
-  registerSectionCtor(ASK_GROUP_TOPOLOGY, "GROUP_TOPOLOGY", "group_topology", false, false, boost::factory<SectionGroupTopology*>()); 
+  auto sectionInfo = std::make_unique<SectionInfo>(ASK_GROUP_TOPOLOGY, "GROUP_TOPOLOGY", boost::factory<SectionGroupTopology*>()); 
+  sectionInfo->nodeName = "group_topology";
+
+  addSectionType(std::move(sectionInfo));
 }
 
 const std::string
@@ -279,7 +282,7 @@ SectionGroupTopology::marshalFromJSON(const boost::property_tree::ptree& _ptSect
 bool 
 SectionGroupTopology::doesSupportAddFormatType(FormatType _eFormatType) const
 {
-  if (_eFormatType == FT_JSON) {
+  if (_eFormatType == FormatType::JSON) {
     return true;
   }
   return false;
@@ -288,9 +291,9 @@ SectionGroupTopology::doesSupportAddFormatType(FormatType _eFormatType) const
 bool 
 SectionGroupTopology::doesSupportDumpFormatType(FormatType _eFormatType) const
 {
-    if ((_eFormatType == FT_JSON) ||
-        (_eFormatType == FT_HTML) ||
-        (_eFormatType == FT_RAW))
+    if ((_eFormatType == FormatType::JSON) ||
+        (_eFormatType == FormatType::HTML) ||
+        (_eFormatType == FormatType::RAW))
     {
       return true;
     }

--- a/src/runtime_src/tools/xclbinutil/SectionIPLayout.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionIPLayout.cxx
@@ -28,7 +28,10 @@ SectionIPLayout::init SectionIPLayout::initializer;
 
 SectionIPLayout::init::init() 
 { 
-  registerSectionCtor(IP_LAYOUT, "IP_LAYOUT", "ip_layout", false, false, boost::factory<SectionIPLayout*>()); 
+  auto sectionInfo = std::make_unique<SectionInfo>(IP_LAYOUT, "IP_LAYOUT", boost::factory<SectionIPLayout*>()); 
+  sectionInfo->nodeName = "ip_layout";
+
+  addSectionType(std::move(sectionInfo));
 }
 
 
@@ -375,7 +378,7 @@ SectionIPLayout::marshalFromJSON(const boost::property_tree::ptree& _ptSection,
 bool 
 SectionIPLayout::doesSupportAddFormatType(FormatType _eFormatType) const
 {
-  if (_eFormatType == FT_JSON) {
+  if (_eFormatType == FormatType::JSON) {
     return true;
   }
   return false;
@@ -384,9 +387,9 @@ SectionIPLayout::doesSupportAddFormatType(FormatType _eFormatType) const
 bool 
 SectionIPLayout::doesSupportDumpFormatType(FormatType _eFormatType) const
 {
-  if ((_eFormatType == FT_JSON) ||
-      (_eFormatType == FT_HTML) ||
-      (_eFormatType == FT_RAW))
+  if ((_eFormatType == FormatType::JSON) ||
+      (_eFormatType == FormatType::HTML) ||
+      (_eFormatType == FormatType::RAW))
   {
     return true;
   }

--- a/src/runtime_src/tools/xclbinutil/SectionKeyValueMetadata.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionKeyValueMetadata.cxx
@@ -27,7 +27,10 @@ SectionKeyValueMetadata::init SectionKeyValueMetadata::initializer;
 
 SectionKeyValueMetadata::init::init() 
 { 
-  registerSectionCtor(KEYVALUE_METADATA, "KEYVALUE_METADATA", "keyvalue_metadata", false, false, boost::factory<SectionKeyValueMetadata*>()); 
+  auto sectionInfo = std::make_unique<SectionInfo>(KEYVALUE_METADATA, "KEYVALUE_METADATA", boost::factory<SectionKeyValueMetadata*>()); 
+  sectionInfo->nodeName = "keyvalue_metadata";
+
+  addSectionType(std::move(sectionInfo));
 }
 
 void 
@@ -94,7 +97,7 @@ SectionKeyValueMetadata::marshalFromJSON(const boost::property_tree::ptree& _ptS
 bool 
 SectionKeyValueMetadata::doesSupportAddFormatType(FormatType _eFormatType) const
 {
-  if (_eFormatType == FT_JSON) {
+  if (_eFormatType == FormatType::JSON) {
     return true;
   }
   return false;
@@ -103,8 +106,8 @@ SectionKeyValueMetadata::doesSupportAddFormatType(FormatType _eFormatType) const
 bool 
 SectionKeyValueMetadata::doesSupportDumpFormatType(FormatType _eFormatType) const
 {
-    if ((_eFormatType == FT_JSON) ||
-        (_eFormatType == FT_HTML))
+    if ((_eFormatType == FormatType::JSON) ||
+        (_eFormatType == FormatType::HTML))
     {
       return true;
     }

--- a/src/runtime_src/tools/xclbinutil/SectionMCS.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionMCS.cxx
@@ -34,7 +34,10 @@ SectionMCS::init SectionMCS::initializer;
 
 SectionMCS::init::init() 
 { 
-  registerSectionCtor(MCS, "MCS", "", true, false, boost::factory<SectionMCS*>()); 
+  auto sectionInfo = std::make_unique<SectionInfo>(MCS, "MCS", boost::factory<SectionMCS*>());
+  sectionInfo->supportsSubSections = true;
+
+  addSectionType(std::move(sectionInfo));
 }
 
 // --------------------------------------------------------------------------
@@ -134,7 +137,7 @@ SectionMCS::getSubPayload(char* _pDataSection,
   }
 
   // Make sure we support the format type
-  if (_eFormatType != FT_RAW) {
+  if (_eFormatType != FormatType::RAW) {
     auto errMsg = boost::format("ERROR: For section '%s' the format type (%d) is not supported.") % getSectionKindAsString() % (unsigned int) _eFormatType;
     throw std::runtime_error(errMsg.str());
   }
@@ -302,7 +305,7 @@ SectionMCS::readSubPayload(const char* _pOrigDataSection,
   }
 
   // Validate format type
-  if (_eFormatType != Section::FT_RAW) {
+  if (_eFormatType != Section::FormatType::RAW) {
       auto errMsg = boost::format("ERROR: Section '%s' only supports 'RAW' subsections.") % getSectionKindAsString();
     throw std::runtime_error(errMsg.str());
   }
@@ -408,7 +411,7 @@ SectionMCS::writeSubPayload(const std::string & _sSubSectionName,
                             FormatType _eFormatType, 
                             std::fstream&  _oStream) const {
   // Validate format type
-  if (_eFormatType != Section::FT_RAW) {
+  if (_eFormatType != Section::FormatType::RAW) {
     auto errMsg = boost::format("ERROR: Section '%s' only supports 'RAW' subsections.") % getSectionKindAsString();
     throw std::runtime_error(errMsg.str());
   }

--- a/src/runtime_src/tools/xclbinutil/SectionManagementFW.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionManagementFW.cxx
@@ -23,7 +23,9 @@ SectionManagementFW::init SectionManagementFW::initializer;
 
 SectionManagementFW::init::init() 
 { 
-  registerSectionCtor(FIRMWARE, "FIRMWARE", "", false, false, boost::factory<SectionManagementFW*>()); 
+  auto sectionInfo = std::make_unique<SectionInfo>(FIRMWARE, "FIRMWARE", boost::factory<SectionManagementFW*>()); 
+
+  addSectionType(std::move(sectionInfo));
 }
 
 

--- a/src/runtime_src/tools/xclbinutil/SectionMemTopology.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionMemTopology.cxx
@@ -28,7 +28,10 @@ SectionMemTopology::init SectionMemTopology::initializer;
 
 SectionMemTopology::init::init() 
 { 
-  registerSectionCtor(MEM_TOPOLOGY, "MEM_TOPOLOGY", "mem_topology", false, false, boost::factory<SectionMemTopology*>()); 
+  auto sectionInfo = std::make_unique<SectionInfo>(MEM_TOPOLOGY, "MEM_TOPOLOGY", boost::factory<SectionMemTopology*>()); 
+  sectionInfo->nodeName = "mem_topology";
+
+  addSectionType(std::move(sectionInfo));
 }
 
 const std::string
@@ -280,7 +283,7 @@ SectionMemTopology::marshalFromJSON(const boost::property_tree::ptree& _ptSectio
 bool 
 SectionMemTopology::doesSupportAddFormatType(FormatType _eFormatType) const
 {
-  if (_eFormatType == FT_JSON) {
+  if (_eFormatType == FormatType::JSON) {
     return true;
   }
   return false;
@@ -289,9 +292,9 @@ SectionMemTopology::doesSupportAddFormatType(FormatType _eFormatType) const
 bool 
 SectionMemTopology::doesSupportDumpFormatType(FormatType _eFormatType) const
 {
-    if ((_eFormatType == FT_JSON) ||
-        (_eFormatType == FT_HTML) ||
-        (_eFormatType == FT_RAW))
+    if ((_eFormatType == FormatType::JSON) ||
+        (_eFormatType == FormatType::HTML) ||
+        (_eFormatType == FormatType::RAW))
     {
       return true;
     }

--- a/src/runtime_src/tools/xclbinutil/SectionOverlay.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionOverlay.cxx
@@ -23,6 +23,8 @@ SectionOverlay::init SectionOverlay::initializer;
 
 SectionOverlay::init::init() 
 { 
-  registerSectionCtor(OVERLAY, "OVERLAY", "", false, false, boost::factory<SectionOverlay*>()); 
+  auto sectionInfo = std::make_unique<SectionInfo>(OVERLAY, "OVERLAY", boost::factory<SectionOverlay*>()); 
+
+  addSectionType(std::move(sectionInfo));
 }
 

--- a/src/runtime_src/tools/xclbinutil/SectionPDI.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionPDI.cxx
@@ -23,7 +23,9 @@ SectionPDI::init SectionPDI::initializer;
 
 SectionPDI::init::init() 
 { 
-  registerSectionCtor(PDI, "PDI", "", false, false, boost::factory<SectionPDI*>()); 
+  auto sectionInfo = std::make_unique<SectionInfo>(PDI, "PDI", boost::factory<SectionPDI*>()); 
+
+  addSectionType(std::move(sectionInfo));
 }
 
 

--- a/src/runtime_src/tools/xclbinutil/SectionPartitionMetadata.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionPartitionMetadata.cxx
@@ -26,6 +26,18 @@
 
 namespace XUtil = XclBinUtilities;
 
+// Static Variables / Classes
+SectionPartitionMetadata::init SectionPartitionMetadata::initializer;
+
+SectionPartitionMetadata::init::init() 
+{ 
+  auto sectionInfo = std::make_unique<SectionInfo>(PARTITION_METADATA, "PARTITION_METADATA", boost::factory<SectionPartitionMetadata *>()); 
+  sectionInfo->nodeName = "partition_metadata";
+
+  addSectionType(std::move(sectionInfo));
+}
+
+
 template <typename T>
 std::vector<T> as_vector(boost::property_tree::ptree const& pt, 
                          boost::property_tree::ptree::key_type const& key)
@@ -36,13 +48,6 @@ std::vector<T> as_vector(boost::property_tree::ptree const& pt,
     return r;
 }
 
-// Static Variables / Classes
-SectionPartitionMetadata::init SectionPartitionMetadata::initializer;
-
-SectionPartitionMetadata::init::init() 
-{ 
-  registerSectionCtor(PARTITION_METADATA, "PARTITION_METADATA", "partition_metadata", false, false, boost::factory<SectionPartitionMetadata *>()); 
-}
 
 // Variable name to data size mapping table
 const FDTProperty::PropertyNameFormat SectionPartitionMetadata::m_propertyNameFormat = {
@@ -782,8 +787,8 @@ SchemaTransformToPM_root( const boost::property_tree::ptree & _ptOriginal,
 bool 
 SectionPartitionMetadata::doesSupportAddFormatType(FormatType _eFormatType) const
 {
-  if (( _eFormatType == FT_JSON ) ||
-      ( _eFormatType == FT_RAW )) {
+  if (( _eFormatType == FormatType::JSON ) ||
+      ( _eFormatType == FormatType::RAW )) {
     return true;
   }
   return false;
@@ -792,9 +797,9 @@ SectionPartitionMetadata::doesSupportAddFormatType(FormatType _eFormatType) cons
 bool 
 SectionPartitionMetadata::doesSupportDumpFormatType(FormatType _eFormatType) const
 {
-    if ((_eFormatType == FT_JSON) ||
-        (_eFormatType == FT_HTML) ||
-        (_eFormatType == FT_RAW))
+    if ((_eFormatType == FormatType::JSON) ||
+        (_eFormatType == FormatType::HTML) ||
+        (_eFormatType == FormatType::RAW))
     {
       return true;
     }

--- a/src/runtime_src/tools/xclbinutil/SectionSchedulerFW.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionSchedulerFW.cxx
@@ -23,7 +23,9 @@ SectionSchedulerFW::init SectionSchedulerFW::initializer;
 
 SectionSchedulerFW::init::init() 
 { 
-  registerSectionCtor(SCHED_FIRMWARE, "SCHED_FIRMWARE", "", false, false, boost::factory<SectionSchedulerFW*>()); 
+  auto sectionInfo = std::make_unique<SectionInfo>(SCHED_FIRMWARE, "SCHED_FIRMWARE", boost::factory<SectionSchedulerFW*>()); 
+
+  addSectionType(std::move(sectionInfo));
 }
 
 

--- a/src/runtime_src/tools/xclbinutil/SectionSmartNic.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionSmartNic.cxx
@@ -40,14 +40,17 @@ SectionSmartNic::init SectionSmartNic::initializer;
 
 SectionSmartNic::init::init() 
 { 
-  registerSectionCtor(SMARTNIC, "SMARTNIC", "smartnic", false, false, boost::factory<SectionSmartNic*>()); 
+  auto sectionInfo = std::make_unique<SectionInfo>(SMARTNIC, "SMARTNIC", boost::factory<SectionSmartNic*>()); 
+  sectionInfo->nodeName = "smartnic";
+
+  addSectionType(std::move(sectionInfo));
 }
 
 
 bool
 SectionSmartNic::doesSupportAddFormatType(FormatType _eFormatType) const {
-  if ((_eFormatType == FT_JSON) ||
-      (_eFormatType == FT_RAW))
+  if ((_eFormatType == FormatType::JSON) ||
+      (_eFormatType == FormatType::RAW))
     return true;
 
   return false;
@@ -55,9 +58,9 @@ SectionSmartNic::doesSupportAddFormatType(FormatType _eFormatType) const {
 
 bool
 SectionSmartNic::doesSupportDumpFormatType(FormatType _eFormatType) const {
-  if ((_eFormatType == FT_JSON) ||
-      (_eFormatType == FT_HTML) ||
-      (_eFormatType == FT_RAW))
+  if ((_eFormatType == FormatType::JSON) ||
+      (_eFormatType == FormatType::HTML) ||
+      (_eFormatType == FormatType::RAW))
     return true;
 
   return false;

--- a/src/runtime_src/tools/xclbinutil/SectionSoftKernel.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionSoftKernel.cxx
@@ -34,14 +34,18 @@ SectionSoftKernel::init SectionSoftKernel::initializer;
 
 SectionSoftKernel::init::init() 
 { 
-  registerSectionCtor(SOFT_KERNEL, "SOFT_KERNEL", "", true, true, boost::factory<SectionSoftKernel*>()); 
+  auto sectionInfo = std::make_unique<SectionInfo>(SOFT_KERNEL, "SOFT_KERNEL", boost::factory<SectionSoftKernel*>()); 
+  sectionInfo->supportsSubSections = true;
+  sectionInfo->supportsIndexing = true;
+
+  addSectionType(std::move(sectionInfo));
 }
 
 // -------------------------------------------------------------------------
 
 bool
 SectionSoftKernel::doesSupportAddFormatType(FormatType _eFormatType) const {
-  // The Soft Kernel top-level section does support any add syntax.
+  // The Soft Kernel top-level section doesn't support any add syntax.
   // Must use sub-sections
   return false;
 }
@@ -337,7 +341,7 @@ SectionSoftKernel::readSubPayload(const char* _pOrigDataSection,
         throw std::runtime_error(errMsg);
       }
 
-      if (_eFormatType != Section::FT_RAW) {
+      if (_eFormatType != Section::FormatType::RAW) {
         std::string errMsg = "ERROR: Soft kernel's object only supports the RAW format.";
         throw std::runtime_error(errMsg);
       }
@@ -352,7 +356,7 @@ SectionSoftKernel::readSubPayload(const char* _pOrigDataSection,
           throw std::runtime_error(errMsg);
         }
 
-        if (_eFormatType != Section::FT_JSON) {
+        if (_eFormatType != Section::FormatType::JSON) {
           std::string errMsg = "ERROR: SOFT_KERNEL-METADATA only supports the JSON format.";
           throw std::runtime_error(errMsg);
         }
@@ -451,7 +455,7 @@ SectionSoftKernel::writeSubPayload(const std::string& _sSubSectionName,
   switch (eSubSection) {
     case SS_OBJ:
       // Some basic DRC checks
-      if (_eFormatType != Section::FT_RAW) {
+      if (_eFormatType != Section::FormatType::RAW) {
         std::string errMsg = "ERROR: SOFT_KERNEL-OBJ only supports the RAW format.";
         throw std::runtime_error(errMsg);
       }
@@ -460,7 +464,7 @@ SectionSoftKernel::writeSubPayload(const std::string& _sSubSectionName,
       break;
 
     case SS_METADATA: {
-        if (_eFormatType != Section::FT_JSON) {
+        if (_eFormatType != Section::FormatType::JSON) {
           std::string errMsg = "ERROR: SOFT_KERNEL-METADATA only supports the JSON format.";
           throw std::runtime_error(errMsg);
         }

--- a/src/runtime_src/tools/xclbinutil/SectionSystemMetadata.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionSystemMetadata.cxx
@@ -28,7 +28,9 @@ SectionSystemMetadata::init SectionSystemMetadata::initializer;
 
 SectionSystemMetadata::init::init() 
 { 
-    registerSectionCtor(SYSTEM_METADATA, "SYSTEM_METADATA", "", false, false, boost::factory<SectionSystemMetadata*>()); 
+    auto sectionInfo = std::make_unique<SectionInfo>(SYSTEM_METADATA, "SYSTEM_METADATA", boost::factory<SectionSystemMetadata*>()); 
+
+    addSectionType(std::move(sectionInfo));
 }
 
 void

--- a/src/runtime_src/tools/xclbinutil/SectionUserMetadata.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionUserMetadata.cxx
@@ -23,7 +23,9 @@ SectionUserMetadata::init SectionUserMetadata::initializer;
 
 SectionUserMetadata::init::init() 
 { 
-  registerSectionCtor(USER_METADATA, "USER_METADATA", "", false, false, boost::factory<SectionUserMetadata*>()); 
+  auto sectionInfo = std::make_unique<SectionInfo>(USER_METADATA, "USER_METADATA", boost::factory<SectionUserMetadata*>()); 
+
+  addSectionType(std::move(sectionInfo));
 }
 
 

--- a/src/runtime_src/tools/xclbinutil/SectionVenderMetadata.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionVenderMetadata.cxx
@@ -34,7 +34,11 @@ SectionVenderMetadata::init SectionVenderMetadata::initializer;
 
 SectionVenderMetadata::init::init() 
 { 
-  registerSectionCtor(VENDER_METADATA, "VENDER_METADATA", "", true, true, boost::factory<SectionVenderMetadata*>()); 
+  auto sectionInfo = std::make_unique<SectionInfo>(VENDER_METADATA, "VENDER_METADATA", boost::factory<SectionVenderMetadata*>()); 
+  sectionInfo->supportsSubSections = true;
+  sectionInfo->supportsIndexing = true;
+
+  addSectionType(std::move(sectionInfo));
 }
 
 // -------------------------------------------------------------------------
@@ -42,7 +46,7 @@ SectionVenderMetadata::init::init()
 bool
 SectionVenderMetadata::doesSupportAddFormatType(FormatType _eFormatType) const
 {
-  // The Vender Metadata top-level section does support any add syntax.
+  // The Vender Metadata top-level section doesn't support any add syntax.
   // Must use sub-sections
   return false;
 }
@@ -224,7 +228,7 @@ SectionVenderMetadata::readSubPayload(const char* _pOrigDataSection,
     throw std::runtime_error(errMsg);
   }
 
-  if (_eFormatType != Section::FT_RAW) {
+  if (_eFormatType != Section::FormatType::RAW) {
     std::string errMsg = "ERROR: Vendor Metadata only supports the RAW format.";
     throw std::runtime_error(errMsg);
   }
@@ -308,7 +312,7 @@ SectionVenderMetadata::writeSubPayload(const std::string& _sSubSectionName,
   }
 
   // Some basic DRC checks
-  if (_eFormatType != Section::FT_RAW) {
+  if (_eFormatType != Section::FormatType::RAW) {
     std::string errMsg = "ERROR: Vendor Metadata section only supports the RAW format.";
     throw std::runtime_error(errMsg);
   }

--- a/src/runtime_src/tools/xclbinutil/XclBinClass.cxx
+++ b/src/runtime_src/tools/xclbinutil/XclBinClass.cxx
@@ -312,8 +312,8 @@ XclBin::writeXclBinBinarySections(std::ostream& _ostream, boost::property_tree::
       pt_sectionHeader.put("Size", (boost::format("0x%lx") % sectionHeader[index].m_sectionSize).str());
 
       boost::property_tree::ptree pt_Payload;
-      if (m_sections[index]->doesSupportAddFormatType(Section::FT_JSON) &&
-          m_sections[index]->doesSupportDumpFormatType(Section::FT_JSON)) {
+      if (m_sections[index]->doesSupportAddFormatType(Section::FormatType::JSON) &&
+          m_sections[index]->doesSupportDumpFormatType(Section::FormatType::JSON)) {
         m_sections[index]->getPayload(pt_Payload);
       }
 
@@ -655,7 +655,7 @@ XclBin::addMergeSection(ParameterSectionData& _PSD)
   enum axlf_section_kind eKind;
   Section::translateSectionKindStrToKind(_PSD.getSectionName(), eKind);
 
-  if (_PSD.getFormatType() != Section::FT_JSON) {
+  if (_PSD.getFormatType() != Section::FormatType::JSON) {
     std::string errMsg = "ERROR: Adding or merging of sections are only supported with the JSON format.";
     throw std::runtime_error(errMsg);
   }
@@ -1054,7 +1054,7 @@ XclBin::addSection(ParameterSectionData& _PSD)
   pSection->setName(sBaseName);
 
   bool bAllowZeroSize = ((pSection->getSectionKind() == DEBUG_DATA)
-                         && (_PSD.getFormatType() == Section::FT_RAW));
+                         && (_PSD.getFormatType() == Section::FormatType::RAW));
 
   if ((!bAllowZeroSize) && (pSection->getSize() == 0)) {
     XUtil::QUIET("");
@@ -1091,7 +1091,7 @@ XclBin::addSections(ParameterSectionData& _PSD)
     throw std::runtime_error(errMsg);
   }
 
-  if (_PSD.getFormatType() != Section::FT_JSON) {
+  if (_PSD.getFormatType() != Section::FormatType::JSON) {
     auto errMsg = boost::format("ERROR: Expecting JSON format type, got '%s'.") % _PSD.getFormatTypeAsStr();
     throw std::runtime_error(errMsg.str());
   }
@@ -1177,7 +1177,7 @@ XclBin::appendSections(ParameterSectionData& _PSD)
     throw std::runtime_error(errMsg);
   }
 
-  if (_PSD.getFormatType() != Section::FT_JSON) {
+  if (_PSD.getFormatType() != Section::FormatType::JSON) {
     auto errMsg = boost::format("ERROR: Expecting JSON format type, got '%s'.") % _PSD.getFormatTypeAsStr();
     throw std::runtime_error(errMsg.str());
   }
@@ -1332,12 +1332,12 @@ XclBin::dumpSection(ParameterSectionData& _PSD)
     throw XUtil::XclBinUtilException(XET_MISSING_SECTION, boost::str(errMsg));
   }
 
-  if (_PSD.getFormatType() == Section::FT_UNKNOWN) {
+  if (_PSD.getFormatType() == Section::FormatType::UNKNOWN) {
     std::string errMsg = "ERROR: Unknown format type '" + _PSD.getFormatTypeAsStr() + "' in the dump section option: '" + _PSD.getOriginalFormattedString() + "'";
     throw std::runtime_error(errMsg);
   }
 
-  if (_PSD.getFormatType() == Section::FT_UNDEFINED) {
+  if (_PSD.getFormatType() == Section::FormatType::UNDEFINED) {
     std::string errMsg = "ERROR: The format type is missing from the dump section option: '" + _PSD.getOriginalFormattedString() + "'.  Expected: <SECTION>:<FORMAT>:<OUTPUT_FILE>.  See help for more format details.";
     throw std::runtime_error(errMsg);
   }
@@ -1375,7 +1375,7 @@ XclBin::dumpSections(ParameterSectionData& _PSD)
     throw std::runtime_error(errMsg);
   }
 
-  if (_PSD.getFormatType() != Section::FT_JSON) {
+  if (_PSD.getFormatType() != Section::FormatType::JSON) {
     auto errMsg = boost::format("ERROR: Expecting JSON format type, got '%s'.") % _PSD.getFormatTypeAsStr();
     throw std::runtime_error(errMsg.str());
   }
@@ -1390,7 +1390,7 @@ XclBin::dumpSections(ParameterSectionData& _PSD)
   }
 
   switch (_PSD.getFormatType()) {
-    case Section::FT_JSON: {
+    case Section::FormatType::JSON: {
         boost::property_tree::ptree pt;
         for (const auto pSection : m_sections) {
           std::string sectionName = pSection->getSectionKindAsString();
@@ -1401,11 +1401,11 @@ XclBin::dumpSections(ParameterSectionData& _PSD)
         boost::property_tree::write_json(oDumpFile, pt, true /*Pretty print*/);
         break;
       }
-    case Section::FT_HTML:
-    case Section::FT_RAW:
-    case Section::FT_TXT:
-    case Section::FT_UNDEFINED:
-    case Section::FT_UNKNOWN:
+    case Section::FormatType::HTML:
+    case Section::FormatType::RAW:
+    case Section::FormatType::TXT:
+    case Section::FormatType::UNDEFINED:
+    case Section::FormatType::UNKNOWN:
     default:
       break;
   }
@@ -1844,7 +1844,7 @@ XclBin::addPsKernel(const std::string& encodedString)
       throw std::runtime_error(errMsg);
     }
 
-    pSection->readSubPayload(iSectionFile, "OBJ", Section::FT_RAW);
+    pSection->readSubPayload(iSectionFile, "OBJ", Section::FormatType::RAW);
 
     // -- Add the metadata
     XUtil::TRACE(boost::format("Adding PS Kernel SubSection '%s' METADATA") % kernelName);
@@ -1861,7 +1861,7 @@ XclBin::addPsKernel(const std::string& encodedString)
     std::ostringstream buffer;
     boost::property_tree::write_json(buffer, ptRTD);
     std::istringstream iSectionMetadata(buffer.str());
-    pSection->readSubPayload(iSectionMetadata, "METADATA", Section::FT_JSON);
+    pSection->readSubPayload(iSectionMetadata, "METADATA", Section::FormatType::JSON);
 
     // -- Now add the section to the collection and report our successful status
     addSection(pSection);

--- a/src/runtime_src/tools/xclbinutil/XclBinUtilMain.cxx
+++ b/src/runtime_src/tools/xclbinutil/XclBinUtilMain.cxx
@@ -477,7 +477,7 @@ int main_(int argc, const char** argv) {
   for (const auto &section : sectionsToAdd) {
     ParameterSectionData psd(section);
     if (psd.getSectionName().empty() &&
-        psd.getFormatType() == Section::FT_JSON) {
+        psd.getFormatType() == Section::FormatType::JSON) {
       xclBin.addSections(psd);
     } else {
       xclBin.addSection(psd);
@@ -494,7 +494,7 @@ int main_(int argc, const char** argv) {
   for (const auto &section : sectionsToAppend) {
     ParameterSectionData psd(section);
     if (psd.getSectionName().empty() &&
-        psd.getFormatType() == Section::FT_JSON) {
+        psd.getFormatType() == Section::FormatType::JSON) {
       xclBin.appendSections(psd);
     } else {
       std::string errMsg = "ERROR: Appending of sections only supported via wildcards and the JSON format (e.g. :JSON:appendfile.rtd).";
@@ -544,7 +544,7 @@ int main_(int argc, const char** argv) {
   for (const auto &section : sectionsToDump) {
     ParameterSectionData psd(section);
     if (psd.getSectionName().empty() &&
-        psd.getFormatType() == Section::FT_JSON) {
+        psd.getFormatType() == Section::FormatType::JSON) {
       xclBin.dumpSections(psd);
     } else {
       xclBin.dumpSection(psd);

--- a/src/runtime_src/tools/xclbinutil/XclBinUtilities.cxx
+++ b/src/runtime_src/tools/xclbinutil/XclBinUtilities.cxx
@@ -1100,7 +1100,7 @@ XclBinUtilities::createAIEPartition(XclBin & xclbin)
   std::ostringstream buffer;
   boost::property_tree::write_json(buffer, ptRoot);
   std::istringstream iSectionMetadata(buffer.str());
-  pSection->readPayload(iSectionMetadata, Section::FT_JSON);
+  pSection->readPayload(iSectionMetadata, Section::FormatType::JSON);
 
   // -- Now add the section to the collection and report our successful status
   XUtil::TRACE("Adding AIE_PARTITION section to xclbin");

--- a/src/runtime_src/tools/xclbinutil/unittests/TestAddSection.cxx
+++ b/src/runtime_src/tools/xclbinutil/unittests/TestAddSection.cxx
@@ -70,7 +70,7 @@ TEST(AddSection, AddReplaceClearingBitstream) {
 
    // Record the contents that was read in
    std::ostringstream uniqueData1Contents;
-   pSection->dumpContents(uniqueData1Contents, Section::FT_RAW);
+   pSection->dumpContents(uniqueData1Contents, Section::FormatType::RAW);
 
    {
       // Replace the contents of the CLEARING_BITSTREAM section
@@ -88,7 +88,7 @@ TEST(AddSection, AddReplaceClearingBitstream) {
 
    // Record the contents that was read in
    std::ostringstream uniqueData2Contents;
-   pSection->dumpContents(uniqueData2Contents, Section::FT_RAW);
+   pSection->dumpContents(uniqueData2Contents, Section::FormatType::RAW);
 
    // Validate the data is different
    ASSERT_TRUE(uniqueData1Contents.str().compare(uniqueData2Contents.str())) << "Data contents was not replaced";
@@ -140,7 +140,7 @@ TEST(AddSection, AddMergeIPLayout) {
    const std::string outputFile = "ip_layout_merged_output.json";
    std::fstream oDumpFile(outputFile, std::ifstream::out | std::ifstream::binary);
    ASSERT_TRUE(oDumpFile.is_open()) << "Unable to open the file for writing: " << outputFile;
-   pSection->dumpContents(oDumpFile, Section::FT_JSON);
+   pSection->dumpContents(oDumpFile, Section::FormatType::JSON);
 
    // Validate the JSON images on disk
    std::stringstream obuffer;

--- a/src/runtime_src/tools/xclbinutil/unittests/UnitParameterSectionData.cxx
+++ b/src/runtime_src/tools/xclbinutil/unittests/UnitParameterSectionData.cxx
@@ -7,7 +7,7 @@ TEST(ParameterSectionData, ValidTuple) {
    ParameterSectionData *pPSD = new ParameterSectionData(sOption);
 
    EXPECT_STREQ("BUILD_METADATA", pPSD->getSectionName().c_str());
-   EXPECT_EQ(Section::FT_JSON, pPSD->getFormatType());
+   EXPECT_EQ(Section::FormatType::JSON, pPSD->getFormatType());
    EXPECT_STREQ("myfile.json", pPSD->getFile().c_str());
 }
 
@@ -17,7 +17,7 @@ TEST(ParameterSectionData, FileColon) {
    ParameterSectionData *pPSD = new ParameterSectionData(sOption);
 
    EXPECT_STREQ("BUILD_METADATA", pPSD->getSectionName().c_str());
-   EXPECT_EQ(Section::FT_JSON, pPSD->getFormatType());
+   EXPECT_EQ(Section::FormatType::JSON, pPSD->getFormatType());
    EXPECT_STREQ("C:\\file.json", pPSD->getFile().c_str());
 }
 
@@ -27,7 +27,7 @@ TEST(ParameterSectionData, EmptySectionWithJSON) {
    ParameterSectionData *pPSD = new ParameterSectionData(sOption);
 
    EXPECT_STREQ("", pPSD->getSectionName().c_str());
-   EXPECT_EQ(Section::FT_JSON, pPSD->getFormatType());
+   EXPECT_EQ(Section::FormatType::JSON, pPSD->getFormatType());
    EXPECT_STREQ("myfile.json", pPSD->getFile().c_str());
 }
 


### PR DESCRIPTION
#### Problem solved by the commit
Note: This pull request is 2 of 2 building off of PR 6627,

What was done:
* Replaced the helper function registerSectionCtor() with addSectionType.  This enabled a more fine grain control with how the section registers itself along with what it supported.  Note: Future releases will migrate helper virtual functions (e.g., doesSupport*() in more of a data driven solution using SectionInfo.
* Change enum Format type to a class enumeration and renamed the enumeration values to be more readable.
* Refactored various helper methods that translate pretty names to enumeration types.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
n/a

#### How problem was solved, alternative solutions (if any) and why they were rejected
n/a

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
Unit and manual testing

#### Documentation impact (if any)
n/a