### PR TITLE
fix extra_cu_mask related issues

### DIFF
--- a/src/runtime_src/core/common/drv/xgq_execbuf.c
+++ b/src/runtime_src/core/common/drv/xgq_execbuf.c
@@ -23,6 +23,12 @@ int xgq_exec_convert_start_cu_cmd(struct xgq_cmd_start_cuidx *xgq_cmd,
 	int num_mask = 0;
 	int payload_size = 0;
 
+	/*
+	 * Based on ert.h, ecmd->count is the number of words following header.
+	 * In ert_start_kernel_cmd, the CU register map size is
+	 * (count - (1 + extra_cu_masks)) and I would like to Skip
+	 * first 4 control registers
+	 */
 	num_mask = 1 + ecmd->extra_cu_masks;
 	payload_size = (ecmd->count - num_mask - 4) * sizeof(u32);
 	memcpy(xgq_cmd->data, &ecmd->data[4 + ecmd->extra_cu_masks], payload_size);
@@ -44,7 +50,7 @@ int xgq_exec_convert_start_scu_cmd(struct xgq_cmd_start_cuidx *xgq_cmd,
 
 	num_mask = 1 + ecmd->extra_cu_masks;
 	payload_size = (ecmd->count - num_mask) * sizeof(u32);
-	memcpy(xgq_cmd->data, &ecmd->data[0], payload_size);
+	memcpy(xgq_cmd->data, &ecmd->data[ecmd->extra_cu_masks], payload_size);
 
 	xgq_cmd->hdr.opcode = XGQ_CMD_OP_START_CUIDX;
 	xgq_cmd->hdr.state = 1;

--- a/src/runtime_src/core/edge/drm/zocl/cu_scu.c
+++ b/src/runtime_src/core/edge/drm/zocl/cu_scu.c
@@ -98,6 +98,14 @@ static int scu_configure(void *core, u32 *data, size_t sz, int type)
 
 	num_reg = sz / sizeof(u32);
 	hdr = (struct xgq_cmd_sq_hdr *)data;
+#if 0
+	{
+		int i;
+		for (i = 0; i < hdr->count/sizeof(u32); i++) {
+			printk("DEBUG %s scu data(%d) 0x%x\n", __func__, i, data[i]);
+		}
+	}
+#endif
 	scu_xgq_start(scu, data);
 	return 0;
 }

--- a/src/runtime_src/core/edge/drm/zocl/zocl_xgq.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_xgq.c
@@ -133,6 +133,14 @@ static int zxgq_fetch_request(struct zocl_xgq *zxgq, struct xgq_cmd_sq_hdr **cmd
 		zxgq_err(zxgq, "Payload size %dB is too big, truncated!", (*cmd)->count);
 	}
 	cpy_fromio(buf + header_sz, cmd_addr + header_sz, cnt);
+#if 0
+	{
+		int i;
+		printk("DEBUG: %s received a command\n", __func__);
+		for (i = 0; i < cnt/sizeof(u32); i++)
+			printk("DEBUG: %s cmd data(%d) 0x%x\n", __func__, i, ((u32 *)buf)[i]);
+	}
+#endif
 
 	xgq_notify_peer_consumed(xgq);
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -591,7 +591,7 @@ static int xocl_fill_payload_xgq(struct xocl_dev *xdev, struct kds_command *xcmd
 		xcmd->type = KDS_SCU;
 		xcmd->opcode = OP_START_SK;
 		xcmd->cu_mask[0] = kecmd->cu_mask;
-		memcpy(&xcmd->cu_mask[1], kecmd->data, kecmd->extra_cu_masks);
+		memcpy(&xcmd->cu_mask[1], kecmd->data, kecmd->extra_cu_masks * sizeof(u32));
 		xcmd->num_mask = 1 + kecmd->extra_cu_masks;
 		xcmd->isize = xgq_exec_convert_start_scu_cmd(xcmd->info, kecmd);
 		ret = 1; /* hack */
@@ -601,7 +601,7 @@ static int xocl_fill_payload_xgq(struct xocl_dev *xdev, struct kds_command *xcmd
 		xcmd->type = KDS_CU;
 		xcmd->opcode = OP_START;
 		xcmd->cu_mask[0] = kecmd->cu_mask;
-		memcpy(&xcmd->cu_mask[1], kecmd->data, kecmd->extra_cu_masks);
+		memcpy(&xcmd->cu_mask[1], kecmd->data, kecmd->extra_cu_masks * sizeof(u32));
 		xcmd->num_mask = 1 + kecmd->extra_cu_masks;
 		xcmd->isize = xgq_exec_convert_start_cu_cmd(xcmd->info, kecmd);
 		ret = 1; /* hack */
@@ -639,7 +639,7 @@ static int xocl_fill_payload_xgq(struct xocl_dev *xdev, struct kds_command *xcmd
 		xcmd->type = KDS_CU;
 		xcmd->opcode = OP_START;
 		xcmd->cu_mask[0] = kecmd->cu_mask;
-		memcpy(&xcmd->cu_mask[1], kecmd->data, kecmd->extra_cu_masks);
+		memcpy(&xcmd->cu_mask[1], kecmd->data, kecmd->extra_cu_masks * sizeof(u32));
 		xcmd->num_mask = 1 + kecmd->extra_cu_masks;
 		xcmd->isize = xgq_exec_convert_start_kv_cu_cmd(xcmd->info, kecmd);
 		ret = 1;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
A 33 PS kernel test case failed.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
#6361 introduce this bug. This is discovered by a test case with more than 32 PS kernel.

#### How problem was solved, alternative solutions (if any) and why they were rejected
When convert a execbuf to a XGQ command, it should skip extra_cu_mask.

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
versal vck5000

#### Documentation impact (if any)
No