### PR TITLE
Reinit of structure sensor_data while using it causing functionality break on versal

### DIFF
--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -149,7 +149,7 @@ struct sdm_sensor_info
     std::array<std::string, 6> sname_end = {"label", "input", "max", "average", "highest", "status"};
     int max_end_types = sname_end.size();
     std::string errmsg, str_op, target_snode;
-    data_type data = { 0 };
+    data_type data;
     uint32_t uint_op = 0;
 
     //Starting from index 0 in sname_end array, read and store all the sysfs nodes information

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -149,7 +149,9 @@ struct sdm_sensor_info
     std::array<std::string, 6> sname_end = {"label", "input", "max", "average", "highest", "status"};
     int max_end_types = sname_end.size();
     std::string errmsg, str_op, target_snode;
-    data_type data;
+    // data_type has default constructor that initializes data members appropriately,
+    // So, don't use "= {0}", it can only be used for fundamental types.
+    data_type data {};
     uint32_t uint_op = 0;
 
     //Starting from index 0 in sname_end array, read and store all the sysfs nodes information


### PR DESCRIPTION
structure sensor_data is already initialized with defaults during its declaration. Also, data_type has default constructor that initializes data members appropriately, so use "= {0}" for fundamental types only.
Due to assigning of 0 to data_type, next line is not getting executed and hence xbutil reports data is not displaying properly on vck5000 platform. This issue is introduced with PR #6602 .
Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Seeing no proper electrical output in xbutil reports on vck5000. Tried "xbutil examine -r electrical -d" -> shows no electrical info.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
This issue identified while validating vck5000 features using latest XRT package. It is a regression due to PR #6602.
#### How problem was solved, alternative solutions (if any) and why they were rejected
Added changes to fix this issue. Reinit of structure sensor_data causing this issue. This code was introduced as part of PR #6602

#### Risks (if any) associated the changes in the commit
NA
#### What has been tested and how, request additional testing if necessary
xbutil examine reports.
#### Documentation impact (if any)
NA