### PR TITLE
CR-1137584 [vck5000_qdma_base_1] system panic by xbmgmt program -b

### DIFF
--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -676,11 +676,13 @@ switch_partition(xrt_core::device* device, int boot)
   std::cout << boost::format("Rebooting device: [%s] with '%s' partition")
                 % bdf % (boot ? "backup" : "default") << std::endl;
   try {
+    // sets sysfs node boot_from_back [1:backup, 0:default], then hot reset
     auto value = xrt_core::query::flush_default_only::value_type(boot);
     xrt_core::device_update<xrt_core::query::boot_partition>(device, value);
+
     std::cout << "Performing hot reset..." << std::endl;
-    auto hot_reset = XBU::str_to_reset_obj("hot");
-    device->reset(hot_reset);
+    device->device_shutdown();
+    device->device_online();
     std::cout << "Rebooted successfully" << std::endl;
   }
   catch (const xrt_core::query::exception& ex) {


### PR DESCRIPTION
system panic by xbmgmt program -b backup

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
the xbmgmt program --boot backup will only reset xclmgmt but not xocl, this can create system panic
the xbmgmt program has existing API to gracefully reset both xocl and xclmgmt, this will resolve this panice

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1137584

#### How problem was solved, alternative solutions (if any) and why they were rejected
using right way to reset XRT driver

#### Risks (if any) associated the changes in the commit
N/A this is versal only and tested on versal

#### What has been tested and how, request additional testing if necessary
xbmgmt program --boot backup
xbmgmt program --boot default

#### Documentation impact (if any)
N/A