### PR TITLE
Remove aie_trace_buffer_offload_interval_us  and few clang tidy fixes

### DIFF
--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -359,13 +359,6 @@ get_aie_trace_buffer_offload_interval_ms()
 }
 
 inline unsigned int
-get_aie_trace_buffer_offload_interval_us()
-{
-  static unsigned int value = detail::get_uint_value("Debug.aie_trace_buffer_offload_interval_us", 100);
-  return value;
-}
-
-inline unsigned int
 get_aie_trace_file_dump_interval_s()
 {
   static unsigned int value = detail::get_uint_value("Debug.aie_trace_file_dump_interval_s", 5);

--- a/src/runtime_src/core/include/xdp/fifo.h
+++ b/src/runtime_src/core/include/xdp/fifo.h
@@ -33,23 +33,24 @@ constexpr unsigned int RDFD = 0x1000;
 
 // IP and V++ specific
 namespace properties {
-    constexpr unsigned int SZ_1K   = 1024;
-    constexpr unsigned int SZ_2K   = 2048;
-    constexpr unsigned int SZ_4K   = 4096;
-    constexpr unsigned int SZ_8K   = 8192;
-    constexpr unsigned int SZ_16K  = 16384;
-    constexpr unsigned int SZ_32K  = 32768;
-    constexpr unsigned int SZ_64K  = 65536;
-    constexpr unsigned int SZ_128K = 131072;
+    constexpr unsigned int SIZE_1K   = 1024;
+    constexpr unsigned int SIZE_2K   = 2048;
+    constexpr unsigned int SIZE_4K   = 4096;
+    constexpr unsigned int SIZE_8K   = 8192;
+    constexpr unsigned int SIZE_16K  = 16384;
+    constexpr unsigned int SIZE_32K  = 32768;
+    constexpr unsigned int SIZE_64K  = 65536;
+    constexpr unsigned int SIZE_128K = 131072;
+    // Property to size map
     const std::array<unsigned int, 8> size = {
-        SZ_8K,
-        SZ_1K,
-        SZ_2K,
-        SZ_4K,
-        SZ_16K,
-        SZ_32K,
-        SZ_64K,
-        SZ_128K
+        SIZE_8K,
+        SIZE_1K,
+        SIZE_2K,
+        SIZE_4K,
+        SIZE_16K,
+        SIZE_32K,
+        SIZE_64K,
+        SIZE_128K
     };
 }
 

--- a/src/runtime_src/core/include/xdp/fifo.h
+++ b/src/runtime_src/core/include/xdp/fifo.h
@@ -20,6 +20,8 @@
 #ifndef FIFO_DOT_H
 #define FIFO_DOT_H
 
+#include<array>
+
 namespace xdp::IP::FIFO {
 
 constexpr int alignment = 0x1000;
@@ -30,6 +32,21 @@ namespace AXI_LITE {
 // contents of the FIFO one-by-one over the AXI-Lite connection
 constexpr unsigned int RDFD = 0x1000;
 } // end namespace AXI_LITE
+
+// IP and V++ specific
+namespace properties {
+    constexpr unsigned int MIN_SIZE = 1024;
+    const std::array<unsigned int, 8> size = {
+        8 *   MIN_SIZE,
+        1 *   MIN_SIZE,
+        2 *   MIN_SIZE,
+        4 *   MIN_SIZE,
+        16 *  MIN_SIZE,
+        32 *  MIN_SIZE,
+        64 *  MIN_SIZE,
+        128 * MIN_SIZE
+    };
+}
 
 } // end namespace xdp::IP::FIFO
 

--- a/src/runtime_src/core/include/xdp/fifo.h
+++ b/src/runtime_src/core/include/xdp/fifo.h
@@ -42,6 +42,7 @@ namespace properties {
     constexpr unsigned int SIZE_64K  = 65536;
     constexpr unsigned int SIZE_128K = 131072;
     // Property to size map
+    // Property 0 represents 8k FIFO
     const std::array<unsigned int, 8> size = {
         SIZE_8K,
         SIZE_1K,

--- a/src/runtime_src/core/include/xdp/fifo.h
+++ b/src/runtime_src/core/include/xdp/fifo.h
@@ -20,6 +20,8 @@
 #ifndef FIFO_DOT_H
 #define FIFO_DOT_H
 
+#include <array>
+
 namespace xdp::IP::FIFO {
 
 constexpr int alignment = 0x1000;

--- a/src/runtime_src/core/include/xdp/fifo.h
+++ b/src/runtime_src/core/include/xdp/fifo.h
@@ -20,8 +20,6 @@
 #ifndef FIFO_DOT_H
 #define FIFO_DOT_H
 
-#include<array>
-
 namespace xdp::IP::FIFO {
 
 constexpr int alignment = 0x1000;
@@ -35,16 +33,23 @@ constexpr unsigned int RDFD = 0x1000;
 
 // IP and V++ specific
 namespace properties {
-    constexpr unsigned int MIN_SIZE = 1024;
+    constexpr unsigned int SZ_1K   = 1024;
+    constexpr unsigned int SZ_2K   = 2048;
+    constexpr unsigned int SZ_4K   = 4096;
+    constexpr unsigned int SZ_8K   = 8192;
+    constexpr unsigned int SZ_16K  = 16384;
+    constexpr unsigned int SZ_32K  = 32768;
+    constexpr unsigned int SZ_64K  = 65536;
+    constexpr unsigned int SZ_128K = 131072;
     const std::array<unsigned int, 8> size = {
-        8 *   MIN_SIZE,
-        1 *   MIN_SIZE,
-        2 *   MIN_SIZE,
-        4 *   MIN_SIZE,
-        16 *  MIN_SIZE,
-        32 *  MIN_SIZE,
-        64 *  MIN_SIZE,
-        128 * MIN_SIZE
+        SZ_8K,
+        SZ_1K,
+        SZ_2K,
+        SZ_4K,
+        SZ_16K,
+        SZ_32K,
+        SZ_64K,
+        SZ_128K
     };
 }
 

--- a/src/runtime_src/xdp/profile/database/static_info_database.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info_database.cpp
@@ -50,8 +50,8 @@
 #include "xdp/profile/plugin/vp_base/utility.h"
 #include "xdp/profile/writer/vp_base/vp_run_summary.h"
 
-#define XAM_STALL_PROPERTY_MASK        0x4
-#define XMON_TRACE_PROPERTY_MASK       0x1
+constexpr unsigned int XAM_STALL_PROPERTY_MASK  = 0x4;
+constexpr unsigned int XMON_TRACE_PROPERTY_MASK = 0x1;
 
 namespace xdp {
 

--- a/src/runtime_src/xdp/profile/device/add.cpp
+++ b/src/runtime_src/xdp/profile/device/add.cpp
@@ -16,7 +16,7 @@
 
 #include "add.h"
 
-#define SYSTEM_DEADLOCK_OFFSET  0x0
+constexpr uint32_t SYSTEM_DEADLOCK_OFFSET = 0x0;
 
 namespace xdp {
 

--- a/src/runtime_src/xdp/profile/device/aieTraceS2MM.cpp
+++ b/src/runtime_src/xdp/profile/device/aieTraceS2MM.cpp
@@ -55,7 +55,7 @@ uint64_t AIETraceS2MM::getWordCount(bool final)
 
     uint32_t regValue = 0;
     read(TS2MM_WRITTEN_LOW, BYTES_PER_WORD, &regValue);
-    uint64_t wordCount = static_cast<uint64_t>(regValue);
+    auto wordCount = static_cast<uint64_t>(regValue);
     read(TS2MM_WRITTEN_HIGH, BYTES_PER_WORD, &regValue);
     wordCount |= static_cast<uint64_t>(regValue) << BITS_PER_WORD;
 

--- a/src/runtime_src/xdp/profile/device/am.cpp
+++ b/src/runtime_src/xdp/profile/device/am.cpp
@@ -18,7 +18,9 @@
 #define XDP_SOURCE
 #include "core/include/xdp/am.h"
 #include "xdp/profile/device/am.h"
+#include "xdp/profile/device/tracedefs.h"
 #include "xdp/profile/device/utility.h"
+
 #include <bitset>
 
 namespace xdp {
@@ -117,10 +119,10 @@ size_t AM::readCounter(xdp::CounterResults& counterResults)
         size += read(IP::AM::AXI_LITE::MIN_EXECUTION_CYCLES_UPPER, 4, &upper[2]);
         size += read(IP::AM::AXI_LITE::MAX_EXECUTION_CYCLES_UPPER, 4, &upper[3]);
 
-        counterResults.CuExecCount[s]     += (upper[0] << 32);
-        counterResults.CuExecCycles[s]    += (upper[1] << 32);
-        counterResults.CuMinExecCycles[s] += (upper[2] << 32);
-        counterResults.CuMaxExecCycles[s] += (upper[3] << 32);
+        counterResults.CuExecCount[s]     += (upper[0] << BITS_PER_WORD);
+        counterResults.CuExecCycles[s]    += (upper[1] << BITS_PER_WORD);
+        counterResults.CuMinExecCycles[s] += (upper[2] << BITS_PER_WORD);
+        counterResults.CuMaxExecCycles[s] += (upper[3] << BITS_PER_WORD);
 
 #if 0
         if(out_stream)
@@ -140,8 +142,8 @@ size_t AM::readCounter(xdp::CounterResults& counterResults)
             uint64_t upper[2] = {};
             size += read(IP::AM::AXI_LITE::BUSY_CYCLES_UPPER, 4, &upper[0]);
             size += read(IP::AM::AXI_LITE::MAX_PARALLEL_ITER_UPPER, 4, &upper[1]);
-            counterResults.CuBusyCycles[s]  += (upper[0] << 32);
-            counterResults.CuMaxParallelIter[s]  += (upper[1] << 32);
+            counterResults.CuBusyCycles[s]  += (upper[0] << BITS_PER_WORD);
+            counterResults.CuMaxParallelIter[s]  += (upper[1] << BITS_PER_WORD);
         }
     } else {
         counterResults.CuBusyCycles[s] = counterResults.CuExecCycles[s];

--- a/src/runtime_src/xdp/profile/device/device_intf.cpp
+++ b/src/runtime_src/xdp/profile/device/device_intf.cpp
@@ -237,7 +237,7 @@ DeviceIntf::~DeviceIntf()
     if((type == xdp::MonitorType::accel)  && (index < mAmList.size()))  { return mAmList[index]->getName(); }
     if((type == xdp::MonitorType::str)    && (index < mAsmList.size())) { return mAsmList[index]->getName(); }
     if((type == xdp::MonitorType::noc)    && (index < nocList.size()))  { return nocList[index]->getName(); }
-    return std::string("");
+    return {};
   }
 
   // Same as defined in vpl tcl

--- a/src/runtime_src/xdp/profile/device/device_intf.cpp
+++ b/src/runtime_src/xdp/profile/device/device_intf.cpp
@@ -21,8 +21,6 @@
 #include "device_intf.h"
 #include "tracedefs.h"
 
-#include "xdp/profile/plugin/vp_base/utility.h"
-
 #ifndef _WIN32
 // open+ioctl based Profile IP 
 #include "ioctl_monitors/ioctl_aim.h"

--- a/src/runtime_src/xdp/profile/device/device_intf.h
+++ b/src/runtime_src/xdp/profile/device/device_intf.h
@@ -45,6 +45,7 @@
 #include "xdp/profile/device/traceFifoLite.h"
 #include "xdp/profile/device/traceFunnel.h"
 #include "xdp/profile/device/traceS2MM.h"
+#include "xdp/profile/plugin/vp_base/utility.h"
 
 namespace xdp {
 
@@ -238,10 +239,10 @@ class DeviceIntf {
      * For Edge Device:
      *  total BW: DDR4 memory bandwidth
      */
-    double mHostMaxReadBW    = 15753.85;
-    double mHostMaxWriteBW   = 15753.85;
-    double mKernelMaxReadBW  = 19250.00;
-    double mKernelMaxWriteBW = 19250.00;
+    double mHostMaxReadBW    = hw_constants::pcie_gen3x16_bandwidth;
+    double mHostMaxWriteBW   = hw_constants::pcie_gen3x16_bandwidth;
+    double mKernelMaxReadBW  = hw_constants::ddr4_2400_bandwidth;
+    double mKernelMaxWriteBW = hw_constants::ddr4_2400_bandwidth;
 
 }; /* DeviceIntf */
 

--- a/src/runtime_src/xdp/profile/device/traceFifoFull.cpp
+++ b/src/runtime_src/xdp/profile/device/traceFifoFull.cpp
@@ -16,10 +16,7 @@
 
 #include "traceFifoFull.h"
 
-#define AXI_FIFO_RDFD_AXI_FULL          0x1000
-
-#define TRACE_WORD_WIDTH            64
-#define TRACE_NUMBER_SAMPLES        8192
+constexpr unsigned int TRACE_NUMBER_SAMPLES = 8192;
 
 #include<iomanip>
 #include<cstring>

--- a/src/runtime_src/xdp/profile/device/traceS2MM.cpp
+++ b/src/runtime_src/xdp/profile/device/traceS2MM.cpp
@@ -23,6 +23,10 @@
 
 namespace xdp {
 
+constexpr uint64_t TIMESTAMP_MASK = 0x1FFFFFFFFFFF;
+constexpr unsigned int NUM_CLOCK_TRAIN_PKTS = 8;
+constexpr unsigned int CLOCK_TRAIN_SHIFT = 63;
+
 TraceS2MM::TraceS2MM(Device* handle /** < [in] the xrt or hal device handle */,
                      uint64_t index /** < [in] the index of the IP in debug_ip_layout */, debug_ip_data* data)
     : ProfileIP(handle, index, data),
@@ -56,11 +60,11 @@ void TraceS2MM::init(uint64_t bo_size, int64_t bufaddr, bool circular)
 
     // Configure DDR Offset
     write32(TS2MM_WRITE_OFFSET_LOW, static_cast<uint32_t>(bufaddr));
-    write32(TS2MM_WRITE_OFFSET_HIGH, static_cast<uint32_t>(bufaddr >> 32));
+    write32(TS2MM_WRITE_OFFSET_HIGH, static_cast<uint32_t>(bufaddr >> BITS_PER_WORD));
     // Configure Number of trace words
     uint64_t word_count = bo_size / TRACE_PACKET_SIZE;
     write32(TS2MM_COUNT_LOW, static_cast<uint32_t>(word_count));
-    write32(TS2MM_COUNT_HIGH, static_cast<uint32_t>(word_count >> 32));
+    write32(TS2MM_COUNT_HIGH, static_cast<uint32_t>(word_count >> BITS_PER_WORD));
 
     // Enable use of circular buffer
     if (supportsCircBuf()) {
@@ -109,9 +113,9 @@ uint64_t TraceS2MM::getWordCount(bool final)
 
     uint32_t regValue = 0;
     read(TS2MM_WRITTEN_LOW, 4, &regValue);
-    uint64_t wordCount = static_cast<uint64_t>(regValue);
+    auto wordCount = static_cast<uint64_t>(regValue);
     read(TS2MM_WRITTEN_HIGH, 4, &regValue);
-    wordCount |= static_cast<uint64_t>(regValue) << 32;
+    wordCount |= static_cast<uint64_t>(regValue) << BITS_PER_WORD;
 
     // V2 datamover only writes data in bursts
     // Only the final write can be a non multiple of burst length
@@ -163,13 +167,12 @@ inline void TraceS2MM::parsePacketClockTrain(uint64_t packet)
     if (out_stream)
         (*out_stream) << " TraceS2MM::parsePacketClockTrain " << std::endl;
 
-    static const uint64_t tsmask = 0x1FFFFFFFFFFF;
     if (mModulus == 0) {
-      uint64_t timestamp = packet & tsmask;
+      uint64_t timestamp = packet & TIMESTAMP_MASK;
       if (timestamp >= mPacketFirstTs)
         partialResult.Timestamp = timestamp - mPacketFirstTs;
       else
-        partialResult.Timestamp = timestamp + (tsmask - mPacketFirstTs);
+        partialResult.Timestamp = timestamp + (TIMESTAMP_MASK - mPacketFirstTs);
       partialResult.isClockTrain = 1 ;
     }
 
@@ -187,7 +190,7 @@ void TraceS2MM::parsePacket(uint64_t packet, uint64_t firstTimestamp, xdp::Trace
     if (out_stream)
         (*out_stream) << " TraceS2MM::parsePacket " << std::endl;
 
-    result.Timestamp = (packet & 0x1FFFFFFFFFFF) - firstTimestamp;
+    result.Timestamp = (packet & TIMESTAMP_MASK) - firstTimestamp;
     result.EventType = ((packet >> 45) & 0xF) ? xdp::TraceEventType::end :
       xdp::TraceEventType::start;
     result.TraceID = (packet >> 49) & 0xFFF;
@@ -219,7 +222,7 @@ uint64_t TraceS2MM::seekClockTraining(uint64_t* arr, uint64_t count)
   if (out_stream)
       (*out_stream) << " TraceS2MM::seekClockTraining " << std::endl;
 
-  uint64_t n = 8;
+  uint64_t n = NUM_CLOCK_TRAIN_PKTS;
   if (mTraceFormat < 1  || mclockTrainingdone)
     return 0;
   if (count < n)
@@ -228,7 +231,7 @@ uint64_t TraceS2MM::seekClockTraining(uint64_t* arr, uint64_t count)
   count -= n;
   for (uint64_t i=0; i <= count; i++) {
     for (uint64_t j=i; j < i + n; j++) {
-      if (!((arr[j] >> 63) & 0x1))
+      if (!((arr[j] >> CLOCK_TRAIN_SHIFT) & 0x1))
         break;
       if (j == i+n-1)
         return i;
@@ -242,7 +245,7 @@ void TraceS2MM::parseTraceBuf(void* buf, uint64_t size, std::vector<xdp::TraceEv
     if (out_stream)
         (*out_stream) << " TraceS2MM::parseTraceBuf " << std::endl;
 
-    uint32_t packetSizeBytes = 8;
+    uint32_t packetSizeBytes = TRACE_PACKET_SIZE;
     traceVector.clear();
 
     uint64_t count = size / packetSizeBytes;
@@ -265,13 +268,13 @@ void TraceS2MM::parseTraceBuf(void* buf, uint64_t size, std::vector<xdp::TraceEv
         break;
       // Poor man's reset
       if (i == 0 && !mPacketFirstTs)
-        mPacketFirstTs = currentPacket & 0x1FFFFFFFFFFF;
+        mPacketFirstTs = currentPacket & TIMESTAMP_MASK;
 
       bool isClockTrain = false;
       if (mTraceFormat == 1) {
-        isClockTrain = ((currentPacket >> 63) & 0x1);
+        isClockTrain = ((currentPacket >> CLOCK_TRAIN_SHIFT) & 0x1);
       } else {
-        isClockTrain = (i < 8 && !mclockTrainingdone);
+        isClockTrain = (i < NUM_CLOCK_TRAIN_PKTS && !mclockTrainingdone);
       }
 
       if (isClockTrain) {

--- a/src/runtime_src/xdp/profile/device/tracedefs.h
+++ b/src/runtime_src/xdp/profile/device/tracedefs.h
@@ -100,6 +100,7 @@ trace settings."
 #define TRACE_DUMP_FILE_COUNT_WARN 10
 #define TRACE_DUMP_FILE_COUNT_WARN_MSG "Continuous Trace might create a large number of trace files. Please use trace_file_dump_interval \
 to control how often trace data is written."
+#define DEFAULT_AIE_TRACE_DUMP_INTERVAL_S 5
 
 namespace xdp {
 

--- a/src/runtime_src/xdp/profile/device/utility.h
+++ b/src/runtime_src/xdp/profile/device/utility.h
@@ -59,6 +59,8 @@ namespace xdp {
   constexpr int min_trace_id_asm     = 576;
   constexpr int max_trace_id_asm     = 607;
 
+  constexpr unsigned int sysfs_max_path_length = 512;
+
 } // end namespace xdp
 
 #endif

--- a/src/runtime_src/xdp/profile/plugin/aie_debug/aie_debug_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_debug/aie_debug_plugin.cpp
@@ -20,6 +20,7 @@
 #include "xdp/profile/plugin/aie_debug/aie_debug_plugin.h"
 
 #include "xdp/profile/database/database.h"
+#include "xdp/profile/device/utility.h"
 #include "xdp/profile/plugin/vp_base/info.h"
 #include "xdp/profile/writer/aie_debug/aie_debug_writer.h"
 
@@ -29,6 +30,7 @@
 #include "core/common/config_reader.h"
 #include "core/include/experimental/xrt-next.h"
 #include "core/edge/user/shim.h"
+
 #include <set>
 
 namespace {
@@ -377,12 +379,9 @@ namespace xdp {
     if (!xrt_core::config::get_aie_status())
       return;
 
-    const unsigned int PATH_LENGTH = 512;
-    char pathBuf[PATH_LENGTH];
-    memset(pathBuf, 0, PATH_LENGTH);
-    xclGetDebugIPlayoutPath(handle, pathBuf, PATH_LENGTH);
-
-    std::string sysfspath(pathBuf);
+    std::array<char, sysfs_max_path_length> pathBuf = {0};
+    xclGetDebugIPlayoutPath(handle, pathBuf.data(), (sysfs_max_path_length-1) ) ;
+    std::string sysfspath(pathBuf.data());
     uint64_t deviceID = db->addDevice(sysfspath); // Get the unique device Id
 
     if (!(db->getStaticInfo()).isDeviceReady(deviceID)) {

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.cpp
@@ -28,6 +28,7 @@
 
 #include "xdp/profile/database/database.h"
 #include "xdp/profile/database/static_info/aie_constructs.h"
+#include "xdp/profile/device/utility.h"
 #include "xdp/profile/plugin/aie_profile/aie_plugin.h"
 #include "xdp/profile/plugin/vp_base/info.h"
 #include "xdp/profile/writer/aie_profile/aie_writer.h"
@@ -891,11 +892,9 @@ namespace xdp {
     if (!xrt_core::config::get_aie_profile())
       return;
 
-    char pathBuf[512];
-    memset(pathBuf, 0, 512);
-    xclGetDebugIPlayoutPath(handle, pathBuf, 512);
-
-    std::string sysfspath(pathBuf);
+    std::array<char, sysfs_max_path_length> pathBuf = {0};
+    xclGetDebugIPlayoutPath(handle, pathBuf.data(), (sysfs_max_path_length-1) ) ;
+    std::string sysfspath(pathBuf.data());
     uint64_t deviceId = db->addDevice(sysfspath); // Get the unique device Id
 
     if (!(db->getStaticInfo()).isDeviceReady(deviceId)) {

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.cpp
@@ -32,22 +32,22 @@
 #include "xdp/profile/plugin/vp_base/info.h"
 #include "xdp/profile/writer/aie_profile/aie_writer.h"
 
-#define NUM_CORE_COUNTERS     4
-#define NUM_MEMORY_COUNTERS   2
-#define NUM_SHIM_COUNTERS     2
-#define BASE_MEMORY_COUNTER 128
-#define BASE_SHIM_COUNTER   256
+constexpr unsigned int NUM_CORE_COUNTERS   = 4;
+constexpr unsigned int NUM_MEMORY_COUNTERS = 2;
+constexpr unsigned int NUM_SHIM_COUNTERS  =  2;
+constexpr unsigned int BASE_MEMORY_COUNTER = 128;
+constexpr unsigned int BASE_SHIM_COUNTER =   256;
 
-#define GROUP_DMA_MASK                   0x0000f000
-#define GROUP_LOCK_MASK                  0x55555555
-#define GROUP_CONFLICT_MASK              0x000000ff
-#define GROUP_ERROR_MASK                 0x00003fff
-#define GROUP_STREAM_SWITCH_IDLE_MASK    0x11111111
-#define GROUP_STREAM_SWITCH_RUNNING_MASK 0x22222222
-#define GROUP_STREAM_SWITCH_STALLED_MASK 0x44444444
-#define GROUP_STREAM_SWITCH_TLAST_MASK   0x88888888
-#define GROUP_CORE_PROGRAM_FLOW_MASK     0x00001FE0
-#define GROUP_CORE_STALL_MASK            0x0000000F
+constexpr uint32_t GROUP_DMA_MASK                   = 0x0000f000;
+constexpr uint32_t GROUP_LOCK_MASK                  = 0x55555555;
+constexpr uint32_t GROUP_CONFLICT_MASK              = 0x000000ff;
+constexpr uint32_t GROUP_ERROR_MASK                 = 0x00003fff;
+constexpr uint32_t GROUP_STREAM_SWITCH_IDLE_MASK    = 0x11111111;
+constexpr uint32_t GROUP_STREAM_SWITCH_RUNNING_MASK = 0x22222222;
+constexpr uint32_t GROUP_STREAM_SWITCH_STALLED_MASK = 0x44444444;
+constexpr uint32_t GROUP_STREAM_SWITCH_TLAST_MASK   = 0x88888888;
+constexpr uint32_t GROUP_CORE_PROGRAM_FLOW_MASK     = 0x00001FE0;
+constexpr uint32_t GROUP_CORE_STALL_MASK            = 0x0000000F;
 
 namespace {
   static void* fetchAieDevInst(void* devHandle)

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -37,12 +37,13 @@
 #include "xdp/profile/device/tracedefs.h"
 #include "xdp/profile/plugin/aie_trace/aie_trace_plugin.h"
 #include "xdp/profile/plugin/vp_base/info.h"
+#include "xdp/profile/plugin/vp_base/utility.h"
 #include "xdp/profile/writer/aie_trace/aie_trace_writer.h"
 #include "xdp/profile/writer/aie_trace/aie_trace_config_writer.h"
 
-#define NUM_CORE_TRACE_EVENTS   8
-#define NUM_MEMORY_TRACE_EVENTS 8
-#define CORE_BROADCAST_EVENT_BASE 107
+constexpr unsigned int NUM_CORE_TRACE_EVENTS = 8;
+constexpr unsigned int NUM_MEMORY_TRACE_EVENTS = 8;
+constexpr unsigned int CORE_BROADCAST_EVENT_BASE = 107;
 
 namespace {
   static void* fetchAieDevInst(void* devHandle)
@@ -58,16 +59,15 @@ namespace {
 
   static void* allocateAieDevice(void* devHandle)
   {
-    XAie_DevInst* aieDevInst =
-      static_cast<XAie_DevInst*>(fetchAieDevInst(devHandle)) ;
+    auto aieDevInst = static_cast<XAie_DevInst*>(fetchAieDevInst(devHandle)) ;
     if (!aieDevInst)
-      return nullptr ;
+      return nullptr;
     return new xaiefal::XAieDev(aieDevInst, false) ;
   }
 
   static void deallocateAieDevice(void* aieDevice)
   {
-    xaiefal::XAieDev* object = static_cast<xaiefal::XAieDev*>(aieDevice) ;
+    auto object = static_cast<xaiefal::XAieDev*>(aieDevice) ;
     if (object != nullptr)
       delete object ;
   }
@@ -106,7 +106,7 @@ namespace xdp {
       if (offloadIntervalms != 10) {
         xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", 
           "The xrt.ini flag \"aie_trace_buffer_offload_interval_ms\" is deprecated and will be removed in future release. Please use \"buffer_offload_interval_us\" under \"AIE_trace_settings\" section.");
-        offloadIntervalUs = offloadIntervalms * 1e3;
+        offloadIntervalUs = offloadIntervalms * uint_constants::one_thousand;;
       } else {
         offloadIntervalUs = xrt_core::config::get_aie_trace_settings_buffer_offload_interval_us();
         if (100 == offloadIntervalUs) {
@@ -451,7 +451,7 @@ namespace xdp {
       }
 
       std::smatch pieces_match;
-      uint64_t cycles_per_sec = static_cast<uint64_t>(freqMhz * 1e6);
+      uint64_t cycles_per_sec = static_cast<uint64_t>(freqMhz * uint_constants::one_million);
 
       // AIE_trace_settings configs have higher priority than older Debug configs
       std::string size_str = xrt_core::config::get_aie_trace_settings_start_time();
@@ -471,11 +471,11 @@ namespace xdp {
           if (pieces_match[2] == "s") {
             cycles = static_cast<uint64_t>(std::stof(pieces_match[1]) * cycles_per_sec);
           } else if (pieces_match[2] == "ms") {
-            cycles = static_cast<uint64_t>(std::stof(pieces_match[1]) * cycles_per_sec /  1e3);
+            cycles = static_cast<uint64_t>(std::stof(pieces_match[1]) * cycles_per_sec /  uint_constants::one_thousand);
           } else if (pieces_match[2] == "us") {
-            cycles = static_cast<uint64_t>(std::stof(pieces_match[1]) * cycles_per_sec /  1e6);
+            cycles = static_cast<uint64_t>(std::stof(pieces_match[1]) * cycles_per_sec /  uint_constants::one_million);
           } else if (pieces_match[2] == "ns") {
-            cycles = static_cast<uint64_t>(std::stof(pieces_match[1]) * cycles_per_sec /  1e9);
+            cycles = static_cast<uint64_t>(std::stof(pieces_match[1]) * cycles_per_sec /  uint_constants::one_billion);
           } else {
             cycles = static_cast<uint64_t>(std::stof(pieces_match[1]));
           }
@@ -1039,12 +1039,9 @@ bool AieTracePlugin::configureStartIteration(xaiefal::XAieMod& core)
     if (handle == nullptr)
       return;
 
-    char pathBuf[512];
-    memset(pathBuf, 0, 512);
-    xclGetDebugIPlayoutPath(handle, pathBuf, 512);
-
-    std::string sysfspath(pathBuf);
-
+    std::array<char, MAX_PATH_LENGTH> pathBuf = {0};
+    xclGetDebugIPlayoutPath(handle, pathBuf.data(), (MAX_PATH_LENGTH-1) );
+    std::string sysfspath(pathBuf.data());
     uint64_t deviceId = db->addDevice(sysfspath); // Get the unique device Id
 
     deviceIdToHandle[deviceId] = handle;

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -35,6 +35,7 @@
 #include "xdp/profile/device/device_intf.h"
 #include "xdp/profile/device/hal_device/xdp_hal_device.h"
 #include "xdp/profile/device/tracedefs.h"
+#include "xdp/profile/device/utility.h"
 #include "xdp/profile/plugin/aie_trace/aie_trace_plugin.h"
 #include "xdp/profile/plugin/vp_base/info.h"
 #include "xdp/profile/plugin/vp_base/utility.h"
@@ -1035,8 +1036,8 @@ bool AieTracePlugin::configureStartIteration(xaiefal::XAieMod& core)
     if (handle == nullptr)
       return;
 
-    std::array<char, MAX_PATH_LENGTH> pathBuf = {0};
-    xclGetDebugIPlayoutPath(handle, pathBuf.data(), (MAX_PATH_LENGTH-1) );
+    std::array<char, sysfs_max_path_length> pathBuf = {0};
+    xclGetDebugIPlayoutPath(handle, pathBuf.data(), (sysfs_max_path_length-1) );
     std::string sysfspath(pathBuf.data());
     uint64_t deviceId = db->addDevice(sysfspath); // Get the unique device Id
 

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -45,6 +45,9 @@ constexpr unsigned int NUM_CORE_TRACE_EVENTS = 8;
 constexpr unsigned int NUM_MEMORY_TRACE_EVENTS = 8;
 constexpr unsigned int CORE_BROADCAST_EVENT_BASE = 107;
 
+constexpr uint32_t ES1_TRACE_COUNTER = 1020;
+constexpr uint32_t ES2_TRACE_COUNTER = 0x3FF00;
+
 namespace {
   static void* fetchAieDevInst(void* devHandle)
   {
@@ -109,13 +112,6 @@ namespace xdp {
         offloadIntervalUs = offloadIntervalms * uint_constants::one_thousand;;
       } else {
         offloadIntervalUs = xrt_core::config::get_aie_trace_settings_buffer_offload_interval_us();
-        if (100 == offloadIntervalUs) {
-          // if set to default value, then check for old style config
-          offloadIntervalUs = xrt_core::config::get_aie_trace_buffer_offload_interval_us();
-          if (100 != offloadIntervalUs)
-            xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT",
-              "The xrt.ini flag \"aie_trace_buffer_offload_interval_us\" is deprecated and will be removed in future release. Please use \"buffer_offload_interval_us\" under \"AIE_trace_settings\" section.");
-        }
       }
     }
 
@@ -173,12 +169,12 @@ namespace xdp {
     if (counterScheme == "es1") {
       coreCounterStartEvents   = {XAIE_EVENT_ACTIVE_CORE,             XAIE_EVENT_ACTIVE_CORE};
       coreCounterEndEvents     = {XAIE_EVENT_DISABLED_CORE,           XAIE_EVENT_DISABLED_CORE};
-      coreCounterEventValues   = {1020, 1020*1020};
+      coreCounterEventValues   = {ES1_TRACE_COUNTER, ES1_TRACE_COUNTER * ES1_TRACE_COUNTER};
     }
     else if (counterScheme == "es2") {
       coreCounterStartEvents   = {XAIE_EVENT_ACTIVE_CORE};
       coreCounterEndEvents     = {XAIE_EVENT_DISABLED_CORE};
-      coreCounterEventValues   = {0x3FF00};
+      coreCounterEventValues   = {ES2_TRACE_COUNTER};
     }
     
     // **** Memory Module Counters ****
@@ -189,20 +185,20 @@ namespace xdp {
     if (counterScheme == "es1") {
       memoryCounterStartEvents = {XAIE_EVENT_TRUE_MEM,                XAIE_EVENT_TRUE_MEM};
       memoryCounterEndEvents   = {XAIE_EVENT_NONE_MEM,                XAIE_EVENT_NONE_MEM};
-      memoryCounterEventValues = {1020, 1020*1020};
+      memoryCounterEventValues = {ES1_TRACE_COUNTER, ES1_TRACE_COUNTER * ES1_TRACE_COUNTER};
     }
     else if (counterScheme == "es2") {
       memoryCounterStartEvents = {XAIE_EVENT_TRUE_MEM};
       memoryCounterEndEvents   = {XAIE_EVENT_NONE_MEM};
-      memoryCounterEventValues = {0x3FF00};
+      memoryCounterEventValues = {ES2_TRACE_COUNTER};
     }
 
     //Process the file dump interval
     aie_trace_file_dump_int_s = xrt_core::config::get_aie_trace_settings_file_dump_interval_s();
-    if (5 == aie_trace_file_dump_int_s) {
+    if (aie_trace_file_dump_int_s == DEFAULT_AIE_TRACE_DUMP_INTERVAL_S) {
       // if set to default value, then check for old style config
       aie_trace_file_dump_int_s = xrt_core::config::get_aie_trace_file_dump_interval_s();
-      if (5 != aie_trace_file_dump_int_s)
+      if (aie_trace_file_dump_int_s != DEFAULT_AIE_TRACE_DUMP_INTERVAL_S)
         xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT",
           "The xrt.ini flag \"aie_trace_file_dump_interval_s\" is deprecated and will be removed in future release. Please use \"file_dump_interval_s\" under \"AIE_trace_settings\" section.");
     }

--- a/src/runtime_src/xdp/profile/plugin/aie_trace_new/aie_trace_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace_new/aie_trace_metadata.cpp
@@ -65,11 +65,11 @@ namespace xdp {
       if (offloadIntervalms != 10) {
         std::stringstream msg;
         msg << "aie_trace_buffer_offload_interval_ms will be deprecated in future. "
-            << "Please use aie_trace_buffer_offload_interval_us instead.";
+            << "Please use \"buffer_offload_interval_us\" under \"AIE_trace_settings\" section.";
         xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", msg.str());
         offloadIntervalUs = offloadIntervalms * uint_constants::one_thousand;
       } else {
-        offloadIntervalUs = xrt_core::config::get_aie_trace_buffer_offload_interval_us();
+        offloadIntervalUs = xrt_core::config::get_aie_trace_settings_buffer_offload_interval_us();
       }
     }
 

--- a/src/runtime_src/xdp/profile/plugin/aie_trace_new/aie_trace_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace_new/aie_trace_metadata.cpp
@@ -96,7 +96,7 @@ namespace xdp {
     }
 
     // Catch when compile-time trace is specified (e.g., --event-trace=functions)
-    std::shared_ptr<xrt_core::device> device = xrt_core::get_userpf_device(handle);
+    auto device = xrt_core::get_userpf_device(handle);
     auto compilerOptions = get_aiecompiler_options(device.get());
     runtimeMetrics = (compilerOptions.event_trace == "runtime");
   }
@@ -105,7 +105,7 @@ namespace xdp {
   {
     // Catch when compile-time trace is specified (e.g., --event-trace=functions)
     if (!getRuntimeMetrics()) {
-      std::shared_ptr<xrt_core::device> device = xrt_core::get_userpf_device(handle);
+      auto device = xrt_core::get_userpf_device(handle);
       auto compilerOptions = get_aiecompiler_options(device.get());
       std::stringstream msg;
       msg << "Found compiler trace option of " << compilerOptions.event_trace
@@ -184,7 +184,7 @@ namespace xdp {
       freqMhz = get_clock_freq_mhz(device.get());
     }
 
-    uint64_t cycles_per_sec = static_cast<uint64_t>(freqMhz * uint_constants::one_million);
+    auto cycles_per_sec = static_cast<uint64_t>(freqMhz * uint_constants::one_million);
     const uint64_t max_cycles = 0xffffffff;
     std::string size_str = xrt_core::config::get_aie_trace_start_time();
 
@@ -335,13 +335,12 @@ namespace xdp {
   {
     auto data = device->get_axlf_section(AIE_METADATA);
     if (!data.first || !data.second)
-      return 1000.0;  // magic
+      return AIE_DEFAULT_FREQ_MHZ;
 
     pt::ptree aie_meta;
     read_aie_metadata(data.first, data.second, aie_meta);
     auto dev_node = aie_meta.get_child("aie_metadata.DeviceData");
-    double clockFreqMhz = dev_node.get<double>("AIEFrequency");
-    return clockFreqMhz;
+    return dev_node.get<double>("AIEFrequency");
   }
 
   std::vector<gmio_type> AieTraceMetadata::get_trace_gmios(const xrt_core::device* device)

--- a/src/runtime_src/xdp/profile/plugin/aie_trace_new/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace_new/aie_trace_plugin.cpp
@@ -28,6 +28,7 @@
 #include "xdp/profile/device/aie_trace/aie_trace_offload.h"
 #include "xdp/profile/device/device_intf.h"
 #include "xdp/profile/device/hal_device/xdp_hal_device.h"
+#include "xdp/profile/device/utility.h"
 #include "xdp/profile/plugin/vp_base/info.h"
 #include "xdp/profile/writer/aie_trace/aie_trace_writer.h"
 #include "xdp/profile/writer/aie_trace/aie_trace_config_writer.h"
@@ -73,16 +74,13 @@ namespace xdp {
 
   uint64_t AieTracePluginUnified::getDeviceIDFromHandle(void* handle)
   {
-    constexpr uint32_t PATH_LENGTH = 512;
-
     auto itr = handleToAIEData.find(handle);
     if (itr != handleToAIEData.end())
       return itr->second.deviceID;
 
-    char pathBuf[PATH_LENGTH];
-    memset(pathBuf, 0, PATH_LENGTH);
-    xclGetDebugIPlayoutPath(handle, pathBuf, PATH_LENGTH);
-    std::string sysfspath(pathBuf);
+    std::array<char, sysfs_max_path_length> pathBuf = {0};
+    xclGetDebugIPlayoutPath(handle, pathBuf.data(), (sysfs_max_path_length-1) ) ;
+    std::string sysfspath(pathBuf.data());
     uint64_t deviceID =  db->addDevice(sysfspath); // Get the unique device Id
     return deviceID;
   }

--- a/src/runtime_src/xdp/profile/plugin/device_offload/hal/hal_device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/hal/hal_device_offload_plugin.cpp
@@ -16,6 +16,7 @@
 
 #define XDP_SOURCE
 
+#include <array>
 #include <string>
 #include <vector>
 

--- a/src/runtime_src/xdp/profile/plugin/device_offload/hal/hal_device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/hal/hal_device_offload_plugin.cpp
@@ -27,6 +27,7 @@
 #include "xdp/profile/database/database.h"
 #include "xdp/profile/device/device_intf.h"
 #include "xdp/profile/device/hal_device/xdp_hal_device.h"
+#include "xdp/profile/device/utility.h"
 #include "xdp/profile/plugin/device_offload/hal/hal_device_offload_plugin.h"
 #include "xdp/profile/plugin/vp_base/info.h"
 #include "xdp/profile/plugin/vp_base/utility.h"
@@ -49,11 +50,9 @@ namespace xdp {
       deviceHandles.push_back(handle) ;
 
       // Second, add all the information and a writer for this device
-      char pathBuf[maxPathLength] ;
-      memset(pathBuf, 0, maxPathLength) ;
-      xclGetDebugIPlayoutPath(handle, pathBuf, maxPathLength-1) ;
-
-      std::string path(pathBuf) ;
+      std::array<char, sysfs_max_path_length> pathBuf = {0};
+      xclGetDebugIPlayoutPath(handle, pathBuf.data(), (sysfs_max_path_length-1) ) ;
+      std::string path(pathBuf.data());
       if (path != "") {
         addDevice(path) ;
 

--- a/src/runtime_src/xdp/profile/plugin/device_offload/hw_emu/hw_emu_device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/hw_emu/hw_emu_device_offload_plugin.cpp
@@ -21,8 +21,9 @@
 #include "core/common/message.h"
 #include "core/common/xrt_profiling.h"
 
-#include "xdp/profile/device/hal_device/xdp_hal_device.h"
 #include "xdp/profile/database/database.h"
+#include "xdp/profile/device/hal_device/xdp_hal_device.h"
+#include "xdp/profile/device/utility.h"
 #include "xdp/profile/plugin/device_offload/hw_emu/hw_emu_device_offload_plugin.h"
 #include "xdp/profile/plugin/vp_base/info.h"
 
@@ -31,11 +32,8 @@ namespace {
 
   static std::string getDebugIPLayoutPath(void* handle)
   {
-    constexpr int MAX_PATH_LENGTH = 512 ;
-
-    std::array<char, MAX_PATH_LENGTH> pathBuf = {0};
-    xclGetDebugIPlayoutPath(handle, pathBuf.data(), (MAX_PATH_LENGTH-1) ) ;
-
+    std::array<char, xdp::sysfs_max_path_length> pathBuf = {0};
+    xclGetDebugIPlayoutPath(handle, pathBuf.data(), (xdp::sysfs_max_path_length-1) ) ;
     std::string path(pathBuf.data());
 
     if (path == "")

--- a/src/runtime_src/xdp/profile/plugin/device_offload/hw_emu/hw_emu_device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/hw_emu/hw_emu_device_offload_plugin.cpp
@@ -33,14 +33,13 @@ namespace {
   {
     constexpr int MAX_PATH_LENGTH = 512 ;
 
-    char pathBuf[MAX_PATH_LENGTH] ;
-    memset(pathBuf, 0, MAX_PATH_LENGTH);
-    xclGetDebugIPlayoutPath(handle, pathBuf, (MAX_PATH_LENGTH-1) ) ;
+    std::array<char, MAX_PATH_LENGTH> pathBuf = {0};
+    xclGetDebugIPlayoutPath(handle, pathBuf.data(), (MAX_PATH_LENGTH-1) ) ;
 
-    std::string path(pathBuf) ;
+    std::string path(pathBuf.data());
 
     if (path == "")
-      return path ;
+      return path;
 
     // Full paths to the hardware emulation debug_ip_layout for different
     //  xclbins on the same device are different.  On disk, they are laid

--- a/src/runtime_src/xdp/profile/plugin/hal/hal_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/hal/hal_plugin.cpp
@@ -30,8 +30,6 @@
 #include "core/common/xrt_profiling.h"
 #include "core/common/message.h"
 
-#define MAX_PATH_SZ 512
-
 namespace xdp {
 
   bool HALPlugin::live = false;

--- a/src/runtime_src/xdp/profile/plugin/pl_deadlock/pl_deadlock_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/pl_deadlock/pl_deadlock_plugin.cpp
@@ -29,6 +29,7 @@
 
 #include "xdp/profile/device/device_intf.h"
 #include "xdp/profile/device/hal_device/xdp_hal_device.h"
+#include "xdp/profile/device/utility.h"
 
 #include "core/common/system.h"
 #include "core/common/message.h"
@@ -106,11 +107,9 @@ namespace xdp {
 
   void PLDeadlockPlugin::updateDevice(void* handle)
   {
-    const unsigned int PATH_LENGTH = 512;
-    char pathBuf[PATH_LENGTH];
-    memset(pathBuf, 0, PATH_LENGTH);
-    xclGetDebugIPlayoutPath(handle, pathBuf, PATH_LENGTH);
-    std::string path(pathBuf);
+    std::array<char, sysfs_max_path_length> pathBuf = {0};
+    xclGetDebugIPlayoutPath(handle, pathBuf.data(), (sysfs_max_path_length-1) ) ;
+    std::string path(pathBuf.data());
     uint64_t deviceId = db->addDevice(path);
 
     if (!(db->getStaticInfo()).isDeviceReady(deviceId)) {

--- a/src/runtime_src/xdp/profile/plugin/pl_deadlock/pl_deadlock_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/pl_deadlock/pl_deadlock_plugin.cpp
@@ -16,9 +16,10 @@
 
 #define XDP_SOURCE
 
+#include <array>
+#include <iostream>
 #include <string>
 #include <vector>
-#include <iostream>
 
 #include "core/common/xrt_profiling.h"
 #include "core/common/message.h"

--- a/src/runtime_src/xdp/profile/plugin/vp_base/utility.h
+++ b/src/runtime_src/xdp/profile/plugin/vp_base/utility.h
@@ -45,6 +45,11 @@ namespace xdp {
     constexpr uint64_t one_gb = 1024 * 1024 * 1024;
   }
 
+  namespace hw_constants {
+    constexpr double pcie_gen3x16_bandwidth = 15753.85;
+    constexpr double ddr4_2400_bandwidth = 19250.00;
+  }
+
   XDP_EXPORT Flow getFlowMode() ;
 
 } // end namespace xdp

--- a/src/runtime_src/xdp/profile/plugin/vp_base/utility.h
+++ b/src/runtime_src/xdp/profile/plugin/vp_base/utility.h
@@ -37,9 +37,9 @@ namespace xdp {
   };
 
   namespace uint_constants {
-    constexpr uint64_t one_thousand = 1e3;
-    constexpr uint64_t one_million  = 1e6;
-    constexpr uint64_t one_billion  = 1e9;
+    constexpr uint64_t one_thousand = 1000;
+    constexpr uint64_t one_million  = 1000000;
+    constexpr uint64_t one_billion  = 1000000000;
     constexpr uint64_t one_kb = 1024;
     constexpr uint64_t one_mb = 1024 * 1024;
     constexpr uint64_t one_gb = 1024 * 1024 * 1024;

--- a/src/runtime_src/xdp/profile/plugin/vp_base/utility.h
+++ b/src/runtime_src/xdp/profile/plugin/vp_base/utility.h
@@ -40,6 +40,9 @@ namespace xdp {
     constexpr uint64_t one_thousand = 1e3;
     constexpr uint64_t one_million  = 1e6;
     constexpr uint64_t one_billion  = 1e9;
+    constexpr uint64_t one_kb = 1024;
+    constexpr uint64_t one_mb = 1024 * 1024;
+    constexpr uint64_t one_gb = 1024 * 1024 * 1024;
   }
 
   XDP_EXPORT Flow getFlowMode() ;

--- a/src/runtime_src/xdp/profile/plugin/vp_base/utility.h
+++ b/src/runtime_src/xdp/profile/plugin/vp_base/utility.h
@@ -34,7 +34,13 @@ namespace xdp {
     HW_EMU  = 1,
     HW      = 2,
     UNKNOWN = 3
-  } ;
+  };
+
+  namespace uint_constants {
+    constexpr uint64_t one_thousand = 1e3;
+    constexpr uint64_t one_million  = 1e6;
+    constexpr uint64_t one_billion  = 1e9;
+  }
 
   XDP_EXPORT Flow getFlowMode() ;
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Switch aie_trace_buffer_offload_interval_us was added in 2022.2 so no need to deprecate it. It was moved to AIE_trace_settings section
Cleaned up some clang tidy warnings
Commits say coverity by mistake
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
NA
#### How problem was solved, alternative solutions (if any) and why they were rejected
NA
#### Risks (if any) associated the changes in the commit
Low
#### What has been tested and how, request additional testing if necessary
Tested on a pcie hw design with trace
#### Documentation impact (if any)
