### PR TITLE
One command monitor thread per xrt_core::device

### DIFF
--- a/src/runtime_src/core/common/api/hw_queue.cpp
+++ b/src/runtime_src/core/common/api/hw_queue.cpp
@@ -508,8 +508,24 @@ namespace {
 // For time being there is only one hw_queue per hw_context
 // Use static map with weak pointers to implementation.
 using hwc2hwq_type = std::map<xcl_hwctx_handle, std::weak_ptr<xrt_core::hw_queue_impl>>;
+using queue_ptr = std::shared_ptr<xrt_core::hw_queue_impl>;
 static std::mutex mutex;
 static std::map<const xrt_core::device*, hwc2hwq_type> dev2hwc;  // per device
+
+// This function ensures that only one kds_device is created per
+// xrt_core::device regardless of hwctx.  It allocates (if necessary)
+// a kds_device queue impl in the sentinel slot that represents a null
+// hardware context.
+static std::shared_ptr<xrt_core::hw_queue_impl>
+get_kds_device_nolock(hwc2hwq_type& queues, const xrt_core::device* device)
+{
+  auto hwqimpl = queues[XRT_NULL_HWCTX].lock();
+  if (!hwqimpl)
+    queues[XRT_NULL_HWCTX] = hwqimpl =
+      queue_ptr{new xrt_core::kds_device(const_cast<xrt_core::device*>(device))};
+
+  return hwqimpl;
+}
 
 // Create a hw_queue implementation assosicated with a device without
 // any hw context.  This is used for legacy construction for internal
@@ -520,17 +536,13 @@ get_hw_queue_impl(const xrt_core::device* device)
 {
   std::lock_guard lk(mutex);
   auto& queues = dev2hwc[device];
-  auto hwqimpl = queues[XRT_NULL_HWCTX].lock();
-  if (!hwqimpl)
-    queues[XRT_NULL_HWCTX] = hwqimpl =
-      std::shared_ptr<xrt_core::hw_queue_impl>(new xrt_core::kds_device(const_cast<xrt_core::device*>(device)));
-
-  return hwqimpl;
+  return get_kds_device_nolock(queues, device);
 }
 
 // Create a hw_queue implementation for a hw context.
 // Ensure unique queue per device since driver doesn't currently
-// guarantee unique hwctx handle cross devices
+// guarantee unique hwctx handle cross devices.  Also make sure
+// only one kds_device queue impl is created per device.
 static std::shared_ptr<xrt_core::hw_queue_impl>
 get_hw_queue_impl(const xrt::hw_context& hwctx)
 {
@@ -542,10 +554,9 @@ get_hw_queue_impl(const xrt::hw_context& hwctx)
   if (!hwqimpl) {
     auto hwqueue_hdl = device->create_hw_queue(hwctx);
     queues[hwctx_hdl] = hwqimpl = (hwqueue_hdl == XRT_NULL_HWQUEUE)
-      ? std::shared_ptr<xrt_core::hw_queue_impl>(new xrt_core::kds_device(device))
-      : std::shared_ptr<xrt_core::hw_queue_impl>(new xrt_core::qds_device(device, hwqueue_hdl));
+      ? get_kds_device_nolock(queues, device)
+      : queue_ptr{new xrt_core::qds_device(device, hwqueue_hdl)};
   }
-
   return hwqimpl;
 }
 


### PR DESCRIPTION
#### Problem solved by the commit
Ensure that only one legacy command monitor thread (kds_device) is created for platforms that do not implement create_hw_queue.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
The legacy command monitor handles command completion for the enqueued command execution, mostly OpenCL or native XRT with callback, latter rarely used.  The APIs used by the monitor are legacy execbuf and execwait() APIs that operate at the device level.

Testing of #7712 found that when a platform supports hardware contexts, but not hardware queue, it ends up creating multiple kds_devices (command monitor threads) one for each unique hwctx handle.  The command monitor does not support a single thread creating multiple instances and also it is wasteful to use multiple monitor threads for same device when execbuf and execwait calls go through the xrt_core::device object anyway.

#### How problem was solved, alternative solutions (if any) and why they were rejected
This PR thus adds logic to ensure that only one kds_device is created for each xrt_core::device.

For platforms that support hardware queue, new queue specific APIs are used to manage command execution and as such require a command monitor per hardware queue, so no changes are made here.  Only legacy non hardware queue flow is changed.

Signed-off-by: Soren Soe <2106410+stsoe@users.noreply.github.com>
