### PR TITLE
CR-1147558 clock throttling percentage in the dmesg

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
@@ -1275,12 +1275,14 @@ static int xgq_firewall_op(struct platform_device *pdev, enum xgq_cmd_log_page_t
 	}
 
 	if (log_size != 0) {
-		char *log_msg = vmalloc(log_size);
+		char *log_msg = vmalloc(log_size + 1);
 		if (log_msg == NULL) {
-			XGQ_ERR(xgq, "vmalloc failed, no msg");
+			XGQ_ERR(xgq, "vmalloc failed, no memory");
 			goto done;
 		}
 		memcpy_from_device(xgq, address, log_msg, log_size);
+		log_msg[log_size] = '\0';
+
 		XGQ_ERR(xgq, "%s", log_msg);
 		vfree(log_msg);
 	}

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
@@ -1187,12 +1187,13 @@ static int xgq_firewall_op(struct platform_device *pdev, enum xgq_cmd_log_page_t
 	struct xocl_xgq_vmr *xgq = platform_get_drvdata(pdev);
 	struct xocl_xgq_vmr_cmd *cmd = NULL;
 	struct xgq_cmd_log_payload *payload = NULL;
+	struct xgq_cmd_cq_log_page_payload *log = NULL;
 	struct xgq_cmd_sq_hdr *hdr = NULL;
 	int ret = 0;
 	int id = 0;
 	u32 address = 0;
 	u32 len = 0;
-
+	u32 log_size = 0;
 	/*
 	 * avoid warning messages, skip periodic firewall check
 	 * when xgq service is halted
@@ -1259,29 +1260,29 @@ static int xgq_firewall_op(struct platform_device *pdev, enum xgq_cmd_log_page_t
 	ret = (cmd->xgq_cmd_rcode == -ETIME || cmd->xgq_cmd_rcode == -EINVAL) ?
 		0 : cmd->xgq_cmd_rcode;
 
-	if (ret) {
-		struct xgq_cmd_cq_log_page_payload *log = NULL;
-		u32 log_size = 0;
+	/*
+	 * No matter ret is 0 or non-zero, the device might return
+	 * error messages to print into the dmesg.
+	 */
+	log = (struct xgq_cmd_cq_log_page_payload *)&cmd->xgq_cmd_cq_payload;
+	log_size = log->count;
 
-		log = (struct xgq_cmd_cq_log_page_payload *)&cmd->xgq_cmd_cq_payload;
-		log_size = log->count;
+	if (log_size > len) {
+		XGQ_WARN(xgq, "return log size %d is greater than request %d",
+			log->count, len);
+		/* reset to valid shared memory size */
+		log_size = len;
+	}
 
-		if (log_size > len) {
-			XGQ_ERR(xgq, "return log size %d is greater than request %d",
-				log->count, len);
-			log_size = len;
-		} else if (log_size  == 0) {
-			XGQ_ERR(xgq, "no error message");
-		} else {
-			char *log_msg = vmalloc(log_size);
-			if (log_msg == NULL) {
-				XGQ_ERR(xgq, "vmalloc failed, no msg");
-				goto done;
-			}
-			memcpy_from_device(xgq, address, log_msg, log_size);
-			XGQ_ERR(xgq, "%s", log_msg);
-			vfree(log_msg);
+	if (log_size != 0) {
+		char *log_msg = vmalloc(log_size);
+		if (log_msg == NULL) {
+			XGQ_ERR(xgq, "vmalloc failed, no msg");
+			goto done;
 		}
+		memcpy_from_device(xgq, address, log_msg, log_size);
+		XGQ_ERR(xgq, "%s", log_msg);
+		vfree(log_msg);
 	}
 
 done:


### PR DESCRIPTION
Signed-off-by: David Zhang <davidzha@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
This is to support checking of both firewall and clock shutdown, clock throttling.
For clock throttling, it is non critical thus return value is 0.
However, we want to print dmesg by checking the log has data (count > 0).

For firewall and clock shutdown, those are critical and return value is non-zero.
They also have dmesg if count > 0.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
