### PR TITLE
xbflash2 output msg when not proceeding

### DIFF
--- a/src/runtime_src/core/tools/xbflash2/OO_Program_Spi.cpp
+++ b/src/runtime_src/core/tools/xbflash2/OO_Program_Spi.cpp
@@ -58,7 +58,7 @@ spiCommand(po::variables_map& vm) {
     if (vm.count("revert-to-golden")) { //spi - reset/revert-to-golden
         std::cout << "About to revert to golden image for device " << bdf << std::endl;
         if (!force && !XBU::can_proceed())
-            return;
+            throw std::errc::operation_canceled;
 
         pcidev::pci_device dev(bdf, bar, baroff);
         XSPI_Flasher xspi(&dev, dualflash);
@@ -75,7 +75,7 @@ spiCommand(po::variables_map& vm) {
 
         std::cout << "Preparing to program flash on device: " << bdf << std::endl;
         if (!force && !XBU::can_proceed())
-            return;
+            throw std::errc::operation_canceled;
 
         pcidev::pci_device dev(bdf, bar, baroff);
         XSPI_Flasher xspi(&dev, dualflash);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
If a user chooses not to proceed, the "Cold reboot machine to load new image on device." message does not appear now.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1131263