### PR TITLE
Fix wrong driver minor version for 2022.2 branch

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/Makefile
+++ b/src/runtime_src/core/edge/drm/zocl/Makefile
@@ -30,7 +30,8 @@ ifneq ($(cflags_zocl),)
 endif
 
 # XRT driver version used in apu reporting
-# Version is specific to release
+# Version info is repeated here as Petalinux doesn't have access to 
+# user space top level CMake file. Version is specific to release
 XRT_DRIVER_VERSION ?= 2.14.0
 
 # Add patch number in version if 'XRT_VERSION_PATCH' env variable is defined

--- a/src/runtime_src/core/edge/drm/zocl/Makefile
+++ b/src/runtime_src/core/edge/drm/zocl/Makefile
@@ -29,8 +29,9 @@ ifneq ($(cflags_zocl),)
 	ccflags-y += $(cflags_zocl)
 endif
 
+# XRT driver version used in apu reporting
 # Version is specific to release
-XRT_DRIVER_VERSION ?= 2.15.0
+XRT_DRIVER_VERSION ?= 2.14.0
 
 # Add patch number in version if 'XRT_VERSION_PATCH' env variable is defined
 ifneq ($(XRT_VERSION_PATCH),)


### PR DESCRIPTION
Signed-off-by: rbramand <rbramand@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
XRT driver version is 2.15.0 for 2022.2 branch, updated it to 2.14.0 which is proper one.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
