### PR TITLE
CR-1140242 Added the support for auto dtb creation for DC platforms

### DIFF
--- a/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.h
+++ b/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.h
@@ -222,6 +222,7 @@ using addr_type = uint64_t;
       void saveWaveDataBase();
       void extractEmuData(const std::string& simPath, int binaryCounter, bitStreamArg args);
       void nocMmapInitialization(const std::string &simPath);
+      void getDtbs(const std::string& emu_data_path, std::string& qemu_dtb, std::string& pmc_dtb);
 
       // Sanity checks
       static HwEmShim *handleCheck(void *handle);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Instead of considering the fixed PMC DTB, dynamically generated PMC DTB is considered for V70 and VCK5000 sort of platforms

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Due to some changes in the PLM firmware, we identified default one no more useful, we should make use of update PMC dts file

#### How problem was solved, alternative solutions (if any) and why they were rejected
Applied the auto generated PMC DTBs even for V70 platforms in the similar lines of embedded versal platforms

#### Risks (if any) associated the changes in the commit
No

#### What has been tested and how, request additional testing if necessary
Ran the basic V70 designs and Vitis Canary

#### Documentation impact (if any)
no