### PR TITLE
CID 282923:  Memory - illegal accesses  (USE_AFTER_FREE)

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
@@ -2741,7 +2741,10 @@ static ssize_t vmr_system_dtb_read(struct file *filp, struct kobject *kobj,
 	 * which indicates that there is a new request.
 	 */
 	if (off == 0)
-		xgq_refresh_system_dtb(xgq);
+		ret = xgq_refresh_system_dtb(xgq);
+
+	if (ret)
+		return ret;
 
 	mutex_lock(&xgq->xgq_lock);
 
@@ -2785,7 +2788,10 @@ static ssize_t vmr_plm_log_read(struct file *filp, struct kobject *kobj,
 
 	/* refresh cached data if off is 0 */
 	if (off == 0)
-		xgq_refresh_plm_log(xgq);
+		ret = xgq_refresh_plm_log(xgq);
+
+	if (ret)
+		return ret;
 
 	mutex_lock(&xgq->xgq_lock);
 


### PR DESCRIPTION
Signed-off-by: David Zhang <davidzha@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
we should avoid passing NULL 

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
