### PR TITLE
Fixed ZOCL dtbo path len issue

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_xclbin.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_xclbin.h
@@ -41,6 +41,6 @@ int zocl_xclbin_load_pdi(struct drm_zocl_dev *zdev, void *data,
 int zocl_xclbin_load_pskernel(struct drm_zocl_dev *zdev, void *data);
 bool zocl_xclbin_accel_adapter(int kds_mask);
 int zocl_xclbin_set_dtbo_path(struct drm_zocl_dev *zdev,
-			      struct drm_zocl_slot *slot, char *dtbo_path);
+		      struct drm_zocl_slot *slot, char *dtbo_path, uint32_t len);
 
 #endif /* _ZOCL_XCLBIN_H_ */

--- a/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
@@ -1484,7 +1484,8 @@ zocl_xclbin_read_axlf(struct drm_zocl_dev *zdev, struct drm_zocl_axlf *axlf_obj,
 	 * Remember xclbin_uuid for opencontext.
 	 */
 	if(ZOCL_PLATFORM_ARM64)
-		zocl_xclbin_set_dtbo_path(zdev, slot, axlf_obj->za_dtbo_path);
+		zocl_xclbin_set_dtbo_path(zdev, slot,
+			axlf_obj->za_dtbo_path, axlf_obj->za_dtbo_path_len);
 
 	zocl_xclbin_set_uuid(zdev, slot, &axlf_head.m_header.uuid);
 
@@ -1727,7 +1728,7 @@ zocl_xclbin_fini(struct drm_zocl_dev *zdev, struct drm_zocl_slot *slot)
  */
 int
 zocl_xclbin_set_dtbo_path(struct drm_zocl_dev *zdev,
-			  struct drm_zocl_slot *slot, char *dtbo_path)
+		struct drm_zocl_slot *slot, char *dtbo_path, uint32_t len)
 {
         char *path = slot->slot_xclbin->zx_dtbo_path;
 
@@ -1737,7 +1738,6 @@ zocl_xclbin_set_dtbo_path(struct drm_zocl_dev *zdev,
         }
 
 	if(dtbo_path) {
-		uint32_t len = strlen(dtbo_path);
 		path = vmalloc(len + 1);
 		if (!path)
 			return -ENOMEM;

--- a/src/runtime_src/core/edge/include/zynq_ioctl.h
+++ b/src/runtime_src/core/edge/include/zynq_ioctl.h
@@ -445,6 +445,7 @@ struct drm_zocl_axlf {
 	char			*za_kernels;
 	uint32_t		za_slot_id;
 	char			*za_dtbo_path;
+	uint32_t		za_dtbo_path_len;
 	uint8_t		        hw_gen;
 	struct drm_zocl_kds	kds_cfg;
 };

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -735,6 +735,7 @@ xclLoadAxlf(const axlf *buffer)
       .za_kernels = NULL,
       .za_slot_id = 0, // TODO Cleanup: Once uuid interface id available we need to remove this
       .za_dtbo_path = const_cast<char *>(dtbo_path.c_str()),
+      .za_dtbo_path_len = dtbo_path.length(),
       .hw_gen = hw_gen,
     };
 


### PR DESCRIPTION
The DTBO information shred between ZOCL and shim is incorrect. From ZOCL we are accessing the userspace pointer to get the length of the string.
Updated the ioctl data structure to share dtbo path information along with length.