### PR TITLE
Fixing Coverity issues introduced in profiling refactoring.

### DIFF
--- a/src/runtime_src/xdp/profile/database/dynamic_event_database.cpp
+++ b/src/runtime_src/xdp/profile/database/dynamic_event_database.cpp
@@ -39,7 +39,7 @@ namespace xdp {
       delete host;
 
     std::lock_guard<std::mutex> lock(deviceDBLock);
-    for (auto iter : devices) {
+    for (auto& iter : devices) {
       auto device = iter.second;
       delete device;
     }

--- a/src/runtime_src/xdp/profile/database/dynamic_info/host_db.cpp
+++ b/src/runtime_src/xdp/profile/database/dynamic_info/host_db.cpp
@@ -24,7 +24,7 @@ namespace xdp {
     // Delete sorted events still in the database and not moved
     {
       std::lock_guard<std::mutex> lock(sortedLock);
-      for (auto iter : sortedEvents) {
+      for (auto& iter : sortedEvents) {
         auto event = iter.second;
         delete event;
       }
@@ -58,7 +58,7 @@ namespace xdp {
   bool HostDB::sortedEventsExist(std::function<bool (VTFEvent*)>& filter)
   {
     std::lock_guard<std::mutex> lock(sortedLock);
-    for (auto iter : sortedEvents) {
+    for (auto& iter : sortedEvents) {
       auto event = iter.second;
       if (filter(event))
         return true;
@@ -72,7 +72,7 @@ namespace xdp {
     std::lock_guard<std::mutex> lock(sortedLock);
 
     std::vector<VTFEvent*> collected;
-    for (auto iter : sortedEvents) {
+    for (auto& iter : sortedEvents) {
       auto event = iter.second;
       if (filter(event))
         collected.push_back(event);

--- a/src/runtime_src/xdp/profile/writer/opencl/opencl_trace_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/opencl/opencl_trace_writer.cpp
@@ -95,7 +95,7 @@ namespace xdp {
     fout << "Group_End,Data Transfer\n";
     fout << "Group_Start,Kernel Enqueues\n";
 
-    for (auto b : enqueueBuckets) {
+    for (auto& b : enqueueBuckets) {
       fout << "Dynamic_Row_Summary," << b.second << "," << b.first 
            << ",Kernel Enqueue\n";
     }
@@ -152,7 +152,7 @@ namespace xdp {
 
     collapseDependencyChains(dependencies) ;
 
-    for (auto dependency : dependencies) {
+    for (auto& dependency : dependencies) {
       for (auto dependent : dependency.second) {
         // We have logged all of the dependencies of XRT side events.
         //  There is the possibility that these events don't correspond to


### PR DESCRIPTION
#### Problem solved by the commit
This pull request fixes performance issues discovered by Coverity.  Specifically, this changes auto to auto& when iterating over a container of pairs to remove the unnecessary copy.
