### PR TITLE
Add new internal shim API xrt::shim_int::close_cu_context

### DIFF
--- a/src/runtime_src/core/common/ishim.h
+++ b/src/runtime_src/core/common/ishim.h
@@ -51,10 +51,7 @@ struct ishim
   open_cu_context(const xrt::hw_context& hwctx, const std::string& cuname) = 0;
 
   virtual void
-  close_cu_context(const xrt::hw_context& hwctx, cuidx_type ip_index)
-  {
-    close_context(hwctx.get_xclbin_uuid(), ip_index.index);
-  }
+  close_cu_context(const xrt::hw_context& hwctx, cuidx_type ip_index) = 0;
 
   // Legacy, to be removed
   virtual void
@@ -283,6 +280,12 @@ struct shim : public DeviceType
   open_cu_context(const xrt::hw_context& hwctx, const std::string& cuname) override
   {
     return xrt::shim_int::open_cu_context(DeviceType::get_device_handle(), hwctx, cuname);
+  }
+
+  void
+  close_cu_context(const xrt::hw_context& hwctx, cuidx_type cuidx) override
+  {
+    xrt::shim_int::close_cu_context(DeviceType::get_device_handle(), hwctx, cuidx);
   }
 
   // Legacy, to be removed

--- a/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/halapi.cxx
+++ b/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/halapi.cxx
@@ -35,6 +35,13 @@ open_cu_context(xclDeviceHandle handle, const xrt::hw_context& hwctx, const std:
   return shim->open_cu_context(hwctx, cuname);
 }
 
+void
+close_cu_context(xclDeviceHandle handle, const xrt::hw_context& hwctx, xrt_core::cuidx_type cuidx)
+{
+  auto shim = get_shim_object(handle);
+  return shim->close_cu_context(hwctx, cuidx);
+}
+
 } // xrt::shim_int
 
 xclDeviceHandle xclOpen(unsigned deviceIndex, const char *logfileName, xclVerbosityLevel level)

--- a/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/shim.cxx
@@ -2181,6 +2181,15 @@ open_cu_context(const xrt::hw_context& hwctx, const std::string& cuname)
   return cuidx;
 }
 
