### PR TITLE
fix CR-1130364

### DIFF
--- a/src/runtime_src/core/common/drv/include/kds_core.h
+++ b/src/runtime_src/core/common/drv/include/kds_core.h
@@ -215,6 +215,7 @@ int kds_map_cu_addr(struct kds_sched *kds, struct kds_client *client,
 int kds_add_command(struct kds_sched *kds, struct kds_command *xcmd);
 /* Use this function in xclbin download flow for config commands */
 int kds_submit_cmd_and_wait(struct kds_sched *kds, struct kds_command *xcmd);
+int kds_set_cu_read_range(struct kds_sched *kds, u32 cu_idx, u32 start, u32 size);
 
 struct kds_command *kds_alloc_command(struct kds_client *client, u32 size);
 

--- a/src/runtime_src/core/common/drv/include/xrt_cu.h
+++ b/src/runtime_src/core/common/drv/include/xrt_cu.h
@@ -270,12 +270,20 @@ struct xrt_cu_log {
 #define CU_LOG_STAGE_SQ		3
 #define CU_LOG_STAGE_CQ		4
 
+struct xrt_cu_range {
+	struct mutex		  xcr_lock;
+	u32			  xcr_start;
+	u32			  xcr_end;
+};
+
 /* Supported event type */
 struct xrt_cu {
 	struct device		 *dev;
 	struct xrt_cu_info	  info;
 	struct resource		**res;
 	struct list_head	  cu;
+	/* Range of Read-only registers */
+	struct xrt_cu_range	  read_regs;
 	/* pending queue */
 	struct list_head	  pq;
 	spinlock_t		  pq_lock;

--- a/src/runtime_src/core/common/drv/xrt_cu.c
+++ b/src/runtime_src/core/common/drv/xrt_cu.c
@@ -738,6 +738,9 @@ int xrt_cu_init(struct xrt_cu *xcu)
 	INIT_LIST_HEAD(&xcu->events);
 	sema_init(&xcu->sem, 0);
 	sema_init(&xcu->sem_cu, 0);
+	mutex_init(&xcu->read_regs.xcr_lock);
+	xcu->read_regs.xcr_start = -1;
+	xcu->read_regs.xcr_end = -1;
 
 	INIT_LIST_HEAD(&xcu->hpq);
 	spin_lock_init(&xcu->hpq_lock);

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -282,6 +282,9 @@ enum class key_type
   hwmon_sdm_fan_presence,
   hotplug_offline,
 
+  cu_size,
+  cu_read_range,
+
   noop
 };
 
@@ -3037,6 +3040,28 @@ struct hotplug_offline : request
 
   virtual boost::any
   get(const device*) const = 0;
+};
+
+struct cu_size : request
+{
+  using result_type = uint32_t;
+  static const key_type key = key_type::cu_size;
+
+  virtual boost::any
+  get(const device* device, const boost::any& cu_idx) const = 0;
+};
+
+struct cu_read_range : request
+{
+  struct range_data {
+      uint32_t start;
+      uint32_t end;
+  };
+  using result_type = range_data;
+  static const key_type key = key_type::cu_read_range;
+
+  virtual boost::any
+  get(const device* device, const boost::any& cu_idx) const = 0;
 };
 
 } // query

--- a/src/runtime_src/core/include/deprecated/xrt.h
+++ b/src/runtime_src/core/include/deprecated/xrt.h
@@ -191,6 +191,27 @@ int
 xclExecBufWithWaitList(xclDeviceHandle handle, xclBufferHandle cmdBO,
                        size_t num_bo_in_wait_list, xclBufferHandle *bo_wait_list);
 
+/* 
+ * This function is for internal use. We don't want outside user to use it.
+ * Once the internal project move to XRT APIs. Then we can create an internal function
+ * and remove this one.
+ */
+ /*
+  * @handle: Device handle
+  * @ipIndex: IP index
+  * @start: the start offset of the read-only register range
+  * @size: the size of the read-only register range
+  * Return: 0 on success or appropriate error number
+  *
+  * This function is to set the read-only register range on a CU. It will be system-wide impact.
+  * This is used when open a CU in shared context. It allows multiple users to call xclRegRead()
+  * to access CU without impact KDS/ERT scheduling. It is not able to change the range after
+  * the first xclRegRead().
+  * This function returns error when called in an exclusive context.
+  */
+XCL_DRIVER_DLLESPEC
+int
+xclIPSetReadRange(xclDeviceHandle handle, uint32_t ipIndex, uint32_t start, uint32_t size);
 #ifdef __cplusplus
 }
 #endif

