### PR TITLE
Displaying only valid sensors in the xrt tool report command

### DIFF
--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -142,6 +142,7 @@ struct sdm_sensor_info
     result_type output;
     std::vector<std::string> stats;
     std::string errmsg;
+    const std::string SD_PRESENT_CHECK = "1";
 
     // The voltage_sensors_raw is printing in formatted string of each line
     // Format: "%s,%u,%u,%u,%u"
@@ -155,7 +156,7 @@ struct sdm_sensor_info
       tokenizer tokens(line, sep);
 
       if (std::distance(tokens.begin(), tokens.end()) != 6)
-        throw xrt_core::query::sysfs_error("CU statistic sysfs node corrupted");
+        throw xrt_core::query::sysfs_error("Sensor sysfs node corrupted");
 
       data_type data { };
       tokenizer::iterator tok_it = tokens.begin();
@@ -164,9 +165,10 @@ struct sdm_sensor_info
       data.input     = std::stoi(std::string(*tok_it++));
       data.average   = std::stoi(std::string(*tok_it++));
       data.max       = std::stoi(std::string(*tok_it++));
-      data.status    = std::stoi(std::string(*tok_it++));
+      data.status    = std::string(*tok_it++);
       data.unitm     = std::stoi(std::string(*tok_it++));
-      output.push_back(data);
+      if (data.status == SD_PRESENT_CHECK)
+	 output.push_back(data);
     }
 
     return output;

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -142,7 +142,7 @@ struct sdm_sensor_info
     result_type output;
     std::vector<std::string> stats;
     std::string errmsg;
-    const std::string SD_PRESENT_CHECK = "1";
+    constexpr const char* sd_present_check = "1";
 
     // The voltage_sensors_raw is printing in formatted string of each line
     // Format: "%s,%u,%u,%u,%u"
@@ -167,7 +167,7 @@ struct sdm_sensor_info
       data.max       = std::stoi(std::string(*tok_it++));
       data.status    = std::string(*tok_it++);
       data.unitm     = std::stoi(std::string(*tok_it++));
-      if (data.status == SD_PRESENT_CHECK)
+      if (data.status == sd_present_check)
 	 output.push_back(data);
     }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
[CR-1146994](https://jira.xilinx.com/browse/CR-1146994)- Add command option support for sensor status reporting on Versal platforms
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
We are now displaying only valid sensors through the XRT tool report command, so a check has been added to verify the sensor status and only then add the sensor.
Sensor status byte value represents the following
     0 – Sensor Data not present
     1 - Sensor Data present & valid
     2 – sensor Data not available.
#### Risks (if any) associated the changes in the commit
low
#### What has been tested and how, request additional testing if necessary
Example: On vck5000, using xbutil examine -r thermal -d
Thermals
  Temperature            : Celcius
  PCB                    :     27 C
  device                 :     37 C
  vccint                 :     38 C
  cage_temp_0            :      0 C
  cage_temp_1            :      0 C

Now, the thermal report shows only valid sensor information:
Thermals
  Temperature            : Celcius
  PCB                    :     27 C
  device                 :     37 C
  vccint                 :     38 C

#### Documentation impact (if any)
na