### PR TITLE
CR-1140236: Print the path of sim directory explicitly in hw emu alveo shim.cxx

### DIFF
--- a/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.cxx
@@ -1054,7 +1054,6 @@ namespace xclhwemhal2 {
         if (!launcherArgs.empty())
           simMode = launcherArgs.c_str();
 
-        std::cout << "Path of the simulation directory : " << getSimPath() << std::endl;
         //if (!xclemulation::file_exists(sim_file))
         if (!boost::filesystem::exists(sim_file))
           sim_file = "simulate.sh";
@@ -1090,6 +1089,10 @@ namespace xclhwemhal2 {
       //throw std::runtime_error(" Simulator did not start/exited, please refer simulate.log in .run directory!");
       exit(EXIT_FAILURE);
     }
+
+    std::string simulationDirectoryMsg = "INFO: [HW-EMU 05] Path of the simulation directory : " + getSimPath();
+    logMessage(simulationDirectoryMsg);
+
     sock = std::make_shared<unix_socket>();
     set_simulator_started(true);
     sock->monitor_socket();

--- a/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.cxx
@@ -1054,6 +1054,7 @@ namespace xclhwemhal2 {
         if (!launcherArgs.empty())
           simMode = launcherArgs.c_str();
 
+        std::cout << "Path of the simulation directory : " << getSimPath() << std::endl;
         //if (!xclemulation::file_exists(sim_file))
         if (!boost::filesystem::exists(sim_file))
           sim_file = "simulate.sh";


### PR DESCRIPTION
Fix :  Added a cout statement to print the simulation directory path always on the console in  hw emu alveo shim.cxx
Risk: Very Low.
Tests: Canary run. Results are clean.
Reviewer: venkatp