### PR TITLE
CR-1142217 xball xbutil validate throws error KeyError: 'XILINX_XRT'

### DIFF
--- a/src/runtime_src/core/tools/common/xball
+++ b/src/runtime_src/core/tools/common/xball
@@ -125,7 +125,7 @@ temp_log_file=$(mktemp -u --suffix=.xball.log)
 
 # 4. Use python to read the JSON file to find the devices of interest
 # This command invokes the python script found at the bottom of this file
-python3 $0 "${temp_python_status}" "${temp_json_file}" "${device_filter}" "${xrt_app}" "$prog_args"
+python3 $0 "${temp_python_status}" "${temp_json_file}" "${device_filter}" "${xrt_app}" "$prog_args" "${XRT_BIN_DIR}"
 
 # 5. Get python exit code
 python_exit_code=1     # Assume the it failed
@@ -155,6 +155,7 @@ temp_json_file = sys.argv[2]
 device_filter = sys.argv[3]
 xrt_app = sys.argv[4]
 prog_args = sys.argv[5]
+xrt_bin_dir = sys.argv[6]
 
 # Read in the JSON file produced earlier
 with open(temp_json_file) as f:
@@ -197,7 +198,7 @@ for device in working_devices:
   print("\n")
   print("=====================================================================")
   print("%d / %d [%s] : %s" % (device_count, len(working_devices), device["bdf"], device["vbnv"]))
-  cmd = os.environ['XILINX_XRT'] + "/bin/" + xrt_app + " --device " + device["bdf"] + " " + prog_args
+  cmd = xrt_bin_dir + "/" + xrt_app + " --device " + device["bdf"] + " " + prog_args
   print("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
   print("Command: %s\n" % cmd)
   exit_code = os.system(cmd)


### PR DESCRIPTION
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1142217 Using sudo xball (not just validate) was throwing an error when looking for XILINX_XRT variable.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
This is a specific use case where xrt is installed in a /bin dir that can be found by sudo, where all tools except for xball work with sudo (otherwise, we expect to see `sudo: xball: command not found`). The issue arose [here](https://github.com/Xilinx/XRT/commit/ff35e8a78cba106779e842cda213b3c38ed1e64f) when XILINX_XRT was used instead of XRT_BIN_DIR.
#### How problem was solved, alternative solutions (if any) and why they were rejected
XRT_BIN_DIR is used again as an argument.
#### Risks (if any) associated the changes in the commit
N/A
#### What has been tested and how, request additional testing if necessary
Testing was done on a vck5000.
```
rchane@xsjsagarw50:/proj/rdi/staff/rchane/XRT$ export PATH=$PATH:$RCHOME/build/Debug/opt/xilinx/xrt/bin
rchane@xsjsagarw50:/proj/rdi/staff/rchane/XRT$ echo $PATH
/proj/xsjhdstaff4/rchane/.vscode-server/bin/74b1f979648cc44d385a2286793c226e611f59e7/bin/remote-cli:/home/rchane/bin:/usr/local/bin:/mis/TREE/bin:/usr/bin:/bin:/usr/ucb:/proj/rdi/staff/rchane/XRT/build/Debug/opt/xilinx/xrt/bin
rchane@xsjsagarw50:/proj/rdi/staff/rchane/XRT$ sudo env "PATH=$PATH" xball xbutil examine
[sudo] password for rchane: 
Discovering installed devices....


=====================================================================
1 / 3 [0000:65:00.1] : xilinx_vck5000_gen4x8_qdma_base_2
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Command: /proj/rdi/staff/rchane/XRT/build/Debug/opt/xilinx/xrt/bin/xbutil --device 0000:65:00.1 examine

WARNING: Unexpected xocl version (2.14.340) was found. Expected 2.15.0, to match XRT tools.

---------------------------------------------------
[0000:65:00.1] : xilinx_vck5000_gen4x8_qdma_base_2
---------------------------------------------------
Platform
  XSA Name               : xilinx_vck5000_gen4x8_qdma_base_2 
  Platform UUID          : 8A0D97AA-4F00-6E56-3818-1EF41366138A 
  FPGA Name              :  
```
(more examine info...)
```
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Summary:
   Installed device(s) : 3
          Shell Filter : '.'
      Number Evaluated : 3
                Passed : 3
                Failed : 0
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
#### Documentation impact (if any)
N/A