### PR TITLE
CR-1149984: Fixing malformed guidance rules in software emulation

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info_database.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info_database.cpp
@@ -59,7 +59,7 @@ namespace xdp {
     : db(d)
     , runSummary(nullptr)
     , systemDiagram("")
-    , softwareEmulationDeviceName("")
+    , softwareEmulationDeviceName("default_sw_emu_device")
     , aieDevInst(nullptr)
     , aieDevice(nullptr)
     , deallocateAieDevice(nullptr)


### PR DESCRIPTION
#### Problem solved by the commit
On applications where the host interfaces with XRT using the Native XRT level, when running software emulation profiling will generate a summary file with a few malformed guidance rules which are missing the device name.  This pull request adds a default name for the device in profiling constructs so the guidance rules will always be the correct form.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
For software emulation, profiling does not support any device level profiling so there is no device offload profiling plugin loaded during execution.  The summary file generated by profiling does include guidance rules that require a device name, but in software emulation profiling only intercepts the name of the device in OpenCL level applications.  Applications that interface with XRT at the Native XRT level have no path to set the name of the device in the profiling data structures.  This was discovered through extensive regression testing.

#### How problem was solved, alternative solutions (if any) and why they were rejected
The addition of a default name fixes the guidance rules in cases where we cannot determine the name.

#### Risks (if any) associated the changes in the commit
Low risk as hardware and hardware emulation flows do not use the software emulation device name in profiling, and for software emulation this only changes the cases where the device name is never set in the profiling data structures.

#### What has been tested and how, request additional testing if necessary
The original test case has been verified.

#### Documentation impact (if any)
No documentation impact.