### PR TITLE
CR-1147044 hwmon_sdm: fix xocl drvinst leak in hwmon_sdm driver

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/hwmon_sdm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/hwmon_sdm.c
@@ -1233,6 +1233,7 @@ hwmon_reg_failed:
 static int hwmon_sdm_remove(struct platform_device *pdev)
 {
 	struct xocl_hwmon_sdm *sdm;
+	void *hdl;
 
 	sdm = platform_get_drvdata(pdev);
 	if (!sdm) {
@@ -1240,11 +1241,14 @@ static int hwmon_sdm_remove(struct platform_device *pdev)
 		return -EINVAL;
 	}
 
+	xocl_drvinst_release(sdm, &hdl);
+
 	if (sdm->sysfs_created)
 		destroy_hwmon_sysfs(pdev);
 
 	mutex_destroy(&sdm->sdm_lock);
 	platform_set_drvdata(pdev, NULL);
+	xocl_drvinst_free(hdl);
 
 	return 0;
 }


### PR DESCRIPTION
Signed-off-by: Rajkumar Rampelli <rampelli@amd.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
hwmon_sdm driver not releasing driver inst resources in driver remove() path. Fixed this leak by adding required changes in hwmon_sdm_remove() function in hwmon_sdm driver.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1147044
#### How problem was solved, alternative solutions (if any) and why they were rejected
Added changes in hwmon_sdm driver to release drvinst resources properly.
#### Risks (if any) associated the changes in the commit
NA
#### What has been tested and how, request additional testing if necessary
xbutil reset & validate tests
#### Documentation impact (if any)
NA