### PR TITLE
CR-1144398 plm reset subsystem only works for v70, but hungs on vck5000

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
@@ -2905,7 +2905,6 @@ static ssize_t xgq_ospi_write(struct file *filp, const char __user *udata,
 
 		rval = xgq_download_apu_firmware(xgq->xgq_pdev);
 		if (rval) {
-			ret = rval;
 			XGQ_WARN(xgq, "unable to download APU: %d", rval);
 		}
 	}


### PR DESCRIPTION
Signed-off-by: David Zhang <davidzha@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

Found 2 issues on vck5000.
1) the plm should be build with stdout uart1, otherwise the subsystem reset doesn't work with VMR. 
2) host driver should continue even if APU pkg is not installed.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1144398
#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
tested on both vck5000 and v70
#### Documentation impact (if any)
