### PR TITLE
exec_buf() with hw_context in master

### DIFF
--- a/src/runtime_src/core/common/api/command.h
+++ b/src/runtime_src/core/common/api/command.h
@@ -64,6 +64,12 @@ public:
   virtual void
   notify(ert_cmd_state) const = 0;
 
+  /**
+  * get_hw_context() - get hw context of command buffer
+  */
+  virtual xrt::hw_context
+  get_hw_context() const = 0;
+
 private:
   unsigned long m_uid;
 };

--- a/src/runtime_src/core/common/api/command.h
+++ b/src/runtime_src/core/common/api/command.h
@@ -65,10 +65,14 @@ public:
   notify(ert_cmd_state) const = 0;
 
   /**
-  * get_hw_context() - get hw context of command buffer
+  * get_hwctx_handle() - get submission hw context of command buffer
+  * 
+  * The submission hw context is the hardware context used for command execution.
+  * This context is used in multi-xclbin / slot support when submitting a command with 
+  * execbuf when the core implementation does not support hardware queue.
   */
-  virtual xrt::hw_context
-  get_hw_context() const = 0;
+  virtual xcl_hwctx_handle
+  get_hwctx_handle() const = 0;
 
 private:
   unsigned long m_uid;

--- a/src/runtime_src/core/common/api/hw_queue.cpp
+++ b/src/runtime_src/core/common/api/hw_queue.cpp
@@ -560,7 +560,8 @@ public:
   void
   submit(xrt_core::command* cmd) override
   {
-    m_device->exec_buf(cmd->get_exec_bo(), cmd->get_hw_context());
+    auto ctxhndl = (cmd->get_hw_context()) ? static_cast<xcl_hwctx_handle>(cmd->get_hw_context()) : XRT_NULL_HWCTX;
+    m_device->exec_buf(cmd->get_exec_bo(), ctxhndl);
   }
 };
 

--- a/src/runtime_src/core/common/api/hw_queue.cpp
+++ b/src/runtime_src/core/common/api/hw_queue.cpp
@@ -560,8 +560,7 @@ public:
   void
   submit(xrt_core::command* cmd) override
   {
-    auto ctxhndl = (cmd->get_hw_context()) ? static_cast<xcl_hwctx_handle>(cmd->get_hw_context()) : XRT_NULL_HWCTX;
-    m_device->exec_buf(cmd->get_exec_bo(), ctxhndl);
+    m_device->exec_buf(cmd->get_exec_bo(), cmd->get_hwctx_handle());
   }
 };
 

--- a/src/runtime_src/core/common/api/hw_queue.cpp
+++ b/src/runtime_src/core/common/api/hw_queue.cpp
@@ -560,7 +560,7 @@ public:
   void
   submit(xrt_core::command* cmd) override
   {
-    m_device->exec_buf(cmd->get_exec_bo());
+    m_device->exec_buf(cmd->get_exec_bo(), cmd->get_hw_context());
   }
 };
 

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -688,16 +688,28 @@ private:
 
 public:
   explicit
-  kernel_command(std::shared_ptr<device_type> dev, xrt_core::hw_queue hwqueue, xrt::hw_context hwctx)
+  kernel_command(std::shared_ptr<device_type> dev, xrt_core::hw_queue hwqueue)
     : m_device(std::move(dev))
     , m_hwqueue(std::move(hwqueue))
-    , m_hwctx(std::move(hwctx))
     , m_execbuf(m_device->create_exec_buf<ert_start_kernel_cmd>())
     , m_done(true)
   {
     static unsigned int count = 0;
     m_uid = count++;
     XRT_DEBUGF("kernel_command::kernel_command(%d)\n", m_uid);
+  }
+
+  explicit
+  kernel_command(std::shared_ptr<device_type> dev, xrt_core::hw_queue hwqueue, xrt::hw_context hwctx)
+      : m_device(std::move(dev))
+      , m_hwqueue(std::move(hwqueue))
+      , m_hwctx(std::move(hwctx))
+      , m_execbuf(m_device->create_exec_buf<ert_start_kernel_cmd>())
+      , m_done(true)
+  {
+      static unsigned int count = 0;
+      m_uid = count++;
+      XRT_DEBUGF("kernel_command::kernel_command(%d)\n", m_uid);
   }
 
   ~kernel_command() override
