### PR TITLE
Introducing Client cu context

### DIFF
--- a/src/runtime_src/core/common/drv/include/kds_client.h
+++ b/src/runtime_src/core/common/drv/include/kds_client.h
@@ -36,6 +36,13 @@ struct kds_client_cu_ctx {
 	struct list_head		link;
 };
 
+/* KDS CU information. */
+struct kds_client_cu_info {
+	u32				cu_idx;
+	u32		  		cu_domain;
+	u32				flags;
+};
+
 /* Multiple xclbin context can be active under a single client.
  * Client should maintain all the active XCLBIN.
  */

--- a/src/runtime_src/core/common/drv/include/kds_client.h
+++ b/src/runtime_src/core/common/drv/include/kds_client.h
@@ -3,6 +3,7 @@
  * Xilinx Kernel Driver Scheduler
  *
  * Copyright (C) 2021-2022 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Authors: min.ma@xilinx.com
  *

--- a/src/runtime_src/core/common/drv/include/kds_client.h
+++ b/src/runtime_src/core/common/drv/include/kds_client.h
@@ -24,16 +24,27 @@
 
 #define EV_ABORT	0x1
 
+/* Multiple CU context can be active under a single KDS client Context.
+ */
+struct kds_client_cu_ctx {
+	struct kds_client_ctx		*ctx;
+	u32				cu_idx;
+	u32		  		cu_domain;
+	u32				flags;
+	u32				ref_cnt;
+	struct list_head		link;
+};
+
 /* Multiple xclbin context can be active under a single client.
  * Client should maintain all the active XCLBIN.
  */
 struct kds_client_ctx {
-	struct list_head          link;
-	void			 *xclbin_id;
-	u32			  slot_idx;
-	u32			  num_ctx;
-	u32			  num_scu_ctx;
-	u32			  virt_cu_ref;
+	/* To support multiple context for multislot case */
+	struct list_head		link;
+	void				*xclbin_id;
+	u32				slot_idx;
+	/* To support multiple CU context */
+	struct list_head		cu_ctx_list;
 };
 
 struct kds_client_cu_refcnt {

--- a/src/runtime_src/core/common/drv/include/kds_core.h
+++ b/src/runtime_src/core/common/drv/include/kds_core.h
@@ -200,9 +200,11 @@ u32 kds_get_cu_addr(struct kds_sched *kds, int idx);
 u32 kds_get_cu_proto(struct kds_sched *kds, int idx);
 int kds_get_max_regmap_size(struct kds_sched *kds);
 struct kds_client_cu_ctx *
-kds_get_cu_ctx(struct kds_client *client, struct kds_client_ctx *ctx, uint32_t cu_index);
+kds_get_cu_ctx(struct kds_client *client, struct kds_client_ctx *ctx,
+		struct kds_client_cu_info *cu_info);
 struct kds_client_cu_ctx *
-kds_alloc_cu_ctx(struct kds_client *client, struct kds_client_ctx *ctx, uint32_t cu_index);
+kds_alloc_cu_ctx(struct kds_client *client, struct kds_client_ctx *ctx,
+		struct kds_client_cu_info *cu_info);
 int kds_free_cu_ctx(struct kds_client *client, struct kds_client_cu_ctx *cu_ctx);
 int kds_add_context(struct kds_sched *kds, struct kds_client *client,
 		    struct kds_client_cu_ctx *cu_ctx);

--- a/src/runtime_src/core/common/drv/include/kds_core.h
+++ b/src/runtime_src/core/common/drv/include/kds_core.h
@@ -3,6 +3,7 @@
  * Xilinx Kernel Driver Scheduler
  *
  * Copyright (C) 2020-2022 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Authors: min.ma@xilinx.com
  *
@@ -198,6 +199,11 @@ int kds_get_cu_total(struct kds_sched *kds);
 u32 kds_get_cu_addr(struct kds_sched *kds, int idx);
 u32 kds_get_cu_proto(struct kds_sched *kds, int idx);
 int kds_get_max_regmap_size(struct kds_sched *kds);
+struct kds_client_cu_ctx *
+kds_get_cu_ctx(struct kds_client *client, struct kds_client_ctx *ctx, uint32_t cu_index);
+struct kds_client_cu_ctx *
+kds_alloc_cu_ctx(struct kds_client *client, struct kds_client_ctx *ctx, uint32_t cu_index);
+int kds_free_cu_ctx(struct kds_client *client, struct kds_client_cu_ctx *cu_ctx);
 int kds_add_context(struct kds_sched *kds, struct kds_client *client,
 		    struct kds_client_cu_ctx *cu_ctx);
 int kds_del_context(struct kds_sched *kds, struct kds_client *client,

--- a/src/runtime_src/core/common/drv/include/kds_core.h
+++ b/src/runtime_src/core/common/drv/include/kds_core.h
@@ -80,13 +80,6 @@ enum kds_type {
 	KDS_MAX_TYPE, // always the last one
 };
 
-struct kds_ctx_info {
-	u32		  cu_domain;
-	u32		  cu_idx;
-	u32		  flags;
-	void		 *curr_ctx; // Holds the current context ptr for kds
-};
-
 /* Context properties */
 #define	CU_CTX_PROP_MASK	0x0F
 #define	CU_CTX_SHARED		0x00
@@ -206,9 +199,9 @@ u32 kds_get_cu_addr(struct kds_sched *kds, int idx);
 u32 kds_get_cu_proto(struct kds_sched *kds, int idx);
 int kds_get_max_regmap_size(struct kds_sched *kds);
 int kds_add_context(struct kds_sched *kds, struct kds_client *client,
-		    struct kds_ctx_info *info);
+		    struct kds_client_cu_ctx *cu_ctx);
 int kds_del_context(struct kds_sched *kds, struct kds_client *client,
-		    struct kds_ctx_info *info);
+		    struct kds_client_cu_ctx *cu_ctx);
 int kds_open_ucu(struct kds_sched *kds, struct kds_client *client, u32 cu_idx);
 int kds_map_cu_addr(struct kds_sched *kds, struct kds_client *client,
 		    int idx, unsigned long size, u32 *addrp);

