### PR TITLE
CR-1147768 when VMR is offline, xbutil reset stops working

### DIFF
--- a/src/runtime_src/core/common/info_vmr.cpp
+++ b/src/runtime_src/core/common/info_vmr.cpp
@@ -72,7 +72,7 @@ vmr_info(const xrt_core::device* device)
 }
 
 bool
-is_vmr_status_true(const xrt_core::device* device, std::string status)
+get_vmr_status(const xrt_core::device* device, const std::string& status)
 {
   const auto pt = vmr_info(device);
   boost::property_tree::ptree pt_empty;
@@ -85,7 +85,7 @@ is_vmr_status_true(const xrt_core::device* device, std::string status)
       return boost::iequals(vmr_stat.get<std::string>("value"), "1");
   }
 
-  return false;
+  throw xrt_core::error(boost::str(boost::format("Did not find %s label within VMR status") % status));
 }
 
 } // vmr, xrt

--- a/src/runtime_src/core/common/info_vmr.cpp
+++ b/src/runtime_src/core/common/info_vmr.cpp
@@ -72,8 +72,18 @@ vmr_info(const xrt_core::device* device)
 }
 
 bool
-get_vmr_status(const xrt_core::device* device, const std::string& status)
+get_vmr_status(const xrt_core::device* device, const vmr_status_type& status)
 {
+  std::string status_string;
+  switch (status) {
+    case vmr_status_type::boot_on_default:
+      status_string = "Boot on default";
+      break;
+    default:
+      throw xrt_core::error(boost::str(boost::format("Unexpected key for VMR Status type %u") % static_cast<uint32_t>(status)));
+  }
+
+
   const auto pt = vmr_info(device);
   boost::property_tree::ptree pt_empty;
   const boost::property_tree::ptree& ptree = pt.get_child("vmr", pt_empty);
@@ -81,11 +91,11 @@ get_vmr_status(const xrt_core::device* device, const std::string& status)
     const boost::property_tree::ptree& vmr_stat = ks.second;
     const auto val = vmr_stat.get<std::string>("label");
     const auto nval = vmr_stat.get<std::string>("value");
-    if (boost::iequals(val, status))
+    if (boost::iequals(val, status_string))
       return boost::iequals(vmr_stat.get<std::string>("value"), "1");
   }
 
-  throw xrt_core::error(boost::str(boost::format("Did not find %s label within VMR status") % status));
+  throw xrt_core::error(boost::str(boost::format("Did not find %s label within VMR status") % status_string));
 }
 
 } // vmr, xrt

--- a/src/runtime_src/core/common/info_vmr.cpp
+++ b/src/runtime_src/core/common/info_vmr.cpp
@@ -72,7 +72,7 @@ vmr_info(const xrt_core::device* device)
 }
 
 bool
-get_vmr_status(const xrt_core::device* device, const vmr_status_type& status)
+get_vmr_status(const xrt_core::device* device, vmr_status_type status)
 {
   std::string status_string;
   switch (status) {

--- a/src/runtime_src/core/common/info_vmr.cpp
+++ b/src/runtime_src/core/common/info_vmr.cpp
@@ -72,7 +72,7 @@ vmr_info(const xrt_core::device* device)
 }
 
 bool
-is_default_boot(const xrt_core::device* device)
+is_vmr_status_true(const xrt_core::device* device, std::string status)
 {
   const auto pt = vmr_info(device);
   boost::property_tree::ptree pt_empty;
@@ -81,11 +81,11 @@ is_default_boot(const xrt_core::device* device)
     const boost::property_tree::ptree& vmr_stat = ks.second;
     const auto val = vmr_stat.get<std::string>("label");
     const auto nval = vmr_stat.get<std::string>("value");
-    if (boost::iequals(val, "Boot on default"))
+    if (boost::iequals(val, status))
       return boost::iequals(vmr_stat.get<std::string>("value"), "1");
   }
 
-  throw std::runtime_error("Missing 'Boot on default' data in VMR status");
+  return false;
 }
 
 } // vmr, xrt

--- a/src/runtime_src/core/common/info_vmr.h
+++ b/src/runtime_src/core/common/info_vmr.h
@@ -21,7 +21,7 @@ enum class vmr_status_type {
 
 XRT_CORE_COMMON_EXPORT
 bool
-get_vmr_status(const xrt_core::device* device, const vmr_status_type& status);
+get_vmr_status(const xrt_core::device* device, vmr_status_type status);
 
 }} // vmr, xrt
 

