### PR TITLE
Support for newest kernels and GCC

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/zocl_bo.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_bo.c
@@ -18,8 +18,14 @@
 #include <linux/of_address.h>
 #include <linux/iommu.h>
 #include <linux/version.h>
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 11, 0))
-#include <linux/iosys-map.h>
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 18, 0))
+	#include <linux/iosys-map.h>
+	#define MAP_TYPE iosys_map
+	#define MAP_IS_NULL iosys_map_is_null
+#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 11, 0))
+	#include <linux/dma-buf-map.h>
+	#define MAP_TYPE dma_buf_map
+	#define MAP_IS_NULL dma_buf_map_is_null
 #endif
 #include <asm/io.h>
 #include "xrt_drv.h"
@@ -877,7 +883,7 @@ static int zocl_bo_rdwr_ioctl(struct drm_device *dev, void *data,
 	char __user *user_data = to_user_ptr(args->data_ptr);
 	struct drm_zocl_bo *bo;
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 11, 0))
-	struct iosys_map map;
+	struct MAP_TYPE map;
 #endif
 	int ret = 0;
 	char *kaddr;
@@ -906,7 +912,7 @@ static int zocl_bo_rdwr_ioctl(struct drm_device *dev, void *data,
 	if (bo->flags & ZOCL_BO_FLAGS_CMA) {
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 12, 0)
 		ret = drm_gem_cma_vmap(gem_obj, &map);
-		if(ret || iosys_map_is_null(&map))
+		if(ret || MAP_IS_NULL(&map))
 			kaddr = NULL;
 		else
 			kaddr = map.is_iomem ? map.vaddr_iomem : map.vaddr;

--- a/src/runtime_src/core/edge/drm/zocl/zocl_bo.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_bo.c
@@ -19,7 +19,7 @@
 #include <linux/iommu.h>
 #include <linux/version.h>
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 11, 0))
-#include <linux/dma-buf-map.h>
+#include <linux/iosys-map.h>
 #endif
 #include <asm/io.h>
 #include "xrt_drv.h"
@@ -877,7 +877,7 @@ static int zocl_bo_rdwr_ioctl(struct drm_device *dev, void *data,
 	char __user *user_data = to_user_ptr(args->data_ptr);
 	struct drm_zocl_bo *bo;
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 11, 0))
-	struct dma_buf_map map;
+	struct iosys_map map;
 #endif
 	int ret = 0;
 	char *kaddr;
