### PR TITLE
Fix fallout from #7087

### DIFF
--- a/src/runtime_src/core/common/system.cpp
+++ b/src/runtime_src/core/common/system.cpp
@@ -61,12 +61,25 @@ get_device_id(const std::string& str) const
 static void
 load_shim()
 {
+  // This is where the xrt_core library is loaded at run-time. Loading
+  // of the library will create an instance of the system singleton
+  // and set the singleton variable in this file. However, the
+  // singleton, while set, can not be assumed to be valid until after
+  // this function returns.  This is because the derived system class
+  // could have constructor body that is executed after the base
+  // class is constructed.
   static xrt_core::shim_loader shim;
 }
 
 inline system&
 instance()
 {
+  // Multiple threads could enter here at the same time.  The first
+  // thread will call the shim loader, where the singleton is set, but
+  // not necessarily ready.  See comment in load_shim().
+  static std::mutex mtx;
+  std::lock_guard lk(mtx);
+
   if (!singleton)
     load_shim();
 


### PR DESCRIPTION
#### Problem solved by the commit
Ensure the singleton instance of xrt_core::system is valid before use.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Changes in #7087 added constructor body to system_linux, but this constructor body is executed after the base class is executed.  The xrt_core syystem singleton is created during base class construction before the derived class has been fully constructed.  This can lead to multiple threads trying to access and use the singleton before it is valid.

#### How problem was solved, alternative solutions (if any) and why they were rejected
This PR simply protects access to the singleton until the first thread has fully completed the shim library loading.

#### Risks (if any) associated the changes in the commit
Slightly less efficient system instance access, but not on critical path.

#### What has been tested and how, request additional testing if necessary
OpenCL regressions.  Multi-threaded test case that create n-number of xrt::device objects.

Signed-off-by: Soren Soe <2106410+stsoe@users.noreply.github.com>
