### PR TITLE
CR-1130186 Refactor verify test to use XRT native API instead of OpenCL

### DIFF
--- a/tests/validate/verify_test/CMakeLists.txt
+++ b/tests/validate/verify_test/CMakeLists.txt
@@ -3,7 +3,6 @@
 #
 set(TESTNAME "validate.exe")
 
-set(xrt_core_LIBRARY xrt_core)
 set(xrt_coreutil_LIBRARY xrt_coreutil)
 
 include_directories(
@@ -20,7 +19,7 @@ add_executable(${TESTNAME}
 target_link_libraries(${TESTNAME} PRIVATE ${xrt_coreutil_LIBRARY} ${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY})
 
 if (NOT WIN32)
-  target_link_libraries(${TESTNAME} PRIVATE ${uuid_LIBRARY}  pthread ${xrt_coreutil_LIBRARY} ${xrt_core_LIBRARY})
+  target_link_libraries(${TESTNAME} PRIVATE ${uuid_LIBRARY}  pthread ${xrt_coreutil_LIBRARY})
 endif(NOT WIN32)
 
 if (NOT DEFINED XRT_VALIDATE_DIR)

--- a/tests/validate/verify_test/CMakeLists.txt
+++ b/tests/validate/verify_test/CMakeLists.txt
@@ -3,26 +3,16 @@
 #
 set(TESTNAME "validate.exe")
 
-if (WIN32)
-  set(OpenCL_INCLUDE_DIR ${OCL_ROOT}/include)
-  find_library(OpenCL_LIBRARY
-    NAMES OpenCL
-    HINTS "${OCL_ROOT}/lib")
-  include_directories(${OpenCL_INCLUDE_DIR})
-else()
-  find_package(OpenCL)
-endif(WIN32)
+set(xrt_core_LIBRARY xrt_core)
+set(xrt_coreutil_LIBRARY xrt_coreutil)
 
 include_directories(
-  ../../../src/include/1_2
   ../../../src/runtime_src/core/include src/
-  ../common/includes/xcl2
   ../common/includes/cmdparser
   ../common/includes/logger
   )
 
 add_executable(${TESTNAME}
-  ../common/includes/xcl2/xcl2.cpp
   ../common/includes/cmdparser/cmdlineparser.cpp
   ../common/includes/logger/logger.cpp src/host.cpp
   )
@@ -30,7 +20,7 @@ add_executable(${TESTNAME}
 target_link_libraries(${TESTNAME} PRIVATE ${xrt_coreutil_LIBRARY} ${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY})
 
 if (NOT WIN32)
-  target_link_libraries(${TESTNAME} PRIVATE ${uuid_LIBRARY} pthread ${OpenCL_LIBRARY} )
+  target_link_libraries(${TESTNAME} PRIVATE ${uuid_LIBRARY}  pthread ${xrt_coreutil_LIBRARY} ${xrt_core_LIBRARY})
 endif(NOT WIN32)
 
 if (NOT DEFINED XRT_VALIDATE_DIR)
@@ -44,7 +34,6 @@ install(TARGETS ${TESTNAME}
 if (XRT_STATIC_BUILD)
   set(TESTNAME_STATIC "validate_static.exe")
   add_executable(${TESTNAME_STATIC}
-    ../common/includes/xcl2/xcl2.cpp
     ../common/includes/cmdparser/cmdlineparser.cpp
     ../common/includes/logger/logger.cpp src/host.cpp
     )
@@ -61,7 +50,6 @@ if (XRT_STATIC_BUILD)
     )
   target_link_libraries(${TESTNAME_STATIC}
     PRIVATE
-    xilinxopencl_static
     xrt++_static
     xrt_core_static
     xrt_coreutil_static

--- a/tests/validate/verify_test/CMakeLists.txt
+++ b/tests/validate/verify_test/CMakeLists.txt
@@ -7,16 +7,11 @@ set(xrt_coreutil_LIBRARY xrt_coreutil)
 
 include_directories(
   ../../../src/runtime_src/core/include src/
-  ../common/includes/cmdparser
-  ../common/includes/logger
   )
 
 add_executable(${TESTNAME}
-  ../common/includes/cmdparser/cmdlineparser.cpp
-  ../common/includes/logger/logger.cpp src/host.cpp
+  src/host.cpp
   )
-
-target_link_libraries(${TESTNAME} PRIVATE ${xrt_coreutil_LIBRARY} ${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY})
 
 if (NOT WIN32)
   target_link_libraries(${TESTNAME} PRIVATE ${uuid_LIBRARY}  pthread ${xrt_coreutil_LIBRARY})
@@ -33,14 +28,13 @@ install(TARGETS ${TESTNAME}
 if (XRT_STATIC_BUILD)
   set(TESTNAME_STATIC "validate_static.exe")
   add_executable(${TESTNAME_STATIC}
-    ../common/includes/cmdparser/cmdlineparser.cpp
-    ../common/includes/logger/logger.cpp src/host.cpp
+    src/host.cpp
     )
   # Specify path directory with boost static libraries. The boost link dir
   # should be same as the one used to build XRT. In most case this is the
   # default /usr/lib, but if XRT was built with -with-static-boost, then
   # the libraries cannot be located without specified the link path.
-  target_link_options(${TESTNAME_STATIC} PRIVATE "-static" "-L${Boost_LIBRARY_DIRS}")
+  target_link_options(${TESTNAME_STATIC} PRIVATE "-static")
   target_link_libraries(${TESTNAME_STATIC}
     PRIVATE
     # force linking of whole archive to enable static globals

--- a/tests/validate/verify_test/src/host.cpp
+++ b/tests/validate/verify_test/src/host.cpp
@@ -64,16 +64,14 @@ int main(int argc, char** argv) {
     auto krnl = xrt::kernel(device, xclbin_uuid, "verify");
 
     // Allocate the output buffer to hold the kernel ooutput
-    auto bank_grp_arg0 = krnl.group_id(0);
-    auto output_buffer = xrt::bo(device, sizeof(char) * LENGTH, bank_grp_arg0);
+    auto output_buffer = xrt::bo(device, sizeof(char) * LENGTH, krnl.group_id(0));
 
     // Run the kernel and store its contents within the allocated output buffer
     auto run = krnl(output_buffer);
     run.wait();
 
     // Prepare local buffer
-    char received_data[LENGTH];
-    std::memset(received_data, 0, LENGTH);
+    char received_data[LENGTH] = {};
 
     // Acquire and read the buffer data
     output_buffer.sync(XCL_BO_SYNC_BO_FROM_DEVICE);

--- a/tests/validate/verify_test/src/host.cpp
+++ b/tests/validate/verify_test/src/host.cpp
@@ -18,8 +18,7 @@
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
 
-#include <string.h>
-#include <algorithm>
+#include <cstring>
 #define LENGTH 64
 
 static void printHelp() {
@@ -78,7 +77,7 @@ int main(int argc, char** argv) {
 
     // Compare received data against expected data
     std::string expected_data = "Hello World\n";
-    if (std::equal(expected_data.begin(), expected_data.end(), received_data)) {
+    if (std::memcmp(received_data, expected_data.data(), expected_data.size())) {
         std::cout << "TEST FAILED\n";
         throw std::runtime_error("Value read back does not match reference");
     }

--- a/tests/validate/verify_test/src/host.cpp
+++ b/tests/validate/verify_test/src/host.cpp
@@ -14,13 +14,12 @@
 * under the License.
 */
 
-#include "xrt/xrt_device.h"
 #include "xrt/xrt_bo.h"
+#include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
 
-#include <boost/filesystem.hpp>
+#include <string.h>
 #include <algorithm>
-#include <vector>
 #define LENGTH 64
 
 static void printHelp() {
@@ -79,7 +78,7 @@ int main(int argc, char** argv) {
 
     // Compare received data against expected data
     std::string expected_data = "Hello World\n";
-    if (std::memcmp(expected_data.c_str(), received_data, expected_data.size()) != 0) {
+    if (std::equal(expected_data.begin(), expected_data.end(), received_data)) {
         std::cout << "TEST FAILED\n";
         throw std::runtime_error("Value read back does not match reference");
     }

--- a/tests/validate/verify_test/src/host.cpp
+++ b/tests/validate/verify_test/src/host.cpp
@@ -78,8 +78,8 @@ int main(int argc, char** argv) {
     output_buffer.read(received_data);
 
     // Compare received data against expected data
-    char expected_data[LENGTH] = "Hello World\n";
-    if (std::memcmp(expected_data, received_data, LENGTH) != 0) {
+    std::string expected_data = "Hello World\n";
+    if (std::memcmp(expected_data.c_str(), received_data, expected_data.size()) != 0) {
         std::cout << "TEST FAILED\n";
         throw std::runtime_error("Value read back does not match reference");
     }

--- a/tests/validate/verify_test/src/host.cpp
+++ b/tests/validate/verify_test/src/host.cpp
@@ -13,7 +13,11 @@
 * License for the specific language governing permissions and limitations
 * under the License.
 */
-#include "xcl2.hpp"
+
+#include "xrt/xrt_device.h"
+#include "xrt/xrt_bo.h"
+#include "xrt/xrt_kernel.h"
+
 #include <boost/filesystem.hpp>
 #include <algorithm>
 #include <vector>
@@ -49,96 +53,39 @@ int main(int argc, char** argv) {
         std::cout << "ERROR : please provide the platform test path to -p option\n";
         return EXIT_FAILURE;
     }
-    auto binaryFile = boost::filesystem::path(test_path) / b_file;
-    std::ifstream infile(binaryFile.string());
-    if (flag_s) {
-        if (!infile.good()) {
-            std::cout << "\nNOT SUPPORTED" << std::endl;
-            return EOPNOTSUPP;
-        } else {
-            std::cout << "\nSUPPORTED" << std::endl;
-            return EXIT_SUCCESS;
-        }
+
+    // Get the device reference using the device argument
+    auto device = xrt::device(dev_id);
+
+    std::cout << "Trying to program device...\n";
+    auto xclbin_uuid = device.load_xclbin(test_path.append(b_file));
+    std::cout << "Device program successful!\n";
+
+    auto krnl = xrt::kernel(device, xclbin_uuid, "verify");
+
+    // Allocate the output buffer to hold the kernel ooutput
+    auto bank_grp_arg0 = krnl.group_id(0);
+    auto output_buffer = xrt::bo(device, sizeof(char) * LENGTH, bank_grp_arg0);
+
+    // Run the kernel and store its contents within the allocated output buffer
+    auto run = krnl(output_buffer);
+    run.wait();
+
+    // Prepare local buffer
+    char received_data[LENGTH];
+    std::memset(received_data, 0, LENGTH);
+
+    // Acquire and read the buffer data
+    output_buffer.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
+    output_buffer.read(received_data);
+
+    // Compare received data against expected data
+    char expected_data[LENGTH] = "Hello World\n";
+    if (std::memcmp(expected_data, received_data, LENGTH) != 0) {
+        std::cout << "TEST FAILED\n";
+        throw std::runtime_error("Value read back does not match reference");
     }
 
-    if (!infile.good()) {
-        std::cout << "\nNOT SUPPORTED" << std::endl;
-        return EOPNOTSUPP;
-    }
-    cl_int err;
-    cl::Context context;
-    cl::Kernel krnl_verify;
-    cl::CommandQueue q;
-
-    std::vector<char, aligned_allocator<char> > h_buf(LENGTH);
-
-    // Create the test data
-    for (int i = 0; i < LENGTH; i++) {
-        h_buf[i] = 0;
-    }
-
-    // OPENCL HOST CODE AREA START
-    // get_xil_devices() is a utility API which will find the xilinx
-    // platforms and will return list of devices connected to Xilinx platform
-    auto devices = xcl::get_xil_devices();
-    std::vector<cl::Platform> platforms;
-    OCL_CHECK(err, err = cl::Platform::get(&platforms));
-    std::string platform_vers(1024, '\0'), platform_prof(1024, '\0'), platform_exts(1024, '\0');
-    OCL_CHECK(err, err = platforms[0].getInfo(CL_PLATFORM_VERSION, &platform_vers));
-    OCL_CHECK(err, err = platforms[0].getInfo(CL_PLATFORM_PROFILE, &platform_prof));
-    OCL_CHECK(err, err = platforms[0].getInfo(CL_PLATFORM_EXTENSIONS, &platform_exts));
-    std::cout << "Platform Version: " << platform_vers << std::endl;
-    std::cout << "Platform Profile: " << platform_prof << std::endl;
-    std::cout << "Platform Extensions: " << platform_exts << std::endl;
-
-    // read_binary_file() is a utility API which will load the binaryFile
-    // and will return the pointer to file buffer.
-    auto fileBuf = xcl::read_binary_file(binaryFile.string());
-    cl::Program::Binaries bins{{fileBuf.data(), fileBuf.size()}};
-
-    auto pos = dev_id.find(":");
-    cl::Device device;
-    if (pos == std::string::npos) {
-        uint32_t device_index = stoi(dev_id);
-        if (device_index >= devices.size()) {
-            std::cout << "The device_index provided using -d flag is outside the range of "
-                         "available devices\n";
-            return EXIT_FAILURE;
-        }
-        device = devices[device_index];
-    } else {
-        if (xcl::is_emulation()) {
-            std::cout << "Device bdf is not supported for the emulation flow\n";
-            return EXIT_FAILURE;
-        }
-        device = xcl::find_device_bdf(devices, dev_id);
-    }
-
-    // Creating Context and Command Queue for selected Device
-    OCL_CHECK(err, context = cl::Context(device, nullptr, nullptr, nullptr, &err));
-    OCL_CHECK(err, q = cl::CommandQueue(context, device, CL_QUEUE_PROFILING_ENABLE, &err));
-    std::cout << "Trying to program device " << device.getInfo<CL_DEVICE_NAME>() << std::endl;
-    cl::Program program(context, {device}, bins, nullptr, &err);
-    if (err != CL_SUCCESS) {
-        std::cout << "Failed to program device with xclbin file!\n";
-    } else {
-        std::cout << "Device program successful!\n";
-        OCL_CHECK(err, krnl_verify = cl::Kernel(program, "verify", &err));
-    }
-
-    OCL_CHECK(err, cl::Buffer d_buf(context, CL_MEM_WRITE_ONLY, sizeof(char) * LENGTH, nullptr, &err));
-
-    OCL_CHECK(err, err = krnl_verify.setArg(0, d_buf));
-
-    // Launch the Kernel
-    OCL_CHECK(err, err = q.enqueueTask(krnl_verify));
-    q.finish();
-
-    OCL_CHECK(err, err = q.enqueueReadBuffer(d_buf, CL_TRUE, 0, sizeof(char) * LENGTH, h_buf.data(), nullptr, nullptr));
-    q.finish();
-    for (int i = 0; i < 12; i++) {
-        std::cout << h_buf[i];
-    }
     std::cout << "TEST PASSED\n";
     return 0;
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1130186
The verify test failure is not being passed back correctly to the xbutil tool. The test uses the OpenCl framework which prevents immediate feedback and suppresses task return codes which makes handing back valid failure information difficult. As a result the DMA test would fail due to the verify kernel test task not succeeding. 

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Discovered via test case failure.

#### How problem was solved, alternative solutions (if any) and why they were rejected
The problem was solved by migrating the verify executable to use the XRT native API which does not suffer from the same limitation.

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Ubutntu 20 \ u55c
Detecting failure
```
dbenusov@xsjpranjal01:/proj/rdi/staff/dbenusov$ ./XRT/build/Debug/opt/xilinx/xrt/test/validate.exe -p /opt/xilinx/firmware/u55c/gen3x16-xdma/base/test/ -d 0000:17:00.1
Trying to program device...
Device program successful!
terminate called after throwing an instance of 'xrt_core::system_error'
  what():  unable to sync BO: Input/output error
Aborted (core dumped)
dbenusov@xsjpranjal01:/proj/rdi/staff/dbenusov$ echo $?
134
dbenusov@xsjpranjal01:/proj/rdi/staff/dbenusov$ xbutil validate -d 17:00 -r verify
Starting validation for 1 devices

Validate Device           : [0000:17:00.1]
    Platform              : xilinx_u55c_gen3x16_xdma_base_3
    SC Version            : 7.1.17
    Platform ID           : 97088961-FEAE-DA91-52A2-1D9DFD63CCEF
-------------------------------------------------------------------------------
Test 1 [0000:17:00.1]     : verify
    Error(s)              :
                            terminate called after throwing an instance of
                            'xrt_core::system_error'
                              what():  unable to sync BO: Input/output error
    Test Status           : [FAILED]
-------------------------------------------------------------------------------
Validation failed. Please run the command '--verbose' option for more details
```
Detecting success
```
dbenusov@xsjpranjal01:/proj/rdi/staff/dbenusov/XRT$ ./build/Debug/opt/xilinx/xrt/test/validate.exe -p /opt/xilinx/firmware/u55c/gen3x16-xdma/base/test/ -d 0000:17:00.1
Trying to program device...
Device program successful!
TEST PASSED
dbenusov@xsjpranjal01:/proj/rdi/staff/dbenusov/XRT$ xbutil validate -d 17:00 -r verify
Starting validation for 1 devices

Validate Device           : [0000:17:00.1]
    Platform              : xilinx_u55c_gen3x16_xdma_base_3
    SC Version            : 7.1.17
    Platform ID           : 97088961-FEAE-DA91-52A2-1D9DFD63CCEF
-------------------------------------------------------------------------------
Test 1 [0000:17:00.1]     : verify
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Validation completed. Please run the command '--verbose' option for more details
```
#### Documentation impact (if any)
None
