### PR TITLE
CR-1147768 when VMR is offline, xbutil reset stops working (#7261)

### DIFF
--- a/src/runtime_src/core/common/info_vmr.cpp
+++ b/src/runtime_src/core/common/info_vmr.cpp
@@ -72,8 +72,18 @@ vmr_info(const xrt_core::device* device)
 }
 
 bool
-is_default_boot(const xrt_core::device* device)
+get_vmr_status(const xrt_core::device* device, vmr_status_type status)
 {
+  std::string status_string;
+  switch (status) {
+    case vmr_status_type::boot_on_default:
+      status_string = "Boot on default";
+      break;
+    default:
+      throw xrt_core::error(boost::str(boost::format("Unexpected key for VMR Status type %u") % static_cast<uint32_t>(status)));
+  }
+
+
   const auto pt = vmr_info(device);
   boost::property_tree::ptree pt_empty;
   const boost::property_tree::ptree& ptree = pt.get_child("vmr", pt_empty);
@@ -81,11 +91,11 @@ is_default_boot(const xrt_core::device* device)
     const boost::property_tree::ptree& vmr_stat = ks.second;
     const auto val = vmr_stat.get<std::string>("label");
     const auto nval = vmr_stat.get<std::string>("value");
-    if (boost::iequals(val, "Boot on default"))
+    if (boost::iequals(val, status_string))
       return boost::iequals(vmr_stat.get<std::string>("value"), "1");
   }
 
-  throw std::runtime_error("Missing 'Boot on default' data in VMR status");
+  throw xrt_core::error(boost::str(boost::format("Did not find %s label within VMR status") % status_string));
 }
 
 } // vmr, xrt

--- a/src/runtime_src/core/common/info_vmr.h
+++ b/src/runtime_src/core/common/info_vmr.h
@@ -15,9 +15,13 @@ XRT_CORE_COMMON_EXPORT
 boost::property_tree::ptree
 vmr_info(const xrt_core::device * device);
 
+enum class vmr_status_type {
+  boot_on_default = 0
+};
+
 XRT_CORE_COMMON_EXPORT
 bool
