### PR TITLE
CR-1135373 hwmon_sdm: fix buffer overflow error in memcpy()

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/hwmon_sdm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/hwmon_sdm.c
@@ -560,7 +560,6 @@ index, repo_id);
 		sz = sprintf(buf, "%u\n", uval);
 	} else if (field_id == SYSFS_SDR_UNIT_MODIFIER_VAL) {
 		memcpy(&unitm, &sdm->sensor_data[repo_id][buf_index], buf_len);
-		xocl_err(&sdm->pdev->dev, "+++unitm: %d", unitm);
 		sz = sprintf(buf, "%d\n", unitm);
 	} else if (field_id == SYSFS_SDR_STATUS_VAL) {
 		memcpy(&uval, &sdm->sensor_data[repo_id][buf_index], buf_len);
@@ -1105,7 +1104,6 @@ static int parse_sdr_info(char *in_buf, struct xocl_hwmon_sdm *sdm, bool create_
 
 				//Create *_unitm sysfs node
 				if(strlen(sysfs_name[SYSFS_SDR_UNIT_MODIFIER_VAL]) != 0) {
-					xocl_err(&sdm->pdev->dev, "+++unitm: %d", in_buf[unit_modifier_index]);
 					err = hwmon_sysfs_create(sdm, sysfs_name[SYSFS_SDR_UNIT_MODIFIER_VAL], repo_id,
 											 SYSFS_SDR_UNIT_MODIFIER_VAL, unit_modifier_index, 1);
 					if (err)

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -165,7 +165,7 @@ struct sdm_sensor_info
       boost::char_separator<char> sep(",");
       tokenizer tokens(line, sep);
 
-      if (std::distance(tokens.begin(), tokens.end()) != 5)
+      if (std::distance(tokens.begin(), tokens.end()) != 6)
         throw xrt_core::query::sysfs_error("CU statistic sysfs node corrupted");
 
       data_type data { };
@@ -176,6 +176,7 @@ struct sdm_sensor_info
       data.average   = std::stoi(std::string(*tok_it++));
       data.max       = std::stoi(std::string(*tok_it++));
       data.status    = std::stoi(std::string(*tok_it++));
+      data.unitm     = std::stoi(std::string(*tok_it++));
       output.push_back(data);
     }
 


### PR DESCRIPTION
Signed-off-by: Rajkumar Rampelli <rampelli@amd.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
For the BDINFO repo type, the sensor's value length is more than 4 bytes and this value is handled separately for this repo type, hence this overflow issue has seen for memcpy() in parse_sdr_info() API.  Moved memcpy() APIs to right place to fix this issue.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1135373
#### How problem was solved, alternative solutions (if any) and why they were rejected
Fixed the memcpy() buffer overflow issues in hwmon_sdm driver.
#### Risks (if any) associated the changes in the commit
NA
#### What has been tested and how, request additional testing if necessary
XRT drivers installation, tool sensors reports.
#### Documentation impact (if any)
NA