### PR TITLE
xclbinutil - Added kernel_id support

### DIFF
--- a/src/runtime_src/core/common/xclbin_parser.cpp
+++ b/src/runtime_src/core/common/xclbin_parser.cpp
@@ -251,7 +251,7 @@ get_kernel_id(const pt::ptree& xml_kernel, const std::string& element)
     if (elem.first != element)
       continue;
 
-    return convert(elem.second.get<std::string>("<xmlattr>.kernel_id"));
+    return convert(elem.second.get<std::string>("<xmlattr>.dpu_kernel_id"));
   }
 
   return 0;
@@ -875,7 +875,7 @@ get_aie_partition(const axlf* top)
       auto cdop = reinterpret_cast<const cdo_group*>(topbase + aiepdip->cdo_groups.offset + j * sizeof(cdo_group));
       auto kernel_idp = reinterpret_cast<const uint64_t*>(topbase + cdop->dpu_kernel_ids.offset);
       for (uint32_t k = 0; k < cdop->dpu_kernel_ids.size; ++k)
-        dpu_kernel_ids.push_back(*(kernel_idp++));
+        dpu_kernel_ids.push_back(kernel_idp[k]);
 
       pdiobj.cdo_groups.emplace_back<aie_cdo_group_obj>({topbase + cdop->mpo_name, cdop->cdo_type, cdop->pdi_id, std::move(dpu_kernel_ids)});
     }

--- a/src/runtime_src/core/common/xclbin_parser.cpp
+++ b/src/runtime_src/core/common/xclbin_parser.cpp
@@ -243,6 +243,20 @@ get_functional(const pt::ptree& xml_kernel, const std::string& element)
   return 0;
 }
 
+//Get the cu kernel id from kernel xml entry
+static size_t
+get_kernel_id(const pt::ptree& xml_kernel, const std::string& element)
+{
+  for (auto& elem : xml_kernel) {
+    if (elem.first != element)
+      continue;
+
+    return convert(elem.second.get<std::string>("<xmlattr>.kernel_id"));
+  }
+
+  return 0;
+}
+
 // Determine the address range from kernel xml entry
 static size_t
 get_address_range(const pt::ptree& xml_kernel)
@@ -857,10 +871,13 @@ get_aie_partition(const axlf* top)
     pdiobj.pdi.resize(aiepdip->pdi_image.size);
     memcpy(pdiobj.pdi.data(), topbase + aiepdip->pdi_image.offset, pdiobj.pdi.size());
     for (uint32_t j = 0; j < aiepdip->cdo_groups.size; j++) {
+      std::vector<uint64_t> dpu_kernel_ids;
       auto cdop = reinterpret_cast<const cdo_group*>(topbase + aiepdip->cdo_groups.offset + j * sizeof(cdo_group));
+      auto kernel_idp = reinterpret_cast<const uint64_t*>(topbase + cdop->dpu_kernel_ids.offset);
+      for (uint32_t k = 0; k < cdop->dpu_kernel_ids.size; ++k)
+        dpu_kernel_ids.push_back(*(kernel_idp++));
 
-      // TODO: Update this code to use a collection of kernel IDs instead of just one
-      pdiobj.cdo_groups.emplace_back<aie_cdo_group_obj>({topbase + cdop->mpo_name, cdop->cdo_type, cdop->pdi_id});
+      pdiobj.cdo_groups.emplace_back<aie_cdo_group_obj>({topbase + cdop->mpo_name, cdop->cdo_type, cdop->pdi_id, std::move(dpu_kernel_ids)});
     }
 
     obj.pdis.emplace_back(std::move(pdiobj));
