### PR TITLE
CR-1131075 Support CU interrupt to APU

### DIFF
--- a/src/runtime_src/core/common/drv/include/xrt_cu.h
+++ b/src/runtime_src/core/common/drv/include/xrt_cu.h
@@ -27,6 +27,14 @@
 #define ioremap_nocache         ioremap
 #endif
 
+/* Avoid the CU soft lockup warning when CU thread keep busy.
+ * Small value leads to lower performance on APU.
+ */
+#define MAX_CU_LOOP 100
+
+/* If poll count reach this threashold, switch to interrupt mode */
+#define CU_DEFAULT_POLL_THRESHOLD 30 /* About 60 us on APU */
+
 /* The normal CU in ip_layout would assign a interrupt
  * ID in range 0 to 127. Use 128 for m2m cu could ensure
  * m2m CU is at the end of the CU, which is compatible with
@@ -340,6 +348,8 @@ struct xrt_cu {
 	 * one for submit, one for complete
 	 */
 	struct task_struct	  *thread;
+	u32			   poll_count;
+	u32                        poll_threshold;
 	/* Good for debug */
 	u32			   sleep_cnt;
 	u32			   max_running;

--- a/src/runtime_src/core/common/drv/include/xrt_cu.h
+++ b/src/runtime_src/core/common/drv/include/xrt_cu.h
@@ -3,6 +3,7 @@
  * Xilinx Unify CU Model
  *
  * Copyright (C) 2020-2022 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Authors: min.ma@xilinx.com
  *

--- a/src/runtime_src/core/common/drv/include/xrt_cu.h
+++ b/src/runtime_src/core/common/drv/include/xrt_cu.h
@@ -350,6 +350,7 @@ struct xrt_cu {
 	struct task_struct	  *thread;
 	u32			   poll_count;
 	u32                        poll_threshold;
+	u32			   interrupt_used;
 	/* Good for debug */
 	u32			   sleep_cnt;
 	u32			   max_running;

--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -194,7 +194,7 @@ static int kds_polling_thread(void *data)
 			usleep_range(kds->interval, kds->interval + 3);
 
 		/* Avoid large num_rq leads to more 120 sec blocking */
-		if (++loop_cnt == 8) {
+		if (++loop_cnt == MAX_CU_LOOP) {
 			loop_cnt = 0;
 			schedule();
 		}
@@ -1094,13 +1094,13 @@ _kds_fini_client(struct kds_sched *kds, struct kds_client *client,
 			info.cu_domain = DOMAIN_PS;
 			info.curr_ctx = cctx;
 			kds_del_context(kds, client, &info);
+			kds_info(client,"Removing CU Domain[%d] CU Index [%d]",info.cu_domain,info.cu_idx);
 		}
-		kds_info(client,"Removing CU Domain[%d] CU Index [%d]",info.cu_domain,info.cu_idx);
 		count_idx += 1;
 	};
 	kds_client_set_cu_refs_zero(client, DOMAIN_PS);
-	count_idx = 0;
 
+	count_idx = 0;
 	while (count_idx < MAX_CUS) {
 		/* Check whether this CU belongs to current slot */
 		if (is_cu_in_ctx_slot(kds, cctx, count_idx, DOMAIN_PL)) {
@@ -1108,8 +1108,8 @@ _kds_fini_client(struct kds_sched *kds, struct kds_client *client,
 			info.cu_domain = DOMAIN_PL;
 			info.curr_ctx = cctx;
 			kds_del_context(kds, client, &info);
+			kds_info(client,"Removing CU Domain[%d] CU Index [%d]",info.cu_domain,info.cu_idx);
 		}
-		kds_info(client,"Removing CU Domain[%d] CU Index [%d]",info.cu_domain,info.cu_idx);
 		count_idx += 1;
 	};
 	kds_client_set_cu_refs_zero(client, DOMAIN_PL);

--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -3,6 +3,7 @@
  * Xilinx Kernel Driver Scheduler
  *
  * Copyright (C) 2020-2022 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Authors: min.ma@xilinx.com
  *

--- a/src/runtime_src/core/common/drv/xrt_cu.c
+++ b/src/runtime_src/core/common/drv/xrt_cu.c
@@ -3,6 +3,7 @@
  * Xilinx Unify CU Model
  *
  * Copyright (C) 2020-2022 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Authors: min.ma@xilinx.com
  *

--- a/src/runtime_src/core/edge/drm/zocl/cu.c
+++ b/src/runtime_src/core/edge/drm/zocl/cu.c
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: GPL-2.0 OR Apache-2.0 */
 /*
  * Copyright (C) 2020-2022 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Author(s):
  *        Min Ma <min.ma@xilinx.com>

--- a/src/runtime_src/core/edge/drm/zocl/cu.c
+++ b/src/runtime_src/core/edge/drm/zocl/cu.c
@@ -11,6 +11,7 @@
 
 #include "zocl_drv.h"
 #include "xrt_cu.h"
+#include "zocl_ert_intc.h"
 
 #define IRQ_DISABLED 0
 
@@ -26,25 +27,26 @@ struct zocl_cu {
 static ssize_t debug_show(struct device *dev,
 	struct device_attribute *attr, char *buf)
 {
-#if 0
 	struct platform_device *pdev = to_platform_device(dev);
 	struct zocl_cu *cu = platform_get_drvdata(pdev);
 	struct xrt_cu *xcu = &cu->base;
-#endif
-	/* Place holder for now. */
-	return 0;
+
+	return sprintf(buf, "%d\n", xcu->debug);
 }
 
 static ssize_t debug_store(struct device *dev,
 	struct device_attribute *da, const char *buf, size_t count)
 {
-#if 0
 	struct platform_device *pdev = to_platform_device(dev);
 	struct zocl_cu *cu = platform_get_drvdata(pdev);
 	struct xrt_cu *xcu = &cu->base;
-#endif
+	u32 debug;
 
-	/* Place holder for now. */
+	if (kstrtou32(buf, 10, &debug) == -EINVAL)
+		return -EINVAL;
+
+	xcu->debug = debug;
+
 	return count;
 }
 static DEVICE_ATTR_RW(debug);
@@ -79,22 +81,83 @@ stat_show(struct device *dev, struct device_attribute *attr, char *buf)
 }
 static DEVICE_ATTR_RO(stat);
 
