### PR TITLE
Complete plumbing of pcie/linux hw_em shim for HW context

### DIFF
--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/device_hwemu.h
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/device_hwemu.h
@@ -20,6 +20,8 @@
 #include "core/common/ishim.h"
 #include "core/pcie/common/device_pcie.h"
 
+#include "shim_int.h"
+
 namespace xrt_core { namespace hwemu {
 
 // concrete class derives from device_edge, but mixes in
@@ -33,6 +35,24 @@ private:
   // Private look up function for concrete query::request
   virtual const query::request&
   lookup_query(query::key_type query_key) const;
+
+  uint32_t // ctx handle aka slotidx
+  create_hw_context(const xrt::uuid& xclbin_uuid, uint32_t qos) const override
+  {
+    return xrt::shim_int::create_hw_context(get_device_handle(), xclbin_uuid, qos);
+  }
+
+  void
+  destroy_hw_context(uint32_t ctxhdl) const override
+  {
+    xrt::shim_int::destroy_hw_context(get_device_handle(), ctxhdl);
+  }
+
+  void
+  register_xclbin(const xrt::xclbin& xclbin) const override
+  {
+    xrt::shim_int::register_xclbin(get_device_handle(), xclbin);
+  }
 };
 
 }} // hwemu, xrt_core

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/halapi.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/halapi.cxx
@@ -48,6 +48,27 @@ open_context(xclDeviceHandle handle, uint32_t slot, const xrt::uuid& xclbin_uuid
   // shim->open_context(slot, xclbin_uuid, cuname, shared);
 }
 
+uint32_t // ctxhdl aka slotidx
+create_hw_context(xclDeviceHandle handle, const xrt::uuid& xclbin_uuid, uint32_t qos)
+{
+  auto shim = get_shim_object(handle);
+  return shim->create_hw_context(xclbin_uuid, qos);
+}
+
+void
+destroy_hw_context(xclDeviceHandle handle, uint32_t ctxhdl)
+{
+  auto shim = get_shim_object(handle);
+  shim->destroy_hw_context(ctxhdl);
+}
+
+void
+register_xclbin(xclDeviceHandle handle, const xrt::xclbin& xclbin)
+{
+  auto shim = get_shim_object(handle);
+  shim->register_xclbin(xclbin);
+}
+
 } // xrt::shim_int
 
 

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
@@ -3169,6 +3169,56 @@ int HwEmShim::xclExecWait(int timeoutMilliSec)
   return 1;
 }
 
