### PR TITLE
CR-1066713 Provide way to get zocl version info using xbutil/xbmgmt

### DIFF
--- a/build/build_edge.sh
+++ b/build/build_edge.sh
@@ -67,6 +67,9 @@ install_recipes()
         echo 'PACKAGE_CLASSES = "package_rpm"' >> $ZOCL_BB
         echo 'LICENSE = "GPLv2 & Apache-2.0"' >> $ZOCL_BB
         echo 'LIC_FILES_CHKSUM = "file://LICENSE;md5=7d040f51aae6ac6208de74e88a3795f8"' >> $ZOCL_BB
+        if [[ ! -z $XRT_VERSION_PATCH ]]; then
+            echo "EXTRA_OEMAKE += \"XRT_VERSION_PATCH=$XRT_VERSION_PATCH\"" >> $ZOCL_BB
+        fi
         echo 'pkg_postinst_ontarget_${PN}() {' >> $ZOCL_BB
         echo '  #!/bin/sh' >> $ZOCL_BB
         echo '  echo "Unloading old XRT Linux kernel modules"' >> $ZOCL_BB

--- a/src/runtime_src/core/common/info_vmr.cpp
+++ b/src/runtime_src/core/common/info_vmr.cpp
@@ -61,10 +61,14 @@ vmr_info(const xrt_core::device* device)
   //parse one line at a time
   for (auto& stat_raw : vmr_status_raw) {
     ptree_type pt_stat;
-    std::vector<std::string> stat;
-    boost::split(stat, stat_raw, boost::is_any_of(":")); // eg: HAS_FPT:1
-    pt_stat.add("label", pretty_label(stat.at(0)));      // eg: Has ftp
-    pt_stat.add("value", stat.at(1));                    // eg: 1
+    const auto idx = stat_raw.find_first_of(':');
+    if (idx != std::string::npos) {
+      pt_stat.add("label", pretty_label(stat_raw.substr(0, idx)));
+      pt_stat.add("value", stat_raw.substr(idx + 1));
+    }
+    else {
+      throw std::runtime_error("Incorrect vmr stat format");
+    }
     pt_vmr_stats.push_back(std::make_pair("", pt_stat));
   }
   pt_vmr_status_array.add_child("vmr", pt_vmr_stats);

--- a/src/runtime_src/core/edge/drm/zocl/Makefile
+++ b/src/runtime_src/core/edge/drm/zocl/Makefile
@@ -87,7 +87,6 @@ git_variables:
 	$(eval DATE_NOW ?= $(shell date "+%Y-%m-%d"))
 
 	$(eval cflags_module := -DXRT_HASH="\"$(GIT_HASH)\"" -DXRT_HASH_DATE="\"$(GIT_HASH_DATE)\"" -DXRT_BRANCH="\"$(GIT_BRANCH)\"" -DXRT_MODIFIED_FILES="\"$(GIT_MODIFIED_FILES)\"" -DXRT_DATE="\"$(DATE_NOW)\"" -DXRT_DRIVER_VERSION="\"$(XRT_DRIVER_VERSION)\"")
-	$(error "flags - $(cflags_module)")
 
 modules: git_variables
 	$(MAKE) -C $(KERNEL_SRC) M=$(SRC) CFLAGS_MODULE='$(cflags_module)' modules

--- a/src/runtime_src/core/edge/drm/zocl/Makefile
+++ b/src/runtime_src/core/edge/drm/zocl/Makefile
@@ -22,11 +22,19 @@ endif
 
 endif
 
-ccflags-y := -I$(src)/include -I$(src)/../../include -I$(src)/../../../include -I$(src)/../../../common/drv/include -DXRT_HASH="\"$(GIT_HASH)\"" -DXRT_HASH_DATE="\"$(GIT_HASH_DATE)\"" -DXRT_BRANCH="\"$(GIT_BRANCH)\"" -DXRT_MODIFIED_FILES="\"$(GIT_MODIFIED_FILES)\"" -DXRT_DATE="\"$(DATE_NOW)\"" -DXRT_DRIVER_VERSION="\"$(XRT_DRIVER_VERSION)\""
+ccflags-y := -I$(src)/include -I$(src)/../../include -I$(src)/../../../include -I$(src)/../../../common/drv/include
 
 #flags passed from xrt_git.bb file are added below
 ifneq ($(cflags_zocl),)
 	ccflags-y += $(cflags_zocl)
