### PR TITLE
Preliminary support for circular buffer with aie plio and multi-slr pl trace

### DIFF
--- a/src/runtime_src/xdp/profile/database/dynamic_event_database.cpp
+++ b/src/runtime_src/xdp/profile/database/dynamic_event_database.cpp
@@ -428,7 +428,7 @@ namespace xdp {
   }
 
   void VPDynamicDatabase::addAIETraceData(uint64_t deviceId,
-                             uint64_t strmIndex, void* buffer, uint64_t bufferSz) 
+                             uint64_t strmIndex, void* buffer, uint64_t bufferSz)
   {
     std::lock_guard<std::mutex> lock(aieLock);
 
@@ -440,7 +440,11 @@ namespace xdp {
     if (nullptr == aieTraceData[deviceId][strmIndex]) {
       aieTraceData[deviceId][strmIndex] = new AIETraceDataType;
     }
-    aieTraceData[deviceId][strmIndex]->buffer.push_back(buffer);
+
+    // We need to copy trace buffer data as it could be be overwritten by datamover
+    auto buffer_copy = std::make_unique<unsigned char[]>(bufferSz);
+    std::memcpy(buffer_copy.get(), buffer, bufferSz);
+    aieTraceData[deviceId][strmIndex]->buffer.push_back(std::move(buffer_copy));
     aieTraceData[deviceId][strmIndex]->bufferSz.push_back(bufferSz);
   }
 

--- a/src/runtime_src/xdp/profile/database/dynamic_event_database.h
+++ b/src/runtime_src/xdp/profile/database/dynamic_event_database.h
@@ -40,7 +40,7 @@ namespace xdp {
 
   // AIE Trace data type
   struct AIETraceDataType {
-    std::vector<void*> buffer;
+    std::vector<std::unique_ptr<unsigned char[]>> buffer;
     std::vector<uint64_t> bufferSz;
   };
   typedef std::vector<AIETraceDataType*> AIETraceDataVector;

--- a/src/runtime_src/xdp/profile/database/events/creator/aie_trace_data_logger.h
+++ b/src/runtime_src/xdp/profile/database/events/creator/aie_trace_data_logger.h
@@ -36,7 +36,7 @@ public:
   virtual ~AIETraceDataLogger();
 
   XDP_EXPORT
-  virtual void addAIETraceData(uint64_t strmIndex, void* buffer, uint64_t bufferSz); 
+  virtual void addAIETraceData(uint64_t strmIndex, void* buffer, uint64_t bufferSz);
 };
 
 }

--- a/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.h
+++ b/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.h
@@ -34,8 +34,19 @@ struct AIETraceBufferInfo
 //  uint64_t allocSz;	// currently all the buffers are equal size
   uint64_t usedSz;
   uint64_t offset;
+  uint32_t rollover_count;
   bool     isFull;
   bool     offloadDone;
+
+  AIETraceBufferInfo()
+    : boHandle(0),
+      usedSz(0),
+      offset(0),
+      rollover_count(0),
+      isFull(false),
+      offloadDone(false),
+      isCircular(false)
+  {}
 };
 
 struct AIETraceGmioDMAInst
@@ -119,6 +130,13 @@ private:
     AIEOffloadThreadStatus offloadStatus;
     std::thread offloadThread;
 
+  //Circular Buffer Tracking
+  bool mEnCircularBuf;
+  // 100 mb of trace per second
+  uint64_t circ_buf_min_rate_plio = TS2MM_DEF_BUF_SIZE * 100;
+  uint64_t circ_buf_cur_rate_plio;
+
+private:
     void configAIETs2mm(uint64_t index, bool final);
 
     void continuousOffload();

