### PR TITLE
hw ctx support for PCI shim and xocl driver 

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/include/xocl_ioctl.h
+++ b/src/runtime_src/core/pcie/driver/linux/include/xocl_ioctl.h
@@ -77,6 +77,8 @@
  * 11   Send an execute job to a compute unit  DRM_IOCTL_XOCL_EXECBUF         drm_xocl_execbuf
  * 12   Register eventfd handle for MSIX       DRM_IOCTL_XOCL_USER_INTR       drm_xocl_user_intr
  *      interrupt
+ * 13   Register a specifi xclbin image with   DRM_IOCTL_XOCL_REGISTER_AXLF   drm_xocl_axlf
+ *      the device
  * 13   Update device view with a specific     DRM_IOCTL_XOCL_READ_AXLF       drm_xocl_axlf
  *      xclbin image
  * 14   Obtain info of bo                      DRM_IOCTL_XOCL_INFO            drm_xocl_info_bo
@@ -152,6 +154,8 @@ enum drm_xocl_ops {
 	DRM_XOCL_EXECBUF,
 	/* Register eventfd for user interrupts */
 	DRM_XOCL_USER_INTR,
+	/* Register xclbin/axlf */
+	DRM_XOCL_REGISTER_AXLF,
 	/* Read xclbin/axlf */
 	DRM_XOCL_READ_AXLF,
 	/* Hot reset request */
@@ -500,6 +504,9 @@ struct drm_xocl_pread_bo {
 enum drm_xocl_ctx_code {
 	XOCL_CTX_OP_ALLOC_CTX = 0,
 	XOCL_CTX_OP_FREE_CTX,
+	XOCL_CTX_OP_ALLOC_HW_CTX,
+	XOCL_CTX_OP_FREE_HW_CTX,
+	XOCL_CTX_OP_OPEN_CU_CTX,
 	XOCL_CTX_OP_OPEN_UCU_FD,
 };
 
@@ -510,7 +517,8 @@ enum drm_xocl_ctx_code {
  * struct drm_xocl_ctx - Open or close a context on a compute unit on device
  * used with DRM_XOCL_CTX ioctl
  *
- * @op:            Alloc or free a context (XOCL_CTX_OP_ALLOC_CTX/XOCL_CTX_OP_FREE_CTX)
+ * @op:            Alloc or free a context (XOCL_CTX_OP_ALLOC_CTX/XOCL_CTX_OP_FREE_CTX/
+ * 					XOCL_CTX_OP_ALLOC_HW_CTX/XOCL_CTX_OP_FREE_HW_CTX)
  * @xclbin_id:	   UUID of the device image (xclbin)
  * @cu_index:	   Index of the compute unit in the device inage for which
  *                 the request is being made
@@ -522,8 +530,8 @@ struct drm_xocl_ctx {
 	xuid_t   xclbin_id;
 	uint32_t cu_index;
 	uint32_t flags;
-	// unused, in future it would return context id
-	uint32_t handle;
+	// it return context id
+	uint32_t  handle;
 };
 
 struct drm_xocl_info {
@@ -699,6 +707,7 @@ struct drm_xocl_alloc_cma_info {
 #define	DRM_IOCTL_XOCL_CTX		XOCL_IOC_ARG(CTX, ctx)
 #define	DRM_IOCTL_XOCL_INFO		XOCL_IOC_ARG(INFO, info)
 #define	DRM_IOCTL_XOCL_READ_AXLF	XOCL_IOC_ARG(READ_AXLF, axlf)
+#define	DRM_IOCTL_XOCL_REGISTER_AXLF	XOCL_IOC_ARG(REGISTER_AXLF, axlf)
 #define	DRM_IOCTL_XOCL_PWRITE_UNMGD	XOCL_IOC_ARG(PWRITE_UNMGD, pwrite_unmgd)
 #define	DRM_IOCTL_XOCL_PREAD_UNMGD	XOCL_IOC_ARG(PREAD_UNMGD, pread_unmgd)
 #define	DRM_IOCTL_XOCL_USAGE_STAT	XOCL_IOC_ARG(USAGE_STAT, usage_stat)

--- a/src/runtime_src/core/pcie/driver/linux/include/xocl_ioctl.h
+++ b/src/runtime_src/core/pcie/driver/linux/include/xocl_ioctl.h
@@ -528,6 +528,7 @@ enum drm_xocl_ctx_code {
 struct drm_xocl_ctx {
 	enum drm_xocl_ctx_code op;
 	xuid_t   xclbin_id;
+	char	 cu_name[64];
 	uint32_t cu_index;
 	uint32_t flags;
 	// it return context id

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/common.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/common.h
@@ -103,8 +103,6 @@ struct xocl_dev	{
 	struct xocl_subdev	*dyn_subdev_store;
 	int			dyn_subdev_num;
 
-	void			*ulp_blob;
-
 	unsigned int		mbx_offset;
 
 	uint64_t		mig_cache_expire_secs;
@@ -161,6 +159,8 @@ int xocl_user_intr_ioctl(struct drm_device *dev, void *data,
 	struct drm_file *filp);
 int xocl_read_axlf_ioctl(struct drm_device *dev, void *data,
 	struct drm_file *filp);
+int xocl_register_axlf_ioctl(struct drm_device *dev, void *data,
+	struct drm_file *filp);
 int xocl_hot_reset_ioctl(struct drm_device *dev, void *data,
 	struct drm_file *filp);
 int xocl_reclock_ioctl(struct drm_device *dev, void *data,
@@ -193,7 +193,9 @@ void xocl_reset_notify(struct pci_dev *pdev, bool prepare);
 void user_pci_reset_prepare(struct pci_dev *pdev);
 void user_pci_reset_done(struct pci_dev *pdev);
 #endif
-
+int xocl_unregister_axlf_by_index(struct xocl_dev *xdev, uint32_t idx);
+int xocl_download_axlf_helper(struct xocl_drm *drm_p, 
+		struct xocl_axlf_obj_cache *axlf_obj, uint32_t *slot_hndl);
 int xocl_refresh_subdevs(struct xocl_dev *xdev);
 
 u32 get_live_clients(struct xocl_dev *xdev, pid_t **pid_list);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
@@ -412,6 +412,8 @@ static const struct drm_ioctl_desc xocl_ioctls[] = {
 			  DRM_AUTH|DRM_UNLOCKED|DRM_RENDER_ALLOW),
 	DRM_IOCTL_DEF_DRV(XOCL_READ_AXLF, xocl_read_axlf_ioctl,
 			  DRM_AUTH|DRM_UNLOCKED|DRM_RENDER_ALLOW),
+	DRM_IOCTL_DEF_DRV(XOCL_REGISTER_AXLF, xocl_register_axlf_ioctl,
+			  DRM_AUTH|DRM_UNLOCKED|DRM_RENDER_ALLOW),
 	DRM_IOCTL_DEF_DRV(XOCL_PWRITE_UNMGD, xocl_pwrite_unmgd_ioctl,
 			  DRM_AUTH|DRM_UNLOCKED|DRM_RENDER_ALLOW),
 	DRM_IOCTL_DEF_DRV(XOCL_PREAD_UNMGD, xocl_pread_unmgd_ioctl,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
@@ -1163,6 +1163,20 @@ static int identify_bar(struct xocl_dev *xdev)
 		identify_bar_legacy(xdev);
 }
 
+static void xocl_unregister_axlf(struct xocl_dev *xdev)
+{
+        int i = 0;
+        struct xocl_dev_core *xdev_core = XDEV(xdev);
+
+        /* Check if this uuid already exists */
+        for (i = 0; i < MAX_SLOT_SUPPORT; i++) {
+                if (!xdev_core->axlf_obj[i])
+                        continue;
+		
+		xocl_unregister_axlf_by_index(xdev, i);
+        }
+}
+
 void xocl_userpf_remove(struct pci_dev *pdev)
 {
 	struct xocl_dev		*xdev;
@@ -1208,8 +1222,7 @@ void xocl_userpf_remove(struct pci_dev *pdev)
 	unmap_bar(xdev);
 
 	xocl_subdev_fini(xdev);
-	if (xdev->ulp_blob)
-		vfree(xdev->ulp_blob);
+	xocl_unregister_axlf(xdev);
 	mutex_destroy(&xdev->dev_lock);
 
 	if (xdev->core.bars)

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
@@ -521,7 +521,7 @@ get_next_free_cache_index(struct xocl_dev *xdev, const xuid_t *uuid)
 	}
 
 
-	/* SAIF TODO : Check the ref_cnt of axlf_obj, to delete
+	/* TODO : Check the ref_cnt of axlf_obj, to delete
 	 * some unused xclbin cache data to make some room for
 	 * new xclbin.
 	 */	

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -256,7 +256,7 @@ static int xocl_open_cu_context(struct xocl_dev *xdev, struct kds_client *client
 			goto out;
 		}
 
-		/* SAIF TODO : Currently using cache index.. This should be slot index */
+		/* TODO : Currently using cache index.. This should be slot index */
 		axlf_obj = XDEV(xdev)->axlf_obj[args->handle];
 		if (!axlf_obj)
 			goto out1;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_sysfs.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_sysfs.c
@@ -704,20 +704,28 @@ static DEVICE_ATTR_RO(logic_uuids);
 static ssize_t ulp_uuids_show(struct device *dev,
 		struct device_attribute *attr, char *buf)
 {
+        struct xocl_axlf_obj_cache *axlf_obj = NULL;
 	struct xocl_dev *xdev = dev_get_drvdata(dev);
 	const void *uuid;
 	int node = -1, off = 0;
+        int i = 0;
 
-	if (!xdev->ulp_blob || fdt_check_header(xdev->ulp_blob))
-		return -EINVAL;
+	for (i = 0; i < MAX_SLOT_SUPPORT; i++) {
+		axlf_obj = XDEV(xdev)->axlf_obj[i];
+		/* First free Index */
+		if (!axlf_obj)
+			continue;
 
-	for (node = xocl_fdt_get_next_prop_by_name(xdev, xdev->ulp_blob,
-		-1, PROP_INTERFACE_UUID, &uuid, NULL);
-	    uuid && node > 0;
-	    node = xocl_fdt_get_next_prop_by_name(xdev, xdev->ulp_blob,
-		node, PROP_INTERFACE_UUID, &uuid, NULL))
-		off += sprintf(buf + off, "%s\n", (char *)uuid);
+		if (!axlf_obj->ulp_blob || fdt_check_header(axlf_obj->ulp_blob))
+			return -EINVAL;
 
+		for (node = xocl_fdt_get_next_prop_by_name(xdev, axlf_obj->ulp_blob,
+					-1, PROP_INTERFACE_UUID, &uuid, NULL);
+				uuid && node > 0;
+				node = xocl_fdt_get_next_prop_by_name(xdev, axlf_obj->ulp_blob,
+					node, PROP_INTERFACE_UUID, &uuid, NULL))
+			off += sprintf(buf + off, "%s\n", (char *)uuid);
+	}
 	return off;
 }
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -2098,7 +2098,7 @@ xocl_query_kernel(xdev_handle_t xdev_hdl, const char *name)
 	int off = 0;
 	int i = 0;
 
-	/* SAIF TODO : Assumption that no two kernel names are same for
+	/* TODO : Assumption that no two kernel names are same for
 	 * two different XCLBIN.
 	 */
 	for (i = 0; i < MAX_SLOT_SUPPORT; i++) {

--- a/src/runtime_src/core/pcie/linux/shim.h
+++ b/src/runtime_src/core/pcie/linux/shim.h
@@ -158,6 +158,7 @@ public:
   register_xclbin(const xrt::xclbin&);
 
 private:
+  bool legacyCtxSupport;
   std::shared_ptr<xrt_core::device> mCoreDevice;
   std::shared_ptr<pcidev::pci_device> mDev;
   std::ofstream mLogStream;

--- a/src/runtime_src/core/pcie/linux/shim.h
+++ b/src/runtime_src/core/pcie/linux/shim.h
@@ -70,6 +70,7 @@ public:
   int xclGetBOProperties(unsigned int boHandle, xclBOProperties *properties);
 
   // Bitstream/bin download
+  int xclRegisterAxlf(const xclBin *buffer);
   int xclLoadXclBin(const xclBin *buffer);
   int xclGetErrorStatus(xclErrorStatus *info);
   int xclGetDeviceInfo2(xclDeviceInfo2 *info);

--- a/tests/validate/CMakeLists.txt
+++ b/tests/validate/CMakeLists.txt
@@ -36,3 +36,6 @@ add_subdirectory(ps_validate_test)
 add_subdirectory(ps_aie_test)
 add_subdirectory(ps_bandwidth_test)
 add_subdirectory(ps_iops_test)
+
+# New HW Context tests
+add_subdirectory(verify_hw_ctx_test)

--- a/tests/validate/verify_hw_ctx_test/CMakeLists.txt
+++ b/tests/validate/verify_hw_ctx_test/CMakeLists.txt
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2022 Xilinx, Inc. All rights reserved.
+#
+set(TESTNAME "validate_hw_ctx.exe")
+
+set(xrt_core_LIBRARY xrt_core)
+set(xrt_coreutil_LIBRARY xrt_coreutil)
+
+include_directories(
+  ../../../src/runtime_src/core/include src/
+  ../common/includes/cmdparser
+  ../common/includes/logger
+  )
+
+add_executable(${TESTNAME}
+  ../common/includes/cmdparser/cmdlineparser.cpp
+  ../common/includes/logger/logger.cpp src/host.cpp
+  )
+
+target_link_libraries(${TESTNAME} PRIVATE ${xrt_coreutil_LIBRARY})
+
+if (NOT WIN32)
+  target_link_libraries(${TESTNAME} PRIVATE ${uuid_LIBRARY}  pthread ${xrt_coreutil_LIBRARY} ${xrt_core_LIBRARY})
+endif(NOT WIN32)
+
+if (NOT DEFINED XRT_VALIDATE_DIR)
+  set(XRT_VALIDATE_DIR "${CMAKE_CURRENT_BINARY_DIR}/")
+endif()
+
+install(TARGETS ${TESTNAME}
+  RUNTIME DESTINATION ${XRT_VALIDATE_DIR}
+  ) 

--- a/tests/validate/verify_hw_ctx_test/src/host.cpp
+++ b/tests/validate/verify_hw_ctx_test/src/host.cpp
@@ -36,7 +36,7 @@ static void printHelp() {
 int main(int argc, char** argv) {
     std::string dev_id = "0";
     std::string test_path;
-    std::string b_file = "/ps_validate_bandwidth.xclbin";
+    std::string b_file = "/verify.xclbin";
     bool flag_s = false;
     for (int i = 1; i < argc; i++) {
         if ((strcmp(argv[i], "-p") == 0) || (strcmp(argv[i], "--path") == 0)) {
@@ -78,8 +78,8 @@ int main(int argc, char** argv) {
 
     auto uuid = device.register_xclbin(xrt::xclbin{binaryfile});
     xrt::hw_context ctx{device, uuid};
-    //auto hello_world = xrt::kernel(device, uuid.get(), "hello_world");
-    auto hello_world = xrt::kernel(ctx, "hello_world");
+    //auto hello_world = xrt::kernel(device, uuid.get(), "verify");
+    auto hello_world = xrt::kernel(ctx, "verify");
     const size_t DATA_SIZE = COUNT * sizeof(int);
     auto bo0 = xrt::bo(device, DATA_SIZE, hello_world.group_id(0));
     auto bo1 = xrt::bo(device, DATA_SIZE, hello_world.group_id(1));

--- a/tests/validate/verify_hw_ctx_test/src/host.cpp
+++ b/tests/validate/verify_hw_ctx_test/src/host.cpp
@@ -1,0 +1,123 @@
+/**
+* Copyright (C) 2022 Xilinx, Inc
+*
+* Licensed under the Apache License, Version 2.0 (the "License"). You may
+* not use this file except in compliance with the License. A copy of the
+* License is located at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+* License for the specific language governing permissions and limitations
+* under the License.
+*/
+#include <algorithm>
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <vector>
+// XRT includes
+#include "experimental/xrt_system.h"
+#include "xrt/xrt_device.h"
+#include "xrt/xrt_kernel.h"
+#include "xrt/xrt_bo.h"
+static const int COUNT = 1024;
+
+static void printHelp() {
+    std::cout << "usage: %s <options>\n";
+    std::cout << "  -p <path>\n";
+    std::cout << "  -d <device> \n";
+    std::cout << "  -s <supported>\n";
+    std::cout << "  -h <help>\n";
+}
+
+int main(int argc, char** argv) {
+    std::string dev_id = "0";
+    std::string test_path;
+    std::string b_file = "/ps_validate_bandwidth.xclbin";
+    bool flag_s = false;
+    for (int i = 1; i < argc; i++) {
+        if ((strcmp(argv[i], "-p") == 0) || (strcmp(argv[i], "--path") == 0)) {
+            test_path = argv[i + 1];
+        } else if ((strcmp(argv[i], "-d") == 0) || (strcmp(argv[i], "--device") == 0)) {
+            dev_id = argv[i + 1];
+        } else if ((strcmp(argv[i], "-s") == 0) || (strcmp(argv[i], "--supported") == 0)) {
+            flag_s = true;
+        } else if ((strcmp(argv[i], "-h") == 0) || (strcmp(argv[i], "--help") == 0)) {
+            printHelp();
+            return 1;
+        }
+    }
+
+    if (test_path.empty()) {
+        std::cout << "ERROR : please provide the platform test path to -p option\n";
+        return EXIT_FAILURE;
+    }
+    std::string binaryfile = test_path + b_file;
+    std::ifstream infile(binaryfile);
+    if (flag_s) {
+        if (!infile.good()) {
+            std::cout << "\nNOT SUPPORTED" << std::endl;
+            return EOPNOTSUPP;
+        } else {
+            std::cout << "\nSUPPORTED" << std::endl;
+            return EXIT_SUCCESS;
+        }
+    }
+
+    if (!infile.good()) {
+        std::cout << "\nNOT SUPPORTED" << std::endl;
+        return EOPNOTSUPP;
+    }
+
+    auto num_devices = xrt::system::enumerate_devices();
+
+    auto device = xrt::device {dev_id};
+
+    auto uuid = device.register_xclbin(xrt::xclbin{binaryfile});
+    xrt::hw_context ctx{device, uuid};
+    //auto hello_world = xrt::kernel(device, uuid.get(), "hello_world");
+    auto hello_world = xrt::kernel(ctx, "hello_world");
+    const size_t DATA_SIZE = COUNT * sizeof(int);
+    auto bo0 = xrt::bo(device, DATA_SIZE, hello_world.group_id(0));
+    auto bo1 = xrt::bo(device, DATA_SIZE, hello_world.group_id(1));
+    auto bo0_map = bo0.map<int*>();
+    auto bo1_map = bo1.map<int*>();
+    std::fill(bo0_map, bo0_map + COUNT, 0);
+    std::fill(bo1_map, bo1_map + COUNT, 0);
+
+    // Fill our data sets with pattern
+    int bufReference[COUNT];
+    bo0_map[0] = 'h';
+    bo0_map[1] = 'e';
+    bo0_map[2] = 'l';
+    bo0_map[3] = 'l';
+    bo0_map[4] = 'o';
+    for (int i = 5; i < COUNT; ++i) {
+      bo0_map[i] = 0;
+      bo1_map[i] = i;
+      bufReference[i] = i;
+    }
+    
+    bo0.sync(XCL_BO_SYNC_BO_TO_DEVICE, DATA_SIZE, 0);
+    bo1.sync(XCL_BO_SYNC_BO_TO_DEVICE, DATA_SIZE, 0);
+    
+    auto run = hello_world(bo0, bo1, COUNT);
+    run.wait();
+    
+    //Get the output;
+    bo1.sync(XCL_BO_SYNC_BO_FROM_DEVICE, DATA_SIZE, 0);
+    
+    // Validate our results
+    if (std::memcmp(bo1_map, bo0_map, DATA_SIZE)) {
+      for (int i=0;i< COUNT;i++) {
+	std::cout << "bo0[" << i << "] = " << bo0_map[i] << ", bo1[" << i << "] = " << bo1_map[i] << std::endl;
+      }
+      throw std::runtime_error("Value read back does not match reference");
+      return EXIT_FAILURE;
+    }
+    std::cout << "TEST PASSED\n";
+    return 0;
+}


### PR DESCRIPTION
I have added support for new hw context for pci shim and xocl driver, 
The changes are backward comparability. The existing code is minimal modified to make sure it will not break the existing flow. 
Basic validate is working fine. 

