### PR TITLE
Update scu statistics sysfs node to use new logic

### DIFF
--- a/src/runtime_src/core/common/drv/include/kds_core.h
+++ b/src/runtime_src/core/common/drv/include/kds_core.h
@@ -230,5 +230,5 @@ int store_kds_echo(struct kds_sched *kds, const char *buf, size_t count,
 		   int *echo);
 ssize_t show_kds_stat(struct kds_sched *kds, char *buf);
 ssize_t show_kds_custat_raw(struct kds_sched *kds, char *buf, size_t buf_size, loff_t offset);
-ssize_t show_kds_scustat_raw(struct kds_sched *kds, char *buf);
+ssize_t show_kds_scustat_raw(struct kds_sched *kds, char *buf, size_t buf_size, loff_t offset);
 #endif

--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -139,46 +139,13 @@ ssize_t show_kds_custat_raw(struct kds_sched *kds, char *buf, size_t buf_size, l
 	return sz;
 }
 
-ssize_t show_kds_scustat_raw(struct kds_sched *kds, char *buf)
+ssize_t show_kds_scustat_raw(struct kds_sched *kds, char *buf, size_t buf_size, loff_t offset)
 {
 	struct kds_cu_mgmt *scu_mgmt = &kds->scu_mgmt;
-	/* Each line is a PS kernel, format:
-	 * "slot,idx,kernel_name,status,usage"
-	 */
-	char *cu_fmt = "%d,%d,%s:%s,0x%x,%u\n";
-	struct xrt_cu *xcu = NULL;
 	ssize_t sz = 0;
-	int i;
-	int j;
 
-	/* TODO: The number of PS kernel could be 64 or even more.
-	 * Sysfs has PAGE_SIZE limit, which keep bother us in old KDS.
-	 * In 128 PS kernels case, each line is average 32 bytes.
-	 * The kernel name is no more than 19 bytes.
-	 *
-	 * Old KDS shows FPGA Kernel and PS kernel in one file.
-	 * So, this separate kds_scustat_raw is better.
-	 *
-	 * But in the worst case, this is still not good enough.
-	 */
 	mutex_lock(&scu_mgmt->lock);
-	for (j = 0; j < MAX_SLOT; ++j) {
-		for (i = 0; i < MAX_CUS; ++i) {
-			xcu = scu_mgmt->xcus[i];
-			if (!xcu)
-				continue;
-
-			/* Show the CUs as per slot order */
-			if (xcu->info.slot_idx != j)
-				continue;
-
-			sz += scnprintf(buf+sz, PAGE_SIZE - sz, cu_fmt, j,
-					set_domain(DOMAIN_PS, i),
-					xcu->info.kname,xcu->info.iname,
-					xcu->status,
-					cu_stat_read(scu_mgmt,usage[i]));
-		}
-	}
+	sz = kds_populate_cu_buf(scu_mgmt, buf, buf_size, offset, KDS_SCU);
 	mutex_unlock(&scu_mgmt->lock);
 
 	return sz;

--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -58,7 +58,7 @@ static ssize_t kds_create_cu_string(struct xrt_cu *xcu,
 			*/
 			cu_sz = scnprintf(*buf, sizeof(*buf),
 					"%d,%d,%s:%s,0x%llx,0x%x,%llu\n", slot,
-					idx,
+					set_domain(DOMAIN_PL, idx),
 					xcu->info.kname, xcu->info.iname,
 					xcu->info.addr, xcu->status,
 					usage_count);
@@ -69,7 +69,7 @@ static ssize_t kds_create_cu_string(struct xrt_cu *xcu,
 			*/
 			cu_sz = scnprintf(*buf, sizeof(*buf),
 					"%d,%d,%s:%s,0x%x,%llu\n", slot,
-					idx,
+					set_domain(DOMAIN_PS, idx),
 					xcu->info.kname, xcu->info.iname,
 					xcu->status,
 					usage_count);
@@ -105,8 +105,7 @@ static ssize_t kds_populate_cu_buf(struct kds_cu_mgmt *cu_mgmt, char *buf,
 
 			/* Generate the CU string to write into the buffer */
 			memset(cu_buf, 0, sizeof(cu_buf));
-			cu_sz = kds_create_cu_string(xcu, &cu_buf, j,
-					set_domain(DOMAIN_PL, i),
+			cu_sz = kds_create_cu_string(xcu, &cu_buf, j, i,
 					cu_stat_read(cu_mgmt, usage[i]), type);
 
 			/* Store the CU string length with previous lengths */


### PR DESCRIPTION
Signed-off-by: Daniel Benusovich <dbenusov@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Second part of changes related to https://github.com/Xilinx/XRT/pull/5726
This converts the SCU sysfs node to support more than a single page of information.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
When an xclbin contains a very large number of SCUs the current sysfs node will not output all available data. In addition, the XRT tools correctly states that the data is corrupted due to missing information.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Updated the current node, kds_scustat_raw, to a binary node which is capable of transferring the all SCU data defined by kds_core. The current solution does not account for the chance that the SCU data will change during the request. @houlz0507 and I discussed how to solve this issue and found that implementing a solution is rather complicated and consumes a large amount of resources for a sysfs node.

#### Risks (if any) associated the changes in the commit
If the SCU data changes between read invocations the user may see strange results. This was a tradeoff vs a much more complicated design. If users complain enough about this issue we can fix it.

#### What has been tested and how, request additional testing if necessary
Ubuntu 20.04 on vck5000 with custom xclbin
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov/XRT$ xbutil examine -d 17:00 -r dynamic-regions
WARNING: Unexpected xocl version (2.14.0) was found. Expected 2.15.0, to match XRT tools.

---------------------------------------------------
[0000:17:00.1] : xilinx_vck5000_gen4x8_qdma_base_2
---------------------------------------------------
Xclbin UUID
  54303CEF-56F8-039A-6C87-DC9E5889BC94

Compute Units
  PL Compute Units
    Index   Name                                              Base_Address    Usage   Status
    0       bandwidth:bandwidth_1                             0x20200010000   0       (IDLE)

  PS Compute Units
    Index   Name                                              Base_Address    Usage   Status
    0       hello_world:hello_world_0                         0x0             3       (IDLE)
	
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov/XRT$ cat /sys/bus/pci/devices/0000\:17\:00.1/kds_scustat_raw
0,65536,hello_world:hello_world_0,0x4,3
```

#### Documentation impact (if any)
None