--- a/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.h
+++ b/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.h
@@ -25,6 +25,9 @@ namespace xdp {
 class DeviceIntf;
 class AIETraceLogger;
 
+#define debug_stream \
+if(!m_debug); else std::cout
+
 struct AIETraceBufferInfo
 {
   size_t   boHandle;
@@ -99,6 +102,10 @@ private:
     uint64_t totalSz;
     uint64_t numStream;
 
+    // Set this to true for more verbose trace offload
+    // Internal use only
+    bool m_debug = true;
+
     uint64_t bufAllocSz;
 
     std::vector<AIETraceBufferInfo>  buffers;
@@ -112,7 +119,6 @@ private:
     AIEOffloadThreadStatus offloadStatus;
     std::thread offloadThread;
 
-    uint64_t readPartialTrace(uint64_t);
     void configAIETs2mm(uint64_t index, bool final);
 
     void continuousOffload();

--- a/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.h
+++ b/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.h
@@ -115,7 +115,7 @@ private:
 
     // Set this to true for more verbose trace offload
     // Internal use only
-    bool m_debug = true;
+    bool m_debug = false;
 
     uint64_t bufAllocSz;
 

--- a/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.h
+++ b/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.h
@@ -19,6 +19,7 @@
 
 #include "xdp/config.h"
 #include "core/edge/user/aie/aie.h"
+#include "xdp/profile/device/tracedefs.h"
 
 namespace xdp {
 
@@ -44,8 +45,7 @@ struct AIETraceBufferInfo
       offset(0),
       rollover_count(0),
       isFull(false),
-      offloadDone(false),
-      isCircular(false)
+      offloadDone(false)
   {}
 };
 
@@ -142,8 +142,7 @@ private:
     void continuousOffload();
     bool keepOffloading();
     void offloadFinished();
-
-    //Circular Buffer Tracking : Not for now
+    void checkCircularBufferSupport();
 };
 
 }

--- a/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.h
+++ b/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.h
@@ -132,8 +132,9 @@ private:
 
   //Circular Buffer Tracking
   bool mEnCircularBuf;
-  // 100 mb of trace per second
-  uint64_t circ_buf_min_rate_plio = TS2MM_DEF_BUF_SIZE * 100;
+  // 1000 mb of trace per second
+  // Very high bandwidth requirement
+  uint64_t circ_buf_min_rate_plio = TS2MM_DEF_BUF_SIZE * 1000;
   uint64_t circ_buf_cur_rate_plio;
 
 private:

--- a/src/runtime_src/xdp/profile/device/device_intf.cpp
+++ b/src/runtime_src/xdp/profile/device/device_intf.cpp
@@ -959,11 +959,11 @@ DeviceIntf::~DeviceIntf()
   }
 
   // Initialize an AIE trace data mover
-  void DeviceIntf::initAIETs2mm(uint64_t bufSz, uint64_t bufAddr, uint64_t index)
+  void DeviceIntf::initAIETs2mm(uint64_t bufSz, uint64_t bufAddr, uint64_t index, bool circular)
   {
     if(index >= mAieTraceDmaList.size())
       return;
-    mAieTraceDmaList[index]->init(bufSz, bufAddr, false);
+    mAieTraceDmaList[index]->init(bufSz, bufAddr, circular);
   }
 
   // Get word count written by AIE trace data mover

