### PR TITLE
Update build.sh for documentation build 

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -316,8 +316,6 @@ if [[ $opt == 1 ]]; then
 
   if [[ $docs == 1 ]]; then
       echo "make xrt_docs"
-      # Source the XRT environment so we can find modules like pyxrt
-      source ./opt/xilinx/xrt/setup.sh
       make xrt_docs
   fi
 


### PR DESCRIPTION
#### Problem solved by the commit

We had a prerequisite to build full XRT before building Documentation for some python related reason. So the documentation-building recipe was 
       1) build.sh // build full XRT
       2) build.sh docs // build document

The above requirement step 1 should not have been required in the first place. With the latest master branch, I no longer need to build full XRT before building documentation. Hence I am removing those two lines from the build.sh which are checking XRT full source build before doing the documentation build. 

As explained above, the below lines are removed

``` 
   # Source the XRT environment so we can find modules like pyxrt
      source ./opt/xilinx/xrt/setup.sh
```

