### PR TITLE
Displaying only valid sensors in the xrt tool report command (#7270)

### DIFF
--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -142,6 +142,7 @@ struct sdm_sensor_info
     result_type output;
     std::vector<std::string> stats;
     std::string errmsg;
+    constexpr const char* sd_present_check = "1";
 
     // The voltage_sensors_raw is printing in formatted string of each line
     // Format: "%s,%u,%u,%u,%u"
@@ -155,7 +156,7 @@ struct sdm_sensor_info
       tokenizer tokens(line, sep);
 
       if (std::distance(tokens.begin(), tokens.end()) != 6)
-        throw xrt_core::query::sysfs_error("CU statistic sysfs node corrupted");
+        throw xrt_core::query::sysfs_error("Sensor sysfs node corrupted");
 
       data_type data { };
       tokenizer::iterator tok_it = tokens.begin();
@@ -164,9 +165,10 @@ struct sdm_sensor_info
       data.input     = std::stoi(std::string(*tok_it++));
       data.average   = std::stoi(std::string(*tok_it++));
       data.max       = std::stoi(std::string(*tok_it++));
-      data.status    = std::stoi(std::string(*tok_it++));
+      data.status    = std::string(*tok_it++);
       data.unitm     = std::stoi(std::string(*tok_it++));
-      output.push_back(data);
+      if (data.status == sd_present_check)
+	 output.push_back(data);
     }
 
     return output;


### PR DESCRIPTION
* Adding check to display only valid sensors in report

* Fix review comment

Signed-off-by: saumya garg <saumyag@xilinx.com>

Signed-off-by: saumya garg <saumyag@xilinx.com>
Co-authored-by: saumya garg <saumyag@xilinx.com>
(cherry picked from commit 6d9997068634fafb5c58b49ea6297b753d3359e3)

Signed-off-by: saumya garg <saumyag@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
cherry picked from master branch
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
