### PR TITLE
Add petalinux in apu package name

### DIFF
--- a/src/runtime_src/tools/scripts/pkgapu.sh
+++ b/src/runtime_src/tools/scripts/pkgapu.sh
@@ -297,6 +297,13 @@ fi
 dodeb $INSTALL_ROOT
 dorpm $INSTALL_ROOT
 
-cp -v $BUILD_DIR/${PKG_NAME}*.rpm $OUTPUT_DIR/${PKG_NAME}_${PKG_RELEASE}.${PKG_VER}.noarch.rpm
-cp -v $BUILD_DIR/${PKG_NAME}*.deb $OUTPUT_DIR/${PKG_NAME}_${PKG_RELEASE}.${PKG_VER}_all.deb
+# Add _petalinux in apu package name for xrt pipeline build
+# remove this check after apu package build is removed from emb pipeline
+if [[ ! -z $XRT_VERSION_PATCH ]]; then
+    cp -v $BUILD_DIR/${PKG_NAME}*.rpm $OUTPUT_DIR/${PKG_NAME}_${PKG_RELEASE}.${PKG_VER}_petalinux.noarch.rpm
+    cp -v $BUILD_DIR/${PKG_NAME}*.deb $OUTPUT_DIR/${PKG_NAME}_${PKG_RELEASE}.${PKG_VER}_petalinux_all.deb
+else
+    cp -v $BUILD_DIR/${PKG_NAME}*.rpm $OUTPUT_DIR/${PKG_NAME}_${PKG_RELEASE}.${PKG_VER}.noarch.rpm
+    cp -v $BUILD_DIR/${PKG_NAME}*.deb $OUTPUT_DIR/${PKG_NAME}_${PKG_RELEASE}.${PKG_VER}_all.deb
+fi
 rm -rf $BUILD_DIR


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Added petalinux string in apu package name, apu packages will now look like -> **xrt-apu_202220.2.14.192_petalinux_all.deb** and **xrt-apu_202220.2.14.192_petalinux.noarch.rpm**
At present adding this change only when XRT_VERSION_PATCH is defined so that package name generated from xrt pipeline is only affected.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Renaming the package after creation as package version should not change from 2.14.x

#### Risks (if any) associated the changes in the commit
none

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
NA