### PR TITLE
CR-1142217 Change cmd to use xrt_bin_dir instead of XILINX_XRT (#7090)

### DIFF
--- a/src/runtime_src/core/tools/common/xball
+++ b/src/runtime_src/core/tools/common/xball
@@ -125,7 +125,7 @@ temp_log_file=$(mktemp -u --suffix=.xball.log)
 
 # 4. Use python to read the JSON file to find the devices of interest
 # This command invokes the python script found at the bottom of this file
-python3 $0 "${temp_python_status}" "${temp_json_file}" "${device_filter}" "${xrt_app}" "$prog_args"
+python3 $0 "${temp_python_status}" "${temp_json_file}" "${device_filter}" "${xrt_app}" "$prog_args" "${XRT_BIN_DIR}"
 
 # 5. Get python exit code
 python_exit_code=1     # Assume the it failed
@@ -155,6 +155,7 @@ temp_json_file = sys.argv[2]
 device_filter = sys.argv[3]
 xrt_app = sys.argv[4]
 prog_args = sys.argv[5]
+xrt_bin_dir = sys.argv[6]
 
 # Read in the JSON file produced earlier
 with open(temp_json_file) as f:
@@ -197,7 +198,7 @@ for device in working_devices:
   print("\n")
   print("=====================================================================")
   print("%d / %d [%s] : %s" % (device_count, len(working_devices), device["bdf"], device["vbnv"]))
-  cmd = os.environ['XILINX_XRT'] + "/bin/" + xrt_app + " --device " + device["bdf"] + " " + prog_args
+  cmd = xrt_bin_dir + "/" + xrt_app + " --device " + device["bdf"] + " " + prog_args
   print("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
   print("Command: %s\n" % cmd)
   exit_code = os.system(cmd)


### PR DESCRIPTION
(cherry picked from commit f623347121679faf55f1f88055019a81dbf16367)


#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1142217 sudo xball was throwing a key error.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
