### PR TITLE
Profiling bandwidth calculation fixes for AWS in 2021.2 branch

### DIFF
--- a/src/runtime_src/core/common/xrt_profiling.h
+++ b/src/runtime_src/core/common/xrt_profiling.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2019, Xilinx Inc - All rights reserved
+ * Copyright (C) 2019, Xilinx Inc
+ * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
  * Xilinx Runtime (XRT) APIs
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
@@ -37,9 +38,13 @@ XCL_DRIVER_DLLESPEC size_t xclGetDeviceTimestamp(xclDeviceHandle handle);
 
 XCL_DRIVER_DLLESPEC double xclGetDeviceClockFreqMHz(xclDeviceHandle handle);
 
-XCL_DRIVER_DLLESPEC double xclGetReadMaxBandwidthMBps(xclDeviceHandle handle);
+XCL_DRIVER_DLLESPEC double xclGetHostReadMaxBandwidthMBps(xclDeviceHandle handle);
 
-XCL_DRIVER_DLLESPEC double xclGetWriteMaxBandwidthMBps(xclDeviceHandle handle);
+XCL_DRIVER_DLLESPEC double xclGetHostWriteMaxBandwidthMBps(xclDeviceHandle handle);
+
+XCL_DRIVER_DLLESPEC double xclGetKernelReadMaxBandwidthMBps(xclDeviceHandle handle);
+
+XCL_DRIVER_DLLESPEC double xclGetKernelWriteMaxBandwidthMBps(xclDeviceHandle handle);
 
 XCL_DRIVER_DLLESPEC void xclGetDebugIpLayout(xclDeviceHandle hdl, char* buffer, size_t size, size_t* size_ret);
 

