### PR TITLE
CR-1147934: Fix seg fault at end of execution when profiling is enabled on some devices

### DIFF
--- a/src/runtime_src/core/pcie/linux/plugin/xdp/shim_callbacks.h
+++ b/src/runtime_src/core/pcie/linux/plugin/xdp/shim_callbacks.h
@@ -1,0 +1,75 @@
+/**
+ * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+// This file contains the callbacks to the various XDP plugins that deal
+// with retrieving data from the device, which need to be called from
+// the shim at various times.  Since all of the plugins are independent and
+// may or may not be loaded in different executions, we must call each plugins
+// function sequentially.  The functions themselves will simply return if
+// the plugin was not loaded, so there is minimal overhead when profiling
+// is turned off.
+
+#ifndef SHIM_CALLBACKS_DOT_H
+#define SHIM_CALLBACKS_DOT_H
+
+#include "aie_trace.h"
+#include "hal_device_offload.h"
+#include "pl_deadlock.h"
+
+namespace xdp {
+
+// The update_device callback should be called when a new xclbin has been
+// loaded onto a device.  It will call the profiling code to update the
+// profiling data structures with the information from the new xclbin.
+inline
+void update_device(void* handle)
+{
+  hal::update_device(handle);
+  aie::update_device(handle);
+  pl_deadlock::update_device(handle);
+}
+
+// The flush_device callback should be called just before a new xclbin
+// is loaded.  In the case where multiple xclbins are loaded in a single
+// application execution, this callback makes sure that all profiling
+// information is collected from a device before it is wiped out by the
+// xclbin reconfiguration and stored in the profiling data structures.
+inline
+void flush_device(void* handle)
+{
+  hal::flush_device(handle);
+  aie::flush_device(handle);
+  pl_deadlock::flush_device(handle);
+}
+
+// The finish_flush_device callback should be called in the destructor of
+// the shim object.  When the application is finishing and static objects are
+// being cleaned up, it is possible that the shim object is destroyed before
+// the profiling data structures are destroyed.  In that case, we make sure
+// that the final profiling data is flushed from the device into the profiling
+// data structures before the shim connection is destroyed so the profiling
+// side can process and dump the data.  If the profiling objects are destroyed
+// before the shim, these functions just return.
+inline
+void finish_flush_device(void* handle)
+{
+  hal::flush_device(handle);
+  aie::finish_flush_device(handle);
+}
+
+} // end namespace xdp
+
+#endif


### PR DESCRIPTION
#### Problem solved by the commit
On some devices and OS configurations, applications were crashing at the end of execution when PL profiling was turned on.  This was due to profiling trying to access information on the device after the hardware shim had been destroyed.  This pull request makes sure that any PL profiling information is offloaded to the profiling library before the shim is destroyed by adding a callback in the shim destructor.  This is necessary as when profiling dumps its information it requires the last data from the device.

This pull request also comments the shim functions and consolidates all of the individual profiling plugin callbacks into a single location in the plugin/xdp directory so they can scale without changing the shim.cpp file.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
The bug was discovered through daily regression testing.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Since the order of static objects destruction is undefined, the added callback handles the case when the shim is destroyed before profiling objects are destroyed.  If profiling objects are destroyed first, then these functions simply return when the shim is destroyed.

#### Risks (if any) associated the changes in the commit
Low risk as this structure of callbacks was in use for other profiling plugins.  When profiling is not enabled, the callbacks simply return so there is minimal overhead added.

#### What has been tested and how, request additional testing if necessary
The failing test case on hardware has been verified to be fixed with good profiling data being retrieved after the fix was applied.

#### Documentation impact (if any)
No documentation impact.