### PR TITLE
Fix Unable to free interrupt after driver removal in edge platforms

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
@@ -1274,10 +1274,10 @@ static int zocl_drm_platform_remove(struct platform_device *pdev)
 	if (zdev->fpga_mgr)
 		fpga_mgr_put(zdev->fpga_mgr);
 
-	zocl_ert_destroy_intc(zdev->cu_intc);
 	zocl_clear_mem(zdev);
 	mutex_destroy(&zdev->mm_lock);
 	zocl_pr_slot_fini(zdev);
+	zocl_ert_destroy_intc(zdev->cu_intc);
 	zocl_destroy_aie(zdev);
 	mutex_destroy(&zdev->aie_lock);
 	zocl_fini_sysfs(drm->dev);


### PR DESCRIPTION
Signed-off-by: rbramand <rbramand@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Interrupt requested is not freed even after driver removal in edge platforms because new intc platform device remove function is being called before cu platform device remove function which has free_irq function. This PR solves that issue.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
PR - https://github.com/Xilinx/XRT/pull/6862 introduced this bug and it was caught in internal testing

#### How problem was solved, alternative solutions (if any) and why they were rejected
Corrected the order of platform devices removal in zocl driver removal function

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
1. Load xclbin  -> creates cu where irq is registered
2. rmmod zocl  ->  destroys cu and irq is freed
3. modprobe zocl and load xclbin  -> cu is created and irq registration does not fail after this fix
Tested this flow using vck190 hw_emu test case

#### Documentation impact (if any)
NA