### PR TITLE
CR-1145946 - Fix seg fault due to wrong device handle in native C api's

### DIFF
--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -1476,7 +1476,7 @@ xrtBOAllocUserPtr(xrtDeviceHandle dhdl, void* userptr, size_t size, xrtBufferFla
   try {
     return xdp::native::profiling_wrapper(__func__,
     [dhdl, userptr, size, flags, grp]{
-      auto boh = alloc_userptr(xcl_to_core_device(dhdl), userptr, size, flags, grp);
+      auto boh = alloc_userptr(xrt_to_core_device(dhdl), userptr, size, flags, grp);
       auto hdl = boh.get();
       bo_cache.add(hdl, std::move(boh));
       return hdl;
@@ -1499,7 +1499,7 @@ xrtBOAlloc(xrtDeviceHandle dhdl, size_t size, xrtBufferFlags flags, xrtMemoryGro
   try {
     return xdp::native::profiling_wrapper(__func__,
     [dhdl, size, flags, grp]{
-      auto boh = alloc(xcl_to_core_device(dhdl), size, flags, grp);
+      auto boh = alloc(xrt_to_core_device(dhdl), size, flags, grp);
       auto hdl = boh.get();
       bo_cache.add(hdl, std::move(boh));
       return hdl;
@@ -1543,7 +1543,7 @@ xrtBOImport(xrtDeviceHandle dhdl, xclBufferExportHandle ehdl)
 {
   try {
     return xdp::native::profiling_wrapper(__func__, [dhdl, ehdl]{
-      auto boh = alloc_import(xcl_to_core_device(dhdl), ehdl);
+      auto boh = alloc_import(xrt_to_core_device(dhdl), ehdl);
       auto hdl = boh.get();
       bo_cache.add(hdl, std::move(boh));
       return hdl;

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -131,7 +131,7 @@ XBUtilities::get_available_devices(bool inUserDomain)
     }
 
     }
-    pt_dev.put("is_ready", xrt_core::device_query<xrt_core::query::is_ready>(device));
+    pt_dev.put("is_ready", xrt_core::device_query_default<xrt_core::query::is_ready>(device, true));
     pt.push_back(std::make_pair("", pt_dev));
   }
   return pt;


### PR DESCRIPTION
Signed-off-by: rbramand <rbramand@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
When XRT native C api's are called with xrtdevicehandle, we are using wrong api to get core device out of it which is causing seg fault. Fixed this issue.
Minor Fix: xbutil examine fails in edge platforms because of newly introduced device_query_default function.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
It was reproduced in SSW_Embedded pipeline.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Used correct api for mapping

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
Tested AIE application with C api's using hw_emu and sw_emu and both tests passed

#### Documentation impact (if any)
NA