### PR TITLE
CR1140018 : Correctly list all graph names in warning message for use of incorrect name in AIE_trace_settings.graph_based_aie_tile_metrics

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -1576,7 +1576,7 @@ bool AieTracePlugin::configureStartIteration(xaiefal::XAieMod& core)
         std::string msg = "Could not find graph named " + graphmetrics[i][0] + ", as specified in graph_based_aie_tile_metrics configuration."
                           + " Following graphs are present in the design : " + graphs[0] ;
         for (size_t j = 1; j < graphs.size(); j++) {
-          msg += ", " + graphs[i];
+          msg += ", " + graphs[j];
         }
         msg += ".";
         xrt_core::message::send(severity_level::warning, "XRT", msg);


### PR DESCRIPTION
#### Problem solved by the commit
When an incorrect graph name is specified in "AIE_trace_settings.graph_based_aie_tile_metrics", XRT gives a warning to help user.
The issue is that the warning message incorrectly repeats a single graph name instead of listing all AIE graphs names in the design.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Internal testing

#### How problem was solved, alternative solutions (if any) and why they were rejected
Wrong index was used while iterating over entries for graph in the design. This is now fixed.

#### What has been tested and how, request additional testing if necessary
Tested with reported design