### PR TITLE
Programmatic access to aie_partition fingerprints

### DIFF
--- a/src/runtime_src/core/common/api/xrt_xclbin.cpp
+++ b/src/runtime_src/core/common/api/xrt_xclbin.cpp
@@ -365,6 +365,16 @@ public:
   }
 };
 
+class xclbin::aie_partition_impl
+{
+public: // purposely not a struct to match decl in xrt_xclbin.h
+  const ::aie_partition* m_aiep;
+
+  aie_partition_impl(const ::aie_partition* aiep)
+    : m_aiep(aiep)
+  {}
+};
+
 // class xclbin_impl - Base class for xclbin objects
 class xclbin_impl
 {
@@ -383,6 +393,7 @@ class xclbin_impl
     std::vector<xclbin::mem> m_mems;
     std::vector<xclbin::ip> m_ips;
     std::vector<xclbin::kernel> m_kernels;
+    std::vector<xclbin::aie_partition> m_aie_partitions;
 
     // encoded / compressed memory connection used by
     // xrt core to manage compute unit connectivity.
@@ -460,6 +471,18 @@ class xclbin_impl
       }
 
       return kernels;
+    }
+
+    static std::vector<xclbin::aie_partition>
+    init_aie_partitions(const xclbin_impl* ximpl)
+    {
+      auto xaiep = ximpl->get_section<const ::aie_partition*>(AIE_PARTITION);
+      if (!xaiep)
+        return {};
+
+      std::vector<xclbin::aie_partition> aie_partitions;
+      aie_partitions.emplace_back(std::make_shared<xclbin::aie_partition_impl>(xaiep));
+      return aie_partitions;
     }
 
     static std::string
@@ -559,6 +582,7 @@ class xclbin_impl
       , m_mems(init_mems(m_ximpl))
       , m_ips(init_ips(m_ximpl, m_mems))
       , m_kernels(init_kernels(m_ximpl, m_ips))
+      , m_aie_partitions(init_aie_partitions(m_ximpl))
       , m_membank_encoding(init_mem_encoding(m_mems))
     {}
   };
@@ -716,6 +740,11 @@ public:
     return get_xclbin_info()->m_fpga_device_name;
   }
 
+  const std::vector<xclbin::aie_partition>&
+  get_aie_partitions() const
+  {
+    return get_xclbin_info()->m_aie_partitions;
+  }
 };
 
 // class xclbin_full - Implementation of full xclbin
@@ -932,6 +961,13 @@ xclbin::
 get_mems() const
 {
   return handle ? handle->get_mems() : std::vector<xclbin::mem>{};
+}
+
+std::vector<xclbin::aie_partition>
+xclbin::
+get_aie_partitions() const
+{
+  return handle ? handle->get_aie_partitions() : std::vector<xclbin::aie_partition>{};
 }
 
 std::string
@@ -1232,6 +1268,29 @@ xclbin::mem::
 get_index() const
 {
   return handle ? handle->m_mem_data_idx : std::numeric_limits<int32_t>::max();
+}
+
+////////////////////////////////////////////////////////////////
+// xrt::xclbin::aie_partition
+////////////////////////////////////////////////////////////////
+uint64_t
+xclbin::aie_partition::
+get_inference_fingerprint() const
+{
+  if (!handle)
+    throw std::runtime_error("internal error: missing aie_partition handle");
+
+  return handle->m_aiep->inference_fingerprint;
+}
+
+uint64_t
+xclbin::aie_partition::
+get_pre_post_fingerprint() const
+{
+  if (!handle)
+    throw std::runtime_error("internal error: missing aie_partition handle");
+
+  return handle->m_aiep->pre_post_fingerprint;
 }
 
 } // namespace xrt

--- a/src/runtime_src/core/include/experimental/xrt_xclbin.h
+++ b/src/runtime_src/core/include/experimental/xrt_xclbin.h
@@ -530,6 +530,27 @@ public:
     get_arg(int32_t index) const;
   };
 
+  /// @cond
+  /** undocumented access to aie metadata, subject to change **/
+  class aie_partition_impl;
+  class aie_partition : detail::pimpl<aie_partition_impl>
+  {
+  public:
+    explicit
+    aie_partition(std::shared_ptr<aie_partition_impl> handle)
+      : detail::pimpl<aie_partition_impl>(std::move(handle))
+    {}
+
+    XCL_DRIVER_DLLESPEC
+    uint64_t
+    get_inference_fingerprint() const;
+
+    XCL_DRIVER_DLLESPEC
+    uint64_t
+    get_pre_post_fingerprint() const;
+  };
+  /// @endcond
+
 public:
   /**
    * xclbin() - Construct empty xclbin object
@@ -668,6 +689,12 @@ public:
   XCL_DRIVER_DLLESPEC
   std::vector<mem>
   get_mems() const;
+
+  /// @cond
+  XCL_DRIVER_DLLESPEC
+  std::vector<aie_partition>
+  get_aie_partitions() const;
+  /// @endcond
 
   /**
    * get_xsa_name() - Get Xilinx Support Archive (XSA) name of xclbin

--- a/tests/xrt/56_xclbin/main.cpp
+++ b/tests/xrt/56_xclbin/main.cpp
@@ -120,6 +120,16 @@ operator << (std::ostream& ostr, const xrt::xclbin::kernel& kernel)
   return ostr;
 }
 
+std::ostream&
+operator << (std::ostream& ostr, const xrt::xclbin::aie_partition& aiep)
+{
+  ostr << "aie_partition\n";
+  ostr << "inference_fingerprint: " << aiep.get_inference_fingerprint() << '\n';
+  ostr << "pre_post_fingerprint: " << aiep.get_pre_post_fingerprint() << '\n';
+
+  return ostr;
+}
+
 void
 run_cpp(const std::string& xclbin_fnm)
 {
@@ -137,6 +147,9 @@ run_cpp(const std::string& xclbin_fnm)
 
   for (auto& mem : xclbin.get_mems())
     std::cout << mem << '\n';
+
+  for (auto& aiep : xclbin.get_aie_partitions())
+    std::cout << aiep << '\n';
 }
 
 void


### PR DESCRIPTION
#### Problem solved by the commit
Follow up to #7073, provide APIs to access fingerprints

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added new xclbin::aie_partition subclass for future expansion.  For now only fingerprint access is provided.

#### What has been tested
Updated xclbin xrt native test case to print  the aie_partition sections if any
