### PR TITLE
Reorganize implementation of internal shim level APIs

### DIFF
--- a/src/runtime_src/core/common/ishim.h
+++ b/src/runtime_src/core/common/ishim.h
@@ -281,8 +281,7 @@ struct shim : public DeviceType
   void
   open_context(uint32_t slot, const xrt::uuid& xclbin_uuid, const std::string& cuname, bool shared) override
   {
-    if (auto ret = xclOpenContextByName(DeviceType::get_device_handle(), slot, xclbin_uuid.get(), cuname.c_str(), shared))
-      throw system_error(ret, "failed to open ip context");
+    xrt::shim_int::open_context(DeviceType::get_device_handle(), slot, xclbin_uuid, cuname, shared);
   }
 
   void

--- a/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/shim.cxx
@@ -2111,11 +2111,6 @@ int CpuemShim::xclOpenContext(const uuid_t xclbinId, unsigned int ipIndex, bool 
   return 0;
 }
 
-int CpuemShim::xclOpenContext(uint32_t slot, const uuid_t xclbinId, const char* cuname, bool shared) const
-{
-  return 0;
-}
-
 /*
 * xclExecWait
 */
@@ -2172,6 +2167,16 @@ int CpuemShim::xclIPName2Index(const char *name)
   //Get IP_LAYOUT buffer from xclbin
   auto buffer = mCoreDevice->get_axlf_section(IP_LAYOUT);
   return xclemulation::getIPName2Index(name, buffer.first);
+}
+
+// open_context() - aka xclOpenContextByName
+void
+CpuemShim::
+open_context(uint32_t slot, const xrt::uuid& xclbin_uuid, const std::string& cuname, bool shared) const
+{
+  // Alveo Linux PCIE does not yet support multiple xclbins.
+  // Call regular flow
+  xclOpenContext(xclbin_uuid.get(), mCoreDevice->get_cuidx(slot, cuname).index, shared);
 }
 
 /******************************* XRT Graph API's **************************************************/