+static ssize_t
+crc_buf_show(struct file *filp, struct kobject *kobj,
+	     struct bin_attribute *attr, char *buf,
+	     loff_t offset, size_t count)
+{
+	struct device *dev = container_of(kobj, struct device, kobj);
+	struct zocl_cu *cu = (struct zocl_cu *)dev_get_drvdata(dev);
+	struct xrt_cu *xcu;
+
+	if (!cu)
+		return 0;
+
+	xcu = &cu->base;
+	return xrt_cu_circ_consume_all(xcu, buf, count);
+}
+
+static ssize_t poll_threshold_show(struct device *dev,
+	struct device_attribute *attr, char *buf)
+{
+	struct platform_device *pdev = to_platform_device(dev);
+	struct zocl_cu *cu = platform_get_drvdata(pdev);
+	struct xrt_cu *xcu = &cu->base;
+
+	return sprintf(buf, "%d\n", xcu->poll_threshold);
+}
+
+static ssize_t poll_threshold_store(struct device *dev,
+	struct device_attribute *da, const char *buf, size_t count)
+{
+	struct platform_device *pdev = to_platform_device(dev);
+	struct zocl_cu *cu = platform_get_drvdata(pdev);
+	struct xrt_cu *xcu = &cu->base;
+	u32 threshold;
+
+	if (kstrtou32(buf, 10, &threshold) == -EINVAL)
+		return -EINVAL;
+
+	xcu->poll_threshold = threshold;
+
+	return count;
+}
+static DEVICE_ATTR_RW(poll_threshold);
+
 static struct attribute *cu_attrs[] = {
 	&dev_attr_debug.attr,
 	&dev_attr_cu_stat.attr,
 	&dev_attr_cu_info.attr,
 	&dev_attr_stat.attr,
+	&dev_attr_poll_threshold.attr,
+	NULL,
+};
+
+static struct bin_attribute crc_buf_attr = {
+	.attr = {
+		.name = "crc_buf",
+		.mode = 0444
+	},
+	.read = crc_buf_show,
+	.write = NULL,
+	.size = 0,
+};
+
+static struct bin_attribute *cu_bin_attrs[] = {
+	&crc_buf_attr,
 	NULL,
 };
 
 static const struct attribute_group cu_attrgroup = {
 	.attrs = cu_attrs,
+	.bin_attrs = cu_bin_attrs,
 };
 
 irqreturn_t cu_isr(int irq, void *arg)
 {
 	struct zocl_cu *zcu = arg;
 
+	xrt_cu_circ_produce(&zcu->base, CU_LOG_STAGE_ISR, 0);
 	xrt_cu_clear_intr(&zcu->base);
 
 	up(&zcu->base.sem_cu);
@@ -174,6 +237,7 @@ static int cu_probe(struct platform_device *pdev)
 	struct resource **res;
 	struct xrt_cu_info *info;
 	struct drm_zocl_dev *zdev;
+	struct platform_device *intc;
 	struct xrt_cu_arg *args = NULL;
 	int err = 0;
 	int i;
@@ -217,18 +281,13 @@ static int cu_probe(struct platform_device *pdev)
 	sprintf(zcu->irq_name, "zocl_cu[%d]", info->intr_id);
 
 	if (info->intr_enable) {
-		zcu->irq = zdev->cu_subdev.irq[info->intr_id];
-		/* Currently requesting irq if it's enable in cu config.
-		 * Not disabling it further, even user wants to use 
-		 * polling.
-		 */
-		err = request_irq(zcu->irq, cu_isr, 0,
-			  zcu->irq_name, zcu);
-		if (err) {
+		intc = zocl_find_pdev(ERT_CU_INTC_DEV_NAME);
+		if (!intc) {
 			DRM_WARN("Failed to initial CU interrupt. "
-			    "Fall back to polling\n");
+				 "Fall back to polling\n");
 			zcu->base.info.intr_enable = 0;
-		}
+		} else
+			zocl_ert_intc_add(intc, info->intr_id, cu_isr, zcu);
 	}
 
 	switch (info->model) {
@@ -272,6 +331,7 @@ static int cu_remove(struct platform_device *pdev)
 	struct zocl_cu *zcu;
 	struct drm_zocl_dev *zdev;
 	struct xrt_cu_info *info;
+	struct platform_device *intc;
 
 	zcu = platform_get_drvdata(pdev);
 	if (!zcu)
@@ -287,8 +347,11 @@ static int cu_remove(struct platform_device *pdev)
 		break;
 	}
 
