### PR TITLE
CR1139733 : Fix for wrong generation of warning of deadlock in HW Emu AIE status

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_debug/aie_debug_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_debug/aie_debug_plugin.cpp
@@ -22,6 +22,7 @@
 #include "xdp/profile/database/database.h"
 #include "xdp/profile/device/utility.h"
 #include "xdp/profile/plugin/vp_base/info.h"
+#include "xdp/profile/plugin/vp_base/utility.h"
 #include "xdp/profile/writer/aie_debug/aie_debug_writer.h"
 
 #include "core/common/message.h"
@@ -317,21 +318,25 @@ namespace xdp {
 
         std::stringstream warningMessage;
         if (graphStallCounter == graphTilesVec.size()) {
-          // We have a stuck graph
-          warningMessage
-          << "Potential deadlock/hang found in AI Engines. Graph : " << graphName;
-          xrt_core::message::send(severity_level::warning, "XRT", warningMessage.str());
+          if (xdp::HW_EMU != xdp::getFlowMode()) {
+            // We have a stuck graph
+            warningMessage
+            << "Potential deadlock/hang found in AI Engines. Graph : " << graphName;
+            xrt_core::message::send(severity_level::warning, "XRT", warningMessage.str());
+          }
           // Send next warning if all tiles come out of hang & reach threshold again
           graphStallCounter = 0;
         } else if (foundStuckCores) {
-          // We have a stuck core within this graph
-          warningMessage
-          << "Potential stuck cores found in AI Engines. Graph : " << graphName << " "
-          << "Tile : " << "(" << stuckTile.col << "," << stuckTile.row + 1 << ") "
-          << "Status 0x" << std::hex << stuckCoreStatus << std::dec
-          << " : " << getCoreStatusString(stuckCoreStatus);
+          if (xdp::HW_EMU != xdp::getFlowMode()) {
+            // We have a stuck core within this graph
+            warningMessage
+            << "Potential stuck cores found in AI Engines. Graph : " << graphName << " "
+            << "Tile : " << "(" << stuckTile.col << "," << stuckTile.row + 1 << ") "
+            << "Status 0x" << std::hex << stuckCoreStatus << std::dec
+            << " : " << getCoreStatusString(stuckCoreStatus);
 
-          xrt_core::message::send(severity_level::warning, "XRT", warningMessage.str());
+            xrt_core::message::send(severity_level::warning, "XRT", warningMessage.str());
+          }
           foundStuckCores = false;
         }
 


### PR DESCRIPTION
Signed-off-by: IshitaGhosh <ighosh.account@gmail.com>

#### Problem solved by the commit
In HW Emu, AIE status wrongly generates warning for deadlock.

#### How problem was solved, alternative solutions (if any) and why they were rejected
In HW Emu as simulation is slower, a design may hit realtime threshold for deadlock even if the design is not deadlocked. This causes wrong generation of warnings for deadlock. To fix this, deadlock warnings are disabled in HW Emu.
Another solution could be to read and use timer values to determine whether the design is actually deadlocked. But this would need extensive changes, may be even in driver. So, this can be looked into in later releases.

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Reported design.

#### Documentation impact (if any)
Generation of warning message for potential deadlock is now disabled in HW Emu AIE  Status. This change in behavior needs to be documented.
