### PR TITLE
CR-1130345 versal: Display board revision and mfg date through xbutil examine…

### DIFF
--- a/src/runtime_src/core/common/info_platform.cpp
+++ b/src/runtime_src/core/common/info_platform.cpp
@@ -88,6 +88,11 @@ add_board_info(const xrt_core::device* device, ptree_type& pt)
     bd_info.add("error_msg", ex.what());
   }
 
+  if (xrt_core::device_query<xq::is_versal>(device)) {
+    bd_info.put("revision", xrt_core::device_query<xq::hwmon_sdm_revision>(device));
+    bd_info.put("mfg_date", xrt_core::device_query<xq::hwmon_sdm_mfg_date>(device));
+  }
+
   pt.put_child("off_chip_board_info", bd_info);
 }
 

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -282,6 +282,7 @@ enum class key_type
   hwmon_sdm_mac_addr1,
   hwmon_sdm_revision,
   hwmon_sdm_fan_presence,
+  hwmon_sdm_mfg_date,
   hotplug_offline,
 
   cu_size,
@@ -3068,6 +3069,15 @@ struct hwmon_sdm_fan_presence : request
 {
   using result_type = std::string;
   static const key_type key = key_type::hwmon_sdm_fan_presence;
+
+  virtual boost::any
+  get(const device*) const = 0;
+};
+
+struct hwmon_sdm_mfg_date : request
+{
+  using result_type = std::string;
+  static const key_type key = key_type::hwmon_sdm_mfg_date;
 
   virtual boost::any
   get(const device*) const = 0;

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -3074,6 +3074,7 @@ struct hwmon_sdm_fan_presence : request
   get(const device*) const = 0;
 };
 
+// Retrieve board MFG date from xocl hwmon_sdm driver
 struct hwmon_sdm_mfg_date : request
 {
   using result_type = std::string;

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -1240,6 +1240,7 @@ initialize_query_table()
   emplace_sysfs_get<query::hwmon_sdm_mac_addr1>                ("hwmon_sdm", "mac_addr1");
   emplace_sysfs_get<query::hwmon_sdm_fan_presence>             ("hwmon_sdm", "fan_presence");
   emplace_sysfs_get<query::hwmon_sdm_revision>                 ("hwmon_sdm", "revision");
+  emplace_sysfs_get<query::hwmon_sdm_mfg_date>                 ("hwmon_sdm", "mfg_date");
 
   emplace_sysfs_get<query::cu_size>                            ("", "size");
   emplace_sysfs_get<query::cu_read_range>                      ("", "read_range");

--- a/src/runtime_src/core/tools/common/ReportPlatforms.cpp
+++ b/src/runtime_src/core/tools/common/ReportPlatforms.cpp
@@ -67,6 +67,11 @@ ReportPlatforms::writeReport( const xrt_core::device* /*_pDevice*/,
     const boost::property_tree::ptree& pt_board_info = pt_platform.get_child("off_chip_board_info");
     _output << boost::format("  %-23s: %s Bytes\n") % "DDR Size" % pt_board_info.get<std::string>("ddr_size_bytes");
     _output << boost::format("  %-23s: %s \n") % "DDR Count" % pt_board_info.get<std::string>("ddr_count");
+    try {
+      _output << boost::format("  %-23s: %s \n") % "Revision" % pt_board_info.get<std::string>("revision");
+      _output << boost::format("  %-23s: %s \n") % "MFG Date" % pt_board_info.get<std::string>("mfg_date");
+    } catch(...) {
+    }
     
     const boost::property_tree::ptree& pt_status = pt_platform.get_child("status");
     _output << boost::format("  %-23s: %s \n") % "Mig Calibrated" % pt_status.get<std::string>("mig_calibrated");


### PR DESCRIPTION
… platform reports.
MFG date info is represented in "Number of minutes from 0:00 hrs 1/1/96 (Represented in GMT)".

Signed-off-by: Rajkumar Rampelli <rampelli@amd.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
xbutil examine reports doesn't display board revision & mfg date information. So, added changes in XRT to display the same.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1130345
#### How problem was solved, alternative solutions (if any) and why they were rejected
Added support in XRT tools to read & display required information.
#### Risks (if any) associated the changes in the commit
NA
#### What has been tested and how, request additional testing if necessary
Reading xbutil examine reports
#### Documentation impact (if any)
NA