### PR TITLE
CR-1141309 Removed the conditions done for sw_emu to return the memid…

### DIFF
--- a/src/runtime_src/core/common/xclbin_parser.cpp
+++ b/src/runtime_src/core/common/xclbin_parser.cpp
@@ -418,9 +418,6 @@ memidx_to_name(const mem_topology* mem_topology,  int32_t midx)
 int32_t
 address_to_memidx(const mem_topology* mem_topology, uint64_t address)
 {
-  if (is_sw_emulation())
-    return 0;  // default bank in software emulation
-
   // Reserve look for preferred group id
   for (int idx = mem_topology->m_count-1; idx >= 0; --idx) {
     auto& mem = mem_topology->m_mem_data[idx];

--- a/src/runtime_src/core/edge/common_em/em_defines.h
+++ b/src/runtime_src/core/edge/common_em/em_defines.h
@@ -136,13 +136,7 @@ namespace xclemulation {
   //we should not create a memory in default bank for hw_emu. As sw_emu doesnt have rtd information, we are not doing any error check
   static inline unsigned xocl_bo_ddr_idx(unsigned flags, bool is_sw_emu = true)
   {
-    unsigned flag = flags & 0xFFFFFFLL;
-    //unsigned type = flags & 0xFF000000LL ;
-
-    if(flag == 0 || ((flag == 0xFFFFFFLL) && is_sw_emu))
-      return 0;
-
-    return flag;
+    return (flags & 0xFFFFFFLL);
   }
 
   static inline bool xocl_bo_p2p(const struct drm_xocl_bo *bo)

--- a/src/runtime_src/core/pcie/emulation/common_em/em_defines.h
+++ b/src/runtime_src/core/pcie/emulation/common_em/em_defines.h
@@ -138,13 +138,7 @@ namespace xclemulation {
   //we should not create a memory in default bank for hw_emu. As sw_emu doesnt have rtd information, we are not doing any error check
   static inline unsigned xocl_bo_ddr_idx(unsigned flags, bool is_sw_emu = true)
   {
-    unsigned flag = flags & 0xFFFFFFLL;
-    //unsigned type = flags & 0xFF000000LL ;
-
-    if(flag == 0 || ((flag == 0xFFFFFFLL) && is_sw_emu))
-      return 0;
-
-    return flag;
+    return (flags & 0xFFFFFFLL);
   }
 
   static inline bool xocl_bo_p2p(const struct drm_xocl_bo *bo)

--- a/src/runtime_src/xocl/core/memory.cpp
+++ b/src/runtime_src/xocl/core/memory.cpp
@@ -30,14 +30,6 @@
 
 namespace {
 
-static bool
-is_sw_emulation()
-{
-  static auto xem = std::getenv("XCL_EMULATION_MODE");
-  static bool swem = xem ? std::strcmp(xem,"sw_emu")==0 : false;
-  return swem;
-}
-
 // Hack to determine if a context is associated with exactly one
 // device.  Additionally, in emulation mode, the device must be
 // active, e.g. loaded through a call to loadBinary.
@@ -251,12 +243,6 @@ get_ext_memidx_nolock(const xclbin& xclbin) const
         m_memidx = -1;
     }
   }
-
-  // In software emulation all connections must default to memory
-  // index 0 to reflect the connectiviy in the internally created
-  // CONNECTIVITY section (core/common/xclbin_swemu.cpp)
-  if (m_memidx > 0 && is_sw_emulation())
-    m_memidx = 0;
 
   return m_memidx;
 }


### PR DESCRIPTION
CR-1141309 Removed the conditions done for sw_emu to return the memidx as 0 as we have updated the RTD of sw_emu to be similar to hw_emu.

This is DSV and Libraries team escalated CR. This addressed ~4 CRs. Please review it on high priority.

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Updated the RTD file in sw_emu to be similar to the hw_emu in all the scenarios including the HBM bus notation. So memidx should return based on the RTD file, not 0.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
None of the PRs introduced this issue. We got this issue when we addressed the HBM memory support.

#### Risks (if any) associated the changes in the commit
No Risk

#### What has been tested and how, request additional testing if necessary
Ran Various designs involving different memory configurations. And Ran the Vitis Canaries to ensure none of the existing tests are impacted

#### Documentation impact (if any)
No