### PR TITLE
CR-1134860 PCIE IO from host to DDR shared memory is too slow

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
@@ -145,6 +145,8 @@ struct xocl_xgq_vmr {
 	struct xgq	 	xgq_queue;
 	u64			xgq_io_hdl;
 	void __iomem		*xgq_payload_base;
+	resource_size_t		xgq_payload_base_start;
+	void __iomem		*xgq_payload_data_base;
 	void __iomem		*xgq_sq_base;
 	void __iomem		*xgq_ring_base;
 	void __iomem		*xgq_cq_base;
@@ -477,17 +479,44 @@ static inline bool xgq_device_is_ready(struct xocl_xgq_vmr *xgq)
 
 		memcpy_fromio(&xgq->xgq_vmr_shared_mem, xgq->xgq_payload_base,
 			sizeof(xgq->xgq_vmr_shared_mem));
-		if (xgq->xgq_vmr_shared_mem.vmr_magic_no == VMR_MAGIC_NO) {
-			rval = ioread32(xgq->xgq_payload_base +
-				xgq->xgq_vmr_shared_mem.vmr_status_off);
-			if (rval) {
-				XGQ_INFO(xgq, "ready after %d ms", interval * i);
-				return true;
-			}
-		}
+		if (xgq->xgq_vmr_shared_mem.vmr_magic_no != VMR_MAGIC_NO)
+			continue;
+
+		rval = ioread32(xgq->xgq_payload_base +
+			xgq->xgq_vmr_shared_mem.vmr_status_off);
+
+		if (!rval)
+			continue;
+
+		/* if service is ready, we remap the payload to
+		 * 1st segment: 0-> data, nocache
+		 * 2nd segment: data->end, wc (write combined)
+		 */
+		iounmap(xgq->xgq_payload_base);
+		xgq->xgq_payload_base = ioremap_nocache(
+			xgq->xgq_payload_base_start,
+			xgq->xgq_vmr_shared_mem.vmr_data_start);
+		XGQ_INFO(xgq, "remap nocache from 0x%llx, size 0x%x",
+			xgq->xgq_payload_base_start,
+			xgq->xgq_vmr_shared_mem.vmr_data_start);
+
+		xgq->xgq_payload_data_base = ioremap_wc(
+			xgq->xgq_payload_base_start +
+			xgq->xgq_vmr_shared_mem.vmr_data_start,
+			xgq->xgq_vmr_shared_mem.vmr_data_end -
+			xgq->xgq_vmr_shared_mem.vmr_data_start + 1);
+		XGQ_INFO(xgq, "remap wc from 0x%llx, size 0x%x",
+			xgq->xgq_payload_base_start +
+			xgq->xgq_vmr_shared_mem.vmr_data_start,
+			xgq->xgq_vmr_shared_mem.vmr_data_end -
+			xgq->xgq_vmr_shared_mem.vmr_data_start + 1);
+
+		XGQ_INFO(xgq, "ready after %d s", interval * i);
+		return true;
 	}
 
-	XGQ_ERR(xgq, "not ready after %d ms", interval * retry);
+	XGQ_ERR(xgq, "not ready after %d ms, magic:0x%X, status:%d", interval * retry,
+		xgq->xgq_vmr_shared_mem.vmr_magic_no, rval);
 	return false;
 }
 
@@ -824,18 +853,22 @@ static void shm_release_data(struct xocl_xgq_vmr *xgq)
 	up(&xgq->xgq_data_sema);
 }
 
