### PR TITLE
CR-1131190 Rtl_user_managed testcase failing in 2022.2(HEAD)

### DIFF
--- a/src/python/pybind11/src/pyxrt.cpp
+++ b/src/python/pybind11/src/pyxrt.cpp
@@ -292,7 +292,12 @@ PYBIND11_MODULE(pyxrt, m) {
         .def(py::init([](const axlf* top) {
                           return new xrt::xclbin(top);
                       }))
-        .def("get_ips", &xrt::xclbin::get_ips)
+        .def("get_ips", ([](xrt::xclbin& xbin) {
+                         xbin.get_ips();
+                      }))
+        .def("get_ips", ([](xrt::xclbin& xbin, const std::string& nm) {
+                         xbin.get_ips(nm);
+                      }))
         .def("get_kernels", &xrt::xclbin::get_kernels, "Get list of kernels from xclbin")
         .def("get_xsa_name", &xrt::xclbin::get_xsa_name, "Get Xilinx Support Archive (XSA) name of xclbin")
         .def("get_uuid", &xrt::xclbin::get_uuid, "Get the uuid of the xclbin")

--- a/src/runtime_src/core/common/api/xrt_xclbin.cpp
+++ b/src/runtime_src/core/common/api/xrt_xclbin.cpp
@@ -907,6 +907,13 @@ get_ips() const
   return handle ? handle->get_ips() : std::vector<xclbin::ip>{};
 }
 
+std::vector<xclbin::ip>
+xclbin::
+get_ips(const std::string& name) const
+{
+  return handle ? handle->get_ips(name) : std::vector<xclbin::ip>{};
+}
+
 xclbin::ip
 xclbin::
 get_ip(const std::string& name) const

--- a/src/runtime_src/core/include/experimental/xrt_xclbin.h
+++ b/src/runtime_src/core/include/experimental/xrt_xclbin.h
@@ -610,6 +610,22 @@ public:
   get_ips() const;
 
   /**
+   * get_ips() - Get list of ips that matches name
+   *
+   * @param name
+   *  Name to match against, prefixed with kernel name
+   * @return
+   *  A list of xrt::xclbin::ip objects that are compute units
+   *  of this kernel object and matches the specified name.
+   *
+   * The kernel name can optionally specify which kernel instance(s) to
+   * match "kernel:{ip1,ip2,...} syntax.
+   */
+  XCL_DRIVER_DLLESPEC
+  std::vector<ip>
+  get_ips(const std::string& name) const;
+
+  /**
    * get_ip() - Get a specific IP from the xclbin
    *
    * @return


### PR DESCRIPTION
#### Problem solved by the commit
Allow xrt::ip construction from all variations of specified name.

#### How problem was solved, alternative solutions (if any) and why they were rejected
The specified name can be either of
1. "ip", ip base name
2. "ip:inst", ip canonical name
3. "ip:{inst}", ip special braced syntax

In either case the name must specify one and only one IP or exception
is throw.

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
CR has been validate with all 3 variations of ip instance name