+void
+CpuemShim::
+close_cu_context(const xrt::hw_context& hwctx, xrt_core::cuidx_type cuidx)
+{
+  // To-be-implemented
+  if (xclCloseContext(hwctx.get_xclbin_uuid().get(), cuidx.index))
+    throw xrt_core::system_error(errno, "failed to close cu context (" + std::to_string(cuidx.index) + ")");
+}
+
 /******************************* XRT Graph API's **************************************************/
 /**
 * xrtGraphInit() - Initialize  graph

--- a/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/shim.h
@@ -311,6 +311,9 @@ namespace xclcpuemhal2 {
       xrt_core::cuidx_type
       open_cu_context(const xrt::hw_context& hwctx, const std::string& cuname);
 
+      void
+      close_cu_context(const xrt::hw_context& hwctx, xrt_core::cuidx_type cuidx);
+
     private:
       std::shared_ptr<xrt_core::device> mCoreDevice;
       std::mutex mMemManagerMutex;

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -1130,6 +1130,15 @@ open_cu_context(const xrt::hw_context& hwctx, const std::string& cuname)
   return cuidx;
 }
 
+void
+shim::
+close_cu_context(const xrt::hw_context& hwctx, xrt_core::cuidx_type cuidx)
+{
+  // To-be-implemented
+  if (xclCloseContext(hwctx.get_xclbin_uuid().get(), cuidx.index))
+    throw xrt_core::system_error(errno, "failed to close cu context (" + std::to_string(cuidx.index) + ")");
+}
+
 int
 shim::
 xclCloseContext(const uuid_t xclbinId, unsigned int ipIndex)
@@ -1818,6 +1827,13 @@ open_cu_context(xclDeviceHandle handle, const xrt::hw_context& hwctx, const std:
 {
   auto shim = get_shim_object(handle);
   return shim->open_cu_context(hwctx, cuname);
+}
+
+void
+close_cu_context(xclDeviceHandle handle, const xrt::hw_context& hwctx, xrt_core::cuidx_type cuidx)
+{
+  auto shim = get_shim_object(handle);
+  return shim->close_cu_context(hwctx, cuidx);
 }
 
 } // xrt::shim_int

--- a/src/runtime_src/core/edge/user/shim.h
+++ b/src/runtime_src/core/edge/user/shim.h
@@ -68,6 +68,7 @@ public:
   int xclOpenContext(const uuid_t xclbinId, unsigned int ipIndex, bool shared);
   // aka xclOpenContextByName()
   xrt_core::cuidx_type open_cu_context(const xrt::hw_context& hwctx, const std::string& cuname);
+  void close_cu_context(const xrt::hw_context& hwctx, xrt_core::cuidx_type cuidx);
   int xclCloseContext(const uuid_t xclbinId, unsigned int ipIndex);
 
   int xclSKGetCmd(xclSKCmd *cmd);

--- a/src/runtime_src/core/include/shim_int.h
+++ b/src/runtime_src/core/include/shim_int.h
@@ -30,17 +30,26 @@ XCL_DRIVER_DLLESPEC
 xclDeviceHandle
 open_by_bdf(const std::string& bdf);
 
-// open_context() - Open a shared/exclusive context on a named compute unit
+// open_cu_context() - Open a shared/exclusive context on a named compute unit
 //
 // @handle:        Device handle
-// @slot:          Slot index of xclbin to service this context requiest
-// @xclbin_uuid:   UUID of the xclbin image with the CU to open a context on
+// @hwctx:         Hardware context in which to open the CU
 // @cuname:        Name of compute unit to open
-// @shared:        Shared access or exclusive access
+// Returns:        The cuidx assigned by the driver
 //
 // Throws on error
 xrt_core::cuidx_type
 open_cu_context(xclDeviceHandle handle, const xrt::hw_context& hwctx, const std::string& cuname);
+
+// close_cu_context() - Close a previously opened CU context
+//
+// @handle:        Device handle
+// @hwctx:         The hardware context in which this CU was opened
+// @cuidx:         UUID of the xclbin image with the CU to open a context on
+//
+// Throws on error, e.g. the CU context was not opened previously
+void
+close_cu_context(xclDeviceHandle handle, const xrt::hw_context& hwctx, xrt_core::cuidx_type cuidx);
 
 // create_hw_context() -
 uint32_t // ctxhdl aka slotidx

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/halapi.cxx
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/halapi.cxx
@@ -36,6 +36,13 @@ open_cu_context(xclDeviceHandle handle, const xrt::hw_context& hwctx, const std:
   return shim->open_cu_context(hwctx, cuname);
 }
 
+void
+close_cu_context(xclDeviceHandle handle, const xrt::hw_context& hwctx, xrt_core::cuidx_type cuidx)
+{
+  auto shim = get_shim_object(handle);
+  return shim->close_cu_context(hwctx, cuidx);
+}
+
 } // xrt::shim_int
 
 ////////////////////////////////////////////////////////////////

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
@@ -39,14 +39,14 @@ namespace xclcpuemhal2
   if (mLogStream.is_open()) \
     mLogStream << __func__ << " ended " << std::endl;
 
-  CpuemShim::CpuemShim(unsigned int deviceIndex, 
-                       xclDeviceInfo2 &info, 
-                       std::list<xclemulation::DDRBank> &DDRBankList, 
-                       bool _unified, 
+  CpuemShim::CpuemShim(unsigned int deviceIndex,
+                       xclDeviceInfo2 &info,
+                       std::list<xclemulation::DDRBank> &DDRBankList,
+                       bool _unified,
                        bool _xpr,
-                       FeatureRomHeader &fRomHeader, 
+                       FeatureRomHeader &fRomHeader,
                        const boost::property_tree::ptree &platformData)
-              : mTag(TAG), mRAMSize(info.mDDRSize), mCoalesceThreshold(4), 
+              : mTag(TAG), mRAMSize(info.mDDRSize), mCoalesceThreshold(4),
 	      mDeviceIndex(deviceIndex), mIsDeviceProcessStarted(false)
   {
     binaryCounter = 0;
@@ -152,7 +152,7 @@ namespace xclcpuemhal2
       return 0;
     if (!((CpuemShim *)handle)->isGood())
       return 0;
-    
+
     return (CpuemShim *)handle;
   }
 
@@ -384,7 +384,7 @@ namespace xclcpuemhal2
         char *vitisInstallEnvvar = getenv("XILINX_VITIS");
         if (vitisInstallEnvvar != NULL)
           xilinxInstall = std::string(vitisInstallEnvvar);
-        
+
         char *scoutInstallEnvvar = getenv("XILINX_SCOUT");
         if (scoutInstallEnvvar != NULL && xilinxInstall.empty())
           xilinxInstall = std::string(scoutInstallEnvvar);
@@ -777,7 +777,7 @@ namespace xclcpuemhal2
       if (!mMessengerThread.joinable())
         mMessengerThread = std::thread([this]
                                        { messagesThread(); });
-      
+
       setDriverVersion("2.0");
       xclLoadBitstream_RPC_CALL(xclLoadBitstream, xmlFile, tempdlopenfilename, deviceDirectory, binaryDirectory, verbose);
       if (!ack)
@@ -831,7 +831,7 @@ namespace xclcpuemhal2
     size_t requestedSize = size;
     if (mLogStream.is_open())
       mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << size << std::endl;
-    
+
     if (!sock)
       launchTempProcess();
 
@@ -1720,7 +1720,7 @@ namespace xclcpuemhal2
       unsigned char *host_only_buffer = (unsigned char *)(sBO->buf) + src_offset;
       if (xclCopyBufferHost2Device(dBO->base, (void*)host_only_buffer, size, dst_offset) != size)
       {
-        std::cerr << "ERROR: copy buffer from host to device failed " << std::endl;      
+        std::cerr << "ERROR: copy buffer from host to device failed " << std::endl;
         return -1;
       }
     } // source buffer is device_only and destination buffer is host_only
@@ -1729,7 +1729,7 @@ namespace xclcpuemhal2
       unsigned char *host_only_buffer = (unsigned char *)(dBO->buf) + dst_offset;
       if (xclCopyBufferDevice2Host((void*)host_only_buffer, sBO->base, size, src_offset) != size)
       {
-        std::cerr << "ERROR: copy buffer from device to host failed " << std::endl;      
+        std::cerr << "ERROR: copy buffer from device to host failed " << std::endl;
         return -1;
       }
     }
@@ -2153,7 +2153,7 @@ namespace xclcpuemhal2
     if (mLogStream.is_open())
       mLogStream << __func__ << ", " << std::this_thread::get_id() << std::endl;
 
-    std::lock_guard<std::mutex> lk(mApiMtx);     
+    std::lock_guard<std::mutex> lk(mApiMtx);
     bool ack = false;
     auto ghPtr = (xclcpuemhal2::GraphType *)gh;
     if (!ghPtr)
@@ -2181,7 +2181,7 @@ namespace xclcpuemhal2
   {
     if (mLogStream.is_open())
       mLogStream << __func__ << ", " << std::this_thread::get_id() << std::endl;
-    
+
     std::lock_guard<std::mutex> lk(mApiMtx);
     bool ack = false;
     auto ghPtr = (xclcpuemhal2::GraphType *)gh;
@@ -2211,7 +2211,7 @@ namespace xclcpuemhal2
   {
     if (mLogStream.is_open())
       mLogStream << __func__ << ", " << std::this_thread::get_id() << std::endl;
-    
+
     std::lock_guard<std::mutex> lk(mApiMtx);
     bool ack = false;
     auto ghPtr = (xclcpuemhal2::GraphType *)gh;
@@ -2242,7 +2242,7 @@ namespace xclcpuemhal2
     if (mLogStream.is_open())
       mLogStream << __func__ << ", " << std::this_thread::get_id() << std::endl;
 
-    std::lock_guard<std::mutex> lk(mApiMtx);    
+    std::lock_guard<std::mutex> lk(mApiMtx);
     bool ack = false;
     auto ghPtr = (xclcpuemhal2::GraphType *)gh;
     if (!ghPtr)
@@ -2280,7 +2280,7 @@ namespace xclcpuemhal2
     if (mLogStream.is_open())
       mLogStream << __func__ << ", " << std::this_thread::get_id() << std::endl;
 
-    std::lock_guard<std::mutex> lk(mApiMtx);     
+    std::lock_guard<std::mutex> lk(mApiMtx);
     bool ack = false;
     auto ghPtr = (xclcpuemhal2::GraphType *)gh;
     if (!ghPtr)
@@ -2289,7 +2289,7 @@ namespace xclcpuemhal2
     DEBUG_MSGS("%s, %d()\n", __func__, __LINE__);
     auto graphhandle = ghPtr->getGraphHandle();
     xclGraphEnd_RPC_CALL(xclGraphEnd, graphhandle);
-    
+
     if (!ack)
     {
       DEBUG_MSGS("%s, %d(Failed to get the ack)\n", __func__, __LINE__);
@@ -2319,7 +2319,7 @@ namespace xclcpuemhal2
   {
     if (mLogStream.is_open())
       mLogStream << __func__ << ", " << std::this_thread::get_id() << std::endl;
-    
+
     std::lock_guard<std::mutex> lk(mApiMtx);
     bool ack = false;
     auto ghPtr = (xclcpuemhal2::GraphType *)gh;
@@ -2348,7 +2348,7 @@ namespace xclcpuemhal2
   {
     if (mLogStream.is_open())
       mLogStream << __func__ << ", " << std::this_thread::get_id() << std::endl;
-    
+
     std::lock_guard<std::mutex> lk(mApiMtx);
     bool ack = false;
     auto ghPtr = (xclcpuemhal2::GraphType *)gh;
@@ -2382,7 +2382,7 @@ namespace xclcpuemhal2
   {
     if (mLogStream.is_open())
       mLogStream << __func__ << ", " << std::this_thread::get_id() << std::endl;
-    
+
     std::lock_guard<std::mutex> lk(mApiMtx);
     auto ghPtr = (xclcpuemhal2::GraphType *)gh;
     if (!ghPtr)
@@ -2413,7 +2413,7 @@ namespace xclcpuemhal2
   {
     if (mLogStream.is_open())
       mLogStream << __func__ << ", " << std::this_thread::get_id() << std::endl;
-    
+
     std::lock_guard<std::mutex> lk(mApiMtx);
     auto ghPtr = (xclcpuemhal2::GraphType *)gh;
     if (!ghPtr)
@@ -2481,7 +2481,7 @@ namespace xclcpuemhal2
   {
     if (mLogStream.is_open())
       mLogStream << __func__ << ", " << std::this_thread::get_id() << std::endl;
-  
+
     std::lock_guard<std::mutex> lk(mApiMtx);
     bool ack = false;
     if (!gmioname)
@@ -2499,11 +2499,11 @@ namespace xclcpuemhal2
     return 0;
   }
 
-  // open_context() - aka xclOpenContextByName
+  // open_cu_context() - aka xclOpenContextByName
   // Throw on error, return cuidx
   xrt_core::cuidx_type
   CpuemShim::
-      open_cu_context(const xrt::hw_context &hwctx, const std::string &cuname)
+  open_cu_context(const xrt::hw_context &hwctx, const std::string &cuname)
   {
     // Emulation does not yet support multiple xclbins.  Call
     // regular flow.  Default access mode to shared unless explicitly
@@ -2514,6 +2514,16 @@ namespace xclcpuemhal2
     xclOpenContext(hwctx.get_xclbin_uuid().get(), cuidx.index, shared);
 
     return cuidx;
+  }
+
+  // close_cu_context() - aka xclCloseContext
+  // Throw on error
+  void
+  CpuemShim::
+  close_cu_context(const xrt::hw_context& hwctx, xrt_core::cuidx_type cuidx)
+  {
+    if (xclCloseContext(hwctx.get_xclbin_uuid().get(), cuidx.index))
+      throw xrt_core::system_error(errno, "failed to close cu context (" + std::to_string(cuidx.index) + ")");
   }
 
   /**********************************************HAL2 API's END HERE **********************************************/

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.h
@@ -410,6 +410,9 @@ namespace xclcpuemhal2
     xrt_core::cuidx_type
     open_cu_context(const xrt::hw_context &hwctx, const std::string &cuname);
 
