### PR TITLE
Enable aie2 for Versal PCIe platforms

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
@@ -902,7 +902,7 @@ zocl_xclbin_load_pskernel(struct drm_zocl_dev *zdev, void *data)
         int ret = 0;
         int count = 0;
 	void *aie_res = 0;
-	struct device_node *aienode;
+	struct device_node *aienode = NULL;
 	uint8_t hw_gen = 1;
 
         if (memcmp(axlf_head->m_magic, "xclbin2", 8)) {
@@ -957,11 +957,12 @@ zocl_xclbin_load_pskernel(struct drm_zocl_dev *zdev, void *data)
 			DRM_WARN("no aie dev generation information in device tree\n");
 		}
 		of_node_put(aienode);
+		aienode = NULL;
 	}
 
 	// Cache full xclbin
 	//last argument represents aie generation. 1. aie, 2. aie-ml ...
-	DRM_INFO("%s AIE set to gen %d", __func__, hw_gen);
+	DRM_INFO("AIE Device set to gen %d", hw_gen);
 	zocl_create_aie(zdev, axlf, aie_res, hw_gen);
 
 	count = xrt_xclbin_get_section_num(axlf, SOFT_KERNEL);

--- a/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
@@ -954,7 +954,7 @@ zocl_xclbin_load_pskernel(struct drm_zocl_dev *zdev, void *data)
 	else {
 		ret = of_property_read_u8(aienode, "xlnx,aie-gen", &hw_gen);
 		if (ret < 0) {
-			DRM_WARN("no aie dev generation information in device tree\n");
+			DRM_WARN("No AIE array generation information in the device tree, assuming generation %d\n", hw_gen);
 		}
 		of_node_put(aienode);
 		aienode = NULL;


### PR DESCRIPTION
Updated zocl_xclbin.c to look up AIE device generation from device tree
and pass it to zocl_create_aie

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Add support for aie2 for Versal PCIe platforms

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Look up aie gen from device tree and pass the info to zocl_create_aie

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Tested on vck5000 and v70

#### Documentation impact (if any)
None
