### PR TITLE
fixing sysroot generation failure for vck5000

### DIFF
--- a/build/build_edge.sh
+++ b/build/build_edge.sh
@@ -105,6 +105,7 @@ config_versal_project()
     sed -i 's/^CONFIG_imagefeature-debug-tweaks.*//g' $VERSAL_PROJECT_DIR/project-spec/configs/rootfs_config
     sed -i 's/^CONFIG_gdb.*//g' $VERSAL_PROJECT_DIR/project-spec/configs/rootfs_config
     sed -i 's/^CONFIG_valgrind.*//g' $VERSAL_PROJECT_DIR/project-spec/configs/rootfs_config
+    sed -i 's/^CONFIG_packagegroup-core-ssh-dropbear.*//g' $VERSAL_PROJECT_DIR/project-spec/configs/rootfs_config
 
 
 
@@ -356,6 +357,7 @@ if [[ $full == 1 ]]; then
   $PETA_BIN/petalinux-build
   if [[ $gen_sysroot == 1 ]]; then
         $PETA_BIN/petalinux-build --sdk
+        echo "Run $ORIGINAL_DIR/$PETALINUX_NAME/images/linux/sdk.sh to generate the syroot"
   fi
 else
 #Run just xrt build if -full option is not provided


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
sysroot generation was failing in vck5000

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
NA

#### How problem was solved, alternative solutions (if any) and why they were rejected
We should either enable openssh or dropbear. Sysroot generation fails if we enable both openssh and dropbear.

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Generated sysroot and verified

#### Documentation impact (if any)
NA