### PR TITLE
CR-1139031 : xclbinutil fails to add ps kernel

### DIFF
--- a/src/runtime_src/tools/xclbinutil/ElfUtilities.cxx
+++ b/src/runtime_src/tools/xclbinutil/ElfUtilities.cxx
@@ -18,13 +18,13 @@
 
 #include "XclBinUtilities.h"
 
+#include <algorithm>
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/format.hpp>
 #include <boost/version.hpp>
 #include <cstdlib>
-#include <algorithm>
 
 #if (BOOST_VERSION >= 106400)
   #include <boost/process/search_path.hpp>
@@ -865,7 +865,7 @@ drcCheckExportedFunctions(const std::vector<std::string> exportedFunctions)
   // C++ mangling is enabled.
   XUtil::TRACE("DRC: Looking for mangled function names");
   std::vector<std::string> mangledFunctions;
-  for (auto entry : exportedFunctions) {
+  for (const auto & entry : exportedFunctions) {
     // A signature starts with a '('.  For example:  kernel0_fini(xrtHandles*)
     if (entry.find("(") != std::string::npos)
       mangledFunctions.push_back(entry);
@@ -877,7 +877,7 @@ drcCheckExportedFunctions(const std::vector<std::string> exportedFunctions)
               
     auto errMsg = boost::str(boost::format("ERROR: C++ mangled functions are not supported, please export the function. \nOffending function(s):\n"));
 
-    for (auto& entry : mangledFunctions) 
+    for (const auto& entry : mangledFunctions) 
       errMsg += boost::str(boost::format("     %s\n") % entry);
 
     throw std::runtime_error(errMsg);


### PR DESCRIPTION
Fixed code crash when producing an error message regarding found C++ mangled names.

#### Problem solved by the commit
When adding a PS kernel with c++ mangled names, a Design Rule Check (DRC) was triggered to indicated that C++ mangled names is NOT supported.  In the code to create the error message, the underlying coded was missing a argument used to describe the offending function name.  This resulted in an exception, which stopped the flow.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
This bug was introduced several months ago when the xclbinutility::format was replaced by boost::format()

#### How problem was solved, alternative solutions (if any) and why they were rejected
The DRC coded was updated to provide a more detail account of ALL of the offending C++ mangled functions.

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Manually testing and unit testing

#### Documentation impact (if any)
None