### PR TITLE
Fix CU context manager to be hwctx aware

### DIFF
--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -517,13 +517,10 @@ public:
   {
     // - IP index is unique per device
     // - IP index is unique per domain
-    // - IP index is unique per slot
+    // - IP index is unique per slot (is this true for PS kernels in PL/PS xclbin?)
     // - IP index can be shared between hwctx, provided hwctx refer
     //   to same slot
-    // - A slot can contain only one domain type of CUs
-    //
-    // In 2022.2, before true support for multi-xclbin, it is assumed
-    // that hwctx referring to same xclbin also shares the same ctxhdl.
+    // - A slot can contain only one domain type of CUs (PL/PS xclbin ??)
     //
     // For cases (drivers) that support multi-xclbin and sharing it is
     // assumed that each hwctx is unique and has a unique ctx handle,


### PR DESCRIPTION
#### Problem solved by the commit
For platforms that support multi-xclbin and/or multi hardware contexts
for same or different xclbin, each unique hardware context must open
its corresponding compute unit contexts.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
The reason for the changes is xocl adding support for creating
multiple hardware contexts for same xclbin.  This exposed a bug in
the compute unit context handing where the context manager did not
differentiate between different context.  This lead to compute units
contexts being closed prematurely during destruction of first hardware
context.

#### How problem was solved, alternative solutions (if any) and why they were rejected
The changes in this PR manages compute unit context per hwctx and
calls open_cu_context for each used compute unit within a hardware
context regardless of the hardware contexts referring to same physical
hardware slot (something user space XRT doesn't know or care about).

#### Risks (if any) associated the changes in the commit
#### What has been tested and how, request additional testing if necessary
Testing was done with standard opencl hw regression tests.

#### Documentation impact (if any)
No end-user changes.