### PR TITLE
CR-1144981 hwmon_sdm: fix memcpy() overflow issue (#7174)

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/hwmon_sdm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/hwmon_sdm.c
@@ -70,7 +70,7 @@ struct xocl_sdr_bdinfo {
 	char revision[SDR_BDINFO_ENTRY_LEN_MAX];
 	uint64_t mfg_date;
 	uint64_t pcie_info;
-	uint64_t uuid;
+	char uuid[UUID_STRING_LEN + 1];
 	char mac_addr0[SDR_BDINFO_ENTRY_LEN_MAX];
 	char mac_addr1[SDR_BDINFO_ENTRY_LEN_MAX];
 	char active_msp_ver[SDR_BDINFO_ENTRY_LEN_MAX];
@@ -675,7 +675,7 @@ static void hwmon_sdm_load_bdinfo(struct xocl_hwmon_sdm *sdm, uint8_t repo_id,
 	else if (!strcmp(sensor_name, "PCIE Info"))
 		memcpy(&sdm->bdinfo.pcie_info, &sdm->sensor_data[repo_id][ins_index], val_len);
 	else if (!strcmp(sensor_name, "UUID"))
-		memcpy(&sdm->bdinfo.uuid, &sdm->sensor_data[repo_id][ins_index], val_len);
+		memcpy(sdm->bdinfo.uuid, &sdm->sensor_data[repo_id][ins_index], val_len);
 	else if (!strcmp(sensor_name, "MAC 0"))
 		memcpy(sdm->bdinfo.mac_addr0, &sdm->sensor_data[repo_id][ins_index], val_len);
 	else if (!strcmp(sensor_name, "MAC 1"))
@@ -1308,7 +1308,7 @@ uuid_show(struct device *dev, struct device_attribute *attr, char *buf)
 {
 	struct xocl_hwmon_sdm *sdm = dev_get_drvdata(dev);
 
-	return sprintf(buf, "0x%llx\n", sdm->bdinfo.uuid);
+	return sprintf(buf, "%pUB", sdm->bdinfo.uuid);
 };
 static DEVICE_ATTR_RO(uuid);
 


### PR DESCRIPTION
* CR-1144981 hwmon_sdm: fix memcoy overflow issue

Signed-off-by: Rajkumar Rampelli <rampelli@amd.com>

* Use existing UUID_STRING_LEN macro in uuid declaration

Fix review comments

Signed-off-by: Rajkumar Rampelli <rampelli@amd.com>

* minor fix

Signed-off-by: Rajkumar Rampelli <rampelli@amd.com>

Signed-off-by: Rajkumar Rampelli <rampelli@amd.com>
Co-authored-by: Rajkumar Rampelli <rampelli@amd.com>
(cherry picked from commit 5d82b90cc68e357ca27a820105299a754782d5f2)

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
