### PR TITLE
CR-1120194: Addressed hang issue for external IO example, specific thread polls the client file descriptor periodically

### DIFF
--- a/src/runtime_src/core/include/xcl_api_macros.h
+++ b/src/runtime_src/core/include/xcl_api_macros.h
@@ -20,10 +20,14 @@
 
 
 #define AQUIRE_MUTEX() \
-mtx.lock(); \
+if ( sock->server_started == false ) { std::cerr<<"\n socket communication is not possible now!"; exit(0);  }\
+std::lock_guard<std::mutex> socketlk{mtx}; 
 
-#define RELEASE_MUTEX() \
-mtx.unlock();
+
+// dummy Release Mutex Call.
+#define RELEASE_MUTEX() 
+
+
 
 #define RPC_PROLOGUE(func_name) \
     auto _s_inst = sock;  \
@@ -37,24 +41,24 @@ mtx.unlock();
     auto c_len = c_msg.ByteSize();                                      \
     buf_size = alloc_void(c_len);                                       \
     bool rv = c_msg.SerializeToArray(buf,c_len);                        \
-    if(rv == false){std::cerr<<"FATAL ERROR:protobuf SerializeToArray failed"<<std::endl;exit(1);} \
+    if(rv == false){std::cerr<<"FATAL ERROR:protobuf SerializeToArray failed"<<std::endl; exit(1);} \
                                                                         \
     ci_msg.set_size(c_len);                                             \
     ci_msg.set_xcl_api(func_name##_n);                                  \
     auto ci_len = ci_msg.ByteSize();                                    \
     rv = ci_msg.SerializeToArray(ci_buf,ci_len);                        \
-    if(rv == false){std::cerr<<"FATAL ERROR:protobuf SerializeToArray failed"<<std::endl;exit(1);} \
+    if(rv == false){std::cerr<<"FATAL ERROR:protobuf SerializeToArray failed"<<std::endl; exit(1); } \
                                                                         \
     _s_inst->sk_write(ci_buf,ci_len);                                   \
     _s_inst->sk_write(buf,c_len);                                       \
                                                                         \
     _s_inst->sk_read(ri_buf,ri_msg.ByteSize());                         \
     rv = ri_msg.ParseFromArray(ri_buf,ri_msg.ByteSize());               \
-    assert(true == rv);                                                 \
+    if (true != rv) { std::cerr<<"\n unable to get data from Protobuff or socket, so exit the application now!"; exit(0);  }                                                 \
     buf_size = alloc_void(ri_msg.size());                               \
     _s_inst->sk_read(buf,ri_msg.size());                                \
     rv = r_msg.ParseFromArray(buf,ri_msg.size());                       \
-    assert(true == rv);
+    if (true != rv){ std::cerr<<"\n unable to get data from Protobuff or socket, so exit- the application now!!!"; exit(0); }
 #else
 // More recent protoc handles 64 bit size objects and the 32 bit version is deprecated
 #define SERIALIZE_AND_SEND_MSG(func_name)                               \

--- a/src/runtime_src/core/pcie/emulation/common_em/unix_socket.cxx
+++ b/src/runtime_src/core/pcie/emulation/common_em/unix_socket.cxx
@@ -17,7 +17,9 @@
 
 #ifndef _WINDOWS
 
+#include <fcntl.h>
 #include "unix_socket.h"
+
 
 unix_socket::unix_socket(const std::string& env, const std::string& sock_id, double timeout_insec, bool fatal_error)
 {
@@ -44,7 +46,10 @@ unix_socket::unix_socket(const std::string& env, const std::string& sock_id, dou
         name = "/tmp/" + socket;
       }
   }
+  //by default, all calls should be blocking only.
+  mNonBlocking = false;               
   start_server(timeout_insec,fatal_error);
+  
 }
 
 void unix_socket::start_server(double timeout_insec, bool fatal_error)
@@ -62,9 +67,11 @@ void unix_socket::start_server(double timeout_insec, bool fatal_error)
   //Coverity
   strncpy(server.sun_path, name.c_str(),STR_MAX_LEN);
   if (connect(sock, (struct sockaddr*)&server, sizeof(server)) >= 0){
+    // So I am a client now.
     fd = sock;
     std::cout<<"\n server socket name is\t"<<name<<"\n";
     server_started.store(true);
+    m_is_socket_live.store(true);
     return;
   }
   unlink(server.sun_path);
@@ -93,7 +100,7 @@ void unix_socket::start_server(double timeout_insec, bool fatal_error)
       unlink(name.c_str());
       return;
   }