--- a/src/runtime_src/xdp/profile/device/device_intf.h
+++ b/src/runtime_src/xdp/profile/device/device_intf.h
@@ -130,8 +130,19 @@ class DeviceIntf {
     size_t getNumberTS2MM() {
       return mPlTraceDmaList.size();
     };
-    bool supportsCircBuf() {
-      return ((1 == getNumberTS2MM()) ? (mPlTraceDmaList[0]->supportsCircBuf()) : false);
+
+    // All datamovers support circular buffer for PL Trace
+    bool supportsCircBufPL() {
+      if (mPlTraceDmaList.size() > 0)
+        return mPlTraceDmaList[0]->supportsCircBuf();
+      return false;
+    }
+
+    // Only version 2 Datamover supports circular buffer for AIE Trace
+    bool supportsCircBufAIE() {
+      if (mAieTraceDmaList.size() > 0)
+        return mAieTraceDmaList[0]->isVersion2();
+      return false;
     }
 
     XDP_EXPORT
@@ -149,7 +160,7 @@ class DeviceIntf {
     XDP_EXPORT
     void resetAIETs2mm(uint64_t index);
     XDP_EXPORT
-    void initAIETs2mm(uint64_t bufferSz, uint64_t bufferAddr, uint64_t index);
+    void initAIETs2mm(uint64_t bufferSz, uint64_t bufferAddr, uint64_t index, bool circular);
 
     XDP_EXPORT
     uint64_t getWordCountAIETs2mm(uint64_t index, bool final);

--- a/src/runtime_src/xdp/profile/device/device_intf.h
+++ b/src/runtime_src/xdp/profile/device/device_intf.h
@@ -138,8 +138,13 @@ class DeviceIntf {
       return false;
     }
 
-    // Only version 2 Datamover supports circular buffer for AIE Trace
+    // Only version 2 Datamover supports circular buffer/flush for AIE Trace
     bool supportsCircBufAIE() {
+      if (mAieTraceDmaList.size() > 0)
+        return mAieTraceDmaList[0]->isVersion2();
+      return false;
+    }
+    bool supportsflushAIE() {
       if (mAieTraceDmaList.size() > 0)
         return mAieTraceDmaList[0]->isVersion2();
       return false;

--- a/src/runtime_src/xdp/profile/device/device_trace_offload.cpp
+++ b/src/runtime_src/xdp/profile/device/device_trace_offload.cpp
@@ -38,7 +38,7 @@ DeviceTraceOffload
   , m_process_trace_done(false)
 {
   // Select appropriate reader
-  if(has_fifo()) {
+  if (has_fifo()) {
     m_read_trace = std::bind(&DeviceTraceOffload::read_trace_fifo, this, std::placeholders::_1);
   } else {
     m_read_trace = std::bind(&DeviceTraceOffload::read_trace_s2mm, this, std::placeholders::_1);
@@ -63,14 +63,7 @@ DeviceTraceOffload::
 void DeviceTraceOffload::
 offload_device_continuous()
 {
-  std::vector<uint64_t> buf_sizes;
-  if(!ts2mm_info.buffers.empty()) {
-    buf_sizes.resize(ts2mm_info.num_ts2mm);
-    for(size_t i = 0; i < ts2mm_info.num_ts2mm; i++) {
-       buf_sizes[i] = ts2mm_info.buffers[i].buf_size;
-    }
-  }
-  if (!m_initialized && !read_trace_init(true, buf_sizes)) {
+  if (!m_initialized) {
     offload_finished();
     return;
   }
@@ -281,7 +274,7 @@ read_leftover_circular_buf()
   // If we use circular buffer then, final trace read
   // might stop at trace buffer boundry and to read the entire
   // trace, we need one last read
-  if (ts2mm_info.use_circ_buf && ts2mm_info.buffers[0].used_size == ts2mm_info.full_buf_size) {
+  if (ts2mm_info.use_circ_buf && ts2mm_info.buffers[0].used_size == ts2mm_info.buffers[0].alloc_size) {
     debug_stream
       << "Try to read left over circular buffer data" << std::endl;
     m_read_trace(true);
@@ -314,8 +307,9 @@ read_trace_s2mm(bool force)
     << ts2mm_info.num_ts2mm << std::endl;
 
   for(uint64_t i = 0; i < ts2mm_info.num_ts2mm; i++) {
+  auto& bd = ts2mm_info.buffers[i];
   auto wordcount = dev_intf->getWordCountTs2mm(i, force);
-  auto bytes_written = (wordcount - ts2mm_info.buffers[i].prv_wordcount) * TRACE_PACKET_SIZE;
+  auto bytes_written = (wordcount - bd.prv_wordcount) * TRACE_PACKET_SIZE;
 
   // Don't read data if there's less than 512B trace
   if (!force && (bytes_written < TS2MM_MIN_READ_SIZE)) {
@@ -324,15 +318,15 @@ read_trace_s2mm(bool force)
     return;
   }
   // There's enough data available
-  ts2mm_info.buffers[i].prv_wordcount = wordcount;
+  bd.prv_wordcount = wordcount;
 
   if (!config_s2mm_reader(i, wordcount))
     return;
 
-  uint64_t nBytes = ts2mm_info.buffers[i].used_size - ts2mm_info.buffers[i].offset;
+  uint64_t nBytes = bd.used_size - bd.offset;
 
   auto start = std::chrono::steady_clock::now();
-  void* host_buf = dev_intf->syncTraceBuf(ts2mm_info.buffers[i].buf, ts2mm_info.buffers[i].offset, nBytes);
+  void* host_buf = dev_intf->syncTraceBuf(bd.buf, bd.offset, nBytes);
   auto end = std::chrono::steady_clock::now();
   debug_stream
     << "For " << i << " ts2mm : Elapsed time in microseconds for sync : "
@@ -351,30 +345,32 @@ read_trace_s2mm(bool force)
   ts2mm_info.process_queue_lock.unlock();
 
   // Print warning if processing large amount of trace
-  if (nBytes > TS2MM_WARN_BIG_BUF_SIZE && !ts2mm_info.buffers[i].big_trace_warn_done) {
+  if (nBytes > TS2MM_WARN_BIG_BUF_SIZE && !bd.big_trace_warn_done) {
     xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", TS2MM_WARN_MSG_BIG_BUF);
-    ts2mm_info.buffers[i].big_trace_warn_done = true;
+    bd.big_trace_warn_done = true;
   }
 
-  if (ts2mm_info.buffers[i].used_size == ts2mm_info.buffers[i].buf_size && ts2mm_info.use_circ_buf == false)
-    ts2mm_info.buffers[i].full = true;
+  if (bd.used_size == bd.alloc_size && ts2mm_info.use_circ_buf == false)
+    bd.full = true;
   }
 }
 
 bool DeviceTraceOffload::
 config_s2mm_reader(uint64_t i, uint64_t wordCount)
 {
-  if (ts2mm_info.buffers[i].offload_done)
+  auto& bd = ts2mm_info.buffers[i];
+
+  if (bd.offload_done)
     return false;
 
   auto bytes_written = wordCount * TRACE_PACKET_SIZE;
-  auto bytes_read = ts2mm_info.buffers[i].rollover_count*ts2mm_info.buffers[i].buf_size + ts2mm_info.buffers[i].used_size;
+  auto bytes_read = bd.rollover_count * bd.alloc_size + bd.used_size;
 
   // Offload cannot keep up with the DMA
-  if (bytes_written > bytes_read + ts2mm_info.buffers[i].buf_size) {
+  if (bytes_written > bytes_read + bd.alloc_size) {
     // Don't read any data
-    ts2mm_info.buffers[i].offset = ts2mm_info.buffers[i].used_size;
-    ts2mm_info.buffers[i].offload_done = true;
+    bd.offset = bd.used_size;
+    bd.offload_done = true;
 
     // Add warnings and user markers
     xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", TS2MM_WARN_MSG_CIRC_BUF_OVERWRITE);
@@ -386,30 +382,30 @@ config_s2mm_reader(uint64_t i, uint64_t wordCount)
   }
 
   // Start Offload from previous offset
-  ts2mm_info.buffers[i].offset = ts2mm_info.buffers[i].used_size;
-  if (ts2mm_info.buffers[i].offset == ts2mm_info.full_buf_size) {
+  bd.offset = bd.used_size;
+  if (bd.offset == bd.alloc_size) {
     if (!ts2mm_info.use_circ_buf) {
-      ts2mm_info.buffers[i].offload_done = true;
+      bd.offload_done = true;
       stop_offload();
       return false;
     }
-    ts2mm_info.buffers[i].rollover_count++;
-    ts2mm_info.buffers[i].offset = 0;
+    bd.rollover_count++;
+    bd.offset = 0;
   }
 
   // End Offload at this offset
-  ts2mm_info.buffers[i].used_size = bytes_written - ts2mm_info.buffers[i].rollover_count*ts2mm_info.full_buf_size;
-  if (ts2mm_info.buffers[i].used_size > ts2mm_info.full_buf_size) {
-    ts2mm_info.buffers[i].used_size = ts2mm_info.full_buf_size;
+  bd.used_size = bytes_written - bd.rollover_count * bd.alloc_size;
+  if (bd.used_size > bd.alloc_size) {
+    bd.used_size = bd.alloc_size;
   }
 
   debug_stream
     << "DeviceTraceOffload::config_s2mm_reader for " << i << " ts2mm " 
     << "Reading from 0x"
-    << std::hex << ts2mm_info.buffers[i].offset << " to 0x" << ts2mm_info.buffers[i].used_size << std::dec
+    << std::hex << bd.offset << " to 0x" << bd.used_size << std::dec
     << " Bytes Read : " << bytes_read
     << " Bytes Written : " << bytes_written
-    << " Rollovers : " << ts2mm_info.buffers[i].rollover_count
+    << " Rollovers : " << bd.rollover_count
     << std::endl;
 
   return true;
@@ -418,25 +414,20 @@ config_s2mm_reader(uint64_t i, uint64_t wordCount)
 bool DeviceTraceOffload::
 init_s2mm(bool circ_buf, const std::vector<uint64_t> &buf_sizes)
 {
-  debug_stream
-    << "DeviceTraceOffload::init_s2mm with size : " << ts2mm_info.full_buf_size
-    << std::endl;
   /* If buffer is already allocated and still attempting to initialize again,
    * then reset the TS2MM IP and free the old buffer
    */
-  if (!ts2mm_info.buffers.empty()) {
+  if (!ts2mm_info.buffers.empty())
     reset_s2mm();
-  }
-
-  if (!ts2mm_info.full_buf_size)
-    return false;
-
   ts2mm_info.buffers.resize(ts2mm_info.num_ts2mm);
 
+  if (buf_sizes.empty())
+    return false;
+
   // Check if allocated buffer and sleep interval can keep up with offload
-  if (dev_intf->supportsCircBuf() && circ_buf) {
+  if (dev_intf->supportsCircBufPL() && circ_buf) {
     if (sleep_interval_ms != 0) {
-      ts2mm_info.circ_buf_cur_rate = buf_sizes[0] * (1000 / sleep_interval_ms);
+      ts2mm_info.circ_buf_cur_rate = buf_sizes.front() * (1000 / sleep_interval_ms);
       if (ts2mm_info.circ_buf_cur_rate >= ts2mm_info.circ_buf_min_rate)
         ts2mm_info.use_circ_buf = true;
     } else {
@@ -444,21 +435,20 @@ init_s2mm(bool circ_buf, const std::vector<uint64_t> &buf_sizes)
     }
   }
 
-  for(uint64_t i = 0; i < ts2mm_info.num_ts2mm; i++) {
-    ts2mm_info.buffers[i].buf_size = buf_sizes[i];
+  for (uint64_t i = 0; i < ts2mm_info.num_ts2mm; i++) {
+    auto& bd = ts2mm_info.buffers[i];
+    bd.alloc_size = buf_sizes[i];
 
-    ts2mm_info.buffers[i].buf = dev_intf->allocTraceBuf(ts2mm_info.buffers[i].buf_size, dev_intf->getTS2MmMemIndex(i));
-
-    if (!ts2mm_info.buffers[i].buf) {
+    bd.buf = dev_intf->allocTraceBuf(bd.alloc_size, dev_intf->getTS2MmMemIndex(i));
+    if (!bd.buf)
       return false;
-    }
 
     // Data Mover will write input stream to this address
-    ts2mm_info.buffers[i].address = dev_intf->getDeviceAddr(ts2mm_info.buffers[i].buf);
-    dev_intf->initTS2MM(i, ts2mm_info.buffers[i].buf_size, ts2mm_info.buffers[i].address, ts2mm_info.use_circ_buf);
+    bd.address = dev_intf->getDeviceAddr(bd.buf);
+    dev_intf->initTS2MM(i, bd.alloc_size, bd.address, ts2mm_info.use_circ_buf);
 
     debug_stream
-    << "DeviceTraceOffload::init_s2mm with each size : " << ts2mm_info.buffers[i].buf_size
+    << "DeviceTraceOffload::init_s2mm with each size : " << bd.alloc_size
     << " initiated " << i << " ts2mm " << std::endl;
   }
   return true;
@@ -471,7 +461,7 @@ reset_s2mm()
   if (ts2mm_info.buffers.empty())
     return;
 
-  for(uint64_t i = 0; i < ts2mm_info.num_ts2mm; i++) {
+  for (uint64_t i = 0; i < ts2mm_info.num_ts2mm; i++) {
     // Need to re-initialize datamover with circular buffer off for reset to work properly
     if (ts2mm_info.use_circ_buf)
       dev_intf->initTS2MM(i, 0, ts2mm_info.buffers[i].address, 0);
@@ -498,7 +488,7 @@ trace_buffer_full()
   }
 
   bool isFull = false;
-  for(uint32_t i = 0 ; i < ts2mm_info.num_ts2mm && !isFull; i++) {
+  for (uint32_t i = 0 ; i < ts2mm_info.num_ts2mm && !isFull; i++) {
     isFull |= ts2mm_info.buffers[i].full;
   }
   // Throw warning for this offloader if we detect full buffer

--- a/src/runtime_src/xdp/profile/device/device_trace_offload.cpp
+++ b/src/runtime_src/xdp/profile/device/device_trace_offload.cpp
@@ -312,7 +312,7 @@ read_trace_s2mm(bool force)
   auto bytes_written = (wordcount - bd.prv_wordcount) * TRACE_PACKET_SIZE;
 
   // Don't read data if there's less than 512B trace
-  if (!force && (bytes_written < TS2MM_MIN_READ_SIZE)) {
+  if (!force && !ts2mm_info.use_circ_buf && (bytes_written < TS2MM_MIN_READ_SIZE)) {
     debug_stream
       << "Skipping trace read. Amount of data: " << bytes_written << std::endl;
     return;

--- a/src/runtime_src/xdp/profile/device/device_trace_offload.h
+++ b/src/runtime_src/xdp/profile/device/device_trace_offload.h
@@ -52,7 +52,7 @@ enum class OffloadThreadType {
 
 struct TraceBufferInfo {
   size_t   buf;
-  uint64_t buf_size;
+  uint64_t alloc_size;
   uint64_t used_size;
   uint64_t offset;
   uint64_t address;
@@ -64,7 +64,7 @@ struct TraceBufferInfo {
   
   TraceBufferInfo()
     : buf(0),
-      buf_size(0),
+      alloc_size(0),
       used_size(0),
       offset(0),
       address(0),

--- a/src/runtime_src/xdp/profile/device/tracedefs.h
+++ b/src/runtime_src/xdp/profile/device/tracedefs.h
@@ -73,7 +73,8 @@ buffer size and/or reduce trace_buffer_offload_interval."
 #define TS2MM_WARN_MSG_QUEUE_SZ        "Too much trace in processing queue. This could have negative impact on host memory utilization. \
 Please increase trace_buffer_size and trace_buffer_offload_interval together or use 'coarse' option for device_trace."
 
-#define AIE_TS2MM_WARN_MSG_BUF_FULL       "AIE Trace Buffer is full. Device trace could be incomplete."
+#define AIE_TS2MM_WARN_MSG_BUF_FULL             "AIE Trace Buffer is full. Device trace could be incomplete."
+#define AIE_TS2MM_WARN_MSG_CIRC_BUF_OVERWRITE   "Circular buffer overwrite was detected in device trace. AIE trace could be incomplete."
 
 // Trace file Dump Settings and Warnings
 #define MIN_TRACE_DUMP_INTERVAL_S 1

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -1280,7 +1280,12 @@ namespace xdp {
     // NOTE 1: The data mover uses a burst length of 128, so we need dummy packets
     //         to ensure all execution trace gets written to DDR.
     // NOTE 2: This flush mechanism is only valid for runtime event trace
-    if (runtimeMetrics && xrt_core::config::get_aie_trace_flush()) {
+    // NOTE 3: Disable flush if we have new datamover
+    DeviceIntf* deviceIntf = (db->getStaticInfo()).getDeviceIntf(deviceId);
+    bool ts2mmFlushSupported = false;
+    if (deviceIntf)
+      ts2mmFlushSupported = deviceIntf->supportsflushAIE();
+    if (runtimeMetrics && xrt_core::config::get_aie_trace_flush() && !ts2mmFlushSupported) {
       setFlushMetrics(deviceId, handle);
       std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -1096,6 +1096,12 @@ namespace xdp {
                                               aieTraceBufSize,     // total trace buffer size
                                               numAIETraceOutput);  // numStream
 
+    // Can't call init without setting important details in offloader
+    if (continuousTrace && isPLIO) {
+      aieTraceOffloader->setContinuousTrace();
+      aieTraceOffloader->setOffloadIntervalms(offloadIntervalms);
+    }
+
     if (!aieTraceOffloader->initReadTrace()) {
       std::string msg = "Allocation of buffer for AIE trace failed. AIE trace will not be available.";
       xrt_core::message::send(severity_level::warning, "XRT", msg);
@@ -1106,11 +1112,8 @@ namespace xdp {
     aieOffloaders[deviceId] = std::make_tuple(aieTraceOffloader, aieTraceLogger, deviceIntf);
 
     // Continuous Trace Offload is supported only for PLIO flow
-    if (continuousTrace && isPLIO) {
-      aieTraceOffloader->setContinuousTrace();
-      aieTraceOffloader->setOffloadIntervalms(offloadIntervalms);
+    if (continuousTrace && isPLIO)
       aieTraceOffloader->startOffload();
-    }
   }
 
   void AieTracePlugin::setFlushMetrics(uint64_t deviceId, void* handle)

--- a/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
@@ -274,7 +274,7 @@ namespace xdp {
       offloader->start_offload(OffloadThreadType::TRACE);
       offloader->set_continuous();
       if (m_enable_circular_buffer) {
-        if (devInterface->supportsCircBuf()) {
+        if (devInterface->supportsCircBufPL()) {
           uint64_t min_offload_rate = 0 ;
           uint64_t requested_offload_rate = 0 ;
           bool use_circ_buf =

--- a/src/runtime_src/xdp/profile/writer/aie_trace/aie_trace_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/aie_trace/aie_trace_writer.cpp
@@ -83,7 +83,7 @@ namespace xdp {
 
     size_t num = traceData->buffer.size();
     for(size_t j = 0; j < num; j++) {
-      void*    buf = traceData->buffer[j];
+      void*    buf = traceData->buffer[j].get();
       // We write 4 bytes at a time
       // Max chunk size should be multiple of 4
       // If last chunk is not multiple of 4 then in worst case, 


### PR DESCRIPTION
Enable circular buffer for 1gb/s bandwidth in plio
clean up pl trace offload code
turn off flush with datamover 2.0
Enable buffer copying instead of reusing