### PR TITLE
Add sysfs nodes for host_mem_addr and host_mem_size on zocl

### DIFF
--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -209,6 +209,7 @@ enum class key_type
   firewall_status,
   firewall_time_sec,
   power_microwatts,
+  host_mem_addr,
   host_mem_size,
   kds_numcdmas,
 
@@ -2377,6 +2378,22 @@ struct power_warning : request
   to_string(result_type value)
   {
     return value ? "true" : "false";
+  }
+};
+
+struct host_mem_addr : request
+{
+  using result_type = uint64_t;
+  static const key_type key = key_type::host_mem_addr;
+  static const char* name() { return "host_mem_addr"; }
+
+  virtual boost::any
+  get(const device*) const = 0;
+
+  static std::string
+  to_string(result_type val)
+  {
+    return std::to_string(val);
   }
 };
 

--- a/src/runtime_src/core/edge/drm/zocl/zocl_sysfs.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_sysfs.c
@@ -391,6 +391,32 @@ static ssize_t errors_show(struct device *dev,
 }
 static DEVICE_ATTR_RO(errors);
 
+static ssize_t host_mem_addr_show(struct device *dev,
+	struct device_attribute *attr, char *buf)
+{
+	struct drm_zocl_dev *zdev = dev_get_drvdata(dev);
+	uint64_t val = 0;
+
+	if (zdev->host_mem)
+		val = zdev->host_mem;
+
+	return sprintf(buf, "%lld\n", val);
+}
+static DEVICE_ATTR_RO(host_mem_addr);
+
+static ssize_t host_mem_size_show(struct device *dev,
+	struct device_attribute *attr, char *buf)
+{
+	struct drm_zocl_dev *zdev = dev_get_drvdata(dev);
+	uint64_t val = 0;
+
+	if (zdev->host_mem_len)
+		val = zdev->host_mem_len;
+
+	return sprintf(buf, "%lld\n", val);
+}
+static DEVICE_ATTR_RO(host_mem_size);
+
 static struct attribute *zocl_attrs[] = {
 	&dev_attr_xclbinid.attr,
 	&dev_attr_kds_numcus.attr,
@@ -405,6 +431,8 @@ static struct attribute *zocl_attrs[] = {
 	&dev_attr_errors.attr,
 	&dev_attr_graph_status.attr,
 	&dev_attr_dtbo_path.attr,
+	&dev_attr_host_mem_addr.attr,
+	&dev_attr_host_mem_size.attr,
 	NULL,
 };
 

--- a/src/runtime_src/core/edge/user/device_linux.cpp
+++ b/src/runtime_src/core/edge/user/device_linux.cpp
@@ -886,6 +886,8 @@ initialize_query_table()
   emplace_sysfs_get<query::memstat_raw>               ("memstat_raw");
   emplace_sysfs_get<query::error>                     ("errors");
   emplace_sysfs_get<query::xclbin_full>               ("xclbin_full");
+  emplace_sysfs_get<query::host_mem_addr>             ("host_mem_addr");
+  emplace_sysfs_get<query::host_mem_size>             ("host_mem_size");
   emplace_func0_request<query::pcie_bdf,                bdf>();
   emplace_func0_request<query::board_name,              board_name>();
   emplace_func0_request<query::is_ready,                is_ready>();


### PR DESCRIPTION
This is for usecase where we need to map the entire reserved ddr space for PS kernel.

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Enhancement

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
None

#### How problem was solved, alternative solutions (if any) and why they were rejected
NA

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Test on vck5000 platform

#### Documentation impact (if any)
