### PR TITLE
CR-1129798 No Error Message for mixed versions of XRT in release 2022.1

### DIFF
--- a/src/runtime_src/core/tools/common/XBMain.cpp
+++ b/src/runtime_src/core/tools/common/XBMain.cpp
@@ -97,7 +97,7 @@ void  main_(int argc, char** argv,
   }
 
   // If not asking for version or help in xbutil, ensure the versions of XRT and xbutil match
-  if (!bHelp && isUserDomain)
+  if (!bHelp && !bForce && isUserDomain)
     XBU::xrt_xbutil_version_cmp();
  
   // -- Enable/Disable helper "global" options

--- a/src/runtime_src/core/tools/common/XBMain.cpp
+++ b/src/runtime_src/core/tools/common/XBMain.cpp
@@ -95,6 +95,10 @@ void  main_(int argc, char** argv,
     std::cout << XBU::get_xrt_pretty_version();
     return;
   }
+
+  // If not asking for version or help in xbutil, ensure the versions of XRT and xbutil match
+  if (!bHelp && isUserDomain)
+    XBU::xrt_xbutil_version_cmp();
  
   // -- Enable/Disable helper "global" options
   XBU::disable_escape_codes( bBatchMode );

--- a/src/runtime_src/core/tools/common/XBMain.cpp
+++ b/src/runtime_src/core/tools/common/XBMain.cpp
@@ -97,8 +97,8 @@ void  main_(int argc, char** argv,
   }
 
   // If not asking for version or help in xbutil, ensure the versions of XRT and xbutil match
-  if (!bHelp && !bForce && isUserDomain)
-    XBU::xrt_xbutil_version_cmp();
+  if (!bHelp && isUserDomain)
+    XBU::xrt_xbutil_version_cmp(bForce);
  
   // -- Enable/Disable helper "global" options
   XBU::disable_escape_codes( bBatchMode );

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -260,13 +260,8 @@ XBUtilities::xrt_xbutil_version_cmp()
     const boost::property_tree::ptree& driver = drv.second;
     std::string drv_name = driver.get<std::string>("name", "N/A");
     std::string drv_version = driver.get<std::string>("version", "N/A");
-    if (drv_name.compare("xocl") == 0) {
-      if (drv_version.compare("unknown") == 0)
-        throw std::runtime_error(boost::str(boost::format("XRT Driver version unknown. Expected %s, to match XRT tools.") % xrt_version));
-      if (xrt_version.compare(drv_version) != 0)
-        throw std::runtime_error(boost::str(boost::format("Unexpected XRT Driver version (%s) was found. Expected %s, to match XRT tools.") % drv_version % xrt_version));
-      break;
-    }
+    if (drv_name.compare("xocl") == 0 && drv_version.compare("unknown") != 0 && xrt_version.compare(drv_version) != 0)
+      throw std::runtime_error(boost::str(boost::format("Unexpected XRT Driver version (%s) was found. Expected %s, to match XRT tools.") % drv_version % xrt_version));
   }
 }
 

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -248,6 +248,24 @@ str2index(const std::string& str, bool _inUserDomain)
 }
 
 void
+XBUtilities::xrt_xbutil_version_cmp()
+{
+  boost::property_tree::ptree pt_xrt;
+  xrt_core::get_xrt_info(pt_xrt);
+  boost::property_tree::ptree empty_ptree;
+
+  std::string xrt_version = pt_xrt.get<std::string>("version", "N/A");
+  const boost::property_tree::ptree& available_drivers = pt_xrt.get_child("drivers", empty_ptree);
+  for(auto& drv : available_drivers) {
+    const boost::property_tree::ptree& driver = drv.second;
+    std::string drv_name = driver.get<std::string>("name", "N/A");
+    std::string drv_version = driver.get<std::string>("version", "N/A");
+    if (drv_name.compare("xocl") == 0 && drv_version.compare("unknown") != 0 && xrt_version.compare(drv_version) != 0)
+      throw std::runtime_error("Mixed versions of XRT and xbutil are not supported. Please install matching versions of XRT and xbutil.");
+  }
+}
+
+void
 XBUtilities::collect_devices( const std::set<std::string> &_deviceBDFs,
                               bool _inUserDomain,
                               xrt_core::device_collection &_deviceCollection)

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -260,8 +260,13 @@ XBUtilities::xrt_xbutil_version_cmp()
     const boost::property_tree::ptree& driver = drv.second;
     std::string drv_name = driver.get<std::string>("name", "N/A");
     std::string drv_version = driver.get<std::string>("version", "N/A");