@@ -2901,9 +2913,8 @@ copy_bo_with_kdma(const std::shared_ptr<xrt_core::device>& core_device,
 
   // Construct a kernel command to copy bo.  Kernel commands
   // must be shared ptrs
-  xrt::hw_context hwctx;
   auto dev = get_device(core_device);
-  auto cmd = std::make_shared<kernel_command>(dev, xrt_core::hw_queue{core_device.get()}, hwctx);
+  auto cmd = std::make_shared<kernel_command>(dev, xrt_core::hw_queue{core_device.get()});
 
   // Get and fill the underlying packet
   auto pkt = cmd->get_ert_cmd<ert_start_copybo_cmd*>();

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -688,19 +688,7 @@ private:
 
 public:
   explicit
-  kernel_command(std::shared_ptr<device_type> dev, xrt_core::hw_queue hwqueue)
-    : m_device(std::move(dev))
-    , m_hwqueue(std::move(hwqueue))
-    , m_execbuf(m_device->create_exec_buf<ert_start_kernel_cmd>())
-    , m_done(true)
-  {
-    static unsigned int count = 0;
-    m_uid = count++;
-    XRT_DEBUGF("kernel_command::kernel_command(%d)\n", m_uid);
-  }
-
-  explicit
-  kernel_command(std::shared_ptr<device_type> dev, xrt_core::hw_queue hwqueue, xrt::hw_context hwctx)
+  kernel_command(std::shared_ptr<device_type> dev, xrt_core::hw_queue hwqueue, xrt::hw_context hwctx = xrt::hw_context())
       : m_device(std::move(dev))
       , m_hwqueue(std::move(hwqueue))
       , m_hwctx(std::move(hwctx))
@@ -914,10 +902,12 @@ public:
     return m_execbuf.first;
   }
 
-  xrt::hw_context
-  get_hw_context() const override
+  xcl_hwctx_handle
+  get_hwctx_handle() const override
   {
-      return m_hwctx;
+    return (m_hwctx)
+       ? static_cast<xcl_hwctx_handle>(m_hwctx)
+       : XRT_NULL_HWCTX;
   }
 
   void

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -689,15 +689,15 @@ private:
 public:
   explicit
   kernel_command(std::shared_ptr<device_type> dev, xrt_core::hw_queue hwqueue, xrt::hw_context hwctx = xrt::hw_context())
-      : m_device(std::move(dev))
-      , m_hwqueue(std::move(hwqueue))
-      , m_hwctx(std::move(hwctx))
-      , m_execbuf(m_device->create_exec_buf<ert_start_kernel_cmd>())
-      , m_done(true)
+    : m_device(std::move(dev))
+    , m_hwqueue(std::move(hwqueue))
+    , m_hwctx(std::move(hwctx))
+    , m_execbuf(m_device->create_exec_buf<ert_start_kernel_cmd>())
+    , m_done(true)
   {
-      static unsigned int count = 0;
-      m_uid = count++;
-      XRT_DEBUGF("kernel_command::kernel_command(%d)\n", m_uid);
+    static unsigned int count = 0;
+    m_uid = count++;
+    XRT_DEBUGF("kernel_command::kernel_command(%d)\n", m_uid);
   }
 
   ~kernel_command() override

--- a/src/runtime_src/core/common/ishim.h
+++ b/src/runtime_src/core/common/ishim.h
@@ -226,7 +226,6 @@ struct ishim
   register_xclbin(const xrt::xclbin&) const
   { throw not_supported_error{__func__}; }
 
-
   // Allocate a bo within ctx.  This is opt-in, currently reverts to
   // legacy alloc_bo
   virtual xrt_buffer_handle
@@ -245,7 +244,7 @@ struct ishim
 
   //Exec Buf with ctx handle.
   virtual void
-  exec_buf(xrt_buffer_handle boh, const xrt::hw_context& /*hwctx*/)
+  exec_buf(xrt_buffer_handle boh, xcl_hwctx_handle /*ctxhdl*/)
   {      
     // Context aware execution is an opt-in.  If not supported, then just call legacy exec_buf
     exec_buf(boh);

--- a/src/runtime_src/core/common/ishim.h
+++ b/src/runtime_src/core/common/ishim.h
@@ -242,11 +242,11 @@ struct ishim
     return alloc_bo(userptr, size, flags);
   }
 
-  //Exec Buf with ctx handle.
+  // Execute a command bo within a ctx.  This is opt-in,  if not supported, then
+  // just call legacy exec_buf without the hardware context.
   virtual void
   exec_buf(xrt_buffer_handle boh, xcl_hwctx_handle /*ctxhdl*/)