+    void
+    close_cu_context(const xrt::hw_context& hwctx, xrt_core::cuidx_type cuidx);
+
   private:
     std::shared_ptr<xrt_core::device> mCoreDevice;
     std::mutex mMemManagerMutex;

--- a/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/halapi.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/halapi.cxx
@@ -37,6 +37,13 @@ open_cu_context(xclDeviceHandle handle, const xrt::hw_context& hwctx, const std:
   return shim->open_cu_context(hwctx, cuname);
 }
 
+void
+close_cu_context(xclDeviceHandle handle, const xrt::hw_context& hwctx, xrt_core::cuidx_type cuidx)
+{
+  auto shim = get_shim_object(handle);
+  return shim->close_cu_context(hwctx, cuidx);
+}
+
 uint32_t // ctxhdl aka slotidx
 create_hw_context(xclDeviceHandle handle, const xrt::uuid& xclbin_uuid, uint32_t qos)
 {

--- a/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.cxx
@@ -211,7 +211,7 @@ namespace xclhwemhal2 {
                   this->xclClose();                                               // Let's have a proper clean if xsim is NOT running
                   exit(0);                                                        // It's a clean exit only.
               }
-                
+
             }
           }
         }
@@ -1680,9 +1680,9 @@ uint32_t HwEmShim::getAddressSpace (uint32_t topology)
     }
     // All RPC calls fail if no socket is live. so skipping of sending RPC calls if no socket connection is present.
     if (sock->m_is_socket_live)
