### PR TITLE
fix bug at cu-stats VITIS-3304

### DIFF
--- a/src/runtime_src/core/common/drv/xrt_cu.c
+++ b/src/runtime_src/core/common/drv/xrt_cu.c
@@ -99,7 +99,7 @@ static void cu_stats_timer(struct timer_list *t)
 #endif
 	unsigned long   flags;
 
-	if (xcu->stats.stats_enabled)
+	if (!xcu->stats.stats_enabled)
 		return;
 
 	spin_lock_irqsave(&xcu->stats.xcs_lock, flags);


### PR DESCRIPTION
#### Problem solved by the commit
Average sq length value in the output of stat sysfs node is always zero

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
The average submitted length is always zero in all test case. #6933  cu stats introduced the bug 

#### How problem was solved, alternative solutions (if any) and why they were rejected
The branch condition inside the cu_stats_timer which enables the sq statistic update is not right. Correct it by using the right branch condition.

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
Tested on iops, mem-bw and verify testcases.

#### Documentation impact (if any)
No