### PR TITLE
Error handling for exec_buf() with hw_ctx

### DIFF
--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -2220,7 +2220,8 @@ shim::
 exec_buf(xclBufferHandle boh, const xrt::hw_context& hwctx)
 {
   // TODO: Implement new function, for now just call legacy xclExecBuf().
-    xclExecBuf(boh);
+  if (auto ret = xclExecBuf(boh))
+    throw xrt_core::system_error(ret, "failed to launch execution buffer");
 }
 
 } // namespace xocl


### PR DESCRIPTION
Signed-off-by: vboggara <vboggara@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
 Added error handling functionality in shim::exec_buf() with hw_ctx.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
In PR https://github.com/Xilinx/XRT/pull/7159, introduced hw_ctx in exec_buf(). Because of this PR, one of the test case with clEnqueueCopyBuffer is hanging.
#### How problem was solved, alternative solutions (if any) and why they were rejected
 Added error handling functionality in shim::exec_buf() with hw_ctx.
#### Risks (if any) associated the changes in the commit
low
#### What has been tested and how, request additional testing if necessary
Tested failing case with this change, its passing with this fix.
#### Documentation impact (if any)
n/a