### PR TITLE
extra sync at circular buffer boundary and use microseconds for aie trace offload interval

### DIFF
--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -390,10 +390,20 @@ get_aie_trace_periodic_offload()
   return value;
 }
 
+/**
+ * Deprecated in future. Ms is too long for aie trace
+ */
 inline unsigned int
 get_aie_trace_buffer_offload_interval_ms()
 {
   static unsigned int value = detail::get_uint_value("Debug.aie_trace_buffer_offload_interval_ms", 10);
+  return value;
+}
+
+inline unsigned int
+get_aie_trace_buffer_offload_interval_us()
+{
+  static unsigned int value = detail::get_uint_value("Debug.aie_trace_buffer_offload_interval_us", 100);
   return value;
 }
 

--- a/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.cpp
+++ b/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.cpp
@@ -246,10 +246,10 @@ void AIETraceOffload::readTrace(bool final)
 
     // End Offload at this offset
     // limit size to not cross circular buffer boundary
-    uint64_t circBufRolloberBytes = 0;
+    uint64_t circBufRolloverBytes = 0;
     bd.usedSz = bytes_written - bd.rollover_count * bufAllocSz;
     if (bd.usedSz > bufAllocSz) {
-      circBufRolloberBytes = bd.usedSz - bufAllocSz;
+      circBufRolloverBytes = bd.usedSz - bufAllocSz;
       bd.usedSz = bufAllocSz;
     }
 
@@ -268,16 +268,16 @@ void AIETraceOffload::readTrace(bool final)
       continue;
 
     // Do another sync if we're crossing circular buffer boundary
-    if (mEnCircularBuf && circBufRolloberBytes) {
+    if (mEnCircularBuf && circBufRolloverBytes) {
       // Start from 0
       bd.rollover_count++;
       bd.offset = 0;
       // End at leftover bytes
-      bd.usedSz = circBufRolloberBytes;
+      bd.usedSz = circBufRolloverBytes;
 
       debug_stream
         << "Circular buffer boundary read from 0x0 to 0x: "
-        << std::hex << circBufRolloberBytes << std::dec << std::endl;
+        << std::hex << circBufRolloverBytes << std::dec << std::endl;
 
       syncAndLog(index);
     }

--- a/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.h
+++ b/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.h
@@ -93,7 +93,7 @@ public:
     inline AIETraceLogger* getAIETraceLogger() { return traceLogger; }
     inline void setContinuousTrace() { traceContinuous = true; }
     inline bool continuousTrace()    { return traceContinuous; }
-    inline void setOffloadIntervalms(uint64_t v) { offloadIntervalms = v; }
+    inline void setOffloadIntervalUs(uint64_t v) { offloadIntervalUs = v; }
 
     inline AIEOffloadThreadStatus getOffloadStatus() {
       std::lock_guard<std::mutex> lock(statusLock);
@@ -124,7 +124,7 @@ private:
 
     // Continuous Trace Offload (For PLIO)
     bool traceContinuous;
-    uint64_t offloadIntervalms;
+    uint64_t offloadIntervalUs;
     bool bufferInitialized;
     std::mutex statusLock;
     AIEOffloadThreadStatus offloadStatus;

--- a/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.h
+++ b/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.h
@@ -138,12 +138,11 @@ private:
   uint64_t circ_buf_cur_rate_plio;
 
 private:
-    void configAIETs2mm(uint64_t index, bool final);
-
     void continuousOffload();
     bool keepOffloading();
     void offloadFinished();
     void checkCircularBufferSupport();
+    bool syncAndLog(uint64_t index);
 };
 
 }

--- a/src/runtime_src/xdp/profile/device/device_trace_offload.cpp
+++ b/src/runtime_src/xdp/profile/device/device_trace_offload.cpp
@@ -75,10 +75,9 @@ offload_device_continuous()
     std::this_thread::sleep_for(std::chrono::milliseconds(sleep_interval_ms));
   }
 
-  // Do final forced reads
+  // Do final forced read
   // Note : Passing "true" also flushes and resets the datamover
   m_read_trace(true);
-  read_leftover_circular_buf();
 
   // Stop processing thread
   m_process_trace = false;
@@ -128,7 +127,7 @@ process_trace()
 
   bool q_read = false;
   bool q_empty = true;
-  std::unique_ptr<char[]> buf;
+  std::unique_ptr<unsigned char[]> buf;
   uint64_t size = 0;
   do {
     q_read=false;
@@ -269,19 +268,6 @@ read_trace_init(bool circ_buf, const std::vector<uint64_t> &buf_sizes)
 }
 
 void DeviceTraceOffload::
