### PR TITLE
CR-1121893 - Fix debian packages creation for Edge(zynqmp) platforms

### DIFF
--- a/build/build_edge_deb.sh
+++ b/build/build_edge_deb.sh
@@ -14,7 +14,7 @@ usage()
     echo "  options:"
     echo "          -help                           Print this usage"
     echo "          -aarch                          Architecture <aarch32/aarch64>"
-    echo "          -sysroot_name                   Name of sysroot folder created for compilation"
+    echo "          -dist                           Distribution for the package build <focal/jammy>"
     echo "          -clean, clean                   Remove build directories, pass 'aarch' option to it"
     echo ""
 }
@@ -30,13 +30,16 @@ SAVED_OPTIONS=$(set +o)
 set +x
 # Get the canonical file name of the current script
 THIS_SCRIPT=`readlink -f ${BASH_SOURCE[0]}`
- 
+
 PROGRAM=`basename $0`
 
 # XRT Version variables
 XRT_MAJOR_VERSION=2
-XRT_MINOR_VERSION=13
-RELEASE_VERSION=202210
+XRT_MINOR_VERSION=15
+RELEASE_VERSION=202310
+
+# Default distribution
+DIST=jammy
 
 # Pick XRT_VERSION_PATCH from Env variable
 if [ -z $XRT_VERSION_PATCH ]; then
@@ -57,13 +60,13 @@ while [ $# -gt 0 ]; do
                 -help | --help )
                         usage_and_exit 0
                         ;;
+                -dist | --dist )
+                        shift
+                        DIST=$1
+                        ;;
                 -aarch | --aarch )
                         shift
                         AARCH=$1
-                        ;;
-                -sysroot_name | --sysroot_name )
-                        shift
-                        SYSROOT=$1
                         ;;
                 -clean | clean | --clean )
                         clean=1
@@ -81,6 +84,18 @@ done
 THIS_SCRIPT_DIR=$(dirname "$THIS_SCRIPT")
 XRT_DIR=`readlink -f $THIS_SCRIPT_DIR/../`
 DEBIAN=`readlink -f $THIS_SCRIPT_DIR/debian`
+
+if [ -z $DIST ]; then
+    error "-dist is required option"
+fi
+
+if [[ $DIST == "jammy" ]]; then
+    OS_VERSION="22.04"
+elif [[ $DIST == "focal" ]]; then
+    OS_VERSION="20.04"
+else
+    error "$DIST is not a valid dist option"
+fi
 
 if [ -z $AARCH ]; then
     error "-aarch is required option"
@@ -101,11 +116,6 @@ if [[ $clean == 1 ]]; then
     exit 0
 fi
 
-# Sanity Check
-if [ -z $SYSROOT ] ; then
-    error "Please provide the required option 'sysroot_name'"
-fi
-
 if [ ! -d $DEBIAN ]; then
     error "$DEBIAN is not accessible"
 fi
@@ -113,7 +123,7 @@ fi
 DEBIAN_ARTIFACTS=$THIS_SCRIPT_DIR/$BUILD_FOLDER/debian_artifacts
 mkdir -p $DEBIAN_ARTIFACTS
 cd $DEBIAN_ARTIFACTS
-# TODO: 
+# TODO:
 # Debian expects XRT source tarball to be in parent directory of folder having debian folder, that way we should place
 # tar ball outside XRT directory which makes clean process difficult, find a flag to point to XRT source tar ball.
 # Current implementation copies source code to build folder
@@ -128,13 +138,13 @@ cp -rf $DEBIAN $DEBIAN_ARTIFACTS
 sed -i "1d" $DEBIAN_ARTIFACTS/debian/changelog
 sed -i "1s/^/xrt (${XRT_MAJOR_VERSION}.${XRT_MINOR_VERSION}.${XRT_VERSION_PATCH}) experimental;urgency=medium\n/" $DEBIAN_ARTIFACTS/debian/changelog
 
-time sbuild --no-run-lintian -d focal --arch=arm64 -c $SYSROOT -s -n
+time sbuild --no-run-lintian -d $DIST --arch=arm64 -s -n
 
 cd $THIS_SCRIPT_DIR/$BUILD_FOLDER
 # rename the packages created for consistency
