### PR TITLE
Update default XILINX_XRT for Windows and remove 'bin' folder requirement

### DIFF
--- a/src/CMake/nativeWin.cmake
+++ b/src/CMake/nativeWin.cmake
@@ -54,7 +54,7 @@ INCLUDE (FindGTest)
 
 # --- XRT Variables ---
 set (XRT_INSTALL_DIR "xrt")
-set (XRT_INSTALL_BIN_DIR       "${XRT_INSTALL_DIR}/bin")
+set (XRT_INSTALL_BIN_DIR       "${XRT_INSTALL_DIR}")
 set (XRT_INSTALL_UNWRAPPED_DIR "${XRT_INSTALL_BIN_DIR}/unwrapped")
 set (XRT_INSTALL_INCLUDE_DIR   "${XRT_INSTALL_DIR}/include")
 set (XRT_INSTALL_LIB_DIR       "${XRT_INSTALL_DIR}/lib")

--- a/src/runtime_src/core/common/module_loader.cpp
+++ b/src/runtime_src/core/common/module_loader.cpp
@@ -101,6 +101,8 @@ xilinx_xrt()
   if (xrt.empty()){
 #if defined (__aarch64__) || defined (__arm__)
     xrt = bfs::path("/usr");
+#elif defined (_WIN32)
+    xrt = bfs::path("C:/Windows/System32/AMD");
 #else
     throw std::runtime_error("XILINX_XRT not set");
 #endif
@@ -114,7 +116,7 @@ module_path(const std::string& module)
 {
   auto path = xilinx_xrt();
 #ifdef _WIN32
-  path /= "bin/" + module + ".dll";
+  path /= module + ".dll";
 #else
   path /= "lib/xrt/module/lib" + module + ".so";
 #endif
@@ -133,7 +135,7 @@ shim_path()
   auto name = shim_name();
 
 #ifdef _WIN32
-  path /= "bin/" + name + ".dll";
+  path /= name + ".dll";
 #else
   path /= "lib/lib" + name + ".so." + XRT_VERSION_MAJOR;
 #endif

--- a/src/runtime_src/tools/scripts/loader.bat
+++ b/src/runtime_src/tools/scripts/loader.bat
@@ -4,7 +4,7 @@ setlocal
 REM SPDX-License-Identifier: Apache-2.0
 REM Copyright (C) 2019-2021 Xilinx, Inc. All rights reserved.
 
-REM Working Variables 
+REM Working Variables
 set XRT_EXEC=""
 set XRT_UNWRAPPED_DIR=%~dp0
 
@@ -17,12 +17,12 @@ set XRT_LOADER_ARGS=
       goto argsParsed
     ) else (
       REM exec option
-      if [%1] == [-exec] ( 
+      if [%1] == [-exec] (
         set XRT_EXEC=%2
         shift
         shift
       ) else (
-      if [%1] == [--exec] ( 
+      if [%1] == [--exec] (
         set XRT_EXEC=%2
         shift
         shift
@@ -49,7 +49,7 @@ if not exist %XRT_PROG_UNWRAPPED% (
 )
 
 REM -- Find the setup script and configure environment
-set XRT_SETUP_SCRIPT=%XRT_UNWRAPPED_DIR%..\..\setup.bat
+set XRT_SETUP_SCRIPT=%XRT_UNWRAPPED_DIR%..\setup.bat
 
 if not exist %XRT_SETUP_SCRIPT% (
   echo ERROR: Could not find XRT setup script.

--- a/src/runtime_src/tools/scripts/setup.bat
+++ b/src/runtime_src/tools/scripts/setup.bat
@@ -9,7 +9,7 @@ REM be sourced from that location
 
 set XILINX_XRT=%~dp0
 
-set PATH=%XILINX_XRT%\bin;%XILINX_XRT%\ext\bin;%PATH%
+set PATH=%XILINX_XRT%;%XILINX_XRT%\ext\bin;%PATH%
 
 echo XILINX_XRT      : %XILINX_XRT%
 echo PATH            : %PATH%


### PR DESCRIPTION
#### Problem solved by the commit
On Windows, users are required to define a XILINX_XRT environment variable because there is no default path. The XRT dlls are also required to be located in a subfolder named "bin". These requirements aren't always well-known and have often tripped up developers. On Linux, a default path for XILINX_XRT is already defined.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Set default path for XILINX_XRT to point to C:\Windows\System32\AMD on Windows
Remove the requirement for a "bin" folder, and expect the XRT dlls to reside directly at XILINX_XRT instead
