### PR TITLE
CR-1129783 XRT setup fails with ansible invocation on Ubuntu

### DIFF
--- a/src/runtime_src/tools/scripts/setup.sh
+++ b/src/runtime_src/tools/scripts/setup.sh
@@ -34,20 +34,23 @@ if [[ $XILINX_XRT != *"/opt/xilinx/xrt" ]]; then
 fi
 
 COMP_FILE="/usr/share/bash-completion/bash_completion"
-# This is a hack to get around set -e
+# 1. This is a hack to get around set -e
 # The issue is chaining conditionals with actual commands and is
 # documented here: http://mywiki.wooledge.org/BashFAQ/105\
 # The issue is caused when sourcing the ${COMP_FILE}.
 # Specifically ${COMP_FILE}::_sysvdirs. Each check in that function
 # will fail the script due to the issues documented in the FAQ above.
 # If set -e is removed from the pipeline then check can be removed
-if [[ $- != *e* ]] && [ -f "${COMP_FILE}" ]; then
+# 2. Make sure that the shell is bash! The completion may not function
+# correctly or setup on other shells.
+# 3. Make sure the bash completion file exists
+if [[ $- != *e* ]] && [[ "$BASH" == *"/bash" ]] && [ -f "${COMP_FILE}" ]; then
     # Enable autocompletion for the xbutil and xbmgmt commands
     source $COMP_FILE
     source $XILINX_XRT/share/completions/xbutil-bash-completion
     source $XILINX_XRT/share/completions/xbmgmt-bash-completion
 else
-  echo Autocomplete not enabled for XRT tools
+    echo Autocomplete not enabled for XRT tools
 fi
 
 # To use the newest version of the XRT tools, either uncomment or set 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
When sourcing the XRT setup ansible fails on Ubuntu due to an issue with a bash completion file found in the bash-completion install.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Ansible runs commands through sh rather than in bash on Ubuntu. This was causing the issue while sourcing. Introduced in https://github.com/Xilinx/XRT/pull/6571

