### PR TITLE
Add AIE_profile_settings and AIE_trace_settings config and their usages

### DIFF
--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -850,6 +850,115 @@ get_device_offline_timer()
   return value;
 }
 
+// Configurations under AIE_profile_settings section
+inline unsigned int
+get_aie_profile_settings_interval_us()
+{
+  static unsigned int value = detail::get_uint_value("AIE_profile_settings.interval_us", 1000) ;
+  return value ;
+}
+
+inline std::string
+get_aie_profile_settings_graph_core_metrics()
+{
+  static std::string value = detail::get_string_value("AIE_profile_settings.graph_core_metrics", "");
+  return value;
+}
+
+inline std::string
+get_aie_profile_settings_graph_memory_metrics()
+{
+  static std::string value = detail::get_string_value("AIE_profile_settings.graph_memory_metrics", "");
+  return value;
+}
+
+inline std::string
+get_aie_profile_settings_graph_interface_tile_metrics()
+{
+  static std::string value = detail::get_string_value("AIE_profile_settings.graph_interface_tile_metrics", "");
+  return value;
+}
+
+inline std::string
+get_aie_profile_settings_graph_mem_tile_metrics()
+{
+  static std::string value = detail::get_string_value("AIE_profile_settings.graph_mem_tile_metrics", "");
+  return value;
+}
+
+inline std::string
+get_aie_profile_settings_core_metrics()
+{
+  static std::string value = detail::get_string_value("AIE_profile_settings.core_metrics", "");
+  return value;
+}
+
+inline std::string
+get_aie_profile_settings_memory_metrics()
+{
+  static std::string value = detail::get_string_value("AIE_profile_settings.memory_metrics", "");
+  return value;
+}
+
+inline std::string
+get_aie_profile_settings_interface_tile_metrics()
+{
+  static std::string value = detail::get_string_value("AIE_profile_settings.interface_tile_metrics", "");
+  return value;
+}
+
+inline std::string
+get_aie_profile_settings_mem_tile_metrics()
+{
+  static std::string value = detail::get_string_value("AIE_profile_settings.mem_tile_metrics", "");
+  return value;
+}
+
+// AIE_trace_settings
+inline std::string
+get_aie_trace_settings_start_type()
+{
+  static std::string value = detail::get_string_value("AIE_trace_settings.start_type", "off");
+  return value;
+}
+
+inline std::string
+get_aie_trace_settings_start_time()
+{
+  //default value ?
+  static std::string value = detail::get_string_value("AIE_trace_settings.start_time", "0");
+  return value;
+}
+
+inline unsigned int
+get_aie_trace_settings_start_iteration()
+{
+  static unsigned int value = detail::get_uint_value("AIE_trace_settings.start_iteration", 1);
+  return value;
+}
+
+inline std::string
+get_aie_trace_settings_graph_metrics()
+{
+  static std::string value = detail::get_string_value("AIE_profile_settings.graph_metrics", "");
+  return value;
+}
+
+inline std::string
+get_aie_trace_settings_graph_aie_tile_metrics()
+{
+  static std::string value = detail::get_string_value("AIE_profile_settings.graph_aie_tile_metrics", "");
+  return value;
+}
+
+inline std::string
+get_aie_trace_settings_graph_mem_tile_metrics()
+{
+  static std::string value = detail::get_string_value("AIE_profile_settings.graph_mem_tile_metrics", "");
+  return value;
+}
+
+
 }} // config,xrt_core
 
 #endif

--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -940,23 +940,33 @@ get_aie_trace_settings_start_iteration()
 inline std::string
 get_aie_trace_settings_graph_metrics()
 {
-  static std::string value = detail::get_string_value("AIE_profile_settings.graph_metrics", "");
+  static std::string value = detail::get_string_value("AIE_trace_settings.graph_metrics", "");
   return value;
 }
 
 inline std::string
-get_aie_trace_settings_graph_aie_tile_metrics()
+get_aie_trace_settings_aie_tile_metrics()
 {
-  static std::string value = detail::get_string_value("AIE_profile_settings.graph_aie_tile_metrics", "");
+  static std::string value = detail::get_string_value("AIE_trace_settings.aie_tile_metrics", "");
   return value;
 }
 
 inline std::string
-get_aie_trace_settings_graph_mem_tile_metrics()
+get_aie_trace_settings_mem_tile_metrics()
 {
-  static std::string value = detail::get_string_value("AIE_profile_settings.graph_mem_tile_metrics", "");
+  static std::string value = detail::get_string_value("AIE_trace_settings.mem_tile_metrics", "");
   return value;
 }
