### PR TITLE
CR-1138935 Corrected the logic to dump the kernel deadlock informatio…

### DIFF
--- a/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.cxx
@@ -232,10 +232,6 @@ namespace xclhwemhal2 {
 
   void HwEmShim::dumpDeadlockMessages()
   {
-
-    if (!xrt_core::config::get_pl_deadlock_detection())
-      return;
-    
     std::string simPath = getSimPath();
     std::string content = loadFileContentsToString(simPath + "/kernel_deadlock_diagnosis.rpt");
 
@@ -246,14 +242,20 @@ namespace xclhwemhal2 {
         logMessage(content);
         parsedMsgs.push_back(content);
       }
+    }
 
-      char path[FILENAME_MAX];
-      size_t size = MAXPATHLEN;
-      char *pPath = GetCurrentDir(path, size);
+    if (!xrt_core::config::get_pl_deadlock_detection())
+      return;
 
-      if (pPath)
+    char path[FILENAME_MAX];
+    size_t size = MAXPATHLEN;
+    char *pPath = GetCurrentDir(path, size);
+
+    if (pPath)
+    {
+      std::string deadlockReportFile = simPath + "/kernel_deadlock_diagnosis.rpt";
+      if (boost::filesystem::exists(deadlockReportFile))
       {
-        std::string deadlockReportFile = simPath + "/kernel_deadlock_diagnosis.rpt";
         std::string destPath = std::string(path) + "/pl_deadlock_diagnosis.txt";
         systemUtil::makeSystemCall(deadlockReportFile, systemUtil::systemOperation::COPY, destPath, std::to_string(__LINE__));
       }


### PR DESCRIPTION
CR-1138935 Corrected the logic to dump the kernel deadlock information on console irrespective of ini switch.

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
Always dump the kernel deadlock info on to the console
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
its an enhancement request done as part of Kernel deadlock analysis PR

#### How problem was solved, alternative solutions (if any) and why they were rejected
No alternate solutions

#### Risks (if any) associated the changes in the commit
No risk

#### What has been tested and how, request additional testing if necessary
tested the designs and ran canary

#### Documentation impact (if any)
No
