### PR TITLE
CR-1136573 ASTeR TC 00.01 - vck5000 - null pointer dereference causin…

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-sysfs.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-sysfs.c
@@ -347,6 +347,9 @@ static ssize_t interface_uuids_show(struct device *dev,
 	const void *uuid;
 	int node = -1, off = 0;
 
+	if (!lro->ready)
+		return -EINVAL;
+
 	if (!lro->core.fdt_blob && xocl_get_timestamp(lro) == 0)
 		xclmgmt_load_fdt(lro);
 
@@ -378,6 +381,9 @@ static ssize_t logic_uuids_show(struct device *dev,
         struct xclmgmt_dev *lro = dev_get_drvdata(dev);
 	const void *uuid = NULL, *blp_uuid = NULL;
 	int node = -1, off = 0;
+
+	if (!lro->ready)
+		return -EINVAL;
 
 	if (!lro->core.fdt_blob && xocl_get_timestamp(lro) == 0)
 		xclmgmt_load_fdt(lro);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-utils.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-utils.c
@@ -703,6 +703,12 @@ int xclmgmt_program_shell(struct xclmgmt_dev *lro)
 	char *blob = NULL;
 	int len;
 
+	if (!lro->ready) {
+		mgmt_warn(lro, "not ready yet");
+		ret = -EINVAL;
+		goto failed;
+	}
+
 	if (!lro->core.fdt_blob && xocl_get_timestamp(lro) == 0)
 		xclmgmt_load_fdt(lro);
 


### PR DESCRIPTION
…g crash

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

xbmgmt examine can access sysfs node before driver probe finish and set the ready to true.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1136573

#### How problem was solved, alternative solutions (if any) and why they were rejected
avoid accessing driver data before lro->ready is true

#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
tested with 2 threads, 1 thread attach the driver, 1 thread run xbmgmt exmaine
without the fix, system panic
with the fix, no panic anymore

#### Documentation impact (if any)
N/A