--- a/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/halapi.cxx
+++ b/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/halapi.cxx
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2016-2020 Xilinx, Inc
+ * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -313,30 +314,28 @@ size_t xclPerfMonReadTrace(xclDeviceHandle handle, xclPerfMonType type, xclTrace
 
 double xclGetDeviceClockFreqMHz(xclDeviceHandle handle)
 {
-//  xclcpuemhal2::CpuemShim *drv = xclcpuemhal2::CpuemShim::handleCheck(handle);
-//  if (!drv)
-//    return 0.0;
   return 0.0;
 }
 
-
-double xclGetReadMaxBandwidthMBps(xclDeviceHandle handle)
+double xclGetHostReadMaxBandwidthMBps(xclDeviceHandle handle)
 {
-//  xclcpuemhal2::CpuemShim *drv = xclcpuemhal2::CpuemShim::handleCheck(handle);
-//  if (!drv)
-//    return 0.0;
   return 0.0;
 }
 
-
-double xclGetWriteMaxBandwidthMBps(xclDeviceHandle handle)
+double xclGetHostWriteMaxBandwidthMBps(xclDeviceHandle handle)
 {
-//  xclcpuemhal2::CpuemShim *drv = xclcpuemhal2::CpuemShim::handleCheck(handle);
-//  if (!drv)
-//    return 0.0;
   return 0.0;
 }
 
+double xclGetKernelReadMaxBandwidthMBps(xclDeviceHandle handle)
+{
+  return 0.0;
+}
+
+double xclGetKernelWriteMaxBandwidthMBps(xclDeviceHandle handle)
+{
+  return 0.0;
+}
 
 size_t xclGetDeviceTimestamp(xclDeviceHandle handle)
 {

--- a/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/shim.h
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2016-2019 Xilinx, Inc
+ * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -116,8 +117,10 @@ namespace xclcpuemhal2 {
       // Performance monitoring
       // Control
       double xclGetDeviceClockFreqMHz();
-      double xclGetReadMaxBandwidthMBps();
-      double xclGetWriteMaxBandwidthMBps();
+      double xclGetHostReadMaxBandwidthMBps();
+      double xclGetHostWriteMaxBandwidthMBps();
+      double xclGetKernelReadMaxBandwidthMBps();
+      double xclGetKernelWriteMaxBandwidthMBps();
       void xclSetProfilingNumberSlots(xclPerfMonType type, uint32_t numSlots);
       size_t xclPerfMonClockTraining(xclPerfMonType type);
       // Counters

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -731,22 +731,36 @@ xclReadTraceData(void* traceBuf, uint32_t traceBufSz, uint32_t numSamples, uint6
   return 0;
 }
 
-// Get the maximum bandwidth for host reads from the device (in MB/sec)
-// NOTE: for now, set to: (256/8 bytes) * 300 MHz = 9600 MBps
+// For DDR4: Typical Max BW = 19.25 GB/s
 double
 shim::
-xclGetReadMaxBandwidthMBps()
+xclGetHostReadMaxBandwidthMBps()
 {
-  return 9600.0;
+  return 19250.00;
 }
 
-// Get the maximum bandwidth for host writes to the device (in MB/sec)
-// NOTE: for now, set to: (256/8 bytes) * 300 MHz = 9600 MBps
+// For DDR4: Typical Max BW = 19.25 GB/s
 double
 shim::
-xclGetWriteMaxBandwidthMBps()
+xclGetHostWriteMaxBandwidthMBps()
 {
-  return 9600.0;
+  return 19250.00;
+}
+
+// For DDR4: Typical Max BW = 19.25 GB/s
+double
+shim::
+xclGetKernelReadMaxBandwidthMBps()
+{
+  return 19250.00;
+}
+
+// For DDR4: Typical Max BW = 19.25 GB/s
+double
+shim::
+xclGetKernelWriteMaxBandwidthMBps()
+{
+  return 19250.00;
 }
 
 int
@@ -2048,20 +2062,32 @@ xclGetDeviceClockFreqMHz(xclDeviceHandle handle)
 }
 
 double
-xclGetReadMaxBandwidthMBps(xclDeviceHandle handle)
+xclGetHostReadMaxBandwidthMBps(xclDeviceHandle handle)
 {
   ZYNQ::shim *drv = ZYNQ::shim::handleCheck(handle);
-  return drv ? drv->xclGetReadMaxBandwidthMBps() : 0.0;
+  return drv ? drv->xclGetHostReadMaxBandwidthMBps() : 0.0;
 }
-
 
 double
-xclGetWriteMaxBandwidthMBps(xclDeviceHandle handle)
+xclGetHostWriteMaxBandwidthMBps(xclDeviceHandle handle)
 {
   ZYNQ::shim *drv = ZYNQ::shim::handleCheck(handle);
-  return drv ? drv->xclGetWriteMaxBandwidthMBps() : 0.0;
+  return drv ? drv->xclGetHostWriteMaxBandwidthMBps() : 0.0;
 }
 
+double
+xclGetKernelReadMaxBandwidthMBps(xclDeviceHandle handle)
+{
+  ZYNQ::shim *drv = ZYNQ::shim::handleCheck(handle);
+  return drv ? drv->xclGetKernelReadMaxBandwidthMBps() : 0.0;
+}
+
+double
+xclGetKernelWriteMaxBandwidthMBps(xclDeviceHandle handle)
+{
+  ZYNQ::shim *drv = ZYNQ::shim::handleCheck(handle);
+  return drv ? drv->xclGetKernelWriteMaxBandwidthMBps() : 0.0;
+}
 
 int
 xclSKGetCmd(xclDeviceHandle handle, xclSKCmd *cmd)

--- a/src/runtime_src/core/edge/user/shim.h
+++ b/src/runtime_src/core/edge/user/shim.h
@@ -97,8 +97,10 @@ public:
   int xclGetTraceBufferInfo(uint32_t nSamples, uint32_t& traceSamples, uint32_t& traceBufSz);
   int xclReadTraceData(void* traceBuf, uint32_t traceBufSz, uint32_t numSamples, uint64_t ipBaseAddress, uint32_t& wordsPerSample);
 
-  double xclGetReadMaxBandwidthMBps();
-  double xclGetWriteMaxBandwidthMBps();
+  double xclGetHostReadMaxBandwidthMBps();
+  double xclGetHostWriteMaxBandwidthMBps();
+  double xclGetKernelReadMaxBandwidthMBps();
+  double xclGetKernelWriteMaxBandwidthMBps();
 
   // Bitstream/bin download
   int xclLoadXclBin(const xclBin *buffer);

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/halapi.cxx
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/halapi.cxx
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2016-2019 Xilinx, Inc
+ * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -290,27 +291,30 @@ size_t xclPerfMonReadTrace(xclDeviceHandle handle, xclPerfMonType type, xclTrace
 
 double xclGetDeviceClockFreqMHz(xclDeviceHandle handle)
 {
-//  xclcpuemhal2::CpuemShim *drv = xclcpuemhal2::CpuemShim::handleCheck(handle);
-//  if (!drv)
-//    return 0.0;
   return 0.0;
 }
 
 
-double xclGetReadMaxBandwidthMBps(xclDeviceHandle handle)
+double xclGetHostReadMaxBandwidthMBps(xclDeviceHandle handle)
 {
-//  xclcpuemhal2::CpuemShim *drv = xclcpuemhal2::CpuemShim::handleCheck(handle);
-//  if (!drv)
-//    return 0.0;
   return 0.0;
 }
 
 
-double xclGetWriteMaxBandwidthMBps(xclDeviceHandle handle)
+double xclGetHostWriteMaxBandwidthMBps(xclDeviceHandle handle)
 {
-//  xclcpuemhal2::CpuemShim *drv = xclcpuemhal2::CpuemShim::handleCheck(handle);
-//  if (!drv)
-//    return 0.0;
+  return 0.0;
+}
+
+
+double xclGetKernelReadMaxBandwidthMBps(xclDeviceHandle handle)
+{
+  return 0.0;
+}
+
+
+double xclGetKernelWriteMaxBandwidthMBps(xclDeviceHandle handle)
+{
   return 0.0;
 }
 

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.h
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2016-2019 Xilinx, Inc
+ * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -115,8 +116,10 @@ namespace xclcpuemhal2 {
       // Performance monitoring
       // Control
       double xclGetDeviceClockFreqMHz();
-      double xclGetReadMaxBandwidthMBps();
-      double xclGetWriteMaxBandwidthMBps();
+      double xclGetHostReadMaxBandwidthMBps();
+      double xclGetHostWriteMaxBandwidthMBps();
+      double xclGetKernelReadMaxBandwidthMBps();
+      double xclGetKernelWriteMaxBandwidthMBps();
       void xclSetProfilingNumberSlots(xclPerfMonType type, uint32_t numSlots);
       size_t xclPerfMonClockTraining(xclPerfMonType type);
       // Counters

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/halapi.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/halapi.cxx
@@ -443,20 +443,36 @@ double xclGetDeviceClockFreqMHz(xclDeviceHandle handle)
   return drv->xclGetDeviceClockFreqMHz();
 }
 
-double xclGetReadMaxBandwidthMBps(xclDeviceHandle handle)
+double xclGetHostReadMaxBandwidthMBps(xclDeviceHandle handle)
 {
   xclhwemhal2::HwEmShim *drv = xclhwemhal2::HwEmShim::handleCheck(handle);
   if (!drv)
     return -1;
-  return drv->xclGetReadMaxBandwidthMBps();
+  return drv->xclGetHostReadMaxBandwidthMBps();
 }
 
-double xclGetWriteMaxBandwidthMBps(xclDeviceHandle handle)
+double xclGetHostWriteMaxBandwidthMBps(xclDeviceHandle handle)
 {
   xclhwemhal2::HwEmShim *drv = xclhwemhal2::HwEmShim::handleCheck(handle);
   if (!drv)
     return -1;
-  return drv->xclGetWriteMaxBandwidthMBps();
+  return drv->xclGetHostWriteMaxBandwidthMBps();
+}
+
+double xclGetKernelReadMaxBandwidthMBps(xclDeviceHandle handle)
+{
+  xclhwemhal2::HwEmShim *drv = xclhwemhal2::HwEmShim::handleCheck(handle);
+  if (!drv)
+    return -1;
+  return drv->xclGetKernelReadMaxBandwidthMBps();
+}
+
+double xclGetKernelWriteMaxBandwidthMBps(xclDeviceHandle handle)
+{
+  xclhwemhal2::HwEmShim *drv = xclhwemhal2::HwEmShim::handleCheck(handle);
+  if (!drv)
+    return -1;
+  return drv->xclGetKernelWriteMaxBandwidthMBps();
 }
 
 /*

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
@@ -3401,16 +3401,16 @@ double HwEmShim::xclGetHostWriteMaxBandwidthMBps()
   return 15753.85;
 }
 
-// For DDR4: Typical Max BW = 19.25 GB/s
+// For DDR4: Typical Max BW = 16 GB/s
 double HwEmShim::xclGetKernelReadMaxBandwidthMBps()
 {
-  return 19250.00;
+  return 16000.00;
 }
 
-// For DDR4: Typical Max BW = 19.25 GB/s
+// For DDR4: Typical Max BW = 16 GB/s
 double HwEmShim::xclGetKernelWriteMaxBandwidthMBps()
 {
-  return 19250.00;
+  return 16000.00;
 }
 
 uint32_t HwEmShim::getPerfMonNumberSlots(xclPerfMonType type)

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
@@ -3387,18 +3387,30 @@ double HwEmShim::xclGetDeviceClockFreqMHz()
   return clockSpeed;
 }
 
-// Get the maximum bandwidth for host reads from the device (in MB/sec)
-// NOTE: for now, just return 8.0 GBps (the max achievable for PCIe Gen3)
-double HwEmShim::xclGetReadMaxBandwidthMBps()
+// For PCIe gen 3x16 or 4x8:
+// Max BW = 16.0 * (128b/130b encoding) = 15.75385 GB/s
+double HwEmShim::xclGetHostReadMaxBandwidthMBps()
 {
-  return 8000.0;
+  return 15753.85;
 }
 
-// Get the maximum bandwidth for host writes to the device (in MB/sec)
-// NOTE: for now, just return 8.0 GBps (the max achievable for PCIe Gen3)
-double HwEmShim::xclGetWriteMaxBandwidthMBps()
+// For PCIe gen 3x16 or 4x8:
+// Max BW = 16.0 * (128b/130b encoding) = 15.75385 GB/s
+double HwEmShim::xclGetHostWriteMaxBandwidthMBps()
 {
-  return 8000.0;
+  return 15753.85;
+}
+
+// For DDR4: Typical Max BW = 19.25 GB/s
+double HwEmShim::xclGetKernelReadMaxBandwidthMBps()
+{
+  return 19250.00;
+}
+
+// For DDR4: Typical Max BW = 19.25 GB/s
+double HwEmShim::xclGetKernelWriteMaxBandwidthMBps()
+{
+  return 19250.00;
 }
 
 uint32_t HwEmShim::getPerfMonNumberSlots(xclPerfMonType type)

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.h
@@ -169,8 +169,10 @@ using addr_type = uint64_t;
 
       //Performance Monitor APIs
       double xclGetDeviceClockFreqMHz();
-      double xclGetReadMaxBandwidthMBps();
-      double xclGetWriteMaxBandwidthMBps();
+      double xclGetHostReadMaxBandwidthMBps();
+      double xclGetHostWriteMaxBandwidthMBps();
+      double xclGetKernelReadMaxBandwidthMBps();
+      double xclGetKernelWriteMaxBandwidthMBps();
       size_t xclGetDeviceTimestamp();
       void xclReadBusStatus(xclPerfMonType type);
       void xclGetDebugMessages(bool force = false);

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -2172,17 +2172,30 @@ double shim::xclGetDeviceClockFreqMHz()
   return ((double)clockFreq);
 }
 
-// Get the maximum bandwidth for host reads from the device (in MB/sec)
-// NOTE: for now, set to: (256/8 bytes) * 300 MHz = 9600 MBps
-double shim::xclGetReadMaxBandwidthMBps()
+// For PCIe gen 3x16 or 4x8:
+// Max BW = 16.0 * (128b/130b encoding) = 15.75385 GB/s
+double shim::xclGetHostReadMaxBandwidthMBps()
 {
-  return 9600.0;
+  return 15753.85;
 }
 
-// Get the maximum bandwidth for host writes to the device (in MB/sec)
-// NOTE: for now, set to: (256/8 bytes) * 300 MHz = 9600 MBps
-double shim::xclGetWriteMaxBandwidthMBps() {
-  return 9600.0;
+// For PCIe gen 3x16 or 4x8:
+// Max BW = 16.0 * (128b/130b encoding) = 15.75385 GB/s
+double shim::xclGetHostWriteMaxBandwidthMBps()
+{
+  return 15753.85;
+}
+
+// For DDR4: Typical Max BW = 19.25 GB/s
+double shim::xclGetKernelReadMaxBandwidthMBps()
+{
+  return 19250.00;
+}
+
+// For DDR4: Typical Max BW = 19.25 GB/s
+double shim::xclGetKernelWriteMaxBandwidthMBps()
+{
+  return 19250.00;
 }
 
 int shim::xclGetSysfsPath(const char* subdev, const char* entry, char* sysfsPath, size_t size)
@@ -2924,17 +2937,30 @@ double xclGetDeviceClockFreqMHz(xclDeviceHandle handle)
   return drv ? drv->xclGetDeviceClockFreqMHz() : 0.0;
 }
 
-double xclGetReadMaxBandwidthMBps(xclDeviceHandle handle)
+double xclGetHostReadMaxBandwidthMBps(xclDeviceHandle handle)
 {
   xocl::shim *drv = xocl::shim::handleCheck(handle);
-  return drv ? drv->xclGetReadMaxBandwidthMBps() : 0.0;
+  return drv ? drv->xclGetHostReadMaxBandwidthMBps() : 0.0;
 }
 
 
-double xclGetWriteMaxBandwidthMBps(xclDeviceHandle handle)
+double xclGetHostWriteMaxBandwidthMBps(xclDeviceHandle handle)
 {
   xocl::shim *drv = xocl::shim::handleCheck(handle);
-  return drv ? drv->xclGetWriteMaxBandwidthMBps() : 0.0;
+  return drv ? drv->xclGetHostWriteMaxBandwidthMBps() : 0.0;
+}
+
+double xclGetKernelReadMaxBandwidthMBps(xclDeviceHandle handle)
+{
+  xocl::shim *drv = xocl::shim::handleCheck(handle);
+  return drv ? drv->xclGetHostReadMaxBandwidthMBps() : 0.0;
+}
+
+
+double xclGetKernelWriteMaxBandwidthMBps(xclDeviceHandle handle)
+{
+  xocl::shim *drv = xocl::shim::handleCheck(handle);
+  return drv ? drv->xclGetHostWriteMaxBandwidthMBps() : 0.0;
 }
 
 int xclGetSysfsPath(xclDeviceHandle handle, const char* subdev,

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -2186,16 +2186,16 @@ double shim::xclGetHostWriteMaxBandwidthMBps()
   return 15753.85;
 }
 
-// For DDR4: Typical Max BW = 19.25 GB/s
+// For DDR4: Typical Max BW = 16 GB/s
 double shim::xclGetKernelReadMaxBandwidthMBps()
 {
-  return 19250.00;
+  return 16000.00;
 }
 
-// For DDR4: Typical Max BW = 19.25 GB/s
+// For DDR4: Typical Max BW = 16 GB/s
 double shim::xclGetKernelWriteMaxBandwidthMBps()
 {
-  return 19250.00;
+  return 16000.00;
 }
 
 int shim::xclGetSysfsPath(const char* subdev, const char* entry, char* sysfsPath, size_t size)

--- a/src/runtime_src/core/pcie/linux/shim.h
+++ b/src/runtime_src/core/pcie/linux/shim.h
@@ -107,8 +107,10 @@ public:
     int xclGetSectionInfo(void *section_info, size_t *section_size, enum axlf_section_kind, int index);
 
     double xclGetDeviceClockFreqMHz();
-    double xclGetReadMaxBandwidthMBps();
-    double xclGetWriteMaxBandwidthMBps();
+    double xclGetHostReadMaxBandwidthMBps();
+    double xclGetHostWriteMaxBandwidthMBps();
+    double xclGetKernelReadMaxBandwidthMBps();
+    double xclGetKernelWriteMaxBandwidthMBps();
     //debug related
     uint32_t getCheckerNumberSlots(int type);
     uint32_t getIPCountAddrNames(int type, uint64_t *baseAddress, std::string * portNames,

--- a/src/runtime_src/core/pcie/windows/perf.cpp
+++ b/src/runtime_src/core/pcie/windows/perf.cpp
@@ -45,14 +45,30 @@ xclGetDeviceTimestamp(xclDeviceHandle handle)
   return 0;
 }
 
-double xclGetReadMaxBandwidthMBps(xclDeviceHandle handle)
+// For PCIe gen 3x16 or 4x8:
+// Max BW = 16.0 * (128b/130b encoding) = 15.75385 GB/s
+double xclGetHostReadMaxBandwidthMBps(xclDeviceHandle handle)
 {
-  return 9600.0;
+  return 15753.85;
 }
 
-double xclGetWriteMaxBandwidthMBps(xclDeviceHandle handle)
+// For PCIe gen 3x16 or 4x8:
+// Max BW = 16.0 * (128b/130b encoding) = 15.75385 GB/s
+double xclGetHostWriteMaxBandwidthMBps(xclDeviceHandle handle)
 {
-  return 9600.0;
+  return 15753.85;
+}
+
+// For DDR4: Typical Max BW = 19.25 GB/s
+double xclGetKernelReadMaxBandwidthMBps(xclDeviceHandle handle)
+{
+  return 19250.00;
+}
+
+// For DDR4: Typical Max BW = 19.25 GB/s
+double xclGetKernelWriteMaxBandwidthMBps(xclDeviceHandle handle)
+{
+  return 19250.00;
 }
 
 #if 0

--- a/src/runtime_src/core/pcie/windows/perf.cpp
+++ b/src/runtime_src/core/pcie/windows/perf.cpp
@@ -59,16 +59,16 @@ double xclGetHostWriteMaxBandwidthMBps(xclDeviceHandle handle)
   return 15753.85;
 }
 
-// For DDR4: Typical Max BW = 19.25 GB/s
+// For DDR4: Typical Max BW = 16 GB/s
 double xclGetKernelReadMaxBandwidthMBps(xclDeviceHandle handle)
 {
-  return 19250.00;
+  return 16000.00;
 }
 
-// For DDR4: Typical Max BW = 19.25 GB/s
+// For DDR4: Typical Max BW = 16 GB/s
 double xclGetKernelWriteMaxBandwidthMBps(xclDeviceHandle handle)
 {
-  return 19250.00;
+  return 16000.00;
 }
 
 #if 0

--- a/src/runtime_src/xdp/profile/database/static_info_database.h
+++ b/src/runtime_src/xdp/profile/database/static_info_database.h
@@ -277,8 +277,10 @@ class aie_cfg_tile
 
   struct XclbinInfo {
     // Choose reasonable defaults
-    double maxReadBW = 0.0 ;
-    double maxWriteBW = 0.0 ;
+    double hostMaxReadBW = 0.0;
+    double hostMaxWriteBW = 0.0;
+    double kernelMaxReadBW = 0.0;
+    double kernelMaxWriteBW = 0.0;
     double clockRateMHz = 300 ;
     bool usesTs2mm = false ;
     bool hasFloatingAIMwithTrace = false;
@@ -816,36 +818,53 @@ class aie_cfg_tile
       return deviceInfo[deviceId]->kdmaCount; 
     }
 
-    void setMaxReadBW(uint64_t deviceId, double bw)
+    void setHostMaxReadBW(uint64_t deviceId, double bw)
     {
-      if (deviceInfo.find(deviceId) == deviceInfo.end()) return ;
+      if (deviceInfo.find(deviceId) == deviceInfo.end()) return;
       if (deviceInfo[deviceId]->loadedXclbins.size() <= 0) return ;
-      deviceInfo[deviceId]->loadedXclbins.back()->maxReadBW = bw ;
-      //deviceInfo[deviceId]->maxReadBW = bw ;
+      deviceInfo[deviceId]->loadedXclbins.back()->hostMaxReadBW = bw ;
     }
-
-    double getMaxReadBW(uint64_t deviceId)
+    double getHostMaxReadBW(uint64_t deviceId)
     {
       if (deviceInfo.find(deviceId) == deviceInfo.end()) return 0 ;
       if (deviceInfo[deviceId]->loadedXclbins.size() <= 0) return 0 ;
-      return deviceInfo[deviceId]->loadedXclbins.back()->maxReadBW ;
-      //return deviceInfo[deviceId]->maxReadBW ;
+      return deviceInfo[deviceId]->loadedXclbins.back()->hostMaxReadBW ;
     }
-
-    void setMaxWriteBW(uint64_t deviceId, double bw)
+    void setHostMaxWriteBW(uint64_t deviceId, double bw)
     {
-      if (deviceInfo.find(deviceId) == deviceInfo.end()) return ;
+      if (deviceInfo.find(deviceId) == deviceInfo.end()) return;
       if (deviceInfo[deviceId]->loadedXclbins.size() <= 0) return ;
-      deviceInfo[deviceId]->loadedXclbins.back()->maxWriteBW = bw ;
-      //deviceInfo[deviceId]->maxWriteBW = bw ;
+      deviceInfo[deviceId]->loadedXclbins.back()->hostMaxWriteBW = bw ;
     }
-
-    double getMaxWriteBW(uint64_t deviceId)
+    double getHostMaxWriteBW(uint64_t deviceId)
     {
       if (deviceInfo.find(deviceId) == deviceInfo.end()) return 0 ;
       if (deviceInfo[deviceId]->loadedXclbins.size() <= 0) return 0 ;
-      return deviceInfo[deviceId]->loadedXclbins.back()->maxWriteBW ;
-      //return deviceInfo[deviceId]->maxWriteBW ;
+      return deviceInfo[deviceId]->loadedXclbins.back()->hostMaxWriteBW ;
+    }
+    void setKernelMaxReadBW(uint64_t deviceId, double bw)
+    {
+      if (deviceInfo.find(deviceId) == deviceInfo.end()) return;
+      if (deviceInfo[deviceId]->loadedXclbins.size() <= 0) return ;
+      deviceInfo[deviceId]->loadedXclbins.back()->kernelMaxReadBW = bw ;
+    }
+    double getKernelMaxReadBW(uint64_t deviceId)
+    {
+      if (deviceInfo.find(deviceId) == deviceInfo.end()) return 0 ;
+      if (deviceInfo[deviceId]->loadedXclbins.size() <= 0) return 0 ;
+      return deviceInfo[deviceId]->loadedXclbins.back()->kernelMaxReadBW ;
+    }
+    void setKernelMaxWriteBW(uint64_t deviceId, double bw)
+    {
+      if (deviceInfo.find(deviceId) == deviceInfo.end()) return;
+      if (deviceInfo[deviceId]->loadedXclbins.size() <= 0) return ;
+      deviceInfo[deviceId]->loadedXclbins.back()->kernelMaxWriteBW = bw ;
+    }
+    double getKernelMaxWriteBW(uint64_t deviceId)
+    {
+      if (deviceInfo.find(deviceId) == deviceInfo.end()) return 0 ;
+      if (deviceInfo[deviceId]->loadedXclbins.size() <= 0) return 0 ;
+      return deviceInfo[deviceId]->loadedXclbins.back()->kernelMaxWriteBW ;
     }
 
     std::string getXclbinName(uint64_t deviceId) { 

--- a/src/runtime_src/xdp/profile/device/device_intf.cpp
+++ b/src/runtime_src/xdp/profile/device/device_intf.cpp
@@ -989,14 +989,23 @@ DeviceIntf::~DeviceIntf()
     return mAieTraceDmaList[index]->getMemIndex();
   }
 
-  void DeviceIntf::setMaxBwRead()
+  void DeviceIntf::setHostMaxBwRead()
   {
-    mMaxReadBW = mDevice->getMaxBwRead();
+    mHostMaxReadBW = mDevice->getHostMaxBwRead();
+  }
+  void DeviceIntf::setHostMaxBwWrite()
+  {
+    mHostMaxWriteBW = mDevice->getHostMaxBwWrite();
+  }
+  void DeviceIntf::setKernelMaxBwRead()
+  {
+    mKernelMaxReadBW = mDevice->getKernelMaxBwRead();
+  }
+  void DeviceIntf::setKernelMaxBwWrite()
+  {
+    mKernelMaxWriteBW = mDevice->getKernelMaxBwWrite();
   }
 
-  void DeviceIntf::setMaxBwWrite()
-  {
-    mMaxWriteBW = mDevice->getMaxBwWrite();
-  }
+
 
 } // namespace xdp

--- a/src/runtime_src/xdp/profile/device/device_intf.h
+++ b/src/runtime_src/xdp/profile/device/device_intf.h
@@ -210,8 +210,8 @@ class DeviceIntf {
      */
     double mHostMaxReadBW  = 15753.85;
     double mHostMaxWriteBW = 15753.85;
-    double mKernelMaxReadBW  = 19250.00;
-    double mKernelMaxWriteBW = 19250.00;
+    double mKernelMaxReadBW  = 16000.00;
+    double mKernelMaxWriteBW = 16000.00;
 
 }; /* DeviceIntf */
 

--- a/src/runtime_src/xdp/profile/device/device_intf.h
+++ b/src/runtime_src/xdp/profile/device/device_intf.h
@@ -160,12 +160,18 @@ class DeviceIntf {
     XDP_EXPORT
     uint8_t  getAIETs2mmMemIndex(uint64_t index);
     
-    double getMaxBwRead() const {return mMaxReadBW;}
-    double getMaxBwWrite() const {return mMaxWriteBW;}
+    double getHostMaxBwRead() const {return mHostMaxReadBW;}
+    double getHostMaxBwWrite() const {return mHostMaxWriteBW;}
+    double getKernelMaxBwRead() const {return mKernelMaxReadBW;}
+    double getKernelMaxBwWrite() const {return mKernelMaxWriteBW;}
     XDP_EXPORT
-    void setMaxBwRead();
+    void setHostMaxBwRead();
     XDP_EXPORT
-    void setMaxBwWrite();
+    void setHostMaxBwWrite();
+    XDP_EXPORT
+    void setKernelMaxBwRead();
+    XDP_EXPORT
+    void setKernelMaxBwWrite();
 
     inline xdp::Device* getAbstractDevice() {return mDevice;}
 
@@ -195,16 +201,17 @@ class DeviceIntf {
     std::vector<TraceS2MM*> mAieTraceDmaList;
 
     /*
-     * Set bandwidth number to a reasonable default
+     * Set max bandwidths to reasonable defaults
      * For PCIE Device:
-     *   bw_per_lane = 985 MB/s (Wikipedia on PCIE 3.0)
-     *   num_lanes = 16/8/4 depending on host system
-     *   total bw = bw_per_lane * num_lanes
+     * configuration: gdn 3x16, gen 4x8
+     * encoding 128b/130b
      * For Edge Device:
-     *  total bw = DDR4 memory bandwidth
+     *  total BW: DDR4 memory bandwidth
      */
-    double mMaxReadBW  = 9600.0;
-    double mMaxWriteBW = 9600.0;
+    double mHostMaxReadBW  = 15753.85;
+    double mHostMaxWriteBW = 15753.85;
+    double mKernelMaxReadBW  = 19250.00;
+    double mKernelMaxWriteBW = 19250.00;
 
 }; /* DeviceIntf */
 

--- a/src/runtime_src/xdp/profile/device/hal_device/xdp_hal_device.cpp
+++ b/src/runtime_src/xdp/profile/device/hal_device/xdp_hal_device.cpp
@@ -188,14 +188,24 @@ uint64_t HalDevice::getDeviceAddr(size_t id)
   return xrtBOAddress(xrtBufHandles[boIndex]);
 }
 
-double HalDevice::getMaxBwRead()
+double HalDevice::getHostMaxBwRead()
 {
-  return xclGetReadMaxBandwidthMBps(mHalDevice);
+  return xclGetHostReadMaxBandwidthMBps(mHalDevice);
 }
 
-double HalDevice::getMaxBwWrite()
+double HalDevice::getHostMaxBwWrite()
 {
-   return xclGetWriteMaxBandwidthMBps(mHalDevice);
+   return xclGetHostWriteMaxBandwidthMBps(mHalDevice);
+}
+
+double HalDevice::getKernelMaxBwRead()
+{
+  return xclGetKernelReadMaxBandwidthMBps(mHalDevice);
+}
+
+double HalDevice::getKernelMaxBwWrite()
+{
+   return xclGetKernelWriteMaxBandwidthMBps(mHalDevice);
 }
 
 std::string HalDevice::getSubDevicePath(std::string& subdev, uint32_t index)

--- a/src/runtime_src/xdp/profile/device/hal_device/xdp_hal_device.h
+++ b/src/runtime_src/xdp/profile/device/hal_device/xdp_hal_device.h
@@ -68,8 +68,10 @@ public:
   virtual uint64_t getDeviceAddr(size_t xdpBoHandle);
   virtual void* getRawDevice() { return mHalDevice ; }
 
-  virtual double getMaxBwRead();
-  virtual double getMaxBwWrite();
+  virtual double getHostMaxBwRead();
+  virtual double getHostMaxBwWrite();
+  virtual double getKernelMaxBwRead();
+  virtual double getKernelMaxBwWrite();
 
   virtual std::string getSubDevicePath(std::string& subdev, uint32_t index);
 };

--- a/src/runtime_src/xdp/profile/device/xdp_base_device.h
+++ b/src/runtime_src/xdp/profile/device/xdp_base_device.h
@@ -58,8 +58,10 @@ public:
   virtual int getTraceBufferInfo(uint32_t nSamples, uint32_t& traceSamples, uint32_t& traceBufSz) = 0;
   virtual int readTraceData(void* traceBuf, uint32_t traceBufSz, uint32_t numSamples, uint64_t ipBaseAddress, uint32_t& wordsPerSample) = 0;
 
-  virtual double getMaxBwRead() = 0;
-  virtual double getMaxBwWrite() = 0;
+  virtual double getHostMaxBwRead() = 0;
+  virtual double getHostMaxBwWrite() = 0;
+  virtual double getKernelMaxBwRead() = 0;
+  virtual double getKernelMaxBwWrite() = 0;
 
   virtual void* getRawDevice() = 0 ;
 

--- a/src/runtime_src/xdp/profile/device/xrt_device/xdp_xrt_device.cpp
+++ b/src/runtime_src/xdp/profile/device/xrt_device/xdp_xrt_device.cpp
@@ -140,14 +140,24 @@ uint64_t XrtDevice::getDeviceAddr(size_t xdpBoHandle)
   return mXrtDevice->getDeviceAddr(m_bos[idx]);
 }
 
