### PR TITLE
Add XCLBIN parser of AIE_PARTITION with CDO groups

### DIFF
--- a/src/runtime_src/core/common/xclbin_parser.cpp
+++ b/src/runtime_src/core/common/xclbin_parser.cpp
@@ -853,7 +853,7 @@ get_aie_partition(const axlf* top)
     aie_pdi_obj pdiobj;
     auto aiepdip = reinterpret_cast<const aie_pdi*>(topbase + aiep->aie_pdi.offset + i * sizeof(aie_pdi));
 
-    uuid_copy(pdiobj.uuid, aiepdip->uuid);
+    pdiobj.uuid = aiepdip->uuid;
     pdiobj.pdi.resize(aiepdip->pdi_image.size);
     memcpy(pdiobj.pdi.data(), topbase + aiepdip->pdi_image.offset, pdiobj.pdi.size());
     for (uint32_t j = 0; j < aiepdip->cdo_groups.size; j++) {

--- a/src/runtime_src/core/common/xclbin_parser.h
+++ b/src/runtime_src/core/common/xclbin_parser.h
@@ -19,6 +19,7 @@
 #include "config.h"
 #include "cuidx_type.h"
 #include "core/include/xclbin.h"
+#include "core/include/xrt/xrt_uuid.h"
 
 #include <array>
 #include <limits>
@@ -116,7 +117,7 @@ struct aie_cdo_group_obj
 // @pdi: PDI blob
 struct aie_pdi_obj
 {
-  xuid_t uuid;
+  xrt::uuid uuid;
   std::vector<aie_cdo_group_obj> cdo_groups;
   std::vector<uint8_t> pdi;
 };

--- a/src/runtime_src/core/common/xclbin_parser.h
+++ b/src/runtime_src/core/common/xclbin_parser.h
@@ -95,16 +95,44 @@ struct softkernel_object
   char *sk_buf;
 };
 
+// struct aie_cdo_obj - wrapper for an AIE CDO group object
+//
+// @cdo_name: CDO group name
+// @cdo_type: CDO group type
+// @pdi_id: ID of this CDO group in PDI
+// @kernel_id: Kernel ID associated with this CDO group
+struct aie_cdo_group_obj
+{
+  std::string cdo_name;
+  uint8_t cdo_type;
+  uint64_t pdi_id;
+  uint64_t kernel_id;
+};
+
+// struct aie_pdi_obj - wrapper for an AIE PDI object
+//
+// @uuid: PDI UUID
+// @cdo_groups: Array of CDO groups
+// @pdi: PDI blob
+struct aie_pdi_obj
+{
+  xuid_t uuid;
+  std::vector<aie_cdo_group_obj> cdo_groups;
+  std::vector<uint8_t> pdi;
+};
+
 // struct aie_partition_obj - wrapper for an AIE Partition object
 //
 // @ncol: number of columns in this partition
 // @start_col_list: Array of start column for partition relocation
 // @name: partition name
+// @pdis: PDIs (blob and metadata) associated with this partition
 struct aie_partition_obj
 {
   uint16_t ncol;
   std::vector<uint16_t> start_col_list;
   std::string name;
+  std::vector<aie_pdi_obj> pdis;
 };
 
 /**


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Extend AIE_PARTITION parser after https://github.com/Xilinx/XRT/pull/6765

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Extend aie_partition_obj to include PDI blobs and CDO groups' metadata

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Tested on hw_emu with a new XCLBIN that AIE Partition metadata along with PDIs and CDO groups' metadata can be correctly retrieved.

#### Documentation impact (if any)
