### PR TITLE
CR-1145195 Fixes related to default clock scaling override values (#7221)

### DIFF
--- a/src/runtime_src/core/tools/common/ReportCmcStatus.cpp
+++ b/src/runtime_src/core/tools/common/ReportCmcStatus.cpp
@@ -123,6 +123,8 @@ ReportCmcStatus::writeReport( const xrt_core::device* /*_pDevice*/,
     }
     if (!cmc_scale.get<bool>("enabled")) {
       _output << "    Not enabled\n";
+    } else {
+      _output << "    Enabled\n";
     }
 
     cmc_scale = cmc.get_child("scaling").get_child("shutdown_threshold_limits");


### PR DESCRIPTION

* CR-1145195 Fixes related to default scaling override values

Signed-off-by: Rajkumar Rampelli <rampelli@amd.com>

* Minor fix

Signed-off-by: Rajkumar Rampelli <rampelli@amd.com>

Signed-off-by: Rajkumar Rampelli <rampelli@amd.com>
Co-authored-by: Rajkumar Rampelli <rampelli@amd.com>
(cherry picked from commit 8a24f58b27d895f2ae47035cb7a7d5b4c05b5f2d)

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
