### PR TITLE
Adjust hwctx implementation for QoS definition 

### DIFF
--- a/src/runtime_src/core/common/api/hw_context_int.h
+++ b/src/runtime_src/core/common/api/hw_context_int.h
@@ -13,9 +13,17 @@
 // XRT core implementation.
 namespace xrt_core { namespace hw_context_int {
 
-// get_xcl_handle() - Retrieve the driver handle index associated with the context
+// get_xcl_handle() - Driver handle index
+// Retrieve the driver handle index associated with the context
 xcl_hwctx_handle
 get_xcl_handle(const xrt::hw_context& ctx);
+
+// Backdoor for changing qos of a hardware context after it has
+// been constructed.  The new qos affects how compute units are
+// within the context are opened.  This is used for legacy
+// xrt::kernel objects associated with a mailbox
+void
+set_exclusive(xrt::hw_context& ctx);
 
 }} // hw_context_int, xrt_core
 

--- a/src/runtime_src/core/common/api/hw_context_int.h
+++ b/src/runtime_src/core/common/api/hw_context_int.h
@@ -14,8 +14,8 @@
 namespace xrt_core { namespace hw_context_int {
 
 // get_slot() - Retrieve the slot index associated with the context
-uint32_t
-get_slot(const xrt::hw_context& ctx);
+xcl_hwctx_handle
+get_xcl_handle(const xrt::hw_context& ctx);
 
 }} // hw_context_int, xrt_core
 

