### PR TITLE
Enable 64 bit aie trace delay using daisy chained counters

### DIFF
--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -351,7 +351,7 @@ get_aie_trace()
 inline bool
 get_aie_trace_flush()
 {
-  static bool value = detail::get_bool_value("Debug.aie_trace_flush", true);
+  static bool value = detail::get_bool_value("Debug.aie_trace_flush", false);
   return value;
 }
 

--- a/src/runtime_src/xdp/profile/device/tracedefs.h
+++ b/src/runtime_src/xdp/profile/device/tracedefs.h
@@ -93,6 +93,7 @@ constexpr unsigned int BITS_PER_WORD = 32;
 constexpr unsigned int BYTES_PER_WORD = 4;
 constexpr unsigned int BYTES_64BIT = 8;
 constexpr unsigned int BYTES_128BIT = 16;
+constexpr uint32_t MAX_COUNT_32BIT = 0xffffffff;
 
 }
 

--- a/src/runtime_src/xdp/profile/device/tracedefs.h
+++ b/src/runtime_src/xdp/profile/device/tracedefs.h
@@ -93,7 +93,6 @@ constexpr unsigned int BITS_PER_WORD = 32;
 constexpr unsigned int BYTES_PER_WORD = 4;
 constexpr unsigned int BYTES_64BIT = 8;
 constexpr unsigned int BYTES_128BIT = 16;
-constexpr uint32_t MAX_COUNT_32BIT = 0xffffffff;
 
 }
 

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -105,11 +105,6 @@ namespace xdp {
       }
     }
 
-    // Set Delay parameters
-    // Update delay with clock cycles when we get device handle later
-    mDelayCycles = static_cast<uint32_t>(getTraceStartDelayCycles(nullptr));
-    mUseDelay = (mDelayCycles > 0) ? true : false;
-
     // Pre-defined metric sets
     metricSets = {"functions", "functions_partial_stalls", "functions_all_stalls", "all"};
     