-	if (info->intr_enable)
-		free_irq(zcu->irq, zcu);
+	if (info->intr_enable) {
+		intc = zocl_find_pdev(ERT_CU_INTC_DEV_NAME);
+		if (intc)
+			zocl_ert_intc_remove(intc, info->intr_id);
+	}
 
 	zdev = zocl_get_zdev();
 	if(zdev)

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
@@ -305,7 +305,7 @@ void subdev_destroy_scu(struct drm_zocl_dev *zdev);
 /* Sub device driver */
 extern struct platform_driver zocl_cu_xgq_driver;
 extern struct platform_driver zocl_csr_intc_driver;
-extern struct platform_driver zocl_xgq_intc_driver;
+extern struct platform_driver zocl_irq_intc_driver;
 extern struct platform_driver zocl_rpu_channel_driver;
 extern struct platform_driver cu_driver;
 extern struct platform_driver scu_driver;

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
@@ -4,6 +4,7 @@
  * OpenCL accelerators.
  *
  * Copyright (C) 2016-2022 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Authors:
  *    Sonal Santan <sonal.santan@xilinx.com>

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_ert_intc.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_ert_intc.h
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: GPL-2.0 OR Apache-2.0 */
 /*
- * Copyright (C) 2021-2022 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2021 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Author(s):
  *        Max Zhen <maxz@xilinx.com>

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_ert_intc.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_ert_intc.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0 OR Apache-2.0 */
 /*
- * Copyright (C) 2021 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2021-2022 Xilinx, Inc. All rights reserved.
  *
  * Author(s):
  *        Max Zhen <maxz@xilinx.com>
@@ -20,6 +20,7 @@
 
 #define ERT_CSR_INTC_DEV_NAME		"ZOCL_CSR_INTC"
 #define ERT_XGQ_INTC_DEV_NAME		"ZOCL_XGQ_INTC"
+#define ERT_CU_INTC_DEV_NAME		"ZOCL_CU_INTC"
 
 /*
  * Resources for one ERT INTC device.
@@ -34,11 +35,12 @@ struct zocl_ert_intc_status_reg {
 };
 
 struct zocl_ert_intc_handler {
-	struct platform_device *zeih_pdev;
-	u32		zeih_irq;
-	irq_handler_t	zeih_cb;
-	void		*zeih_arg;
-	bool		zeih_enabled;
+	struct platform_device	*zeih_pdev;
+	spinlock_t		 zeih_lock;
+	u32			 zeih_irq;
+	irq_handler_t		 zeih_cb;
+	void			*zeih_arg;
+	bool			 zeih_enabled;
 };
 
 struct zocl_ert_intc_drv_data {

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_util.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_util.h
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: GPL-2.0 OR Apache-2.0 */
 /*
  * Copyright (C) 2016-2022 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Author(s):
  *        Min Ma <min.ma@xilinx.com>

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_util.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_util.h
@@ -150,6 +150,7 @@ struct drm_zocl_dev {
 	struct list_head	 ctx_list;
 
 	struct zocl_cu_subdev	 cu_subdev;
+	struct platform_device	*cu_intc;
 	struct kds_sched	 kds;
 
 	/*

--- a/src/runtime_src/core/edge/drm/zocl/zocl_ctrl_ert.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_ctrl_ert.c
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: GPL-2.0 OR Apache-2.0 */
 /*
  * Copyright (C) 2021-2022 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Author(s):
  *        Max Zhen <maxz@xilinx.com>
@@ -561,6 +562,7 @@ static int zert_cu_intc_init(struct zocl_ctrl_ert *zert)
 				   &zert->zce_cu_intc);
 	if (ret)
 		zert_err(zert, "Failed to create CU intc device: %d", ret);
+	kfree(irqs);
 
 out:
 	return 0;

--- a/src/runtime_src/core/edge/drm/zocl/zocl_ctrl_ert.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_ctrl_ert.c
@@ -138,6 +138,7 @@ struct zocl_ctrl_ert {
 	struct zocl_ctrl_ert_cu *zce_scus;
 
 	struct platform_device	*zce_xgq_intc;
+	struct platform_device	*zce_cu_intc;
 
 	bool			zce_config_completed;
 	bool			zce_echo_mode;
@@ -165,8 +166,8 @@ static void cu_conf2info(struct xgq_cmd_config_cu *conf, struct xrt_cu_info *inf
 	info->addr <<= 32;
 	info->addr |= conf->laddr;
 	info->size = conf->map_size;
-	info->intr_enable = 0;
-	info->intr_id = 0;
+	info->intr_enable = conf->intr_enable;
+	info->intr_id = conf->intr_id;
 	info->slot_idx = 0;
 	info->protocol = conf->ip_ctrl;
 	if (info->protocol == CTRL_FA)
@@ -518,6 +519,53 @@ static void zert_destroy_cu_xgqs(struct zocl_ctrl_ert *zert)
 	}
 }
 
+static int zert_cu_intc_init(struct zocl_ctrl_ert *zert)
+{
+	const char *cu_interrupt = "cu_interrupt";
+	struct device_node *np = NULL;
+	struct device_node *parent = NULL;
+	u32 *irqs = NULL;
+	int num_irq = 0;
+	int ret = 0;
+	int i;
+
+	/* TODO: We only have one AXI intc for 32 CU interrupts at the moment */
+	np = of_get_child_by_name(ZERT2DEV(zert)->of_node, cu_interrupt);
+	if (!np) {
+		zert_err(zert, "failed to find CU interrupt node");
+		return -ENODEV;
+	}
+
+	/* Try get number of CU irqs */
+	parent = of_irq_find_parent(np);
+	if (!parent) {
+		zert_err(zert, "failed to find CU intc");
+		return -EINVAL;
+	}
+
+	ret = of_property_read_u32(parent, "xlnx,num-intr-inputs", &num_irq);
+	if (ret < 0) {
+		zert_err(zert, "unable to read xlnx,num-intr-inputs");
+		return -EINVAL;
+	}
+
+	irqs = kzalloc(sizeof(u32) * num_irq, GFP_KERNEL);
+	if (!irqs) {
+		zert_err(zert, "Failed to alloc irq array for CU intc device");
+		goto out;
+	}
+
+	for (i = 0; i < num_irq; i++)
+		irqs[i] = of_irq_get(np, i);
+	ret = zocl_ert_create_intc(ZERT2DEV(zert), irqs, num_irq, 0, ERT_CU_INTC_DEV_NAME,
+				   &zert->zce_cu_intc);
+	if (ret)
+		zert_err(zert, "Failed to create CU intc device: %d", ret);
+
+out:
+	return 0;
+}
+
 static int zert_versal_init(struct zocl_ctrl_ert *zert)
 {
 	int i = 0;
@@ -548,6 +596,10 @@ static int zert_versal_init(struct zocl_ctrl_ert *zert)
 	if (!zert->zce_cu_xgqs)
 		return -ENOMEM;
 
+	irqs = kzalloc(sizeof(u32) * zert->zce_num_cu_xgqs, GFP_KERNEL);
+	if (!irqs)
+		zert_err(zert, "Failed to alloc irq array for intc device");
+
 	for (i = 0; i < zert->zce_num_cu_xgqs; i++) {
 		np = of_parse_phandle(ZERT2DEV(zert)->of_node, xgq_res_name, i);
 		if (!np) {
@@ -561,32 +613,34 @@ static int zert_versal_init(struct zocl_ctrl_ert *zert)
 		}
 
 		cuxgq = &zert->zce_cu_xgqs[i];
-		cuxgq->zcecx_irq = of_irq_get(np, 0);
+		cuxgq->zcecx_irq = i;
+		if (irqs)
+			irqs[i] = of_irq_get(np, 0);
 		cuxgq->zcecx_xgq_reg = res.start;
 		/* Write to tail pointer will trigger interrupt. */
 		cuxgq->zcecx_cq_int_reg = 0;
 
-		zert_info(zert, "Found CU XGQ @ %pR on irq %d", &res, cuxgq->zcecx_irq);
+		zert_info(zert, "Found CU XGQ @ %pR on irq %d", &res, irqs[i]);
 	}
 
 	/* Bring up XGQ INTC. */
-	irqs = kzalloc(sizeof(u32) * zert->zce_num_cu_xgqs, GFP_KERNEL);
-	if (!irqs) {
-		zert_err(zert, "Failed to alloc irq array for intc device");
-	} else {
-		for (i = 0; i < zert->zce_num_cu_xgqs; i++)
-			irqs[i] = zert->zce_cu_xgqs[i].zcecx_irq;
+	if (irqs) {
 		ret = zocl_ert_create_intc(ZERT2DEV(zert), irqs, i, 0, ERT_XGQ_INTC_DEV_NAME,
 					   &zert->zce_xgq_intc);
 		if (ret)
 			zert_err(zert, "Failed to create xgq intc device: %d", ret);
 	}
 
-	/* TODO: Bringup INTC sub-dev to handle interrupts for all CUs. */
+	/* Bringup INTC sub-dev to handle interrupts for all CUs. */
+	ret = zert_cu_intc_init(zert);
+	if (ret) {
+		zert_err(zert, "Failed to initial CU intc");
+	}
 
 	/* Initialize soft kernel data structure */
 	zocl_init_soft_kernel(zocl_get_zdev());
 
+	kfree(irqs);
 	return 0;
 }
 
@@ -643,7 +697,7 @@ static int zert_mpsoc_init(struct zocl_ctrl_ert *zert)
 
 	/* Initialize soft kernel data structure */
 	zocl_init_soft_kernel(zocl_get_zdev());
-	
+
 	return 0;
 }
 
