### PR TITLE
Add patch version to apu package version

### DIFF
--- a/src/runtime_src/tools/scripts/pkgapu.sh
+++ b/src/runtime_src/tools/scripts/pkgapu.sh
@@ -169,7 +169,13 @@ PKG_VER=`cat $IMAGES_DIR/rootfs.manifest | grep "^xrt " | sed s/.*\ //`
 if [[ "X$PKG_VER" == "X" ]]; then
 	error "Can not get package version"
 fi
-echo VERSION "$PKG_VER"
+
+# Add patch number in version if 'APU_VERSION_PATCH' env variable is defined
+if [[ ! -z $APU_VERSION_PATCH ]]; then
+	PKG_VER=${PKG_VER%.*}.$APU_VERSION_PATCH
+fi
+
+echo APU Package version : "$PKG_VER"
 
 if [ -d $BUILD_DIR ]; then
 	rm -rf $BUILD_DIR

--- a/src/runtime_src/tools/scripts/pkgapu.sh
+++ b/src/runtime_src/tools/scripts/pkgapu.sh
@@ -165,17 +165,21 @@ if [[ ! (`which mkimage` && `which bootgen` && `which xclbinutil`) ]]; then
 	error "Please source Xilinx VITIS and Petalinux tools to make sure mkimage, bootgen and xclbinutil is accessible."
 fi
 
-PKG_VER=`cat $IMAGES_DIR/rootfs.manifest | grep "^xrt " | sed s/.*\ //`
-if [[ "X$PKG_VER" == "X" ]]; then
+PKG_VER_WITH_RELEASE=`cat $IMAGES_DIR/rootfs.manifest | grep "^xrt " | sed s/.*\ //`
+if [[ "X$PKG_VER_WITH_RELEASE" == "X" ]]; then
 	error "Can not get package version"
 fi
 
-# Add patch number in version if 'APU_VERSION_PATCH' env variable is defined
-if [[ ! -z $APU_VERSION_PATCH ]]; then
-	PKG_VER=${PKG_VER%.*}.$APU_VERSION_PATCH
+PKG_VER=${PKG_VER_WITH_RELEASE#*.}
+PKG_RELEASE=${PKG_VER_WITH_RELEASE%%.*}
+
+# Add patch number in version if 'XRT_VERSION_PATCH' env variable is defined
+if [[ ! -z $XRT_VERSION_PATCH ]]; then
+	PKG_VER=${PKG_VER%.*}.$XRT_VERSION_PATCH
 fi
 
 echo APU Package version : "$PKG_VER"
+echo APU Package release : "$PKG_RELEASE"
 
 if [ -d $BUILD_DIR ]; then
 	rm -rf $BUILD_DIR
@@ -293,6 +297,6 @@ fi
 dodeb $INSTALL_ROOT
 dorpm $INSTALL_ROOT
 
-cp $BUILD_DIR/*.rpm $OUTPUT_DIR
-cp $BUILD_DIR/*.deb $OUTPUT_DIR
+cp -v $BUILD_DIR/${PKG_NAME}*.rpm $OUTPUT_DIR/${PKG_NAME}_${PKG_RELEASE}.${PKG_VER}.noarch.rpm
+cp -v $BUILD_DIR/${PKG_NAME}*.deb $OUTPUT_DIR/${PKG_NAME}_${PKG_RELEASE}.${PKG_VER}_all.deb
 rm -rf $BUILD_DIR


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Added a way to provide patch version to apu package, this number can be incremented daily just like XRT builds
Eg: dpkg --info /scratch/tmp/**xrt-apu_202210.2.13.513_all.deb** 
 new debian package, version 2.0.
 size 149069688 bytes: control archive=256 bytes.
     141 bytes,     7 lines      control              
 
 Package: xrt-apu
 Architecture: all
 **Version: 202210.2.13.513**
 Priority: optional
 Description: Xilinx Versal firmware
 Maintainer: Xilinx Inc.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
pkgapu script checks for XRT_PATCH_VERSION env variable and if it is set, patch number will be added to apu package version, else it will be 0

#### Risks (if any) associated the changes in the commit
none

#### What has been tested and how, request additional testing if necessary
created apu package by setting env variable and the same is reflected in apu package version

#### Documentation impact (if any)
NA