### PR TITLE
backport PR7078 and PR7183 for versal A/B boot improvements

### DIFF
--- a/src/runtime_src/core/common/device.h
+++ b/src/runtime_src/core/common/device.h
@@ -511,6 +511,36 @@ device_query(const std::shared_ptr<device>& device, Args&&... args)
   return boost::any_cast<typename QueryRequestType::result_type>(ret);
 }
 
+template <typename QueryRequestType>
+inline typename QueryRequestType::result_type
+device_query_default(const device* device, const typename QueryRequestType::result_type& default_value)
+{
+  try {
+    return device_query<QueryRequestType>(device);
+  }
+  catch (const query::no_such_key&) {
+    return default_value;
+  }
+  catch (const query::sysfs_error&) {
+    return default_value;
+  }
+}
+
+template <typename QueryRequestType>
+inline typename QueryRequestType::result_type
+device_query_default(const std::shared_ptr<device>& device, const typename QueryRequestType::result_type& default_value)
+{
+  try {
+    return device_query<QueryRequestType>(device);
+  }
+  catch (const query::no_such_key&) {
+    return default_value;
+  }
+  catch (const query::sysfs_error&) {
+    return default_value;
+  }
+}
+
 template <typename QueryRequestType, typename ...Args>
 inline void
 device_update(const device* device, Args&&... args)

--- a/src/runtime_src/core/common/info_vmr.h
+++ b/src/runtime_src/core/common/info_vmr.h
@@ -1,18 +1,6 @@
-/**
- * Copyright (C) 2022 Xilinx, Inc
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2022 Xilinx, Inc
+// Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
 
 #ifndef COMMON_INFO_VMR_H
 #define COMMON_INFO_VMR_H
@@ -26,6 +14,10 @@ namespace vmr {
 XRT_CORE_COMMON_EXPORT
 boost::property_tree::ptree
 vmr_info(const xrt_core::device * device);
+
+XRT_CORE_COMMON_EXPORT
+bool
+is_default_boot(const xrt_core::device* device);
 
 }} // vmr, xrt
 

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -1,18 +1,6 @@
-/**
- * Copyright (C) 2020-2022 Xilinx, Inc
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2020-2022 Xilinx, Inc
+// Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
 
 #ifndef xrt_core_common_query_requests_h
 #define xrt_core_common_query_requests_h
@@ -295,69 +283,6 @@ enum class key_type
   xgq_scaling_power_override,
   xgq_scaling_temp_override,
   noop
-};
-
-// Base class for query request exceptions.
-//
-// Provides granularity for calling code to catch errors specific to
-// query request which are often acceptable errors because some
-// devices may not support all types of query requests.
-//
-// Other non query exceptions signal a different kind of error which
-// should maybe not be caught.
-//
-// The addition of the query request exception hierarchy does not
-// break existing code that catches std::exception (or all errors)
-// because ultimately the base query exception is-a std::exception
-class exception : public std::runtime_error
-{
-public:
-  explicit
-  exception(const std::string& err)
-    : std::runtime_error(err)
-  {}
-};
-
-class no_such_key : public exception
-{
-  key_type m_key;
-
-  using qtype = std::underlying_type<query::key_type>::type;
-public:
-  explicit
-  no_such_key(key_type k)
-    : exception(boost::str(boost::format("No such query request (%d)") % static_cast<qtype>(k)))
-    , m_key(k)
-  {}
-
-  no_such_key(key_type k, const std::string& msg)
-    : exception(msg)
-    , m_key(k)
-  {}
-
-  key_type
-  get_key() const
-  {
-    return m_key;
-  }
-};
-
-class sysfs_error : public exception
-{
-public:
-  explicit
-  sysfs_error(const std::string& msg)
-    : exception(msg)
-  {}
-};
-
-class not_supported : public exception
-{
-public:
-  explicit
-  not_supported(const std::string& msg)
-    : exception(msg)
-  {}
 };
 
 struct pcie_vendor : request
@@ -2527,12 +2452,11 @@ struct is_recovery : request
   get(const device*) const = 0;
 };
 
-/*
- * struct is_versal - check if device is versal or not
- * A value of true means it is a versal device.
- * This entry is needed as some of the operations are handled
- * differently on versal devices compared to Alveo devices
- */
+
+// struct is_versal - check if device is versal or not
+// A value of true means it is a versal device.
+// This entry is needed as some of the operations are handled
+// differently on versal devices compared to Alveo devices
 struct is_versal : request
 {
   using result_type = bool;
@@ -2542,6 +2466,9 @@ struct is_versal : request
   get(const device*) const = 0;
 };
 