-  {      
-    // Context aware execution is an opt-in.  If not supported, then just call legacy exec_buf
+  {
     exec_buf(boh);
   }
   ////////////////////////////////////////////////////////////////

--- a/src/runtime_src/core/common/ishim.h
+++ b/src/runtime_src/core/common/ishim.h
@@ -226,6 +226,7 @@ struct ishim
   register_xclbin(const xrt::xclbin&) const
   { throw not_supported_error{__func__}; }
 
+
   // Allocate a bo within ctx.  This is opt-in, currently reverts to
   // legacy alloc_bo
   virtual xrt_buffer_handle
@@ -240,6 +241,14 @@ struct ishim
   alloc_bo(xcl_hwctx_handle, void* userptr, size_t size, unsigned int flags)
   {
     return alloc_bo(userptr, size, flags);
+  }
+
+  //Exec Buf with ctx handle.
+  virtual void
+  exec_buf(xrt_buffer_handle boh, const xrt::hw_context& /*hwctx*/)
+  {      
+    // Context aware execution is an opt-in.  If not supported, then just call legacy exec_buf
+    exec_buf(boh);
   }
   ////////////////////////////////////////////////////////////////
 

--- a/src/runtime_src/core/include/shim_int.h
+++ b/src/runtime_src/core/include/shim_int.h
@@ -84,7 +84,7 @@ submit_command(xclDeviceHandle handle, xcl_hwqueue_handle qhdl, xclBufferHandle 
 int
 wait_command(xclDeviceHandle handle, xcl_hwqueue_handle qhdl, xclBufferHandle cmdbo, int timeout_ms);
 
-//exec_buf_ctx() - Exec Buf with hw ctx handle.
+// exec_buf() - Exec Buf with hw ctx handle.
 void
 exec_buf(xclDeviceHandle handle, xrt_buffer_handle bohdl, xcl_hwctx_handle ctxhdl);
 }} // shim_int, xrt

--- a/src/runtime_src/core/include/shim_int.h
+++ b/src/runtime_src/core/include/shim_int.h
@@ -86,7 +86,7 @@ wait_command(xclDeviceHandle handle, xcl_hwqueue_handle qhdl, xclBufferHandle cm
 
 //exec_buf_ctx() - Exec Buf with hw ctx handle.
 void
-exec_buf(xclDeviceHandle handle, xrt_buffer_handle bohdl, const xrt::hw_context& hwctx);
+exec_buf(xclDeviceHandle handle, xrt_buffer_handle bohdl, xcl_hwctx_handle ctxhdl);
 }} // shim_int, xrt
 
 #endif

--- a/src/runtime_src/core/include/shim_int.h
+++ b/src/runtime_src/core/include/shim_int.h
@@ -84,6 +84,9 @@ submit_command(xclDeviceHandle handle, xcl_hwqueue_handle qhdl, xclBufferHandle 
 int
 wait_command(xclDeviceHandle handle, xcl_hwqueue_handle qhdl, xclBufferHandle cmdbo, int timeout_ms);
 
+//exec_buf_ctx() - Exec Buf with hw ctx handle.
+void
+exec_buf(xclDeviceHandle handle, xrt_buffer_handle bohdl, const xrt::hw_context& hwctx);
 }} // shim_int, xrt
 
 #endif

--- a/src/runtime_src/core/pcie/linux/device_linux.h
+++ b/src/runtime_src/core/pcie/linux/device_linux.h
@@ -81,9 +81,9 @@ public:
 
   //Exec Buf with ctx handle.
   void
-  exec_buf(xrt_buffer_handle boh, const xrt::hw_context& hwctx) override
+  exec_buf(xrt_buffer_handle boh, xcl_hwctx_handle ctxhdl) override
   {
-      xrt::shim_int::exec_buf(get_device_handle(), boh, hwctx);
+      xrt::shim_int::exec_buf(get_device_handle(), boh, ctxhdl);
   }
   ////////////////////////////////////////////////////////////////
 

--- a/src/runtime_src/core/pcie/linux/device_linux.h
+++ b/src/runtime_src/core/pcie/linux/device_linux.h
@@ -79,7 +79,7 @@ public:
     xrt::shim_int::register_xclbin(get_device_handle(), xclbin);
   }
 
