### PR TITLE
[2022.2] CR-1149239 (#7283) 

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/zocl_cu_xgq.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_cu_xgq.c
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0 OR Apache-2.0 */
 /*
- * Copyright (C) 2021-2022 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Xilinx, Inc. All rights reserved.
  *
  * Author(s):
  *        Max Zhen <maxz@xilinx.com>
@@ -25,7 +25,7 @@
 #define zcu_xgq_info(zcu_xgq, fmt, args...)	zocl_info(ZCU_XGQ2DEV(zcu_xgq), fmt"\n", ##args)
 #define zcu_xgq_dbg(zcu_xgq, fmt, args...)	zocl_dbg(ZCU_XGQ2DEV(zcu_xgq), fmt"\n", ##args)
 
-#define ZCU_XGQ_MAX_SLOT_SIZE	1024
+#define ZCU_XGQ_MAX_SLOT_SIZE	4096
 #define ZCU_XGQ_FAST_PATH(zcu_xgq)		(((zcu_xgq)->zxc_num_cu == 1) && ((zcu_xgq)->zxc_cu_domain == 0))
 
 static void zcu_xgq_cmd_handler(struct platform_device *pdev, struct xgq_cmd_sq_hdr *cmd);


### PR DESCRIPTION
This is a backport of #7283 to 2022.2 branch.

This fix is needed for VAI library. 