### PR TITLE
64-bit BO handle in ishim on Linux

### DIFF
--- a/src/runtime_src/core/common/api/command.h
+++ b/src/runtime_src/core/common/api/command.h
@@ -54,7 +54,7 @@ public:
   /**
    * get_exec_bo() - get BO handle of command buffer
    */
-  virtual xclBufferHandle
+  virtual xrt_buffer_handle
   get_exec_bo() const = 0;
 
   /**

--- a/src/runtime_src/core/common/api/hw_queue.cpp
+++ b/src/runtime_src/core/common/api/hw_queue.cpp
@@ -317,7 +317,7 @@ public:
   std::cv_status
   wait(size_t timeout_ms) override
   {
-    return m_device->wait_command(m_qhdl, XRT_NULL_BO, static_cast<int>(timeout_ms))
+    return m_device->wait_command(m_qhdl, XRT_INVALID_BUFFER_HANDLE, static_cast<int>(timeout_ms))
       ? std::cv_status::no_timeout
       : std::cv_status::timeout;
   }

--- a/src/runtime_src/core/common/api/kernel_int.h
+++ b/src/runtime_src/core/common/api/kernel_int.h
@@ -37,8 +37,8 @@ namespace xrt_core { namespace kernel_int {
 void
 copy_bo_with_kdma(const std::shared_ptr<xrt_core::device>& core_device,
                   size_t sz,
-                  xclBufferHandle dst_bo, size_t dst_offset,
-                  xclBufferHandle src_bo, size_t src_offset);
+                  xrt_buffer_handle dst_bo, size_t dst_offset,
+                  xrt_buffer_handle src_bo, size_t src_offset);
 
 XRT_CORE_COMMON_EXPORT
 std::vector<const xclbin::kernel_argument*>

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -895,7 +895,7 @@ public:
     return m_device->get_core_device();
   }
 
-  xclBufferHandle
+  xrt_buffer_handle
   get_exec_bo() const override
   {
     return m_execbuf.first;
@@ -2884,8 +2884,8 @@ namespace xrt_core { namespace kernel_int {
 void
 copy_bo_with_kdma(const std::shared_ptr<xrt_core::device>& core_device,
                   size_t sz,
-                  xclBufferHandle dst_bo, size_t dst_offset,
-                  xclBufferHandle src_bo, size_t src_offset)
+                  xrt_buffer_handle dst_bo, size_t dst_offset,
+                  xrt_buffer_handle src_bo, size_t src_offset)
 {
 #ifndef _WIN32
   if (is_sw_emulation())
@@ -2898,7 +2898,8 @@ copy_bo_with_kdma(const std::shared_ptr<xrt_core::device>& core_device,
 
   // Get and fill the underlying packet
   auto pkt = cmd->get_ert_cmd<ert_start_copybo_cmd*>();
-  ert_fill_copybo_cmd(pkt, src_bo, dst_bo, src_offset, dst_offset, sz);
+  ert_fill_copybo_cmd(pkt, to_xclBufferHandle(src_bo), to_xclBufferHandle(dst_bo),
+    src_offset, dst_offset, sz);
 
   // Run the command and wait for completion
   cmd->run();

--- a/src/runtime_src/core/common/bo_cache.h
+++ b/src/runtime_src/core/common/bo_cache.h
@@ -39,7 +39,7 @@ public:
   // Helper typedef for std::pair. Note the elements are const so that the
   // pair is immutable. The clients should not change the contents of cmd_bo.
   template <typename CommandType>
-  using cmd_bo = std::pair<const xclBufferHandle, CommandType *const>;
+  using cmd_bo = std::pair<const xrt_buffer_handle, CommandType *const>;
 private:
 
   // We are really allocating a page size as that is what xocl/zocl do. Note on

--- a/src/runtime_src/core/common/ishim.h
+++ b/src/runtime_src/core/common/ishim.h
@@ -60,19 +60,19 @@ struct ishim
   virtual void
   close_context(const xrt::uuid& xclbin_uuid, unsigned int ip_index) = 0;
 
-  virtual xclBufferHandle
+  virtual xrt_buffer_handle
   alloc_bo(size_t size, unsigned int flags) = 0;
 
-  virtual xclBufferHandle
+  virtual xrt_buffer_handle
   alloc_bo(void* userptr, size_t size, unsigned int flags) = 0;
 
   virtual void
-  free_bo(xclBufferHandle boh) = 0;
+  free_bo(xrt_buffer_handle boh) = 0;
 
   virtual xclBufferExportHandle
-  export_bo(xclBufferHandle boh) const = 0;
+  export_bo(xrt_buffer_handle boh) const = 0;
 
-  virtual xclBufferHandle
+  virtual xrt_buffer_handle
   import_bo(xclBufferExportHandle ehdl) = 0;
 
   virtual void
@@ -80,24 +80,24 @@ struct ishim
 
   // Import an exported BO from another process identified by argument pid.
   // This function is only supported on systems with pidfd kernel support
-  virtual xclBufferHandle
+  virtual xrt_buffer_handle
   import_bo(pid_t, xclBufferExportHandle)
   { throw not_supported_error{__func__}; }
 
   virtual void
-  copy_bo(xclBufferHandle dst, xclBufferHandle src, size_t size, size_t dst_offset, size_t src_offset) = 0;
+  copy_bo(xrt_buffer_handle dst, xrt_buffer_handle src, size_t size, size_t dst_offset, size_t src_offset) = 0;
 
   virtual void
-  sync_bo(xclBufferHandle bo, xclBOSyncDirection dir, size_t size, size_t offset) = 0;
+  sync_bo(xrt_buffer_handle bo, xclBOSyncDirection dir, size_t size, size_t offset) = 0;
 
   virtual void*
-  map_bo(xclBufferHandle boh, bool write) = 0;
+  map_bo(xrt_buffer_handle boh, bool write) = 0;
 
   virtual void
-  unmap_bo(xclBufferHandle boh, void* addr) = 0;
+  unmap_bo(xrt_buffer_handle boh, void* addr) = 0;
 
   virtual void
-  get_bo_properties(xclBufferHandle boh, struct xclBOProperties *properties) const = 0;
+  get_bo_properties(xrt_buffer_handle boh, struct xclBOProperties *properties) const = 0;
 
   virtual void
   reg_read(uint32_t ipidx, uint32_t offset, uint32_t* data) const = 0;
@@ -118,7 +118,7 @@ struct ishim
   unmgd_pwrite(const void* buffer, size_t size, uint64_t offset) = 0;
 
   virtual void
-  exec_buf(xclBufferHandle boh) = 0;
+  exec_buf(xrt_buffer_handle boh) = 0;
 
   virtual int
   exec_wait(int timeout_ms) const = 0;
@@ -172,7 +172,7 @@ struct ishim
 
   // Submits command for execution through hw queue
   virtual void
-  submit_command(xcl_hwqueue_handle, xclBufferHandle /*cmdbo*/) const
+  submit_command(xcl_hwqueue_handle, xrt_buffer_handle /*cmdbo*/) const
   { throw not_supported_error{__func__}; }
 
   // Wait for command completion through hw queue
