### PR TITLE
VITIS-5805 QDMA: XRT to support pre downloaded QDMA lib driver files using XRT build options

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -270,6 +270,7 @@ if [[ -z $qdmalib ]]; then
     GIT_MODULES=$BUILDDIR/../.gitmodules
     if [ -f "$GIT_MODULES" ]; then
         cd $BUILDDIR/../
+        rm -rf src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma
         git submodule update --init
         cd $BUILDDIR
     fi

--- a/build/build.sh
+++ b/build/build.sh
@@ -58,6 +58,7 @@ usage()
     echo "[-verbose]                  Turn on verbosity when compiling"
     echo "[-ertbsp <dir>]             Path to directory with pre-downloaded BSP files for building ERT (default: download BSP files during build time)"
     echo "[-ertfw <dir>]              Path to directory with pre-built ert firmware (default: build the firmware)"
+    echo "[-qdmalib <dir>]            Path to directory with pre-downloaded QDMA lib files for building QDMA (default: download QDMA lib files during build time)"
     echo ""
     echo "ERT firmware is built if and only if MicroBlaze gcc compiler can be located."
     echo "When compiler is not accesible, use -ertfw to specify path to directory with"
@@ -89,6 +90,7 @@ noctest=0
 static_boost=""
 ertbsp=""
 ertfw=""
+qdmalib=""
 cmake_flags="-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
 
 while [ $# -gt 0 ]; do
@@ -113,6 +115,11 @@ while [ $# -gt 0 ]; do
         -ertfw)
             shift
             ertfw=$1
+            shift
+            ;;
+        -qdmalib)
+            shift
+            qdmalib=$1
             shift
             ;;
         -edge)
@@ -229,6 +236,11 @@ if [[ ! -z $ertfw ]]; then
     export XRT_FIRMWARE_DIR=$ertfw
 fi
 
+if [[ ! -z $qdmalib ]]; then
+    echo "export QDMA_LIB_DIR=$qdmalib"
+    export QDMA_LIB_DIR=$qdmalib
+fi
+
 if [[ ! -z $static_boost ]]; then
     echo "export XRT_BOOST_INSTALL=$static_boost"
     export XRT_BOOST_INSTALL=$static_boost
@@ -254,11 +266,13 @@ if [[ -z ${XILINX_VITIS:+x} ]] || [[ ! -d ${XILINX_VITIS} ]]; then
 fi
 
 #If git modules config file exist then try to clone them
-GIT_MODULES=$BUILDDIR/../.gitmodules
-if [ -f "$GIT_MODULES" ]; then
-    cd $BUILDDIR/../
-    git submodule update --init
-    cd $BUILDDIR
+if [[ -z $qdmalib ]]; then
+    GIT_MODULES=$BUILDDIR/../.gitmodules
+    if [ -f "$GIT_MODULES" ]; then
+        cd $BUILDDIR/../
+        git submodule update --init
+        cd $BUILDDIR
+    fi
 fi
 
 if [[ $dbg == 1 ]]; then

--- a/build/build.sh
+++ b/build/build.sh
@@ -58,7 +58,7 @@ usage()
     echo "[-verbose]                  Turn on verbosity when compiling"
     echo "[-ertbsp <dir>]             Path to directory with pre-downloaded BSP files for building ERT (default: download BSP files during build time)"
     echo "[-ertfw <dir>]              Path to directory with pre-built ert firmware (default: build the firmware)"
-    echo "[-qdmadir <dir>]            Path to directory with pre-downloaded QDMA lib files for building QDMA (default: download QDMA lib files during build time)"
+    echo "[-qdmalib <dir>]            Path to directory with pre-downloaded QDMA lib files for building QDMA (default: download QDMA lib files during build time)"
     echo ""
     echo "ERT firmware is built if and only if MicroBlaze gcc compiler can be located."
     echo "When compiler is not accesible, use -ertfw to specify path to directory with"
@@ -90,7 +90,7 @@ noctest=0
 static_boost=""
 ertbsp=""
 ertfw=""
-qdmadir=""
+qdmalib=""
 cmake_flags="-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
 
 while [ $# -gt 0 ]; do
@@ -117,9 +117,9 @@ while [ $# -gt 0 ]; do
             ertfw=$1
             shift
             ;;
-        -qdmadir)
+        -qdmalib)
             shift
-            qdmadir=$1
+            qdmalib=$1
             shift
             ;;
         -edge)
@@ -236,9 +236,9 @@ if [[ ! -z $ertfw ]]; then
     export XRT_FIRMWARE_DIR=$ertfw
 fi
 
-if [[ ! -z $qdmadir ]]; then
-    echo "export QDMA_LIB_DIR=$qdmadir"
-    export QDMA_LIB_DIR=$qdmadir
+if [[ ! -z $qdmalib ]]; then
+    echo "export QDMA_LIB_DIR=$qdmalib"
+    export QDMA_LIB_DIR=$qdmalib
 fi
 
 if [[ ! -z $static_boost ]]; then
