### PR TITLE
Addressed all review comments from PR:7194

### DIFF
--- a/src/runtime_src/core/pcie/emulation/common_em/config.cxx
+++ b/src/runtime_src/core/pcie/emulation/common_em/config.cxx
@@ -105,10 +105,7 @@ namespace xclemulation{
   void config::populateEnvironmentSetup(std::map<std::string,std::string>& mEnvironmentNameValueMap)
   {
     setenv("HW_EM_DISABLE_LATENCY", "true", true);
-    for (auto i : mEnvironmentNameValueMap)
-    {
-      std::string name  = i.first;
-      std::string value = i.second;
+    for (auto& [name, value] : mEnvironmentNameValueMap) {
       if(value.empty() || name.empty())
         continue;
 
@@ -657,6 +654,7 @@ namespace xclemulation{
       info.mVendorId = 0x10ee;
       info.mSubsystemVendorId = 0x0000;
       info.mDeviceVersion = 0x0000;
+      info.mDeviceId = 0x0000;
       info.mDDRSize = MEMSIZE_4G;
       info.mDataAlignment = DDR_BUFFER_ALIGNMENT;
       info.mDDRBankCount = 1;

--- a/src/runtime_src/core/pcie/emulation/common_em/unix_socket.cxx
+++ b/src/runtime_src/core/pcie/emulation/common_em/unix_socket.cxx
@@ -51,7 +51,7 @@ unix_socket::unix_socket(const std::string& env, const std::string& sock_id, dou
   //by default, all calls should be blocking only.
   mNonBlocking = false;               
   start_server(timeout_insec,fatal_error);
-  
+  mpoll_on_filedescriptor = {fd, POLLERR, 0};   // CID-271874 This will be affective for monitor_socket_status callers only.
 }
 
 void unix_socket::start_server(double timeout_insec, bool fatal_error)

--- a/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/debug.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/debug.cxx
@@ -298,7 +298,7 @@ namespace xclhwemhal2
       // My wait time > 300 seconds, Let's fetch the exact details behind late connection with Simulator.
       if (std::chrono::duration_cast<std::chrono::seconds>(l_time_end - l_time).count() > kMaxTimeToConnectSimulator) {
        
-        std::lock_guard<std::mutex> guard(mPrintMessagesLock);
+        std::lock_guard guard{mPrintMessagesLock};
         if (get_simulator_started() == false)
           return;
         // Possibility of deadlock detection?
@@ -309,14 +309,14 @@ namespace xclhwemhal2
       auto end_time = std::chrono::high_resolution_clock::now();
       if (std::chrono::duration_cast<std::chrono::seconds>(end_time - start_time).count() <= kMaxTimeToConnectSimulator) {
         
-        std::lock_guard<std::mutex> guard(mPrintMessagesLock);
         if (get_simulator_started() == false) 
           return;
-
-        dumpDeadlockMessages();
-        // Any status message found in parse log file?
-        lParseLog.parseLog();
-
+        { // This is for limiting the scope of lock
+          std::lock_guard<std::mutex> guard(mPrintMessagesLock);
+          dumpDeadlockMessages();
+          // Any status message found in parse log file?
+          lParseLog.parseLog();
+        }
         parseCount++;
         if (parseCount%5 == 0) {
           std::this_thread::sleep_for(5s);

--- a/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/mbscheduler_hwemu.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/mbscheduler_hwemu.cxx
@@ -173,15 +173,17 @@ namespace hwemu {
         // copy pkt cus to command object cu bitmap
         //if (type() == ERT_CU) 
         {
-            uint32_t cumasks[4] = {0};
+            constexpr uint32_t max_cu_masks = 4;
+            uint32_t cumasks[max_cu_masks] = {0};
 
             cumasks[0] = ert_cu->cu_mask;
-            for (uint32_t i = 0; i < num_cumasks() -1 ; ++i) {
-                cumasks[i+1] = ert_cu->data[i];
-            }
+            auto j = num_cumasks();
+            if (j >= max_cu_masks)
+                std::runtime_error("invalid CU index");
+            std::copy(ert_cu->data, (ert_cu->data)+num_cumasks()-1, cumasks+1 );
 
             //! Set cu_bitmap from cumasks
-            for (int i =  num_cumasks(); i >= 0;  --i) {
+            for (uint32_t i =  num_cumasks() ; (i >= 0) && (i<max_cu_masks);  --i) {
                 cu_bitmap <<= 32;
                 cu_bitmap |= cumasks[i];
             }
@@ -1813,7 +1815,7 @@ namespace hwemu {
         uint32_t cuidx = MAX_CUS;
         uint32_t bit;
         SCHED_DEBUGF("-> %s exec(%d) cmd(%lu)\n", __func__, this->uid, xcmd->uid);
-        for (bit = xcmd->first_cu(); bit < this->num_cus; bit = xcmd->next_cu(bit)) {
+        for (bit = xcmd->first_cu(); (bit < this->num_cus) && (bit < 128); bit = xcmd->next_cu(bit)) {
             uint32_t load_count = this->cu_load_count[bit];
             SCHED_DEBUGF(" bit(%d) num_cus(%d) load_count(%d) min_load_count(%d)\n", bit, num_cus, load_count, min_load_count);
             if (load_count >= min_load_count)

--- a/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/nocddr_fastaccess_hwemu.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/nocddr_fastaccess_hwemu.cxx
@@ -102,14 +102,23 @@ bool nocddr_fastaccess_hwemu::init(std::string filename, std::string simdir)
     ss1 >> foffset;
     ss2 >> fsize;
     fname = simdir + "/" + fname;
-    std::cerr << "Creating fname=" << fname << std::hex << ", offset=0x" << foffset << ", size=0x" << fsize << std::endl;
     //mmap the file create a tuple and add to the array
     int fd = open(fname.c_str(), (O_CREAT | O_RDWR), 0666);
-    int rf = ftruncate(fd, fsize);
-    if (rf == -1)
+    if(fd >= 0)
     {
+      int rf = ftruncate(fd, fsize);
+      if (rf == -1)
+      {
+        close(fd);      // ftruncate failed, close fd
+        return false;
+      }
+    }
+    else
+    {
+      close(fd);         // open failed, close fd
       return false;
     }
+    // fd is open if and only ftruncate successful
     unsigned char *memP = (unsigned char *)mmap(NULL, fsize, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_SHARED, fd, 0);
     if (memP != NULL)
     {


### PR DESCRIPTION
Fixed following coverity issues:

Coverity IDs: 275404
Issue type: Resource leak - variable fd going out of scope.
Fix: Called close(fd) before return.

Coverity IDs: 256953, 249231
Issue type: Uninitialized scalar variable
Fix: Initialized required variable.

Coverity IDs: 249249, 249245
Issue type: Out-of-bounds read
Fix: Fixed overrunning conditions in for loop.

Coverity IDs: 275406
Issue type: Not restoring ostream format
Fix: Removed a line having unnecessary print statement.

Coverity IDs: 275405
Issue type: Argument cannot be negative
Fix: Checked for positive arguments, else return false

Coverity IDs: 271876
Issue type: Dereference before null check
Fix: Exception handling for Null-pointer

Coverity IDs: 271874
Issue type: Uninitialized scalar field
Fix: Initialized in constructor

Coverity IDs: 256970
Issue type: Waiting while holding a lock
Fix: Unlocked with unique_lock before sleep.

Coverity IDs: 253416, 211531
Issue type: Unchecked return value
Fix: If condition fails, return -1;

Coverity IDs: 218500, 218498
Issue type: Invalid type in argument to printf format specifier
Fix: Changed %d to proper format specifier %lu and %u

Coverity IDs: 218499
Issue type: Dereference null return value
Fix: Applied Null-pointer check.

Coverity IDs: 275623, 275608, 275601, 275546, 275545
Issue type: AUTO_CAUSES_COPY
Fix: Replaced 'auto' keyword with 'auto &'.

Tests: Canary run. Results are clean.
Reviewer: sgundime, venkatp