-mv xrt-embedded_${XRT_MAJOR_VERSION}.${XRT_MINOR_VERSION}.${XRT_VERSION_PATCH}_arm64.deb xrt_embedded_${RELEASE_VERSION}.${XRT_MAJOR_VERSION}.${XRT_MINOR_VERSION}.${XRT_VERSION_PATCH}_20.04-arm64.deb
-mv xrt-zocl-dkms_${XRT_MAJOR_VERSION}.${XRT_MINOR_VERSION}.${XRT_VERSION_PATCH}_arm64.deb xrt_zocl_dkms_${RELEASE_VERSION}.${XRT_MAJOR_VERSION}.${XRT_MINOR_VERSION}.${XRT_VERSION_PATCH}_20.04-arm64.deb
-mv xrt-embedded-dbgsym_${XRT_MAJOR_VERSION}.${XRT_MINOR_VERSION}.${XRT_VERSION_PATCH}_arm64.ddeb xrt_embedded_dbgsym_${RELEASE_VERSION}.${XRT_MAJOR_VERSION}.${XRT_MINOR_VERSION}.${XRT_VERSION_PATCH}_20.04-arm64.ddeb
+mv xrt-embedded_${XRT_MAJOR_VERSION}.${XRT_MINOR_VERSION}.${XRT_VERSION_PATCH}_arm64.deb xrt_embedded_${RELEASE_VERSION}.${XRT_MAJOR_VERSION}.${XRT_MINOR_VERSION}.${XRT_VERSION_PATCH}_${OS_VERSION}-arm64.deb
+mv xrt-zocl-dkms_${XRT_MAJOR_VERSION}.${XRT_MINOR_VERSION}.${XRT_VERSION_PATCH}_arm64.deb xrt_zocl_dkms_${RELEASE_VERSION}.${XRT_MAJOR_VERSION}.${XRT_MINOR_VERSION}.${XRT_VERSION_PATCH}_${OS_VERSION}-arm64.deb
+mv xrt-embedded-dbgsym_${XRT_MAJOR_VERSION}.${XRT_MINOR_VERSION}.${XRT_VERSION_PATCH}_arm64.ddeb xrt_embedded_dbgsym_${RELEASE_VERSION}.${XRT_MAJOR_VERSION}.${XRT_MINOR_VERSION}.${XRT_VERSION_PATCH}_${OS_VERSION}-arm64.ddeb
 
 eval "$SAVED_OPTIONS"; # Restore shell options
 echo "** COMPLETE [${BASH_SOURCE[0]}] **"

--- a/build/debian/control
+++ b/build/debian/control
@@ -28,6 +28,7 @@ Build-Depends: cmake,
                opencl-clhpp-headers,
                pkg-config,
                protobuf-compiler,
+               rapidjson-dev,
                uuid-dev,
 Standards-Version: 4.5.0
 

--- a/build/debian/rules
+++ b/build/debian/rules
@@ -22,5 +22,5 @@ override_dh_install:
 # Create configuration file for OpenCL
 	mkdir -p debian/tmp/etc/OpenCL/vendors/
 	echo "libxilinxopencl.so" > debian/tmp/etc/OpenCL/vendors/xilinx.icd
-	chmod -R 755 /etc/OpenCL
+	chmod -R 755 debian/tmp/etc/OpenCL
 	dh_install

--- a/build/debian/rules
+++ b/build/debian/rules
@@ -16,4 +16,11 @@ override_dh_auto_test:
 	dh_auto_test || true
 
 override_dh_shlibdeps:
-	dh_shlibdeps -l/opt/xilinx/xrt/lib
+	dh_shlibdeps -l/usr/lib -l/usr/lib/xrt/module
+
+override_dh_install:
+# Create configuration file for OpenCL
+	mkdir -p debian/tmp/etc/OpenCL/vendors/
+	echo "libxilinxopencl.so" > debian/tmp/etc/OpenCL/vendors/xilinx.icd
+	chmod -R 755 /etc/OpenCL
+	dh_install

--- a/build/debian/xrt-embedded.install
+++ b/build/debian/xrt-embedded.install
@@ -1,3 +1,4 @@
+etc/OpenCL/
 usr/bin/
 usr/include/
 usr/lib/

--- a/build/debian/xrt-embedded.install
+++ b/build/debian/xrt-embedded.install
@@ -2,3 +2,4 @@ etc/OpenCL/
 usr/bin/
 usr/include/
 usr/lib/
+usr/share

