### PR TITLE
VITIS-5012: Async BO APIs

### DIFF
--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -45,13 +45,6 @@
 # pragma warning( disable : 4244 4100 4996 4505 )
 #endif
 
-/*
-namespace xrt::aie::bo
-{
-  class async_handle_impl;
-}
-*/
-
 namespace {
   //Map of gmio -> list of async handles
   static std::unordered_map<std::string, std::vector<xrt::aie::bo::async_handle_impl*>> async_bo_hdls;

--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -45,14 +45,16 @@
 # pragma warning( disable : 4244 4100 4996 4505 )
 #endif
 
-namespace xrt
+/*
+namespace xrt::aie::bo
 {
-  class async_bo_impl;
+  class async_handle_impl;
 }
+*/
 
 namespace {
   //Map of gmio -> list of async handles
-  static std::unordered_map<std::string, std::vector<xrt::async_bo_impl*>> async_bo_hdls;
+  static std::unordered_map<std::string, std::vector<xrt::aie::bo::async_handle_impl*>> async_bo_hdls;
   std::mutex async_bo_hdls_mutex;//Mutex for use with above map
 
 XRT_CORE_UNUSED
@@ -129,39 +131,6 @@ send_exception_message(const std::string& msg)
 } // namespace
 
 namespace xrt {
-
-/*!
- * @class async_bo_impl
- * 
- * @brief
- * Impl Class associated with async bo which allows to wait for completion
- *
- */
-class async_bo_impl
-{
-private:
-  size_t m_bd_num; //For future use
-  std::string m_gmio_name;
-  xrt::bo m_bo;
-
-public:
-
-  /**
-   * async_bo_impl() - Construct async_bo_obj
-   */
-  async_bo_impl(const xrt::bo& bo, const size_t bd_num, const std::string& gmio_name)
-    : m_bd_num(bd_num),
-      m_gmio_name(gmio_name),
-      m_bo(bo)
-  {
-  }
-
-  /**
-   * wait() - Wait for async to complete
-   */
-  void wait();//For Alveo
-  void wait_aie();
-};
 
 // class bo_impl - Base class for buffer objects
 //
@@ -410,24 +379,27 @@ public:
     device->sync_aie_bo(bo, port.c_str(), dir, sz, offset);
   }
 
-  xrt::async_bo_hdl
+  xrt::bo::async_handle
   async(xrt::bo& bo, const std::string& port, xclBOSyncDirection dir, size_t sz, size_t offset)
   {
     device->sync_aie_bo_nb(bo, port.c_str(), dir, sz, offset);
-    auto a_bo_impl = std::make_shared<xrt::async_bo_impl>(bo, 0, port);
+    auto a_bo_impl = std::make_shared<xrt::aie::bo::async_handle_impl>(bo, 0, port);
     std::unique_lock lk(::async_bo_hdls_mutex);
     ::async_bo_hdls[port].emplace_back(a_bo_impl.get());
 
-    return xrt::async_bo_hdl{a_bo_impl};
+    return xrt::bo::async_handle(std::dynamic_pointer_cast<xrt::bo::async_handle_impl>(a_bo_impl));
+    //return xrt::bo::async_handle(a_bo_impl);
   }
 #endif
 
-  xrt::async_bo_hdl
+  xrt::bo::async_handle
   async(xrt::bo& bo, xclBOSyncDirection dir, size_t sz, size_t offset)
   {
+    throw std::runtime_error("Unsupported feature");
+
     //TODO for Alveo; base xrt::bo class
-    auto a_bo_impl = std::make_shared<xrt::async_bo_impl>(bo, 0, "");
-    return xrt::async_bo_hdl{a_bo_impl};
+    auto a_bo_impl = std::make_shared<xrt::bo::async_handle_impl>(bo, 0, "");
+    return xrt::bo::async_handle{a_bo_impl};
   }
 
   virtual void
@@ -480,6 +452,70 @@ public:
   virtual bool   is_imported()   const { return false;   }
 };
 
