### PR TITLE
CID 257986:  Class hierarchy inconsistencies  (BAD_OVERRIDE)

### DIFF
--- a/src/runtime_src/core/common/api/xrt_device.cpp
+++ b/src/runtime_src/core/common/api/xrt_device.cpp
@@ -277,7 +277,7 @@ register_xclbin(const xclbin& xclbin)
 {
   return xdp::native::profiling_wrapper("xrt::device::register_xclbin",
   [this, &xclbin]{
-    handle->register_xclbin(xclbin);
+    handle->record_xclbin(xclbin);
     return xclbin.get_uuid();
   });
 }

--- a/src/runtime_src/core/common/device.cpp
+++ b/src/runtime_src/core/common/device.cpp
@@ -85,12 +85,13 @@ get_xclbin_uuid() const
 
 // Registering an xclbin has one entry point (this one) only.
 // Shim level registering is not exposed to end-user application.
-//
+// Naming of "record" as in record_xclbin is to compensate for
+// virtual register_xclbin which is defined by shim.
 void
 device::
-register_xclbin(const xrt::xclbin& xclbin)
+record_xclbin(const xrt::xclbin& xclbin)
 {
-  static_cast<ishim*>(this)->register_xclbin(xclbin);
+  register_xclbin(xclbin); // shim level registration
   m_xclbins.insert(xclbin);
 }
 

--- a/src/runtime_src/core/common/device.h
+++ b/src/runtime_src/core/common/device.h
@@ -242,15 +242,18 @@ public:
     return qr.put(this, std::forward<Args>(args)...);
   }
 
-  // register_xclbin() - Registers an xclbin with the device
+  // record_xclbin() - Registers an xclbin with the device
   //
-  // This function registers an xclbin without loading it onto
-  // hardware resource.  Once registered, a hardware context
-  // can be created once or more times, which will assign the
-  // xclbin to hardware resources.
+  // This function records/registers an xclbin without loading it onto
+  // hardware resource.  Once registered, a hardware context can be
+  // created once or more times, which will assign the xclbin to
+  // hardware resources.
+  //
+  // Naming of "record" as in record_xclbin is to compensate for
+  // virtual register_xclbin which is defined by shim.
   XRT_CORE_COMMON_EXPORT
   void
-  register_xclbin(const xrt::xclbin& xclbin);
+  record_xclbin(const xrt::xclbin& xclbin);
 
   /**
    * load_xclbin() - Load an xclbin object on this device


### PR DESCRIPTION
#### Problem solved by the commit
Fix naming to avoid potential override problem of
xrt_core::device::register_xclbin.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CID 257986

#### How problem was solved, alternative solutions (if any) and why they were rejected
The shim class hierarchy defines register_xclbin at the shim level
core library.  Rename xrt_core::device version as record_xclbin.