### PR TITLE
CR-1144398 plm reset subsystem only works for v70, but hungs on vck50…

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
@@ -2854,7 +2854,6 @@ static ssize_t xgq_ospi_write(struct file *filp, const char __user *udata,
 
 		rval = xgq_download_apu_firmware(xgq->xgq_pdev);
 		if (rval) {
-			ret = rval;
 			XGQ_WARN(xgq, "unable to download APU: %d", rval);
 		}
 	}


### PR DESCRIPTION
…00 (#7142)

Signed-off-by: David Zhang <davidzha@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
a clean backport

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
tested with v70

#### Documentation impact (if any)
