### PR TITLE
emulation get_total_devices update

### DIFF
--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/system_swemu.cxx
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/system_swemu.cxx
@@ -54,7 +54,8 @@ std::pair<device::id_type, device::id_type>
 system::
 get_total_devices(bool is_user) const
 {
-  return {0,0};
+  auto nd = xclProbe();
+  return {nd,nd};
 }
 
 std::shared_ptr<xrt_core::device>

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/system_hwemu.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/system_hwemu.cxx
@@ -54,7 +54,8 @@ std::pair<device::id_type, device::id_type>
 system::
 get_total_devices(bool is_user) const
 {
-  return {0,0};
+  auto nd = xclProbe();
+  return {nd,nd};
 }
 
 std::shared_ptr<xrt_core::device>


### PR DESCRIPTION
Updated system_swemu.cxx and system_hwemu.cxx to properly return number of devices.

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Return correct number of devices for emulation flow

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Running hw_emu on vck5000

#### How problem was solved, alternative solutions (if any) and why they were rejected
Return number of devices from xclProbe function

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Tested with vck5000 hw_emu

#### Documentation impact (if any)
None