### PR TITLE
CR-1149626 Add logic to control SC flashing on Versal platforms

### DIFF
--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -362,15 +362,6 @@ are_scs_equal(const DSAInfo& candidate, const DSAInfo& current)
 }
 
 static bool
-is_sc_inactive(const DSAInfo& current)
-{
-  if (current.dsaname().empty())
-    throw std::runtime_error("Current shell name is empty.");
-
-  return (current.bmcVer.compare("INACTIVE") == 0);
-}
-
-static bool
 update_sc(unsigned int boardIdx, DSAInfo& candidate)
 {
   Flasher flasher(boardIdx);
@@ -398,12 +389,6 @@ update_sc(unsigned int boardIdx, DSAInfo& candidate)
   if ((same_bmc == true) && (XBU::getForce() == true)) {
     std::cout << "INFO: Forcing flashing of the Satellite Controller (SC) image (Force flag is set).\n";
     same_bmc = false;
-  }
-
-  auto dev = xrt_core::get_mgmtpf_device(boardIdx);
-  if (xrt_core::device_query<xrt_core::query::is_versal>(dev) && is_sc_inactive(current)) {
-    std::cout << "WARNING: Current SC is incompatible with the current shell. Use `xbmgmt program -b SC --image` to specify the desired SC package\n";
-    return false;
   }
 
   // Don't program the same images

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -362,6 +362,15 @@ are_scs_equal(const DSAInfo& candidate, const DSAInfo& current)
 }
 
 static bool
