### PR TITLE
Use explicit types in mailbox protocol

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/include/mailbox_proto.h
+++ b/src/runtime_src/core/pcie/driver/linux/include/mailbox_proto.h
@@ -353,7 +353,7 @@ struct xcl_mailbox_clock_freqscaling {
 struct xcl_mailbox_req {
 	uint64_t flags;
 	int32_t req;
-	uint8_t data[4]; /* variable length of payload, explicitly padded to int32_t */
+	int8_t data[4]; /* variable length of payload, explicitly padded to int32_t */
 };
 
 /**
@@ -373,7 +373,7 @@ struct xcl_sw_chan {
 	uint64_t sz;
 	uint64_t flags;
 	uint64_t id;
-	uint8_t data[4]; /* variable length of payload, explicitly padded to int32_t */
+	int8_t data[4]; /* variable length of payload, explicitly padded to int32_t */
 };
 
 /**

--- a/src/runtime_src/core/pcie/driver/linux/include/mailbox_proto.h
+++ b/src/runtime_src/core/pcie/driver/linux/include/mailbox_proto.h
@@ -136,6 +136,7 @@ struct xcl_board_info {
 	int8_t		exp_bmc_ver[256];
 	uint32_t	mac_contiguous_num;
 	int8_t		mac_addr_first[6];
+	int8_t		padding[2];
 };
 
 /**
@@ -197,6 +198,7 @@ struct xcl_sensor {
 	uint32_t qspi_status;
 	uint32_t vccint_vcu_0v9;
 	uint32_t heartbeat_count;
+	uint32_t padding;
 	uint64_t heartbeat_err_time;
 	uint32_t heartbeat_err_code;
 	uint32_t heartbeat_stall;
@@ -244,6 +246,7 @@ struct xcl_firewall {
 	uint64_t err_detected_level;
 	uint64_t err_detected_time;
 	int8_t err_detected_level_name[50];
+	int8_t padding[14];
 };
 
 
@@ -353,7 +356,7 @@ struct xcl_mailbox_clock_freqscaling {
 struct xcl_mailbox_req {
 	uint64_t flags;
 	int32_t req;
-	int8_t data[4]; /* variable length of payload, explicitly padded to int32_t */
+	int32_t data[1]; /* variable length of payload from now on */
 };
 
 /**
@@ -373,7 +376,7 @@ struct xcl_sw_chan {
 	uint64_t sz;
 	uint64_t flags;
 	uint64_t id;
-	int8_t data[4]; /* variable length of payload, explicitly padded to int32_t */
+	uint64_t data[1]; /* variable length of payload from now on */
 };
 
 /**

--- a/src/runtime_src/core/pcie/driver/linux/include/mailbox_proto.h
+++ b/src/runtime_src/core/pcie/driver/linux/include/mailbox_proto.h
@@ -246,7 +246,7 @@ struct xcl_firewall {
 	uint64_t err_detected_level;
 	uint64_t err_detected_time;
 	int8_t err_detected_level_name[50];
-	int8_t padding[14];
+	int8_t padding[6];
 };
 
 

--- a/src/runtime_src/core/pcie/driver/linux/include/mailbox_proto.h
+++ b/src/runtime_src/core/pcie/driver/linux/include/mailbox_proto.h
@@ -122,20 +122,20 @@ enum xcl_group_kind {
  * struct xcl_board_info - Data structure used to fetch BDINFO group
  */
 struct xcl_board_info {
-	char	 serial_num[256];
-	char	 mac_addr0[32];
-	char	 mac_addr1[32];
-	char	 mac_addr2[32];
-	char	 mac_addr3[32];
-	char	 revision[256];
-	char	 bd_name[256];
-	char	 bmc_ver[256];
-	uint32_t max_power;
-	uint32_t fan_presence;
-	uint32_t config_mode;
-	char exp_bmc_ver[256];
-	uint32_t mac_contiguous_num;
-	char     mac_addr_first[6];
+	int8_t		serial_num[256];
+	int8_t		mac_addr0[32];
+	int8_t		mac_addr1[32];
+	int8_t		mac_addr2[32];
+	int8_t		mac_addr3[32];
+	int8_t		revision[256];
+	int8_t		bd_name[256];
+	int8_t		bmc_ver[256];
+	uint32_t	max_power;
+	uint32_t	fan_presence;
+	uint32_t	config_mode;
+	int8_t		exp_bmc_ver[256];
+	uint32_t	mac_contiguous_num;
+	int8_t		mac_addr_first[6];
 };
 
 /**
@@ -243,7 +243,7 @@ struct xcl_firewall {
 	uint64_t err_detected_status;
 	uint64_t err_detected_level;
 	uint64_t err_detected_time;
-	char err_detected_level_name[50];
+	int8_t err_detected_level_name[50];
 };
 
 
@@ -270,11 +270,11 @@ struct xcl_subdev {
 };
 /**
  * struct mailbox_subdev_peer - MAILBOX_REQ_PEER_DATA payload type
- * @kind: data group
+ * @kind: data group (enum xcl_group_kind)
  * @size: buffer size for receiving response
  */
 struct xcl_mailbox_subdev_peer {
-	enum xcl_group_kind kind;
+	int32_t kind;
 	uint32_t padding;
 	uint64_t size;
 	uint64_t entries;
@@ -310,7 +310,7 @@ struct xcl_mailbox_conn_resp {
 	uint32_t reserved;
 	uint64_t conn_flags;
 	uint64_t chan_switch;
-	char comm_id[XCL_COMM_ID_SIZE];
+	int8_t comm_id[XCL_COMM_ID_SIZE];
 	uint64_t chan_disable;
 };
 
@@ -338,22 +338,22 @@ struct xcl_mailbox_bitstream_kaddr {
  * @target_freqs: array of target clock frequencies (max clocks: 16)
  */
 struct xcl_mailbox_clock_freqscaling {
-	unsigned int region;
-	unsigned short target_freqs[16];
+	uint32_t region;
+	uint16_t target_freqs[16];
 };
 
 #define XCL_MB_REQ_FLAG_RESPONSE	(1 << 0)
 #define XCL_MB_REQ_FLAG_REQUEST		(1 << 1)
 /**
  * struct mailbox_req - mailbox request message header
- * @req: opcode
+ * @req: opcode (enum xcl_mailbox_request)
  * @flags: flags of this message
  * @data: payload of variable length
  */
 struct xcl_mailbox_req {
 	uint64_t flags;
-	enum xcl_mailbox_request req;
-	char data[1]; /* variable length of payload */
+	int32_t req;
+	uint8_t data[4]; /* variable length of payload, explicitly padded to int32_t */
 };
 
 /**
@@ -373,7 +373,7 @@ struct xcl_sw_chan {
 	uint64_t sz;
 	uint64_t flags;
 	uint64_t id;
-	char data[1]; /* variable length of payload */
+	uint8_t data[4]; /* variable length of payload, explicitly padded to int32_t */
 };
 
 /**

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
@@ -999,7 +999,7 @@ void xclmgmt_mailbox_srv(void *arg, void *data, size_t len,
 			break;
 		}
 
-		ret = xclmgmt_read_subdev_req(lro, req->data, &resp, &sz);
+		ret = xclmgmt_read_subdev_req(lro, (char *)req->data, &resp, &sz);
 		if (ret) {
 			/* if can't get data, return 0 as response */
 			ret = 0;
@@ -1102,7 +1102,7 @@ void xclmgmt_mailbox_srv(void *arg, void *data, size_t len,
 			break;
 		}
 
-		ret = xclmgmt_read_subdev_req(lro, req->data, &resp, &sz);
+		ret = xclmgmt_read_subdev_req(lro, (char *)req->data, &resp, &sz);
 		if (ret) {
 			/* if can't get data, return 0 as response */
 			ret = 0;

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/msd.cpp
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/msd.cpp
@@ -289,7 +289,7 @@ int Msd::remoteMsgHandler(const pcieFunc& dev, std::unique_ptr<sw_msg>& orig,
             break;
         }
 
-        int ret = download_xclbin(dev, req->data);
+        int ret = download_xclbin(dev, reinterpret_cast<char *>(req->data));
         dev.log(LOG_INFO, "xclbin download, ret=%d", ret);
         processed = std::make_unique<sw_msg>(&ret, sizeof(ret), orig->id(),
             XCL_MB_REQ_FLAG_RESPONSE);

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/sw_msg.cpp
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/sw_msg.cpp
@@ -72,7 +72,7 @@ char *sw_msg::data()
 char *sw_msg::payloadData()
 {
     xcl_sw_chan *sc = reinterpret_cast<xcl_sw_chan *>(buf.data());
-    return sc->data;
+    return reinterpret_cast<char *>(sc->data);
 }
 
 uint64_t sw_msg::id()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
After mailbox is supported on X3, the two ends of mailbox communication channel may run on different CPU architectures. It is important to use explicit type to avoid any mis-match in mailbox protocol data structures.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
N/A
#### How problem was solved, alternative solutions (if any) and why they were rejected
Use explicit types
#### Risks (if any) associated the changes in the commit
Should not change any data structure in binary
#### What has been tested and how, request additional testing if necessary
Tested on U55n with xbutil validate
#### Documentation impact (if any)
N/A