### PR TITLE
CR-1140339 Running test "sysc_pkt_process_v2" on X3 hybrid board got "[XRT] ERROR: xclRegRW: read range is set, not allow write"

### DIFF
--- a/src/runtime_src/core/common/drv/cu_hls.c
+++ b/src/runtime_src/core/common/drv/cu_hls.c
@@ -513,6 +513,7 @@ int xrt_cu_hls_init(struct xrt_cu *xcu)
 	xcu->busy_threshold = -1;
 	xcu->interval_min = 2;
 	xcu->interval_max = 5;
+	mutex_init(&xcu->read_regs.xcr_lock);
 
 	/* No control and interrupt registers in ap_ctrl_none protocol.
 	 * In this case, return here for creating CU sub-dev. No need to setup

--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -1312,7 +1312,7 @@ int kds_map_cu_addr(struct kds_sched *kds, struct kds_client *client,
 	}
 
 	mutex_lock(&cu_mgmt->lock);
-	if (cu_mgmt->xcus[idx]->read_regs.xcr_start != -1) {
+	if (cu_mgmt->xcus[idx]->read_regs.xcr_start) {
 		goto get_cu_addr;
 	}
 

--- a/src/runtime_src/core/common/drv/xrt_cu.c
+++ b/src/runtime_src/core/common/drv/xrt_cu.c
@@ -908,10 +908,7 @@ int xrt_cu_init(struct xrt_cu *xcu)
 	INIT_LIST_HEAD(&xcu->events);
 	sema_init(&xcu->sem, 0);
 	sema_init(&xcu->sem_cu, 0);
-	mutex_init(&xcu->read_regs.xcr_lock);
 	spin_lock_init(&xcu->stats.xcs_lock);
-	xcu->read_regs.xcr_start = -1;
-	xcu->read_regs.xcr_end = -1;
 
 	INIT_LIST_HEAD(&xcu->hpq);
 	spin_lock_init(&xcu->hpq_lock);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/cu_xgq.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/cu_xgq.c
@@ -156,6 +156,7 @@ int xrt_cu_xgq_init(struct xrt_cu *xcu, int slow_path)
 	xcu->busy_threshold = 2;
 	xcu->interval_min = 2;
 	xcu->interval_max = 5;
+	mutex_init(&xcu->read_regs.xcr_lock);
 
 	xcu->status = 0x4;
 	err = xrt_cu_init(xcu);

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -2044,7 +2044,7 @@ int shim::xclRegRW(bool rd, uint32_t ipIndex, uint32_t offset, uint32_t *datap)
     return -EINVAL;
   }
 
-  if (cumap.start != 0xFFFFFFFF) {
+  if (cumap.start) {
     if (!rd) {
         xrt_logmsg(XRT_ERROR, "%s: read range is set, not allow write", __func__);
         return -EINVAL;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
CR-1140339

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
#6741 introduce this issue.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Initial CU read register range as 0xFFFFFFF for AP_CTRL_NONE CUs.

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
The test case in the CR.

#### Documentation impact (if any)
No