### PR TITLE
Remove virtual dtor from xrt::detail::pimpl

### DIFF
--- a/src/runtime_src/core/include/xrt/detail/pimpl.h
+++ b/src/runtime_src/core/include/xrt/detail/pimpl.h
@@ -28,11 +28,11 @@ namespace xrt { namespace detail {
 template<typename ImplType>
 class pimpl
 {
+protected:
+  ~pimpl() = default;
+
 public:
   pimpl() = default;
-
-  virtual
-  ~pimpl() = default;
 
   explicit
   pimpl(std::shared_ptr<ImplType> handle)


### PR DESCRIPTION
#### Problem solved by the commit
XRT native APIs are not polymorphic and cannot be destructed through
the pimpl base class.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
A virtual pimpl base class adds a vtable pointer to each native class
object, and this vtable is not useful at all.  In fact it creates link
problems at least on windows if the first function is inline.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Remove the virtual dtor from xrt::detail::pimpl.

#### Risks (if any) associated the changes in the commit
This change breaks ABI compatibility of any XRT API object that is implemented using the pimpl class.
Only two experimental APIs fall under this category
* `xrt::xclbin`
* `xrt::ip`

Applications using these would have to be recompiled.   The change in this PR is justified by the pimpl class being used only by experimental APIs.

#### What has been tested and how, request additional testing if necessary
Verify compilation works.