### PR TITLE
Add AIE trace buffer reuse switch

### DIFF
--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -383,6 +383,13 @@ get_aie_trace_periodic_offload()
   return value;
 }
 
+inline bool
+get_aie_trace_reuse_buffer()
+{
+  static bool value = detail::get_bool_value("Debug.aie_trace_reuse_buffer", false);
+  return value;
+}
+
 /**
  * Deprecated in future. Ms is too long for aie trace
  */
@@ -406,6 +413,7 @@ get_aie_trace_file_dump_interval_s()
   static unsigned int value = detail::get_uint_value("Debug.aie_trace_file_dump_interval_s", 5);
   return value;
 }
+
 
 inline std::string
 get_aie_profile_core_metrics()

--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -414,7 +414,6 @@ get_aie_trace_file_dump_interval_s()
   return value;
 }
 
-
 inline std::string
 get_aie_profile_core_metrics()
 {

--- a/src/runtime_src/xdp/profile/database/dynamic_event_database.cpp
+++ b/src/runtime_src/xdp/profile/database/dynamic_event_database.cpp
@@ -445,10 +445,10 @@ namespace xdp {
       aieTraceData[deviceId][strmIndex] = new AIETraceDataType;
     }
 
-    void* trace_buffer = buffer;
+    unsigned char* trace_buffer = static_cast<unsigned char *>(buffer);
     // We need to copy trace buffer data as it could be be overwritten by datamover
     if (copy) {
-      trace_buffer = std::malloc(bufferSz);
+      trace_buffer = new unsigned char[bufferSz];
       std::memcpy(trace_buffer, buffer, bufferSz);
     }
 

--- a/src/runtime_src/xdp/profile/database/dynamic_event_database.h
+++ b/src/runtime_src/xdp/profile/database/dynamic_event_database.h
@@ -40,8 +40,9 @@ namespace xdp {
 
   // AIE Trace data type
   struct AIETraceDataType {
-    std::vector<std::unique_ptr<unsigned char[]>> buffer;
+    std::vector<void *> buffer;
     std::vector<uint64_t> bufferSz;
+    bool owner;
   };
   typedef std::vector<AIETraceDataType*> AIETraceDataVector;
 
@@ -225,7 +226,7 @@ namespace xdp {
     XDP_EXPORT std::map<uint64_t, std::vector<uint64_t>> getDependencyMap() ;
 
     // Add and get AIE Trace Data Buffer 
-    XDP_EXPORT void addAIETraceData(uint64_t deviceId, uint64_t strmIndex, void* buffer, uint64_t bufferSz);
+    XDP_EXPORT void addAIETraceData(uint64_t deviceId, uint64_t strmIndex, void* buffer, uint64_t bufferSz, bool copy);
     XDP_EXPORT AIETraceDataType* getAIETraceData(uint64_t deviceId, uint64_t strmIndex);
 
     // Functions that are used by counter-based plugins

--- a/src/runtime_src/xdp/profile/database/dynamic_event_database.h
+++ b/src/runtime_src/xdp/profile/database/dynamic_event_database.h
@@ -40,7 +40,7 @@ namespace xdp {
 
   // AIE Trace data type
   struct AIETraceDataType {
-    std::vector<void *> buffer;
+    std::vector<unsigned char *> buffer;
     std::vector<uint64_t> bufferSz;
     bool owner;
   };

--- a/src/runtime_src/xdp/profile/database/events/creator/aie_trace_data_logger.cpp
+++ b/src/runtime_src/xdp/profile/database/events/creator/aie_trace_data_logger.cpp
@@ -31,12 +31,12 @@ AIETraceDataLogger::~AIETraceDataLogger()
 {
 }
 
-void AIETraceDataLogger::addAIETraceData(uint64_t strmIndex, void* buffer, uint64_t bufferSz)
+void AIETraceDataLogger::addAIETraceData(uint64_t strmIndex, void* buffer, uint64_t bufferSz, bool copy)
 {
   if(!VPDatabase::alive()) {
     return;
   }
-  db->getDynamicInfo().addAIETraceData(deviceId, strmIndex, buffer, bufferSz);
+  db->getDynamicInfo().addAIETraceData(deviceId, strmIndex, buffer, bufferSz, copy);
 }
 
 }

--- a/src/runtime_src/xdp/profile/database/events/creator/aie_trace_data_logger.h
+++ b/src/runtime_src/xdp/profile/database/events/creator/aie_trace_data_logger.h
@@ -36,7 +36,7 @@ public:
   virtual ~AIETraceDataLogger();
 
   XDP_EXPORT
-  virtual void addAIETraceData(uint64_t strmIndex, void* buffer, uint64_t bufferSz);
+  virtual void addAIETraceData(uint64_t strmIndex, void* buffer, uint64_t bufferSz, bool copy);
 };
 
 }

--- a/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_logger.h
+++ b/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_logger.h
@@ -28,7 +28,7 @@ public:
   AIETraceLogger() {}
   virtual ~AIETraceLogger() {}
 
-  virtual void addAIETraceData(uint64_t strmIndex, void* buffer, uint64_t bufferSz) = 0; 
+  virtual void addAIETraceData(uint64_t strmIndex, void* buffer, uint64_t bufferSz, bool copy) = 0;
 };
 
 }

