### PR TITLE
CR-1135117 when hardware is tripped, avoid dmesg being flooded by 65535

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
@@ -76,7 +76,7 @@
 #define	XGQ_DEV_NAME "ospi_xgq" SUBDEV_SUFFIX
 
 static DEFINE_IDR(xocl_xgq_vmr_cid_idr);
-#define XOCL_VMR_INVALID_CID	0xFFFF;
+#define XOCL_VMR_INVALID_CID	0xFFFF
 
 /* cmd timeout in seconds */
 #define XOCL_XGQ_FLASH_TIME	msecs_to_jiffies(600 * 1000) 
@@ -181,12 +181,15 @@ static void cmd_complete(struct xocl_xgq_vmr *xgq, struct xgq_com_queue_entry *c
 	}
 
 	XGQ_WARN(xgq, "unknown cid %d received", ccmd->hdr.cid);
-	/*
-	 * Note: xgq_lock mutex is on, release the lock and offline service.
-	 */
-	mutex_unlock(&xgq->xgq_lock);
-	xgq_offline_service(xgq);
-	mutex_lock(&xgq->xgq_lock);
+	if (ccmd->hdr.cid == XOCL_VMR_INVALID_CID) {
+		XGQ_ERR(xgq, "invalid cid %d, offlineing xgq services...", ccmd->hdr.cid);
+		/*
+		 * Note: xgq_lock mutex is on, release the lock and offline service.
+		 */
+		mutex_unlock(&xgq->xgq_lock);
+		xgq_offline_service(xgq);
+		mutex_lock(&xgq->xgq_lock);
+	}
 	return;
 }
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
@@ -76,6 +76,7 @@
 #define	XGQ_DEV_NAME "ospi_xgq" SUBDEV_SUFFIX
 
 static DEFINE_IDR(xocl_xgq_vmr_cid_idr);
+#define XOCL_VMR_INVALID_CID	0xFFFF;
 
 /* cmd timeout in seconds */
 #define XOCL_XGQ_FLASH_TIME	msecs_to_jiffies(600 * 1000) 
@@ -85,7 +86,6 @@ static DEFINE_IDR(xocl_xgq_vmr_cid_idr);
 
 #define MAX_WAIT 30
 #define WAIT_INTERVAL 1000 //ms
-
 /*
  * reserved shared memory size and number for log page.
  * currently, only 1 resource controlled by sema. Can be extended to n.
@@ -156,6 +156,7 @@ struct xocl_xgq_vmr {
 };
 
 static int vmr_status_query(struct platform_device *pdev);
+static void xgq_offline_service(struct xocl_xgq_vmr *xgq);
 
 /*
  * when detect cmd is completed, find xgq_cmd from submitted_cmds list
@@ -180,6 +181,12 @@ static void cmd_complete(struct xocl_xgq_vmr *xgq, struct xgq_com_queue_entry *c
 	}
 
 	XGQ_WARN(xgq, "unknown cid %d received", ccmd->hdr.cid);
+	/*
+	 * Note: xgq_lock mutex is on, release the lock and offline service.
+	 */
+	mutex_unlock(&xgq->xgq_lock);
+	xgq_offline_service(xgq);
+	mutex_lock(&xgq->xgq_lock);
 	return;
 }
 
@@ -438,6 +445,7 @@ static void xgq_vmr_log_dump_debug(struct xocl_xgq_vmr *xgq, struct xocl_xgq_vmr
  */
 static void xgq_stop_services(struct xocl_xgq_vmr *xgq)
 {
+	XGQ_INFO(xgq, "halting xgq services");
 
 	/* stop receiving incoming commands */
 	mutex_lock(&xgq->xgq_lock);
@@ -463,8 +471,24 @@ static void xgq_stop_services(struct xocl_xgq_vmr *xgq)
 		msleep(XOCL_XGQ_MSLEEP_1S);
 		xgq_submitted_cmds_drain(xgq);
 	}
+
+	XGQ_INFO(xgq, "xgq service is halted");
 }
 
+static void xgq_offline_service(struct xocl_xgq_vmr *xgq)
+{
+	XGQ_INFO(xgq, "xgq service is going offline...");
+
+	/* If we see timeout cmd first time, dump log into dmesg */
+	if (!xgq->xgq_halted) {
+		xgq_vmr_log_dump_all(xgq);
+	}
+
+	/* then we stop service */
+	xgq_stop_services(xgq);
+
+	XGQ_INFO(xgq, "xgq service is offline");
+}
 
 /*
  * periodically check if there are outstanding timed out commands.
@@ -479,14 +503,7 @@ static int health_worker(void *data)
 		msleep(XOCL_XGQ_MSLEEP_1S * 10);
 
 		if (xgq_submitted_cmd_check(xgq)) {
-
-			/* If we see timeout cmd first time, dump log into dmesg */
-			if (!xgq->xgq_halted) {
-				xgq_vmr_log_dump_all(xgq);
-			}
-
-			/* then we stop service */
-			xgq_stop_services(xgq);
+			xgq_offline_service(xgq);
 		}
 
 		if (kthread_should_stop()) {


### PR DESCRIPTION
xgq cids

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
stop xgq services when cid 0xffff is received.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1135117 

#### How problem was solved, alternative solutions (if any) and why they were rejected
when there is hardware error, like downloading xclbin cause the hardware issue, cid becomes 0xffff,
the dmesg can be flooded with full of cid is 65535.

#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
tested with vck5000 and v70 shell(currently has xclbin download issue)

#### Documentation impact (if any)
