### PR TITLE
Catch any boost exceptions and return the fallback path

### DIFF
--- a/src/runtime_src/core/common/api/xrt_xclbin.cpp
+++ b/src/runtime_src/core/common/api/xrt_xclbin.cpp
@@ -47,8 +47,10 @@
 #ifdef _WIN32
 # include "windows/uuid.h"
 # pragma warning( disable : 4244 4267 4996)
-#else
+#elifdef __linux__
 # include <linux/uuid.h>
+#else
+# include <uuid/uuid.h>
 #endif
 
 namespace {

--- a/src/runtime_src/core/common/api/xrt_xclbin.cpp
+++ b/src/runtime_src/core/common/api/xrt_xclbin.cpp
@@ -20,6 +20,7 @@
 #define XCL_DRIVER_DLL_EXPORT  // exporting xrt_xclbin.h
 #define XRT_CORE_COMMON_SOURCE // in same dll as core_common
 #include "core/include/experimental/xrt_xclbin.h"
+#include "xrt/xrt_uuid.h"
 
 #include "core/common/system.h"
 #include "core/common/device.h"
@@ -45,12 +46,7 @@
 #include <mutex>
 
 #ifdef _WIN32
-# include "windows/uuid.h"
 # pragma warning( disable : 4244 4267 4996)
-#elifdef __linux__
-# include <linux/uuid.h>
-#else
-# include <uuid/uuid.h>
 #endif
 
 namespace {

--- a/src/runtime_src/core/common/config_reader.cpp
+++ b/src/runtime_src/core/common/config_reader.cpp
@@ -81,7 +81,7 @@ is_true(const std::string& str)
 static std::string
 get_self_path()
 {
-#ifdef __GNUC__
+#ifdef __linux__
   char buf[PATH_MAX] = {0};
   auto len = ::readlink("/proc/self/exe", buf, PATH_MAX);
   return std::string(buf, (len>0) ? len : 0);

--- a/src/runtime_src/core/common/memalign.h
+++ b/src/runtime_src/core/common/memalign.h
@@ -21,12 +21,14 @@
 #include <memory>
 #include <stdexcept>
 
+#include <stdlib.h>
+
 namespace xrt_core {
 
 inline int
 posix_memalign(void **memptr, size_t alignment, size_t size)
 {
-#if defined(__linux__)
+#if defined(__linux__) || defined(__rtems__)
   return ::posix_memalign(memptr,alignment,size);
 #elif defined(_WINDOWS)
   // this is not good, _aligned_malloc requires _aligned_free

--- a/src/runtime_src/core/common/message.cpp
+++ b/src/runtime_src/core/common/message.cpp
@@ -29,9 +29,11 @@
 #include <algorithm>
 #include <cstdarg>
 #include <climits>
-#ifdef __linux__
+#if defined(__linux__) || defined(__rtems__)
 # include <syslog.h>
+#ifdef __linux__
 # include <linux/limits.h>
+#endif
 # include <sys/stat.h>
 # include <sys/types.h>
 #include <unistd.h>

--- a/src/runtime_src/core/common/thread.cpp
+++ b/src/runtime_src/core/common/thread.cpp
@@ -127,11 +127,9 @@ set_cpu_affinity(std::thread& thread)
   if (all)
     return;
 
-#ifdef __linux__
   if (pthread_setaffinity_np(thread.native_handle(),sizeof(cpu_set_t),&cpuset)) {
     throw std::runtime_error("error calling pthread_setaffinity_np");
   }
-#endif
 }
 
 #else

--- a/src/runtime_src/core/common/thread.cpp
+++ b/src/runtime_src/core/common/thread.cpp
@@ -127,9 +127,11 @@ set_cpu_affinity(std::thread& thread)
   if (all)
     return;
 
+#ifdef __linux__
   if (pthread_setaffinity_np(thread.native_handle(),sizeof(cpu_set_t),&cpuset)) {
     throw std::runtime_error("error calling pthread_setaffinity_np");
   }
+#endif
 }
 
 #else

--- a/src/runtime_src/core/edge/user/zynq_dev.cpp
+++ b/src/runtime_src/core/edge/user/zynq_dev.cpp
@@ -164,15 +164,19 @@ get_render_devname()
     // A symlink to render device is created based on this node name
     static const std::regex filter{"platform.*zyxclmm_drm-render"};
 
-    boost::filesystem::directory_iterator end_itr;
-    for( boost::filesystem::directory_iterator itr( render_dev_sym_dir ); itr != end_itr; ++itr) {
-        if (!std::regex_match(itr->path().filename().string(), filter))
-	    continue;
+    try {
+        boost::filesystem::directory_iterator end_itr;
+        for( boost::filesystem::directory_iterator itr( render_dev_sym_dir ); itr != end_itr; ++itr) {
+            if (!std::regex_match(itr->path().filename().string(), filter))
+                continue;
 
-	if (boost::filesystem::is_symlink(itr->path()))
-	    render_devname = boost::filesystem::read_symlink(itr->path()).filename().string();
+            if (boost::filesystem::is_symlink(itr->path()))
+                render_devname = boost::filesystem::read_symlink(itr->path()).filename().string();
 
-	break;
+            break;
+        }
+    } catch (std::exception& e) {
+        /* consume any boost related exceptions, fall through and return the default */
     }
 
     if (render_devname.empty())

--- a/src/runtime_src/core/edge/user/zynq_dev.cpp
+++ b/src/runtime_src/core/edge/user/zynq_dev.cpp
@@ -166,7 +166,7 @@ get_render_devname()
 
     try {
         boost::filesystem::directory_iterator end_itr;
-        for( boost::filesystem::directory_iterator itr( render_dev_sym_dir ); itr != end_itr; ++itr) {
+        for (boost::filesystem::directory_iterator itr { render_dev_sym_dir }; itr != end_itr; ++itr) {
             if (!std::regex_match(itr->path().filename().string(), filter))
                 continue;
 

--- a/src/runtime_src/core/tools/common/Process.cpp
+++ b/src/runtime_src/core/tools/common/Process.cpp
@@ -101,6 +101,7 @@ XBUtilities::runScript( const std::string & env,
                         std::ostringstream & os_stderr,
                         bool /*erasePassFailMessage*/)
 {
+#ifndef __rtems__
   // Fix environment variables before running test case
   setenv("XILINX_XRT", "/opt/xilinx/xrt", 0);
   setShellPathEnv("PYTHONPATH", "/python");
@@ -177,6 +178,7 @@ XBUtilities::runScript( const std::string & env,
   else if (passed)
     return 0;
   else
+#endif
     return 1;
 }
 #else

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -43,6 +43,7 @@
 /* need to link the lib for the following to work */
 # define be32toh ntohl
 #else
+# include <sys/endian.h>
 # include <unistd.h> // SUDO check
 #endif
 

--- a/src/runtime_src/core/tools/xbutil2/xbutil.cpp
+++ b/src/runtime_src/core/tools/xbutil2/xbutil.cpp
@@ -35,7 +35,14 @@
 #include <string>
 
 // Program entry
+#if __rtems__
+extern "C" {
+  int xbutil_main( int argc, char** argv );
+};
+int xbutil_main( int argc, char** argv )
+#else
 int main( int argc, char** argv )
+#endif
 {
   // -- Build the supported subcommands
   SubCmdsCollection subCommands;


### PR DESCRIPTION
#### Problem solved by the commit
Stop a C call to `xclProbe()` throwing an exception if there was no directory iterator path present for render device node.

A call to `xclProbe()` is needed to initialise the singleton and avoid errors related the XRT core shared library not being loaded. RTEMS users tend to statically link applications and this means the XRT core is statically linked and due to the way the arena is put together just running `xbutil2` did not construct the needed singleton. A call to `xclProbe()` before anything else resolved this and the singleton is constructed.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Building XRT on RTEMS.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Catch exception thrown by render device name does not exist.