+/*!
+ * @class async_bo_impl
+ * 
+ * @brief
+ * Impl Class associated with async bo which allows to wait for completion
+ *
+ */
+class bo::async_handle_impl
+{
+public:
+  size_t m_bd_num; //For future use
+  std::string m_gmio_name;
+  xrt::bo m_bo;
+
+public:
+  /**
+   * async_bo_impl() - Construct async_bo_obj
+   */
+  async_handle_impl(const xrt::bo& bo, const size_t bd_num, const std::string& gmio_name)
+    : m_bd_num(bd_num),
+      m_gmio_name(gmio_name),
+      m_bo(bo)
+  {
+  }
+
+  /**
+   * wait() - Wait for async to complete
+   */
+  virtual void wait() {
+    throw std::runtime_error("Unsupported feature");
+  }
+};
+
+class aie::bo::async_handle_impl : public xrt::bo::async_handle_impl
+{
+public:
+  /**
+   * async_bo_impl() - Construct async_bo_obj
+   */
+  async_handle_impl(const xrt::bo& bo, const size_t bd_num, const std::string& gmio_name)
+    : xrt::bo::async_handle_impl(bo, bd_num, gmio_name)
+  {
+  }
+
+  /**
+   * wait() - Wait for async to complete
+   */
+  virtual void wait() override
+  {
+    auto dev = const_cast<xrt_core::device*>(m_bo.get_handle()->get_device());
+
+    std::unique_lock lk(::async_bo_hdls_mutex);
+    auto itr = ::async_bo_hdls.find(m_gmio_name);
+    if (itr == ::async_bo_hdls.end())
+      throw std::runtime_error("Unexpected error");
+
+    if (std::find(itr->second.begin(), itr->second.end(), this) == itr->second.end())
+      return;//This DMA has already finished
+
+    //In future wait only for specific m_bd_num
+    dev->wait_gmio(m_gmio_name.c_str());
+    itr->second.clear();//All outstanding DMAs for this gmio_name have finished
+  }
+};
 
 // class buffer_ubuf - User provide host side buffer
 //
@@ -1114,45 +1150,11 @@ alignment()
 namespace xrt {
 
 void
-async_bo_hdl::
+bo::async_handle::
 wait()
 {
   handle->wait();
 }
-
-void
-async_bo_impl::
-wait()
-{
-  if (m_gmio_name.empty()) {
-    //TODO; Alveo wait for DMA to finish
-    return;
-  };
-
-  //Wait for AIE GMIO txfer to finish
-  wait_aie();
-}
-
-#ifdef XRT_ENABLE_AIE
-void
-async_bo_impl::
-wait_aie()
-{
-  auto dev = const_cast<xrt_core::device*>(m_bo.get_handle()->get_device());
-
-  std::unique_lock lk(::async_bo_hdls_mutex);
-  auto itr = ::async_bo_hdls.find(m_gmio_name);
-  if (itr == ::async_bo_hdls.end())
-    throw std::runtime_error("Unexpected error");
-
-  if (std::find(itr->second.begin(), itr->second.end(), this) == itr->second.end())
-    return;//This DMA has already finished
-
-  //In future wait only for specific m_bd_num
-  dev->wait_gmio(m_gmio_name.c_str());
-  itr->second.clear();//All outstanding DMAs for this gmio_name have finished
-}
-#endif
 
 bo::
 bo(xclDeviceHandle dhdl, void* userptr, size_t sz, bo::flags flags, memory_group grp)
@@ -1251,7 +1253,7 @@ sync(xclBOSyncDirection dir, size_t size, size_t offset)
     });
 }
 
