### PR TITLE
Added support for XRT scheduling of PS kernels. 

### DIFF
--- a/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.cpp
+++ b/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.cpp
@@ -26,6 +26,8 @@
 #include "xdp/profile/device/aie_trace/aie_trace_logger.h"
 #include "xdp/profile/device/aie_trace/aie_trace_offload.h"
 #include "xdp/profile/device/device_intf.h"
+#include "core/include/xrt/xrt_kernel.h"
+#include "xdp/profile/plugin/aie_trace_new/x86/aie_trace_kernel_config.h"
 
 /*
  * XRT_NATIVE_BUILD is set only for x86 builds
@@ -69,9 +71,68 @@ AIETraceOffload::~AIETraceOffload()
 {
   stopOffload();
   if (offloadThread.joinable()) {
-    offloadThread.join();
+  offloadThread.join();
   }
 }
+
+bool AIETraceOffload::setupPSKernel() {
+
+  auto spdevice = xrt_core::get_userpf_device(deviceHandle);
+  auto device = xrt::device(spdevice);
+
+  auto uuid = device.get_xclbin_uuid();
+  auto gmio_kernel = xrt::kernel(device, uuid.get(), "aie_trace_gmio");
+
+
+  std::size_t total_size = sizeof(xdp::built_in::GMIOConfiguration) + sizeof(xdp::built_in::GMIOBuffer[numStream-1]);
+  xdp::built_in::GMIOConfiguration* input_params = (xdp::built_in::GMIOConfiguration*)malloc(total_size);
+  input_params->bufAllocSz = bufAllocSz;
+  input_params->numStreams = numStream;
+
+
+  xdp::built_in::GMIOBuffer hostBuffer[numStream];
+  for(uint64_t i = 0; i < numStream; i ++) {
+    buffers[i].boHandle = deviceIntf->allocTraceBuf(bufAllocSz, 0);
+    
+    if(!buffers[i].boHandle) {
+      bufferInitialized = false;
+      return bufferInitialized;
+    }
+
+    uint64_t bufAddr = deviceIntf->getDeviceAddr(buffers[i].boHandle);
+
+    VPDatabase* db = VPDatabase::Instance();
+    TraceGMIO*  traceGMIO = (db->getStaticInfo()).getTraceGMIO(deviceId, i);
+
+    hostBuffer[i].shimColumn = traceGMIO->shimColumn;
+    hostBuffer[i].burstLength = traceGMIO->burstLength;
+    hostBuffer[i].channelNumber = traceGMIO->channelNumber;
+    hostBuffer[i].physAddr = bufAddr;
+    input_params->gmioData[i] = hostBuffer[i];
+  }
+
+  const size_t DATA_SIZE = 4096; // Data size aligned to 4096, and won't be passed for 400 tiles
+  //Cast struct to uint8_t pointer and pass this data
+  uint8_t* temp = reinterpret_cast<uint8_t*>(input_params);
+
+  auto in_bo = xrt::bo(device, DATA_SIZE, 2);
+  auto in_bo_map = in_bo.map<uint8_t*>();
+  std::fill(in_bo_map, in_bo_map + 1024, 0);
+
+  //copy the input configuration buffer to the buffer object.
+  std::memcpy(in_bo_map, temp, total_size);
+
+  in_bo.sync(XCL_BO_SYNC_BO_TO_DEVICE, DATA_SIZE, 0);
+  auto run = gmio_kernel(in_bo);
+  run.wait();
+
+  std::string msg = "The aie_trace_gmio PS kernel was successfully scheduled.";
+  xrt_core::message::send(xrt_core::message::severity_level::info, "XRT", msg);
+
+  bufferInitialized = true;
+  return bufferInitialized;
+}
+
 
 bool AIETraceOffload::initReadTrace()
 {
@@ -80,95 +141,101 @@ bool AIETraceOffload::initReadTrace()
 
   uint8_t  memIndex = 0;
   if (isPLIO) {
-    memIndex = deviceIntf->getAIETs2mmMemIndex(0); // all the AIE Ts2mm s will have same memory index selected
+  memIndex = deviceIntf->getAIETs2mmMemIndex(0); // all the AIE Ts2mm s will have same memory index selected
   } else {
-    memIndex = 0;  // for now
+  memIndex = 0;  // for now
+
+#if defined (XRT_ENABLE_AIE) && defined (XRT_NATIVE_BUILD)
+  bool success = setupPSKernel();
+  return success;
+#endif
+
 /*
  * XRT_NATIVE_BUILD is set only for x86 builds
  * Only compile this on edge+versal build
  */
 #if defined (XRT_ENABLE_AIE) && ! defined (XRT_NATIVE_BUILD)
-    gmioDMAInsts.clear();
-    gmioDMAInsts.resize(numStream);
+  gmioDMAInsts.clear();
+  gmioDMAInsts.resize(numStream);
 #endif
   }
 
   checkCircularBufferSupport();
 
   for(uint64_t i = 0; i < numStream ; ++i) {
-    buffers[i].boHandle = deviceIntf->allocTraceBuf(bufAllocSz, memIndex);
-    if(!buffers[i].boHandle) {
-      bufferInitialized = false;
-      return bufferInitialized;
-    }
+  buffers[i].boHandle = deviceIntf->allocTraceBuf(bufAllocSz, memIndex);
+  if(!buffers[i].boHandle) {
+    bufferInitialized = false;
+    return bufferInitialized;
+  }
 
-    // Data Mover will write input stream to this address
-    uint64_t bufAddr = deviceIntf->getDeviceAddr(buffers[i].boHandle);
+  // Data Mover will write input stream to this address
+  uint64_t bufAddr = deviceIntf->getDeviceAddr(buffers[i].boHandle);
 
-    std::string msg = "Allocating trace buffer of size " + std::to_string(bufAllocSz) + " for AIE Stream " + std::to_string(i);
-    xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT", msg.c_str());
+  std::string msg = "Allocating trace buffer of size " + std::to_string(bufAllocSz) + " for AIE Stream " + std::to_string(i);
+  xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT", msg.c_str());
 
-    if (isPLIO) {
-      deviceIntf->initAIETs2mm(bufAllocSz, bufAddr, i, mEnCircularBuf);
-    } else {
+  if (isPLIO) {
+    deviceIntf->initAIETs2mm(bufAllocSz, bufAddr, i, mEnCircularBuf);
+  } else {
 /*
  * XRT_NATIVE_BUILD is set only for x86 builds
  * Only compile this on edge+versal build
  */
 #if defined (XRT_ENABLE_AIE) && ! defined (XRT_NATIVE_BUILD)
-      VPDatabase* db = VPDatabase::Instance();
-      TraceGMIO*  traceGMIO = (db->getStaticInfo()).getTraceGMIO(deviceId, i);
+    VPDatabase* db = VPDatabase::Instance();
+    TraceGMIO*  traceGMIO = (db->getStaticInfo()).getTraceGMIO(deviceId, i);
 
-      ZYNQ::shim *drv = ZYNQ::shim::handleCheck(deviceHandle);
-      if(!drv) {
-        bufferInitialized = false;
-        return bufferInitialized;
-      }
-      zynqaie::Aie* aieObj = drv->getAieArray();
+    ZYNQ::shim *drv = ZYNQ::shim::handleCheck(deviceHandle);
+    if(!drv) {
+    bufferInitialized = false;
+    return bufferInitialized;
+    }
+    zynqaie::Aie* aieObj = drv->getAieArray();
 
-      XAie_DevInst* devInst = aieObj->getDevInst();
+    XAie_DevInst* devInst = aieObj->getDevInst();
 
-      gmioDMAInsts[i].gmioTileLoc = XAie_TileLoc(traceGMIO->shimColumn, 0);
+    gmioDMAInsts[i].gmioTileLoc = XAie_TileLoc(traceGMIO->shimColumn, 0);
 
-      int driverStatus = XAIE_OK;
-      driverStatus = XAie_DmaDescInit(devInst, &(gmioDMAInsts[i].shimDmaInst), gmioDMAInsts[i].gmioTileLoc);
-      if(XAIE_OK != driverStatus) {
-        throw std::runtime_error("Initialization of DMA Descriptor failed while setting up SHIM DMA channel for GMIO Trace offload");
-      }
+    int driverStatus = XAIE_OK;
+    driverStatus = XAie_DmaDescInit(devInst, &(gmioDMAInsts[i].shimDmaInst), gmioDMAInsts[i].gmioTileLoc);
+    if(XAIE_OK != driverStatus) {
+    throw std::runtime_error("Initialization of DMA Descriptor failed while setting up SHIM DMA channel for GMIO Trace offload");
+    }
 
-      // channelNumber: (0-S2MM0,1-S2MM1,2-MM2S0,3-MM2S1)
-      // Enable shim DMA channel, need to start first so the status is correct
-      uint16_t channelNumber = (traceGMIO->channelNumber > 1) ? (traceGMIO->channelNumber - 2) : traceGMIO->channelNumber;
-      XAie_DmaDirection dir = (traceGMIO->channelNumber > 1) ? DMA_MM2S : DMA_S2MM;
+    // channelNumber: (0-S2MM0,1-S2MM1,2-MM2S0,3-MM2S1)
+    // Enable shim DMA channel, need to start first so the status is correct
+    uint16_t channelNumber = (traceGMIO->channelNumber > 1) ? (traceGMIO->channelNumber - 2) : traceGMIO->channelNumber;
+    XAie_DmaDirection dir = (traceGMIO->channelNumber > 1) ? DMA_MM2S : DMA_S2MM;
 
-      XAie_DmaChannelEnable(devInst, gmioDMAInsts[i].gmioTileLoc, channelNumber, dir);
+    XAie_DmaChannelEnable(devInst, gmioDMAInsts[i].gmioTileLoc, channelNumber, dir);
 
-      // Set AXI burst length
-      XAie_DmaSetAxi(&(gmioDMAInsts[i].shimDmaInst), 0, traceGMIO->burstLength, 0, 0, 0);
+    // Set AXI burst length
+    XAie_DmaSetAxi(&(gmioDMAInsts[i].shimDmaInst), 0, traceGMIO->burstLength, 0, 0, 0);
 
-      XAie_MemInst memInst;
-      XAie_MemCacheProp prop = XAIE_MEM_CACHEABLE;
-      xclBufferExportHandle boExportHandle = xclExportBO(deviceHandle, buffers[i].boHandle);
-      if(XRT_NULL_BO_EXPORT == boExportHandle) {
-        throw std::runtime_error("Unable to export BO while attaching to AIE Driver");
-      }
-      XAie_MemAttach(devInst,  &memInst, 0, 0, 0, prop, boExportHandle);
+    XAie_MemInst memInst;
+    XAie_MemCacheProp prop = XAIE_MEM_CACHEABLE;
+    xclBufferExportHandle boExportHandle = xclExportBO(deviceHandle, buffers[i].boHandle);
+    if(XRT_NULL_BO_EXPORT == boExportHandle) {
+    throw std::runtime_error("Unable to export BO while attaching to AIE Driver");
+    }
+    XAie_MemAttach(devInst,  &memInst, 0, 0, 0, prop, boExportHandle);
 
-      char* vaddr = reinterpret_cast<char *>(mmap(NULL, bufAllocSz, PROT_READ | PROT_WRITE, MAP_SHARED, boExportHandle, 0));
-      XAie_DmaSetAddrLen(&(gmioDMAInsts[i].shimDmaInst), (uint64_t)vaddr, bufAllocSz);
+    char* vaddr = reinterpret_cast<char *>(mmap(NULL, bufAllocSz, PROT_READ | PROT_WRITE, MAP_SHARED, boExportHandle, 0));
+    XAie_DmaSetAddrLen(&(gmioDMAInsts[i].shimDmaInst), (uint64_t)vaddr, bufAllocSz);
 
-      XAie_DmaEnableBd(&(gmioDMAInsts[i].shimDmaInst));
+    XAie_DmaEnableBd(&(gmioDMAInsts[i].shimDmaInst));
 
-      // For trace, use bd# 0 for S2MM0, use bd# 4 for S2MM1
-      int bdNum = channelNumber * 4;
-      // Write to shim DMA BD AxiMM registers
-      XAie_DmaWriteBd(devInst, &(gmioDMAInsts[i].shimDmaInst), gmioDMAInsts[i].gmioTileLoc, bdNum);
+    // For trace, use bd# 0 for S2MM0, use bd# 4 for S2MM1
+    int bdNum = channelNumber * 4;
+    // Write to shim DMA BD AxiMM registers
+    XAie_DmaWriteBd(devInst, &(gmioDMAInsts[i].shimDmaInst), gmioDMAInsts[i].gmioTileLoc, bdNum);
 
-      // Enqueue BD
-      XAie_DmaChannelPushBdToQueue(devInst, gmioDMAInsts[i].gmioTileLoc, channelNumber, dir, bdNum);
+    // Enqueue BD
+    XAie_DmaChannelPushBdToQueue(devInst, gmioDMAInsts[i].gmioTileLoc, channelNumber, dir, bdNum);
 
 #endif
-    }
+  }
   }
   bufferInitialized = true;
   return bufferInitialized;
