### PR TITLE
CR-1116635 Incorrect xbutil examine report documentation

### DIFF
--- a/src/runtime_src/doc/toc/xbutil.rst
+++ b/src/runtime_src/doc/toc/xbutil.rst
@@ -173,7 +173,7 @@ The command ``xbutil examine``  can be used to find the details of the specific 
     - ``platform``: Platforms flashed on the device (default when ``--device`` is provided)
     - ``qspi-status``: QSPI write protection status
     - ``thermal``: Reports thermal sensors present on the device
-    - ``cmc-status``: Reports cmc status of the device
+    - ``cmc``: Reports cmc status of the device
 
 - The ``--format`` (or ``-f``) specifies the report format. Note that ``--format`` also needs an ``--output`` to dump the report in json format. If ``--output`` is missing text format will be shown in stdout
     


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1116635
xbutil examine -r cmc-status -d card failed with invalid argument

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Discovered via DSV. Introduced in https://github.com/Xilinx/XRT/pull/5570
The name of the report in documentation and code differed. `cmc-status` never worked while `cmc` did.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Updated the documentation to reflect the report name.

#### Risks (if any) associated the changes in the commit
None. Anyone who used the name in the documentation would find that it did not work to begin with.

#### What has been tested and how, request additional testing if necessary
This is a documentation update. Generated the docs and saw the correct name is displayed.

#### Documentation impact (if any)
Updated the documentation from `cmc-status` to `cmc` to generate the CMC status report under `xbutil reset`