+////////////////////////////////////////////////////////////////
+// Context handling
+////////////////////////////////////////////////////////////////
+int
+HwEmShim::
+xclOpenContext(const uuid_t xclbinId, unsigned int ipIndex, bool shared) const
+{
+  return 0; // success
+}
+
+// aka xclOpenContextByName, internal shim API for native C++ applications only
+// Once properly implemented, this API should throw on error
+void
+HwEmShim::
+open_context(uint32_t slot, const xrt::uuid& xclbin_uuid, const std::string& cuname, bool shared) const
+{
+  xclOpenContext(xclbin_uuid.get(), mCoreDevice->get_cuidx(slot, cuname).index, shared);
+}
+
+// aka xclCreateHWContext, internal shim API for native C++ applications only
+// Once properly implemented, this API should throw on error
+uint32_t // ctx handle aka slot idx
+HwEmShim::
+create_hw_context(const xrt::uuid& xclbin_uuid, uint32_t qos) const
+{
+  // Explicit hardware contexts are not yet supported
+  throw xrt_core::ishim::not_supported_error{__func__};
+}
+
+// aka xclDestroyHWContext, internal shim API for native C++ applications only
+// Once properly implemented, this API should throw on error
+void
+HwEmShim::
+destroy_hw_context(uint32_t ctxhdl) const
+{
+  // Explicit hardware contexts are not yet supported
+  throw xrt_core::ishim::not_supported_error{__func__};
+}
+
+// aka xclRegisterXclbin, internal shim API for native C++ applications only
+// Once properly implemented, this API should throw on error
+void
+HwEmShim::
+register_xclbin(const xrt::xclbin&) const
+{
+  // Explicit hardware contexts are not yet supported
+  throw xrt_core::ishim::not_supported_error{__func__};
+}
+////////////////////////////////////////////////////////////////
+
 ssize_t HwEmShim::xclUnmgdPwrite(unsigned flags, const void *buf, size_t count, uint64_t offset)
 {
   if (flags)

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.h
@@ -126,14 +126,37 @@ using addr_type = uint64_t;
       static int xcl_LogMsg(xrtLogMsgLevel level, const char* tag, const char* format, ...);
       static int xclLogMsg(xrtLogMsgLevel level, const char* tag, const char* format, va_list args1);
 
-      //P2P Support
+      // P2P Support
       int xclExportBO(unsigned int boHandle);
       unsigned int xclImportBO(int boGlobalHandle, unsigned flags);
       int xclCopyBO(unsigned int dst_boHandle, unsigned int src_boHandle, size_t size, size_t dst_offset, size_t src_offset);
 
-      //MB scheduler related API's
+      // MB scheduler related API's
       int xclExecBuf( unsigned int cmdBO);
       int xclExecBuf(unsigned int cmdBO, size_t num_bo_in_wait_list, unsigned int *bo_wait_list);
+
+      ////////////////////////////////////////////////////////////////
+      // Context handling
+      ////////////////////////////////////////////////////////////////
+      int
+      xclOpenContext(const uuid_t xclbinId, unsigned int ipIndex, bool shared) const;
+
+      // aka xclOpenContextByName, internal shim API for native C++ applications only
+      void
+      open_context(uint32_t slot, const xrt::uuid& xclbin_uuid, const std::string& cuname, bool shared) const;
+
+      // aka xclCreateHWContext, internal shim API for native C++ applications only
+      uint32_t // ctx handle aka slot idx
+      create_hw_context(const xrt::uuid& xclbin_uuid, uint32_t qos) const;
+
+      // aka xclDestroyHWContext, internal shim API for native C++ applications only
+      void
+      destroy_hw_context(uint32_t ctxhdl) const;
+
+      // aka xclRegisterXclbin, internal shim API for native C++ applications only
+      void
+      register_xclbin(const xrt::xclbin&) const;
+      ////////////////////////////////////////////////////////////////
 
       int xclRegisterEventNotify( unsigned int userInterrupt, int fd);
       int xclExecWait( int timeoutMilliSec);

--- a/src/runtime_src/core/pcie/linux/device_linux.h
+++ b/src/runtime_src/core/pcie/linux/device_linux.h
@@ -47,7 +47,7 @@ public:
   ////////////////////////////////////////////////////////////////
   xclInterruptNotifyHandle
   open_ip_interrupt_notify(unsigned int ip_index) override;
-  
+
   void
   close_ip_interrupt_notify(xclInterruptNotifyHandle handle) override;
 
@@ -65,6 +65,24 @@ public:
 
   xclBufferHandle
   import_bo(pid_t pid, xclBufferExportHandle ehdl) override;
+
+  uint32_t // ctx handle aka slotidx
+  create_hw_context(const xrt::uuid& xclbin_uuid, uint32_t qos) const override
+  {
+    return xrt::shim_int::create_hw_context(get_device_handle(), xclbin_uuid, qos);
+  }
+
+  void
+  destroy_hw_context(uint32_t ctxhdl) const override
+  {
+    xrt::shim_int::destroy_hw_context(get_device_handle(), ctxhdl);
+  }
+
+  void
+  register_xclbin(const xrt::xclbin& xclbin) const override
+  {
+    xrt::shim_int::register_xclbin(get_device_handle(), xclbin);
+  }
   ////////////////////////////////////////////////////////////////
 
 private:

--- a/src/runtime_src/core/pcie/linux/shim.h
+++ b/src/runtime_src/core/pcie/linux/shim.h
@@ -38,178 +38,188 @@ const uint64_t mNullBO = 0xffffffff;
 class shim
 {
 public:
-    ~shim();
-    shim(unsigned index);
-    void init(unsigned index);
+  ~shim();
+  shim(unsigned index);
+  void init(unsigned index);
 
-    // Raw unmanaged read/write on the entire PCIE user BAR
-    size_t xclWrite(xclAddressSpace space, uint64_t offset, const void *hostBuf, size_t size);
-    size_t xclRead(xclAddressSpace space, uint64_t offset, void *hostBuf, size_t size);
-    // Restricted read/write on IP register space
-    int xclRegWrite(uint32_t ipIndex, uint32_t offset, uint32_t data);
-    int xclRegRead(uint32_t ipIndex, uint32_t offset, uint32_t *datap);
+  // Raw unmanaged read/write on the entire PCIE user BAR
+  size_t xclWrite(xclAddressSpace space, uint64_t offset, const void *hostBuf, size_t size);
+  size_t xclRead(xclAddressSpace space, uint64_t offset, void *hostBuf, size_t size);
+  // Restricted read/write on IP register space
+  int xclRegWrite(uint32_t ipIndex, uint32_t offset, uint32_t data);
+  int xclRegRead(uint32_t ipIndex, uint32_t offset, uint32_t *datap);
 
-    unsigned int xclAllocBO(size_t size, int unused, unsigned flags);
-    unsigned int xclAllocUserPtrBO(void *userptr, size_t size, unsigned flags);
-    void xclFreeBO(unsigned int boHandle);
-    int xclWriteBO(unsigned int boHandle, const void *src, size_t size, size_t seek);
-    int xclReadBO(unsigned int boHandle, void *dst, size_t size, size_t skip);
-    void *xclMapBO(unsigned int boHandle, bool write);
-    int xclUnmapBO(unsigned int boHandle, void* addr);
-    int xclSyncBO(unsigned int boHandle, xclBOSyncDirection dir, size_t size, size_t offset);
-    int xclCopyBO(unsigned int dst_boHandle, unsigned int src_boHandle, size_t size,
-                  size_t dst_offset, size_t src_offset);
+  unsigned int xclAllocBO(size_t size, int unused, unsigned flags);
+  unsigned int xclAllocUserPtrBO(void *userptr, size_t size, unsigned flags);
+  void xclFreeBO(unsigned int boHandle);
+  int xclWriteBO(unsigned int boHandle, const void *src, size_t size, size_t seek);
+  int xclReadBO(unsigned int boHandle, void *dst, size_t size, size_t skip);
+  void *xclMapBO(unsigned int boHandle, bool write);
+  int xclUnmapBO(unsigned int boHandle, void* addr);
+  int xclSyncBO(unsigned int boHandle, xclBOSyncDirection dir, size_t size, size_t offset);
+  int xclCopyBO(unsigned int dst_boHandle, unsigned int src_boHandle, size_t size,
+                size_t dst_offset, size_t src_offset);
 
-    int xclUpdateSchedulerStat();
+  int xclUpdateSchedulerStat();
 
-    int xclExportBO(unsigned int boHandle);
-    unsigned int xclImportBO(int fd, unsigned flags);
-    int xclGetBOProperties(unsigned int boHandle, xclBOProperties *properties);
+  int xclExportBO(unsigned int boHandle);
+  unsigned int xclImportBO(int fd, unsigned flags);
+  int xclGetBOProperties(unsigned int boHandle, xclBOProperties *properties);
 
-    // Bitstream/bin download
-    int xclLoadXclBin(const xclBin *buffer);
-    int xclGetErrorStatus(xclErrorStatus *info);
-    int xclGetDeviceInfo2(xclDeviceInfo2 *info);
-    bool isGood() const;
-    static shim *handleCheck(void * handle);
-    int resetDevice(xclResetKind kind);
-    int p2pEnable(bool enable, bool force);
-    int cmaEnable(bool enable, uint64_t size);
-    bool xclLockDevice();
-    bool xclUnlockDevice();
-    int xclReClock2(unsigned short region, const unsigned short *targetFreqMHz);
-    int xclGetUsageInfo(xclDeviceUsage *info);
+  // Bitstream/bin download
+  int xclLoadXclBin(const xclBin *buffer);
+  int xclGetErrorStatus(xclErrorStatus *info);
+  int xclGetDeviceInfo2(xclDeviceInfo2 *info);
+  bool isGood() const;
+  static shim *handleCheck(void * handle);
+  int resetDevice(xclResetKind kind);
+  int p2pEnable(bool enable, bool force);
+  int cmaEnable(bool enable, uint64_t size);
+  bool xclLockDevice();
+  bool xclUnlockDevice();
+  int xclReClock2(unsigned short region, const unsigned short *targetFreqMHz);
+  int xclGetUsageInfo(xclDeviceUsage *info);
 
-    int xclTestXSpi(int device_index);
-    int xclBootFPGA();
-    int xclRemoveAndScanFPGA();
+  int xclTestXSpi(int device_index);
+  int xclBootFPGA();
+  int xclRemoveAndScanFPGA();
 
-    ssize_t xclUnmgdPwrite(unsigned flags, const void *buf, size_t count, uint64_t offset);
-    ssize_t xclUnmgdPread(unsigned flags, void *buf, size_t count, uint64_t offset);
+  ssize_t xclUnmgdPwrite(unsigned flags, const void *buf, size_t count, uint64_t offset);
+  ssize_t xclUnmgdPread(unsigned flags, void *buf, size_t count, uint64_t offset);
 
-    int xclGetSectionInfo(void *section_info, size_t *section_size, enum axlf_section_kind, int index);
+  int xclGetSectionInfo(void *section_info, size_t *section_size, enum axlf_section_kind, int index);
 
-    double xclGetDeviceClockFreqMHz();
-    double xclGetHostReadMaxBandwidthMBps();
-    double xclGetHostWriteMaxBandwidthMBps();
-    double xclGetKernelReadMaxBandwidthMBps();
-    double xclGetKernelWriteMaxBandwidthMBps();
-    //debug related
-    uint32_t getCheckerNumberSlots(int type);
-    uint32_t getIPCountAddrNames(int type, uint64_t *baseAddress, std::string * portNames,
-                                    uint8_t *properties, uint8_t *majorVersions, uint8_t *minorVersions,
-                                    size_t size);
-    size_t xclDebugReadCounters(xclDebugCountersResults* debugResult);
-    size_t xclDebugReadCheckers(xclDebugCheckersResults* checkerResult);
-    size_t xclDebugReadStreamingCounters(xclStreamingDebugCountersResults* streamingResult);
-    size_t xclDebugReadStreamingCheckers(xclDebugStreamingCheckersResults* streamingCheckerResult);
-    size_t xclDebugReadAccelMonitorCounters(xclAccelMonitorCounterResults* samResult);
+  double xclGetDeviceClockFreqMHz();
+  double xclGetHostReadMaxBandwidthMBps();
+  double xclGetHostWriteMaxBandwidthMBps();
+  double xclGetKernelReadMaxBandwidthMBps();
+  double xclGetKernelWriteMaxBandwidthMBps();
+  //debug related
+  uint32_t getCheckerNumberSlots(int type);
+  uint32_t getIPCountAddrNames(int type, uint64_t *baseAddress, std::string * portNames,
+                               uint8_t *properties, uint8_t *majorVersions, uint8_t *minorVersions,
+                               size_t size);
+  size_t xclDebugReadCounters(xclDebugCountersResults* debugResult);
+  size_t xclDebugReadCheckers(xclDebugCheckersResults* checkerResult);
+  size_t xclDebugReadStreamingCounters(xclStreamingDebugCountersResults* streamingResult);
+  size_t xclDebugReadStreamingCheckers(xclDebugStreamingCheckersResults* streamingCheckerResult);
+  size_t xclDebugReadAccelMonitorCounters(xclAccelMonitorCounterResults* samResult);
 
-    // APIs using sysfs information
-    uint32_t xclGetNumLiveProcesses();
-    int xclGetSysfsPath(const char* subdev, const char* entry, char* sysfsPath, size_t size);
+  // APIs using sysfs information
+  uint32_t xclGetNumLiveProcesses();
+  int xclGetSysfsPath(const char* subdev, const char* entry, char* sysfsPath, size_t size);
 
-    /* Enable/disable CMA chunk with specific size
-     * e.g. enable = true, sz = 0x100000 (2M): add 2M CMA chunk
-     *      enable = false: remove CMA chunk
-     */
-    int xclCmaEnable(xclDeviceHandle handle, bool enable, uint64_t total_size);
+  /* Enable/disable CMA chunk with specific size
+   * e.g. enable = true, sz = 0x100000 (2M): add 2M CMA chunk
+   *      enable = false: remove CMA chunk
+   */
+  int xclCmaEnable(xclDeviceHandle handle, bool enable, uint64_t total_size);
 
-    int xclGetDebugIPlayoutPath(char* layoutPath, size_t size);
-    int xclGetSubdevPath(const char* subdev, uint32_t idx, char* path, size_t size);
-    int xclGetTraceBufferInfo(uint32_t nSamples, uint32_t& traceSamples, uint32_t& traceBufSz);
-    int xclReadTraceData(void* traceBuf, uint32_t traceBufSz, uint32_t numSamples, uint64_t ipBaseAddress, uint32_t& wordsPerSample);
+  int xclGetDebugIPlayoutPath(char* layoutPath, size_t size);
+  int xclGetSubdevPath(const char* subdev, uint32_t idx, char* path, size_t size);
+  int xclGetTraceBufferInfo(uint32_t nSamples, uint32_t& traceSamples, uint32_t& traceBufSz);
+  int xclReadTraceData(void* traceBuf, uint32_t traceBufSz, uint32_t numSamples, uint64_t ipBaseAddress, uint32_t& wordsPerSample);
 
-    // Experimental debug profile device data API
-    int xclGetDebugProfileDeviceInfo(xclDebugProfileDeviceInfo* info);
+  // Experimental debug profile device data API
+  int xclGetDebugProfileDeviceInfo(xclDebugProfileDeviceInfo* info);
 
-    // Execute and interrupt abstraction
-    int xclExecBuf(unsigned int cmdBO);
-    int xclExecBuf(unsigned int cmdBO,size_t numdeps, unsigned int* bo_wait_list);
-    int xclRegisterEventNotify(unsigned int userInterrupt, int fd);
-    int xclExecWait(int timeoutMilliSec);
-    int xclOpenContext(const uuid_t xclbinId, unsigned int ipIndex, bool shared) const;
-    int xclCloseContext(const uuid_t xclbinId, unsigned int ipIndex);
+  // Execute and interrupt abstraction
+  int xclExecBuf(unsigned int cmdBO);
+  int xclExecBuf(unsigned int cmdBO,size_t numdeps, unsigned int* bo_wait_list);
+  int xclRegisterEventNotify(unsigned int userInterrupt, int fd);
+  int xclExecWait(int timeoutMilliSec);
+  int xclOpenContext(const uuid_t xclbinId, unsigned int ipIndex, bool shared) const;
+  int xclCloseContext(const uuid_t xclbinId, unsigned int ipIndex);
 
-    int getBoardNumber( void ) { return mBoardNumber; }
+  int getBoardNumber( void ) { return mBoardNumber; }
 
-    int xclIPName2Index(const char *name);
+  int xclIPName2Index(const char *name);
 
-    int xclOpenIPInterruptNotify(uint32_t ipIndex, unsigned int flags);
-    int xclCloseIPInterruptNotify(int fd);
+  int xclOpenIPInterruptNotify(uint32_t ipIndex, unsigned int flags);
+  int xclCloseIPInterruptNotify(int fd);
 
-    ////////////////////////////////////////////////////////////////
-    // Internal SHIM APIs
-    ////////////////////////////////////////////////////////////////
-    // aka xclOpenContextByName
-    void
-    open_context(uint32_t slot, const xrt::uuid& xclbin_uuid, const std::string& cuname, bool shared) const;
+  ////////////////////////////////////////////////////////////////
+  // Internal SHIM APIs
+  ////////////////////////////////////////////////////////////////
+  // aka xclOpenContextByName
+  void
+  open_context(uint32_t slot, const xrt::uuid& xclbin_uuid, const std::string& cuname, bool shared) const;
+
+  uint32_t // ctx handle aka slot idx
+  create_hw_context(const xrt::uuid& xclbin_uuid, uint32_t qos) const;
+
+  void
+  destroy_hw_context(uint32_t ctxhdl) const;
+
+  // Registers an xclbin, but does not load it.
+  void
+  register_xclbin(const xrt::xclbin&) const;
 
 private:
-    std::shared_ptr<xrt_core::device> mCoreDevice;
-    std::shared_ptr<pcidev::pci_device> mDev;
-    std::ofstream mLogStream;
-    int mUserHandle;
-    int mStreamHandle;
-    int mBoardNumber;
-    uint64_t mOffsets[XCL_ADDR_SPACE_MAX];
-    xclDeviceInfo2 mDeviceInfo;
-    uint32_t mMemoryProfilingNumberSlots;
-    uint32_t mAccelProfilingNumberSlots;
-    uint32_t mStallProfilingNumberSlots;
-    uint32_t mStreamProfilingNumberSlots;
-    std::string mDevUserName;
-    std::unique_ptr<xrt_core::bo_cache> mCmdBOCache;
+  std::shared_ptr<xrt_core::device> mCoreDevice;
+  std::shared_ptr<pcidev::pci_device> mDev;
+  std::ofstream mLogStream;
+  int mUserHandle;
+  int mStreamHandle;
+  int mBoardNumber;
+  uint64_t mOffsets[XCL_ADDR_SPACE_MAX];
+  xclDeviceInfo2 mDeviceInfo;
+  uint32_t mMemoryProfilingNumberSlots;
+  uint32_t mAccelProfilingNumberSlots;
+  uint32_t mStallProfilingNumberSlots;
+  uint32_t mStreamProfilingNumberSlots;
+  std::string mDevUserName;
+  std::unique_ptr<xrt_core::bo_cache> mCmdBOCache;
 
-    /*
-     * Mapped CU register space for xclRegRead/Write(). We support at most
-     * 128 CUs and each CU map is a pair <address, size>.
-     */
-    std::vector<std::pair<uint32_t*, uint32_t>> mCuMaps;
-    std::mutex mCuMapLock;
+  /*
+   * Mapped CU register space for xclRegRead/Write(). We support at most
+   * 128 CUs and each CU map is a pair <address, size>.
+   */
+  std::vector<std::pair<uint32_t*, uint32_t>> mCuMaps;
+  std::mutex mCuMapLock;
 
-    bool zeroOutDDR();
-    bool isXPR() const {
-        return ((mDeviceInfo.mSubsystemId >> 12) == 4);
-    }
+  bool zeroOutDDR();
+  bool isXPR() const {
+    return ((mDeviceInfo.mSubsystemId >> 12) == 4);
+  }
 
-    int dev_init();
-    void dev_fini();
+  int dev_init();
+  void dev_fini();
 
-    int xclLoadAxlf(const axlf *buffer);
-    void xclSysfsGetDeviceInfo(xclDeviceInfo2 *info);
-    void xclSysfsGetUsageInfo(drm_xocl_usage_stat& stat);
-    void xclSysfsGetErrorStatus(xclErrorStatus& stat);
+  int xclLoadAxlf(const axlf *buffer);
+  void xclSysfsGetDeviceInfo(xclDeviceInfo2 *info);
+  void xclSysfsGetUsageInfo(drm_xocl_usage_stat& stat);
+  void xclSysfsGetErrorStatus(xclErrorStatus& stat);
 
-    int freezeAXIGate();
-    int freeAXIGate();
+  int freezeAXIGate();
+  int freeAXIGate();
 
-    int xclRegRW(bool rd, uint32_t ipIndex, uint32_t offset, uint32_t *datap);
+  int xclRegRW(bool rd, uint32_t ipIndex, uint32_t offset, uint32_t *datap);
 
-    bool readPage(unsigned addr, uint8_t readCmd = 0xff);
-    bool writePage(unsigned addr, uint8_t writeCmd = 0xff);
-    unsigned readReg(unsigned offset);
-    int writeReg(unsigned regOffset, unsigned value);
-    bool finalTransfer(uint8_t *sendBufPtr, uint8_t *recvBufPtr, int byteCount);
-    bool getFlashId();
-    //All remaining read /write register commands can be issued through this function.
-    bool readRegister(unsigned commandCode, unsigned bytes);
-    bool writeRegister(unsigned commandCode, unsigned value, unsigned bytes);
-    bool select4ByteAddressMode();
-    bool deSelect4ByteAddressMode();
+  bool readPage(unsigned addr, uint8_t readCmd = 0xff);
+  bool writePage(unsigned addr, uint8_t writeCmd = 0xff);
+  unsigned readReg(unsigned offset);
+  int writeReg(unsigned regOffset, unsigned value);
+  bool finalTransfer(uint8_t *sendBufPtr, uint8_t *recvBufPtr, int byteCount);
+  bool getFlashId();
+  //All remaining read /write register commands can be issued through this function.
+  bool readRegister(unsigned commandCode, unsigned bytes);
+  bool writeRegister(unsigned commandCode, unsigned value, unsigned bytes);
+  bool select4ByteAddressMode();
+  bool deSelect4ByteAddressMode();
 
-    // Performance monitoring helper functions
-    signed cmpMonVersions(unsigned major1, unsigned minor1, unsigned major2, unsigned minor2);
+  // Performance monitoring helper functions
+  signed cmpMonVersions(unsigned major1, unsigned minor1, unsigned major2, unsigned minor2);
 
-    // QDMA AIO
-    aio_context_t mAioContext;
-    bool mAioEnabled;
+  // QDMA AIO
+  aio_context_t mAioContext;
+  bool mAioEnabled;
 
-    /* CopyBO helpers */
-    int execbufCopyBO(unsigned int dst_boHandle, unsigned int src_boHandle, size_t size,
-                  size_t dst_offset, size_t src_offset);
-    int m2mCopyBO(unsigned int dst_boHandle, unsigned int src_boHandle, size_t size,
-                  size_t dst_offset, size_t src_offset);
+  /* CopyBO helpers */
+  int execbufCopyBO(unsigned int dst_boHandle, unsigned int src_boHandle, size_t size,
+                    size_t dst_offset, size_t src_offset);
+  int m2mCopyBO(unsigned int dst_boHandle, unsigned int src_boHandle, size_t size,
+                size_t dst_offset, size_t src_offset);
 }; /* shim */
 
 } /* xocl */


### PR DESCRIPTION
#### Problem solved by the commit
Add stubs for create/destroy_hw_context and register_xclbin.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Complete the plumbing for APIs required for hardware context.  The functions are stubbed out
in this PR.  To be implemented later.