+
+#if 0
+// Post 2022.2
+inline std::string
+get_aie_trace_settings_interface_tile_metrics()
+{
+  static std::string value = detail::get_string_value("AIE_trace_settings.interface_tile_metrics", "");
+  return value;
+}
+#endif
 
 
 }} // config,xrt_core

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.cpp
@@ -729,7 +729,7 @@ namespace xdp {
         auto& xaieTile  = (mod == XAIE_PL_MOD) ? aieDevice->tile(col, 0) 
                         : aieDevice->tile(col, row + 1);
         auto xaieModule = (mod == XAIE_CORE_MOD) ? xaieTile.core()
-                        : ((mod == XAIE_MEM_MOD) ? xaieTile.mem()
+                        : ((mod == XAIE_MEM_MOD) ? xaieTile.mem() 
                         : xaieTile.pl());
         
         for (int i=0; i < numFreeCounters; ++i) {

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.cpp
@@ -1208,7 +1208,7 @@ namespace xdp {
 
     metricsConfig.push_back(xrt_core::config::get_aie_profile_settings_graph_core_metrics());
     metricsConfig.push_back(xrt_core::config::get_aie_profile_settings_graph_memory_metrics());
-    metricsConfig.push_back(xrt_core::config::get_aie_profile_settings_graph_interface_metrics());
+    metricsConfig.push_back(xrt_core::config::get_aie_profile_settings_graph_interface_tile_metrics());
 //    metricsConfig.push_back(xrt_core::config::get_aie_profile_settings_graph_mem_tile_metrics());
 
     // Process AIE_profile_settings metrics
@@ -1226,7 +1226,7 @@ namespace xdp {
       if (metricsConfig.empty()){
         std::string modName = moduleNames[module].substr(0, moduleNames[module].find(" "));
         std::string metricMsg = "No graph_metric set specified for " + modName + " module. " +
-                                "Please specify the AIE_profile_settings. graph_" + modname + "_metrics setting in your xrt.ini.";
+                                "Please specify the AIE_profile_settings. graph_" + modName + "_metrics setting in your xrt.ini.";
         xrt_core::message::send(severity_level::warning, "XRT", metricMsg);
         continue;
       }

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.cpp
@@ -656,7 +656,7 @@ namespace xdp {
     xaiefal::XAieDev* aieDevice =
       static_cast<xaiefal::XAieDev*>(db->getStaticInfo().getAieDevice(allocateAieDevice, deallocateAieDevice, handle)) ;
     if (!aieDevInst || !aieDevice) {
-      xrt_core::message::send(severity_level::warning, "XRT", 
+      xrt_core::message::send(severity_level::warning, "XRT",
           "Unable to get AIE device. There will be no AIE profiling.");
       return false;
     }
@@ -677,10 +677,10 @@ namespace xdp {
 
     int numCounters[NUM_MODULES] =
         {NUM_CORE_COUNTERS, NUM_MEMORY_COUNTERS, NUM_SHIM_COUNTERS};
-    XAie_ModuleType falModuleTypes[NUM_MODULES] = 
+    XAie_ModuleType falModuleTypes[NUM_MODULES] =
         {XAIE_CORE_MOD, XAIE_MEM_MOD, XAIE_PL_MOD};
     std::string moduleNames[NUM_MODULES] = {"core", "memory", "interface tile"};
-    std::string metricSettings[NUM_MODULES] = 
+    std::string metricSettings[NUM_MODULES] =
         {xrt_core::config::get_aie_profile_core_metrics(),
          xrt_core::config::get_aie_profile_memory_metrics(),
          interfaceMetric};
@@ -709,29 +709,29 @@ namespace xdp {
       // Get vector of pre-defined metrics for this set
       uint8_t resetEvent = 0;
       auto startEvents = (mod == XAIE_CORE_MOD) ? mCoreStartEvents[metricSet]
-                       : ((mod == XAIE_MEM_MOD) ? mMemoryStartEvents[metricSet] 
+                       : ((mod == XAIE_MEM_MOD) ? mMemoryStartEvents[metricSet]
                        : mShimStartEvents[metricSet]);
       auto endEvents   = (mod == XAIE_CORE_MOD) ? mCoreEndEvents[metricSet]
-                       : ((mod == XAIE_MEM_MOD) ? mMemoryEndEvents[metricSet] 
+                       : ((mod == XAIE_MEM_MOD) ? mMemoryEndEvents[metricSet]
                        : mShimEndEvents[metricSet]);
 
       int numTileCounters[NUM_COUNTERS+1] = {0};
-      
+
       // Iterate over tiles and metrics to configure all desired counters
       for (auto& tile : tiles) {
         int numCounters = 0;
         auto col = tile.col;
         auto row = tile.row;
-        
+
         // NOTE: resource manager requires absolute row number
-        auto loc        = (mod == XAIE_PL_MOD) ? XAie_TileLoc(col, 0) 
+        auto loc        = (mod == XAIE_PL_MOD) ? XAie_TileLoc(col, 0)
                         : XAie_TileLoc(col, row + 1);
-        auto& xaieTile  = (mod == XAIE_PL_MOD) ? aieDevice->tile(col, 0) 
+        auto& xaieTile  = (mod == XAIE_PL_MOD) ? aieDevice->tile(col, 0)
                         : aieDevice->tile(col, row + 1);
         auto xaieModule = (mod == XAIE_CORE_MOD) ? xaieTile.core()
-                        : ((mod == XAIE_MEM_MOD) ? xaieTile.mem() 
+                        : ((mod == XAIE_MEM_MOD) ? xaieTile.mem()
                         : xaieTile.pl());
-        
+
         for (int i=0; i < numFreeCounters; ++i) {
           auto startEvent = startEvents.at(i);
           auto endEvent   = endEvents.at(i);
@@ -742,10 +742,10 @@ namespace xdp {
           if (ret != XAIE_OK) break;
           ret = perfCounter->reserve();
           if (ret != XAIE_OK) break;
-          
+
           configGroupEvents(aieDevInst, loc, mod, startEvent, metricSet);
           configStreamSwitchPorts(aieDevInst, tile, xaieTile, loc, startEvent, metricSet);
-          
+
           // Start the counters after group events have been configured
           ret = perfCounter->start();
           if (ret != XAIE_OK) break;
@@ -768,7 +768,7 @@ namespace xdp {
           // Store counter info in database
           std::string counterName = "AIE Counter " + std::to_string(counterId);
           (db->getStaticInfo()).addAIECounter(deviceId, counterId, col, row, i,
-              phyStartEvent, phyEndEvent, resetEvent, payload, clockFreqMhz, 
+              phyStartEvent, phyEndEvent, resetEvent, payload, clockFreqMhz,
               moduleName, counterName);
           counterId++;
           numCounters++;
@@ -984,4 +984,291 @@ namespace xdp {
     mThreadMap.clear();
   }
 
+  // Set metrics for all specified AIE counters on this device with configs given in AIE_profile_settings
+  bool AIEProfilingPlugin::setMetricsSettings(uint64_t deviceId, void* handle)
+  {
+    XAie_DevInst* aieDevInst =
+      static_cast<XAie_DevInst*>(db->getStaticInfo().getAieDevInst(fetchAieDevInst, handle)) ;
+    xaiefal::XAieDev* aieDevice =
+      static_cast<xaiefal::XAieDev*>(db->getStaticInfo().getAieDevice(allocateAieDevice, deallocateAieDevice, handle)) ;
+    if (!aieDevInst || !aieDevice) {
+      xrt_core::message::send(severity_level::warning, "XRT", 
+          "Unable to get AIE device. There will be no AIE profiling.");
+      return false;
+    }
+
+    int counterId = 0;
+    bool runtimeCounters = false;
+
+    // Currently supporting Core, Memory, Interface Tile metrics only. Need to add Memory Tile metrics
+    constexpr int NUM_MODULES = 3;
+
+    // Get the metrics settings
+    std::vector<std::string> metricsConfig;
+
+    metricsConfig.push_back(xrt_core::config::get_aie_profile_settings_core_metrics());
+    metricsConfig.push_back(xrt_core::config::get_aie_profile_settings_memory_metrics());
+    metricsConfig.push_back(xrt_core::config::get_aie_profile_settings_interface_metrics());
+//    metricsConfig.push_back(xrt_core::config::get_aie_profile_settings_mem_tile_metrics());
+
+    // Process AIE_profile_settings metrics
+    // Each of the metrics can have ; separated multiple values. Process and save all
+    std::vector<std::vector<std::string>> metricsSettings(NUM_MODULES);
+
+#if 0
+    typedef std::vector<std::vector<std::string>> 2DStringVectorType;
+    std::vector<2DStringVectorType> metricsSettings(NUM_MODULES);
+#endif
+
+    std::string moduleNames[NUM_MODULES] = {"core", "memory", "interface tile"};
+
+    for(int module = 0; module < NUM_MODULES; ++module) {
+      if (metricsConfig.empty()){
+        std::string modName = moduleNames[module].substr(0, moduleNames[module].find(" "));
+        std::string metricMsg = "No metric set specified for " + modName + " module. " +
+                                "Please specify the AIE_profile_settings." + modname + "_metrics" + " or Debug.aie_profile_" + modName + "_metrics setting in your xrt.ini.";
+        xrt_core::message::send(severity_level::warning, "XRT", metricMsg);
+        continue;
+      }
+      boost::split(metricSettings[module], metricsConfig[module], boost::is_any_of(";"));
+
+#if 0
+      std::vector<std::string> multMetricVal;
+      boost::split(multMetricsVal, metricsConfig[module], boost::is_any_of(";"));
+
+      2DStringVectorType metricValVec(multMetricVal.size());
+
+      for(size_t i = 0; i < multMetricVal.size(); i++) {
+        boost::split(metricValVec[i], multMetricVal[i], boost::is_any_of(":"));
+      }
+      metricSettings[module] = metricValVec;
+#endif
+    }
+
+    // Get AIE clock frequency
+    std::shared_ptr<xrt_core::device> device = xrt_core::get_userpf_device(handle);
+    auto clockFreqMhz = xrt_core::edge::aie::get_clock_freq_mhz(device.get());
+
+    // Get Channel Id in interface metric ; check all the entries
+    for(auto &interfaceMetric : metricsSettings[NUM_MODULES-1]) {
+      if(3 == interfaceMetric.size()) {
+        // current entry has channel ID
+        try {
+          mChannelId = std::stoi(interfaceMetric.at(2));
+          // Found one channel id, now break the loop
+          break;
+        }
+        catch (...) {
+          mChannelId = -1;
+        }
+      }
+    }
+
+    int numCounters[NUM_MODULES] =
+        {NUM_CORE_COUNTERS, NUM_MEMORY_COUNTERS, NUM_SHIM_COUNTERS};
+    XAie_ModuleType falModuleTypes[NUM_MODULES] = 
+        {XAIE_CORE_MOD, XAIE_MEM_MOD, XAIE_PL_MOD};
+
+    // Configure core, memory, and shim counters
+    for (int module=0; module < NUM_MODULES; ++module) {
+      std::string metricsStr = metricSettings[module];
+
+      int NUM_COUNTERS       = numCounters[module];
+      XAie_ModuleType mod    = falModuleTypes[module];
+      std::string moduleName = moduleNames[module];
+      auto metricSet         = getMetricSet(mod, metricsStr);
+      auto tiles             = getTilesForProfiling(mod, metricsStr, handle);
+
+
+      // Ask Resource manager for resource availability
+      auto numFreeCounters   = getNumFreeCtr(aieDevice, tiles, mod, metricSet);
+      if (numFreeCounters == 0)
+        continue;
+
+      // Get vector of pre-defined metrics for this set
+      uint8_t resetEvent = 0;
+      auto startEvents = (mod == XAIE_CORE_MOD) ? mCoreStartEvents[metricSet]
+                       : ((mod == XAIE_MEM_MOD) ? mMemoryStartEvents[metricSet] 
+                       : mShimStartEvents[metricSet]);
+      auto endEvents   = (mod == XAIE_CORE_MOD) ? mCoreEndEvents[metricSet]
+                       : ((mod == XAIE_MEM_MOD) ? mMemoryEndEvents[metricSet] 
+                       : mShimEndEvents[metricSet]);
+
+      int numTileCounters[NUM_COUNTERS+1] = {0};
+      
+      // Iterate over tiles and metrics to configure all desired counters
+      for (auto& tile : tiles) {
+        int numCounters = 0;
+        auto col = tile.col;
+        auto row = tile.row;
+        
+        // NOTE: resource manager requires absolute row number
+        auto loc        = (mod == XAIE_PL_MOD) ? XAie_TileLoc(col, 0) 
+                        : XAie_TileLoc(col, row + 1);
+        auto& xaieTile  = (mod == XAIE_PL_MOD) ? aieDevice->tile(col, 0) 
+                        : aieDevice->tile(col, row + 1);
+        auto xaieModule = (mod == XAIE_CORE_MOD) ? xaieTile.core()
+                        : ((mod == XAIE_MEM_MOD) ? xaieTile.mem() 
+                        : xaieTile.pl());
+        
+        for (int i=0; i < numFreeCounters; ++i) {
+          auto startEvent = startEvents.at(i);
+          auto endEvent   = endEvents.at(i);
+
+          // Request counter from resource manager
+          auto perfCounter = xaieModule.perfCounter();
+          auto ret = perfCounter->initialize(mod, startEvent, mod, endEvent);
+          if (ret != XAIE_OK) break;
+          ret = perfCounter->reserve();
+          if (ret != XAIE_OK) break;
+          
+          configGroupEvents(aieDevInst, loc, mod, startEvent, metricSet);
+          configStreamSwitchPorts(aieDevInst, tile, xaieTile, loc, startEvent, metricSet);
+          
+          // Start the counters after group events have been configured
+          ret = perfCounter->start();
+          if (ret != XAIE_OK) break;
+          mPerfCounters.push_back(perfCounter);
+
+          // Convert enums to physical event IDs for reporting purposes
+          uint8_t tmpStart;
+          uint8_t tmpEnd;
+          XAie_EventLogicalToPhysicalConv(aieDevInst, loc, mod, startEvent, &tmpStart);
+          XAie_EventLogicalToPhysicalConv(aieDevInst, loc, mod,   endEvent, &tmpEnd);
+          uint16_t phyStartEvent = (mod == XAIE_CORE_MOD) ? tmpStart
+                                 : ((mod == XAIE_MEM_MOD) ? (tmpStart + BASE_MEMORY_COUNTER)
+                                 : (tmpStart + BASE_SHIM_COUNTER));
+          uint16_t phyEndEvent   = (mod == XAIE_CORE_MOD) ? tmpEnd
+                                 : ((mod == XAIE_MEM_MOD) ? (tmpEnd + BASE_MEMORY_COUNTER)
+                                 : (tmpEnd + BASE_SHIM_COUNTER));
+
+          auto payload = getCounterPayload(aieDevInst, tile, col, row, startEvent);
+
+          // Store counter info in database
+          std::string counterName = "AIE Counter " + std::to_string(counterId);
+          (db->getStaticInfo()).addAIECounter(deviceId, counterId, col, row, i,
+              phyStartEvent, phyEndEvent, resetEvent, payload, clockFreqMhz, 
+              moduleName, counterName);
+          counterId++;
+          numCounters++;
+        }
+
+        std::stringstream msg;
+        msg << "Reserved " << numCounters << " counters for profiling AIE tile (" << col << "," << row << ").";
+        xrt_core::message::send(severity_level::debug, "XRT", msg.str());
+        numTileCounters[numCounters]++;
+      }
+
+      // Report counters reserved per tile
+      {
+        std::stringstream msg;
+        msg << "AIE profile counters reserved in " << moduleName << " modules - ";
+        for (int n=0; n <= NUM_COUNTERS; ++n) {
+          if (numTileCounters[n] == 0) continue;
+          msg << n << ": " << numTileCounters[n] << " tiles";
+          if (n != NUM_COUNTERS) msg << ", ";
+
+          (db->getStaticInfo()).addAIECounterResources(deviceId, n, numTileCounters[n], module);
+        }
+        xrt_core::message::send(severity_level::info, "XRT", msg.str());
+      }
+
+      runtimeCounters = true;
+    } // for module
+
+    return runtimeCounters;
+  }
+
+  // Set Graph Metrics for all specified AIE counters on this device with configs given in AIE_profile_settings
+  bool AIEProfilingPlugin::setGraphMetricsSettings(uint64_t deviceId, void* handle)
+  {
+    XAie_DevInst* aieDevInst =
+      static_cast<XAie_DevInst*>(db->getStaticInfo().getAieDevInst(fetchAieDevInst, handle)) ;
+    xaiefal::XAieDev* aieDevice =
+      static_cast<xaiefal::XAieDev*>(db->getStaticInfo().getAieDevice(allocateAieDevice, deallocateAieDevice, handle)) ;
+    if (!aieDevInst || !aieDevice) {
+      xrt_core::message::send(severity_level::warning, "XRT", 
+          "Unable to get AIE device. There will be no AIE profiling.");
+      return false;
+    }
+
+    int counterId = 0;
+    bool runtimeCounters = false;
+
+    // Currently supporting Core, Memory, Interface Tile metrics only. Need to add Memory Tile metrics
+    constexpr int NUM_MODULES = 3;
+
+    // Get the metrics settings
+    std::vector<std::string> metricsConfig;
+
+    metricsConfig.push_back(xrt_core::config::get_aie_profile_settings_graph_core_metrics());
+    metricsConfig.push_back(xrt_core::config::get_aie_profile_settings_graph_memory_metrics());
+    metricsConfig.push_back(xrt_core::config::get_aie_profile_settings_graph_interface_metrics());
+//    metricsConfig.push_back(xrt_core::config::get_aie_profile_settings_graph_mem_tile_metrics());
+
+    // Process AIE_profile_settings metrics
+    // Each of the metrics can have ; separated multiple values. Process and save all
+    std::vector<std::vector<std::string>> metricsSettings(NUM_MODULES);
+
+#if 0
+    typedef std::vector<std::vector<std::string>> 2DStringVectorType;
+    std::vector<2DStringVectorType> metricsSettings(NUM_MODULES);
+#endif
+
+    std::string moduleNames[NUM_MODULES] = {"core", "memory", "interface tile"};
+
+    for(int module = 0; module < NUM_MODULES; ++module) {
+      if (metricsConfig.empty()){
+        std::string modName = moduleNames[module].substr(0, moduleNames[module].find(" "));
+        std::string metricMsg = "No graph_metric set specified for " + modName + " module. " +
+                                "Please specify the AIE_profile_settings. graph_" + modname + "_metrics setting in your xrt.ini.";
+        xrt_core::message::send(severity_level::warning, "XRT", metricMsg);
+        continue;
+      }
+      boost::split(metricSettings[module], metricsConfig[module], boost::is_any_of(";"));
+
+#if 0
+      std::vector<std::string> multMetricVal;
+      boost::split(multMetricsVal, metricsConfig[module], boost::is_any_of(";"));
+
+      2DStringVectorType metricValVec(multMetricVal.size());
+
+      for(size_t i = 0; i < multMetricVal.size(); i++) {
+        boost::split(metricValVec[i], multMetricVal[i], boost::is_any_of(":"));
+      }
+      metricSettings[module] = metricValVec;
+#endif
+    }
+
+    // Get AIE clock frequency
+    std::shared_ptr<xrt_core::device> device = xrt_core::get_userpf_device(handle);
+    auto clockFreqMhz = xrt_core::edge::aie::get_clock_freq_mhz(device.get());
+
+    // Get Channel Id in interface metric ; check all the entries
+    for(auto &interfaceMetric : metricsSettings[NUM_MODULES-1]) {
+      if(3 == interfaceMetric.size()) {
+        // current entry has channel ID
+        try {
+          mChannelId = std::stoi(interfaceMetric.at(2));
+          // Found one channel id, now break the loop
+          break;
+        }
+        catch (...) {
+          mChannelId = -1;
+        }
+      }
+    }
+
+    int numCounters[NUM_MODULES] =
+        {NUM_CORE_COUNTERS, NUM_MEMORY_COUNTERS, NUM_SHIM_COUNTERS};
+    XAie_ModuleType falModuleTypes[NUM_MODULES] = 
+        {XAIE_CORE_MOD, XAIE_MEM_MOD, XAIE_PL_MOD};
+
+    // Configure core, memory, and shim counters
+    for (int module=0; module < NUM_MODULES; ++module) {
+      // Implementation
+    }
+
+   }
+ 
 } // end namespace xdp

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.cpp
@@ -1032,7 +1032,7 @@ namespace xdp {
         xrt_core::message::send(severity_level::warning, "XRT", metricMsg);
         continue;
       }
-      boost::split(metricSettings[module], metricsConfig[module], boost::is_any_of(";"));
+      boost::split(metricsSettings[module], metricsConfig[module], boost::is_any_of(";"));
 
 #if 0
       std::vector<std::string> multMetricVal;
@@ -1043,7 +1043,7 @@ namespace xdp {
       for(size_t i = 0; i < multMetricVal.size(); i++) {
         boost::split(metricValVec[i], multMetricVal[i], boost::is_any_of(":"));
       }
-      metricSettings[module] = metricValVec;
+      metricsSettings[module] = metricValVec;
 #endif
     }
 
@@ -1074,7 +1074,7 @@ namespace xdp {
     // Configure core, memory, and shim counters
     for (int module=0; module < NUM_MODULES; ++module) {
 
-      for(auto &metricStr : metricSettings[module]) { 
+      for(auto &metricsStr : metricsSettings[module]) { 
 //      std::string metricsStr = metricSettings[module];
 
         int NUM_COUNTERS       = numCounters[module];
@@ -1230,7 +1230,7 @@ namespace xdp {
         xrt_core::message::send(severity_level::warning, "XRT", metricMsg);
         continue;
       }
-      boost::split(metricSettings[module], metricsConfig[module], boost::is_any_of(";"));
+      boost::split(metricsSettings[module], metricsConfig[module], boost::is_any_of(";"));
 
 #if 0
       std::vector<std::string> multMetricVal;
@@ -1241,7 +1241,7 @@ namespace xdp {
       for(size_t i = 0; i < multMetricVal.size(); i++) {
         boost::split(metricValVec[i], multMetricVal[i], boost::is_any_of(":"));
       }
-      metricSettings[module] = metricValVec;
+      metricsSettings[module] = metricValVec;
 #endif
     }
 

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.cpp
@@ -656,7 +656,7 @@ namespace xdp {
     xaiefal::XAieDev* aieDevice =
       static_cast<xaiefal::XAieDev*>(db->getStaticInfo().getAieDevice(allocateAieDevice, deallocateAieDevice, handle)) ;
     if (!aieDevInst || !aieDevice) {
-      xrt_core::message::send(severity_level::warning, "XRT",
+      xrt_core::message::send(severity_level::warning, "XRT", 
           "Unable to get AIE device. There will be no AIE profiling.");
       return false;
     }

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.cpp
@@ -1035,7 +1035,7 @@ namespace xdp {
     auto clockFreqMhz = xrt_core::edge::aie::get_clock_freq_mhz(device.get());
 
     // Get Channel Id in interface metric ; check all the entries
-    for(auto &interfaceMetric : metricsSettings[NUM_MODULES-1]) {
+    for(auto &interfaceMetric : metricsSettings) {
       if(3 == interfaceMetric.size()) {
         // current entry has channel ID
         try {
@@ -1216,7 +1216,7 @@ namespace xdp {
     auto clockFreqMhz = xrt_core::edge::aie::get_clock_freq_mhz(device.get());
 
     // Get Channel Id in interface metric ; check all the entries
-    for(auto &interfaceMetric : metricsSettings[NUM_MODULES-1]) {
+    for(auto &interfaceMetric : metricsSettings) {
       if(3 == interfaceMetric.size()) {
         // current entry has channel ID
         try {

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.cpp
@@ -1010,7 +1010,7 @@ namespace xdp {
 
     metricsConfig.push_back(xrt_core::config::get_aie_profile_settings_core_metrics());
     metricsConfig.push_back(xrt_core::config::get_aie_profile_settings_memory_metrics());
-    metricsConfig.push_back(xrt_core::config::get_aie_profile_settings_interface_metrics());
+    metricsConfig.push_back(xrt_core::config::get_aie_profile_settings_interface_tile_metrics());
 //    metricsConfig.push_back(xrt_core::config::get_aie_profile_settings_mem_tile_metrics());
 
     // Process AIE_profile_settings metrics
@@ -1273,7 +1273,7 @@ namespace xdp {
     for (int module=0; module < NUM_MODULES; ++module) {
       // Implementation
     }
-
-   }
+    return true;
+  }
  
 } // end namespace xdp

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.cpp
@@ -1028,7 +1028,7 @@ namespace xdp {
       if (metricsConfig.empty()){
         std::string modName = moduleNames[module].substr(0, moduleNames[module].find(" "));
         std::string metricMsg = "No metric set specified for " + modName + " module. " +
-                                "Please specify the AIE_profile_settings." + modname + "_metrics" + " or Debug.aie_profile_" + modName + "_metrics setting in your xrt.ini.";
+                                "Please specify the AIE_profile_settings." + modName + "_metrics" + " or Debug.aie_profile_" + modName + "_metrics setting in your xrt.ini.";
         xrt_core::message::send(severity_level::warning, "XRT", metricMsg);
         continue;
       }

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.cpp
@@ -1017,11 +1017,6 @@ namespace xdp {
     // Each of the metrics can have ; separated multiple values. Process and save all
     std::vector<std::vector<std::string>> metricsSettings(NUM_MODULES);
 
-#if 0
-    typedef std::vector<std::vector<std::string>> 2DStringVectorType;
-    std::vector<2DStringVectorType> metricsSettings(NUM_MODULES);
-#endif
-
     std::string moduleNames[NUM_MODULES] = {"core", "memory", "interface tile"};
 
     for(int module = 0; module < NUM_MODULES; ++module) {
@@ -1033,18 +1028,6 @@ namespace xdp {
         continue;
       }
       boost::split(metricsSettings[module], metricsConfig[module], boost::is_any_of(";"));
-
-#if 0
-      std::vector<std::string> multMetricVal;
-      boost::split(multMetricsVal, metricsConfig[module], boost::is_any_of(";"));
-
-      2DStringVectorType metricValVec(multMetricVal.size());
-
-      for(size_t i = 0; i < multMetricVal.size(); i++) {
-        boost::split(metricValVec[i], multMetricVal[i], boost::is_any_of(":"));
-      }
-      metricsSettings[module] = metricValVec;
-#endif
     }
 
     // Get AIE clock frequency
@@ -1075,7 +1058,6 @@ namespace xdp {
     for (int module=0; module < NUM_MODULES; ++module) {
 
       for(auto &metricsStr : metricsSettings[module]) { 
-//      std::string metricsStr = metricSettings[module];
 
         int NUM_COUNTERS       = numCounters[module];
         XAie_ModuleType mod    = falModuleTypes[module];
@@ -1215,11 +1197,6 @@ namespace xdp {
     // Each of the metrics can have ; separated multiple values. Process and save all
     std::vector<std::vector<std::string>> metricsSettings(NUM_MODULES);
 
-#if 0
-    typedef std::vector<std::vector<std::string>> 2DStringVectorType;
-    std::vector<2DStringVectorType> metricsSettings(NUM_MODULES);
-#endif
-
     std::string moduleNames[NUM_MODULES] = {"core", "memory", "interface tile"};
 
     for(int module = 0; module < NUM_MODULES; ++module) {
@@ -1232,17 +1209,6 @@ namespace xdp {
       }
       boost::split(metricsSettings[module], metricsConfig[module], boost::is_any_of(";"));
 
-#if 0
-      std::vector<std::string> multMetricVal;
-      boost::split(multMetricsVal, metricsConfig[module], boost::is_any_of(";"));
-
-      2DStringVectorType metricValVec(multMetricVal.size());
-
-      for(size_t i = 0; i < multMetricVal.size(); i++) {
-        boost::split(metricValVec[i], multMetricVal[i], boost::is_any_of(":"));
-      }
-      metricsSettings[module] = metricValVec;
-#endif
     }
 
     // Get AIE clock frequency

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.cpp
@@ -677,10 +677,10 @@ namespace xdp {
 
     int numCounters[NUM_MODULES] =
         {NUM_CORE_COUNTERS, NUM_MEMORY_COUNTERS, NUM_SHIM_COUNTERS};
-    XAie_ModuleType falModuleTypes[NUM_MODULES] =
+    XAie_ModuleType falModuleTypes[NUM_MODULES] = 
         {XAIE_CORE_MOD, XAIE_MEM_MOD, XAIE_PL_MOD};
     std::string moduleNames[NUM_MODULES] = {"core", "memory", "interface tile"};
-    std::string metricSettings[NUM_MODULES] =
+    std::string metricSettings[NUM_MODULES] = 
         {xrt_core::config::get_aie_profile_core_metrics(),
          xrt_core::config::get_aie_profile_memory_metrics(),
          interfaceMetric};
@@ -709,29 +709,29 @@ namespace xdp {
       // Get vector of pre-defined metrics for this set
       uint8_t resetEvent = 0;
       auto startEvents = (mod == XAIE_CORE_MOD) ? mCoreStartEvents[metricSet]
-                       : ((mod == XAIE_MEM_MOD) ? mMemoryStartEvents[metricSet]
+                       : ((mod == XAIE_MEM_MOD) ? mMemoryStartEvents[metricSet] 
                        : mShimStartEvents[metricSet]);
       auto endEvents   = (mod == XAIE_CORE_MOD) ? mCoreEndEvents[metricSet]
-                       : ((mod == XAIE_MEM_MOD) ? mMemoryEndEvents[metricSet]
+                       : ((mod == XAIE_MEM_MOD) ? mMemoryEndEvents[metricSet] 
                        : mShimEndEvents[metricSet]);
 
       int numTileCounters[NUM_COUNTERS+1] = {0};
-
+      
       // Iterate over tiles and metrics to configure all desired counters
       for (auto& tile : tiles) {
         int numCounters = 0;
         auto col = tile.col;
         auto row = tile.row;
-
+        
         // NOTE: resource manager requires absolute row number
-        auto loc        = (mod == XAIE_PL_MOD) ? XAie_TileLoc(col, 0)
+        auto loc        = (mod == XAIE_PL_MOD) ? XAie_TileLoc(col, 0) 
                         : XAie_TileLoc(col, row + 1);
-        auto& xaieTile  = (mod == XAIE_PL_MOD) ? aieDevice->tile(col, 0)
+        auto& xaieTile  = (mod == XAIE_PL_MOD) ? aieDevice->tile(col, 0) 
                         : aieDevice->tile(col, row + 1);
         auto xaieModule = (mod == XAIE_CORE_MOD) ? xaieTile.core()
                         : ((mod == XAIE_MEM_MOD) ? xaieTile.mem()
                         : xaieTile.pl());
-
+        
         for (int i=0; i < numFreeCounters; ++i) {
           auto startEvent = startEvents.at(i);
           auto endEvent   = endEvents.at(i);
@@ -742,10 +742,10 @@ namespace xdp {
           if (ret != XAIE_OK) break;
           ret = perfCounter->reserve();
           if (ret != XAIE_OK) break;
-
+          
           configGroupEvents(aieDevInst, loc, mod, startEvent, metricSet);
           configStreamSwitchPorts(aieDevInst, tile, xaieTile, loc, startEvent, metricSet);
-
+          
           // Start the counters after group events have been configured
           ret = perfCounter->start();
           if (ret != XAIE_OK) break;
@@ -768,7 +768,7 @@ namespace xdp {
           // Store counter info in database
           std::string counterName = "AIE Counter " + std::to_string(counterId);
           (db->getStaticInfo()).addAIECounter(deviceId, counterId, col, row, i,
-              phyStartEvent, phyEndEvent, resetEvent, payload, clockFreqMhz,
+              phyStartEvent, phyEndEvent, resetEvent, payload, clockFreqMhz, 
               moduleName, counterName);
           counterId++;
           numCounters++;

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.h
@@ -57,6 +57,8 @@ namespace xdp {
   private:
     void getPollingInterval();
     bool setMetrics(uint64_t deviceId, void* handle);
+    bool setMetricsSettings(uint64_t deviceId, void* handle);
+    bool setGraphMetricsSettings(uint64_t deviceId, void* handle);
 
     std::string getMetricSet(const XAie_ModuleType mod, 
                              const std::string& metricsStr);

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -338,7 +338,7 @@ namespace xdp {
     xrt_core::message::send(severity_level::info, "XRT", msg.str());
   }
 
-  std::string AieTracePlugin::getMetricSet(void* handle, const std::string& metricStr)
+  std::string AieTracePlugin::getMetricSet(void* handle, const std::string& metricsStr)
   {
 
     std::vector<std::string> vec;
@@ -956,6 +956,8 @@ namespace xdp {
 
   void AieTracePlugin::updateAIEDevice(void* handle)
   {
+      xrt_core::message::send(severity_level::warning, "XRT", "Checking call");
+
     if (handle == nullptr)
       return;
 
@@ -1439,6 +1441,7 @@ namespace xdp {
 
     metricsConfig.push_back(xrt_core::config::get_aie_trace_settings_aie_tile_metrics());
     metricsConfig.push_back(xrt_core::config::get_aie_trace_settings_mem_tile_metrics());
+//    metricsConfig.push_back(xrt_core::config::get_aie_trace_settings_graph_metrics());
 #if 0
     // Post 2022.2
     metricsConfig.push_back(xrt_core::config::get_aie_trace_settings_interface_tile_metrics());
@@ -1466,14 +1469,14 @@ namespace xdp {
         xrt_core::message::send(severity_level::warning, "XRT", metricMsg);
         continue;
       }
-      boost::split(metricSettings[module], metricsConfig[module], boost::is_any_of(";"));
+      boost::split(metricsSettings[module], metricsConfig[module], boost::is_any_of(";"));
 
     }
 
    // Configure aie, memory tiles
     for (int module=0; module < NUM_MODULES; ++module) {
 
-      for(auto &metricStr : metricSettings[module]) {
+      for(auto &metricsStr : metricsSettings[module]) {
         auto metricSet = getMetricSet(handle, metricsStr);
         if (metricSet.empty()) {
           if (!runtimeMetrics)

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -440,7 +440,11 @@ namespace xdp {
     std::smatch pieces_match;
     uint64_t cycles_per_sec = static_cast<uint64_t>(freqMhz * 1e6);
     const uint64_t max_cycles = 0xffffffff;
-    std::string size_str = xrt_core::config::get_aie_trace_start_time();
+    // AIE_trace_settings configs have higher priority than older Debug configs
+    std::string size_str = xrt_core::config::get_aie_trace_settings_start_time();
+    if(0 == size_str.compare("0")) {
+      size_str = xrt_core::config::get_aie_trace_start_time();
+    }
 
     // Catch cases like "1Ms" "1NS"
     std::transform(size_str.begin(), size_str.end(), size_str.begin(),

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -338,27 +338,8 @@ namespace xdp {
     xrt_core::message::send(severity_level::info, "XRT", msg.str());
   }
 
-  std::string AieTracePlugin::getMetricSet(void* handle)
+  std::string AieTracePlugin::getMetricSet(void* handle, const std::string& metricStr)
   {
-    // Catch when compile-time trace is specified (e.g., --event-trace=functions)
-    std::shared_ptr<xrt_core::device> device = xrt_core::get_userpf_device(handle);
-    auto compilerOptions = xrt_core::edge::aie::get_aiecompiler_options(device.get());
-    runtimeMetrics = (compilerOptions.event_trace == "runtime");
-
-    if (!runtimeMetrics) {
-      std::stringstream msg;
-      msg << "Found compiler trace option of " << compilerOptions.event_trace
-          << ". No runtime AIE metrics will be changed.";
-      xrt_core::message::send(severity_level::info, "XRT", msg.str());
-      return {};
-    }
-
-    std::string metricsStr = xrt_core::config::get_aie_trace_metrics();
-    if (metricsStr.empty()) {
-      std::string msg("The setting aie_trace_metrics was not specified in xrt.ini. AIE event trace will not be available.");
-      xrt_core::message::send(severity_level::warning, "XRT", msg);
-      return {};
-    }
 
     std::vector<std::string> vec;
     boost::split(vec, metricsStr, boost::is_any_of(":"));
@@ -568,7 +549,29 @@ namespace xdp {
       return false;
     }
 
-    auto metricSet = getMetricSet(handle);
+    // Catch when compile-time trace is specified (e.g., --event-trace=functions)
+    std::shared_ptr<xrt_core::device> device = xrt_core::get_userpf_device(handle);
+    auto compilerOptions = xrt_core::edge::aie::get_aiecompiler_options(device.get());
+    runtimeMetrics = (compilerOptions.event_trace == "runtime");
+
+    if (!runtimeMetrics) {
+      std::stringstream msg;
+      msg << "Found compiler trace option of " << compilerOptions.event_trace
+          << ". No runtime AIE metrics will be changed.";
+      xrt_core::message::send(severity_level::info, "XRT", msg.str());
+      return true;
+    }
+
+    std::string metricsStr = xrt_core::config::get_aie_trace_metrics();
+    if (metricsStr.empty()) {
+      std::string msg("The setting aie_trace_metrics was not specified in xrt.ini. AIE event trace will not be available.");
+      xrt_core::message::send(severity_level::warning, "XRT", msg);
+      if (!runtimeMetrics)
+        return true;
+      return false;
+    }
+
+    auto metricSet = getMetricSet(handle, metricsStr);
     if (metricSet.empty()) {
       if (!runtimeMetrics)
         return true;
@@ -993,10 +996,12 @@ namespace xdp {
     }
 
     // Set metrics for counters and trace events 
-    if (!setMetrics(deviceId, handle)) {
-      std::string msg("Unable to configure AIE trace control and events. No trace will be generated.");
-      xrt_core::message::send(severity_level::warning, "XRT", msg);
-      return;
+    if (!setMetricsSettings(deviceId, handle)) {
+      if (!setMetrics(deviceId, handle)) {
+        std::string msg("Unable to configure AIE trace control and events. No trace will be generated.");
+        xrt_core::message::send(severity_level::warning, "XRT", msg);
+        return;
+      }
     }
     
     if (!(db->getStaticInfo()).isGMIORead(deviceId)) {
@@ -1401,5 +1406,458 @@ namespace xdp {
 
     XDPPlugin::endWrite();
   }
+
+  // Configure all resources necessary for trace control and events
+  bool AieTracePlugin::setMetricsSettings(uint64_t deviceId, void* handle)
+  {
+    XAie_DevInst* aieDevInst =
+      static_cast<XAie_DevInst*>(db->getStaticInfo().getAieDevInst(fetchAieDevInst, handle)) ;
+    xaiefal::XAieDev* aieDevice =
+      static_cast<xaiefal::XAieDev*>(db->getStaticInfo().getAieDevice(allocateAieDevice, deallocateAieDevice, handle)) ;
+    if (!aieDevInst || !aieDevice) {
+      xrt_core::message::send(severity_level::warning, "XRT",
+          "Unable to get AIE device. AIE event trace will not be available.");
+      return false;
+    }
+
+    // Catch when compile-time trace is specified (e.g., --event-trace=functions)
+    std::shared_ptr<xrt_core::device> device = xrt_core::get_userpf_device(handle);
+    auto compilerOptions = xrt_core::edge::aie::get_aiecompiler_options(device.get());
+    runtimeMetrics = (compilerOptions.event_trace == "runtime");
+
+    if (!runtimeMetrics) {
+      std::stringstream msg;
+      msg << "Found compiler trace option of " << compilerOptions.event_trace
+          << ". No runtime AIE metrics will be changed.";
+      xrt_core::message::send(severity_level::info, "XRT", msg.str());
+      return true;
+    }
+
+    constexpr int NUM_MODULES = 2; // aie_tile, mem_tile
+
+    std::vector<std::string> metricsConfig;
+
+    metricsConfig.push_back(xrt_core::config::get_aie_trace_settings_aie_tile_metrics());
+    metricsConfig.push_back(xrt_core::config::get_aie_trace_settings_mem_tile_metrics());
+#if 0
+    // Post 2022.2
+    metricsConfig.push_back(xrt_core::config::get_aie_trace_settings_interface_tile_metrics());
+#endif
+
+    if (metricsConfig[0].empty() && metricsConfig[1].empty()) {
+      std::string msg("AIE_trace_settings.aie_tile_metrics and mem_tile_metrics were not specified in xrt.ini. AIE event trace will not be available.");
+      xrt_core::message::send(severity_level::warning, "XRT", msg);
+      if (!runtimeMetrics)
+        return true;
+      return false;
+    }
+
+
+    // Process AIE_profile_settings metrics
+    // Each of the metrics can have ; separated multiple values. Process and save all
+    std::vector<std::vector<std::string>> metricsSettings(NUM_MODULES);
+
+    std::string moduleNames[NUM_MODULES] = {"aie tile", "memory tile"};
+
+    for(int module = 0; module < NUM_MODULES; ++module) {
+      if (metricsConfig[module].empty()){
+        std::string modName = moduleNames[module].substr(0, moduleNames[module].find(" "));
+        std::string metricMsg("AIE_trace_settings.aie_tile_metrics and mem_tile_metrics were not specified in xrt.ini. AIE event trace will not be available.");
+        xrt_core::message::send(severity_level::warning, "XRT", metricMsg);
+        continue;
+      }
+      boost::split(metricSettings[module], metricsConfig[module], boost::is_any_of(";"));
+
+    }
+
+   // Configure aie, memory tiles
+    for (int module=0; module < NUM_MODULES; ++module) {
+
+      for(auto &metricStr : metricSettings[module]) {
+        auto metricSet = getMetricSet(handle, metricsStr);
+        if (metricSet.empty()) {
+          if (!runtimeMetrics)
+            return true;
+          return false;
+        }
+    
+        auto tiles = getTilesForTracing(handle);
+        setTraceStartDelayCycles(handle);
+    
+        // Keep track of number of events reserved per tile
+        int numTileCoreTraceEvents[NUM_CORE_TRACE_EVENTS+1] = {0};
+        int numTileMemoryTraceEvents[NUM_MEMORY_TRACE_EVENTS+1] = {0};
+    
+        // Iterate over all used/specified tiles
+        for (auto& tile : tiles) {
+          auto  col    = tile.col;
+          auto  row    = tile.row;
+          // NOTE: resource manager requires absolute row number
+          auto& core   = aieDevice->tile(col, row + 1).core();
+          auto& memory = aieDevice->tile(col, row + 1).mem();
+          auto loc = XAie_TileLoc(col, row + 1);
+    
+          // AIE config object for this tile
+          auto cfgTile  = std::make_unique<aie_cfg_tile>(col, row + 1);
+    
+          // Get vector of pre-defined metrics for this set
+          // NOTE: these are local copies as we are adding tile/counter-specific events
+          EventVector coreEvents = coreEventSets[metricSet];
+          EventVector memoryCrossEvents = memoryEventSets[metricSet];
+          EventVector memoryEvents;
+    
+          // Check Resource Availability
+          // For now only counters are checked
+          if (!tileHasFreeRsc(aieDevice, loc, metricSet)) {
+            xrt_core::message::send(severity_level::warning, "XRT", "Tile doesn't have enough free resources for trace. Aborting trace configuration.");
+            printTileStats(aieDevice, tile);
+            return false;
+          }
+    
+          //
+          // 1. Reserve and start core module counters (as needed)
+          //
+          int numCoreCounters = 0;
+          {
+            XAie_ModuleType mod = XAIE_CORE_MOD;
+    
+            for (int i=0; i < coreCounterStartEvents.size(); ++i) {
+              auto perfCounter = core.perfCounter();
+              if (perfCounter->initialize(mod, coreCounterStartEvents.at(i),
+                                          mod, coreCounterEndEvents.at(i)) != XAIE_OK)
+                break;
+              if (perfCounter->reserve() != XAIE_OK) 
+                break;
+    
+              // NOTE: store events for later use in trace
+              XAie_Events counterEvent;
+              perfCounter->getCounterEvent(mod, counterEvent);
+              int idx = static_cast<int>(counterEvent) - static_cast<int>(XAIE_EVENT_PERF_CNT_0_CORE);
+              perfCounter->changeThreshold(coreCounterEventValues.at(i));
+    
+              // Set reset event based on counter number
+              perfCounter->changeRstEvent(mod, counterEvent);
+              coreEvents.push_back(counterEvent);
+    
+              // If no memory counters are used, then we need to broadcast the core counter
+              if (memoryCounterStartEvents.empty())
+                memoryCrossEvents.push_back(counterEvent);
+    
+              if (perfCounter->start() != XAIE_OK) 
+                break;
+    
+              mCoreCounterTiles.push_back(tile);
+              mCoreCounters.push_back(perfCounter);
+              numCoreCounters++;
+    
+              // Update config file
+              uint8_t phyEvent = 0;
+              auto& cfg = cfgTile->core_trace_config.pc[idx];
+              XAie_EventLogicalToPhysicalConv(aieDevInst, loc, mod, coreCounterStartEvents[i], &phyEvent);
+              cfg.start_event = phyEvent;
+              XAie_EventLogicalToPhysicalConv(aieDevInst, loc, mod, coreCounterEndEvents[i], &phyEvent);
+              cfg.stop_event = phyEvent;
+              XAie_EventLogicalToPhysicalConv(aieDevInst, loc, mod, counterEvent, &phyEvent);
+              cfg.reset_event = phyEvent;
+              cfg.event_value = coreCounterEventValues[i];
+            }
+          }
+    
+          //
+          // 2. Reserve and start memory module counters (as needed)
+          //
+          int numMemoryCounters = 0;
+          {
+            XAie_ModuleType mod = XAIE_MEM_MOD;
+    
+            for (int i=0; i < memoryCounterStartEvents.size(); ++i) {
+              auto perfCounter = memory.perfCounter();
+              if (perfCounter->initialize(mod, memoryCounterStartEvents.at(i),
+                                          mod, memoryCounterEndEvents.at(i)) != XAIE_OK) 
+                break;
+              if (perfCounter->reserve() != XAIE_OK) 
+                break;
+    
+              // Set reset event based on counter number
+              XAie_Events counterEvent;
+              perfCounter->getCounterEvent(mod, counterEvent);
+              int idx = static_cast<int>(counterEvent) - static_cast<int>(XAIE_EVENT_PERF_CNT_0_MEM);
+              perfCounter->changeThreshold(memoryCounterEventValues.at(i));
+    
+              perfCounter->changeRstEvent(mod, counterEvent);
+              memoryEvents.push_back(counterEvent);
+    
+              if (perfCounter->start() != XAIE_OK) 
+                break;
+    
+              mMemoryCounters.push_back(perfCounter);
+              numMemoryCounters++;
+    
+              // Update config file
+              uint8_t phyEvent = 0;
+              auto& cfg = cfgTile->memory_trace_config.pc[idx];
+              XAie_EventLogicalToPhysicalConv(aieDevInst, loc, mod, memoryCounterStartEvents[i], &phyEvent);
+              cfg.start_event = phyEvent;
+              XAie_EventLogicalToPhysicalConv(aieDevInst, loc, mod, memoryCounterEndEvents[i], &phyEvent);
+              cfg.stop_event = phyEvent;
+              XAie_EventLogicalToPhysicalConv(aieDevInst, loc, mod, counterEvent, &phyEvent);
+              cfg.reset_event = phyEvent;
+              cfg.event_value = memoryCounterEventValues[i];
+            }
+          }
+    
+          // Catch when counters cannot be reserved: report, release, and return
+          if ((numCoreCounters < coreCounterStartEvents.size())
+              || (numMemoryCounters < memoryCounterStartEvents.size())) {
+            std::stringstream msg;
+            msg << "Unable to reserve " << coreCounterStartEvents.size() << " core counters"
+                << " and " << memoryCounterStartEvents.size() << " memory counters"
+                << " for AIE tile (" << col << "," << row + 1 << ") required for trace.";
+            xrt_core::message::send(severity_level::warning, "XRT", msg.str());
+    
+            releaseCurrentTileCounters(numCoreCounters, numMemoryCounters);
+            // Print resources availability for this tile
+            printTileStats(aieDevice, tile);
+            return false;
+          }
+    
+          //
+          // 3. Configure Core Tracing Events
+          //
+          {
+            XAie_ModuleType mod = XAIE_CORE_MOD;
+            uint8_t phyEvent = 0;
+            auto coreTrace = core.traceControl();
+    
+            // Delay cycles and user control are not compatible with each other
+            if (xrt_core::config::get_aie_trace_user_control()) {
+              coreTraceStartEvent = XAIE_EVENT_INSTR_EVENT_0_CORE;
+              coreTraceEndEvent = XAIE_EVENT_INSTR_EVENT_1_CORE;
+            } else if (mUseDelay && !configureStartDelay(core)) {
+              break;
+            }
+    
+            // Set overall start/end for trace capture
+            // Wendy said this should be done first
+            if (coreTrace->setCntrEvent(coreTraceStartEvent, coreTraceEndEvent) != XAIE_OK) 
+              break;
+    
+            auto ret = coreTrace->reserve();
+            if (ret != XAIE_OK) {
+              std::stringstream msg;
+              msg << "Unable to reserve core module trace control for AIE tile (" 
+                  << col << "," << row + 1 << ").";
+              xrt_core::message::send(severity_level::warning, "XRT", msg.str());
+    
+              releaseCurrentTileCounters(numCoreCounters, numMemoryCounters);
+              // Print resources availability for this tile
+              printTileStats(aieDevice, tile);
+              return false;
+            }
+    
+            int numTraceEvents = 0;
+            for (int i=0; i < coreEvents.size(); i++) {
+              uint8_t slot;
+              if (coreTrace->reserveTraceSlot(slot) != XAIE_OK) 
+                break;
+              if (coreTrace->setTraceEvent(slot, coreEvents[i]) != XAIE_OK) 
+                break;
+              numTraceEvents++;
+    
+              // Update config file
+              XAie_EventLogicalToPhysicalConv(aieDevInst, loc, mod, coreEvents[i], &phyEvent);
+              cfgTile->core_trace_config.traced_events[slot] = phyEvent;
+            }
+            // Update config file
+            XAie_EventLogicalToPhysicalConv(aieDevInst, loc, mod, coreTraceStartEvent, &phyEvent);
+            cfgTile->core_trace_config.start_event = phyEvent;
+            XAie_EventLogicalToPhysicalConv(aieDevInst, loc, mod, coreTraceEndEvent, &phyEvent);
+            cfgTile->core_trace_config.stop_event = phyEvent;
+            
+            coreEvents.clear();
+            numTileCoreTraceEvents[numTraceEvents]++;
+    
+            std::stringstream msg;
+            msg << "Reserved " << numTraceEvents << " core trace events for AIE tile (" << col << "," << row << ").";
+            xrt_core::message::send(severity_level::debug, "XRT", msg.str());
+    
+            if (coreTrace->setMode(XAIE_TRACE_EVENT_PC) != XAIE_OK) 
+              break;
+            XAie_Packet pkt = {0, 0};
+            if (coreTrace->setPkt(pkt) != XAIE_OK) 
+              break;
+            if (coreTrace->start() != XAIE_OK) 
+              break;
+          }
+    
+          //
+          // 4. Configure Memory Tracing Events
+          //
+          // TODO: Configure group or combo events where applicable
+          uint32_t coreToMemBcMask = 0;
+          {
+            auto memoryTrace = memory.traceControl();
+            // Set overall start/end for trace capture
+            // Wendy said this should be done first
+            if (memoryTrace->setCntrEvent(coreTraceStartEvent, coreTraceEndEvent) != XAIE_OK) 
+              break;
+    
+            auto ret = memoryTrace->reserve();
+            if (ret != XAIE_OK) {
+              std::stringstream msg;
+              msg << "Unable to reserve memory module trace control for AIE tile (" 
+                  << col << "," << row + 1 << ").";
+              xrt_core::message::send(severity_level::warning, "XRT", msg.str());
+    
+              releaseCurrentTileCounters(numCoreCounters, numMemoryCounters);
+              // Print resources availability for this tile
+              printTileStats(aieDevice, tile);
+              return false;
+            }
+    
+            int numTraceEvents = 0;
+            
+            // Configure cross module events
+            for (int i=0; i < memoryCrossEvents.size(); i++) {
+              uint32_t bcBit = 0x1;
+              auto TraceE = memory.traceEvent();
+              TraceE->setEvent(XAIE_CORE_MOD, memoryCrossEvents[i]);
+              if (TraceE->reserve() != XAIE_OK) 
+                break;
+    
+              int bcId = TraceE->getBc();
+              coreToMemBcMask |= (bcBit << bcId);
+    
+              if (TraceE->start() != XAIE_OK) 
+                break;
+              numTraceEvents++;
+    
+              // Update config file
+              uint32_t S = 0;
+              XAie_LocType L;
+              XAie_ModuleType M;
+              TraceE->getRscId(L, M, S);
+              cfgTile->memory_trace_config.traced_events[S] = bcIdToEvent(bcId);
+              auto mod = XAIE_CORE_MOD;
+              uint8_t phyEvent = 0;
+              XAie_EventLogicalToPhysicalConv(aieDevInst, loc, mod, memoryCrossEvents[i], &phyEvent);
+              cfgTile->core_trace_config.internal_events_broadcast[bcId] = phyEvent;
+            }
+    
+            // Configure same module events
+            for (int i=0; i < memoryEvents.size(); i++) {
+              auto TraceE = memory.traceEvent();
+              TraceE->setEvent(XAIE_MEM_MOD, memoryEvents[i]);
+              if (TraceE->reserve() != XAIE_OK) 
+                break;
+              if (TraceE->start() != XAIE_OK) 
+                break;
+              numTraceEvents++;
+    
+              // Update config file
+              // Get Trace slot
+              uint32_t S = 0;
+              XAie_LocType L;
+              XAie_ModuleType M;
+              TraceE->getRscId(L, M, S);
+              // Get Physical event
+              auto mod = XAIE_MEM_MOD;
+              uint8_t phyEvent = 0;
+              XAie_EventLogicalToPhysicalConv(aieDevInst, loc, mod, memoryEvents[i], &phyEvent);
+              cfgTile->memory_trace_config.traced_events[S] = phyEvent;
+            }
+    
+            // Update config file
+            {
+              // Add Memory module trace control events
+              uint32_t bcBit = 0x1;
+              auto bcId = memoryTrace->getStartBc();
+              coreToMemBcMask |= (bcBit << bcId);
+              auto mod = XAIE_CORE_MOD;
+              uint8_t phyEvent = 0;
+              XAie_EventLogicalToPhysicalConv(aieDevInst, loc, mod, coreTraceStartEvent, &phyEvent);
+              cfgTile->memory_trace_config.start_event = bcIdToEvent(bcId);
+              cfgTile->core_trace_config.internal_events_broadcast[bcId] = phyEvent;
+    
+              bcBit = 0x1;
+              bcId = memoryTrace->getStopBc();
+              coreToMemBcMask |= (bcBit << bcId);
+              XAie_EventLogicalToPhysicalConv(aieDevInst, loc, mod, coreTraceEndEvent, &phyEvent);
+              cfgTile->memory_trace_config.stop_event = bcIdToEvent(bcId);
+              cfgTile->core_trace_config.internal_events_broadcast[bcId] = phyEvent;
+            }
+    
+            // Odd absolute rows change east mask end even row change west mask
+            if ((row + 1) % 2) {
+              cfgTile->core_trace_config.broadcast_mask_east = coreToMemBcMask;
+            } else {
+              cfgTile->core_trace_config.broadcast_mask_west = coreToMemBcMask;
+            }
+            // Done update config file
+    
+            memoryEvents.clear();
+            numTileMemoryTraceEvents[numTraceEvents]++;
+    
+            std::stringstream msg;
+            msg << "Reserved " << numTraceEvents << " memory trace events for AIE tile (" << col << "," << row << ").";
+            xrt_core::message::send(severity_level::debug, "XRT", msg.str());
+    
+            if (memoryTrace->setMode(XAIE_TRACE_EVENT_TIME) != XAIE_OK) 
+              break;
+            XAie_Packet pkt = {0, 1};
+            if (memoryTrace->setPkt(pkt) != XAIE_OK) 
+              break;
+            if (memoryTrace->start() != XAIE_OK) 
+              break;
+    
+            // Update memory packet type in config file
+            // NOTE: Use time packets for memory module (type 1)
+            cfgTile->memory_trace_config.packet_type = 1;
+          }
+    
+          std::stringstream msg;
+          msg << "Adding tile (" << col << "," << row << ") to static database";
+          xrt_core::message::send(severity_level::debug, "XRT", msg.str());
+    
+          // Add config info to static database
+          // NOTE: Do not access cfgTile after this
+          (db->getStaticInfo()).addAIECfgTile(deviceId, cfgTile);
+        } // For tiles
+    
+        // Report trace events reserved per tile
+        {
+          std::stringstream msg;
+          msg << "AIE trace events reserved in core modules - ";
+          for (int n=0; n <= NUM_CORE_TRACE_EVENTS; ++n) {
+            if (numTileCoreTraceEvents[n] == 0)
+              continue;
+            msg << n << ": " << numTileCoreTraceEvents[n] << " tiles";
+            if (n != NUM_CORE_TRACE_EVENTS)
+              msg << ", ";
+    
+            (db->getStaticInfo()).addAIECoreEventResources(deviceId, n, numTileCoreTraceEvents[n]);
+          }
+          xrt_core::message::send(severity_level::info, "XRT", msg.str());
+        }
+        {
+          std::stringstream msg;
+          msg << "AIE trace events reserved in memory modules - ";
+          for (int n=0; n <= NUM_MEMORY_TRACE_EVENTS; ++n) {
+            if (numTileMemoryTraceEvents[n] == 0)
+              continue;
+            msg << n << ": " << numTileMemoryTraceEvents[n] << " tiles";
+            if (n != NUM_MEMORY_TRACE_EVENTS)
+              msg << ", ";
+    
+            (db->getStaticInfo()).addAIEMemoryEventResources(deviceId, n, numTileMemoryTraceEvents[n]);
+          }
+          xrt_core::message::send(severity_level::info, "XRT", msg.str());
+        }
+
+      } // multiple metrics
+    } // modules
+
+    return true;
+  } // end setMetricsSettings
 
 } // namespace xdp

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.h
@@ -61,6 +61,8 @@ namespace xdp {
       inline uint32_t bcIdToEvent(int bcId);
       void releaseCurrentTileCounters(int numCoreCounters, int numMemoryCounters);
       bool setMetrics(uint64_t deviceId, void* handle);
+      bool setMetricsSettings(uint64_t deviceId, void* handle);
+
       void setFlushMetrics(uint64_t deviceId, void* handle);
       void setTraceStartDelayCycles(void* handle);
 
@@ -70,7 +72,7 @@ namespace xdp {
       bool configureStartDelay(xaiefal::XAieMod& core);
 
       // Utility functions
-      std::string getMetricSet(void* handle);
+      std::string getMetricSet(void* handle, const std::string& metricStr);
       std::vector<tile_type> getTilesForTracing(void* handle);
 
     private:


### PR DESCRIPTION
Add new metrics under AIE_trace_settings and AIE_profile_settings configurations in xrt.ini for finer granularity in AIE profile and trace.