### PR TITLE
Fix for CR-1142773: ul3x24 - Upgrading to working blp from MFG Image …

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
@@ -2940,7 +2940,7 @@ struct xocl_subdev_map {
 		.flags = XOCL_DSAFLAG_DYNAMIC_IP,			\
 		.subdev_info	= RES_USER_VSEC,			\
 		.subdev_num = ARRAY_SIZE(RES_USER_VSEC),		\
-		.board_name = "avalon",					\
+		.board_name = "avalon"					\
 	}
 
 #define	XOCL_BOARD_AVALON_MGMT_RAPTOR2				\
@@ -2949,7 +2949,7 @@ struct xocl_subdev_map {
 		.subdev_info	= RES_MGMT_VSEC,			\
 		.subdev_num = ARRAY_SIZE(RES_MGMT_VSEC),		\
 		.flash_type = FLASH_TYPE_SPI,				\
-		.board_name = "avalon"					\
+		.board_name = "avalon"		                        \
 	}
 
 /*********************************VCK190 MGMTPF START*******************/
@@ -3640,11 +3640,11 @@ struct xocl_subdev_map {
 		.priv_data = &XOCL_BOARD_U30_USER_RAPTOR2,		\
 		.type = XOCL_DSAMAP_RAPTOR2 },				\
 	{ 0x10EE, 0x5099, PCI_ANY_ID,					\
-		.vbnv = "xilinx_avalon",				\
+		.vbnv = "xilinx_ul3x24",				\
 		.priv_data = &XOCL_BOARD_AVALON_USER_RAPTOR2,		\
 		.type = XOCL_DSAMAP_RAPTOR2 },				\
 	{ 0x10EE, 0x5098, PCI_ANY_ID,					\
-		.vbnv = "xilinx_avalon",				\
+		.vbnv = "xilinx_ul3x24",				\
 		.priv_data = &XOCL_BOARD_AVALON_MGMT_RAPTOR2,		\
 		.type = XOCL_DSAMAP_RAPTOR2 }
 

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -285,6 +285,9 @@ pretty_print_platform_info(const boost::property_tree::ptree& _ptDevice, const s
   std::cout << "\nIncoming Configuration\n";
   const boost::property_tree::ptree& available_shells = _ptDevice.get_child("platform.available_shells");
 
+  if (available_shells.empty())
+    throw xrt_core::error("No shell matched for given flash image");
+  
   boost::property_tree::ptree platform_to_flash;
   for (auto& image : available_shells) {
     if ((image.second.get<std::string>("vbnv")).compare(vbnv) == 0) {


### PR DESCRIPTION
…fails with error : "[xbmgmt] ERROR: No such node (file)" (#7111)

(cherry picked from commit ab659e225e9dea6acc18bb05bf0aa2bc17c97c9f)
Signed-off-by: saumyag <saumyag@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
cherry pick from master branch
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
