### PR TITLE
 [split #6908 3/3] Use iosys-map instead of deprecated dma-buf-map

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/zocl_bo.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_bo.c
@@ -18,8 +18,14 @@
 #include <linux/of_address.h>
 #include <linux/iommu.h>
 #include <linux/version.h>
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 11, 0))
-#include <linux/dma-buf-map.h>
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 18, 0))
+	#include <linux/iosys-map.h>
+	#define MAP_TYPE iosys_map
+	#define MAP_IS_NULL iosys_map_is_null
+#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 11, 0))
+	#include <linux/dma-buf-map.h>
+	#define MAP_TYPE dma_buf_map
+	#define MAP_IS_NULL dma_buf_map_is_null
 #endif
 #include <asm/io.h>
 #include "xrt_drv.h"
@@ -877,7 +883,7 @@ static int zocl_bo_rdwr_ioctl(struct drm_device *dev, void *data,
 	char __user *user_data = to_user_ptr(args->data_ptr);
 	struct drm_zocl_bo *bo;
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 11, 0))
-	struct dma_buf_map map;
+	struct MAP_TYPE map;
 #endif
 	int ret = 0;
 	char *kaddr;
@@ -906,7 +912,7 @@ static int zocl_bo_rdwr_ioctl(struct drm_device *dev, void *data,
 	if (bo->flags & ZOCL_BO_FLAGS_CMA) {
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 12, 0)
 		ret = drm_gem_cma_vmap(gem_obj, &map);
-		if(ret || dma_buf_map_is_null(&map))
+		if(ret || MAP_IS_NULL(&map))
 			kaddr = NULL;
 		else
 			kaddr = map.is_iomem ? map.vaddr_iomem : map.vaddr;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libxdma.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libxdma.c
@@ -836,7 +836,7 @@ static void xdma_request_release(struct xdma_dev *xdev,
 {
 	struct sg_table *sgt = req->sgt;
 	if (!req->dma_mapped) {
-		pci_unmap_sg(xdev->pdev, sgt->sgl, sgt->orig_nents,
+		dma_unmap_sg(&xdev->pdev->dev, sgt->sgl, sgt->orig_nents,
 			     req->dir);
 	}
 
@@ -3296,7 +3296,8 @@ ssize_t xdma_xfer_fastpath(void *dev_hndl, int channel, bool write, u64 ep_addr,
 		engine = &xdev->engine_c2h[channel];
 
 	if (!dma_mapped) {
-		nents = pci_map_sg(xdev->pdev, sg, sgt->orig_nents, engine->dir);
+		nents = dma_map_sg(&xdev->pdev->dev, sg, sgt->orig_nents,
+				   engine->dir);
 		if (!nents) {
 			xocl_pr_info("map sgl failed, sgt 0x%p.\n", sgt);
 			return -EIO;
@@ -3354,8 +3355,8 @@ ssize_t xdma_xfer_fastpath(void *dev_hndl, int channel, bool write, u64 ep_addr,
 			       (unsigned long)(&engine->regs));
 	}
 	if (!dma_mapped) {
-                pci_unmap_sg(xdev->pdev, sgt->sgl, sgt->orig_nents,
-                             engine->dir);
+                dma_unmap_sg(&xdev->pdev->dev, sgt->sgl, sgt->orig_nents,
+			     engine->dir);
         }
 
 	if (ret < 0)
@@ -3424,7 +3425,7 @@ ssize_t xdma_xfer_submit(void *dev_hndl, int channel, bool write, u64 ep_addr,
 	}
 
 	if (!dma_mapped) {
-		nents = pci_map_sg(xdev->pdev, sg, sgt->orig_nents, dir);
+		nents = dma_map_sg(&xdev->pdev->dev, sg, sgt->orig_nents, dir);
 		if (!nents) {
 			xocl_pr_info("map sgl failed, sgt 0x%p.\n", sgt);
 			return -EIO;
@@ -3709,18 +3710,18 @@ static int set_dma_mask(struct pci_dev *pdev)
 
 	dbg_init("sizeof(dma_addr_t) == %ld\n", sizeof(dma_addr_t));
 	/* 64-bit addressing capability for XDMA? */
-	if (!pci_set_dma_mask(pdev, DMA_BIT_MASK(64))) {
+	if (!dma_set_mask(&pdev->dev, DMA_BIT_MASK(64))) {
 		/* query for DMA transfer */
 		/* @see Documentation/DMA-mapping.txt */
 		dbg_init("pci_set_dma_mask()\n");
 		/* use 64-bit DMA */
 		dbg_init("Using a 64-bit DMA mask.\n");
 		/* use 32-bit DMA for descriptors */
-		pci_set_consistent_dma_mask(pdev, DMA_BIT_MASK(32));
+		dma_set_coherent_mask(&pdev->dev, DMA_BIT_MASK(32));
 		/* use 64-bit DMA, 32-bit for consistent */
-	} else if (!pci_set_dma_mask(pdev, DMA_BIT_MASK(32))) {
+	} else if (!dma_set_mask(&pdev->dev, DMA_BIT_MASK(32))) {
 		dbg_init("Could not set 64-bit DMA mask.\n");
-		pci_set_consistent_dma_mask(pdev, DMA_BIT_MASK(32));
+		dma_set_coherent_mask(&pdev->dev, DMA_BIT_MASK(32));
 		/* use 32-bit DMA */
 		dbg_init("Using a 32-bit DMA mask.\n");
 	} else {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/qdma.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/qdma.c
@@ -346,7 +346,8 @@ static ssize_t qdma_migrate_bo(struct platform_device *pdev,
 	chan = &qdma->chans[write][channel];
 
 	dir = write ? DMA_TO_DEVICE : DMA_FROM_DEVICE;
-	nents = pci_map_sg(XDEV(xdev)->pdev, sgt->sgl, sgt->orig_nents, dir);
+	nents = dma_map_sg(&XDEV(xdev)->pdev->dev, sgt->sgl, sgt->orig_nents,
+			   dir);
         if (!nents) {
 		xocl_err(&pdev->dev, "map sgl failed, sgt 0x%p.\n", sgt);
 		return -EIO;
@@ -379,7 +380,7 @@ static ssize_t qdma_migrate_bo(struct platform_device *pdev,
 		dump_sgtable(&pdev->dev, sgt);
 	}
 
-	pci_unmap_sg(XDEV(xdev)->pdev, sgt->sgl, nents, dir);
+	dma_unmap_sg(&XDEV(xdev)->pdev->dev, sgt->sgl, nents, dir);
 	kfree(req);
 
 	return ret;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
@@ -60,7 +60,6 @@ static inline void xocl_release_pages(struct page **pages, int nr, bool cold)
 #endif
 }
 
-
 static inline void __user *to_user_ptr(u64 address)
 {
 	return (void __user *)(uintptr_t)address;
@@ -189,8 +188,8 @@ static void xocl_free_bo(struct drm_gem_object *obj)
 	}
 
 	if (xobj->dma_nsg) {
-		pci_unmap_sg(xdev->core.pdev, xobj->sgt->sgl, xobj->dma_nsg,
-			PCI_DMA_BIDIRECTIONAL);
+		dma_unmap_sg(&xdev->core.pdev->dev, xobj->sgt->sgl,
+			     xobj->dma_nsg, DMA_BIDIRECTIONAL);
 	}
 
 	if (xobj->pages) {
@@ -1275,17 +1274,17 @@ void xocl_gem_prime_vunmap(struct drm_gem_object *obj, void *vaddr)
 
 }
 #else
-int xocl_gem_prime_vmap(struct drm_gem_object *obj, struct dma_buf_map *map)
+int xocl_gem_prime_vmap(struct drm_gem_object *obj, struct MAP_TYPE *map)
 {
         struct drm_xocl_bo *xobj = to_xocl_bo(obj);
 
         BO_ENTER("xobj %p", xobj);
-        dma_buf_map_set_vaddr(map, xobj->vmapping);
+        MAP_SET_VADDR(map, xobj->vmapping);
 
         return 0;
 }
 
-void xocl_gem_prime_vunmap(struct drm_gem_object *obj, struct dma_buf_map *map)
+void xocl_gem_prime_vunmap(struct drm_gem_object *obj, struct MAP_TYPE *map)
 {
 
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.h
@@ -69,6 +69,17 @@
  */
 #define XOCL_BO_ARE  (1 << 26)
 
+// Linux 5.18 uses iosys-map instead of dma-buf-map
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 18, 0)
+	#define MAP_TYPE iosys_map
+	#define MAP_SET_VADDR iosys_map_set_vaddr
+	#define MAP_IS_NULL iosys_map_is_null
+#else
+	#define MAP_TYPE dma_buf_map
+	#define MAP_SET_VADDR dma_buf_map_set_vaddr
+	#define MAP_IS_NULL dma_buf_map_is_null
+#endif
+
 static inline bool xocl_bo_userptr(const struct drm_xocl_bo *bo)
 {
 	return (bo->flags == XOCL_BO_USERPTR);
@@ -199,8 +210,8 @@ struct drm_gem_object *xocl_gem_prime_import_sg_table(struct drm_device *dev,
 void *xocl_gem_prime_vmap(struct drm_gem_object *obj);
 void xocl_gem_prime_vunmap(struct drm_gem_object *obj, void *vaddr);
 #else
-int xocl_gem_prime_vmap(struct drm_gem_object *obj, struct dma_buf_map *map);
-void xocl_gem_prime_vunmap(struct drm_gem_object *obj, struct dma_buf_map *map);
+int xocl_gem_prime_vmap(struct drm_gem_object *obj, struct MAP_TYPE *map);
+void xocl_gem_prime_vunmap(struct drm_gem_object *obj, struct MAP_TYPE *map);
 #endif
 
 int xocl_gem_prime_mmap(struct drm_gem_object *obj, struct vm_area_struct *vma);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
@@ -1252,7 +1252,7 @@ static void xocl_cma_mem_free(struct xocl_dev *xdev, uint32_t idx)
 
 	if (cma_mem->regular_page) {
 		dma_unmap_page(&xdev->core.pdev->dev, cma_mem->paddr,
-			cma_mem->size, PCI_DMA_BIDIRECTIONAL);
+			cma_mem->size, DMA_BIDIRECTIONAL);
 		__free_pages(cma_mem->regular_page, get_order(cma_mem->size));
 		cma_mem->regular_page = NULL;
 	} else if (cma_mem->pages) {
@@ -1502,7 +1502,7 @@ static int xocl_cma_mem_alloc_by_idx(struct xocl_dev *xdev, uint64_t size, uint3
 	}
 
 	dma_addr = dma_map_page(dev, page, 0, size,
-		PCI_DMA_BIDIRECTIONAL);
+		DMA_BIDIRECTIONAL);
 	if (unlikely(dma_mapping_error(dev, dma_addr))) {
 		DRM_ERROR("Unable to dma map pages");
 		__free_pages(page, order);
@@ -1513,7 +1513,7 @@ static int xocl_cma_mem_alloc_by_idx(struct xocl_dev *xdev, uint64_t size, uint3
 		roundup(PAGE_SIZE, size) >> PAGE_SHIFT);
 
 	if (!cma_mem->pages) {
-		dma_unmap_page(dev, dma_addr, size, PCI_DMA_BIDIRECTIONAL);
+		dma_unmap_page(dev, dma_addr, size, DMA_BIDIRECTIONAL);
 		__free_pages(page, order);
 		return -ENOMEM;
 	}
@@ -1783,18 +1783,18 @@ int xocl_userpf_probe(struct pci_dev *pdev,
 
 	xocl_drvinst_set_offline(xdev, false);
 
-	if (!pci_set_dma_mask(pdev, DMA_BIT_MASK(64))) {
+	if (!dma_set_mask(&pdev->dev, DMA_BIT_MASK(64))) {
 		/* query for DMA transfer */
 		/* @see Documentation/DMA-mapping.txt */
 		xocl_info(&pdev->dev, "pci_set_dma_mask()\n");
 		/* use 64-bit DMA */
 		xocl_info(&pdev->dev, "Using a 64-bit DMA mask.\n");
 		/* use 32-bit DMA for descriptors */
-		pci_set_consistent_dma_mask(pdev, DMA_BIT_MASK(32));
+		dma_set_coherent_mask(&pdev->dev, DMA_BIT_MASK(32));
 		/* use 64-bit DMA, 32-bit for consistent */
-	} else if (!pci_set_dma_mask(pdev, DMA_BIT_MASK(32))) {
+	} else if (!dma_set_mask(&pdev->dev, DMA_BIT_MASK(32))) {
 		xocl_info(&pdev->dev, "Could not set 64-bit DMA mask.\n");
-		pci_set_consistent_dma_mask(pdev, DMA_BIT_MASK(32));
+		dma_set_coherent_mask(&pdev->dev, DMA_BIT_MASK(32));
 		/* use 32-bit DMA */
 		xocl_info(&pdev->dev, "Using a 32-bit DMA mask.\n");
 	} else {


### PR DESCRIPTION
I split my PR #6908 into three which was already partly reviewed. This is part 3/3.