### PR TITLE
fix typo in ert_cmd_state comment

### DIFF
--- a/src/runtime_src/core/include/ert.h
+++ b/src/runtime_src/core/include/ert.h
@@ -468,7 +468,7 @@ struct ert_access_valid_cmd {
  * @ERT_CMD_STATE_QUEUED:      Internal scheduler state
  * @ERT_CMD_STATE_SUBMITTED:   Internal scheduler state
  * @ERT_CMD_STATE_RUNNING:     Internal scheduler state
- * @ERT_CMD_STATE_COMPLETE:    Set by scheduler when command completes
+ * @ERT_CMD_STATE_COMPLETED:   Set by scheduler when command completes
  * @ERT_CMD_STATE_ERROR:       Set by scheduler if command failed
  * @ERT_CMD_STATE_ABORT:       Set by scheduler if command abort
  * @ERT_CMD_STATE_TIMEOUT:     Set by scheduler if command timeout and reset

--- a/src/runtime_src/core/include/ert.h
+++ b/src/runtime_src/core/include/ert.h
@@ -468,7 +468,7 @@ struct ert_access_valid_cmd {
  * @ERT_CMD_STATE_QUEUED:      Internal scheduler state
  * @ERT_CMD_STATE_SUBMITTED:   Internal scheduler state
  * @ERT_CMD_STATE_RUNNING:     Internal scheduler state
- * @ERT_CMD_STATE_COMPLETED:   Set by scheduler when command completes
+ * @ERT_CMD_STATE_COMPLETED:   Set by scheduler when command completes 
  * @ERT_CMD_STATE_ERROR:       Set by scheduler if command failed
  * @ERT_CMD_STATE_ABORT:       Set by scheduler if command abort
  * @ERT_CMD_STATE_TIMEOUT:     Set by scheduler if command timeout and reset


### PR DESCRIPTION
This change corrects the commenting on the ert_cmd_state enum. Previously, the comment for ERT_CMD_STATE_COMPLETED listed the value as 'ERT_CMD_STATE_COMPLETE' (without the D). This reads as a reasonable name, but ended up wasting a good 25 minutes of my time. Now, the commenting (and implicitly any docs generated from it) will correctly inform users of the correct possible values of the enum

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Issue with documentation that results in users attempting to use a reasonable-sounding enum value that does not exist.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Adding a 'D' to the end of the ERT_CMD_STATE_COMPLETE' name in the comment.

#### Risks (if any) associated the changes in the commit
If any documentation is autogenerated from these comments, it may need to be updated.

#### What has been tested and how, request additional testing if necessary
No testing has been performed.

#### Documentation impact (if any)
I assume this is all that will need to be changed, but if there are any other places this enum value list was copy/pasted, it may need to be changed there, as well.