### PR TITLE
Programmatic access to aie_partition operations per cycle

### DIFF
--- a/src/runtime_src/core/common/api/xrt_xclbin.cpp
+++ b/src/runtime_src/core/common/api/xrt_xclbin.cpp
@@ -1293,6 +1293,16 @@ get_pre_post_fingerprint() const
   return handle->m_aiep->pre_post_fingerprint;
 }
 
+uint32_t
+xclbin::aie_partition::
+get_operations_per_cycle() const
+{
+  if (!handle)
+    throw std::runtime_error("internal error: missing aie_partition handle");
+
+  return handle->m_aiep->operations_per_cycle;
+}
+
 } // namespace xrt
 
 namespace {

--- a/src/runtime_src/core/include/experimental/xrt_xclbin.h
+++ b/src/runtime_src/core/include/experimental/xrt_xclbin.h
@@ -548,6 +548,10 @@ public:
     XCL_DRIVER_DLLESPEC
     uint64_t
     get_pre_post_fingerprint() const;
+
+    XCL_DRIVER_DLLESPEC
+    uint32_t
+    get_operations_per_cycle() const;
   };
   /// @endcond
 

--- a/tests/xrt/56_xclbin/main.cpp
+++ b/tests/xrt/56_xclbin/main.cpp
@@ -124,6 +124,7 @@ std::ostream&
 operator << (std::ostream& ostr, const xrt::xclbin::aie_partition& aiep)
 {
   ostr << "aie_partition\n";
+  ostr << "operations_per_cycle: " << aiep.get_operations_per_cycle() << '\n';
   ostr << "inference_fingerprint: " << aiep.get_inference_fingerprint() << '\n';
   ostr << "pre_post_fingerprint: " << aiep.get_pre_post_fingerprint() << '\n';
 


### PR DESCRIPTION
#### Problem solved by the commit
Follow up to #7076, provide API access to aie_partition operations_per_cycle.

#### What has been tested and how, request additional testing if necessary
Updated xclbin xrt native test case to print the aie_partition sections if any.
