### PR TITLE
 fixing qdma msix vector index issue

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/qdma.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/qdma.c
@@ -43,7 +43,7 @@
 #define	MINOR_NAME_MASK		0xffffffff
 
 #define QDMA_MAX_INTR		16
-#define QDMA_USER_INTR_MASK	0xff
+#define QDMA_USER_INTR_MASK	0xffff
 
 #define QDMA_QSETS_MAX		256
 #define QDMA_QSETS_BASE		0
@@ -821,8 +821,8 @@ static int qdma_probe(struct platform_device *pdev)
 	conf->bar_num_user = -1;
 	conf->bar_num_bypass = -1;
 	conf->data_msix_qvec_max = 1;
-	conf->user_msix_qvec_max = 8;
-	conf->msix_qvec_max = 16;
+	conf->user_msix_qvec_max = 16;
+	conf->msix_qvec_max = 32;
 	conf->qdma_drv_mode = qdma_interrupt_mode;
 
 	conf->fp_user_isr_handler = (void*)qdma_isr;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Latest Platform is using MSIX vectors from 9 to 12 for the command queue XGQs. Currently we kept max msix vector as 8. Changed that to 16
Host is still not getting interrupts, but that could be a hardware issue.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
it never worked.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Increased the maximum msix user interrupt vector index from 8 to 16

#### Risks (if any) associated the changes in the commit
No

#### What has been tested and how, request additional testing if necessary
Veirifed xbutil validate on V70

#### Documentation impact (if any)
NA