--- a/src/runtime_src/core/common/info_vmr.h
+++ b/src/runtime_src/core/common/info_vmr.h
@@ -17,7 +17,7 @@ vmr_info(const xrt_core::device * device);
 
 XRT_CORE_COMMON_EXPORT
 bool
-is_vmr_status_true(const xrt_core::device* device, std::string status);
+get_vmr_status(const xrt_core::device* device, const std::string& status);
 
 }} // vmr, xrt
 

--- a/src/runtime_src/core/common/info_vmr.h
+++ b/src/runtime_src/core/common/info_vmr.h
@@ -17,7 +17,7 @@ vmr_info(const xrt_core::device * device);
 
 XRT_CORE_COMMON_EXPORT
 bool
-is_default_boot(const xrt_core::device* device);
+is_vmr_status_true(const xrt_core::device* device, std::string status);
 
 }} // vmr, xrt
 

--- a/src/runtime_src/core/common/info_vmr.h
+++ b/src/runtime_src/core/common/info_vmr.h
@@ -15,9 +15,13 @@ XRT_CORE_COMMON_EXPORT
 boost::property_tree::ptree
 vmr_info(const xrt_core::device * device);
 
+enum class vmr_status_type {
+  boot_on_default = 0
+};
+
 XRT_CORE_COMMON_EXPORT
 bool
