### PR TITLE
CR-1141702 allow pdi flash and basic operation when xgq regular service

### DIFF
--- a/src/runtime_src/core/include/xgq_cmd_vmr.h
+++ b/src/runtime_src/core/include/xgq_cmd_vmr.h
@@ -46,6 +46,11 @@
 /* The Clock IP use index 0 for data, 1 for kernel, 2 for sys, 3 for sys1 */ 
 #define XGQ_CLOCK_WIZ_MAX_RES           4
 
+/* VMR Identify Command Version Major and Minor Numbers */
+#define VMR_IDENTIFY_CMD_MAJOR                  1
+#define VMR_IDENTIFY_CMD_MINOR                  0
+
+
 /**
  * clock scaling request types
  */
@@ -368,9 +373,15 @@ struct xgq_cmd_cq_vmr_payload {
 	uint16_t boot_on_offset;
 };
 
-struct xgq_cmd_cq_id_payload {
-	uint16_t major;
-	uint16_t minor;
+/*
+ * struct xgq_cmd_cq_vmr_identify_payload: Identify Command payload
+ *
+ * VMR Identify Command
+*/
+struct xgq_cmd_cq_vmr_identify_payload {
+    uint16_t ver_major;
+    uint16_t ver_minor;
+    uint32_t resvd;
 };
 
 /*
@@ -393,7 +404,7 @@ struct xgq_cmd_cq {
 		struct xgq_cmd_cq_log_page_payload	cq_log_payload;
 		struct xgq_cmd_cq_data_payload		cq_xclbin_payload;
 		struct xgq_cmd_cq_clk_scaling_payload cq_clk_scaling_payload;
-		struct xgq_cmd_cq_id_payload		cq_identify_payload;
+		struct xgq_cmd_cq_vmr_identify_payload  cq_vmr_identify_payload;
 	};
 	uint32_t rcode;
 };

--- a/src/runtime_src/core/include/xgq_cmd_vmr.h
+++ b/src/runtime_src/core/include/xgq_cmd_vmr.h
@@ -89,6 +89,14 @@ enum xgq_cmd_clock_req_type {
 };
 
 /**
+ * clock scaling request types
+ */
+enum xgq_cmd_clock_scaling_req_type {
+	XGQ_CMD_CLK_SCALING_GET_STATUS	= 0x1,
+	XGQ_CMD_CLK_SCALING_SET_OVERRIDE= 0x2,
+};
+
+/**
  * multi-boot operation request types
  */
 enum xgq_cmd_vmr_control_type {
@@ -360,6 +368,11 @@ struct xgq_cmd_cq_vmr_payload {
 	uint16_t boot_on_offset;
 };
 
+struct xgq_cmd_cq_id_payload {
+	uint16_t major;
+	uint16_t minor;
+};
+
 /*
  * struct xgq_cmd_cq: vmr completion command
  *
@@ -380,6 +393,7 @@ struct xgq_cmd_cq {
 		struct xgq_cmd_cq_log_page_payload	cq_log_payload;
 		struct xgq_cmd_cq_data_payload		cq_xclbin_payload;
 		struct xgq_cmd_cq_clk_scaling_payload cq_clk_scaling_payload;
+		struct xgq_cmd_cq_id_payload		cq_identify_payload;
 	};
 	uint32_t rcode;
 };

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
@@ -1780,13 +1780,13 @@ static int vmr_identify_op(struct platform_device *pdev)
 	if (ret) {
 		XGQ_ERR(xgq, "ret %d", ret);
 	} else {
-		struct xgq_cmd_cq_id_payload *version = NULL;
+		struct xgq_cmd_cq_vmr_identify_payload *version = NULL;
 		uint16_t major = 0;
 		uint16_t minor = 0;
 
-		version = (struct xgq_cmd_cq_id_payload *)&cmd->xgq_cmd_cq_payload;
-		major = version->major;
-		minor = version->minor;
+		version = (struct xgq_cmd_cq_vmr_identify_payload *)&cmd->xgq_cmd_cq_payload;
+		major = version->ver_major;
+		minor = version->ver_minor;
 
 		ret = xgq_vmr_supported_version(major, minor) ? 0 : -ENOTSUPP;
 		XGQ_INFO(xgq, "version: %d.%d ret:%d", major, minor, ret);


### PR DESCRIPTION
Not ready for review yet. Waiting for identify PR done first.

Signed-off-by: David Zhang <davidzha@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Resolve 2 issues:
1) current xgq driver can send new cmds that older shell cannot handle, this leads to offline xgq services. To resolved this, we need identify command, older shell will reject report identify, then xgq will continue probe but only allow basic operations like shell flashing, vmr status check.
2) in the future, incompatible changes will bump the version number, so that host driver will report warning and ask user to flash a compatible shell. currently, we only have 1.0 (major.minor).

also, @rajkumar-xilinx  I fixed the missing definition in the xgq header file. please take a look.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1141702

#### How problem was solved, alternative solutions (if any) and why they were rejected
see "problem solved by comment"

#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
tested with v70 and vck5000 shell

#### Documentation impact (if any)
N/A