### PR TITLE
CR-1129824 Fix for PS kernel instance name issue

### DIFF
--- a/src/runtime_src/core/common/info_memory.cpp
+++ b/src/runtime_src/core/common/info_memory.cpp
@@ -564,6 +564,8 @@ populate_cus(const xrt_core::device *device)
     } 
     else { // scu_name e.g. kernel_vcu_encoder_2
       scu_name = ps_kernels.at(psk_inst).pkd_sym_name;
+      scu_name.append(":");
+      scu_name.append(ps_kernels.at(psk_inst).pkd_sym_name);
       scu_name.append("_");
       scu_name.append(std::to_string(num_scu));
     }

--- a/src/runtime_src/tools/xclbinutil/KernelUtilities.cxx
+++ b/src/runtime_src/tools/xclbinutil/KernelUtilities.cxx
@@ -588,7 +588,7 @@ XclBinUtilities::createPSKernelMetadata(unsigned long numInstances,
     boost::property_tree::ptree ptInstanceArray;
     for (unsigned long instance = 0; instance < numInstances; ++instance) {
       boost::property_tree::ptree ptInstance;
-      ptInstance.put("name", "scu_" + std::to_string(instance));
+      ptInstance.put("name", kernelName + "_" + std::to_string(instance));
       ptInstanceArray.push_back(std::make_pair("", ptInstance));
     }
     ptKernel.add_child("instances", ptInstanceArray);

--- a/src/runtime_src/tools/xclbinutil/unittests/PSKernel/embedded_metadata_expected.xml
+++ b/src/runtime_src/tools/xclbinutil/unittests/PSKernel/embedded_metadata_expected.xml
@@ -75,7 +75,7 @@
           <arg name="increment" addressQualifier="0" id="5" size="0x4" offset="0x38" hostOffset="0x0" hostSize="0x4" type="float"/>
           <arg name="increment_out" addressQualifier="1" id="6" size="0x10" offset="0x3c" hostOffset="0x0" hostSize="0x10" type="float*"/>
           <arg name="handles" addressQualifier="1" id="" size="0x10" offset="0x4c" hostOffset="0x0" hostSize="0x10" type="xrtHandles*"/>
-          <instance name="scu_0"/>
+          <instance name="kernel0_0"/>
         </kernel>
       </core>
     </device>

--- a/src/runtime_src/tools/xclbinutil/unittests/PSKernel/embedded_metadata_psk_expected.xml
+++ b/src/runtime_src/tools/xclbinutil/unittests/PSKernel/embedded_metadata_psk_expected.xml
@@ -12,7 +12,7 @@
           <arg name="increment" addressQualifier="0" id="5" size="0x4" offset="0x38" hostOffset="0x0" hostSize="0x4" type="float"/>
           <arg name="increment_out" addressQualifier="1" id="6" size="0x10" offset="0x3c" hostOffset="0x0" hostSize="0x10" type="float*"/>
           <arg name="handles" addressQualifier="1" id="" size="0x10" offset="0x4c" hostOffset="0x0" hostSize="0x10" type="xrtHandles*"/>
-          <instance name="scu_0"/>
+          <instance name="kernel0_0"/>
         </kernel>
       </core>
     </device>

--- a/src/runtime_src/tools/xclbinutil/unittests/PSKernel/ip_layout_expected.json
+++ b/src/runtime_src/tools/xclbinutil/unittests/PSKernel/ip_layout_expected.json
@@ -14,7 +14,7 @@
                 "m_type": "IP_PS_KERNEL",
                 "properties": "0x0",
                 "m_base_address": "not_used",
-                "m_name": "kernel0:scu_0"
+                "m_name": "kernel0:kernel0_0"
             }
         ]
     }

--- a/src/runtime_src/tools/xclbinutil/unittests/PSKernel/ip_layout_psk_expected.json
+++ b/src/runtime_src/tools/xclbinutil/unittests/PSKernel/ip_layout_psk_expected.json
@@ -6,7 +6,7 @@
                 "m_type": "IP_PS_KERNEL",
                 "properties": "0x0",
                 "m_base_address": "not_used",
-                "m_name": "kernel0:scu_0"
+                "m_name": "kernel0:kernel0_0"
             }
         ]
     }


### PR DESCRIPTION
Need to change both info_memory.cpp and xclbinutil's KernelUtilities.cxx

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Change PS kernel instance name to be KernelName:KernelName_<N>
This change is reflected in xclbinutil as well as info_memory.cpp where it contracts PS kernel instance name.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Found from DSV testing

#### How problem was solved, alternative solutions (if any) and why they were rejected
Changed instance name to follow kernel name.

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Tested on vck5000

#### Documentation impact (if any)
None
