### PR TITLE
VITIS-5847 Resilient VMR - add task,mem stats

### DIFF
--- a/src/runtime_src/core/include/xgq_cmd_vmr.h
+++ b/src/runtime_src/core/include/xgq_cmd_vmr.h
@@ -100,6 +100,8 @@ enum xgq_cmd_log_page_type {
 	XGQ_CMD_LOG_INFO	= 0x2,
 	XGQ_CMD_LOG_AF_CLEAR	= 0x3,
 	XGQ_CMD_LOG_ENDPOINT	= 0x4,
+	XGQ_CMD_LOG_TASK_STATS  = 0x5,
+	XGQ_CMD_LOG_MEM_STATS	= 0x6,
 };
 
 /**

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
@@ -1191,6 +1191,18 @@ static int vmr_endpoint_info_query(struct platform_device *pdev,
 	return vmr_info_query_op(pdev, buf, cnt, XGQ_CMD_LOG_ENDPOINT);
 }
 
+static int vmr_task_info_query(struct platform_device *pdev,
+	char *buf, size_t *cnt)
+{
+	return vmr_info_query_op(pdev, buf, cnt, XGQ_CMD_LOG_TASK_STATS);
+}
+
+static int vmr_memory_info_query(struct platform_device *pdev,
+	char *buf, size_t *cnt)
+{
+	return vmr_info_query_op(pdev, buf, cnt, XGQ_CMD_LOG_MEM_STATS);
+}
+
 /* On versal, verify is enforced. */
 static int xgq_freq_scaling(struct platform_device *pdev,
 	unsigned short *freqs, int num_freqs, int verify)
@@ -1957,7 +1969,6 @@ static ssize_t vmr_verbose_info_show(struct device *dev,
 	struct xocl_xgq_vmr *xgq = platform_get_drvdata(to_platform_device(dev));
 	ssize_t cnt = 0;
 
-	/* update boot status */
 	if (vmr_verbose_info_query(xgq->xgq_pdev, buf, &cnt))
 		return -EINVAL;
 
@@ -1971,13 +1982,38 @@ static ssize_t vmr_endpoint_show(struct device *dev,
 	struct xocl_xgq_vmr *xgq = platform_get_drvdata(to_platform_device(dev));
 	ssize_t cnt = 0;
 
-	/* update boot status */
 	if (vmr_endpoint_info_query(xgq->xgq_pdev, buf, &cnt))
 		return -EINVAL;
 
 	return cnt;
 }
 static DEVICE_ATTR_RO(vmr_endpoint);
+
+static ssize_t vmr_task_stats_show(struct device *dev,
+	struct device_attribute *attr, char *buf)
+{
+	struct xocl_xgq_vmr *xgq = platform_get_drvdata(to_platform_device(dev));
+	ssize_t cnt = 0;
+
+	if (vmr_task_info_query(xgq->xgq_pdev, buf, &cnt))
+		return -EINVAL;
+
+	return cnt;
+}
+static DEVICE_ATTR_RO(vmr_task_stats);
+
+static ssize_t vmr_mem_stats_show(struct device *dev,
+	struct device_attribute *attr, char *buf)
+{
+	struct xocl_xgq_vmr *xgq = platform_get_drvdata(to_platform_device(dev));
+	ssize_t cnt = 0;
+
+	if (vmr_memory_info_query(xgq->xgq_pdev, buf, &cnt))
+		return -EINVAL;
+
+	return cnt;
+}
+static DEVICE_ATTR_RO(vmr_mem_stats);
 
 static ssize_t vmr_debug_type_store(struct device *dev,
 	struct device_attribute *attr, const char *buf, size_t count)
@@ -2009,6 +2045,8 @@ static struct attribute *xgq_attrs[] = {
 	&dev_attr_vmr_status.attr,
 	&dev_attr_vmr_verbose_info.attr,
 	&dev_attr_vmr_endpoint.attr,
+	&dev_attr_vmr_task_stats.attr,
+	&dev_attr_vmr_mem_stats.attr,
 	&dev_attr_program_sc.attr,
 	&dev_attr_vmr_debug_level.attr,
 	&dev_attr_vmr_debug_dump.attr,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
add rtos task and memory stats

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
VITIS-5847
#### How problem was solved, alternative solutions (if any) and why they were rejected
using freertos API to get human-readable task and memory stats 
#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary

[root@xsjyliu51 ~]# cat /sys/bus/pci/devices/0000\:d9\:00.0/xgq_vmr.m.54525953/vmr_task_stats 
Name                 State   Priority        Stack   UniqNum
XGQ Opera        X       1       65186   6
IDLE                   R       0       172     2
SC Common     B       1       65310   8
XGQ Recei        B       1       65452   4
Sensor Mo        B       1       65340   7
XGQ Progr        B       1       65456   5
Tmr Svc            B       7       364     3

[root@xsjyliu51 ~]# cat /sys/bus/pci/devices/0000\:d9\:00.0/xgq_vmr.m.54525953/vmr_mem_stats 
Available heap size: 233558184
Max size of free blocks in bytes: 233295720
Min size of free blocks in bytes: 216
Num of free blocks: 3
Min amount of free blocks since system booted: 233295936
Num of successful pvPortMalloc: 159
Num of successful pvPortFree: 5

#### Documentation impact (if any)
https://confluence.xilinx.com/pages/viewpage.action?pageId=302345261