### PR TITLE
Add xclbin uuid optional argument to xrt_core::device::get_ert_slots()

### DIFF
--- a/src/runtime_src/core/common/device.cpp
+++ b/src/runtime_src/core/common/device.cpp
@@ -405,9 +405,9 @@ get_ert_slots(const char* xml_data, size_t xml_size) const
 
 std::pair<size_t, size_t>
 device::
-get_ert_slots() const
+get_ert_slots(const uuid& xclbin_id) const
 {
-  auto xml =  get_axlf_section(EMBEDDED_METADATA);
+  auto xml =  get_axlf_section(EMBEDDED_METADATA, xclbin_id);
   if (!xml.first)
     throw error(EINVAL, "No xml metadata in xclbin");
   return get_ert_slots(xml.first, xml.second);

--- a/src/runtime_src/core/common/device.h
+++ b/src/runtime_src/core/common/device.h
@@ -404,7 +404,7 @@ public:
 
   XRT_CORE_COMMON_EXPORT
   std::pair<size_t, size_t>
-  get_ert_slots() const;
+  get_ert_slots(const uuid& xclbin_id = uuid()) const;
 
   // Move all these 'pt' functions out the class interface
   virtual void get_info(boost::property_tree::ptree&) const {}


### PR DESCRIPTION
#### Problem solved by the commit
Allow multi-xclbin cases to gather meta data for correct xclbin.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Add optional xclbin uuid argument to function that use xclbin meta data

