### PR TITLE
CR-1142046 Fix APU boot on v70 obfuscated device

### DIFF
--- a/build/build_edge.sh
+++ b/build/build_edge.sh
@@ -458,7 +458,7 @@ if [[ $full == 1 ]]; then
   mkdir -p $ORIGINAL_DIR/$PETALINUX_NAME/apu_packages
   export PATH=$PETALINUX/../../tool/petalinux-v$PETALINUX_VER-final/components/yocto/buildtools/sysroots/x86_64-petalinux-linux/usr/bin:$PATH
   $XRT_REPO_DIR/src/runtime_src/tools/scripts/pkgapu.sh -output $ORIGINAL_DIR/$PETALINUX_NAME/apu_packages -images $ORIGINAL_DIR/$PETALINUX_NAME/images/linux/ -idcode "0x14ca8093" -package-name xrt-apu-vck5000
-  $XRT_REPO_DIR/src/runtime_src/tools/scripts/pkgapu.sh -output $ORIGINAL_DIR/$PETALINUX_NAME/apu_packages -images $ORIGINAL_DIR/$PETALINUX_NAME/images/linux/ -idcode "0x04cd0093" -package-name xrt-apu
+  $XRT_REPO_DIR/src/runtime_src/tools/scripts/pkgapu.sh -output $ORIGINAL_DIR/$PETALINUX_NAME/apu_packages -images $ORIGINAL_DIR/$PETALINUX_NAME/images/linux/ -idcode "0x04cd7093" -package-name xrt-apu
   
 fi
 


### PR DESCRIPTION
Signed-off-by: rbramand <rbramand@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Because of id code change APU boot fails on V70 obfuscated device, changed id code to fix it

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Changed id code that is used in bif file to generate pdi according to new V70 obfuscated device. Generating new apu package is also an option but all V70 devices will be changed in future.

#### Risks (if any) associated the changes in the commit
Using new APU package on non obfuscated V70 devices may cause APU boot failures but it is expected.

#### What has been tested and how, request additional testing if necessary
Tested APU booting on V70 device and it is successful

#### Documentation impact (if any)
NA