### PR TITLE
New exec_buf implementation with hw_ctxt

### DIFF
--- a/src/runtime_src/core/common/api/hw_queue.cpp
+++ b/src/runtime_src/core/common/api/hw_queue.cpp
@@ -269,12 +269,11 @@ public:
   void
   exec_buf(xrt_core::command* cmd, const xrt::hw_context& hwctx)
   {    
-    try 
-    {
+    try {
       device->exec_buf_ctx(cmd->get_exec_bo(), hwctx);
       return;
     }
-    catch (const xrt_core::error& ex) {
+    catch (const xrt_core::error&) {
         //do nothing
     }
     device->exec_buf(cmd->get_exec_bo());

--- a/src/runtime_src/core/common/api/hw_queue.cpp
+++ b/src/runtime_src/core/common/api/hw_queue.cpp
@@ -268,7 +268,7 @@ public:
   // of argument command having been scheduled for execution.
   void
   exec_buf(xrt_core::command* cmd, const xrt::hw_context& hwctx)
-  {    
+  {
     device->exec_buf_ctx(cmd->get_exec_bo(), hwctx);
   }
 

--- a/src/runtime_src/core/common/api/hw_queue.cpp
+++ b/src/runtime_src/core/common/api/hw_queue.cpp
@@ -269,7 +269,7 @@ public:
   void
   exec_buf(xrt_core::command* cmd, const xrt::hw_context& hwctx)
   {
-    device->exec_buf_ctx(cmd->get_exec_bo(), hwctx);
+    device->exec_buf(cmd->get_exec_bo(), hwctx);
   }
 
   // launch() - Submit a command for managed execution

--- a/src/runtime_src/core/common/api/hw_queue.cpp
+++ b/src/runtime_src/core/common/api/hw_queue.cpp
@@ -269,14 +269,7 @@ public:
   void
   exec_buf(xrt_core::command* cmd, const xrt::hw_context& hwctx)
   {    
-    try {
-      device->exec_buf_ctx(cmd->get_exec_bo(), hwctx);
-      return;
-    }
-    catch (const xrt_core::error&) {
-        //do nothing
-    }
-    device->exec_buf(cmd->get_exec_bo());
+    device->exec_buf_ctx(cmd->get_exec_bo(), hwctx);
   }
 
   // launch() - Submit a command for managed execution

--- a/src/runtime_src/core/common/ishim.h
+++ b/src/runtime_src/core/common/ishim.h
@@ -177,7 +177,7 @@ struct ishim
 
   //Exec Buf with ctx handle.
   virtual void
-  exec_buf_ctx(xclBufferHandle boh, const xrt::hw_context& /*hwctx*/)
+  exec_buf(xclBufferHandle boh, const xrt::hw_context& /*hwctx*/)
   {      
     // Context aware execution is an opt-in.  If not supported, then just call legacy exec_buf
     exec_buf(boh);

--- a/src/runtime_src/core/common/ishim.h
+++ b/src/runtime_src/core/common/ishim.h
@@ -177,8 +177,11 @@ struct ishim
 
   //Exec Buf with ctx handle.
   virtual void
-  exec_buf_ctx(xclBufferHandle /*boh*/, const xrt::hw_context& /*hwctx*/) const
-  { throw not_supported_error{ __func__ }; }
+  exec_buf_ctx(xclBufferHandle boh, const xrt::hw_context& /*hwctx*/)
+  {      
+    // Context aware execution is an opt-in.  If not supported, then just call legacy exec_buf
+    exec_buf(boh);
+  }
   ////////////////////////////////////////////////////////////////
 
   ////////////////////////////////////////////////////////////////

--- a/src/runtime_src/core/common/ishim.h
+++ b/src/runtime_src/core/common/ishim.h
@@ -174,6 +174,11 @@ struct ishim
   virtual void
   register_xclbin(const xrt::xclbin&) const
   { throw not_supported_error{__func__}; }
+
+  //Exec Buf with ctx handle.
+  virtual void
+  exec_buf_ctx(xclBufferHandle /*boh*/, const xrt::hw_context& /*hwctx*/) const
+  { throw not_supported_error{ __func__ }; }
   ////////////////////////////////////////////////////////////////
 
   ////////////////////////////////////////////////////////////////

--- a/src/runtime_src/core/include/shim_int.h
+++ b/src/runtime_src/core/include/shim_int.h
@@ -76,6 +76,9 @@ destroy_hw_queue(xclDeviceHandle handle, xcl_hwqueue_handle qhdl);
 void
 register_xclbin(xclDeviceHandle handle, const xrt::xclbin& xclbin);
 
+//exec_buf_ctx() - Exec Buf with ctx handle.
+void
+exec_buf_ctx(xclDeviceHandle handle, xclBufferHandle bohdl, const xrt::hw_context& hwctx);
 }} // shim_int, xrt
 
 #endif

--- a/src/runtime_src/core/include/shim_int.h
+++ b/src/runtime_src/core/include/shim_int.h
@@ -76,9 +76,9 @@ destroy_hw_queue(xclDeviceHandle handle, xcl_hwqueue_handle qhdl);
 void
 register_xclbin(xclDeviceHandle handle, const xrt::xclbin& xclbin);
 
-//exec_buf_ctx() - Exec Buf with ctx handle.
+//exec_buf - Exec Buf with hw ctx handle.
 void
-exec_buf_ctx(xclDeviceHandle handle, xclBufferHandle bohdl, const xrt::hw_context& hwctx);
+exec_buf(xclDeviceHandle handle, xclBufferHandle bohdl, const xrt::hw_context& hwctx);
 }} // shim_int, xrt
 
 #endif

--- a/src/runtime_src/core/pcie/linux/device_linux.h
+++ b/src/runtime_src/core/pcie/linux/device_linux.h
@@ -93,9 +93,9 @@ public:
 
   //Exec Buf with ctx handle.
   void
-  exec_buf_ctx(xclBufferHandle boh, const xrt::hw_context& hwctx) override
+  exec_buf(xclBufferHandle boh, const xrt::hw_context& hwctx) override
   {
-      xrt::shim_int::exec_buf_ctx(get_device_handle(), boh, hwctx);
+      xrt::shim_int::exec_buf(get_device_handle(), boh, hwctx);
   }
   ////////////////////////////////////////////////////////////////
 

--- a/src/runtime_src/core/pcie/linux/device_linux.h
+++ b/src/runtime_src/core/pcie/linux/device_linux.h
@@ -90,6 +90,13 @@ public:
   {
     xrt::shim_int::register_xclbin(get_device_handle(), xclbin);
   }
+
+  //Exec Buf with ctx handle.
+  void
+  exec_buf_ctx(xclBufferHandle boh, const xrt::hw_context& hwctx) const override
+  {
+      xrt::shim_int::exec_buf_ctx(get_device_handle(), boh, hwctx);
+  }
   ////////////////////////////////////////////////////////////////
 
 private:

--- a/src/runtime_src/core/pcie/linux/device_linux.h
+++ b/src/runtime_src/core/pcie/linux/device_linux.h
@@ -93,7 +93,7 @@ public:
 
   //Exec Buf with ctx handle.
   void
-  exec_buf_ctx(xclBufferHandle boh, const xrt::hw_context& hwctx) const override
+  exec_buf_ctx(xclBufferHandle boh, const xrt::hw_context& hwctx) override
   {
       xrt::shim_int::exec_buf_ctx(get_device_handle(), boh, hwctx);
   }

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -2214,6 +2214,15 @@ register_xclbin(const xrt::xclbin&)
   throw xrt_core::ishim::not_supported_error{__func__};
 }
 
