### PR TITLE
CR-1129143 Add AIE PL test into xbutil validate

### DIFF
--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -291,13 +291,13 @@ runTestCase( const std::shared_ptr<xrt_core::device>& _dev, const std::string& p
       { "xcl_iops_test.exe",        "xcl_iops_test.exe"}
     };
 
-    if (test_map.find(py) == test_map.end()) {
-      logger(_ptTest, "Error", boost::str(boost::format("Failed to find %s") % py));
-      _ptTest.put("status", test_token_failed);
-      return;
-    }
+    // Validate the legacy names
+    std::string test_name = py;
+    if (test_map.find(py) != test_map.end())
+      test_name = test_map.find(py)->second;
 
-    std::string  xrtTestCasePath = "/opt/xilinx/xrt/test/" + test_map.find(py)->second;
+    // Parse if the file exists here
+    std::string  xrtTestCasePath = "/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt/test/" + test_name;
     boost::filesystem::path xrt_path(xrtTestCasePath);
     if (!boost::filesystem::exists(xrt_path)) {
       logger(_ptTest, "Error", boost::str(boost::format("Failed to find %s") % xrtTestCasePath));
@@ -1294,13 +1294,13 @@ static std::vector<TestCollection> testSuite = {
   { create_init_test("verify", "Run 'Hello World' kernel test", "verify.xclbin"), verifyKernelTest },
   { create_init_test("dma", "Run dma test", "verify.xclbin"), dmaTest },
   { create_init_test("iops", "Run scheduler performance measure test", "verify.xclbin"), iopsTest },
-  { create_init_test("aie-pl", "Needs description", "verify.xclbin"), aiePlTest },
   { create_init_test("mem-bw", "Run 'bandwidth kernel' and check the throughput", "bandwidth.xclbin"), bandwidthKernelTest },
   { create_init_test("p2p", "Run P2P test", "bandwidth.xclbin"), p2pTest },
   { create_init_test("m2m", "Run M2M test", "bandwidth.xclbin"), m2mTest },
   { create_init_test("hostmem-bw", "Run 'bandwidth kernel' when host memory is enabled", "bandwidth.xclbin"), hostMemBandwidthKernelTest },
   { create_init_test("bist", "Run BIST test", "verify.xclbin", true), bistTest },
-  { create_init_test("vcu", "Run decoder test", "transcode.xclbin"), vcuKernelTest }
+  { create_init_test("vcu", "Run decoder test", "transcode.xclbin"), vcuKernelTest },
+  { create_init_test("aie-pl", "", "vck5000_pcie_pl_controller.xclbin.xclbin"), aiePlTest }
 };
 
 
@@ -1498,7 +1498,7 @@ run_test_suite_device( const std::shared_ptr<xrt_core::device>& device,
     // Hack: Until we have an option in the tests to query SUPP/NOT SUPP
     // we need to print the test description before running the test
     auto is_black_box_test = [ptTest]() {
-      std::vector<std::string> black_box_tests = {"verify", "mem-bw", "iops", "vcu"};
+      std::vector<std::string> black_box_tests = {"verify", "mem-bw", "iops", "vcu", "aie-pl"};
       auto test = ptTest.get<std::string>("name");
       return std::find(black_box_tests.begin(), black_box_tests.end(), test) != black_box_tests.end() ? true : false;
     };

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -299,7 +299,7 @@ runTestCase( const std::shared_ptr<xrt_core::device>& _dev, const std::string& p
       test_name = test_map.find(py)->second;
 
     // Parse if the file exists here
-    std::string  xrtTestCasePath = "/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt/test/" + test_name;
+    std::string  xrtTestCasePath = "/opt/xilinx/xrt/test/" + test_name;
     boost::filesystem::path xrt_path(xrtTestCasePath);
     if (!boost::filesystem::exists(xrt_path)) {
       logger(_ptTest, "Error", boost::str(boost::format("Failed to find %s") % xrtTestCasePath));

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -1258,6 +1258,26 @@ iopsTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree::pt
 }
 
 /*
+ * TEST #13
+ */
+void
+aiePlTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree::ptree& _ptTest)
+{
+  std::cout << "The aie pl test!\n";
+    // runTestCase(_dev, "aie_pl.exe", _ptTest.get<std::string>("xclbin"), _ptTest);
+}
+
+/*
+ * TEST #14
+ */
+void
+psIopsTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree::ptree& _ptTest)
+{
+  std::cout << "The ps iops test!\n";
+    // runTestCase(_dev, "ps_iops_test.exe", _ptTest.get<std::string>("xclbin"), _ptTest);
+}
+
+/*
 * helper function to initialize test info
 */
 static boost::property_tree::ptree
@@ -1285,6 +1305,8 @@ static std::vector<TestCollection> testSuite = {
   { create_init_test("verify", "Run 'Hello World' kernel test", "verify.xclbin"), verifyKernelTest },
   { create_init_test("dma", "Run dma test", "verify.xclbin"), dmaTest },
   { create_init_test("iops", "Run scheduler performance measure test", "verify.xclbin"), iopsTest },
+  { create_init_test("aie-pl", "Needs description", "verify.xclbin"), aiePlTest },
+  { create_init_test("ps-iops", "Needs description", "verify.xclbin"), psIopsTest },
   { create_init_test("mem-bw", "Run 'bandwidth kernel' and check the throughput", "bandwidth.xclbin"), bandwidthKernelTest },
   { create_init_test("p2p", "Run P2P test", "bandwidth.xclbin"), p2pTest },
   { create_init_test("m2m", "Run M2M test", "bandwidth.xclbin"), m2mTest },

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -292,6 +292,7 @@ runTestCase( const std::shared_ptr<xrt_core::device>& _dev, const std::string& p
     };
 
     // Validate the legacy names
+    // If no legacy name exists use the passed in test name
     std::string test_name = py;
     if (test_map.find(py) != test_map.end())
       test_name = test_map.find(py)->second;
@@ -1300,7 +1301,7 @@ static std::vector<TestCollection> testSuite = {
   { create_init_test("hostmem-bw", "Run 'bandwidth kernel' when host memory is enabled", "bandwidth.xclbin"), hostMemBandwidthKernelTest },
   { create_init_test("bist", "Run BIST test", "verify.xclbin", true), bistTest },
   { create_init_test("vcu", "Run decoder test", "transcode.xclbin"), vcuKernelTest },
-  { create_init_test("aie-pl", "", "vck5000_pcie_pl_controller.xclbin.xclbin"), aiePlTest }
+  { create_init_test("aie-pl", "Run AIE PL test", "vck5000_pcie_pl_controller.xclbin.xclbin"), aiePlTest }
 };
 
 

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -1263,18 +1263,7 @@ iopsTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree::pt
 void
 aiePlTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree::ptree& _ptTest)
 {
-  std::cout << "The aie pl test!\n";
-    // runTestCase(_dev, "aie_pl.exe", _ptTest.get<std::string>("xclbin"), _ptTest);
-}
-
-/*
- * TEST #14
- */
-void
-psIopsTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree::ptree& _ptTest)
-{
-  std::cout << "The ps iops test!\n";
-    // runTestCase(_dev, "ps_iops_test.exe", _ptTest.get<std::string>("xclbin"), _ptTest);
+    runTestCase(_dev, "aie_pl.exe", _ptTest.get<std::string>("xclbin"), _ptTest);
 }
 
 /*
@@ -1306,7 +1295,6 @@ static std::vector<TestCollection> testSuite = {
   { create_init_test("dma", "Run dma test", "verify.xclbin"), dmaTest },
   { create_init_test("iops", "Run scheduler performance measure test", "verify.xclbin"), iopsTest },
   { create_init_test("aie-pl", "Needs description", "verify.xclbin"), aiePlTest },
-  { create_init_test("ps-iops", "Needs description", "verify.xclbin"), psIopsTest },
   { create_init_test("mem-bw", "Run 'bandwidth kernel' and check the throughput", "bandwidth.xclbin"), bandwidthKernelTest },
   { create_init_test("p2p", "Run P2P test", "bandwidth.xclbin"), p2pTest },
   { create_init_test("m2m", "Run M2M test", "bandwidth.xclbin"), m2mTest },

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2019-2022 Xilinx, Inc
+ * Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the

--- a/src/runtime_src/doc/toc/xbutil.rst
+++ b/src/runtime_src/doc/toc/xbutil.rst
@@ -3,6 +3,7 @@
 ..
    comment:: SPDX-License-Identifier: Apache-2.0
    comment:: Copyright (C) 2019-2022 Xilinx, Inc. All rights reserved.
+   comment:: Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
 
 
 xbutil

--- a/src/runtime_src/doc/toc/xbutil.rst
+++ b/src/runtime_src/doc/toc/xbutil.rst
@@ -86,19 +86,20 @@ The command ``xbutil validate`` validates the installed card by running precompi
 - The ``--run`` (or ``-r``) specifies the perticular test(s) to execute
         
     - ``all`` (**default**): runs all the tests listed below
-    - ``Aux connection``: Check if auxiliary power is connected
-    - ``PCIE link``: Check if PCIE link is active
-    - ``SC version``: Check if SC firmware is up-to-date
-    - ``Verify kernel``: Run 'Hello World' kernel test
-    - ``DMA``: Run dma test
+    - ``aux-connection``: Check if auxiliary power is connected
+    - ``pcie-link``: Check if PCIE link is active
+    - ``sc-version``: Check if SC firmware is up-to-date
+    - ``verify``: Run 'Hello World' kernel test
+    - ``dma``: Run dma test
     - ``iops``: Run test to measure performance of scheduler (number of `hello world` kernel execution per second)
-    - ``Bandwidth kernel``: Run 'bandwidth kernel' and check the throughput
-    - ``Peer to peer bar``: Run peer-to-peer test
-    - ``Memory to memory DMA``: Run zero copy memory to memory data transfer test
-    - ``Host memory bandwidth test``: Run 'bandwidth kernel' when host memory is enabled
+    - ``mem-bw``: Run 'bandwidth kernel' and check the throughput
+    - ``p2p``: Run peer-to-peer test
+    - ``m2m``: Run zero copy memory to memory data transfer test
+    - ``hostmem-bw``: Run 'bandwidth kernel' when host memory is enabled
     - ``bist``: Run BIST test
-    - ``vcu``: Run decoder test (only applicable for specific platform). 
-    - ``quick``: Run first four tests (Aux connection, PCIE link, SC version and Verify kernel)   
+    - ``vcu``: Run decoder test (only applicable for specific platform).
+    - ``quick``: Run first four tests (Aux connection, PCIE link, SC version and Verify kernel)
+    - ``aie-pl``: Run AIE PL test
   
 - The ``--format`` (or ``-f``) specifies the report format. Note that ``--format`` also needs an ``--output`` to dump the report in json format. If ``--output`` is missing text format will be shown in stdout
     


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1129143
For VCK5000 Discovery base-2 platform there is a new PL controller with AIE validation test.  

There is a corresponding new host code in XRT/tests/validate/aie_pl_test

xbutil should now include aie_pl_test as part of xbutil validate flow

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added the new AIE PL test under the name aie-pl for xbutil validate.

#### Risks (if any) associated the changes in the commit
At the moment the AIE PL test fails if ran more than once. This seems to be a xclbin issue as @jeffli-xilinx has mentioned to me.

Here is an example:
```
dbenusov@xsjchrisd42:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil validate -r aie-pl -d 17:00
Starting validation for 1 devices

Validate Device           : [0000:17:00.1]
    Platform              : xilinx_vck5000_gen4x8_xdma_base_2
    SC Version            : 4.4.32
    Platform ID           : 04624343-B44B-B0A1-3CD4-8A411789FF20
-------------------------------------------------------------------------------
Test 1 [0000:17:00.1]     : aie-pl
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Validation completed. Please run the command '--verbose' option for more details
dbenusov@xsjchrisd42:/proj/xsjhdstaff6/dbenusov/XRT$ echo $?
0
dbenusov@xsjchrisd42:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil validate -r aie-pl -d 17:00 --verbose
Verbose: Enabling Verbosity
Starting validation for 1 devices
>>>>^^^^>>>> This is an issue with the kernel
Validate Device           : [0000:17:00.1]
    Platform              : xilinx_vck5000_gen4x8_xdma_base_2
    SC Version            : 4.4.32
    Platform ID           : 04624343-B44B-B0A1-3CD4-8A411789FF20
-------------------------------------------------------------------------------
Test 1 [0000:17:00.1]     : aie-pl
    Description           : Needs description
    Xclbin                : /opt/xilinx/firmware/vck5000/gen4x8-xdma/base/test
    Testcase              : /proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt/test/aie_pl.exe
    Error(s)              : Time Out
    Test Status           : [FAILED]
-------------------------------------------------------------------------------
Validation failed
```
To get around this issue the user must reset the user partition using `xbutil reset`

#### What has been tested and how, request additional testing if necessary
Manual testing on vck5000
Non-verbose
```
dbenusov@xsjchrisd42:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil validate -r aie-pl -d 17:00
Starting validation for 1 devices

Validate Device           : [0000:17:00.1]
    Platform              : xilinx_vck5000_gen4x8_xdma_base_2
    SC Version            : 4.4.32
    Platform ID           : 04624343-B44B-B0A1-3CD4-8A411789FF20
-------------------------------------------------------------------------------
Test 1 [0000:17:00.1]     : aie-pl
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Validation completed. Please run the command '--verbose' option for more details
dbenusov@xsjchrisd42:/proj/xsjhdstaff6/dbenusov/XRT$ echo $?
0
```
Verbose
```
dbenusov@xsjchrisd42:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil validate -r aie-pl -d 17:00 --verbose
Verbose: Enabling Verbosity
Starting validation for 1 devices

Validate Device           : [0000:17:00.1]
    Platform              : xilinx_vck5000_gen4x8_xdma_base_2
    SC Version            : 4.4.32
    Platform ID           : 04624343-B44B-B0A1-3CD4-8A411789FF20
-------------------------------------------------------------------------------
Test 1 [0000:17:00.1]     : aie-pl
    Description           : Run AIE PL test
    Xclbin                : /opt/xilinx/firmware/vck5000/gen4x8-xdma/base/test
    Testcase              : /proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt/test/aie_pl.exe
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Validation completed
dbenusov@xsjchrisd42:/proj/xsjhdstaff6/dbenusov/XRT$ echo $?
0
```
On a non-supported card
```
dbenusov@xsjsagarw50:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil validate -r aie-pl -d 17:00
Starting validation for 1 devices

Validate Device           : [0000:17:00.1]
    Platform              : xilinx_u30_gen3x4_base_2
    SC Version            :
    Platform ID           : 6E7C97F7-949F-5106-3075-A77784C30A4B
-------------------------------------------------------------------------------
Test 1 [0000:17:00.1]     : aie-pl
Validation completed. Please run the command '--verbose' option for more details
dbenusov@xsjsagarw50:/proj/xsjhdstaff6/dbenusov/XRT$ echo $?
0
dbenusov@xsjsagarw50:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil validate -r aie-pl -d 17:00 --verbose
Verbose: Enabling Verbosity
Starting validation for 1 devices

Validate Device           : [0000:17:00.1]
    Platform              : xilinx_u30_gen3x4_base_2
    SC Version            :
    Platform ID           : 6E7C97F7-949F-5106-3075-A77784C30A4B
-------------------------------------------------------------------------------
Test 1 [0000:17:00.1]     : aie-pl
    Description           : Run AIE PL test
    Details               : Verify xclbin not available or shell partition is not
                            programmed. Skipping validation.
    Test Status           : [SKIPPED]
-------------------------------------------------------------------------------
Validation completed
dbenusov@xsjsagarw50:/proj/xsjhdstaff6/dbenusov/XRT$ echo $?
0
```
#### Documentation impact (if any)
Need to add AIE PL test into documentation. I also noticed the legacy names were being used so they have been replaced with the new names.