### PR TITLE
CR-1147044 hwmon_sdm: fix drvinst leak in hwmon_sdm driver (#7205)

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/hwmon_sdm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/hwmon_sdm.c
@@ -1233,6 +1233,7 @@ hwmon_reg_failed:
 static int hwmon_sdm_remove(struct platform_device *pdev)
 {
 	struct xocl_hwmon_sdm *sdm;
+	void *hdl;
 
 	sdm = platform_get_drvdata(pdev);
 	if (!sdm) {
@@ -1240,11 +1241,14 @@ static int hwmon_sdm_remove(struct platform_device *pdev)
 		return -EINVAL;
 	}
 
+	xocl_drvinst_release(sdm, &hdl);
+
 	if (sdm->sysfs_created)
 		destroy_hwmon_sysfs(pdev);
 
 	mutex_destroy(&sdm->sdm_lock);
 	platform_set_drvdata(pdev, NULL);
+	xocl_drvinst_free(hdl);
 
 	return 0;
 }


### PR DESCRIPTION
Signed-off-by: Rajkumar Rampelli <rampelli@amd.com>

Signed-off-by: Rajkumar Rampelli <rampelli@amd.com>
Co-authored-by: Rajkumar Rampelli <rampelli@amd.com>
(cherry picked from commit b24a86a299f4ac5ca57a9bba5d6f293e86b0eb1f)

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
