### PR TITLE
Increase kds / ert command timeout

### DIFF
--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -1016,7 +1016,7 @@ int kds_submit_cmd_and_wait(struct kds_sched *kds, struct kds_command *xcmd)
 
 	 * To avoid this, wait for few seconds for ERT to complete command.
 	 */
-	ret = wait_for_completion_timeout(&kds->comp, msecs_to_jiffies(3000));
+	ret = wait_for_completion_timeout(&kds->comp, msecs_to_jiffies(10000));
 	if (!ret) {
 		kds->ert->abort_sync(kds->ert, client, NO_INDEX);
 		/* ERT abort would handle command in time. The command would be

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_ctrl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_ctrl.c
@@ -41,7 +41,7 @@
 #define ERT_CTRL_SQ_TAIL_OFF	0x4
 #define ERT_CTRL_CQ_TAIL_OFF	0x8
 
-#define ERT_CTRL_CMD_TIMEOUT	msecs_to_jiffies(2 * 1000)
+#define ERT_CTRL_CMD_TIMEOUT	msecs_to_jiffies(8 * 1000)
 
 #define ERT_CTRL_ADD_NUM_ERT_XGQ	4
 


### PR DESCRIPTION
Increase kds / ert command timeout to accomodate longer PS kernel init time due to vdu driver initialization for V70

Signed-off-by: Jeff Lin <jeffylin@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
V70's PS kernel init taking longer due to VDU driver initialization

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Increase timeout

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
V70 with VDU xclbin

#### Documentation impact (if any)
None