### PR TITLE
CR-1145120 & CR-1145112

### DIFF
--- a/src/runtime_src/core/common/drv/cu_hls.c
+++ b/src/runtime_src/core/common/drv/cu_hls.c
@@ -50,7 +50,6 @@ struct xrt_cu_hls {
 	bool			 sw_reset;
 	spinlock_t		 cu_lock;
 	u32			 done;
-	u32			 ready;
 	struct list_head	 submitted;
 	struct list_head	 completed;
 };
@@ -246,16 +245,15 @@ cu_hls_ctrl_chain_check(struct xrt_cu_hls *cu_hls, struct xcu_status *status, bo
 	 */
 	spin_lock_irqsave(&cu_hls->cu_lock, flags);
 	done_reg  = cu_hls->done;
-	ready_reg = cu_hls->ready;
 	cu_hls->done = 0;
-	cu_hls->ready = 0;
 
 	ctrl_reg = cu_read32(cu_hls, CTRL);
+	spin_unlock_irqrestore(&cu_hls->cu_lock, flags);
 
 	/* if there is submitted tasks, then check if ap_start bit is clear
 	 * See comments in cu_hls_start().
 	 */
-	if (!ready_reg && used_credit && !(ctrl_reg & CU_AP_START))
+	if (used_credit && !(ctrl_reg & CU_AP_START))
 		ready_reg = 1;
 
 	if (ctrl_reg & CU_AP_DONE) {
@@ -265,7 +263,6 @@ cu_hls_ctrl_chain_check(struct xrt_cu_hls *cu_hls, struct xcu_status *status, bo
 
 	for (i = 0; i < done_reg; i++)
 		cu_move_to_complete(cu_hls, KDS_COMPLETED);
-	spin_unlock_irqrestore(&cu_hls->cu_lock, flags);
 
 	status->num_done  = done_reg;
 	status->num_ready = ready_reg;
@@ -346,9 +343,6 @@ static u32 cu_hls_clear_intr(void *core)
 		/* See comment in cu_hls_ctrl_chain_check() */
 		if (cu_hls->ctrl_chain) {
 			spin_lock_irqsave(&cu_hls->cu_lock, flags);
-			if (isr & CU_INTR_READY)
-				cu_hls->ready++;
-
 			if (isr & CU_INTR_DONE) {
 				ctrl_reg = cu_read32(cu_hls, CTRL);
 				if (ctrl_reg & CU_AP_DONE) {
@@ -504,7 +498,6 @@ int xrt_cu_hls_init(struct xrt_cu *xcu)
 	core->ctrl_chain = (xcu->info.protocol == CTRL_CHAIN)? true : false;
 	spin_lock_init(&core->cu_lock);
 	core->done = 0;
-	core->ready = 0;
 	core->sw_reset = xcu->info.sw_reset;
 	INIT_LIST_HEAD(&core->submitted);
 	INIT_LIST_HEAD(&core->completed);

--- a/src/runtime_src/core/common/drv/cu_hls.c
+++ b/src/runtime_src/core/common/drv/cu_hls.c
@@ -230,6 +230,7 @@ cu_hls_ctrl_chain_check(struct xrt_cu_hls *cu_hls, struct xcu_status *status, bo
 	u32 ready_reg = 0;
 	u32 used_credit;
 	unsigned long flags;
+	int i = 0;
 
 	used_credit = cu_hls->max_credits - cu_hls->credits;
 
@@ -260,8 +261,10 @@ cu_hls_ctrl_chain_check(struct xrt_cu_hls *cu_hls, struct xcu_status *status, bo
 	if (ctrl_reg & CU_AP_DONE) {
 		done_reg += 1;
 		cu_write32(cu_hls, CTRL, CU_AP_CONTINUE);
-		cu_move_to_complete(cu_hls, KDS_COMPLETED);
 	}
+
+	for (i = 0; i < done_reg; i++)
+		cu_move_to_complete(cu_hls, KDS_COMPLETED);
 	spin_unlock_irqrestore(&cu_hls->cu_lock, flags);
 
 	status->num_done  = done_reg;
@@ -350,7 +353,6 @@ static u32 cu_hls_clear_intr(void *core)
 				ctrl_reg = cu_read32(cu_hls, CTRL);
 				if (ctrl_reg & CU_AP_DONE) {
 					cu_hls->done++;
-					cu_move_to_complete(cu_hls, KDS_COMPLETED);
 					cu_write32(cu_hls, CTRL, CU_AP_CONTINUE);
 				}
 			}

--- a/src/runtime_src/core/common/drv/xrt_cu.c
+++ b/src/runtime_src/core/common/drv/xrt_cu.c
@@ -552,8 +552,10 @@ int xrt_cu_intr_thread(void *data)
 	xcu->interrupt_used = 0;
 	xcu_info(xcu, "CU[%d] start", xcu->info.cu_idx);
 	mod_timer(&xcu->timer, jiffies + CU_TIMER);
-	if (xcu->force_intr)
+	if (xcu->force_intr) {
+		xcu->interrupt_used = 1;
 		xrt_cu_switch_to_interrupt(xcu);
+	}
 	while (!xcu->stop) {
 		/* Make sure to submit as many commands as possible.
 		 * This is why we call continue here. This is important to make

--- a/src/runtime_src/core/edge/drm/zocl/cu.c
+++ b/src/runtime_src/core/edge/drm/zocl/cu.c
@@ -432,7 +432,8 @@ static int cu_probe(struct platform_device *pdev)
 	zcu->base.user_manage_irq = user_manage_irq;
 	zcu->base.configure_irq = configure_irq;
 	/* This is a workaround for DPU kernel */
-	zcu->base.force_intr = 1;
+	if (!zocl_find_pdev("ert_hw"))
+		zcu->base.force_intr = 1;
 
 	zocl_info(&pdev->dev, "CU[%d] created", info->inst_idx);
 	return 0;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Fix CR-1145120
Fix CR-1145112

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
This is bug is there for a long time. Because we enable interrupt on VCK5000 platform, this was discovered.

#### How problem was solved, alternative solutions (if any) and why they were rejected
The issue is that the interrupt handler do check ap_ready/ap_done and move command to completion queue. This cause the race condition with the CU's intr_thread.

#### Risks (if any) associated the changes in the commit
Low Risk

#### What has been tested and how, request additional testing if necessary
Vck5000 and zcu102

#### Documentation impact (if any)
No