### PR TITLE
Fixed ffi_call return code type which was causing stack smashing error

### DIFF
--- a/src/runtime_src/core/edge/skd/xrt_skd.cpp
+++ b/src/runtime_src/core/edge/skd/xrt_skd.cpp
@@ -221,7 +221,10 @@ namespace xrt {
       }
 
       ffi_call(&cif,FFI_FN(kernel), &kernel_return, ffi_arg_values);
-      args_from_host[return_offset] = (uint32_t)kernel_return;
+      if (kernel_return >= 0)
+	args_from_host[return_offset] = static_cast<uint32_t>(kernel_return);
+      else
+	args_from_host[return_offset] = 255; // Exit status out of range if returning negative value
 
       // Unmap Buffers
       for(auto i:bo_list) {

--- a/src/runtime_src/core/edge/skd/xrt_skd.cpp
+++ b/src/runtime_src/core/edge/skd/xrt_skd.cpp
@@ -175,7 +175,7 @@ namespace xrt {
   XCL_DRIVER_DLLESPEC
   void
   skd::run() {
-    int32_t kernel_return = 0;
+    ffi_sarg kernel_return = 0;
     int ret = 0;
     void* ffi_arg_values[num_args];
     // Buffer Objects

--- a/src/runtime_src/core/edge/skd/xrt_skd.cpp
+++ b/src/runtime_src/core/edge/skd/xrt_skd.cpp
@@ -221,10 +221,7 @@ namespace xrt {
       }
 
       ffi_call(&cif,FFI_FN(kernel), &kernel_return, ffi_arg_values);
-      if (kernel_return >= 0)
-	args_from_host[return_offset] = static_cast<uint32_t>(kernel_return);
-      else
-	args_from_host[return_offset] = 255; // Exit status out of range if returning negative value
+      args_from_host[return_offset] = (kernel_return >= 0) ? static_cast<uint32_t>(kernel_return) : 255; // Exit status out of range if returning negative value
 
       // Unmap Buffers
       for(auto i:bo_list) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Fix PS kernel crash due to not sufficient size for the return code

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Use ffi_sarg which will hold signed return value from ffi_call

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
PS kernel iops test

#### Documentation impact (if any)
None
