### PR TITLE
CR-1142750 xbmgmt program --boot does not update the device platform version

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-utils.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-utils.c
@@ -18,6 +18,9 @@
 #define XCLMGMT_RESET_MAX_RETRY		10
 
 static void xclmgmt_reset_pci(struct xclmgmt_dev *lro);
+static int xclmgmt_reload_fdt_blob(struct xclmgmt_dev *lro);
+static int xclmgmt_reload_fdt_blob_vmr(struct xclmgmt_dev *lro);
+
 /**
  * @returns: NULL if AER apability is not found walking up to the root port
  *         : pci_dev ptr to the port which is AER capable.
@@ -377,8 +380,17 @@ long xclmgmt_hot_reset(struct xclmgmt_dev *lro, bool force)
 	xocl_clear_pci_errors(lro);
 	store_pcie_link_info(lro);
 
-	/* Update the userspace fdt with the current values in the mgmt driver */
+	/*
+	 * Update the userspace fdt with the current values in the mgmt driver
+	 *
+	 * For vmr supported versal devices, we enabled A/B boot, thus we should
+	 * reload fdt from the right boot image instead of using unchanged fdt
+	 * for other ALEVO devices.
+	 */
+	mutex_lock(&lro->busy_mutex);
+	(void) xclmgmt_reload_fdt_blob_vmr(lro);
 	(void) xclmgmt_update_userpf_blob(lro);
+	mutex_unlock(&lro->busy_mutex);
 
 	if (xrt_reset_syncup)
 		xocl_set_master_on(lro);
@@ -608,13 +620,37 @@ static void xclmgmt_reset_pci(struct xclmgmt_dev *lro)
 	xclmgmt_config_pci(lro);
 }
 
+static void xclmgmt_debug_dump_uuid(struct xclmgmt_dev *lro)
+{
+	int node = -1;
+	const void *uuid;
+
+	if (!lro->core.fdt_blob)
+		return;
+
+	node = xocl_fdt_get_next_prop_by_name(lro, lro->core.fdt_blob,
+		-1, PROP_INTERFACE_UUID, &uuid, NULL);
+	if (!uuid || node < 0)
+		mgmt_dbg(lro, "no uuid");
+
+	mgmt_dbg(lro, "interface_uuid:%s", (char *)uuid);
+
+	node = xocl_fdt_get_next_prop_by_name(lro, lro->core.fdt_blob,
+		-1, PROP_LOGIC_UUID, &uuid, NULL);
+	if (!uuid || node < 0)
+		mgmt_dbg(lro, "no logic uuid");
+
+	mgmt_dbg(lro, "logic_uuid:%s", (char *)uuid);
+
+}
+
 int xclmgmt_update_userpf_blob(struct xclmgmt_dev *lro)
 {
 	int len = 0;
 	int userpf_idx = 0;
 	int ret = 0;
-	struct FeatureRomHeader rom_header = {};
-	struct VmrStatus vmr_header = {};
+	struct FeatureRomHeader rom_header = { 0 };
+	struct VmrStatus vmr_header = { 0 };
 	int offset = 0;
 	const int *version = NULL;
 
@@ -795,7 +831,9 @@ int xclmgmt_program_shell(struct xclmgmt_dev *lro)
 
 	xocl_thread_start(lro);
 
+	mutex_lock(&lro->busy_mutex);
 	xclmgmt_update_userpf_blob(lro);
+	mutex_unlock(&lro->busy_mutex);
 	xocl_drvinst_set_offline(lro, false);
 
 failed:
@@ -804,15 +842,104 @@ failed:
 
 }
 
