### PR TITLE
Add sc_pid to SCU subdevice sysfs to support PS kernel stat gathering

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/scu.c
+++ b/src/runtime_src/core/edge/drm/zocl/scu.c
@@ -32,8 +32,8 @@ struct zocl_scu {
 	 * soft cu pid and parent pid. This can be used to identify if the
 	 * soft cu is still running or not. The parent should never crash
 	 */
-	uint32_t		sc_pid;
-	uint32_t		sc_parent_pid;
+	u32		sc_pid;
+	u32		sc_parent_pid;
 };
 
 static ssize_t debug_show(struct device *dev,
@@ -92,11 +92,33 @@ stat_show(struct device *dev, struct device_attribute *attr, char *buf)
 }
 static DEVICE_ATTR_RO(stat);
 
+ssize_t show_sc_pid(u32 sc_pid, char *buf)
+{
+	ssize_t sz = 0;
+	char *fmt = "%u\n";
+
+	sz += scnprintf(buf+sz, PAGE_SIZE - sz, fmt,
+			sc_pid);
+
+	return sz;
+}
+
+static ssize_t
+sc_pid_show(struct device *dev, struct device_attribute *attr, char *buf)
+{
+	struct platform_device *pdev = to_platform_device(dev);
+	struct zocl_scu *scu = platform_get_drvdata(pdev);
+
+	return show_sc_pid(scu->sc_pid, buf);
+}
+static DEVICE_ATTR_RO(sc_pid);
+
 static struct attribute *scu_attrs[] = {
 	&dev_attr_debug.attr,
 	&dev_attr_cu_stat.attr,
 	&dev_attr_cu_info.attr,
 	&dev_attr_stat.attr,
+	&dev_attr_sc_pid.attr,
 	NULL,
 };
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Allows query of PS kernel pid

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
None

#### How problem was solved, alternative solutions (if any) and why they were rejected
Expose pid through sysfs node on SCU platform subdevice

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
PS kernel validate tests

#### Documentation impact (if any)
Example sysfs node:
/sys/devices/platform/ert_hw/SCU.4.auto/sc_pid

