### PR TITLE
CR-1136416 Dumped the deadlock message on to the console and created …

### DIFF
--- a/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/debug.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/debug.cxx
@@ -69,6 +69,7 @@ namespace xclhwemhal2
                                               "HLS_PRINT",
                                               "Exiting xsim",
                                               "FATAL_ERROR"};
+
   constexpr auto kMaxTimeToConnectSimulator = 300;  // in seconds
 
   void HwEmShim::readDebugIpLayout(const std::string debugFileName)
@@ -311,14 +312,16 @@ namespace xclhwemhal2
         std::lock_guard<std::mutex> guard(mPrintMessagesLock);
         if (get_simulator_started() == false) 
           return;
+
+        dumpDeadlockMessages();
         // Any status message found in parse log file?
-        lParseLog.parseLog();         
+        lParseLog.parseLog();
+
         parseCount++;
         if (parseCount%5 == 0) {
           std::this_thread::sleep_for(5s);
         }
       }
-      
     } //while end.
   }
 } // namespace xclhwemhal2

--- a/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.cxx
@@ -230,6 +230,36 @@ namespace xclhwemhal2 {
     }
   }
 
+  void HwEmShim::dumpDeadlockMessages()
+  {
+
+    if (!xrt_core::config::get_pl_deadlock_detection())
+      return;
+    
+    std::string simPath = getSimPath();
+    std::string content = loadFileContentsToString(simPath + "/kernel_deadlock_diagnosis.rpt");
+
+    if (content.find("start to dump deadlock path") != std::string::npos)
+    {
+      if (std::find(parsedMsgs.begin(), parsedMsgs.end(), content) == parsedMsgs.end())
+      {
+        logMessage(content);
+        parsedMsgs.push_back(content);
+      }
+
+      char path[FILENAME_MAX];
+      size_t size = MAXPATHLEN;
+      char *pPath = GetCurrentDir(path, size);
+
+      if (pPath)
+      {
+        std::string deadlockReportFile = simPath + "/kernel_deadlock_diagnosis.rpt";
+        std::string destPath = std::string(path) + "/pl_deadlock_diagnosis.txt";
+        systemUtil::makeSystemCall(deadlockReportFile, systemUtil::systemOperation::COPY, destPath, std::to_string(__LINE__));
+      }
+    }
+  }
+
   void HwEmShim::parseSimulateLog ()
   {
     std::string simPath = getSimPath();

--- a/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.h
+++ b/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.h
@@ -302,6 +302,7 @@ using addr_type = uint64_t;
       //CR-1120700
       int parseLog();
       void parseSimulateLog();
+      void dumpDeadlockMessages();
       void setSimPath(std::string simPath) { sim_path = simPath; }
       std::string getSimPath () { return sim_path; }
       bool isHostOnlyBuffer(const struct xclemulation::drm_xocl_bo *bo) {


### PR DESCRIPTION
CR-1136416 Dumped the deadlock message on to the console and createdthe file pl_deadlock_diagnosis.txt as requested in application path.

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
Its a new request to dump the HLS kernel deadlock message on the user console and create a file using that message to show that as part of the vitis analyzer

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
This is part of the new PR PL deadlock detection

#### How problem was solved, alternative solutions (if any) and why they were rejected
Its a enhancement

#### Risks (if any) associated the changes in the commit
No

#### What has been tested and how, request additional testing if necessary
tested the deadlock detection designs 

#### Documentation impact (if any)
No
