### PR TITLE
CR-1129295 ASTeR TS29.03 + 29.04 - u200, u250 - Correctable Error not detected after manual injection

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -2309,8 +2309,6 @@ static int __icap_download_bitstream_user(struct platform_device *pdev,
 		DEBUG_IP_LAYOUT);
 	icap_cache_clock_freq_topology(icap, xclbin);
 
-	icap_create_subdev_ip_layout(pdev);
-
 	/* Create cu/scu subdev by slot */
 	err = xocl_register_cus(xdev, 0, &xclbin->m_header.uuid,
 				icap->ip_layout, icap->ps_kernel);
@@ -2338,6 +2336,7 @@ done:
 	if (err) {
 		uuid_copy(&icap->icap_bitstream_uuid, &uuid_null);
 	} else {
+		icap_create_subdev_ip_layout(pdev);
 		/* Remember "this" bitstream, so avoid re-download next time. */
 		uuid_copy(&icap->icap_bitstream_uuid, &xclbin->m_header.uuid);
 	}


### PR DESCRIPTION
#### Problem solved by the commit
Create mig sub device with wrong memory topology information.

XRT should create the mig sub-device based on the latest cached memory topology, 

however, PR 5986 moved the logic after the point where we create the mig sub device. 

So XRT can't create the mig sub-device because it can't find the memory topology.

or It'll create the wrong sub-device based on wrong memory topology metadata


#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://github.com/Xilinx/XRT/pull/5968
