### PR TITLE
Vitis-6101 Support read and write directly from/to device buffer

### DIFF
--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -263,7 +263,7 @@ public:
     return export_handle;
   }
 
-  void
+  virtual void
   write(const void* src, size_t sz, size_t seek)
   {
     if (sz + seek > size)
@@ -272,7 +272,7 @@ public:
     std::memcpy(hbuf, src, sz);
   }
 
-  void
+  virtual void
   read(void* dst, size_t sz, size_t skip)
   {
     if (sz + skip > size)
@@ -722,6 +722,22 @@ public:
   get_hbuf() const override
   {
     throw xrt_core::error(-EINVAL, "device only buffer has no host buffer");
+  }
+
+  void
+  read(void* dst, size_t sz, size_t skip) override
+  {
+    if (sz + skip > size)
+      throw xrt_core::error(-EINVAL,"attempting to read past buffer size");
+    device->unmgd_pread(dst, sz, get_address() + skip);
+  }
+
+  void
+  write(const void* src, size_t sz, size_t seek) override
+  {
+    if (sz + seek > size)
+      throw xrt_core::error(-EINVAL,"attempting to write past buffer size");
+    device->unmgd_pwrite(src, sz, get_address() + seek);
   }
 };
 

--- a/src/runtime_src/core/include/xrt/xrt_bo.h
+++ b/src/runtime_src/core/include/xrt/xrt_bo.h
@@ -495,6 +495,9 @@ public:
    * Copy source data to host buffer of this buffer object.
    * ``seek`` specifies how many bytes to skip at the beginning
    * of the BO before copying-in ``size`` bytes to host buffer.
+   *
+   * If BO has no host backing storage, e.g. a device only buffer,
+   * then write is directly to the device buffer.
    */
   XCL_DRIVER_DLLESPEC
   void
@@ -507,6 +510,9 @@ public:
    *  Source data pointer
    *
    * Copy specified source data to host buffer of this buffer object.
+   *
+   * If BO has no host backing storage, e.g. a device only buffer,
+   * then write is directly to the device buffer.
    */
   void
   write(const void* src)
@@ -528,6 +534,9 @@ public:
    * destination.  ``skip`` specifies how many bytes to skip from the
    * beginning of the BO before copying-out ``size`` bytes of host
    * buffer.
+   *
+   * If BO has no host backing storage, e.g. a device only buffer,
+   * then read is directly from the device buffer.
    */
   XCL_DRIVER_DLLESPEC
   void
@@ -541,6 +550,9 @@ public:
    *
    * Copy content of host buffer of this buffer object to specified
    * destination.
+   *
+   * If BO has no host backing storage, e.g. a device only buffer,
+   * then read is directly from the device buffer.
    */
   void
   read(void* dst)

--- a/tests/xrt/00_hello/main.cpp
+++ b/tests/xrt/00_hello/main.cpp
@@ -24,10 +24,14 @@
 #include "xrt/xrt_kernel.h"
 #include "xrt/xrt_bo.h"
 #include "experimental/xrt_ini.h"
-/**
- * Trivial loopback example which runs OpenCL loopback kernel. Does not use OpenCL
- * runtime but directly exercises the XRT driver API.
- */
+
+// Trivial loopback example which runs OpenCL loopback kernel. Does
+// not use OpenCL runtime but directly exercises the XRT driver API.
+//
+// Misc. other tests
+//
+// % g++ -g -std=c++17 -I$XILINX_XRT/include -L$XILINX_XRT/lib -o host.exe main.cpp -lxrt_coreutil -luuid -pthread
+// % host.exe -k verify.xclbin -c hello
 
 
 static void usage()
@@ -64,7 +68,7 @@ copy_test(const xrt::device& device, size_t bytes, int32_t grpidx)
   auto bo1 = xrt::bo(device, bytes, 0, grpidx);
   auto bo1_data = bo1.map<char*>();
   std::generate_n(bo1_data, bytes, []() { return std::rand() % 256; });
-  
+
   bo1.sync(XCL_BO_SYNC_BO_TO_DEVICE , bytes , 0);
 
   auto bo2 = xrt::bo(device, bytes, 0, grpidx);
@@ -73,6 +77,20 @@ copy_test(const xrt::device& device, size_t bytes, int32_t grpidx)
   auto bo2_data = bo2.map<char*>();
   if (!std::equal(bo1_data, bo1_data + bytes, bo2_data))
     throw std::runtime_error("Value read back from copy bo does not match value written");
+}
+
+static void
+rw_test(const xrt::device& device, size_t bytes, int32_t grpidx)
+{
+  xrt::bo bo1(device, bytes, xrt::bo::flags::device_only, grpidx);
+  std::vector<char> buf1(bytes, 'a');
+  bo1.write(buf1.data(), bytes, 0);
+
+  std::vector<char> buf2(bytes, 'b');
+  bo1.read(buf2.data(), bytes, 0);
+
+  if (!std::equal(buf1.begin(), buf1.end(), buf2.begin()))
+    throw std::runtime_error("Value read back from device only bo does not match value written");
 }
 
 static void
@@ -87,7 +105,7 @@ register_test(const xrt::kernel& kernel, int argno)
   }
   catch (const std::exception& ex) {
     std::cout << "Expected failure reading kernel register (" << ex.what() << ")\n";
-  }      
+  }
 }
 
 static void
@@ -150,7 +168,7 @@ int run(int argc, char** argv)
 
   // Configuration options can be change before accessed
   ini_test();
-  
+
   auto device = xrt::device(device_index);
   auto uuid = device.load_xclbin(xclbin_fnm);
   auto kernel = xrt::kernel(device, uuid, cu_name);
@@ -161,6 +179,9 @@ int run(int argc, char** argv)
 
   // Copy through host not 64 byte aligned
   copy_test(device, 40, grpidx);
+
+  // Read write test of device only BO
+  rw_test(device, 1024, grpidx);
 
   // Test of kernel.read_register (expected failure)
   register_test(kernel, 0);


### PR DESCRIPTION
#### Problem solved by the commit
This PR extends the semantics of xclUnmgdPwrite/read into the native
xrt::bo APIs.  The xcl APIs are deprecated and should not be used.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
To avoid of host memcpy with the usage of xclSynBO(), Vitis AI runtime
(VART) currently leverages xclUnmgdPwrite() and xclUnmgdPread() to
perform PCIe DMA data transfer between host and device so as to
achieve better performance.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Extend xrt::bo::read() and xrt::bo::write() to write directly to
device buffer if buffer object has not host backing storage.

#### Risks (if any) associated the changes in the commit
None, exposes previously unsupported functionality

#### What has been tested and how, request additional testing if necessary
Test case updated for quick sanity check

#### Documentation impact (if any)
Inline doxygen updated.
