### PR TITLE
Issue #6619 Implement xrt::device equality

### DIFF
--- a/src/runtime_src/core/common/api/xrt_device.cpp
+++ b/src/runtime_src/core/common/api/xrt_device.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2020-2022 Xilinx, Inc. All rights reserved.
+// Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
 
 // This file implements XRT xclbin APIs as declared in
 // core/include/experimental/xrt_device.h
@@ -337,6 +338,15 @@ get_info_std(info::device param, const xrt::detail::abi& abi) const
   return query::get_info<std::any>(handle.get(), param, abi);
 }
 #endif
+
+// Equality means that both device objects refer to the same
+// underlying device.  The underlying device is opened based
+// on device id
+bool
+operator== (const device& d1, const device& d2)
+{
+  return d1.get_handle()->get_device_id() == d2.get_handle()->get_device_id();
+}
 
 } // xrt
 

--- a/src/runtime_src/core/include/xrt/xrt_device.h
+++ b/src/runtime_src/core/include/xrt/xrt_device.h
@@ -412,6 +412,28 @@ private:
   std::shared_ptr<xrt_core::device> handle;
 };
 
+/**
+ * operator==() - Compare two device objects
+ *
+ * @return
+ *   True if device objects refers to same physical device
+ */
+XCL_DRIVER_DLLESPEC
+bool
+operator== (const device& d1, const device& d2);
+
+/**
+ * operator!=() - Compare two device objects
+ *
+ * @return
+ *   True if device objects do not refer to same physical device
+ */
+inline bool
+operator!= (const device& d1, const device& d2)
+{
+  return !(d1 == d2);
+}
+
 } // namespace xrt
 
 /// @cond

--- a/tests/xrt/query/main.cpp
+++ b/tests/xrt/query/main.cpp
@@ -1,29 +1,16 @@
-/**
- * Copyright (C) 2021 Xilinx, Inc
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2021 Xilinx, Inc. All rights reserved.
+// Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
 #include <iostream>
 #include <stdexcept>
 #include <string>
 
 #include "xrt/xrt_device.h"
 
-/**
- * Exercise some xrt::info::device query parameters as defined in
- * xrt_device.h
- */
+// Exercise some xrt::info::device query parameters as defined in
+// xrt_device.h
+//
+// % g++ -g -std=c++17 -I$XILINX_XRT/include -L$XILINX_XRT/lib -o query.exe main.cpp -lxrt_coreutil -luuid -pthread
 
 static void
 usage()
@@ -111,6 +98,18 @@ run(int argc, char** argv)
     std::cout << device.get_info<xrt::info::device::dynamic_regions>();
     std::cout << "device host json info ==========================================\n";
     std::cout << device.get_info<xrt::info::device::host>();
+  }
+
+  // Equality implemented in 2.14
+  auto device2 = xrt::device{device_index};
+  if (device2 != device) {
+#if XRT_VERSION_CODE >= XRT_VERSION(2,14)
+    throw std::runtime_error("Equality check failed");
+#else
+    std::cout << "device equality not implemented in XRT("
+              << XRT_MAJOR(XRT_VERSION_CODE) << ","
+              << XRT_MINOR(XRT_VERSION_CODE) << ")\n";
+#endif
   }
 
   return 0;


### PR DESCRIPTION
Two xrt::device objects referring to same physical device
now compare equal.


#### Problem solved by the commit
Equality fails on two xrt::device objects even if both refer to same underlying physical device

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Fixes #6619

#### How problem was solved, alternative solutions (if any) and why they were rejected
Implement operator== to compare the device id with which the device object was constructed.

#### Risks (if any) associated the changes in the commit
Behavior changes because the previous default operator== compared the xrt::device opaque implementation handle and would return false when after this change the comparison may return true if the handle implementation refers to same physical device.

#### What has been tested and how, request additional testing if necessary
Updated unit test accordingly

#### Documentation impact (if any)
Per doxygen
