### PR TITLE
start aie trace on graph iterator

### DIFF
--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -369,6 +369,16 @@ get_aie_trace_metrics()
   return value;
 }
 
+/**
+ * off|time|graph|user
+ */
+inline std::string
+get_aie_trace_start_type()
+{
+  static std::string value = detail::get_string_value("Debug.aie_trace_start_type", "off");
+  return value;
+}
+
 inline std::string
 get_aie_trace_start_time()
 {
@@ -376,10 +386,10 @@ get_aie_trace_start_time()
   return value;
 }
 
-inline bool
-get_aie_trace_user_control()
+inline unsigned int
+get_aie_trace_start_iteration()
 {
-  static bool value = detail::get_bool_value("Debug.aie_trace_user_control", false);
+  static unsigned int value = detail::get_uint_value("Debug.aie_trace_start_iteration", 1);
   return value;
 }
 

--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -369,27 +369,10 @@ get_aie_trace_metrics()
   return value;
 }
 
-/**
- * off|time|graph|user
- */
-inline std::string
-get_aie_trace_start_type()
-{
-  static std::string value = detail::get_string_value("Debug.aie_trace_start_type", "off");
-  return value;
-}
-
 inline std::string
 get_aie_trace_start_time()
 {
   static std::string value = detail::get_string_value("Debug.aie_trace_start_time", "0");
-  return value;
-}
-
-inline unsigned int
-get_aie_trace_start_iteration()
-{
-  static unsigned int value = detail::get_uint_value("Debug.aie_trace_start_iteration", 1);
   return value;
 }
 
@@ -925,6 +908,10 @@ get_aie_profile_settings_mem_tile_metrics()
 }
 
 // AIE_trace_settings
