### PR TITLE
Support hw_queue command submission

### DIFF
--- a/src/runtime_src/core/common/api/hw_queue.cpp
+++ b/src/runtime_src/core/common/api/hw_queue.cpp
@@ -62,25 +62,36 @@ notify_host(xrt_core::command* cmd)
   notify_host(cmd, get_command_state(cmd));
 }
 
-
-// class kds_device - kds book keeping data for command scheduling
+// class command_manager - managed command executuon
 //
-// @device: The core device used for shim level calls
-// @exec_wait_mutex: Synchronize acces to exec_wait
+// @m_qimpl: The hw queue used for command submission
 // @work_mutex: Syncrhonize monitor thread with launched commands
 // @work_cond: Kick off monitor thread when there are new commands
 // @monitor_thread: Thread for asynchronous monitoring of command execution
-// @exec_wait_call_count:  Count of number of calls to exec wait
 // @stop: Stop the monitor thread
 //
-// This class is per xrt_core::device. The class constructor starts a
-// command monitor thread that manages command execution.  It also
-// provides a thread safe interface to shim level exec_wait which can
-// be called explicitly to wait for command completion.
-class kds_device
+// This is constructed on demand when commands are submitted for managed
+// execution through a command queue.  Managed execution means that
+// commands are submitted for execution and receive a callback on
+// completion.  This is the OpenCL model but is also supported by
+// native XRT APIs.
+//
+// The command manager requires submission and wait APIs to be implemented
+// by which ever object (hw queue) uses the manager.
+class command_manager
 {
-  xrt_core::device* device;
-  std::mutex exec_wait_mutex;
+public:
+  struct executor
+  {
+    virtual std::cv_status
+    wait(size_t timeout_ms) = 0;
+
+    virtual void
+    submit(xrt_core::command* cmd) = 0;
+  };
+
+private:
+  executor* m_impl;
   std::mutex work_mutex;
   std::condition_variable work_cond;
   command_queue_type submitted_cmds;
@@ -116,7 +127,7 @@ class kds_device
         return;
 
       // Finer wait
-      exec_wait();
+      m_impl->wait(0);
 
       // Drain submitted commands.  It is important that this comes
       // after exec_wait and is synchronized with launch() that added
@@ -172,20 +183,169 @@ class kds_device
     }
   }
 
-
 public:
   // Constructor starts monitor thread
-  kds_device(xrt_core::device* dev)
-      : device(dev), monitor_thread(xrt_core::thread(&kds_device::monitor, this))
+  command_manager(executor* impl)
+    : m_impl(impl), monitor_thread(xrt_core::thread(&command_manager::monitor, this))
   {}
 
   // Destructor stops and joins monitor thread
-  ~kds_device()
+  ~command_manager()
   {
     stop = true;
     work_cond.notify_one();
     monitor_thread.join();
   }
