### PR TITLE
CR-1066713 Method to discover zocl version number via xbutil/xbmgmt

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/zocl_rpu_channel.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_rpu_channel.c
@@ -36,6 +36,9 @@
 #define ZRPU_CHANNEL_XGQ_BUFFER_SIZE	4096
 #define ZRPU_CHANNEL_XGQ_SLOT_SIZE	1024
 
+#define MAX_LOG_LEN 80
+static char info_buf[MAX_LOG_LEN] = { 0 };
+
 struct zocl_rpu_data_entry {
 	struct list_head	entry_list;
 	char			*data_entry;
@@ -119,6 +122,43 @@ static void zchan_cmd_identify(struct zocl_rpu_channel *chan, struct xgq_cmd_sq_
 	r->minor = ZCHAN_CMD_HANDLER_VER_MINOR;
 }
 
+static void zchan_cmd_log_page(struct zocl_rpu_channel *chan, struct xgq_cmd_sq_hdr *cmd,
+	struct xgq_com_queue_entry *resp)
+{
+	struct xgq_cmd_sq *sq = (struct xgq_cmd_sq *)cmd;
+	struct xgq_cmd_cq *cq = (struct xgq_cmd_cq *)resp;
+	u32 add_off = sq->log_payload.address;
+	u32 size = sq->log_payload.size;
+	u32 count = 0;
+	u32 total_count = 0;
+	int ret = 0;
+
+	zchan_info(chan, "addr_off 0x%x, size %d", add_off, size);
+
+	count = snprintf(info_buf, sizeof(info_buf), "ZOCL Version:");
+	if (count > size) {
+		zchan_err(chan, "message is trunked to %d len", total_count);
+		ret = -EINVAL;
+		goto done;
+	}
+	memcpy_toio(chan->mem_base + add_off, info_buf, count);
+	total_count += count;
+
+	count = snprintf(info_buf, sizeof(info_buf), "put zocl version here\n");
+	if (total_count + count > size) {
+		zchan_err(chan, "message is trunked to %d len", total_count);
+		ret = -EINVAL;
+		goto done;
+	}
+	memcpy_toio(chan->mem_base + add_off + total_count, info_buf, count);
+	total_count += count;
+
+done:
+	init_resp(resp, cmd->cid, ret);
+	cq->cq_log_payload.count = total_count;
+	return;
+}
+
 static void zchan_cmd_load_xclbin(struct zocl_rpu_channel *chan, struct xgq_cmd_sq_hdr *cmd,
 	struct xgq_com_queue_entry *resp)
 {
@@ -190,7 +230,7 @@ static void zchan_cmd_load_xclbin(struct zocl_rpu_channel *chan, struct xgq_cmd_
 			   total_size, list_empty(&chan->data_list));
 		INIT_LIST_HEAD(&chan->data_list);
 
-		ret = zocl_xclbin_load_pskernel(zocl_get_zdev(),total_data);
+		ret = zocl_xclbin_load_pskernel(zocl_get_zdev(), total_data);
 		if (ret)
 			zchan_err(chan, "failed to cache xclbin: %d", ret);
 
@@ -214,9 +254,9 @@ fail:
 		}
 		INIT_LIST_HEAD(&chan->data_list);
 	}
+
 	init_resp(resp, cmd->cid, ret);
 	return;
-
 }
 
 static void zchan_cmd_default_handler(struct zocl_rpu_channel *chan, struct xgq_cmd_sq_hdr *cmd,
@@ -233,6 +273,7 @@ struct zchan_ops {
 } zchan_op_table[] = {
 	{ XGQ_CMD_OP_IDENTIFY, "XGQ_CMD_OP_IDENTIFY", zchan_cmd_identify },
 	{ XGQ_CMD_OP_LOAD_XCLBIN, "XGQ_CMD_OP_LOAD_XCLBIN", zchan_cmd_load_xclbin },
+	{ XGQ_CMD_OP_GET_LOG_PAGE, "XGQ_CMD_OP_GET_LOG_PAGE", zchan_cmd_log_page },
 };
 
 static inline const struct zchan_ops *opcode2op(u32 op)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

This is the long-standing feature that user wants to see what "versioning info" is on APU, including zocl version and ps kernel version etc. The enhancement will bring the infra for zocl developer to transfer back whatever they want to display back to host, max size limit is around 4K (1 PAGE).

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1066713

#### How problem was solved, alternative solutions (if any) and why they were rejected
pass log_page back from APU to host via RPU

#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
Tested on vck5000 qdma2

```
root@xsjdavidz01:/davidz# xbmgmt examine -d c1:0 -r vmr --verbose
Verbose: Enabling Verbosity
Verbose: SubCommand: examine

---------------------------------------------------
[0000:c1:00.0] : xilinx_vck5000_gen4x8_qdma_base_2
---------------------------------------------------
Vmr Status
  Build flags          :  default full build
  Vitis version        :  2022.2_daily_latest
  Git hash             :  143647efeb14ec8be1c34202179479a22268c93f
  Git branch           :  bsp_stable
  Git hash date        :  Thu, 18 Aug 2022 08
  Vmr build date       :  Thu 18 Aug 2022 12
  Vmr build version    :  0.0.0.0
  Apu xgq version      :  1.0 <<<=== APU XGQ version
  Zocl version         : put zocl version here <<<=== zocl version 
  Default image offset :  0x48000
  Default image size   :  0x644eb0
  Default image capacity :  0x5fb8000
  Backup image offset  :  0x6008000
  Backup image size    :  0x641e80
  Backup image capacity :  0x5fb8000
  Scfw image size      :  0x456c2
  Scfw image version   :  4.4.35
  Has fpt              : 1
  Has fpt recovery     : 1
  Boot on default      : 1
  Boot on backup       : 0
  Boot on recovery     : 0
  Current multi boot offset : 0x9
  Boot on offset       : 0x9
  Has extfpt           : 1
  Has ext meta xsabin  : 1
  Has ext sc fw        : 1
  Has ext system dtb   : 1
  Debug level          : 0
  Program progress     : 0
  Pl is ready          : 1
  Ps is ready          : 1
```
#### Documentation impact (if any)
