### PR TITLE
Fix for CR-1133640: xbflash2 tool doc update

### DIFF
--- a/src/runtime_src/doc/toc/xbflash2.rst
+++ b/src/runtime_src/doc/toc/xbflash2.rst
@@ -15,6 +15,8 @@ This tool supported for all Alveo platforms, U2 and U30 platforms.
 
 This tool doesn't come with XRT package, it comes as separate xbflash package.
 
+This tool is verified and supported only on XDMA PCIe DMA designs.
+
 **Global options**: These are the global options can be used with any command. 
 
  - ``--help`` : Get help message to use this application.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Documentation update for xbflash2 tool.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
This issue is specific to the customer's design using an Atomic Rules/3rd party PCIe DMA. It appears that not all of the information is making it from xbflash to the flash controller. There is nothing between xbflash/the host and the flash controller except for the Atomic Rules/3rd party PCIe DMA. 
So, expecting document update for xbflash2 tool saying that it supports only XDMA PCIe DMA designs.
#### How problem was solved, alternative solutions (if any) and why they were rejected
xbflash2 doc update - This tool is verified and supported only on XDMA PCIe DMA designs.
#### Risks (if any) associated the changes in the commit
Low
#### What has been tested and how, request additional testing if necessary
Tested manually the documentation with this update.
#### Documentation impact (if any)
yes