### PR TITLE
CR-1145195 Fixes related to default clock scaling override values

### DIFF
--- a/src/runtime_src/core/tools/common/ReportCmcStatus.cpp
+++ b/src/runtime_src/core/tools/common/ReportCmcStatus.cpp
@@ -123,9 +123,9 @@ ReportCmcStatus::writeReport( const xrt_core::device* /*_pDevice*/,
     }
     if (!cmc_scale.get<bool>("enabled")) {
       _output << "    Not enabled\n";
+    } else {
+      _output << "    Enabled\n";
     }
-
-    _output << "    Enabled\n";
 
     cmc_scale = cmc.get_child("scaling").get_child("shutdown_threshold_limits");
     _output << boost::format("    %-22s:\n") % "Critical threshold (clock shutdown) limits";

--- a/src/runtime_src/core/tools/common/ReportCmcStatus.cpp
+++ b/src/runtime_src/core/tools/common/ReportCmcStatus.cpp
@@ -125,6 +125,8 @@ ReportCmcStatus::writeReport( const xrt_core::device* /*_pDevice*/,
       _output << "    Not enabled\n";
     }
 
+    _output << "    Enabled\n";
+
     cmc_scale = cmc.get_child("scaling").get_child("shutdown_threshold_limits");
     _output << boost::format("    %-22s:\n") % "Critical threshold (clock shutdown) limits";
     _output << boost::format("      %s : %s W\n") % "Power" % cmc_scale.get<std::string>("power_watts");


### PR DESCRIPTION
Signed-off-by: Rajkumar Rampelli <rampelli@amd.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
By default, power & temp scaling override feature disabled, and hence the override values should also be set to 0 initially. But, XRT reports these values as max values (threshold values), which is not correct.
Also, CMC report in "xbmgmt examine" not display the clock scaling feature enable message which causing a little confusion for the user. So, fix this message.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1145195
#### How problem was solved, alternative solutions (if any) and why they were rejected
For scaling override values, keep a copy of local override data and report the same to user whenever requested.
#### Risks (if any) associated the changes in the commit
NA

#### What has been tested and how, request additional testing if necessary
xbmgmt examine's cmc report.
#### Documentation impact (if any)
NA