### PR TITLE
Fix for CR-1139265: xbmgmt incorrect BDF causes seg fault

### DIFF
--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -118,7 +118,7 @@ struct bdf
   static result_type
   get(const xrt_core::device* device, key_type)
   {
-    auto pdev = get_pcidev(device);    
+    auto pdev = get_pcidev(device);
     return std::make_tuple(pdev->domain, pdev->bus, pdev->dev, pdev->func);
   }
 };

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -116,6 +116,8 @@ struct bdf
   get(const xrt_core::device* device, key_type)
   {
     auto pdev = get_pcidev(device);
+    if (!pdev)
+      throw xrt_core::error("Invalid device handle");
     return std::make_tuple(pdev->domain, pdev->bus, pdev->dev, pdev->func);
   }
 };

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -63,7 +63,10 @@ get_render_value(const std::string& dir)
 inline pdev
 get_pcidev(const xrt_core::device* device)
 {
-  return pcidev::get_dev(device->get_device_id(), device->is_userpf());
+  auto pdev = pcidev::get_dev(device->get_device_id(), device->is_userpf());
+  if (!pdev)
+    throw xrt_core::error("Invalid device handle");
+  return pdev;
 }
 
 static std::vector<uint64_t>
@@ -115,9 +118,7 @@ struct bdf
   static result_type
   get(const xrt_core::device* device, key_type)
   {
-    auto pdev = get_pcidev(device);
-    if (!pdev)
-      throw xrt_core::error("Invalid device handle");
+    auto pdev = get_pcidev(device);    
     return std::make_tuple(pdev->domain, pdev->bus, pdev->dev, pdev->func);
   }
 };


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Fix for CR-1139265: XRT - Running 'xbmgmt examine' with incorrect BDF causes seg fault
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1139265
#### How problem was solved, alternative solutions (if any) and why they were rejected
added null check for get() in bdf struct
#### Risks (if any) associated the changes in the commit
Low
#### What has been tested and how, request additional testing if necessary
Ran bugcase locally with this change, testcase passed.
#### Documentation impact (if any)
