### PR TITLE
xclbinutil - Fixed logic issue where subsections were not removed.

### DIFF
--- a/src/runtime_src/tools/xclbinutil/XclBinClass.cxx
+++ b/src/runtime_src/tools/xclbinutil/XclBinClass.cxx
@@ -786,7 +786,7 @@ XclBin::removeSection(const std::string& _sSectionToRemove)
   Section::translateSectionKindStrToKind(sectionName, _eKind);
 
   if ((Section::supportsSectionIndex(_eKind) == true) &&
-      (sectionIndexName.empty())) {
+      (sectionIndexName.empty() && !Section::supportsSubSectionName(_eKind, ""))) {
     auto errMsg = boost::format("ERROR: Section '%s' can only be deleted with indexes.") % sectionName;
     throw std::runtime_error(errMsg.str());
   }


### PR DESCRIPTION
#### Problem solved by the commit
There was a logic issue where sections with empty indexes could not be removed.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
This issue has been in the system since subsection indexes were introduced.   It was discovered with the AIE_PARTITION work that is currently under development.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Updated the logic of the removal method to take into account if if a section supports an empty named subsection index.

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Manual testing

#### Documentation impact (if any)
None