### PR TITLE
Revert "CR-1147558 clock throttling percentage in the dmesg (#7229)"

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
@@ -1191,13 +1191,12 @@ static int xgq_firewall_op(struct platform_device *pdev, enum xgq_cmd_log_page_t
 	struct xocl_xgq_vmr *xgq = platform_get_drvdata(pdev);
 	struct xocl_xgq_vmr_cmd *cmd = NULL;
 	struct xgq_cmd_log_payload *payload = NULL;
-	struct xgq_cmd_cq_log_page_payload *log = NULL;
 	struct xgq_cmd_sq_hdr *hdr = NULL;
 	int ret = 0;
 	int id = 0;
 	u32 address = 0;
 	u32 len = 0;
-	u32 log_size = 0;
+
 	/*
 	 * avoid warning messages, skip periodic firewall check
 	 * when xgq service is halted
@@ -1264,31 +1263,29 @@ static int xgq_firewall_op(struct platform_device *pdev, enum xgq_cmd_log_page_t
 	ret = (cmd->xgq_cmd_rcode == -ETIME || cmd->xgq_cmd_rcode == -EINVAL) ?
 		0 : cmd->xgq_cmd_rcode;
 
-	/*
-	 * No matter ret is 0 or non-zero, the device might return
-	 * error messages to print into the dmesg.
-	 */
-	log = (struct xgq_cmd_cq_log_page_payload *)&cmd->xgq_cmd_cq_payload;
-	log_size = log->count;
+	if (ret) {
+		struct xgq_cmd_cq_log_page_payload *log = NULL;
+		u32 log_size = 0;
 
-	if (log_size > len) {
-		XGQ_WARN(xgq, "return log size %d is greater than request %d",
-			log->count, len);
-		/* reset to valid shared memory size */
-		log_size = len;
-	}
+		log = (struct xgq_cmd_cq_log_page_payload *)&cmd->xgq_cmd_cq_payload;
+		log_size = log->count;
 
-	if (log_size != 0) {
-		char *log_msg = vmalloc(log_size + 1);
-		if (log_msg == NULL) {
-			XGQ_ERR(xgq, "vmalloc failed, no memory");
-			goto done;
+		if (log_size > len) {
+			XGQ_ERR(xgq, "return log size %d is greater than request %d",
+				log->count, len);
+			log_size = len;
+		} else if (log_size  == 0) {
+			XGQ_ERR(xgq, "no error message");
+		} else {
+			char *log_msg = vmalloc(log_size);
+			if (log_msg == NULL) {
+				XGQ_ERR(xgq, "vmalloc failed, no msg");
+				goto done;
+			}
+			memcpy_from_device(xgq, address, log_msg, log_size);
+			XGQ_ERR(xgq, "%s", log_msg);
+			vfree(log_msg);
 		}
-		memcpy_from_device(xgq, address, log_msg, log_size);
-		log_msg[log_size] = '\0';
-
-		XGQ_ERR(xgq, "%s", log_msg);
-		vfree(log_msg);
 	}
 
 done:


### PR DESCRIPTION
needs more work, this solution doesn't work as default value is not 0 but ffff.

This reverts commit 9e4ae2b36c75676a27d075cce3592229cd634f55.

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