--- a/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.cpp
+++ b/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.cpp
@@ -55,6 +55,7 @@ AIETraceOffload::AIETraceOffload
   , bufferInitialized(false)
   , offloadStatus(AIEOffloadThreadStatus::IDLE)
   , mEnCircularBuf(false)
+  , mCircularBufOverwrite(false)
 {
   bufAllocSz = deviceIntf->getAlignedTraceBufferSize(totalSz, static_cast<unsigned int>(numStream));
 }
@@ -81,8 +82,7 @@ bool AIETraceOffload::initReadTrace()
     gmioDMAInsts.resize(numStream);
   }
 
-  if (isPLIO && continuousTrace())
-    checkCircularBufferSupport();
+  checkCircularBufferSupport();
 
   for(uint64_t i = 0; i < numStream ; ++i) {
     buffers[i].boHandle = deviceIntf->allocTraceBuf(bufAllocSz, memIndex);
@@ -198,6 +198,9 @@ void AIETraceOffload::endReadTrace()
 
 void AIETraceOffload::readTrace(bool final)
 {
+  if (mCircularBufOverwrite)
+    return;
+
   for (uint64_t index = 0; index < numStream; ++index) {
     auto& bd = buffers[index];
 
@@ -225,12 +228,16 @@ void AIETraceOffload::readTrace(bool final)
     if (bytes_written > bytes_read + bufAllocSz) {
       // Don't read any more data
       bd.offloadDone = true;
-      xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", AIE_TS2MM_WARN_MSG_CIRC_BUF_OVERWRITE);
+      std::stringstream msg;
+      msg << AIE_TS2MM_WARN_MSG_CIRC_BUF_OVERWRITE << " Stream : " << index + 1 << std::endl;
+      xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", msg.str());
       debug_stream
         << "Bytes Read : " << bytes_read
         << " Bytes Written : " << bytes_written
         << std::endl;
+
       // Fatal condition. Abort offload
+      mCircularBufOverwrite = true;
       stopOffload();
       return;
     }
@@ -307,13 +314,13 @@ bool AIETraceOffload::syncAndLog(uint64_t index)
   }
 
   // Log trace buffer
-  traceLogger->addAIETraceData(index, hostBuf, nBytes);
+  traceLogger->addAIETraceData(index, hostBuf, nBytes, mEnCircularBuf);
 
-    debug_stream
-      << "ts2mm_" << index << " : bytes : " << nBytes << " "
-      << "sync: " << std::chrono::duration_cast<std::chrono::microseconds>(end - start).count() << "µs "
-      << std::hex << "from 0x" << bd.offset << " to 0x"
-      << bd.usedSz << std::dec << std::endl;
+  debug_stream
+    << "ts2mm_" << index << " : bytes : " << nBytes << " "
+    << "sync: " << std::chrono::duration_cast<std::chrono::microseconds>(end - start).count() << "µs "
+    << std::hex << "from 0x" << bd.offset << " to 0x"
+    << bd.usedSz << std::dec << std::endl;
 
     // check for full buffer
   if ((bd.offset + nBytes >= bufAllocSz) && !mEnCircularBuf)
@@ -336,37 +343,43 @@ bool AIETraceOffload::isTraceBufferFull()
 
 void AIETraceOffload::checkCircularBufferSupport()
 {
-  if (!isPLIO || !deviceIntf->supportsCircBufAIE())
+  if (!deviceIntf->supportsCircBufAIE())
     return;
 
+  mEnCircularBuf = xrt_core::config::get_aie_trace_reuse_buffer();
+
+  if (!mEnCircularBuf)
+    return;
+
+  // gmio not supported
+  if (!isPLIO) {
+    mEnCircularBuf = false;
+    xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", AIE_TRACE_WARN_REUSE_GMIO);
+    return;
+  }
+
+  if (!continuousTrace()) {
+    mEnCircularBuf = false;
+    xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", AIE_TRACE_WARN_REUSE_PERIODIC);
+    return;
+  }
+
+  // Warn if circular buffer settings not adequate
   if (offloadIntervalUs)
     circ_buf_cur_rate_plio = bufAllocSz * (1e6 / offloadIntervalUs);
   else
     circ_buf_cur_rate_plio = circ_buf_min_rate_plio;
 
-  bool buffer_large_enough = (bufAllocSz >= AIE_MIN_SIZE_CIRCULAR_BUF);
-  bool  offload_fast_enough = (circ_buf_cur_rate_plio >= circ_buf_min_rate_plio);
-  mEnCircularBuf = (buffer_large_enough && offload_fast_enough);
+  bool buffer_not_large_enough = (bufAllocSz < AIE_MIN_SIZE_CIRCULAR_BUF);
+  bool offload_not_fast_enough = (circ_buf_cur_rate_plio < circ_buf_min_rate_plio);
 
-  if (!mEnCircularBuf &&
-      (xrt_core::config::get_verbosity() >= static_cast<unsigned int>(xrt_core::message::severity_level::info))) {
-
+  if (buffer_not_large_enough || offload_not_fast_enough) {
     std::stringstream msg;
-    msg << AIE_TS2MM_WARN_MSG_CIRC_BUF
-        << " Minimum required offload rate (trace buffer bytes/sec) : " << circ_buf_min_rate_plio
-        << " Requested rate : " << circ_buf_cur_rate_plio
-        << ". Minimum required trace buffer bytes : " << AIE_MIN_SIZE_CIRCULAR_BUF
-        << " Requested bytes : " << bufAllocSz;
-    xrt_core::message::send(xrt_core::message::severity_level::info, "XRT", msg.str());
+    msg << AIE_TRACE_BUF_REUSE_WARN
+        << " Recommended offload rate (trace buffer bytes/sec) : " << circ_buf_min_rate_plio
+        << " Requested : " << circ_buf_cur_rate_plio ;
+    xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", msg.str());
   }
-
-  debug_stream
-    << "Circular buffer support : " << mEnCircularBuf
-    << " Min Rate : " << circ_buf_min_rate_plio
-    << " Cur Rate : " << circ_buf_cur_rate_plio
-    << " offloadIntervalUs : " << offloadIntervalUs
-    << " bufAllocSz : " << bufAllocSz
-    << std::endl;
 }
 
 void AIETraceOffload::startOffload()

--- a/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.h
+++ b/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.h
@@ -132,9 +132,10 @@ private:
 
     //Circular Buffer Tracking
     bool mEnCircularBuf;
+    bool mCircularBufOverwrite;
     // 1000 mb of trace per second
     // Very high bandwidth requirement
-    uint64_t circ_buf_min_rate_plio = TS2MM_DEF_BUF_SIZE * 1000;
+    uint64_t circ_buf_min_rate_plio = AIE_CIR_BUF_MIN_RATE_PLIO;
     uint64_t circ_buf_cur_rate_plio;
 
 private:

--- a/src/runtime_src/xdp/profile/device/tracedefs.h
+++ b/src/runtime_src/xdp/profile/device/tracedefs.h
@@ -73,13 +73,18 @@ buffer size and/or reduce trace_buffer_offload_interval."
 #define TS2MM_WARN_MSG_QUEUE_SZ        "Too much trace in processing queue. This could have negative impact on host memory utilization. \
 Please increase trace_buffer_size and trace_buffer_offload_interval together or use 'coarse' option for device_trace."
 
-// Minimum of 1MB per offloader for circular buffer to be enabled
-#define AIE_MIN_SIZE_CIRCULAR_BUF      0x100000
+// Throw warning if less than 8M is used or rate is less than 8 GB/S
+#define AIE_MIN_SIZE_CIRCULAR_BUF 0x800000
+#define AIE_CIR_BUF_MIN_RATE_PLIO 0x200000000
 
-#define AIE_TS2MM_WARN_MSG_BUF_FULL             "AIE Trace Buffer is full. Device trace could be incomplete."
-#define AIE_TS2MM_WARN_MSG_CIRC_BUF_OVERWRITE   "Circular buffer overwrite was detected in device trace. AIE trace could be incomplete."
-#define AIE_TS2MM_WARN_MSG_CIRC_BUF             "AIE trace will be limited to trace buffer size due to insufficient trace offload rate. Please increase \
-aie_trace_buffer_size and/or reduce aie_trace_buffer_offload_interval_us."
+#define AIE_TS2MM_WARN_MSG_BUF_FULL           "AIE Trace Buffer is full. Device trace could be incomplete."
+#define AIE_TS2MM_WARN_MSG_CIRC_BUF_OVERWRITE "Circular buffer overwrite was detected in device trace. AIE trace could be incomplete."
+#define AIE_TRACE_BUF_REUSE_WARN              "AIE trace reuse setting may lead to buffer overrun. Please increase \
+aie_trace_buffer_size and/or reduce aie_trace_buffer_offload_interval_us. Recommended (min) trace buffer size per stream : \
+functions : 8M functions_partial_stalls : 16M functions_all_stalls 32M. For large AIE designs, use granular \
+trace settings."
+#define AIE_TRACE_WARN_REUSE_PERIODIC  "AIE Trace Buffer reuse only supported with periodic offload."
+#define AIE_TRACE_WARN_REUSE_GMIO      "AIE Trace buffer reuse is not supported on GMIO trace."
 
 // Trace file Dump Settings and Warnings
 #define MIN_TRACE_DUMP_INTERVAL_S 1

--- a/src/runtime_src/xdp/profile/writer/aie_trace/aie_trace_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/aie_trace/aie_trace_writer.cpp
@@ -100,7 +100,7 @@ namespace xdp {
 
       // Free the memory immediately if we own it
       if (traceData->owner)
-        std::free(traceData->buffer[j]);
+        delete[] (traceData->buffer[j]);
     }
     fout << std::endl;
     delete traceData;

--- a/src/runtime_src/xdp/profile/writer/aie_trace/aie_trace_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/aie_trace/aie_trace_writer.cpp
@@ -83,7 +83,7 @@ namespace xdp {
 
     size_t num = traceData->buffer.size();
     for (size_t j = 0; j < num; j++) {
-      void*    buf = traceData->buffer[j].get();
+      void*    buf = traceData->buffer[j];
       // We write 4 bytes at a time
       // Max chunk size should be multiple of 4
       // If last chunk is not multiple of 4 then in worst case, 
@@ -98,8 +98,9 @@ namespace xdp {
       for (uint64_t i = 0; i < bufferSz; i++)
         fout << "0x" << std::hex << dataBuffer[i] << std::endl;
 
-      // Free the memory immediately
-      traceData->buffer[j].reset();
+      // Free the memory immediately if we own it
+      if (traceData->owner)
+        std::free(traceData->buffer[j]);
     }
     fout << std::endl;
     delete traceData;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Use a dedicated switch to control use of circular buffer in aie trace
Copy trace buffer data only when trace buffer reuse is enabled
Use better messaging for runtime guidance
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
NA
#### How problem was solved, alternative solutions (if any) and why they were rejected
NA
#### Risks (if any) associated the changes in the commit
Medium risk
Comment: Some of these switches will be moved to AIE_trace_settings section as a part of general cleanup
#### What has been tested and how, request additional testing if necessary
Tested on Tx chain 8 Antenna Design
#### Documentation impact (if any)
