### PR TITLE
Minor update to run summary format

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info_database.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info_database.cpp
@@ -119,6 +119,17 @@ namespace xdp {
     applicationStartTime = t ;
   }
 
+  bool VPStaticDatabase::getAieApplication() const
+  {
+    return aieApplication;
+  }
+
+  void VPStaticDatabase::setAieApplication()
+  {
+    std::lock_guard<std::mutex> lock(summaryLock);
+    aieApplication = true;
+  }
+
   // ***************************************************
   // ***** Functions related to OpenCL information *****
 

--- a/src/runtime_src/xdp/profile/database/static_info_database.h
+++ b/src/runtime_src/xdp/profile/database/static_info_database.h
@@ -72,6 +72,7 @@ namespace xdp {
     // ********* Information specific to each host execution **********
     int pid ;
     uint64_t applicationStartTime = 0 ;
+    bool aieApplication = false;
     
     // The files that need to be included in the run summary for
     //  consumption by Vitis_Analyzer
@@ -136,6 +137,9 @@ namespace xdp {
     //  are loaded.
     XDP_EXPORT uint64_t getApplicationStartTime() const ;
     XDP_EXPORT void setApplicationStartTime(uint64_t t) ;
+
+    XDP_EXPORT bool getAieApplication() const ;
+    XDP_EXPORT void setAieApplication() ;
 
     // Due to changes in hardware IP, we can only support profiling on
     //  xclbins built using 2019.2 or later tools.

--- a/src/runtime_src/xdp/profile/plugin/aie_debug/aie_debug_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_debug/aie_debug_plugin.cpp
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2021 Xilinx, Inc
+ * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -70,6 +71,7 @@ namespace xdp {
 
     db->registerPlugin(this);
     db->registerInfo(info::aie_status);
+    db->getStaticInfo().setAieApplication();
 
     mPollingInterval = xrt_core::config::get_aie_status_interval_us();
   }

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.cpp
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2020-2022 Xilinx, Inc
+ * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -90,6 +91,7 @@ namespace xdp {
 
     db->registerPlugin(this);
     db->registerInfo(info::aie_profile);
+    db->getStaticInfo().setAieApplication();
     getPollingInterval();
 
     //

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2020-2021 Xilinx, Inc
+ * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -89,6 +90,7 @@ namespace xdp {
 
     db->registerPlugin(this);
     db->registerInfo(info::aie_trace);
+    db->getStaticInfo().setAieApplication();
 
     // Check whether continuous trace is enabled in xrt.ini
     // AIE trace is now supported for HW only

--- a/src/runtime_src/xdp/profile/writer/vp_base/vp_run_summary.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/vp_run_summary.cpp
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2016-2020 Xilinx, Inc
+ * Copyright (C) 2022 Advanced Micro Devices, Inc - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -77,13 +78,14 @@ namespace xdp {
     {
       boost::property_tree::ptree ptSchema ;
       ptSchema.put("major", "1") ;
-      ptSchema.put("minor", "2") ;
+      ptSchema.put("minor", "3") ;
       ptSchema.put("patch", "0") ; 
       ptRunSummary.add_child("schema_version", ptSchema) ;
     }
 
     {
       auto pid = (db->getStaticInfo()).getPid() ;
+      bool aieApplication = db->getStaticInfo().getAieApplication();
       auto timestamp = (std::chrono::system_clock::now()).time_since_epoch() ;
       auto value = std::chrono::duration_cast<std::chrono::milliseconds>(timestamp) ;
       uint64_t timeMsec = value.count() ;
@@ -109,6 +111,19 @@ namespace xdp {
       ptGeneration.put("source", "vp") ;
       ptGeneration.put("PID", std::to_string(pid)) ;
       ptGeneration.put("timestamp", std::to_string(timeMsec)) ;
+      // Adding a generic flag field to handle arbitrary information
+      boost::property_tree::ptree flags;
+      if (aieApplication) {
+        boost::property_tree::ptree flag;
+        flag.put("", "aie");
+        flags.push_back(std::make_pair("", flag));
+      }
+      else {
+        // If empty, make sure we output a list with nothing in it
+	boost::property_tree::ptree empty;
+        flags.push_back(std::make_pair("", empty));
+      }
+      ptGeneration.add_child("flags", flags);
       ptRunSummary.add_child("generation", ptGeneration) ;
     }
 


### PR DESCRIPTION
#### Problem solved by the commit
When profiling or debug features are enabled, a run summary file is produced with pointers to all of the generated data files that contain profiling or debug information.  This run summary file is consumed by tools, like Vitis Analyzer, which then can make choices on how to present the raw information to the user.

In some cases, the user may run an AIE application in XRT and enable AIE trace generation, but the AIE trace files are not listed in the run summary file.  When this happens, the tool that consumes the run summary has no knowledge that the design was an AIE application and may not display the information correctly.

This pull request updates the run summary being generated to a new minor version and adds a generic "flags" element to the JSON.  The only flag currently supported is "aie" which will be added whenever an AIE profiling/trace/debug option is enabled.  This allows the tool that consumes the run summary to determine to display AIE layouts even if no AIE files are directly pointed to by the run summary.  Additional flags may be added in the future to help downstream tools make display decisions.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Each AIE XDP plugin now registers the fact that the application is AIE based.  At the end of the application, when the run_summary is being generated we check this information and add the flag if appropriate.

#### What has been tested and how, request additional testing if necessary
The generation of the new run summary and consumption by downstream tools has been tested.