--- a/src/CMake/dkms-edge.cmake
+++ b/src/CMake/dkms-edge.cmake
@@ -41,70 +41,94 @@ SET (XRT_DKMS_DRIVER_SRCS
   zocl/include/zocl_aie.h
   zocl/include/zocl_bo.h
   zocl/include/zocl_cu.h
+  zocl/include/zocl_cu_xgq.h
   zocl/include/zocl_dma.h
   zocl/include/zocl_drv.h
   zocl/include/zocl_error.h
   zocl/include/zocl_ert.h
+  zocl/include/zocl_ert_intc.h
   zocl/include/zocl_generic_cu.h
   zocl/include/zocl_ioctl.h
+  zocl/include/zocl_lib.h
   zocl/include/zocl_mailbox.h
   zocl/include/zocl_ospi_versal.h
   zocl/include/zocl_sk.h
   zocl/include/zocl_util.h
   zocl/include/zocl_watchdog.h
   zocl/include/zocl_xclbin.h
+  zocl/include/zocl_xgq.h
+  zocl/include/zocl_xgq_plat.h
   zocl/10-zocl.rules
   zocl/cu.c
+  zocl/cu_scu.c
   zocl/LICENSE
   zocl/Makefile
   zocl/zocl_aie.c
   zocl/zocl_bo.c
+  zocl/zocl_csr_intc.c
+  zocl/zocl_ctrl_ert.c
   zocl/zocl_cu.c
+  zocl/zocl_cu_xgq.c
   zocl/zocl_dma.c
   zocl/zocl_drv.c
   zocl/zocl_error.c
   zocl/zocl_ert.c
   zocl/zocl_ioctl.c
   zocl/zocl_kds.c
+  zocl/zocl_lib.c
   zocl/zocl_mailbox.c
   zocl/zocl_ospi_versal.c
   zocl/zocl_ov_sysfs.c
   zocl/zocl_sk.c
+  zocl/zocl_rpu_channel.c
+  zocl/zocl_sk.c
   zocl/zocl_sysfs.c
   zocl/zocl_watchdog.c
   zocl/zocl_xclbin.c
+  zocl/zocl_xgq.c
+  zocl/zocl_xgq_intc.c
   )
 
 # includes relative to core
 SET (XRT_DKMS_CORE_INCLUDES
   include/ert.h
+  include/ps_kernel.h
+  include/types.h
   include/xclfeatures.h
   include/xclbin.h
   include/xclerr.h
-  include/xrt_mem.h
-  include/types.h
+  include/xclerr_int.h
   include/xclhal2_mem.h
   include/xrt_error_code.h
+  include/xrt_mem.h
+  include/xgq_cmd_common.h
+  include/xgq_cmd_ert.h
+  include/xgq_cmd_vmr.h
+  include/xgq_impl.h
+  include/xgq_resp_parser.h
   )
 
 SET (XRT_DKMS_COMMON_XRT_DRV
-  common/drv/kds_core.c
-  common/drv/xrt_cu.c
   common/drv/cu_hls.c
-  common/drv/cu_plram.c
   common/drv/fast_adapter.c
-  common/drv/xrt_xclbin.c
+  common/drv/kds_core.c
   common/drv/Makefile
+  common/drv/xgq_execbuf.c
+  common/drv/xrt_cu.c
+  common/drv/xrt_xclbin.c
   )
 
 SET (XRT_DKMS_COMMON_XRT_DRV_INCLUDES
+  common/drv/include/cu_xgq.h
   common/drv/include/kds_client.h
   common/drv/include/kds_command.h
   common/drv/include/kds_core.h
   common/drv/include/kds_ert_table.h
   common/drv/include/kds_stat.h
+  common/drv/include/xgq_execbuf.h
   common/drv/include/xrt_cu.h
   common/drv/include/xrt_drv.h
+  common/drv/include/xrt_ert.h
   common/drv/include/xrt_xclbin.h
   )
 

--- a/src/runtime_src/core/edge/drm/zocl/Makefile
+++ b/src/runtime_src/core/edge/drm/zocl/Makefile
@@ -6,18 +6,19 @@ KERNEL_SRC ?= /lib/modules/$(shell uname -r)/build
 ifneq ($(src),)
 # building modules
 ifneq ($(wildcard $(src)/../common),)
-# dkms dir
-common_dir = ../common
+# dkms flow
+common_dir := ../common
 else
 # build from source code
-common_dir = ../../../common/drv
+common_dir := ../../../common/drv
 endif
 
 else
 # clean
-common_dir = ../../../common/drv
-ifeq ($(wildcard ../../../common/drv),)
-common_dir = ../common
+make_dir := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+common_dir := $(make_dir)/../../../common/drv
+ifeq ($(wildcard $(make_dir)/../../../common/drv),)
+common_dir := $(make_dir)/../common
 endif
 
 endif


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Fixed build failure in creation of debian packages for edge platforms using sbuild mechanism.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Discovered in pipeline regression

#### How problem was solved, alternative solutions (if any) and why they were rejected
As XRT has standard packages as dependencies, instead of creating sysroot from custom tar and providing it as an input to build script we have added changes to use standard mechanism. 
Setting up environment and creation of sysroot, creation of packages are explained in below confluence page:
https://confluence.xilinx.com/display/DCG/Creation+of+Debian+packages+for+Edge+Platforms+using+sbuild

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
Tested creation of debian packages on 20.04 and 22.04 Ubuntu machines using both jammy and focal sysroots.

Example of created packages format:
1. xrt_embedded_202310.2.15.0_20.04-arm64.deb  - user space package
2. xrt_zocl_dkms_202310.2.15.0_20.04-arm64.deb  - zocl driver package which is built on target using dkms flow (like DC platform packages)

#### Documentation impact (if any)
We need to discuss on updating xrt docs with the build steps.