+//Exec Buf with ctx handle.
+void
+shim::
+exec_buf_ctx(xclBufferHandle boh, const xrt::hw_context& hwctx)
+{
+  //TODO: Implement new fuction
+  throw xrt_core::ishim::not_supported_error{ __func__ };
+}
+
 } // namespace xocl
 
 ////////////////////////////////////////////////////////////////
@@ -2265,6 +2274,13 @@ register_xclbin(xclDeviceHandle handle, const xrt::xclbin& xclbin)
   shim->register_xclbin(xclbin);
 }
 
+//Exec Buf with ctx handle.
+void
+exec_buf_ctx(xclDeviceHandle handle, xclBufferHandle bohdl, const xrt::hw_context& hwctx)
+{
+    auto shim = get_shim_object(handle);
+    return shim->exec_buf_ctx(bohdl, hwctx);
+}
 
 } // xrt::shim_int
 ////////////////////////////////////////////////////////////////

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -2217,10 +2217,10 @@ register_xclbin(const xrt::xclbin&)
 //Exec Buf with ctx handle.
 void
 shim::
-exec_buf_ctx(xclBufferHandle boh, const xrt::hw_context& hwctx)
+exec_buf(xclBufferHandle boh, const xrt::hw_context& hwctx)
 {
-  //TODO: Implement new fuction
-  throw xrt_core::ishim::not_supported_error{ __func__ };
+  // TODO: Implement new function, for now just call legacy xclExecBuf().
+    xclExecBuf(boh);
 }
 
 } // namespace xocl
