### PR TITLE
CR-1129990 azure: increase mailbox timeout to 120 secs

### DIFF
--- a/src/runtime_src/core/pcie/tools/cloud-daemon/azure/azure.h
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/azure/azure.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019-2021 Xilinx, Inc
+ * Copyright (C) 2019-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -112,7 +112,7 @@ private:
     static const int rest_timeout { 30 }; //in second
     static const int upload_retry { 15 };
     static const int reset_retry { 3 };
-    static const int timeout_threshold { 49 }; //mailbox timeout set as 50s
+    static const int timeout_threshold { 120 }; //mailbox timeout set as 120 seconds
     std::shared_ptr<pcidev::pci_device> dev;
     size_t index;
     struct timeval start;


### PR DESCRIPTION
Increase the timeout value of mpd from 50 sec to 2 min. Relevant situation
1. User performs download of xclbin and wireserver receives the attested xclbin.
2. Next it fetches the full xclbin from the storage server and there is a delay in
   fetching the xclbin. This delay is sometimes more then 1 min and so MS suggested
   to increase the timeout value to 2 minutes

Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
xclbin download will not fail due to timeout issue

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1129990
#### How problem was solved, alternative solutions (if any) and why they were rejected
Increased mailbox timeout value to 120 sec in XRT
#### Risks (if any) associated the changes in the commit
NA
#### What has been tested and how, request additional testing if necessary
xclbin download
#### Documentation impact (if any)
NA