### PR TITLE
Fix XOCL_MAP_SET_VADDR define in kernel 5.18+

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.h
@@ -72,7 +72,7 @@
 // Linux 5.18 uses iosys-map instead of dma-buf-map
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 18, 0)
 	#define XOCL_MAP_TYPE iosys_map
-	#define XOCL_MAP_SET_VADDRVADDR iosys_map_set_vaddr
+	#define XOCL_MAP_SET_VADDR iosys_map_set_vaddr
 	#define XOCL_MAP_IS_NULL iosys_map_is_null
 #else
 	#define XOCL_MAP_TYPE dma_buf_map


### PR DESCRIPTION
Signed-off-by: Abraham Gonzalez [abe.gonzalez@berkeley.edu](mailto:abe.gonzalez@berkeley.edu)

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#7007 added an extra `VADDR` to `XOCL_MAP_SET_VADDR` when building for kernel 5.18+. This PR removes this so that things match the pre-5.18 defines. This was discovered in building XRT for a more recent kernel.

Now the following defines match:

https://github.com/Xilinx/XRT/blob/ecd4239e6557886f2405549c0c986e64a59e0588/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.h#L73-L81

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

See description above.

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

N/A

#### What has been tested and how, request additional testing if necessary

No testing

#### Documentation impact (if any)

N/A
