### PR TITLE
CR-1139753 fix compile time warnings in xgq driver

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
@@ -2249,8 +2249,8 @@ static ssize_t clk_scaling_configure_store(struct device *dev,
 	uint8_t enable = 0;
 	uint16_t pwr = 0;
 	uint8_t temp = 0;
-	char* args = buf;
-	char* end = buf;
+	char* args = (char*) buf;
+	char* end = (char*) buf;
 	int ret = 0;
 
 	if (!cs_payload->has_clk_scaling)


### PR DESCRIPTION
Signed-off-by: Rajkumar Rampelli <rampelli@amd.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Fixed compile time warnings in xgq driver
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1139753
#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit
NA
#### What has been tested and how, request additional testing if necessary
make
#### Documentation impact (if any)
NA