--- a/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/shim.h
@@ -151,7 +151,6 @@ namespace xclcpuemhal2 {
       bool isGood() const;
 
       int xclOpenContext(const uuid_t xclbinId, unsigned int ipIndex, bool shared) const;
-      int xclOpenContext(uint32_t slot, const uuid_t xclbinId, const char* cuname, bool shared) const;
       int xclExecWait(int timeoutMilliSec);
       int xclExecBuf(unsigned int cmdBO);
       int xclCloseContext(const uuid_t xclbinId, unsigned int ipIndex) const;
@@ -312,6 +311,13 @@ namespace xclcpuemhal2 {
       */
       int
         xrtGraphTimedWait(void * gh, uint64_t cycle);
+
+      ////////////////////////////////////////////////////////////////
+      // Internal SHIM APIs
+      ////////////////////////////////////////////////////////////////
+      // aka xclOpenContextByName
+      void
+      open_context(uint32_t slot, const xrt::uuid& xclbin_uuid, const std::string& cuname, bool shared) const;
 
     private:
       std::shared_ptr<xrt_core::device> mCoreDevice;

--- a/src/runtime_src/core/edge/user/shim.h
+++ b/src/runtime_src/core/edge/user/shim.h
@@ -75,8 +75,9 @@ public:
   int xclExecBuf(unsigned int cmdBO);
   int xclExecWait(int timeoutMilliSec);
 
-  int xclOpenContext(const uuid_t xclbinId, unsigned int ipIndex, bool shared);
-  int xclOpenContext(uint32_t slot, const uuid_t xclbinId, const char* cuname, bool shared);
+  int xclOpenContext(const uuid_t xclbinId, unsigned int ipIndex, bool shared) const;
+  // aka xclOpenContextByName()
+  void open_context(uint32_t slot, const xrt::uuid& xclbinId, const std::string& cuname, bool shared) const;
   int xclCloseContext(const uuid_t xclbinId, unsigned int ipIndex);
 
   int xclSKGetCmd(xclSKCmd *cmd);

--- a/src/runtime_src/core/include/shim_int.h
+++ b/src/runtime_src/core/include/shim_int.h
@@ -1,43 +1,58 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2021-2022 Xilinx, Inc. All rights reserved.
+// Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
 #ifndef SHIM_INT_H_
 #define SHIM_INT_H_
 
 #include "core/include/xrt.h"
 
+#include <string>
+
+namespace xrt {
+
+class xclbin;
+class uuid;
+
+namespace shim_int {
+
 // This file defines internal shim APIs, which is not end user visible.
 // This header file should not be published to xrt release include/ folder.
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-/**
- * xclOpenByBDF() - Open a device and obtain its handle by PCI BDF
- *
- * @bdf:           Deice PCE BDF
- * Return:         Device handle
- */
+// open_by_bdf() - Open a device and obtain its handle by PCI BDF
+//
+// @bdf:           Deice PCE BDF
+// Return:         Device handle
+//
+// Throws on error
 XCL_DRIVER_DLLESPEC
 xclDeviceHandle
-xclOpenByBDF(const char *bdf);
+open_by_bdf(const std::string& bdf);
 
-/**
- * xclOpenContextByName() - Open a shared/exclusive context on a named compute unit
- *
- * @handle:        Device handle
- * @slot:          Slot index of xclbin to service this context requiest
- * @xclbin_uuid:   UUID of the xclbin image with the CU to open a context on
- * @cuname:        Name of compute unit to open
- * @shared:        Shared access or exclusive access
- * Return:         0 on success, EAGAIN, or appropriate error number
- */
+// open_context() - Open a shared/exclusive context on a named compute unit
+//
+// @handle:        Device handle
+// @slot:          Slot index of xclbin to service this context requiest
+// @xclbin_uuid:   UUID of the xclbin image with the CU to open a context on
+// @cuname:        Name of compute unit to open
+// @shared:        Shared access or exclusive access
+//
+// Throws on error
 XCL_DRIVER_DLLESPEC
-int
-xclOpenContextByName(xclDeviceHandle handle, uint32_t slot, const xuid_t xclbin_uuid, const char* cuname, bool shared);
+void
+open_context(xclDeviceHandle handle, uint32_t slot, const xrt::uuid& xclbin_uuid, const std::string& cuname, bool shared);
 
-#ifdef __cplusplus
-}
-#endif
+// create_hw_context() -
+uint32_t // ctxhdl aka slotidx
+create_hw_context(xclDeviceHandle handle, const xrt::uuid& xclbin_uuid, uint32_t qos);
+
+// dsstroy_hw_context() -
+void
+destroy_hw_context(xclDeviceHandle handle, uint32_t ctxhdl);
+
+// register_xclbin() -
+void
+register_xclbin(xclDeviceHandle handle, const xrt::xclbin& xclbin);
+
+}} // shim_int, xrt
 
 #endif

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
@@ -1935,11 +1935,6 @@ int CpuemShim::xclOpenContext(const uuid_t xclbinId, unsigned int ipIndex, bool 
   return 0;
 }
 
-int CpuemShim::xclOpenContextByName(uint32_t slot, const uuid_t xclbinId, const char* cuname, bool shared) const
-{
-  return xclOpenContext(xclbinId, mCoreDevice->get_cuidx(slot, cuname).index, shared);
-}
-
 /*
 * xclExecWait
 */
@@ -2301,5 +2296,15 @@ int CpuemShim::xrtGMIOWait(const char *gmioname)
   return 0;
 }
 
-/**********************************************HAL2 API's END HERE **********************************************/
+// open_context() - aka xclOpenContextByName
+void
+CpuemShim::
+open_context(uint32_t slot, const xrt::uuid& xclbin_uuid, const std::string& cuname, bool shared) const
+{
+  // Alveo Linux PCIE does not yet support multiple xclbins.
+  // Call regular flow
+  xclOpenContext(xclbin_uuid.get(), mCoreDevice->get_cuidx(slot, cuname).index, shared);
 }
