### PR TITLE
Properly connecting the User and Native API tracing profiling plugins on Windows

### DIFF
--- a/src/runtime_src/core/common/api/native_profile.cpp
+++ b/src/runtime_src/core/common/api/native_profile.cpp
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2016-2022 Xilinx, Inc
+ * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -22,8 +23,7 @@
 #include "core/common/dlfcn.h"
 #include "core/common/time.h"
 
-namespace xdp {
-namespace native {
+namespace xdp::native {
 
 bool load()
 {
@@ -54,24 +54,16 @@ void register_functions(void* handle)
   // Generic callbacks
   function_start_cb =
     reinterpret_cast<start_type>(xrt_core::dlsym(handle, "native_function_start")) ;
-  if (xrt_core::dlerror() != nullptr)
-    function_start_cb = nullptr ;
 
   function_end_cb =
     reinterpret_cast<end_type>(xrt_core::dlsym(handle, "native_function_end")) ;
-  if (xrt_core::dlerror() != nullptr)
-    function_end_cb = nullptr ;
 
   // Sync callbacks
   sync_start_cb =
     reinterpret_cast<sync_start_type>(xrt_core::dlsym(handle, "native_sync_start")) ;
-  if (xrt_core::dlerror() != nullptr)
-    sync_start_cb = nullptr ;
 
   sync_end_cb =
     reinterpret_cast<end_sync_type>(xrt_core::dlsym(handle, "native_sync_end")) ;
-  if (xrt_core::dlerror() != nullptr)
-    sync_end_cb = nullptr ;
 }
 
 void warning_function()
@@ -132,6 +124,5 @@ sync_logger::
   }
 }
 
-} // end namespace native
-} // end namespace xdp
+} // end namespace xdp::native
 

--- a/src/runtime_src/core/common/api/xrt_profile.cpp
+++ b/src/runtime_src/core/common/api/xrt_profile.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2020-2022, Xilinx Inc - All rights reserved
+ * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
  * Xilinx Runtime (XRT) Experimental APIs
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
@@ -110,25 +111,19 @@ std::function<void (unsigned long long int, const char*)> user_event_time_ns_cb;
 static void
 register_user_functions(void* handle)
 {
-  using dtype = void(*)(unsigned int, const char*, const char*);
-  user_range_start_cb = (dtype)(xrt_core::dlsym(handle, "user_event_start_cb"));
-  if (xrt_core::dlerror() != NULL)
-    user_range_start_cb = nullptr;
+  using startType = void(*)(unsigned int, const char*, const char*);
+  using endType   = void(*)(unsigned int);
+  using pipeType  = void(*)(const char*);
+  using nsType    = void(*)(unsigned long long int, const char*);
 
-  using ftype = void(*)(unsigned int);
-  user_range_end_cb = (ftype)(xrt_core::dlsym(handle, "user_event_end_cb"));
-  if (xrt_core::dlerror() != NULL)
-    user_range_end_cb = nullptr;
-
-  using btype = void(*)(const char*);
-  user_event_cb = (btype)(xrt_core::dlsym(handle, "user_event_happened_cb"));
-  if (xrt_core::dlerror() != NULL)
-    user_event_cb = nullptr;
-
-  using ctype = void(*)(unsigned long long int, const char*);
-  user_event_time_ns_cb = (ctype)(xrt_core::dlsym(handle, "user_event_time_ns_cb"));
-  if (xrt_core::dlerror() != NULL)
-    user_event_time_ns_cb = nullptr;
+  user_range_start_cb =
+    reinterpret_cast<startType>(xrt_core::dlsym(handle, "user_event_start_cb"));
+  user_range_end_cb =
+    reinterpret_cast<endType>(xrt_core::dlsym(handle, "user_event_end_cb"));
+  user_event_cb =
+    reinterpret_cast<pipeType>(xrt_core::dlsym(handle, "user_event_happened_cb"));
+  user_event_time_ns_cb =
+    reinterpret_cast<nsType>(xrt_core::dlsym(handle, "user_event_time_ns_cb"));
 }
 
 static void

--- a/src/runtime_src/xdp/profile/plugin/native/native_cb.cpp
+++ b/src/runtime_src/xdp/profile/plugin/native/native_cb.cpp
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2016-2022 Xilinx, Inc
+ * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -17,11 +18,12 @@
 #include <map>
 #include <mutex>
 
-#include "xdp/profile/plugin/native/native_cb.h"
-#include "xdp/profile/plugin/native/native_plugin.h"
-#include "xdp/profile/database/events/native_events.h"
+#define XDP_SOURCE
 
 #include "core/common/time.h"
