### PR TITLE
Support DPU Designs for profiling

### DIFF
--- a/src/runtime_src/core/include/xdp/add.h
+++ b/src/runtime_src/core/include/xdp/add.h
@@ -26,7 +26,7 @@ namespace AXI_LITE {
 // These are the actual physical offsets of the 32-bit registers in
 // the ADD IP accessible over the AXI-Lite connection.  If using
 // xclRead or xclWrite, these offsets are used.
-constexpr int STATUS = 0x0;
+constexpr unsigned int STATUS = 0x0;
 
 } // end namespace AXI_LITE
 

--- a/src/runtime_src/core/include/xdp/aim.h
+++ b/src/runtime_src/core/include/xdp/aim.h
@@ -33,39 +33,39 @@ namespace AXI_LITE {
 // the AIM IP accessible over the AXI-Lite connection.  If using 
 // xclRead or xclWrite, these offsets are used.  The upper 32-bits
 // of each register require a separate offset and access.
-constexpr int CONTROL                  = 0x08;
-constexpr int TRACE_CTRL               = 0x10;
-constexpr int SAMPLE                   = 0x20; // Capture current values
-constexpr int WRITE_BYTES              = 0x80;
-constexpr int WRITE_TRANX              = 0x84;
-constexpr int WRITE_LATENCY            = 0x88;
-constexpr int READ_BYTES               = 0x8C;
-constexpr int READ_TRANX               = 0x90;
-constexpr int READ_LATENCY             = 0x94;
-constexpr int MIN_MAX_WRITE_LATENCY    = 0x98; // Unused
-constexpr int MIN_MAX_READ_LATENCY     = 0x9C; // Unused
-constexpr int OUTSTANDING_COUNTS       = 0xA0;
-constexpr int LAST_WRITE_ADDRESS       = 0xA4;
-constexpr int LAST_WRITE_DATA          = 0xA8;
-constexpr int LAST_READ_ADDRESS        = 0xAC;
-constexpr int LAST_READ_DATA           = 0xB0;
-constexpr int READ_BUSY_CYCLES         = 0xB4;
-constexpr int WRITE_BUSY_CYCLES        = 0xB8;
-constexpr int WRITE_BYTES_UPPER        = 0xC0;
-constexpr int WRITE_TRANX_UPPER        = 0xC4;
-constexpr int WRITE_LATENCY_UPPER      = 0xC8;
-constexpr int READ_BYTES_UPPER         = 0xCC;
-constexpr int READ_TRANX_UPPER         = 0xD0;
-constexpr int READ_LATENCY_UPPER       = 0xD4;
+constexpr unsigned int CONTROL                  = 0x08;
+constexpr unsigned int TRACE_CTRL               = 0x10;
+constexpr unsigned int SAMPLE                   = 0x20; // Capture current values
+constexpr unsigned int WRITE_BYTES              = 0x80;
+constexpr unsigned int WRITE_TRANX              = 0x84;
+constexpr unsigned int WRITE_LATENCY            = 0x88;
+constexpr unsigned int READ_BYTES               = 0x8C;
+constexpr unsigned int READ_TRANX               = 0x90;
+constexpr unsigned int READ_LATENCY             = 0x94;
+constexpr unsigned int MIN_MAX_WRITE_LATENCY    = 0x98; // Unused
+constexpr unsigned int MIN_MAX_READ_LATENCY     = 0x9C; // Unused
+constexpr unsigned int OUTSTANDING_COUNTS       = 0xA0;
+constexpr unsigned int LAST_WRITE_ADDRESS       = 0xA4;
+constexpr unsigned int LAST_WRITE_DATA          = 0xA8;
+constexpr unsigned int LAST_READ_ADDRESS        = 0xAC;
+constexpr unsigned int LAST_READ_DATA           = 0xB0;
+constexpr unsigned int READ_BUSY_CYCLES         = 0xB4;
+constexpr unsigned int WRITE_BUSY_CYCLES        = 0xB8;
+constexpr unsigned int WRITE_BYTES_UPPER        = 0xC0;
+constexpr unsigned int WRITE_TRANX_UPPER        = 0xC4;
+constexpr unsigned int WRITE_LATENCY_UPPER      = 0xC8;
+constexpr unsigned int READ_BYTES_UPPER         = 0xCC;
+constexpr unsigned int READ_TRANX_UPPER         = 0xD0;
+constexpr unsigned int READ_LATENCY_UPPER       = 0xD4;
 // Reserved for high 32-bits of MIN_MAX_WRITE_LATENCY - 0xD8
 // Reserved for high 32-bits of MIN_MAX_READ_LATENCY - 0xDC
-constexpr int OUTSTANDING_COUNTS_UPPER = 0xE0;
-constexpr int LAST_WRITE_ADDRESS_UPPER = 0xE4;
-constexpr int LAST_WRITE_DATA_UPPER    = 0xE8;
-constexpr int LAST_READ_ADDRESS_UPPER  = 0xEC;
-constexpr int LAST_READ_DATA_UPPER     = 0xF0;
-constexpr int READ_BUSY_CYCLES_UPPER   = 0xF4;
-constexpr int WRITE_BUSY_CYCLES_UPPER  = 0xF8;
+constexpr unsigned int OUTSTANDING_COUNTS_UPPER = 0xE0;
+constexpr unsigned int LAST_WRITE_ADDRESS_UPPER = 0xE4;
+constexpr unsigned int LAST_WRITE_DATA_UPPER    = 0xE8;
+constexpr unsigned int LAST_READ_ADDRESS_UPPER  = 0xEC;
+constexpr unsigned int LAST_READ_DATA_UPPER     = 0xF0;
+constexpr unsigned int READ_BUSY_CYCLES_UPPER   = 0xF4;
+constexpr unsigned int WRITE_BUSY_CYCLES_UPPER  = 0xF8;
 } // end namespace AXI_LITE
 
 namespace sysfs {
@@ -109,11 +109,12 @@ constexpr int READ_LAST_DATA     = 8;
 namespace mask {
 // These are masks on the property of the IP that give information
 // on the specific instance.
-constexpr int PROPERTY_HOST     = 0x4;
-constexpr int PROPERTY_64BIT    = 0x8;
-constexpr int CR_COUNTER_RESET  = 0x00000002;
-constexpr int CR_COUNTER_ENABLE = 0x00000001;
-constexpr int TRACE_CTRL        = 0x00000003;
+constexpr unsigned int PROPERTY_HOST            = 0x4;
+constexpr unsigned int PROPERTY_64BIT           = 0x8;
+constexpr unsigned int PROPERTY_COARSE_MODE_OFF = 0x10;
+constexpr unsigned int CR_COUNTER_RESET  = 0x00000002;
+constexpr unsigned int CR_COUNTER_ENABLE = 0x00000001;
+constexpr unsigned int TRACE_CTRL        = 0x00000003;
 } // end namespace mask
 
 } // end namespace xdp::IP::AIM

