### PR TITLE
Convert hwctx_handle to opaque pointer

### DIFF
--- a/src/runtime_src/core/common/api/command.h
+++ b/src/runtime_src/core/common/api/command.h
@@ -66,12 +66,12 @@ public:
 
   /**
   * get_hwctx_handle() - get submission hw context of command buffer
-  * 
+  *
   * The submission hw context is the hardware context used for command execution.
-  * This context is used in multi-xclbin / slot support when submitting a command with 
+  * This context is used in multi-xclbin / slot support when submitting a command with
   * execbuf when the core implementation does not support hardware queue.
   */
-  virtual xcl_hwctx_handle
+  virtual xrt_hwctx_handle
   get_hwctx_handle() const = 0;
 
 private:

--- a/src/runtime_src/core/common/api/context_mgr.cpp
+++ b/src/runtime_src/core/common/api/context_mgr.cpp
@@ -76,7 +76,7 @@ class device_context_mgr
   };
 
   std::mutex m_mutex;
-  std::map<xcl_hwctx_handle, ctx> m_ctx;
+  std::map<xrt_hwctx_handle, ctx> m_ctx;
   std::condition_variable m_cv;
   xrt_core::device* m_device;
 
@@ -94,7 +94,7 @@ public:
   open(const xrt::hw_context& hwctx, const std::string& ipname)
   {
     std::unique_lock<std::mutex> ul(m_mutex);
-    auto& ctx = m_ctx[static_cast<xcl_hwctx_handle>(hwctx)];
+    auto& ctx = m_ctx[static_cast<xrt_hwctx_handle>(hwctx)];
     while (ctx.get(ipname)) {
       if (m_cv.wait_for(ul, 100ms) == std::cv_status::timeout)
         throw std::runtime_error("aquiring cu context timed out");
@@ -111,7 +111,7 @@ public:
   close(const xrt::hw_context& hwctx, cuidx_type ipidx)
   {
     std::lock_guard<std::mutex> lk(m_mutex);
-    auto& ctx = m_ctx[static_cast<xcl_hwctx_handle>(hwctx)];
+    auto& ctx = m_ctx[static_cast<xrt_hwctx_handle>(hwctx)];
     if (!ctx.get(ipidx))
       throw std::runtime_error("ctx " + std::to_string(ipidx.index) + " not open");
 

--- a/src/runtime_src/core/common/api/hw_queue.cpp
+++ b/src/runtime_src/core/common/api/hw_queue.cpp
@@ -588,7 +588,7 @@ namespace {
 // Manage hw_queue implementations.
 // For time being there is only one hw_queue per hw_context
 // Use static map with weak pointers to implementation.
-using hwc2hwq_type = std::map<xcl_hwctx_handle, std::weak_ptr<xrt_core::hw_queue_impl>>;
+using hwc2hwq_type = std::map<xrt_hwctx_handle, std::weak_ptr<xrt_core::hw_queue_impl>>;
 using queue_ptr = std::shared_ptr<xrt_core::hw_queue_impl>;
 static std::map<const xrt_core::device*, hwc2hwq_type> dev2hwc;  // per device
 static std::mutex mutex;
@@ -629,12 +629,12 @@ static std::shared_ptr<xrt_core::hw_queue_impl>
 get_hw_queue_impl(const xrt::hw_context& hwctx)
 {
   auto device = xrt_core::hw_context_int::get_core_device_raw(hwctx);
-  auto hwctx_hdl = static_cast<xcl_hwctx_handle>(hwctx);
+  auto hwctx_hdl = static_cast<xrt_hwctx_handle>(hwctx);
   std::lock_guard lk(mutex);
   auto& queues = dev2hwc[device];
   auto hwqimpl = queues[hwctx_hdl].lock();
   if (!hwqimpl) {
-    auto hwqueue_hdl = device->create_hw_queue(static_cast<xcl_hwctx_handle>(hwctx));
+    auto hwqueue_hdl = device->create_hw_queue(static_cast<xrt_hwctx_handle>(hwctx));
     queues[hwctx_hdl] = hwqimpl = (hwqueue_hdl == XRT_NULL_HWQUEUE)
       ? get_kds_device_nolock(queues, device)
       : queue_ptr{new xrt_core::qds_device(device, hwqueue_hdl)};

--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -143,11 +143,11 @@ public:
     return m_device;
   }
 
-  xcl_hwctx_handle
+  xrt_hwctx_handle
   get_hwctx_handle() const
   {
     return (m_hwctx)
-      ? static_cast<xcl_hwctx_handle>(m_hwctx)
+      ? static_cast<xrt_hwctx_handle>(m_hwctx)
       : XRT_NULL_HWCTX;
   }
 

--- a/src/runtime_src/core/common/api/xrt_hw_context.cpp
+++ b/src/runtime_src/core/common/api/xrt_hw_context.cpp
@@ -28,7 +28,7 @@ class hw_context_impl
   struct ctx_handle
   {
     const xrt_core::device* m_device;
-    xcl_hwctx_handle m_hdl;
+    xrt_hwctx_handle m_hdl;
     bool m_destroy_context = true;
 
     ctx_handle(const xrt_core::device* device, const xrt::uuid& uuid, const qos_type& qos, access_mode mode)
@@ -116,8 +116,8 @@ void
     return m_mode;
   }
 
-  xcl_hwctx_handle
-  get_xcl_handle() const
+  xrt_hwctx_handle
+  get_xrt_handle() const
   {
     return m_ctx_handle.m_hdl;
   }
@@ -195,9 +195,9 @@ get_mode() const
 }
 
 hw_context::
-operator xcl_hwctx_handle() const
+operator xrt_hwctx_handle() const
 {
-  return get_handle()->get_xcl_handle();
+  return get_handle()->get_xrt_handle();
 }
 
 } // xrt

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -557,11 +557,11 @@ public:
     // hwctx handle, implying that even for same handle index, the CU
     // should be opened again if the device is different
     using ctx_ips = std::map<std::string, std::weak_ptr<ip_context>>;
-    using ctx_to_ips = std::map<xcl_hwctx_handle, ctx_ips>;
+    using ctx_to_ips = std::map<xrt_hwctx_handle, ctx_ips>;
     static std::mutex mutex;
     static std::map<xrt_core::device*, ctx_to_ips> dev2ips;
     auto device = xrt_core::hw_context_int::get_core_device_raw(hwctx);
-    auto ctxhdl = static_cast<xcl_hwctx_handle>(hwctx);
+    auto ctxhdl = static_cast<xrt_hwctx_handle>(hwctx);
     std::lock_guard<std::mutex> lk(mutex);
     auto& ctx2ips = dev2ips[device]; // hwctx handle -> [ip_context]*
     auto& ips = ctx2ips[ctxhdl];     // ipname -> ip_context
@@ -611,7 +611,7 @@ public:
   slot_id
   get_slot() const
   {
-    return static_cast<xcl_hwctx_handle>(m_hwctx);
+    return static_cast<xrt_hwctx_handle>(m_hwctx);
   }
 
   // Check if arg is connected to specified memory bank
@@ -902,11 +902,11 @@ public:
     return m_execbuf.first;
   }
 
-  xcl_hwctx_handle
+  xrt_hwctx_handle
   get_hwctx_handle() const override
   {
     return (m_hwctx)
-       ? static_cast<xcl_hwctx_handle>(m_hwctx)
+       ? static_cast<xrt_hwctx_handle>(m_hwctx)
        : XRT_NULL_HWCTX;
   }
 

--- a/src/runtime_src/core/common/device.cpp
+++ b/src/runtime_src/core/common/device.cpp
@@ -238,7 +238,7 @@ update_cu_info()
     // It assumes that m_xclbin is the single xclbin and that
     // there is only one default slot with number 0.
     auto ip_layout = get_axlf_section<const ::ip_layout*>(IP_LAYOUT);
-    auto& cu2idx = m_cu2idx[0]; // default slot 0
+    auto& cu2idx = m_cu2idx[0u]; // default slot 0
     if (ip_layout != nullptr) {
       m_cus = xclbin::get_cus(ip_layout);
       cu2idx = xclbin::get_cu_indices(ip_layout);

--- a/src/runtime_src/core/common/device.h
+++ b/src/runtime_src/core/common/device.h
@@ -13,6 +13,7 @@
 #include "scope_guard.h"
 #include "uuid.h"
 
+#include "core/include/xcl_hwctx.h"
 #include "core/include/xrt.h"
 #include "core/include/experimental/xrt_xclbin.h"
 
@@ -45,7 +46,7 @@ class device : public ishim
   class xclbin_map
   {
   public:
-    using slot_id = uint32_t;
+    using slot_id = xrt_hwctx_handle;
 
   private:
     std::map<slot_id, xrt::uuid> m_slot2uuid;
@@ -84,7 +85,7 @@ class device : public ishim
     {
       auto itr = m_slot2uuid.find(slot);
       if (itr == m_slot2uuid.end())
-        throw error("No xclbin in slot '" + std::to_string(slot) + "'");
+        throw error("No xclbin in slot");
 
       return get((*itr).second);
     }

--- a/src/runtime_src/core/common/ishim.h
+++ b/src/runtime_src/core/common/ishim.h
@@ -139,11 +139,11 @@ struct ishim
   user_reset(xclResetKind kind) = 0;
 
   virtual cuidx_type
-  open_cu_context(xcl_hwctx_handle, const std::string& /*cuname*/)
+  open_cu_context(xrt_hwctx_handle, const std::string& /*cuname*/)
   { throw not_supported_error{__func__}; }
 
   virtual void
-  close_cu_context(xcl_hwctx_handle, cuidx_type /*ip_index*/)
+  close_cu_context(xrt_hwctx_handle, cuidx_type /*ip_index*/)
   { throw not_supported_error{__func__}; }
 
   // Deprecated API to be removed when all shims manage a hwctx handle
@@ -163,7 +163,7 @@ struct ishim
   open_cu_context_wrap(const xrt::hw_context& hwctx, const std::string& cuname)
   {
     try {
-      return open_cu_context(static_cast<xcl_hwctx_handle>(hwctx), cuname);
+      return open_cu_context(static_cast<xrt_hwctx_handle>(hwctx), cuname);
     }
     catch (const not_supported_error&) {
       return open_cu_context(hwctx, cuname);
@@ -174,7 +174,7 @@ struct ishim
   close_cu_context_wrap(const xrt::hw_context& hwctx, cuidx_type ip_index)
   {
     try {
-      close_cu_context(static_cast<xcl_hwctx_handle>(hwctx), ip_index);
+      close_cu_context(static_cast<xrt_hwctx_handle>(hwctx), ip_index);
     }
     catch (const not_supported_error&) {
       close_cu_context(hwctx, ip_index);
@@ -189,17 +189,17 @@ struct ishim
   // cannot be created for that xclbin.  This function throws
   // not_supported_error, if either not implemented or an xclbin
   // was explicitly loaded using load_xclbin
-  virtual xcl_hwctx_handle
+  virtual xrt_hwctx_handle
   create_hw_context(const xrt::uuid& /*xclbin_uuid*/, const xrt::hw_context::qos_type& /*qos*/, xrt::hw_context::access_mode /*mode*/) const
   { throw not_supported_error{__func__}; }
 
   virtual void
-  destroy_hw_context(xcl_hwctx_handle /*ctxhdl*/) const
+  destroy_hw_context(xrt_hwctx_handle /*ctxhdl*/) const
   { throw not_supported_error{__func__}; }
 
   // Return default sentinel for legacy platforms without hw_queue support
   virtual xcl_hwqueue_handle
-  create_hw_queue(xcl_hwctx_handle) const
+  create_hw_queue(xrt_hwctx_handle) const
   { return XRT_NULL_HWQUEUE; }
 
   // Default noop for legacy platforms without hw_queue support
@@ -229,7 +229,7 @@ struct ishim
   // Allocate a bo within ctx.  This is opt-in, currently reverts to
   // legacy alloc_bo
   virtual xrt_buffer_handle
-  alloc_bo(xcl_hwctx_handle, size_t size, unsigned int flags)
+  alloc_bo(xrt_hwctx_handle, size_t size, unsigned int flags)
   {
     return alloc_bo(size, flags);
   }
@@ -237,7 +237,7 @@ struct ishim
   // Allocate a userptr bo within ctx.  This is opt-in, currently
   // reverts to legacy alloc_bo
   virtual xrt_buffer_handle
-  alloc_bo(xcl_hwctx_handle, void* userptr, size_t size, unsigned int flags)
+  alloc_bo(xrt_hwctx_handle, void* userptr, size_t size, unsigned int flags)
   {
     return alloc_bo(userptr, size, flags);
   }
@@ -245,7 +245,7 @@ struct ishim
   // Execute a command bo within a ctx.  This is opt-in,  if not supported, then
   // just call legacy exec_buf without the hardware context.
   virtual void
-  exec_buf(xrt_buffer_handle boh, xcl_hwctx_handle /*ctxhdl*/)
+  exec_buf(xrt_buffer_handle boh, xrt_hwctx_handle /*ctxhdl*/)
   {
     exec_buf(boh);
   }

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -9,6 +9,7 @@
 #include "uuid.h"
 
 #include "core/include/xclerr_int.h"
+#include "core/include/xcl_hwctx.h"
 
 #include <iomanip>
 #include <map>
@@ -2936,7 +2937,7 @@ struct extended_vmr_status : request
 // from xclbin uuid to the slot index created by the driver
 struct xclbin_slots : request
 {
-  using slot_id = uint32_t;
+  using slot_id = xrt_hwctx_handle;
 
   struct slot_info {
     slot_id slot;

--- a/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/shim.cxx
@@ -2179,7 +2179,7 @@ open_cu_context(const xrt::hw_context& hwctx, const std::string& cuname)
   // regular flow.  Default access mode to shared unless explicitly
   // exclusive.
   auto shared = (hwctx.get_mode() != xrt::hw_context::access_mode::exclusive);
-  auto ctxhdl = static_cast<xcl_hwctx_handle>(hwctx);
+  auto ctxhdl = static_cast<xrt_hwctx_handle>(hwctx);
   auto cuidx = mCoreDevice->get_cuidx(ctxhdl, cuname);
   xclOpenContext(hwctx.get_xclbin_uuid().get(), cuidx.index, shared);
 

--- a/src/runtime_src/core/edge/user/device_linux.cpp
+++ b/src/runtime_src/core/edge/user/device_linux.cpp
@@ -361,7 +361,7 @@ struct xclbin_slots
       if (std::distance(tokens.begin(), tokens.end()) != 2)
         throw xrt_core::query::sysfs_error("xclbinid sysfs node corrupted");
 
-      slot_info data = { 0 };
+      slot_info data {};
       tokenizer::iterator tok_it = tokens.begin();
       data.slot = std::stoi(std::string(*tok_it++));
       data.uuid = std::string(*tok_it++);

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -1125,7 +1125,7 @@ open_cu_context(const xrt::hw_context& hwctx, const std::string& cuname)
   // regular flow.  Default access mode to shared unless explicitly
   // exclusive.
   auto shared = (hwctx.get_mode() != xrt::hw_context::access_mode::exclusive);
-  auto ctxhdl = static_cast<xcl_hwctx_handle>(hwctx);
+  auto ctxhdl = static_cast<xrt_hwctx_handle>(hwctx);
   auto cuidx = mCoreDevice->get_cuidx(ctxhdl, cuname);
   xclOpenContext(hwctx.get_xclbin_uuid().get(), cuidx.index, shared);
 

--- a/src/runtime_src/core/include/shim_int.h
+++ b/src/runtime_src/core/include/shim_int.h
@@ -54,7 +54,7 @@ void
 close_cu_context(xclDeviceHandle handle, const xrt::hw_context& hwctx, xrt_core::cuidx_type cuidx);
 
 // create_hw_context() -
-xcl_hwctx_handle // ctxhdl aka slotidx
+xrt_hwctx_handle // ctxhdl aka slotidx
 create_hw_context(xclDeviceHandle handle,
                   const xrt::uuid& xclbin_uuid,
                   const xrt::hw_context::qos_type& qos,
@@ -62,7 +62,7 @@ create_hw_context(xclDeviceHandle handle,
 
 // dsstroy_hw_context() -
 void
-destroy_hw_context(xclDeviceHandle handle, xcl_hwctx_handle ctxhdl);
+destroy_hw_context(xclDeviceHandle handle, xrt_hwctx_handle ctxhdl);
 
 // create_hw_queue() -
 xcl_hwqueue_handle
@@ -86,7 +86,7 @@ wait_command(xclDeviceHandle handle, xcl_hwqueue_handle qhdl, xclBufferHandle cm
 
 // exec_buf() - Exec Buf with hw ctx handle.
 void
-exec_buf(xclDeviceHandle handle, xrt_buffer_handle bohdl, xcl_hwctx_handle ctxhdl);
+exec_buf(xclDeviceHandle handle, xrt_buffer_handle bohdl, xrt_hwctx_handle ctxhdl);
 }} // shim_int, xrt
 
 #endif

--- a/src/runtime_src/core/include/xcl_hwctx.h
+++ b/src/runtime_src/core/include/xcl_hwctx.h
@@ -1,33 +1,46 @@
 // SPDX-License-Identifier: Apache-2.0
-// SPDX-License-Identifier: GPL-2.0
 // Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
 #ifndef XCL_HWCTX_H_
 #define XCL_HWCTX_H_
 
-// Definitions related to HW context shared between user space XRT and
-// Linux kernel driver.  The header file is exported as underlying
-// types are exposed in xrt::hw_context::qos definition.
+#include <cstdint>
 
 #ifdef __cplusplus
-# include <cstdint>
-extern "C" {
-#else
-# if defined(__KERNEL__)
-#  include <linux/types.h>
-# else
-#  include <stdint.h>
-# endif
+
+#ifdef _WIN32
+# pragma warning( push )
+# pragma warning( disable : 4201 )
 #endif
 
-// Underlying representation of a hardware context handle.
+// Shim level representation of a hardware context handle is an opaque
+// pointer, e.g. a void*, but when the handle is exchanged between
+// shim and XRT common layer it is wrapped in a typed
+// xrt_hwctx_handle.
 //
-// The context handle is among other things used with / encoded in
-// buffer object flags.
-typedef uint32_t xcl_hwctx_handle;
-#define XRT_NULL_HWCTX 0xffffffff
+// The struct allows the handle to be both a true pointer to some
+// opaque structure managed by shim, or a slot index for legacy
+// reasons.
+struct xrt_hwctx_handle
+{
+  union {
+    void* handle;
+    uint64_t slot;
+  };
 
-#ifdef __cplusplus
-}
+  xrt_hwctx_handle() : handle(nullptr) {}
+  xrt_hwctx_handle(void* hdl) : handle(hdl) {}
+  xrt_hwctx_handle(uint32_t slotidx) : slot(slotidx) {}
+  operator void* () const { return handle; }
+  operator uint32_t () const { return static_cast<uint32_t>(slot); }
+  bool operator < (const xrt_hwctx_handle& rhs) const { return handle < rhs.handle; }
+};
+
+const xrt_hwctx_handle XRT_NULL_HWCTX {nullptr};
+
+#ifdef _WIN32
+# pragma warning( pop )
 #endif
+
+#endif // __cplusplus
 
 #endif

--- a/src/runtime_src/core/include/xrt/xrt_hw_context.h
+++ b/src/runtime_src/core/include/xrt/xrt_hw_context.h
@@ -140,7 +140,7 @@ public:
   // Undocumented internal access to low level context handle
   // Subject to change without warning
   XRT_API_EXPORT
-  explicit operator xcl_hwctx_handle () const;
+  explicit operator xrt_hwctx_handle () const;
   /// @endcond
 };
 

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
@@ -808,7 +808,7 @@ namespace xclcpuemhal2
         aiesim_sock = nullptr;
       else
         aiesim_sock = new unix_socket("AIESIM_SOCKETID");
-        
+
     }
 
     return 0;
@@ -2534,7 +2534,7 @@ namespace xclcpuemhal2
     // regular flow.  Default access mode to shared unless explicitly
     // exclusive.
     auto shared = (hwctx.get_mode() != xrt::hw_context::access_mode::exclusive);
-    auto ctxhdl = static_cast<xcl_hwctx_handle>(hwctx);
+    auto ctxhdl = static_cast<xrt_hwctx_handle>(hwctx);
     auto cuidx = mCoreDevice->get_cuidx(ctxhdl, cuname);
     xclOpenContext(hwctx.get_xclbin_uuid().get(), cuidx.index, shared);
 

--- a/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/device_hwemu.h
+++ b/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/device_hwemu.h
@@ -36,7 +36,7 @@ private:
   virtual const query::request&
   lookup_query(query::key_type query_key) const;
 
-  uint32_t // ctx handle aka slotidx
+  xrt_hwctx_handle
   create_hw_context(const xrt::uuid& xclbin_uuid,
                     const xrt::hw_context::qos_type& qos,
                     xrt::hw_context::access_mode mode) const override
@@ -45,7 +45,7 @@ private:
   }
 
   void
-  destroy_hw_context(uint32_t ctxhdl) const override
+  destroy_hw_context(xrt_hwctx_handle ctxhdl) const override
   {
     xrt::shim_int::destroy_hw_context(get_device_handle(), ctxhdl);
   }

--- a/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/halapi.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/halapi.cxx
@@ -45,7 +45,7 @@ close_cu_context(xclDeviceHandle handle, const xrt::hw_context& hwctx, xrt_core:
   return shim->close_cu_context(hwctx, cuidx);
 }
 
-uint32_t // ctxhdl aka slotidx
+xrt_hwctx_handle
 create_hw_context(xclDeviceHandle handle,
                   const xrt::uuid& xclbin_uuid,
                   const xrt::hw_context::qos_type& qos,
@@ -56,7 +56,7 @@ create_hw_context(xclDeviceHandle handle,
 }
 
 void
-destroy_hw_context(xclDeviceHandle handle, uint32_t ctxhdl)
+destroy_hw_context(xclDeviceHandle handle, xrt_hwctx_handle ctxhdl)
 {
   auto shim = get_shim_object(handle);
   shim->destroy_hw_context(ctxhdl);

--- a/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.cxx
@@ -205,8 +205,8 @@ namespace xclhwemhal2 {
       std::string line;
       while (std::getline(ifs, line)) {
         // If xsim is terminated by logging in simulate.log then call xclClose to properly clean all instances, threads.
-        if ( (std::string::npos != line.find("Exiting xsim")) || 
-             (std::string::npos != line.find("ERROR")) 
+        if ( (std::string::npos != line.find("Exiting xsim")) ||
+             (std::string::npos != line.find("ERROR"))
            ) {
                   std::cout << "SIMULATION EXITED" << std::endl;
                   lstatus = -1;
@@ -215,12 +215,12 @@ namespace xclhwemhal2 {
         }
         for (auto& matchString : myvector) {
           std::string::size_type index = line.find(matchString);
-          if (index == std::string::npos) 
+          if (index == std::string::npos)
             continue;
-          
+
           if(std::find(parsedMsgs.begin(), parsedMsgs.end(), line) != parsedMsgs.end())
             continue;
-          
+
           logMessage(line);
           parsedMsgs.push_back(line);
         }
@@ -763,7 +763,7 @@ namespace xclhwemhal2 {
           logMessage(dMsg, 0);
           throw std::runtime_error(" Simulator did not start/exited, please simulate.log in .run directory!");
         }
-        
+
       }
 
       if (lWaveform == xclemulation::debug_mode::batch)
@@ -1020,7 +1020,7 @@ namespace xclhwemhal2 {
 
           if (!qemu_dtb.empty())
             launcherArgs += " -qemu-dtb " + qemu_dtb;
-        
+
           if (!pmc_dtb.empty())
             launcherArgs += " -pmc-dtb  " + pmc_dtb;
 
@@ -1057,15 +1057,15 @@ namespace xclhwemhal2 {
         //if (!xclemulation::file_exists(sim_file))
         if (!boost::filesystem::exists(sim_file))
           sim_file = "simulate.sh";
-          
+
         if (mLogStream.is_open() )
             mLogStream << __TIME__ <<"\t"<< __func__ << " The simulate script is "  <<sim_file  << std::endl;
 
         int r = execl(sim_file.c_str(), sim_file.c_str(), simMode, NULL);
         if (r == -1) {
-          std::cerr << "FATAL ERROR : Simulation process did not launch" << std::endl; 
+          std::cerr << "FATAL ERROR : Simulation process did not launch" << std::endl;
           exit(1);
-        } 
+        }
         exit(0);
       }
 #endif
@@ -1084,7 +1084,7 @@ namespace xclhwemhal2 {
     if (parseLog() != 0) {
       if (mLogStream.is_open())
         mLogStream << __func__ << " ERROR: [HW-EMU 26] Simulator is NOT started so exiting the application! " << std::endl;
-        
+
       // If no simulator running then no need to try a connection, hence exit with a failure now.
       //throw std::runtime_error(" Simulator did not start/exited, please refer simulate.log in .run directory!");
       exit(EXIT_FAILURE);
@@ -1096,7 +1096,7 @@ namespace xclhwemhal2 {
     sock = std::make_shared<unix_socket>();
     set_simulator_started(true);
     sock->monitor_socket();
-    
+
     //Thread to fetch messages from Device to display on host
     if (mMessengerThreadStarted == false) {
       mMessengerThread = std::thread([this]() { messagesThread(); } );
@@ -1216,7 +1216,7 @@ namespace xclhwemhal2 {
     }
   }
 
-  void HwEmShim::getDtbs(const std::string& emu_data_path, std::string& qemu_dtb, std::string& pmc_dtb) 
+  void HwEmShim::getDtbs(const std::string& emu_data_path, std::string& qemu_dtb, std::string& pmc_dtb)
   {
     boost::filesystem::path dts_dir = emu_data_path;
     boost::filesystem::directory_iterator end_itr;
@@ -1866,8 +1866,8 @@ namespace xclhwemhal2 {
       return;
     }
     // RPC calls will not be made in resetprogram
-    // resetProgram has to be called in xclclose because all running threads will be exited gracefully 
-    // which results clean exit of driver code.  
+    // resetProgram has to be called in xclclose because all running threads will be exited gracefully
+    // which results clean exit of driver code.
       resetProgram(false);
 
 
@@ -3394,7 +3394,7 @@ open_cu_context(const xrt::hw_context& hwctx, const std::string& cuname)
   // regular flow.  Default access mode to shared unless explicitly
   // exclusive.
   auto shared = (hwctx.get_mode() != xrt::hw_context::access_mode::exclusive);
-  auto ctxhdl = static_cast<xcl_hwctx_handle>(hwctx);
+  auto ctxhdl = static_cast<xrt_hwctx_handle>(hwctx);
   auto cuidx = mCoreDevice->get_cuidx(ctxhdl, cuname);
   xclOpenContext(hwctx.get_xclbin_uuid().get(), cuidx.index, shared);
 
@@ -3411,7 +3411,7 @@ close_cu_context(const xrt::hw_context& hwctx, xrt_core::cuidx_type cuidx)
 
 // aka xclCreateHWContext, internal shim API for native C++ applications only
 // Once properly implemented, this API should throw on error
-uint32_t // ctx handle aka slot idx
+xrt_hwctx_handle
 HwEmShim::
 create_hw_context(const xrt::uuid&, const xrt::hw_context::qos_type&, xrt::hw_context::access_mode)
 {
@@ -3423,7 +3423,7 @@ create_hw_context(const xrt::uuid&, const xrt::hw_context::qos_type&, xrt::hw_co
 // Once properly implemented, this API should throw on error
 void
 HwEmShim::
-destroy_hw_context(uint32_t ctxhdl)
+destroy_hw_context(xrt_hwctx_handle ctxhdl)
 {
   // Explicit hardware contexts are not yet supported
   throw xrt_core::ishim::not_supported_error{__func__};

--- a/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.h
+++ b/src/runtime_src/core/pcie/emulation/hw_em/alveo_shim/shim.h
@@ -144,12 +144,12 @@ using addr_type = uint64_t;
       close_cu_context(const xrt::hw_context& hwctx, xrt_core::cuidx_type cuidx);
 
       // aka xclCreateHWContext, internal shim API for native C++ applications only
-      uint32_t // ctx handle aka slot idx
+      xrt_hwctx_handle
       create_hw_context(const xrt::uuid&, const xrt::hw_context::qos_type&, xrt::hw_context::access_mode);
 
       // aka xclDestroyHWContext, internal shim API for native C++ applications only
       void
-      destroy_hw_context(uint32_t ctxhdl);
+      destroy_hw_context(xrt_hwctx_handle ctxhdl);
 
       // aka xclRegisterXclbin, internal shim API for native C++ applications only
       void

--- a/src/runtime_src/core/pcie/linux/device_linux.h
+++ b/src/runtime_src/core/pcie/linux/device_linux.h
@@ -59,7 +59,7 @@ public:
   xrt_buffer_handle
   import_bo(pid_t pid, xclBufferExportHandle ehdl) override;
 
-  uint32_t // ctx handle aka slotidx
+  xrt_hwctx_handle
   create_hw_context(const xrt::uuid& xclbin_uuid,
                     const xrt::hw_context::qos_type& qos,
                     xrt::hw_context::access_mode mode) const override
@@ -68,7 +68,7 @@ public:
   }
 
   void
-  destroy_hw_context(uint32_t ctxhdl) const override
+  destroy_hw_context(xrt_hwctx_handle ctxhdl) const override
   {
     xrt::shim_int::destroy_hw_context(get_device_handle(), ctxhdl);
   }
@@ -81,7 +81,7 @@ public:
 
   // Exec Buf with hw ctx handle.
   void
-  exec_buf(xrt_buffer_handle boh, xcl_hwctx_handle ctxhdl) override
+  exec_buf(xrt_buffer_handle boh, xrt_hwctx_handle ctxhdl) override
   {
       xrt::shim_int::exec_buf(get_device_handle(), boh, ctxhdl);
   }

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -2154,7 +2154,7 @@ open_cu_context(const xrt::hw_context& hwctx, const std::string& cuname)
   // regular flow.  Default access mode to shared unless explicitly
   // exclusive.
   auto shared = (hwctx.get_mode() != xrt::hw_context::access_mode::exclusive);
-  auto ctxhdl = static_cast<xcl_hwctx_handle>(hwctx);
+  auto ctxhdl = static_cast<xrt_hwctx_handle>(hwctx);
   auto cuidx = mCoreDevice->get_cuidx(ctxhdl, cuname);
   xclOpenContext(hwctx.get_xclbin_uuid().get(), cuidx.index, shared);
 
@@ -2202,7 +2202,7 @@ register_xclbin(const xrt::xclbin&)
 // Exec Buf with hw ctx handle.
 void
 shim::
-exec_buf(xclBufferHandle boh, xcl_hwctx_handle ctxhdl)
+exec_buf(xclBufferHandle boh, xrt_hwctx_handle ctxhdl)
 {
   // TODO: Implement new function, for now just call legacy xclExecBuf().
   if (auto ret = xclExecBuf(boh))
@@ -2236,7 +2236,7 @@ close_cu_context(xclDeviceHandle handle, const xrt::hw_context& hwctx, xrt_core:
   return shim->close_cu_context(hwctx, cuidx);
 }
 
-uint32_t // ctxhdl aka slotidx
+xrt_hwctx_handle
 create_hw_context(xclDeviceHandle handle,
                   const xrt::uuid& xclbin_uuid,
                   const xrt::hw_context::qos_type& qos,
@@ -2247,7 +2247,7 @@ create_hw_context(xclDeviceHandle handle,
 }
 
 void
-destroy_hw_context(xclDeviceHandle handle, uint32_t ctxhdl)
+destroy_hw_context(xclDeviceHandle handle, xrt_hwctx_handle ctxhdl)
 {
   auto shim = get_shim_object(handle);
   shim->destroy_hw_context(ctxhdl);
@@ -2262,7 +2262,7 @@ register_xclbin(xclDeviceHandle handle, const xrt::xclbin& xclbin)
 
 // Exec Buf with hw ctx handle.
 void
-exec_buf(xclDeviceHandle handle, xrt_buffer_handle bohdl, xcl_hwctx_handle ctxhdl)
+exec_buf(xclDeviceHandle handle, xrt_buffer_handle bohdl, xrt_hwctx_handle ctxhdl)
 {
     auto shim = get_shim_object(handle);
     return shim->exec_buf(to_xclBufferHandle(bohdl), ctxhdl);

--- a/src/runtime_src/core/pcie/linux/shim.h
+++ b/src/runtime_src/core/pcie/linux/shim.h
@@ -161,7 +161,7 @@ public:
 
   // Exec Buf with hw ctx handle.
   void
-  exec_buf(xclBufferHandle boh, xcl_hwctx_handle ctxhdl);
+  exec_buf(xclBufferHandle boh, xrt_hwctx_handle ctxhdl);
 private:
   std::shared_ptr<xrt_core::device> mCoreDevice;
   std::shared_ptr<xrt_core::pci::dev> mDev;

--- a/src/runtime_src/core/pcie/noop/device_noop.h
+++ b/src/runtime_src/core/pcie/noop/device_noop.h
@@ -24,14 +24,14 @@ private:
   virtual const query::request&
   lookup_query(query::key_type query_key) const override;
 
-  uint32_t // ctx handle aka slotidx
+  xrt_hwctx_handle
   create_hw_context(const xrt::uuid& xclbin_uuid, const xrt::hw_context::qos_type& qos, xrt::hw_context::access_mode mode) const override
   {
     return xrt::shim_int::create_hw_context(get_device_handle(), xclbin_uuid, qos, mode);
   }
 
   void
-  destroy_hw_context(uint32_t ctxhdl) const override
+  destroy_hw_context(xrt_hwctx_handle ctxhdl) const override
   {
     xrt::shim_int::destroy_hw_context(get_device_handle(), ctxhdl);
   }

--- a/src/runtime_src/core/pcie/windows/alveo/shim.cpp
+++ b/src/runtime_src/core/pcie/windows/alveo/shim.cpp
@@ -1388,7 +1388,7 @@ done:
     // regular flow.  Default access mode to shared unless explicitly
     // exclusive.
     auto shared = (hwctx.get_mode() != xrt::hw_context::access_mode::exclusive);
-    auto ctxhdl = static_cast<xcl_hwctx_handle>(hwctx);
+    auto ctxhdl = static_cast<xrt_hwctx_handle>(hwctx);
     auto cuidx = m_core_device->get_cuidx(ctxhdl, cuname);
     open_cu_context(hwctx.get_xclbin_uuid().get(), cuidx.index, shared);
 

--- a/src/runtime_src/xrt/xrt++/xrtexec.cpp
+++ b/src/runtime_src/xrt/xrt++/xrtexec.cpp
@@ -189,7 +189,7 @@ struct command::impl : xrt_core::command
     return m_execbuf.first;
   }
 
-  virtual xcl_hwctx_handle
+  virtual xrt_hwctx_handle
   get_hwctx_handle() const
   {
       return XRT_NULL_HWCTX;


### PR DESCRIPTION
#### Problem solved by the commit
Use opaque pointer for hwctx handle exchange between XRT coreutil and shim.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
In the original design of hwctx, the underlying handle was/is represented as an index (slot index).  The xrt::hw_context class encapsulates the handle and provides an abstraction API for host applications.   The slot index is encoded in the BO flags when BOs are created, which is the real reason for the handle had to be integral.  

However, in many cases the shim level implementation of create_hw_context has to manage auxiliary data associated with the hardware context and this data is best managed within a local struct in shim.   If the local struct is used as the handle itself, then book-keeping becomes simpler as the auxiliary data is readily available.  

This PR is a step in the direction of getting rid of the slot index representation.  Rather than encoding slot index in BO flags, #7165 and #7203 makes the hwctx explicit when BOs are constructed so integral type of hwctx handle is no longer required.

#### How problem was solved, alternative solutions (if any) and why they were rejected
This PR replaces the uint32_t typedef of xcl_hwctx_handle with a struct wrapping an opaque pointer managed by shim.  The struct is used to avoid ambiguity of simple void*, and also to transparently support legacy hwctx handled as a slot index.

#### Risks (if any) associated the changes in the commit
Minor, legacy integral slot index is still used.

#### What has been tested and how, request additional testing if necessary
Standard regression testing with OpenCL test cases and misc manual tests.

