### PR TITLE
Added Error Message Support for AIE Trace PS Kernels

### DIFF
--- a/src/runtime_src/core/edge/ps_kernels/profiling/aie_trace_config/aie_trace_config.cpp
+++ b/src/runtime_src/core/edge/ps_kernels/profiling/aie_trace_config/aie_trace_config.cpp
@@ -97,9 +97,6 @@ namespace {
       required += 1;
     if (available < required) {
       addMessage(packet, Messages::NO_CORE_MODULE_PCS, src);
-      //packet->messageCode = static_cast<uint8_t>(Messages::NO_CORE_MODULE_PCS);
-      //std::copy(std::begin(src), std::end(src), std::begin(packet->params));
-      //messageCounter++; packet++;
       return false;
     }
 
@@ -108,9 +105,6 @@ namespace {
     required = config.coreCounterStartEvents.size() + config.coreEventsBase.size();
     if (available < required) {
       addMessage(packet, Messages::NO_CORE_MODULE_TRACE_SLOTS, src);
-      //packet->messageCode = static_cast<uint8_t>(Messages::NO_CORE_MODULE_TRACE_SLOTS);
-      //std::copy(std::begin(src), std::end(src), std::begin(packet->params));
-      //messageCounter++; packet++;
       return false;
     }
 
@@ -119,9 +113,6 @@ namespace {
     required = config.memoryCounterStartEvents.size();
     if (available < required) {
       addMessage(packet, Messages::NO_MEM_MODULE_PCS, src);
-      //packet->messageCode = static_cast<uint8_t>(Messages::NO_MEM_MODULE_PCS);
-      //std::copy(std::begin(src), std::end(src), std::begin(packet->params));
-      //messageCounter++; packet++;
       return false;
     }
 
@@ -130,9 +121,6 @@ namespace {
     required = config.memoryCounterStartEvents.size() + config.memoryCrossEventsBase.size();
     if (available < required) {
       addMessage(packet, Messages::NO_MEM_MODULE_TRACE_SLOTS, src);
-      //packet->messageCode = static_cast<uint8_t>(Messages::NO_MEM_MODULE_TRACE_SLOTS);
-      //std::copy(std::begin(src), std::end(src), std::begin(packet->params));
-      //MessageCounter++; packet++;
       return false;
     }
 
@@ -205,9 +193,6 @@ namespace {
         std::vector<uint32_t> src = {0, 0, 0, 0};
         addMessage(packet, Messages::NO_RESOURCES, src);
         packet++;
-        //packet->messageCode = static_cast<uint8_t>(Messages::NO_RESOURCES);
-        //std::copy(std::begin(src), std::end(src), std::begin(packet->params));
-        //messageCounter++; packet++;
         return 1;
       }
 
@@ -309,9 +294,6 @@ namespace {
         std::vector<uint32_t> src = {config.coreCounterStartEvents.size(), config.memoryCounterStartEvents.size(), col    , row + 1}; 
         addMessage(packet, Messages::COUNTERS_NOT_RESERVED, src);
         packet++;
-        //packet->messageCode = static_cast<uint8_t>(Messages::COUNTERS_NOT_RESERVED);
-        //std::copy(std::begin(src), std::end(src), std::begin(packet->params));
-        //messageCounter++; packet++;
         releaseCurrentTileCounters(config);
         return 1;
       }
@@ -362,9 +344,6 @@ namespace {
           std::vector<uint32_t> src = {col, row + 1, 0, 0};
           addMessage(packet, Messages::CORE_MODULE_TRACE_NOT_RESERVED, src);
           packet++;
-          //packet->messageCode = static_cast<uint8_t>(Messages::CORE_MODULE_TRACE_NOT_RESERVED);
-          //std::copy(std::begin(src), std::end(src), std::begin(packet->params));
-          //messageCounter++; packet++;
           releaseCurrentTileCounters(config);
           return 1;
         }
@@ -394,9 +373,6 @@ namespace {
         std::vector<uint32_t> src = {numTraceEvents, col, row, 0};
         addMessage(packet, Messages::CORE_TRACE_EVENTS_RESERVED, src);
         packet++;
-        //packet->messageCode = static_cast<uint8_t>(Messages::CORE_TRACE_EVENTS_RESERVED);
-        //std::copy(std::begin(src), std::end(src), std::begin(packet->params));
-        //messageCounter++; packet++;
 
         if (coreTrace->setMode(XAIE_TRACE_EVENT_PC) != XAIE_OK) 
           break;
@@ -424,9 +400,6 @@ namespace {
           std::vector<uint32_t> src = {col, row + 1, 0, 0};
           addMessage(packet, Messages::MEMORY_MODULE_TRACE_NOT_RESERVED, src);
           packet++;
-          //packet->messageCode = static_cast<uint8_t>(Messages::MEMORY_MODULE_TRACE_NOT_RESERVED);
-          //std::copy(std::begin(src), std::end(src), std::begin(packet->params));
-          //messageCounter++; packet++;
           releaseCurrentTileCounters(config);
           return 1;
         }
@@ -517,9 +490,6 @@ namespace {
         std::vector<uint32_t> src = {numTraceEvents, col, row, 0};
         addMessage(packet, Messages::MEMORY_TRACE_EVENTS_RESERVED, src);
         packet++;
-        //packet->messageCode = static_cast<uint8_t>(Messages::MEMORY_TRACE_EVENTS_RESERVED);
-        //std::copy(std::begin(src), std::end(src), std::begin(packet->params));
-        //messageCounter++; packet++;
 
         if (memoryTrace->setMode(XAIE_TRACE_EVENT_TIME) != XAIE_OK) 
           break;

--- a/src/runtime_src/xdp/profile/plugin/aie_trace_new/x86/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace_new/x86/aie_trace.cpp
@@ -282,7 +282,7 @@ namespace xdp {
         case xdp::built_in::Messages::COUNTERS_NOT_RESERVED:
           msg << "Unable to reserve " << packet.params[0] << " core counters"
               << " and " << packet.params[1] << " memory counters"
-              << " for AIE tile (" << packet.params[3] << "," << packet.params[4] << ") required for trace.";
+              << " for AIE tile (" << packet.params[2] << "," << packet.params[3] << ") required for trace.";
           xrt_core::message::send(severity_level::warning, "XRT", msg.str());
           break;
         case xdp::built_in::Messages::CORE_MODULE_TRACE_NOT_RESERVED:

--- a/src/runtime_src/xdp/profile/plugin/aie_trace_new/x86/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace_new/x86/aie_trace.cpp
@@ -39,7 +39,7 @@
 #include "aie_trace.h"
 
 constexpr uint32_t MAX_TILES = 400;
-constexpr uint32_t MAX_LENGTH = 4096;
+constexpr uint32_t ALIGNMENT_SIZE = 4096;
 
 namespace xdp {
   using severity_level = xrt_core::message::severity_level;
@@ -68,9 +68,9 @@ namespace xdp {
 
   bool AieTrace_x86Impl::setMetrics(uint64_t deviceId, void* handle) {
       
-    constexpr uint64_t OUTPUT_SIZE = 4096 * 38; //Calculated maximum output size for all 400 tiles
-    constexpr uint64_t INPUT_SIZE = 4096; // input/output must be aligned to 4096
-    constexpr uint64_t MSG_OUTPUT_SIZE = 4096 * 5; //Calculated maximum output size for all 400 tiles
+    constexpr uint64_t OUTPUT_SIZE = ALIGNMENT_SIZE * 38; //Calculated maximum output size for all 400 tiles
+    constexpr uint64_t INPUT_SIZE = ALIGNMENT_SIZE; // input/output must be aligned to 4096
+    constexpr uint64_t MSG_OUTPUT_SIZE = ALIGNMENT_SIZE * ((sizeof(xdp::built_in::MessageConfiguration)%ALIGNMENT_SIZE) > 0 ? (sizeof(xdp::built_in::MessageConfiguration)/ALIGNMENT_SIZE) + 1 : (sizeof(xdp::built_in::MessageConfiguration)%ALIGNMENT_SIZE));
 
     //Gather data to send to PS Kernel
     std::string counterScheme = xrt_core::config::get_aie_trace_counter_scheme();
@@ -302,10 +302,8 @@ namespace xdp {
         case xdp::built_in::Messages::MEMORY_TRACE_EVENTS_RESERVED: 
           msg << "Reserved " << packet.params[0] << " memory trace events for AIE tile (" << packet.params[1] << "," << packet.params[2] << ").";
           xrt_core::message::send(severity_level::debug, "XRT", msg.str());
-          break;
- 
+          break; 
       }
     }
   }
-
 }

--- a/src/runtime_src/xdp/profile/plugin/aie_trace_new/x86/aie_trace.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace_new/x86/aie_trace.h
@@ -34,6 +34,7 @@ namespace xdp {
       void finishFlushDevice();
       bool setMetrics(uint64_t deviceId, void* handle);
       uint64_t checkTraceBufSize(uint64_t size);
+      void parseMessages(uint8_t* messages);
   };
 
 }   

--- a/src/runtime_src/xdp/profile/plugin/aie_trace_new/x86/aie_trace_kernel_config.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace_new/x86/aie_trace_kernel_config.h
@@ -36,6 +36,34 @@ namespace built_in {
     ES2 = 1
   };
 
+  enum class Messages : uint8_t
+  {
+    NO_CORE_MODULE_PCS = 0,
+    NO_CORE_MODULE_TRACE_SLOTS = 1,
+    NO_CORE_MODULE_BROADCAST_CHANNELS = 2,
+    NO_MEM_MODULE_PCS = 3,
+    NO_MEM_MODULE_TRACE_SLOTS = 4,
+    NO_RESOURCES = 5,
+    COUNTERS_NOT_RESERVED = 6,
+    CORE_MODULE_TRACE_NOT_RESERVED = 7,
+    CORE_TRACE_EVENTS_RESERVED = 8,
+    MEMORY_MODULE_TRACE_NOT_RESERVED = 9,
+    MEMORY_TRACE_EVENTS_RESERVED = 10
+  };
+
+  struct MessagePacket
+  {
+    uint8_t messageCode;
+    uint32_t params[4] = {}; 
+  };
+
+  struct MessageConfiguration
+  {
+    static constexpr auto MAX_NUM_MESSAGES = 800;
+    uint32_t numMessages;
+    MessagePacket packets[MAX_NUM_MESSAGES];
+  };
+
   // This struct is used for input for the PS kernel.  It contains all of
   // the information gathered from the user controls in the xrt.ini file
   // and the information we can infer from the debug ip layout file.


### PR DESCRIPTION
Added Error Message Support for AIE Trace PS Kernels, which now display on the host machine. The PS kernel message output buffer size is now automatically calculated. 