+
+/**********************************************HAL2 API's END HERE **********************************************/
+} //xclcpuemhal2

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.h
@@ -155,7 +155,6 @@ namespace xclcpuemhal2 {
       bool isGood() const;
 
       int xclOpenContext(const uuid_t xclbinId, unsigned int ipIndex, bool shared) const;
-      int xclOpenContextByName(uint32_t slot, const uuid_t xclbinId, const char* cuname, bool shared) const;
       int xclExecWait(int timeoutMilliSec);
       int xclExecBuf(unsigned int cmdBO);
       int xclCloseContext(const uuid_t xclbinId, unsigned int ipIndex) const;
@@ -405,6 +404,13 @@ namespace xclcpuemhal2 {
       // */
       // int
       //   xrtGraphReadRTP(void * gh, const char *hierPathPort, char *buffer, size_t size);
+
+      ////////////////////////////////////////////////////////////////
+      // Internal SHIM APIs
+      ////////////////////////////////////////////////////////////////
+      // aka xclOpenContextByName
+      void
+      open_context(uint32_t slot, const xrt::uuid& xclbin_uuid, const std::string& cuname, bool shared) const;
 
     private:
       std::shared_ptr<xrt_core::device> mCoreDevice;

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/halapi.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/halapi.cxx
@@ -21,6 +21,36 @@
 #include "plugin/xdp/device_offload.h"
 #include "plugin/xdp/hal_trace.h"
 
+namespace {
+
+// Wrap handle check to throw on error
+static xclhwemhal2::HwEmShim*
+get_shim_object(xclDeviceHandle handle)
+{
+  if (auto shim = xclhwemhal2::HwEmShim::handleCheck(handle))
+    return shim;
+
+  throw xrt_core::error("Invalid shim handle");
+}
+
+} // namespace
+
+////////////////////////////////////////////////////////////////
+// Implementation of internal SHIM APIs
+////////////////////////////////////////////////////////////////
+namespace xrt::shim_int {
+
+// open_context - aka xclOpenContextByName
+void
+open_context(xclDeviceHandle handle, uint32_t slot, const xrt::uuid& xclbin_uuid, const std::string& cuname, bool shared)
+{
+  get_shim_object(handle);
+  // shim->open_context(slot, xclbin_uuid, cuname, shared);
+}
+
+} // xrt::shim_int
+
+
 int xclExportBO(xclDeviceHandle handle, unsigned int boHandle)
 {
   xclhwemhal2::HwEmShim *drv = xclhwemhal2::HwEmShim::handleCheck(handle);
@@ -183,11 +213,6 @@ int xclExecBufWithWaitList(xclDeviceHandle handle, unsigned int cmdBO, size_t nu
 
 //defining following two functions as they gets called in scheduler init call
 int xclOpenContext(xclDeviceHandle handle, const uuid_t xclbinId, unsigned int ipIndex, bool shared)
-{
-  return 0;
-}
-
-int xclOpenContextByName(xclDeviceHandle handle, uint32_t slot, const uuid_t xclbinId, const char* cuname, bool shared)
 {
   return 0;
 }

--- a/src/runtime_src/core/pcie/linux/shim.h
+++ b/src/runtime_src/core/pcie/linux/shim.h
@@ -129,7 +129,6 @@ public:
     int xclRegisterEventNotify(unsigned int userInterrupt, int fd);
     int xclExecWait(int timeoutMilliSec);
     int xclOpenContext(const uuid_t xclbinId, unsigned int ipIndex, bool shared) const;
-    int xclOpenContext(uint32_t slot, const uuid_t xclbinId, const char* cuname, bool shared) const;
     int xclCloseContext(const uuid_t xclbinId, unsigned int ipIndex);
 
     int getBoardNumber( void ) { return mBoardNumber; }
@@ -138,6 +137,13 @@ public:
 
     int xclOpenIPInterruptNotify(uint32_t ipIndex, unsigned int flags);
     int xclCloseIPInterruptNotify(int fd);
+
+    ////////////////////////////////////////////////////////////////
+    // Internal SHIM APIs
+    ////////////////////////////////////////////////////////////////
+    // aka xclOpenContextByName
+    void
+    open_context(uint32_t slot, const xrt::uuid& xclbin_uuid, const std::string& cuname, bool shared) const;
 
 private:
     std::shared_ptr<xrt_core::device> mCoreDevice;

--- a/src/runtime_src/core/pcie/noop/device_noop.h
+++ b/src/runtime_src/core/pcie/noop/device_noop.h
@@ -8,7 +8,7 @@
 #include "core/common/query_requests.h"
 #include "core/pcie/common/device_pcie.h"
 
-#include "shim.h"
+#include "shim_int.h"
 
 namespace xrt_core { namespace noop {
 
@@ -24,22 +24,22 @@ private:
   virtual const query::request&
   lookup_query(query::key_type query_key) const override;
 
-  uint32_t // slotidx
+  uint32_t // ctx handle aka slotidx
   create_hw_context(const xrt::uuid& xclbin_uuid, uint32_t qos) const override
   {
-    return userpf::create_hw_context(this, xclbin_uuid, qos);
+    return xrt::shim_int::create_hw_context(get_device_handle(), xclbin_uuid, qos);
   }
 
   void
-  destroy_hw_context(uint32_t slotidx) const override
+  destroy_hw_context(uint32_t ctxhdl) const override
   {
-    userpf::destroy_hw_context(this, slotidx);
+    xrt::shim_int::destroy_hw_context(get_device_handle(), ctxhdl);
   }
 
   void
   register_xclbin(const xrt::xclbin& xclbin) const override
   {
-    userpf::register_xclbin(this, xclbin);
+    xrt::shim_int::register_xclbin(get_device_handle(), xclbin);
   }
 };
 

--- a/src/runtime_src/core/pcie/noop/shim.h
+++ b/src/runtime_src/core/pcie/noop/shim.h
@@ -17,15 +17,6 @@ kds_cu_info(const xrt_core::device* device);
 xrt_core::query::xclbin_slots::result_type
 xclbin_slots(const xrt_core::device* device);
 
-uint32_t // slotidx
-create_hw_context(const xrt_core::device* device, const xrt::uuid& xclbin_uuid, uint32_t qos);
-
-void
-destroy_hw_context(const xrt_core::device* device, uint32_t slotidx);
-
-void
-register_xclbin(const xrt_core::device* device, const xrt::xclbin& xclbn);
-
 } // userpf
 
 

--- a/src/runtime_src/core/pcie/windows/alveo/shim.cpp
+++ b/src/runtime_src/core/pcie/windows/alveo/shim.cpp
@@ -380,7 +380,7 @@ done:
 
 
   int
-  open_context(const xuid_t xclbin_id, unsigned int ip_idx, bool shared)
+  open_context(const xuid_t xclbin_id, unsigned int ip_idx, bool shared) const
   {
     HANDLE deviceHandle = m_dev;
     XOCL_CTX_ARGS ctxArgs = { 0 };
@@ -404,22 +404,10 @@ done:
                          0,
                          &bytesRet,
                          NULL)) {
-
-      auto error = GetLastError();
-      xrt_core::message::
-        send(xrt_core::message::severity_level::error, "XRT", "CTX failed with error %d", error);
-      return error;
+      throw xrt_core::system_error(GetLastError(), "Failed to open ip context");
     }
 
     return 0;
-  }
-
-  int
-  open_context(uint32_t slot, const xuid_t xclbin_id, const char* cuname, bool shared)
-  {
-    // Alveo Windows PCIE does not yet support multiple xclbins.
-    // Call regular flow
-    return open_context(xclbin_id, m_core_device->get_cuidx(slot, cuname).index, shared);
   }
 
   int
@@ -1423,6 +1411,18 @@ done:
         throw std::runtime_error("DeviceIoControl IOCTL_XOCL_STAT (get_kds_custat) failed in retrieving KDS CU info");
   }
 
+  ////////////////////////////////////////////////////////////////
+  // Internal SHIM APIs
+  ////////////////////////////////////////////////////////////////
+  // aka xclOpenContextByName
+  void
+  open_context(uint32_t slot, const xrt::uuid& xclbin_uuid, const std::string& cuname, bool shared) const
+  {
+    // Alveo Windows PCIE does not yet support multiple xclbins.
+    // Call regular flow
+    open_context(xclbin_uuid.get(), m_core_device->get_cuidx(slot, cuname).index, shared);
+  }
+
 }; // struct shim
 
 shim*
