### PR TITLE
Cleanup statically cached device entries from kds_device map

### DIFF
--- a/src/runtime_src/core/common/api/exec.cpp
+++ b/src/runtime_src/core/common/api/exec.cpp
@@ -142,4 +142,13 @@ init(xrt_core::device* device)
     sws::init(device);
 }
 
+void
+finish(const xrt_core::device* device)
+{
+  if (kds_enabled())
+    kds::finish(device);
+  else
+    sws::finish(device);
+}
+
 }} // exec, xrt_core

--- a/src/runtime_src/core/common/api/exec.h
+++ b/src/runtime_src/core/common/api/exec.h
@@ -49,6 +49,9 @@ stop();
 void
 init(xrt_core::device* device);
 
+void
+finish(const xrt_core::device* device);
+
 } // sws
 
 /**
@@ -79,6 +82,9 @@ stop();
 
 void
 init(xrt_core::device* device);
+
+void
+finish(const xrt_core::device* device);
 
 } // kds
 
@@ -133,6 +139,9 @@ stop();
 XRT_CORE_COMMON_EXPORT
 void
 init(xrt_core::device* device);
+
+void
+finish(const xrt_core::device* device);
 
 } // scheduler
 

--- a/src/runtime_src/core/common/device.cpp
+++ b/src/runtime_src/core/common/device.cpp
@@ -30,6 +30,7 @@
 #include "core/include/xrt/xrt_uuid.h"
 #include "core/include/experimental/xrt_xclbin.h"
 
+#include "core/common/api/exec.h"
 #include "core/common/api/xclbin_int.h"
 
 #include <boost/format.hpp>
@@ -57,6 +58,7 @@ device::
 {
   // virtual must be declared and defined
   XRT_DEBUGF("xrt_core::device::~device(0x%x) idx(%d)\n", this, m_device_id);
+  xrt_core::exec::finish(this);
 }
 
 bool


### PR DESCRIPTION
#### Problem solved by the commit
Ensure that cached device entries are removed when device is destructed.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Applications that repeatedly create and delete xrt::device objects can end up as bogus dead entries in a static map that manages harware queue entries.  While the stale entries are not referenced, they can end up accoummulating 8 bytes leaked memory that is not reclaimed until process exit where the map is destructed.

#### How problem was solved, alternative solutions (if any) and why they were rejected
This PR fixes this problem by having the xrt_core::~device destructor remove the device entry from the static map.

#### Risks (if any) associated the changes in the commit
Refactored code involves backport from master with some significant changes.  This has risk.

#### What has been tested and how, request additional testing if necessary
OpenCL regressions.  Single test regressions, stress testing.  Multi-threaded testing.

Signed-off-by: Soren Soe <2106410+stsoe@users.noreply.github.com>











