### PR TITLE
CR-1145195 & CR-1145192 xgq: retrieve clock scaling configs properly

### DIFF
--- a/src/runtime_src/core/include/xgq_cmd_vmr.h
+++ b/src/runtime_src/core/include/xgq_cmd_vmr.h
@@ -244,9 +244,12 @@ struct xgq_cmd_vmr_control_payload {
  * @aid: Clock scaling API ID which decides API in VMC.
  *          0x1 - READ_CLOCK_THROTTLING_CONFIGURATION
  *          0x2 - SET_CLOCK_THROTTLING_CONFIGURATION
- * @scaling_enable: enable or disable flag
- * @pwr_ovrd: power override value
- * @temp_ovrd: temperature override value
+ * @scaling_en: enable or disable flag
+ * @pwr_scaling_ovrd_limit: set power override value
+ * @temp_scaling_ovrd_limit: set temperature override value
+ * @reset: reset the clock scaling configs to defaults
+ * @pwr_scaling_ovrd_en: power override enable/disable flag
+ * @temp_scaling_ovrd_en: temperature override enable/disable flag
  *
  * This payload is used for clock scaling configuration report.
  */
@@ -340,7 +343,15 @@ struct xgq_cmd_cq_data_payload {
 /**
  * struct xgq_cmd_cq_clk_scaling_payload: clock scaling status payload
  *
- * clock scaling status
+ * @has_clk scaling: shows if the platform support clock scaling feature
+ * @clk_scaling_mode: which clock scaling mode enabled currently
+ * @clk_scaling_en: shows if clock scaling is enabled (1) or disabled (0)
+ * @pwr_scaling_ovrd_en: power scaling override is enabled or not
+ * @temp_scaling_ovrd_en: temperature scaling override is enabled or not
+ * @temp_shutdown_limit: temperature shutdown limit
+ * @temp_scaling_limit: temperature scaling override value set
+ * @pwr_shutdown_limit: power shutdown limit
+ * @pwr_scaling_limit: power scaling override value set
  */
 struct xgq_cmd_cq_clk_scaling_payload {
 	uint8_t has_clk_scaling:1;

--- a/src/runtime_src/core/include/xgq_cmd_vmr.h
+++ b/src/runtime_src/core/include/xgq_cmd_vmr.h
@@ -255,7 +255,10 @@ struct xgq_cmd_clk_scaling_payload {
 	uint32_t scaling_en:1;
 	uint32_t pwr_scaling_ovrd_limit:16;
 	uint32_t temp_scaling_ovrd_limit:8;
-	uint32_t rsvd1:4;
+	uint32_t reset:1;
+	uint32_t pwr_scaling_ovrd_en:1;
+	uint32_t temp_scaling_ovrd_en:1;
+	uint32_t rsvd1:1;
 };
 
 /**
@@ -343,7 +346,9 @@ struct xgq_cmd_cq_clk_scaling_payload {
 	uint8_t has_clk_scaling:1;
 	uint8_t clk_scaling_mode:2;
 	uint8_t clk_scaling_en:1;
-	uint8_t rsvd:4;
+	uint8_t pwr_scaling_ovrd_en:1;
+	uint8_t temp_scaling_ovrd_en:1;
+	uint8_t rsvd:2;
 	uint8_t temp_shutdown_limit;
 	uint8_t temp_scaling_limit;
 	uint16_t pwr_shutdown_limit;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
@@ -2081,18 +2081,18 @@ static int clk_scaling_get_default_configs(struct platform_device *pdev)
                                    0, 0, 0, true);
 	if (ret) {
 		XGQ_WARN(xgq, "Failed to reset clock scaling default settings, ret: %d", ret);
-		return ret;
+		goto out;
 	}
 
 	ret = clk_scaling_status_query(pdev);
 	if (ret) {
 		XGQ_WARN(xgq, "Failed to receive clock scaling default settings, ret: %d", ret);
-		return ret;
+		goto out;
 	}
 
 	xgq->pwr_scaling_threshold_limit = cs_payload->pwr_scaling_limit;
 	xgq->temp_scaling_threshold_limit = cs_payload->temp_scaling_limit;
-
+out:
 	mutex_unlock(&xgq->clk_scaling_lock);
 
 	return ret;
@@ -2801,7 +2801,6 @@ static ssize_t xgq_scaling_power_override_store(struct device *dev,
 		goto out;
 	}
 
-	mutex_lock(&xgq->clk_scaling_lock);
 	ret = clk_scaling_configure_op(xgq->xgq_pdev, XGQ_CMD_CLK_THROTTLING_AID_CONFIGURE,
 				   cs_payload->clk_scaling_en, pwr, 0, 0);
 	if (ret) {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
@@ -1969,8 +1969,6 @@ static void clk_scaling_cq_result_copy(struct xocl_xgq_vmr *xgq,
 
 	mutex_lock(&xgq->xgq_lock);
 	memcpy(&xgq->xgq_cq_payload, payload, sizeof(*payload));
-	xgq->pwr_scaling_ovrd_limit = cs_payload->pwr_scaling_limit;
-	xgq->temp_scaling_ovrd_limit = cs_payload->temp_scaling_limit;
 	mutex_unlock(&xgq->xgq_lock);
 }
 
@@ -2487,6 +2485,13 @@ static ssize_t clk_scaling_stat_raw_show(struct device *dev,
 	struct xgq_cmd_cq_clk_scaling_payload *cs_payload=
 		(struct xgq_cmd_cq_clk_scaling_payload *)&xgq->xgq_cq_payload;
 	ssize_t cnt = 0;
+	int ret = 0;
+
+	ret = clk_scaling_status_query(xgq->xgq_pdev);
+	if (ret) {
+		XGQ_WARN(xgq, "Failed to receive clock scaling configs, ret: %d", ret);
+		return ret;
+	}
 
 	//Read clock scaling configuration settings
 	cnt += sprintf(buf + cnt, "HAS_CLOCK_THROTTLING:%d\n", cs_payload->has_clk_scaling);
@@ -2512,6 +2517,13 @@ static ssize_t clk_scaling_configure_show(struct device *dev,
 	struct xgq_cmd_cq_clk_scaling_payload *cs_payload=
 		(struct xgq_cmd_cq_clk_scaling_payload *)&xgq->xgq_cq_payload;
 	ssize_t cnt = 0;
+	int ret = 0;
+
+	ret = clk_scaling_status_query(xgq->xgq_pdev);
+	if (ret) {
+		XGQ_WARN(xgq, "Failed to receive clock scaling configs, ret: %d", ret);
+		return ret;
+	}
 
 	cnt += sprintf(buf + cnt, "%d,%u,%u\n", cs_payload->clk_scaling_en,
 				   xgq->pwr_scaling_ovrd_limit, xgq->temp_scaling_ovrd_limit);
@@ -2546,6 +2558,12 @@ static ssize_t clk_scaling_configure_store(struct device *dev,
 	char* args = (char*) buf;
 	char* end = (char*) buf;
 	int ret = 0;
+
+	ret = clk_scaling_status_query(xgq->xgq_pdev);
+	if (ret) {
+		XGQ_WARN(xgq, "Failed to receive clock scaling configs, ret: %d", ret);
+		return ret;
+	}
 
 	if (!cs_payload->has_clk_scaling)
 	{
@@ -2583,6 +2601,7 @@ static ssize_t clk_scaling_configure_store(struct device *dev,
 		}
 		args = end;
 	}
+
 	mutex_lock(&xgq->clk_scaling_lock);
 	ret = clk_scaling_configure_op(xgq->xgq_pdev,
                                    XGQ_CMD_CLK_THROTTLING_AID_CONFIGURE,
@@ -2625,6 +2644,12 @@ static ssize_t xgq_scaling_temp_override_store(struct device *dev,
 		(struct xgq_cmd_cq_clk_scaling_payload *)&xgq->xgq_cq_payload;
 	u16 temp = 0;
 	int ret = 0;
+
+	ret = clk_scaling_status_query(xgq->xgq_pdev);
+	if (ret) {
+		XGQ_WARN(xgq, "Failed to receive clock scaling configs, ret: %d", ret);
+		return ret;
+	}
 
 	if (!cs_payload->has_clk_scaling)
 	{
@@ -2672,6 +2697,12 @@ static ssize_t xgq_scaling_power_override_store(struct device *dev,
 	u16 pwr = 0;
 	int ret = 0;
 
+	ret = clk_scaling_status_query(xgq->xgq_pdev);
+	if (ret) {
+		XGQ_WARN(xgq, "Failed to receive clock scaling configs, ret: %d", ret);
+		return ret;
+	}
+
 	if (!cs_payload->has_clk_scaling)
 	{
 		XGQ_ERR(xgq, "clock scaling feature is not supported");
@@ -2704,6 +2735,13 @@ static ssize_t xgq_scaling_enable_show(struct device *dev,
 	struct xgq_cmd_cq_clk_scaling_payload *cs_payload =
 		(struct xgq_cmd_cq_clk_scaling_payload *)&xgq->xgq_cq_payload;
 	ssize_t cnt = 0;
+	int ret = 0;
+
+	ret = clk_scaling_status_query(xgq->xgq_pdev);
+	if (ret) {
+		XGQ_WARN(xgq, "Failed to receive clock scaling configs, ret: %d", ret);
+		return ret;
+	}
 
 	cnt += sprintf(buf + cnt, "%d\n", cs_payload->clk_scaling_en);
 
@@ -2720,6 +2758,12 @@ static ssize_t xgq_scaling_enable_store(struct device *dev,
 	bool enable = false;
 	u32 val = 0;
 	int ret = 0;
+
+	ret = clk_scaling_status_query(xgq->xgq_pdev);
+	if (ret) {
+		XGQ_WARN(xgq, "Failed to receive clock scaling configs, ret: %d", ret);
+		return ret;
+	}
 
 	if (!cs_payload->has_clk_scaling)
 	{

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -545,8 +545,8 @@ struct clk_scaling_info
       data.temp_scaling_limit = get_value(stats[5]);
       data.pwr_scaling_ovrd_limit = get_value(stats[6]);
       data.temp_scaling_ovrd_limit = get_value(stats[7]);
-      data.pwr_scaling_ovrd_enable = get_value(stats[8]);
-      data.temp_scaling_ovrd_enable = get_value(stats[9]);
+      data.pwr_scaling_ovrd_enable = get_value(stats[8]) ? true : false;
+      data.temp_scaling_ovrd_enable = get_value(stats[9]) ? true : false;
     } catch (const std::exception& e) {
       xrt_core::send_exception_message(e.what(), "Failed to receive clk_scaling_stat_raw data in specified format");
     }

--- a/src/runtime_src/core/tools/common/ReportCmcStatus.cpp
+++ b/src/runtime_src/core/tools/common/ReportCmcStatus.cpp
@@ -69,12 +69,12 @@ ReportCmcStatus::getPropertyTree20202( const xrt_core::device * _pDevice,
       runtime_tree.add_child("override_threshold_limits", threshold_data);
 
       boost::property_tree::ptree temp_override_data;
-      temp_override_data.put("enabled", "true");
+      temp_override_data.put("enabled", pt.temp_scaling_ovrd_enable);
       temp_override_data.put("temp_celsius", pt.temp_scaling_ovrd_limit);
       runtime_tree.add_child("temp_threshold_override", temp_override_data);
 
       boost::property_tree::ptree pwr_override_data;
-      pwr_override_data.put("enabled", "true");
+      pwr_override_data.put("enabled", pt.pwr_scaling_ovrd_enable);
       pwr_override_data.put("power_watts", pt.pwr_scaling_ovrd_limit);
       runtime_tree.add_child("power_threshold_override", pwr_override_data);
 


### PR DESCRIPTION
Signed-off-by: Rajkumar Rampelli <rampelli@amd.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
xgq driver requesting for clock scaling configs only once during it's init sequence and copied to scaling payload. But, this payload getting override by other sensor payload request/response data since all payloads are combined with union. So, at a time, only one payload information is valid. Fix is to request clock scaling configs whenever required in xgq driver and read the configs from the scaling payload.
Change#2: When XRT drivers are reloaded, during init, XRT reads previously configured clock scaling values, but not the default values. To fix this problem, introduced a new clock scaling command option "reset" for resetting clock scaling configuration parameters to default settings. So, XRT sets reset option and issues scaling command for reading default settings.
Change#3: By default, power scaling override & temperature scaling override are disabled. if user tries to set override values, then only enable override flag. So, in xbmgmt cmc report, override enable flag shows disabled now by default.
VMR PR https://github.com/Xilinx/VMR/pull/265 
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1145195 & CR-1145192
#### How problem was solved, alternative solutions (if any) and why they were rejected
Added changes in XGQ driver to issue clock scaling configs read request to VMR wherever required.
#### Risks (if any) associated the changes in the commit
NA
#### What has been tested and how, request additional testing if necessary
xbmgmt's cmc report & config commands, and access xgq's scaling sysfs nodes
#### Documentation impact (if any)
NA