### PR TITLE
CR-1135612 load system.dtb blob into sysfs

### DIFF
--- a/src/runtime_src/core/include/xgq_cmd_vmr.h
+++ b/src/runtime_src/core/include/xgq_cmd_vmr.h
@@ -102,6 +102,7 @@ enum xgq_cmd_log_page_type {
 	XGQ_CMD_LOG_ENDPOINT	= 0x4,
 	XGQ_CMD_LOG_TASK_STATS  = 0x5,
 	XGQ_CMD_LOG_MEM_STATS	= 0x6,
+	XGQ_CMD_LOG_SYSTEM_DTB	= 0x7,
 };
 
 /**

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
@@ -154,7 +154,7 @@ struct xocl_xgq_vmr {
 	struct xgq_cmd_cq_default_payload xgq_cq_payload;
 	int 			xgq_vmr_debug_level;
 	u8			xgq_vmr_debug_type;
-	u8			*xgq_vmr_system_dtb;
+	char			*xgq_vmr_system_dtb;
 	size_t			xgq_vmr_system_dtb_size;
 };
 
@@ -2118,7 +2118,18 @@ static ssize_t vmr_system_dtb_read(struct file *filp, struct kobject *kobj,
 out:
 	return ret;
 }
-static BIN_ATTR_RO(vmr_system_dtb, 0);
+/* Some older linux kernel doesn't support
+ * static BIN_ATTR_RO(vmr_system_dtb, 0);
+ */
+static struct bin_attribute bin_attr_vmr_system_dtb = {
+	.attr = {
+		.name = "vmr_system_dtb",
+		.mode = 0444
+	},
+	.read = vmr_system_dtb_read,
+	.write = NULL,
+	.size = 0
+};
 
 static struct attribute *vmr_attrs[] = {
 	&dev_attr_polling.attr,
@@ -2137,8 +2148,8 @@ static struct attribute *vmr_attrs[] = {
 	NULL,
 };
 
-static struct bin_attrbute *vmr_bin_attrs[] = {
-	&dev_attr_vmr_system_dtb,
+static struct bin_attribute *vmr_bin_attrs[] = {
+	&bin_attr_vmr_system_dtb,
 	NULL,
 };
 static struct attribute_group xgq_attr_group = {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
@@ -154,6 +154,8 @@ struct xocl_xgq_vmr {
 	struct xgq_cmd_cq_default_payload xgq_cq_payload;
 	int 			xgq_vmr_debug_level;
 	u8			xgq_vmr_debug_type;
+	u8			*xgq_vmr_system_dtb;
+	size_t			xgq_vmr_system_dtb_size;
 };
 
 static int vmr_status_query(struct platform_device *pdev);
@@ -873,8 +875,9 @@ static int xgq_program_scfw(struct platform_device *pdev)
 		XGQ_CMD_OP_PROGRAM_SCFW, XOCL_XGQ_DOWNLOAD_TIME);
 }
 
+/* Note: caller is responsibe for vfree(*fw) */
 static int xgq_log_page_fw(struct platform_device *pdev,
-	char **fw, size_t *fw_size)
+	char **fw, size_t *fw_size, enum xgq_cmd_log_page_type req_pid)
 {
 	struct xocl_xgq_vmr *xgq = platform_get_drvdata(pdev);
 	struct xocl_xgq_vmr_cmd *cmd = NULL;
@@ -904,7 +907,7 @@ static int xgq_log_page_fw(struct platform_device *pdev,
 	payload->address = address;
 	payload->size = len;
 	payload->offset = 0;
-	payload->pid = XGQ_CMD_LOG_FW;
+	payload->pid = req_pid;
 
 	hdr = &(cmd->xgq_cmd_entry.hdr);
 	hdr->opcode = XGQ_CMD_OP_GET_LOG_PAGE;
@@ -912,6 +915,7 @@ static int xgq_log_page_fw(struct platform_device *pdev,
 	hdr->count = sizeof(*payload);
 	id = get_xgq_cid(xgq);
 	if (id < 0) {
+		ret = -ENOMEM;
 		XGQ_ERR(xgq, "alloc cid failed: %d", id);
 		goto cid_alloc_failed;
 	}
@@ -931,6 +935,7 @@ static int xgq_log_page_fw(struct platform_device *pdev,
 
 	/* wait for command completion */
 	if (wait_for_completion_killable(&cmd->xgq_cmd_complete)) {
+		ret = -ETIME;
 		XGQ_ERR(xgq, "submitted cmd killed");
 		xgq_submitted_cmd_remove(xgq, cmd);
 	}
@@ -975,6 +980,18 @@ acquire_failed:
 	kfree(cmd);
 
 	return ret;
+}
+
+static int xgq_log_page_metadata(struct platform_device *pdev,
+	char **fw, size_t *fw_size)
+{
+	return xgq_log_page_fw(pdev, fw, fw_size, XGQ_CMD_LOG_FW);
+}
+
+static int xgq_log_page_system_dtb(struct platform_device *pdev,
+	char **fw, size_t *fw_size)
+{
+	return xgq_log_page_fw(pdev, fw, fw_size, XGQ_CMD_LOG_SYSTEM_DTB);
 }
 
 static int xgq_firewall_op(struct platform_device *pdev, enum xgq_cmd_log_page_type type_pid)
@@ -2076,7 +2093,34 @@ static ssize_t vmr_debug_type_store(struct device *dev,
 }
 static DEVICE_ATTR_WO(vmr_debug_type);
 
-static struct attribute *xgq_attrs[] = {
+static ssize_t vmr_system_dtb_read(struct file *filp, struct kobject *kobj,
+	struct bin_attribute *attr, char *buf, loff_t off, size_t count)
+{
+	struct xocl_xgq_vmr *xgq = 
+		dev_get_drvdata(container_of(kobj, struct device, kobj));
+	unsigned char *blob;
+	size_t size;
+	ssize_t ret = 0;
+
+	mutex_lock(&xgq->xgq_lock);
+	blob = xgq->xgq_vmr_system_dtb;
+	size = xgq->xgq_vmr_system_dtb_size;
+	mutex_unlock(&xgq->xgq_lock);
+
+	if (off >= size)
+		goto out;
+
+	if (off + count > size)
+		count = size - off;
+	memcpy(buf, blob + off, count);
+
+	ret = count;
+out:
+	return ret;
+}
+static BIN_ATTR_RO(vmr_system_dtb, 0);
+
+static struct attribute *vmr_attrs[] = {
 	&dev_attr_polling.attr,
 	&dev_attr_boot_from_backup.attr,
 	&dev_attr_flash_default_only.attr,
@@ -2093,8 +2137,13 @@ static struct attribute *xgq_attrs[] = {
 	NULL,
 };
 
+static struct bin_attrbute *vmr_bin_attrs[] = {
+	&dev_attr_vmr_system_dtb,
+	NULL,
+};
 static struct attribute_group xgq_attr_group = {
-	.attrs = xgq_attrs,
+	.attrs = vmr_attrs,
+	.bin_attrs = vmr_bin_attrs,
 };
 
 static ssize_t xgq_ospi_write(struct file *filp, const char __user *udata,
@@ -2175,6 +2224,11 @@ static int xgq_vmr_remove(struct platform_device *pdev)
 	xocl_subdev_destroy_by_id(xdev, XOCL_SUBDEV_HWMON_SDM);
 
 	sysfs_remove_group(&pdev->dev.kobj, &xgq_attr_group);
+
+	/* make sure cached system_dtb blob is freed */
+	if (xgq->xgq_vmr_system_dtb)
+		vfree(xgq->xgq_vmr_system_dtb);
+
 	mutex_destroy(&xgq->xgq_lock);
 
 	platform_set_drvdata(pdev, NULL);
@@ -2223,6 +2277,8 @@ static int xgq_vmr_probe(struct platform_device *pdev)
 	platform_set_drvdata(pdev, xgq);
 	xgq->xgq_pdev = pdev;
 	xgq->xgq_cmd_id = 0;
+	xgq->xgq_vmr_system_dtb = NULL;
+	xgq->xgq_vmr_system_dtb_size = 0;
 
 	mutex_init(&xgq->xgq_lock);
 	sema_init(&xgq->xgq_data_sema, 1);
@@ -2326,6 +2382,12 @@ static int xgq_vmr_probe(struct platform_device *pdev)
 		return ret;
 	}
 
+	ret = xgq_log_page_system_dtb(pdev, &xgq->xgq_vmr_system_dtb,
+			&xgq->xgq_vmr_system_dtb_size);
+	if (ret) {
+		XGQ_WARN(xgq, "cannot load system dtb from shell, ret: %d", ret);
+		ret = 0;
+	}
 	ret = xgq_download_apu_firmware(pdev);
 	if (ret) {
 		XGQ_WARN(xgq, "unable to download APU, ret: %d", ret);
@@ -2362,7 +2424,7 @@ static struct xocl_xgq_vmr_funcs xgq_vmr_ops = {
 	.xgq_collect_sensors_by_repo_id = xgq_collect_sensors_by_repo_id,
 	.xgq_collect_sensors_by_sensor_id = xgq_collect_sensors_by_sensor_id,
 	.xgq_collect_all_inst_sensors = xgq_collect_all_inst_sensors,
-	.vmr_load_firmware = xgq_log_page_fw,
+	.vmr_load_firmware = xgq_log_page_metadata,
 };
 
 static const struct file_operations xgq_vmr_fops = {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

adding system dtb blob back to host as a sysfs node

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1135612

#### How problem was solved, alternative solutions (if any) and why they were rejected
we need the full system.dtb blob to debug what is actually loaded for ApU

#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
tested with qdma_1 shell

#### Documentation impact (if any)
https://confluence.xilinx.com/pages/viewpage.action?pageId=302345261#XGQ1.0CommandandQueueSpecification(WIP)-GetLogPage