+
+/**
+ * off|time|graph|user
+ */
 inline std::string
 get_aie_trace_settings_start_type()
 {
@@ -935,7 +922,6 @@ get_aie_trace_settings_start_type()
 inline std::string
 get_aie_trace_settings_start_time()
 {
-  //default value ?
   static std::string value = detail::get_string_value("AIE_trace_settings.start_time", "0");
   return value;
 }

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -245,7 +245,8 @@ namespace xdp {
       ++required;
       if (!mUseOneDelayCtr)
         ++required;
-    }
+    } else if (mUseGraphIterator)
+      ++required;
     if (available < required) {
       msg << "Available core module performance counters for aie trace : " << available << std::endl
           << "Required core module performance counters for aie trace : "  << required;
@@ -424,59 +425,75 @@ namespace xdp {
     return tiles;
   }
 
-  void AieTracePlugin::setTraceStartDelayCycles(void* handle)
+  void AieTracePlugin::setTraceStartControl(void* handle)
   {
-    double freqMhz = AIE_DEFAULT_FREQ_MHZ;
+    mUseDelay = false;
+    mUseGraphIterator = false;
+    mUseUserControl = false;
 
-    if (handle != nullptr) {
-      auto device = xrt_core::get_userpf_device(handle);
-      freqMhz = xrt_core::edge::aie::get_clock_freq_mhz(device.get());
-    }
+    auto startType = xrt_core::config::get_aie_trace_start_type();
 
-    std::smatch pieces_match;
-    uint64_t cycles_per_sec = static_cast<uint64_t>(freqMhz * 1e6);
-    std::string size_str = xrt_core::config::get_aie_trace_start_time();
+    if (startType == "time") {
+    // Use number of cycles to start trace
+      double freqMhz = AIE_DEFAULT_FREQ_MHZ;
+      if (handle != nullptr) {
+        auto device = xrt_core::get_userpf_device(handle);
+        freqMhz = xrt_core::edge::aie::get_clock_freq_mhz(device.get());
+      }
 
-    // Catch cases like "1Ms" "1NS"
-    std::transform(size_str.begin(), size_str.end(), size_str.begin(),
-      [](unsigned char c){ return std::tolower(c); });
+      std::smatch pieces_match;
+      uint64_t cycles_per_sec = static_cast<uint64_t>(freqMhz * 1e6);
+      std::string size_str = xrt_core::config::get_aie_trace_start_time();
 
-    // Default is 0 cycles
-    uint64_t cycles = 0;
-    // Regex can parse values like : "1s" "1ms" "1ns"
-    const std::regex size_regex("\\s*(\\d+\\.?\\d*)\\s*(s|ms|us|ns|)\\s*");
-    if (std::regex_match(size_str, pieces_match, size_regex)) {
-      try {
-        if (pieces_match[2] == "s") {
-          cycles = static_cast<uint64_t>(std::stof(pieces_match[1]) * cycles_per_sec);
-        } else if (pieces_match[2] == "ms") {
-          cycles = static_cast<uint64_t>(std::stof(pieces_match[1]) * cycles_per_sec /  1e3);
-        } else if (pieces_match[2] == "us") {
-          cycles = static_cast<uint64_t>(std::stof(pieces_match[1]) * cycles_per_sec /  1e6);
-        } else if (pieces_match[2] == "ns") {
-          cycles = static_cast<uint64_t>(std::stof(pieces_match[1]) * cycles_per_sec /  1e9);
-        } else {
-          cycles = static_cast<uint64_t>(std::stof(pieces_match[1]));
-        }
+      // Catch cases like "1Ms" "1NS"
+      std::transform(size_str.begin(), size_str.end(), size_str.begin(),
+        [](unsigned char c){ return std::tolower(c); });
+
+      // Default is 0 cycles
+      uint64_t cycles = 0;
+      // Regex can parse values like : "1s" "1ms" "1ns"
+      const std::regex size_regex("\\s*(\\d+\\.?\\d*)\\s*(s|ms|us|ns|)\\s*");
+      if (std::regex_match(size_str, pieces_match, size_regex)) {
+        try {
+          if (pieces_match[2] == "s") {
+            cycles = static_cast<uint64_t>(std::stof(pieces_match[1]) * cycles_per_sec);
+          } else if (pieces_match[2] == "ms") {
+            cycles = static_cast<uint64_t>(std::stof(pieces_match[1]) * cycles_per_sec /  1e3);
+          } else if (pieces_match[2] == "us") {
+            cycles = static_cast<uint64_t>(std::stof(pieces_match[1]) * cycles_per_sec /  1e6);
+          } else if (pieces_match[2] == "ns") {
+            cycles = static_cast<uint64_t>(std::stof(pieces_match[1]) * cycles_per_sec /  1e9);
+          } else {
+            cycles = static_cast<uint64_t>(std::stof(pieces_match[1]));
+          }
         
-        std::string msg("Parsed aie_trace_start_time: " + std::to_string(cycles) + " cycles.");
-        xrt_core::message::send(xrt_core::message::severity_level::info, "XRT", msg);
+          std::string msg("Parsed aie_trace_start_time: " + std::to_string(cycles) + " cycles.");
+          xrt_core::message::send(xrt_core::message::severity_level::info, "XRT", msg);
 
-      } catch (const std::exception& ) {
-        // User specified number cannot be parsed
+        } catch (const std::exception& ) {
+          // User specified number cannot be parsed
+          std::string msg("Unable to parse aie_trace_start_time. Setting start time to 0.");
+          xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", msg);
+        }
+      } else {
         std::string msg("Unable to parse aie_trace_start_time. Setting start time to 0.");
         xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", msg);
       }
-    } else {  
-      std::string msg("Unable to parse aie_trace_start_time. Setting start time to 0.");
-      xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", msg);
+
+      if (cycles > std::numeric_limits<uint32_t>::max())
+        mUseOneDelayCtr = false;
+
+      mUseDelay = (cycles != 0);
+      mDelayCycles = cycles;
+    } else if (startType == "graph") {
+    // Start trace when graph iterator reaches a threshold
+      mIterationCount = xrt_core::config::get_aie_trace_start_iteration();
+      mUseGraphIterator = (mIterationCount != 0);
+    } else if (startType == "user") {
+    // Start trace using user events
+      mUseUserControl = true;
     }
 
-    if (cycles > std::numeric_limits<uint32_t>::max())
-      mUseOneDelayCtr = false;
-
-    mUseDelay = ( cycles != 0 );
-    mDelayCycles = cycles;
   }
 
   bool AieTracePlugin::configureStartDelay(xaiefal::XAieMod& core)
@@ -549,6 +566,38 @@ namespace xdp {
     return true;
   }
 
+bool AieTracePlugin::configureStartIteration(xaiefal::XAieMod& core)
+  {
+    XAie_ModuleType mod = XAIE_CORE_MOD;
+    // Count up by 1 for every iteration
+    auto pc = core.perfCounter();
+    if (pc->initialize(mod, XAIE_EVENT_INSTR_EVENT_0_CORE,
+                       mod, XAIE_EVENT_INSTR_EVENT_0_CORE) != XAIE_OK)
+      return false;
+    if (pc->reserve() != XAIE_OK)
+      return false;
+    pc->changeThreshold(mIterationCount);
+    XAie_Events counterEvent;
+    pc->getCounterEvent(mod, counterEvent);
+    // Reset when done counting
+    pc->changeRstEvent(mod, counterEvent);
+    if (pc->start() != XAIE_OK)
+        return false;
+
+    if (xrt_core::config::get_verbosity() >= static_cast<uint32_t>(severity_level::debug)) {
+      std::stringstream msg;
+      msg << "Configuring aie trace to start on iteration : " << mIterationCount;
+      xrt_core::message::send(severity_level::debug, "XRT", msg.str());
+    }
+
+    coreTraceStartEvent = counterEvent;
+    // This is needed because the cores are started/stopped during execution
+    // to get around some hw bugs. We cannot restart tracemodules when that happens
+    coreTraceEndEvent = XAIE_EVENT_NONE_CORE;
+
+    return true;
+  }
+
   // Configure all resources necessary for trace control and events
   bool AieTracePlugin::setMetrics(uint64_t deviceId, void* handle)
   {
@@ -570,7 +619,7 @@ namespace xdp {
     }
 
     auto tiles = getTilesForTracing(handle);
-    setTraceStartDelayCycles(handle);
+    setTraceStartControl(handle);
 
     // Keep track of number of events reserved per tile
     int numTileCoreTraceEvents[NUM_CORE_TRACE_EVENTS+1] = {0};
@@ -718,9 +767,11 @@ namespace xdp {
         auto coreTrace = core.traceControl();
 
         // Delay cycles and user control are not compatible with each other
-        if (xrt_core::config::get_aie_trace_user_control()) {
+        if (mUseUserControl) {
           coreTraceStartEvent = XAIE_EVENT_INSTR_EVENT_0_CORE;
           coreTraceEndEvent = XAIE_EVENT_INSTR_EVENT_1_CORE;
+        } else if (mUseGraphIterator && !configureStartIteration(core)) {
+          break;
         } else if (mUseDelay && !configureStartDelay(core)) {
           break;
         }

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.h
@@ -62,12 +62,13 @@ namespace xdp {
       void releaseCurrentTileCounters(int numCoreCounters, int numMemoryCounters);
       bool setMetrics(uint64_t deviceId, void* handle);
       void setFlushMetrics(uint64_t deviceId, void* handle);
-      void setTraceStartDelayCycles(void* handle);
+      void setTraceStartControl(void* handle);
 
       // Aie resource manager utility functions
       bool tileHasFreeRsc(xaiefal::XAieDev* aieDevice, XAie_LocType& loc, const std::string& metricSet);
       void printTileStats(xaiefal::XAieDev* aieDevice, const tile_type& tile);
       bool configureStartDelay(xaiefal::XAieMod& core);
+      bool configureStartIteration(xaiefal::XAieMod& core);
 
       // Utility functions
       std::string getMetricSet(void* handle);
@@ -82,9 +83,18 @@ namespace xdp {
       bool runtimeMetrics = true;
 
       // These flags are used to decide configuration at various points
+
+      // Start Delay in cycles
       bool mUseDelay = false;
       uint64_t mDelayCycles = 0;
       bool mUseOneDelayCtr = true;
+
+      // Start Delay using graph iterator
+      bool mUseGraphIterator = false;
+      uint32_t mIterationCount = 0;
+
+      // Start using user control
+      bool mUseUserControl = false;
 
       bool continuousTrace;
       uint64_t offloadIntervalUs;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

Support aie trace start using graph iterator counter (partly implemented in aiecompiler)
Use one switch for aie trace start control

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
N/A
#### How problem was solved, alternative solutions (if any) and why they were rejected
N/A
#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Cycle delay tested on a design. Graph iterator cannot be tested until aiecompiler changes are implemented
#### Documentation impact (if any)
aie trace delay now requires turning on both aie_trace_start_type and aie_trace_start_time switches. Previously it was just one switch.