### PR TITLE
VITIS-5847 Resilient VMR - RMGMT

### DIFF
--- a/src/runtime_src/core/include/xgq_cmd_common.h
+++ b/src/runtime_src/core/include/xgq_cmd_common.h
@@ -90,6 +90,7 @@ enum xgq_cmd_opcode {
 	XGQ_CMD_OP_SENSOR		= 0xc,
 	XGQ_CMD_OP_LOAD_APUBIN		= 0xd,
 	XGQ_CMD_OP_VMR_CONTROL		= 0xe,
+	XGQ_CMD_OP_PROGRAM_SCFW		= 0xf,
 
 	/* User command type */
 	XGQ_CMD_OP_START_CUIDX	        = 0x100,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

making scfw flash exclusive with pdi flash and xclbin program.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

In the past, we request the scfw flash and acquire a mutex to exclude with PDI flash and xclbin program.
With new design, we add scfw and PDI, xclbin program operations into the same FIFO queue, so that we will
be performed one by one. A semaphore is hold on host side to avoid race condition of using shared memory which is better so that we can pass back any additional verbose error messages from the device (VMR on RPU).

#### How problem was solved, alternative solutions (if any) and why they were rejected
See above.

#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
tested with resilient VMR changes, this is needed to make VMR pipeline pass.

#### Documentation impact (if any)
https://confluence.xilinx.com/pages/viewpage.action?pageId=302345261#XGQ1.0CommandandQueueSpecification(WIP)-GetLogPage