### PR TITLE
VITIS-5892 hwmon_sdm: Add support for Single SDR data API request using sensor ID

### DIFF
--- a/src/runtime_src/core/include/xgq_cmd_vmr.h
+++ b/src/runtime_src/core/include/xgq_cmd_vmr.h
@@ -50,10 +50,10 @@
  * sensor data request types
  */
 enum xgq_cmd_sensor_application_id {
-	XGQ_CMD_SENSOR_AID_GET_SIZE			= 0x1,
-	XGQ_CMD_SENSOR_AID_GET_SDR			= 0x2,
-	XGQ_CMD_SENSOR_AID_GET_SINGLE_SENSOR_DATA	= 0x3,
-	XGQ_CMD_SENSOR_AID_GET_ALL_SENSOR_DATA		= 0x4,
+	XGQ_CMD_SENSOR_AID_GET_SIZE		= 0x1,
+	XGQ_CMD_SENSOR_AID_GET_SDR		= 0x2,
+	XGQ_CMD_SENSOR_AID_GET_SINGLE_SDR	= 0x3,
+	XGQ_CMD_SENSOR_AID_GET_ALL_SDR		= 0x4,
 };
 
 /**
@@ -128,8 +128,14 @@ struct xgq_cmd_log_payload {
  * @address:	pre-allocated sensor data, device writes sensor data at this address
  * @size:	size of pre-allocated sensor data
  * @offset:	offset of returned device data
- * @pid:	sensor request id
- * @addr_type:	pre-allocated address type
+ * @aid: Sensor API ID which decides API in VMC.
+ *          0x1 - GET_SDR_SIZE
+ *          0x2 - GET_SDR
+ *          0x3 - GET_SINGLE_SENSOR_DATA
+ *          0x4 - GET_ALL_SENSOR_DATA
+ * @sid: sensor request id, it is same as repo_id
+ * @addr_type: pre-allocated address type
+ * @sensor_id: sensor id values used to get single instantaneous sensor data
  *
  * This payload is used for sensor data report.
  */
@@ -140,7 +146,8 @@ struct xgq_cmd_sensor_payload {
 	uint32_t aid:8;
 	uint32_t sid:8;
 	uint32_t addr_type:3;
-	uint32_t rsvd1:13;
+	uint32_t sensor_id:8;
+	uint32_t rsvd1:5;
 	uint32_t pad;
 };
 

--- a/src/runtime_src/core/include/xgq_resp_parser.h
+++ b/src/runtime_src/core/include/xgq_resp_parser.h
@@ -61,6 +61,8 @@
 #define THRESHOLD_SENSOR_AVG_MASK		(0x1 << 6)
 #define THRESHOLD_SENSOR_MAX_MASK		(0x1 << 7)
 
