### PR TITLE
CR-1147859 fix reading target sc version data on versal (#7247)

### DIFF
--- a/src/runtime_src/core/common/info_platform.cpp
+++ b/src/runtime_src/core/common/info_platform.cpp
@@ -175,8 +175,20 @@ add_controller_info(const xrt_core::device* device, ptree_type& pt)
         // Ignoring if not available
       }
     }
+
+    std::string exp_sc_ver = xrt_core::device_query<xq::expected_sc_version>(device);
+    if (exp_sc_ver.empty()) {
+      try {
+        exp_sc_ver = xrt_core::device_query<xq::hwmon_sdm_target_msp_ver>(device);
+      }
+      catch (const xq::exception&) {
+        // Ignoring if not available
+      }
+    }
+
     sc.add("version", sc_ver);
-    sc.add("expected_version", xrt_core::device_query<xq::expected_sc_version>(device));
+    sc.add("expected_version", exp_sc_ver);
+
     ptree_type cmc;
 
     /*

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -267,6 +267,7 @@ enum class key_type
   hwmon_sdm_oem_id,
   hwmon_sdm_board_name,
   hwmon_sdm_active_msp_ver,
+  hwmon_sdm_target_msp_ver,
   hwmon_sdm_mac_addr0,
   hwmon_sdm_mac_addr1,
   hwmon_sdm_revision,
@@ -2954,6 +2955,7 @@ struct xclbin_slots : request
   get(const xrt_core::device* device) const = 0;
 };
 
+// Retrieve Board Serial number from xocl hwmon_sdm driver
 struct hwmon_sdm_serial_num : request
 {
   using result_type = std::string;
@@ -2963,6 +2965,7 @@ struct hwmon_sdm_serial_num : request
   get(const device*) const = 0;
 };
 
+// Retrieve OEM ID data from xocl hwmon_sdm driver
 struct hwmon_sdm_oem_id : request
 {
   using result_type = std::string;
@@ -2972,6 +2975,7 @@ struct hwmon_sdm_oem_id : request
   get(const device*) const = 0;
 };
 
+// Retrieve Board name from xocl hwmon_sdm driver
 struct hwmon_sdm_board_name : request
 {
   using result_type = std::string;
@@ -2981,6 +2985,7 @@ struct hwmon_sdm_board_name : request
   get(const device*) const = 0;
 };
 
+// Retrieve active SC version from xocl hwmon_sdm driver
 struct hwmon_sdm_active_msp_ver : request
 {
   using result_type = std::string;
@@ -2990,6 +2995,17 @@ struct hwmon_sdm_active_msp_ver : request
   get(const device*) const = 0;
 };
 
+// Retrieve expected SC version from xocl hwmon_sdm driver
+struct hwmon_sdm_target_msp_ver : request
+{
+  using result_type = std::string;
+  static const key_type key = key_type::hwmon_sdm_target_msp_ver;
+
+  virtual boost::any
+  get(const device*) const = 0;
+};
+
+// Retrieve MAC ADDR0 from xocl hwmon_sdm driver
 struct hwmon_sdm_mac_addr0 : request
 {
   using result_type = std::string;
@@ -2999,6 +3015,7 @@ struct hwmon_sdm_mac_addr0 : request
   get(const device*) const = 0;
 };
 
+// Retrieve MAC ADDR1 from xocl hwmon_sdm driver
 struct hwmon_sdm_mac_addr1 : request
 {
   using result_type = std::string;
@@ -3008,6 +3025,7 @@ struct hwmon_sdm_mac_addr1 : request
   get(const device*) const = 0;
 };
 
+// Retrieve Revision data from xocl hwmon_sdm driver
 struct hwmon_sdm_revision : request
 {
   using result_type = std::string;
@@ -3017,6 +3035,7 @@ struct hwmon_sdm_revision : request
   get(const device*) const = 0;
 };
 
+// Retrieve FAN presence status from xocl hwmon_sdm driver
 struct hwmon_sdm_fan_presence : request
 {
   using result_type = std::string;

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -1259,6 +1259,7 @@ initialize_query_table()
   emplace_sysfs_get<query::hwmon_sdm_oem_id>                   ("hwmon_sdm", "oem_id");
   emplace_sysfs_get<query::hwmon_sdm_board_name>               ("hwmon_sdm", "bd_name");
   emplace_sysfs_get<query::hwmon_sdm_active_msp_ver>           ("hwmon_sdm", "active_msp_ver");
+  emplace_sysfs_get<query::hwmon_sdm_target_msp_ver>           ("hwmon_sdm", "target_msp_ver");
   emplace_sysfs_get<query::hwmon_sdm_mac_addr0>                ("hwmon_sdm", "mac_addr0");
   emplace_sysfs_get<query::hwmon_sdm_mac_addr1>                ("hwmon_sdm", "mac_addr1");
   emplace_sysfs_get<query::hwmon_sdm_fan_presence>             ("hwmon_sdm", "fan_presence");


### PR DESCRIPTION
* CR-1147859 fix reading target sc version data on versal

Signed-off-by: Rajkumar Rampelli <rampelli@amd.com>

* Fix review comments

Signed-off-by: Rajkumar Rampelli <rampelli@amd.com>

Signed-off-by: Rajkumar Rampelli <rampelli@amd.com>
Co-authored-by: Rajkumar Rampelli <rampelli@amd.com>
(cherry picked from commit 637c3644c9ab24e73830822ac06813d98947d566)

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
