### PR TITLE
CR-1138159 & CR-1138289 Handle xgq_vmr's sysfs_get error properly

### DIFF
--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -526,19 +526,21 @@ struct clk_scaling_info
   {
     auto pdev = get_pcidev(device);
     std::vector<std::string> stats;
+    result_type ctStats;
     std::string errmsg;
     bool is_versal = false;
 
     pdev->sysfs_get<bool>("", "versal", errmsg, is_versal, false);
 	if (is_versal) {
       pdev->sysfs_get("xgq_vmr", "clk_scaling_stat_raw", errmsg, stats);
+      if (!errmsg.empty())
+        return ctStats;
 	} else {
       // Backward compatibilty check.
       // Read XMC sysfs nodes
       return get_legacy_clk_scaling_stat(device);
     }
 
-    result_type ctStats;
     data_type data = {};
     //parse one line at a time
     // The clk_scaling_stat_raw is printing in formatted string of each line


### PR DESCRIPTION
Signed-off-by: Rajkumar Rampelli <rampelli@amd.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Since xgq_vmr driver is absent in userpf, sysfs_get of xgq_vmr will throw error message in xbutil case. So, handle xgq_vmr's sysfs_get error properly in xbutil.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1138289
#### How problem was solved, alternative solutions (if any) and why they were rejected
Added fix in driver to handle sysfs_get error.
#### Risks (if any) associated the changes in the commit
NA
#### What has been tested and how, request additional testing if necessary
xbutil examine -r cmc
#### Documentation impact (if any)
NA