### PR TITLE
New API xrt::hw_context

### DIFF
--- a/src/runtime_src/core/common/api/CMakeLists.txt
+++ b/src/runtime_src/core/common/api/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(core_common_api_library_objects OBJECT
   xrt_device.cpp
   xrt_enqueue.cpp
   xrt_error.cpp
+  xrt_hw_context.cpp
   xrt_ini.cpp
   xrt_ip.cpp
   xrt_kernel.cpp

--- a/src/runtime_src/core/common/api/hw_context_int.h
+++ b/src/runtime_src/core/common/api/hw_context_int.h
@@ -1,0 +1,22 @@
+// PDX-License-Identifier: Apache-2.0
+// Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+#ifndef XRT_COMMON_API_HW_CONTEXT_INT_H
+#define XRT_COMMON_API_HW_CONTEXT_INT_H
+
+// This file defines implementation extensions to the XRT XCLBIN APIs.
+#include "core/include/experimental/xrt_hw_context.h"
+
+#include <cstdint>
+
+// Provide access to xrt::xclbin data that is not directly exposed
+// to end users via xrt::xclbin.   These functions are used by
+// XRT core implementation.
+namespace xrt_core { namespace hw_context_int {
+
+// get_slot() - Retrieve the slot index associated with the context
+uint32_t
+get_slot(const xrt::hw_context& ctx);
+
+}} // hw_context_int, xrt_core
+
+#endif

--- a/src/runtime_src/core/common/api/hw_context_int.h
+++ b/src/runtime_src/core/common/api/hw_context_int.h
@@ -11,7 +11,7 @@
 // Provide access to xrt::xclbin data that is not directly exposed
 // to end users via xrt::xclbin.   These functions are used by
 // XRT core implementation.
-namespace xrt_core { namespace hw_context_int {
+namespace xrt_core::hw_context_int {
 
 // get_slot() - Retrieve the slot index associated with the context
 uint32_t

--- a/src/runtime_src/core/common/api/hw_context_int.h
+++ b/src/runtime_src/core/common/api/hw_context_int.h
@@ -11,7 +11,7 @@
 // Provide access to xrt::xclbin data that is not directly exposed
 // to end users via xrt::xclbin.   These functions are used by
 // XRT core implementation.
-namespace xrt_core::hw_context_int {
+namespace xrt_core { namespace hw_context_int {
 
 // get_slot() - Retrieve the slot index associated with the context
 uint32_t

--- a/src/runtime_src/core/common/api/xrt_device.cpp
+++ b/src/runtime_src/core/common/api/xrt_device.cpp
@@ -273,6 +273,17 @@ load_xclbin(const xclbin& xclbin)
 
 uuid
 device::
+register_xclbin(const xclbin& xclbin)
+{
+  return xdp::native::profiling_wrapper("xrt::device::register_xclbin",
+  [this, &xclbin]{
+    handle->register_xclbin(xclbin);
+    return xclbin.get_uuid();
+  });
+}
+
+uuid
+device::
 get_xclbin_uuid() const
 {
   return xdp::native::profiling_wrapper("xrt::device::get_xclbin_uuid", [this]{

--- a/src/runtime_src/core/common/api/xrt_hw_context.cpp
+++ b/src/runtime_src/core/common/api/xrt_hw_context.cpp
@@ -49,7 +49,7 @@ class hw_context_impl
         // Without a hw_context, it is an error if multiple slots have
         // loaded same xclbin
         auto slots = m_device->get_slots(uuid);
-        if (!slots.size())
+        if (slots.empty())
           throw std::runtime_error("Unexpected error, xclbin has not been loaded");
         if (slots.size() > 1)
           throw std::runtime_error("Unexpected error, multi-slot xclbin requires hw_context");
@@ -122,7 +122,7 @@ public:
 ////////////////////////////////////////////////////////////////
 // xrt_hw_context implementation of extension APIs not exposed to end-user
 ////////////////////////////////////////////////////////////////
-namespace xrt_core { namespace hw_context_int {
+namespace xrt_core::hw_context_int {
 
 uint32_t
 get_slot(const xrt::hw_context& hwctx)

--- a/src/runtime_src/core/common/api/xrt_hw_context.cpp
+++ b/src/runtime_src/core/common/api/xrt_hw_context.cpp
@@ -122,7 +122,7 @@ public:
 ////////////////////////////////////////////////////////////////
 // xrt_hw_context implementation of extension APIs not exposed to end-user
 ////////////////////////////////////////////////////////////////
-namespace xrt_core::hw_context_int {
+namespace xrt_core { namespace hw_context_int {
 
 uint32_t
 get_slot(const xrt::hw_context& hwctx)

--- a/src/runtime_src/core/common/api/xrt_hw_context.cpp
+++ b/src/runtime_src/core/common/api/xrt_hw_context.cpp
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+
+// This file implements XRT xclbin APIs as declared in
+// core/include/experimental/xrt_queue.h
+#define XRT_API_SOURCE         // exporting xrt_hwcontext.h
+#define XRT_CORE_COMMON_SOURCE // in same dll as core_common
+#include "core/include/experimental/xrt_hw_context.h"
+
+#include "core/common/device.h"
+
+#include <limits>
+
+#ifdef _WIN32
+//# pragma warning( disable : 4244 )
+#endif
+
+namespace xrt {
+
+// class hw_context_impl - insulated implemention of an xrt::hw_context
+//
+class hw_context_impl
+{
+  using qos_type = uint32_t; // TBD
+
+
+  // Managed context handle with special handling for flows
+  // or applications that use load_xclbin (legacy Alveo)
+  struct ctx_handle
+  {
+    using ctx_handle_type = uint32_t;
+    const xrt_core::device* m_device;
+    ctx_handle_type m_hdl;
+    bool m_destroy_context = true;
+
+    ctx_handle(const xrt_core::device* device, const xrt::uuid& uuid, qos_type qos)
+      : m_device(device)
+    {
+      try {
+        // Throws if (1) load_xclbin was called by application, or
+        // or (2) create_hw_context is not supported. (2) => (1) so
+        // in both cases simply lookup the slot into which the xclbin
+        // has been loaded.
+        m_hdl = m_device->create_hw_context(uuid.get(), qos);
+      }
+      catch (const xrt_core::ishim::not_supported_error&) {
+        // xclbin must have been loaded, get the slot id for the xclbin
+        // Without a hw_context, it is an error if multiple slots have
+        // loaded same xclbin
+        auto slots = m_device->get_slots(uuid);
+        if (!slots.size())
+          throw std::runtime_error("Unexpected error, xclbin has not been loaded");
+        if (slots.size() > 1)
+          throw std::runtime_error("Unexpected error, multi-slot xclbin requires hw_context");
+
+        m_hdl = slots.back();
+        m_destroy_context = false;
+      }
+    }
+
+    ~ctx_handle()
+    {
+      if (m_destroy_context)
+        m_device->destroy_hw_context(m_hdl);
+    }
+  };
+
+  qos_type
+  priority_to_qos(xrt::hw_context::priority qos)
+  {
+    return 0; // TBD
+  }
+
+  std::shared_ptr<xrt_core::device> m_core_device;
+  xrt::xclbin m_xclbin;
+  qos_type m_qos;
+  ctx_handle m_ctx_handle;
+
+public:
+  hw_context_impl(std::shared_ptr<xrt_core::device> device, const xrt::uuid& xclbin_id, xrt::hw_context::priority qos)
+    : m_core_device(std::move(device))
+    , m_xclbin(m_core_device->get_xclbin(xclbin_id))
+    , m_qos(priority_to_qos(qos))
+    , m_ctx_handle{m_core_device.get(), xclbin_id, m_qos}
+  {
+  }
+
+  std::shared_ptr<xrt_core::device>
+  get_core_device() const
+  {
+    return m_core_device;
+  }
+
+  xrt::uuid
+  get_uuid() const
+  {
+    return m_xclbin.get_uuid();
+  }
+
+  xrt::xclbin
+  get_xclbin() const
+  {
+    return m_xclbin;
+  }
+
+  qos_type
+  get_qos() const
+  {
+    return m_qos;
+  }
+
+  uint32_t
+  get_slot() const
+  {
+    return m_ctx_handle.m_hdl;
+  }
+};
+
+} // xrt
+
+////////////////////////////////////////////////////////////////
+// xrt_hw_context implementation of extension APIs not exposed to end-user
+////////////////////////////////////////////////////////////////
+namespace xrt_core { namespace hw_context_int {
+
+uint32_t
+get_slot(const xrt::hw_context& hwctx)
+{
+  return hwctx.get_handle()->get_slot();
+}
+
+}} // hw_context_int, xrt_core
+
+////////////////////////////////////////////////////////////////
+// xrt_hwcontext C++ API implmentations (xrt_hw_context.h)
+////////////////////////////////////////////////////////////////
+namespace xrt {
+
+hw_context::
+hw_context(const xrt::device& device, const xrt::uuid& xclbin_id, xrt::hw_context::priority qos)
+  : detail::pimpl<hw_context_impl>(std::make_shared<hw_context_impl>(device.get_handle(), xclbin_id, qos))
+{}
+
+xrt::device
+hw_context::
+get_device() const
+{
+  return xrt::device{get_handle()->get_core_device()};
+}
+
+xrt::uuid
+hw_context::
+get_xclbin_uuid() const
+{
+  return get_handle()->get_uuid();
+}
+
+xrt::xclbin
+hw_context::
+get_xclbin() const
+{
+  return get_handle()->get_xclbin();
+}
+
+} // xrt

--- a/src/runtime_src/core/common/api/xrt_hw_context.cpp
+++ b/src/runtime_src/core/common/api/xrt_hw_context.cpp
@@ -4,6 +4,7 @@
 // This file implements XRT xclbin APIs as declared in
 // core/include/experimental/xrt_queue.h
 #define XRT_API_SOURCE         // exporting xrt_hwcontext.h
+#define XCL_DRIVER_DLL_EXPORT  // exporting xrt_xclbin.h
 #define XRT_CORE_COMMON_SOURCE // in same dll as core_common
 #include "core/include/experimental/xrt_hw_context.h"
 
@@ -66,7 +67,7 @@ class hw_context_impl
   };
 
   qos_type
-  priority_to_qos(xrt::hw_context::priority qos)
+  priority_to_qos(xrt::hw_context::priority /*qos*/)
   {
     return 0; // TBD
   }

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -5,7 +5,9 @@
 // core/include/experimental/xrt_kernel.h
 #define XCL_DRIVER_DLL_EXPORT  // exporting xrt_kernel.h
 #define XRT_CORE_COMMON_SOURCE // in same dll as core_common
-#include "core/include/experimental/xrt_kernel.h"
+#include "core/include/xrt/xrt_kernel.h"
+
+#include "core/include/experimental/xrt_hw_context.h"
 #include "core/include/experimental/xrt_mailbox.h"
 #include "core/include/experimental/xrt_xclbin.h"
 #include "core/include/ert.h"
@@ -18,6 +20,7 @@
 #include "enqueue.h"
 #include "exec.h"
 #include "handle.h"
+#include "hw_context_int.h"
 #include "kernel_int.h"
 #include "native_profile.h"
 #include "xclbin_int.h"
@@ -333,6 +336,12 @@ struct device_type
   get_core_device() const
   {
     return core_device.get();
+  }
+
+  xrt::device
+  get_xrt_device() const
+  {
+    return xrt::device{core_device};
   }
 };
 
@@ -1229,6 +1238,7 @@ private:
   std::string name;                    // kernel name
   std::shared_ptr<device_type> device; // shared ownership
   std::shared_ptr<ctxmgr_type> ctxmgr; // device context mgr ownership
+  xrt::hw_context hwctx;               // context for hw resources if any (can be null)
   xrt::xclbin xclbin;                  // xclbin with this kernel
   xrt::xclbin::kernel xkernel;         // kernel xclbin metadata
   std::vector<argument> args;          // kernel args sorted by argument index
@@ -1245,73 +1255,28 @@ private:
   control_type protocol = control_type::none; // Default opcode
   uint32_t uid;                        // Internal unique id for debug
 
-
-  // Update device slot info and return list of new slots
-  // added compared to old slots
-  std::vector<slot_id>
-  get_new_xclbin_slots(const std::vector<slot_id>& old)
-  {
-    // update xclbin info to reflect changes made by driver
-    // and get new list of slots
-    auto cdevice = device->get_core_device();
-    cdevice->update_xclbin_info();
-    auto slots = cdevice->get_slots(xclbin.get_uuid());
-
-    // compare set difference returning only new slots
-    std::vector<slot_id> diff;
-    std::set_difference(slots.begin(), slots.end(), old.begin(), old.end(),
-                        std::inserter(diff, diff.begin()));
-    return diff;
-  }
-
   // Open context of a specific compute unit.
   //
   // @cu:  compute unit to open
   // @am:  access mode for the CU
   // Return: shared ownership to the context in form of a shared_ptr
   //
-  // This function tries to open the compute unit in all slots that
-  // match xclbin uuid from which this kernel was constructed.  If
-  // context creation fails with EAGAIN then this indicates that the
-  // driver may have re-loaded the xclbin, maybe into a different
-  // slot, and opening the context should be tried again after
-  // refreshing the slots.
+  // This function opens the compute unit the slot associated with
+  // the hardware context from which the kernel was constructed.
   void
   open_cu_context(const xrt::xclbin::ip& cu, ip_context::access_mode am)
   {
+    auto slot = xrt_core::hw_context_int::get_slot(hwctx);
     auto cdevice = device->get_core_device();
-    auto slots = cdevice->get_slots(xclbin.get_uuid());
 
-    while (1) {
-      bool again = false;
-      for (auto slot : slots) {
-        try {
-          // try open the cu context.  this may throw if cu in slot cannot be aquired.
-          auto ctx = ip_context::open(cdevice, xclbin, slot, cu, am); // may throw
+    // try open the cu context.  this may throw if cu in slot cannot be acquired.
+    auto ctx = ip_context::open(cdevice, xclbin, slot, cu, am); // may throw
 
-          // success, record cuidx in kernel cumask
-          auto cuidx = ctx->get_cuidx();
-          ipctxs.push_back(std::move(ctx));
-          cumask.set(cuidx);
-          num_cumasks = std::max<size_t>(num_cumasks, (cuidx / cus_per_word) + 1);
-        }
-        catch (const xrt_core::system_error& ex) {
-          if (ex.get_code() == EAGAIN) {
-            // open context caused re-load of xclbin into a different slot
-            // stop current iteration, re-fresh slots, and try the new ones
-            again = true;
-            break; // stop current iteration, re-fresh, and try new slots
-          }
-        }
-      }
-
-      // open context did not re-load any xclbin
-      if (!again)
-        break;
-
-      // update the slots
-      slots = get_new_xclbin_slots(slots);
-    }
+    // success, record cuidx in kernel cumask
+    auto cuidx = ctx->get_cuidx();
+    ipctxs.push_back(std::move(ctx));
+    cumask.set(cuidx);
+    num_cumasks = std::max<size_t>(num_cumasks, (cuidx / cus_per_word) + 1);
   }
 
   // Compute data for FAST_ADAPTER descriptor use (see ert_fa.h)
@@ -1470,11 +1435,12 @@ public:
   //
   // The ctxmgr is not directly used by kernel_impl, but its
   // construction and shared ownership must be tied to the kernel_impl
-  kernel_impl(std::shared_ptr<device_type> dev, const xrt::uuid& xclbin_id, const std::string& nm, ip_context::access_mode am)
+  kernel_impl(std::shared_ptr<device_type> dev, xrt::hw_context ctx, const std::string& nm, ip_context::access_mode am)
     : name(nm.substr(0,nm.find(":")))                          // filter instance names
     , device(std::move(dev))                                   // share ownership
     , ctxmgr(xrt_core::context_mgr::create(device->core_device.get())) // owership tied to kernel_impl
-    , xclbin(device->core_device->get_xclbin(xclbin_id))       // xclbin with kernel
+    , hwctx(std::move(ctx))                                    // hw context
+    , xclbin(hwctx.get_xclbin())                               // xclbin with kernel
     , xkernel(get_kernel_or_error(xclbin, name))               // kernel meta data managed by xclbin
     , properties(xrt_core::xclbin_int::get_properties(xkernel))// cache kernel properties
     , vctx(ip_context::open_virtual_cu(device->core_device.get(), xclbin))
@@ -2390,7 +2356,7 @@ class mailbox_impl : public run_impl
     if (mbop == mailbox_operation::read) {
         while (m_busy_read) //poll read done bit
             poll(mailbox_operation::read);
-        if (m_aquire_read) //Return if already aquired. 
+        if (m_aquire_read) //Return if already aquired.
             return;
         uint32_t ctrlreg_read = kernel->read_register(mailbox_output_ctrl_reg);
         kernel->write_register(mailbox_output_ctrl_reg, ctrlreg_read & ~mailbox_output_read);//0, Mailbox Aquire/Lock sync HOST -> SW
@@ -2733,7 +2699,15 @@ alloc_kernel(const std::shared_ptr<device_type>& dev,
 	     const std::string& name,
 	     xrt::kernel::cu_access_mode mode)
 {
-  return std::make_shared<xrt::kernel_impl>(dev, xclbin_id, name, mode) ;
+  return std::make_shared<xrt::kernel_impl>(dev, xrt::hw_context{dev->get_xrt_device(), xclbin_id}, name, mode);
+}
+
+static std::shared_ptr<xrt::kernel_impl>
+alloc_kernel_from_ctx(const std::shared_ptr<device_type>& dev,
+                      const xrt::hw_context& hwctx,
+                      const std::string& name)
+{
+  return std::make_shared<xrt::kernel_impl>(dev, hwctx, name, xrt::kernel::cu_access_mode::shared);
 }
 
 static std::shared_ptr<xrt::mailbox_impl>
@@ -2755,7 +2729,7 @@ xrtKernelHandle
 xrtKernelOpen(xrtDeviceHandle dhdl, const xuid_t xclbin_uuid, const char *name, ip_context::access_mode am)
 {
   auto device = get_device(dhdl);
-  auto kernel = std::make_shared<xrt::kernel_impl>(device, xclbin_uuid, name, am);
+  auto kernel = std::make_shared<xrt::kernel_impl>(device, xrt::hw_context{device->get_xrt_device(), xclbin_uuid}, name, am);
   auto handle = kernel.get();
   kernels.add(handle, std::move(kernel));
   return handle;
@@ -3081,13 +3055,18 @@ get_ert_packet() const
 kernel::
 kernel(const xrt::device& xdev, const xrt::uuid& xclbin_id, const std::string& name, cu_access_mode mode)
   : handle(xdp::native::profiling_wrapper("xrt::kernel::kernel",
-	   alloc_kernel, get_device(xdev), xclbin_id, name, mode))
+      alloc_kernel, get_device(xdev), xclbin_id, name, mode))
 {}
 
 kernel::
 kernel(xclDeviceHandle dhdl, const xrt::uuid& xclbin_id, const std::string& name, cu_access_mode mode)
   : handle(xdp::native::profiling_wrapper("xrt::kernel::kernel",
-	   alloc_kernel, get_device(xrt_core::get_userpf_device(dhdl)), xclbin_id, name, mode))
+      alloc_kernel, get_device(xrt_core::get_userpf_device(dhdl)), xclbin_id, name, mode))
+{}
+
+kernel::
+kernel(const xrt::hw_context& ctx, const std::string& name)
+  : handle(alloc_kernel_from_ctx(get_device(ctx.get_device()), ctx, name))
 {}
 
 uint32_t

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -3,6 +3,7 @@
 
 // This file implements XRT kernel APIs as declared in
 // core/include/experimental/xrt_kernel.h
+#define XRT_API_SOURCE  // exporting xrt_kernel.h
 #define XCL_DRIVER_DLL_EXPORT  // exporting xrt_kernel.h
 #define XRT_CORE_COMMON_SOURCE // in same dll as core_common
 #include "core/include/xrt/xrt_kernel.h"

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -1261,7 +1261,7 @@ private:
   // @am:  access mode for the CU
   // Return: shared ownership to the context in form of a shared_ptr
   //
-  // This function opens the compute unit the slot associated with
+  // This function opens the compute unit in the slot associated with
   // the hardware context from which the kernel was constructed.
   void
   open_cu_context(const xrt::xclbin::ip& cu, ip_context::access_mode am)
@@ -1269,7 +1269,7 @@ private:
     auto slot = xrt_core::hw_context_int::get_slot(hwctx);
     auto cdevice = device->get_core_device();
 
-    // try open the cu context.  this may throw if cu in slot cannot be acquired.
+    // try open the cu context.  This may throw if cu in slot cannot be acquired.
     auto ctx = ip_context::open(cdevice, xclbin, slot, cu, am); // may throw
 
     // success, record cuidx in kernel cumask

--- a/src/runtime_src/core/common/device.cpp
+++ b/src/runtime_src/core/common/device.cpp
@@ -84,7 +84,7 @@ get_xclbin_uuid() const
 }
 
 // Registering an xclbin has one entry point (this one) only.
-// Shim level registering is not exposed to end application.
+// Shim level registering is not exposed to end-user application.
 //
 void
 device::
@@ -94,7 +94,7 @@ register_xclbin(const xrt::xclbin& xclbin)
   m_xclbins.insert(xclbin);
 }
 
-// Unforunately there are two independent entry points into loading an
+// Unfortunately there are two independent entry points to load an
 // xclbin.  One is this function via xrt::device::load_xclbin(), the
 // other is xclLoadXclBin(). The two entrypoints converge in
 // register_axlf() upon successful xclbin loading. It is possible for

--- a/src/runtime_src/core/common/device.cpp
+++ b/src/runtime_src/core/common/device.cpp
@@ -1,18 +1,6 @@
-/**
- * Copyright (C) 2019-2022 Xilinx, Inc
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2019-2022 Xilinx, Inc.  All rights reserved.
+// Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
 #define XCL_DRIVER_DLL_EXPORT  // in same dll as exported xrt apis
 #define XRT_CORE_COMMON_SOURCE // in same dll as core_common
 #include "device.h"
@@ -93,6 +81,17 @@ get_xclbin_uuid() const
   // Emulation mode likely, just return m_xclbin_uuid which reflects
   // the uuid of the xclbin loaded by this process.
   return m_xclbin ? m_xclbin.get_uuid() : uuid{};
+}
+
+// Registering an xclbin has one entry point (this one) only.
+// Shim level registering is not exposed to end application.
+//
+void
+device::
+register_xclbin(const xrt::xclbin& xclbin)
+{
+  static_cast<ishim*>(this)->register_xclbin(xclbin);
+  m_xclbins.insert(xclbin);
 }
 
 // Unforunately there are two independent entry points into loading an

--- a/src/runtime_src/core/common/device.h
+++ b/src/runtime_src/core/common/device.h
@@ -244,9 +244,9 @@ public:
 
   // register_xclbin() - Registers an xclbin with the device
   //
-  // This function registers an xclbin without loading it on
-  // to hardware resource.  Once registered, a hardware context
-  // can be created one or more times, which will assign the
+  // This function registers an xclbin without loading it onto
+  // hardware resource.  Once registered, a hardware context
+  // can be created once or more times, which will assign the
   // xclbin to hardware resources.
   XRT_CORE_COMMON_EXPORT
   void

--- a/src/runtime_src/core/common/device.h
+++ b/src/runtime_src/core/common/device.h
@@ -1,19 +1,6 @@
-/*
- * Copyright (C) 2019-2022 Xilinx, Inc
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2019-2022 Xilinx, Inc.  All rights reserved.
+// Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
 #ifndef XRT_CORE_DEVICE_H
 #define XRT_CORE_DEVICE_H
 
@@ -254,6 +241,16 @@ public:
     auto& qr = lookup_query(QueryRequestType::key);
     return qr.put(this, std::forward<Args>(args)...);
   }
+
+  // register_xclbin() - Registers an xclbin with the device
+  //
+  // This function registers an xclbin without loading it on
+  // to hardware resource.  Once registered, a hardware context
+  // can be created one or more times, which will assign the
+  // xclbin to hardware resources.
+  XRT_CORE_COMMON_EXPORT
+  void
+  register_xclbin(const xrt::xclbin& xclbin);
 
   /**
    * load_xclbin() - Load an xclbin object on this device

--- a/src/runtime_src/core/common/ishim.h
+++ b/src/runtime_src/core/common/ishim.h
@@ -147,7 +147,7 @@ struct ishim
   // not_supported_error, if either not implemented or an xclbin
   // was explicitly loaded using load_xclbin
   virtual uint32_t // slotidx
-  create_hw_context(const xuid_t xclbin_uuid, uint32_t qos) const
+  create_hw_context(const xuid_t /*xclbin_uuid*/, uint32_t /*qos*/) const
   { throw not_supported_error{__func__}; }
 
   virtual void

--- a/src/runtime_src/core/common/ishim.h
+++ b/src/runtime_src/core/common/ishim.h
@@ -1,19 +1,6 @@
-/*
- * Copyright (C) 2019-2022 Xilinx, Inc
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2019-2022 Xilinx, Inc.  All rights reserved.
+// Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
 #ifndef core_common_ishim_h
 #define core_common_ishim_h
 
@@ -46,6 +33,15 @@ namespace xrt_core {
  */
 struct ishim
 {
+  //
+  class not_supported_error : public xrt_core::error
+  {
+  public:
+    not_supported_error(const std::string& msg)
+      : xrt_core::error{std::errc::not_supported, msg}
+    {}
+  };
+
   virtual void
   close_device() = 0;
 
@@ -80,7 +76,7 @@ struct ishim
   // This function is only supported on systems with pidfd kernel support
   virtual xclBufferHandle
   import_bo(pid_t, xclBufferExportHandle)
-  { throw xrt_core::error(std::errc::not_supported,"import_bo(pid, hdl)"); }
+  { throw not_supported_error{__func__}; }
 
   virtual void
   copy_bo(xclBufferHandle dst, xclBufferHandle src, size_t size, size_t dst_offset, size_t src_offset) = 0;
@@ -143,33 +139,55 @@ struct ishim
   user_reset(xclResetKind kind) = 0;
 
   ////////////////////////////////////////////////////////////////
+  // Interfaces for hw context handling
+  // Implemented explicitly by concrete shim device class
+  ////////////////////////////////////////////////////////////////
+  // If an xclbin is loaded with load_xclbin, an explicit hw_context
+  // cannot be created for that xclbin.  This function throws
+  // not_supported_error, if either not implemented or an xclbin
+  // was explicitly loaded using load_xclbin
+  virtual uint32_t // slotidx
+  create_hw_context(const xuid_t xclbin_uuid, uint32_t qos) const
+  { throw not_supported_error{__func__}; }
+
+  virtual void
+  destroy_hw_context(uint32_t /*slotidx*/) const
+  { throw not_supported_error{__func__}; }
+
+  // Registers an xclbin, but does not load it.
+  virtual void
+  register_xclbin(const xrt::xclbin&) const
+  { throw not_supported_error{__func__}; }
+  ////////////////////////////////////////////////////////////////
+
+  ////////////////////////////////////////////////////////////////
   // Interfaces for custom IP interrupt handling
   // Implemented explicitly by concrete shim device class
   // 2021.1: Only supported for edge shim
   ////////////////////////////////////////////////////////////////
   virtual xclInterruptNotifyHandle
   open_ip_interrupt_notify(unsigned int)
-  { throw xrt_core::error(std::errc::not_supported,"open_ip_interrupt_notify()"); }
+  { throw not_supported_error{__func__}; }
 
   virtual void
   close_ip_interrupt_notify(xclInterruptNotifyHandle)
-  { throw xrt_core::error(std::errc::not_supported,"close_ip_interrupt_notify()"); }
+  { throw not_supported_error{__func__}; }
 
   virtual void
   enable_ip_interrupt(xclInterruptNotifyHandle)
-  { throw xrt_core::error(std::errc::not_supported,"enable_ip_interrupt()"); }
+  { throw not_supported_error{__func__}; }
 
   virtual void
   disable_ip_interrupt(xclInterruptNotifyHandle)
-  { throw xrt_core::error(std::errc::not_supported,"disable_ip_interrupt()"); }
+  { throw not_supported_error{__func__}; }
 
   virtual void
   wait_ip_interrupt(xclInterruptNotifyHandle)
-  { throw xrt_core::error(std::errc::not_supported,"wait_ip_interrupt()"); }
+  { throw not_supported_error{__func__}; }
 
   virtual std::cv_status
   wait_ip_interrupt(xclInterruptNotifyHandle, int32_t)
-  { throw xrt_core::error(std::errc::not_supported,"wait_ip_interrupt()"); }
+  { throw not_supported_error{__func__}; }
   ////////////////////////////////////////////////////////////////
 
 #ifdef XRT_ENABLE_AIE

--- a/src/runtime_src/core/include/experimental/CMakeLists.txt
+++ b/src/runtime_src/core/include/experimental/CMakeLists.txt
@@ -9,6 +9,7 @@ set(XRT_EXPERIMENTAL_HEADER_SRC
   xrt_device.h
   xrt_enqueue.h
   xrt_error.h
+  xrt_hw_context.h
   xrt_ini.h
   xrt_ip.h
   xrt_kernel.h

--- a/src/runtime_src/core/include/experimental/xrt_hw_context.h
+++ b/src/runtime_src/core/include/experimental/xrt_hw_context.h
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+#ifndef XRT_HW_CONTEXT_H_
+#define XRT_HW_CONTEXT_H_
+
+#include "xrt/detail/config.h"
+#include "xrt/detail/pimpl.h"
+
+#include "xrt/xrt_device.h"
+#include "xrt/xrt_uuid.h"
+
+#ifdef __cplusplus
+
+namespace xrt {
+
+/**
+ * class hw_context -- manage hw resources
+ *
+ * A hardware context associates an xclbin with hardware
+ * resources.  Prior to creating a context, the xclbin
+ * must be registered with the device (`xrt::device::register_xclbin`)
+ *
+ */
+class hw_context_impl;
+class hw_context : public detail::pimpl<hw_context_impl>
+{
+public:
+  enum class priority {};
+public:
+  /**
+   * hw_context() - Constructor for empty context
+   */
+  hw_context() = default;
+
+  /**
+   * hw_context() - Constructor
+   */
+  XRT_API_EXPORT
+  hw_context(const xrt::device& device, const xrt::uuid& xclbin_id, priority qos);
+
+  hw_context(const xrt::device& device, const xrt::uuid& xclbin_id)
+    : hw_context{device, xclbin_id, static_cast<priority>(0)}
+  {}
+
+  XRT_API_EXPORT
+  xrt::device
+  get_device() const;
+
+  XRT_API_EXPORT
+  xrt::uuid
+  get_xclbin_uuid() const;
+
+  XRT_API_EXPORT
+  xrt::xclbin
+  get_xclbin() const;
+};
+
+} // namespace xrt
+
+#else
+# error xrt_hwcontext is only implemented for C++
+#endif // __cplusplus
+
+#endif

--- a/src/runtime_src/core/include/xrt/xrt_device.h
+++ b/src/runtime_src/core/include/xrt/xrt_device.h
@@ -1,20 +1,6 @@
-/*
- * Copyright (C) 2020-2022, Xilinx Inc - All rights reserved
- * Xilinx Runtime (XRT) Experimental APIs
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2020-2022 Xilinx, Inc.  All rights reserved.
+// Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
 #ifndef _XRT_DEVICE_H_
 #define _XRT_DEVICE_H_
 
@@ -281,6 +267,24 @@ public:
     >(get_info(param, xrt::detail::abi{}));
 #endif
   }
+
+  /// @cond
+  /// Experimental 2022.2
+  /**
+   * register_xclbin() - Register an xclbin with the device
+   *
+   * @param xclbin
+   *  xrt::xclbin object
+   * @return
+   *  UUID of argument xclbin
+   *
+   * This function registers an xclbin with the device, but
+   * does not associate the xclbin with hardware resources.
+   */
+  XCL_DRIVER_DLLESPEC
+  uuid
+  register_xclbin(const xrt::xclbin& xclbin);
+  /// @endcond
 
   /**
    * load_xclbin() - Load an xclbin

--- a/src/runtime_src/core/include/xrt/xrt_kernel.h
+++ b/src/runtime_src/core/include/xrt/xrt_kernel.h
@@ -11,6 +11,8 @@
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_uuid.h"
 
+#include "experimental/xrt_hw_context.h"
+
 #ifdef __cplusplus
 # include "experimental/xrt_enqueue.h"
 # include <chrono>
@@ -604,6 +606,13 @@ public:
   kernel(const xrt::device& device, const xrt::uuid& xclbin_id, const std::string& name,
          cu_access_mode mode = cu_access_mode::shared);
 
+
+  /// @cond
+  /// Experimental in 2022.2
+  XCL_DRIVER_DLLESPEC
+  kernel(const xrt::hw_context& ctx, const std::string& name);
+  /// @endcond
+
   /// @cond
   /// Deprecated construtor for exclusive access
   kernel(const xrt::device& device, const xrt::uuid& xclbin_id, const std::string& name, bool ex)
@@ -704,14 +713,14 @@ public:
    * get_name() - Return the name of the kernel
    */
   XCL_DRIVER_DLLESPEC
-  std::string 
+  std::string
   get_name() const;
-  
+
   /**
    * get_xclbin() - Return the xclbin containing the kernel
    */
   XCL_DRIVER_DLLESPEC
-  xrt::xclbin 
+  xrt::xclbin
   get_xclbin() const;
 
 public:

--- a/src/runtime_src/core/pcie/noop/device_noop.h
+++ b/src/runtime_src/core/pcie/noop/device_noop.h
@@ -1,11 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2020-2022 Xilinx, Inc. All rights reserved.
+// Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
 #ifndef PCIE_NOOP_DEVICE_LINUX_H
 #define PCIE_NOOP_DEVICE_LINUX_H
 
 #include "core/common/ishim.h"
 #include "core/common/query_requests.h"
 #include "core/pcie/common/device_pcie.h"
+
+#include "shim.h"
 
 namespace xrt_core { namespace noop {
 
@@ -20,6 +23,24 @@ private:
   // Private look up function for concrete query::request
   virtual const query::request&
   lookup_query(query::key_type query_key) const override;
+
+  uint32_t // slotidx
+  create_hw_context(const xuid_t xclbin_uuid, uint32_t qos) const override
+  {
+    return userpf::create_hw_context(this, xclbin_uuid, qos);
+  }
+
+  void
+  destroy_hw_context(uint32_t slotidx) const override
+  {
+    userpf::destroy_hw_context(this, slotidx);
+  }
+
+  void
+  register_xclbin(const xrt::xclbin& xclbin) const override
+  {
+    userpf::register_xclbin(this, xclbin);
+  }
 };
 
 }} // noop, xrt_core

--- a/src/runtime_src/core/pcie/noop/shim.h
+++ b/src/runtime_src/core/pcie/noop/shim.h
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2021-2022 Xilinx, Inc. All rights reserved.
+// Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
 #ifndef XRT_CORE_PCIE_NOOP_SHIM_H
 #define XRT_CORE_PCIE_NOOP_SHIM_H
 
@@ -15,6 +16,15 @@ kds_cu_info(const xrt_core::device* device);
 
 xrt_core::query::xclbin_slots::result_type
 xclbin_slots(const xrt_core::device* device);
+
+uint32_t // slotidx
+create_hw_context(const xrt_core::device* device, const xuid_t xclbin_uuid, uint32_t qos);
+
+void
+destroy_hw_context(const xrt_core::device* device, uint32_t slotidx);
+
+void
+register_xclbin(const xrt_core::device* device, const xrt::xclbin& xclbn);
 
 } // userpf
 

--- a/src/runtime_src/xocl/core/program.cpp
+++ b/src/runtime_src/xocl/core/program.cpp
@@ -1,19 +1,6 @@
-/**
- * Copyright (C) 2016-2021 Xilinx, Inc
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2016-2022 Xilinx, Inc.  All rights reserved.
+// Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
 #include "program.h"
 #include "device.h"
 #include "kernel.h"
@@ -126,10 +113,12 @@ xrt_core::uuid
 program::
 get_xclbin_uuid(const device* d) const
 {
+  // switch to parent device if necessary
+  d = d->get_root_device();
   auto itr = m_binaries.find(d);
   if (itr == m_binaries.end())
     return {};
-  
+
   auto top = reinterpret_cast<const axlf*>((*itr).second.data());
   return top->m_header.uuid;
 }
@@ -170,7 +159,7 @@ get_num_kernels() const
     return metadata.num_kernels();
   return 0;
 }
-  
+
 std::vector<std::string>
 program::
 get_kernel_names() const

--- a/tests/xrt/multi_xclbin/simple.cpp
+++ b/tests/xrt/multi_xclbin/simple.cpp
@@ -12,13 +12,10 @@ multiple xclbins
 
 #include "experimental/xrt_hw_context.h"
 
-#include <array>
-#include <atomic>
-#include <cstdlib>
-#include <fstream>
+#include <algorithm>
+#include <stdexcept>
 #include <iostream>
-#include <list>
-#include <thread>
+#include <string>
 #include <vector>
 
 #ifdef _WIN32

--- a/tests/xrt/multi_xclbin/simple.cpp
+++ b/tests/xrt/multi_xclbin/simple.cpp
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+/****************************************************************
+This example illustrates the use of xrt::hw_context for working with
+multiple xclbins
+
+% g++ -g -std=c++17 -I$XILINX_XRT/include -L$XILINX_XRT/lib -o simple.exe simple.cpp -lxrt_coreutil -luuid -pthread
+****************************************************************/
+#include "xrt/xrt_bo.h"
+#include "xrt/xrt_device.h"
+#include "xrt/xrt_kernel.h"
+
+#include "experimental/xrt_hw_context.h"
+
+#include <array>
+#include <atomic>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <list>
+#include <thread>
+#include <vector>
+
+#ifdef _WIN32
+# pragma warning ( disable : 4267 )
+#endif
+
+// Kernel specifics
+// void addone (__global ulong8 *a, __global ulong8 * b, unsigned int  elements)
+// addone(a, b, ELEMENTS)
+// The kernel is compiled with 8 CUs same connectivity.
+static constexpr size_t elements = 16;
+static constexpr size_t array_size = 8;
+static constexpr size_t maxcus = 8;
+static constexpr size_t data_size = elements * array_size;
+static size_t compute_units = maxcus;
+
+static void
+usage()
+{
+  std::cout << "usage: %s [options] \n\n";
+  std::cout << "  -k <bitstream>\n";
+  std::cout << "  -d <device_index>\n";
+  std::cout << "";
+  std::cout << "  [--cus <number>]: number of cus to use (default: 8) (max: 8)\n";
+  std::cout << "";
+}
+
+static std::string
+get_kernel_name(size_t cus)
+{
+  std::string k("addone:{");
+  for (int i=1; i<cus; ++i)
+    k.append("addone_").append(std::to_string(i)).append(",");
+  k.append("addone_").append(std::to_string(cus)).append("}");
+  return k;
+}
+
+static int
+run(int argc, char** argv)
+{
+  std::vector<std::string> args(argv+1,argv+argc);
+
+  std::vector<xrt::xclbin> xclbins;
+  unsigned int device_index = 0;
+  size_t cus  = 1;
+
+  std::string cur;
+  for (auto& arg : args) {
+    if (arg == "-h") {
+      usage();
+      return 1;
+    }
+
+    if (arg[0] == '-') {
+      cur = arg;
+      continue;
+    }
+
+    if (cur == "-d")
+      device_index = std::stoi(arg);
+    else if (cur == "-k")
+      xclbins.push_back(xrt::xclbin{arg});
+    else if (cur == "--cus")
+      cus = std::stoi(arg);
+    else
+      throw std::runtime_error("bad argument '" + cur + " " + arg + "'");
+  }
+
+  xrt::device device{device_index};
+
+  // Register all xclbins
+  for (const auto& xclbin : xclbins)
+    device.register_xclbin(xclbin);
+
+  compute_units = cus = std::min(cus, compute_units);
+  std::string kname = get_kernel_name(cus);
+
+  std::vector<xrt::run> runs;
+  for (const auto& xclbin : xclbins) {
+    xrt::hw_context ctx{device, xclbin.get_uuid()};
+    xrt::kernel kernel{ctx, kname};
+    xrt::bo a(device, data_size * sizeof(unsigned long), kernel.group_id(0));
+    xrt::bo b(device, data_size * sizeof(unsigned long), kernel.group_id(1));
+    runs.push_back(kernel(a, b, elements));
+  }
+
+  for (auto& run : runs)
+    run.wait();
+
+  return 0;
+}
+
+int
+main(int argc, char* argv[])
+{
+  try {
+    return run(argc,argv);
+  }
+  catch (const std::exception& ex) {
+    std::cout << "TEST FAILED: " << ex.what() << "\n";
+  }
+  catch (...) {
+    std::cout << "TEST FAILED\n";
+  }
+
+  return 1;
+}


### PR DESCRIPTION
New concept to represent hardware resources (columns, regions, PS
processes) used by an xclbin.  A hardware context is used by an
application to control where execution takes place.  In a multi-xclbin
scenario, the hardware context is specific to one xclbin even if that
xclbin is loaded multiple times.

The feature is optional for legacy applications / platforms.

Constructed from a device and an xclbin uuid that has been registered
with the device (driver)

A context is 1-1 with a slot index. A resource resolver assigns a
hardware context to hardware resources, maybe sharing, or fails.
On success, the driver assigns a unique slot index to the context.

A kernel object is created from a hardware context. CU context
creation no longer needs EAGAIN as opening of CU context always
succeeds if the hardware context was successfully created. The rather
complicated code for EAGAIN per #6421 has been removed in this PR.

A hardware context can be shared between threads. A process
can construct multiple hardware contexts.