### PR TITLE
Fix a warning

### DIFF
--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
@@ -994,7 +994,7 @@ namespace xclcpuemhal2 {
       return -EINVAL;
 
     const unsigned REG_BUFF_SIZE = 0x4;
-    std::array<char, REG_BUFF_SIZE> buff;
+    std::array<char, REG_BUFF_SIZE> buff = {};
     uint64_t baseAddr = cuidx2addr[cu_index];
     if (rd) {
       size_t size=4;


### PR DESCRIPTION
I prevented the warning from appearing but it is likely a real bug. since `xclRegRead_RPC_CALL` will not write anything to the buffer in case of error so `*datap = tmp_buff[0];` was reading uninitialized data in that case before this patch.

@stsoe is it possible to stop forcing to compile with -Werror. because it makes XRT depend on a specific compiler version. which makes it harder to compile XRT anywhere. warnings should be fixed but often like here the person facing the issue is not the one able to fixe the fundamental issue.