@@ -906,7 +906,7 @@ static int zocl_bo_rdwr_ioctl(struct drm_device *dev, void *data,
 	if (bo->flags & ZOCL_BO_FLAGS_CMA) {
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 12, 0)
 		ret = drm_gem_cma_vmap(gem_obj, &map);
-		if(ret || dma_buf_map_is_null(&map))
+		if(ret || iosys_map_is_null(&map))
 			kaddr = NULL;
 		else
 			kaddr = map.is_iomem ? map.vaddr_iomem : map.vaddr;

--- a/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/shim.cxx
@@ -214,10 +214,11 @@ namespace xclcpuemhal2 {
     }
     if (buf_size < new_size)
     {
-      void *temp = buf;
-      buf = (void*) realloc(buf,new_size);
-      if (!buf) // prevent leak of original buf
-        free(temp);
+      void *result = realloc(buf, new_size);
+      // If realloc was unsuccessful, then return the original size of buf.
+      if (result == NULL)
+        return buf_size;
+      buf = result;
       return new_size;
     }
     return buf_size;

--- a/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/shim.cxx
@@ -216,7 +216,7 @@ namespace xclcpuemhal2 {
     {
       void *result = realloc(buf, new_size);
       // If realloc was unsuccessful, then return the original size of buf.
-      if (result == NULL)
+      if (result == nullptr)
         return buf_size;
       buf = result;
       return new_size;

--- a/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/shim.cxx
@@ -215,9 +215,13 @@ namespace xclcpuemhal2 {
     if (buf_size < new_size)
     {
       void *result = realloc(buf, new_size);
-      // If realloc was unsuccessful, then return the original size of buf.
+      // If realloc was unsuccessful, then give up and deallocate.
       if (result == nullptr)
-        return buf_size;
+      {
+        free(buf);
+        buf = nullptr;
+        return 0;
+      }
       buf = result;
       return new_size;
     }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libxdma.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libxdma.c
@@ -836,7 +836,7 @@ static void xdma_request_release(struct xdma_dev *xdev,
 {
 	struct sg_table *sgt = req->sgt;
 	if (!req->dma_mapped) {
-		pci_unmap_sg(xdev->pdev, sgt->sgl, sgt->orig_nents,
+		dma_unmap_sg(&xdev->pdev->dev, sgt->sgl, sgt->orig_nents,
 			     req->dir);
 	}
 
@@ -3296,7 +3296,8 @@ ssize_t xdma_xfer_fastpath(void *dev_hndl, int channel, bool write, u64 ep_addr,
 		engine = &xdev->engine_c2h[channel];
 
 	if (!dma_mapped) {
-		nents = pci_map_sg(xdev->pdev, sg, sgt->orig_nents, engine->dir);
+		nents = dma_map_sg(&xdev->pdev->dev, sg, sgt->orig_nents,
+				   engine->dir);
 		if (!nents) {
 			xocl_pr_info("map sgl failed, sgt 0x%p.\n", sgt);
 			return -EIO;
@@ -3354,8 +3355,8 @@ ssize_t xdma_xfer_fastpath(void *dev_hndl, int channel, bool write, u64 ep_addr,
 			       (unsigned long)(&engine->regs));
 	}
 	if (!dma_mapped) {
-                pci_unmap_sg(xdev->pdev, sgt->sgl, sgt->orig_nents,
-                             engine->dir);
+                dma_unmap_sg(&xdev->pdev->dev, sgt->sgl, sgt->orig_nents,
+			     engine->dir);
         }
 
 	if (ret < 0)
@@ -3424,7 +3425,7 @@ ssize_t xdma_xfer_submit(void *dev_hndl, int channel, bool write, u64 ep_addr,
 	}
 
 	if (!dma_mapped) {
-		nents = pci_map_sg(xdev->pdev, sg, sgt->orig_nents, dir);
+		nents = dma_map_sg(&xdev->pdev->dev, sg, sgt->orig_nents, dir);
 		if (!nents) {
 			xocl_pr_info("map sgl failed, sgt 0x%p.\n", sgt);
 			return -EIO;
@@ -3709,18 +3710,18 @@ static int set_dma_mask(struct pci_dev *pdev)
 
 	dbg_init("sizeof(dma_addr_t) == %ld\n", sizeof(dma_addr_t));
 	/* 64-bit addressing capability for XDMA? */
-	if (!pci_set_dma_mask(pdev, DMA_BIT_MASK(64))) {
+	if (!dma_set_mask(&pdev->dev, DMA_BIT_MASK(64))) {
 		/* query for DMA transfer */
 		/* @see Documentation/DMA-mapping.txt */
 		dbg_init("pci_set_dma_mask()\n");
 		/* use 64-bit DMA */
 		dbg_init("Using a 64-bit DMA mask.\n");
 		/* use 32-bit DMA for descriptors */
-		pci_set_consistent_dma_mask(pdev, DMA_BIT_MASK(32));
+		dma_set_coherent_mask(&pdev->dev, DMA_BIT_MASK(32));
 		/* use 64-bit DMA, 32-bit for consistent */
-	} else if (!pci_set_dma_mask(pdev, DMA_BIT_MASK(32))) {
+	} else if (!dma_set_mask(&pdev->dev, DMA_BIT_MASK(32))) {
 		dbg_init("Could not set 64-bit DMA mask.\n");
-		pci_set_consistent_dma_mask(pdev, DMA_BIT_MASK(32));
+		dma_set_coherent_mask(&pdev->dev, DMA_BIT_MASK(32));
 		/* use 32-bit DMA */
 		dbg_init("Using a 32-bit DMA mask.\n");
 	} else {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/qdma.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/qdma.c
@@ -346,7 +346,8 @@ static ssize_t qdma_migrate_bo(struct platform_device *pdev,
 	chan = &qdma->chans[write][channel];
 
 	dir = write ? DMA_TO_DEVICE : DMA_FROM_DEVICE;
-	nents = pci_map_sg(XDEV(xdev)->pdev, sgt->sgl, sgt->orig_nents, dir);
+	nents = dma_map_sg(&XDEV(xdev)->pdev->dev, sgt->sgl, sgt->orig_nents,
+			   dir);
         if (!nents) {
 		xocl_err(&pdev->dev, "map sgl failed, sgt 0x%p.\n", sgt);
 		return -EIO;
@@ -379,7 +380,7 @@ static ssize_t qdma_migrate_bo(struct platform_device *pdev,
 		dump_sgtable(&pdev->dev, sgt);
 	}
 
-	pci_unmap_sg(XDEV(xdev)->pdev, sgt->sgl, nents, dir);
+	dma_unmap_sg(&XDEV(xdev)->pdev->dev, sgt->sgl, nents, dir);
 	kfree(req);
 
 	return ret;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
@@ -189,8 +189,8 @@ static void xocl_free_bo(struct drm_gem_object *obj)
 	}
 
 	if (xobj->dma_nsg) {
-		pci_unmap_sg(xdev->core.pdev, xobj->sgt->sgl, xobj->dma_nsg,
-			PCI_DMA_BIDIRECTIONAL);
+		dma_unmap_sg(&xdev->core.pdev->dev, xobj->sgt->sgl,
+			     xobj->dma_nsg, DMA_BIDIRECTIONAL);
 	}
 
 	if (xobj->pages) {
@@ -1275,17 +1275,17 @@ void xocl_gem_prime_vunmap(struct drm_gem_object *obj, void *vaddr)
 
 }
 #else
-int xocl_gem_prime_vmap(struct drm_gem_object *obj, struct dma_buf_map *map)
+int xocl_gem_prime_vmap(struct drm_gem_object *obj, struct iosys_map *map)
 {
         struct drm_xocl_bo *xobj = to_xocl_bo(obj);
 
         BO_ENTER("xobj %p", xobj);
-        dma_buf_map_set_vaddr(map, xobj->vmapping);
+        iosys_map_set_vaddr(map, xobj->vmapping);
 
         return 0;
 }
 
-void xocl_gem_prime_vunmap(struct drm_gem_object *obj, struct dma_buf_map *map)
+void xocl_gem_prime_vunmap(struct drm_gem_object *obj, struct iosys_map *map)
 {
 
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
@@ -60,7 +60,6 @@ static inline void xocl_release_pages(struct page **pages, int nr, bool cold)
 #endif
 }
 
-
 static inline void __user *to_user_ptr(u64 address)
 {
 	return (void __user *)(uintptr_t)address;
@@ -1275,17 +1274,17 @@ void xocl_gem_prime_vunmap(struct drm_gem_object *obj, void *vaddr)
 
 }
 #else
-int xocl_gem_prime_vmap(struct drm_gem_object *obj, struct iosys_map *map)
+int xocl_gem_prime_vmap(struct drm_gem_object *obj, struct MAP_TYPE *map)
 {
         struct drm_xocl_bo *xobj = to_xocl_bo(obj);
 
         BO_ENTER("xobj %p", xobj);
-        iosys_map_set_vaddr(map, xobj->vmapping);
+        MAP_SET_VADDR(map, xobj->vmapping);
 
         return 0;
 }
 
-void xocl_gem_prime_vunmap(struct drm_gem_object *obj, struct iosys_map *map)
+void xocl_gem_prime_vunmap(struct drm_gem_object *obj, struct MAP_TYPE *map)
 {
 
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.h
@@ -69,6 +69,17 @@
  */
 #define XOCL_BO_ARE  (1 << 26)
 
+// Linux 5.18 uses iosys-map instead of dma-buf-map
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 18, 0)
+	#define MAP_TYPE iosys_map
+	#define MAP_SET_VADDR iosys_map_set_vaddr
+	#define MAP_IS_NULL iosys_map_is_null
+#else
+	#define MAP_TYPE dma_buf_map
+	#define MAP_SET_VADDR dma_buf_map_set_vaddr
+	#define MAP_IS_NULL dma_buf_map_is_null
+#endif
+
 static inline bool xocl_bo_userptr(const struct drm_xocl_bo *bo)
 {
 	return (bo->flags == XOCL_BO_USERPTR);
@@ -199,8 +210,8 @@ struct drm_gem_object *xocl_gem_prime_import_sg_table(struct drm_device *dev,
 void *xocl_gem_prime_vmap(struct drm_gem_object *obj);
 void xocl_gem_prime_vunmap(struct drm_gem_object *obj, void *vaddr);
 #else
-int xocl_gem_prime_vmap(struct drm_gem_object *obj, struct iosys_map *map);
-void xocl_gem_prime_vunmap(struct drm_gem_object *obj, struct iosys_map *map);
+int xocl_gem_prime_vmap(struct drm_gem_object *obj, struct MAP_TYPE *map);
+void xocl_gem_prime_vunmap(struct drm_gem_object *obj, struct MAP_TYPE *map);
 #endif
 
 int xocl_gem_prime_mmap(struct drm_gem_object *obj, struct vm_area_struct *vma);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.h
@@ -199,8 +199,8 @@ struct drm_gem_object *xocl_gem_prime_import_sg_table(struct drm_device *dev,
 void *xocl_gem_prime_vmap(struct drm_gem_object *obj);
 void xocl_gem_prime_vunmap(struct drm_gem_object *obj, void *vaddr);
 #else
-int xocl_gem_prime_vmap(struct drm_gem_object *obj, struct dma_buf_map *map);
-void xocl_gem_prime_vunmap(struct drm_gem_object *obj, struct dma_buf_map *map);
+int xocl_gem_prime_vmap(struct drm_gem_object *obj, struct iosys_map *map);
+void xocl_gem_prime_vunmap(struct drm_gem_object *obj, struct iosys_map *map);
 #endif
 
 int xocl_gem_prime_mmap(struct drm_gem_object *obj, struct vm_area_struct *vma);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
@@ -1252,7 +1252,7 @@ static void xocl_cma_mem_free(struct xocl_dev *xdev, uint32_t idx)
 
 	if (cma_mem->regular_page) {
 		dma_unmap_page(&xdev->core.pdev->dev, cma_mem->paddr,
-			cma_mem->size, PCI_DMA_BIDIRECTIONAL);
+			cma_mem->size, DMA_BIDIRECTIONAL);
 		__free_pages(cma_mem->regular_page, get_order(cma_mem->size));
 		cma_mem->regular_page = NULL;
 	} else if (cma_mem->pages) {
@@ -1502,7 +1502,7 @@ static int xocl_cma_mem_alloc_by_idx(struct xocl_dev *xdev, uint64_t size, uint3
 	}
 
 	dma_addr = dma_map_page(dev, page, 0, size,
-		PCI_DMA_BIDIRECTIONAL);
+		DMA_BIDIRECTIONAL);
 	if (unlikely(dma_mapping_error(dev, dma_addr))) {
 		DRM_ERROR("Unable to dma map pages");
 		__free_pages(page, order);
@@ -1513,7 +1513,7 @@ static int xocl_cma_mem_alloc_by_idx(struct xocl_dev *xdev, uint64_t size, uint3
 		roundup(PAGE_SIZE, size) >> PAGE_SHIFT);
 
 	if (!cma_mem->pages) {
-		dma_unmap_page(dev, dma_addr, size, PCI_DMA_BIDIRECTIONAL);
+		dma_unmap_page(dev, dma_addr, size, DMA_BIDIRECTIONAL);
 		__free_pages(page, order);
 		return -ENOMEM;
 	}
@@ -1783,18 +1783,18 @@ int xocl_userpf_probe(struct pci_dev *pdev,
 
 	xocl_drvinst_set_offline(xdev, false);
 
-	if (!pci_set_dma_mask(pdev, DMA_BIT_MASK(64))) {
+	if (!dma_set_mask(&pdev->dev, DMA_BIT_MASK(64))) {
 		/* query for DMA transfer */
 		/* @see Documentation/DMA-mapping.txt */
 		xocl_info(&pdev->dev, "pci_set_dma_mask()\n");
 		/* use 64-bit DMA */
 		xocl_info(&pdev->dev, "Using a 64-bit DMA mask.\n");
 		/* use 32-bit DMA for descriptors */
-		pci_set_consistent_dma_mask(pdev, DMA_BIT_MASK(32));
+		dma_set_coherent_mask(&pdev->dev, DMA_BIT_MASK(32));
 		/* use 64-bit DMA, 32-bit for consistent */
-	} else if (!pci_set_dma_mask(pdev, DMA_BIT_MASK(32))) {
+	} else if (!dma_set_mask(&pdev->dev, DMA_BIT_MASK(32))) {
 		xocl_info(&pdev->dev, "Could not set 64-bit DMA mask.\n");
-		pci_set_consistent_dma_mask(pdev, DMA_BIT_MASK(32));
+		dma_set_coherent_mask(&pdev->dev, DMA_BIT_MASK(32));
 		/* use 32-bit DMA */
 		xocl_info(&pdev->dev, "Using a 32-bit DMA mask.\n");
 	} else {

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
@@ -113,9 +113,13 @@ namespace xclcpuemhal2
     if (buf_size < new_size)
     {
       void *result = realloc(buf, new_size);
-      // If realloc was unsuccessful, then return the original size of buf.
-      if (result == NULL)
-        return buf_size;
+      // If realloc was unsuccessful, then give up and deallocate.
+      if (result == nullptr)
+      {
+        free(buf);
+        buf = nullptr;
+        return 0;
+	  }
       buf = result;
       return new_size;
     }

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
@@ -112,10 +112,11 @@ namespace xclcpuemhal2
     }
     if (buf_size < new_size)
     {
-      void *temp = buf;
-      buf = (void*)realloc(temp, new_size);
-      if (!buf) // prevent leak of original buf
-        free(temp);
+      void *result = realloc(buf, new_size);
+      // If realloc was unsuccessful, then return the original size of buf.
+      if (result == NULL)
+        return buf_size;
+      buf = result;
       return new_size;
     }
     return buf_size;

--- a/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.cxx
@@ -154,10 +154,11 @@ namespace xclhwemhal2 {
     }
     if (buf_size < new_size)
     {
-      void *temp = buf;
-      buf = (void*) realloc(temp,new_size);
-      if (!buf) // prevent leak of original buf
-        free(temp);
+      void *result = realloc(buf, new_size);
+      // If realloc was unsuccessful, then return the original size of buf.
+      if (result == NULL)
+        return buf_size;
+      buf = result;
       return new_size;
     }
     return buf_size;

--- a/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.cxx
@@ -155,9 +155,13 @@ namespace xclhwemhal2 {
     if (buf_size < new_size)
     {
       void *result = realloc(buf, new_size);
-      // If realloc was unsuccessful, then return the original size of buf.
-      if (result == NULL)
-        return buf_size;
+      // If realloc was unsuccessful, then give up and deallocate.
+      if (result == nullptr)
+      {
+        free(buf);
+        buf = nullptr;
+        return 0;
+      }
       buf = result;
       return new_size;
     }

--- a/src/runtime_src/core/pcie/linux/scan.cpp
+++ b/src/runtime_src/core/pcie/linux/scan.cpp
@@ -1066,7 +1066,7 @@ get_dev(unsigned index, bool user)
 }
 
 int
-get_axlf_section(const std::string& filename, int kind, std::shared_ptr<char>& buf)
+get_axlf_section(const std::string& filename, int kind, std::shared_ptr<char[]>& buf)
 {
   std::ifstream in(filename);
   if (!in.is_open()) {
@@ -1102,7 +1102,7 @@ get_axlf_section(const std::string& filename, int kind, std::shared_ptr<char>& b
   if (!section)
     return -EINVAL;
 
-  buf = std::shared_ptr<char>(new char[section->m_sectionSize]);
+  buf = std::shared_ptr<char[]>(new char[section->m_sectionSize]);
   in.seekg(section->m_sectionOffset);
   in.read(buf.get(), section->m_sectionSize);
 

--- a/src/runtime_src/core/pcie/linux/scan.h
+++ b/src/runtime_src/core/pcie/linux/scan.h
@@ -169,7 +169,7 @@ size_t get_dev_total(bool user = true);
 size_t get_dev_ready(bool user = true);
 std::shared_ptr<pci_device> get_dev(unsigned index, bool user = true);
 
-int get_axlf_section(const std::string& filename, int kind, std::shared_ptr<char>& buf);
+int get_axlf_section(const std::string& filename, int kind, std::shared_ptr<char[]>& buf);
 int get_uuids(std::shared_ptr<char>& dtbbuf, std::vector<std::string>& uuids);
 std::shared_ptr<pcidev::pci_device> lookup_user_dev(std::shared_ptr<pcidev::pci_device> mgmt_dev);
 int shutdown(std::shared_ptr<pcidev::pci_device> mgmt_dev, bool remove_user = false, bool remove_mgmt = false);

--- a/src/runtime_src/tools/xclbinutil/Section.cxx
+++ b/src/runtime_src/tools/xclbinutil/Section.cxx
@@ -510,7 +510,7 @@ Section::readPayload(std::istream& _istream, FormatType _eFormatType)
         _istream.seekg(0, _istream.end);
         std::streamsize fileSize =  _istream.tellg();
 
-        std::unique_ptr<unsigned char> memBuffer(new unsigned char[fileSize]);
+        auto memBuffer = std::make_unique<unsigned char[]>(fileSize);
         _istream.clear();
         _istream.seekg(0);
         _istream.read((char*)memBuffer.get(), fileSize);

--- a/src/runtime_src/tools/xclbinutil/SectionBMC.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionBMC.cxx
@@ -134,7 +134,7 @@ SectionBMC::copyBufferUpdateMetadata(const char* _pOrigDataSection,
   XUtil::TRACE("SectionBMC::CopyBufferUpdateMetadata");
 
   // Copy the buffer
-  std::unique_ptr<unsigned char> copyBuffer(new unsigned char[_origSectionSize]);
+  auto copyBuffer = std::make_unique<unsigned char[]>(_origSectionSize);
   memcpy(copyBuffer.get(), _pOrigDataSection, _origSectionSize);
 
   // ----------------------
@@ -172,7 +172,7 @@ SectionBMC::copyBufferUpdateMetadata(const char* _pOrigDataSection,
   _istream.seekg(0, _istream.end);
   std::streamsize fileSize = _istream.tellg();
 
-  std::unique_ptr<unsigned char> memBuffer(new unsigned char[fileSize]);
+  auto memBuffer = std::make_unique<unsigned char[]>(fileSize);
   _istream.clear();
   _istream.seekg(0);
   _istream.read((char*)memBuffer.get(), fileSize);
@@ -273,9 +273,7 @@ SectionBMC::createDefaultFWImage(std::istream& _istream, std::ostringstream& _bu
 
   // Write Data
   {
-
-
-    std::unique_ptr<unsigned char> memBuffer(new unsigned char[bmcHdr.m_size]);
+    auto memBuffer = std::make_unique<unsigned char[]>(bmcHdr.m_size);
     _istream.seekg(0);
     _istream.clear();
     _istream.read((char*)memBuffer.get(), bmcHdr.m_size);

--- a/src/runtime_src/tools/xclbinutil/SectionBuildMetadata.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionBuildMetadata.cxx
@@ -50,7 +50,7 @@ SectionBuildMetadata::marshalToJSON(char* _pDataSection,
   XUtil::TRACE("");
   XUtil::TRACE("Extracting: BUILD_METADATA");
 
-  std::unique_ptr<unsigned char> memBuffer(new unsigned char[_sectionSize + 1]);
+  auto memBuffer = std::make_unique<unsigned char[]>(_sectionSize + 1);
   memcpy((char*)memBuffer.get(), _pDataSection, _sectionSize);
   memBuffer.get()[_sectionSize] = '\0';
 

--- a/src/runtime_src/tools/xclbinutil/SectionKeyValueMetadata.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionKeyValueMetadata.cxx
@@ -53,7 +53,7 @@ SectionKeyValueMetadata::marshalToJSON(char* _pDataSection,
     boost::property_tree::ptree ptEmptyKeyvalues;
     ptKeyValuesMetadata.add_child("key_values", ptEmptyKeyvalues);
   } else {
-    std::unique_ptr<unsigned char> memBuffer(new unsigned char[_sectionSize + 1]);
+    auto memBuffer = std::make_unique<unsigned char[]>(_sectionSize + 1);
     memcpy((char*)memBuffer.get(), _pDataSection, _sectionSize);
     memBuffer.get()[_sectionSize] = '\0';
 

--- a/src/runtime_src/tools/xclbinutil/SectionMCS.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionMCS.cxx
@@ -372,7 +372,7 @@ SectionMCS::readSubPayload(const char* _pOrigDataSection,
     std::streamsize mcsSize = _istream.tellg();
 
     // -- Read contents into memory buffer --
-    std::unique_ptr<unsigned char> memBuffer(new unsigned char[mcsSize]);
+    auto memBuffer = std::make_unique<unsigned char[]>(mcsSize);
     _istream.clear();
     _istream.seekg(0, _istream.beg);
     _istream.read((char*)memBuffer.get(), mcsSize);

--- a/src/runtime_src/tools/xclbinutil/SectionSoftKernel.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionSoftKernel.cxx
@@ -180,7 +180,7 @@ SectionSoftKernel::copyBufferUpdateMetadata(const char* _pOrigDataSection,
   std::streampos fileSize = _istream.tellg();  // Go to the end
 
   // Copy the buffer into memory
-  std::unique_ptr<unsigned char> memBuffer(new unsigned char[fileSize]);
+  auto memBuffer = std::make_unique<unsigned char[]>(fileSize);
   _istream.clear();                                // Clear any previous errors
   _istream.seekg(0);                               // Go to the beginning
   _istream.read((char*)memBuffer.get(), fileSize); // Read in the buffer into memory
@@ -328,7 +328,7 @@ SectionSoftKernel::createDefaultImage(std::istream& _istream, std::ostringstream
 
   // Write Data
   {
-    std::unique_ptr<unsigned char> memBuffer(new unsigned char[softKernelHdr.m_image_size]);
+    auto memBuffer = std::make_unique<unsigned char[]>(softKernelHdr.m_image_size);
     _istream.seekg(0);
     _istream.clear();
     _istream.read(reinterpret_cast<char*>(memBuffer.get()), softKernelHdr.m_image_size);

--- a/src/runtime_src/tools/xclbinutil/SectionVenderMetadata.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionVenderMetadata.cxx
@@ -97,7 +97,7 @@ SectionVenderMetadata::copyBufferUpdateMetadata(const char* _pOrigDataSection,
   std::streampos fileSize = _istream.tellg();  // Go to the end
 
   // Copy the buffer into memory
-  std::unique_ptr<unsigned char> memBuffer(new unsigned char[fileSize]);
+  auto memBuffer = std::make_unique<unsigned char[]>(fileSize);
   _istream.clear();                                // Clear any previous errors
   _istream.seekg(0);                               // Go to the beginning
   _istream.read((char*)memBuffer.get(), fileSize); // Read in the buffer into memory
@@ -188,7 +188,7 @@ SectionVenderMetadata::createDefaultImage(std::istream& _istream, std::ostringst
 
   // Write Data
   {
-    std::unique_ptr<unsigned char> memBuffer(new unsigned char[venderMetadataHdr.m_image_size]);
+	auto memBuffer = std::make_unique<unsigned char[]>(venderMetadataHdr.m_image_size);
     _istream.seekg(0);
     _istream.clear();
     _istream.read(reinterpret_cast<char*>(memBuffer.get()), venderMetadataHdr.m_image_size);

--- a/src/runtime_src/tools/xclbinutil/XclBinUtilities.cxx
+++ b/src/runtime_src/tools/xclbinutil/XclBinUtilities.cxx
@@ -429,7 +429,7 @@ XclBinUtilities::getSignature(std::fstream& _istream, std::string& _sSignature,
   if (signature.signedBySize != 0)
   {
     _istream.seekg(signatureOffset + signature.signedByOffset);
-    std::unique_ptr<char> data( new char[ signature.signedBySize ] );
+    auto data = std::make_unique<char[]>(signature.signedBySize);
     _istream.read( data.get(), signature.signedBySize );
     _sSignedBy = std::string(data.get(), signature.signedBySize);
   }
@@ -438,7 +438,7 @@ XclBinUtilities::getSignature(std::fstream& _istream, std::string& _sSignature,
   if (signature.signatureSize != 0)
   {
     _istream.seekg(signatureOffset + signature.signatureOffset);
-    std::unique_ptr<char> data( new char[ signature.signatureSize ] );
+    auto data = std::make_unique<char[]>(signature.signatureSize);
     _istream.read( data.get(), signature.signatureSize );
     _sSignature = std::string(data.get(), signature.signatureSize);
   }

--- a/src/runtime_src/xocl/api/clReleaseCommandQueue.cpp
+++ b/src/runtime_src/xocl/api/clReleaseCommandQueue.cpp
@@ -37,7 +37,7 @@ static cl_int
 clReleaseCommandQueue(cl_command_queue command_queue)
 {
   validOrError(command_queue);
-  if (xocl(command_queue)->release())
+  if (xocl(command_queue) != nullptr && xocl(command_queue)->release())
     delete xocl(command_queue);
   return CL_SUCCESS;
 }

--- a/src/runtime_src/xocl/api/clReleaseContext.cpp
+++ b/src/runtime_src/xocl/api/clReleaseContext.cpp
@@ -36,7 +36,7 @@ static cl_int
 clReleaseContext(cl_context  context )
 {
   validOrError(context);
-  if (xocl(context)->release())
+  if (xocl(context) != nullptr && xocl(context)->release())
     delete xocl(context);
   return CL_SUCCESS;
 }

--- a/src/runtime_src/xocl/api/clReleaseKernel.cpp
+++ b/src/runtime_src/xocl/api/clReleaseKernel.cpp
@@ -37,7 +37,7 @@ static cl_int
 clReleaseKernel(cl_kernel kernel)
 {
   validOrError(kernel);
-  if (xocl(kernel)->release())
+  if (xocl(kernel) != nullptr && xocl(kernel)->release())
     delete xocl(kernel);
   return CL_SUCCESS;
 }

--- a/src/runtime_src/xocl/api/clReleaseMemObject.cpp
+++ b/src/runtime_src/xocl/api/clReleaseMemObject.cpp
@@ -38,8 +38,7 @@ static cl_int
 clReleaseMemObject(cl_mem memobj)
 {
   validOrError(memobj);
-
-  if (!xocl(memobj)->release())
+  if (xocl(memobj) != nullptr && !xocl(memobj)->release())
     return CL_SUCCESS;
 
   delete xocl(memobj);

--- a/src/runtime_src/xocl/api/clReleaseProgram.cpp
+++ b/src/runtime_src/xocl/api/clReleaseProgram.cpp
@@ -36,8 +36,7 @@ static cl_int
 clReleaseProgram(cl_program program)
 {
   validOrError(program);
-
-  if (xocl::xocl(program)->release())
+  if (xocl::xocl(program) != nullptr && xocl::xocl(program)->release())
     delete xocl::xocl(program);
 
   return CL_SUCCESS;

--- a/src/runtime_src/xocl/api/clReleaseSampler.cpp
+++ b/src/runtime_src/xocl/api/clReleaseSampler.cpp
@@ -36,7 +36,7 @@ static cl_int
 clReleaseSampler(cl_sampler sampler)
 {
   validOrError(sampler);
-  if (xocl(sampler)->release())
+  if (xocl(sampler) != nullptr && xocl(sampler)->release())
     delete xocl(sampler);
   return CL_SUCCESS;
 }


### PR DESCRIPTION
#### Problem solved by the commit

1. realloc error handling
2. GCC 12.1.1-related warnings
   1. nullptr->member accesses 
   2. `new`-`delete` type mismatches
3. Rename dma-buf-map to iosys-map in the driver code

Additional details can be found in the commit messages.

##### Additional info on `realloc`

realloc() returns a NULL if reallocation was not successful. This was not handled properly (by returning `new_size` after conditional execution `free(temp)`.

More info on `realloc`:

- [`realloc` from C17 standard](https://web.archive.org/web/20181230041359if_/http://www.open-std.org/jtc1/sc22/wg14/www/abq/c17_updated_proposed_fdis.pdf#subsection.7.22.3)
- [SO: How to handle realloc if it fails](https://stackoverflow.com/a/1986572)

#### How problem was solved, alternative solutions (if any) and why they were rejected

N/A

#### Risks (if any) associated the changes in the commit

I do not know.

#### What has been tested and how, request additional testing if necessary

<s>I did not carry any tests. I request additional testing.</s>. I tested the changes on on U280 using `xbutil validate` using tests 1 to 7.

#### Documentation impact (if any)

I do not know.
