### PR TITLE
CR-1128510

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
@@ -124,6 +124,9 @@ namespace xdp {
   {
     uint64_t deviceId = db->addDevice(sysfsPath) ;
 
+    if (!device_trace)
+        return;
+    
     // When adding a device, also add a writer to dump the information
     std::string version = "1.1" ;
     std::string creationTime = xdp::getCurrentDateTime() ;
@@ -139,7 +142,7 @@ namespace xdp {
                                              creationTime,
                                              xrtVersion,
                                              toolVersion);
-    writers.push_back(writer) ;
+    writers.push_back(writer);
     (db->getStaticInfo()).addOpenedFile(writer->getcurrentFileName(), "VP_TRACE") ;
 
     if (continuous_trace)


### PR DESCRIPTION
Signed-off-by: Nishant Mysore <nishraptor@gmail.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
- Device trace csv's now only created when device_trace=true

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
- Device trace csv's were being generated with just the device_counters and opencl_trace settings.

#### How problem was solved, alternative solutions (if any) and why they were rejected
- Only create csv's if device_trace=true

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
- Tested on kernel vadd example on U200 board.
#### Documentation impact (if any)