@@ -180,7 +180,7 @@ struct ishim
   // cmdbo completed.  If cmdbo is XRT_NULL_BO then function must
   // returns when some previously submitted command completes.
   virtual int
-  wait_command(xcl_hwqueue_handle, xclBufferHandle /*cmdbo*/, int /*timeout_ms*/) const
+  wait_command(xcl_hwqueue_handle, xrt_buffer_handle /*cmdbo*/, int /*timeout_ms*/) const
   { throw not_supported_error{__func__}; }
 
   // Registers an xclbin, but does not load it.
@@ -335,36 +335,36 @@ struct shim : public DeviceType
       throw system_error(ret, "failed to close ip context");
   }
 
-  xclBufferHandle
+  xrt_buffer_handle
   alloc_bo(size_t size, unsigned int flags) override
   {
     auto bo = xclAllocBO(DeviceType::get_device_handle(), size, 0, flags);
     if (bo == XRT_NULL_BO)
       throw std::bad_alloc();
 
-    return bo;
+    return to_xrt_buffer_handle(bo);
   }
 
-  xclBufferHandle
+  xrt_buffer_handle
   alloc_bo(void* userptr, size_t size, unsigned int flags) override
   {
     auto bo = xclAllocUserPtrBO(DeviceType::get_device_handle(), userptr, size, flags);
     if (bo == XRT_NULL_BO)
       throw std::bad_alloc();
 
-    return bo;
+    return to_xrt_buffer_handle(bo);
   }
 
   void
