### PR TITLE
Increase skd cgroup memory limit from 1G to 2G

### DIFF
--- a/src/runtime_src/tools/scripts/apu_recipes/skd.service
+++ b/src/runtime_src/tools/scripts/apu_recipes/skd.service
@@ -7,7 +7,7 @@ Type=forking
 User=softkernel
 ExecStart=/usr/bin/skd
 StandardOutput=journal+console
-MemoryLimit=1G
+MemoryLimit=2G
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Increase PS kernel service group memory limit from 1G to 2G to accommodate larger cached xclbin sizes.

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
