### PR TITLE
CR-1131883 - Add separate pc.in file for embedded cases

### DIFF
--- a/src/CMake/config/xrt-edge.pc.in
+++ b/src/CMake/config/xrt-edge.pc.in
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2019-2021 Xilinx, Inc. All rights reserved.
+
+prefix=@XRT_INSTALL_DIR@
+exec_prefix=${prefix}
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: XRT
+Description: Xilinx RunTime
+Version: @XRT_VERSION_STRING@
+Libs: -L${libdir} -lxrt_core -lxrt_coreutil
+Cflags: -I${includedir} -I${includedir}/xrt

--- a/src/CMake/embedded_system.cmake
+++ b/src/CMake/embedded_system.cmake
@@ -108,7 +108,7 @@ message("-- Preparing XRT pkg-config")
 set(XRT_PKG_CONFIG_DIR "/usr/lib/pkgconfig")
 
 configure_file (
-  ${XRT_SOURCE_DIR}/CMake/config/xrt.pc.in
+  ${XRT_SOURCE_DIR}/CMake/config/xrt-edge.pc.in
   xrt.pc
   @ONLY
   )


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Use separate pc.in file for embedded cases because of include files directory differences between edge and dc cases

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added new xrt-edge.pc.in file which will be used for edge platforms to generate xrt.pc file

#### Risks (if any) associated the changes in the commit
none

#### What has been tested and how, request additional testing if necessary
Used vvas application for testing the generated xrt.pc file

#### Documentation impact (if any)
NA