### PR TITLE
Updated skd.service to automatically restart on failure

### DIFF
--- a/src/runtime_src/tools/scripts/apu_recipes/skd.service
+++ b/src/runtime_src/tools/scripts/apu_recipes/skd.service
@@ -1,14 +1,13 @@
 [Unit]
 Description=Soft Kernel Daemon
-After=apu-boot
+After=apu-boot.service
 
 [Service]
-StartLimitIntervalSec=0
-Restart=always
-RestartSec=1
+Type=forking
+Restart=on-failure
+RestartSec=1s
 User=softkernel
 ExecStart=/usr/bin/skd
-RemainAfterExit=on
 StandardOutput=journal+console
  
 [Install]


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Keep skd running if it had issues on startup or the process was killed

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Observed some cases where skd was not started after petalinux boot

#### How problem was solved, alternative solutions (if any) and why they were rejected
Updated skd.service to restart 1 second after failure or exit

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
vck5000 / v70

#### Documentation impact (if any)
None
