### PR TITLE
Defer extraction of underlying type for xrt::uuid and std::string

### DIFF
--- a/src/runtime_src/core/common/api/context_mgr.cpp
+++ b/src/runtime_src/core/common/api/context_mgr.cpp
@@ -95,7 +95,7 @@ public:
       if (m_cv.wait_for(ul, 100ms) == std::cv_status::timeout)
         throw std::runtime_error("aquiring cu context timed out");
     }
-    m_device->open_context(slot, uuid.get(), ipname.c_str(), shared);
+    m_device->open_context(slot, uuid, ipname, shared);
 
     // Successful context creation means CU idx is now known
     if (!ctx)
@@ -121,7 +121,7 @@ public:
       if (m_cv.wait_for(ul, 100ms) == std::cv_status::timeout)
         throw std::runtime_error("aquiring cu context timed out");
     }
-    m_device->open_context(uuid.get(), ipidx.index, shared);
+    m_device->open_context(uuid, ipidx.index, shared);
     ctx->set(idx);
   }
 
@@ -135,7 +135,7 @@ public:
     auto ctx = get_ctx(ipidx);
     if (!ctx->test(idx))
       throw std::runtime_error("ctx " + std::to_string(ipidx.index) + " not open");
-    m_device->close_context(uuid.get(), ipidx.index);
+    m_device->close_context(uuid, ipidx.index);
     ctx->reset(idx);
     m_cv.notify_all();
   }

--- a/src/runtime_src/core/common/api/xrt_ip.cpp
+++ b/src/runtime_src/core/common/api/xrt_ip.cpp
@@ -159,7 +159,7 @@ class ip_impl
       size = ip.get_size();
 
       // context, driver allows shared context per xrt.ini
-      device->open_context(slot, xclbin_uuid.get(), ipnm.c_str(), xrt_core::config::get_rw_shared());
+      device->open_context(slot, xclbin_uuid, ipnm, xrt_core::config::get_rw_shared());
 
       // idx is guaranteed valid only after context creation
       idx = device->get_cuidx(slot, ipnm);

--- a/src/runtime_src/core/pcie/noop/device_noop.h
+++ b/src/runtime_src/core/pcie/noop/device_noop.h
@@ -25,7 +25,7 @@ private:
   lookup_query(query::key_type query_key) const override;
 
   uint32_t // slotidx
-  create_hw_context(const xuid_t xclbin_uuid, uint32_t qos) const override
+  create_hw_context(const xrt::uuid& xclbin_uuid, uint32_t qos) const override
   {
     return userpf::create_hw_context(this, xclbin_uuid, qos);
   }

--- a/src/runtime_src/core/pcie/noop/shim.cpp
+++ b/src/runtime_src/core/pcie/noop/shim.cpp
@@ -474,7 +474,7 @@ struct shim
     auto xclbin = m_core_device->get_xclbin(top->m_header.uuid);
     m_pldev->register_xclbin(xclbin);
     auto uuid = xclbin.get_uuid();
-    m_load_xclbin_slots[uuid] = create_hw_context(uuid.get(), 0);
+    m_load_xclbin_slots[uuid] = create_hw_context(uuid, 0);
     return 0;
   }
 
@@ -521,7 +521,7 @@ struct shim
   }
 
   uint32_t // slotidx
-  create_hw_context(const xuid_t xclbin_uuid, uint32_t qos)
+  create_hw_context(const xrt::uuid& xclbin_uuid, uint32_t qos)
   {
     if (m_load_xclbin_slots.find(xclbin_uuid) != m_load_xclbin_slots.end())
       throw xrt_core::ishim::not_supported_error(__func__);
@@ -585,7 +585,7 @@ xclbin_slots(const xrt_core::device* device)
 }
 
 uint32_t // slotidx
-create_hw_context(const xrt_core::device* device, const xuid_t xclbin_uuid, uint32_t qos)
+create_hw_context(const xrt_core::device* device, const xrt::uuid& xclbin_uuid, uint32_t qos)
 {
   auto shim = get_shim_object(device->get_device_handle());
   return shim->create_hw_context(xclbin_uuid, qos);

--- a/src/runtime_src/core/pcie/noop/shim.h
+++ b/src/runtime_src/core/pcie/noop/shim.h
@@ -18,7 +18,7 @@ xrt_core::query::xclbin_slots::result_type
 xclbin_slots(const xrt_core::device* device);
 
 uint32_t // slotidx
-create_hw_context(const xrt_core::device* device, const xuid_t xclbin_uuid, uint32_t qos);
+create_hw_context(const xrt_core::device* device, const xrt::uuid& xclbin_uuid, uint32_t qos);
 
 void
 destroy_hw_context(const xrt_core::device* device, uint32_t slotidx);

--- a/src/runtime_src/core/tools/xbutil2/OO_P2P.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_P2P.cpp
@@ -200,7 +200,7 @@ test(xrt_core::device* device)
 {
   // lock xclbin
   auto uuid = xrt::uuid(xrt_core::device_query<xrt_core::query::xclbin_uuid>(device));
-  device->open_context(uuid.get(), -1, true);
+  device->open_context(uuid, -1, true);
   auto at_exit = [] (auto device, auto uuid) { device->close_context(uuid.get(), -1); };
   xrt_core::scope_guard<std::function<void()>> g(std::bind(at_exit, device, uuid));
 
@@ -318,9 +318,9 @@ OO_P2P::execute(const SubCmdOptions& _options) const
   std::set<std::string> deviceNames;
   xrt_core::device_collection deviceCollection;
 
-  for (const auto & deviceName : m_devices) 
+  for (const auto & deviceName : m_devices)
     deviceNames.insert(boost::algorithm::to_lower_copy(deviceName));
-  
+
   try {
     XBU::collect_devices(deviceNames, true /*inUserDomain*/, deviceCollection);
   } catch (const std::runtime_error& e) {
@@ -346,7 +346,7 @@ OO_P2P::execute(const SubCmdOptions& _options) const
     p2p(deviceCollection[0].get(), action, XBU::getForce());
   } catch (const xrt_core::system_error& ex) {
     std::cerr << "ERROR: " << ex.what() << std::endl;
-    throw xrt_core::error(std::errc::operation_canceled); 
+    throw xrt_core::error(std::errc::operation_canceled);
   }
 
   // Print success message for the user
@@ -354,7 +354,7 @@ OO_P2P::execute(const SubCmdOptions& _options) const
     case action_type::enable:
       std::cout <<  "Please WARM reboot the machine to enable P2P now.\n";
       break;
-    
+
     case action_type::disable:
       std::cout << "Please WARM reboot the machine to disable P2P now.\n";
       break;


### PR DESCRIPTION
#### Problem solved by the commit
Prep work for adding shim level hw context APIs.
Stay native (xrt::uuid, std::string) until shim level.

#### How problem was solved, alternative solutions (if any) and why they were rejected
This simple PR defers extracting underlying type of composite objects
until shim level functions are called.  Later PR will move composite
objects into shim itself rather than convert back and forth as is
sometimes done with `xrt::uuid <-> uuid_t` and `std::string <-> const char*`

