### PR TITLE
CR-1132010 Move PS kernel return code to the end of command packet

### DIFF
--- a/src/runtime_src/core/include/ert.h
+++ b/src/runtime_src/core/include/ert.h
@@ -137,12 +137,38 @@ struct ert_start_kernel_cmd {
   };
 
   /* payload */
-  union {
-    uint32_t cu_mask;          /* mandatory cu mask */
-    int32_t return_code;       /* return code from soft kernel*/
-  };
+  uint32_t cu_mask;          /* mandatory cu mask */
   uint32_t data[1];            /* count-1 number of words */
 };
+
+#ifndef U30_DEBUG
+#define ert_write_return_code(cmd, value) \
+do { \
+  struct ert_start_kernel_cmd *skcmd = (struct ert_start_kernel_cmd *)cmd; \
+  int end_idx = skcmd->count - 1 - skcmd->extra_cu_masks; \
+  skcmd->data[end_idx] = value; \
+} while (0)
+
+#define ert_read_return_code(cmd, ret) \
+do { \
+  struct ert_start_kernel_cmd *skcmd = (struct ert_start_kernel_cmd *)cmd; \
+  int end_idx = skcmd->count - 1 - skcmd->extra_cu_masks; \
+  ret = skcmd->data[end_idx]; \
+} while (0)
+#else
+/* These are for debug legacy U30 firmware */
+#define ert_write_return_code(cmd, value) \
+do { \
+  struct ert_start_kernel_cmd *skcmd = (struct ert_start_kernel_cmd *)cmd; \
+  skcmd->cu_mask = value; \
+} while (0)
+
+#define ert_read_return_code(cmd, ret) \
+do { \
+  struct ert_start_kernel_cmd *skcmd = (struct ert_start_kernel_cmd *)cmd; \
+  ret = skcmd->cu_mask; \
+} while (0)
+#endif
 
 /**
  * struct ert_init_kernel_cmd: ERT initialize kernel command format

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -401,7 +401,7 @@ static void notify_execbuf(struct kds_command *xcmd, int status)
 		scmd = (struct ert_start_kernel_cmd *)ecmd;
 		if (scmd->state < ERT_CMD_STATE_COMPLETED)
 			/* It is old shell, return code is missing */
-			scmd->return_code = -ENODATA;
+			ert_write_return_code(scmd, -ENODATA);
 		status = scmd->state;
 	} else {
 		if (xcmd->opcode == OP_GET_STAT)
@@ -458,7 +458,7 @@ static void notify_execbuf_xgq(struct kds_command *xcmd, int status)
 		struct ert_start_kernel_cmd *scmd;
 
 		scmd = (struct ert_start_kernel_cmd *)ecmd;
-		scmd->return_code = xcmd->rcode;
+		ert_write_return_code(scmd, xcmd->rcode);
 
 		client_stat_inc(client, scu_c_cnt[xcmd->cu_idx]);
 	}

--- a/src/xma/src/xmaapi/xma_utils.cpp
+++ b/src/xma/src/xmaapi/xma_utils.cpp
@@ -583,8 +583,10 @@ int32_t check_all_execbo(XmaSession s_handle) {
                         priv1->CU_cmds.erase(ebo.cu_cmd_id1);
                         priv1->num_cu_cmds--;
                     } else if (cu_state == ERT_CMD_STATE_SKERROR) {
+                        uint32_t return_code;
                         //If PS Kernel error, add cmd obj to CU_error_cmds map; Right now this is only for PS Kernels
-                        xma_logmsg(XMA_ERROR_LOG, XMAUTILS_MOD, "Session id: %d, type: %s, PS Kernel error code: %d", s_handle.session_id, xma_core::get_session_name(s_handle.session_type).c_str(), cu_cmd_pkt->return_code);
+                        ert_read_return_code(cu_cmd_pkt, return_code);
+                        xma_logmsg(XMA_ERROR_LOG, XMAUTILS_MOD, "Session id: %d, type: %s, PS Kernel error code: %d", s_handle.session_id, xma_core::get_session_name(s_handle.session_type).c_str(), return_code);
                         if (s_handle.session_type < XMA_ADMIN) {
                             priv1->kernel_complete_count++;
                             priv1->kernel_complete_total++;
@@ -595,7 +597,7 @@ int32_t check_all_execbo(XmaSession s_handle) {
                         auto itr_tmp1 = priv1->CU_error_cmds.emplace(ebo.cu_cmd_id1, std::move(priv1->CU_cmds[ebo.cu_cmd_id1]));
                         priv1->CU_cmds.erase(ebo.cu_cmd_id1);
                         itr_tmp1.first->second.cmd_finished = true;
-                        itr_tmp1.first->second.return_code = cu_cmd_pkt->return_code;
+                        itr_tmp1.first->second.return_code = return_code;
                         itr_tmp1.first->second.cmd_state = xma_cmd_state::psk_error;
                         priv1->num_cu_cmds--;
                     } else if (cu_state == ERT_CMD_STATE_ERROR ||
@@ -652,8 +654,10 @@ int32_t check_all_execbo(XmaSession s_handle) {
                         //priv1->execbo_lru.emplace_back(val);Let's not reuse execbo immediately after completion
                         ebo_it = priv1->execbo_to_check.erase(ebo_it);
                     } else if (cu_state == ERT_CMD_STATE_SKERROR) {
+                        uint32_t return_code;
                         //If PS Kernel error, add cmd obj to CU_error_cmds map; Right now this is only for PS Kernels
-                        xma_logmsg(XMA_ERROR_LOG, XMAUTILS_MOD, "Session id: %d, type: %s, PS Kernel error code: %d", s_handle.session_id, xma_core::get_session_name(s_handle.session_type).c_str(), cu_cmd_pkt->return_code);
+                        ert_read_return_code(cu_cmd_pkt, return_code);
+                        xma_logmsg(XMA_ERROR_LOG, XMAUTILS_MOD, "Session id: %d, type: %s, PS Kernel error code: %d", s_handle.session_id, xma_core::get_session_name(s_handle.session_type).c_str(), return_code);
                         if (s_handle.session_type < XMA_ADMIN) {
                             priv1->kernel_complete_count++;
                             priv1->kernel_complete_total++;
@@ -665,7 +669,7 @@ int32_t check_all_execbo(XmaSession s_handle) {
                         auto itr_tmp1 = priv1->CU_error_cmds.emplace(ebo.cu_cmd_id1, std::move(priv1->CU_cmds[ebo.cu_cmd_id1]));
                         priv1->CU_cmds.erase(ebo.cu_cmd_id1);
                         itr_tmp1.first->second.cmd_finished = true;
-                        itr_tmp1.first->second.return_code = cu_cmd_pkt->return_code;
+                        itr_tmp1.first->second.return_code = return_code;
                         itr_tmp1.first->second.cmd_state = xma_cmd_state::psk_error;
                         priv1->num_cu_cmds--;
                         ebo_it = priv1->execbo_to_check.erase(ebo_it);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Return code will override cu_mask.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Jeff point this out. This doesn't work well with PS kernel

#### How problem was solved, alternative solutions (if any) and why they were rejected
Move PS kernel return code to the end of command package
Add write/read macro for return code

#### Risks (if any) associated the changes in the commit
This is not a compatible change on U30 shell. After this change, if XRT doesn't work with legacy U30 firmware.
If someone want to use XRT after this change with U30, the firmware must be updated.

#### What has been tested and how, request additional testing if necessary
U50 xbutil validate

#### Documentation impact (if any)
No