### PR TITLE
ERT should re-build when header changes

### DIFF
--- a/src/runtime_src/ert/scheduler/sched.mk
+++ b/src/runtime_src/ert/scheduler/sched.mk
@@ -3,9 +3,11 @@ include $(SRCDIR)/../ert.mk
 # BSP archive is created from SDK generated bsp
 # Extract to build dir in includes target
 # Also update the MicroBlaze linker script when it changes
-SRC := $(SRCDIR)/sched.c 
-XGQ_CTRL_SRC := $(SRCDIR)/xgq_ctrl.c
-XGQ_CU_SRC := $(SRCDIR)/xgq_cu.c
+RTS := $(SRCDIR)/../..
+HEADERS := $(SRCDIR)/*.h $(RTS)/core/include/xgq_impl.h $(RTS)/core/include/ert.h
+SRC := $(SRCDIR)/sched.c $(HEADERS)
+XGQ_CTRL_SRC := $(SRCDIR)/xgq_ctrl.c $(HEADERS)
+XGQ_CU_SRC := $(SRCDIR)/xgq_cu.c $(HEADERS)
 
 OBJ := $(BLDDIR)/sched.o
 XGQ_CTRL_OBJ := $(BLDDIR)/xgq_ctrl.o
@@ -13,7 +15,6 @@ XGQ_CU_OBJ := $(BLDDIR)/xgq_cu.o
 ELF := $(BLDDIR)/sched.elf
 BIN := $(BLDDIR)/sched.bin
 BSP := $(BLDDIR)/bsp
-RTS := $(SRCDIR)/../..
 
 ifndef SCHED_VERSION
  export SCHED_VERSION := 0x$(shell git rev-list -1 HEAD $(SRC) | cut -c1-8)
@@ -24,7 +25,7 @@ MYCFLAGS += -I$(BSP)/include -I$(RTS) -I$(RTS)/core/include $(DEFINES) -DERT_VER
 MYLFLAGS := -Wl,--defsym=_HEAP_SIZE=0x0 -Wl,--gc-sections
 MYLFLAGS += -Wl,-T,$(BLDDIR)/lscript.ld
 
-$(OBJ): $(SRC) $(BSP).extracted $(RTS)/core/include/ert.h
+$(OBJ): $(SRC) $(BSP).extracted
 	$(C) $(MYCFLAGS) -c -o $@ $<
 
 $(XGQ_CTRL_OBJ): $(XGQ_CTRL_SRC)

--- a/src/runtime_src/ert/scheduler/xgq_ctrl.c
+++ b/src/runtime_src/ert/scheduler/xgq_ctrl.c
@@ -19,13 +19,13 @@ inline void xgq_ctrl_init(struct xgq_ctrl *xgq_ctrl, struct xgq *xgq)
 inline void xgq_ctrl_response(struct xgq_ctrl *xgq_ctrl, void *resp, uint32_t size)
 {
 	int offset = 0;
-	uint32_t slot_addr;
+	uint64_t slot_addr;
 	struct sched_cmd *cmd = &xgq_ctrl->ctrl_cmd;
 
 	cmd_clear_header(cmd, 0);
 	xgq_notify_peer_consumed(xgq_ctrl->xgq);
 
-	while (xgq_produce(xgq_ctrl->xgq, (uint64_t *)&slot_addr))
+	while (xgq_produce(xgq_ctrl->xgq, &slot_addr))
 		continue;
 
 	for (; offset < size; offset+=4) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
1. Fix ERT makefile to make sure ERT will rebuild when header files change
2. Fix potential stack memory corruption in ERT
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
N/A
#### How problem was solved, alternative solutions (if any) and why they were rejected
N/A
#### Risks (if any) associated the changes in the commit
N/A
#### What has been tested and how, request additional testing if necessary
Tested new ERT and make sure there is no performance regression
#### Documentation impact (if any)
N/A