### PR TITLE
Use hwctx when xrt::kernel implementation opens compute units

### DIFF
--- a/src/runtime_src/core/common/api/hw_context_int.h
+++ b/src/runtime_src/core/common/api/hw_context_int.h
@@ -18,6 +18,11 @@ namespace xrt_core { namespace hw_context_int {
 xcl_hwctx_handle
 get_xcl_handle(const xrt::hw_context& ctx);
 
+// Get a raw pointer to the core device associated with
+// the hw context
+xrt_core::device*
+get_core_device_raw(const xrt::hw_context& ctx);
+
 // Backdoor for changing qos of a hardware context after it has
 // been constructed.  The new qos affects how compute units are
 // within the context are opened.  This is used for legacy

--- a/src/runtime_src/core/common/api/xrt_hw_context.cpp
+++ b/src/runtime_src/core/common/api/xrt_hw_context.cpp
@@ -84,7 +84,7 @@ public:
     m_qos = xrt::hw_context::qos::exclusive;
   }
 
-  std::shared_ptr<xrt_core::device>
+  const std::shared_ptr<xrt_core::device>&
   get_core_device() const
   {
     return m_core_device;
@@ -126,6 +126,12 @@ xcl_hwctx_handle
 get_xcl_handle(const xrt::hw_context& hwctx)
 {
   return hwctx.get_handle()->get_xcl_handle();
+}
+
+xrt_core::device*
+get_core_device_raw(const xrt::hw_context& hwctx)
+{
+  return hwctx.get_handle()->get_core_device().get();
 }
 
 void

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -502,7 +502,6 @@ class ip_context
 public:
   using access_mode = xrt::kernel::cu_access_mode;
   using slot_id = xrt_core::device::slot_id;
-  static constexpr unsigned int virtual_cu_idx = std::numeric_limits<unsigned int>::max();
 
   // open() - open a context in a specific IP/CU
   //
@@ -512,57 +511,37 @@ public:
   // @cuidx:     Index of CU used when opening context and populating cmd pkt
   // @am:        Access mode, how this CU should be opened
   static std::shared_ptr<ip_context>
-  open(xrt_core::device* device, const xrt::xclbin& xclbin, slot_id slot, const xrt::xclbin::ip& ip, access_mode am)
+  open(const xrt::hw_context& hwctx, const xrt::xclbin::ip& ip)
   {
     // Slightly complicated handling of shared ownership of ip_context objects.
+    // This code would be greatly simplified to the point of not needed if only
+    // driver would manage CU context within a HW context as opposed to per slot.
     // Contexts are managed per device.
     // Within a device, a CU is opened in a slot.
     // This function manages the ip_context objects per device and slot.
-    using slot_ips = std::map<std::string, std::weak_ptr<ip_context>>;
-    using slot_to_ips = std::map<slot_id, slot_ips>;
+    using ctx_ips = std::map<std::string, std::weak_ptr<ip_context>>;
+    using ctx_to_ips = std::map<xcl_hwctx_handle, ctx_ips>;
     static std::mutex mutex;
-    static std::map<xrt_core::device*, slot_to_ips> dev2ips;
+    static std::map<xrt_core::device*, ctx_to_ips> dev2ips;
+    auto device = xrt_core::hw_context_int::get_core_device_raw(hwctx);
+    auto ctxhdl = xrt_core::hw_context_int::get_xcl_handle(hwctx);
     std::lock_guard<std::mutex> lk(mutex);
-    auto& slot2ips = dev2ips[device]; // domain -> ip_context_list
-    auto& ips = slot2ips[slot];
+    auto& ctx2ips = dev2ips[device]; // domain -> ip_context_list
+    auto& ips = ctx2ips[ctxhdl];
     auto ipctx = ips[ip.get_name()].lock();
     if (!ipctx) {
       // NOLINTNEXTLINE(modernize-make-shared)  used in weak_ptr
-      ipctx = std::shared_ptr<ip_context>(new ip_context(device, xclbin, slot, ip, am));
+      ipctx = std::shared_ptr<ip_context>(new ip_context(hwctx, ip));
       ips[ip.get_name()] = ipctx;
     }
 
-    if (ipctx->access != am)
-      throw std::runtime_error("Conflicting access mode for IP(" + ip.get_name() + ")");
-
-    return ipctx;
-  }
-
-  // open() - open a context on the device virtual CU
-  //
-  // @device:    The device on which to open the virtual CU
-  // xclbin_id:  The xclbin that is locked by this call
-  //
-  // This keeps a lock on the xclbin after it is loaded onto the device
-  // without locking any specific CU.
-  static std::shared_ptr<ip_context>
-  open_virtual_cu(xrt_core::device* device, const xrt::xclbin& xclbin)
-  {
-    static std::mutex mutex;
-    static std::map<xrt_core::device*, std::weak_ptr<ip_context>> dev2vip;
-    std::lock_guard<std::mutex> lk(mutex);
-    auto& vip = dev2vip[device];
-    auto ipctx = vip.lock();
-    if (!ipctx)
-      // NOLINTNEXTLINE(modernize-make-shared)  used in weak_ptr
-      vip = ipctx = std::shared_ptr<ip_context>(new ip_context(device, xclbin));
     return ipctx;
   }
 
   access_mode
   get_access_mode() const
   {
-    return access;
+    return qos_to_mode(m_hwctx.get_qos());
   }
 
   // For symmetry
@@ -573,32 +552,32 @@ public:
   size_t
   get_size() const
   {
-    return size;
+    return m_size;
   }
 
   uint64_t
   get_address() const
   {
-    return address;
+    return m_address;
   }
 
   unsigned int
   get_cuidx() const
   {
-    return idx.domain_index; // index used for execution cumask
+    return m_idx.domain_index; // index used for execution cumask
   }
 
   slot_id
   get_slot() const
   {
-    return slot;
+    return xrt_core::hw_context_int::get_xcl_handle(m_hwctx);
   }
 
   // Check if arg is connected to specified memory bank
   bool
   valid_connection(size_t argidx, int32_t memidx)
   {
-    return args.valid_arg_connection(argidx, memidx);
+    return m_args.valid_arg_connection(argidx, memidx);
   }
 
   // Get default memory bank for argument at specified index The
@@ -607,12 +586,14 @@ public:
   int32_t
   arg_memidx(size_t argidx) const
   {
-    return args.get_arg_memidx(argidx);
+    return m_args.get_arg_memidx(argidx);
   }
 
   ~ip_context()
   {
-    xrt_core::context_mgr::close_context(device, xid, idx);
+    auto device = xrt_core::hw_context_int::get_core_device_raw(m_hwctx);
+    auto xid = m_hwctx.get_xclbin_uuid();
+    xrt_core::context_mgr::close_context(device, xid, m_idx);
   }
 
   ip_context(const ip_context&) = delete;
@@ -622,48 +603,31 @@ public:
 
 private:
   // regular CU
-  ip_context(xrt_core::device* dev, const xrt::xclbin& xclbin, slot_id slot_idx, xrt::xclbin::ip xip, access_mode am)
-    : device(dev)
-    , xid(xclbin.get_uuid())
-    , ip(std::move(xip))
-    , args(dev, xclbin, ip)
-    , slot(slot_idx)
-    , address(ip.get_base_address())
-    , size(ip.get_size())
-    , access(am)
+  ip_context(xrt::hw_context xhwctx, xrt::xclbin::ip xip)
+    : m_hwctx(std::move(xhwctx))
+    , m_device(xrt_core::hw_context_int::get_core_device_raw(m_hwctx))
+    , m_ip(std::move(xip))
+    , m_args(m_device, m_hwctx.get_xclbin(), m_ip)
+    , m_address(m_ip.get_base_address())
+    , m_size(m_ip.get_size())
+    , m_access(qos_to_mode(m_hwctx.get_qos()))
   {
-    if (access == access_mode::none)
-      // access_mode::none is not used anywhere
-      throw xrt_core::error("Unexpected access mode 'none'");
-
-    xrt_core::context_mgr::open_context(device, slot, xid, ip.get_name(), std::underlying_type<access_mode>::type(access));
+    auto slot = xrt_core::hw_context_int::get_xcl_handle(m_hwctx);
+    auto xid = m_hwctx.get_xclbin_uuid();
+    xrt_core::context_mgr::open_context(m_device, slot, xid, m_ip.get_name(), std::underlying_type<access_mode>::type(m_access));
 
     // If open context was successful, then the cuidx is recorded in device
-    idx = dev->get_cuidx(slot, ip.get_name());
+    m_idx = m_device->get_cuidx(slot, m_ip.get_name());
   }
 
-  // virtual CU
-  ip_context(xrt_core::device* dev, const xrt::xclbin& xclbin)
-    : device(dev)
-    , xid(xclbin.get_uuid())
-    , idx{virtual_cu_idx}   // virtual CU is in default (0) domain
-    , slot(0)               // virtual CU is in default (0) slot
-    , address(0)
-    , size(0)
-    , access(access_mode::shared)
-  {
-    xrt_core::context_mgr::open_context(device, xid, idx, std::underlying_type<access_mode>::type(access));
-  }
-
-  xrt_core::device* device; //
-  xrt::uuid xid;            // xclbin uuid
-  xrt::xclbin::ip ip;       // the xclbin ip object
-  connectivity args;        // argument memory connections
-  xrt_core::cuidx_type idx; // cu domain and index
-  slot_id slot;             // xclbin slot in which this context is opened
-  uint64_t address;         // cache base address for programming
-  size_t size;              // cache address space size
-  access_mode access;       // compute unit access mode
+  xrt::hw_context m_hwctx;    // hw context in which IP is opened
+  xrt_core::device* m_device; // cached from hwctx
+  xrt::xclbin::ip m_ip;       // the xclbin ip object
+  connectivity m_args;        // argument memory connections
+  xrt_core::cuidx_type m_idx; // cu domain and index
+  uint64_t m_address;         // cache base address for programming
+  size_t m_size;              // cache address space size
+  access_mode m_access;       // compute unit access mode
 };
 
 // Remove when c++17
@@ -1272,7 +1236,6 @@ private:
   std::vector<argument> args;          // kernel args sorted by argument index
   std::vector<ipctx> ipctxs;           // CU context locks
   const property_type& properties;     // Kernel properties from XML meta
-  ipctx vctx;                          // virtual CU context
   std::bitset<max_cus> cumask;         // cumask for command execution
   size_t regmap_size = 0;              // CU register map size
   size_t fa_num_inputs = 0;            // Fast adapter number of inputs per meta data
@@ -1294,13 +1257,8 @@ private:
   void
   open_cu_context(const xrt::xclbin::ip& cu)
   {
-    // TO BE CHANGED next
-    auto slot = xrt_core::hw_context_int::get_xcl_handle(hwctx);
-    auto cdevice = device->get_core_device();
-    auto am = qos_to_mode(hwctx.get_qos());
-
     // try open the cu context.  This may throw if cu in slot cannot be acquired.
-    auto ctx = ip_context::open(cdevice, xclbin, slot, cu, am); // may throw
+    auto ctx = ip_context::open(hwctx, cu); // may throw
 
     // success, record cuidx in kernel cumask
     auto cuidx = ctx->get_cuidx();
@@ -1473,7 +1431,6 @@ public:
     , xclbin(hwctx.get_xclbin())                               // xclbin with kernel
     , xkernel(get_kernel_or_error(xclbin, name))               // kernel meta data managed by xclbin
     , properties(xrt_core::xclbin_int::get_properties(xkernel))// cache kernel properties
-    , vctx(ip_context::open_virtual_cu(device->core_device.get(), xclbin))
     , uid(create_uid())
   {
     XRT_DEBUGF("kernel_impl::kernel_impl(%d)\n" , uid);


### PR DESCRIPTION
#### Problem solved by the commit
This is a continuation of changes in #6727.  

#### How problem was solved, alternative solutions (if any) and why they were rejected
Use of xrt::hw_context will move all the way to xclOpenContextByName, but changes are done in
small incremental steps.

This PR also removes the virtual CU context from the xrt::kernel
constructor.  Opening a virtual CU context makes no sense when the
kernel constructor anyway opens regular CU context or fails if no
regular CU can be opened.

#### Risks (if any) associated the changes in the commit
The virtual CU context creation was removed from xrt::kernel constructor.  It appeared to not 
be needed and commit logs are clear why it was originally added few years back.

#### What has been tested and how, request additional testing if necessary
Regression HW tests
