### PR TITLE
make bandwidth host.cpp error message clear when buffer mismatch

### DIFF
--- a/tests/validate/bandwidth_test/src/host.cpp
+++ b/tests/validate/bandwidth_test/src/host.cpp
@@ -192,6 +192,9 @@ int main(int argc, char** argv) {
                 std::fill(output_host[i].begin(), output_host[i].end(), 0);
             }
 
+	    for (uint32_t j = 0; j < 256; j+=100)
+		    std::cout << "j:" << j << "=" << (uint32_t)input_host[j] << std::endl;
+
             std::vector<cl::Buffer> input_buffer(num_kernel_ddr);
             std::vector<cl::Buffer> output_buffer(num_kernel_ddr);
 
@@ -237,8 +240,8 @@ int main(int argc, char** argv) {
             for (int i = 0; i < num_kernel_ddr; i++) {
                 for (uint32_t j = 0; j < data_size; j++) {
                     if (output_host[i][j] != input_host[j]) {
-                        std::cout << "ERROR : kernel failed to copy entry " << j << " input " << input_host[j]
-                                  << " output " << output_host[i][j] << std::endl;
+                        std::cout << "ERROR : kernel failed to copy entry " << j << " input " << (uint32_t)input_host[j]
+                                  << " output " << (uint32_t)output_host[i][j] << std::endl;
                         return EXIT_FAILURE;
                     }
                 }
@@ -313,8 +316,8 @@ int main(int argc, char** argv) {
             // check
             for (uint32_t j = 0; j < data_size; j++) {
                 if (output_host[j] != input_host[j]) {
-                    std::cout << "ERROR : kernel failed to copy entry " << j << " input " << input_host[j] << " output "
-                              << output_host[j] << std::endl;
+                    std::cout << "HBM ERROR : kernel failed to copy entry " << j << " input " << (uint32_t)input_host[j] << " output "
+                              << (uint32_t)output_host[j] << std::endl;
                     return EXIT_FAILURE;
                 }
             }


### PR DESCRIPTION
for vck5000

Signed-off-by: David Zhang <davidzha@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

This is very unlikely an XRT issue. Instead this should be a shell issue that sometimes the data is not correct in the hardware DDR memory.

However, the bandwidth test cpp code prints the value without casting it to int, thus the cpp will take it as an ASCII and sometimes it is "invisible" when print out. So the fix is to cast the value to it's original int value, it should be from 0-256 based on the design of the bandwidth test.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
