### PR TITLE
CR-1141521 Xbmgmt tool aborts, on failure to update SC firmware

### DIFF
--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -155,6 +155,7 @@ update_versal_SC(std::shared_ptr<xrt_core::device> dev)
   catch (const xrt_core::query::sysfs_error& e) {
     done = true;
     progress_reporter.get()->finish(false, "Failed to update SC flash image.");
+    t.join();
     throw xrt_core::error(std::string("Error accessing sysfs entry : ") + e.what());
   }
 }


### PR DESCRIPTION
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1141521 Xbmgmt would abort after sc update failed.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
There was a loose thread after throwing an exception when sc update failed.
#### How problem was solved, alternative solutions (if any) and why they were rejected
The loose thread was taken care of with join.
#### Risks (if any) associated the changes in the commit
N/A
#### What has been tested and how, request additional testing if necessary
Testing was done on a vck5000.
```
root@xsjsagarw50:~# xbmgmt program --base sc -d 65:00 --image /proj/rdi/staff/rchane/vck5000_sc_update_force_fail.xsabin
WARNING: Unexpected xclmgmt version (2.14.273) was found. Expected 2.14.0, to match XRT tools.
Programming SC: ......................
[FAILED]: Failed to update SC flash image. < 22s >
XRT build version: 2.14.0
Build hash: 79c7d08cc72a14d6c5e98404c7529c7e2563d8db
Build date: 2022-09-22 16:44:36
Git branch: CR-1141521
PID: 27100
UID: 0
[Thu Sep 22 23:52:21 2022 GMT]
HOST: xsjsagarw50
EXE: /proj/xsjhdstaff4/rchane/XRT/build/Debug/opt/xilinx/xrt/bin/unwrapped/xbmgmt2
[xbmgmt] ERROR: Error accessing sysfs entry : Failed to write /sys/bus/pci/devices/0000:65:00.0/xgq_vmr.m.54525952/program_sc: No such file or directory
: Invalid argument
```
#### Documentation impact (if any)
N/A