+#include "xdp/profile/database/events/native_events.h"
+#include "xdp/profile/plugin/native/native_cb.h"
+#include "xdp/profile/plugin/native/native_plugin.h"
 
 namespace xdp {
 

--- a/src/runtime_src/xdp/profile/plugin/native/native_cb.h
+++ b/src/runtime_src/xdp/profile/plugin/native/native_cb.h
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2016-2021 Xilinx, Inc
+ * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -17,18 +18,24 @@
 #ifndef NATIVE_CB_DOT_H
 #define NATIVE_CB_DOT_H
 
+#include "xdp/config.h"
+
 // These are the functions that are visible when the plugin is dynamically
 //  linked in.  XRT should call them directly
 extern "C"
+XDP_EXPORT
 void native_function_start(const char* functionName, unsigned long long int functionID) ;
 
 extern "C"
+XDP_EXPORT
 void native_function_end(const char* functionName, unsigned long long int functionID, unsigned long long int timestamp) ;
 
 extern "C"
+XDP_EXPORT
 void native_sync_start(const char* functionName, unsigned long long int functionID, bool isWrite) ;
 
 extern "C"
+XDP_EXPORT
 void native_sync_end(const char* functionName, unsigned long long int functionID, unsigned long long int timestamp, bool isWrite, unsigned long long int size);
 
 #endif

--- a/src/runtime_src/xdp/profile/plugin/user/user_cb.cpp
+++ b/src/runtime_src/xdp/profile/plugin/user/user_cb.cpp
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2020 Xilinx, Inc
+ * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -14,13 +15,14 @@
  * under the License.
  */
 
-#include "xdp/profile/plugin/user/user_cb.h"
-#include "xdp/profile/plugin/user/user_plugin.h"
+#define XDP_SOURCE
+
+#include "core/common/time.h"
 
 #include "xdp/profile/database/database.h"
 #include "xdp/profile/database/events/user_events.h"
-
-#include "core/common/time.h"
+#include "xdp/profile/plugin/user/user_cb.h"
+#include "xdp/profile/plugin/user/user_plugin.h"
 
 namespace xdp {
 

--- a/src/runtime_src/xdp/profile/plugin/user/user_cb.h
+++ b/src/runtime_src/xdp/profile/plugin/user/user_cb.h
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2020 Xilinx, Inc
+ * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -17,20 +18,26 @@
 #ifndef USER_EVENT_CALLBACKS_DOT_H
 #define USER_EVENT_CALLBACKS_DOT_H
 
+#include "xdp/config.h"
+
 // These are the functions that are visible when the plugin is dynamically
 //  linked in.  XRT should call them directly
 extern "C"
+XDP_EXPORT
 void user_event_start_cb(unsigned int functionID,
                          const char* label,
                          const char* tooltip) ;
 
 extern "C"
+XDP_EXPORT
 void user_event_end_cb(unsigned int functionID) ;
 
 extern "C"
+XDP_EXPORT
 void user_event_happened_cb(const char* label) ;
 
 extern "C"
+XDP_EXPORT
 void user_event_time_ns_cb(unsigned long long int time_ns, const char* label) ;
 
 #endif


### PR DESCRIPTION
Signed-off-by: Jason Villarreal <jvillar@xilinx.com>

#### Problem solved by the commit
On Windows, the Native XRT API tracing plugin and the User Event plugin in profiling were being loaded but not generating any trace or capturing events in the summary file.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
The issue was twofold.  First, the functions which get dynamically linked using dlsym were not exported from the plugin modules, making them invisible on Windows.  When we attempted to link them to our callback routines using dlsym we were unsuccessful.

Second, the code performed a check to see if xrt_core::dlerror() was non-null to determine if the dynamic linking succeeded.  On Windows, this xrt_core::dlerror() function was returning the empty string "", which was not nullptr so we were incorrectly assuming an error occurred when the connection was successful.

#### How problem was solved, alternative solutions (if any) and why they were rejected
To solve the first problem, I added the proper EXPORT commands so the functions are visible outside of the plugin module on Windows.

For the second problem, I removed the redundant check of dlerror().  On both Linux and Windows, the dlsym function is already returning nullptr on failure so the check is unnecessary, and the check was incorrect on Windows.

#### Risks (if any) associated the changes in the commit
Very low risk as this adds functionality on Windows and should not effect Linux.

#### What has been tested and how, request additional testing if necessary
This has been tested on a Windows setup to verify that the connections are correct now.

#### Documentation impact (if any)
No documentation changes necessary.
