### PR TITLE
Modified to refer the single MMap file to allocate the device memory …

### DIFF
--- a/src/runtime_src/core/edge/common_em/rpc_messages.proto
+++ b/src/runtime_src/core/edge/common_em/rpc_messages.proto
@@ -404,7 +404,15 @@ message xclSetupInstance_call {
 }
 
 message xclSetupInstance_response {
-  optional bool success =1;
+  optional bool success = 1;
+}
+
+message swemuDriverVersion_call {
+  required string version = 1;
+}
+
+message swemuDriverVersion_response {
+  optional bool success = 1;
 }
 
 //messages for SSPM IP

--- a/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/shim.cxx
@@ -603,6 +603,15 @@ namespace xclcpuemhal2 {
     }
   }
 
+  void CpuemShim::setDriverVersion(const std::string& version)
+  {
+    bool success = false;
+    swemuDriverVersion_RPC_CALL(swemuDriverVersion, version);
+
+    if (mLogStream.is_open())
+      mLogStream << __func__ << " success " << success << std::endl;
+  }
+
   int CpuemShim::xclLoadXclBin(const xclBin *header)
   {
     if (mLogStream.is_open()) mLogStream << __func__ << " begin " << std::endl;
@@ -821,7 +830,10 @@ namespace xclcpuemhal2 {
       bool verbose = false;
       if(mLogStream.is_open())
         verbose = true;
+
+      setDriverVersion("2.0");
       xclLoadBitstream_RPC_CALL(xclLoadBitstream,xmlFile,tempdlopenfilename,deviceDirectory,binaryDirectory,verbose);
+
       if(!ack)
         return -1;
     }

--- a/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/shim.h
@@ -85,6 +85,7 @@ namespace xclcpuemhal2 {
 
       //Configuration
       void socketConnection(bool isTCPSocket);
+      void setDriverVersion(const std::string& version);
       void xclOpen(const char* logfileName);
       int xclLoadXclBin(const xclBin *buffer);
       int xclLoadXclBinNewFlow(const xclBin *buffer);

--- a/src/runtime_src/core/include/xcl_api_macros.h
+++ b/src/runtime_src/core/include/xcl_api_macros.h
@@ -72,13 +72,13 @@ std::lock_guard<std::mutex> socketlk{mtx};
     auto c_len = c_msg.ByteSizeLong();                                  \
     buf_size = alloc_void(c_len);                                       \
     bool rv = c_msg.SerializeToArray(buf,c_len);                        \
-    if(rv == false){std::cerr<<"FATAL ERROR:protobuf SerializeToArray failed"<<std::endl;exit(1);} \
+    if (rv == false) { std::cerr<<"FATAL ERROR:protobuf SerializeToArray failed" << std::endl; exit(1); } \
                                                                         \
     ci_msg.set_size(c_len);                                             \
     ci_msg.set_xcl_api(func_name##_n);                                  \
     auto ci_len = ci_msg.ByteSizeLong();                                \
     rv = ci_msg.SerializeToArray(ci_buf,ci_len);                        \
-    if(rv == false){std::cerr<<"FATAL ERROR:protobuf SerializeToArray failed"<<std::endl;exit(1);} \
+    if (rv == false) { std::cerr<<"FATAL ERROR:protobuf SerializeToArray failed" << std::endl; exit(1); } \
                                                                         \
     _s_inst->sk_write(ci_buf,ci_len);                                   \
     _s_inst->sk_write(buf,c_len);                                       \
@@ -1037,3 +1037,16 @@ std::lock_guard<std::mutex> socketlk{mtx};
     SERIALIZE_AND_SEND_MSG(func_name)\
     xclLoadXclbinContent_SET_PROTO_RESPONSE(); \
     xclLoadXclbinContent_RETURN();
+
+#define swemuDriverVersion_SET_PROTOMESSAGE(version) \
+  c_msg.set_version(version);
+
+#define swemuDriverVersion_SET_PROTO_RESPONSE() \
+  success = r_msg.success();
+
+#define swemuDriverVersion_RPC_CALL(func_name, version) \
+  RPC_PROLOGUE(func_name);                              \
+  swemuDriverVersion_SET_PROTOMESSAGE(version);         \
+  SERIALIZE_AND_SEND_MSG(func_name)                     \
+  swemuDriverVersion_SET_PROTO_RESPONSE();              
+

--- a/src/runtime_src/core/include/xcl_macros.h
+++ b/src/runtime_src/core/include/xcl_macros.h
@@ -82,5 +82,6 @@
 #define xclCopyBOFromFd_n 50
 #define xclRegWrite_n 51
 #define xclRegRead_n 52
+#define swemuDriverVersion_n 53
 
 #endif

--- a/src/runtime_src/core/pcie/emulation/common_em/em_defines.h
+++ b/src/runtime_src/core/pcie/emulation/common_em/em_defines.h
@@ -169,7 +169,15 @@ namespace xclemulation {
 
   static inline bool is_cacheable(const struct drm_xocl_bo *bo) {
     return (bo->flags & XCL_BO_FLAGS_CACHEABLE);
-  }  
+  }
+
+  //API which denotes whether the sync of data is required or not
+  static inline bool is_zero_copy(const struct drm_xocl_bo *bo) {
+    bool isCacheable = xclemulation::is_cacheable(bo);
+    bool memCheck = xclemulation::no_host_memory(bo) || xclemulation::xocl_bo_host_only(bo);
+    bool zeroCopy = (memCheck || !isCacheable) ? true : false;
+    return zeroCopy;
+  }
 }
 
 /**

--- a/src/runtime_src/core/pcie/emulation/common_em/rpc_messages.proto
+++ b/src/runtime_src/core/pcie/emulation/common_em/rpc_messages.proto
@@ -422,6 +422,14 @@ message xclSetupInstance_response {
   optional bool success =1;
 }
 
+message swemuDriverVersion_call {
+  required string version = 1;
+}
+
+message swemuDriverVersion_response {
+  optional bool success = 1;
+}
+
 //messages for SSPM IP
 message xclPerfMonReadCounters_Streaming_call {
   required string slotname = 1;

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
@@ -18,32 +18,36 @@
 #define DEBUG_MSGS(format, ...)
 //#define DEBUG_MSGS(format, ...) printf(format, ##__VA_ARGS__)
 
-namespace xclcpuemhal2 {
-
-  std::map<unsigned int, CpuemShim*> devices;
+namespace xclcpuemhal2
+{
+  std::map<unsigned int, CpuemShim *> devices;
   unsigned int CpuemShim::mBufferCount = 0;
   unsigned int GraphType::mGraphHandle = 0;
-  std::map<int, std::tuple<std::string, uint64_t, void*> > CpuemShim::mFdToFileNameMap;
+  std::map<int, std::tuple<std::string, uint64_t, void *>> CpuemShim::mFdToFileNameMap;
   bool CpuemShim::mFirstBinary = true;
   const unsigned CpuemShim::TAG = 0X586C0C6C; // XL OpenCL X->58(ASCII), L->6C(ASCII), O->0 C->C L->6C(ASCII);
   const unsigned CpuemShim::CONTROL_AP_START = 1;
-  const unsigned CpuemShim::CONTROL_AP_DONE  = 2;
-  const unsigned CpuemShim::CONTROL_AP_IDLE  = 4;
+  const unsigned CpuemShim::CONTROL_AP_DONE = 2;
+  const unsigned CpuemShim::CONTROL_AP_IDLE = 4;
   const unsigned CpuemShim::CONTROL_AP_CONTINUE = 0x10;
   constexpr unsigned int simulationWaitTime = 300;
 
   std::map<std::string, std::string> CpuemShim::mEnvironmentNameValueMap(xclemulation::getEnvironmentByReadingIni());
 
   namespace bf = boost::filesystem;
-#define PRINTENDFUNC if (mLogStream.is_open()) mLogStream << __func__ << " ended " << std::endl;
+#define PRINTENDFUNC        \
+  if (mLogStream.is_open()) \
+    mLogStream << __func__ << " ended " << std::endl;
 
-  CpuemShim::CpuemShim(unsigned int deviceIndex, xclDeviceInfo2 &info, std::list<xclemulation::DDRBank>& DDRBankList, bool _unified, bool _xpr,
-    FeatureRomHeader& fRomHeader, const boost::property_tree::ptree& platformData)
-    :mTag(TAG)
-    ,mRAMSize(info.mDDRSize)
-    ,mCoalesceThreshold(4)
-    ,mDeviceIndex(deviceIndex)
-    ,mIsDeviceProcessStarted(false)
+  CpuemShim::CpuemShim(unsigned int deviceIndex, 
+                       xclDeviceInfo2 &info, 
+                       std::list<xclemulation::DDRBank> &DDRBankList, 
+                       bool _unified, 
+                       bool _xpr,
+                       FeatureRomHeader &fRomHeader, 
+                       const boost::property_tree::ptree &platformData)
+              : mTag(TAG), mRAMSize(info.mDDRSize), mCoalesceThreshold(4), 
+	      mDeviceIndex(deviceIndex), mIsDeviceProcessStarted(false)
   {
     binaryCounter = 0;
     mReqCounter = 0;
@@ -68,8 +72,8 @@ namespace xclcpuemhal2 {
     buf = nullptr;
     buf_size = 0;
 
-    deviceName = "device"+std::to_string(deviceIndex);
-    deviceDirectory = xclemulation::getRunDirectory() + "/"+std::to_string(getpid())+"/sw_emu/"+deviceName;
+    deviceName = "device" + std::to_string(deviceIndex);
+    deviceDirectory = xclemulation::getRunDirectory() + "/" + std::to_string(getpid()) + "/sw_emu/" + deviceName;
     simulator_started = false;
     mVerbosity = XCL_INFO;
 
@@ -77,16 +81,16 @@ namespace xclcpuemhal2 {
     constructQueryTable();
 
     std::memset(&mDeviceInfo, 0, sizeof(xclDeviceInfo2));
-    fillDeviceInfo(&mDeviceInfo,&info);
+    fillDeviceInfo(&mDeviceInfo, &info);
     initMemoryManager(DDRBankList);
 
     std::memset(&mFeatureRom, 0, sizeof(FeatureRomHeader));
     std::memcpy(&mFeatureRom, &fRomHeader, sizeof(FeatureRomHeader));
 
-    char* pack_size = getenv("SW_EMU_PACKET_SIZE");
-    if(pack_size)
+    char *pack_size = getenv("SW_EMU_PACKET_SIZE");
+    if (pack_size)
     {
-      unsigned int messageSize = strtoll(pack_size,NULL,0);
+      unsigned int messageSize = strtoll(pack_size, NULL, 0);
       message_size = messageSize;
     }
     else
@@ -109,7 +113,7 @@ namespace xclcpuemhal2 {
     if (buf_size < new_size)
     {
       void *temp = buf;
-      buf = (void*) realloc(temp,new_size);
+      buf = (void*)realloc(temp, new_size);
       if (!buf) // prevent leak of original buf
         free(temp);
       return new_size;
@@ -117,22 +121,22 @@ namespace xclcpuemhal2 {
     return buf_size;
   }
 
-  void CpuemShim::initMemoryManager(std::list<xclemulation::DDRBank>& DDRBankList)
+  void CpuemShim::initMemoryManager(std::list<xclemulation::DDRBank> &DDRBankList)
   {
     std::list<xclemulation::DDRBank>::iterator start = DDRBankList.begin();
     std::list<xclemulation::DDRBank>::iterator end = DDRBankList.end();
     uint64_t base = 0;
-    for(;start != end; start++)
+    for (; start != end; start++)
     {
       const uint64_t bankSize = (*start).ddrSize;
       mDdrBanks.push_back(*start);
       //CR 966701: alignment to 4k (instead of mDeviceInfo.mDataAlignment)
-      mDDRMemoryManager.push_back(new xclemulation::MemoryManager(bankSize, base , getpagesize()));
+      mDDRMemoryManager.push_back(new xclemulation::MemoryManager(bankSize, base, getpagesize()));
       base += bankSize;
     }
   }
 
-//private
+  //private
   bool CpuemShim::isGood() const
   {
     // TODO: Add sanity check for card state
@@ -146,29 +150,29 @@ namespace xclcpuemhal2 {
       return 0;
     if (*(unsigned *)handle != TAG)
       return 0;
-    if (!((CpuemShim *)handle)->isGood()) {
+    if (!((CpuemShim *)handle)->isGood())
       return 0;
-    }
+    
     return (CpuemShim *)handle;
   }
 
   static void saveDeviceProcessOutputs()
   {
-    std::map<unsigned int, CpuemShim*>::iterator start = devices.begin();
-    std::map<unsigned int, CpuemShim*>::iterator end = devices.end();
-    for(; start != end; start++)
+    std::map<unsigned int, CpuemShim *>::iterator start = devices.begin();
+    std::map<unsigned int, CpuemShim *>::iterator end = devices.end();
+    for (; start != end; start++)
     {
-      CpuemShim* handle = (*start).second;
-      if(!handle)
+      CpuemShim *handle = (*start).second;
+      if (!handle)
         continue;
       handle->saveDeviceProcessOutput();
     }
-
   }
 
   static void sigHandler(int sn, siginfo_t *si, void *sc)
   {
-    switch (sn) {
+    switch (sn)
+    {
     case SIGSEGV:
       saveDeviceProcessOutputs();
       kill(0, SIGSEGV);
@@ -201,33 +205,35 @@ namespace xclcpuemhal2 {
     }
   }
 
-  int CpuemShim::dumpXML(const xclBin* header, std::string& fileLocation)
+  int CpuemShim::dumpXML(const xclBin *header, std::string &fileLocation)
   {
-    if (!header) return 0 ; // We didn't dump it, but this isn't an error
+    if (!header)
+      return 0; // We didn't dump it, but this isn't an error
 
-    char* xclbininmemory =
-      reinterpret_cast<char*>(const_cast<xclBin*>(header)) ;
+    char *xclbininmemory =
+        reinterpret_cast<char *>(const_cast<xclBin *>(header));
 
-    char* xmlfile = nullptr ;
-    int xmllength = 0 ;
+    char *xmlfile = nullptr;
+    int xmllength = 0;
 
     if (memcmp(xclbininmemory, "xclbin0", 8) == 0)
     {
-       if (mLogStream.is_open())
-       {
-	   mLogStream << __func__ << " unsupported Legacy XCLBIN header " << std::endl;
-       }
-       return -1;
+      if (mLogStream.is_open())
+      {
+        mLogStream << __func__ << " unsupported Legacy XCLBIN header " << std::endl;
+      }
+      return -1;
 
       //xmlfile = xclbininmemory + (header->m_metadataOffset) ;
       //xmllength = (int)(header->m_metadataLength);
     }
-    else if (memcmp(xclbininmemory,"xclbin2",7) == 0)
+    else if (memcmp(xclbininmemory, "xclbin2", 7) == 0)
     {
-      auto top = reinterpret_cast<const axlf*>(header);
-      if (auto sec = xclbin::get_axlf_section(top,EMBEDDED_METADATA)) {
-	xmlfile = xclbininmemory + sec->m_sectionOffset;
-	xmllength = sec->m_sectionSize;
+      auto top = reinterpret_cast<const axlf *>(header);
+      if (auto sec = xclbin::get_axlf_section(top, EMBEDDED_METADATA))
+      {
+        xmlfile = xclbininmemory + sec->m_sectionOffset;
+        xmllength = sec->m_sectionSize;
       }
     }
     else
@@ -235,9 +241,9 @@ namespace xclcpuemhal2 {
       // This was not a valid xclbin file
       if (mLogStream.is_open())
       {
-	mLogStream << __func__ << " invalid XCLBIN header " << std::endl;
+        mLogStream << __func__ << " invalid XCLBIN header " << std::endl;
       }
-      return -1 ;
+      return -1;
     }
 
     if (xmlfile == nullptr || xmllength == 0)
@@ -245,87 +251,87 @@ namespace xclcpuemhal2 {
       // This xclbin file did not contain any XML meta-data
       if (mLogStream.is_open())
       {
-	mLogStream << __func__ << " XCLBIN did not contain meta-data"
-		   << std::endl ;
+        mLogStream << __func__ << " XCLBIN did not contain meta-data"
+                   << std::endl;
       }
-      return -1 ;
+      return -1;
     }
 
     // First, create the device directory if it doesn't exist
     systemUtil::makeSystemCall(deviceDirectory,
-			       systemUtil::systemOperation::CREATE) ;
+                               systemUtil::systemOperation::CREATE);
     // Second, create the binary directory if it doesn't exist
-    std::stringstream binaryDirectory ;
-    binaryDirectory << deviceDirectory << "/binary_" << binaryCounter ;
-    std::string binDir = binaryDirectory.str() ;
+    std::stringstream binaryDirectory;
+    binaryDirectory << deviceDirectory << "/binary_" << binaryCounter;
+    std::string binDir = binaryDirectory.str();
     systemUtil::makeSystemCall(binDir,
-			       systemUtil::systemOperation::CREATE) ;
+                               systemUtil::systemOperation::CREATE);
     systemUtil::makeSystemCall(binDir,
-			       systemUtil::systemOperation::PERMISSIONS,
-			       "777") ;
+                               systemUtil::systemOperation::PERMISSIONS,
+                               "777");
 
     // The XML file will exist in this binary directory
-    fileLocation = binDir + "/xmltmp" ;
+    fileLocation = binDir + "/xmltmp";
 
     // Keep appending underscore to the file name until we find
     //  a file that does not exist.
-    bool foundName = false ;
+    bool foundName = false;
     while (!foundName)
     {
-      FILE* fp = fopen(fileLocation.c_str(), "rb") ;
+      FILE *fp = fopen(fileLocation.c_str(), "rb");
       if (fp == NULL)
       {
-	// The file does not exist, so we can use this file location
-	foundName = true ;
+        // The file does not exist, so we can use this file location
+        foundName = true;
       }
       else
       {
-	// The name we've chosen already exists, so append an underscore
-	//  and try again
-	fclose(fp) ;
-	fileLocation += "_" ;
+        // The name we've chosen already exists, so append an underscore
+        //  and try again
+        fclose(fp);
+        fileLocation += "_";
       }
     }
 
     // The file name we've chosen does not exist, so attempt to
     //  open it for writing
-    FILE* fp = fopen(fileLocation.c_str(), "wb") ;
-    if(fp==NULL)
+    FILE *fp = fopen(fileLocation.c_str(), "wb");
+    if (fp == NULL)
     {
       if (mLogStream.is_open())
       {
-	mLogStream << __func__ << " failed to create temporary xml file " << std::endl;
+        mLogStream << __func__ << " failed to create temporary xml file " << std::endl;
       }
       return -1;
     }
-    fwrite(xmlfile,xmllength,1,fp);
+    fwrite(xmlfile, xmllength, 1, fp);
     fflush(fp);
     fclose(fp);
 
-    return 0 ;
+    return 0;
   }
 
-  bool CpuemShim::parseIni(unsigned int& debugPort)
+  bool CpuemShim::parseIni(unsigned int &debugPort)
   {
-    debugPort = xclemulation::config::getInstance()->getServerPort() ;
+    debugPort = xclemulation::config::getInstance()->getServerPort();
     if (debugPort == 0)
     {
-      return false ;
+      return false;
     }
-    return true ;
+    return true;
   }
 
-  void CpuemShim::launchDeviceProcess(bool debuggable, std::string& binaryDirectory)
+  void CpuemShim::launchDeviceProcess(bool debuggable, std::string &binaryDirectory)
   {
     std::lock_guard<std::mutex> lk(mProcessLaunchMtx);
     systemUtil::makeSystemCall(deviceDirectory, systemUtil::systemOperation::CREATE);
     std::stringstream ss1;
-    ss1<<deviceDirectory<<"/binary_"<<binaryCounter;
+    ss1 << deviceDirectory << "/binary_" << binaryCounter;
     binaryDirectory = ss1.str();
     systemUtil::makeSystemCall(binaryDirectory, systemUtil::systemOperation::CREATE);
     systemUtil::makeSystemCall(binaryDirectory, systemUtil::systemOperation::PERMISSIONS, "777");
     binaryCounter++;
-    if(sock)
+    if (sock)
     {
       return;
     }
@@ -335,7 +341,7 @@ namespace xclcpuemhal2 {
     s.sa_flags = SA_SIGINFO;
     s.sa_sigaction = sigHandler;
     if (sigaction(SIGSEGV, &s, (struct sigaction *)0) ||
-        sigaction(SIGFPE , &s, (struct sigaction *)0) ||
+        sigaction(SIGFPE, &s, (struct sigaction *)0) ||
         sigaction(SIGABRT, &s, (struct sigaction *)0) ||
         sigaction(SIGUSR1, &s, (struct sigaction *)0) ||
         sigaction(SIGCHLD, &s, (struct sigaction *)0))
@@ -346,26 +352,26 @@ namespace xclcpuemhal2 {
     // We also need to check the .ini file in order to determine
     //  if the dynamic port on the sdx_server the child process
     //  must connect to was specified
-    unsigned int debugPort = 0 ;
-    bool passPort = parseIni(debugPort) ;
-    std::stringstream portStream ;
-    portStream << debugPort ;
+    unsigned int debugPort = 0;
+    bool passPort = parseIni(debugPort);
+    std::stringstream portStream;
+    portStream << debugPort;
 
     // If debuggable, the child process also requires the PID of the parent (us)
-    pid_t parentPid = getpid() ;
-    std::stringstream pidStream ;
-    pidStream << parentPid ;
+    pid_t parentPid = getpid();
+    std::stringstream pidStream;
+    pidStream << parentPid;
 
     // Spawn off the process to run the stub
     bool simDontRun = xclemulation::config::getInstance()->isDontRun();
-    if(!simDontRun)
+    if (!simDontRun)
     {
       std::stringstream socket_id;
       std::stringstream aiesim_sock_id;
       socket_id << deviceName << "_" << binaryCounter << "_" << getpid();
       aiesim_sock_id << deviceName << "_aiesim" << binaryCounter << "_" << getpid();
-      setenv("EMULATION_SOCKETID",socket_id.str().c_str(),true);
-      setenv("AIESIM_SOCKETID",aiesim_sock_id.str().c_str(),true);
+      setenv("EMULATION_SOCKETID", socket_id.str().c_str(), true);
+      setenv("AIESIM_SOCKETID", aiesim_sock_id.str().c_str(), true);
 
       pid_t pid = fork();
       assert(pid >= 0);
@@ -376,14 +382,12 @@ namespace xclcpuemhal2 {
 
         //Added the latest ENV to get the install path
         char *vitisInstallEnvvar = getenv("XILINX_VITIS");
-        if (vitisInstallEnvvar != NULL) {
+        if (vitisInstallEnvvar != NULL)
           xilinxInstall = std::string(vitisInstallEnvvar);
-        }
-
-        char *scoutInstallEnvvar =  getenv("XILINX_SCOUT");
-        if(scoutInstallEnvvar != NULL && xilinxInstall.empty() ){
+        
+        char *scoutInstallEnvvar = getenv("XILINX_SCOUT");
+        if (scoutInstallEnvvar != NULL && xilinxInstall.empty())
           xilinxInstall = std::string(scoutInstallEnvvar);
-        }
 
         char *installEnvvar = getenv("XILINX_SDX");
         if (installEnvvar != NULL && xilinxInstall.empty())
@@ -410,14 +414,14 @@ namespace xclcpuemhal2 {
           std::string sLdLibs("");
           std::string DS("/");
           std::string sPlatform("lnx64");
-          char* sLdLib = getenv("LD_LIBRARY_PATH");
+          char *sLdLib = getenv("LD_LIBRARY_PATH");
           if (sLdLib)
             sLdLibs = std::string(sLdLib) + ":";
-          sLdLibs += sHlsBinDir +  DS + sPlatform + DS + "tools" + DS + "fft_v9_1" + ":";
-          sLdLibs += sHlsBinDir +  DS + sPlatform + DS + "tools" + DS + "fir_v7_0" + ":";
-          sLdLibs += sHlsBinDir +  DS + sPlatform + DS + "tools" + DS + "fpo_v7_0" + ":";
-          sLdLibs += sHlsBinDir +  DS + sPlatform + DS + "tools" + DS + "dds_v6_0" + ":";
-          sLdLibs += sHlsBinDir +  DS + sPlatform + DS + "tools" + DS + "opencv"   + ":";
+          sLdLibs += sHlsBinDir + DS + sPlatform + DS + "tools" + DS + "fft_v9_1" + ":";
+          sLdLibs += sHlsBinDir + DS + sPlatform + DS + "tools" + DS + "fir_v7_0" + ":";
+          sLdLibs += sHlsBinDir + DS + sPlatform + DS + "tools" + DS + "fpo_v7_0" + ":";
+          sLdLibs += sHlsBinDir + DS + sPlatform + DS + "tools" + DS + "dds_v6_0" + ":";
+          sLdLibs += sHlsBinDir + DS + sPlatform + DS + "tools" + DS + "opencv" + ":";
           sLdLibs += sHlsBinDir + DS + sPlatform + DS + "lib" + DS + "csim" + ":";
           sLdLibs += sHlsBinDir + DS + "lib" + DS + "lnx64.o" + DS + "Default" + DS + ":";
           sLdLibs += sHlsBinDir + DS + "lib" + DS + "lnx64.o" + DS + ":";
@@ -427,21 +431,22 @@ namespace xclcpuemhal2 {
           sLdLibs += sVitisBinDir + DS + "tps" + DS + "lnx64" + DS + "python-3.8.3" + DS + "lib" + DS + ":";
           sLdLibs += sVitisBinDir + DS + "lib" + DS + "lnx64.o" + DS;
 
-          setenv("LD_LIBRARY_PATH",sLdLibs.c_str(),true);
+          setenv("LD_LIBRARY_PATH", sLdLibs.c_str(), true);
         }
 
-        if (xilinxInstall.empty()) {
+        if (xilinxInstall.empty())
+        {
           std::cerr << "ERROR : [SW-EM 10] Please make sure that the XILINX_VITIS environment variable is set correctly" << std::endl;
           exit(1);
         }
 
         std::string modelDirectory("");
 #if defined(RDIPF_aarch64)
-        modelDirectory= xilinxInstall + "/data/emulation/unified/cpu_em/zynqu/model/genericpciemodel";
+        modelDirectory = xilinxInstall + "/data/emulation/unified/cpu_em/zynqu/model/genericpciemodel";
 #elif defined(RDIPF_arm64)
-        modelDirectory= xilinxInstall + "/data/emulation/unified/cpu_em/zynq/model/genericpciemodel";
+        modelDirectory = xilinxInstall + "/data/emulation/unified/cpu_em/zynq/model/genericpciemodel";
 #else
-        modelDirectory= xilinxInstall + "/data/emulation/unified/cpu_em/generic_pcie/model/genericpciemodel";
+        modelDirectory = xilinxInstall + "/data/emulation/unified/cpu_em/generic_pcie/model/genericpciemodel";
 #endif
 
         FILE *filep;
@@ -457,24 +462,23 @@ namespace xclcpuemhal2 {
           exit(1);
         }
 
-        const char* childArgv[6] = { NULL, NULL, NULL, NULL, NULL, NULL } ;
-        childArgv[0] = modelDirectory.c_str() ;
+        const char *childArgv[6] = {NULL, NULL, NULL, NULL, NULL, NULL};
+        childArgv[0] = modelDirectory.c_str();
 
         // If we determined this should be debuggable, pass the proper
         //  arguments to the process
         if (debuggable)
         {
-          childArgv[1] = "-debug" ;
-          childArgv[2] = "-ppid" ;
-          childArgv[3] = pidStream.str().c_str() ;
+          childArgv[1] = "-debug";
+          childArgv[2] = "-ppid";
+          childArgv[3] = pidStream.str().c_str();
 
           if (passPort)
           {
-            childArgv[4] = "-port" ;
-            childArgv[5] = portStream.str().c_str() ;
+            childArgv[4] = "-port";
+            childArgv[5] = portStream.str().c_str();
           }
         }
-
 
         int r = 0;
 
@@ -483,7 +487,7 @@ namespace xclcpuemhal2 {
           std::cout << "INFO : "
                     << "SW_EMU Kernel debug enabled in GDB." << std::endl;
           std::string commandStr = "/usr/bin/gdb -args " + modelDirectory + "; csh";
-          r = execl("/usr/bin/xterm", "/usr/bin/xterm", "-hold", "-T", "SW_EMU Kernel Debug", "-geometry", "120x80", "-fa", "Monospace", "-fs", "14", "-e", "csh", "-c", commandStr.c_str(), (void *)NULL);
+          r = execl("/usr/bin/xterm", "/usr/bin/xterm", "-hold", "-T", "SW_EMU Kernel Debug", "-geometry", "120x80", "-fa", "Monospace", "-fs", "14", "-e", "csh", "-c", commandStr.c_str(), (void*)NULL);
         }
         else
         {
@@ -493,22 +497,29 @@ namespace xclcpuemhal2 {
         }
 
         //fclose (stdout);
-        if(r == -1){std::cerr << "FATAL ERROR : child process did not launch" << std::endl; exit(1);}
+        if (r == -1)
+        {
+          std::cerr << "FATAL ERROR : child process did not launch" << std::endl;
+          exit(1);
+        }
         exit(0);
       }
     }
     sock = new unix_socket("EMULATION_SOCKETID");
   }
 
-  void CpuemShim::getCuRangeIdx() {
+  void CpuemShim::getCuRangeIdx()
+  {
     std::string instance_name = "";
-    for (const auto& kernel : m_xclbin.get_kernels()) {
+    for (const auto& kernel : m_xclbin.get_kernels())
+    {
       // get properties of each kernel object
       const auto& props = xrt_core::xclbin_int::get_properties(kernel);
       //get CU's of each kernel object.iterate over CU's to get arguments
       if (props.address_range != 0 && !props.name.empty())
         continue;
-      for (const auto& cu : kernel.get_cus()) {
+      for (const auto& cu : kernel.get_cus())
+      {
         instance_name = cu.get_name();
         if (!instance_name.empty())
           mCURangeMap[instance_name] = props.address_range;
@@ -522,13 +533,24 @@ namespace xclcpuemhal2 {
     return lpath;
   }
 
+  void CpuemShim::setDriverVersion(const std::string& version)
+  {
+    bool success = false;
+    swemuDriverVersion_RPC_CALL(swemuDriverVersion, version);
+
+    if (mLogStream.is_open())
+      mLogStream << __func__ << " success " << success << std::endl;
+  }
+
   int CpuemShim::xclLoadXclBin(const xclBin *header)
   {
-    if(mLogStream.is_open()) mLogStream << __func__ << " begin " << std::endl;
+    if (mLogStream.is_open())
+      mLogStream << __func__ << " begin " << std::endl;
 
-    std::string xmlFile = "" ;
-    int result = dumpXML(header, xmlFile) ;
-    if (result != 0) return result ;
+    std::string xmlFile = "";
+    int result = dumpXML(header, xmlFile);
+    if (result != 0)
+      return result;
 
     // Before we spawn off the child process, we must determine
     //  if the process will be debuggable or not.  We get that
@@ -536,19 +558,19 @@ namespace xclcpuemhal2 {
     //  the xclbin file.  Note, this only works with xclbin2
     //  files.  Also, the GUI can overwrite this by setting an
     //  environment variable
-    bool debuggable = false ;
+    bool debuggable = false;
     if (getenv("ENABLE_KERNEL_DEBUG") != NULL &&
-	strcmp("true", getenv("ENABLE_KERNEL_DEBUG")) == 0)
+        strcmp("true", getenv("ENABLE_KERNEL_DEBUG")) == 0)
     {
-      char* xclbininmemory =
-        reinterpret_cast<char*>(const_cast<xclBin*>(header)) ;
+      char *xclbininmemory =
+          reinterpret_cast<char *>(const_cast<xclBin *>(header));
       if (!memcmp(xclbininmemory, "xclbin2", 7))
       {
-        auto top = reinterpret_cast<const axlf*>(header) ;
-        auto sec = xclbin::get_axlf_section(top, DEBUG_DATA) ;
+        auto top = reinterpret_cast<const axlf *>(header);
+        auto sec = xclbin::get_axlf_section(top, DEBUG_DATA);
         if (sec)
         {
-          debuggable = true ;
+          debuggable = true;
         }
       }
     }
@@ -561,23 +583,25 @@ namespace xclcpuemhal2 {
     if (boost::filesystem::exists(extIoTxtFile))
       boost::filesystem::remove(extIoTxtFile);
 
-    launchDeviceProcess(debuggable,binaryDirectory);
+    launchDeviceProcess(debuggable, binaryDirectory);
 
-    if (header) {
+    if (header)
+    {
       resetProgram();
       std::string logFilePath = xrt_core::config::get_hal_logging();
-      if (!logFilePath.empty()) {
+      if (!logFilePath.empty())
+      {
         mLogStream.open(logFilePath);
         mLogStream << "FUNCTION, THREAD ID, ARG..." << std::endl;
         mLogStream << __func__ << ", " << std::this_thread::get_id() << std::endl;
       }
 
-      if( mFirstBinary )
+      if (mFirstBinary)
       {
         mFirstBinary = false;
       }
 
-      char *xclbininmemory = reinterpret_cast<char*> (const_cast<xclBin*> (header));
+      char *xclbininmemory = reinterpret_cast<char *>(const_cast<xclBin *>(header));
 
       //parse header
       char *sharedlib = nullptr;
@@ -598,27 +622,32 @@ namespace xclcpuemhal2 {
         }
         return -1;
       }
-      else if (!memcmp(xclbininmemory,"xclbin2",7)) {
-        auto top = reinterpret_cast<const axlf*>(header);
-	m_xclbin = xrt::xclbin{top};
-        if (auto sec = xclbin::get_axlf_section(top,BITSTREAM)) {
+      else if (!memcmp(xclbininmemory, "xclbin2", 7))
+      {
+        auto top = reinterpret_cast<const axlf *>(header);
+        m_xclbin = xrt::xclbin{top};
+        if (auto sec = xclbin::get_axlf_section(top, BITSTREAM))
+        {
           sharedlib = xclbininmemory + sec->m_sectionOffset;
           sharedliblength = sec->m_sectionSize;
         }
-        if (auto sec = xrt_core::xclbin::get_axlf_section(top, ASK_GROUP_TOPOLOGY)) {
+        if (auto sec = xrt_core::xclbin::get_axlf_section(top, ASK_GROUP_TOPOLOGY))
+        {
           memTopologySize = sec->m_sectionSize;
           memTopology = std::unique_ptr<char[]>(new char[memTopologySize]);
           memcpy(memTopology.get(), xclbininmemory + sec->m_sectionOffset, memTopologySize);
         }
         //Extract EMULATION_DATA from XCLBIN
-        if (auto sec = xrt_core::xclbin::get_axlf_section(top, EMULATION_DATA)) {
+        if (auto sec = xrt_core::xclbin::get_axlf_section(top, EMULATION_DATA))
+        {
           emuDataSize = sec->m_sectionSize;
           emuData = std::unique_ptr<char[]>(new char[emuDataSize]);
           memcpy(emuData.get(), xclbininmemory + sec->m_sectionOffset, emuDataSize);
           getCuRangeIdx();
         }
-	      //Extract CONNECTIVITY section from XCLBIN
-        if (auto sec = xrt_core::xclbin::get_axlf_section(top, CONNECTIVITY)) {
+        //Extract CONNECTIVITY section from XCLBIN
+        if (auto sec = xrt_core::xclbin::get_axlf_section(top, CONNECTIVITY))
+        {
           connectvitybufsize = sec->m_sectionSize;
           connectvitybuf = std::unique_ptr<char[]>(new char[connectvitybufsize]);
           memcpy(connectvitybuf.get(), xclbininmemory + sec->m_sectionOffset, connectvitybufsize);
@@ -629,19 +658,19 @@ namespace xclcpuemhal2 {
         if (mLogStream.is_open())
         {
           mLogStream << __func__ << " invalid XCLBIN header " << std::endl;
-          mLogStream << __func__ << " header " << xclbininmemory[0] << xclbininmemory[1] << xclbininmemory[2] <<  xclbininmemory[3] <<
-            xclbininmemory[4] << xclbininmemory[5] << std::endl;
+          mLogStream << __func__ << " header " << xclbininmemory[0] << xclbininmemory[1] << xclbininmemory[2] << xclbininmemory[3] << xclbininmemory[4] << xclbininmemory[5] << std::endl;
         }
         return -1;
       }
       //write out shared library to file for consumption with dlopen
-      std::string tempdlopenfilename = binaryDirectory+"/dltmp";
+      std::string tempdlopenfilename = binaryDirectory + "/dltmp";
       {
         bool tempfilecreated = false;
         unsigned int counter = 0;
-        while( !tempfilecreated ) {
-          FILE *fp = fopen(tempdlopenfilename.c_str(),"rb");
-          if(fp==NULL)
+        while (!tempfilecreated)
+        {
+          FILE *fp = fopen(tempdlopenfilename.c_str(), "rb");
+          if (fp == NULL)
           {
             tempfilecreated = true;
           }
@@ -650,57 +679,58 @@ namespace xclcpuemhal2 {
             fclose(fp);
             std::stringstream ss;
             ss << std::hex << counter;
-            tempdlopenfilename+=ss.str();
-            counter = counter+1;
+            tempdlopenfilename += ss.str();
+            counter = counter + 1;
           }
         }
-        FILE *fp = fopen(tempdlopenfilename.c_str(),"wb");
-        if( !fp )
+        FILE *fp = fopen(tempdlopenfilename.c_str(), "wb");
+        if (!fp)
         {
-          if(mLogStream.is_open()) mLogStream << __func__ << " failed to create temporary dlopen file" << std::endl;
+          if (mLogStream.is_open())
+            mLogStream << __func__ << " failed to create temporary dlopen file" << std::endl;
           return -1;
         }
-        fwrite(sharedlib,sharedliblength,1,fp);
+        fwrite(sharedlib, sharedliblength, 1, fp);
         fflush(fp);
         fclose(fp);
       }
       if (memTopology && connectvitybuf)
       {
-        auto m_mem = (reinterpret_cast<const ::mem_topology*>(memTopology.get()));
-        auto m_conn = (reinterpret_cast<const ::connectivity*>(connectvitybuf.get()));
+        auto m_mem = (reinterpret_cast<const ::mem_topology *>(memTopology.get()));
+        auto m_conn = (reinterpret_cast<const ::connectivity *>(connectvitybuf.get()));
         if (m_mem && m_conn)
         {
           //uint64_t argNum = 0;
           uint64_t prev_instanceBaseAddr = ULLONG_MAX;
-          std::map<uint64_t, std::pair<uint64_t,std::string> > argFlowIdMap;
-          for (int32_t conn_idx = 0; conn_idx<m_conn->m_count; ++conn_idx)
+          std::map<uint64_t, std::pair<uint64_t, std::string>> argFlowIdMap;
+          for (int32_t conn_idx = 0; conn_idx < m_conn->m_count; ++conn_idx)
           {
             int32_t memdata_idx = m_conn->m_connection[conn_idx].mem_data_index;
-            if (memdata_idx >(m_mem->m_count - 1))
+            if (memdata_idx > (m_mem->m_count - 1))
               return -1;
             uint64_t route_id = m_mem->m_mem_data[memdata_idx].route_id;
             uint64_t arg_id = m_conn->m_connection[conn_idx].arg_index;
-            uint64_t flow_id = m_mem->m_mem_data[memdata_idx].flow_id;//base address + flow_id combo
+            uint64_t flow_id = m_mem->m_mem_data[memdata_idx].flow_id; //base address + flow_id combo
             uint64_t instanceBaseAddr = 0xFFFF0000 & flow_id;
             if (mLogStream.is_open())
               mLogStream << __func__ << " flow_id : " << flow_id << " route_id : " << route_id << " inst addr : " << instanceBaseAddr << " arg_id : " << arg_id << std::endl;
-            if(prev_instanceBaseAddr != ULLONG_MAX && instanceBaseAddr != prev_instanceBaseAddr)
+            if (prev_instanceBaseAddr != ULLONG_MAX && instanceBaseAddr != prev_instanceBaseAddr)
             {
               //RPC CALL
               bool success = false;
-              xclSetupInstance_RPC_CALL(xclSetupInstance, prev_instanceBaseAddr , argFlowIdMap);
+              xclSetupInstance_RPC_CALL(xclSetupInstance, prev_instanceBaseAddr, argFlowIdMap);
 
-              if(mLogStream.is_open())
-                mLogStream << __func__ << " setup instance: " << prev_instanceBaseAddr <<" success "<< success << std::endl;
+              if (mLogStream.is_open())
+                mLogStream << __func__ << " setup instance: " << prev_instanceBaseAddr << " success " << success << std::endl;
 
               argFlowIdMap.clear();
               //argNum = 0;
             }
-            if(m_mem->m_mem_data[memdata_idx].m_type == MEM_TYPE::MEM_STREAMING)
+            if (m_mem->m_mem_data[memdata_idx].m_type == MEM_TYPE::MEM_STREAMING)
             {
-              std::string m_tag (reinterpret_cast<const char*>(m_mem->m_mem_data[memdata_idx].m_tag));
-              std::pair<uint64_t,std::string> mPair;
-              mPair.first  = flow_id;
+              std::string m_tag(reinterpret_cast<const char *>(m_mem->m_mem_data[memdata_idx].m_tag));
+              std::pair<uint64_t, std::string> mPair;
+              mPair.first = flow_id;
               mPair.second = m_tag;
               argFlowIdMap[arg_id] = mPair;
               //argFlowIdMap[argNum] = mPair;
@@ -711,8 +741,8 @@ namespace xclcpuemhal2 {
           bool success = false;
           xclSetupInstance_RPC_CALL(xclSetupInstance, prev_instanceBaseAddr, argFlowIdMap);
 
-          if(mLogStream.is_open())
-            mLogStream << __func__ << " setup instance: " << prev_instanceBaseAddr <<" success "<< success << std::endl;
+          if (mLogStream.is_open())
+            mLogStream << __func__ << " setup instance: " << prev_instanceBaseAddr << " success " << success << std::endl;
         }
       }
 
@@ -727,7 +757,8 @@ namespace xclcpuemhal2 {
       }
 
       //Extract EMULATION_DATA from XCLBIN
-      if (emuData && (emuDataSize > 1)) {
+      if (emuData && (emuDataSize > 1))
+      {
         isVersal = true;
         std::string emuDataFilePath = binaryDirectory + "/emuDataFile";
         std::ofstream os(emuDataFilePath);
@@ -739,31 +770,34 @@ namespace xclcpuemhal2 {
 
       bool ack = true;
       bool verbose = false;
-      if ( mLogStream.is_open() ) {
+      if (mLogStream.is_open())
+      {
         verbose = true;
       }
 
       mIsDeviceProcessStarted = true;
       if (!mMessengerThread.joinable())
-        mMessengerThread = std::thread([this] { messagesThread(); });
-
+        mMessengerThread = std::thread([this]
+                                       { messagesThread(); });
+      
+      setDriverVersion("2.0");
       xclLoadBitstream_RPC_CALL(xclLoadBitstream, xmlFile, tempdlopenfilename, deviceDirectory, binaryDirectory, verbose);
-      if (!ack) {
+      if (!ack)
         return -1;
-      }
+
     }
 
-    if (isVersal) {
+    if (isVersal)
+    {
       std::string aieLibSimPath = binaryDirectory + "/aie/aie.libsim";
       bf::path fp(aieLibSimPath);
 
       // Setting the aiesim_sock to null when we have the aie.libsim which is ideally generated only for the x86sim target
       // This determines the whether we are running the sw_emu interacting with the x86sim process or the aiesim process
-      if (bf::exists(fp) && !bf::is_empty(fp)) {
+      if (bf::exists(fp) && !bf::is_empty(fp))
         aiesim_sock = nullptr;
-      } else {
+      else
         aiesim_sock = new unix_socket("AIESIM_SOCKETID");
-      }
     }
 
     return 0;
@@ -772,7 +806,7 @@ namespace xclcpuemhal2 {
   int CpuemShim::xclGetDeviceInfo2(xclDeviceInfo2 *info)
   {
     std::memset(info, 0, sizeof(xclDeviceInfo2));
-    fillDeviceInfo(info,&mDeviceInfo);
+    fillDeviceInfo(info, &mDeviceInfo);
     for (auto i : mDDRMemoryManager)
     {
       info->mDDRFreeSize += i->freeSize();
@@ -783,80 +817,76 @@ namespace xclcpuemhal2 {
   void CpuemShim::launchTempProcess()
   {
     std::string binaryDirectory("");
-    launchDeviceProcess(false,binaryDirectory);
+    launchDeviceProcess(false, binaryDirectory);
     std::string xmlFile("");
     std::string tempdlopenfilename("");
     SHIM_UNUSED bool ack = true;
     bool verbose = false;
-    if(mLogStream.is_open())
+    if (mLogStream.is_open())
       verbose = true;
-    xclLoadBitstream_RPC_CALL(xclLoadBitstream,xmlFile,tempdlopenfilename,deviceDirectory,binaryDirectory,verbose);
+    xclLoadBitstream_RPC_CALL(xclLoadBitstream, xmlFile, tempdlopenfilename, deviceDirectory, binaryDirectory, verbose);
   }
 
   uint64_t CpuemShim::xclAllocDeviceBuffer(size_t size)
   {
 
-    size_t requestedSize =  size;
-    if (mLogStream.is_open()) {
+    size_t requestedSize = size;
+    if (mLogStream.is_open())
       mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << size << std::endl;
-    }
-    if(!sock)
-    {
+    
+    if (!sock)
       launchTempProcess();
-    }
 
     if (size == 0)
       size = DDR_BUFFER_ALIGNMENT;
 
     uint64_t result = xclemulation::MemoryManager::mNull;
-    for (auto i : mDDRMemoryManager) {
+    for (auto i : mDDRMemoryManager)
+    {
       result = i->alloc(size);
       if (result != xclemulation::MemoryManager::mNull)
         break;
     }
     bool ack = false;
     //   Memory Manager Has allocated aligned address,
-	//   size contains alignement + original size requested.
-	//   We are passing original size to device process for exact stats.
+    //   size contains alignement + original size requested.
+    //   We are passing original size to device process for exact stats.
     bool noHostMemory = false;
     std::string sFileName("");
-    xclAllocDeviceBuffer_RPC_CALL(xclAllocDeviceBuffer,result,requestedSize,noHostMemory);
-    if(!ack)
+    xclAllocDeviceBuffer_RPC_CALL(xclAllocDeviceBuffer, result, requestedSize, noHostMemory);
+    if (!ack)
     {
       PRINTENDFUNC;
       return 0;
     }
-      PRINTENDFUNC;
+    PRINTENDFUNC;
     return result;
   }
 
-  uint64_t CpuemShim::xclAllocDeviceBuffer2(size_t& size, xclMemoryDomains domain, unsigned flags, bool zeroCopy, std::string &sFileName)
+  uint64_t CpuemShim::xclAllocDeviceBuffer2(size_t &size, xclMemoryDomains domain, unsigned flags, bool zeroCopy, std::string &sFileName)
   {
-    if (mLogStream.is_open()) {
-      mLogStream << __func__ << " , "<<std::this_thread::get_id() << ", " << size <<", "<<domain<<", "<< flags << std::endl;
-    }
+    if (mLogStream.is_open())
+      mLogStream << __func__ << " , " << std::this_thread::get_id() << ", " << size << ", " << domain << ", " << flags << std::endl;
 
     DEBUG_MSGS("%s, %d(size: %zx flags: %x)\n", __func__, __LINE__, size, flags);
 
-    if(!sock) {
+    if (!sock)
       launchTempProcess();
-    }
 
     //flags = flags % 32;
-    if (domain != XCL_MEM_DEVICE_RAM) {
+    if (domain != XCL_MEM_DEVICE_RAM)
       return xclemulation::MemoryManager::mNull;
-    }
 
     if (size == 0)
       size = DDR_BUFFER_ALIGNMENT;
 
-    if (flags >= mDDRMemoryManager.size()) {
+    if (flags >= mDDRMemoryManager.size())
       return xclemulation::MemoryManager::mNull;
-    }
 
     uint64_t result = mDDRMemoryManager[flags]->alloc(size);
 
-    if (result == xclemulation::MemoryManager::mNull) {
+    if (result == xclemulation::MemoryManager::mNull)
+    {
       auto ddrSize = mDDRMemoryManager[flags]->size();
       std::string ddrSizeStr = std::to_string(ddrSize);
       std::string initMsg = "ERROR: [SW-EM 12] OutOfMemoryError : Requested Global memory size exceeds DDR limit 16 GB.";
@@ -870,7 +900,8 @@ namespace xclcpuemhal2 {
     // We are passing original size to device process for exact stats.
     xclAllocDeviceBuffer_RPC_CALL(xclAllocDeviceBuffer, result, size, zeroCopy);
 
-    if(!ack) {
+    if (!ack)
+    {
       PRINTENDFUNC;
       return 0;
     }
@@ -882,21 +913,22 @@ namespace xclcpuemhal2 {
 
   void CpuemShim::xclFreeDeviceBuffer(uint64_t offset)
   {
-    if (mLogStream.is_open()) {
+    if (mLogStream.is_open())
       mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << offset << std::endl;
-    }
 
-    for (auto i : mDDRMemoryManager) {
-      if (offset < i->start() + i->size()) {
+    for (auto i : mDDRMemoryManager)
+    {
+      if (offset < i->start() + i->size())
+      {
         i->free(offset);
       }
     }
     bool ack = true;
-    if(sock)
+    if (sock)
     {
-      xclFreeDeviceBuffer_RPC_CALL(xclFreeDeviceBuffer,offset);
+      xclFreeDeviceBuffer_RPC_CALL(xclFreeDeviceBuffer, offset);
     }
-    if(!ack)
+    if (!ack)
     {
       PRINTENDFUNC;
       return;
@@ -908,33 +940,38 @@ namespace xclcpuemhal2 {
   size_t CpuemShim::xclWrite(xclAddressSpace space, uint64_t offset, const void *hostBuf, size_t size)
   {
     std::lock_guard<std::mutex> lk(mApiMtx);
-    if (mLogStream.is_open()) {
-      mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << offset<<", "<<hostBuf<<", "<< size<<std::endl;
-    }
+    if (mLogStream.is_open())
+      mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << offset << ", " << hostBuf << ", " << size << std::endl;
 
-    if(!sock)
+    if (!sock)
       return size;
 
-    if(space != XCL_ADDR_KERNEL_CTRL) {
-      if (mLogStream.is_open()) mLogStream << "xclWrite called with xclAddressSpace != XCL_ADDR_KERNEL_CTRL " << std::endl;
+    if (space != XCL_ADDR_KERNEL_CTRL)
+    {
+      if (mLogStream.is_open())
+        mLogStream << "xclWrite called with xclAddressSpace != XCL_ADDR_KERNEL_CTRL " << std::endl;
       return -1;
     }
 
-    if(size%4) {
-      if (mLogStream.is_open()) mLogStream << "xclWrite only supports 32-bit writes" << std::endl;
+    if (size % 4)
+    {
+      if (mLogStream.is_open())
+        mLogStream << "xclWrite only supports 32-bit writes" << std::endl;
       return -1;
     }
 
     fflush(stdout);
-    xclWriteAddrKernelCtrl_RPC_CALL(xclWriteAddrKernelCtrl,space,offset,hostBuf,size,kernelArgsInfo,0,0);
+    xclWriteAddrKernelCtrl_RPC_CALL(xclWriteAddrKernelCtrl, space, offset, hostBuf, size, kernelArgsInfo, 0, 0);
     PRINTENDFUNC;
     return size;
   }
 
-  bool CpuemShim::isValidCu(uint32_t cu_index) {
+  bool CpuemShim::isValidCu(uint32_t cu_index)
+  {
     // get sorted cu addresses to match up with cu_index
     const auto& cuidx2addr = mCoreDevice->get_cus();
-    if (cu_index >= cuidx2addr.size()) {
+    if (cu_index >= cuidx2addr.size())
+    {
       std::string strMsg = "ERROR: [SW-EMU 20] invalid CU index: " + std::to_string(cu_index);
       mLogStream << __func__ << strMsg << std::endl;
       return false;
@@ -942,14 +979,17 @@ namespace xclcpuemhal2 {
     return true;
   }
 
-  uint64_t CpuemShim::getCuAddRange(uint32_t cu_index) {
+  uint64_t CpuemShim::getCuAddRange(uint32_t cu_index)
+  {
     uint64_t cuAddRange = 64 * 1024;
-    for (const auto& cuInfo : mCURangeMap) {
+    for (const auto& cuInfo : mCURangeMap)
+    {
       std::string instName = cuInfo.first;
       int cuIdx = static_cast<int>(cu_index);
       int tmpCuIdx = xclIPName2Index(instName.c_str());
-      mLogStream << __func__ << " , instName :  " << instName  << " cuIdx : " << cuIdx << " tmpCuIdx: " << tmpCuIdx << std::endl;
-      if (tmpCuIdx == cuIdx) {
+      mLogStream << __func__ << " , instName :  " << instName << " cuIdx : " << cuIdx << " tmpCuIdx: " << tmpCuIdx << std::endl;
+      if (tmpCuIdx == cuIdx)
+      {
         cuAddRange = cuInfo.second;
         mLogStream << __func__ << " , cuAddRange :  " << cuAddRange << std::endl;
       }
@@ -957,8 +997,10 @@ namespace xclcpuemhal2 {
     return cuAddRange;
   }
 
-  bool CpuemShim::isValidOffset(uint32_t offset, uint64_t cuAddRange) {
-    if (offset >= cuAddRange || (offset & (sizeof(uint32_t) - 1)) != 0) {
+  bool CpuemShim::isValidOffset(uint32_t offset, uint64_t cuAddRange)
+  {
+    if (offset >= cuAddRange || (offset & (sizeof(uint32_t) - 1)) != 0)
+    {
       std::string strMsg = "ERROR: [SW-EMU 21] xclRegRW - invalid CU offset: " + std::to_string(offset);
       mLogStream << __func__ << strMsg << std::endl;
       return false;
@@ -969,7 +1011,8 @@ namespace xclcpuemhal2 {
   int CpuemShim::xclRegRW(bool rd, uint32_t cu_index, uint32_t offset, uint32_t *datap)
   {
     if (mLogStream.is_open())
-      mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << "CU Idx : " << cu_index << " Offset : " << offset << " Datap : " << (*datap) << std::endl;
+      mLogStream << __func__ << ", " << std::this_thread::get_id() << ", "
+                 << "CU Idx : " << cu_index << " Offset : " << offset << " Datap : " << (*datap) << std::endl;
 
     if (!isValidCu(cu_index))
       return -EINVAL;
@@ -984,32 +1027,38 @@ namespace xclcpuemhal2 {
     const unsigned REG_BUFF_SIZE = 0x4;
     std::array<char, REG_BUFF_SIZE> buff = {};
     uint64_t baseAddr = cuidx2addr[cu_index];
-    if (rd) {
-      size_t size=4;
-      xclRegRead_RPC_CALL(xclRegRead,baseAddr,offset,buff.data(),size,0,0);
-      auto tmp_buff = reinterpret_cast<uint32_t*>(buff.data());
+    if (rd)
+    {
+      size_t size = 4;
+      xclRegRead_RPC_CALL(xclRegRead, baseAddr, offset, buff.data(), size, 0, 0);
+      auto tmp_buff = reinterpret_cast<uint32_t *>(buff.data());
       *datap = tmp_buff[0];
     }
-    else {
-      uint32_t * tmp_buff = reinterpret_cast<uint32_t*>(buff.data());
+    else
+    {
+      uint32_t *tmp_buff = reinterpret_cast<uint32_t *>(buff.data());
       tmp_buff[0] = *datap;
-      xclRegWrite_RPC_CALL(xclRegWrite,baseAddr,offset,tmp_buff,0,0);
+      xclRegWrite_RPC_CALL(xclRegWrite, baseAddr, offset, tmp_buff, 0, 0);
     }
     return 0;
   }
 
   int CpuemShim::xclRegRead(uint32_t cu_index, uint32_t offset, uint32_t *datap)
   {
-    if (mLogStream.is_open()) {
-      mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << "CU Idx : " << cu_index << " Offset : " << offset << " Datap : " << (*datap)  << std::endl;
+    if (mLogStream.is_open())
+    {
+      mLogStream << __func__ << ", " << std::this_thread::get_id() << ", "
+                 << "CU Idx : " << cu_index << " Offset : " << offset << " Datap : " << (*datap) << std::endl;
     }
     return xclRegRW(true, cu_index, offset, datap);
   }
 
   int CpuemShim::xclRegWrite(uint32_t cu_index, uint32_t offset, uint32_t data)
   {
-    if (mLogStream.is_open()) {
-      mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << "CU Idx : " << cu_index << " Offset : " << offset << " Datap : " << data << std::endl;
+    if (mLogStream.is_open())
+    {
+      mLogStream << __func__ << ", " << std::this_thread::get_id() << ", "
+                 << "CU Idx : " << cu_index << " Offset : " << offset << " Datap : " << data << std::endl;
     }
     return xclRegRW(false, cu_index, offset, &data);
   }
@@ -1017,46 +1066,53 @@ namespace xclcpuemhal2 {
   size_t CpuemShim::xclRead(xclAddressSpace space, uint64_t offset, void *hostBuf, size_t size)
   {
     std::lock_guard<std::mutex> lk(mApiMtx);
-    if (mLogStream.is_open()) {
+    if (mLogStream.is_open())
+    {
       mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << space << ", "
-        << offset << ", " << hostBuf << ", " << size << std::endl;
+                 << offset << ", " << hostBuf << ", " << size << std::endl;
     }
 
-    if(!sock) {
+    if (!sock)
+    {
       PRINTENDFUNC;
       return size;
     }
 
-    if(space != XCL_ADDR_KERNEL_CTRL) {
-      if (mLogStream.is_open()) mLogStream << "xclRead called with xclAddressSpace != XCL_ADDR_KERNEL_CTRL " << std::endl;
+    if (space != XCL_ADDR_KERNEL_CTRL)
+    {
+      if (mLogStream.is_open())
+        mLogStream << "xclRead called with xclAddressSpace != XCL_ADDR_KERNEL_CTRL " << std::endl;
       PRINTENDFUNC;
       return -1;
     }
 
-    if(size!=4) {
-      if (mLogStream.is_open()) mLogStream << "xclRead called with size != 4 " << std::endl;
+    if (size != 4)
+    {
+      if (mLogStream.is_open())
+        mLogStream << "xclRead called with size != 4 " << std::endl;
       PRINTENDFUNC;
       return -1;
     }
 
-    xclReadAddrKernelCtrl_RPC_CALL(xclReadAddrKernelCtrl,space,offset,hostBuf,size,0,0);
+    xclReadAddrKernelCtrl_RPC_CALL(xclReadAddrKernelCtrl, space, offset, hostBuf, size, 0, 0);
     PRINTENDFUNC;
     return size;
   }
 
   size_t CpuemShim::xclCopyBufferHost2Device(uint64_t dest, const void *src, size_t size, size_t seek)
   {
-    if (mLogStream.is_open()) {
+    if (mLogStream.is_open())
+    {
       mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << dest << ", "
-        << src << ", " << size << ", " << seek << std::endl;
+                 << src << ", " << size << ", " << seek << std::endl;
     }
 
     DEBUG_MSGS("%s, %d(dest: %lx size: %zx seek: %zx src: %p)\n", __func__, __LINE__, dest, size, seek, src);
 
-    if(!sock)
+    if (!sock)
       launchTempProcess();
 
-    src = (unsigned char*)src + seek;
+    src = (unsigned char *)src + seek;
     dest += seek;
 
     void *handle = this;
@@ -1064,40 +1120,44 @@ namespace xclcpuemhal2 {
     unsigned int messageSize = get_messagesize();
     unsigned int c_size = messageSize;
     unsigned int processed_bytes = 0;
-    while(processed_bytes < size){
-      if((size - processed_bytes) < messageSize){
+    while (processed_bytes < size)
+    {
+      if ((size - processed_bytes) < messageSize)
+      {
         c_size = size - processed_bytes;
-      }else{
+      }
+      else
+      {
         c_size = messageSize;
       }
 
-      void* c_src = (((unsigned char*)(src)) + processed_bytes);
+      void *c_src = (((unsigned char *)(src)) + processed_bytes);
       uint64_t c_dest = dest + processed_bytes;
 #ifndef _WINDOWS
-      uint32_t space =0;
-      xclCopyBufferHost2Device_RPC_CALL(xclCopyBufferHost2Device,handle,c_dest,c_src,c_size,seek,space);
+      uint32_t space = 0;
+      xclCopyBufferHost2Device_RPC_CALL(xclCopyBufferHost2Device, handle, c_dest, c_src, c_size, seek, space);
 #endif
       processed_bytes += c_size;
     }
 
-     DEBUG_MSGS("%s, %d(ENDED)\n", __func__, __LINE__);
+    DEBUG_MSGS("%s, %d(ENDED)\n", __func__, __LINE__);
     return size;
   }
 
   size_t CpuemShim::xclCopyBufferDevice2Host(void *dest, uint64_t src, size_t size, size_t skip)
   {
-    if (mLogStream.is_open()) {
+    if (mLogStream.is_open())
+    {
       mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << dest << ", "
-        << src << ", " << size << ", " << skip << std::endl;
+                 << src << ", " << size << ", " << skip << std::endl;
     }
 
     DEBUG_MSGS("%s, %d(src: %lx dest: %p size: %zx skip: %zx)\n", __func__, __LINE__, src, dest, size, skip);
 
-    dest = ((unsigned char*)dest) + skip;
+    dest = ((unsigned char *)dest) + skip;
 
-    if(!sock) {
+    if (!sock)
       launchTempProcess();
-    }
 
     src += skip;
     void *handle = this;
@@ -1106,18 +1166,18 @@ namespace xclcpuemhal2 {
     unsigned int c_size = messageSize;
     unsigned int processed_bytes = 0;
 
-    while(processed_bytes < size) {
+    while (processed_bytes < size)
+    {
 
-      if ((size - processed_bytes) < messageSize) {
+      if ((size - processed_bytes) < messageSize)
         c_size = size - processed_bytes;
-      } else {
+      else
         c_size = messageSize;
-      }
 
-      void* c_dest = (((unsigned char*)(dest)) + processed_bytes);
+      void *c_dest = (((unsigned char *)(dest)) + processed_bytes);
       uint64_t c_src = src + processed_bytes;
 #ifndef _WINDOWS
-      uint32_t space =0;
+      uint32_t space = 0;
       xclCopyBufferDevice2Host_RPC_CALL(xclCopyBufferDevice2Host, handle, c_dest, c_src, c_size, skip, space);
 #endif
 
@@ -1128,12 +1188,13 @@ namespace xclcpuemhal2 {
     return size;
   }
 
-  void CpuemShim::xclOpen(const char* logfileName)
+  void CpuemShim::xclOpen(const char *logfileName)
   {
     xclemulation::config::getInstance()->populateEnvironmentSetup(mEnvironmentNameValueMap);
     std::string logFilePath = (logfileName && (logfileName[0] != '\0')) ? logfileName : xrt_core::config::get_hal_logging();
 
-    if (!logFilePath.empty()) {
+    if (!logFilePath.empty())
+    {
       mLogStream.open(logFilePath);
       mLogStream << "FUNCTION, THREAD ID, ARG..." << std::endl;
       mLogStream << __func__ << ", " << std::this_thread::get_id() << std::endl;
@@ -1144,54 +1205,54 @@ namespace xclcpuemhal2 {
     mCoreDevice = xrt_core::swemu::get_userpf_device(this, mDeviceIndex);
   }
 
-  void CpuemShim::fillDeviceInfo(xclDeviceInfo2* dest, xclDeviceInfo2* src)
+  void CpuemShim::fillDeviceInfo(xclDeviceInfo2 *dest, xclDeviceInfo2 *src)
   {
     std::strcpy(dest->mName, src->mName);
-    dest->mMagic               =    src->mMagic ;
-    dest->mHALMajorVersion    =    src->mHALMajorVersion;
-    dest->mHALMinorVersion    =    src->mHALMinorVersion;
-    dest->mVendorId           =    src->mVendorId;
-    dest->mDeviceId           =    src->mDeviceId;
-    dest->mSubsystemVendorId  =    src->mSubsystemVendorId;
-    dest->mDeviceVersion      =    src->mDeviceVersion;
-    dest->mDDRSize            =    src->mDDRSize;
-    dest->mDataAlignment      =    src->mDataAlignment;
-    dest->mDDRBankCount       =    src->mDDRBankCount;
-    for(unsigned int i = 0; i < 4 ;i++)
-      dest->mOCLFrequency[i]       =    src->mOCLFrequency[i];
+    dest->mMagic = src->mMagic;
+    dest->mHALMajorVersion = src->mHALMajorVersion;
+    dest->mHALMinorVersion = src->mHALMinorVersion;
+    dest->mVendorId = src->mVendorId;
+    dest->mDeviceId = src->mDeviceId;
+    dest->mSubsystemVendorId = src->mSubsystemVendorId;
+    dest->mDeviceVersion = src->mDeviceVersion;
+    dest->mDDRSize = src->mDDRSize;
+    dest->mDataAlignment = src->mDataAlignment;
+    dest->mDDRBankCount = src->mDDRBankCount;
+    for (unsigned int i = 0; i < 4; i++)
+      dest->mOCLFrequency[i] = src->mOCLFrequency[i];
   }
 
   void CpuemShim::saveDeviceProcessOutput()
   {
-    if(!sock)
+    if (!sock)
       return;
 
-    for(int i = binaryCounter-1; i >= 0; i--)
+    for (int i = binaryCounter - 1; i >= 0; i--)
     {
       std::stringstream sw_emu_folder;
-      sw_emu_folder <<deviceDirectory<<"/binary_"<<i;
+      sw_emu_folder << deviceDirectory << "/binary_" << i;
       char path[FILENAME_MAX];
       size_t size = PATH_MAX;
-      char* pPath = GetCurrentDir(path,size);
-      if(pPath)
+      char *pPath = GetCurrentDir(path, size);
+      if (pPath)
       {
-        std::string debugFilePath = sw_emu_folder.str()+"/genericpcieoutput";
-        std::string destPath = std::string(path) + "/genericpcieoutput_device"+ std::to_string(mDeviceIndex) + "_"+std::to_string(i);
-        systemUtil::makeSystemCall(debugFilePath, systemUtil::systemOperation::COPY,destPath);
+        std::string debugFilePath = sw_emu_folder.str() + "/genericpcieoutput";
+        std::string destPath = std::string(path) + "/genericpcieoutput_device" + std::to_string(mDeviceIndex) + "_" + std::to_string(i);
+        systemUtil::makeSystemCall(debugFilePath, systemUtil::systemOperation::COPY, destPath);
       }
     }
 
-    if (mLogStream.is_open()) {
+    if (mLogStream.is_open())
+    {
       mLogStream.close();
     }
   }
   void CpuemShim::resetProgram(bool callingFromClose)
   {
-    auto ismMapEnabled= std::getenv("VITIS_SW_EMU_ENABLE_SINGLE_MMAP");
-    if (ismMapEnabled) {
-      mFdToFileNameMap.clear();
-    } else {
-      for (auto &it : mFdToFileNameMap)
+    auto isSinglemMapDisabled = std::getenv("VITIS_SW_EMU_DISABLE_SINGLE_MMAP");
+    if (isSinglemMapDisabled)
+    {
+      for (auto& it : mFdToFileNameMap)
       {
         int fd = it.first;
         uint64_t sSize = std::get<1>(it.second);
@@ -1202,11 +1263,16 @@ namespace xclcpuemhal2 {
 
       mFdToFileNameMap.clear();
     }
-
-    if (mLogStream.is_open()) {
-      mLogStream << __func__ << ", " << std::this_thread::get_id() << std::endl;
+    else
+    {
+      mFdToFileNameMap.clear();
     }
-    if (!sock) {
+
+    if (mLogStream.is_open())
+      mLogStream << __func__ << ", " << std::this_thread::get_id() << std::endl;
+
+    if (!sock)
+    {
       PRINTENDFUNC
       if (mIsKdsSwEmu && mSWSch && mCore)
       {
@@ -1225,11 +1291,11 @@ namespace xclcpuemhal2 {
     if (!socketName.empty())
     {
 #ifndef _WINDOWS
-      xclClose_RPC_CALL(xclClose,this);
+      xclClose_RPC_CALL(xclClose, this);
 #endif
     }
-   closeMessengerThread();
-   saveDeviceProcessOutput();
+    closeMessengerThread();
+    saveDeviceProcessOutput();
   }
 
   void CpuemShim::closeMessengerThread()
@@ -1253,32 +1319,32 @@ namespace xclcpuemhal2 {
 
       auto end_time = std::chrono::high_resolution_clock::now();
 
-      if (std::chrono::duration_cast<std::chrono::seconds>(end_time - start_time).count() <= simulationWaitTime) {
+      if (std::chrono::duration_cast<std::chrono::seconds>(end_time - start_time).count() <= simulationWaitTime)
+      {
         deviceProcessLog.parseLog();
         ++count;
         // giving some time for the simulator to run
-        if (count%5 == 0) {
-          std::this_thread::sleep_for(std::chrono::seconds(std::min(10*(count/5), 300)));
-          }
-        }
+        if (count % 5 == 0)
+          std::this_thread::sleep_for(std::chrono::seconds(std::min(10 * (count / 5), 300)));
+
+      }
     }
   }
 
   void CpuemShim::xclClose()
   {
     std::lock_guard<std::mutex> lk(mApiMtx);
-    if (mLogStream.is_open()) {
+    if (mLogStream.is_open())
       mLogStream << __func__ << ", " << std::this_thread::get_id() << std::endl;
-    }
 
     // Shim object is not deleted as part of closing device.
     // The core device must correspond to open and close, so
     // reset here rather than in destructor
     mCoreDevice.reset();
 
-    if(!sock)
+    if (!sock)
     {
-      if( xclemulation::config::getInstance()->isKeepRunDirEnabled() == false)
+      if (xclemulation::config::getInstance()->isKeepRunDirEnabled() == false)
         systemUtil::makeSystemCall(deviceDirectory, systemUtil::systemOperation::REMOVE);
       if (mIsKdsSwEmu && mSWSch && mCore)
       {
@@ -1291,7 +1357,8 @@ namespace xclcpuemhal2 {
       return;
     }
 
-    for (auto& it: mFdToFileNameMap) {
+    for (auto& it : mFdToFileNameMap)
+    {
       int fd = it.first;
       // CR-1123001 munmap() call is not required while exiting the application
       // OS will take care of cleaning once file descriptor close call is performed.
@@ -1305,17 +1372,17 @@ namespace xclcpuemhal2 {
     mIsDeviceProcessStarted = false;
     mCloseAll = true;
     std::string socketName = sock->get_name();
-    if(socketName.empty() == false)// device is active if socketName is non-empty
+    if (socketName.empty() == false) // device is active if socketName is non-empty
     {
 #ifndef _WINDOWS
-      xclClose_RPC_CALL(xclClose,this);
+      xclClose_RPC_CALL(xclClose, this);
 #endif
     }
     mCloseAll = false;
 
     int status = 0;
     bool simDontRun = xclemulation::config::getInstance()->isDontRun();
-    if(!simDontRun)
+    if (!simDontRun)
       while (-1 == waitpid(0, &status, 0));
 
     systemUtil::makeSystemCall(socketName, systemUtil::systemOperation::REMOVE);
@@ -1331,7 +1398,7 @@ namespace xclcpuemhal2 {
       mSWSch = nullptr;
     }
     //clean up directories which are created inside the driver
-    if( xclemulation::config::getInstance()->isKeepRunDirEnabled() == false)
+    if (xclemulation::config::getInstance()->isKeepRunDirEnabled() == false)
     {
       //TODO sleeping for some time sothat gdb releases the process and its contents
       sleep(5);
@@ -1373,530 +1440,599 @@ namespace xclcpuemhal2 {
 
   /**********************************************HAL2 API's START HERE **********************************************/
 
-/*********************************** Utility ******************************************/
+  /*********************************** Utility ******************************************/
 
-xclemulation::drm_xocl_bo* CpuemShim::xclGetBoByHandle(unsigned int boHandle)
-{
-  auto it = mXoclObjMap.find(boHandle);
-  if(it == mXoclObjMap.end())
-    return nullptr;
-
-  xclemulation::drm_xocl_bo* bo = (*it).second;
-  return bo;
-}
-
-inline unsigned short CpuemShim::xocl_ddr_channel_count()
-{
-  return mDeviceInfo.mDDRBankCount;
-}
-
-inline unsigned long long CpuemShim::xocl_ddr_channel_size()
-{
-  return 0;
-}
-
-int CpuemShim::xclGetBOProperties(unsigned int boHandle, xclBOProperties *properties)
-{
-  std::lock_guard<std::mutex> lk(mApiMtx);
-  if (mLogStream.is_open())
+  xclemulation::drm_xocl_bo *CpuemShim::xclGetBoByHandle(unsigned int boHandle)
   {
-    mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << std::hex << boHandle << std::endl;
+    auto it = mXoclObjMap.find(boHandle);
+    if (it == mXoclObjMap.end())
+      return nullptr;
+
+    xclemulation::drm_xocl_bo *bo = (*it).second;
+    return bo;
   }
-  xclemulation::drm_xocl_bo* bo = xclGetBoByHandle(boHandle);
-  if (!bo) {
+
+  inline unsigned short CpuemShim::xocl_ddr_channel_count()
+  {
+    return mDeviceInfo.mDDRBankCount;
+  }
+
+  inline unsigned long long CpuemShim::xocl_ddr_channel_size()
+  {
+    return 0;
+  }
+
+  int CpuemShim::xclGetBOProperties(unsigned int boHandle, xclBOProperties *properties)
+  {
+    std::lock_guard<std::mutex> lk(mApiMtx);
+    if (mLogStream.is_open())
+    {
+      mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << std::hex << boHandle << std::endl;
+    }
+    xclemulation::drm_xocl_bo *bo = xclGetBoByHandle(boHandle);
+    if (!bo)
+    {
+      PRINTENDFUNC;
+      return -1;
+    }
+    properties->handle = bo->handle;
+    properties->flags = bo->flags;
+    properties->size = bo->size;
+    properties->paddr = bo->base;
     PRINTENDFUNC;
-    return  -1;
+    return 0;
   }
-  properties->handle = bo->handle;
-  properties->flags  = bo->flags;
-  properties->size   = bo->size;
-  properties->paddr  = bo->base;
-  PRINTENDFUNC;
-  return 0;
-}
-/*****************************************************************************************/
+  /*****************************************************************************************/
 
-/******************************** xclAllocBO *********************************************/
-uint64_t CpuemShim::xoclCreateBo(xclemulation::xocl_create_bo* info)
-{
-  size_t size = info->size;
-  unsigned ddr = xclemulation::xocl_bo_ddr_idx(info->flags);
-
-  if (!size)
-    return -1;
-
-  // system linker doesnt run in sw_emu. if ddr idx morethan ddr_count, then create it in 0 by considering all plrams in zero'th ddr
-	const unsigned ddr_count = xocl_ddr_channel_count();
-  if(ddr_count <= ddr)
+  /******************************** xclAllocBO *********************************************/
+  uint64_t CpuemShim::xoclCreateBo(xclemulation::xocl_create_bo *info)
   {
-    ddr = 0;
+    size_t size = info->size;
+    unsigned ddr = xclemulation::xocl_bo_ddr_idx(info->flags);
+
+    if (!size)
+      return -1;
+
+    // system linker doesnt run in sw_emu. if ddr idx morethan ddr_count, then create it in 0 by considering all plrams in zero'th ddr
+    const unsigned ddr_count = xocl_ddr_channel_count();
+    if (ddr_count <= ddr)
+    {
+      ddr = 0;
+    }
+
+    //struct xclemulation::drm_xocl_bo *xobj = new xclemulation::drm_xocl_bo;
+    auto xobj = std::make_unique<xclemulation::drm_xocl_bo>();
+    xobj->flags = info->flags;
+
+    bool zeroCopy = xclemulation::is_zero_copy(xobj.get());
+    if (mLogStream.is_open())
+      mLogStream << __func__ << ", " << std::this_thread::get_id() << ", zeroCopy: " << zeroCopy << std::endl;
+
+    std::string sFileName("");
+    xobj->base = xclAllocDeviceBuffer2(size, XCL_MEM_DEVICE_RAM, ddr, zeroCopy, sFileName);
+    xobj->filename = sFileName;
+    xobj->size = size;
+    xobj->userptr = NULL;
+    xobj->buf = NULL;
+    xobj->fd = -1;
+
+    if (xobj->base == xclemulation::MemoryManager::mNull)
+    {
+      return xclemulation::MemoryManager::mNull;
+    }
+
+    info->handle = mBufferCount;
+
+    if (mLogStream.is_open())
+    {
+      mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << std::hex << " mBufferCount: " << mBufferCount << " ,sFileName:  "
+                 << sFileName << " , deviceName: " << deviceName << std::endl;
+    }
+
+    DEBUG_MSGS("%s, %d( mBufferCount: %x sFileName: %s deviceName: %s)\n", __func__, __LINE__, mBufferCount, sFileName.c_str(), deviceName.c_str());
+    mXoclObjMap[mBufferCount++] = xobj.release();
+    return 0;
   }
 
-  //struct xclemulation::drm_xocl_bo *xobj = new xclemulation::drm_xocl_bo;
-  auto xobj = std::make_unique<xclemulation::drm_xocl_bo>();
-  xobj->flags = info->flags;
-  /* check whether buffer is p2p or not*/
-  bool isCacheable = xclemulation::is_cacheable(xobj.get());
-  bool memCheck = xclemulation::no_host_memory(xobj.get()) || xclemulation::xocl_bo_host_only(xobj.get());
-
-  // Moving to file handle mechanism, if the memory is either non-cacheable or opted for p2p or host_only
-  bool zeroCopy = (memCheck || !isCacheable) ? true : false;
-  if (mLogStream.is_open())
-    mLogStream << __func__ << ", " << std::this_thread::get_id() << ", isCacheable: " << isCacheable << ", memCheck: " << memCheck << ", zeroCopy: "<< zeroCopy << std::endl;
-
-  std::string sFileName("");
-  xobj->base = xclAllocDeviceBuffer2(size, XCL_MEM_DEVICE_RAM, ddr, zeroCopy, sFileName);
-  xobj->filename = sFileName;
-  xobj->size = size;
-  xobj->userptr = NULL;
-  xobj->buf = NULL;
-  xobj->fd = -1;
-
-  if (xobj->base == xclemulation::MemoryManager::mNull)
+  unsigned int CpuemShim::xclAllocBO(size_t size, int unused, unsigned flags)
   {
-    return xclemulation::MemoryManager::mNull;
-  }
-
-  info->handle = mBufferCount;
-  mXoclObjMap[mBufferCount++] = xobj.release();
-  return 0;
-}
-
-unsigned int CpuemShim::xclAllocBO(size_t size, int unused, unsigned flags)
-{
-  std::lock_guard<std::mutex> lk(mApiMtx);
-  if (mLogStream.is_open())
-  {
-    mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << std::hex << size << std::dec << " , "<< unused <<" , "<< flags << std::endl;
-  }
-  xclemulation::xocl_create_bo info = {size, mNullBO, flags};
-  uint64_t result = xoclCreateBo(&info);
-  PRINTENDFUNC;
-  return result ? mNullBO : info.handle;
-}
-/***************************************************************************************/
-
-/******************************** xclAllocUserPtrBO ************************************/
-unsigned int CpuemShim::xclAllocUserPtrBO(void *userptr, size_t size, unsigned flags)
-{
-  std::lock_guard<std::mutex> lk(mApiMtx);
-  if (mLogStream.is_open()) {
-    mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << userptr <<", " << std::hex << size << std::dec <<" , "<< flags << std::endl;
-  }
-  xclemulation::xocl_create_bo info = {size, mNullBO, flags};
-  uint64_t result = xoclCreateBo(&info);
-  xclemulation::drm_xocl_bo* bo = xclGetBoByHandle(info.handle);
-  if (bo) {
-    bo->userptr = userptr;
-  }
-  PRINTENDFUNC;
-  return result ? mNullBO : info.handle;
-}
-/***************************************************************************************/
-
-/******************************** xclExportBO *******************************************/
-int CpuemShim::xclExportBO(unsigned int boHandle)
-{
-  if (mLogStream.is_open()) {
-    mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << std::hex << boHandle << std::endl;
-  }
-
-  DEBUG_MSGS("%s, %d( boHandle: %x )\n", __func__, __LINE__, boHandle);
-
-  xclemulation::drm_xocl_bo* bo = xclGetBoByHandle(boHandle);
-
-  if(!bo)
-    return -1;
-
-  std::string sFileName = bo->filename;
-  DEBUG_MSGS("%s, %d(sFileName: %s)\n", __func__, __LINE__, sFileName.c_str());
-  if(sFileName.empty()) {
-    std::cout<<"Exported Buffer is not P2P "<<std::endl;
+    std::lock_guard<std::mutex> lk(mApiMtx);
+    if (mLogStream.is_open())
+    {
+      mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << std::hex << size << std::dec << " , " << unused << " , " << flags << std::endl;
+    }
+    xclemulation::xocl_create_bo info = {size, mNullBO, flags};
+    uint64_t result = xoclCreateBo(&info);
     PRINTENDFUNC;
-    return -1;
+    return result ? mNullBO : info.handle;
   }
+  /***************************************************************************************/
 
-  uint64_t size = bo->size;
-  int fd = open(sFileName.c_str(), (O_CREAT | O_RDWR), 0666);
-  if (fd == -1) {
-    printf("Error opening exported BO file.\n");
+  /******************************** xclAllocUserPtrBO ************************************/
+  unsigned int CpuemShim::xclAllocUserPtrBO(void *userptr, size_t size, unsigned flags)
+  {
+    std::lock_guard<std::mutex> lk(mApiMtx);
+    if (mLogStream.is_open())
+      mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << userptr << ", " << std::hex << size << std::dec << " , " << flags << std::endl;
+
+    xclemulation::xocl_create_bo info = {size, mNullBO, flags};
+    uint64_t result = xoclCreateBo(&info);
+    xclemulation::drm_xocl_bo *bo = xclGetBoByHandle(info.handle);
+    if (bo)
+      bo->userptr = userptr;
+
     PRINTENDFUNC;
-    return -1;
+    return result ? mNullBO : info.handle;
   }
+  /***************************************************************************************/
 
-  char *data = nullptr;
-  auto ismMapEnabled = std::getenv("VITIS_SW_EMU_ENABLE_SINGLE_MMAP");
-  if (ismMapEnabled) {
-    data = (char*)mmap(0, MEMSIZE, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_SHARED, fd, 0);
-    data += bo->base;
+  /******************************** xclExportBO *******************************************/
+  int CpuemShim::xclExportBO(unsigned int boHandle)
+  {
+    if (mLogStream.is_open())
+      mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << std::hex << boHandle << std::endl;
 
-    DEBUG_MSGS("%s, %d( sFileName: %s MEMSIZE: %lx )\n", __func__, __LINE__, sFileName.c_str(), size);
-    mFdToFileNameMap[fd] = std::make_tuple(sFileName, size, (void*)data);
-  } else {
-    data = (char*)mmap(0, bo->size, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_SHARED, fd, 0);
-    if (!data) {
+    DEBUG_MSGS("%s, %d( boHandle: %x )\n", __func__, __LINE__, boHandle);
+
+    xclemulation::drm_xocl_bo *bo = xclGetBoByHandle(boHandle);
+
+    if (!bo)
+      return -1;
+
+    bool zeroCopy = xclemulation::is_zero_copy(bo);
+
+    if (!zeroCopy)
+    {
+      std::cerr << "Exported Buffer is not P2P " << std::endl;
       PRINTENDFUNC;
       return -1;
     }
 
-    int fR = ftruncate(fd, bo->size);
-    if (fR == -1) {
-      close(fd);
-      munmap(data, bo->size);
-      return -1;
-    }
+    std::string sFileName = bo->filename;
+    uint64_t size = bo->size;
+    DEBUG_MSGS("%s, %d(sFileName: %s bo->base: %lx size: %lx)\n", __func__, __LINE__, sFileName.c_str(), bo->base, size);
 
-    DEBUG_MSGS("%s, %d( sFileName: %s size: %lx )\n", __func__, __LINE__, sFileName.c_str(), size);
-    mFdToFileNameMap[fd] = std::make_tuple(sFileName, size, (void*)data);
-  }
-
-  PRINTENDFUNC;
-  DEBUG_MSGS("%s, %d( fd: %d ENDED )\n", __func__, __LINE__, fd);
-  return fd;
-}
-/***************************************************************************************/
-
-/******************************** xclImportBO *******************************************/
-unsigned int CpuemShim::xclImportBO(int boGlobalHandle, unsigned flags)
-{
-  //TODO
-  if (mLogStream.is_open()) {
-    mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << std::hex << boGlobalHandle << std::endl;
-  }
-
-  DEBUG_MSGS("%s, %d( boGlobalHandle: %x )\n", __func__, __LINE__, boGlobalHandle);
-
-  auto itr = mFdToFileNameMap.find(boGlobalHandle);
-  if(itr != mFdToFileNameMap.end()) {
-
-    const std::string& fileName = std::get<0>((*itr).second);
-    uint64_t size = std::get<1>((*itr).second);
-
-    DEBUG_MSGS("%s, %d( fileName: %s size: %zx )\n", __func__, __LINE__, fileName.c_str(), size);
-
-    unsigned int importedBo = xclAllocBO(size, 0, flags);
-
-    xclemulation::drm_xocl_bo* bo = xclGetBoByHandle(importedBo);
-    if(!bo) {
-      std::cout<<"ERROR HERE in importBO "<<std::endl;
-      return -1;
-    }
-
-    mImportedBOs.insert(importedBo);
-    bo->fd = boGlobalHandle;
-
-    bool ack;
-    xclImportBO_RPC_CALL(xclImportBO, fileName, bo->base, size);
-
-    if(!ack)
-      return -1;
-
-    PRINTENDFUNC;
-
-    DEBUG_MSGS("%s, %d( ENDED )\n", __func__, __LINE__);
-    return importedBo;
-  }
-  return -1;
-}
-/***************************************************************************************/
-
-/******************************** xclCopyBO *******************************************/
-int CpuemShim::xclCopyBO(unsigned int dst_boHandle, unsigned int src_boHandle, size_t size, size_t dst_offset, size_t src_offset)
-{
-  std::lock_guard<std::mutex> lk(mApiMtx);
-  //TODO
-  if (mLogStream.is_open()) {
-    mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << std::hex << dst_boHandle
-      << ", "<< src_boHandle << ", "<< size <<"," << dst_offset << ", " << src_offset << std::endl;
-  }
-
-  DEBUG_MSGS("%s, %d( src_boHandle: %x size: %zx  dst_offset: %zx src_offset: %zx )\n", __func__, __LINE__, src_boHandle, size, dst_offset, src_offset);
-
-  xclemulation::drm_xocl_bo* sBO = xclGetBoByHandle(src_boHandle);
-  if(!sBO) {
-    PRINTENDFUNC;
-    return -1;
-  }
-
-  xclemulation::drm_xocl_bo* dBO = xclGetBoByHandle(dst_boHandle);
-  if(!dBO) {
-    PRINTENDFUNC;
-    return -1;
-  }
-
-  // source buffer is host_only and destination buffer is device_only
-  if (xclemulation::xocl_bo_host_only(sBO) && !xclemulation::xocl_bo_p2p(sBO) && xclemulation::xocl_bo_dev_only(dBO)) {
-    unsigned char* host_only_buffer = (unsigned char*)(sBO->buf) + src_offset;
-    if (xclCopyBufferHost2Device(dBO->base, (void*) host_only_buffer, size, dst_offset) != size) {
-      return -1;
-    }
-  } // source buffer is device_only and destination buffer is host_only
-  else if (xclemulation::xocl_bo_host_only(dBO) && !xclemulation::xocl_bo_p2p(dBO) && xclemulation::xocl_bo_dev_only(sBO)) {
-    unsigned char* host_only_buffer = (unsigned char*)(dBO->buf) + dst_offset;
-    if (xclCopyBufferDevice2Host((void*) host_only_buffer, sBO->base, size, src_offset) != size) {
-      return -1;
-    }
-  }
-  else if (!xclemulation::xocl_bo_host_only(sBO) && !xclemulation::xocl_bo_host_only(dBO) && (dBO->fd < 0) && (sBO->fd < 0)) {
-    unsigned char temp_buffer[size];
-    // copy data from source buffer to temp buffer
-    if (xclCopyBufferDevice2Host((void*)temp_buffer, sBO->base, size, src_offset) != size) {
-      std::cerr << "ERROR: copy buffer from device to host failed " << std::endl;
-      return -1;
-    }
-    // copy data from temp buffer to destination buffer
-    if (xclCopyBufferHost2Device(dBO->base, (void*)temp_buffer, size, dst_offset) != size) {
-      std::cerr << "ERROR: copy buffer from host to device failed " << std::endl;
-      return -1;
-    }
-  }
-  else if (dBO->fd >= 0) {
-    int ack = false;
-    auto fItr = mFdToFileNameMap.find(dBO->fd);
-    if (fItr != mFdToFileNameMap.end()) {
-      const std::string& sFileName = std::get<0>((*fItr).second);
-      DEBUG_MSGS("%s, %d( dBO->fd: %d  sFileName: %s sBO->base: %lx dBO->base: %lx)\n", __func__, __LINE__, dBO->fd, sFileName.c_str(), sBO->base, dBO->base);
-      auto ismMapEnabled= std::getenv("VITIS_SW_EMU_ENABLE_SINGLE_MMAP");
-      if (ismMapEnabled) {
-        xclCopyBO_RPC_CALL(xclCopyBO, sBO->base, sFileName, size, src_offset, dBO->base + dst_offset);
-      } else {
-        xclCopyBO_RPC_CALL(xclCopyBO, sBO->base, sFileName, size, src_offset, dst_offset);
-      }
-    }
-    if (!ack)
-      return -1;
-  }
-  else if (sBO->fd >= 0) {
-    int ack = false;
-    auto fItr = mFdToFileNameMap.find(sBO->fd);
-    if (fItr != mFdToFileNameMap.end()) {
-      const std::string& sFileName = std::get<0>((*fItr).second);
-      DEBUG_MSGS("%s, %d( sBO->fd: %d  sFileName: %s)\n", __func__, __LINE__, sBO->fd, sFileName.c_str());
-      xclCopyBOFromFd_RPC_CALL(xclCopyBOFromFd, sFileName, dBO->base, size, src_offset, dst_offset);
-    }
-
-    if (!ack)
-      return -1;
-  }
-  else {
-    std::cerr << "ERROR: Copy buffer from source to destination failed" << std::endl;
-    return -1;
-  }
-
-  PRINTENDFUNC;
-  DEBUG_MSGS("%s, %d( ENDED )\n", __func__, __LINE__);
-  return 0;
-}
-/***************************************************************************************/
-
-/******************************** xclMapBO *********************************************/
-void *CpuemShim::xclMapBO(unsigned int boHandle, bool write)
-{
-  std::lock_guard<std::mutex> lk(mApiMtx);
-  if (mLogStream.is_open())
-    mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << std::hex << boHandle << ", " << write << std::endl;
-
-  DEBUG_MSGS("%s, %d(boHandle: %x write: %s)\n", __func__, __LINE__, boHandle, write ? "true" : "false");
-
-  xclemulation::drm_xocl_bo* bo = xclGetBoByHandle(boHandle);
-  if (!bo) {
-    PRINTENDFUNC;
-    return nullptr;
-  }
-
-  std::string sFileName = bo->filename;
-  DEBUG_MSGS("%s, %d(sFileName: %s)\n", __func__, __LINE__, sFileName.c_str());
-  if(!sFileName.empty()) //P2P or non cacheable scenario: TODO: modify the condition to check for flags instead of filename empty check
-  {
     int fd = open(sFileName.c_str(), (O_CREAT | O_RDWR), 0666);
-    if (fd == -1) {
+    if (fd == -1)
+    {
       printf("Error opening exported BO file.\n");
-      return nullptr;
-    };
+      PRINTENDFUNC;
+      return -1;
+    }
 
-    char* data = nullptr;
-    auto ismMapEnabled= std::getenv("VITIS_SW_EMU_ENABLE_SINGLE_MMAP");
-    if (ismMapEnabled) {
-      data = (char*) mmap(0, MEMSIZE, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_SHARED, fd, 0);
-      data += bo->base;
-
-      if(!data)
-        return nullptr;
-
-      mFdToFileNameMap[fd] = std::make_tuple(sFileName, MEMSIZE, (void*)data);
-
-    } else {
-      data = (char*) mmap(0, bo->size, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_SHARED, fd, 0);
-
-      if(!data)
-        return nullptr;
+    char *data = nullptr;
+    auto isSinglemMapDisabled = std::getenv("VITIS_SW_EMU_DISABLE_SINGLE_MMAP");
+    if (isSinglemMapDisabled)
+    {
+      data = (char *)mmap(0, bo->size, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_SHARED, fd, 0);
+      if (!data)
+      {
+        PRINTENDFUNC;
+        return -1;
+      }
 
       int fR = ftruncate(fd, bo->size);
-      if(fR == -1) {
+      if (fR == -1)
+      {
         close(fd);
         munmap(data, bo->size);
-        return nullptr;
+        return -1;
       }
-      mFdToFileNameMap[fd] = std::make_tuple(sFileName, bo->size, (void*)data);
+
+      DEBUG_MSGS("%s, %d( sFileName: %s size: %lx fd: %x )\n", __func__, __LINE__, sFileName.c_str(), size, fd);
+      mFdToFileNameMap[fd] = std::make_tuple(sFileName, size, (void*)data);
+    }
+    else
+    {
+      data = (char *)mmap(0, MEMSIZE, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_SHARED, fd, bo->base);
+
+      if (!data)
+      {
+        PRINTENDFUNC;
+        return -1;
+      }
+
+      DEBUG_MSGS("%s, %d( sFileName: %s bo->base: %lx size: %lx fd: %x )\n", __func__, __LINE__, sFileName.c_str(), bo->base, size, fd);
+      mFdToFileNameMap[fd] = std::make_tuple(sFileName, size, (void*)data);
     }
 
-    bo->buf = data;
-
-    DEBUG_MSGS("%s, %d(bo->base: %lx bo->buf: %p fd: %d)\n", __func__, __LINE__, bo->base, bo->buf, fd);
     PRINTENDFUNC;
-
-    DEBUG_MSGS("%s, %d(ENDED )\n", __func__, __LINE__);
-    return data;
+    DEBUG_MSGS("%s, %d( fd: %x ENDED )\n", __func__, __LINE__, fd);
+    return fd;
   }
-  else { // NON P2P cacheable scenario
+  /***************************************************************************************/
 
-    void *pBuf = nullptr;
-    if (posix_memalign(&pBuf, getpagesize(), bo->size)) {
-      if (mLogStream.is_open())
-        mLogStream << "posix_memalign failed" << std::endl;
+  /******************************** xclImportBO *******************************************/
+  unsigned int CpuemShim::xclImportBO(int boGlobalHandle, unsigned flags)
+  {
+    if (mLogStream.is_open())
+      mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << std::hex << boGlobalHandle << std::endl;
+
+    DEBUG_MSGS("%s, %d( boGlobalHandle: %x )\n", __func__, __LINE__, boGlobalHandle);
+
+    auto itr = mFdToFileNameMap.find(boGlobalHandle);
+    if (itr != mFdToFileNameMap.end())
+    {
+      uint64_t size = std::get<1>((*itr).second);
+      DEBUG_MSGS("%s, %d(size: %zx )\n", __func__, __LINE__, size);
+
+      unsigned int importedBo = xclAllocBO(size, 0, flags);
+
+      xclemulation::drm_xocl_bo *bo = xclGetBoByHandle(importedBo);
+      if (!bo)
+      {
+        std::cerr << "ERROR HERE in importBO " << std::endl;
+        return -1;
+      }
+
+      mImportedBOs.insert(importedBo);
+      bo->fd = boGlobalHandle;
+
+      auto isSinglemMapDisabled = std::getenv("VITIS_SW_EMU_DISABLE_SINGLE_MMAP");
+      if (isSinglemMapDisabled)
+      {
+        bool ack;
+        const std::string &fileName = std::get<0>((*itr).second);
+        xclImportBO_RPC_CALL(xclImportBO, fileName, bo->base, size);
+
+        if (!ack)
+          return -1;
+      }
+
+      DEBUG_MSGS("%s, %d( bo->base: %lx size: %zx )\n", __func__, __LINE__, bo->base, size);
+      PRINTENDFUNC;
+
+      DEBUG_MSGS("%s, %d( ENDED )\n", __func__, __LINE__);
+      return importedBo;
+    }
+    return -1;
+  }
+  /***************************************************************************************/
+
+  /******************************** xclCopyBO *******************************************/
+  int CpuemShim::xclCopyBO(unsigned int dst_boHandle, unsigned int src_boHandle, size_t size, size_t dst_offset, size_t src_offset)
+  {
+    std::lock_guard<std::mutex> lk(mApiMtx);
+    //TODO
+    if (mLogStream.is_open())
+    {
+      mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << std::hex << dst_boHandle
+                 << ", " << src_boHandle << ", " << size << "," << dst_offset << ", " << src_offset << std::endl;
+    }
+
+    DEBUG_MSGS("%s, %d( src_boHandle: %x dst_boHandle: %x size: %zx  dst_offset: %zx src_offset: %zx )\n", __func__, __LINE__, src_boHandle, dst_boHandle, size, dst_offset, src_offset);
+
+    xclemulation::drm_xocl_bo *sBO = xclGetBoByHandle(src_boHandle);
+    if (!sBO)
+    {
+      PRINTENDFUNC;
+      return -1;
+    }
+
+    xclemulation::drm_xocl_bo *dBO = xclGetBoByHandle(dst_boHandle);
+    if (!dBO)
+    {
+      PRINTENDFUNC;
+      return -1;
+    }
+
+    // source buffer is host_only and destination buffer is device_only
+    if (xclemulation::xocl_bo_host_only(sBO) && !xclemulation::xocl_bo_p2p(sBO) && xclemulation::xocl_bo_dev_only(dBO))
+    {
+      unsigned char *host_only_buffer = (unsigned char *)(sBO->buf) + src_offset;
+      if (xclCopyBufferHost2Device(dBO->base, (void*)host_only_buffer, size, dst_offset) != size)
+      {
+        std::cerr << "ERROR: copy buffer from host to device failed " << std::endl;      
+        return -1;
+      }
+    } // source buffer is device_only and destination buffer is host_only
+    else if (xclemulation::xocl_bo_host_only(dBO) && !xclemulation::xocl_bo_p2p(dBO) && xclemulation::xocl_bo_dev_only(sBO))
+    {
+      unsigned char *host_only_buffer = (unsigned char *)(dBO->buf) + dst_offset;
+      if (xclCopyBufferDevice2Host((void*)host_only_buffer, sBO->base, size, src_offset) != size)
+      {
+        std::cerr << "ERROR: copy buffer from device to host failed " << std::endl;      
+        return -1;
+      }
+    }
+    else if (!xclemulation::xocl_bo_host_only(sBO) && !xclemulation::xocl_bo_host_only(dBO) && (dBO->fd < 0) && (sBO->fd < 0))
+    {
+      unsigned char temp_buffer[size];
+      // copy data from source buffer to temp buffer
+      if (xclCopyBufferDevice2Host((void*)temp_buffer, sBO->base, size, src_offset) != size)
+      {
+        std::cerr << "ERROR: copy buffer from device to host failed " << std::endl;
+        return -1;
+      }
+      // copy data from temp buffer to destination buffer
+      if (xclCopyBufferHost2Device(dBO->base, (void*)temp_buffer, size, dst_offset) != size)
+      {
+        std::cerr << "ERROR: copy buffer from host to device failed " << std::endl;
+        return -1;
+      }
+    }
+    else if (dBO->fd >= 0)
+    {
+      auto fItr = mFdToFileNameMap.find(dBO->fd);
+      if (fItr != mFdToFileNameMap.end())
+      {
+        auto isSinglemMapDisabled = std::getenv("VITIS_SW_EMU_DISABLE_SINGLE_MMAP");
+        if (isSinglemMapDisabled)
+        {
+          int ack = false;
+          const std::string &sFileName = std::get<0>((*fItr).second);
+          xclCopyBO_RPC_CALL(xclCopyBO, sBO->base, sFileName, size, src_offset, dst_offset);
+          if (!ack)
+            return -1;
+        }
+        else
+        {
+          void *lmapData = std::get<2>((*fItr).second);
+          DEBUG_MSGS("%s, %d( dBO->fd: %x sBO->base: %lx dBO->base: %lx)\n", __func__, __LINE__, dBO->fd, sBO->base, dBO->base);
+          if (xclCopyBufferDevice2Host(lmapData, sBO->base, size, src_offset) != size)
+          {
+            std::cerr << "ERROR: copy buffer from device to host failed " << std::endl;
+            return -1;
+          }
+        }
+      }
+      else
+      {
+        return -1;
+      }
+    }
+    else if (sBO->fd >= 0)
+    {
+      auto fItr = mFdToFileNameMap.find(sBO->fd);
+      if (fItr != mFdToFileNameMap.end())
+      {
+        auto isSinglemMapDisabled = std::getenv("VITIS_SW_EMU_DISABLE_SINGLE_MMAP");
+        if (isSinglemMapDisabled)
+        {
+          int ack = false;
+          const std::string &sFileName = std::get<0>((*fItr).second);
+          xclCopyBOFromFd_RPC_CALL(xclCopyBOFromFd, sFileName, dBO->base, size, src_offset, dst_offset);
+          if (!ack)
+            return -1;
+        }
+        else
+        {
+          void *lmapData = std::get<2>((*fItr).second);
+          DEBUG_MSGS("%s, %d( sBO->fd: %d)\n", __func__, __LINE__, sBO->fd);
+
+          if (xclCopyBufferHost2Device(dBO->base, lmapData, size, dst_offset) != size)
+          {
+            std::cerr << "ERROR: copy buffer from device to host failed " << std::endl;
+            return -1;
+          }
+        }
+      }
+      else
+      {
+        return -1;
+      }
+    }
+    else
+    {
+      std::cerr << "ERROR: Copy buffer from source to destination failed" << std::endl;
+      return -1;
+    }
+
+    PRINTENDFUNC;
+    DEBUG_MSGS("%s, %d( ENDED )\n", __func__, __LINE__);
+    return 0;
+  }
+  /***************************************************************************************/
+
+  /******************************** xclMapBO *********************************************/
+  void *CpuemShim::xclMapBO(unsigned int boHandle, bool write)
+  {
+    std::lock_guard<std::mutex> lk(mApiMtx);
+    if (mLogStream.is_open())
+      mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << std::hex << boHandle << ", " << write << std::endl;
+
+    DEBUG_MSGS("%s, %d(boHandle: %x write: %s)\n", __func__, __LINE__, boHandle, write ? "true" : "false");
+
+    xclemulation::drm_xocl_bo *bo = xclGetBoByHandle(boHandle);
+    if (!bo)
+    {
       PRINTENDFUNC;
       return nullptr;
     }
 
-    memset(pBuf, 0, bo->size);
-    bo->buf = pBuf;
+    bool zeroCopy = xclemulation::is_zero_copy(bo);
+    if (zeroCopy)
+    {
+      std::string sFileName = bo->filename;
+      DEBUG_MSGS("%s, %d(zero copy design sFileName: %s)\n", __func__, __LINE__, sFileName.c_str());
 
-    DEBUG_MSGS("%s, %d(bo->base: %lx bo->buf: %p)\n", __func__, __LINE__, bo->base, bo->buf);
+      int fd = open(sFileName.c_str(), (O_CREAT | O_RDWR), 0666);
+      if (fd == -1)
+      {
+        printf("Error opening exported BO file.\n");
+        return nullptr;
+      };
 
-    PRINTENDFUNC;
-    return pBuf;
-  }
-}
+      char *data = nullptr;
+      auto isSinglemMapDisabled = std::getenv("VITIS_SW_EMU_DISABLE_SINGLE_MMAP");
+      if (isSinglemMapDisabled)
+      {
+        data = (char *)mmap(0, bo->size, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_SHARED, fd, 0);
+        if (!data)
+          return nullptr;
 
-int CpuemShim::xclUnmapBO(unsigned int boHandle, void* addr)
-{
-  std::lock_guard<std::mutex> lk(mApiMtx);
-  auto bo = xclGetBoByHandle(boHandle);
-  return bo ? munmap(addr,bo->size) : -1;
-}
+        int fR = ftruncate(fd, bo->size);
+        if (fR == -1)
+        {
+          close(fd);
+          munmap(data, bo->size);
+          return nullptr;
+        }
+        mFdToFileNameMap[fd] = std::make_tuple(sFileName, bo->size, (void*)data);
+      }
+      else
+      {
+        data = (char *)mmap(0, MEMSIZE, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_SHARED, fd, bo->base);
+        if (!data)
+          return nullptr;
 
-/**************************************************************************************/
+        mFdToFileNameMap[fd] = std::make_tuple(sFileName, MEMSIZE, (void*)data);
+      }
 
-/******************************** xclSyncBO *******************************************/
-int CpuemShim::xclSyncBO(unsigned int boHandle, xclBOSyncDirection dir, size_t size, size_t offset)
-{
-  std::lock_guard<std::mutex> lk(mApiMtx);
-  if (mLogStream.is_open())
-    mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << std::hex << boHandle << " , " << std::endl;
+      bo->buf = data;
 
-  DEBUG_MSGS("%s, %d(boHandle: %x offset: %zx)\n", __func__, __LINE__, boHandle, offset);
+      DEBUG_MSGS("%s, %d(bo->base: %lx bo->buf: %p fd: %x)\n", __func__, __LINE__, bo->base, bo->buf, fd);
+      PRINTENDFUNC;
 
-  xclemulation::drm_xocl_bo* bo = xclGetBoByHandle(boHandle);
-  if(!bo) {
-    PRINTENDFUNC;
-    return -1;
-  }
+      DEBUG_MSGS("%s, %d(ENDED )\n", __func__, __LINE__);
+      return data;
+    }
+    else
+    { //NON zeroCopy scenario
 
-  int returnVal = 0;
-  if(dir == XCL_BO_SYNC_BO_TO_DEVICE)
-  {
-    void* buffer =  bo->userptr ? bo->userptr : bo->buf;
-    if (xclCopyBufferHost2Device(bo->base, buffer, size, offset) != size) {
-      returnVal = EIO;
+      DEBUG_MSGS("%s, %d(non zero copy design)\n", __func__, __LINE__);
+      void *pBuf = nullptr;
+      if (posix_memalign(&pBuf, getpagesize(), bo->size))
+      {
+        if (mLogStream.is_open())
+          mLogStream << "posix_memalign failed" << std::endl;
+        PRINTENDFUNC;
+        return nullptr;
+      }
+
+      memset(pBuf, 0, bo->size);
+      bo->buf = pBuf;
+
+      DEBUG_MSGS("%s, %d(bo->base: %lx bo->buf: %p)\n", __func__, __LINE__, bo->base, bo->buf);
+
+      PRINTENDFUNC;
+      return pBuf;
     }
   }
-  else
+
+  int CpuemShim::xclUnmapBO(unsigned int boHandle, void *addr)
   {
-    void* buffer =  bo->userptr ? bo->userptr : bo->buf;
-    if (xclCopyBufferDevice2Host(buffer, bo->base, size, offset) != size) {
-      returnVal = EIO;
+    std::lock_guard<std::mutex> lk(mApiMtx);
+    auto bo = xclGetBoByHandle(boHandle);
+    return bo ? munmap(addr, bo->size) : -1;
+  }
+
+  /**************************************************************************************/
+
+  /******************************** xclSyncBO *******************************************/
+  int CpuemShim::xclSyncBO(unsigned int boHandle, xclBOSyncDirection dir, size_t size, size_t offset)
+  {
+    std::lock_guard<std::mutex> lk(mApiMtx);
+    if (mLogStream.is_open())
+      mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << std::hex << boHandle << " , " << std::endl;
+
+    DEBUG_MSGS("%s, %d(boHandle: %x offset: %zx)\n", __func__, __LINE__, boHandle, offset);
+
+    xclemulation::drm_xocl_bo *bo = xclGetBoByHandle(boHandle);
+    if (!bo)
+    {
+      PRINTENDFUNC;
+      return -1;
     }
-  }
-  PRINTENDFUNC;
-  DEBUG_MSGS("%s, %d( ENDED )\n", __func__, __LINE__);
-  return returnVal;
-}
-/***************************************************************************************/
 
-/******************************** xclFreeBO *******************************************/
-void CpuemShim::xclFreeBO(unsigned int boHandle)
-{
-  std::lock_guard<std::mutex> lk(mApiMtx);
-  if (mLogStream.is_open())
-  {
-    mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << std::hex << boHandle << std::endl;
-  }
-  auto it = mXoclObjMap.find(boHandle);
-  if(it == mXoclObjMap.end())
-  {
+    int returnVal = 0;
+    if (dir == XCL_BO_SYNC_BO_TO_DEVICE)
+    {
+      void *buffer = bo->userptr ? bo->userptr : bo->buf;
+      if (xclCopyBufferHost2Device(bo->base, buffer, size, offset) != size)
+        returnVal = EIO;
+    }
+    else
+    {
+      void *buffer = bo->userptr ? bo->userptr : bo->buf;
+      if (xclCopyBufferDevice2Host(buffer, bo->base, size, offset) != size)
+        returnVal = EIO;
+    }
     PRINTENDFUNC;
-    return;
+    DEBUG_MSGS("%s, %d( ENDED )\n", __func__, __LINE__);
+    return returnVal;
   }
-  xclemulation::drm_xocl_bo* bo = (*it).second;;
-  if(bo)
-  {
-    xclFreeDeviceBuffer(bo->base);
-    mXoclObjMap.erase(it);
-  }
-  PRINTENDFUNC;
-}
-/***************************************************************************************/
+  /***************************************************************************************/
 
-/******************************** xclWriteBO *******************************************/
-size_t CpuemShim::xclWriteBO(unsigned int boHandle, const void *src, size_t size, size_t seek)
-{
-  std::lock_guard<std::mutex> lk(mApiMtx);
-  if (mLogStream.is_open())
+  /******************************** xclFreeBO *******************************************/
+  void CpuemShim::xclFreeBO(unsigned int boHandle)
   {
-    mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << std::hex << boHandle << " , "<< src <<" , "<< size << ", " << seek << std::endl;
-  }
-  xclemulation::drm_xocl_bo* bo = xclGetBoByHandle(boHandle);
-  if(!bo)
-  {
+    std::lock_guard<std::mutex> lk(mApiMtx);
+    if (mLogStream.is_open())
+      mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << std::hex << boHandle << std::endl;
+    auto it = mXoclObjMap.find(boHandle);
+    if (it == mXoclObjMap.end())
+    {
+      PRINTENDFUNC;
+      return;
+    }
+    xclemulation::drm_xocl_bo *bo = (*it).second;
+
+    if (bo)
+    {
+      xclFreeDeviceBuffer(bo->base);
+      mXoclObjMap.erase(it);
+    }
     PRINTENDFUNC;
-    return -1;
   }
-  size_t returnVal = 0;
-  if (xclCopyBufferHost2Device(bo->base, src, size, seek) != size) {
-    returnVal = EIO;
-  }
-  PRINTENDFUNC;
-  return returnVal;
-}
-/***************************************************************************************/
+  /***************************************************************************************/
 
-/******************************** xclReadBO *******************************************/
-size_t CpuemShim::xclReadBO(unsigned int boHandle, void *dst, size_t size, size_t skip)
-{
-  std::lock_guard<std::mutex> lk(mApiMtx);
-  if (mLogStream.is_open())
+  /******************************** xclWriteBO *******************************************/
+  size_t CpuemShim::xclWriteBO(unsigned int boHandle, const void *src, size_t size, size_t seek)
   {
-    mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << std::hex << boHandle << " , "<< dst <<" , "<< size << ", " << skip << std::endl;
-  }
-  xclemulation::drm_xocl_bo* bo = xclGetBoByHandle(boHandle);
-  if(!bo)
-  {
+    std::lock_guard<std::mutex> lk(mApiMtx);
+    if (mLogStream.is_open())
+      mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << std::hex << boHandle << " , " << src << " , " << size << ", " << seek << std::endl;
+    xclemulation::drm_xocl_bo *bo = xclGetBoByHandle(boHandle);
+    if (!bo)
+    {
+      PRINTENDFUNC;
+      return -1;
+    }
+    size_t returnVal = 0;
+    if (xclCopyBufferHost2Device(bo->base, src, size, seek) != size)
+      returnVal = EIO;
+
     PRINTENDFUNC;
-    return -1;
+    return returnVal;
   }
-  size_t returnVal = 0;
-  if (xclCopyBufferDevice2Host(dst, bo->base, size, skip) != size) {
-    returnVal = EIO;
-  }
-  PRINTENDFUNC;
-  return returnVal;
-}
-/***************************************************************************************/
+  /***************************************************************************************/
 
-/*
+  /******************************** xclReadBO *******************************************/
+  size_t CpuemShim::xclReadBO(unsigned int boHandle, void *dst, size_t size, size_t skip)
+  {
+    std::lock_guard<std::mutex> lk(mApiMtx);
+    if (mLogStream.is_open())
+      mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << std::hex << boHandle << " , " << dst << " , " << size << ", " << skip << std::endl;
+    xclemulation::drm_xocl_bo *bo = xclGetBoByHandle(boHandle);
+    if (!bo)
+    {
+      PRINTENDFUNC;
+      return -1;
+    }
+    size_t returnVal = 0;
+    if (xclCopyBufferDevice2Host(dst, bo->base, size, skip) != size)
+      returnVal = EIO;
+
+    PRINTENDFUNC;
+    return returnVal;
+  }
+  /***************************************************************************************/
+
+  /*
  * xclLogMsg()
  */
-int CpuemShim::xclLogMsg(xclDeviceHandle handle, xrtLogMsgLevel level, const char* tag, const char* format, va_list args1)
-{
+  int CpuemShim::xclLogMsg(xclDeviceHandle handle, xrtLogMsgLevel level, const char *tag, const char *format, va_list args1)
+  {
     int len = std::vsnprintf(nullptr, 0, format, args1);
 
     if (len < 0)
     {
-        //illegal arguments
-        std::string err_str = "ERROR: Illegal arguments in log format string. ";
-        err_str.append(std::string(format));
-        xrt_core::message::send((xrt_core::message::severity_level)level, tag, err_str.c_str());
-        return len;
+      //illegal arguments
+      std::string err_str = "ERROR: Illegal arguments in log format string. ";
+      err_str.append(std::string(format));
+      xrt_core::message::send((xrt_core::message::severity_level)level, tag, err_str.c_str());
+      return len;
     }
     len++; //To include null terminator
 
@@ -1905,197 +2041,216 @@ int CpuemShim::xclLogMsg(xclDeviceHandle handle, xrtLogMsgLevel level, const cha
 
     if (len < 0)
     {
-        //error processing arguments
-        std::string err_str = "ERROR: When processing arguments in log format string. ";
-        err_str.append(std::string(format));
-        xrt_core::message::send((xrt_core::message::severity_level)level, tag, err_str.c_str());
-        return len;
+      //error processing arguments
+      std::string err_str = "ERROR: When processing arguments in log format string. ";
+      err_str.append(std::string(format));
+      xrt_core::message::send((xrt_core::message::severity_level)level, tag, err_str.c_str());
+      return len;
     }
     xrt_core::message::send((xrt_core::message::severity_level)level, tag, buf.data());
     return 0;
-}
+  }
 
-/*
+  /*
 * xclOpenContext
 */
-int CpuemShim::xclOpenContext(const uuid_t xclbinId, unsigned int ipIndex, bool shared)
-{
-  // When properly implemented this function must throw on error
-  // and any exception must be caught by global xclOpenContext and
-  // converted to error code
-  return 0;
-}
+  int CpuemShim::xclOpenContext(const uuid_t xclbinId, unsigned int ipIndex, bool shared)
+  {
+    // When properly implemented this function must throw on error
+    // and any exception must be caught by global xclOpenContext and
+    // converted to error code
+    return 0;
+  }
 
-/*
+  /*
 * xclExecWait
 */
-int CpuemShim::xclExecWait(int timeoutMilliSec)
-{
-  //unsigned int tSec = 0;
-  //static bool bConfig = true;
-  //tSec = timeoutMilliSec / 1000;
-  //if (bConfig)
-  //{
-  //  tSec = timeoutMilliSec / 1000;
-  //  bConfig = false;
-  //}
-  //sleep(tSec);
-  //PRINTENDFUNC;
-  return 1;
-}
+  int CpuemShim::xclExecWait(int timeoutMilliSec)
+  {
+    //unsigned int tSec = 0;
+    //static bool bConfig = true;
+    //tSec = timeoutMilliSec / 1000;
+    //if (bConfig)
+    //{
+    //  tSec = timeoutMilliSec / 1000;
+    //  bConfig = false;
+    //}
+    //sleep(tSec);
+    //PRINTENDFUNC;
+    return 1;
+  }
 
-/*
+  /*
 * xclExecBuf
 */
-int CpuemShim::xclExecBuf(unsigned int cmdBO)
-{
-  if (mLogStream.is_open())
+  int CpuemShim::xclExecBuf(unsigned int cmdBO)
   {
-    mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << cmdBO << std::endl;
-  }
+    if (mLogStream.is_open())
+      mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << cmdBO << std::endl;
 
-  if (!mIsKdsSwEmu)
-    return 0;
+    if (!mIsKdsSwEmu)
+      return 0;
 
-  xclemulation::drm_xocl_bo* bo = xclGetBoByHandle(cmdBO);
-  if (!mSWSch || !bo)
-  {
+    xclemulation::drm_xocl_bo *bo = xclGetBoByHandle(cmdBO);
+    if (!mSWSch || !bo)
+    {
+      PRINTENDFUNC;
+      return -1;
+    }
+    int ret = mSWSch->add_exec_buffer(mCore, bo);
     PRINTENDFUNC;
-    return -1;
+    return ret;
   }
-  int ret = mSWSch->add_exec_buffer(mCore, bo);
-  PRINTENDFUNC;
-  return ret;
-}
 
-/*
+  /*
 * xclCloseContext
 */
-int CpuemShim::xclCloseContext(const uuid_t xclbinId, unsigned int ipIndex)
-{
-  return 0;
-}
+  int CpuemShim::xclCloseContext(const uuid_t xclbinId, unsigned int ipIndex)
+  {
+    return 0;
+  }
 
-//Get CU index from IP_LAYOUT section for corresponding kernel name
-int CpuemShim::xclIPName2Index(const char *name)
-{
-  //Get IP_LAYOUT buffer from xclbin
-  auto buffer = mCoreDevice->get_axlf_section(IP_LAYOUT);
-  return xclemulation::getIPName2Index(name, buffer.first);
-}
+  //Get CU index from IP_LAYOUT section for corresponding kernel name
+  int CpuemShim::xclIPName2Index(const char *name)
+  {
+    //Get IP_LAYOUT buffer from xclbin
+    auto buffer = mCoreDevice->get_axlf_section(IP_LAYOUT);
+    return xclemulation::getIPName2Index(name, buffer.first);
+  }
 
-// New API's for m2m and no-dma
+  // New API's for m2m and no-dma
 
-void CpuemShim::constructQueryTable() {
-  if (xclemulation::config::getInstance()->getIsPlatformEnabled()) {
-    if (mPlatformData.get_optional<std::string>("plp.m2m").is_initialized()) {
-      mQueryTable[key_type::m2m] = mPlatformData.get<std::string>("plp.m2m");
-    }
+  void CpuemShim::constructQueryTable()
+  {
+    if (xclemulation::config::getInstance()->getIsPlatformEnabled())
+    {
+      if (mPlatformData.get_optional<std::string>("plp.m2m").is_initialized())
+      {
+        mQueryTable[key_type::m2m] = mPlatformData.get<std::string>("plp.m2m");
+      }
 
-    if (mPlatformData.get_optional<std::string>("plp.dma").is_initialized()) {
-      std::string dmaVal = mPlatformData.get<std::string>("plp.dma");
-      mQueryTable[key_type::nodma] = (dmaVal == "none" ? "enabled" : "disabled");
+      if (mPlatformData.get_optional<std::string>("plp.dma").is_initialized())
+      {
+        std::string dmaVal = mPlatformData.get<std::string>("plp.dma");
+        mQueryTable[key_type::nodma] = (dmaVal == "none" ? "enabled" : "disabled");
+      }
     }
   }
-}
 
-int CpuemShim::deviceQuery(key_type queryKey) {
-  if(mQueryTable.find(queryKey) != mQueryTable.end())
-    return (mQueryTable[queryKey] == "enabled" ? 1 : 0);
-  return 0;
-}
+  int CpuemShim::deviceQuery(key_type queryKey)
+  {
+    if (mQueryTable.find(queryKey) != mQueryTable.end())
+      return (mQueryTable[queryKey] == "enabled" ? 1 : 0);
+    return 0;
+  }
 
-/********************************************** QDMA APIs IMPLEMENTATION END**********************************************/
+  /********************************************** QDMA APIs IMPLEMENTATION END**********************************************/
 
-/******************************* XRT Graph API's **************************************************/
-/**
+  /******************************* XRT Graph API's **************************************************/
+  /**
 * xrtGraphInit() - Initialize  graph
 */
-int CpuemShim::xrtGraphInit(void *gh) {
-  bool ack = false;
-  auto ghPtr = (xclcpuemhal2::GraphType*)gh;
-  if (!ghPtr)
-    return -1;
-  auto graphhandle = ghPtr->getGraphHandle();
-  auto graphname = ghPtr->getGraphName();
-
-  DEBUG_MSGS("%s, %d(graphname: %s)\n", __func__, __LINE__, graphname);
-
-  xclGraphInit_RPC_CALL(xclGraphInit, graphhandle, graphname);
-  if (!ack)
+  int CpuemShim::xrtGraphInit(void *gh)
   {
-    PRINTENDFUNC;
-    return -1;
-  }
-  return 0;
-}
+    if (mLogStream.is_open())
+      mLogStream << __func__ << ", " << std::this_thread::get_id() << std::endl;
+        
+    bool ack = false;
+    auto ghPtr = (xclcpuemhal2::GraphType *)gh;
+    if (!ghPtr)
+      return -1;
+    auto graphhandle = ghPtr->getGraphHandle();
+    auto graphname = ghPtr->getGraphName();
 
-/**
+    DEBUG_MSGS("%s, %d(graphname: %s)\n", __func__, __LINE__, graphname);
+
+    xclGraphInit_RPC_CALL(xclGraphInit, graphhandle, graphname);
+    if (!ack)
+    {
+      PRINTENDFUNC;
+      return -1;
+    }
+    return 0;
+  }
+
+  /**
 * xrtGraphRun() - Start a graph execution
 */
-int CpuemShim::xrtGraphRun(void * gh, uint32_t iterations) {
-  bool ack = false;
-  auto ghPtr = (xclcpuemhal2::GraphType*)gh;
-  if (!ghPtr)
-    return -1;
-
-  DEBUG_MSGS("%s, %d(iterations: %d)\n", __func__, __LINE__, (int)iterations);
-  auto graphhandle = ghPtr->getGraphHandle();
-  xclGraphRun_RPC_CALL(xclGraphRun, graphhandle, iterations);
-  if (!ack)
+  int CpuemShim::xrtGraphRun(void *gh, uint32_t iterations)
   {
-    PRINTENDFUNC;
-    return -1;
-  }
-  return 0;
-}
+    if (mLogStream.is_open())
+      mLogStream << __func__ << ", " << std::this_thread::get_id() << std::endl;
+        
+    bool ack = false;
+    auto ghPtr = (xclcpuemhal2::GraphType *)gh;
+    if (!ghPtr)
+      return -1;
 
-/**
+    DEBUG_MSGS("%s, %d(iterations: %d)\n", __func__, __LINE__, (int)iterations);
+    auto graphhandle = ghPtr->getGraphHandle();
+    xclGraphRun_RPC_CALL(xclGraphRun, graphhandle, iterations);
+    if (!ack)
+    {
+      PRINTENDFUNC;
+      return -1;
+    }
+    return 0;
+  }
+
+  /**
 * xrtGraphWait() -  Wait a given AIE cycle since the last xrtGraphRun and
 *                   then stop the graph. If cycle is 0, busy wait until graph
 *                   is done. If graph already run more than the given
 *                   cycle, stop the graph immediateley.
 */
-int CpuemShim::xrtGraphWait(void * gh) {
-  bool ack = false;
-  auto ghPtr = (xclcpuemhal2::GraphType*)gh;
-  if (!ghPtr)
-    return -1;
-
-  DEBUG_MSGS("%s, %d()\n", __func__, __LINE__);
-  auto graphhandle = ghPtr->getGraphHandle();
-  xclGraphWait_RPC_CALL(xclGraphWait, graphhandle);
-  if (!ack)
+  int CpuemShim::xrtGraphWait(void *gh)
   {
-    PRINTENDFUNC;
-    return -1;
-  }
-  return 0;
-}
+    if (mLogStream.is_open())
+      mLogStream << __func__ << ", " << std::this_thread::get_id() << std::endl;
+        
+    bool ack = false;
+    auto ghPtr = (xclcpuemhal2::GraphType *)gh;
+    if (!ghPtr)
+      return -1;
 
-/**
+    DEBUG_MSGS("%s, %d()\n", __func__, __LINE__);
+    auto graphhandle = ghPtr->getGraphHandle();
+    xclGraphWait_RPC_CALL(xclGraphWait, graphhandle);
+    if (!ack)
+    {
+      PRINTENDFUNC;
+      return -1;
+    }
+    return 0;
+  }
+
+  /**
 * xrtGraphTimedWait() -  Wait a given AIE cycle since the last xrtGraphRun and
 *                   then stop the graph. If cycle is 0, busy wait until graph
 *                   is done. If graph already run more than the given
 *                   cycle, stop the graph immediateley.
 */
-int CpuemShim::xrtGraphTimedWait(void * gh, uint64_t cycle) {
-  bool ack = false;
-  auto ghPtr = (xclcpuemhal2::GraphType*)gh;
-  if (!ghPtr)
-    return -1;
-  auto graphhandle = ghPtr->getGraphHandle();
-  DEBUG_MSGS("%s, %d(cycle: %lu)\n", __func__, __LINE__, cycle);
-  xclGraphTimedWait_RPC_CALL(xclGraphTimedWait, graphhandle, cycle);
-  if (!ack)
+  int CpuemShim::xrtGraphTimedWait(void *gh, uint64_t cycle)
   {
-    PRINTENDFUNC;
-    return -1;
+    if (mLogStream.is_open())
+      mLogStream << __func__ << ", " << std::this_thread::get_id() << std::endl;
+        
+    bool ack = false;
+    auto ghPtr = (xclcpuemhal2::GraphType *)gh;
+    if (!ghPtr)
+      return -1;
+    auto graphhandle = ghPtr->getGraphHandle();
+    DEBUG_MSGS("%s, %d(cycle: %lu)\n", __func__, __LINE__, cycle);
+    xclGraphTimedWait_RPC_CALL(xclGraphTimedWait, graphhandle, cycle);
+    if (!ack)
+    {
+      PRINTENDFUNC;
+      return -1;
+    }
+    return 0;
   }
-  return 0;
-}
 
-/**
+  /**
 * xrtGraphEnd() - Wait a given AIE cycle since the last xrtGraphRun and
 *                 then end the graph. If cycle is 0, busy wait until graph
 *                 is done before end the graph. If graph already run more
@@ -2110,24 +2265,28 @@ int CpuemShim::xrtGraphTimedWait(void * gh, uint64_t cycle) {
 * Note: This API with non-zero AIE cycle is for graph that is running
 * forever or graph that has multi-rate core(s).
 */
-int CpuemShim::xrtGraphEnd(void * gh) {
-  bool ack = false;
-  auto ghPtr = (xclcpuemhal2::GraphType*)gh;
-  if (!ghPtr)
-    return -1;
-
-  DEBUG_MSGS("%s, %d()\n", __func__, __LINE__);
-  auto graphhandle = ghPtr->getGraphHandle();
-  xclGraphEnd_RPC_CALL(xclGraphEnd, graphhandle);
-  if (!ack)
+  int CpuemShim::xrtGraphEnd(void *gh)
   {
-    PRINTENDFUNC;
-    return -1;
-  }
-  return 0;
-}
+    if (mLogStream.is_open())
+      mLogStream << __func__ << ", " << std::this_thread::get_id() << std::endl;
+        
+    bool ack = false;
+    auto ghPtr = (xclcpuemhal2::GraphType *)gh;
+    if (!ghPtr)
+      return -1;
 
-/**
+    DEBUG_MSGS("%s, %d()\n", __func__, __LINE__);
+    auto graphhandle = ghPtr->getGraphHandle();
+    xclGraphEnd_RPC_CALL(xclGraphEnd, graphhandle);
+    if (!ack)
+    {
+      PRINTENDFUNC;
+      return -1;
+    }
+    return 0;
+  }
+
+  /**
 * xrtGraphTimedEnd() - Wait a given AIE cycle since the last xrtGraphRun and
 *                 then end the graph. If cycle is 0, busy wait until graph
 *                 is done before end the graph. If graph already run more
@@ -2142,46 +2301,54 @@ int CpuemShim::xrtGraphEnd(void * gh) {
 * Note: This API with non-zero AIE cycle is for graph that is running
 * forever or graph that has multi-rate core(s).
 */
-int CpuemShim::xrtGraphTimedEnd(void * gh , uint64_t cycle) {
-  bool ack = false;
-  auto ghPtr = (xclcpuemhal2::GraphType*)gh;
-  if (!ghPtr)
-    return -1;
-
-  DEBUG_MSGS("%s, %d(cycle: %lu)\n", __func__, __LINE__, cycle);
-  auto graphhandle = ghPtr->getGraphHandle();
-  xclGraphTimedEnd_RPC_CALL(xclGraphTimedEnd, graphhandle, cycle);
-  if (!ack)
+  int CpuemShim::xrtGraphTimedEnd(void *gh, uint64_t cycle)
   {
-    PRINTENDFUNC;
-    return -1;
-  }
-  return 0;
-}
+    if (mLogStream.is_open())
+      mLogStream << __func__ << ", " << std::this_thread::get_id() << std::endl;
+        
+    bool ack = false;
+    auto ghPtr = (xclcpuemhal2::GraphType *)gh;
+    if (!ghPtr)
+      return -1;
 
-/**
+    DEBUG_MSGS("%s, %d(cycle: %lu)\n", __func__, __LINE__, cycle);
+    auto graphhandle = ghPtr->getGraphHandle();
+    xclGraphTimedEnd_RPC_CALL(xclGraphTimedEnd, graphhandle, cycle);
+    if (!ack)
+    {
+      PRINTENDFUNC;
+      return -1;
+    }
+    return 0;
+  }
+
+  /**
 * xrtGraphResume() - Resume a suspended graph.
 *
 * Resume graph execution which was paused by suspend() or wait(cycles) APIs
 */
-int CpuemShim::xrtGraphResume(void * gh) {
-  bool ack = false;
-  auto ghPtr = (xclcpuemhal2::GraphType*)gh;
-  if (!ghPtr)
-    return -1;
-
-  DEBUG_MSGS("%s, %d()\n", __func__, __LINE__);
-  auto graphhandle = ghPtr->getGraphHandle();
-  xclGraphResume_RPC_CALL(xclGraphResume, graphhandle);
-  if (!ack)
+  int CpuemShim::xrtGraphResume(void *gh)
   {
-    PRINTENDFUNC;
-    return -1;
-  }
-  return 0;
-}
+    if (mLogStream.is_open())
+      mLogStream << __func__ << ", " << std::this_thread::get_id() << std::endl;
+        
+    bool ack = false;
+    auto ghPtr = (xclcpuemhal2::GraphType *)gh;
+    if (!ghPtr)
+      return -1;
 
-/**
+    DEBUG_MSGS("%s, %d()\n", __func__, __LINE__);
+    auto graphhandle = ghPtr->getGraphHandle();
+    xclGraphResume_RPC_CALL(xclGraphResume, graphhandle);
+    if (!ack)
+    {
+      PRINTENDFUNC;
+      return -1;
+    }
+    return 0;
+  }
+
+  /**
 * xrtGraphUpdateRTP() - Update RTP value of port with hierarchical name
 *
 * @gh:              Handle to graph previously opened with xrtGraphOpen.
@@ -2191,19 +2358,23 @@ int CpuemShim::xrtGraphResume(void * gh) {
 *
 * Return:          0 on success, -1 on error.
 */
-int CpuemShim::xrtGraphUpdateRTP(void * gh, const char *hierPathPort, const char *buffer, size_t size) {
-  auto ghPtr = (xclcpuemhal2::GraphType*)gh;
-  if (!ghPtr)
-    return -1;
+  int CpuemShim::xrtGraphUpdateRTP(void *gh, const char *hierPathPort, const char *buffer, size_t size)
+  {
+    if (mLogStream.is_open())
+      mLogStream << __func__ << ", " << std::this_thread::get_id() << std::endl;
+        
+    auto ghPtr = (xclcpuemhal2::GraphType *)gh;
+    if (!ghPtr)
+      return -1;
 
-  DEBUG_MSGS("%s, %d(size: %zx hierPathPort: %s)\n", __func__, __LINE__, size, hierPathPort);
-  auto graphhandle = ghPtr->getGraphHandle();
-  xclGraphUpdateRTP_RPC_CALL(xclGraphUpdateRTP, graphhandle, hierPathPort, buffer, size);
-  PRINTENDFUNC
+    DEBUG_MSGS("%s, %d(size: %zx hierPathPort: %s)\n", __func__, __LINE__, size, hierPathPort);
+    auto graphhandle = ghPtr->getGraphHandle();
+    xclGraphUpdateRTP_RPC_CALL(xclGraphUpdateRTP, graphhandle, hierPathPort, buffer, size);
+    PRINTENDFUNC
     return 0;
-}
+  }
 
-/**
+  /**
 * xrtGraphUpdateRTP() - Read RTP value of port with hierarchical name
 *
 * @gh:              Handle to graph previously opened with xrtGraphOpen.
@@ -2216,19 +2387,23 @@ int CpuemShim::xrtGraphUpdateRTP(void * gh, const char *hierPathPort, const char
 * Note: Caller is reponsible for allocating enough memory for RTP value
 *       being copied to.
 */
-int CpuemShim::xrtGraphReadRTP(void * gh, const char *hierPathPort, char *buffer, size_t size) {
-  auto ghPtr = (xclcpuemhal2::GraphType*)gh;
-  if (!ghPtr)
-    return -1;
+  int CpuemShim::xrtGraphReadRTP(void *gh, const char *hierPathPort, char *buffer, size_t size)
+  {
+    if (mLogStream.is_open())
+      mLogStream << __func__ << ", " << std::this_thread::get_id() << std::endl;
+      
+    auto ghPtr = (xclcpuemhal2::GraphType *)gh;
+    if (!ghPtr)
+      return -1;
 
-  DEBUG_MSGS("%s, %d(size: %zx hierPathPort: %s)\n", __func__, __LINE__, size, hierPathPort);
-  auto graphhandle = ghPtr->getGraphHandle();
-  xclGraphReadRTP_RPC_CALL(xclGraphReadRTP, graphhandle, hierPathPort, buffer, size);
-  PRINTENDFUNC
+    DEBUG_MSGS("%s, %d(size: %zx hierPathPort: %s)\n", __func__, __LINE__, size, hierPathPort);
+    auto graphhandle = ghPtr->getGraphHandle();
+    xclGraphReadRTP_RPC_CALL(xclGraphReadRTP, graphhandle, hierPathPort, buffer, size);
+    PRINTENDFUNC
     return 0;
-}
+  }
 
-/**
+  /**
 * xrtSyncBOAIENB() - Transfer data between DDR and Shim DMA channel
 *
 * @bo:           BO obj.
@@ -2243,66 +2418,73 @@ int CpuemShim::xrtGraphReadRTP(void * gh, const char *hierPathPort, char *buffer
 * Note: Upon return, the synchronization is submitted or error out
 */
 
-int CpuemShim::xrtSyncBOAIENB(xrt::bo& bo, const char *gmioname, enum xclBOSyncDirection dir, size_t size, size_t offset)
-{
-  bool ack = false;
-  if (!gmioname)
-    return -1;
+  int CpuemShim::xrtSyncBOAIENB(xrt::bo &bo, const char *gmioname, enum xclBOSyncDirection dir, size_t size, size_t offset)
+  {
+    if (mLogStream.is_open())
+      mLogStream << __func__ << ", " << std::this_thread::get_id() << std::endl;
 
-  if (mLogStream.is_open())
-    mLogStream << __func__ << ", bo.address() " << bo.address() << std::endl;
+    bool ack = false;
+    if (!gmioname)
+      return -1;
 
-  auto boBase = bo.address();
-  //bool isCacheable = bo.flags & XCL_BO_FLAGS_CACHEABLE;
-  DEBUG_MSGS("%s, %d(gmioname: %s size: %zx offset: %zx boBase: %lx)\n", __func__, __LINE__, gmioname, size, offset, boBase);
+    if (mLogStream.is_open())
+      mLogStream << __func__ << ", bo.address() " << bo.address() << std::endl;
 
-  xclSyncBOAIENB_RPC_CALL(xclSyncBOAIENB, gmioname, dir, size, offset, boBase);
-  if (!ack) {
-    PRINTENDFUNC;
-    return -1;
+    auto boBase = bo.address();
+    //bool isCacheable = bo.flags & XCL_BO_FLAGS_CACHEABLE;
+    DEBUG_MSGS("%s, %d(gmioname: %s size: %zx offset: %zx boBase: %lx)\n", __func__, __LINE__, gmioname, size, offset, boBase);
+
+    xclSyncBOAIENB_RPC_CALL(xclSyncBOAIENB, gmioname, dir, size, offset, boBase);
+    if (!ack)
+    {
+      PRINTENDFUNC;
+      return -1;
+    }
+    return 0;
   }
-  return 0;
-}
 
-
-/**
+  /**
 * xrtGMIOWait() - Wait a shim DMA channel to be idle for a given GMIO port
 *
 * @gmioName:        GMIO port name
 *
 * Return:          0 on success, or appropriate error number.
 */
-int CpuemShim::xrtGMIOWait(const char *gmioname)
-{
-  bool ack = false;
-  if (!gmioname)
-    return -1;
+  int CpuemShim::xrtGMIOWait(const char *gmioname)
+  {
+    if (mLogStream.is_open())
+      mLogStream << __func__ << ", " << std::this_thread::get_id() << std::endl;
+  
+    bool ack = false;
+    if (!gmioname)
+      return -1;
 
-  DEBUG_MSGS("%s, %d(gmioname: %s)\n", __func__, __LINE__, gmioname);
-  xclGMIOWait_RPC_CALL(xclGMIOWait, gmioname);
-  if (!ack) {
-    PRINTENDFUNC;
-    return -1;
+    DEBUG_MSGS("%s, %d(gmioname: %s)\n", __func__, __LINE__, gmioname);
+    xclGMIOWait_RPC_CALL(xclGMIOWait, gmioname);
+    if (!ack)
+    {
+      PRINTENDFUNC;
+      return -1;
+    }
+    return 0;
   }
-  return 0;
-}
 
-// open_context() - aka xclOpenContextByName
-// Throw on error, return cuidx
-xrt_core::cuidx_type
-CpuemShim::
-open_cu_context(const xrt::hw_context& hwctx, const std::string& cuname)
-{
-  // Emulation does not yet support multiple xclbins.  Call
-  // regular flow.  Default access mode to shared unless explicitly
-  // exclusive.
-  auto shared = (hwctx.get_qos() != xrt::hw_context::qos::exclusive);
-  auto ctxhdl = static_cast<xcl_hwctx_handle>(hwctx);
-  auto cuidx = mCoreDevice->get_cuidx(ctxhdl, cuname);
-  xclOpenContext(hwctx.get_xclbin_uuid().get(), cuidx.index, shared);
+  // open_context() - aka xclOpenContextByName
+  // Throw on error, return cuidx
+  xrt_core::cuidx_type
+  CpuemShim::
+      open_cu_context(const xrt::hw_context &hwctx, const std::string &cuname)
+  {
+    // Emulation does not yet support multiple xclbins.  Call
+    // regular flow.  Default access mode to shared unless explicitly
+    // exclusive.
+    auto shared = (hwctx.get_qos() != xrt::hw_context::qos::exclusive);
+    auto ctxhdl = static_cast<xcl_hwctx_handle>(hwctx);
+    auto cuidx = mCoreDevice->get_cuidx(ctxhdl, cuname);
+    xclOpenContext(hwctx.get_xclbin_uuid().get(), cuidx.index, shared);
 
-  return cuidx;
-}
+    return cuidx;
+  }
 
-/**********************************************HAL2 API's END HERE **********************************************/
+  /**********************************************HAL2 API's END HERE **********************************************/
 } //xclcpuemhal2

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.h
@@ -43,141 +43,145 @@
 #include <dlfcn.h>
 #endif
 
-namespace xclcpuemhal2 {
+namespace xclcpuemhal2
+{
   using key_type = xrt_core::query::key_type;
-  const uint64_t MEMSIZE = 0x0000000080000000;
+  //8GB MEMSIZE to access the MMAP FILE
+  const uint64_t MEMSIZE = 0x0000000200000000;
   const auto endOfSimulationString = "received request to end simulation from connected initiator";
 
   // XDMA Shim
-  class CpuemShim {
-    public:
-      static const unsigned TAG;
-      static const unsigned CONTROL_AP_START;
-      static const unsigned CONTROL_AP_DONE;
-      static const unsigned CONTROL_AP_IDLE;
-      static const unsigned CONTROL_AP_CONTINUE;
-
-  private:
-      // This is a hidden signature of this class and helps in preventing
-      // user errors when incorrect pointers are passed in as handles.
-      const unsigned mTag;
-
-  private:
-      // Helper functions - added for kernel debug
-      int dumpXML(const xclBin* header, std::string& fileLocation) ;
-      bool parseIni(unsigned int& debugPort) ;
-      void getCuRangeIdx();
-      static std::map<std::string, std::string> mEnvironmentNameValueMap;
+  class CpuemShim
+  {
   public:
-      // HAL2 RELATED member functions start
-      unsigned int xclAllocBO(size_t size, int unused, unsigned flags);
-      uint64_t xoclCreateBo(xclemulation::xocl_create_bo *info);
-      void* xclMapBO(unsigned int boHandle, bool write);
-      int xclUnmapBO(unsigned int boHandle, void* addr);
-      int xclSyncBO(unsigned int boHandle, xclBOSyncDirection dir, size_t size, size_t offset);
-      unsigned int xclAllocUserPtrBO(void *userptr, size_t size, unsigned flags);
-      int xclGetBOProperties(unsigned int boHandle, xclBOProperties *properties);
-      size_t xclWriteBO(unsigned int boHandle, const void *src, size_t size, size_t seek);
-      size_t xclReadBO(unsigned int boHandle, void *dst, size_t size, size_t skip);
-      void xclFreeBO(unsigned int boHandle);
-      //P2P buffer support
-      int xclExportBO(unsigned int boHandle);
-      unsigned int xclImportBO(int boGlobalHandle, unsigned flags);
-      int xclCopyBO(unsigned int dst_boHandle, unsigned int src_boHandle, size_t size, size_t dst_offset, size_t src_offset);
-      static int xclLogMsg(xclDeviceHandle handle, xrtLogMsgLevel level, const char* tag, const char* format, va_list args1);
+    static const unsigned TAG;
+    static const unsigned CONTROL_AP_START;
+    static const unsigned CONTROL_AP_DONE;
+    static const unsigned CONTROL_AP_IDLE;
+    static const unsigned CONTROL_AP_CONTINUE;
 
+  private:
+    // This is a hidden signature of this class and helps in preventing
+    // user errors when incorrect pointers are passed in as handles.
+    const unsigned mTag;
 
-      xclemulation::drm_xocl_bo* xclGetBoByHandle(unsigned int boHandle);
-      inline unsigned short xocl_ddr_channel_count();
-      inline unsigned long long xocl_ddr_channel_size();
-      // HAL2 RELATED member functions end
+  private:
+    // Helper functions - added for kernel debug
+    int dumpXML(const xclBin *header, std::string &fileLocation);
+    bool parseIni(unsigned int &debugPort);
+    void getCuRangeIdx();
+    static std::map<std::string, std::string> mEnvironmentNameValueMap;
 
-      //Configuration
-      void xclOpen(const char* logfileName);
-      int xclLoadXclBin(const xclBin *buffer);
-      //int xclLoadBitstream(const char *fileName);
-      int xclUpgradeFirmware(const char *fileName);
-      int xclBootFPGA();
-      void xclClose();
-      void resetProgram(bool callingFromClose = false);
+  public:
+    // HAL2 RELATED member functions start
+    unsigned int xclAllocBO(size_t size, int unused, unsigned flags);
+    uint64_t xoclCreateBo(xclemulation::xocl_create_bo *info);
+    void *xclMapBO(unsigned int boHandle, bool write);
+    int xclUnmapBO(unsigned int boHandle, void *addr);
+    int xclSyncBO(unsigned int boHandle, xclBOSyncDirection dir, size_t size, size_t offset);
+    unsigned int xclAllocUserPtrBO(void *userptr, size_t size, unsigned flags);
+    int xclGetBOProperties(unsigned int boHandle, xclBOProperties *properties);
+    size_t xclWriteBO(unsigned int boHandle, const void *src, size_t size, size_t seek);
+    size_t xclReadBO(unsigned int boHandle, void *dst, size_t size, size_t skip);
+    void xclFreeBO(unsigned int boHandle);
+    //P2P buffer support
+    int xclExportBO(unsigned int boHandle);
+    unsigned int xclImportBO(int boGlobalHandle, unsigned flags);
+    int xclCopyBO(unsigned int dst_boHandle, unsigned int src_boHandle, size_t size, size_t dst_offset, size_t src_offset);
+    static int xclLogMsg(xclDeviceHandle handle, xrtLogMsgLevel level, const char *tag, const char *format, va_list args1);
 
-      // Raw read/write
-      size_t xclWrite(xclAddressSpace space, uint64_t offset, const void *hostBuf, size_t size);
-      size_t xclRead(xclAddressSpace space, uint64_t offset, void *hostBuf, size_t size);
+    xclemulation::drm_xocl_bo *xclGetBoByHandle(unsigned int boHandle);
+    inline unsigned short xocl_ddr_channel_count();
+    inline unsigned long long xocl_ddr_channel_size();
+    // HAL2 RELATED member functions end
 
-      // Buffer management
-      uint64_t xclAllocDeviceBuffer(size_t size);
-      uint64_t xclAllocDeviceBuffer2(size_t& size, xclMemoryDomains domain, unsigned flags, bool p2pBuffer, std::string &sFileName);
+    //Configuration
+    void xclOpen(const char *logfileName);
+    void setDriverVersion(const std::string& version);
+    int xclLoadXclBin(const xclBin *buffer);
+    //int xclLoadBitstream(const char *fileName);
+    int xclUpgradeFirmware(const char *fileName);
+    int xclBootFPGA();
+    void xclClose();
+    void resetProgram(bool callingFromClose = false);
 
-      void xclFreeDeviceBuffer(uint64_t buf);
-      size_t xclCopyBufferHost2Device(uint64_t dest, const void *src, size_t size, size_t seek);
-      size_t xclCopyBufferDevice2Host(void *dest, uint64_t src, size_t size, size_t skip);
+    // Raw read/write
+    size_t xclWrite(xclAddressSpace space, uint64_t offset, const void *hostBuf, size_t size);
+    size_t xclRead(xclAddressSpace space, uint64_t offset, void *hostBuf, size_t size);
 
-      // Performance monitoring
-      // Control
-      double xclGetDeviceClockFreqMHz();
-      double xclGetHostReadMaxBandwidthMBps();
-      double xclGetHostWriteMaxBandwidthMBps();
-      double xclGetKernelReadMaxBandwidthMBps();
-      double xclGetKernelWriteMaxBandwidthMBps();
-      void xclSetProfilingNumberSlots(xdp::MonitorType type, uint32_t numSlots);
-      size_t xclPerfMonClockTraining(xdp::MonitorType type);
-      // Counters
-      size_t xclPerfMonStartCounters(xdp::MonitorType type);
-      size_t xclPerfMonStopCounters(xdp::MonitorType type);
-      size_t xclPerfMonReadCounters(xdp::MonitorType type, xdp::CounterResults& counterResults);
-      // Trace
-      size_t xclPerfMonStartTrace(xdp::MonitorType type, uint32_t startTrigger);
-      size_t xclPerfMonStopTrace(xdp::MonitorType type);
-      uint32_t xclPerfMonGetTraceCount(xdp::MonitorType type);
-      size_t xclPerfMonReadTrace(xdp::MonitorType type, xdp::TraceEventsVector& traceVector);
+    // Buffer management
+    uint64_t xclAllocDeviceBuffer(size_t size);
+    uint64_t xclAllocDeviceBuffer2(size_t &size, xclMemoryDomains domain, unsigned flags, bool p2pBuffer, std::string &sFileName);
 
-      // Sanity checks
-      int xclGetDeviceInfo2(xclDeviceInfo2 *info);
-      static unsigned xclProbe();
-      void fillDeviceInfo(xclDeviceInfo2* dest, xclDeviceInfo2* src);
-      void saveDeviceProcessOutput();
+    void xclFreeDeviceBuffer(uint64_t buf);
+    size_t xclCopyBufferHost2Device(uint64_t dest, const void *src, size_t size, size_t seek);
+    size_t xclCopyBufferDevice2Host(void *dest, uint64_t src, size_t size, size_t skip);
 
-      void set_messagesize( unsigned int messageSize ) { message_size = messageSize; }
-      unsigned int get_messagesize(){ return message_size; }
+    // Performance monitoring
+    // Control
+    double xclGetDeviceClockFreqMHz();
+    double xclGetHostReadMaxBandwidthMBps();
+    double xclGetHostWriteMaxBandwidthMBps();
+    double xclGetKernelReadMaxBandwidthMBps();
+    double xclGetKernelWriteMaxBandwidthMBps();
+    void xclSetProfilingNumberSlots(xdp::MonitorType type, uint32_t numSlots);
+    size_t xclPerfMonClockTraining(xdp::MonitorType type);
+    // Counters
+    size_t xclPerfMonStartCounters(xdp::MonitorType type);
+    size_t xclPerfMonStopCounters(xdp::MonitorType type);
+    size_t xclPerfMonReadCounters(xdp::MonitorType type, xdp::CounterResults &counterResults);
+    // Trace
+    size_t xclPerfMonStartTrace(xdp::MonitorType type, uint32_t startTrigger);
+    size_t xclPerfMonStopTrace(xdp::MonitorType type);
+    uint32_t xclPerfMonGetTraceCount(xdp::MonitorType type);
+    size_t xclPerfMonReadTrace(xdp::MonitorType type, xdp::TraceEventsVector &traceVector);
 
-      ~CpuemShim();
-      CpuemShim(unsigned int deviceIndex, xclDeviceInfo2 &info, std::list<xclemulation::DDRBank>& DDRBankList, bool bUnified,
-        bool bXPR, FeatureRomHeader &featureRom, const boost::property_tree::ptree & platformData);
+    // Sanity checks
+    int xclGetDeviceInfo2(xclDeviceInfo2 *info);
+    static unsigned xclProbe();
+    void fillDeviceInfo(xclDeviceInfo2 *dest, xclDeviceInfo2 *src);
+    void saveDeviceProcessOutput();
 
-      static CpuemShim *handleCheck(void *handle);
-      bool isGood() const;
+    void set_messagesize(unsigned int messageSize) { message_size = messageSize; }
+    unsigned int get_messagesize() { return message_size; }
 
-      int xclOpenContext(const uuid_t xclbinId, unsigned int ipIndex, bool shared);
-      int xclExecWait(int timeoutMilliSec);
-      int xclExecBuf(unsigned int cmdBO);
-      int xclCloseContext(const uuid_t xclbinId, unsigned int ipIndex);
-      //Get CU index from IP_LAYOUT section for corresponding kernel name
-      int xclIPName2Index(const char *name);
+    ~CpuemShim();
+    CpuemShim(unsigned int deviceIndex, xclDeviceInfo2 &info, std::list<xclemulation::DDRBank> &DDRBankList, bool bUnified,
+              bool bXPR, FeatureRomHeader &featureRom, const boost::property_tree::ptree &platformData);
 
-      bool isValidCu(uint32_t cu_index);
-      uint64_t getCuAddRange(uint32_t cu_index);
-      std::string getDeviceProcessLogPath();
-      bool isValidOffset(uint32_t offset, uint64_t cuAddRange);
-      int xclRegRW(bool rd, uint32_t cu_index, uint32_t offset, uint32_t *datap);
-      int xclRegRead(uint32_t cu_index, uint32_t offset, uint32_t *datap);
-      int xclRegWrite(uint32_t cu_index, uint32_t offset, uint32_t data);
-      bool isImported(unsigned int _bo)
-      {
-        if (mImportedBOs.find(_bo) != mImportedBOs.end())
-          return true;
-        return false;
-      }
-      struct exec_core* getExecCore() { return mCore; }
-      SWScheduler* getScheduler() { return mSWSch; }
+    static CpuemShim *handleCheck(void *handle);
+    bool isGood() const;
 
-      // New API's for m2m and no-dma
-      void constructQueryTable();
-      int deviceQuery(key_type queryKey);
-      void messagesThread();
+    int xclOpenContext(const uuid_t xclbinId, unsigned int ipIndex, bool shared);
+    int xclExecWait(int timeoutMilliSec);
+    int xclExecBuf(unsigned int cmdBO);
+    int xclCloseContext(const uuid_t xclbinId, unsigned int ipIndex);
+    //Get CU index from IP_LAYOUT section for corresponding kernel name
+    int xclIPName2Index(const char *name);
 
-      //******************************* XRT Graph API's **************************************************//
-      /**
+    bool isValidCu(uint32_t cu_index);
+    uint64_t getCuAddRange(uint32_t cu_index);
+    std::string getDeviceProcessLogPath();
+    bool isValidOffset(uint32_t offset, uint64_t cuAddRange);
+    int xclRegRW(bool rd, uint32_t cu_index, uint32_t offset, uint32_t *datap);
+    int xclRegRead(uint32_t cu_index, uint32_t offset, uint32_t *datap);
+    int xclRegWrite(uint32_t cu_index, uint32_t offset, uint32_t data);
+    bool isImported(unsigned int _bo)
+    {
+      if (mImportedBOs.find(_bo) != mImportedBOs.end())
+        return true;
+      return false;
+    }
+    struct exec_core *getExecCore() { return mCore; }
+    SWScheduler *getScheduler() { return mSWSch; }
+
+    // New API's for m2m and no-dma
+    void constructQueryTable();
+    int deviceQuery(key_type queryKey);
+    void messagesThread();
+
+    //******************************* XRT Graph API's **************************************************//
+    /**
       * xrtGraphInit() - Initialize graph
       *
       * @gh:             Handle to graph previously opened with xrtGraphOpen.
@@ -185,10 +189,10 @@ namespace xclcpuemhal2 {
       *
       * Note: Run by enable tiles and disable tile reset
       */
-      int
-        xrtGraphInit(void * gh);
+    int
+    xrtGraphInit(void *gh);
 
-      /**
+    /**
       * xrtGraphRun() - Start a graph execution
       *
       * @gh:             Handle to graph previously opened with xrtGraphOpen.
@@ -197,10 +201,10 @@ namespace xclcpuemhal2 {
       *
       * Note: Run by enable tiles and disable tile reset
       */
-      int
-        xrtGraphRun(void * gh, uint32_t iterations);
+    int
+    xrtGraphRun(void *gh, uint32_t iterations);
 
-      /**
+    /**
       * xrtGraphWait() -  Wait a given AIE cycle since the last xrtGraphRun and
       *                   then stop the graph. If cycle is 0, busy wait until graph
       *                   is done. If graph already run more than the given
@@ -213,10 +217,10 @@ namespace xclcpuemhal2 {
       * Note: This API with non-zero AIE cycle is for graph that is running
       * forever or graph that has multi-rate core(s).
       */
-      int
-        xrtGraphWait(void * gh);
+    int
+    xrtGraphWait(void *gh);
 
-      /**
+    /**
       * xrtGraphEnd() - Wait a given AIE cycle since the last xrtGraphRun and
       *                 then end the graph. busy wait until graph
       *                 is done before end the graph. If graph already run more
@@ -229,10 +233,10 @@ namespace xclcpuemhal2 {
       * Note: This API with non-zero AIE cycle is for graph that is running
       * forever or graph that has multi-rate core(s).
       */
-      int
-        xrtGraphEnd(void * gh);
+    int
+    xrtGraphEnd(void *gh);
 
-      /**
+    /**
       * xrtGraphUpdateRTP() - Update RTP value of port with hierarchical name
       *
       * @gh:              Handle to graph previously opened with xrtGraphOpen.
@@ -242,10 +246,10 @@ namespace xclcpuemhal2 {
       *
       * Return:          0 on success, -1 on error.
       */
-      int
-        xrtGraphUpdateRTP(void * gh, const char *hierPathPort, const char *buffer, size_t size);
+    int
+    xrtGraphUpdateRTP(void *gh, const char *hierPathPort, const char *buffer, size_t size);
 
-      /**
+    /**
       * xrtGraphUpdateRTP() - Read RTP value of port with hierarchical name
       *
       * @gh:              Handle to graph previously opened with xrtGraphOpen.
@@ -258,10 +262,10 @@ namespace xclcpuemhal2 {
       * Note: Caller is reponsible for allocating enough memory for RTP value
       *       being copied to.
       */
-      int
-        xrtGraphReadRTP(void * gh, const char *hierPathPort, char *buffer, size_t size);
+    int
+    xrtGraphReadRTP(void *gh, const char *hierPathPort, char *buffer, size_t size);
 
-      /**
+    /**
       * xrtSyncBOAIENB() - Transfer data between DDR and Shim DMA channel
       *
       * @bo:           BO obj.
@@ -275,246 +279,248 @@ namespace xclcpuemhal2 {
       * Synchronize the buffer contents between GMIO and AIE.
       * Note: Upon return, the synchronization is submitted or error out
       */
-      int
-        xrtSyncBOAIENB(xrt::bo& bo, const char *gmioname, enum xclBOSyncDirection dir, size_t size, size_t offset);
+    int
+    xrtSyncBOAIENB(xrt::bo &bo, const char *gmioname, enum xclBOSyncDirection dir, size_t size, size_t offset);
 
-      /**
+    /**
       * xrtGMIOWait() - Wait a shim DMA channel to be idle for a given GMIO port
       *
       * @gmioName:        GMIO port name
       *
       * Return:          0 on success, or appropriate error number.
       */
-      int
-        xrtGMIOWait(const char *gmioname);
+    int
+    xrtGMIOWait(const char *gmioname);
 
-      /**
+    /**
       * xrtGraphResume() - Resume a suspended graph.
       *
       * Resume graph execution which was paused by suspend() or wait(cycles) APIs
       */
-      int
-        xrtGraphResume(void * gh);
+    int
+    xrtGraphResume(void *gh);
 
-      /**
+    /**
       * xrtGraphTimedEnd() - Wait a given AIE cycle since the last xrtGraphRun and
       *                 then end the graph. If cycle is 0, busy wait until graph
       *                 is done before end the graph. If graph already run more
       *                 than the given cycle, stop the graph immediately and end it.
       */
-      int
-        xrtGraphTimedEnd(void * gh, uint64_t cycle);
+    int
+    xrtGraphTimedEnd(void *gh, uint64_t cycle);
 
-      /**
+    /**
       * xrtGraphTimedWait() -  Wait a given AIE cycle since the last xrtGraphRun and
       *                   then stop the graph. If cycle is 0, busy wait until graph
       *                   is done. If graph already run more than the given
       *                   cycle, stop the graph immediateley.
       */
-      int
-        xrtGraphTimedWait(void * gh, uint64_t cycle);
+    int
+    xrtGraphTimedWait(void *gh, uint64_t cycle);
 
-      // //******************************* XRT Graph API's **************************************************//
-      // /**
-      // * xrtGraphInit() - Initialize graph
-      // *
-      // * @gh:             Handle to graph previously opened with xrtGraphOpen.
-      // * Return:          0 on success, -1 on error
-      // *
-      // * Note: Run by enable tiles and disable tile reset
-      // */
-      // int
-      //   xrtGraphInit(void * gh);
-      //
-      // /**
-      // * xrtGraphRun() - Start a graph execution
-      // *
-      // * @gh:             Handle to graph previously opened with xrtGraphOpen.
-      // * @iterations:     The run iteration to update to graph. 0 for infinite.
-      // * Return:          0 on success, -1 on error
-      // *
-      // * Note: Run by enable tiles and disable tile reset
-      // */
-      // int
-      //   xrtGraphRun(void * gh, uint32_t iterations);
-      //
-      // /**
-      // * xrtGraphWait() -  Wait a given AIE cycle since the last xrtGraphRun and
-      // *                   then stop the graph. If cycle is 0, busy wait until graph
-      // *                   is done. If graph already run more than the given
-      // *                   cycle, stop the graph immediateley.
-      // *
-      // * @gh:              Handle to graph previously opened with xrtGraphOpen.
-      // *
-      // * Return:          0 on success, -1 on error.
-      // *
-      // * Note: This API with non-zero AIE cycle is for graph that is running
-      // * forever or graph that has multi-rate core(s).
-      // */
-      // int
-      //   xrtGraphWait(void * gh);
-      //
-      // /**
-      // * xrtGraphEnd() - Wait a given AIE cycle since the last xrtGraphRun and
-      // *                 then end the graph. busy wait until graph
-      // *                 is done before end the graph. If graph already run more
-      // *                 than the given cycle, stop the graph immediately and end it.
-      // *
-      // * @gh:              Handle to graph previously opened with xrtGraphOpen.
-      // *
-      // * Return:          0 on success, -1 on timeout.
-      // *
-      // * Note: This API with non-zero AIE cycle is for graph that is running
-      // * forever or graph that has multi-rate core(s).
-      // */
-      // int
-      //   xrtGraphEnd(void * gh);
-      //
-      // /**
-      // * xrtGraphUpdateRTP() - Update RTP value of port with hierarchical name
-      // *
-      // * @gh:              Handle to graph previously opened with xrtGraphOpen.
-      // * @hierPathPort:    hierarchial name of RTP port.
-      // * @buffer:          pointer to the RTP value.
-      // * @size:            size in bytes of the RTP value.
-      // *
-      // * Return:          0 on success, -1 on error.
-      // */
-      // int
-      //   xrtGraphUpdateRTP(void * gh, const char *hierPathPort, const char *buffer, size_t size);
-      //
-      // /**
-      // * xrtGraphUpdateRTP() - Read RTP value of port with hierarchical name
-      // *
-      // * @gh:              Handle to graph previously opened with xrtGraphOpen.
-      // * @hierPathPort:    hierarchial name of RTP port.
-      // * @buffer:          pointer to the buffer that RTP value is copied to.
-      // * @size:            size in bytes of the RTP value.
-      // *
-      // * Return:          0 on success, -1 on error.
-      // *
-      // * Note: Caller is reponsible for allocating enough memory for RTP value
-      // *       being copied to.
-      // */
-      // int
-      //   xrtGraphReadRTP(void * gh, const char *hierPathPort, char *buffer, size_t size);
+    // //******************************* XRT Graph API's **************************************************//
+    // /**
+    // * xrtGraphInit() - Initialize graph
+    // *
+    // * @gh:             Handle to graph previously opened with xrtGraphOpen.
+    // * Return:          0 on success, -1 on error
+    // *
+    // * Note: Run by enable tiles and disable tile reset
+    // */
+    // int
+    //   xrtGraphInit(void * gh);
+    //
+    // /**
+    // * xrtGraphRun() - Start a graph execution
+    // *
+    // * @gh:             Handle to graph previously opened with xrtGraphOpen.
+    // * @iterations:     The run iteration to update to graph. 0 for infinite.
+    // * Return:          0 on success, -1 on error
+    // *
+    // * Note: Run by enable tiles and disable tile reset
+    // */
+    // int
+    //   xrtGraphRun(void * gh, uint32_t iterations);
+    //
+    // /**
+    // * xrtGraphWait() -  Wait a given AIE cycle since the last xrtGraphRun and
+    // *                   then stop the graph. If cycle is 0, busy wait until graph
+    // *                   is done. If graph already run more than the given
+    // *                   cycle, stop the graph immediateley.
+    // *
+    // * @gh:              Handle to graph previously opened with xrtGraphOpen.
+    // *
+    // * Return:          0 on success, -1 on error.
+    // *
+    // * Note: This API with non-zero AIE cycle is for graph that is running
+    // * forever or graph that has multi-rate core(s).
+    // */
+    // int
+    //   xrtGraphWait(void * gh);
+    //
+    // /**
+    // * xrtGraphEnd() - Wait a given AIE cycle since the last xrtGraphRun and
+    // *                 then end the graph. busy wait until graph
+    // *                 is done before end the graph. If graph already run more
+    // *                 than the given cycle, stop the graph immediately and end it.
+    // *
+    // * @gh:              Handle to graph previously opened with xrtGraphOpen.
+    // *
+    // * Return:          0 on success, -1 on timeout.
+    // *
+    // * Note: This API with non-zero AIE cycle is for graph that is running
+    // * forever or graph that has multi-rate core(s).
+    // */
+    // int
+    //   xrtGraphEnd(void * gh);
+    //
+    // /**
+    // * xrtGraphUpdateRTP() - Update RTP value of port with hierarchical name
+    // *
+    // * @gh:              Handle to graph previously opened with xrtGraphOpen.
+    // * @hierPathPort:    hierarchial name of RTP port.
+    // * @buffer:          pointer to the RTP value.
+    // * @size:            size in bytes of the RTP value.
+    // *
+    // * Return:          0 on success, -1 on error.
+    // */
+    // int
+    //   xrtGraphUpdateRTP(void * gh, const char *hierPathPort, const char *buffer, size_t size);
+    //
+    // /**
+    // * xrtGraphUpdateRTP() - Read RTP value of port with hierarchical name
+    // *
+    // * @gh:              Handle to graph previously opened with xrtGraphOpen.
+    // * @hierPathPort:    hierarchial name of RTP port.
+    // * @buffer:          pointer to the buffer that RTP value is copied to.
+    // * @size:            size in bytes of the RTP value.
+    // *
+    // * Return:          0 on success, -1 on error.
+    // *
+    // * Note: Caller is reponsible for allocating enough memory for RTP value
+    // *       being copied to.
+    // */
+    // int
+    //   xrtGraphReadRTP(void * gh, const char *hierPathPort, char *buffer, size_t size);
 
-      ////////////////////////////////////////////////////////////////
-      // Internal SHIM APIs
-      ////////////////////////////////////////////////////////////////
-      // aka xclOpenContextByName
-      xrt_core::cuidx_type
-      open_cu_context(const xrt::hw_context& hwctx, const std::string& cuname);
+    ////////////////////////////////////////////////////////////////
+    // Internal SHIM APIs
+    ////////////////////////////////////////////////////////////////
+    // aka xclOpenContextByName
+    xrt_core::cuidx_type
+    open_cu_context(const xrt::hw_context &hwctx, const std::string &cuname);
 
-    private:
-      std::shared_ptr<xrt_core::device> mCoreDevice;
-      std::mutex mMemManagerMutex;
+  private:
+    std::shared_ptr<xrt_core::device> mCoreDevice;
+    std::mutex mMemManagerMutex;
 
-      // Performance monitoring helper functions
-      bool isDSAVersion(double checkVersion, bool onlyThisVersion);
-      uint64_t getHostTraceTimeNsec();
-      uint64_t getPerfMonBaseAddress(xdp::MonitorType type);
-      uint64_t getPerfMonFifoBaseAddress(xdp::MonitorType type, uint32_t fifonum);
-      uint64_t getPerfMonFifoReadBaseAddress(xdp::MonitorType type, uint32_t fifonum);
-      uint32_t getPerfMonNumberSlots(xdp::MonitorType type);
-      uint32_t getPerfMonNumberSamples(xdp::MonitorType type);
-      uint32_t getPerfMonNumberFifos(xdp::MonitorType type);
-      uint32_t getPerfMonByteScaleFactor(xdp::MonitorType type);
-      uint8_t  getPerfMonShowIDS(xdp::MonitorType type);
-      uint8_t  getPerfMonShowLEN(xdp::MonitorType type);
-      size_t resetFifos(xdp::MonitorType type);
-      uint32_t bin2dec(std::string str, int start, int number);
-      uint32_t bin2dec(const char * str, int start, int number);
-      std::string dec2bin(uint32_t n);
-      std::string dec2bin(uint32_t n, unsigned bits);
-      void closeMessengerThread();
+    // Performance monitoring helper functions
+    bool isDSAVersion(double checkVersion, bool onlyThisVersion);
+    uint64_t getHostTraceTimeNsec();
+    uint64_t getPerfMonBaseAddress(xdp::MonitorType type);
+    uint64_t getPerfMonFifoBaseAddress(xdp::MonitorType type, uint32_t fifonum);
+    uint64_t getPerfMonFifoReadBaseAddress(xdp::MonitorType type, uint32_t fifonum);
+    uint32_t getPerfMonNumberSlots(xdp::MonitorType type);
+    uint32_t getPerfMonNumberSamples(xdp::MonitorType type);
+    uint32_t getPerfMonNumberFifos(xdp::MonitorType type);
+    uint32_t getPerfMonByteScaleFactor(xdp::MonitorType type);
+    uint8_t getPerfMonShowIDS(xdp::MonitorType type);
+    uint8_t getPerfMonShowLEN(xdp::MonitorType type);
+    size_t resetFifos(xdp::MonitorType type);
+    uint32_t bin2dec(std::string str, int start, int number);
+    uint32_t bin2dec(const char *str, int start, int number);
+    std::string dec2bin(uint32_t n);
+    std::string dec2bin(uint32_t n, unsigned bits);
+    void closeMessengerThread();
 
-      std::mutex mtx;
-      unsigned int message_size;
-      bool simulator_started;
+    std::mutex mtx;
+    unsigned int message_size;
+    bool simulator_started;
 
-      std::ofstream mLogStream;
-      xclVerbosityLevel mVerbosity;
+    std::ofstream mLogStream;
+    xclVerbosityLevel mVerbosity;
 
-      std::vector<std::string> mTempdlopenfilenames;
-      std::string deviceName;
-      std::string deviceDirectory;
-      // a thread variable which calls messagesThread,
-      // messagesThread is a joinable thread used to display any messages seen in device_process.log
-      std::thread mMessengerThread;
-      std::list<xclemulation::DDRBank> mDdrBanks;
-      std::map<uint64_t,std::pair<std::string,unsigned int>> kernelArgsInfo;
-      xclDeviceInfo2 mDeviceInfo;
+    std::vector<std::string> mTempdlopenfilenames;
+    std::string deviceName;
+    std::string deviceDirectory;
+    // a thread variable which calls messagesThread,
+    // messagesThread is a joinable thread used to display any messages seen in device_process.log
+    std::thread mMessengerThread;
+    std::list<xclemulation::DDRBank> mDdrBanks;
+    std::map<uint64_t, std::pair<std::string, unsigned int>> kernelArgsInfo;
+    xclDeviceInfo2 mDeviceInfo;
 
-      void launchDeviceProcess(bool debuggable, std::string& binDir);
-      void launchTempProcess();
-      void initMemoryManager(std::list<xclemulation::DDRBank>& DDRBankList);
-      std::vector<xclemulation::MemoryManager *> mDDRMemoryManager;
+    void launchDeviceProcess(bool debuggable, std::string &binDir);
+    void launchTempProcess();
+    void initMemoryManager(std::list<xclemulation::DDRBank> &DDRBankList);
+    std::vector<xclemulation::MemoryManager *> mDDRMemoryManager;
 
-      void* ci_buf;
-      call_packet_info ci_msg;
+    void *ci_buf;
+    call_packet_info ci_msg;
 
-      response_packet_info ri_msg;
-      void* ri_buf;
-      size_t alloc_void(size_t new_size);
+    response_packet_info ri_msg;
+    void *ri_buf;
+    size_t alloc_void(size_t new_size);
 
-      void* buf;
-      size_t buf_size;
-      unsigned int binaryCounter;
-      unix_socket* sock;
-      unix_socket* aiesim_sock;
+    void *buf;
+    size_t buf_size;
+    unsigned int binaryCounter;
+    unix_socket *sock;
+    unix_socket *aiesim_sock;
 
+    uint64_t mRAMSize;
+    size_t mCoalesceThreshold;
+    unsigned int mDeviceIndex;
+    bool mCloseAll;
 
-      uint64_t mRAMSize;
-      size_t mCoalesceThreshold;
-      unsigned int mDeviceIndex;
-      bool mCloseAll;
-
-      std::mutex mProcessLaunchMtx;
-      std::mutex mApiMtx;
-      static bool mFirstBinary;
-      bool bUnified;
-      bool bXPR;
-      // HAL2 RELATED member variables start
-      std::map<int, xclemulation::drm_xocl_bo*> mXoclObjMap;
-      static unsigned int mBufferCount;
-      static std::map<int, std::tuple<std::string, uint64_t, void*> > mFdToFileNameMap;
-      // HAL2 RELATED member variables end
-      std::list<std::tuple<uint64_t, void*, std::map<uint64_t, uint64_t> > > mReqList;
-      uint64_t mReqCounter;
-      FeatureRomHeader mFeatureRom;
-      boost::property_tree::ptree mPlatformData;
-      std::map<key_type, std::string> mQueryTable;
-      std::map<std::string, uint64_t> mCURangeMap;
-      xrt::xclbin m_xclbin;
-      std::set<unsigned int > mImportedBOs;
-      exec_core* mCore;
-      SWScheduler* mSWSch;
-      bool mIsKdsSwEmu;
-      std::atomic<bool> mIsDeviceProcessStarted;
+    std::mutex mProcessLaunchMtx;
+    std::mutex mApiMtx;
+    static bool mFirstBinary;
+    bool bUnified;
+    bool bXPR;
+    // HAL2 RELATED member variables start
+    std::map<int, xclemulation::drm_xocl_bo *> mXoclObjMap;
+    static unsigned int mBufferCount;
+    static std::map<int, std::tuple<std::string, uint64_t, void *>> mFdToFileNameMap;
+    // HAL2 RELATED member variables end
+    std::list<std::tuple<uint64_t, void *, std::map<uint64_t, uint64_t>>> mReqList;
+    uint64_t mReqCounter;
+    FeatureRomHeader mFeatureRom;
+    boost::property_tree::ptree mPlatformData;
+    std::map<key_type, std::string> mQueryTable;
+    std::map<std::string, uint64_t> mCURangeMap;
+    xrt::xclbin m_xclbin;
+    std::set<unsigned int> mImportedBOs;
+    exec_core *mCore;
+    SWScheduler *mSWSch;
+    bool mIsKdsSwEmu;
+    std::atomic<bool> mIsDeviceProcessStarted;
   };
 
-  class GraphType {
+  class GraphType
+  {
     // Core device to which the graph belongs.  The core device
     // has been loaded with an xclbin from which meta data can
     // be extracted
   public:
-    GraphType(xclcpuemhal2::CpuemShim* handle, const char* graph) {
+    GraphType(xclcpuemhal2::CpuemShim *handle, const char *graph)
+    {
       _deviceHandle = handle;
       //_xclbin_uuid = xclbin_uuid;
       _graph = graph;
       graphHandle = mGraphHandle++;
       _state = graph_state::stop;
       _name = "";
-      _startTime= 0;
+      _startTime = 0;
     }
-    xclcpuemhal2::CpuemShim*  getDeviceHandle() {  return _deviceHandle;  }
-    const char*  getGraphName() { return _graph; }
-    unsigned int  getGraphHandle() { return graphHandle; }
+    xclcpuemhal2::CpuemShim *getDeviceHandle() { return _deviceHandle; }
+    const char *getGraphName() { return _graph; }
+    unsigned int getGraphHandle() { return graphHandle; }
+
   private:
-    xclcpuemhal2::CpuemShim*  _deviceHandle;
+    xclcpuemhal2::CpuemShim *_deviceHandle;
     //const uuid_t _xclbin_uuid;
-    const char* _graph;
+    const char *_graph;
     unsigned int graphHandle;
     enum class graph_state : unsigned short
     {
@@ -531,24 +537,22 @@ namespace xclcpuemhal2 {
     std::vector<std::string> rtps;
     static unsigned int mGraphHandle;
   };
-  extern std::map<unsigned int, CpuemShim*> devices;
+  extern std::map<unsigned int, CpuemShim *> devices;
 
-   // sParseLog structure parses a file named mFileName and looks for a matchString
-   // On successfull match, print the line to the console
-   // Currently, we are using this structure to parse the external IO file that is
-   // generated by the deviceProcess during SW EMU.
+  // sParseLog structure parses a file named mFileName and looks for a matchString
+  // On successfull match, print the line to the console
+  // Currently, we are using this structure to parse the external IO file that is
+  // generated by the deviceProcess during SW EMU.
 
   struct sParseLog
   {
     std::ifstream file;
     std::string mFileName;
     std::atomic<bool> mFileExists;
-    CpuemShim * mCpuShimPtr;
+    CpuemShim *mCpuShimPtr;
 
-    sParseLog(CpuemShim * iPtr, const std::string& iDeviceLog)
-    : mFileName(iDeviceLog)
-    , mFileExists{false}
-    , mCpuShimPtr(iPtr)
+    sParseLog(CpuemShim *iPtr, const std::string &iDeviceLog)
+        : mFileName(iDeviceLog), mFileExists{false}, mCpuShimPtr(iPtr)
     {
     }
 
@@ -563,8 +567,10 @@ namespace xclcpuemhal2 {
     void closeApplicationOnMagicStrFound(const std::string &matchString)
     {
       std::string line;
-      while (std::getline(file, line)) {
-        if (line.find(matchString) != std::string::npos) {
+      while (std::getline(file, line))
+      {
+        if (line.find(matchString) != std::string::npos)
+        {
           std::cout << "Received request to end the application. Exiting the application." << std::endl;
           mCpuShimPtr->xclClose();
         }
@@ -578,8 +584,10 @@ namespace xclcpuemhal2 {
     */
     void parseLog()
     {
-      if (!mFileExists) {
-        if (boost::filesystem::exists(mFileName)) {
+      if (!mFileExists)
+      {
+        if (boost::filesystem::exists(mFileName))
+        {
           file.open(mFileName);
           if (file.is_open())
             mFileExists = true;
@@ -588,7 +596,6 @@ namespace xclcpuemhal2 {
 
       if (mFileExists)
         closeApplicationOnMagicStrFound(endOfSimulationString);
-
     }
   };
 }


### PR DESCRIPTION
Modified to refer the single MMap file to allocate the device memory instead of allocating the memory using malloc

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
We have modified to refer the single mmap file instead of multiple mmap files to align the solution and to enable the Hybrid emulation. And as part of the PR corrected the copy_bo command during p2p scenarios when single mmap is used. And these changes are specific to sw_emu. You could see lot of indentation changes to the xcl_api_macros.h and shim.cxx of sw_emu driver

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
This is an enhancement to accommodate the hybrid emulation, not a bug

#### How problem was solved, alternative solutions (if any) and why they were rejected
No alternate solutions. This is needed to enhance the memory usage for sw_emu and support various new aie requirements

#### Risks (if any) associated the changes in the commit
No

#### What has been tested and how, request additional testing if necessary
Canary is clean and also ran the various designs manually which covers various scenarios

#### Documentation impact (if any)
not user visible change, no impact
