### PR TITLE
Added env checks for USER, XILINX_VITIS variables

### DIFF
--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
@@ -365,8 +365,7 @@ namespace xclcpuemhal2
     char *login_user = getenv("USER");
     if (!login_user)
     {
-      std::string dMsg = "ERROR: [SW-EMU 22] $USER variable is not SET. Please make sure the USER env variable is set properly.";
-      logMessage(dMsg, 0);
+      std::cerr << "ERROR: [SW-EMU 22] $USER variable is not SET. Please make sure the USER env variable is set properly." << std::endl;
       exit(EXIT_FAILURE);
     }
     // Spawn off the process to run the stub

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
@@ -362,6 +362,13 @@ namespace xclcpuemhal2
     std::stringstream pidStream;
     pidStream << parentPid;
 
+    char *login_user = getenv("USER");
+    if (!login_user)
+    {
+      std::string dMsg = "ERROR: [SW-EMU 22] $USER variable is not SET. Please make sure the USER env variable is set properly.";
+      logMessage(dMsg, 0);
+      exit(EXIT_FAILURE);
+    }
     // Spawn off the process to run the stub
     bool simDontRun = xclemulation::config::getInstance()->isDontRun();
     if (!simDontRun)

--- a/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.cxx
@@ -672,7 +672,7 @@ namespace xclhwemhal2 {
       exit(EXIT_FAILURE);
     }
     char *vitisInstallEnvvar = getenv("XILINX_VITIS");
-    if (vitisInstallEnvvar != NULL) {
+    if (!vitisInstallEnvvar) {
       std::string dMsg = "ERROR: [HW-EMU 27] $XILINX_VITIS variable is not SET. Please make sure the XILINX_VITIS env variable is SOURCED properly.";
       logMessage(dMsg, 0);
       exit(EXIT_FAILURE);

--- a/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.cxx
@@ -664,7 +664,19 @@ namespace xclhwemhal2 {
     }
 
     std::string userSpecifiedSimPath = xclemulation::config::getInstance()->getSimDir();
-
+    char *login_user = getenv("USER");
+    if (!login_user)
+    {
+      std::string dMsg = "ERROR: [HW-EMU 26] $USER variable is not SET. Please make sure the USER env variable is set properly.";
+      logMessage(dMsg, 0);
+      exit(EXIT_FAILURE);
+    }
+    char *vitisInstallEnvvar = getenv("XILINX_VITIS");
+    if (vitisInstallEnvvar != NULL) {
+      std::string dMsg = "ERROR: [HW-EMU 27] $XILINX_VITIS variable is not SET. Please make sure the XILINX_VITIS env variable is SOURCED properly.";
+      logMessage(dMsg, 0);
+      exit(EXIT_FAILURE);
+    }
     if (!mSimDontRun)
     {
       wdbFileName = std::string(mDeviceInfo.mName) + "-" + std::to_string(mDeviceIndex) + "-" + xclBinName;


### PR DESCRIPTION
Fix: XRT emulation has now a conditional check for USER environment variable. If the variable is not set then it will report an error on the console and exit with failure. The same conditional check added for XILINX_VITIS if it is not sourced properly.

Risk: Very Low

Tests: Canary run. Results are Clean.

Reviewer: venkatp
