### PR TITLE
CR-1132437 ASTeR TC22.06 - x3522/u280 - host mem enable segmentation fault

### DIFF
--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -1216,6 +1216,7 @@ int shim::cmaEnable(bool enable, uint64_t size)
         uint64_t allocated_size = 0;
         uint32_t page_num = size >> 30;
         drm_xocl_alloc_cma_info cma_info = {0};
+        uint64_t user_addr[page_num] = {0};
 
         /* We check the sysfs node host_mem_size first before going forward
          * If the same size of host memory chunk is allocated
@@ -1228,8 +1229,7 @@ int shim::cmaEnable(bool enable, uint64_t size)
 
         cma_info.total_size = size;
         cma_info.entry_num = page_num;
-
-        cma_info.user_addr = (uint64_t *)alloca(sizeof(uint64_t)*page_num);
+        cma_info.user_addr = user_addr;
 
         for (uint32_t i = 0; i < page_num; ++i) {
             void *addr_local = mmap(0x0, page_sz, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB | hugepage_flag << MAP_HUGE_SHIFT, 0, 0);
@@ -1252,7 +1252,7 @@ int shim::cmaEnable(bool enable, uint64_t size)
             if (!cma_info.user_addr[i])
                 continue;
 
-             munmap((void*)cma_info.user_addr[i], page_sz);
+            munmap((void*)cma_info.user_addr[i], page_sz);
         }
 
         if (ret) {

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -1216,7 +1216,7 @@ int shim::cmaEnable(bool enable, uint64_t size)
         uint64_t allocated_size = 0;
         uint32_t page_num = size >> 30;
         drm_xocl_alloc_cma_info cma_info = {0};
-        uint64_t user_addr[page_num] = {0};
+        std::vector<uint64_t> user_addr(page_num, 0);
 
         /* We check the sysfs node host_mem_size first before going forward
          * If the same size of host memory chunk is allocated
@@ -1229,7 +1229,7 @@ int shim::cmaEnable(bool enable, uint64_t size)
 
         cma_info.total_size = size;
         cma_info.entry_num = page_num;
-        cma_info.user_addr = user_addr;
+        cma_info.user_addr = user_addr.data();
 
         for (uint32_t i = 0; i < page_num; ++i) {
             void *addr_local = mmap(0x0, page_sz, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB | hugepage_flag << MAP_HUGE_SHIFT, 0, 0);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
CR-1132437, segmentation fault when enable host mem  

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
I believe this bug is introduced since #5747. In the CR, the reporter has a script to keep enable and disable host mem. The segmentation fault issue will happen by chance.

#### How problem was solved, alternative solutions (if any) and why they were rejected
The issue is cma_info.user_addr[i] is uninitialized in "munmap((void*)cma_info.user_addr[i], page_sz);".
In most of the cases, munmap() returns error. But sometimes, munmap() can destroy the stack frame. I guess this is because of that user_addr is allocated by alloca(). Maybe the uninitialized value is related to stack frame. BTW, I tried simply replace alloca() by malloc(). Then I don't see segmentation fault.

Base on what I have found, I make two changs:
1.  In `man alloca`, it says _"If the allocation causes stack overflow, program behavior is undefined."_. I thought that unless there is a strong reason, we should avoid use alloca(). So, I remove it. 
2. I use std::vector<uint64_t> for user_addr and initialized it.

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
On u280, keep enable and disable host mem in a infinit loop. It runs 2 hours without any issue. In before, it can be reproduce in less than 2 minutes.

#### Documentation impact (if any)
No