### PR TITLE
Xrt mm changes

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/include/xocl_ioctl.h
+++ b/src/runtime_src/core/pcie/driver/linux/include/xocl_ioctl.h
@@ -576,6 +576,7 @@ struct drm_xocl_pread_unmgd {
 
 
 struct drm_xocl_mm_stat {
+	bool 	is_used;
 	size_t memory_usage;
 	unsigned int bo_count;
 };

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
@@ -455,7 +455,7 @@ static struct drm_xocl_bo *xocl_create_bo(struct drm_device *dev,
 	xocl_xdev_dbg(xdev, "alloc bo from bank%u, flag %x, host bank %d",
 		memidx, xobj->flags, drm_p->cma_bank_idx);
 
-	err = xocl_mm_insert_node(drm_p, memidx, slotidx, xobj->mm_node,
+	err = xocl_mm_insert_node(drm_p, memidx, slotidx, xobj,
 		xobj->base.size);
 	if (err)
 		goto failed;
@@ -464,8 +464,6 @@ static struct drm_xocl_bo *xocl_create_bo(struct drm_device *dev,
 		xobj->mm_node, xobj->mm_node->start,
 		xobj->mm_node->size);
 	xocl_bo_update_usage_stat(drm_p, xobj->flags, xobj->base.size, 1);
-	/* Record the DDR we allocated the buffer on */
-	xobj->mem_idx = memidx;
 
 done:
 	mutex_unlock(&drm_p->mm_lock);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
@@ -662,7 +662,7 @@ void xocl_mm_get_usage_stat(struct xocl_drm *drm_p, u32 ddr,
 	struct drm_xocl_mm_stat *mm_stat = &drm_p->mm_usage_stat[ddr];
 
 	if (!pstat) {
-        	xocl_err(drm_p->ddev->dev, "Invalid memory stats");
+        	xocl_err(drm_p->ddev->dev, "Invalid memory %d stats", ddr);
 		return;
 	}
 
@@ -676,7 +676,7 @@ void xocl_mm_update_usage_stat(struct xocl_drm *drm_p, u32 ddr,
 	struct drm_xocl_mm_stat *mm_stat = &drm_p->mm_usage_stat[ddr];
 
 	if (!mm_stat->is_used) {
-        	xocl_err(drm_p->ddev->dev, "Invalid memory stats");
+        	xocl_err(drm_p->ddev->dev, "Invalid memory %d stats", ddr);
 		return;
 	}
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
@@ -763,9 +763,10 @@ static int xocl_mm_insert_node_range(struct xocl_drm *drm_p, u32 mem_id,
 }
 
 int xocl_mm_insert_node(struct xocl_drm *drm_p, unsigned memidx,
-			uint32_t slotidx, struct drm_mm_node *node, u64 size)
+			uint32_t slotidx, struct drm_xocl_bo *xobj, u64 size)
 {
 	int ret = 0;
+	struct drm_mm_node *node = xobj->mm_node;
 	struct xocl_mem_stat *curr_mem = NULL;
 	struct mem_topology *grp_topology = NULL;
 	
@@ -804,6 +805,8 @@ int xocl_mm_insert_node(struct xocl_drm *drm_p, unsigned memidx,
 			}
 		}
 	}
+	/* Record the DDR we allocated the buffer on */
+	xobj->mem_idx = memidx;
 
         return ret;
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
@@ -525,7 +525,7 @@ xocl_read_axlf_helper(struct xocl_drm *drm_p, struct drm_xocl_axlf *axlf_ptr)
 
 	err = xocl_icap_download_axlf(xdev, axlf, force_download);
 	if (err)
-        goto done;
+	        goto done;
 
 	/*
 	 * Don't just bail out here, always recreate drm mem

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
@@ -524,6 +524,9 @@ xocl_read_axlf_helper(struct xocl_drm *drm_p, struct drm_xocl_axlf *axlf_ptr)
 	memcpy(&XDEV(xdev)->kds_cfg, &axlf_ptr->kds_cfg, sizeof(axlf_ptr->kds_cfg));
 
 	err = xocl_icap_download_axlf(xdev, axlf, force_download);
+	if (err)
+        goto done;
+
 	/*
 	 * Don't just bail out here, always recreate drm mem
 	 * since we have cleaned it up before download.

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_sysfs.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_sysfs.c
@@ -144,6 +144,7 @@ static ssize_t xocl_mm_stat(struct xocl_dev *xdev, char *buf, bool raw)
 	}
 
 	for (i = 0; i < topo->m_count; i++) {
+		memset(&stat, 0, sizeof(struct drm_xocl_mm_stat));
 		xocl_mm_get_usage_stat(XOCL_DRM(xdev), i, &stat);
 
 		if (raw) {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drm.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drm.h
@@ -23,6 +23,8 @@
 #include <linux/hashtable.h>
 #endif
 
+#define MAX_MEM_BANK_COUNT 	128
+
 typedef void (*xocl_execbuf_callback)(unsigned long data, int error);
 
 /**
@@ -61,10 +63,9 @@ struct xocl_mm {
 	uint64_t		end_addr;
 	uint32_t                m_count;
 
-	/* Array of bo and memory usage stats 
+	/* Array of bo  stats 
 	 * for whole device memory manager */
 	struct drm_xocl_mm_stat *bo_usage_stat;
-	struct drm_xocl_mm_stat **mm_usage_stat;
 };
 
 struct xocl_mem_stat {
@@ -84,6 +85,7 @@ struct xocl_drm {
 	/* Memory manager */
 	struct xocl_mm		*xocl_mm;
 	bool			xocl_mm_done;
+	struct drm_xocl_mm_stat mm_usage_stat[MAX_MEM_BANK_COUNT];
 
 	/* Xocl driver memory list head */
 	struct list_head        mem_list_head;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drm.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drm.h
@@ -130,7 +130,7 @@ void xocl_mm_update_usage_stat(struct xocl_drm *drm_p, u32 ddr,
         u64 size, int count);
 
 int xocl_mm_insert_node(struct xocl_drm *drm_p, unsigned memidx,
-                uint32_t slotidx, struct drm_mm_node *node, u64 size);
+                uint32_t slotidx, struct drm_xocl_bo *xobj, u64 size);
 
 void *xocl_drm_init(xdev_handle_t xdev);
 void xocl_drm_fini(struct xocl_drm *drm_p);


### PR DESCRIPTION
Fixed memory manager issue for multislot. 
For multi slot changes some of the issue introduced.
This PR consists of following  fixes:
1) Memory topology is not consistent between multiple xclbin 
re-initialize the memory manager if xclbin memory topology changes. 
2) Static memory to maintain stats of memory topology
3) Avoid initialization of dummy memory banks entry (size=0)
4) PS kernel validate issue fix