+is_sc_inactive(const DSAInfo& current)
+{
+  if (current.dsaname().empty())
+    throw std::runtime_error("Current shell name is empty.");
+
+  return (current.bmcVer.compare("INACTIVE") == 0);
+}
+
+static bool
 update_sc(unsigned int boardIdx, DSAInfo& candidate)
 {
   Flasher flasher(boardIdx);
@@ -389,6 +398,12 @@ update_sc(unsigned int boardIdx, DSAInfo& candidate)
   if ((same_bmc == true) && (XBU::getForce() == true)) {
     std::cout << "INFO: Forcing flashing of the Satellite Controller (SC) image (Force flag is set).\n";
     same_bmc = false;
+  }
+
+  auto dev = xrt_core::get_mgmtpf_device(boardIdx);
+  if (xrt_core::device_query<xrt_core::query::is_versal>(dev) && is_sc_inactive(current)) {
+    std::cout << "WARNING: Current SC is incompatible with the current shell. Use `xbmgmt program -b SC --image` to specify the desired SC package\n";
+    return false;
   }
 
   // Don't program the same images

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -324,7 +324,7 @@ report_status(const std::string& vbnv, boost::property_tree::ptree& pt_device)
     action_list << boost::format("  [%s] : Program base (FLASH) image\n") % pt_device.get<std::string>("platform.bdf");
 
   if (!pt_device.get<bool>("platform.status.sc")) {
-    // Versal devices cannot flash the SC in the same cycle as the base
+    // Versal devices cannot flash the SC in the same cycle as the shell
     if (pt_device.get<bool>("platform.status.versal")) {
       if (pt_device.get<bool>("platform.status.shell"))
         action_list << boost::format("  [%s] : Program Satellite Controller (SC) image\n") % pt_device.get<std::string>("platform.bdf");
@@ -555,8 +555,9 @@ auto_flash(std::shared_ptr<xrt_core::device> & device, Flasher::E_FlasherType fl
   report_status(dsa.name, pt_dev);
 
   // Continue to flash whatever we have collected in boardsToUpdate.
-  bool needreboot = false;
-  bool need_warm_reboot = false;
+  enum class reboot_type {COLD_REBOOT, WARM_REBOOT, NOT_REQUIRED};
+  enum reboot_type reboot = reboot_type::NOT_REQUIRED;
+  const auto is_versal = xrt_core::device_query<xrt_core::query::is_versal>(device.get());
   std::stringstream report_stream;
 
   // Prompt user about what boards will be updated and ask for permission.
@@ -571,13 +572,14 @@ auto_flash(std::shared_ptr<xrt_core::device> & device, Flasher::E_FlasherType fl
       // 1) Flash the Satellite Controller image
       if (xrt_core::device_query<xrt_core::query::is_mfg>(device.get()) || xrt_core::device_query<xrt_core::query::is_recovery>(device.get()))
         report_stream << boost::format("  [%s] : Factory or Recovery image detected. Reflash the device after the reboot to update the SC firmware.\n") % getBDF(p.first);
-      // Versal devices cannot flash the SC in the same cycle as the base
-      else if (xrt_core::device_query<xrt_core::query::is_versal>(device.get()) && !same_shell)
+      // Versal devices cannot flash the SC in the same cycle as the shell
+      else if (is_versal && !same_shell)
         report_stream << boost::format("  [%s] : Reflash the device after the reboot to update the SC firmware.\n") % getBDF(p.first);
       else {
         if (update_sc(p.first, p.second) == true)  {
-          report_stream << boost::format("  [%s] : Successfully flashed the Satellite Controller (SC) image\n") % getBDF(p.first);
-          need_warm_reboot = true;
+          report_stream << boost::format("  [%s] : Successfully flashed the Satellite Controller (SC) image\n") % getBDF(p.first);\
+          // Versal devices require a cold reboot to initialize the SC firmware
+          reboot = is_versal ? reboot_type::COLD_REBOOT : reboot_type::WARM_REBOOT;
         } else
           report_stream << boost::format("  [%s] : Satellite Controller (SC) is either up-to-date, fixed, or not installed. No actions taken.\n") % getBDF(p.first);
       }
@@ -585,7 +587,7 @@ auto_flash(std::shared_ptr<xrt_core::device> & device, Flasher::E_FlasherType fl
       // 2) Flash shell image
       if (update_shell(p.first, p.second, flashType) == true)  {
         report_stream << boost::format("  [%s] : Successfully flashed the base (e.g., shell) image\n") % getBDF(p.first);
-        needreboot = true;
+        reboot = reboot_type::COLD_REBOOT;
       } else
         report_stream << boost::format("  [%s] : Base (e.g., shell) image is up-to-date.  No actions taken.\n") % getBDF(p.first);
       } catch (const xrt_core::error& e) {
@@ -606,14 +608,23 @@ auto_flash(std::shared_ptr<xrt_core::device> & device, Flasher::E_FlasherType fl
     throw xrt_core::error(std::errc::operation_canceled);
   }
 
-  if (needreboot) {
+  switch (reboot) {
+  case reboot_type::COLD_REBOOT:
+  {
     std::cout << "****************************************************\n";
     std::cout << "Cold reboot machine to load the new image on device.\n";
     std::cout << "****************************************************\n";
-  } else if (need_warm_reboot) {
+    break;
+  }
+  case reboot_type::WARM_REBOOT:
+  {
     std::cout << "******************************************************************\n";
     std::cout << "Warm reboot is required to recognize new SC image on the device.\n";
     std::cout << "******************************************************************\n";
+    break;
+  }
+  case reboot_type::NOT_REQUIRED:
+    break;
   }
 }
 


### PR DESCRIPTION
Signed-off-by: Daniel Benusovich <dbenusov@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1147768
There is not a CLEAN way that customers can flash a shell on a Versal platform without warnings or errors. After flashing the shell the users are expected to flash the device again to update the SC, but, we make no mention of that requirement in the tooling. As a result, users are confused when their shells fail due to interacting the with incorrect SC.

To deal with this problem we would like to add three features:
1. Add a message when the user flashes a device with `xbmgmt program -d <BDF> -b` to output a warning stating to program again to change the SC (Versal devices only)
2. Update the messages being displayed when programming to device to reflect that either the shell or the SC are being flashed (Versal devices only)
3. Display a more substantial warning then the current `xbmgmt examine -b <BDF> -r platform` warning if the SC version does not match the expected SC version from the shell

There will be 2 PRs for this change.
The first deals with the flashing behavior (This PR)
The second deals with the additional warning message (Not this PR)

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
1. Add a message when the user flashes a device with `xbmgmt program -d <BDF> -b` to output a warning stating to program again to change the SC (Versal devices only)
2. Update the messages being displayed when programming to device to reflect that either the shell or the SC are being flashed (Versal devices only)

#### How problem was solved, alternative solutions (if any) and why they were rejected
Used the existing program reports and modified them to include logic for handling specific Versal issues.

#### Risks (if any) associated the changes in the commit
Could somehow affect Alveo cards if certain flags are added one day. The added logic is very specific to Versal, but, that does make maintenance a little more painful.

#### What has been tested and how, request additional testing if necessary
Centos, V70
Initial boot examine
```
[root@xsjyliu51 base]# xbmgmt examine -d 3b:00 -r platform
WARNING: Unexpected xclmgmt version (2.14.313) was found. Expected 2.15.0, to match XRT tools.

-----------------------------------------------
[0000:3b:00.0] : xilinx_v70_gen5x8_qdma_base_2
-----------------------------------------------
Flash properties
  Type                 : ospi_xgq
  Serial Number        : 51171A228B26

Device properties
  Type                 : v70
  Name                 : ALVEO V70 ES2

Flashable partitions running on FPGA
  Platform             : xilinx_v70_gen5x8_qdma_base_2
  SC Version           : 8.5.1
  Platform UUID        : 5439DA23-5282-922E-5124-6A57293B4C08
  Interface UUID       : 1540D50F-21A9-E6BF-21BB-551EC4E659AF

Flashable partitions installed in system
  Platform             : xilinx_v70_gen5x8_qdma_base_2
  SC Version           : 8.5.2
  Platform UUID        : 4DBF41A4-C095-3625-71FA-1BF25AFCDD7C

Bootable Partitions:
  Default              : ACTIVE
  Backup               : INACTIVE


  Mac Address          : 00:00:00:00:00:00

WARNING  : Device is not up-to-date.
```

1st flash
```
[root@xsjyliu51 base]# xbmgmt program -d 3b:00 -b
WARNING: Unexpected xclmgmt version (2.14.313) was found. Expected 2.15.0, to match XRT tools.
----------------------------------------------------
Device : [0000:3b:00.0]

Current Configuration
  Platform             : xilinx_v70_gen5x8_qdma_base_2
  SC Version           : 8.5.1
  Platform ID          : 0x5439da235282922e


Incoming Configuration
  Deployment File      : partition.xsabin
  Deployment Directory : /lib/firmware/xilinx/4dbf41a4c095362571fa1bf25afcdd7c
  Size                 : 6,404,142 bytes
  Timestamp            : Tue Jan 10 12:27:49 2023

  Platform             : xilinx_v70_gen5x8_qdma_base_2
  SC Version           : 8.5.2
  Platform UUID        : 4DBF41A4-C095-3625-71FA-1BF25AFCDD7C
----------------------------------------------------
Actions to perform:
  [0000:3b:00.0] : Program base (FLASH) image
----------------------------------------------------
Are you sure you wish to proceed? [Y/n]: Y

[0000:3b:00.0] : Updating base (e.g., shell) flash image...
PDI dsabin supports only primary bitstream: /lib/firmware/xilinx/4dbf41a4c095362571fa1bf25afcdd7c/partition.xsabin
INFO: ***xsabin has 6404142 bytes
INFO: ***Write 6404142 bytes
INFO     : Base flash image has been programmed successfully.
----------------------------------------------------
Report
  [0000:3b:00.0] : Reflash the device after the reboot to update the SC firmware.
  [0000:3b:00.0] : Successfully flashed the base (e.g., shell) image

Device flashed successfully.
****************************************************
Cold reboot machine to load the new image on device.
****************************************************
```

After reboot
2nd examine
```
[root@xsjyliu51 xocl]# xbmgmt examine -d 3b:00 -r platform
WARNING: Unexpected xclmgmt version (2.14.0) was found. Expected 2.15.0, to match XRT tools.

-----------------------------------------------
[0000:3b:00.0] : xilinx_v70_gen5x8_qdma_base_2
-----------------------------------------------
Flash properties
  Type                 : ospi_xgq
  Serial Number        : 51171A228B26

Device properties
  Type                 : v70
  Name                 : ALVEO V70 ES2

Flashable partitions running on FPGA
  Platform             : xilinx_v70_gen5x8_qdma_base_2
  SC Version           : 8.5.1
  Platform UUID        : 4DBF41A4-C095-3625-71FA-1BF25AFCDD7C
  Interface UUID       : 4401A96F-E8EF-F8B3-492A-8C61B18EB4D2

Flashable partitions installed in system
  Platform             : xilinx_v70_gen5x8_qdma_base_2
  SC Version           : 8.5.2
  Platform UUID        : 4DBF41A4-C095-3625-71FA-1BF25AFCDD7C

Bootable Partitions:
  Default              : ACTIVE
  Backup               : INACTIVE


  Mac Address          : 00:00:00:00:00:00

WARNING  : SC image on the device is not up-to-date.
```

2nd flash
```
[root@xsjyliu51 xocl]# xbmgmt program -d 3b:00 -b
WARNING: Unexpected xclmgmt version (2.14.0) was found. Expected 2.15.0, to match XRT tools.
----------------------------------------------------
Device : [0000:3b:00.0]

Current Configuration
  Platform             : xilinx_v70_gen5x8_qdma_base_2
  SC Version           : 8.5.1
  Platform ID          : 0x4dbf41a4c0953625


Incoming Configuration
  Deployment File      : partition.xsabin
  Deployment Directory : /lib/firmware/xilinx/4dbf41a4c095362571fa1bf25afcdd7c
  Size                 : 6,404,142 bytes
  Timestamp            : Tue Jan 10 12:27:49 2023

  Platform             : xilinx_v70_gen5x8_qdma_base_2
  SC Version           : 8.5.2
  Platform UUID        : 4DBF41A4-C095-3625-71FA-1BF25AFCDD7C
----------------------------------------------------
Actions to perform:
  [0000:3b:00.0] : Program Satellite Controller (SC) image
----------------------------------------------------
Are you sure you wish to proceed? [Y/n]: y

[0000:3b:00.0] : Updating Satellite Controller (SC) firmware flash image
Programming SC: ....................
[PASSED]: SC firmware image has been programmed successfully. < 20s >

INFO: Base (e.g., shell) flash images are the same.
----------------------------------------------------
Report
  [0000:3b:00.0] : Successfully flashed the Satellite Controller (SC) image
  [0000:3b:00.0] : Base (e.g., shell) image is up-to-date.  No actions taken.

Device flashed successfully.
****************************************************
Cold reboot machine to load the new image on device.
****************************************************
```

After reboot
3rd examine
```
-----------------------------------------------
[0000:3b:00.0] : xilinx_v70_gen5x8_qdma_base_2
-----------------------------------------------
Flash properties
  Type                 : ospi_xgq
  Serial Number        : 51171A228B26

Device properties
  Type                 : v70
  Name                 : ALVEO V70 ES2

Flashable partitions running on FPGA
  Platform             : xilinx_v70_gen5x8_qdma_base_2
  SC Version           : 8.5.2
  Platform UUID        : 4DBF41A4-C095-3625-71FA-1BF25AFCDD7C
  Interface UUID       : 4401A96F-E8EF-F8B3-492A-8C61B18EB4D2

Flashable partitions installed in system
  Platform             : xilinx_v70_gen5x8_qdma_base_2
  SC Version           : 8.5.2
  Platform UUID        : 4DBF41A4-C095-3625-71FA-1BF25AFCDD7C

Bootable Partitions:
  Default              : ACTIVE
  Backup               : INACTIVE


  Mac Address          : 00:00:00:00:00:00
```
#### Documentation impact (if any)
Nothing on XRT end. However, the platform team does need the new warnings and flashing instructions for their documentation.