### PR TITLE
Fix 1133474 : Use old aie_profile/trace metrics configurations if none of the new style metrics are present

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.cpp
@@ -341,7 +341,7 @@ namespace xdp {
     return numFreeCtr;
   }
 
-  std::string AIEProfilingPlugin::getMetricSet(const XAie_ModuleType mod, const std::string& metricsStr)
+  std::string AIEProfilingPlugin::getMetricSet(const XAie_ModuleType mod, const std::string& metricsStr, bool ignoreOldConfig)
   {
     std::vector<std::string> vec;
 
@@ -376,6 +376,9 @@ namespace xdp {
       std::stringstream msg;
       msg << "Unable to find " << moduleName << " metric set " << metricSet
           << ". Using default of " << defaultSet << ".";
+      if (ignoreOldConfig) {
+        msg << " As new AIE_profile_settings section is given, old style metric configurations, if any, are ignored.";
+      }
       xrt_core::message::send(severity_level::warning, "XRT", msg.str());
       metricSet = defaultSet;
     }
@@ -1017,8 +1020,9 @@ namespace xdp {
 
     std::string moduleNames[NUM_MODULES] = {"core", "memory", "interface tile"};
 
+    bool newConfigUsed = false;
     for(int module = 0; module < NUM_MODULES; ++module) {
-      if (metricsConfig.empty()){
+      if (metricsConfig[module].empty()){
 #if 0
 // No need to add the warning message here, as all the tests are using configs under Debug
         std::string modName = moduleNames[module].substr(0, moduleNames[module].find(" "));
@@ -1028,7 +1032,13 @@ namespace xdp {
 #endif
         continue;
       }
+      newConfigUsed = true;
       boost::split(metricsSettings[module], metricsConfig[module], boost::is_any_of(";"));
+    }
+
+    if (!newConfigUsed) {
+      // None of the new style AIE profile metrics have been used. So check for old style.
+      return false;
     }
 
     // Get AIE clock frequency
@@ -1063,7 +1073,7 @@ namespace xdp {
         int NUM_COUNTERS       = numCounters[module];
         XAie_ModuleType mod    = falModuleTypes[module];
         std::string moduleName = moduleNames[module];
-        auto metricSet         = getMetricSet(mod, metricsStr);
+        auto metricSet         = getMetricSet(mod, metricsStr, true);
         auto tiles             = getTilesForProfiling(mod, metricsStr, handle);
 
 

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.cpp
@@ -1021,8 +1021,8 @@ namespace xdp {
     std::string moduleNames[NUM_MODULES] = {"core", "memory", "interface tile"};
 
     bool newConfigUsed = false;
-    for(int module = 0; module < NUM_MODULES; ++module) {
-      if (metricsConfig[module].empty()){
+    for (int module = 0; module < NUM_MODULES; ++module) {
+      if (metricsConfig[module].empty()) {
 #if 0
 // No need to add the warning message here, as all the tests are using configs under Debug
         std::string modName = moduleNames[module].substr(0, moduleNames[module].find(" "));
@@ -1068,7 +1068,7 @@ namespace xdp {
     // Configure core, memory, and shim counters
     for (int module=0; module < NUM_MODULES; ++module) {
 
-      for(auto &metricsStr : metricsSettings[module]) { 
+      for (auto &metricsStr : metricsSettings[module]) { 
 
         int NUM_COUNTERS       = numCounters[module];
         XAie_ModuleType mod    = falModuleTypes[module];

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.h
@@ -63,7 +63,8 @@ namespace xdp {
     bool checkAieDevice(uint64_t deviceId, void* handle);
 
     std::string getMetricSet(const XAie_ModuleType mod, 
-                             const std::string& metricsStr);
+                             const std::string& metricsStr,
+                             bool  ignoreOldConfig = false);
     std::vector<tile_type> getTilesForProfiling(const XAie_ModuleType mod,
                                                 const std::string& metricsStr,
                                                 void* handle);

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.h
@@ -75,7 +75,7 @@ namespace xdp {
       bool configureStartIteration(xaiefal::XAieMod& core);
 
       // Utility functions
-      std::string getMetricSet(void* handle, const std::string& metricStr);
+      std::string getMetricSet(void* handle, const std::string& metricStr, bool ignoreOldConfig = false);
       std::vector<tile_type> getTilesForTracing(void* handle);
 
     private:


### PR DESCRIPTION
CR 1133474 reports warning about use of default metrics from new style AIE_profile_settings processing, even if xrt.ini contains old style aie_profile_<>_metrics.
When both new and old style metrics configurations are present in xrt.ini, the new style configs are given precedence, if at least one new style metric is specified. If only a single new style, say core_metrics, is given, the assumption is user wants to use new style configuration. So, default value for other metrics will be used, instead of checking for old style metric configuration. However, there will be a warning about use of default value.
The old style profile/trace configuration will be used/processed only if xrt.ini does not contain any new style profile/trace configuration.