### PR TITLE
CR 1130998 : Enable AIE profile and status in HW Emu on Edge

### DIFF
--- a/src/runtime_src/core/edge/hw_em/CMakeLists.txt
+++ b/src/runtime_src/core/edge/hw_em/CMakeLists.txt
@@ -38,6 +38,10 @@ file(GLOB XDP_PLUGIN_HW_EM_FILES
   "${XDP_PLUGIN_DIR}/plugin_loader.cpp"
   "${XDP_PLUGIN_DIR}/hal_profile.h"
   "${XDP_PLUGIN_DIR}/hal_profile.cpp"
+  "${XDP_PLUGIN_DIR}/aie_debug.h"
+  "${XDP_PLUGIN_DIR}/aie_debug.cpp"
+  "${XDP_PLUGIN_DIR}/aie_profile.h"
+  "${XDP_PLUGIN_DIR}/aie_profile.cpp"
   )
 
 if (DEFINED XRT_AIE_BUILD)

--- a/src/runtime_src/core/edge/user/plugin/xdp/plugin_loader.cpp
+++ b/src/runtime_src/core/edge/user/plugin/xdp/plugin_loader.cpp
@@ -21,9 +21,10 @@
 #include "hal_profile.h"
 #include "plugin_loader.h"
 
-#ifndef __HWEM__
 #include "aie_debug.h"
 #include "aie_profile.h"
+
+#ifndef __HWEM__
 #include "aie_trace.h"
 #include "hal_device_offload.h"
 #include "noc_profile.h"
@@ -99,6 +100,12 @@ bool load()
   if (xrt_core::config::get_device_trace() != "off" ||
       xrt_core::config::get_device_counters())
     xdp::hal::hw_emu::device_offload::load() ;
+
+  if (xrt_core::config::get_aie_status())
+    xdp::aie::debug::load();
+
+  if (xrt_core::config::get_aie_profile())
+    xdp::aie::profile::load();
 #endif
   return true ;
 }

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -44,13 +44,14 @@
 #include <sys/mman.h>
 
 #include "plugin/xdp/hal_profile.h"
+#include "plugin/xdp/aie_profile.h"
+#include "plugin/xdp/aie_debug.h"
+
 #ifndef __HWEM__
 #include "plugin/xdp/hal_api_interface.h"
 #include "plugin/xdp/hal_device_offload.h"
 
 #include "plugin/xdp/aie_trace.h"
-#include "plugin/xdp/aie_profile.h"
-#include "plugin/xdp/aie_debug.h"
 #include "plugin/xdp/pl_deadlock.h"
 #else
 #include "plugin/xdp/hw_emu_device_offload.h"
@@ -141,9 +142,9 @@ shim::
 #ifndef __HWEM__
 //  xdphal::finish_flush_device(handle) ;
   xdp::aie::finish_flush_device(this) ;
+#endif
   xdp::aie::ctr::end_poll(this);
   xdp::aie::dbg::end_poll(this);
-#endif
 
   // The BO cache unmaps and releases all execbo, but this must
   // be done before the device (mKernelFD) is closed.
@@ -2166,8 +2167,10 @@ xclLoadXclBinImpl(xclDeviceHandle handle, const xclBin *buffer, bool meta)
 #ifndef __HWEM__
     xdp::hal::update_device(handle);
     xdp::aie::update_device(handle);
+#endif
     xdp::aie::ctr::update_device(handle);
     xdp::aie::dbg::update_device(handle);
+#ifndef __HWEM__
     xdp::pl_deadlock::update_device(handle);
 
     START_DEVICE_PROFILING_CB(handle);

--- a/src/runtime_src/xdp/CMakeLists.txt
+++ b/src/runtime_src/xdp/CMakeLists.txt
@@ -463,8 +463,8 @@ endif()
 if (DEFINED XRT_AIE_BUILD AND ${XRT_NATIVE_BUILD} STREQUAL "no")
   # AIE Profile plugin
   add_library(xdp_aie_profile_plugin MODULE ${XRT_XDP_PROFILE_AIE_PLUGIN_FILES})
-  add_dependencies(xdp_aie_profile_plugin xdp_core xrt_core)
-  target_link_libraries(xdp_aie_profile_plugin PRIVATE xdp_core xrt_core metal xaiengine)
+  add_dependencies(xdp_aie_profile_plugin xdp_core)
+  target_link_libraries(xdp_aie_profile_plugin PRIVATE xdp_core metal xaiengine)
   set_target_properties(xdp_aie_profile_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
 
   install (TARGETS xdp_aie_profile_plugin
@@ -483,8 +483,8 @@ if (DEFINED XRT_AIE_BUILD AND ${XRT_NATIVE_BUILD} STREQUAL "no")
 
   # AIE Debug plugin
   add_library(xdp_aie_debug_plugin MODULE ${XRT_XDP_AIE_DEBUG_PLUGIN_FILES})
-  add_dependencies(xdp_aie_debug_plugin xdp_core xrt_core)
-  target_link_libraries(xdp_aie_debug_plugin PRIVATE xdp_core xrt_core metal xaiengine)
+  add_dependencies(xdp_aie_debug_plugin xdp_core)
+  target_link_libraries(xdp_aie_debug_plugin PRIVATE xdp_core metal xaiengine)
   set_target_properties(xdp_aie_debug_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
 
   install (TARGETS xdp_aie_debug_plugin


### PR DESCRIPTION
Signed-off-by: IshitaGhosh <ighosh.account@gmail.com>

#### Problem solved by the commit
Enable AIE Profile and AIE status support for HW Emu on Edge
This is a duplicate of PR#6989 to get past DCO fail. The PR#6989 had non-signed commits and that made it fail DCO checks.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR 1130998

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
