### PR TITLE
Cr 1119458 - Replace raw pointers with smart pointers 

### DIFF
--- a/src/runtime_src/core/pcie/emulation/common_em/em_defines.h
+++ b/src/runtime_src/core/pcie/emulation/common_em/em_defines.h
@@ -133,6 +133,47 @@ namespace xclemulation {
     std::string           filename;
     int                   fd;
     std::map<uint64_t,uint64_t> chunks;
+    drm_xocl_bo() = default;
+    ~drm_xocl_bo() = default;
+    drm_xocl_bo(const drm_xocl_bo& rhs) {
+      this->metadata.state = rhs.metadata.state;
+      this->metadata.index = rhs.metadata.index;
+      this->base = rhs.base;
+      this->size = rhs.size;
+
+      this->buf = rhs.buf;             //shallow copy
+      this->userptr = rhs.userptr;         //shallow copy
+
+      this->flags = rhs.flags;
+      this->handle = rhs.handle;
+      this->topology = rhs.topology;
+      this->filename = rhs.filename;
+      this->fd = rhs.fd;
+      this->chunks = rhs.chunks;
+
+    }
+
+    drm_xocl_bo& operator = (const drm_xocl_bo& rhs) {
+      if (this == &rhs) {
+        return *this;
+      }
+      this->metadata.state = rhs.metadata.state;
+      this->metadata.index = rhs.metadata.index;
+      this->base = rhs.base;
+      this->size = rhs.size;
+
+      this->buf = rhs.buf;             //shallow copy
+      this->userptr = rhs.userptr;         //shallow copy
+
+      this->flags = rhs.flags;
+      this->handle = rhs.handle;
+      this->topology = rhs.topology;
+      this->filename = rhs.filename;
+      this->fd = rhs.fd;
+      this->chunks = rhs.chunks;
+
+    }
+
   };
 
   //we should not create a memory in default bank for hw_emu. As sw_emu doesnt have rtd information, we are not doing any error check

--- a/src/runtime_src/core/pcie/emulation/common_em/em_defines.h
+++ b/src/runtime_src/core/pcie/emulation/common_em/em_defines.h
@@ -34,6 +34,7 @@
 #include <cstdint>
 #include <iostream>
 #include <map>
+#include <memory>
 #include "xrt_mem.h"
 #define GCC_VERSION (__GNUC__ * 10000 \
                      + __GNUC_MINOR__ * 100 \
@@ -147,32 +148,32 @@ namespace xclemulation {
     return flag;
   }
 
-  static inline bool xocl_bo_p2p(const struct drm_xocl_bo *bo)
+  static inline bool xocl_bo_p2p(const std::shared_ptr<struct drm_xocl_bo>& bo)
   {
     return (bo->flags & XCL_BO_FLAGS_P2P);
   }
   
-  static inline bool xocl_bo_dev_only(const struct drm_xocl_bo *bo)
+  static inline bool xocl_bo_dev_only(const std::shared_ptr<struct drm_xocl_bo>& bo)
   {
     return (bo->flags & XCL_BO_FLAGS_DEV_ONLY);
   }
 
-  static inline bool xocl_bo_host_only(const struct drm_xocl_bo *bo)
+  static inline bool xocl_bo_host_only(const std::shared_ptr<struct drm_xocl_bo>& bo)
   {
     return (bo->flags & XCL_BO_FLAGS_HOST_ONLY);
   }  
 
-  static inline bool no_host_memory(const struct drm_xocl_bo *bo)
+  static inline bool no_host_memory(const std::shared_ptr<struct drm_xocl_bo>& bo)
   {
     return xocl_bo_dev_only(bo) || xocl_bo_p2p(bo) ;
   }
 
