### PR TITLE
Update SCU subdevice name to SCU[n] instead of CU[n]

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/scu.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/scu.c
@@ -137,7 +137,7 @@ name_show(struct device *dev, struct device_attribute *attr, char *buf)
 	struct xocl_cu *cu = platform_get_drvdata(pdev);
 	struct xrt_cu_info *info = &cu->base.info;
 
-	return sprintf(buf, "CU[%d]\n", info->cu_idx);
+	return sprintf(buf, "SCU[%d]\n", info->cu_idx);
 }
 static DEVICE_ATTR_RO(name);
 


### PR DESCRIPTION
Fixes xclRegRW sysfs querry error

Signed-off-by: Jeff Lin <jeffylin@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Fixes sysfs CU query as PS kernel SCU do not have read_range attribute

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
xclRegRW access for DPU xclbin with ps kernel included in the xclbin

#### How problem was solved, alternative solutions (if any) and why they were rejected
Modify name shown in sysfs node to SCU

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
v70

#### Documentation impact (if any)
None
