### PR TITLE
CR-1105659 use device bdf in python tests command line args instead of device index

### DIFF
--- a/src/python/xrt_binding.py
+++ b/src/python/xrt_binding.py
@@ -1008,7 +1008,7 @@ def xrtDeviceOpenByBDF(bdf):
     """
     libcoreutil.xrtDeviceOpenByBDF.restype = ctypes.POINTER(xrtDeviceHandle)
     libcoreutil.xrtDeviceOpenByBDF.argTypes = [ctypes.c_char_p]
-    return _valueOrError(libcoreutil.xrtDeviceOpenBDF(bdf))
+    return _valueOrError(libcoreutil.xrtDeviceOpenByBDF(bdf))
 
 def xrtDeviceClose(handle):
     """

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -344,7 +344,7 @@ runTestCase( const std::shared_ptr<xrt_core::device>& _dev, const std::string& p
     logger(_ptTest, "Testcase", xrtTestCasePath);
 
     std::vector<std::string> args = { "-k", xclbinPath,
-                                      "-d", std::to_string(_dev.get()->get_device_id()) };
+                                      "-d", xrt_core::query::pcie_bdf::to_string(xrt_core::device_query<xrt_core::query::pcie_bdf>(_dev)) };
     int exit_code;
     try {
       if (py.find(".exe") != std::string::npos)

--- a/tests/python/utils_binding.py
+++ b/tests/python/utils_binding.py
@@ -33,7 +33,7 @@ class Options(object):
         self.halLogFile = None
         self.alignment = 4096
         self.option_index = 0
-        self.index = 0
+        self.bdf = None
         self.cu_index = 0
         self.verbose = False
         self.handle = None
@@ -61,7 +61,7 @@ class Options(object):
             elif o in ("--cu_index", "-c"):
                 self.cu_index = int(arg)
             elif o in ("--device", "-d"):
-                self.index = int(arg)
+                self.bdf = arg
             elif o in ("--help", "-h"):
                 print(self.printHelp())
             elif o == "-v":
@@ -91,17 +91,18 @@ class Options(object):
 
 def initXRT(opt):
     deviceInfo = xclDeviceInfo2()
-    if opt.index >= xclProbe():
-        raise RuntimeError("Incorrect device index")
 
-    opt.handle = xrtDeviceOpen(opt.index)
+    opt.handle = xrtDeviceOpenByBDF(opt.bdf)
+    if opt.handle is None:
+            raise RuntimeError("Invalid device BDF")
+
     opt.xcl_handle = xrtDeviceToXclDevice(opt.handle)
 
     xclGetDeviceInfo2(opt.xcl_handle, ctypes.byref(deviceInfo))
 
     if sys.version_info[0] == 3:
         print("Shell = %s" % deviceInfo.mName)
-        print("Index = %d" % opt.index)
+        print("Index = %s" % opt.bdf)
         print("PCIe = GEN%d x %d" % (deviceInfo.mPCIeLinkSpeed, deviceInfo.mPCIeLinkWidth))
         print("OCL Frequency = (%d, %d) MHz" % (deviceInfo.mOCLFrequency[0], deviceInfo.mOCLFrequency[1]))
         print("DDR Bank = %d" % deviceInfo.mDDRBankCount)
@@ -109,7 +110,7 @@ def initXRT(opt):
         print("MIG Calibration = %s" % deviceInfo.mMigCalib)
     else:
         print("Shell = %s") % deviceInfo.mName
-        print("Index = %s") % opt.index
+        print("Index = %s") % opt.bdf
         print("PCIe = GEN%s" + " x %s") % (deviceInfo.mPCIeLinkSpeed, deviceInfo.mPCIeLinkWidth)
         print("OCL Frequency = %s MHz") % deviceInfo.mOCLFrequency[0]
         print("DDR Bank = %d") % deviceInfo.mDDRBankCount

--- a/tests/python/utils_binding.py
+++ b/tests/python/utils_binding.py
@@ -33,7 +33,7 @@ class Options(object):
         self.halLogFile = None
         self.alignment = 4096
         self.option_index = 0
-        self.bdf = None
+        self.index = None
         self.cu_index = 0
         self.verbose = False
         self.handle = None
@@ -61,7 +61,7 @@ class Options(object):
             elif o in ("--cu_index", "-c"):
                 self.cu_index = int(arg)
             elif o in ("--device", "-d"):
-                self.bdf = arg
+                self.index = arg
             elif o in ("--help", "-h"):
                 print(self.printHelp())
             elif o == "-v":
@@ -92,7 +92,7 @@ class Options(object):
 def initXRT(opt):
     deviceInfo = xclDeviceInfo2()
 
-    opt.handle = xrtDeviceOpenByBDF(opt.bdf)
+    opt.handle = xrtDeviceOpenByBDF(opt.index)
     if opt.handle is None:
             raise RuntimeError("Invalid device BDF")
 
@@ -102,7 +102,7 @@ def initXRT(opt):
 
     if sys.version_info[0] == 3:
         print("Shell = %s" % deviceInfo.mName)
-        print("Index = %s" % opt.bdf)
+        print("Index = %s" % opt.index)
         print("PCIe = GEN%d x %d" % (deviceInfo.mPCIeLinkSpeed, deviceInfo.mPCIeLinkWidth))
         print("OCL Frequency = (%d, %d) MHz" % (deviceInfo.mOCLFrequency[0], deviceInfo.mOCLFrequency[1]))
         print("DDR Bank = %d" % deviceInfo.mDDRBankCount)
@@ -110,7 +110,7 @@ def initXRT(opt):
         print("MIG Calibration = %s" % deviceInfo.mMigCalib)
     else:
         print("Shell = %s") % deviceInfo.mName
-        print("Index = %s") % opt.bdf
+        print("Index = %s") % opt.index
         print("PCIe = GEN%s" + " x %s") % (deviceInfo.mPCIeLinkSpeed, deviceInfo.mPCIeLinkWidth)
         print("OCL Frequency = %s MHz") % deviceInfo.mOCLFrequency[0]
         print("DDR Bank = %d") % deviceInfo.mDDRBankCount

--- a/tests/xrt/100_ert_ncu/xrtx.cpp
+++ b/tests/xrt/100_ert_ncu/xrtx.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020-2022 Xilinx, Inc
+ * Copyright (C) 2020 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -44,7 +44,7 @@ usage()
 {
   std::cout << "usage: %s [options] \n\n";
   std::cout << "  -k <bitstream>\n";
-  std::cout << "  -d <device_bdf>\n";
+  std::cout << "  -d <device_index>\n";
   std::cout << "";
   std::cout << "  [--jobs <number>]: number of concurrently scheduled jobs\n";
   std::cout << "  [--cus <number>]: number of cus to use (default: 8) (max: 8)\n";
@@ -226,7 +226,7 @@ run(int argc, char** argv)
   std::vector<std::string> args(argv+1,argv+argc);
 
   std::string xclbin_fnm;
-  std::string device_bdf;
+  unsigned int device_index = 0;
   size_t secs = 0;
   size_t jobs = 1;
   size_t cus  = 1;
@@ -244,7 +244,7 @@ run(int argc, char** argv)
     }
 
     if (cur == "-d")
-      device_bdf = arg;
+      device_index = std::stoi(arg);
     else if (cur == "-k")
       xclbin_fnm = arg;
     else if (cur == "--jobs")
@@ -257,7 +257,7 @@ run(int argc, char** argv)
       throw std::runtime_error("bad argument '" + cur + " " + arg + "'");
   }
 
