### PR TITLE
CR-1146382: Fixing issue where debug plugin has unresolved dependency

### DIFF
--- a/src/runtime_src/xdp/debug/CMakeLists.txt
+++ b/src/runtime_src/xdp/debug/CMakeLists.txt
@@ -8,7 +8,8 @@
 # This plugin is only available on Linux and contains the functions
 # that pass information from the debug server to the running process
 # in order to support gdb based debug of software emulation kernel
-# executions
+# executions.  This is only accessed in OpenCL flows so it has
+# a dependency on the OpenCL library.
 # ==================================================================
 
 if (NOT WIN32)
@@ -22,8 +23,8 @@ file(GLOB DEBUG_FILES
 
 add_library(xdp_debug_plugin MODULE ${DEBUG_FILES})
 
-add_dependencies(xdp_debug_plugin xrt_coreutil)
-target_link_libraries(xdp_debug_plugin PRIVATE xrt_coreutil)
+add_dependencies(xdp_debug_plugin xrt_coreutil xilinxopencl)
+target_link_libraries(xdp_debug_plugin PRIVATE xrt_coreutil xilinxopencl)
 
 set_target_properties(xdp_debug_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
 

--- a/src/runtime_src/xdp/debug/CMakeLists.txt
+++ b/src/runtime_src/xdp/debug/CMakeLists.txt
@@ -8,8 +8,8 @@
 # This plugin is only available on Linux and contains the functions
 # that pass information from the debug server to the running process
 # in order to support gdb based debug of software emulation kernel
-# executions.  This is only accessed in OpenCL flows so it has
-# a dependency on the OpenCL library.
+# executions.  This is accessed in OpenCL software emulation so it
+# has a dependency on the OpenCL library.
 # ==================================================================
 
 if (NOT WIN32)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
The recent refactoring of the xdp CMake file structure unintentionally left off a necessary dependency for the plugin used for software emulation debug.  This resulted in the plugin being unable to load in certain conditions.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
PR 7173 introduced the issue and it was discovered via extensive nightly testing.

#### How problem was solved, alternative solutions (if any) and why they were rejected
The dependency that was unintentionally removed has been reintroduced.

#### Risks (if any) associated the changes in the commit
Low risk as this reintroduces the build behavior from before the refactoring.

#### What has been tested and how, request additional testing if necessary
A failing test case has been tested and passes after the reintroduction of the dependency.

#### Documentation impact (if any)
No documentation impact