-      resetProgram(false);      
-    
-    
+      resetProgram(false);
+
+
     int status = 0;
     xclemulation::debug_mode lWaveform = xclemulation::config::getInstance()->getLaunchWaveform();
     if ((lWaveform == xclemulation::debug_mode::gui || lWaveform == xclemulation::debug_mode::batch || lWaveform == xclemulation::debug_mode::off)
@@ -1811,7 +1811,7 @@ uint32_t HwEmShim::getAddressSpace (uint32_t topology)
       std::lock_guard<std::mutex> guard(mPrintMessagesLock);
       simulator_started = false;
       fetchAndPrintMessages();
-      
+
     }
     catch (std::exception& ex) {
       if (mLogStream.is_open())
@@ -3211,6 +3211,14 @@ open_cu_context(const xrt::hw_context& hwctx, const std::string& cuname)
   xclOpenContext(hwctx.get_xclbin_uuid().get(), cuidx.index, shared);
 
   return cuidx;
+}
+
+void
+HwEmShim::
+close_cu_context(const xrt::hw_context& hwctx, xrt_core::cuidx_type cuidx)
+{
+  if (xclCloseContext(hwctx.get_xclbin_uuid().get(), cuidx.index))
+    throw xrt_core::system_error(errno, "failed to close cu context (" + std::to_string(cuidx.index) + ")");
 }
 
 // aka xclCreateHWContext, internal shim API for native C++ applications only

