### PR TITLE
Enable cgroup v2 in petalinux

### DIFF
--- a/src/runtime_src/tools/scripts/apu_recipes/skd.service
+++ b/src/runtime_src/tools/scripts/apu_recipes/skd.service
@@ -10,7 +10,6 @@ User=softkernel
 ExecStart=/usr/bin/skd
 RemainAfterExit=on
 StandardOutput=journal+console
-CPUShare=1024
 MemoryLimit=1G
 
 [Install]

--- a/src/runtime_src/tools/scripts/apu_recipes/skd.service
+++ b/src/runtime_src/tools/scripts/apu_recipes/skd.service
@@ -10,6 +10,8 @@ User=softkernel
 ExecStart=/usr/bin/skd
 RemainAfterExit=on
 StandardOutput=journal+console
- 
+CPUShare=1024
+MemoryLimit=1G
+
 [Install]
 WantedBy=multi-user.target

--- a/src/runtime_src/tools/scripts/pkgapu.sh
+++ b/src/runtime_src/tools/scripts/pkgapu.sh
@@ -239,7 +239,7 @@ MKIMAGE=mkimage
 UBOOT_SCRIPT="$BUILD_DIR/boot.scr"
 UBOOT_CMD="$BUILD_DIR/boot.cmd"
 cat << EOF > $UBOOT_CMD
-setenv bootargs "console=ttyUL0 clk_ignore_unused modprobe.blacklist=allegro,al5d"
+setenv bootargs "console=ttyUL0 clk_ignore_unused modprobe.blacklist=allegro,al5d systemd.unified_cgroup_hierarchy=1"
 bootm $KERNEL_ADDR $ROOTFS_ADDR $SYSTEM_DTB_ADDR
 EOF
 $MKIMAGE -A arm -O linux -T script -C none -a 0 -e 0 -n "boot" -d $UBOOT_CMD $UBOOT_SCRIPT


### PR DESCRIPTION
Added cgroup CPUShare and MemoryLimit to skd.service

Signed-off-by: Jeff Lin <jeffylin@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Enabled cgroup v2 and added CPUShare of 1024 and MemoryLimit of 1GB for skd

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
None.  This is enhancement for skd.

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Test skd on vck5000 and v70

#### Documentation impact (if any)
None
