### PR TITLE
Use xocl_memcpy_fromio/toio to replace memcpy_fromio/toio

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_ctrl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_ctrl.c
@@ -436,7 +436,7 @@ int __ert_ctrl_submit(struct ert_ctrl *ec, struct xgq_cmd_sq_hdr *req, uint32_t 
 		ret = xgq_consume(&ec->ec_ctrl_xgq, &slot_addr);
 		if (!ret) {
 			xocl_memcpy_fromio(resp, (void __iomem *)slot_addr, resp_size);
-			xocl_memcpy_fromio(&cq_hdr, (void __iomem *)slot_addr, sizeof(cq_hdr));
+			memcpy_fromio(&cq_hdr, (void __iomem *)slot_addr, sizeof(cq_hdr));
 			xgq_notify_peer_consumed(&ec->ec_ctrl_xgq);
 			break;
 		}

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_ctrl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_ctrl.c
@@ -422,7 +422,7 @@ int __ert_ctrl_submit(struct ert_ctrl *ec, struct xgq_cmd_sq_hdr *req, uint32_t 
 	req->cid = g_ctrl_xgq_cid++;
 
 	ert_ctrl_pre_process(ec, req->opcode, (void *)slot_addr);
-	memcpy_toio((void __iomem *)slot_addr, req, req_size);
+	xocl_memcpy_toio((void __iomem *)slot_addr, req, req_size);
 
 	xgq_notify_peer_produced(&ec->ec_ctrl_xgq);
 
@@ -435,8 +435,8 @@ int __ert_ctrl_submit(struct ert_ctrl *ec, struct xgq_cmd_sq_hdr *req, uint32_t 
 
 		ret = xgq_consume(&ec->ec_ctrl_xgq, &slot_addr);
 		if (!ret) {
-			memcpy_fromio(resp, (void __iomem *)slot_addr, resp_size);
-			memcpy_fromio(&cq_hdr, (void __iomem *)slot_addr, sizeof(cq_hdr));
+			xocl_memcpy_fromio(resp, (void __iomem *)slot_addr, resp_size);
+			xocl_memcpy_fromio(&cq_hdr, (void __iomem *)slot_addr, sizeof(cq_hdr));
 			xgq_notify_peer_consumed(&ec->ec_ctrl_xgq);
 			break;
 		}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
On X86, Linux kernel API memcpy_fromio/toio will use "movsl" instruction under the hook.
This might lead to some strange issues on 64bit unfriendly hardware. Thus we introduce xocl_memcpy_fromio/toio to make sure all IO area access is 32 bits based. To be safe, replace memcpy_fromio/toio.  

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
U50/Vck5000 validate test

#### Documentation impact (if any)
No