@@ -716,6 +770,7 @@ static int zert_remove(struct platform_device *pdev)
 	zert->zce_cu_xgqs = NULL;
 	zert->zce_num_cu_xgqs = 0;
 	zocl_ert_destroy_intc(zert->zce_xgq_intc);
+	zocl_ert_destroy_intc(zert->zce_cu_intc);
 
 	return 0;
 }
@@ -806,7 +861,7 @@ static void zert_cmd_cfg_start(struct zocl_ctrl_ert *zert, struct xgq_cmd_sq_hdr
 	init_resp(resp, cmd->cid, 0);
 	r->i2h = true;
 	r->i2e = true;
-	r->cui = false;
+	r->cui = (zert->zce_cu_intc) ? true : false;
 	r->ob = false;
 }
 
@@ -823,7 +878,7 @@ static void zert_cmd_cfg_end(struct zocl_ctrl_ert *zert, struct xgq_cmd_sq_hdr *
 	zert->zce_config_completed = true;
 
 	zocl_get_zdev()->kds.cu_intr_cap = 1;
-	zocl_get_zdev()->kds.cu_intr = 0;
+	zocl_get_zdev()->kds.cu_intr = 1;
 	kds_cfg_update(&zocl_get_zdev()->kds);
 
 	rc = zert_validate_cus(zert);

--- a/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
@@ -34,6 +34,7 @@
 #include "sched_exec.h"
 #include "zocl_xclbin.h"
 #include "zocl_error.h"
+#include "zocl_ert_intc.h"
 
 #define ZOCL_DRIVER_NAME        "zocl"
 #define ZOCL_DRIVER_DESC        "Zynq BO manager"
@@ -1067,6 +1068,10 @@ static int zocl_drm_platform_probe(struct platform_device *pdev)
 		zdev->cu_subdev.irq[index] = irq;
 	}
 	zdev->cu_subdev.cu_num = index;
