### PR TITLE
Enable xrt run object to return PS kernel return code

### DIFF
--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -745,6 +745,16 @@ public:
     return state;
   }
 
+  // Return kernel return code from command object for PS kernels
+  int
+  get_return_code() const
+  {
+    auto pkt = get_ert_packet();
+    int ret;
+    ert_read_return_code(pkt, ret);
+    return ret;
+  }
+
   // Cast underlying exec buffer to its requested type
   template <typename ERT_COMMAND_TYPE>
   const ERT_COMMAND_TYPE
@@ -2281,6 +2291,16 @@ public:
     return cmd->get_state();
   }
 
+  // return_code() - get kernel execution return code
+  int
+  return_code() const
+  {
+    auto ktype = kernel->get_kernel_type();
+    if (ktype == kernel_type::ps)
+      return cmd->get_return_code();
+    return 0;
+  }
+
   ert_packet*
   get_ert_packet() const
   {
@@ -3041,6 +3061,15 @@ state() const
 {
   return xdp::native::profiling_wrapper("xrt::run::state", [this]{
     return handle->state();
+  });
+}
+
+int
+run::
+return_code() const
+{
+  return xdp::native::profiling_wrapper("xrt::run::return_code", [this]{
+    return handle->return_code();
   });
 }
 

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -746,11 +746,11 @@ public:
   }
 
   // Return kernel return code from command object for PS kernels
-  int
+  uint32_t
   get_return_code() const
   {
     auto pkt = get_ert_packet();
-    int ret;
+    uint32_t ret;
     ert_read_return_code(pkt, ret);
     return ret;
   }
@@ -2292,7 +2292,7 @@ public:
   }
 
   // return_code() - get kernel execution return code
-  int
+  uint32_t
   return_code() const
   {
     auto ktype = kernel->get_kernel_type();
@@ -3064,7 +3064,7 @@ state() const
   });
 }
 
-int
+uint32_t
 run::
 return_code() const
 {

--- a/src/runtime_src/core/edge/drm/zocl/cu_scu.c
+++ b/src/runtime_src/core/edge/drm/zocl/cu_scu.c
@@ -83,7 +83,6 @@ static void scu_xgq_start(struct xrt_cu_scu *scu, u32 *data)
 
 	scu->num_reg = (cmd->hdr.count - (sizeof(struct xgq_cmd_start_cuidx)
 				     - sizeof(cmd->hdr) - sizeof(cmd->data)))/sizeof(u32);
-	printk("Num Kernel Reg = %d\n", scu->num_reg);
 	for (i = 0; i < scu->num_reg; ++i) {
 		cu_regfile[i+1] = cmd->data[i];
 	}

--- a/src/runtime_src/core/include/xrt/xrt_kernel.h
+++ b/src/runtime_src/core/include/xrt/xrt_kernel.h
@@ -343,7 +343,7 @@ public:
    *  Return code from PS kernel run
    */
   XCL_DRIVER_DLLESPEC
-  int
+  uint32_t
   return_code() const;
 
   /**

--- a/src/runtime_src/core/include/xrt/xrt_kernel.h
+++ b/src/runtime_src/core/include/xrt/xrt_kernel.h
@@ -337,6 +337,16 @@ public:
   state() const;
 
   /**
+   * return_code() - Get the return code from PS kernel
+   *
+   * @return
+   *  Return code from PS kernel run
+   */
+  XCL_DRIVER_DLLESPEC
+  int
+  return_code() const;
+
+  /**
    * add_callback() - Add a callback function for run state
    *
    * @param state       State to invoke callback on


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Add new function return_code to XRT run object to enable PS kernel return code to be passed back to host.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
New feature for PS kernel

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added new function to return return code if kernel type is ps.

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Tested on vck5000 with PS kernel

#### Documentation impact (if any)
Need to document new return_code function for XRT run object
