### PR TITLE
HW context specific group id for buffer allocation

### DIFF
--- a/src/runtime_src/core/common/api/hw_queue.cpp
+++ b/src/runtime_src/core/common/api/hw_queue.cpp
@@ -2,6 +2,7 @@
 // Copyright (C) 2021-2022 Xilinx, Inc. All rights reserved.
 // Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
 #define XRT_CORE_COMMON_SOURCE // in same dll as core_common
+#define XRT_API_SOURCE         // in same dll as API sources
 
 #include "hw_queue.h"
 

--- a/src/runtime_src/core/common/api/xrt_hw_context.cpp
+++ b/src/runtime_src/core/common/api/xrt_hw_context.cpp
@@ -10,6 +10,7 @@
 #include "hw_context_int.h"
 
 #include "core/common/device.h"
+#include "core/include/xrt_mem.h"
 
 #include <limits>
 
@@ -195,6 +196,16 @@ hw_context::
 get_mode() const
 {
   return get_handle()->get_mode();
+}
+
+uint32_t
+hw_context::
+get_memory_group_id() const
+{
+  xcl_bo_flags grp = {0}; // xrt_mem.h
+  grp.bank = 0;
+  grp.slot = static_cast<uint8_t>(get_handle()->get_xcl_handle());
+  return grp.flags;
 }
 
 hw_context::

--- a/src/runtime_src/core/include/experimental/xrt_hw_context.h
+++ b/src/runtime_src/core/include/experimental/xrt_hw_context.h
@@ -132,6 +132,22 @@ public:
   access_mode
   get_mode() const;
 
+  /**
+   * get_memory_group_id() - Get the memory group id for this context
+   *
+   * @return 
+   *  The memory group id to be used when allocating buffers
+   *  (see xrt::bo) that are not used as kernel arguments.
+   *
+   * The group_id can be used when allocating a buffer specific to
+   * this hw context.  If buffers are allocated as kernel arguments,
+   * then the group id should be obtained specific to the kernel
+   * argument for which the buffer is used (see xrt::kernel::group_id())
+   */
+  XRT_API_EXPORT
+  uint32_t
+  get_memory_group_id() const;
+
 public:
   /// @cond
   // Undocumented internal access to low level context handle


### PR DESCRIPTION
#### Problem solved by the commit
Add API to get the memory group id associated with a hardware context.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
For some platforms, buffer allocation can be specific to a hardware
context when the buffer is not specifically used as a kernel argument.

#### How problem was solved, alternative solutions (if any) and why they were rejected
This PR add xrt::hw_context::get_memory_group_id() which returns an
encoded group id flag which can be used with xrt::bo constructors.
