### PR TITLE
Fix RC when accessing singleton's sessions vector

### DIFF
--- a/src/xma/include/lib/xmaapi.h
+++ b/src/xma/include/lib/xmaapi.h
@@ -43,7 +43,7 @@ typedef struct XmaSingleton
     XmaHwCfg          hwcfg;
     bool              xma_initialized;
     bool              kds_old;
-    uint32_t          cpu_mode;
+    std::atomic<uint32_t> cpu_mode;
     std::mutex            m_mutex;
     std::atomic<uint32_t> num_decoders;
     std::atomic<uint32_t> num_encoders;

--- a/src/xma/src/xmaapi/xmaapi.cpp
+++ b/src/xma/src/xmaapi/xmaapi.cpp
@@ -265,13 +265,13 @@ void xma_thread2(uint32_t hw_dev_index) {
     bool desired = true;
     auto xrt_device_obj = g_xma_singleton->hwcfg.devices[hw_dev_index].xrt_device;
     while (!g_xma_singleton->xma_exit) {
+        std::lock_guard<std::mutex> lock(g_xma_singleton->m_mutex);
         if (g_xma_singleton->cpu_mode == XMA_CPU_MODE2) {
             std::this_thread::sleep_for(std::chrono::milliseconds(3));
         } else {
             xrt_device_obj.get_handle()->exec_wait(100);
         }
 
-        std::lock_guard<std::mutex> lock(g_xma_singleton->m_mutex);
         for (auto& itr1: g_xma_singleton->all_sessions_vec) {
             if (g_xma_singleton->xma_exit) {
                 break;

--- a/src/xma/src/xmaapi/xmaapi.cpp
+++ b/src/xma/src/xmaapi/xmaapi.cpp
@@ -108,7 +108,9 @@ void xma_thread1() {
             //bool expected = false;
             //bool desired = true;
             XmaHwSessionPrivate *slowest_session = nullptr;
-            uint32_t sessioin_cmd_busiest_val = 0;
+            uint32_t session_cmd_busiest_val = 0;
+            std::lock_guard lock(g_xma_singleton->m_mutex);
+
             for (auto& itr1: g_xma_singleton->all_sessions_vec) {
                 if (g_xma_singleton->xma_exit) {
                     break;
@@ -129,8 +131,8 @@ void xma_thread1() {
                     continue;
                 }
                 if (priv1->kernel_complete_total > 127) {
-                    if (priv1->cmd_busy > sessioin_cmd_busiest_val) {
-                        sessioin_cmd_busiest_val = priv1->cmd_busy;
+                    if (priv1->cmd_busy > session_cmd_busiest_val) {
+                        session_cmd_busiest_val = priv1->cmd_busy;
                         slowest_session = priv1;
                     }
                 }
@@ -210,6 +212,8 @@ void xma_thread1() {
         }
     }
     //Print all stats here
+    std::lock_guard lock(g_xma_singleton->m_mutex);
+
     xclLogMsg(NULL, XRT_INFO, "XMA-Session-Stats", "=== Session CU Command Relative Stats: ===");
     for (auto& itr1: g_xma_singleton->all_sessions_vec) {
         xclLogMsg(NULL, XRT_INFO, "XMA-Session-Stats", "--------");
@@ -267,6 +271,7 @@ void xma_thread2(uint32_t hw_dev_index) {
             xrt_device_obj.get_handle()->exec_wait(100);
         }
 
+        std::lock_guard<std::mutex> lock(g_xma_singleton->m_mutex);
         for (auto& itr1: g_xma_singleton->all_sessions_vec) {
             if (g_xma_singleton->xma_exit) {
                 break;

--- a/src/xma/src/xmaapi/xmaapi.cpp
+++ b/src/xma/src/xmaapi/xmaapi.cpp
@@ -427,7 +427,7 @@ int32_t xma_initialize(XmaXclbinParameter *devXclbins, int32_t num_parms)
     else
         xma_logmsg(XMA_DEBUG_LOG, XMAAPI_MOD, "XMA for KDS 2.0. Default mode.");
     g_xma_singleton->cpu_mode = xrt_core::config::get_xma_cpu_mode();
-    xma_logmsg(XMA_DEBUG_LOG, XMAAPI_MOD, "XMA CPU Mode is: %d", g_xma_singleton->cpu_mode);
+    xma_logmsg(XMA_DEBUG_LOG, XMAAPI_MOD, "XMA CPU Mode is: %d", g_xma_singleton->cpu_mode.load());
 
     g_xma_singleton->xma_thread1 = std::thread(xma_thread1);
     g_xma_singleton->all_thread2.reserve(MAX_XILINX_DEVICES);

--- a/src/xma/src/xmaapi/xmaapi.cpp
+++ b/src/xma/src/xmaapi/xmaapi.cpp
@@ -265,13 +265,13 @@ void xma_thread2(uint32_t hw_dev_index) {
     bool desired = true;
     auto xrt_device_obj = g_xma_singleton->hwcfg.devices[hw_dev_index].xrt_device;
     while (!g_xma_singleton->xma_exit) {
-        std::lock_guard<std::mutex> lock(g_xma_singleton->m_mutex);
         if (g_xma_singleton->cpu_mode == XMA_CPU_MODE2) {
             std::this_thread::sleep_for(std::chrono::milliseconds(3));
         } else {
             xrt_device_obj.get_handle()->exec_wait(100);
         }
 
+        std::lock_guard<std::mutex> lock(g_xma_singleton->m_mutex);
         for (auto& itr1: g_xma_singleton->all_sessions_vec) {
             if (g_xma_singleton->xma_exit) {
                 break;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
There are 2 threads `xma_thread1` and `xma_thread2` reading from a vector of sessions inside the `g_xma_singleton`. The access was not guarded by any mutex while other threads could access the sessions vector and push a new element, this sometimes was causing a race condition where the thread was looping over elements and a new elements was being added causing a vector resize. This automatically invalidated any existing vector iterator (which the threads were using for reading from vector) which resulted in a segfault when trying to dereference it.  

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
The bug has been discovered when running a lot of quite short-lived sessions which caused the application to exit due to
segfaults.
#### How problem was solved, alternative solutions (if any) and why they were rejected
Locking a mutex before accessing a list of sessions.
#### Risks (if any) associated with the changes in the commit
Probably none, the mutex could be replaced with `std::shared_mutex` as there are probably more reads than writes but with that low frequency of locking it, it is probably not worth it.
#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
