### PR TITLE
CR-1136686 & CR-1135803 & CR-1136789

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/cu.c
+++ b/src/runtime_src/core/edge/drm/zocl/cu.c
@@ -283,12 +283,13 @@ static int cu_probe(struct platform_device *pdev)
 
 	if (info->intr_enable) {
 		intc = zocl_find_pdev(ERT_CU_INTC_DEV_NAME);
-		if (!intc) {
+		if (intc)
+			err = zocl_ert_intc_add(intc, info->intr_id, cu_isr, zcu);
+		if (!intc || err) {
 			DRM_WARN("Failed to initial CU interrupt. "
 				 "Fall back to polling\n");
 			zcu->base.info.intr_enable = 0;
-		} else
-			zocl_ert_intc_add(intc, info->intr_id, cu_isr, zcu);
+		}
 	}
 
 	switch (info->model) {

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_ert_intc.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_ert_intc.h
@@ -45,7 +45,7 @@ struct zocl_ert_intc_handler {
 };
 
 struct zocl_ert_intc_drv_data {
-	void (*add)(struct platform_device *pdev, u32 id, irq_handler_t handler, void *arg);
+	int (*add)(struct platform_device *pdev, u32 id, irq_handler_t handler, void *arg);
 	void (*remove)(struct platform_device *pdev, u32 id);
 	void (*config)(struct platform_device *pdev, u32 id, bool enabled);
 };
@@ -53,10 +53,10 @@ struct zocl_ert_intc_drv_data {
 #define	ERT_INTC_DRVDATA(pdev)	\
 	((struct zocl_ert_intc_drv_data *)platform_get_device_id(pdev)->driver_data)
 
-static inline void
+static inline int
 zocl_ert_intc_add(struct platform_device *pdev, u32 id, irq_handler_t cb, void *arg)
 {
-	ERT_INTC_DRVDATA(pdev)->add(pdev, id, cb, arg);
+	return ERT_INTC_DRVDATA(pdev)->add(pdev, id, cb, arg);
 }
 
 static inline void

--- a/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
@@ -1069,10 +1069,13 @@ static int zocl_drm_platform_probe(struct platform_device *pdev)
 		zdev->cu_subdev.irq[index] = irq;
 	}
 	zdev->cu_subdev.cu_num = index;
-	ret = zocl_ert_create_intc(&pdev->dev, zdev->cu_subdev.irq, index, 0,
-				   ERT_CU_INTC_DEV_NAME, &zdev->cu_intc);
-	if (ret)
-		DRM_ERROR("Failed to create cu intc device, ret %d\n", ret);
+	if (zdev->cu_subdev.cu_num) {
+		ret = zocl_ert_create_intc(&pdev->dev, zdev->cu_subdev.irq,
+					   zdev->cu_subdev.cu_num, 0,
+					   ERT_CU_INTC_DEV_NAME, &zdev->cu_intc);
+		if (ret)
+			DRM_ERROR("Failed to create cu intc device, ret %d\n", ret);
+	}
 
 	/* set to 0xFFFFFFFF(32bit) or 0xFFFFFFFFFFFFFFFF(64bit) */
 	zdev->host_mem = (phys_addr_t) -1;

--- a/src/runtime_src/core/edge/drm/zocl/zocl_xgq.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_xgq.c
@@ -351,7 +351,7 @@ void *zxgq_init(struct zocl_xgq_init_args *arg)
 	zxgq_start_worker(zxgq);
 
 	if (ZXGQ_IS_INTR_ENABLED(zxgq)) {
-		zocl_ert_intc_add(zxgq->zx_intc_pdev, zxgq->zx_irq, zxgq_isr, zxgq);
+		BUG_ON(zocl_ert_intc_add(zxgq->zx_intc_pdev, zxgq->zx_irq, zxgq_isr, zxgq));
 	} else {
 		timer_setup(&zxgq->zx_timer, zxgq_timer, 0);
 		mod_timer(&zxgq->zx_timer, jiffies + ZXGQ_THREAD_TIMER);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
CR-1136686 & CR-1135803 & CR-1136789

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
#6862 introduced the bug. It is discovered by edge regression test

#### How problem was solved, alternative solutions (if any) and why they were rejected
For CR-1136789, don't create intc subdev when shell doesn't support interrupt.
For CR-1135803, fall back to polling mode when cannot setup interrupt in cu subdev. Like the old behavior.
For CR-1136686, sw_emu will crash when requst the 31th irq. Delay request irq.

It looks like the behavior change in #6862 expose other issues in CR-1135803 and CR-1136686. This PR make zocl still use old behavior with intc sub-device. All test cases passed.

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
Test case in CRs

#### Documentation impact (if any)
No.