### PR TITLE
Automatically handle devtoolset-9

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -3,11 +3,25 @@
 set -e
 
 OSDIST=`grep '^ID=' /etc/os-release | awk -F= '{print $2}' | tr -d '"'`
+VERSION=`grep '^VERSION_ID=' /etc/os-release | awk -F= '{print $2}' | tr -d '"'`
+MAJOR=${VERSION%.*}
 BUILDDIR=$(readlink -f $(dirname ${BASH_SOURCE[0]}))
 CORE=`grep -c ^processor /proc/cpuinfo`
 CMAKE=cmake
 CMAKE_MAJOR_VERSION=`cmake --version | head -n 1 | awk '{print $3}' |awk -F. '{print $1}'`
 CPU=`uname -m`
+
+# Documentation states that devtoolset-9 is a requirement for building on RHEL/CentOS 7.x
+if [[ ( $OSDIST == "rhel" || $OSDIST == "centos" ) && $MAJOR -lt "8" ]]; then
+    echo "Setting up devtoolset-9"
+    {
+        # Try
+	source scl_source enable devtoolset-9
+    } || {
+        # Except
+	echo "devtoolset-9 is not installed, please run xrtdeps.sh" && exit 1
+    }
+fi
 
 if [[ $CMAKE_MAJOR_VERSION != 3 ]]; then
     if [[ $OSDIST == "centos" ]] || [[ $OSDIST == "amzn" ]] || [[ $OSDIST == "rhel" ]] || [[ $OSDIST == "fedora" ]]; then

--- a/build/build.sh
+++ b/build/build.sh
@@ -3,23 +3,26 @@
 set -e
 
 OSDIST=`grep '^ID=' /etc/os-release | awk -F= '{print $2}' | tr -d '"'`
-VERSION=`grep '^VERSION_ID=' /etc/os-release | awk -F= '{print $2}' | tr -d '"'`
-MAJOR=${VERSION%.*}
+OSVERSION=`grep '^VERSION_ID=' /etc/os-release | awk -F= '{print $2}' | tr -d '"'`
+OSMAJOR=${OSVERSION%.*}
+GCCVERSION=`gcc -v 2>&1 >/dev/null | grep 'gcc version' | awk '{print $3}'`
+GCCMAJOR=${GCCVERSION:0:1}
 BUILDDIR=$(readlink -f $(dirname ${BASH_SOURCE[0]}))
 CORE=`grep -c ^processor /proc/cpuinfo`
 CMAKE=cmake
 CMAKE_MAJOR_VERSION=`cmake --version | head -n 1 | awk '{print $3}' |awk -F. '{print $1}'`
 CPU=`uname -m`
 
-# Documentation states that devtoolset-9 is a requirement for building on RHEL/CentOS 7.x
-if [[ ( $OSDIST == "rhel" || $OSDIST == "centos" ) && $MAJOR -lt "8" ]]; then
-    echo "Setting up devtoolset-9"
+if [[ ( $OSDIST == "rhel" || $OSDIST == "centos" ) && $OSMAJOR -lt "8" && $GCCMAJOR -lt "9" ]]; then
+    # RHEL/CentOS 7.x does not have C++17 support by default
+    # Attempt fallback option with devtoolset-9
+    echo "Trying devtoolset-9"
     {
         # Try
 	source scl_source enable devtoolset-9
     } || {
         # Except
-	echo "devtoolset-9 is not installed, please run xrtdeps.sh" && exit 1
+	echo "Could not find a suitable gcc version" && exit 1
     }
 fi
 

--- a/src/runtime_src/doc/toc/build.rst
+++ b/src/runtime_src/doc/toc/build.rst
@@ -13,8 +13,8 @@ Building the XRT Installation Package
 Installing Building Dependencies
 ................................
 
-XRT requires C++17 compiler and a few development libraries bundled
-with modern Linux distribution. Please install the necessary tools and
+XRT requires a C++17 compiler and a few development libraries bundled
+with modern Linux distributions. Please install the necessary tools and
 dependencies using the provided ``xrtdeps.sh``.
 
 ::
@@ -26,8 +26,7 @@ for the tools and libraries XRT depends on. If any system libraries
 XRT depends on (for example Boost libraries) are updated to non
 standard versions, then XRT must be rebuilt.
 
-On RHEL7.x/CentOS7.x devtoolset-9 is required to switch to a C++17 devlopment
-environment.
+Note: Standard RHEL7.x/CentOS7.x distributions and associated YUM repositories do not provide a C++17 capable g++.
 
 XRT includes source code for ERT firmware. 
 It needs to be compiled with the MicroBlaze GCC compiler, which is available in `Xilinx Vitis™ Software Platform <https://www.xilinx.com/products/design-tools/vitis.html>`_. 

--- a/src/runtime_src/doc/toc/build.rst
+++ b/src/runtime_src/doc/toc/build.rst
@@ -2,7 +2,7 @@
 
 ..
    comment:: SPDX-License-Identifier: Apache-2.0
-   comment:: Copyright (C) 2019-2021 Xilinx, Inc. All rights reserved.
+   comment:: Copyright (C) 2019-2022 Xilinx, Inc. All rights reserved.
 
 Building the XRT Software Stack
 -------------------------------
@@ -13,7 +13,7 @@ Building the XRT Installation Package
 Installing Building Dependencies
 ................................
 
-XRT requires C++14 compiler and a few development libraries bundled
+XRT requires C++17 compiler and a few development libraries bundled
 with modern Linux distribution. Please install the necessary tools and
 dependencies using the provided ``xrtdeps.sh``.
 
@@ -26,13 +26,8 @@ for the tools and libraries XRT depends on. If any system libraries
 XRT depends on (for example Boost libraries) are updated to non
 standard versions, then XRT must be rebuilt.
 
-On RHEL7.x/CentOS7.x use devtoolset to switch to C++14 devlopment
-environment. This step is not applicable to Ubuntu, which already has
-C++14 capable GCC.
-
-::
-
-   scl enable devtoolset-9 bash
+On RHEL7.x/CentOS7.x devtoolset-9 is required to switch to a C++17 devlopment
+environment.
 
 XRT includes source code for ERT firmware. 
 It needs to be compiled with the MicroBlaze GCC compiler, which is available in `Xilinx Vitis™ Software Platform <https://www.xilinx.com/products/design-tools/vitis.html>`_. 
@@ -51,10 +46,6 @@ Building the XRT Runtime
    ./build.sh
 
 ``build.sh`` script builds for both Debug and Release profiles.  
-
-On RHEL/CentOS, if ``build.sh`` was accidentally run prior to enabling
-the devtoolset, then it is necessary to clean stale files makefiles by
-running ``build.sh clean`` prior to the next build.
 
 Please check ERT firmware is built properly at ``build/Release/opt/xilinx/xrt/share/fw/sched*.bin``.
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Ease of use enhancement.   
No one has to remember to do `scl enable devtoolset-9 bash`.  

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
`source scl_source enable devtoolset-9`  

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
We don't need special install instructions for building on RHEL/CentOS anymore.   
@uday610 @stsoe 