### PR TITLE
Multislot mm support

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/common.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/common.h
@@ -141,15 +141,6 @@ struct client_ctx {
 };
 #define	CLIENT_NUM_CU_CTX(client) ((client)->num_cus + (client)->virt_cu_ref)
 
-struct xocl_mm_wrapper {
-  struct drm_mm *mm;
-  struct drm_xocl_mm_stat *mm_usage_stat;
-  uint64_t start_addr;
-  uint64_t size;
-  uint32_t ddr;
-  struct hlist_node node;
-};
-
 /* ioctl functions */
 int xocl_info_ioctl(struct drm_device *dev, void *data,
 	struct drm_file *filp);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
@@ -89,21 +89,25 @@ void xocl_describe(const struct drm_xocl_bo *xobj)
 void xocl_bo_get_usage_stat(struct xocl_drm *drm_p, u32 bo_idx,
 	struct drm_xocl_mm_stat *pstat)
 {
-	if (!drm_p->bo_usage_stat)
+	struct xocl_mm *xocl_mm = drm_p->xocl_mm;
+
+	if (!xocl_mm->bo_usage_stat)
 		return;
+
 	if (bo_idx >= XOCL_BO_USAGE_TOTAL)
 		return;
 
-	pstat->memory_usage = drm_p->bo_usage_stat[bo_idx].memory_usage;
-	pstat->bo_count = drm_p->bo_usage_stat[bo_idx].bo_count;
+	pstat->memory_usage = xocl_mm->bo_usage_stat[bo_idx].memory_usage;
+	pstat->bo_count = xocl_mm->bo_usage_stat[bo_idx].bo_count;
 }
 
 static int xocl_bo_update_usage_stat(struct xocl_drm *drm_p, unsigned bo_flag,
 	u64 size, int count)
 {
 	int idx = -1;
+	struct xocl_mm *xocl_mm = drm_p->xocl_mm;
 
-	if (!drm_p->bo_usage_stat)
+	if (!xocl_mm->bo_usage_stat)
 		return -EINVAL;
 
 	switch (bo_flag) {
@@ -135,8 +139,8 @@ static int xocl_bo_update_usage_stat(struct xocl_drm *drm_p, unsigned bo_flag,
 	if (idx < 0)
 		return -EINVAL;
 
-	drm_p->bo_usage_stat[idx].memory_usage += (count > 0) ? size : -size;
-	drm_p->bo_usage_stat[idx].bo_count += count;
+	xocl_mm->bo_usage_stat[idx].memory_usage += (count > 0) ? size : -size;
+	xocl_mm->bo_usage_stat[idx].bo_count += count;
 	return 0;
 }
 
@@ -145,11 +149,23 @@ static void xocl_free_mm_node(struct drm_xocl_bo *xobj)
 	struct drm_device *ddev = xobj->base.dev;
 	struct xocl_drm *drm_p = ddev->dev_private;
 	unsigned ddr = xobj->mem_idx;
+	struct xocl_mem_stat *curr_mem = NULL;
+	unsigned slotidx = xocl_bo_slot_idx(xobj->user_flags);
 
 	mutex_lock(&drm_p->mm_lock);
 	BO_ENTER("xobj %p, mm_node %p", xobj, xobj->mm_node);
 	if (!xobj->mm_node)
 		goto end;
+
+	/* Update slot specific stats */
+	list_for_each_entry(curr_mem, &drm_p->mem_list_head, link) {
+		if ((slotidx == curr_mem->slot_idx) &&
+				(ddr == curr_mem->mem_idx)) {
+			curr_mem->mm_usage_stat.memory_usage -=
+				xobj->base.size;
+			curr_mem->mm_usage_stat.bo_count -= 1;
+		}
+	}
 
 	xocl_mm_update_usage_stat(drm_p, ddr, xobj->base.size, -1);
 	xocl_bo_update_usage_stat(drm_p, xobj->flags, xobj->base.size, -1);
@@ -438,7 +454,7 @@ static struct drm_xocl_bo *xocl_create_bo(struct drm_device *dev,
 	xocl_xdev_dbg(xdev, "alloc bo from bank%u, flag %x, host bank %d",
 		memidx, xobj->flags, drm_p->cma_bank_idx);
 
-	err = xocl_mm_insert_node(drm_p, memidx, xobj->mm_node,
+	err = xocl_mm_insert_node(drm_p, xobj->user_flags, xobj->mm_node,
 		xobj->base.size);
 	if (err)
 		goto failed;
@@ -446,7 +462,6 @@ static struct drm_xocl_bo *xocl_create_bo(struct drm_device *dev,
 	BO_DEBUG("insert mm_node:%p, start:%llx size: %llx",
 		xobj->mm_node, xobj->mm_node->start,
 		xobj->mm_node->size);
-	xocl_mm_update_usage_stat(drm_p, memidx, xobj->base.size, 1);
 	xocl_bo_update_usage_stat(drm_p, xobj->flags, xobj->base.size, 1);
 	/* Record the DDR we allocated the buffer on */
 	xobj->mem_idx = memidx;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
@@ -378,6 +378,7 @@ static struct drm_xocl_bo *xocl_create_bo(struct drm_device *dev,
 	struct xocl_dev *xdev = drm_p->xdev;
 	struct drm_gem_object *obj;
 	unsigned memidx = xocl_bo_ddr_idx(user_flags);
+	unsigned slotidx = xocl_bo_slot_idx(user_flags);
 	bool xobj_inited = false;
 	int err = 0;
 
@@ -454,7 +455,7 @@ static struct drm_xocl_bo *xocl_create_bo(struct drm_device *dev,
 	xocl_xdev_dbg(xdev, "alloc bo from bank%u, flag %x, host bank %d",
 		memidx, xobj->flags, drm_p->cma_bank_idx);
 
-	err = xocl_mm_insert_node(drm_p, xobj->user_flags, xobj->mm_node,
+	err = xocl_mm_insert_node(drm_p, memidx, slotidx, xobj->mm_node,
 		xobj->base.size);
 	if (err)
 		goto failed;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.h
@@ -128,7 +128,18 @@ static inline struct drm_xocl_dev *bo_xocl_dev(const struct drm_xocl_bo *bo)
 
 static inline unsigned xocl_bo_ddr_idx(unsigned user_flags)
 {
-        return user_flags & XRT_BO_FLAGS_MEMIDX_MASK;
+	struct xcl_bo_flags bo_flag = {};
+
+	bo_flag.flags = user_flags & XRT_BO_FLAGS_MEMIDX_MASK;
+	return bo_flag.bank; 
+}
+
+static inline unsigned xocl_bo_slot_idx(unsigned user_flags)
+{
+	struct xcl_bo_flags bo_flag = {};
+
+	bo_flag.flags = user_flags & XRT_BO_FLAGS_MEMIDX_MASK;
+	return bo_flag.slot; 
 }
 
 static inline unsigned xocl_bo_type(unsigned user_flags)

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
@@ -54,6 +54,7 @@
 
 static char driver_date[9];
 
+int xocl_cleanup_mem_nolock(struct xocl_drm *drm_p);
 static int xocl_cleanup_memory_manager(struct xocl_drm *drm_p);
 static int xocl_init_drm_memory_manager(struct xocl_drm *drm_p);
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
@@ -968,13 +968,6 @@ static int xocl_init_drm_mm(struct xocl_drm *drm_p, struct xocl_mm *xocl_mm,
 	}
 
 	drm_mm_init(xocl_mm->mm, mm_start_addr, (mm_end_addr - mm_start_addr));
-	if (!xocl_mm->mm) {
-		xocl_err(drm_p->ddev->dev,
-				"init memory manager failed");
-		err = -EINVAL;
-		goto error;
-	}
-
 	xocl_mm->start_addr = mm_start_addr;
 	xocl_mm->end_addr = mm_end_addr;
 	xocl_mm->m_count = m_count;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
@@ -54,6 +54,8 @@
 
 static char driver_date[9];
 
+static int xocl_cleanup_memory_manager(struct xocl_drm *drm_p);
+
 static void xocl_free_object(struct drm_gem_object *obj)
 {
 	DRM_ENTER("");
@@ -603,10 +605,8 @@ void *xocl_drm_init(xdev_handle_t xdev_hdl)
 #endif
 
 	mutex_init(&drm_p->mm_lock);
+	INIT_LIST_HEAD(&drm_p->mem_list_head);
 	ddev->dev_private = drm_p;
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 7, 0)
-	hash_init(drm_p->mm_range);
-#endif
 
 	xocl_drvinst_set_filedev(drm_p, ddev);
 	xocl_drvinst_set_offline(drm_p, false);
@@ -630,6 +630,7 @@ void xocl_drm_fini(struct xocl_drm *drm_p)
 	xocl_drvinst_release(drm_p, &hdl);
 
 	xocl_cleanup_mem(drm_p);
+	xocl_cleanup_memory_manager(drm_p);
 	drm_put_dev(drm_p->ddev);
 	mutex_destroy(&drm_p->mm_lock);
 
@@ -639,257 +640,195 @@ void xocl_drm_fini(struct xocl_drm *drm_p)
 void xocl_mm_get_usage_stat(struct xocl_drm *drm_p, u32 ddr,
 	struct drm_xocl_mm_stat *pstat)
 {
-	if (!drm_p->mm_usage_stat)
+	struct xocl_mm *xocl_mm = drm_p->xocl_mm;
+
+	if (!xocl_mm && !xocl_mm->mm_usage_stat)
 		return;
 
-	pstat->memory_usage = drm_p->mm_usage_stat[ddr] ?
-		drm_p->mm_usage_stat[ddr]->memory_usage : 0;
-	pstat->bo_count = drm_p->mm_usage_stat[ddr] ?
-		drm_p->mm_usage_stat[ddr]->bo_count : 0;
+	pstat->memory_usage = xocl_mm->mm_usage_stat[ddr] ?
+		xocl_mm->mm_usage_stat[ddr]->memory_usage : 0;
+	pstat->bo_count = xocl_mm->mm_usage_stat[ddr] ?
+		xocl_mm->mm_usage_stat[ddr]->bo_count : 0;
 }
 
 void xocl_mm_update_usage_stat(struct xocl_drm *drm_p, u32 ddr,
 	u64 size, int count)
 {
-	BUG_ON(!drm_p->mm_usage_stat[ddr]);
+	struct xocl_mm *xocl_mm = drm_p->xocl_mm;
 
-	drm_p->mm_usage_stat[ddr]->memory_usage += (count > 0) ? size : -size;
-	drm_p->mm_usage_stat[ddr]->bo_count += count;
+	BUG_ON(!xocl_mm && !xocl_mm->mm_usage_stat[ddr]);
+
+	xocl_mm->mm_usage_stat[ddr]->memory_usage +=
+		(count > 0) ? size : -size;
+	xocl_mm->mm_usage_stat[ddr]->bo_count += count;
 }
 
-static int xocl_mm_insert_node_range_all(struct xocl_drm *drm_p, u32 mem_id,
+static int xocl_mm_insert_node_range_all(struct xocl_drm *drm_p, uint32_t *mem_id,
 		struct mem_topology *grp_topology, struct drm_mm_node *dnode, u64 size)
 {
-	struct xocl_mm_wrapper *wrapper = NULL;
+	struct mem_data *mem_data = NULL;
+	struct xocl_mm *xocl_mm = drm_p->xocl_mm;
 	uint64_t start_addr = 0;
 	uint64_t end_addr = 0;
-	uint64_t hash_start_addr = 0;
 	int ret = 0;
 	int i = 0;
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 7, 0)
+	BUG_ON(!xocl_mm && !xocl_mm->mm);
+
 	for (i = 0; i < grp_topology->m_count; i++) {
-		if ((convert_mem_tag(grp_topology->m_mem_data[i].m_tag) == MEM_TAG_HOST) ||
-				XOCL_IS_PS_KERNEL_MEM(grp_topology, i))
+		mem_data = &grp_topology->m_mem_data[i];
+		if ((convert_mem_tag(mem_data->m_tag) == MEM_TAG_HOST) ||
+				!XOCL_IS_PS_KERNEL_MEM(grp_topology, i))
 			continue;
 
-		hash_start_addr = grp_topology->m_mem_data[i].m_base_address;
-		hash_for_each_possible(drm_p->mm_range, wrapper, node, hash_start_addr) {
-			start_addr = wrapper->start_addr;
-			end_addr = wrapper->start_addr + wrapper->size;
+		start_addr = mem_data->m_base_address;
+		end_addr = start_addr + mem_data->m_size;
 
 #if defined(XOCL_DRM_FREE_MALLOC)
-			ret = drm_mm_insert_node_in_range(drm_p->mm, dnode, size, PAGE_SIZE, 0,
-					start_addr, end_addr, 0);
+		ret = drm_mm_insert_node_in_range(xocl_mm->mm, dnode, size, PAGE_SIZE, 0,
+				start_addr, end_addr, 0);
 #else
-			ret = drm_mm_insert_node_in_range(drm_p->mm, dnode, size, PAGE_SIZE,
-					start_addr, end_addr, 0);
+		ret = drm_mm_insert_node_in_range(xocl_mm->mm, dnode, size, PAGE_SIZE,
+				start_addr, end_addr, 0);
 #endif
-
-			if (!ret) 
-				/* Found the memory. Return it from here  */
-				return 0;
+		if (!ret) {
+			// Memory is allocated to this Bank
+			*mem_id = i;
+			return 0;
 		}
-	}	
-#endif
+	}
 
 	return ret;
 }
-
 
 static int xocl_mm_insert_node_range(struct xocl_drm *drm_p, u32 mem_id,
 		struct mem_topology *grp_topology, struct drm_mm_node *node, u64 size)
 {
+	struct xocl_mm *xocl_mm = drm_p->xocl_mm;
 	uint64_t start_addr = 0;
 	uint64_t end_addr = 0;
 	int ret = 0;
 
+	BUG_ON(!xocl_mm && !xocl_mm->mm);
 	start_addr = grp_topology->m_mem_data[mem_id].m_base_address;
 	end_addr = start_addr + grp_topology->m_mem_data[mem_id].m_size * 1024;
 
 #if defined(XOCL_DRM_FREE_MALLOC)
-	ret = drm_mm_insert_node_in_range(drm_p->mm, node, size, PAGE_SIZE, 0,
+	ret = drm_mm_insert_node_in_range(xocl_mm->mm, node, size, PAGE_SIZE, 0,
 					   start_addr, end_addr, 0);
 #else
-	ret = drm_mm_insert_node_in_range(drm_p->mm, node, size, PAGE_SIZE,
+	ret = drm_mm_insert_node_in_range(xocl_mm->mm, node, size, PAGE_SIZE,
 					   start_addr, end_addr, 0);
 #endif
 
 	return ret;
 }
 
-int xocl_mm_insert_node(struct xocl_drm *drm_p, u32 mem_id,
+int xocl_mm_insert_node(struct xocl_drm *drm_p, unsigned user_flags,
 			struct drm_mm_node *node, u64 size)
 {
 	int ret = 0;
+	struct xocl_mem_stat *curr_mem = NULL;
+	unsigned memidx = xocl_bo_ddr_idx(user_flags);
+	unsigned slotidx = xocl_bo_slot_idx(user_flags);
 	struct mem_topology *grp_topology = NULL;
 	
 	BUG_ON(!mutex_is_locked(&drm_p->mm_lock));
-        if (drm_p->mm == NULL)
+        if (drm_p->xocl_mm->mm == NULL)
                 return -EINVAL;
 
 	ret = XOCL_GET_GROUP_TOPOLOGY(drm_p->xdev, grp_topology);
         if (ret)
                 return 0;
 
-	if (grp_topology->m_mem_data[mem_id].m_type == MEM_PS_KERNEL) {
-		ret = xocl_mm_insert_node_range_all(drm_p, mem_id, 
+	if (grp_topology->m_mem_data[memidx].m_type == MEM_PS_KERNEL) {
+		ret = xocl_mm_insert_node_range_all(drm_p, &memidx,
 				grp_topology, node, size);
 	}
 	else {
-		ret = xocl_mm_insert_node_range(drm_p, mem_id,
+		ret = xocl_mm_insert_node_range(drm_p, memidx,
 				grp_topology, node, size);
 	}
 
         XOCL_PUT_GROUP_TOPOLOGY(drm_p->xdev);
-        return ret;
+	if (!ret) {
+		/* Update memory manager stats for whole device */
+		xocl_mm_update_usage_stat(drm_p,
+				memidx, size, 1);
+		/* Update slot specific stats */
+		list_for_each_entry(curr_mem, &drm_p->mem_list_head, link) {
+			if ((slotidx == curr_mem->slot_idx) &&
+					(memidx == curr_mem->mem_idx)) {
+				curr_mem->mm_usage_stat.memory_usage += size;
+				curr_mem->mm_usage_stat.bo_count += 1;
+			}
+		}
+	}
 
+        return ret;
 }
 
 int xocl_check_topology(struct xocl_drm *drm_p)
 {
-	struct mem_topology    *group_topology = NULL;
-	int32_t	i;
-	int	err = 0;
+	struct xocl_mem_stat *curr_mem = NULL;
+	int err = 0;
+	uint32_t slot_id = 0;
 
-	err = XOCL_GET_GROUP_TOPOLOGY(drm_p->xdev, group_topology);
-	if (err)
+	if (list_empty(&drm_p->mem_list_head))
 		return 0;
 
-	if (group_topology == NULL)
-		goto done;
-
-	if (!drm_p->mm_usage_stat)
-		goto done;
-
-	for (i = 0; i < group_topology->m_count; i++) {
-		if (!group_topology->m_mem_data[i].m_used)
+	list_for_each_entry(curr_mem, &drm_p->mem_list_head, link) {
+		if (slot_id != curr_mem->slot_idx)
 			continue;
 
-		if (XOCL_IS_STREAM(group_topology, i))
-			continue;
-
-		if (!drm_p->mm_usage_stat[i])
-			continue;
-
-		if (drm_p->mm_usage_stat[i]->bo_count != 0) {
+		if (curr_mem->mm_usage_stat.bo_count != 0) {
 			err = -EPERM;
 			xocl_err(drm_p->ddev->dev,
-				 "The ddr %d has pre-existing buffer allocations, please exit and re-run.",
-				 i);
+				"The ddr %d has pre-existing buffer allocations,"
+				" for slot %d, please exit and re-run.",
+				 curr_mem->mem_idx, curr_mem->slot_idx);
 		}
 	}
 
-done:
-	XOCL_PUT_GROUP_TOPOLOGY(drm_p->xdev);
 	return err;
-}
-
-static uint32_t xocl_get_shared_ddr(struct xocl_drm *drm_p, struct mem_data *m_data)
-{
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 7, 0)
-	struct xocl_mm_wrapper *wrapper = NULL;
-	uint64_t start_addr = m_data->m_base_address;
-	uint64_t sz = m_data->m_size*1024;
-
-	BUG_ON(!drm_p->mm_range);
-	BUG_ON(!m_data);
-
-	hash_for_each_possible(drm_p->mm_range, wrapper, node, start_addr) {
-		if (wrapper->start_addr == start_addr) {
-			if (wrapper->size == sz)
-				return wrapper->ddr;
-			else
-				return 0xffffffff;
-		}
-	}
-#endif
-	return 0xffffffff;
 }
 
 int xocl_cleanup_mem_nolock(struct xocl_drm *drm_p)
 {
 	int err;
-	struct mem_topology *topology = NULL;
 	struct mem_topology *group_topology = NULL;
-	int32_t i, ddr;
-	uint64_t addr;
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 7, 0)
-	struct xocl_mm_wrapper *wrapper;
-	struct hlist_node *tmp;
-#endif
+	struct xocl_mem_stat *curr_mem = NULL;
+        struct xocl_mem_stat *next = NULL;
+	uint32_t slot_id = 0; // Default slot till multi slot support added
 
 	BUG_ON(!mutex_is_locked(&drm_p->mm_lock));
 
-	if (drm_p->bo_usage_stat) {
-		vfree(drm_p->bo_usage_stat);
-		drm_p->bo_usage_stat = NULL;
-	}
 	err = xocl_check_topology(drm_p);
 	if (err)
 		return err;
 
-	err = XOCL_GET_MEM_TOPOLOGY(drm_p->xdev, topology);
-	if (err)
-		goto done;
-
-	if (topology) {
-		xocl_p2p_mem_cleanup(drm_p->xdev);
-		ddr = topology->m_count;
-		for (i = 0; i < ddr; i++) {
-			if (!topology->m_mem_data[i].m_used)
-				continue;
-
-			if (XOCL_IS_STREAM(topology, i))
-				continue;
-
-			if (convert_mem_tag(topology->m_mem_data[i].m_tag) == MEM_TAG_HOST)
-				xocl_addr_translator_clean(drm_p->xdev);
-
-			xocl_info(drm_p->ddev->dev, "Taking down DDR : %d", i);
-			addr = topology->m_mem_data[i].m_base_address;
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 7, 0)
-			hash_for_each_possible_safe(drm_p->mm_range, wrapper,
-					tmp, node, addr) {
-				if (wrapper->ddr != i)
-					continue;
-				hash_del(&wrapper->node);
-				vfree(wrapper);
-			}
-#endif
-		}
-	}
-	XOCL_PUT_MEM_TOPOLOGY(drm_p->xdev);
-
-	/* Cleanup stats based on group_topology */
+	/* Cleanup stats memory based on group_topology */
 	err = XOCL_GET_GROUP_TOPOLOGY(drm_p->xdev, group_topology);
 	if (err)
 		goto done;
 
 	if (group_topology) {
-		for (i = 0; i < group_topology->m_count; i++) {
-			if (!group_topology->m_mem_data[i].m_used)
+		if (list_empty(&drm_p->mem_list_head))
+			goto done;
+
+		list_for_each_entry_safe(curr_mem, next, &drm_p->mem_list_head,
+				link) {
+			if (slot_id != curr_mem->slot_idx)
 				continue;
 
-			if (XOCL_IS_STREAM(group_topology, i))
-				continue;
-
-			if (drm_p->mm_usage_stat && drm_p->mm_usage_stat[i]) {
-				vfree(drm_p->mm_usage_stat[i]);
-				drm_p->mm_usage_stat[i] = NULL;
-			}
+			list_del(&curr_mem->link);
+			vfree(curr_mem);
 		}
-		vfree(drm_p->mm_usage_stat);
-		drm_p->mm_usage_stat = NULL;
 	}
+	
 	XOCL_PUT_GROUP_TOPOLOGY(drm_p->xdev);
-done:
-	if (drm_p->mm) {
-		drm_mm_takedown(drm_p->mm);
-	vfree(drm_p->mm);
-	}
-	drm_p->mm = NULL;
 
+done:
 	return 0;
 }
 
@@ -928,19 +867,231 @@ int xocl_cleanup_mem(struct xocl_drm *drm_p)
 	return ret;
 }
 
+static int xocl_cleanup_memory_manager(struct xocl_drm *drm_p)
+{
+	struct mem_topology *topo = NULL;
+	struct xocl_mm *xocl_mm = drm_p->xocl_mm;
+	struct mem_data *mem_data = NULL;
+	int err = 0;
+	int i = 0;
+
+	if (!xocl_mm)
+		return 0;
+
+	mutex_lock(&drm_p->mm_lock);
+
+	err = xocl_check_topology(drm_p);
+	if (err) {
+		mutex_unlock(&drm_p->mm_lock);
+		return err;
+	}
+
+        err = XOCL_GET_MEM_TOPOLOGY(drm_p->xdev, topo);
+        if (err) {
+		mutex_unlock(&drm_p->mm_lock);
+		return err;
+	}
+
+	if (topo) {
+		for (i = 0; i < topo->m_count; i++) {
+			mem_data = &topo->m_mem_data[i];
+			if (XOCL_IS_STREAM(topo, i))
+				continue;
+
+			if (XOCL_IS_PS_KERNEL_MEM(topo, i))
+				continue;
+
+			if (!is_mem_region_valid(drm_p, mem_data))
+				continue;
+
+			if (convert_mem_tag(topo->m_mem_data[i].m_tag) == MEM_TAG_HOST)
+                                xocl_addr_translator_clean(drm_p->xdev);
+
+			if (xocl_mm->mm_usage_stat && xocl_mm->mm_usage_stat[i]) {
+				vfree(xocl_mm->mm_usage_stat[i]);
+				xocl_mm->mm_usage_stat[i] = NULL;
+			}
+
+                        xocl_info(drm_p->ddev->dev, "Taking down DDR : %d", i);
+                }
+
+		vfree(xocl_mm->mm_usage_stat);
+		xocl_mm->mm_usage_stat = NULL;
+		
+		if (xocl_mm->bo_usage_stat) {
+			vfree(xocl_mm->bo_usage_stat);
+			xocl_mm->bo_usage_stat = NULL;
+		}
+        }
+        XOCL_PUT_MEM_TOPOLOGY(drm_p->xdev);
+
+	/* Now cleanup the P2P memory */
+        xocl_p2p_mem_cleanup(drm_p->xdev);
+
+        /* cleanup the memory manager */
+        if (xocl_mm && xocl_mm->mm) {
+                drm_mm_takedown(xocl_mm->mm);
+		vfree(xocl_mm->mm);
+		vfree(xocl_mm);
+		drm_p->xocl_mm = NULL;		
+	}
+		
+	mutex_unlock(&drm_p->mm_lock);
+
+        return 0;
+}
+
+static int xocl_init_memory_manager(struct xocl_drm *drm_p)
+{
+	struct mem_topology *topo = NULL;
+	struct xocl_mm *xocl_mm = NULL;
+	struct mem_data *mem_data = NULL;
+        uint64_t mm_start_addr = 0;
+        uint64_t mm_end_addr = 0;
+	size_t ddr_bank_size = 0;
+	size_t size = 0;
+	int err = 0;
+	int i = 0;
+
+	/* Memory manager initialize should be done only once */
+        if (drm_p->xocl_mm)
+                return 0; // Memory manager is already initialized
+
+	mutex_lock(&drm_p->mm_lock);
+        err = xocl_p2p_mem_init(drm_p->xdev);
+        if (err && err != -ENODEV) {
+		mutex_unlock(&drm_p->mm_lock);
+                xocl_err(drm_p->ddev->dev,
+                        "init p2p mem failed, err %d", err);
+                return err;
+        }
+        err = 0;
+
+	xocl_mm = vzalloc(sizeof(struct xocl_mm));
+        if (!xocl_mm) {
+		mutex_unlock(&drm_p->mm_lock);
+                return -ENOMEM;
+	}
+
+	err = XOCL_GET_MEM_TOPOLOGY(drm_p->xdev, topo);
+	if (err) {
+		mutex_unlock(&drm_p->mm_lock);
+		return err;
+	}
+
+	size = topo->m_count * sizeof(void *);
+	xocl_mm->mm_usage_stat = vzalloc(size);
+        if (!xocl_mm->mm_usage_stat) {
+                err = -ENOMEM;
+                goto error;
+        }
+
+	/* Initialize memory status for the memory manager */
+	xocl_mm->bo_usage_stat = vzalloc(XOCL_BO_USAGE_TOTAL *
+			sizeof(struct drm_xocl_mm_stat));
+	if (!xocl_mm->bo_usage_stat) {
+		err = -ENOMEM;
+		goto error;
+	}
+
+	/* Initialize with max and min possible value */
+        mm_start_addr = 0xffffFFFFffffFFFF;
+        mm_end_addr = 0;
+
+        /* Initialize all the banks and their sizes */
+        /* Currently only fixed sizes are supported */
+        for (i = 0; i < topo->m_count; i++) {
+                mem_data = &topo->m_mem_data[i];
+                ddr_bank_size = mem_data->m_size * 1024;
+
+                if (XOCL_IS_P2P_MEM(topo, i)) {
+                        if (mem_data->m_used) {
+                                xocl_p2p_mem_map(drm_p->xdev,
+                                    mem_data->m_base_address,
+                                    ddr_bank_size, 0, 0, NULL);
+                        } else {
+                                xocl_p2p_mem_map(drm_p->xdev, ~0UL,
+                                     ddr_bank_size, 0, 0, NULL);
+                        }
+                }
+
+		if (XOCL_IS_STREAM(topo, i))
+                        continue;
+
+                if (XOCL_IS_PS_KERNEL_MEM(topo, i))
+                        continue;
+
+                if (!is_mem_region_valid(drm_p, mem_data))
+                        continue;
+
+		xocl_mm->mm_usage_stat[i] = vzalloc(sizeof(struct drm_xocl_mm_stat));
+                if (!xocl_mm->mm_usage_stat[i]) {
+                        err = -ENOMEM;
+                        goto error;
+                }
+
+                /* Update the start and end address for the memory manager */
+                if (mem_data->m_base_address < mm_start_addr)
+                        mm_start_addr = mem_data->m_base_address;
+                if ((mem_data->m_base_address + ddr_bank_size) > mm_end_addr)
+                        mm_end_addr = mem_data->m_base_address + ddr_bank_size;
+
+		if (convert_mem_tag(mem_data->m_tag) == MEM_TAG_HOST) {
+			drm_p->cma_bank_idx = i;
+			err = xocl_set_cma_bank(drm_p, mem_data->m_base_address, ddr_bank_size);
+			if (err) {
+				xocl_err(drm_p->ddev->dev, 
+					"Run host_mem to setup host memory access, request 0x%lx bytes",
+					ddr_bank_size);
+				goto error;
+			}
+		}
+	}
+
+        /* Initialize the memory manager */
+        xocl_mm->mm = vzalloc(sizeof(struct drm_mm));
+        if (!xocl_mm->mm) {
+                err = -ENOMEM;
+                goto error;
+        }
+
+        drm_mm_init(xocl_mm->mm, mm_start_addr, (mm_end_addr - mm_start_addr));
+	if (!xocl_mm->mm) {
+                xocl_err(drm_p->ddev->dev,
+                        "init memory manager failed");
+                err = -EINVAL;
+                goto error;
+	}
+
+        xocl_mm->start_addr = mm_start_addr;
+        xocl_mm->end_addr = mm_end_addr;
+
+        xocl_info(drm_p->ddev->dev, "drm_mm_init called for the available memory range"
+			" <%llx - %llx>", mm_start_addr, mm_end_addr);
+
+        drm_p->xocl_mm = xocl_mm;
+	
+	XOCL_PUT_MEM_TOPOLOGY(drm_p->xdev);
+        mutex_unlock(&drm_p->mm_lock);
+
+	return 0;
+
+error:
+	XOCL_PUT_MEM_TOPOLOGY(drm_p->xdev);
+	mutex_unlock(&drm_p->mm_lock);
+
+	if (err)
+	       xocl_cleanup_memory_manager(drm_p);	
+
+	return err;
+}
+
 int xocl_init_mem(struct xocl_drm *drm_p)
 {
-	size_t length = 0;
-	size_t mm_stat_size = 0;
-	size_t size = 0, wrapper_size = 0;
 	size_t ddr_bank_size;
-	struct mem_topology *topo = NULL;
 	struct mem_topology *group_topo = NULL;
-	struct mem_data *mem_data;
-	uint32_t shared;
-	struct xocl_mm_wrapper *wrapper = NULL;
-	uint64_t mm_start_addr = 0;
-	uint64_t mm_end_addr = 0;
+	struct xocl_mem_stat *mem_stat = NULL;
+	struct mem_data *mem_data = NULL;
 	uint64_t reserved1 = 0;
 	uint64_t reserved2 = 0;
 	uint64_t reserved_start;
@@ -954,184 +1105,72 @@ int xocl_init_mem(struct xocl_drm *drm_p)
 		reserved2 = 0x1000000;
 	}
 
-	err = XOCL_GET_MEM_TOPOLOGY(drm_p->xdev, topo);
+	/* Initialize the memory manager  */
+	err = xocl_init_memory_manager(drm_p);
 	if (err)
 		return err;
 
-	if (topo == NULL) {
-		err = -ENODEV;
-		XOCL_PUT_MEM_TOPOLOGY(drm_p->xdev);
-		return err;
-	}
-
-	length = topo->m_count * sizeof(struct mem_data);
-	wrapper_size = sizeof(struct xocl_mm_wrapper);
-	mm_stat_size = sizeof(struct drm_xocl_mm_stat);
-	xocl_info(drm_p->ddev->dev, "Topology count = %d, data_length = %ld",
-		topo->m_count, length);
-
 	mutex_lock(&drm_p->mm_lock);
 
-	err = xocl_p2p_mem_init(drm_p->xdev);
-	if (err && err != -ENODEV) {
-		xocl_err(drm_p->ddev->dev,
-			"init p2p mem failed, err %d", err);
-		goto done;
-	}
-	err = 0;
-
-	/* Initialize memory stats based on Group topology */
+	/* Initialize memory stats based on Group topology for this xclbin */
 	err = XOCL_GET_GROUP_TOPOLOGY(drm_p->xdev, group_topo);
 	if (err) {
-		XOCL_PUT_MEM_TOPOLOGY(drm_p->xdev);
 		mutex_unlock(&drm_p->mm_lock);
 		return err;
-	}
-
-	if (group_topo == NULL) {
-		err = -ENODEV;
-		XOCL_PUT_MEM_TOPOLOGY(drm_p->xdev);
-		XOCL_PUT_GROUP_TOPOLOGY(drm_p->xdev);
-		mutex_unlock(&drm_p->mm_lock);
-		return err;
-	}
-
-	size = group_topo->m_count * sizeof(void *);
-	drm_p->mm_usage_stat = vzalloc(size);
-	if (!drm_p->mm_usage_stat) {
-		err = -ENOMEM;
-		XOCL_PUT_GROUP_TOPOLOGY(drm_p->xdev);
-		goto done;
-	}
-
-	drm_p->bo_usage_stat = vzalloc(XOCL_BO_USAGE_TOTAL * sizeof(struct drm_xocl_mm_stat));
-	if (!drm_p->bo_usage_stat) {
-		err = -ENOMEM;
-		XOCL_PUT_GROUP_TOPOLOGY(drm_p->xdev);
-		goto done;
 	}
 
 	drm_p->cma_bank_idx = -1;
 	for (i = 0; i < group_topo->m_count; i++) {
 		mem_data = &group_topo->m_mem_data[i];
 		ddr_bank_size = mem_data->m_size * 1024;
-		xocl_info(drm_p->ddev->dev, "  Memory Bank: %s", mem_data->m_tag);
+		xocl_info(drm_p->ddev->dev, "Memory Bank: %s", mem_data->m_tag);
 		xocl_info(drm_p->ddev->dev, "  Base Address:0x%llx",
 			mem_data->m_base_address);
 		xocl_info(drm_p->ddev->dev, "  Size:0x%lx", ddr_bank_size);
 		xocl_info(drm_p->ddev->dev, "  Type:%d", mem_data->m_type);
 		xocl_info(drm_p->ddev->dev, "  Used:%d", mem_data->m_used);
-		if (convert_mem_tag(mem_data->m_tag) == MEM_TAG_HOST)
-			drm_p->cma_bank_idx = i;
-
-		if (!group_topo->m_mem_data[i].m_used)
+		
+		if (!mem_data->m_used)
 			continue;
 
 		if (XOCL_IS_STREAM(group_topo, i))
 			continue;
 
-		drm_p->mm_usage_stat[i] = vzalloc(mm_stat_size);
-		if (!drm_p->mm_usage_stat[i]) {
-			err = -ENOMEM;
-			XOCL_PUT_GROUP_TOPOLOGY(drm_p->xdev);
-			goto done;
-		}
-	}
-
-	XOCL_PUT_GROUP_TOPOLOGY(drm_p->xdev);
-	/* Initialize with max and min possible value */
-	mm_start_addr = 0xffffFFFFffffFFFF;
-	mm_end_addr = 0;
-
-	/* Initialize the used banks and their sizes */
-	/* Currently only fixed sizes are supported */
-	for (i = 0; i < topo->m_count; i++) {
-		mem_data = &topo->m_mem_data[i];
-		ddr_bank_size = mem_data->m_size * 1024;
-
-		if (XOCL_IS_P2P_MEM(topo, i)) {
-			if (mem_data->m_used) {
-				xocl_p2p_mem_map(drm_p->xdev,
-				    mem_data->m_base_address,
-				    ddr_bank_size, 0, 0, NULL);
-			} else {
-				xocl_p2p_mem_map(drm_p->xdev, ~0UL,
-				     ddr_bank_size, 0, 0, NULL);
-			}
-		}
-
-		if (!mem_data->m_used)
-			continue;
-
-		if (XOCL_IS_STREAM(topo, i))
-			continue;
-
-		if (XOCL_IS_PS_KERNEL_MEM(topo, i))
+		if (XOCL_IS_PS_KERNEL_MEM(group_topo, i))
 			continue;
 
 		if (!is_mem_region_valid(drm_p, mem_data))
 			continue;
 
-		xocl_info(drm_p->ddev->dev, "Allocating Memory Bank: %s", mem_data->m_tag);
-		xocl_info(drm_p->ddev->dev, "  base_addr:0x%llx, total size:0x%lx",
+		xocl_info(drm_p->ddev->dev, "   Initializing Memory Bank: %s", mem_data->m_tag);
+		xocl_info(drm_p->ddev->dev, "    base_addr:0x%llx, total size:0x%lx",
 			mem_data->m_base_address, ddr_bank_size);
-
-		/* Update the start and end address for the memory manager */
-		if (mem_data->m_base_address < mm_start_addr)
-			mm_start_addr = mem_data->m_base_address;
-		if ((mem_data->m_base_address + ddr_bank_size) > mm_end_addr)
-			mm_end_addr = mem_data->m_base_address + ddr_bank_size;
-
+		
 		if (XOCL_DSA_IS_MPSOC(drm_p->xdev)) {
 			reserved_end = mem_data->m_base_address + ddr_bank_size;
 			reserved_start = reserved_end - reserved1 - reserved2;
 			xocl_info(drm_p->ddev->dev, "  reserved region:0x%llx - 0x%llx",
 				reserved_start, reserved_end - 1);
 		}
-
-		shared = xocl_get_shared_ddr(drm_p, mem_data);
-		if (shared != 0xffffffff) {
-			xocl_info(drm_p->ddev->dev, "Found duplicated memory region!");
-			continue;
-		}
-
-		xocl_info(drm_p->ddev->dev, "Found a new memory region");
-		wrapper = vzalloc(wrapper_size);
-		if (!wrapper) {
+	
+		mem_stat = vzalloc(sizeof(struct xocl_mem_stat));
+		if (!mem_stat) {
 			err = -ENOMEM;
 			goto done;
 		}
 
-		wrapper->start_addr = mem_data->m_base_address;
-		wrapper->size = mem_data->m_size*1024;
-		wrapper->ddr = i;
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 7, 0)
-		hash_add(drm_p->mm_range, &wrapper->node, wrapper->start_addr);
-#endif
-
-		if (convert_mem_tag(mem_data->m_tag) == MEM_TAG_HOST) {
-			err = xocl_set_cma_bank(drm_p, mem_data->m_base_address, ddr_bank_size);
-			if (err) {
-				xocl_err(drm_p->ddev->dev, "Run host_mem to setup host memory access, request 0x%lx bytes", ddr_bank_size);
-				goto done;
-			}
-		}
+		mem_stat->mem_idx = i;
+		mem_stat->slot_idx = 0; // Default slot id
+		list_add_tail(&mem_stat->link, &drm_p->mem_list_head);
 	}
-
-    drm_p->mm = vzalloc(sizeof(struct drm_mm));
-	if (!drm_p->mm) {
-		err = -ENOMEM;
-		goto done;
-	}
-
-    drm_mm_init(drm_p->mm, mm_start_addr, (mm_end_addr - mm_start_addr));
-    xocl_info(drm_p->ddev->dev, "drm_mm_init called for the available memory range");
 
 done:
+	XOCL_PUT_GROUP_TOPOLOGY(drm_p->xdev);
 	if (err)
 		xocl_cleanup_mem_nolock(drm_p);
-	XOCL_PUT_MEM_TOPOLOGY(drm_p->xdev);
+
 	mutex_unlock(&drm_p->mm_lock);
 	xocl_info(drm_p->ddev->dev, "ret %d", err);
+	
 	return err;
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
@@ -641,26 +641,42 @@ void xocl_mm_get_usage_stat(struct xocl_drm *drm_p, u32 ddr,
 	struct drm_xocl_mm_stat *pstat)
 {
 	struct xocl_mm *xocl_mm = drm_p->xocl_mm;
+	struct drm_xocl_mm_stat *mm_stat = NULL;
 
-	if (!xocl_mm && !xocl_mm->mm_usage_stat)
+	if (!xocl_mm) {
+        xocl_err(drm_p->ddev->dev, "Invalid memory manager");
 		return;
+	}
 
-	pstat->memory_usage = xocl_mm->mm_usage_stat[ddr] ?
-		xocl_mm->mm_usage_stat[ddr]->memory_usage : 0;
-	pstat->bo_count = xocl_mm->mm_usage_stat[ddr] ?
-		xocl_mm->mm_usage_stat[ddr]->bo_count : 0;
+	if (!pstat) {
+        xocl_err(drm_p->ddev->dev, "Invalid memory stats");
+		return;
+	}
+
+	mm_stat = xocl_mm->mm_usage_stat[ddr];
+	pstat->memory_usage = mm_stat ? mm_stat->memory_usage : 0;
+	pstat->bo_count = mm_stat ? mm_stat->bo_count : 0;
 }
 
 void xocl_mm_update_usage_stat(struct xocl_drm *drm_p, u32 ddr,
 	u64 size, int count)
 {
 	struct xocl_mm *xocl_mm = drm_p->xocl_mm;
+	struct drm_xocl_mm_stat *mm_stat = NULL;
 
-	BUG_ON(!xocl_mm && !xocl_mm->mm_usage_stat[ddr]);
+	if (!xocl_mm) {
+        xocl_err(drm_p->ddev->dev, "Invalid memory manager");
+		return;
+	}
 
-	xocl_mm->mm_usage_stat[ddr]->memory_usage +=
-		(count > 0) ? size : -size;
-	xocl_mm->mm_usage_stat[ddr]->bo_count += count;
+	mm_stat = xocl_mm->mm_usage_stat[ddr];
+	if (!mm_stat) {
+        xocl_err(drm_p->ddev->dev, "Invalid memory stats");
+		return;
+	}
+
+	mm_stat->memory_usage += (count > 0) ? size : -size;
+	mm_stat->bo_count += count;
 }
 
 static int xocl_mm_insert_node_range_all(struct xocl_drm *drm_p, uint32_t *mem_id,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
@@ -663,12 +663,12 @@ void xocl_mm_get_usage_stat(struct xocl_drm *drm_p, u32 ddr,
 	struct drm_xocl_mm_stat *mm_stat = NULL;
 
 	if (!xocl_mm) {
-        xocl_err(drm_p->ddev->dev, "Invalid memory manager");
+        	xocl_err(drm_p->ddev->dev, "Invalid memory manager");
 		return;
 	}
 
 	if (!pstat) {
-        xocl_err(drm_p->ddev->dev, "Invalid memory stats");
+        	xocl_err(drm_p->ddev->dev, "Invalid memory stats");
 		return;
 	}
 
@@ -684,13 +684,13 @@ void xocl_mm_update_usage_stat(struct xocl_drm *drm_p, u32 ddr,
 	struct drm_xocl_mm_stat *mm_stat = NULL;
 
 	if (!xocl_mm) {
-        xocl_err(drm_p->ddev->dev, "Invalid memory manager");
+        	xocl_err(drm_p->ddev->dev, "Invalid memory manager");
 		return;
 	}
 
 	mm_stat = xocl_mm->mm_usage_stat[ddr];
 	if (!mm_stat) {
-        xocl_err(drm_p->ddev->dev, "Invalid memory stats");
+        	xocl_err(drm_p->ddev->dev, "Invalid memory stats");
 		return;
 	}
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
@@ -750,13 +750,11 @@ static int xocl_mm_insert_node_range(struct xocl_drm *drm_p, u32 mem_id,
 	return ret;
 }
 
-int xocl_mm_insert_node(struct xocl_drm *drm_p, unsigned user_flags,
-			struct drm_mm_node *node, u64 size)
+int xocl_mm_insert_node(struct xocl_drm *drm_p, unsigned memidx,
+			uint32_t slotidx, struct drm_mm_node *node, u64 size)
 {
 	int ret = 0;
 	struct xocl_mem_stat *curr_mem = NULL;
-	unsigned memidx = xocl_bo_ddr_idx(user_flags);
-	unsigned slotidx = xocl_bo_slot_idx(user_flags);
 	struct mem_topology *grp_topology = NULL;
 	
 	BUG_ON(!mutex_is_locked(&drm_p->mm_lock));

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
@@ -619,6 +619,11 @@ void *xocl_drm_init(xdev_handle_t xdev_hdl)
 	}
 
         drm_p->cma_bank_idx = -1;
+	/* Memory manager initialization is done in two phase. 
+	 * Phase 1 is done based on platform and Phase 2 is done 
+	 * based on XCLBIN. We have done phase 1 here.
+	 */
+        drm_p->xocl_mm_done = false;
 
 	return drm_p;
 
@@ -911,6 +916,75 @@ static int xocl_cleanup_drm_memory_manager(struct xocl_mm *xocl_mm)
 	return 0;
 }
 
+static int xocl_init_drm_mm(struct xocl_drm *drm_p, uint64_t mm_start_addr,
+		uint64_t mm_end_addr, uint32_t m_count)
+{
+	struct xocl_mm *xocl_mm = NULL;
+	size_t size = 0;
+	int err = 0;
+	int i = 0;
+	
+	BUG_ON(!mutex_is_locked(&drm_p->mm_lock));
+
+	xocl_mm = vzalloc(sizeof(struct xocl_mm));
+	if (!xocl_mm) {
+		return -ENOMEM;
+	}
+
+	size = m_count * sizeof(void *);
+	xocl_mm->mm_usage_stat = vzalloc(size);
+	if (!xocl_mm->mm_usage_stat) {
+		err = -ENOMEM;
+		goto error;
+	}
+
+	/* Initialize memory status for the memory manager */
+	xocl_mm->bo_usage_stat = vzalloc(XOCL_BO_USAGE_TOTAL *
+			sizeof(struct drm_xocl_mm_stat));
+	if (!xocl_mm->bo_usage_stat) {
+		err = -ENOMEM;
+		goto error;
+	}
+
+	for (i = 0; i < m_count; i++) {
+		xocl_mm->mm_usage_stat[i] = vzalloc(sizeof(struct drm_xocl_mm_stat));
+		if (!xocl_mm->mm_usage_stat[i]) {
+			err = -ENOMEM;
+			goto error;
+		}
+	}
+
+	/* Initialize the memory manager */
+	xocl_mm->mm = vzalloc(sizeof(struct drm_mm));
+	if (!xocl_mm->mm) {
+		err = -ENOMEM;
+		goto error;
+	}
+
+	drm_mm_init(xocl_mm->mm, mm_start_addr, (mm_end_addr - mm_start_addr));
+	if (!xocl_mm->mm) {
+		xocl_err(drm_p->ddev->dev,
+				"init memory manager failed");
+		err = -EINVAL;
+		goto error;
+	}
+
+	xocl_mm->start_addr = mm_start_addr;
+	xocl_mm->end_addr = mm_end_addr;
+	xocl_mm->m_count = m_count;
+
+	xocl_info(drm_p->ddev->dev, "drm_mm_init called for the available memory range"
+			" <%llx - %llx>", mm_start_addr, mm_end_addr);
+
+	drm_p->xocl_mm = xocl_mm;
+
+	return 0;
+
+error:
+	xocl_cleanup_drm_memory_manager(xocl_mm);
+	return err;
+}
+
 static int xocl_init_drm_memory_manager(struct xocl_drm *drm_p)
 {
         struct xocl_dev *xdev = drm_p->xdev;
@@ -922,8 +996,6 @@ static int xocl_init_drm_memory_manager(struct xocl_drm *drm_p)
         const char *ipname;
         uint64_t mm_start_addr = 0;
         uint64_t mm_end_addr = 0;
-	size_t size = 0;
-	int i = 0;
         int err = 0;
 
         blob = XDEV(xdev)->fdt_blob;
@@ -969,54 +1041,12 @@ static int xocl_init_drm_memory_manager(struct xocl_drm *drm_p)
                 return 0;
 	}
 
-	size = xocl_mm->m_count * sizeof(void *);
-	xocl_mm->mm_usage_stat = vzalloc(size);
-        if (!xocl_mm->mm_usage_stat) {
-                err = -ENOMEM;
-                goto error;
-        }
-
-	/* Initialize memory status for the memory manager */
-	xocl_mm->bo_usage_stat = vzalloc(XOCL_BO_USAGE_TOTAL *
-			sizeof(struct drm_xocl_mm_stat));
-	if (!xocl_mm->bo_usage_stat) {
-		err = -ENOMEM;
-		goto error;
+	if (drm_p->xocl_mm == NULL) {
+		err = xocl_init_drm_mm(drm_p, mm_start_addr, mm_end_addr,
+				xocl_mm->m_count);
+		if (err)
+			goto error;
 	}
-
-        /* Initialize all the banks and their sizes */
-        /* Currently only fixed sizes are supported */
-        for (i = 0; i < xocl_mm->m_count; i++) {
-		xocl_mm->mm_usage_stat[i] = vzalloc(sizeof(struct drm_xocl_mm_stat));
-                if (!xocl_mm->mm_usage_stat[i]) {
-                        err = -ENOMEM;
-                        goto error;
-                }
-	}
-
-        /* Initialize the memory manager */
-        xocl_mm->mm = vzalloc(sizeof(struct drm_mm));
-        if (!xocl_mm->mm) {
-                err = -ENOMEM;
-                goto error;
-        }
-
-        drm_mm_init(xocl_mm->mm, mm_start_addr, (mm_end_addr - mm_start_addr));
-	if (!xocl_mm->mm) {
-                xocl_err(drm_p->ddev->dev,
-                        "init memory manager failed");
-                err = -EINVAL;
-                goto error;
-	}
-
-        xocl_mm->start_addr = mm_start_addr;
-        xocl_mm->end_addr = mm_end_addr;
-
-        xocl_info(drm_p->ddev->dev, "drm_mm_init called for the available memory range"
-			" <%llx - %llx>", mm_start_addr, mm_end_addr);
-
-        drm_p->xocl_mm = xocl_mm;
-
 error:
 	if (err)
 		xocl_cleanup_drm_memory_manager(xocl_mm);
@@ -1102,17 +1132,15 @@ static int xocl_cleanup_memory_manager(struct xocl_drm *drm_p)
 static int xocl_init_memory_manager(struct xocl_drm *drm_p)
 {
 	struct mem_topology *topo = NULL;
-	struct xocl_mm *xocl_mm = NULL;
 	struct mem_data *mem_data = NULL;
         uint64_t mm_start_addr = 0;
         uint64_t mm_end_addr = 0;
 	size_t ddr_bank_size = 0;
-	size_t size = 0;
 	int err = 0;
 	int i = 0;
 
 	/* Memory manager initialize should be done only once */
-        if (drm_p->xocl_mm)
+        if (drm_p->xocl_mm_done)
                 return 0; // Memory manager is already initialized
 
 	mutex_lock(&drm_p->mm_lock);
@@ -1125,31 +1153,10 @@ static int xocl_init_memory_manager(struct xocl_drm *drm_p)
         }
         err = 0;
 
-	xocl_mm = vzalloc(sizeof(struct xocl_mm));
-        if (!xocl_mm) {
-		mutex_unlock(&drm_p->mm_lock);
-                return -ENOMEM;
-	}
-
 	err = XOCL_GET_MEM_TOPOLOGY(drm_p->xdev, topo);
 	if (err) {
 		mutex_unlock(&drm_p->mm_lock);
 		return err;
-	}
-
-	size = topo->m_count * sizeof(void *);
-	xocl_mm->mm_usage_stat = vzalloc(size);
-        if (!xocl_mm->mm_usage_stat) {
-                err = -ENOMEM;
-                goto error;
-        }
-
-	/* Initialize memory status for the memory manager */
-	xocl_mm->bo_usage_stat = vzalloc(XOCL_BO_USAGE_TOTAL *
-			sizeof(struct drm_xocl_mm_stat));
-	if (!xocl_mm->bo_usage_stat) {
-		err = -ENOMEM;
-		goto error;
 	}
 
 	/* Initialize with max and min possible value */
@@ -1163,17 +1170,6 @@ static int xocl_init_memory_manager(struct xocl_drm *drm_p)
                 mem_data = &topo->m_mem_data[i];
                 ddr_bank_size = mem_data->m_size * 1024;
 
-                if (XOCL_IS_P2P_MEM(topo, i)) {
-                        if (mem_data->m_used) {
-                                xocl_p2p_mem_map(drm_p->xdev,
-                                    mem_data->m_base_address,
-                                    ddr_bank_size, 0, 0, NULL);
-                        } else {
-                                xocl_p2p_mem_map(drm_p->xdev, ~0UL,
-                                     ddr_bank_size, 0, 0, NULL);
-                        }
-                }
-
 		if (XOCL_IS_STREAM(topo, i))
                         continue;
 
@@ -1182,12 +1178,6 @@ static int xocl_init_memory_manager(struct xocl_drm *drm_p)
 
                 if (!is_mem_region_valid(drm_p, mem_data))
                         continue;
-
-		xocl_mm->mm_usage_stat[i] = vzalloc(sizeof(struct drm_xocl_mm_stat));
-                if (!xocl_mm->mm_usage_stat[i]) {
-                        err = -ENOMEM;
-                        goto error;
-                }
 
                 /* Update the start and end address for the memory manager */
                 if (mem_data->m_base_address < mm_start_addr)
@@ -1207,32 +1197,15 @@ static int xocl_init_memory_manager(struct xocl_drm *drm_p)
 		}
 	}
 
-        /* Initialize the memory manager */
-        xocl_mm->mm = vzalloc(sizeof(struct drm_mm));
-        if (!xocl_mm->mm) {
-                err = -ENOMEM;
-                goto error;
-        }
-
-        drm_mm_init(xocl_mm->mm, mm_start_addr, (mm_end_addr - mm_start_addr));
-	if (!xocl_mm->mm) {
-                xocl_err(drm_p->ddev->dev,
-                        "init memory manager failed");
-                err = -EINVAL;
-                goto error;
+	if (drm_p->xocl_mm == NULL) {
+		err = xocl_init_drm_mm(drm_p, mm_start_addr, mm_end_addr, topo->m_count);
+		if (err)
+			goto error;
 	}
-
-        xocl_mm->start_addr = mm_start_addr;
-        xocl_mm->end_addr = mm_end_addr;
-	xocl_mm->m_count = topo->m_count;
-
-        xocl_info(drm_p->ddev->dev, "drm_mm_init called for the available memory range"
-			" <%llx - %llx>", mm_start_addr, mm_end_addr);
-
-        drm_p->xocl_mm = xocl_mm;
 
 	XOCL_PUT_MEM_TOPOLOGY(drm_p->xdev);
         mutex_unlock(&drm_p->mm_lock);
+        drm_p->xocl_mm_done = true;
 
 	return 0;
 
@@ -1289,6 +1262,17 @@ int xocl_init_mem(struct xocl_drm *drm_p)
 		xocl_info(drm_p->ddev->dev, "  Type:%d", mem_data->m_type);
 		xocl_info(drm_p->ddev->dev, "  Used:%d", mem_data->m_used);
 		
+		if (XOCL_IS_P2P_MEM(group_topo, i)) {
+			if (mem_data->m_used) {
+				xocl_p2p_mem_map(drm_p->xdev,
+						mem_data->m_base_address,
+						ddr_bank_size, 0, 0, NULL);
+			} else {
+				xocl_p2p_mem_map(drm_p->xdev, ~0UL,
+						ddr_bank_size, 0, 0, NULL);
+			}
+		}
+
 		if (!mem_data->m_used)
 			continue;
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
@@ -740,13 +740,11 @@ static int xocl_mm_insert_node_range(struct xocl_drm *drm_p, u32 mem_id,
 	return ret;
 }
 
-int xocl_mm_insert_node(struct xocl_drm *drm_p, unsigned user_flags,
-			struct drm_mm_node *node, u64 size)
+int xocl_mm_insert_node(struct xocl_drm *drm_p, unsigned memidx,
+			uint32_t slotidx, struct drm_mm_node *node, u64 size)
 {
 	int ret = 0;
 	struct xocl_mem_stat *curr_mem = NULL;
-	unsigned memidx = xocl_bo_ddr_idx(user_flags);
-	unsigned slotidx = xocl_bo_slot_idx(user_flags);
 	struct mem_topology *grp_topology = NULL;
 	
 	BUG_ON(!mutex_is_locked(&drm_p->mm_lock));

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
@@ -930,6 +930,13 @@ static int xocl_init_drm_memory_manager(struct xocl_drm *drm_p)
         if (!blob)
                 return 0;
 
+	mutex_lock(&drm_p->mm_lock);
+	xocl_mm = vzalloc(sizeof(struct xocl_mm));
+        if (!xocl_mm) {
+		mutex_unlock(&drm_p->mm_lock);
+                return -ENOMEM;
+	}
+
         /* Initialize with max and min possible value */
         mm_start_addr = 0xffffFFFFffffFFFF;
         mm_end_addr = 0;
@@ -957,14 +964,9 @@ static int xocl_init_drm_memory_manager(struct xocl_drm *drm_p)
 		++xocl_mm->m_count;
         }
 
-	if (!xocl_mm->m_count)
-                return 0;
-
-	mutex_lock(&drm_p->mm_lock);
-	xocl_mm = vzalloc(sizeof(struct xocl_mm));
-        if (!xocl_mm) {
+	if (!xocl_mm->m_count) {
 		mutex_unlock(&drm_p->mm_lock);
-                return -ENOMEM;
+                return 0;
 	}
 
 	size = xocl_mm->m_count * sizeof(void *);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
@@ -1013,6 +1013,7 @@ static int xocl_init_memory_manager(struct xocl_drm *drm_p)
 	/* Initialize with max and min possible value */
         mm_start_addr = 0xffffFFFFffffFFFF;
         mm_end_addr = 0;
+	drm_p->cma_bank_idx = -1;
 
         /* Initialize all the banks and their sizes */
         /* Currently only fixed sizes are supported */
@@ -1135,7 +1136,6 @@ int xocl_init_mem(struct xocl_drm *drm_p)
 		return err;
 	}
 
-	drm_p->cma_bank_idx = -1;
 	for (i = 0; i < group_topo->m_count; i++) {
 		mem_data = &group_topo->m_mem_data[i];
 		ddr_bank_size = mem_data->m_size * 1024;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
@@ -317,7 +317,8 @@ static int xocl_preserve_mem(struct xocl_drm *drm_p, struct mem_topology *new_to
 	 * Compare MEM_TOPOLOGY previous vs new.
 	 * Ignore this and keep disable preserve_mem if not for aws.
 	 */
-	if (xocl_icap_get_data(xdev, DATA_RETAIN) && (topology != NULL) && drm_p->mm) {
+	if (xocl_icap_get_data(xdev, DATA_RETAIN) && (topology != NULL) &&
+		drm_p->xocl_mm->mm) {
 		if ((size == sizeof_sect(topology, m_mem_data)) &&
 		    !xocl_preserve_memcmp(new_topology, topology, size)) {
 			userpf_info(xdev, "preserving mem_topology.");

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drm.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drm.h
@@ -59,7 +59,8 @@ struct xocl_mm {
 	struct drm_mm           *mm;
 	uint64_t		start_addr;
 	uint64_t		end_addr;
-	
+	uint32_t                m_count;
+
 	/* Array of bo and memory usage stats 
 	 * for whole device memory manager */
 	struct drm_xocl_mm_stat *bo_usage_stat;
@@ -125,8 +126,8 @@ void xocl_mm_get_usage_stat(struct xocl_drm *drm_p, u32 ddr,
 void xocl_mm_update_usage_stat(struct xocl_drm *drm_p, u32 ddr,
         u64 size, int count);
 
-int xocl_mm_insert_node(struct xocl_drm *drm_p, unsigned memidx,
-                uint32_t slotidx, struct drm_mm_node *node, u64 size);
+int xocl_mm_insert_node(struct xocl_drm *drm_p, unsigned user_flags,
+                struct drm_mm_node *node, u64 size);
 
 void *xocl_drm_init(xdev_handle_t xdev);
 void xocl_drm_fini(struct xocl_drm *drm_p);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drm.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drm.h
@@ -54,22 +54,39 @@ struct xocl_cma_bank {
 	struct xocl_cma_memory	cma_mem[1];
 };
 
-struct xocl_drm {
-	xdev_handle_t		xdev;
-	/* memory management */
-	struct drm_device       *ddev;
+struct xocl_mm {
 	/* Memory manager */
 	struct drm_mm           *mm;
-	struct mutex            mm_lock;
-	struct drm_xocl_mm_stat **mm_usage_stat;
-	/* Array of bo usage stats */
+	uint64_t		start_addr;
+	uint64_t		end_addr;
+	
+	/* Array of bo and memory usage stats 
+	 * for whole device memory manager */
 	struct drm_xocl_mm_stat *bo_usage_stat;
+	struct drm_xocl_mm_stat **mm_usage_stat;
+};
+
+struct xocl_mem_stat {
+	struct list_head        link;
+	uint32_t 		mem_idx;
+	uint32_t 		slot_idx;
+	
+	/* Memory usage stats for each memory bank per slot */
+	struct drm_xocl_mm_stat mm_usage_stat;
+};
+
+struct xocl_drm {
+	xdev_handle_t		xdev;
+	struct drm_device       *ddev;
+	struct mutex            mm_lock;
+
+	/* Memory manager */
+	struct xocl_mm		*xocl_mm;
+
+	/* Xocl driver memory list head */
+	struct list_head        mem_list_head;
 
 	int			cma_bank_idx;
-
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 7, 0)
-	DECLARE_HASHTABLE(mm_range, 6);
-#endif
 };
 
 struct drm_xocl_bo {
@@ -108,7 +125,7 @@ void xocl_mm_get_usage_stat(struct xocl_drm *drm_p, u32 ddr,
 void xocl_mm_update_usage_stat(struct xocl_drm *drm_p, u32 ddr,
         u64 size, int count);
 
-int xocl_mm_insert_node(struct xocl_drm *drm_p, u32 ddr,
+int xocl_mm_insert_node(struct xocl_drm *drm_p, unsigned user_flags,
                 struct drm_mm_node *node, u64 size);
 
 void *xocl_drm_init(xdev_handle_t xdev);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drm.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drm.h
@@ -126,8 +126,8 @@ void xocl_mm_get_usage_stat(struct xocl_drm *drm_p, u32 ddr,
 void xocl_mm_update_usage_stat(struct xocl_drm *drm_p, u32 ddr,
         u64 size, int count);
 
-int xocl_mm_insert_node(struct xocl_drm *drm_p, unsigned user_flags,
-                struct drm_mm_node *node, u64 size);
+int xocl_mm_insert_node(struct xocl_drm *drm_p, unsigned memidx,
+                uint32_t slotidx, struct drm_mm_node *node, u64 size);
 
 void *xocl_drm_init(xdev_handle_t xdev);
 void xocl_drm_fini(struct xocl_drm *drm_p);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drm.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drm.h
@@ -125,8 +125,8 @@ void xocl_mm_get_usage_stat(struct xocl_drm *drm_p, u32 ddr,
 void xocl_mm_update_usage_stat(struct xocl_drm *drm_p, u32 ddr,
         u64 size, int count);
 
-int xocl_mm_insert_node(struct xocl_drm *drm_p, unsigned user_flags,
-                struct drm_mm_node *node, u64 size);
+int xocl_mm_insert_node(struct xocl_drm *drm_p, unsigned memidx,
+                uint32_t slotidx, struct drm_mm_node *node, u64 size);
 
 void *xocl_drm_init(xdev_handle_t xdev);
 void xocl_drm_fini(struct xocl_drm *drm_p);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drm.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drm.h
@@ -83,6 +83,7 @@ struct xocl_drm {
 
 	/* Memory manager */
 	struct xocl_mm		*xocl_mm;
+	bool			xocl_mm_done;
 
 	/* Xocl driver memory list head */
 	struct list_head        mem_list_head;


### PR DESCRIPTION
Memory manager changes for multislot support. This PR has following changes:
-> Introduce a memory manager.
   --> Memory manager initialization is done in two phases. memory manager init is done only once for a device.
         --> Phase 1 : In the drm init state, read the memory information from platform. This is done even before first xclbin is 
                               loaded. Here We read all the available banks and create a drm_mm_init for <start_addr - end_addr>.
                               Also allocated memory for all the stats. This phase is required if build in PS kernel is loading first which 
                               doesn't have memory information.
                               
             --> Phase 2 : This is done while first XCLBIN is loading, which has memory topology information. In this phase we also 
                               initialized p2p memory. Some platform doesn't have memory information. For that case Phase 1 is also 
                               done here. Here memory initialization is done based on memory topology.

-> xocl_init_mem is done everytime when a new xclbin is loaded. Now this is a link list which has only stats information and memory is allocated based on the start end address of that bank from memory manager. 

-> Removed wrapper data structure. I believe we don't need this.


![image](https://user-images.githubusercontent.com/54270703/190799567-7d989eb2-6d06-4a48-a3fd-d2e02b514e58.png)


