### PR TITLE
fix KDS mode performance degradation issue

### DIFF
--- a/src/runtime_src/core/common/drv/include/kds_core.h
+++ b/src/runtime_src/core/common/drv/include/kds_core.h
@@ -158,6 +158,7 @@ struct kds_sched {
 
 	/* KDS polling thread */
 	struct task_struct     *polling_thread;
+	struct list_head	alive_cus; /* alive CU list */
 	wait_queue_head_t	wait_queue;
 	int			polling_start;
 	int			polling_stop;

--- a/src/runtime_src/core/common/drv/include/xrt_cu.h
+++ b/src/runtime_src/core/common/drv/include/xrt_cu.h
@@ -283,6 +283,7 @@ struct xrt_cu {
 	struct device		 *dev;
 	struct xrt_cu_info	  info;
 	struct resource		**res;
+	struct list_head	  cu;
 	/* pending queue */
 	struct list_head	  pq;
 	spinlock_t		  pq_lock;

--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -175,27 +175,15 @@ kds_wake_up_poll(struct kds_sched *kds)
 static int kds_polling_thread(void *data)
 {
 	struct kds_sched *kds = (struct kds_sched *)data;
-	struct kds_cu_mgmt *cu_mgmt = &kds->cu_mgmt;
-	struct kds_scu_mgmt *scu_mgmt = &kds->scu_mgmt;
-	struct xrt_cu **xcus = cu_mgmt->xcus;
-	struct xrt_cu **xscus = scu_mgmt->xcus;
 	int busy_cnt = 0;
 	int loop_cnt = 0;
-	int cu_idx = 0;
 
 	while (!kds->polling_stop) {
+		struct xrt_cu *xcu;
 		busy_cnt = 0;
-		for (cu_idx = 0; cu_idx < MAX_CUS; cu_idx++) {
-			if (!xcus[cu_idx])
-				continue;
 
-			if (xrt_cu_process_queues(xcus[cu_idx]) == XCU_BUSY)
-				busy_cnt += 1;
-		}
-		for (cu_idx = 0; cu_idx < MAX_CUS; cu_idx++) {
-			if (!xscus[cu_idx])
-				continue;
-			if (xrt_cu_process_queues(xscus[cu_idx]) == XCU_BUSY)
+		list_for_each_entry(xcu, &kds->alive_cus, cu) {
+			if (xrt_cu_process_queues(xcu) == XCU_BUSY)
 				busy_cnt += 1;
 		}
 
@@ -1021,6 +1009,7 @@ int kds_init_sched(struct kds_sched *kds)
 		return -ENOMEM;
 
 	INIT_LIST_HEAD(&kds->clients);
+	INIT_LIST_HEAD(&kds->alive_cus);
 	mutex_init(&kds->lock);
 	mutex_init(&kds->cu_mgmt.lock);
 	mutex_init(&kds->scu_mgmt.lock);
@@ -1393,7 +1382,7 @@ int kds_add_cu(struct kds_sched *kds, struct xrt_cu *xcu)
 	if (cu_mgmt->num_cus >= MAX_CUS)
 		return -ENOMEM;
 
-	/* 
+	/*
 	 * For multi slot sorting CUs are not possible. We will find a free slot and
 	 * assign the CUs to that.
 	 */
@@ -1403,6 +1392,7 @@ int kds_add_cu(struct kds_sched *kds, struct xrt_cu *xcu)
 		if (cu_mgmt->xcus[i] == NULL) {
 			insert_cu(cu_mgmt, i, xcu);
 			++cu_mgmt->num_cus;
+			list_add_tail(&xcu->cu, &kds->alive_cus);
 			break;
 		}
 	}
@@ -1425,6 +1415,7 @@ int kds_del_cu(struct kds_sched *kds, struct xrt_cu *xcu)
 		cu_mgmt->xcus[i] = NULL;
 		cu_mgmt->cu_intr[i] = 0;
 		--cu_mgmt->num_cus;
+		list_del(&xcu->cu);
 		cu_stat_write(cu_mgmt, usage[i], 0);
 		break;
 	}
@@ -1451,6 +1442,7 @@ int kds_add_scu(struct kds_sched *kds, struct xrt_cu *xcu)
 			xcu->info.cu_idx = i;
 			++scu_mgmt->num_cus;
 
+			list_add_tail(&xcu->cu, &kds->alive_cus);
 			return 0;
 		}
 	}
@@ -1472,6 +1464,7 @@ int kds_del_scu(struct kds_sched *kds, struct xrt_cu *xcu)
 
 		scu_mgmt->xcus[i] = NULL;
 		--scu_mgmt->num_cus;
+		list_del(&xcu->cu);
 		cu_stat_write(scu_mgmt, usage[i], 0);
 		break;
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
We observed ~20% KDS performance degradation in 2022.1 XRT, when ERT is disabled. The test case is "xbutil validate -r iops". 

#### How problem was solved, alternative solutions (if any) and why they were rejected
The reason is the KDS polling thread will iterate 128 CU + 128 SCU slots. If there is no alive CU in the slot, it will 'continue'. This behavior has a big performance impact.

I added an alive CU list for the KDS polling thread. All of alive PL/PS CUs are on the same list.

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
The IOPS test case on u50 base-5 shell.

#### Documentation impact (if any)
No