### PR TITLE
Better management of padding in mailbox messages

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/include/mailbox_proto.h
+++ b/src/runtime_src/core/pcie/driver/linux/include/mailbox_proto.h
@@ -346,13 +346,13 @@ struct xcl_mailbox_clock_freqscaling {
 #define XCL_MB_REQ_FLAG_REQUEST		(1 << 1)
 /**
  * struct mailbox_req - mailbox request message header
- * @req: opcode
+ * @req: opcode (see enum xcl_mailbox_request)
  * @flags: flags of this message
  * @data: payload of variable length
  */
 struct xcl_mailbox_req {
 	uint64_t flags;
-	enum xcl_mailbox_request req;
+	uint32_t req;
 	char data[1]; /* variable length of payload */
 };
 

--- a/src/runtime_src/core/pcie/driver/linux/include/mailbox_proto.h
+++ b/src/runtime_src/core/pcie/driver/linux/include/mailbox_proto.h
@@ -19,6 +19,7 @@
 
 #ifndef __KERNEL__
 #include <stdint.h>
+#include <stddef.h>
 #endif
 
 /*
@@ -355,6 +356,12 @@ struct xcl_mailbox_req {
 	uint32_t req;
 	char data[1]; /* variable length of payload */
 };
+
+/**
+ * Definition to use for sizing mailbox request buffers
+ * e.g. size = XCL_MAILBOX_REQ_SIZE + message_length
+ */
+#define XCL_MAILBOX_REQ_SIZE (offsetof(struct xcl_mailbox_req, data))
 
 /**
  * struct sw_chan - mailbox software channel message metadata. This defines the

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
@@ -1126,7 +1126,7 @@ void xclmgmt_connect_notify(struct xclmgmt_dev *lro, bool online)
 	size_t data_len = 0, reqlen = 0;
 
 	data_len = sizeof(struct xcl_mailbox_peer_state);
-	reqlen = sizeof(struct xcl_mailbox_req) + data_len;
+	reqlen = XCL_MAILBOX_REQ_SIZE + data_len;
 	mb_req = vzalloc(reqlen);
 	if (!mb_req)
 		return;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/dna.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/dna.c
@@ -86,7 +86,7 @@ static void xlnx_dna_read_from_peer(struct platform_device *pdev)
 	size_t resp_len = sizeof(struct xcl_dna);
 	size_t data_len = sizeof(struct xcl_mailbox_subdev_peer);
 	struct xcl_mailbox_req *mb_req = NULL;
-	size_t reqlen = sizeof(struct xcl_mailbox_req) + data_len;
+	size_t reqlen = XCL_MAILBOX_REQ_SIZE + data_len;
 	xdev_handle_t xdev = xocl_get_xdev(pdev);
 
 	mb_req = vmalloc(reqlen);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/firewall.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/firewall.c
@@ -190,7 +190,7 @@ static void fw_read_from_peer(struct platform_device *pdev)
 	size_t resp_len = sizeof(struct xcl_firewall);
 	size_t data_len = sizeof(struct xcl_mailbox_subdev_peer);
 	struct xcl_mailbox_req *mb_req = NULL;
-	size_t reqlen = sizeof(struct xcl_mailbox_req) + data_len;
+	size_t reqlen = XCL_MAILBOX_REQ_SIZE + data_len;
 	xdev_handle_t xdev = xocl_get_xdev(pdev);
 
 	xocl_info(&pdev->dev, "reading from peer");

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/hwmon_sdm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/hwmon_sdm.c
@@ -203,7 +203,7 @@ static int hwmon_sdm_read_from_peer(struct platform_device *pdev, int repo_type)
 {
 	struct xocl_hwmon_sdm *sdm = platform_get_drvdata(pdev);
 	size_t data_len = sizeof(struct xcl_mailbox_subdev_peer);
-	size_t reqlen = sizeof(struct xcl_mailbox_req) + data_len;
+	size_t reqlen = XCL_MAILBOX_REQ_SIZE + data_len;
 	struct xcl_mailbox_subdev_peer subdev_peer = {0};
 	xdev_handle_t xdev = xocl_get_xdev(pdev);
 	struct xcl_mailbox_req *mb_req = NULL;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -318,7 +318,7 @@ static void icap_read_from_peer(struct platform_device *pdev)
 	size_t resp_len = sizeof(struct xcl_pr_region);
 	size_t data_len = sizeof(struct xcl_mailbox_subdev_peer);
 	struct xcl_mailbox_req *mb_req = NULL;
-	size_t reqlen = sizeof(struct xcl_mailbox_req) + data_len;
+	size_t reqlen = XCL_MAILBOX_REQ_SIZE + data_len;
 	xdev_handle_t xdev = xocl_get_xdev(pdev);
 
 	ICAP_INFO(icap, "reading from peer");
@@ -1121,7 +1121,7 @@ static int icap_download_rp(struct platform_device *pdev, int level, int flag)
 		goto end;
 	else if (flag == RP_DOWNLOAD_NORMAL) {
 		(void) xocl_peer_notify(xocl_get_xdev(icap->icap_pdev), &mbreq,
-				sizeof(struct xcl_mailbox_req));
+				XCL_MAILBOX_REQ_SIZE);
 		ICAP_INFO(icap, "Notified userpf to program rp");
 		goto end;
 	}
@@ -1750,7 +1750,7 @@ static int __icap_peer_xclbin_download(struct icap *icap, struct axlf *xclbin, b
 
 	xocl_mailbox_get(xdev, CHAN_STATE, &ch_state);
 	if ((ch_state & XCL_MB_PEER_SAME_DOMAIN) != 0) {
-		data_len = sizeof(struct xcl_mailbox_req) +
+		data_len = XCL_MAILBOX_REQ_SIZE +
 			sizeof(struct xcl_mailbox_bitstream_kaddr);
 		mb_req = vmalloc(data_len);
 		if (!mb_req) {
@@ -1762,7 +1762,7 @@ static int __icap_peer_xclbin_download(struct icap *icap, struct axlf *xclbin, b
 		memcpy(mb_req->data, &mb_addr,
 			sizeof(struct xcl_mailbox_bitstream_kaddr));
 	} else {
-		data_len = sizeof(struct xcl_mailbox_req) +
+		data_len = XCL_MAILBOX_REQ_SIZE +
 			xclbin->m_header.m_length;
 		mb_req = vmalloc(data_len);
 		if (!mb_req) {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mailbox.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mailbox.c
@@ -1880,7 +1880,7 @@ static void mailbox_send_test_load_xclbin_kaddr(struct mailbox *mbx)
 	mbx->mbx_recv_body_len = sizeof (int);
 
 	data_len = sizeof(struct xcl_mailbox_bitstream_kaddr);
-	reqlen = sizeof(struct xcl_mailbox_req) + data_len;
+	reqlen = XCL_MAILBOX_REQ_SIZE + data_len;
 	req = kzalloc(reqlen, GFP_KERNEL);
 	if (!req) {
 		mbx->mbx_test_send_status = -ENOMEM;
@@ -1917,7 +1917,7 @@ static void _mailbox_send_test(struct mailbox *mbx, size_t data_len, size_t resp
 		mbx->mbx_recv_body_len = resp_len;
 	}
 
-	reqlen = sizeof(struct xcl_mailbox_req) + data_len;
+	reqlen = XCL_MAILBOX_REQ_SIZE + data_len;
 	req = vzalloc(reqlen);
 	if (!req) {
 		mbx->mbx_test_send_status = -ENOMEM;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/p2p.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/p2p.c
@@ -499,7 +499,7 @@ static void p2p_read_addr_mgmtpf(struct p2p *p2p)
 		return;
 
 	mb_p2p_len = sizeof(struct xcl_mailbox_p2p_bar_addr);
-	reqlen = sizeof(struct xcl_mailbox_req) + mb_p2p_len;
+	reqlen = XCL_MAILBOX_REQ_SIZE + mb_p2p_len;
 	mb_req = vzalloc(reqlen);
 	if (!mb_req) {
 		p2p_err(p2p, "dropped request (%d), mem alloc issue",

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
@@ -547,7 +547,7 @@ static void xmc_read_from_peer(struct platform_device *pdev)
 	size_t resp_len = sizeof(struct xcl_sensor);
 	size_t data_len = sizeof(struct xcl_mailbox_subdev_peer);
 	struct xcl_mailbox_req *mb_req = NULL;
-	size_t reqlen = sizeof(struct xcl_mailbox_req) + data_len;
+	size_t reqlen = XCL_MAILBOX_REQ_SIZE + data_len;
 	xdev_handle_t xdev = xocl_get_xdev(pdev);
 
 	xocl_info(&pdev->dev, "reading from peer");
@@ -981,7 +981,7 @@ static void read_bdinfo_from_peer(struct platform_device *pdev)
 	size_t resp_len = sizeof(struct xcl_board_info);
 	size_t data_len = sizeof(struct xcl_mailbox_subdev_peer);
 	struct xcl_mailbox_req *mb_req = NULL;
-	size_t reqlen = sizeof(struct xcl_mailbox_req) + data_len;
+	size_t reqlen = XCL_MAILBOX_REQ_SIZE + data_len;
 	xdev_handle_t xdev = xocl_get_xdev(pdev);
 	int ret = 0;
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc_u2.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc_u2.c
@@ -488,7 +488,7 @@ static void xmc_read_from_peer(struct platform_device *pdev)
 	size_t resp_len = sizeof(struct xcl_sensor);
 	size_t data_len = sizeof(struct xcl_mailbox_subdev_peer);
 	struct xcl_mailbox_req *mb_req = NULL;
-	size_t reqlen = sizeof(struct xcl_mailbox_req) + data_len;
+	size_t reqlen = XCL_MAILBOX_REQ_SIZE + data_len;
 	xdev_handle_t xdev = xocl_get_xdev(pdev);
 
 	xocl_info(&pdev->dev, "reading from peer");
@@ -892,7 +892,7 @@ static void read_bdinfo_from_peer(struct platform_device *pdev)
 	size_t resp_len = sizeof(struct xcl_board_info);
 	size_t data_len = sizeof(struct xcl_mailbox_subdev_peer);
 	struct xcl_mailbox_req *mb_req = NULL;
-	size_t reqlen = sizeof(struct xcl_mailbox_req) + data_len;
+	size_t reqlen = XCL_MAILBOX_REQ_SIZE + data_len;
 	xdev_handle_t xdev = xocl_get_xdev(pdev);
 	int ret = 0;
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
@@ -120,7 +120,7 @@ static void xocl_mig_cache_read_from_peer(struct xocl_dev *xdev)
 	size_t resp_len = sizeof(struct xcl_mig_ecc)*MAX_M_COUNT;
 	size_t data_len = sizeof(struct xcl_mailbox_subdev_peer);
 	struct xcl_mailbox_req *mb_req = NULL;
-	size_t reqlen = sizeof(struct xcl_mailbox_req) + data_len;
+	size_t reqlen = XCL_MAILBOX_REQ_SIZE + data_len;
 	int ret = 0;
 
 	mb_req = vmalloc(reqlen);
@@ -330,7 +330,7 @@ int xocl_program_shell(struct xocl_dev *xdev, bool force)
 		goto failed;
 
 	userpf_info(xdev, "request mgmtpf to program prp");
-	mbret = xocl_peer_request(xdev, &mbreq, sizeof(struct xcl_mailbox_req),
+	mbret = xocl_peer_request(xdev, &mbreq, XCL_MAILBOX_REQ_SIZE,
 		&ret, &resplen, NULL, NULL, 0, 0);
 	if (mbret)
 		ret = mbret;
@@ -406,7 +406,7 @@ int xocl_hot_reset(struct xocl_dev *xdev, u32 flag)
 		if (flag & XOCL_RESET_NO)
 			return 0;
 
-		mbret = xocl_peer_request(xdev, &mbreq, sizeof(struct xcl_mailbox_req),
+		mbret = xocl_peer_request(xdev, &mbreq, XCL_MAILBOX_REQ_SIZE,
 			&ret, &resplen, NULL, NULL, 0, 6);
 		/*
 		 * Check the return values mbret & ret (mpd (peer) side response) and confirm
@@ -429,7 +429,7 @@ int xocl_hot_reset(struct xocl_dev *xdev, u32 flag)
 		return 0;
 	}
 
-	mbret = xocl_peer_request(xdev, &mbreq, sizeof(struct xcl_mailbox_req),
+	mbret = xocl_peer_request(xdev, &mbreq, XCL_MAILBOX_REQ_SIZE,
 		&ret, &resplen, NULL, NULL, 0, 0);
 
 	xocl_reset_notify(xdev->core.pdev, true);
@@ -609,7 +609,7 @@ static void xocl_mb_connect(struct xocl_dev *xdev)
 		goto done;
 
 	data_len = sizeof(struct xcl_mailbox_conn);
-	reqlen = sizeof(struct xcl_mailbox_req) + data_len;
+	reqlen = XCL_MAILBOX_REQ_SIZE + data_len;
 	mb_req = vzalloc(reqlen);
 	if (!mb_req)
 		goto done;
@@ -654,7 +654,7 @@ int xocl_reclock(struct xocl_dev *xdev, void *data)
 	struct xcl_mailbox_req *req = NULL;
 	size_t resplen = sizeof(msg);
 	size_t data_len = sizeof(struct xcl_mailbox_clock_freqscaling);
-	size_t reqlen = sizeof(struct xcl_mailbox_req)+data_len;
+	size_t reqlen = XCL_MAILBOX_REQ_SIZE+data_len;
 	struct drm_xocl_reclock_info *freqs = (struct drm_xocl_reclock_info *)data;
 	struct xcl_mailbox_clock_freqscaling mb_freqs = {0};
 
@@ -822,7 +822,7 @@ int xocl_refresh_subdevs(struct xocl_dev *xdev)
 	struct xcl_mailbox_subdev_peer subdev_peer = {0};
 	size_t data_len = sizeof(struct xcl_mailbox_subdev_peer);
 	struct xcl_mailbox_req	*mb_req = NULL;
-	size_t reqlen = sizeof(struct xcl_mailbox_req) + data_len;
+	size_t reqlen = XCL_MAILBOX_REQ_SIZE + data_len;
 	struct xcl_subdev	*resp = NULL;
 	size_t resp_len = sizeof(*resp) + XOCL_MSG_SUBDEV_DATA_LEN;
 	char *blob = NULL, *tmp;
@@ -1030,7 +1030,7 @@ static int xocl_hwmon_sdm_init_sysfs(struct xocl_dev *xdev, enum xcl_group_kind 
 	size_t data_len = sizeof(struct xcl_mailbox_subdev_peer);
 	struct xcl_mailbox_req *mb_req = NULL;
 	char *in_buf = NULL;
-	size_t reqlen = sizeof(struct xcl_mailbox_req) + data_len;
+	size_t reqlen = XCL_MAILBOX_REQ_SIZE + data_len;
 	int ret = 0;
 
 	mb_req = vmalloc(reqlen);

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/aws/aws_dev.cpp
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/aws/aws_dev.cpp
@@ -134,7 +134,7 @@ int mb_notify(size_t index, int fd, bool online)
     std::unique_ptr<sw_msg> swmsg;
     struct xcl_mailbox_req *mb_req = NULL;
     struct xcl_mailbox_peer_state mb_conn = { 0 };
-    size_t data_len = sizeof(struct xcl_mailbox_peer_state) + sizeof(struct xcl_mailbox_req);
+    size_t data_len = sizeof(struct xcl_mailbox_peer_state) + XCL_MAILBOX_REQ_SIZE;
     pcieFunc dev(index);
    
     std::vector<char> buf(data_len, 0);

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/mpd.cpp
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/mpd.cpp
@@ -498,7 +498,7 @@ int Mpd::localMsgHandler(const pcieFunc& dev, std::unique_ptr<sw_msg>& orig,
     int ret = 0;
     xcl_mailbox_req *req = reinterpret_cast<xcl_mailbox_req *>(orig->payloadData());
     size_t reqSize;
-    if (orig->payloadSize() < sizeof(xcl_mailbox_req)) {
+    if (orig->payloadSize() < XCL_MAILBOX_REQ_SIZE) {
         dev.log(LOG_ERR, "local request dropped, wrong size");
         ret = -EINVAL;
         processed = std::make_unique<sw_msg>(&ret, sizeof(ret), orig->id(),
@@ -506,7 +506,7 @@ int Mpd::localMsgHandler(const pcieFunc& dev, std::unique_ptr<sw_msg>& orig,
         dev.log(LOG_INFO, "mpd daemon: response %d sent ret = %d", req->req, ret);
         return FOR_LOCAL;
     }
-    reqSize = orig->payloadSize() - sizeof(xcl_mailbox_req);
+    reqSize = orig->payloadSize() - XCL_MAILBOX_REQ_SIZE;
 
     dev.log(LOG_INFO, "mpd daemon: request %d received(reqSize: %d)",
            req->req, reqSize);

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/msd.cpp
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/msd.cpp
@@ -268,11 +268,11 @@ int Msd::remoteMsgHandler(const pcieFunc& dev, std::unique_ptr<sw_msg>& orig,
 {
     int pass = FOR_LOCAL;
     xcl_mailbox_req *req = reinterpret_cast<xcl_mailbox_req *>(orig->payloadData());
-    if (orig->payloadSize() < sizeof(xcl_mailbox_req)) {
+    if (orig->payloadSize() < XCL_MAILBOX_REQ_SIZE) {
         dev.log(LOG_ERR, "peer request dropped, wrong size");
         return -EINVAL;
     }
-    size_t reqSize = orig->payloadSize() - sizeof(xcl_mailbox_req);
+    size_t reqSize = orig->payloadSize() - XCL_MAILBOX_REQ_SIZE;
     
     switch (req->req) {
     case XCL_MAILBOX_REQ_LOAD_XCLBIN: {


### PR DESCRIPTION
#### Problem solved by the commit
Interoperation between the XOCL driver and the X3 FW is simplified by eliminating this padding.  The mailbox protocol is also made more explicit, using fixed-width types and deliberate padding instead of architecture/compiler padding and type sizing.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1130511.

#### How problem was solved, alternative solutions (if any) and why they were rejected
We originally had a workaround in the FW to account for the fact that the last 4 bytes of data from the XOCL driver were padding.  This workaround was found to be inadequate when this padding straddles the last two packets of a message.  Fixing it in the FW was going to be convoluted, requiring more careful tracking of how many bytes the host had sent and potentially ignoring the entire last packet of a stream if it contains only padding.  Rather than add more kludges on top of the existing kludge, it seemed much easier to try to fix the problem at source, by eliminating the padding.  The changes on the XOCL and FW sides were both trivial in comparison to the alternative

#### Risks (if any) associated the changes in the commit
The original incarnation of this PR moved the padding to the front of the data stream, but this would cause interoperability problems if different versions of XOCL and XCLMGMT were mixed and matched.  The revised PR resolves this problem by simply eliminating the padding - it's redundant and the drivers are not reliant on it being there.

#### What has been tested and how, request additional testing if necessary
Interop with X3, which involves sending several mailbox requests and transferring a full XCLBIN works fine.  Waiting to see if the Github CI flags any problems

#### Documentation impact (if any)
None, because this protocol is not fully documented to begin with!