### PR TITLE
fix ps kernel hang issue when cu interrupt is enabled

### DIFF
--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -183,6 +183,9 @@ static int kds_polling_thread(void *data)
 		busy_cnt = 0;
 
 		list_for_each_entry(xcu, &kds->alive_cus, cu) {
+			if (xcu->thread)
+				continue;
+
 			if (xrt_cu_process_queues(xcu) == XCU_BUSY)
 				busy_cnt += 1;
 		}
@@ -1661,7 +1664,7 @@ static int kds_cfg_legacy_update(struct kds_sched *kds)
 	}
 
 run_polling:
-	if (!KDS_SETTING(kds->cu_intr) && !kds->polling_thread) {
+	if ((!KDS_SETTING(kds->cu_intr) && !kds->polling_thread) || kds->scu_mgmt.num_cus) {
 		kds->polling_stop = 0;
 		kds->polling_thread = kthread_run(kds_polling_thread, kds, "kds_poll");
 		if (IS_ERR(kds->polling_thread)) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
PS kernel hang issue

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Jeff encounter this issue with latest XRT and latest shell. #6862 introduce this issue. But that time, CU interrupt is not enabled in the shell. So, this was not found.

#### How problem was solved, alternative solutions (if any) and why they were rejected
launch KDS polling thread for ps kernel. Skip CU with interrupt enabled.

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
Vck5000

#### Documentation impact (if any)
no