### PR TITLE
Add useful getters to xrt::kernel

### DIFF
--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -1571,6 +1571,12 @@ public:
     return name;
   }
 
+  xrt::xclbin
+  get_xclbin() const
+  {
+    return xclbin;
+  }
+
   const std::bitset<max_cus>&
   get_cumask() const
   {
@@ -3122,6 +3128,20 @@ offset(int argno) const
   return xdp::native::profiling_wrapper("xrt::kernel::offset", [this, argno]{
     return handle->arg_offset(argno);
   });
+}
+
+std::string
+kernel::
+get_name() const
+{
+  return handle->get_name();
+}
+
+xrt::xclbin
+kernel::
+get_xclbin() const
+{
+  return handle->get_xclbin();
 }
 
 } // namespace xrt

--- a/src/runtime_src/core/include/xrt/xrt_kernel.h
+++ b/src/runtime_src/core/include/xrt/xrt_kernel.h
@@ -700,6 +700,20 @@ public:
   uint32_t
   read_register(uint32_t offset) const;
 
+  /**
+   * get_name() - Return the name of the kernel
+   */
+  XCL_DRIVER_DLLESPEC
+  std::string 
+  get_name() const;
+  
+  /**
+   * get_xclbin() - Return the xclbin containing the kernel
+   */
+  XCL_DRIVER_DLLESPEC
+  xrt::xclbin 
+  get_xclbin() const;
+
 public:
   /// @cond
   const std::shared_ptr<kernel_impl>&


### PR DESCRIPTION
I needed this while building interop support for our SYCL plugin.

@stsoe : do you want those to be documented or not ?