### PR TITLE
CR-1138144 and CR-1138164: Improve profile summary table column headers

### DIFF
--- a/src/runtime_src/xdp/profile/writer/vp_base/summary_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/summary_writer.cpp
@@ -1517,6 +1517,8 @@ namespace xdp {
     fout << transferRate << ",";
     fout << achievedBW << ",";
     fout << idealBW << ",";
+    fout << maxAchievableBW << ",";
+    fout << maxTheoreticalBW << ",";
     fout << aveSize << ",";
     fout << aveLatency << ",\n";
   }
@@ -1539,8 +1541,10 @@ namespace xdp {
          << "Transfer Type,"
          << "Number Of Transfers,"
          << "Transfer Rate (MB/s),"
-         << "Bandwidth Utilization On Current Port (%),"
-         << "Bandwidth Utilization On Ideal Port (%),"
+         << "Bandwidth Utilization With Respect To Current Port Configuration (%),"
+         << "Bandwidth Utilization With Respect To Ideal Port Configuration (%),"
+         << "Maximum Achievable BW on Current Port Configuration (MB/s),"
+         << "Maximum Theoretical BW on Ideal Port Configuration (MB/s),"
          << "Average Size (KB),"
          << "Average Latency (ns),\n";
 


### PR DESCRIPTION
#### Problem solved by the commit
Adjusting the column header names on the kernel to global memory data transfer table in the profile summary to better reflect the values being presented.  Also adds two new columns to show the maximum bandwidths possible on the current port so the user can compare their performance.

#### Documentation impact (if any)
Documentation that describes the table will have to be updated.