### PR TITLE
CR-1144910: Addressing seg fault in Native XRT API trace/profile

### DIFF
--- a/src/runtime_src/xdp/profile/database/dynamic_info/host_db.cpp
+++ b/src/runtime_src/xdp/profile/database/dynamic_info/host_db.cpp
@@ -122,7 +122,7 @@ namespace xdp {
     for (auto iter = unsortedEvents.begin();
          iter != unsortedEvents.end();
          /* Intentionally blank*/) {
-      auto event = (*iter);
+      auto event = *iter;
       if (filter(event)) {
         collected.emplace_back(event);
         iter = unsortedEvents.erase(iter);

--- a/src/runtime_src/xdp/profile/database/dynamic_info/host_db.cpp
+++ b/src/runtime_src/xdp/profile/database/dynamic_info/host_db.cpp
@@ -121,10 +121,14 @@ namespace xdp {
 
     for (auto iter = unsortedEvents.begin();
          iter != unsortedEvents.end();
-         ++iter) {
+         /* Intentionally blank*/) {
       auto event = (*iter);
-      if (filter(event))
+      if (filter(event)) {
         collected.emplace_back(event);
+        iter = unsortedEvents.erase(iter);
+      }
+      else
+        ++iter;
     }
     return collected;
   }


### PR DESCRIPTION
#### Problem solved by the commit
Turning on Native XRT API tracing resulted in a segmentation fault at the end of execution.  This was due to two different objects believing they had ownership of stored unsorted events and both objects deleting the memory incorrectly.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Pull request 7089 (refactoring of some profiling data structures) introduced the bug as the function that was meant to move ownership of the unsorted events only copied and did not move the events.  It was discovered in thorough regression tests that tested all aspects of profiling.

#### How problem was solved, alternative solutions (if any) and why they were rejected
The function that was meant to move ownership was altered to actually transfer ownership and not just make a copy.

#### Risks (if any) associated the changes in the commit
Low risk as this particular function is currently only used by the Native XRT API tracing functionality.

#### What has been tested and how, request additional testing if necessary
The Native XRT API tracing has been verified with this change.

#### Documentation impact (if any)
No documentation impact.