### PR TITLE
CR-1137845, CR-1139609 : Fix user managed interrupts on edge platforms

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/cu.c
+++ b/src/runtime_src/core/edge/drm/zocl/cu.c
@@ -288,16 +288,23 @@ irqreturn_t ucu_isr(int irq, void *arg)
 static int user_manage_irq(struct xrt_cu *xcu, bool user_manage)
 {
 	struct zocl_cu *zcu = (struct zocl_cu *)xcu;
-	int ret;
+	struct platform_device *intc;
+	int ret = 0;
+
+	intc = zocl_find_pdev(ERT_CU_INTC_DEV_NAME);
+	if (!intc) {
+		DRM_INFO("%s: finding platform device - %s failed\n", __func__, ERT_CU_INTC_DEV_NAME);
+		return -ENODEV;
+	}
 
 	if (xcu->info.intr_enable)
-		free_irq(zcu->irq, zcu);
+		zocl_ert_intc_remove(intc, xcu->info.intr_id);
 
 	/* Do not use IRQF_SHARED! */
 	if (user_manage)
-		ret = request_irq(zcu->irq, ucu_isr, 0, zcu->irq_name, zcu);
+		ret = zocl_ert_intc_add(intc, xcu->info.intr_id, ucu_isr, zcu);
 	else
-		ret = request_irq(zcu->irq, cu_isr, 0, zcu->irq_name, zcu);
+		ret = zocl_ert_intc_add(intc, xcu->info.intr_id, cu_isr, zcu);
 	if (ret) {
 		DRM_INFO("%s: request_irq() failed\n", __func__);
 		return ret;
@@ -306,7 +313,7 @@ static int user_manage_irq(struct xrt_cu *xcu, bool user_manage)
 	if (user_manage) {
 		__set_bit(IRQ_DISABLED, zcu->flag);
 		spin_lock_init(&zcu->lock);
-		disable_irq(zcu->irq);
+		zocl_ert_intc_config(intc, xcu->info.intr_id, false); // disable irq
 	}
 
 	return 0;
@@ -315,17 +322,22 @@ static int user_manage_irq(struct xrt_cu *xcu, bool user_manage)
 static int configure_irq(struct xrt_cu *xcu, bool enable)
 {
 	struct zocl_cu *zcu = (struct zocl_cu *)xcu;
+	struct platform_device *intc;
 	unsigned long flags;
 
-	spin_lock_irqsave(&zcu->lock, flags);
+	intc = zocl_find_pdev(ERT_CU_INTC_DEV_NAME);
+	if (!intc) {
+		DRM_INFO("%s: finding platform device - %s failed\n", __func__, ERT_CU_INTC_DEV_NAME);
+		return -ENODEV;
+	}
+
 	if (enable) {
 		if (__test_and_clear_bit(IRQ_DISABLED, zcu->flag))
-			enable_irq(zcu->irq);
+			zocl_ert_intc_config(intc, xcu->info.intr_id, true); // enable irq
 	} else {
 		if (!__test_and_set_bit(IRQ_DISABLED, zcu->flag))
-			disable_irq(zcu->irq);
+			zocl_ert_intc_config(intc, xcu->info.intr_id, false); // disable irq
 	}
-	spin_unlock_irqrestore(&zcu->lock, flags);
 
 	return 0;
 }

--- a/src/runtime_src/core/edge/drm/zocl/zocl_xgq_intc.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_xgq_intc.c
@@ -152,9 +152,28 @@ static void zocl_irq_intc_remove(struct platform_device *pdev, u32 id)
 	spin_unlock_irqrestore(&zintc->zei_lock, irqflags);
 }
 
+static void zocl_irq_intc_config(struct platform_device *pdev, u32 id, bool enabled)
+{
+	unsigned long irqflags;
+	struct zocl_irq_intc *zintc = platform_get_drvdata(pdev);
+	struct zocl_ert_intc_handler *h;
+
+	BUG_ON(id >= zintc->zei_num_irqs);
+	h = &zintc->zei_handler[id];
+	spin_lock_irqsave(&zintc->zei_lock, irqflags);
+
+	if (enabled)
+		enable_irq(h->zeih_irq);
+	else
+		disable_irq(h->zeih_irq);
+
+	spin_unlock_irqrestore(&zintc->zei_lock, irqflags);
+}
+
 static struct zocl_ert_intc_drv_data zocl_irq_intc_drvdata = {
 	.add = zocl_irq_intc_add,
 	.remove = zocl_irq_intc_remove,
+	.config = zocl_irq_intc_config
 };
 
 static const struct platform_device_id zocl_irq_intc_id_match[] = {


### PR DESCRIPTION
Signed-off-by: rbramand <rbramand@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Fix User managed interrupts code path on edge platforms

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://github.com/Xilinx/XRT/pull/6862 introduced the bug.  It is discovered in edge regression testing.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added proper callbacks to register user managed irq isr. Also added config callback for enabling and disabling irq .

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
Tested applications attached to CRs on vck190, need to check edge regression results as well.

#### Documentation impact (if any)
NA