### PR TITLE
adding -s flag to query test support

### DIFF
--- a/tests/python/22_verify/22_verify.py
+++ b/tests/python/22_verify/22_verify.py
@@ -71,7 +71,8 @@ def runKernel(opt):
 
 def main(args):
     opt = Options()
-    Options.getOptions(opt, args)
+    b_file = "verify.xclbin"
+    Options.getOptions(opt, args, b_file)
 
     try:
         runKernel(opt)

--- a/tests/python/23_bandwidth/23_bandwidth.py
+++ b/tests/python/23_bandwidth/23_bandwidth.py
@@ -130,7 +130,8 @@ def runKernel(opt):
 
 def main(args):
     opt = Options()
-    Options.getOptions(opt, args)
+    b_file = "bandwidth.xclbin"
+    Options.getOptions(opt, args, b_file)
 
     try:
         runKernel(opt)

--- a/tests/python/23_bandwidth/host_mem_23_bandwidth.py
+++ b/tests/python/23_bandwidth/host_mem_23_bandwidth.py
@@ -158,7 +158,8 @@ def runKernel(opt):
 
 def main(args):
     opt = Options()
-    Options.getOptions(opt, args)
+    b_file = "hostmemory.xclbin"
+    Options.getOptions(opt, args, b_file)
 
     try:
         initXRT(opt)

--- a/tests/python/23_bandwidth/versal_23_bandwidth.py
+++ b/tests/python/23_bandwidth/versal_23_bandwidth.py
@@ -168,7 +168,8 @@ def runKernel(opt):
 
 def main(args):
     opt = Options()
-    Options.getOptions(opt, args)
+    b_file = "bandwidth.xclbin"
+    Options.getOptions(opt, args, b_file)
 
     try:
         initXRT(opt)

--- a/tests/python/utils_binding.py
+++ b/tests/python/utils_binding.py
@@ -35,6 +35,7 @@ class Options(object):
         self.option_index = 0
         self.index = None
         self.cu_index = 0
+        self.s_flag = False
         self.verbose = False
         self.handle = None
         self.xcl_handle = None
@@ -43,10 +44,10 @@ class Options(object):
         self.xuuid = uuid.uuid4()
         self.kernels = []
 
-    def getOptions(self, argv):
+    def getOptions(self, argv, b_file):
         try:
-            opts, args = getopt.getopt(argv[1:], "k:l:a:c:d:vhe", ["bitstream=", "hal_logfile=", "alignment=",
-                                                                   "cu_index=", "device=", "verbose", "help", "ert"])
+            opts, args = getopt.getopt(argv[1:], "k:l:a:c:d:svhe", ["bitstream=", "hal_logfile=", "alignment=",
+                                                                   "cu_index=", "device=", "supported", "verbose", "help", "ert"])
         except getopt.GetoptError:
             print(self.printHelp())
             sys.exit(2)
@@ -60,6 +61,8 @@ class Options(object):
                 print("-a/--alignment switch is not supported")
             elif o in ("--cu_index", "-c"):
                 self.cu_index = int(arg)
+            elif o in ("--supported", "-s"):
+                self.s_flag = True
             elif o in ("--device", "-d"):
                 self.index = arg
             elif o in ("--help", "-h"):
@@ -79,11 +82,24 @@ class Options(object):
         print("Host buffer alignment " + str(self.alignment) + " bytes")
         print("Compiled kernel = " + self.bitstreamFile)
 
+        if(os.path.isfile(self.bitstreamFile)):
+            tempfile = self.bitstreamFile
+        else:
+            tempfile = os.path.join(self.bitstreamFile, b_file)
+        if self.s_flag:
+            if os.path.isfile(tempfile):
+                print("TEST SUPPORTED")
+                sys.exit()
+            else :
+                print("TEST NOT SUPPORTED")
+                sys.exit(1)
+
     def printHelp(self):
         print("usage: %s [options] -k <bitstream>")
         print("  -k <bitstream>")
         print("  -d <device_index>")
         print("  -c <cu_index>")
+        print("  -s <test_support>")
         print("  -v")
         print("  -h")
         print("")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Added the "-s" flag to query test support and now it supports following executables:
22_verify.py
23_bandwidth.py
versal_23_bandwidth.py
host_mem_23_bandwidth.py
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1134431