@@ -152,9 +147,6 @@ namespace xdp {
     //         to produce events before hitting the bug. For example, sync packets 
     //         occur after 1024 cycles and with no events, is incorrectly repeated.
     auto counterScheme = xrt_core::config::get_aie_trace_counter_scheme();
-    // ES1 is more stable for delay usecase
-    if (mUseDelay)
-      counterScheme = "es1";
 
     if (counterScheme == "es1") {
       coreCounterStartEvents   = {XAIE_EVENT_ACTIVE_CORE,             XAIE_EVENT_ACTIVE_CORE};
@@ -185,7 +177,7 @@ namespace xdp {
 
     //Process the file dump interval
     aie_trace_file_dump_int_s = xrt_core::config::get_aie_trace_file_dump_interval_s();
-    if (aie_trace_file_dump_int_s < MIN_TRACE_DUMP_INTERVAL_S){
+    if (aie_trace_file_dump_int_s < MIN_TRACE_DUMP_INTERVAL_S) {
       aie_trace_file_dump_int_s = MIN_TRACE_DUMP_INTERVAL_S;
       xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", AIE_TRACE_DUMP_INTERVAL_WARN_MSG);
     }
@@ -193,7 +185,7 @@ namespace xdp {
 
   AieTracePlugin::~AieTracePlugin()
   {
-    if(VPDatabase::alive()) {
+    if (VPDatabase::alive()) {
       try {
         writeAll(false);
       }
@@ -205,9 +197,9 @@ namespace xdp {
     // If the database is dead, then we must have already forced a 
     //  write at the database destructor so we can just move on
 
-    for(auto h : deviceHandles) {
+    for (auto h : deviceHandles)
       xclClose(h);
-    }
+
     AieTracePlugin::live = false;
   }
 
@@ -248,8 +240,11 @@ namespace xdp {
     // Core Module perf counters
     available = stats.getNumRsc(loc, XAIE_CORE_MOD, XAIE_PERFCNT_RSC);
     required = coreCounterStartEvents.size();
-    if (mUseDelay)
-      required += 1;
+    if (mUseDelay) {
+      ++required;
+      if (!mUseOneDelayCtr)
+        ++required;
+    }
     if (available < required) {
       msg << "Available core module performance counters for aie trace : " << available << std::endl
           << "Required core module performance counters for aie trace : "  << required;
@@ -428,7 +423,7 @@ namespace xdp {
     return tiles;
   }
 
-  uint64_t AieTracePlugin::getTraceStartDelayCycles(void* handle)
+  void AieTracePlugin::setTraceStartDelayCycles(void* handle)
   {
     double freqMhz = AIE_DEFAULT_FREQ_MHZ;
 
@@ -439,7 +434,6 @@ namespace xdp {
 
     std::smatch pieces_match;
     uint64_t cycles_per_sec = static_cast<uint64_t>(freqMhz * 1e6);
-    const uint64_t max_cycles = 0xffffffff;
     std::string size_str = xrt_core::config::get_aie_trace_start_time();
 
     // Catch cases like "1Ms" "1NS"
@@ -477,13 +471,80 @@ namespace xdp {
       xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", msg);
     }
 
-    if (cycles > max_cycles) {
-      cycles = max_cycles;
-      std::string msg("Setting aie_trace_delay to max supported of 0xffffffff cycles.");
-      xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", msg);
+    if (cycles > MAX_COUNT_32BIT)
+      mUseOneDelayCtr = false;
+
+    mUseDelay = ( cycles != 0 );
+    mDelayCycles = cycles;
+  }
+
+  bool AieTracePlugin::configureStartDelay(xaiefal::XAieMod& core)
+  {
+    if (!mDelayCycles)
+      return false;
+
+    // This algorithm daisy chains counters to get an effective 64 bit delay
+    // counterLow -> counterHigh -> trace start
+    uint32_t delayCyclesHigh = 0;
+    uint32_t delayCyclesLow = 0;
+    XAie_ModuleType mod = XAIE_CORE_MOD;
+
+    if (!mUseOneDelayCtr) {
+      // ceil(x/y) where x and y are  positive integers
+      delayCyclesLow =  static_cast<uint32_t>(1 + ((mDelayCycles - 1) / MAX_COUNT_32BIT));
+      delayCyclesHigh = static_cast<uint32_t>(mDelayCycles / delayCyclesLow);
+    } else {
+      delayCyclesLow = static_cast<uint32_t>(mDelayCycles);
     }
 
-    return cycles;
+    // Configure lower 32 bits
+    auto pc = core.perfCounter();
+    if (pc->initialize(mod, XAIE_EVENT_ACTIVE_CORE,
+                       mod, XAIE_EVENT_DISABLED_CORE) != XAIE_OK)
+      return false;
+    if (pc->reserve() != XAIE_OK)
+      return false;
+    pc->changeThreshold(delayCyclesLow);
+    XAie_Events counterEvent;
+    pc->getCounterEvent(mod, counterEvent);
+    // Set reset and trace start using this counter
+    pc->changeRstEvent(mod, counterEvent);
+    if (pc->start() != XAIE_OK)
+        return false;
+
+    // Configure upper 32 bits if necessary
+    // Use previous counter to start a new counter
+    if (!mUseOneDelayCtr && delayCyclesHigh) {
+      auto pc = core.perfCounter();
+      if (pc->initialize(mod, counterEvent,
+                         mod, XAIE_EVENT_DISABLED_CORE) != XAIE_OK)
+        return false;
+      if (pc->reserve() != XAIE_OK)
+      return false;
+      pc->changeThreshold(delayCyclesHigh);
+      pc->getCounterEvent(mod, counterEvent);
+      // Set reset and trace start using this counter
+      pc->changeRstEvent(mod, counterEvent);
+      if (pc->start() != XAIE_OK)
+        return false;
+    }
+
+    if (xrt_core::config::get_verbosity() >= static_cast<uint32_t>(severity_level::debug)) {
+      std::stringstream msg;
+      msg << "Configuring delay : "
+      << "mDelay : "<< mDelayCycles << " "
+      << "low : " << delayCyclesLow << " "
+      << "high : " << delayCyclesHigh << " "
+      << std::endl;
+      xrt_core::message::send(severity_level::debug, "XRT", msg.str());
+    }
+
+    coreTraceStartEvent = counterEvent;
+    // This is needed because the cores are started/stopped during execution
+    // to get around some hw bugs. We cannot restart tracemodules when that happens
+    coreTraceEndEvent = XAIE_EVENT_NONE_CORE;
+
+    return true;
   }
 
   // Configure all resources necessary for trace control and events
@@ -505,9 +566,9 @@ namespace xdp {
         return true;
       return false;
     }
+
     auto tiles = getTilesForTracing(handle);
-    // getTraceStartDelayCycles is 32 bit for now
-    mDelayCycles = static_cast<uint32_t>(getTraceStartDelayCycles(handle));
+    setTraceStartDelayCycles(handle);
 
     // Keep track of number of events reserved per tile
     int numTileCoreTraceEvents[NUM_CORE_TRACE_EVENTS+1] = {0};
@@ -658,27 +719,8 @@ namespace xdp {
         if (xrt_core::config::get_aie_trace_user_control()) {
           coreTraceStartEvent = XAIE_EVENT_INSTR_EVENT_0_CORE;
           coreTraceEndEvent = XAIE_EVENT_INSTR_EVENT_1_CORE;
-        } else if (mUseDelay) {
-          auto perfCounter = core.perfCounter();
-          if (perfCounter->initialize(mod, XAIE_EVENT_ACTIVE_CORE,
-                                      mod, XAIE_EVENT_DISABLED_CORE) != XAIE_OK) 
-            break;
-          if (perfCounter->reserve() != XAIE_OK) 
-            break;
-
-          perfCounter->changeThreshold(mDelayCycles);
-          XAie_Events counterEvent;
-          perfCounter->getCounterEvent(mod, counterEvent);
-
-          // Set reset and trace start using this counter
-          perfCounter->changeRstEvent(mod, counterEvent);
-          coreTraceStartEvent = counterEvent;
-          // This is needed because the cores are started/stopped during execution
-          // to get around some hw bugs. We cannot restart tracemodules when that happens
-          coreTraceEndEvent = XAIE_EVENT_NONE_CORE;
-
-          if (perfCounter->start() != XAIE_OK) 
-            break;
+        } else if (mUseDelay && !configureStartDelay(core)) {
+          break;
         }
 
         // Set overall start/end for trace capture
@@ -873,9 +915,11 @@ namespace xdp {
       std::stringstream msg;
       msg << "AIE trace events reserved in core modules - ";
       for (int n=0; n <= NUM_CORE_TRACE_EVENTS; ++n) {
-        if (numTileCoreTraceEvents[n] == 0) continue;
+        if (numTileCoreTraceEvents[n] == 0)
+          continue;
         msg << n << ": " << numTileCoreTraceEvents[n] << " tiles";
-        if (n != NUM_CORE_TRACE_EVENTS) msg << ", ";
+        if (n != NUM_CORE_TRACE_EVENTS)
+          msg << ", ";
 
         (db->getStaticInfo()).addAIECoreEventResources(deviceId, n, numTileCoreTraceEvents[n]);
       }
@@ -885,9 +929,11 @@ namespace xdp {
       std::stringstream msg;
       msg << "AIE trace events reserved in memory modules - ";
       for (int n=0; n <= NUM_MEMORY_TRACE_EVENTS; ++n) {
-        if (numTileMemoryTraceEvents[n] == 0) continue;
+        if (numTileMemoryTraceEvents[n] == 0)
+          continue;
         msg << n << ": " << numTileMemoryTraceEvents[n] << " tiles";
-        if (n != NUM_MEMORY_TRACE_EVENTS) msg << ", ";
+        if (n != NUM_MEMORY_TRACE_EVENTS)
+          msg << ", ";
 
         (db->getStaticInfo()).addAIEMemoryEventResources(deviceId, n, numTileMemoryTraceEvents[n]);
       }
@@ -916,7 +962,7 @@ namespace xdp {
     if (!(db->getStaticInfo()).isDeviceReady(deviceId)) {
       // first delete the offloader, logger
       // Delete the old offloader as data is already from it
-      if(aieOffloaders.find(deviceId) != aieOffloaders.end()) {
+      if (aieOffloaders.find(deviceId) != aieOffloaders.end()) {
         auto entry = aieOffloaders[deviceId];
 
         auto aieOffloader = std::get<0>(entry);
@@ -933,9 +979,8 @@ namespace xdp {
       (db->getStaticInfo()).updateDevice(deviceId, handle);
       {
         struct xclDeviceInfo2 info;
-        if(xclGetDeviceInfo2(handle, &info) == 0) {
+        if (xclGetDeviceInfo2(handle, &info) == 0)
           (db->getStaticInfo()).setDeviceName(deviceId, std::string(info.mName));
-        }
       }
     }
 
@@ -995,7 +1040,7 @@ namespace xdp {
     }
 
     // Create trace output files
-    for(uint64_t n = 0; n < numAIETraceOutput; n++) {
+    for (uint64_t n = 0; n < numAIETraceOutput; n++) {
       // Consider both Device Id and Stream Id to create the output file name
       std::string fileName = "aie_trace_" + std::to_string(deviceId) + "_" + std::to_string(n) + ".txt";
       VPWriter* writer = new AIETraceWriter(fileName.c_str(), deviceId, n,
@@ -1326,7 +1371,7 @@ namespace xdp {
   void AieTracePlugin::writeAll(bool /*openNewFiles*/)
   {
     // read the trace data from device and wrie to the output file
-    for(auto o : aieOffloaders) {
+    for (auto o : aieOffloaders) {
       auto offloader = std::get<0>(o.second);
       auto logger    = std::get<1>(o.second);
 

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.h
@@ -62,11 +62,12 @@ namespace xdp {
       void releaseCurrentTileCounters(int numCoreCounters, int numMemoryCounters);
       bool setMetrics(uint64_t deviceId, void* handle);
       void setFlushMetrics(uint64_t deviceId, void* handle);
-      uint64_t getTraceStartDelayCycles(void* handle);
+      void setTraceStartDelayCycles(void* handle);
 
       // Aie resource manager utility functions
       bool tileHasFreeRsc(xaiefal::XAieDev* aieDevice, XAie_LocType& loc, const std::string& metricSet);
       void printTileStats(xaiefal::XAieDev* aieDevice, const tile_type& tile);
+      bool configureStartDelay(xaiefal::XAieMod& core);
 
       // Utility functions
       std::string getMetricSet(void* handle);
@@ -82,7 +83,8 @@ namespace xdp {
 
       // These flags are used to decide configuration at various points
       bool mUseDelay = false;
-      uint32_t mDelayCycles = 0;
+      uint64_t mDelayCycles = 0;
+      bool mUseOneDelayCtr = true;
 
       bool continuousTrace;
       uint64_t offloadIntervalUs;


### PR DESCRIPTION
Use 2 counters if necessary to turn on aie trace.
Turn off aie trace flush by default and use "es2" configuration when delay is applied