### PR TITLE
CR-1146440 VMR Log Dump Implementation

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
@@ -1460,6 +1460,56 @@ acquire_failed:
 	return ret;
 }
 
+static int vmr_log_dump_op(struct xocl_xgq_vmr *xgq, char *buf, size_t *cnt,int num_recs)
+{
+	struct vmr_log log = { 0 };
+	uint32_t count = 0;
+	//char *start_ptr = buf_ptr;
+
+	if (num_recs > VMR_LOG_MAX_RECS)
+		num_recs = VMR_LOG_MAX_RECS;
+
+	xocl_memcpy_fromio(&xgq->xgq_vmr_shared_mem, xgq->xgq_payload_base,
+		sizeof(xgq->xgq_vmr_shared_mem));
+
+	/*
+	 * log_msg_index which is the oldest log in a ring buffer.
+	 * if we want to only dump num_recs, we start from
+	 * (log_msg_index + VMR_LOG_MAX_RECS - num_recs) % VMR_LOG_MAX_RECS.
+	 */
+	if (xgq->xgq_vmr_shared_mem.vmr_magic_no == VMR_MAGIC_NO) {
+		u32 idx, log_idx = xgq->xgq_vmr_shared_mem.log_msg_index;
+
+		log_idx = (log_idx + VMR_LOG_MAX_RECS - num_recs) % VMR_LOG_MAX_RECS;
+
+		XGQ_WARN(xgq, "=== start dumping vmr log sysfs node===");
+
+		for (idx = 0; idx < num_recs; idx++) {
+			xocl_memcpy_fromio(&log.log_buf, xgq->xgq_payload_base +
+				xgq->xgq_vmr_shared_mem.log_msg_buf_off +
+				sizeof(log) * log_idx,
+				sizeof(log));
+			log_idx = (log_idx + 1) % VMR_LOG_MAX_RECS;
+
+			if(count >= PAGE_SIZE){
+				XGQ_WARN(xgq,"VMR Messages size exceeds Page Size");
+				goto done;
+			}
+			count += snprintf(buf + count, PAGE_SIZE, "%s\n", log.log_buf);
+		}
+	} 
+	else {
+		XGQ_WARN(xgq, "vmr payload partition table is not available");
+	}
+	if(count == 0){
+		XGQ_DBG(xgq, "VMR Log Empty");
+		return -EINVAL;
+	}
+done:
+	*cnt = min(count, PAGE_SIZE);
+	return 0;
+}
+
 static int vmr_verbose_info_query(struct platform_device *pdev,
 	char *buf, size_t *cnt)
 {
@@ -1481,6 +1531,13 @@ static int vmr_memory_info_query(struct platform_device *pdev,
 	char *buf, size_t *cnt)
 {
 	return vmr_info_query_op(pdev, buf, cnt, XGQ_CMD_LOG_MEM_STATS);
+}
+
+static int vmr_log_dump_query(struct platform_device *pdev,
+	char *buf, size_t *cnt)
+{
+	struct xocl_xgq_vmr *xgq = platform_get_drvdata(pdev);
+	return vmr_log_dump_op(xgq, buf, cnt, VMR_LOG_MAX_RECS);
 }
 
 /* On versal, verify is enforced. */
@@ -2547,6 +2604,19 @@ static ssize_t vmr_mem_stats_show(struct device *dev,
 }
 static DEVICE_ATTR_RO(vmr_mem_stats);
 
+static ssize_t vmr_log_dump_show(struct device *dev,
+	struct device_attribute *attr, char *buf)
+{
+	struct xocl_xgq_vmr *xgq = platform_get_drvdata(to_platform_device(dev));
+	ssize_t cnt = 0;
+
+	if (vmr_log_dump_query(xgq->xgq_pdev, buf, &cnt))
+		return -EINVAL;
+
+	return cnt;
+}
+static DEVICE_ATTR_RO(vmr_log_dump);
+
 static ssize_t vmr_debug_type_store(struct device *dev,
 	struct device_attribute *attr, const char *buf, size_t count)
 {
@@ -3065,6 +3135,7 @@ static struct attribute *vmr_attrs[] = {
 	&dev_attr_xgq_scaling_enable.attr,
 	&dev_attr_xgq_scaling_power_override.attr,
 	&dev_attr_xgq_scaling_temp_override.attr,
+	&dev_attr_vmr_log_dump.attr,
 	NULL,
 };
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
@@ -446,9 +446,9 @@ static size_t xgq_vmr_log_dump(struct xocl_xgq_vmr *xgq, int num_recs, char *buf
 
 static void xgq_vmr_log_dump_all(struct xocl_xgq_vmr *xgq)
 {
-	XGQ_WARN(xgq, "=== start ===");
+	XGQ_WARN(xgq, "=== start dumping vmr log===");
 	xgq_vmr_log_dump(xgq, VMR_LOG_MAX_RECS, NULL, vmr_log_dump_to_dmesg);
-	XGQ_WARN(xgq, "=== end ===");
+	XGQ_WARN(xgq, "=== end dumping vmr log===");
 }
 
 static struct opcode_name {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
@@ -383,9 +383,28 @@ static bool xgq_submitted_cmds_empty(struct xocl_xgq_vmr *xgq)
 	return false;
 }
 
-static void xgq_vmr_log_dump(struct xocl_xgq_vmr *xgq, int num_recs, bool dump_to_debug_log)
+static int vmr_log_dump_to_debug(struct xocl_xgq_vmr *xgq, char *buf, char *log_buf)
+{
+	XGQ_DBG(xgq, "%s", log_buf);
+	return 0;
+}
+
+static int vmr_log_dump_to_dmesg(struct xocl_xgq_vmr *xgq, char *buf, char *log_buf)
+{
+	XGQ_WARN(xgq, "%s", log_buf);
+	return 0;
+}
+	
+static int vmr_log_dump_to_buf(struct xocl_xgq_vmr *xgq, char *buf, char *log_buf)
+{
+	return buf == NULL ? 0 : snprintf(buf, PAGE_SIZE, "%s\n", log_buf);
+}
+
+static size_t xgq_vmr_log_dump(struct xocl_xgq_vmr *xgq, int num_recs, char *buf,
+	int(*dump_cb)(struct xocl_xgq_vmr *xgq, char *buf, char *log_buf))
 {
 	struct vmr_log log = { 0 };
+	size_t count = 0;
 
 	if (num_recs > VMR_LOG_MAX_RECS)
 		num_recs = VMR_LOG_MAX_RECS;
@@ -403,9 +422,6 @@ static void xgq_vmr_log_dump(struct xocl_xgq_vmr *xgq, int num_recs, bool dump_t
 
 		log_idx = (log_idx + VMR_LOG_MAX_RECS - num_recs) % VMR_LOG_MAX_RECS;
 
-		if (!dump_to_debug_log)
-			XGQ_WARN(xgq, "=== start dumping vmr log ===");
-
 		for (idx = 0; idx < num_recs; idx++) {
 			xocl_memcpy_fromio(&log.log_buf, xgq->xgq_payload_base +
 				xgq->xgq_vmr_shared_mem.log_msg_buf_off +
@@ -413,22 +429,26 @@ static void xgq_vmr_log_dump(struct xocl_xgq_vmr *xgq, int num_recs, bool dump_t
 				sizeof(log));
 			log_idx = (log_idx + 1) % VMR_LOG_MAX_RECS;
 
-			if (dump_to_debug_log)
-				XGQ_DBG(xgq, "%s", log.log_buf);
-			else
-				XGQ_WARN(xgq, "%s", log.log_buf);
+			/* calling call back function */
+			count += dump_cb(xgq, buf ? buf + count : NULL, log.log_buf);
+			if (count > PAGE_SIZE) {
+				XGQ_WARN(xgq, "message size %ld exceeds page %ld",
+					count, PAGE_SIZE);
+				break;
+			}
 		}
-
-		if (!dump_to_debug_log)
-			XGQ_WARN(xgq, "=== end dumping vmr log ===");
 	} else {
 		XGQ_WARN(xgq, "vmr payload partition table is not available");
 	}
+
+	return min(count, PAGE_SIZE);
 }
 
 static void xgq_vmr_log_dump_all(struct xocl_xgq_vmr *xgq)
 {
-	xgq_vmr_log_dump(xgq, VMR_LOG_MAX_RECS, false);
+	XGQ_WARN(xgq, "=== start ===");
+	xgq_vmr_log_dump(xgq, VMR_LOG_MAX_RECS, NULL, vmr_log_dump_to_dmesg);
+	XGQ_WARN(xgq, "=== end ===");
 }
 
 static struct opcode_name {
@@ -462,13 +482,17 @@ const char *get_opcode_name(int opcode)
 
 static void xgq_vmr_log_dump_debug(struct xocl_xgq_vmr *xgq, struct xocl_xgq_vmr_cmd *cmd)
 {
-	XGQ_WARN(xgq, "opcode: %s(0x%x), rcode: %d, check debug trace for detailed log.",
+	XGQ_WARN(xgq, "opcode: %s(0x%x), rcode: %d, check vmr_log sysfs node and xclmgmt trace log.",
 		get_opcode_name(cmd->xgq_cmd_entry.hdr.opcode),
 		cmd->xgq_cmd_entry.hdr.opcode,
 		cmd->xgq_cmd_rcode);
 
 	/* Dump VMR logs into xclmgmt debugfs */
-	xgq_vmr_log_dump(xgq, 20, true);
+	XGQ_DBG(xgq, "log for opcode: %s(0x%x), rcode: %d",
+		get_opcode_name(cmd->xgq_cmd_entry.hdr.opcode),
+		cmd->xgq_cmd_entry.hdr.opcode,
+		cmd->xgq_cmd_rcode);
+	xgq_vmr_log_dump(xgq, 20, NULL, vmr_log_dump_to_debug);
 }
 
 /* Wait for xgq service is fully ready after a reset. */
@@ -1460,56 +1484,6 @@ acquire_failed:
 	return ret;
 }
 
-static int vmr_log_dump_op(struct xocl_xgq_vmr *xgq, char *buf, size_t *cnt,int num_recs)
-{
-	struct vmr_log log = { 0 };
-	uint32_t count = 0;
-	//char *start_ptr = buf_ptr;
-
-	if (num_recs > VMR_LOG_MAX_RECS)
-		num_recs = VMR_LOG_MAX_RECS;
-
-	xocl_memcpy_fromio(&xgq->xgq_vmr_shared_mem, xgq->xgq_payload_base,
-		sizeof(xgq->xgq_vmr_shared_mem));
-
-	/*
-	 * log_msg_index which is the oldest log in a ring buffer.
-	 * if we want to only dump num_recs, we start from
-	 * (log_msg_index + VMR_LOG_MAX_RECS - num_recs) % VMR_LOG_MAX_RECS.
-	 */
-	if (xgq->xgq_vmr_shared_mem.vmr_magic_no == VMR_MAGIC_NO) {
-		u32 idx, log_idx = xgq->xgq_vmr_shared_mem.log_msg_index;
-
-		log_idx = (log_idx + VMR_LOG_MAX_RECS - num_recs) % VMR_LOG_MAX_RECS;
-
-		XGQ_WARN(xgq, "=== start dumping vmr log sysfs node===");
-
-		for (idx = 0; idx < num_recs; idx++) {
-			xocl_memcpy_fromio(&log.log_buf, xgq->xgq_payload_base +
-				xgq->xgq_vmr_shared_mem.log_msg_buf_off +
-				sizeof(log) * log_idx,
-				sizeof(log));
-			log_idx = (log_idx + 1) % VMR_LOG_MAX_RECS;
-
-			if(count >= PAGE_SIZE){
-				XGQ_WARN(xgq,"VMR Messages size exceeds Page Size");
-				goto done;
-			}
-			count += snprintf(buf + count, PAGE_SIZE, "%s\n", log.log_buf);
-		}
-	} 
-	else {
-		XGQ_WARN(xgq, "vmr payload partition table is not available");
-	}
-	if(count == 0){
-		XGQ_DBG(xgq, "VMR Log Empty");
-		return -EINVAL;
-	}
-done:
-	*cnt = min(count, PAGE_SIZE);
-	return 0;
-}
-
 static int vmr_verbose_info_query(struct platform_device *pdev,
 	char *buf, size_t *cnt)
 {
@@ -1531,13 +1505,6 @@ static int vmr_memory_info_query(struct platform_device *pdev,
 	char *buf, size_t *cnt)
 {
 	return vmr_info_query_op(pdev, buf, cnt, XGQ_CMD_LOG_MEM_STATS);
-}
-
-static int vmr_log_dump_query(struct platform_device *pdev,
-	char *buf, size_t *cnt)
-{
-	struct xocl_xgq_vmr *xgq = platform_get_drvdata(pdev);
-	return vmr_log_dump_op(xgq, buf, cnt, VMR_LOG_MAX_RECS);
 }
 
 /* On versal, verify is enforced. */
@@ -2513,7 +2480,7 @@ static ssize_t vmr_debug_dump_store(struct device *dev,
 		return -EINVAL;
 	}
 
-	xgq_vmr_log_dump(xgq, val, true);
+	xgq_vmr_log_dump(xgq, val, NULL, vmr_log_dump_to_debug);
 
 	return count;
 }
@@ -2604,18 +2571,17 @@ static ssize_t vmr_mem_stats_show(struct device *dev,
 }
 static DEVICE_ATTR_RO(vmr_mem_stats);
 
-static ssize_t vmr_log_dump_show(struct device *dev,
+static ssize_t vmr_log_show(struct device *dev,
 	struct device_attribute *attr, char *buf)
 {
 	struct xocl_xgq_vmr *xgq = platform_get_drvdata(to_platform_device(dev));
 	ssize_t cnt = 0;
 
-	if (vmr_log_dump_query(xgq->xgq_pdev, buf, &cnt))
-		return -EINVAL;
+	cnt = xgq_vmr_log_dump(xgq, VMR_LOG_MAX_RECS, buf, vmr_log_dump_to_buf);
 
-	return cnt;
+	return cnt == 0 ? -EINVAL : cnt;
 }
-static DEVICE_ATTR_RO(vmr_log_dump);
+static DEVICE_ATTR_RO(vmr_log);
 
 static ssize_t vmr_debug_type_store(struct device *dev,
 	struct device_attribute *attr, const char *buf, size_t count)
@@ -3135,7 +3101,7 @@ static struct attribute *vmr_attrs[] = {
 	&dev_attr_xgq_scaling_enable.attr,
 	&dev_attr_xgq_scaling_power_override.attr,
 	&dev_attr_xgq_scaling_temp_override.attr,
-	&dev_attr_vmr_log_dump.attr,
+	&dev_attr_vmr_log.attr,
 	NULL,
 };
 


### PR DESCRIPTION
Signed-off-by: prapulkrishnamurthy <prapulk@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
The Log reports from VMR shared space is now available at sysfs node.
Idea is to dump all VMR reports to make it available at XRT host.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Copied and forwarded all reports towards sysfs node.

#### Risks (if any) associated the changes in the commit
the existing Dmesg forwarding is not removed yet.

#### What has been tested and how, request additional testing if necessary
Tested to print maximum of 50 records when polled the sysfs node name "vmr_log"

#### Documentation impact (if any)
