### PR TITLE
Fix for PS kernel skd to only create 1 copy of ps kernel object

### DIFF
--- a/src/runtime_src/core/edge/skd/xrt_skd.cpp
+++ b/src/runtime_src/core/edge/skd/xrt_skd.cpp
@@ -309,7 +309,7 @@ namespace xrt {
     snprintf(path, XRT_MAX_PATH_LENGTH, "%s", SOFT_KERNEL_FILE_PATH);
 
     /* If not exist, create the path one by one. */
-    if(!std::filesystem::exists(path))
+    if (!std::filesystem::exists(path))
       std::filesystem::create_directories(path);
 
     if(!std::filesystem::exists(sk_path)) {

--- a/src/runtime_src/core/edge/skd/xrt_skd.cpp
+++ b/src/runtime_src/core/edge/skd/xrt_skd.cpp
@@ -312,7 +312,7 @@ namespace xrt {
     if (!std::filesystem::exists(path))
       std::filesystem::create_directories(path);
 
-    if(!std::filesystem::exists(sk_path)) {
+    if (!std::filesystem::exists(sk_path)) {
       fptr = fopen(sk_path, "w+b");
       if (fptr == NULL) {
 	syslog(LOG_ERR, "Cannot create file: %s\n", sk_path);
@@ -341,8 +341,8 @@ namespace xrt {
    */
   int skd::deleteSoftKernelFile()
   {
-      if(std::filesystem::exists(sk_path))
-	return(remove(sk_path));
+      if (std::filesystem::exists(sk_path))
+	return std::filesystem::remove(sk_path);
       return 0;
   }
 

--- a/src/runtime_src/core/edge/skd/xrt_skd.cpp
+++ b/src/runtime_src/core/edge/skd/xrt_skd.cpp
@@ -343,8 +343,7 @@ namespace xrt {
   {
       if(std::filesystem::exists(sk_path))
 	return(remove(sk_path));
-      else
-	return 0;
+      return 0;
   }
 
   /* Convert argument to ffi_type */

--- a/src/runtime_src/core/edge/skd/xrt_skd.cpp
+++ b/src/runtime_src/core/edge/skd/xrt_skd.cpp
@@ -44,8 +44,8 @@ namespace xrt {
     memcpy(xclbin_uuid,uuid,sizeof(xclbin_uuid));
 
     // Set sk_path according to sk_name
-    snprintf(sk_path, XRT_MAX_PATH_LENGTH, "%s%s%d", SOFT_KERNEL_FILE_PATH,
-	     sk_name,cu_idx);
+    snprintf(sk_path, XRT_MAX_PATH_LENGTH, "%s%s", SOFT_KERNEL_FILE_PATH,
+	     sk_name);
   }
 
   XCL_DRIVER_DLLESPEC
@@ -309,26 +309,29 @@ namespace xrt {
     snprintf(path, XRT_MAX_PATH_LENGTH, "%s", SOFT_KERNEL_FILE_PATH);
 
     /* If not exist, create the path one by one. */
-    std::filesystem::create_directories(path);
+    if(!std::filesystem::exists(path))
+      std::filesystem::create_directories(path);
 
-    fptr = fopen(sk_path, "w+b");
-    if (fptr == NULL) {
-      syslog(LOG_ERR, "Cannot create file: %s\n", sk_path);
-      munmap(buf, prop.size);
-      return -1;
-    }
+    if(!std::filesystem::exists(sk_path)) {
+      fptr = fopen(sk_path, "w+b");
+      if (fptr == NULL) {
+	syslog(LOG_ERR, "Cannot create file: %s\n", sk_path);
+	munmap(buf, prop.size);
+	return -1;
+      }
 
-    /* copy the soft kernel to file */
-    if (fwrite(buf, prop.size, 1, fptr) != 1) {
-      syslog(LOG_ERR, "Fail to write to file %s.\n", sk_path);
+      /* copy the soft kernel to file */
+      if (fwrite(buf, prop.size, 1, fptr) != 1) {
+	syslog(LOG_ERR, "Fail to write to file %s.\n", sk_path);
+	fclose(fptr);
+	munmap(buf, prop.size);
+	return -1;
+      }
+      syslog(LOG_INFO,"File created at %s\n", sk_path);
+
       fclose(fptr);
       munmap(buf, prop.size);
-      return -1;
     }
-    syslog(LOG_INFO,"File created at %s\n", sk_path);
-
-    fclose(fptr);
-    munmap(buf, prop.size);
 
     return 0;
   }
@@ -338,7 +341,10 @@ namespace xrt {
    */
   int skd::deleteSoftKernelFile()
   {
-    return(remove(sk_path));
+      if(std::filesystem::exists(sk_path))
+	return(remove(sk_path));
+      else
+	return 0;
   }
 
   /* Convert argument to ffi_type */


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
PS kernel was creating 1 file for each ps kernel instance, so for larger objects it was taking up memory and eventually run out of memory

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Keep only 1 copy of object per PS kernel type

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
v70 and vck5000 ps kernel

#### Documentation impact (if any)
None
