### PR TITLE
Generating sdk.sh (sysroot) and keeping it in apu_package

### DIFF
--- a/build/build_edge.sh
+++ b/build/build_edge.sh
@@ -241,7 +241,7 @@ XRT_REPO_DIR=`readlink -f ${THIS_SCRIPT_DIR}/..`
 clean=0
 full=0
 archiver=0
-gen_sysroot=0
+gen_sysroot=1
 SSTATE_CACHE=""
 SETTINGS_FILE="petalinux.build"
 while [ $# -gt 0 ]; do

--- a/build/petalinux.build
+++ b/build/petalinux.build
@@ -1,3 +1,3 @@
 # When updating Petalinux build please file a SH ticket to retain the build
 # https://jira.xilinx.com/secure/CreateIssue!default.jspa
-PETALINUX="/proj/petalinux/2022.2/petalinux-v2022.2_08051432/tool/petalinux-v2022.2-final"
+PETALINUX="/proj/petalinux/2022.2/petalinux-v2022.2_09072250/tool/petalinux-v2022.2-final"

--- a/src/runtime_src/tools/scripts/pkgapu.sh
+++ b/src/runtime_src/tools/scripts/pkgapu.sh
@@ -163,7 +163,7 @@ BUILD_DIR="$OUTPUT_DIR/apu_build"
 PACKAGE_DIR="$BUILD_DIR"
 FW_FILE="$BUILD_DIR/lib/firmware/xilinx/xrt-versal-apu.xsabin"
 INSTALL_ROOT="$BUILD_DIR/lib"
-SDK="$BUILD_DIR/lib/sysroot/sdk.sh"
+SDK="$BUILD_DIR/lib/firmware/xilinx/sysroot/sdk.sh"
 
 if [[ $clean == 1 ]]; then
 	echo $PWD

--- a/src/runtime_src/tools/scripts/pkgapu.sh
+++ b/src/runtime_src/tools/scripts/pkgapu.sh
@@ -163,6 +163,7 @@ BUILD_DIR="$OUTPUT_DIR/apu_build"
 PACKAGE_DIR="$BUILD_DIR"
 FW_FILE="$BUILD_DIR/lib/firmware/xilinx/xrt-versal-apu.xsabin"
 INSTALL_ROOT="$BUILD_DIR/lib"
+SDK="$BUILD_DIR/lib/sysroot/sdk.sh"
 
 if [[ $clean == 1 ]]; then
 	echo $PWD
@@ -291,6 +292,12 @@ if [[ ! -e $FW_FILE ]]; then
 	error "failed to generate XSABIN"
 fi
 
+#copy the sysroot sdk.sh
+mkdir -p `dirname $SDK`
+if [ -e $IMAGES_DIR/sdk.sh ]; then
+        echo "sdk.sh exists copy it to apu package"
+        cp $IMAGES_DIR/sdk.sh $SDK
+fi
 # Generate PS Kernel xclbin
 # Hardcoding the ps kernel xclbin name to ps_kernels.xclbin
 # We can create one xclbin per PS Kernel also based on future requirements


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Generating sdk.sh (sysroot) and keeping it in apu package so that application can use this to compile PS apps/PS Kernels

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
NA

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added sdk.sh in apu package

#### Risks (if any) associated the changes in the commit
**APU package size is increased by 534 MB**

#### What has been tested and how, request additional testing if necessary
VCK5000

#### Documentation impact (if any)
NA