### PR TITLE
Add profiling compile time guards

### DIFF
--- a/src/runtime_src/xdp/profile/device/device_intf.cpp
+++ b/src/runtime_src/xdp/profile/device/device_intf.cpp
@@ -86,6 +86,7 @@ uint64_t GetTS2MMBufSize(bool isAIETrace)
 {
   std::string size_str;
   if (isAIETrace) {
+#ifndef SKIP_AIE_INI
     size_str = xrt_core::config::get_aie_trace_settings_buffer_size();
     if (0 == size_str.compare("8M")) {
       // if set to default value, then check for old style config
@@ -95,6 +96,9 @@ uint64_t GetTS2MMBufSize(bool isAIETrace)
         xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", 
           "The xrt.ini flag \"aie_trace_buffer_size\" is deprecated and will be removed in future release. Please use \"buffer_size\" under \"AIE_trace_settings\" section.");
     }
+#else
+    size_str = "8M";
+#endif
   } else {
     size_str = xrt_core::config::get_trace_buffer_size();
   }

--- a/src/runtime_src/xdp/profile/device/ioctl_monitors/ioctl_add.cpp
+++ b/src/runtime_src/xdp/profile/device/ioctl_monitors/ioctl_add.cpp
@@ -16,8 +16,7 @@
  * under the License.
  */
 
-#ifndef _WIN32
-#ifndef SKIP_IOCTL
+#if !defined(_WIN32) && !defined(SKIP_IOCTL)
 
 #include <sys/fcntl.h>
 #include <sys/mman.h>
@@ -98,5 +97,4 @@ int IOCtlDeadlockDetector::write(uint64_t /*offset*/, size_t size, void* /*data*
 }
 
 }
-#endif
 #endif

--- a/src/runtime_src/xdp/profile/device/ioctl_monitors/ioctl_add.cpp
+++ b/src/runtime_src/xdp/profile/device/ioctl_monitors/ioctl_add.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2021 Xilinx Inc - All rights reserved
+ * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
  * Xilinx Debug & Profile (XDP) APIs
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
@@ -16,6 +17,7 @@
  */
 
 #ifndef _WIN32
+#ifndef SKIP_IOCTL
 
 #include <sys/fcntl.h>
 #include <sys/mman.h>
@@ -96,4 +98,5 @@ int IOCtlDeadlockDetector::write(uint64_t /*offset*/, size_t size, void* /*data*
 }
 
 }
+#endif
 #endif

--- a/src/runtime_src/xdp/profile/device/ioctl_monitors/ioctl_aieTraceS2MM.cpp
+++ b/src/runtime_src/xdp/profile/device/ioctl_monitors/ioctl_aieTraceS2MM.cpp
@@ -16,8 +16,7 @@
  * under the License.
  */
 
-#ifndef _WIN32
-#ifndef SKIP_IOCTL
+#if !defined(_WIN32) && !defined(SKIP_IOCTL)
 
 #include <sys/fcntl.h>
 #include <sys/mman.h>
@@ -137,5 +136,4 @@ int IOCtlAIETraceS2MM::write(uint64_t /*offset*/, size_t size, void* /*data*/)
 }
 
 }
-#endif
 #endif

--- a/src/runtime_src/xdp/profile/device/ioctl_monitors/ioctl_aieTraceS2MM.cpp
+++ b/src/runtime_src/xdp/profile/device/ioctl_monitors/ioctl_aieTraceS2MM.cpp
@@ -17,6 +17,7 @@
  */
 
 #ifndef _WIN32
+#ifndef SKIP_IOCTL
 
 #include <sys/fcntl.h>
 #include <sys/mman.h>
@@ -136,4 +137,5 @@ int IOCtlAIETraceS2MM::write(uint64_t /*offset*/, size_t size, void* /*data*/)
 }
 
 }
+#endif
 #endif

--- a/src/runtime_src/xdp/profile/device/ioctl_monitors/ioctl_aim.cpp
+++ b/src/runtime_src/xdp/profile/device/ioctl_monitors/ioctl_aim.cpp
@@ -17,6 +17,7 @@
  */
 
 #ifndef _WIN32
+#ifndef SKIP_IOCTL
 
 #include <sys/fcntl.h>
 #include <sys/mman.h>
@@ -149,3 +150,5 @@ int IOCtlAIM::write(uint64_t /*offset*/, size_t size, void* /*data*/)
 
 }
 #endif
+#endif
+

--- a/src/runtime_src/xdp/profile/device/ioctl_monitors/ioctl_aim.cpp
+++ b/src/runtime_src/xdp/profile/device/ioctl_monitors/ioctl_aim.cpp
@@ -16,8 +16,7 @@
  * under the License.
  */
 
-#ifndef _WIN32
-#ifndef SKIP_IOCTL
+#if !defined(_WIN32) && !defined(SKIP_IOCTL)
 
 #include <sys/fcntl.h>
 #include <sys/mman.h>
