### PR TITLE
Handle CRLF to LF automatically

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto


### PR DESCRIPTION
Avoid CRLF mess as per #6681 and issue #6672.
Let Git do what it thinks is best.
See https://git-scm.com/docs/gitattributes

Ran `git add --renormalize .`  with the `.gitattributes`  in a workspace prior to #6681 and it converted the same files.