### PR TITLE
CR-1148012 fix hwmon device register & unregister sequence

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/hwmon_sdm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/hwmon_sdm.c
@@ -1203,28 +1203,28 @@ static int create_hwmon_sysfs(struct platform_device *pdev)
 	if (!sdm->supported)
 		return 0;
 
-	err = device_create_file(sdm->hwmon_dev, &name_attr.dev_attr);
-	if (err) {
-		xocl_err(&pdev->dev, "create attr name failed: 0x%x", err);
-		return err;
-	}
-
 	sdm->hwmon_dev = hwmon_device_register(&core->pdev->dev);
 	if (IS_ERR(sdm->hwmon_dev)) {
 		err = PTR_ERR(sdm->hwmon_dev);
 		xocl_err(&pdev->dev, "register sdm hwmon failed: 0x%x", err);
 		sdm->hwmon_dev = NULL;
-		goto failed;
+		return err;
 	}
 
 	dev_set_drvdata(sdm->hwmon_dev, sdm);
+
+	err = device_create_file(sdm->hwmon_dev, &name_attr.dev_attr);
+	if (err) {
+		xocl_err(&pdev->dev, "create attr name failed: 0x%x", err);
+		goto failed;
+	}
 
 	xocl_dbg(&pdev->dev, "created hwmon sysfs list");
 	sdm->sysfs_created = true;
 
 	return 0;
 failed:
-	device_remove_file(sdm->hwmon_dev, &name_attr.dev_attr);
+	hwmon_device_unregister(sdm->hwmon_dev);
 	sdm->hwmon_dev = NULL;
 	return err;
 }
@@ -1409,14 +1409,13 @@ static void destroy_hwmon_sysfs(struct platform_device *pdev)
 	if (!sdm->supported)
 		return;
 
-	sysfs_remove_group(&pdev->dev.kobj, &hwmon_sdm_bdinfo_attrgroup);
-
 	if (sdm->hwmon_dev) {
-		hwmon_device_unregister(sdm->hwmon_dev);
 		device_remove_file(sdm->hwmon_dev, &name_attr.dev_attr);
+		hwmon_device_unregister(sdm->hwmon_dev);
 		sdm->hwmon_dev = NULL;
 	}
 
+	sysfs_remove_group(&pdev->dev.kobj, &hwmon_sdm_bdinfo_attrgroup);
 }
 
 static int hwmon_sdm_probe(struct platform_device *pdev)
@@ -1432,16 +1431,8 @@ static int hwmon_sdm_probe(struct platform_device *pdev)
 	platform_set_drvdata(pdev, sdm);
 	sdm->pdev = pdev;
 	sdm->supported = true;
-	mutex_init(&sdm->sdm_lock);
-
-	/* create hwmon sysfs nodes */
-	err = create_hwmon_sysfs(pdev);
-	if (err) {
-		xocl_err(&pdev->dev, "hwmon_sdm hwmon_sysfs is failed, err: %d", err);
-		goto failed;
-	}
-
 	sdm->cache_expire_secs = HWMON_SDM_DEFAULT_EXPIRE_SECS;
+	mutex_init(&sdm->sdm_lock);
 
 	if (XGQ_DEV(xdev) == NULL) {
 		xocl_dbg(&pdev->dev, "in userpf driver");
@@ -1451,14 +1442,25 @@ static int hwmon_sdm_probe(struct platform_device *pdev)
 		sdm->privileged = true;
 	}
 
-	if (sysfs_create_group(&pdev->dev.kobj, &hwmon_sdm_bdinfo_attrgroup))
-		xocl_err(&pdev->dev, "unable to create sysfs group for bdinfo");
+	err = sysfs_create_group(&pdev->dev.kobj, &hwmon_sdm_bdinfo_attrgroup);
+	if (err) {
+		xocl_err(&pdev->dev, "unable to create sysfs group for bdinfo, err: %d", err);
+		return err;
+	}
+
+	/* create hwmon sysfs nodes */
+	err = create_hwmon_sysfs(pdev);
+	if (err) {
+		xocl_err(&pdev->dev, "hwmon_sdm hwmon_sysfs is failed, err: %d", err);
+		goto failed;
+	}
 
 	xocl_info(&pdev->dev, "hwmon_sdm driver probe is successful");
 
-	return err;
+	return 0;
 
 failed:
+	sysfs_remove_group(&pdev->dev.kobj, &hwmon_sdm_bdinfo_attrgroup);
 	hwmon_sdm_remove(pdev);
 	return err;
 }


### PR DESCRIPTION
Signed-off-by: Rajkumar Rampelli <rampelli@amd.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Fix hwmon device registration sequence in hwmon_sdm driver
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1148012
#### How problem was solved, alternative solutions (if any) and why they were rejected
Fixed hwmon driver registration sequence in hwmon_sdm driver. 
#### Risks (if any) associated the changes in the commit
NA
#### What has been tested and how, request additional testing if necessary
XRT driver load & unload, reset.
#### Documentation impact (if any)
NA