### PR TITLE
Multislot fixes for multiple xclbin loaded parallelly

### DIFF
--- a/src/runtime_src/core/common/drv/include/xrt_cu.h
+++ b/src/runtime_src/core/common/drv/include/xrt_cu.h
@@ -239,8 +239,10 @@ enum CU_PROTOCOL {
 
 struct xrt_cu_info {
 	u32			 model;
-	int			 cu_idx;
 	u32			 slot_idx;
+	/* CU Index respected to a slot */
+	int			 cu_idx;
+	/* Global CU Index respected to a device */
 	int			 inst_idx;
 	u64			 addr;
 	size_t			 size;

--- a/src/runtime_src/core/edge/drm/zocl/cu.c
+++ b/src/runtime_src/core/edge/drm/zocl/cu.c
@@ -217,7 +217,7 @@ static int cu_probe(struct platform_device *pdev)
 	sprintf(zcu->irq_name, "zocl_cu[%d]", info->intr_id);
 
 	if (info->intr_enable) {
-		zcu->irq = zdev->irq[info->intr_id];
+		zcu->irq = zdev->cu_subdev.irq[info->intr_id];
 		/* Currently requesting irq if it's enable in cu config.
 		 * Not disabling it further, even user wants to use 
 		 * polling.
@@ -255,7 +255,7 @@ static int cu_probe(struct platform_device *pdev)
 	zcu->base.user_manage_irq = user_manage_irq;
 	zcu->base.configure_irq = configure_irq;
 
-	zocl_info(&pdev->dev, "CU[%d] created", info->cu_idx);
+	zocl_info(&pdev->dev, "CU[%d] created", info->inst_idx);
 	return 0;
 err2:
 	zocl_kds_del_cu(zdev, &zcu->base);
@@ -299,7 +299,7 @@ static int cu_remove(struct platform_device *pdev)
 
 	sysfs_remove_group(&pdev->dev.kobj, &cu_attrgroup);
 
-	zocl_info(&pdev->dev, "CU[%d] removed", info->cu_idx);
+	zocl_info(&pdev->dev, "CU[%d] removed", info->inst_idx);
 	kfree(zcu->irq_name);
 	kfree(zcu);
 

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
@@ -228,7 +228,7 @@ int zocl_iommu_unmap_bo(struct drm_device *dev, struct drm_zocl_bo *bo);
 
 int zocl_init_sysfs(struct device *dev);
 void zocl_fini_sysfs(struct device *dev);
-void zocl_free_sections(struct drm_zocl_slot *slot);
+void zocl_free_sections(struct drm_zocl_dev *dev, struct drm_zocl_slot *slot);
 void zocl_free_bo(struct drm_gem_object *obj);
 void zocl_drm_free_bo(struct drm_zocl_bo *bo);
 struct drm_zocl_bo *zocl_drm_create_bo(struct drm_device *dev,
@@ -320,7 +320,7 @@ zocl_cu_submit_xcmd(struct drm_zocl_dev *zdev, int i, struct kds_command *xcmd)
 	struct zocl_drv_private *priv;
 	struct zocl_cu_ops *ops;
 
-	pdev = zdev->cu_pldev[i];
+	pdev = zdev->cu_subdev.cu_pldev[i];
 	priv = (void *)platform_get_device_id(pdev)->driver_data;
 	ops = (struct zocl_cu_ops *)priv->ops;
 	return ops->submit(pdev, xcmd);

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_util.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_util.h
@@ -122,6 +122,15 @@ struct drm_zocl_slot {
 	struct mutex		 slot_xclbin_lock;
 };
 
+struct zocl_cu_subdev {
+	unsigned int		 cu_num;
+	unsigned int             irq[MAX_CU_NUM];
+	struct platform_device	*cu_pldev[MAX_CU_NUM];
+	struct addr_aperture	*apertures;
+	unsigned int		 num_apts;
+	struct mutex		 lock;
+};
+
 struct drm_zocl_dev {
 	struct drm_device       *ddev;
 	struct fpga_manager     *fpga_mgr;
@@ -131,8 +140,6 @@ struct drm_zocl_dev {
 	resource_size_t          host_mem_len;
 	/* Record start address, this is only for MPSoC as PCIe platform */
 	phys_addr_t		 res_start;
-	unsigned int		 cu_num;
-	unsigned int             irq[MAX_CU_NUM];
 	struct sched_exec_core  *exec;
 	/* Zocl driver memory list head */
 	struct list_head	 zm_list_head;
@@ -142,11 +149,8 @@ struct drm_zocl_dev {
 
 	struct list_head	 ctx_list;
 
-	struct addr_aperture	*apertures;
-	unsigned int		 num_apts;
-
+	struct zocl_cu_subdev	 cu_subdev;
 	struct kds_sched	 kds;
-	struct platform_device	*cu_pldev[MAX_CU_NUM];
 
 	/*
 	 * This RW lock is to protect the sysfs nodes exported

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_xclbin.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_xclbin.h
@@ -23,7 +23,8 @@ struct zocl_xclbin {
 int zocl_xclbin_init(struct drm_zocl_slot *slot);
 void zocl_xclbin_fini(struct drm_zocl_dev *zdev, struct drm_zocl_slot *slot);
 
-int zocl_xclbin_set_uuid(struct drm_zocl_slot *slot, void *uuid);
+int zocl_xclbin_set_uuid(struct drm_zocl_dev *zdev,
+			 struct drm_zocl_slot *slot, void *uuid);
 void *zocl_xclbin_get_uuid(struct drm_zocl_slot *slot);
 int zocl_xclbin_hold(struct drm_zocl_slot *slot, const uuid_t *id);
 int zocl_lock_bitstream(struct drm_zocl_slot *slot, const uuid_t *id);
@@ -39,6 +40,7 @@ int zocl_xclbin_load_pdi(struct drm_zocl_dev *zdev, void *data,
 			struct drm_zocl_slot *slot);
 int zocl_xclbin_load_pskernel(struct drm_zocl_dev *zdev, void *data);
 bool zocl_xclbin_accel_adapter(int kds_mask);
-int zocl_xclbin_set_dtbo_path(struct drm_zocl_slot *slot, char *dtbo_path);
+int zocl_xclbin_set_dtbo_path(struct drm_zocl_dev *zdev,
+			      struct drm_zocl_slot *slot, char *dtbo_path);
 
 #endif /* _ZOCL_XCLBIN_H_ */

--- a/src/runtime_src/core/edge/drm/zocl/zocl_aie.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_aie.c
@@ -325,9 +325,8 @@ zocl_destroy_aie(struct drm_zocl_dev *zdev)
 	if (!zdev->aie_information)
 		return;
 
-	vfree(zdev->aie_information);
 	mutex_lock(&zdev->aie_lock);
-
+	vfree(zdev->aie_information);
 	if (!zdev->aie) {
 		mutex_unlock(&zdev->aie_lock);
 		return;

--- a/src/runtime_src/core/edge/drm/zocl/zocl_ioctl.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_ioctl.c
@@ -64,7 +64,7 @@ zocl_info_cu_ioctl(struct drm_device *ddev, void *data, struct drm_file *filp)
 {
 	struct drm_zocl_info_cu *args = data;
 	struct drm_zocl_dev *zdev = ddev->dev_private;
-	struct addr_aperture *apts = zdev->apertures;
+	struct addr_aperture *apts = zdev->cu_subdev.apertures;
 	int apt_idx = args->apt_idx;
 	int cu_idx = args->cu_idx;
 	phys_addr_t addr = args->paddr;

--- a/src/runtime_src/core/edge/drm/zocl/zocl_sysfs.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_sysfs.c
@@ -66,17 +66,21 @@ static ssize_t xclbinid_show(struct device *dev,
 	ssize_t count = 0;
 	int i = 0;
 
+	read_lock(&zdev->attr_rwlock);
 	for (i = 0; i < zdev->num_pr_slot; i++) {
 		zocl_slot = zdev->pr_slot[i];
 		if (!zocl_slot || !zocl_slot->slot_xclbin ||
-		    !zocl_slot->slot_xclbin->zx_uuid)
+		    !zocl_slot->slot_xclbin->zx_uuid) {
+			read_unlock(&zdev->attr_rwlock);
 			return 0;
+		}
 
 		count = sprintf(buf+size, raw_fmt, zocl_slot->slot_idx,
 				zocl_slot->slot_xclbin->zx_uuid);
 		size += count;
 	}
 
+	read_unlock(&zdev->attr_rwlock);
 	return size;
 }
 static DEVICE_ATTR_RO(xclbinid);
@@ -91,6 +95,7 @@ static ssize_t dtbo_path_show(struct device *dev,
 	ssize_t count = 0;
 	int i = 0;
 
+	read_lock(&zdev->attr_rwlock);
 	for (i = 0; i < zdev->num_pr_slot; i++) {
 		zocl_slot = zdev->pr_slot[i];
 		if (!zocl_slot || !zocl_slot->slot_xclbin ||
@@ -102,6 +107,7 @@ static ssize_t dtbo_path_show(struct device *dev,
 		size += count;
 	}
 
+	read_unlock(&zdev->attr_rwlock);
 	return size;
 }
 static DEVICE_ATTR_RO(dtbo_path);

--- a/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
@@ -1015,16 +1015,14 @@ zocl_load_aie_only_pdi(struct drm_zocl_dev *zdev, struct axlf *axlf,
  */
 void zocl_free_sections(struct drm_zocl_dev *zdev, struct drm_zocl_slot *slot)
 {
-	if (slot->ip)
-		vfree(slot->ip);
-	if (slot->debug_ip)
-		vfree(slot->debug_ip);
-	if (slot->connectivity)
-		vfree(slot->connectivity);
-	if (slot->topology)
-		vfree(slot->topology);
-	if (slot->axlf)
-		vfree(slot->axlf);
+	/*
+	 * vfree can ignore NULL pointer. We don't need to check if it is NULL.
+	 */
+	vfree(slot->ip);
+	vfree(slot->debug_ip);
+	vfree(slot->connectivity);
+	vfree(slot->topology);
+	vfree(slot->axlf);
 
 	write_lock(&zdev->attr_rwlock);
 	CLEAR(slot->ip);


### PR DESCRIPTION
**Issue :** 
Multi slot code is working for single slot only. But while testing with multiple xclbin, it's failing.

**Root Cause:**
The root cause of this is locking. We haven't use the locks efficiently to support multiple xclbin loaded parallelly. 
Also many places we have taken spinlocks in non-atomic context. 

**Test:** 
I have a customized test case for multiple xclbin (multi slot verification) with multiple PL kernels (i.e. vadd, vsub, vmul, vdiv).
I have different xclbin for each kernels. The test application is forking multiple child processes. 
Each child process is loading/reloading a different xclbin to a different slot parallelly.  

