### PR TITLE
Add experimental support for QoS specification in hwctx

### DIFF
--- a/src/runtime_src/core/common/api/xrt_hw_context.cpp
+++ b/src/runtime_src/core/common/api/xrt_hw_context.cpp
@@ -23,7 +23,8 @@ namespace xrt {
 //
 class hw_context_impl
 {
-  using qos_type = xrt::hw_context::qos;
+  using qos_type = xrt::hw_context::qos_type;
+  using access_mode = xrt::hw_context::access_mode;
 
   // Managed context handle with exceptional handling for flows
   // or applications that use load_xclbin (legacy Alveo)
@@ -33,7 +34,7 @@ class hw_context_impl
     xcl_hwctx_handle m_hdl;
     bool m_destroy_context = true;
 
-    ctx_handle(const xrt_core::device* device, const xrt::uuid& uuid, qos_type qos)
+    ctx_handle(const xrt_core::device* device, const xrt::uuid& uuid, const qos_type& qos, access_mode mode)
       : m_device(device)
     {
       try {
@@ -41,7 +42,7 @@ class hw_context_impl
         // or (2) create_hw_context is not supported. (2) => (1) so
         // in both cases simply lookup the slot into which the xclbin
         // has been loaded.
-        m_hdl = m_device->create_hw_context(uuid.get(), static_cast<xcl_qos_type>(qos));
+        m_hdl = m_device->create_hw_context(uuid, qos, mode);
       }
       catch (const xrt_core::ishim::not_supported_error&) {
         // xclbin must have been loaded, get the slot id for the xclbin
@@ -68,21 +69,30 @@ class hw_context_impl
   std::shared_ptr<xrt_core::device> m_core_device;
   xrt::xclbin m_xclbin;
   qos_type m_qos;
+  access_mode m_mode;
   ctx_handle m_ctx_handle;
 
 public:
-  hw_context_impl(std::shared_ptr<xrt_core::device> device, const xrt::uuid& xclbin_id, xrt::hw_context::qos qos)
+  hw_context_impl(std::shared_ptr<xrt_core::device> device, const xrt::uuid& xclbin_id, const qos_type& qos)
     : m_core_device(std::move(device))
     , m_xclbin(m_core_device->get_xclbin(xclbin_id))
     , m_qos(qos)
-    , m_ctx_handle{m_core_device.get(), xclbin_id, m_qos}
+    , m_mode(xrt::hw_context::access_mode::shared)
+    , m_ctx_handle{m_core_device.get(), xclbin_id, m_qos, m_mode}
   {
   }
 
-  void
+  hw_context_impl(std::shared_ptr<xrt_core::device> device, const xrt::uuid& xclbin_id, access_mode mode)
+    : m_core_device(std::move(device))
+    , m_xclbin(m_core_device->get_xclbin(xclbin_id))
+    , m_mode(mode)
+    , m_ctx_handle{m_core_device.get(), xclbin_id, m_qos, m_mode}
+  {}
+
+void
   set_exclusive()
   {
-    m_qos = xrt::hw_context::qos::exclusive;
+    m_mode = xrt::hw_context::access_mode::exclusive;
   }
 
   const std::shared_ptr<xrt_core::device>&
@@ -103,10 +113,10 @@ public:
     return m_xclbin;
   }
 
-  qos_type
-  get_qos() const
+  access_mode
+  get_mode() const
   {
-    return m_qos;
+    return m_mode;
   }
 
   xcl_hwctx_handle
@@ -149,8 +159,14 @@ set_exclusive(xrt::hw_context& hwctx)
 namespace xrt {
 
 hw_context::
-hw_context(const xrt::device& device, const xrt::uuid& xclbin_id, xrt::hw_context::qos qos)
+hw_context(const xrt::device& device, const xrt::uuid& xclbin_id, const xrt::hw_context::qos_type& qos)
   : detail::pimpl<hw_context_impl>(std::make_shared<hw_context_impl>(device.get_handle(), xclbin_id, qos))
+{}
+
+
+hw_context::
+hw_context(const xrt::device& device, const xrt::uuid& xclbin_id, access_mode mode)
+  : detail::pimpl<hw_context_impl>(std::make_shared<hw_context_impl>(device.get_handle(), xclbin_id, mode))
 {}
 
 xrt::device
@@ -174,11 +190,11 @@ get_xclbin() const
   return get_handle()->get_xclbin();
 }
 
-hw_context::qos
+hw_context::access_mode
 hw_context::
-get_qos() const
+get_mode() const
 {
-  return get_handle()->get_qos();
+  return get_handle()->get_mode();
 }
 
 hw_context::

--- a/src/runtime_src/core/common/api/xrt_ip.cpp
+++ b/src/runtime_src/core/common/api/xrt_ip.cpp
@@ -67,12 +67,12 @@ has_reg_read_write()
 // Determine the QoS value to use when constructing xrt::hw_context in
 // legacy constructor.  The default is exclusive context, but if
 // xrt.ini:get_rw_shared() is set then access should be shared.
-static xrt::hw_context::qos
-hwctx_qos()
+static xrt::hw_context::access_mode
+hwctx_access_mode()
 {
   return (xrt_core::config::get_rw_shared())
-    ? xrt::hw_context::qos::shared
-    : xrt::hw_context::qos::exclusive;
+    ? xrt::hw_context::access_mode::shared
+    : xrt::hw_context::access_mode::exclusive;
 }
 
 } // namespace
@@ -245,7 +245,7 @@ public:
   // @nm:      name identifying an ip in IP_LAYOUT of xclbin
   ip_impl(std::shared_ptr<xrt_core::device> dev, const xrt::uuid& xid, const std::string& nm)
     : m_device(std::move(dev))                                   // share ownership
-    , m_ipctx(xrt::hw_context{xrt::device{m_device}, xid, hwctx_qos()}, nm)
+    , m_ipctx(xrt::hw_context{xrt::device{m_device}, xid, hwctx_access_mode()}, nm)
     , m_uid(create_uid())
   {
     XRT_DEBUGF("ip_impl::ip_impl(%d)\n" , uid);

--- a/src/runtime_src/core/common/ishim.h
+++ b/src/runtime_src/core/common/ishim.h
@@ -153,7 +153,7 @@ struct ishim
   // not_supported_error, if either not implemented or an xclbin
   // was explicitly loaded using load_xclbin
   virtual uint32_t // ctx handle aka slot idx
-  create_hw_context(const xrt::uuid& /*xclbin_uuid*/, uint32_t /*qos*/) const
+  create_hw_context(const xrt::uuid& /*xclbin_uuid*/, const xrt::hw_context::qos_type& /*qos*/, xrt::hw_context::access_mode /*mode*/) const
   { throw not_supported_error{__func__}; }
 
   virtual void

--- a/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/shim.cxx
@@ -2173,7 +2173,7 @@ open_cu_context(const xrt::hw_context& hwctx, const std::string& cuname)
   // Edge does not yet support multiple xclbins.  Call
   // regular flow.  Default access mode to shared unless explicitly
   // exclusive.
-  auto shared = (hwctx.get_qos() != xrt::hw_context::qos::exclusive);
+  auto shared = (hwctx.get_mode() != xrt::hw_context::access_mode::exclusive);
   auto ctxhdl = static_cast<xcl_hwctx_handle>(hwctx);
   auto cuidx = mCoreDevice->get_cuidx(ctxhdl, cuname);
   xclOpenContext(hwctx.get_xclbin_uuid().get(), cuidx.index, shared);

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -1122,7 +1122,7 @@ open_cu_context(const xrt::hw_context& hwctx, const std::string& cuname)
   // Edge does not yet support multiple xclbins.  Call
   // regular flow.  Default access mode to shared unless explicitly
   // exclusive.
-  auto shared = (hwctx.get_qos() != xrt::hw_context::qos::exclusive);
+  auto shared = (hwctx.get_mode() != xrt::hw_context::access_mode::exclusive);
   auto ctxhdl = static_cast<xcl_hwctx_handle>(hwctx);
   auto cuidx = mCoreDevice->get_cuidx(ctxhdl, cuname);
   xclOpenContext(hwctx.get_xclbin_uuid().get(), cuidx.index, shared);

--- a/src/runtime_src/core/include/experimental/xrt_hw_context.h
+++ b/src/runtime_src/core/include/experimental/xrt_hw_context.h
@@ -13,6 +13,8 @@
 
 #ifdef __cplusplus
 
+#include <map>
+
 namespace xrt {
 
 /**
@@ -27,8 +29,26 @@ class hw_context_impl;
 class hw_context : public detail::pimpl<hw_context_impl>
 {
 public:
+
   /**
-   * @enum priority - tbd
+   * Experimental specification of QoS requirements
+   *
+   * Free formed key-value entry.
+   *
+   * Supported keys are:
+   *  - tops                   // tera operations per second
+   *  - fps                    // frames per second
+   *  - dma_bandwidth          // gigabytes per second
+   *  - latency                // ??
+   *  - frame_execution_time   // ??
+   *  - priority               // ??
+   *
+   * Currently ignore for legacy platforms
+   */
+  using qos_type = std::map<std::string, uint32_t>;
+
+  /**
+   * @enum access_mode - legacy access mode
    *
    * @var exclusive
    *  Create a context for exclusive access to shareable resources.
@@ -36,11 +56,12 @@ public:
    * @var shared
    *  Create a context for shared access to shareable resources
    *  Legacy compute unit access control.
+   *
+   * Access mode is mutually exclusive with qos
    */
-  enum class qos : xcl_qos_type {
-    exclusive = XCL_QOS_EXCLUSIVE,  // legacy
-    shared = XCL_QOS_SHARED,        // legacy
-    reserved = 0
+  enum class access_mode : uint8_t {
+    exclusive = 0,
+    shared = 1
   };
 
 public:
@@ -50,7 +71,7 @@ public:
   hw_context() = default;
 
   /**
-   * hw_context() - Constructor
+   * hw_context() - Constructor with QoS control
    *
    * @param device
    *  Device where context is created
@@ -60,13 +81,26 @@ public:
    *  Quality of service request that should be fulfilled by the context
    */
   XRT_API_EXPORT
-  hw_context(const xrt::device& device, const xrt::uuid& xclbin_id, qos qos);
+  hw_context(const xrt::device& device, const xrt::uuid& xclbin_id, const qos_type& qos);
+
+  /**
+   * hw_context() - Construct with specific access control
+   *
+   * @param device
+   *  Device where context is created
+   * @param xclbin_id
+   *  UUID of xclbin that should be assigned to HW resources
+   * @param mode
+   *  Access control for the context
+   */
+  XRT_API_EXPORT
+  hw_context(const xrt::device& device, const xrt::uuid& xclbin_id, access_mode mode);
 
   ///@cond
   // Undocumented construction w/o specifying qos
   // Subject to change in default qos value
   hw_context(const xrt::device& device, const xrt::uuid& xclbin_id)
-    : hw_context{device, xclbin_id, static_cast<qos>(0)}
+    : hw_context{device, xclbin_id, access_mode::shared}
   {}
   /// @endcond
 
@@ -92,11 +126,11 @@ public:
   get_xclbin() const;
 
   /**
-   * get_qos() - Get the QOS value of the context
+   * get_mode() - Get the context access mode
    */
   XRT_API_EXPORT
-  qos
-  get_qos() const;
+  access_mode
+  get_mode() const;
 
 public:
   /// @cond

--- a/src/runtime_src/core/include/shim_int.h
+++ b/src/runtime_src/core/include/shim_int.h
@@ -5,13 +5,13 @@
 #define SHIM_INT_H_
 
 #include "core/include/xrt.h"
+#include "core/include/experimental/xrt_hw_context.h"
 #include "core/common/cuidx_type.h"
 
 #include <string>
 
 namespace xrt {
 
-class hw_context;
 class xclbin;
 class uuid;
 
@@ -53,7 +53,10 @@ close_cu_context(xclDeviceHandle handle, const xrt::hw_context& hwctx, xrt_core:
 
 // create_hw_context() -
 uint32_t // ctxhdl aka slotidx
-create_hw_context(xclDeviceHandle handle, const xrt::uuid& xclbin_uuid, uint32_t qos);
+create_hw_context(xclDeviceHandle handle,
+                  const xrt::uuid& xclbin_uuid,
+                  const xrt::hw_context::qos_type& qos,
+                  xrt::hw_context::access_mode mode);
 
 // dsstroy_hw_context() -
 void

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
@@ -2290,7 +2290,7 @@ namespace xclcpuemhal2
 
     // ack = 0 : defines RPC Call is completed with failure status
     // ack = 1 : defines RPC Call is completed with success status
-    // ack = 2 : defines RPC Call is returned with running status. 
+    // ack = 2 : defines RPC Call is returned with running status.
     // Recalling the RPC after a wait if the ack returned is 2.
     do {
       {
@@ -2518,7 +2518,7 @@ namespace xclcpuemhal2
     // Emulation does not yet support multiple xclbins.  Call
     // regular flow.  Default access mode to shared unless explicitly
     // exclusive.
-    auto shared = (hwctx.get_qos() != xrt::hw_context::qos::exclusive);
+    auto shared = (hwctx.get_mode() != xrt::hw_context::access_mode::exclusive);
     auto ctxhdl = static_cast<xcl_hwctx_handle>(hwctx);
     auto cuidx = mCoreDevice->get_cuidx(ctxhdl, cuname);
     xclOpenContext(hwctx.get_xclbin_uuid().get(), cuidx.index, shared);

--- a/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/device_hwemu.h
+++ b/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/device_hwemu.h
@@ -37,9 +37,11 @@ private:
   lookup_query(query::key_type query_key) const;
 
   uint32_t // ctx handle aka slotidx
-  create_hw_context(const xrt::uuid& xclbin_uuid, uint32_t qos) const override
+  create_hw_context(const xrt::uuid& xclbin_uuid,
+                    const xrt::hw_context::qos_type& qos,
+                    xrt::hw_context::access_mode mode) const override
   {
-    return xrt::shim_int::create_hw_context(get_device_handle(), xclbin_uuid, qos);
+    return xrt::shim_int::create_hw_context(get_device_handle(), xclbin_uuid, qos, mode);
   }
 
   void

--- a/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/halapi.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/halapi.cxx
@@ -46,10 +46,13 @@ close_cu_context(xclDeviceHandle handle, const xrt::hw_context& hwctx, xrt_core:
 }
 
 uint32_t // ctxhdl aka slotidx
-create_hw_context(xclDeviceHandle handle, const xrt::uuid& xclbin_uuid, uint32_t qos)
+create_hw_context(xclDeviceHandle handle,
+                  const xrt::uuid& xclbin_uuid,
+                  const xrt::hw_context::qos_type& qos,
+                  xrt::hw_context::access_mode mode)
 {
   auto shim = get_shim_object(handle);
-  return shim->create_hw_context(xclbin_uuid, qos);
+  return shim->create_hw_context(xclbin_uuid, qos, mode);
 }
 
 void

--- a/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.cxx
@@ -927,7 +927,7 @@ namespace xclhwemhal2 {
             launcherArgs += " -qspi-high-image " + sim_path + "/emulation_data/qemu_qspi_high.bin";
           }
 
-          // V70 support: Setting this option, launch_emulator does not set the NOCSIM_DRAM_FILE file, it auto sets the 
+          // V70 support: Setting this option, launch_emulator does not set the NOCSIM_DRAM_FILE file, it auto sets the
           // NOCSIM_MULTI_DRAM_FILE
           if (fs::exists(sim_path + "/emulation_data/noc_memory_config.txt")) {
             launcherArgs += " -noc-memory-config " + sim_path + "/emulation_data/noc_memory_config.txt";
@@ -1099,11 +1099,11 @@ namespace xclhwemhal2 {
     if (xclemulation::config::getInstance()->isFastNocDDRAccessEnabled())
     {
       std::string nocMemSpecFilePath = simPath + "/emulation_data/noc_memory_config.txt";
-      if (fs::exists(nocMemSpecFilePath))        
+      if (fs::exists(nocMemSpecFilePath))
         this->mNocFastAccess.init(nocMemSpecFilePath, simPath);
-    } 
+    }
   }
-  
+
   void HwEmShim::extractEmuData(const std::string &simPath, int binaryCounter, bitStreamArg args)
   {
 
@@ -3270,7 +3270,7 @@ open_cu_context(const xrt::hw_context& hwctx, const std::string& cuname)
   // Emulation does not yet support multiple xclbins.  Call
   // regular flow.  Default access mode to shared unless explicitly
   // exclusive.
-  auto shared = (hwctx.get_qos() != xrt::hw_context::qos::exclusive);
+  auto shared = (hwctx.get_mode() != xrt::hw_context::access_mode::exclusive);
   auto ctxhdl = static_cast<xcl_hwctx_handle>(hwctx);
   auto cuidx = mCoreDevice->get_cuidx(ctxhdl, cuname);
   xclOpenContext(hwctx.get_xclbin_uuid().get(), cuidx.index, shared);
@@ -3290,7 +3290,7 @@ close_cu_context(const xrt::hw_context& hwctx, xrt_core::cuidx_type cuidx)
 // Once properly implemented, this API should throw on error
 uint32_t // ctx handle aka slot idx
 HwEmShim::
-create_hw_context(const xrt::uuid& xclbin_uuid, uint32_t qos)
+create_hw_context(const xrt::uuid&, const xrt::hw_context::qos_type&, xrt::hw_context::access_mode)
 {
   // Explicit hardware contexts are not yet supported
   throw xrt_core::ishim::not_supported_error{__func__};

--- a/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.h
+++ b/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.h
@@ -145,7 +145,7 @@ using addr_type = uint64_t;
 
       // aka xclCreateHWContext, internal shim API for native C++ applications only
       uint32_t // ctx handle aka slot idx
-      create_hw_context(const xrt::uuid& xclbin_uuid, uint32_t qos);
+      create_hw_context(const xrt::uuid&, const xrt::hw_context::qos_type&, xrt::hw_context::access_mode);
 
       // aka xclDestroyHWContext, internal shim API for native C++ applications only
       void

--- a/src/runtime_src/core/pcie/linux/device_linux.h
+++ b/src/runtime_src/core/pcie/linux/device_linux.h
@@ -72,9 +72,11 @@ public:
   import_bo(pid_t pid, xclBufferExportHandle ehdl) override;
 
   uint32_t // ctx handle aka slotidx
-  create_hw_context(const xrt::uuid& xclbin_uuid, uint32_t qos) const override
+  create_hw_context(const xrt::uuid& xclbin_uuid,
+                    const xrt::hw_context::qos_type& qos,
+                    xrt::hw_context::access_mode mode) const override
   {
-    return xrt::shim_int::create_hw_context(get_device_handle(), xclbin_uuid, qos);
+    return xrt::shim_int::create_hw_context(get_device_handle(), xclbin_uuid, qos, mode);
   }
 
   void

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -2168,7 +2168,7 @@ open_cu_context(const xrt::hw_context& hwctx, const std::string& cuname)
   // Alveo Linux PCIE does not yet support multiple xclbins.  Call
   // regular flow.  Default access mode to shared unless explicitly
   // exclusive.
-  auto shared = (hwctx.get_qos() != xrt::hw_context::qos::exclusive);
+  auto shared = (hwctx.get_mode() != xrt::hw_context::access_mode::exclusive);
   auto ctxhdl = static_cast<xcl_hwctx_handle>(hwctx);
   auto cuidx = mCoreDevice->get_cuidx(ctxhdl, cuname);
   xclOpenContext(hwctx.get_xclbin_uuid().get(), cuidx.index, shared);
@@ -2189,7 +2189,9 @@ close_cu_context(const xrt::hw_context& hwctx, xrt_core::cuidx_type cuidx)
 // The context handle is 1:1 with a slot idx
 uint32_t
 shim::
-create_hw_context(const xrt::uuid& xclbin_uuid, uint32_t qos)
+create_hw_context(const xrt::uuid& xclbin_uuid,
+                  const xrt::hw_context::qos_type& qos,
+                  xrt::hw_context::access_mode mode)
 {
   // Explicit hardware contexts are not supported in Alveo.
   throw xrt_core::ishim::not_supported_error{__func__};
@@ -2240,10 +2242,13 @@ close_cu_context(xclDeviceHandle handle, const xrt::hw_context& hwctx, xrt_core:
 }
 
 uint32_t // ctxhdl aka slotidx
-create_hw_context(xclDeviceHandle handle, const xrt::uuid& xclbin_uuid, uint32_t qos)
+create_hw_context(xclDeviceHandle handle,
+                  const xrt::uuid& xclbin_uuid,
+                  const xrt::hw_context::qos_type& qos,
+                  const xrt::hw_context::access_mode mode)
 {
   auto shim = get_shim_object(handle);
-  return shim->create_hw_context(xclbin_uuid, qos);
+  return shim->create_hw_context(xclbin_uuid, qos, mode);
 }
 
 void

--- a/src/runtime_src/core/pcie/linux/shim.h
+++ b/src/runtime_src/core/pcie/linux/shim.h
@@ -150,7 +150,7 @@ public:
   close_cu_context(const xrt::hw_context& hwctx, xrt_core::cuidx_type cuidx);
 
   uint32_t // ctx handle aka slot idx
-  create_hw_context(const xrt::uuid& xclbin_uuid, uint32_t qos);
+  create_hw_context(const xrt::uuid&, const xrt::hw_context::qos_type&, xrt::hw_context::access_mode);
 
   void
   destroy_hw_context(uint32_t ctxhdl);

--- a/src/runtime_src/core/pcie/noop/device_noop.h
+++ b/src/runtime_src/core/pcie/noop/device_noop.h
@@ -25,9 +25,9 @@ private:
   lookup_query(query::key_type query_key) const override;
 
   uint32_t // ctx handle aka slotidx
-  create_hw_context(const xrt::uuid& xclbin_uuid, uint32_t qos) const override
+  create_hw_context(const xrt::uuid& xclbin_uuid, const xrt::hw_context::qos_type& qos, xrt::hw_context::access_mode mode) const override
   {
-    return xrt::shim_int::create_hw_context(get_device_handle(), xclbin_uuid, qos);
+    return xrt::shim_int::create_hw_context(get_device_handle(), xclbin_uuid, qos, mode);
   }
 
   void

--- a/src/runtime_src/core/pcie/noop/shim.cpp
+++ b/src/runtime_src/core/pcie/noop/shim.cpp
@@ -169,7 +169,7 @@ public:
   }
 
   xcl_hwctx_handle
-  create_hw_context(const xrt::uuid& xid, uint32_t qos)
+  create_hw_context(const xrt::uuid& xid)
   {
     std::lock_guard lk(m_mutex);
     auto itr = m_xclbins.find(xid);
@@ -489,7 +489,7 @@ struct shim
     auto xclbin = m_core_device->get_xclbin(top->m_header.uuid);
     m_pldev->register_xclbin(xclbin);
     auto uuid = xclbin.get_uuid();
-    m_load_xclbin_slots[uuid] = create_hw_context(uuid, 0);
+    m_load_xclbin_slots[uuid] = create_hw_context(uuid);
     return 0;
   }
 
@@ -536,12 +536,12 @@ struct shim
   }
 
   uint32_t // ctxhdl aka slotidx
-  create_hw_context(const xrt::uuid& xclbin_uuid, uint32_t qos)
+  create_hw_context(const xrt::uuid& xclbin_uuid)
   {
     if (m_load_xclbin_slots.find(xclbin_uuid) != m_load_xclbin_slots.end())
       throw xrt_core::ishim::not_supported_error(__func__);
 
-    return m_pldev->create_hw_context(xclbin_uuid, qos);
+    return m_pldev->create_hw_context(xclbin_uuid);
   }
 
   void
@@ -621,10 +621,13 @@ close_cu_context(xclDeviceHandle handle, const xrt::hw_context& hwctx, xrt_core:
 }
 
 uint32_t // ctxhdl aka slotidx
-create_hw_context(xclDeviceHandle handle, const xrt::uuid& xclbin_uuid, uint32_t qos)
+create_hw_context(xclDeviceHandle handle,
+                  const xrt::uuid& xclbin_uuid,
+                  const xrt::hw_context::qos_type&,
+                  xrt::hw_context::access_mode)
 {
   auto shim = get_shim_object(handle);
-  return shim->create_hw_context(xclbin_uuid, qos);
+  return shim->create_hw_context(xclbin_uuid);
 }
 
 void

--- a/src/runtime_src/core/pcie/windows/alveo/shim.cpp
+++ b/src/runtime_src/core/pcie/windows/alveo/shim.cpp
@@ -1387,7 +1387,7 @@ done:
     // Alveo PCIE does not yet support multiple xclbins.  Call
     // regular flow.  Default access mode to shared unless explicitly
     // exclusive.
-    auto shared = (hwctx.get_qos() != xrt::hw_context::qos::exclusive);
+    auto shared = (hwctx.get_mode() != xrt::hw_context::access_mode::exclusive);
     auto ctxhdl = static_cast<xcl_hwctx_handle>(hwctx);
     auto cuidx = m_core_device->get_cuidx(ctxhdl, cuname);
     open_cu_context(hwctx.get_xclbin_uuid().get(), cuidx.index, shared);


### PR DESCRIPTION
#### Problem solved by the commit
Allow applications to create a hwctx specifying the necessary QoS.
This is *very* preliminary experimental support subject to change w/o
warning.

#### How problem was solved, alternative solutions (if any) and why they were rejected
QoS for a hwctx is supposed to guide the resource solver to find
available HW resources sufficient to statisfy the specified QoS or
fail if no resources are available.  For platforms that support
multiple programmable regions (slots), the QoS can be used to
determine if an existing slot can be shared with another context or if
a new region (slot) needs to be programmed.

QoS is a set of metrics defined as a key-value pair represented as
std::map.  The accepted keys are communicated internally in this
version and their value type (represented as uint32_t) is also
internally documented.

The QoS is bound to evolve as more platform drivers support our
concept of xclbin sharing per QoS specifications, so view this PR as
work-in-progress trial feature until we determine exactly what metrics
are needed can be supported.

#### Risks (if any) associated the changes in the commit
This PR changes the type of the QoS parameter and adds a second
parameter for legacy support of CU shared/exclusive access mode.  The
vast number of files changed is due to the extra access mode parameter
and the type changes of the QoS paramter. The QoS type is aliased in
one place so that future change to some more intelligent
representation should trigger ripple effects.

#### What has been tested and how, request additional testing if necessary
The changes has been tested with standard hw regression tests that
exercise legacy OpenCL test cases.

#### Documentation impact (if any)
QoS is internal for now