+// struct is_ready - A boolean stating
+// if the specified device is ready for
+// XRT operations such as program or reset
 struct is_ready : request
 {
   using result_type = bool;
@@ -2982,6 +2909,11 @@ struct program_sc : request
   put(const device*, const boost::any&) const = 0;
 };
 
+
+// Returns the status the vmr subdevice. This
+// includes boot information and other data.
+// In the user partition only the boot information
+// is returned.
 struct vmr_status : request
 {
   using result_type = std::vector<std::string>;

--- a/src/runtime_src/core/edge/user/device_linux.cpp
+++ b/src/runtime_src/core/edge/user/device_linux.cpp
@@ -108,17 +108,6 @@ struct board_name
   }
 };
 
-struct is_ready
-{
-  using result_type = query::is_ready::result_type;
-
-  static result_type
-  get(const xrt_core::device* device, key_type)
-  {
-    return true;
-  }
-};
-
 static xclDeviceInfo2
 init_device_info(const xrt_core::device* device)
 {
@@ -890,7 +879,6 @@ initialize_query_table()
   emplace_sysfs_get<query::host_mem_size>             ("host_mem_size");
   emplace_func0_request<query::pcie_bdf,                bdf>();
   emplace_func0_request<query::board_name,              board_name>();
-  emplace_func0_request<query::is_ready,                is_ready>();
   emplace_func0_request<query::xclbin_uuid ,            xclbin_uuid>();
 
   emplace_func0_request<query::kds_cu_info,             kds_cu_info>();

--- a/src/runtime_src/core/include/xclfeatures.h
+++ b/src/runtime_src/core/include/xclfeatures.h
@@ -1,37 +1,7 @@
 /**
- *  Copyright (C) 2015-2018, Xilinx Inc
- *
- *  This file is dual licensed.	 It may be redistributed and/or modified
- *  under the terms of the Apache 2.0 License OR version 2 of the GNU
- *  General Public License.
- *
- *  Apache License Verbiage
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
- *  GPL license Verbiage:
- *
- *  This program is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU General Public License as
- *  published by the Free Software Foundation; either version 2 of the
- *  License, or (at your option) any later version.  This program is
- *  distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or
- *  FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
- *  License for more details.  You should have received a copy of the
- *  GNU General Public License along with this program; if not, write
- *  to the Free Software Foundation, Inc., 59 Temple Place, Suite 330,
- *  Boston, MA 02111-1307 USA
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (C) 2015-2018 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
  *
  */
 
@@ -141,6 +111,17 @@ struct FeatureRomHeader {
 	uint8_t HBMCount;		    // Number of HBMs
 	uint8_t HBMSize;		    // Size of (each) HBM in GB
 	uint32_t CDMABaseAddress[4];	    // CDMA base addresses
+};
+
+// A boiled down version of the vmr status for userpf use
+// To get a complete version of the vmr status investigate the
+// vmr status sysfs node within the mgmtpf
+// This struct contains the status of the VMR subdevice found
+// on certain cards like u50s and versal platforms.
+struct VmrStatus {
+	uint16_t boot_on_default; // 1 If the VMR device is currently running on its "A" or default image
+	uint16_t boot_on_backup; // 1 If the VMR device is currently running on its "B" or backup image
+	uint16_t boot_on_recovery; // 1 If the VMR device is currently running on its recovery image
 };
 
 #endif // xclfeatures_h_

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/feature_rom.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/feature_rom.c
@@ -541,15 +541,20 @@ static int load_firmware(struct platform_device *pdev, char **fw, size_t *len)
 	size_t size = 0;
 	int ret;
 
-	ret = load_firmware_from_disk(pdev, &buf, &size, "xsabin");
+	/*
+	 * If this is a vmr devices, load firmware from device first.
+	 * If this is not a vmr device, we continue to try next possible
+	 * location.
+	 */
+	ret = load_firmware_from_vmr(pdev, &buf, &size);
+	if (ret)
+		ret = load_firmware_from_disk(pdev, &buf, &size, "xsabin");
 	if (ret)
 		ret = load_firmware_from_disk(pdev, &buf, &size, "dsabin");
 	if (ret)
 		ret = load_firmware_from_flash(pdev, &buf, &size);
-	if (ret)
-		ret = load_firmware_from_vmr(pdev, &buf, &size);
 	if (ret) {
-		xocl_err(&pdev->dev, "can't load firmware, give up");
+		xocl_err(&pdev->dev, "can't load firmware, ret:%d, give up", ret);
 		return ret;
 	}
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -1,18 +1,10 @@
-/*
+/**
+ * SPDX-License-Identifier: Apache-2.0
  * Copyright (C) 2016-2022 Xilinx, Inc. All rights reserved.
  * Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Authors: Lizhi.Hou@Xilinx.com
  *          Jan Stephan <j.stephan@hzdr.de>
- *
- * This software is licensed under the terms of the GNU General Public
- * License version 2, as published by the Free Software Foundation, and
- * may be copied, distributed, and modified under those terms.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
  */
 
 #ifndef	_XOCL_DRV_H_
@@ -51,8 +43,10 @@
 #include <linux/types.h>
 #include <linux/moduleparam.h>
 #include <linux/cdev.h>
+
 #include "xocl_types.h"
 #include "xclbin.h"
+#include "xclfeatures.h"
 #include "xrt_xclbin.h"
 #include "xocl_xclbin.h"
 #include "xrt_mem.h"
@@ -2151,6 +2145,7 @@ struct xocl_xgq_vmr_funcs {
 	int (*xgq_collect_all_inst_sensors)(struct platform_device *pdev, char *buf,
                                      uint8_t id, uint32_t len);
 	int (*vmr_load_firmware)(struct platform_device *pdev, char **fw, size_t *fw_size);
+	int (*vmr_status)(struct platform_device *pdev, struct VmrStatus *vmr_status_ptr);
 };
 #define	XGQ_DEV(xdev)						\
 	(SUBDEV(xdev, XOCL_SUBDEV_XGQ_VMR) ? 			\
@@ -2196,6 +2191,9 @@ struct xocl_xgq_vmr_funcs {
 #define	xocl_vmr_load_firmware(xdev, fw, fw_size)		\
 	(XGQ_CB(xdev, vmr_load_firmware) ?			\
 	XGQ_OPS(xdev)->vmr_load_firmware(XGQ_DEV(xdev), fw, fw_size) : -ENODEV)
+#define	xocl_vmr_status(xdev, vmr_status_ptr)		\
+	(XGQ_CB(xdev, vmr_load_firmware) ?			\
+	XGQ_OPS(xdev)->vmr_status(XGQ_DEV(xdev), vmr_status_ptr) : -ENODEV)
 
 struct xocl_sdm_funcs {
 	struct xocl_subdev_funcs common_funcs;

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -919,6 +919,23 @@ struct sysfs_fcn<std::vector<VectorValueType>>
   }
 };
 
+/* Accelerator Deadlock Detector status
+ * In PCIe Linux, access the sysfs file for Accelerator Deadlock Detector to retrieve the deadlock status
+ */
+struct vmr_status
+{
+  using result_type = query::vmr_status::result_type;
+
+  static result_type
+  get(const xrt_core::device* device, key_type)
+  {
+    if (device->is_userpf())
+      return sysfs_fcn<result_type>::get(get_pcidev(device), "", "vmr_status");
+    else
+      return sysfs_fcn<result_type>::get(get_pcidev(device), "xgq_vmr", "vmr_status");
+  }
+};
+
 template <typename QueryRequestType>
 struct sysfs_get : virtual QueryRequestType
 {
@@ -1231,7 +1248,7 @@ initialize_query_table()
   emplace_sysfs_getput<query::boot_partition>                  ("xgq_vmr", "boot_from_backup");
   emplace_sysfs_getput<query::flush_default_only>              ("xgq_vmr", "flush_default_only");
   emplace_sysfs_getput<query::program_sc>                      ("xgq_vmr", "program_sc");
-  emplace_sysfs_get<query::vmr_status>                         ("xgq_vmr", "vmr_status");
+  emplace_func0_request<query::vmr_status,                     vmr_status>();
   emplace_sysfs_get<query::extended_vmr_status>                ("xgq_vmr", "vmr_verbose_info");
   emplace_sysfs_getput<query::xgq_scaling_enabled>             ("xgq_vmr", "xgq_scaling_enable");
   emplace_sysfs_getput<query::xgq_scaling_power_override>      ("xgq_vmr", "xgq_scaling_power_override");

--- a/src/runtime_src/core/pcie/windows/alveo/device_windows.cpp
+++ b/src/runtime_src/core/pcie/windows/alveo/device_windows.cpp
@@ -68,23 +68,6 @@ struct flash
   }
 };
 
-struct ready
-{
-  using result_type = bool;
-
-  static result_type
-  user(const xrt_core::device* device, key_type key)
-  {
-    return true;
-  }
-
-  static result_type
-  mgmt(const xrt_core::device* device, key_type key)
-  {
-    return true;
-  }
-};
-
 
 struct firewall
 {
@@ -1541,7 +1524,6 @@ initialize_query_table()
   emplace_function0_getter<query::f_flash_type,              flash>();
   emplace_function0_getter<query::flash_type,                flash>();
   emplace_function0_getter<query::is_mfg,                    devinfo>();
-  emplace_function0_getter<query::is_ready,                  ready>();
   emplace_function0_getter<query::board_name,                devinfo>();
   emplace_function0_getter<query::flash_bar_offset,          flash_bar_offset>();
   emplace_function0_getter<query::xmc_sc_presence,           devinfo>();

--- a/src/runtime_src/core/tools/common/XBHelpMenus.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenus.cpp
@@ -4,24 +4,23 @@
 
 // ------ I N C L U D E   F I L E S -------------------------------------------
 // Local - Include Files
+#include "core/common/time.h"
+#include "core/common/query_requests.h"
 #include "XBHelpMenusCore.h"
 #include "XBUtilitiesCore.h"
 #include "XBHelpMenus.h"
 #include "XBUtilities.h"
-#include "core/common/time.h"
-#include "core/common/query_requests.h"
-
 namespace XBU = XBUtilities;
 
 
 // 3rd Party Library - Include Files
-#include <boost/property_tree/json_parser.hpp>
 #include <boost/format.hpp>
+#include <boost/property_tree/json_parser.hpp>
 namespace po = boost::program_options;
 
 // System - Include Files
-#include <iostream>
 #include <algorithm>
+#include <iostream>
 #include <numeric>
 
 // ------ N A M E S P A C E ---------------------------------------------------
@@ -243,7 +242,7 @@ XBUtilities::produce_reports( const std::shared_ptr<xrt_core::device>& device,
     consoleStream << dev_desc;
     consoleStream << std::string(dev_desc.length(), '-') << std::endl;
 
-    const auto is_ready = xrt_core::device_query<xrt_core::query::is_ready>(device);
+    const auto is_ready = xrt_core::device_query_default<xrt_core::query::is_ready>(device, true);
     bool is_recovery = false;
     try {
       is_recovery = xrt_core::device_query<xrt_core::query::is_recovery>(device);
@@ -257,7 +256,7 @@ XBUtilities::produce_reports( const std::shared_ptr<xrt_core::device>& device,
     // 1. Is in factory mode and is not in recovery mode
     // 2. Is not ready and is not in recovery mode
     if ((is_mfg || !is_ready) && !is_recovery)
-      std::cout << "Warning: Device is not ready - Limited functionality available with XRT tools.\n\n";
+      std::cout << "Warning: Device is not ready - Limited functionality available with XRT tools.\n";
 
     for (auto &report : reportsToProcess) {
       if (!report->isDeviceRequired())

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -131,7 +131,7 @@ XBUtilities::get_available_devices(bool inUserDomain)
     }
 
     }
-    pt_dev.put("is_ready", xrt_core::device_query<xrt_core::query::is_ready>(device));
+    pt_dev.put("is_ready", xrt_core::device_query<xrt_core::query::is_ready>(device, true));
     pt.push_back(std::make_pair("", pt_dev));
   }
   return pt;

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -131,7 +131,7 @@ XBUtilities::get_available_devices(bool inUserDomain)
     }
 
     }
-    pt_dev.put("is_ready", xrt_core::device_query<xrt_core::query::is_ready>(device, true));
+    pt_dev.put("is_ready", xrt_core::device_query_default<xrt_core::query::is_ready>(device, true));
     pt.push_back(std::make_pair("", pt_dev));
   }
   return pt;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

This is not a clean backport. 
The PR 7183 depends on PR 7078.
But PR 7078 is too huge. I would like @dbenusov-xilinx to review it only backport 7078 to 2022.2 is safe or not.

If not, we will have to manually redo the conflicts in mgmt-utils.c for PR7182 backport only.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