--- a/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.h
+++ b/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.h
@@ -139,6 +139,9 @@ using addr_type = uint64_t;
       xrt_core::cuidx_type
       open_cu_context(const xrt::hw_context& hwctx, const std::string& cuname);
 
+      void
+      close_cu_context(const xrt::hw_context& hwctx, xrt_core::cuidx_type cuidx);
+
       // aka xclCreateHWContext, internal shim API for native C++ applications only
       uint32_t // ctx handle aka slot idx
       create_hw_context(const xrt::uuid& xclbin_uuid, uint32_t qos);

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -2176,6 +2176,15 @@ open_cu_context(const xrt::hw_context& hwctx, const std::string& cuname)
   return cuidx;
 }
 
+void
+shim::
+close_cu_context(const xrt::hw_context& hwctx, xrt_core::cuidx_type cuidx)
+{
+  // To-be-implemented
+  if (xclCloseContext(hwctx.get_xclbin_uuid().get(), cuidx.index))
+    throw xrt_core::system_error(errno, "failed to close cu context (" + std::to_string(cuidx.index) + ")");
+}
+
 // Assign xclbin with uuid to hardware resources and return a context id
 // The context handle is 1:1 with a slot idx
 uint32_t
@@ -2221,6 +2230,13 @@ open_cu_context(xclDeviceHandle handle, const xrt::hw_context& hwctx, const std:
 {
   auto shim = get_shim_object(handle);
   return shim->open_cu_context(hwctx, cuname);
+}
+
+void
+close_cu_context(xclDeviceHandle handle, const xrt::hw_context& hwctx, xrt_core::cuidx_type cuidx)
+{
+  auto shim = get_shim_object(handle);
+  return shim->close_cu_context(hwctx, cuidx);
 }
 
 uint32_t // ctxhdl aka slotidx

--- a/src/runtime_src/core/pcie/linux/shim.h
+++ b/src/runtime_src/core/pcie/linux/shim.h
@@ -146,6 +146,9 @@ public:
   xrt_core::cuidx_type
   open_cu_context(const xrt::hw_context& hwctx, const std::string& cuname);
 
+  void
+  close_cu_context(const xrt::hw_context& hwctx, xrt_core::cuidx_type cuidx);
+
   uint32_t // ctx handle aka slot idx
   create_hw_context(const xrt::uuid& xclbin_uuid, uint32_t qos);
 

--- a/src/runtime_src/core/pcie/noop/shim.cpp
+++ b/src/runtime_src/core/pcie/noop/shim.cpp
@@ -444,6 +444,12 @@ struct shim
     return m_pldev->open_cu_context(hwctx, cuname);
   }
 