-  //Exec Buf with ctx handle.
+  // Exec Buf with hw ctx handle.
   void
   exec_buf(xrt_buffer_handle boh, xcl_hwctx_handle ctxhdl) override
   {

--- a/src/runtime_src/core/pcie/linux/device_linux.h
+++ b/src/runtime_src/core/pcie/linux/device_linux.h
@@ -78,6 +78,13 @@ public:
   {
     xrt::shim_int::register_xclbin(get_device_handle(), xclbin);
   }
+
+  //Exec Buf with ctx handle.
+  void
+  exec_buf(xrt_buffer_handle boh, const xrt::hw_context& hwctx) override
+  {
+      xrt::shim_int::exec_buf(get_device_handle(), boh, hwctx);
+  }
   ////////////////////////////////////////////////////////////////
 
 private:

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -2199,7 +2199,7 @@ register_xclbin(const xrt::xclbin&)
   throw xrt_core::ishim::not_supported_error{__func__};
 }
 
-//Exec Buf with ctx handle.
+// Exec Buf with hw ctx handle.
 void
 shim::
 exec_buf(xclBufferHandle boh, xcl_hwctx_handle ctxhdl)
@@ -2259,7 +2259,7 @@ register_xclbin(xclDeviceHandle handle, const xrt::xclbin& xclbin)
   shim->register_xclbin(xclbin);
 }
 
-//Exec Buf with ctx handle.
+// Exec Buf with hw ctx handle.
 void
 exec_buf(xclDeviceHandle handle, xrt_buffer_handle bohdl, xcl_hwctx_handle ctxhdl)
 {

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -2202,7 +2202,7 @@ register_xclbin(const xrt::xclbin&)
 //Exec Buf with ctx handle.
 void
 shim::
-exec_buf(xclBufferHandle boh, const xrt::hw_context& hwctx)
+exec_buf(xclBufferHandle boh, xcl_hwctx_handle ctxhdl)
 {
   // TODO: Implement new function, for now just call legacy xclExecBuf().
     xclExecBuf(boh);
@@ -2261,10 +2261,10 @@ register_xclbin(xclDeviceHandle handle, const xrt::xclbin& xclbin)
 
 //Exec Buf with ctx handle.
 void
-exec_buf(xclDeviceHandle handle, xrt_buffer_handle bohdl, const xrt::hw_context& hwctx)
+exec_buf(xclDeviceHandle handle, xrt_buffer_handle bohdl, xcl_hwctx_handle ctxhdl)
 {
     auto shim = get_shim_object(handle);
-    return shim->exec_buf(to_xclBufferHandle(bohdl), hwctx);
+    return shim->exec_buf(to_xclBufferHandle(bohdl), ctxhdl);
 }
 
 } // xrt::shim_int

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -2205,7 +2205,7 @@ shim::
 exec_buf(xclBufferHandle boh, xcl_hwctx_handle ctxhdl)
 {
   // TODO: Implement new function, for now just call legacy xclExecBuf().
-    xclExecBuf(boh);
+  xclExecBuf(boh);
 }
 
 } // namespace xocl

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -2205,7 +2205,8 @@ shim::
 exec_buf(xclBufferHandle boh, xcl_hwctx_handle ctxhdl)
 {
   // TODO: Implement new function, for now just call legacy xclExecBuf().
-  xclExecBuf(boh);
+  if (auto ret = xclExecBuf(boh))
+    throw xrt_core::system_error(ret, "failed to launch execution buffer");
 }
 
 } // namespace xocl

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -2199,6 +2199,15 @@ register_xclbin(const xrt::xclbin&)
   throw xrt_core::ishim::not_supported_error{__func__};
 }
 
+//Exec Buf with ctx handle.
+void
+shim::
+exec_buf(xclBufferHandle boh, const xrt::hw_context& hwctx)
+{
+  // TODO: Implement new function, for now just call legacy xclExecBuf().
+    xclExecBuf(boh);
+}
+
 } // namespace xocl
 
 ////////////////////////////////////////////////////////////////
@@ -2250,6 +2259,13 @@ register_xclbin(xclDeviceHandle handle, const xrt::xclbin& xclbin)
   shim->register_xclbin(xclbin);
 }
 
+//Exec Buf with ctx handle.
+void
+exec_buf(xclDeviceHandle handle, xrt_buffer_handle bohdl, const xrt::hw_context& hwctx)
+{
+    auto shim = get_shim_object(handle);
+    return shim->exec_buf(to_xclBufferHandle(bohdl), hwctx);
+}
 
 } // xrt::shim_int
 ////////////////////////////////////////////////////////////////