@@ -266,11 +266,10 @@ if [[ -z ${XILINX_VITIS:+x} ]] || [[ ! -d ${XILINX_VITIS} ]]; then
 fi
 
 #If git modules config file exist then try to clone them
-if [[ -z $qdmadir ]]; then
+if [[ -z $qdmalib ]]; then
     GIT_MODULES=$BUILDDIR/../.gitmodules
     if [ -f "$GIT_MODULES" ]; then
         cd $BUILDDIR/../
-        git submodule sync
         git submodule update --init
         cd $BUILDDIR
     fi

--- a/build/build.sh
+++ b/build/build.sh
@@ -58,7 +58,7 @@ usage()
     echo "[-verbose]                  Turn on verbosity when compiling"
     echo "[-ertbsp <dir>]             Path to directory with pre-downloaded BSP files for building ERT (default: download BSP files during build time)"
     echo "[-ertfw <dir>]              Path to directory with pre-built ert firmware (default: build the firmware)"
-    echo "[-qdmalib <dir>]            Path to directory with pre-downloaded QDMA lib files for building QDMA (default: download QDMA lib files during build time)"
+    echo "[-qdmadir <dir>]            Path to directory with pre-downloaded QDMA lib files for building QDMA (default: download QDMA lib files during build time)"
     echo ""
     echo "ERT firmware is built if and only if MicroBlaze gcc compiler can be located."
     echo "When compiler is not accesible, use -ertfw to specify path to directory with"
@@ -90,7 +90,7 @@ noctest=0
 static_boost=""
 ertbsp=""
 ertfw=""
-qdmalib=""
+qdmadir=""
 cmake_flags="-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
 
 while [ $# -gt 0 ]; do
@@ -117,9 +117,9 @@ while [ $# -gt 0 ]; do
             ertfw=$1
             shift
             ;;
-        -qdmalib)
+        -qdmadir)
             shift
-            qdmalib=$1
+            qdmadir=$1
             shift
             ;;
         -edge)
@@ -236,9 +236,9 @@ if [[ ! -z $ertfw ]]; then
     export XRT_FIRMWARE_DIR=$ertfw
 fi
 
-if [[ ! -z $qdmalib ]]; then
-    echo "export QDMA_LIB_DIR=$qdmalib"
-    export QDMA_LIB_DIR=$qdmalib
+if [[ ! -z $qdmadir ]]; then
+    echo "export QDMA_LIB_DIR=$qdmadir"
+    export QDMA_LIB_DIR=$qdmadir
 fi
 
 if [[ ! -z $static_boost ]]; then
@@ -266,10 +266,11 @@ if [[ -z ${XILINX_VITIS:+x} ]] || [[ ! -d ${XILINX_VITIS} ]]; then
 fi
 
 #If git modules config file exist then try to clone them
-if [[ -z $qdmalib ]]; then
+if [[ -z $qdmadir ]]; then
     GIT_MODULES=$BUILDDIR/../.gitmodules
     if [ -f "$GIT_MODULES" ]; then
         cd $BUILDDIR/../
+        git submodule sync
         git submodule update --init
         cd $BUILDDIR
     fi

--- a/src/runtime_src/core/pcie/driver/linux/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/driver/linux/CMakeLists.txt
@@ -1,11 +1,24 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (C) 2019-2021 Xilinx, Inc. All rights reserved.
+# Copyright (C) 2019-2022 Xilinx, Inc. All rights reserved.
 #
 add_subdirectory(include)
 
 set(XRT_KERNEL_HEADERS
   include/xocl_ioctl.h
 )
+
+set(QDMA_LIB_DESTINATION_DIR
+  ${CMAKE_CURRENT_SOURCE_DIR}/xocl/lib/libqdma/
+)
+
+function(CopyQDMALIB)
+ message(STATUS "Copying QDMA lib file from $ENV{QDMA_LIB_DIR}")
+ file(COPY $ENV{QDMA_LIB_DIR} DESTINATION ${QDMA_LIB_DESTINATION_DIR})
+endfunction()
+
+if(DEFINED ENV{QDMA_LIB_DIR})
+ CopyQDMALIB()
+endif()
 
 install(FILES ${XRT_KERNEL_HEADERS} DESTINATION ${XRT_INSTALL_DIR}/include)
 


### PR DESCRIPTION
Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Support pre downloaded QDMA drivers to build it in XRT. 
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
VITIS-5805
#### How problem was solved, alternative solutions (if any) and why they were rejected
Introduced new build option -qdmalib to provide pre downloaded QDMA driver path to XRT
#### Risks (if any) associated the changes in the commit
NA
#### What has been tested and how, request additional testing if necessary
XRT build with new introduced option
bash-4.2# ./build.sh -qdmalib /scratch/dma_ip_drivers/
#### Documentation impact (if any)
NA