### PR TITLE
Reverted the PR #6785 changes due to IVT failure

### DIFF
--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
@@ -1484,7 +1484,7 @@ uint32_t HwEmShim::getAddressSpace (uint32_t topology)
     uint64_t finalSize = size+(2*paddingFactor*size);
     mAddrMap[finalValidAddress] = finalSize;
     bool ack = false;
-    if (sock && (boFlags & XCL_BO_FLAGS_P2P)) // bypassed the xclAllocDeviceBuffer RPC call for Non-P2P
+    if (sock)
     {
       if (boFlags & XCL_BO_FLAGS_HOST_ONLY) { // bypassed the xclAllocDeviceBuffer RPC call for Slave Bridge (host only buffer)
       } else {


### PR DESCRIPTION
Reverting the changes of PR #6785 due to a testcase failure in IVT
There is no workaround for the solution
Low Risk
We had ran the failing testcase manually which is passing with the reverted changes
No impact on Documentation
