### PR TITLE
CR-1136383: Incorrect error message when enabling device level profiling

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info_database.h
+++ b/src/runtime_src/xdp/profile/database/static_info_database.h
@@ -152,8 +152,12 @@ namespace xdp {
     XDP_EXPORT void setAieApplication() ;
 
     // Due to changes in hardware IP, we can only support profiling on
-    //  xclbins built using 2019.2 or later tools.
-    inline double earliestSupportedToolVersion() const { return 2019.2 ; }
+    // xclbins built using 2019.2 or later tools.  Each xclbin is stamped
+    // with the corresponding XRT version as well, and for 2019.2 tools
+    // the XRT version was 2.5.459
+    constexpr double   earliestSupportedToolVersion() const { return 2019.2; }
+    constexpr uint16_t earliestSupportedXRTVersionMajor() const { return 2; }
+    constexpr uint16_t earliestSupportedXRTVersionMinor() const { return 5; }
     XDP_EXPORT bool validXclbin(void* devHandle) ;
 
     // ****************************************************


### PR DESCRIPTION
#### Problem solved by the commit
In order for the profiling library to communicate correctly with the profiling IP in the PL, the profiling library must verify that the xclbin was built with a recent tool version.  When device level profiling is turned on, some xclbins built with recent tools were incorrectly reporting that they needed to be rebuilt in order to enable device level profiling.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
The bug was discovered by running applications that loaded xclbins that did not have the optional BUILD_METADATA section with the xrt.ini switch "device_trace=fine" set.  Even though the xclbin did not contain any profiling IP and was built with the most recent version of the tools, the error message was being output because the BUILD_METADATA section was missing.

#### How problem was solved, alternative solutions (if any) and why they were rejected
The function that checks if an xclbin is valid for device level profiling has changed its implementation to use the major and minor number in the header of the axlf instead of looking into the BUILD_METADATA section.

#### What has been tested and how, request additional testing if necessary
Tested on a recent xclbin and an xclbin built using 2019.1 tools.

#### Documentation impact (if any)
No documentation impact.