### PR TITLE
PRE/POST kernel support

### DIFF
--- a/src/runtime_src/core/include/xclbin.h
+++ b/src/runtime_src/core/include/xclbin.h
@@ -530,7 +530,9 @@ extern "C" {
     enum CDO_Type {
         CT_UNKNOWN = 0,
         CT_PRIMARY = 1,
-        CT_LITE    = 2
+        CT_LITE    = 2,
+        CT_PRE     = 3,
+        CT_POST    = 4
     };
 
     struct cdo_group {

--- a/src/runtime_src/tools/xclbinutil/SectionAIEPartition.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionAIEPartition.cxx
@@ -103,7 +103,9 @@ SectionAIEPartition::subSectionExists(const std::string& /*sSubSectionName*/) co
 static const std::vector<std::pair<std::string, CDO_Type>> CTTypes = {
   { "UNKNOWN", CT_UNKNOWN },
   { "PRIMARY", CT_PRIMARY },
-  { "LITE", CT_LITE }
+  { "LITE", CT_LITE },
+  { "PRE", CT_PRE },
+  { "POST", CT_POST }
 };
 
 static const std::string&


### PR DESCRIPTION
#### Problem solved by the commit
To support the pre/post kernel and parse the information from aie partition json file, we have to add two more types: CT_PRE and CT_POST