--- a/src/runtime_src/core/include/xdp/am.h
+++ b/src/runtime_src/core/include/xdp/am.h
@@ -33,29 +33,29 @@ namespace AXI_LITE {
 // the AM IP accessible over the AXI-Lite connection.  If using
 // xclRead or xclWrite, these offsets are used.  The upper 32-bits
 // of each register require a separate offset and access.
-constexpr int CONTROL                    = 0x08;
-constexpr int TRACE_CTRL                 = 0x10;
-constexpr int SAMPLE                     = 0x20;
-constexpr int EXECUTION_COUNT            = 0x80;
-constexpr int EXECUTION_CYCLES           = 0x84;
-constexpr int STALL_INT                  = 0x88;
-constexpr int STALL_STR                  = 0x8C;
-constexpr int STALL_EXT                  = 0x90;
-constexpr int MIN_EXECUTION_CYCLES       = 0x94;
-constexpr int MAX_EXECUTION_CYCLES       = 0x98;
-constexpr int TOTAL_CU_START             = 0x9C;
-constexpr int EXECUTION_COUNT_UPPER      = 0xA0;
-constexpr int EXECUTION_CYCLES_UPPER     = 0xA4;
-constexpr int STALL_INT_UPPER            = 0xA8;
-constexpr int STALL_STR_UPPER            = 0xAC;
-constexpr int STALL_EXT_UPPER            = 0xB0;
-constexpr int MIN_EXECUTION_CYCLES_UPPER = 0xB4;
-constexpr int MAX_EXECUTION_CYCLES_UPPER = 0xB8;
-constexpr int TOTAL_CU_START_UPPER       = 0xBC;
-constexpr int BUSY_CYCLES                = 0xC0;
-constexpr int BUSY_CYCLES_UPPER          = 0xC4;
-constexpr int MAX_PARALLEL_ITER          = 0xC8;
-constexpr int MAX_PARALLEL_ITER_UPPER    = 0xCC;
+constexpr unsigned int CONTROL                    = 0x08;
+constexpr unsigned int TRACE_CTRL                 = 0x10;
+constexpr unsigned int SAMPLE                     = 0x20;
+constexpr unsigned int EXECUTION_COUNT            = 0x80;
+constexpr unsigned int EXECUTION_CYCLES           = 0x84;
+constexpr unsigned int STALL_INT                  = 0x88;
+constexpr unsigned int STALL_STR                  = 0x8C;
+constexpr unsigned int STALL_EXT                  = 0x90;
+constexpr unsigned int MIN_EXECUTION_CYCLES       = 0x94;
+constexpr unsigned int MAX_EXECUTION_CYCLES       = 0x98;
+constexpr unsigned int TOTAL_CU_START             = 0x9C;
+constexpr unsigned int EXECUTION_COUNT_UPPER      = 0xA0;
+constexpr unsigned int EXECUTION_CYCLES_UPPER     = 0xA4;
+constexpr unsigned int STALL_INT_UPPER            = 0xA8;
+constexpr unsigned int STALL_STR_UPPER            = 0xAC;
+constexpr unsigned int STALL_EXT_UPPER            = 0xB0;
+constexpr unsigned int MIN_EXECUTION_CYCLES_UPPER = 0xB4;
+constexpr unsigned int MAX_EXECUTION_CYCLES_UPPER = 0xB8;
+constexpr unsigned int TOTAL_CU_START_UPPER       = 0xBC;
+constexpr unsigned int BUSY_CYCLES                = 0xC0;
+constexpr unsigned int BUSY_CYCLES_UPPER          = 0xC4;
+constexpr unsigned int MAX_PARALLEL_ITER          = 0xC8;
+constexpr unsigned int MAX_PARALLEL_ITER_UPPER    = 0xCC;
 } // end namespace AXI_LITE
 
 namespace sysfs {
@@ -94,11 +94,11 @@ constexpr int TOTAL_CU_START       = 7;
 namespace mask {
 // These are the masks to be applied to the properties field of the AM
 // to determine a particular instance's configuration.
-constexpr int PROPERTY_64BIT     = 0x8;
-constexpr int PROPERTY_STALL     = 0x4;
-constexpr int COUNTER_RESET      = 0x00000002;
-constexpr int DATAFLOW_EN        = 0x00000008;
-constexpr int TRACE_STALL_SELECT = 0x0000001c;
+constexpr unsigned int PROPERTY_64BIT     = 0x8;
+constexpr unsigned int PROPERTY_STALL     = 0x4;
+constexpr unsigned int COUNTER_RESET      = 0x00000002;
+constexpr unsigned int DATAFLOW_EN        = 0x00000008;
+constexpr unsigned int TRACE_STALL_SELECT = 0x0000001c;
 } // end namespace mask 
 
 } // end namespace xdp::IP::AM

