### PR TITLE
CR-1127959 TC18.01 - u55c - validate dma test reporting high bandwidth figure with 256MB block size

### DIFF
--- a/src/runtime_src/core/pcie/common/dmatest.h
+++ b/src/runtime_src/core/pcie/common/dmatest.h
@@ -95,7 +95,7 @@ namespace xcldev {
              *          4        |   2   |     b+4
              */
             unsigned int len = (((unsigned int)(e - b)) < count) ? 1 : ((unsigned int)(e - b))/count;
-            unsigned int bo_cnt = ((unsigned int)(e - b));
+            auto bo_cnt = static_cast<unsigned int>(e - b);
             const auto adjust_e = b + len * ((len == 1) ? bo_cnt : std::min<unsigned int>(count, len));
 
             std::vector<std::future<int>> threads;

--- a/src/runtime_src/core/pcie/common/dmatest.h
+++ b/src/runtime_src/core/pcie/common/dmatest.h
@@ -84,11 +84,22 @@ namespace xcldev {
                 auto future0 = std::async(std::launch::async, &DMARunner::runSyncWorker, this, b, e, dir);
                 return future0.get();
             }
-
+            /* Calculate the DMA workers number, the DMA may have one or more channels
+             * which means it's capable to run multi DMA transaction at the same time
+             *   mBOList.size()  |  len  |  ajust_e
+             * --------------------------------------
+             *          1        |   1   |     b+1
+             * --------------------------------------
+             *          2        |   1   |     b+2
+             * --------------------------------------
+             *          4        |   2   |     b+4
+             */
             unsigned int len = (((unsigned int)(e - b)) < count) ? 1 : ((unsigned int)(e - b))/count;
-            const auto ajust_e = b + len * std::min<unsigned int>(count, len);
+            unsigned int bo_cnt = ((unsigned int)(e - b));
+            const auto adjust_e = b + len * ((len == 1) ? bo_cnt : std::min<unsigned int>(count, len));
+
             std::vector<std::future<int>> threads;
-            while (b < ajust_e) {
+            while (b < adjust_e) {
                 threads.push_back(std::async(std::launch::async, &DMARunner::runSyncWorker, this, b, b + len, dir));
                 b += len;
             }


### PR DESCRIPTION
#### Problem solved by the commit
Miscalculate the DMA workers number  to be performed, only submits half of the BOs.

So the throughput is twice as fast as theoretical limit.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://github.com/Xilinx/XRT/pull/6184
'


