### PR TITLE
CR-1135840 Modify XRT driver to downgrade from error to warning for loading xclbin with ps kernel without APU loaded

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -1364,8 +1364,11 @@ static int xocl_config_ert(struct xocl_dev *xdev, struct drm_xocl_kds cfg,
 	}
 
 	ret = xocl_scu_cfg_cmd(xdev, client, ecmd, ps_kernel);
-	if (ret)
-		userpf_err(xdev, "PS kernel config failed");
+	if (ret) {
+		userpf_err(xdev, "PS kernel config failed, ret %d", ret);
+		ret = 0;
+		userpf_info(xdev, "Application use PS kernel will fail");
+	}
 
 out:
 	vfree(ecmd);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Modify XRT driver to downgrade from error to warning for loading xclbin with ps kernel without APU loaded

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
This is not a bug. But an easy of use enhancement.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Just downgrade the error to warning and let xclbin download complete.

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
vck5000

#### Documentation impact (if any)
No


When APU is not loaded, if use download a xclbin with PS kernel. Below two message will show in dmesg.
```
...
[10800.898487] xocl 0000:04:00.1:  ffff89cf432660d0 xocl_config_ert: PS kernel config failed, ret -22
[10800.906175] xocl 0000:04:00.1:  ffff89cf432660d0 xocl_config_ert: Application use PS kernel will fail
...
```

In above case, if use try to run application and the application will failed when it open PS kernel. For example:
``` bash
$./host.exe -k kernel2_4cu.xclbin
Exception: No such compute unit 'hello_world:hello_world_0': Invalid argument
FAILED TEST
```