-  free_bo(xclBufferHandle bo) override
+  free_bo(xrt_buffer_handle bo) override
   {
-    xclFreeBO(DeviceType::get_device_handle(), bo);
+    xclFreeBO(DeviceType::get_device_handle(), to_xclBufferHandle(bo));
   }
 
   xclBufferExportHandle
-  export_bo(xclBufferHandle bo) const override
+  export_bo(xrt_buffer_handle bo) const override
   {
-    auto ehdl = xclExportBO(DeviceType::get_device_handle(), bo);
+    auto ehdl = xclExportBO(DeviceType::get_device_handle(), to_xclBufferHandle(bo));
     if (ehdl == XRT_NULL_BO_EXPORT)
       throw system_error(EINVAL, "Unable to export BO");
     if (ehdl < 0) // system error code
@@ -372,7 +372,7 @@ struct shim : public DeviceType
     return ehdl;
   }
 
-  xclBufferHandle
+  xrt_buffer_handle
   import_bo(xclBufferExportHandle ehdl) override
   {
     auto ihdl = xclImportBO(DeviceType::get_device_handle(), ehdl, 0);
@@ -380,7 +380,7 @@ struct shim : public DeviceType
       throw system_error(EINVAL, "unable to import BO");
     if (ihdl < 0) // system error code
       throw system_error(ENODEV, "unable to import BO");
-    return ihdl;
+    return to_xrt_buffer_handle(ihdl);
   }
 
   void
@@ -391,38 +391,39 @@ struct shim : public DeviceType
   }
 
   void
-  copy_bo(xclBufferHandle dst, xclBufferHandle src, size_t size, size_t dst_offset, size_t src_offset) override
+  copy_bo(xrt_buffer_handle dst, xrt_buffer_handle src, size_t size, size_t dst_offset, size_t src_offset) override
   {
-    if (auto err = xclCopyBO(DeviceType::get_device_handle(), dst, src, size, dst_offset, src_offset))
+    if (auto err = xclCopyBO(DeviceType::get_device_handle(),
+      to_xclBufferHandle(dst), to_xclBufferHandle(src), size, dst_offset, src_offset))
       throw system_error(err, "unable to copy BO");
   }
 
   void
-  sync_bo(xclBufferHandle bo, xclBOSyncDirection dir, size_t size, size_t offset) override
+  sync_bo(xrt_buffer_handle bo, xclBOSyncDirection dir, size_t size, size_t offset) override
   {
-    if (auto err = xclSyncBO(DeviceType::get_device_handle(), bo, dir, size, offset))
+    if (auto err = xclSyncBO(DeviceType::get_device_handle(), to_xclBufferHandle(bo), dir, size, offset))
       throw system_error(err, "unable to sync BO");
   }
 
   void*
-  map_bo(xclBufferHandle bo, bool write) override
+  map_bo(xrt_buffer_handle bo, bool write) override
   {
-    if (auto mapped = xclMapBO(DeviceType::get_device_handle(), bo, write))
+    if (auto mapped = xclMapBO(DeviceType::get_device_handle(), to_xclBufferHandle(bo), write))
       return mapped;
     throw system_error(EINVAL, "could not map BO");
   }
 
   void
-  unmap_bo(xclBufferHandle bo, void* addr) override
+  unmap_bo(xrt_buffer_handle bo, void* addr) override
   {
-    if (auto ret = xclUnmapBO(DeviceType::get_device_handle(), bo, addr))
+    if (auto ret = xclUnmapBO(DeviceType::get_device_handle(), to_xclBufferHandle(bo), addr))
       throw system_error(ret, "failed to unmap BO");
   }
 
   void
-  get_bo_properties(xclBufferHandle bo, struct xclBOProperties *properties) const override
+  get_bo_properties(xrt_buffer_handle bo, struct xclBOProperties *properties) const override
   {
-    if (auto ret = xclGetBOProperties(DeviceType::get_device_handle(), bo, properties))
+    if (auto ret = xclGetBOProperties(DeviceType::get_device_handle(), to_xclBufferHandle(bo), properties))
       throw system_error(ret, "failed to get BO properties");
   }
 
@@ -476,9 +477,9 @@ struct shim : public DeviceType
   }
 
   void
