### PR TITLE
Enlarge default poll value for quick CU

### DIFF
--- a/src/runtime_src/core/common/drv/include/xrt_cu.h
+++ b/src/runtime_src/core/common/drv/include/xrt_cu.h
@@ -31,13 +31,13 @@
 /* Avoid the CU soft lockup warning when CU thread keep busy.
  * Small value leads to lower performance on APU.
  */
-#define MAX_CU_LOOP 100
+#define MAX_CU_LOOP 300
 
 /* If poll count reach this threashold, switch to interrupt mode */
 #if defined(CONFIG_ARM64)
 #define CU_DEFAULT_POLL_THRESHOLD 30 /* About 60 us on APU */
 #else
-#define CU_DEFAULT_POLL_THRESHOLD 200 /* About 50 us on host */
+#define CU_DEFAULT_POLL_THRESHOLD 300 /* About 75 us on host */
 #endif
 
 /* The normal CU in ip_layout would assign a interrupt


### PR DESCRIPTION
Signed-off-by: Min Ma <min.ma@amd.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
IOPS performance drop on vck5000 since hardware interrupt issue.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Enlarge poll value to let CU thread poll longer time.

#### Risks (if any) associated the changes in the commit
No

#### What has been tested and how, request additional testing if necessary
VCK5000

#### Documentation impact (if any)
No