### PR TITLE
CR-1127986 P2P status shows "reboot" instead of "no iomem"

### DIFF
--- a/src/runtime_src/core/common/query_requests.cpp
+++ b/src/runtime_src/core/common/query_requests.cpp
@@ -19,7 +19,7 @@ to_string(xrt_core::query::p2p_config::value_type value)
    { xrt_core::query::p2p_config::value_type::disabled,      "disabled" },
    { xrt_core::query::p2p_config::value_type::enabled,       "enabled" },
    { xrt_core::query::p2p_config::value_type::error,         "error" },
-   { xrt_core::query::p2p_config::value_type::reboot,        "reboot" },
+   { xrt_core::query::p2p_config::value_type::no_iomem,        "no iomem" },
    { xrt_core::query::p2p_config::value_type::not_supported, "not supported" },
   };
 
@@ -62,10 +62,10 @@ parse(const xrt_core::query::p2p_config::result_type& config)
     return {xrt_core::query::p2p_config::value_type::not_supported, "P2P config failed. P2P is not supported. Can't find P2P BAR."};
 
   if (config_map.find("rbar") != config_map.end() && config_map.at("rbar") > config_map.at("bar"))
-    return {xrt_core::query::p2p_config::value_type::reboot, "Warning:Please WARM reboot to enable p2p now."};
+    return {xrt_core::query::p2p_config::value_type::no_iomem, "Warning: Please WARM reboot to enable p2p now."};
 
   if (config_map.find("remap") != config_map.end() && config_map.at("remap") > 0 && config_map.at("remap") != config_map.at("bar"))
-    return {xrt_core::query::p2p_config::value_type::error, "Error:P2P config failed. P2P remapper is not set correctly"};
+    return {xrt_core::query::p2p_config::value_type::error, "Error: P2P config failed. P2P remapper is not set correctly"};
 
   if (config_map.find("exp_bar") != config_map.end() && config_map.at("exp_bar") == config_map.at("bar"))
     return {xrt_core::query::p2p_config::value_type::enabled, ""};

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -1478,7 +1478,7 @@ struct p2p_config : request
   static const key_type key = key_type::p2p_config;
   static const char* name() { return "p2p_config"; }
 
-  enum class value_type { disabled, enabled, error, reboot, not_supported };
+  enum class value_type { disabled, enabled, error, no_iomem, not_supported };
 
   // parse a config result and return value and msg
   XRT_CORE_COMMON_EXPORT


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
As per P2P documentation there are 3 p2p status and when you enable p2p, xbutil examine is expected to show p2p status as no iomem but in 22.1 XRT when p2p is enabled xbutil examine shows status as "reboot" :

This status is incorrect and xbutil examine needs update.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Internal discovery

#### How problem was solved, alternative solutions (if any) and why they were rejected
`reboot` has been changed to `no iomem` in an effort to get the users to look into the P2P documentation and find the correct course of action.  Otherwise the user may think that the P2P device is rebooting and continue to wait.

#### Risks (if any) associated the changes in the commit
This is a text change so there is risk if someone is parsing the output of the p2p status and checking for reboot. But that is not very likely.

#### What has been tested and how, request additional testing if necessary
Ubuntu 20.04 on U280
```
root@xsjminm50:/proj/rdi/staff/dbenusov/XRT/src/runtime_src/core/pcie/driver/linux/xocl/userpf# xbutil examine -d 03:00 -r platform

-------------------------------------------
[0000:03:00.1] : xilinx_u280_xdma_201920_3
-------------------------------------------
Platform
  XSA Name               : xilinx_u280_xdma_201920_3
  Platform UUID          : 0x5e278820
  FPGA Name              : xcu280-fsvh2892-2L-e
  JTAG ID Code           : 0x14b7d093
  DDR Size               : 34359738368 Bytes
  DDR Count              : 2
  Mig Calibrated         : true
  P2P Status             : disabled
  P2P IO space required  : 64 GB

Mac Addresses            : 01:02:03:04:05:06
                         : 01:02:03:04:05:07

root@xsjminm50:/proj/rdi/staff/dbenusov/XRT/src/runtime_src/core/pcie/driver/linux/xocl/userpf# xbutil configure -d 03:00 --p2p ENABLE
Please WARM reboot the machine to enable P2P now.
root@xsjminm50:/proj/rdi/staff/dbenusov/XRT/src/runtime_src/core/pcie/driver/linux/xocl/userpf# xbutil examine -d 03:00 -r platform

-------------------------------------------
[0000:03:00.1] : xilinx_u280_xdma_201920_3
-------------------------------------------
Platform
  XSA Name               : xilinx_u280_xdma_201920_3
  Platform UUID          : 0x5e278820
  FPGA Name              : xcu280-fsvh2892-2L-e
  JTAG ID Code           : 0x14b7d093
  DDR Size               : 34359738368 Bytes
  DDR Count              : 2
  Mig Calibrated         : true
  P2P Status             : no iomem
  P2P IO space required  : 64 GB

Mac Addresses            : 01:02:03:04:05:06
                         : 01:02:03:04:05:07
```

#### Documentation impact (if any)
None.
