### PR TITLE
Add missing #include <stdexcept>

### DIFF
--- a/src/runtime_src/core/common/memalign.h
+++ b/src/runtime_src/core/common/memalign.h
@@ -16,8 +16,10 @@
 
 #ifndef xrtcore_memalign_h_
 #define xrtcore_memalign_h_
-#include <memory>
+
 #include <cstdlib>
+#include <memory>
+#include <stdexcept>
 
 namespace xrt_core {
 


### PR DESCRIPTION
There was a throw std::runtime_error which was undefined when
compiling with g++ 11.2 on Ubuntu 21.10.