### PR TITLE
Initial APU time sync commit to synchronize APU date/time with host

### DIFF
--- a/src/runtime_src/core/common/drv/include/kds_core.h
+++ b/src/runtime_src/core/common/drv/include/kds_core.h
@@ -171,6 +171,9 @@ struct kds_sched {
 	bool			ert_disable;
 	u32			cu_intr;
 
+	/* APU Timestamp Set Flag */
+	bool			timestamp_set;
+
 	/* KDS polling thread */
 	struct task_struct     *polling_thread;
 	struct list_head	alive_cus; /* alive CU list */

--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -938,6 +938,7 @@ int kds_init_sched(struct kds_sched *kds)
 	/* At this point, I don't know if ERT subdev exist or not */
 	kds->ert_disable = true;
 	kds->ini_disable = false;
+	kds->timestamp_set = false;
 	init_completion(&kds->comp);
 	init_waitqueue_head(&kds->wait_queue);
 
@@ -1569,6 +1570,7 @@ void kds_reset(struct kds_sched *kds)
 {
 	kds->bad_state = 0;
 	kds->ini_disable = false;
+	kds->timestamp_set = false;
 
 	if (!kds->ert)
 		kds->ert_disable = true;

--- a/src/runtime_src/core/edge/drm/zocl/zocl_ctrl_ert.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_ctrl_ert.c
@@ -10,6 +10,7 @@
  * License version 2 or Apache License, Version 2.0.
  */
 
+#include <linux/time.h>
 #include <linux/platform_device.h>
 #include <linux/of_address.h>
 #include <linux/of_irq.h>
@@ -819,6 +820,18 @@ static void zert_cmd_identify(struct zocl_ctrl_ert *zert, struct xgq_cmd_sq_hdr 
 	r->minor = ZERT_CMD_HANDLER_VER_MINOR;
 }
 
+static void zert_cmd_timeset(struct zocl_ctrl_ert *zert, struct xgq_cmd_sq_hdr *cmd,
+			      struct xgq_com_queue_entry *resp)
+{
+	struct xgq_cmd_timeset *c = (struct xgq_cmd_timeset *)cmd;
+	struct timespec64 ts;
+	int ret = 0;
+
+	ts = ns_to_timespec64((const long long int)(c->ts));
+	ret = do_settimeofday64(&ts);
+	init_resp(resp, cmd->cid, ret);
+}
+
 static void zert_cmd_cfg_start(struct zocl_ctrl_ert *zert, struct xgq_cmd_sq_hdr *cmd,
 			       struct xgq_com_queue_entry *resp)
 {
@@ -978,7 +991,8 @@ struct zert_ops {
 	{ XGQ_CMD_OP_CFG_END, "XGQ_CMD_OP_CFG_END", zert_cmd_cfg_end },
 	{ XGQ_CMD_OP_CFG_CU, "XGQ_CMD_OP_CFG_CU", zert_cmd_cfg_cu },
 	{ XGQ_CMD_OP_QUERY_CU, "XGQ_CMD_OP_QUERY_CU", zert_cmd_query_cu },
-	{ XGQ_CMD_OP_IDENTIFY, "XGQ_CMD_OP_IDENTIFY", zert_cmd_identify }
+	{ XGQ_CMD_OP_IDENTIFY, "XGQ_CMD_OP_IDENTIFY", zert_cmd_identify },
+	{ XGQ_CMD_OP_TIMESET, "XGQ_CMD_OP_TIMESET", zert_cmd_timeset }
 };
 
 static inline const struct zert_ops *opcode2op(u32 op)

--- a/src/runtime_src/core/include/xgq_cmd_common.h
+++ b/src/runtime_src/core/include/xgq_cmd_common.h
@@ -116,6 +116,7 @@ enum xgq_cmd_opcode {
 	XGQ_CMD_OP_BARRIER		= 0x200,
 	XGQ_CMD_OP_EXIT_ERT		= 0x201,
 	XGQ_CMD_OP_IDENTIFY		= 0x202,
+	XGQ_CMD_OP_TIMESET		= 0x204,
 };
 
 enum xgq_cmd_addr_type {
@@ -300,7 +301,7 @@ struct xgq_cmd_configure {
 };
 
 /**
- * struct xgq_cmd_indentify: identify command
+ * struct xgq_cmd_identify: identify command
  *
  * @hdr: header of the command
  *
@@ -312,7 +313,7 @@ struct xgq_cmd_identify {
 };
 
 /**
- * struct xgq_cmd_resp_indentify: identify command response
+ * struct xgq_cmd_resp_identify: identify command response
  *
  * @minor: minor version of the XGQ command set
  * @major: major version of the XGQ command set
@@ -328,6 +329,28 @@ struct xgq_cmd_resp_identify {
 		};
 		uint32_t result;
 	};
+	uint32_t resvd;
+	uint32_t rcode;
+};
+
+/**
+ * struct xgq_cmd_timeset: timeset command
+ *
+ * @hdr: header of the command
+ *
+ * This command is used to set Linux system time
+ */
+struct xgq_cmd_timeset {
+	struct xgq_cmd_sq_hdr  hdr;
+	int64_t ts;
+};
+
+/**
+ * struct xgq_cmd_resp_indentify: timeset command response
+ */
+struct xgq_cmd_resp_timeset {
+	struct xgq_cmd_cq_hdr  hdr;
+	uint32_t result;
 	uint32_t resvd;
 	uint32_t rcode;
 };

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -2034,7 +2034,8 @@ static int xocl_kds_update_xgq(struct xocl_dev *xdev, int slot_hdl,
 	}
 
 	// Set APU Timestamp
-	xocl_kds_xgq_set_timestamp(xdev);
+	if (major != 1)
+		xocl_kds_xgq_set_timestamp(xdev);
 
 	ret = xocl_kds_xgq_cfg_start(xdev, cfg, num_cus, num_scus);
 	if (ret)


### PR DESCRIPTION
Add new command to set date/time on APU
Update xclbin download flow to update APU date/time

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Enable setting of APU date/time from host

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Enhancement

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Tested on v70

#### Documentation impact (if any)
None