@@ -149,6 +148,5 @@ int IOCtlAIM::write(uint64_t /*offset*/, size_t size, void* /*data*/)
 }
 
 }
-#endif
 #endif
 

--- a/src/runtime_src/xdp/profile/device/ioctl_monitors/ioctl_am.cpp
+++ b/src/runtime_src/xdp/profile/device/ioctl_monitors/ioctl_am.cpp
@@ -16,8 +16,7 @@
  * under the License.
  */
 
-#ifndef _WIN32
-#ifndef SKIP_IOCTL
+#if !defined(_WIN32) && !defined(SKIP_IOCTL)
 
 #include <sys/fcntl.h>
 #include <sys/mman.h>
@@ -209,5 +208,4 @@ int IOCtlAM::write(uint64_t /*offset*/, size_t size, void* /*data*/)
 }
 
 }
-#endif
 #endif

--- a/src/runtime_src/xdp/profile/device/ioctl_monitors/ioctl_am.cpp
+++ b/src/runtime_src/xdp/profile/device/ioctl_monitors/ioctl_am.cpp
@@ -17,6 +17,7 @@
  */
 
 #ifndef _WIN32
+#ifndef SKIP_IOCTL
 
 #include <sys/fcntl.h>
 #include <sys/mman.h>
@@ -208,4 +209,5 @@ int IOCtlAM::write(uint64_t /*offset*/, size_t size, void* /*data*/)
 }
 
 }
+#endif
 #endif

--- a/src/runtime_src/xdp/profile/device/ioctl_monitors/ioctl_asm.cpp
+++ b/src/runtime_src/xdp/profile/device/ioctl_monitors/ioctl_asm.cpp
@@ -16,8 +16,7 @@
  * under the License.
  */
 
-#ifndef _WIN32
-#ifndef SKIP_IOCTL
+#if !defined(_WIN32) && !defined(SKIP_IOCTL)
 
 #include <sys/fcntl.h>
 #include <sys/mman.h>
@@ -158,5 +157,4 @@ int IOCtlASM::write(uint64_t /*offset*/, size_t size, void* /*data*/)
 }
 
 }
-#endif
 #endif

--- a/src/runtime_src/xdp/profile/device/ioctl_monitors/ioctl_asm.cpp
+++ b/src/runtime_src/xdp/profile/device/ioctl_monitors/ioctl_asm.cpp
@@ -17,6 +17,7 @@
  */
 
 #ifndef _WIN32
+#ifndef SKIP_IOCTL
 
 #include <sys/fcntl.h>
 #include <sys/mman.h>
@@ -157,4 +158,5 @@ int IOCtlASM::write(uint64_t /*offset*/, size_t size, void* /*data*/)
 }
 
 }
+#endif
 #endif

--- a/src/runtime_src/xdp/profile/device/ioctl_monitors/ioctl_traceFifoFull.cpp
+++ b/src/runtime_src/xdp/profile/device/ioctl_monitors/ioctl_traceFifoFull.cpp
@@ -16,8 +16,7 @@
  * under the License.
  */
 
-#ifndef _WIN32
-#ifndef SKIP_IOCTL
+#if !defined(_WIN32) && !defined(SKIP_IOCTL)
 
 #include <sys/fcntl.h>
 #include <sys/mman.h>
@@ -88,5 +87,4 @@ int IOCtlTraceFifoFull::write(uint64_t /*offset*/, size_t size, void* /*data*/)
 }
 
 }
-#endif
 #endif

--- a/src/runtime_src/xdp/profile/device/ioctl_monitors/ioctl_traceFifoFull.cpp
+++ b/src/runtime_src/xdp/profile/device/ioctl_monitors/ioctl_traceFifoFull.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2020 Xilinx Inc - All rights reserved
+ * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
  * Xilinx Debug & Profile (XDP) APIs
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
@@ -16,6 +17,7 @@
  */
 
 #ifndef _WIN32
+#ifndef SKIP_IOCTL
 
 #include <sys/fcntl.h>
 #include <sys/mman.h>
@@ -86,4 +88,5 @@ int IOCtlTraceFifoFull::write(uint64_t /*offset*/, size_t size, void* /*data*/)
 }
 
 }
+#endif
 #endif

--- a/src/runtime_src/xdp/profile/device/ioctl_monitors/ioctl_traceFifoLite.cpp
+++ b/src/runtime_src/xdp/profile/device/ioctl_monitors/ioctl_traceFifoLite.cpp
@@ -17,6 +17,7 @@
  */
 
 #ifndef _WIN32
+#ifndef SKIP_IOCTL
 
 #include <chrono>
 #include <cstring>
@@ -114,4 +115,5 @@ int IOCtlTraceFifoLite::write(uint64_t /*offset*/, size_t size, void* /*data*/)
 }
 
 }
+#endif
 #endif