-
+  // I am waiting for a client connection now.
   fd = accept(sock, 0, 0);
   close(sock);
   if (fd == -1){
@@ -101,56 +108,192 @@ void unix_socket::start_server(double timeout_insec, bool fatal_error)
     exit(1);
   } else {
     server_started.store(true);
+    m_is_socket_live.store(true);    // server started so socket liveness present.
   }
   return;
 }
 
+//....................................................................................................//
+//....................................READ ME..........................................................//
+//....................................................................................................//
+// The socket write/read system API's are replaced with send/recv system API
+// The benifit out it, is able to provide more flags to API's
+// to get the much needed feature. Here, non-blocking with timedout.
+//....................................................................................................//
+
+
+
+/************************************************************************
+ * sk_write - A block/non-block send call on the client file descriptor
+ *  
+ ************************************************************************/
 ssize_t unix_socket::sk_write(const void *wbuf, size_t count)
 {
-  if (not server_started) {
-    std::cout<< "\n unix_socket::sk_write failed, no socket connection established.\n";
+  if (false == server_started.load())
+  {
+    std::cerr << "\n unix_socket::sk_write failed, no socket connection established.\n";
     return -1;
   }
   ssize_t r;
   ssize_t wlen = 0;
-  auto buf = reinterpret_cast<const unsigned char*>(wbuf);
-  do {
-    if ((r = write(fd, buf + wlen, count - wlen)) < 0) {
-      if (errno == EINTR || errno == EAGAIN) {
+  auto buf = reinterpret_cast<const unsigned char *>(wbuf);
+  int flags = MSG_WAITALL;          // wait for whole message.
+  
+  // make fd as non-blocking if and only if it is asked for.
+  if (mNonBlocking)
+  {
+    struct timeval timeout;
+    timeout.tv_sec = 0;
+    timeout.tv_usec = 10000; // 10 ms
+    fd_set rfds;
+    FD_ZERO(&rfds);
+    FD_SET(fd, &rfds);
+    // Let's wait for a specific time on the file descriptor fd for a state change.
+    if (select(fd + 1, &rfds, NULL, NULL, &timeout) < 0)
+    {
+      std::cerr << "\n failed to set select timedout for sk_write \n";
+    }
+    flags = MSG_DONTWAIT;       // for non-blocking calls, DO NOT WAIT for more than timedout period.
+  }
+
+  do
+  {
+    
+    // send() system API is a non-blocking call based on flags set.
+    if ((r = send(fd, buf + wlen, count - wlen, flags)) < 0)
+    {
+      // I did not get data, alright Let me recall.
+      if (errno == EAGAIN || errno == EWOULDBLOCK)
+      {
+        std::cerr<<"\n unable to send data to peer\n";
         continue;
       }
-      if (EBADF == errno){
-        std::cout<< "\n file descriptor pointing to invalid file.\n";
-        break;
-      }
-       
+      // something fishy! so let's return.
+      if (EBADF == errno)
+        std::cerr << "\n file descriptor pointing to invalid file.\n";
+      
       return -1;
     }
     wlen += r;
-  } while (wlen < static_cast<unsigned int>(count));
+  } while ( (server_started == true) && (wlen < static_cast<unsigned int>(count)) );
   return wlen;
 }
 
+/************************************************************************
+ * sk_read - A block/non-block recv call on the client file descriptor
+ *  
+ ************************************************************************/
 ssize_t unix_socket::sk_read(void *rbuf, size_t count)
 {
-  if (not server_started) {
-    std::cout<< "\n unix_socket::sk_read failed, no socket connection established.\n";
+  if (false == server_started.load())
+  {
+    std::cerr << "\n unix_socket::sk_read failed, no socket connection established.\n";
     return -1;
   }
+
   ssize_t r;
   ssize_t rlen = 0;
-  auto buf = reinterpret_cast<unsigned char*>(rbuf);
+  auto buf = reinterpret_cast<unsigned char *>(rbuf);
+  int flags = MSG_WAITALL;          // wait for whole message.
 
-  do {
-    if ((r = read(fd, buf + rlen, count - rlen)) < 0) {
-      if (errno == EINTR || errno == EAGAIN)
-        continue;
-      return -1;
+  // make fd as non-blocking if and only if it is asked for.
+  if (mNonBlocking)
+  {
+    struct timeval timeout;
+    timeout.tv_sec = 0;
+    timeout.tv_usec = 10000;      // 10ms
+    fd_set rfds;
+    FD_ZERO(&rfds);
+    FD_SET(fd, &rfds);
+    // Let's wait for a specific time on the file descriptor fd for a state change.
+    if (select(fd + 1, &rfds, NULL, NULL, &timeout) < 0)
+    {
+      std::cerr << "\n failed to set select timedout for read socket\n";
+    }
+    flags = MSG_DONTWAIT;        // for non-blocking calls, DO NOT WAIT for more than timedout period.
+  }
+
+  do
+  {
+    // recv() system API is a non-blocking call based on flags set.
+    if ( (r = recv(fd, buf + rlen, count - rlen, flags)) < 0 )
+    {
+      // Alright! I did not get any data in the timedout period, so Let me retry again!!!
+      if (errno == EAGAIN || errno == EWOULDBLOCK)
+        continue; // OMG! data is not received, timedout? ok, Let's try
+      
+      return -1; // other failures, then let me stop calling recv.
     }
     rlen += r;
-  } while ((rlen < static_cast<unsigned int>(count)) );
+  } while ( (server_started == true) && (rlen < static_cast<unsigned int>(count)) );
 
   return rlen;
+}
+
+/************************************************************************
+ * monitor_socket - Public function available to shim layer if 
+ *                  it wants to monitor the status.
+ *                  Q2h_sock is not interested but sock is interested 
+ *                  from shim class.
+ *  
+ ************************************************************************/
+void unix_socket::monitor_socket() {
+  //Let's make non-blocking calls.
+  int status = fcntl(fd, F_SETFL, fcntl(fd, F_GETFL, 0) | O_NONBLOCK);
+
+  if (status == -1)
+    std::cerr<<"\n unable to change the socket to non-blocking call\n"; 
+
+  mNonBlocking.store(true);
+  mthread = std::thread([&]{ this->monitor_socket_thread();});
+}
+/************************************************************************
+ * monitor_socket_thread - A thread which monitors a valid client socket
+ *                          for every 500ms in its state change such as 
+ *                          for reading , HUP , ERROR.
+ * 
+ *  
+ ************************************************************************/
+
+void unix_socket::monitor_socket_thread() {
+
+  using namespace std::chrono_literals;
+
+  while( true ) {
+
+    if ( false == server_started.load() ) {
+      std::cerr<<"\n socket connect is not established/broken \n";
+      break;
+    }
+    
+    mpoll_on_filedescriptor = {fd, POLLERR, 0};                 // monitor client socket file descriptor for a state change.
+    auto retval = poll(&mpoll_on_filedescriptor, 1, 500);       // Let's do polling on it for utmost 500 ms
+    if ( retval < 0 ) {
+      std::cerr<<"\n poll is failed";
+      continue;
+    }
+    if (retval == 0)       
+      continue;                                                 // Poll is timedout so can retry this.
+    
+    // The same logic can be implemented by looking at ~POLLIN or POLLRDHUP & POLLERR & POLLHUP
+    if( mpoll_on_filedescriptor.revents & POLLHUP ) {
+      std::cerr<<"\n Client socket state has changed & it is not readable anymore! So application will exit now.";
+      m_is_socket_live.store(false);
+      server_started.store(false);                              // Let's other monitoring threads exit
+      std::this_thread::sleep_for(5s);                          // provide some time so that spawned threads will terminate themselves messagesThread.
+      break;
+    }
+
+    if ( mpoll_on_filedescriptor.revents & POLLERR ) {
+      std::cerr<< "\n Hurrah! client connection is lost ::";
+      m_is_socket_live.store(false);
+      server_started.store(false);
+      break;
+    }
+    std::this_thread::sleep_for(500ms);             // monitor fd state change for every 500ms only.
+
+  }  // end of while
+  
 }
 
 #endif

--- a/src/runtime_src/core/pcie/emulation/common_em/unix_socket.cxx
+++ b/src/runtime_src/core/pcie/emulation/common_em/unix_socket.cxx
@@ -280,7 +280,6 @@ void unix_socket::monitor_socket_thread() {
       std::cerr<<"\n Client socket state has changed & it is not readable anymore! So application will exit now.";
       m_is_socket_live.store(false);
       server_started.store(false);                              // Let's other monitoring threads exit
-      std::this_thread::sleep_for(5s);                          // provide some time so that spawned threads will terminate themselves messagesThread.
       break;
     }
 

--- a/src/runtime_src/core/pcie/emulation/common_em/unix_socket.h
+++ b/src/runtime_src/core/pcie/emulation/common_em/unix_socket.h
@@ -23,31 +23,45 @@
 #include "system_utils.h"
 #include "xclhal2.h"
 // c-style system headers
+#include <poll.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/un.h>
 // C++ headers
 #include <atomic>
 #include <boost/algorithm/string.hpp>
+#include <chrono>
 #include <iostream>
+#include <thread>
 
 class unix_socket {
   private:
-    int fd;
+    int fd;                                     // A valid file descriptor - Client or Server
     std::string name;
+    std::thread mthread;                        // Let's start socket monitor thread.
+    struct pollfd mpoll_on_filedescriptor;      // Let's perform poll on Connected Client Socket only.
 public:
-    std::atomic<bool> server_started;
+    std::atomic<bool> server_started;           // Is Server Socket/Client Socket started?
+    std::atomic<bool> m_is_socket_live;         // Is Server socket Live?
+    std::atomic<bool> mNonBlocking;             // send/recv flags to set.
     void set_name(const std::string &sock_name) { name = sock_name;}
     std::string get_name() { return name;}
     unix_socket(const std::string& env = "EMULATION_SOCKETID", const std::string& sock_id="xcl_sock",double timeout_insec=300,bool fatal_error=true);
     ~unix_socket()
     {
-       server_started = false;
-       close(fd);
+      server_started = false;
+      // Let's join the thread if spawned already.
+      if ( mthread.joinable() )
+        mthread.join();
+
+      close(fd);
     }
     void start_server(double timeout_insec,bool fatal_error);
     ssize_t sk_write(const void *wbuf, size_t count);
     ssize_t sk_read(void *rbuf, size_t count);
+    void monitor_socket();                    //API to shim layer that can requested to monitor the client socket fd.
+    void monitor_socket_thread();             // A Thread where actual monitoring performed.
+
 };
 
 

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
@@ -1680,7 +1680,7 @@ uint32_t HwEmShim::getAddressSpace (uint32_t topology)
       return;
     }
     // All RPC calls fail if no socket is live.
-    if (sock->m_is_socket_live != false) {
+    if ( !sock->m_is_socket_live ) {
       resetProgram(false);      
     }
     

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
@@ -206,8 +206,12 @@ namespace xclhwemhal2 {
             if(std::find(parsedMsgs.begin(), parsedMsgs.end(), line) == parsedMsgs.end()) {
               logMessage(line);
               parsedMsgs.push_back(line);
-              if (!matchString.compare("Exiting xsim") || !matchString.compare("FATAL_ERROR"))
-                 std::cout << "SIMULATION EXITED" << std::endl;
+              if (!matchString.compare("Exiting xsim") || !matchString.compare("FATAL_ERROR")) {
+                  std::cout << "SIMULATION EXITED" << std::endl;
+                  this->xclClose();                                               // Let's have a proper clean if xsim is NOT running
+                  exit(0);                                                        // It's a clean exit only.
+              }
+                
             }
           }
         }
@@ -988,6 +992,7 @@ namespace xclhwemhal2 {
 
     sock = std::make_shared<unix_socket>();
     set_simulator_started(true);
+    sock->monitor_socket();
     //Thread to fetch messages from Device to display on host
     if (mMessengerThreadStarted == false) {
       std::cout<<"\n messages Thread is created\n";
@@ -1674,9 +1679,11 @@ uint32_t HwEmShim::getAddressSpace (uint32_t topology)
       }
       return;
     }
-
-    resetProgram(false);
-
+    // All RPC calls fail if no socket is live.
+    if (sock->m_is_socket_live != false) {
+      resetProgram(false);      
+    }
+    
     int status = 0;
     xclemulation::debug_mode lWaveform = xclemulation::config::getInstance()->getLaunchWaveform();
     if(( lWaveform == xclemulation::debug_mode::gui || lWaveform == xclemulation::debug_mode::batch || lWaveform == xclemulation::debug_mode::off)
@@ -1803,8 +1810,9 @@ uint32_t HwEmShim::getAddressSpace (uint32_t topology)
     xclGetDebugMessages(true);
     try {
       std::lock_guard<std::mutex> guard(mPrintMessagesLock);
-      fetchAndPrintMessages();
       simulator_started = false;
+      fetchAndPrintMessages();
+      
     }
     catch (std::exception& ex) {
       if (mLogStream.is_open())


### PR DESCRIPTION
Fix : Currently XRT is hanging once simulator is connected and exits after time. So XRT should be notified if socket is no more active. But XRT cannot except a graceful exit from simulator so a polling mechanism is introduced to track the state change of client socket periodically.

Risk: very Low.
Tests: Canary run. Results are clean.
Reviewer: venkatp