### PR TITLE
enable xgq cid for debugging

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_ctrl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_ctrl.c
@@ -763,7 +763,7 @@ static void ert_ctrl_dump_xgq(struct platform_device *pdev)
 
 	/* special value at 0x600 */
 	print_hex_dump(KERN_INFO, "raw data: ", DUMP_PREFIX_OFFSET,
-		       16, 4, ec->ec_cq_base + 0x600, 16, true);
+		       16, 4, ec->ec_cq_base + 0x600, 48, true);
 }
 
 static int ert_ctrl_xgq_ip_init(struct platform_device *pdev)

--- a/src/runtime_src/ert/scheduler/sched_cmd.h
+++ b/src/runtime_src/ert/scheduler/sched_cmd.h
@@ -19,6 +19,8 @@
 #include "xgq_impl.h"
 #include "xgq_cmd_ert.h"
 
+#define XGQ_CMD_DEBUG
+
 /* One CU command. */
 struct sched_cmd {
 	uint64_t cc_addr;
@@ -45,6 +47,9 @@ static inline void cmd_load_header(struct sched_cmd *cu_cmd)
 	 */
 	if (cu_cmd->cc_header.hdr.header[0] != 0)
 		cu_cmd->cc_header.hdr.header[0] = reg_read((uint64_t)(uintptr_t)&ch->hdr.header[0]);
+#endif
+#ifdef XGQ_CMD_DEBUG
+	cu_cmd->cc_header.hdr.header[1] = reg_read((uint64_t)(uintptr_t)&ch->hdr.header[1]);
 #endif
 }
 

--- a/src/runtime_src/ert/scheduler/xgq_ctrl.c
+++ b/src/runtime_src/ert/scheduler/xgq_ctrl.c
@@ -72,6 +72,15 @@ struct sched_cmd *xgq_ctrl_get_cmd(struct xgq_ctrl *xgq_ctrl)
 		if (!ret) {
 			cmd_set_addr(cmd, addr);
 			cmd_load_header(cmd);
+            /* TODO: for debug */
+            {
+                uint32_t off = addr & 0x00000FFF;
+                uint32_t cq_base = addr & 0xFFFFF000;
+                if ((off != 0x30) && (off != 0x230)) {
+                    xgq_reg_write32(0, cq_base + 0x604, off);
+                }
+            }
+            /* debug end */
 		}
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Add XGQ CID in MB ERT for debug. This will lower the performance of iops. So, this will be disable before 2022.2 release.