### PR TITLE
Add handling for new HSDP Trace IP

### DIFF
--- a/src/runtime_src/core/include/xclbin.h
+++ b/src/runtime_src/core/include/xclbin.h
@@ -375,6 +375,7 @@ extern "C" {
         TRACE_S2MM_FULL,
         AXI_NOC,
         ACCEL_DEADLOCK_DETECTOR,
+        HSDP_TRACE,
         DEBUG_IP_TYPE_MAX
     };
 

--- a/src/runtime_src/tools/xclbinutil/SectionDebugIPLayout.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionDebugIPLayout.cxx
@@ -76,6 +76,8 @@ SectionDebugIPLayout::getDebugIPTypeStr(DEBUG_IP_TYPE _debugIpType) const
       return "AXI_NOC";
     case ACCEL_DEADLOCK_DETECTOR:
       return "ACCEL_DEADLOCK_DETECTOR";
+    case HSDP_TRACE:
+      return "HSDP_TRACE";
     case DEBUG_IP_TYPE_MAX:
       return "DEBUG_IP_TYPE_MAX";
   }
@@ -127,6 +129,9 @@ SectionDebugIPLayout::getDebugIPType(std::string& _sDebugIPType) const
 
   if (_sDebugIPType == "ACCEL_DEADLOCK_DETECTOR")
     return ACCEL_DEADLOCK_DETECTOR;
+
+  if (_sDebugIPType == "HSDP_TRACE")
+    return HSDP_TRACE;
 
   if (_sDebugIPType == "UNDEFINED")
     return UNDEFINED;

--- a/src/runtime_src/xdp/profile/device/device_intf.cpp
+++ b/src/runtime_src/xdp/profile/device/device_intf.cpp
@@ -549,6 +549,7 @@ DeviceIntf::~DeviceIntf()
               mDeadlockDetector = new DeadlockDetector(mDevice, i, &(map->m_debug_ip_data[i]));
               break;
             case AXI_STREAM_PROTOCOL_CHECKER :
+            case HSDP_TRACE :
             default : 
               break;
           }


### PR DESCRIPTION
HSDP Trace IP is a new IP to offload AIE ( and later PL) trace via High Speed Debug Port on Versal devices. An entry for this IP will be added to debug_ip_layout section. This PR adds the new IP type to implement successful recognition of the IP at runtime and show in xbutil debug-ip-status report.
