### PR TITLE
CR-1143553 xgq: wait for SC readiness during driver init (#7120)

### DIFF
--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -793,11 +793,11 @@ get_flag_sw_emu_kernel_debug()
 }
 
 // This flag is added to exit device offline status check loop forcibly.
-// By default, device offline status loop runs for 120 seconds.
+// By default, device offline status loop runs for 320 seconds.
 inline unsigned int
 get_device_offline_timer()
 {
-  static unsigned int value = detail::get_uint_value("Runtime.dev_offline_timer", 120);
+  static unsigned int value = detail::get_uint_value("Runtime.dev_offline_timer", 320);
   return value;
 }
 

--- a/src/runtime_src/core/include/xgq_cmd_vmr.h
+++ b/src/runtime_src/core/include/xgq_cmd_vmr.h
@@ -368,7 +368,8 @@ struct xgq_cmd_cq_vmr_payload {
 	uint16_t has_ext_sysdtb:1;
 	uint16_t ps_is_ready:1;
 	uint16_t pl_is_ready:1;
-	uint16_t resvd1:5;
+	uint16_t sc_is_ready:1;
+	uint16_t resvd1:4;
 	uint16_t current_multi_boot_offset;
 	uint32_t debug_level:3;
 	uint32_t program_progress:7;
@@ -396,6 +397,10 @@ struct xgq_cmd_cq_vmr_identify_payload {
  * @clock_payload:
  * @sensor_payload:
  * @multiboot_payload:
+ * @log_payload:
+ * @xclbin_payload:
+ * @clk_scaling_payload:
+ * @vmr_identify_payload:
  */
 struct xgq_cmd_cq {
 	struct xgq_cmd_cq_hdr hdr;


### PR DESCRIPTION
* CR-1143553 xgq: wait for SC readiness during init

XRT shall not issue any sensor requests if SC is in unknown/error state So, load hwmon_sdm driver only when SC is in ready & active state

Signed-off-by: Rajkumar Rampelli <rampelli@amd.com>

* Fix reset wait time to 320 seconds now

In cases where SC doesn't come online during reset, XRT's XGQ driver will poll for the SC ready status for 200 seconds. So, increase the reset timeout to 320 seconds.

Signed-off-by: Rajkumar Rampelli <rampelli@amd.com>

* Fixing review comments

Signed-off-by: Rajkumar Rampelli <rampelli@amd.com>

* small fix

Signed-off-by: Rajkumar Rampelli <rampelli@amd.com>

* xgq: check SC ready state before issuing any sensor commands

Signed-off-by: Rajkumar Rampelli <rampelli@amd.com>

* small fix

Signed-off-by: Rajkumar Rampelli <rampelli@amd.com>

* Add more details about 200 sec delay in XGQ driver for SC status check

Signed-off-by: Rajkumar Rampelli <rampelli@amd.com>

* Fix review comments

Signed-off-by: Rajkumar Rampelli <rampelli@amd.com>

Signed-off-by: Rajkumar Rampelli <rampelli@amd.com>
Co-authored-by: Rajkumar Rampelli <rampelli@amd.com>
(cherry picked from commit ef9b7396e7a92903f406be94a2905b3dfa95658f)

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