-double XrtDevice::getMaxBwRead()
+double XrtDevice::getHostMaxBwRead()
 {
-  return mXrtDevice->getDeviceMaxRead().get();
+  return mXrtDevice->getHostMaxRead().get();
 }
 
-double XrtDevice::getMaxBwWrite()
+double XrtDevice::getHostMaxBwWrite()
 {
-  return mXrtDevice->getDeviceMaxWrite().get();
+  return mXrtDevice->getHostMaxWrite().get();
+}
+
+double XrtDevice::getKernelMaxBwRead()
+{
+  return mXrtDevice->getKernelMaxRead().get();
+}
+
+double XrtDevice::getKernelMaxBwWrite()
+{
+  return mXrtDevice->getKernelMaxWrite().get();
 }
 
 std::string XrtDevice::getSubDevicePath(std::string& subdev, uint32_t index)

--- a/src/runtime_src/xdp/profile/device/xrt_device/xdp_xrt_device.h
+++ b/src/runtime_src/xdp/profile/device/xrt_device/xdp_xrt_device.h
@@ -61,8 +61,10 @@ public:
   virtual uint64_t getDeviceAddr(size_t xdpBoHandle);
   virtual void* getRawDevice() { return mXrtDevice ; } 
 
-  virtual double getMaxBwRead();
-  virtual double getMaxBwWrite();
+  virtual double getHostMaxBwRead();
+  virtual double getHostMaxBwWrite();
+  virtual double getKernelMaxBwRead();
+  virtual double getKernelMaxBwWrite();
 
   virtual std::string getSubDevicePath(std::string& subdev, uint32_t index);
 };

