### PR TITLE
Change tops to gops

### DIFF
--- a/src/runtime_src/core/include/experimental/xrt_hw_context.h
+++ b/src/runtime_src/core/include/experimental/xrt_hw_context.h
@@ -36,7 +36,7 @@ public:
    * Free formed key-value entry.
    *
    * Supported keys are:
-   *  - tops                   // tera operations per second
+   *  - gops                   // giga operations per second
    *  - fps                    // frames per second
    *  - dma_bandwidth          // gigabytes per second
    *  - latency                // ??


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Change QoS key from "tops" to "gops" because we need smaller granularity description.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
This changed QoS API documentation