+
+  // launch() - Submit a command for managed execution
+  //
+  // This function is used to schedule managed commands for
+  // execution. Managed means that the command will be monitored for
+  // completion and notified upon completion.  Notification is through
+  // command callback.
+  void
+  launch(xrt_core::command* cmd)
+  {
+    XRT_DEBUGF("xrt_core::kds::command(%d) [new->submitted->running]\n", cmd->get_uid());
+
+    // Store command so completion can be tracked.  Make sure this is
+    // done prior to exec_buf as exec_wait can otherwise be missed.
+    // See detailed explanation in monitor loop.
+    {
+      std::lock_guard<std::mutex> lk(work_mutex);
+      submitted_cmds.push_back(cmd);
+    }
+
+    // Submit the command
+    try {
+      m_impl->submit(cmd);
+    }
+    catch (...) {
+      // Remove the pending command
+      std::lock_guard<std::mutex> lk(work_mutex);
+      assert(get_command_state(cmd)==ERT_CMD_STATE_NEW);
+      if (!submitted_cmds.empty())
+        submitted_cmds.pop_back();
+      throw;
+    }
+
+    // This is somewhat expensive, it is better to have this after the
+    // exec_buf call so that actual execution doesn't have to wait.
+    work_cond.notify_one();
+  }
+};
+
+} // namespace
+
+namespace xrt_core {
+
+// class hw_queue_impl - base implementation class
+//
+// Implements the interface required for both managed
+// and unmanaged execution.
+class hw_queue_impl : public command_manager::executor
+{
+  std::unique_ptr<command_manager> m_cmd_manager;
+protected:
+
+public:
+  hw_queue_impl()
+  {}
+
+  virtual
+  ~hw_queue_impl()
+  {}
+
+  // Submit command for execution
+  virtual void
+  submit(xrt_core::command* cmd) = 0;
+
+  // Wait for some command to finish
+  virtual std::cv_status
+  wait(size_t timeout_ms) = 0;
+
+  // Wait for specified command to finish
+  virtual std::cv_status
+  wait(const xrt_core::command* cmd, size_t timeout_ms) = 0;
+
+  // Managed start uses command manager for monitoring command
+  // completion
+  void
+  managed_start(xrt_core::command* cmd)
+  {
+    if (!m_cmd_manager)
+      m_cmd_manager = std::make_unique<command_manager>(this);
+
+    m_cmd_manager->launch(cmd);
+  }
+
+  // Unmanaged start submits command directly for execution
+  // Command completion must be explicitly managed by application
+  void
+  unmanaged_start(xrt_core::command* cmd)
+  {
+    submit(cmd);
+  }
+};
+
+// class qds_device - queue implementation for shim queue support
+class qds_device : public hw_queue_impl
+{
+  xrt_core::device* m_device;
+  xcl_hwqueue_handle m_qhdl;
+
+public:
+  qds_device(xrt_core::device* device, xcl_hwqueue_handle qhdl)
+    : m_device(device), m_qhdl(qhdl)
+  {}
+
+  ~qds_device()
+  {
+    m_device->destroy_hw_queue(m_qhdl);
+  }
+
+  std::cv_status
+  wait(size_t timeout_ms) override
+  {
+    return m_device->wait_command(m_qhdl, XRT_NULL_BO, static_cast<int>(timeout_ms))
+      ? std::cv_status::no_timeout
+      : std::cv_status::timeout;
+  }
+
+  std::cv_status
+  wait(const xrt_core::command* cmd, size_t timeout_ms) override
+  {
+    auto pkt = cmd->get_ert_packet();
+    while (pkt->state < ERT_CMD_STATE_COMPLETED) {
+      // return immediately on timeout
+      if (m_device->wait_command(m_qhdl, cmd->get_exec_bo(), static_cast<int>(timeout_ms)) == 0)
+        return std::cv_status::timeout;
+    }
+
+    // notify_host is not strictly necessary for unmanaged
+    // command execution but provides a central place to update
+    // and mark commands as done so they can be re-executed.
+    notify_host(const_cast<xrt_core::command*>(cmd), static_cast<ert_cmd_state>(pkt->state));
+
+    return std::cv_status::no_timeout;
+  }
+
+  void
+  submit(xrt_core::command* cmd) override
+  {
+    m_device->submit_command(m_qhdl, cmd->get_exec_bo());
+  }
+};
+
+// class kds_device - queue implementation for legacy shim support
+//
+// @exec_wait_mutex: Synchronize access to exec_wait
+// @exec_wait_call_count:  Count of number of calls to exec wait
+class kds_device : public hw_queue_impl
+{
+  xrt_core::device* m_device;
+  std::mutex m_exec_wait_mutex;
+  uint64_t m_exec_wait_call_count = 0;
 
   // Thread safe shim level exec wait call.   This function allows
   // multiple threads to call exec_wait through same device handle.
@@ -210,13 +370,13 @@ public:
   exec_wait(size_t timeout_ms=0)
   {
     static thread_local uint64_t thread_exec_wait_call_count = 0;
-    std::lock_guard<std::mutex> lk(exec_wait_mutex);
+    std::lock_guard lk(m_exec_wait_mutex);
 
-    if (thread_exec_wait_call_count != exec_wait_call_count) {
+    if (thread_exec_wait_call_count != m_exec_wait_call_count) {
       // some other thread has called exec_wait and may have
       // covered this thread's commands, synchronize thread
       // local call count and return to caller.
-      thread_exec_wait_call_count = exec_wait_call_count;
+      thread_exec_wait_call_count = m_exec_wait_call_count;
       return std::cv_status::no_timeout;
     }
 
@@ -225,26 +385,33 @@ public:
       // device exec_wait is a system poll which returns
       // 0 when specified timeout is exceeded without any
       // file descriptors to read
-      if (device->exec_wait(static_cast<int>(timeout_ms)) == 0)
+      if (m_device->exec_wait(static_cast<int>(timeout_ms)) == 0)
         status = std::cv_status::timeout;
     }
     else {
       // wait for ever for some command to complete
-      while (device->exec_wait(1000) == 0) {}
+      while (m_device->exec_wait(1000) == 0) {}
     }
 
     // synchronize this thread with total call count
-    thread_exec_wait_call_count = ++exec_wait_call_count;
+    thread_exec_wait_call_count = ++m_exec_wait_call_count;
 
     return status;
   }
 
-  // exec_wait() - Wait for specific command completion with optional timeout
-  //
-  // Wait for command completion
-  // This function is safe to call for managed and unmanaged commands.
+public:
+  kds_device(xrt_core::device* device)
+    : m_device(device)
+  {}
+
   std::cv_status
-  exec_wait(const xrt_core::command* cmd, size_t timeout_ms=0)
+  wait(size_t timeout_ms) override
+  {
+    return exec_wait(timeout_ms);
+  }
+
+  std::cv_status
+  wait(const xrt_core::command* cmd, size_t timeout_ms) override
   {
     auto pkt = cmd->get_ert_packet();
     while (pkt->state < ERT_CMD_STATE_COMPLETED) {
@@ -261,165 +428,65 @@ public:
     return std::cv_status::no_timeout;
   }
 
-  // exec_buf() - Submit a command for execution
-  //
-  // This function is used to schedule unmanaged commands for
-  // execution. The execution monitor is by-passed and will be unaware
-  // of argument command having been scheduled for execution.
   void
-  exec_buf(xrt_core::command* cmd)
+  submit(xrt_core::command* cmd) override
   {
-    device->exec_buf(cmd->get_exec_bo());
-  }
-
-  // launch() - Submit a command for managed execution
-  //
-  // This function is used to schedule managed commands for
-  // execution. Managed means that the command will be monitored for
-  // completion and notified upon completion.  Notification is through
-  // command callback.
-  void
-  launch(xrt_core::command* cmd)
-  {
-    XRT_DEBUGF("xrt_core::kds::command(%d) [new->submitted->running]\n", cmd->get_uid());
-
-    // Store command so completion can be tracked.  Make sure this is
-    // done prior to exec_buf as exec_wait can otherwise be missed.
-    // See detailed explanation in monitor loop.
-    {
-      std::lock_guard<std::mutex> lk(work_mutex);
-      submitted_cmds.push_back(cmd);
-    }
-
-    // Submit the command
-    try {
-      exec_buf(cmd);
-    }
-    catch (...) {
-      // Remove the pending command
-      std::lock_guard<std::mutex> lk(work_mutex);
-      assert(get_command_state(cmd)==ERT_CMD_STATE_NEW);
-      if (!submitted_cmds.empty())
-        submitted_cmds.pop_back();
-      throw;
-    }
-
-    // This is somewhat expensive, it is better to have this after the
-    // exec_buf call so that actual execution doesn't have to wait.
-    work_cond.notify_one();
-  }
-}; // kds_device
-
-// Statically allocated kds_device object for each core device
-static std::map<const xrt_core::device*, std::unique_ptr<kds_device>> kds_devices;
-
-// Get or create kds_device object from core device
-static kds_device*
-get_kds_device(xrt_core::device* device)
-{
-  static std::mutex mutex;
-  std::lock_guard lk(mutex);
-
-  auto itr = kds_devices.find(device);
-  if (itr != kds_devices.end())
-    return (*itr).second.get();
-
-  auto iitr = kds_devices.insert(std::make_pair(device, std::make_unique<kds_device>(device)));
-  return (iitr.first)->second.get();
-}
-
-} // namespace
-
-namespace xrt_core {
-
-// class hw_queue_impl - implementation of hardware queue
-//
-// This class provides a command submission API on top of
-// xrt_core::device::ishim APIs. It leverage the KDS execbuf
-// and execwait protocol through kds_device.
-class hw_queue_impl
-{
-  xrt::hw_context m_hwctx;
-  device* m_core_device;
-  xcl_hwqueue_handle m_hdl;
-
-  // This is logically const
-  mutable kds_device* m_kds_device;
-
-public:
-  // Construct from hardware context
-  hw_queue_impl(xrt::hw_context hwctx)
-    : m_hwctx(std::move(hwctx))
-    , m_core_device(hw_context_int::get_core_device_raw(m_hwctx))
-    , m_hdl(m_core_device->create_hw_queue(m_hwctx))
-    , m_kds_device(get_kds_device(m_core_device))
-  {}
-
-  // This constructor is for legacy command execution where there
-  // is no associated hw context.
-  hw_queue_impl(xrt_core::device* device)
-    : m_core_device(device)
-    , m_hdl(XRT_NULL_HWQUEUE)
-    , m_kds_device(get_kds_device(m_core_device))
-  {}
-
-  ~hw_queue_impl()
-  {
-    m_core_device->destroy_hw_queue(m_hdl);
-  }
-
-  // Managed start uses execution monitor for command completion
-  void
-  managed_start(xrt_core::command* cmd)
-  {
-    m_kds_device->launch(cmd);
-  }
-
-  // Unmanaged start submits command directly for execution
-  // Command completion must be explicitly managed by application
-  void
-  unmanaged_start(xrt_core::command* cmd)
-  {
-    m_kds_device->exec_buf(cmd);
-  }
-
-  // Wait for command completion. Supports both managed and
-  // unmanaged commands
-  void
-  wait(const xrt_core::command* cmd) const
-  {
-    m_kds_device->exec_wait(cmd);
-  }
-
-  // Wait for command completion with timeout. Supports both managed
-  // and unmanaged commands
-  std::cv_status
-  wait(const xrt_core::command* cmd, const std::chrono::milliseconds& timeout_ms) const
-  {
-    return m_kds_device->exec_wait(cmd, timeout_ms.count());
+    m_device->exec_buf(cmd->get_exec_bo());
   }
 };
 
+}  // xrt_core
+
+namespace {
+
+// Manage hw_queue implementations.
 // For time being there is only one hw_queue per hw_context
 // Use static map with weak pointers to implementation.
-// Ensure unique queue per device since driver doesn't currently
-// guarantee unique hwctx handle cross devices
-static std::shared_ptr<hw_queue_impl>
-get_hw_queue_impl(const xrt::hw_context& hwctx)
+using hwc2hwq_type = std::map<xcl_hwctx_handle, std::weak_ptr<xrt_core::hw_queue_impl>>;
+static std::mutex mutex;
+static std::map<const xrt_core::device*, hwc2hwq_type> dev2hwc;  // per device
+
+// Create a hw_queue implementation assosicated with a device without
+// any hw context.  This is used for legacy construction for internal
+// support of command execution that is not tied to kernel execution,
+// .e.g for copy_bo_with_kdma.
+static std::shared_ptr<xrt_core::hw_queue_impl>
+get_hw_queue_impl(const xrt_core::device* device)
 {
-  using hwc2hwq_type = std::map<xcl_hwctx_handle, std::weak_ptr<hw_queue_impl>>;
-  static std::mutex mutex;
-  static std::map<device*, hwc2hwq_type> dev2hwc;  // per device
-  auto device = xrt_core::hw_context_int::get_core_device_raw(hwctx);
-  auto xhdl = static_cast<xcl_hwctx_handle>(hwctx);
   std::lock_guard lk(mutex);
   auto& queues = dev2hwc[device];
-  auto hwqimpl = queues[xhdl].lock();
+  auto hwqimpl = queues[XRT_NULL_HWCTX].lock();
   if (!hwqimpl)
-    queues[xhdl] = hwqimpl = std::shared_ptr<hw_queue_impl>(new hw_queue_impl(hwctx));
+    queues[XRT_NULL_HWCTX] = hwqimpl =
+      std::shared_ptr<xrt_core::hw_queue_impl>(new xrt_core::kds_device(const_cast<xrt_core::device*>(device)));
 
   return hwqimpl;
 }
+
+// Create a hw_queue implementation for a hw context.
+// Ensure unique queue per device since driver doesn't currently
+// guarantee unique hwctx handle cross devices
+static std::shared_ptr<xrt_core::hw_queue_impl>
+get_hw_queue_impl(const xrt::hw_context& hwctx)
+{
+  auto device = xrt_core::hw_context_int::get_core_device_raw(hwctx);
+  auto hwctx_hdl = static_cast<xcl_hwctx_handle>(hwctx);
+  std::lock_guard lk(mutex);
+  auto& queues = dev2hwc[device];
+  auto hwqimpl = queues[hwctx_hdl].lock();
+  if (!hwqimpl) {
+    auto hwqueue_hdl = device->create_hw_queue(hwctx);
+    queues[hwctx_hdl] = hwqimpl = (hwqueue_hdl == XRT_NULL_HWQUEUE)
+      ? std::shared_ptr<xrt_core::hw_queue_impl>(new xrt_core::kds_device(device))
+      : std::shared_ptr<xrt_core::hw_queue_impl>(new xrt_core::qds_device(device, hwqueue_hdl));
+  }
+
+  return hwqimpl;
+}
+
+}
+
+namespace xrt_core {
 
 ////////////////////////////////////////////////////////////////
 // Public APIs
@@ -431,7 +498,7 @@ hw_queue(const xrt::hw_context& hwctx)
 
 hw_queue::
 hw_queue(const xrt_core::device* device)
-  : xrt::detail::pimpl<hw_queue_impl>(std::make_shared<hw_queue_impl>(const_cast<xrt_core::device*>(device)))
+  : xrt::detail::pimpl<hw_queue_impl>(get_hw_queue_impl(device))
 {}
 
 void
@@ -453,7 +520,7 @@ void
 hw_queue::
 wait(const xrt_core::command* cmd) const
 {
-  get_handle()->wait(cmd);
+  get_handle()->wait(cmd, 0);
 }
 
 // Wait for command completion for unmanaged command execution with timeout
@@ -461,7 +528,7 @@ std::cv_status
 hw_queue::
 wait(const xrt_core::command* cmd, const std::chrono::milliseconds& timeout_ms) const
 {
-  return get_handle()->wait(cmd, timeout_ms);
+  return get_handle()->wait(cmd, timeout_ms.count());
 }
 
 std::cv_status
@@ -469,17 +536,16 @@ hw_queue::
 exec_wait(const xrt_core::device* device, const std::chrono::milliseconds& timeout_ms)
 {
   // bypass hwqueue and call exec wait directly
-  auto kds_device = get_kds_device(const_cast<xrt_core::device*>(device));
+  auto impl = get_hw_queue_impl(device);
 
   // add dummy hwqueue null arg when changing shim
-  return kds_device->exec_wait(timeout_ms.count());
+  return impl->wait(timeout_ms.count());
 }
 
 void
 hw_queue::
 stop()
 {
-  kds_devices.clear();
 }
 
 } // namespace xrt_core

--- a/src/runtime_src/core/common/ishim.h
+++ b/src/runtime_src/core/common/ishim.h
@@ -170,6 +170,19 @@ struct ishim
   destroy_hw_queue(xcl_hwqueue_handle) const
   {}
 
+  // Submits command for execution through hw queue
+  virtual void
+  submit_command(xcl_hwqueue_handle, xclBufferHandle /*cmdbo*/)
+  { throw not_supported_error{__func__}; }
+
+  // Wait for command completion through hw queue
+  // Returns 0 on timeout else a value that indicates specified
+  // cmdbo completed.  If cmdbo is XRT_NULL_BO then function must
+  // returns when some previously submitted command completes.
+  virtual int
+  wait_command(xcl_hwqueue_handle, xclBufferHandle /*cmdbo*/, int /*timeout_ms*/)
+  { throw not_supported_error{__func__}; }
+
   // Registers an xclbin, but does not load it.
   virtual void
   register_xclbin(const xrt::xclbin&) const

--- a/src/runtime_src/core/include/xcl_hwctx.h
+++ b/src/runtime_src/core/include/xcl_hwctx.h
@@ -24,6 +24,7 @@ extern "C" {
 // The context handle is among other things used with / encoded in
 // buffer object flags.
 typedef uint32_t xcl_hwctx_handle;
+#define XRT_NULL_HWCTX 0xffffffff
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Add shim APIs for command submission and wait.
Refactor hw_queue implementation to support both platforms with hw_queue support and platforms (legacy) without.