--- a/src/runtime_src/core/pcie/linux/shim.h
+++ b/src/runtime_src/core/pcie/linux/shim.h
@@ -159,6 +159,9 @@ public:
   void
   register_xclbin(const xrt::xclbin&);
 
+  //Exec Buf with ctx handle.
+  void
+  exec_buf(xclBufferHandle boh, const xrt::hw_context& hwctx);
 private:
   std::shared_ptr<xrt_core::device> mCoreDevice;
   std::shared_ptr<xrt_core::pci::dev> mDev;

--- a/src/runtime_src/core/pcie/linux/shim.h
+++ b/src/runtime_src/core/pcie/linux/shim.h
@@ -161,7 +161,7 @@ public:
 
   //Exec Buf with ctx handle.
   void
-  exec_buf(xclBufferHandle boh, const xrt::hw_context& hwctx);
+  exec_buf(xclBufferHandle boh, xcl_hwctx_handle ctxhdl);
 private:
   std::shared_ptr<xrt_core::device> mCoreDevice;
   std::shared_ptr<xrt_core::pci::dev> mDev;

--- a/src/runtime_src/core/pcie/linux/shim.h
+++ b/src/runtime_src/core/pcie/linux/shim.h
@@ -159,7 +159,7 @@ public:
   void
   register_xclbin(const xrt::xclbin&);
 
-  //Exec Buf with ctx handle.
+  // Exec Buf with hw ctx handle.
   void
   exec_buf(xclBufferHandle boh, xcl_hwctx_handle ctxhdl);
 private:

--- a/src/runtime_src/xrt/xrt++/xrtexec.cpp
+++ b/src/runtime_src/xrt/xrt++/xrtexec.cpp
@@ -114,6 +114,7 @@ struct command::impl : xrt_core::command
 
   xrt_xocl::device* m_device;
   xrt_core::hw_queue m_hwqueue;
+  xrt::hw_context m_hwctx;       // hw_context for command
   execbuf_type m_execbuf;      // underlying execution buffer
   mutable bool m_done = true;
 
@@ -187,6 +188,12 @@ struct command::impl : xrt_core::command
   get_exec_bo() const
   {
     return m_execbuf.first;
+  }
+
+  virtual xrt::hw_context
+  get_hw_context() const
+  {
+      return m_hwctx;
   }
 
   virtual void

--- a/src/runtime_src/xrt/xrt++/xrtexec.cpp
+++ b/src/runtime_src/xrt/xrt++/xrtexec.cpp
@@ -114,7 +114,6 @@ struct command::impl : xrt_core::command
 
   xrt_xocl::device* m_device;
   xrt_core::hw_queue m_hwqueue;
-  xrt::hw_context m_hwctx;       // hw_context for command
   execbuf_type m_execbuf;      // underlying execution buffer
   mutable bool m_done = true;
 
@@ -190,10 +189,10 @@ struct command::impl : xrt_core::command
     return m_execbuf.first;
   }
 
-  virtual xrt::hw_context
-  get_hw_context() const
+  virtual xcl_hwctx_handle
+  get_hwctx_handle() const
   {
-      return m_hwctx;
+      return XRT_NULL_HWCTX;
   }
 
   virtual void


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
In hw context implementation, one slot can be mapped to multiple hw contexts. This means multiple hw contexts can share the same CU index. Current implementation is not passing hw context information to exec_buf(), So, KDS in the driver doesn't know hw context information for each CU. So, CU can not determine which command corresponds to which hw context. This is causing a problem while closing hw context.
NOTE: Implemented this functionality in  2022.2 branch, PR: https://github.com/Xilinx/XRT/pull/7159
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Implemented new exec_buf function with hw context information. so that shim can send hw context information to KDS.

NOTE: For now just calling legacy xclExecBuf() in new exec_buf() with hw_ctx in linux/shim.cpp to support legacy functionality of exec_buf(). @saifuddin-xilinx is parallelly doing the required change in another PR.
#### How problem was solved, alternative solutions (if any) and why they were rejected
Added new functions for exec_buf with hw context in hw_queue.cpp, ishim.h, linux/shim.cpp
#### Risks (if any) associated the changes in the commit
low and this change is backward compatible for other platforms.
#### What has been tested and how, request additional testing if necessary
Tested locally hw and hw emu cases with this change.
#### Documentation impact (if any)
n/a