### PR TITLE
CR-1141702 allow pdi flash and basic operation when xgq regular servi…

### DIFF
--- a/src/runtime_src/core/include/xgq_cmd_vmr.h
+++ b/src/runtime_src/core/include/xgq_cmd_vmr.h
@@ -46,6 +46,11 @@
 /* The Clock IP use index 0 for data, 1 for kernel, 2 for sys, 3 for sys1 */ 
 #define XGQ_CLOCK_WIZ_MAX_RES           4
 
+/* VMR Identify Command Version Major and Minor Numbers */
+#define VMR_IDENTIFY_CMD_MAJOR                  1
+#define VMR_IDENTIFY_CMD_MINOR                  0
+
+
 /**
  * clock scaling request types
  */
@@ -86,6 +91,14 @@ enum xgq_cmd_clock_req_type {
 	XGQ_CMD_CLOCK_WIZARD 		= 0x0,
 	XGQ_CMD_CLOCK_COUNTER		= 0x1,
 	XGQ_CMD_CLOCK_SCALE		= 0x2,
+};
+
+/**
+ * clock scaling request types
+ */
+enum xgq_cmd_clock_scaling_req_type {
+	XGQ_CMD_CLK_SCALING_GET_STATUS	= 0x1,
+	XGQ_CMD_CLK_SCALING_SET_OVERRIDE= 0x2,
 };
 
 /**
@@ -361,6 +374,17 @@ struct xgq_cmd_cq_vmr_payload {
 };
 
 /*
+ * struct xgq_cmd_cq_vmr_identify_payload: Identify Command payload
+ *
+ * VMR Identify Command
+*/
+struct xgq_cmd_cq_vmr_identify_payload {
+    uint16_t ver_major;
+    uint16_t ver_minor;
+    uint32_t resvd;
+};
+
+/*
  * struct xgq_cmd_cq: vmr completion command
  *
  * @hdr:		vmr completion command header
@@ -380,6 +404,7 @@ struct xgq_cmd_cq {
 		struct xgq_cmd_cq_log_page_payload	cq_log_payload;
 		struct xgq_cmd_cq_data_payload		cq_xclbin_payload;
 		struct xgq_cmd_cq_clk_scaling_payload cq_clk_scaling_payload;
+		struct xgq_cmd_cq_vmr_identify_payload  cq_vmr_identify_payload;
 	};
 	uint32_t rcode;
 };

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
@@ -577,6 +577,25 @@ static irqreturn_t xgq_irq_handler(int irq, void *arg)
 }
 #endif
 
+static enum xgq_cmd_opcode opcode[] = {
+	XGQ_CMD_OP_DOWNLOAD_PDI,
+	XGQ_CMD_OP_PROGRAM_SCFW,
+	XGQ_CMD_OP_VMR_CONTROL,
+	XGQ_CMD_OP_IDENTIFY,
+};
+
+bool vmr_xgq_basic_op(struct xocl_xgq_vmr_cmd *cmd)
+{
+	int i = 0;
+
+	for (i = 0; i < ARRAY_SIZE(opcode); i++) {
+		if (cmd->xgq_cmd_entry.hdr.opcode == opcode[i])
+			return true;
+	}
+
+	return false;
+}
+
 /*
  * submit new cmd into XGQ SQ(submition queue)
  */
@@ -586,7 +605,13 @@ static int submit_cmd(struct xocl_xgq_vmr *xgq, struct xocl_xgq_vmr_cmd *cmd)
 	int rval = 0;
 
 	mutex_lock(&xgq->xgq_lock);
