### PR TITLE
Wire in shim construction of hw queue

### DIFF
--- a/src/runtime_src/core/common/api/hw_queue.cpp
+++ b/src/runtime_src/core/common/api/hw_queue.cpp
@@ -14,6 +14,7 @@
 #include "core/common/thread.h"
 #include "experimental/xrt_hw_context.h"
 #include "core/include/ert.h"
+#include "core/include/xcl_hwqueue.h"
 
 #include <algorithm>
 #include <condition_variable>
@@ -340,6 +341,7 @@ class hw_queue_impl
 {
   xrt::hw_context m_hwctx;
   device* m_core_device;
+  xcl_hwqueue_handle m_hdl;
 
   // This is logically const
   mutable kds_device* m_kds_device;
@@ -349,6 +351,7 @@ public:
   hw_queue_impl(xrt::hw_context hwctx)
     : m_hwctx(std::move(hwctx))
     , m_core_device(hw_context_int::get_core_device_raw(m_hwctx))
+    , m_hdl(m_core_device->create_hw_queue(hwctx))
     , m_kds_device(get_kds_device(m_core_device))
   {}
 
@@ -356,8 +359,14 @@ public:
   // is no associated hw context.
   hw_queue_impl(xrt_core::device* device)
     : m_core_device(device)
+    , m_hdl(XRT_NULL_HWQUEUE)
     , m_kds_device(get_kds_device(m_core_device))
   {}
+
+  ~hw_queue_impl()
+  {
+    m_core_device->destroy_hw_queue(m_hdl);
+  }
 
   // Managed start uses execution monitor for command completion
   void

--- a/src/runtime_src/core/common/ishim.h
+++ b/src/runtime_src/core/common/ishim.h
@@ -152,13 +152,23 @@ struct ishim
   // cannot be created for that xclbin.  This function throws
   // not_supported_error, if either not implemented or an xclbin
   // was explicitly loaded using load_xclbin
-  virtual uint32_t // ctx handle aka slot idx
+  virtual xcl_hwctx_handle // ctx handle aka slot idx
   create_hw_context(const xrt::uuid& /*xclbin_uuid*/, const xrt::hw_context::qos_type& /*qos*/, xrt::hw_context::access_mode /*mode*/) const
   { throw not_supported_error{__func__}; }
 
   virtual void
-  destroy_hw_context(uint32_t /*ctxhdl*/) const
+  destroy_hw_context(xcl_hwctx_handle /*ctxhdl*/) const
   { throw not_supported_error{__func__}; }
+
+  // Return default sentinel for legacy platforms without hw_queue support
+  virtual xcl_hwqueue_handle
+  create_hw_queue(const xrt::hw_context&) const
+  { return XRT_NULL_HWQUEUE; }
+
+  // Default noop for legacy platforms without hw_queue support
+  virtual void
+  destroy_hw_queue(xcl_hwqueue_handle) const
+  {}
 
   // Registers an xclbin, but does not load it.
   virtual void

--- a/src/runtime_src/core/include/shim_int.h
+++ b/src/runtime_src/core/include/shim_int.h
@@ -5,6 +5,8 @@
 #define SHIM_INT_H_
 
 #include "core/include/xrt.h"
+#include "core/include/xcl_hwctx.h"
+#include "core/include/xcl_hwqueue.h"
 #include "core/include/experimental/xrt_hw_context.h"
 #include "core/common/cuidx_type.h"
 
@@ -52,7 +54,7 @@ void
 close_cu_context(xclDeviceHandle handle, const xrt::hw_context& hwctx, xrt_core::cuidx_type cuidx);
 
 // create_hw_context() -
-uint32_t // ctxhdl aka slotidx
+xcl_hwctx_handle // ctxhdl aka slotidx
 create_hw_context(xclDeviceHandle handle,
                   const xrt::uuid& xclbin_uuid,
                   const xrt::hw_context::qos_type& qos,
@@ -60,7 +62,15 @@ create_hw_context(xclDeviceHandle handle,
 
 // dsstroy_hw_context() -
 void
-destroy_hw_context(xclDeviceHandle handle, uint32_t ctxhdl);
+destroy_hw_context(xclDeviceHandle handle, xcl_hwctx_handle ctxhdl);
+
+// create_hw_queue() -
+xcl_hwqueue_handle
+create_hw_queue(xclDeviceHandle handle, const xrt::hw_context& hwctx);
+
+// create_hw_queue() -
+void
+destroy_hw_queue(xclDeviceHandle handle, xcl_hwqueue_handle qhdl);
 
 // register_xclbin() -
 void

--- a/src/runtime_src/core/include/xcl_hwqueue.h
+++ b/src/runtime_src/core/include/xcl_hwqueue.h
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: GPL-2.0
 // Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
-#ifndef XCL_HWCTX_H_
-#define XCL_HWCTX_H_
+#ifndef XCL_HWQUEUE_H_
+#define XCL_HWQUEUE_H_
 
 // Definitions related to HW context shared between user space XRT and
 // Linux kernel driver.  The header file is exported as underlying
@@ -19,11 +19,17 @@ extern "C" {
 # endif
 #endif
 
-// Underlying representation of a hardware context handle.
+// Underlying representation of a hardware queue handle.
 //
-// The context handle is among other things used with / encoded in
-// buffer object flags.
-typedef uint32_t xcl_hwctx_handle;
+// A hardware queue is create by shim.  The underlying representation
+// is platform specific.
+#if defined(_WIN32)
+typedef void* xcl_hwqueue_handle;
+# define XRT_NULL_HWQUEUE NULL
+#else
+typedef unsigned int xcl_hwqueue_handle;
+# define XRT_NULL_HWQUEUE 0xffffffff
+#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
#### Problem solved by the commit
Queue implementation is constructed through shim level call back,

#### How problem was solved, alternative solutions (if any) and why they were rejected
The shim level callback is implemented only for platforms that support the
concept of hardware queue.  Default hw queue sentinel used for legacy
platforms.

This PR declares the shim level interfaces that must be implemented to
get hardware queue support.

Later PRs will use the shim level hw queue handle when submitting
commands for execution and waiting for command completion.