### PR TITLE
Vitis-5963 xclRead and xclWrite APIs should be removed from XRT code base

### DIFF
--- a/src/runtime_src/core/common/ishim.h
+++ b/src/runtime_src/core/common/ishim.h
@@ -25,7 +25,9 @@ int xclUpdateSchedulerStat(xclDeviceHandle handle);
 int xclInternalResetDevice(xclDeviceHandle handle, xclResetKind kind);
 int xclCmaEnable(xclDeviceHandle handle, bool enable, uint64_t total_size);
 int xclCloseExportHandle(xclBufferExportHandle);
+XCL_DRIVER_DLLESPEC
 size_t xclWrite(xclDeviceHandle handle, enum xclAddressSpace space, uint64_t offset, const void *hostBuf, size_t size);
+XCL_DRIVER_DLLESPEC
 size_t xclRead(xclDeviceHandle handle, enum xclAddressSpace space, uint64_t offset, void *hostbuf, size_t size);
 
 namespace xrt_core {

--- a/src/runtime_src/core/common/ishim.h
+++ b/src/runtime_src/core/common/ishim.h
@@ -25,6 +25,8 @@ int xclUpdateSchedulerStat(xclDeviceHandle handle);
 int xclInternalResetDevice(xclDeviceHandle handle, xclResetKind kind);
 int xclCmaEnable(xclDeviceHandle handle, bool enable, uint64_t total_size);
 int xclCloseExportHandle(xclBufferExportHandle);
+size_t xclWrite(xclDeviceHandle handle, enum xclAddressSpace space, uint64_t offset, const void *hostBuf, size_t size);
+size_t xclRead(xclDeviceHandle handle, enum xclAddressSpace space, uint64_t offset, void *hostbuf, size_t size);
 
 namespace xrt_core {
 

--- a/src/runtime_src/core/include/deprecated/xrt.h
+++ b/src/runtime_src/core/include/deprecated/xrt.h
@@ -766,20 +766,6 @@ xclGetDeviceAddr(xclDeviceHandle handle, xclBufferHandle boHandle)
     return !xclGetBOProperties(handle, boHandle, &p) ? p.paddr : (uint64_t)-1;
 }
 
-/* Use xclRegWrite */
-XRT_DEPRECATED
-XCL_DRIVER_DLLESPEC
-size_t
-xclWrite(xclDeviceHandle handle, enum xclAddressSpace space, uint64_t offset,
-         const void *hostBuf, size_t size);
-
-/* Use xclRegRead */
-XRT_DEPRECATED
-XCL_DRIVER_DLLESPEC
-size_t
-xclRead(xclDeviceHandle handle, enum xclAddressSpace space, uint64_t offset,
-        void *hostbuf, size_t size);
-
 /* Not supported */
 XRT_DEPRECATED
 XCL_DRIVER_DLLESPEC

--- a/src/runtime_src/xrt/device/halops2.cpp
+++ b/src/runtime_src/xrt/device/halops2.cpp
@@ -102,8 +102,6 @@ operations(const std::string &fileName, void *fileHandle, unsigned int count)
   mMapBO    = (mapBOFuncType)xrt_core::dlsym(const_cast<void *>(mDriverHandle), "xclMapBO");
   mUnmapBO  = (unmapBOFuncType)xrt_core::dlsym(const_cast<void *>(mDriverHandle), "xclUnmapBO");
 
-  mWrite      = (writeFuncType)xrt_core::dlsym(const_cast<void *>(mDriverHandle), "xclWrite");
-  mRead       = (readFuncType)xrt_core::dlsym(const_cast<void *>(mDriverHandle), "xclRead");
   mUnmgdPread = (unmgdPreadFuncType)xrt_core::dlsym(const_cast<void *>(mDriverHandle), "xclUnmgdPread");
 
   mReClock2 = (reClock2FuncType)xrt_core::dlsym(const_cast<void *>(mDriverHandle), "xclReClock2");

--- a/src/runtime_src/xrt/device/halops2_static.cpp
+++ b/src/runtime_src/xrt/device/halops2_static.cpp
@@ -105,8 +105,6 @@ operations(const std::string &fileName, void *fileHandle, unsigned int count)
   mMapBO    = &xclMapBO;
   mUnmapBO  = &xclUnmapBO;
 
-  mWrite      = &xclWrite;
-  mRead       = &xclRead;
   mUnmgdPread = &xclUnmgdPread;
 
   mReClock2 = &xclReClock2;


### PR DESCRIPTION
Signed-off-by: Min Ma <min.ma@amd.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Vitis-5963

#### How problem was solved, alternative solutions (if any) and why they were rejected
Do not export deprecated APIs xclRead and xclWrite to end user.
Make them for internal use only.

#### Risks (if any) associated the changes in the commit
Customer use these APIs will fail to compile with new XRT.
The suggestion is
1.  Move to Native XRT API
2. Or, if it needs to use HAL APIs, use xclRegRead and xclRegWrite instead

#### What has been tested and how, request additional testing if necessary
xbutil validate on U50.

#### Documentation impact (if any)
Should remove this two APIs.