-    if (drv_name.compare("xocl") == 0 && drv_version.compare("unknown") != 0 && xrt_version.compare(drv_version) != 0)
-      throw std::runtime_error("Mixed versions of XRT and xbutil are not supported. Please install matching versions of XRT and xbutil.");
+    if (drv_name.compare("xocl") == 0) {
+      if (drv_version.compare("unknown") == 0)
+        throw std::runtime_error(boost::str(boost::format("XRT Driver version unknown. Expected %s, to match XRT tools.") % xrt_version));
+      if (xrt_version.compare(drv_version) != 0)
+        throw std::runtime_error(boost::str(boost::format("Unexpected XRT Driver version (%s) was found. Expected %s, to match XRT tools.") % drv_version % xrt_version));
+      break;
+    }
   }
 }
 

--- a/src/runtime_src/core/tools/common/XBUtilities.h
+++ b/src/runtime_src/core/tools/common/XBUtilities.h
@@ -50,6 +50,8 @@ namespace XBUtilities {
   void throw_cancel(const boost::format& format);
   void print_exception(const std::system_error& e);
 
+  void xrt_xbutil_version_cmp();
+
 
   void collect_devices( const std::set<std::string>  &_deviceBDFs,
                         bool _inUserDomain,

--- a/src/runtime_src/core/tools/common/XBUtilities.h
+++ b/src/runtime_src/core/tools/common/XBUtilities.h
@@ -50,7 +50,7 @@ namespace XBUtilities {
   void throw_cancel(const boost::format& format);
   void print_exception(const std::system_error& e);
 
-  void xrt_xbutil_version_cmp();
+  void xrt_xbutil_version_cmp(bool force);
 
 
   void collect_devices( const std::set<std::string>  &_deviceBDFs,


### PR DESCRIPTION
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1129798
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
In 2022.1, an error message is no longer given to warn users of mixed version usage. This was noticed while running `xbutil examine` on a container with a different XRT version than its host.
#### How problem was solved, alternative solutions (if any) and why they were rejected
The previous warning was re-adapted to current ptree structure and command flags. The logic underneath is essentially the same as [before legacy tools were removed](https://github.com/Xilinx/XRT/pull/6570) to only produce the error message in the given conditions.
#### Risks (if any) associated the changes in the commit
Users must ensure that their XRT versions match to use xbutil properly without throwing this error (unless they use --force, but they will still see the warning message).
#### What has been tested and how, request additional testing if necessary
EDIT: Updated error message/showing usage with --force.
```
rchane@xsjbrd102bx:/proj/rdi/staff/rchane/XRT$ xbutil examine
XRT build version: 2.14.0
Build hash: 6bd8485bd340219087c5c08363ffedf13ec4e51b
Build date: 2022-07-20 11:46:14
Git branch: CR-1129798
PID: 317247
UID: 90979
[Wed Jul 20 19:47:22 2022 GMT]
HOST: xsjbrd102bx
EXE: /proj/xsjhdstaff4/rchane/XRT/build/Debug/opt/xilinx/xrt/bin/unwrapped/xbutil2
[xbutil] ERROR: Unexpected XRT Driver version (unknown) was found. Expected 2.14.0, to match XRT tools.

rchane@xsjbrd102bx:/proj/rdi/staff/rchane/XRT$ xbutil examine --force
Unexpected XRT Driver version (unknown) was found. Expected 2.14.0, to match XRT tools.
Bypassing mismatch with --force.
System Configuration
  OS Name              : Linux
  Release              : 5.4.0-100-generic
  Version              : #113-Ubuntu SMP Thu Feb 3 18:43:29 UTC 2022
  Machine              : x86_64
  CPU Cores            : 6
[more examine info...]
```
#### Documentation impact (if any)
N/A