### PR TITLE
CR-1126565 Offline Build Option for XRT

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -56,6 +56,7 @@ usage()
     echo "[-driver]                   Include building driver code"
     echo "[-checkpatch]               Run checkpatch.pl on driver code"
     echo "[-verbose]                  Turn on verbosity when compiling"
+    echo "[-ertbsp <dir>]             Path to directory with pre-downloaded BSP files for building ERT (default: download BSP files during build time)"
     echo "[-ertfw <dir>]              Path to directory with pre-built ert firmware (default: build the firmware)"
     echo ""
     echo "ERT firmware is built if and only if MicroBlaze gcc compiler can be located."
@@ -86,6 +87,7 @@ nocmake=0
 nobuild=0
 noctest=0
 static_boost=""
+ertbsp=""
 ertfw=""
 cmake_flags="-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
 
@@ -101,6 +103,11 @@ while [ $# -gt 0 ]; do
         -dbg)
             dbg=1
             opt=0
+            shift
+            ;;
+        -ertbsp)
+            shift
+            ertbsp=$1
             shift
             ;;
         -ertfw)
@@ -210,6 +217,11 @@ if [[ $ccache == 1 ]]; then
     if [[ -e /proj/rdi/env/HEAD/hierdesign/ccache/cleanup.pl ]]; then
         /proj/rdi/env/HEAD/hierdesign/ccache/cleanup.pl 1 30 $RDI_CCACHEROOT
     fi
+fi
+
+if [[ ! -z $ertbsp ]]; then
+    echo "export ERT_BSP_DIR=$ertbsp"
+    export ERT_BSP_DIR=$ertbsp
 fi
 
 if [[ ! -z $ertfw ]]; then

--- a/src/runtime_src/ert/scheduler/CMakeLists.txt
+++ b/src/runtime_src/ert/scheduler/CMakeLists.txt
@@ -5,12 +5,28 @@
 
 if (${ERT_BUILD_ALL} STREQUAL "yes")
 
-function(GetBSP BSP)
+function(CopyBSP BSP)
+ message(STATUS "Copying ${BSP} from $ENV{ERT_BSP_DIR}")
+ file(COPY $ENV{ERT_BSP_DIR}/${BSP} DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+endfunction()
+
+function(DownloadBSP BSP)
  set(URL https://github.com/Xilinx/ERT-BSP/raw/main/BSPs/${BSP})
+ message(STATUS "Downloading ${BSP} from ${URL}")
  FILE(DOWNLOAD ${URL} ${CMAKE_CURRENT_BINARY_DIR}/${BSP} STATUS dlstatus)
  if(NOT dlstatus EQUAL 0)
   message(FATAL_ERROR "ERROR: Failed to retrieve files from: ${URL}\n"
                        "   error code: ${dlstatus}\n")
+ endif()
+endfunction()
+
+function(GetBSP BSP)
+ if(EXISTS ${CMAKE_CURRENT_BINARY_DIR}/${BSP})
+  message(STATUS "${BSP} exists, skip fetching")
+ elseif(DEFINED ENV{ERT_BSP_DIR})
+  CopyBSP(${BSP})
+ else()
+  DownloadBSP(${BSP})
  endif()
 endfunction()
 
@@ -49,7 +65,7 @@ function(build_ert_fw version)
    COMMAND ${CMAKE_COMMAND} -E make_directory ${version}
    COMMAND $(MAKE) DEFINES="-DERT_BUILD_${CFLAG_VERSION} " BLDDIR=${CMAKE_CURRENT_BINARY_DIR}/${version} SRCDIR=${CMAKE_CURRENT_SOURCE_DIR} -f ${CMAKE_CURRENT_SOURCE_DIR}/sched.mk ert
    DEPENDS ${version}/bsp.extracted ${CMAKE_CURRENT_SOURCE_DIR}/sched.c
-   COMMENT "Generating binary for ERT scheduler"
+   COMMENT "Generating binary for ERT scheduler: ${version}/sched.bin"
   )
 
   install (FILES

--- a/src/runtime_src/ert/scheduler/CMakeLists.txt
+++ b/src/runtime_src/ert/scheduler/CMakeLists.txt
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (C) 2019-2021 Xilinx, Inc. All rights reserved.
+# Copyright (C) 2019-2022 Xilinx, Inc. All rights reserved.
 #
 # Build ERT under legacy ,u50, v20, and v30 directories
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
The PR#5776 moved BSP files required for building ERT to a standalone repo. It introduced a regression that, after the change, Internet access is required when user builds XRT for downloading these BSP files. This regression is caught by one of our customers and caused CR-1126565 to be filed.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Fixing CR-1126565 introduced by PR#5776
#### How problem was solved, alternative solutions (if any) and why they were rejected
Since these BSP files are not part of XRT repo any more, they can be downloaded separately onto local disk. Adding an XRT build option (-ertbsp) to point to pre-downloaded BSP files to avoid downloading them during build time.

Also changed makefile to skip downloading, if they are already in place.

Alternatively, we could make BSP repo a git submodule of XRT repo. However, this will change XRT's build flow for all users, less ideal?
#### Risks (if any) associated the changes in the commit
N/A
#### What has been tested and how, request additional testing if necessary
Tested building XRT with or without -ertbsp option
#### Documentation impact (if any)
N/A