### PR TITLE
CR-1132277 xrt_kernel.h requires xrt_hw_context.h which only works with C++

### DIFF
--- a/src/runtime_src/core/include/xrt/xrt_kernel.h
+++ b/src/runtime_src/core/include/xrt/xrt_kernel.h
@@ -11,10 +11,10 @@
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_uuid.h"
 
-#include "experimental/xrt_hw_context.h"
 
 #ifdef __cplusplus
 # include "experimental/xrt_enqueue.h"
+# include "experimental/xrt_hw_context.h"
 # include <chrono>
 # include <cstdint>
 # include <functional>


### PR DESCRIPTION
#### Problem solved by the commit
Move inclusion of xrt_hw_context.h under __cplusplus guard

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1132277 xrt header, xrt_kernel.h, requires xrt_hw_context.h which only works with C++
