### PR TITLE
Generate PDB files in release mode on Windows

### DIFF
--- a/src/CMake/nativeWin.cmake
+++ b/src/CMake/nativeWin.cmake
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2019-2022 Xilinx, Inc. All rights reserved.
+# Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
 #
 # This cmake file is for native build. Host and target processor are the same.
 # Custom variables imported by this CMake stub which should be defined by parent CMake:
@@ -10,6 +11,9 @@
 
 # install under c:/xrt
 set (CMAKE_INSTALL_PREFIX "${PROJECT_BINARY_DIR}/xilinx")
+
+# pdb install dir
+set (CMAKE_PDB_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/symbols")
 
 # --- Git ---
 find_package(Git)
@@ -48,6 +52,10 @@ add_compile_definitions("_SILENCE_CXX17_ALLOCATOR_VOID_DEPRECATION_WARNING")
 
 if (MSVC)
   add_compile_options(/Zc:__cplusplus)
+  # generate pdb files even in release mode
+  add_compile_options(/Zi)
+  # instruct linker to create debugging info
+  add_link_options(/DEBUG)
 endif()
 
 INCLUDE (FindGTest)


### PR DESCRIPTION
Enable generation of PDB file in release mode and consolidate all PDB
files into single PDB_OUTPUT_DIRECTORY for easier distribution.

TBD if PDB files are to be released to field and if so, how.
