### PR TITLE
Fix windows compile flag for proper cplusplus

### DIFF
--- a/src/CMake/nativeWin.cmake
+++ b/src/CMake/nativeWin.cmake
@@ -46,6 +46,10 @@ add_compile_definitions("BOOST_BIND_GLOBAL_PLACEHOLDERS")
 # the warning is bogus.  Remove defintion when fixed
 add_compile_definitions("_SILENCE_CXX17_ALLOCATOR_VOID_DEPRECATION_WARNING")
 
+if (MSVC)
+  add_compile_options(/Zc:__cplusplus)
+endif()
+
 INCLUDE (FindGTest)
 
 # --- XRT Variables ---

--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -549,9 +549,11 @@ async(xrt::bo& bo, xclBOSyncDirection dir, size_t sz, size_t offset)
 {
   throw std::runtime_error("Unsupported feature");
 
+#if 0
   //TODO for Alveo; base xrt::bo class
   auto a_bo_impl = std::make_shared<xrt::bo::async_handle_impl>(bo);
   return xrt::bo::async_handle{a_bo_impl};
+#endif
 }
 
 // class buffer_ubuf - User provide host side buffer

--- a/tests/unit_test/CMakeLists.txt
+++ b/tests/unit_test/CMakeLists.txt
@@ -10,6 +10,10 @@ set(CMAKE_VERBOSE_MAKEFILE ON)
 set(XILINX_XRT $ENV{XILINX_XRT})
 set(XRT_CORE_LIBRARY xrt_core)
 
+if (MSVC)
+  add_compile_options(/Zc:__cplusplus)
+endif()
+
 if (NOT DEFINED ${INSTALL_DIR})
   set(INSTALL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/build/${CMAKE_SYSTEM_NAME}/${CMAKE_BUILD_TYPE}/${MODE}")
 endif()
@@ -39,4 +43,3 @@ add_subdirectory(cdma)
 add_subdirectory(cuselect)
 add_subdirectory(subdevice)
 add_subdirectory(vadd_bank3)
-

--- a/tests/xrt/CMakeLists.txt
+++ b/tests/xrt/CMakeLists.txt
@@ -10,6 +10,10 @@ set(CMAKE_VERBOSE_MAKEFILE ON)
 set(XILINX_XRT $ENV{XILINX_XRT})
 set(XRT_CORE_LIBRARY xrt_core)
 
+if (MSVC)
+  add_compile_options(/Zc:__cplusplus)
+endif()
+
 if (NOT DEFINED ${INSTALL_DIR})
   set(INSTALL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/build/${CMAKE_SYSTEM_NAME}/${CMAKE_BUILD_TYPE}/${MODE}")
 endif()


### PR DESCRIPTION
#### Problem solved by the commit
Compile with proper definition of __cplusplus on windows

#### How problem was solved, alternative solutions (if any) and why they were rejected
The /Zc:__cplusplus compiler option enables the __cplusplus
preprocessor macro to report an updated value for recent C++ language
standards support. By default, Visual Studio always returns the value
199711L for the __cplusplus preprocessor macro

Also fix debug compile error for dead code warning.

#### Documentation impact (if any)
Note that host code on windows must be built using /Z:c:__cplusplus