-read_leftover_circular_buf()
-{
-  // If we use circular buffer then, final trace read
-  // might stop at trace buffer boundry and to read the entire
-  // trace, we need one last read
-  if (ts2mm_info.use_circ_buf && ts2mm_info.buffers[0].used_size == ts2mm_info.buffers[0].alloc_size) {
-    debug_stream
-      << "Try to read left over circular buffer data" << std::endl;
-    m_read_trace(true);
-  }
-}
-
-void DeviceTraceOffload::
 read_trace_end()
 {
   // Trace logger will clear it's state and add approximations 
@@ -302,41 +288,110 @@ read_trace_end()
 void DeviceTraceOffload::
 read_trace_s2mm(bool force)
 {
-  debug_stream
-    << "DeviceTraceOffload::read_trace_s2mm : number of ts2mm in design "
-    << ts2mm_info.num_ts2mm << std::endl;
+  for (uint64_t i = 0; i < ts2mm_info.num_ts2mm; i++) {
+    auto& bd = ts2mm_info.buffers[i];
 
-  for(uint64_t i = 0; i < ts2mm_info.num_ts2mm; i++) {
-  auto& bd = ts2mm_info.buffers[i];
-  auto wordcount = dev_intf->getWordCountTs2mm(i, force);
-  auto bytes_written = (wordcount - bd.prv_wordcount) * TRACE_PACKET_SIZE;
+    if (bd.offload_done)
+      continue;
 
-  // Don't read data if there's less than 512B trace
-  if (!force && !ts2mm_info.use_circ_buf && (bytes_written < TS2MM_MIN_READ_SIZE)) {
+    auto bytes_written = dev_intf->getWordCountTs2mm(i, force) * TRACE_PACKET_SIZE;
+    auto bytes_read = bd.rollover_count * bd.alloc_size + bd.used_size;
+
+    // Offload cannot keep up with the DMA
+    if (bytes_written > bytes_read + bd.alloc_size) {
+      // Don't read any data
+      bd.offload_done = true;
+
+       debug_stream
+        << "ts2mm_ " << i << " Reading from 0x"
+        << std::hex << bd.offset << " to 0x" << bd.used_size << std::dec
+        << " Bytes Read : " << bytes_read
+        << " Bytes Written : " << bytes_written
+        << " Rollovers : " << bd.rollover_count
+        << std::endl;
+
+      // Add warnings and user markers
+      xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", TS2MM_WARN_MSG_CIRC_BUF_OVERWRITE);
+      xrt::profile::user_event events;
+      events.mark("Trace Buffer Overwrite Detected");
+      // Fatal condition. Abort offload
+      stop_offload();
+      return;
+    }
+
+    // Start Offload from previous offset
+    bd.offset = bd.used_size;
+    if (bd.offset == bd.alloc_size) {
+      if (!ts2mm_info.use_circ_buf) {
+        bd.offload_done = true;
+        continue;
+      }
+      bd.rollover_count++;
+      bd.offset = 0;
+    }
+
+    // End Offload at this offset
+    // limit size to not cross circular buffer boundary
+    uint64_t cir_buf_rollover_bytes = 0;
+    bd.used_size = bytes_written - bd.rollover_count * bd.alloc_size;
+    if (bd.used_size > bd.alloc_size) {
+      cir_buf_rollover_bytes = bd.used_size - bd.alloc_size;
+      bd.used_size = bd.alloc_size;
+    }
+
     debug_stream
-      << "Skipping trace read. Amount of data: " << bytes_written << std::endl;
-    return;
-  }
-  // There's enough data available
-  bd.prv_wordcount = wordcount;
+      << "ts2mm_" << i << " Reading from 0x"
+      << std::hex << bd.offset << " to 0x" << bd.used_size << std::dec
+      << " Bytes Read : " << bytes_read
+      << " Bytes Written : " << bytes_written
+      << " Rollovers : " << bd.rollover_count
+      << std::endl;
 
-  if (!config_s2mm_reader(i, wordcount))
-    return;
+    if (!sync_and_log(i))
+      continue;
+
+    // Do another sync if we're crossing circular buffer boundary
+    if (ts2mm_info.use_circ_buf && cir_buf_rollover_bytes) {
+      // Start from 0
+      bd.rollover_count++;
+      bd.offset = 0;
+      // End at leftover bytes
+      bd.used_size = cir_buf_rollover_bytes;
+
+      debug_stream
+        << "Circular buffer boundary read from 0x0 to 0x: "
+        << std::hex << cir_buf_rollover_bytes << std::dec << std::endl;
+
+      sync_and_log(i);
+    }
+  }
+}
+
+bool DeviceTraceOffload::
+sync_and_log(uint64_t index)
+{
+  auto& bd = ts2mm_info.buffers[index];
+
+  // No data or invalid settings
+  if (bd.offset >= bd.used_size)
+    return false;
 
   uint64_t nBytes = bd.used_size - bd.offset;
-
   auto start = std::chrono::steady_clock::now();
   void* host_buf = dev_intf->syncTraceBuf(bd.buf, bd.offset, nBytes);
   auto end = std::chrono::steady_clock::now();
+
   debug_stream
-    << "For " << i << " ts2mm : Elapsed time in microseconds for sync : "
+    << "ts2mm_" << index << " : sync : "
     << std::chrono::duration_cast<std::chrono::microseconds>(end - start).count()
     << " µs" << " nBytes : " << nBytes << std::endl;
 
-  if (!host_buf)
-    return;
+  if (!host_buf) {
+    bd.offload_done = true;
+    return false;
+  }
 
-  auto tmp = std::make_unique<char[]>(nBytes);
+  auto tmp = std::make_unique<unsigned char[]>(nBytes);
   std::memcpy(tmp.get(), host_buf, nBytes);
   // Push new data into queue for processing
   ts2mm_info.process_queue_lock.lock();
@@ -352,61 +407,6 @@ read_trace_s2mm(bool force)
 
   if (bd.used_size == bd.alloc_size && ts2mm_info.use_circ_buf == false)
     bd.full = true;
-  }
-}
-
-bool DeviceTraceOffload::
-config_s2mm_reader(uint64_t i, uint64_t wordCount)
-{
-  auto& bd = ts2mm_info.buffers[i];
-
-  if (bd.offload_done)
-    return false;
-
-  auto bytes_written = wordCount * TRACE_PACKET_SIZE;
-  auto bytes_read = bd.rollover_count * bd.alloc_size + bd.used_size;
-
-  // Offload cannot keep up with the DMA
-  if (bytes_written > bytes_read + bd.alloc_size) {
-    // Don't read any data
-    bd.offset = bd.used_size;
-    bd.offload_done = true;
-
-    // Add warnings and user markers
-    xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", TS2MM_WARN_MSG_CIRC_BUF_OVERWRITE);
-    xrt::profile::user_event events;
-    events.mark("Trace Buffer Overwrite Detected");
-
-    stop_offload();
-    return false;
-  }
-
-  // Start Offload from previous offset
-  bd.offset = bd.used_size;
-  if (bd.offset == bd.alloc_size) {
-    if (!ts2mm_info.use_circ_buf) {
-      bd.offload_done = true;
-      stop_offload();
-      return false;
-    }
-    bd.rollover_count++;
-    bd.offset = 0;
-  }
-
-  // End Offload at this offset
-  bd.used_size = bytes_written - bd.rollover_count * bd.alloc_size;
-  if (bd.used_size > bd.alloc_size) {
-    bd.used_size = bd.alloc_size;
-  }
-
-  debug_stream
-    << "DeviceTraceOffload::config_s2mm_reader for " << i << " ts2mm " 
-    << "Reading from 0x"
-    << std::hex << bd.offset << " to 0x" << bd.used_size << std::dec
-    << " Bytes Read : " << bytes_read
-    << " Bytes Written : " << bytes_written
-    << " Rollovers : " << bd.rollover_count
-    << std::endl;
 
   return true;
 }

--- a/src/runtime_src/xdp/profile/device/device_trace_offload.h
+++ b/src/runtime_src/xdp/profile/device/device_trace_offload.h
@@ -89,7 +89,7 @@ struct Ts2mmInfo {
   uint64_t circ_buf_min_rate = TS2MM_DEF_BUF_SIZE * 100;
   uint64_t circ_buf_cur_rate;
 
-  std::queue<std::unique_ptr<char[]>> data_queue;
+  std::queue<std::unique_ptr<unsigned char[]>> data_queue;
   std::queue<uint64_t> size_queue;
   std::mutex process_queue_lock;
 
@@ -161,7 +161,6 @@ private:
   void read_trace_fifo(bool force=true);
   void read_trace_s2mm(bool force=true);
   uint64_t read_trace_s2mm_partial();
-  bool config_s2mm_reader(uint64_t i, uint64_t wordCount);
   bool init_s2mm(bool circ_buf, const std::vector<uint64_t> &);
   void reset_s2mm();
   bool should_continue();
@@ -169,7 +168,7 @@ private:
   void offload_device_continuous();
   void offload_finished();
   void process_trace_continuous();
-  void read_leftover_circular_buf();
+  bool sync_and_log(uint64_t index);
 
 protected:
   DeviceIntf* dev_intf;

--- a/src/runtime_src/xdp/profile/device/tracedefs.h
+++ b/src/runtime_src/xdp/profile/device/tracedefs.h
@@ -75,6 +75,8 @@ Please increase trace_buffer_size and trace_buffer_offload_interval together or 
 
 #define AIE_TS2MM_WARN_MSG_BUF_FULL             "AIE Trace Buffer is full. Device trace could be incomplete."
 #define AIE_TS2MM_WARN_MSG_CIRC_BUF_OVERWRITE   "Circular buffer overwrite was detected in device trace. AIE trace could be incomplete."
+#define AIE_TS2MM_WARN_MSG_CIRC_BUF             "AIE trace will be limited to trace buffer size due to insufficient trace offload rate. Please increase \
+aie_trace_buffer_size and/or reduce aie_trace_buffer_offload_interval_us."
 
 // Trace file Dump Settings and Warnings
 #define MIN_TRACE_DUMP_INTERVAL_S 1

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -1257,9 +1257,8 @@ namespace xdp {
 
     uint64_t deviceId = db->addDevice(sysfspath); // Get the unique device Id
 
-    if(aieOffloaders.find(deviceId) != aieOffloaders.end()) {
+    if (aieOffloaders.find(deviceId) != aieOffloaders.end())
       (std::get<0>(aieOffloaders[deviceId]))->readTrace(true);
-    }
   }
 
   void AieTracePlugin::finishFlushAIEDevice(void* handle)
@@ -1293,7 +1292,7 @@ namespace xdp {
       std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
 
-    if(aieOffloaders.find(deviceId) != aieOffloaders.end()) {
+    if (aieOffloaders.find(deviceId) != aieOffloaders.end()) {
       auto offloader = std::get<0>(aieOffloaders[deviceId]);
       auto logger    = std::get<1>(aieOffloaders[deviceId]);
 
@@ -1312,7 +1311,7 @@ namespace xdp {
 
       aieOffloaders.erase(deviceId);
     }
-    
+
   }
 
   void AieTracePlugin::writeAll(bool /*openNewFiles*/)

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -82,7 +82,7 @@ namespace xdp {
   AieTracePlugin::AieTracePlugin()
                 : XDPPlugin(),
                   continuousTrace(false),
-                  offloadIntervalms(0)
+                  offloadIntervalUs(0)
   {
     AieTracePlugin::live = true;
 
@@ -93,7 +93,16 @@ namespace xdp {
     // AIE trace is now supported for HW only
     continuousTrace = xrt_core::config::get_aie_trace_periodic_offload();
     if (continuousTrace) {
-      offloadIntervalms = xrt_core::config::get_aie_trace_buffer_offload_interval_ms();
+      auto offloadIntervalms = xrt_core::config::get_aie_trace_buffer_offload_interval_ms();
+      if (offloadIntervalms != 10) {
+        std::stringstream msg;
+        msg << "aie_trace_buffer_offload_interval_ms will be deprecated in future. "
+            << "Please use aie_trace_buffer_offload_interval_us instead.";
+        xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", msg.str());
+        offloadIntervalUs = offloadIntervalms * 1e3;
+      } else {
+        offloadIntervalUs = xrt_core::config::get_aie_trace_buffer_offload_interval_us();
+      }
     }
 
     // Set Delay parameters
@@ -1099,7 +1108,7 @@ namespace xdp {
     // Can't call init without setting important details in offloader
     if (continuousTrace && isPLIO) {
       aieTraceOffloader->setContinuousTrace();
-      aieTraceOffloader->setOffloadIntervalms(offloadIntervalms);
+      aieTraceOffloader->setOffloadIntervalUs(offloadIntervalUs);
     }
 
     if (!aieTraceOffloader->initReadTrace()) {

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.h
@@ -85,7 +85,7 @@ namespace xdp {
       uint32_t mDelayCycles = 0;
 
       bool continuousTrace;
-      uint64_t offloadIntervalms;
+      uint64_t offloadIntervalUs;
       unsigned int aie_trace_file_dump_int_s;
 
       // Trace Runtime Status


### PR DESCRIPTION
Fix an issue where reads crossing circular boundary stop at boundary
Fix issue where we don't throw warning when aie trace buffer is full
Use microseconds instead of milliseconds for aie trace offload period
