### PR TITLE
CR-1135119 xclbin download failed with -19(ENODEV) when APU is not

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -2297,7 +2297,7 @@ static int __icap_download_bitstream_user(struct platform_device *pdev,
 	/* TODO: Use slot handle to unregister CUs. CU subdev will be destroyed */
 	xocl_subdev_destroy_by_level(xdev, XOCL_SUBDEV_LEVEL_URP);
 	err = xocl_unregister_cus(xdev, 0);
-	if (err)
+	if (err && (err != -ENODEV))
 		goto done;
 
 	err = __icap_peer_xclbin_download(icap, xclbin, force_download);


### PR DESCRIPTION
installed

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
xclbin download failed (-19) without APU is up

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
currently, for v70 we don't have validate APU running yet, however we still can run xclbin download and run xbutil validate -r quick before the recent fix.

#### How problem was solved, alternative solutions (if any) and why they were rejected
just ignore the -ENODEV

#### Risks (if any) associated the changes in the commit
low

#### What has been tested and how, request additional testing if necessary
tested with vck5000 and v70.
test both with/wo APU 
#### Documentation impact (if any)
