### PR TITLE
CR-1121339: Addressed hw_emu hand issue when xsim is exited

### DIFF
--- a/src/runtime_src/core/include/xcl_api_macros.h
+++ b/src/runtime_src/core/include/xcl_api_macros.h
@@ -33,6 +33,7 @@ std::lock_guard<std::mutex> socketlk{mtx};
 #define SERIALIZE_AND_SEND_MSG(func_name)                               \
     auto c_len = c_msg.ByteSize();                                      \
     buf_size = alloc_void(c_len);                                       \
+    auto socket_call_status = -1;                                       \
     bool rv = c_msg.SerializeToArray(buf,c_len);                        \
     if (rv == false) { std::cerr << "FATAL ERROR:protobuf SerializeToArray failed for alloc_void call." << std::endl; exit(1);} \
                                                                         \
@@ -45,12 +46,12 @@ std::lock_guard<std::mutex> socketlk{mtx};
     _s_inst->sk_write(ci_buf,ci_len);                                   \
     _s_inst->sk_write(buf,c_len);                                       \
                                                                         \
-    _s_inst->sk_read(ri_buf,ri_msg.ByteSize());                         \
-    rv = ri_msg.ParseFromArray(ri_buf,ri_msg.ByteSize());               \
+    socket_call_status = _s_inst->sk_read(ri_buf,ri_msg.ByteSize());    \
+    if (socket_call_status != -1) { rv = ri_msg.ParseFromArray(ri_buf,ri_msg.ByteSize()); }              \
     if (true != rv) { if (mLogStream.is_open()) mLogStream << __func__ << "\n ParseFromArray failed, sk_read/sk_write failed, so exit the application now!"; exit(0);  } \
     buf_size = alloc_void(ri_msg.size());                               \
-    _s_inst->sk_read(buf,ri_msg.size());                                \
-    rv = r_msg.ParseFromArray(buf,ri_msg.size());                       \
+    socket_call_status = _s_inst->sk_read(buf,ri_msg.size());           \
+    if (socket_call_status != -1) { rv = r_msg.ParseFromArray(buf,ri_msg.size()); } \
     if (true != rv) { if (mLogStream.is_open()) mLogStream << __func__ << "\n ParseFromArray failed, sk_read failed for alloc_void, so exit- the application now!!!"; exit(0); }
 #else
 // More recent protoc handles 64 bit size objects and the 32 bit version is deprecated

--- a/src/runtime_src/core/pcie/emulation/common_em/config.h
+++ b/src/runtime_src/core/pcie/emulation/common_em/config.h
@@ -30,8 +30,8 @@
 #include <tuple>
 #include <vector>
 
