### PR TITLE
xclbinutil : Added AIE_PARTITION TOPs and multiple dpu_kernel_ids.

### DIFF
--- a/src/runtime_src/core/common/xclbin_parser.cpp
+++ b/src/runtime_src/core/common/xclbin_parser.cpp
@@ -857,9 +857,10 @@ get_aie_partition(const axlf* top)
     pdiobj.pdi.resize(aiepdip->pdi_image.size);
     memcpy(pdiobj.pdi.data(), topbase + aiepdip->pdi_image.offset, pdiobj.pdi.size());
     for (uint32_t j = 0; j < aiepdip->cdo_groups.size; j++) {
-      auto cdop = reinterpret_cast<const cdo_group*>(topbase + aiepdip->cdo_groups.offset + j * sizeof(cdo_group));
+      // auto cdop = reinterpret_cast<const cdo_group*>(topbase + aiepdip->cdo_groups.offset + j * sizeof(cdo_group));
 
-      pdiobj.cdo_groups.emplace_back<aie_cdo_group_obj>({topbase + cdop->mpo_name, cdop->cdo_type, cdop->pdi_id, cdop->dpu_kernel_id});
+      // TODO: Update this code to use a collection of kernel IDs instead of just one
+      // pdiobj.cdo_groups.emplace_back<aie_cdo_group_obj>({topbase + cdop->mpo_name, cdop->cdo_type, cdop->pdi_id, cdop->dpu_kernel_id});
     }
 
     obj.pdis.emplace_back(std::move(pdiobj));

--- a/src/runtime_src/core/include/xclbin.h
+++ b/src/runtime_src/core/include/xclbin.h
@@ -538,7 +538,7 @@ extern "C" {
         uint8_t cdo_type;                   // CDO group type (CDO_Type)
         uint8_t padding[3];             
         uint64_t pdi_id;                    // PDI ID
-        uint64_t dpu_kernel_id;             // DPU kernel ID
+        struct array_offset dpu_kernel_ids; // Array of dpu_kernel_ids (uint64_t)
         struct array_offset pre_cdo_groups; // Array of Pre CDO Group IDs (uint32_t)
         uint8_t reserved[64];               // Reserved
     };
@@ -552,6 +552,7 @@ extern "C" {
         struct array_offset cdo_groups;     // Array of cdo_groups (cdo_group)
         uint8_t reserved[64];               // Reserved
     };
+
     XCLBIN_STATIC_ASSERT(sizeof(struct aie_pdi) == 96, "aie_pdi structure no longer is 96 bytes in size");
     XCLBIN_STATIC_ASSERT(sizeof(struct aie_pdi) % sizeof(uint64_t) == 0, "aie_pdi structure needs to be 64-bit word aligned");
 
@@ -567,11 +568,13 @@ extern "C" {
         uint8_t schema_version;             // Group schema version (default 0)
         uint8_t padding0[3];                // Byte alignment          
         uint32_t mpo_name;                  // Name of the aie_partition 
+        uint32_t tile_operation_per_cycle;  // TOPs
+        uint8_t padding[4];
         struct aie_partition_info info;     // Partition information
         struct array_offset aie_pdi;        // PDI Array (aie_partition_info)
         uint8_t reserved[54];               // Reserved
     };
-    XCLBIN_STATIC_ASSERT(sizeof(struct aie_partition) == 160, "aie_partition structure no longer is 160 bytes in size");
+    XCLBIN_STATIC_ASSERT(sizeof(struct aie_partition) == 168, "aie_partition structure no longer is 168 bytes in size");
     XCLBIN_STATIC_ASSERT(sizeof(struct aie_partition) % sizeof(uint64_t) == 0, "aie_partition structure needs to be 64-bit word aligned");
 
     /**** END : Xilinx internal section *****/

