### PR TITLE
CR-1127142 shim: add flag to exit dev_offline status check loop forcibly

### DIFF
--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -832,11 +832,11 @@ get_flag_sw_emu_kernel_debug()
 }
 
 // This flag is added to exit device offline status check loop forcibly.
-// By default, device offline status loop runs for 60 seconds.
+// By default, device offline status loop runs for 120 seconds.
 inline unsigned int
 get_device_offline_timer()
 {
-  static unsigned int value = detail::get_uint_value("Runtime.dev_offline_timer", 60);
+  static unsigned int value = detail::get_uint_value("Runtime.dev_offline_timer", 120);
   return value;
 }
 

--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -833,7 +833,7 @@ get_flag_sw_emu_kernel_debug()
 
 // This flag is added to exit device offline status check loop forcibly.
 // By default, device offline status loop runs for 60 seconds.
-inline bool
+inline unsigned int
 get_device_offline_timer()
 {
   static unsigned int value = detail::get_uint_value("Runtime.dev_offline_timer", 60);

--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -831,6 +831,15 @@ get_flag_sw_emu_kernel_debug()
   return value;
 }
 
+// This flag is added to exit device offline status check loop forcibly.
+// By default, device offline status loop runs for 60 seconds.
+inline bool
+get_device_offline_timer()
+{
+  static unsigned int value = detail::get_uint_value("Runtime.dev_offline_timer", 60);
+  return value;
+}
+
 }} // config,xrt_core
 
 #endif

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -1098,6 +1098,8 @@ int shim::xclGetDeviceInfo2(xclDeviceInfo2 *info)
  */
 int shim::resetDevice(xclResetKind kind)
 {
+    int err = 0;
+
     // Only XCL_USER_RESET is supported on user pf.
     if (kind != XCL_USER_RESET)
         return -EINVAL;
@@ -1127,13 +1129,13 @@ int shim::resetDevice(xclResetKind kind)
         std::chrono::duration<double> elapsed_seconds = end - start;
         if (elapsed_seconds.count() > loop_timer) {
             xrt_logmsg(XRT_WARNING, "%s: device unable to come online during reset, try again", __func__);
-            break;
+            err = -EAGAIN;
         }
     }
 
     dev_init();
 
-    return 0;
+    return err;
 }
 
 int shim::p2pEnable(bool enable, bool force)

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -1098,27 +1098,23 @@ int shim::xclGetDeviceInfo2(xclDeviceInfo2 *info)
  */
 int shim::resetDevice(xclResetKind kind)
 {
-    int ret = 0;
-
     // Only XCL_USER_RESET is supported on user pf.
     if (kind != XCL_USER_RESET)
         return -EINVAL;
 
     std::string err;
     int dev_offline = 1;
-    ret = mDev->ioctl(mUserHandle, DRM_IOCTL_XOCL_HOT_RESET);
+    int ret = mDev->ioctl(mUserHandle, DRM_IOCTL_XOCL_HOT_RESET);
     if (ret)
         return -errno;
 
     dev_fini();
 
-    /*
-     * This loop used to wait for device come online and ready to use. It uses "dev_offline"
-     * sysfs node to retrieve latest status of device in the interval of 500 milli sec.
-     * In certain testing environement, reset never complete and waits indefinitely
-     * in this loop for dev_offline status to be false. To overcome this infinite loop issue,
-     * added loop_timer (default value set to 120 sec) which is used to exit the loop.
-     */
+    // This loop used to wait for device come online and ready to use. It reads "dev_offline"
+    // sysfs node to retrieve latest status of device in the interval of 500 milli sec.
+    // In certain testing environement, reset never complete and waits indefinitely
+    // in this loop for dev_offline status to be false. To overcome this infinite loop issue,
+    // added loop_timer (default value set to 120 sec) which is used to exit the loop.
     unsigned int loop_timer = xrt_core::config::get_device_offline_timer();
     auto start = std::chrono::system_clock::now();
     while (dev_offline) {

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -1098,7 +1098,7 @@ int shim::xclGetDeviceInfo2(xclDeviceInfo2 *info)
  */
 int shim::resetDevice(xclResetKind kind)
 {
-    int err = 0;
+    int ret = 0;
 
     // Only XCL_USER_RESET is supported on user pf.
     if (kind != XCL_USER_RESET)
@@ -1106,7 +1106,7 @@ int shim::resetDevice(xclResetKind kind)
 
     std::string err;
     int dev_offline = 1;
-    int ret = mDev->ioctl(mUserHandle, DRM_IOCTL_XOCL_HOT_RESET);
+    ret = mDev->ioctl(mUserHandle, DRM_IOCTL_XOCL_HOT_RESET);
     if (ret)
         return -errno;
 
@@ -1117,7 +1117,7 @@ int shim::resetDevice(xclResetKind kind)
      * sysfs node to retrieve latest status of device in the interval of 500 milli sec.
      * In certain testing environement, reset never complete and waits indefinitely
      * in this loop for dev_offline status to be false. To overcome this infinite loop issue,
-     * added loop_timer (default value set to 60 sec) which is used to exit the loop.
+     * added loop_timer (default value set to 120 sec) which is used to exit the loop.
      */
     unsigned int loop_timer = xrt_core::config::get_device_offline_timer();
     auto start = std::chrono::system_clock::now();
@@ -1129,13 +1129,13 @@ int shim::resetDevice(xclResetKind kind)
         std::chrono::duration<double> elapsed_seconds = end - start;
         if (elapsed_seconds.count() > loop_timer) {
             xrt_logmsg(XRT_WARNING, "%s: device unable to come online during reset, try again", __func__);
-            err = -EAGAIN;
+            ret = -EAGAIN;
         }
     }
 
     dev_init();
 
-    return err;
+    return ret;
 }
 
 int shim::p2pEnable(bool enable, bool force)


### PR DESCRIPTION
Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
xbutil reset test hangs indefinitely on Microsoft Azure multi-cards test environment when multiple tests run simultaneously.
It is due to device is not coming online after reset.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1127142 This PR fixes indefinite run in while loop issue in reset sequence.
#### How problem was solved, alternative solutions (if any) and why they were rejected
Added a timer in shim driver, which exits the while loop if the timer reaches 120 seconds (default). One can set to any value using xrt runtime config file, for example, set value to 100 seconds
Runtime.dev_offline_timer=100
#### Risks (if any) associated the changes in the commit
NA
#### What has been tested and how, request additional testing if necessary
xbutil reset, xbutil validate
#### Documentation impact (if any)
NA