### PR TITLE
CR-1118375 CU stat node outputs more than 4KB data

### DIFF
--- a/src/runtime_src/core/common/drv/include/kds_core.h
+++ b/src/runtime_src/core/common/drv/include/kds_core.h
@@ -228,6 +228,6 @@ int kds_ip_layout2scu_info(struct ip_layout *ip_layout, struct xrt_cu_info cu_in
 int store_kds_echo(struct kds_sched *kds, const char *buf, size_t count,
 		   int *echo);
 ssize_t show_kds_stat(struct kds_sched *kds, char *buf);
-ssize_t show_kds_custat_raw(struct kds_sched *kds, char *buf);
-ssize_t show_kds_scustat_raw(struct kds_sched *kds, char *buf);
+ssize_t show_kds_custat_raw(struct kds_sched *kds, char *buf, size_t buf_size);
+ssize_t show_kds_scustat_raw(struct kds_sched *kds, char *buf, size_t buf_size);
 #endif

--- a/src/runtime_src/core/common/drv/include/kds_core.h
+++ b/src/runtime_src/core/common/drv/include/kds_core.h
@@ -228,6 +228,8 @@ int kds_ip_layout2scu_info(struct ip_layout *ip_layout, struct xrt_cu_info cu_in
 int store_kds_echo(struct kds_sched *kds, const char *buf, size_t count,
 		   int *echo);
 ssize_t show_kds_stat(struct kds_sched *kds, char *buf);
+#define MAX_CU_STAT_LINE_LENGTH  128
+#define MAX_CU_STAT_BUFFER_SIZE (MAX_CU_STAT_LINE_LENGTH * MAX_CUS)
 ssize_t show_kds_custat_raw(struct kds_sched *kds, char *buf, size_t buf_size);
 ssize_t show_kds_scustat_raw(struct kds_sched *kds, char *buf, size_t buf_size);
 #endif

--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -45,7 +45,7 @@ int store_kds_echo(struct kds_sched *kds, const char *buf, size_t count,
 	return count;
 }
 
-ssize_t show_kds_custat_raw(struct kds_sched *kds, char *buf)
+ssize_t show_kds_custat_raw(struct kds_sched *kds, char *buf, size_t buf_size)
 {
 	struct kds_cu_mgmt *cu_mgmt = &kds->cu_mgmt;
 	struct xrt_cu *xcu = NULL;
@@ -68,7 +68,7 @@ ssize_t show_kds_custat_raw(struct kds_sched *kds, char *buf)
 			if (xcu->info.slot_idx != j)
 				continue;
 
-			sz += scnprintf(buf+sz, PAGE_SIZE - sz, cu_fmt, j,
+			sz += scnprintf(buf+sz, buf_size - sz, cu_fmt, j,
 					set_domain(DOMAIN_PL, i),
 					xcu->info.kname, xcu->info.iname,
 					xcu->info.addr, xcu->status,
@@ -80,7 +80,7 @@ ssize_t show_kds_custat_raw(struct kds_sched *kds, char *buf)
 	return sz;
 }
 
-ssize_t show_kds_scustat_raw(struct kds_sched *kds, char *buf)
+ssize_t show_kds_scustat_raw(struct kds_sched *kds, char *buf, size_t buf_size)
 {
 	struct kds_cu_mgmt *scu_mgmt = &kds->scu_mgmt;
 	/* Each line is a PS kernel, format:
@@ -113,7 +113,7 @@ ssize_t show_kds_scustat_raw(struct kds_sched *kds, char *buf)
 			if (xcu->info.slot_idx != j)
 				continue;
 
-			sz += scnprintf(buf+sz, PAGE_SIZE - sz, cu_fmt, j,
+			sz += scnprintf(buf+sz, buf_size - sz, cu_fmt, j,
 					set_domain(DOMAIN_PS, i),
 					xcu->info.kname,xcu->info.iname,
 					xcu->status,

--- a/src/runtime_src/core/edge/user/device_linux.cpp
+++ b/src/runtime_src/core/edge/user/device_linux.cpp
@@ -270,10 +270,10 @@ struct kds_cu_info
     std::vector<std::string> stats;
     std::string errmsg;
 
-    // The kds_custat_raw is printing in formatted string of each line
+    // The kds_custat_bin is printing in formatted string of each line
     // Format: "%d,%s:%s,0x%lx,0x%x,%lu"
     // Using comma as separator.
-    edev->sysfs_get("kds_custat_raw", errmsg, stats);
+    edev->sysfs_get("kds_custat_bin", errmsg, stats);
     if (!errmsg.empty())
       throw xrt_core::query::sysfs_error(errmsg);
 

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -360,10 +360,10 @@ struct kds_cu_info
     std::vector<std::string> stats;
     std::string errmsg;
 
-    // The kds_custat_raw is printing in formatted string of each line
+    // The kds_custat_bin is printing in formatted string of each line
     // Format: "%d,%s:%s,0x%lx,0x%x,%lu"
     // Using comma as separator.
-    pdev->sysfs_get("", "kds_custat_raw", errmsg, stats);
+    pdev->sysfs_get("", "kds_custat_bin", errmsg, stats);
     if (!errmsg.empty())
       throw xrt_core::query::sysfs_error(errmsg);
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1118375
CU statistic sysfs node corrupted because the sysfs node is providing more than one page (4KB) worth of data.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
When an xclbin contains a very large number of CUs the current sysfs node will not output all available data. In addition, the XRT tools correctly states that the data is corrupted due to missing information.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Created a new node, kds_custat_bin, which is capable of transferring the all CU data defined by kds_core. The current solution does not account for the chance that the CU data will change during the request. @houlz0507 and I discussed how to solve this issue and found that implementing a solution is rather complicated and consumes a large amount of resources for a sysfs node.

#### Risks (if any) associated the changes in the commit
None, this is a bug fix. The original sysfs node should remain in the system, we should deprecate kds_custat_raw and remove it in a few releases.

#### What has been tested and how, request additional testing if necessary
Ubuntu 20.04 with a very large sysfs node output
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ cat /sys/bus/pci/devices/0000\:17\:00.1/kds_custat_bin
0,0,verify:verify_1,0x20200010000,0x4,1
0,0,verify:verify_1,0x20200010000,0x4,1
0,0,verify:verify_1,0x20200010000,0x4,1
... Many more CUs ...
0,0,verify:verify_1,0x20200010000,0x4,1
0,0,verify:verify_1,0x20200010000,0x4,1
0,0,verify:verify_1,0x20200010000,0x4,1
0,0,verify:verify_1,0x20200010000,0x4,1

dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov/XRT/build/Debug/opt/xilinx/xrt/test$ xbutil validate -d 17:00 -r verify
WARNING: Unexpected xocl version (2.14.0) was found. Expected 2.15.0, to match XRT tools.
Validate Device           : [0000:17:00.1]
    Platform              : xilinx_vck5000_gen4x8_qdma_base_2
    SC Version            : 4.4.35
    Platform ID           : 1971A813-FB69-0FE5-3BD6-46F30F4D9987
-------------------------------------------------------------------------------
Verbose: Enabling Verbosity
Test 1 [0000:17:00.1]     : verify
    Description           : Run 'Hello World' kernel test
    Xclbin                : /opt/xilinx/firmware/vck5000/gen4x8-qdma/base/test
    Testcase              : /opt/xilinx/xrt/test/validate.exe
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Validation completed
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov/XRT/build/Debug/opt/xilinx/xrt/test$ xbutil examine -d 17:00 -r dynamic-regions
WARNING: Unexpected xocl version (2.14.0) was found. Expected 2.15.0, to match XRT tools.

---------------------------------------------------
[0000:17:00.1] : xilinx_vck5000_gen4x8_qdma_base_2
---------------------------------------------------
Xclbin UUID
  BBBF933F-0FB0-E22E-36AC-973B8B0C1217

Compute Units
  PL Compute Units
    Index   Name                                              Base_Address    Usage   Status
    0       verify:verify_1                                   0x20200010000   2       (IDLE)
    1       verify:verify_1                                   0x20200010000   2       (IDLE)
    2       verify:verify_1                                   0x20200010000   2       (IDLE)
    ... Many more CUs ...
    197     verify:verify_1                                   0x20200010000   2       (IDLE)
    198     verify:verify_1                                   0x20200010000   2       (IDLE)
    199     verify:verify_1                                   0x20200010000   2       (IDLE)

  PS Compute Units
    Index   Name                                              Base_Address    Usage   Status

```
Ubuntu 20.04 Normal Operation
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ xbutil validate -d 17:00 -r verify
WARNING: Unexpected xocl version (2.14.0) was found. Expected 2.15.0, to match XRT tools.
Validate Device           : [0000:17:00.1]
    Platform              : xilinx_vck5000_gen4x8_qdma_base_2
    SC Version            : 4.4.35
    Platform ID           : 1971A813-FB69-0FE5-3BD6-46F30F4D9987
-------------------------------------------------------------------------------
Verbose: Enabling Verbosity
Test 1 [0000:17:00.1]     : verify
    Description           : Run 'Hello World' kernel test
    Xclbin                : /opt/xilinx/firmware/vck5000/gen4x8-qdma/base/test
    Testcase              : /opt/xilinx/xrt/test/validate.exe
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Validation completed
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ cat /sys/bus/pci/devices/0000\:17\:00.1/kds_custat_bin
0,0,verify:verify_1,0x20200010000,0x4,1
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ xbutil examine -d 17:00 -r dynamic-regions
WARNING: Unexpected xocl version (2.14.0) was found. Expected 2.15.0, to match XRT tools.

---------------------------------------------------
[0000:17:00.1] : xilinx_vck5000_gen4x8_qdma_base_2
---------------------------------------------------
Xclbin UUID
  BBBF933F-0FB0-E22E-36AC-973B8B0C1217

Compute Units
  PL Compute Units
    Index   Name                                              Base_Address    Usage   Status
    0       verify:verify_1                                   0x20200010000   1       (IDLE)

  PS Compute Units
    Index   Name                                              Base_Address    Usage   Status
```
#### Documentation impact (if any)
None