### PR TITLE
trace enhancements for pl and aie

### DIFF
--- a/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.cpp
+++ b/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.cpp
@@ -81,6 +81,9 @@ bool AIETraceOffload::initReadTrace()
     gmioDMAInsts.resize(numStream);
   }
 
+  if (isPLIO && continuousTrace())
+    checkCircularBufferSupport();
+
   for(uint64_t i = 0; i < numStream ; ++i) {
     buffers[i].boHandle = deviceIntf->allocTraceBuf(bufAllocSz, memIndex);
     if(!buffers[i].boHandle) {
@@ -95,8 +98,6 @@ bool AIETraceOffload::initReadTrace()
     xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT", msg.c_str());
 
     if (isPLIO) {
-      if (continuousTrace())
-        checkCircularBufferSupport();
       deviceIntf->initAIETs2mm(bufAllocSz, bufAddr, i, mEnCircularBuf);
     } else {
 #ifdef XRT_ENABLE_AIE

--- a/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.h
+++ b/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.h
@@ -130,12 +130,12 @@ private:
     AIEOffloadThreadStatus offloadStatus;
     std::thread offloadThread;
 
-  //Circular Buffer Tracking
-  bool mEnCircularBuf;
-  // 1000 mb of trace per second
-  // Very high bandwidth requirement
-  uint64_t circ_buf_min_rate_plio = TS2MM_DEF_BUF_SIZE * 1000;
-  uint64_t circ_buf_cur_rate_plio;
+    //Circular Buffer Tracking
+    bool mEnCircularBuf;
+    // 1000 mb of trace per second
+    // Very high bandwidth requirement
+    uint64_t circ_buf_min_rate_plio = TS2MM_DEF_BUF_SIZE * 1000;
+    uint64_t circ_buf_cur_rate_plio;
 
 private:
     void continuousOffload();

--- a/src/runtime_src/xdp/profile/device/device_trace_logger.cpp
+++ b/src/runtime_src/xdp/profile/device/device_trace_logger.cpp
@@ -704,6 +704,7 @@ namespace xdp {
     static double y2 = 0.0;
     static double x1 = 0.0;
     static double x2 = 0.0;
+
     if (!y1 && !x1) {
       y1 = static_cast <double> (hostTimestamp);
       x1 = static_cast <double> (deviceTimestamp);
@@ -731,13 +732,12 @@ namespace xdp {
 
   void DeviceTraceLogger::processTraceData(void* data, uint64_t numBytes)
   {
-    if (numBytes == 0)      return ;
-    if (!VPDatabase::alive()) return ;
+    if (numBytes == 0)
+      return ;
+    if (!VPDatabase::alive())
+      return ;
 
-    uint32_t modulus = 0 ;
-    uint64_t clockTrainingHostTimestamp = 0 ;
     uint64_t numPackets = numBytes / sizeof(uint64_t) ;
-
     uint64_t start = 0 ;
 
     // Try to find 8 contiguous clock training packets.  Anything before that
@@ -748,18 +748,22 @@ namespace xdp {
       for (uint64_t i = 0 ; i < numPackets - 8 ; ++i) {
         for (uint64_t j = i ; j < i + 8 ; ++j) {
           uint64_t packet = (static_cast<uint64_t*>(data))[j] ;
-          if (!isClockTraining(packet)) {
+          if (!isClockTraining(packet))
             break ;
-          }
           if (j == (i + 7)) {
             start = i ;
             found = true ;
           }
         }
-        if (found) break ;
+        if (found)
+          break ;
       }
     }
-    
+
+    // Clock Training state is preserved across calls
+    static uint32_t modulus = 0 ;
+    static uint64_t clockTrainingHostTimestamp = 0 ;
+
     for (uint64_t i = start ; i < numPackets ; ++i) {
       uint64_t packet = (static_cast<uint64_t*>(data))[i] ;
       auto deviceTimestamp = getDeviceTimestamp(packet) ;

--- a/src/runtime_src/xdp/profile/device/device_trace_offload.cpp
+++ b/src/runtime_src/xdp/profile/device/device_trace_offload.cpp
@@ -339,13 +339,15 @@ read_trace_s2mm(bool force)
       bd.used_size = bd.alloc_size;
     }
 
-    debug_stream
-      << "ts2mm_" << i << " Reading from 0x"
-      << std::hex << bd.offset << " to 0x" << bd.used_size << std::dec
-      << " Bytes Read : " << bytes_read
-      << " Bytes Written : " << bytes_written
-      << " Rollovers : " << bd.rollover_count
-      << std::endl;
+    if (bd.offset != bd.used_size) {
+      debug_stream
+        << "ts2mm_" << i << " Reading from 0x"
+        << std::hex << bd.offset << " to 0x" << bd.used_size << std::dec
+        << " Bytes Read : " << bytes_read
+        << " Bytes Written : " << bytes_written
+        << " Rollovers : " << bd.rollover_count
+        << std::endl;
+    }
 
     if (!sync_and_log(i))
       continue;

--- a/src/runtime_src/xdp/profile/device/tracedefs.h
+++ b/src/runtime_src/xdp/profile/device/tracedefs.h
@@ -73,6 +73,9 @@ buffer size and/or reduce trace_buffer_offload_interval."
 #define TS2MM_WARN_MSG_QUEUE_SZ        "Too much trace in processing queue. This could have negative impact on host memory utilization. \
 Please increase trace_buffer_size and trace_buffer_offload_interval together or use 'coarse' option for device_trace."
 
+// Minimum of 1MB per offloader for circular buffer to be enabled
+#define AIE_MIN_SIZE_CIRCULAR_BUF      0x100000
+
 #define AIE_TS2MM_WARN_MSG_BUF_FULL             "AIE Trace Buffer is full. Device trace could be incomplete."
 #define AIE_TS2MM_WARN_MSG_CIRC_BUF_OVERWRITE   "Circular buffer overwrite was detected in device trace. AIE trace could be incomplete."
 #define AIE_TS2MM_WARN_MSG_CIRC_BUF             "AIE trace will be limited to trace buffer size due to insufficient trace offload rate. Please increase \

--- a/src/runtime_src/xdp/profile/writer/aie_trace/aie_trace_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/aie_trace/aie_trace_writer.cpp
@@ -76,52 +76,33 @@ namespace xdp {
   {
     // write the entire buffer
     AIETraceDataType* traceData = (db->getDynamicInfo()).getAIETraceData(deviceId, traceStreamId);
-    if(nullptr == traceData) {
+    if (nullptr == traceData) {
       fout << std::endl;
       return;
     }
 
     size_t num = traceData->buffer.size();
-    for(size_t j = 0; j < num; j++) {
+    for (size_t j = 0; j < num; j++) {
       void*    buf = traceData->buffer[j].get();
       // We write 4 bytes at a time
       // Max chunk size should be multiple of 4
       // If last chunk is not multiple of 4 then in worst case, 
       // 3 bytes of data will not be written. But this is not possible, as we always write full packet.
       uint64_t bufferSz = (traceData->bufferSz[j] / 4);
-      if(nullptr == buf) {
+      if (nullptr == buf) {
         fout << std::endl;
         return;
       }
 
       uint32_t* dataBuffer = static_cast<uint32_t*>(buf);
-      for(uint64_t i = 0; i < bufferSz; i++) {
+      for (uint64_t i = 0; i < bufferSz; i++)
         fout << "0x" << std::hex << dataBuffer[i] << std::endl;
-      }
+
+      // Free the memory immediately
+      traceData->buffer[j].reset();
     }
     fout << std::endl;
     delete traceData;
-
-#if 0
-    void*    buf = traceData->buffer;
-    uint64_t bufferSz = traceData->bufferSz;
-std::cout << " AIETraceWriter::writeTraceEvents : buf " << buf << " bufferSz " << bufferSz << std::endl;
-    if(nullptr == buf) {
-      fout << std::endl;
-      return;
-    }
-
-    uint32_t* dataBuffer = static_cast<uint32_t*>(buf);
-std::cout << " AIETraceWriter::writeTraceEvents : dataBuffer " << dataBuffer << std::endl;
-    for(uint64_t i = 0; i < bufferSz; i++) {
-      fout << "0x" << std::hex << dataBuffer[i] << std::endl;
-      if(i < 100) {
-        std::cout << "0x" << std::hex << dataBuffer[i] << std::endl;
-      }
-    }
-    std::cout << std::dec << std::endl;
-    fout << std::endl;
-#endif
   }
 
   void AIETraceWriter::writeDependencies()
@@ -130,22 +111,8 @@ std::cout << " AIETraceWriter::writeTraceEvents : dataBuffer " << dataBuffer << 
 
   bool AIETraceWriter::write(bool /*openNewFile*/)
   {
-#if 0
-    writeHeader() ;
-    fout << std::endl ;
-    writeStructure() ;
-    fout << std::endl ;
-    writeStringTable() ;
-    fout << std::endl ;
-#endif
-    writeTraceEvents() ;
-    fout << std::endl ;
-#if 0
-    writeDependencies() ;
-    fout << std::endl ;
-#endif
-
-   // if (openNewFile) switchFiles() ;
+    writeTraceEvents();
+    fout << std::endl;
     return true;
   }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

1. Set minimum of 1MB as buffer size for circular buffer in AIE
2. Check for circular buffer support only once 
3. Free trace buffer immediately upon write
4. Fix issue where PL trace clock training didn't work across chunks
5. Remove unused code in aie trace writer

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
tested on aie and pl trace designs
#### Documentation impact (if any)
