### PR TITLE
Don't confuse slotidx 0 with null handle

### DIFF
--- a/src/runtime_src/core/include/xcl_hwctx.h
+++ b/src/runtime_src/core/include/xcl_hwctx.h
@@ -32,10 +32,11 @@ struct xrt_hwctx_handle
   xrt_hwctx_handle(uint32_t slotidx) : slot(slotidx) {}
   operator void* () const { return handle; }
   operator uint32_t () const { return static_cast<uint32_t>(slot); }
-  bool operator < (const xrt_hwctx_handle& rhs) const { return handle < rhs.handle; }
+  bool operator<  (const xrt_hwctx_handle& rhs) const { return handle < rhs.handle; }
+  bool operator== (const xrt_hwctx_handle& rhs) const { return handle == rhs.handle; }
 };
 
-const xrt_hwctx_handle XRT_NULL_HWCTX {nullptr};
+const xrt_hwctx_handle XRT_NULL_HWCTX {0xffffffff};
 
 #ifdef _WIN32
 # pragma warning( pop )

--- a/src/runtime_src/core/pcie/noop/shim.cpp
+++ b/src/runtime_src/core/pcie/noop/shim.cpp
@@ -213,7 +213,7 @@ public:
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-variable"
     for (const auto& [idx, cud] : m_idx2cu)
-      if (cud.name == cuname && cud.slot == static_cast<void*>(slot))
+      if (cud.name == cuname && cud.slot == slot)
         throw xrt_core::error("Context already opened on cu: " + cuname);
 #pragma GCC diagnostic pop
 


### PR DESCRIPTION
#### Problem solved by the commit
Fix #7224 use of incorrect sentinel to indicate no hardware context.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Replace XRT_NULL_HWCTX with distinct sentinel to avoid interpreting legacy slotidx 0 as a null hwctx.

Signed-off-by: Soren Soe <2106410+stsoe@users.noreply.github.com>