@@ -1580,6 +1580,25 @@ get_kds_custat(xclDeviceHandle hdl, char* buffer, DWORD size, int* size_ret)
 }
 } // namespace userpf
 
+////////////////////////////////////////////////////////////////
+// Implementation of internal SHIM APIs
+////////////////////////////////////////////////////////////////
+namespace xrt::shim_int {
+
+void
+open_context(xclDeviceHandle handle, uint32_t slot, const xrt::uuid& xclbin_uuid, const std::string& cuname, bool shared)
+{
+  auto shim = get_shim_object(handle);
+  shim->open_context(slot, xclbin_uuid, cuname, shared);
+}
+
+} // namespace xrt::shim_int
+////////////////////////////////////////////////////////////////
+
+////////////////////////////////////////////////////////////////
+// Implementation of user exposed SHIM APIs
+// This are C level functions
+////////////////////////////////////////////////////////////////
 // Basic
 unsigned int
 xclProbe()
@@ -1753,23 +1772,6 @@ xclOpenContext(xclDeviceHandle handle, const xuid_t xclbinId, unsigned int ipInd
   return (ipIndex == (unsigned int)-1)
 	  ? 0
 	  : shim->open_context(xclbinId, ipIndex, shared);
-}
-
-int
-xclOpenContextByName(xclDeviceHandle handle, uint32_t slot, const xuid_t xclbin_uuid, const char* cuname, bool shared)
-{
-  try {
-    auto shim = get_shim_object(handle);
-    return shim->open_context(slot, xclbin_uuid, cuname, shared);
-  }
-  catch (const xrt_core::error& ex) {
-    xrt_core::send_exception_message(ex.what());
-    return ex.get_code();
-  }
-  catch (const std::exception& ex) {
-    xrt_core::send_exception_message(ex.what());
-    return -ENOENT;
-  }
 }
 
 int

