### PR TITLE
CID-240280 overrunning array

### DIFF
--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -273,7 +273,7 @@ acquire_cu_idx(struct kds_cu_mgmt *cu_mgmt, int domain, struct kds_command *xcmd
 	/* After validation */
 	uint8_t valid_cus[MAX_CUS];
 	int num_valid = 0;
-	uint8_t index;
+	int8_t index;
 	u64 usage;
 	u64 min_usage;
 	int cu_set;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Overrunning array issue reported by CID

#### How problem was solved, alternative solutions (if any) and why they were rejected
Because 'index' was uint8_t, if it was assigned as -EAGAIN. The caller will get a result of 245 instead of a negative error code.
Define index as int8_t should fix this issue. 

#### Risks (if any) associated the changes in the commit
If cu_bitmap/scu_bitmap is not corrupted, then index will never be -EAGAIN, which is fine.

#### What has been tested and how, request additional testing if necessary
U50 validate.

#### Documentation impact (if any)
No