--- a/src/runtime_src/core/include/xclbin.h
+++ b/src/runtime_src/core/include/xclbin.h
@@ -568,7 +568,7 @@ extern "C" {
         uint8_t schema_version;             // Group schema version (default 0)
         uint8_t padding0[3];                // Byte alignment          
         uint32_t mpo_name;                  // Name of the aie_partition 
-        uint32_t operation_per_cycle;       // TOPs
+        uint32_t operations_per_cycle;      // Operations per cycle. Used later to create TOPS (operations_per_cycle * <AIE Clock Frequency>)
         uint8_t padding[4];
         struct aie_partition_info info;     // Partition information
         struct array_offset aie_pdi;        // PDI Array (aie_partition_info)

--- a/src/runtime_src/core/include/xclbin.h
+++ b/src/runtime_src/core/include/xclbin.h
@@ -568,7 +568,7 @@ extern "C" {
         uint8_t schema_version;             // Group schema version (default 0)
         uint8_t padding0[3];                // Byte alignment          
         uint32_t mpo_name;                  // Name of the aie_partition 
-        uint32_t tile_operation_per_cycle;  // TOPs
+        uint32_t operation_per_cycle;       // TOPs
         uint8_t padding[4];
         struct aie_partition_info info;     // Partition information
         struct array_offset aie_pdi;        // PDI Array (aie_partition_info)

--- a/src/runtime_src/tools/xclbinutil/SectionAIEPartition.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionAIEPartition.cxx
@@ -278,10 +278,23 @@ process_PDI_cdo_groups(const boost::property_tree::ptree& ptAIEPartitionPDI,
 
     aieCDOGroup.pdi_id = std::strtoul(sPDIValue.c_str(), NULL, 0);
 
-    // DPU Function ID (optional)
-    auto sDPUValue = element.get<std::string>("dpu_kernel_id", "");
-    if (!sDPUValue.empty())
-      aieCDOGroup.dpu_kernel_id = std::strtoul(sDPUValue.c_str(), NULL, 0);
+    // DPU Function IDs (optional)
+    std::vector<std::string> dpuKernelIDs = XUtil::as_vector_simple<std::string>(element, "dpu_kernel_ids");
+    aieCDOGroup.dpu_kernel_ids.size = static_cast<decltype(aieCDOGroup.dpu_kernel_ids.size)>(dpuKernelIDs.size());
+
+    if (aieCDOGroup.dpu_kernel_ids.size != 0) {
+      // Record where the dpu kernel IDs array starts
+      aieCDOGroup.dpu_kernel_ids.offset = static_cast<decltype(aieCDOGroup.dpu_kernel_ids.offset)>(heap.getNextBufferOffset());
+
+      // Write out the DPU values to the heap.
+      for (const auto& element : dpuKernelIDs) {
+        uint64_t dpuKernelID = std::strtoul(element.c_str(), NULL, 0);
+        heap.write(reinterpret_cast<const char*>(&dpuKernelID), sizeof(decltype(dpuKernelID)), false /*align*/);
+      }
+
+      // Align the heap to the next 64-bit word.
+      heap.write(nullptr, 0);
+    }
 
     // PRE CDO Groups (optional)
     process_pre_cdo_groups(element, aieCDOGroup, heap);
@@ -392,8 +405,12 @@ createAIEPartitionImage(const std::string& sectionIndexName,
   // Initialized the start of the section heap
   SectionHeap heap(sizeof(aie_partition));
 
+  // Name
   aie_partitionHdr.mpo_name = static_cast<decltype(aie_partitionHdr.mpo_name)>(heap.getNextBufferOffset());
   heap.write(sectionIndexName.c_str(), sectionIndexName.size() + 1 /*Null char*/);
+
+  // TOPs
+  aie_partitionHdr.tile_operation_per_cycle = ptAIEPartition.get<uint32_t>("tile_operation_per_cycle", 0);
 
   //  Process the nodes
   process_partition_info(ptAIEPartition, aie_partitionHdr.info, heap);
@@ -517,9 +534,17 @@ populate_cdo_groups(const char* pBase,
     // PDI ID
     ptElement.put("pdi_id", (boost::format("0x%x") % element.pdi_id).str());
 
-    // Function ID
-    if (element.dpu_kernel_id)
-      ptElement.put("dpu_kernel_id", (boost::format("0x%x") % element.dpu_kernel_id).str());
+    // DPU Kernel IDs
+    if (element.dpu_kernel_ids.size) {
+      boost::property_tree::ptree ptDPUKernelIDs;
+      const uint64_t* kernelIDsArray = reinterpret_cast<const uint64_t*>(pBase + element.dpu_kernel_ids.offset);
+      for (uint32_t index = 0; index < element.dpu_kernel_ids.size; index++) {
+        boost::property_tree::ptree ptID;
+        ptID.put("", (boost::format("0x%x") % kernelIDsArray[index]).str());
+        ptDPUKernelIDs.push_back({ "", ptID });
+      }
+      ptElement.add_child("dpu_kernel_ids", ptDPUKernelIDs);
+    }
 
     // Pre cdo groups
     populate_pre_cdo_groups(pBase, element, ptElement);
@@ -608,6 +633,9 @@ writeAIEPartitionImage(const char* pBuffer,
   // Name
   boost::property_tree::ptree ptAiePartition;
   ptAiePartition.put("name", pBuffer + pHdr->mpo_name);
+
+  // TOPs
+  ptAiePartition.put("tile_operation_per_cycle", (boost::format("%d") % pHdr->tile_operation_per_cycle).str());
 
   // Partition info
   populate_partition_info(pBuffer, pHdr->info, ptAiePartition);

--- a/src/runtime_src/tools/xclbinutil/SectionAIEPartition.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionAIEPartition.cxx
@@ -538,7 +538,7 @@ populate_cdo_groups(const char* pBase,
     if (element.dpu_kernel_ids.size) {
       boost::property_tree::ptree ptDPUKernelIDs;
       const uint64_t* kernelIDsArray = reinterpret_cast<const uint64_t*>(pBase + element.dpu_kernel_ids.offset);
-      for (uint32_t kernelIDindex = 0; index < element.dpu_kernel_ids.size; index++) {
+      for (uint32_t kernelIDindex = 0; kernelIDindex < element.dpu_kernel_ids.size; kernelIDindex++) {
         boost::property_tree::ptree ptID;
         ptID.put("", (boost::format("0x%x") % kernelIDsArray[kernelIDindex]).str());
         ptDPUKernelIDs.push_back({ "", ptID });

--- a/src/runtime_src/tools/xclbinutil/SectionAIEPartition.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionAIEPartition.cxx
@@ -410,7 +410,7 @@ createAIEPartitionImage(const std::string& sectionIndexName,
   heap.write(sectionIndexName.c_str(), sectionIndexName.size() + 1 /*Null char*/);
 
   // TOPs
-  aie_partitionHdr.operation_per_cycle = ptAIEPartition.get<uint32_t>("operation_per_cycle", 0);
+  aie_partitionHdr.operations_per_cycle = ptAIEPartition.get<uint32_t>("operations_per_cycle", 0);
 
   //  Process the nodes
   process_partition_info(ptAIEPartition, aie_partitionHdr.info, heap);
@@ -635,7 +635,7 @@ writeAIEPartitionImage(const char* pBuffer,
   ptAiePartition.put("name", pBuffer + pHdr->mpo_name);
 
   // TOPs
-  ptAiePartition.put("operation_per_cycle", (boost::format("%d") % pHdr->operation_per_cycle).str());
+  ptAiePartition.put("operations_per_cycle", (boost::format("%d") % pHdr->operations_per_cycle).str());
 
   // Partition info
   populate_partition_info(pBuffer, pHdr->info, ptAiePartition);

--- a/src/runtime_src/tools/xclbinutil/SectionAIEPartition.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionAIEPartition.cxx
@@ -287,8 +287,8 @@ process_PDI_cdo_groups(const boost::property_tree::ptree& ptAIEPartitionPDI,
       aieCDOGroup.dpu_kernel_ids.offset = static_cast<decltype(aieCDOGroup.dpu_kernel_ids.offset)>(heap.getNextBufferOffset());
 
       // Write out the DPU values to the heap.
-      for (const auto& element : dpuKernelIDs) {
-        uint64_t dpuKernelID = std::strtoul(element.c_str(), NULL, 0);
+      for (const auto& kernelID : dpuKernelIDs) {
+        uint64_t dpuKernelID = std::strtoul(kernelID.c_str(), NULL, 0);
         heap.write(reinterpret_cast<const char*>(&dpuKernelID), sizeof(decltype(dpuKernelID)), false /*align*/);
       }
 
@@ -410,7 +410,7 @@ createAIEPartitionImage(const std::string& sectionIndexName,
   heap.write(sectionIndexName.c_str(), sectionIndexName.size() + 1 /*Null char*/);
 
   // TOPs
-  aie_partitionHdr.tile_operation_per_cycle = ptAIEPartition.get<uint32_t>("tile_operation_per_cycle", 0);
+  aie_partitionHdr.operation_per_cycle = ptAIEPartition.get<uint32_t>("operation_per_cycle", 0);
 
   //  Process the nodes
   process_partition_info(ptAIEPartition, aie_partitionHdr.info, heap);
@@ -538,9 +538,9 @@ populate_cdo_groups(const char* pBase,
     if (element.dpu_kernel_ids.size) {
       boost::property_tree::ptree ptDPUKernelIDs;
       const uint64_t* kernelIDsArray = reinterpret_cast<const uint64_t*>(pBase + element.dpu_kernel_ids.offset);
-      for (uint32_t index = 0; index < element.dpu_kernel_ids.size; index++) {
+      for (uint32_t kernelIDindex = 0; index < element.dpu_kernel_ids.size; index++) {
         boost::property_tree::ptree ptID;
-        ptID.put("", (boost::format("0x%x") % kernelIDsArray[index]).str());
+        ptID.put("", (boost::format("0x%x") % kernelIDsArray[kernelIDindex]).str());
         ptDPUKernelIDs.push_back({ "", ptID });
       }
       ptElement.add_child("dpu_kernel_ids", ptDPUKernelIDs);
@@ -635,7 +635,7 @@ writeAIEPartitionImage(const char* pBuffer,
   ptAiePartition.put("name", pBuffer + pHdr->mpo_name);
 
   // TOPs
-  ptAiePartition.put("tile_operation_per_cycle", (boost::format("%d") % pHdr->tile_operation_per_cycle).str());
+  ptAiePartition.put("operation_per_cycle", (boost::format("%d") % pHdr->operation_per_cycle).str());
 
   // Partition info
   populate_partition_info(pBuffer, pHdr->info, ptAiePartition);

--- a/src/runtime_src/tools/xclbinutil/unittests/AIEPartition/aie_partition.json
+++ b/src/runtime_src/tools/xclbinutil/unittests/AIEPartition/aie_partition.json
@@ -1,6 +1,6 @@
 {
 	"aie_partition": {
-        "operation_per_cycle": "135",
+        "operations_per_cycle": "135",
 		"partition": {
 			"column_width": 1,
 			"start_columns": [1, 2, 3, 4]

--- a/src/runtime_src/tools/xclbinutil/unittests/AIEPartition/aie_partition.json
+++ b/src/runtime_src/tools/xclbinutil/unittests/AIEPartition/aie_partition.json
@@ -1,6 +1,6 @@
 {
 	"aie_partition": {
-        "tile_operation_per_cycle": "135",
+        "operation_per_cycle": "135",
 		"partition": {
 			"column_width": 1,
 			"start_columns": [1, 2, 3, 4]

--- a/src/runtime_src/tools/xclbinutil/unittests/AIEPartition/aie_partition.json
+++ b/src/runtime_src/tools/xclbinutil/unittests/AIEPartition/aie_partition.json
@@ -1,5 +1,6 @@
 {
 	"aie_partition": {
+        "tile_operation_per_cycle": "135",
 		"partition": {
 			"column_width": 1,
 			"start_columns": [1, 2, 3, 4]
@@ -11,14 +12,14 @@
 						"name": "DPU",
 						"type": "PRIMARY",
 						"pdi_id": "0xF0",
-						"dpu_kernel_id": "0x100",
+						"dpu_kernel_ids": ["0x100"],
 						"pre_cdo_groups": ["0xC0"]
 					},
 					{
 						"name": "PP0",
 						"type": "LITE",
 						"pdi_id": "0xF1",
-						"dpu_kernel_id": "0x101",
+						"dpu_kernel_ids": ["0x101"],
 						"pre_cdo_groups": ["0xC0"]
 
 					},
@@ -26,7 +27,7 @@
 						"name": "PP1",
 						"type": "LITE",
 						"pdi_id": "0xF2",
-						"dpu_kernel_id": "0x102",
+						"dpu_kernel_ids": ["0x102"],
 						"pre_cdo_groups": ["0xC0"]
 					},
 					{
@@ -47,7 +48,7 @@
 					"name": "PP3",
 					"type": "LITE",
 					"pdi_id": "0xF1",
-					"dpu_kernel_id": "0x104"
+					"dpu_kernel_ids": ["0x104", "0x105"]
 				}]
 			}
 		]

--- a/src/runtime_src/tools/xclbinutil/unittests/AIEPartition/aie_partition_expected.json
+++ b/src/runtime_src/tools/xclbinutil/unittests/AIEPartition/aie_partition_expected.json
@@ -1,7 +1,7 @@
 {
     "aie_partition": {
         "name": "Flavor",
-        "tile_operation_per_cycle": "135",
+        "operation_per_cycle": "135",
         "partition": {
             "column_width": "1",
             "start_columns": [

--- a/src/runtime_src/tools/xclbinutil/unittests/AIEPartition/aie_partition_expected.json
+++ b/src/runtime_src/tools/xclbinutil/unittests/AIEPartition/aie_partition_expected.json
@@ -1,6 +1,7 @@
 {
     "aie_partition": {
         "name": "Flavor",
+        "tile_operation_per_cycle": "135",
         "partition": {
             "column_width": "1",
             "start_columns": [
@@ -19,7 +20,9 @@
                         "name": "DPU",
                         "type": "PRIMARY",
                         "pdi_id": "0xf0",
-                        "dpu_kernel_id": "0x100",
+                        "dpu_kernel_ids": [
+                            "0x100"
+                        ],
                         "pre_cdo_groups": [
                             "0xc0"
                         ]
@@ -28,7 +31,9 @@
                         "name": "PP0",
                         "type": "LITE",
                         "pdi_id": "0xf1",
-                        "dpu_kernel_id": "0x101",
+                        "dpu_kernel_ids": [
+                            "0x101"
+                        ],
                         "pre_cdo_groups": [
                             "0xc0"
                         ]
@@ -37,7 +42,9 @@
                         "name": "PP1",
                         "type": "LITE",
                         "pdi_id": "0xf2",
-                        "dpu_kernel_id": "0x102",
+                        "dpu_kernel_ids": [
+                            "0x102"
+                        ],
                         "pre_cdo_groups": [
                             "0xc0"
                         ]
@@ -63,7 +70,10 @@
                         "name": "PP3",
                         "type": "LITE",
                         "pdi_id": "0xf1",
-                        "dpu_kernel_id": "0x104"
+                        "dpu_kernel_ids": [
+                            "0x104",
+                            "0x105"
+                        ]
                     }
                 ]
             }

--- a/src/runtime_src/tools/xclbinutil/unittests/AIEPartition/aie_partition_expected.json
+++ b/src/runtime_src/tools/xclbinutil/unittests/AIEPartition/aie_partition_expected.json
@@ -1,7 +1,7 @@
 {
     "aie_partition": {
         "name": "Flavor",
-        "operation_per_cycle": "135",
+        "operations_per_cycle": "135",
         "partition": {
             "column_width": "1",
             "start_columns": [


### PR DESCRIPTION
#### Problem solved by the commit
Modified the AIE_PARTITION xclbin binary formation to support:
1. TOPs - Tile Operation Per Cycle
2. Multiple dpu_kernel_ids (previously only supported 1 element)

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
n/a

#### How problem was solved, alternative solutions (if any) and why they were rejected
n/a

#### Risks (if any) associated the changes in the commit
This change makes the AIE_PARTITION metadata section binary incompatible with previously generated xclbin containers.   Being that this work has yet to go public and that it is still in development, it was determined that this regression was acceptable.

In addition, the portions of the method `get_aie_partition()` has been commented out to allow for the XRT driver developer to update the code flow to support these changes.

#### What has been tested and how, request additional testing if necessary
1. Unit tests - New unit tests were created.
2. Manual Testing

#### Documentation impact (if any)
n/a