### PR TITLE
Update skd.service to automatically restart on failure

### DIFF
--- a/src/runtime_src/core/edge/skd/main.cpp
+++ b/src/runtime_src/core/edge/skd/main.cpp
@@ -70,6 +70,12 @@ int main(int argc, char *argv[])
 
   handle = initXRTHandle(0);
   if (!handle) {
+    syslog(LOG_INFO, "Fail to init XRT first time\n");
+  }
+  // Retry XRT init after delay
+  sleep(1);
+  handle = initXRTHandle(0);
+  if (!handle) {
     syslog(LOG_INFO, "Fail to init XRT\n");
     closelog();
     exit(EXIT_FAILURE);

--- a/src/runtime_src/tools/scripts/apu_recipes/skd.service
+++ b/src/runtime_src/tools/scripts/apu_recipes/skd.service
@@ -1,14 +1,13 @@
 [Unit]
 Description=Soft Kernel Daemon
-After=apu-boot
+After=apu-boot.service
 
 [Service]
-StartLimitIntervalSec=0
-Restart=always
-RestartSec=1
+Type=forking
+Restart=on-failure
+RestartSec=1s
 User=softkernel
 ExecStart=/usr/bin/skd
-RemainAfterExit=on
 StandardOutput=journal+console
  
 [Install]

--- a/src/runtime_src/tools/scripts/apu_recipes/skd.service
+++ b/src/runtime_src/tools/scripts/apu_recipes/skd.service
@@ -4,8 +4,6 @@ After=apu-boot.service
 
 [Service]
 Type=forking
-Restart=on-failure
-RestartSec=1s
 User=softkernel
 ExecStart=/usr/bin/skd
 StandardOutput=journal+console


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
skd not running after petalinux boot in some cases.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Noticed sometimes skd do not start after petalinux boot

#### How problem was solved, alternative solutions (if any) and why they were rejected
Updated skd.service to restart skd on exit

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
vck5000 / v70

#### Documentation impact (if any)
None