-	if (xgq->xgq_halted) {
+	/*
+	 * We might not support newer xgq commands after checking VMR
+	 * supported XGQ version, but those basic ops should always
+	 * be supported and unchanged. They will provide basic operations
+	 * across older and newer VMR versions.
+	 */
+	if (xgq->xgq_halted && !vmr_xgq_basic_op(cmd)) {
 		XGQ_ERR(xgq, "xgq service is halted");
 		rval = -EIO;
 		goto done;
@@ -1010,7 +1035,10 @@ static int xgq_firewall_op(struct platform_device *pdev, enum xgq_cmd_log_page_t
 	u32 address = 0;
 	u32 len = 0;
 
-	/* skip periodic firewall check when xgq service is halted */
+	/*
+	 * avoid warning messages, skip periodic firewall check
+	 * when xgq service is halted
+	 */
 	if (xgq->xgq_halted)
 		return 0;
 
@@ -1612,10 +1640,6 @@ static int vmr_control_op(struct platform_device *pdev,
 	int ret = 0;
 	int id = 0;
 
-	if (xgq->xgq_halted) {
-		XGQ_WARN(xgq, "VMR XGQ service is haulted. skip.");
-		return -EIO;
-	}
 	cmd = kmalloc(sizeof(*cmd), GFP_KERNEL);
 	if (!cmd) {
 		XGQ_ERR(xgq, "kmalloc failed, retry");
@@ -1683,6 +1707,100 @@ static int vmr_status_query(struct platform_device *pdev)
 	return vmr_control_op(pdev, XGQ_CMD_VMR_QUERY);
 }
 
+struct xgq_vmr_supported_ver {
+	uint16_t major;
+	uint16_t minor;
+} supported_vers[] = {
+	{1, 0},
+};
+
+static bool xgq_vmr_supported_version(u16 major, u16 minor)
+{
+	int i = 0;
+
+	for (i = 0; i < ARRAY_SIZE(supported_vers); i++) {
+		if (supported_vers[i].major == major &&
+		    supported_vers[i].minor == minor)
+			return true;
+	}
+
+	return false;
+}
+
+static int vmr_identify_op(struct platform_device *pdev)
+{
+	struct xocl_xgq_vmr *xgq = platform_get_drvdata(pdev);
+	struct xocl_xgq_vmr_cmd *cmd = NULL;
+	struct xgq_cmd_sq_hdr *hdr = NULL;
+	int ret = 0;
+	int id = 0;
+
+	cmd = kmalloc(sizeof(*cmd), GFP_KERNEL);
+	if (!cmd) {
+		XGQ_ERR(xgq, "kmalloc failed, retry");
+		return -ENOMEM;
+	}
+
+	memset(cmd, 0, sizeof(*cmd));
+	cmd->xgq_cmd_cb = xgq_complete_cb;
+	cmd->xgq_cmd_arg = cmd;
+	cmd->xgq_vmr = xgq;
+
+	hdr = &(cmd->xgq_cmd_entry.hdr);
+	hdr->opcode = XGQ_CMD_OP_IDENTIFY;
+	hdr->state = XGQ_SQ_CMD_NEW;
+	hdr->count = 0; //no payload
+	id = get_xgq_cid(xgq);
+	if (id < 0) {
+		XGQ_ERR(xgq, "alloc cid failed: %d", id);
+		goto cid_alloc_failed;
+	}
+	hdr->cid = id;
+
+	/* init condition veriable */
+	init_completion(&cmd->xgq_cmd_complete);
+
+	/* set timout actual jiffies */
+	cmd->xgq_cmd_timeout_jiffies = jiffies + XOCL_XGQ_CONFIG_TIME;
+
+	ret = submit_cmd(xgq, cmd);
+	if (ret) {
+		XGQ_ERR(xgq, "submit cmd failed, cid %d", id);
+		goto done;
+	}
+
+	/* wait for command completion */
+	if (wait_for_completion_killable(&cmd->xgq_cmd_complete)) {
+		XGQ_ERR(xgq, "submitted cmd killed");
+		xgq_submitted_cmd_remove(xgq, cmd);
+	}
+
+	ret = cmd->xgq_cmd_rcode;
+
+	if (ret) {
+		XGQ_ERR(xgq, "ret %d", ret);
+	} else {
+		struct xgq_cmd_cq_vmr_identify_payload *version = NULL;
+		uint16_t major = 0;
+		uint16_t minor = 0;
+
+		version = (struct xgq_cmd_cq_vmr_identify_payload *)&cmd->xgq_cmd_cq_payload;
+		major = version->ver_major;
+		minor = version->ver_minor;
+
+		ret = xgq_vmr_supported_version(major, minor) ? 0 : -ENOTSUPP;
+		XGQ_INFO(xgq, "version: %d.%d ret:%d", major, minor, ret);
+	}
+
+done:
+	remove_xgq_cid(xgq, id);
+
+cid_alloc_failed:
+	kfree(cmd);
+
+	return ret;
+}
+
 static void clk_scaling_cq_result_copy(struct xocl_xgq_vmr *xgq,
                                        struct xocl_xgq_vmr_cmd *cmd)
 {
@@ -1709,11 +1827,6 @@ static int clk_scaling_configure_op(struct platform_device *pdev,
 	struct xgq_cmd_sq_hdr *hdr = NULL;
 	int ret = 0;
 	int id = 0;
-
-	if (xgq->xgq_halted) {
-		XGQ_WARN(xgq, "VMR XGQ service is haulted. skip.");
-		return -EIO;
-	}
 
 	cmd = kmalloc(sizeof(*cmd), GFP_KERNEL);
 	if (!cmd) {
@@ -2778,6 +2891,18 @@ static int xgq_vmr_probe(struct platform_device *pdev)
 		return ret;
 	}
 
+	/*
+	 * First check vmr firmware version.
+	 * We don't want to send unsupported cmds to vmr.
+	 */
+	ret = vmr_identify_op(pdev);
+	if (ret) {
+		XGQ_WARN(xgq, "Unsupported vmr firmware version, only basic operations allowed. ret:%d", ret);
+		xgq_stop_services(xgq);
+		ret = 0;
+		goto done;
+	}
+
 	ret = xgq_log_page_system_dtb(pdev, &xgq->xgq_vmr_system_dtb,
 			&xgq->xgq_vmr_system_dtb_size);
 	if (ret) {
@@ -2810,6 +2935,7 @@ static int xgq_vmr_probe(struct platform_device *pdev)
 		ret = 0;
 	}
 
+done:
 	XGQ_INFO(xgq, "Initialized xgq subdev, polling (%d)", xgq->xgq_polling);
 
 	return ret;


### PR DESCRIPTION
…ce (#7069)

This is a clean backport from master to 2022.2. We need this fix to enable VMR identify cmd in XRT.
So that any older shell can still be flashed to newer shell. Tested with TA shell.

* CR-1141702 allow pdi flash and basic operation when xgq regular service is offline

Signed-off-by: Krishnamurthy, Prapul <Prapul.Krishnamurthy@amd.com>
Signed-off-by: David Zhang <davidzha@xilinx.com>

* syncup missing definition in xgq_cmd_vmr.h

Signed-off-by: David Zhang <davidzha@xilinx.com>

Signed-off-by: Krishnamurthy, Prapul <Prapul.Krishnamurthy@amd.com>
Signed-off-by: David Zhang <davidzha@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
