### PR TITLE
CR-1141332 and CR-1141338: Fix issues in Kernel to Global Memory data transfer table in profile summary

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info/pl_constructs.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info/pl_constructs.cpp
@@ -21,6 +21,83 @@
 
 #include "xdp/profile/database/static_info/pl_constructs.h"
 
+// Anonymous namespace for local static helper functions
+namespace {
+
+  // This function will check if the spTag a particular port or argument
+  // is connected to belongs to a particular memory resource.  If the strings
+  // are an exact match, or if the memory resource is a range that the
+  // spTag is a part of, we return true.
+  static bool compare(const std::string& spTag, const std::string& memory)
+  {
+    if (spTag == memory)
+      return true;
+
+    // If it is not an exact match, check to see if there is a range
+    // specification and if the spTag falls in that range.  For example,
+    // PLRAM[2] should match PLRAM[0:2].
+
+    auto bracePosSpTag    = spTag.find("[");
+    auto endBracePosSpTag = spTag.find("]");
+    auto bracePosMem      = memory.find("[");
+    auto endBracePosMem   = memory.find("]");
+
+    // Both the spTag and memory resource must have braces in order
+    if (bracePosSpTag    == std::string::npos ||
+        bracePosMem      == std::string::npos ||
+        endBracePosSpTag == std::string::npos ||
+        endBracePosMem   == std::string::npos)
+      return false;
+
+    // First, make sure the memory type before the brace is the same
+    std::string spResource  = spTag.substr(0, bracePosSpTag);
+    std::string memResource = memory.substr(0, bracePosMem);
+
+    if (spResource != memResource)
+      return false;
+
+    // The two memory types are the same, so we need to check the range.
+    // We are assuming the spTag is a single location and the memory has
+    // the range.
+    std::string spRange = spTag.substr(bracePosSpTag + 1,
+                                       endBracePosSpTag - bracePosSpTag - 1);
+    std::string memRange = memory.substr(bracePosMem + 1,
+                                         endBracePosMem - bracePosMem - 1);
+
+    auto colonPos = memRange.find(":");
+    if (colonPos == std::string::npos)
+      return false;
+
+    int spBank = 0;
+    try {
+      spBank = std::stoi(spRange);
+    } catch (std::exception&) {
+      // If the spRange isn't actually a single integer, an exception
+      // will be thrown and we should just assume the spTag does not match
+      // the memory range
+      return false ;
+    }
+
+    std::string rangeStart = memRange.substr(0, colonPos);
+    std::string rangeEnd = memRange.substr(colonPos + 1);
+
+    int memRangeStart = 0;
+    int memRangeEnd = 0;
+    try {
+      memRangeStart = std::stoi(rangeStart);
+      memRangeEnd = std::stoi(rangeEnd);
+    } catch(std::exception& e) {
+      // The start and/or end of the range aren't well formed integers.  Just
+      // return false then as we cannot compare the range.
+      return false;
+    }
+
+    // If the specified bank is in the range, return true
+    return (spBank >= memRangeStart) && (spBank <= memRangeEnd);
+  }
+
+} // end anonymous namespace
+
 namespace xdp {
 
   void Port::addMemoryConnection(Memory* mem)
@@ -37,7 +114,7 @@ namespace xdp {
     std::string argList = "";
     bool first = true;
     for (auto& arg : args) {
-      if (argToMemory[arg] && argToMemory[arg]->spTag == memoryName) {
+      if (argToMemory[arg] && compare(argToMemory[arg]->spTag, memoryName)) {
         if (!first)
           argList += "|";
         argList += arg;

--- a/src/runtime_src/xdp/profile/database/static_info/pl_constructs.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info/pl_constructs.cpp
@@ -86,7 +86,7 @@ namespace {
     try {
       memRangeStart = std::stoi(rangeStart);
       memRangeEnd = std::stoi(rangeEnd);
-    } catch(std::exception& e) {
+    } catch(std::exception&) {
       // The start and/or end of the range aren't well formed integers.  Just
       // return false then as we cannot compare the range.
       return false;

--- a/src/runtime_src/xdp/profile/writer/vp_base/summary_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/summary_writer.cpp
@@ -1484,7 +1484,7 @@ namespace xdp {
                                               const std::string& args,
                                               const std::string& memoryName,
                                               bool isRead,
-                                              double numTransactions,
+                                              uint64_t numTransactions,
                                               double totalTransferTime,
                                               double bytes,
                                               double maxAchievableBW,
@@ -1505,8 +1505,8 @@ namespace xdp {
     if (idealBW > one_hundred)
       idealBW = one_hundred;
 
-    auto aveSize = (bytes / numTransactions) / one_thousand;
-    auto aveLatency = latency / numTransactions;
+    auto aveSize = (bytes / static_cast<double>(numTransactions)) / one_thousand;
+    auto aveLatency = latency / static_cast<double>(numTransactions);
 
     fout << deviceName << ",";
     fout << cuName << "/" << portName << ",";
@@ -1599,7 +1599,7 @@ namespace xdp {
                                     arguments,
                                     memoryName,
                                     false, // isRead
-                                    static_cast<double>(writeTranx),
+                                    writeTranx,
                                     transferTime,
                                     static_cast<double>(values.WriteBytes[monitorSlot]),
                                     maxAchievableBW,
@@ -1617,7 +1617,7 @@ namespace xdp {
                                     arguments,
                                     memoryName,
                                     true, // isRead
-                                    static_cast<double>(readTranx),
+                                    readTranx,
                                     transferTime,
                                     static_cast<double>(values.ReadBytes[monitorSlot]),
                                     maxAchievableBW,

--- a/src/runtime_src/xdp/profile/writer/vp_base/summary_writer.h
+++ b/src/runtime_src/xdp/profile/writer/vp_base/summary_writer.h
@@ -78,7 +78,7 @@ namespace xdp {
                                  const std::string& args,
                                  const std::string& memoryName,
                                  bool isRead,
-                                 double numTransactions,
+                                 uint64_t numTransactions,
                                  double totalTransferTime,
                                  double bytes,
                                  double maxAchievableBW,


### PR DESCRIPTION
#### Problem solved by the commit
The "Data Transfers: Kernel to Global Memory" table in the profile summary was reporting incorrect numbers for the number of transactions as well as sometimes not showing the argument associated with a set of transfers.  Both of these issues are fixed in this pull request.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
The incorrect number of transactions displayed was due to the number of transactions being treated and output as a double value.  When millions of transactions were recorded, the value was output in exponential notation which was incorrectly parsed by post-processing tools and made it appear that only 1 transaction was recorded.  This was introduced earlier in some refactoring that was done and noticed when a stress test was run.

The issue with the missing argument was due to the code doing a string comparison to see if an argument was going to a memory resource.  The string comparison needed an exact match, so if it was compared to a range of memory resources it would fail even if the memory should have been contained in the range.  The argument missing issue was introduced when the argument matching was moved from being OpenCL specific to all applications.  It was found via internal stress testing.

#### How problem was solved, alternative solutions (if any) and why they were rejected
The first issue was fixed by treating and printing the number of transactions as a uint64_t instead of a double, and explicitly casting it as a double when we need to.

The second issue was fixed by introducing a new function to check if a memory is either the same or is contained in a range.  For example, we now match that DDR[1] is part of DDR[0:2] and add the argument to the table.

#### Risks (if any) associated the changes in the commit
Low risk as this attacks a very specific issue on a single table in the profile summary.

#### What has been tested and how, request additional testing if necessary
The stress test cases have been run to verify the changes.

#### Documentation impact (if any)
No documentation impact.