--- a/src/runtime_src/core/pcie/driver/linux/include/xocl_ioctl.h
+++ b/src/runtime_src/core/pcie/driver/linux/include/xocl_ioctl.h
@@ -164,6 +164,8 @@ enum drm_xocl_ops {
 	DRM_XOCL_FREE_CMA,
 	/* Memory to Memory BO copy */
 	DRM_XOCL_COPY_BO,
+	/* Set CU read-only range */
+	DRM_XOCL_SET_READ_RANGE,
 
 	/* The following IOCTLs can only be called from linux kernel space
 	 * WARNING: INTERNAL USE ONLY. NOT FOR PUBLIC CONSUMPTION.
@@ -338,6 +340,12 @@ struct drm_xocl_copy_bo {
 	uint64_t size;
 	uint64_t dst_offset;
 	uint64_t src_offset;
+};
+
+struct drm_xocl_set_range {
+	uint32_t cu_index;
+	uint32_t start;
+	uint32_t size;
 };
 
 /**
@@ -693,6 +701,7 @@ struct drm_xocl_alloc_cma_info {
 #define	DRM_IOCTL_XOCL_ALLOC_CMA	XOCL_IOC_ARG(ALLOC_CMA, alloc_cma_info)
 #define	DRM_IOCTL_XOCL_FREE_CMA		XOCL_IOC(FREE_CMA)
 #define	DRM_IOCTL_XOCL_COPY_BO		XOCL_IOC_ARG(COPY_BO, copy_bo)
+#define	DRM_IOCTL_XOCL_SET_READ_RANGE	XOCL_IOC_ARG(SET_READ_RANGE, set_range)
 
 #define	DRM_IOCTL_XOCL_KINFO_BO		XOCL_IOC_ARG(KINFO_BO, kinfo_bo)
 #define	DRM_IOCTL_XOCL_MAP_KERN_MEM	XOCL_IOC_ARG(MAP_KERN_MEM, map_kern_mem)

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/cu.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/cu.c
@@ -199,6 +199,22 @@ crc_buf_show(struct file *filp, struct kobject *kobj,
 	return xrt_cu_circ_consume_all(xcu, buf, count);
 }
 
+static ssize_t
+read_range_show(struct device *dev, struct device_attribute *attr, char *buf)
+{
+	struct platform_device *pdev = to_platform_device(dev);
+	struct xocl_cu *cu = platform_get_drvdata(pdev);
+	u32 start = 0;
+	u32 end = 0;
+
+	mutex_lock(&cu->base.read_regs.xcr_lock);
+	start = cu->base.read_regs.xcr_start;
+	end = cu->base.read_regs.xcr_end;
+	mutex_unlock(&cu->base.read_regs.xcr_lock);
+	return sprintf(buf, "0x%x 0x%x\n", start, end);
+}
+static DEVICE_ATTR_RO(read_range);
+
 static struct attribute *cu_attrs[] = {
 	&dev_attr_debug.attr,
 	&dev_attr_cu_stat.attr,
@@ -210,6 +226,7 @@ static struct attribute *cu_attrs[] = {
 	&dev_attr_size.attr,
 	&dev_attr_stat.attr,
 	&dev_attr_is_ucu.attr,
+	&dev_attr_read_range.attr,
 	NULL,
 };
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/common.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/common.h
@@ -169,6 +169,8 @@ int xocl_alloc_cma_ioctl(struct drm_device *dev, void *data,
 	struct drm_file *filp);
 int xocl_free_cma_ioctl(struct drm_device *dev, void *data,
 	struct drm_file *filp);
+int xocl_set_range_ioctl(struct drm_device *dev, void *data,
+	struct drm_file *filp);
 
 /* sysfs functions */
 int xocl_init_sysfs(struct xocl_dev *xdev);
@@ -235,5 +237,7 @@ int xocl_kds_register_cus(struct xocl_dev *xdev, int slot_hd, xuid_t *uuid,
 			  struct ip_layout *ip_layout,
 			  struct ps_kernel_node *ps_kernel);
 void xocl_kds_unregister_cus(struct xocl_dev *xdev, int slot_hd);
+int xocl_kds_set_cu_read_range(struct xocl_dev *xdev, u32 cu_idx,
+			       u32 start, u32 size);
 
 #endif

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
@@ -432,6 +432,8 @@ static const struct drm_ioctl_desc xocl_ioctls[] = {
 			  DRM_AUTH|DRM_UNLOCKED|DRM_RENDER_ALLOW),
 	DRM_IOCTL_DEF_DRV(XOCL_FREE_CMA, xocl_free_cma_ioctl,
 			  DRM_AUTH|DRM_UNLOCKED|DRM_RENDER_ALLOW),
+	DRM_IOCTL_DEF_DRV(XOCL_SET_READ_RANGE, xocl_set_range_ioctl,
+			  DRM_AUTH|DRM_UNLOCKED|DRM_RENDER_ALLOW),
 
 /* LINUX KERNEL-SPACE IOCTLS - The following entries are meant to be
  * accessible only from Linux Kernel and need be grouped to at the end

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
@@ -657,3 +657,15 @@ int xocl_free_cma_ioctl(struct drm_device *dev, void *data,
 
 	return err;
 }
+
+int xocl_set_range_ioctl(struct drm_device *dev, void *data,
+			 struct drm_file *filp)
+{
+	struct drm_xocl_set_range *info = data;
+	struct xocl_drm *drm_p = dev->dev_private;
+	struct xocl_dev *xdev = drm_p->xdev;
+	int ret = 0;
+
+	ret = xocl_kds_set_cu_read_range(xdev, info->cu_index, info->start, info->size);
+	return ret;
+}

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -2118,3 +2118,9 @@ void xocl_kds_unregister_cus(struct xocl_dev *xdev, int slot_hdl)
 	kds_reset(&XDEV(xdev)->kds);
 }
 
+int xocl_kds_set_cu_read_range(struct xocl_dev *xdev, u32 cu_idx,
+			       u32 start, u32 size)
+{
+	return kds_set_cu_read_range(&XDEV(xdev)->kds, cu_idx, start, size);
+}
+

--- a/src/runtime_src/core/pcie/linux/shim.h
+++ b/src/runtime_src/core/pcie/linux/shim.h
@@ -130,6 +130,7 @@ public:
   int xclExecWait(int timeoutMilliSec);
   int xclOpenContext(const uuid_t xclbinId, unsigned int ipIndex, bool shared) const;
   int xclCloseContext(const uuid_t xclbinId, unsigned int ipIndex);
+  int xclIPSetReadRange(uint32_t ipIndex, uint32_t start, uint32_t size);
 
   int getBoardNumber( void ) { return mBoardNumber; }
 
@@ -175,7 +176,13 @@ private:
    * Mapped CU register space for xclRegRead/Write(). We support at most
    * 128 CUs and each CU map is a pair <address, size>.
    */
-  std::vector<std::pair<uint32_t*, uint32_t>> mCuMaps;
+  struct CuData {
+      uint32_t* addr;
+      uint32_t  size;
+      uint32_t  start;
+      uint32_t  end;
+  };
+  std::vector<CuData> mCuMaps;
   std::mutex mCuMapLock;
 
   bool zeroOutDDR();


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Some internal users want to access some CU register in a shared context. They still want to use KDS/ERT. But XRT xclRegRead() doesn't allow read with a shared context.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Not a bug.

#### How problem was solved, alternative solutions (if any) and why they were rejected
We don't want to change the old behavior too much. So, when CU is opened in an exclusive context, everything will be the same.

What's changed:
1. When open a CU in a shared context, call xclIPSetReadRange() to set a read only range on the CU. This will allow xclRegRead() to read this range even KDS/ERT is still running.
2. The new API is added in deprecated/xrt.h, it will be move to the internal header file when the internal user move to XRT APIs.

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
u50/vck5000 xbutil validate, local xclRegRead() test cases.

#### Documentation impact (if any)
No