+static int xclmgmt_refresh_fdt_blob(struct xclmgmt_dev *lro, const char *fw_buf)
+{
+	const struct axlf_section_header	*dtc_header = NULL;
+	struct axlf				*bin_axlf = NULL;
+	int					ret = 0;
+
+	bin_axlf = (struct axlf *)fw_buf;
+
+	dtc_header = xocl_axlf_section_header(lro, bin_axlf, PARTITION_METADATA);
+	if (!dtc_header) {
+		mgmt_err(lro, "Firmware does not contain PARTITION_METADATA");
+		return -ENOENT;
+	}
+
+	ret = xocl_fdt_blob_input(lro,
+			(char *)fw_buf + dtc_header->m_sectionOffset,
+			dtc_header->m_sectionSize, XOCL_SUBDEV_LEVEL_BLD,
+			bin_axlf->m_header.m_platformVBNV);
+	if (ret)
+		mgmt_err(lro, "Invalid PARTITION_METADATA");
+
+	xclmgmt_debug_dump_uuid(lro);
+
+	return ret;
+}
+
+/*
+ * load firmware, the fdt blob in the partition metadata, and
+ * refresh cached fdt_blob
+ */
+static int xclmgmt_reload_fdt_blob(struct xclmgmt_dev *lro)
+{
+	char	*fw_buf = NULL;
+	size_t	fw_size = 0;
+	int	ret = 0;
+
+	BUG_ON(!mutex_is_locked(&lro->busy_mutex));
+
+	ret = xocl_rom_load_firmware(lro, &fw_buf, &fw_size);
+	if (ret) {
+		mgmt_err(lro, "ROM firmware load failure %d", ret);
+		return ret;
+	}
+
+	ret = xclmgmt_refresh_fdt_blob(lro, fw_buf);
+
+	vfree(fw_buf);
+	return ret;
+}
+
+/*
+ * load firmware from vmr devices
+ *   - then clean up existing fdt_blob if this is a hot reset request
+ *   - after fdt_blob is refreshed, the blp_blob should be updated.
+ */
+static int xclmgmt_reload_fdt_blob_vmr(struct xclmgmt_dev *lro)
+{
+	char	*fw_buf = NULL;
+	size_t	fw_size = 0;
+	int	ret = 0;
+
+	BUG_ON(!mutex_is_locked(&lro->busy_mutex));
+
+	ret = xocl_vmr_load_firmware(lro, &fw_buf, &fw_size);
+	if (ret)
+		return ret;
+
+	/* clean up existing fdt_blob */
+	if (lro->core.fdt_blob) {
+		vfree(lro->core.fdt_blob);
+		lro->core.fdt_blob = NULL;
+	}
+
+	ret = xclmgmt_refresh_fdt_blob(lro, fw_buf);
+
+	/* replace blp_blob */
+	if (lro->core.blp_blob) {
+		vfree(lro->core.blp_blob);
+		lro->core.blp_blob = vmalloc(fdt_totalsize(lro->core.fdt_blob));
+		if (!lro->core.blp_blob) {
+			ret = -ENOMEM;
+			mgmt_err(lro, "Failed to allocate blp data region");
+			goto out;
+		}
+
+		memcpy(lro->core.blp_blob, lro->core.fdt_blob,
+			fdt_totalsize(lro->core.fdt_blob));
+	}
+out:
+	vfree(fw_buf);
+	return ret;
+}
+
+
 int xclmgmt_load_fdt(struct xclmgmt_dev *lro)
 {
 	struct xocl_board_private *dev_info = &lro->core.priv;
-	const struct axlf_section_header	*dtc_header;
-	struct axlf				*bin_axlf;
-	int					ret;
-	char					*fw_buf = NULL;
-	size_t					fw_size = 0;
-
+	int ret = 0;
 
 	if (xocl_subdev_is_vsec_recovery(lro)) {
 		mgmt_info(lro, "Skip load_fdt for vsec Golden image");
@@ -821,28 +948,10 @@ int xclmgmt_load_fdt(struct xclmgmt_dev *lro)
 	}
 
 	mutex_lock(&lro->busy_mutex);
-	ret = xocl_rom_load_firmware(lro, &fw_buf, &fw_size);
-	if (ret) {
-		mgmt_err(lro, "ROM firmware load failure %d", ret);
-		goto failed;
-	}
-	bin_axlf = (struct axlf *)fw_buf;
 
-	dtc_header = xocl_axlf_section_header(lro, bin_axlf, PARTITION_METADATA);
-	if (!dtc_header) {
-		ret = -ENOENT;
-		mgmt_err(lro, "Firmware does not contain PARTITION_METADATA");
+	ret = xclmgmt_reload_fdt_blob(lro);
+	if (ret)
 		goto failed;
-	}
-
-	ret = xocl_fdt_blob_input(lro,
-			(char *)fw_buf + dtc_header->m_sectionOffset,
-			dtc_header->m_sectionSize, XOCL_SUBDEV_LEVEL_BLD,
-			bin_axlf->m_header.m_platformVBNV);
-	if (ret) {
-		mgmt_err(lro, "Invalid PARTITION_METADATA");
-		goto failed;
-	}
 
 	if (lro->core.priv.flags & XOCL_DSAFLAG_MFG) {
 		/* Minimum set up for golden image. */
@@ -888,7 +997,6 @@ int xclmgmt_load_fdt(struct xclmgmt_dev *lro)
 	lro->ready = true;
 
 failed:
-	vfree(fw_buf);
 	mutex_unlock(&lro->busy_mutex);
 
 	return ret;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/feature_rom.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/feature_rom.c
@@ -541,15 +541,20 @@ static int load_firmware(struct platform_device *pdev, char **fw, size_t *len)
 	size_t size = 0;
 	int ret;
 
-	ret = load_firmware_from_disk(pdev, &buf, &size, "xsabin");
+	/*
+	 * If this is a vmr devices, load firmware from device first.
+	 * If this is not a vmr device, we continue to try next possible
+	 * location.
+	 */
+	ret = load_firmware_from_vmr(pdev, &buf, &size);
+	if (ret)
+		ret = load_firmware_from_disk(pdev, &buf, &size, "xsabin");
 	if (ret)
 		ret = load_firmware_from_disk(pdev, &buf, &size, "dsabin");
 	if (ret)
 		ret = load_firmware_from_flash(pdev, &buf, &size);
-	if (ret)
-		ret = load_firmware_from_vmr(pdev, &buf, &size);
 	if (ret) {
-		xocl_err(&pdev->dev, "can't load firmware, give up");
+		xocl_err(&pdev->dev, "can't load firmware, ret:%d, give up", ret);
 		return ret;
 	}
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
@@ -1727,7 +1727,6 @@ int xocl_fdt_blob_input(xdev_handle_t xdev_hdl, char *blob, u32 blob_sz,
 	if (!blob)
 		return -EINVAL;
 
-
 	len = fdt_totalsize(blob);
 	if (len > blob_sz) {
 		xocl_xdev_err(xdev_hdl, "Invalid blob inbut size");

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
@@ -1727,6 +1727,7 @@ int xocl_fdt_blob_input(xdev_handle_t xdev_hdl, char *blob, u32 blob_sz,
 	if (!blob)
 		return -EINVAL;
 
+
 	len = fdt_totalsize(blob);
 	if (len > blob_sz) {
 		xocl_xdev_err(xdev_hdl, "Invalid blob inbut size");


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1142750

#### How problem was solved, alternative solutions (if any) and why they were rejected
We introduced A/B boots for vmr supported versal devices. We should update the cached blob_fdt with corresponding correct image A or image B during hot reset.

For other ALEVO board, behavior is unchanged. 

#### Risks (if any) associated the changes in the commit
N/A, only fix vmr based devices, others are unchanged

#### What has been tested and how, request additional testing if necessary

```
Check boot image is default, uuid is also from default (aka. image A)

root@xsjdavidz01:~# xbmgmt examine -r platform -d c1:0

---------------------------------------------------
[0000:c1:00.0] : xilinx_vck5000_gen4x8_qdma_base_2
---------------------------------------------------
Flash properties
  Type                 : ospi_xgq
  Serial Number        : XFL1DEL3G0U3

Device properties
  Type                 : vck5000
  Name                 : VCK5000-PP

Flashable partitions running on FPGA
  Platform             : xilinx_vck5000_gen4x8_qdma_base_2
  SC Version           : 4.4.35
  Platform UUID        : D44E2200-9FE8-5F2A-2B10-3AB6A5063AAB
  Interface UUID       : AED3E95A-48CF-64BB-2475-22FAC4F92DDC

Flashable partitions installed in system
  Platform             : xilinx_vck5000_gen4x8_qdma_base_2
  SC Version           : 4.4.35
  Platform UUID        : D44E2200-9FE8-5F2A-2B10-3AB6A5063AAB

Bootable Partitions:
  Default              : ACTIVE
  Backup               : INACTIVE
```

```
can run verify xclbin
root@xsjdavidz01:~# xbutil validate -r verify -d c1:0
Validate Device           : [0000:c1:00.1]
    Platform              : xilinx_vck5000_gen4x8_qdma_base_2
    SC Version            : 4.4.35
    Platform ID           : D44E2200-9FE8-5F2A-2B10-3AB6A5063AAB
-------------------------------------------------------------------------------
Test 1 [0000:c1:00.1]     : verify 
    Test Status           : [PASSED]                                            
-------------------------------------------------------------------------------
Validation completed. Please run the command '--verbose' option for more details
```

```
boot to backup image (image B)

root@xsjdavidz01:~# xbmgmt program --boot backup -d c1:0
Rebooting device: [0000:c1:00.0] with 'backup' partition
Performing hot reset...
Stopping user function...
Rebooted successfully
```

**Note: without the fix, uuid will remain unchanged, and xclbin uuid check will be bypassed by XRT and sent to vmr this will potentially damage the hardware.**

```
check backup image uuid 

root@xsjdavidz01:~# xbmgmt examine -r platform -d c1:0

---------------------------------------------------
[0000:c1:00.0] : xilinx_vck5000_gen4x8_qdma_base_2
---------------------------------------------------
Flash properties
  Type                 : ospi_xgq
  Serial Number        : XFL1DEL3G0U3

Device properties
  Type                 : vck5000
  Name                 : VCK5000-PP

Flashable partitions running on FPGA
  Platform             : xilinx_vck5000_gen4x8_qdma_base_2
  SC Version           : 4.4.35
  Platform UUID        : C1D06F11-2954-51A7-E524-4A47D6FDE073
  Interface UUID       : 6FF16AB8-8693-25FA-47B2-F29BD40EE476

Flashable partitions installed in system
  Platform             : xilinx_vck5000_gen4x8_qdma_base_2
  SC Version           : 4.4.35
  Platform UUID        : D44E2200-9FE8-5F2A-2B10-3AB6A5063AAB

Bootable Partitions:
  Default              : INACTIVE
  Backup               : ACTIVE
```

```
cannot run verify 
root@xsjdavidz01:~# xbutil validate -r verify -d c1:0 --verbose
Verbose: Enabling Verbosity
Validate Device           : [0000:c1:00.1]
    Platform              : xilinx_vck5000_gen4x8_qdma_base_2
    SC Version            : 4.4.35
    Platform ID           : C1D06F11-2954-51A7-E524-4A47D6FDE073
-------------------------------------------------------------------------------
Test 1 [0000:c1:00.1]     : verify 
    Description           : Run 'Hello World' kernel test
    Details               : verify.xclbin not available. Skipping validation
                            Verify xclbin not available or shell partition is not
                            programmed. Skipping validation.
    Test Status           : [SKIPPED]
-------------------------------------------------------------------------------
```
**this is expected, because the installed xclbin has different uuid (for image A), but image B is up, thus skipping loading wrong xclbin against image B is expected behavior**

#### Documentation impact (if any)

