### PR TITLE
Add AIE_PARTITION parser

### DIFF
--- a/src/runtime_src/core/common/api/xrt_xclbin.cpp
+++ b/src/runtime_src/core/common/api/xrt_xclbin.cpp
@@ -56,7 +56,7 @@ namespace {
 // NOLINTNEXTLINE
 constexpr size_t operator"" _kb(unsigned long long v)  { return 1024u * v; }
 
-constexpr size_t max_sections = 12;
+constexpr size_t max_sections = 13;
 static const std::array<axlf_section_kind, max_sections> kinds = {
   EMBEDDED_METADATA,
   AIE_METADATA,
@@ -69,7 +69,8 @@ static const std::array<axlf_section_kind, max_sections> kinds = {
   SYSTEM_METADATA,
   CLOCK_FREQ_TOPOLOGY,
   BUILD_METADATA,
-  SOFT_KERNEL
+  SOFT_KERNEL,
+  AIE_PARTITION
 };
 
 XRT_CORE_UNUSED

--- a/src/runtime_src/core/common/xclbin_parser.cpp
+++ b/src/runtime_src/core/common/xclbin_parser.cpp
@@ -836,25 +836,18 @@ get_softkernels(const axlf* top)
   return sks;
 }
 
-aie_partition_obj get_aie_partition(const axlf* top)
+aie_partition_obj
+get_aie_partition(const axlf* top)
 {
-  aie_partition_obj obj{};
-
   auto pSection = ::xclbin::get_axlf_section(top, AIE_PARTITION);
   if (!pSection)
-    return obj;
+    return {};
 
   auto begin = reinterpret_cast<const char*>(top) + pSection->m_sectionOffset;
   auto aiep = reinterpret_cast<const aie_partition*>(begin);
-  obj.ncol = aiep->info.column_width;
-  obj.name = std::string(begin + aiep->mpo_name);
-  auto scp = reinterpret_cast<const uint8_t*>(begin + aiep->info.mpo_auint16_start_columns);
-  for (uint32_t i = 0; i < aiep->info.start_columns_count; i++) {
-    obj.start_col_list.push_back(scp[i]);
-    scp++;
-  }
+  auto scp = reinterpret_cast<const uint16_t*>(begin + aiep->info.mpo_auint16_start_columns);
 
-  return obj;
+  return {aiep->info.column_width, {scp, scp + aiep->info.start_columns_count}, begin + aiep->mpo_name};
 }
 
 size_t

--- a/src/runtime_src/core/common/xclbin_parser.cpp
+++ b/src/runtime_src/core/common/xclbin_parser.cpp
@@ -836,6 +836,27 @@ get_softkernels(const axlf* top)
   return sks;
 }
 
+aie_partition_obj get_aie_partition(const axlf* top)
+{
+  aie_partition_obj obj{};
+
+  auto pSection = ::xclbin::get_axlf_section(top, AIE_PARTITION);
+  if (!pSection)
+    return obj;
+
+  auto begin = reinterpret_cast<const char*>(top) + pSection->m_sectionOffset;
+  auto aiep = reinterpret_cast<const aie_partition*>(begin);
+  obj.ncol = aiep->info.column_width;
+  obj.name = std::string(begin + aiep->mpo_name);
+  auto scp = reinterpret_cast<const uint8_t*>(begin + aiep->info.mpo_auint16_start_columns);
+  for (uint32_t i = 0; i < aiep->info.start_columns_count; i++) {
+    obj.start_col_list.push_back(scp[i]);
+    scp++;
+  }
+
+  return obj;
+}
+
 size_t
 get_kernel_freq(const axlf* top)
 {

--- a/src/runtime_src/core/common/xclbin_parser.h
+++ b/src/runtime_src/core/common/xclbin_parser.h
@@ -95,6 +95,18 @@ struct softkernel_object
   char *sk_buf;
 };
 
+// struct aie_partition_obj - wrapper for an AIE Partition object
+//
+// @ncol: number of columns in this partition
+// @start_col_list: Array of start column for partition relocation
+// @name: partition name
+struct aie_partition_obj
+{
+  uint16_t ncol;
+  std::vector<uint16_t> start_col_list;
+  std::string name;
+};
+
 /**
  * get_axlf_section_header() - retrieve axlf section header
  *
@@ -272,6 +284,10 @@ get_dbg_ips_pair(const axlf* top);
  */
 std::vector<softkernel_object>
 get_softkernels(const axlf* top);
+
+XRT_CORE_COMMON_EXPORT
+aie_partition_obj
+get_aie_partition(const axlf* top);
 
 /**
  * get_kernel_freq() - Get kernel frequency.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Add an parser of AIE_PARTITION section in XCLBIN

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Create a wrapper and a helper function to walk through AIE_PARTITION section in XCLBIN to fill required information to the wrapper and return that wrapper in the helper function

#### Risks (if any) associated the changes in the commit
No

#### What has been tested and how, request additional testing if necessary
Wrote a small test code in hw_emu to call the helper function to get the data in AIE_PARTITION with a 1x4 AIE design that can be relocated to any column on {1, 2, 3, 4}. The parsed partition metadata is correct. See below output of the test code

ncol is 1
name is xclbinutil-generated
start col 0 is 1
start col 1 is 2
start col 2 is 3
start col 3 is 4

#### Documentation impact (if any)
N/A