### PR TITLE
workaround for CR-1141322

### DIFF
--- a/src/runtime_src/core/common/drv/include/xrt_cu.h
+++ b/src/runtime_src/core/common/drv/include/xrt_cu.h
@@ -367,7 +367,8 @@ struct xrt_cu {
 	struct timer_list	  timer;
 	atomic_t		  tick;
 	u32			  start_tick;
-	
+	u32			  force_intr;
+
 	struct xrt_cu_stats        stats;
 	/**
 	 * @funcs:

--- a/src/runtime_src/core/common/drv/xrt_cu.c
+++ b/src/runtime_src/core/common/drv/xrt_cu.c
@@ -385,7 +385,7 @@ static inline int process_rq(struct xrt_cu *xcu)
 	xrt_cu_start(xcu);
 	if (xcu->thread) {
 		xcu->poll_count = 0;
-		if (xcu->interrupt_used)
+		if (!xcu->force_intr && xcu->interrupt_used)
 			xrt_cu_switch_to_poll(xcu);
 	}
 	set_xcmd_timestamp(xcmd, KDS_RUNNING);
@@ -551,6 +551,8 @@ int xrt_cu_intr_thread(void *data)
 	xcu->interrupt_used = 0;
 	xcu_info(xcu, "CU[%d] start", xcu->info.cu_idx);
 	mod_timer(&xcu->timer, jiffies + CU_TIMER);
+	if (xcu->force_intr)
+		xrt_cu_switch_to_interrupt(xcu);
 	while (!xcu->stop) {
 		/* Make sure to submit as many commands as possible.
 		 * This is why we call continue here. This is important to make

--- a/src/runtime_src/core/edge/drm/zocl/cu.c
+++ b/src/runtime_src/core/edge/drm/zocl/cu.c
@@ -431,6 +431,8 @@ static int cu_probe(struct platform_device *pdev)
 
 	zcu->base.user_manage_irq = user_manage_irq;
 	zcu->base.configure_irq = configure_irq;
+	/* This is a workaround for DPU kernel */
+	zcu->base.force_intr = 1;
 
 	zocl_info(&pdev->dev, "CU[%d] created", info->inst_idx);
 	return 0;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
DPU hang with XRT 2022.2

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
In XRT 2022.2, KDS launch a kthread which can polling CU and wait interrupt from CU.
The process is,
1. Once submit a command to CU. The thread will polling CU for a while, like 30 times.
2. If CU is done very fast, this thread can get CU is done and notify host quickly.
3. If CU is slow, the thread will stop polling and wait for CU interrupt (with 0.5 second timeout).

But in this new process, the DPU will get stuck in ap_start statue. After many experiment, it seems DPU doesn't like write GIE (Global Interrupt Enable) register after ap_start is set.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Because this is related to the DPU kernel behavior. There is no final solution yet.
This is a workaround in CU subdevice, which will force the thread to use interrupt and never polling.
This workaround only impact Edge platform.

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
ZCU102 DPU test case

#### Documentation impact (if any)
No