### PR TITLE
CR-1149239 xrt failed to write more registers when ert_start_kernel_cmd count is larger

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/zocl_cu_xgq.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_cu_xgq.c
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0 OR Apache-2.0 */
 /*
- * Copyright (C) 2021-2022 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Xilinx, Inc. All rights reserved.
  *
  * Author(s):
  *        Max Zhen <maxz@xilinx.com>
@@ -25,7 +25,7 @@
 #define zcu_xgq_info(zcu_xgq, fmt, args...)	zocl_info(ZCU_XGQ2DEV(zcu_xgq), fmt"\n", ##args)
 #define zcu_xgq_dbg(zcu_xgq, fmt, args...)	zocl_dbg(ZCU_XGQ2DEV(zcu_xgq), fmt"\n", ##args)
 
-#define ZCU_XGQ_MAX_SLOT_SIZE	1024
+#define ZCU_XGQ_MAX_SLOT_SIZE	4096
 
 /* We can't support FAST PATH with multislot. As we are initializing the CU XGQs
  * at the probe time and there could be a chance that in future multiple


### PR DESCRIPTION
Signed-off-by: Min Ma <min.ma@amd.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
CR-1149239

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
This bug is here at the beginning. Recently, there is a DPU related use case will need to create a command more than 1KB and less than 2KB. So, this is exposed.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Extent the command slow size limited to 4KB.

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
V70

#### Documentation impact (if any)
no