### PR TITLE
Updated init-apu.service to ensure skd.service starts after init-apu

### DIFF
--- a/src/runtime_src/tools/scripts/apu_recipes/init-apu.service
+++ b/src/runtime_src/tools/scripts/apu_recipes/init-apu.service
@@ -1,7 +1,9 @@
 [Unit]
 Description=APU init Daemon
+Before=skd.service
 
 [Service]
+Type=exec
 ExecStart=/usr/bin/init-apu
 StandardOutput=journal+console
 


### PR DESCRIPTION
Addresses CR-1141939

Signed-off-by: Jeff Lin <jeffylin@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Sometimes skd service could not start if user soft kernel has not been created yes due to race condition between init-apu service and skd service

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
init-apu.service was added ensure all initialization is done before apu-boot which signals to rpu that apu has completed boot process.  However, there was no clear signal to indicate skd service need to run after init-apu service has completed.
Thus occasionally skd would not start which lead to xclbin download failure with ps kernels.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added Before keyword to ensure init-apu is run before skd.service, and also make it an exec so it is only considered done after the script has finished.

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Tested on vck5000 and v70

#### Documentation impact (if any)
None