### PR TITLE
CR-1140334 simplify warnings for reuse buffer

### DIFF
--- a/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.cpp
+++ b/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.cpp
@@ -445,19 +445,17 @@ void AIETraceOffload::checkCircularBufferSupport()
   }
 
   // Warn if circular buffer settings not adequate
-  if (offloadIntervalUs)
-    circ_buf_cur_rate_plio = bufAllocSz * (1e6 / offloadIntervalUs);
-  else
-    circ_buf_cur_rate_plio = circ_buf_min_rate_plio;
-
   bool buffer_not_large_enough = (bufAllocSz < AIE_MIN_SIZE_CIRCULAR_BUF);
-  bool offload_not_fast_enough = (circ_buf_cur_rate_plio < circ_buf_min_rate_plio);
+  bool offload_not_fast_enough = (offloadIntervalUs > AIE_TRACE_REUSE_MAX_OFFLOAD_INT_US);
+  bool too_many_streams = (numStream > AIE_TRACE_REUSE_MAX_STREAMS);
 
-  if (buffer_not_large_enough || offload_not_fast_enough) {
+  if (buffer_not_large_enough || offload_not_fast_enough || too_many_streams) {
     std::stringstream msg;
     msg << AIE_TRACE_BUF_REUSE_WARN
-        << " Recommended offload rate (trace buffer bytes/sec) : " << circ_buf_min_rate_plio
-        << " Requested : " << circ_buf_cur_rate_plio ;
+        << "Requested Settings: "
+        << "buffer_size/stream : " << bufAllocSz << ", "
+        << "buffer_offload_interval_us : " << offloadIntervalUs << ", "
+        << "trace streams : " << numStream;
     xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", msg.str());
   }
 }

--- a/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.h
+++ b/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.h
@@ -165,10 +165,6 @@ private:
     //Circular Buffer Tracking
     bool mEnCircularBuf;
     bool mCircularBufOverwrite;
-    // 1000 mb of trace per second
-    // Very high bandwidth requirement
-    uint64_t circ_buf_min_rate_plio = AIE_CIR_BUF_MIN_RATE_PLIO;
-    uint64_t circ_buf_cur_rate_plio;
 
 private:
     bool setupPSKernel();

--- a/src/runtime_src/xdp/profile/device/tracedefs.h
+++ b/src/runtime_src/xdp/profile/device/tracedefs.h
@@ -76,18 +76,22 @@ buffer size and/or reduce trace_buffer_offload_interval."
 #define TS2MM_WARN_MSG_QUEUE_SZ        "Too much trace in processing queue. This could have negative impact on host memory utilization. \
 Please increase trace_buffer_size and trace_buffer_offload_interval together or use 'coarse' option for device_trace."
 
-// Throw warning if less than 8M is used or rate is less than 8 GB/S
+// Throw warning if following thresholds aren't met for reuse_buffer
 #define AIE_MIN_SIZE_CIRCULAR_BUF 0x800000
-#define AIE_CIR_BUF_MIN_RATE_PLIO 0x200000000
+#define AIE_TRACE_REUSE_MAX_STREAMS 4
+#define AIE_TRACE_REUSE_MAX_OFFLOAD_INT_US 100
 
 #define AIE_TRACE_UNAVAILABLE "Neither PLIO nor GMIO trace infrastucture is found in the given design. So, AIE event trace will not be available."
 #define AIE_TRACE_BUF_ALLOC_FAIL              "Allocation of buffer for AIE trace failed. AIE trace will not be available."
 #define AIE_TS2MM_WARN_MSG_BUF_FULL           "AIE Trace Buffer is full. Device trace could be incomplete."
 #define AIE_TS2MM_WARN_MSG_CIRC_BUF_OVERWRITE "Circular buffer overwrite was detected in device trace. AIE trace could be incomplete."
-#define AIE_TRACE_BUF_REUSE_WARN              "AIE trace reuse setting may lead to buffer overrun. Please increase \
-aie_trace_buffer_size and/or reduce aie_trace_buffer_offload_interval_us. Recommended (min) trace buffer size per stream : \
-functions : 8M functions_partial_stalls : 16M functions_all_stalls 32M. For large AIE designs, use granular \
-trace settings."
+
+#define AIE_TRACE_BUF_REUSE_WARN              "AIE reuse_buffer may cause overrun. \
+Recommended settings: \
+buffer_size/stream: functions >= 8M functions_partial_stalls >= 16M functions_all_stalls >= 32M, \
+trace streams <= 4, buffer_offload_interval_us <= 100. \
+For large tile count, use granular trace. "
+
 #define AIE_TRACE_WARN_REUSE_PERIODIC  "AIE Trace Buffer reuse only supported with periodic offload."
 #define AIE_TRACE_WARN_REUSE_GMIO      "AIE Trace buffer reuse is not supported on GMIO trace."
 #define AIE_TRACE_PERIODIC_OFFLOAD_UNSUPPORTED "Continuous offload of AIE Trace is not supported for GMIO mode. So, AIE Trace for GMIO mode will be offloaded only at the end of application."


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Simplified the warnings for reuse buffer and clearly list settings
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
tested on tx chain
#### Documentation impact (if any)