--- a/src/runtime_src/core/include/xdp/asm.h
+++ b/src/runtime_src/core/include/xdp/asm.h
@@ -30,13 +30,13 @@ namespace AXI_LITE {
 // These are the actual physical offsets of the 64-bit registers in
 // the ASM IP accessible over the AXI-Lite connection.  If using
 // xclRead or xclWrite, these offsets are used.
-constexpr int CONTROL       = 0x00;
-constexpr int SAMPLE        = 0x20;
-constexpr int NUM_TRANX     = 0x80;
-constexpr int DATA_BYTES    = 0x88;
-constexpr int BUSY_CYCLES   = 0x90;
-constexpr int STALL_CYCLES  = 0x98;
-constexpr int STARVE_CYCLES = 0xA0;
+constexpr unsigned int CONTROL       = 0x00;
+constexpr unsigned int SAMPLE        = 0x20;
+constexpr unsigned int NUM_TRANX     = 0x80;
+constexpr unsigned int DATA_BYTES    = 0x88;
+constexpr unsigned int BUSY_CYCLES   = 0x90;
+constexpr unsigned int STALL_CYCLES  = 0x98;
+constexpr unsigned int STARVE_CYCLES = 0xA0;
 } // end namespace AXI_LITE
 
 namespace sysfs {
@@ -51,9 +51,9 @@ constexpr int STARVE_CYCLES = 4;
 } // end namespace sysfs
 
 namespace mask {
-constexpr int COUNTER_RESET = 0x00000001;
-constexpr int TRACE_ENABLE  = 0x00000002;
-constexpr int TRACE_CTRL    = 0x2;
+constexpr unsigned int COUNTER_RESET = 0x00000001;
+constexpr unsigned int TRACE_ENABLE  = 0x00000002;
+constexpr unsigned int TRACE_CTRL    = 0x2;
 } // end namespace mask
 
 } // end namespace xdp::IP::ASM

