### PR TITLE
Add accessor for type of xrt::xclbin::ip

### DIFF
--- a/src/runtime_src/core/common/api/xrt_xclbin.cpp
+++ b/src/runtime_src/core/common/api/xrt_xclbin.cpp
@@ -263,6 +263,12 @@ public:
     return m_args[argidx];
   }
 
+  xrt::xclbin::ip::ip_type
+  get_type() const
+  {
+    return static_cast<xrt::xclbin::ip::ip_type>(m_ip->m_type);
+  }
+
   xrt::xclbin::ip::control_type
   get_control_type() const
   {
@@ -1058,6 +1064,15 @@ xclbin::ip::
 get_name() const
 {
   return handle ? reinterpret_cast<const char*>(handle->m_ip->m_name) : "";
+}
+
+xclbin::ip::ip_type
+xclbin::ip::
+get_type() const
+{
+  return handle
+    ? handle->get_type()
+    : static_cast<xclbin::ip::ip_type>(std::numeric_limits<uint8_t>::max());
 }
 
 xclbin::ip::control_type

--- a/src/runtime_src/core/include/experimental/xrt_xclbin.h
+++ b/src/runtime_src/core/include/experimental/xrt_xclbin.h
@@ -311,6 +311,14 @@ public:
      */
     enum class control_type : uint8_t { hs = 0, chain = 1, none = 2, fa = 5 };
 
+    /**
+     * @enum ip_type
+     *
+     * @details
+     * See `xclbin.h`
+     */
+    enum class ip_type : uint8_t { pl = IP_KERNEL, ps = IP_PS_KERNEL };
+
   public:
     ip() = default;
 
@@ -328,6 +336,16 @@ public:
     XCL_DRIVER_DLLESPEC
     std::string
     get_name() const;
+
+    /**
+     * get_type() - Get the IP type
+     *
+     * @return
+     *  IP type
+     */
+    XCL_DRIVER_DLLESPEC
+    ip_type
+    get_type() const;
 
     /**
      * get_control_type() - Get the IP control protocol

--- a/tests/xrt/56_xclbin/main.cpp
+++ b/tests/xrt/56_xclbin/main.cpp
@@ -69,10 +69,29 @@ operator << (std::ostream& ostr, const xrt::xclbin::arg& arg)
 }
 
 std::ostream&
+operator << (std::ostream& ostr, xrt::xclbin::ip::ip_type ip_type)
+{
+  switch (ip_type) {
+  case xrt::xclbin::ip::ip_type::pl :
+    ostr << "pl";
+    return ostr;
+  case xrt::xclbin::ip::ip_type::ps :
+    ostr << "ps";
+    return ostr;
+  default:
+    ostr << "not defined";
+    return ostr;
+  }
+
+  return ostr;
+}
+
+std::ostream&
 operator << (std::ostream& ostr, const xrt::xclbin::ip& cu)
 {
-  ostr << "instance name:    " << cu.get_name() << "\n";
-  ostr << "base address:     0x" << std::hex << cu.get_base_address() << std::dec << "\n";
+  ostr << "instance name:  " << cu.get_name() << "\n";
+  ostr << "base address:   0x" << std::hex << cu.get_base_address() << std::dec << "\n";
+  ostr << "cu type:        " << cu.get_type() << "\n";
 
   // ip arguments
   for (const auto& arg : cu.get_args())


### PR DESCRIPTION
#### Problem solved by the commit
Add accessor for type of xrt::xclbin::ip

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Per need.  

#### How problem was solved, alternative solutions (if any) and why they were rejected
Define only types that make sense for compute units.  All
types (even undefined in class enum) are comparable with static_cast
to int and correspond to IP_TYPE from xclbin.h

#### Risks (if any) associated the changes in the commit
None, new API.

#### What has been tested and how, request additional testing if necessary
Low level test part of this pull request

