### PR TITLE
Mmap size update sw emu

### DIFF
--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.h
@@ -46,8 +46,8 @@
 namespace xclcpuemhal2
 {
   using key_type = xrt_core::query::key_type;
-  //8GB MEMSIZE to access the MMAP FILE
-  const uint64_t MEMSIZE = 0x0000000200000000;
+  //16GB MEMSIZE to access the MMAP FILE
+  const uint64_t MEMSIZE = 0x0000000400000000;
   const auto endOfSimulationString = "received request to end simulation from connected initiator";
 
   // XDMA Shim

--- a/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.cxx
@@ -232,10 +232,6 @@ namespace xclhwemhal2 {
 
   void HwEmShim::dumpDeadlockMessages()
   {
-
-    if (!xrt_core::config::get_pl_deadlock_detection())
-      return;
-    
     std::string simPath = getSimPath();
     std::string content = loadFileContentsToString(simPath + "/kernel_deadlock_diagnosis.rpt");
 
@@ -246,14 +242,20 @@ namespace xclhwemhal2 {
         logMessage(content);
         parsedMsgs.push_back(content);
       }
+    }
 
-      char path[FILENAME_MAX];
-      size_t size = MAXPATHLEN;
-      char *pPath = GetCurrentDir(path, size);
+    if (!xrt_core::config::get_pl_deadlock_detection())
+      return;
 
-      if (pPath)
+    char path[FILENAME_MAX];
+    size_t size = MAXPATHLEN;
+    char *pPath = GetCurrentDir(path, size);
+
+    if (pPath)
+    {
+      std::string deadlockReportFile = simPath + "/kernel_deadlock_diagnosis.rpt";
+      if (boost::filesystem::exists(deadlockReportFile))
       {
-        std::string deadlockReportFile = simPath + "/kernel_deadlock_diagnosis.rpt";
         std::string destPath = std::string(path) + "/pl_deadlock_diagnosis.txt";
         systemUtil::makeSystemCall(deadlockReportFile, systemUtil::systemOperation::COPY, destPath, std::to_string(__LINE__));
       }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
To have backward compatibility enabled to support up to 16GB even with mmap

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
hybrid_sw_emu PR introduced this issue.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Just correction in mmap file reading whose size is 16GB 

#### Risks (if any) associated the changes in the commit
No

#### What has been tested and how, request additional testing if necessary
Ran the sw_emu canary tests

#### Documentation impact (if any)
No