--- a/src/runtime_src/xdp/profile/plugin/device_offload/hal/hal_device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/hal/hal_device_offload_plugin.cpp
@@ -236,8 +236,10 @@ namespace xdp {
 
     // Once the device has been set up, add additional information to 
     //  the static database
-    (db->getStaticInfo()).setMaxReadBW(deviceId, devInterface->getMaxBwRead()) ;
-    (db->getStaticInfo()).setMaxWriteBW(deviceId, devInterface->getMaxBwWrite());
+    (db->getStaticInfo()).setHostMaxReadBW(deviceId, devInterface->getHostMaxBwRead()) ;
+    (db->getStaticInfo()).setHostMaxWriteBW(deviceId, devInterface->getHostMaxBwWrite());
+    (db->getStaticInfo()).setKernelMaxReadBW(deviceId, devInterface->getKernelMaxBwRead()) ;
+    (db->getStaticInfo()).setKernelMaxWriteBW(deviceId, devInterface->getKernelMaxBwWrite());
   }
   
 } // end namespace xdp

--- a/src/runtime_src/xdp/profile/plugin/device_offload/opencl/opencl_device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/opencl/opencl_device_offload_plugin.cpp
@@ -324,8 +324,10 @@ namespace xdp {
 
     // Once the device has been set up, add additional information to 
     //  the static database specific to OpenCL runs
-    (db->getStaticInfo()).setMaxReadBW(deviceId, devInterface->getMaxBwRead()) ;
-    (db->getStaticInfo()).setMaxWriteBW(deviceId, devInterface->getMaxBwWrite());
+    (db->getStaticInfo()).setHostMaxReadBW(deviceId, devInterface->getHostMaxBwRead()) ;
+    (db->getStaticInfo()).setHostMaxWriteBW(deviceId, devInterface->getHostMaxBwWrite());
+    (db->getStaticInfo()).setKernelMaxReadBW(deviceId, devInterface->getKernelMaxBwRead()) ;
+    (db->getStaticInfo()).setKernelMaxWriteBW(deviceId, devInterface->getKernelMaxBwWrite());
     updateOpenCLInfo(deviceId) ;
     deviceIdsToBeFlushed.emplace(deviceId) ;
   }

