### PR TITLE
CR-1130084 Fix for xclbin with aie download issue on vck5000

### DIFF
--- a/build/petalinux.build
+++ b/build/petalinux.build
@@ -1,4 +1,4 @@
 # When updating Petalinux build please file a SH ticket to retain the build
 # https://jira.xilinx.com/secure/CreateIssue!default.jspa
 # Current ticket - https://jira.xilinx.com/browse/SH-1819
-PETALINUX="/proj/petalinux/2022.1/petalinux-v2022.1_02210750/tool/petalinux-v2022.1-final"
+PETALINUX="/proj/petalinux/2022.1/petalinux-v2022.1_03180759/tool/petalinux-v2022.1-final"

--- a/build/petalinux.build
+++ b/build/petalinux.build
@@ -1,4 +1,3 @@
 # When updating Petalinux build please file a SH ticket to retain the build
 # https://jira.xilinx.com/secure/CreateIssue!default.jspa
-# Current ticket - https://jira.xilinx.com/browse/SH-1819
-PETALINUX="/proj/petalinux/2022.1/petalinux-v2022.1_03180759/tool/petalinux-v2022.1-final"
+PETALINUX="/proj/petalinux/2022.1/petalinux-v2022.1_stable_latest/tool/petalinux-v2022.1-final"

