### PR TITLE
CR-1105659 use device bdf in python tests command line args instead of device index (#6651)

### DIFF
--- a/src/python/xrt_binding.py
+++ b/src/python/xrt_binding.py
@@ -1008,7 +1008,7 @@ def xrtDeviceOpenByBDF(bdf):
     """
     libcoreutil.xrtDeviceOpenByBDF.restype = ctypes.POINTER(xrtDeviceHandle)
     libcoreutil.xrtDeviceOpenByBDF.argTypes = [ctypes.c_char_p]
-    return _valueOrError(libcoreutil.xrtDeviceOpenBDF(bdf))
+    return _valueOrError(libcoreutil.xrtDeviceOpenByBDF(bdf))
 
 def xrtDeviceClose(handle):
     """

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -343,7 +343,7 @@ runTestCase( const std::shared_ptr<xrt_core::device>& _dev, const std::string& p
     logger(_ptTest, "Testcase", xrtTestCasePath);
 
     std::vector<std::string> args = { "-k", xclbinPath,
-                                      "-d", std::to_string(_dev.get()->get_device_id()) };
+                                      "-d", xrt_core::query::pcie_bdf::to_string(xrt_core::device_query<xrt_core::query::pcie_bdf>(_dev)) };
     int exit_code;
     try {
       if (py.find(".exe") != std::string::npos)

--- a/tests/python/utils_binding.py
+++ b/tests/python/utils_binding.py
@@ -33,7 +33,7 @@ class Options(object):
         self.halLogFile = None
         self.alignment = 4096
         self.option_index = 0
-        self.index = 0
+        self.index = None
         self.cu_index = 0
         self.verbose = False
         self.handle = None
@@ -61,7 +61,7 @@ class Options(object):
             elif o in ("--cu_index", "-c"):
                 self.cu_index = int(arg)
             elif o in ("--device", "-d"):
-                self.index = int(arg)
+                self.index = arg
             elif o in ("--help", "-h"):
                 print(self.printHelp())
             elif o == "-v":
@@ -91,17 +91,18 @@ class Options(object):
 
 def initXRT(opt):
     deviceInfo = xclDeviceInfo2()
-    if opt.index >= xclProbe():
-        raise RuntimeError("Incorrect device index")
 
-    opt.handle = xrtDeviceOpen(opt.index)
+    opt.handle = xrtDeviceOpenByBDF(opt.index)
+    if opt.handle is None:
+            raise RuntimeError("Invalid device BDF")
+
     opt.xcl_handle = xrtDeviceToXclDevice(opt.handle)
 
     xclGetDeviceInfo2(opt.xcl_handle, ctypes.byref(deviceInfo))
 
     if sys.version_info[0] == 3:
         print("Shell = %s" % deviceInfo.mName)
-        print("Index = %d" % opt.index)
+        print("Index = %s" % opt.index)
         print("PCIe = GEN%d x %d" % (deviceInfo.mPCIeLinkSpeed, deviceInfo.mPCIeLinkWidth))
         print("OCL Frequency = (%d, %d) MHz" % (deviceInfo.mOCLFrequency[0], deviceInfo.mOCLFrequency[1]))
         print("DDR Bank = %d" % deviceInfo.mDDRBankCount)


### PR DESCRIPTION
* tests: use device bdf in python tests command line args instead of device index

-Python applications (as part of xbutil validate) are using device indexes in command line args.
 This is causing a problem when multiple tests run on multi card setup simultaneously.
Example:
   1. Issue reset on device0 (has index 0), and issue validate on device1 (has index 1).
   2. In device0 reset sequence, it resets the card and removes the index from devicesList.
      Hence, device1 index become 0.
   3. This same issue not seen if validate test run on device0 and reset on device1.
      Since, reset of device1 removes the index from deviceList, and doesn't affect device0 index.

Signed-off-by: Durga prasad Kotipalli <dkotipal@xilinx.com>
Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>

* Minor fix

Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>

* Fix compile time error

Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>

* minor fix

Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>
(cherry picked from commit 0b30609ce15f3484da46d0a4602c084b10d401b0)

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