On Ubuntu x.x
```
cfgmgr@xcoengvm229179 [311]: ansible xcosdae364 -m shell -a "source /opt/xilinx/xrt/setup.sh; xbmgmt examine" --vault-password-file /home/cfgmgr/.ssh/vault_password --become -P 2 -B 30
xcosdae364 | FAILED | rc=2 >>
/etc/bash_completion.d/apport_completion: line 107: `_apport-bug': not a valid identifiernon-zero return code
```

#### How problem was solved, alternative solutions (if any) and why they were rejected
The fix is to make sure that the current shell is bash before proceeding with the command completion setup. Adding condition to the setup auto completion section to validate the shell is bash will do the trick.

#### Risks (if any) associated the changes in the commit
If anyone uses auto-completion outside of bash it will now be disabled. We may need more maintenance to add additional shells. For instance zsh may support bash-completion but it will not function as it is not 'bash'. On the upside it is guaranteed that the bash completion script is invoked only for bash (which makes a lot of sense now that I think about it). 

#### What has been tested and how, request additional testing if necessary
Manual testing on pipeline machine
Ubuntu
```
cfgmgr@xcoengvm229179 [312]: ansible xcosdae364 -m shell -a "source /opt/xilinx/xrt/setup.sh; xbmgmt examine" --vault-password-file /home/cfgmgr/.ssh/vault_password --become -P 2 -B 30
xcosdae364 | CHANGED => {
    "ansible_job_id": "325574778100.911148",
    "changed": true,
    "cmd": "source /opt/xilinx/xrt/setup.sh; xbmgmt examine",
    "delta": "0:00:00.133289",
    "end": "2022-05-04 14:08:29.173839",
    "finished": 1,
    "rc": 0,
    "start": "2022-05-04 14:08:29.040550",
    "stderr": "",
    "stderr_lines": [],
    "stdout": "Autocomplete not enabled for XRT tools\nXILINX_XRT        : /opt/xilinx/xrt\nPATH              : /opt/xilinx/xrt/bin:/tools/batonroot/rodin/devkits/lnx64/python-2.7.5_ucs4/bin:/proj/rdi/builds/2020.1/nightly/RUNNING_BUILD/hierdesign/util:/tools/batonroot/rodin/devkits/lnx24/rsync-2.6.9/bin:/tools/batonroot/rodin/devkits/lnx24/make-4.1/bin:/tools/batonroot/rodin/devkits/lnx24/swig-3.0.10/bin:/tools/batonroot/rodin/devkits/lnx64/binutils-2.26/bin:/tools/batonroot/rodin/devkits/lnx64/python-2.7.5/bin:/tools/batonroot/rodin/devkits/lnx24/7z-4.65/bin:/tools/batonroot/rodin/devkits/lnx24/bison-2.3/bin:/tools/batonroot/rodin/devkits/lnx64/gcc-6.2.0/bin:/tools/batonroot/rodin/devkits/lnx24/perl-5.8.8/bin:/tools/batonroot/rodin/devkits/lnx24/m4-1.4.10/bin:/tools/batonroot/rodin/devkits/lnx24/flex-2.5.4a-33/bin:/tools/batonroot/rodin/devkits/lnx24/ruby-1.8.6-p111/bin:/tools/batonroot/rodin/devkits/lnx64/gdb-8.3/bin:/tools/batonroot/rodin/devkits/lnx24/perforce-2013.2/bin:/tools/batonroot/rodin/devkits/lnx24/perforce-2013.1/bin:/tools/batonroot/rodin/devkits/lnx24/jdk1.8.0_112/bin:/tools/batonroot/rodin/devkits/lnx24/doxygen-1.8.3/bin:/tools/batonroot/rodin/devkits/lnx24/ddd-3.3.14/bin:/tools/batonroot/rodin/devkits/lnx24/ksh-93t/bin:/tools/baton/totalview/toolworks/totalview.2018.2.6/bin:/tools/baton/valgrind/3.12.0/bin:/tools/batonroot/rodin/devkits/python/docutils-0.8/bin:/tools/batonroot/rodin/devkits/python/sphinx-1.1.3/bin:/tools/batonroot/rodin/devkits/python/pygments-1.4/bin:.:/group/xcofarm/lsf/10.1/linux3.10-glibc2.17-x86_64/etc:/group/xcofarm/lsf/10.1/linux3.10-glibc2.17-x86_64/bin:/home/cfgmgr/bin:/usr/local/bin:/mis/TREE/bin:/usr/bin:/bin:/usr/ucb:/usr/sbin:/usr/bin:/usr/ucb:/usr/local/bin:/usr/etc:/usr/local/etc:/bin:/bin/env:/etc:/usr/lib:/sbin\nLD_LIBRARY_PATH   : /opt/xilinx/xrt/lib:\nPYTHONPATH        : /opt/xilinx/xrt/python:\nSystem Configuration\n  OS Name              : Linux\n  Release              : 5.4.0-100-generic\n  Version              : #113-Ubuntu SMP Thu Feb 3 18:43:29 UTC 2022\n  Machine              : x86_64\n  CPU Cores            : 32\n  Memory               : 128585 MB\n  Distribution         : Ubuntu 20.04.3 LTS\n  GLIBC                : 2.31\n  Model                : PowerEdge R7525\n\nXRT\n  Version              : 2.14.11861\n  Branch               : HEAD\n  Hash                 : 2c81fe8969fb548b968d65d592bfcb1cac0e1820\n  Hash Date            : 2022-04-29 14:39:31\n  XOCL                 : 2.14.11861, 2c81fe8969fb548b968d65d592bfcb1cac0e1820\n  XCLMGMT              : 2.14.11861, 2c81fe8969fb548b968d65d592bfcb1cac0e1820\n\nDevices present\nBDF             :  Shell                            Platform UUID                         Device ID         Device Ready*  \n[0000:c1:00.0]  :  xilinx_u200_gen3x16_xdma_base_2  0B095B81-FA2B-E6BD-4524-72B1C1474F18  mgmt(inst=49408)  Yes            \n\n* Devices that are not ready will have reduced functionality when using XRT tools",
    "stdout_lines": [
        "Autocomplete not enabled for XRT tools",
        "XILINX_XRT        : /opt/xilinx/xrt",
        "PATH              : /opt/xilinx/xrt/bin:/tools/batonroot/rodin/devkits/lnx64/python-2.7.5_ucs4/bin:/proj/rdi/builds/2020.1/nightly/RUNNING_BUILD/hierdesign/util:/tools/batonroot/rodin/devkits/lnx24/rsync-2.6.9/bin:/tools/batonroot/rodin/devkits/lnx24/make-4.1/bin:/tools/batonroot/rodin/devkits/lnx24/swig-3.0.10/bin:/tools/batonroot/rodin/devkits/lnx64/binutils-2.26/bin:/tools/batonroot/rodin/devkits/lnx64/python-2.7.5/bin:/tools/batonroot/rodin/devkits/lnx24/7z-4.65/bin:/tools/batonroot/rodin/devkits/lnx24/bison-2.3/bin:/tools/batonroot/rodin/devkits/lnx64/gcc-6.2.0/bin:/tools/batonroot/rodin/devkits/lnx24/perl-5.8.8/bin:/tools/batonroot/rodin/devkits/lnx24/m4-1.4.10/bin:/tools/batonroot/rodin/devkits/lnx24/flex-2.5.4a-33/bin:/tools/batonroot/rodin/devkits/lnx24/ruby-1.8.6-p111/bin:/tools/batonroot/rodin/devkits/lnx64/gdb-8.3/bin:/tools/batonroot/rodin/devkits/lnx24/perforce-2013.2/bin:/tools/batonroot/rodin/devkits/lnx24/perforce-2013.1/bin:/tools/batonroot/rodin/devkits/lnx24/jdk1.8.0_112/bin:/tools/batonroot/rodin/devkits/lnx24/doxygen-1.8.3/bin:/tools/batonroot/rodin/devkits/lnx24/ddd-3.3.14/bin:/tools/batonroot/rodin/devkits/lnx24/ksh-93t/bin:/tools/baton/totalview/toolworks/totalview.2018.2.6/bin:/tools/baton/valgrind/3.12.0/bin:/tools/batonroot/rodin/devkits/python/docutils-0.8/bin:/tools/batonroot/rodin/devkits/python/sphinx-1.1.3/bin:/tools/batonroot/rodin/devkits/python/pygments-1.4/bin:.:/group/xcofarm/lsf/10.1/linux3.10-glibc2.17-x86_64/etc:/group/xcofarm/lsf/10.1/linux3.10-glibc2.17-x86_64/bin:/home/cfgmgr/bin:/usr/local/bin:/mis/TREE/bin:/usr/bin:/bin:/usr/ucb:/usr/sbin:/usr/bin:/usr/ucb:/usr/local/bin:/usr/etc:/usr/local/etc:/bin:/bin/env:/etc:/usr/lib:/sbin",
        "LD_LIBRARY_PATH   : /opt/xilinx/xrt/lib:",
        "PYTHONPATH        : /opt/xilinx/xrt/python:",
        "System Configuration",
        "  OS Name              : Linux",
        "  Release              : 5.4.0-100-generic",
```
CentOS:
```
cfgmgr@xcoengvm229179 [314]: ansible xcosda61 -m shell -a "source /opt/xilinx/xrt/setup.sh; xbmgmt examine" --vault-password-file /home/cfgmgr/.ssh/vault_password --become -P 2 -B 30
xcosda61 | CHANGED => {
    "ansible_job_id": "928453308300.21365",
    "changed": true,
    "cmd": "source /opt/xilinx/xrt/setup.sh; xbmgmt examine",
    "delta": "0:00:00.334441",
    "end": "2022-05-04 14:16:21.587432",
    "finished": 1,
    "rc": 0,
    "start": "2022-05-04 14:16:21.252991",
    "stderr": "",
    "stderr_lines": [],
    "stdout": "Autocomplete not enabled for XRT tools\nXILINX_XRT        : /opt/xilinx/xrt\nPATH              : /opt/xilinx/xrt/bin:/tools/batonroot/rodin/devkits/lnx64/python-2.7.5_ucs4/bin:/proj/rdi/builds/2020.1/nightly/RUNNING_BUILD/hierdesign/util:/tools/batonroot/rodin/devkits/lnx24/xemacs-21.4.21/bin:/tools/batonroot/rodin/devkits/lnx24/rsync-2.6.9/bin:/tools/batonroot/rodin/devkits/lnx24/make-4.1/bin:/tools/batonroot/rodin/devkits/lnx24/swig-3.0.10/bin:/tools/batonroot/rodin/devkits/lnx64/binutils-2.26/bin:/tools/batonroot/rodin/devkits/lnx64/python-2.7.5_ucs4/bin:/tools/batonroot/rodin/devkits/lnx24/7z-4.65/bin:/tools/batonroot/rodin/devkits/lnx24/bison-2.3/bin:/tools/batonroot/rodin/devkits/lnx64/gcc-6.2.0/bin:/tools/batonroot/rodin/devkits/lnx24/perl-5.8.8/bin:/tools/batonroot/rodin/devkits/lnx24/m4-1.4.10/bin:/tools/batonroot/rodin/devkits/lnx24/flex-2.5.4a-33/bin:/tools/batonroot/rodin/devkits/lnx24/ruby-1.8.6-p111/bin:/tools/batonroot/rodin/devkits/lnx64/gdb-8.3/bin:/tools/batonroot/rodin/devkits/lnx24/perforce-2013.2/bin:/tools/batonroot/rodin/devkits/lnx24/perforce-2013.1/bin:/tools/batonroot/rodin/devkits/lnx24/jdk1.8.0_112/bin:/tools/batonroot/rodin/devkits/lnx24/doxygen-1.8.3/bin:/tools/batonroot/rodin/devkits/lnx24/ddd-3.3.14/bin:/tools/batonroot/rodin/devkits/lnx24/ksh-93t/bin:/tools/baton/totalview/toolworks/totalview.2018.2.6/bin:/tools/baton/valgrind/3.12.0/bin:/tools/batonroot/rodin/devkits/python/docutils-0.8/bin:/tools/batonroot/rodin/devkits/python/sphinx-1.1.3/bin:/tools/batonroot/rodin/devkits/python/pygments-1.4/bin:.:/group/xcofarm/lsf/10.1/linux3.10-glibc2.17-x86_64/etc:/group/xcofarm/lsf/10.1/linux3.10-glibc2.17-x86_64/bin:/home/cfgmgr/bin:/usr/local/bin:/mis/TREE/bin:/usr/bin:/bin:/usr/ucb:/usr/sbin:/usr/bin:/usr/ucb:/usr/local/bin:/usr/etc:/usr/local/etc:/bin:/bin/env:/etc:/usr/lib:/sbin\nLD_LIBRARY_PATH   : /opt/xilinx/xrt/lib:\nPYTHONPATH        : /opt/xilinx/xrt/python:\nSystem Configuration\n  OS Name              : Linux\n  Release              : 3.10.0-1160.el7.x86_64\n  Version              : #1 SMP Mon Oct 19 16:18:59 UTC 2020\n  Machine              : x86_64\n  CPU Cores            : 12\n  Memory               : 64171 MB\n  Distribution         : CentOS Linux 7 (Core)\n  GLIBC                : 2.17\n  Model                : PowerEdge R730\n\nXRT\n  Version              : 2.13.467\n  Branch               : 2022.1\n  Hash                 : 8a9c0e8173f87ef179d91c1e26faa281db1cbd36\n  Hash Date            : 2022-04-27 09:03:44\n  XOCL                 : 2.13.467, 8a9c0e8173f87ef179d91c1e26faa281db1cbd36\n  XCLMGMT              : 2.13.467, 8a9c0e8173f87ef179d91c1e26faa281db1cbd36\n\nDevices present\nBDF             :  Shell                              Platform UUID                         Device ID         Device Ready*  \n[0000:82:00.0]  :  xilinx_vck5000_gen4x8_xdma_base_2  04624343-B44B-B0A1-3CD4-8A411789FF20  mgmt(inst=33280)  Yes            \n\n* Devices that are not ready will have reduced functionality when using XRT tools",
    "stdout_lines": [
        "Autocomplete not enabled for XRT tools",
        "XILINX_XRT        : /opt/xilinx/xrt",
        "PATH              : /opt/xilinx/xrt/bin:/tools/batonroot/rodin/devkits/lnx64/python-2.7.5_ucs4/bin:/proj/rdi/builds/2020.1/nightly/RUNNING_BUILD/hierdesign/util:/tools/batonroot/rodin/devkits/lnx24/xemacs-21.4.21/bin:/tools/batonroot/rodin/devkits/lnx24/rsync-2.6.9/bin:/tools/batonroot/rodin/devkits/lnx24/make-4.1/bin:/tools/batonroot/rodin/devkits/lnx24/swig-3.0.10/bin:/tools/batonroot/rodin/devkits/lnx64/binutils-2.26/bin:/tools/batonroot/rodin/devkits/lnx64/python-2.7.5_ucs4/bin:/tools/batonroot/rodin/devkits/lnx24/7z-4.65/bin:/tools/batonroot/rodin/devkits/lnx24/bison-2.3/bin:/tools/batonroot/rodin/devkits/lnx64/gcc-6.2.0/bin:/tools/batonroot/rodin/devkits/lnx24/perl-5.8.8/bin:/tools/batonroot/rodin/devkits/lnx24/m4-1.4.10/bin:/tools/batonroot/rodin/devkits/lnx24/flex-2.5.4a-33/bin:/tools/batonroot/rodin/devkits/lnx24/ruby-1.8.6-p111/bin:/tools/batonroot/rodin/devkits/lnx64/gdb-8.3/bin:/tools/batonroot/rodin/devkits/lnx24/perforce-2013.2/bin:/tools/batonroot/rodin/devkits/lnx24/perforce-2013.1/bin:/tools/batonroot/rodin/devkits/lnx24/jdk1.8.0_112/bin:/tools/batonroot/rodin/devkits/lnx24/doxygen-1.8.3/bin:/tools/batonroot/rodin/devkits/lnx24/ddd-3.3.14/bin:/tools/batonroot/rodin/devkits/lnx24/ksh-93t/bin:/tools/baton/totalview/toolworks/totalview.2018.2.6/bin:/tools/baton/valgrind/3.12.0/bin:/tools/batonroot/rodin/devkits/python/docutils-0.8/bin:/tools/batonroot/rodin/devkits/python/sphinx-1.1.3/bin:/tools/batonroot/rodin/devkits/python/pygments-1.4/bin:.:/group/xcofarm/lsf/10.1/linux3.10-glibc2.17-x86_64/etc:/group/xcofarm/lsf/10.1/linux3.10-glibc2.17-x86_64/bin:/home/cfgmgr/bin:/usr/local/bin:/mis/TREE/bin:/usr/bin:/bin:/usr/ucb:/usr/sbin:/usr/bin:/usr/ucb:/usr/local/bin:/usr/etc:/usr/local/etc:/bin:/bin/env:/etc:/usr/lib:/sbin",
        "LD_LIBRARY_PATH   : /opt/xilinx/xrt/lib:",
        "PYTHONPATH        : /opt/xilinx/xrt/python:",
        "System Configuration",
        "  OS Name              : Linux",
        "  Release              : 3.10.0-1160.el7.x86_64",
        "  Version              : #1 SMP Mon Oct 19 16:18:59 UTC 2020",
        "  Machine              : x86_64",
        "  CPU Cores            : 12",
        "  Memory               : 64171 MB",
        "  Distribution         : CentOS Linux 7 (Core)",
        "  GLIBC                : 2.17",
        "  Model                : PowerEdge R730",
        "",
        "XRT",
        "  Version              : 2.13.467",
        "  Branch               : 2022.1",
        "  Hash                 : 8a9c0e8173f87ef179d91c1e26faa281db1cbd36",
        "  Hash Date            : 2022-04-27 09:03:44",
        "  XOCL                 : 2.13.467, 8a9c0e8173f87ef179d91c1e26faa281db1cbd36",
        "  XCLMGMT              : 2.13.467, 8a9c0e8173f87ef179d91c1e26faa281db1cbd36",
        "",
        "Devices present",
        "BDF             :  Shell                              Platform UUID                         Device ID         Device Ready*  ",
        "[0000:82:00.0]  :  xilinx_vck5000_gen4x8_xdma_base_2  04624343-B44B-B0A1-3CD4-8A411789FF20  mgmt(inst=33280)  Yes            ",
        "",
        "* Devices that are not ready will have reduced functionality when using XRT tools"
    ]
}
```
#### Documentation impact (if any)
None