### PR TITLE
XBUtilties::xclbin_lock should not use xcl APIs

### DIFF
--- a/src/runtime_src/core/tools/common/XBUtilities.h
+++ b/src/runtime_src/core/tools/common/XBUtilities.h
@@ -32,7 +32,7 @@
 #include <boost/algorithm/string.hpp>
 
 namespace XBUtilities {
- 
+
   void can_proceed_or_throw(const std::string& info, const std::string& error);
 
   void sudo_or_throw(const std::string& msg);
@@ -46,7 +46,7 @@ namespace XBUtilities {
 
   boost::property_tree::ptree
   get_available_devices(bool inUserDomain);
-  
+
    /**
    * get_axlf_section() - Get section from the file passed in
    *
@@ -72,15 +72,15 @@ namespace XBUtilities {
   get_xrt_pretty_version();
 
   /**
-   * OEM ID is a unique number called as the 
+   * OEM ID is a unique number called as the
    * Private Enterprise Number (PEN) maintained by IANA
-   * 
+   *
    * Return: Manufacturer's name
    */
-  std::string 
+  std::string
   parse_oem_id(const std::string& oemid);
 
-  std::string 
+  std::string
   parse_clock_id(const std::string& id);
 
 
@@ -95,7 +95,7 @@ namespace XBUtilities {
   uint64_t
   string_to_base_units(std::string str, const unit& conversion_unit);
 
-  inline bool 
+  inline bool
   is_power_of_2(const uint64_t x)
   {
     /*
@@ -111,29 +111,28 @@ namespace XBUtilities {
   */
   struct xclbin_lock
   {
-    xclDeviceHandle m_handle;
+    xrt_core::device* m_device;
     xuid_t m_uuid;
 
-    xclbin_lock(std::shared_ptr<xrt_core::device> _dev)
-      : m_handle(_dev->get_device_handle())
+    xclbin_lock(xrt_core::device* device)
+      : m_device(device)
     {
-      auto xclbinid = xrt_core::device_query<xrt_core::query::xclbin_uuid>(_dev);
+      auto xclbinid = xrt_core::device_query<xrt_core::query::xclbin_uuid>(m_device);
 
       uuid_parse(xclbinid.c_str(), m_uuid);
 
       if (uuid_is_null(m_uuid))
         throw std::runtime_error("'uuid' invalid, please re-program xclbin.");
 
-      if (xclOpenContext(m_handle, m_uuid, std::numeric_limits<unsigned int>::max(), true))
-        throw std::runtime_error("'Failed to lock down xclbin");
+      m_device->open_context(m_uuid, std::numeric_limits<unsigned int>::max(), true);
     }
 
-    ~xclbin_lock(){
-      xclCloseContext(m_handle, m_uuid, std::numeric_limits<unsigned int>::max());
+    ~xclbin_lock()
+    {
+      m_device->close_context(m_uuid, std::numeric_limits<unsigned int>::max());
     }
   };
 
 };
 
 #endif
-

--- a/src/runtime_src/core/tools/xbutil2/OO_MemRead.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_MemRead.cpp
@@ -80,13 +80,13 @@ OO_MemRead::execute(const SubCmdOptions& _options) const
     //-- Device
     if(m_device.size() > 1)
       throw xrt_core::error("Multiple devices not supported. Please specify a single device");
-    
+
     // Collect the device of interest
     std::set<std::string> deviceNames;
     xrt_core::device_collection deviceCollection;
-    for (const auto & deviceName : m_device) 
+    for (const auto & deviceName : m_device)
       deviceNames.insert(boost::algorithm::to_lower_copy(deviceName));
-    
+
     XBU::collect_devices(deviceNames, true /*inUserDomain*/, deviceCollection); // Can throw
     // set working variable
     device = deviceCollection.front();
@@ -129,8 +129,8 @@ OO_MemRead::execute(const SubCmdOptions& _options) const
   XBU::verbose(boost::str(boost::format("Output file: %s") % m_outputFile));
 
   //read mem
-  XBU::xclbin_lock xclbin_lock(device);
-  
+  XBU::xclbin_lock xclbin_lock(device.get());
+
   try{
     xrt_core::mem_read(device.get(), addr, size, m_outputFile);
   } catch(const xrt_core::error& e) {
@@ -139,4 +139,3 @@ OO_MemRead::execute(const SubCmdOptions& _options) const
   }
   std::cout << "Memory read succeeded" << std::endl;
 }
-

--- a/src/runtime_src/core/tools/xbutil2/OO_MemWrite.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_MemWrite.cpp
@@ -83,13 +83,13 @@ XBU::verbose("SubCommand option: read mem");
     //-- Device
     if(m_device.size() > 1)
       throw xrt_core::error("Multiple devices not supported. Please specify a single device");
-    
+
     // Collect the device of interest
     std::set<std::string> deviceNames;
     xrt_core::device_collection deviceCollection;
-    for (const auto & deviceName : m_device) 
+    for (const auto & deviceName : m_device)
       deviceNames.insert(boost::algorithm::to_lower_copy(deviceName));
-    
+
     XBU::collect_devices(deviceNames, true /*inUserDomain*/, deviceCollection); // Can throw
     // set working variable
     device = deviceCollection.front();
@@ -139,8 +139,8 @@ XBU::verbose("SubCommand option: read mem");
   XBU::verbose(boost::str(boost::format("Fill pattern: %s") % m_fill));
 
   //read mem
-  XBU::xclbin_lock xclbin_lock(device);
-  
+  XBU::xclbin_lock xclbin_lock(device.get());
+
   try {
     xrt_core::mem_write(device.get(), addr, size, fill_byte);
   } catch(const xrt_core::error& e) {
@@ -149,4 +149,3 @@ XBU::verbose("SubCommand option: read mem");
   }
   std::cout << "Memory write succeeded" << std::endl;
 }
-

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -1055,7 +1055,7 @@ p2pTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree::ptr
   }
 
   std::string msg;
-  XBU::xclbin_lock xclbin_lock(_dev);
+  XBU::xclbin_lock xclbin_lock(_dev.get());
   std::vector<std::string> config;
   try {
     config = xrt_core::device_query<xrt_core::query::p2p_config>(_dev);
@@ -1134,7 +1134,7 @@ m2mTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree::ptr
     return;
   }
 
-  XBU::xclbin_lock xclbin_lock(_dev);
+  XBU::xclbin_lock xclbin_lock(_dev.get());
   // Assume m2m is not enabled
   uint32_t m2m_enabled = 0;
   try {
@@ -1232,7 +1232,7 @@ bistTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree::pt
     return;
   }
 
-  XBU::xclbin_lock xclbin_lock(_dev);
+  XBU::xclbin_lock xclbin_lock(_dev.get());
 
   if (!clock_calibration(_dev, _dev->get_device_handle(), _ptTest))
      _ptTest.put("status", test_token_failed);


### PR DESCRIPTION
#### Problem solved by the commit
Change xcl APIs to core XRT device APIs

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
xbutil2 and xbmgmt2 should be rid of xclAPI dependencies.

#### How problem was solved, alternative solutions (if any) and why they were rejected
This is just one small change.  Subcmd validate need fixing.

