### PR TITLE
Updated build scripts to generate two apu packages

### DIFF
--- a/build/build_edge.sh
+++ b/build/build_edge.sh
@@ -467,7 +467,8 @@ cp $ORIGINAL_DIR/$PETALINUX_NAME/reinstall_xrt.sh $ORIGINAL_DIR/$PETALINUX_NAME/
 if [[ $full == 1 ]]; then
   mkdir -p $ORIGINAL_DIR/$PETALINUX_NAME/apu_packages
   export PATH=$PETALINUX/../../tool/petalinux-v$PETALINUX_VER-final/components/yocto/buildtools/sysroots/x86_64-petalinux-linux/usr/bin:$PATH
-  $XRT_REPO_DIR/src/runtime_src/tools/scripts/pkgapu.sh -output $ORIGINAL_DIR/$PETALINUX_NAME/apu_packages -images $ORIGINAL_DIR/$PETALINUX_NAME/images/linux/ -idcode "0x14ca8093"
+  $XRT_REPO_DIR/src/runtime_src/tools/scripts/pkgapu.sh -output $ORIGINAL_DIR/$PETALINUX_NAME/apu_packages -images $ORIGINAL_DIR/$PETALINUX_NAME/images/linux/ -idcode "0x14ca8093" -package-name xrt-apu-vck5000
+  $XRT_REPO_DIR/src/runtime_src/tools/scripts/pkgapu.sh -output $ORIGINAL_DIR/$PETALINUX_NAME/apu_packages -images $ORIGINAL_DIR/$PETALINUX_NAME/images/linux/ -idcode "0x04cd0093" -package-name xrt-apu
   
 fi
 

--- a/src/runtime_src/tools/scripts/pkgapu.sh
+++ b/src/runtime_src/tools/scripts/pkgapu.sh
@@ -31,6 +31,7 @@ usage()
 	echo "          -clean                          Remove build files"
         echo "          -output                         output path"
         echo "          -idcode                         id code of the part"
+        echo "          -package-name                   package name"
 	echo "This script requires tools: mkimage, xclbinutil, bootgen, rpmbuild, dpkg-deb. "
 	echo "There is mkimage in petalinux build, e.g."
 	echo "/proj/petalinux/2021.2/petalinux-v2021.2_daily_latest/tool/petalinux-v2021.2-final/components/yocto/buildtools/sysroots/x86_64-petalinux-linux/usr/bin/mkimage"
@@ -118,6 +119,9 @@ METADATA_BUFFER_LEN=131072
 # default id code is for vck5000 part
 ID_CODE="0x14ca8093"
 
+# default package name is xrt-apu
+PKG_NAME="xrt-apu"
+
 clean=0
 while [ $# -gt 0 ]; do
 	case $1 in
@@ -135,6 +139,10 @@ while [ $# -gt 0 ]; do
                 -idcode )
 			shift
                         ID_CODE=$1
+			;;
+                -package-name )
+			shift
+                        PKG_NAME=$1
 			;;
 		-clean )
 			clean=1
@@ -155,7 +163,6 @@ BUILD_DIR="$OUTPUT_DIR/apu_build"
 PACKAGE_DIR="$BUILD_DIR"
 FW_FILE="$BUILD_DIR/lib/firmware/xilinx/xrt-versal-apu.xsabin"
 INSTALL_ROOT="$BUILD_DIR/lib"
-PKG_NAME="xrt-apu"
 
 if [[ $clean == 1 ]]; then
 	echo $PWD


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
We have a problem supporting all versal platforms with single APU package ( https://jira.xilinx.com/browse/CR-1136488)
We are creating apu package separately for each versal variation for the time being, 
We dont need to add any dependencies as both packages generates same file name in /lib/firmware/xilinx/ folder. if one package is installed, you cannot install another package

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
NA

#### How problem was solved, alternative solutions (if any) and why they were rejected
Creating two APU Packages.

#### Risks (if any) associated the changes in the commit
Boardfarm team / DSV / Aster team has to change their scripts to install xrt-apu-vck5000.rpm instead of xrt-apu.rpm

#### What has been tested and how, request additional testing if necessary
vck5000

#### Documentation impact (if any)
NA