### PR TITLE
Fix ReportPower when `electrical_raw` is empty

### DIFF
--- a/src/runtime_src/core/tools/xbtop/ReportPower.py
+++ b/src/runtime_src/core/tools/xbtop/ReportPower.py
@@ -13,6 +13,7 @@ import XBUtil
 # found in PYTHONPATH
 import pyxrt
 
+
 class ReportPower:
 
     def report_name(self):
@@ -22,7 +23,7 @@ class ReportPower:
         self.report_length = report_length
         #get power info
         electrical_json = dev.get_info(pyxrt.xrt_info_device.electrical)
-        electrical_raw = json.loads(electrical_json) #read into a dictionary
+        electrical_raw = json.loads(electrical_json)  #read into a dictionary
 
         # check if xclbin is loaded
         if not electrical_raw:
@@ -53,7 +54,7 @@ class ReportPower:
             return offset + 1
 
         # Create the complete power buffer
-        all_data=[
+        all_data = [
             'Power     : %s Watts' % self._df['Power'],
             'Max Power : %s Watts' % self._df['Max Power'],
             'Warning   : %s' % self._df['Warning']
@@ -63,7 +64,7 @@ class ReportPower:
         page_offset = page * self.report_length
         # The upper offset is bounded by the size of the full power buffer
         upper_page_offset = min(self.report_length + page_offset, len(all_data))
-        data=all_data[page_offset:upper_page_offset]
+        data = all_data[page_offset:upper_page_offset]
 
         if (not data):
             XBUtil.print_warning(term, lock, start_y + offset, "Data unavailable")

--- a/src/runtime_src/core/tools/xbtop/ReportPower.py
+++ b/src/runtime_src/core/tools/xbtop/ReportPower.py
@@ -48,11 +48,7 @@ class ReportPower:
         XBUtil.print_section_heading(term, lock, self.report_name(), start_y)
         offset = 1
 
-        if len(self._df) == 0:
-            XBUtil.print_warning(term, lock, start_y + offset, "Data unavailable. Acceleration image not loaded")
-            return offset + 1
-
-        if (self.page_count == 0):
+        if len(self._df) == 0 or self.page_count == 0:
             XBUtil.print_warning(term, lock, start_y + offset, "Data unavailable. Acceleration image not loaded")
             return offset + 1
 

--- a/src/runtime_src/core/tools/xbtop/ReportPower.py
+++ b/src/runtime_src/core/tools/xbtop/ReportPower.py
@@ -26,7 +26,7 @@ class ReportPower:
 
         # check if xclbin is loaded
         if not electrical_raw:
-            self._df.clear()
+            self._df = {}
             # If data is missing set the page count to 0!
             self.page_count = 0
             return self.page_count
@@ -49,7 +49,7 @@ class ReportPower:
         offset = 1
 
         if len(self._df) == 0:
-            print_warning(term, lock, start_y + offset, "Data unavailable. Acceleration image not loaded")
+            XBUtil.print_warning(term, lock, start_y + offset, "Data unavailable. Acceleration image not loaded")
             return offset + 1
 
         if (self.page_count == 0):


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->

#### Problem solved by the commit

Show page 3 of `xbtop` even if the electrical report is not populated. This is part of CR-1131532

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

Discovered when trying to use `xbtop` with a VCK5000. This seems to be a bug from the initial implementation https://github.com/Xilinx/XRT/pull/6181

```python
AttributeError: 'ReportPower' object has no attribute '_df'
```
#### How problem was solved, alternative solutions (if any) and why they were rejected

If the `electrical_raw` variable is empty, the `self._df` was not declared, hence the `AttributeError`. To fix this, instead of use `.clear()` for an non existing variable, `self._df` is created as empty dictionary. 

#### Risks (if any) associated the changes in the commit

I see no risks as this part of the code should only execute if  `electrical_raw` is empty

#### What has been tested and how, request additional testing if necessary

Tested locally with VCK5000 and U250

```sh
Wed May 25 11:05:35 2022                                                                                  Power (3/3)                                                                           Refresh Count: 9 (Rate: 1.0 s)
                                                                                                          Page (1/0)             
----------------------------------------------
  Shell : xilinx_vck5000_gen3x16_xdma_base_1
  UUID  : A96ADB1F-78C8-BEAC-9173-81FEF01B08CD
  BDF   : 0000:e2:00.1
----------------------------------------------

Power
    Data unavailable. Acceleration image not loade
```

```sh
Wed May 25 11:06:47 2022                                                 Power (3/3)                                          Refresh Count: 1 (Rate: 1.0 s)
                                                                         Page (1/1)             
----------------------------------------------
  Shell : xilinx_u250_gen3x16_xdma_shell_4_1
  UUID  : 12C8FAFB-0632-499D-B1C0-C6676271B8A6
  BDF   : 0000:73:00.1
----------------------------------------------

Power
  Power     : 33.903248 Watts
  Max Power : 225 Watts
  Warning   : false
```

#### Documentation impact (if any)

N/A