+	ret = zocl_ert_create_intc(&pdev->dev, zdev->cu_subdev.irq, index, 0,
+				   ERT_CU_INTC_DEV_NAME, &zdev->cu_intc);
+	if (ret)
+		DRM_ERROR("Failed to create cu intc device, ret %d\n", ret);
 
 	/* set to 0xFFFFFFFF(32bit) or 0xFFFFFFFFFFFFFFFF(64bit) */
 	zdev->host_mem = (phys_addr_t) -1;
@@ -1248,6 +1253,7 @@ static int zocl_drm_platform_remove(struct platform_device *pdev)
 	if (zdev->fpga_mgr)
 		fpga_mgr_put(zdev->fpga_mgr);
 
+	zocl_ert_destroy_intc(zdev->cu_intc);
 	zocl_clear_mem(zdev);
 	mutex_destroy(&zdev->mm_lock);
 	zocl_pr_slot_fini(zdev);
@@ -1280,10 +1286,10 @@ static struct platform_driver *drivers[] = {
 	&zocl_ospi_versal_driver,
 	&cu_driver,
 	&scu_driver,
-	&zocl_drm_private_driver,
 	&zocl_csr_intc_driver,
-	&zocl_xgq_intc_driver,
+	&zocl_irq_intc_driver,
 	&zocl_cu_xgq_driver,
+	&zocl_drm_private_driver,
 	&zocl_ctrl_ert_driver,
 	&zocl_rpu_channel_driver,
 };

--- a/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
@@ -4,6 +4,7 @@
  * OpenCL accelerators.
  *
  * Copyright (C) 2016-2022 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Authors:
  *    Sonal Santan <sonal.santan@xilinx.com>

--- a/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: GPL-2.0 OR Apache-2.0 */
 /*
  * Copyright (C) 2020-2022 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Author(s):
  *        Min Ma <min.ma@xilinx.com>

--- a/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
@@ -967,9 +967,9 @@ int zocl_kds_update(struct drm_zocl_dev *zdev, struct drm_zocl_slot *slot,
 	}
 
 	zocl_detect_fa_cmdmem(zdev, slot);
-	
+
 	// Default supporting interrupt mode
-	zdev->kds.cu_intr_cap = 1;	
+	zdev->kds.cu_intr_cap = 1;
 
 	for (i = 0; i < MAX_CUS; i++) {
 		struct xrt_cu *xcu;

--- a/src/runtime_src/core/edge/drm/zocl/zocl_rpu_channel.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_rpu_channel.c
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: GPL-2.0 OR Apache-2.0 */
 /*
- * Copyright (C) 2021-2022 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2021 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Author(s):
  *        Lizhi Hou <lizhih@xilinx.com>

--- a/src/runtime_src/core/edge/drm/zocl/zocl_rpu_channel.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_rpu_channel.c
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0 OR Apache-2.0 */
 /*
- * Copyright (C) 2021 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2021-2022 Xilinx, Inc. All rights reserved.
  *
  * Author(s):
  *        Lizhi Hou <lizhih@xilinx.com>
@@ -351,7 +351,8 @@ static int zrpu_channel_probe(struct platform_device *pdev)
 	xgq_arg.zxia_ring = chan->mem_base + ZRPU_CHANNEL_XGQ_BUFFER;
 	xgq_arg.zxia_ring_size = ZRPU_CHANNEL_XGQ_BUFFER_SIZE;
 	xgq_arg.zxia_ring_slot_size = ZRPU_CHANNEL_XGQ_SLOT_SIZE;
-	xgq_arg.zxia_irq = irq;
+	/* There is only 1 irq in intc subdev. The irq_id is 0 */
+	xgq_arg.zxia_irq = 0;
 	xgq_arg.zxia_intc_pdev = chan->intc_pdev;
 	xgq_arg.zxia_xgq_ip = chan->xgq_base;
 	xgq_arg.zxia_cmd_handler = zchan_cmd_handler;

