### PR TITLE
Coverity fix to intialize the hal major and minor version to default …

### DIFF
--- a/src/runtime_src/core/edge/common_em/config.cxx
+++ b/src/runtime_src/core/edge/common_em/config.cxx
@@ -595,8 +595,8 @@ namespace xclemulation{
 
       //fill info with default values
       info.mMagic = 0X586C0C6C;
-      //info.mHALMajorVersion = XCLHAL_MAJOR_VER;
-      //info.mHALMinorVersion= XCLHAL_MINOR_VER;
+      info.mHALMajorVersion = XCLHAL_MAJOR_VER;
+      info.mHALMinorVersion= XCLHAL_MINOR_VER;
       info.mVendorId = 0x10ee;
       info.mSubsystemVendorId = 0x0000;
       info.mDeviceVersion = 0x0000;
@@ -612,7 +612,6 @@ namespace xclemulation{
       DDRBankList.push_back(bank);
       FeatureRomHeader fRomHeader;
       std::memset(&fRomHeader, 0, sizeof(FeatureRomHeader));
-
 
       //iterate over all the properties of device and fill the info structure. This info object gets used to create  device object
       for (auto& prop : device.second)

--- a/src/runtime_src/core/pcie/emulation/common_em/config.cxx
+++ b/src/runtime_src/core/pcie/emulation/common_em/config.cxx
@@ -647,8 +647,8 @@ namespace xclemulation{
 
       //fill info with default values
       info.mMagic = 0X586C0C6C;
-      //info.mHALMajorVersion = XCLHAL_MAJOR_VER;
-      //info.mHALMinorVersion= XCLHAL_MINOR_VER;
+      info.mHALMajorVersion = XCLHAL_MAJOR_VER;
+      info.mHALMinorVersion= XCLHAL_MINOR_VER;
       info.mVendorId = 0x10ee;
       info.mSubsystemVendorId = 0x0000;
       info.mDeviceVersion = 0x0000;


### PR DESCRIPTION
…value.

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
Coverity reported an issue regarding the default initialization of the hal major and minor version

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Not a bug. Issue reported by Coverity

#### How problem was solved, alternative solutions (if any) and why they were rejected
Initialized with proper value

#### Risks (if any) associated the changes in the commit
No

#### What has been tested and how, request additional testing if necessary
Ran the canaries

#### Documentation impact (if any)
No
