### PR TITLE
Fix for CR-1097956: xbutil2 validate shows success for 2RP platform when PLP not loaded

### DIFF
--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -1522,7 +1522,7 @@ run_test_suite_device( const std::shared_ptr<xrt_core::device>& device,
     // Hack: Until we have an option in the tests to query SUPP/NOT SUPP
     // we need to print the test description before running the test
     auto is_black_box_test = [ptTest]() {
-      std::vector<std::string> black_box_tests = {"verify", "mem-bw", "iops", "vcu", "aie-pl", "dma", "p2p"};   
+      std::vector<std::string> black_box_tests = {"verify", "mem-bw", "iops", "vcu", "aie-pl", "dma", "p2p"};
       auto test = ptTest.get<std::string>("name");
       return std::find(black_box_tests.begin(), black_box_tests.end(), test) != black_box_tests.end() ? true : false;
     };
@@ -1543,9 +1543,8 @@ run_test_suite_device( const std::shared_ptr<xrt_core::device>& device,
     pretty_print_test_run(ptTest, status, std::cout);
 
     // consider only when testcase is part of black_box_tests.
-    if (is_black_box_test() && boost::equals(ptTest.get<std::string>("status", ""), test_token_skipped)) {
-        black_box_tests_skipped++;
-    }
+    if (is_black_box_test() && boost::equals(ptTest.get<std::string>("status", ""), test_token_skipped))
+      black_box_tests_skipped++;
 
     // If a test fails, don't test the remaining ones
     if (status == test_status::failed) {

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -1520,7 +1520,7 @@ run_test_suite_device( const std::shared_ptr<xrt_core::device>& device,
     // Hack: Until we have an option in the tests to query SUPP/NOT SUPP
     // we need to print the test description before running the test
     auto is_black_box_test = [ptTest]() {
-      std::vector<std::string> black_box_tests = {"verify", "mem-bw", "iops", "vcu", "aie-pl", "dma", "p2p"};      
+      std::vector<std::string> black_box_tests = {"verify", "mem-bw", "iops", "vcu", "aie-pl", "dma", "p2p"};   
       auto test = ptTest.get<std::string>("name");
       return std::find(black_box_tests.begin(), black_box_tests.end(), test) != black_box_tests.end() ? true : false;
     };

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -1351,16 +1351,16 @@ get_test_name(const std::string& input_name)
  */
 static void
 pretty_print_test_desc(const boost::property_tree::ptree& test, int& test_idx,
-                       std::ostream & _ostream, const std::string& bdf)
+                       std::ostream & _ostream, const std::string& bdf, bool single_case)
 {
   // If the status is anything other than skipped print the test name
   auto _status = test.get<std::string>("status", "");
-  if (!boost::equals(_status, test_token_skipped)) {
+  if (!boost::equals(_status, test_token_skipped) || single_case) {
     std::string test_desc = boost::str(boost::format("Test %d [%s]") % ++test_idx % bdf);
     // Only use the long name option when displaying the test
     _ostream << boost::format("%-26s: %s \n") % test_desc % test.get<std::string>("name", "<unknown>");
 
-    if (XBU::getVerbose())
+    if (XBU::getVerbose() || single_case)
       XBU::message(boost::str(boost::format("    %-22s: %s\n") % "Description" % test.get<std::string>("description")), false, _ostream);
   }
   else if (XBU::getVerbose()) {
@@ -1376,7 +1376,7 @@ pretty_print_test_desc(const boost::property_tree::ptree& test, int& test_idx,
  */
 static void
 pretty_print_test_run(const boost::property_tree::ptree& test,
-                      test_status& status, std::ostream & _ostream)
+                      test_status& status, std::ostream & _ostream, bool single_case)
 {
   auto _status = test.get<std::string>("status", "");
   std::string prev_tag = "";
@@ -1388,8 +1388,10 @@ pretty_print_test_run(const boost::property_tree::ptree& test,
   // if not supported: verbose
   auto redirect_log = [&](const std::string& tag, const std::string& log_str) {
     std::vector<std::string> verbose_tags = {"Xclbin", "Testcase"};
+    if (!boost::equals(_status, test_token_passed) && single_case)
+      status = test_status::failed;  // Failed AND skipped single tests display 'Validation Failed'
     if (boost::equals(_status, test_token_skipped) || (std::find(verbose_tags.begin(), verbose_tags.end(), tag) != verbose_tags.end())) {
-      if (XBU::getVerbose())
+      if (XBU::getVerbose() || single_case)
         XBU::message(log_str, false, _ostream);
       else
         return;
@@ -1442,7 +1444,7 @@ pretty_print_test_run(const boost::property_tree::ptree& test,
  * print final status of the card
  */
 static void
-print_status(test_status status, std::ostream & _ostream)
+print_status(test_status status, std::ostream & _ostream, bool single_case)
 {
   if (status == test_status::failed)
     _ostream << "Validation failed";
@@ -1450,7 +1452,7 @@ print_status(test_status status, std::ostream & _ostream)
     _ostream << "Validation completed";
   if (status == test_status::warning)
     _ostream << ", but with warnings";
-  if (!XBU::getVerbose())
+  if(!XBU::getVerbose() && !single_case)
     _ostream << ". Please run the command '--verbose' option for more details";
   _ostream << std::endl;
 }
@@ -1510,6 +1512,8 @@ run_test_suite_device( const std::shared_ptr<xrt_core::device>& device,
   std::cout << "-------------------------------------------------------------------------------" << std::endl;
 
   int test_idx = 0;
+  bool single_case = (testObjectsToRun.size() == 1);
+  bool all_tests_skipped = true;
   for (TestCollection * testPtr : testObjectsToRun) {
     boost::property_tree::ptree ptTest = testPtr->ptTest; // Create a copy of our entry
 
@@ -1524,15 +1528,19 @@ run_test_suite_device( const std::shared_ptr<xrt_core::device>& device,
     auto bdf = xrt_core::device_query<xrt_core::query::pcie_bdf>(device);
 
     if (is_black_box_test())
-      pretty_print_test_desc(ptTest, test_idx, std::cout, xrt_core::query::pcie_bdf::to_string(bdf));
+      pretty_print_test_desc(ptTest, test_idx, std::cout, xrt_core::query::pcie_bdf::to_string(bdf), single_case);
 
     testPtr->testHandle(device, ptTest);
     ptDeviceTestSuite.push_back( std::make_pair("", ptTest) );
 
     if (!is_black_box_test())
-      pretty_print_test_desc(ptTest, test_idx, std::cout, xrt_core::query::pcie_bdf::to_string(bdf));
+      pretty_print_test_desc(ptTest, test_idx, std::cout, xrt_core::query::pcie_bdf::to_string(bdf), single_case);
 
-    pretty_print_test_run(ptTest, status, std::cout);
+    pretty_print_test_run(ptTest, status, std::cout, single_case);
+
+    // consider only when testcase is part of lack_box_tests.
+    if (is_black_box_test() && !boost::equals(ptTest.get<std::string>("status", ""), test_token_skipped))
+      all_tests_skipped = false;
 
     // If a test fails, don't test the remaining ones
     if (status == test_status::failed) {
@@ -1540,7 +1548,10 @@ run_test_suite_device( const std::shared_ptr<xrt_core::device>& device,
     }
   }
 
-  print_status(status, std::cout);
+  if (all_tests_skipped)
+    status = test_status::failed;
+
+  print_status(status, std::cout, single_case);
 
   ptDeviceInfo.put_child("tests", ptDeviceTestSuite);
   ptDevCollectionTestSuite.push_back( std::make_pair("", ptDeviceInfo) );

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -1520,7 +1520,7 @@ run_test_suite_device( const std::shared_ptr<xrt_core::device>& device,
     // Hack: Until we have an option in the tests to query SUPP/NOT SUPP
     // we need to print the test description before running the test
     auto is_black_box_test = [ptTest]() {
-      std::vector<std::string> black_box_tests = {"verify", "mem-bw", "iops", "vcu", "aie-pl", "dma", "p2p"};   
+      std::vector<std::string> black_box_tests = {"verify", "mem-bw", "iops", "vcu", "aie-pl", "dma", "p2p"};
       auto test = ptTest.get<std::string>("name");
       return std::find(black_box_tests.begin(), black_box_tests.end(), test) != black_box_tests.end() ? true : false;
     };
@@ -1528,8 +1528,8 @@ run_test_suite_device( const std::shared_ptr<xrt_core::device>& device,
     auto bdf = xrt_core::device_query<xrt_core::query::pcie_bdf>(device);
 
     if (is_black_box_test()) {
-        black_box_tests_counter++;
-        pretty_print_test_desc(ptTest, test_idx, std::cout, xrt_core::query::pcie_bdf::to_string(bdf));
+      black_box_tests_counter++;
+      pretty_print_test_desc(ptTest, test_idx, std::cout, xrt_core::query::pcie_bdf::to_string(bdf));
     }
 
     testPtr->testHandle(device, ptTest);
@@ -1541,9 +1541,8 @@ run_test_suite_device( const std::shared_ptr<xrt_core::device>& device,
     pretty_print_test_run(ptTest, status, std::cout);
 
     // consider only when testcase is part of lack_box_tests.
-    if (is_black_box_test() && boost::equals(ptTest.get<std::string>("status", ""), test_token_skipped)) {
-        black_box_tests_skipped++;
-    }
+    if (is_black_box_test() && boost::equals(ptTest.get<std::string>("status", ""), test_token_skipped))
+      black_box_tests_skipped++;
 
     // If a test fails, don't test the remaining ones
     if (status == test_status::failed) {

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -1510,17 +1510,19 @@ run_test_suite_device( const std::shared_ptr<xrt_core::device>& device,
   std::cout << "-------------------------------------------------------------------------------" << std::endl;
 
   int test_idx = 0;
-  if (testObjectsToRun.size() == 1)
-      XBU::setVerbose(true);// setting verbose true for single_case.
   int black_box_tests_skipped = 0;
   int black_box_tests_counter = 0;
+
+  if (testObjectsToRun.size() == 1)
+    XBU::setVerbose(true);// setting verbose true for single_case.
+  
   for (TestCollection * testPtr : testObjectsToRun) {
     boost::property_tree::ptree ptTest = testPtr->ptTest; // Create a copy of our entry
 
     // Hack: Until we have an option in the tests to query SUPP/NOT SUPP
     // we need to print the test description before running the test
     auto is_black_box_test = [ptTest]() {
-      std::vector<std::string> black_box_tests = {"verify", "mem-bw", "iops", "vcu", "aie-pl", "dma", "p2p"};
+      std::vector<std::string> black_box_tests = {"verify", "mem-bw", "iops", "vcu", "aie-pl", "dma", "p2p"};   
       auto test = ptTest.get<std::string>("name");
       return std::find(black_box_tests.begin(), black_box_tests.end(), test) != black_box_tests.end() ? true : false;
     };
@@ -1528,8 +1530,8 @@ run_test_suite_device( const std::shared_ptr<xrt_core::device>& device,
     auto bdf = xrt_core::device_query<xrt_core::query::pcie_bdf>(device);
 
     if (is_black_box_test()) {
-      black_box_tests_counter++;
-      pretty_print_test_desc(ptTest, test_idx, std::cout, xrt_core::query::pcie_bdf::to_string(bdf));
+        black_box_tests_counter++;
+        pretty_print_test_desc(ptTest, test_idx, std::cout, xrt_core::query::pcie_bdf::to_string(bdf));
     }
 
     testPtr->testHandle(device, ptTest);
@@ -1540,9 +1542,10 @@ run_test_suite_device( const std::shared_ptr<xrt_core::device>& device,
 
     pretty_print_test_run(ptTest, status, std::cout);
 
-    // consider only when testcase is part of lack_box_tests.
-    if (is_black_box_test() && boost::equals(ptTest.get<std::string>("status", ""), test_token_skipped))
-      black_box_tests_skipped++;
+    // consider only when testcase is part of black_box_tests.
+    if (is_black_box_test() && boost::equals(ptTest.get<std::string>("status", ""), test_token_skipped)) {
+        black_box_tests_skipped++;
+    }
 
     // If a test fails, don't test the remaining ones
     if (status == test_status::failed) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1097956
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Test results for validate were unclear for users in below cases
1. when tests are skipped due to the shell platform not being programmed.
2. when running a single test in the event of a skipped test, 
as they would see "Validation Completed" with an exit code of 0 without any additional information about the test.
#### How problem was solved, alternative solutions (if any) and why they were rejected
The validate result for a single test or all test will now always be reported, regardless if the test is skipped/failed/passed. A non-zero exit code will be returned and "Validation Failed" will be displayed for the skipped case now (in addition to the failed case), 
"Validation Failed" will be displayed for users in below scenarios.
1. when all tests or single test skipped except default tests like aux-connection, pcie-link, etc.
2.  When all tests or single test failed.
Reference PR: https://github.com/Xilinx/XRT/pull/6853
#### Risks (if any) associated the changes in the commit
This CR changes what the user can see when running ''xbutil validate
#### What has been tested and how, request additional testing if necessary
Single test runs and multi-test runs were tested.
Example of skipped test.
`

xbutil validate -d
Validate Device           : [0000:86:00.1]
    Platform              : xilinx_u250_gen3x16_base_4
    SC Version            : 4.6.20
    Platform ID           : F8DAC62E-49D9-B0AA-E9FC-6F260D9D0DFB

Test 1 [0000:86:00.1]     : aux-connection
    Test Status           : [PASSED]

Test 2 [0000:86:00.1]     : pcie-link
    Test Status           : [PASSED]

Test 3 [0000:86:00.1]     : sc-version
    Test Status           : [PASSED]

Test 4 [0000:86:00.1]     : verify
Test 5 [0000:86:00.1]     : dma
Test 6 [0000:86:00.1]     : iops                                                
Test 7 [0000:86:00.1]     : mem-bw
Test 8 [0000:86:00.1]     : p2p
Test 9 [0000:86:00.1]     : vcu
Test 10 [0000:86:00.1]    : aie-pl
Validation failed. Please run the command --verbose option for more detail

xbutil validate -d
Validate Device           : [0000:86:00.1]
    Platform              : xilinx_u250_gen3x16_xdma_shell_4_1
    SC Version            : 4.6.20
    Platform ID           : 12C8FAFB-0632-499D-B1C0-C6676271B8A6

Test 1 [0000:86:00.1]     : aux-connection 
    Test Status           : [PASSED]

Test 2 [0000:86:00.1]     : pcie-link 
    Test Status           : [PASSED]

Test 3 [0000:86:00.1]     : sc-version 
    Test Status           : [PASSED]

Test 4 [0000:86:00.1]     : verify 
    Test Status           : [PASSED]                                            

Test 5 [0000:86:00.1]     : dma 
    Details               : Buffer size - '16 MB'                               
                            Host -> PCIe -> FPGA write bandwidth = 9041.7 MB/s
                            Host <- PCIe <- FPGA read bandwidth = 11944.3 MB/s
                            Buffer size - '16 MB'
                            Host -> PCIe -> FPGA write bandwidth = 9112.1 MB/s
                            Host <- PCIe <- FPGA read bandwidth = 11918.5 MB/s
                            Buffer size - '16 MB'
                            Host -> PCIe -> FPGA write bandwidth = 9084.4 MB/s
                            Host <- PCIe <- FPGA read bandwidth = 11914.5 MB/s
                            Buffer size - '16 MB'
                            Host -> PCIe -> FPGA write bandwidth = 8962.5 MB/s
                            Host <- PCIe <- FPGA read bandwidth = 11918.1 MB/s
    Test Status           : [PASSED]

Test 6 [0000:86:00.1]     : iops 
    Details               : IOPS: 544268 (verify)                               
    Test Status           : [PASSED]

Test 7 [0000:86:00.1]     : mem-bw 
    Error(s)              : Found Platform                                      
                            Platform Name: Xilinx
                            INFO: Reading
                            /opt/xilinx/firmware/u250/gen3x16/xdma-shell/test/bandwidth.xclbin
                            
    Test Status           : [FAILED]

Validation failed. Please run the command --verbose option for more details
`

#### Documentation impact (if any)
none.