### PR TITLE
Updating petalinux build to 0608 build path in 2022.2

### DIFF
--- a/build/petalinux.build
+++ b/build/petalinux.build
@@ -1,3 +1,3 @@
 # When updating Petalinux build please file a SH ticket to retain the build
 # https://jira.xilinx.com/secure/CreateIssue!default.jspa
-PETALINUX="/proj/petalinux/2022.1/petalinux-v2022.1_stable_latest/tool/petalinux-v2022.1-final"
+PETALINUX="/proj/petalinux/2022.2/petalinux-v2022.2_06081049/tool/petalinux-v2022.2-final"


### PR DESCRIPTION
Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Updating petalinux build to 2022.2
https://jira.xilinx.com/browse/SH-1874 to retain this TA

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
NA
#### How problem was solved, alternative solutions (if any) and why they were rejected
NA
#### Risks (if any) associated the changes in the commit
NA
#### What has been tested and how, request additional testing if necessary
Built APU Package and verified with this build.
#### Documentation impact (if any)
NA