### PR TITLE
CR-1138205 when APU download is failed, XRT should have clear dmesg	

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
@@ -1560,7 +1560,7 @@ static int xgq_download_apu_bin(struct platform_device *pdev, char *buf,
 		XOCL_XGQ_DOWNLOAD_TIME);
 	if (ret != len) {
 		XGQ_ERR(xgq, "return %d, but request %ld", ret, len);
-		ret = -EIO;
+		return -EIO;
 	}
 
 	XGQ_INFO(xgq, "successfully download len %ld", len);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, and remove sections that don't apply to your pull request.  -->
#### Problem solved by the commit
Commit Hash:- 7aa54b35989faee8c7919f88d08ee9e979eca654

#### How the problem was solved, alternative solutions (if any), and why they were rejected
Error Handling was improved by adding a return statement.

#### What has been tested and how to request additional testing if necessary
Master branch versus Commit branch builds are tested by loading drivers and Dmesg is observed to understand the return values.
APU Download failure event is handled gracefully evident from what Dmesg observed.
From Dmesg output below, please note that, on a APU Download failure event, Dmesg reads "Successful Download". This fix handles this case to remove the same.
**Before Fix:-**

       [ 646.031081] xclmgmt 0000:19:00.0: xgq_vmr.m.54525952 ffff8f0c4890a810 xgq_vmr_log_dump_debug: opcode: LOAD                   APUBIN(0xd), rcode: 654376964, check debug trace for detailed log.
       [ 646.031608] xclmgmt 0000:19:00.0: xgq_vmr.m.54525952 ffff8f0c4890a810 xgq_download_apu_bin: return 654376964, but           request 83736203
       [ 646.043385] xclmgmt 0000:19:00.0: xgq_vmr.m.54525952 ffff8f0c4890a810 _xgq_download_apu_bin: successfully download           len 83736203_
       [ 646.047224] xclmgmt 0000:19:00.0: xgq_vmr.m.54525952 ffff8f0c4890a810 xgq_download_apu_firmware: start waiting apu           becomes ready

**After Fix:-**

        [ 3599.768985] xclmgmt 0000:19:00.0: xgq_vmr.m.54525952 ffff8f0c58f06010 xgq_vmr_log_dump_debug: opcode: LOAD                APUBIN(0xd), rcode: 654376964, check debug trace for detailed log.
        [ 3599.769533] xclmgmt 0000:19:00.0: xgq_vmr.m.54525952 ffff8f0c58f06010 xgq_download_apu_bin: return 654376964, but          request 83736203
        [ 3599.785000] xclmgmt 0000:19:00.0: xgq_vmr.m.54525952 ffff8f0c58f06010 xgq_vmr_probe: unable to download APU, ret:            -5
        [ 3600.283563] xclmgmt 0000:19:00.0: xgq_vmr.m.54525952 ffff8f0c58f06010 xgq_vmr_probe: clock scaling feature is not                supported
#### Documentation impact (if any)
None