+endif
+
+# Version is specific to release
+XRT_DRIVER_VERSION ?= 2.15.0
+
+# Add patch number in version if 'XRT_VERSION_PATCH' env variable is defined
+ifneq ($(XRT_VERSION_PATCH),)
+	XRT_DRIVER_VERSION:=$(XRT_DRIVER_VERSION:.0=.$(XRT_VERSION_PATCH))
 endif
 
 drv_common-y   := $(common_dir)/kds_core.o \
@@ -68,8 +76,21 @@ obj-m	+= zocl.o
 
 SRC := $(shell pwd)
 
-modules:
-	$(MAKE) -C $(KERNEL_SRC) M=$(SRC) modules
+all: modules
+
+git_variables:
+	$(eval GIT_HASH ?= $(shell git rev-parse --verify HEAD))
+	$(eval GIT_HASH_DATE ?= $(shell git log -1 --pretty=format:%cD))
+	$(eval GIT_BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD))
+	$(eval TMP_MODIFIED_FILES ?= $(shell git status --porcelain -uno))
+	$(eval GIT_MODIFIED_FILES ?= $(subst \\n,\,,$(TMP_MODIFIED_FILES)))
+	$(eval DATE_NOW ?= $(shell date "+%Y-%m-%d"))
+
+	$(eval cflags_module := -DXRT_HASH="\"$(GIT_HASH)\"" -DXRT_HASH_DATE="\"$(GIT_HASH_DATE)\"" -DXRT_BRANCH="\"$(GIT_BRANCH)\"" -DXRT_MODIFIED_FILES="\"$(GIT_MODIFIED_FILES)\"" -DXRT_DATE="\"$(DATE_NOW)\"" -DXRT_DRIVER_VERSION="\"$(XRT_DRIVER_VERSION)\"")
+	$(error "flags - $(cflags_module)")
+
+modules: git_variables
+	$(MAKE) -C $(KERNEL_SRC) M=$(SRC) CFLAGS_MODULE='$(cflags_module)' modules
 
 modules_install:
 	$(MAKE) -C $(KERNEL_SRC) M=$(SRC) modules_install

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
@@ -40,6 +40,18 @@
 #define ZOCL_PLATFORM_ARM64   0
 #endif
 
+#ifndef XRT_DRIVER_VERSION
+#define XRT_DRIVER_VERSION ""
+#endif
+
+#ifndef XRT_HASH
+#define XRT_HASH ""
+#endif
+
+#ifndef XRT_HASH_DATE
+#define XRT_HASH_DATE ""
+#endif
+
 /* Ensure compatibility with newer kernels and backported Red Hat kernels. */
 /* The y2k38 bug fix was introduced with Kernel 3.17 and backported to Red Hat
  * 7.2.

--- a/src/runtime_src/core/edge/drm/zocl/zocl_rpu_channel.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_rpu_channel.c
@@ -144,7 +144,25 @@ static void zchan_cmd_log_page(struct zocl_rpu_channel *chan, struct xgq_cmd_sq_
 	memcpy_toio(chan->mem_base + add_off, info_buf, count);
 	total_count += count;
 
-	count = snprintf(info_buf, sizeof(info_buf), "put zocl version here\n");
+	count = snprintf(info_buf, sizeof(info_buf), "%s%s%s\n", XRT_DRIVER_VERSION, ", ", XRT_HASH);
+	if (total_count + count > size) {
+		zchan_err(chan, "message is trunked to %d len", total_count);
+		ret = -EINVAL;
+		goto done;
+	}
+	memcpy_toio(chan->mem_base + add_off + total_count, info_buf, count);
+	total_count += count;
+
+	count = snprintf(info_buf, sizeof(info_buf), "ZOCL Build Date:");
+	if (total_count + count > size) {
+		zchan_err(chan, "message is trunked to %d len", total_count);
+		ret = -EINVAL;
+		goto done;
+	}
+	memcpy_toio(chan->mem_base + add_off + total_count, info_buf, count);
+	total_count += count;
+
+	count = snprintf(info_buf, sizeof(info_buf), "%s\n", XRT_HASH_DATE);
 	if (total_count + count > size) {
 		zchan_err(chan, "message is trunked to %d len", total_count);
 		ret = -EINVAL;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Added changes to get zocl version info that can be reported using xbutil/xbmgmt commands.
In this PR I have added changes to report zocl version using -> xbmgmt examine -r vmr -d --verbose
TODO: Print this zocl version using xbutil examine command as well

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
As Edge platforms dont use dkms flow added commands to get git info in Makefile which is passed to zocl during module build process.

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
Tested the changes on V70 device and below is the sample o/p:
![image](https://user-images.githubusercontent.com/54270708/197725212-60bbfbfb-79c7-471a-828d-ab4d944bae35.png)


#### Documentation impact (if any)
NA