+#define SENSOR_IDS_MAX				256
+
 enum xgq_sdr_repo_type {
     SDR_TYPE_GET_SIZE     = 0x00,
     SDR_TYPE_BDINFO       = 0xC0,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
@@ -725,10 +725,12 @@ static void xclmgmt_subdev_get_data(struct xclmgmt_dev *lro, size_t offset,
 	lro->userpf_blob_updated = false;
 }
 
-static int xclmgmt_read_subdev_req(struct xclmgmt_dev *lro, char *data_ptr, void **resp, size_t *sz)
+static int xclmgmt_read_subdev_req(struct xclmgmt_dev *lro, void *data_ptr, void **resp, size_t *sz)
 {
 	size_t resp_sz = 0, current_sz = 0, entry_sz = 0, entries = 0;
-	struct xcl_mailbox_subdev_peer *subdev_req = (struct xcl_mailbox_subdev_peer *)data_ptr;
+	struct xcl_mailbox_req *req = (struct xcl_mailbox_req *)data_ptr;
+	struct xcl_mailbox_subdev_peer *subdev_req =
+			(struct xcl_mailbox_subdev_peer *)req->data;
 	int ret = 0;
 
 	BUG_ON(!lro);
@@ -782,27 +784,27 @@ static int xclmgmt_read_subdev_req(struct xclmgmt_dev *lro, char *data_ptr, void
 	case XCL_SDR_BDINFO:
 		current_sz = SIZE_4KB;
 		*resp = vzalloc(current_sz);
-		ret = xocl_hwmon_sdm_get_sensors(lro, *resp, XCL_SDR_BDINFO);
+		ret = xocl_hwmon_sdm_get_sensors(lro, *resp, XCL_SDR_BDINFO, req->flags);
 		break;
 	case XCL_SDR_TEMP:
 		current_sz = SIZE_4KB;
 		*resp = vzalloc(current_sz);
-		ret = xocl_hwmon_sdm_get_sensors(lro, *resp, XCL_SDR_TEMP);
+		ret = xocl_hwmon_sdm_get_sensors(lro, *resp, XCL_SDR_TEMP, req->flags);
 		break;
 	case XCL_SDR_VOLTAGE:
 		current_sz = SIZE_4KB;
 		*resp = vzalloc(current_sz);
-		ret = xocl_hwmon_sdm_get_sensors(lro, *resp, XCL_SDR_VOLTAGE);
+		ret = xocl_hwmon_sdm_get_sensors(lro, *resp, XCL_SDR_VOLTAGE, req->flags);
 		break;
 	case XCL_SDR_CURRENT:
 		current_sz = SIZE_4KB;
 		*resp = vzalloc(current_sz);
-		ret = xocl_hwmon_sdm_get_sensors(lro, *resp, XCL_SDR_CURRENT);
+		ret = xocl_hwmon_sdm_get_sensors(lro, *resp, XCL_SDR_CURRENT, req->flags);
 		break;
 	case XCL_SDR_POWER:
 		current_sz = SIZE_4KB;
 		*resp = vzalloc(current_sz);
-		ret = xocl_hwmon_sdm_get_sensors(lro, *resp, XCL_SDR_POWER);
+		ret = xocl_hwmon_sdm_get_sensors(lro, *resp, XCL_SDR_POWER, req->flags);
 		break;
 	default:
 		break;
@@ -999,7 +1001,7 @@ void xclmgmt_mailbox_srv(void *arg, void *data, size_t len,
 			break;
 		}
 
-		ret = xclmgmt_read_subdev_req(lro, (char *)req->data, &resp, &sz);
+		ret = xclmgmt_read_subdev_req(lro, data, &resp, &sz);
 		if (ret) {
 			/* if can't get data, return 0 as response */
 			ret = 0;
@@ -1102,7 +1104,7 @@ void xclmgmt_mailbox_srv(void *arg, void *data, size_t len,
 			break;
 		}
 
-		ret = xclmgmt_read_subdev_req(lro, (char *)req->data, &resp, &sz);
+		ret = xclmgmt_read_subdev_req(lro, data, &resp, &sz);
 		if (ret) {
 			/* if can't get data, return 0 as response */
 			ret = 0;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/hwmon_sdm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/hwmon_sdm.c
@@ -82,11 +82,13 @@ struct xocl_hwmon_sdm {
 	/* Keep sensor data for maitaining hwmon sysfs nodes */
 	char                    *sensor_data[SDR_TYPE_MAX];
 	bool                    sensor_data_avail[SDR_TYPE_MAX];
+	uint16_t                sensor_ids[SDR_TYPE_MAX][SENSOR_IDS_MAX];
+	uint16_t                sensor_ids_max[SDR_TYPE_MAX];
 	struct xocl_sdr_bdinfo	bdinfo;
 
 	struct mutex            sdm_lock;
 	u64                     cache_expire_secs;
-	ktime_t                 cache_expires[SDR_TYPE_MAX];
+	ktime_t                 cache_expires[SDR_TYPE_MAX][SENSOR_IDS_MAX];
 };
 
 #define SDM_BUF_IDX_INCR(buf_index, len, buf_len) \
@@ -99,11 +101,13 @@ static int parse_sdr_info(char *in_buf, struct xocl_hwmon_sdm *sdm,
 static void hwmon_sdm_get_sensors_list(struct platform_device *pdev,
                                        bool create_sysfs);
 static int hwmon_sdm_update_sensors(struct platform_device *pdev,
-                                    uint8_t repo_id);
+                                    uint8_t repo_id, uint64_t data_args);
 static int hwmon_sdm_update_sensors_by_type(struct platform_device *pdev,
                                             enum xgq_sdr_repo_type repo_type,
-                                            bool create_sysfs);
+                                            bool create_sysfs, uint64_t data_args);
 static void destroy_hwmon_sysfs(struct platform_device *pdev);
+static int parse_single_sdr_info(struct xocl_hwmon_sdm *sdm, char *in_buf,
+                                 uint8_t repo_id, uint64_t data_args);
 
 static int to_sensor_repo_type(int repo_id)
 {
@@ -195,9 +199,10 @@ static int get_sdr_type(enum xcl_group_kind kind)
 	return type;
 }
 
-static void update_cache_expiry_time(struct xocl_hwmon_sdm *sdm, uint8_t repo_id)
+static void update_cache_expiry_time(struct xocl_hwmon_sdm *sdm, uint8_t repo_id,
+                                     uint8_t sensor_id)
 {
-	sdm->cache_expires[repo_id] = ktime_add(ktime_get_boottime(),
+	sdm->cache_expires[repo_id][sensor_id] = ktime_add(ktime_get_boottime(),
                                       ktime_set(sdm->cache_expire_secs, 0));
 }
 
@@ -206,7 +211,8 @@ static void update_cache_expiry_time(struct xocl_hwmon_sdm *sdm, uint8_t repo_id
  * This API prepares mailbox request with sensor repo type and send to mailbox
  * It receives the response and store it to sensor_data
  */
-static int hwmon_sdm_read_from_peer(struct platform_device *pdev, int repo_type)
+static int hwmon_sdm_read_from_peer(struct platform_device *pdev, int repo_type,
+                                    int32_t kind, uint64_t data_args)
 {
 	struct xocl_hwmon_sdm *sdm = platform_get_drvdata(pdev);
 	size_t data_len = sizeof(struct xcl_mailbox_subdev_peer);
@@ -216,14 +222,8 @@ static int hwmon_sdm_read_from_peer(struct platform_device *pdev, int repo_type)
 	struct xcl_mailbox_req *mb_req = NULL;
 	size_t resp_len = RESP_LEN;
 	char *in_buf = NULL;
-	int repo_id, kind;
+	int repo_id;
 	int ret = 0;
-
-	kind = to_xcl_sdr_type(repo_type);
-	if (kind < 0) {
-		xocl_err(&pdev->dev, "received invalid xcl grp type: %d", kind);
-		return -EINVAL;
-	}
 
 	mb_req = vmalloc(reqlen);
 	if (!mb_req)
@@ -234,6 +234,8 @@ static int hwmon_sdm_read_from_peer(struct platform_device *pdev, int repo_type)
 		goto done;
 
 	mb_req->req = XCL_MAILBOX_REQ_SDR_DATA;
+	mb_req->flags = data_args;
+
 	subdev_peer.size = resp_len;
 	subdev_peer.kind = kind;
 	subdev_peer.entries = 1;
@@ -254,21 +256,23 @@ done:
 }
 
 /*
- * get_sensors_data(): Used to check the cache timer and updates the sensor data
+ * get_sensors_data_by_sensor_id(): Used to check the cache timer and updates the sensor data
  */
-static int get_sensors_data(struct platform_device *pdev, uint8_t repo_id)
+static int get_sensors_data_by_sensor_id(struct platform_device *pdev,
+                                         uint8_t repo_id, uint64_t data_args)
 {
 	struct xocl_hwmon_sdm *sdm = platform_get_drvdata(pdev);
+	uint8_t sensor_id = data_args & 0xFF;
 	ktime_t now = ktime_get_boottime();
 
-	if (ktime_compare(now, sdm->cache_expires[repo_id]) > 0)
-		return hwmon_sdm_update_sensors(pdev, repo_id);
+	if (ktime_compare(now, sdm->cache_expires[repo_id][sensor_id]) > 0)
+		return hwmon_sdm_update_sensors(pdev, repo_id, data_args);
 
 	return 0;
 }
 
 static ssize_t show_hwmon_name(struct device *dev, struct device_attribute *da,
-	char *buf)
+                               char *buf)
 {
 	struct FeatureRomHeader rom = { {0} };
 	struct xocl_hwmon_sdm *sdm = dev_get_drvdata(dev);
@@ -286,6 +290,28 @@ static ssize_t show_hwmon_name(struct device *dev, struct device_attribute *da,
 }
 static struct sensor_device_attribute name_attr =
 	SENSOR_ATTR(name, 0444, show_hwmon_name, NULL, 0);
+
+static int16_t get_sensor_index(uint16_t sid[], uint32_t sid_len, uint32_t buf_index)
+{
+	int16_t sensor_index;
+	int id;
+
+	//Handle corner cases
+	if (buf_index <= sid[0])
+		return -EINVAL;
+
+	if (buf_index >= sid[sid_len - 1])
+		return sid[sid_len - 1];
+
+	for (id = 0; id < sid_len; id++)
+	{
+		if (buf_index <= sid[id])
+			break;
+		sensor_index = sid[id];
+	}
+
+	return sensor_index;
+}
 
 /*
  * hwmon_sensor_show(): This API is called when hwmon sysfs node is read
@@ -307,6 +333,10 @@ static ssize_t hwmon_sensor_show(struct device *dev,
 	char output[64];
 	uint32_t uval = 0;
 	ssize_t sz = 0;
+	uint32_t sid_len = sdm->sensor_ids_max[repo_id];
+	uint8_t target_sensor_id = 0;
+	int16_t sensor_index = 0;
+	uint64_t data_args = ((u64)buf_index << 16) | (field_id << 8);
 
 	if (repo_id >= SDR_TYPE_MAX) {
 		xocl_dbg(&sdm->pdev->dev, "repo_id: 0x%x is corrupted or not supported\n", repo_id);
@@ -322,8 +352,18 @@ static ssize_t hwmon_sensor_show(struct device *dev,
 	if ((field_id == SYSFS_SDR_INS_VAL) ||
 	    (field_id == SYSFS_SDR_MAX_VAL) ||
 	    (field_id == SYSFS_SDR_AVG_VAL) ||
-	    (field_id == SYSFS_SDR_STATUS_VAL))
-		get_sensors_data(sdm->pdev, repo_id);
+	    (field_id == SYSFS_SDR_STATUS_VAL)) {
+		sensor_index = get_sensor_index(sdm->sensor_ids[repo_id], sid_len, buf_index);
+		if (sensor_index < 0) {
+			xocl_dbg(&sdm->pdev->dev, "Invalid request with buf_index: %d is received for repo_id: 0x%x\n",
+buf_index, repo_id);
+			sz = sprintf(buf, "%d\n", 0);
+			goto done;
+		}
+		target_sensor_id = sdm->sensor_data[repo_id][sensor_index];
+		data_args |= target_sensor_id;
+		get_sensors_data_by_sensor_id(sdm->pdev, repo_id, data_args);
+	}
 
 	if ((sdm->sensor_data[repo_id] == NULL) || (!sdm->sensor_data_avail[repo_id])) {
 		xocl_dbg(&sdm->pdev->dev, "sensor_data is empty for repo_id: 0x%x\n", repo_id);
@@ -483,6 +523,66 @@ static void hwmon_sdm_load_bdinfo(struct xocl_hwmon_sdm *sdm, uint8_t repo_id,
 		memcpy(&sdm->bdinfo.oem_id, &sdm->sensor_data[repo_id][ins_index], val_len);
 }
 
+static void dump_error_message(struct xocl_hwmon_sdm *sdm, uint8_t completion_code)
+{
+	if(completion_code == SDR_CODE_NOT_AVAILABLE)
+		xocl_err(&sdm->pdev->dev, "Error: SDR Code Not Available");
+	else if(completion_code == SDR_CODE_OP_FAILED)
+		xocl_err(&sdm->pdev->dev, "Error: SDR Code Operation Failed");
+	else if(completion_code == SDR_CODE_FLOW_CONTROL_READ_STALE)
+		xocl_err(&sdm->pdev->dev, "Error: SDR Code Flow Control Read Stale");
+	else if(completion_code == SDR_CODE_FLOW_CONTROL_WRITE_ERROR)
+		xocl_err(&sdm->pdev->dev, "Error: SDR Code Flow Control Write Error");
+	else if(completion_code == SDR_CODE_INVALID_SENSOR_ID)
+		xocl_err(&sdm->pdev->dev, "Error: SDR Code Invalid Sensor ID");
+	else
+		xocl_err(&sdm->pdev->dev, "Failed in sending SDR Repository command, completion_code: 0x%x", completion_code);
+}
+
+static int parse_single_sdr_info(struct xocl_hwmon_sdm *sdm, char *in_buf,
+                                 uint8_t repo_id, uint64_t data_args)
+{
+	uint8_t sensor_id = data_args & 0xFF;
+	uint32_t sdr_index = (data_args >> 16) & 0xFFF;
+	uint8_t field_id = (data_args >> 8) & 0xF;
+	uint8_t completion_code, repo_type, val_len;
+	int buf_index;
+
+	completion_code = in_buf[SDR_COMPLETE_IDX];
+	if(completion_code != SDR_CODE_OP_SUCCESS) {
+		dump_error_message(sdm, completion_code);
+		return -EINVAL;
+	}
+
+	repo_type = in_buf[SDR_REPO_IDX];
+	repo_id = sdr_get_id(repo_type);
+	if (repo_id < 0) {
+		xocl_err(&sdm->pdev->dev, "SDR Responce has INVALID REPO TYPE: %d", repo_type);
+		return -EINVAL;
+	}
+
+	buf_index = SDR_REPO_IDX + 1;
+	val_len = in_buf[buf_index];
+
+	buf_index = buf_index + 1;
+	if (field_id == SYSFS_SDR_INS_VAL)
+		memcpy(&sdm->sensor_data[repo_id][sdr_index], &in_buf[buf_index], val_len);
+
+	buf_index = buf_index + val_len;
+	if (field_id == SYSFS_SDR_AVG_VAL)
+		memcpy(&sdm->sensor_data[repo_id][sdr_index], &in_buf[buf_index], val_len);
+
+	buf_index = buf_index + val_len;
+	if (field_id == SYSFS_SDR_MAX_VAL)
+		memcpy(&sdm->sensor_data[repo_id][sdr_index], &in_buf[buf_index], val_len);
+
+	buf_index = buf_index + val_len;
+	if (field_id == SYSFS_SDR_STATUS_VAL)
+		sdm->sensor_data[repo_id][sdr_index] = in_buf[buf_index];
+
+	return 0;
+}
+
 /*
  * parse_sdr_info(): Parse the received buffer and creates sysfs node under hwmon driver
  * This API parses the buffer received from XGQ driver.
@@ -492,32 +592,18 @@ static void hwmon_sdm_load_bdinfo(struct xocl_hwmon_sdm *sdm, uint8_t repo_id,
 static int parse_sdr_info(char *in_buf, struct xocl_hwmon_sdm *sdm, bool create_sysfs)
 {
 	bool create = false;
-	uint8_t status;
-	int buf_index, err, repo_id;
-	uint8_t remaining_records, completion_code, repo_type;
+	int buf_index, err, repo_id, sid = 0;
+	uint8_t remaining_records, completion_code, repo_type, status;
 	uint8_t name_length, name_type_length, sys_index, fan_index;
 	uint8_t val_len, value_type_length, threshold_support_byte;
-	uint8_t bu_len, sensor_id, base_unit_type_length, unit_modifier_byte;
-	uint32_t buf_size, name_index, ins_index, max_index = 0, avg_index = 0, status_index, unit_type_index;
+	uint8_t bu_len = 0, sensor_id, base_unit_type_length, unit_modifier_byte;
+	uint32_t buf_size = 0, name_index = 0, ins_index = 0, max_index = 0, avg_index = 0, status_index = 0, unit_type_index = 0;
 	uint32_t upper_warning = 0, upper_critical = 0, upper_fatal = 0;
 	uint32_t lower_warning = 0, lower_critical = 0, lower_fatal = 0;
 
 	completion_code = in_buf[SDR_COMPLETE_IDX];
-
-	if(completion_code != SDR_CODE_OP_SUCCESS)
-	{
-		if(completion_code == SDR_CODE_NOT_AVAILABLE)
-			xocl_err(&sdm->pdev->dev, "Error: SDR Code Not Available");
-		else if(completion_code == SDR_CODE_OP_FAILED)
-			xocl_err(&sdm->pdev->dev, "Error: SDR Code Operation Failed");
-		else if(completion_code == SDR_CODE_FLOW_CONTROL_READ_STALE)
-			xocl_err(&sdm->pdev->dev, "Error: SDR Code Flow Control Read Stale");
-		else if(completion_code == SDR_CODE_FLOW_CONTROL_WRITE_ERROR)
-			xocl_err(&sdm->pdev->dev, "Error: SDR Code Flow Control Write Error");
-		else if(completion_code == SDR_CODE_INVALID_SENSOR_ID)
-			xocl_err(&sdm->pdev->dev, "Error: SDR Code Invalid Sensor ID");
-		else
-			xocl_err(&sdm->pdev->dev, "Failed in sending SDR Repository command, completion_code: 0x%x", completion_code);
+	if(completion_code != SDR_CODE_OP_SUCCESS) {
+		dump_error_message(sdm, completion_code);
 		return -EINVAL;
 	}
 
@@ -543,8 +629,13 @@ static int parse_sdr_info(char *in_buf, struct xocl_hwmon_sdm *sdm, bool create_
 	if (repo_type == SDR_TYPE_VOLTAGE)
 		sys_index = 0;
 
+	if (create_sysfs)
+		sdm->sensor_ids_max[repo_id] = remaining_records;
+
 	while((remaining_records > 0) && (buf_index < buf_size))
 	{
+		if (create_sysfs)
+			sdm->sensor_ids[repo_id][sid++] = buf_index;
 		sensor_id = in_buf[buf_index++];
 
 		name_type_length = in_buf[buf_index++];
@@ -1149,11 +1240,12 @@ failed:
  */
 static int hwmon_sdm_update_sensors_by_type(struct platform_device *pdev,
                                             enum xgq_sdr_repo_type repo_type,
-                                            bool create_sysfs)
+                                            bool create_sysfs, uint64_t data_args)
 {
 	struct xocl_hwmon_sdm *sdm = platform_get_drvdata(pdev);
+	uint8_t sensor_id = data_args & 0xFF;
 	xdev_handle_t xdev = xocl_get_xdev(pdev);
-	int repo_id, ret;
+	int repo_id, kind = 0, ret = 0;
 
 	repo_id = sdr_get_id(repo_type);
 	if (repo_id < 0) {
@@ -1161,24 +1253,43 @@ static int hwmon_sdm_update_sensors_by_type(struct platform_device *pdev,
 		return -EINVAL;
 	}
 
-	if (!sdm->privileged)
-		return hwmon_sdm_read_from_peer(pdev, repo_type);
+	if (!sdm->privileged) {
+		kind = to_xcl_sdr_type(repo_type);
+		if (kind < 0) {
+			xocl_err(&pdev->dev, "received invalid xcl grp type: %d", kind);
+			return -EINVAL;
+		}
+		return hwmon_sdm_read_from_peer(pdev, repo_type, kind, data_args);
+	}
 
 	if (!sdm->sensor_data[repo_id])
 		sdm->sensor_data[repo_id] = (char*)devm_kzalloc(&sdm->pdev->dev, sizeof(char) * RESP_LEN, GFP_KERNEL);
 
-	ret = xocl_xgq_collect_sensors_by_id(xdev, sdm->sensor_data[repo_id],
+	if (sensor_id == 0) {
+		ret = xocl_xgq_collect_sensors_by_repo_id(xdev, sdm->sensor_data[repo_id],
                                          repo_id, RESP_LEN);
-
-	if (!ret) {
-		ret = parse_sdr_info(sdm->sensor_data[repo_id], sdm, create_sysfs);
-		if (!ret)
-			sdm->sensor_data_avail[repo_id] = true;
+		if (!ret) {
+			ret = parse_sdr_info(sdm->sensor_data[repo_id], sdm, create_sysfs);
+			if (!ret)
+				sdm->sensor_data_avail[repo_id] = true;
+		} else {
+			xocl_err(&pdev->dev, "request is failed with err: %d", ret);
+			sdm->sensor_data_avail[repo_id] = false;
+		}
 	} else {
-		xocl_err(&pdev->dev, "request is failed with err: %d", ret);
-		sdm->sensor_data_avail[repo_id] = false;
+		char* single_sdr_buf = vzalloc(128);
+		if (!single_sdr_buf)
+			goto done;
+		ret = xocl_xgq_collect_sensors_by_sensor_id(xdev, single_sdr_buf,
+                                         repo_id, RESP_LEN, sensor_id);
+		if (!ret)
+			ret = parse_single_sdr_info(sdm, single_sdr_buf, repo_id, data_args);
+		else
+			xocl_err(&pdev->dev, "sensor_id request is failed with err: %d", ret);
+		vfree(single_sdr_buf);
 	}
 
+done:
 	return ret;
 }
 
@@ -1189,11 +1300,11 @@ static int hwmon_sdm_update_sensors_by_type(struct platform_device *pdev,
  */
 static void hwmon_sdm_get_sensors_list(struct platform_device *pdev, bool create_sysfs)
 {
-	(void) hwmon_sdm_update_sensors_by_type(pdev, SDR_TYPE_BDINFO, create_sysfs);
-	(void) hwmon_sdm_update_sensors_by_type(pdev, SDR_TYPE_TEMP, create_sysfs);
-	(void) hwmon_sdm_update_sensors_by_type(pdev, SDR_TYPE_CURRENT, create_sysfs);
-	(void) hwmon_sdm_update_sensors_by_type(pdev, SDR_TYPE_POWER, create_sysfs);
-	(void) hwmon_sdm_update_sensors_by_type(pdev, SDR_TYPE_VOLTAGE, create_sysfs);
+	(void) hwmon_sdm_update_sensors_by_type(pdev, SDR_TYPE_BDINFO, create_sysfs, 0);
+	(void) hwmon_sdm_update_sensors_by_type(pdev, SDR_TYPE_TEMP, create_sysfs, 0);
+	(void) hwmon_sdm_update_sensors_by_type(pdev, SDR_TYPE_CURRENT, create_sysfs, 0);
+	(void) hwmon_sdm_update_sensors_by_type(pdev, SDR_TYPE_POWER, create_sysfs, 0);
+	(void) hwmon_sdm_update_sensors_by_type(pdev, SDR_TYPE_VOLTAGE, create_sysfs, 0);
 }
 
 /*
@@ -1203,20 +1314,29 @@ static void hwmon_sdm_get_sensors_list(struct platform_device *pdev, bool create
  * In unprivileged mode:
  *    It prepares mailbox request to receive the required sensors.
  */
-static int hwmon_sdm_update_sensors(struct platform_device *pdev, uint8_t repo_id)
+static int hwmon_sdm_update_sensors(struct platform_device *pdev, uint8_t repo_id,
+                                    uint64_t data_args)
 {
 	struct xocl_hwmon_sdm *sdm = platform_get_drvdata(pdev);
+	uint8_t sensor_id = data_args & 0xFF;
 	int repo_type;
-	int ret = 0;
+	int ret = 0, kind = 0;
 
 	repo_type = to_sensor_repo_type(repo_id);
-	if (sdm->privileged)
-		ret = hwmon_sdm_update_sensors_by_type(pdev, repo_type, false);
-	else
-		ret = hwmon_sdm_read_from_peer(pdev, repo_type);
+
+	if (sdm->privileged) {
+		ret = hwmon_sdm_update_sensors_by_type(pdev, repo_type, false, data_args);
+	} else {
+		kind = to_xcl_sdr_type(repo_type);
+		if (kind < 0) {
+			xocl_err(&pdev->dev, "received invalid xcl grp type: %d", kind);
+			return -EINVAL;
+		}
+		ret = hwmon_sdm_read_from_peer(pdev, repo_type, kind, data_args);
+	}
 
 	if (!ret)
-		update_cache_expiry_time(sdm, repo_id);
+		update_cache_expiry_time(sdm, repo_id, sensor_id);
 
 	return ret;
 }
@@ -1225,8 +1345,8 @@ static int hwmon_sdm_update_sensors(struct platform_device *pdev, uint8_t repo_i
  * hwmon_sdm_get_sensors(): used to read sensors of given sensor group
  * This API is a callback called from mgmt driver
  */
-static int hwmon_sdm_get_sensors(struct platform_device *pdev,
-                                 char *resp, enum xcl_group_kind kind)
+static int hwmon_sdm_get_sensors(struct platform_device *pdev, char *resp,
+                                 enum xcl_group_kind kind, uint64_t data_args)
 {
 	struct xocl_hwmon_sdm *sdm = platform_get_drvdata(pdev);
 	int repo_type, repo_id;
@@ -1244,7 +1364,7 @@ static int hwmon_sdm_get_sensors(struct platform_device *pdev,
 		return -EINVAL;
 	}
 
-	ret = hwmon_sdm_update_sensors_by_type(pdev, repo_type, false);
+	ret = hwmon_sdm_update_sensors_by_type(pdev, repo_type, false, data_args);
 	if (!ret)
 		memcpy(resp, sdm->sensor_data[repo_id], RESP_LEN);
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
@@ -1586,8 +1586,8 @@ static int vmr_enable_multiboot(struct platform_device *pdev)
 		xgq->xgq_boot_from_backup ? XGQ_CMD_BOOT_BACKUP : XGQ_CMD_BOOT_DEFAULT);
 }
 
-static int xgq_collect_sensors(struct platform_device *pdev, int sid,
-	char *data_buf, uint32_t len)
+static int xgq_collect_sensors(struct platform_device *pdev, int aid, int sid,
+                               char *data_buf, uint32_t len, uint8_t sensor_id)
 {
 	struct xocl_xgq_vmr *xgq = platform_get_drvdata(pdev);
 	struct xocl_xgq_vmr_cmd *cmd = NULL;
@@ -1620,8 +1620,12 @@ static int xgq_collect_sensors(struct platform_device *pdev, int sid,
 	payload = &(cmd->xgq_cmd_entry.sensor_payload);
 	payload->address = address;
 	payload->size = len;
-	payload->aid = XGQ_CMD_SENSOR_AID_GET_SDR;
+	//Sensor API ID
+	payload->aid = aid;
+	//Sensor request ID
 	payload->sid = sid;
+	//Sensor ID
+	payload->sensor_id = sensor_id;
 
 	hdr = &(cmd->xgq_cmd_entry.hdr);
 	hdr->opcode = XGQ_CMD_OP_SENSOR;
@@ -1673,10 +1677,16 @@ acquire_failed:
 	return ret;
 }
 
-static int xgq_collect_sensors_by_id(struct platform_device *pdev, char *buf,
-	 uint8_t id, uint32_t len)
+static int xgq_collect_sensors_by_repo_id(struct platform_device *pdev, char *buf,
+	 uint8_t repo_id, uint32_t len)
 {
-	return xgq_collect_sensors(pdev, id, buf, len);
+	return xgq_collect_sensors(pdev, XGQ_CMD_SENSOR_AID_GET_SDR, repo_id, buf, len, 0);
+}
+
+static int xgq_collect_sensors_by_sensor_id(struct platform_device *pdev, char *buf,
+	 uint8_t repo_id, uint32_t len, uint8_t sensor_id)
+{
+	return xgq_collect_sensors(pdev, XGQ_CMD_SENSOR_AID_GET_SINGLE_SDR, repo_id, buf, len, sensor_id);
 }
 
 /* sysfs */
@@ -2234,7 +2244,8 @@ static struct xocl_xgq_vmr_funcs xgq_vmr_ops = {
 	.xgq_get_data = xgq_get_data,
 	.xgq_download_apu_firmware = xgq_download_apu_firmware,
 	.vmr_enable_multiboot = vmr_enable_multiboot,
-	.xgq_collect_sensors_by_id = xgq_collect_sensors_by_id,
+	.xgq_collect_sensors_by_repo_id = xgq_collect_sensors_by_repo_id,
+	.xgq_collect_sensors_by_sensor_id = xgq_collect_sensors_by_sensor_id,
 	.vmr_load_firmware = xgq_log_page_fw,
 };
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
@@ -1042,6 +1042,7 @@ static int xocl_hwmon_sdm_init_sysfs(struct xocl_dev *xdev, enum xcl_group_kind 
 		goto done;
 
 	mb_req->req = XCL_MAILBOX_REQ_SDR_DATA;
+	mb_req->flags = 0x0;
 	subdev_peer.size = resp_len;
 	subdev_peer.kind = kind;
 	subdev_peer.entries = 1;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -2140,8 +2140,10 @@ struct xocl_xgq_vmr_funcs {
 		enum data_kind kind);
 	int (*xgq_download_apu_firmware)(struct platform_device *pdev);
 	int (*vmr_enable_multiboot)(struct platform_device *pdev);
-	int (*xgq_collect_sensors_by_id)(struct platform_device *pdev, char *buf,
+	int (*xgq_collect_sensors_by_repo_id)(struct platform_device *pdev, char *buf,
                                      uint8_t id, uint32_t len);
+	int (*xgq_collect_sensors_by_sensor_id)(struct platform_device *pdev, char *buf,
+                                     uint8_t id, uint32_t len, uint8_t sid);
 	int (*vmr_load_firmware)(struct platform_device *pdev, char **fw, size_t *fw_size);
 };
 #define	XGQ_DEV(xdev)						\
@@ -2176,9 +2178,12 @@ struct xocl_xgq_vmr_funcs {
 #define	xocl_vmr_enable_multiboot(xdev) 			\
 	(XGQ_CB(xdev, vmr_enable_multiboot) ?			\
 	XGQ_OPS(xdev)->vmr_enable_multiboot(XGQ_DEV(xdev)) : -ENODEV)
-#define	xocl_xgq_collect_sensors_by_id(xdev, buf, id, len)		\
-	(XGQ_CB(xdev, xgq_collect_sensors_by_id) ?		\
-	XGQ_OPS(xdev)->xgq_collect_sensors_by_id(XGQ_DEV(xdev), buf, id, len) : -ENODEV)
+#define	xocl_xgq_collect_sensors_by_repo_id(xdev, buf, id, len)	\
+	(XGQ_CB(xdev, xgq_collect_sensors_by_repo_id) ?		\
+	XGQ_OPS(xdev)->xgq_collect_sensors_by_repo_id(XGQ_DEV(xdev), buf, id, len) : -ENODEV)
+#define	xocl_xgq_collect_sensors_by_sensor_id(xdev, buf, id, len, sid)	\
+	(XGQ_CB(xdev, xgq_collect_sensors_by_sensor_id) ?	\
+	XGQ_OPS(xdev)->xgq_collect_sensors_by_sensor_id(XGQ_DEV(xdev), buf, id, len, sid) : -ENODEV)
 #define	xocl_vmr_load_firmware(xdev, fw, fw_size)		\
 	(XGQ_CB(xdev, vmr_load_firmware) ?			\
 	XGQ_OPS(xdev)->vmr_load_firmware(XGQ_DEV(xdev), fw, fw_size) : -ENODEV)
@@ -2187,7 +2192,7 @@ struct xocl_sdm_funcs {
 	struct xocl_subdev_funcs common_funcs;
 	void (*hwmon_sdm_get_sensors_list)(struct platform_device *pdev, bool create_sysfs);
 	int (*hwmon_sdm_get_sensors)(struct platform_device *pdev, char *resp,
-                                 enum xcl_group_kind repo_type);
+                                 enum xcl_group_kind repo_type, uint64_t data_args);
 	int (*hwmon_sdm_create_sensors_sysfs)(struct platform_device *pdev, char *in_buf,
                                           size_t len, enum xcl_group_kind kind);
 };
@@ -2202,9 +2207,9 @@ struct xocl_sdm_funcs {
 #define	xocl_hwmon_sdm_get_sensors_list(xdev, create_sysfs)		\
 	(SDM_CB(xdev, hwmon_sdm_get_sensors_list) ?			\
 	SDM_OPS(xdev)->hwmon_sdm_get_sensors_list(SDM_DEV(xdev), create_sysfs) : -ENODEV)
-#define	xocl_hwmon_sdm_get_sensors(xdev, resp, repo_type)		\
+#define	xocl_hwmon_sdm_get_sensors(xdev, resp, repo_type, data_args)	\
 	(SDM_CB(xdev, hwmon_sdm_get_sensors) ?			\
-	SDM_OPS(xdev)->hwmon_sdm_get_sensors(SDM_DEV(xdev), resp, repo_type) : -ENODEV)
+	SDM_OPS(xdev)->hwmon_sdm_get_sensors(SDM_DEV(xdev), resp, repo_type, data_args) : -ENODEV)
 #define	xocl_hwmon_sdm_create_sensors_sysfs(xdev, buf, size, kind)		\
 	(SDM_CB(xdev, hwmon_sdm_create_sensors_sysfs) ?			\
 	SDM_OPS(xdev)->hwmon_sdm_create_sensors_sysfs(SDM_DEV(xdev), buf, size, kind) : -ENODEV)


### PR DESCRIPTION
VMR supports new API "GET_SINGLE_SENSOR_DATA" which sends instantaneous sensor data (sensor value, average, max & status) based on the input sensor's repo_type & sensor ID received from XRT.
Added changes in XRT hwmon_sdm driver to support this new API. Followed command/response formats from https://confluence.xilinx.com/pages/viewpage.action?spaceKey=DCG&title=Versal+ASDM+APIs 
Signed-off-by: Rajkumar Rampelli <rampelli@amd.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
XRT issues Get_SDR request for single sensor data also now, and receives complete SDR data. Subsequently, the individual instantaneous sensor values within each SDR can be refreshed by calling Get_Single_Sensor_Data APIs.
This PR adds support for adding single sensor data using new API ID defined.
It uses mailbox request flags field to differentiate the requests and also to pass the sensor ID to the mgmtpf side.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
VITIS-5892
#### How problem was solved, alternative solutions (if any) and why they were rejected
Added changes in XRT's hwmon_sdm.c driver for issuing single SDR data requests wherever required.
VMC provided two APIs to get sensor information. First API is to get full sensor information, Second API is to get only instantaneous data. Current XRT is calling first API in all the cases. XRT should call first API in driver init and second API in each xbutil/xbmgmt call. This PR adds second API implementation in XRT.
Updated XGQ documentation at https://confluence.xilinx.com/pages/viewpage.action?pageId=302345261 
#### Risks (if any) associated the changes in the commit
NA
#### What has been tested and how, request additional testing if necessary
xbutil & xbmgmt reports.
#### Documentation impact (if any)
NA