### PR TITLE
CR-1132448 add data empty check before adding to sensor output

### DIFF
--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -237,7 +237,8 @@ struct sdm_sensor_info
        */
       std::string tpath = path + "/" + type + std::to_string(start_id) + "_";
       data = parse_sysfs_nodes(device, tpath, &next_id);
-      output.push_back(data);
+      if (!data.label.empty())
+        output.push_back(data);
 
       start_id++;
     } //while (!next_id)


### PR DESCRIPTION
Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
CR-1132448: xbutil reports printing empty data at the end of each report

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
xbutil reports no longer prints empty sensor data

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added data empty check in device_linux driver to fix this issue. So, empty data is not added to sensor output vector.

#### Risks (if any) associated the changes in the commit
NA
#### What has been tested and how, request additional testing if necessary
xbutil reports
#### Documentation impact (if any)
NA