### PR TITLE
Fix build failure on Edge 32 bit platforms

### DIFF
--- a/src/runtime_src/core/common/drv/xrt_cu.c
+++ b/src/runtime_src/core/common/drv/xrt_cu.c
@@ -12,6 +12,7 @@
  */
 
 #include <linux/delay.h>
+#include <linux/math64.h>
 #include "kds_client.h"
 #include "xrt_cu.h"
 
@@ -1159,7 +1160,7 @@ u64 xrt_cu_get_idle(struct xrt_cu *xcu, u64 last_timestamp, u64 idle_start, u64 
 		ts_status = 1;
 	}
 
-	cu_idle = cu_idle * 100 / delta_xcu_time;
+	cu_idle = div64_u64(cu_idle * 100, delta_xcu_time);
 
 	spin_lock_irqsave(&xcu->stats.xcs_lock, flags);
 	xcu->stats.last_read_idle_start = idle_start;
@@ -1175,7 +1176,7 @@ u64 xrt_cu_get_iops(struct xrt_cu *xcu, u64 last_timestamp, u64 incre_ecmds, u64
 	u64 		iops = 0;
 
 	if (new_ts - last_timestamp > 0 && incre_ecmds != 0)
-		iops = incre_ecmds * 1000000000 / (new_ts - last_timestamp);
+		iops = div64_u64(incre_ecmds * 1000000000, (new_ts - last_timestamp));
 	else
 		iops = 0;
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
On 32 bit platforms zocl build fails at modpost step with following undefined symbol error
**ERROR: modpost: "__aeabi_uldivmod" undefined**
Fixed this issue

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
PR - https://github.com/Xilinx/XRT/pull/6933 introduced this issue and is caught in yocto pipeline when sending xrt commit id

#### How problem was solved, alternative solutions (if any) and why they were rejected
Because of 64 bit division operation gcc is trying to link libgcc library which is not available for kernel module compilation. So using div64_u64 api from linux/math64.h header to overcome this issue.
https://stackoverflow.com/questions/51708273/how-can-i-do-64-bit-division-on-linux-kernel  -  reference

#### Risks (if any) associated the changes in the commit
None as replacing direct division operation with standard api call

#### What has been tested and how, request additional testing if necessary
Built zocl module on 64 bit and 32 bit architectures and it succeeded. x86 architecture build testing is needed as change is made in common driver code. Pipeline will do that.

#### Documentation impact (if any)
NA