--- a/src/runtime_src/core/common/api/hw_context_int.h
+++ b/src/runtime_src/core/common/api/hw_context_int.h
@@ -13,7 +13,7 @@
 // XRT core implementation.
 namespace xrt_core { namespace hw_context_int {
 
-// get_slot() - Retrieve the slot index associated with the context
+// get_xcl_handle() - Retrieve the driver handle index associated with the context
 xcl_hwctx_handle
 get_xcl_handle(const xrt::hw_context& ctx);
 

--- a/src/runtime_src/core/common/api/xrt_hw_context.cpp
+++ b/src/runtime_src/core/common/api/xrt_hw_context.cpp
@@ -22,14 +22,13 @@ namespace xrt {
 //
 class hw_context_impl
 {
-  using qos_type = uint32_t; // TBD
-
+  using qos_type = xcl_qos_type;
+  using ctx_handle_type = xcl_hwctx_handle;
 
   // Managed context handle with special handling for flows
   // or applications that use load_xclbin (legacy Alveo)
   struct ctx_handle
   {
-    using ctx_handle_type = uint32_t;
     const xrt_core::device* m_device;
     ctx_handle_type m_hdl;
     bool m_destroy_context = true;
@@ -66,12 +65,6 @@ class hw_context_impl
     }
   };
 
-  qos_type
-  priority_to_qos(xrt::hw_context::priority /*qos*/)
-  {
-    return 0; // TBD
-  }
-
   std::shared_ptr<xrt_core::device> m_core_device;
   xrt::xclbin m_xclbin;
   qos_type m_qos;
@@ -81,7 +74,7 @@ public:
   hw_context_impl(std::shared_ptr<xrt_core::device> device, const xrt::uuid& xclbin_id, xrt::hw_context::priority qos)
     : m_core_device(std::move(device))
     , m_xclbin(m_core_device->get_xclbin(xclbin_id))
-    , m_qos(priority_to_qos(qos))
+    , m_qos(static_cast<qos_type>(qos))
     , m_ctx_handle{m_core_device.get(), xclbin_id, m_qos}
   {
   }
@@ -110,8 +103,8 @@ public:
     return m_qos;
   }
 
-  uint32_t
-  get_slot() const
+  ctx_handle_type
+  get_xcl_handle() const
   {
     return m_ctx_handle.m_hdl;
   }
@@ -124,10 +117,10 @@ public:
 ////////////////////////////////////////////////////////////////
 namespace xrt_core { namespace hw_context_int {
 
-uint32_t
-get_slot(const xrt::hw_context& hwctx)
+xcl_hwctx_handle
+get_xcl_handle(const xrt::hw_context& hwctx)
 {
-  return hwctx.get_handle()->get_slot();
+  return hwctx.get_handle()->get_xcl_handle();
 }
 
 }} // hw_context_int, xrt_core

--- a/src/runtime_src/core/common/api/xrt_hw_context.cpp
+++ b/src/runtime_src/core/common/api/xrt_hw_context.cpp
@@ -78,6 +78,12 @@ public:
   {
   }
 
+  void
+  set_exclusive()
+  {
+    m_qos = xrt::hw_context::qos::exclusive;
+  }
+
   std::shared_ptr<xrt_core::device>
   get_core_device() const
   {
@@ -120,6 +126,12 @@ xcl_hwctx_handle
 get_xcl_handle(const xrt::hw_context& hwctx)
 {
   return hwctx.get_handle()->get_xcl_handle();
+}
+
+void
+set_exclusive(xrt::hw_context& hwctx)
+{
+  hwctx.get_handle()->set_exclusive();
 }
 
 }} // hw_context_int, xrt_core

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -1267,7 +1267,7 @@ private:
   void
   open_cu_context(const xrt::xclbin::ip& cu, ip_context::access_mode am)
   {
-    auto slot = xrt_core::hw_context_int::get_slot(hwctx);
+    auto slot = xrt_core::hw_context_int::get_xcl_handle(hwctx);
     auto cdevice = device->get_core_device();
 
     // try open the cu context.  This may throw if cu in slot cannot be acquired.

--- a/src/runtime_src/core/include/CMakeLists.txt
+++ b/src/runtime_src/core/include/CMakeLists.txt
@@ -16,6 +16,7 @@ set(XRT_HEADER_SRC
   xcl_app_debug.h
   xclperf.h
   xclhal2_mem.h
+  xcl_hwctx.h
   xrt_mem.h
   xrt_error_code.h
   xgq_cmd_common.h

--- a/src/runtime_src/core/include/experimental/xrt_hw_context.h
+++ b/src/runtime_src/core/include/experimental/xrt_hw_context.h
@@ -37,7 +37,7 @@ public:
    *  Create a context for shared access to shareable resources
    *  Legacy compute unit access control.
    */
-  enum class priority : xcl_qos_type {
+  enum class qos : xcl_qos_type {
     exclusive = XCL_QOS_EXCLUSIVE,  // legacy
     shared = XCL_QOS_SHARED,        // legacy
     reserved = 0
@@ -53,10 +53,10 @@ public:
    * hw_context() - Constructor
    */
   XRT_API_EXPORT
-  hw_context(const xrt::device& device, const xrt::uuid& xclbin_id, priority qos);
+  hw_context(const xrt::device& device, const xrt::uuid& xclbin_id, qos qos);
 
   hw_context(const xrt::device& device, const xrt::uuid& xclbin_id)
-    : hw_context{device, xclbin_id, static_cast<priority>(0)}
+    : hw_context{device, xclbin_id, static_cast<qos>(0)}
   {}
 
   XRT_API_EXPORT
@@ -70,6 +70,10 @@ public:
   XRT_API_EXPORT
   xrt::xclbin
   get_xclbin() const;
+
+  XRT_API_EXPORT
+  qos
+  get_qos() const;
 };
 
 } // namespace xrt

--- a/src/runtime_src/core/include/experimental/xrt_hw_context.h
+++ b/src/runtime_src/core/include/experimental/xrt_hw_context.h
@@ -9,6 +9,8 @@
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_uuid.h"
 
+#include "xcl_hwctx.h"
+
 #ifdef __cplusplus
 
 namespace xrt {
@@ -25,7 +27,22 @@ class hw_context_impl;
 class hw_context : public detail::pimpl<hw_context_impl>
 {
 public:
-  enum class priority {};
+  /**
+   * @enum priority - tbd
+   *
+   * @var exclusive
+   *  Create a context for exclusive access to shareable resources.
+   *  Legacy compute unit access control.
+   * @var shared
+   *  Create a context for shared access to shareable resources
+   *  Legacy compute unit access control.
+   */
+  enum class priority : xcl_qos_type {
+    exclusive = XCL_QOS_EXCLUSIVE,  // legacy
+    shared = XCL_QOS_SHARED,        // legacy
+    reserved = 0
+  };
+
 public:
   /**
    * hw_context() - Constructor for empty context

--- a/src/runtime_src/core/include/experimental/xrt_hw_context.h
+++ b/src/runtime_src/core/include/experimental/xrt_hw_context.h
@@ -51,26 +51,49 @@ public:
 
   /**
    * hw_context() - Constructor
+   *
+   * @param device
+   *  Device where context is created
+   * @param xclbin_id
+   *  UUID of xclbin that should be assigned to HW resources
+   * @qos
+   *  Quality of service request that should be fulfilled by the context
    */
   XRT_API_EXPORT
   hw_context(const xrt::device& device, const xrt::uuid& xclbin_id, qos qos);
 
+  ///@cond
+  // Undocumented construction w/o specifying qos
+  // Subject to change in default qos value
   hw_context(const xrt::device& device, const xrt::uuid& xclbin_id)
     : hw_context{device, xclbin_id, static_cast<qos>(0)}
   {}
+  /// @endcond
 
+  /**
+   * get_device() - Device from which context was created
+   */
   XRT_API_EXPORT
   xrt::device
   get_device() const;
 
+  /**
+   * get_xclbin_uuid() - UUID of xclbin from which context was created
+   */
   XRT_API_EXPORT
   xrt::uuid
   get_xclbin_uuid() const;
 
+  /**
+   * get_xclbin() - Retrieve underlying xclbin matching the UUID
+   */
   XRT_API_EXPORT
   xrt::xclbin
   get_xclbin() const;
 
+  /**
+   * get_qos() - Get the QOS value of the context
+   */
   XRT_API_EXPORT
   qos
   get_qos() const;

--- a/src/runtime_src/core/include/xcl_hwctx.h
+++ b/src/runtime_src/core/include/xcl_hwctx.h
@@ -4,10 +4,9 @@
 #ifndef XCL_HWCTX_H_
 #define XCL_HWCTX_H_
 
-/* #ifdef _WIN32 */
-/* # pragma warning( push ) */
-/* # pragma warning( disable : 4201 ) */
-/* #endif */
+// Definitions related to HW context shared between user space XRT and
+// Linux kernel driver.  The header file is exported as underlying
+// types are exposed in xrt::hw_context::qos definition.
 
 #ifdef __cplusplus
 # include <cstdint>
@@ -20,18 +19,24 @@ extern "C" {
 # endif
 #endif
 
+// Underlying representation of a hardware context handle.
+//
+// The context handle is among other things used with / encoded in
+// buffer object flags.
 typedef uint32_t xcl_hwctx_handle;
 
+// Underlying representation of a hardware context QoS value.
 typedef uint32_t xcl_qos_type;
+
+// Special sentinels that represent legacy compute unit context
+// access.  All compute units associated with a hardware context
+// are opened with same QoS value.  Legacy PL supports shared
+// or exclusive mode for compute unit access.
 #define XCL_QOS_SHARED 0xFFFFFFFF
 #define XCL_QOS_EXCLUSIVE 0xFFFFFFFE
 
 #ifdef __cplusplus
 }
 #endif
-
-/* #ifdef _WIN32 */
-/* # pragma warning( pop ) */
-/* #endif */
 
 #endif

--- a/src/runtime_src/core/include/xcl_hwctx.h
+++ b/src/runtime_src/core/include/xcl_hwctx.h
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: GPL-2.0
+// Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+#ifndef XCL_HWCTX_H_
+#define XCL_HWCTX_H_
+
+/* #ifdef _WIN32 */
+/* # pragma warning( push ) */
+/* # pragma warning( disable : 4201 ) */
+/* #endif */
+
+#ifdef __cplusplus
+# include <cstdint>
+extern "C" {
+#else
+# if defined(__KERNEL__)
+#  include <linux/types.h>
+# else
+#  include <stdint.h>
+# endif
+#endif
+
+typedef uint32_t xcl_hwctx_handle;
+
+typedef uint32_t xcl_qos_type;
+#define XCL_QOS_SHARED 0xFFFFFFFF
+#define XCL_QOS_EXCLUSIVE 0xFFFFFFFE
+
+#ifdef __cplusplus
+}
+#endif
+
+/* #ifdef _WIN32 */
+/* # pragma warning( pop ) */
+/* #endif */
+
+#endif


### PR DESCRIPTION
#### Problem solved by the commit
Consolidate low level internals specific to shim in exported
xcl_hwctx.h and modify xrt::hw_context accordingly.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Hardware context spec or more or less finalized now and the changes in this
PR reflects our current definition.  Later PRs will build on this one.

#### How problem was solved, alternative solutions (if any) and why they were rejected
The new header file `xcl_hwctx.h` defines underlying representation of hardware context handle and QoS. 
It contains basic definition of QoS sentinels for shared and exclusive CU access.

#### What has been tested and how, request additional testing if necessary
Standard hw regression tests
