### PR TITLE
Issue #6640 Option to disable warnings as error 

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -43,6 +43,7 @@ usage()
     echo "[-dbg]                      Build debug library only (default)"
     echo "[-opt]                      Build optimized library only (default)"
     echo "[-edge]                     Build edge of x64.  Turns off opt and dbg"
+    echo "[-no-werror]                Disable compilation with warnings as error"
     echo "[-nocmake]                  Skip CMake call"
     echo "[-noctest]                  Skip unit tests"
     echo "[-with-static-boost <boost> Build binaries using static linking of boost from specified boost install"
@@ -132,6 +133,10 @@ while [ $# -gt 0 ]; do
             ;;
         -noctest)
             noctest=1
+            shift
+            ;;
+        -no-werror|--no-werror)
+            cmake_flags+=" -DXRT_NO_WERROR=1"
             shift
             ;;
         -j)

--- a/build/build.sh
+++ b/build/build.sh
@@ -43,7 +43,7 @@ usage()
     echo "[-dbg]                      Build debug library only (default)"
     echo "[-opt]                      Build optimized library only (default)"
     echo "[-edge]                     Build edge of x64.  Turns off opt and dbg"
-    echo "[-no-werror]                Disable compilation with warnings as error"
+    echo "[-disable-werror]           Disable compilation with warnings as error"
     echo "[-nocmake]                  Skip CMake call"
     echo "[-noctest]                  Skip unit tests"
     echo "[-with-static-boost <boost> Build binaries using static linking of boost from specified boost install"
@@ -90,6 +90,7 @@ noctest=0
 static_boost=""
 ertbsp=""
 ertfw=""
+werror=1
 cmake_flags="-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
 
 while [ $# -gt 0 ]; do
@@ -135,8 +136,8 @@ while [ $# -gt 0 ]; do
             noctest=1
             shift
             ;;
-        -no-werror|--no-werror)
-            cmake_flags+=" -DXRT_NO_WERROR=1"
+        -disable-werror|--disable-werror)
+            werror=0
             shift
             ;;
         -j)
@@ -200,6 +201,11 @@ done
 debug_dir=${DEBUG_DIR:-Debug}
 release_dir=${REL_DIR:-Release}
 edge_dir=${EDGE_DIR:-Edge}
+
+# By default compile with warnings as errors.
+# Update every time CMake is generating makefiles.
+# Disable with '-disable-werror' option.
+cmake_flags+=" -DXRT_ENABLE_WERROR=$werror"
 
 here=$PWD
 cd $BUILDDIR

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,7 +31,7 @@ endif()
 
 if ( ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" )
   set(XRT_WARN_OPTS
-  -Wall -Werror
+  -Wall
   -Wno-mismatched-tags
   -Wno-unused-const-variable
   -Wno-unused-private-field
@@ -45,7 +45,7 @@ if ( ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" )
   -Wno-overloaded-virtual
    )
 else()
-  set(XRT_WARN_OPTS -Wall -Werror )
+  set(XRT_WARN_OPTS -Wall)
 endif()
 
 if (DEFINED ENV{XRT_NATIVE_BUILD})

--- a/src/runtime_src/CMakeLists.txt
+++ b/src/runtime_src/CMakeLists.txt
@@ -23,7 +23,10 @@ endif()
 
 add_compile_options("-fPIC")
 
-# TODO CL_TARGET_OPENCL_VERSION is not defined..
+if (NOT XRT_NO_WERROR)
+  list(APPEND XRT_WARN_OPTS "-Werror")
+endif(NOT XRT_NO_WERROR)
+
 if (${XRT_NATIVE_BUILD} STREQUAL "yes")
   add_compile_options( ${XRT_WARN_OPTS} )
 endif()

--- a/src/runtime_src/CMakeLists.txt
+++ b/src/runtime_src/CMakeLists.txt
@@ -23,9 +23,9 @@ endif()
 
 add_compile_options("-fPIC")
 
-if (NOT XRT_NO_WERROR)
+if (XRT_ENABLE_WERROR)
   list(APPEND XRT_WARN_OPTS "-Werror")
-endif(NOT XRT_NO_WERROR)
+endif(XRT_ENABLE_WERROR)
 
 if (${XRT_NATIVE_BUILD} STREQUAL "yes")
   add_compile_options( ${XRT_WARN_OPTS} )


### PR DESCRIPTION
#### Problem solved by the commit
Provide build.sh option `-disable-werror` to disable warnings
as errors.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Issue #6640 

#### How problem was solved, alternative solutions (if any) and why they were rejected
Not willing to disable `-Werror` by default, since I can't seem to
find a good way to have it enabled for all internal builds including
all developers.

#### Risks (if any) associated the changes in the commit
Fixes https://github.com/Xilinx/XRT/issues/6640, maybe not exactly per comments, but close enough.
