### PR TITLE
Reinstate xrt::bo constructors from device object

### DIFF
--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -1280,9 +1280,34 @@ wait()
 }
 
 bo::
+bo(const xrt::device& device, void* userptr, size_t sz, bo::flags flags, memory_group grp)
+  : handle(xdp::native::profiling_wrapper("xrt::bo::bo",
+      alloc_userptr, device_type{device.get_handle()}, userptr, sz
+    , adjust_buffer_flags(device_type{device.get_handle()}, flags, grp), grp))
+{}
+
+bo::
+bo(const xrt::device& device, void* userptr, size_t sz, memory_group grp)
+  : bo(device, userptr, sz, bo::flags::normal, grp)
+{}
+
+bo::
+bo(const xrt::device& device, size_t sz, bo::flags flags, memory_group grp)
+  : handle(xdp::native::profiling_wrapper("xrt::bo::bo",
+      alloc, device_type{device.get_handle()}, sz
+    , adjust_buffer_flags(device_type{device.get_handle()}, flags, grp), grp))
+{}
+
+bo::
+bo(const xrt::device& device, size_t sz, memory_group grp)
+  : bo(device, sz, bo::flags::normal, grp)
+{}
+
+bo::
 bo(const xrt::hw_context& hwctx, void* userptr, size_t sz, bo::flags flags, memory_group grp)
   : handle(xdp::native::profiling_wrapper("xrt::bo::bo",
-      alloc_userptr, device_type{hwctx}, userptr, sz, adjust_buffer_flags(device_type{hwctx}, flags, grp), grp))
+      alloc_userptr, device_type{hwctx}, userptr, sz
+    , adjust_buffer_flags(device_type{hwctx}, flags, grp), grp))
 {}
 
 bo::
@@ -1293,7 +1318,8 @@ bo(const xrt::hw_context& hwctx, void* userptr, size_t sz, memory_group grp)
 bo::
 bo(const xrt::hw_context& hwctx, size_t sz, bo::flags flags, memory_group grp)
   : handle(xdp::native::profiling_wrapper("xrt::bo::bo",
-      alloc, device_type{hwctx}, sz, adjust_buffer_flags(device_type{hwctx}, flags, grp), grp))
+      alloc, device_type{hwctx}, sz
+    , adjust_buffer_flags(device_type{hwctx}, flags, grp), grp))
 {}
 
 bo::
@@ -1301,16 +1327,20 @@ bo(const xrt::hw_context& hwctx, size_t sz, memory_group grp)
   : bo(hwctx, sz, bo::flags::normal, grp)
 {}
 
+// Deprecated
 bo::
 bo(xclDeviceHandle dhdl, void* userptr, size_t sz, bo::flags flags, memory_group grp)
   : handle(xdp::native::profiling_wrapper("xrt::bo::bo",
-      alloc_userptr, xcl_to_core_device(dhdl), userptr, sz, adjust_buffer_flags(xcl_to_core_device(dhdl), flags, grp), grp))
+      alloc_userptr, xcl_to_core_device(dhdl), userptr, sz
+    , adjust_buffer_flags(xcl_to_core_device(dhdl), flags, grp), grp))
 {}
 
+// Deprecated
 bo::
 bo(xclDeviceHandle dhdl, size_t size, bo::flags flags, memory_group grp)
   : handle(xdp::native::profiling_wrapper("xrt::bo::bo",
-      alloc, xcl_to_core_device(dhdl), size, adjust_buffer_flags(xcl_to_core_device(dhdl), flags, grp), grp))
+      alloc, xcl_to_core_device(dhdl), size
+    , adjust_buffer_flags(xcl_to_core_device(dhdl), flags, grp), grp))
 {}
 
 bo::

--- a/src/runtime_src/core/include/xrt/xrt_bo.h
+++ b/src/runtime_src/core/include/xrt/xrt_bo.h
@@ -64,6 +64,7 @@ using memory_group = xrtMemoryGroup;
  */
 struct pid_type { pid_t pid; };
 
+class device;
 class hw_context;
 class bo_impl;
 class bo
@@ -129,6 +130,84 @@ public:
    */
   bo()
   {}
+
+  /**
+   * bo() - Constructor with user host buffer and flags
+   *
+   * @param device
+   *  The device on which to allocate this buffer
+   * @param userptr
+   *  Pointer to aligned user memory
+   * @param sz
+   *  Size of buffer
+   * @param flags
+   *  Specify type of buffer
+   * @param grp
+   *  Device memory group to allocate buffer in
+   *
+   * The device memory group depends on connectivity.  If the buffer
+   * as a kernel argument, then the memory group can be obtained from
+   * the xrt::kernel object.
+   */
+  XCL_DRIVER_DLLESPEC
+  bo(const xrt::device& device, void* userptr, size_t sz, bo::flags flags, memory_group grp);
+
+  /**
+   * bo() - Constructor with user host buffer and default flags
+   *
+   * @param device
+   *  The device on which to allocate this buffer
+   * @param userptr
+   *  Pointer to aligned user memory
+   * @param sz
+   *  Size of buffer
+   * @param grp
+   *  Device memory group to allocate buffer in
+   *
+   * The device memory group depends on connectivity.  If the buffer
+   * as a kernel argument, then the memory group can be obtained from
+   * the xrt::kernel object.
+   */
+  XCL_DRIVER_DLLESPEC
+  bo(const xrt::device& device, void* userptr, size_t sz, memory_group grp);
+
+  /**
+   * bo() - Constructor where XRT manages host buffer if needed
+   *
+   * @param device
+   *  The device on which to allocate this buffer
+   * @param sz
+   *  Size of buffer
+   * @param flags
+   *  Specify type of buffer
+   * @param grp
+   *  Device memory group to allocate buffer in
+   *
+   * The device memory group depends on connectivity.  If the buffer
+   * as a kernel argument, then the memory group can be obtained from
+   * the xrt::kernel object.
+   */
+  XCL_DRIVER_DLLESPEC
+  bo(const xrt::device& device, size_t sz, bo::flags flags, memory_group grp);
+
+  /**
+   * bo() - Constructor, default flags, where XRT manages host buffer if any
+   *
+   * @param device
+   *  The device on which to allocate this buffer
+   * @param sz
+   *  Size of buffer
+   * @param flags
+   *  Specify type of buffer
+   * @param grp
+   *  Device memory group to allocate buffer in
+   *
+   * The device memory group depends on connectivity.  If the buffer
+   * as a kernel argument, then the memory group can be obtained from
+   * the xrt::kernel object.
+   */
+  XCL_DRIVER_DLLESPEC
+  bo(const xrt::device& device, size_t sz, memory_group grp);
 
   /**
    * bo() - Constructor with user host buffer and flags


### PR DESCRIPTION
#### Problem solved by the commit
Allocating an xrt::bo for device was prematurely deprecated in PR #7165, this PR reinstates the constructors but this time with xrt::device objects rather than xclDeviceHandle.

The original xclDeviceHandle variants remain deprecated and will be removed in a future release.

#### How problem was solved, alternative solutions (if any) and why they were rejected
In #7165 constructors specific to a hardware context were added. These constructors remain for the cases where buffers truly are hardware context specific.  The implementation is free to ignore the hwctx if it is not applicable to the type of buffer being created, e.g. for cases where the buffer can in fact be shared across device process and is not specific to a hwctx.

#### Risks (if any) associated the changes in the commit
New constructors, unused in existing code, so low risk.

Signed-off-by: Soren Soe <2106410+stsoe@users.noreply.github.com>