@@ -178,39 +245,39 @@ void AIETraceOffload::endReadTrace()
 {
   // reset
   for (uint64_t i = 0; i < numStream ; ++i) {
-    if (!buffers[i].boHandle) {
-      continue;
-    }
-    if(isPLIO) {
-      deviceIntf->resetAIETs2mm(i);
-//      deviceIntf->freeTraceBuf(b.boHandle);
-    } else {
+  if (!buffers[i].boHandle) {
+    continue;
+  }
+  if(isPLIO) {
+    deviceIntf->resetAIETs2mm(i);
+//    deviceIntf->freeTraceBuf(b.boHandle);
+  } else {
 /*
  * XRT_NATIVE_BUILD is set only for x86 builds
  * Only compile this on edge+versal build
  */
 #if defined (XRT_ENABLE_AIE) && ! defined (XRT_NATIVE_BUILD)
-      VPDatabase* db = VPDatabase::Instance();
-      TraceGMIO*  traceGMIO = (db->getStaticInfo()).getTraceGMIO(deviceId, i);
+    VPDatabase* db = VPDatabase::Instance();
+    TraceGMIO*  traceGMIO = (db->getStaticInfo()).getTraceGMIO(deviceId, i);
 
-      ZYNQ::shim *drv = ZYNQ::shim::handleCheck(deviceHandle);
-      if(!drv) {
-        return ;
-      }
-      zynqaie::Aie* aieObj = drv->getAieArray();
-      XAie_DevInst* devInst = aieObj->getDevInst();
-
-      // channelNumber: (0-S2MM0,1-S2MM1,2-MM2S0,3-MM2S1)
-      // Enable shim DMA channel, need to start first so the status is correct
-      uint16_t channelNumber = (traceGMIO->channelNumber > 1) ? (traceGMIO->channelNumber - 2) : traceGMIO->channelNumber;
-      XAie_DmaDirection dir = (traceGMIO->channelNumber > 1) ? DMA_MM2S : DMA_S2MM;
-
-      XAie_DmaChannelDisable(devInst, gmioDMAInsts[i].gmioTileLoc, channelNumber, dir);
-#endif
-      
+    ZYNQ::shim *drv = ZYNQ::shim::handleCheck(deviceHandle);
+    if(!drv) {
+    return ;
     }
-    deviceIntf->freeTraceBuf(buffers[i].boHandle);
-    buffers[i].boHandle = 0;
+    zynqaie::Aie* aieObj = drv->getAieArray();
+    XAie_DevInst* devInst = aieObj->getDevInst();
+
+    // channelNumber: (0-S2MM0,1-S2MM1,2-MM2S0,3-MM2S1)
+    // Enable shim DMA channel, need to start first so the status is correct
+    uint16_t channelNumber = (traceGMIO->channelNumber > 1) ? (traceGMIO->channelNumber - 2) : traceGMIO->channelNumber;
+    XAie_DmaDirection dir = (traceGMIO->channelNumber > 1) ? DMA_MM2S : DMA_S2MM;
+
+    XAie_DmaChannelDisable(devInst, gmioDMAInsts[i].gmioTileLoc, channelNumber, dir);
+#endif
+    
+  }
+  deviceIntf->freeTraceBuf(buffers[i].boHandle);
+  buffers[i].boHandle = 0;
   }
   bufferInitialized = false;
 }
@@ -218,97 +285,97 @@ void AIETraceOffload::endReadTrace()
 void AIETraceOffload::readTrace(bool final)
 {
   if (mCircularBufOverwrite)
-    return;
+  return;
 
   for (uint64_t index = 0; index < numStream; ++index) {
-    auto& bd = buffers[index];
+  auto& bd = buffers[index];
 
-    if (bd.offloadDone)
-      continue;
+  if (bd.offloadDone)
+    continue;
 
-    // read complete trace buffer in gmio
-    if (!isPLIO) {
-      bd.usedSz = bufAllocSz;
-      bd.offloadDone = true;
-      syncAndLog(index);
-      continue;
+  // read complete trace buffer in gmio
+  if (!isPLIO) {
+    bd.usedSz = bufAllocSz;
+    bd.offloadDone = true;
+    syncAndLog(index);
+    continue;
+  }
+
+  uint64_t wordCount = deviceIntf->getWordCountAIETs2mm(index, final);
+  // AIE Trace packets are 4 words of 64 bit
+  wordCount -= wordCount % 4;
+
+  uint64_t bytes_written  = wordCount * TRACE_PACKET_SIZE;
+  uint64_t bytes_read = bd.usedSz + bd.rollover_count * bufAllocSz;
+
+  // Offload cannot keep up with the DMA
+  // There is a slight chance that overwrite could occur
+  // during this check. In that case trace could be corrupt
+  if (bytes_written > bytes_read + bufAllocSz) {
+    // Don't read any more data
+    bd.offloadDone = true;
+    std::stringstream msg;
+    msg << AIE_TS2MM_WARN_MSG_CIRC_BUF_OVERWRITE << " Stream : " << index + 1 << std::endl;
+    xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", msg.str());
+    debug_stream
+    << "Bytes Read : " << bytes_read
+    << " Bytes Written : " << bytes_written
+    << std::endl;
+
+    // Fatal condition. Abort offload
+    mCircularBufOverwrite = true;
+    stopOffload();
+    return;
+  }
+
+  // Start Offload from previous offset
+  bd.offset = bd.usedSz;
+  if (bd.offset == bufAllocSz) {
+    if (!mEnCircularBuf) {
+    bd.offloadDone = true;
+    continue;
     }
+    bd.rollover_count++;
+    bd.offset = 0;
+  }
 
-    uint64_t wordCount = deviceIntf->getWordCountAIETs2mm(index, final);
-    // AIE Trace packets are 4 words of 64 bit
-    wordCount -= wordCount % 4;
+  // End Offload at this offset
+  // limit size to not cross circular buffer boundary
+  uint64_t circBufRolloverBytes = 0;
+  bd.usedSz = bytes_written - bd.rollover_count * bufAllocSz;
+  if (bd.usedSz > bufAllocSz) {
+    circBufRolloverBytes = bd.usedSz - bufAllocSz;
+    bd.usedSz = bufAllocSz;
+  }
 
-    uint64_t bytes_written  = wordCount * TRACE_PACKET_SIZE;
-    uint64_t bytes_read = bd.usedSz + bd.rollover_count * bufAllocSz;
+  if (bd.offset != bd.usedSz) {
+    debug_stream
+    << "AIETraceOffload::config_s2mm_" << index << " "
+    << "Reading from 0x"
+    << std::hex << bd.offset << " to 0x" << bd.usedSz << std::dec
+    << " Bytes Read : " << bytes_read
+    << " Bytes Written : " << bytes_written
+    << " Rollovers : " << bd.rollover_count
+    << std::endl;
+  }
 
-    // Offload cannot keep up with the DMA
-    // There is a slight chance that overwrite could occur
-    // during this check. In that case trace could be corrupt
-    if (bytes_written > bytes_read + bufAllocSz) {
-      // Don't read any more data
-      bd.offloadDone = true;
-      std::stringstream msg;
-      msg << AIE_TS2MM_WARN_MSG_CIRC_BUF_OVERWRITE << " Stream : " << index + 1 << std::endl;
-      xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", msg.str());
-      debug_stream
-        << "Bytes Read : " << bytes_read
-        << " Bytes Written : " << bytes_written
-        << std::endl;
+  if (!syncAndLog(index))
+    continue;
 
-      // Fatal condition. Abort offload
-      mCircularBufOverwrite = true;
-      stopOffload();
-      return;
-    }
+  // Do another sync if we're crossing circular buffer boundary
+  if (mEnCircularBuf && circBufRolloverBytes) {
+    // Start from 0
+    bd.rollover_count++;
+    bd.offset = 0;
+    // End at leftover bytes
+    bd.usedSz = circBufRolloverBytes;
 
-    // Start Offload from previous offset
-    bd.offset = bd.usedSz;
-    if (bd.offset == bufAllocSz) {
-      if (!mEnCircularBuf) {
-        bd.offloadDone = true;
-        continue;
-      }
-      bd.rollover_count++;
-      bd.offset = 0;
-    }
+    debug_stream
+    << "Circular buffer boundary read from 0x0 to 0x: "
+    << std::hex << circBufRolloverBytes << std::dec << std::endl;
 
-    // End Offload at this offset
-    // limit size to not cross circular buffer boundary
-    uint64_t circBufRolloverBytes = 0;
-    bd.usedSz = bytes_written - bd.rollover_count * bufAllocSz;
-    if (bd.usedSz > bufAllocSz) {
-      circBufRolloverBytes = bd.usedSz - bufAllocSz;
-      bd.usedSz = bufAllocSz;
-    }
-
-    if (bd.offset != bd.usedSz) {
-      debug_stream
-        << "AIETraceOffload::config_s2mm_" << index << " "
-        << "Reading from 0x"
-        << std::hex << bd.offset << " to 0x" << bd.usedSz << std::dec
-        << " Bytes Read : " << bytes_read
-        << " Bytes Written : " << bytes_written
-        << " Rollovers : " << bd.rollover_count
-        << std::endl;
-    }
-
-    if (!syncAndLog(index))
-      continue;
-
-    // Do another sync if we're crossing circular buffer boundary
-    if (mEnCircularBuf && circBufRolloverBytes) {
-      // Start from 0
-      bd.rollover_count++;
-      bd.offset = 0;
-      // End at leftover bytes
-      bd.usedSz = circBufRolloverBytes;
-
-      debug_stream
-        << "Circular buffer boundary read from 0x0 to 0x: "
-        << std::hex << circBufRolloverBytes << std::dec << std::endl;
-
-      syncAndLog(index);
-    }
+    syncAndLog(index);
+  }
   }
 }
 
@@ -317,7 +384,7 @@ bool AIETraceOffload::syncAndLog(uint64_t index)
   auto& bd = buffers[index];
 
   if (bd.offset >= bd.usedSz)
-    return false;
+  return false;
 
   // Amount of newly written trace
   uint64_t nBytes = bd.usedSz - bd.offset;
@@ -328,22 +395,22 @@ bool AIETraceOffload::syncAndLog(uint64_t index)
   auto end = std::chrono::steady_clock::now();
 
   if (!hostBuf) {
-    bd.offloadDone = true;
-    return false;
+  bd.offloadDone = true;
+  return false;
   }
 
   // Log trace buffer
   traceLogger->addAIETraceData(index, hostBuf, nBytes, mEnCircularBuf);
 
   debug_stream
-    << "ts2mm_" << index << " : bytes : " << nBytes << " "
-    << "sync: " << std::chrono::duration_cast<std::chrono::microseconds>(end - start).count() << "µs "
-    << std::hex << "from 0x" << bd.offset << " to 0x"
-    << bd.usedSz << std::dec << std::endl;
+  << "ts2mm_" << index << " : bytes : " << nBytes << " "
+  << "sync: " << std::chrono::duration_cast<std::chrono::microseconds>(end - start).count() << "µs "
+  << std::hex << "from 0x" << bd.offset << " to 0x"
+  << bd.usedSz << std::dec << std::endl;
 
-    // check for full buffer
+  // check for full buffer
   if ((bd.offset + nBytes >= bufAllocSz) && !mEnCircularBuf)
-    bd.isFull = true;
+  bd.isFull = true;
 
   return true;
 }
@@ -352,10 +419,10 @@ bool AIETraceOffload::isTraceBufferFull()
 {
   // Detect if any trace buffer was full
   if (isPLIO) {
-    for (auto& buf: buffers) {
-      if (buf.isFull)
-        return true;
-    }
+  for (auto& buf: buffers) {
+    if (buf.isFull)
+    return true;
+  }
   }
   return false;
 }
@@ -363,48 +430,47 @@ bool AIETraceOffload::isTraceBufferFull()
 void AIETraceOffload::checkCircularBufferSupport()
 {
   if (!deviceIntf->supportsCircBufAIE())
-    return;
+  return;
 
   mEnCircularBuf = xrt_core::config::get_aie_trace_settings_reuse_buffer();
   if (!mEnCircularBuf)
-    return;
+  return;
 
   // gmio not supported
   if (!isPLIO) {
-    mEnCircularBuf = false;
-    xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", AIE_TRACE_WARN_REUSE_GMIO);
-    return;
+  mEnCircularBuf = false;
+  xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", AIE_TRACE_WARN_REUSE_GMIO);
+  return;
   }
 
   if (!continuousTrace()) {
-    mEnCircularBuf = false;
-    xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", AIE_TRACE_WARN_REUSE_PERIODIC);
-    return;
+  mEnCircularBuf = false;
+  xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", AIE_TRACE_WARN_REUSE_PERIODIC);
+  return;
   }
 
   // Warn if circular buffer settings not adequate
   if (offloadIntervalUs)
-    circ_buf_cur_rate_plio = bufAllocSz * (1e6 / offloadIntervalUs);
+  circ_buf_cur_rate_plio = bufAllocSz * (1e6 / offloadIntervalUs);
   else
-    circ_buf_cur_rate_plio = circ_buf_min_rate_plio;
+  circ_buf_cur_rate_plio = circ_buf_min_rate_plio;
 
   bool buffer_not_large_enough = (bufAllocSz < AIE_MIN_SIZE_CIRCULAR_BUF);
   bool offload_not_fast_enough = (circ_buf_cur_rate_plio < circ_buf_min_rate_plio);
 
   if (buffer_not_large_enough || offload_not_fast_enough) {
-    std::stringstream msg;
-    msg << AIE_TRACE_BUF_REUSE_WARN
-        << " Recommended offload rate (trace buffer bytes/sec) : " << circ_buf_min_rate_plio
-        << " Requested : " << circ_buf_cur_rate_plio ;
-    xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", msg.str());
+  std::stringstream msg;
+  msg << AIE_TRACE_BUF_REUSE_WARN
+    << " Recommended offload rate (trace buffer bytes/sec) : " << circ_buf_min_rate_plio
+    << " Requested : " << circ_buf_cur_rate_plio ;
+  xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", msg.str());
   }
-  xrt_core::message::send(xrt_core::message::severity_level::info, "XRT", AIE_TRACE_CIRC_BUF_EN);
 }
 
 void AIETraceOffload::startOffload()
 {
   if (offloadStatus == AIEOffloadThreadStatus::RUNNING)
-    return;
+  return;
 
   std::lock_guard<std::mutex> lock(statusLock);
   offloadStatus = AIEOffloadThreadStatus::RUNNING;
@@ -415,13 +481,13 @@ void AIETraceOffload::startOffload()
 void AIETraceOffload::continuousOffload()
 {
   if (!bufferInitialized && !initReadTrace()) {
-    offloadFinished();
-    return;
+  offloadFinished();
+  return;
   }
 
   while (keepOffloading()) {
-    readTrace(false);
-    std::this_thread::sleep_for(std::chrono::microseconds(offloadIntervalUs));
+  readTrace(false);
+  std::this_thread::sleep_for(std::chrono::microseconds(offloadIntervalUs));
   }
 
   // Note: This will call flush and reset on datamover
@@ -440,7 +506,7 @@ void AIETraceOffload::stopOffload()
 {
   std::lock_guard<std::mutex> lock(statusLock);
   if (AIEOffloadThreadStatus::STOPPED == offloadStatus)
-    return;
+  return;
   offloadStatus = AIEOffloadThreadStatus::STOPPING;
 }
 
@@ -448,7 +514,7 @@ void AIETraceOffload::offloadFinished()
 {
   std::lock_guard<std::mutex> lock(statusLock);
   if (AIEOffloadThreadStatus::STOPPED == offloadStatus)
-    return;
+  return;
   offloadStatus = AIEOffloadThreadStatus::STOPPED;
 }
 

--- a/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.cpp
+++ b/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.cpp
@@ -79,16 +79,13 @@ bool AIETraceOffload::setupPSKernel() {
 
   auto spdevice = xrt_core::get_userpf_device(deviceHandle);
   auto device = xrt::device(spdevice);
-
   auto uuid = device.get_xclbin_uuid();
   auto gmio_kernel = xrt::kernel(device, uuid.get(), "aie_trace_gmio");
-
 
   std::size_t total_size = sizeof(xdp::built_in::GMIOConfiguration) + sizeof(xdp::built_in::GMIOBuffer[numStream-1]);
   xdp::built_in::GMIOConfiguration* input_params = (xdp::built_in::GMIOConfiguration*)malloc(total_size);
   input_params->bufAllocSz = bufAllocSz;
   input_params->numStreams = numStream;
-
 
   xdp::built_in::GMIOBuffer hostBuffer[numStream];
   for(uint64_t i = 0; i < numStream; i ++) {
@@ -133,7 +130,6 @@ bool AIETraceOffload::setupPSKernel() {
   return bufferInitialized;
 }
 
-
 bool AIETraceOffload::initReadTrace()
 {
   buffers.clear();
@@ -141,9 +137,9 @@ bool AIETraceOffload::initReadTrace()
 
   uint8_t  memIndex = 0;
   if (isPLIO) {
-  memIndex = deviceIntf->getAIETs2mmMemIndex(0); // all the AIE Ts2mm s will have same memory index selected
+    memIndex = deviceIntf->getAIETs2mmMemIndex(0); // all the AIE Ts2mm s will have same memory index selected
   } else {
-  memIndex = 0;  // for now
+    memIndex = 0;  // for now
 
 #if defined (XRT_ENABLE_AIE) && defined (XRT_NATIVE_BUILD)
   bool success = setupPSKernel();
@@ -163,79 +159,79 @@ bool AIETraceOffload::initReadTrace()
   checkCircularBufferSupport();
 
   for(uint64_t i = 0; i < numStream ; ++i) {
-  buffers[i].boHandle = deviceIntf->allocTraceBuf(bufAllocSz, memIndex);
-  if(!buffers[i].boHandle) {
-    bufferInitialized = false;
-    return bufferInitialized;
-  }
+    buffers[i].boHandle = deviceIntf->allocTraceBuf(bufAllocSz, memIndex);
+    if(!buffers[i].boHandle) {
+      bufferInitialized = false;
+      return bufferInitialized;
+    }
 
-  // Data Mover will write input stream to this address
-  uint64_t bufAddr = deviceIntf->getDeviceAddr(buffers[i].boHandle);
+    // Data Mover will write input stream to this address
+    uint64_t bufAddr = deviceIntf->getDeviceAddr(buffers[i].boHandle);
 
-  std::string msg = "Allocating trace buffer of size " + std::to_string(bufAllocSz) + " for AIE Stream " + std::to_string(i);
-  xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT", msg.c_str());
+    std::string msg = "Allocating trace buffer of size " + std::to_string(bufAllocSz) + " for AIE Stream " + std::to_string(i);
+    xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT", msg.c_str());
 
-  if (isPLIO) {
-    deviceIntf->initAIETs2mm(bufAllocSz, bufAddr, i, mEnCircularBuf);
-  } else {
-/*
- * XRT_NATIVE_BUILD is set only for x86 builds
- * Only compile this on edge+versal build
- */
+    if (isPLIO) {
+      deviceIntf->initAIETs2mm(bufAllocSz, bufAddr, i, mEnCircularBuf);
+    } else {
+  /*
+   * XRT_NATIVE_BUILD is set only for x86 builds
+   * Only compile this on edge+versal build
+   */
 #if defined (XRT_ENABLE_AIE) && ! defined (XRT_NATIVE_BUILD)
-    VPDatabase* db = VPDatabase::Instance();
-    TraceGMIO*  traceGMIO = (db->getStaticInfo()).getTraceGMIO(deviceId, i);
+      VPDatabase* db = VPDatabase::Instance();
+      TraceGMIO*  traceGMIO = (db->getStaticInfo()).getTraceGMIO(deviceId, i);
 
-    ZYNQ::shim *drv = ZYNQ::shim::handleCheck(deviceHandle);
-    if(!drv) {
-    bufferInitialized = false;
-    return bufferInitialized;
-    }
-    zynqaie::Aie* aieObj = drv->getAieArray();
+      ZYNQ::shim *drv = ZYNQ::shim::handleCheck(deviceHandle);
+      if(!drv) {
+      bufferInitialized = false;
+      return bufferInitialized;
+      }
+      zynqaie::Aie* aieObj = drv->getAieArray();
 
-    XAie_DevInst* devInst = aieObj->getDevInst();
+      XAie_DevInst* devInst = aieObj->getDevInst();
 
-    gmioDMAInsts[i].gmioTileLoc = XAie_TileLoc(traceGMIO->shimColumn, 0);
+      gmioDMAInsts[i].gmioTileLoc = XAie_TileLoc(traceGMIO->shimColumn, 0);
 
-    int driverStatus = XAIE_OK;
-    driverStatus = XAie_DmaDescInit(devInst, &(gmioDMAInsts[i].shimDmaInst), gmioDMAInsts[i].gmioTileLoc);
-    if(XAIE_OK != driverStatus) {
-    throw std::runtime_error("Initialization of DMA Descriptor failed while setting up SHIM DMA channel for GMIO Trace offload");
-    }
+      int driverStatus = XAIE_OK;
+      driverStatus = XAie_DmaDescInit(devInst, &(gmioDMAInsts[i].shimDmaInst), gmioDMAInsts[i].gmioTileLoc);
+      if(XAIE_OK != driverStatus) {
+      throw std::runtime_error("Initialization of DMA Descriptor failed while setting up SHIM DMA channel for GMIO Trace offload");
+      }
 
-    // channelNumber: (0-S2MM0,1-S2MM1,2-MM2S0,3-MM2S1)
-    // Enable shim DMA channel, need to start first so the status is correct
-    uint16_t channelNumber = (traceGMIO->channelNumber > 1) ? (traceGMIO->channelNumber - 2) : traceGMIO->channelNumber;
-    XAie_DmaDirection dir = (traceGMIO->channelNumber > 1) ? DMA_MM2S : DMA_S2MM;
+      // channelNumber: (0-S2MM0,1-S2MM1,2-MM2S0,3-MM2S1)
+      // Enable shim DMA channel, need to start first so the status is correct
+      uint16_t channelNumber = (traceGMIO->channelNumber > 1) ? (traceGMIO->channelNumber - 2) : traceGMIO->channelNumber;
+      XAie_DmaDirection dir = (traceGMIO->channelNumber > 1) ? DMA_MM2S : DMA_S2MM;
 
-    XAie_DmaChannelEnable(devInst, gmioDMAInsts[i].gmioTileLoc, channelNumber, dir);
+      XAie_DmaChannelEnable(devInst, gmioDMAInsts[i].gmioTileLoc, channelNumber, dir);
 
-    // Set AXI burst length
-    XAie_DmaSetAxi(&(gmioDMAInsts[i].shimDmaInst), 0, traceGMIO->burstLength, 0, 0, 0);
+      // Set AXI burst length
+      XAie_DmaSetAxi(&(gmioDMAInsts[i].shimDmaInst), 0, traceGMIO->burstLength, 0, 0, 0);
 
-    XAie_MemInst memInst;
-    XAie_MemCacheProp prop = XAIE_MEM_CACHEABLE;
-    xclBufferExportHandle boExportHandle = xclExportBO(deviceHandle, buffers[i].boHandle);
-    if(XRT_NULL_BO_EXPORT == boExportHandle) {
-    throw std::runtime_error("Unable to export BO while attaching to AIE Driver");
-    }
-    XAie_MemAttach(devInst,  &memInst, 0, 0, 0, prop, boExportHandle);
+      XAie_MemInst memInst;
+      XAie_MemCacheProp prop = XAIE_MEM_CACHEABLE;
+      xclBufferExportHandle boExportHandle = xclExportBO(deviceHandle, buffers[i].boHandle);
+      if(XRT_NULL_BO_EXPORT == boExportHandle) {
+      throw std::runtime_error("Unable to export BO while attaching to AIE Driver");
+      }
+      XAie_MemAttach(devInst,  &memInst, 0, 0, 0, prop, boExportHandle);
 
-    char* vaddr = reinterpret_cast<char *>(mmap(NULL, bufAllocSz, PROT_READ | PROT_WRITE, MAP_SHARED, boExportHandle, 0));
-    XAie_DmaSetAddrLen(&(gmioDMAInsts[i].shimDmaInst), (uint64_t)vaddr, bufAllocSz);
+      char* vaddr = reinterpret_cast<char *>(mmap(NULL, bufAllocSz, PROT_READ | PROT_WRITE, MAP_SHARED, boExportHandle, 0));
+      XAie_DmaSetAddrLen(&(gmioDMAInsts[i].shimDmaInst), (uint64_t)vaddr, bufAllocSz);
 
-    XAie_DmaEnableBd(&(gmioDMAInsts[i].shimDmaInst));
+      XAie_DmaEnableBd(&(gmioDMAInsts[i].shimDmaInst));
 
-    // For trace, use bd# 0 for S2MM0, use bd# 4 for S2MM1
-    int bdNum = channelNumber * 4;
-    // Write to shim DMA BD AxiMM registers
-    XAie_DmaWriteBd(devInst, &(gmioDMAInsts[i].shimDmaInst), gmioDMAInsts[i].gmioTileLoc, bdNum);
+      // For trace, use bd# 0 for S2MM0, use bd# 4 for S2MM1
+      int bdNum = channelNumber * 4;
+      // Write to shim DMA BD AxiMM registers
+      XAie_DmaWriteBd(devInst, &(gmioDMAInsts[i].shimDmaInst), gmioDMAInsts[i].gmioTileLoc, bdNum);
 
-    // Enqueue BD
-    XAie_DmaChannelPushBdToQueue(devInst, gmioDMAInsts[i].gmioTileLoc, channelNumber, dir, bdNum);
+      // Enqueue BD
+      XAie_DmaChannelPushBdToQueue(devInst, gmioDMAInsts[i].gmioTileLoc, channelNumber, dir, bdNum);
 
 #endif
-  }
+    }
   }
   bufferInitialized = true;
   return bufferInitialized;
@@ -248,7 +244,7 @@ void AIETraceOffload::endReadTrace()
   if (!buffers[i].boHandle) {
     continue;
   }
-  if(isPLIO) {
+  if (isPLIO) {
     deviceIntf->resetAIETs2mm(i);
 //    deviceIntf->freeTraceBuf(b.boHandle);
   } else {
@@ -261,9 +257,8 @@ void AIETraceOffload::endReadTrace()
     TraceGMIO*  traceGMIO = (db->getStaticInfo()).getTraceGMIO(deviceId, i);
 
     ZYNQ::shim *drv = ZYNQ::shim::handleCheck(deviceHandle);
-    if(!drv) {
-    return ;
-    }
+    if (!drv)
+      return;
     zynqaie::Aie* aieObj = drv->getAieArray();
     XAie_DevInst* devInst = aieObj->getDevInst();
 
@@ -285,97 +280,97 @@ void AIETraceOffload::endReadTrace()
 void AIETraceOffload::readTrace(bool final)
 {
   if (mCircularBufOverwrite)
-  return;
+    return;
 
   for (uint64_t index = 0; index < numStream; ++index) {
-  auto& bd = buffers[index];
+    auto& bd = buffers[index];
 
-  if (bd.offloadDone)
-    continue;
+    if (bd.offloadDone)
+      continue;
 
-  // read complete trace buffer in gmio
-  if (!isPLIO) {
-    bd.usedSz = bufAllocSz;
-    bd.offloadDone = true;
-    syncAndLog(index);
-    continue;
-  }
-
-  uint64_t wordCount = deviceIntf->getWordCountAIETs2mm(index, final);
-  // AIE Trace packets are 4 words of 64 bit
-  wordCount -= wordCount % 4;
-
-  uint64_t bytes_written  = wordCount * TRACE_PACKET_SIZE;
-  uint64_t bytes_read = bd.usedSz + bd.rollover_count * bufAllocSz;
-
-  // Offload cannot keep up with the DMA
-  // There is a slight chance that overwrite could occur
-  // during this check. In that case trace could be corrupt
-  if (bytes_written > bytes_read + bufAllocSz) {
-    // Don't read any more data
-    bd.offloadDone = true;
-    std::stringstream msg;
-    msg << AIE_TS2MM_WARN_MSG_CIRC_BUF_OVERWRITE << " Stream : " << index + 1 << std::endl;
-    xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", msg.str());
-    debug_stream
-    << "Bytes Read : " << bytes_read
-    << " Bytes Written : " << bytes_written
-    << std::endl;
-
-    // Fatal condition. Abort offload
-    mCircularBufOverwrite = true;
-    stopOffload();
-    return;
-  }
-
-  // Start Offload from previous offset
-  bd.offset = bd.usedSz;
-  if (bd.offset == bufAllocSz) {
-    if (!mEnCircularBuf) {
-    bd.offloadDone = true;
-    continue;
+    // read complete trace buffer in gmio
+    if (!isPLIO) {
+      bd.usedSz = bufAllocSz;
+      bd.offloadDone = true;
+      syncAndLog(index);
+      continue;
     }
-    bd.rollover_count++;
-    bd.offset = 0;
-  }
 
-  // End Offload at this offset
-  // limit size to not cross circular buffer boundary
-  uint64_t circBufRolloverBytes = 0;
-  bd.usedSz = bytes_written - bd.rollover_count * bufAllocSz;
-  if (bd.usedSz > bufAllocSz) {
-    circBufRolloverBytes = bd.usedSz - bufAllocSz;
-    bd.usedSz = bufAllocSz;
-  }
+    uint64_t wordCount = deviceIntf->getWordCountAIETs2mm(index, final);
+    // AIE Trace packets are 4 words of 64 bit
+    wordCount -= wordCount % 4;
 
-  if (bd.offset != bd.usedSz) {
-    debug_stream
-    << "AIETraceOffload::config_s2mm_" << index << " "
-    << "Reading from 0x"
-    << std::hex << bd.offset << " to 0x" << bd.usedSz << std::dec
-    << " Bytes Read : " << bytes_read
-    << " Bytes Written : " << bytes_written
-    << " Rollovers : " << bd.rollover_count
-    << std::endl;
-  }
+    uint64_t bytes_written  = wordCount * TRACE_PACKET_SIZE;
+    uint64_t bytes_read = bd.usedSz + bd.rollover_count * bufAllocSz;
 
-  if (!syncAndLog(index))
-    continue;
+    // Offload cannot keep up with the DMA
+    // There is a slight chance that overwrite could occur
+    // during this check. In that case trace could be corrupt
+    if (bytes_written > bytes_read + bufAllocSz) {
+      // Don't read any more data
+      bd.offloadDone = true;
+      std::stringstream msg;
+      msg << AIE_TS2MM_WARN_MSG_CIRC_BUF_OVERWRITE << " Stream : " << index + 1 << std::endl;
+      xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", msg.str());
+      debug_stream
+      << "Bytes Read : " << bytes_read
+      << " Bytes Written : " << bytes_written
+      << std::endl;
 
-  // Do another sync if we're crossing circular buffer boundary
-  if (mEnCircularBuf && circBufRolloverBytes) {
-    // Start from 0
-    bd.rollover_count++;
-    bd.offset = 0;
-    // End at leftover bytes
-    bd.usedSz = circBufRolloverBytes;
+      // Fatal condition. Abort offload
+      mCircularBufOverwrite = true;
+      stopOffload();
+      return;
+    }
 
-    debug_stream
-    << "Circular buffer boundary read from 0x0 to 0x: "
-    << std::hex << circBufRolloverBytes << std::dec << std::endl;
+    // Start Offload from previous offset
+    bd.offset = bd.usedSz;
+    if (bd.offset == bufAllocSz) {
+      if (!mEnCircularBuf) {
+      bd.offloadDone = true;
+      continue;
+      }
+      bd.rollover_count++;
+      bd.offset = 0;
+    }
 
-    syncAndLog(index);
-  }
+    // End Offload at this offset
+    // limit size to not cross circular buffer boundary
+    uint64_t circBufRolloverBytes = 0;
+    bd.usedSz = bytes_written - bd.rollover_count * bufAllocSz;
+    if (bd.usedSz > bufAllocSz) {
+      circBufRolloverBytes = bd.usedSz - bufAllocSz;
+      bd.usedSz = bufAllocSz;
+    }
+
+    if (bd.offset != bd.usedSz) {
+      debug_stream
+      << "AIETraceOffload::config_s2mm_" << index << " "
+      << "Reading from 0x"
+      << std::hex << bd.offset << " to 0x" << bd.usedSz << std::dec
+      << " Bytes Read : " << bytes_read
+      << " Bytes Written : " << bytes_written
+      << " Rollovers : " << bd.rollover_count
+      << std::endl;
+    }
+
+    if (!syncAndLog(index))
+      continue;
+
+    // Do another sync if we're crossing circular buffer boundary
+    if (mEnCircularBuf && circBufRolloverBytes) {
+      // Start from 0
+      bd.rollover_count++;
+      bd.offset = 0;
+      // End at leftover bytes
+      bd.usedSz = circBufRolloverBytes;
+
+      debug_stream
+      << "Circular buffer boundary read from 0x0 to 0x: "
+      << std::hex << circBufRolloverBytes << std::dec << std::endl;
+
+      syncAndLog(index);
+    }
   }
 }
 
@@ -384,7 +379,7 @@ bool AIETraceOffload::syncAndLog(uint64_t index)
   auto& bd = buffers[index];
 
   if (bd.offset >= bd.usedSz)
-  return false;
+    return false;
 
   // Amount of newly written trace
   uint64_t nBytes = bd.usedSz - bd.offset;
@@ -395,8 +390,8 @@ bool AIETraceOffload::syncAndLog(uint64_t index)
   auto end = std::chrono::steady_clock::now();
 
   if (!hostBuf) {
-  bd.offloadDone = true;
-  return false;
+    bd.offloadDone = true;
+    return false;
   }
 
   // Log trace buffer
@@ -410,7 +405,7 @@ bool AIETraceOffload::syncAndLog(uint64_t index)
 
   // check for full buffer
   if ((bd.offset + nBytes >= bufAllocSz) && !mEnCircularBuf)
-  bd.isFull = true;
+    bd.isFull = true;
 
   return true;
 }
@@ -419,10 +414,10 @@ bool AIETraceOffload::isTraceBufferFull()
 {
   // Detect if any trace buffer was full
   if (isPLIO) {
-  for (auto& buf: buffers) {
-    if (buf.isFull)
-    return true;
-  }
+    for (auto& buf: buffers) {
+      if (buf.isFull)
+        return true;
+    }
   }
   return false;
 }
@@ -430,47 +425,47 @@ bool AIETraceOffload::isTraceBufferFull()
 void AIETraceOffload::checkCircularBufferSupport()
 {
   if (!deviceIntf->supportsCircBufAIE())
-  return;
+    return;
 
   mEnCircularBuf = xrt_core::config::get_aie_trace_settings_reuse_buffer();
   if (!mEnCircularBuf)
-  return;
+    return;
 
   // gmio not supported
   if (!isPLIO) {
-  mEnCircularBuf = false;
-  xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", AIE_TRACE_WARN_REUSE_GMIO);
-  return;
+    mEnCircularBuf = false;
+    xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", AIE_TRACE_WARN_REUSE_GMIO);
+    return;
   }
 
   if (!continuousTrace()) {
-  mEnCircularBuf = false;
-  xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", AIE_TRACE_WARN_REUSE_PERIODIC);
-  return;
+    mEnCircularBuf = false;
+    xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", AIE_TRACE_WARN_REUSE_PERIODIC);
+    return;
   }
 
   // Warn if circular buffer settings not adequate
   if (offloadIntervalUs)
-  circ_buf_cur_rate_plio = bufAllocSz * (1e6 / offloadIntervalUs);
+    circ_buf_cur_rate_plio = bufAllocSz * (1e6 / offloadIntervalUs);
   else
-  circ_buf_cur_rate_plio = circ_buf_min_rate_plio;
+    circ_buf_cur_rate_plio = circ_buf_min_rate_plio;
 
   bool buffer_not_large_enough = (bufAllocSz < AIE_MIN_SIZE_CIRCULAR_BUF);
   bool offload_not_fast_enough = (circ_buf_cur_rate_plio < circ_buf_min_rate_plio);
 
   if (buffer_not_large_enough || offload_not_fast_enough) {
-  std::stringstream msg;
-  msg << AIE_TRACE_BUF_REUSE_WARN
-    << " Recommended offload rate (trace buffer bytes/sec) : " << circ_buf_min_rate_plio
-    << " Requested : " << circ_buf_cur_rate_plio ;
-  xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", msg.str());
+    std::stringstream msg;
+    msg << AIE_TRACE_BUF_REUSE_WARN
+      << " Recommended offload rate (trace buffer bytes/sec) : " << circ_buf_min_rate_plio
+      << " Requested : " << circ_buf_cur_rate_plio ;
+    xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", msg.str());
   }
 }
 
 void AIETraceOffload::startOffload()
 {
   if (offloadStatus == AIEOffloadThreadStatus::RUNNING)
-  return;
+    return;
 
   std::lock_guard<std::mutex> lock(statusLock);
   offloadStatus = AIEOffloadThreadStatus::RUNNING;
@@ -481,13 +476,13 @@ void AIETraceOffload::startOffload()
 void AIETraceOffload::continuousOffload()
 {
   if (!bufferInitialized && !initReadTrace()) {
-  offloadFinished();
-  return;
+    offloadFinished();
+    return;
   }
 
   while (keepOffloading()) {
-  readTrace(false);
-  std::this_thread::sleep_for(std::chrono::microseconds(offloadIntervalUs));
+    readTrace(false);
+    std::this_thread::sleep_for(std::chrono::microseconds(offloadIntervalUs));
   }
 
   // Note: This will call flush and reset on datamover
@@ -506,7 +501,7 @@ void AIETraceOffload::stopOffload()
 {
   std::lock_guard<std::mutex> lock(statusLock);
   if (AIEOffloadThreadStatus::STOPPED == offloadStatus)
-  return;
+    return;
   offloadStatus = AIEOffloadThreadStatus::STOPPING;
 }
 
@@ -514,7 +509,7 @@ void AIETraceOffload::offloadFinished()
 {
   std::lock_guard<std::mutex> lock(statusLock);
   if (AIEOffloadThreadStatus::STOPPED == offloadStatus)
-  return;
+    return;
   offloadStatus = AIEOffloadThreadStatus::STOPPED;
 }
 

--- a/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.cpp
+++ b/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.cpp
@@ -184,8 +184,8 @@ bool AIETraceOffload::initReadTrace()
 
       ZYNQ::shim *drv = ZYNQ::shim::handleCheck(deviceHandle);
       if(!drv) {
-      bufferInitialized = false;
-      return bufferInitialized;
+        bufferInitialized = false;
+        return bufferInitialized;
       }
       zynqaie::Aie* aieObj = drv->getAieArray();
 
@@ -196,7 +196,7 @@ bool AIETraceOffload::initReadTrace()
       int driverStatus = XAIE_OK;
       driverStatus = XAie_DmaDescInit(devInst, &(gmioDMAInsts[i].shimDmaInst), gmioDMAInsts[i].gmioTileLoc);
       if(XAIE_OK != driverStatus) {
-      throw std::runtime_error("Initialization of DMA Descriptor failed while setting up SHIM DMA channel for GMIO Trace offload");
+        throw std::runtime_error("Initialization of DMA Descriptor failed while setting up SHIM DMA channel for GMIO Trace offload");
       }
 
       // channelNumber: (0-S2MM0,1-S2MM1,2-MM2S0,3-MM2S1)
@@ -213,7 +213,7 @@ bool AIETraceOffload::initReadTrace()
       XAie_MemCacheProp prop = XAIE_MEM_CACHEABLE;
       xclBufferExportHandle boExportHandle = xclExportBO(deviceHandle, buffers[i].boHandle);
       if(XRT_NULL_BO_EXPORT == boExportHandle) {
-      throw std::runtime_error("Unable to export BO while attaching to AIE Driver");
+        throw std::runtime_error("Unable to export BO while attaching to AIE Driver");
       }
       XAie_MemAttach(devInst,  &memInst, 0, 0, 0, prop, boExportHandle);
 

--- a/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.cpp
+++ b/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.cpp
@@ -71,7 +71,7 @@ AIETraceOffload::~AIETraceOffload()
 {
   stopOffload();
   if (offloadThread.joinable()) {
-  offloadThread.join();
+    offloadThread.join();
   }
 }
 

--- a/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.cpp
+++ b/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.cpp
@@ -313,9 +313,9 @@ void AIETraceOffload::readTrace(bool final)
       msg << AIE_TS2MM_WARN_MSG_CIRC_BUF_OVERWRITE << " Stream : " << index + 1 << std::endl;
       xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", msg.str());
       debug_stream
-      << "Bytes Read : " << bytes_read
-      << " Bytes Written : " << bytes_written
-      << std::endl;
+        << "Bytes Read : " << bytes_read
+        << " Bytes Written : " << bytes_written
+        << std::endl;
 
       // Fatal condition. Abort offload
       mCircularBufOverwrite = true;
@@ -327,8 +327,8 @@ void AIETraceOffload::readTrace(bool final)
     bd.offset = bd.usedSz;
     if (bd.offset == bufAllocSz) {
       if (!mEnCircularBuf) {
-      bd.offloadDone = true;
-      continue;
+        bd.offloadDone = true;
+        continue;
       }
       bd.rollover_count++;
       bd.offset = 0;
@@ -345,13 +345,13 @@ void AIETraceOffload::readTrace(bool final)
 
     if (bd.offset != bd.usedSz) {
       debug_stream
-      << "AIETraceOffload::config_s2mm_" << index << " "
-      << "Reading from 0x"
-      << std::hex << bd.offset << " to 0x" << bd.usedSz << std::dec
-      << " Bytes Read : " << bytes_read
-      << " Bytes Written : " << bytes_written
-      << " Rollovers : " << bd.rollover_count
-      << std::endl;
+        << "AIETraceOffload::config_s2mm_" << index << " "
+        << "Reading from 0x"
+        << std::hex << bd.offset << " to 0x" << bd.usedSz << std::dec
+        << " Bytes Read : " << bytes_read
+        << " Bytes Written : " << bytes_written
+        << " Rollovers : " << bd.rollover_count
+        << std::endl;
     }
 
     if (!syncAndLog(index))
@@ -366,8 +366,8 @@ void AIETraceOffload::readTrace(bool final)
       bd.usedSz = circBufRolloverBytes;
 
       debug_stream
-      << "Circular buffer boundary read from 0x0 to 0x: "
-      << std::hex << circBufRolloverBytes << std::dec << std::endl;
+        << "Circular buffer boundary read from 0x0 to 0x: "
+        << std::hex << circBufRolloverBytes << std::dec << std::endl;
 
       syncAndLog(index);
     }
@@ -398,10 +398,10 @@ bool AIETraceOffload::syncAndLog(uint64_t index)
   traceLogger->addAIETraceData(index, hostBuf, nBytes, mEnCircularBuf);
 
   debug_stream
-  << "ts2mm_" << index << " : bytes : " << nBytes << " "
-  << "sync: " << std::chrono::duration_cast<std::chrono::microseconds>(end - start).count() << "µs "
-  << std::hex << "from 0x" << bd.offset << " to 0x"
-  << bd.usedSz << std::dec << std::endl;
+    << "ts2mm_" << index << " : bytes : " << nBytes << " "
+    << "sync: " << std::chrono::duration_cast<std::chrono::microseconds>(end - start).count() << "µs "
+    << std::hex << "from 0x" << bd.offset << " to 0x"
+    << bd.usedSz << std::dec << std::endl;
 
   // check for full buffer
   if ((bd.offset + nBytes >= bufAllocSz) && !mEnCircularBuf)
@@ -456,8 +456,8 @@ void AIETraceOffload::checkCircularBufferSupport()
   if (buffer_not_large_enough || offload_not_fast_enough) {
     std::stringstream msg;
     msg << AIE_TRACE_BUF_REUSE_WARN
-      << " Recommended offload rate (trace buffer bytes/sec) : " << circ_buf_min_rate_plio
-      << " Requested : " << circ_buf_cur_rate_plio ;
+        << " Recommended offload rate (trace buffer bytes/sec) : " << circ_buf_min_rate_plio
+        << " Requested : " << circ_buf_cur_rate_plio ;
     xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", msg.str());
   }
 }

--- a/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.h
+++ b/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.h
@@ -171,7 +171,6 @@ private:
     uint64_t circ_buf_cur_rate_plio;
 
 private:
-
     bool setupPSKernel();
     void continuousOffload();
     bool keepOffloading();

--- a/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.h
+++ b/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.h
@@ -171,6 +171,8 @@ private:
     uint64_t circ_buf_cur_rate_plio;
 
 private:
+
+    bool setupPSKernel();
     void continuousOffload();
     bool keepOffloading();
     void offloadFinished();

--- a/src/runtime_src/xdp/profile/device/tracedefs.h
+++ b/src/runtime_src/xdp/profile/device/tracedefs.h
@@ -116,6 +116,7 @@ constexpr uint32_t EVENT_CORE_ACTIVE = 28;
 constexpr uint32_t EVENT_CORE_DISABLED = 29;
 constexpr uint32_t BROADCAST_MASK_DEFAULT = 65535;
 constexpr uint32_t NUM_TRACE_PCS = 4;
+constexpr uint32_t NUM_MEM_TRACE_PCS = 2;
 
 constexpr uint32_t NUM_COMBO_EVENT_CONTROL = 3;
 constexpr uint32_t NUM_COMBO_EVENT_INPUT = 4;

--- a/src/runtime_src/xdp/profile/plugin/aie_trace_new/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace_new/aie_trace_plugin.cpp
@@ -336,7 +336,7 @@ namespace xdp {
     }
     handleToAIEData.clear();
 	
-	if (platformSupported)
+    if (platformSupported)
       XDPPlugin::endWrite();
   }
 

--- a/src/runtime_src/xdp/profile/plugin/aie_trace_new/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace_new/aie_trace_plugin.cpp
@@ -337,7 +337,7 @@ namespace xdp {
     handleToAIEData.clear();
 	
 	if (platformSupported)
-    	XDPPlugin::endWrite();
+      XDPPlugin::endWrite();
   }
 
   bool AieTracePluginUnified::alive()

--- a/src/runtime_src/xdp/profile/plugin/aie_trace_new/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace_new/aie_trace_plugin.cpp
@@ -260,13 +260,13 @@ namespace xdp {
     try {
       if (!offloader->initReadTrace()) {
         xrt_core::message::send(severity_level::warning, "XRT", AIE_TRACE_BUF_ALLOC_FAIL);
-        platformSupported = false;
+        AIEData.supported = false;
         return;
       }
     } catch (...) {
         std::string msg = "AIE trace is currently not supported on this platform.";
         xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", msg);
-        AIEData.supported=false;
+        platformSupported = false;
     }
 
     //Sets up and calls the PS kernel on x86 implementation

--- a/src/runtime_src/xdp/profile/plugin/aie_trace_new/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace_new/aie_trace_plugin.cpp
@@ -127,7 +127,7 @@ namespace xdp {
     DeviceIntf* deviceIntf = (db->getStaticInfo()).getDeviceIntf(deviceID);
     if (deviceIntf == nullptr) {
     // If DeviceIntf is not already created, create a new one to communicate with physical device
-    DeviceIntf* deviceIntf = new DeviceIntf();
+    deviceIntf = new DeviceIntf();
     AIEData.devIntf = deviceIntf;
     try {
       deviceIntf->setDevice(new HalDevice(handle));
@@ -257,10 +257,16 @@ namespace xdp {
       offloader->setOffloadIntervalUs(metadata->getOffloadIntervalUs());
     }
 
-    if (!offloader->initReadTrace()) {
-      xrt_core::message::send(severity_level::warning, "XRT", AIE_TRACE_BUF_ALLOC_FAIL);
-      AIEData.supported = false;
-      return;
+    try {
+      if (!offloader->initReadTrace()) {
+        xrt_core::message::send(severity_level::warning, "XRT", AIE_TRACE_BUF_ALLOC_FAIL);
+        platformSupported = false;
+        return;
+      }
+    } catch (...) {
+        std::string msg = "AIE trace is currently not supported on this platform.";
+        xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", msg);
+        AIEData.supported=false;
     }
 
     //Sets up and calls the PS kernel on x86 implementation
@@ -329,7 +335,9 @@ namespace xdp {
       flushOffloader(AIEData.offloader, true);
     }
     handleToAIEData.clear();
-    XDPPlugin::endWrite();
+	
+	if (platformSupported)
+    	XDPPlugin::endWrite();
   }
 
   bool AieTracePluginUnified::alive()

--- a/src/runtime_src/xdp/profile/plugin/aie_trace_new/aie_trace_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace_new/aie_trace_plugin.h
@@ -39,6 +39,7 @@ namespace xdp {
 
   private:
     static bool live;
+	bool platformSupported = true;
     struct AIEData {
       uint64_t deviceID;
       bool supported;

--- a/src/runtime_src/xdp/profile/plugin/aie_trace_new/aie_trace_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace_new/aie_trace_plugin.h
@@ -39,7 +39,7 @@ namespace xdp {
 
   private:
     static bool live;
-	bool platformSupported = true;
+    bool platformSupported = true;
     struct AIEData {
       uint64_t deviceID;
       bool supported;

--- a/src/runtime_src/xdp/profile/plugin/aie_trace_new/x86/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace_new/x86/aie_trace.cpp
@@ -105,7 +105,7 @@ namespace xdp {
       metricSetInt = static_cast<uint8_t>(xdp::built_in::MetricSet::PARTIAL_STALLS);
     } else if (metricSet.compare("functions_all_stalls") == 0) {  
       metricSetInt = static_cast<uint8_t>(xdp::built_in::MetricSet::ALL_STALLS);
-	} else {
+    } else {
       metricSetInt = static_cast<uint8_t>(xdp::built_in::MetricSet::ALL);
     }
 
@@ -151,7 +151,7 @@ namespace xdp {
       memset(outTileConfigbomapped, 0 , OUTPUT_SIZE);
 
       std::memcpy(bo0_map, input, total_size);
-      bo0.sync(XCL_BO_SYNC_BO_TO_DEVICE, 4096, 0);
+      bo0.sync(XCL_BO_SYNC_BO_TO_DEVICE, INPUT_SIZE, 0);
 
       auto run = aie_trace_kernel(bo0, outTileConfigbo);
       run.wait();
@@ -164,7 +164,7 @@ namespace xdp {
         auto cfgTile = std::make_unique<aie_cfg_tile>(cfg->tiles[i].column, cfg->tiles[i].row);
         cfgTile->trace_metric_set = metricSet;
           
-        for (int corePC = 0; corePC < 4; ++corePC) {
+        for (uint32_t corePC = 0; corePC < NUM_TRACE_PCS; ++corePC) {
           auto& cfgData = cfgTile->core_trace_config.pc[corePC];
           cfgData.start_event = cfg->tiles[i].core_trace_config.pc[corePC].start_event;
           cfgData.stop_event  = cfg->tiles[i].core_trace_config.pc[corePC].stop_event;
@@ -172,7 +172,7 @@ namespace xdp {
           cfgData.event_value = cfg->tiles[i].core_trace_config.pc[corePC].event_value;
         } 
         //update mem pcs  
-        for (int memPC = 0; memPC < 2; ++memPC) {
+        for (uint32_t memPC = 0; memPC < NUM_MEM_TRACE_PCS; ++memPC) {
           auto& cfgData = cfgTile->memory_trace_config.pc[memPC];
           cfgData.start_event = cfg->tiles[i].memory_trace_config.pc[memPC].start_event;
           cfgData.stop_event  = cfg->tiles[i].memory_trace_config.pc[memPC].stop_event;
@@ -180,7 +180,7 @@ namespace xdp {
           cfgData.event_value = cfg->tiles[i].memory_trace_config.pc[memPC].event_value;
         } 
         
-        for (int tracedEvent = 0; tracedEvent < 8; tracedEvent++) {
+        for (uint32_t tracedEvent = 0; tracedEvent < NUM_TRACE_EVENTS; tracedEvent++) {
           cfgTile->core_trace_config.traced_events[tracedEvent] = cfg->tiles[i].core_trace_config.traced_events[tracedEvent];
         }
 
@@ -188,11 +188,11 @@ namespace xdp {
         cfgTile->core_trace_config.stop_event = cfg->tiles[i].core_trace_config.stop_event;
       
       
-        for (int tracedEvent = 0; tracedEvent < 8; tracedEvent++) {
+        for (uint32_t tracedEvent = 0; tracedEvent < NUM_TRACE_EVENTS; tracedEvent++) {
           cfgTile->memory_trace_config.traced_events[tracedEvent] = cfg->tiles[i].memory_trace_config.traced_events[tracedEvent];
         }
 
-        for (int bcEvent = 0; bcEvent < 16; bcEvent++) {
+        for (uint32_t bcEvent = 0; bcEvent < NUM_BROADCAST_EVENTS; bcEvent++) {
           cfgTile->core_trace_config.internal_events_broadcast[bcEvent] = cfg->tiles[i].core_trace_config.internal_events_broadcast[bcEvent];
         }
         
@@ -205,7 +205,7 @@ namespace xdp {
         (db->getStaticInfo()).addAIECfgTile(deviceId, cfgTile); 
       }
     
-      for (int event = 0; event < 9; event ++) {
+      for (uint32_t event = 0; event < NUM_OUTPUT_TRACE_EVENTS; event ++) {
         if (cfg->numTileCoreTraceEvents[event] != 0)
           (db->getStaticInfo()).addAIECoreEventResources(deviceId, event, cfg->numTileCoreTraceEvents[event]);
 

--- a/src/runtime_src/xdp/profile/plugin/aie_trace_new/x86/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace_new/x86/aie_trace.cpp
@@ -33,7 +33,7 @@
 #include "xdp/profile/device/tracedefs.h"
 #include "xdp/profile/plugin/aie_trace_new/aie_trace_metadata.h"
 
-#include "xrt/xrt_kernel.h"
+#include "core/include/xrt/xrt_kernel.h"
 
 #include "aie_trace_kernel_config.h"
 #include "aie_trace.h"
@@ -67,7 +67,11 @@ namespace xdp {
   }
 
   bool AieTrace_x86Impl::setMetrics(uint64_t deviceId, void* handle) {
-    // Create struct to pass to PS kernel
+      
+    constexpr uint64_t OUTPUT_SIZE = 4096 * 38; //Calculated maximum output size for all 400 tiles
+    constexpr uint64_t INPUT_SIZE = 4096; // input/output must be aligned to 4096
+
+    //Gather data to send to PS Kernel
     std::string counterScheme = xrt_core::config::get_aie_trace_counter_scheme();
     std::string metricSet = metadata->getMetricSet();
     uint8_t counterSchemeInt;
@@ -83,29 +87,29 @@ namespace xdp {
 
     uint16_t numTiles = 0;
 
-    for (auto& tile : tiles){
+    for (auto& tile : tiles) {
       rows[numTiles] = tile.row;
       cols[numTiles] = tile.col;
       numTiles++;
     }
 
     if (counterScheme.compare("es1")) {
-      counterSchemeInt = 0;
+      counterSchemeInt = static_cast<uint8_t>(xdp::built_in::CounterScheme::ES1);
     } else {
-      counterSchemeInt = 1;
+      counterSchemeInt = static_cast<uint8_t>(xdp::built_in::CounterScheme::ES2);
     }
 
-    if (metricSet.compare("functions") == 0){
-      metricSetInt = 0;
-    } else if (metricSet.compare("functions_partial_stalls") == 0){
-      metricSetInt = 1;
-    } else if (metricSet.compare("functions_all_stalls") == 0){
-      metricSetInt = 2;
-    } else { //all
-      metricSetInt = 3;
+    if (metricSet.compare("functions") == 0) {
+      metricSetInt = static_cast<uint8_t>(xdp::built_in::MetricSet::FUNCTIONS);
+    } else if (metricSet.compare("functions_partial_stalls") == 0) {
+      metricSetInt = static_cast<uint8_t>(xdp::built_in::MetricSet::PARTIAL_STALLS);
+    } else if (metricSet.compare("functions_all_stalls") == 0) {  
+      metricSetInt = static_cast<uint8_t>(xdp::built_in::MetricSet::ALL_STALLS);
+	} else {
+      metricSetInt = static_cast<uint8_t>(xdp::built_in::MetricSet::ALL);
     }
 
-    //Build struct
+    //Build input struct
     std::size_t total_size = sizeof(xdp::built_in::InputConfiguration) + sizeof(uint16_t[(numTiles * 2) - 1]);
     xdp::built_in::InputConfiguration* input_params = (xdp::built_in::InputConfiguration*)malloc(total_size);
     input_params->delayCycles = delayCycles;
@@ -115,68 +119,110 @@ namespace xdp {
     input_params->useDelay = useDelay;
     input_params->userControl = userControl;
 
-    int counter = 0;
-    for (int i = 0; i < numTiles * 2; i +=2){
-      input_params->tiles[i] = rows[counter];
-      input_params->tiles[i+1] = cols[counter];
-      counter += 1;
+    int tileIdx = 0;
+    for (int i = 0; i < numTiles * 2; i +=2) {
+      input_params->tiles[i] = rows[tileIdx];
+      input_params->tiles[i+1] = cols[tileIdx];
+      tileIdx += 1;
     }
 
     total_size = sizeof(xdp::built_in::InputConfiguration) + sizeof(uint16_t[(numTiles * 2) - 1]);
 
     //Cast struct to uint8_t pointer and pass this data
-    //uint8_t* input = reinterpret_cast<uint8_t*>(input_params);
+    uint8_t* input = reinterpret_cast<uint8_t*>(input_params);
 
-    // needs to be modified
-/*
-    auto device = xrt::device(0);
-    auto uuid = device.load_xclbin("runtime_trace_kernel.xclbin");
-    auto aie_trace_kernel = xrt::kernel(device, uuid.get(), "aie_trace_kernel");
-
-    auto bo0 = xrt::bo(device, MAX_LENGTH, 2);
-    auto bo0_map = bo0.map<uint8_t*>();
-    std::fill(bo0_map, bo0_map + MAX_LENGTH, 0);
+    //Attempt to schedule the kernel and parse the tile configuration output
+    try {
+      
+      auto spdevice = xrt_core::get_userpf_device(handle);
+      auto device = xrt::device(spdevice);
     
+      auto uuid = device.get_xclbin_uuid();
+      auto aie_trace_kernel = xrt::kernel(device, uuid.get(), "aie_trace_config");
 
-    std::memcpy(bo0_map, input, total_size);
-    bo0.sync(XCL_BO_SYNC_BO_TO_DEVICE, MAX_LENGTH, 0);
-    auto run = aie_trace_kernel(bo0);
-    run.wait();
-*/
+      //input bo  
+      auto bo0 = xrt::bo(device, INPUT_SIZE, 2);
+      auto bo0_map = bo0.map<uint8_t*>();
+      std::fill(bo0_map, bo0_map + INPUT_SIZE, 0);
+   
+      //output bo
+      auto outTileConfigbo = xrt::bo(device, OUTPUT_SIZE, 2);
+      auto outTileConfigbomapped = outTileConfigbo.map<uint8_t*>();
+      memset(outTileConfigbomapped, 0 , OUTPUT_SIZE);
+
+      std::memcpy(bo0_map, input, total_size);
+      bo0.sync(XCL_BO_SYNC_BO_TO_DEVICE, 4096, 0);
+
+      auto run = aie_trace_kernel(bo0, outTileConfigbo);
+      run.wait();
+
+      outTileConfigbo.sync(XCL_BO_SYNC_BO_FROM_DEVICE, OUTPUT_SIZE, 0);
+      xdp::built_in::OutputConfiguration* cfg = reinterpret_cast<xdp::built_in::OutputConfiguration*>(outTileConfigbomapped);
+
+      // Update the config tiles
+      for (uint32_t i = 0; i < cfg->numTiles; ++i) {
+        auto cfgTile = std::make_unique<aie_cfg_tile>(cfg->tiles[i].column, cfg->tiles[i].row);
+        cfgTile->trace_metric_set = metricSet;
+          
+        for (int corePC = 0; corePC < 4; ++corePC) {
+          auto& cfgData = cfgTile->core_trace_config.pc[corePC];
+          cfgData.start_event = cfg->tiles[i].core_trace_config.pc[corePC].start_event;
+          cfgData.stop_event  = cfg->tiles[i].core_trace_config.pc[corePC].stop_event;
+          cfgData.reset_event = cfg->tiles[i].core_trace_config.pc[corePC].reset_event;
+          cfgData.event_value = cfg->tiles[i].core_trace_config.pc[corePC].event_value;
+        } 
+        //update mem pcs  
+        for (int memPC = 0; memPC < 2; ++memPC) {
+          auto& cfgData = cfgTile->memory_trace_config.pc[memPC];
+          cfgData.start_event = cfg->tiles[i].memory_trace_config.pc[memPC].start_event;
+          cfgData.stop_event  = cfg->tiles[i].memory_trace_config.pc[memPC].stop_event;
+          cfgData.reset_event = cfg->tiles[i].memory_trace_config.pc[memPC].reset_event;
+          cfgData.event_value = cfg->tiles[i].memory_trace_config.pc[memPC].event_value;
+        } 
+        
+        for (int tracedEvent = 0; tracedEvent < 8; tracedEvent++) {
+          cfgTile->core_trace_config.traced_events[tracedEvent] = cfg->tiles[i].core_trace_config.traced_events[tracedEvent];
+        }
+
+        cfgTile->core_trace_config.start_event = cfg->tiles[i].core_trace_config.start_event;
+        cfgTile->core_trace_config.stop_event = cfg->tiles[i].core_trace_config.stop_event;
+      
+      
+        for (int tracedEvent = 0; tracedEvent < 8; tracedEvent++) {
+          cfgTile->memory_trace_config.traced_events[tracedEvent] = cfg->tiles[i].memory_trace_config.traced_events[tracedEvent];
+        }
+
+        for (int bcEvent = 0; bcEvent < 16; bcEvent++) {
+          cfgTile->core_trace_config.internal_events_broadcast[bcEvent] = cfg->tiles[i].core_trace_config.internal_events_broadcast[bcEvent];
+        }
+        
+        cfgTile->memory_trace_config.start_event = cfg->tiles[i].memory_trace_config.start_event;
+        cfgTile->memory_trace_config.stop_event = cfg->tiles[i].memory_trace_config.stop_event;
+        cfgTile->core_trace_config.broadcast_mask_east = cfg->tiles[i].core_trace_config.broadcast_mask_east;   
+        cfgTile->core_trace_config.broadcast_mask_west = cfg->tiles[i].core_trace_config.broadcast_mask_west; 
+        cfgTile->memory_trace_config.packet_type = cfg->tiles[i].memory_trace_config.packet_type;
+
+        (db->getStaticInfo()).addAIECfgTile(deviceId, cfgTile); 
+      }
+    
+      for (int event = 0; event < 9; event ++) {
+        if (cfg->numTileCoreTraceEvents[event] != 0)
+          (db->getStaticInfo()).addAIECoreEventResources(deviceId, event, cfg->numTileCoreTraceEvents[event]);
+
+        if (cfg->numTileMemoryTraceEvents[event] != 0)
+          (db->getStaticInfo()).addAIEMemoryEventResources(deviceId, event, cfg->numTileMemoryTraceEvents[event]);
+      } 
+
+    } catch (...) {
+      std::string msg = "The aie_trace_config PS kernel was not found.";
+        xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", msg);
+      return false;
+    } 
+
+    std::string msg = "The aie_trace_config PS kernel was successfully scheduled.";
+    xrt_core::message::send(xrt_core::message::severity_level::info, "XRT", msg);
+    
     free(input_params);
-
-  // auto device = xrt::device("0");
-  // auto uuid = device.load_xclbin(xclbin_fnm);
-
-  // Create kernel.  
-  // auto trace_kernel = xrt::kernel(device, uuid.get(), "trace_kernel");
-
-  // // Create a parent BO for kernel input data
-  // auto bo = xrt::bo(device, num*sizeof(uint8_t), trace_kernel.group_id(0));
-  // auto bo_mapped = bo.map<int*>();
-
-  // //Populate the input and reference vectors.
-  // int reference[DATA_SIZE];
-  // for (int i = 0; i < DATA_SIZE; i++) {
-  //   bo_mapped[i] = i;
-  //   int val = 0;
-  //   if(i%4==0)  val = i+2;
-  //   if(i%4==1)  val = i+2;
-  //   if(i%4==2)  val = i-2;
-  //   if(i%4==3)  val = i-2;
-  //   reference[i] = val;
-  // }
-
-    //Call the SetMetrics PS Kernel (TODO)
-    // auto device = xrt::device(device_index);
-    // auto uuid = device.load_xclbin(xclbin_fnm);
-
-    // auto loopback = xrt::kernel(device, uuid.get(), "configure_aie_trace");
-
-    //OutputConfiguration = getDataFromPS();
-    //return OutputConfiguration->success;
     return true; //placeholder
   }
-
-  
 }


### PR DESCRIPTION
Currently, the PS kernels must be attached to the .xclbin to be scheduled correctly. In the future, they will be independent, and the scheduling code will change to reflect how to properly access them.