### PR TITLE
Fix querying 'is_versal' on edge platforms

### DIFF
--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -345,7 +345,7 @@ XBUtilities::collect_devices( const std::set<std::string> &_deviceBDFs,
     else
       device = xrt_core::get_mgmtpf_device(index);
 
-    if (xrt_core::device_query<xq::is_versal>(device))
+    if (xrt_core::device_query_default<xq::is_versal>(device, false))
       check_versal_boot(device);
 
     return device;


### PR DESCRIPTION
Signed-off-by: rbramand <rbramand@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Querying is_versal on edge platforms throws as this query request is not defined for edge platforms. Using device_query_default to fix this issue.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Alternatively we can define that query for edge platforms but there is no operation specific to versal in edge platforms userspace.

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
Tested all xbutil commands on vck190 device and they are working as expected

#### Documentation impact (if any)
NA