-#define DEBUG_MSG_COUT(x) 
-//#define DEBUG_MSG_COUT(x) std::cout<<std::endl<<__TIME__<<"::"<<__func__<<"::"<<__LINE__<<"::"<<x<<std::endl
+#define DEBUG_MSGS_COUT(x) 
+//#define DEBUG_MSGS_COUT(x) std::cout<<std::endl<<"\t"<<__func__<<"\t"<<std::dec<<__LINE__<<"\t"<<x<<".\t"<<std::endl
 
 namespace xclemulation{
   

--- a/src/runtime_src/core/pcie/emulation/common_em/config.h
+++ b/src/runtime_src/core/pcie/emulation/common_em/config.h
@@ -30,8 +30,8 @@
 #include <tuple>
 #include <vector>
 
-#define DEBUG_MSGS_COUT(x) 
-//#define DEBUG_MSGS_COUT(x) std::cout<<std::endl<<__func__<<__LINE__<<x<<std::endl;
+//#define DEBUG_MSG_COUT(x) 
+#define DEBUG_MSG_COUT(x) std::cout<<std::endl<<__TIME__<<"::"<<__func__<<"::"<<__LINE__<<"::"<<x<<std::endl
 
 namespace xclemulation{
   

--- a/src/runtime_src/core/pcie/emulation/common_em/config.h
+++ b/src/runtime_src/core/pcie/emulation/common_em/config.h
@@ -30,8 +30,8 @@
 #include <tuple>
 #include <vector>
 
-//#define DEBUG_MSG_COUT(x) 
-#define DEBUG_MSG_COUT(x) std::cout<<std::endl<<__TIME__<<"::"<<__func__<<"::"<<__LINE__<<"::"<<x<<std::endl
+#define DEBUG_MSG_COUT(x) 
+//#define DEBUG_MSG_COUT(x) std::cout<<std::endl<<__TIME__<<"::"<<__func__<<"::"<<__LINE__<<"::"<<x<<std::endl
 
 namespace xclemulation{
   

--- a/src/runtime_src/core/pcie/emulation/common_em/unix_socket.cxx
+++ b/src/runtime_src/core/pcie/emulation/common_em/unix_socket.cxx
@@ -274,7 +274,7 @@ void unix_socket::monitor_socket_thread() {
     auto retval = poll(&mpoll_on_filedescriptor, 1, 500); // Let's do polling on it for utmost 500 ms
     if (retval < 0)
     {
-      DEBUG_MSGS_COUT("poll is failed");
+      DEBUG_MSG_COUT("poll is failed");
       continue;
     }
     if (retval == 0)
@@ -283,7 +283,7 @@ void unix_socket::monitor_socket_thread() {
     // The same logic can be implemented by looking at ~POLLIN or POLLRDHUP & POLLERR & POLLHUP
     if (mpoll_on_filedescriptor.revents & POLLHUP)
     {
-      DEBUG_MSGS_COUT("Client socket state has changed & it is not readable anymore! So application will exit now.");
+      DEBUG_MSG_COUT("Client socket state has changed & it is not readable anymore! So application will exit now.");
       m_is_socket_live.store(false);
       server_started.store(false); // Let's other monitoring threads exit
       break;
@@ -291,7 +291,7 @@ void unix_socket::monitor_socket_thread() {
 
     if (mpoll_on_filedescriptor.revents & POLLERR)
     {
-      DEBUG_MSGS_COUT("Hurrah! client connection is lost.");
+      DEBUG_MSG_COUT("Hurrah! client connection is lost.");
       m_is_socket_live.store(false);
       server_started.store(false);
       break;

--- a/src/runtime_src/core/pcie/emulation/common_em/unix_socket.cxx
+++ b/src/runtime_src/core/pcie/emulation/common_em/unix_socket.cxx
@@ -274,7 +274,7 @@ void unix_socket::monitor_socket_thread() {
     auto retval = poll(&mpoll_on_filedescriptor, 1, 500); // Let's do polling on it for utmost 500 ms
     if (retval < 0)
     {
-      DEBUG_MSG_COUT("poll is failed");
+      DEBUG_MSGS_COUT("poll is failed");
       continue;
     }
     if (retval == 0)
@@ -283,7 +283,7 @@ void unix_socket::monitor_socket_thread() {
     // The same logic can be implemented by looking at ~POLLIN or POLLRDHUP & POLLERR & POLLHUP
     if (mpoll_on_filedescriptor.revents & POLLHUP)
     {
-      DEBUG_MSG_COUT("Client socket state has changed & it is not readable anymore! So application will exit now.");
+      DEBUG_MSGS_COUT("Client socket state has changed & it is not readable anymore! So application will exit now.");
       m_is_socket_live.store(false);
       server_started.store(false); // Let's other monitoring threads exit
       break;
@@ -291,7 +291,7 @@ void unix_socket::monitor_socket_thread() {
 
     if (mpoll_on_filedescriptor.revents & POLLERR)
     {
-      DEBUG_MSG_COUT("Hurrah! client connection is lost.");
+      DEBUG_MSGS_COUT("Hurrah! client connection is lost.");
       m_is_socket_live.store(false);
       server_started.store(false);
       break;

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
@@ -808,6 +808,7 @@ namespace xclcpuemhal2
         aiesim_sock = nullptr;
       else
         aiesim_sock = new unix_socket("AIESIM_SOCKETID");
+        
     }
 
     return 0;
@@ -1338,7 +1339,8 @@ namespace xclcpuemhal2
         ++count;
         // giving some time for the simulator to run
         if (count % 5 == 0)
-          std::this_thread::sleep_for(std::chrono::seconds(std::min(10 * (count / 5), 300)));
+          std::this_thread::sleep_for(std::chrono::seconds(5));
+          //std::this_thread::sleep_for(std::chrono::seconds(std::min(10 * (count / 5), 300)));
 
       }
     }

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
@@ -1310,14 +1310,17 @@ namespace xclcpuemhal2
 
   void CpuemShim::closeMessengerThread()
   {
+    mIsDeviceProcessStarted = false;
     if (mMessengerThread.joinable())
       mMessengerThread.join();
   }
 
   void CpuemShim::messagesThread()
   {
+    DEBUG_MSG_COUT("start");
     auto start_time = std::chrono::high_resolution_clock::now();
     auto lpath = getDeviceProcessLogPath();
+    DEBUG_MSG_COUT("The file path is::"<<lpath);
     sParseLog deviceProcessLog(this, lpath);
     int count = 0;
     while (mIsDeviceProcessStarted)

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
@@ -1318,10 +1318,8 @@ namespace xclcpuemhal2
 
   void CpuemShim::messagesThread()
   {
-    DEBUG_MSG_COUT("start");
     auto start_time = std::chrono::high_resolution_clock::now();
     auto lpath = getDeviceProcessLogPath();
-    DEBUG_MSG_COUT("The file path is::"<<lpath);
     sParseLog deviceProcessLog(this, lpath);
     int count = 0;
     while (mIsDeviceProcessStarted)
@@ -1339,8 +1337,8 @@ namespace xclcpuemhal2
         ++count;
         // giving some time for the simulator to run
         if (count % 5 == 0)
-          std::this_thread::sleep_for(std::chrono::seconds(5));
-          //std::this_thread::sleep_for(std::chrono::seconds(std::min(10 * (count / 5), 300)));
+          std::this_thread::sleep_for(std::chrono::seconds(std::min(10 * (count / 5), 300)));
+          //std::this_thread::sleep_for(std::chrono::seconds(5));
 
       }
     }

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.h
@@ -569,6 +569,7 @@ namespace xclcpuemhal2
     */
     void closeApplicationOnMagicStrFound(const std::string &matchString)
     {
+      DEBUG_MSG_COUT("start");
       std::string line;
       while (std::getline(file, line))
       {
@@ -578,6 +579,7 @@ namespace xclcpuemhal2
           mCpuShimPtr->xclClose();
         }
       }
+      DEBUG_MSG_COUT("end");
     }
 
     //**********************************************************************************//
@@ -591,7 +593,7 @@ namespace xclcpuemhal2
       {
         if (boost::filesystem::exists(mFileName))
         {
-          file.open(mFileName);
+          file.open(mFileName,std::ios::in);
           if (file.is_open())
             mFileExists = true;
         }

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.h
@@ -573,8 +573,7 @@ namespace xclcpuemhal2
         if (line.find(matchString) != std::string::npos)
         {
           std::cout << "Received request to end the application. Exiting the application." << std::endl;
-          //mCpuShimPtr->xclClose();
-          exit(0);
+          mCpuShimPtr->xclClose();
         }
       }
     }

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.h
@@ -409,10 +409,8 @@ namespace xclcpuemhal2
     // aka xclOpenContextByName
     xrt_core::cuidx_type
     open_cu_context(const xrt::hw_context &hwctx, const std::string &cuname);
-
     void
     close_cu_context(const xrt::hw_context& hwctx, xrt_core::cuidx_type cuidx);
-
   private:
     std::shared_ptr<xrt_core::device> mCoreDevice;
     std::mutex mMemManagerMutex;
@@ -569,17 +567,16 @@ namespace xclcpuemhal2
     */
     void closeApplicationOnMagicStrFound(const std::string &matchString)
     {
-      DEBUG_MSG_COUT("start");
       std::string line;
       while (std::getline(file, line))
       {
         if (line.find(matchString) != std::string::npos)
         {
           std::cout << "Received request to end the application. Exiting the application." << std::endl;
-          mCpuShimPtr->xclClose();
+          //mCpuShimPtr->xclClose();
+          exit(0);
         }
       }
-      DEBUG_MSG_COUT("end");
     }
 
     //**********************************************************************************//

--- a/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.cxx
@@ -752,7 +752,7 @@ namespace xclhwemhal2 {
         {
           if (mLogStream.is_open())
           {
-            mLogStream << __func__ << " DISPLAY environment is not available so expect exit from the application " << std::endl;
+            mLogStream << __func__ << " DISPLAY environment is not available so expect an exit from the application " << std::endl;
             DEBUG_MSG_COUT(" DISPLAY environment is not available so expect exit from the application ");
           }
           exit(0);

--- a/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.cxx
@@ -1826,8 +1826,9 @@ namespace xclhwemhal2 {
       }
       return;
     }
-    // All RPC calls fail if no socket is live. so skipping of sending RPC calls if no socket connection is present.
-    if (sock->m_is_socket_live)
+    // RPC calls will not be made in resetprogram
+    // resetProgram has to be called in xclclose because all running threads will be exited gracefully 
+    // which results clean exit of driver code.  
       resetProgram(false);
 
 

--- a/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.cxx
@@ -753,7 +753,8 @@ namespace xclhwemhal2 {
           if (mLogStream.is_open())
           {
             mLogStream << __func__ << " DISPLAY environment is not available so expect an exit from the application " << std::endl;
-            DEBUG_MSG_COUT(" DISPLAY environment is not available so expect exit from the application ");
+            DEBUG_MSG_COUT(" DISPLAY environment is not available so expect an exit from the application ");
+            std::cerr << "DISPLAY environment is not available so expect an exit from the application";
           }
           exit(0);
         }

--- a/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.cxx
@@ -215,18 +215,14 @@ namespace xclhwemhal2 {
         }
         for (auto& matchString : myvector) {
           std::string::size_type index = line.find(matchString);
-          if (index == std::string::npos) {
+          if (index == std::string::npos) 
             continue;
-          }
-          else {
-            if(std::find(parsedMsgs.begin(), parsedMsgs.end(), line) != parsedMsgs.end()) {
-              continue;
-            }
-            else {
-              logMessage(line);
-              parsedMsgs.push_back(line);
-            }
-          }
+          
+          if(std::find(parsedMsgs.begin(), parsedMsgs.end(), line) != parsedMsgs.end())
+            continue;
+          
+          logMessage(line);
+          parsedMsgs.push_back(line);
         }
       }
     }
@@ -1087,7 +1083,8 @@ namespace xclhwemhal2 {
         mLogStream << __func__ << " ERROR: [HW-EMU 26] Simulator is NOT started so exiting the application! " << std::endl;
         
       // If no simulator running then no need to try a connection, hence exit with a failure now.
-      throw std::runtime_error(" Simulator did not start/exited, please refer simulate.log in .run directory!");
+      //throw std::runtime_error(" Simulator did not start/exited, please refer simulate.log in .run directory!");
+      exit(EXIT_FAILURE);
     }
     sock = std::make_shared<unix_socket>();
     set_simulator_started(true);

--- a/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.cxx
@@ -1054,9 +1054,6 @@ namespace xclhwemhal2 {
           sim_file = "simulate.sh";
           
         if (mLogStream.is_open() )
-            mLogStream << __TIME__ <<"\t"<< __func__ << " before launching xsim process sim_file::"<<sim_file  << std::endl;
-
-        if (mLogStream.is_open() )
             mLogStream << __TIME__ <<"\t"<< __func__ << " The simulate script is "  <<sim_file  << std::endl;
 
         int r = execl(sim_file.c_str(), sim_file.c_str(), simMode, NULL);
@@ -1083,7 +1080,7 @@ namespace xclhwemhal2 {
     std::this_thread::sleep_for(10s);
     if (parseLog() != 0) {
       if (mLogStream.is_open())
-        mLogStream << __func__ << " Simulator is NOT started so exiting the application! " << std::endl;
+        mLogStream << __func__ << " ERROR: [HW-EMU 26] Simulator is NOT started so exiting the application! " << std::endl;
       // If no simulator running then no need to try a connection, hence exit with a failure now.
       exit(EXIT_FAILURE);
     }

--- a/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.cxx
@@ -753,12 +753,10 @@ namespace xclhwemhal2 {
           if (mLogStream.is_open())
           {
             mLogStream << __func__ << " DISPLAY environment is not available so expect an exit from the application " << std::endl;
-
-            std::string dMsg = "ERROR: [HW-EMU 26] DISPLAY environment is not available so expect an exit from the application";
-            logMessage(dMsg, 0);
             //DEBUG_MSG_COUT(" DISPLAY environment is not available so expect an exit from the application ");
-            
           }
+          std::string dMsg = "ERROR: [HW-EMU 26] DISPLAY environment is not available so expect an exit from the application";
+          logMessage(dMsg, 0);
           exit(EXIT_FAILURE);
         }
         

--- a/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.cxx
@@ -753,10 +753,13 @@ namespace xclhwemhal2 {
           if (mLogStream.is_open())
           {
             mLogStream << __func__ << " DISPLAY environment is not available so expect an exit from the application " << std::endl;
-            DEBUG_MSG_COUT(" DISPLAY environment is not available so expect an exit from the application ");
-            std::cerr << "DISPLAY environment is not available so expect an exit from the application";
+
+            std::string dMsg = "ERROR: [HW-EMU 26] DISPLAY environment is not available so expect an exit from the application";
+            logMessage(dMsg, 0);
+            //DEBUG_MSG_COUT(" DISPLAY environment is not available so expect an exit from the application ");
+            
           }
-          exit(0);
+          exit(EXIT_FAILURE);
         }
         
       }

--- a/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.cxx
@@ -1078,19 +1078,18 @@ namespace xclhwemhal2 {
     {
       mEnvironmentNameValueMap["enable_pr"] = "false";
     }
-    //Ensuring the simulate is ready to connect
+    //Providing enough time to simulate script to set up it's environment and start xsim.
     using namespace std::chrono_literals;
     std::this_thread::sleep_for(10s);
     if (parseLog() != 0) {
       if (mLogStream.is_open())
         mLogStream << __func__ << " Simulator is NOT started so exiting the application! " << std::endl;
-
+      // If no simulator running then no need to try a connection, hence exit with a failure now.
       exit(EXIT_FAILURE);
     }
     sock = std::make_shared<unix_socket>();
     set_simulator_started(true);
     sock->monitor_socket();
-    // check for any errors if present in simulate.log, if yes then log them onto screen.
     
     //Thread to fetch messages from Device to display on host
     if (mMessengerThreadStarted == false) {
@@ -1780,6 +1779,7 @@ namespace xclhwemhal2 {
       mLogStream << __func__ << ", " << std::this_thread::get_id() << std::endl;
     }
 
+    // Ensuring parseLog call to xclClose not to call parseLog again. - no recursive call should happen.
     if (!DonotRunParseLog)
         parseLog();
 

--- a/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.cxx
@@ -213,10 +213,16 @@ namespace xclhwemhal2 {
                   parsedMsgs.push_back(line);
                   this->xclClose(true);                                               // Let's have a proper clean if xsim is NOT running
         }
-        for (auto matchString : myvector) {
+        for (auto& matchString : myvector) {
           std::string::size_type index = line.find(matchString);
-          if (index != std::string::npos) {
-            if(std::find(parsedMsgs.begin(), parsedMsgs.end(), line) == parsedMsgs.end()) {
+          if (index == std::string::npos) {
+            continue;
+          }
+          else {
+            if(std::find(parsedMsgs.begin(), parsedMsgs.end(), line) != parsedMsgs.end()) {
+              continue;
+            }
+            else {
               logMessage(line);
               parsedMsgs.push_back(line);
             }
@@ -1081,7 +1087,7 @@ namespace xclhwemhal2 {
         mLogStream << __func__ << " ERROR: [HW-EMU 26] Simulator is NOT started so exiting the application! " << std::endl;
         
       // If no simulator running then no need to try a connection, hence exit with a failure now.
-      exit(EXIT_FAILURE);
+      throw std::runtime_error(" Simulator did not start/exited, please refer simulate.log in .run directory!");
     }
     sock = std::make_shared<unix_socket>();
     set_simulator_started(true);

--- a/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.h
+++ b/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.h
@@ -190,7 +190,7 @@ using addr_type = uint64_t;
       void xclFreeDeviceBuffer(uint64_t buf,bool sendtosim);
       size_t xclCopyBufferHost2Device(uint64_t dest, const void *src, size_t size, size_t seek, uint32_t topology);
       size_t xclCopyBufferDevice2Host(void *dest, uint64_t src, size_t size, size_t skip, uint32_t topology);
-      void xclClose();
+      void xclClose(bool DonotRunParseLog = false);
       unsigned int xclProbe();
 
       //Performance Monitor APIs


### PR DESCRIPTION

Fix:  The current branch fixed the below issues.

1. CR-1135191: Calling xclClose exits the calling application, i.e. never returns to the caller
   CR-1134600: Vitis 9999.0_0701_1: Vitis simulator can't exit after xsim exit
    CR-1118351: Emulation/external_io example hangs for hw_emu when targeting PCIe platform

   Fix:  added xclClose() in ParseLog() function. Removed a recursive call back to ParseLog() from xclClose() which eliminated a segfault issue of double free of pointers.


3. CR-1132012: HW EMU failed with missing required fields error
   Fix: as part of RPC calls in xcl_api_macros.h libprotobuf is printing error messages when buf argument is empty. buf argument is empty if socket call fails. This happens in case of xsim exit. The conditional check is added.

4. CR-1121339: XSIM crashes when run in waveform mode, but X Display is not set properly
    Fix: Added DISPLAY environment variable check, Calling ParseLog() in case simulator writes any exception to the file so that it can be parsed. 

Risk: Very Low

Tests: Canary run. Results are Clean.

Reviewer: venkatp

