### PR TITLE
Set log level for skd syslog to not print debug messages

### DIFF
--- a/src/runtime_src/core/edge/skd/main.cpp
+++ b/src/runtime_src/core/edge/skd/main.cpp
@@ -51,6 +51,7 @@ int main(int argc, char *argv[])
 
   /* Open syslog and send the first message */
   openlog("skd", LOG_PID | LOG_CONS, LOG_LOCAL0);
+  setlogmask(LOG_UPTO(LOG_INFO)); // set log level
   syslog(LOG_INFO, "Daemon Start...\n");
 
   /* Create a new SID for the child process */

--- a/src/runtime_src/tools/scripts/apu_recipes/vdu-init
+++ b/src/runtime_src/tools/scripts/apu_recipes/vdu-init
@@ -18,8 +18,8 @@ function vdu_probe() {
         if [ $? == 0 ]
         then
                 write_log 'modprobe successful'
-                write_log 'chmod 777 /dev/allegroDecodeIP'
-                chmod 777 /dev/allegroDecodeIP
+                write_log 'chmod 777 /dev/allegroDecodeIP*'
+                chmod 777 /dev/allegroDecodeIP*
                 chmod 444 /sys/kernel/debug/cma/cma-vdu_dma_mem/used
                 chown softkernel:softkernel /sys/kernel/debug/cma/cma-vdu_dma_mem/used
         else


### PR DESCRIPTION
Signed-off-by: rbramand <rbramand@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
syslog for skd prints all kind of messages, setting log level to disable debug prints.
minor fix - multiple instances of allegro decoder ip are present, so changing permissions on all nodes 

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Log message "Got new kernel command" in skd::run is printed multiple times so changed its log level to debug and made changes to not print debug messages

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
Maruti tested apu package created on V70 and it is working as expected

#### Documentation impact (if any)
NA