-  exec_buf(xclBufferHandle bo) override
+  exec_buf(xrt_buffer_handle bo) override
   {
-    if (auto ret = xclExecBuf(DeviceType::get_device_handle(), bo))
+    if (auto ret = xclExecBuf(DeviceType::get_device_handle(), to_xclBufferHandle(bo)))
       throw system_error(ret, "failed to launch execution buffer");
   }
 

--- a/src/runtime_src/core/include/deprecated/xrt.h
+++ b/src/runtime_src/core/include/deprecated/xrt.h
@@ -67,9 +67,9 @@ typedef void * xclDeviceHandle;
 /*
  * typedef xclBufferHandle - opaque buffer handle
  *
- * A buffer handle of xclBufferHandle kind is obtained by allocating
- * buffer objects. The buffer handle is used by XRT APIs that operate
- * on on buffer objects.
+ * A buffer handle of xclBufferHandle kind is obtained by allocating buffer
+ * objects through HAL API. The buffer handle is used by XRT HAL APIs that
+ * operate on on buffer objects.
  */
 #ifdef _WIN32
 typedef void * xclBufferHandle;
@@ -79,6 +79,28 @@ typedef unsigned int xclBufferHandle;
 # define NULLBO	0xffffffff
 #endif
 #define XRT_NULL_BO NULLBO
+
+/*
+ * typedef xrt_buffer_handle - opaque buffer handle
+ *
+ * A buffer handle of xrt_buffer_handle kind is obtained by allocating buffer
+ * objects through ISHIM API. The buffer handle is used by XRT ISHIM APIs
+ * that operate on on buffer objects.
+ */
+typedef void * xrt_buffer_handle;
+#define XRT_INVALID_BUFFER_HANDLE	NULL
+
+static inline xclBufferHandle
+to_xclBufferHandle(xrt_buffer_handle hdl)
+{
+  return hdl == XRT_INVALID_BUFFER_HANDLE ? XRT_NULL_BO : reinterpret_cast<uintptr_t>(hdl);
+}
+
+static inline xrt_buffer_handle
+to_xrt_buffer_handle(xclBufferHandle hdl)
+{
+  return hdl == XRT_NULL_BO ? XRT_INVALID_BUFFER_HANDLE : reinterpret_cast<xrt_buffer_handle>(hdl);
+}
 
 /*
  * typedef xclBufferExportHandle

--- a/src/runtime_src/core/include/xrt/xrt_bo.h
+++ b/src/runtime_src/core/include/xrt/xrt_bo.h
@@ -44,7 +44,7 @@ typedef uint32_t xrtMemoryGroup;
  * @details
  * Use when constructing xrt::bo from xclBufferHandle
  */
-struct xcl_buffer_handle { xclBufferHandle bhdl; };
+struct xcl_buffer_handle { xrt_buffer_handle bhdl; };
 
 #ifdef __cplusplus
 

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -1476,7 +1476,7 @@ wait_ip_interrupt(xclInterruptNotifyHandle handle, int32_t timeout)
   throw error(-EINVAL, boost::str(boost::format("wait_timeout: POSIX poll unexpected event: %d")  % pfd.revents));
 }
 