@@ -994,6 +1011,7 @@ get_kernel_properties(const char* xml_data, size_t xml_size, const std::string& 
       sw_reset = get_sw_reset_from_ini(kname);
 
     auto functional = get_functional(xml_kernel.second, "extended-data");
+    auto kernel_id = get_kernel_id(xml_kernel.second, "extended-data");
 
     return kernel_properties
       { kname
@@ -1003,6 +1021,7 @@ get_kernel_properties(const char* xml_data, size_t xml_size, const std::string& 
       , get_address_range(xml_kernel.second)
       , sw_reset
       , functional
+      , kernel_id
 
       , convert(xml_kernel.second.get<std::string>("<xmlattr>.workGroupSize", "0"))
       , get_xyz(xml_kernel.second, "compileWorkGroupSize")

--- a/src/runtime_src/core/common/xclbin_parser.h
+++ b/src/runtime_src/core/common/xclbin_parser.h
@@ -64,6 +64,7 @@ struct kernel_properties
   size_t address_range = 0x10000;  // NOLINT, default address range
   bool sw_reset = false;
   size_t functional = 0;
+  size_t kernel_id = 0;
 
   // opencl specifics
   size_t workgroupsize = 0;
@@ -106,6 +107,7 @@ struct aie_cdo_group_obj
   std::string cdo_name;
   uint8_t cdo_type;
   uint64_t pdi_id;
+  std::vector<uint64_t> kernel_ids;
 };
 
 // struct aie_pdi_obj - wrapper for an AIE PDI object

--- a/src/runtime_src/core/include/xclbin.h
+++ b/src/runtime_src/core/include/xclbin.h
@@ -530,7 +530,8 @@ extern "C" {
     enum CDO_Type {
         CT_UNKNOWN = 0,
         CT_PRIMARY = 1,
-        CT_LITE    = 2
+        CT_LITE    = 2,
+        CT_PREPOST = 3
     };
 
     struct cdo_group {

--- a/src/runtime_src/tools/xclbinutil/KernelUtilities.cxx
+++ b/src/runtime_src/tools/xclbinutil/KernelUtilities.cxx
@@ -129,7 +129,15 @@ void buildXMLKernelEntry(const boost::property_tree::ptree& ptKernel,
   const boost::property_tree::ptree& ptExtendedData = ptKernel.get_child("extended-data", ptEmpty);
   if (!ptExtendedData.empty()) {
     boost::property_tree::ptree ptEntry;
-    ptEntry.add_child("<xmlattr>", ptExtendedData);
+    boost::property_tree::ptree ptNewExtendedData;
+    const std::string& kernel_id = ptExtendedData.get<std::string>("dpu_kernel_id", "");
+    const std::string& functional = ptExtendedData.get<std::string>("functional", "");
+    if (!functional.empty())
+      ptNewExtendedData.put("functional", functional);
+    if (!kernel_id.empty())
+      ptNewExtendedData.put("kernel_id", kernel_id);
+
+    ptEntry.add_child("<xmlattr>", ptNewExtendedData);
     ptKernelXML.add_child("extended-data", ptEntry);
   }
 

--- a/src/runtime_src/tools/xclbinutil/KernelUtilities.cxx
+++ b/src/runtime_src/tools/xclbinutil/KernelUtilities.cxx
@@ -129,15 +129,7 @@ void buildXMLKernelEntry(const boost::property_tree::ptree& ptKernel,
   const boost::property_tree::ptree& ptExtendedData = ptKernel.get_child("extended-data", ptEmpty);
   if (!ptExtendedData.empty()) {
     boost::property_tree::ptree ptEntry;
-    boost::property_tree::ptree ptNewExtendedData;
-    const std::string& kernel_id = ptExtendedData.get<std::string>("dpu_kernel_id", "");
-    const std::string& functional = ptExtendedData.get<std::string>("functional", "");
-    if (!functional.empty())
-      ptNewExtendedData.put("functional", functional);
-    if (!kernel_id.empty())
-      ptNewExtendedData.put("kernel_id", kernel_id);
-
-    ptEntry.add_child("<xmlattr>", ptNewExtendedData);
+    ptEntry.add_child("<xmlattr>", ptExtendedData);
     ptKernelXML.add_child("extended-data", ptEntry);
   }
 

--- a/src/runtime_src/tools/xclbinutil/SectionAIEPartition.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionAIEPartition.cxx
@@ -103,7 +103,9 @@ SectionAIEPartition::subSectionExists(const std::string& /*sSubSectionName*/) co
 static const std::vector<std::pair<std::string, CDO_Type>> CTTypes = {
   { "UNKNOWN", CT_UNKNOWN },
   { "PRIMARY", CT_PRIMARY },
-  { "LITE", CT_LITE }
+  { "LITE", CT_LITE },
+  { "PRE", CT_PREPOST },
+  { "POST", CT_PREPOST }
 };
 
 static const std::string&

--- a/src/runtime_src/tools/xclbinutil/SectionAIEPartition.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionAIEPartition.cxx
@@ -104,8 +104,7 @@ static const std::vector<std::pair<std::string, CDO_Type>> CTTypes = {
   { "UNKNOWN", CT_UNKNOWN },
   { "PRIMARY", CT_PRIMARY },
   { "LITE", CT_LITE },
-  { "PRE", CT_PREPOST },
-  { "POST", CT_PREPOST }
+  { "PRE_POST", CT_PREPOST }
 };
 
 static const std::string&

--- a/src/runtime_src/tools/xclbinutil/unittests/FixedKernel/embedded_metadata_expected.xml
+++ b/src/runtime_src/tools/xclbinutil/unittests/FixedKernel/embedded_metadata_expected.xml
@@ -67,7 +67,7 @@
         <connection srcType="core" srcInst="OCL_REGION_0" srcPort="noc_32_0_M13_AXI" dstType="kernel" dstInst="vadd_1" dstPort="S_AXI_CONTROL"/>
         <connection srcType="core" srcInst="OCL_REGION_0" srcPort="noc_64_0_S02_AXI" dstType="kernel" dstInst="vadd_1" dstPort="M_AXI_GMEM"/>
         <kernel name="DPU" language="c" type="dpu">
-          <extended-data functional="0"/>
+          <extended-data functional="0" kernel_id="0x101"/>
           <arg name="ifm" addressQualifier="1" id="0" size="0x8" offset="0x00" hostOffset="0x0" hostSize="0x8" type="char *"/>
           <arg name="param" addressQualifier="1" id="1" size="0x8" offset="0x08" hostOffset="0x0" hostSize="0x8" type="char *"/>
           <arg name="ofm" addressQualifier="1" id="2" size="0x8" offset="0x10" hostOffset="0x0" hostSize="0x8" type="char *"/>

--- a/src/runtime_src/tools/xclbinutil/unittests/FixedKernel/embedded_metadata_expected.xml
+++ b/src/runtime_src/tools/xclbinutil/unittests/FixedKernel/embedded_metadata_expected.xml
@@ -67,7 +67,7 @@
         <connection srcType="core" srcInst="OCL_REGION_0" srcPort="noc_32_0_M13_AXI" dstType="kernel" dstInst="vadd_1" dstPort="S_AXI_CONTROL"/>
         <connection srcType="core" srcInst="OCL_REGION_0" srcPort="noc_64_0_S02_AXI" dstType="kernel" dstInst="vadd_1" dstPort="M_AXI_GMEM"/>
         <kernel name="DPU" language="c" type="dpu">
-          <extended-data functional="0" kernel_id="0x101"/>
+          <extended-data functional="0" dpu_kernel_id="0x101"/>
           <arg name="ifm" addressQualifier="1" id="0" size="0x8" offset="0x00" hostOffset="0x0" hostSize="0x8" type="char *"/>
           <arg name="param" addressQualifier="1" id="1" size="0x8" offset="0x08" hostOffset="0x0" hostSize="0x8" type="char *"/>
           <arg name="ofm" addressQualifier="1" id="2" size="0x8" offset="0x10" hostOffset="0x0" hostSize="0x8" type="char *"/>

--- a/src/runtime_src/tools/xclbinutil/unittests/FixedKernel/fixed_kernel_add.json
+++ b/src/runtime_src/tools/xclbinutil/unittests/FixedKernel/fixed_kernel_add.json
@@ -5,7 +5,8 @@
         "name" : "DPU",   
         "type" : "dpu",
         "extended-data" : {
-            "functional" : "0"
+            "functional" : "0",
+            "dpu_kernel_id" : "0x101"
         },
         "arguments" : [         
           {


### PR DESCRIPTION
Added kernel_id in extended-data for Pre/Post kernel pdi swapping enhancement.

Extract the value of dpu_kernel_id@kernel.json => kernel_id@EMBEDDED_METADATA

#### Problem solved by the commit
New functionality

#### Risks (if any) associated the changes in the commit
Low risk, modified the metadata and passed the xclbinutil unit test 

