### PR TITLE
CR-1132124 - Install json to /usr/share in embedded platforms

### DIFF
--- a/build/build_edge.sh
+++ b/build/build_edge.sh
@@ -51,7 +51,8 @@ install_recipes()
         echo 'DEPENDS += "rapidjson"' >> $XRT_BB
         echo 'DEPENDS:append:versal += "libdfx"' >> $XRT_BB
         echo 'DEPENDS:append:zynqmp += "libdfx"' >> $XRT_BB
-        echo "FILES:\${PN} += \"\${libdir}/ps_kernels_lib\"" >> $XRT_BB
+        echo "FILES:\${PN} += \"\${libdir}/ps_kernels_lib \ " >> $XRT_BB
+        echo "                 \${datadir}\"" >> $XRT_BB
         echo 'PACKAGE_CLASSES = "package_rpm"' >> $XRT_BB
         echo 'LICENSE = "GPLv2 & Apache-2.0"' >> $XRT_BB
         echo 'LIC_FILES_CHKSUM = "file://../LICENSE;md5=da5408f748bce8a9851dac18e66f4bcf \' >> $XRT_BB

--- a/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
@@ -98,7 +98,7 @@ endif()
 # This file acts as sample json file and will be removed in future releases
 if (${XRT_NATIVE_BUILD} STREQUAL "no")
   set(XRT_SUBCOMMANDS_JSON ../common/xrt_subcommands.json)
-  install(FILES ${XRT_SUBCOMMANDS_JSON} DESTINATION ${XRT_INSTALL_INCLUDE_DIR})
+  install(FILES ${XRT_SUBCOMMANDS_JSON} DESTINATION ${XRT_INSTALL_DIR}/share)
 endif()
 
 # Install our built executable


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Installing json file to /usr/share folder instead of /usr/include/xrt folder

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
copying file to /usr/include/xrt is making yocto to copy this file to xrt-dev package but dev package will not be installed on run time production system. So moving the file to proper location.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Copying file to proper location solved the issue

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Tested on SOM board

#### Documentation impact (if any)
NA