### PR TITLE
CR-1143379 pass slot it by xclbin xgq command to APU

### DIFF
--- a/src/runtime_src/core/include/xgq_cmd_vmr.h
+++ b/src/runtime_src/core/include/xgq_cmd_vmr.h
@@ -47,8 +47,8 @@
 #define XGQ_CLOCK_WIZ_MAX_RES           4
 
 /* VMR Identify Command Version Major and Minor Numbers */
-#define VMR_IDENTIFY_CMD_MAJOR                  1
-#define VMR_IDENTIFY_CMD_MINOR                  0
+#define VMR_IDENTIFY_CMD_MAJOR		1
+#define VMR_IDENTIFY_CMD_MINOR		0
 
 
 /**
@@ -209,6 +209,7 @@ struct xgq_cmd_data_payload {
 	uint32_t flash_type:4;
 	uint32_t rsvd1:24;
 	uint32_t pad1;
+	uint64_t priv;
 };
 
 enum xgq_cmd_flash_type {
@@ -379,9 +380,9 @@ struct xgq_cmd_cq_vmr_payload {
  * VMR Identify Command
 */
 struct xgq_cmd_cq_vmr_identify_payload {
-    uint16_t ver_major;
-    uint16_t ver_minor;
-    uint32_t resvd;
+	uint16_t ver_major;
+	uint16_t ver_minor;
+	uint32_t resvd;
 };
 
 /*
@@ -403,7 +404,7 @@ struct xgq_cmd_cq {
 		struct xgq_cmd_cq_vmr_payload		cq_vmr_payload;
 		struct xgq_cmd_cq_log_page_payload	cq_log_payload;
 		struct xgq_cmd_cq_data_payload		cq_xclbin_payload;
-		struct xgq_cmd_cq_clk_scaling_payload cq_clk_scaling_payload;
+		struct xgq_cmd_cq_clk_scaling_payload	cq_clk_scaling_payload;
 		struct xgq_cmd_cq_vmr_identify_payload  cq_vmr_identify_payload;
 	};
 	uint32_t rcode;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -2132,6 +2132,8 @@ struct xocl_xgq_vmr_funcs {
 	struct xocl_subdev_funcs common_funcs;
 	int (*xgq_load_xclbin)(struct platform_device *pdev,
 		const void __user *arg);
+	int (*xgq_load_xclbin_slot)(struct platform_device *pdev,
+		const void __user *arg, uint64_t slot);
 	int (*xgq_check_firewall)(struct platform_device *pdev);
 	int (*xgq_clear_firewall)(struct platform_device *pdev);
 	int (*xgq_freq_scaling)(struct platform_device *pdev,


### PR DESCRIPTION
Signed-off-by: David Zhang <davidzha@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Hi

David will extend the VMR load XCLBIN command with a 64 bits metadata.
So that host can put any private data there and it will be pass to APU.
VMR is not able to understand the meaning of the metadata.
David will also enhance the APIs of VMR XGQ sub-device.

Once his part is done. I can sync with [@Kaijar, Saifuddin](mailto:saifuddin.kaijar@amd.com).
 
Thank you,
Min Ma
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1143379 
#### How problem was solved, alternative solutions (if any) and why they were rejected
N/A

#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
V70

#### Documentation impact (if any)
https://confluence.xilinx.com/pages/viewpage.action?pageId=302345261#XGQ1.0CommandandQueueSpecification(WIP)-ManagementCommandType