--- a/src/runtime_src/xdp/profile/writer/opencl/opencl_summary_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/opencl/opencl_summary_writer.cpp
@@ -731,7 +731,7 @@ namespace xdp {
         double transferRate  = totalSizeInMB / totalTimeInS; 
 
 	double maxReadBW =
-	  (db->getStaticInfo()).getMaxReadBW(read.first.second) ;
+	  (db->getStaticInfo()).getHostMaxReadBW(read.first.second) ;
 	double aveBWUtil = (100.0 * transferRate) / maxReadBW ;
 
 	fout << contextName << ":" << numDevices << ","
@@ -769,7 +769,7 @@ namespace xdp {
         double transferRate  = totalSizeInMB / totalTimeInS; 
 
 	double maxWriteBW =
-	  (db->getStaticInfo()).getMaxWriteBW(write.first.second);
+	  (db->getStaticInfo()).getHostMaxWriteBW(write.first.second);
 	double aveBWUtil = (100.0 * transferRate) / maxWriteBW ;
 
 	fout << contextName << ":" << numDevices << "," 
@@ -856,7 +856,7 @@ namespace xdp {
 	    double transferRate = (totalWriteTime == 0.0) ? 0 :
 	      (double)(values.WriteBytes[monitorId]) / (1000.0 * totalWriteTime);
 	    double aveBW =
-	      (100.0 * transferRate) / xclbin->maxWriteBW ;
+	      (100.0 * transferRate) / xclbin->kernelMaxWriteBW ;
 	    if (aveBW > 100.0) aveBW = 100.0 ;
 
 	    fout << device->getUniqueDeviceName() << ","
@@ -876,7 +876,7 @@ namespace xdp {
 	      double transferRate = (totalReadTime == 0.0) ? 0 :
 		(double)(values.ReadBytes[monitorId]) / (1000.0 * totalReadTime);
 	      double aveBW =
-		(100.0 * transferRate) / xclbin->maxReadBW ;
+		(100.0 * transferRate) / xclbin->kernelMaxReadBW ;
 	      if (aveBW > 100.0) aveBW = 100.0 ;
 
 	      fout << device->getUniqueDeviceName() << ","

--- a/src/runtime_src/xdp/profile/writer/opencl/opencl_summary_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/opencl/opencl_summary_writer.cpp
@@ -1521,7 +1521,7 @@ namespace xdp {
 	 ++iter)
     {
       double durationMS = (double)((*iter).duration) / 1.0e6 ;
-      double rate = ((double)((*iter).size) / 1000.0) * durationMS ;
+      double rate = ((double)((*iter).size) / 1000.0) / durationMS ;
 
       fout << (*iter).address << ","
 	   << (*iter).contextId << ","
@@ -1558,7 +1558,7 @@ namespace xdp {
 	 ++iter)
     {
       double durationMS = (double)((*iter).duration) / 1.0e6 ;
-      double rate = ((double)((*iter).size) / 1000.0) * durationMS ;
+      double rate = ((double)((*iter).size) / 1000.0) / durationMS ;
 
       fout << (*iter).address << "," 
 	   << (*iter).contextId << ","

--- a/src/runtime_src/xdp/profile/writer/opencl/opencl_summary_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/opencl/opencl_summary_writer.cpp
@@ -733,6 +733,7 @@ namespace xdp {
 	double maxReadBW =
 	  (db->getStaticInfo()).getHostMaxReadBW(read.first.second) ;
 	double aveBWUtil = (100.0 * transferRate) / maxReadBW ;
+        if (aveBWUtil > 100.0) aveBWUtil = 100.0 ;
 
 	fout << contextName << ":" << numDevices << ","
 	     << "READ" << ","
@@ -771,6 +772,7 @@ namespace xdp {
 	double maxWriteBW =
 	  (db->getStaticInfo()).getHostMaxWriteBW(write.first.second);
 	double aveBWUtil = (100.0 * transferRate) / maxWriteBW ;
+        if (aveBWUtil > 100.0) aveBWUtil = 100.0 ;
 
 	fout << contextName << ":" << numDevices << "," 
 	     << "WRITE" << ","

--- a/src/runtime_src/xdp/profile/writer/vp_base/summary_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/summary_writer.cpp
@@ -569,7 +569,7 @@ namespace xdp {
 	 iter != (db->getStats()).getTopHostWrites().end() ;
 	 ++iter) {
       double durationMS = (double)((*iter).duration) / one_million ;
-      double rate = ((double)((*iter).size) / one_thousand) * durationMS ;
+      double rate = ((double)((*iter).size) / one_thousand) / durationMS ;
 
       fout << (*iter).address << ","
 	   << (*iter).contextId << ","
@@ -603,7 +603,7 @@ namespace xdp {
 	 iter != (db->getStats()).getTopHostReads().end() ;
 	 ++iter) {
       double durationMS = (double)((*iter).duration) / one_million ;
-      double rate = ((double)((*iter).size) / one_thousand) * durationMS ;
+      double rate = ((double)((*iter).size) / one_thousand) / durationMS ;
 
       fout << (*iter).address << "," 
 	   << (*iter).contextId << ","
@@ -1909,7 +1909,7 @@ namespace xdp {
       fout << (double)((iter).size) / one_thousand << "," ;
       if (getFlowMode() == HW) {
         double durationMS = (double)((iter).duration) / one_million ;
-        double rate = ((double)((iter).size) / one_thousand) * durationMS ;
+        double rate = ((double)((iter).size) / one_thousand) / durationMS ;
         fout << durationMS << "," ;
         fout << rate << "," ;
       }
@@ -1941,7 +1941,7 @@ namespace xdp {
       fout << (double)((iter).size) / one_thousand << "," ;
       if (getFlowMode() == HW) {
         double durationMS = (double)((iter).duration) / one_million ;
-        double rate = ((double)((iter).size) / one_thousand) * durationMS ;
+        double rate = ((double)((iter).size) / one_thousand) / durationMS ;
         fout << durationMS << "," ;
         fout << rate << "," ;
       }

--- a/src/runtime_src/xdp/profile/writer/vp_base/summary_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/summary_writer.cpp
@@ -982,6 +982,7 @@ namespace xdp {
 	double maxReadBW =
 	  (db->getStaticInfo()).getHostMaxReadBW(deviceId) ;
 	double aveBWUtil = (one_hundred * transferRate) / maxReadBW ;
+        if (aveBWUtil > 100.0) aveBWUtil = 100.0;
 
 	fout << transferRate << "," ;
 	fout << aveBWUtil << "," ;
@@ -1046,6 +1047,7 @@ namespace xdp {
 	double maxReadBW =
 	  (db->getStaticInfo()).getHostMaxReadBW(deviceId) ;
 	double aveBWUtil = (one_hundred * transferRate) / maxReadBW ;
+        if (aveBWUtil > 100.0) aveBWUtil = 100.0;
 
 	fout << transferRate << "," ;
 	fout << aveBWUtil << "," ;

--- a/src/runtime_src/xdp/profile/writer/vp_base/summary_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/summary_writer.cpp
@@ -874,8 +874,9 @@ namespace xdp {
         double transferRate  = totalSizeInMB / totalTimeInS; 
 
 	double maxReadBW =
-	  (db->getStaticInfo()).getMaxReadBW(read.first.second) ;
+	  (db->getStaticInfo()).getHostMaxReadBW(read.first.second) ;
 	double aveBWUtil = (one_hundred * transferRate) / maxReadBW ;
+        if (aveBWUtil > one_hundred) aveBWUtil = one_hundred;
 
 	fout << contextName << ":" << numDevices << ","
 	     << "READ" << ","
@@ -912,8 +913,9 @@ namespace xdp {
         double transferRate  = totalSizeInMB / totalTimeInS; 
 
 	double maxWriteBW =
-	  (db->getStaticInfo()).getMaxWriteBW(write.first.second);
+	  (db->getStaticInfo()).getHostMaxWriteBW(write.first.second);
 	double aveBWUtil = (one_hundred * transferRate) / maxWriteBW ;
+        if (aveBWUtil > one_hundred) aveBWUtil = one_hundred;
 
 	fout << contextName << ":" << numDevices << "," 
 	     << "WRITE" << ","
@@ -978,7 +980,7 @@ namespace xdp {
         auto totalSizeInMB = (double)(stats.totalSize / one_million);
         double transferRate  = totalSizeInMB / totalTimeInS; 
 	double maxReadBW =
-	  (db->getStaticInfo()).getMaxReadBW(deviceId) ;
+	  (db->getStaticInfo()).getHostMaxReadBW(deviceId) ;
 	double aveBWUtil = (one_hundred * transferRate) / maxReadBW ;
 
 	fout << transferRate << "," ;
@@ -1042,7 +1044,7 @@ namespace xdp {
         auto totalSizeInMB = (double)(stats.totalSize / one_million);
         double transferRate  = totalSizeInMB / totalTimeInS; 
 	double maxReadBW =
-	  (db->getStaticInfo()).getMaxReadBW(deviceId) ;
+	  (db->getStaticInfo()).getHostMaxReadBW(deviceId) ;
 	double aveBWUtil = (one_hundred * transferRate) / maxReadBW ;
 
 	fout << transferRate << "," ;
@@ -1731,7 +1733,7 @@ namespace xdp {
 	    double transferRate = (totalWriteTime == zero) ? 0 :
 	      (double)(values.WriteBytes[monitorId]) / (one_thousand * totalWriteTime);
 	    double aveBW =
-	      (one_hundred * transferRate) / xclbin->maxWriteBW ;
+	      (one_hundred * transferRate) / xclbin->kernelMaxWriteBW ;
 	    if (aveBW > one_hundred) aveBW = one_hundred ;
 	    auto aveLatency =
               static_cast<double>(values.WriteLatency[monitorId]) /
@@ -1753,11 +1755,11 @@ namespace xdp {
 	      double transferRate = (totalReadTime == zero) ? 0 :
 		(double)(values.ReadBytes[monitorId]) / (one_thousand * totalReadTime);
 	      double aveBW =
-		(one_hundred * transferRate) / xclbin->maxReadBW ;
+		(one_hundred * transferRate) / xclbin->kernelMaxReadBW ;
 	      if (aveBW > one_hundred) aveBW = one_hundred ;
               auto aveLatency =
                 static_cast<double>(values.ReadLatency[monitorId]) /
-                static_cast<double>(readTranx) ;
+                static_cast<double>(readTranx);
 
 	      fout << device->getUniqueDeviceName() << ","
 		   << xclbin->cus[monitor->cuIndex]->getName() << "/"

--- a/src/runtime_src/xrt/device/device.h
+++ b/src/runtime_src/xrt/device/device.h
@@ -683,15 +683,27 @@ public:
   }
 
   hal::operations_result<double>
-  getDeviceMaxRead()
+  getHostMaxRead()
   {
-    return m_hal->getDeviceMaxRead();
+    return m_hal->getHostMaxRead();
   }
 
   hal::operations_result<double>
-  getDeviceMaxWrite()
+  getHostMaxWrite()
   {
-    return m_hal->getDeviceMaxWrite();
+    return m_hal->getHostMaxWrite();
+  }
+
+  hal::operations_result<double>
+  getKernelMaxRead()
+  {
+    return m_hal->getKernelMaxRead();
+  }
+
+  hal::operations_result<double>
+  getKernelMaxWrite()
+  {
+    return m_hal->getKernelMaxWrite();
   }
 
   hal::operations_result<size_t>

--- a/src/runtime_src/xrt/device/hal.h
+++ b/src/runtime_src/xrt/device/hal.h
@@ -509,13 +509,25 @@ public:
   }
 
   virtual operations_result<double>
-  getDeviceMaxRead()
+  getHostMaxRead()
   {
     return operations_result<double>();
   }
 
   virtual operations_result<double>
-  getDeviceMaxWrite()
+  getHostMaxWrite()
+  {
+    return operations_result<double>();
+  }
+
+  virtual operations_result<double>
+  getKernelMaxRead()
+  {
+    return operations_result<double>();
+  }
+
+  virtual operations_result<double>
+  getKernelMaxWrite()
   {
     return operations_result<double>();
   }

--- a/src/runtime_src/xrt/device/hal2.h
+++ b/src/runtime_src/xrt/device/hal2.h
@@ -420,19 +420,35 @@ public:
   }
 
   virtual hal::operations_result<double>
-  getDeviceMaxRead()
+  getHostMaxRead()
   {
-    if (!m_ops->mGetDeviceMaxRead)
+    if (!m_ops->mGetHostMaxRead)
       return hal::operations_result<double>();
-    return m_ops->mGetDeviceMaxRead(m_handle);
+    return m_ops->mGetHostMaxRead(m_handle);
   }
 
   virtual hal::operations_result<double>
-  getDeviceMaxWrite()
+  getHostMaxWrite()
   {
-    if (!m_ops->mGetDeviceMaxWrite)
+    if (!m_ops->mGetHostMaxWrite)
       return hal::operations_result<double>();
-    return m_ops->mGetDeviceMaxWrite(m_handle);
+    return m_ops->mGetHostMaxWrite(m_handle);
+  }
+
+  virtual hal::operations_result<double>
+  getKernelMaxRead()
+  {
+    if (!m_ops->mGetKernelMaxRead)
+      return hal::operations_result<double>();
+    return m_ops->mGetKernelMaxRead(m_handle);
+  }
+
+  virtual hal::operations_result<double>
+  getKernelMaxWrite()
+  {
+    if (!m_ops->mGetKernelMaxWrite)
+      return hal::operations_result<double>();
+    return m_ops->mGetKernelMaxWrite(m_handle);
   }
 
   virtual hal::operations_result<size_t>

--- a/src/runtime_src/xrt/device/halops2.cpp
+++ b/src/runtime_src/xrt/device/halops2.cpp
@@ -53,8 +53,10 @@ operations(const std::string &fileName, void *fileHandle, unsigned int count)
   ,mGetDeviceInfo(0)
   ,mGetDeviceTime(0)
   ,mGetDeviceClock(0)
-  ,mGetDeviceMaxRead(0)
-  ,mGetDeviceMaxWrite(0)
+  ,mGetHostMaxRead(0)
+  ,mGetHostMaxWrite(0)
+  ,mGetKernelMaxRead(0)
+  ,mGetKernelMaxWrite(0)
   ,mSetProfilingSlots(0)
   ,mGetProfilingSlots(0)
   ,mGetProfilingSlotName(0)
@@ -132,8 +134,10 @@ operations(const std::string &fileName, void *fileHandle, unsigned int count)
   // Profiling Functions
   mGetDeviceTime = (getDeviceTimeFuncType)xrt_core::dlsym(const_cast<void *>(mDriverHandle), "xclGetDeviceTimestamp");
   mGetDeviceClock = (getDeviceClockFuncType)xrt_core::dlsym(const_cast<void *>(mDriverHandle), "xclGetDeviceClockFreqMHz");
-  mGetDeviceMaxRead = (getDeviceMaxReadFuncType)xrt_core::dlsym(const_cast<void *>(mDriverHandle), "xclGetReadMaxBandwidthMBps");
-  mGetDeviceMaxWrite = (getDeviceMaxWriteFuncType)xrt_core::dlsym(const_cast<void *>(mDriverHandle), "xclGetWriteMaxBandwidthMBps");
+  mGetHostMaxRead = (getHostMaxReadFuncType)xrt_core::dlsym(const_cast<void *>(mDriverHandle), "xclGetHostReadMaxBandwidthMBps");
+  mGetHostMaxWrite = (getHostMaxWriteFuncType)xrt_core::dlsym(const_cast<void *>(mDriverHandle), "xclGetHostWriteMaxBandwidthMBps");
+  mGetKernelMaxRead = (getKernelMaxReadFuncType)xrt_core::dlsym(const_cast<void *>(mDriverHandle), "xclGetKernelReadMaxBandwidthMBps");
+  mGetKernelMaxWrite = (getKernelMaxWriteFuncType)xrt_core::dlsym(const_cast<void *>(mDriverHandle), "xclGetKernelWriteMaxBandwidthMBps");
   mSetProfilingSlots = (setSlotFuncType)xrt_core::dlsym(const_cast<void *>(mDriverHandle), "xclSetProfilingNumberSlots");
   mGetProfilingSlots = (getSlotFuncType)xrt_core::dlsym(const_cast<void *>(mDriverHandle), "xclGetProfilingNumberSlots");
   mGetProfilingSlotName = (getSlotNameFuncType)xrt_core::dlsym(const_cast<void *>(mDriverHandle), "xclGetProfilingSlotName");

--- a/src/runtime_src/xrt/device/halops2.h
+++ b/src/runtime_src/xrt/device/halops2.h
@@ -94,8 +94,10 @@ private:
 
   typedef size_t (* getDeviceTimeFuncType)(xclDeviceHandle handle);
   typedef double (* getDeviceClockFuncType)(xclDeviceHandle handle);
-  typedef double (* getDeviceMaxReadFuncType)(xclDeviceHandle handle);
-  typedef double (* getDeviceMaxWriteFuncType)(xclDeviceHandle handle);
+  typedef double (* getHostMaxReadFuncType)(xclDeviceHandle handle);
+  typedef double (* getHostMaxWriteFuncType)(xclDeviceHandle handle);
+  typedef double (* getKernelMaxReadFuncType)(xclDeviceHandle handle);
+  typedef double (* getKernelMaxWriteFuncType)(xclDeviceHandle handle);
   typedef void (* setSlotFuncType)(xclDeviceHandle handle, xclPerfMonType type, uint32_t numSlots);
   typedef uint32_t (* getSlotFuncType)(xclDeviceHandle handle, xclPerfMonType type);
   typedef void (* getSlotNameFuncType)(xclDeviceHandle handle, xclPerfMonType type, uint32_t slotnum,
@@ -187,8 +189,10 @@ public:
 
   getDeviceTimeFuncType mGetDeviceTime;
   getDeviceClockFuncType mGetDeviceClock;
-  getDeviceMaxReadFuncType mGetDeviceMaxRead;
-  getDeviceMaxWriteFuncType mGetDeviceMaxWrite;
+  getHostMaxReadFuncType mGetHostMaxRead;
+  getHostMaxWriteFuncType mGetHostMaxWrite;
+  getKernelMaxReadFuncType mGetKernelMaxRead;
+  getKernelMaxWriteFuncType mGetKernelMaxWrite;
   setSlotFuncType mSetProfilingSlots;
   getSlotFuncType mGetProfilingSlots;
   getSlotNameFuncType mGetProfilingSlotName;

--- a/src/runtime_src/xrt/device/halops2_static.cpp
+++ b/src/runtime_src/xrt/device/halops2_static.cpp
@@ -52,8 +52,10 @@ operations(const std::string &fileName, void *fileHandle, unsigned int count)
   ,mGetDeviceInfo(0)
   ,mGetDeviceTime(0)
   ,mGetDeviceClock(0)
-  ,mGetDeviceMaxRead(0)
-  ,mGetDeviceMaxWrite(0)
+  ,mGetHostMaxRead(0)
+  ,mGetHostMaxWrite(0)
+  ,mGetKernelMaxRead(0)
+  ,mGetKernelMaxWrite(0)
   ,mSetProfilingSlots(0)
   ,mGetProfilingSlots(0)
   ,mGetProfilingSlotName(0)
@@ -136,8 +138,10 @@ operations(const std::string &fileName, void *fileHandle, unsigned int count)
   // Profiling Functions
   mGetDeviceTime = &xclGetDeviceTimestamp;
   mGetDeviceClock = &xclGetDeviceClockFreqMHz;
-  mGetDeviceMaxRead = &xclGetReadMaxBandwidthMBps;
-  mGetDeviceMaxWrite = &xclGetWriteMaxBandwidthMBps;
+  mGetHostMaxRead = &xclGetHostReadMaxBandwidthMBps;
+  mGetHostMaxWrite = &xclGetHostWriteMaxBandwidthMBps;
+  mGetKernelMaxRead = &xclGetKernelReadMaxBandwidthMBps;
+  mGetKernelMaxWrite = &xclGetKernelWriteMaxBandwidthMBps;
   mSetProfilingSlots = &xclSetProfilingNumberSlots;
   mGetProfilingSlots = &xclGetProfilingNumberSlots;
   mGetProfilingSlotName = &xclGetProfilingSlotName;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
This pull request back-ports some fixes implemented in 2022.1 to the 2021.2 branch to address incorrect profiling numbers seen on AWS.

In particular, this back-ports the splitting of "max bandwidth" calculations to the max bandwidth between the host and the device, and the max bandwidth between the kernel and the memory.  Each shim returns a different max bandwidth based on the device capabilities so that the numbers calculated by profiling reflect the correct percentage of bandwidth.

Since these are shim functions, stubs are added for the emulation shims.

#### What has been tested and how, request additional testing if necessary
This has been tested on designs on an AWS instance and the numbers reported are now as expected.

#### Documentation impact (if any)
When merged, the commit hash ID will be added to an Action Record for AWS users to grab the correct version of 2021.2 with the fixes.