### PR TITLE
VITIS-6253 Update xbutil/xbmgmt tools help menu

### DIFF
--- a/src/runtime_src/core/common/unistd.h
+++ b/src/runtime_src/core/common/unistd.h
@@ -20,6 +20,7 @@
 #ifndef _WIN32
 #include <unistd.h>
 #else
+#include <Shlobj.h>
 #endif
 
 namespace xrt_core {
@@ -33,6 +34,17 @@ getpagesize()
   return 4096;
 #endif
 }
+
+inline bool
+is_user_privileged()
+{
+#ifndef _WIN32
+  return (getuid() == 0) || (geteuid() == 0);
+#else
+  return IsUserAnAdmin();
+#endif
+}
+
 
 } // xrt_core
 #endif

--- a/src/runtime_src/core/tools/common/OptionOptions.cpp
+++ b/src/runtime_src/core/tools/common/OptionOptions.cpp
@@ -66,9 +66,12 @@ OptionOptions::printHelp() const
 {
   XBU::report_subcommand_help( m_executable,
                                m_command,
-                               m_description, m_extendedHelp, 
-                               m_optionsDescription, m_optionsHidden, 
-                               m_positionalOptions, m_globalOptions);
+                               m_description,
+                               m_extendedHelp, 
+                               m_optionsDescription,
+                               m_optionsHidden,
+                               m_globalOptions,
+                               m_positionalOptions);
 }
 
 std::vector<std::string>

--- a/src/runtime_src/core/tools/common/OptionOptions.cpp
+++ b/src/runtime_src/core/tools/common/OptionOptions.cpp
@@ -38,9 +38,7 @@ OptionOptions::OptionOptions( const std::string & longName,
   , m_extendedHelp("")
   , m_defaultOptionValue(false)
 {
-  m_optionsDescription.add_options()
-    (m_longName.c_str(), boost::program_options::bool_switch(&m_defaultOptionValue)->required(), m_description.c_str())
-  ;
+  m_optionsDescription.add_options()(m_longName.c_str(), boost::program_options::bool_switch(&m_defaultOptionValue)->required(), m_description.c_str());
 }
 
 OptionOptions::OptionOptions( const std::string & longName,
@@ -58,9 +56,7 @@ OptionOptions::OptionOptions( const std::string & longName,
   , m_description(optionDescription)
   , m_extendedHelp("")
 {
-  m_selfOption.add_options()
-    (optionNameString().c_str(), optionValue, valueDescription.c_str())
-  ;
+  m_selfOption.add_options()(optionNameString().c_str(), optionValue, valueDescription.c_str());
   m_optionsDescription.add(m_selfOption);
 }
 

--- a/src/runtime_src/core/tools/common/OptionOptions.cpp
+++ b/src/runtime_src/core/tools/common/OptionOptions.cpp
@@ -58,14 +58,10 @@ OptionOptions::OptionOptions( const std::string & longName,
   , m_description(optionDescription)
   , m_extendedHelp("")
 {
-  if (shortName.empty())
-    m_optionsDescription.add_options()
-      (m_longName.c_str(), optionValue, valueDescription.c_str())
-    ;
-  else
-    m_optionsDescription.add_options()
-      ((m_longName + "," + shortName).c_str(), optionValue, valueDescription.c_str())
-    ;
+  m_selfOption.add_options()
+    (optionNameString().c_str(), optionValue, valueDescription.c_str())
+  ;
+  m_optionsDescription.add(m_selfOption);
 }
 
 void 

--- a/src/runtime_src/core/tools/common/OptionOptions.cpp
+++ b/src/runtime_src/core/tools/common/OptionOptions.cpp
@@ -28,7 +28,7 @@
 namespace XBU = XBUtilities;
 namespace po = boost::program_options;
 
-OptionOptions::OptionOptions(const std::string &longName, bool isHidden, const std::string &description)
+OptionOptions::OptionOptions(const std::string& longName, bool isHidden, const std::string& description)
   : m_executable("<unknown>")
   , m_command("<unknown>")
   , m_longName(longName)
@@ -43,11 +43,11 @@ OptionOptions::OptionOptions(const std::string &longName, bool isHidden, const s
   m_optionsDescription.add(m_selfOption);
 }
 
-OptionOptions::OptionOptions(const std::string &longName,
-                             const std::string &shortName,
-                             const std::string &optionDescription,
-                             const boost::program_options::value_semantic *optionValue,
-                             const std::string &valueDescription,
+OptionOptions::OptionOptions(const std::string& longName,
+                             const std::string& shortName,
+                             const std::string& optionDescription,
+                             const boost::program_options::value_semantic* optionValue,
+                             const std::string& valueDescription,
                              bool isHidden)
   : m_executable("<unknown>")
   , m_command("<unknown>")
@@ -75,8 +75,8 @@ OptionOptions::printHelp() const
 }
 
 std::vector<std::string>
-OptionOptions::process_arguments(boost::program_options::variables_map &vm,
-                                 const SubCmdOptions &options,
+OptionOptions::process_arguments(boost::program_options::variables_map& vm,
+                                 const SubCmdOptions& options,
                                  bool validate_arguments) const
 {
   po::options_description all_options("All Options");
@@ -86,7 +86,7 @@ OptionOptions::process_arguments(boost::program_options::variables_map &vm,
   try {
     po::command_line_parser parser(options);
     return XBU::process_arguments(vm, parser, all_options, m_positionalOptions, validate_arguments);
-  } catch (boost::program_options::error &e) {
+  } catch (boost::program_options::error& e) {
     std::cerr << boost::format("ERROR: %s\n") % e.what();
     printHelp();
     throw xrt_core::error(std::errc::operation_canceled);

--- a/src/runtime_src/core/tools/common/OptionOptions.cpp
+++ b/src/runtime_src/core/tools/common/OptionOptions.cpp
@@ -39,17 +39,17 @@ OptionOptions::OptionOptions( const std::string & longName,
   , m_defaultOptionValue(false)
 {
   m_optionsDescription.add_options()
-    (m_longName.c_str(), boost::program_options::bool_switch(&m_defaultOptionValue), m_description.c_str())
+    (m_longName.c_str(), boost::program_options::bool_switch(&m_defaultOptionValue)->required(), m_description.c_str())
   ;
 }
 
-OptionOptions::OptionOptions(const std::string & longName,
-                            const std::string & shortName,
-                            const std::string & optionDescription,
-                            const boost::program_options::value_semantic* optionValue,
-                            const std::string & valueDescription,
-                            bool isHidden
-                            )
+OptionOptions::OptionOptions( const std::string & longName,
+                              const std::string & shortName,
+                              const std::string & optionDescription,
+                              const boost::program_options::value_semantic* optionValue,
+                              const std::string & valueDescription,
+                              bool isHidden
+                              )
   : m_executable("<unknown>")
   , m_command("<unknown>")
   , m_longName(longName)
@@ -58,9 +58,14 @@ OptionOptions::OptionOptions(const std::string & longName,
   , m_description(optionDescription)
   , m_extendedHelp("")
 {
-  m_optionsDescription.add_options()
-    ((m_longName + "," + m_shortName).c_str(), optionValue, valueDescription.c_str())
-  ;
+  if (shortName.empty())
+    m_optionsDescription.add_options()
+      (m_longName.c_str(), optionValue, valueDescription.c_str())
+    ;
+  else
+    m_optionsDescription.add_options()
+      ((m_longName + "," + shortName).c_str(), optionValue, valueDescription.c_str())
+    ;
 }
 
 void 

--- a/src/runtime_src/core/tools/common/OptionOptions.cpp
+++ b/src/runtime_src/core/tools/common/OptionOptions.cpp
@@ -53,20 +53,21 @@ OptionOptions::OptionOptions(const std::string & longName,
   : m_executable("<unknown>")
   , m_command("<unknown>")
   , m_longName(longName)
+  , m_shortName(shortName)
   , m_isHidden(isHidden)
   , m_description(optionDescription)
   , m_extendedHelp("")
 {
   m_optionsDescription.add_options()
-    (m_longName.c_str(), optionValue, valueDescription.c_str())
+    ((m_longName + "," + m_shortName).c_str(), optionValue, valueDescription.c_str())
   ;
 }
 
 void 
 OptionOptions::printHelp() const
 {
-  XBU::report_subcommand_help( m_executable, 
-                               m_command + " --" + m_longName, 
+  XBU::report_subcommand_help( m_executable,
+                               m_command,
                                m_description, m_extendedHelp, 
                                m_optionsDescription, m_optionsHidden, 
                                m_positionalOptions, m_globalOptions);

--- a/src/runtime_src/core/tools/common/OptionOptions.cpp
+++ b/src/runtime_src/core/tools/common/OptionOptions.cpp
@@ -38,7 +38,8 @@ OptionOptions::OptionOptions( const std::string & longName,
   , m_extendedHelp("")
   , m_defaultOptionValue(false)
 {
-  m_optionsDescription.add_options()(m_longName.c_str(), boost::program_options::bool_switch(&m_defaultOptionValue)->required(), m_description.c_str());
+  m_selfOption.add_options()(m_longName.c_str(), boost::program_options::bool_switch(&m_defaultOptionValue)->required(), m_description.c_str());
+  m_optionsDescription.add(m_selfOption);
 }
 
 OptionOptions::OptionOptions( const std::string & longName,

--- a/src/runtime_src/core/tools/common/OptionOptions.cpp
+++ b/src/runtime_src/core/tools/common/OptionOptions.cpp
@@ -18,18 +18,17 @@
 // ------ I N C L U D E   F I L E S -------------------------------------------
 // Local - Include Files
 #include "OptionOptions.h"
-#include <iostream>
+
 #include <boost/format.hpp>
+#include <iostream>
 
 #include "core/common/error.h"
-#include "XBUtilitiesCore.h"
 #include "XBHelpMenusCore.h"
+#include "XBUtilitiesCore.h"
 namespace XBU = XBUtilities;
 namespace po = boost::program_options;
 
-OptionOptions::OptionOptions( const std::string & longName,
-                              bool isHidden,
-                              const std::string & description)
+OptionOptions::OptionOptions(const std::string &longName, bool isHidden, const std::string &description)
   : m_executable("<unknown>")
   , m_command("<unknown>")
   , m_longName(longName)
@@ -38,17 +37,18 @@ OptionOptions::OptionOptions( const std::string & longName,
   , m_extendedHelp("")
   , m_defaultOptionValue(false)
 {
-  m_selfOption.add_options()(m_longName.c_str(), boost::program_options::bool_switch(&m_defaultOptionValue)->required(), m_description.c_str());
+  m_selfOption.add_options()(m_longName.c_str(),
+                             boost::program_options::bool_switch(&m_defaultOptionValue)->required(),
+                             m_description.c_str());
   m_optionsDescription.add(m_selfOption);
 }
 
-OptionOptions::OptionOptions( const std::string & longName,
-                              const std::string & shortName,
-                              const std::string & optionDescription,
-                              const boost::program_options::value_semantic* optionValue,
-                              const std::string & valueDescription,
-                              bool isHidden
-                              )
+OptionOptions::OptionOptions(const std::string &longName,
+                             const std::string &shortName,
+                             const std::string &optionDescription,
+                             const boost::program_options::value_semantic *optionValue,
+                             const std::string &valueDescription,
+                             bool isHidden)
   : m_executable("<unknown>")
   , m_command("<unknown>")
   , m_longName(longName)
@@ -61,23 +61,23 @@ OptionOptions::OptionOptions( const std::string & longName,
   m_optionsDescription.add(m_selfOption);
 }
 
-void 
+void
 OptionOptions::printHelp() const
 {
-  XBU::report_subcommand_help( m_executable,
-                               m_command,
-                               m_description,
-                               m_extendedHelp, 
-                               m_optionsDescription,
-                               m_optionsHidden,
-                               m_globalOptions,
-                               m_positionalOptions);
+  XBU::report_subcommand_help(m_executable,
+                              m_command,
+                              m_description,
+                              m_extendedHelp,
+                              m_optionsDescription,
+                              m_optionsHidden,
+                              m_globalOptions,
+                              m_positionalOptions);
 }
 
 std::vector<std::string>
-OptionOptions::process_arguments( boost::program_options::variables_map& vm,
-                                  const SubCmdOptions& options,
-                                  bool validate_arguments) const
+OptionOptions::process_arguments(boost::program_options::variables_map &vm,
+                                 const SubCmdOptions &options,
+                                 bool validate_arguments) const
 {
   po::options_description all_options("All Options");
   all_options.add(m_optionsDescription);
@@ -86,10 +86,9 @@ OptionOptions::process_arguments( boost::program_options::variables_map& vm,
   try {
     po::command_line_parser parser(options);
     return XBU::process_arguments(vm, parser, all_options, m_positionalOptions, validate_arguments);
-  } catch(boost::program_options::error& e) {
+  } catch (boost::program_options::error &e) {
     std::cerr << boost::format("ERROR: %s\n") % e.what();
     printHelp();
     throw xrt_core::error(std::errc::operation_canceled);
   }
 }
-

--- a/src/runtime_src/core/tools/common/OptionOptions.cpp
+++ b/src/runtime_src/core/tools/common/OptionOptions.cpp
@@ -29,47 +29,44 @@ namespace po = boost::program_options;
 
 OptionOptions::OptionOptions( const std::string & longName,
                               bool isHidden,
-                              const std::string & description,
-                              bool includeLongName)
+                              const std::string & description)
   : m_executable("<unknown>")
   , m_command("<unknown>")
   , m_longName(longName)
   , m_isHidden(isHidden)
   , m_description(description)
   , m_extendedHelp("")
-  , m_includeLongName(includeLongName)
+  , m_defaultOptionValue(false)
 {
-  m_selfOption.add_options()(m_longName.c_str(), boost::program_options::bool_switch(&m_defaultOptionValue)->required(), m_description.c_str());
-  m_optionsDescription.add(m_selfOption);
+  m_optionsDescription.add_options()
+    (m_longName.c_str(), boost::program_options::bool_switch(&m_defaultOptionValue), m_description.c_str())
+  ;
 }
 
-OptionOptions::OptionOptions( const std::string & longName,
-                              const std::string & shortName,
-                              const std::string & optionDescription,
-                              const boost::program_options::value_semantic* optionValue,
-                              const std::string & valueDescription,
-                              bool isHidden
-                              )
+OptionOptions::OptionOptions(const std::string & longName,
+                            const std::string & shortName,
+                            const std::string & optionDescription,
+                            const boost::program_options::value_semantic* optionValue,
+                            const std::string & valueDescription,
+                            bool isHidden
+                            )
   : m_executable("<unknown>")
   , m_command("<unknown>")
   , m_longName(longName)
-  , m_shortName(shortName)
   , m_isHidden(isHidden)
   , m_description(optionDescription)
   , m_extendedHelp("")
 {
-  m_selfOption.add_options()(optionNameString().c_str(), optionValue, valueDescription.c_str());
-  m_optionsDescription.add(m_selfOption);
+  m_optionsDescription.add_options()
+    (m_longName.c_str(), optionValue, valueDescription.c_str())
+  ;
 }
 
 void 
 OptionOptions::printHelp() const
 {
-  std::string command = m_command;
-  if (m_includeLongName)
-    command.append(" --" + m_longName);
   XBU::report_subcommand_help( m_executable, 
-                               command, 
+                               m_command + " --" + m_longName, 
                                m_description, m_extendedHelp, 
                                m_optionsDescription, m_optionsHidden, 
                                m_positionalOptions, m_globalOptions);

--- a/src/runtime_src/core/tools/common/OptionOptions.cpp
+++ b/src/runtime_src/core/tools/common/OptionOptions.cpp
@@ -28,7 +28,9 @@
 namespace XBU = XBUtilities;
 namespace po = boost::program_options;
 
-OptionOptions::OptionOptions(const std::string& longName, bool isHidden, const std::string& description)
+OptionOptions::OptionOptions( const std::string& longName,
+                              bool isHidden,
+                              const std::string& description)
   : m_executable("<unknown>")
   , m_command("<unknown>")
   , m_longName(longName)

--- a/src/runtime_src/core/tools/common/OptionOptions.cpp
+++ b/src/runtime_src/core/tools/common/OptionOptions.cpp
@@ -29,14 +29,15 @@ namespace po = boost::program_options;
 
 OptionOptions::OptionOptions( const std::string & longName,
                               bool isHidden,
-                              const std::string & description)
+                              const std::string & description,
+                              bool includeLongName)
   : m_executable("<unknown>")
   , m_command("<unknown>")
   , m_longName(longName)
   , m_isHidden(isHidden)
   , m_description(description)
   , m_extendedHelp("")
-  , m_defaultOptionValue(false)
+  , m_includeLongName(includeLongName)
 {
   m_selfOption.add_options()(m_longName.c_str(), boost::program_options::bool_switch(&m_defaultOptionValue)->required(), m_description.c_str());
   m_optionsDescription.add(m_selfOption);
@@ -64,8 +65,11 @@ OptionOptions::OptionOptions( const std::string & longName,
 void 
 OptionOptions::printHelp() const
 {
-  XBU::report_subcommand_help( m_executable,
-                               m_command,
+  std::string command = m_command;
+  if (m_includeLongName)
+    command.append(" --" + m_longName);
+  XBU::report_subcommand_help( m_executable, 
+                               command, 
                                m_description, m_extendedHelp, 
                                m_optionsDescription, m_optionsHidden, 
                                m_positionalOptions, m_globalOptions);

--- a/src/runtime_src/core/tools/common/OptionOptions.h
+++ b/src/runtime_src/core/tools/common/OptionOptions.h
@@ -19,10 +19,10 @@
 #define __OptionOptions_h_
 
 // Please keep eternal include file dependencies to a minimum
-#include <vector>
-#include <string>
 #include <boost/program_options.hpp>
-  
+#include <string>
+#include <vector>
+
 class OptionOptions {
  public:
   typedef std::vector<std::string> SubCmdOptions;
@@ -33,44 +33,41 @@ class OptionOptions {
   const boost::shared_ptr<boost::program_options::option_description> &option() const { return m_selfOption.options()[0]; };
   const std::string &longName() const { return m_longName; };
   const std::string optionNameString() const { return m_shortName.empty() ? m_longName : m_longName + "," + m_shortName; };
-  const std::string &description() const {return m_description; };
+  const std::string &description() const { return m_description; };
   const std::string &extendedHelp() const { return m_extendedHelp; };
   bool isHidden() const { return m_isHidden; };
 
-  void setExecutable( const std::string &_executable) {m_executable = _executable; };
-  void setCommand( const std::string & _command) {m_command = _command; };
+  void setExecutable(const std::string &_executable) { m_executable = _executable; };
+  void setCommand(const std::string &_command) { m_command = _command; };
 
-  const boost::program_options::options_description & 
-    getOptionsDescription() const { return m_optionsDescription; } ;
-  const boost::program_options::positional_options_description & 
-    getPositionalOptions() const { return m_positionalOptions; } ;
+  const boost::program_options::options_description &
+    getOptionsDescription() const { return m_optionsDescription; };
+  const boost::program_options::positional_options_description &
+    getPositionalOptions() const { return m_positionalOptions; };
 
   void setGlobalOptions(const boost::program_options::options_description &globalOptions) { m_globalOptions.add(globalOptions); };
 
  public:
-  virtual ~OptionOptions() {};
+  virtual ~OptionOptions(){};
 
- // Child class Helper methods
+  // Child class Helper methods
  protected:
-  OptionOptions(const std::string & longName,
-                bool isHidden,
-                const std::string & description);
-  OptionOptions(const std::string & longName,
-                const std::string & shortName,
-                const std::string & optionDescription,
-                const boost::program_options::value_semantic* optionValue,
-                const std::string & valueDescription,
+  OptionOptions(const std::string &longName, bool isHidden, const std::string &description);
+  OptionOptions(const std::string &longName,
+                const std::string &shortName,
+                const std::string &optionDescription,
+                const boost::program_options::value_semantic *optionValue,
+                const std::string &valueDescription,
                 bool isHidden);
   void setExtendedHelp(const std::string &extendedHelp) { m_extendedHelp = extendedHelp; };
   void printHelp() const;
-  std::vector<std::string> process_arguments( boost::program_options::variables_map& vm,
-                                              const SubCmdOptions& options,
-                                              bool validate_arguments = true) const;
+  std::vector<std::string> process_arguments(boost::program_options::variables_map &vm,
+                                             const SubCmdOptions &options,
+                                             bool validate_arguments = true) const;
 
  private:
   OptionOptions() = delete;
 
- // Variables
  protected:
   boost::program_options::options_description m_selfOption;
   boost::program_options::options_description m_optionsDescription;
@@ -88,6 +85,5 @@ class OptionOptions {
   bool m_defaultOptionValue;
   boost::program_options::options_description m_globalOptions;
 };
-  
-#endif
 
+#endif

--- a/src/runtime_src/core/tools/common/OptionOptions.h
+++ b/src/runtime_src/core/tools/common/OptionOptions.h
@@ -27,42 +27,40 @@ class OptionOptions {
  public:
   typedef std::vector<std::string> SubCmdOptions;
 
-  virtual void execute(const SubCmdOptions &_options) const = 0;
+  virtual void execute(const SubCmdOptions& _options) const = 0;
 
  public:
-  const boost::shared_ptr<boost::program_options::option_description> &option() const { return m_selfOption.options()[0]; };
-  const std::string &longName() const { return m_longName; };
+  const boost::shared_ptr<boost::program_options::option_description>& option() const { return m_selfOption.options()[0]; };
+  const std::string& longName() const { return m_longName; };
   const std::string optionNameString() const { return m_shortName.empty() ? m_longName : m_longName + "," + m_shortName; };
-  const std::string &description() const { return m_description; };
-  const std::string &extendedHelp() const { return m_extendedHelp; };
+  const std::string& description() const { return m_description; };
+  const std::string& extendedHelp() const { return m_extendedHelp; };
   bool isHidden() const { return m_isHidden; };
 
-  void setExecutable(const std::string &_executable) { m_executable = _executable; };
-  void setCommand(const std::string &_command) { m_command = _command; };
+  void setExecutable(const std::string& _executable) { m_executable = _executable; };
+  void setCommand(const std::string& _command) { m_command = _command; };
 
-  const boost::program_options::options_description &
-    getOptionsDescription() const { return m_optionsDescription; };
-  const boost::program_options::positional_options_description &
-    getPositionalOptions() const { return m_positionalOptions; };
+  const boost::program_options::options_description& getOptionsDescription() const { return m_optionsDescription; };
+  const boost::program_options::positional_options_description& getPositionalOptions() const { return m_positionalOptions; };
 
-  void setGlobalOptions(const boost::program_options::options_description &globalOptions) { m_globalOptions.add(globalOptions); };
+  void setGlobalOptions(const boost::program_options::options_description& globalOptions) { m_globalOptions.add(globalOptions); };
 
  public:
   virtual ~OptionOptions(){};
 
   // Child class Helper methods
  protected:
-  OptionOptions(const std::string &longName, bool isHidden, const std::string &description);
-  OptionOptions(const std::string &longName,
-                const std::string &shortName,
-                const std::string &optionDescription,
-                const boost::program_options::value_semantic *optionValue,
-                const std::string &valueDescription,
+  OptionOptions(const std::string& longName, bool isHidden, const std::string& description);
+  OptionOptions(const std::string& longName,
+                const std::string& shortName,
+                const std::string& optionDescription,
+                const boost::program_options::value_semantic* optionValue,
+                const std::string& valueDescription,
                 bool isHidden);
-  void setExtendedHelp(const std::string &extendedHelp) { m_extendedHelp = extendedHelp; };
+  void setExtendedHelp(const std::string& extendedHelp) { m_extendedHelp = extendedHelp; };
   void printHelp() const;
-  std::vector<std::string> process_arguments(boost::program_options::variables_map &vm,
-                                             const SubCmdOptions &options,
+  std::vector<std::string> process_arguments(boost::program_options::variables_map& vm,
+                                             const SubCmdOptions& options,
                                              bool validate_arguments = true) const;
 
  private:

--- a/src/runtime_src/core/tools/common/OptionOptions.h
+++ b/src/runtime_src/core/tools/common/OptionOptions.h
@@ -58,8 +58,7 @@ class OptionOptions {
                 const std::string & optionDescription,
                 const boost::program_options::value_semantic* optionValue,
                 const std::string & valueDescription,
-                bool isHidden
-                );
+                bool isHidden);
   void setExtendedHelp(const std::string &extendedHelp) { m_extendedHelp = extendedHelp; };
   void printHelp() const;
   std::vector<std::string> process_arguments( boost::program_options::variables_map& vm,

--- a/src/runtime_src/core/tools/common/OptionOptions.h
+++ b/src/runtime_src/core/tools/common/OptionOptions.h
@@ -30,7 +30,9 @@ class OptionOptions {
   virtual void execute(const SubCmdOptions &_options) const = 0;
 
  public:
+  const boost::program_options::options_description &option() const { return m_selfOption; };
   const std::string &longName() const { return m_longName; };
+  const std::string optionNameString() const { return m_shortName.empty() ? m_longName : m_longName + "," + m_shortName; };
   const std::string &description() const {return m_description; };
   const std::string &extendedHelp() const { return m_extendedHelp; };
   bool isHidden() const { return m_isHidden; };
@@ -70,6 +72,7 @@ class OptionOptions {
 
  // Variables
  protected:
+  boost::program_options::options_description m_selfOption;
   boost::program_options::options_description m_optionsDescription;
   boost::program_options::options_description m_optionsHidden;
   boost::program_options::positional_options_description m_positionalOptions;

--- a/src/runtime_src/core/tools/common/OptionOptions.h
+++ b/src/runtime_src/core/tools/common/OptionOptions.h
@@ -30,7 +30,7 @@ class OptionOptions {
   virtual void execute(const SubCmdOptions &_options) const = 0;
 
  public:
-  const boost::program_options::options_description &option() const { return m_selfOption; };
+  const boost::shared_ptr<boost::program_options::option_description> &option() const { return m_selfOption.options()[0]; };
   const std::string &longName() const { return m_longName; };
   const std::string optionNameString() const { return m_shortName.empty() ? m_longName : m_longName + "," + m_shortName; };
   const std::string &description() const {return m_description; };

--- a/src/runtime_src/core/tools/common/OptionOptions.h
+++ b/src/runtime_src/core/tools/common/OptionOptions.h
@@ -52,7 +52,16 @@ class OptionOptions {
 
  // Child class Helper methods
  protected:
-  OptionOptions(const std::string & longName, bool isHidden, const std::string & description, bool includeLongName = true);
+  OptionOptions(const std::string & longName,
+                bool isHidden,
+                const std::string & description);
+  OptionOptions(const std::string & longName,
+                const std::string & shortName,
+                const std::string & optionDescription,
+                const boost::program_options::value_semantic* optionValue,
+                const std::string & valueDescription,
+                bool isHidden
+                );
   void setExtendedHelp(const std::string &extendedHelp) { m_extendedHelp = extendedHelp; };
   void printHelp() const;
   std::vector<std::string> process_arguments( boost::program_options::variables_map& vm,
@@ -77,7 +86,7 @@ class OptionOptions {
   bool m_isHidden;
   std::string m_description;
   std::string m_extendedHelp;
-  bool m_includeLongName;
+  bool m_defaultOptionValue;
   boost::program_options::options_description m_globalOptions;
 };
   

--- a/src/runtime_src/core/tools/common/OptionOptions.h
+++ b/src/runtime_src/core/tools/common/OptionOptions.h
@@ -52,15 +52,7 @@ class OptionOptions {
 
  // Child class Helper methods
  protected:
-  OptionOptions(const std::string & longName,
-                bool isHidden,
-                const std::string & description);
-  OptionOptions(const std::string & longName,
-                const std::string & shortName,
-                const std::string & optionDescription,
-                const boost::program_options::value_semantic* optionValue,
-                const std::string & valueDescription,
-                bool isHidden);
+  OptionOptions(const std::string & longName, bool isHidden, const std::string & description, bool includeLongName = true);
   void setExtendedHelp(const std::string &extendedHelp) { m_extendedHelp = extendedHelp; };
   void printHelp() const;
   std::vector<std::string> process_arguments( boost::program_options::variables_map& vm,
@@ -85,7 +77,7 @@ class OptionOptions {
   bool m_isHidden;
   std::string m_description;
   std::string m_extendedHelp;
-  bool m_defaultOptionValue;
+  bool m_includeLongName;
   boost::program_options::options_description m_globalOptions;
 };
   

--- a/src/runtime_src/core/tools/common/OptionOptions.h
+++ b/src/runtime_src/core/tools/common/OptionOptions.h
@@ -30,7 +30,7 @@ class OptionOptions {
   virtual void execute(const SubCmdOptions &_options) const = 0;
 
  public:
-  const boost::shared_ptr<boost::program_options::option_description> &option() const { return m_selfOption.options()[0]; };
+  const boost::program_options::options_description &option() const { return m_selfOption; };
   const std::string &longName() const { return m_longName; };
   const std::string optionNameString() const { return m_shortName.empty() ? m_longName : m_longName + "," + m_shortName; };
   const std::string &description() const {return m_description; };

--- a/src/runtime_src/core/tools/common/OptionOptions.h
+++ b/src/runtime_src/core/tools/common/OptionOptions.h
@@ -60,8 +60,7 @@ class OptionOptions {
                 const std::string & optionDescription,
                 const boost::program_options::value_semantic* optionValue,
                 const std::string & valueDescription,
-                bool isHidden
-                );
+                bool isHidden);
   void setExtendedHelp(const std::string &extendedHelp) { m_extendedHelp = extendedHelp; };
   void printHelp() const;
   std::vector<std::string> process_arguments( boost::program_options::variables_map& vm,

--- a/src/runtime_src/core/tools/common/OptionOptions.h
+++ b/src/runtime_src/core/tools/common/OptionOptions.h
@@ -20,6 +20,7 @@
 
 // Please keep eternal include file dependencies to a minimum
 #include <boost/program_options.hpp>
+#include <boost/format.hpp>
 #include <string>
 #include <vector>
 
@@ -30,7 +31,13 @@ class OptionOptions {
   virtual void execute(const SubCmdOptions& _options) const = 0;
 
  public:
-  const boost::shared_ptr<boost::program_options::option_description>& option() const { return m_selfOption.options()[0]; };
+  const boost::shared_ptr<boost::program_options::option_description>&
+  option() const
+  {
+    if (m_selfOption.options().empty())
+      throw std::runtime_error(boost::str(boost::format("%s missing self option") % longName()));
+    return m_selfOption.options()[0];
+  };
   const std::string& longName() const { return m_longName; };
   const std::string optionNameString() const { return m_shortName.empty() ? m_longName : m_longName + "," + m_shortName; };
   const std::string& description() const { return m_description; };
@@ -51,17 +58,10 @@ class OptionOptions {
   // Child class Helper methods
  protected:
   OptionOptions(const std::string& longName, bool isHidden, const std::string& description);
-  OptionOptions(const std::string& longName,
-                const std::string& shortName,
-                const std::string& optionDescription,
-                const boost::program_options::value_semantic* optionValue,
-                const std::string& valueDescription,
-                bool isHidden);
+  OptionOptions(const std::string& longName, const std::string& shortName, const std::string& optionDescription, const boost::program_options::value_semantic* optionValue, const std::string& valueDescription, bool isHidden);
   void setExtendedHelp(const std::string& extendedHelp) { m_extendedHelp = extendedHelp; };
   void printHelp() const;
-  std::vector<std::string> process_arguments(boost::program_options::variables_map& vm,
-                                             const SubCmdOptions& options,
-                                             bool validate_arguments = true) const;
+  std::vector<std::string> process_arguments(boost::program_options::variables_map& vm, const SubCmdOptions& options, bool validate_arguments = true) const;
 
  private:
   OptionOptions() = delete;

--- a/src/runtime_src/core/tools/common/SubCmd.cpp
+++ b/src/runtime_src/core/tools/common/SubCmd.cpp
@@ -45,29 +45,20 @@ SubCmd::SubCmd(const std::string & _name,
 }
 
 void
-SubCmd::printHelp( const boost::program_options::options_description & _optionDescription,
-                   const boost::program_options::options_description & _optionHidden,
-                   bool removeLongOptDashes,
-                   const std::string& customHelpSection) const
-{
-  boost::program_options::positional_options_description emptyPOD;
-  XBUtilities::report_subcommand_help(m_executableName, m_subCmdName, m_longDescription,  m_exampleSyntax, _optionDescription, _optionHidden, emptyPOD, m_globalOptions, removeLongOptDashes, customHelpSection);
-}
-
-void
-SubCmd::printHelp( const boost::program_options::options_description & _optionDescription,
-                   const boost::program_options::options_description & _optionHidden,
-                   const SubOptionOptions & _subOptionOptions) const
-{
-  XBUtilities::report_subcommand_help(m_executableName, m_subCmdName, m_longDescription,  m_exampleSyntax, _optionDescription, _optionHidden, _subOptionOptions, m_globalOptions);
-}
-
-void
-SubCmd::printHelp(bool removeLongOptDashes, 
+SubCmd::printHelp(bool removeLongOptDashes,
                   const std::string& customHelpSection) const
 {
-  std::cout << customHelpSection << removeLongOptDashes;
-  XBUtilities::report_subcommand_help(m_executableName, m_subCmdName, m_longDescription,  m_exampleSyntax, m_commonOptions, m_hiddenOptions, m_subOptionOptions, m_globalOptions);
+  XBUtilities::report_subcommand_help(m_executableName,
+                                      m_subCmdName,
+                                      m_longDescription,
+                                      m_exampleSyntax,
+                                      m_commonOptions,
+                                      m_hiddenOptions,
+                                      m_globalOptions,
+                                      m_positionals,
+                                      m_subOptionOptions,
+                                      removeLongOptDashes,
+                                      customHelpSection);
 }
 
 std::vector<std::string> 
@@ -106,7 +97,13 @@ SubCmd::process_arguments( boost::program_options::variables_map& vm,
                           const SubCmdOptions& _options,
                           bool validate_arguments) const
 {
-  return process_arguments(vm, _options, m_commonOptions, m_hiddenOptions, m_positionals, m_subOptionOptions, validate_arguments);
+  return process_arguments( vm,
+                            _options,
+                            m_commonOptions,
+                            m_hiddenOptions,
+                            m_positionals,
+                            m_subOptionOptions,
+                            validate_arguments);
 }
 
 void 

--- a/src/runtime_src/core/tools/common/SubCmd.cpp
+++ b/src/runtime_src/core/tools/common/SubCmd.cpp
@@ -81,6 +81,9 @@ SubCmd::process_arguments( po::variables_map& vm,
   all_options.add(common_options);
   all_options.add(hidden_options);
 
+  for (const auto & subCmd : suboptions)
+      all_options.add_options()(subCmd->optionNameString().c_str(), subCmd->description().c_str());
+
   try {
     po::command_line_parser parser(_options);
     const auto options = XBU::process_arguments(vm, parser, all_options, positionals, validate_arguments);
@@ -89,7 +92,7 @@ SubCmd::process_arguments( po::variables_map& vm,
         conflictingOptions(vm, suboptions[index1]->longName(), suboptions[index2]->longName());
     return options;
   } catch(boost::program_options::error& e) {
-    printHelp(common_options, hidden_options, suboptions);
+    printHelp();
     XBU::throw_cancel(boost::format("ERROR: %s\n") % e.what());
   }
   return std::vector<std::string>();

--- a/src/runtime_src/core/tools/common/SubCmd.cpp
+++ b/src/runtime_src/core/tools/common/SubCmd.cpp
@@ -61,6 +61,12 @@ SubCmd::printHelp( const boost::program_options::options_description & _optionDe
  XBUtilities::report_subcommand_help(m_executableName, m_subCmdName, m_longDescription,  m_exampleSyntax, _optionDescription, _optionHidden, _subOptionOptions, m_globalOptions);
 }
 
+void
+SubCmd::printHelp() const
+{
+ XBUtilities::report_subcommand_help(m_executableName, m_subCmdName, m_longDescription,  m_exampleSyntax, m_commonOptions, m_hiddenOptions, m_subOptionOptions, m_globalOptions);
+}
+
 std::vector<std::string> 
 SubCmd::process_arguments( po::variables_map& vm,
                            const SubCmdOptions& _options,
@@ -84,6 +90,13 @@ SubCmd::process_arguments( po::variables_map& vm,
   }
 }
 
+std::vector<std::string>
+SubCmd::process_arguments( boost::program_options::variables_map& vm,
+                          const SubCmdOptions& _options,
+                          bool validate_arguments) const
+{
+  return process_arguments(vm, _options, m_commonOptions, m_hiddenOptions, m_positionals, m_subOptionOptions, validate_arguments);
+}
 
 void 
 SubCmd::conflictingOptions( const boost::program_options::variables_map& _vm, 

--- a/src/runtime_src/core/tools/common/SubCmd.cpp
+++ b/src/runtime_src/core/tools/common/SubCmd.cpp
@@ -92,8 +92,9 @@ SubCmd::process_arguments( po::variables_map& vm,
         conflictingOptions(vm, suboptions[index1]->longName(), suboptions[index2]->longName());
     return options;
   } catch(boost::program_options::error& e) {
+    std::cerr << boost::format("ERROR: %s\n") % e.what();
     printHelp();
-    XBU::throw_cancel(boost::format("ERROR: %s\n") % e.what());
+    throw xrt_core::error(std::errc::operation_canceled);
   }
   return std::vector<std::string>();
 }

--- a/src/runtime_src/core/tools/common/SubCmd.cpp
+++ b/src/runtime_src/core/tools/common/SubCmd.cpp
@@ -29,7 +29,7 @@
 namespace XBU = XBUtilities;
 namespace po = boost::program_options;
 
-SubCmd::SubCmd(const std::string &_name, const std::string &_shortDescription)
+SubCmd::SubCmd(const std::string& _name, const std::string& _shortDescription)
   : m_commonOptions("Common Options")
   , m_hiddenOptions("Hidden Options")
   , m_executableName("")
@@ -45,7 +45,7 @@ SubCmd::SubCmd(const std::string &_name, const std::string &_shortDescription)
 }
 
 void
-SubCmd::printHelp(bool removeLongOptDashes, const std::string &customHelpSection) const
+SubCmd::printHelp(bool removeLongOptDashes, const std::string& customHelpSection) const
 {
   XBUtilities::report_subcommand_help(m_executableName,
                                       m_subCmdName,
@@ -61,19 +61,19 @@ SubCmd::printHelp(bool removeLongOptDashes, const std::string &customHelpSection
 }
 
 std::vector<std::string>
-SubCmd::process_arguments(po::variables_map &vm,
-                          const SubCmdOptions &_options,
-                          const po::options_description &common_options,
-                          const po::options_description &hidden_options,
-                          const po::positional_options_description &positionals,
-                          const SubOptionOptions &suboptions,
+SubCmd::process_arguments(po::variables_map& vm,
+                          const SubCmdOptions& _options,
+                          const po::options_description& common_options,
+                          const po::options_description& hidden_options,
+                          const po::positional_options_description& positionals,
+                          const SubOptionOptions& suboptions,
                           bool validate_arguments) const
 {
   po::options_description all_options("All Options");
   all_options.add(common_options);
   all_options.add(hidden_options);
 
-  for (const auto &subCmd : suboptions)
+  for (const auto& subCmd : suboptions)
     all_options.add_options()(subCmd->optionNameString().c_str(), subCmd->description().c_str());
 
   try {
@@ -87,7 +87,7 @@ SubCmd::process_arguments(po::variables_map &vm,
 
     return options;
 
-  } catch (boost::program_options::error &e) {
+  } catch (boost::program_options::error& e) {
     std::cerr << boost::format("ERROR: %s\n") % e.what();
     printHelp();
     throw xrt_core::error(std::errc::operation_canceled);
@@ -95,8 +95,8 @@ SubCmd::process_arguments(po::variables_map &vm,
 }
 
 std::vector<std::string>
-SubCmd::process_arguments(boost::program_options::variables_map &vm,
-                          const SubCmdOptions &_options,
+SubCmd::process_arguments(boost::program_options::variables_map& vm,
+                          const SubCmdOptions& _options,
                           bool validate_arguments) const
 {
   return process_arguments( vm,
@@ -109,9 +109,9 @@ SubCmd::process_arguments(boost::program_options::variables_map &vm,
 }
 
 void
-SubCmd::conflictingOptions(const boost::program_options::variables_map &_vm,
-                           const std::string &_opt1,
-                           const std::string &_opt2) const
+SubCmd::conflictingOptions(const boost::program_options::variables_map& _vm,
+                           const std::string& _opt1,
+                           const std::string& _opt2) const
 {
   if (_vm.count(_opt1)
       && !_vm[_opt1].defaulted()
@@ -129,11 +129,11 @@ SubCmd::addSubOption(std::shared_ptr<OptionOptions> option)
 }
 
 std::shared_ptr<OptionOptions>
-SubCmd::checkForSubOption(const boost::program_options::variables_map &vm) const
+SubCmd::checkForSubOption(const boost::program_options::variables_map& vm) const
 {
   std::shared_ptr<OptionOptions> option;
   // Loop through the available sub options searching for a name match
-  for (auto &subOO : m_subOptionOptions) {
+  for (auto& subOO : m_subOptionOptions) {
     if (vm.count(subOO->longName()) != 0) {
       // Store the matched option if no other match has been found
       if (!option)

--- a/src/runtime_src/core/tools/common/SubCmd.cpp
+++ b/src/runtime_src/core/tools/common/SubCmd.cpp
@@ -22,6 +22,7 @@
 #include <boost/format.hpp>
 
 #include "core/common/error.h"
+#include "XBUtilities.h"
 #include "XBUtilitiesCore.h"
 #include "XBHelpMenusCore.h"
 namespace XBU = XBUtilities;
@@ -82,12 +83,16 @@ SubCmd::process_arguments( po::variables_map& vm,
 
   try {
     po::command_line_parser parser(_options);
-    return XBU::process_arguments(vm, parser, all_options, positionals, validate_arguments);
+    const auto options = XBU::process_arguments(vm, parser, all_options, positionals, validate_arguments);
+    for (unsigned int index1 = 0; index1 < suboptions.size(); ++index1)
+      for (unsigned int index2 = index1 + 1; index2 < suboptions.size(); ++index2)
+        conflictingOptions(vm, suboptions[index1]->longName(), suboptions[index2]->longName());
+    return options;
   } catch(boost::program_options::error& e) {
-    std::cerr << boost::format("ERROR: %s\n") % e.what();
     printHelp(common_options, hidden_options, suboptions);
-    throw xrt_core::error(std::errc::operation_canceled);
+    XBU::throw_cancel(boost::format("ERROR: %s\n") % e.what());
   }
+  return std::vector<std::string>();
 }
 
 std::vector<std::string>

--- a/src/runtime_src/core/tools/common/SubCmd.cpp
+++ b/src/runtime_src/core/tools/common/SubCmd.cpp
@@ -92,7 +92,6 @@ SubCmd::process_arguments(po::variables_map &vm,
     printHelp();
     throw xrt_core::error(std::errc::operation_canceled);
   }
-  return std::vector<std::string>();
 }
 
 std::vector<std::string>

--- a/src/runtime_src/core/tools/common/SubCmd.cpp
+++ b/src/runtime_src/core/tools/common/SubCmd.cpp
@@ -59,13 +59,15 @@ SubCmd::printHelp( const boost::program_options::options_description & _optionDe
                    const boost::program_options::options_description & _optionHidden,
                    const SubOptionOptions & _subOptionOptions) const
 {
- XBUtilities::report_subcommand_help(m_executableName, m_subCmdName, m_longDescription,  m_exampleSyntax, _optionDescription, _optionHidden, _subOptionOptions, m_globalOptions);
+  XBUtilities::report_subcommand_help(m_executableName, m_subCmdName, m_longDescription,  m_exampleSyntax, _optionDescription, _optionHidden, _subOptionOptions, m_globalOptions);
 }
 
 void
-SubCmd::printHelp() const
+SubCmd::printHelp(bool removeLongOptDashes, 
+                  const std::string& customHelpSection) const
 {
- XBUtilities::report_subcommand_help(m_executableName, m_subCmdName, m_longDescription,  m_exampleSyntax, m_commonOptions, m_hiddenOptions, m_subOptionOptions, m_globalOptions);
+  std::cout << customHelpSection << removeLongOptDashes;
+  XBUtilities::report_subcommand_help(m_executableName, m_subCmdName, m_longDescription,  m_exampleSyntax, m_commonOptions, m_hiddenOptions, m_subOptionOptions, m_globalOptions);
 }
 
 std::vector<std::string> 

--- a/src/runtime_src/core/tools/common/SubCmd.cpp
+++ b/src/runtime_src/core/tools/common/SubCmd.cpp
@@ -114,10 +114,6 @@ SubCmd::conflictingOptions( const boost::program_options::variables_map& _vm,
 void
 SubCmd::addSubOption(std::shared_ptr<OptionOptions> option)
 {
-  if (option->isHidden()) 
-    m_hiddenOptions.add_options()(option->optionNameString().c_str(), option->description().c_str());
-  else
-    m_commonOptions.add_options()(option->optionNameString().c_str(), option->description().c_str());
   option->setExecutable(getExecutableName());
   option->setCommand(getName());
   m_subOptionOptions.emplace_back(option);

--- a/src/runtime_src/core/tools/common/SubCmd.cpp
+++ b/src/runtime_src/core/tools/common/SubCmd.cpp
@@ -123,10 +123,6 @@ SubCmd::conflictingOptions( const boost::program_options::variables_map& _vm,
 void
 SubCmd::addSubOption(std::shared_ptr<OptionOptions> option)
 {
-  if (option->isHidden()) 
-    m_hiddenOptions.add_options()(option->optionNameString().c_str(), option->description().c_str());
-  else
-    m_commonOptions.add_options()(option->optionNameString().c_str(), option->description().c_str());
   option->setExecutable(getExecutableName());
   option->setCommand(getName());
   m_subOptionOptions.emplace_back(option);

--- a/src/runtime_src/core/tools/common/SubCmd.cpp
+++ b/src/runtime_src/core/tools/common/SubCmd.cpp
@@ -92,9 +92,8 @@ SubCmd::process_arguments( po::variables_map& vm,
         conflictingOptions(vm, suboptions[index1]->longName(), suboptions[index2]->longName());
     return options;
   } catch(boost::program_options::error& e) {
-    std::cerr << boost::format("ERROR: %s\n") % e.what();
-    printHelp();
-    throw xrt_core::error(std::errc::operation_canceled);
+    printHelp(common_options, hidden_options, suboptions);
+    XBU::throw_cancel(boost::format("ERROR: %s\n") % e.what());
   }
   return std::vector<std::string>();
 }

--- a/src/runtime_src/core/tools/common/SubCmd.cpp
+++ b/src/runtime_src/core/tools/common/SubCmd.cpp
@@ -123,6 +123,10 @@ SubCmd::conflictingOptions( const boost::program_options::variables_map& _vm,
 void
 SubCmd::addSubOption(std::shared_ptr<OptionOptions> option)
 {
+  if (option->isHidden()) 
+    m_hiddenOptions.add_options()(option->optionNameString().c_str(), option->description().c_str());
+  else
+    m_commonOptions.add_options()(option->optionNameString().c_str(), option->description().c_str());
   option->setExecutable(getExecutableName());
   option->setCommand(getName());
   m_subOptionOptions.emplace_back(option);

--- a/src/runtime_src/core/tools/common/SubCmd.cpp
+++ b/src/runtime_src/core/tools/common/SubCmd.cpp
@@ -92,7 +92,7 @@ SubCmd::process_arguments( po::variables_map& vm,
         conflictingOptions(vm, suboptions[index1]->longName(), suboptions[index2]->longName());
     return options;
   } catch(boost::program_options::error& e) {
-    printHelp(common_options, hidden_options, suboptions);
+    printHelp();
     XBU::throw_cancel(boost::format("ERROR: %s\n") % e.what());
   }
   return std::vector<std::string>();

--- a/src/runtime_src/core/tools/common/SubCmd.h
+++ b/src/runtime_src/core/tools/common/SubCmd.h
@@ -72,7 +72,8 @@ public:
   void printHelp( const boost::program_options::options_description & _optionDescription,
                   const boost::program_options::options_description & _optionHidden,
                   const SubOptionOptions & _subOptionOptions) const;
-  void printHelp() const;
+  void printHelp( bool removeLongOptDashes = false,
+                  const std::string& customHelpSection = "") const;
   std::vector<std::string> process_arguments( boost::program_options::variables_map& vm,
                            const SubCmdOptions& _options,
                            const boost::program_options::options_description& common_options,

--- a/src/runtime_src/core/tools/common/SubCmd.h
+++ b/src/runtime_src/core/tools/common/SubCmd.h
@@ -65,13 +65,6 @@ public:
   void setIsDefaultDevValid(bool _defaultDeviceValid) { m_defaultDeviceValid = _defaultDeviceValid; };
   void setLongDescription(const std::string &_longDescription) {m_longDescription = _longDescription; };
   void setExampleSyntax(const std::string &_exampleSyntax) {m_exampleSyntax = _exampleSyntax; };
-  void printHelp(const boost::program_options::options_description & _optionDescription,
-                 const boost::program_options::options_description & _optionHidden,
-                 bool removeLongOptDashes = false,
-                 const std::string& customHelpSection = "") const;
-  void printHelp( const boost::program_options::options_description & _optionDescription,
-                  const boost::program_options::options_description & _optionHidden,
-                  const SubOptionOptions & _subOptionOptions) const;
   void printHelp( bool removeLongOptDashes = false,
                   const std::string& customHelpSection = "") const;
   std::vector<std::string> process_arguments( boost::program_options::variables_map& vm,

--- a/src/runtime_src/core/tools/common/SubCmd.h
+++ b/src/runtime_src/core/tools/common/SubCmd.h
@@ -32,54 +32,54 @@ class SubCmd {
   using SubOptionOptions = std::vector<std::shared_ptr<OptionOptions>>;
 
  public:
-  virtual void execute(const SubCmdOptions &_options) const = 0;
+  virtual void execute(const SubCmdOptions& _options) const = 0;
 
  public:
-  const std::string &getName() const { return m_subCmdName; };
-  const std::string &getShortDescription() const { return m_shortDescription; };
+  const std::string& getName() const { return m_subCmdName; };
+  const std::string& getShortDescription() const { return m_shortDescription; };
   bool isHidden() const { return m_isHidden; };
   bool isDeprecated() const { return m_isDeprecated; };
   bool isPreliminary() const { return m_isPreliminary; };
   bool isDefaultDeviceValid() const { return m_defaultDeviceValid; };
 
  public:
-  void setExecutableName(const std::string &_name) { m_executableName = _name; };
-  const std::string &getExecutableName() const { return m_executableName; };
+  void setExecutableName(const std::string& _name) { m_executableName = _name; };
+  const std::string& getExecutableName() const { return m_executableName; };
 
-  void setGlobalOptions(const boost::program_options::options_description &globalOptions) { m_globalOptions.add(globalOptions); };
+  void setGlobalOptions(const boost::program_options::options_description& globalOptions) { m_globalOptions.add(globalOptions); };
 
  protected:
-  const boost::program_options::options_description &getGlobalOptions() const { return m_globalOptions; };
+  const boost::program_options::options_description& getGlobalOptions() const { return m_globalOptions; };
 
  public:
   virtual ~SubCmd(){};
 
   // Child class Helper methods
  protected:
-  SubCmd(const std::string &_name, const std::string &_shortDescription);
+  SubCmd(const std::string& _name, const std::string& _shortDescription);
   void setIsHidden(bool _isHidden) { m_isHidden = _isHidden; };
   void setIsDeprecated(bool _isDeprecated) { m_isDeprecated = _isDeprecated; };
   void setIsPreliminary(bool _isPreliminary) { m_isPreliminary = _isPreliminary; };
   void setIsDefaultDevValid(bool _defaultDeviceValid) { m_defaultDeviceValid = _defaultDeviceValid; };
-  void setLongDescription(const std::string &_longDescription) { m_longDescription = _longDescription; };
-  void setExampleSyntax(const std::string &_exampleSyntax) { m_exampleSyntax = _exampleSyntax; };
-  void printHelp(bool removeLongOptDashes = false, const std::string &customHelpSection = "") const;
-  std::vector<std::string> process_arguments(boost::program_options::variables_map &vm,
-                                             const SubCmdOptions &_options,
-                                             const boost::program_options::options_description &common_options,
-                                             const boost::program_options::options_description &hidden_options,
-                                             const boost::program_options::positional_options_description &positionals =
+  void setLongDescription(const std::string& _longDescription) { m_longDescription = _longDescription; };
+  void setExampleSyntax(const std::string& _exampleSyntax) { m_exampleSyntax = _exampleSyntax; };
+  void printHelp(bool removeLongOptDashes = false, const std::string& customHelpSection = "") const;
+  std::vector<std::string> process_arguments(boost::program_options::variables_map& vm,
+                                             const SubCmdOptions& _options,
+                                             const boost::program_options::options_description& common_options,
+                                             const boost::program_options::options_description& hidden_options,
+                                             const boost::program_options::positional_options_description& positionals =
                                                  boost::program_options::positional_options_description(),
-                                             const SubOptionOptions &suboptions = SubOptionOptions(),
+                                             const SubOptionOptions& suboptions = SubOptionOptions(),
                                              bool validate_arguments = true) const;
-  std::vector<std::string> process_arguments(boost::program_options::variables_map &vm,
-                                             const SubCmdOptions &_options,
+  std::vector<std::string> process_arguments(boost::program_options::variables_map& vm,
+                                             const SubCmdOptions& _options,
                                              bool validate_arguments = true) const;
-  void conflictingOptions(const boost::program_options::variables_map &_vm,
-                          const std::string &_opt1,
-                          const std::string &_opt2) const;
+  void conflictingOptions(const boost::program_options::variables_map& _vm,
+                          const std::string& _opt1,
+                          const std::string& _opt2) const;
   void addSubOption(std::shared_ptr<OptionOptions> option);
-  std::shared_ptr<OptionOptions> checkForSubOption(const boost::program_options::variables_map &vm) const;
+  std::shared_ptr<OptionOptions> checkForSubOption(const boost::program_options::variables_map& vm) const;
 
  protected:
   SubOptionOptions m_subOptionOptions;

--- a/src/runtime_src/core/tools/common/SubCmd.h
+++ b/src/runtime_src/core/tools/common/SubCmd.h
@@ -88,7 +88,7 @@ public:
   void addSubOption(std::shared_ptr<OptionOptions> option);
   std::shared_ptr<OptionOptions> checkForSubOption(const boost::program_options::variables_map& vm) const;
 
-
+protected:
   SubOptionOptions m_subOptionOptions;
   boost::program_options::options_description m_commonOptions;
   boost::program_options::options_description m_hiddenOptions;

--- a/src/runtime_src/core/tools/common/SubCmd.h
+++ b/src/runtime_src/core/tools/common/SubCmd.h
@@ -72,6 +72,7 @@ public:
   void printHelp( const boost::program_options::options_description & _optionDescription,
                   const boost::program_options::options_description & _optionHidden,
                   const SubOptionOptions & _subOptionOptions) const;
+  void printHelp() const;
   std::vector<std::string> process_arguments( boost::program_options::variables_map& vm,
                            const SubCmdOptions& _options,
                            const boost::program_options::options_description& common_options,
@@ -79,10 +80,15 @@ public:
                            const boost::program_options::positional_options_description& positionals = boost::program_options::positional_options_description(),
                            const SubOptionOptions& suboptions = SubOptionOptions(),
                            bool validate_arguments = true) const;
+  std::vector<std::string> process_arguments( boost::program_options::variables_map& vm,
+                           const SubCmdOptions& _options,
+                           bool validate_arguments = true) const;
   void conflictingOptions( const boost::program_options::variables_map& _vm, 
                            const std::string &_opt1, const std::string &_opt2) const;
   void addSubOption(std::shared_ptr<OptionOptions> option);
   std::shared_ptr<OptionOptions> checkForSubOption(const boost::program_options::variables_map& vm) const;
+
+
   SubOptionOptions m_subOptionOptions;
   boost::program_options::options_description m_commonOptions;
   boost::program_options::options_description m_hiddenOptions;

--- a/src/runtime_src/core/tools/common/SubCmd.h
+++ b/src/runtime_src/core/tools/common/SubCmd.h
@@ -19,70 +19,69 @@
 #define __SubCmd_h_
 
 // Please keep eternal include file dependencies to a minimum
-#include <vector>
-#include <string>
-#include <map>
 #include <boost/program_options.hpp>
+#include <map>
+#include <string>
+#include <vector>
 
 #include "OptionOptions.h"
-  
+
 class SubCmd {
  public:
-   using SubCmdOptions = std::vector<std::string>;
-   using SubOptionOptions = std::vector<std::shared_ptr<OptionOptions>>;
+  using SubCmdOptions = std::vector<std::string>;
+  using SubOptionOptions = std::vector<std::shared_ptr<OptionOptions>>;
 
  public:
-   virtual void execute(const SubCmdOptions &_options) const = 0;
+  virtual void execute(const SubCmdOptions &_options) const = 0;
 
  public:
-   const std::string &getName() const { return m_subCmdName; };
-   const std::string &getShortDescription() const { return m_shortDescription; };
-   bool isHidden() const { return m_isHidden; };
-   bool isDeprecated() const { return m_isDeprecated; };
-   bool isPreliminary() const { return m_isPreliminary; };
-   bool isDefaultDeviceValid() const { return m_defaultDeviceValid; };
+  const std::string &getName() const { return m_subCmdName; };
+  const std::string &getShortDescription() const { return m_shortDescription; };
+  bool isHidden() const { return m_isHidden; };
+  bool isDeprecated() const { return m_isDeprecated; };
+  bool isPreliminary() const { return m_isPreliminary; };
+  bool isDefaultDeviceValid() const { return m_defaultDeviceValid; };
 
  public:
-   void setExecutableName(const std::string & _name) { m_executableName = _name; };
-   const std::string & getExecutableName() const {return m_executableName; };
+  void setExecutableName(const std::string &_name) { m_executableName = _name; };
+  const std::string &getExecutableName() const { return m_executableName; };
 
-   void setGlobalOptions(const boost::program_options::options_description &globalOptions) { m_globalOptions.add(globalOptions); };
+  void setGlobalOptions(const boost::program_options::options_description &globalOptions) { m_globalOptions.add(globalOptions); };
 
  protected:
-   const boost::program_options::options_description & getGlobalOptions() const { return m_globalOptions; };
+  const boost::program_options::options_description &getGlobalOptions() const { return m_globalOptions; };
 
  public:
-   virtual ~SubCmd() {};
+  virtual ~SubCmd(){};
 
-public:
-
- // Child class Helper methods
+  // Child class Helper methods
  protected:
-  SubCmd(const std::string & _name, const std::string & _shortDescription);
+  SubCmd(const std::string &_name, const std::string &_shortDescription);
   void setIsHidden(bool _isHidden) { m_isHidden = _isHidden; };
   void setIsDeprecated(bool _isDeprecated) { m_isDeprecated = _isDeprecated; };
   void setIsPreliminary(bool _isPreliminary) { m_isPreliminary = _isPreliminary; };
   void setIsDefaultDevValid(bool _defaultDeviceValid) { m_defaultDeviceValid = _defaultDeviceValid; };
-  void setLongDescription(const std::string &_longDescription) {m_longDescription = _longDescription; };
-  void setExampleSyntax(const std::string &_exampleSyntax) {m_exampleSyntax = _exampleSyntax; };
-  void printHelp( bool removeLongOptDashes = false,
-                  const std::string& customHelpSection = "") const;
-  std::vector<std::string> process_arguments( boost::program_options::variables_map& vm,
-                           const SubCmdOptions& _options,
-                           const boost::program_options::options_description& common_options,
-                           const boost::program_options::options_description& hidden_options,
-                           const boost::program_options::positional_options_description& positionals = boost::program_options::positional_options_description(),
-                           const SubOptionOptions& suboptions = SubOptionOptions(),
-                           bool validate_arguments = true) const;
-  std::vector<std::string> process_arguments( boost::program_options::variables_map& vm,
-                           const SubCmdOptions& _options,
-                           bool validate_arguments = true) const;
-  void conflictingOptions( const boost::program_options::variables_map& _vm, 
-                           const std::string &_opt1, const std::string &_opt2) const;
+  void setLongDescription(const std::string &_longDescription) { m_longDescription = _longDescription; };
+  void setExampleSyntax(const std::string &_exampleSyntax) { m_exampleSyntax = _exampleSyntax; };
+  void printHelp(bool removeLongOptDashes = false, const std::string &customHelpSection = "") const;
+  std::vector<std::string> process_arguments(boost::program_options::variables_map &vm,
+                                             const SubCmdOptions &_options,
+                                             const boost::program_options::options_description &common_options,
+                                             const boost::program_options::options_description &hidden_options,
+                                             const boost::program_options::positional_options_description &positionals =
+                                                 boost::program_options::positional_options_description(),
+                                             const SubOptionOptions &suboptions = SubOptionOptions(),
+                                             bool validate_arguments = true) const;
+  std::vector<std::string> process_arguments(boost::program_options::variables_map &vm,
+                                             const SubCmdOptions &_options,
+                                             bool validate_arguments = true) const;
+  void conflictingOptions(const boost::program_options::variables_map &_vm,
+                          const std::string &_opt1,
+                          const std::string &_opt2) const;
   void addSubOption(std::shared_ptr<OptionOptions> option);
-  std::shared_ptr<OptionOptions> checkForSubOption(const boost::program_options::variables_map& vm) const;
+  std::shared_ptr<OptionOptions> checkForSubOption(const boost::program_options::variables_map &vm) const;
 
-protected:
+ protected:
   SubOptionOptions m_subOptionOptions;
   boost::program_options::options_description m_commonOptions;
   boost::program_options::options_description m_hiddenOptions;
@@ -91,7 +90,6 @@ protected:
  private:
   SubCmd() = delete;
 
- // Variables
  private:
   std::string m_executableName;
   std::string m_subCmdName;
@@ -107,5 +105,3 @@ protected:
 };
 
 #endif
-
-

--- a/src/runtime_src/core/tools/common/SubCmd.h
+++ b/src/runtime_src/core/tools/common/SubCmd.h
@@ -81,6 +81,12 @@ public:
                            bool validate_arguments = true) const;
   void conflictingOptions( const boost::program_options::variables_map& _vm, 
                            const std::string &_opt1, const std::string &_opt2) const;
+  void addSubOption(std::shared_ptr<OptionOptions> option);
+  std::shared_ptr<OptionOptions> checkForSubOption(const boost::program_options::variables_map& vm) const;
+  SubOptionOptions m_subOptionOptions;
+  boost::program_options::options_description m_commonOptions;
+  boost::program_options::options_description m_hiddenOptions;
+  boost::program_options::positional_options_description m_positionals;
 
  private:
   SubCmd() = delete;

--- a/src/runtime_src/core/tools/common/SubCmd.h
+++ b/src/runtime_src/core/tools/common/SubCmd.h
@@ -87,8 +87,6 @@ public:
                            const std::string &_opt1, const std::string &_opt2) const;
   void addSubOption(std::shared_ptr<OptionOptions> option);
   std::shared_ptr<OptionOptions> checkForSubOption(const boost::program_options::variables_map& vm) const;
-
-protected:
   SubOptionOptions m_subOptionOptions;
   boost::program_options::options_description m_commonOptions;
   boost::program_options::options_description m_hiddenOptions;

--- a/src/runtime_src/core/tools/common/SubCmd.h
+++ b/src/runtime_src/core/tools/common/SubCmd.h
@@ -87,6 +87,8 @@ public:
                            const std::string &_opt1, const std::string &_opt2) const;
   void addSubOption(std::shared_ptr<OptionOptions> option);
   std::shared_ptr<OptionOptions> checkForSubOption(const boost::program_options::variables_map& vm) const;
+
+
   SubOptionOptions m_subOptionOptions;
   boost::program_options::options_description m_commonOptions;
   boost::program_options::options_description m_hiddenOptions;

--- a/src/runtime_src/core/tools/common/SubCmdJSON.cpp
+++ b/src/runtime_src/core/tools/common/SubCmdJSON.cpp
@@ -55,8 +55,7 @@ SubCmdJSON::SubCmdJSON(bool _isHidden, bool _isDepricated, bool _isPreliminary, 
     , m_subCmdOptions(_subCmdOptions)
     , m_help(false)
 {
-  const std::string longDescription = desc;
-  setLongDescription(longDescription);
+  setLongDescription(desc);
   setExampleSyntax("");
   setIsHidden(_isHidden);
   setIsDeprecated(_isDepricated);

--- a/src/runtime_src/core/tools/common/SubCmdJSON.cpp
+++ b/src/runtime_src/core/tools/common/SubCmdJSON.cpp
@@ -69,18 +69,15 @@ SubCmdJSON::SubCmdJSON(bool _isHidden,
 
   m_commonOptions.add_options()("help", boost::program_options::bool_switch(&m_help), "Help to use this sub-command");
 
-  for (auto &opt : m_subCmdOptions) {
+  for (auto &opt : m_subCmdOptions)
     m_commonOptions.add_options()(opt.option.c_str(), opt.description.c_str());
-  }
 
   m_hiddenOptions.add_options()
     ("subCmd", po::value<std::string>(), "Command to execute")
-    ("subCmdArgs", po::value<std::vector<std::string> >(), "Arguments for command")
   ;
 
   m_positionals
-    .add("subCmd", 1 /* max_count */)
-    .add("subCmdArgs", -1 /* Unlimited max_count */);
+    .add("subCmd", 1 /* max_count */);
 }
 
 void

--- a/src/runtime_src/core/tools/common/SubCmdJSON.h
+++ b/src/runtime_src/core/tools/common/SubCmdJSON.h
@@ -35,7 +35,8 @@ class SubCmdJSON : public SubCmd {
   SubCmdJSON(bool _isHidden, bool _isDepricated, bool _isPreliminary, std::string& name, std::string& desc, std::vector<struct JSONCmd>& _subCmdOptions);
 
  private:
-  std::vector<struct JSONCmd> subCmdOptions;
+  std::vector<struct JSONCmd> m_subCmdOptions;
+  bool                        m_help;
 };
 
 using SubCmdsCollection = std::vector<std::shared_ptr<SubCmd>>;

--- a/src/runtime_src/core/tools/common/SubCmdJSON.h
+++ b/src/runtime_src/core/tools/common/SubCmdJSON.h
@@ -19,12 +19,13 @@
 
 #include "tools/common/SubCmd.h"
 
-struct JSONCmd {
-    std::string parentName;
-    std::string description;
-    std::string application;
-    std::string defaultArgs;
-    std::string option;
+struct JSONCmd
+{
+  std::string parentName;
+  std::string description;
+  std::string application;
+  std::string defaultArgs;
+  std::string option;
 };
 
 class SubCmdJSON : public SubCmd {
@@ -32,14 +33,19 @@ class SubCmdJSON : public SubCmd {
   virtual void execute(const SubCmdOptions &_options) const;
 
  public:
-  SubCmdJSON(bool _isHidden, bool _isDepricated, bool _isPreliminary, std::string& name, std::string& desc, std::vector<struct JSONCmd>& _subCmdOptions);
+  SubCmdJSON(bool _isHidden,
+             bool _isDepricated,
+             bool _isPreliminary,
+             std::string &name,
+             std::string &desc,
+             std::vector<struct JSONCmd> &_subCmdOptions);
 
  private:
   std::vector<struct JSONCmd> m_subCmdOptions;
-  bool                        m_help;
+  bool m_help;
 };
 
 using SubCmdsCollection = std::vector<std::shared_ptr<SubCmd>>;
-void populateSubCommandsFromJSON(SubCmdsCollection &subCmds, const std::string& exeName);
+void populateSubCommandsFromJSON(SubCmdsCollection &subCmds, const std::string &exeName);
 
 #endif

--- a/src/runtime_src/core/tools/common/XBHelpMenus.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenus.cpp
@@ -141,8 +141,8 @@ XBUtilities::collect_and_validate_reports( const ReportCollection &allReportsAva
 void 
 XBUtilities::produce_reports( const std::shared_ptr<xrt_core::device>& device, 
                               const ReportCollection & reportsToProcess, 
-                              Report::SchemaVersion schemaVersion, 
-                              std::vector<std::string> & elementFilter,
+                              const Report::SchemaVersion schemaVersion, 
+                              const std::vector<std::string> & elementFilter,
                               std::ostream & consoleStream,
                               std::ostream & schemaStream)
 {

--- a/src/runtime_src/core/tools/common/XBHelpMenus.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenus.cpp
@@ -4,14 +4,14 @@
 
 // ------ I N C L U D E   F I L E S -------------------------------------------
 // Local - Include Files
-#include "core/common/time.h"
-#include "core/common/query_requests.h"
-#include "XBHelpMenusCore.h"
-#include "XBUtilitiesCore.h"
 #include "XBHelpMenus.h"
+#include "XBHelpMenusCore.h"
 #include "XBUtilities.h"
-namespace XBU = XBUtilities;
+#include "XBUtilitiesCore.h"
+#include "core/common/query_requests.h"
+#include "core/common/time.h"
 
+namespace XBU = XBUtilities;
 
 // 3rd Party Library - Include Files
 #include <boost/format.hpp>
@@ -31,35 +31,35 @@ static unsigned int m_maxColumnWidth = 100;
 static unsigned int m_shortDescriptionColumn = 24;
 
 // ------ F U N C T I O N S ---------------------------------------------------
-std::string 
-XBUtilities::create_suboption_list_string(const VectorPairStrings &_collection)
+std::string
+XBUtilities::create_suboption_list_string(const VectorPairStrings& _collection)
 {
   // Working variables
-  const unsigned int maxColumnWidth = m_maxColumnWidth - m_shortDescriptionColumn; 
-  std::string supportedValues;        // Formatted string of supported values
-                                      
+  const unsigned int maxColumnWidth = m_maxColumnWidth - m_shortDescriptionColumn;
+  std::string supportedValues;  // Formatted string of supported values
+
   // Make a copy of the data (since it is going to be modified)
   VectorPairStrings workingCollection = _collection;
 
   // Determine the indention width
   unsigned int maxStringLength = 0;
-  for (auto & pairs : workingCollection) {
+  for (auto& pairs : workingCollection) {
     // Determine if the keyName needs to have 'quotes', if so add them
-    if (pairs.first.find(' ') != std::string::npos ) {
-      pairs.first.insert(0, 1, '\'');  
-      pairs.first += "\'";     
+    if (pairs.first.find(' ') != std::string::npos) {
+      pairs.first.insert(0, 1, '\'');
+      pairs.first += "\'";
     }
 
     maxStringLength = std::max<unsigned int>(maxStringLength, static_cast<unsigned int>(pairs.first.length()));
   }
 
   const unsigned int indention = maxStringLength + 5;  // New line indention after the '-' character (5 extra spaces)
-  boost::format reportFmt(std::string("  %-") + std::to_string(maxStringLength) + "s - %s");  
-  boost::format reportFmtQuotes(std::string(" %-") + std::to_string(maxStringLength + 1) + "s - %s");  
+  boost::format reportFmt(std::string("  %-") + std::to_string(maxStringLength) + "s - %s");
+  boost::format reportFmtQuotes(std::string(" %-") + std::to_string(maxStringLength + 1) + "s - %s");
 
   // Report names and description
-  for (const auto & pairs : workingCollection) {
-    boost::format &reportFormat = pairs.first[0] == '\'' ? reportFmtQuotes : reportFmt;
+  for (const auto& pairs : workingCollection) {
+    boost::format& reportFormat = pairs.first[0] == '\'' ? reportFmtQuotes : reportFmt;
     auto formattedString = XBU::wrap_paragraphs(boost::str(reportFormat % pairs.first % pairs.second), indention, maxColumnWidth, false /*indent first line*/);
     supportedValues += formattedString + "\n";
   }
@@ -67,68 +67,67 @@ XBUtilities::create_suboption_list_string(const VectorPairStrings &_collection)
   return supportedValues;
 }
 
-
-
-std::string 
-XBUtilities::create_suboption_list_string( const ReportCollection &_reportCollection, 
-                                           bool _addAllOption)
+std::string
+XBUtilities::create_suboption_list_string(const ReportCollection& _reportCollection, bool _addAllOption)
 {
   VectorPairStrings reportDescriptionCollection;
 
   // Add the report names and description
-  for (const auto & report : _reportCollection) {
+  for (const auto& report : _reportCollection) {
     // Skip hidden reports
-    if (!XBU::getShowHidden() && report->isHidden()) 
+    if (!XBU::getShowHidden() && report->isHidden())
       continue;
     reportDescriptionCollection.emplace_back(report->getReportName(), report->getShortDescription());
   }
 
   // 'verbose' option
-  if (_addAllOption) 
+  if (_addAllOption)
     reportDescriptionCollection.emplace_back("all", "All known reports are produced");
 
   // Sort the collection
   sort(reportDescriptionCollection.begin(), reportDescriptionCollection.end(), 
-       [](const std::pair<std::string, std::string> & a, const std::pair<std::string, std::string> & b) -> bool
+       [](const std::pair<std::string, std::string>& a, const std::pair<std::string, std::string>& b) -> bool
        { return (a.first.compare(b.first) < 0); });
 
   return create_suboption_list_string(reportDescriptionCollection);
 }
 
-std::string 
-XBUtilities::create_suboption_list_string( const Report::SchemaDescriptionVector &_formatCollection)
+std::string
+XBUtilities::create_suboption_list_string(const Report::SchemaDescriptionVector& _formatCollection)
 {
   VectorPairStrings reportDescriptionCollection;
 
   // report names and description
-  for (const auto & format : _formatCollection) {
-    if (format.isVisable == true) 
+  for (const auto& format : _formatCollection) {
+    if (format.isVisable == true)
       reportDescriptionCollection.emplace_back(format.optionName, format.shortDescription);
   }
 
   return create_suboption_list_string(reportDescriptionCollection);
 }
 
-
-void 
-XBUtilities::collect_and_validate_reports( const ReportCollection &allReportsAvailable,
-                                           const std::vector<std::string> &reportNamesToAdd,
-                                           ReportCollection & reportsToUse)
+void
+XBUtilities::collect_and_validate_reports(const ReportCollection& allReportsAvailable,
+                                          const std::vector<std::string>& reportNamesToAdd,
+                                          ReportCollection& reportsToUse)
 {
   // If "verbose" used, then use all of the reports
   if (std::find(reportNamesToAdd.begin(), reportNamesToAdd.end(), "all") != reportNamesToAdd.end()) {
-    for (const auto & report : allReportsAvailable) {
+    for (const auto& report : allReportsAvailable) {
       // Skip hidden reports
-      if (report->isHidden()) 
+      if (report->isHidden())
         continue;
       reportsToUse.emplace_back(report);
     }
-  } else { 
-    // Examine each report name for a match 
-    for (const auto & reportName : reportNamesToAdd) {
-      auto iter = std::find_if(allReportsAvailable.begin(), allReportsAvailable.end(), 
-                               [&reportName](const std::shared_ptr<Report>& obj) {return obj->getReportName() == reportName;});
-      if (iter != allReportsAvailable.end()) 
+  }
+  else {
+    // Examine each report name for a match
+    for (const auto& reportName : reportNamesToAdd) {
+      auto iter = std::find_if(
+          allReportsAvailable.begin(), allReportsAvailable.end(), [&reportName](const std::shared_ptr<Report>& obj) {
+            return obj->getReportName() == reportName;
+          });
+      if (iter != allReportsAvailable.end())
         reportsToUse.push_back(*iter);
       else {
         throw xrt_core::error((boost::format("No report generator found for report: '%s'\n") % reportName).str());
@@ -137,14 +136,13 @@ XBUtilities::collect_and_validate_reports( const ReportCollection &allReportsAva
   }
 }
 
-
-void 
-XBUtilities::produce_reports( const std::shared_ptr<xrt_core::device>& device, 
-                              const ReportCollection & reportsToProcess, 
-                              const Report::SchemaVersion schemaVersion, 
-                              const std::vector<std::string> & elementFilter,
-                              std::ostream & consoleStream,
-                              std::ostream & schemaStream)
+void
+XBUtilities::produce_reports(const std::shared_ptr<xrt_core::device>& device,
+                             const ReportCollection& reportsToProcess,
+                             const Report::SchemaVersion schemaVersion,
+                             const std::vector<std::string>& elementFilter,
+                             std::ostream& consoleStream,
+                             std::ostream& schemaStream)
 {
   // Some simple DRCs
   if (reportsToProcess.empty()) {
@@ -173,40 +171,43 @@ XBUtilities::produce_reports( const std::shared_ptr<xrt_core::device>& device,
 
   // -- Process the reports that don't require a device
   boost::property_tree::ptree ptSystem;
-  for (const auto & report : reportsToProcess) {
+  for (const auto& report : reportsToProcess) {
     if (report->isDeviceRequired() == true)
       continue;
 
     boost::property_tree::ptree ptReport;
     try {
       report->getFormattedReport(nullptr, schemaVersion, elementFilter, consoleStream, ptReport);
-    } catch (const std::exception&) {
+    }
+    catch (const std::exception&) {
       is_report_output_valid = false;
     }
 
     // Only support 1 node on the root
     if (ptReport.size() > 1)
-      throw xrt_core::error((boost::format("Invalid JSON - The report '%s' has too many root nodes.") % Report::getSchemaDescription(schemaVersion).optionName).str());
+      throw xrt_core::error((boost::format("Invalid JSON - The report '%s' has too many root nodes.")
+                             % Report::getSchemaDescription(schemaVersion).optionName)
+                                .str());
 
     // We have 1 node, copy the child to the root property tree
     if (ptReport.size() == 1) {
-      for (const auto & ptChild : ptReport) 
+      for (const auto& ptChild : ptReport)
         ptSystem.add_child(ptChild.first, ptChild.second);
     }
   }
-  if (!ptSystem.empty()) 
+  if (!ptSystem.empty())
     ptRoot.add_child("system", ptSystem);
 
   // -- Check if any device specific report is requested
   auto dev_report = [reportsToProcess]() {
-    for (auto &report : reportsToProcess) {
+    for (auto& report : reportsToProcess) {
       if (report->isDeviceRequired() == true)
         return true;
     }
     return false;
   };
 
-  if(dev_report()) {
+  if (dev_report()) {
     // -- Process reports that work on a device
     boost::property_tree::ptree ptDevice;
     auto bdf = xrt_core::device_query<xrt_core::query::pcie_bdf>(device);
@@ -216,12 +217,12 @@ XBUtilities::produce_reports( const std::shared_ptr<xrt_core::device>& device,
     bool is_mfg = false;
     try {
       is_mfg = xrt_core::device_query<xrt_core::query::is_mfg>(device);
-    } 
+    }
     catch (const xrt_core::query::exception&) {
       is_mfg = false;
     }
 
-    //if factory mode
+    // if factory mode
     std::string platform;
     try {
       if (is_mfg) {
@@ -230,13 +231,14 @@ XBUtilities::produce_reports( const std::shared_ptr<xrt_core::device>& device,
       else {
         platform = xrt_core::device_query<xrt_core::query::rom_vbnv>(device);
       }
-    } 
+    }
     catch (const xrt_core::query::exception&) {
       // proceed even if the platform name is not available
       platform = "<not defined>";
     }
     // Bound the device description on top and bottom with '-' characters
-    const std::string dev_desc = (boost::format("[%s] : %s\n") % ptDevice.get<std::string>("device_id") % platform).str();
+    const std::string dev_desc =
+        (boost::format("[%s] : %s\n") % ptDevice.get<std::string>("device_id") % platform).str();
     consoleStream << std::endl;
     consoleStream << std::string(dev_desc.length(), '-') << std::endl;
     consoleStream << dev_desc;
@@ -247,7 +249,7 @@ XBUtilities::produce_reports( const std::shared_ptr<xrt_core::device>& device,
     try {
       is_recovery = xrt_core::device_query<xrt_core::query::is_recovery>(device);
     }
-    catch(const xrt_core::query::exception&) { 
+    catch (const xrt_core::query::exception&) {
       is_recovery = false;
     }
 
@@ -258,24 +260,27 @@ XBUtilities::produce_reports( const std::shared_ptr<xrt_core::device>& device,
     if ((is_mfg || !is_ready) && !is_recovery)
       std::cout << "Warning: Device is not ready - Limited functionality available with XRT tools.\n";
 
-    for (auto &report : reportsToProcess) {
+    for (auto& report : reportsToProcess) {
       if (!report->isDeviceRequired())
         continue;
 
       boost::property_tree::ptree ptReport;
       try {
         report->getFormattedReport(device.get(), schemaVersion, elementFilter, consoleStream, ptReport);
-      } catch (const std::exception&) {
+      }
+      catch (const std::exception&) {
         is_report_output_valid = false;
       }
 
       // Only support 1 node on the root
       if (ptReport.size() > 1)
-        throw xrt_core::error((boost::format("Invalid JSON - The report '%s' has too many root nodes.") % Report::getSchemaDescription(schemaVersion).optionName).str());
+        throw xrt_core::error((boost::format("Invalid JSON - The report '%s' has too many root nodes.")
+                               % Report::getSchemaDescription(schemaVersion).optionName)
+                                  .str());
 
       // We have 1 node, copy the child to the root property tree
       if (ptReport.size() == 1) {
-        for (const auto & ptChild : ptReport)
+        for (const auto& ptChild : ptReport)
           ptDevice.add_child(ptChild.first, ptChild.second);
       }
     }
@@ -287,11 +292,11 @@ XBUtilities::produce_reports( const std::shared_ptr<xrt_core::device>& device,
     }
   }
 
-  // -- Write the formatted output 
+  // -- Write the formatted output
   switch (schemaVersion) {
     case Report::SchemaVersion::json_20202:
       boost::property_tree::json_parser::write_json(schemaStream, ptRoot, true /*Pretty Print*/);
-      schemaStream << std::endl;  
+      schemaStream << std::endl;
       break;
 
     default:
@@ -300,7 +305,6 @@ XBUtilities::produce_reports( const std::shared_ptr<xrt_core::device>& device,
   }
 
   // If any the data reports failed to generate with an exception throw an operation cancelled but output everything
-  if(!is_report_output_valid)
+  if (!is_report_output_valid)
     throw xrt_core::error(std::errc::operation_canceled);
 }
-

--- a/src/runtime_src/core/tools/common/XBHelpMenus.h
+++ b/src/runtime_src/core/tools/common/XBHelpMenus.h
@@ -35,8 +35,8 @@ namespace XBUtilities {
   void 
      produce_reports( const std::shared_ptr<xrt_core::device>& device, 
                       const ReportCollection & reportsToProcess, 
-                      Report::SchemaVersion schema, 
-                      std::vector<std::string> & elementFilter,
+                      const Report::SchemaVersion schema, 
+                      const std::vector<std::string> & elementFilter,
                       std::ostream & consoleStream,
                       std::ostream & schemaStream);
 };

--- a/src/runtime_src/core/tools/common/XBHelpMenus.h
+++ b/src/runtime_src/core/tools/common/XBHelpMenus.h
@@ -7,38 +7,38 @@
 
 // Include files
 // Please keep these to the bare minimum
+#include <boost/program_options.hpp>
+#include <string>
+#include <utility>  // Pair template
+#include <vector>
+
 #include "Report.h"
 
-#include <string>
-#include <vector>
-#include <utility> // Pair template
-#include <boost/program_options.hpp>
+namespace XBUtilities
+{
+using VectorPairStrings = std::vector<std::pair<std::string, std::string> >;
 
-namespace XBUtilities {
+std::string
+create_suboption_list_string(const VectorPairStrings& _collection);
 
-  using VectorPairStrings = std::vector< std::pair< std::string, std::string > >;
+std::string
+create_suboption_list_string(const ReportCollection& _reportCollection, bool _addAllOption);
 
-  std::string 
-    create_suboption_list_string(const VectorPairStrings &_collection);
+std::string
+create_suboption_list_string(const Report::SchemaDescriptionVector& _formatCollection);
 
-  std::string 
-    create_suboption_list_string(const ReportCollection &_reportCollection, bool _addAllOption);
+void
+collect_and_validate_reports(const ReportCollection& allReportsAvailable,
+                             const std::vector<std::string>& reportNamesToAdd,
+                             ReportCollection& reportsToUse);
 
-  std::string 
-    create_suboption_list_string(const Report::SchemaDescriptionVector &_formatCollection);
-
-  void 
-    collect_and_validate_reports( const ReportCollection & allReportsAvailable,
-                                  const std::vector<std::string> &reportNamesToAdd,
-                                  ReportCollection & reportsToUse);
-
-  void 
-     produce_reports( const std::shared_ptr<xrt_core::device>& device, 
-                      const ReportCollection & reportsToProcess, 
-                      const Report::SchemaVersion schema, 
-                      const std::vector<std::string> & elementFilter,
-                      std::ostream & consoleStream,
-                      std::ostream & schemaStream);
-};
+void
+produce_reports(const std::shared_ptr<xrt_core::device>& device,
+                const ReportCollection& reportsToProcess,
+                const Report::SchemaVersion schema,
+                const std::vector<std::string>& elementFilter,
+                std::ostream& consoleStream,
+                std::ostream& schemaStream);
+};  // namespace XBUtilities
 
 #endif

--- a/src/runtime_src/core/tools/common/XBHelpMenusCore.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenusCore.cpp
@@ -409,90 +409,17 @@ XBUtilities::report_option_help( const std::string & _groupName,
 }
 
 void 
-XBUtilities::report_subcommand_help( const std::string &_executableName,
-                                     const std::string &_subCommand,
-                                     const std::string &_description, 
-                                     const std::string &_extendedHelp,
-                                     const boost::program_options::options_description &_optionDescription,
-                                     const boost::program_options::options_description &_optionHidden,
-                                     const boost::program_options::positional_options_description & _positionalDescription,
-                                     const boost::program_options::options_description &_globalOptions,
-                                     bool removeLongOptDashes,
-                                     const std::string& customHelpSection)
-{
-  // Formatting color parameters
-  // Color references: https://en.wikipedia.org/wiki/ANSI_escape_code
-  const std::string fgc_header      = XBUtilities::is_escape_codes_disabled() ? "" : ec::fgcolor(FGC_HEADER).string();
-  const std::string fgc_headerBody  = XBUtilities::is_escape_codes_disabled() ? "" : ec::fgcolor(FGC_HEADER_BODY).string();
-  const std::string fgc_poption      = XBUtilities::is_escape_codes_disabled() ? "" : ec::fgcolor(FGC_POSITIONAL).string();
-  const std::string fgc_poptionBody  = XBUtilities::is_escape_codes_disabled() ? "" : ec::fgcolor(FGC_POSITIONAL_BODY).string();
-  const std::string fgc_usageBody   = XBUtilities::is_escape_codes_disabled() ? "" : ec::fgcolor(FGC_USAGE_BODY).string();
-  const std::string fgc_extendedBody = XBUtilities::is_escape_codes_disabled() ? "" : ec::fgcolor(FGC_EXTENDED_BODY).string();
-  const std::string fgc_reset       = XBUtilities::is_escape_codes_disabled() ? "" : ec::fgcolor::reset();
-
-  // -- Command description
-  {
-    static const std::string key = "DESCRIPTION: ";
-    auto formattedString = XBU::wrap_paragraphs(_description, static_cast<unsigned int>(key.size()), m_maxColumnWidth - static_cast<unsigned int>(key.size()), false);
-    boost::format fmtHeader(fgc_header + "\n" + key + fgc_headerBody + "%s\n" + fgc_reset);
-    if ( !formattedString.empty() )
-      std::cout << fmtHeader % formattedString;
-  }
-
-  // -- Command usage
-  const std::string usage = XBU::create_usage_string(_optionDescription, _positionalDescription, removeLongOptDashes);
-  boost::format fmtUsage(fgc_header + "\nUSAGE: " + fgc_usageBody + "%s %s %s\n" + fgc_reset);
-  std::cout << fmtUsage % _executableName % _subCommand % usage;
-  
-  // -- Add positional arguments
-  boost::format fmtOOSubPositional(fgc_poption + "  %-15s" + fgc_poptionBody + " - %s\n" + fgc_reset);
-  for (auto option : _optionDescription.options()) {
-    if ( !::isPositional( option->canonical_display_name(po::command_line_style::allow_dash_for_short),
-                          _positionalDescription))  {
-      continue;
-    }
-
-    std::string optionDisplayFormat = create_option_format_name(option.get(), false);
-    unsigned int optionDescTab = 33;
-    auto formattedString = XBU::wrap_paragraphs(option->description(), optionDescTab, m_maxColumnWidth, false);
-
-    std::string completeOptionName = option->canonical_display_name(po::command_line_style::allow_dash_for_short);
-    std::cout << fmtOOSubPositional % ("<" + option->long_name() + ">") % formattedString;
-  }
-
-
-  // -- Options
-  report_option_help("OPTIONS", _optionDescription, _positionalDescription, false, removeLongOptDashes);
-
-  // -- Custom Section
-  std::cout << customHelpSection << "\n";
-
-  // -- Global Options
-  report_option_help("GLOBAL OPTIONS", _globalOptions, _positionalDescription, false);
-
-  if (XBU::getShowHidden()) 
-    report_option_help("OPTIONS (Hidden)", _optionHidden, _positionalDescription, false);
-
-  // Extended help
-  {
-    boost::format fmtExtHelp(fgc_extendedBody + "\n  %s\n" +fgc_reset);
-    auto formattedString = XBU::wrap_paragraphs(_extendedHelp, 2, m_maxColumnWidth, false);
-    if (!formattedString.empty()) 
-      std::cout << fmtExtHelp % formattedString;
-  }
-}
-
-void 
-XBUtilities::report_subcommand_help( const std::string &_executableName,
-                                     const std::string &_subCommand,
-                                     const std::string &_description, 
-                                     const std::string &_extendedHelp,
-                                     const boost::program_options::options_description &_optionDescription,
-                                     const boost::program_options::options_description &_optionHidden,
-                                     const SubCmd::SubOptionOptions & _subOptionOptions,
-                                     const boost::program_options::options_description &_globalOptions,
-                                     const boost::program_options::positional_options_description & _positionalDescription,
-                                     bool removeLongOptDashes)
+XBUtilities::report_subcommand_help(const std::string &_executableName,
+                                    const std::string &_subCommand,
+                                    const std::string &_description, 
+                                    const std::string &_extendedHelp,
+                                    const boost::program_options::options_description &_optionDescription,
+                                    const boost::program_options::options_description &_optionHidden,
+                                    const boost::program_options::options_description &_globalOptions,
+                                    const boost::program_options::positional_options_description & _positionalDescription,
+                                    const SubCmd::SubOptionOptions & _subOptionOptions,
+                                    bool removeLongOptDashes,
+                                    const std::string& customHelpSection)
 {
   // Formatting color parameters
   // Color references: https://en.wikipedia.org/wiki/ANSI_escape_code
@@ -557,6 +484,9 @@ XBUtilities::report_subcommand_help( const std::string &_executableName,
   // -- Options
   boost::program_options::positional_options_description emptyPOD;
   report_option_help("OPTIONS", allOptions, emptyPOD, false);
+
+  // -- Custom Section
+  std::cout << customHelpSection << "\n";
 
   // -- Global Options
   report_option_help("GLOBAL OPTIONS", _globalOptions, emptyPOD, false);

--- a/src/runtime_src/core/tools/common/XBHelpMenusCore.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenusCore.cpp
@@ -515,8 +515,7 @@ XBUtilities::report_subcommand_help( const std::string &_executableName,
     usageSubCmds.append(subCmd->longName());
   }
 
-  const std::string usage = XBU::create_usage_string(_optionDescription, _positionalDescription, removeLongOptDashes);
-  std::cout << boost::format(fgc_header + "\nUSAGE: " + fgc_usageBody + "%s %s --[ %s ]%s\n" + fgc_reset) % _executableName % _subCommand % usageSubCmds % usage;
+  std::cout << boost::format(fgc_header + "\nUSAGE: " + fgc_usageBody + "%s %s --[ %s ] [--help] [commandArgs]\n" + fgc_reset) % _executableName % _subCommand % usageSubCmds;
 
   // -- Options
   boost::program_options::positional_options_description emptyPOD;

--- a/src/runtime_src/core/tools/common/XBHelpMenusCore.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenusCore.cpp
@@ -267,7 +267,7 @@ XBUtilities::report_commands_help( const std::string &_executable,
   boost::program_options::positional_options_description emptyPOD;
   std::string usage = XBU::create_usage_string(_optionDescription, emptyPOD);
   usage += " [command [commandArgs]]";
-  boost::format fmtUsage(fgc_header + "\nUSAGE: " + fgc_usageBody + "%s%s\n" + fgc_reset);
+  boost::format fmtUsage(fgc_header + "\nUSAGE: " + fgc_usageBody + "%s %s\n" + fgc_reset);
   std::cout << fmtUsage % _executable % usage;
 
   // -- Sort the SubCommands
@@ -280,7 +280,7 @@ XBUtilities::report_commands_help( const std::string &_executable,
     if (!XBU::getShowHidden() && subCmdEntry->isHidden()) 
       continue;
 
-    // Depricated sub-command
+    // Deprecated sub-command
     if (subCmdEntry->isDeprecated()) {
       subCmdsDepricated.push_back(subCmdEntry);
       continue;

--- a/src/runtime_src/core/tools/common/XBHelpMenusCore.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenusCore.cpp
@@ -472,7 +472,9 @@ XBUtilities::report_subcommand_help( const std::string &_executableName,
                                      const boost::program_options::options_description &_optionDescription,
                                      const boost::program_options::options_description &_optionHidden,
                                      const SubCmd::SubOptionOptions & _subOptionOptions,
-                                     const boost::program_options::options_description &_globalOptions)
+                                     const boost::program_options::options_description &_globalOptions,
+                                     const boost::program_options::positional_options_description & _positionalDescription,
+                                     bool removeLongOptDashes)
 {
   // Formatting color parameters
   // Color references: https://en.wikipedia.org/wiki/ANSI_escape_code
@@ -513,7 +515,8 @@ XBUtilities::report_subcommand_help( const std::string &_executableName,
     usageSubCmds.append(subCmd->longName());
   }
 
-  std::cout << boost::format(fgc_header + "\nUSAGE: " + fgc_usageBody + "%s %s [-h] --[ %s ] [commandArgs]\n" + fgc_reset) % _executableName % _subCommand % usageSubCmds;
+  const std::string usage = XBU::create_usage_string(_optionDescription, _positionalDescription, removeLongOptDashes);
+  std::cout << boost::format(fgc_header + "\nUSAGE: " + fgc_usageBody + "%s %s --[ %s ]%s\n" + fgc_reset) % _executableName % _subCommand % usageSubCmds % usage;
 
   // -- Options
   boost::program_options::positional_options_description emptyPOD;

--- a/src/runtime_src/core/tools/common/XBHelpMenusCore.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenusCore.cpp
@@ -152,7 +152,6 @@ get_option_type(const boost::shared_ptr<boost::program_options::option_descripti
 
     return long_arg;
   }
-  throw std::runtime_error("Invalid argument setup detected");
 }
 
 static std::string

--- a/src/runtime_src/core/tools/common/XBHelpMenusCore.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenusCore.cpp
@@ -515,7 +515,7 @@ XBUtilities::report_subcommand_help( const std::string &_executableName,
   // -- Usage
   std::string usageSubCmds;
   for (const auto & subCmd : _subOptionOptions) {
-    if (subCmd->isHidden()) 
+    if (subCmd->isHidden() && !XBU::getShowHidden()) 
       continue;
 
     if (!usageSubCmds.empty()) 

--- a/src/runtime_src/core/tools/common/XBHelpMenusCore.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenusCore.cpp
@@ -441,7 +441,7 @@ XBUtilities::report_subcommand_help( const std::string &_executableName,
 
   // -- Command usage
   const std::string usage = XBU::create_usage_string(_optionDescription, _positionalDescription, removeLongOptDashes);
-  boost::format fmtUsage(fgc_header + "\nUSAGE: " + fgc_usageBody + "%s %s%s\n" + fgc_reset);
+  boost::format fmtUsage(fgc_header + "\nUSAGE: " + fgc_usageBody + "%s %s %s\n" + fgc_reset);
   std::cout << fmtUsage % _executableName % _subCommand % usage;
   
   // -- Add positional arguments
@@ -549,7 +549,10 @@ XBUtilities::report_subcommand_help( const std::string &_executableName,
     usageSubCmds.append(optionString);
   }
 
-  std::cout << boost::format(fgc_header + "\nUSAGE: " + fgc_usageBody + "%s %s [ %s ] %s\n" + fgc_reset) % _executableName % _subCommand % usageSubCmds % usage;
+  if (usageSubCmds.empty())
+    std::cout << boost::format(fgc_header + "\nUSAGE: " + fgc_usageBody + "%s %s %s\n" + fgc_reset) % _executableName % _subCommand % usage;
+  else
+    std::cout << boost::format(fgc_header + "\nUSAGE: " + fgc_usageBody + "%s %s [ %s ] %s\n" + fgc_reset) % _executableName % _subCommand % usageSubCmds % usage;
 
   // -- Options
   boost::program_options::positional_options_description emptyPOD;

--- a/src/runtime_src/core/tools/common/XBHelpMenusCore.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenusCore.cpp
@@ -202,9 +202,7 @@ XBUtilities::create_usage_string( const boost::program_options::options_descript
                                   bool removeLongOptDashes)
 {
   // Create list of buffers to store each argument type
-  std::vector<std::stringstream> buffers;
-  for (auto i = 0; i < flag_type_size; i++)
-    buffers.push_back(std::stringstream());
+  std::vector<std::stringstream> buffers(flag_type_size);
 
   const auto &options = _od.options();
 

--- a/src/runtime_src/core/tools/common/XBHelpMenusCore.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenusCore.cpp
@@ -18,49 +18,48 @@
 // ------ I N C L U D E   F I L E S -------------------------------------------
 // Local - Include Files
 #include "XBHelpMenusCore.h"
+
 #include "XBUtilitiesCore.h"
 
 namespace XBU = XBUtilities;
 
-
 // 3rd Party Library - Include Files
-#include <boost/property_tree/json_parser.hpp>
 #include <boost/format.hpp>
+#include <boost/property_tree/json_parser.hpp>
 namespace po = boost::program_options;
 
 // System - Include Files
-#include <iostream>
 #include <algorithm>
+#include <iostream>
 #include <numeric>
 
 // ------ N A M E S P A C E ---------------------------------------------------
 using namespace XBUtilities;
 
 // Temporary color objects until the supporting color library becomes available
-namespace ec {
-  class fgcolor
-    {
-    public:
-      fgcolor(uint8_t _color) : m_color(_color) {};
-      std::string string() const { return "\033[38;5;" + std::to_string(m_color) + "m"; }
-      static const std::string reset() { return "\033[39m"; };
-      friend std::ostream& operator <<(std::ostream& os, const fgcolor & _obj) { return os << _obj.string(); }
-  
-   private:
-     uint8_t m_color;
-  };
+namespace ec
+{
+class fgcolor {
+ public:
+  fgcolor(uint8_t _color) : m_color(_color){};
+  std::string string() const { return "\033[38;5;" + std::to_string(m_color) + "m"; }
+  static const std::string reset() { return "\033[39m"; };
+  friend std::ostream& operator<<(std::ostream& os, const fgcolor& _obj) { return os << _obj.string(); }
 
-  class bgcolor
-    {
-    public:
-      bgcolor(uint8_t _color) : m_color(_color) {};
-      std::string string() const { return "\033[48;5;" + std::to_string(m_color) + "m"; }
-      static const std::string reset() { return "\033[49m"; };
-      friend std::ostream& operator <<(std::ostream& os, const bgcolor & _obj) { return  os << _obj.string(); }
+ private:
+  uint8_t m_color;
+};
 
-   private:
-     uint8_t m_color;
-  };
+class bgcolor {
+ public:
+  bgcolor(uint8_t _color) : m_color(_color){};
+  std::string string() const { return "\033[48;5;" + std::to_string(m_color) + "m"; }
+  static const std::string reset() { return "\033[49m"; };
+  friend std::ostream& operator<<(std::ostream& os, const bgcolor& _obj) { return os << _obj.string(); }
+
+ private:
+  uint8_t m_color;
+};
 }
 // ------ C O L O R S ---------------------------------------------------------
 static const uint8_t FGC_HEADER           = 3;   // 3
@@ -88,12 +87,11 @@ static unsigned int m_maxColumnWidth = 100;
 
 // ------ F U N C T I O N S ---------------------------------------------------
 static bool
-isPositional(const std::string &_name, 
-             const boost::program_options::positional_options_description & _pod)
+isPositional(const std::string& _name, const boost::program_options::positional_options_description& _pod)
 {
   // Look through the list of positional arguments
   for (unsigned int index = 0; index < _pod.max_total_count(); ++index) {
-    if ( _name.compare(_pod.name_for_position(index)) == 0) {
+    if (_name.compare(_pod.name_for_position(index)) == 0) {
       return true;
     }
   }
@@ -119,7 +117,8 @@ enum OptionDescriptionFlagType {
 };
 
 static enum OptionDescriptionFlagType
-get_option_type(const boost::shared_ptr<boost::program_options::option_description>& option, const boost::program_options::positional_options_description & _pod)
+get_option_type(const boost::shared_ptr<boost::program_options::option_description>& option,
+                const boost::program_options::positional_options_description& _pod)
 {
   const static int SHORT_OPTION_STRING_SIZE = 2;
   std::string optionDisplayName = option->canonical_display_name(po::command_line_style::allow_dash_for_short);
@@ -141,12 +140,13 @@ get_option_type(const boost::shared_ptr<boost::program_options::option_descripti
     }
   }
 
-  if (option->semantic()->max_tokens() == 0) { // Parse for simple flags
+  if (option->semantic()->max_tokens() == 0) {  // Parse for simple flags
     if (optionDisplayName.size() == SHORT_OPTION_STRING_SIZE)
       return short_simple;
 
     return long_simple;
-  } else { // Parse for flags with arguments
+  }
+  else { // Parse for flags with arguments
     if (optionDisplayName.size() == SHORT_OPTION_STRING_SIZE)
       return short_arg;
 
@@ -155,11 +155,13 @@ get_option_type(const boost::shared_ptr<boost::program_options::option_descripti
 }
 
 static std::string
-create_option_string(enum OptionDescriptionFlagType optionType, const boost::shared_ptr<boost::program_options::option_description>& option, bool removeLongOptDashes)
+create_option_string(enum OptionDescriptionFlagType optionType,
+                     const boost::shared_ptr<boost::program_options::option_description>& option,
+                     bool removeLongOptDashes)
 {
   const std::string& shortName = option->canonical_display_name(po::command_line_style::allow_dash_for_short);
-  const std::string& longName = removeLongOptDashes ? option->long_name() : 
-                                option->canonical_display_name(po::command_line_style::allow_long);
+  const std::string& longName =
+      removeLongOptDashes ? option->long_name() : option->canonical_display_name(po::command_line_style::allow_long);
   switch (optionType) {
     case short_simple:
       return boost::str(boost::format("%s") % shortName[1]);
@@ -196,16 +198,16 @@ create_option_string(enum OptionDescriptionFlagType optionType, const boost::sha
 }
 
 std::string
-XBUtilities::create_usage_string( const boost::program_options::options_description &_od,
-                                  const boost::program_options::positional_options_description & _pod,
-                                  bool removeLongOptDashes)
+XBUtilities::create_usage_string(const boost::program_options::options_description& _od,
+                                 const boost::program_options::positional_options_description& _pod,
+                                 bool removeLongOptDashes)
 {
   // Create list of buffers to store each argument type
   std::vector<std::stringstream> buffers(flag_type_size);
 
-  const auto &options = _od.options();
+  const auto& options = _od.options();
 
-  for (const auto &option : options) {
+  for (const auto& option : options) {
     const auto optionType = get_option_type(option, _pod);
     const auto optionString = create_option_string(optionType, option, removeLongOptDashes);
     const auto is_buffer_empty = buffers[optionType].str().empty();
@@ -213,7 +215,7 @@ XBUtilities::create_usage_string( const boost::program_options::options_descript
     if ((optionType == short_simple) && is_buffer_empty)
       buffers[optionType] << "[-";
     // Add spaces only after the first character to simplify upper level formatting
-    else if((optionType != short_simple) && !is_buffer_empty)
+    else if ((optionType != short_simple) && !is_buffer_empty)
       buffers[optionType] << " ";
 
     buffers[optionType] << boost::format("%s") % optionString;
@@ -236,12 +238,12 @@ XBUtilities::create_usage_string( const boost::program_options::options_descript
   return outputBuffer.str();
 }
 
-void 
-XBUtilities::report_commands_help( const std::string &_executable, 
-                                   const std::string &_description,
-                                   const boost::program_options::options_description& _optionDescription,
-                                   const boost::program_options::options_description& _optionHidden,
-                                   const SubCmdsCollection &_subCmds)
+void
+XBUtilities::report_commands_help(const std::string& _executable,
+                                  const std::string& _description,
+                                  const boost::program_options::options_description& _optionDescription,
+                                  const boost::program_options::options_description& _optionHidden,
+                                  const SubCmdsCollection& _subCmds)
 {
   // Formatting color parameters
   // Color references: https://en.wikipedia.org/wiki/ANSI_escape_code
@@ -258,9 +260,12 @@ XBUtilities::report_commands_help( const std::string &_executable,
   // -- Command description
   {
     static const std::string key = "DESCRIPTION: ";
-    auto formattedString = XBU::wrap_paragraphs(_description, static_cast<unsigned int>(key.size()), m_maxColumnWidth - static_cast<unsigned int>(key.size()), false);
+    auto formattedString = XBU::wrap_paragraphs(_description,
+                                                static_cast<unsigned int>(key.size()),
+                                                m_maxColumnWidth - static_cast<unsigned int>(key.size()),
+                                                false);
     boost::format fmtHeader(fgc_header + "\n" + key + fgc_headerBody + "%s\n" + fgc_reset);
-    if ( !formattedString.empty() )
+    if (!formattedString.empty())
       std::cout << fmtHeader % formattedString;
   }
 
@@ -278,7 +283,7 @@ XBUtilities::report_commands_help( const std::string &_executable,
 
   for (auto& subCmdEntry : _subCmds) {
     // Filter out hidden subcommand
-    if (!XBU::getShowHidden() && subCmdEntry->isHidden()) 
+    if (!XBU::getShowHidden() && subCmdEntry->isHidden())
       continue;
 
     // Deprecated sub-command
@@ -303,15 +308,14 @@ XBUtilities::report_commands_help( const std::string &_executable,
   std::sort(subCmdsPreliminary.begin(), subCmdsPreliminary.end(), sortByName);
   std::sort(subCmdsDepricated.begin(), subCmdsDepricated.end(), sortByName);
 
-
   // -- Report the SubCommands
-  boost::format fmtSubCmdHdr(fgc_header + "\n%s COMMANDS:\n" + fgc_reset);  
-  boost::format fmtSubCmd(fgc_subCmd + "  %-10s " + fgc_subCmdBody + "- %s\n" + fgc_reset); 
+  boost::format fmtSubCmdHdr(fgc_header + "\n%s COMMANDS:\n" + fgc_reset);
+  boost::format fmtSubCmd(fgc_subCmd + "  %-10s " + fgc_subCmdBody + "- %s\n" + fgc_reset);
   unsigned int subCmdDescTab = 15;
 
   if (!subCmdsReleased.empty()) {
     std::cout << fmtSubCmdHdr % "AVAILABLE";
-    for (auto & subCmdEntry : subCmdsReleased) {
+    for (auto& subCmdEntry : subCmdsReleased) {
       std::string sPreAppend = subCmdEntry->isHidden() ? sHidden + " " : "";
       auto formattedString = XBU::wrap_paragraphs(sPreAppend + subCmdEntry->getShortDescription(), subCmdDescTab, m_maxColumnWidth, false);
       std::cout << fmtSubCmd % subCmdEntry->getName() % formattedString;
@@ -320,7 +324,7 @@ XBUtilities::report_commands_help( const std::string &_executable,
 
   if (!subCmdsPreliminary.empty()) {
     std::cout << fmtSubCmdHdr % "PRELIMINARY";
-    for (auto & subCmdEntry : subCmdsPreliminary) {
+    for (auto& subCmdEntry : subCmdsPreliminary) {
       std::string sPreAppend = subCmdEntry->isHidden() ? sHidden + " " : "";
       auto formattedString = XBU::wrap_paragraphs(sPreAppend + subCmdEntry->getShortDescription(), subCmdDescTab, m_maxColumnWidth, false);
       std::cout << fmtSubCmd % subCmdEntry->getName() % formattedString;
@@ -329,7 +333,7 @@ XBUtilities::report_commands_help( const std::string &_executable,
 
   if (!subCmdsDepricated.empty()) {
     std::cout << fmtSubCmdHdr % "DEPRECATED";
-    for (auto & subCmdEntry : subCmdsDepricated) {
+    for (auto& subCmdEntry : subCmdsDepricated) {
       std::string sPreAppend = subCmdEntry->isHidden() ? sHidden + " " : "";
       auto formattedString = XBU::wrap_paragraphs(sPreAppend + subCmdEntry->getShortDescription(), subCmdDescTab, m_maxColumnWidth, false);
       std::cout << fmtSubCmd % subCmdEntry->getName() % formattedString;
@@ -338,16 +342,16 @@ XBUtilities::report_commands_help( const std::string &_executable,
 
   report_option_help("OPTIONS", _optionDescription, emptyPOD);
 
-  if (XBU::getShowHidden()) 
+  if (XBU::getShowHidden())
     report_option_help(std::string("OPTIONS ") + sHidden, _optionHidden, emptyPOD);
 }
 
-static std::string 
-create_option_format_name(const boost::program_options::option_description * _option,
+static std::string
+create_option_format_name(const boost::program_options::option_description* _option,
                           bool _reportParameter = true,
                           bool removeLongOptDashes = false)
 {
-  if (_option == nullptr) 
+  if (_option == nullptr)
     return "";
 
   std::string optionDisplayName = _option->canonical_display_name(po::command_line_style::allow_dash_for_short);
@@ -359,24 +363,24 @@ create_option_format_name(const boost::program_options::option_description * _op
   // Get the long name (if it exists)
   std::string longName = _option->canonical_display_name(po::command_line_style::allow_long);
   if ((longName.size() > 2) && (longName[0] == '-') && (longName[1] == '-')) {
-    if (!optionDisplayName.empty()) 
+    if (!optionDisplayName.empty())
       optionDisplayName += ", ";
 
     optionDisplayName += removeLongOptDashes ? _option->long_name() : longName;
   }
 
-  if (_reportParameter && !_option->format_parameter().empty()) 
+  if (_reportParameter && !_option->format_parameter().empty())
     optionDisplayName += " " + _option->format_parameter();
 
   return optionDisplayName;
 }
 
 void
-XBUtilities::report_option_help( const std::string & _groupName, 
-                                 const boost::program_options::options_description& _optionDescription,
-                                 const boost::program_options::positional_options_description & _positionalDescription,
-                                 bool _bReportParameter,
-                                 bool removeLongOptDashes)
+XBUtilities::report_option_help(const std::string& _groupName,
+                                const boost::program_options::options_description& _optionDescription,
+                                const boost::program_options::positional_options_description& _positionalDescription,
+                                bool _bReportParameter,
+                                bool removeLongOptDashes)
 {
   // Formatting color parameters
   // Color references: https://en.wikipedia.org/wiki/ANSI_escape_code
@@ -391,14 +395,14 @@ XBUtilities::report_option_help( const std::string & _groupName,
 
   // Report option group name (if defined)
   boost::format fmtHeader(fgc_header + "\n%s:\n" + fgc_reset);
-  if ( !_groupName.empty() )
+  if (!_groupName.empty())
     std::cout << fmtHeader % _groupName;
 
   // Report the options
   boost::format fmtOption(fgc_optionName + "  %-18s " + fgc_optionBody + "- %s\n" + fgc_reset);
-  for (auto & option : _optionDescription.options()) {
-    if ( ::isPositional( option->canonical_display_name(po::command_line_style::allow_dash_for_short),
-                         _positionalDescription) )  {
+  for (auto& option : _optionDescription.options()) {
+    if (::isPositional(option->canonical_display_name(po::command_line_style::allow_dash_for_short),
+                       _positionalDescription)) {
       continue;
     }
 
@@ -409,18 +413,19 @@ XBUtilities::report_option_help( const std::string & _groupName,
   }
 }
 
-void 
-XBUtilities::report_subcommand_help(const std::string &_executableName,
-                                    const std::string &_subCommand,
-                                    const std::string &_description, 
-                                    const std::string &_extendedHelp,
-                                    const boost::program_options::options_description &_optionDescription,
-                                    const boost::program_options::options_description &_optionHidden,
-                                    const boost::program_options::options_description &_globalOptions,
-                                    const boost::program_options::positional_options_description &_positionalDescription,
-                                    const SubCmd::SubOptionOptions &_subOptionOptions,
-                                    bool removeLongOptDashes,
-                                    const std::string &customHelpSection)
+void
+XBUtilities::report_subcommand_help(
+    const std::string& _executableName,
+    const std::string& _subCommand,
+    const std::string& _description,
+    const std::string& _extendedHelp,
+    const boost::program_options::options_description& _optionDescription,
+    const boost::program_options::options_description& _optionHidden,
+    const boost::program_options::options_description& _globalOptions,
+    const boost::program_options::positional_options_description& _positionalDescription,
+    const SubCmd::SubOptionOptions& _subOptionOptions,
+    bool removeLongOptDashes,
+    const std::string& customHelpSection)
 {
   // Formatting color parameters
   // Color references: https://en.wikipedia.org/wiki/ANSI_escape_code
@@ -438,14 +443,14 @@ XBUtilities::report_subcommand_help(const std::string &_executableName,
 
   // -- Command
   boost::format fmtCommand(fgc_header + "\nCOMMAND: " + fgc_commandBody + "%s\n" + fgc_reset);
-  if ( !_subCommand.empty() )
+  if (!_subCommand.empty())
     std::cout << fmtCommand % _subCommand;
- 
+
   // -- Command description
   {
     auto formattedString = XBU::wrap_paragraphs(_description, 15, m_maxColumnWidth, false);
     boost::format fmtHeader(fgc_header + "\nDESCRIPTION: " + fgc_headerBody + "%s\n" + fgc_reset);
-    if ( !formattedString.empty() )
+    if (!formattedString.empty())
       std::cout << fmtHeader % formattedString;
   }
 
@@ -458,17 +463,17 @@ XBUtilities::report_subcommand_help(const std::string &_executableName,
   boost::program_options::options_description allHiddenOptions(_optionHidden);
 
   std::string usageSubCmds;
-  for (const auto & subCmd : _subOptionOptions) {
+  for (const auto& subCmd : _subOptionOptions) {
     // As we go through the sub options add them into the options description for the list display
     if (subCmd->isHidden())
       allHiddenOptions.add_options()(subCmd->optionNameString().c_str(), subCmd->description().c_str());
     else
       allOptions.add_options()(subCmd->optionNameString().c_str(), subCmd->description().c_str());
 
-    if (subCmd->isHidden() && !XBU::getShowHidden()) 
+    if (subCmd->isHidden() && !XBU::getShowHidden())
       continue;
 
-    if (!usageSubCmds.empty()) 
+    if (!usageSubCmds.empty())
       usageSubCmds.append(" | ");
 
     const auto& option = subCmd->option();
@@ -491,25 +496,24 @@ XBUtilities::report_subcommand_help(const std::string &_executableName,
   // -- Global Options
   report_option_help("GLOBAL OPTIONS", _globalOptions, _positionalDescription, false);
 
-  if (XBU::getShowHidden()) 
+  if (XBU::getShowHidden())
     report_option_help("OPTIONS (Hidden)", allHiddenOptions, _positionalDescription, false);
 
   // Extended help
   {
-    boost::format fmtExtHelp(fgc_extendedBody + "\n  %s\n" +fgc_reset);
+    boost::format fmtExtHelp(fgc_extendedBody + "\n  %s\n" + fgc_reset);
     auto formattedString = XBU::wrap_paragraphs(_extendedHelp, 2, m_maxColumnWidth, false);
-    if (!formattedString.empty()) 
+    if (!formattedString.empty())
       std::cout << fmtExtHelp % formattedString;
   }
 }
 
 std::vector<std::string>
-XBUtilities::process_arguments( po::variables_map& vm,
-                                po::command_line_parser& parser,
-                                const po::options_description& options,
-                                const po::positional_options_description& positionals,
-                                bool validate_arguments
-                                )
+XBUtilities::process_arguments(po::variables_map& vm,
+                               po::command_line_parser& parser,
+                               const po::options_description& options,
+                               const po::positional_options_description& positionals,
+                               bool validate_arguments)
 {
   // Add unregistered "option"" that will catch all extra positional arguments
   po::options_description all_options(options);
@@ -519,7 +523,7 @@ XBUtilities::process_arguments( po::variables_map& vm,
 
   // Parse the given options and hold onto the results
   auto parsed_options = parser.options(all_options).positional(all_positionals).allow_unregistered().run();
-  
+
   if (validate_arguments) {
     // This variables holds options denoted with a '-' or '--' that were not registered
     const auto unrecognized_options = po::collect_unrecognized(parsed_options.options, po::exclude_positional);

--- a/src/runtime_src/core/tools/common/XBHelpMenusCore.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenusCore.cpp
@@ -100,6 +100,7 @@ isPositional(const std::string &_name,
   return false;
 }
 
+/* This determines the order of options in the usage string */
 enum FlagType {
   short_required = 0,
   long_required,
@@ -527,7 +528,7 @@ XBUtilities::report_subcommand_help( const std::string &_executableName,
     usageSubCmds.append(optionString);
   }
 
-  std::cout << boost::format(fgc_header + "\nUSAGE: " + fgc_usageBody + "%s %s [ %s ] [--help] [commandArgs]\n" + fgc_reset) % _executableName % _subCommand % usageSubCmds;
+  std::cout << boost::format(fgc_header + "\nUSAGE: " + fgc_usageBody + "%s %s [ %s ] [commandArgs]\n" + fgc_reset) % _executableName % _subCommand % usageSubCmds;
 
   // -- Options
   boost::program_options::positional_options_description emptyPOD;

--- a/src/runtime_src/core/tools/common/XBHelpMenusCore.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenusCore.cpp
@@ -549,7 +549,10 @@ XBUtilities::report_subcommand_help( const std::string &_executableName,
     usageSubCmds.append(optionString);
   }
 
-  std::cout << boost::format(fgc_header + "\nUSAGE: " + fgc_usageBody + "%s %s [ %s ] %s\n" + fgc_reset) % _executableName % _subCommand % usageSubCmds % usage;
+  if (usageSubCmds.empty())
+    std::cout << boost::format(fgc_header + "\nUSAGE: " + fgc_usageBody + "%s %s %s\n" + fgc_reset) % _executableName % _subCommand % usage;
+  else
+    std::cout << boost::format(fgc_header + "\nUSAGE: " + fgc_usageBody + "%s %s [ %s ] %s\n" + fgc_reset) % _executableName % _subCommand % usageSubCmds % usage;
 
   // -- Options
   boost::program_options::positional_options_description emptyPOD;

--- a/src/runtime_src/core/tools/common/XBHelpMenusCore.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenusCore.cpp
@@ -150,6 +150,47 @@ get_option_type(const boost::shared_ptr<boost::program_options::option_descripti
   throw std::runtime_error("Invalid argument setup detected");
 }
 
+static std::string
+create_option_string(enum FlagType optionType, const boost::shared_ptr<boost::program_options::option_description>& option, bool removeLongOptDashes)
+{
+  const std::string& shortName = option->canonical_display_name(po::command_line_style::allow_dash_for_short);
+  const std::string& longName = removeLongOptDashes ? option->long_name() : 
+                                option->canonical_display_name(po::command_line_style::allow_long);
+  switch (optionType) {
+    case short_simple:
+      return boost::str(boost::format("%s") % shortName[1]);
+      break;
+    case long_simple:
+      return boost::str(boost::format("[%s]") % longName);
+      break;
+    case short_arg:
+      return boost::str(boost::format("[%s arg]") % shortName);
+      break;
+    case long_arg:
+      return boost::str(boost::format("[%s arg]") % longName);
+      break;
+    case short_required:
+      return boost::str(boost::format("%s") % shortName);
+      break;
+    case long_required:
+      return boost::str(boost::format("%s") % longName);
+      break;
+    case short_required_arg:
+      return boost::str(boost::format("%s arg") % shortName);
+      break;
+    case long_required_arg:
+      return boost::str(boost::format("%s arg") % longName);
+      break;
+    case positional:
+      return boost::str(boost::format("%s") % shortName);
+      break;
+    case flag_type_size:
+      throw std::runtime_error("Invalid argument setup detected");
+      break;
+  }
+  throw std::runtime_error("Invalid argument setup detected");
+}
+
 std::string
 XBUtilities::create_usage_string( const boost::program_options::options_description &_od,
                                   const boost::program_options::positional_options_description & _pod,
@@ -162,46 +203,14 @@ XBUtilities::create_usage_string( const boost::program_options::options_descript
 
   auto &options = _od.options();
 
-  for (auto & option : options) {
+  for (const auto & option : options) {
     const auto optionType = get_option_type(option, _pod);
-    const std::string& shortName = option->canonical_display_name(po::command_line_style::allow_dash_for_short);
-    const std::string& longName = removeLongOptDashes ? option->long_name() : 
-                                  option->canonical_display_name(po::command_line_style::allow_long);
-    switch (optionType) {
-      case short_simple:
-        // The short options have a bracket surrounding all options
-        if (buffers[optionType].str().empty())
-          buffers[optionType] << " [-";
-        buffers[optionType] << shortName[1];
-        break;
-      case long_simple:
-        buffers[optionType] << boost::format(" [%s]") % longName;
-        break;
-      case short_arg:
-        buffers[optionType] << boost::format(" [%s arg]") % shortName;
-        break;
-      case long_arg:
-        buffers[optionType] << boost::format(" [%s arg]") % longName;
-        break;
-      case short_required:
-        buffers[optionType] << boost::format(" %s") % shortName;
-        break;
-      case long_required:
-        buffers[optionType] << boost::format(" %s") % longName;
-        break;
-      case short_required_arg:
-        buffers[optionType] << boost::format(" %s arg") % shortName;
-        break;
-      case long_required_arg:
-        buffers[optionType] << boost::format(" %s arg") % longName;
-        break;
-      case positional:
-        buffers[optionType] << boost::format(" %s") % shortName;
-        break;
-      case flag_type_size:
-        throw std::runtime_error("Invalid argument setup detected");
-        break;
-    }
+    const auto optionString = create_option_string(optionType, option, removeLongOptDashes);
+    // The short options have a bracket surrounding all options
+    if ((optionType == short_simple) && buffers[short_simple].str().empty())
+      buffers[short_simple] << " [-";
+
+    buffers[optionType] << boost::format(" %s") % optionString;
   }
 
   // The short simple options have a bracket surrounding all options
@@ -525,13 +534,13 @@ XBUtilities::report_subcommand_help( const std::string &_executableName,
     if (!usageSubCmds.empty()) 
       usageSubCmds.append(" | ");
 
-    const auto& option = subCmd->option();
+    const auto& option = subCmd->option().options()[0];
     const auto optionType = get_option_type(option, boost::program_options::positional_options_description());
     const auto optionString = create_option_string(optionType, option, false);
     usageSubCmds.append(optionString);
   }
 
-  std::cout << boost::format(fgc_header + "\nUSAGE: " + fgc_usageBody + "%s %s --[ %s ] [--help] [commandArgs]\n" + fgc_reset) % _executableName % _subCommand % usageSubCmds;
+  std::cout << boost::format(fgc_header + "\nUSAGE: " + fgc_usageBody + "%s %s [ %s ] [--help] [commandArgs]\n" + fgc_reset) % _executableName % _subCommand % usageSubCmds;
 
   // -- Options
   boost::program_options::positional_options_description emptyPOD;

--- a/src/runtime_src/core/tools/common/XBHelpMenusCore.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenusCore.cpp
@@ -100,6 +100,7 @@ isPositional(const std::string &_name,
   return false;
 }
 
+/* This determines the order of options in the usage string */
 enum FlagType {
   short_required = 0,
   long_required,
@@ -534,7 +535,7 @@ XBUtilities::report_subcommand_help( const std::string &_executableName,
     usageSubCmds.append(optionString);
   }
 
-  std::cout << boost::format(fgc_header + "\nUSAGE: " + fgc_usageBody + "%s %s [ %s ] [--help] [commandArgs]\n" + fgc_reset) % _executableName % _subCommand % usageSubCmds;
+  std::cout << boost::format(fgc_header + "\nUSAGE: " + fgc_usageBody + "%s %s [ %s ] [commandArgs]\n" + fgc_reset) % _executableName % _subCommand % usageSubCmds;
 
   // -- Options
   boost::program_options::positional_options_description emptyPOD;

--- a/src/runtime_src/core/tools/common/XBHelpMenusCore.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenusCore.cpp
@@ -44,6 +44,8 @@ class fgcolor {
   fgcolor(uint8_t _color) : m_color(_color){};
   std::string string() const { return "\033[38;5;" + std::to_string(m_color) + "m"; }
   static const std::string reset() { return "\033[39m"; };
+  // Friend modifier required as an operator overloading function must be made a
+  // friend function if it requires access to the private members of the class
   friend std::ostream& operator<<(std::ostream& os, const fgcolor& _obj) { return os << _obj.string(); }
 
  private:
@@ -55,6 +57,8 @@ class bgcolor {
   bgcolor(uint8_t _color) : m_color(_color){};
   std::string string() const { return "\033[48;5;" + std::to_string(m_color) + "m"; }
   static const std::string reset() { return "\033[49m"; };
+  // Friend modifier required as an operator overloading function must be made a
+  // friend function if it requires access to the private members of the class
   friend std::ostream& operator<<(std::ostream& os, const bgcolor& _obj) { return os << _obj.string(); }
 
  private:

--- a/src/runtime_src/core/tools/common/XBHelpMenusCore.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenusCore.cpp
@@ -531,10 +531,8 @@ XBUtilities::report_subcommand_help( const std::string &_executableName,
     usageSubCmds.append(optionString);
   }
 
-  if (usageSubCmds.empty())
-    std::cout << boost::format(fgc_header + "\nUSAGE: " + fgc_usageBody + "%s %s %s\n" + fgc_reset) % _executableName % _subCommand % usage;
-  else
-    std::cout << boost::format(fgc_header + "\nUSAGE: " + fgc_usageBody + "%s %s [ %s ] %s\n" + fgc_reset) % _executableName % _subCommand % usageSubCmds % usage;
+  const std::string usage = XBU::create_usage_string(_optionDescription, _positionalDescription, removeLongOptDashes);
+  std::cout << boost::format(fgc_header + "\nUSAGE: " + fgc_usageBody + "%s %s --[ %s ]%s\n" + fgc_reset) % _executableName % _subCommand % usageSubCmds % usage;
 
   // -- Options
   boost::program_options::positional_options_description emptyPOD;

--- a/src/runtime_src/core/tools/common/XBHelpMenusCore.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenusCore.cpp
@@ -522,12 +522,6 @@ XBUtilities::report_subcommand_help( const std::string &_executableName,
 
   std::string usageSubCmds;
   for (const auto & subCmd : _subOptionOptions) {
-    // As we go through the sub options add them into the options description for the list display
-    if (subCmd->isHidden())
-      allHiddenOptions.add_options()(subCmd->optionNameString().c_str(), subCmd->description().c_str());
-    else
-      allOptions.add_options()(subCmd->optionNameString().c_str(), subCmd->description().c_str());
-
     if (subCmd->isHidden() && !XBU::getShowHidden()) 
       continue;
 

--- a/src/runtime_src/core/tools/common/XBHelpMenusCore.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenusCore.cpp
@@ -207,11 +207,15 @@ XBUtilities::create_usage_string( const boost::program_options::options_descript
   for (const auto & option : options) {
     const auto optionType = get_option_type(option, _pod);
     const auto optionString = create_option_string(optionType, option, removeLongOptDashes);
+    const auto is_buffer_empty = buffers[optionType].str().empty();
     // The short options have a bracket surrounding all options
-    if ((optionType == short_simple) && buffers[short_simple].str().empty())
-      buffers[short_simple] << " [-";
+    if ((optionType == short_simple) && is_buffer_empty)
+      buffers[optionType] << "[-";
+    // Add spaces only after the first character to simplify upper level formatting
+    else if((optionType != short_simple) && !is_buffer_empty)
+      buffers[optionType] << " ";
 
-    buffers[optionType] << boost::format(" %s") % optionString;
+    buffers[optionType] << boost::format("%s") % optionString;
   }
 
   // The short simple options have a bracket surrounding all options
@@ -220,8 +224,12 @@ XBUtilities::create_usage_string( const boost::program_options::options_descript
 
   std::stringstream outputBuffer;
   for (const auto& buffer : buffers) {
-    if (!buffer.str().empty())
+    if (!buffer.str().empty()) {
+      // Add spaces only after the first buffer to simplify upper level formatting
+      if (!outputBuffer.str().empty())
+        outputBuffer << " ";
       outputBuffer << buffer.str();
+    }
   }
 
   return outputBuffer.str();
@@ -523,19 +531,25 @@ XBUtilities::report_subcommand_help( const std::string &_executableName,
 
   std::string usageSubCmds;
   for (const auto & subCmd : _subOptionOptions) {
+    // As we go through the sub options add them into the options description for the list display
+    if (subCmd->isHidden())
+      allHiddenOptions.add_options()(subCmd->optionNameString().c_str(), subCmd->description().c_str());
+    else
+      allOptions.add_options()(subCmd->optionNameString().c_str(), subCmd->description().c_str());
+
     if (subCmd->isHidden() && !XBU::getShowHidden()) 
       continue;
 
     if (!usageSubCmds.empty()) 
       usageSubCmds.append(" | ");
 
-    const auto& option = subCmd->option().options()[0];
+    const auto& option = subCmd->option();
     const auto optionType = get_option_type(option, boost::program_options::positional_options_description());
     const auto optionString = create_option_string(optionType, option, false);
     usageSubCmds.append(optionString);
   }
 
-  std::cout << boost::format(fgc_header + "\nUSAGE: " + fgc_usageBody + "%s %s [ %s ] [commandArgs]\n" + fgc_reset) % _executableName % _subCommand % usageSubCmds;
+  std::cout << boost::format(fgc_header + "\nUSAGE: " + fgc_usageBody + "%s %s [ %s ] %s\n" + fgc_reset) % _executableName % _subCommand % usageSubCmds % usage;
 
   // -- Options
   boost::program_options::positional_options_description emptyPOD;

--- a/src/runtime_src/core/tools/common/XBHelpMenusCore.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenusCore.cpp
@@ -531,8 +531,7 @@ XBUtilities::report_subcommand_help( const std::string &_executableName,
     usageSubCmds.append(optionString);
   }
 
-  const std::string usage = XBU::create_usage_string(_optionDescription, _positionalDescription, removeLongOptDashes);
-  std::cout << boost::format(fgc_header + "\nUSAGE: " + fgc_usageBody + "%s %s --[ %s ]%s\n" + fgc_reset) % _executableName % _subCommand % usageSubCmds % usage;
+  std::cout << boost::format(fgc_header + "\nUSAGE: " + fgc_usageBody + "%s %s --[ %s ] [--help] [commandArgs]\n" + fgc_reset) % _executableName % _subCommand % usageSubCmds;
 
   // -- Options
   boost::program_options::positional_options_description emptyPOD;

--- a/src/runtime_src/core/tools/common/XBHelpMenusCore.h
+++ b/src/runtime_src/core/tools/common/XBHelpMenusCore.h
@@ -32,7 +32,7 @@ using SubCmdsCollection = std::vector<std::shared_ptr<SubCmd>>;
 
 namespace XBUtilities {
   void 
-    report_commands_help( const std::string &_executable, 
+    report_commands_help( const std::string &_executable,
                           const std::string &_description,
                           const boost::program_options::options_description& _optionDescription,
                           const boost::program_options::options_description& _optionHidden,
@@ -41,18 +41,18 @@ namespace XBUtilities {
   void 
     report_subcommand_help( const std::string &_executableName,
                             const std::string &_subCommand,
-                            const std::string &_description, 
+                            const std::string &_description,
                             const std::string &_extendedHelp,
                             const boost::program_options::options_description &_optionDescription,
                             const boost::program_options::options_description &_optionHidden,
                             const boost::program_options::options_description &_globalOptions,
-                            const boost::program_options::positional_options_description & _positionalDescription = boost::program_options::positional_options_description(),
-                            const SubCmd::SubOptionOptions & _subOptionOptions = SubCmd::SubOptionOptions(),
+                            const boost::program_options::positional_options_description &_positionalDescription = boost::program_options::positional_options_description(),
+                            const SubCmd::SubOptionOptions &_subOptionOptions = SubCmd::SubOptionOptions(),
                             bool removeLongOptDashes = false,
-                            const std::string& customHelpSection = "");
+                            const std::string &customHelpSection = "");
 
   void 
-    report_option_help( const std::string & _groupName, 
+    report_option_help( const std::string & _groupName,
                         const boost::program_options::options_description& _optionDescription,
                         const boost::program_options::positional_options_description & _positionalDescription,
                         bool _bReportParameter = true,

--- a/src/runtime_src/core/tools/common/XBHelpMenusCore.h
+++ b/src/runtime_src/core/tools/common/XBHelpMenusCore.h
@@ -57,7 +57,9 @@ namespace XBUtilities {
                             const boost::program_options::options_description &_optionDescription,
                             const boost::program_options::options_description &_optionHidden,
                             const SubCmd::SubOptionOptions & _subOptionOptions,
-                            const boost::program_options::options_description &_globalOptions);
+                            const boost::program_options::options_description &_globalOptions,
+                            const boost::program_options::positional_options_description & _positionalDescription = boost::program_options::positional_options_description(),
+                            bool removeLongOptDashes=false);
 
   void 
     report_option_help( const std::string & _groupName, 

--- a/src/runtime_src/core/tools/common/XBHelpMenusCore.h
+++ b/src/runtime_src/core/tools/common/XBHelpMenusCore.h
@@ -37,17 +37,6 @@ namespace XBUtilities {
                           const boost::program_options::options_description& _optionDescription,
                           const boost::program_options::options_description& _optionHidden,
                           const SubCmdsCollection &_subCmds );
-  void 
-    report_subcommand_help( const std::string &_executableName,
-                            const std::string &_subCommand,
-                            const std::string &_description, 
-                            const std::string &_extendedHelp,
-                            const boost::program_options::options_description & _optionDescription,
-                            const boost::program_options::options_description &_optionHidden,
-                            const boost::program_options::positional_options_description & _positionalDescription,
-                            const boost::program_options::options_description &_globalOptions,
-                            bool removeLongOptDashes = false,
-                            const std::string& customHelpSection = "");
 
   void 
     report_subcommand_help( const std::string &_executableName,
@@ -56,10 +45,11 @@ namespace XBUtilities {
                             const std::string &_extendedHelp,
                             const boost::program_options::options_description &_optionDescription,
                             const boost::program_options::options_description &_optionHidden,
-                            const SubCmd::SubOptionOptions & _subOptionOptions,
                             const boost::program_options::options_description &_globalOptions,
                             const boost::program_options::positional_options_description & _positionalDescription = boost::program_options::positional_options_description(),
-                            bool removeLongOptDashes=false);
+                            const SubCmd::SubOptionOptions & _subOptionOptions = SubCmd::SubOptionOptions(),
+                            bool removeLongOptDashes = false,
+                            const std::string& customHelpSection = "");
 
   void 
     report_option_help( const std::string & _groupName, 

--- a/src/runtime_src/core/tools/common/XBHelpMenusCore.h
+++ b/src/runtime_src/core/tools/common/XBHelpMenusCore.h
@@ -20,55 +20,57 @@
 
 // Include files
 // Please keep these to the bare minimum
-#include "SubCmd.h"
-
-#include <string>
-#include <vector>
-#include <utility> // Pair template
 #include <boost/program_options.hpp>
+#include <string>
+#include <utility>  // Pair template
+#include <vector>
+
+#include "SubCmd.h"
 
 // ----------------------- T Y P E D E F S -----------------------------------
 using SubCmdsCollection = std::vector<std::shared_ptr<SubCmd>>;
 
-namespace XBUtilities {
-  void 
-    report_commands_help( const std::string &_executable,
-                          const std::string &_description,
-                          const boost::program_options::options_description& _optionDescription,
-                          const boost::program_options::options_description& _optionHidden,
-                          const SubCmdsCollection &_subCmds );
+namespace XBUtilities
+{
+void
+report_commands_help(const std::string& _executable,
+                     const std::string& _description,
+                     const boost::program_options::options_description& _optionDescription,
+                     const boost::program_options::options_description& _optionHidden,
+                     const SubCmdsCollection& _subCmds);
 
-  void 
-    report_subcommand_help( const std::string &_executableName,
-                            const std::string &_subCommand,
-                            const std::string &_description,
-                            const std::string &_extendedHelp,
-                            const boost::program_options::options_description &_optionDescription,
-                            const boost::program_options::options_description &_optionHidden,
-                            const boost::program_options::options_description &_globalOptions,
-                            const boost::program_options::positional_options_description &_positionalDescription = boost::program_options::positional_options_description(),
-                            const SubCmd::SubOptionOptions &_subOptionOptions = SubCmd::SubOptionOptions(),
-                            bool removeLongOptDashes = false,
-                            const std::string &customHelpSection = "");
+void
+report_subcommand_help(const std::string& _executableName,
+                       const std::string& _subCommand,
+                       const std::string& _description,
+                       const std::string& _extendedHelp,
+                       const boost::program_options::options_description& _optionDescription,
+                       const boost::program_options::options_description& _optionHidden,
+                       const boost::program_options::options_description& _globalOptions,
+                       const boost::program_options::positional_options_description& _positionalDescription =
+                           boost::program_options::positional_options_description(),
+                       const SubCmd::SubOptionOptions& _subOptionOptions = SubCmd::SubOptionOptions(),
+                       bool removeLongOptDashes = false,
+                       const std::string& customHelpSection = "");
 
-  void 
-    report_option_help( const std::string & _groupName,
-                        const boost::program_options::options_description& _optionDescription,
-                        const boost::program_options::positional_options_description & _positionalDescription,
-                        bool _bReportParameter = true,
-                        bool removeLongOptDashes = false);
+void
+report_option_help(const std::string& _groupName,
+                   const boost::program_options::options_description& _optionDescription,
+                   const boost::program_options::positional_options_description& _positionalDescription,
+                   bool _bReportParameter = true,
+                   bool removeLongOptDashes = false);
 
-  std::string 
-    create_usage_string( const boost::program_options::options_description &_od,
-                         const boost::program_options::positional_options_description & _pod,
-                         bool removeLongOptDashes = false);
+std::string
+create_usage_string(const boost::program_options::options_description& _od,
+                    const boost::program_options::positional_options_description& _pod,
+                    bool removeLongOptDashes = false);
 
-  std::vector<std::string>
-    process_arguments( boost::program_options::variables_map& vm,
-                       boost::program_options::command_line_parser& parser,
-                       const boost::program_options::options_description& options,
-                       const boost::program_options::positional_options_description& positionals,
-                       bool validate_arguments);
-};
+std::vector<std::string>
+process_arguments(boost::program_options::variables_map& vm,
+                  boost::program_options::command_line_parser& parser,
+                  const boost::program_options::options_description& options,
+                  const boost::program_options::positional_options_description& positionals,
+                  bool validate_arguments);
+};  // namespace XBUtilities
 
 #endif

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -517,7 +517,7 @@ XBUtilities::parse_oem_id(const std::string& oemid)
   }
 
   auto oemstr = oemid_map.find(oem_id_val);
-  return oemstr != oemid_map.end() ? oemstr->second : "N/A";
+  return oemstr != oemid_map.end() ? oemstr->second : data_not_available;
 }
 
 static const std::map<std::string, std::string> clock_map = {
@@ -598,17 +598,17 @@ get_xrt_pretty_version()
   xrt_core::get_xrt_info(pt_xrt);
   boost::property_tree::ptree empty_ptree;
 
-  ss << boost::format("%-20s : %s\n") % "Version" % pt_xrt.get<std::string>("version", "N/A");
-  ss << boost::format("%-20s : %s\n") % "Branch" % pt_xrt.get<std::string>("branch", "N/A");
-  ss << boost::format("%-20s : %s\n") % "Hash" % pt_xrt.get<std::string>("hash", "N/A");
-  ss << boost::format("%-20s : %s\n") % "Hash Date" % pt_xrt.get<std::string>("build_date", "N/A");
+  ss << boost::format("%-20s : %s\n") % "Version" % pt_xrt.get<std::string>("version", data_not_available);
+  ss << boost::format("%-20s : %s\n") % "Branch" % pt_xrt.get<std::string>("branch", data_not_available);
+  ss << boost::format("%-20s : %s\n") % "Hash" % pt_xrt.get<std::string>("hash", data_not_available);
+  ss << boost::format("%-20s : %s\n") % "Hash Date" % pt_xrt.get<std::string>("build_date", data_not_available);
   const boost::property_tree::ptree& available_drivers = pt_xrt.get_child("drivers", empty_ptree);
   for(auto& drv : available_drivers) {
     const boost::property_tree::ptree& driver = drv.second;
-    std::string drv_name = driver.get<std::string>("name", "N/A");
+    std::string drv_name = driver.get<std::string>("name", data_not_available);
     boost::algorithm::to_upper(drv_name);
     ss << boost::format("%-20s : %s, %s\n") % drv_name
-        % driver.get<std::string>("version", "N/A") % driver.get<std::string>("hash", "N/A");
+        % driver.get<std::string>("version", data_not_available) % driver.get<std::string>("hash", data_not_available);
   }
   return ss.str();
 }

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -360,18 +360,6 @@ XBUtilities::can_proceed_or_throw(const std::string& info, const std::string& er
 }
 
 void
-XBUtilities::sudo_or_throw(const std::string& msg)
-{
-#ifndef _WIN32
-  if ((getuid() == 0) || (geteuid() == 0))
-    return;
-
-  std::cerr << "ERROR: " << msg << std::endl;
-  throw xrt_core::error(std::errc::operation_canceled);
-#endif
-}
-
-void
 XBUtilities::print_exception(const std::system_error& e)
 {
   // Remove the type of error from the message.

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -372,18 +372,6 @@ XBUtilities::sudo_or_throw(const std::string& msg)
 }
 
 void
-XBUtilities::throw_cancel(const std::string& msg)
-{
-  throw_cancel(boost::format("%s") % msg);
-}
-
-void
-XBUtilities::throw_cancel(const boost::format& format)
-{
-  throw xrt_core::error(std::errc::operation_canceled, boost::str(format));
-}
-
-void
 XBUtilities::print_exception(const std::system_error& e)
 {
   // Remove the type of error from the message.

--- a/src/runtime_src/core/tools/common/XBUtilities.h
+++ b/src/runtime_src/core/tools/common/XBUtilities.h
@@ -46,8 +46,6 @@ namespace XBUtilities {
 
   void sudo_or_throw(const std::string& msg);
 
-  void throw_cancel(const std::string& msg);
-  void throw_cancel(const boost::format& format);
   void print_exception(const std::system_error& e);
 
   void xrt_version_cmp(bool isUserDomain);

--- a/src/runtime_src/core/tools/common/XBUtilities.h
+++ b/src/runtime_src/core/tools/common/XBUtilities.h
@@ -44,8 +44,6 @@ namespace XBUtilities {
  
   void can_proceed_or_throw(const std::string& info, const std::string& error);
 
-  void sudo_or_throw(const std::string& msg);
-
   void print_exception(const std::system_error& e);
 
   void xrt_version_cmp(bool isUserDomain);

--- a/src/runtime_src/core/tools/common/XBUtilitiesCore.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilitiesCore.cpp
@@ -19,6 +19,7 @@
 #include "XBUtilitiesCore.h"
 
 #include "core/common/error.h"
+#include "core/common/unistd.h"
 
 // 3rd Party Library - Include Files
 #include <boost/algorithm/string/split.hpp>
@@ -314,13 +315,11 @@ XBUtilities::can_proceed(bool force)
 void
 XBUtilities::sudo_or_throw(const std::string& msg)
 {
-#ifndef _WIN32
-  if ((getuid() == 0) || (geteuid() == 0))
+  if (xrt_core::is_user_privileged())
     return;
 
   std::cerr << "ERROR: " << msg << std::endl;
   throw xrt_core::error(std::errc::operation_canceled);
-#endif
 }
 
 void

--- a/src/runtime_src/core/tools/common/XBUtilitiesCore.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilitiesCore.cpp
@@ -18,6 +18,8 @@
 // Local - Include Files
 #include "XBUtilitiesCore.h"
 
+#include "core/common/error.h"
+
 // 3rd Party Library - Include Files
 #include <boost/algorithm/string/split.hpp>
 #include <boost/property_tree/json_parser.hpp>
@@ -318,4 +320,16 @@ XBUtilities::sudo_or_throw_err()
     std::cout << "ERROR: root privileges required." << std::endl;
     throw std::errc::operation_canceled;
 #endif
+}
+
+void
+XBUtilities::throw_cancel(const std::string& msg)
+{
+  throw_cancel(boost::format("%s") % msg);
+}
+
+void
+XBUtilities::throw_cancel(const boost::format& format)
+{
+  throw xrt_core::error(std::errc::operation_canceled, boost::str(format));
 }

--- a/src/runtime_src/core/tools/common/XBUtilitiesCore.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilitiesCore.cpp
@@ -312,13 +312,14 @@ XBUtilities::can_proceed(bool force)
 }
 
 void
-XBUtilities::sudo_or_throw_err()
+XBUtilities::sudo_or_throw(const std::string& msg)
 {
 #ifndef _WIN32
-    if ((getuid() == 0) || (geteuid() == 0))
-        return;
-    std::cout << "ERROR: root privileges required." << std::endl;
-    throw std::errc::operation_canceled;
+  if ((getuid() == 0) || (geteuid() == 0))
+    return;
+
+  std::cerr << "ERROR: " << msg << std::endl;
+  throw xrt_core::error(std::errc::operation_canceled);
 #endif
 }
 

--- a/src/runtime_src/core/tools/common/XBUtilitiesCore.h
+++ b/src/runtime_src/core/tools/common/XBUtilitiesCore.h
@@ -79,7 +79,7 @@ namespace XBUtilities {
 
 
   bool can_proceed(bool force = false);
-  void sudo_or_throw_err();
+  void sudo_or_throw(const std::string& msg);
   void throw_cancel(const std::string& msg);
   void throw_cancel(const boost::format& format);
 

--- a/src/runtime_src/core/tools/common/XBUtilitiesCore.h
+++ b/src/runtime_src/core/tools/common/XBUtilitiesCore.h
@@ -80,6 +80,8 @@ namespace XBUtilities {
 
   bool can_proceed(bool force = false);
   void sudo_or_throw_err();
+  void throw_cancel(const std::string& msg);
+  void throw_cancel(const boost::format& format);
 
   template <typename T>
   std::vector<T> as_vector( boost::property_tree::ptree const& pt, 

--- a/src/runtime_src/core/tools/common/XBUtilitiesCore.h
+++ b/src/runtime_src/core/tools/common/XBUtilitiesCore.h
@@ -29,6 +29,9 @@
 #include <boost/property_tree/ptree.hpp>
 
 namespace XBUtilities {
+
+  static const std::string data_not_available = "N/A";
+
   typedef enum {
     MT_MESSAGE,
     MT_INFO,

--- a/src/runtime_src/core/tools/xbflash2/OO_Dump_Qspips.cpp
+++ b/src/runtime_src/core/tools/xbflash2/OO_Dump_Qspips.cpp
@@ -99,7 +99,7 @@ OO_Dump_Qspips::execute(const SubCmdOptions& _options) const
 
   XBU::verbose("Option(s):");
   for (auto & aString : _options)
-      XBU::verbose(std::string(" ") + aString);
+      XBU::verbose(" " + aString);
 
   // Honor help option first
   if (std::find(_options.begin(), _options.end(), "--help") != _options.end()) {

--- a/src/runtime_src/core/tools/xbflash2/OO_Dump_Qspips.cpp
+++ b/src/runtime_src/core/tools/xbflash2/OO_Dump_Qspips.cpp
@@ -40,7 +40,7 @@ void
 qspips_readback(po::variables_map& vm)
 {
     //root privileges required.
-    XBU::sudo_or_throw_err();    
+    XBU::sudo_or_throw("ERROR: root privileges required.");    
    
     //mandatory command line args
     std::string bdf = vm.count("device") ? vm["device"].as<std::string>() : "";
@@ -125,7 +125,7 @@ OO_Dump_Qspips::execute(const SubCmdOptions& _options) const
     return;
   }
 
-  XBU::sudo_or_throw_err();
+  XBU::sudo_or_throw("ERROR: root privileges required.");
 
   try {
       qspips_readback(vm);

--- a/src/runtime_src/core/tools/xbflash2/OO_Program_Qspips.cpp
+++ b/src/runtime_src/core/tools/xbflash2/OO_Program_Qspips.cpp
@@ -41,7 +41,7 @@ void
 qspipsCommand(po::variables_map& vm)
 {
     //root privileges required.
-    XBU::sudo_or_throw_err();
+    XBU::sudo_or_throw("ERROR: root privileges required.");
 
     //mandatory command line args
     std::string bdf = vm.count("device") ? vm["device"].as<std::string>() : "";
@@ -159,7 +159,7 @@ OO_Program_Qspips::execute(const SubCmdOptions& _options) const
     return;
   }
 
-  XBU::sudo_or_throw_err();
+  XBU::sudo_or_throw("ERROR: root privileges required.");
   try {
       qspipsCommand(vm);      
   }

--- a/src/runtime_src/core/tools/xbflash2/OO_Program_Qspips.cpp
+++ b/src/runtime_src/core/tools/xbflash2/OO_Program_Qspips.cpp
@@ -133,7 +133,7 @@ OO_Program_Qspips::execute(const SubCmdOptions& _options) const
 
   XBU::verbose("Option(s):");
   for (auto & aString : _options)
-      XBU::verbose(std::string(" ") + aString);
+      XBU::verbose(" " + aString);
 
   // Honor help option first
   if (std::find(_options.begin(), _options.end(), "--help") != _options.end()) {

--- a/src/runtime_src/core/tools/xbflash2/OO_Program_Spi.cpp
+++ b/src/runtime_src/core/tools/xbflash2/OO_Program_Spi.cpp
@@ -125,7 +125,7 @@ OO_Program_Spi::execute(const SubCmdOptions& _options) const
   XBU::verbose("SubCommand option: Flash type - spi");
   XBU::verbose("Option(s):");
   for (auto & aString : _options)
-    XBU::verbose(std::string(" ") + aString);
+    XBU::verbose(" " + aString);
 
   // Honor help option first
   if (std::find(_options.begin(), _options.end(), "--help") != _options.end()) {

--- a/src/runtime_src/core/tools/xbflash2/OO_Program_Spi.cpp
+++ b/src/runtime_src/core/tools/xbflash2/OO_Program_Spi.cpp
@@ -40,7 +40,7 @@ namespace {
 void
 spiCommand(po::variables_map& vm) {
     //root privileges required.
-    XBU::sudo_or_throw_err();
+    XBU::sudo_or_throw("ERROR: root privileges required.");
 
     //mandatory command line args
     std::string bdf = vm.count("device") ? vm["device"].as<std::string>() : "";
@@ -151,7 +151,7 @@ OO_Program_Spi::execute(const SubCmdOptions& _options) const
     return;
   }
 
-  XBU::sudo_or_throw_err();
+  XBU::sudo_or_throw("ERROR: root privileges required.");
  
   try {
       spiCommand(vm);

--- a/src/runtime_src/core/tools/xbflash2/SubCmdDump.cpp
+++ b/src/runtime_src/core/tools/xbflash2/SubCmdDump.cpp
@@ -34,6 +34,7 @@ namespace po = boost::program_options;
 SubCmdDump::SubCmdDump(bool _isHidden, bool _isDepricated, bool _isPreliminary)
     : SubCmd("dump", 
              "Reads the image(s) for a given device for a given length and outputs the same to given file.\nIt is applicable for only QSPIPS flash.")
+    , m_help(false)
 {
   const std::string longDescription = "Reads the image(s) for a given device for a given length and outputs the same to given file.\nIt is applicable for only QSPIPS flash.";
   setLongDescription(longDescription);
@@ -41,89 +42,39 @@ SubCmdDump::SubCmdDump(bool _isHidden, bool _isDepricated, bool _isPreliminary)
   setIsHidden(_isHidden);
   setIsDeprecated(_isDepricated);
   setIsPreliminary(_isPreliminary);
+
+  m_commonOptions.add_options()
+    ("help", boost::program_options::bool_switch(&m_help), "Help to use this sub-command")
+  ;
+
+  addSubOption(std::make_shared<OO_Dump_Qspips>("qspips"));
 }
 
 
 void
 SubCmdDump::execute(const SubCmdOptions& _options) const
 {
-  // -- Common top level options ---
-  bool help = false;
-
-  po::options_description commonOptions("Common Options"); 
-  commonOptions.add_options()
-    ("help", boost::program_options::bool_switch(&help), "Help to use this sub-command")
-  ;
-
-  po::options_description hiddenOptions("Hidden Options"); 
-
-  // -- Define the supporting option options ----
-  SubOptionOptions subOptionOptions; 
-  subOptionOptions.emplace_back(std::make_shared<OO_Dump_Qspips>("qspips"));
-
-  for (auto & subOO : subOptionOptions) {
-    if (subOO->isHidden()) 
-      hiddenOptions.add_options()(subOO->longName().c_str(), subOO->description().c_str());
-    else
-      commonOptions.add_options()(subOO->longName().c_str(), subOO->description().c_str());
-    subOO->setExecutable(getExecutableName());
-    subOO->setCommand(getName());
-  }
-
-  po::options_description allOptions("All Options");
-  allOptions.add(commonOptions);
-  allOptions.add(hiddenOptions);
-
   // =========== Process the options ========================================
-
-  // 1) Process the common top level options 
-  po::parsed_options parsedCommonTop = 
-    po::command_line_parser(_options).
-    options(allOptions).          
-    allow_unregistered().           // Allow for unregistered options
-    run();                          // Parse the options
-
   po::variables_map vm;
+  auto topOptions = process_arguments(vm, _options, false);
 
-  try {
-    po::store(parsedCommonTop, vm);  // Can throw
-    po::notify(vm);                  // Can throw (but really isn't used)
-
-    // Mutual DRC
-    for (unsigned int index1 = 0; index1 < subOptionOptions.size(); ++index1) {
-      for (unsigned int index2 = index1 + 1; index2 < subOptionOptions.size(); ++index2) {
-        conflictingOptions(vm, subOptionOptions[index1]->longName(), subOptionOptions[index2]->longName());
-      }
-    }
-  } catch (const std::exception & e) {
-    std::cerr << "ERROR: " << e.what() << std::endl;
-    printHelp(commonOptions, hiddenOptions, subOptionOptions);
-    throw std::errc::operation_canceled;
-  }
 
   // Find the subOption;
-  std::shared_ptr<OptionOptions> optionOption;
-  for (auto& subOO : subOptionOptions) {
-    if (vm.count(subOO->longName().c_str()) != 0) {
-      optionOption = subOO;
-      break;
-    }
-  }
+  auto optionOption = checkForSubOption(vm);
 
   // No suboption print help
   if (!optionOption) {
-      if (help) {
-          printHelp(commonOptions, hiddenOptions, subOptionOptions);
+      if (m_help) {
+          printHelp();
           return;
       }
       std::cerr << "\nERROR: Suboption missing" << std::endl;
-      printHelp(commonOptions, hiddenOptions, subOptionOptions);
+      printHelp();
       throw std::errc::operation_canceled;
   }
 
   // 2) Process the top level options
-  std::vector<std::string> topOptions = po::collect_unrecognized(parsedCommonTop.options, po::include_positional);
-  if (help)
+  if (m_help)
     topOptions.push_back("--help");
 
   optionOption->setGlobalOptions(getGlobalOptions());

--- a/src/runtime_src/core/tools/xbflash2/SubCmdDump.cpp
+++ b/src/runtime_src/core/tools/xbflash2/SubCmdDump.cpp
@@ -36,8 +36,7 @@ SubCmdDump::SubCmdDump(bool _isHidden, bool _isDepricated, bool _isPreliminary)
              "Reads the image(s) for a given device for a given length and outputs the same to given file.\nIt is applicable for only QSPIPS flash.")
     , m_help(false)
 {
-  const std::string longDescription = "Reads the image(s) for a given device for a given length and outputs the same to given file.\nIt is applicable for only QSPIPS flash.";
-  setLongDescription(longDescription);
+  setLongDescription("Reads the image(s) for a given device for a given length and outputs the same to given file.\nIt is applicable for only QSPIPS flash.");
   setExampleSyntax("");
   setIsHidden(_isHidden);
   setIsDeprecated(_isDepricated);

--- a/src/runtime_src/core/tools/xbflash2/SubCmdDump.h
+++ b/src/runtime_src/core/tools/xbflash2/SubCmdDump.h
@@ -26,6 +26,9 @@ class SubCmdDump : public SubCmd {
  public:
   SubCmdDump(bool _isHidden, bool _isDepricated, bool _isPreliminary);
   virtual ~SubCmdDump() {};
+
+ private:
+  bool m_help;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbflash2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbflash2/SubCmdProgram.cpp
@@ -36,8 +36,7 @@ SubCmdProgram::SubCmdProgram(bool _isHidden, bool _isDepricated, bool _isPrelimi
              "Updates the image(s) for a given device")
     , m_help(false)
 {
-  const std::string longDescription = "Programs the given acceleration image into the device's shell.";
-  setLongDescription(longDescription);
+  setLongDescription("Programs the given acceleration image into the device's shell.");
   setExampleSyntax("");
   setIsHidden(_isHidden);
   setIsDeprecated(_isDepricated);

--- a/src/runtime_src/core/tools/xbflash2/SubCmdProgram.h
+++ b/src/runtime_src/core/tools/xbflash2/SubCmdProgram.h
@@ -26,6 +26,9 @@ class SubCmdProgram : public SubCmd {
  public:
   SubCmdProgram(bool _isHidden, bool _isDepricated, bool _isPreliminary);
   virtual ~SubCmdProgram() {};
+
+ private:
+  bool m_help;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbmgmt2/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbmgmt2/CMakeLists.txt
@@ -28,10 +28,11 @@ file(GLOB XBMGMT_V2_SUBCMD_FILES
   "SubCmdAdvanced.cpp"
   "SubCmdDump.cpp"
   "SubCmdConfigure.cpp"
+  "OO_FactoryReset.cpp"
   "OO_Hotplug.cpp"
   "OO_UpdateBase.cpp"
   "OO_UpdateShell.cpp"
-  "OO_FactoryReset.cpp"
+  "OO_UpdateXclbin.cpp"
   "Report*.cpp"
   "flash/*.cpp"
 )

--- a/src/runtime_src/core/tools/xbmgmt2/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbmgmt2/CMakeLists.txt
@@ -31,6 +31,7 @@ file(GLOB XBMGMT_V2_SUBCMD_FILES
   "OO_Hotplug.cpp"
   "OO_UpdateBase.cpp"
   "OO_UpdateShell.cpp"
+  "OO_FactoryReset.cpp"
   "Report*.cpp"
   "flash/*.cpp"
 )

--- a/src/runtime_src/core/tools/xbmgmt2/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbmgmt2/CMakeLists.txt
@@ -30,6 +30,7 @@ file(GLOB XBMGMT_V2_SUBCMD_FILES
   "SubCmdConfigure.cpp"
   "OO_Hotplug.cpp"
   "OO_UpdateBase.cpp"
+  "OO_UpdateShell.cpp"
   "Report*.cpp"
   "flash/*.cpp"
 )

--- a/src/runtime_src/core/tools/xbmgmt2/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbmgmt2/CMakeLists.txt
@@ -28,6 +28,7 @@ file(GLOB XBMGMT_V2_SUBCMD_FILES
   "SubCmdAdvanced.cpp"
   "SubCmdDump.cpp"
   "SubCmdConfigure.cpp"
+  "OO_ChangeBoot.cpp"
   "OO_FactoryReset.cpp"
   "OO_Hotplug.cpp"
   "OO_UpdateBase.cpp"

--- a/src/runtime_src/core/tools/xbmgmt2/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbmgmt2/CMakeLists.txt
@@ -32,8 +32,6 @@ file(GLOB XBMGMT_V2_SUBCMD_FILES
   "OO_FactoryReset.cpp"
   "OO_Hotplug.cpp"
   "OO_UpdateBase.cpp"
-  "OO_UpdateShell.cpp"
-  "OO_UpdateXclbin.cpp"
   "Report*.cpp"
   "flash/*.cpp"
 )

--- a/src/runtime_src/core/tools/xbmgmt2/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbmgmt2/CMakeLists.txt
@@ -32,6 +32,7 @@ file(GLOB XBMGMT_V2_SUBCMD_FILES
   "OO_FactoryReset.cpp"
   "OO_Hotplug.cpp"
   "OO_UpdateBase.cpp"
+  "OO_UpdateShell.cpp"
   "Report*.cpp"
   "flash/*.cpp"
 )

--- a/src/runtime_src/core/tools/xbmgmt2/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbmgmt2/CMakeLists.txt
@@ -33,6 +33,7 @@ file(GLOB XBMGMT_V2_SUBCMD_FILES
   "OO_Hotplug.cpp"
   "OO_UpdateBase.cpp"
   "OO_UpdateShell.cpp"
+  "OO_FactoryReset.cpp"
   "Report*.cpp"
   "flash/*.cpp"
 )

--- a/src/runtime_src/core/tools/xbmgmt2/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbmgmt2/CMakeLists.txt
@@ -28,12 +28,11 @@ file(GLOB XBMGMT_V2_SUBCMD_FILES
   "SubCmdAdvanced.cpp"
   "SubCmdDump.cpp"
   "SubCmdConfigure.cpp"
-  "OO_ChangeBoot.cpp"
   "OO_FactoryReset.cpp"
   "OO_Hotplug.cpp"
   "OO_UpdateBase.cpp"
   "OO_UpdateShell.cpp"
-  "OO_FactoryReset.cpp"
+  "OO_UpdateXclbin.cpp"
   "Report*.cpp"
   "flash/*.cpp"
 )

--- a/src/runtime_src/core/tools/xbmgmt2/OO_ChangeBoot.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_ChangeBoot.cpp
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+
+// ------ I N C L U D E   F I L E S -------------------------------------------
+// Local - Include Files
+#include "OO_ChangeBoot.h"
+
+// XRT - Include Files
+#include "core/common/error.h"
+#include "core/common/query_requests.h"
+#include "tools/common/XBHelpMenusCore.h"
+#include "tools/common/XBUtilitiesCore.h"
+#include "tools/common/XBUtilities.h"
+namespace XBU = XBUtilities;
+
+// 3rd Party Library - Include Files
+#include <boost/format.hpp>
+#include <boost/filesystem.hpp>
+#include <boost/program_options.hpp>
+#include <boost/algorithm/string.hpp>
+namespace po = boost::program_options;
+
+// System - Include Files
+#include <fstream>
+#include <iostream>
+// =============================================================================
+
+// ----- H E L P E R M E T H O D S ------------------------------------------
+
+
+// ----- C L A S S   M E T H O D S -------------------------------------------
+
+OO_ChangeBoot::OO_ChangeBoot(const std::string &_longName, const std::string &_shortName, bool _isHidden )
+    : OptionOptions(_longName,
+                    _shortName,
+                    "Modify the boot for an RPU and/or APU to either partition A or partition B",
+                    boost::program_options::value<decltype(boot)>(&boot)->implicit_value("default")->required(),
+                    "RPU and/or APU will be booted to either partition A or partition B.  Valid values:\n"
+                    "  DEFAULT - Reboot RPU to partition A\n"
+                    "  BACKUP  - Reboot RPU to partition B\n",
+                    _isHidden),
+      m_device(""),
+      boot("")
+{
+  m_optionsDescription.add_options()
+    ("device,d", po::value<decltype(m_device)>(&m_device), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest")
+    ("help", po::bool_switch(&m_help), "Help to use this sub-command")
+  ;
+}
+
+static void
+switch_partition(xrt_core::device* device, int boot)
+{
+  auto bdf = xrt_core::query::pcie_bdf::to_string(xrt_core::device_query<xrt_core::query::pcie_bdf>(device));
+  std::cout << boost::format("Rebooting device: [%s] with '%s' partition")
+                % bdf % (boot ? "backup" : "default") << std::endl;
+  try {
+    auto value = xrt_core::query::flush_default_only::value_type(boot);
+    xrt_core::device_update<xrt_core::query::boot_partition>(device, value);
+    std::cout << "Performing hot reset..." << std::endl;
+    auto hot_reset = XBU::str_to_reset_obj("hot");
+    device->reset(hot_reset);
+    std::cout << "Rebooted successfully" << std::endl;
+  }
+  catch (const xrt_core::query::exception& ex) {
+    std::cout << "ERROR: " << ex.what() << std::endl;
+    throw xrt_core::error(std::errc::operation_canceled);
+    // only available for versal devices
+  }
+}
+
+void
+OO_ChangeBoot::execute(const SubCmdOptions& _options) const
+{
+  XBUtilities::verbose("SubCommand option: Change boot");
+
+  XBUtilities::verbose("Option(s):");
+  for (const auto & aString : _options)
+    XBUtilities::verbose(std::string(" ") + aString);
+
+  // Honor help option first
+  if (std::find(_options.begin(), _options.end(), "--help") != _options.end()) {
+    printHelp();
+    return;
+  }
+
+  // Parse sub-command ...
+  po::variables_map vm;
+  process_arguments(vm, _options);
+
+  std::shared_ptr<xrt_core::device> device;
+  try {
+    device = XBU::get_device(boost::algorithm::to_lower_copy(m_device), false /*inUserDomain*/);
+  } catch (const std::runtime_error& e) {
+    XBU::throw_cancel(e.what());
+  }
+
+  if (boost::iequals(boot, "DEFAULT"))
+    switch_partition(device.get(), 0);
+  else if (boost::iequals(boot, "BACKUP"))
+    switch_partition(device.get(), 1);
+  else 
+    XBU::throw_cancel(boost::format("Invalid value for boot: %s") % boot);
+}

--- a/src/runtime_src/core/tools/xbmgmt2/OO_ChangeBoot.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_ChangeBoot.cpp
@@ -6,18 +6,15 @@
 #include "OO_ChangeBoot.h"
 
 // XRT - Include Files
-#include "core/common/error.h"
 #include "core/common/query_requests.h"
-#include "tools/common/XBHelpMenusCore.h"
-#include "tools/common/XBUtilitiesCore.h"
 #include "tools/common/XBUtilities.h"
+#include "tools/common/XBUtilitiesCore.h"
 namespace XBU = XBUtilities;
 
 // 3rd Party Library - Include Files
-#include <boost/format.hpp>
-#include <boost/filesystem.hpp>
-#include <boost/program_options.hpp>
 #include <boost/algorithm/string.hpp>
+#include <boost/format.hpp>
+#include <boost/program_options.hpp>
 namespace po = boost::program_options;
 
 // System - Include Files

--- a/src/runtime_src/core/tools/xbmgmt2/OO_ChangeBoot.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_ChangeBoot.cpp
@@ -24,7 +24,7 @@ namespace po = boost::program_options;
 
 // ----- CLASS METHODS -------------------------------------------
 
-OO_ChangeBoot::OO_ChangeBoot(const std::string &_longName, const std::string &_shortName, bool _isHidden)
+OO_ChangeBoot::OO_ChangeBoot(const std::string& _longName, const std::string& _shortName, bool _isHidden)
     : OptionOptions(_longName,
                     _shortName,
                     "Modify the boot for an RPU and/or APU to either partition A or partition B",
@@ -43,11 +43,10 @@ OO_ChangeBoot::OO_ChangeBoot(const std::string &_longName, const std::string &_s
 }
 
 static void
-switch_partition(xrt_core::device *device, int m_boot)
+switch_partition(xrt_core::device* device, int m_boot)
 {
   auto bdf = xrt_core::query::pcie_bdf::to_string(xrt_core::device_query<xrt_core::query::pcie_bdf>(device));
-  std::cout << boost::format("Rebooting device: [%s] with '%s' partition\n")
-                % bdf % (m_boot ? "backup" : "default");
+  std::cout << boost::format("Rebooting device: [%s] with '%s' partition\n") % bdf % (m_boot ? "backup" : "default");
   try {
     auto value = xrt_core::query::flush_default_only::value_type(m_boot);
     xrt_core::device_update<xrt_core::query::boot_partition>(device, value);
@@ -55,7 +54,7 @@ switch_partition(xrt_core::device *device, int m_boot)
     auto hot_reset = XBU::str_to_reset_obj("hot");
     device->reset(hot_reset);
     std::cout << "Rebooted successfully" << std::endl;
-  } catch (const xrt_core::query::exception &ex) {
+  } catch (const xrt_core::query::exception& ex) {
     std::cout << "ERROR: " << ex.what() << std::endl;
     throw xrt_core::error(std::errc::operation_canceled);
     // only available for versal devices
@@ -63,12 +62,12 @@ switch_partition(xrt_core::device *device, int m_boot)
 }
 
 void
-OO_ChangeBoot::execute(const SubCmdOptions &_options) const
+OO_ChangeBoot::execute(const SubCmdOptions& _options) const
 {
   XBUtilities::verbose("SubCommand option: Change boot");
 
   XBUtilities::verbose("Option(s):");
-  for (const auto &aString : _options)
+  for (const auto& aString : _options)
     XBUtilities::verbose(" " + aString);
 
   // Honor help option first
@@ -84,7 +83,7 @@ OO_ChangeBoot::execute(const SubCmdOptions &_options) const
   std::shared_ptr<xrt_core::device> device;
   try {
     device = XBU::get_device(boost::algorithm::to_lower_copy(m_device), false /*inUserDomain*/);
-  } catch (const std::runtime_error &e) {
+  } catch (const std::runtime_error& e) {
     XBU::throw_cancel(e.what());
   }
 

--- a/src/runtime_src/core/tools/xbmgmt2/OO_ChangeBoot.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_ChangeBoot.cpp
@@ -6,15 +6,18 @@
 #include "OO_ChangeBoot.h"
 
 // XRT - Include Files
+#include "core/common/error.h"
 #include "core/common/query_requests.h"
-#include "tools/common/XBUtilities.h"
+#include "tools/common/XBHelpMenusCore.h"
 #include "tools/common/XBUtilitiesCore.h"
+#include "tools/common/XBUtilities.h"
 namespace XBU = XBUtilities;
 
 // 3rd Party Library - Include Files
-#include <boost/algorithm/string.hpp>
 #include <boost/format.hpp>
+#include <boost/filesystem.hpp>
 #include <boost/program_options.hpp>
+#include <boost/algorithm/string.hpp>
 namespace po = boost::program_options;
 
 // System - Include Files

--- a/src/runtime_src/core/tools/xbmgmt2/OO_ChangeBoot.h
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_ChangeBoot.h
@@ -15,7 +15,7 @@ class OO_ChangeBoot : public OptionOptions {
 
  private:
   std::string m_device;
-  std::string boot;
+  std::string m_boot;
   bool m_help;
 };
 

--- a/src/runtime_src/core/tools/xbmgmt2/OO_ChangeBoot.h
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_ChangeBoot.h
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+
+#ifndef __OO_ChangeBoot_h_
+#define __OO_ChangeBoot_h_
+
+#include "tools/common/OptionOptions.h"
+
+class OO_ChangeBoot : public OptionOptions {
+ public:
+  virtual void execute( const SubCmdOptions &_options ) const;
+
+ public:
+  OO_ChangeBoot( const std::string &_longName, const std::string &_shortName="", bool _isHidden = false);
+
+ private:
+  std::string m_device;
+  std::string boot;
+  bool m_help;
+};
+
+#endif

--- a/src/runtime_src/core/tools/xbmgmt2/OO_ChangeBoot.h
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_ChangeBoot.h
@@ -8,10 +8,10 @@
 
 class OO_ChangeBoot : public OptionOptions {
  public:
-  virtual void execute(const SubCmdOptions &_options) const;
+  virtual void execute(const SubCmdOptions& _options) const;
 
  public:
-  OO_ChangeBoot(const std::string &_longName, const std::string &_shortName = "", bool _isHidden = false);
+  OO_ChangeBoot(const std::string& _longName, const std::string& _shortName = "", bool _isHidden = false);
 
  private:
   std::string m_device;

--- a/src/runtime_src/core/tools/xbmgmt2/OO_ChangeBoot.h
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_ChangeBoot.h
@@ -8,10 +8,10 @@
 
 class OO_ChangeBoot : public OptionOptions {
  public:
-  virtual void execute( const SubCmdOptions &_options ) const;
+  virtual void execute(const SubCmdOptions &_options) const;
 
  public:
-  OO_ChangeBoot( const std::string &_longName, const std::string &_shortName="", bool _isHidden = false);
+  OO_ChangeBoot(const std::string &_longName, const std::string &_shortName = "", bool _isHidden = false);
 
  private:
   std::string m_device;

--- a/src/runtime_src/core/tools/xbmgmt2/OO_ChangeBoot.h
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_ChangeBoot.h
@@ -16,7 +16,7 @@ class OO_ChangeBoot : public OptionOptions {
  private:
   std::string m_device;
   std::string m_boot;
-  bool m_help;
+  bool        m_help;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbmgmt2/OO_FactoryReset.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_FactoryReset.cpp
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+
+// ------ I N C L U D E   F I L E S -------------------------------------------
+// Local - Include Files
+#include "OO_FactoryReset.h"
+
+// XRT - Include Files
+#include "core/common/error.h"
+#include "core/common/message.h"
+#include "core/common/query_requests.h"
+#include "core/common/system.h"
+#include "flash/flasher.h"
+#include "tools/common/XBHelpMenusCore.h"
+#include "tools/common/XBUtilitiesCore.h"
+#include "tools/common/XBUtilities.h"
+namespace XBU = XBUtilities;
+
+// 3rd Party Library - Include Files
+#include <boost/format.hpp>
+#include <boost/filesystem.hpp>
+#include <boost/program_options.hpp>
+#include <boost/algorithm/string.hpp>
+namespace po = boost::program_options;
+
+// System - Include Files
+#include <fstream>
+#include <iostream>
+#include <vector>
+// =============================================================================
+
+// ----- H E L P E R M E T H O D S ------------------------------------------
+
+
+// ----- C L A S S   M E T H O D S -------------------------------------------
+
+OO_FactoryReset::OO_FactoryReset(const std::string &_longName, const std::string &_shortName, bool _isHidden )
+    : OptionOptions(_longName,
+                    _shortName,
+                    "Reset the FPGA PROM back to the factory image",
+                    boost::program_options::bool_switch(&revertToGolden)->required(),
+                    "Resets the FPGA PROM back to the factory image.\n"
+                      "Note: The Satellite Controller does not have a golden image and cannot be reverted",
+                    _isHidden),
+      m_device(""),
+      flashType(""),
+      revertToGolden(false)
+{
+  m_optionsDescription.add_options()
+    ("device,d", po::value<decltype(m_device)>(&m_device), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest")
+    ("help", po::bool_switch(&m_help), "Help to use this sub-command")
+  ;
+
+  m_optionsHidden.add_options()
+    ("flash-type", boost::program_options::value<decltype(flashType)>(&flashType),
+    "Overrides the flash mode. Use with caution.  Valid values:\n"
+    "  ospi\n"
+    "  ospi_versal")
+  ;
+}
+
+void
+OO_FactoryReset::execute(const SubCmdOptions& _options) const
+{
+  XBUtilities::verbose("SubCommand option: Factory Reset");
+
+  XBUtilities::verbose("Option(s):");
+  for (const auto & aString : _options)
+    XBUtilities::verbose(std::string(" ") + aString);
+
+  // Honor help option first
+  if (std::find(_options.begin(), _options.end(), "--help") != _options.end()) {
+    printHelp();
+    return;
+  }
+
+  // Parse sub-command ...
+  po::variables_map vm;
+  process_arguments(vm, _options);
+
+  std::shared_ptr<xrt_core::device> device;
+  try {
+    device = XBU::get_device(boost::algorithm::to_lower_copy(m_device), false /*inUserDomain*/);
+  } catch (const std::runtime_error& e) {
+    // Catch only the exceptions that we have generated earlier
+    std::cerr << boost::format("ERROR: %s\n") % e.what();
+    throw xrt_core::error(std::errc::operation_canceled);
+  }
+
+  // Populate flash type. Uses board's default when passing an empty input string.
+  if (!flashType.empty()) {
+      xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT",
+        "Overriding flash mode is not recommended.\nYou may damage your device with this option.");
+  }
+  Flasher flasher(device->get_device_id());
+  bool has_reset = false;
+
+  //collect information of all the devices that will be reset
+  if (!flasher.isValid())
+    xrt_core::error(boost::str(boost::format("%d is an invalid index") % device->get_device_id()));
+
+  auto flash_type = flasher.getFlashType(flashType);
+
+  std::cout << boost::format("%-8s : %s %s %s \n") % "INFO" % "Resetting device ["
+    % flasher.sGetDBDF() % "] back to factory mode.";
+
+  XBUtilities::sudo_or_throw("Root privileges are required to revert the device to its golden flash image");
+
+  //ask user's permission
+  if (!XBU::can_proceed(XBU::getForce()))
+    throw xrt_core::error(std::errc::operation_canceled);
+
+  if (!flasher.upgradeFirmware(flash_type, nullptr, nullptr, nullptr)) {
+    std::cout << boost::format("%-8s : %s %s %s\n") % "INFO" % "Shell on [" % flasher.sGetDBDF() % "]"
+                                " is reset successfully.";
+    has_reset = true;
+  }
+
+  if (!has_reset)
+    throw xrt_core::error(std::errc::operation_canceled, "Failed to flash factory image onto device");
+
+  std::cout << "****************************************************\n";
+  std::cout << "Cold reboot machine to load the new image on device.\n";
+  std::cout << "****************************************************\n";
+
+  return;
+}

--- a/src/runtime_src/core/tools/xbmgmt2/OO_FactoryReset.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_FactoryReset.cpp
@@ -31,13 +31,13 @@ OO_FactoryReset::OO_FactoryReset(const std::string &_longName, const std::string
     : OptionOptions(_longName,
                     _shortName,
                     "Reset the FPGA PROM back to the factory image",
-                    boost::program_options::bool_switch(&revertToGolden)->required(),
+                    boost::program_options::bool_switch(&m_revertToGolden)->required(),
                     "Resets the FPGA PROM back to the factory image.\n"
                       "Note: The Satellite Controller does not have a golden image and cannot be reverted",
                     _isHidden),
       m_device(""),
-      flashType(""),
-      revertToGolden(false)
+      m_flashType(""),
+      m_revertToGolden(false)
 {
   m_optionsDescription.add_options()
     ("device,d", po::value<decltype(m_device)>(&m_device), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest")
@@ -45,7 +45,7 @@ OO_FactoryReset::OO_FactoryReset(const std::string &_longName, const std::string
   ;
 
   m_optionsHidden.add_options()
-    ("flash-type", boost::program_options::value<decltype(flashType)>(&flashType),
+    ("flash-type", boost::program_options::value<decltype(m_flashType)>(&m_flashType),
     "Overrides the flash mode. Use with caution.  Valid values:\n"
     "  ospi\n"
     "  ospi_versal")
@@ -81,7 +81,7 @@ OO_FactoryReset::execute(const SubCmdOptions& _options) const
   }
 
   // Populate flash type. Uses board's default when passing an empty input string.
-  if (!flashType.empty()) {
+  if (!m_flashType.empty()) {
       xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT",
         "Overriding flash mode is not recommended.\nYou may damage your device with this option.");
   }
@@ -92,7 +92,7 @@ OO_FactoryReset::execute(const SubCmdOptions& _options) const
   if (!flasher.isValid())
     xrt_core::error(boost::str(boost::format("%d is an invalid index") % device->get_device_id()));
 
-  auto flash_type = flasher.getFlashType(flashType);
+  auto flash_type = flasher.getFlashType(m_flashType);
 
   std::cout << boost::format("%-8s : %s %s %s \n") % "INFO" % "Resetting device ["
     % flasher.sGetDBDF() % "] back to factory mode.";

--- a/src/runtime_src/core/tools/xbmgmt2/OO_FactoryReset.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_FactoryReset.cpp
@@ -9,8 +9,8 @@
 #include "core/common/message.h"
 #include "core/common/query_requests.h"
 #include "flash/flasher.h"
-#include "tools/common/XBUtilitiesCore.h"
 #include "tools/common/XBUtilities.h"
+#include "tools/common/XBUtilitiesCore.h"
 namespace XBU = XBUtilities;
 
 // 3rd Party Library - Include Files
@@ -20,24 +20,18 @@ namespace po = boost::program_options;
 
 // System - Include Files
 #include <iostream>
-// =============================================================================
 
-// ----- H E L P E R M E T H O D S ------------------------------------------
-
-
-// ----- C L A S S   M E T H O D S -------------------------------------------
-
-OO_FactoryReset::OO_FactoryReset(const std::string &_longName, const std::string &_shortName, bool _isHidden )
+OO_FactoryReset::OO_FactoryReset(const std::string &_longName, const std::string &_shortName, bool _isHidden)
     : OptionOptions(_longName,
                     _shortName,
                     "Reset the FPGA PROM back to the factory image",
                     boost::program_options::bool_switch(&m_revertToGolden)->required(),
                     "Resets the FPGA PROM back to the factory image.\n"
-                      "Note: The Satellite Controller does not have a golden image and cannot be reverted",
-                    _isHidden),
-      m_device(""),
-      m_flashType(""),
-      m_revertToGolden(false)
+                    "Note: The Satellite Controller does not have a golden image and cannot be reverted",
+                    _isHidden)
+    , m_device("")
+    , m_flashType("")
+    , m_revertToGolden(false)
 {
   m_optionsDescription.add_options()
     ("device,d", po::value<decltype(m_device)>(&m_device), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest")
@@ -53,13 +47,13 @@ OO_FactoryReset::OO_FactoryReset(const std::string &_longName, const std::string
 }
 
 void
-OO_FactoryReset::execute(const SubCmdOptions& _options) const
+OO_FactoryReset::execute(const SubCmdOptions &_options) const
 {
   XBUtilities::verbose("SubCommand option: Factory Reset");
 
   XBUtilities::verbose("Option(s):");
-  for (const auto & aString : _options)
-    XBUtilities::verbose(std::string(" ") + aString);
+  for (const auto &aString : _options)
+    XBUtilities::verbose(" " + aString);
 
   // Honor help option first
   if (std::find(_options.begin(), _options.end(), "--help") != _options.end()) {
@@ -74,7 +68,7 @@ OO_FactoryReset::execute(const SubCmdOptions& _options) const
   std::shared_ptr<xrt_core::device> device;
   try {
     device = XBU::get_device(boost::algorithm::to_lower_copy(m_device), false /*inUserDomain*/);
-  } catch (const std::runtime_error& e) {
+  } catch (const std::runtime_error &e) {
     // Catch only the exceptions that we have generated earlier
     std::cerr << boost::format("ERROR: %s\n") % e.what();
     throw xrt_core::error(std::errc::operation_canceled);
@@ -88,7 +82,7 @@ OO_FactoryReset::execute(const SubCmdOptions& _options) const
   Flasher flasher(device->get_device_id());
   bool has_reset = false;
 
-  //collect information of all the devices that will be reset
+  // collect information of all the devices that will be reset
   if (!flasher.isValid())
     xrt_core::error(boost::str(boost::format("%d is an invalid index") % device->get_device_id()));
 
@@ -99,7 +93,7 @@ OO_FactoryReset::execute(const SubCmdOptions& _options) const
 
   XBUtilities::sudo_or_throw("Root privileges are required to revert the device to its golden flash image");
 
-  //ask user's permission
+  // ask user's permission
   if (!XBU::can_proceed(XBU::getForce()))
     throw xrt_core::error(std::errc::operation_canceled);
 

--- a/src/runtime_src/core/tools/xbmgmt2/OO_FactoryReset.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_FactoryReset.cpp
@@ -21,7 +21,7 @@ namespace po = boost::program_options;
 // System - Include Files
 #include <iostream>
 
-OO_FactoryReset::OO_FactoryReset(const std::string &_longName, const std::string &_shortName, bool _isHidden)
+OO_FactoryReset::OO_FactoryReset(const std::string& _longName, const std::string& _shortName, bool _isHidden)
     : OptionOptions(_longName,
                     _shortName,
                     "Reset the FPGA PROM back to the factory image",
@@ -47,12 +47,12 @@ OO_FactoryReset::OO_FactoryReset(const std::string &_longName, const std::string
 }
 
 void
-OO_FactoryReset::execute(const SubCmdOptions &_options) const
+OO_FactoryReset::execute(const SubCmdOptions& _options) const
 {
   XBUtilities::verbose("SubCommand option: Factory Reset");
 
   XBUtilities::verbose("Option(s):");
-  for (const auto &aString : _options)
+  for (const auto& aString : _options)
     XBUtilities::verbose(" " + aString);
 
   // Honor help option first
@@ -68,7 +68,7 @@ OO_FactoryReset::execute(const SubCmdOptions &_options) const
   std::shared_ptr<xrt_core::device> device;
   try {
     device = XBU::get_device(boost::algorithm::to_lower_copy(m_device), false /*inUserDomain*/);
-  } catch (const std::runtime_error &e) {
+  } catch (const std::runtime_error& e) {
     // Catch only the exceptions that we have generated earlier
     std::cerr << boost::format("ERROR: %s\n") % e.what();
     throw xrt_core::error(std::errc::operation_canceled);

--- a/src/runtime_src/core/tools/xbmgmt2/OO_FactoryReset.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_FactoryReset.cpp
@@ -6,27 +6,20 @@
 #include "OO_FactoryReset.h"
 
 // XRT - Include Files
-#include "core/common/error.h"
 #include "core/common/message.h"
 #include "core/common/query_requests.h"
-#include "core/common/system.h"
 #include "flash/flasher.h"
-#include "tools/common/XBHelpMenusCore.h"
 #include "tools/common/XBUtilitiesCore.h"
 #include "tools/common/XBUtilities.h"
 namespace XBU = XBUtilities;
 
 // 3rd Party Library - Include Files
 #include <boost/format.hpp>
-#include <boost/filesystem.hpp>
 #include <boost/program_options.hpp>
-#include <boost/algorithm/string.hpp>
 namespace po = boost::program_options;
 
 // System - Include Files
-#include <fstream>
 #include <iostream>
-#include <vector>
 // =============================================================================
 
 // ----- H E L P E R M E T H O D S ------------------------------------------

--- a/src/runtime_src/core/tools/xbmgmt2/OO_FactoryReset.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_FactoryReset.cpp
@@ -109,6 +109,4 @@ OO_FactoryReset::execute(const SubCmdOptions& _options) const
   std::cout << "****************************************************\n";
   std::cout << "Cold reboot machine to load the new image on device.\n";
   std::cout << "****************************************************\n";
-
-  return;
 }

--- a/src/runtime_src/core/tools/xbmgmt2/OO_FactoryReset.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_FactoryReset.cpp
@@ -6,20 +6,27 @@
 #include "OO_FactoryReset.h"
 
 // XRT - Include Files
+#include "core/common/error.h"
 #include "core/common/message.h"
 #include "core/common/query_requests.h"
+#include "core/common/system.h"
 #include "flash/flasher.h"
+#include "tools/common/XBHelpMenusCore.h"
 #include "tools/common/XBUtilitiesCore.h"
 #include "tools/common/XBUtilities.h"
 namespace XBU = XBUtilities;
 
 // 3rd Party Library - Include Files
 #include <boost/format.hpp>
+#include <boost/filesystem.hpp>
 #include <boost/program_options.hpp>
+#include <boost/algorithm/string.hpp>
 namespace po = boost::program_options;
 
 // System - Include Files
+#include <fstream>
 #include <iostream>
+#include <vector>
 // =============================================================================
 
 // ----- H E L P E R M E T H O D S ------------------------------------------

--- a/src/runtime_src/core/tools/xbmgmt2/OO_FactoryReset.h
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_FactoryReset.h
@@ -8,10 +8,10 @@
 
 class OO_FactoryReset : public OptionOptions {
  public:
-  virtual void execute( const SubCmdOptions &_options ) const;
+  virtual void execute(const SubCmdOptions &_options) const;
 
  public:
-  OO_FactoryReset( const std::string &_longName, const std::string &_shortName="", bool _isHidden = false);
+  OO_FactoryReset(const std::string &_longName, const std::string &_shortName = "", bool _isHidden = false);
 
  private:
   std::string m_device;

--- a/src/runtime_src/core/tools/xbmgmt2/OO_FactoryReset.h
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_FactoryReset.h
@@ -8,10 +8,10 @@
 
 class OO_FactoryReset : public OptionOptions {
  public:
-  virtual void execute(const SubCmdOptions &_options) const;
+  virtual void execute(const SubCmdOptions& _options) const;
 
  public:
-  OO_FactoryReset(const std::string &_longName, const std::string &_shortName = "", bool _isHidden = false);
+  OO_FactoryReset(const std::string& _longName, const std::string& _shortName = "", bool _isHidden = false);
 
  private:
   std::string m_device;

--- a/src/runtime_src/core/tools/xbmgmt2/OO_FactoryReset.h
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_FactoryReset.h
@@ -16,8 +16,8 @@ class OO_FactoryReset : public OptionOptions {
  private:
   std::string m_device;
   std::string m_flashType;
-  bool m_revertToGolden;
-  bool m_help;
+  bool        m_revertToGolden;
+  bool        m_help;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbmgmt2/OO_FactoryReset.h
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_FactoryReset.h
@@ -15,8 +15,8 @@ class OO_FactoryReset : public OptionOptions {
 
  private:
   std::string m_device;
-  std::string flashType;
-  bool revertToGolden;
+  std::string m_flashType;
+  bool m_revertToGolden;
   bool m_help;
 };
 

--- a/src/runtime_src/core/tools/xbmgmt2/OO_FactoryReset.h
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_FactoryReset.h
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+
+#ifndef __OO_FactoryReset_h_
+#define __OO_FactoryReset_h_
+
+#include "tools/common/OptionOptions.h"
+
+class OO_FactoryReset : public OptionOptions {
+ public:
+  virtual void execute( const SubCmdOptions &_options ) const;
+
+ public:
+  OO_FactoryReset( const std::string &_longName, const std::string &_shortName="", bool _isHidden = false);
+
+ private:
+  std::string m_device;
+  std::string flashType;
+  bool revertToGolden;
+  bool m_help;
+};
+
+#endif

--- a/src/runtime_src/core/tools/xbmgmt2/OO_Hotplug.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_Hotplug.cpp
@@ -19,9 +19,7 @@ namespace po = boost::program_options;
 
 // System - Include Files
 #include <fstream>
-// =============================================================================
 
-// ----- H E L P E R M E T H O D S ------------------------------------------
 static void
 hotplug_online()
 {
@@ -68,7 +66,7 @@ OO_Hotplug::execute(const SubCmdOptions& _options) const
 
   XBUtilities::verbose("Option(s):");
   for (const auto & aString : _options)
-    XBUtilities::verbose(std::string(" ") + aString);
+    XBUtilities::verbose(" " + aString);
 
   // Honor help option first
   if (std::find(_options.begin(), _options.end(), "--help") != _options.end()) {

--- a/src/runtime_src/core/tools/xbmgmt2/OO_Hotplug.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_Hotplug.cpp
@@ -66,7 +66,7 @@ OO_Hotplug::execute(const SubCmdOptions& _options) const
 
   XBUtilities::verbose("Option(s):");
   for (const auto & aString : _options)
-    XBUtilities::verbose(" " + aString);
+    XBUtilities::verbose(boost::format(" %s") % aString);
 
   // Honor help option first
   if (std::find(_options.begin(), _options.end(), "--help") != _options.end()) {

--- a/src/runtime_src/core/tools/xbmgmt2/OO_Hotplug.h
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_Hotplug.h
@@ -16,7 +16,7 @@ class OO_Hotplug : public OptionOptions {
  private:
   std::string m_devices;
   std::string m_action;
-  bool m_help;
+  bool        m_help;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbmgmt2/OO_UpdateBase.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_UpdateBase.cpp
@@ -64,7 +64,7 @@ namespace po = boost::program_options;
 // ----- C L A S S   M E T H O D S -------------------------------------------
 
 OO_UpdateBase::OO_UpdateBase(const std::string &_longName, bool _isHidden )
-    : OptionOptions(_longName, _isHidden, "Update base partition")
+    : OptionOptions(_longName, _isHidden, "Update base partition", false)
 {
   m_optionsDescription.add_options()
     ("device,d", po::value<decltype(m_device)>(&m_device), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest")

--- a/src/runtime_src/core/tools/xbmgmt2/OO_UpdateBase.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_UpdateBase.cpp
@@ -80,8 +80,7 @@ OO_UpdateBase::OO_UpdateBase(const std::string &_longName, bool _isHidden )
     ("image", boost::program_options::value<decltype(image)>(&image)->multitoken(),  "Specifies an image to use used to update the persistent device.  Valid values:\n"
                                                                     "  Name (and path) to the mcs image on disk\n"
                                                                     "  Name (and path) to the xsabin image on disk")
-    ("help,h", po::bool_switch(&m_help), "Help to use this sub-command")
-    ("no,n", po::bool_switch(&m_help), "Help to use this sub-command")
+    ("help", po::bool_switch(&m_help), "Help to use this sub-command")
   ;
 
   m_optionsHidden.add_options()

--- a/src/runtime_src/core/tools/xbmgmt2/OO_UpdateBase.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_UpdateBase.cpp
@@ -9,15 +9,15 @@
 #include "core/common/message.h"
 #include "flash/flasher.h"
 #include "ReportPlatform.h"
-#include "tools/common/XBUtilitiesCore.h"
 #include "tools/common/ProgressBar.h"
+#include "tools/common/XBUtilitiesCore.h"
 namespace XBU = XBUtilities;
 
 // 3rd Party Library - Include Files
-#include <boost/format.hpp>
-#include <boost/tokenizer.hpp>
 #include <boost/filesystem.hpp>
+#include <boost/format.hpp>
 #include <boost/program_options.hpp>
+#include <boost/tokenizer.hpp>
 namespace po = boost::program_options;
 
 // System - Include Files
@@ -28,25 +28,19 @@ namespace po = boost::program_options;
 #include <iostream>
 #include <map>
 #include <thread>
-// =============================================================================
 
-// ----- H E L P E R M E T H O D S ------------------------------------------
-
-
-// ----- C L A S S   M E T H O D S -------------------------------------------
-
-OO_UpdateBase::OO_UpdateBase(const std::string &_longName, const std::string &_shortName, bool _isHidden )
-    : OptionOptions(_longName,
-                    _shortName,
-                    "Update base partition",
-                    boost::program_options::value<decltype(m_update)>(&m_update)->implicit_value("all")->required(),
-                    "Update the persistent images and/or the Satellite controller (SC) firmware image.  Valid values:\n"
-                      "  ALL   - All images will be updated\n"
-                      "  SHELL - Platform image\n"
-                      "  SC    - Satellite controller (Warning: Damage could occur to the device)\n"
-                      "  NO-BACKUP   - Backup boot remains unchanged",
-                    _isHidden)
-    , m_update("all")
+OO_UpdateBase::OO_UpdateBase(const std::string &_longName, const std::string &_shortName, bool _isHidden)
+  : OptionOptions(_longName,
+                  _shortName,
+                  "Update base partition",
+                  boost::program_options::value<decltype(m_update)>(&m_update)->implicit_value("all")->required(),
+                  "Update the persistent images and/or the Satellite controller (SC) firmware image.  Valid values:\n"
+                  "  ALL   - All images will be updated\n"
+                  "  SHELL - Platform image\n"
+                  "  SC    - Satellite controller (Warning: Damage could occur to the device)\n"
+                  "  NO-BACKUP   - Backup boot remains unchanged",
+                  _isHidden)
+  , m_update("")
 {
   m_optionsDescription.add_options()
     ("device,d", po::value<decltype(m_device)>(&m_device), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest")
@@ -66,14 +60,14 @@ OO_UpdateBase::OO_UpdateBase(const std::string &_longName, const std::string &_s
 
 // Create a list of images that are known to exist based on given names and paths
 static std::vector<std::string>
-find_flash_image_paths(const std::vector<std::string>& image_list)
+find_flash_image_paths(const std::vector<std::string> &image_list)
 {
   std::vector<std::string> path_list;
   auto installedShells = firmwareImage::getIntalledDSAs();
 
-  for (const auto& img : image_list) {
+  for (const auto &img : image_list) {
     // Check if the passed in image is absolute path
-    if (boost::filesystem::is_regular_file(img)){
+    if (boost::filesystem::is_regular_file(img)) {
       if (boost::filesystem::extension(img).compare(".xsabin") != 0) {
         std::cout << "Warning: Non-xsabin file detected. Development usage, this may damage the card\n";
         if (!XBU::can_proceed(XBU::getForce()))
@@ -83,9 +77,9 @@ find_flash_image_paths(const std::vector<std::string>& image_list)
     }
     // Search through the installed shells and get the complete path
     else {
-       // Checks installed shell names against the shell name passed in by the user
+      // Checks installed shell names against the shell name passed in by the user
       std::string img_path;
-      for (auto const& shell : installedShells) {
+      for (auto const &shell : installedShells) {
         if (img.compare(shell.name) == 0) {
           // Only set the image path on the first shell match
           if (img_path.empty())
@@ -115,15 +109,16 @@ find_flash_image_paths(const std::vector<std::string>& image_list)
  *                       blank to use the boards default flashing mode
  */
 static void
-update_shell(unsigned int index, std::map<std::string, std::string>& image_paths, Flasher::E_FlasherType flash_type)
+update_shell(unsigned int index, std::map<std::string, std::string> &image_paths, Flasher::E_FlasherType flash_type)
 {
   Flasher flasher(index);
   if (!flasher.isValid())
     throw xrt_core::error(boost::str(boost::format("%d is an invalid index") % index));
 
   if (image_paths.empty())
-    throw xrt_core::error("No image specified.\n Usage: xbmgmt program --device='0000:00:00.0' --base [all|sc|shell]"
-                            " --image=['/path/to/flash_image'|'shell name']");
+    throw xrt_core::error(
+        "No image specified.\n Usage: xbmgmt program --device='0000:00:00.0' --base [all|sc|shell]"
+        " --image=['/path/to/flash_image'|'shell name']");
 
   auto pri = std::make_unique<firmwareImage>(image_paths["primary"], MCS_FIRMWARE_PRIMARY);
   if (pri->fail())
@@ -154,22 +149,20 @@ getBDF(unsigned int index)
   return xrt_core::query::pcie_bdf::to_string(bdf);
 }
 
-
 static bool
 is_SC_fixed(unsigned int index)
 {
   try {
     auto device = xrt_core::get_mgmtpf_device(index);
     return xrt_core::device_query<xrt_core::query::is_sc_fixed>(device);
-  }
-  catch (...) {
-    //TODO Catching all the exceptions for now. We may need to catch specific exceptions
-    //Work-around. Assume that sc is not fixed if above query throws an exception
+  } catch (...) {
+    // TODO Catching all the exceptions for now. We may need to catch specific exceptions
+    // Work-around. Assume that sc is not fixed if above query throws an exception
     return false;
   }
 }
 
-//versal flow to flash sc
+// versal flow to flash sc
 static void
 update_versal_SC(std::shared_ptr<xrt_core::device> dev)
 {
@@ -195,8 +188,7 @@ update_versal_SC(std::shared_ptr<xrt_core::device> dev)
     done = true;
     progress_reporter.get()->finish(true, "SC firmware image has been programmed successfully.");
     t.join();
-  }
-  catch (const xrt_core::query::sysfs_error& e) {
+  } catch (const xrt_core::query::sysfs_error &e) {
     done = true;
     progress_reporter.get()->finish(false, "Failed to update SC flash image.");
     t.join();
@@ -206,7 +198,7 @@ update_versal_SC(std::shared_ptr<xrt_core::device> dev)
 
 // Update SC firmware on the board
 static void
-update_SC(unsigned int  index, const std::string& file)
+update_SC(unsigned int index, const std::string &file)
 {
   Flasher flasher(index);
 
@@ -221,7 +213,7 @@ update_SC(unsigned int  index, const std::string& file)
     return;
   }
 
-  //if factory image, update SC
+  // if factory image, update SC
   auto is_mfg = xrt_core::device_query<xrt_core::query::is_mfg>(dev);
   if (is_mfg) {
     std::unique_ptr<firmwareImage> bmc = std::make_unique<firmwareImage>(file, BMC_FIRMWARE);
@@ -240,9 +232,10 @@ update_SC(unsigned int  index, const std::string& file)
   // Mgmt pf needs to shutdown so that the board doesn't brick
   try {
     dev->device_shutdown();
-  }
-  catch (const xrt_core::error& e) {
-    throw xrt_core::error(std::string("Only proceed with SC update if all user applications for the target card(s) are stopped. ") + e.what());
+  } catch (const xrt_core::error &e) {
+    throw xrt_core::error(
+        std::string("Only proceed with SC update if all user applications for the target card(s) are stopped. ")
+        + e.what());
   }
 
   std::unique_ptr<firmwareImage> bmc = std::make_unique<firmwareImage>(file, BMC_FIRMWARE);
@@ -256,8 +249,7 @@ update_SC(unsigned int  index, const std::string& file)
   // Bring back mgmt pf
   try {
     dev->device_online();
-  }
-  catch (const xrt_core::error& e) {
+  } catch (const xrt_core::error &e) {
     throw xrt_core::error(e.what() + std::string(" Please warm reboot."));
   }
 
@@ -266,17 +258,17 @@ update_SC(unsigned int  index, const std::string& file)
 
 // Helper function for header info
 static std::string
-file_size(const std::string & _file)
+file_size(const std::string &_file)
 {
-  std::ifstream in(_file.c_str(), std::ifstream::ate | std::ifstream::binary);
+  std::ifstream in(_file, std::ifstream::ate | std::ifstream::binary);
   auto total_size = std::to_string(in.tellg());
   int strSize = static_cast<int>(total_size.size());
 
-  //if file size is > 3 digits, insert commas after every 3 digits
+  // if file size is > 3 digits, insert commas after every 3 digits
   static const int COMMA_SPACING = 3;
   if (strSize > COMMA_SPACING) {
-   for (int i = (strSize - COMMA_SPACING);  i > 0;  i -= COMMA_SPACING)
-     total_size.insert(static_cast<size_t>(i), 1, ',');
+    for (int i = (strSize - COMMA_SPACING); i > 0; i -= COMMA_SPACING)
+      total_size.insert(static_cast<size_t>(i), 1, ',');
   }
 
   return total_size + std::string(" bytes");
@@ -286,14 +278,14 @@ file_size(const std::string & _file)
 static std::pair<std::string, std::string>
 deployment_path_and_filename(std::string file)
 {
-  using tokenizer = boost::tokenizer< boost::char_separator<char> >;
+  using tokenizer = boost::tokenizer<boost::char_separator<char>>;
   boost::char_separator<char> sep("\\/");
   tokenizer tokens(file, sep);
   std::string dsafile = "";
   for (auto tok_iter = tokens.begin(); tok_iter != tokens.end(); ++tok_iter) {
-  	if ((std::string(*tok_iter).find(XSABIN_FILE_SUFFIX) != std::string::npos)
-          || (std::string(*tok_iter).find(DSABIN_FILE_SUFFIX) != std::string::npos))
-          dsafile = *tok_iter;
+    if ((std::string(*tok_iter).find(XSABIN_FILE_SUFFIX) != std::string::npos)
+        || (std::string(*tok_iter).find(DSABIN_FILE_SUFFIX) != std::string::npos))
+      dsafile = *tok_iter;
   }
   auto pos = file.rfind('/') != std::string::npos ? file.rfind('/') : file.rfind('\\');
   std::string path = file.erase(pos);
@@ -303,12 +295,12 @@ deployment_path_and_filename(std::string file)
 
 // Helper function for header info
 static std::string
-get_file_timestamp(const std::string & _file)
+get_file_timestamp(const std::string &_file)
 {
   boost::filesystem::path p(_file);
-	if (!boost::filesystem::exists(p)) {
-		throw xrt_core::error("Invalid platform path.");
-	}
+  if (!boost::filesystem::exists(p))
+    throw xrt_core::error("Invalid platform path.");
+
   std::time_t ftime = boost::filesystem::last_write_time(boost::filesystem::path(_file));
   std::string timeStr(std::asctime(std::localtime(&ftime)));
   timeStr.pop_back();  // Remove the new-line character that gets inserted by asctime.
@@ -316,7 +308,7 @@ get_file_timestamp(const std::string & _file)
 }
 
 static void
-pretty_print_platform_info(const boost::property_tree::ptree& _ptDevice, const std::string& vbnv)
+pretty_print_platform_info(const boost::property_tree::ptree &_ptDevice, const std::string &vbnv)
 {
   std::cout << boost::format("%s : [%s]\n") % "Device" % _ptDevice.get<std::string>("platform.bdf");
   std::cout << std::endl;
@@ -327,16 +319,16 @@ pretty_print_platform_info(const boost::property_tree::ptree& _ptDevice, const s
   std::cout << boost::format("  %-20s : %s\n") % "Platform ID" % _ptDevice.get<std::string>("platform.current_shell.id", "N/A");
   std::cout << std::endl;
   std::cout << "\nIncoming Configuration\n";
-  const boost::property_tree::ptree& available_shells = _ptDevice.get_child("platform.available_shells");
+  const boost::property_tree::ptree &available_shells = _ptDevice.get_child("platform.available_shells");
 
   boost::property_tree::ptree platform_to_flash;
-  for (auto& image : available_shells) {
+  for (auto &image : available_shells) {
     if ((image.second.get<std::string>("vbnv")).compare(vbnv) == 0) {
       platform_to_flash = image.second;
       break;
     }
   }
-  std::pair <std::string, std::string> s = deployment_path_and_filename(platform_to_flash.get<std::string>("file"));
+  std::pair<std::string, std::string> s = deployment_path_and_filename(platform_to_flash.get<std::string>("file"));
   std::cout << boost::format("  %-20s : %s\n") % "Deployment File" % s.first;
   std::cout << boost::format("  %-20s : %s\n") % "Deployment Directory" % s.second;
   std::cout << boost::format("  %-20s : %s\n") % "Size" % file_size(platform_to_flash.get<std::string>("file").c_str());
@@ -353,7 +345,7 @@ pretty_print_platform_info(const boost::property_tree::ptree& _ptDevice, const s
 }
 
 static void
-report_status(const std::string& vbnv, boost::property_tree::ptree& pt_device)
+report_status(const std::string &vbnv, boost::property_tree::ptree &pt_device)
 {
   std::cout << "----------------------------------------------------\n";
   pretty_print_platform_info(pt_device, vbnv);
@@ -373,9 +365,8 @@ report_status(const std::string& vbnv, boost::property_tree::ptree& pt_device)
   }
 }
 
-
 static bool
-are_shells_equal(const DSAInfo& candidate, const DSAInfo& current)
+are_shells_equal(const DSAInfo &candidate, const DSAInfo &current)
 {
   if (current.dsaname().empty())
     throw std::runtime_error("Current shell name is empty.");
@@ -383,9 +374,8 @@ are_shells_equal(const DSAInfo& candidate, const DSAInfo& current)
   return ((candidate.dsaname() == current.dsaname()) && candidate.matchId(current));
 }
 
-
 static bool
-are_scs_equal(const DSAInfo& candidate, const DSAInfo& current)
+are_scs_equal(const DSAInfo &candidate, const DSAInfo &current)
 {
   if (current.dsaname().empty())
     throw std::runtime_error("Current shell name is empty.");
@@ -395,7 +385,7 @@ are_scs_equal(const DSAInfo& candidate, const DSAInfo& current)
 }
 
 static bool
-update_sc(unsigned int boardIdx, DSAInfo& candidate)
+update_sc(unsigned int boardIdx, DSAInfo &candidate)
 {
   Flasher flasher(boardIdx);
 
@@ -408,8 +398,8 @@ update_sc(unsigned int boardIdx, DSAInfo& candidate)
   // -- Some DRCs (Design Rule Checks) --
   // Is the SC present
   if (current.bmc_ver().empty() || candidate.bmc_ver().empty()) {
-     std::cout << "INFO: Satellite controller is not present.\n";
-     return false;
+    std::cout << "INFO: Satellite controller is not present.\n";
+    return false;
   }
 
   // Can the SC be programmed
@@ -439,12 +429,10 @@ update_sc(unsigned int boardIdx, DSAInfo& candidate)
   return true;
 }
 
-
-
 // Flash shell and sc firmware
 // Helper method for auto_flash
 static bool
-update_shell(unsigned int boardIdx, DSAInfo& candidate, Flasher::E_FlasherType flash_type)
+update_shell(unsigned int boardIdx, DSAInfo &candidate, Flasher::E_FlasherType flash_type)
 {
   Flasher flasher(boardIdx);
 
@@ -486,14 +474,14 @@ update_shell(unsigned int boardIdx, DSAInfo& candidate, Flasher::E_FlasherType f
 }
 
 static void
-update_default_only(xrt_core::device* device, bool value)
+update_default_only(xrt_core::device *device, bool value)
 {
   try {
     // get boot on backup from vmr_status sysfs node
     boost::property_tree::ptree pt_empty;
     const auto pt = xrt_core::vmr::vmr_info(device).get_child("vmr", pt_empty);
-    for (const auto& ks : pt) {
-      const boost::property_tree::ptree& vmr_stat = ks.second;
+    for (const auto &ks : pt) {
+      const boost::property_tree::ptree &vmr_stat = ks.second;
       if (boost::iequals(vmr_stat.get<std::string>("label"), "Boot on default")) {
         // if backup is booted, then do not proceed
         if (std::stoi(vmr_stat.get<std::string>("value")) != 1) {
@@ -505,8 +493,7 @@ update_default_only(xrt_core::device* device, bool value)
 
     uint32_t val = xrt_core::query::flush_default_only::value_type(value);
     xrt_core::device_update<xrt_core::query::flush_default_only>(device, val);
-  }
-  catch (const xrt_core::query::exception&) {
+  } catch (const xrt_core::query::exception &) {
     // only available for versal devices
   }
 }
@@ -514,7 +501,7 @@ update_default_only(xrt_core::device* device, bool value)
 // Update shell and sc firmware on the device automatically
 // Refactor code to support only 1 device.
 static void
-auto_flash(std::shared_ptr<xrt_core::device> & device, Flasher::E_FlasherType flashType, const std::string& image = "")
+auto_flash(std::shared_ptr<xrt_core::device> &device, Flasher::E_FlasherType flashType, const std::string &image = "")
 {
   // Get platform information
   boost::property_tree::ptree pt;
@@ -524,12 +511,13 @@ auto_flash(std::shared_ptr<xrt_core::device> & device, Flasher::E_FlasherType fl
   pt.push_back(std::make_pair(std::to_string(device->get_device_id()), ptDevice));
 
   // Collect all indexes of boards need updating
-  std::vector<std::pair<unsigned int , DSAInfo>> boardsToUpdate;
+  std::vector<std::pair<unsigned int, DSAInfo>> boardsToUpdate;
 
-  std::string image_path = image; // Set default image path
+  std::string image_path = image;  // Set default image path
   if (image_path.empty()) {
     static boost::property_tree::ptree ptEmpty;
-    auto available_shells = pt.get_child(std::to_string(device->get_device_id()) + ".platform.available_shells", ptEmpty);
+    auto available_shells =
+        pt.get_child(std::to_string(device->get_device_id()) + ".platform.available_shells", ptEmpty);
 
     // Check if any base packages are available
     if (available_shells.empty()) {
@@ -539,7 +527,8 @@ auto_flash(std::shared_ptr<xrt_core::device> & device, Flasher::E_FlasherType fl
 
     // Check if multiple base packages are available
     if (available_shells.size() > 1) {
-      std::cout << "ERROR: Multiple images installed on the server. Please specify a single image using --image option. Operation canceled.\n";
+      std::cout << "ERROR: Multiple images installed on the server. Please specify a single image using --image "
+                   "option. Operation canceled.\n";
       throw xrt_core::error(std::errc::operation_canceled);
     }
     image_path = available_shells.front().second.get<std::string>("file");
@@ -548,13 +537,13 @@ auto_flash(std::shared_ptr<xrt_core::device> & device, Flasher::E_FlasherType fl
   DSAInfo dsa(image_path);
 
   // If the shell is not up-to-date and dsa has a flash image, queue the board for update
-  boost::property_tree::ptree& pt_dev = pt.get_child(std::to_string(device->get_device_id()));
+  boost::property_tree::ptree &pt_dev = pt.get_child(std::to_string(device->get_device_id()));
   bool same_shell = (dsa.name == pt_dev.get<std::string>("platform.current_shell.vbnv", ""))
-                      && (dsa.matchId(pt_dev.get<std::string>("platform.current_shell.id", "")));
+      && (dsa.matchId(pt_dev.get<std::string>("platform.current_shell.id", "")));
 
   auto sc = pt_dev.get<std::string>("platform.current_shell.sc_version", "");
-  bool same_sc = ((sc.empty()) || (dsa.bmcVer.empty()) ||
-                  (dsa.bmcVer == sc) || (sc.find("FIXED") != std::string::npos));
+  bool same_sc =
+      ((sc.empty()) || (dsa.bmcVer.empty()) || (dsa.bmcVer == sc) || (sc.find("FIXED") != std::string::npos));
 
   // Always update Arista devices
   auto vendor = xrt_core::device_query<xrt_core::query::pcie_vendor>(device);
@@ -583,7 +572,7 @@ auto_flash(std::shared_ptr<xrt_core::device> & device, Flasher::E_FlasherType fl
   pt_dev.put("platform.status.shell", same_shell);
   pt_dev.put("platform.status.sc", same_sc);
 
-  //report status of the device
+  // report status of the device
   report_status(dsa.name, pt_dev);
 
   // Continue to flash whatever we have collected in boardsToUpdate.
@@ -597,35 +586,44 @@ auto_flash(std::shared_ptr<xrt_core::device> & device, Flasher::E_FlasherType fl
 
   // Perform DSA and BMC updating
   std::stringstream error_stream;
-  for (auto& p : boardsToUpdate) {
+  for (auto &p : boardsToUpdate) {
     try {
       std::cout << std::endl;
       // 1) Flash the Satellite Controller image
-      if (xrt_core::device_query<xrt_core::query::is_mfg>(device.get()) || xrt_core::device_query<xrt_core::query::is_recovery>(device.get()))
-        report_stream << boost::format("  [%s] : Factory or Recovery image detected. Reflash the device after the reboot to update the SC firmware.\n") % getBDF(p.first);
+      if (xrt_core::device_query<xrt_core::query::is_mfg>(device.get())
+          || xrt_core::device_query<xrt_core::query::is_recovery>(device.get()))
+        report_stream << boost::format(
+                             "  [%s] : Factory or Recovery image detected. Reflash the device after the reboot to "
+                             "update the SC firmware.\n")
+                % getBDF(p.first);
       else {
-        if (update_sc(p.first, p.second) == true)  {
-          report_stream << boost::format("  [%s] : Successfully flashed the Satellite Controller (SC) image\n") % getBDF(p.first);
+        if (update_sc(p.first, p.second) == true) {
+          report_stream << boost::format("  [%s] : Successfully flashed the Satellite Controller (SC) image\n")
+                  % getBDF(p.first);
           need_warm_reboot = true;
         } else
-          report_stream << boost::format("  [%s] : Satellite Controller (SC) is either up-to-date, fixed, or not installed. No actions taken.\n") % getBDF(p.first);
+          report_stream << boost::format(
+                               "  [%s] : Satellite Controller (SC) is either up-to-date, fixed, or not installed. No "
+                               "actions taken.\n")
+                  % getBDF(p.first);
       }
 
       // 2) Flash shell image
-      if (update_shell(p.first, p.second, flashType) == true)  {
-        report_stream << boost::format("  [%s] : Successfully flashed the base (e.g., shell) image\n") % getBDF(p.first);
+      if (update_shell(p.first, p.second, flashType) == true) {
+        report_stream << boost::format("  [%s] : Successfully flashed the base (e.g., shell) image\n")
+                % getBDF(p.first);
         needreboot = true;
       } else
-        report_stream << boost::format("  [%s] : Base (e.g., shell) image is up-to-date.  No actions taken.\n") % getBDF(p.first);
-      } catch (const xrt_core::error& e) {
-        error_stream << boost::format("ERROR: %s\n") % e.what();
-      }
+        report_stream << boost::format("  [%s] : Base (e.g., shell) image is up-to-date.  No actions taken.\n")
+                % getBDF(p.first);
+    } catch (const xrt_core::error &e) {
+      error_stream << boost::format("ERROR: %s\n") % e.what();
+    }
   }
 
   std::cout << "----------------------------------------------------\n";
   std::cout << "Report\n";
   std::cout << report_stream.str();
-
 
   if (error_stream.str().empty()) {
     std::cout << "\nDevice flashed successfully.\n";
@@ -647,13 +645,13 @@ auto_flash(std::shared_ptr<xrt_core::device> & device, Flasher::E_FlasherType fl
 }
 
 void
-OO_UpdateBase::execute(const SubCmdOptions& _options) const
+OO_UpdateBase::execute(const SubCmdOptions &_options) const
 {
   XBUtilities::verbose("SubCommand option: Update Base");
 
   XBUtilities::verbose("Option(s):");
-  for (const auto & aString : _options)
-    XBUtilities::verbose(std::string(" ") + aString);
+  for (const auto &aString : _options)
+    XBUtilities::verbose(" " + aString);
 
   // Honor help option first
   if (std::find(_options.begin(), _options.end(), "--help") != _options.end()) {
@@ -668,7 +666,7 @@ OO_UpdateBase::execute(const SubCmdOptions& _options) const
   std::shared_ptr<xrt_core::device> device;
   try {
     device = XBU::get_device(boost::algorithm::to_lower_copy(m_device), false /*inUserDomain*/);
-  } catch (const std::runtime_error& e) {
+  } catch (const std::runtime_error &e) {
     // Catch only the exceptions that we have generated earlier
     std::cerr << boost::format("ERROR: %s\n") % e.what();
     throw xrt_core::error(std::errc::operation_canceled);
@@ -680,8 +678,9 @@ OO_UpdateBase::execute(const SubCmdOptions& _options) const
 
   // Populate flash type. Uses board's default when passing an empty input string.
   if (!m_flashType.empty()) {
-      xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT",
-        "Overriding flash mode is not recommended.\nYou may damage your device with this option.");
+    xrt_core::message::send(xrt_core::message::severity_level::warning,
+                            "XRT",
+                            "Overriding flash mode is not recommended.\nYou may damage your device with this option.");
   }
   Flasher working_flasher(device->get_device_id());
   auto flash_type = working_flasher.getFlashType(m_flashType);
@@ -695,8 +694,7 @@ OO_UpdateBase::execute(const SubCmdOptions& _options) const
       auto_flash(device, flash_type);
       return;
     }
-  }
-  else if (m_update.compare("no-backup") == 0) {
+  } else if (m_update.compare("no-backup") == 0) {
     if (m_image.empty()) {
       update_default_only(device.get(), true);
       auto_flash(device, flash_type);
@@ -729,26 +727,24 @@ OO_UpdateBase::execute(const SubCmdOptions& _options) const
   }
 
   if (m_update.compare("all") == 0) {
-      update_default_only(device.get(), false);
-      auto_flash(device, flash_type, validated_image_map["primary"]);
+    update_default_only(device.get(), false);
+    auto_flash(device, flash_type, validated_image_map["primary"]);
   }
   // For the following two if conditions regarding the validated images portion
   // The user may have provided an image, but, it may not exist or the shell name is wrong
   else if (m_update.compare("sc") == 0) {
     update_SC(device.get()->get_device_id(), validated_image_map["primary"]);
-  }
-  else if (m_update.compare("shell") == 0) {
+  } else if (m_update.compare("shell") == 0) {
     update_default_only(device.get(), false);
     update_shell(device.get()->get_device_id(), validated_image_map, flash_type);
     std::cout << "****************************************************\n";
     std::cout << "Cold reboot machine to load the new image on device.\n";
     std::cout << "****************************************************\n";
-  }
-  else if (m_update.compare("no-backup") == 0) {
+  } else if (m_update.compare("no-backup") == 0) {
     update_default_only(device.get(), true);
     auto_flash(device, flash_type, validated_image_map["primary"]);
-  }
-  else
-    throw xrt_core::error("Usage: xbmgmt program --device='0000:00:00.0' --base [all|sc|shell]"
-                          " --image=['/path/to/flash_image'|'shell name']");
+  } else
+    throw xrt_core::error(
+        "Usage: xbmgmt program --device='0000:00:00.0' --base [all|sc|shell]"
+        " --image=['/path/to/flash_image'|'shell name']");
 }

--- a/src/runtime_src/core/tools/xbmgmt2/OO_UpdateBase.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_UpdateBase.cpp
@@ -64,15 +64,19 @@ namespace po = boost::program_options;
 // ----- C L A S S   M E T H O D S -------------------------------------------
 
 OO_UpdateBase::OO_UpdateBase(const std::string &_longName, bool _isHidden )
-    : OptionOptions(_longName, _isHidden, "Update base partition", false)
+    : OptionOptions( _longName, 
+                    std::string("b"),
+                    "Update base partition",
+                    boost::program_options::value<decltype(update)>(&update)->implicit_value("all"),
+                    "Update the persistent images and/or the Satellite controller (SC) firmware image.  Valid values:\n"
+                      "  ALL   - All images will be updated\n"
+                      "  SHELL - Platform image\n"
+                      "  SC    - Satellite controller (Warning: Damage could occur to the device)\n"
+                      "  NO-BACKUP   - Backup boot remains unchanged",
+                    _isHidden)
 {
   m_optionsDescription.add_options()
     ("device,d", po::value<decltype(m_device)>(&m_device), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest")
-    ("base,b", boost::program_options::value<decltype(update)>(&update)->implicit_value("all"), "Update the persistent images and/or the Satellite controller (SC) firmware image.  Valid values:\n"
-                                                                        "  ALL   - All images will be updated\n"
-                                                                        "  SHELL - Platform image\n"
-                                                                        "  SC    - Satellite controller (Warning: Damage could occur to the device)\n"
-                                                                        "  NO-BACKUP   - Backup boot remains unchanged")
     ("image", boost::program_options::value<decltype(image)>(&image)->multitoken(),  "Specifies an image to use used to update the persistent device.  Valid values:\n"
                                                                     "  Name (and path) to the mcs image on disk\n"
                                                                     "  Name (and path) to the xsabin image on disk")

--- a/src/runtime_src/core/tools/xbmgmt2/OO_UpdateBase.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_UpdateBase.cpp
@@ -197,6 +197,7 @@ update_versal_SC(std::shared_ptr<xrt_core::device> dev)
   catch (const xrt_core::query::sysfs_error& e) {
     done = true;
     progress_reporter.get()->finish(false, "Failed to update SC flash image.");
+    t.join();
     throw xrt_core::error(std::string("Error accessing sysfs entry : ") + e.what());
   }
 }

--- a/src/runtime_src/core/tools/xbmgmt2/OO_UpdateBase.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_UpdateBase.cpp
@@ -29,6 +29,10 @@ namespace po = boost::program_options;
 #include <map>
 #include <thread>
 
+#ifdef _WIN32
+#pragma warning(disable : 4996) // disable warning caused by std::asctime
+#endif
+
 OO_UpdateBase::OO_UpdateBase(const std::string &_longName, const std::string &_shortName, bool _isHidden)
   : OptionOptions(_longName,
                   _shortName,

--- a/src/runtime_src/core/tools/xbmgmt2/OO_UpdateBase.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_UpdateBase.cpp
@@ -33,18 +33,18 @@ namespace po = boost::program_options;
 #pragma warning(disable : 4996) // disable warning caused by std::asctime
 #endif
 
-OO_UpdateBase::OO_UpdateBase(const std::string &_longName, const std::string &_shortName, bool _isHidden)
-  : OptionOptions(_longName,
-                  _shortName,
-                  "Update base partition",
-                  boost::program_options::value<decltype(m_update)>(&m_update)->implicit_value("all")->required(),
-                  "Update the persistent images and/or the Satellite controller (SC) firmware image.  Valid values:\n"
-                  "  ALL   - All images will be updated\n"
-                  "  SHELL - Platform image\n"
-                  "  SC    - Satellite controller (Warning: Damage could occur to the device)\n"
-                  "  NO-BACKUP   - Backup boot remains unchanged",
-                  _isHidden)
-  , m_update("")
+OO_UpdateBase::OO_UpdateBase(const std::string& _longName, const std::string& _shortName, bool _isHidden)
+    : OptionOptions(_longName,
+                    _shortName,
+                    "Update base partition",
+                    boost::program_options::value<decltype(m_update)>(&m_update)->implicit_value("all")->required(),
+                    "Update the persistent images and/or the Satellite controller (SC) firmware image.  Valid values:\n"
+                    "  ALL   - All images will be updated\n"
+                    "  SHELL - Platform image\n"
+                    "  SC    - Satellite controller (Warning: Damage could occur to the device)\n"
+                    "  NO-BACKUP   - Backup boot remains unchanged",
+                    _isHidden)
+    , m_update("")
 {
   m_optionsDescription.add_options()
     ("device,d", po::value<decltype(m_device)>(&m_device), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest")
@@ -64,12 +64,12 @@ OO_UpdateBase::OO_UpdateBase(const std::string &_longName, const std::string &_s
 
 // Create a list of images that are known to exist based on given names and paths
 static std::vector<std::string>
-find_flash_image_paths(const std::vector<std::string> &image_list)
+find_flash_image_paths(const std::vector<std::string>& image_list)
 {
   std::vector<std::string> path_list;
   auto installedShells = firmwareImage::getIntalledDSAs();
 
-  for (const auto &img : image_list) {
+  for (const auto& img : image_list) {
     // Check if the passed in image is absolute path
     if (boost::filesystem::is_regular_file(img)) {
       if (boost::filesystem::extension(img).compare(".xsabin") != 0) {
@@ -83,7 +83,7 @@ find_flash_image_paths(const std::vector<std::string> &image_list)
     else {
       // Checks installed shell names against the shell name passed in by the user
       std::string img_path;
-      for (auto const &shell : installedShells) {
+      for (auto const& shell : installedShells) {
         if (img.compare(shell.name) == 0) {
           // Only set the image path on the first shell match
           if (img_path.empty())
@@ -113,7 +113,7 @@ find_flash_image_paths(const std::vector<std::string> &image_list)
  *                       blank to use the boards default flashing mode
  */
 static void
-update_shell(unsigned int index, std::map<std::string, std::string> &image_paths, Flasher::E_FlasherType flash_type)
+update_shell(unsigned int index, std::map<std::string, std::string>& image_paths, Flasher::E_FlasherType flash_type)
 {
   Flasher flasher(index);
   if (!flasher.isValid())
@@ -192,7 +192,7 @@ update_versal_SC(std::shared_ptr<xrt_core::device> dev)
     done = true;
     progress_reporter.get()->finish(true, "SC firmware image has been programmed successfully.");
     t.join();
-  } catch (const xrt_core::query::sysfs_error &e) {
+  } catch (const xrt_core::query::sysfs_error& e) {
     done = true;
     progress_reporter.get()->finish(false, "Failed to update SC flash image.");
     t.join();
@@ -202,7 +202,7 @@ update_versal_SC(std::shared_ptr<xrt_core::device> dev)
 
 // Update SC firmware on the board
 static void
-update_SC(unsigned int index, const std::string &file)
+update_SC(unsigned int index, const std::string& file)
 {
   Flasher flasher(index);
 
@@ -236,7 +236,7 @@ update_SC(unsigned int index, const std::string &file)
   // Mgmt pf needs to shutdown so that the board doesn't brick
   try {
     dev->device_shutdown();
-  } catch (const xrt_core::error &e) {
+  } catch (const xrt_core::error& e) {
     throw xrt_core::error(
         std::string("Only proceed with SC update if all user applications for the target card(s) are stopped. ")
         + e.what());
@@ -253,7 +253,7 @@ update_SC(unsigned int index, const std::string &file)
   // Bring back mgmt pf
   try {
     dev->device_online();
-  } catch (const xrt_core::error &e) {
+  } catch (const xrt_core::error& e) {
     throw xrt_core::error(e.what() + std::string(" Please warm reboot."));
   }
 
@@ -262,7 +262,7 @@ update_SC(unsigned int index, const std::string &file)
 
 // Helper function for header info
 static std::string
-file_size(const std::string &_file)
+file_size(const std::string& _file)
 {
   std::ifstream in(_file, std::ifstream::ate | std::ifstream::binary);
   auto total_size = std::to_string(in.tellg());
@@ -296,12 +296,12 @@ deployment_path_and_filename(std::string file)
   auto pos = file.rfind('/') != std::string::npos ? file.rfind('/') : file.rfind('\\');
   std::string path = file.erase(pos);
 
-  return { dsafile, path };
+  return {dsafile, path};
 }
 
 // Helper function for header info
 static std::string
-get_file_timestamp(const std::string &_file)
+get_file_timestamp(const std::string& _file)
 {
   boost::filesystem::path p(_file);
   if (!boost::filesystem::exists(p))
@@ -314,7 +314,7 @@ get_file_timestamp(const std::string &_file)
 }
 
 static void
-pretty_print_platform_info(const boost::property_tree::ptree &_ptDevice, const std::string &vbnv)
+pretty_print_platform_info(const boost::property_tree::ptree& _ptDevice, const std::string& vbnv)
 {
   std::cout << boost::format("%s : [%s]\n") % "Device" % _ptDevice.get<std::string>("platform.bdf");
   std::cout << std::endl;
@@ -325,10 +325,10 @@ pretty_print_platform_info(const boost::property_tree::ptree &_ptDevice, const s
   std::cout << boost::format("  %-20s : %s\n") % "Platform ID" % _ptDevice.get<std::string>("platform.current_shell.id", "N/A");
   std::cout << std::endl;
   std::cout << "\nIncoming Configuration\n";
-  const boost::property_tree::ptree &available_shells = _ptDevice.get_child("platform.available_shells");
+  const boost::property_tree::ptree& available_shells = _ptDevice.get_child("platform.available_shells");
 
   boost::property_tree::ptree platform_to_flash;
-  for (auto &image : available_shells) {
+  for (auto& image : available_shells) {
     if ((image.second.get<std::string>("vbnv")).compare(vbnv) == 0) {
       platform_to_flash = image.second;
       break;
@@ -351,7 +351,7 @@ pretty_print_platform_info(const boost::property_tree::ptree &_ptDevice, const s
 }
 
 static void
-report_status(const std::string &vbnv, boost::property_tree::ptree &pt_device)
+report_status(const std::string& vbnv, boost::property_tree::ptree& pt_device)
 {
   std::cout << "----------------------------------------------------\n";
   pretty_print_platform_info(pt_device, vbnv);
@@ -372,7 +372,7 @@ report_status(const std::string &vbnv, boost::property_tree::ptree &pt_device)
 }
 
 static bool
-are_shells_equal(const DSAInfo &candidate, const DSAInfo &current)
+are_shells_equal(const DSAInfo& candidate, const DSAInfo& current)
 {
   if (current.dsaname().empty())
     throw std::runtime_error("Current shell name is empty.");
@@ -381,17 +381,16 @@ are_shells_equal(const DSAInfo &candidate, const DSAInfo &current)
 }
 
 static bool
-are_scs_equal(const DSAInfo &candidate, const DSAInfo &current)
+are_scs_equal(const DSAInfo& candidate, const DSAInfo& current)
 {
   if (current.dsaname().empty())
     throw std::runtime_error("Current shell name is empty.");
 
-  return ((current.bmcVer.compare("INACTIVE") == 0) ||
-          (candidate.bmc_ver() == current.bmc_ver()));
+  return ((current.bmcVer.compare("INACTIVE") == 0) || (candidate.bmc_ver() == current.bmc_ver()));
 }
 
 static bool
-update_sc(unsigned int boardIdx, DSAInfo &candidate)
+update_sc(unsigned int boardIdx, DSAInfo& candidate)
 {
   Flasher flasher(boardIdx);
 
@@ -438,7 +437,7 @@ update_sc(unsigned int boardIdx, DSAInfo &candidate)
 // Flash shell and sc firmware
 // Helper method for auto_flash
 static bool
-update_shell(unsigned int boardIdx, DSAInfo &candidate, Flasher::E_FlasherType flash_type)
+update_shell(unsigned int boardIdx, DSAInfo& candidate, Flasher::E_FlasherType flash_type)
 {
   Flasher flasher(boardIdx);
 
@@ -480,14 +479,14 @@ update_shell(unsigned int boardIdx, DSAInfo &candidate, Flasher::E_FlasherType f
 }
 
 static void
-update_default_only(xrt_core::device *device, bool value)
+update_default_only(xrt_core::device* device, bool value)
 {
   try {
     // get boot on backup from vmr_status sysfs node
     boost::property_tree::ptree pt_empty;
     const auto pt = xrt_core::vmr::vmr_info(device).get_child("vmr", pt_empty);
-    for (const auto &ks : pt) {
-      const boost::property_tree::ptree &vmr_stat = ks.second;
+    for (const auto& ks : pt) {
+      const boost::property_tree::ptree& vmr_stat = ks.second;
       if (boost::iequals(vmr_stat.get<std::string>("label"), "Boot on default")) {
         // if backup is booted, then do not proceed
         if (std::stoi(vmr_stat.get<std::string>("value")) != 1) {
@@ -499,7 +498,7 @@ update_default_only(xrt_core::device *device, bool value)
 
     uint32_t val = xrt_core::query::flush_default_only::value_type(value);
     xrt_core::device_update<xrt_core::query::flush_default_only>(device, val);
-  } catch (const xrt_core::query::exception &) {
+  } catch (const xrt_core::query::exception&) {
     // only available for versal devices
   }
 }
@@ -507,7 +506,7 @@ update_default_only(xrt_core::device *device, bool value)
 // Update shell and sc firmware on the device automatically
 // Refactor code to support only 1 device.
 static void
-auto_flash(std::shared_ptr<xrt_core::device> &device, Flasher::E_FlasherType flashType, const std::string &image = "")
+auto_flash(std::shared_ptr<xrt_core::device>& device, Flasher::E_FlasherType flashType, const std::string& image = "")
 {
   // Get platform information
   boost::property_tree::ptree pt;
@@ -543,7 +542,7 @@ auto_flash(std::shared_ptr<xrt_core::device> &device, Flasher::E_FlasherType fla
   DSAInfo dsa(image_path);
 
   // If the shell is not up-to-date and dsa has a flash image, queue the board for update
-  boost::property_tree::ptree &pt_dev = pt.get_child(std::to_string(device->get_device_id()));
+  boost::property_tree::ptree& pt_dev = pt.get_child(std::to_string(device->get_device_id()));
   bool same_shell = (dsa.name == pt_dev.get<std::string>("platform.current_shell.vbnv", ""))
       && (dsa.matchId(pt_dev.get<std::string>("platform.current_shell.id", "")));
 
@@ -592,7 +591,7 @@ auto_flash(std::shared_ptr<xrt_core::device> &device, Flasher::E_FlasherType fla
 
   // Perform DSA and BMC updating
   std::stringstream error_stream;
-  for (auto &p : boardsToUpdate) {
+  for (auto& p : boardsToUpdate) {
     try {
       std::cout << std::endl;
       // 1) Flash the Satellite Controller image
@@ -622,7 +621,7 @@ auto_flash(std::shared_ptr<xrt_core::device> &device, Flasher::E_FlasherType fla
       } else
         report_stream << boost::format("  [%s] : Base (e.g., shell) image is up-to-date.  No actions taken.\n")
                 % getBDF(p.first);
-    } catch (const xrt_core::error &e) {
+    } catch (const xrt_core::error& e) {
       error_stream << boost::format("ERROR: %s\n") % e.what();
     }
   }
@@ -651,12 +650,12 @@ auto_flash(std::shared_ptr<xrt_core::device> &device, Flasher::E_FlasherType fla
 }
 
 void
-OO_UpdateBase::execute(const SubCmdOptions &_options) const
+OO_UpdateBase::execute(const SubCmdOptions& _options) const
 {
   XBUtilities::verbose("SubCommand option: Update Base");
 
   XBUtilities::verbose("Option(s):");
-  for (const auto &aString : _options)
+  for (const auto& aString : _options)
     XBUtilities::verbose(" " + aString);
 
   // Honor help option first
@@ -672,7 +671,7 @@ OO_UpdateBase::execute(const SubCmdOptions &_options) const
   std::shared_ptr<xrt_core::device> device;
   try {
     device = XBU::get_device(boost::algorithm::to_lower_copy(m_device), false /*inUserDomain*/);
-  } catch (const std::runtime_error &e) {
+  } catch (const std::runtime_error& e) {
     // Catch only the exceptions that we have generated earlier
     std::cerr << boost::format("ERROR: %s\n") % e.what();
     throw xrt_core::error(std::errc::operation_canceled);

--- a/src/runtime_src/core/tools/xbmgmt2/OO_UpdateBase.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_UpdateBase.cpp
@@ -65,7 +65,7 @@ namespace po = boost::program_options;
 
 OO_UpdateBase::OO_UpdateBase(const std::string &_longName, const std::string &_shortName, bool _isHidden )
     : OptionOptions(_longName,
-                    "",
+                    _shortName,
                     "Update base partition",
                     boost::program_options::value<decltype(update)>(&update)->implicit_value("all")->required(),
                     "Update the persistent images and/or the Satellite controller (SC) firmware image.  Valid values:\n"

--- a/src/runtime_src/core/tools/xbmgmt2/OO_UpdateBase.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_UpdateBase.cpp
@@ -279,6 +279,8 @@ file_size(const std::string &_file)
 }
 
 // Helper function for header info
+// Seperates the given file path into its path
+// and name components
 static std::pair<std::string, std::string>
 deployment_path_and_filename(std::string file)
 {
@@ -294,7 +296,7 @@ deployment_path_and_filename(std::string file)
   auto pos = file.rfind('/') != std::string::npos ? file.rfind('/') : file.rfind('\\');
   std::string path = file.erase(pos);
 
-  return std::make_pair(dsafile, path);
+  return { dsafile, path };
 }
 
 // Helper function for header info

--- a/src/runtime_src/core/tools/xbmgmt2/OO_UpdateBase.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_UpdateBase.cpp
@@ -2,58 +2,29 @@
 // Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
 
 // ------ I N C L U D E   F I L E S -------------------------------------------
-// Local - Include Files
 #include "OO_UpdateBase.h"
-#include "tools/common/XBUtilitiesCore.h"
-#include "tools/common/XBUtilities.h"
 
 // XRT - Include Files
-#include "core/common/query_requests.h"
-#include "core/common/system.h"
-#include "flash/flasher.h"
-#include "tools/common/XBHelpMenusCore.h"
-#include "tools/common/XBUtilitiesCore.h"
-#include "tools/common/XBUtilities.h"
-#include "tools/common/XBHelpMenus.h"
-#include "tools/common/ProgressBar.h"
-#include "tools/common/Process.h"
-namespace XBU = XBUtilities;
-
-#include "xrt.h"
-#include "core/common/system.h"
-#include "core/common/device.h"
-#include "core/common/error.h"
-#include "core/common/query_requests.h"
-#include "core/common/message.h"
-#include "core/common/utils.h"
-#include "flash/flasher.h"
 #include "core/common/info_vmr.h"
-// Remove linux specific code
-#ifdef __linux__
-#include "core/pcie/linux/scan.h"
-#endif
+#include "core/common/message.h"
+#include "flash/flasher.h"
+#include "ReportPlatform.h"
+#include "tools/common/XBUtilitiesCore.h"
+#include "tools/common/ProgressBar.h"
+namespace XBU = XBUtilities;
 
 // 3rd Party Library - Include Files
 #include <boost/format.hpp>
 #include <boost/tokenizer.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/program_options.hpp>
-#include <boost/algorithm/string.hpp>
 namespace po = boost::program_options;
-
-// ---- Reports ------
-#include "ReportPlatform.h"
-#include "tools/common/Report.h"
-#include "tools/common/ReportHost.h"
 
 // System - Include Files
 #include <atomic>
 #include <chrono>
-#include <ctime>
-#include <fcntl.h>
 #include <fstream>
 #include <iostream>
-#include <locale>
 #include <map>
 #include <thread>
 // =============================================================================

--- a/src/runtime_src/core/tools/xbmgmt2/OO_UpdateBase.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_UpdateBase.cpp
@@ -63,11 +63,11 @@ namespace po = boost::program_options;
 
 // ----- C L A S S   M E T H O D S -------------------------------------------
 
-OO_UpdateBase::OO_UpdateBase(const std::string &_longName, bool _isHidden )
-    : OptionOptions( _longName, 
-                    std::string("b"),
+OO_UpdateBase::OO_UpdateBase(const std::string &_longName, const std::string &_shortName, bool _isHidden )
+    : OptionOptions(_longName,
+                    "",
                     "Update base partition",
-                    boost::program_options::value<decltype(update)>(&update)->implicit_value("all"),
+                    boost::program_options::value<decltype(update)>(&update)->implicit_value("all")->required(),
                     "Update the persistent images and/or the Satellite controller (SC) firmware image.  Valid values:\n"
                       "  ALL   - All images will be updated\n"
                       "  SHELL - Platform image\n"

--- a/src/runtime_src/core/tools/xbmgmt2/OO_UpdateBase.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_UpdateBase.cpp
@@ -80,7 +80,8 @@ OO_UpdateBase::OO_UpdateBase(const std::string &_longName, bool _isHidden )
     ("image", boost::program_options::value<decltype(image)>(&image)->multitoken(),  "Specifies an image to use used to update the persistent device.  Valid values:\n"
                                                                     "  Name (and path) to the mcs image on disk\n"
                                                                     "  Name (and path) to the xsabin image on disk")
-    ("help", po::bool_switch(&m_help), "Help to use this sub-command")
+    ("help,h", po::bool_switch(&m_help), "Help to use this sub-command")
+    ("no,n", po::bool_switch(&m_help), "Help to use this sub-command")
   ;
 
   m_optionsHidden.add_options()

--- a/src/runtime_src/core/tools/xbmgmt2/OO_UpdateBase.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_UpdateBase.cpp
@@ -333,9 +333,9 @@ pretty_print_platform_info(const boost::property_tree::ptree& _ptDevice, const s
   std::cout << "\n";
   std::cout << "Current Configuration\n";
 
-  std::cout << boost::format("  %-20s : %s\n") % "Platform" % _ptDevice.get<std::string>("platform.current_shell.vbnv", "N/A");
-  std::cout << boost::format("  %-20s : %s\n") % "SC Version" % _ptDevice.get<std::string>("platform.current_shell.sc_version", "N/A");
-  std::cout << boost::format("  %-20s : %s\n") % "Platform ID" % _ptDevice.get<std::string>("platform.current_shell.id", "N/A");
+  std::cout << boost::format("  %-20s : %s\n") % "Platform" % _ptDevice.get<std::string>("platform.current_shell.vbnv", XBU::data_not_available);
+  std::cout << boost::format("  %-20s : %s\n") % "SC Version" % _ptDevice.get<std::string>("platform.current_shell.sc_version", XBU::data_not_available);
+  std::cout << boost::format("  %-20s : %s\n") % "Platform ID" % _ptDevice.get<std::string>("platform.current_shell.id", XBU::data_not_available);
   std::cout << "\n";
   std::cout << "\nIncoming Configuration\n";
   const boost::property_tree::ptree& available_shells = _ptDevice.get_child("platform.available_shells");
@@ -353,13 +353,13 @@ pretty_print_platform_info(const boost::property_tree::ptree& _ptDevice, const s
   std::cout << boost::format("  %-20s : %s\n") % "Size" % file_size(platform_to_flash.get<std::string>("file").c_str());
   std::cout << boost::format("  %-20s : %s\n\n") % "Timestamp" % get_file_timestamp(platform_to_flash.get<std::string>("file").c_str());
 
-  std::cout << boost::format("  %-20s : %s\n") % "Platform" % platform_to_flash.get<std::string>("vbnv", "N/A");
-  std::cout << boost::format("  %-20s : %s\n") % "SC Version" % platform_to_flash.get<std::string>("sc_version", "N/A");
+  std::cout << boost::format("  %-20s : %s\n") % "Platform" % platform_to_flash.get<std::string>("vbnv", XBU::data_not_available);
+  std::cout << boost::format("  %-20s : %s\n") % "SC Version" % platform_to_flash.get<std::string>("sc_version", XBU::data_not_available);
   auto logic_uuid = platform_to_flash.get<std::string>("logic-uuid", "");
   if (!logic_uuid.empty())
     std::cout << boost::format("  %-20s : %s\n") % "Platform UUID" % logic_uuid;
   else
-    std::cout << boost::format("  %-20s : %s\n") % "Platform ID" % platform_to_flash.get<std::string>("id", "N/A");
+    std::cout << boost::format("  %-20s : %s\n") % "Platform ID" % platform_to_flash.get<std::string>("id", XBU::data_not_available);
 }
 
 static void

--- a/src/runtime_src/core/tools/xbmgmt2/OO_UpdateBase.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_UpdateBase.cpp
@@ -620,7 +620,7 @@ auto_flash(std::shared_ptr<xrt_core::device>& device, Flasher::E_FlasherType fla
                                         % getBDF(p.first);
         need_warm_reboot = true;
       } catch (const xrt_core::error& e) {
-        std::cerr << e.what();
+        std::cerr << e.what() << "\n";
         report_stream << boost::format( "  [%s] : Satellite Controller (SC) is either up-to-date, fixed, or"
                                         "not installed. No actions taken.\n")
                                         % getBDF(p.first);
@@ -634,6 +634,7 @@ auto_flash(std::shared_ptr<xrt_core::device>& device, Flasher::E_FlasherType fla
                                       % getBDF(p.first);
       needreboot = true;
     } catch (const xrt_core::error& e) {
+      std::cerr << e.what() << "\n";
       report_stream << boost::format( "  [%s] : Base (e.g., shell) image is up-to-date.  No actions taken.\n")
                                       % getBDF(p.first);
     }

--- a/src/runtime_src/core/tools/xbmgmt2/OO_UpdateBase.h
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_UpdateBase.h
@@ -14,11 +14,11 @@ class OO_UpdateBase : public OptionOptions {
   OO_UpdateBase( const std::string &_longName, const std::string &_shortName, bool _isHidden = false);
 
  private:
-  std::string m_device;
-  std::string m_update;
-  std::vector<std::string> m_image;
-  std::string m_flashType;
-  bool m_help;
+  std::string               m_device;
+  std::string               m_update;
+  std::vector<std::string>  m_image;
+  std::string               m_flashType;
+  bool                      m_help;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbmgmt2/OO_UpdateBase.h
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_UpdateBase.h
@@ -15,9 +15,9 @@ class OO_UpdateBase : public OptionOptions {
 
  private:
   std::string m_device;
-  std::string update;
-  std::vector<std::string> image;
-  std::string flashType;
+  std::string m_update;
+  std::vector<std::string> m_image;
+  std::string m_flashType;
   bool m_help;
 };
 

--- a/src/runtime_src/core/tools/xbmgmt2/OO_UpdateBase.h
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_UpdateBase.h
@@ -8,10 +8,10 @@
 
 class OO_UpdateBase : public OptionOptions {
  public:
-  virtual void execute(const SubCmdOptions &_options) const;
+  virtual void execute(const SubCmdOptions& _options) const;
 
  public:
-  OO_UpdateBase(const std::string &_longName, const std::string &_shortName, bool _isHidden = false);
+  OO_UpdateBase(const std::string& _longName, const std::string& _shortName, bool _isHidden = false);
 
  private:
   std::string               m_device;

--- a/src/runtime_src/core/tools/xbmgmt2/OO_UpdateBase.h
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_UpdateBase.h
@@ -11,7 +11,7 @@ class OO_UpdateBase : public OptionOptions {
   virtual void execute( const SubCmdOptions &_options ) const;
 
  public:
-  OO_UpdateBase( const std::string &_longName, bool _isHidden = false);
+  OO_UpdateBase( const std::string &_longName, const std::string &_shortName, bool _isHidden = false);
 
  private:
   std::string m_device;

--- a/src/runtime_src/core/tools/xbmgmt2/OO_UpdateBase.h
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_UpdateBase.h
@@ -8,10 +8,10 @@
 
 class OO_UpdateBase : public OptionOptions {
  public:
-  virtual void execute( const SubCmdOptions &_options ) const;
+  virtual void execute(const SubCmdOptions &_options) const;
 
  public:
-  OO_UpdateBase( const std::string &_longName, const std::string &_shortName, bool _isHidden = false);
+  OO_UpdateBase(const std::string &_longName, const std::string &_shortName, bool _isHidden = false);
 
  private:
   std::string               m_device;

--- a/src/runtime_src/core/tools/xbmgmt2/OO_UpdateBase.h
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_UpdateBase.h
@@ -15,7 +15,6 @@ class OO_UpdateBase : public OptionOptions {
 
  private:
   std::string m_device;
-  std::string m_action;
   std::string update;
   std::vector<std::string> image;
   std::string flashType;

--- a/src/runtime_src/core/tools/xbmgmt2/OO_UpdateBase.h
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_UpdateBase.h
@@ -11,10 +11,11 @@ class OO_UpdateBase : public OptionOptions {
   virtual void execute( const SubCmdOptions &_options ) const;
 
  public:
-  OO_UpdateBase( const std::string &_longName, const std::string &_shortName, bool _isHidden = false);
+  OO_UpdateBase( const std::string &_longName, bool _isHidden = false);
 
  private:
   std::string m_device;
+  std::string m_action;
   std::string update;
   std::vector<std::string> image;
   std::string flashType;

--- a/src/runtime_src/core/tools/xbmgmt2/OO_UpdateShell.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_UpdateShell.cpp
@@ -20,7 +20,6 @@ namespace XBU = XBUtilities;
 namespace po = boost::program_options;
 
 // System - Include Files
-#include <filesystem>
 #include <fstream>
 #include <iostream>
 
@@ -48,7 +47,9 @@ program_plp(const xrt_core::device *dev, const std::string &partition)
     throw xrt_core::error(boost::str(boost::format("Cannot open %s") % partition));
 
   // size of the stream
-  auto total_size = std::filesystem::file_size(partition);
+  stream.seekg(0, stream.end);
+  int total_size = static_cast<int>(stream.tellg());
+  stream.seekg(0, stream.beg);
 
   // copy stream into a vector
   std::vector<char> buffer(total_size);

--- a/src/runtime_src/core/tools/xbmgmt2/OO_UpdateShell.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_UpdateShell.cpp
@@ -33,10 +33,11 @@ OO_UpdateShell::OO_UpdateShell(const std::string &_longName, const std::string &
     : OptionOptions(_longName,
                     _shortName,
                     "Update the shell partition for a 2RP platform",
-                    boost::program_options::value<decltype(plp)>(&plp)->implicit_value("all")->required(),
+                    boost::program_options::value<decltype(m_plp)>(&m_plp)->implicit_value("all")->required(),
                     "The partition to be loaded.  Valid values:\n"
                       "  Name (and path) of the partition.",
                     _isHidden)
+    , m_plp("plp")
 {
   m_optionsDescription.add_options()
     ("device,d", po::value<decltype(m_device)>(&m_device), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest")
@@ -98,7 +99,7 @@ OO_UpdateShell::execute(const SubCmdOptions& _options) const
     throw xrt_core::error(std::errc::operation_canceled);
   }
 
-  XBU::verbose(boost::str(boost::format("  shell: %s") % plp));
+  XBU::verbose(boost::str(boost::format("  shell: %s") % m_plp));
 
   Flasher flasher(device->get_device_id());
   if (!flasher.isValid())
@@ -109,10 +110,10 @@ OO_UpdateShell::execute(const SubCmdOptions& _options) const
                           " is installed.");
 
   // Check if file exists
-  if (!boost::filesystem::exists(plp))
+  if (!boost::filesystem::exists(m_plp))
     throw xrt_core::error("File not found. Please specify the correct path");
 
-  DSAInfo dsa(plp);
+  DSAInfo dsa(m_plp);
   //TO_DO: add a report for plp before asking permission to proceed. Replace following 2 lines
   std::cout << "Programming shell on device [" << flasher.sGetDBDF() << "]..." << std::endl;
   std::cout << "Partition file: " << dsa.file << std::endl;

--- a/src/runtime_src/core/tools/xbmgmt2/OO_UpdateShell.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_UpdateShell.cpp
@@ -9,16 +9,14 @@
 #include "core/common/query_requests.h"
 #include "core/common/system.h"
 #include "flash/flasher.h"
-#include "tools/common/XBHelpMenusCore.h"
 #include "tools/common/XBUtilitiesCore.h"
 #include "tools/common/XBUtilities.h"
 namespace XBU = XBUtilities;
 
 // 3rd Party Library - Include Files
-#include <boost/format.hpp>
 #include <boost/filesystem.hpp>
+#include <boost/format.hpp>
 #include <boost/program_options.hpp>
-#include <boost/algorithm/string.hpp>
 namespace po = boost::program_options;
 
 // System - Include Files

--- a/src/runtime_src/core/tools/xbmgmt2/OO_UpdateShell.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_UpdateShell.cpp
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+
+// ------ I N C L U D E   F I L E S -------------------------------------------
+// Local - Include Files
+#include "OO_UpdateShell.h"
+
+// XRT - Include Files
+#include "core/common/query_requests.h"
+#include "core/common/system.h"
+#include "flash/flasher.h"
+#include "tools/common/XBHelpMenusCore.h"
+#include "tools/common/XBUtilitiesCore.h"
+#include "tools/common/XBUtilities.h"
+namespace XBU = XBUtilities;
+
+// 3rd Party Library - Include Files
+#include <boost/format.hpp>
+#include <boost/filesystem.hpp>
+#include <boost/program_options.hpp>
+#include <boost/algorithm/string.hpp>
+namespace po = boost::program_options;
+
+// System - Include Files
+#include <fstream>
+#include <iostream>
+// =============================================================================
+
+// ----- H E L P E R M E T H O D S ------------------------------------------
+
+
+// ----- C L A S S   M E T H O D S -------------------------------------------
+
+OO_UpdateShell::OO_UpdateShell(const std::string &_longName, const std::string &_shortName, bool _isHidden )
+    : OptionOptions(_longName,
+                    _shortName,
+                    "Update the shell partition for a 2RP platform",
+                    boost::program_options::value<decltype(plp)>(&plp)->implicit_value("all")->required(),
+                    "The partition to be loaded.  Valid values:\n"
+                      "  Name (and path) of the partition.",
+                    _isHidden)
+{
+  m_optionsDescription.add_options()
+    ("device,d", po::value<decltype(m_device)>(&m_device), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest")
+    ("help", po::bool_switch(&m_help), "Help to use this sub-command")
+  ;
+}
+
+static void
+program_plp(const xrt_core::device* dev, const std::string& partition)
+{
+  std::ifstream stream(partition.c_str(), std::ios_base::binary);
+  if (!stream.is_open())
+    throw xrt_core::error(boost::str(boost::format("Cannot open %s") % partition));
+
+  //size of the stream
+  stream.seekg(0, stream.end);
+  int total_size = static_cast<int>(stream.tellg());
+  stream.seekg(0, stream.beg);
+
+  //copy stream into a vector
+  std::vector<char> buffer(total_size);
+  stream.read(buffer.data(), total_size);
+
+  try {
+    xrt_core::program_plp(dev, buffer, XBU::getForce());
+  }
+  catch (xrt_core::error& e) {
+    std::cout << "ERROR: " << e.what() << std::endl;
+    throw xrt_core::error(std::errc::operation_canceled);
+  }
+  std::cout << "Programmed shell successfully" << std::endl;
+}
+
+void
+OO_UpdateShell::execute(const SubCmdOptions& _options) const
+{
+  XBUtilities::verbose("SubCommand option: Update Base");
+
+  XBUtilities::verbose("Option(s):");
+  for (const auto & aString : _options)
+    XBUtilities::verbose(std::string(" ") + aString);
+
+  // Honor help option first
+  if (std::find(_options.begin(), _options.end(), "--help") != _options.end()) {
+    printHelp();
+    return;
+  }
+
+  // Parse sub-command ...
+  po::variables_map vm;
+  process_arguments(vm, _options);
+
+  std::shared_ptr<xrt_core::device> device;
+  try {
+    device = XBU::get_device(boost::algorithm::to_lower_copy(m_device), false /*inUserDomain*/);
+  } catch (const std::runtime_error& e) {
+    // Catch only the exceptions that we have generated earlier
+    std::cerr << boost::format("ERROR: %s\n") % e.what();
+    throw xrt_core::error(std::errc::operation_canceled);
+  }
+
+  XBU::verbose(boost::str(boost::format("  shell: %s") % plp));
+
+  Flasher flasher(device->get_device_id());
+  if (!flasher.isValid())
+    throw xrt_core::error(boost::str(boost::format("%d is an invalid index") % device->get_device_id()));
+
+  if (xrt_core::device_query<xrt_core::query::interface_uuids>(device).empty())
+    throw xrt_core::error("Can not get BLP interface uuid. Please make sure corresponding BLP package"
+                          " is installed.");
+
+  // Check if file exists
+  if (!boost::filesystem::exists(plp))
+    throw xrt_core::error("File not found. Please specify the correct path");
+
+  DSAInfo dsa(plp);
+  //TO_DO: add a report for plp before asking permission to proceed. Replace following 2 lines
+  std::cout << "Programming shell on device [" << flasher.sGetDBDF() << "]..." << std::endl;
+  std::cout << "Partition file: " << dsa.file << std::endl;
+
+  for (const auto& uuid : dsa.uuids) {
+
+    //check if plp is compatible with the installed blp
+    if (xrt_core::device_query<xrt_core::query::interface_uuids>(device).front().compare(uuid) == 0) {
+      XBUtilities::sudo_or_throw("Root privileges are required to load the PLP image");
+      program_plp(device.get(), dsa.file);
+      return;
+    }
+  }
+
+  // Fall through error
+  throw xrt_core::error("uuid does not match BLP");
+}

--- a/src/runtime_src/core/tools/xbmgmt2/OO_UpdateShell.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_UpdateShell.cpp
@@ -23,7 +23,7 @@ namespace po = boost::program_options;
 #include <fstream>
 #include <iostream>
 
-OO_UpdateShell::OO_UpdateShell(const std::string &_longName, const std::string &_shortName, bool _isHidden)
+OO_UpdateShell::OO_UpdateShell(const std::string& _longName, const std::string& _shortName, bool _isHidden)
     : OptionOptions(_longName,
                     _shortName,
                     "Update the shell partition for a 2RP platform",
@@ -40,7 +40,7 @@ OO_UpdateShell::OO_UpdateShell(const std::string &_longName, const std::string &
 }
 
 static void
-program_plp(const xrt_core::device *dev, const std::string &partition)
+program_plp(const xrt_core::device* dev, const std::string& partition)
 {
   std::ifstream stream(partition, std::ios_base::binary);
   if (!stream.is_open())
@@ -57,7 +57,7 @@ program_plp(const xrt_core::device *dev, const std::string &partition)
 
   try {
     xrt_core::program_plp(dev, buffer, XBU::getForce());
-  } catch (xrt_core::error &e) {
+  } catch (xrt_core::error& e) {
     std::cout << "ERROR: " << e.what() << std::endl;
     throw xrt_core::error(std::errc::operation_canceled);
   }
@@ -65,12 +65,12 @@ program_plp(const xrt_core::device *dev, const std::string &partition)
 }
 
 void
-OO_UpdateShell::execute(const SubCmdOptions &_options) const
+OO_UpdateShell::execute(const SubCmdOptions& _options) const
 {
   XBUtilities::verbose("SubCommand option: Update Shell");
 
   XBUtilities::verbose("Option(s):");
-  for (const auto &aString : _options)
+  for (const auto& aString : _options)
     XBUtilities::verbose(" " + aString);
 
   // Honor help option first
@@ -86,7 +86,7 @@ OO_UpdateShell::execute(const SubCmdOptions &_options) const
   std::shared_ptr<xrt_core::device> device;
   try {
     device = XBU::get_device(boost::algorithm::to_lower_copy(m_device), false /*inUserDomain*/);
-  } catch (const std::runtime_error &e) {
+  } catch (const std::runtime_error& e) {
     // Catch only the exceptions that we have generated earlier
     std::cerr << boost::format("ERROR: %s\n") % e.what();
     throw xrt_core::error(std::errc::operation_canceled);
@@ -111,7 +111,7 @@ OO_UpdateShell::execute(const SubCmdOptions &_options) const
   std::cout << "Programming shell on device [" << flasher.sGetDBDF() << "]..." << std::endl;
   std::cout << "Partition file: " << dsa.file << std::endl;
 
-  for (const auto &uuid : dsa.uuids) {
+  for (const auto& uuid : dsa.uuids) {
     // check if plp is compatible with the installed blp
     if (xrt_core::device_query<xrt_core::query::interface_uuids>(device).front().compare(uuid) == 0) {
       XBUtilities::sudo_or_throw("Root privileges are required to load the PLP image");

--- a/src/runtime_src/core/tools/xbmgmt2/OO_UpdateShell.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_UpdateShell.cpp
@@ -75,7 +75,7 @@ program_plp(const xrt_core::device* dev, const std::string& partition)
 void
 OO_UpdateShell::execute(const SubCmdOptions& _options) const
 {
-  XBUtilities::verbose("SubCommand option: Update Base");
+  XBUtilities::verbose("SubCommand option: Update Shell");
 
   XBUtilities::verbose("Option(s):");
   for (const auto & aString : _options)

--- a/src/runtime_src/core/tools/xbmgmt2/OO_UpdateShell.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_UpdateShell.cpp
@@ -9,8 +9,8 @@
 #include "core/common/query_requests.h"
 #include "core/common/system.h"
 #include "flash/flasher.h"
-#include "tools/common/XBUtilitiesCore.h"
 #include "tools/common/XBUtilities.h"
+#include "tools/common/XBUtilitiesCore.h"
 namespace XBU = XBUtilities;
 
 // 3rd Party Library - Include Files
@@ -20,24 +20,19 @@ namespace XBU = XBUtilities;
 namespace po = boost::program_options;
 
 // System - Include Files
+#include <filesystem>
 #include <fstream>
 #include <iostream>
-// =============================================================================
 
-// ----- H E L P E R M E T H O D S ------------------------------------------
-
-
-// ----- C L A S S   M E T H O D S -------------------------------------------
-
-OO_UpdateShell::OO_UpdateShell(const std::string &_longName, const std::string &_shortName, bool _isHidden )
+OO_UpdateShell::OO_UpdateShell(const std::string &_longName, const std::string &_shortName, bool _isHidden)
     : OptionOptions(_longName,
                     _shortName,
                     "Update the shell partition for a 2RP platform",
                     boost::program_options::value<decltype(m_plp)>(&m_plp)->implicit_value("all")->required(),
                     "The partition to be loaded.  Valid values:\n"
-                      "  Name (and path) of the partition.",
+                    "  Name (and path) of the partition.",
                     _isHidden)
-    , m_plp("plp")
+    , m_plp("")
 {
   m_optionsDescription.add_options()
     ("device,d", po::value<decltype(m_device)>(&m_device), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest")
@@ -46,25 +41,22 @@ OO_UpdateShell::OO_UpdateShell(const std::string &_longName, const std::string &
 }
 
 static void
-program_plp(const xrt_core::device* dev, const std::string& partition)
+program_plp(const xrt_core::device *dev, const std::string &partition)
 {
-  std::ifstream stream(partition.c_str(), std::ios_base::binary);
+  std::ifstream stream(partition, std::ios_base::binary);
   if (!stream.is_open())
     throw xrt_core::error(boost::str(boost::format("Cannot open %s") % partition));
 
-  //size of the stream
-  stream.seekg(0, stream.end);
-  int total_size = static_cast<int>(stream.tellg());
-  stream.seekg(0, stream.beg);
+  // size of the stream
+  auto total_size = std::filesystem::file_size(partition);
 
-  //copy stream into a vector
+  // copy stream into a vector
   std::vector<char> buffer(total_size);
   stream.read(buffer.data(), total_size);
 
   try {
     xrt_core::program_plp(dev, buffer, XBU::getForce());
-  }
-  catch (xrt_core::error& e) {
+  } catch (xrt_core::error &e) {
     std::cout << "ERROR: " << e.what() << std::endl;
     throw xrt_core::error(std::errc::operation_canceled);
   }
@@ -72,13 +64,13 @@ program_plp(const xrt_core::device* dev, const std::string& partition)
 }
 
 void
-OO_UpdateShell::execute(const SubCmdOptions& _options) const
+OO_UpdateShell::execute(const SubCmdOptions &_options) const
 {
   XBUtilities::verbose("SubCommand option: Update Shell");
 
   XBUtilities::verbose("Option(s):");
-  for (const auto & aString : _options)
-    XBUtilities::verbose(std::string(" ") + aString);
+  for (const auto &aString : _options)
+    XBUtilities::verbose(" " + aString);
 
   // Honor help option first
   if (std::find(_options.begin(), _options.end(), "--help") != _options.end()) {
@@ -93,7 +85,7 @@ OO_UpdateShell::execute(const SubCmdOptions& _options) const
   std::shared_ptr<xrt_core::device> device;
   try {
     device = XBU::get_device(boost::algorithm::to_lower_copy(m_device), false /*inUserDomain*/);
-  } catch (const std::runtime_error& e) {
+  } catch (const std::runtime_error &e) {
     // Catch only the exceptions that we have generated earlier
     std::cerr << boost::format("ERROR: %s\n") % e.what();
     throw xrt_core::error(std::errc::operation_canceled);
@@ -114,13 +106,12 @@ OO_UpdateShell::execute(const SubCmdOptions& _options) const
     throw xrt_core::error("File not found. Please specify the correct path");
 
   DSAInfo dsa(m_plp);
-  //TO_DO: add a report for plp before asking permission to proceed. Replace following 2 lines
+  // TO_DO: add a report for plp before asking permission to proceed. Replace following 2 lines
   std::cout << "Programming shell on device [" << flasher.sGetDBDF() << "]..." << std::endl;
   std::cout << "Partition file: " << dsa.file << std::endl;
 
-  for (const auto& uuid : dsa.uuids) {
-
-    //check if plp is compatible with the installed blp
+  for (const auto &uuid : dsa.uuids) {
+    // check if plp is compatible with the installed blp
     if (xrt_core::device_query<xrt_core::query::interface_uuids>(device).front().compare(uuid) == 0) {
       XBUtilities::sudo_or_throw("Root privileges are required to load the PLP image");
       program_plp(device.get(), dsa.file);

--- a/src/runtime_src/core/tools/xbmgmt2/OO_UpdateShell.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_UpdateShell.cpp
@@ -9,14 +9,16 @@
 #include "core/common/query_requests.h"
 #include "core/common/system.h"
 #include "flash/flasher.h"
+#include "tools/common/XBHelpMenusCore.h"
 #include "tools/common/XBUtilitiesCore.h"
 #include "tools/common/XBUtilities.h"
 namespace XBU = XBUtilities;
 
 // 3rd Party Library - Include Files
-#include <boost/filesystem.hpp>
 #include <boost/format.hpp>
+#include <boost/filesystem.hpp>
 #include <boost/program_options.hpp>
+#include <boost/algorithm/string.hpp>
 namespace po = boost::program_options;
 
 // System - Include Files
@@ -73,7 +75,7 @@ program_plp(const xrt_core::device* dev, const std::string& partition)
 void
 OO_UpdateShell::execute(const SubCmdOptions& _options) const
 {
-  XBUtilities::verbose("SubCommand option: Update Shell");
+  XBUtilities::verbose("SubCommand option: Update Base");
 
   XBUtilities::verbose("Option(s):");
   for (const auto & aString : _options)

--- a/src/runtime_src/core/tools/xbmgmt2/OO_UpdateShell.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_UpdateShell.cpp
@@ -107,7 +107,7 @@ OO_UpdateShell::execute(const SubCmdOptions& _options) const
     throw xrt_core::error("File not found. Please specify the correct path");
 
   DSAInfo dsa(m_plp);
-  // TO_DO: add a report for plp before asking permission to proceed. Replace following 2 lines
+  // TODO add a report for plp before asking permission to proceed. Replace following 2 lines
   std::cout << "Programming shell on device [" << flasher.sGetDBDF() << "]..." << std::endl;
   std::cout << "Partition file: " << dsa.file << std::endl;
 

--- a/src/runtime_src/core/tools/xbmgmt2/OO_UpdateShell.h
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_UpdateShell.h
@@ -1,23 +1,21 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
 
-#ifndef __OO_UpdateBase_h_
-#define __OO_UpdateBase_h_
+#ifndef __OO_UpdateShell_h_
+#define __OO_UpdateShell_h_
 
 #include "tools/common/OptionOptions.h"
 
-class OO_UpdateBase : public OptionOptions {
+class OO_UpdateShell : public OptionOptions {
  public:
   virtual void execute( const SubCmdOptions &_options ) const;
 
  public:
-  OO_UpdateBase( const std::string &_longName, const std::string &_shortName, bool _isHidden = false);
+  OO_UpdateShell( const std::string &_longName, const std::string &_shortName, bool _isHidden = false);
 
  private:
   std::string m_device;
-  std::string update;
-  std::vector<std::string> image;
-  std::string flashType;
+  std::string plp;
   bool m_help;
 };
 

--- a/src/runtime_src/core/tools/xbmgmt2/OO_UpdateShell.h
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_UpdateShell.h
@@ -16,7 +16,7 @@ class OO_UpdateShell : public OptionOptions {
  private:
   std::string m_device;
   std::string m_plp;
-  bool m_help;
+  bool        m_help;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbmgmt2/OO_UpdateShell.h
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_UpdateShell.h
@@ -15,7 +15,7 @@ class OO_UpdateShell : public OptionOptions {
 
  private:
   std::string m_device;
-  std::string plp;
+  std::string m_plp;
   bool m_help;
 };
 

--- a/src/runtime_src/core/tools/xbmgmt2/OO_UpdateShell.h
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_UpdateShell.h
@@ -8,10 +8,10 @@
 
 class OO_UpdateShell : public OptionOptions {
  public:
-  virtual void execute(const SubCmdOptions &_options) const;
+  virtual void execute(const SubCmdOptions& _options) const;
 
  public:
-  OO_UpdateShell(const std::string &_longName, const std::string &_shortName, bool _isHidden = false);
+  OO_UpdateShell(const std::string& _longName, const std::string& _shortName, bool _isHidden = false);
 
  private:
   std::string m_device;

--- a/src/runtime_src/core/tools/xbmgmt2/OO_UpdateShell.h
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_UpdateShell.h
@@ -8,10 +8,10 @@
 
 class OO_UpdateShell : public OptionOptions {
  public:
-  virtual void execute( const SubCmdOptions &_options ) const;
+  virtual void execute(const SubCmdOptions &_options) const;
 
  public:
-  OO_UpdateShell( const std::string &_longName, const std::string &_shortName, bool _isHidden = false);
+  OO_UpdateShell(const std::string &_longName, const std::string &_shortName, bool _isHidden = false);
 
  private:
   std::string m_device;

--- a/src/runtime_src/core/tools/xbmgmt2/OO_UpdateXclbin.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_UpdateXclbin.cpp
@@ -17,7 +17,6 @@ namespace XBU = XBUtilities;
 namespace po = boost::program_options;
 
 // System - Include Files
-#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <vector>
@@ -71,7 +70,9 @@ OO_UpdateXclbin::execute(const SubCmdOptions &_options) const
   if (!stream)
     throw xrt_core::error(boost::str(boost::format("Could not open %s for reading") % m_xclbin));
 
-  auto size = std::filesystem::file_size(m_xclbin);
+  stream.seekg(0,stream.end);
+  ssize_t size = stream.tellg();
+  stream.seekg(0,stream.beg);
 
   std::vector<char> xclbin_buffer(size);
   stream.read(xclbin_buffer.data(), size);

--- a/src/runtime_src/core/tools/xbmgmt2/OO_UpdateXclbin.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_UpdateXclbin.cpp
@@ -21,7 +21,7 @@ namespace po = boost::program_options;
 #include <iostream>
 #include <vector>
 
-OO_UpdateXclbin::OO_UpdateXclbin(const std::string &_longName, const std::string &_shortName, bool _isHidden)
+OO_UpdateXclbin::OO_UpdateXclbin(const std::string& _longName, const std::string& _shortName, bool _isHidden)
     : OptionOptions(_longName,
                     _shortName,
                     "Load an xclbin onto the FPGA",
@@ -39,12 +39,12 @@ OO_UpdateXclbin::OO_UpdateXclbin(const std::string &_longName, const std::string
 }
 
 void
-OO_UpdateXclbin::execute(const SubCmdOptions &_options) const
+OO_UpdateXclbin::execute(const SubCmdOptions& _options) const
 {
   XBUtilities::verbose("SubCommand option: Update xclbin");
 
   XBUtilities::verbose("Option(s):");
-  for (const auto &aString : _options)
+  for (const auto& aString : _options)
     XBUtilities::verbose(" " + aString);
 
   // Honor help option first
@@ -60,7 +60,7 @@ OO_UpdateXclbin::execute(const SubCmdOptions &_options) const
   std::shared_ptr<xrt_core::device> device;
   try {
     device = XBU::get_device(boost::algorithm::to_lower_copy(m_device), false /*inUserDomain*/);
-  } catch (const std::runtime_error &e) {
+  } catch (const std::runtime_error& e) {
     XBU::throw_cancel(e.what());
   }
 
@@ -70,9 +70,9 @@ OO_UpdateXclbin::execute(const SubCmdOptions &_options) const
   if (!stream)
     throw xrt_core::error(boost::str(boost::format("Could not open %s for reading") % m_xclbin));
 
-  stream.seekg(0,stream.end);
+  stream.seekg(0, stream.end);
   ssize_t size = stream.tellg();
-  stream.seekg(0,stream.beg);
+  stream.seekg(0, stream.beg);
 
   std::vector<char> xclbin_buffer(size);
   stream.read(xclbin_buffer.data(), size);
@@ -81,7 +81,7 @@ OO_UpdateXclbin::execute(const SubCmdOptions &_options) const
   std::cout << "Downloading xclbin on device [" << bdf << "]..." << std::endl;
   try {
     device->xclmgmt_load_xclbin(xclbin_buffer.data());
-  } catch (xrt_core::error &e) {
+  } catch (xrt_core::error& e) {
     XBU::throw_cancel(e.what());
   }
   std::cout << boost::format("INFO: Successfully downloaded xclbin \n") << std::endl;

--- a/src/runtime_src/core/tools/xbmgmt2/OO_UpdateXclbin.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_UpdateXclbin.cpp
@@ -31,12 +31,12 @@ OO_UpdateXclbin::OO_UpdateXclbin(const std::string &_longName, const std::string
     : OptionOptions(_longName,
                     _shortName,
                     "Load an xclbin onto the FPGA",
-                    boost::program_options::value<decltype(xclbin)>(&xclbin)->required(),
+                    boost::program_options::value<decltype(m_xclbin)>(&m_xclbin)->required(),
                     "The xclbin to be loaded.  Valid values:\n"
                     "  Name (and path) of the xclbin.",
                     _isHidden),
       m_device(""),
-      xclbin("")
+      m_xclbin("")
 {
   m_optionsDescription.add_options()
     ("device,d", po::value<decltype(m_device)>(&m_device), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest")
@@ -72,9 +72,9 @@ OO_UpdateXclbin::execute(const SubCmdOptions& _options) const
 
   XBU::sudo_or_throw("Root privileges are required to download xclbin");
 
-  std::ifstream stream(xclbin, std::ios::binary);
+  std::ifstream stream(m_xclbin, std::ios::binary);
   if (!stream)
-    throw xrt_core::error(boost::str(boost::format("Could not open %s for reading") % xclbin));
+    throw xrt_core::error(boost::str(boost::format("Could not open %s for reading") % m_xclbin));
 
   stream.seekg(0,stream.end);
   ssize_t size = stream.tellg();

--- a/src/runtime_src/core/tools/xbmgmt2/OO_UpdateXclbin.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_UpdateXclbin.cpp
@@ -6,18 +6,14 @@
 #include "OO_UpdateXclbin.h"
 
 // XRT - Include Files
-#include "core/common/error.h"
 #include "core/common/query_requests.h"
-#include "tools/common/XBHelpMenusCore.h"
-#include "tools/common/XBUtilitiesCore.h"
 #include "tools/common/XBUtilities.h"
+#include "tools/common/XBUtilitiesCore.h"
 namespace XBU = XBUtilities;
 
 // 3rd Party Library - Include Files
 #include <boost/format.hpp>
-#include <boost/filesystem.hpp>
 #include <boost/program_options.hpp>
-#include <boost/algorithm/string.hpp>
 namespace po = boost::program_options;
 
 // System - Include Files

--- a/src/runtime_src/core/tools/xbmgmt2/OO_UpdateXclbin.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_UpdateXclbin.cpp
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+
+// ------ I N C L U D E   F I L E S -------------------------------------------
+// Local - Include Files
+#include "OO_UpdateXclbin.h"
+
+// XRT - Include Files
+#include "core/common/error.h"
+#include "core/common/query_requests.h"
+#include "tools/common/XBHelpMenusCore.h"
+#include "tools/common/XBUtilitiesCore.h"
+#include "tools/common/XBUtilities.h"
+namespace XBU = XBUtilities;
+
+// 3rd Party Library - Include Files
+#include <boost/format.hpp>
+#include <boost/filesystem.hpp>
+#include <boost/program_options.hpp>
+#include <boost/algorithm/string.hpp>
+namespace po = boost::program_options;
+
+// System - Include Files
+#include <fstream>
+#include <iostream>
+#include <vector>
+// =============================================================================
+
+// ----- H E L P E R M E T H O D S ------------------------------------------
+
+
+// ----- C L A S S   M E T H O D S -------------------------------------------
+
+OO_UpdateXclbin::OO_UpdateXclbin(const std::string &_longName, const std::string &_shortName, bool _isHidden )
+    : OptionOptions(_longName,
+                    _shortName,
+                    "Load an xclbin onto the FPGA",
+                    boost::program_options::value<decltype(xclbin)>(&xclbin)->required(),
+                    "The xclbin to be loaded.  Valid values:\n"
+                    "  Name (and path) of the xclbin.",
+                    _isHidden),
+      m_device(""),
+      xclbin("")
+{
+  m_optionsDescription.add_options()
+    ("device,d", po::value<decltype(m_device)>(&m_device), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest")
+    ("help", po::bool_switch(&m_help), "Help to use this sub-command")
+  ;
+}
+
+void
+OO_UpdateXclbin::execute(const SubCmdOptions& _options) const
+{
+  XBUtilities::verbose("SubCommand option: Update xclbin");
+
+  XBUtilities::verbose("Option(s):");
+  for (const auto & aString : _options)
+    XBUtilities::verbose(std::string(" ") + aString);
+
+  // Honor help option first
+  if (std::find(_options.begin(), _options.end(), "--help") != _options.end()) {
+    printHelp();
+    return;
+  }
+
+  // Parse sub-command ...
+  po::variables_map vm;
+  process_arguments(vm, _options);
+
+  std::shared_ptr<xrt_core::device> device;
+  try {
+    device = XBU::get_device(boost::algorithm::to_lower_copy(m_device), false /*inUserDomain*/);
+  } catch (const std::runtime_error& e) {
+    XBU::throw_cancel(e.what());
+  }
+
+  XBU::sudo_or_throw("Root privileges are required to download xclbin");
+
+  std::ifstream stream(xclbin, std::ios::binary);
+  if (!stream)
+    throw xrt_core::error(boost::str(boost::format("Could not open %s for reading") % xclbin));
+
+  stream.seekg(0,stream.end);
+  ssize_t size = stream.tellg();
+  stream.seekg(0,stream.beg);
+
+  std::vector<char> xclbin_buffer(size);
+  stream.read(xclbin_buffer.data(), size);
+
+  auto bdf = xrt_core::query::pcie_bdf::to_string(xrt_core::device_query<xrt_core::query::pcie_bdf>(device));
+  std::cout << "Downloading xclbin on device [" << bdf << "]..." << std::endl;
+  try {
+    device->xclmgmt_load_xclbin(xclbin_buffer.data());
+  } catch (xrt_core::error& e) {
+    XBU::throw_cancel(e.what());
+  }
+  std::cout << boost::format("INFO: Successfully downloaded xclbin \n") << std::endl;
+  return;
+}

--- a/src/runtime_src/core/tools/xbmgmt2/OO_UpdateXclbin.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_UpdateXclbin.cpp
@@ -85,5 +85,4 @@ OO_UpdateXclbin::execute(const SubCmdOptions& _options) const
     XBU::throw_cancel(e.what());
   }
   std::cout << boost::format("INFO: Successfully downloaded xclbin \n") << std::endl;
-  return;
 }

--- a/src/runtime_src/core/tools/xbmgmt2/OO_UpdateXclbin.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_UpdateXclbin.cpp
@@ -6,14 +6,18 @@
 #include "OO_UpdateXclbin.h"
 
 // XRT - Include Files
+#include "core/common/error.h"
 #include "core/common/query_requests.h"
-#include "tools/common/XBUtilities.h"
+#include "tools/common/XBHelpMenusCore.h"
 #include "tools/common/XBUtilitiesCore.h"
+#include "tools/common/XBUtilities.h"
 namespace XBU = XBUtilities;
 
 // 3rd Party Library - Include Files
 #include <boost/format.hpp>
+#include <boost/filesystem.hpp>
 #include <boost/program_options.hpp>
+#include <boost/algorithm/string.hpp>
 namespace po = boost::program_options;
 
 // System - Include Files

--- a/src/runtime_src/core/tools/xbmgmt2/OO_UpdateXclbin.h
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_UpdateXclbin.h
@@ -16,7 +16,7 @@ class OO_UpdateXclbin : public OptionOptions {
  private:
   std::string m_device;
   std::string m_xclbin;
-  bool m_help;
+  bool        m_help;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbmgmt2/OO_UpdateXclbin.h
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_UpdateXclbin.h
@@ -15,7 +15,7 @@ class OO_UpdateXclbin : public OptionOptions {
 
  private:
   std::string m_device;
-  std::string xclbin;
+  std::string m_xclbin;
   bool m_help;
 };
 

--- a/src/runtime_src/core/tools/xbmgmt2/OO_UpdateXclbin.h
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_UpdateXclbin.h
@@ -8,10 +8,10 @@
 
 class OO_UpdateXclbin : public OptionOptions {
  public:
-  virtual void execute( const SubCmdOptions &_options ) const;
+  virtual void execute(const SubCmdOptions &_options) const;
 
  public:
-  OO_UpdateXclbin( const std::string &_longName, const std::string &_shortName="", bool _isHidden = false);
+  OO_UpdateXclbin(const std::string &_longName, const std::string &_shortName = "", bool _isHidden = false);
 
  private:
   std::string m_device;

--- a/src/runtime_src/core/tools/xbmgmt2/OO_UpdateXclbin.h
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_UpdateXclbin.h
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+
+#ifndef __OO_UpdateXclbin_h_
+#define __OO_UpdateXclbin_h_
+
+#include "tools/common/OptionOptions.h"
+
+class OO_UpdateXclbin : public OptionOptions {
+ public:
+  virtual void execute( const SubCmdOptions &_options ) const;
+
+ public:
+  OO_UpdateXclbin( const std::string &_longName, const std::string &_shortName="", bool _isHidden = false);
+
+ private:
+  std::string m_device;
+  std::string xclbin;
+  bool m_help;
+};
+
+#endif

--- a/src/runtime_src/core/tools/xbmgmt2/OO_UpdateXclbin.h
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_UpdateXclbin.h
@@ -8,10 +8,10 @@
 
 class OO_UpdateXclbin : public OptionOptions {
  public:
-  virtual void execute(const SubCmdOptions &_options) const;
+  virtual void execute(const SubCmdOptions& _options) const;
 
  public:
-  OO_UpdateXclbin(const std::string &_longName, const std::string &_shortName = "", bool _isHidden = false);
+  OO_UpdateXclbin(const std::string& _longName, const std::string& _shortName = "", bool _isHidden = false);
 
  private:
   std::string m_device;

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdAdvanced.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdAdvanced.cpp
@@ -46,8 +46,7 @@ SubCmdAdvanced::SubCmdAdvanced(bool _isHidden, bool _isDepricated, bool _isPreli
     : SubCmd("advanced", "Low level command operations")
     , m_help(false)
 {
-  const std::string longDescription = "Low level command operations.";
-  setLongDescription(longDescription);
+  setLongDescription("Low level command operations.");
   setExampleSyntax("");
   setIsHidden(_isHidden);
   setIsDeprecated(_isDepricated);

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdAdvanced.h
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdAdvanced.h
@@ -26,6 +26,9 @@ class SubCmdAdvanced : public SubCmd {
  public:
   SubCmdAdvanced(bool _isHidden, bool _isDepricated, bool _isPreliminary);
   virtual ~SubCmdAdvanced() {};
+
+  private:
+    bool m_help;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdConfigure.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdConfigure.cpp
@@ -98,8 +98,7 @@ SubCmdConfigure::SubCmdConfigure(bool _isHidden, bool _isDepricated, bool _isPre
     , m_cs_reset("")
     , m_showx(false)
 {
-  const std::string long_description = "Advanced options for configuring a device";
-  setLongDescription(long_description);
+  setLongDescription("Advanced options for configuring a device");
   setExampleSyntax("");
   setIsHidden(_isHidden);
   setIsDeprecated(_isDepricated);

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdConfigure.h
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdConfigure.h
@@ -26,6 +26,23 @@ class SubCmdConfigure : public SubCmd {
  public:
   SubCmdConfigure(bool _isHidden, bool _isDepricated, bool _isPreliminary);
   virtual ~SubCmdConfigure() {};
+
+ private:
+  // Common options
+  std::string m_device;
+  std::string m_path;
+  std::string m_retention;
+  bool        m_help;
+  // Hidden options
+  bool        m_daemon;
+  bool        m_purge;
+  std::string m_host;
+  std::string m_security;
+  std::string m_clk_scale;
+  std::string m_power_override;
+  std::string m_temp_override;
+  std::string m_cs_reset;
+  bool        m_showx;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdDump.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdDump.cpp
@@ -119,8 +119,7 @@ SubCmdDump::SubCmdDump(bool _isHidden, bool _isDepricated, bool _isPreliminary)
     , m_config(false)
     , m_help(false)
 {
-  const std::string longDescription = "Dump out the contents of the specified option.";
-  setLongDescription(longDescription);
+  setLongDescription("Dump out the contents of the specified option.");
   setExampleSyntax("");
   setIsHidden(_isHidden);
   setIsDeprecated(_isDepricated);

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdDump.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdDump.cpp
@@ -158,7 +158,7 @@ SubCmdDump::execute(const SubCmdOptions& _options) const
   // -- process "device" option -----------------------------------------------
   XBU::verbose("Option: device");
   for (auto & str : m_device)
-    XBU::verbose(std::string(" ") + str);
+    XBU::verbose(" " + str);
 
   // Find device of interest
   std::shared_ptr<xrt_core::device> device;

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdDump.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdDump.cpp
@@ -158,7 +158,7 @@ SubCmdDump::execute(const SubCmdOptions& _options) const
   // -- process "device" option -----------------------------------------------
   XBU::verbose("Option: device");
   for (auto & str : m_device)
-    XBU::verbose(" " + str);
+    XBU::verbose(boost::format(" %s") % str);
 
   // Find device of interest
   std::shared_ptr<xrt_core::device> device;

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdDump.h
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdDump.h
@@ -25,6 +25,13 @@ class SubCmdDump : public SubCmd {
 
  public:
   SubCmdDump(bool _isHidden, bool _isDepricated, bool _isPreliminary);
+
+ private:
+  std::string m_device;
+  std::string m_output;
+  bool m_flash;
+  bool m_config;
+  bool m_help;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdExamine.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdExamine.cpp
@@ -65,9 +65,8 @@ SubCmdExamine::SubCmdExamine(bool _isHidden, bool _isDepricated, bool _isPrelimi
     , m_output("")
     , m_help(false)
 {
-  const std::string longDescription = "This command will 'examine' the state of the system/device and will"
-                                      " generate a report of interest in a text or JSON format.";
-  setLongDescription(longDescription);
+  setLongDescription( "This command will 'examine' the state of the system/device and will"
+                      " generate a report of interest in a text or JSON format.");
   setExampleSyntax("");
   setIsHidden(_isHidden);
   setIsDeprecated(_isDepricated);

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdExamine.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdExamine.cpp
@@ -76,7 +76,7 @@ SubCmdExamine::SubCmdExamine(bool _isHidden, bool _isDepricated, bool _isPrelimi
   m_commonOptions.add_options()
     ("device,d", boost::program_options::value<decltype(m_device)>(&m_device), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest")
     ("report,r", boost::program_options::value<decltype(m_reportNames)>(&m_reportNames)->multitoken(), (std::string("The type of report to be produced. Reports currently available are:\n") + reportOptionValues).c_str() )
-    ("format,f", boost::program_options::value<decltype(m_format)>(&m_format)->implicit_value("json"), (std::string("Report output format. Valid values are:\n") + formatOptionValues).c_str() )
+    ("format,f", boost::program_options::value<decltype(m_format)>(&m_format), (std::string("Report output format. Valid values are:\n") + formatOptionValues).c_str() )
     ("output,o", boost::program_options::value<decltype(m_output)>(&m_output), "Direct the output to the given file")
     ("help", boost::program_options::bool_switch(&m_help), "Help to use this sub-command")
   ;
@@ -116,10 +116,12 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
   if (!m_format.empty() && m_output.empty())
     throw xrt_core::error("Please specify an output file to redirect the json to");
 
+  const auto validated_format = m_format.empty() ? "json" : m_format;
+
   // Output Format
-  Report::SchemaVersion schemaVersion = Report::getSchemaDescription(m_format).schemaVersion;
+  Report::SchemaVersion schemaVersion = Report::getSchemaDescription(validated_format).schemaVersion;
   if (schemaVersion == Report::SchemaVersion::unknown) 
-    throw xrt_core::error((boost::format("Unknown output format: '%s'") % m_format).str());
+    throw xrt_core::error((boost::format("Unknown output format: '%s'") % validated_format).str());
 
   // Output file
   if (!m_output.empty() && boost::filesystem::exists(m_output) && !XBU::getForce()) 

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdExamine.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdExamine.cpp
@@ -99,7 +99,7 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
 
   // Determine report leveld
   std::vector<std::string> reportsToRun(m_reportNames);
-  if (reportsToRun.empty()) {
+  if (m_reportNames.empty()) {
     if (m_device.empty())
       reportsToRun.push_back("host");
     else

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdExamine.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdExamine.cpp
@@ -76,7 +76,7 @@ SubCmdExamine::SubCmdExamine(bool _isHidden, bool _isDepricated, bool _isPrelimi
   m_commonOptions.add_options()
     ("device,d", boost::program_options::value<decltype(m_device)>(&m_device), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest")
     ("report,r", boost::program_options::value<decltype(m_reportNames)>(&m_reportNames)->multitoken(), (std::string("The type of report to be produced. Reports currently available are:\n") + reportOptionValues).c_str() )
-    ("format,f", boost::program_options::value<decltype(m_format)>(&m_format), (std::string("Report output format. Valid values are:\n") + formatOptionValues).c_str() )
+    ("format,f", boost::program_options::value<decltype(m_format)>(&m_format)->implicit_value("json"), (std::string("Report output format. Valid values are:\n") + formatOptionValues).c_str() )
     ("output,o", boost::program_options::value<decltype(m_output)>(&m_output), "Direct the output to the given file")
     ("help", boost::program_options::bool_switch(&m_help), "Help to use this sub-command")
   ;
@@ -116,12 +116,10 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
   if (!m_format.empty() && m_output.empty())
     throw xrt_core::error("Please specify an output file to redirect the json to");
 
-  const auto validated_format = m_format.empty() ? "json" : m_format;
-
   // Output Format
-  Report::SchemaVersion schemaVersion = Report::getSchemaDescription(validated_format).schemaVersion;
+  Report::SchemaVersion schemaVersion = Report::getSchemaDescription(m_format).schemaVersion;
   if (schemaVersion == Report::SchemaVersion::unknown) 
-    throw xrt_core::error((boost::format("Unknown output format: '%s'") % validated_format).str());
+    throw xrt_core::error((boost::format("Unknown output format: '%s'") % m_format).str());
 
   // Output file
   if (!m_output.empty() && boost::filesystem::exists(m_output) && !XBU::getForce()) 

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdExamine.h
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdExamine.h
@@ -25,6 +25,14 @@ class SubCmdExamine : public SubCmd {
 
  public:
   SubCmdExamine(bool _isHidden, bool _isDepricated, bool _isPreliminary);
+
+ private:
+  std::string               m_device;
+  std::vector<std::string>  m_reportNames;
+  std::vector<std::string>  m_elementsFilter;
+  std::string               m_format;
+  std::string               m_output;
+  bool                      m_help;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -105,7 +105,7 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
 
   // Parse sub-command ...
   po::variables_map vm;
-  auto topOptions = process_arguments(vm, _options, m_commonOptions, m_hiddenOptions, m_positionals, m_subOptionOptions, false);
+  auto topOptions = process_arguments(vm, _options, false);
 
   // Check for a suboption
   auto optionOption = checkForSubOption(vm);
@@ -117,11 +117,11 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
 
   // Check to see if help was requested or no command was found
   if (help) {
-    printHelp(m_commonOptions, m_hiddenOptions, m_subOptionOptions);
+    printHelp();
     return;
   }
 
   std::cout << "\nERROR: Missing operation.  No action taken.\n\n";
-  printHelp(m_commonOptions, m_hiddenOptions, m_subOptionOptions);
+  printHelp();
   throw xrt_core::error(std::errc::operation_canceled);
 }

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -6,52 +6,23 @@
 // Local - Include Files
 #include "SubCmdProgram.h"
 
+// XRT - Include Files
 #include "OO_ChangeBoot.h"
 #include "OO_FactoryReset.h"
 #include "OO_UpdateBase.h"
 #include "OO_UpdateShell.h"
 #include "OO_UpdateXclbin.h"
-
-#include "tools/common/XBHelpMenusCore.h"
-#include "tools/common/XBUtilitiesCore.h"
 #include "tools/common/XBUtilities.h"
-#include "tools/common/XBHelpMenus.h"
-#include "tools/common/ProgressBar.h"
-#include "tools/common/Process.h"
+#include "tools/common/XBUtilitiesCore.h"
 namespace XBU = XBUtilities;
-
-#include "xrt.h"
-#include "core/common/system.h"
-#include "core/common/device.h"
-#include "core/common/error.h"
-#include "core/common/query_requests.h"
-#include "core/common/message.h"
-#include "core/common/utils.h"
-#include "flash/flasher.h"
-#include "core/common/info_vmr.h"
-// Remove linux specific code
-#ifdef __linux__
-#include "core/pcie/linux/scan.h"
-#endif
 
 // 3rd Party Library - Include Files
 #include <boost/format.hpp>
-#include <boost/tokenizer.hpp>
-#include <boost/filesystem.hpp>
 #include <boost/program_options.hpp>
-#include <boost/algorithm/string.hpp>
 namespace po = boost::program_options;
 
 // System - Include Files
-#include <atomic>
-#include <chrono>
-#include <ctime>
-#include <fcntl.h>
-#include <fstream>
 #include <iostream>
-#include <locale>
-#include <map>
-#include <thread>
 
 #ifdef _WIN32
 #pragma warning(disable : 4996) //std::asctime
@@ -121,7 +92,7 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
     return;
   }
 
-  std::cout << "\nERROR: Missing operation.  No action taken.\n\n";
+  std::cout << "\nERROR: Missing operation. No action taken.\n\n";
   printHelp();
   throw xrt_core::error(std::errc::operation_canceled);
 }

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -38,8 +38,7 @@ SubCmdProgram::SubCmdProgram(const std::string& executable, bool _isHidden, bool
     , m_device("")
     , m_help(false)
 {
-  const std::string longDescription = "Updates the image(s) for a given device.";
-  setLongDescription(longDescription);
+  setLongDescription("Updates the image(s) for a given device.");
   setExampleSyntax("");
   setIsHidden(_isHidden);
   setIsDeprecated(_isDepricated);

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -153,9 +153,9 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
 
   for (auto & subOO : subOptionOptions) {
     if (subOO->isHidden()) 
-      hiddenOptions.add_options()(subOO->longName().c_str(), subOO->description().c_str());
+      hiddenOptions.add_options()(subOO->optionNameString().c_str(), subOO->description().c_str());
     else
-      commonOptions.add_options()(subOO->longName().c_str(), subOO->description().c_str());
+      commonOptions.add_options()(subOO->optionNameString().c_str(), subOO->description().c_str());
     subOO->setExecutable(getExecutableName());
     subOO->setCommand(getName());
   }

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -33,12 +33,10 @@ namespace po = boost::program_options;
 
 // ----- C L A S S   M E T H O D S -------------------------------------------
 
-std::string device_str;
-bool help = false;
-
 SubCmdProgram::SubCmdProgram(const std::string& executable, bool _isHidden, bool _isDepricated, bool _isPreliminary)
-    : SubCmd("program",
-             "Update image(s) for a given device")
+    : SubCmd("program", "Update image(s) for a given device")
+    , m_device("")
+    , m_help(false)
 {
   const std::string longDescription = "Updates the image(s) for a given device.";
   setLongDescription(longDescription);
@@ -49,8 +47,8 @@ SubCmdProgram::SubCmdProgram(const std::string& executable, bool _isHidden, bool
   setExecutableName(executable);
 
   m_commonOptions.add_options()
-    ("device,d", boost::program_options::value<decltype(device_str)>(&device_str), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest.")
-    ("help", boost::program_options::bool_switch(&help), "Help to use this sub-command")
+    ("device,d", boost::program_options::value<decltype(m_device)>(&m_device), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest.")
+    ("help", boost::program_options::bool_switch(&m_help), "Help to use this sub-command")
   ;
 
   addSubOption(std::make_shared<OO_UpdateBase>("base", "b"));
@@ -88,7 +86,7 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
   }
 
   // Check to see if help was requested or no command was found
-  if (help) {
+  if (m_help) {
     printHelp();
     return;
   }

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -62,6 +62,9 @@ namespace po = boost::program_options;
 
 // ----- C L A S S   M E T H O D S -------------------------------------------
 
+std::string device_str;
+bool help = false;
+
 SubCmdProgram::SubCmdProgram(bool _isHidden, bool _isDepricated, bool _isPreliminary)
     : SubCmd("program",
              "Update image(s) for a given device")
@@ -72,6 +75,17 @@ SubCmdProgram::SubCmdProgram(bool _isHidden, bool _isDepricated, bool _isPrelimi
   setIsHidden(_isHidden);
   setIsDeprecated(_isDepricated);
   setIsPreliminary(_isPreliminary);
+
+  m_commonOptions.add_options()
+    ("device,d", boost::program_options::value<decltype(device_str)>(&device_str), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest.")
+    ("help", boost::program_options::bool_switch(&help), "Help to use this sub-command")
+  ;
+
+  addSubOption(std::make_shared<OO_UpdateBase>("base", "b"));
+  addSubOption(std::make_shared<OO_UpdateShell>("shell", "s"));
+  addSubOption(std::make_shared<OO_FactoryReset>("revert-to-golden"));
+  addSubOption(std::make_shared<OO_UpdateXclbin>("user", "u"));
+  addSubOption(std::make_shared<OO_ChangeBoot>("boot", "", true));
 }
 
 void
@@ -89,48 +103,12 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
     XBU::verbose(msg);
   }
 
-  // -- Retrieve and parse the subcommand options -----------------------------
-  std::string device_str;
-  bool help = false;
-
-  po::options_description commonOptions("Common Options");
-  commonOptions.add_options()
-    ("device,d", boost::program_options::value<decltype(device_str)>(&device_str), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest.")
-    ("help", boost::program_options::bool_switch(&help), "Help to use this sub-command")
-  ;
-
-  po::options_description hiddenOptions("Hidden Options");
-
-  po::positional_options_description positionals;
-
-  SubOptionOptions subOptionOptions;
-  subOptionOptions.emplace_back(std::make_shared<OO_UpdateBase>("base", "b"));
-  subOptionOptions.emplace_back(std::make_shared<OO_UpdateShell>("shell", "s"));
-  subOptionOptions.emplace_back(std::make_shared<OO_FactoryReset>("revert-to-golden"));
-  subOptionOptions.emplace_back(std::make_shared<OO_UpdateXclbin>("user", "u"));
-  subOptionOptions.emplace_back(std::make_shared<OO_ChangeBoot>("boot", "", true));
-
-  for (auto & subOO : subOptionOptions) {
-    if (subOO->isHidden()) 
-      hiddenOptions.add_options()(subOO->optionNameString().c_str(), subOO->description().c_str());
-    else
-      commonOptions.add_options()(subOO->optionNameString().c_str(), subOO->description().c_str());
-    subOO->setExecutable(getExecutableName());
-    subOO->setCommand(getName());
-  }
-
   // Parse sub-command ...
   po::variables_map vm;
-  auto topOptions = process_arguments(vm, _options, commonOptions, hiddenOptions, positionals, subOptionOptions, false);
+  auto topOptions = process_arguments(vm, _options, m_commonOptions, m_hiddenOptions, m_positionals, m_subOptionOptions, false);
 
-    // Find the subOption;
-  std::shared_ptr<OptionOptions> optionOption;
-  for (auto& subOO : subOptionOptions) {
-    if (vm.count(subOO->longName().c_str()) != 0) {
-      optionOption = subOO;
-      break;
-    }
-  }
+  // Check for a suboption
+  auto optionOption = checkForSubOption(vm);
 
   if (optionOption) {
     optionOption->execute(_options);
@@ -139,11 +117,11 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
 
   // Check to see if help was requested or no command was found
   if (help) {
-    printHelp(commonOptions, hiddenOptions, subOptionOptions);
+    printHelp(m_commonOptions, m_hiddenOptions, m_subOptionOptions);
     return;
   }
 
   std::cout << "\nERROR: Missing operation.  No action taken.\n\n";
-  printHelp(commonOptions, hiddenOptions, subOptionOptions);
+  printHelp(m_commonOptions, m_hiddenOptions, m_subOptionOptions);
   throw xrt_core::error(std::errc::operation_canceled);
 }

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -24,10 +24,6 @@ namespace po = boost::program_options;
 // System - Include Files
 #include <iostream>
 
-#ifdef _WIN32
-#pragma warning(disable : 4996) //std::asctime
-#endif
-
 
 // =============================================================================
 

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -36,7 +36,7 @@ namespace po = boost::program_options;
 std::string device_str;
 bool help = false;
 
-SubCmdProgram::SubCmdProgram(bool _isHidden, bool _isDepricated, bool _isPreliminary)
+SubCmdProgram::SubCmdProgram(const std::string& executable, bool _isHidden, bool _isDepricated, bool _isPreliminary)
     : SubCmd("program",
              "Update image(s) for a given device")
 {
@@ -46,6 +46,7 @@ SubCmdProgram::SubCmdProgram(bool _isHidden, bool _isDepricated, bool _isPrelimi
   setIsHidden(_isHidden);
   setIsDeprecated(_isDepricated);
   setIsPreliminary(_isPreliminary);
+  setExecutableName(executable);
 
   m_commonOptions.add_options()
     ("device,d", boost::program_options::value<decltype(device_str)>(&device_str), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest.")

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -180,7 +180,7 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
   po::positional_options_description positionals;
 
   SubOptionOptions subOptionOptions;
-  subOptionOptions.emplace_back(std::make_shared<OO_UpdateBase>("base"));
+  subOptionOptions.emplace_back(std::make_shared<OO_UpdateBase>("base", "b"));
 
   for (auto & subOO : subOptionOptions) {
     if (subOO->isHidden()) 

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -146,9 +146,9 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
 
   for (auto & subOO : subOptionOptions) {
     if (subOO->isHidden()) 
-      hiddenOptions.add_options()(subOO->longName().c_str(), subOO->description().c_str());
+      hiddenOptions.add_options()(subOO->optionNameString().c_str(), subOO->description().c_str());
     else
-      commonOptions.add_options()(subOO->longName().c_str(), subOO->description().c_str());
+      commonOptions.add_options()(subOO->optionNameString().c_str(), subOO->description().c_str());
     subOO->setExecutable(getExecutableName());
     subOO->setCommand(getName());
   }

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -5,9 +5,11 @@
 // ------ I N C L U D E   F I L E S -------------------------------------------
 // Local - Include Files
 #include "SubCmdProgram.h"
+
+#include "OO_FactoryReset.h"
 #include "OO_UpdateBase.h"
 #include "OO_UpdateShell.h"
-#include "OO_FactoryReset.h"
+#include "OO_UpdateXclbin.h"
 
 #include "tools/common/XBHelpMenusCore.h"
 #include "tools/common/XBUtilitiesCore.h"
@@ -124,8 +126,6 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
   po::options_description commonOptions("Common Options");
   commonOptions.add_options()
     ("device,d", boost::program_options::value<decltype(device_str)>(&device_str), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest.")
-    ("user,u", boost::program_options::value<decltype(xclbin)>(&xclbin), "The xclbin to be loaded.  Valid values:\n"
-                                                                      "  Name (and path) of the xclbin.")
     ("help", boost::program_options::bool_switch(&help), "Help to use this sub-command")
   ;
 
@@ -143,6 +143,7 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
   subOptionOptions.emplace_back(std::make_shared<OO_UpdateBase>("base", "b"));
   subOptionOptions.emplace_back(std::make_shared<OO_UpdateShell>("shell", "s"));
   subOptionOptions.emplace_back(std::make_shared<OO_FactoryReset>("revert-to-golden"));
+  subOptionOptions.emplace_back(std::make_shared<OO_UpdateXclbin>("user", "u"));
 
   for (auto & subOO : subOptionOptions) {
     if (subOO->isHidden()) 
@@ -186,34 +187,6 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
     // Catch only the exceptions that we have generated earlier
     std::cerr << boost::format("ERROR: %s\n") % e.what();
     throw xrt_core::error(std::errc::operation_canceled);
-  }
-
-  // -- process "user" option ---------------------------------------
-  if (!xclbin.empty()) {
-    XBU::verbose(boost::str(boost::format("  xclbin: %s") % xclbin));
-    XBU::sudo_or_throw("Root privileges are required to download xclbin");
-
-    std::ifstream stream(xclbin, std::ios::binary);
-    if (!stream)
-      throw xrt_core::error(boost::str(boost::format("Could not open %s for reading") % xclbin));
-
-    stream.seekg(0,stream.end);
-    ssize_t size = stream.tellg();
-    stream.seekg(0,stream.beg);
-
-    std::vector<char> xclbin_buffer(size);
-    stream.read(xclbin_buffer.data(), size);
-
-    auto bdf = xrt_core::query::pcie_bdf::to_string(xrt_core::device_query<xrt_core::query::pcie_bdf>(device));
-    std::cout << "Downloading xclbin on device [" << bdf << "]..." << std::endl;
-    try {
-      device->xclmgmt_load_xclbin(xclbin_buffer.data());
-    } catch (xrt_core::error& e) {
-      std::cout << "ERROR: " << e.what() << std::endl;
-      throw xrt_core::error(std::errc::operation_canceled);
-    }
-    std::cout << boost::format("INFO: Successfully downloaded xclbin \n") << std::endl;
-    return;
   }
 
   // -- process "boot" option ------------------------------------------

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -217,7 +217,7 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
   auto flash_type = working_flasher.getFlashType(flashType);
 
   if (vm.count("base") != 0) {
-    subOptionOptions[0]->execute(topOptions);
+    subOptionOptions[0]->execute(_options);
     return;
   }
 

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -92,7 +92,7 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
 
   // Parse sub-command ...
   po::variables_map vm;
-  auto topOptions = process_arguments(vm, _options, m_commonOptions, m_hiddenOptions, m_positionals, m_subOptionOptions, false);
+  auto topOptions = process_arguments(vm, _options, false);
 
   // Check for a suboption
   auto optionOption = checkForSubOption(vm);
@@ -104,11 +104,11 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
 
   // Check to see if help was requested or no command was found
   if (help) {
-    printHelp(m_commonOptions, m_hiddenOptions, m_subOptionOptions);
+    printHelp();
     return;
   }
 
   std::cout << "\nERROR: Missing operation.  No action taken.\n\n";
-  printHelp(m_commonOptions, m_hiddenOptions, m_subOptionOptions);
+  printHelp();
   throw xrt_core::error(std::errc::operation_canceled);
 }

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -188,6 +188,20 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
   po::variables_map vm;
   auto topOptions = process_arguments(vm, _options, commonOptions, hiddenOptions, positionals, subOptionOptions, false);
 
+    // Find the subOption;
+  std::shared_ptr<OptionOptions> optionOption;
+  for (auto& subOO : subOptionOptions) {
+    if (vm.count(subOO->longName().c_str()) != 0) {
+      optionOption = subOO;
+      break;
+    }
+  }
+
+  if (optionOption) {
+    optionOption->execute(_options);
+    return;
+  }
+
   // Check to see if help was requested or no command was found
   if (help) {
     printHelp(commonOptions, hiddenOptions);

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -6,31 +6,15 @@
 // Local - Include Files
 #include "SubCmdProgram.h"
 
+// XRT - Include Files
 #include "OO_ChangeBoot.h"
 #include "OO_FactoryReset.h"
 #include "OO_UpdateBase.h"
 #include "OO_UpdateShell.h"
 #include "OO_UpdateXclbin.h"
-
-#include "tools/common/XBHelpMenusCore.h"
-#include "tools/common/XBUtilitiesCore.h"
 #include "tools/common/XBUtilities.h"
 #include "tools/common/XBUtilitiesCore.h"
 namespace XBU = XBUtilities;
-
-#include "xrt.h"
-#include "core/common/system.h"
-#include "core/common/device.h"
-#include "core/common/error.h"
-#include "core/common/query_requests.h"
-#include "core/common/message.h"
-#include "core/common/utils.h"
-#include "flash/flasher.h"
-#include "core/common/info_vmr.h"
-// Remove linux specific code
-#ifdef __linux__
-#include "core/pcie/linux/scan.h"
-#endif
 
 // 3rd Party Library - Include Files
 #include <boost/format.hpp>
@@ -108,7 +92,7 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
     return;
   }
 
-  std::cout << "\nERROR: Missing operation.  No action taken.\n\n";
+  std::cout << "\nERROR: Missing operation. No action taken.\n\n";
   printHelp();
   throw xrt_core::error(std::errc::operation_canceled);
 }

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -5,16 +5,27 @@
 // ------ I N C L U D E   F I L E S -------------------------------------------
 // Local - Include Files
 #include "SubCmdProgram.h"
-
-// XRT - Include Files
-#include "OO_ChangeBoot.h"
-#include "OO_FactoryReset.h"
 #include "OO_UpdateBase.h"
-#include "OO_UpdateShell.h"
-#include "OO_UpdateXclbin.h"
+
+#include "tools/common/XBHelpMenusCore.h"
+#include "tools/common/XBUtilitiesCore.h"
 #include "tools/common/XBUtilities.h"
 #include "tools/common/XBUtilitiesCore.h"
 namespace XBU = XBUtilities;
+
+#include "xrt.h"
+#include "core/common/system.h"
+#include "core/common/device.h"
+#include "core/common/error.h"
+#include "core/common/query_requests.h"
+#include "core/common/message.h"
+#include "core/common/utils.h"
+#include "flash/flasher.h"
+#include "core/common/info_vmr.h"
+// Remove linux specific code
+#ifdef __linux__
+#include "core/pcie/linux/scan.h"
+#endif
 
 // 3rd Party Library - Include Files
 #include <boost/format.hpp>
@@ -30,6 +41,60 @@ namespace po = boost::program_options;
 
 
 // =============================================================================
+
+// ------ L O C A L   F U N C T I O N S ---------------------------------------
+
+namespace {
+
+static void
+program_plp(const xrt_core::device* dev, const std::string& partition)
+{
+  std::ifstream stream(partition.c_str(), std::ios_base::binary);
+  if (!stream.is_open())
+    throw xrt_core::error(boost::str(boost::format("Cannot open %s") % partition));
+
+  //size of the stream
+  stream.seekg(0, stream.end);
+  int total_size = static_cast<int>(stream.tellg());
+  stream.seekg(0, stream.beg);
+
+  //copy stream into a vector
+  std::vector<char> buffer(total_size);
+  stream.read(buffer.data(), total_size);
+
+  try {
+    xrt_core::program_plp(dev, buffer, XBU::getForce());
+  }
+  catch (xrt_core::error& e) {
+    std::cout << "ERROR: " << e.what() << std::endl;
+    throw xrt_core::error(std::errc::operation_canceled);
+  }
+  std::cout << "Programmed shell successfully" << std::endl;
+}
+
+static void
+switch_partition(xrt_core::device* device, int boot)
+{
+  auto bdf = xrt_core::query::pcie_bdf::to_string(xrt_core::device_query<xrt_core::query::pcie_bdf>(device));
+  std::cout << boost::format("Rebooting device: [%s] with '%s' partition")
+                % bdf % (boot ? "backup" : "default") << std::endl;
+  try {
+    auto value = xrt_core::query::flush_default_only::value_type(boot);
+    xrt_core::device_update<xrt_core::query::boot_partition>(device, value);
+    std::cout << "Performing hot reset..." << std::endl;
+    auto hot_reset = XBU::str_to_reset_obj("hot");
+    device->reset(hot_reset);
+    std::cout << "Rebooted successfully" << std::endl;
+  }
+  catch (const xrt_core::query::exception& ex) {
+    std::cout << "ERROR: " << ex.what() << std::endl;
+    throw xrt_core::error(std::errc::operation_canceled);
+    // only available for versal devices
+  }
+}
+
+}
+//end anonymous namespace
 
 // ----- C L A S S   M E T H O D S -------------------------------------------
 
@@ -73,15 +138,86 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
     XBU::verbose(msg);
   }
 
+  // -- Retrieve and parse the subcommand options -----------------------------
+  std::string device_str;
+  std::string plp;
+  std::string xclbin;
+  std::string boot;
+  std::string flashType;
+  bool revertToGolden = false;
+  bool help = false;
+
+  po::options_description commonOptions("Common Options");
+  commonOptions.add_options()
+    ("device,d", boost::program_options::value<decltype(device_str)>(&device_str), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest.")
+    ("shell,s", boost::program_options::value<decltype(plp)>(&plp), "The partition to be loaded.  Valid values:\n"
+                                                                      "  Name (and path) of the partition.")
+    ("user,u", boost::program_options::value<decltype(xclbin)>(&xclbin), "The xclbin to be loaded.  Valid values:\n"
+                                                                      "  Name (and path) of the xclbin.")
+    ("revert-to-golden", boost::program_options::bool_switch(&revertToGolden), "Resets the FPGA PROM back to the factory image. Note: The Satellite Controller will not be reverted for a golden image does not exist.")
+    ("help", boost::program_options::bool_switch(&help), "Help to use this sub-command")
+  ;
+
+  po::options_description hiddenOptions("Hidden Options");
+  hiddenOptions.add_options()
+    ("flash-type", boost::program_options::value<decltype(flashType)>(&flashType),
+      "Overrides the flash mode. Use with caution.  Valid values:\n"
+      "  ospi\n"
+      "  ospi_versal")
+    ("boot", boost::program_options::value<decltype(boot)>(&boot)->implicit_value("default"),
+    "RPU and/or APU will be booted to either partition A or partition B.  Valid values:\n"
+    "  DEFAULT - Reboot RPU to partition A\n"
+    "  BACKUP  - Reboot RPU to partition B\n")
+  ;
+
+  po::positional_options_description positionals;
+
+  SubOptionOptions subOptionOptions;
+  subOptionOptions.emplace_back(std::make_shared<OO_UpdateBase>("base"));
+
+  for (auto & subOO : subOptionOptions) {
+    if (subOO->isHidden()) 
+      hiddenOptions.add_options()(subOO->longName().c_str(), subOO->description().c_str());
+    else
+      commonOptions.add_options()(subOO->longName().c_str(), subOO->description().c_str());
+    subOO->setExecutable(getExecutableName());
+    subOO->setCommand(getName());
+  }
+
   // Parse sub-command ...
   po::variables_map vm;
-  auto topOptions = process_arguments(vm, _options, false);
+  auto topOptions = process_arguments(vm, _options, commonOptions, hiddenOptions, positionals, subOptionOptions, false);
 
-  // Check for a suboption
-  auto optionOption = checkForSubOption(vm);
+  // Check to see if help was requested or no command was found
+  if (help) {
+    printHelp(commonOptions, hiddenOptions);
+    return;
+  }
 
-  if (optionOption) {
-    optionOption->execute(_options);
+  // -- Now process the subcommand --------------------------------------------
+  // XBU::verbose(boost::str(boost::format("  Base: %s") % update));
+
+  // -- process "device" option -----------------------------------------------
+  // Find device of interest
+  std::shared_ptr<xrt_core::device> device;
+  try {
+    device = XBU::get_device(boost::algorithm::to_lower_copy(device_str), false /*inUserDomain*/);
+  } catch (const std::runtime_error& e) {
+    // Catch only the exceptions that we have generated earlier
+    std::cerr << boost::format("ERROR: %s\n") % e.what();
+    throw xrt_core::error(std::errc::operation_canceled);
+  }
+
+  // Populate flash type. Uses board's default when passing an empty input string.
+  if (!flashType.empty()) {
+      xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT",
+        "Overriding flash mode is not recommended.\nYou may damage your device with this option.");
+  }
+  Flasher working_flasher(device->get_device_id());
+  auto flash_type = working_flasher.getFlashType(flashType);
+
+  if (vm.count("base") != 0) {
+    subOptionOptions[0]->execute(topOptions);
     return;
   }
 

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -7,6 +7,7 @@
 #include "SubCmdProgram.h"
 #include "OO_UpdateBase.h"
 #include "OO_UpdateShell.h"
+#include "OO_FactoryReset.h"
 
 #include "tools/common/XBHelpMenusCore.h"
 #include "tools/common/XBUtilitiesCore.h"
@@ -118,8 +119,6 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
   std::string plp;
   std::string xclbin;
   std::string boot;
-  std::string flashType;
-  bool revertToGolden = false;
   bool help = false;
 
   po::options_description commonOptions("Common Options");
@@ -127,16 +126,11 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
     ("device,d", boost::program_options::value<decltype(device_str)>(&device_str), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest.")
     ("user,u", boost::program_options::value<decltype(xclbin)>(&xclbin), "The xclbin to be loaded.  Valid values:\n"
                                                                       "  Name (and path) of the xclbin.")
-    ("revert-to-golden", boost::program_options::bool_switch(&revertToGolden), "Resets the FPGA PROM back to the factory image. Note: The Satellite Controller will not be reverted for a golden image does not exist.")
     ("help", boost::program_options::bool_switch(&help), "Help to use this sub-command")
   ;
 
   po::options_description hiddenOptions("Hidden Options");
   hiddenOptions.add_options()
-    ("flash-type", boost::program_options::value<decltype(flashType)>(&flashType),
-      "Overrides the flash mode. Use with caution.  Valid values:\n"
-      "  ospi\n"
-      "  ospi_versal")
     ("boot", boost::program_options::value<decltype(boot)>(&boot)->implicit_value("default"),
     "RPU and/or APU will be booted to either partition A or partition B.  Valid values:\n"
     "  DEFAULT - Reboot RPU to partition A\n"
@@ -148,6 +142,7 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
   SubOptionOptions subOptionOptions;
   subOptionOptions.emplace_back(std::make_shared<OO_UpdateBase>("base", "b"));
   subOptionOptions.emplace_back(std::make_shared<OO_UpdateShell>("shell", "s"));
+  subOptionOptions.emplace_back(std::make_shared<OO_FactoryReset>("revert-to-golden"));
 
   for (auto & subOO : subOptionOptions) {
     if (subOO->isHidden()) 
@@ -182,9 +177,6 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
     return;
   }
 
-  // -- Now process the subcommand --------------------------------------------
-  // XBU::verbose(boost::str(boost::format("  Base: %s") % update));
-
   // -- process "device" option -----------------------------------------------
   // Find device of interest
   std::shared_ptr<xrt_core::device> device;
@@ -194,58 +186,6 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
     // Catch only the exceptions that we have generated earlier
     std::cerr << boost::format("ERROR: %s\n") % e.what();
     throw xrt_core::error(std::errc::operation_canceled);
-  }
-
-  // Populate flash type. Uses board's default when passing an empty input string.
-  if (!flashType.empty()) {
-      xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT",
-        "Overriding flash mode is not recommended.\nYou may damage your device with this option.");
-  }
-  Flasher working_flasher(device->get_device_id());
-  auto flash_type = working_flasher.getFlashType(flashType);
-
-  if (vm.count("base") != 0) {
-    subOptionOptions[0]->execute(_options);
-    return;
-  }
-
-  // -- process "revert-to-golden" option ---------------------------------------
-  if (revertToGolden) {
-    XBU::verbose("Sub command: --revert-to-golden");
-    bool has_reset = false;
-
-    std::vector<Flasher> flasher_list;
-    //collect information of all the devices that will be reset
-    Flasher flasher(device->get_device_id());
-    if (!flasher.isValid())
-      xrt_core::error(boost::str(boost::format("%d is an invalid index") % device->get_device_id()));
-
-    std::cout << boost::format("%-8s : %s %s %s \n") % "INFO" % "Resetting device ["
-      % flasher.sGetDBDF() % "] back to factory mode.";
-    flasher_list.push_back(flasher);
-
-    XBUtilities::sudo_or_throw("Root privileges are required to revert the device to its golden flash image");
-
-    //ask user's permission
-    if (!XBU::can_proceed(XBU::getForce()))
-      throw xrt_core::error(std::errc::operation_canceled);
-
-    for (auto& f : flasher_list) {
-      if (!f.upgradeFirmware(flash_type, nullptr, nullptr, nullptr)) {
-        std::cout << boost::format("%-8s : %s %s %s\n") % "INFO" % "Shell on [" % f.sGetDBDF() % "]"
-                                   " is reset successfully.";
-        has_reset = true;
-      }
-    }
-
-    if (!has_reset)
-      return;
-
-    std::cout << "****************************************************\n";
-    std::cout << "Cold reboot machine to load the new image on device.\n";
-    std::cout << "****************************************************\n";
-
-    return;
   }
 
   // -- process "user" option ---------------------------------------

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -173,7 +173,7 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
   po::positional_options_description positionals;
 
   SubOptionOptions subOptionOptions;
-  subOptionOptions.emplace_back(std::make_shared<OO_UpdateBase>("base"));
+  subOptionOptions.emplace_back(std::make_shared<OO_UpdateBase>("base", "b"));
 
   for (auto & subOO : subOptionOptions) {
     if (subOO->isHidden()) 

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -6,6 +6,7 @@
 // Local - Include Files
 #include "SubCmdProgram.h"
 
+#include "OO_ChangeBoot.h"
 #include "OO_FactoryReset.h"
 #include "OO_UpdateBase.h"
 #include "OO_UpdateShell.h"
@@ -45,34 +46,6 @@ namespace po = boost::program_options;
 
 
 // =============================================================================
-
-// ------ L O C A L   F U N C T I O N S ---------------------------------------
-
-namespace {
-
-static void
-switch_partition(xrt_core::device* device, int boot)
-{
-  auto bdf = xrt_core::query::pcie_bdf::to_string(xrt_core::device_query<xrt_core::query::pcie_bdf>(device));
-  std::cout << boost::format("Rebooting device: [%s] with '%s' partition")
-                % bdf % (boot ? "backup" : "default") << std::endl;
-  try {
-    auto value = xrt_core::query::flush_default_only::value_type(boot);
-    xrt_core::device_update<xrt_core::query::boot_partition>(device, value);
-    std::cout << "Performing hot reset..." << std::endl;
-    auto hot_reset = XBU::str_to_reset_obj("hot");
-    device->reset(hot_reset);
-    std::cout << "Rebooted successfully" << std::endl;
-  }
-  catch (const xrt_core::query::exception& ex) {
-    std::cout << "ERROR: " << ex.what() << std::endl;
-    throw xrt_core::error(std::errc::operation_canceled);
-    // only available for versal devices
-  }
-}
-
-}
-//end anonymous namespace
 
 // ----- C L A S S   M E T H O D S -------------------------------------------
 
@@ -118,9 +91,6 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
 
   // -- Retrieve and parse the subcommand options -----------------------------
   std::string device_str;
-  std::string plp;
-  std::string xclbin;
-  std::string boot;
   bool help = false;
 
   po::options_description commonOptions("Common Options");
@@ -130,12 +100,6 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
   ;
 
   po::options_description hiddenOptions("Hidden Options");
-  hiddenOptions.add_options()
-    ("boot", boost::program_options::value<decltype(boot)>(&boot)->implicit_value("default"),
-    "RPU and/or APU will be booted to either partition A or partition B.  Valid values:\n"
-    "  DEFAULT - Reboot RPU to partition A\n"
-    "  BACKUP  - Reboot RPU to partition B\n")
-  ;
 
   po::positional_options_description positionals;
 
@@ -144,6 +108,7 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
   subOptionOptions.emplace_back(std::make_shared<OO_UpdateShell>("shell", "s"));
   subOptionOptions.emplace_back(std::make_shared<OO_FactoryReset>("revert-to-golden"));
   subOptionOptions.emplace_back(std::make_shared<OO_UpdateXclbin>("user", "u"));
+  subOptionOptions.emplace_back(std::make_shared<OO_ChangeBoot>("boot", "", true));
 
   for (auto & subOO : subOptionOptions) {
     if (subOO->isHidden()) 
@@ -178,33 +143,7 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
     return;
   }
 
-  // -- process "device" option -----------------------------------------------
-  // Find device of interest
-  std::shared_ptr<xrt_core::device> device;
-  try {
-    device = XBU::get_device(boost::algorithm::to_lower_copy(device_str), false /*inUserDomain*/);
-  } catch (const std::runtime_error& e) {
-    // Catch only the exceptions that we have generated earlier
-    std::cerr << boost::format("ERROR: %s\n") % e.what();
-    throw xrt_core::error(std::errc::operation_canceled);
-  }
-
-  // -- process "boot" option ------------------------------------------
-  if (!boot.empty()) {
-    if (boost::iequals(boot, "DEFAULT"))
-      switch_partition(device.get(), 0);
-    else if (boost::iequals(boot, "BACKUP"))
-      switch_partition(device.get(), 1);
-    else {
-      std::cout << "ERROR: Invalid value.\n"
-                << "Usage: xbmgmt program --device='0000:00:00.0' --boot [default|backup]"
-                << std::endl;
-      throw xrt_core::error(std::errc::operation_canceled);
-    }
-    return;
-  }
-
-  std::cout << "\nERROR: Missing flash operation.  No action taken.\n\n";
+  std::cout << "\nERROR: Missing operation.  No action taken.\n\n";
   printHelp(commonOptions, hiddenOptions, subOptionOptions);
   throw xrt_core::error(std::errc::operation_canceled);
 }

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.h
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.h
@@ -24,7 +24,7 @@ class SubCmdProgram : public SubCmd {
   virtual void execute(const SubCmdOptions &_options) const;
 
  public:
-  SubCmdProgram(bool _isHidden, bool _isDepricated, bool _isPreliminary);
+  SubCmdProgram(const std::string& executable, bool _isHidden, bool _isDepricated, bool _isPreliminary);
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.h
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.h
@@ -25,6 +25,10 @@ class SubCmdProgram : public SubCmd {
 
  public:
   SubCmdProgram(const std::string& executable, bool _isHidden, bool _isDepricated, bool _isPreliminary);
+
+  private:
+  std::string m_device;
+  bool m_help;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.h
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.h
@@ -25,10 +25,6 @@ class SubCmdProgram : public SubCmd {
 
  public:
   SubCmdProgram(const std::string& executable, bool _isHidden, bool _isDepricated, bool _isPreliminary);
-
-  private:
-  std::string m_device;
-  bool m_help;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdReset.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdReset.cpp
@@ -77,6 +77,7 @@ supported(std::string resetType) {
 SubCmdReset::SubCmdReset(bool _isHidden, bool _isDepricated, bool _isPreliminary)
     : SubCmd("reset", 
              "Resets the given device")
+    , m_resetType("hot")
 {
   setLongDescription("Resets the given device.");
   setExampleSyntax("");

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdReset.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdReset.cpp
@@ -78,8 +78,7 @@ SubCmdReset::SubCmdReset(bool _isHidden, bool _isDepricated, bool _isPreliminary
     : SubCmd("reset", 
              "Resets the given device")
 {
-  const std::string longDescription = "Resets the given device.";
-  setLongDescription(longDescription);
+  setLongDescription("Resets the given device.");
   setExampleSyntax("");
   setIsHidden(_isHidden);
   setIsDeprecated(_isDepricated);

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdReset.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdReset.cpp
@@ -64,6 +64,16 @@ reset_device(const std::shared_ptr<xrt_core::device>& dev, xrt_core::query::rese
     % xrt_core::query::pcie_bdf::to_string(xrt_core::device_query<xrt_core::query::pcie_bdf>(dev));
 }
 
+static void
+supported(std::string resetType) {
+  std::vector<std::string> vec { "hot", "kernel", "ert", "ecc", "soft-kernel", "aie" };
+  std::vector<std::string>::iterator it;
+  it = std::find (vec.begin(), vec.end(), resetType);
+  if (it == vec.end()) {
+    throw xrt_core::error(-ENODEV, "reset not supported");
+  }
+}
+
 SubCmdReset::SubCmdReset(bool _isHidden, bool _isDepricated, bool _isPreliminary)
     : SubCmd("reset", 
              "Resets the given device")
@@ -74,16 +84,19 @@ SubCmdReset::SubCmdReset(bool _isHidden, bool _isDepricated, bool _isPreliminary
   setIsHidden(_isHidden);
   setIsDeprecated(_isDepricated);
   setIsPreliminary(_isPreliminary);
-}
 
-void
-supported(std::string resetType) {
-  std::vector<std::string> vec { "hot", "kernel", "ert", "ecc", "soft-kernel", "aie" };
-  std::vector<std::string>::iterator it;
-  it = std::find (vec.begin(), vec.end(), resetType);
-  if (it == vec.end()) {
-    throw xrt_core::error(-ENODEV, "reset not supported");
-  }
+  m_commonOptions.add_options()
+    ("device,d", boost::program_options::value<decltype(m_device)>(&m_device), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest.")
+    ("help", boost::program_options::bool_switch(&m_help), "Help to use this sub-command")
+  ;
+
+  m_hiddenOptions.add_options()
+    ("type,t", boost::program_options::value<decltype(m_resetType)>(&m_resetType)->notifier(supported), "The type of reset to perform. Types resets available:\n"
+                                                                        "  kernel       - Kernel communication links\n" 
+                                                                        "  ert          - Reset management processor\n"
+                                                                        "  ecc          - Reset ecc memory\n"
+                                                                        "  soft-kernel  - Reset soft kernel");
+
 }
 
 void
@@ -92,37 +105,24 @@ SubCmdReset::execute(const SubCmdOptions& _options) const
 
 {
   XBU::verbose("SubCommand: reset");
-  // -- Retrieve and parse the subcommand options -----------------------------
-  std::string device_str;
-  std::string resetType = "hot";
-  bool help = false;
 
   po::options_description commonOptions("Common Options");
-  commonOptions.add_options()
-    ("device,d", boost::program_options::value<decltype(device_str)>(&device_str), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest.")
-    ("help", boost::program_options::bool_switch(&help), "Help to use this sub-command")
-  ;
+
 
   po::options_description hiddenOptions("Hidden Options");
-  hiddenOptions.add_options()
-    ("type,t", boost::program_options::value<decltype(resetType)>(&resetType)->notifier(supported), "The type of reset to perform. Types resets available:\n"
-                                                                        "  kernel       - Kernel communication links\n" 
-                                                                        "  ert          - Reset management processor\n"
-                                                                        "  ecc          - Reset ecc memory\n"
-                                                                        "  soft-kernel  - Reset soft kernel");
 
   // Parse sub-command ...
   po::variables_map vm;
-  process_arguments(vm, _options, commonOptions, hiddenOptions);
+  process_arguments(vm, _options);
 
   // Check to see if help was requested or no command was found
-  if (help) {
-    printHelp(commonOptions, hiddenOptions);
+  if (m_help) {
+    printHelp();
     return;
   }
 
   // -- Now process the subcommand --------------------------------------------
-  XBU::verbose(boost::str(boost::format("  Reset: %s") % resetType));
+  XBU::verbose(boost::str(boost::format("  Reset: %s") % m_resetType));
 
   // -- process "device" option -----------------------------------------------
   // Find device of interest
@@ -130,14 +130,14 @@ SubCmdReset::execute(const SubCmdOptions& _options) const
 
 
   try {
-    device = XBU::get_device(boost::algorithm::to_lower_copy(device_str), false /*inUserDomain*/);
+    device = XBU::get_device(boost::algorithm::to_lower_copy(m_device), false /*inUserDomain*/);
   } catch (const std::runtime_error& e) {
     // Catch only the exceptions that we have generated earlier
     std::cerr << boost::format("ERROR: %s\n") % e.what();
     throw xrt_core::error(std::errc::operation_canceled);
   }
   
-  xrt_core::query::reset_type type = XBU::str_to_reset_obj(resetType);
+  xrt_core::query::reset_type type = XBU::str_to_reset_obj(m_resetType);
   pretty_print_action_list(device.get(), type);
 
   // Ask user for permission

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdReset.h
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdReset.h
@@ -25,6 +25,11 @@ class SubCmdReset : public SubCmd {
 
  public:
   SubCmdReset(bool _isHidden, bool _isDepricated, bool _isPreliminary);
+
+ private:
+  std::string m_device;
+  std::string m_resetType;
+  bool        m_help;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbmgmt2/xbmgmt.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/xbmgmt.cpp
@@ -37,18 +37,16 @@ int main( int argc, char** argv )
 
   // -- Build the supported subcommands
   SubCmdsCollection subCommands;
-
+  const std::string executable = "xbmgmt";
   {
     // Syntax: SubCmdClass( IsHidden, IsDepricated, IsPreliminary)
-    subCommands.emplace_back(std::make_shared<   SubCmdProgram  >(false, false, false));
+    subCommands.emplace_back(std::make_shared<   SubCmdProgram  >(executable, false, false, false));
     subCommands.emplace_back(std::make_shared<     SubCmdReset  >(false, false, false));
     subCommands.emplace_back(std::make_shared<  SubCmdAdvanced  >(false, false,  true));
     subCommands.emplace_back(std::make_shared<   SubCmdExamine  >(false, false, false));
     subCommands.emplace_back(std::make_shared<      SubCmdDump  >(false, false, false));
     subCommands.emplace_back(std::make_shared< SubCmdConfigure  >(false, false, false));
   }
-
-  const std::string executable = "xbmgmt";
 
   for (auto & subCommand : subCommands) 
     subCommand->setExecutableName(executable);

--- a/src/runtime_src/core/tools/xbutil2/OO_AieClockFreq.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_AieClockFreq.cpp
@@ -24,7 +24,6 @@ namespace qr = xrt_core::query;
 #include <iostream>
 #include <math.h>
 
-// ----- H E L P E R M E T H O D S ------------------------------------------
 static double
 to_megaHz(uint64_t value)
 {
@@ -106,7 +105,7 @@ OO_AieClockFreq::execute(const SubCmdOptions& _options) const
 
   XBU::verbose("Option(s):");
   for (auto & aString : _options)
-    XBU::verbose(std::string(" ") + aString);
+    XBU::verbose(" " + aString);
 
   // Honor help option first
   if (std::find(_options.begin(), _options.end(), "--help") != _options.end()) {

--- a/src/runtime_src/core/tools/xbutil2/OO_AieRegRead.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_AieRegRead.cpp
@@ -401,7 +401,7 @@ OO_AieRegRead::execute(const SubCmdOptions& _options) const
 
   XBU::verbose("Option(s):");
   for (auto & aString : _options)
-    XBU::verbose(std::string(" ") + aString);
+    XBU::verbose(" " + aString);
 
   // Honor help option first
   if (std::find(_options.begin(), _options.end(), "--help") != _options.end()) {

--- a/src/runtime_src/core/tools/xbutil2/OO_HostMem.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_HostMem.cpp
@@ -52,7 +52,7 @@ OO_HostMem::execute(const SubCmdOptions& _options) const
 
   XBUtilities::verbose("Option(s):");
   for (auto & aString : _options)
-    XBUtilities::verbose(std::string(" ") + aString);
+    XBUtilities::verbose(" " + aString);
 
   // Honor help option first
   if (std::find(_options.begin(), _options.end(), "--help") != _options.end()) {

--- a/src/runtime_src/core/tools/xbutil2/OO_MemWrite.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_MemWrite.cpp
@@ -19,7 +19,6 @@ namespace XBU = XBUtilities;
 namespace po = boost::program_options;
 
 // System - Include Files
-#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <math.h>
@@ -123,9 +122,10 @@ OO_MemWrite::execute(const SubCmdOptions& _options) const
     // If count is unspecified, calculate based on the file size and block size
     uint64_t count = m_count;
     if (vm["count"].defaulted()) {
+      input_stream.seekg(0, input_stream.end);
       // tellg returns a signed value as the number of bytes. Validate the return code and
       // cast it into a useful format
-      auto nonvalidated_length = std::filesystem::file_size(m_inputFile);
+      auto nonvalidated_length = input_stream.tellg();
       if (nonvalidated_length < 0)
         throw std::runtime_error("Failed to get input file length");
 

--- a/src/runtime_src/core/tools/xbutil2/OO_MemWrite.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_MemWrite.cpp
@@ -19,6 +19,7 @@ namespace XBU = XBUtilities;
 namespace po = boost::program_options;
 
 // System - Include Files
+#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <math.h>
@@ -122,10 +123,9 @@ OO_MemWrite::execute(const SubCmdOptions& _options) const
     // If count is unspecified, calculate based on the file size and block size
     uint64_t count = m_count;
     if (vm["count"].defaulted()) {
-      input_stream.seekg(0, input_stream.end);
       // tellg returns a signed value as the number of bytes. Validate the return code and
       // cast it into a useful format
-      auto nonvalidated_length = input_stream.tellg();
+      auto nonvalidated_length = std::filesystem::file_size(m_inputFile);
       if (nonvalidated_length < 0)
         throw std::runtime_error("Failed to get input file length");
 

--- a/src/runtime_src/core/tools/xbutil2/OO_P2P.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_P2P.cpp
@@ -267,7 +267,7 @@ OO_P2P::execute(const SubCmdOptions& _options) const
 
   XBU::verbose("Option(s):");
   for (auto & aString : _options)
-    XBU::verbose(std::string(" ") + aString);
+    XBU::verbose(" " + aString);
 
   // Honor help option first
   if (std::find(_options.begin(), _options.end(), "--help") != _options.end()) {

--- a/src/runtime_src/core/tools/xbutil2/SubCmdAdvanced.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdAdvanced.cpp
@@ -50,8 +50,7 @@ SubCmdAdvanced::SubCmdAdvanced(bool _isHidden, bool _isDepricated, bool _isPreli
     : SubCmd("advanced", "Low level command operations")
     , m_help(false)
 {
-  const std::string longDescription = "Low level command operations.";
-  setLongDescription(longDescription);
+  setLongDescription("Low level command operations.");
   setExampleSyntax("");
   setIsHidden(_isHidden);
   setIsDeprecated(_isDepricated);

--- a/src/runtime_src/core/tools/xbutil2/SubCmdAdvanced.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdAdvanced.cpp
@@ -47,8 +47,8 @@ namespace po = boost::program_options;
 // ----- C L A S S   M E T H O D S -------------------------------------------
 
 SubCmdAdvanced::SubCmdAdvanced(bool _isHidden, bool _isDepricated, bool _isPreliminary)
-    : SubCmd("advanced", 
-             "Low level command operations")
+    : SubCmd("advanced", "Low level command operations")
+    , m_help(false)
 {
   const std::string longDescription = "Low level command operations.";
   setLongDescription(longDescription);
@@ -56,6 +56,18 @@ SubCmdAdvanced::SubCmdAdvanced(bool _isHidden, bool _isDepricated, bool _isPreli
   setIsHidden(_isHidden);
   setIsDeprecated(_isDepricated);
   setIsPreliminary(_isPreliminary);
+
+  m_commonOptions.add_options()
+    ("help", boost::program_options::bool_switch(&m_help), "Help to use this sub-command")
+  ;
+
+  addSubOption(std::make_shared<OO_MemRead>("read-mem"));
+  addSubOption(std::make_shared<OO_MemWrite>("write-mem"));
+// Only defined for embedded platform
+#ifndef ENABLE_NATIVE_SUBCMDS_AND_REPORTS
+  addSubOption(std::make_shared<OO_AieRegRead>("read-aie-reg"));
+  addSubOption(std::make_shared<OO_AieClockFreq>("aie-clock"));
+#endif
 }
 
 
@@ -64,69 +76,24 @@ SubCmdAdvanced::execute(const SubCmdOptions& _options) const
 {
   XBU::verbose("SubCommand: advanced");
 
-  // -- Common top level options ---
-  bool help = false;
-
-  po::options_description commonOptions("Common Options"); 
-  commonOptions.add_options()
-    ("help", boost::program_options::bool_switch(&help), "Help to use this sub-command")
-  ;
-
-  po::options_description hiddenOptions("Hidden Options"); 
-
-  // -- Define the supporting option options ----
-  SubOptionOptions subOptionOptions;
-  subOptionOptions.emplace_back(std::make_shared<OO_MemRead>("read-mem"));
-  subOptionOptions.emplace_back(std::make_shared<OO_MemWrite>("write-mem"));
-// Only defined for embedded platform
-#ifndef ENABLE_NATIVE_SUBCMDS_AND_REPORTS
-  subOptionOptions.emplace_back(std::make_shared<OO_AieRegRead>("read-aie-reg"));
-  subOptionOptions.emplace_back(std::make_shared<OO_AieClockFreq>("aie-clock"));
-#endif
-
-  for (auto & subOO : subOptionOptions) {
-    if (subOO->isHidden()) 
-      hiddenOptions.add_options()(subOO->longName().c_str(), subOO->description().c_str());
-    else
-      commonOptions.add_options()(subOO->longName().c_str(), subOO->description().c_str());
-    subOO->setExecutable(getExecutableName());
-    subOO->setCommand(getName());
-  }
-
-  po::options_description allOptions("All Options");
-  allOptions.add(commonOptions);
-  allOptions.add(hiddenOptions);
-
-  po::positional_options_description positionals;
-
   // =========== Process the options ========================================
 
   // 1) Process the common top level options 
   po::variables_map vm;
   // Used for the suboption arguments
-  auto topOptions = process_arguments(vm, _options, commonOptions, hiddenOptions, positionals, subOptionOptions, false);
-  // DRC check between suboptions
-  for (unsigned int index1 = 0; index1 < subOptionOptions.size(); ++index1)
-    for (unsigned int index2 = index1 + 1; index2 < subOptionOptions.size(); ++index2)
-      conflictingOptions(vm, subOptionOptions[index1]->longName(), subOptionOptions[index2]->longName());
+  auto topOptions = process_arguments(vm, _options, false);
 
-  // Find the subOption;
-  std::shared_ptr<OptionOptions> optionOption;
-  for (auto& subOO : subOptionOptions) {
-    if (vm.count(subOO->longName().c_str()) != 0) {
-      optionOption = subOO;
-      break;
-    }
-  }
+  // Check for a suboption
+  auto optionOption = checkForSubOption(vm);
 
   // No suboption print help
   if (!optionOption) {
-    printHelp(commonOptions, hiddenOptions, subOptionOptions);
+    printHelp();
     return;
   }
 
   // 2) Process the top level options
-  if (help)
+  if (m_help)
     topOptions.push_back("--help");
 
   optionOption->setGlobalOptions(getGlobalOptions());

--- a/src/runtime_src/core/tools/xbutil2/SubCmdAdvanced.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdAdvanced.h
@@ -26,6 +26,9 @@ class SubCmdAdvanced : public SubCmd {
  public:
   SubCmdAdvanced(bool _isHidden, bool _isDepricated, bool _isPreliminary);
   virtual ~SubCmdAdvanced() {};
+
+ private:
+    bool m_help;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdConfigure.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdConfigure.cpp
@@ -38,6 +38,8 @@ namespace po = boost::program_options;
 
 // ----- C L A S S   M E T H O D S -------------------------------------------
 
+bool help = false;
+
 SubCmdConfigure::SubCmdConfigure(bool _isHidden, bool _isDepricated, bool _isPreliminary)
     : SubCmd("configure", 
              "Device and host configuration")
@@ -48,72 +50,37 @@ SubCmdConfigure::SubCmdConfigure(bool _isHidden, bool _isDepricated, bool _isPre
   setIsHidden(_isHidden);
   setIsDeprecated(_isDepricated);
   setIsPreliminary(_isPreliminary);
+
+  m_commonOptions.add_options()
+    ("help", boost::program_options::bool_switch(&help), "Help to use this sub-command")
+  ;
+
+  addSubOption(std::make_shared<OO_HostMem>("host-mem"));
+  addSubOption(std::make_shared<OO_P2P>("p2p"));
 }
 
 
 void
 SubCmdConfigure::execute(const SubCmdOptions& _options) const
 {
-  // -- Common top level options ---
-  bool help = false;
-
-  po::options_description commonOptions("Common Options"); 
-  commonOptions.add_options()
-    ("help", boost::program_options::bool_switch(&help), "Help to use this sub-command")
-  ;
-
-  po::options_description hiddenOptions("Hidden Options"); 
-
-  // -- Define the supporting option options ----
-  SubOptionOptions subOptionOptions;
-  subOptionOptions.emplace_back(std::make_shared<OO_HostMem>("host-mem"));
-  subOptionOptions.emplace_back(std::make_shared<OO_P2P>("p2p"));
-
-  for (auto & subOO : subOptionOptions) {
-    if (subOO->isHidden()) 
-      hiddenOptions.add_options()(subOO->longName().c_str(), subOO->description().c_str());
-    else
-      commonOptions.add_options()(subOO->longName().c_str(), subOO->description().c_str());
-    subOO->setExecutable(getExecutableName());
-    subOO->setCommand(getName());
-  }
-
-  po::options_description allOptions("All Options");
-  allOptions.add(commonOptions);
-  allOptions.add(hiddenOptions);
-
-  po::positional_options_description positionals;
-
   // =========== Process the options ========================================
   po::variables_map vm;
   // Used for the suboption arguments
-  auto topOptions = process_arguments(vm, _options, commonOptions, hiddenOptions, positionals, subOptionOptions, false);
+  auto topOptions = process_arguments(vm, _options, false);
 
-  // Mutual DRC
-  for (unsigned int index1 = 0; index1 < subOptionOptions.size(); ++index1)
-    for (unsigned int index2 = index1 + 1; index2 < subOptionOptions.size(); ++index2)
-      conflictingOptions(vm, subOptionOptions[index1]->longName(), subOptionOptions[index2]->longName());
-
-
-  // Find the subOption;
-  std::shared_ptr<OptionOptions> optionOption;
-  for (auto& subOO : subOptionOptions) {
-    if (vm.count(subOO->longName().c_str()) != 0) {
-      optionOption = subOO;
-      break;
-    }
-  }
+  // Check for a suboption
+  auto optionOption = checkForSubOption(vm);
 
   // No suboption print help
   if (!optionOption) {
     if (help) {
-      printHelp(commonOptions, hiddenOptions, subOptionOptions);
+      printHelp();
       return;
     }
     // If help was not requested and additional options dont match we must throw to prevent
     // invalid positional arguments from passing through without warnings
     std::cerr << "ERROR: Suboption missing" << std::endl;
-    printHelp(commonOptions, hiddenOptions, subOptionOptions);
+    printHelp();
     throw xrt_core::error(std::errc::operation_canceled);
   }
 

--- a/src/runtime_src/core/tools/xbutil2/SubCmdConfigure.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdConfigure.cpp
@@ -38,21 +38,19 @@ namespace po = boost::program_options;
 
 // ----- C L A S S   M E T H O D S -------------------------------------------
 
-bool help = false;
-
 SubCmdConfigure::SubCmdConfigure(bool _isHidden, bool _isDepricated, bool _isPreliminary)
     : SubCmd("configure", 
              "Device and host configuration")
+    , m_help(false)
 {
-  const std::string longDescription = "Device and host configuration.";
-  setLongDescription(longDescription);
+  setLongDescription("Device and host configuration.");
   setExampleSyntax("");
   setIsHidden(_isHidden);
   setIsDeprecated(_isDepricated);
   setIsPreliminary(_isPreliminary);
 
   m_commonOptions.add_options()
-    ("help", boost::program_options::bool_switch(&help), "Help to use this sub-command")
+    ("help", boost::program_options::bool_switch(&m_help), "Help to use this sub-command")
   ;
 
   addSubOption(std::make_shared<OO_HostMem>("host-mem"));
@@ -73,7 +71,7 @@ SubCmdConfigure::execute(const SubCmdOptions& _options) const
 
   // No suboption print help
   if (!optionOption) {
-    if (help) {
+    if (m_help) {
       printHelp();
       return;
     }
@@ -85,7 +83,7 @@ SubCmdConfigure::execute(const SubCmdOptions& _options) const
   }
 
   // 2) Process the top level options
-  if (help)
+  if (m_help)
     topOptions.push_back("--help");
 
   optionOption->setGlobalOptions(getGlobalOptions());

--- a/src/runtime_src/core/tools/xbutil2/SubCmdConfigure.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdConfigure.h
@@ -26,6 +26,9 @@ class SubCmdConfigure : public SubCmd {
  public:
   SubCmdConfigure(bool _isHidden, bool _isDepricated, bool _isPreliminary);
   virtual ~SubCmdConfigure() {};
+
+ private:
+  bool m_help;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
@@ -88,9 +88,8 @@ SubCmdExamine::SubCmdExamine(bool _isHidden, bool _isDepricated, bool _isPrelimi
     , m_output("")
     , m_help(false)
 {
-  const std::string longDescription = "This command will 'examine' the state of the system/device and will"
-                                      " generate a report of interest in a text or JSON format.";
-  setLongDescription(longDescription);
+  setLongDescription( "This command will 'examine' the state of the system/device and will"
+                      " generate a report of interest in a text or JSON format.");
   setExampleSyntax("");
   setIsHidden(_isHidden);
   setIsDeprecated(_isDepricated);

--- a/src/runtime_src/core/tools/xbutil2/SubCmdExamine.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdExamine.h
@@ -25,6 +25,14 @@ class SubCmdExamine : public SubCmd {
 
  public:
   SubCmdExamine(bool _isHidden, bool _isDepricated, bool _isPreliminary);
+
+ private:
+  std::string               m_device;
+  std::vector<std::string>  m_reportNames; // Default set of report names are determined if there is a device or not
+  std::vector<std::string>  m_elementsFilter;
+  std::string               m_format; // Don't define default output format.  Will be defined later.
+  std::string               m_output;
+  bool                      m_help;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdProgram.cpp
@@ -24,6 +24,7 @@ namespace po = boost::program_options;
 
 // System - Include Files
 #include <iostream>
+#include <filesystem>
 #include <fstream>
 
 // ----- C L A S S   M E T H O D S -------------------------------------------
@@ -82,9 +83,7 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
     if (!stream)
       throw xrt_core::error(boost::str(boost::format("Could not open %s for reading") % m_xclbin));
 
-    stream.seekg(0,stream.end);
-    size_t size = stream.tellg();
-    stream.seekg(0,stream.beg);
+    size_t size = std::filesystem::file_size(m_xclbin);
 
     std::vector<char> raw(size);
     stream.read(raw.data(),size);

--- a/src/runtime_src/core/tools/xbutil2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdProgram.cpp
@@ -35,8 +35,7 @@ SubCmdProgram::SubCmdProgram(bool _isHidden, bool _isDepricated, bool _isPrelimi
     , m_xclbin("")
     , m_help(false)
 {
-  const std::string longDescription = "Programs the given acceleration image into the device's shell.";
-  setLongDescription(longDescription);
+  setLongDescription("Programs the given acceleration image into the device's shell.");
   setExampleSyntax("");
   setIsHidden(_isHidden);
   setIsDeprecated(_isDepricated);

--- a/src/runtime_src/core/tools/xbutil2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdProgram.cpp
@@ -24,7 +24,6 @@ namespace po = boost::program_options;
 
 // System - Include Files
 #include <iostream>
-#include <filesystem>
 #include <fstream>
 
 // ----- C L A S S   M E T H O D S -------------------------------------------
@@ -83,7 +82,9 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
     if (!stream)
       throw xrt_core::error(boost::str(boost::format("Could not open %s for reading") % m_xclbin));
 
-    size_t size = std::filesystem::file_size(m_xclbin);
+    stream.seekg(0,stream.end);
+    size_t size = stream.tellg();
+    stream.seekg(0,stream.beg);
 
     std::vector<char> raw(size);
     stream.read(raw.data(),size);

--- a/src/runtime_src/core/tools/xbutil2/SubCmdProgram.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdProgram.h
@@ -25,6 +25,11 @@ class SubCmdProgram : public SubCmd {
 
  public:
   SubCmdProgram(bool _isHidden, bool _isDepricated, bool _isPreliminary);
+
+ private:
+  std::string m_device;
+  std::string m_xclbin;
+  bool        m_help;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdReset.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdReset.cpp
@@ -57,9 +57,8 @@ supported(std::string resetType) {
   std::vector<std::string> vec { "user" };
   std::vector<std::string>::iterator it;
   it = std::find (vec.begin(), vec.end(), resetType); 
-  if (it == vec.end()) {
+  if (it == vec.end())
     throw xrt_core::error(std::errc::operation_canceled, "Reset type not supported");
-  }
 }
 
 SubCmdReset::SubCmdReset(bool _isHidden, bool _isDepricated, bool _isPreliminary)
@@ -69,8 +68,7 @@ SubCmdReset::SubCmdReset(bool _isHidden, bool _isDepricated, bool _isPreliminary
     , m_resetType("user")
     , m_help(false)
 {
-  const std::string longDescription = "Resets the given device.";
-  setLongDescription(longDescription);
+  setLongDescription( "Resets the given device.");
   setExampleSyntax("");
   setIsHidden(_isHidden);
   setIsDeprecated(_isDepricated);

--- a/src/runtime_src/core/tools/xbutil2/SubCmdReset.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdReset.cpp
@@ -58,7 +58,7 @@ supported(std::string resetType) {
   std::vector<std::string>::iterator it;
   it = std::find (vec.begin(), vec.end(), resetType); 
   if (it == vec.end()) {
-    throw xrt_core::error(-ENODEV, "reset not supported");
+    throw xrt_core::error(std::errc::operation_canceled, "Reset type not supported");
   }
 }
 
@@ -66,7 +66,7 @@ SubCmdReset::SubCmdReset(bool _isHidden, bool _isDepricated, bool _isPreliminary
     : SubCmd("reset", 
              "Resets the given device")
     , m_device("")
-    , m_resetType("")
+    , m_resetType("user")
     , m_help(false)
 {
   const std::string longDescription = "Resets the given device.";

--- a/src/runtime_src/core/tools/xbutil2/SubCmdReset.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdReset.h
@@ -25,6 +25,11 @@ class SubCmdReset : public SubCmd {
 
  public:
   SubCmdReset(bool _isHidden, bool _isDepricated, bool _isPreliminary);
+
+ private:
+  std::string m_device;
+  std::string m_resetType;
+  bool        m_help;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -31,7 +31,6 @@ namespace po = boost::program_options;
 
 // System - Include Files
 #include <algorithm>
-#include <filesystem>
 #include <iostream>
 #include <regex>
 #include <sstream>
@@ -696,7 +695,9 @@ program_xclbin(const xclDeviceHandle hdl, const std::string& xclbin, boost::prop
     return 1;
   }
 
-  size_t size = std::filesystem::file_size(xclbin);
+  stream.seekg(0,stream.end);
+  size_t size = stream.tellg();
+  stream.seekg(0,stream.beg);
 
   std::vector<char> raw(size);
   stream.read(raw.data(),size);

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -31,6 +31,7 @@ namespace po = boost::program_options;
 
 // System - Include Files
 #include <algorithm>
+#include <filesystem>
 #include <iostream>
 #include <regex>
 #include <sstream>
@@ -113,7 +114,7 @@ searchSSV2Xclbin(const std::string& logic_uuid,
           boost::filesystem::symlink_option::recurse), end; iter != end;) {
       std::string name = iter->path().string();
       std::smatch cm;
-      if (!boost::filesystem::is_directory(boost::filesystem::path(name.c_str()))) {
+      if (!boost::filesystem::is_directory(boost::filesystem::path(name))) {
         iter.no_push();
       }
       else {
@@ -695,9 +696,7 @@ program_xclbin(const xclDeviceHandle hdl, const std::string& xclbin, boost::prop
     return 1;
   }
 
-  stream.seekg(0,stream.end);
-  size_t size = stream.tellg();
-  stream.seekg(0,stream.beg);
+  size_t size = std::filesystem::file_size(xclbin);
 
   std::vector<char> raw(size);
   stream.read(raw.data(),size);

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -1592,24 +1592,7 @@ run_tests_on_devices( std::shared_ptr<xrt_core::device> &device,
   return has_failures;
 }
 
-}
-//end anonymous namespace
-
-// ----- C L A S S   M E T H O D S -------------------------------------------
-
-SubCmdValidate::SubCmdValidate(bool _isHidden, bool _isDepricated, bool _isPreliminary)
-    : SubCmd("validate",
-             "Validates the basic shell acceleration functionality")
-{
-  const std::string longDescription = "Validates the given device by executing the platform's validate executable.";
-  setLongDescription(longDescription);
-  setExampleSyntax("");
-  setIsHidden(_isHidden);
-  setIsDeprecated(_isDepricated);
-  setIsPreliminary(_isPreliminary);
-}
-
-XBU::VectorPairStrings
+static XBU::VectorPairStrings
 getTestNameDescriptions(bool addAdditionOptions)
 {
   XBU::VectorPairStrings reportDescriptionCollection;
@@ -1627,6 +1610,41 @@ getTestNameDescriptions(bool addAdditionOptions)
   }
 
   return reportDescriptionCollection;
+}
+
+}
+//end anonymous namespace
+
+// ----- C L A S S   M E T H O D S -------------------------------------------
+
+  // -- Build up the format options
+static const auto formatOptionValues = XBU::create_suboption_list_string(Report::getSchemaDescriptionVector());
+static const auto testNameDescription = getTestNameDescriptions(true /* Add "all" and "quick" options*/);
+static const auto formatRunValues = XBU::create_suboption_list_string(testNameDescription);
+
+
+
+SubCmdValidate::SubCmdValidate(bool _isHidden, bool _isDepricated, bool _isPreliminary)
+    : SubCmd("validate",
+             "Validates the basic shell acceleration functionality")
+{
+  const std::string longDescription = "Validates the given device by executing the platform's validate executable.";
+  setLongDescription(longDescription);
+  setExampleSyntax("");
+  setIsHidden(_isHidden);
+  setIsDeprecated(_isDepricated);
+  setIsPreliminary(_isPreliminary);
+
+  m_commonOptions.add_options()
+    ("device,d", boost::program_options::value<decltype(m_device)>(&m_device), "The device of interest. This is specified as follows:\n"
+                                                                           "  <BDF> - Bus:Device.Function (e.g., 0000:d8:00.0)")
+    ("format,f", boost::program_options::value<decltype(m_format)>(&m_format), (std::string("Report output format. Valid values are:\n") + formatOptionValues).c_str() )
+    ("run,r", boost::program_options::value<decltype(m_tests_to_run)>(&m_tests_to_run)->multitoken(), (std::string("Run a subset of the test suite.  Valid options are:\n") + formatRunValues).c_str() )
+    ("output,o", boost::program_options::value<decltype(m_output)>(&m_output), "Direct the output to the given file")
+    ("param", boost::program_options::value<decltype(m_param)>(&m_param), "Extended parameter for a given test. Format: <test-name>:<key>:<value>")
+    ("path,p", boost::program_options::value<decltype(m_xclbin_location)>(&m_xclbin_location), "Path to the directory containing validate xclbins")
+    ("help", boost::program_options::bool_switch(&m_help), "Help to use this sub-command")
+  ;
 }
 
 /*
@@ -1675,94 +1693,68 @@ void
 SubCmdValidate::execute(const SubCmdOptions& _options) const
 
 {
-  // -- Build up the format options
-  const std::string formatOptionValues = XBU::create_suboption_list_string(Report::getSchemaDescriptionVector());
-
-  const XBU::VectorPairStrings testNameDescription = getTestNameDescriptions(true /* Add "all" and "quick" options*/);
-  const std::string formatRunValues = XBU::create_suboption_list_string(testNameDescription);
-
-  // -- Retrieve and parse the subcommand options -----------------------------
-  std::string device_str;
-  std::vector<std::string> testsToRun = {"all"};
-  std::string sFormat = "JSON";
-  std::string sOutput;
-  std::string sParam;
-  std::string xclbin_location;
-  bool help = false;
-
-  po::options_description commonOptions("Commmon Options");
-  commonOptions.add_options()
-    ("device,d", boost::program_options::value<decltype(device_str)>(&device_str), "The device of interest. This is specified as follows:\n"
-                                                                           "  <BDF> - Bus:Device.Function (e.g., 0000:d8:00.0)")
-    ("format,f", boost::program_options::value<decltype(sFormat)>(&sFormat), (std::string("Report output format. Valid values are:\n") + formatOptionValues).c_str() )
-    ("run,r", boost::program_options::value<decltype(testsToRun)>(&testsToRun)->multitoken(), (std::string("Run a subset of the test suite.  Valid options are:\n") + formatRunValues).c_str() )
-    ("output,o", boost::program_options::value<decltype(sOutput)>(&sOutput), "Direct the output to the given file")
-    ("param", boost::program_options::value<decltype(sParam)>(&sParam), "Extended parameter for a given test. Format: <test-name>:<key>:<value>")
-    ("path,p", boost::program_options::value<decltype(xclbin_location)>(&xclbin_location), "Path to the directory containing validate xclbins")
-    ("help", boost::program_options::bool_switch(&help), "Help to use this sub-command")
-  ;
-
-  po::options_description hiddenOptions("Hidden Options");
-
   // Parse sub-command ...
   po::variables_map vm;
-  process_arguments(vm, _options, commonOptions, hiddenOptions);
+  process_arguments(vm, _options);
 
   // Check to see if help was requested or no command was found
-  if (help) {
-    printHelp(commonOptions, hiddenOptions, false, extendedKeysOptions());
+  if (m_help) {
+    printHelp(false, extendedKeysOptions());
     return;
   }
 
   // -- Process the options --------------------------------------------
   Report::SchemaVersion schemaVersion = Report::SchemaVersion::unknown;    // Output schema version
   std::vector<std::string> param;
+  std::vector<std::string> validatedTests;
+  std::string validateXclbinPath = m_xclbin_location;
   try {
     // Output Format
-    schemaVersion = Report::getSchemaDescription(sFormat).schemaVersion;
+    schemaVersion = Report::getSchemaDescription(m_format).schemaVersion;
     if (schemaVersion == Report::SchemaVersion::unknown)
-      throw xrt_core::error((boost::format("Unknown output format: '%s'") % sFormat).str());
+      throw xrt_core::error((boost::format("Unknown output format: '%s'") % m_format).str());
 
     // Output file
-    if (!sOutput.empty() && !XBU::getForce() && boost::filesystem::exists(sOutput))
-        throw xrt_core::error((boost::format("Output file already exists: '%s'") % sOutput).str());
+    if (!m_output.empty() && !XBU::getForce() && boost::filesystem::exists(m_output))
+        throw xrt_core::error((boost::format("Output file already exists: '%s'") % m_output).str());
 
-    if (testsToRun.empty())
+    if (m_tests_to_run.empty())
       throw std::runtime_error("No test given to validate against.");
 
     // Validate the user test requests
-    for (auto &userTestName : testsToRun) {
-      userTestName = get_test_name(userTestName);
+    for (auto &userTestName : m_tests_to_run) {
+      const auto validatedTestName = get_test_name(userTestName);
 
-      if ((userTestName == "all") && (testsToRun.size() > 1))
+      if ((validatedTestName == "all") && (m_tests_to_run.size() > 1))
         throw xrt_core::error("The 'all' value for the tests to run cannot be used with any other named tests.");
 
-      if ((userTestName == "quick") && (testsToRun.size() > 1))
+      if ((validatedTestName == "quick") && (m_tests_to_run.size() > 1))
         throw xrt_core::error("The 'quick' value for the tests to run cannot be used with any other name tests.");
 
       // Verify the current user test request exists in the test suite
-      doesTestExist(userTestName, testNameDescription);
+      doesTestExist(validatedTestName, testNameDescription);
+      validatedTests.push_back(validatedTestName);
     }
 
     // check if xclbin folder path is provided
-    if (!xclbin_location.empty()) {
+    if (!validateXclbinPath.empty()) {
       XBU::verbose("Sub command: --path");
-      if (!boost::filesystem::exists(xclbin_location) || !boost::filesystem::is_directory(xclbin_location))
-        throw xrt_core::error((boost::format("Invalid directory path : '%s'") % xclbin_location).str());
-      if (xclbin_location.compare(".") == 0 || xclbin_location.compare("./") == 0)
-        xclbin_location = boost::filesystem::current_path().string();
-      if (xclbin_location.back() != '/')
-        xclbin_location.append("/");
+      if (!boost::filesystem::exists(validateXclbinPath) || !boost::filesystem::is_directory(validateXclbinPath))
+        throw xrt_core::error((boost::format("Invalid directory path : '%s'") % validateXclbinPath).str());
+      if (validateXclbinPath.compare(".") == 0 || validateXclbinPath.compare("./") == 0)
+        validateXclbinPath = boost::filesystem::current_path().string();
+      if (validateXclbinPath.back() != '/')
+        validateXclbinPath.append("/");
     }
 
     //check if param option is provided
-    if (!sParam.empty()) {
+    if (!m_param.empty()) {
       XBU::verbose("Sub command: --param");
-      boost::split(param, sParam, boost::is_any_of(":")); // eg: dma:block-size:1024
+      boost::split(param, m_param, boost::is_any_of(":")); // eg: dma:block-size:1024
 
       //check parameter format
       if (param.size() != 3)
-        throw xrt_core::error((boost::format("Invalid parameter format (expected 3 positional arguments): '%s'") % sParam).str());
+        throw xrt_core::error((boost::format("Invalid parameter format (expected 3 positional arguments): '%s'") % m_param).str());
 
       //check test case name
       doesTestExist(param[0], testNameDescription);
@@ -1777,7 +1769,7 @@ SubCmdValidate::execute(const SubCmdOptions& _options) const
   } catch (const xrt_core::error& e) {
     // Catch only the exceptions that we have generated earlier
     std::cerr << boost::format("ERROR: %s\n") % e.what();
-    printHelp(commonOptions, hiddenOptions, false, extendedKeysOptions());
+    printHelp(false, extendedKeysOptions());
     throw xrt_core::error(std::errc::operation_canceled);
   }
 
@@ -1785,7 +1777,7 @@ SubCmdValidate::execute(const SubCmdOptions& _options) const
   // Find device of interest
   std::shared_ptr<xrt_core::device> device;
   try {
-    device = XBU::get_device(boost::algorithm::to_lower_copy(device_str), true /*inUserDomain*/);
+    device = XBU::get_device(boost::algorithm::to_lower_copy(m_device), true /*inUserDomain*/);
   } catch (const std::runtime_error& e) {
     // Catch only the exceptions that we have generated earlier
     std::cerr << boost::format("ERROR: %s\n") % e.what();
@@ -1800,7 +1792,7 @@ SubCmdValidate::execute(const SubCmdOptions& _options) const
   for (size_t index = 0; index < testSuite.size(); ++index) {
     std::string testSuiteName = get_test_name(testSuite[index].ptTest.get("name","<unknown>"));
     // The all option enqueues all test suites not marked explicit
-    if (testsToRun[0] == "all") {
+    if (validatedTests[0] == "all") {
       // Do not queue test suites that must be explicitly passed in
       if (testSuite[index].ptTest.get<bool>("explicit"))
         continue;
@@ -1809,31 +1801,31 @@ SubCmdValidate::execute(const SubCmdOptions& _options) const
       if (!param.empty() && boost::equals(param[0], testSuiteName)) {
         testSuite[index].ptTest.put(param[1], param[2]);
       }
-      if (!xclbin_location.empty())
-        testSuite[index].ptTest.put("xclbin_directory", xclbin_location);
+      if (!validateXclbinPath.empty())
+        testSuite[index].ptTest.put("xclbin_directory", validateXclbinPath);
       continue;
     }
 
     // The quick test option enqueues only the first three test suites
-    if (testsToRun[0] == "quick") {
+    if (validatedTests[0] == "quick") {
       testObjectsToRun.push_back(&testSuite[index]);
-      if (!xclbin_location.empty())
-        testSuite[index].ptTest.put("xclbin_directory", xclbin_location);
+      if (!validateXclbinPath.empty())
+        testSuite[index].ptTest.put("xclbin_directory", validateXclbinPath);
       if (index == 3)
         break;
     }
 
     // Logic for individually defined tests
     // Enqueue the matching test suites to be executed
-    for (const auto & testName : testsToRun) {
+    for (const auto & testName : validatedTests) {
       if (boost::equals(testName, testSuiteName)) {
         testObjectsToRun.push_back(&testSuite[index]);
         // add custom param to the ptree if available
         if (!param.empty() && boost::equals(param[0], testSuiteName)) {
           testSuite[index].ptTest.put(param[1], param[2]);
         }
-        if (!xclbin_location.empty())
-          testSuite[index].ptTest.put("xclbin_directory", xclbin_location);
+        if (!validateXclbinPath.empty())
+          testSuite[index].ptTest.put("xclbin_directory", validateXclbinPath);
         break;
       }
     }
@@ -1844,15 +1836,15 @@ SubCmdValidate::execute(const SubCmdOptions& _options) const
   bool has_failures = run_tests_on_devices(device, schemaVersion, testObjectsToRun, oSchemaOutput);
 
   // -- Write output file ----------------------------------------------
-  if (!sOutput.empty()) {
+  if (!m_output.empty()) {
     std::ofstream fOutput;
-    fOutput.open(sOutput, std::ios::out | std::ios::binary);
+    fOutput.open(m_output, std::ios::out | std::ios::binary);
     if (!fOutput.is_open())
-      throw xrt_core::error((boost::format("Unable to open the file '%s' for writing.") % sOutput).str());
+      throw xrt_core::error((boost::format("Unable to open the file '%s' for writing.") % m_output).str());
 
     fOutput << oSchemaOutput.str();
 
-    std::cout << boost::format("Successfully wrote the %s file: %s") % sFormat % sOutput << std::endl;
+    std::cout << boost::format("Successfully wrote the %s file: %s") % m_format % m_output << std::endl;
   }
 
   if (has_failures == true)

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -1628,8 +1628,7 @@ SubCmdValidate::SubCmdValidate(bool _isHidden, bool _isDepricated, bool _isPreli
     : SubCmd("validate",
              "Validates the basic shell acceleration functionality")
 {
-  const std::string longDescription = "Validates the given device by executing the platform's validate executable.";
-  setLongDescription(longDescription);
+  setLongDescription("Validates the given device by executing the platform's validate executable.");
   setExampleSyntax("");
   setIsHidden(_isHidden);
   setIsDeprecated(_isDepricated);

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -1480,9 +1480,9 @@ get_platform_info(const std::shared_ptr<xrt_core::device>& device,
   for (auto& kp : platforms) {
     const boost::property_tree::ptree& pt_platform = kp.second;
     const boost::property_tree::ptree& pt_static_region = pt_platform.get_child("static_region", empty_ptree);
-    ptTree.put("platform", pt_static_region.get<std::string>("vbnv", "N/A"));
-    ptTree.put("platform_id", pt_static_region.get<std::string>("logic_uuid", "N/A"));
-    ptTree.put("sc_version", pt_platform.get<std::string>("controller.satellite_controller.version", "N/A"));
+    ptTree.put("platform", pt_static_region.get<std::string>("vbnv", XBU::data_not_available));
+    ptTree.put("platform_id", pt_static_region.get<std::string>("logic_uuid", XBU::data_not_available));
+    ptTree.put("sc_version", pt_platform.get<std::string>("controller.satellite_controller.version", XBU::data_not_available));
 
   }
 

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -1626,6 +1626,8 @@ static const auto formatRunValues = XBU::create_suboption_list_string(testNameDe
 SubCmdValidate::SubCmdValidate(bool _isHidden, bool _isDepricated, bool _isPreliminary)
     : SubCmd("validate",
              "Validates the basic shell acceleration functionality")
+    , m_tests_to_run({"all"})
+    , m_format("JSON")
 {
   setLongDescription("Validates the given device by executing the platform's validate executable.");
   setExampleSyntax("");

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.h
@@ -25,6 +25,15 @@ class SubCmdValidate : public SubCmd {
 
  public:
   SubCmdValidate(bool _isHidden, bool _isDepricated, bool _isPreliminary);
+
+ private:
+  std::string               m_device;
+  std::vector<std::string>  m_tests_to_run;
+  std::string               m_format;
+  std::string               m_output;
+  std::string               m_param;
+  std::string               m_xclbin_location;
+  bool                      m_help;
 };
 
 #endif


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/VITIS-6253
Certain subcommands contain options that are mutually exclusive, xbmgmt program as a prime example. To fix this issue those subcommands should be broken into separate options.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Help menu did not specify which options are mutually exclusive from one another

#### How problem was solved, alternative solutions (if any) and why they were rejected
Refactored how SubCommands and OptionOptions classes generate their help menu and store their options.

#### Risks (if any) associated the changes in the commit
This is a major change to how the SubCommands create their options. Theoretically everything will be exactly the same as before when using the tools and examining the help menu. Hopefully that is the case!

#### What has been tested and how, request additional testing if necessary
Tested each subcommand to make sure the help menu looks roughly the same as before and functions as expected.

#### Documentation impact (if any)
None.