### PR TITLE
Doesn't copy entire extra cu mask

### DIFF
--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -1786,7 +1786,7 @@ void start_skrnl_ecmd2xcmd(struct ert_start_kernel_cmd *ecmd,
 	}
 
 	xcmd->cu_mask[0] = ecmd->cu_mask;
-	memcpy(&xcmd->cu_mask[1], ecmd->data, ecmd->extra_cu_masks);
+	memcpy(&xcmd->cu_mask[1], ecmd->data, ecmd->extra_cu_masks * sizeof(u32));
 	xcmd->num_mask = 1 + ecmd->extra_cu_masks;
 
 	xcmd->isize = (ecmd->count - xcmd->num_mask) * sizeof(u32);
@@ -1806,7 +1806,7 @@ void start_krnl_ecmd2xcmd(struct ert_start_kernel_cmd *ecmd,
 	}
 
 	xcmd->cu_mask[0] = ecmd->cu_mask;
-	memcpy(&xcmd->cu_mask[1], ecmd->data, ecmd->extra_cu_masks);
+	memcpy(&xcmd->cu_mask[1], ecmd->data, ecmd->extra_cu_masks * sizeof(u32));
 	xcmd->num_mask = 1 + ecmd->extra_cu_masks;
 
 	/* Copy resigter map into info and isize is the size of info in bytes.
@@ -1834,7 +1834,7 @@ void start_krnl_kv_ecmd2xcmd(struct ert_start_kernel_cmd *ecmd,
 	}
 
 	xcmd->cu_mask[0] = ecmd->cu_mask;
-	memcpy(&xcmd->cu_mask[1], ecmd->data, ecmd->extra_cu_masks);
+	memcpy(&xcmd->cu_mask[1], ecmd->data, ecmd->extra_cu_masks * sizeof(u32));
 	xcmd->num_mask = 1 + ecmd->extra_cu_masks;
 
 	/* Copy resigter map into info and isize is the size of info in bytes.
@@ -1861,7 +1861,7 @@ void start_fa_ecmd2xcmd(struct ert_start_kernel_cmd *ecmd,
 	}
 
 	xcmd->cu_mask[0] = ecmd->cu_mask;
-	memcpy(&xcmd->cu_mask[1], ecmd->data, ecmd->extra_cu_masks);
+	memcpy(&xcmd->cu_mask[1], ecmd->data, ecmd->extra_cu_masks * sizeof(u32));
 	xcmd->num_mask = 1 + ecmd->extra_cu_masks;
 
 	/* Copy descriptor into info and isize is the size of info in bytes.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
When extra_cu_mask is not zero, KDS doesn't copy all CU mask to xcmd.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
@pranjalv-xilinx found this issue.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Just use correct size.

#### Risks (if any) associated the changes in the commit
This will impact CU when index exceed 35.

#### What has been tested and how, request additional testing if necessary
U50 xbutil validate

#### Documentation impact (if any)
No