--- a/src/runtime_src/core/include/xdp/fifo.h
+++ b/src/runtime_src/core/include/xdp/fifo.h
@@ -28,7 +28,7 @@ namespace AXI_LITE {
 // On some devices (like edge) we cannot transfer values via
 // the AXI-full connection.  Instead, we need to read the
 // contents of the FIFO one-by-one over the AXI-Lite connection
-constexpr int RDFD = 0x1000;
+constexpr unsigned int RDFD = 0x1000;
 } // end namespace AXI_LITE
 
 } // end namespace xdp::IP::FIFO

--- a/src/runtime_src/core/include/xdp/lapc.h
+++ b/src/runtime_src/core/include/xdp/lapc.h
@@ -32,15 +32,15 @@ namespace AXI_LITE {
 // These are the actual physical offsets of the 32-bit registers in
 // the LAPC IP accessible over the AXI-Lite connection.  If using
 // xclRead or xclWrite, these offsets are used.
-constexpr int STATUS              = 0x0;
-constexpr int CUMULATIVE_STATUS_0 = 0x100;
-constexpr int CUMULATIVE_STATUS_1 = 0x104;
-constexpr int CUMULATIVE_STATUS_2 = 0x108;
-constexpr int CUMULATIVE_STATUS_3 = 0x10c;
-constexpr int SNAPSHOT_STATUS_0   = 0x200;
-constexpr int SNAPSHOT_STATUS_1   = 0x204;
-constexpr int SNAPSHOT_STATUS_2   = 0x208;
-constexpr int SNAPSHOT_STATUS_3   = 0x20c;
+constexpr unsigned int STATUS              = 0x0;
+constexpr unsigned int CUMULATIVE_STATUS_0 = 0x100;
+constexpr unsigned int CUMULATIVE_STATUS_1 = 0x104;
+constexpr unsigned int CUMULATIVE_STATUS_2 = 0x108;
+constexpr unsigned int CUMULATIVE_STATUS_3 = 0x10c;
+constexpr unsigned int SNAPSHOT_STATUS_0   = 0x200;
+constexpr unsigned int SNAPSHOT_STATUS_1   = 0x204;
+constexpr unsigned int SNAPSHOT_STATUS_2   = 0x208;
+constexpr unsigned int SNAPSHOT_STATUS_3   = 0x20c;
 } // end namespace AXI_LITE
 
 namespace sysfs {

--- a/src/runtime_src/core/include/xdp/spc.h
+++ b/src/runtime_src/core/include/xdp/spc.h
@@ -30,9 +30,9 @@ namespace AXI_LITE {
 // These are the actual physical offsets of the 32-bit registers in
 // the SPC IP accessible over the AXI-Lite connection.  If using
 // xclRead or xclWrite, these offsets are used.
-constexpr int PC_ASSERTED = 0x0;
-constexpr int CURRENT_PC  = 0x100;
-constexpr int SNAPSHOT_PC = 0x200;
+constexpr unsigned int PC_ASSERTED = 0x0;
+constexpr unsigned int CURRENT_PC  = 0x100;
+constexpr unsigned int SNAPSHOT_PC = 0x200;
 } // end namespace AXI_LITE
 
 namespace sysfs {

--- a/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.cpp
+++ b/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.cpp
@@ -398,6 +398,7 @@ void AIETraceOffload::checkCircularBufferSupport()
         << " Requested : " << circ_buf_cur_rate_plio ;
     xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", msg.str());
   }
+  xrt_core::message::send(xrt_core::message::severity_level::info, "XRT", AIE_TRACE_CIRC_BUF_EN);
 }
 
 void AIETraceOffload::startOffload()

--- a/src/runtime_src/xdp/profile/device/aim.cpp
+++ b/src/runtime_src/xdp/profile/device/aim.cpp
@@ -196,5 +196,10 @@ void AIM::showProperties()
     ProfileIP::showProperties();
 }
 
+bool AIM::hasCoarseMode() const
+{
+    return ((properties & IP::AIM::mask::PROPERTY_COARSE_MODE_OFF) ? false : true);
+}
+
 }   // namespace xdp
 

--- a/src/runtime_src/xdp/profile/device/aim.h
+++ b/src/runtime_src/xdp/profile/device/aim.h
@@ -70,6 +70,8 @@ public:
     bool isHostMonitor() const ;
     bool isShellMonitor();
     bool has64bit() const ;
+    XDP_EXPORT
+    bool hasCoarseMode() const ;
 
     virtual size_t triggerTrace(uint32_t traceOption /*startTrigger*/);
 

