### PR TITLE
CR-1140644 missing xgq_vmr_log_dump_debug for some failure scenarios

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
@@ -615,6 +615,7 @@ static void xgq_complete_cb(void *arg, struct xgq_com_queue_entry *ccmd)
 {
 	struct xocl_xgq_vmr_cmd *xgq_cmd = (struct xocl_xgq_vmr_cmd *)arg;
 	struct xgq_cmd_cq *cmd_cq = (struct xgq_cmd_cq *)ccmd;
+	struct xocl_xgq_vmr *xgq_vmr = xgq_cmd->xgq_vmr;
 
 	xgq_cmd->xgq_cmd_rcode = (int)ccmd->rcode;
 	/* preserve payload prior to free xgq_cmd_cq */
@@ -622,6 +623,9 @@ static void xgq_complete_cb(void *arg, struct xgq_com_queue_entry *ccmd)
 		sizeof(cmd_cq->cq_default_payload));
 
 	complete(&xgq_cmd->xgq_cmd_complete);
+
+	if (xgq_cmd->xgq_cmd_rcode)
+		xgq_vmr_log_dump_debug(xgq_vmr, xgq_cmd);
 }
 
 static size_t inline vmr_shared_mem_size(struct xocl_xgq_vmr *xgq)
@@ -838,7 +842,6 @@ static ssize_t xgq_transfer_data(struct xocl_xgq_vmr *xgq, const void *buf,
 
 	/* If return is 0, we set length as return value */
 	if (cmd->xgq_cmd_rcode) {
-		xgq_vmr_log_dump_debug(xgq, cmd);
 		ret = cmd->xgq_cmd_rcode;
 	} else {
 		ret = len;


### PR DESCRIPTION
Signed-off-by: David Zhang <davidzha@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
The current xgq only dump VMR logs for xclbin and pdi download failures. but missing for any other VMR return code.
The contract between host and VMR is that any non-zero return code is an error, so we should dump the debug logs whenever we get non-zero return code.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1140644

#### How problem was solved, alternative solutions (if any) and why they were rejected
dump the log when see rcode != 0

#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
tested on v70 vmr

#### Documentation impact (if any)
N/A