### PR TITLE
VITIS-5808 Add new device IDs to support Avalon platform

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
@@ -3461,6 +3461,7 @@ struct xocl_subdev_map {
 	{ XOCL_PCI_DEVID(0x10EE, 0xD03C, PCI_ANY_ID, XBB_MFG_U30) }, \
 	{ XOCL_PCI_DEVID(0x10EE, 0xD04C, PCI_ANY_ID, XBB_MFG_U25) }, \
 	{ XOCL_PCI_DEVID(0x10EE, 0xEB10, PCI_ANY_ID, XBB_MFG("twitch")) }, \
+	{ XOCL_PCI_DEVID(0x10EE, 0x5098, PCI_ANY_ID, XBB_MFG("avalon")) },\
 	{ XOCL_PCI_DEVID(0x13FE, 0x806C, PCI_ANY_ID, XBB_MFG("advantech")) }
 
 #define	XOCL_USER_XDMA_PCI_IDS						\

--- a/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
@@ -2935,6 +2935,23 @@ struct xocl_subdev_map {
 		.vbnv       = "xilinx_v70"				\
 	}
 
+#define	XOCL_BOARD_AVALON_USER_RAPTOR2				\
+	(struct xocl_board_private){					\
+		.flags = XOCL_DSAFLAG_DYNAMIC_IP,			\
+		.subdev_info	= RES_USER_VSEC,			\
+		.subdev_num = ARRAY_SIZE(RES_USER_VSEC),		\
+		.board_name = "avalon",					\
+	}
+
+#define	XOCL_BOARD_AVALON_MGMT_RAPTOR2				\
+	(struct xocl_board_private){					\
+		.flags = XOCL_DSAFLAG_DYNAMIC_IP,			\
+		.subdev_info	= RES_MGMT_VSEC,			\
+		.subdev_num = ARRAY_SIZE(RES_MGMT_VSEC),		\
+		.flash_type = FLASH_TYPE_SPI,				\
+		.board_name = "avalon"					\
+	}
+
 /*********************************VCK190 MGMTPF START*******************/
 
 #define XOCL_BOARD_VCK190_MGMT_RAPTOR2                                  \
@@ -3619,6 +3636,14 @@ struct xocl_subdev_map {
 	{ 0x10EE, 0x513D, PCI_ANY_ID,					\
 		.vbnv = "xilinx_u30",					\
 		.priv_data = &XOCL_BOARD_U30_USER_RAPTOR2,		\
+		.type = XOCL_DSAMAP_RAPTOR2 },				\
+	{ 0x10EE, 0x5099, PCI_ANY_ID,					\
+		.vbnv = "xilinx_avalon",				\
+		.priv_data = &XOCL_BOARD_AVALON_USER_RAPTOR2,		\
+		.type = XOCL_DSAMAP_RAPTOR2 },				\
+	{ 0x10EE, 0x5098, PCI_ANY_ID,					\
+		.vbnv = "xilinx_avalon",				\
+		.priv_data = &XOCL_BOARD_AVALON_MGMT_RAPTOR2,		\
 		.type = XOCL_DSAMAP_RAPTOR2 }
 
 #endif


### PR DESCRIPTION
Add new device IDs in XRT to support UL-3x24 Gen3x8 XDMA+SB+P2P.
Followed https://confluence.xilinx.com/display/XIP/PCIe+Device+ID+Mapping

Signed-off-by: Rajkumar Rampelli <rampelli@amd.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Support new platform named "Avalon UL-3x24".
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
VITIS-5808
#### How problem was solved, alternative solutions (if any) and why they were rejected
Added changes in XRT
#### Risks (if any) associated the changes in the commit
NA
#### What has been tested and how, request additional testing if necessary
Avalon platform is not available for testing.
#### Documentation impact (if any)
NA