-  auto device = xrtDeviceOpenByBDF(device_bdf);
+  auto device = xrtDeviceOpen(device_index);
 
   if (xrtDeviceLoadXclbinFile(device, xclbin_fnm.c_str()))
     throw std::runtime_error("failed to load xclbin");

--- a/tests/xrt/100_ert_ncu/xrtx.cpp
+++ b/tests/xrt/100_ert_ncu/xrtx.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Xilinx, Inc
+ * Copyright (C) 2020-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -44,7 +44,7 @@ usage()
 {
   std::cout << "usage: %s [options] \n\n";
   std::cout << "  -k <bitstream>\n";
-  std::cout << "  -d <device_index>\n";
+  std::cout << "  -d <device_bdf>\n";
   std::cout << "";
   std::cout << "  [--jobs <number>]: number of concurrently scheduled jobs\n";
   std::cout << "  [--cus <number>]: number of cus to use (default: 8) (max: 8)\n";
@@ -226,7 +226,7 @@ run(int argc, char** argv)
   std::vector<std::string> args(argv+1,argv+argc);
 
   std::string xclbin_fnm;
-  unsigned int device_index = 0;
+  std::string device_bdf;
   size_t secs = 0;
   size_t jobs = 1;
   size_t cus  = 1;
@@ -244,7 +244,7 @@ run(int argc, char** argv)
     }
 
     if (cur == "-d")
-      device_index = std::stoi(arg);
+      device_bdf = arg;
     else if (cur == "-k")
       xclbin_fnm = arg;
     else if (cur == "--jobs")
@@ -257,7 +257,7 @@ run(int argc, char** argv)
       throw std::runtime_error("bad argument '" + cur + " " + arg + "'");
   }
 
-  auto device = xrtDeviceOpen(device_index);
+  auto device = xrtDeviceOpenByBDF(device_bdf);
 
   if (xrtDeviceLoadXclbinFile(device, xclbin_fnm.c_str()))
     throw std::runtime_error("failed to load xclbin");


### PR DESCRIPTION
#### Problem solved by the commit
Python applications (as part of xbutil validate) are using device indexes in command line args.
 This is causing a problem when running xbutil tests run on multi card setup (ex: Microsoft Azure) concurrently.
Example:
   1. Issue reset on device0 (has index 0), and issue validate on device1 (has index 1).
   2. In device0 reset sequence, it resets the card and removes the index from devicesList.
      Hence, device1 index become 0.
   3. This same issue not seen if validate test run on device0 and reset on device1.
      Since, reset of device1 removes the index from deviceList, and doesn't affect device0 index.

Signed-off-by: Durga prasad Kotipalli <dkotipal@xilinx.com>
Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>

Validate tests failure is solved.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1105659

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added change in XRT tests.

#### Risks (if any) associated the changes in the commit
NA

#### What has been tested and how, request additional testing if necessary
xbutil reset and validate tests on multi card setup.

#### Documentation impact (if any)
NA