### PR TITLE
CR 1135678 Optimized the access to the ddr via noc using mmap files

### DIFF
--- a/src/runtime_src/core/pcie/emulation/common_em/config.cxx
+++ b/src/runtime_src/core/pcie/emulation/common_em/config.cxx
@@ -74,16 +74,17 @@ namespace xclemulation{
     mPrintErrorsInConsole = true;
     mVerbosity = 0;
     mServerPort = 0;
-    mKeepRunDir=true;
+    mKeepRunDir = true;
     mLauncherArgs = "";
     mSystemDPA = true;
     mLegacyErt = ertmode::none;
-    mCuBaseAddrForce=-1;
-    mIsSharedFmodel=true;
+    mCuBaseAddrForce = -1;
+    mIsSharedFmodel = true;
     mIsM2MEnabled = false;
-    mTimeOutScale=TIMEOUT_SCALE::NA;
+    mTimeOutScale = TIMEOUT_SCALE::NA;
     mIsPlatformDataAvailable = false;
-    mIsDisabledHostBuffer=false;
+    mIsDisabledHostBuffer = false;
+    mIsFasterNocDDRAccessEnabled = false;
   }
 
   static bool getBoolValue(std::string& value,bool defaultValue)
@@ -236,6 +237,10 @@ namespace xclemulation{
         unsigned int verbosity = strtoll(value.c_str(),NULL,0);
         if(verbosity > 0 )
           setVerbosityLevel(verbosity);
+      }
+      else if(name == "fast_nocddr_access")
+      {
+        mIsFasterNocDDRAccessEnabled = getBoolValue(value, false);
       }
       else if(name == "packet_size")
       {

--- a/src/runtime_src/core/pcie/emulation/common_em/config.h
+++ b/src/runtime_src/core/pcie/emulation/common_em/config.h
@@ -318,6 +318,7 @@ struct sParseLog
       inline void setIsPlatformEnabled(bool isPlatformDataAvailable) {mIsPlatformDataAvailable = isPlatformDataAvailable; }
       inline bool getIsPlatformEnabled() { return mIsPlatformDataAvailable;}
       inline bool isDisabledHostBUffer() { return mIsDisabledHostBuffer;}
+      inline bool isFastNocDDRAccessEnabled() { return mIsFasterNocDDRAccessEnabled;}
       void populateEnvironmentSetup(std::map<std::string,std::string>& mEnvironmentNameValueMap);
 
     private:
@@ -354,6 +355,7 @@ struct sParseLog
       bool mIsM2MEnabled;
       bool mIsPlatformDataAvailable;
       bool mIsDisabledHostBuffer;
+      bool mIsFasterNocDDRAccessEnabled;
       TIMEOUT_SCALE mTimeOutScale;
       config();
       ~config() { };//empty destructor

--- a/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/nocddr_fastaccess_hwemu.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/nocddr_fastaccess_hwemu.cxx
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2016-2022 Xilinx, Inc. All rights reserved.
+// Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+
+#include "nocddr_fastaccess_hwemu.h"
+#include <stdio.h>
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <sys/mman.h>
+#include <sstream>
+#include <tuple>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/types.h>
+
+nocddr_fastaccess_hwemu::nocddr_fastaccess_hwemu()
+{
+  // TODO Auto-generated constructor stub
+}
+
+bool nocddr_fastaccess_hwemu::isAddressMapped(uint64_t addr,
+                                              size_t size)
+{
+  std::cerr << __func__ << " PRASAD " << __LINE__ << " addr: " << addr << " size: " << size << std::endl;
+  for (auto itr = mDDRMap.begin(); itr < mDDRMap.end(); itr++)
+  {
+    uint64_t addrI = std::get<0>(*itr);
+    uint64_t sizeI = std::get<1>(*itr);
+    std::cerr << __func__ << " PRASAD " << __LINE__ << " addrI: " << addrI << " sizeI: " << sizeI << std::endl;
+    if (addr >= addrI && (addr + size) <= (addrI + sizeI))
+    {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool nocddr_fastaccess_hwemu::read(uint64_t addr, unsigned char *dest,
+                                   size_t size)
+{
+  for (auto itr = mDDRMap.begin(); itr < mDDRMap.end(); itr++)
+  {
+    uint64_t addrI = std::get<0>(*itr);
+    uint64_t sizeI = std::get<1>(*itr);
+    unsigned char *ptrI = std::get<2>(*itr);
+    if (addr >= addrI && (addr + size) <= (addrI + sizeI))
+    {
+      uint64_t offset = addr - addrI;
+      ptrI = ptrI + offset;
+      memcpy((void *)dest, (const void *)ptrI, (unsigned long int)size);
+      return true;
+    }
+  }
+  return false;
+}
+
+bool nocddr_fastaccess_hwemu::write(uint64_t addr, unsigned char *src,
+                                    size_t size)
+{
+  for (auto itr = mDDRMap.begin(); itr < mDDRMap.end(); itr++)
+  {
+    uint64_t addrI = std::get<0>(*itr);
+    uint64_t sizeI = std::get<1>(*itr);
+    unsigned char *ptrI = std::get<2>(*itr);
+    if (addr >= addrI && (addr + size) <= (addrI + sizeI))
+    {
+      uint64_t offset = addr - addrI;
+      ptrI = ptrI + offset;
+      memcpy((void *)ptrI, (const void *)src, (unsigned long int)size);
+      return true;
+    }
+  }
+  return false;
+}
+
+bool nocddr_fastaccess_hwemu::init(std::string filename, std::string simdir)
+{
+  simdirPath = simdir;
+  std::ifstream mapFile(filename.c_str());
+  if (!mapFile.good() || !mapFile.is_open())
+  {
+    return false;
+  }
+  //Open the file and parse it
+  std::string line;
+
+  while (std::getline(mapFile, line))
+  {
+    std::cout << "LINE " << line << std::endl;
+    std::stringstream ss(line);
+    std::string fname;
+    std::string foffset_str;
+    std::string fsize_str;
+    std::getline(ss, fname, ',');
+    std::getline(ss, foffset_str, ',');
+    std::getline(ss, fsize_str, ',');
+    uint64_t foffset = 0;
+    uint64_t fsize = 0;
+    std::stringstream ss1(foffset_str);
+    std::stringstream ss2(fsize_str);
+    ss1 >> foffset;
+    ss2 >> fsize;
+    fname = simdir + "/" + fname;
+    std::cerr << "Creating fname=" << fname << std::hex << ", offset=0x" << foffset << ", size=0x" << fsize << std::endl;
+    //mmap the file create a tuple and add to the array
+    int fd = open(fname.c_str(), (O_CREAT | O_RDWR), 0666);
+    int rf = ftruncate(fd, fsize);
+    if (rf == -1)
+    {
+      return false;
+    }
+    unsigned char *memP = (unsigned char *)mmap(NULL, fsize, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_SHARED, fd, 0);
+    if (memP != NULL)
+    {
+      std::tuple<unsigned long long, size_t, unsigned char *> t(foffset, fsize, memP);
+      mDDRMap.push_back(t);
+    }
+    else
+    {
+      close(fd);
+    }
+  }
+  mapFile.close();
+  return true;
+}
+
+nocddr_fastaccess_hwemu::~nocddr_fastaccess_hwemu()
+{
+  for (auto itr = mDDRMap.begin(); itr < mDDRMap.end(); itr++)
+  {
+    uint64_t size = std::get<1>(*itr);
+    unsigned char *ptr = std::get<2>(*itr);
+    munmap((void *)ptr, size);
+    close(mFdMap[std::get<0>(*itr)]);
+  }
+  mDDRMap.clear();
+  mFdMap.clear();
+}

--- a/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/nocddr_fastaccess_hwemu.h
+++ b/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/nocddr_fastaccess_hwemu.h
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2016-2022 Xilinx, Inc. All rights reserved.
+// Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+
+#ifndef _NOCDDR_FASTACCESS_HWEMU_H_
+#define _NOCDDR_FASTACCESS_HWEMU_H_
+
+#include <string>
+#include <vector>
+#include <cstdint>
+#include <map>
+class nocddr_fastaccess_hwemu
+{
+public:
+  nocddr_fastaccess_hwemu();
+  bool init(std::string filename, std::string simdir);
+  bool isAddressMapped(uint64_t addr, size_t size);
+  bool read(uint64_t addr, unsigned char *dest, size_t size);
+  bool write(uint64_t addr, unsigned char *src, size_t size);
+  virtual ~nocddr_fastaccess_hwemu();
+
+private:
+  std::vector<std::tuple<unsigned long long, size_t, unsigned char *>> mDDRMap;
+  std::map<unsigned long long, int> mFdMap;
+  std::string simdirPath;
+};
+
+#endif /* _NOCDDR_FASTACCESS_HWEMU_H_ */

--- a/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.h
+++ b/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.h
@@ -29,6 +29,7 @@
 #include "xcl_api_macros.h"
 #include "xcl_macros.h"
 #include "unix_socket.h"
+#include "nocddr_fastaccess_hwemu.h"
 
 #endif
 
@@ -220,6 +221,7 @@ using addr_type = uint64_t;
       void fillDeviceInfo(xclDeviceInfo2* dest, xclDeviceInfo2* src);
       void saveWaveDataBase();
       void extractEmuData(const std::string& simPath, int binaryCounter, bitStreamArg args);
+      void nocMmapInitialization(const std::string &simPath);
 
       // Sanity checks
       static HwEmShim *handleCheck(void *handle);
@@ -419,6 +421,7 @@ using addr_type = uint64_t;
       std::map<uint64_t, std::pair<void*, uint64_t> > mHostOnlyMemMap;
       unsigned int host_sptag_idx;
       bool mSimDontRun;
+      nocddr_fastaccess_hwemu mNocFastAccess;
   };
 
   extern std::map<unsigned int, HwEmShim*> devices;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
Reading the large amounts of date from host to device is taking long time. Bypassed the TLM transaction and writing to the noc mmap file created directly from the host memory. This reduced the simulation time from hours to mins 

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
This is not a bug, this is a enhancement request.

#### How problem was solved, alternative solutions (if any) and why they were rejected
This is the best solution to transfer the data from the host mem to noc accessible ddr in fast manner

#### Risks (if any) associated the changes in the commit
No, currently this change is under ENV control

#### What has been tested and how, request additional testing if necessary
Ran the impactful design and performance is as expected. Canary is clean with this change.

#### Documentation impact (if any)
nope
