### PR TITLE
Modified to refer the single MMap file to allocate the device memory …

### DIFF
--- a/src/runtime_src/core/pcie/emulation/common_em/em_defines.h
+++ b/src/runtime_src/core/pcie/emulation/common_em/em_defines.h
@@ -169,7 +169,14 @@ namespace xclemulation {
 
   static inline bool is_cacheable(const struct drm_xocl_bo *bo) {
     return (bo->flags & XCL_BO_FLAGS_CACHEABLE);
-  }  
+  }
+
+  static inline bool is_zero_copy(const struct drm_xocl_bo *bo) {
+    bool isCacheable = xclemulation::is_cacheable(bo);
+    bool memCheck = xclemulation::no_host_memory(bo) || xclemulation::xocl_bo_host_only(bo);
+    bool zeroCopy = (memCheck || !isCacheable) ? true : false;
+    return zeroCopy;
+  }
 }
 
 /**

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.h
@@ -45,7 +45,7 @@
 
 namespace xclcpuemhal2 {
   using key_type = xrt_core::query::key_type;
-  const uint64_t MEMSIZE = 0x0000000080000000;
+  const uint64_t MEMSIZE = 0x0000000200000000;
   const auto endOfSimulationString = "received request to end simulation from connected initiator";
 
   // XDMA Shim


### PR DESCRIPTION
Modified to refer the single MMap file to allocate the device memory instead of allocating the memory using malloc

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
We have modified to refer the single mmap file instead of multiple mmap files to align the solution and to enable the Hybrid emulation. And as part of the PR corrected the copy_bo command during p2p scenarios

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
This is an enhancement, not a bug

#### How problem was solved, alternative solutions (if any) and why they were rejected
No alternate solutions. This is needed to enhance the memory usage for sw_emu and support various new aie requirements

#### Risks (if any) associated the changes in the commit
No

#### What has been tested and how, request additional testing if necessary
Canary is clean and also ran the various designs manually which covers various scenarios

#### Documentation impact (if any)
No