--- a/tests/validate/xcl_iops_test/src/xcl_api_iops.cpp
+++ b/tests/validate/xcl_iops_test/src/xcl_api_iops.cpp
@@ -164,7 +164,7 @@ void fillCmdVector(xclDeviceHandle handle, std::vector<std::shared_ptr<task_info
         cmd.ecmd->data[rsz] = boh_addr >> 32;
 
         cmds.push_back(std::make_shared<task_info>(cmd));
-        /* 
+        /*
          * If it is a small memory bank, allocate buffer might failed in some threads.
          * Thus we use barrier to wait other threads to allocate output
          * and command buffers to make sure each thread can have similar number of commands.
@@ -189,7 +189,7 @@ void runTestThread(arg_t &arg)
     if (arg.dev_str.find(":") == std::string::npos)
         handle = xclOpen(std::stoi(arg.dev_str), "", XCL_QUIET);
     else
-        handle = xclOpenByBDF(arg.dev_str.c_str());
+        handle = xrt::shim_int::open_by_bdf(arg.dev_str);
 
     if (!handle)
         throw std::runtime_error("Could not open device");


### PR DESCRIPTION
#### Problem solved by the commit
Move xclOpenContextByName into xrt::shim_int and implement accordingly.

#### How problem was solved, alternative solutions (if any) and why they were rejected
xrt::shim_int are for internal (no end-user access) C++ shim APIs.
These function will throw on error and will use lower_case() function
name signature to distinguish them from xcl (xrt.h) APIs.

xrt_core::ishim will reference these xrt::shim_int symbols for
corresping xrt_core::device level functionality.

This is prep work for making it easier addition of hardware context APIs.