### PR TITLE
CR1140948 : Fix seg fault when AIE_trace_settings.tile_based_aie_tile_metrics is used 

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -1773,11 +1773,13 @@ bool AieTracePlugin::configureStartIteration(xaiefal::XAieMod& core)
     // Each of the metrics can have ; separated multiple values. Process and save all
     std::vector<std::string> metricsSettings;
     boost::replace_all(metricsConfig, " ", "");
+
     if (!metricsConfig.empty())
       boost::split(metricsSettings, metricsConfig, boost::is_any_of(";"));
 
     std::vector<std::string> graphmetricsSettings;
     boost::replace_all(graphmetricsConfig, " ", "");
+
     if (!graphmetricsConfig.empty())
       boost::split(graphmetricsSettings, graphmetricsConfig, boost::is_any_of(";"));
 

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -1773,11 +1773,13 @@ bool AieTracePlugin::configureStartIteration(xaiefal::XAieMod& core)
     // Each of the metrics can have ; separated multiple values. Process and save all
     std::vector<std::string> metricsSettings;
     boost::replace_all(metricsConfig, " ", "");
-    boost::split(metricsSettings, metricsConfig, boost::is_any_of(";"));
+    if (!metricsConfig.empty())
+      boost::split(metricsSettings, metricsConfig, boost::is_any_of(";"));
 
     std::vector<std::string> graphmetricsSettings;
     boost::replace_all(graphmetricsConfig, " ", "");
-    boost::split(graphmetricsSettings, graphmetricsConfig, boost::is_any_of(";"));
+    if (!graphmetricsConfig.empty())
+      boost::split(graphmetricsSettings, graphmetricsConfig, boost::is_any_of(";"));
 
     getConfigMetricsForTiles(metricsSettings, graphmetricsSettings, handle);
 


### PR DESCRIPTION
#### Problem solved by the commit
CR 1140948 reports a recent regression where AIE_trace_settings.tile_based_aie_tile_metrics in xrt.ini causes seg fault. This PR fixes it.

#### How problem was solved
The seg fault was due to incorrect processing when graph_based_aie_tile_metrics is not specified but tile_based ones are given. The seg fault is solved by proper size check and subsequent handling for empty graph based metrics.

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
The fix is verified with reported test.

#### Documentation impact (if any)
