### PR TITLE
Fix driver compilation warnings for define overlap

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/zocl_bo.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_bo.c
@@ -20,12 +20,12 @@
 #include <linux/version.h>
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 18, 0))
 	#include <linux/iosys-map.h>
-	#define MAP_TYPE iosys_map
-	#define MAP_IS_NULL iosys_map_is_null
+	#define ZOCL_MAP_TYPE iosys_map
+	#define ZOCL_MAP_IS_NULL iosys_map_is_null
 #elif (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 11, 0))
 	#include <linux/dma-buf-map.h>
-	#define MAP_TYPE dma_buf_map
-	#define MAP_IS_NULL dma_buf_map_is_null
+	#define ZOCL_MAP_TYPE dma_buf_map
+	#define ZOCL_MAP_IS_NULL dma_buf_map_is_null
 #endif
 #include <asm/io.h>
 #include "xrt_drv.h"
@@ -883,7 +883,7 @@ static int zocl_bo_rdwr_ioctl(struct drm_device *dev, void *data,
 	char __user *user_data = to_user_ptr(args->data_ptr);
 	struct drm_zocl_bo *bo;
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 11, 0))
-	struct MAP_TYPE map;
+	struct ZOCL_MAP_TYPE map;
 #endif
 	int ret = 0;
 	char *kaddr;
@@ -912,7 +912,7 @@ static int zocl_bo_rdwr_ioctl(struct drm_device *dev, void *data,
 	if (bo->flags & ZOCL_BO_FLAGS_CMA) {
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 12, 0)
 		ret = drm_gem_cma_vmap(gem_obj, &map);
-		if(ret || MAP_IS_NULL(&map))
+		if(ret || ZOCL_MAP_IS_NULL(&map))
 			kaddr = NULL;
 		else
 			kaddr = map.is_iomem ? map.vaddr_iomem : map.vaddr;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
@@ -1274,17 +1274,17 @@ void xocl_gem_prime_vunmap(struct drm_gem_object *obj, void *vaddr)
 
 }
 #else
-int xocl_gem_prime_vmap(struct drm_gem_object *obj, struct MAP_TYPE *map)
+int xocl_gem_prime_vmap(struct drm_gem_object *obj, struct XOCL_MAP_TYPE *map)
 {
         struct drm_xocl_bo *xobj = to_xocl_bo(obj);
 
         BO_ENTER("xobj %p", xobj);
-        MAP_SET_VADDR(map, xobj->vmapping);
+        XOCL_MAP_SET_VADDR(map, xobj->vmapping);
 
         return 0;
 }
 
-void xocl_gem_prime_vunmap(struct drm_gem_object *obj, struct MAP_TYPE *map)
+void xocl_gem_prime_vunmap(struct drm_gem_object *obj, struct XOCL_MAP_TYPE *map)
 {
 
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.h
@@ -71,13 +71,13 @@
 
 // Linux 5.18 uses iosys-map instead of dma-buf-map
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 18, 0)
-	#define MAP_TYPE iosys_map
-	#define MAP_SET_VADDR iosys_map_set_vaddr
-	#define MAP_IS_NULL iosys_map_is_null
+	#define XOCL_MAP_TYPE iosys_map
+	#define XOCL_MAP_SET_VADDRVADDR iosys_map_set_vaddr
+	#define XOCL_MAP_IS_NULL iosys_map_is_null
 #else
-	#define MAP_TYPE dma_buf_map
-	#define MAP_SET_VADDR dma_buf_map_set_vaddr
-	#define MAP_IS_NULL dma_buf_map_is_null
+	#define XOCL_MAP_TYPE dma_buf_map
+	#define XOCL_MAP_SET_VADDR dma_buf_map_set_vaddr
+	#define XOCL_MAP_IS_NULL dma_buf_map_is_null
 #endif
 
 static inline bool xocl_bo_userptr(const struct drm_xocl_bo *bo)
@@ -210,8 +210,8 @@ struct drm_gem_object *xocl_gem_prime_import_sg_table(struct drm_device *dev,
 void *xocl_gem_prime_vmap(struct drm_gem_object *obj);
 void xocl_gem_prime_vunmap(struct drm_gem_object *obj, void *vaddr);
 #else
-int xocl_gem_prime_vmap(struct drm_gem_object *obj, struct MAP_TYPE *map);
-void xocl_gem_prime_vunmap(struct drm_gem_object *obj, struct MAP_TYPE *map);
+int xocl_gem_prime_vmap(struct drm_gem_object *obj, struct XOCL_MAP_TYPE *map);
+void xocl_gem_prime_vunmap(struct drm_gem_object *obj, struct XOCL_MAP_TYPE *map);
 #endif
 
 int xocl_gem_prime_mmap(struct drm_gem_object *obj, struct vm_area_struct *vma);


### PR DESCRIPTION
Signed-off-by: Daniel Benusovich <dbenusov@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Some new defines were recently added that cause a series of warnings.
Example:
```
In file included from /proj/xsjhdstaff6/dbenusov/XRT/src/runtime_src/core/pcie/driver/linux/xocl/userpf/../subdev/../userpf/common.h:20,
                 from /proj/xsjhdstaff6/dbenusov/XRT/src/runtime_src/core/pcie/driver/linux/xocl/userpf/../subdev/m2m.c:21:
/proj/xsjhdstaff6/dbenusov/XRT/src/runtime_src/core/pcie/driver/linux/xocl/userpf/../subdev/../userpf/xocl_bo.h:78: warning: "MAP_TYPE" redefined
   78 |  #define MAP_TYPE dma_buf_map
      |
In file included from ./include/uapi/asm-generic/mman.h:5,
                 from ./arch/x86/include/uapi/asm/mman.h:29,
                 from ./include/uapi/linux/mman.h:5,
                 from ./include/linux/mman.h:9,
                 from ./include/drm/drmP.h:60,
                 from /proj/xsjhdstaff6/dbenusov/XRT/src/runtime_src/core/pcie/driver/linux/xocl/userpf/../subdev/../xocl_drv.h:36,
                 from /proj/xsjhdstaff6/dbenusov/XRT/src/runtime_src/core/pcie/driver/linux/xocl/userpf/../subdev/m2m.c:20:
./include/uapi/asm-generic/mman-common.h:19: note: this is the location of the previous definition
   19 | #define MAP_TYPE 0x0f  /* Mask for type of mapping */
```
For each reference made to the define the warnings repeats.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Introduced in https://github.com/Xilinx/XRT/pull/6985

#### How problem was solved, alternative solutions (if any) and why they were rejected
Replaced `MAP_TYPE` with `XOCL_MAP_TYPE` or `ZOCL_MAP_TYPE` depending on file location.

#### Risks (if any) associated the changes in the commit
Hopefully we are not depending on the define being overwritten! If so I'll close the PR.

#### What has been tested and how, request additional testing if necessary
I built the drivers locally on my machine.

#### Documentation impact (if any)
None
