### PR TITLE
Fix exception thrown when '/dev/dri/by-path' doesnot exist on edge platforms

### DIFF
--- a/src/runtime_src/core/edge/user/zynq_dev.cpp
+++ b/src/runtime_src/core/edge/user/zynq_dev.cpp
@@ -176,7 +176,7 @@ get_render_devname()
 	    break;
 	}
     }
-    catch (exception &e) {
+    catch (std::exception &e) {
         render_devname = "renderD128";
     }
 

--- a/src/runtime_src/core/edge/user/zynq_dev.cpp
+++ b/src/runtime_src/core/edge/user/zynq_dev.cpp
@@ -162,17 +162,22 @@ get_render_devname()
 
     // On Edge platforms 'zyxclmm_drm' is the name of zocl node in device tree
     // A symlink to render device is created based on this node name
-    static const std::regex filter{"platform.*zyxclmm_drm-render"};
+    try {
+        static const std::regex filter{"platform.*zyxclmm_drm-render"};
 
-    boost::filesystem::directory_iterator end_itr;
-    for( boost::filesystem::directory_iterator itr( render_dev_sym_dir ); itr != end_itr; ++itr) {
-        if (!std::regex_match(itr->path().filename().string(), filter))
-	    continue;
+        boost::filesystem::directory_iterator end_itr;
+        for( boost::filesystem::directory_iterator itr( render_dev_sym_dir ); itr != end_itr; ++itr) {
+            if (!std::regex_match(itr->path().filename().string(), filter))
+	        continue;
 
-	if (boost::filesystem::is_symlink(itr->path()))
-	    render_devname = boost::filesystem::read_symlink(itr->path()).filename().string();
+	    if (boost::filesystem::is_symlink(itr->path()))
+	        render_devname = boost::filesystem::read_symlink(itr->path()).filename().string();
 
-	break;
+	    break;
+	}
+    }
+    catch (exception &e) {
+        render_devname = "renderD128";
     }
 
     if (render_devname.empty())

--- a/src/runtime_src/core/edge/user/zynq_dev.cpp
+++ b/src/runtime_src/core/edge/user/zynq_dev.cpp
@@ -166,7 +166,7 @@ get_render_devname()
         static const std::regex filter{"platform.*zyxclmm_drm-render"};
 
         boost::filesystem::directory_iterator end_itr;
-        for( boost::filesystem::directory_iterator itr( render_dev_sym_dir ); itr != end_itr; ++itr) {
+        for (boost::filesystem::directory_iterator itr( render_dev_sym_dir ); itr != end_itr; ++itr) {
             if (!std::regex_match(itr->path().filename().string(), filter))
 	        continue;
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
On Edge platforms when /dev/dri/by-path does not exist exception is thrown, fixed that issue.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
PR - https://github.com/Xilinx/XRT/pull/6413 introduced this bug

#### How problem was solved, alternative solutions (if any) and why they were rejected
Fixed it by catching exception and adding default path renderD128 when exception is thrown

#### Risks (if any) associated the changes in the commit
none

#### What has been tested and how, request additional testing if necessary
tested on versal device.

#### Documentation impact (if any)
NA