### PR TITLE
Add RTEMS support for xbutil2 main as a command

### DIFF
--- a/src/runtime_src/core/common/api/xrt_xclbin.cpp
+++ b/src/runtime_src/core/common/api/xrt_xclbin.cpp
@@ -47,8 +47,10 @@
 #ifdef _WIN32
 # include "windows/uuid.h"
 # pragma warning( disable : 4244 4267 4996)
-#else
+#elifdef __linux__
 # include <linux/uuid.h>
+#else
+# include <uuid/uuid.h>
 #endif
 
 namespace {

--- a/src/runtime_src/core/common/config_reader.cpp
+++ b/src/runtime_src/core/common/config_reader.cpp
@@ -81,7 +81,7 @@ is_true(const std::string& str)
 static std::string
 get_self_path()
 {
-#ifdef __GNUC__
+#ifdef __linux__
   char buf[PATH_MAX] = {0};
   auto len = ::readlink("/proc/self/exe", buf, PATH_MAX);
   return std::string(buf, (len>0) ? len : 0);

--- a/src/runtime_src/core/common/memalign.h
+++ b/src/runtime_src/core/common/memalign.h
@@ -21,12 +21,14 @@
 #include <memory>
 #include <stdexcept>
 
+#include <stdlib.h>
+
 namespace xrt_core {
 
 inline int
 posix_memalign(void **memptr, size_t alignment, size_t size)
 {
-#if defined(__linux__)
+#if defined(__linux__) || defined(__rtems__)
   return ::posix_memalign(memptr,alignment,size);
 #elif defined(_WINDOWS)
   // this is not good, _aligned_malloc requires _aligned_free

--- a/src/runtime_src/core/common/message.cpp
+++ b/src/runtime_src/core/common/message.cpp
@@ -29,9 +29,11 @@
 #include <algorithm>
 #include <cstdarg>
 #include <climits>
-#ifdef __linux__
+#if defined(__linux__) || defined(__rtems__)
 # include <syslog.h>
+#ifdef __linux__
 # include <linux/limits.h>
+#endif
 # include <sys/stat.h>
 # include <sys/types.h>
 #include <unistd.h>

--- a/src/runtime_src/core/common/thread.cpp
+++ b/src/runtime_src/core/common/thread.cpp
@@ -127,9 +127,11 @@ set_cpu_affinity(std::thread& thread)
   if (all)
     return;
 
+#ifdef __linux__
   if (pthread_setaffinity_np(thread.native_handle(),sizeof(cpu_set_t),&cpuset)) {
     throw std::runtime_error("error calling pthread_setaffinity_np");
   }
+#endif
 }
 
 #else

--- a/src/runtime_src/core/tools/common/Process.cpp
+++ b/src/runtime_src/core/tools/common/Process.cpp
@@ -101,6 +101,7 @@ XBUtilities::runScript( const std::string & env,
                         std::ostringstream & os_stderr,
                         bool /*erasePassFailMessage*/)
 {
+#ifndef __rtems__
   // Fix environment variables before running test case
   setenv("XILINX_XRT", "/opt/xilinx/xrt", 0);
   setShellPathEnv("PYTHONPATH", "/python");
@@ -177,6 +178,7 @@ XBUtilities::runScript( const std::string & env,
   else if (passed)
     return 0;
   else
+#endif
     return 1;
 }
 #else

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -43,6 +43,7 @@
 /* need to link the lib for the following to work */
 # define be32toh ntohl
 #else
+# include <sys/endian.h>
 # include <unistd.h> // SUDO check
 #endif
 


### PR DESCRIPTION
With RTEMS there are some constraints:

1. Applications are all statically linked so there can only be a single `main()`. We need to change the name of xbutil2's `main` to something else.
2. Commands on RTEMS are C functions. The function need external C linkage.

This change is a bit messy but it is simple. I could not see an easy compiler trick to do this without touching the code.