### PR TITLE
Fixed CR-1137646 : zocl_create_client() panic for missing NULL pointer checking

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/cu.c
+++ b/src/runtime_src/core/edge/drm/zocl/cu.c
@@ -367,6 +367,11 @@ static int cu_probe(struct platform_device *pdev)
 	zcu->base.res = res;
 
 	zdev = zocl_get_zdev();
+	if (!zdev) {
+		err = -EINVAL;
+		goto err1;
+	}
+
 	err = zocl_kds_add_cu(zdev, &zcu->base);
 	if (err) {
 		DRM_ERROR("Not able to add CU %p to KDS", zcu);

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
@@ -196,6 +196,7 @@ zocl_kds_add_cu(struct drm_zocl_dev *zdev, struct xrt_cu *xcu)
 static inline int
 zocl_kds_add_scu(struct drm_zocl_dev *zdev, struct xrt_cu *xcu)
 {
+	BUG_ON(!zdev);
 	return kds_add_scu(&zdev->kds, xcu);
 }
 

--- a/src/runtime_src/core/edge/drm/zocl/scu.c
+++ b/src/runtime_src/core/edge/drm/zocl/scu.c
@@ -174,9 +174,11 @@ static const struct attribute_group scu_attrgroup = {
 static int configure_soft_kernel(u32 cuidx, char kname[64], unsigned char uuid[16])
 {
 	struct drm_zocl_dev *zdev = zocl_get_zdev();
-	struct soft_krnl *sk = zdev->soft_kernel;
+	struct soft_krnl *sk = NULL;
 	struct soft_krnl_cmd *scmd = NULL;
 	struct config_sk_image_uuid *cp = NULL;
+
+	BUG_ON(!zdev);
 
 	cp = kmalloc(sizeof(struct config_sk_image_uuid), GFP_KERNEL);
 	cp->start_cuidx = cuidx;
@@ -184,6 +186,7 @@ static int configure_soft_kernel(u32 cuidx, char kname[64], unsigned char uuid[1
 	strncpy((char *)cp->sk_name,kname,PS_KERNEL_NAME_LENGTH);
 	memcpy(cp->sk_uuid,uuid,sizeof(cp->sk_uuid));
 
+	sk = zdev->soft_kernel;
 	// Locking soft kernel data structure
 	mutex_lock(&sk->sk_lock);
 
@@ -230,6 +233,7 @@ static int scu_probe(struct platform_device *pdev)
 	memcpy(&zcu->base.info, info, sizeof(struct xrt_cu_info));
 
 	zdev = zocl_get_zdev();
+	BUG_ON(!zdev);
 	zcu->sc_bo = zocl_drm_create_bo(zdev->ddev, SOFT_KERNEL_REG_SIZE, ZOCL_BO_FLAGS_CMA);
 	if (IS_ERR(zcu->sc_bo)) {
 		return -ENOMEM;
@@ -368,6 +372,7 @@ void zocl_scu_sk_ready(struct platform_device *pdev)
 {
 	struct zocl_scu *zcu = platform_get_drvdata(pdev);
 
+	BUG_ON(!zcu);
 	up(&zcu->sc_sem);
 }
 

--- a/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
@@ -861,6 +861,9 @@ int zocl_create_client(struct device *dev, void **client_hdl)
 	if (!client)
 		return -ENOMEM;
 
+	if (!zdev)
+		return -EINVAL;
+
 	kds = &zdev->kds;
 	client->dev = dev;
 	ret = kds_init_client(kds, client);

--- a/src/runtime_src/core/edge/drm/zocl/zocl_sk.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_sk.c
@@ -219,6 +219,7 @@ zocl_init_soft_kernel(struct drm_zocl_dev *zdev)
 {
 	struct soft_krnl *sk;
 
+	BUG_ON(!zdev);
 	sk = devm_kzalloc(zdev->ddev->dev, sizeof(*sk), GFP_KERNEL);
 	if (!sk)
 		return -ENOMEM;
@@ -237,6 +238,7 @@ zocl_fini_soft_kernel(struct drm_zocl_dev *zdev)
 	struct soft_krnl *sk;
 	int i;
 
+	BUG_ON(!zdev);
 	sk = zdev->soft_kernel;
 	mutex_lock(&sk->sk_lock);
 

--- a/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
@@ -910,6 +910,7 @@ zocl_xclbin_load_pskernel(struct drm_zocl_dev *zdev, void *data)
                 return -EINVAL;
         }
 
+	BUG_ON(!zdev);
 	// Currently only 1 slot - TODO: Support multi-slot in the future
 	slot = zdev->pr_slot[0];
 


### PR DESCRIPTION
Fixed this issue. The actual issue is that there is no null pointer checking for zdev in zocl_create_client() of zocl driver.
Added the same. 
