### PR TITLE
Fix for CR-1136504: xbmgmt dump does not work for vck5000 qdma

### DIFF
--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdDump.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdDump.cpp
@@ -154,7 +154,7 @@ SubCmdDump::execute(const SubCmdOptions& _options) const
   std::shared_ptr<xrt_core::device> device;
 
   try {
-    device = XBU::get_device(device_str, true /*inUserDomain*/);
+    device = XBU::get_device(device_str, false /*inUserDomain*/);
   } catch (const std::runtime_error& e) {
     // Catch only the exceptions that we have generated earlier
     std::cerr << boost::format("ERROR: %s\n") % e.what();


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Fixed  xbmgmt dump issue.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
xbmgmt dump is taking userpf as input instead of taking mgmtpf.
#### How problem was solved, alternative solutions (if any) and why they were rejected
Provided mgmtpf as input to the dump.
#### Risks (if any) associated the changes in the commit
Low
#### What has been tested and how, request additional testing if necessary
Tested bugcase locally, testcase is passing with this fix.
#### Documentation impact (if any)
N/A