### PR TITLE
Add 6.1 kernel support for zocl (Edge platforms)

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
@@ -22,8 +22,12 @@
 #include <drm/drm_drv.h>
 #include <drm/drm_gem.h>
 #include <drm/drm_mm.h>
-#include <drm/drm_gem_cma_helper.h>
 #include <linux/version.h>
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+#include <drm/drm_gem_dma_helper.h>
+#else
+#include <drm/drm_gem_cma_helper.h>
+#endif
 #include <linux/poll.h>
 #include "zocl_util.h"
 #include "zocl_ioctl.h"
@@ -129,7 +133,11 @@ struct zocl_drv_private {
 
 struct drm_zocl_bo {
 	union {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+		struct drm_gem_dma_object       cma_base;
+#else
 		struct drm_gem_cma_object       cma_base;
+#endif
 		struct {
 			struct drm_gem_object         gem_base;
 			struct page                 **pages;

--- a/src/runtime_src/core/edge/drm/zocl/zocl_bo.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_bo.c
@@ -41,7 +41,11 @@ static inline void __user *to_user_ptr(u64 address)
 void zocl_describe(const struct drm_zocl_bo *obj)
 {
 	size_t size_in_kb = obj->cma_base.base.size / 1024;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+	size_t physical_addr = obj->cma_base.dma_addr;
+#else
 	size_t physical_addr = obj->cma_base.paddr;
+#endif
 
 	DRM_DEBUG("%px: H[0x%zxKB] D[0x%zx]\n",
 			obj,
@@ -54,7 +58,11 @@ zocl_bo_describe(const struct drm_zocl_bo *bo, uint64_t *size, uint64_t *paddr)
 {
 	if (bo->flags & (ZOCL_BO_FLAGS_CMA | ZOCL_BO_FLAGS_USERPTR)) {
 		*size = (uint64_t)bo->cma_base.base.size;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+		*paddr = (uint64_t)bo->cma_base.dma_addr;
+#else
 		*paddr = (uint64_t)bo->cma_base.paddr;
+#endif
 	} else {
 		*size = (uint64_t)bo->gem_base.size;
 		*paddr = (uint64_t)bo->mm_node->start;
@@ -104,7 +112,11 @@ static struct drm_zocl_bo *zocl_create_userprt_bo(struct drm_device *dev,
 		uint64_t unaligned_size)
 {
 	size_t size = PAGE_ALIGN(unaligned_size);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+	struct drm_gem_dma_object *cma_obj;
+#else
 	struct drm_gem_cma_object *cma_obj;
+#endif
 	int err = 0;
 
 	if (!size)
@@ -127,7 +139,11 @@ static struct drm_zocl_bo *zocl_create_userprt_bo(struct drm_device *dev,
 
 	cma_obj->sgt   = NULL;
 	cma_obj->vaddr = NULL;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+	cma_obj->dma_addr = 0x0;
+#else
 	cma_obj->paddr = 0x0;
+#endif
 
 	return to_zocl_bo(&cma_obj->base);
 out1:
@@ -152,11 +168,19 @@ void zocl_free_userptr_bo(struct drm_gem_object *gem_obj)
 static struct drm_zocl_bo *
 zocl_create_cma_mem(struct drm_device *dev, size_t size)
 {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+	struct drm_gem_dma_object *cma_obj;
+#else
 	struct drm_gem_cma_object *cma_obj;
+#endif
 	struct drm_zocl_bo *bo;
 
 	/* Allocate from CMA buffer */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+	cma_obj = drm_gem_dma_create(dev, size);
+#else
 	cma_obj = drm_gem_cma_create(dev, size);
+#endif
 	if (IS_ERR(cma_obj))
 		return ERR_PTR(-ENOMEM);
 
@@ -506,7 +530,11 @@ zocl_create_bo_ioctl(struct drm_device *dev, void *data, struct drm_file *filp)
 		ret = drm_gem_handle_create(filp, &bo->cma_base.base,
 		    &args->handle);
 		if (ret) {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+			drm_gem_dma_object_free(&bo->cma_base.base);
+#else
 			drm_gem_cma_free_object(&bo->cma_base.base);
+#endif
 			DRM_DEBUG("handle creation failed\n");
 			return ret;
 		}
@@ -597,7 +625,11 @@ zocl_userptr_bo_ioctl(struct drm_device *dev, void *data, struct drm_file *filp)
 		goto out0;
 	}
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+	bo->cma_base.dma_addr = sg_dma_address((bo->cma_base.sgt)->sgl);
+#else
 	bo->cma_base.paddr = sg_dma_address((bo->cma_base.sgt)->sgl);
+#endif
 
 	/* Physical address must be continuous */
 	if (sg_count != 1) {
@@ -674,7 +706,11 @@ int zocl_sync_bo_ioctl(struct drm_device *dev,
 {
 	const struct drm_zocl_sync_bo	*args = data;
 	struct drm_gem_object		*gem_obj;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+	struct drm_gem_dma_object	*cma_obj;
+#else
 	struct drm_gem_cma_object	*cma_obj;
+#endif
 	struct drm_zocl_bo		*bo;
 	dma_addr_t			bus_addr;
 	int				rc = 0;
@@ -698,8 +734,13 @@ int zocl_sync_bo_ioctl(struct drm_device *dev,
 		goto out;
 	}
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+	cma_obj = to_drm_gem_dma_obj(gem_obj);
+	bus_addr = cma_obj->dma_addr;
+#else
 	cma_obj = to_drm_gem_cma_obj(gem_obj);
 	bus_addr = cma_obj->paddr;
+#endif
 
 	/* only invalidate the range of addresses requested by the user */
 	bus_addr += args->offset;
@@ -911,7 +952,11 @@ static int zocl_bo_rdwr_ioctl(struct drm_device *dev, void *data,
 	bo = to_zocl_bo(gem_obj);
 	if (bo->flags & ZOCL_BO_FLAGS_CMA) {
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 12, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+		ret = drm_gem_dma_object_vmap(gem_obj, &map);
+#else
 		ret = drm_gem_cma_vmap(gem_obj, &map);
+#endif
 		if(ret || ZOCL_MAP_IS_NULL(&map))
 			kaddr = NULL;
 		else
@@ -954,10 +999,18 @@ int zocl_pread_bo_ioctl(struct drm_device *dev, void *data,
 	return (zocl_bo_rdwr_ioctl(dev, data, filp, true));
 }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+static struct drm_gem_dma_object *
+#else
 static struct drm_gem_cma_object *
+#endif
 zocl_cma_create(struct drm_device *dev, size_t size)
 {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+	struct drm_gem_dma_object *cma_obj;
+#else
 	struct drm_gem_cma_object *cma_obj;
+#endif
 	struct drm_gem_object *gem_obj;
 	int ret;
 
@@ -966,7 +1019,11 @@ zocl_cma_create(struct drm_device *dev, size_t size)
 		DRM_ERROR("cma_create: alloc failed\n");
 		return ERR_PTR(-ENOMEM);
 	}
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+	cma_obj = container_of(gem_obj, struct drm_gem_dma_object, base);
+#else
 	cma_obj = container_of(gem_obj, struct drm_gem_cma_object, base);
+#endif
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 11, 0)
 	gem_obj->funcs = &zocl_cma_default_funcs;
@@ -997,7 +1054,11 @@ int zocl_get_hbo_ioctl(struct drm_device *dev, void *data,
 {
 	struct drm_zocl_bo *bo;
 	struct drm_zocl_host_bo *args = data;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+	struct drm_gem_dma_object *cma_obj;
+#else
 	struct drm_gem_cma_object *cma_obj;
+#endif
 	struct drm_zocl_dev *zdev = dev->dev_private;
 	u64 host_mem_start = zdev->host_mem;
 	u64 host_mem_end = zdev->host_mem + zdev->host_mem_len;
@@ -1023,7 +1084,11 @@ int zocl_get_hbo_ioctl(struct drm_device *dev, void *data,
 	if (IS_ERR(cma_obj))
 		return -ENOMEM;
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+	cma_obj->dma_addr = args->paddr;
+#else
 	cma_obj->paddr = args->paddr;
+#endif
 	cma_obj->vaddr = memremap(args->paddr, args->size, MEMREMAP_WB);
 	if (!cma_obj->vaddr) {
 		DRM_ERROR("get_hbo: failed to allocate buffer with size %zu\n",
@@ -1039,7 +1104,11 @@ int zocl_get_hbo_ioctl(struct drm_device *dev, void *data,
 
 	ret = drm_gem_handle_create(filp, &bo->cma_base.base, &args->handle);
 	if (ret) {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+		drm_gem_dma_object_free(&bo->cma_base.base);
+#else
 		drm_gem_cma_free_object(&bo->cma_base.base);
+#endif
 		DRM_ERROR("get_hbo: gem handle creation failed\n");
 		return ret;
 	}

--- a/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
@@ -572,7 +572,11 @@ void zocl_free_bo(struct drm_gem_object *obj)
 			zocl_update_mem_stat(zdev, obj->size, -1,
 			    zocl_obj->mem_index);
 			/* free resources associated with a CMA GEM object */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+			drm_gem_dma_object_free(obj);
+#else
 			drm_gem_cma_free_object(obj);
+#endif
 
 		} else {
 			if (zocl_obj->mm_node) {
@@ -637,7 +641,11 @@ void zocl_free_bo(struct drm_gem_object *obj)
 static int
 zocl_gem_mmap(struct file *filp, struct vm_area_struct *vma)
 {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+	struct drm_gem_dma_object *dma_obj = NULL;
+#else
 	struct drm_gem_cma_object *cma_obj = NULL;
+#endif
 	struct drm_gem_object *gem_obj;
 	struct drm_zocl_bo *bo;
 	dma_addr_t paddr;
@@ -678,8 +686,13 @@ zocl_gem_mmap(struct file *filp, struct vm_area_struct *vma)
 		vma->vm_page_prot = prot;
 
 	if (bo->flags & ZOCL_BO_FLAGS_CMA) {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+		dma_obj = to_drm_gem_dma_obj(gem_obj);
+		paddr = dma_obj->dma_addr;
+#else
 		cma_obj = to_drm_gem_cma_obj(gem_obj);
 		paddr = cma_obj->paddr;
+#endif
 	} else
 		paddr = bo->mm_node->start;
 
@@ -692,8 +705,13 @@ zocl_gem_mmap(struct file *filp, struct vm_area_struct *vma)
 		    vma->vm_page_prot);
 	} else {
 		/* Map non-cacheable CMA */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+		rc = dma_mmap_wc(dma_obj->base.dev->dev, vma, dma_obj->vaddr,
+		    paddr, vma->vm_end - vma->vm_start);
+#else
 		rc = dma_mmap_wc(cma_obj->base.dev->dev, vma, cma_obj->vaddr,
 		    paddr, vma->vm_end - vma->vm_start);
+#endif
 	}
 
 	if (rc)
@@ -986,7 +1004,11 @@ static struct drm_driver zocl_driver = {
 	.prime_handle_to_fd        = drm_gem_prime_handle_to_fd,
 	.prime_fd_to_handle        = drm_gem_prime_fd_to_handle,
 	.gem_prime_import          = zocl_gem_import,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+	.gem_prime_import_sg_table = drm_gem_dma_prime_import_sg_table,
+#else
 	.gem_prime_import_sg_table = drm_gem_cma_prime_import_sg_table,
+#endif
 	.gem_prime_mmap            = drm_gem_prime_mmap,
 	.ioctls                    = zocl_ioctls,
 	.num_ioctls                = ARRAY_SIZE(zocl_ioctls),
@@ -1000,14 +1022,23 @@ static struct drm_driver zocl_driver = {
 const struct drm_gem_object_funcs zocl_gem_object_funcs = {
 	.free = zocl_free_bo,
 	.vm_ops = &zocl_bo_vm_ops,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+	.get_sg_table = drm_gem_dma_object_get_sg_table,
+	.vmap = drm_gem_dma_object_vmap,
+#else
 	.get_sg_table = drm_gem_cma_get_sg_table,
 	.vmap = drm_gem_cma_vmap,
+#endif
 	.export = drm_gem_prime_export,
 };
 
 const struct drm_gem_object_funcs zocl_cma_default_funcs = {
 	.free = zocl_free_bo,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+	.get_sg_table = drm_gem_dma_object_get_sg_table,
+#else
 	.get_sg_table = drm_gem_cma_get_sg_table,
+#endif
 	.vm_ops = &zocl_bo_vm_ops,
 };
 #endif

--- a/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
@@ -990,10 +990,14 @@ static void zocl_detect_fa_cmdmem(struct drm_zocl_dev *zdev,
 	if (IS_ERR(bo))
 		return;
 
-	
-	bar_paddr = (uint64_t)bo->cma_base.paddr;	
-	base_addr = (uint64_t)bo->cma_base.paddr;	
-	vaddr = bo->cma_base.vaddr;	
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+	bar_paddr = (uint64_t)bo->cma_base.dma_addr;
+	base_addr = (uint64_t)bo->cma_base.dma_addr;
+#else
+	bar_paddr = (uint64_t)bo->cma_base.paddr;
+	base_addr = (uint64_t)bo->cma_base.paddr;
+#endif
+	vaddr = bo->cma_base.vaddr;
 
 	zdev->kds.cmdmem.bo = bo;
 	zdev->kds.cmdmem.bar_paddr = bar_paddr;


### PR DESCRIPTION
Signed-off-by: rbramand <rbramand@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Fix build failures on zocl when compiled using 6.1 kernel
The main change was all the cma helpers are renamed to dma helpers  - https://gitenterprise.xilinx.com/Linux/linux-xlnx/commit/4a83c26a1d8702c516db77fc4423ae896ee904f1

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Yocto/Petalinux moved to 6.1 kernel, so adding support for this kernel version

#### How problem was solved, alternative solutions (if any) and why they were rejected
added preprocessor checks

#### Risks (if any) associated the changes in the commit
The changes are backward compatible, so low risks

#### What has been tested and how, request additional testing if necessary
Tested compiling zocl against 6.1 kernel and build was successful.

#### Documentation impact (if any)
NA