### PR TITLE
Enabling clang-tidy for Edge compilation on x86

### DIFF
--- a/src/CMake/embedded_system.cmake
+++ b/src/CMake/embedded_system.cmake
@@ -100,6 +100,9 @@ include (CMake/ccache.cmake)
 message("-- ${CMAKE_SYSTEM_INFO_FILE} (${LINUX_FLAVOR}) (Kernel ${LINUX_KERNEL_VERSION})")
 message("-- Compiler: ${CMAKE_CXX_COMPILER} ${CMAKE_C_COMPILER}")
 
+# --- Lint ---
+include (CMake/lint.cmake)
+
 add_subdirectory(runtime_src)
 
 message("-- XRT version: ${XRT_VERSION_STRING}")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
clang-tidy was not enabled when building for edge on x86

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Ran build.sh -edge -clangtidy

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added lint.cmake to embedded_system.cmake

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
edge build with clangtidy

#### Documentation impact (if any)
None