--- a/src/runtime_src/xdp/profile/device/device_intf.h
+++ b/src/runtime_src/xdp/profile/device/device_intf.h
@@ -79,10 +79,19 @@ class DeviceIntf {
     XDP_EXPORT
     uint64_t getFifoSize();
 
+    // Axi Interface Monitor
     bool isHostAIM(uint32_t index) {
       return mAimList[index]->isHostMonitor();
     }
-    
+    // Turn off coarse mode if any of the kernel AIMs can't support it
+    bool supportsCoarseModeAIM() {
+      for (auto mon : mAimList) {
+        if (!mon->isHostMonitor() && !mon->hasCoarseMode()  )
+          return false;
+      }
+      return true;
+    }
+
     // Counters
     XDP_EXPORT
     size_t startCounters();

--- a/src/runtime_src/xdp/profile/device/tracedefs.h
+++ b/src/runtime_src/xdp/profile/device/tracedefs.h
@@ -54,6 +54,9 @@
 // Use some arbitrary large number here
 #define TS2MM_QUEUE_SZ_WARN_THRESHOLD 5000
 
+// In some cases, we cannot use coarse mode
+#define COARSE_MODE_UNSUPPORTED "Coarse mode cannot be enabled. Defaulting to fine mode. Please check compilation for details."
+
 #define FIFO_WARN_MSG "Trace FIFO is full because of too many events. Device trace could be incomplete. Suggested fixes:\n\
 1. Use larger FIFO size or DDR/HBM bank as 'trace_memory' in linking options.\n\
 2. Use 'coarse' option for device_trace and/or turn off stall_trace in runtime settings."
@@ -88,6 +91,7 @@ trace settings."
 #define AIE_TRACE_WARN_REUSE_PERIODIC  "AIE Trace Buffer reuse only supported with periodic offload."
 #define AIE_TRACE_WARN_REUSE_GMIO      "AIE Trace buffer reuse is not supported on GMIO trace."
 #define AIE_TRACE_PERIODIC_OFFLOAD_UNSUPPORTED "Continuous offload of AIE Trace is not supported for GMIO mode. So, AIE Trace for GMIO mode will be offloaded only at the end of application."
+#define AIE_TRACE_CIRC_BUF_EN          "Circular buffers enabled for AIE trace."
 
 // Trace file Dump Settings and Warnings
 #define MIN_TRACE_DUMP_INTERVAL_S 1

--- a/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
@@ -305,20 +305,29 @@ namespace xdp {
     // Set up the hardware trace option
     uint32_t traceOption = 0 ;
     
-    // Bit 1: 1 = Coarse mode, 0 = Fine mode 
-    if (data_transfer_trace == "coarse") traceOption |= 0x1 ;
+    // Bit 1: 1 = Coarse mode, 0 = Fine mode
+    if (data_transfer_trace == "coarse") {
+      if (!devInterface->supportsCoarseModeAIM())
+        xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", COARSE_MODE_UNSUPPORTED);
+      else
+        traceOption |= 0x1 ;
+    }
     
     // Bit 2: 1 = Device trace enabled, 0 = Device trace disabled
-    if (data_transfer_trace != "off" && data_transfer_trace != "accel")    traceOption |= 0x2 ;
+    if (data_transfer_trace != "off" && data_transfer_trace != "accel")
+      traceOption |= 0x2 ;
     
     // Bit 3: 1 = Pipe stalls enabled, 0 = Pipe stalls disabled
-    if (stall_trace == "pipe" || stall_trace == "all") traceOption |= 0x4 ;
+    if (stall_trace == "pipe" || stall_trace == "all")
+      traceOption |= 0x4 ;
     
     // Bit 4: 1 = Dataflow stalls enabled, 0 = Dataflow stalls disabled
-    if (stall_trace == "dataflow" || stall_trace == "all") traceOption |= 0x8;
+    if (stall_trace == "dataflow" || stall_trace == "all")
+      traceOption |= 0x8;
     
     // Bit 5: 1 = Memory stalls enabled, 0 = Memory stalls disabled
-    if (stall_trace == "memory" || stall_trace == "all") traceOption |= 0x10 ;
+    if (stall_trace == "memory" || stall_trace == "all")
+      traceOption |= 0x10 ;
 
     devInterface->startTrace(traceOption) ;
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
1. DPU designs can't support coarse mode in hw.  V++ will communicate this info through a new property and XRT can use that to turn off coarse mode.
2. Add an info message when circular buffers are enabled in aie trace
3. Use unsigned int for IP offsets and masks
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1130411
CR-1137124
#### How problem was solved, alternative solutions (if any) and why they were rejected
A separate change in linker will ensure that coarse mode is turned off when we can't support it.
#### Risks (if any) associated the changes in the commit
Med
#### What has been tested and how, request additional testing if necessary
Tested the new property on hw design
#### Documentation impact (if any)
