### PR TITLE
Fixed CR-1149084, for legacy cu create we also need to reserve the Cu…

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -2433,6 +2433,8 @@ static int xocl_kds_update_xgq(struct xocl_dev *xdev, int slot_hdl,
 
 create_regular_cu:
 	/* Regular CU directly talks to CU, without XGQ */
+	/* Reserve the subdevices for all the CUs before create them */
+	xocl_kds_reserve_cu_subdevices(xdev, cu_info, num_cus);
 	xocl_kds_create_cus(xdev, cu_info, num_cus);
 	XDEV(xdev)->kds.xgq_enable = false;
 


### PR DESCRIPTION
…s index

Signed-off-by: Saifuddin <saifuddi@amd.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
CR-1149084

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
hw context changes introduce this issue. 

#### How problem was solved, alternative solutions (if any) and why they were rejected
Actually as per the new implementation we need to reserve the CUs index before crate them. 
This is required for both XQG and legacy case. For HW context changes we have done for XQG case but for legacy case  we missed it. 

#### Risks (if any) associated the changes in the commit
N/A
#### What has been tested and how, request additional testing if necessary
Regular validate and this CR
#### Documentation impact (if any)
N/A