### PR TITLE
Added the specific device compatible DTB for v70 DC platform

### DIFF
--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
@@ -938,6 +938,13 @@ namespace xclhwemhal2 {
             std::cout << "ERROR: [HW-EMU] Unable to find either PMU/PMC args which are required to launch the emulation." << std::endl;
           }
 
+          // This is temporary solution to enable the support for V70 platform. Will remove this once we have the device based DTB solution.
+          // We have separate DTB for the V70 platform (sv60 device).
+          if (fpgaDeviceName.find("xcvc2802:") != std::string::npos 
+            && fs::exists(sim_path + "/emulation_data/board-versal-xcvc2802-ps-cosim-vitis-virt.dtb") ){
+            launcherArgs += " -qemu-dtb " + sim_path + "/emulation_data/board-versal-xcvc2802-ps-cosim-vitis-virt.dtb";
+          }
+
           if (is_enable_debug) {
             launcherArgs += " -enable-debug ";
           }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Enablement of v70 emulation DC platform

#### How problem was solved, alternative solutions (if any) and why they were rejected
not an issue, its new support

#### Risks (if any) associated the changes in the commit
no

#### What has been tested and how, request additional testing if necessary
verified the hw_emu design with v70 platform. it does not impact any other platforms

#### Documentation impact (if any)
no