+  void
+  close_cu_context(const xrt::hw_context& hwctx, xrt_core::cuidx_type cuidx)
+  {
+    return m_pldev->close_context(hwctx.get_xclbin_uuid(), cuidx.index);
+  }
+
   int
   close_context(const xrt::uuid& xid, unsigned int idx)
   {
@@ -605,6 +611,13 @@ open_cu_context(xclDeviceHandle handle, const xrt::hw_context& hwctx, const std:
 {
   auto shim = get_shim_object(handle);
   return shim->open_cu_context(hwctx, cuname);
+}
+
+void
+close_cu_context(xclDeviceHandle handle, const xrt::hw_context& hwctx, xrt_core::cuidx_type cuidx)
+{
+  auto shim = get_shim_object(handle);
+  return shim->close_cu_context(hwctx, cuidx);
 }
 
 uint32_t // ctxhdl aka slotidx

--- a/src/runtime_src/core/pcie/windows/alveo/shim.cpp
+++ b/src/runtime_src/core/pcie/windows/alveo/shim.cpp
@@ -1419,6 +1419,14 @@ done:
     return cuidx;
   }
 
+  void
+  shim::
+  close_cu_context(const xrt::hw_context& hwctx, xrt_core::cuidx_type cuidx)
+  {
+    // To-be-implemented
+    if (close_context(hwctx.get_xclbin_uuid().get(), cuidx.index))
+      throw xrt_core::system_error(errno, "failed to close cu context (" + std::to_string(cuidx.index) + ")");
+  }
 }; // struct shim
 
 shim*
@@ -1586,6 +1594,13 @@ open_cu_context(xclDeviceHandle handle, const xrt::hw_context& hwctx, const std:
 {
   auto shim = get_shim_object(handle);
   return shim->open_cu_context(hwctx, cuname);
+}
+
+void
+close_cu_context(xclDeviceHandle handle, const xrt::hw_context& hwctx, xrt_core::cuidx_type cuidx)
+{
+  auto shim = get_shim_object(handle);
+  return shim->close_cu_context(hwctx, cuidx);
 }
 
 } // namespace xrt::shim_int


### PR DESCRIPTION
#### Problem solved by the commit
To match open_cu_context, a new close_cu_context shim internal API is
added that takes the hwctx as argument.  This allows driver to track /
associate the CU context with a hardware context.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CU indices are unique across all slots / partitions on device, so
technically the references to a CU context could be tracked as a
global count spanning all hardware contexts.  However, by scoping the
CU context to a hardware context, the driver can do more cross
checking, such as error out if a hardware context is detroyed without
all CU contexts being closed.

#### How problem was solved, alternative solutions (if any) and why they were rejected
The change is purely at the shim level, since all usage of close cu
context at the API implementation (coreutil via ishim) level already
passed the hw context to a close_cu_context function that in turn just
called legacy xclCloseContext for all shims.  The ishim implementation
is now pure virtual and redefined by all shims.

This PR defaults the shim close_cu_context implementation to just call
legacy xclCloseContext, which allows the different shims to evolve to
more detailed implementation when ready.

#### Risks (if any) associated the changes in the commit
Purely function call changes, if all is right, no behavior is changed at all.

#### What has been tested and how, request additional testing if necessary
Legacy OpenCL regression test suite on Alveo Linux.

