### PR TITLE
CR-1106081 updated the mmap file size from 8GB to 16GB.

### DIFF
--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.h
@@ -47,7 +47,7 @@ namespace xclcpuemhal2
 {
   using key_type = xrt_core::query::key_type;
   //8GB MEMSIZE to access the MMAP FILE
-  const uint64_t MEMSIZE = 0x0000000200000000;
+  const uint64_t MEMSIZE = 0x0000000400000000;
   const auto endOfSimulationString = "received request to end simulation from connected initiator";
 
   // XDMA Shim


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Able to run sw_emu designs with DDR limit of 16GB

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
hybrid_sw_emu PR introduced this issue. Manual verification of the design whose data size more 8GB found this issue

#### How problem was solved, alternative solutions (if any) and why they were rejected
Updated the size from 8GB to 16GB to enable the support.

#### Risks (if any) associated the changes in the commit
No

#### What has been tested and how, request additional testing if necessary
Ran the canary for sw_emu

#### Documentation impact (if any)
No
