### PR TITLE
Revert "Vitis-5963 xclRead and xclWrite APIs should be removed from XRT code base"

### DIFF
--- a/src/runtime_src/core/common/ishim.h
+++ b/src/runtime_src/core/common/ishim.h
@@ -25,10 +25,6 @@ int xclUpdateSchedulerStat(xclDeviceHandle handle);
 int xclInternalResetDevice(xclDeviceHandle handle, xclResetKind kind);
 int xclCmaEnable(xclDeviceHandle handle, bool enable, uint64_t total_size);
 int xclCloseExportHandle(xclBufferExportHandle);
-XCL_DRIVER_DLLESPEC
-size_t xclWrite(xclDeviceHandle handle, enum xclAddressSpace space, uint64_t offset, const void *hostBuf, size_t size);
-XCL_DRIVER_DLLESPEC
-size_t xclRead(xclDeviceHandle handle, enum xclAddressSpace space, uint64_t offset, void *hostbuf, size_t size);
 
 namespace xrt_core {
 

--- a/src/runtime_src/core/include/deprecated/xrt.h
+++ b/src/runtime_src/core/include/deprecated/xrt.h
@@ -766,6 +766,20 @@ xclGetDeviceAddr(xclDeviceHandle handle, xclBufferHandle boHandle)
     return !xclGetBOProperties(handle, boHandle, &p) ? p.paddr : (uint64_t)-1;
 }
 
+/* Use xclRegWrite */
+XRT_DEPRECATED
+XCL_DRIVER_DLLESPEC
+size_t
+xclWrite(xclDeviceHandle handle, enum xclAddressSpace space, uint64_t offset,
+         const void *hostBuf, size_t size);
+
+/* Use xclRegRead */
+XRT_DEPRECATED
+XCL_DRIVER_DLLESPEC
+size_t
+xclRead(xclDeviceHandle handle, enum xclAddressSpace space, uint64_t offset,
+        void *hostbuf, size_t size);
+
 /* Not supported */
 XRT_DEPRECATED
 XCL_DRIVER_DLLESPEC

--- a/src/runtime_src/xrt/device/halops2.cpp
+++ b/src/runtime_src/xrt/device/halops2.cpp
@@ -102,6 +102,8 @@ operations(const std::string &fileName, void *fileHandle, unsigned int count)
   mMapBO    = (mapBOFuncType)xrt_core::dlsym(const_cast<void *>(mDriverHandle), "xclMapBO");
   mUnmapBO  = (unmapBOFuncType)xrt_core::dlsym(const_cast<void *>(mDriverHandle), "xclUnmapBO");
 
+  mWrite      = (writeFuncType)xrt_core::dlsym(const_cast<void *>(mDriverHandle), "xclWrite");
+  mRead       = (readFuncType)xrt_core::dlsym(const_cast<void *>(mDriverHandle), "xclRead");
   mUnmgdPread = (unmgdPreadFuncType)xrt_core::dlsym(const_cast<void *>(mDriverHandle), "xclUnmgdPread");
 
   mReClock2 = (reClock2FuncType)xrt_core::dlsym(const_cast<void *>(mDriverHandle), "xclReClock2");

--- a/src/runtime_src/xrt/device/halops2_static.cpp
+++ b/src/runtime_src/xrt/device/halops2_static.cpp
@@ -105,6 +105,8 @@ operations(const std::string &fileName, void *fileHandle, unsigned int count)
   mMapBO    = &xclMapBO;
   mUnmapBO  = &xclUnmapBO;
 
+  mWrite      = &xclWrite;
+  mRead       = &xclRead;
   mUnmgdPread = &xclUnmgdPread;
 
   mReClock2 = &xclReClock2;


### PR DESCRIPTION
Reverts Xilinx/XRT#7042
We have to wait with this change until 2023.1, some Vitis examples need to change.