-xrt::async_bo_hdl
+bo::async_handle
 bo::
 async(xclBOSyncDirection dir, size_t sz, size_t offset)
 {
@@ -1303,7 +1305,7 @@ copy(const bo& src, size_t sz, size_t src_offset, size_t dst_offset)
 ////////////////////////////////////////////////////////////////
 namespace xrt { namespace aie {
 
-xrt::async_bo_hdl
+xrt::bo::async_handle
 bo::
 async(const std::string& port, xclBOSyncDirection dir, size_t sz, size_t offset)
 {

--- a/src/runtime_src/core/include/xrt/xrt_aie.h
+++ b/src/runtime_src/core/include/xrt/xrt_aie.h
@@ -95,6 +95,8 @@ private:
 class bo : public xrt::bo
 {
 public:
+  class async_handle_impl;
+
   /**
    * bo() - Constructor BO that is used for AIE GMIO.
    *
@@ -121,7 +123,7 @@ public:
    * Asynchronously transfer the buffer contents from BO offset to offset + sz
    * between GMIO and AIE.
    */
-  xrt::async_bo_hdl 
+  async_handle 
   async(const std::string& port, xclBOSyncDirection dir, size_t sz, size_t offset);
 
   /**

--- a/src/runtime_src/core/include/xrt/xrt_aie.h
+++ b/src/runtime_src/core/include/xrt/xrt_aie.h
@@ -107,6 +107,24 @@ public:
   {}
 
   /**
+   * async() - Async transfer of data between BO and Shim DMA channel.
+   *
+   * @param port
+   *  GMIO port name.
+   * @param dir
+   *  GM to AIE or AIE to GM
+   * @param sz
+   *  Size of data to transfer
+   * @param offset
+   *  Offset within BO
+   *
+   * Asynchronously transfer the buffer contents from BO offset to offset + sz
+   * between GMIO and AIE.
+   */
+  xrt::async_bo_hdl 
+  async(const std::string& port, xclBOSyncDirection dir, size_t sz, size_t offset);
+
+  /**
    * sync() - Transfer data between BO and Shim DMA channel.
    *
    * @param port

--- a/src/runtime_src/core/include/xrt/xrt_bo.h
+++ b/src/runtime_src/core/include/xrt/xrt_bo.h
@@ -7,6 +7,7 @@
 
 #include "xrt.h"
 #include "xrt_mem.h"
+#include "xrt/detail/pimpl.h"
 
 #ifdef __cplusplus
 # include <memory>
@@ -62,6 +63,23 @@ using memory_group = xrtMemoryGroup;
  * Use xrt::bo bo{..., pid_type{pid}, ...};
  */
 struct pid_type { pid_t pid; };
+
+class async_bo_impl;
+class async_bo_hdl : public detail::pimpl<async_bo_impl>
+{
+public:
+  async_bo_hdl()
+  {}
+
+  explicit
+  async_bo_hdl(std::shared_ptr<async_bo_impl> handle)
+    : detail::pimpl<async_bo_impl>(std::move(handle))
+  {}
+
+  XCL_DRIVER_DLLESPEC
+  void
+  wait();
+};
 
 class bo_impl;
 class bo
@@ -362,6 +380,19 @@ public:
   XCL_DRIVER_DLLESPEC
   xclBufferExportHandle
   export_buffer();
+
+  /**
+   * async() - Start buffer content txfer with device side
+   *
+   */
+  XCL_DRIVER_DLLESPEC
+  xrt::async_bo_hdl
+  async(xclBOSyncDirection dir, size_t sz, size_t offset);
+
+  xrt::async_bo_hdl
+  async(xclBOSyncDirection dir) {
+    return async(dir, size(), 0);
+  }
 
   /**
    * sync() - Synchronize buffer content with device side

--- a/src/runtime_src/core/include/xrt/xrt_bo.h
+++ b/src/runtime_src/core/include/xrt/xrt_bo.h
@@ -393,13 +393,35 @@ public:
   /**
    * async() - Start buffer content txfer with device side
    *
+   * @param dir
+   *  To device or from device
+   * @param sz
+   *  Size of data to synchronize
+   * @param offset
+   *  Offset within the BO
+   *
+   * Asynchronously transfer specified size bytes of buffer
+   * starting at specified offset.
    */
   XCL_DRIVER_DLLESPEC
   async_handle
   async(xclBOSyncDirection dir, size_t sz, size_t offset);
 
+  /**
+   * async() - Start buffer content txfer with device side
+   *
+   * @param dir
+   *  To device or from device
+   * @param sz
+   *  Size of data to synchronize
+   * @param offset
+   *  Offset within the BO
+   *
+   * Asynchronously transfer entire buffer content in specified direction
+   */
   async_handle
-  async(xclBOSyncDirection dir) {
+  async(xclBOSyncDirection dir)
+  {
     return async(dir, size(), 0);
   }
 

--- a/src/runtime_src/core/include/xrt/xrt_bo.h
+++ b/src/runtime_src/core/include/xrt/xrt_bo.h
@@ -64,26 +64,35 @@ using memory_group = xrtMemoryGroup;
  */
 struct pid_type { pid_t pid; };
 
-class async_bo_impl;
-class async_bo_hdl : public detail::pimpl<async_bo_impl>
-{
-public:
-  async_bo_hdl()
-  {}
-
-  explicit
-  async_bo_hdl(std::shared_ptr<async_bo_impl> handle)
-    : detail::pimpl<async_bo_impl>(std::move(handle))
-  {}
-
-  XCL_DRIVER_DLLESPEC
-  void
-  wait();
-};
-
 class bo_impl;
 class bo
 {
+public:
+  /*!
+   * @class async_handle
+   *
+   * @brief
+   * xrt::bo::async_handle represents an asynchronously operation
+   *
+   * @details
+   * A handle object is returned from asynchronous buffer object
+   * operations.  It can be used to wait for the operation to
+   * complete.
+   */
+  class async_handle_impl;
+  class async_handle : public detail::pimpl<async_handle_impl>
+  {
+  public:
+    explicit
+    async_handle(std::shared_ptr<async_handle_impl> handle)
+      : detail::pimpl<async_handle_impl>(std::move(handle))
+    {}
+
+    XCL_DRIVER_DLLESPEC
+    void
+    wait();
+  };
+
 public:
   /**
    * @enum flags - buffer object flags
@@ -386,10 +395,10 @@ public:
    *
    */
   XCL_DRIVER_DLLESPEC
-  xrt::async_bo_hdl
+  async_handle
   async(xclBOSyncDirection dir, size_t sz, size_t offset);
 
-  xrt::async_bo_hdl
+  async_handle
   async(xclBOSyncDirection dir) {
     return async(dir, size(), 0);
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
New API for asynchronous DMA. See API description.
Pseudo host code:
...
auto hdl_aie1 = buf_aie.async("in_sink1", XCL_BO_SYNC_BO_GMIO_TO_AIE, buffer_size, offset);
auto hdl_1 = buf_1.async(XCL_BO_SYNC_BO_TO_DEVICE, buffer_size, offset);
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
None
#### How problem was solved, alternative solutions (if any) and why they were rejected
New feature
#### Risks (if any) associated the changes in the commit
None. Can use other existing APIs
#### What has been tested and how, request additional testing if necessary
Tested locally on vck190
#### Documentation impact (if any)
To do done