### PR TITLE
CR-1140025 warn if writing more than 10mb aie trace data

### DIFF
--- a/src/runtime_src/xdp/profile/writer/aie_trace/aie_trace_writer.h
+++ b/src/runtime_src/xdp/profile/writer/aie_trace/aie_trace_writer.h
@@ -30,6 +30,8 @@ namespace xdp {
   private:
     AIETraceWriter() = delete ;
 
+    static bool largeDataWarning;
+
 #if 0
     // Header information 
     std::string xrtVersion;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
application seems to hang if amount of trace is large
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
NA
#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
tested on txchain
#### Documentation impact (if any)
