### PR TITLE
Legacy multiple context issue

### DIFF
--- a/src/runtime_src/core/common/drv/include/kds_core.h
+++ b/src/runtime_src/core/common/drv/include/kds_core.h
@@ -74,6 +74,7 @@ enum kds_cu_domain {
  */
 #define MAX_SLOT 32
 #define MAX_CU_STAT_LINE_LENGTH  128
+#define DEFAULT_HW_CTX_ID	0
 
 enum kds_type {
 	KDS_CU		= 0,

--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -1266,20 +1266,25 @@ void kds_fini_client(struct kds_sched *kds, struct kds_client *client)
 	struct kds_client_hw_ctx *curr = NULL;
 	struct kds_client_ctx *c_curr = NULL;
 
-	/* Release legacy client's resources */
+	/* Release legacy client's resources for XOCL */
 	if (client->ctx) {
 		_kds_fini_client(kds, client, client->ctx);
+		mutex_lock(&client->lock);
 		curr = kds_get_hw_ctx_by_id(client, 0 /* default hw cx id */);
 		if (curr)
 			kds_free_hw_ctx(client, curr);
+		mutex_unlock(&client->lock);
 	}
+	/* this is for ZOCL legacy client */
 	if(!list_empty(&client->ctx_list)) {
 		list_for_each_entry(c_curr, &client->ctx_list, link) {
 			_kds_fini_client(kds, client, c_curr);
 		}
+		mutex_lock(&client->lock);
 		curr = kds_get_hw_ctx_by_id(client, 0 /* default hw cx id */);
 		if (curr)
 			kds_free_hw_ctx(client, curr);
+		mutex_unlock(&client->lock);
 	}
 
 	if(!list_empty(&client->hw_ctx_list)) {

--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -1261,30 +1261,33 @@ out:
 	mutex_unlock(&client->lock);
 }
 
+static int kds_free_default_hw_ctx(struct kds_client *client)
+{
+	struct kds_client_hw_ctx *curr = NULL;
+
+	mutex_lock(&client->lock);
+	curr = kds_get_hw_ctx_by_id(client, DEFAULT_HW_CTX_ID);
+	if (curr)
+		kds_free_hw_ctx(client, curr);
+	mutex_unlock(&client->lock);
+
+	return 0;
+}
+
 void kds_fini_client(struct kds_sched *kds, struct kds_client *client)
 {
 	struct kds_client_hw_ctx *curr = NULL;
 	struct kds_client_ctx *c_curr = NULL;
 
-	/* Release legacy client's resources for XOCL */
-	if (client->ctx) {
+	/* Release legacy client's resources */
+	if ((client->ctx) || !list_empty(&client->ctx_list)) {
 		_kds_fini_client(kds, client, client->ctx);
-		mutex_lock(&client->lock);
-		curr = kds_get_hw_ctx_by_id(client, 0 /* default hw cx id */);
-		if (curr)
-			kds_free_hw_ctx(client, curr);
-		mutex_unlock(&client->lock);
-	}
-	/* this is for ZOCL legacy client */
-	if(!list_empty(&client->ctx_list)) {
-		list_for_each_entry(c_curr, &client->ctx_list, link) {
-			_kds_fini_client(kds, client, c_curr);
-		}
-		mutex_lock(&client->lock);
-		curr = kds_get_hw_ctx_by_id(client, 0 /* default hw cx id */);
-		if (curr)
-			kds_free_hw_ctx(client, curr);
-		mutex_unlock(&client->lock);
+
+		if(!list_empty(&client->ctx_list))
+			list_for_each_entry(c_curr, &client->ctx_list, link)
+				_kds_fini_client(kds, client, c_curr);
+
+		kds_free_default_hw_ctx(client);
 	}
 
 	if(!list_empty(&client->hw_ctx_list)) {

--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -1216,11 +1216,6 @@ _kds_fini_client(struct kds_sched *kds, struct kds_client *client,
 			goto out;
 		}
 
-		if (kds_free_hw_ctx(client, cu_ctx->hw_ctx)) {
-			kds_err(client, "Freeing HW Context failed");
-			goto out;
-		}
-
 		if (kds_free_cu_ctx(client, cu_ctx)) {
 			kds_err(client, "Freeing CU Context failed");
 			goto out;
@@ -1272,11 +1267,19 @@ void kds_fini_client(struct kds_sched *kds, struct kds_client *client)
 	struct kds_client_ctx *c_curr = NULL;
 
 	/* Release legacy client's resources */
-	_kds_fini_client(kds, client, client->ctx);
+	if (client->ctx) {
+		_kds_fini_client(kds, client, client->ctx);
+		curr = kds_get_hw_ctx_by_id(client, 0 /* default hw cx id */);
+		if (curr)
+			kds_free_hw_ctx(client, curr);
+	}
 	if(!list_empty(&client->ctx_list)) {
 		list_for_each_entry(c_curr, &client->ctx_list, link) {
 			_kds_fini_client(kds, client, c_curr);
 		}
+		curr = kds_get_hw_ctx_by_id(client, 0 /* default hw cx id */);
+		if (curr)
+			kds_free_hw_ctx(client, curr);
 	}
 
 	if(!list_empty(&client->hw_ctx_list)) {

--- a/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
@@ -139,7 +139,7 @@ zocl_remove_client_context(struct drm_zocl_dev *zdev,
 
 	/* For legacy context case there are only one hw context possible i.e. 0
 	*/
-	hw_ctx = kds_get_hw_ctx_by_id(client, 0 /* default hw cx id */);
+	hw_ctx = kds_get_hw_ctx_by_id(client, DEFAULT_HW_CTX_ID);
 	kds_free_hw_ctx(client, hw_ctx);
 
 	/* Get the corresponding slot for this xclbin */
@@ -313,7 +313,7 @@ zocl_add_context(struct drm_zocl_dev *zdev, struct kds_client *client,
 
         /* For legacy context case there are only one hw context possible i.e. 0
          */
-        hw_ctx = kds_get_hw_ctx_by_id(client, 0 /* default hw cx id */);
+        hw_ctx = kds_get_hw_ctx_by_id(client, DEFAULT_HW_CTX_ID);
         if (!hw_ctx) {
                 DRM_ERROR("No valid HW context is open");
 		zocl_remove_client_context(zdev, client, cctx);
@@ -395,7 +395,7 @@ int zocl_add_context_kernel(struct drm_zocl_dev *zdev, void *client_hdl,
 
 	/* For legacy context case there are only one hw context possible i.e. 0
 	 */
-	hw_ctx = kds_get_hw_ctx_by_id(client, 0 /* default hw cx id */);
+	hw_ctx = kds_get_hw_ctx_by_id(client, DEFAULT_HW_CTX_ID);
 	if (!hw_ctx) {
 		DRM_ERROR("No valid HW context is open");
 		mutex_unlock(&client->lock);
@@ -450,7 +450,7 @@ int zocl_del_context_kernel(struct drm_zocl_dev *zdev, void *client_hdl,
 	if (list_empty(&cctx->cu_ctx_list)) {
 		/* For legacy context case there are only one hw context possible i.e. 0
 		*/
-		hw_ctx = kds_get_hw_ctx_by_id(client, 0 /* default hw cx id */);
+		hw_ctx = kds_get_hw_ctx_by_id(client, DEFAULT_HW_CTX_ID);
 		kds_free_hw_ctx(client, hw_ctx);
 
 		list_del(&cctx->link);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -242,7 +242,7 @@ static int xocl_add_context(struct xocl_dev *xdev, struct kds_client *client,
 	}
 
 	/* For legacy context case there are only one hw context possible i.e. 0 */
-	hw_ctx = kds_get_hw_ctx_by_id(client, 0 /* default hw cx id */);
+	hw_ctx = kds_get_hw_ctx_by_id(client, DEFAULT_HW_CTX_ID);
         if (!hw_ctx) {
                 userpf_err(xdev, "No valid HW context is open");
                 ret = -EINVAL;
@@ -327,7 +327,7 @@ static int xocl_del_context(struct xocl_dev *xdev, struct kds_client *client,
 
 	/* unlock bitstream if there is no opening context */
 	if (list_empty(&client->ctx->cu_ctx_list)) {
-		hw_ctx = kds_get_hw_ctx_by_id(client, 0 /* default hw cx id */);
+		hw_ctx = kds_get_hw_ctx_by_id(client, DEFAULT_HW_CTX_ID);
 		if (hw_ctx)
 			kds_free_hw_ctx(client, hw_ctx);
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -285,6 +285,7 @@ out:
 static int xocl_del_context(struct xocl_dev *xdev, struct kds_client *client,
 			    struct drm_xocl_ctx *args)
 {
+	struct kds_client_hw_ctx *hw_ctx = NULL;
 	struct kds_client_cu_ctx *cu_ctx = NULL;
 	struct kds_client_cu_info cu_info = {};
 	xuid_t *uuid;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -320,20 +320,16 @@ static int xocl_del_context(struct xocl_dev *xdev, struct kds_client *client,
 	if (ret)
 		goto out;
 
-	if (cu_ctx->hw_ctx) {
-		ret = kds_free_hw_ctx(client, cu_ctx->hw_ctx);
-		if (ret)
-			goto out;
-
-		cu_ctx->hw_ctx = NULL;
-	}
-
 	ret = kds_free_cu_ctx(client, cu_ctx);
 	if (ret)
 		goto out;
 
 	/* unlock bitstream if there is no opening context */
 	if (list_empty(&client->ctx->cu_ctx_list)) {
+		hw_ctx = kds_get_hw_ctx_by_id(client, 0 /* default hw cx id */);
+		if (hw_ctx)
+			kds_free_hw_ctx(client, hw_ctx);
+
 		vfree(client->ctx->xclbin_id);
 		client->ctx->xclbin_id = NULL;
 		(void) xocl_icap_unlock_bitstream(xdev, &args->xclbin_id);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
- There is a issue for multiple legacy context reported by Soren. Actually for backward comparability we are  introduced a default hw context for legacy context  for XCL API test case. But while deleting the context we haven't check if there are multiple CU context is active for same hw context. 

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
- Multslot hw context introduce this issue

#### How problem was solved, alternative solutions (if any) and why they were rejected
- Added the proper sanity check before deleting the hw context 

#### Risks (if any) associated the changes in the commit
- N/A 

#### What has been tested and how, request additional testing if necessary
- Basic validate and test case provided by soren

#### Documentation impact (if any)
- N/A