### PR TITLE
CR-1137124 Info message when using circ buffers for aie trace

### DIFF
--- a/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.cpp
+++ b/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.cpp
@@ -460,6 +460,8 @@ void AIETraceOffload::checkCircularBufferSupport()
         << " Requested : " << circ_buf_cur_rate_plio ;
     xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", msg.str());
   }
+
+  xrt_core::message::send(xrt_core::message::severity_level::info, "XRT", AIE_TRACE_CIRC_BUF_EN);
 }
 
 void AIETraceOffload::startOffload()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
info message when using circular buffer for aie trace
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit
low
#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
