### PR TITLE
CR-1132228 Please update VCK5000 APU Application to support switch to General Command Queue (GCQ) IP

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/zocl_xgq.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_xgq.c
@@ -31,9 +31,9 @@
 #define ZXGQ_IS_INTR_ENABLED(zxgq)	((zxgq)->zx_intc_pdev != NULL)
 #define	ZXGQ_THREAD_TIMER		(HZ / 20) /* in jiffies */
 
-#define ZXGQ_IP_SQ_PROD			0x0
-#define ZXGQ_IP_CQ_PROD			0x100
-#define ZXGQ_IP_CQ_CONF			0x10C
+#define ZXGQ_IP_SQ_PROD			0x100
+#define ZXGQ_IP_CQ_PROD			0x0
+#define ZXGQ_IP_CQ_CONF			0xC
 #define ZXGQ_IP_RESET			(0x1 << 31)
 
 struct zocl_xgq {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
VCK5000 QDMA shell switch to GCQ implementation. Register offset changed.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Not bug

#### How problem was solved, alternative solutions (if any) and why they were rejected
Change offset

#### Risks (if any) associated the changes in the commit
This is not a compatible change. Since this change, old XGQ IP implementation is not supported.
Impact:
VCK5000 xdma shell will not work.

#### What has been tested and how, request additional testing if necessary
vck5000 qdma base-2 shell

#### Documentation impact (if any)
No