--- a/src/runtime_src/core/edge/drm/zocl/zocl_xgq_intc.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_xgq_intc.c
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0 OR Apache-2.0 */
 /*
- * Copyright (C) 2021 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2021-2022 Xilinx, Inc. All rights reserved.
  *
  * Author(s):
  *        Max Zhen <maxz@xilinx.com>
@@ -14,8 +14,7 @@
 #include "zocl_lib.h"
 #include "zocl_ert_intc.h"
 
-/* ERT INTC driver name. */
-#define ZINTC_NAME			"zocl_xgq_intc"
+#define ZINTC_DRV_NAME			"zocl_irq_intc"
 
 #define ZINTC2PDEV(zintc)		((zintc)->zei_pdev)
 #define ZINTC2DEV(zintc)		(&ZINTC2PDEV(zintc)->dev)
@@ -23,7 +22,7 @@
 #define zintc_info(zintc, fmt, args...)	zocl_info(ZINTC2DEV(zintc), fmt"\n", ##args)
 #define zintc_dbg(zintc, fmt, args...)	zocl_dbg(ZINTC2DEV(zintc), fmt"\n", ##args)
 
-struct zocl_xgq_intc {
+struct zocl_irq_intc {
 	struct platform_device		*zei_pdev;
 
 	spinlock_t			zei_lock;
@@ -37,14 +36,14 @@ static irqreturn_t zintc_isr(int irq, void *arg)
 {
 	unsigned long irqflags;
 	struct zocl_ert_intc_handler *h = (struct zocl_ert_intc_handler *)arg;
-	struct zocl_xgq_intc *zintc = platform_get_drvdata(h->zeih_pdev);
+	struct zocl_irq_intc *zintc = platform_get_drvdata(h->zeih_pdev);
 
-	spin_lock_irqsave(&zintc->zei_lock, irqflags);
+	spin_lock_irqsave(&h->zeih_lock, irqflags);
 	if (h->zeih_cb && h->zeih_enabled)
 		h->zeih_cb(irq, h->zeih_arg);
 	else
-		zintc_err(zintc, "Spurious interrupt received on %d", irq); 
-	spin_unlock_irqrestore(&zintc->zei_lock, irqflags);
+		zintc_err(zintc, "Spurious interrupt received on %d", irq);
+	spin_unlock_irqrestore(&h->zeih_lock, irqflags);
 	return IRQ_HANDLED;
 }
 
@@ -52,11 +51,11 @@ static int zintc_probe(struct platform_device *pdev)
 {
 	int ret;
 	int i;
-	struct zocl_xgq_intc *zintc;
+	struct zocl_irq_intc *zintc;
 	int num_irqs = platform_irq_count(pdev);
 
 	if (num_irqs <= 0) {
-		zocl_err(&pdev->dev, "failed to find IRQs, num of IRQ: %d\n", num_irqs); 
+		zocl_err(&pdev->dev, "failed to find IRQs, num of IRQ: %d\n", num_irqs);
 		return -EINVAL;
 	}
 
@@ -67,11 +66,14 @@ static int zintc_probe(struct platform_device *pdev)
 		return -ENOMEM;
 	zintc->zei_pdev = pdev;
 	zintc->zei_num_irqs = num_irqs;
-	spin_lock_init(&zintc->zei_lock);
 	platform_set_drvdata(pdev, zintc);
 
 	/* Ready to turn on interrupts! */
 	for (i = 0; i < num_irqs; i++) {
+		/*
+		 * The irq resources ordering is important.
+		 * Later on, use the resource index to add a handler.
+		 */
 		struct zocl_ert_intc_handler *h = &zintc->zei_handler[i];
 		struct resource *res = platform_get_resource(ZINTC2PDEV(zintc), IORESOURCE_IRQ, i);
 		u32 irq = res->start;
@@ -79,11 +81,12 @@ static int zintc_probe(struct platform_device *pdev)
 		h->zeih_pdev = pdev;
 		h->zeih_irq = irq;
 		BUG_ON(irq < 0);
-		ret = devm_request_irq(ZINTC2DEV(zintc), irq, zintc_isr, 0, ZINTC_NAME, h);
+		spin_lock_init(&h->zeih_lock);
+		ret = devm_request_irq(ZINTC2DEV(zintc), irq, zintc_isr, 0, ZINTC_DRV_NAME, h);
 		if (ret)
 			zintc_err(zintc, "failed to add isr for IRQ: %d: %d", irq, ret); 
 		else
-			zintc_info(zintc, "managing IRQ %d", irq); 
+			zintc_info(zintc, "managing IRQ %d", irq);
 	}
 
 	return 0;
@@ -91,9 +94,9 @@ static int zintc_probe(struct platform_device *pdev)
 
 static int zintc_remove(struct platform_device *pdev)
 {
-	struct zocl_xgq_intc *zintc = platform_get_drvdata(pdev);
+	struct zocl_irq_intc *zintc = platform_get_drvdata(pdev);
 
-	zintc_info(zintc, "Removing %s", ZINTC_NAME);
+	zintc_info(zintc, "Removing %s", ZINTC_DRV_NAME);
 	return 0;
 }
 
@@ -101,26 +104,14 @@ static int zintc_remove(struct platform_device *pdev)
  * Interfaces exposed to other subdev drivers.
  */
 
-static struct zocl_ert_intc_handler *find_handler(struct zocl_xgq_intc *zintc, u32 irq)
-{
-	int i;
-	struct zocl_ert_intc_handler *h;
-
-	for (i = 0; i < zintc->zei_num_irqs; i++) {
-		h = &zintc->zei_handler[i];
-		if (h->zeih_irq == irq)
-			return h;
-	}
-	return NULL;
-}
-
-static void zocl_xgq_intc_add(struct platform_device *pdev, u32 irq, irq_handler_t cb, void *arg)
+static void zocl_irq_intc_add(struct platform_device *pdev, u32 id, irq_handler_t cb, void *arg)
 {
 	unsigned long irqflags;
-	struct zocl_xgq_intc *zintc = platform_get_drvdata(pdev);
-	struct zocl_ert_intc_handler *h = find_handler(zintc, irq);
+	struct zocl_irq_intc *zintc = platform_get_drvdata(pdev);
+	struct zocl_ert_intc_handler *h;
 
-	BUG_ON(!h);
+	BUG_ON(id >= zintc->zei_num_irqs);
+	h = &zintc->zei_handler[id];
 	spin_lock_irqsave(&zintc->zei_lock, irqflags);
 
 	BUG_ON(h->zeih_cb);
@@ -131,13 +122,14 @@ static void zocl_xgq_intc_add(struct platform_device *pdev, u32 irq, irq_handler
 	spin_unlock_irqrestore(&zintc->zei_lock, irqflags);
 }
 
-static void zocl_xgq_intc_remove(struct platform_device *pdev, u32 irq)
+static void zocl_irq_intc_remove(struct platform_device *pdev, u32 id)
 {
 	unsigned long irqflags;
-	struct zocl_xgq_intc *zintc = platform_get_drvdata(pdev);
-	struct zocl_ert_intc_handler *h = find_handler(zintc, irq);
+	struct zocl_irq_intc *zintc = platform_get_drvdata(pdev);
+	struct zocl_ert_intc_handler *h;
 
-	BUG_ON(!h);
+	BUG_ON(id >= zintc->zei_num_irqs);
+	h = &zintc->zei_handler[id];
 	spin_lock_irqsave(&zintc->zei_lock, irqflags);
 
 	h->zeih_cb = NULL;
@@ -147,21 +139,22 @@ static void zocl_xgq_intc_remove(struct platform_device *pdev, u32 irq)
 	spin_unlock_irqrestore(&zintc->zei_lock, irqflags);
 }
 
-static struct zocl_ert_intc_drv_data zocl_xgq_intc_drvdata = {
-	.add = zocl_xgq_intc_add,
-	.remove = zocl_xgq_intc_remove,
+static struct zocl_ert_intc_drv_data zocl_irq_intc_drvdata = {
+	.add = zocl_irq_intc_add,
+	.remove = zocl_irq_intc_remove,
 };
 
-static const struct platform_device_id zocl_xgq_intc_id_match[] = {
-	{ ERT_XGQ_INTC_DEV_NAME, (kernel_ulong_t)&zocl_xgq_intc_drvdata },
+static const struct platform_device_id zocl_irq_intc_id_match[] = {
+	{ ERT_XGQ_INTC_DEV_NAME, (kernel_ulong_t)&zocl_irq_intc_drvdata },
+	{ ERT_CU_INTC_DEV_NAME, (kernel_ulong_t)&zocl_irq_intc_drvdata },
 	{ /* end of table */ },
 };
 
-struct platform_driver zocl_xgq_intc_driver = {
+struct platform_driver zocl_irq_intc_driver = {
 	.driver = {
-		.name = ZINTC_NAME,
+		.name = ZINTC_DRV_NAME,
 	},
 	.probe  = zintc_probe,
 	.remove = zintc_remove,
-	.id_table = zocl_xgq_intc_id_match,
+	.id_table = zocl_irq_intc_id_match,
 };

--- a/src/runtime_src/core/edge/drm/zocl/zocl_xgq_intc.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_xgq_intc.c
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: GPL-2.0 OR Apache-2.0 */
 /*
- * Copyright (C) 2021-2022 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2021 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Author(s):
  *        Max Zhen <maxz@xilinx.com>

--- a/src/runtime_src/core/include/xgq_cmd_ert.h
+++ b/src/runtime_src/core/include/xgq_cmd_ert.h
@@ -1,5 +1,6 @@
 /*
  *  Copyright (C) 2021-2022, Xilinx Inc
+ *  Copyright (C) 2022 Advanced Micro Devices, Inc.
  *
  *  This file is dual licensed.  It may be redistributed and/or modified
  *  under the terms of the Apache 2.0 License OR version 2 of the GNU

--- a/src/runtime_src/core/include/xgq_cmd_ert.h
+++ b/src/runtime_src/core/include/xgq_cmd_ert.h
@@ -210,7 +210,10 @@ struct xgq_cmd_config_end {
  * struct xgq_cmd_config_cu: configure CU command
  *
  * @cu_idx: cu index to configure
+ * @cu_domain: cu domain to configure
  * @ip_ctrl: IP control protocol
+ * @intr_id: CU interrupt id
+ * @intr_enable: CU interrupt enable
  * @map_size: use this size to map CU if apply
  * @laddr: lower 32 bits of the CU address
  * @haddr: higher 32 bits of the CU address
@@ -227,7 +230,8 @@ struct xgq_cmd_config_cu {
 	uint32_t cu_idx:12;
 	uint32_t cu_domain:4;
 	uint32_t ip_ctrl:8;
-	uint32_t rsvd2:8;
+	uint32_t intr_id:7;
+	uint32_t intr_enable:1;
 
 	uint32_t map_size;
 	uint32_t laddr;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_ctrl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_ctrl.c
@@ -1,7 +1,8 @@
 /*
  * A GEM style device manager for PCIe based OpenCL accelerators.
  *
- * Copyright (C) 2021-2022 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2021 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2022 Advanced Micro Devices, Inc.
  *
  *
  * This software is licensed under the terms of the GNU General Public

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_ctrl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_ctrl.c
@@ -1,7 +1,7 @@
 /*
  * A GEM style device manager for PCIe based OpenCL accelerators.
  *
- * Copyright (C) 2021 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2021-2022 Xilinx, Inc. All rights reserved.
  *
  *
  * This software is licensed under the terms of the GNU General Public
@@ -46,7 +46,7 @@
 
 #define CQ_STATUS_ADDR 0x58
 
-#define CTRL_XGQ_SLOT_SIZE          512	
+#define CTRL_XGQ_SLOT_SIZE          512
 
 /* XGQ IP offsets */
 #define XGQ_SQ_REG		0x0

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -1621,7 +1621,7 @@ xocl_kds_xgq_cfg_start(struct xocl_dev *xdev, struct drm_xocl_kds cfg, int num_c
 	cfg_start->num_cus = num_cus;
 	cfg_start->i2h = 1;
 	cfg_start->i2e = 1;
-	cfg_start->cui = 0;
+	cfg_start->cui = 1;
 	cfg_start->mode = 0;
 	cfg_start->echo = 0;
 	cfg_start->verbose = 0;
@@ -1725,6 +1725,8 @@ xocl_kds_xgq_cfg_cu(struct xocl_dev *xdev, xuid_t *xclbin_id, struct xrt_cu_info
 		cfg_cu->cu_idx = i;
 		cfg_cu->cu_domain = DOMAIN_PL;
 		cfg_cu->ip_ctrl = cu_info[i].protocol;
+		cfg_cu->intr_id = cu_info[i].intr_id;
+		cfg_cu->intr_enable = cu_info[i].intr_enable;
 		cfg_cu->map_size = cu_info[i].size;
 		cfg_cu->laddr = cu_info[i].addr;
 		cfg_cu->haddr = cu_info[i].addr >> 32;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -3,6 +3,7 @@
  * Xilinx Alveo User Function Driver
  *
  * Copyright (C) 2020-2022 Xilinx, Inc.
+ * Copyright (C) 2022 Advanced Micro Devices, Inc.
  *
  * Authors: min.ma@xilinx.com
  */


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Support CU completion interrupt on APU

#### Risks (if any) associated the changes in the commit
No

#### What has been tested and how, request additional testing if necessary
vck5000 xbutil validate test, zcu104

#### Documentation impact (if any)
No

============================================
vck5000 xbutil validate iops result
```
$xbutil validate -d 04:00 -r iops
Starting validation for 1 devices

Validate Device           : [0000:04:00.1]
    Platform              : xilinx_vck5000_gen4x8_qdma_base_1
    SC Version            : 4.4.33
    Platform ID           : 2A6AB1C4-DFA1-27FD-7F24-E8F121039A2E
-------------------------------------------------------------------------------
Test 1 [0000:04:00.1]     : iops
    Details               : IOPS: 483580 (verify)
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Validation completed. Please run the command '--verbose' option for more details
```