--- a/src/runtime_src/core/edge/drm/zocl/cu_scu.c
+++ b/src/runtime_src/core/edge/drm/zocl/cu_scu.c
@@ -200,42 +200,14 @@ err:
 void xrt_cu_scu_fini(struct xrt_cu *xcu)
 {
 	struct xrt_cu_scu *core = xcu->core;
-	struct pid *p = NULL;
-	struct task_struct *task = NULL;
-	int ret = 0;
-
-	// Wait for PS Kernel Process to finish
-	p = find_get_pid(core->sc_pid);
-	if(!p) {
-		// Process already gone
-		goto skip_kill;
-	}
-
-	task = pid_task(p, PIDTYPE_PID);
-	if(!task) {
-		DRM_WARN("Failed to get task for pid %d\n",core->sc_pid);
-		put_pid(p);
-		goto skip_kill;
-	}
-
-	if(core->sc_parent_pid != task_ppid_nr(task)) {
-		DRM_WARN("Parent pid does not match\n");
-		put_pid(p);
-		goto skip_kill;
-	}
-
-	ret = kill_pid(p, SIGTERM, 1);
-	if (ret) {
-		DRM_WARN("Failed to terminate SCU pid %d.  Performing SIGKILL.\n",core->sc_pid);
-		kill_pid(p, SIGKILL, 1);
-	}
-	put_pid(p);
 
 	xrt_cu_fini(xcu);
 
  skip_kill:
 	// Free Command Buffer BO
-	zocl_drm_free_bo(core->sc_bo);
+	if (!IS_ERR(&core->sc_bo)) {
+		zocl_drm_free_bo(core->sc_bo);
+	}
 	if (xcu->core) {
 		kfree(xcu->core);
 	}

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_sk.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_sk.h
@@ -91,5 +91,7 @@ extern int zocl_scu_wait_cmd_sk(struct platform_device *pdev);
 extern int zocl_scu_wait_ready(struct platform_device *pdev);
 extern void zocl_scu_sk_ready(struct platform_device *pdev);
 extern void zocl_scu_sk_crash(struct platform_device *pdev);
+extern void zocl_scu_sk_shutdown(struct platform_device *pdev);
+extern void zocl_scu_sk_fini(struct platform_device *pdev);
 
 #endif

--- a/src/runtime_src/core/edge/drm/zocl/zocl_sk.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_sk.c
@@ -199,6 +199,10 @@ zocl_sk_report_ioctl(struct drm_device *dev, void *data,
 		zocl_scu_sk_crash(scu_pdev);
 		break;
 
+	case ZOCL_SCU_STATE_FINI:
+		zocl_scu_sk_fini(scu_pdev);
+		break;
+
 	default:
 		/*
 		 * More soft kernel state will be added as the kernel
@@ -207,7 +211,7 @@ zocl_sk_report_ioctl(struct drm_device *dev, void *data,
 		return -EINVAL;
 	}
 
-	return 0;
+	return ret;
 }
 
 int
@@ -236,13 +240,14 @@ zocl_fini_soft_kernel(struct drm_zocl_dev *zdev)
 	sk = zdev->soft_kernel;
 	mutex_lock(&sk->sk_lock);
 
-	if(!IS_ERR(&sk->sk_meta_bo))
-		ZOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(&sk->sk_meta_bo->gem_base);		
+	if(!IS_ERR(&sk->sk_meta_bo)) {
+		zocl_drm_free_bo(sk->sk_meta_bo);
+	}
 	
 	for (i = 0; i < sk->sk_nimg; i++) {
 		if (IS_ERR(&sk->sk_img[i].si_bo))
 			continue;
-		ZOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(&sk->sk_img[i].si_bo->gem_base);
+		zocl_drm_free_bo(sk->sk_img[i].si_bo);
 	}
 	kfree(sk->sk_img);
 

--- a/src/runtime_src/core/edge/include/sk_types.h
+++ b/src/runtime_src/core/edge/include/sk_types.h
@@ -50,10 +50,12 @@ typedef int (* kernel_t)(void *args, struct sk_operations *ops);
 /*
  * PS Context Data Structure included by user PS kernel code
  */
+
 class pscontext {
 public:
-  ~pscontext();
- pscontext() : pimpl{std::make_shared<pscontext::impl>()} {}
+ pscontext()
+   : pimpl{std::make_shared<pscontext::impl>()} {}
+  virtual ~pscontext() {}
  
 protected:
   struct impl;

--- a/src/runtime_src/core/edge/include/xclhal2_mpsoc.h
+++ b/src/runtime_src/core/edge/include/xclhal2_mpsoc.h
@@ -52,6 +52,7 @@ enum xrt_scu_state {
     XRT_SCU_STATE_DONE,
     XRT_SCU_STATE_READY,
     XRT_SCU_STATE_CRASH,
+    XRT_SCU_STATE_FINI,
 };
 
 /**

--- a/src/runtime_src/core/edge/include/zynq_ioctl.h
+++ b/src/runtime_src/core/edge/include/zynq_ioctl.h
@@ -498,6 +498,7 @@ enum drm_zocl_scu_state {
 	ZOCL_SCU_STATE_DONE,
 	ZOCL_SCU_STATE_READY,
 	ZOCL_SCU_STATE_CRASH,
+	ZOCL_SCU_STATE_FINI,
 };
 
 /**

--- a/src/runtime_src/core/edge/skd/sk_daemon.cpp
+++ b/src/runtime_src/core/edge/skd/sk_daemon.cpp
@@ -57,13 +57,10 @@ xrt::skd* skd_inst = nullptr;
 /* Define a signal handler for the child to handle signals */
 static void sigLog(const int sig)
 {
-  if(sig != SIGTERM)
+  if(sig != SIGTERM) {
     stacktrace_logger(sig);
-  if(skd_inst != nullptr) {
-    syslog(LOG_INFO,"Terminating PS kernel\n");
-    delete skd_inst;
   }
-  exit(EXIT_SUCCESS);
+  syslog(LOG_INFO,"Terminating PS kernel\n");
 }
 
 #define PNAME_LEN	(16)

--- a/src/runtime_src/core/edge/skd/xrt_skd.cpp
+++ b/src/runtime_src/core/edge/skd/xrt_skd.cpp
@@ -236,6 +236,7 @@ namespace xrt {
     if(cmd_boh >= 0) {
       xclBOProperties prop;
       if (xclGetBOProperties(devHdl, cmd_boh, &prop)) {
+	syslog(LOG_ERR, "Cannot get command BO info in destructor.\n");
       }
       ret = munmap(args_from_host,prop.size);
       if (ret) {

--- a/src/runtime_src/core/edge/skd/xrt_skd.h
+++ b/src/runtime_src/core/edge/skd/xrt_skd.h
@@ -86,6 +86,7 @@ class skd
 
   void report_ready();
   void report_crash();
+  void report_fini();
 
  private:
     xclDeviceHandle parent_devHdl;

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -1077,6 +1077,9 @@ xclSKReport(uint32_t cu_idx, xrt_scu_state state)
   case XRT_SCU_STATE_CRASH:
     scmd.cu_state = ZOCL_SCU_STATE_CRASH;
     break;
+  case XRT_SCU_STATE_FINI:
+    scmd.cu_state = ZOCL_SCU_STATE_FINI;
+    break;
   default:
     return -EINVAL;
   }

--- a/src/runtime_src/tools/scripts/apu_recipes/apu-boot
+++ b/src/runtime_src/tools/scripts/apu_recipes/apu-boot
@@ -1,5 +1,8 @@
 #!/bin/sh
 if [ -e /sys/bus/platform/devices/rpu-channel/ready ]; then
 	echo 1 > /sys/bus/platform/devices/rpu-channel/ready
-	/usr/bin/skd
+	# Add softkernel user for PS kernel daemon to run as
+	useradd softkernel
+	# Work-around for AIE as it defaults root access only
+	chmod 666 /dev/aie0
 fi

--- a/src/runtime_src/tools/scripts/apu_recipes/skd.bb
+++ b/src/runtime_src/tools/scripts/apu_recipes/skd.bb
@@ -1,0 +1,32 @@
+SUMMARY = "PS Kernel Daemon"
+SECTION = "PETALINUX/apps"
+LICENSE = "MIT"
+ 
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+ 
+SRC_URI = "file://skd.sh file://skd.service "
+ 
+S = "${WORKDIR}"
+ 
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+ 
+inherit update-rc.d systemd
+ 
+INITSCRIPT_NAME = "skd.sh"
+INITSCRIPT_PARAMS = "start 99 S ."
+
+SYSTEMD_PACKAGES = "${PN}"
+SYSTEMD_SERVICE:${PN} = "skd.service"
+SYSTEMD_AUTO_ENABLE:${PN}="enable"
+ 
+do_install() {
+        if ${@bb.utils.contains('DISTRO_FEATURES', 'sysvinit', 'true', 'false', d)}; then
+                install -d ${D}${sysconfdir}/init.d/
+                install -m 0755 ${WORKDIR}/skd.sh ${D}${sysconfdir}/init.d/
+        fi
+ 
+        install -d ${D}${systemd_system_unitdir}
+        install -m 0644 ${WORKDIR}/skd.service ${D}${systemd_system_unitdir}
+}
+ 
+FILES:${PN} += "${@bb.utils.contains('DISTRO_FEATURES','sysvinit','${sysconfdir}/*', '', d)}"

--- a/src/runtime_src/tools/scripts/apu_recipes/skd.service
+++ b/src/runtime_src/tools/scripts/apu_recipes/skd.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Soft Kernel Daemon
+After=apu-boot
+
+[Service]
+StartLimitIntervalSec=0
+Restart=always
+RestartSec=1
+User=softkernel
+ExecStart=/usr/bin/skd
+RemainAfterExit=on
+StandardOutput=journal+console
+ 
+[Install]
+WantedBy=multi-user.target

--- a/src/runtime_src/tools/scripts/apu_recipes/skd.sh
+++ b/src/runtime_src/tools/scripts/apu_recipes/skd.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+if [ -e /sys/bus/platform/devices/rpu-channel/ready ]; then
+   /usr/bin/skd
+fi


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
    Updating petalinux to 2022.1_stable_latest (#6592)
    
    Co-authored-by: Jeff Lin <jeffylin@xilinx.com>
    (cherry picked from commit 3d71c4e867bf91e789f89499a97b95708331d7e7)

    Pskernel aie graph support (#6535)
    
    * Fix for PS kernel only without PL kernel
    Added exit from PS kernel crash and updating return status
    
    * Updated petalinux build
    Changed PS kernel path to user petalinux
    Added skd systemd service
    
    * Removed skd from apu-boot
    
    * Updated PS kernel DRM free buffer flow
    
    * Modified /dev/aie0 permission to allow access by petalinux user
    
    * Fixed PS kernel exit flow
    Verified switching between PL kernel and AIE graph
    
    * Correction from PR comments
    
    * Add softkernel user to apu-boot
    switched skd service to use softkernel user
    Modified ps kernel to use softkernel path
    
    * Updated PS kernel fini sequence
    Added new command to indicate end of PS kernel operation
    
    * Updates according to Stephen's comments
    
    Co-authored-by: Jeff Lin <jeffylin@xilinx.com>
    (cherry picked from commit bc08e8ab08ab57d5f8600969a4b66e20f9bbd971)

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1130084, found from platform xbtest

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