--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -1109,6 +1109,7 @@ kds_get_cu_ctx(struct kds_client *client, struct kds_client_ctx *ctx,
         uint32_t cu_domain = get_domain(cu_index);
         uint32_t cu_idx = get_domain_idx(cu_index);
         struct kds_client_cu_ctx *cu_ctx = NULL;
+	bool found = false;
 
         if (!ctx) {
 		kds_err(client, "No Client Context available");
@@ -1118,14 +1119,16 @@ kds_get_cu_ctx(struct kds_client *client, struct kds_client_ctx *ctx,
         /* Find out if same CU context is already exists  */
         list_for_each_entry(cu_ctx, &ctx->cu_ctx_list, link)
                 if ((cu_ctx->cu_idx == cu_idx) &&
-                                (cu_ctx->cu_domain == cu_domain))
-                        break;
+                                (cu_ctx->cu_domain == cu_domain)) {
+                        found = true;
+			break;
+		}
 
         /* CU context exists. Return the context */
-        if (&cu_ctx->link == &ctx->cu_ctx_list)
-                return NULL;
-
-        return cu_ctx;
+	if (found)
+        	return cu_ctx;
+                
+	return NULL;
 }
 
 struct kds_client_cu_ctx *

--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -1185,7 +1185,7 @@ int kds_free_cu_ctx(struct kds_client *client, struct kds_client_cu_ctx *cu_ctx)
 
 	if (!cu_ctx && cu_ctx->ref_cnt) {
 		/* Reference count must be reset before free the context */
-		kds_err(client, "Invalid Context requested to free");
+		kds_err(client, "Invalid CU Context requested to free");
 		return -EINVAL;
 	}
 	

--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -1138,6 +1138,7 @@ kds_initialize_cu_ctx(struct kds_client *client, struct kds_client_cu_ctx *cu_ct
 		return -EINVAL;
 	}
 
+	// Initialize the new context
 	cu_ctx->ctx = client->ctx;
 	cu_ctx->cu_domain = cu_info->cu_domain;
 	cu_ctx->cu_idx = cu_info->cu_idx;

--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -1067,6 +1067,7 @@ _kds_fini_client(struct kds_sched *kds, struct kds_client *client,
 	list_for_each_entry_safe(cu_ctx, next, &cctx->cu_ctx_list, link) {
 		kds_info(client, "Removing CU Domain[%d] CU Index [%d]", cu_ctx->cu_domain,
 				cu_ctx->cu_idx);
+		kds_add_context(kds, client, cu_ctx);
 		kds_free_cu_ctx(client, cu_ctx);
 	}
 	

--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -1110,6 +1110,8 @@ kds_get_cu_ctx(struct kds_client *client, struct kds_client_ctx *ctx,
         uint32_t cu_idx = get_domain_idx(cu_index);
         struct kds_client_cu_ctx *cu_ctx = NULL;
 	bool found = false;
+	
+	BUG_ON(!mutex_is_locked(&client->lock));
 
         if (!ctx) {
 		kds_err(client, "No Client Context available");

--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -1111,9 +1111,6 @@ int kds_add_context(struct kds_sched *kds, struct kds_client *client,
 
 	BUG_ON(!mutex_is_locked(&client->lock));
 
-	if (!client->ctx)
-		return -EINVAL;
-
 	/* TODO: In lagcy KDS, there is a concept of implicit CUs.
 	 * It looks like that part is related to cdma. But it use the same
 	 * cu bit map and it relies on to how user open context.
@@ -1156,13 +1153,9 @@ int kds_del_context(struct kds_sched *kds, struct kds_client *client,
 {
 	u32 cu_idx = cu_ctx->cu_idx;
 	u32 cu_domain = cu_ctx->cu_domain;
-	struct kds_client_ctx *cctx = (struct kds_client_ctx *)cu_ctx->ctx;
 	int i;
 
 	BUG_ON(!mutex_is_locked(&client->lock));
-
-	if (!cctx)
-		return -EINVAL;
 
 	switch (cu_domain) {
 	case DOMAIN_VIRT:

--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -577,10 +577,11 @@ kds_submit_ert(struct kds_sched *kds, struct kds_command *xcmd)
 
 static int
 kds_add_cu_context(struct kds_sched *kds, struct kds_client *client,
-		   int domain, struct kds_ctx_info *info)
+		   struct kds_client_cu_ctx *cu_ctx)
 {
 	struct kds_cu_mgmt *cu_mgmt = NULL;
-	u32 cu_idx = info->cu_idx;
+	u32 cu_idx = cu_ctx->cu_idx;
+	u32 domain = cu_ctx->cu_domain;
 	u32 prop;
 	bool shared;
 	int ret = 0;
@@ -596,7 +597,7 @@ kds_add_cu_context(struct kds_sched *kds, struct kds_client *client,
 	if (cu_set < 0)
 		return cu_set;
 
-	prop = info->flags & CU_CTX_PROP_MASK;
+	prop = cu_ctx->flags & CU_CTX_PROP_MASK;
 	shared = (prop != CU_CTX_EXCLUSIVE);
 
 	/* cu_mgmt->cu_refs is the critical section of multiple clients */
@@ -633,10 +634,11 @@ err:
 
 static int
 kds_del_cu_context(struct kds_sched *kds, struct kds_client *client,
-		   int domain, struct kds_ctx_info *info)
+		   struct kds_client_cu_ctx *cu_ctx)
 {
 	struct kds_cu_mgmt *cu_mgmt = NULL;
-	u32 cu_idx = info->cu_idx;
+	u32 cu_idx = cu_ctx->cu_idx;
+	int domain = cu_ctx->cu_domain;
 	unsigned long submitted;
 	unsigned long completed;
 	bool bad_state = false;
@@ -1050,73 +1052,30 @@ int kds_init_client(struct kds_sched *kds, struct kds_client *client)
 	return 0;
 }
 
-/* This function returns true if the given CU/SCU belongs to the current slot
- * per the kds context argument.
- */
-static bool
-is_cu_in_ctx_slot(struct kds_sched *kds, struct kds_client_ctx *cctx, u32 bit, u32 cu_domain)
-{
-	struct xrt_cu *xcu = NULL;
-
-	if (cu_domain == DOMAIN_PS)
-		xcu = kds->scu_mgmt.xcus[bit];
-	else
-		xcu = kds->cu_mgmt.xcus[bit];
-
-	if (xcu && (xcu->info.slot_idx == cctx->slot_idx))
-		return true;
-
-	return false;
-}
-
 static inline void
 _kds_fini_client(struct kds_sched *kds, struct kds_client *client,
 		 struct kds_client_ctx *cctx)
 {
-	struct kds_ctx_info info;
-	u32 count_idx;
+	struct kds_client_cu_ctx *cu_ctx = NULL;
 
-	kds_info(client, "Client pid(%d) has %d opening context for %d slot",
-			pid_nr(client->pid), cctx->num_ctx, cctx->slot_idx);
+	kds_info(client, "Client pid(%d) has open context for %d slot",
+			pid_nr(client->pid), cctx->slot_idx);
 
 	mutex_lock(&client->lock);
-	while (cctx->virt_cu_ref) {
-		info.cu_idx = 0xFFFF; /* Special index for virtual CU */
-		info.curr_ctx = cctx;
-		info.cu_domain = DOMAIN_VIRT;
-		kds_del_context(kds, client, &info);
+	/* Traverse through all the context and free them up */
+	list_for_each_entry(cu_ctx, &cctx->cu_ctx_list, link) {
+		if (cu_ctx->ref_cnt) {
+			kds_info(client, "Removing CU Domain[%d] CU Index [%d]", cu_ctx->cu_domain,
+					cu_ctx->cu_idx);
+			kds_del_context(kds, client, cu_ctx);
+			list_del(&cu_ctx->link);
+			vfree(cu_ctx);
+		}
 	}
-
-	count_idx = 0;
-	while (count_idx < MAX_CUS) {
-		/* Check whether this SCU belongs to current slot */
-		if (is_cu_in_ctx_slot(kds, cctx, count_idx, DOMAIN_PS)) {
-			info.cu_idx = count_idx;
-			info.cu_domain = DOMAIN_PS;
-			info.curr_ctx = cctx;
-			kds_del_context(kds, client, &info);
-			kds_info(client,"Removing CU Domain[%d] CU Index [%d]",info.cu_domain,info.cu_idx);
-		}
-		count_idx += 1;
-	};
+	
 	kds_client_set_cu_refs_zero(client, DOMAIN_PS);
-
-	count_idx = 0;
-	while (count_idx < MAX_CUS) {
-		/* Check whether this CU belongs to current slot */
-		if (is_cu_in_ctx_slot(kds, cctx, count_idx, DOMAIN_PL)) {
-			info.cu_idx = count_idx;
-			info.cu_domain = DOMAIN_PL;
-			info.curr_ctx = cctx;
-			kds_del_context(kds, client, &info);
-			kds_info(client,"Removing CU Domain[%d] CU Index [%d]",info.cu_domain,info.cu_idx);
-		}
-		count_idx += 1;
-	};
 	kds_client_set_cu_refs_zero(client, DOMAIN_PL);
 	mutex_unlock(&client->lock);
-
-	WARN_ON(cctx->num_ctx);
 }
 
 void kds_fini_client(struct kds_sched *kds, struct kds_client *client)
@@ -1125,8 +1084,7 @@ void kds_fini_client(struct kds_sched *kds, struct kds_client *client)
 
 	list_for_each_entry(curr, &client->ctx_list, link) {
 		/* Release client's resources */
-		if (curr->num_ctx)
-			_kds_fini_client(kds, client, curr);
+		_kds_fini_client(kds, client, curr);
 	}
 
 	put_pid(client->pid);
@@ -1144,17 +1102,16 @@ void kds_fini_client(struct kds_sched *kds, struct kds_client *client)
 }
 
 int kds_add_context(struct kds_sched *kds, struct kds_client *client,
-		    struct kds_ctx_info *info)
+		    struct kds_client_cu_ctx *cu_ctx)
 {
-	u32 cu_idx = info->cu_idx;
-	u32 cu_domain = info->cu_domain;
-	bool shared = (info->flags != CU_CTX_EXCLUSIVE);
-	struct kds_client_ctx *cctx = (struct kds_client_ctx *)info->curr_ctx;
+	u32 cu_idx = cu_ctx->cu_idx;
+	u32 cu_domain = cu_ctx->cu_domain;
+	bool shared = (cu_ctx->flags != CU_CTX_EXCLUSIVE);
 	int i;
 
 	BUG_ON(!mutex_is_locked(&client->lock));
 
-	if (!cctx)
+	if (!client->ctx)
 		return -EINVAL;
 
 	/* TODO: In lagcy KDS, there is a concept of implicit CUs.
@@ -1169,7 +1126,7 @@ int kds_add_context(struct kds_sched *kds, struct kds_client *client,
 			return -EINVAL;
 		}
 		/* a special handling for m2m cu :( */
-		if (kds->cu_mgmt.num_cdma && !cctx->virt_cu_ref) {
+		if (kds->cu_mgmt.num_cdma && !cu_ctx->ref_cnt) {
 			i = kds->cu_mgmt.num_cus - kds->cu_mgmt.num_cdma;
 			if (kds_test_and_refcnt_incr(client, DOMAIN_PL, i) < 0)
 				return -EINVAL;
@@ -1177,11 +1134,10 @@ int kds_add_context(struct kds_sched *kds, struct kds_client *client,
 			++kds->cu_mgmt.cu_refs[i];
 			mutex_unlock(&kds->cu_mgmt.lock);
 		}
-		++cctx->virt_cu_ref;
 		break;
 	case DOMAIN_PL:
 	case DOMAIN_PS:
-		if (kds_add_cu_context(kds, client, cu_domain, info))
+		if (kds_add_cu_context(kds, client, cu_ctx))
 			return -EINVAL;
 		break;
 	default:
@@ -1189,18 +1145,18 @@ int kds_add_context(struct kds_sched *kds, struct kds_client *client,
 		return -EINVAL;
 	}
 
-	++cctx->num_ctx;
+	++cu_ctx->ref_cnt;
 	kds_info(client, "Client pid(%d) add context Domain(%d) CU(0x%x) shared(%s)",
 		 pid_nr(client->pid), cu_domain, cu_idx, shared? "true" : "false");
 	return 0;
 }
 
 int kds_del_context(struct kds_sched *kds, struct kds_client *client,
-		    struct kds_ctx_info *info)
+		    struct kds_client_cu_ctx *cu_ctx)
 {
-	u32 cu_idx = info->cu_idx;
-	u32 cu_domain = info->cu_domain;
-	struct kds_client_ctx *cctx = (struct kds_client_ctx *)info->curr_ctx;
+	u32 cu_idx = cu_ctx->cu_idx;
+	u32 cu_domain = cu_ctx->cu_domain;
+	struct kds_client_ctx *cctx = (struct kds_client_ctx *)cu_ctx->ctx;
 	int i;
 
 	BUG_ON(!mutex_is_locked(&client->lock));
@@ -1210,13 +1166,12 @@ int kds_del_context(struct kds_sched *kds, struct kds_client *client,
 
 	switch (cu_domain) {
 	case DOMAIN_VIRT:
-		if (!cctx->virt_cu_ref) {
+		if (!cu_ctx->ref_cnt) {
 			kds_err(client, "No opening virtual CU");
 			return -EINVAL;
 		}
-		--cctx->virt_cu_ref;
 		/* a special handling for m2m cu :( */
-		if (kds->cu_mgmt.num_cdma && !cctx->virt_cu_ref) {
+		if (kds->cu_mgmt.num_cdma && !cu_ctx->ref_cnt) {
 			i = kds->cu_mgmt.num_cus - kds->cu_mgmt.num_cdma;
 			if (kds_test_and_refcnt_decr(client, DOMAIN_PL, i) < 0)
 				return -EINVAL;
@@ -1231,7 +1186,7 @@ int kds_del_context(struct kds_sched *kds, struct kds_client *client,
 		break;
 	case DOMAIN_PL:
 	case DOMAIN_PS:
-		if (kds_del_cu_context(kds, client, cu_domain, info))
+		if (kds_del_cu_context(kds, client, cu_ctx))
 			return -EINVAL;
 		break;
 	default:
@@ -1239,9 +1194,9 @@ int kds_del_context(struct kds_sched *kds, struct kds_client *client,
 		return -EINVAL;
 	}
 
-	--cctx->num_ctx;
+	--cu_ctx->ref_cnt;
 	kds_info(client, "Client pid(%d) del context Domain(%d) CU(0x%x)",
-		 pid_nr(client->pid), info->cu_domain, cu_idx);
+		 pid_nr(client->pid), cu_domain, cu_idx);
 	return 0;
 }
 
@@ -1682,8 +1637,8 @@ u32 kds_live_clients_nolock(struct kds_sched *kds, pid_t **plist)
 	list_for_each(ptr, &kds->clients) {
 		client = list_entry(ptr, struct kds_client, link);
 		list_for_each_entry(curr, &client->ctx_list, link) {
-			if (curr->num_ctx > 0)
-			count++;
+			if(!list_empty(&curr->cu_ctx_list))
+				count++;
 		}
 	}
 	if (count == 0 || plist == NULL)
@@ -1697,7 +1652,7 @@ u32 kds_live_clients_nolock(struct kds_sched *kds, pid_t **plist)
 	list_for_each(ptr, &kds->clients) {
 		client = list_entry(ptr, struct kds_client, link);
 		list_for_each_entry(curr, &client->ctx_list, link) {
-			if (curr->num_ctx > 0) {
+			if(!list_empty(&curr->cu_ctx_list)) {
 				pl[i] = pid_nr(client->pid);
 				i++;
 			}

--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -1067,7 +1067,7 @@ _kds_fini_client(struct kds_sched *kds, struct kds_client *client,
 	list_for_each_entry_safe(cu_ctx, next, &cctx->cu_ctx_list, link) {
 		kds_info(client, "Removing CU Domain[%d] CU Index [%d]", cu_ctx->cu_domain,
 				cu_ctx->cu_idx);
-		kds_add_context(kds, client, cu_ctx);
+		kds_del_context(kds, client, cu_ctx);
 		kds_free_cu_ctx(client, cu_ctx);
 	}
 	

--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -1064,13 +1064,13 @@ _kds_fini_client(struct kds_sched *kds, struct kds_client *client,
 	mutex_lock(&client->lock);
 	/* Traverse through all the context and free them up */
 	list_for_each_entry(cu_ctx, &cctx->cu_ctx_list, link) {
-		if (cu_ctx->ref_cnt) {
-			kds_info(client, "Removing CU Domain[%d] CU Index [%d]", cu_ctx->cu_domain,
-					cu_ctx->cu_idx);
+		kds_info(client, "Removing CU Domain[%d] CU Index [%d]", cu_ctx->cu_domain,
+				cu_ctx->cu_idx);
+		if (cu_ctx->ref_cnt)
 			kds_del_context(kds, client, cu_ctx);
-			list_del(&cu_ctx->link);
-			vfree(cu_ctx);
-		}
+	
+		list_del(&cu_ctx->link);
+		vfree(cu_ctx);
 	}
 	
 	kds_client_set_cu_refs_zero(client, DOMAIN_PS);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -168,26 +168,16 @@ sk_ecmd2xcmd(struct xocl_dev *xdev, struct ert_packet *ecmd,
 	return 0;
 }
 
-static int
-xocl_initialize_cu_ctx(struct kds_client *client, struct drm_xocl_ctx *args,
-	       	struct kds_client_cu_ctx *cu_ctx)
+static inline void
+xocl_ctx_to_info(struct drm_xocl_ctx *args, struct kds_client_cu_info *cu_info)
 {
-        uint32_t cu_domain = get_domain(args->cu_index);
-        uint32_t cu_idx = get_domain_idx(args->cu_index);
+        cu_info->cu_domain = get_domain(args->cu_index);
+        cu_info->cu_idx = get_domain_idx(args->cu_index);
 
-	if (!cu_ctx)
-		return -EINVAL;
-
-        cu_ctx->ctx = client->ctx;
-        cu_ctx->cu_domain = cu_domain;
-        cu_ctx->cu_idx = cu_idx;
-        cu_ctx->ref_cnt = 0;
         if (args->flags == XOCL_CTX_EXCLUSIVE)
-                cu_ctx->flags = CU_CTX_EXCLUSIVE;
+                cu_info->flags = CU_CTX_EXCLUSIVE;
         else
-                cu_ctx->flags = CU_CTX_SHARED;
-
-	return 0;
+                cu_info->flags = CU_CTX_SHARED;
 }
 
 static int xocl_add_context(struct xocl_dev *xdev, struct kds_client *client,
@@ -195,6 +185,7 @@ static int xocl_add_context(struct xocl_dev *xdev, struct kds_client *client,
 {
 	xuid_t *uuid;
 	struct kds_client_cu_ctx *cu_ctx = NULL;
+	struct kds_client_cu_info cu_info = { 0 };
 	int ret;
 
 	mutex_lock(&client->lock);
@@ -227,14 +218,13 @@ static int xocl_add_context(struct xocl_dev *xdev, struct kds_client *client,
 	/* Bitstream is locked. No one could load a new one
 	 * until this client close all of the contexts.
 	 */
+	xocl_ctx_to_info(args, &cu_info);
 	/* Get a free CU context for the given CU index */
-	cu_ctx = kds_alloc_cu_ctx(client, client->ctx, args->cu_index);
+	cu_ctx = kds_alloc_cu_ctx(client, client->ctx, &cu_info);
 	if (!cu_ctx) {
 		ret = -EINVAL;
 		goto out1;
 	}
-	/* Initialize this cu context with required iniformation */
-	xocl_initialize_cu_ctx(client, args, cu_ctx);
 	 
 	ret = kds_add_context(&XDEV(xdev)->kds, client, cu_ctx);
 	if (ret)
@@ -256,6 +246,7 @@ static int xocl_del_context(struct xocl_dev *xdev, struct kds_client *client,
 			    struct drm_xocl_ctx *args)
 {
 	struct kds_client_cu_ctx *cu_ctx = NULL;
+	struct kds_client_cu_info cu_info = { 0 };
 	xuid_t *uuid;
 	int ret = 0;
 
@@ -277,7 +268,8 @@ static int xocl_del_context(struct xocl_dev *xdev, struct kds_client *client,
 		goto out;
 	}
 
-	cu_ctx = kds_get_cu_ctx(client, client->ctx, args->cu_index);
+	xocl_ctx_to_info(args, &cu_info);
+	cu_ctx = kds_get_cu_ctx(client, client->ctx, &cu_info);
         if (!cu_ctx) {
 		userpf_err(xdev, "No CU context is open");
 		ret = -EINVAL;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -237,7 +237,8 @@ static int xocl_add_context(struct xocl_dev *xdev, struct kds_client *client,
 	xocl_initialize_cu_ctx(client, args, cu_ctx);
 	 
 	ret = kds_add_context(&XDEV(xdev)->kds, client, cu_ctx);
-
+	if (ret)
+		kds_free_cu_ctx(client, cu_ctx);
 out1:
 	/* If client still has no opened context at this point */
 	if (!client->ctx) {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -229,6 +229,7 @@ static int xocl_add_context(struct xocl_dev *xdev, struct kds_client *client,
 	ret = kds_add_context(&XDEV(xdev)->kds, client, cu_ctx);
 	if (ret)
 		kds_free_cu_ctx(client, cu_ctx);
+
 out1:
 	/* If client still has no opened context at this point */
 	if (!client->ctx) {


### PR DESCRIPTION
We have introduced a kds cu context logic in XRT driver code. 
Now each context is having a lists of  CU contexts.
Each CU context refer to a CU index. 

`struct kds_client_cu_ctx {
  struct kds_client_ctx           *ctx;
  u32                             cu_idx;
  u32                             cu_domain;
  u32                             flags;
  u32                             ref_cnt;
  struct list_head                link;
};
` 

For further details:
https://confluence.xilinx.com/display/SPEC/Driver+DS+for+hw_context+implementation

https://amdcloud-my.sharepoint.com/:p:/g/personal/minm_amd_com/Ec57L2Ms3RlPibWhQmaIl-oBwnYkerg8FbLPepPl7GpoQw?e=4%3AZMA6xq&at=9&CID=642DCCB6-6A30-4783-AC46-3E8CCF5A3855&wdLOR=cCFC7C916-D4A1-4E0E-82B0-B82E100F6780

Basic validation test of both ZOCL and XOCL is working fine. 
