### PR TITLE
Use hwctx handle at shim level if supported

### DIFF
--- a/src/runtime_src/core/common/api/context_mgr.cpp
+++ b/src/runtime_src/core/common/api/context_mgr.cpp
@@ -99,7 +99,8 @@ public:
       if (m_cv.wait_for(ul, 100ms) == std::cv_status::timeout)
         throw std::runtime_error("aquiring cu context timed out");
     }
-    auto ipidx = m_device->open_cu_context(hwctx, ipname);
+
+    auto ipidx = m_device->open_cu_context_wrap(hwctx, ipname);
     ctx.add(ipname, ipidx);
     return ipidx;
   }
@@ -113,7 +114,8 @@ public:
     auto& ctx = m_ctx[static_cast<xcl_hwctx_handle>(hwctx)];
     if (!ctx.get(ipidx))
       throw std::runtime_error("ctx " + std::to_string(ipidx.index) + " not open");
-    m_device->close_cu_context(hwctx, ipidx);
+
+    m_device->close_cu_context_wrap(hwctx, ipidx);
     ctx.erase(ipidx);
     m_cv.notify_all();
   }

--- a/src/runtime_src/core/common/api/hw_queue.cpp
+++ b/src/runtime_src/core/common/api/hw_queue.cpp
@@ -616,7 +616,7 @@ get_hw_queue_impl(const xrt::hw_context& hwctx)
   auto& queues = dev2hwc[device];
   auto hwqimpl = queues[hwctx_hdl].lock();
   if (!hwqimpl) {
-    auto hwqueue_hdl = device->create_hw_queue(hwctx);
+    auto hwqueue_hdl = device->create_hw_queue(static_cast<xcl_hwctx_handle>(hwctx));
     queues[hwctx_hdl] = hwqimpl = (hwqueue_hdl == XRT_NULL_HWQUEUE)
       ? get_kds_device_nolock(queues, device)
       : queue_ptr{new xrt_core::qds_device(device, hwqueue_hdl)};

--- a/src/runtime_src/core/common/api/xrt_ip.cpp
+++ b/src/runtime_src/core/common/api/xrt_ip.cpp
@@ -183,12 +183,12 @@ class ip_impl
       m_size = m_ip.get_size();
 
       // context, driver allows shared context per xrt.ini
-      m_idx = m_device->open_cu_context(m_hwctx, m_ip.get_name());
+      m_idx = m_device->open_cu_context_wrap(m_hwctx, m_ip.get_name());
     }
 
     ~ip_context()
     {
-      m_device->close_cu_context(m_hwctx, m_idx);
+      m_device->close_cu_context_wrap(m_hwctx, m_idx);
     }
 
     ip_context(const ip_context&) = delete;

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -736,7 +736,7 @@ xclLoadAxlf(const axlf *buffer)
       .za_kernels = NULL,
       .za_slot_id = 0, // TODO Cleanup: Once uuid interface id available we need to remove this
       .za_dtbo_path = const_cast<char *>(dtbo_path.c_str()),
-      .za_dtbo_path_len = dtbo_path.length(),
+      .za_dtbo_path_len = static_cast<unsigned int>(dtbo_path.length()),
       .hw_gen = hw_gen,
     };
 


### PR DESCRIPTION
#### Problem solved by the commit
This PR corrects a problem associated with hwctx and hwctx handles, where legacy shim APIs were (are) passed xrt::hw_context objects rather than the underlying handle.   

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
This PR works around an inconsistency in how XRT coreutil and XRT core (shim) exchange handles.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Some objects managed by XRT coretutil are wrappers of shim opaque handles that provides a hook into a kernel driver or memory managed by shim.  These opaque handles are created through shim APIs when the corresponding XRT coreutil object is created.

The interface between XRT coreutil and XRT core is through the shim opaque handle if one such is involved.  This means that if shim returns a handle, then shim gets this handle in all API that operate on the the data associated with the handle.  

The fix is only partial in that shim implementations that do not support creation of hw_context still are passed an internally created xrt::hw_context that wraps information (xclbin, qos, mode) needed by shim to do its work.  Once all shims support hw_context creation, some wrapper and try/catch code is this PR can be removed.

#### Risks (if any) associated the changes in the commit
Low risk.  Existing shim APIs are still called with the changes in this PR.

#### What has been tested and how, request additional testing if necessary
OpenCL regressions.

#### Documentation impact (if any)
None.
