### PR TITLE
Use the correct property for reporting firewall status

### DIFF
--- a/src/runtime_src/core/tools/common/ReportFirewall.cpp
+++ b/src/runtime_src/core/tools/common/ReportFirewall.cpp
@@ -37,8 +37,8 @@ ReportFirewall::getPropertyTree20202( const xrt_core::device * _pDevice,
   try {
     pt.put("firewall_level", xrt_core::device_query<xrt_core::query::firewall_detect_level>(_pDevice));
     pt.put("firewall_level_name", xrt_core::device_query<xrt_core::query::firewall_detect_level_name>(_pDevice));
-    pt.put("firewall_status", boost::format("0x%x") % xrt_core::device_query<xrt_core::query::firewall_detect_level>(_pDevice));
-    pt.put("status", xrt_core::utils::parse_firewall_status(static_cast<unsigned int>(xrt_core::device_query<xrt_core::query::firewall_detect_level>(_pDevice))));
+    pt.put("firewall_status", boost::format("0x%x") % xrt_core::device_query<xrt_core::query::firewall_status>(_pDevice));
+    pt.put("status", xrt_core::utils::parse_firewall_status(static_cast<unsigned int>(xrt_core::device_query<xrt_core::query::firewall_status>(_pDevice))));
   } catch(...) {}
   // There can only be 1 root node
   _pt.add_child("firewall", pt);


### PR DESCRIPTION
#### Problem solved by the commit

The firewall status report generated by xbutil examine is incorrect - instead of decoding the details of the firewall trip based on the value of the firewall status register, the firewall level is being used - the latter is supposed to help identify which firewall instance tripped, not provide the details of the trip cause.  For this we need to display and decode the firewall status property.

#### How problem was solved, alternative solutions (if any) and why they were rejected

By using the correct property.

#### Risks (if any) associated the changes in the commit

Perhaps there are people who are expecting the current behaviour and think it to be correct.  Those people would be surprised.

#### What has been tested and how, request additional testing if necessary

Just code inspection.  I'm not set up to build xbutil from source - I know the CI pipeline will do it for me.  However, the change should be verified by someone who can apply the patch and trip a firewall.