### PR TITLE
xrt.h should support C compilation

### DIFF
--- a/src/runtime_src/core/include/deprecated/xrt.h
+++ b/src/runtime_src/core/include/deprecated/xrt.h
@@ -98,14 +98,14 @@ to_xclBufferHandle(xrt_buffer_handle hdl)
 #ifdef _WIN32
     : hdl; // No cast needed, happen to be the same define as xclBufferHandle
 #else
-    : reinterpret_cast<uintptr_t>(hdl);
+    : (xclBufferHandle)(uintptr_t)hdl;
 #endif
 }
 
 static inline xrt_buffer_handle
 to_xrt_buffer_handle(xclBufferHandle hdl)
 {
-  return hdl == XRT_NULL_BO ? XRT_INVALID_BUFFER_HANDLE : reinterpret_cast<xrt_buffer_handle>(hdl);
+  return hdl == XRT_NULL_BO ? XRT_INVALID_BUFFER_HANDLE : (xrt_buffer_handle)(uintptr_t)hdl;
 }
 
 /*


### PR DESCRIPTION
Signed-off-by: Max Zhen <max.zhen@amd.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Fix xrt.h so that it can be included in C code.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Regression introduced by https://github.com/Xilinx/XRT/pull/7109
#### How problem was solved, alternative solutions (if any) and why they were rejected
N/A
#### Risks (if any) associated the changes in the commit
Low risk
#### What has been tested and how, request additional testing if necessary
Build and install XRT and run examine and validate on u55n
Compiled a C program with xrt.h included
#### Documentation impact (if any)
N/A