-xclBufferHandle
+xrt_buffer_handle
 device_linux::
 import_bo(pid_t pid, xclBufferExportHandle ehdl)
 {

--- a/src/runtime_src/core/pcie/linux/device_linux.h
+++ b/src/runtime_src/core/pcie/linux/device_linux.h
@@ -68,7 +68,7 @@ public:
   std::cv_status
   wait_ip_interrupt(xclInterruptNotifyHandle, int32_t timeout) override;
 
-  xclBufferHandle
+  xrt_buffer_handle
   import_bo(pid_t pid, xclBufferExportHandle ehdl) override;
 
   uint32_t // ctx handle aka slotidx

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -853,7 +853,7 @@ int shim::execbufCopyBO(unsigned int dst_bo_handle,
     ert_fill_copybo_cmd(bo.second, src_bo_handle, dst_bo_handle,
                         src_offset, dst_offset, size);
 
-    int ret = xclExecBuf(bo.first);
+    int ret = xclExecBuf(to_xclBufferHandle(bo.first));
     if (ret) {
         mCmdBOCache->release<ert_start_copybo_cmd>(bo);
         return ret;
@@ -907,7 +907,7 @@ int shim::xclUpdateSchedulerStat()
     bo.second->opcode = ERT_CU_STAT;
     bo.second->type = ERT_CTRL;
 
-    int ret = xclExecBuf(bo.first);
+    int ret = xclExecBuf(to_xclBufferHandle(bo.first));
     if (ret) {
         mCmdBOCache->release(bo);
         return ret;

--- a/src/runtime_src/xrt/xrt++/xrtexec.cpp
+++ b/src/runtime_src/xrt/xrt++/xrtexec.cpp
@@ -182,7 +182,7 @@ struct command::impl : xrt_core::command
     return m_device->get_core_device().get();
   }
 
-  virtual xclBufferHandle
+  virtual xrt_buffer_handle
   get_exec_bo() const
   {
     return m_execbuf.first;


### PR DESCRIPTION
Signed-off-by: Max Zhen <max.zhen@amd.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Today, a BO in Linux XRT is represented by a handle of xclBufferHandle type, which is essentially a 32-bit unsigned integer. This works fine since, so far, all BOs' book keeping data structure is maintained by xocl through DRM in Linux kernel. And this 32-bit handle is exactly the DRM BO handle passed up from xocl through entire XRT user space software stack. It is even exposed to end user via XRT's HAL APIs.

As support for new platforms are added to XRT, new drivers and SHIM implementation are introduced where a BO's book keeping data structure may start having user space part alongside the kernel part maintained by new driver through DRM. However, a 32-bit handle can only help to identify the kernel part, not the user part of the data structure. Hence, it is desired to change the handle to be a 64-bit integer or void *, so that it can hold:
+ a 32-bit DRM handle
+ an opaque pointer to user space data structure containing the DRM handle alongside other members for user space code

Or, in user space, we can maintain a map from a 32-bit integer to a pointer and keep using the 32-bit handle as-is. But this solution is not ideal because:
+ For each BO processing, say exec_buf(), we need to search two mapping tables one in user space and one in kernel via DRM. This is really inefficient.
+ It is good to have this flexibility to be able to hide the implementation detail in SHIM from the rest of software stack. Thus, we can keep the upper stack as OS and platform/driver independent.

In Windows XRT, xclBufferHandle has already been defined as void *. However, we can't just simply do the same in Linux since the xclBufferHandle is exposed to end user through HAL APIs, which we can't change. We do not support HAL API on Windows, so we don't have such restriction there.

Considering that HAL APIs are obsolete, we do not have to support them in the SHIM for new platforms. So, as long as we have a unified BO handle representation at ishim level, we are good. The new SHIM implementation will only extend ishim, not adding support for HAL APIs. And ishim is internal to XRT which can be changed at any time.

In this PR, a new BO handle type (xrt_buffer_handle) is introduced replacing xclBufferHandle in ishim API interface. The code using ishim will start using xrt_buffer_handle as BO handle. When the ishim implementation calls into existing SHIM on legacy platforms, xrt_buffer_handle will be explicitly converted to xclBufferHandle. There should be no change to existing SHIM/HAL APIs. When a BO is created via HAL APIs on existing platforms by xocl, its handle will be explicitly converted to xrt_buffer_handle right before it gets passed over to ishim users. So, ishim users should not see xclBufferHandle any more.

New SHIM and driver implementation will extend ishim and can convert xrt_buffer_handle to its own data type as required.

As mentioned above, xrt_buffer_handle can be defined as uint64_t or void *. But, the latter seems better because:
+ It is compatible with Windows' implementation
+ Compiler cannot perform implicit conversion between xrt_buffer_handle and xclBufferHandle, so I get to examine every place the conversion is needed to make sure I don't miss any.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
N/A
#### How problem was solved, alternative solutions (if any) and why they were rejected
See PR description for alternative solutions.
#### Risks (if any) associated the changes in the commit
Some code calls both ishim and HAL APIs, hopefully the conversion is done properly for them, but there may still be bugs.
Some of these code are in current SHIM implementation, so does not apply to new platform anyway. Some of them are in utility code which part also does not apply to new platform.
All platform independent code should start using new type, if change is missed, it's a bug.
#### What has been tested and how, request additional testing if necessary
Built and installed XRT package and ran xbutil examine/validate on U55n.
#### Documentation impact (if any)
N/A