### PR TITLE
CR-1130285 PIPELINE faile about XGQ  command version 0.1

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_ctrl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_ctrl.c
@@ -781,7 +781,7 @@ static int ert_ctrl_xgq_ip_init(struct platform_device *pdev)
 	EC_INFO(ec, "Ring buffer %pR", res);
 
 	ec->ec_cq_range = res->end - res->start + 1;
-	ec->ec_cq_base = devm_ioremap_wc(&pdev->dev, res->start, ec->ec_cq_range);
+	ec->ec_cq_base = devm_ioremap(&pdev->dev, res->start, ec->ec_cq_range);
 	if (!ec->ec_cq_base) {
 		EC_ERR(ec, "failed to map %s", RESNAME_XGQ_USER_RING);
 		return -ENOMEM;
@@ -834,7 +834,7 @@ static int ert_ctrl_cq_init(struct platform_device *pdev)
 	EC_INFO(ec, "CQ %pR", res);
 
 	ec->ec_cq_range = res->end - res->start + 1;
-	ec->ec_cq_base = devm_ioremap_wc(&pdev->dev, res->start, ec->ec_cq_range);
+	ec->ec_cq_base = devm_ioremap(&pdev->dev, res->start, ec->ec_cq_range);
 	if (!ec->ec_cq_base) {
 		EC_ERR(ec, "failed to map CQ");
 		return -ENOMEM;

--- a/src/runtime_src/ert/scheduler/sched_cmd.h
+++ b/src/runtime_src/ert/scheduler/sched_cmd.h
@@ -19,7 +19,7 @@
 #include "xgq_impl.h"
 #include "xgq_cmd_ert.h"
 
-#define XGQ_CMD_DEBUG
+//#define XGQ_CMD_DEBUG
 
 /* One CU command. */
 struct sched_cmd {

--- a/src/runtime_src/ert/scheduler/xgq_ctrl.c
+++ b/src/runtime_src/ert/scheduler/xgq_ctrl.c
@@ -44,15 +44,6 @@ inline void xgq_ctrl_response(struct xgq_ctrl *xgq_ctrl, void *resp, uint32_t si
 	while (xgq_produce(xgq_ctrl->xgq, &slot_addr))
 		continue;
 
-    /* TODO: for debug */
-    {
-        uint32_t off = slot_addr & 0x00000FFF;
-        uint32_t cq_base = slot_addr & 0xFFFFF000;
-        if ((off != 0x430) && (off != 0x440)) {
-            xgq_reg_write32(0, cq_base + 0x600, off);
-        }
-    }
-    /* debug end */
 	for (; offset < size; offset+=4) {
 		xgq_reg_write32(0, slot_addr+offset, *(uint32_t *)(resp+offset));
 	}
@@ -72,15 +63,6 @@ struct sched_cmd *xgq_ctrl_get_cmd(struct xgq_ctrl *xgq_ctrl)
 		if (!ret) {
 			cmd_set_addr(cmd, addr);
 			cmd_load_header(cmd);
-            /* TODO: for debug */
-            {
-                uint32_t off = addr & 0x00000FFF;
-                uint32_t cq_base = addr & 0xFFFFF000;
-                if ((off != 0x30) && (off != 0x230)) {
-                    xgq_reg_write32(0, cq_base + 0x604, off);
-                }
-            }
-            /* debug end */
 		}
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
1. remove debug code and disable cid in ERT fw
2. don't use write combine mapping

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1130285

#### How problem was solved, alternative solutions (if any) and why they were rejected
So far, this is only reproducible in PIPELINE. But we don't see it happen recently.
We suspect this is related to write combine mapping of CQ. Let's see if that error still happen.

#### Risks (if any) associated the changes in the commit
No

#### What has been tested and how, request additional testing if necessary
u50 validate test. After disable write combine, the iops test result is the same.

#### Documentation impact (if any)
No