### PR TITLE
CR-1130359 xmc: don't append units(W or C) for temp & power sysfs readings

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
@@ -1957,7 +1957,7 @@ static ssize_t scaling_threshold_power_override_show(struct device *dev,
 	}
 	mutex_unlock(&xmc->xmc_lock);
 
-	return sprintf(buf, "%uW\n", val);
+	return sprintf(buf, "%u\n", val);
 }
 
 static ssize_t scaling_threshold_power_override_store(struct device *dev,
@@ -2049,7 +2049,7 @@ static ssize_t scaling_critical_temp_threshold_show(struct device *dev,
 		return sprintf(buf, "N/A\n");
 	}
 
-	return sprintf(buf, "%uC\n", val);
+	return sprintf(buf, "%u\n", val);
 }
 static DEVICE_ATTR_RO(scaling_critical_temp_threshold);
 
@@ -2072,7 +2072,7 @@ static ssize_t scaling_threshold_temp_limit_show(struct device *dev,
 		val = xmc_get_threshold_temp(xmc);
 	}
 
-	return sprintf(buf, "%uC\n", val);
+	return sprintf(buf, "%u\n", val);
 }
 static DEVICE_ATTR_RO(scaling_threshold_temp_limit);
 
@@ -2095,7 +2095,7 @@ static ssize_t scaling_threshold_power_limit_show(struct device *dev,
 		val = xmc_get_threshold_power(xmc);
 	}
 
-	return sprintf(buf, "%uW\n", val);
+	return sprintf(buf, "%u\n", val);
 }
 static DEVICE_ATTR_RO(scaling_threshold_power_limit);
 
@@ -2142,7 +2142,7 @@ static ssize_t scaling_threshold_temp_override_show(struct device *dev,
 	}
 	mutex_unlock(&xmc->xmc_lock);
 
-	return sprintf(buf, "%uC\n", val);
+	return sprintf(buf, "%u\n", val);
 }
 
 static ssize_t scaling_threshold_temp_override_store(struct device *dev,
@@ -2324,7 +2324,7 @@ static ssize_t hwmon_scaling_target_power_show(struct device *dev,
 	val = val * 1000000;
 	mutex_unlock(&xmc->xmc_lock);
 
-	return sprintf(buf, "%uW\n", val);
+	return sprintf(buf, "%u\n", val);
 }
 
 static ssize_t hwmon_scaling_target_power_store(struct device *dev,
@@ -2380,7 +2380,7 @@ static ssize_t hwmon_scaling_target_temp_show(struct device *dev,
 	val = val * 1000;
 	mutex_unlock(&xmc->xmc_lock);
 
-	return sprintf(buf, "%uc\n", val);
+	return sprintf(buf, "%u\n", val);
 }
 
 static ssize_t hwmon_scaling_target_temp_store(struct device *dev,
@@ -2443,7 +2443,7 @@ static ssize_t hwmon_scaling_threshold_temp_show(struct device *dev,
 	val = val * 1000;
 	mutex_unlock(&xmc->xmc_lock);
 
-	return sprintf(buf, "%uC\n", val);
+	return sprintf(buf, "%u\n", val);
 }
 
 static ssize_t hwmon_scaling_threshold_power_show(struct device *dev,
@@ -2471,7 +2471,7 @@ static ssize_t hwmon_scaling_threshold_power_show(struct device *dev,
 	val = val * 1000000;
 	mutex_unlock(&xmc->xmc_lock);
 
-	return sprintf(buf, "%uW\n", val);
+	return sprintf(buf, "%u\n", val);
 }
 
 static ssize_t reg_base_show(struct device *dev,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc_u2.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc_u2.c
@@ -2182,7 +2182,7 @@ static ssize_t hwmon_scaling_target_power_show(struct device *dev,
 	val = val * 1000000;
 	mutex_unlock(&xmc->xmc_lock);
 
-	return sprintf(buf, "%uW\n", val);
+	return sprintf(buf, "%u\n", val);
 }
 
 static ssize_t hwmon_scaling_target_power_store(struct device *dev,
@@ -2238,7 +2238,7 @@ static ssize_t hwmon_scaling_target_temp_show(struct device *dev,
 	val = val * 1000;
 	mutex_unlock(&xmc->xmc_lock);
 
-	return sprintf(buf, "%uc\n", val);
+	return sprintf(buf, "%u\n", val);
 }
 
 static ssize_t hwmon_scaling_target_temp_store(struct device *dev,
@@ -2301,7 +2301,7 @@ static ssize_t hwmon_scaling_threshold_temp_show(struct device *dev,
 	val = val * 1000;
 	mutex_unlock(&xmc->xmc_lock);
 
-	return sprintf(buf, "%uC\n", val);
+	return sprintf(buf, "%u\n", val);
 }
 
 static ssize_t hwmon_scaling_threshold_power_show(struct device *dev,
@@ -2329,7 +2329,7 @@ static ssize_t hwmon_scaling_threshold_power_show(struct device *dev,
 	val = val * 1000000;
 	mutex_unlock(&xmc->xmc_lock);
 
-	return sprintf(buf, "%uW\n", val);
+	return sprintf(buf, "%u\n", val);
 }
 
 static ssize_t reg_base_show(struct device *dev,


### PR DESCRIPTION
Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
CR-1130359 due to unit appended to temp/power sysfs readings, xbmgmt dump command dumps the values followed units. The same config file can't be used directly in the configuration command. One has to remove units and then try.
Also, cmc report shows units twice due to this issue as well.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Removed units while printing the temp/power values through sysfs.
#### How problem was solved, alternative solutions (if any) and why they were rejected
Added changes in XRT XMC driver.
#### Risks (if any) associated the changes in the commit
NA
#### What has been tested and how, request additional testing if necessary
xbmgmt dump & xbmgmt config commands.
#### Documentation impact (if any)
NA