### PR TITLE
CR-1134931 Addressed the intermittent hang issue when we have Graph C…

### DIFF
--- a/src/runtime_src/core/edge/common_em/rpc_messages.proto
+++ b/src/runtime_src/core/edge/common_em/rpc_messages.proto
@@ -498,7 +498,7 @@ message xclGraphEnd_call {
   required uint32 gh = 2;  
 }
 message xclGraphEnd_response {
-     required bool ack = 1;
+  required uint32 ack = 1;
 }
 
 //xclGraphUpdateRTP

--- a/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/shim.cxx
@@ -424,7 +424,7 @@ namespace xclcpuemhal2 {
 
   void CpuemShim::launchDeviceProcess(bool debuggable, std::string& binaryDirectory)
   {
-    std::lock_guard<std::mutex> lk(mProcessLaunchMtx);
+    std::lock_guard lk(mProcessLaunchMtx);
     systemUtil::makeSystemCall(deviceDirectory, systemUtil::systemOperation::CREATE);
     std::stringstream ss1;
     ss1<<deviceDirectory<<"/binary_"<<binaryCounter;
@@ -1323,7 +1323,7 @@ namespace xclcpuemhal2 {
 
   size_t CpuemShim::xclWrite(xclAddressSpace space, uint64_t offset, const void *hostBuf, size_t size)
   {
-    std::lock_guard<std::mutex> lk(mApiMtx);
+    std::lock_guard lk(mApiMtx);
     if (mLogStream.is_open()) {
       mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << offset<<", "<<hostBuf<<", "<< size<<std::endl;
     }
@@ -1351,7 +1351,7 @@ namespace xclcpuemhal2 {
 
   size_t CpuemShim::xclRead(xclAddressSpace space, uint64_t offset, void *hostBuf, size_t size)
   {
-    std::lock_guard<std::mutex> lk(mApiMtx);
+    std::lock_guard lk(mApiMtx);
     if (mLogStream.is_open()) {
       mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << space << ", "
         << offset << ", " << hostBuf << ", " << size << std::endl;
@@ -1553,7 +1553,7 @@ namespace xclcpuemhal2 {
 
   void CpuemShim::xclClose()
   {
-    std::lock_guard<std::mutex> lk(mApiMtx);
+    std::lock_guard lk(mApiMtx);
     if (mLogStream.is_open()) {
       mLogStream << __func__ << ", " << std::this_thread::get_id() << std::endl;
     }
@@ -1684,7 +1684,7 @@ inline unsigned long long CpuemShim::xocl_ddr_channel_size()
 
 int CpuemShim::xclGetBOProperties(unsigned int boHandle, xclBOProperties *properties)
 {
-  std::lock_guard<std::mutex> lk(mApiMtx);
+  std::lock_guard lk(mApiMtx);
   if (mLogStream.is_open())
   {
     mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << std::hex << boHandle << std::endl;
@@ -1744,7 +1744,7 @@ uint64_t CpuemShim::xoclCreateBo(xclemulation::xocl_create_bo* info)
 
 unsigned int CpuemShim::xclAllocBO(size_t size, int unused, unsigned flags)
 {
-  std::lock_guard<std::mutex> lk(mApiMtx);
+  std::lock_guard lk(mApiMtx);
   if (mLogStream.is_open())
   {
     mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << std::hex << size << std::dec << " , "<< unused <<" , "<< flags << std::endl;
@@ -1759,7 +1759,7 @@ unsigned int CpuemShim::xclAllocBO(size_t size, int unused, unsigned flags)
 /******************************** xclAllocUserPtrBO ************************************/
 unsigned int CpuemShim::xclAllocUserPtrBO(void *userptr, size_t size, unsigned flags)
 {
-  std::lock_guard<std::mutex> lk(mApiMtx);
+  std::lock_guard lk(mApiMtx);
   if (mLogStream.is_open())
   {
     mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << userptr <<", " << std::hex << size << std::dec <<" , "<< flags << std::endl;
@@ -1859,7 +1859,7 @@ unsigned int CpuemShim::xclImportBO(int boGlobalHandle, unsigned flags)
 /******************************** xclCopyBO *******************************************/
 int CpuemShim::xclCopyBO(unsigned int dst_boHandle, unsigned int src_boHandle, size_t size, size_t dst_offset, size_t src_offset)
 {
-  std::lock_guard<std::mutex> lk(mApiMtx);
+  std::lock_guard lk(mApiMtx);
   //TODO
   if (mLogStream.is_open())
   {
@@ -1902,7 +1902,7 @@ int CpuemShim::xclCopyBO(unsigned int dst_boHandle, unsigned int src_boHandle, s
 /******************************** xclMapBO *********************************************/
 void *CpuemShim::xclMapBO(unsigned int boHandle, bool write)
 {
-  std::lock_guard<std::mutex> lk(mApiMtx);
+  std::lock_guard lk(mApiMtx);
   if (mLogStream.is_open())
   {
     mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << std::hex << boHandle << " , " << write << std::endl;
@@ -1953,7 +1953,7 @@ void *CpuemShim::xclMapBO(unsigned int boHandle, bool write)
 
 int CpuemShim::xclUnmapBO(unsigned int boHandle, void* addr)
 {
-  std::lock_guard<std::mutex> lk(mApiMtx);
+  std::lock_guard lk(mApiMtx);
   auto bo = xclGetBoByHandle(boHandle);
   return bo ? munmap(addr,bo->size) : -1;
 }
@@ -1963,7 +1963,7 @@ int CpuemShim::xclUnmapBO(unsigned int boHandle, void* addr)
 /******************************** xclSyncBO *******************************************/
 int CpuemShim::xclSyncBO(unsigned int boHandle, xclBOSyncDirection dir, size_t size, size_t offset)
 {
-  std::lock_guard<std::mutex> lk(mApiMtx);
+  std::lock_guard lk(mApiMtx);
   if (mLogStream.is_open())
   {
     mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << std::hex << boHandle << " , " << std::endl;
@@ -1998,7 +1998,7 @@ int CpuemShim::xclSyncBO(unsigned int boHandle, xclBOSyncDirection dir, size_t s
 /******************************** xclFreeBO *******************************************/
 void CpuemShim::xclFreeBO(unsigned int boHandle)
 {
-  std::lock_guard<std::mutex> lk(mApiMtx);
+  std::lock_guard lk(mApiMtx);
   if (mLogStream.is_open())
   {
     mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << std::hex << boHandle << std::endl;
@@ -2022,7 +2022,7 @@ void CpuemShim::xclFreeBO(unsigned int boHandle)
 /******************************** xclWriteBO *******************************************/
 size_t CpuemShim::xclWriteBO(unsigned int boHandle, const void *src, size_t size, size_t seek)
 {
-  std::lock_guard<std::mutex> lk(mApiMtx);
+  std::lock_guard lk(mApiMtx);
   if (mLogStream.is_open())
   {
     mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << std::hex << boHandle << " , "<< src <<" , "<< size << ", " << seek << std::endl;
@@ -2045,7 +2045,7 @@ size_t CpuemShim::xclWriteBO(unsigned int boHandle, const void *src, size_t size
 /******************************** xclReadBO *******************************************/
 size_t CpuemShim::xclReadBO(unsigned int boHandle, void *dst, size_t size, size_t skip)
 {
-  std::lock_guard<std::mutex> lk(mApiMtx);
+  std::lock_guard lk(mApiMtx);
   if (mLogStream.is_open())
   {
     mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << std::hex << boHandle << " , "<< dst <<" , "<< size << ", " << skip << std::endl;
@@ -2196,7 +2196,7 @@ close_cu_context(const xrt::hw_context& hwctx, xrt_core::cuidx_type cuidx)
 */
 int CpuemShim::xrtGraphInit(void * gh) {
 
-  std::lock_guard<std::mutex> lk(mApiMtx);
+  std::lock_guard lk(mApiMtx);
   bool ack = false;
   auto ghPtr = (xclcpuemhal2::GraphType*)gh;
   if (!ghPtr)
@@ -2217,7 +2217,7 @@ int CpuemShim::xrtGraphInit(void * gh) {
 */
 int CpuemShim::xrtGraphRun(void * gh, uint32_t iterations) {
 
-  std::lock_guard<std::mutex> lk(mApiMtx);
+  std::lock_guard lk(mApiMtx);
   bool ack = false;
   auto ghPtr = (xclcpuemhal2::GraphType*)gh;
   if (!ghPtr)
@@ -2240,7 +2240,7 @@ int CpuemShim::xrtGraphRun(void * gh, uint32_t iterations) {
 */
 int CpuemShim::xrtGraphWait(void * gh) {
 
-  std::lock_guard<std::mutex> lk(mApiMtx);
+  std::lock_guard lk(mApiMtx);
   bool ack = false;
   auto ghPtr = (xclcpuemhal2::GraphType*)gh;
   if (!ghPtr)
@@ -2263,7 +2263,7 @@ int CpuemShim::xrtGraphWait(void * gh) {
 */
 int CpuemShim::xrtGraphTimedWait(void * gh, uint64_t cycle) {
 
-  std::lock_guard<std::mutex> lk(mApiMtx);
+  std::lock_guard lk(mApiMtx);
   bool ack = false;
   auto ghPtr = (xclcpuemhal2::GraphType*)gh;
   if (!ghPtr)
@@ -2302,11 +2302,17 @@ int CpuemShim::xrtGraphEnd(void * gh) {
     return -1;
 
   auto graphhandle = ghPtr->getGraphHandle();
+
+  // ack = 0 : defines RPC Call is completed with failure status
+  // ack = 1 : defines RPC Call is completed with success status
+  // ack = 2 : defines RPC Call is returned with running status.
+  // Recalling the RPC after a wait if the ack returned is 2.
   do
   {
-    mApiMtx.lock();
-    xclGraphEnd_RPC_CALL(xclGraphEnd, graphhandle);
-    mApiMtx.unlock();
+    {
+      std::lock_guard lk(mApiMtx);
+      xclGraphEnd_RPC_CALL(xclGraphEnd, graphhandle);
+    }
     std::this_thread::sleep_for(std::chrono::seconds(1));
   } while (ack == 2);
 
@@ -2334,7 +2340,7 @@ int CpuemShim::xrtGraphEnd(void * gh) {
 * forever or graph that has multi-rate core(s).
 */
 int CpuemShim::xrtGraphTimedEnd(void * gh , uint64_t cycle) {
-  std::lock_guard<std::mutex> lk(mApiMtx);
+  std::lock_guard lk(mApiMtx);
   bool ack = false;
   auto ghPtr = (xclcpuemhal2::GraphType*)gh;
   if (!ghPtr)
@@ -2355,7 +2361,7 @@ int CpuemShim::xrtGraphTimedEnd(void * gh , uint64_t cycle) {
 * Resume graph execution which was paused by suspend() or wait(cycles) APIs
 */
 int CpuemShim::xrtGraphResume(void * gh) {
-  std::lock_guard<std::mutex> lk(mApiMtx);
+  std::lock_guard lk(mApiMtx);
   bool ack = false;
   auto ghPtr = (xclcpuemhal2::GraphType*)gh;
   if (!ghPtr)
@@ -2381,7 +2387,7 @@ int CpuemShim::xrtGraphResume(void * gh) {
 * Return:          0 on success, -1 on error.
 */
 int CpuemShim::xrtGraphUpdateRTP(void * gh, const char *hierPathPort, const char *buffer, size_t size) {
-  std::lock_guard<std::mutex> lk(mApiMtx);
+  std::lock_guard lk(mApiMtx);
   auto ghPtr = (xclcpuemhal2::GraphType*)gh;
   if (!ghPtr)
     return -1;
@@ -2405,7 +2411,7 @@ int CpuemShim::xrtGraphUpdateRTP(void * gh, const char *hierPathPort, const char
 *       being copied to.
 */
 int CpuemShim::xrtGraphReadRTP(void * gh, const char *hierPathPort, char *buffer, size_t size) {
-  std::lock_guard<std::mutex> lk(mApiMtx);
+  std::lock_guard lk(mApiMtx);
   auto ghPtr = (xclcpuemhal2::GraphType*)gh;
   if (!ghPtr)
     return -1;

--- a/src/runtime_src/core/pcie/emulation/common_em/rpc_messages.proto
+++ b/src/runtime_src/core/pcie/emulation/common_em/rpc_messages.proto
@@ -513,7 +513,7 @@ message xclGraphEnd_call {
   required uint32 gh = 2;  
 }
 message xclGraphEnd_response {
-     required bool ack = 1;
+     required uint32 ack = 1;
 }
 
 //xclGraphUpdateRTP

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
@@ -323,7 +323,7 @@ namespace xclcpuemhal2
 
   void CpuemShim::launchDeviceProcess(bool debuggable, std::string &binaryDirectory)
   {
-    std::lock_guard<std::mutex> lk(mProcessLaunchMtx);
+    std::lock_guard lk(mProcessLaunchMtx);
     systemUtil::makeSystemCall(deviceDirectory, systemUtil::systemOperation::CREATE);
     std::stringstream ss1;
     ss1 << deviceDirectory << "/binary_" << binaryCounter;
@@ -937,7 +937,7 @@ namespace xclcpuemhal2
 
   size_t CpuemShim::xclWrite(xclAddressSpace space, uint64_t offset, const void *hostBuf, size_t size)
   {
-    std::lock_guard<std::mutex> lk(mApiMtx);
+    std::lock_guard lk(mApiMtx);
     if (mLogStream.is_open())
       mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << offset << ", " << hostBuf << ", " << size << std::endl;
 
@@ -1063,7 +1063,7 @@ namespace xclcpuemhal2
 
   size_t CpuemShim::xclRead(xclAddressSpace space, uint64_t offset, void *hostBuf, size_t size)
   {
-    std::lock_guard<std::mutex> lk(mApiMtx);
+    std::lock_guard lk(mApiMtx);
     if (mLogStream.is_open())
     {
       mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << space << ", "
@@ -1331,7 +1331,7 @@ namespace xclcpuemhal2
 
   void CpuemShim::xclClose()
   {
-    std::lock_guard<std::mutex> lk(mApiMtx);
+    std::lock_guard lk(mApiMtx);
     if (mLogStream.is_open())
       mLogStream << __func__ << ", " << std::this_thread::get_id() << std::endl;
 
@@ -1462,7 +1462,7 @@ namespace xclcpuemhal2
 
   int CpuemShim::xclGetBOProperties(unsigned int boHandle, xclBOProperties *properties)
   {
-    std::lock_guard<std::mutex> lk(mApiMtx);
+    std::lock_guard lk(mApiMtx);
     if (mLogStream.is_open())
     {
       mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << std::hex << boHandle << std::endl;
@@ -1534,7 +1534,7 @@ namespace xclcpuemhal2
 
   unsigned int CpuemShim::xclAllocBO(size_t size, int unused, unsigned flags)
   {
-    std::lock_guard<std::mutex> lk(mApiMtx);
+    std::lock_guard lk(mApiMtx);
     if (mLogStream.is_open())
     {
       mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << std::hex << size << std::dec << " , " << unused << " , " << flags << std::endl;
@@ -1549,7 +1549,7 @@ namespace xclcpuemhal2
   /******************************** xclAllocUserPtrBO ************************************/
   unsigned int CpuemShim::xclAllocUserPtrBO(void *userptr, size_t size, unsigned flags)
   {
-    std::lock_guard<std::mutex> lk(mApiMtx);
+    std::lock_guard lk(mApiMtx);
     if (mLogStream.is_open())
       mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << userptr << ", " << std::hex << size << std::dec << " , " << flags << std::endl;
 
@@ -1690,7 +1690,7 @@ namespace xclcpuemhal2
   /******************************** xclCopyBO *******************************************/
   int CpuemShim::xclCopyBO(unsigned int dst_boHandle, unsigned int src_boHandle, size_t size, size_t dst_offset, size_t src_offset)
   {
-    std::lock_guard<std::mutex> lk(mApiMtx);
+    std::lock_guard lk(mApiMtx);
     //TODO
     if (mLogStream.is_open())
     {
@@ -1825,7 +1825,7 @@ namespace xclcpuemhal2
   /******************************** xclMapBO *********************************************/
   void *CpuemShim::xclMapBO(unsigned int boHandle, bool write)
   {
-    std::lock_guard<std::mutex> lk(mApiMtx);
+    std::lock_guard lk(mApiMtx);
     if (mLogStream.is_open())
       mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << std::hex << boHandle << ", " << write << std::endl;
 
@@ -1910,7 +1910,7 @@ namespace xclcpuemhal2
 
   int CpuemShim::xclUnmapBO(unsigned int boHandle, void *addr)
   {
-    std::lock_guard<std::mutex> lk(mApiMtx);
+    std::lock_guard lk(mApiMtx);
     auto bo = xclGetBoByHandle(boHandle);
     return bo ? munmap(addr, bo->size) : -1;
   }
@@ -1920,7 +1920,7 @@ namespace xclcpuemhal2
   /******************************** xclSyncBO *******************************************/
   int CpuemShim::xclSyncBO(unsigned int boHandle, xclBOSyncDirection dir, size_t size, size_t offset)
   {
-    std::lock_guard<std::mutex> lk(mApiMtx);
+    std::lock_guard lk(mApiMtx);
     if (mLogStream.is_open())
       mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << std::hex << boHandle << " , " << std::endl;
 
@@ -1955,7 +1955,7 @@ namespace xclcpuemhal2
   /******************************** xclFreeBO *******************************************/
   void CpuemShim::xclFreeBO(unsigned int boHandle)
   {
-    std::lock_guard<std::mutex> lk(mApiMtx);
+    std::lock_guard lk(mApiMtx);
     if (mLogStream.is_open())
       mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << std::hex << boHandle << std::endl;
     auto it = mXoclObjMap.find(boHandle);
@@ -1978,7 +1978,7 @@ namespace xclcpuemhal2
   /******************************** xclWriteBO *******************************************/
   size_t CpuemShim::xclWriteBO(unsigned int boHandle, const void *src, size_t size, size_t seek)
   {
-    std::lock_guard<std::mutex> lk(mApiMtx);
+    std::lock_guard lk(mApiMtx);
     if (mLogStream.is_open())
       mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << std::hex << boHandle << " , " << src << " , " << size << ", " << seek << std::endl;
     xclemulation::drm_xocl_bo *bo = xclGetBoByHandle(boHandle);
@@ -1999,7 +1999,7 @@ namespace xclcpuemhal2
   /******************************** xclReadBO *******************************************/
   size_t CpuemShim::xclReadBO(unsigned int boHandle, void *dst, size_t size, size_t skip)
   {
-    std::lock_guard<std::mutex> lk(mApiMtx);
+    std::lock_guard lk(mApiMtx);
     if (mLogStream.is_open())
       mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << std::hex << boHandle << " , " << dst << " , " << size << ", " << skip << std::endl;
     xclemulation::drm_xocl_bo *bo = xclGetBoByHandle(boHandle);
@@ -2153,7 +2153,7 @@ namespace xclcpuemhal2
     if (mLogStream.is_open())
       mLogStream << __func__ << ", " << std::this_thread::get_id() << std::endl;
 
-    std::lock_guard<std::mutex> lk(mApiMtx);
+    std::lock_guard lk(mApiMtx);
     bool ack = false;
     auto ghPtr = (xclcpuemhal2::GraphType *)gh;
     if (!ghPtr)
@@ -2182,7 +2182,7 @@ namespace xclcpuemhal2
     if (mLogStream.is_open())
       mLogStream << __func__ << ", " << std::this_thread::get_id() << std::endl;
 
-    std::lock_guard<std::mutex> lk(mApiMtx);
+    std::lock_guard lk(mApiMtx);
     bool ack = false;
     auto ghPtr = (xclcpuemhal2::GraphType *)gh;
     if (!ghPtr)
@@ -2212,7 +2212,7 @@ namespace xclcpuemhal2
     if (mLogStream.is_open())
       mLogStream << __func__ << ", " << std::this_thread::get_id() << std::endl;
 
-    std::lock_guard<std::mutex> lk(mApiMtx);
+    std::lock_guard lk(mApiMtx);
     bool ack = false;
     auto ghPtr = (xclcpuemhal2::GraphType *)gh;
     if (!ghPtr)
@@ -2242,7 +2242,7 @@ namespace xclcpuemhal2
     if (mLogStream.is_open())
       mLogStream << __func__ << ", " << std::this_thread::get_id() << std::endl;
 
-    std::lock_guard<std::mutex> lk(mApiMtx);
+    std::lock_guard lk(mApiMtx);
     bool ack = false;
     auto ghPtr = (xclcpuemhal2::GraphType *)gh;
     if (!ghPtr)
@@ -2288,10 +2288,15 @@ namespace xclcpuemhal2
     DEBUG_MSGS("%s, %d()\n", __func__, __LINE__);
     auto graphhandle = ghPtr->getGraphHandle();
 
+    // ack = 0 : defines RPC Call is completed with failure status
+    // ack = 1 : defines RPC Call is completed with success status
+    // ack = 2 : defines RPC Call is returned with running status. 
+    // Recalling the RPC after a wait if the ack returned is 2.
     do {
-      mApiMtx.lock();
-      xclGraphEnd_RPC_CALL(xclGraphEnd, graphhandle);
-      mApiMtx.unlock();
+      {
+        std::lock_guard lk(mApiMtx);
+        xclGraphEnd_RPC_CALL(xclGraphEnd, graphhandle);
+      }
       std::this_thread::sleep_for(std::chrono::seconds(1));
     } while (ack == 2);
 
@@ -2325,7 +2330,7 @@ namespace xclcpuemhal2
     if (mLogStream.is_open())
       mLogStream << __func__ << ", " << std::this_thread::get_id() << std::endl;
 
-    std::lock_guard<std::mutex> lk(mApiMtx);
+    std::lock_guard lk(mApiMtx);
     bool ack = false;
     auto ghPtr = (xclcpuemhal2::GraphType *)gh;
     if (!ghPtr)
@@ -2354,7 +2359,7 @@ namespace xclcpuemhal2
     if (mLogStream.is_open())
       mLogStream << __func__ << ", " << std::this_thread::get_id() << std::endl;
 
-    std::lock_guard<std::mutex> lk(mApiMtx);
+    std::lock_guard lk(mApiMtx);
     bool ack = false;
     auto ghPtr = (xclcpuemhal2::GraphType *)gh;
     if (!ghPtr)
@@ -2388,7 +2393,7 @@ namespace xclcpuemhal2
     if (mLogStream.is_open())
       mLogStream << __func__ << ", " << std::this_thread::get_id() << std::endl;
 
-    std::lock_guard<std::mutex> lk(mApiMtx);
+    std::lock_guard lk(mApiMtx);
     auto ghPtr = (xclcpuemhal2::GraphType *)gh;
     if (!ghPtr)
       return -1;
@@ -2419,7 +2424,7 @@ namespace xclcpuemhal2
     if (mLogStream.is_open())
       mLogStream << __func__ << ", " << std::this_thread::get_id() << std::endl;
 
-    std::lock_guard<std::mutex> lk(mApiMtx);
+    std::lock_guard lk(mApiMtx);
     auto ghPtr = (xclcpuemhal2::GraphType *)gh;
     if (!ghPtr)
       return -1;
@@ -2452,7 +2457,7 @@ namespace xclcpuemhal2
     if (mLogStream.is_open())
       mLogStream << __func__ << ", " << std::this_thread::get_id() << std::endl;
 
-    std::lock_guard<std::mutex> lk(mApiMtx);
+    std::lock_guard lk(mApiMtx);
     bool ack = false;
     if (!gmioname)
       return -1;
@@ -2487,7 +2492,7 @@ namespace xclcpuemhal2
     if (mLogStream.is_open())
       mLogStream << __func__ << ", " << std::this_thread::get_id() << std::endl;
 
-    std::lock_guard<std::mutex> lk(mApiMtx);
+    std::lock_guard lk(mApiMtx);
     bool ack = false;
     if (!gmioname)
       return -1;


### PR DESCRIPTION
Addressed the intermittent hang issue when we have Graph Calls along with the sw_emu device control calls.

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
We used to get the hang in both the sw_emu x86sim and hybrid sw_emu designs. And the hang is very inconsistent. We observed the issue is with the mutex unlock when xclGraphEnd RPC call is issued to device process.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
ps_on_x86 is a new production feature for this release, and we have enabled the AIE support even thru the x86 flow, and this started to show the issue.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Provided the enhancement on handling the blocking calls from the x86sim and aiesim

#### Risks (if any) associated the changes in the commit
No Risk.

#### What has been tested and how, request additional testing if necessary
Ran the designs manually and ran the canary.

#### Documentation impact (if any)
No
