### PR TITLE
CR-1138782 Pass a valid char buffer as argument to required qdma APIs

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/qdma.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/qdma.c
@@ -438,24 +438,26 @@ static void free_channels(struct platform_device *pdev)
 	struct mm_channel *chan;
 	u32	write, qidx;
 	int i, ret = 0;
+	char	ebuf[MM_EBUF_LEN + 1];
 
 	qdma = platform_get_drvdata(pdev);
 	if (!qdma || !qdma->channel)
 		return;
 
 	for (i = 0; i < qdma->channel * 2; i++) {
+		memset(&ebuf, 0, sizeof (ebuf));
 		write = i / qdma->channel;
 		qidx = i % qdma->channel;
 		chan = &qdma->chans[write][qidx];
 
 		channel_sysfs_destroy(chan);
 
-		ret = qdma_queue_stop(qdma->dma_hndl, chan->queue, NULL, 0);
+		ret = qdma_queue_stop(qdma->dma_hndl, chan->queue, ebuf, MM_EBUF_LEN);
 		if (ret < 0) {
 			xocl_err(&pdev->dev, "Stopping queue for "
 				"channel %d failed, ret %x", qidx, ret);
 		}
-		ret = qdma_queue_remove(qdma->dma_hndl, chan->queue, NULL, 0);
+		ret = qdma_queue_remove(qdma->dma_hndl, chan->queue, ebuf, MM_EBUF_LEN);
 		if (ret < 0) {
 			xocl_err(&pdev->dev, "Destroy queue for "
 				"channel %d failed, ret %x", qidx, ret);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/qdma.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/qdma.c
@@ -461,12 +461,12 @@ static void free_channels(struct platform_device *pdev)
 		ret = qdma_queue_stop(qdma->dma_hndl, chan->queue, ebuf, MM_EBUF_LEN);
 		if (ret < 0) {
 			xocl_err(&pdev->dev, "Stopping queue for "
-				"channel %d failed, ret %x", qidx, ret);
+				"channel %d failed, ret: %x, ebuf: %s", qidx, ret, ebuf);
 		}
 		ret = qdma_queue_remove(qdma->dma_hndl, chan->queue, ebuf, MM_EBUF_LEN);
 		if (ret < 0) {
 			xocl_err(&pdev->dev, "Destroy queue for "
-				"channel %d failed, ret %x", qidx, ret);
+				"channel %d failed, ret: %x, ebuf: %s", qidx, ret, ebuf);
 		}
 	}
 	if (ebuf)


### PR DESCRIPTION
Pass a valid character buffer to qdma_queue_stop() & qdma_queue_remove() APIs,
which will have QDMA driver's return message either success or error message.

Signed-off-by: Rajkumar Rampelli <rampelli@amd.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
QDMA driver APIs expects a empty char buffer so that it can store error message or success message, and the same can be read in client driver (subdev/qdma.c). So, pass a valid char buffer to required QDMA APIs.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1138782
#### How problem was solved, alternative solutions (if any) and why they were rejected
Added fix in qdma driver by passing a valid char buffer to qdma APIs.
#### Risks (if any) associated the changes in the commit
NA
#### What has been tested and how, request additional testing if necessary
xocl & xclmgmt load & unload drivers test.
#### Documentation impact (if any)
NA