--- a/src/runtime_src/xdp/profile/device/ioctl_monitors/ioctl_traceFifoLite.cpp
+++ b/src/runtime_src/xdp/profile/device/ioctl_monitors/ioctl_traceFifoLite.cpp
@@ -16,8 +16,7 @@
  * under the License.
  */
 
-#ifndef _WIN32
-#ifndef SKIP_IOCTL
+#if !defined(_WIN32) && !defined(SKIP_IOCTL)
 
 #include <chrono>
 #include <cstring>
@@ -115,5 +114,4 @@ int IOCtlTraceFifoLite::write(uint64_t /*offset*/, size_t size, void* /*data*/)
 }
 
 }
-#endif
 #endif

--- a/src/runtime_src/xdp/profile/device/ioctl_monitors/ioctl_traceFunnel.cpp
+++ b/src/runtime_src/xdp/profile/device/ioctl_monitors/ioctl_traceFunnel.cpp
@@ -16,8 +16,7 @@
  * under the License.
  */
 
-#ifndef _WIN32
-#ifndef SKIP_IOCTL
+#if !defined(_WIN32) && !defined(SKIP_IOCTL)
 
 #include <sys/fcntl.h>
 #include <sys/mman.h>
@@ -110,5 +109,4 @@ int IOCtlTraceFunnel::write(uint64_t /*offset*/, size_t size, void* /*data*/)
 }
 
 }
-#endif
 #endif

--- a/src/runtime_src/xdp/profile/device/ioctl_monitors/ioctl_traceFunnel.cpp
+++ b/src/runtime_src/xdp/profile/device/ioctl_monitors/ioctl_traceFunnel.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2020-2022 Xilinx Inc - All rights reserved
+ * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
  * Xilinx Debug & Profile (XDP) APIs
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
@@ -16,6 +17,7 @@
  */
 
 #ifndef _WIN32
+#ifndef SKIP_IOCTL
 
 #include <sys/fcntl.h>
 #include <sys/mman.h>
@@ -108,4 +110,5 @@ int IOCtlTraceFunnel::write(uint64_t /*offset*/, size_t size, void* /*data*/)
 }
 
 }
+#endif
 #endif

--- a/src/runtime_src/xdp/profile/device/ioctl_monitors/ioctl_traceS2MM.cpp
+++ b/src/runtime_src/xdp/profile/device/ioctl_monitors/ioctl_traceS2MM.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2020 Xilinx Inc - All rights reserved
+ * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
  * Xilinx Debug & Profile (XDP) APIs
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
@@ -16,6 +17,7 @@
  */
 
 #ifndef _WIN32
+#ifndef SKIP_IOCTL
 
 #include <sys/fcntl.h>
 #include <sys/mman.h>
@@ -132,4 +134,5 @@ int IOCtlTraceS2MM::write(uint64_t /*offset*/, size_t size, void* /*data*/)
 }
 
 }
+#endif
 #endif

--- a/src/runtime_src/xdp/profile/device/ioctl_monitors/ioctl_traceS2MM.cpp
+++ b/src/runtime_src/xdp/profile/device/ioctl_monitors/ioctl_traceS2MM.cpp
@@ -16,8 +16,7 @@
  * under the License.
  */
 
-#ifndef _WIN32
-#ifndef SKIP_IOCTL
+#if !defined(_WIN32) && !defined(SKIP_IOCTL)
 
 #include <sys/fcntl.h>
 #include <sys/mman.h>
@@ -134,5 +133,4 @@ int IOCtlTraceS2MM::write(uint64_t /*offset*/, size_t size, void* /*data*/)
 }
 
 }
-#endif
 #endif

--- a/src/runtime_src/xdp/profile/writer/vp_base/ini_parameters.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/ini_parameters.cpp
@@ -63,6 +63,7 @@ namespace xdp {
                  "Generation of lower overhead OpenCL trace. Should not be used with other OpenCL options.");
     addParameter("debug_mode", xrt_core::config::get_launch_waveform(),
                  "Debug mode (emulation only)");
+#ifndef SKIP_AIE_INI
     addParameter("aie_trace", xrt_core::config::get_aie_trace(),
                  "Generation of AI Engine trace");
     addParameter("aie_trace_buffer_size",
@@ -149,7 +150,8 @@ namespace xdp {
                  "Interval for reading of device AI Engine trace data to host (in us)");
     addParameter("AIE_trace_settings.file_dump_interval_s",
                  xrt_core::config::get_aie_trace_settings_file_dump_interval_s(),
-                 "Interval for dumping AI Engine trace files to host (in s)");  
+                 "Interval for dumping AI Engine trace files to host (in s)");
+#endif
   }
 
   IniParameters::~IniParameters()


### PR DESCRIPTION
#### Problem solved by the commit
This pull request adds (but does not define) compile time guards to different sections of the profiling code base that should be compiled in the main branch, but might want to be excluded in future specialized local branches.