@@ -2276,10 +2276,10 @@ register_xclbin(xclDeviceHandle handle, const xrt::xclbin& xclbin)
 
 //Exec Buf with ctx handle.
 void
-exec_buf_ctx(xclDeviceHandle handle, xclBufferHandle bohdl, const xrt::hw_context& hwctx)
+exec_buf(xclDeviceHandle handle, xclBufferHandle bohdl, const xrt::hw_context& hwctx)
 {
     auto shim = get_shim_object(handle);
-    return shim->exec_buf_ctx(bohdl, hwctx);
+    return shim->exec_buf(bohdl, hwctx);
 }
 
 } // xrt::shim_int

--- a/src/runtime_src/core/pcie/linux/shim.h
+++ b/src/runtime_src/core/pcie/linux/shim.h
@@ -161,7 +161,7 @@ public:
 
   //Exec Buf with ctx handle.
   void
-  exec_buf_ctx(xclBufferHandle boh, const xrt::hw_context& hwctx);
+  exec_buf(xclBufferHandle boh, const xrt::hw_context& hwctx);
 private:
   std::shared_ptr<xrt_core::device> mCoreDevice;
   std::shared_ptr<pcidev::pci_device> mDev;

--- a/src/runtime_src/core/pcie/linux/shim.h
+++ b/src/runtime_src/core/pcie/linux/shim.h
@@ -159,6 +159,9 @@ public:
   void
   register_xclbin(const xrt::xclbin&);
 
+  //Exec Buf with ctx handle.
+  void
+  exec_buf_ctx(xclBufferHandle boh, const xrt::hw_context& hwctx);
 private:
   std::shared_ptr<xrt_core::device> mCoreDevice;
   std::shared_ptr<pcidev::pci_device> mDev;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
In hw context implementation, one slot can be mapped to multiple hw contexts. This means multiple hw contexts can share the same CU index. Current implementation is not passing hw context information to exec_buf(), So, KDS in the driver doesn't know hw context information for each CU. So, CU can not determine which command corresponds to which hw context. This is causing a problem while closing hw context.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Implemented new exec_buf function with hw context information. so that shim can send hw context information to KDS.

NOTE: For now just calling legacy xclExecBuf() in new exec_buf() with hw_ctx in linux/shim.cpp to support legacy functionality of exec_buf(). @saifuddin-xilinx is parallelly doing the required change in another PR.
#### How problem was solved, alternative solutions (if any) and why they were rejected
Added new functions for exec_buf with hw context in hw_queue.cpp, ishim.h, linux/shim.cpp
#### Risks (if any) associated the changes in the commit
low and this change is backward compatible for other platforms.
#### What has been tested and how, request additional testing if necessary
Tested locally hw and hw emu cases with this change.
#### Documentation impact (if any)
n/a