### PR TITLE
Use hwctx in IP context manager

### DIFF
--- a/src/runtime_src/core/common/api/context_mgr.cpp
+++ b/src/runtime_src/core/common/api/context_mgr.cpp
@@ -1,10 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2021-2022 Xilinx, Inc. All rights reserved.
-#define XRT_CORE_COMMON_SOURCE // in same dll as core_common
+// Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+#define XRT_CORE_COMMON_SOURCE // in same dll as coreutil
+#define XRT_API_SOURCE         // in smae dll as coreutil
 #include "context_mgr.h"
 #include "core/common/cuidx_type.h"
 #include "core/common/debug.h"
 #include "core/common/device.h"
+#include "core/common/api/hw_context_int.h"
 
 #include <bitset>
 #include <chrono>
@@ -14,6 +17,24 @@
 #include <mutex>
 
 using namespace std::chrono_literals;
+
+namespace {
+
+// Transition only, to be removed
+static bool
+is_shared(xrt::hw_context::qos qos)
+{
+  switch (qos) {
+  case xrt::hw_context::qos::exclusive:
+    return false;
+  case xrt::hw_context::qos::shared:
+    return true;
+  default:
+    throw std::runtime_error("unexpected access mode for kernel");
+  }
+}
+
+} // namespace
 
 namespace xrt_core { namespace context_mgr {
 
@@ -37,7 +58,8 @@ class device_context_mgr
 
   // CU contexts are managed per domain where indicies are
   // in the range [0..max_cus[.  This allows for a compact
-  // bitset representation.
+  // bitset representation.  CU indices are unique within
+  // a domain and global for all hardware contexts.
   using domain_type = cuidx_type::domain_type;
   std::map<domain_type, std::bitset<max_cus>> m_d2ctx; // domain -> cxt
 
@@ -50,17 +72,17 @@ class device_context_mgr
   }
 
   // Get the CU index within a domain and the domain context bitset
-  // for the CU identified by argument slot and cuname.
+  // for the CU identified by arguments.
   // The returned index is only valid if the context bitset is not null.
-  std::pair<size_t, std::bitset<max_cus>*>
-  get_idx_ctx(slot_id slot, const std::string& cuname)
+  std::pair<cuidx_type, std::bitset<max_cus>*>
+  get_ipidx_ctx(xcl_hwctx_handle ctxhdl, const std::string& cuname)
   {
     try {
-      auto idx = m_device->get_cuidx(slot, cuname);
-      return {ctxidx(idx), get_ctx(idx)};
+      auto ipidx = m_device->get_cuidx(ctxhdl, cuname);
+      return {ipidx, get_ctx(ipidx)};
     }
     catch (const std::exception&) {
-      return {0, nullptr};
+      return {cuidx_type{0}, nullptr};
     }
   }
 
@@ -81,61 +103,46 @@ public:
     : m_device(device)
   {}
 
-  // Open context on cu identified by slot, uuid, and name.
-  // Open the cu context when it is safe to do so.  Note, that usage
+  // Open context on IP in specified hardware context.
+  // Open the IP context when it is safe to do so.  Note, that usage
   // of the context manager does not support multiple threads calling
   // this open() function on the same ip. The intended use-case
   // (xrt::kernel) prevents this situation.
-  void
-  open(slot_id slot, const xrt::uuid& uuid, const std::string& ipname, bool shared)
+  cuidx_type
+  open(const xrt::hw_context& hwctx, const std::string& ipname)
   {
     std::unique_lock<std::mutex> ul(m_mutex);
-    auto [idx, ctx] = get_idx_ctx(slot, ipname);
-    while (ctx && ctx->test(idx)) {
+    auto ctxhdl = xrt_core::hw_context_int::get_xcl_handle(hwctx);
+    auto [ipidx, ctx] = get_ipidx_ctx(ctxhdl, ipname);
+    while (ctx && ctx->test(ctxidx(ipidx))) {
       if (m_cv.wait_for(ul, 100ms) == std::cv_status::timeout)
         throw std::runtime_error("aquiring cu context timed out");
     }
-    m_device->open_context(slot, uuid, ipname, shared);
+    m_device->open_context(ctxhdl, hwctx.get_xclbin_uuid(), ipname, is_shared(hwctx.get_qos()));
 
     // Successful context creation means CU idx is now known
     if (!ctx)
-      std::tie(idx, ctx) = get_idx_ctx(slot, ipname);
+      std::tie(ipidx, ctx) = get_ipidx_ctx(ctxhdl, ipname);
 
     if (!ctx)
       throw std::runtime_error("Unexpected ctx error");
 
-    ctx->set(idx);
-  }
+    ctx->set(ctxidx(ipidx));
 
-  // Open the cu context when it is safe to do so.  Note, that usage
-  // of the context manager does not support multiple threads calling
-  // this open() function on the same ip. The intended use-case
-  // (xrt::kernel) prevents this situation.
-  void
-  open(const xrt::uuid& uuid, cuidx_type ipidx, bool shared)
-  {
-    auto idx = ctxidx(ipidx);
-    std::unique_lock<std::mutex> ul(m_mutex);
-    auto ctx = get_ctx(ipidx);
-    while (ctx->test(idx)) {
-      if (m_cv.wait_for(ul, 100ms) == std::cv_status::timeout)
-        throw std::runtime_error("aquiring cu context timed out");
-    }
-    m_device->open_context(uuid, ipidx.index, shared);
-    ctx->set(idx);
+    return ipidx;
   }
 
   // Close the cu context and notify threads that might be waiting
   // to open this cu
   void
-  close(const xrt::uuid& uuid, cuidx_type ipidx)
+  close(const xrt::hw_context& hwctx, cuidx_type ipidx)
   {
     auto idx = ctxidx(ipidx);
     std::lock_guard<std::mutex> lk(m_mutex);
     auto ctx = get_ctx(ipidx);
     if (!ctx->test(idx))
       throw std::runtime_error("ctx " + std::to_string(ipidx.index) + " not open");
-    m_device->close_context(uuid, ipidx.index);
+    m_device->close_context(hwctx.get_xclbin_uuid(), ipidx.index);
     ctx->reset(idx);
     m_cv.notify_all();
   }
@@ -168,34 +175,22 @@ create(const xrt_core::device* device)
 }
 
 // Regular CU
-void
-open_context(xrt_core::device* device, slot_id slot, const xrt::uuid& uuid, const std::string& cuname, bool shared)
+cuidx_type
+open_context(const xrt::hw_context& hwctx, const std::string& cuname)
 {
-  if (auto ctxmgr = get_device_context_mgr(device)) {
-    ctxmgr->open(slot, uuid, cuname, shared);
-    return;
-  }
-
-  throw std::runtime_error("No context manager for device");
-}
-
-// Virtual CU
-void
-open_context(xrt_core::device* device, const xrt::uuid& uuid, cuidx_type cuidx, bool shared)
-{
-  if (auto ctxmgr = get_device_context_mgr(device)) {
-    ctxmgr->open(uuid, cuidx, shared);
-    return;
-  }
+  auto device = xrt_core::hw_context_int::get_core_device_raw(hwctx);
+  if (auto ctxmgr = get_device_context_mgr(device))
+    return ctxmgr->open(hwctx, cuname);
 
   throw std::runtime_error("No context manager for device");
 }
 
 void
-close_context(xrt_core::device* device, const xrt::uuid& uuid, cuidx_type cuidx)
+close_context(const xrt::hw_context& hwctx, cuidx_type cuidx)
 {
+  auto device = xrt_core::hw_context_int::get_core_device_raw(hwctx);
   if (auto ctxmgr = get_device_context_mgr(device)) {
-    ctxmgr->close(uuid, cuidx);
+    ctxmgr->close(hwctx, cuidx);
     return;
   }
 

--- a/src/runtime_src/core/common/api/context_mgr.h
+++ b/src/runtime_src/core/common/api/context_mgr.h
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2021-2022 Xilinx, Inc. All rights reserved.
+// Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
 
 #include "core/include/xrt/xrt_uuid.h"
+#include "core/include/experimental/xrt_hw_context.h"
+
 #include "core/common/cuidx_type.h"
 #include <memory>
 
@@ -20,7 +23,6 @@ class device;
 namespace context_mgr {
 
 class device_context_mgr;
-using slot_id = uint32_t;    // xrt_core::device::slot_id
 
 // Create a context manager for a specific device The manager is
 // shared and cached so that it is constructed only if necessary.  In
@@ -31,11 +33,9 @@ create(const xrt_core::device* device);
 
 // Open a device context a specified compute unit (ip)
 //
-// @device: device to open context on
-// @slot:   slot index with xclbin
-// @uuid:   xclbin uuid with the CU
-// @ipname: name of IP
-// @shared: open in shared (true) or exclusive mode (false)
+// @hwctx:  hardware context in which the IP should be opened
+// @ipname: name of IP to open
+// @Return: the index of the IP as cuidx_type.
 //
 // The function blocks until the context can be acquired.  If
 // timeout, then the function throws.
@@ -47,37 +47,16 @@ create(const xrt_core::device* device);
 //
 // The function is simply a synchronization between two threads
 // simultanous use of open_context and close_context.
-void
-open_context(xrt_core::device* device, slot_id slot, const xrt::uuid& uuid, const std::string& ipname, bool shared);
-
-// Open a device context a specified compute unit (ip)
-//
-// @device: device to open context on
-// @uuid:   xclbin uuid with the CU
-// @cuidx:  index of CU
-// @shared: open in shared (true) or exclusive mode (false)
-//
-// The function blocks until the context can be acquired.  If
-// timeout, then the function throws.
-//
-// Note that the context manager is not intended to support two or
-// more threads opening a context on the same compute unit. This
-// situation must be guarded by the client (xrt::kernel) of the
-// manager.
-//
-// The function is simply a synchronization between two threads
-// simultanous use of open_context and close_context.
-void
-open_context(xrt_core::device* device, const xrt::uuid& uuid, cuidx_type cuidx, bool shared);
+cuidx_type
+open_context(const xrt::hw_context& hwctx, const std::string& ipname);
 
 // Close a previously opened device context
 //
-// @device: device to close context on
-// @uuid:   xclbin uuid with the CU
+// @hwctx:  hardware context that has the CU opened
 // @cuidx:  index of CU
 //
 // The function throws if no context is open on specified CU.
 void
-close_context(xrt_core::device* device, const xrt::uuid& uuid, cuidx_type cuidx);
+close_context(const xrt::hw_context& hwctx, cuidx_type cuidx);
 
 }} // context_mgr, xrt_core


### PR DESCRIPTION
#### Problem solved by the commit
Use hwctx in IP context manager

#### How problem was solved, alternative solutions (if any) and why they were rejected
This is continuation of changes in #6727 and #6731.  Use of
xrt::hw_context will move all the way to xclOpenContextByName, but
changes are done in small incremental steps.

This PR changes the context manager to return the IP index upon
successfully opening the IP.  This simplifies how ip_context
gets the IP index.

#### What has been tested and how, request additional testing if necessary
HW regression tests