### PR TITLE
Modify xrt_hwctx_handle to support all the variants of a hwctx

### DIFF
--- a/src/runtime_src/core/include/xrt/xrt_hw_context.h
+++ b/src/runtime_src/core/include/xrt/xrt_hw_context.h
@@ -14,7 +14,7 @@
 #include <map>
 
 // Opaque handle for internal use
-struct xrt_hwctx_handle;
+class xrt_hwctx_handle;
 
 namespace xrt {
 

--- a/src/runtime_src/core/include/xrt_hwctx.h
+++ b/src/runtime_src/core/include/xrt_hwctx.h
@@ -4,8 +4,8 @@
 #define XRT_HWCTX_H_
 
 #include <cstdint>
-
-#ifdef __cplusplus
+#include <stdexcept>
+#include <variant>
 
 #ifdef _WIN32
 # pragma warning( push )
@@ -13,27 +13,58 @@
 #endif
 
 // Shim level representation of a hardware context handle is an opaque
-// pointer, e.g. a void*, but when the handle is exchanged between
-// shim and XRT common layer it is wrapped in a typed
-// xrt_hwctx_handle.
+// pointer, but when the handle is exchanged between shim and XRT
+// common layer it is wrapped in a typed xrt_hwctx_handle.
 //
-// The struct allows the handle to be both a true pointer to some
-// opaque structure managed by shim, or a slot index for legacy
-// reasons.
-struct xrt_hwctx_handle
+// The struct allows the handle to be both a pointer to
+// xrt_hwctx_handle for classes derived from xrt_hwctx_handle, and it
+// allows a completely opaque void*, or a just a slot index.  All
+// these variants are too obscure, but this is for supporting existing
+// use while we clean up the ishim layer.  A hwctx_handle should be
+// simply a pointer to an object of this class, but for now it is
+// passed around by value.
+class xrt_hwctx_handle
 {
-  union {
-    void* handle;
-    uint64_t slot;
-  };
+  using self = xrt_hwctx_handle;
+  std::variant<self*, void*, uint32_t> m_handle;
 
-  xrt_hwctx_handle() : handle(nullptr) {}
-  xrt_hwctx_handle(void* hdl) : handle(hdl) {}
-  xrt_hwctx_handle(uint32_t slotidx) : slot(slotidx) {}
-  operator void* () const { return handle; }
-  operator uint32_t () const { return static_cast<uint32_t>(slot); }
-  bool operator<  (const xrt_hwctx_handle& rhs) const { return handle < rhs.handle; }
-  bool operator== (const xrt_hwctx_handle& rhs) const { return handle == rhs.handle; }
+  // Get the slotidx from a handle.  This is for supporting
+  // legacy xrt::kernel::group_id() which encodes the slotidx
+  // in xrt::bo flags for driver.   This again is obscure and
+  // xrt::kernel::group_id should not do any encoding, instead
+  // the hwctx specific xrt::bo constructors should be used.
+  virtual uint32_t
+  get_slotidx() const
+  {
+    switch (m_handle.index()) {
+    case 0:
+      // For classes derived from xrt_hwctx_handle
+      return std::get<0>(m_handle)->get_slotidx();
+    case 1:
+      // Slot index is not accessible for an opaque void* handle.
+      // For shims with void* opaque handle it is not safe to throw
+      // as long as xrt::kernel::group_id() uses this function.
+      return 0;
+    case 2:
+      // For legacy slotidx handles
+      return std::get<2>(m_handle);
+    }
+
+    throw std::runtime_error("Bad index");
+  }
+
+public:
+  xrt_hwctx_handle() {}
+  xrt_hwctx_handle(self* hdl) : m_handle{hdl} {}
+  xrt_hwctx_handle(void* hdl) : m_handle{hdl} {}
+  xrt_hwctx_handle(uint32_t slotidx) : m_handle{slotidx} {}
+  virtual ~xrt_hwctx_handle() {}
+  operator self* () const { return std::get<0>(m_handle); }
+  operator void* () const { return std::get<1>(m_handle); }
+  operator uint32_t () const { return get_slotidx(); }
+  bool operator<  (const xrt_hwctx_handle& rhs) const { return m_handle < rhs.m_handle; }
+  bool operator== (const xrt_hwctx_handle& rhs) const { return m_handle == rhs.m_handle; }
+
 };
 
 const xrt_hwctx_handle XRT_NULL_HWCTX {0xffffffff};
@@ -41,7 +72,5 @@ const xrt_hwctx_handle XRT_NULL_HWCTX {0xffffffff};
 #ifdef _WIN32
 # pragma warning( pop )
 #endif
-
-#endif // __cplusplus
 
 #endif

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -376,14 +376,14 @@ struct xclbin_slots
 
       if (std::distance(tokens.begin(), tokens.end()) == 1) {
         tokenizer::iterator tok_it = tokens.begin();
-        data.slot.slot = 0;
+        data.slot = static_cast<uint32_t>(0);
         data.uuid = std::string(*tok_it++);
         xclbin_data.push_back(std::move(data));
 	break;
       }
       else if (std::distance(tokens.begin(), tokens.end()) == 2) {
         tokenizer::iterator tok_it = tokens.begin();
-        data.slot.slot = std::stoi(std::string(*tok_it++));
+        data.slot = static_cast<uint32_t>(std::stoi(std::string(*tok_it++)));
         data.uuid = std::string(*tok_it++);
 
         xclbin_data.push_back(std::move(data));


### PR DESCRIPTION
#### Problem solved by the commit
This PR changes xrt_hwctx_handle into a class that supports holding either an class derived from xrt_hwctx_handle, a void*, or a slotidx.

This change is necessary for shims that migrate towards representing a hwctx as an opaque handle. 

#### How problem was solved, alternative solutions (if any) and why they were rejected
By converting xrt_hwctx_handle into a base class, a shim derived class can redefine methods for accessing private details, e.g. slotidx, of a context handle.

The slotidx is currently used by xrt::kernel::group_id to encode in flags used when constructing an xrt::bo.  A new hwctx aware xrt::bo constructor has been added, but legacy applications do not use this constructor and continue to rely on the encoding of slotidx.

Until the encoding can be removed, the class xrt_hwctx_handle has a virtual override that can be redefined by shim to return the slotidx, this allows the existing encoding to continue to be used.

#### What has been tested and how, request additional testing if necessary
Standard regression tests.

Signed-off-by: Soren Soe <2106410+stsoe@users.noreply.github.com>
