### PR TITLE
Adding condition for minimal build in XDP

### DIFF
--- a/src/runtime_src/xdp/CMakeLists.txt
+++ b/src/runtime_src/xdp/CMakeLists.txt
@@ -29,7 +29,7 @@ else()
 
 endif()
 
-if (MINIMAL_BUILD STREQUAL "yes")
+if (XDP_MINIMAL_BUILD STREQUAL "yes")
 
  add_compile_options("-DSKIP_IOCTL")
  add_compile_options("-DSKIP_AIE_INI")

--- a/src/runtime_src/xdp/CMakeLists.txt
+++ b/src/runtime_src/xdp/CMakeLists.txt
@@ -29,6 +29,17 @@ else()
 
 endif()
 
-add_subdirectory(appdebug)
-add_subdirectory(debug)
-add_subdirectory(profile)
+if (MINIMAL_BUILD STREQUAL "yes")
+
+ add_compile_options("-DSKIP_IOCTL")
+ add_compile_options("-DSKIP_AIE_INI")
+
+ add_subdirectory(profile)
+
+else()
+
+  add_subdirectory(appdebug)
+  add_subdirectory(debug)
+  add_subdirectory(profile)
+
+endif()

--- a/src/runtime_src/xdp/profile/plugin/CMakeLists.txt
+++ b/src/runtime_src/xdp/profile/plugin/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright (C) 2022 Advanced Micro Devices, Inc.  All rights reserved.
 #
 
-if (MINIMAL_BUILD STREQUAL "yes")
+if (XDP_MINIMAL_BUILD STREQUAL "yes")
 
   add_subdirectory(native)
   add_subdirectory(user)
@@ -43,5 +43,5 @@ else()
 
 endif()
 
-# Matches MINIMAL_BUILD
+# Matches XDP_MINIMAL_BUILD
 endif()

--- a/src/runtime_src/xdp/profile/plugin/CMakeLists.txt
+++ b/src/runtime_src/xdp/profile/plugin/CMakeLists.txt
@@ -2,6 +2,13 @@
 # Copyright (C) 2022 Advanced Micro Devices, Inc.  All rights reserved.
 #
 
+if (MINIMAL_BUILD STREQUAL "yes")
+
+  add_subdirectory(native)
+  add_subdirectory(user)
+
+else()
+
 # =========================================================
 # The plugins to be built on both Linux and Windows
 # =========================================================
@@ -34,4 +41,7 @@ else()
 # The plugins to be built on Windows only (currently empty)
 # =========================================================
 
+endif()
+
+# Matches MINIMAL_BUILD
 endif()


### PR DESCRIPTION
#### Problem solved by the commit
Adding a condition to perform a minimal build of the XDP libraries.

#### What has been tested and how, request additional testing if necessary
Build with the condition set and not set tested on Linux and Windows.

#### Documentation impact (if any)
No documentation impact