-  static inline bool is_cacheable(const struct drm_xocl_bo *bo) {
+  static inline bool is_cacheable(const std::shared_ptr<struct drm_xocl_bo>& bo) {
     return (bo->flags & XCL_BO_FLAGS_CACHEABLE);
   }
 
   //API which denotes whether the sync of data is required or not
-  static inline bool is_zero_copy(const struct drm_xocl_bo *bo) {
+  static inline bool is_zero_copy(const std::shared_ptr<struct drm_xocl_bo>& bo) {
     bool isCacheable = xclemulation::is_cacheable(bo);
     bool memCheck = xclemulation::no_host_memory(bo) || xclemulation::xocl_bo_host_only(bo);
     bool zeroCopy = (memCheck || !isCacheable) ? true : false;

--- a/src/runtime_src/core/pcie/emulation/common_em/em_defines.h
+++ b/src/runtime_src/core/pcie/emulation/common_em/em_defines.h
@@ -133,47 +133,6 @@ namespace xclemulation {
     std::string           filename;
     int                   fd;
     std::map<uint64_t,uint64_t> chunks;
-    drm_xocl_bo() = default;
-    ~drm_xocl_bo() = default;
-    drm_xocl_bo(const drm_xocl_bo& rhs) {
-      this->metadata.state = rhs.metadata.state;
-      this->metadata.index = rhs.metadata.index;
-      this->base = rhs.base;
-      this->size = rhs.size;
-
-      this->buf = rhs.buf;             //shallow copy
-      this->userptr = rhs.userptr;         //shallow copy
-
-      this->flags = rhs.flags;
-      this->handle = rhs.handle;
-      this->topology = rhs.topology;
-      this->filename = rhs.filename;
-      this->fd = rhs.fd;
-      this->chunks = rhs.chunks;
-
-    }
-
-    drm_xocl_bo& operator = (const drm_xocl_bo& rhs) {
-      if (this == &rhs) {
-        return *this;
-      }
-      this->metadata.state = rhs.metadata.state;
-      this->metadata.index = rhs.metadata.index;
-      this->base = rhs.base;
-      this->size = rhs.size;
-
-      this->buf = rhs.buf;             //shallow copy
-      this->userptr = rhs.userptr;         //shallow copy
-
-      this->flags = rhs.flags;
-      this->handle = rhs.handle;
-      this->topology = rhs.topology;
-      this->filename = rhs.filename;
-      this->fd = rhs.fd;
-      this->chunks = rhs.chunks;
-
-    }
-
   };
 
   //we should not create a memory in default bank for hw_emu. As sw_emu doesnt have rtd information, we are not doing any error check

--- a/src/runtime_src/core/pcie/emulation/common_em/memorymanager.h
+++ b/src/runtime_src/core/pcie/emulation/common_em/memorymanager.h
@@ -39,16 +39,16 @@ static std::string DEFAULT_TAG("");
         uint64_t mSize;
         uint64_t mStart;
         uint64_t mAlignment;
-	    std::string mTag;
+        std::string mTag;
         const unsigned mCoalesceThreshold;
         uint64_t mFreeSize;
 
         typedef std::list<std::pair<uint64_t, uint64_t> > PairList;
 
     public:
-	static const uint64_t mNull = 0xffffffffffffffffull;
-    std::list<std::shared_ptr<MemoryManager> > mChildMemories;
-
+        static const uint64_t mNull = 0xffffffffffffffffull;
+        //std::list<std::shared_ptr<MemoryManager> > mChildMemories;
+        std::vector<std::shared_ptr<MemoryManager> > mChildMemories;
     public:
         MemoryManager(uint64_t size, uint64_t start, unsigned alignment, std::string&tag = DEFAULT_TAG );
         ~MemoryManager();
@@ -59,7 +59,7 @@ static std::string DEFAULT_TAG("");
         uint64_t size()     { return mSize; }
         uint64_t start()    { return mStart; }
         uint64_t freeSize() { return mFreeSize; }
-	std::string tag()   { return mTag; }
+	    std::string tag()   { return mTag; }
         static bool isNullAlloc(const std::pair<uint64_t, uint64_t>& buf) { return ((buf.first == mNull) || (buf.second == mNull)); }
 
         std::pair<uint64_t, uint64_t>lookup(uint64_t buf);

--- a/src/runtime_src/core/pcie/emulation/common_em/memorymanager.h
+++ b/src/runtime_src/core/pcie/emulation/common_em/memorymanager.h
@@ -22,6 +22,7 @@
 #include <map>
 #include <cassert>
 #include <algorithm>
+#include <memory>
 
 #include "em_defines.h"
 #include "xclhal2.h"
@@ -46,7 +47,8 @@ static std::string DEFAULT_TAG("");
 
     public:
 	static const uint64_t mNull = 0xffffffffffffffffull;
-	std::list<MemoryManager*> mChildMemories;
+	//std::list<MemoryManager*> mChildMemories;
+    std::list<std::shared_ptr<MemoryManager> > mChildMemories;
 
     public:
         MemoryManager(uint64_t size, uint64_t start, unsigned alignment, std::string&tag = DEFAULT_TAG );

--- a/src/runtime_src/core/pcie/emulation/common_em/memorymanager.h
+++ b/src/runtime_src/core/pcie/emulation/common_em/memorymanager.h
@@ -19,6 +19,7 @@
 
 #include <mutex>
 #include <list>
+#include <vector>
 #include <map>
 #include <cassert>
 #include <algorithm>

--- a/src/runtime_src/core/pcie/emulation/common_em/memorymanager.h
+++ b/src/runtime_src/core/pcie/emulation/common_em/memorymanager.h
@@ -39,7 +39,7 @@ static std::string DEFAULT_TAG("");
         uint64_t mSize;
         uint64_t mStart;
         uint64_t mAlignment;
-	std::string mTag;
+	    std::string mTag;
         const unsigned mCoalesceThreshold;
         uint64_t mFreeSize;
 
@@ -47,7 +47,6 @@ static std::string DEFAULT_TAG("");
 
     public:
 	static const uint64_t mNull = 0xffffffffffffffffull;
-	//std::list<MemoryManager*> mChildMemories;
     std::list<std::shared_ptr<MemoryManager> > mChildMemories;
 
     public:

--- a/src/runtime_src/core/pcie/emulation/common_em/memorymanager.h
+++ b/src/runtime_src/core/pcie/emulation/common_em/memorymanager.h
@@ -47,7 +47,6 @@ static std::string DEFAULT_TAG("");
 
     public:
         static const uint64_t mNull = 0xffffffffffffffffull;
-        //std::list<std::shared_ptr<MemoryManager> > mChildMemories;
         std::vector<std::shared_ptr<MemoryManager> > mChildMemories;
     public:
         MemoryManager(uint64_t size, uint64_t start, unsigned alignment, std::string&tag = DEFAULT_TAG );
@@ -59,7 +58,7 @@ static std::string DEFAULT_TAG("");
         uint64_t size()     { return mSize; }
         uint64_t start()    { return mStart; }
         uint64_t freeSize() { return mFreeSize; }
-	    std::string tag()   { return mTag; }
+        std::string tag()   { return mTag; }
         static bool isNullAlloc(const std::pair<uint64_t, uint64_t>& buf) { return ((buf.first == mNull) || (buf.second == mNull)); }
 
         std::pair<uint64_t, uint64_t>lookup(uint64_t buf);

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/device_swemu.cxx
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/device_swemu.cxx
@@ -35,7 +35,7 @@ struct device_query
   static uint32_t
     get(const xrt_core::device* device, key_type query_key)
   {
-    xclcpuemhal2::CpuemShim *drv = xclcpuemhal2::CpuemShim::handleCheck(device->get_device_handle());
+    auto drv = xclcpuemhal2::CpuemShim::handleCheck(device->get_device_handle());
     if (!drv)
       return 0;
     return drv->deviceQuery(query_key);

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/halapi.cxx
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/halapi.cxx
@@ -88,13 +88,7 @@ xclDeviceHandle xclOpen(unsigned deviceIndex, const char *logfileName, xclVerbos
     handle->set_my_device_index(deviceIndex);
     xclcpuemhal2::devices[deviceIndex++] = handle;
   }
-/* 
-// To be deleted section
-  if (!xclcpuemhal2::CpuemShim::handleCheck(handle)) {
-    delete handle;
-    handle = 0;
-  }
-  */
+
   if (handle) {
     handle->xclOpen(logfileName);
     if (bDefaultDevice)
@@ -113,7 +107,7 @@ void xclClose(xclDeviceHandle handle)
   if (!drv)
     return ;
   drv->xclClose();
-  if (xclcpuemhal2::CpuemShim::handleCheck(handle)){ // && xclcpuemhal2::devices.size() == 0) {
+  if (xclcpuemhal2::CpuemShim::handleCheck(handle)){ 
     auto device_index = drv->get_my_device_index();
     auto itr = xclcpuemhal2::devices.find(device_index);
     if (itr != xclcpuemhal2::devices.end()) {
@@ -670,20 +664,18 @@ void*
 xclGraphOpen(xclDeviceHandle handle, const uuid_t xclbin_uuid, const char* graph, xrt::graph::access_mode am)
 {
   try {
-    //auto raw_drv = xclcpuemhal2::CpuemShim::handleCheck(handle);
     std::shared_ptr<xclcpuemhal2::CpuemShim> drv{xclcpuemhal2::CpuemShim::handleCheck(handle)};
-    // xclGraphHandle graphHandle = new xclcpuemhal2::GraphType(drv, graph);
     auto graphHandle = std::make_shared<xclcpuemhal2::GraphType>(drv, graph);
     if (graphHandle) {
       auto drv = graphHandle->getDeviceHandle();
       if (drv) {
-        //graph handler should be live somewhere thourgh out this shim scope so let's have graph devices map take care of it.
+        // graph handler should be live somewhere thourgh out this shim scope 
+        // so let's have graph devices map to take care of it.
         xclcpuemhal2::graph_devices[graphHandle->getGraphHandle()] = graphHandle;
         drv->xrtGraphInit(graphHandle);
       }
       else {
-        //delete ghPtr;
-        // A graph handler without a shim device handle
+        // A graph handler without a shim device handle, Not possible?
         graphHandle.reset();
         return XRT_NULL_HANDLE;
       }
@@ -712,7 +704,6 @@ xclGraphClose(xclGraphHandle ghl)
       else {
         std::cout << " \n Graph device is invalid, so unable to delete it." << std::endl;
       }
-      // delete ghPtr;
     }
   }
   catch (const std::exception& ex) {

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/halapi.cxx
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/halapi.cxx
@@ -87,7 +87,8 @@ xclDeviceHandle xclOpen(unsigned deviceIndex, const char *logfileName, xclVerbos
     bDefaultDevice = true;
     xclcpuemhal2::devices[deviceIndex++] = handle;
   }
-/*
+/* 
+// To be deleted section
   if (!xclcpuemhal2::CpuemShim::handleCheck(handle)) {
     delete handle;
     handle = 0;
@@ -669,6 +670,7 @@ xclGraphOpen(xclDeviceHandle handle, const uuid_t xclbin_uuid, const char* graph
     if (graphHandle) {
       auto drv = graphHandle->getDeviceHandle();
       if (drv) {
+        //graph handler should be live somewhere thourgh out this shim scope so let's shim devices map here.
         xclcpuemhal2::graph_devices[graphHandle->getGraphHandle()] = graphHandle;
         drv->xrtGraphInit(graphHandle);
       }

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
@@ -137,7 +137,6 @@ namespace xclcpuemhal2
       const uint64_t bankSize = (*start).ddrSize;
       mDdrBanks.push_back(*start);
       //CR 966701: alignment to 4k (instead of mDeviceInfo.mDataAlignment)
-      //mDDRMemoryManager.push_back(new xclemulation::MemoryManager(bankSize, base, getpagesize()));
       mDDRMemoryManager.push_back(std::make_shared<xclemulation::MemoryManager>(bankSize, base, getpagesize()));
       base += bankSize;
     }
@@ -157,21 +156,15 @@ namespace xclcpuemhal2
       return 0;
     return reinterpret_cast<CpuemShim *>(handle);
 /*
-    // why are we checking shim pointer address with a const address?
+    //  This check is to ensure this is a sw_emu shim object only, this will be obselete in future, 
+    //  Lets have it for now.
     if (*(unsigned *)handle != TAG)
       return 0;
-    if (!((CpuemShim *)handle)->isGood())
-      return 0;
-
-    return (CpuemShim *)handle;
     */
   }
 
   static void saveDeviceProcessOutputs()
   {
-    //auto start = devices.begin();
-    //auto end = devices.end();
-    //for (; start != end; start++)
     for(auto & device_pair : devices)
     {
       auto handle = device_pair.second;
@@ -1513,7 +1506,6 @@ namespace xclcpuemhal2
       ddr = 0;
     }
 
-    //struct xclemulation::drm_xocl_bo *xobj = new xclemulation::drm_xocl_bo;
     auto xobj = std::make_shared<xclemulation::drm_xocl_bo>();
     xobj->flags = info->flags;
     bool zeroCopy = xclemulation::is_zero_copy(xobj);
@@ -2170,7 +2162,6 @@ namespace xclcpuemhal2
 
     std::lock_guard lk(mApiMtx);
     bool ack = false;
-    //auto ghPtr = (xclcpuemhal2::GraphType *)gh;
     if (!ghPtr)
       return -1;
     auto graphhandle = ghPtr->getGraphHandle();

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
@@ -157,7 +157,7 @@ namespace xclcpuemhal2
       return 0;
     return reinterpret_cast<CpuemShim *>(handle);
 /*
-
+    // why are we checking shim pointer address with a const address?
     if (*(unsigned *)handle != TAG)
       return 0;
     if (!((CpuemShim *)handle)->isGood())
@@ -523,7 +523,7 @@ namespace xclcpuemhal2
       }
     }
     sock = std::make_shared<unix_socket>("EMULATION_SOCKETID");
-    
+
   }
 
   void CpuemShim::getCuRangeIdx()
@@ -1295,7 +1295,6 @@ namespace xclcpuemhal2
       if (mIsKdsSwEmu && mSWSch && mCore)
       {
         mSWSch->fini_scheduler_thread();
-        //delete mCore;
         mCore.reset();
         mSWSch.reset();
         
@@ -1371,12 +1370,6 @@ namespace xclcpuemhal2
         mSWSch->fini_scheduler_thread();
         mCore.reset();
         mSWSch.reset();
-        /*
-        delete mCore;
-        mCore = nullptr;
-        delete mSWSch;
-        mSWSch = nullptr;
-        */
       }
       return;
     }
@@ -1410,7 +1403,9 @@ namespace xclcpuemhal2
       while (-1 == waitpid(0, &status, 0));
 
     systemUtil::makeSystemCall(socketName, systemUtil::systemOperation::REMOVE);
-      sock.reset();
+    sock.reset();
+    PRINTENDFUNC;
+    if (mIsKdsSwEmu && mSWSch && mCore)
     {
       mSWSch->fini_scheduler_thread();
       mCore.reset();

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.h
@@ -107,7 +107,8 @@ namespace xclcpuemhal2
     int xclBootFPGA();
     void xclClose();
     void resetProgram(bool callingFromClose = false);
-
+    uint32_t get_my_device_index() { return mDevice_Index_for_this_device; };
+    void set_my_device_index(uint32_t index) { mDevice_Index_for_this_device = index; };
     // Raw read/write
     size_t xclWrite(xclAddressSpace space, uint64_t offset, const void *hostBuf, size_t size);
     size_t xclRead(xclAddressSpace space, uint64_t offset, void *hostBuf, size_t size);
@@ -193,7 +194,7 @@ namespace xclcpuemhal2
       * Note: Run by enable tiles and disable tile reset
       */
     int
-    xrtGraphInit(std::shared_ptr<GraphType> gh);
+    xrtGraphInit(std::shared_ptr<GraphType>& gh);
 
     /**
       * xrtGraphRun() - Start a graph execution
@@ -499,6 +500,7 @@ namespace xclcpuemhal2
     std::shared_ptr<SWScheduler> mSWSch;
     bool mIsKdsSwEmu;
     std::atomic<bool> mIsDeviceProcessStarted;
+    uint32_t  mDevice_Index_for_this_device;
   };
 
   class GraphType: public std::enable_shared_from_this<GraphType>

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/swscheduler.cxx
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/swscheduler.cxx
@@ -33,9 +33,6 @@ namespace xclcpuemhal2 {
     poll = 0;
     stop = false;
     pSch = std::weak_ptr{_sch} ;
-    //pthread_mutex_init(&state_lock,NULL);
-    //pthread_cond_init(&state_cond,NULL);
-    //scheduler_thread = 0;
   }
 
   xocl_sched::~xocl_sched()
@@ -45,8 +42,6 @@ namespace xclcpuemhal2 {
     intc = 0;
     poll = 0;
     stop = false;
-    //pthread_mutex_init(&state_lock,NULL);
-    //pthread_cond_init(&state_cond,NULL);
   }
 
   exec_core::exec_core()
@@ -304,7 +299,6 @@ namespace xclcpuemhal2 {
   {
     PRINTSTARTFUNC
     mParent = std::weak_ptr{_parent};
-    //mScheduler = new xocl_sched(this);
     num_pending = 0;
   }
 
@@ -1064,7 +1058,6 @@ namespace xclcpuemhal2 {
     std::cout<<"SWScheduler Thread started "<< std::endl;
 #endif
 
-    //int returnStatus  =  pthread_create(&(mScheduler->scheduler_thread) , NULL, scheduler, (void *)mScheduler);
     mScheduler->scheduler_thread = std::thread([&]
                                                { this->scheduler(); });
     mScheduler->bThreadCreated = true;

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/swscheduler.cxx
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/swscheduler.cxx
@@ -311,7 +311,6 @@ namespace xclcpuemhal2 {
   SWScheduler::~SWScheduler()
   {
     PRINTSTARTFUNC
-    //delete
     mScheduler.reset();
     num_pending = 0;
   }
@@ -1056,7 +1055,7 @@ namespace xclcpuemhal2 {
 
   int SWScheduler::init_scheduler_thread(void)
   {
-     mScheduler = std::make_shared<xocl_sched>(shared_from_this());
+    mScheduler = std::make_shared<xocl_sched>(shared_from_this());
     PRINTSTARTFUNC
     if (mScheduler->bThreadCreated)
       return 0;
@@ -1067,7 +1066,7 @@ namespace xclcpuemhal2 {
 
     //int returnStatus  =  pthread_create(&(mScheduler->scheduler_thread) , NULL, scheduler, (void *)mScheduler);
     mScheduler->scheduler_thread = std::thread([&]
-                                               { this->scheduler();  });
+                                               { this->scheduler(); });
     mScheduler->bThreadCreated = true;
 
     return 0;

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/swscheduler.h
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/swscheduler.h
@@ -42,14 +42,14 @@ namespace xclcpuemhal2 {
       //pthread_mutex_t             state_lock;
       //pthread_cond_t              state_cond;
       std::condition_variable_any    state_cond;
-      std::list<xocl_cmd*>        command_queue;
+      std::list<std::shared_ptr<xocl_cmd>>        command_queue;
       bool                        bThreadCreated;
       unsigned int                error;
       int                         intc;
       int                         poll;
       bool                        stop;
-      SWScheduler*                pSch;
-      xocl_sched(SWScheduler*);
+      std::weak_ptr<SWScheduler>  pSch;
+      xocl_sched(std::shared_ptr<SWScheduler>);
       ~xocl_sched();
   };
 
@@ -64,7 +64,7 @@ namespace xclcpuemhal2 {
       uint32_t           ctrlreg;
       unsigned int       done_cnt;
       unsigned int       run_cnt;
-      std::queue<xocl_cmd*>         running_queue;
+      std::queue<std::shared_ptr<xocl_cmd>>         running_queue;
       xocl_cu();
       ~xocl_cu();
   };
@@ -72,8 +72,8 @@ namespace xclcpuemhal2 {
   class xocl_cmd
   {
     public:
-      xclemulation::drm_xocl_bo *bo;
-      exec_core *exec;
+      std::weak_ptr<xclemulation::drm_xocl_bo> bo;
+      std::weak_ptr<exec_core> exec;
       enum ert_cmd_state state;
       unsigned int cu_idx;
       int slot_idx;
@@ -92,9 +92,9 @@ namespace xclcpuemhal2 {
     uint32_t			  intr_base;
     uint32_t			  intr_num;
 
-    std::list<client_ctx*>     ctx_list;
-    struct xocl_sched          *scheduler;
-    xocl_cmd*                   submitted_cmds[MAX_SLOTS];
+    std::list<std::shared_ptr<client_ctx>>     ctx_list;
+    std::shared_ptr<xocl_sched>          scheduler;
+    std::shared_ptr<xocl_cmd>   submitted_cmds[MAX_SLOTS];
 
     unsigned int               num_slots;
     unsigned int               num_cus;
@@ -112,7 +112,7 @@ namespace xclcpuemhal2 {
     uint32_t                   cu_status[MAX_U32_CU_MASKS];
     unsigned int               num_cu_masks; /* ((num_cus-1)>>5+1 */
     uint32_t                   cu_addr_map[MAX_CUS];
-    xocl_cu*                   cus[MAX_CUS];
+    std::shared_ptr<xocl_cu>   cus[MAX_CUS];
     uint32_t                   cu_usage[MAX_CUS];
     bool                       ertfull;
     bool                       ertpoll;
@@ -126,85 +126,85 @@ namespace xclcpuemhal2 {
 
   };
 
-  class SWScheduler
+  class SWScheduler: public std::enable_shared_from_this<SWScheduler>
   {
     public:
-    void set_cmd_int_state(xocl_cmd* xcmd, enum ert_cmd_state state) { xcmd->state = state; }
-    void set_cmd_state(xocl_cmd* xcmd, enum ert_cmd_state state) { xcmd->state = state; xcmd->packet->state = state; }
-    bool is_ert(exec_core *exec) { return true; }
+    void set_cmd_int_state(std::shared_ptr<xocl_cmd>& xcmd, enum ert_cmd_state state) { xcmd->state = state; }
+    void set_cmd_state(std::shared_ptr<xocl_cmd>& xcmd, enum ert_cmd_state state) { xcmd->state = state; xcmd->packet->state = state; }
+    bool is_ert(std::shared_ptr<exec_core> exec) { return true; }
     int ffz(uint32_t mask) { return( log2( ~mask & (mask+1) )); }
     int ffz_or_neg_one(uint32_t mask){
       if (mask==XOCL_U32_MASK) return -1;
       return ffz(mask);
     }
 
-    unsigned int slot_size(exec_core *exec)   { return ERT_CQ_SIZE / exec->num_slots; }
+    unsigned int slot_size(std::shared_ptr<exec_core>& exec)   { return ERT_CQ_SIZE / exec->num_slots; }
     unsigned int cu_mask_idx(unsigned int cu_idx)    { return cu_idx >> 5; /* 32 cus per mask */ }
     unsigned int cu_idx_in_mask(unsigned int cu_idx) { return cu_idx - (cu_mask_idx(cu_idx) << 5); }
     unsigned int cu_idx_from_mask(unsigned int cu_idx, unsigned int mask_idx) { return cu_idx + (mask_idx << 5); }
     unsigned int slot_mask_idx(unsigned int slot_idx) { return slot_idx >> 5; }
     unsigned int slot_idx_in_mask(unsigned int slot_idx) { return slot_idx - (slot_mask_idx(slot_idx) << 5); }
     unsigned int slot_idx_from_mask_idx(unsigned int slot_idx,unsigned int mask_idx) { return slot_idx + (mask_idx << 5); }
-    uint32_t opcode(xocl_cmd* xcmd) { return xcmd->packet->opcode; }
-    uint32_t payload_size(xocl_cmd *xcmd) { return xcmd->packet->count; }
-    uint32_t packet_size(xocl_cmd *xcmd) { return payload_size(xcmd) + 1; }
-    uint32_t type(struct xocl_cmd* xcmd) { return xcmd->packet->type; }
+    uint32_t opcode(std::shared_ptr<xocl_cmd>& xcmd) { return xcmd->packet->opcode; }
+    uint32_t payload_size(std::shared_ptr<xocl_cmd>& xcmd) { return xcmd->packet->count; }
+    uint32_t packet_size(std::shared_ptr<xocl_cmd>& xcmd) { return payload_size(xcmd) + 1; }
+    uint32_t type(struct std::shared_ptr<xocl_cmd>& xcmd) { return xcmd->packet->type; }
 
-    void mb_query(xocl_cmd *xcmd);
-    int mb_submit(xocl_cmd *xcmd);
-    void penguin_query(xocl_cmd *xcmd);
-    int penguin_submit(xocl_cmd *xcmd);
-    void ert_poll_query(xocl_cmd *xcmd);
-    int ert_poll_submit(xocl_cmd *xcmd);
-    void ert_poll_query_ctrl(xocl_cmd *xcmd);
-    int ert_poll_submit_ctrl(xocl_cmd *xcmd);
-    int acquire_slot(struct xocl_cmd* xcmd);
-    int acquire_slot_idx(exec_core *exec);
-    int configure(xocl_cmd *xcmd);
-    void release_slot_idx(exec_core *exec, unsigned int slot_idx);
-    void notify_host(xocl_cmd *xcmd);
-    void mark_cmd_complete(xocl_cmd *xcmd);
-    void mark_mask_complete(exec_core *exec, uint32_t mask, unsigned int mask_idx);
-    int queued_to_running(xocl_cmd *xcmd) ;
-    void running_to_complete(xocl_cmd *xcmd) ;
-    void complete_to_free(xocl_cmd *xcmd) { }
-    xocl_cmd* get_free_xocl_cmd(void) ; 
-    int add_cmd(exec_core *exec, xclemulation::drm_xocl_bo* bo) ;
-    int scheduler_wait_condition() ;
+    void mb_query(std::shared_ptr<xocl_cmd>& xcmd);
+    int mb_submit(std::shared_ptr<xocl_cmd>& xcmd);
+    void penguin_query(std::shared_ptr<xocl_cmd>& xcmd);
+    int penguin_submit(std::shared_ptr<xocl_cmd>& xcmd);
+    void ert_poll_query(std::shared_ptr<xocl_cmd>& xcmd);
+    int ert_poll_submit(std::shared_ptr<xocl_cmd>& xcmd);
+    void ert_poll_query_ctrl(std::shared_ptr<xocl_cmd>& xcmd);
+    int ert_poll_submit_ctrl(std::shared_ptr<xocl_cmd>& xcmd);
+    int acquire_slot(struct std::shared_ptr<xocl_cmd>& xcmd);
+    int acquire_slot_idx(std::shared_ptr<exec_core>& exec);
+    int configure(std::shared_ptr<xocl_cmd>& xcmd);
+    void release_slot_idx(std::shared_ptr<exec_core>& exec, unsigned int slot_idx);
+    void notify_host(std::shared_ptr<xocl_cmd>& xcmd);
+    void mark_cmd_complete(std::shared_ptr<xocl_cmd>& xcmd);
+    void mark_mask_complete(std::shared_ptr<exec_core>& exec, uint32_t mask, unsigned int mask_idx);
+    int queued_to_running(std::shared_ptr<xocl_cmd>& xcmd) ;
+    void running_to_complete(std::shared_ptr<xocl_cmd>& xcmd) ;
+    void complete_to_free(std::shared_ptr<xocl_cmd>& xcmd) { }
+    std::shared_ptr<xocl_cmd> get_free_xocl_cmd(void);
+    int add_cmd(std::shared_ptr<exec_core> &exec, std::shared_ptr<xclemulation::drm_xocl_bo> &bo);
+    int scheduler_wait_condition();
     void scheduler_queue_cmds();
     void scheduler_iterate_cmds();
-    int get_free_cu(struct xocl_cmd *xcmd);
-    void configure_cu(struct xocl_cmd *xcmd, int cu_idx);
-    bool cu_done(struct exec_core *exec, unsigned int cu_idx);
-    uint32_t cu_masks(struct xocl_cmd *xcmd);
-    uint32_t regmap_size(struct xocl_cmd* xcmd);
-    bool cmd_has_cu(struct xocl_cmd* xcmd, uint32_t f_cu_idx);
-    void cu_configure_ooo(struct xocl_cu *xcu, struct xocl_cmd *xcmd);
-    void cu_configure_ino(struct xocl_cu *xcu, struct xocl_cmd *xcmd);
-    xocl_cmd* cu_first_done(struct xocl_cu *xcu);
-    void cu_pop_done(struct xocl_cu *xcu);
-    void cu_continue(xocl_cu *xcu);
-    void cu_poll(xocl_cu *xcu);
-    bool cu_ready(xocl_cu *xcu);
-    bool cu_start(xocl_cu *xcu, xocl_cmd *xcmd);
+    int get_free_cu(std::shared_ptr<xocl_cmd>& xcmd);
+    void configure_cu(std::shared_ptr<xocl_cmd>& xcmd, int cu_idx);
+    bool cu_done(std::shared_ptr<exec_core>& exec, unsigned int cu_idx);
+    uint32_t cu_masks(std::shared_ptr<xocl_cmd>& xcmd);
+    uint32_t regmap_size(std::shared_ptr<xocl_cmd>& xcmd);
+    bool cmd_has_cu(std::shared_ptr<xocl_cmd>& xcmd, uint32_t f_cu_idx);
+    void cu_configure_ooo(std::shared_ptr<xocl_cu>& xcu, std::shared_ptr<xocl_cmd>& xcmd);
+    void cu_configure_ino(std::shared_ptr<xocl_cu>& xcu, std::shared_ptr<xocl_cmd>& xcmd);
+    std::shared_ptr<xocl_cmd> cu_first_done(std::shared_ptr<xocl_cu>& xcu);
+    void cu_pop_done(std::shared_ptr<xocl_cu>& xcu);
+    void cu_continue(std::shared_ptr<xocl_cu>& xcu);
+    void cu_poll(std::shared_ptr<xocl_cu>& xcu);
+    bool cu_ready(std::shared_ptr<xocl_cu>& xcu);
+    bool cu_start(std::shared_ptr<xocl_cu>& xcu, std::shared_ptr<xocl_cmd>& xcmd);
 
-    friend void scheduler_loop(xocl_sched *xs);
-    friend void* scheduler(void* data) ;
+    void scheduler_loop();
+    void scheduler() ;
 
     int init_scheduler_thread(void) ;
     int fini_scheduler_thread(void) ;
-    int add_exec_buffer(exec_core *eCore , xclemulation::drm_xocl_bo *buf) ;
-    int convert_execbuf(exec_core *exec, xclemulation::drm_xocl_bo *xobj, xocl_cmd* xcmd);
+    int add_exec_buffer(std::shared_ptr<exec_core> &exec, std::shared_ptr<xclemulation::drm_xocl_bo> &buf);//exec_core *eCore , xclemulation::drm_xocl_bo *buf) ;
+    int convert_execbuf(std::shared_ptr<exec_core>& exec, std::shared_ptr<xclemulation::drm_xocl_bo>& xobj, std::shared_ptr<xocl_cmd>& xcmd);
 
-    xocl_sched* mScheduler;
-    SWScheduler(CpuemShim* _parent);
+    std::shared_ptr<xocl_sched> mScheduler;
+    SWScheduler(std::shared_ptr<CpuemShim> _parent);
     ~SWScheduler();
-    CpuemShim* mParent;
+    std::weak_ptr<CpuemShim> mParent;
     private:
-    std::list<xocl_cmd*> free_cmds;
+    std::list<std::shared_ptr<xocl_cmd>> free_cmds;
     std::mutex free_cmds_mutex;
 
-    std::list<xocl_cmd*> pending_cmds;
+    std::list<std::shared_ptr<xocl_cmd>> pending_cmds;
     std::mutex pending_cmds_mutex;
 
     std::mutex m_add_cmd_mutex;

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/swscheduler.h
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/swscheduler.h
@@ -37,10 +37,7 @@ namespace xclcpuemhal2 {
   class xocl_sched
   {
     public:
-      //pthread_t                   scheduler_thread;
       std::thread                 scheduler_thread;
-      //pthread_mutex_t             state_lock;
-      //pthread_cond_t              state_cond;
       std::condition_variable_any    state_cond;
       std::list<std::shared_ptr<xocl_cmd>>   command_queue;
       bool                        bThreadCreated;

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/swscheduler.h
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/swscheduler.h
@@ -42,7 +42,7 @@ namespace xclcpuemhal2 {
       //pthread_mutex_t             state_lock;
       //pthread_cond_t              state_cond;
       std::condition_variable_any    state_cond;
-      std::list<std::shared_ptr<xocl_cmd>>        command_queue;
+      std::list<std::shared_ptr<xocl_cmd>>   command_queue;
       bool                        bThreadCreated;
       unsigned int                error;
       int                         intc;

--- a/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/device_hwemu.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/device_hwemu.cxx
@@ -36,7 +36,7 @@ struct device_query
   static uint32_t
   get(const xrt_core::device* device, key_type query_key)
   {
-    xclhwemhal2::HwEmShim *drv = xclhwemhal2::HwEmShim::handleCheck(device->get_device_handle());
+    auto drv = xclhwemhal2::HwEmShim::handleCheck(device->get_device_handle());
     if (!drv)
       return 0;
     return drv->deviceQuery(query_key);

--- a/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/halapi.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/halapi.cxx
@@ -353,9 +353,6 @@ xclDeviceHandle xclOpen(unsigned deviceIndex, const char *logfileName, xclVerbos
   FeatureRomHeader fRomHeader;
   std::memset(&fRomHeader, 0, sizeof(FeatureRomHeader));
   boost::property_tree::ptree platformData;
-
-  //std::shared_ptr<xclhwemhal2::HwEmShim> handle = nullptr;
-
   
   auto it = xclhwemhal2::devices.find(deviceIndex);
   if (it != xclhwemhal2::devices.end())
@@ -364,7 +361,6 @@ xclDeviceHandle xclOpen(unsigned deviceIndex, const char *logfileName, xclVerbos
   }
   else
   {
-    std::cerr << "\n Memory should be assigned to Map, right?\n";
     handle = std::make_shared<xclhwemhal2::HwEmShim>(deviceIndex, info, DDRBankList, false, false, fRomHeader, platformData);
     bDefaultDevice = true;
     // careful here

--- a/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/halapi.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/halapi.cxx
@@ -370,12 +370,12 @@ xclDeviceHandle xclOpen(unsigned deviceIndex, const char *logfileName, xclVerbos
     // careful here
     xclhwemhal2::devices[deviceIndex++] = handle;
   }
-
+/*
   if (!xclhwemhal2::HwEmShim::handleCheck(handle.get())) {
     std::cout << "\n Clearing handle memory! Take a look at the memory creation\n"; 
     delete (xclhwemhal2::HwEmShim*)handle.get();
   }
-  
+  */
   if(handle)
   {
     handle->xclOpen(logfileName);

--- a/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/halapi.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/halapi.cxx
@@ -368,12 +368,7 @@ xclDeviceHandle xclOpen(unsigned deviceIndex, const char *logfileName, xclVerbos
     // careful here
     xclhwemhal2::devices[deviceIndex++] = handle;
   }
-/*
-  if (!xclhwemhal2::HwEmShim::handleCheck(handle.get())) {
-    std::cout << "\n Clearing handle memory! Take a look at the memory creation\n"; 
-    delete (xclhwemhal2::HwEmShim*)handle.get();
-  }
-  */
+
   if(handle)
   {
     handle->xclOpen(logfileName);

--- a/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/mbscheduler.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/mbscheduler.cxx
@@ -10,11 +10,7 @@ namespace xclhwemhal2 {
 
   xocl_cmd::xocl_cmd()
   {
-    /*
-    bo = NULL;
-    exec = NULL;
     packet = NULL;
-    */
     cu_idx = 0;
     slot_idx = 0;
     state = ERT_CMD_STATE_NEW;
@@ -24,10 +20,6 @@ namespace xclhwemhal2 {
   {
     bo.reset();
     exec.reset();
-    //packet.reset();
-
-    //bo = NULL;
-    //exec = NULL;
     cu_idx = 0;
     slot_idx = 0;
     packet = NULL;  // buf address from shim class is the real owner of this pointer
@@ -137,7 +129,7 @@ namespace xclhwemhal2 {
   {
     auto mParent = weak_mParent.lock();
     if (!mParent) {
-        std::cout<<"\n mParent is nullptr \n";
+        DEBUG_MSGS_COUT("mParent is nullptr");
         return ;
     }
 
@@ -161,7 +153,7 @@ namespace xclhwemhal2 {
   {
     auto mParent = weak_mParent.lock();
     if (!mParent) {
-        std::cout<<"\n mParent is nullptr \n";
+        DEBUG_MSGS_COUT("mParent is nullptr");
         return;
     }
 
@@ -194,7 +186,7 @@ namespace xclhwemhal2 {
   {
     auto mParent = weak_mParent.lock();
     if (!mParent) {
-        std::cout<<"\n mParent is nullptr \n";
+        DEBUG_MSGS_COUT("mParent is nullptr");
         return;
     }
 
@@ -212,7 +204,7 @@ namespace xclhwemhal2 {
   {
     auto mParent = weak_mParent.lock();
     if (!mParent) {
-        std::cout<<"\n mParent is nullptr \n";
+        DEBUG_MSGS_COUT("mParent is nullptr");
         return;
     }
     unsigned int size = regmap_size(xcmd);
@@ -231,7 +223,7 @@ namespace xclhwemhal2 {
   {
     auto mParent = weak_mParent.lock();
     if (!mParent) {
-        std::cout<<"\n mParent is nullptr \n";
+        DEBUG_MSGS_COUT("mParent is nullptr");
         return false;
     }
 
@@ -335,7 +327,6 @@ namespace xclhwemhal2 {
   MBScheduler::MBScheduler(std::shared_ptr<xclhwemhal2::HwEmShim> _parent)
   {
     weak_mParent = std::weak_ptr{_parent};
-    //mScheduler = new xocl_sched(this);
     mScheduler = std::make_shared<xocl_sched>(shared_from_this());
     num_pending = 0;
     ert_version = atoi(_parent->getERTVersion().c_str());
@@ -372,7 +363,7 @@ namespace xclhwemhal2 {
   {
     auto mParent = weak_mParent.lock();
     if (!mParent) {
-        std::cout<<"\n mParent is nullptr \n";
+        DEBUG_MSGS_COUT("mParent is nullptr");
         return false;
     }
 
@@ -444,7 +435,7 @@ namespace xclhwemhal2 {
   {
     auto mParent = weak_mParent.lock();
     if (!mParent) {
-        std::cout<<"\n mParent is nullptr \n";
+        DEBUG_MSGS_COUT("mParent is nullptr");
         return ;
     }
     auto exec = xcmd->exec.lock();
@@ -542,7 +533,7 @@ namespace xclhwemhal2 {
   {
     auto mParent = weak_mParent.lock();
     if (!mParent) {
-        std::cout<<"\n mParent is nullptr \n";
+        DEBUG_MSGS_COUT("mParent is nullptr");
         return ;
     }
     if (type(xcmd) == ERT_KDS_LOCAL)
@@ -602,7 +593,7 @@ namespace xclhwemhal2 {
   {
     auto mParent = weak_mParent.lock();
     if (!mParent) {
-        std::cout<<"\n mParent is nullptr \n";
+        DEBUG_MSGS_COUT("mParent is nullptr");
         return 0;
     }
     if (type(xcmd) == ERT_KDS_LOCAL)
@@ -715,7 +706,7 @@ namespace xclhwemhal2 {
   {
     auto mParent = weak_mParent.lock();
     if (!mParent) {
-        std::cout<<"\n mParent is nullptr \n";
+        DEBUG_MSGS_COUT("mParent is nullptr");
         return ;
     }
 
@@ -752,13 +743,11 @@ namespace xclhwemhal2 {
   {
     auto mParent = weak_mParent.lock();
     if (!mParent) {
-        std::cout<<"\n mParent is nullptr \n";
+        DEBUG_MSGS_COUT("mParent is nullptr");
         return 0;
     }
 
     auto exec=xcmd->exec.lock();
-    //struct ert_configure_cmd *cfg;
-
     //cfg = (struct ert_configure_cmd *)(xcmd->packet);
     auto cfg =  reinterpret_cast<ert_configure_cmd*>(xcmd->packet);
 
@@ -785,7 +774,6 @@ namespace xclhwemhal2 {
       for ( cuidx=0; cuidx<exec->num_cus; cuidx++)
       {
         exec->cu_addr_map[cuidx] = cfg->data[cuidx];
-        //xocl_cu* nCu = new xocl_cu();
         auto nCu = std::make_shared<xocl_cu>();
         exec->cus[cuidx] =  nCu;
         uint64_t polladdr = (ert_poll) ? _CMDQ_BASE_ADDR  + (cuidx+1) * cfg->slot_size : 0;
@@ -808,7 +796,6 @@ namespace xclhwemhal2 {
             ++cfg->count;
             cfg->data[cuidx] = addr;
             exec->cu_addr_map[cuidx] = cfg->data[cuidx];
-            //xocl_cu* nCu = new xocl_cu();
             auto nCu = std::make_shared<xocl_cu>();
             exec->cus[cuidx] =  nCu;
             uint64_t polladdr = (ert_poll) ? _CMDQ_BASE_ADDR + (cuidx+1) * cfg->slot_size : 0;
@@ -978,7 +965,7 @@ namespace xclhwemhal2 {
   {
     auto mParent = weak_mParent.lock();
     if (!mParent) {
-        std::cout<<"\n mParent is nullptr \n";
+        DEBUG_MSGS_COUT("mParent is nullptr");
         return 0;
     }
 
@@ -1159,33 +1146,7 @@ namespace xclhwemhal2 {
      }
 
   }
-/*
-  void scheduler_loop(std::shared_ptr<xocl_sched>& xs)
-  {
-    auto& pSch = xs->pSch;
-    std::lock_guard<std::mutex> lk(pSch->pending_cmds_mutex);
 
-    if (xs->error) { return; }
-
-    // queue new pending commands 
-    pSch->scheduler_queue_cmds();
-
-    // iterate all commands 
-    pSch->scheduler_iterate_cmds();
-  }
-
-  void* scheduler(void* data)
-  {
-    xocl_sched *xs = (xocl_sched *)data;
-    while (!xs->stop && !xs->error)
-    {
-      scheduler_loop(xs);
-      usleep(10);
-    }
-    return NULL;
-  }
-*/
-  //void MBScheduler::scheduler_periodic_loop_thread(std::shared_ptr<xocl_sched>& xs)
   void MBScheduler::scheduler_periodic_loop_thread()
   {
     //MBScheduler* pSch = xs->pSch;
@@ -1222,15 +1183,6 @@ namespace xclhwemhal2 {
 #endif
     this->mscheduler_thread = std::thread([&]{ this->scheduler_thread(); });
     
-    /*
-    int returnStatus = pthread_create(&(mScheduler->scheduler_thread), NULL, scheduler, (void *)mScheduler);
-
-    if (returnStatus != 0)
-    {
-      std::cout << __func__ <<  " pthread_create failed " << " " << returnStatus<< std::endl;
-      exit(1);
-    }
-    */
     mScheduler->bThreadCreated = true;
 
     return 0;

--- a/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/mbscheduler.h
+++ b/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/mbscheduler.h
@@ -40,17 +40,16 @@ namespace xclhwemhal2 {
       pthread_t                   scheduler_thread;
       pthread_mutex_t             state_lock;
       pthread_cond_t              state_cond;
-      std::thread scheduler_threadID;
-      std::mutex state_mutex;
-      std::condition_variable state_condvar;
-      //std::list<xocl_cmd*>        command_queue;
+      std::thread                 scheduler_threadID;
+      std::mutex                  state_mutex;
+      std::condition_variable     state_condvar;
       std::list<std::shared_ptr<xocl_cmd>>        command_queue;
       bool                        bThreadCreated;
       unsigned int                error;
       int                         intc;
       int                         poll;
       bool                        stop;
-      std::weak_ptr<MBScheduler>              pSch;
+      std::weak_ptr<MBScheduler>  pSch;
       xocl_sched(std::shared_ptr<MBScheduler>);
       ~xocl_sched();
   };
@@ -194,11 +193,7 @@ namespace xclhwemhal2 {
     bool cu_ready(std::shared_ptr<xocl_cu>& xcu);
     bool cu_start(std::shared_ptr<xocl_cu>& xcu, std::shared_ptr<xocl_cmd>& xcmd);
 
-    //friend void scheduler_loop(std::shared_ptr<xocl_sched>& xs);
-    //friend void* scheduler(void* data) ;
-    //void scheduler_thread(std::shared_ptr<xocl_sched>& );
     void scheduler_thread();
-    //void scheduler_periodic_loop_thread(std::shared_ptr<xocl_sched>& xs);
     void scheduler_periodic_loop_thread();
 
     int init_scheduler_thread(void) ;

--- a/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/mbscheduler.h
+++ b/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/mbscheduler.h
@@ -7,10 +7,12 @@
 #define _MB_SCHEDULER_H_
 
 #include <list>
+#include <memory>
 #include <mutex>
 #include <cmath>
 #include <cstdint>
 #include <queue>
+#include <thread>
 #include "ert.h"
 
 #define XOCL_U32_MASK 0xFFFFFFFF
@@ -32,20 +34,24 @@ namespace xclhwemhal2 {
     std::mutex mLock;
   };
 
-  class xocl_sched
+  class xocl_sched: public std::enable_shared_from_this<xocl_sched> 
   {
     public:
       pthread_t                   scheduler_thread;
       pthread_mutex_t             state_lock;
       pthread_cond_t              state_cond;
-      std::list<xocl_cmd*>        command_queue;
+      std::thread scheduler_threadID;
+      std::mutex state_mutex;
+      std::condition_variable state_condvar;
+      //std::list<xocl_cmd*>        command_queue;
+      std::list<std::shared_ptr<xocl_cmd>>        command_queue;
       bool                        bThreadCreated;
       unsigned int                error;
       int                         intc;
       int                         poll;
       bool                        stop;
-      MBScheduler*              pSch;
-      xocl_sched(MBScheduler*);
+      std::weak_ptr<MBScheduler>              pSch;
+      xocl_sched(std::shared_ptr<MBScheduler>);
       ~xocl_sched();
   };
 
@@ -61,7 +67,7 @@ namespace xclhwemhal2 {
       uint32_t           ap_check;
       unsigned int       done_cnt;
       unsigned int       run_cnt;
-      std::queue<xocl_cmd*>         running_queue;
+      std::queue<std::shared_ptr<xocl_cmd>>         running_queue;
       xocl_cu();
       ~xocl_cu();
   };
@@ -69,13 +75,13 @@ namespace xclhwemhal2 {
   class xocl_cmd
   {
     public:
-      xclemulation::drm_xocl_bo *bo;
-      exec_core *exec;
+      std::weak_ptr<xclemulation::drm_xocl_bo> bo;
+      std::weak_ptr<exec_core> exec;
       enum ert_cmd_state state;
       int cu_idx;
       int slot_idx;
       /* The actual cmd object representation */
-      struct ert_packet *packet;
+      struct ert_packet* packet;
       xocl_cmd();
       ~xocl_cmd();
   };
@@ -89,11 +95,11 @@ namespace xclhwemhal2 {
     uint32_t			  intr_base;
     uint32_t			  intr_num;
 
-    std::list<client_ctx*>           ctx_list;
+    std::list<std::shared_ptr<client_ctx> >           ctx_list;
 
-    struct xocl_sched          *scheduler;
+    std::shared_ptr<struct xocl_sched>          scheduler;
 
-    xocl_cmd*            submitted_cmds[MAX_SLOTS];
+    std::shared_ptr<xocl_cmd>            submitted_cmds[MAX_SLOTS];
 
     unsigned int               num_slots;
     unsigned int               num_cus;
@@ -111,7 +117,7 @@ namespace xclhwemhal2 {
     uint32_t                        cu_status[MAX_U32_CU_MASKS];
     unsigned int               num_cu_masks; /* ((num_cus-1)>>5+1 */
     uint32_t                        cu_addr_map[MAX_CUS];
-    xocl_cu* cus[MAX_CUS];
+    std::shared_ptr<xocl_cu> cus[MAX_CUS];
     uint32_t                        cu_usage[MAX_CUS];
     bool ertfull;
     bool ertpoll;
@@ -126,85 +132,88 @@ namespace xclhwemhal2 {
 
   };
 
-  class MBScheduler
+  class MBScheduler :public std::enable_shared_from_this<MBScheduler> 
   {
     public:
-    void set_cmd_int_state(xocl_cmd* xcmd, enum ert_cmd_state state) { xcmd->state = state; }
-    void set_cmd_state(xocl_cmd* xcmd, enum ert_cmd_state state) { xcmd->state = state; xcmd->packet->state = state; }
-    bool is_ert(exec_core *exec) { return true; }
+    void set_cmd_int_state(std::shared_ptr<xocl_cmd>& xcmd, enum ert_cmd_state state) { xcmd->state = state; }
+    void set_cmd_state(std::shared_ptr<xocl_cmd>& xcmd, enum ert_cmd_state state) { xcmd->state = state; xcmd->packet->state = state; }
+    bool is_ert(std::shared_ptr<exec_core> exec) { return true; }
     int ffz(uint32_t mask) { return( log2( ~mask & (mask+1) )); }
     int ffz_or_neg_one(uint32_t mask){
       if (mask==XOCL_U32_MASK) return -1;
       return ffz(mask);
     }
 
-    unsigned int slot_size(exec_core *exec)   { return ERT_CQ_SIZE / exec->num_slots; }
+    unsigned int slot_size(std::shared_ptr<exec_core> exec)   { return ERT_CQ_SIZE / exec->num_slots; }
     unsigned int cu_mask_idx(unsigned int cu_idx)    { return cu_idx >> 5; /* 32 cus per mask */ }
     unsigned int cu_idx_in_mask(unsigned int cu_idx) { return cu_idx - (cu_mask_idx(cu_idx) << 5); }
     unsigned int cu_idx_from_mask(unsigned int cu_idx, unsigned int mask_idx) { return cu_idx + (mask_idx << 5); }
     unsigned int slot_mask_idx(unsigned int slot_idx) { return slot_idx >> 5; }
     unsigned int slot_idx_in_mask(unsigned int slot_idx) { return slot_idx - (slot_mask_idx(slot_idx) << 5); }
     unsigned int slot_idx_from_mask_idx(unsigned int slot_idx,unsigned int mask_idx) { return slot_idx + (mask_idx << 5); }
-    uint32_t opcode(xocl_cmd* xcmd) { return xcmd->packet->opcode; }
-    uint32_t payload_size(xocl_cmd *xcmd) { return xcmd->packet->count; }
-    uint32_t packet_size(xocl_cmd *xcmd) { return payload_size(xcmd) + 1; }
-    uint32_t type(struct xocl_cmd* xcmd) { return xcmd->packet->type; }
+    uint32_t opcode(std::shared_ptr<xocl_cmd>& xcmd) { return xcmd->packet->opcode; }
+    uint32_t payload_size(std::shared_ptr<xocl_cmd>& xcmd) { return xcmd->packet->count; }
+    uint32_t packet_size(std::shared_ptr<xocl_cmd>& xcmd) { return payload_size(xcmd) + 1; }
+    uint32_t type(struct std::shared_ptr<xocl_cmd>& xcmd) { return xcmd->packet->type; }
 
-    void mb_query(xocl_cmd *xcmd);
-    int mb_submit(xocl_cmd *xcmd);
-    void penguin_query(xocl_cmd *xcmd);
-    int penguin_submit(xocl_cmd *xcmd);
-    void ert_poll_query(xocl_cmd *xcmd);
-    int ert_poll_submit(xocl_cmd *xcmd);
-    void ert_poll_query_ctrl(xocl_cmd *xcmd);
-    int ert_poll_submit_ctrl(xocl_cmd *xcmd);
-    int acquire_slot(struct xocl_cmd* xcmd);
-    int acquire_slot_idx(exec_core *exec);
-    int configure(xocl_cmd *xcmd);
-    void release_slot_idx(exec_core *exec, unsigned int slot_idx);
-    void notify_host(xocl_cmd *xcmd);
-    void mark_cmd_complete(xocl_cmd *xcmd);
-    void mark_mask_complete(exec_core *exec, uint32_t mask, unsigned int mask_idx);
-    int queued_to_running(xocl_cmd *xcmd) ;
-    void running_to_complete(xocl_cmd *xcmd) ;
-    void complete_to_free(xocl_cmd *xcmd) { }
-    xocl_cmd* get_free_xocl_cmd(void) ; 
-    int add_cmd(exec_core *exec, xclemulation::drm_xocl_bo* bo) ;
+    void mb_query(std::shared_ptr<xocl_cmd>& xcmd);
+    int mb_submit(std::shared_ptr<xocl_cmd>& xcmd);
+    void penguin_query(std::shared_ptr<xocl_cmd>& xcmd);
+    int penguin_submit(std::shared_ptr<xocl_cmd>& xcmd);
+    void ert_poll_query(std::shared_ptr<xocl_cmd>& xcmd);
+    int ert_poll_submit(std::shared_ptr<xocl_cmd>& xcmd);
+    void ert_poll_query_ctrl(std::shared_ptr<xocl_cmd>& xcmd);
+    int ert_poll_submit_ctrl(std::shared_ptr<xocl_cmd>& xcmd);
+    int acquire_slot(std::shared_ptr<struct xocl_cmd>& xcmd);
+    int acquire_slot_idx(std::shared_ptr<exec_core>& exec);
+    int configure(std::shared_ptr<xocl_cmd>& xcmd);
+    void release_slot_idx(std::shared_ptr<exec_core>& exec, unsigned int slot_idx);
+    void notify_host(std::shared_ptr<xocl_cmd>& xcmd);
+    void mark_cmd_complete(std::shared_ptr<xocl_cmd>& xcmd);
+    void mark_mask_complete(std::shared_ptr<exec_core>& exec, uint32_t mask, unsigned int mask_idx);
+    int queued_to_running(std::shared_ptr<xocl_cmd>& xcmd);
+    void running_to_complete(std::shared_ptr<xocl_cmd>& xcmd) ;
+    void complete_to_free(std::shared_ptr<xocl_cmd>& xcmd) { }
+    std::shared_ptr<xocl_cmd> get_free_xocl_cmd(void) ; 
+    int add_cmd(std::shared_ptr<exec_core>& exec, std::shared_ptr<xclemulation::drm_xocl_bo>& bo) ;
     int scheduler_wait_condition() ;
     void scheduler_queue_cmds();
     void scheduler_iterate_cmds();
-    int get_free_cu(struct xocl_cmd *xcmd);
-    void configure_cu(struct xocl_cmd *xcmd, int cu_idx);
-    bool cu_done(struct exec_core *exec, unsigned int cu_idx);
-    uint32_t cu_masks(struct xocl_cmd *xcmd);
-    uint32_t regmap_size(struct xocl_cmd* xcmd);
-    bool cmd_has_cu(struct xocl_cmd* xcmd, uint32_t f_cu_idx);
-    void cu_configure_ooo(struct xocl_cu *xcu, struct xocl_cmd *xcmd);
-    void cu_configure_ino(struct xocl_cu *xcu, struct xocl_cmd *xcmd);
-    xocl_cmd* cu_first_done(struct xocl_cu *xcu);
-    void cu_pop_done(struct xocl_cu *xcu);
-    void cu_continue(xocl_cu *xcu);
-    void cu_poll(xocl_cu *xcu);
-    bool cu_ready(xocl_cu *xcu);
-    bool cu_start(xocl_cu *xcu, xocl_cmd *xcmd);
+    int get_free_cu(std::shared_ptr<struct xocl_cmd>& xcmd);
+    void configure_cu(std::shared_ptr<struct xocl_cmd>& xcmd, int cu_idx);
+    bool cu_done(std::shared_ptr<struct exec_core>& exec, unsigned int cu_idx);
+    uint32_t cu_masks(std::shared_ptr<struct xocl_cmd>& xcmd);
+    uint32_t regmap_size( std::shared_ptr<struct xocl_cmd>& xcmd);
+    bool cmd_has_cu( std::shared_ptr<xocl_cmd>& xcmd, uint32_t f_cu_idx);
+    void cu_configure_ooo(std::shared_ptr<struct xocl_cu>& xcu, std::shared_ptr<struct xocl_cmd>& xcmd);
+    void cu_configure_ino(std::shared_ptr<struct xocl_cu>& xcu, std::shared_ptr<struct xocl_cmd>& xcmd);
+    std::shared_ptr<xocl_cmd> cu_first_done(std::shared_ptr<struct xocl_cu>& xcu);
+    void cu_pop_done(std::shared_ptr<struct xocl_cu>& xcu);
+    void cu_continue(std::shared_ptr<xocl_cu>& xcu);
+    void cu_poll(std::shared_ptr<xocl_cu>& xcu);
+    bool cu_ready(std::shared_ptr<xocl_cu>& xcu);
+    bool cu_start(std::shared_ptr<xocl_cu>& xcu, std::shared_ptr<xocl_cmd>& xcmd);
 
-    friend void scheduler_loop(xocl_sched *xs);
-    friend void* scheduler(void* data) ;
+    //friend void scheduler_loop(std::shared_ptr<xocl_sched>& xs);
+    //friend void* scheduler(void* data) ;
+    void scheduler_thread(std::shared_ptr<xocl_sched>& );
+    void scheduler_periodic_loop_thread(std::shared_ptr<xocl_sched>& xs);
 
     int init_scheduler_thread(void) ;
     int fini_scheduler_thread(void) ;
-    int add_exec_buffer(exec_core *eCore , xclemulation::drm_xocl_bo *buf) ;
-    int convert_execbuf(exec_core *exec, xclemulation::drm_xocl_bo *xobj, xocl_cmd* xcmd);
+    int add_exec_buffer(std::shared_ptr<exec_core>& eCore , std::shared_ptr<xclemulation::drm_xocl_bo>& buf) ;
+    int convert_execbuf(std::shared_ptr<exec_core>& exec, std::shared_ptr<xclemulation::drm_xocl_bo>& xobj, std::shared_ptr<xocl_cmd>& xcmd);
 
-    xocl_sched* mScheduler;
-    MBScheduler(HwEmShim* _parent);
+    std::shared_ptr<xocl_sched> mScheduler;
+    MBScheduler(std::shared_ptr<xclhwemhal2::HwEmShim> _parent);
     ~MBScheduler();
-    HwEmShim* mParent;
+    std::weak_ptr<xclhwemhal2::HwEmShim> weak_mParent;
     private:
-    std::list<xocl_cmd*> free_cmds;
+    std::thread mscheduler_thread;
+    std::list<std::shared_ptr<xocl_cmd>> free_cmds;
     std::mutex free_cmds_mutex;
 
-    std::list<xocl_cmd*> pending_cmds;
+    std::list<std::shared_ptr<xocl_cmd>> pending_cmds;
     std::mutex pending_cmds_mutex;
 
     std::mutex m_add_cmd_mutex;

--- a/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/mbscheduler.h
+++ b/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/mbscheduler.h
@@ -196,8 +196,10 @@ namespace xclhwemhal2 {
 
     //friend void scheduler_loop(std::shared_ptr<xocl_sched>& xs);
     //friend void* scheduler(void* data) ;
-    void scheduler_thread(std::shared_ptr<xocl_sched>& );
-    void scheduler_periodic_loop_thread(std::shared_ptr<xocl_sched>& xs);
+    //void scheduler_thread(std::shared_ptr<xocl_sched>& );
+    void scheduler_thread();
+    //void scheduler_periodic_loop_thread(std::shared_ptr<xocl_sched>& xs);
+    void scheduler_periodic_loop_thread();
 
     int init_scheduler_thread(void) ;
     int fini_scheduler_thread(void) ;

--- a/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/mbscheduler_hwemu.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/mbscheduler_hwemu.cxx
@@ -345,7 +345,7 @@ namespace hwemu {
     {
         auto xdevice = weak_xdevice.lock();
         if (!xdevice) {
-            std::cout<<"\n xdevice is nullptr \n";
+            SCHED_INFO("xdevice is nullptr %s", __func__);
             return;
         }
         xdevice->xclRead(XCL_ADDR_KERNEL_CTRL, cu_base_addr(),(void*)&(ctrlreg),4);
@@ -469,7 +469,7 @@ namespace hwemu {
     {
         auto xdevice = weak_xdevice.lock();
         if (!xdevice) {
-            std::cout<<"\n xdevice is nullptr \n";
+            SCHED_DEBUGF("xdevice is nullptr %s", __func__);
             return;
         }
         if (addr >= ERT_P2P_CMDQ_ADDR) {
@@ -483,7 +483,7 @@ namespace hwemu {
     {
         auto xdevice = weak_xdevice.lock();
         if (!xdevice) {
-            std::cout<<"\n xdevice is nullptr \n";
+            SCHED_INFO("xdevice is nullptr %s", __func__);
             return 0;
         }
         uint32_t data = 0;
@@ -495,7 +495,7 @@ namespace hwemu {
     {
         auto xdevice = weak_xdevice.lock();
         if (!xdevice) {
-            std::cout<<"\n xdevice is nullptr \n";
+            SCHED_INFO("xdevice is nullptr %s", __func__);
             return;
         }
         xdevice->xclCopyBufferHost2Device(addr, (void*)(&data), len ,0,XCL_ADDR_SPACE_DEVICE_RAM);
@@ -505,7 +505,7 @@ namespace hwemu {
     {
         auto xdevice = weak_xdevice.lock();
         if (!xdevice) {
-            std::cout<<"\n xdevice is nullptr \n";
+            SCHED_INFO("xdevice is nullptr %s", __func__);
             return;
         }
         xdevice->xclCopyBufferDevice2Host((void*)(&data),  addr, len, 0, XCL_ADDR_SPACE_DEVICE_RAM);
@@ -676,7 +676,7 @@ namespace hwemu {
     {
         auto xdevice = weak_xdevice.lock();
         if (!xdevice) {
-            std::cout<<"\n xdevice is nullptr \n";
+            SCHED_INFO("xdevice is nullptr %s", __func__);
             return false;
         }
 
@@ -830,7 +830,7 @@ namespace hwemu {
     {
         auto xdevice = weak_xdevice.lock();
         if (!xdevice) {
-            std::cout<<"\n xdevice is nullptr \n";
+            SCHED_INFO("xdevice is nullptr %s", __func__);
             return;
         }
         SCHED_DEBUGF("-> %s addr(0x%lx) data(0x%x)\n", __func__, addr, data);
@@ -846,7 +846,7 @@ namespace hwemu {
     {
         auto xdevice = weak_xdevice.lock();
         if (!xdevice) {
-            std::cout<<"\n xdevice is nullptr \n";
+            SCHED_INFO("xdevice is nullptr %s", __func__);
             return 0;
         }
         SCHED_DEBUGF("-> %s addr(0x%lx) \n", __func__, addr);
@@ -861,7 +861,7 @@ namespace hwemu {
         
         auto xdevice = weak_xdevice.lock();
         if (!xdevice) {
-            std::cout<<"\n xdevice is nullptr \n";
+            SCHED_INFO("xdevice is nullptr %s", __func__);
             return;
         }
 
@@ -876,7 +876,7 @@ namespace hwemu {
     {
         auto xdevice = weak_xdevice.lock();
         if (!xdevice) {
-            std::cout<<"\n xdevice is nullptr \n";
+            SCHED_INFO("xdevice is nullptr %s", __func__);
             return;
         }
         SCHED_DEBUGF("-> %s addr(0x%lx) len(%d)\n", __func__, addr, len);
@@ -889,7 +889,7 @@ namespace hwemu {
         SCHED_DEBUGF("-> %s addr(0x%lx) data(0x%x)\n", __func__, addr, data);
         auto xdevice = weak_xdevice.lock();
         if (!xdevice) {
-            std::cout<<"\n xdevice is nullptr \n";
+            SCHED_INFO("xdevice is nullptr %s", __func__);
             return;
         }
 
@@ -905,7 +905,7 @@ namespace hwemu {
         SCHED_DEBUGF("-> %s addr(0x%lx) \n", __func__, addr);
         auto xdevice = weak_xdevice.lock();
         if (!xdevice) {
-            std::cout<<"\n xdevice is nullptr \n";
+            SCHED_INFO("xdevice is nullptr %s", __func__);
             return 0;
         }
         uint32_t data = 0;
@@ -987,7 +987,7 @@ running_cmd_queue.clear();
     {
         auto xdevice = weak_xdevice.lock();
         if (!xdevice) {
-            std::cout<<"\n xdevice is nullptr \n";
+            SCHED_INFO("xdevice is nullptr %s", __func__);
             return 0;
         }
         ert_configure_cmd *cfg = xcmd->ert_cfg;
@@ -1323,7 +1323,7 @@ running_cmd_queue.clear();
 
         auto scheduler = weak_scheduler.lock();
         if (!scheduler) {
-            std::cout<<"\n scheduler shared ptr is not possible \n";
+            SCHED_INFO("scheduler weak_ptr is nullptr %s", __func__);
             return;
         }
         if (this->polling_mode)
@@ -1752,7 +1752,7 @@ running_cmd_queue.clear();
     {
         auto scheduler = weak_scheduler.lock();
         if (!scheduler) {
-            std::cout<<"\n scheduler shared ptr is not possible \n";
+            SCHED_INFO("scheduler is nullptr %s", __func__);
             return;
         }
         //! Release the xcmd to object pool
@@ -1985,7 +1985,7 @@ running_cmd_queue.clear();
         bool ret = false;
         auto scheduler = weak_scheduler.lock();
         if (!scheduler) {
-            std::cout<<"\n scheduler shared ptr is not possible \n";
+            SCHED_INFO("scheduler is nullptr %s", __func__);
             return ret;
         }
         SCHED_DEBUGF("-> %s exec(%d) cmd(%lu)\n", __func__, this->uid, xcmd->uid);
@@ -2044,7 +2044,7 @@ running_cmd_queue.clear();
     {
         auto scheduler = weak_scheduler.lock();
         if (!scheduler) {
-            std::cout<<"\n scheduler shared ptr is not possible \n";
+            SCHED_INFO("scheduler is nullptr %s", __func__);
             return ; 
         }
         uint32_t started = 0;
@@ -2124,8 +2124,8 @@ running_cmd_queue.clear();
 
     void xocl_scheduler::initialize() {
         exec = std::make_shared<exec_core>(weak_device.lock(), shared_from_this());
-        scheduler_thread = std::thread([&] { std::cout<<"\n testing this \n";
-        this->scheduler();} );     // Not a good way to start a thread from ctor.
+        scheduler_thread = std::thread([&] { 
+        this->scheduler();} );     
     }
     /**
      * cleanup scheduler_thread and other resources on exit
@@ -2346,7 +2346,7 @@ running_cmd_queue.clear();
     {
         auto device = weak_device.lock();
         if (!device) {
-            std::cout<<"\n shared pointer cannot be created\n";
+            SCHED_INFO("device is nullptr %s", __func__);
             return -EINVAL;
         }
             

--- a/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/mbscheduler_hwemu.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/mbscheduler_hwemu.cxx
@@ -7,7 +7,6 @@
 #include <chrono>
 #include <cmath>
 #include <algorithm>
-//#include "mbscheduler_hwemu.h"
 
 #define	CU_ADDR_HANDSHAKE_MASK	(0xff)
 #define	CU_ADDR_VALID(addr)	(((addr) | CU_ADDR_HANDSHAKE_MASK) != (uint64_t)-1)
@@ -44,7 +43,6 @@ namespace hwemu {
         cu_idx = -1;
         slot_idx = -1;
         cu_bitmap.reset();
-        //ert_pkt = NULL;
         state = ERT_CMD_STATE_NEW;
         aborted = false;
     }
@@ -169,7 +167,6 @@ namespace hwemu {
     {
         SCHED_DEBUGF("-> %s(%lu)\n", __func__, uid);
         this->bo = bo.get();
-        //this->ert_pkt = (struct ert_packet *)bo->buf;
         this->ert_pkt = static_cast<ert_packet*>(bo->buf);
 
         // copy pkt cus to command object cu bitmap
@@ -969,18 +966,16 @@ namespace hwemu {
         }
     }
     exec_core::~exec_core() {
-        // all shared pointers should clean in reverse order of their creation
-        /*
-        pending_ctrl_queue.clear();
-pending_kds_queue.clear();
-pending_scu_queue.clear();
-pending_cmd_queue.clear();
-running_cmd_queue.clear();
-*/
-//pending_cu_queue.clear();
-
-
         
+        /* Let's have it for now.
+        // all shared pointers should clean in reverse order of their creation
+        pending_ctrl_queue.clear();
+        pending_kds_queue.clear();
+        pending_scu_queue.clear();
+        pending_cmd_queue.clear();
+        running_cmd_queue.clear();
+        pending_cu_queue.clear();
+        */
     }
 
     int exec_core::exec_cfg_cmd(std::shared_ptr<xocl_cmd>& xcmd)
@@ -1038,8 +1033,6 @@ running_cmd_queue.clear();
                 // cuidx+1 to reserve slot 0 for ctrl => max 127 CUs in ert_poll mode
                 ? this->cq_base + (cuidx+1) * cfg->slot_size : 0;
 
-            //if (!xcu)
-            //    xcu = this->cus[cuidx] = new xocl_cu(xdevice);
             if (!xcu) {
                 xcu = std::make_shared<xocl_cu>(xdevice);
                 this->cus[cuidx] = xcu;
@@ -1060,8 +1053,6 @@ running_cmd_queue.clear();
                     uint64_t polladdr = (ert_poll) 					
                         ? this->cq_base + (cuidx+1) * cfg->slot_size : 0;
 
-                   // if (!xcu)
-                    //    xcu = this->cus[cuidx] = new xocl_cu(xdevice);
                     if (!xcu) {
                         xcu = std::make_shared<xocl_cu>(xdevice);
                         this->cus[cuidx] = xcu;
@@ -1755,9 +1746,6 @@ running_cmd_queue.clear();
             SCHED_INFO("scheduler is nullptr %s", __func__);
             return;
         }
-        //! Release the xcmd to object pool
-        //scheduler->cmd_pool.destroy(xcmd.get());
-        //xcmd = nullptr;
     }
 
     void exec_core::exec_abort_cmd(std::shared_ptr<xocl_cmd>& xcmd)
@@ -2422,8 +2410,6 @@ running_cmd_queue.clear();
     {
         std::lock_guard<std::mutex> lk(pending_cmds_mutex);
         //! Get the command from boost object pool
-        //xocl_cmd *lxcmd = cmd_pool.construct();
-        //std::shared_ptr<xocl_cmd> xcmd{lxcmd};
         std::shared_ptr<xocl_cmd> xcmd = std::make_shared<xocl_cmd>();
         if (!xcmd)
             return 1;

--- a/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/mbscheduler_hwemu.h
+++ b/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/mbscheduler_hwemu.h
@@ -56,8 +56,7 @@ namespace hwemu {
         public:
             xocl_cmd();
             ~xocl_cmd(){ 
-                //bo= nullptr; 
-                };
+            };
             uint32_t opcode();
             uint32_t    type();
             uint64_t    cmd_uid();
@@ -78,7 +77,6 @@ namespace hwemu {
             uint32_t next_cu(uint32_t prev);
             void     set_cu(uint32_t cuidx);
 
-            //std::shared_ptr<xclemulation::drm_xocl_bo> bo;
             xclemulation::drm_xocl_bo* bo;
             enum ert_cmd_state state;
             union {
@@ -490,11 +488,10 @@ namespace hwemu {
             std::atomic<uint32_t>    num_pending;
 
             //! Boost object pool to manage the memory for xocl cmds
-            boost::object_pool<xocl_cmd>  cmd_pool;
+            //boost::object_pool<xocl_cmd>  cmd_pool;
 
             //! exec_core
             std::shared_ptr<exec_core>  exec;
-            //xclhwemhal2::HwEmShim*   device;
             std::weak_ptr<xclhwemhal2::HwEmShim> weak_device;
 
             bool        error;

--- a/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/mbscheduler_hwemu.h
+++ b/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/mbscheduler_hwemu.h
@@ -55,8 +55,10 @@ namespace hwemu {
     {
         public:
             xocl_cmd();
-
-            uint32_t    opcode();
+            ~xocl_cmd(){ 
+                //bo= nullptr; 
+                };
+            uint32_t opcode();
             uint32_t    type();
             uint64_t    cmd_uid();
             uint32_t    payload_size();
@@ -76,7 +78,8 @@ namespace hwemu {
             uint32_t next_cu(uint32_t prev);
             void     set_cu(uint32_t cuidx);
 
-            std::shared_ptr<xclemulation::drm_xocl_bo> bo;
+            //std::shared_ptr<xclemulation::drm_xocl_bo> bo;
+            xclemulation::drm_xocl_bo* bo;
             enum ert_cmd_state state;
             union {
                 struct ert_packet	         *ert_pkt;
@@ -225,7 +228,7 @@ namespace hwemu {
     {
         public:
             exec_core(std::shared_ptr<xclhwemhal2::HwEmShim> dev, std::shared_ptr<xocl_scheduler> sched);
-
+            ~exec_core();
             int      exec_cfg_cmd(std::shared_ptr<xocl_cmd>& xcmd);
             bool     exec_is_ert();
             bool     exec_is_ert_poll();
@@ -344,7 +347,6 @@ namespace hwemu {
             std::queue<std::shared_ptr<xocl_cmd>>   pending_scu_queue;
             std::queue<std::shared_ptr<xocl_cmd>>   pending_cmd_queue;
             std::list<std::shared_ptr<xocl_cmd>>    running_cmd_queue;
-            //std::vector<std::shared_ptr<xocl_cmd>>    running_cmd_queue;
             std::queue<std::shared_ptr<xocl_cmd>>   pending_cu_queue[MAX_CUS];
     };
 
@@ -456,6 +458,8 @@ namespace hwemu {
         public:
             xocl_scheduler(std::shared_ptr<xclhwemhal2::HwEmShim> dev);
             ~xocl_scheduler();
+
+            void initialize();
 
             void  scheduler_wake_up();
             void  scheduler_intr();

--- a/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.cxx
@@ -430,7 +430,7 @@ namespace xclhwemhal2 {
         m_scheduler = std::make_shared<hwemu::xocl_scheduler>(shared_from_this());
     } else if (xclemulation::config::getInstance()->isXgqMode()) {
         //m_xgq = new hwemu::xocl_xgq(this);
-        m_xgq = std::make_shared<hwemu::xocl_xgq>(this);
+        m_xgq = std::make_shared<hwemu::xocl_xgq>(shared_from_this());
         if (m_xgq && pdi && pdiSize > 0) {
             returnValue = m_xgq->load_xclbin(pdi.get(), pdiSize);
         }
@@ -3300,7 +3300,7 @@ int HwEmShim::xclExecBuf(unsigned int cmdBO)
           PRINTENDFUNC;
           return ret;
       }
-      ret = m_xgq->add_exec_buffer(bo.get());  // will update
+      ret = m_xgq->add_exec_buffer(bo);  // will update
       PRINTENDFUNC;
       return ret;
   } else {

--- a/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.cxx
@@ -170,13 +170,9 @@ namespace xclhwemhal2 {
 
   static void saveWaveDataBases()
   {
-    //std::map<unsigned int, HwEmShim*>::iterator 
-    auto start = devices.begin();
-    //std::map<unsigned int, HwEmShim*>::iterator 
-    auto end = devices.end();
-    for(; start != end; start++)
+    for(auto& handle_pair : devices)
     {
-      auto handle = (*start).second;
+      auto handle = handle_pair.second;
       if(!handle)
         continue;
       handle->saveWaveDataBase();
@@ -317,7 +313,6 @@ namespace xclhwemhal2 {
     }
   }
 
-  //static void printMem(std::ofstream &os, int base, uint64_t offset, void* buf, unsigned int size )
   static void printMem(std::shared_ptr<std::ofstream> &os, int base, uint64_t offset, void* buf, unsigned int size )
   {
     if (!os) {
@@ -1515,7 +1510,6 @@ namespace xclhwemhal2 {
       if(!mMemModel)
         mMemModel = std::make_shared<mem_model>(deviceName);
         
-      //mMemModel = new mem_model(deviceName);
       mMemModel->readDevMem(src,dest,size);
       return size;
     }

--- a/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.cxx
@@ -2731,7 +2731,7 @@ uint64_t HwEmShim::xoclCreateBo(xclemulation::xocl_create_bo* info)
   auto xobj = std::make_shared<xclemulation::drm_xocl_bo>();
   xobj->flags=info->flags;
   /* check whether buffer is p2p or not*/
-  bool noHostMemory = xclemulation::no_host_memory(xobj.get());
+  bool noHostMemory = xclemulation::no_host_memory(xobj);
   std::string sFileName("");
 
   if(xobj->flags & XCL_BO_FLAGS_EXECBUF)
@@ -2933,13 +2933,13 @@ int HwEmShim::xclCopyBO(unsigned int dst_boHandle, unsigned int src_boHandle, si
     }
 
   // source buffer is host_only and destination buffer is device_only
-  if (isHostOnlyBuffer(sBO) && !xclemulation::xocl_bo_p2p(sBO.get()) && xclemulation::xocl_bo_dev_only(dBO.get())) {
+  if (isHostOnlyBuffer(sBO) && !xclemulation::xocl_bo_p2p(sBO) && xclemulation::xocl_bo_dev_only(dBO)) {
     unsigned char* host_only_buffer = (unsigned char*)(sBO->buf) + src_offset;
     if (xclCopyBufferHost2Device(dBO->base, (void*)host_only_buffer, size, dst_offset, dBO->topology) != size) {
       return -1;
     }
   } // source buffer is device_only and destination buffer is host_only
-  else if (isHostOnlyBuffer(dBO) && !xclemulation::xocl_bo_p2p(dBO.get()) && xclemulation::xocl_bo_dev_only(sBO.get())) {
+  else if (isHostOnlyBuffer(dBO) && !xclemulation::xocl_bo_p2p(dBO) && xclemulation::xocl_bo_dev_only(sBO)) {
     unsigned char* host_only_buffer = (unsigned char*)(dBO->buf) + dst_offset;
     if (xclCopyBufferDevice2Host((void*)host_only_buffer, sBO->base, size, src_offset, sBO->topology) != size) {
       return -1;

--- a/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.cxx
@@ -426,15 +426,17 @@ namespace xclhwemhal2 {
       mFirstBinary = false;
     }
     if(xclemulation::config::getInstance()->isNewMbscheduler()) {
-        m_scheduler = new hwemu::xocl_scheduler(this);
+        //m_scheduler = new hwemu::xocl_scheduler(this);
+        m_scheduler = std::make_shared<hwemu::xocl_scheduler>(shared_from_this());
     } else if (xclemulation::config::getInstance()->isXgqMode()) {
-        m_xgq = new hwemu::xocl_xgq(this);
+        //m_xgq = new hwemu::xocl_xgq(this);
+        m_xgq = std::make_shared<hwemu::xocl_xgq>(this);
         if (m_xgq && pdi && pdiSize > 0) {
             returnValue = m_xgq->load_xclbin(pdi.get(), pdiSize);
         }
     } else {
-        mCore = new exec_core;
-        mMBSch = new MBScheduler(this);
+        mCore = std::make_shared<exec_core>();
+        mMBSch = std::make_shared<MBScheduler>(shared_from_this());
         mMBSch->init_scheduler_thread();
     }
 
@@ -552,7 +554,7 @@ namespace xclhwemhal2 {
       for (auto it : mMembanks)
       {
         //CR 966701: alignment to 4k (instead of mDeviceInfo.mDataAlignment)
-        mDDRMemoryManager.push_back(new xclemulation::MemoryManager(it.size, it.base_addr, getpagesize(), it.tag));
+        mDDRMemoryManager.push_back(std::make_shared<xclemulation::MemoryManager>(it.size, it.base_addr, getpagesize(), it.tag));
 
         std::size_t found = it.tag.find("HOST");
         if (found != std::string::npos) {
@@ -1844,20 +1846,24 @@ namespace xclhwemhal2 {
       if(mMBSch && mCore)
       {
         mMBSch->fini_scheduler_thread();
-        delete mCore;
-        mCore = NULL;
-        delete mMBSch;
-        mMBSch = NULL;
+//        delete mCore;
+  //      mCore = NULL;
+        mCore.reset();
+        mMBSch.reset();
+        //delete mMBSch;
+        //mMBSch = NULL;
       }
       if(m_scheduler)
       {
-          delete m_scheduler;
-          m_scheduler = nullptr;
+        m_scheduler.reset();
+          //delete m_scheduler;
+          //m_scheduler = nullptr;
       }
       if(m_xgq)
       {
-          delete m_xgq;
-          m_xgq = nullptr;
+        m_xgq.reset();
+        //  delete m_xgq;
+        //  m_xgq = nullptr;
       }
       PRINTENDFUNC;
       if (mLogStream.is_open()) {
@@ -1926,20 +1932,24 @@ namespace xclhwemhal2 {
       if(mMBSch && mCore)
       {
         mMBSch->fini_scheduler_thread();
-        delete mCore;
-        mCore = NULL;
-        delete mMBSch;
-        mMBSch = NULL;
+        //delete mCore;
+        //mCore = NULL;
+        mCore.reset();
+        mMBSch.reset();
+        //delete mMBSch;
+        //mMBSch = NULL;
       }
       if(m_scheduler)
       {
-          delete m_scheduler;
-          m_scheduler = nullptr;
+        m_scheduler.reset();
+          //delete m_scheduler;
+          //m_scheduler = nullptr;
       }
       if(m_xgq)
       {
-          delete m_xgq;
-          m_xgq = nullptr;
+        m_xgq.reset();
+        //  delete m_xgq;
+        //  m_xgq = nullptr;
       }
       return 0;
     }
@@ -2051,20 +2061,26 @@ namespace xclhwemhal2 {
     if(mMBSch && mCore)
     {
       mMBSch->fini_scheduler_thread();
+      mCore.reset();
+      mMBSch.reset();
+      /*
       delete mCore;
       mCore = NULL;
       delete mMBSch;
       mMBSch = NULL;
+      */
     }
     if(m_scheduler)
     {
-        delete m_scheduler;
-        m_scheduler = nullptr;
+      m_scheduler.reset();
+      //  delete m_scheduler;
+      //  m_scheduler = nullptr;
     }
     if(m_xgq)
     {
-        delete m_xgq;
-        m_xgq = nullptr;
+      m_xgq.reset();
+      //  delete m_xgq;
+      //  m_xgq = nullptr;
     }
 
     return 0;
@@ -2106,20 +2122,26 @@ namespace xclhwemhal2 {
     if(mMBSch && mCore)
     {
       mMBSch->fini_scheduler_thread();
+      mCore.reset();
+      mMBSch.reset();
+      /*
       delete mCore;
       mCore = NULL;
       delete mMBSch;
       mMBSch = NULL;
+      */
     }
     if(m_scheduler)
     {
-        delete m_scheduler;
-        m_scheduler = nullptr;
+      m_scheduler.reset();
+      //  delete m_scheduler;
+      //  m_scheduler = nullptr;
     }
     if(m_xgq)
     {
-        delete m_xgq;
-        m_xgq = nullptr;
+      m_xgq.reset();
+      //  delete m_xgq;
+      //  m_xgq = nullptr;
     }
     if(mDataSpace)
     {
@@ -2138,7 +2160,7 @@ namespace xclhwemhal2 {
     {
       const uint64_t bankSize = (*start).ddrSize;
       mDdrBanks.push_back(*start);
-      mDDRMemoryManager.push_back(new xclemulation::MemoryManager(bankSize, base , getpagesize()));
+      mDDRMemoryManager.push_back(std::make_shared<xclemulation::MemoryManager>(bankSize, base , getpagesize()));
       base += bankSize;
     }
   }
@@ -2697,13 +2719,13 @@ static bool check_bo_user_flags(HwEmShim* dev, unsigned flags)
 	return true;
 }
 
-xclemulation::drm_xocl_bo* HwEmShim::xclGetBoByHandle(unsigned int boHandle)
+std::shared_ptr<xclemulation::drm_xocl_bo> HwEmShim::xclGetBoByHandle(unsigned int boHandle)
 {
   auto it = mXoclObjMap.find(boHandle);
   if(it == mXoclObjMap.end())
     return nullptr;
 
-  xclemulation::drm_xocl_bo* bo = (*it).second;
+  auto bo = (*it).second;
   return bo;
 }
 
@@ -2726,7 +2748,8 @@ int HwEmShim::xclGetBOProperties(unsigned int boHandle, xclBOProperties *propert
   {
     mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << std::hex << boHandle << std::endl;
   }
-  xclemulation::drm_xocl_bo* bo = xclGetBoByHandle(boHandle);
+  //xclemulation::drm_xocl_bo* bo = xclGetBoByHandle(boHandle);
+  auto bo = xclGetBoByHandle(boHandle);
   if (!bo) {
     PRINTENDFUNC;
     return  -1;
@@ -2757,7 +2780,8 @@ uint64_t HwEmShim::xoclCreateBo(xclemulation::xocl_create_bo* info)
     return -1;
   }
 
-  auto xobj = std::make_unique<xclemulation::drm_xocl_bo>();
+  //auto xobj = std::make_unique<xclemulation::drm_xocl_bo>();
+  auto xobj = std::make_shared<xclemulation::drm_xocl_bo>();
   xobj->flags=info->flags;
   /* check whether buffer is p2p or not*/
   bool noHostMemory = xclemulation::no_host_memory(xobj.get());
@@ -2784,7 +2808,8 @@ uint64_t HwEmShim::xoclCreateBo(xclemulation::xocl_create_bo* info)
   }
 
   info->handle = mBufferCount;
-  mXoclObjMap[mBufferCount++] = xobj.release();
+  //mXoclObjMap[mBufferCount++] = std::make_shared<xclemulation::drm_xocl_bo>(xobj.release());
+  mXoclObjMap[mBufferCount++] = xobj;
   return 0;
 }
 
@@ -2812,7 +2837,7 @@ unsigned int HwEmShim::xclAllocUserPtrBO(void *userptr, size_t size, unsigned fl
   }
   xclemulation::xocl_create_bo info = {size, mNullBO, flags};
   uint64_t result = xoclCreateBo(&info);
-  xclemulation::drm_xocl_bo* bo = xclGetBoByHandle(info.handle);
+  auto bo = xclGetBoByHandle(info.handle);
   if (bo) {
     bo->userptr = userptr;
   }
@@ -2829,7 +2854,7 @@ int HwEmShim::xclExportBO(unsigned int boHandle)
   {
     mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << std::hex << boHandle << std::endl;
   }
-  xclemulation::drm_xocl_bo* bo = xclGetBoByHandle(boHandle);
+  auto bo = xclGetBoByHandle(boHandle);
   if(!bo)
     return -1;
 
@@ -2885,7 +2910,7 @@ unsigned int HwEmShim::xclImportBO(int boGlobalHandle, unsigned flags)
     unsigned boFlags = std::get<3>((*itr).second);
 
     unsigned int importedBo = xclAllocBO(size, 0, boFlags);
-    xclemulation::drm_xocl_bo* bo = xclGetBoByHandle(importedBo);
+    auto bo = xclGetBoByHandle(importedBo);
     if(!bo)
     {
       std::cout<<"ERROR HERE in importBO "<<std::endl;
@@ -2911,14 +2936,14 @@ int HwEmShim::xclCopyBO(unsigned int dst_boHandle, unsigned int src_boHandle, si
     mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << std::hex << dst_boHandle
       << ", "<< src_boHandle << ", "<< size << ", " << dst_offset << ", " << src_offset<< std::endl;
   }
-  xclemulation::drm_xocl_bo* sBO = xclGetBoByHandle(src_boHandle);
+  auto sBO = xclGetBoByHandle(src_boHandle);
   if(!sBO)
   {
     PRINTENDFUNC;
     return -1;
   }
 
-  xclemulation::drm_xocl_bo* dBO = xclGetBoByHandle(dst_boHandle);
+  auto dBO = xclGetBoByHandle(dst_boHandle);
   if(!dBO)
   {
     PRINTENDFUNC;
@@ -2962,13 +2987,13 @@ int HwEmShim::xclCopyBO(unsigned int dst_boHandle, unsigned int src_boHandle, si
     }
 
   // source buffer is host_only and destination buffer is device_only
-  if (isHostOnlyBuffer(sBO) && !xclemulation::xocl_bo_p2p(sBO) && xclemulation::xocl_bo_dev_only(dBO)) {
+  if (isHostOnlyBuffer(sBO) && !xclemulation::xocl_bo_p2p(sBO.get()) && xclemulation::xocl_bo_dev_only(dBO.get())) {
     unsigned char* host_only_buffer = (unsigned char*)(sBO->buf) + src_offset;
     if (xclCopyBufferHost2Device(dBO->base, (void*)host_only_buffer, size, dst_offset, dBO->topology) != size) {
       return -1;
     }
   } // source buffer is device_only and destination buffer is host_only
-  else if (isHostOnlyBuffer(dBO) && !xclemulation::xocl_bo_p2p(dBO) && xclemulation::xocl_bo_dev_only(sBO)) {
+  else if (isHostOnlyBuffer(dBO) && !xclemulation::xocl_bo_p2p(dBO.get()) && xclemulation::xocl_bo_dev_only(sBO.get())) {
     unsigned char* host_only_buffer = (unsigned char*)(dBO->buf) + dst_offset;
     if (xclCopyBufferDevice2Host((void*)host_only_buffer, sBO->base, size, src_offset, sBO->topology) != size) {
       return -1;
@@ -3062,7 +3087,7 @@ void *HwEmShim::xclMapBO(unsigned int boHandle, bool write)
   {
     mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << std::hex << boHandle << " , " << write << std::endl;
   }
-  xclemulation::drm_xocl_bo* bo = xclGetBoByHandle(boHandle);
+  auto bo = xclGetBoByHandle(boHandle);
   if (!bo) {
     PRINTENDFUNC;
     return nullptr;
@@ -3131,7 +3156,7 @@ int HwEmShim::xclSyncBO(unsigned int boHandle, xclBOSyncDirection dir, size_t si
   {
     mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << std::hex << boHandle << " , " << std::endl;
   }
-  xclemulation::drm_xocl_bo* bo = xclGetBoByHandle(boHandle);
+  auto bo = xclGetBoByHandle(boHandle);
   if(!bo)
   {
     PRINTENDFUNC;
@@ -3176,7 +3201,7 @@ void HwEmShim::xclFreeBO(unsigned int boHandle)
     return;
   }
 
-  xclemulation::drm_xocl_bo* bo = (*it).second;;
+  auto& bo = (*it).second;
   if(bo)
   {
     bool bSendToSim = true;
@@ -3193,7 +3218,9 @@ void HwEmShim::xclFreeBO(unsigned int boHandle)
     {
 	    xclFreeDeviceBuffer(bo->base, bSendToSim);
     }
+
     mXoclObjMap.erase(it);
+    //it.reset();
   }
   PRINTENDFUNC;
 }
@@ -3207,7 +3234,7 @@ size_t HwEmShim::xclWriteBO(unsigned int boHandle, const void *src, size_t size,
   {
     mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << std::hex << boHandle << " , "<< src <<" , "<< size << ", " << seek << std::endl;
   }
-  xclemulation::drm_xocl_bo* bo = xclGetBoByHandle(boHandle);
+  auto bo = xclGetBoByHandle(boHandle);
   if(!bo)
   {
     PRINTENDFUNC;
@@ -3231,7 +3258,7 @@ size_t HwEmShim::xclReadBO(unsigned int boHandle, void *dst, size_t size, size_t
   {
     mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << std::hex << boHandle << " , "<< dst <<" , "<< size << ", " << skip << std::endl;
   }
-  xclemulation::drm_xocl_bo* bo = xclGetBoByHandle(boHandle);
+  auto bo = xclGetBoByHandle(boHandle);
   if(!bo)
   {
     PRINTENDFUNC;
@@ -3255,7 +3282,7 @@ int HwEmShim::xclExecBuf(unsigned int cmdBO)
     mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << cmdBO << std::endl;
   }
 
-  xclemulation::drm_xocl_bo* bo = xclGetBoByHandle(cmdBO);
+  auto bo = xclGetBoByHandle(cmdBO);
   int ret=-1;
   if(xclemulation::config::getInstance()->isNewMbscheduler())
   {
@@ -3273,7 +3300,7 @@ int HwEmShim::xclExecBuf(unsigned int cmdBO)
           PRINTENDFUNC;
           return ret;
       }
-      ret = m_xgq->add_exec_buffer(bo);
+      ret = m_xgq->add_exec_buffer(bo.get());  // will update
       PRINTENDFUNC;
       return ret;
   } else {
@@ -3298,7 +3325,7 @@ int HwEmShim::xclExecBuf(unsigned int cmdBO, size_t num_bo_in_wait_list, unsigne
     mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << cmdBO << ", " << num_bo_in_wait_list << ", " << bo_wait_list << std::endl;
   }
 
-  xclemulation::drm_xocl_bo* bo = xclGetBoByHandle(cmdBO);
+  auto bo = xclGetBoByHandle(cmdBO);
 
   xcl_LogMsg(XRT_INFO, "", "%s, cmdBO: %d, num_bo_in_wait_list: %d, bo_wait_list: %d",
             __func__, cmdBO, num_bo_in_wait_list, bo_wait_list);

--- a/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.h
+++ b/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.h
@@ -312,11 +312,13 @@ using addr_type = uint64_t;
     	  if(xclemulation::config::getInstance()->isDisabledHostBUffer()) {
     		  return false;
     	  } else {
-    		  return xclemulation::xocl_bo_host_only(bo.get());
+    		  return xclemulation::xocl_bo_host_only(bo);
     	  }
       }
 
       bool readEmuSettingsJsonFile(const std::string& emuSettingsFilePath);
+      uint32_t get_my_device_index() { return mDevice_Index_for_this_device; };
+      void set_my_device_index(uint32_t index) { mDevice_Index_for_this_device = index; };
 
     private:
       std::thread mMessengerThread;
@@ -428,6 +430,7 @@ using addr_type = uint64_t;
       unsigned int host_sptag_idx;
       bool mSimDontRun;
       nocddr_fastaccess_hwemu mNocFastAccess;
+      uint32_t  mDevice_Index_for_this_device;
   };
 
   //extern std::map<unsigned int, HwEmShim*> devices;

--- a/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.h
+++ b/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.h
@@ -336,14 +336,11 @@ using addr_type = uint64_t;
       //Mapped CU register space for xclRegRead/Write()
       int xclRegRW(bool rd, uint32_t cu_index, uint32_t offset, uint32_t *datap);
 
-      //std::vector<xclemulation::MemoryManager *> mDDRMemoryManager;
       std::vector<std::shared_ptr<xclemulation::MemoryManager> > mDDRMemoryManager;
-      //xclemulation::MemoryManager* mDataSpace;
       std::shared_ptr<xclemulation::MemoryManager> mDataSpace;
       std::list<xclemulation::DDRBank> mDdrBanks;
       std::map<uint64_t,uint64_t> mAddrMap;
       std::map<std::string,std::string> mBinaryDirectories;
-      //std::map<uint64_t , std::ofstream*> mOffsetInstanceStreamMap;
       std::map<uint64_t , std::shared_ptr<std::ofstream>> mOffsetInstanceStreamMap;
 
       //mutex to control parellel RPC calls
@@ -363,10 +360,7 @@ using addr_type = uint64_t;
       void* buf;
       size_t buf_size;
       std::ofstream mLogStream;
-      /*
-      std::ofstream mGlobalInMemStream;
-      std::ofstream mGlobalOutMemStream;
-*/
+
       std::shared_ptr<std::ofstream> mGlobalInMemStream;
       std::shared_ptr<std::ofstream> mGlobalOutMemStream;
       static std::ofstream mDebugLogStream;
@@ -380,7 +374,6 @@ using addr_type = uint64_t;
       unsigned int mDeviceIndex;
       clock_t last_clk_time;
       bool mCloseAll;
-      //mem_model* mMemModel;
       std::shared_ptr<mem_model> mMemModel;
       bool bUnified;
       bool bXPR;
@@ -389,12 +382,9 @@ using addr_type = uint64_t;
       std::map<int, std::shared_ptr<xclemulation::drm_xocl_bo>> mXoclObjMap;
       static unsigned int mBufferCount;
       // HAL2 RELATED member variables end
-      //exec_core* mCore;
       std::shared_ptr<exec_core> mCore;
       std::shared_ptr<MBScheduler> mMBSch;
-      //hwemu::xocl_scheduler* m_scheduler;
       std::shared_ptr<hwemu::xocl_scheduler> m_scheduler;
-      //hwemu::xocl_xgq* m_xgq;
       std::shared_ptr<hwemu::xocl_xgq> m_xgq;
 
       // Information extracted from platform linker (for profile/debug)

--- a/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.h
+++ b/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.h
@@ -170,6 +170,7 @@ using addr_type = uint64_t;
       int xclLoadXclBin(const xclBin *buffer);
       //int xclLoadBitstream(const char *fileName);
       int xclLoadBitstreamWorker(bitStreamArg);
+      int LaunchSimulatorWithEnvironmentSetUp(bitStreamArg args, std::string& zip_fileName, std::string& binaryDirectory, std::string& xclBinName);
       bool isUltraScale() const;
       int xclUpgradeFirmware(const char *fileName);
       int xclBootFPGA();

--- a/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.h
+++ b/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.h
@@ -433,7 +433,6 @@ using addr_type = uint64_t;
       uint32_t  mDevice_Index_for_this_device;
   };
 
-  //extern std::map<unsigned int, HwEmShim*> devices;
   extern std::map<unsigned int, std::shared_ptr<HwEmShim>> devices;
  }
 #endif

--- a/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.h
+++ b/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.h
@@ -54,28 +54,6 @@ using key_type = xrt_core::query::key_type;
 using addr_type = uint64_t;
 #define PRINTENDFUNC if (mLogStream.is_open()) mLogStream << __func__ << " ended " << std::endl;
 
-/*
-  template< class T>
-  class raw_pointer
-  {
-    public:
-      raw_pointer(const T* lhs) {
-        m_pointer = std::make_shared<T>(lhs);
-      }
-      raw_pointer(const raw_pointer &lhs) : m_pointer{lhs.m_pointer} { lhs.m_pointer = nullptr;  }
-      T* operator ->() { return this->m_pointer.get(); }
-      T* operator * () { return this->m_pointer.get(); }
-      bool operator !() const { return (this->m_pointer == nullptr)?true:false;}
-      bool operator() () const { return (this->m_pointer == nullptr)?false:true;}
-      ~raw_pointer() {
-        m_pointer = nullptr;    // No ownership 
-      }
-
-      private:
-        std::shared_ptr<T> m_pointer;
-  };
-*/
-
   class Event {
     public:
       uint8_t awlen;
@@ -359,11 +337,13 @@ using addr_type = uint64_t;
 
       //std::vector<xclemulation::MemoryManager *> mDDRMemoryManager;
       std::vector<std::shared_ptr<xclemulation::MemoryManager> > mDDRMemoryManager;
-      xclemulation::MemoryManager* mDataSpace;
+      //xclemulation::MemoryManager* mDataSpace;
+      std::shared_ptr<xclemulation::MemoryManager> mDataSpace;
       std::list<xclemulation::DDRBank> mDdrBanks;
       std::map<uint64_t,uint64_t> mAddrMap;
       std::map<std::string,std::string> mBinaryDirectories;
-      std::map<uint64_t , std::ofstream*> mOffsetInstanceStreamMap;
+      //std::map<uint64_t , std::ofstream*> mOffsetInstanceStreamMap;
+      std::map<uint64_t , std::shared_ptr<std::ofstream>> mOffsetInstanceStreamMap;
 
       //mutex to control parellel RPC calls
       std::mutex mtx;
@@ -382,9 +362,14 @@ using addr_type = uint64_t;
       void* buf;
       size_t buf_size;
       std::ofstream mLogStream;
+      /*
       std::ofstream mGlobalInMemStream;
       std::ofstream mGlobalOutMemStream;
+*/
+      std::shared_ptr<std::ofstream> mGlobalInMemStream;
+      std::shared_ptr<std::ofstream> mGlobalOutMemStream;
       static std::ofstream mDebugLogStream;
+
       static bool mFirstBinary;
       unsigned int binaryCounter;
 
@@ -394,7 +379,8 @@ using addr_type = uint64_t;
       unsigned int mDeviceIndex;
       clock_t last_clk_time;
       bool mCloseAll;
-      mem_model* mMemModel;
+      //mem_model* mMemModel;
+      std::shared_ptr<mem_model> mMemModel;
       bool bUnified;
       bool bXPR;
       //MemTopology topology;

--- a/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.h
+++ b/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.h
@@ -54,6 +54,28 @@ using key_type = xrt_core::query::key_type;
 using addr_type = uint64_t;
 #define PRINTENDFUNC if (mLogStream.is_open()) mLogStream << __func__ << " ended " << std::endl;
 
+/*
+  template< class T>
+  class raw_pointer
+  {
+    public:
+      raw_pointer(const T* lhs) {
+        m_pointer = std::make_shared<T>(lhs);
+      }
+      raw_pointer(const raw_pointer &lhs) : m_pointer{lhs.m_pointer} { lhs.m_pointer = nullptr;  }
+      T* operator ->() { return this->m_pointer.get(); }
+      T* operator * () { return this->m_pointer.get(); }
+      bool operator !() const { return (this->m_pointer == nullptr)?true:false;}
+      bool operator() () const { return (this->m_pointer == nullptr)?false:true;}
+      ~raw_pointer() {
+        m_pointer = nullptr;    // No ownership 
+      }
+
+      private:
+        std::shared_ptr<T> m_pointer;
+  };
+*/
+
   class Event {
     public:
       uint8_t awlen;
@@ -234,7 +256,8 @@ using addr_type = uint64_t;
 
       //destructor
       ~HwEmShim();
-
+      HwEmShim& operator=(const HwEmShim& lhs) = default;
+      HwEmShim(const HwEmShim& lhs) = default;
       static const int SPIR_ADDRSPACE_PRIVATE;  //0
       static const int SPIR_ADDRSPACE_GLOBAL;   //1
       static const int SPIR_ADDRSPACE_CONSTANT; //2
@@ -430,6 +453,7 @@ using addr_type = uint64_t;
       nocddr_fastaccess_hwemu mNocFastAccess;
   };
 
-  extern std::map<unsigned int, HwEmShim*> devices;
+  //extern std::map<unsigned int, HwEmShim*> devices;
+  extern std::map<unsigned int, std::shared_ptr<HwEmShim>> devices;
  }
 #endif

--- a/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/xgq_hwemu.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/xgq_hwemu.cxx
@@ -82,9 +82,7 @@ namespace hwemu {
     qid = 0;
 
     sub_thread = std::thread {[&] { this->submit_worker(); } };
-    //new std::thread(&xgq_queue::submit_worker, this);
     com_thread = std::thread {[&] { this->complete_worker(); } };
-    //new std::thread(&xgq_queue::complete_worker, this);
 
     size_t ring_len = XRT_QUEUE1_RING_LENGTH;
     auto devp = reinterpret_cast<uint64_t>(weak_ptr_device.lock().get());

--- a/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/xgq_hwemu.h
+++ b/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/xgq_hwemu.h
@@ -113,9 +113,7 @@ namespace hwemu {
       uint64_t        xgq_sub_base;
       uint64_t        xgq_com_base;
 
-      //std::list<xgq_cmd*>          pending_cmds;
       std::list<std::shared_ptr<xgq_cmd>>          pending_cmds;
-      //std::map<uint64_t, xgq_cmd*> submitted_cmds;
       std::map<uint64_t, std::shared_ptr<xgq_cmd>> submitted_cmds;
       std::mutex                   queue_mutex;
       bool                         stop;


### PR DESCRIPTION
Fix : Memory creation, pointers utilizatioin replaced with smart pointers if the shim layer has the ownership of them. xclBitStreamWorker function is more modular now. This change is across both sw_emu and hw_emu.
Risk: very Low.
Tests: Canary run. Results are clean.
Reviewer: venkatp