-is_default_boot(const xrt_core::device* device);
+get_vmr_status(const xrt_core::device* device, vmr_status_type status);
 
 }} // vmr, xrt
 

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -321,13 +321,46 @@ XBUtilities::collect_devices( const std::set<std::string> &_deviceBDFs,
   static void 
   check_versal_boot(const std::shared_ptr<xrt_core::device> &device)
   {
-    if (xrt_core::vmr::is_default_boot(device.get()))
+    std::vector<std::string> warnings;
+
+    try {
+      const auto is_default = xrt_core::vmr::get_vmr_status(device.get(), xrt_core::vmr::vmr_status_type::boot_on_default);
+      if (!is_default)
+        warnings.push_back("Versal Platform is NOT in default boot");
+    } catch (const xrt_core::error& e) {
+      warnings.push_back(e.what());
+    }
+
+    if (warnings.empty())
       return;
 
-    std::cout << "***********************************************************\n";
+    const std::string star_line = "***********************************************************";
+
+    std::cout << star_line << "\n";
     std::cout << "*        WARNING          WARNING          WARNING        *\n";
-    std::cout << "*             Versal Platform in backup boot              *\n";
-    std::cout << "***********************************************************\n";
+
+    // Print all warnings
+    for (const auto& warning : warnings) {
+      // Subtract the:
+      // 1. Side stars
+      // 2. Single space next to the side star
+      const size_t available_space = star_line.size() - 2 - 2;
+      // Account for strings who are larger than the star line
+      size_t warning_index = 0;
+      while (warning_index < warning.size()) {
+        // Extract the largest possible string from the warning
+        const auto warning_msg = warning.substr(warning_index, available_space);
+        // Update the index so the next substring is valid
+        warning_index += warning_msg.size();
+        const auto side_spaces = available_space - warning_msg.size();
+        // The left side should be larger than the right if there is an imbalance
+        const size_t left_spaces = (side_spaces % 2 == 0) ? side_spaces / 2 : (side_spaces / 2) + 1;
+        const size_t right_spaces = side_spaces / 2;
+        std::cout << "* " << std::string(left_spaces, ' ') << warning_msg << std::string(right_spaces, ' ') << " *\n";
+      }
+    }
+
+    std::cout << star_line << "\n";
   }
 
   std::shared_ptr<xrt_core::device>

--- a/src/runtime_src/core/tools/xbmgmt2/ReportPlatform.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/ReportPlatform.cpp
@@ -104,7 +104,7 @@ static boost::property_tree::ptree
 get_boot_info(const xrt_core::device * dev)
 {
   boost::property_tree::ptree ptree;
-  // get boot on default from vmr_status sysfs node
+  // get boot status from vmr_status sysfs node
   boost::property_tree::ptree pt_empty;
   const auto pt = xrt_core::vmr::vmr_info(dev).get_child("vmr", pt_empty);
   for (auto& ks : pt) {
@@ -112,8 +112,10 @@ get_boot_info(const xrt_core::device * dev)
     if (boost::iequals(vmr_stat.get<std::string>("label"), "Boot on default")) {
       auto is_default_boot = std::stoi(vmr_stat.get<std::string>("value"));
       ptree.add("default", is_default_boot ? "ACTIVE" : "INACTIVE");
-      ptree.add("backup", is_default_boot ? "INACTIVE" : "ACTIVE");
-      break;
+    }
+    if (boost::iequals(vmr_stat.get<std::string>("label"), "Boot on backup")) {
+      auto is_backup_boot = std::stoi(vmr_stat.get<std::string>("value"));
+      ptree.add("backup", is_backup_boot ? "ACTIVE" : "INACTIVE");
     }
   }
   return ptree;


### PR DESCRIPTION
* CR-1147768 when VMR is offline, xbutil reset stops working

Signed-off-by: David Zhang <davidzha@xilinx.com>

* Add logic to better capture warning messages

Signed-off-by: Daniel Benusovich <dbenusov@xilinx.com>

* Add support for very long warning messages wrapping into next line

Signed-off-by: Daniel Benusovich <dbenusov@xilinx.com>

* Refactor string to use enumeration for vmr status request

Signed-off-by: Daniel Benusovich <dbenusov@xilinx.com>

* Remove reference and const from primitive type

Signed-off-by: Daniel Benusovich <dbenusov@xilinx.com>

Signed-off-by: David Zhang <davidzha@xilinx.com>
Signed-off-by: Daniel Benusovich <dbenusov@xilinx.com>
Co-authored-by: Daniel Benusovich <dbenusov@xilinx.com>
(cherry picked from commit 30e688bd3147e61c8cc67ff7a302c5bbf4fe78f7)

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Back port of https://github.com/Xilinx/XRT/pull/7261

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Previous try catch would block users from flashing Versal device if a failure in the VMR occurred. This was very frustrating to fix without developer access.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Catch the exception and generate a better warning message.

#### Risks (if any) associated the changes in the commit
None.

#### What has been tested and how, request additional testing if necessary
Ubuntu 20.04 VCK5000 in Backup boot
```
root@xsjdbenusov50:~# xbmgmt examine -d 17:00
***********************************************************
*        WARNING          WARNING          WARNING        *
*          Versal Platform is NOT in default boot         *
***********************************************************

---------------------------------------------------
[0000:17:00.0] : xilinx_vck5000_gen4x8_qdma_base_2
---------------------------------------------------
Flash properties
  Type                 : ospi_xgq
  Serial Number        : N/A

Device properties
  Type                 : vck5000
  Name                 : N/A
  Config Mode          : 0x760b6850

Flashable partitions running on FPGA
  Platform             : xilinx_vck5000_gen4x8_qdma_base_2
  SC Version           : INACTIVE
  Platform UUID        : 05DCA096-76CB-730B-8D19-EC1192FBAE3F
  Interface UUID       : EAAE3FB8-B262-B65B-21FE-C0676792EBFC

Flashable partitions installed in system
  Platform             : xilinx_vck5000_gen4x8_xdma_base_2
  SC Version           : 4.4.33
  Platform UUID        : 04624343-B44B-B0A1-3CD4-8A411789FF20

  Platform             : xilinx_vck5000_gen4x8_qdma_base_2
  SC Version           : 4.4.35
  Platform UUID        : 05DCA096-76CB-730B-8D19-EC1192FBAE3F

Bootable Partitions:
  Default              : INACTIVE
  Backup               : ACTIVE

WARNING  : Multiple shells are installed on the system.
```
#### Documentation impact (if any)
None.