-static void memcpy_to_device(struct xocl_xgq_vmr *xgq, u32 offset, const void *data,
+static void memcpy_to_device_wc(struct xocl_xgq_vmr *xgq, u32 offset, const void *data,
 	size_t len)
 {
-	void __iomem *dst = xgq->xgq_payload_base + offset;
+	void __iomem *dst = xgq->xgq_payload_data_base +
+		offset - xgq->xgq_vmr_shared_mem.vmr_data_start;
 
 	memcpy_toio(dst, data, len);
+	/* issue a read to trigger write combined data to be synced */
+	ioread32(dst);
 }
 
-static void memcpy_from_device(struct xocl_xgq_vmr *xgq, u32 offset, void *dst,
+static void memcpy_from_device_wc(struct xocl_xgq_vmr *xgq, u32 offset, void *dst,
 	size_t len)
 {
-	void __iomem *src = xgq->xgq_payload_base + offset;
+	void __iomem *src = xgq->xgq_payload_data_base +
+		offset - xgq->xgq_vmr_shared_mem.vmr_data_start;
 
 	memcpy_fromio(dst, src, len);
 }
@@ -934,7 +967,7 @@ static ssize_t xgq_transfer_data(struct xocl_xgq_vmr *xgq, const void *buf,
 	 * Note: if len == 0, it is PROGRAME_SCFW, no payload to copyin
 	 */
 	if (len > 0)
-		memcpy_to_device(xgq, address, buf, len);
+		memcpy_to_device_wc(xgq, address, buf, len);
 	payload->address = address;
 	payload->size = len;
 	payload->addr_type = XGQ_CMD_ADD_TYPE_AP_OFFSET;
@@ -1123,7 +1156,7 @@ static int xgq_log_page_fw(struct platform_device *pdev,
 				ret = -ENOMEM;
 				goto done;
 			}
-			memcpy_from_device(xgq, address, *fw, *fw_size);
+			memcpy_from_device_wc(xgq, address, *fw, *fw_size);
 			ret = 0;
 			XGQ_INFO(xgq, "loading fw from vmr size %ld", *fw_size);
 		}
@@ -1285,7 +1318,8 @@ static int xgq_firewall_op(struct platform_device *pdev, enum xgq_cmd_log_page_t
 			XGQ_ERR(xgq, "vmalloc failed, no memory");
 			goto done;
 		}
-		memcpy_from_device(xgq, address, log_msg, log_size);
+
+		memcpy_from_device_wc(xgq, address, log_msg, log_size);
 		log_msg[log_size] = '\0';
 
 		XGQ_ERR(xgq, "%s", log_msg);
@@ -1403,7 +1437,7 @@ static int vmr_info_query_op(struct platform_device *pdev,
 				ret = -ENOMEM;
 				goto done;
 			}
-			memcpy_from_device(xgq, address, info_data, info_size);
+			memcpy_from_device_wc(xgq, address, info_data, info_size);
 			info_data[info_size] = '\0'; /* terminate the string */
 
 			/* text buffer for sysfs node should be limited to PAGE_SIZE */
@@ -1751,10 +1785,17 @@ static int xgq_download_apu_bin(struct platform_device *pdev, char *buf,
 	size_t len)
 {
 	struct xocl_xgq_vmr *xgq = platform_get_drvdata(pdev);
+	struct timespec start, end;
 	int ret = 0;
 
+	getnstimeofday(&start);
 	ret = xgq_transfer_data(xgq, buf, len, 0,
 		XGQ_CMD_OP_LOAD_APUBIN, XOCL_XGQ_DOWNLOAD_TIME);
+	getnstimeofday(&end);
+
+	if (end.tv_sec - start.tv_sec > 10) {
+		XGQ_WARN(xgq, "download takes longer than 10 seconds");
+	}
 	if (ret != len) {
 		XGQ_ERR(xgq, "return %d, but request %ld", ret, len);
 		return -EIO;
@@ -2199,7 +2240,7 @@ static int xgq_collect_sensors(struct platform_device *pdev, int aid, int sid,
 	if (ret) {
 		XGQ_ERR(xgq, "ret %d", cmd->xgq_cmd_rcode);
 	} else {
-		memcpy_from_device(xgq, address, data_buf, len);
+		memcpy_from_device_wc(xgq, address, data_buf, len);
 	}
 
 done:
@@ -3164,10 +3205,18 @@ static int xgq_vmr_remove(struct platform_device *pdev)
 	fini_worker(&xgq->xgq_complete_worker);
 	fini_worker(&xgq->xgq_health_worker);
 
-	if (xgq->xgq_payload_base)
+	if (xgq->xgq_payload_base) {
 		iounmap(xgq->xgq_payload_base);
-	if (xgq->xgq_sq_base)
+		xgq->xgq_payload_base = NULL;
+	}
+	if (xgq->xgq_payload_data_base) {
+		iounmap(xgq->xgq_payload_data_base);
+		xgq->xgq_payload_data_base = NULL;
+	}
+	if (xgq->xgq_sq_base) {
 		iounmap(xgq->xgq_sq_base);
+		xgq->xgq_sq_base = NULL;
+	}
 
 	xocl_subdev_destroy_by_id(xdev, XOCL_SUBDEV_HWMON_SDM);
 
@@ -3306,6 +3355,7 @@ static int xgq_vmr_probe(struct platform_device *pdev)
 			strlen(NODE_XGQ_VMR_PAYLOAD_BASE))) {
 			xgq->xgq_payload_base = ioremap_nocache(res->start,
 				res->end - res->start + 1);
+			xgq->xgq_payload_base_start = res->start;
 		}
 	}
 
@@ -3319,8 +3369,13 @@ static int xgq_vmr_probe(struct platform_device *pdev)
 	xgq->xgq_cq_base = xgq->xgq_sq_base + XGQ_CQ_TAIL_POINTER;
 
 	ret = xgq_start_services(xgq);
-	if (ret)
+	if (ret) {
+		iounmap(xgq->xgq_sq_base);
+		xgq->xgq_sq_base = NULL;
+		iounmap(xgq->xgq_payload_base);
+		xgq->xgq_payload_base = NULL;
 		goto attach_failed;
+	}
 
 	/* init condition veriable */
 	init_completion(&xgq->xgq_irq_complete);


### PR DESCRIPTION
Signed-off-by: David Zhang <davidzha@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Chatted with Lizhi and Max, the map_bars are only for old legacy shell which is obsoleted.
If we want to use write combined ioremap, we have to make sure no other type of ioremap against same physical memory.
Thus, we 
1) remove map_bars
2) once xgq is ready, remap data physical memory into write combined, but keep other physical memory nocached.
We now can get 24x faster (12s vs 0.5s) APU download time.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Running my stress test over nights. (xbutil reset, xbutil valudate, xrt driver rmmod and modprobe).

#### Documentation impact (if any)
