### PR TITLE
add query request to know if APU/ERT is connected

### DIFF
--- a/src/runtime_src/core/common/query_requests.cpp
+++ b/src/runtime_src/core/common/query_requests.cpp
@@ -177,4 +177,24 @@ to_range(const std::string& range_str)
   return range;
 }
 
+xrt_core::query::ert_status::ert_status_data
+xrt_core::query::ert_status::
+to_ert_status(const result_type& strs)
+{
+  using tokenizer = boost::tokenizer< boost::char_separator<char> >;
+  xrt_core::query::ert_status::ert_status_data ert_status = {0};
+
+  for (auto& line : strs) {
+    // Format on each line: "<name>: <value>"
+    boost::char_separator<char> sep(":");
+    tokenizer tokens(line, sep);
+    auto tok_it = tokens.begin();
+    if (line.find("Connected:") != std::string::npos) {
+      ert_status.connected = std::stoi(std::string(*(++tok_it)));
+    }
+  }
+
+  return ert_status;
+}
+
 }} // query, xrt_core

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -254,6 +254,7 @@ enum class key_type
   ert_cu_write,
   ert_cu_read,
   ert_data_integrity,
+  ert_status,
 
   aim_counter,
   am_counter,
@@ -2766,6 +2767,19 @@ struct ert_data_integrity : request
   {
     return value ? "Pass" : "Fail";
   }
+};
+
+struct ert_status : request
+{
+    struct data {
+        bool        connected;
+        // add more in the future
+    };
+    using result_type = struct data;
+    static const key_type key = key_type::ert_status;
+
+    virtual boost::any
+    get(const device*) const = 0;
 };
 
 struct noop : request

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -2771,15 +2771,18 @@ struct ert_data_integrity : request
 
 struct ert_status : request
 {
-    struct data {
-        bool        connected;
-        // add more in the future
-    };
-    using result_type = struct data;
-    static const key_type key = key_type::ert_status;
+  struct ert_status_data {
+    bool        connected;
+    // add more in the future
+  };
+  using result_type = std::vector<std::string>;
+  static const key_type key = key_type::ert_status;
 
-    virtual boost::any
-    get(const device*) const = 0;
+  virtual boost::any
+  get(const device*) const = 0;
+
+  static ert_status_data
+  to_ert_status(const result_type& strs);
 };
 
 struct noop : request

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -306,39 +306,6 @@ struct sdm_sensor_info
   } //get()
 };
 
-struct ert_status
-{
-  using result_type = query::ert_status::result_type;
-
-  static result_type
-  get(const xrt_core::device* device, key_type)
-  {
-    using tokenizer = boost::tokenizer< boost::char_separator<char> >;
-    auto pdev = get_pcidev(device);
-    std::vector<std::string> status;
-    result_type ertStatus = {0};
-    std::string errmsg;
-
-    pdev->sysfs_get("ert_ctrl", "status", errmsg, status);
-    if (!errmsg.empty())
-      throw xrt_core::query::sysfs_error(errmsg);
-
-    for (auto& line : status) {
-      // Format on each line: "<name>: <value>"
-      boost::char_separator<char> sep(":");
-      tokenizer tokens(line, sep);
-
-      auto tok_it = tokens.begin();
-      if (line.find("Connected:") != std::string::npos) {
-        ertStatus.connected = std::stoi(std::string(*(++tok_it)));
-        std::cout << line << std::endl;
-      }
-    }
-
-    return ertStatus;
-  }
-};
-
 struct kds_cu_info
 {
   using result_type = query::kds_cu_info::result_type;
@@ -1081,7 +1048,7 @@ initialize_query_table()
   emplace_sysfs_get<query::ert_cu_read>                        ("ert_ctrl", "cu_read_cnt");
   emplace_sysfs_get<query::ert_cu_write>                       ("ert_ctrl", "cu_write_cnt");
   emplace_sysfs_get<query::ert_data_integrity>                 ("ert_ctrl", "data_integrity");
-  emplace_func0_request<query::ert_status,                     ert_status>();
+  emplace_sysfs_get<query::ert_status>                         ("ert_ctrl", "status");
   emplace_sysfs_getput<query::config_mailbox_channel_disable>  ("", "config_mailbox_channel_disable");
   emplace_sysfs_getput<query::config_mailbox_channel_switch>   ("", "config_mailbox_channel_switch");
   emplace_sysfs_getput<query::config_xclbin_change>            ("", "config_xclbin_change");


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Add query request to identify if APU/ERT is connected. The "connected" status means that host was able to communicate with APU/ERT. It doesn't mean that APU/ERT is still alive at the moment.

This can be used to tell that if APU package is loaded from the userpf perspective.

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