-get_vmr_status(const xrt_core::device* device, const std::string& status);
+get_vmr_status(const xrt_core::device* device, const vmr_status_type& status);
 
 }} // vmr, xrt
 

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -324,7 +324,7 @@ XBUtilities::collect_devices( const std::set<std::string> &_deviceBDFs,
     std::vector<std::string> warnings;
 
     try {
-      const auto is_default = xrt_core::vmr::get_vmr_status(device.get(), "Boot on default");
+      const auto is_default = xrt_core::vmr::get_vmr_status(device.get(), xrt_core::vmr::vmr_status_type::boot_on_default);
       if (!is_default)
         warnings.push_back("Versal Platform is NOT in default boot");
     } catch (const xrt_core::error& e) {

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -321,13 +321,38 @@ XBUtilities::collect_devices( const std::set<std::string> &_deviceBDFs,
   static void 
   check_versal_boot(const std::shared_ptr<xrt_core::device> &device)
   {
-    if (xrt_core::vmr::is_vmr_status_true(device.get(), "Boot on default"))
+    std::vector<std::string> warnings;
+
+    try {
+      const auto is_default = xrt_core::vmr::get_vmr_status(device.get(), "Boot on default");
+      if (!is_default)
+        warnings.push_back("Versal Platform is NOT in default boot");
+    } catch (const xrt_core::error& e) {
+      warnings.push_back(e.what());
+    }
+
+    if (warnings.empty())
       return;
 
-    std::cout << "***********************************************************\n";
+    const std::string star_line = "***********************************************************";
+
+    std::cout << star_line << "\n";
     std::cout << "*        WARNING          WARNING          WARNING        *\n";
-    std::cout << "*         Versal Platform is NOT in default boot          *\n";
-    std::cout << "***********************************************************\n";
+
+    // Print all warnings
+    for (const auto& warning : warnings) {
+      // Subtract the:
+      // 1. Side stars
+      // 2. Single space next to the side star
+      // 3. The warning message
+      const size_t side_spaces = star_line.size() - 2 - 2 - warning.size();
+      // The left side should be larger than the right if there is an imbalance
+      const size_t left_spaces = (side_spaces % 2 == 0) ? side_spaces / 2 : (side_spaces / 2) + 1;
+      const size_t right_spaces = side_spaces / 2;
+      std::cout << "* " << std::string(left_spaces, ' ') << warning << std::string(right_spaces, ' ') << " *\n";
+    }
+
+    std::cout << star_line << "\n";
   }
 
   std::shared_ptr<xrt_core::device>

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -321,12 +321,12 @@ XBUtilities::collect_devices( const std::set<std::string> &_deviceBDFs,
   static void 
   check_versal_boot(const std::shared_ptr<xrt_core::device> &device)
   {
-    if (xrt_core::vmr::is_default_boot(device.get()))
+    if (xrt_core::vmr::is_vmr_status_true(device.get(), "Boot on default"))
       return;
 
     std::cout << "***********************************************************\n";
     std::cout << "*        WARNING          WARNING          WARNING        *\n";
-    std::cout << "*             Versal Platform in backup boot              *\n";
+    std::cout << "*         Versal Platform is NOT in default boot          *\n";
     std::cout << "***********************************************************\n";
   }
 

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -344,12 +344,20 @@ XBUtilities::collect_devices( const std::set<std::string> &_deviceBDFs,
       // Subtract the:
       // 1. Side stars
       // 2. Single space next to the side star
-      // 3. The warning message
-      const size_t side_spaces = star_line.size() - 2 - 2 - warning.size();
-      // The left side should be larger than the right if there is an imbalance
-      const size_t left_spaces = (side_spaces % 2 == 0) ? side_spaces / 2 : (side_spaces / 2) + 1;
-      const size_t right_spaces = side_spaces / 2;
-      std::cout << "* " << std::string(left_spaces, ' ') << warning << std::string(right_spaces, ' ') << " *\n";
+      const size_t available_space = star_line.size() - 2 - 2;
+      // Account for strings who are larger than the star line
+      size_t warning_index = 0;
+      while (warning_index < warning.size()) {
+        // Extract the largest possible string from the warning
+        const auto warning_msg = warning.substr(warning_index, available_space);
+        // Update the index so the next substring is valid
+        warning_index += warning_msg.size();
+        const auto side_spaces = available_space - warning_msg.size();
+        // The left side should be larger than the right if there is an imbalance
+        const size_t left_spaces = (side_spaces % 2 == 0) ? side_spaces / 2 : (side_spaces / 2) + 1;
+        const size_t right_spaces = side_spaces / 2;
+        std::cout << "* " << std::string(left_spaces, ' ') << warning_msg << std::string(right_spaces, ' ') << " *\n";
+      }
     }
 
     std::cout << star_line << "\n";

--- a/src/runtime_src/core/tools/xbmgmt2/ReportPlatform.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/ReportPlatform.cpp
@@ -104,7 +104,7 @@ static boost::property_tree::ptree
 get_boot_info(const xrt_core::device * dev)
 {
   boost::property_tree::ptree ptree;
-  // get boot on default from vmr_status sysfs node
+  // get boot status from vmr_status sysfs node
   boost::property_tree::ptree pt_empty;
   const auto pt = xrt_core::vmr::vmr_info(dev).get_child("vmr", pt_empty);
   for (auto& ks : pt) {
@@ -112,8 +112,10 @@ get_boot_info(const xrt_core::device * dev)
     if (boost::iequals(vmr_stat.get<std::string>("label"), "Boot on default")) {
       auto is_default_boot = std::stoi(vmr_stat.get<std::string>("value"));
       ptree.add("default", is_default_boot ? "ACTIVE" : "INACTIVE");
-      ptree.add("backup", is_default_boot ? "INACTIVE" : "ACTIVE");
-      break;
+    }
+    if (boost::iequals(vmr_stat.get<std::string>("label"), "Boot on backup")) {
+      auto is_backup_boot = std::stoi(vmr_stat.get<std::string>("value"));
+      ptree.add("backup", is_backup_boot ? "ACTIVE" : "INACTIVE");
     }
   }
   return ptree;


### PR DESCRIPTION
Signed-off-by: David Zhang <davidzha@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Chatted with @dbenusov-xilinx about this. What we want to fix is that we should not use exception to block "xbutil reset" in the worse situation. This is the last chance to bring the card back.

Additionally, Daniel wants to apply additional fixes on top of my initial PR which can:
1) throw better exception and catch and print reasonable better messages;
2) using enum class instead of "string" as arguments

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Ubuntu 20.04 VCK5000 in backup boot
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov/extra/XRT1$ xbutil examine -d 17:00
WARNING: Unexpected xocl version (2.14.0) was found. Expected 2.15.0, to match XRT tools.
***********************************************************
*        WARNING          WARNING          WARNING        *
*          Versal Platform is NOT in default boot         *
***********************************************************

---------------------------------------------------
[0000:17:00.1] : xilinx_vck5000_gen4x8_qdma_base_2
---------------------------------------------------
Platform
  XSA Name               : xilinx_vck5000_gen4x8_qdma_base_2
  Platform UUID          : 05DCA096-76CB-730B-8D19-EC1192FBAE3F
  FPGA Name              :
  JTAG ID Code           : 0x0
  DDR Size               : 0 Bytes
  DDR Count              : 0
  Revision               : A
  MFG Date               : 0xcc344c
  Mig Calibrated         : false
  P2P Status             : not supported

Mac Addresses            : 00:0A:35:0A:7F:AE
                         : 00:0A:35:0A:7F:AF

Xclbin UUID
  20000000-0000-0000-003E-9D3F3A2E0300

Compute Units
  PL Compute Units
    Index   Name                                              Base_Address    Usage   Status

  PS Compute Units
    Index   Name                                              Base_Address    Usage   Status
```

#### Documentation impact (if any)
