### PR TITLE
CR-1127142 shim: add flag to exit dev_offline status check loop forci…

### DIFF
--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -831,6 +831,15 @@ get_flag_sw_emu_kernel_debug()
   return value;
 }
 
+// This flag is added to exit device offline status check loop forcibly.
+// By default, device offline status loop runs for 120 seconds.
+inline unsigned int
+get_device_offline_timer()
+{
+  static unsigned int value = detail::get_uint_value("Runtime.dev_offline_timer", 120);
+  return value;
+}
+
 }} // config,xrt_core
 
 #endif

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -1112,15 +1112,28 @@ int shim::resetDevice(xclResetKind kind)
 
     dev_fini();
 
+    // This loop used to wait for device come online and ready to use. It reads "dev_offline"
+    // sysfs node to retrieve latest status of device in the interval of 500 milli sec.
+    // In certain testing environement, reset never complete and waits indefinitely
+    // in this loop for dev_offline status to be false. To overcome this infinite loop issue,
+    // added loop_timer (default value set to 120 sec) which is used to exit the loop.
+    unsigned int loop_timer = xrt_core::config::get_device_offline_timer();
+    auto start = std::chrono::system_clock::now();
     while (dev_offline) {
         std::this_thread::sleep_for(std::chrono::milliseconds(500));
         pcidev::get_dev(mBoardNumber)->sysfs_get<int>("",
             "dev_offline", err, dev_offline, -1);
+        auto end = std::chrono::system_clock::now();
+        std::chrono::duration<double> elapsed_seconds = end - start;
+        if (elapsed_seconds.count() > loop_timer) {
+            xrt_logmsg(XRT_WARNING, "%s: device unable to come online during reset, try again", __func__);
+            ret = -EAGAIN;
+        }
     }
 
     dev_init();
 
-    return 0;
+    return ret;
 }
 
 int shim::p2pEnable(bool enable, bool force)


### PR DESCRIPTION
…bly (#6632)

* shim: add flag to exit dev_offline status check loop forcibly

Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>

* minor fix

Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>

* fix review comments

Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>

* return error if reset failing

Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>

* Set timeout value to 120 sec

Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>

* fix compile time errors

Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>

* fix review comments

Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>
(cherry picked from commit 5f4f87c52b1fb7b8e2cf0283a213c25cb9964c7d)

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
