### PR TITLE
Mark board as bad status after Ctrl XGQ error

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -2295,9 +2295,10 @@ static int __icap_download_bitstream_user(struct platform_device *pdev,
 	int err = 0;
 
 	/* TODO: Use slot handle to unregister CUs. CU subdev will be destroyed */
-	xocl_unregister_cus(xdev, 0);
-
 	xocl_subdev_destroy_by_level(xdev, XOCL_SUBDEV_LEVEL_URP);
+	err = xocl_unregister_cus(xdev, 0);
+	if (err)
+		goto done;
 
 	err = __icap_peer_xclbin_download(icap, xclbin, force_download);
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/common.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/common.h
@@ -236,7 +236,7 @@ void xocl_kds_cus_disable(struct xocl_dev *xdev);
 int xocl_kds_register_cus(struct xocl_dev *xdev, int slot_hd, xuid_t *uuid,
 			  struct ip_layout *ip_layout,
 			  struct ps_kernel_node *ps_kernel);
-void xocl_kds_unregister_cus(struct xocl_dev *xdev, int slot_hd);
+int xocl_kds_unregister_cus(struct xocl_dev *xdev, int slot_hd);
 int xocl_kds_set_cu_read_range(struct xocl_dev *xdev, u32 cu_idx,
 			       u32 start, u32 size);
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
@@ -170,7 +170,7 @@ int xocl_register_cus(xdev_handle_t xdev_hdl, int slot_hdl, xuid_t *uuid,
 	return xocl_kds_register_cus(xdev, slot_hdl, uuid, ip_layout, ps_kernel);
 }
 
-void xocl_unregister_cus(xdev_handle_t xdev_hdl, int slot_hdl)
+int xocl_unregister_cus(xdev_handle_t xdev_hdl, int slot_hdl)
 {
 	struct xocl_dev *xdev = container_of(XDEV(xdev_hdl), struct xocl_dev, core);
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -2103,10 +2103,13 @@ int xocl_kds_register_cus(struct xocl_dev *xdev, int slot_hdl, xuid_t *uuid,
 
 	ret = xocl_kds_update_xgq(xdev, slot_hdl, uuid, XDEV(xdev)->kds_cfg, ip_layout, ps_kernel);
 out:
+	if (ret)
+		XDEV(xdev)->kds.bad_state = 1;
+
 	return ret;
 }
 
-void xocl_kds_unregister_cus(struct xocl_dev *xdev, int slot_hdl)
+int xocl_kds_unregister_cus(struct xocl_dev *xdev, int slot_hdl)
 {
 	int ret = 0;
 
@@ -2115,18 +2118,23 @@ void xocl_kds_unregister_cus(struct xocl_dev *xdev, int slot_hdl)
 	if (ret) {
 		userpf_info_once(xdev, "ERT will be disabled, ret %d\n", ret);
 		XDEV(xdev)->kds.ert_disable = true;
-		return;
+		return ret;
 	}
 
 	if (!xocl_ert_ctrl_is_version(xdev, 1, 0))
-		return;
+		return ret;
 
 	// Work-around to unconfigure PS kernel
 	// Will be removed once unconfigure command is there
 	ret = xocl_kds_xgq_cfg_start(xdev, XDEV(xdev)->kds_cfg, 0, 0);
 	ret = xocl_kds_xgq_cfg_end(xdev);
 	xocl_ert_ctrl_unset_xgq(xdev);
-	kds_reset(&XDEV(xdev)->kds);
+	if (ret)
+		XDEV(xdev)->kds.bad_state = 1;
+	else
+		kds_reset(&XDEV(xdev)->kds);
+
+	return ret;
 }
 
 int xocl_kds_set_cu_read_range(struct xocl_dev *xdev, u32 cu_idx,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -2473,15 +2473,15 @@ static inline int xocl_register_cus(xdev_handle_t xdev, int slot_hdl, xuid_t *uu
 {
 	return 0;
 }
-static inline void xocl_unregister_cus(xdev_handle_t xdev, int slot_hdl)
+static inline int xocl_unregister_cus(xdev_handle_t xdev, int slot_hdl)
 {
-	return;
+	return 0;
 }
 #else
 int xocl_register_cus(xdev_handle_t xdev, int slot_hdl, xuid_t *uuid,
 		      struct ip_layout *ip_layout,
 		      struct ps_kernel_node *ps_kernel);
-void xocl_unregister_cus(xdev_handle_t xdev, int slot_hdl);
+int xocl_unregister_cus(xdev_handle_t xdev, int slot_hdl);
 #endif
 
 /* context helpers */


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
When unexpected timeout happens on control XGQ, KDS should mark this board is in bad status and not allow to use this board. Reset will be needed to recover from this bad status.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
A PS kernel change enlarge the remove scu process, then host see XGQ command timeout when unconfigure CUs.

#### Risks (if any) associated the changes in the commit
Low risk.

#### What has been tested and how, request additional testing if necessary
Vck5000 xbutil validate

#### Documentation impact (if any)
No