### PR TITLE
CR-1127850 hostmem-bw test fails with bad::alloc for host mem size of 4M

### DIFF
--- a/tests/python/23_bandwidth/host_mem_23_bandwidth.py
+++ b/tests/python/23_bandwidth/host_mem_23_bandwidth.py
@@ -41,7 +41,7 @@ libc.memcpy.restype = (ctypes.c_void_p)
 
 current_micro_time = lambda: int(round(time.time() * 1000000))
 
-globalbuffersize = 1024*1024*16    #16 MB
+globalbuffersize = 1024*1024*2    #2 MB
 
 def getThreshold(devHandle):
     threshold = 30000

--- a/tests/validate/hostmemory_test/src/host.cpp
+++ b/tests/validate/hostmemory_test/src/host.cpp
@@ -172,8 +172,10 @@ int main(int argc, char** argv) {
     double max_throughput = 0;
     int reps = stoi(iter_cnt);
 
-    // Starting at 4K and going up to 16M with increments of power of 2
-    for (uint32_t i = 4 * 1024; i <= 16 * 1024 * 1024; i *= 2) {
+    // Starting at 4K and going up to 1M with increments of power of 2
+    // The minimum size of host-mem user can reserve is 4M,
+    // The sum of the sizes of buffers can't excess the size of host-mem reserved.
+    for (uint32_t i = 4 * 1024; i <= 1 * 1024 * 1024; i *= 2) {
         unsigned int data_size = i;
 
         if (xcl::is_emulation()) {


### PR DESCRIPTION
#### Problem solved by the commit
xbutil validate -r hostmem-bw may use more host-mem than the minimum size of host-mem that users can legitimately reserve.

Modify the hostmem-bw test to cover this scenario.