### PR TITLE
CR-1143553 xgq: wait for SC readiness during driver init

### DIFF
--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -793,11 +793,11 @@ get_flag_sw_emu_kernel_debug()
 }
 
 // This flag is added to exit device offline status check loop forcibly.
-// By default, device offline status loop runs for 120 seconds.
+// By default, device offline status loop runs for 320 seconds.
 inline unsigned int
 get_device_offline_timer()
 {
-  static unsigned int value = detail::get_uint_value("Runtime.dev_offline_timer", 120);
+  static unsigned int value = detail::get_uint_value("Runtime.dev_offline_timer", 320);
   return value;
 }
 

--- a/src/runtime_src/core/include/xgq_cmd_vmr.h
+++ b/src/runtime_src/core/include/xgq_cmd_vmr.h
@@ -366,7 +366,8 @@ struct xgq_cmd_cq_vmr_payload {
 	uint16_t has_ext_sysdtb:1;
 	uint16_t ps_is_ready:1;
 	uint16_t pl_is_ready:1;
-	uint16_t resvd1:5;
+	uint16_t sc_is_ready:1;
+	uint16_t resvd1:4;
 	uint16_t current_multi_boot_offset;
 	uint32_t debug_level:3;
 	uint32_t program_progress:7;

--- a/src/runtime_src/core/include/xgq_cmd_vmr.h
+++ b/src/runtime_src/core/include/xgq_cmd_vmr.h
@@ -395,6 +395,10 @@ struct xgq_cmd_cq_vmr_identify_payload {
  * @clock_payload:
  * @sensor_payload:
  * @multiboot_payload:
+ * @log_payload:
+ * @xclbin_payload:
+ * @clk_scaling_payload:
+ * @vmr_identify_payload:
  */
 struct xgq_cmd_cq {
 	struct xgq_cmd_cq_hdr hdr;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
@@ -3024,7 +3024,7 @@ static bool vmr_wait_for_sc_ready(struct xocl_xgq_vmr *xgq)
 		}
 
 		// display SC status for every SC_ERR_MSG_INTERVAL_SEC i.e. 5 seconds
-		if (!(loop_counter % SC_ERR_MSG_INTERVAL_SEC))
+		if (!(i % SC_ERR_MSG_INTERVAL_SEC))
 			XGQ_WARN(xgq, "SC is not ready in %d sec, waiting for SC to be ready", i);
 	}
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
@@ -2951,7 +2951,7 @@ static bool vmr_check_sc_is_ready(struct xocl_xgq_vmr *xgq)
 		}
 
 		if (loop_counter % SC_ERR_MSG_INTERVAL_SEC == 0)
-			XGQ_WARN(xgq, "SC is not ready after %d sec, waiting for SC to be ready", loop_counter);
+			XGQ_WARN(xgq, "SC is not ready in %d sec, waiting for SC to be ready", i + 1);
 		msleep(SC_WAIT_INTERVAL_MILLI_SEC);
 	}
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
@@ -78,7 +78,12 @@
 static DEFINE_IDR(xocl_xgq_vmr_cid_idr);
 #define XOCL_VMR_INVALID_CID	0xFFFF
 
-/* Retry is set to 200 seconds for SC to be active*/
+/* Retry is set to 200 seconds for SC to be active/ready
+ * On the SC firmware side there is a HW watchdog timer, which will automatically recover the SC
+ * when SC got hung during the bootup.
+ * If SC get hung during bootup, it would take 180 secs to recover and another ~20 secs window
+ * as a buffer time to fetch and get ready with all the sensor data.
+ */
 #define MAX_SC_WAIT_TIMEOUT_SEC     200
 #define SC_WAIT_INTERVAL_MILLI_SEC  1000
 #define SC_ERR_MSG_INTERVAL_SEC     5

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
@@ -85,7 +85,7 @@ static DEFINE_IDR(xocl_xgq_vmr_cid_idr);
  * as a buffer time to fetch and get ready with all the sensor data.
  */
 #define MAX_SC_WAIT_TIMEOUT_SEC     200
-#define SC_WAIT_INTERVAL_MILLI_SEC  1000
+#define SC_WAIT_INTERVAL_MSEC  1000
 #define SC_ERR_MSG_INTERVAL_SEC     5
 
 /* cmd timeout in seconds */
@@ -3012,9 +3012,8 @@ static bool vmr_check_sc_is_ready(struct xocl_xgq_vmr *xgq)
 {
 	struct xgq_cmd_cq_vmr_payload *vmr_status =
 		(struct xgq_cmd_cq_vmr_payload *)&xgq->xgq_cq_payload;
-	int ret = 0;;
+	int ret = vmr_status_query(xgq->xgq_pdev);
 
-	ret = vmr_status_query(xgq->xgq_pdev);
 	if (ret)
 		XGQ_ERR(xgq, "received error %d for vmr_status_query xgq request", ret);
 
@@ -3027,12 +3026,11 @@ static bool vmr_check_sc_is_ready(struct xocl_xgq_vmr *xgq)
 /* Wait for SC is fully ready during driver init (in reset) */
 static bool vmr_wait_for_sc_ready(struct xocl_xgq_vmr *xgq)
 {
-	int loop_counter = MAX_SC_WAIT_TIMEOUT_SEC * (1000 / SC_WAIT_INTERVAL_MILLI_SEC);
-	int sleep_time = SC_WAIT_INTERVAL_MILLI_SEC;
-	int i = 0;
+	const unsigned int loop_counter = MAX_SC_WAIT_TIMEOUT_SEC * (1000 / SC_WAIT_INTERVAL_MSEC);
+	unsigned int i = 0;
 
 	for (i = 1; i <= loop_counter; i++) {
-		msleep(SC_WAIT_INTERVAL_MILLI_SEC);
+		msleep(SC_WAIT_INTERVAL_MSEC);
 		if (vmr_check_sc_is_ready(xgq)) {
 			XGQ_INFO(xgq, "SC is ready after %d sec", i);
 			return true;


### PR DESCRIPTION
XRT shall not issue any sensor requests if SC is in unknown/error state So, load hwmon_sdm driver only when SC is in ready & active state

Signed-off-by: Rajkumar Rampelli <rampelli@amd.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
XRT issues BDINFO request to VMR as part of driver init and receiving SC firmware version as all 0's during reset. Since, by the time VMR receives this request, it doesn't have SC version data due to SC link is not active. To fix this case, Introduced new field in vmr_payload structure called "sc_is_ready" which will be used to get the status of SC. sc_is_ready = 1 means SC is ready.
So, XRT waits for SC readiness and it polls for 200 seconds.
If SC is not ready during this time, XGQ prints the the same and doesn't load hwmon_sdm driver.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1143553
#### How problem was solved, alternative solutions (if any) and why they were rejected
#### Risks (if any) associated the changes in the commit
NA
#### What has been tested and how, request additional testing if necessary
xbutil reset
#### Documentation impact (if any)
NA