### PR TITLE
fix IOPS regression with ERT enabled

### DIFF
--- a/src/runtime_src/core/include/xgq_impl.h
+++ b/src/runtime_src/core/include/xgq_impl.h
@@ -291,13 +291,23 @@ static inline void xgq_ring_write_consumed(uint64_t io_hdl, struct xgq_ring *rin
 static inline uint64_t xgq_ring_slot_ptr_produced(struct xgq_ring *ring)
 {
 	return ring->xr_slot_addr +
-	       (uint64_t)ring->xr_slot_sz * (ring->xr_produced & (ring->xr_slot_num - 1));
+		/*
+		 * In reality, below multiplication of two 32-bit ints will not overflow.
+		 * So, keep it as-is, instead of doing 64-bit mutiplication, which is very
+		 * slow on 32-bit CPU, e.g., Microblaze.
+		 */
+		ring->xr_slot_sz * (ring->xr_produced & (ring->xr_slot_num - 1));
 }
 
 static inline uint64_t xgq_ring_slot_ptr_consumed(struct xgq_ring *ring)
 {
 	return ring->xr_slot_addr +
-	       (uint64_t)ring->xr_slot_sz * (ring->xr_consumed & (ring->xr_slot_num - 1));
+		/*
+		 * In reality, below multiplication of two 32-bit ints will not overflow.
+		 * So, keep it as-is, instead of doing 64-bit mutiplication, which is very
+		 * slow on 32-bit CPU, e.g., Microblaze.
+		 */
+		ring->xr_slot_sz * (ring->xr_consumed & (ring->xr_slot_num - 1));
 }
 
 static inline int xgq_can_produce(struct xgq *xgq)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
With ERT enabled, IOPS dropped by 20+% after PR#6127. This PR revert the change (partly) in 6127 to bring back the good IOPS number.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
The change in xgq_impl.h in PR#6127 caused 64-bit int multiplication on Microblaze unnecessarily. This is, in fact, very slow on Microblaze and caused ERT IOPS degradation.
#### How problem was solved, alternative solutions (if any) and why they were rejected
Reverted offending change.
#### Risks (if any) associated the changes in the commit
No risk since the change is reverted.
#### What has been tested and how, request additional testing if necessary
Tested IOPS on U50/U55n/U250 to confirm the improvement of performance.
E.g., on u55n, before the fix:
-------------------------------------------------------------------------------
Test 1 [0000:b3:00.1]     : iops 
    Details               : IOPS: 380751 (verify)
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
After the fix:
-------------------------------------------------------------------------------
Test 1 [0000:b3:00.1]     : iops 
    Details               : IOPS: 546624 (verify)
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
#### Documentation impact (if any)
N/A