### PR TITLE
Remove obsolete windows conditional code

### DIFF
--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -194,13 +194,6 @@ private:
     addr = prop.paddr;
     grpid = prop.flags & XRT_BO_FLAGS_MEMIDX_MASK;
     flags = static_cast<bo::flags>(prop.flags & ~XRT_BO_FLAGS_MEMIDX_MASK);
-
-#if defined(_WIN32) && !defined(MCDM)
-    // All shims minus windows return proper flags
-    // Remove when driver returns the flags that were used to ctor the bo
-    auto mem_topo = device->get_axlf_section<const ::mem_topology*>(ASK_GROUP_TOPOLOGY);
-    grpid = xrt_core::xclbin::address_to_memidx(mem_topo, addr);
-#endif
   }
 
 protected:


### PR DESCRIPTION
xrt_bo::get_bo_properties compensates for shims not retuning proper BO flags.  For Alveo this may still be the case on windows but this would have to be fixed in driver, not in user space code.  The conditional code is tripping other projects that use XRT as a submodule.
