### PR TITLE
VITIS-6253 Part 1/3 Update tools help menu

### DIFF
--- a/src/runtime_src/core/common/unistd.h
+++ b/src/runtime_src/core/common/unistd.h
@@ -20,6 +20,7 @@
 #ifndef _WIN32
 #include <unistd.h>
 #else
+#include <Shlobj.h>
 #endif
 
 namespace xrt_core {
@@ -33,6 +34,17 @@ getpagesize()
   return 4096;
 #endif
 }
+
+inline bool
+is_user_privileged()
+{
+#ifndef _WIN32
+  return (getuid() == 0) || (geteuid() == 0);
+#else
+  return IsUserAnAdmin();
+#endif
+}
+
 
 } // xrt_core
 #endif

--- a/src/runtime_src/core/tools/common/OptionOptions.cpp
+++ b/src/runtime_src/core/tools/common/OptionOptions.cpp
@@ -37,17 +37,41 @@ OptionOptions::OptionOptions( const std::string & longName,
   , m_description(description)
   , m_extendedHelp("")
 {
-  // Empty
+  m_selfOption.add_options()(m_longName.c_str(),
+                             boost::program_options::bool_switch(&m_defaultOptionValue)->required(),
+                             m_description.c_str());
+  m_optionsDescription.add(m_selfOption);
+}
+
+OptionOptions::OptionOptions(const std::string& longName,
+                             const std::string& shortName,
+                             const std::string& optionDescription,
+                             const boost::program_options::value_semantic* optionValue,
+                             const std::string& valueDescription,
+                             bool isHidden)
+  : m_executable("<unknown>")
+  , m_command("<unknown>")
+  , m_longName(longName)
+  , m_shortName(shortName)
+  , m_isHidden(isHidden)
+  , m_description(optionDescription)
+  , m_extendedHelp("")
+{
+  m_selfOption.add_options()(optionNameString().c_str(), optionValue, valueDescription.c_str());
+  m_optionsDescription.add(m_selfOption);
 }
 
 void 
 OptionOptions::printHelp() const
 {
-  XBU::report_subcommand_help( m_executable, 
-                               m_command + " --" + m_longName, 
-                               m_description, m_extendedHelp, 
-                               m_optionsDescription, m_optionsHidden, 
-                               m_positionalOptions, m_globalOptions);
+  XBU::report_subcommand_help(m_executable,
+                              m_command,
+                              m_description,
+                              m_extendedHelp,
+                              m_optionsDescription,
+                              m_optionsHidden,
+                              m_globalOptions,
+                              m_positionalOptions);
 }
 
 std::vector<std::string>

--- a/src/runtime_src/core/tools/common/OptionOptions.h
+++ b/src/runtime_src/core/tools/common/OptionOptions.h
@@ -21,6 +21,7 @@
 // Please keep eternal include file dependencies to a minimum
 #include <vector>
 #include <string>
+#include <boost/format.hpp>
 #include <boost/program_options.hpp>
   
 class OptionOptions {
@@ -30,7 +31,15 @@ class OptionOptions {
   virtual void execute(const SubCmdOptions &_options) const = 0;
 
  public:
+  const boost::shared_ptr<boost::program_options::option_description>&
+  option() const
+  {
+    if (m_selfOption.options().empty())
+      throw std::runtime_error(boost::str(boost::format("%s missing self option") % longName()));
+    return m_selfOption.options()[0];
+  };
   const std::string &longName() const { return m_longName; };
+  const std::string optionNameString() const { return m_shortName.empty() ? m_longName : m_longName + "," + m_shortName; };
   const std::string &description() const {return m_description; };
   const std::string &extendedHelp() const { return m_extendedHelp; };
   bool isHidden() const { return m_isHidden; };
@@ -51,6 +60,7 @@ class OptionOptions {
  // Child class Helper methods
  protected:
   OptionOptions(const std::string & longName, bool isHidden, const std::string & description);
+  OptionOptions(const std::string& longName, const std::string& shortName, const std::string& optionDescription, const boost::program_options::value_semantic* optionValue, const std::string& valueDescription, bool isHidden);
   void setExtendedHelp(const std::string &extendedHelp) { m_extendedHelp = extendedHelp; };
   void printHelp() const;
   std::vector<std::string> process_arguments( boost::program_options::variables_map& vm,
@@ -62,6 +72,7 @@ class OptionOptions {
 
  // Variables
  protected:
+  boost::program_options::options_description m_selfOption;
   boost::program_options::options_description m_optionsDescription;
   boost::program_options::options_description m_optionsHidden;
   boost::program_options::positional_options_description m_positionalOptions;
@@ -70,9 +81,11 @@ class OptionOptions {
   std::string m_executable;
   std::string m_command;
   std::string m_longName;
+  std::string m_shortName;
   bool m_isHidden;
   std::string m_description;
   std::string m_extendedHelp;
+  bool m_defaultOptionValue;
   boost::program_options::options_description m_globalOptions;
 };
   

--- a/src/runtime_src/core/tools/common/SubCmd.cpp
+++ b/src/runtime_src/core/tools/common/SubCmd.cpp
@@ -29,7 +29,9 @@ namespace po = boost::program_options;
 
 SubCmd::SubCmd(const std::string & _name, 
                const std::string & _shortDescription)
-  : m_executableName("")
+  : m_commonOptions("Common Options")
+  , m_hiddenOptions("Hidden Options")
+  , m_executableName("")
   , m_subCmdName(_name)
   , m_shortDescription(_shortDescription)
   , m_longDescription("")
@@ -41,22 +43,20 @@ SubCmd::SubCmd(const std::string & _name,
   // Empty
 }
 
-void
-SubCmd::printHelp( const boost::program_options::options_description & _optionDescription,
-                   const boost::program_options::options_description & _optionHidden,
-                   bool removeLongOptDashes,
-                   const std::string& customHelpSection) const
+void 
+SubCmd::printHelp(bool removeLongOptDashes, const std::string& customHelpSection) const
 {
-  boost::program_options::positional_options_description emptyPOD;
-  XBUtilities::report_subcommand_help(m_executableName, m_subCmdName, m_longDescription,  m_exampleSyntax, _optionDescription, _optionHidden, emptyPOD, m_globalOptions, removeLongOptDashes, customHelpSection);
-}
-
-void
-SubCmd::printHelp( const boost::program_options::options_description & _optionDescription,
-                   const boost::program_options::options_description & _optionHidden,
-                   const SubOptionOptions & _subOptionOptions) const
-{
- XBUtilities::report_subcommand_help(m_executableName, m_subCmdName, m_longDescription,  m_exampleSyntax, _optionDescription, _optionHidden, _subOptionOptions, m_globalOptions);
+  XBUtilities::report_subcommand_help(m_executableName,
+                                      m_subCmdName,
+                                      m_longDescription,
+                                      m_exampleSyntax,
+                                      m_commonOptions,
+                                      m_hiddenOptions,
+                                      m_globalOptions,
+                                      m_positionals,
+                                      m_subOptionOptions,
+                                      removeLongOptDashes,
+                                      customHelpSection);
 }
 
 std::vector<std::string> 
@@ -72,14 +72,39 @@ SubCmd::process_arguments( po::variables_map& vm,
   all_options.add(common_options);
   all_options.add(hidden_options);
 
+  for (const auto& subCmd : suboptions)
+    all_options.add_options()(subCmd->optionNameString().c_str(), subCmd->description().c_str());
+
   try {
     po::command_line_parser parser(_options);
-    return XBU::process_arguments(vm, parser, all_options, positionals, validate_arguments);
-  } catch(boost::program_options::error& e) {
+    const auto options = XBU::process_arguments(vm, parser, all_options, positionals, validate_arguments);
+
+    // Validate that only one suboption was selected if any exist
+    for (size_t source_option = 0; source_option < suboptions.size(); ++source_option)
+      for (size_t comparison_option = source_option + 1; comparison_option < suboptions.size(); ++comparison_option)
+        conflictingOptions(vm, suboptions[source_option]->longName(), suboptions[comparison_option]->longName());
+
+    return options;
+
+  } catch (boost::program_options::error& e) {
     std::cerr << boost::format("ERROR: %s\n") % e.what();
-    printHelp(common_options, hidden_options, suboptions);
+    printHelp();
     throw xrt_core::error(std::errc::operation_canceled);
   }
+}
+
+std::vector<std::string>
+SubCmd::process_arguments(boost::program_options::variables_map& vm,
+                          const SubCmdOptions& _options,
+                          bool validate_arguments) const
+{
+  return process_arguments( vm,
+                            _options,
+                            m_commonOptions,
+                            m_hiddenOptions,
+                            m_positionals,
+                            m_subOptionOptions,
+                            validate_arguments);
 }
 
 
@@ -94,5 +119,32 @@ SubCmd::conflictingOptions( const boost::program_options::variables_map& _vm,
     std::string errMsg = boost::str(boost::format("Mutually exclusive options: '%s' and '%s'") % _opt1 % _opt2);
     throw std::logic_error(errMsg);
   }
+}
+
+void
+SubCmd::addSubOption(std::shared_ptr<OptionOptions> option)
+{
+  option->setExecutable(getExecutableName());
+  option->setCommand(getName());
+  m_subOptionOptions.emplace_back(option);
+}
+
+std::shared_ptr<OptionOptions>
+SubCmd::checkForSubOption(const boost::program_options::variables_map& vm) const
+{
+  std::shared_ptr<OptionOptions> option;
+  // Loop through the available sub options searching for a name match
+  for (auto& subOO : m_subOptionOptions) {
+    if (vm.count(subOO->longName()) != 0) {
+      // Store the matched option if no other match has been found
+      if (!option)
+        option = subOO;
+      // XRT will not accept more than one suboption per invocation
+      // Throw an exception if more than one suboption is found within the command options
+      else
+        XBUtilities::throw_cancel(boost::format("Mutually exclusive option selected: %s %s") % subOO->longName() % option->longName());
+    }
+  }
+  return option;
 }
 

--- a/src/runtime_src/core/tools/common/SubCmd.h
+++ b/src/runtime_src/core/tools/common/SubCmd.h
@@ -64,14 +64,7 @@ public:
   void setIsPreliminary(bool _isPreliminary) { m_isPreliminary = _isPreliminary; };
   void setIsDefaultDevValid(bool _defaultDeviceValid) { m_defaultDeviceValid = _defaultDeviceValid; };
   void setLongDescription(const std::string &_longDescription) {m_longDescription = _longDescription; };
-  void setExampleSyntax(const std::string &_exampleSyntax) {m_exampleSyntax = _exampleSyntax; };
-  void printHelp(const boost::program_options::options_description & _optionDescription,
-                 const boost::program_options::options_description & _optionHidden,
-                 bool removeLongOptDashes = false,
-                 const std::string& customHelpSection = "") const;
-  void printHelp( const boost::program_options::options_description & _optionDescription,
-                  const boost::program_options::options_description & _optionHidden,
-                  const SubOptionOptions & _subOptionOptions) const;
+  void printHelp(bool removeLongOptDashes = false, const std::string& customHelpSection = "") const;
   std::vector<std::string> process_arguments( boost::program_options::variables_map& vm,
                            const SubCmdOptions& _options,
                            const boost::program_options::options_description& common_options,
@@ -79,8 +72,19 @@ public:
                            const boost::program_options::positional_options_description& positionals = boost::program_options::positional_options_description(),
                            const SubOptionOptions& suboptions = SubOptionOptions(),
                            bool validate_arguments = true) const;
+  std::vector<std::string> process_arguments(boost::program_options::variables_map& vm,
+                                             const SubCmdOptions& _options,
+                                             bool validate_arguments = true) const;
   void conflictingOptions( const boost::program_options::variables_map& _vm, 
                            const std::string &_opt1, const std::string &_opt2) const;
+  void addSubOption(std::shared_ptr<OptionOptions> option);
+  std::shared_ptr<OptionOptions> checkForSubOption(const boost::program_options::variables_map& vm) const;
+
+ protected:
+  SubOptionOptions m_subOptionOptions;
+  boost::program_options::options_description m_commonOptions;
+  boost::program_options::options_description m_hiddenOptions;
+  boost::program_options::positional_options_description m_positionals;
 
  private:
   SubCmd() = delete;

--- a/src/runtime_src/core/tools/common/SubCmd.h
+++ b/src/runtime_src/core/tools/common/SubCmd.h
@@ -64,6 +64,7 @@ public:
   void setIsPreliminary(bool _isPreliminary) { m_isPreliminary = _isPreliminary; };
   void setIsDefaultDevValid(bool _defaultDeviceValid) { m_defaultDeviceValid = _defaultDeviceValid; };
   void setLongDescription(const std::string &_longDescription) {m_longDescription = _longDescription; };
+  void setExampleSyntax(const std::string& _exampleSyntax) { m_exampleSyntax = _exampleSyntax; };
   void printHelp(bool removeLongOptDashes = false, const std::string& customHelpSection = "") const;
   std::vector<std::string> process_arguments( boost::program_options::variables_map& vm,
                            const SubCmdOptions& _options,

--- a/src/runtime_src/core/tools/common/SubCmdJSON.cpp
+++ b/src/runtime_src/core/tools/common/SubCmdJSON.cpp
@@ -51,7 +51,7 @@ namespace pt = boost::property_tree;
 // ----- C L A S S   M E T H O D S -------------------------------------------
 
 SubCmdJSON::SubCmdJSON(bool _isHidden, bool _isDepricated, bool _isPreliminary, std::string& name, std::string& desc, std::vector<struct JSONCmd>& _subCmdOptions)
-    : SubCmd(name, desc), subCmdOptions(_subCmdOptions)
+    : SubCmd(name, desc), m_subCmdOptions(_subCmdOptions), m_help(false)
 {
   const std::string longDescription = desc;
   setLongDescription(longDescription);
@@ -60,83 +60,49 @@ SubCmdJSON::SubCmdJSON(bool _isHidden, bool _isDepricated, bool _isPreliminary, 
   setIsDeprecated(_isDepricated);
   setIsPreliminary(_isPreliminary);
   setIsDefaultDevValid(false);
+
+  m_commonOptions.add_options()("help", boost::program_options::bool_switch(&m_help), "Help to use this sub-command");
+
+  for (auto &opt : m_subCmdOptions)
+    m_commonOptions.add_options()(opt.option.c_str(), opt.description.c_str());
+
+  m_hiddenOptions.add_options()
+    ("subCmd", po::value<std::string>(), "Command to execute")
+  ;
+
+  m_positionals
+    .add("subCmd", 1 /* max_count */);
 }
 
 void
 SubCmdJSON::execute(const SubCmdOptions& _options) const
 {
   XBU::verbose("SubCommand: " + getName());
-  // -- Retrieve and parse the subcommand options -----------------------------
-  bool help = false;
-
-  po::options_description commonOptions("Common Options");
-  commonOptions.add_options()
-    ("--help,h", "Help to use this sub-command")
-  ;
-
-  for( auto &opt : subCmdOptions) {
-      commonOptions.add_options()
-        (opt.option.c_str(),opt.description.c_str())
-      ;
-  }
-
-  po::options_description hiddenOptions("Hidden Options");
-  hiddenOptions.add_options()
-     ("subCmd", po::value<std::string>(), "Command to execute")
-     ("subCmdArgs", po::value<std::vector<std::string> >(), "Arguments for command")
-  ;
-
-  po::positional_options_description positionalCommand;
-  positionalCommand.
-    add("subCmd", 1 /* max_count */).
-    add("subCmdArgs", -1 /* Unlimited max_count */);
-
-  po::options_description allOptions("All Options");
-  allOptions.add_options()
-     ("help,h", boost::program_options::bool_switch(&help), "Help to use this sub-command")
-  ;
-
-  allOptions.add(hiddenOptions);
-
-  po::parsed_options parsed = po::command_line_parser(_options).
-    options(allOptions).            // Global options
-    positional(positionalCommand).  // Our commands
-    allow_unregistered().           // Allow for unregistered options (needed for sub options)
-    run();                          // Parse the options
 
   po::variables_map vm;
-
-  try {
-    po::store(parsed, vm);
-    po::notify(vm); // Can throw
-  } catch (po::error& e) {
-    std::cerr << "ERROR: " << e.what() << std::endl << std::endl;
-    printHelp(commonOptions, hiddenOptions, true);
-    throw xrt_core::error(std::errc::operation_canceled);
-  }
+  auto top_options = process_arguments(vm, _options);
 
   // Check to see if no command was found
   if ((vm.count("subCmd") == 0)) {
-    printHelp(commonOptions, hiddenOptions, true);
+    printHelp();
     return;
   }
 
   // -- Now process the subcommand --------------------------------------------
   std::string sCommand = vm["subCmd"].as<std::string>();
 
-  for ( auto &jsonCmd : subCmdOptions ) {
+  for ( auto &jsonCmd : m_subCmdOptions ) {
     if (sCommand.compare(jsonCmd.option) == 0) {
-      std::vector<std::string> opts = po::collect_unrecognized(parsed.options, po::include_positional);
-      opts.erase(opts.begin());
+      top_options.erase(top_options.begin());
 
-      if(help == true) {
-        opts.push_back("--help");
+      if(m_help) {
+        top_options.push_back("--help");
       }
 
       std::string finalCmd = jsonCmd.application + " " + jsonCmd.defaultArgs;
-      for (auto &opt : opts) {
+      for (auto &opt : top_options) {
         finalCmd += " ";
-	finalCmd += opt;
+        finalCmd += opt;
       }
 
       std::cout << "\nInvoking application : " << jsonCmd.application << std::endl;
@@ -151,7 +117,7 @@ SubCmdJSON::execute(const SubCmdOptions& _options) const
   }
 
   std::cout << "\nERROR: Missing valid program operation. No action taken.\n\n";
-  printHelp(commonOptions, hiddenOptions, true);
+  printHelp();
   throw xrt_core::error(std::errc::operation_canceled);
 }
 

--- a/src/runtime_src/core/tools/common/SubCmdJSON.h
+++ b/src/runtime_src/core/tools/common/SubCmdJSON.h
@@ -35,7 +35,8 @@ class SubCmdJSON : public SubCmd {
   SubCmdJSON(bool _isHidden, bool _isDepricated, bool _isPreliminary, std::string& name, std::string& desc, std::vector<struct JSONCmd>& _subCmdOptions);
 
  private:
-  std::vector<struct JSONCmd> subCmdOptions;
+  std::vector<struct JSONCmd> m_subCmdOptions;
+  bool m_help;
 };
 
 using SubCmdsCollection = std::vector<std::shared_ptr<SubCmd>>;

--- a/src/runtime_src/core/tools/common/XBHelpMenus.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenus.cpp
@@ -141,8 +141,8 @@ XBUtilities::collect_and_validate_reports( const ReportCollection &allReportsAva
 void 
 XBUtilities::produce_reports( const std::shared_ptr<xrt_core::device>& device, 
                               const ReportCollection & reportsToProcess, 
-                              Report::SchemaVersion schemaVersion, 
-                              std::vector<std::string> & elementFilter,
+                              const Report::SchemaVersion schemaVersion, 
+                              const std::vector<std::string> & elementFilter,
                               std::ostream & consoleStream,
                               std::ostream & schemaStream)
 {

--- a/src/runtime_src/core/tools/common/XBHelpMenus.h
+++ b/src/runtime_src/core/tools/common/XBHelpMenus.h
@@ -35,8 +35,8 @@ namespace XBUtilities {
   void 
      produce_reports( const std::shared_ptr<xrt_core::device>& device, 
                       const ReportCollection & reportsToProcess, 
-                      Report::SchemaVersion schema, 
-                      std::vector<std::string> & elementFilter,
+                      const Report::SchemaVersion schema, 
+                      const std::vector<std::string> & elementFilter,
                       std::ostream & consoleStream,
                       std::ostream & schemaStream);
 };

--- a/src/runtime_src/core/tools/common/XBHelpMenusCore.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenusCore.cpp
@@ -100,152 +100,145 @@ isPositional(const std::string &_name,
   return false;
 }
 
+/**
+ * An enumeration to describe the type of argument a given
+ * program option represents.
+ * This determines the output order of options in the usage string
+ */
+enum OptionDescriptionFlagType {
+  short_required = 0,
+  long_required,
+  short_required_arg,
+  long_required_arg,
+  short_simple,
+  long_simple,
+  short_arg,
+  long_arg,
+  positional,
+  flag_type_size
+};
 
-std::string
+static enum OptionDescriptionFlagType
+get_option_type(const boost::shared_ptr<boost::program_options::option_description>& option,
+                const boost::program_options::positional_options_description& _pod)
+{
+  const static int SHORT_OPTION_STRING_SIZE = 2;
+  std::string optionDisplayName = option->canonical_display_name(po::command_line_style::allow_dash_for_short);
+
+  if (isPositional(optionDisplayName, _pod))
+    return positional;
+
+  if (option->semantic()->is_required()) {
+    if (option->semantic()->max_tokens() == 0) {
+      if (optionDisplayName.size() == SHORT_OPTION_STRING_SIZE)
+        return short_required;
+
+      return long_required;
+    } else {
+      if (optionDisplayName.size() == SHORT_OPTION_STRING_SIZE)
+        return short_required_arg;
+
+      return long_required_arg;
+    }
+  }
+
+  if (option->semantic()->max_tokens() == 0) {  // Parse for simple flags
+    if (optionDisplayName.size() == SHORT_OPTION_STRING_SIZE)
+      return short_simple;
+
+    return long_simple;
+  }
+  else { // Parse for flags with arguments
+    if (optionDisplayName.size() == SHORT_OPTION_STRING_SIZE)
+      return short_arg;
+
+    return long_arg;
+  }
+}
+
+static std::string
+create_option_string(enum OptionDescriptionFlagType optionType,
+                     const boost::shared_ptr<boost::program_options::option_description>& option,
+                     bool removeLongOptDashes)
+{
+  const std::string& shortName = option->canonical_display_name(po::command_line_style::allow_dash_for_short);
+  const std::string& longName =
+      removeLongOptDashes ? option->long_name() : option->canonical_display_name(po::command_line_style::allow_long);
+  switch (optionType) {
+    case short_simple:
+      return boost::str(boost::format("%s") % shortName[1]);
+      break;
+    case long_simple:
+      return boost::str(boost::format("[%s]") % longName);
+      break;
+    case short_arg:
+      return boost::str(boost::format("[%s arg]") % shortName);
+      break;
+    case long_arg:
+      return boost::str(boost::format("[%s arg]") % longName);
+      break;
+    case short_required:
+      return boost::str(boost::format("%s") % shortName);
+      break;
+    case long_required:
+      return boost::str(boost::format("%s") % longName);
+      break;
+    case short_required_arg:
+      return boost::str(boost::format("%s arg") % shortName);
+      break;
+    case long_required_arg:
+      return boost::str(boost::format("%s arg") % longName);
+      break;
+    case positional:
+      return boost::str(boost::format("%s") % shortName);
+      break;
+    case flag_type_size:
+      throw std::runtime_error("Invalid argument setup detected");
+      break;
+  }
+  throw std::runtime_error("Invalid argument setup detected");
+}
+
+
+std::string 
 XBUtilities::create_usage_string( const boost::program_options::options_description &_od,
                                   const boost::program_options::positional_options_description & _pod,
                                   bool removeLongOptDashes)
 {
-  const static int SHORT_OPTION_STRING_SIZE = 2;
-  std::stringstream buffer;
+  // Create list of buffers to store each argument type
+  std::vector<std::stringstream> buffers(flag_type_size);
 
-  auto &options = _od.options();
+  const auto& options = _od.options();
 
-  // Gather up the short simple flags
-  {
-    bool firstShortFlagFound = false;
-    for (auto & option : options) {
-      // Get the option name
-      std::string optionDisplayName = option->canonical_display_name(po::command_line_style::allow_dash_for_short);
+  for (const auto& option : options) {
+    const auto optionType = get_option_type(option, _pod);
+    const auto optionString = create_option_string(optionType, option, removeLongOptDashes);
+    const auto is_buffer_empty = buffers[optionType].str().empty();
+    // The short options have a bracket surrounding all options
+    if ((optionType == short_simple) && is_buffer_empty)
+      buffers[optionType] << "[-";
+    // Add spaces only after the first character to simplify upper level formatting
+    else if ((optionType != short_simple) && !is_buffer_empty)
+      buffers[optionType] << " ";
 
-      // See if we have a long flag
-      if (optionDisplayName.size() != SHORT_OPTION_STRING_SIZE)
-        continue;
-
-      // We are not interested in any arguments
-      if (option->semantic()->max_tokens() > 0)
-        continue;
-
-      // This option shouldn't be required
-      if (option->semantic()->is_required())
-        continue;
-
-      if (!firstShortFlagFound) {
-        buffer << " [-";
-        firstShortFlagFound = true;
-      }
-
-      buffer << optionDisplayName[1];
-    }
-
-    if (firstShortFlagFound == true)
-      buffer << "]";
+    buffers[optionType] << boost::format("%s") % optionString;
   }
 
+  // The short simple options have a bracket surrounding all options
+  if (!buffers[short_simple].str().empty())
+    buffers[short_simple] << "]";
 
-  // Gather up the long simple flags (flags with no short versions)
-  {
-    for (auto & option : options) {
-      // Get the option name
-      std::string optionDisplayName = option->canonical_display_name(po::command_line_style::allow_dash_for_short);
-
-      // See if we have a short flag
-      if (optionDisplayName.size() == SHORT_OPTION_STRING_SIZE)
-        continue;
-
-      // We are not interested in any arguments
-      if (option->semantic()->max_tokens() > 0)
-        continue;
-
-      // This option shouldn't be required
-      if (option->semantic()->is_required())
-        continue;
-
-      const std::string completeOptionName = removeLongOptDashes ? option->long_name() :
-				option->canonical_display_name(po::command_line_style::allow_long);
-      buffer << boost::format(" [%s]") % completeOptionName;
+  std::stringstream outputBuffer;
+  for (const auto& buffer : buffers) {
+    if (!buffer.str().empty()) {
+      // Add spaces only after the first buffer to simplify upper level formatting
+      if (!outputBuffer.str().empty())
+        outputBuffer << " ";
+      outputBuffer << buffer.str();
     }
   }
 
-  // Gather up the options with arguments
-  for (auto & option : options) {
-    // Skip if there are no arguments
-    if (option->semantic()->max_tokens() == 0)
-      continue;
-
-    // Required arguments are taken care of later
-    if (option->semantic()->is_required())
-      continue;
-
-    std::string completeOptionName = option->canonical_display_name(po::command_line_style::allow_dash_for_short);
-
-    // Positional arguments are taken care of later
-    if (::isPositional(completeOptionName, _pod))
-      continue;
-
-    // See if we have a long flag
-    if (completeOptionName.size() != SHORT_OPTION_STRING_SIZE)
-      continue;
-
-    buffer << boost::format(" [%s arg]") % completeOptionName;
-  }
-
-  // Gather up the options with arguments (options with no short versions)
-  for (auto & option : options) {
-    // Skip if there are no arguments
-    if (option->semantic()->max_tokens() == 0)
-      continue;
-
-    // Required arguments are taken care of later
-    if (option->semantic()->is_required())
-      continue;
-
-    const std::string optionDisplayName = option->canonical_display_name(po::command_line_style::allow_dash_for_short);
-
-    // Positional arguments are taken care of later
-    if (::isPositional(optionDisplayName, _pod))
-      continue;
-
-    // See if we have a short flag
-    if (optionDisplayName.size() == SHORT_OPTION_STRING_SIZE)
-      continue;
-
-    const std::string completeOptionName = removeLongOptDashes ? option->long_name() :
-      option->canonical_display_name(po::command_line_style::allow_long);
-      buffer << boost::format(" [%s arg]") % completeOptionName;
-  }
-
-  // Gather up the required options with arguments
-  for (auto & option : options) {
-    // Skip if there are no arguments
-    if (option->semantic()->max_tokens() == 0)
-      continue;
-
-    // This option is required
-    if (!option->semantic()->is_required())
-      continue;
-
-    std::string completeOptionName = option->canonical_display_name(po::command_line_style::allow_dash_for_short);
-
-    // Positional arguments are taken care of later
-    if (::isPositional(completeOptionName, _pod))
-      continue;
-
-    buffer << boost::format(" %s arg") % completeOptionName;
-  }
-
-  // Report the positional arguments
-  for (auto & option : options) {
-    std::string completeOptionName = option->canonical_display_name(po::command_line_style::allow_dash_for_short);
-    if ( ! ::isPositional(completeOptionName, _pod) ) {
-      continue;
-    }
-
-    buffer << " " << completeOptionName;
-  }
-
-
-  return buffer.str();
+  return outputBuffer.str();
 }
 
 void
@@ -421,88 +414,17 @@ XBUtilities::report_option_help( const std::string & _groupName,
 }
 
 void
-XBUtilities::report_subcommand_help( const std::string &_executableName,
-                                     const std::string &_subCommand,
-                                     const std::string &_description,
-                                     const std::string &_extendedHelp,
-                                     const boost::program_options::options_description &_optionDescription,
-                                     const boost::program_options::options_description &_optionHidden,
-                                     const boost::program_options::positional_options_description & _positionalDescription,
-                                     const boost::program_options::options_description &_globalOptions,
-                                     bool removeLongOptDashes,
-                                     const std::string& customHelpSection)
-{
-  // Formatting color parameters
-  // Color references: https://en.wikipedia.org/wiki/ANSI_escape_code
-  const std::string fgc_header      = XBUtilities::is_escape_codes_disabled() ? "" : ec::fgcolor(FGC_HEADER).string();
-  const std::string fgc_headerBody  = XBUtilities::is_escape_codes_disabled() ? "" : ec::fgcolor(FGC_HEADER_BODY).string();
-  const std::string fgc_poption      = XBUtilities::is_escape_codes_disabled() ? "" : ec::fgcolor(FGC_POSITIONAL).string();
-  const std::string fgc_poptionBody  = XBUtilities::is_escape_codes_disabled() ? "" : ec::fgcolor(FGC_POSITIONAL_BODY).string();
-  const std::string fgc_usageBody   = XBUtilities::is_escape_codes_disabled() ? "" : ec::fgcolor(FGC_USAGE_BODY).string();
-  const std::string fgc_extendedBody = XBUtilities::is_escape_codes_disabled() ? "" : ec::fgcolor(FGC_EXTENDED_BODY).string();
-  const std::string fgc_reset       = XBUtilities::is_escape_codes_disabled() ? "" : ec::fgcolor::reset();
-
-  // -- Command description
-  {
-    static const std::string key = "DESCRIPTION: ";
-    auto formattedString = XBU::wrap_paragraphs(_description, static_cast<unsigned int>(key.size()), m_maxColumnWidth - static_cast<unsigned int>(key.size()), false);
-    boost::format fmtHeader(fgc_header + "\n" + key + fgc_headerBody + "%s\n" + fgc_reset);
-    if ( !formattedString.empty() )
-      std::cout << fmtHeader % formattedString;
-  }
-
-  // -- Command usage
-  const std::string usage = XBU::create_usage_string(_optionDescription, _positionalDescription, removeLongOptDashes);
-  boost::format fmtUsage(fgc_header + "\nUSAGE: " + fgc_usageBody + "%s %s%s\n" + fgc_reset);
-  std::cout << fmtUsage % _executableName % _subCommand % usage;
-
-  // -- Add positional arguments
-  boost::format fmtOOSubPositional(fgc_poption + "  %-15s" + fgc_poptionBody + " - %s\n" + fgc_reset);
-  for (auto option : _optionDescription.options()) {
-    if ( !::isPositional( option->canonical_display_name(po::command_line_style::allow_dash_for_short),
-                          _positionalDescription))  {
-      continue;
-    }
-
-    std::string optionDisplayFormat = create_option_format_name(option.get(), false);
-    unsigned int optionDescTab = 33;
-    auto formattedString = XBU::wrap_paragraphs(option->description(), optionDescTab, m_maxColumnWidth, false);
-
-    std::string completeOptionName = option->canonical_display_name(po::command_line_style::allow_dash_for_short);
-    std::cout << fmtOOSubPositional % ("<" + option->long_name() + ">") % formattedString;
-  }
-
-
-  // -- Options
-  report_option_help("OPTIONS", _optionDescription, _positionalDescription, false, removeLongOptDashes);
-
-  // -- Custom Section
-  std::cout << customHelpSection << "\n";
-
-  // -- Global Options
-  report_option_help("GLOBAL OPTIONS", _globalOptions, _positionalDescription, false);
-
-  if (XBU::getShowHidden())
-    report_option_help("OPTIONS (Hidden)", _optionHidden, _positionalDescription, false);
-
-  // Extended help
-  {
-    boost::format fmtExtHelp(fgc_extendedBody + "\n  %s\n" +fgc_reset);
-    auto formattedString = XBU::wrap_paragraphs(_extendedHelp, 2, m_maxColumnWidth, false);
-    if (!formattedString.empty())
-      std::cout << fmtExtHelp % formattedString;
-  }
-}
-
-void
-XBUtilities::report_subcommand_help( const std::string &_executableName,
-                                     const std::string &_subCommand,
-                                     const std::string &_description,
-                                     const std::string &_extendedHelp,
-                                     const boost::program_options::options_description &_optionDescription,
-                                     const boost::program_options::options_description &_optionHidden,
-                                     const SubCmd::SubOptionOptions & _subOptionOptions,
-                                     const boost::program_options::options_description &_globalOptions)
+XBUtilities::report_subcommand_help(const std::string& _executableName,
+                                    const std::string& _subCommand,
+                                    const std::string& _description,
+                                    const std::string& _extendedHelp,
+                                    const boost::program_options::options_description& _optionDescription,
+                                    const boost::program_options::options_description& _optionHidden,
+                                    const boost::program_options::options_description& _globalOptions,
+                                    const boost::program_options::positional_options_description& _positionalDescription,
+                                    const SubCmd::SubOptionOptions& _subOptionOptions,
+                                    bool removeLongOptDashes,
+                                    const std::string& customHelpSection)
 {
   // Formatting color parameters
   // Color references: https://en.wikipedia.org/wiki/ANSI_escape_code
@@ -510,7 +432,6 @@ XBUtilities::report_subcommand_help( const std::string &_executableName,
   const std::string fgc_headerBody   = XBUtilities::is_escape_codes_disabled() ? "" : ec::fgcolor(FGC_HEADER_BODY).string();
   const std::string fgc_commandBody  = XBUtilities::is_escape_codes_disabled() ? "" : ec::fgcolor(FGC_SUBCMD).string();
   const std::string fgc_usageBody    = XBUtilities::is_escape_codes_disabled() ? "" : ec::fgcolor(FGC_USAGE_BODY).string();
-
   const std::string fgc_ooption      = XBUtilities::is_escape_codes_disabled() ? "" : ec::fgcolor(FGC_OOPTION).string();
   const std::string fgc_ooptionBody  = XBUtilities::is_escape_codes_disabled() ? "" : ec::fgcolor(FGC_OOPTION_BODY).string();
   const std::string fgc_poption      = XBUtilities::is_escape_codes_disabled() ? "" : ec::fgcolor(FGC_POSITIONAL).string();
@@ -520,44 +441,65 @@ XBUtilities::report_subcommand_help( const std::string &_executableName,
 
   // -- Command
   boost::format fmtCommand(fgc_header + "\nCOMMAND: " + fgc_commandBody + "%s\n" + fgc_reset);
-  if ( !_subCommand.empty() )
+  if (!_subCommand.empty())
     std::cout << fmtCommand % _subCommand;
 
   // -- Command description
   {
     auto formattedString = XBU::wrap_paragraphs(_description, 15, m_maxColumnWidth, false);
     boost::format fmtHeader(fgc_header + "\nDESCRIPTION: " + fgc_headerBody + "%s\n" + fgc_reset);
-    if ( !formattedString.empty() )
+    if (!formattedString.empty())
       std::cout << fmtHeader % formattedString;
   }
 
   // -- Usage
+  // Create option usage string before adding suboptions
+  // The suboptions are displayed seperately in the usage string from the normal options
+  const std::string usage = XBU::create_usage_string(_optionDescription, _positionalDescription, removeLongOptDashes);
+
+  boost::program_options::options_description allOptions(_optionDescription);
+  boost::program_options::options_description allHiddenOptions(_optionHidden);
+
   std::string usageSubCmds;
-  for (const auto & subCmd : _subOptionOptions) {
+  for (const auto& subCmd : _subOptionOptions) {
+    // As we go through the sub options add them into the options description for the list display
     if (subCmd->isHidden())
+      allHiddenOptions.add_options()(subCmd->optionNameString().c_str(), subCmd->description().c_str());
+    else
+      allOptions.add_options()(subCmd->optionNameString().c_str(), subCmd->description().c_str());
+
+    if (subCmd->isHidden() && !XBU::getShowHidden())
       continue;
 
     if (!usageSubCmds.empty())
       usageSubCmds.append(" | ");
 
-    usageSubCmds.append(subCmd->longName());
+    const auto& option = subCmd->option();
+    const auto optionType = get_option_type(option, boost::program_options::positional_options_description());
+    const auto optionString = create_option_string(optionType, option, false);
+    usageSubCmds.append(optionString);
   }
 
-  std::cout << boost::format(fgc_header + "\nUSAGE: " + fgc_usageBody + "%s %s [-h] --[ %s ] [commandArgs]\n" + fgc_reset) % _executableName % _subCommand % usageSubCmds;
+  if (usageSubCmds.empty())
+    std::cout << boost::format(fgc_header + "\nUSAGE: " + fgc_usageBody + "%s %s %s\n" + fgc_reset) % _executableName % _subCommand % usage;
+  else
+    std::cout << boost::format(fgc_header + "\nUSAGE: " + fgc_usageBody + "%s %s [ %s ] %s\n" + fgc_reset) % _executableName % _subCommand % usageSubCmds % usage;
 
   // -- Options
-  boost::program_options::positional_options_description emptyPOD;
-  report_option_help("OPTIONS", _optionDescription, emptyPOD, false);
+  report_option_help("OPTIONS", allOptions, _positionalDescription, false);
+
+  // -- Custom Section
+  std::cout << customHelpSection << "\n";
 
   // -- Global Options
-  report_option_help("GLOBAL OPTIONS", _globalOptions, emptyPOD, false);
+  report_option_help("GLOBAL OPTIONS", _globalOptions, _positionalDescription, false);
 
   if (XBU::getShowHidden())
-    report_option_help("OPTIONS (Hidden)", _optionHidden, emptyPOD, false);
+    report_option_help("OPTIONS (Hidden)", allHiddenOptions, _positionalDescription, false);
 
   // Extended help
   {
-    boost::format fmtExtHelp(fgc_extendedBody + "\n  %s\n" +fgc_reset);
+    boost::format fmtExtHelp(fgc_extendedBody + "\n  %s\n" + fgc_reset);
     auto formattedString = XBU::wrap_paragraphs(_extendedHelp, 2, m_maxColumnWidth, false);
     if (!formattedString.empty())
       std::cout << fmtExtHelp % formattedString;

--- a/src/runtime_src/core/tools/common/XBHelpMenusCore.h
+++ b/src/runtime_src/core/tools/common/XBHelpMenusCore.h
@@ -31,33 +31,26 @@
 using SubCmdsCollection = std::vector<std::shared_ptr<SubCmd>>;
 
 namespace XBUtilities {
-  void 
-    report_commands_help( const std::string &_executable, 
-                          const std::string &_description,
+  void
+  report_commands_help( const std::string& _executable,
+                        const std::string& _description,
+                        const boost::program_options::options_description& _optionDescription,
+                        const boost::program_options::options_description& _optionHidden,
+                        const SubCmdsCollection& _subCmds);
+
+  void
+  report_subcommand_help( const std::string& _executableName,
+                          const std::string& _subCommand,
+                          const std::string& _description,
+                          const std::string& _extendedHelp,
                           const boost::program_options::options_description& _optionDescription,
                           const boost::program_options::options_description& _optionHidden,
-                          const SubCmdsCollection &_subCmds );
-  void 
-    report_subcommand_help( const std::string &_executableName,
-                            const std::string &_subCommand,
-                            const std::string &_description, 
-                            const std::string &_extendedHelp,
-                            const boost::program_options::options_description & _optionDescription,
-                            const boost::program_options::options_description &_optionHidden,
-                            const boost::program_options::positional_options_description & _positionalDescription,
-                            const boost::program_options::options_description &_globalOptions,
-                            bool removeLongOptDashes = false,
-                            const std::string& customHelpSection = "");
-
-  void 
-    report_subcommand_help( const std::string &_executableName,
-                            const std::string &_subCommand,
-                            const std::string &_description, 
-                            const std::string &_extendedHelp,
-                            const boost::program_options::options_description &_optionDescription,
-                            const boost::program_options::options_description &_optionHidden,
-                            const SubCmd::SubOptionOptions & _subOptionOptions,
-                            const boost::program_options::options_description &_globalOptions);
+                          const boost::program_options::options_description& _globalOptions,
+                          const boost::program_options::positional_options_description& _positionalDescription =
+                            boost::program_options::positional_options_description(),
+                          const SubCmd::SubOptionOptions& _subOptionOptions = SubCmd::SubOptionOptions(),
+                          bool removeLongOptDashes = false,
+                          const std::string& customHelpSection = "");
 
   void 
     report_option_help( const std::string & _groupName, 

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -416,30 +416,6 @@ XBUtilities::can_proceed_or_throw(const std::string& info, const std::string& er
 }
 
 void
-XBUtilities::sudo_or_throw(const std::string& msg)
-{
-#ifndef _WIN32
-  if ((getuid() == 0) || (geteuid() == 0))
-    return;
-
-  std::cerr << "ERROR: " << msg << std::endl;
-  throw xrt_core::error(std::errc::operation_canceled);
-#endif
-}
-
-void
-XBUtilities::throw_cancel(const std::string& msg)
-{
-  throw_cancel(boost::format("%s") % msg);
-}
-
-void
-XBUtilities::throw_cancel(const boost::format& format)
-{
-  throw xrt_core::error(std::errc::operation_canceled, boost::str(format));
-}
-
-void
 XBUtilities::print_exception(const std::system_error& e)
 {
   // Remove the type of error from the message.

--- a/src/runtime_src/core/tools/common/XBUtilities.h
+++ b/src/runtime_src/core/tools/common/XBUtilities.h
@@ -44,10 +44,6 @@ namespace XBUtilities {
  
   void can_proceed_or_throw(const std::string& info, const std::string& error);
 
-  void sudo_or_throw(const std::string& msg);
-
-  void throw_cancel(const std::string& msg);
-  void throw_cancel(const boost::format& format);
   void print_exception(const std::system_error& e);
 
   void xrt_version_cmp(bool isUserDomain);

--- a/src/runtime_src/core/tools/common/XBUtilitiesCore.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilitiesCore.cpp
@@ -18,6 +18,9 @@
 // Local - Include Files
 #include "XBUtilitiesCore.h"
 
+#include "core/common/error.h"
+#include "core/common/unistd.h"
+
 // 3rd Party Library - Include Files
 #include <boost/algorithm/string/split.hpp>
 #include <boost/property_tree/json_parser.hpp>
@@ -310,12 +313,25 @@ XBUtilities::can_proceed(bool force)
 }
 
 void
-XBUtilities::sudo_or_throw_err()
+XBUtilities::sudo_or_throw(const std::string& msg)
 {
 #ifndef _WIN32
-    if ((getuid() == 0) || (geteuid() == 0))
-        return;
-    std::cout << "ERROR: root privileges required." << std::endl;
-    throw std::errc::operation_canceled;
+  if ((getuid() == 0) || (geteuid() == 0))
+    return;
+
+  std::cerr << "ERROR: " << msg << std::endl;
+  throw xrt_core::error(std::errc::operation_canceled);
 #endif
+}
+
+void
+XBUtilities::throw_cancel(const std::string& msg)
+{
+  throw_cancel(boost::format("%s") % msg);
+}
+
+void
+XBUtilities::throw_cancel(const boost::format& format)
+{
+  throw xrt_core::error(std::errc::operation_canceled, boost::str(format));
 }

--- a/src/runtime_src/core/tools/common/XBUtilitiesCore.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilitiesCore.cpp
@@ -315,13 +315,10 @@ XBUtilities::can_proceed(bool force)
 void
 XBUtilities::sudo_or_throw(const std::string& msg)
 {
-#ifndef _WIN32
-  if ((getuid() == 0) || (geteuid() == 0))
+  if (xrt_core::is_user_privileged())
     return;
 
-  std::cerr << "ERROR: " << msg << std::endl;
-  throw xrt_core::error(std::errc::operation_canceled);
-#endif
+  throw_cancel(msg);
 }
 
 void

--- a/src/runtime_src/core/tools/common/XBUtilitiesCore.h
+++ b/src/runtime_src/core/tools/common/XBUtilitiesCore.h
@@ -79,7 +79,9 @@ namespace XBUtilities {
 
 
   bool can_proceed(bool force = false);
-  void sudo_or_throw_err();
+  void sudo_or_throw(const std::string& msg);
+  void throw_cancel(const std::string& msg);
+  void throw_cancel(const boost::format& format);
 
   template <typename T>
   std::vector<T> as_vector( boost::property_tree::ptree const& pt, 

--- a/src/runtime_src/core/tools/xbflash2/OO_Dump_Qspips.cpp
+++ b/src/runtime_src/core/tools/xbflash2/OO_Dump_Qspips.cpp
@@ -40,7 +40,7 @@ void
 qspips_readback(po::variables_map& vm)
 {
     //root privileges required.
-    XBU::sudo_or_throw_err();    
+    XBU::sudo_or_throw("ERROR: root privileges required.");
    
     //mandatory command line args
     std::string bdf = vm.count("device") ? vm["device"].as<std::string>() : "";
@@ -125,7 +125,7 @@ OO_Dump_Qspips::execute(const SubCmdOptions& _options) const
     return;
   }
 
-  XBU::sudo_or_throw_err();
+  XBU::sudo_or_throw("ERROR: root privileges required.");
 
   try {
       qspips_readback(vm);

--- a/src/runtime_src/core/tools/xbflash2/OO_Program_Qspips.cpp
+++ b/src/runtime_src/core/tools/xbflash2/OO_Program_Qspips.cpp
@@ -41,7 +41,7 @@ void
 qspipsCommand(po::variables_map& vm)
 {
     //root privileges required.
-    XBU::sudo_or_throw_err();
+    XBU::sudo_or_throw("ERROR: root privileges required.");
 
     //mandatory command line args
     std::string bdf = vm.count("device") ? vm["device"].as<std::string>() : "";
@@ -159,7 +159,7 @@ OO_Program_Qspips::execute(const SubCmdOptions& _options) const
     return;
   }
 
-  XBU::sudo_or_throw_err();
+  XBU::sudo_or_throw("ERROR: root privileges required.");
   try {
       qspipsCommand(vm);      
   }

--- a/src/runtime_src/core/tools/xbflash2/OO_Program_Spi.cpp
+++ b/src/runtime_src/core/tools/xbflash2/OO_Program_Spi.cpp
@@ -40,7 +40,7 @@ namespace {
 void
 spiCommand(po::variables_map& vm) {
     //root privileges required.
-    XBU::sudo_or_throw_err();
+    XBU::sudo_or_throw("ERROR: root privileges required.");
 
     //mandatory command line args
     std::string bdf = vm.count("device") ? vm["device"].as<std::string>() : "";
@@ -151,7 +151,7 @@ OO_Program_Spi::execute(const SubCmdOptions& _options) const
     return;
   }
 
-  XBU::sudo_or_throw_err();
+  XBU::sudo_or_throw("ERROR: root privileges required.");
  
   try {
       spiCommand(vm);

--- a/src/runtime_src/core/tools/xbflash2/SubCmdDump.cpp
+++ b/src/runtime_src/core/tools/xbflash2/SubCmdDump.cpp
@@ -34,6 +34,7 @@ namespace po = boost::program_options;
 SubCmdDump::SubCmdDump(bool _isHidden, bool _isDepricated, bool _isPreliminary)
     : SubCmd("dump", 
              "Reads the image(s) for a given device for a given length and outputs the same to given file.\nIt is applicable for only QSPIPS flash.")
+    , m_help(false)
 {
   const std::string longDescription = "Reads the image(s) for a given device for a given length and outputs the same to given file.\nIt is applicable for only QSPIPS flash.";
   setLongDescription(longDescription);
@@ -41,89 +42,38 @@ SubCmdDump::SubCmdDump(bool _isHidden, bool _isDepricated, bool _isPreliminary)
   setIsHidden(_isHidden);
   setIsDeprecated(_isDepricated);
   setIsPreliminary(_isPreliminary);
+
+  m_commonOptions.add_options()
+    ("help", boost::program_options::bool_switch(&m_help), "Help to use this sub-command")
+  ;
+
+  addSubOption(std::make_shared<OO_Dump_Qspips>("qspips"));
 }
 
 
 void
 SubCmdDump::execute(const SubCmdOptions& _options) const
 {
-  // -- Common top level options ---
-  bool help = false;
-
-  po::options_description commonOptions("Common Options"); 
-  commonOptions.add_options()
-    ("help", boost::program_options::bool_switch(&help), "Help to use this sub-command")
-  ;
-
-  po::options_description hiddenOptions("Hidden Options"); 
-
-  // -- Define the supporting option options ----
-  SubOptionOptions subOptionOptions; 
-  subOptionOptions.emplace_back(std::make_shared<OO_Dump_Qspips>("qspips"));
-
-  for (auto & subOO : subOptionOptions) {
-    if (subOO->isHidden()) 
-      hiddenOptions.add_options()(subOO->longName().c_str(), subOO->description().c_str());
-    else
-      commonOptions.add_options()(subOO->longName().c_str(), subOO->description().c_str());
-    subOO->setExecutable(getExecutableName());
-    subOO->setCommand(getName());
-  }
-
-  po::options_description allOptions("All Options");
-  allOptions.add(commonOptions);
-  allOptions.add(hiddenOptions);
-
   // =========== Process the options ========================================
-
-  // 1) Process the common top level options 
-  po::parsed_options parsedCommonTop = 
-    po::command_line_parser(_options).
-    options(allOptions).          
-    allow_unregistered().           // Allow for unregistered options
-    run();                          // Parse the options
-
   po::variables_map vm;
-
-  try {
-    po::store(parsedCommonTop, vm);  // Can throw
-    po::notify(vm);                  // Can throw (but really isn't used)
-
-    // Mutual DRC
-    for (unsigned int index1 = 0; index1 < subOptionOptions.size(); ++index1) {
-      for (unsigned int index2 = index1 + 1; index2 < subOptionOptions.size(); ++index2) {
-        conflictingOptions(vm, subOptionOptions[index1]->longName(), subOptionOptions[index2]->longName());
-      }
-    }
-  } catch (const std::exception & e) {
-    std::cerr << "ERROR: " << e.what() << std::endl;
-    printHelp(commonOptions, hiddenOptions, subOptionOptions);
-    throw std::errc::operation_canceled;
-  }
+  auto topOptions = process_arguments(vm, _options, false);
 
   // Find the subOption;
-  std::shared_ptr<OptionOptions> optionOption;
-  for (auto& subOO : subOptionOptions) {
-    if (vm.count(subOO->longName().c_str()) != 0) {
-      optionOption = subOO;
-      break;
-    }
-  }
+  auto optionOption = checkForSubOption(vm);
 
   // No suboption print help
   if (!optionOption) {
-      if (help) {
-          printHelp(commonOptions, hiddenOptions, subOptionOptions);
+      if (m_help) {
+          printHelp();
           return;
       }
       std::cerr << "\nERROR: Suboption missing" << std::endl;
-      printHelp(commonOptions, hiddenOptions, subOptionOptions);
+      printHelp();
       throw std::errc::operation_canceled;
   }
 
   // 2) Process the top level options
-  std::vector<std::string> topOptions = po::collect_unrecognized(parsedCommonTop.options, po::include_positional);
-  if (help)
+  if (m_help)
     topOptions.push_back("--help");
 
   optionOption->setGlobalOptions(getGlobalOptions());

--- a/src/runtime_src/core/tools/xbflash2/SubCmdDump.h
+++ b/src/runtime_src/core/tools/xbflash2/SubCmdDump.h
@@ -26,6 +26,9 @@ class SubCmdDump : public SubCmd {
  public:
   SubCmdDump(bool _isHidden, bool _isDepricated, bool _isPreliminary);
   virtual ~SubCmdDump() {};
+
+ private:
+  bool m_help;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbflash2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbflash2/SubCmdProgram.cpp
@@ -34,6 +34,7 @@ namespace po = boost::program_options;
 SubCmdProgram::SubCmdProgram(bool _isHidden, bool _isDepricated, bool _isPreliminary)
     : SubCmd("program", 
              "Updates the image(s) for a given device")
+    , m_help(false)
 {
   const std::string longDescription = "Programs the given acceleration image into the device's shell.";
   setLongDescription(longDescription);
@@ -41,90 +42,39 @@ SubCmdProgram::SubCmdProgram(bool _isHidden, bool _isDepricated, bool _isPrelimi
   setIsHidden(_isHidden);
   setIsDeprecated(_isDepricated);
   setIsPreliminary(_isPreliminary);
+
+  m_commonOptions.add_options()
+    ("help", boost::program_options::bool_switch(&m_help), "Help to use this sub-command")
+  ;
+
+  addSubOption(std::make_shared<OO_Program_Spi>("spi"));
+  addSubOption(std::make_shared<OO_Program_Qspips>("qspips"));
 }
 
 
 void
 SubCmdProgram::execute(const SubCmdOptions& _options) const
 {
-  // -- Common top level options ---
-  bool help = false;
-
-  po::options_description commonOptions("Common Options"); 
-  commonOptions.add_options()
-    ("help", boost::program_options::bool_switch(&help), "Help to use this sub-command")
-  ;
-
-  po::options_description hiddenOptions("Hidden Options"); 
-
-  // -- Define the supporting option options ----
-  SubOptionOptions subOptionOptions;
-  subOptionOptions.emplace_back(std::make_shared<OO_Program_Spi>("spi"));
-  subOptionOptions.emplace_back(std::make_shared<OO_Program_Qspips>("qspips"));
-
-  for (auto & subOO : subOptionOptions) {
-    if (subOO->isHidden()) 
-      hiddenOptions.add_options()(subOO->longName().c_str(), subOO->description().c_str());
-    else
-      commonOptions.add_options()(subOO->longName().c_str(), subOO->description().c_str());
-    subOO->setExecutable(getExecutableName());
-    subOO->setCommand(getName());
-  }
-
-  po::options_description allOptions("All Options");
-  allOptions.add(commonOptions);
-  allOptions.add(hiddenOptions);
-
-  // =========== Process the options ========================================
-
   // 1) Process the common top level options 
-  po::parsed_options parsedCommonTop = 
-    po::command_line_parser(_options).
-    options(allOptions).          
-    allow_unregistered().           // Allow for unregistered options
-    run();                          // Parse the options
-
   po::variables_map vm;
-
-  try {
-    po::store(parsedCommonTop, vm);  // Can throw
-    po::notify(vm);                  // Can throw (but really isn't used)
-
-    // Mutual DRC
-    for (unsigned int index1 = 0; index1 < subOptionOptions.size(); ++index1) {
-      for (unsigned int index2 = index1 + 1; index2 < subOptionOptions.size(); ++index2) {
-        conflictingOptions(vm, subOptionOptions[index1]->longName(), subOptionOptions[index2]->longName());
-      }
-    }
-  } catch (const std::exception & e) {
-    std::cerr << "ERROR: " << e.what() << std::endl;
-    printHelp(commonOptions, hiddenOptions, subOptionOptions);
-    throw std::errc::operation_canceled;
-  }
+  auto topOptions = process_arguments(vm, _options, false);
 
   // Find the subOption;
-  std::shared_ptr<OptionOptions> optionOption;
-  for (auto& subOO : subOptionOptions) {
-    if (vm.count(subOO->longName().c_str()) != 0) {
-      optionOption = subOO;
-      break;
-    }
-  }
+  auto optionOption = checkForSubOption(vm);
 
   // No suboption print help
   if (!optionOption) {
-      if (help) {
-          printHelp(commonOptions, hiddenOptions, subOptionOptions);
+      if (m_help) {
+          printHelp();
           return;
       }
       std::cerr << "\nERROR: Suboption missing" << std::endl;
-      printHelp(commonOptions, hiddenOptions, subOptionOptions);
+      printHelp();
       throw std::errc::operation_canceled;
   }
 
   // 2) Process the top level options
-  std::vector<std::string> topOptions = po::collect_unrecognized(parsedCommonTop.options, po::include_positional);
-  if (help)
+  if (m_help)
     topOptions.push_back("--help");
 
   optionOption->setGlobalOptions(getGlobalOptions());

--- a/src/runtime_src/core/tools/xbflash2/SubCmdProgram.h
+++ b/src/runtime_src/core/tools/xbflash2/SubCmdProgram.h
@@ -26,6 +26,9 @@ class SubCmdProgram : public SubCmd {
  public:
   SubCmdProgram(bool _isHidden, bool _isDepricated, bool _isPreliminary);
   virtual ~SubCmdProgram() {};
+
+ private:
+  bool m_help;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdAdvanced.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdAdvanced.cpp
@@ -45,6 +45,7 @@ namespace po = boost::program_options;
 SubCmdAdvanced::SubCmdAdvanced(bool _isHidden, bool _isDepricated, bool _isPreliminary)
     : SubCmd("advanced", 
              "Low level command operations")
+    , m_help(false)
 {
   const std::string longDescription = "Low level command operations.";
   setLongDescription(longDescription);
@@ -52,6 +53,12 @@ SubCmdAdvanced::SubCmdAdvanced(bool _isHidden, bool _isDepricated, bool _isPreli
   setIsHidden(_isHidden);
   setIsDeprecated(_isDepricated);
   setIsPreliminary(_isPreliminary);
+
+  m_commonOptions.add_options()
+    ("help", boost::program_options::bool_switch(&m_help), "Help to use this sub-command")
+  ;
+
+  addSubOption(std::make_shared<OO_Hotplug>("hotplug"));
 }
 
 
@@ -60,65 +67,24 @@ SubCmdAdvanced::execute(const SubCmdOptions& _options) const
 {
   XBU::verbose("SubCommand: advanced");
 
-  // -- Common top level options ---
-  bool help = false;
-
-  po::options_description commonOptions("Common Options"); 
-  commonOptions.add_options()
-    ("help", boost::program_options::bool_switch(&help), "Help to use this sub-command")
-  ;
-
-  po::options_description hiddenOptions("Hidden Options");
-
-  // -- Define the supporting option options ----
-  SubOptionOptions subOptionOptions;
-  subOptionOptions.emplace_back(std::make_shared<OO_Hotplug>("hotplug"));
-
-  for (auto & subOO : subOptionOptions) {
-    if (subOO->isHidden()) 
-      hiddenOptions.add_options()(subOO->longName().c_str(), subOO->description().c_str());
-    else
-      commonOptions.add_options()(subOO->longName().c_str(), subOO->description().c_str());
-
-    subOO->setExecutable(getExecutableName());
-    subOO->setCommand(getName());
-  }
-
-  po::options_description allOptions("All Options");
-  allOptions.add(commonOptions);
-  allOptions.add(hiddenOptions);
-
-  po::positional_options_description positionals;
-
   // =========== Process the options ========================================
 
   // 1) Process the common top level options 
   po::variables_map vm;
   // Used for the suboption arguments
-  auto topOptions = process_arguments(vm, _options, commonOptions, hiddenOptions, positionals, subOptionOptions, false);
+  auto topOptions = process_arguments(vm, _options, false);
 
   // DRC check between suboptions
-  for (unsigned int index1 = 0; index1 < subOptionOptions.size(); ++index1)
-    for (unsigned int index2 = index1 + 1; index2 < subOptionOptions.size(); ++index2)
-      conflictingOptions(vm, subOptionOptions[index1]->longName(), subOptionOptions[index2]->longName());
-
-  // Find the subOption;
-  std::shared_ptr<OptionOptions> optionOption;
-  for (auto subOO : subOptionOptions) {
-    if (vm.count(subOO->longName().c_str()) != 0) {
-      optionOption = subOO;
-      break;
-    }
-  }
+  auto optionOption = checkForSubOption(vm);
 
   // No suboption print help
   if (!optionOption) {
-    printHelp(commonOptions, hiddenOptions, subOptionOptions);
+    printHelp();
     return;
   }
 
   // 2) Process the top level options
-  if (help)
+  if (m_help)
     topOptions.push_back("--help");
 
   optionOption->setGlobalOptions(getGlobalOptions());

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdAdvanced.h
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdAdvanced.h
@@ -26,6 +26,9 @@ class SubCmdAdvanced : public SubCmd {
  public:
   SubCmdAdvanced(bool _isHidden, bool _isDepricated, bool _isPreliminary);
   virtual ~SubCmdAdvanced() {};
+
+  private:
+    bool m_help;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdConfigure.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdConfigure.cpp
@@ -77,9 +77,26 @@ struct config
   }
 };
 
+static po::options_description loadConfigOptions("Load Config Options");
+static po::options_description configOptions("Config Options");
+static po::options_description configHiddenOptions("Hidden Config Options");
+
 SubCmdConfigure::SubCmdConfigure(bool _isHidden, bool _isDepricated, bool _isPreliminary)
     : SubCmd("configure",
              "Advanced options for configuring a device")
+    , m_device("")
+    , m_path("")
+    , m_retention("")
+    , m_help(false)
+    , m_daemon(false)
+    , m_purge(false)
+    , m_host("")
+    , m_security("")
+    , m_clk_scale("")
+    , m_power_override("")
+    , m_temp_override("")
+    , m_cs_reset("")
+    , m_showx(false)
 {
   const std::string long_description = "Advanced options for configuring a device";
   setLongDescription(long_description);
@@ -87,9 +104,41 @@ SubCmdConfigure::SubCmdConfigure(bool _isHidden, bool _isDepricated, bool _isPre
   setIsHidden(_isHidden);
   setIsDeprecated(_isDepricated);
   setIsPreliminary(_isPreliminary);
+
+  // Options previously under the load config command
+  loadConfigOptions.add_options()
+    ("input", boost::program_options::value<decltype(m_path)>(&m_path),"INI file with the memory configuration")
+  ;
+
+  // Options previously under the config command
+  configOptions.add_options()
+    ("retention", boost::program_options::value<decltype(m_retention)>(&m_retention),"Enables / Disables memory retention.  Valid values are: [ENABLE | DISABLE]")
+  ;
+
+  m_commonOptions.add_options()
+    ("device,d", boost::program_options::value<decltype(m_device)>(&m_device), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest")
+    ("help", boost::program_options::bool_switch(&m_help), "Help to use this sub-command")
+  ;
+  m_commonOptions.add(loadConfigOptions);
+  m_commonOptions.add(configOptions);
+
+  // Options previously hidden under the config command
+  configHiddenOptions.add_options()
+    ("daemon", boost::program_options::bool_switch(&m_daemon), "Update the device daemon configuration")
+    ("purge", boost::program_options::bool_switch(&m_purge), "Remove the daemon configuration file")
+    ("host", boost::program_options::value<decltype(m_host)>(&m_host), "IP or hostname for device peer")
+    ("security", boost::program_options::value<decltype(m_security)>(&m_security), "Update the security level for the device")
+    ("runtime_clk_scale", boost::program_options::value<decltype(m_clk_scale)>(&m_clk_scale), "Enable/disable the device runtime clock scaling")
+    ("cs_threshold_power_override", boost::program_options::value<decltype(m_power_override)>(&m_power_override), "Update the power threshold in watts")
+    ("cs_threshold_temp_override", boost::program_options::value<decltype(m_temp_override)>(&m_temp_override), "Update the temperature threshold in celsius")
+    ("cs_reset", boost::program_options::value<decltype(m_cs_reset)>(&m_cs_reset), "Reset all scaling options")
+    ("showx", boost::program_options::bool_switch(&m_showx), "Display the device configuration settings")
+  ;
+
+  m_hiddenOptions.add(configHiddenOptions);
 }
 
-static void load_config(const std::shared_ptr<xrt_core::device>& _dev, const std::string path)
+static void load_config(const std::shared_ptr<xrt_core::device>& _dev, const std::string& path)
 {
   boost::property_tree::ptree pt_root;
   boost::property_tree::ini_parser::read_ini(path, pt_root);
@@ -368,61 +417,9 @@ SubCmdConfigure::execute(const SubCmdOptions& _options) const
 {
     XBU::verbose("SubCommand: configure");
     // -- Retrieve and parse the subcommand options -----------------------------
-    // Common options
-    std::string device_str;
-    std::string path;
-    std::string retention;
-    bool help = false;
-    // Hidden options
-    bool daemon = false;
-    bool purge  = false;
-    std::string host;
-    std::string security;
-    std::string clk_scale;
-    std::string power_override;
-    std::string temp_override;
-    std::string cs_reset;
-    bool showx = false;
-
-    // Options previously under the load config command
-    po::options_description loadConfigOptions("Load Config Options");
-    loadConfigOptions.add_options()
-      ("input", boost::program_options::value<decltype(path)>(&path),"INI file with the memory configuration")
-    ;
-
-    // Options previously under the config command
-    po::options_description configOptions("Config Options");
-    configOptions.add_options()
-      ("retention", boost::program_options::value<decltype(retention)>(&retention),"Enables / Disables memory retention.  Valid values are: [ENABLE | DISABLE]")
-    ;
-
-    po::options_description commonOptions("Common Options");
-    commonOptions.add_options()
-        ("device,d", boost::program_options::value<decltype(device_str)>(&device_str), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest")
-        ("help", boost::program_options::bool_switch(&help), "Help to use this sub-command")
-    ;
-
-    commonOptions.add(loadConfigOptions);
-    commonOptions.add(configOptions);
-
-    // Hidden options previously under the config command
-    po::options_description configHiddenOptions("Hidden Options");
-    configHiddenOptions.add_options()
-        ("daemon", boost::program_options::bool_switch(&daemon), "Update the device daemon configuration")
-        ("purge", boost::program_options::bool_switch(&purge), "Remove the daemon configuration file")
-        ("host", boost::program_options::value<decltype(host)>(&host), "IP or hostname for device peer")
-        ("security", boost::program_options::value<decltype(security)>(&security), "Update the security level for the device")
-        ("runtime_clk_scale", boost::program_options::value<decltype(clk_scale)>(&clk_scale), "Enable/disable the device runtime clock scaling")
-        ("cs_threshold_power_override", boost::program_options::value<decltype(power_override)>(&power_override), "Update the power threshold in watts")
-        ("cs_threshold_temp_override", boost::program_options::value<decltype(temp_override)>(&temp_override), "Update the temperature threshold in celsius")
-        ("cs_reset", boost::program_options::value<decltype(cs_reset)>(&cs_reset), "Reset all scaling options")
-        ("showx", boost::program_options::bool_switch(&showx), "Display the device configuration settings")
-    ;
-
     // Parse sub-command ...
     po::variables_map vm;
-
-    process_arguments(vm, _options, commonOptions, configHiddenOptions);
+    process_arguments(vm, _options);
 
     // Ensure mutual exclusion amongst the load config and config options
     // TODO Once all of the config options are incorporated into the load config file
@@ -439,23 +436,23 @@ SubCmdConfigure::execute(const SubCmdOptions& _options) const
 
     // Check the options
     // -- process "help" option -----------------------------------------------
-    if (help) {
-        printHelp(commonOptions, configHiddenOptions);
+    if (m_help) {
+        printHelp();
         return;
     }
 
     // Non-device options
     // Remove the daemon config file
-    if (purge) {
+    if (m_purge) {
         XBU::verbose("Sub command: --purge");
         remove_daemon_config();
         return;
     }
 
     // Update daemon
-    if (daemon) {
+    if (m_daemon) {
         XBU::verbose("Sub command: --daemon");
-        update_daemon_config(host);
+        update_daemon_config(m_host);
         return;
     }
 
@@ -463,7 +460,7 @@ SubCmdConfigure::execute(const SubCmdOptions& _options) const
     std::shared_ptr<xrt_core::device> device;
 
     try {
-        device = XBU::get_device(boost::algorithm::to_lower_copy(device_str), false /*inUserDomain*/);
+        device = XBU::get_device(boost::algorithm::to_lower_copy(m_device_str), false /*inUserDomain*/);
     } catch (const std::runtime_error& e) {
         // Catch only the exceptions that we have generated earlier
         std::cerr << boost::format("ERROR: %s\n") % e.what();
@@ -478,19 +475,19 @@ SubCmdConfigure::execute(const SubCmdOptions& _options) const
 
     // Load Config commands
     // -- process "input" option -----------------------------------------------
-    if (!path.empty()) {
-        if (!boost::filesystem::exists(path)) {
-            std::cerr << boost::format("ERROR: Input file does not exist: '%s'") % path << "\n\n";
+    if (!m_path.empty()) {
+        if (!boost::filesystem::exists(m_path)) {
+            std::cerr << boost::format("ERROR: Input file does not exist: '%s'") % m_path << "\n\n";
             throw xrt_core::error(std::errc::operation_canceled);
         }
 
-        if(boost::filesystem::extension(path).compare(".ini") != 0) {
-            std::cerr << boost::format("ERROR: Input file should be an INI file: '%s'") % path << "\n\n";
+        if(boost::filesystem::extension(m_path).compare(".ini") != 0) {
+            std::cerr << boost::format("ERROR: Input file should be an INI file: '%s'") % m_path << "\n\n";
             throw xrt_core::error(std::errc::operation_canceled);
         }
 
         try {
-            load_config(device, path);
+            load_config(device, m_path);
             std::cout << "Config has been successfully loaded" << std::endl;
             return;
         } catch (const std::runtime_error& e) {
@@ -501,10 +498,10 @@ SubCmdConfigure::execute(const SubCmdOptions& _options) const
     }
 
     // Config commands
-    // Option:showx
-    if (showx) {
+    // Option:m_showx
+    if (m_showx) {
         XBU::verbose("Sub command: --showx");
-        if(daemon)
+        if(m_daemon)
             show_daemon_conf();
 
         show_device_conf(device.get());
@@ -515,34 +512,34 @@ SubCmdConfigure::execute(const SubCmdOptions& _options) const
     bool is_something_updated = false;
 
     // Update security
-    if (!security.empty())
-        is_something_updated = update_device_conf(device.get(), security, config_type::security);
+    if (!m_security.empty())
+        is_something_updated = update_device_conf(device.get(), m_security, config_type::security);
 
     // Clock scaling
-    if (!clk_scale.empty())
-        is_something_updated = update_device_conf(device.get(), clk_scale, config_type::clk_scaling);
+    if (!m_clk_scale.empty())
+        is_something_updated = update_device_conf(device.get(), m_clk_scale, config_type::clk_scaling);
     
     // Update threshold power override
-    if (!power_override.empty())
-        is_something_updated = update_device_conf(device.get(), power_override, config_type::threshold_power_override);
+    if (!m_power_override.empty())
+        is_something_updated = update_device_conf(device.get(), m_power_override, config_type::threshold_power_override);
 
     // Update threshold temp override
-    if (!temp_override.empty())
-        is_something_updated = update_device_conf(device.get(), temp_override, config_type::threshold_temp_override);
+    if (!m_temp_override.empty())
+        is_something_updated = update_device_conf(device.get(), m_temp_override, config_type::threshold_temp_override);
 
-    // cs_reset?? TODO needs better comment
-    if (!cs_reset.empty())
-        is_something_updated = update_device_conf(device.get(), cs_reset, config_type::reset);
+    // m_cs_reset?? TODO needs better comment
+    if (!m_cs_reset.empty())
+        is_something_updated = update_device_conf(device.get(), m_cs_reset, config_type::reset);
 
     // Enable/Disable Retention
-    if (!retention.empty()) {
+    if (!m_retention.empty()) {
         // Validate the given retention string
-        boost::algorithm::to_upper(retention);
-        bool enableRetention = boost::iequals(retention, "ENABLE");
-        bool disableRetention = boost::iequals(retention, "DISABLE");
+        boost::algorithm::to_upper(m_retention);
+        bool enableRetention = boost::iequals(m_retention, "ENABLE");
+        bool disableRetention = boost::iequals(m_retention, "DISABLE");
         if (!enableRetention && !disableRetention) {
-            std::cerr << "ERROR: Invalidate '--retention' option: " << retention << std::endl;
-            printHelp(commonOptions, configHiddenOptions);
+            std::cerr << "ERROR: Invalidate '--retention' option: " << m_retention << std::endl;
+            printHelp();
             throw xrt_core::error(std::errc::operation_canceled);
         }
 
@@ -553,7 +550,7 @@ SubCmdConfigure::execute(const SubCmdOptions& _options) const
 
     if (!is_something_updated) {
         std::cerr << "ERROR: Please specify a valid option to configure the device" << "\n\n";
-        printHelp(commonOptions, configHiddenOptions);
+        printHelp();
         throw xrt_core::error(std::errc::operation_canceled);
     }
 }

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdConfigure.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdConfigure.cpp
@@ -460,7 +460,7 @@ SubCmdConfigure::execute(const SubCmdOptions& _options) const
     std::shared_ptr<xrt_core::device> device;
 
     try {
-        device = XBU::get_device(boost::algorithm::to_lower_copy(m_device_str), false /*inUserDomain*/);
+        device = XBU::get_device(boost::algorithm::to_lower_copy(m_device), false /*inUserDomain*/);
     } catch (const std::runtime_error& e) {
         // Catch only the exceptions that we have generated earlier
         std::cerr << boost::format("ERROR: %s\n") % e.what();
@@ -534,9 +534,9 @@ SubCmdConfigure::execute(const SubCmdOptions& _options) const
     // Enable/Disable Retention
     if (!m_retention.empty()) {
         // Validate the given retention string
-        boost::algorithm::to_upper(m_retention);
-        bool enableRetention = boost::iequals(m_retention, "ENABLE");
-        bool disableRetention = boost::iequals(m_retention, "DISABLE");
+        const auto upper_retention = boost::algorithm::to_upper_copy(m_retention);
+        bool enableRetention = boost::iequals(upper_retention, "ENABLE");
+        bool disableRetention = boost::iequals(upper_retention, "DISABLE");
         if (!enableRetention && !disableRetention) {
             std::cerr << "ERROR: Invalidate '--retention' option: " << m_retention << std::endl;
             printHelp();

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdConfigure.h
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdConfigure.h
@@ -26,6 +26,23 @@ class SubCmdConfigure : public SubCmd {
  public:
   SubCmdConfigure(bool _isHidden, bool _isDepricated, bool _isPreliminary);
   virtual ~SubCmdConfigure() {};
+
+ private:
+  // Common options
+  std::string m_device;
+  std::string m_path;
+  std::string m_retention;
+  bool        m_help;
+  // Hidden options
+  bool        m_daemon;
+  bool        m_purge;
+  std::string m_host;
+  std::string m_security;
+  std::string m_clk_scale;
+  std::string m_power_override;
+  std::string m_temp_override;
+  std::string m_cs_reset;
+  bool        m_showx;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdDump.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdDump.cpp
@@ -130,7 +130,7 @@ SubCmdDump::SubCmdDump(bool _isHidden, bool _isDepricated, bool _isPreliminary)
     ("device,d", boost::program_options::value<decltype(m_device)>(&m_device), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest.")
     ("config,c", boost::program_options::bool_switch(&m_config), "Dumps the m_output of system configuration, requires a .ini m_output file by -o option")
     ("flash,f", boost::program_options::bool_switch(&m_flash), "Dumps the m_output of programmed system image, requires a .bin m_output file by -o option")
-    ("m_output,o", boost::program_options::value<decltype(m_m_output)>(&m_m_output), "Direct the m_output to the given file")
+    ("output,o", boost::program_options::value<decltype(m_output)>(&m_output), "Direct the m_output to the given file")
     ("help", boost::program_options::bool_switch(&m_help), "Help to use this sub-command")
   ;
 }
@@ -171,12 +171,12 @@ SubCmdDump::execute(const SubCmdOptions& _options) const
     throw xrt_core::error(std::errc::operation_canceled);
   }
 
-  // -- process "m_output" option -----------------------------------------------
-  // m_output file
-  XBU::verbose("Option: m_output: " + m_output);
+  // -- process "output" option -----------------------------------------------
+  // output file
+  XBU::verbose("Option: output: " + m_output);
 
   if (m_output.empty()) {
-    std::cerr << "ERROR: Please specify an m_output file using --m_output option" << "\n\n";
+    std::cerr << "ERROR: Please specify an output file using --output option" << "\n\n";
     printHelp();
     throw xrt_core::error(std::errc::operation_canceled);
   }

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdDump.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdDump.cpp
@@ -26,10 +26,10 @@ namespace po = boost::program_options;
 // ------ L O C A L   F U N C T I O N S ---------------------------------------
 
 static void
-flash_dump(const std::shared_ptr<xrt_core::device>& _dev, const std::string output)
+flash_dump(const std::shared_ptr<xrt_core::device>& _dev, const std::string m_output)
 {
-  // Sample output:
-  //   Output file: foo.bin
+  // Sample m_output:
+  //   m_output file: foo.bin
   //   Flash Size: 0x222 (Mbits)
   //   <Progress Bar>
 
@@ -39,7 +39,7 @@ flash_dump(const std::shared_ptr<xrt_core::device>& _dev, const std::string outp
     return;
   }
   try{
-    flasher.readBack(output);
+    flasher.readBack(m_output);
   } catch(const std::exception& ex){
       std::cerr << "  ERROR: " << ex.what() << std::endl << std::endl;
       throw xrt_core::error(std::errc::operation_canceled);
@@ -77,7 +77,7 @@ is_supported(const std::shared_ptr<xrt_core::device>& dev)
  * cache_xclbin = 0
  */
 static void
-config_dump(const std::shared_ptr<xrt_core::device>& _dev, const std::string output)
+config_dump(const std::shared_ptr<xrt_core::device>& _dev, const std::string m_output)
 {
   boost::property_tree::ptree ptRoot;
 
@@ -106,13 +106,18 @@ config_dump(const std::shared_ptr<xrt_core::device>& _dev, const std::string out
 
   ptRoot.put_child("Device", child);
 
-  boost::property_tree::ini_parser::write_ini(output, ptRoot);
-  std::cout << "config has been dumped to " << output << std::endl;
+  boost::property_tree::ini_parser::write_ini(m_output, ptRoot);
+  std::cout << "config has been dumped to " << m_output << std::endl;
 }
 
 SubCmdDump::SubCmdDump(bool _isHidden, bool _isDepricated, bool _isPreliminary)
     : SubCmd("dump",
              "Dump out the contents of the specified option")
+    , m_device("")
+    , m_m_output("")
+    , m_flash(false)
+    , m_config(false)
+    , m_help(false)
 {
   const std::string longDescription = "Dump out the contents of the specified option.";
   setLongDescription(longDescription);
@@ -120,6 +125,14 @@ SubCmdDump::SubCmdDump(bool _isHidden, bool _isDepricated, bool _isPreliminary)
   setIsHidden(_isHidden);
   setIsDeprecated(_isDepricated);
   setIsPreliminary(_isPreliminary);
+
+  m_commonOptions.add_options()
+    ("device,d", boost::program_options::value<decltype(m_device)>(&m_device), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest.")
+    ("config,c", boost::program_options::bool_switch(&m_config), "Dumps the m_output of system configuration, requires a .ini m_output file by -o option")
+    ("flash,f", boost::program_options::bool_switch(&m_flash), "Dumps the m_output of programmed system image, requires a .bin m_output file by -o option")
+    ("m_output,o", boost::program_options::value<decltype(m_m_output)>(&m_m_output), "Direct the m_output to the given file")
+    ("help", boost::program_options::bool_switch(&m_help), "Help to use this sub-command")
+  ;
 }
 
 // ----- C L A S S   M E T H O D S -------------------------------------------
@@ -128,30 +141,13 @@ void
 SubCmdDump::execute(const SubCmdOptions& _options) const
 {
   XBU::verbose("SubCommand: dump");
-  // -- Retrieve and parse the subcommand options -----------------------------
-  std::string device_str;
-  std::string output = "";
-  bool flash = false;
-  bool config = false;
-  bool help = false;
-
-  po::options_description commonOptions("Common Options");
-  commonOptions.add_options()
-    ("device,d", boost::program_options::value<decltype(device_str)>(&device_str), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest.")
-    ("config,c", boost::program_options::bool_switch(&config), "Dumps the output of system configuration, requires a .ini output file by -o option")
-    ("flash,f", boost::program_options::bool_switch(&flash), "Dumps the output of programmed system image, requires a .bin output file by -o option")
-    ("output,o", boost::program_options::value<decltype(output)>(&output), "Direct the output to the given file")
-    ("help", boost::program_options::bool_switch(&help), "Help to use this sub-command")
-  ;
-
-  po::options_description hiddenOptions("Hidden Options");
 
   // Parse sub-command ...
   po::variables_map vm;
-  process_arguments(vm, _options, commonOptions, hiddenOptions);
+  process_arguments(vm, _options);
 
   // Check to see if help was requested or no command was found
-  if (help)  {
+  if (m_help)  {
     printHelp(commonOptions, hiddenOptions);
     return;
   }
@@ -161,45 +157,45 @@ SubCmdDump::execute(const SubCmdOptions& _options) const
 
   // -- process "device" option -----------------------------------------------
   XBU::verbose("Option: device");
-  for (auto & str : device_str)
+  for (auto & str : m_device)
     XBU::verbose(std::string(" ") + str);
 
   // Find device of interest
   std::shared_ptr<xrt_core::device> device;
 
   try {
-    device = XBU::get_device(device_str, false /*inUserDomain*/);
+    device = XBU::get_device(m_device, false /*inUserDomain*/);
   } catch (const std::runtime_error& e) {
     // Catch only the exceptions that we have generated earlier
     std::cerr << boost::format("ERROR: %s\n") % e.what();
     throw xrt_core::error(std::errc::operation_canceled);
   }
 
-  // -- process "output" option -----------------------------------------------
-  // Output file
-  XBU::verbose("Option: output: " + output);
+  // -- process "m_output" option -----------------------------------------------
+  // m_output file
+  XBU::verbose("Option: m_output: " + m_output);
 
-  if (output.empty()) {
-    std::cerr << "ERROR: Please specify an output file using --output option" << "\n\n";
-    printHelp(commonOptions, hiddenOptions);
+  if (m_output.empty()) {
+    std::cerr << "ERROR: Please specify an m_output file using --m_output option" << "\n\n";
+    printHelp();
     throw xrt_core::error(std::errc::operation_canceled);
   }
-  if (!output.empty() && boost::filesystem::exists(output) && !XBU::getForce()) {
-    std::cerr << boost::format("Output file already exists: '%s'") % output << "\n\n";
+  if (!m_output.empty() && boost::filesystem::exists(m_output) && !XBU::getForce()) {
+    std::cerr << boost::format("m_output file already exists: '%s'") % m_output << "\n\n";
     throw xrt_core::error(std::errc::operation_canceled);
   }
 
   //decide the contents of the dump file
-  if(flash) {
-    flash_dump(device, output);
+  if(m_flash) {
+    flash_dump(device, m_output);
     return;
   }
-  if (config) {
-    config_dump(device, output);
+  if (m_config) {
+    config_dump(device, m_output);
     return;
   }
 
   std::cerr << "ERROR: Please specify a valid option to determine the type of dump" << "\n\n";
-  printHelp(commonOptions, hiddenOptions);
+  printHelp();
   throw xrt_core::error(std::errc::operation_canceled);
 }

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdDump.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdDump.cpp
@@ -114,7 +114,7 @@ SubCmdDump::SubCmdDump(bool _isHidden, bool _isDepricated, bool _isPreliminary)
     : SubCmd("dump",
              "Dump out the contents of the specified option")
     , m_device("")
-    , m_m_output("")
+    , m_output("")
     , m_flash(false)
     , m_config(false)
     , m_help(false)
@@ -148,7 +148,7 @@ SubCmdDump::execute(const SubCmdOptions& _options) const
 
   // Check to see if help was requested or no command was found
   if (m_help)  {
-    printHelp(commonOptions, hiddenOptions);
+    printHelp();
     return;
   }
 

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdDump.h
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdDump.h
@@ -25,6 +25,13 @@ class SubCmdDump : public SubCmd {
 
  public:
   SubCmdDump(bool _isHidden, bool _isDepricated, bool _isPreliminary);
+
+ private:
+  std::string m_device;
+  std::string m_output;
+  bool m_flash;
+  bool m_config;
+  bool m_help;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdExamine.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdExamine.cpp
@@ -50,10 +50,19 @@ static const ReportCollection fullReportCollection = {
 };
 
 // ----- C L A S S   M E T H O D S -------------------------------------------
+// -- Build up the report & format options
+static const std::string reportOptionValues = XBU::create_suboption_list_string(fullReportCollection, true /*add 'all' option*/);
+static const std::string formatOptionValues = XBU::create_suboption_list_string(Report::getSchemaDescriptionVector());
 
 SubCmdExamine::SubCmdExamine(bool _isHidden, bool _isDepricated, bool _isPreliminary)
     : SubCmd("examine", 
              "Returns detail information for the specified device.")
+    , m_device("")
+    , m_reportNames()
+    , m_elementsFilter()
+    , m_format("")
+    , m_output("")
+    , m_help(false)
 {
   const std::string longDescription = "This command will 'examine' the state of the system/device and will"
                                       " generate a report of interest in a text or JSON format.";
@@ -62,6 +71,14 @@ SubCmdExamine::SubCmdExamine(bool _isHidden, bool _isDepricated, bool _isPrelimi
   setIsHidden(_isHidden);
   setIsDeprecated(_isDepricated);
   setIsPreliminary(_isPreliminary);
+
+  m_commonOptions.add_options()
+    ("device,d", boost::program_options::value<decltype(m_device)>(&m_device), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest")
+    ("report,r", boost::program_options::value<decltype(m_reportNames)>(&m_reportNames)->multitoken(), (std::string("The type of report to be produced. Reports currently available are:\n") + reportOptionValues).c_str() )
+    ("format,f", boost::program_options::value<decltype(m_format)>(&m_format), (std::string("Report output format. Valid values are:\n") + formatOptionValues).c_str() )
+    ("output,o", boost::program_options::value<decltype(m_output)>(&m_output), "Direct the output to the given file")
+    ("help", boost::program_options::bool_switch(&m_help), "Help to use this sub-command")
+  ;
 }
 
 void

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdExamine.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdExamine.cpp
@@ -73,72 +73,52 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
   const std::string reportOptionValues = XBU::create_suboption_list_string(fullReportCollection, true /*add 'all' option*/);
   const std::string formatOptionValues = XBU::create_suboption_list_string(Report::getSchemaDescriptionVector());
 
-  // Option Variables
-  std::string device_str;
-  std::vector<std::string> reportNames;
-  std::vector<std::string> elementsFilter;
-  std::string sFormat = "";
-  std::string sOutput = "";
-  bool bHelp = false;
-
-  // -- Retrieve and parse the subcommand options -----------------------------
-  po::options_description commonOptions("Common Options");  
-  commonOptions.add_options()
-    ("device,d", boost::program_options::value<decltype(device_str)>(&device_str), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest")
-    ("report,r", boost::program_options::value<decltype(reportNames)>(&reportNames)->multitoken(), (std::string("The type of report to be produced. Reports currently available are:\n") + reportOptionValues).c_str() )
-    ("format,f", boost::program_options::value<decltype(sFormat)>(&sFormat), (std::string("Report output format. Valid values are:\n") + formatOptionValues).c_str() )
-    ("output,o", boost::program_options::value<decltype(sOutput)>(&sOutput), "Direct the output to the given file")
-    ("help", boost::program_options::bool_switch(&bHelp), "Help to use this sub-command")
-  ;
-
-  po::options_description hiddenOptions("Hidden Options");
-
   // Parse sub-command ...
   po::variables_map vm;
-  process_arguments(vm, _options, commonOptions, hiddenOptions);
+  process_arguments(vm, _options);
 
   // Check to see if help was requested 
-  if (bHelp) {
-    printHelp(commonOptions, hiddenOptions);
+  if (m_help) {
+    printHelp();
     return;
   }
 
-  // Determine report leveld
-  if (reportNames.empty()) {
-    if (device_str.empty())
-      reportNames.push_back("host");
+  // Determine report level
+  std::vector<std::string> reportsToRun(m_reportNames);
+  if (reportsToRun.empty()) {
+    if (m_device.empty())
+      reportsToRun.push_back("host");
     else
-      reportNames.push_back("platform");
+      reportsToRun.push_back("platform");
   }
 
   // -- Process the options --------------------------------------------
   ReportCollection reportsToProcess;            // Reports of interest
 
   // Collect the reports to be processed
-  XBU::collect_and_validate_reports(fullReportCollection, reportNames, reportsToProcess);
+  XBU::collect_and_validate_reports(fullReportCollection, reportsToRun, reportsToProcess);
 
   // when json is specified, make sure an accompanying output file is also specified
-  if (!sFormat.empty() && sOutput.empty())
+  if (!m_format.empty() && m_output.empty())
     throw xrt_core::error("Please specify an output file to redirect the json to");
 
-  if(sFormat.empty())
-    sFormat = "json";
+  const auto validated_format = m_format.empty() ? "json" : m_format;
 
   // Output Format
-  Report::SchemaVersion schemaVersion = Report::getSchemaDescription(sFormat).schemaVersion;
+  Report::SchemaVersion schemaVersion = Report::getSchemaDescription(validated_format).schemaVersion;
   if (schemaVersion == Report::SchemaVersion::unknown) 
-    throw xrt_core::error((boost::format("Unknown output format: '%s'") % sFormat).str());
+    throw xrt_core::error((boost::format("Unknown output format: '%s'") % validated_format).str());
 
   // Output file
-  if (!sOutput.empty() && boost::filesystem::exists(sOutput) && !XBU::getForce()) 
-      throw xrt_core::error((boost::format("Output file already exists: '%s'") % sOutput).str());
+  if (!m_output.empty() && boost::filesystem::exists(m_output) && !XBU::getForce()) 
+      throw xrt_core::error((boost::format("Output file already exists: '%s'") % m_output).str());
 
   // Find device of interest
   std::shared_ptr<xrt_core::device> device;
   
   try {
-    if(reportsToProcess.size() > 1 || reportNames.front().compare("host") != 0)
-      device = XBU::get_device(boost::algorithm::to_lower_copy(device_str), false /*inUserDomain*/);
+    if(reportsToProcess.size() > 1 || reportsToRun.front().compare("host") != 0)
+      device = XBU::get_device(boost::algorithm::to_lower_copy(m_device), false /*inUserDomain*/);
   } catch (const std::runtime_error& e) {
     // Catch only the exceptions that we have generated earlier
     std::cerr << boost::format("ERROR: %s\n") % e.what();
@@ -180,22 +160,22 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
   // Create the report
   std::ostringstream oSchemaOutput;
   try {
-    XBU::produce_reports(device, reportsToProcess, schemaVersion, elementsFilter, std::cout, oSchemaOutput);
+    XBU::produce_reports(device, reportsToProcess, schemaVersion, m_elementsFilter, std::cout, oSchemaOutput);
   } catch (const std::exception&) {
     // Exception is thrown at the end of this function to allow for report writing
     is_report_output_valid = false;
   }
 
   // -- Write output file ----------------------------------------------
-  if (!sOutput.empty()) {
+  if (!m_output.empty()) {
     std::ofstream fOutput;
-    fOutput.open(sOutput, std::ios::out | std::ios::binary);
+    fOutput.open(m_output, std::ios::out | std::ios::binary);
     if (!fOutput.is_open()) 
-      throw xrt_core::error((boost::format("Unable to open the file '%s' for writing.") % sOutput).str());
+      throw xrt_core::error((boost::format("Unable to open the file '%s' for writing.") % m_output).str());
 
     fOutput << oSchemaOutput.str();
 
-    std::cout << boost::format("Successfully wrote the %s file: %s") % sFormat % sOutput << std::endl;
+    std::cout << boost::format("Successfully wrote the %s file: %s") % validated_format % m_output << std::endl;
   }
 
   if (!is_report_output_valid)

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdExamine.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdExamine.cpp
@@ -86,10 +86,6 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
 {
   XBU::verbose("SubCommand: examine");
 
-  // -- Build up the report & format options
-  const std::string reportOptionValues = XBU::create_suboption_list_string(fullReportCollection, true /*add 'all' option*/);
-  const std::string formatOptionValues = XBU::create_suboption_list_string(Report::getSchemaDescriptionVector());
-
   // Parse sub-command ...
   po::variables_map vm;
   process_arguments(vm, _options);

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdExamine.h
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdExamine.h
@@ -25,6 +25,14 @@ class SubCmdExamine : public SubCmd {
 
  public:
   SubCmdExamine(bool _isHidden, bool _isDepricated, bool _isPreliminary);
+
+ private:
+  std::string               m_device;
+  std::vector<std::string>  m_reportNames;
+  std::vector<std::string>  m_elementsFilter;
+  std::string               m_format;
+  std::string               m_output;
+  bool                      m_help;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -747,66 +747,24 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
     XBU::verbose(msg);
   }
 
-  // -- Retrieve and parse the subcommand options -----------------------------
-  std::string device_str;
-  std::string plp;
-  std::string update;
-  std::string xclbin;
-  std::string flashType;
-  std::string boot;
-  std::vector<std::string> image;
-  bool revertToGolden = false;
-  bool help = false;
-
-  po::options_description commonOptions("Common Options");
-  commonOptions.add_options()
-    ("device,d", boost::program_options::value<decltype(device_str)>(&device_str), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest.")
-    ("shell,s", boost::program_options::value<decltype(plp)>(&plp), "The partition to be loaded.  Valid values:\n"
-                                                                      "  Name (and path) of the partition.")
-    ("base,b", boost::program_options::value<decltype(update)>(&update)->implicit_value("all"), "Update the persistent images and/or the Satellite controller (SC) firmware image.  Valid values:\n"
-                                                                         "  ALL   - All images will be updated\n"
-                                                                         "  SHELL - Platform image\n"
-                                                                         "  SC    - Satellite controller (Warning: Damage could occur to the device)\n"
-                                                                         "  NO-BACKUP   - Backup boot remains unchanged")
-    ("user,u", boost::program_options::value<decltype(xclbin)>(&xclbin), "The xclbin to be loaded.  Valid values:\n"
-                                                                      "  Name (and path) of the xclbin.")
-    ("image", boost::program_options::value<decltype(image)>(&image)->multitoken(),  "Specifies an image to use used to update the persistent device.  Valid values:\n"
-                                                                    "  Name (and path) to the mcs image on disk\n"
-                                                                    "  Name (and path) to the xsabin image on disk")
-    ("revert-to-golden", boost::program_options::bool_switch(&revertToGolden), "Resets the FPGA PROM back to the factory image. Note: The Satellite Controller will not be reverted for a golden image does not exist.")
-    ("help", boost::program_options::bool_switch(&help), "Help to use this sub-command")
-  ;
-
-  po::options_description hiddenOptions("Hidden Options");
-  hiddenOptions.add_options()
-    ("flash-type", boost::program_options::value<decltype(flashType)>(&flashType),
-      "Overrides the flash mode. Use with caution.  Valid values:\n"
-      "  ospi\n"
-      "  ospi_versal")
-    ("boot", boost::program_options::value<decltype(boot)>(&boot)->implicit_value("default"),
-    "RPU and/or APU will be booted to either partition A or partition B.  Valid values:\n"
-    "  DEFAULT - Reboot RPU to partition A\n"
-    "  BACKUP  - Reboot RPU to partition B\n")
-  ;
-
   // Parse sub-command ...
   po::variables_map vm;
-  process_arguments(vm, _options, commonOptions, hiddenOptions);
+  process_arguments(vm, _options);
 
   // Check to see if help was requested or no command was found
-  if (help) {
-    printHelp(commonOptions, hiddenOptions);
+  if (m_help) {
+    printHelp();
     return;
   }
 
   // -- Now process the subcommand --------------------------------------------
-  XBU::verbose(boost::str(boost::format("  Base: %s") % update));
+  XBU::verbose(boost::str(boost::format("  Base: %s") % m_update));
 
   // -- process "device" option -----------------------------------------------
   // Find device of interest
   std::shared_ptr<xrt_core::device> device;
   try {
-    device = XBU::get_device(boost::algorithm::to_lower_copy(device_str), false /*inUserDomain*/);
+    device = XBU::get_device(boost::algorithm::to_lower_copy(m_device), false /*inUserDomain*/);
   } catch (const std::runtime_error& e) {
     // Catch only the exceptions that we have generated earlier
     std::cerr << boost::format("ERROR: %s\n") % e.what();
@@ -814,30 +772,30 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
   }
 
   // Only two images options are supported
-  if (image.size() > 2)
+  if (m_image.size() > 2)
     throw xrt_core::error("Multiple flash images provided. Please specify either 1 or 2 flash images.");
 
   // Populate flash type. Uses board's default when passing an empty input string.
-  if (!flashType.empty()) {
+  if (!m_flashType.empty()) {
       xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT",
         "Overriding flash mode is not recommended.\nYou may damage your device with this option.");
   }
   Flasher working_flasher(device->get_device_id());
-  auto flash_type = working_flasher.getFlashType(flashType);
+  auto flash_type = working_flasher.getFlashType(m_flashType);
 
-  if (!update.empty()) {
+  if (!m_update.empty()) {
     XBU::verbose("Sub command: --base");
     XBU::sudo_or_throw("Root privileges are required to update the devices flash image");
     // User did not provide an image for all. Select image automatically.
-    if (update.compare("all") == 0) {
+    if (m_update.compare("all") == 0) {
       update_default_only(device.get(), false);
-      if (image.empty()) {
+      if (m_image.empty()) {
         auto_flash(device, flash_type);
         return;
       }
     }
-    else if (update.compare("no-backup") == 0) {
-      if (image.empty()) {
+    else if (m_update.compare("no-backup") == 0) {
+      if (m_image.empty()) {
         update_default_only(device.get(), true);
         auto_flash(device, flash_type);
         return;
@@ -847,7 +805,7 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
     // All other cases have a specified image
     // Get a list of images known exist
 
-    const auto validated_images = find_flash_image_paths(image);
+    const auto validated_images = find_flash_image_paths(m_image);
     // Fail early here to reduce additional conditions below
     // Technically validated_images will never be empty as: if image is not empty but has a bad
     // path or bad shell name find_flash_image_paths exits early. This statement can be removed
@@ -868,23 +826,23 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
         break;
     }
 
-    if (update.compare("all") == 0) {
+    if (m_update.compare("all") == 0) {
         update_default_only(device.get(), false);
         auto_flash(device, flash_type, validated_image_map["primary"]);
     }
     // For the following two if conditions regarding the validated images portion
     // The user may have provided an image, but, it may not exist or the shell name is wrong
-    else if (update.compare("sc") == 0) {
+    else if (m_update.compare("sc") == 0) {
       update_SC(device.get()->get_device_id(), validated_image_map["primary"]);
     }
-    else if (update.compare("shell") == 0) {
+    else if (m_update.compare("shell") == 0) {
       update_default_only(device.get(), false);
       update_shell(device.get()->get_device_id(), validated_image_map, flash_type);
       std::cout << "****************************************************\n";
       std::cout << "Cold reboot machine to load the new image on device.\n";
       std::cout << "****************************************************\n";
     }
-    else if (update.compare("no-backup") == 0) {
+    else if (m_update.compare("no-backup") == 0) {
       update_default_only(device.get(), true);
       auto_flash(device, flash_type, validated_image_map["primary"]);
     }
@@ -896,7 +854,7 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
   }
 
   // -- process "revert-to-golden" option ---------------------------------------
-  if (revertToGolden) {
+  if (m_revertToGolden) {
     XBU::verbose("Sub command: --revert-to-golden");
     bool has_reset = false;
 
@@ -935,8 +893,8 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
   }
 
   // -- process "plp" option ---------------------------------------
-  if (!plp.empty()) {
-    XBU::verbose(boost::str(boost::format("  shell: %s") % plp));
+  if (!m_plp.empty()) {
+    XBU::verbose(boost::str(boost::format("  shell: %s") % m_plp));
 
     Flasher flasher(device->get_device_id());
     if (!flasher.isValid())
@@ -947,10 +905,10 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
                             " is installed.");
 
     // Check if file exists
-    if (!boost::filesystem::exists(plp))
+    if (!boost::filesystem::exists(m_plp))
       throw xrt_core::error("File not found. Please specify the correct path");
 
-    DSAInfo dsa(plp);
+    DSAInfo dsa(m_plp);
     //TO_DO: add a report for plp before asking permission to proceed. Replace following 2 lines
     std::cout << "Programming shell on device [" << flasher.sGetDBDF() << "]..." << std::endl;
     std::cout << "Partition file: " << dsa.file << std::endl;
@@ -970,13 +928,13 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
   }
 
   // -- process "user" option ---------------------------------------
-  if (!xclbin.empty()) {
-    XBU::verbose(boost::str(boost::format("  xclbin: %s") % xclbin));
+  if (!m_xclbin.empty()) {
+    XBU::verbose(boost::str(boost::format("  xclbin: %s") % m_xclbin));
     XBU::sudo_or_throw("Root privileges are required to download xclbin");
 
-    std::ifstream stream(xclbin, std::ios::binary);
+    std::ifstream stream(m_xclbin, std::ios::binary);
     if (!stream)
-      throw xrt_core::error(boost::str(boost::format("Could not open %s for reading") % xclbin));
+      throw xrt_core::error(boost::str(boost::format("Could not open %s for reading") % m_xclbin));
 
     stream.seekg(0,stream.end);
     ssize_t size = stream.tellg();
@@ -998,10 +956,10 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
   }
 
   // -- process "boot" option ------------------------------------------
-  if (!boot.empty()) {
-    if (boost::iequals(boot, "DEFAULT"))
+  if (!m_boot.empty()) {
+    if (boost::iequals(m_boot, "DEFAULT"))
       switch_partition(device.get(), 0);
-    else if (boost::iequals(boot, "BACKUP"))
+    else if (boost::iequals(m_boot, "BACKUP"))
       switch_partition(device.get(), 1);
     else {
       std::cout << "ERROR: Invalid value.\n"
@@ -1013,6 +971,6 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
   }
 
   std::cout << "\nERROR: Missing flash operation.  No action taken.\n\n";
-  printHelp(commonOptions, hiddenOptions);
+  printHelp();
   throw xrt_core::error(std::errc::operation_canceled);
 }

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -723,6 +723,16 @@ switch_partition(xrt_core::device* device, int boot)
 SubCmdProgram::SubCmdProgram(bool _isHidden, bool _isDepricated, bool _isPreliminary)
     : SubCmd("program",
              "Update image(s) for a given device")
+    , m_device("")
+    , m_plp("")
+    , m_update("")
+    , m_xclbin("")
+    , m_flashType("")
+    , m_boot("")
+    , m_image()
+    , m_revertToGolden(false)
+    , m_help(false)
+
 {
   const std::string longDescription = "Updates the image(s) for a given device.";
   setLongDescription(longDescription);
@@ -730,6 +740,35 @@ SubCmdProgram::SubCmdProgram(bool _isHidden, bool _isDepricated, bool _isPrelimi
   setIsHidden(_isHidden);
   setIsDeprecated(_isDepricated);
   setIsPreliminary(_isPreliminary);
+
+  m_commonOptions.add_options()
+    ("device,d", boost::program_options::value<decltype(m_device)>(&m_device), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest.")
+    ("shell,s", boost::program_options::value<decltype(m_plp)>(&m_plp), "The partition to be loaded.  Valid values:\n"
+                                                                      "  Name (and path) of the partition.")
+    ("base,b", boost::program_options::value<decltype(m_update)>(&m_update)->implicit_value("all"), "Update the persistent images and/or the Satellite controller (SC) firmware image.  Valid values:\n"
+                                                                         "  ALL   - All images will be updated\n"
+                                                                         "  SHELL - Platform image\n"
+                                                                         "  SC    - Satellite controller (Warning: Damage could occur to the device)\n"
+                                                                         "  NO-BACKUP   - Backup boot remains unchanged")
+    ("user,u", boost::program_options::value<decltype(m_xclbin)>(&m_xclbin), "The xclbin to be loaded.  Valid values:\n"
+                                                                      "  Name (and path) of the xclbin.")
+    ("image", boost::program_options::value<decltype(m_image)>(&m_image)->multitoken(),  "Specifies an image to use used to update the persistent device.  Valid values:\n"
+                                                                    "  Name (and path) to the mcs image on disk\n"
+                                                                    "  Name (and path) to the xsabin image on disk")
+    ("revert-to-golden", boost::program_options::bool_switch(&m_revertToGolden), "Resets the FPGA PROM back to the factory image. Note: The Satellite Controller will not be reverted for a golden image does not exist.")
+    ("help", boost::program_options::bool_switch(&m_help), "Help to use this sub-command")
+  ;
+
+  m_hiddenOptions.add_options()
+    ("flash-type", boost::program_options::value<decltype(m_flashType)>(&m_flashType),
+      "Overrides the flash mode. Use with caution.  Valid values:\n"
+      "  ospi\n"
+      "  ospi_versal")
+    ("boot", boost::program_options::value<decltype(m_boot)>(&m_boot)->implicit_value("default"),
+    "RPU and/or APU will be booted to either partition A or partition B.  Valid values:\n"
+    "  DEFAULT - Reboot RPU to partition A\n"
+    "  BACKUP  - Reboot RPU to partition B\n")
+  ;
 }
 
 void

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.h
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.h
@@ -25,6 +25,17 @@ class SubCmdProgram : public SubCmd {
 
  public:
   SubCmdProgram(bool _isHidden, bool _isDepricated, bool _isPreliminary);
+
+ private:
+  std::string               m_device;
+  std::string               m_plp;
+  std::string               m_update;
+  std::string               m_xclbin;
+  std::string               m_flashType;
+  std::string               m_boot;
+  std::vector<std::string>  m_image;
+  bool                      m_revertToGolden;
+  bool                      m_help;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdReset.h
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdReset.h
@@ -25,6 +25,11 @@ class SubCmdReset : public SubCmd {
 
  public:
   SubCmdReset(bool _isHidden, bool _isDepricated, bool _isPreliminary);
+
+ private:
+  std::string m_device;
+  std::string m_resetType;
+  bool        m_help;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdAdvanced.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdAdvanced.cpp
@@ -56,6 +56,18 @@ SubCmdAdvanced::SubCmdAdvanced(bool _isHidden, bool _isDepricated, bool _isPreli
   setIsHidden(_isHidden);
   setIsDeprecated(_isDepricated);
   setIsPreliminary(_isPreliminary);
+
+  m_commonOptions.add_options()
+    ("help", boost::program_options::bool_switch(&m_help), "Help to use this sub-command")
+  ;
+
+  addSubOption(std::make_shared<OO_MemRead>("read-mem"));
+  addSubOption(std::make_shared<OO_MemWrite>("write-mem"));
+// Only defined for embedded platform
+#ifndef ENABLE_NATIVE_SUBCMDS_AND_REPORTS
+  addSubOption(std::make_shared<OO_AieRegRead>("read-aie-reg"));
+  addSubOption(std::make_shared<OO_AieClockFreq>("aie-clock"));
+#endif
 }
 
 
@@ -64,69 +76,24 @@ SubCmdAdvanced::execute(const SubCmdOptions& _options) const
 {
   XBU::verbose("SubCommand: advanced");
 
-  // -- Common top level options ---
-  bool help = false;
-
-  po::options_description commonOptions("Common Options"); 
-  commonOptions.add_options()
-    ("help", boost::program_options::bool_switch(&help), "Help to use this sub-command")
-  ;
-
-  po::options_description hiddenOptions("Hidden Options"); 
-
-  // -- Define the supporting option options ----
-  SubOptionOptions subOptionOptions;
-  subOptionOptions.emplace_back(std::make_shared<OO_MemRead>("read-mem"));
-  subOptionOptions.emplace_back(std::make_shared<OO_MemWrite>("write-mem"));
-// Only defined for embedded platform
-#ifndef ENABLE_NATIVE_SUBCMDS_AND_REPORTS
-  subOptionOptions.emplace_back(std::make_shared<OO_AieRegRead>("read-aie-reg"));
-  subOptionOptions.emplace_back(std::make_shared<OO_AieClockFreq>("aie-clock"));
-#endif
-
-  for (auto & subOO : subOptionOptions) {
-    if (subOO->isHidden()) 
-      hiddenOptions.add_options()(subOO->longName().c_str(), subOO->description().c_str());
-    else
-      commonOptions.add_options()(subOO->longName().c_str(), subOO->description().c_str());
-    subOO->setExecutable(getExecutableName());
-    subOO->setCommand(getName());
-  }
-
-  po::options_description allOptions("All Options");
-  allOptions.add(commonOptions);
-  allOptions.add(hiddenOptions);
-
-  po::positional_options_description positionals;
-
   // =========== Process the options ========================================
 
   // 1) Process the common top level options 
   po::variables_map vm;
   // Used for the suboption arguments
-  auto topOptions = process_arguments(vm, _options, commonOptions, hiddenOptions, positionals, subOptionOptions, false);
-  // DRC check between suboptions
-  for (unsigned int index1 = 0; index1 < subOptionOptions.size(); ++index1)
-    for (unsigned int index2 = index1 + 1; index2 < subOptionOptions.size(); ++index2)
-      conflictingOptions(vm, subOptionOptions[index1]->longName(), subOptionOptions[index2]->longName());
+  auto topOptions = process_arguments(vm, _options, false);
 
-  // Find the subOption;
-  std::shared_ptr<OptionOptions> optionOption;
-  for (auto& subOO : subOptionOptions) {
-    if (vm.count(subOO->longName().c_str()) != 0) {
-      optionOption = subOO;
-      break;
-    }
-  }
+  // Check for a suboption
+  auto optionOption = checkForSubOption(vm);
 
   // No suboption print help
   if (!optionOption) {
-    printHelp(commonOptions, hiddenOptions, subOptionOptions);
+    printHelp();
     return;
   }
 
   // 2) Process the top level options
-  if (help)
+  if (m_help)
     topOptions.push_back("--help");
 
   optionOption->setGlobalOptions(getGlobalOptions());

--- a/src/runtime_src/core/tools/xbutil2/SubCmdAdvanced.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdAdvanced.h
@@ -26,6 +26,9 @@ class SubCmdAdvanced : public SubCmd {
  public:
   SubCmdAdvanced(bool _isHidden, bool _isDepricated, bool _isPreliminary);
   virtual ~SubCmdAdvanced() {};
+
+  private:
+    bool m_help;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdConfigure.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdConfigure.h
@@ -26,6 +26,9 @@ class SubCmdConfigure : public SubCmd {
  public:
   SubCmdConfigure(bool _isHidden, bool _isDepricated, bool _isPreliminary);
   virtual ~SubCmdConfigure() {};
+
+ private:
+  bool m_help;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
@@ -75,10 +75,18 @@ namespace po = boost::program_options;
   };
 
 // ----- C L A S S   M E T H O D S -------------------------------------------
+static const std::string reportOptionValues = XBU::create_suboption_list_string(fullReportCollection, true /*add 'all' option*/);
+static const std::string formatOptionValues = XBU::create_suboption_list_string(Report::getSchemaDescriptionVector());
 
 SubCmdExamine::SubCmdExamine(bool _isHidden, bool _isDepricated, bool _isPreliminary)
     : SubCmd("examine",
              "Status of the system and device")
+    , m_device("")
+    , m_reportNames()
+    , m_elementsFilter()
+    , m_format("")
+    , m_output("")
+    , m_help(false)
 {
   const std::string longDescription = "This command will 'examine' the state of the system/device and will"
                                       " generate a report of interest in a text or JSON format.";
@@ -88,6 +96,18 @@ SubCmdExamine::SubCmdExamine(bool _isHidden, bool _isDepricated, bool _isPrelimi
   setIsDeprecated(_isDepricated);
   setIsPreliminary(_isPreliminary);
   setIsDefaultDevValid(false);
+
+  m_commonOptions.add_options()
+    ("device,d", boost::program_options::value<decltype(m_device)>(&m_device), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest.\n")
+    ("report,r", boost::program_options::value<decltype(m_reportNames)>(&m_reportNames)->multitoken(), (std::string("The type of report to be produced. Reports currently available are:\n") + reportOptionValues).c_str() )
+    ("format,f", boost::program_options::value<decltype(m_format)>(&m_format), (std::string("Report output format. Valid values are:\n") + formatOptionValues).c_str() )
+    ("output,o", boost::program_options::value<decltype(m_output)>(&m_output), "Direct the output to the given file")
+    ("help", boost::program_options::bool_switch(&m_help), "Help to use this sub-command")
+  ;
+
+  m_hiddenOptions.add_options()
+    ("element,e", boost::program_options::value<decltype(m_elementsFilter)>(&m_elementsFilter)->multitoken(), "Filters individual elements(s) from the report. Format: '/<key>/<key>/...'")
+  ;
 }
 
 void
@@ -95,77 +115,50 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
 {
   XBU::verbose("SubCommand: examine");
 
-  // -- Build up the report & format options
-  const std::string reportOptionValues = XBU::create_suboption_list_string(fullReportCollection, true /*add 'all' option*/);
-  const std::string formatOptionValues = XBU::create_suboption_list_string(Report::getSchemaDescriptionVector());
-
-  // Option Variables
-  std::string sDevice;                 
-  std::vector<std::string> reportNames;    // Default set of report names are determined if there is a device or not
-  std::vector<std::string> elementsFilter;
-  std::string sFormat;                     // Don't define default output format.  Will be defined later.
-  std::string sOutput;
-  bool bHelp = false;
-
-  // -- Retrieve and parse the subcommand options -----------------------------
-  po::options_description commonOptions("Common Options");
-  commonOptions.add_options()
-    ("device,d", boost::program_options::value<decltype(sDevice)>(&sDevice), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest.\n")
-    ("report,r", boost::program_options::value<decltype(reportNames)>(&reportNames)->multitoken(), (std::string("The type of report to be produced. Reports currently available are:\n") + reportOptionValues).c_str() )
-    ("format,f", boost::program_options::value<decltype(sFormat)>(&sFormat), (std::string("Report output format. Valid values are:\n") + formatOptionValues).c_str() )
-    ("output,o", boost::program_options::value<decltype(sOutput)>(&sOutput), "Direct the output to the given file")
-    ("help", boost::program_options::bool_switch(&bHelp), "Help to use this sub-command")
-  ;
-
-  po::options_description hiddenOptions("Hidden Options");
-  hiddenOptions.add_options()
-    ("element,e", boost::program_options::value<decltype(elementsFilter)>(&elementsFilter)->multitoken(), "Filters individual elements(s) from the report. Format: '/<key>/<key>/...'")
-  ;
-
   // Parse sub-command ...
   po::variables_map vm;
-  process_arguments(vm, _options, commonOptions, hiddenOptions);
+  process_arguments(vm, _options);
 
   // Check to see if help was requested
-  if (bHelp) {
-    printHelp(commonOptions, hiddenOptions);
+  if (m_help) {
+    printHelp();
     return;
   }
 
   // -- Determine default values --
   
   // Report default value
-  if (reportNames.empty()) {
-    if (sDevice.empty())
-      reportNames.push_back("host");
+  std::vector<std::string> reportsToRun(m_reportNames);
+  if (m_reportNames.empty()) {
+    if (m_device.empty())
+      reportsToRun.push_back("host");
     else {
-      reportNames.push_back("platform");
-      reportNames.push_back("dynamic-regions");
+      reportsToRun.push_back("platform");
+      reportsToRun.push_back("dynamic-regions");
     }
   }
 
   // DRC check
   // When  is specified, make sure an accompanying output file is also specified
-  if (!sFormat.empty() && sOutput.empty()) {
+  if (!m_format.empty() && m_output.empty()) {
     std::cerr << "ERROR: Please specify an output file to redirect the json to" << std::endl;
     throw xrt_core::error(std::errc::operation_canceled);
   }
 
-  if (sFormat.empty())
-    sFormat = "json";
+  const auto validated_format = m_format.empty() ? "json" : m_format;
 
   // DRC: Examine the output format
-  Report::SchemaVersion schemaVersion = Report::getSchemaDescription(sFormat).schemaVersion;
+  Report::SchemaVersion schemaVersion = Report::getSchemaDescription(validated_format).schemaVersion;
   if (schemaVersion == Report::SchemaVersion::unknown) {
-    std::cerr << boost::format("ERROR: Unsupported --format option value '%s'") % sFormat << std::endl
+    std::cerr << boost::format("ERROR: Unsupported --format option value '%s'") % validated_format << std::endl
               << boost::format("       Supported values can be found in --format's help section below.") << std::endl;
-    printHelp(commonOptions, hiddenOptions);
+    printHelp();
     throw xrt_core::error(std::errc::operation_canceled);
   }
 
   // DRC: Output file
-  if (!sOutput.empty() && boost::filesystem::exists(sOutput) && !XBU::getForce()) {
-    std::cerr << boost::format("ERROR: The output file '%s' already exists.  Please either remove it or execute this command again with the '--force' option to overwrite it.") % sOutput << std::endl;
+  if (!m_output.empty() && boost::filesystem::exists(m_output) && !XBU::getForce()) {
+    std::cerr << boost::format("ERROR: The output file '%s' already exists.  Please either remove it or execute this command again with the '--force' option to overwrite it.") % m_output << std::endl;
     throw xrt_core::error(std::errc::operation_canceled);
   }
 
@@ -174,14 +167,14 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
 
   bool is_report_output_valid = true;
   // Collect the reports to be processed
-  XBU::collect_and_validate_reports(fullReportCollection, reportNames, reportsToProcess);
+  XBU::collect_and_validate_reports(fullReportCollection, reportsToRun, reportsToProcess);
 
   // Find device of interest
   std::shared_ptr<xrt_core::device> device;
   
   try {
-    if(reportsToProcess.size() > 1 || reportNames.front().compare("host") != 0)
-      device = XBU::get_device(boost::algorithm::to_lower_copy(sDevice), true /*inUserDomain*/);
+    if(reportsToProcess.size() > 1 || reportsToRun.front().compare("host") != 0)
+      device = XBU::get_device(boost::algorithm::to_lower_copy(m_device), true /*inUserDomain*/);
   } catch (const std::runtime_error& e) {
     // Catch only the exceptions that we have generated earlier
     std::cerr << boost::format("ERROR: %s\n") % e.what();
@@ -222,24 +215,24 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
   // Create the report
   std::ostringstream oSchemaOutput;
   try {
-    XBU::produce_reports(device, reportsToProcess, schemaVersion, elementsFilter, std::cout, oSchemaOutput);
+    XBU::produce_reports(device, reportsToProcess, schemaVersion, m_elementsFilter, std::cout, oSchemaOutput);
   } catch (const std::exception&) {
     // Exception is thrown at the end of this function to allow for report writing
     is_report_output_valid = false;
   }
 
   // -- Write output file ----------------------------------------------
-  if (!sOutput.empty()) {
+  if (!m_output.empty()) {
     std::ofstream fOutput;
-    fOutput.open(sOutput, std::ios::out | std::ios::binary);
+    fOutput.open(m_output, std::ios::out | std::ios::binary);
     if (!fOutput.is_open()) {
-      std::cerr << boost::format("Unable to open the file '%s' for writing.") % sOutput << std::endl;
+      std::cerr << boost::format("Unable to open the file '%s' for writing.") % m_output << std::endl;
       throw xrt_core::error(std::errc::operation_canceled);
     }
 
     fOutput << oSchemaOutput.str();
 
-    std::cout << boost::format("Successfully wrote the %s file: %s") % sFormat % sOutput << std::endl;
+    std::cout << boost::format("Successfully wrote the %s file: %s") % validated_format % m_output << std::endl;
   }
 
   if (!is_report_output_valid)

--- a/src/runtime_src/core/tools/xbutil2/SubCmdExamine.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdExamine.h
@@ -25,6 +25,14 @@ class SubCmdExamine : public SubCmd {
 
  public:
   SubCmdExamine(bool _isHidden, bool _isDepricated, bool _isPreliminary);
+
+ private:
+  std::string               m_device;
+  std::vector<std::string>  m_reportNames; // Default set of report names are determined if there is a device or not
+  std::vector<std::string>  m_elementsFilter;
+  std::string               m_format; // Don't define default output format.  Will be defined later.
+  std::string               m_output;
+  bool                      m_help;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdProgram.cpp
@@ -78,9 +78,9 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
   }
 
   // -- process "program" option -----------------------------------------------
-  if (!xclbin.empty()) {
+  if (!m_xclbin.empty()) {
     auto bdf = xrt_core::query::pcie_bdf::to_string(xrt_core::device_query<xrt_core::query::pcie_bdf>(device));
-    auto xclbin_obj = xrt::xclbin{xclbin};
+    auto xclbin_obj = xrt::xclbin{m_xclbin};
     try {
       device->load_xclbin(xclbin_obj);
     }

--- a/src/runtime_src/core/tools/xbutil2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdProgram.cpp
@@ -30,6 +30,9 @@ namespace po = boost::program_options;
 SubCmdProgram::SubCmdProgram(bool _isHidden, bool _isDepricated, bool _isPreliminary)
     : SubCmd("program", 
              "Download the acceleration program to a given device")
+    , m_device("")
+    , m_xclbin("")
+    , m_help(false)
 {
   const std::string longDescription = "Programs the given acceleration image into the device's shell.";
   setLongDescription(longDescription);
@@ -37,44 +40,37 @@ SubCmdProgram::SubCmdProgram(bool _isHidden, bool _isDepricated, bool _isPrelimi
   setIsHidden(_isHidden);
   setIsDeprecated(_isDepricated);
   setIsPreliminary(_isPreliminary);
+
+  m_commonOptions.add_options()
+    ("device,d", boost::program_options::value<decltype(m_device)>(&m_device), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest.")
+    ("user,u", boost::program_options::value<std::string>(&m_xclbin), "The name (and path) of the xclbin to be loaded")
+    ("help", boost::program_options::bool_switch(&m_help), "Help to use this sub-command")
+  ;
 }
 
 void
 SubCmdProgram::execute(const SubCmdOptions& _options) const
 {
   XBU::verbose("SubCommand: program");
-  // -- Retrieve and parse the subcommand options -----------------------------
-  std::string device_str;
-  std::string xclbin;
-  bool help = false;
-
-  po::options_description commonOptions("Common Options");
-  commonOptions.add_options()
-    ("device,d", boost::program_options::value<decltype(device_str)>(&device_str), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest.")
-    ("user,u", boost::program_options::value<std::string>(&xclbin), "The name (and path) of the xclbin to be loaded")
-    ("help", boost::program_options::bool_switch(&help), "Help to use this sub-command")
-  ;
-
-  po::options_description hiddenOptions("Hidden Options");
 
   // Parse sub-command ...
   po::variables_map vm;
-  process_arguments(vm, _options, commonOptions, hiddenOptions);
+  process_arguments(vm, _options);
 
   // Check to see if help was requested or no command was found
-  if (help) {
-    printHelp(commonOptions, hiddenOptions);
+  if (m_help) {
+    printHelp();
     return;
   }
 
   // -- Now process the subcommand --------------------------------------------
-  XBU::verbose(boost::str(boost::format("  XclBin: %s") % xclbin));
+  XBU::verbose(boost::str(boost::format("  XclBin: %s") % m_xclbin));
 
   // -- process "device" option -----------------------------------------------
   // Find device of interest
   std::shared_ptr<xrt_core::device> device;
   try {
-    device = XBU::get_device(boost::algorithm::to_lower_copy(device_str), true /*inUserDomain*/);
+    device = XBU::get_device(boost::algorithm::to_lower_copy(m_device), true /*inUserDomain*/);
   } catch (const std::runtime_error& e) {
     // Catch only the exceptions that we have generated earlier
     std::cerr << boost::format("ERROR: %s\n") % e.what();
@@ -97,6 +93,6 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
   }
 
   std::cout << "\nERROR: Missing program operation. No action taken.\n\n";
-  printHelp(commonOptions, hiddenOptions);
+  printHelp();
   throw xrt_core::error(std::errc::operation_canceled);
 }

--- a/src/runtime_src/core/tools/xbutil2/SubCmdProgram.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdProgram.h
@@ -25,6 +25,11 @@ class SubCmdProgram : public SubCmd {
 
  public:
   SubCmdProgram(bool _isHidden, bool _isDepricated, bool _isPreliminary);
+
+ private:
+  std::string m_device;
+  std::string m_xclbin;
+  bool        m_help;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdReset.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdReset.cpp
@@ -52,19 +52,7 @@ reset_device(xrt_core::device* dev, xrt_core::query::reset_type reset)
     % xrt_core::query::pcie_bdf::to_string(xrt_core::device_query<xrt_core::query::pcie_bdf>(dev));
 }
 
-SubCmdReset::SubCmdReset(bool _isHidden, bool _isDepricated, bool _isPreliminary)
-    : SubCmd("reset", 
-             "Resets the given device")
-{
-  const std::string longDescription = "Resets the given device.";
-  setLongDescription(longDescription);
-  setExampleSyntax("");
-  setIsHidden(_isHidden);
-  setIsDeprecated(_isDepricated);
-  setIsPreliminary(_isPreliminary);
-}
-
-void
+static void
 supported(std::string resetType) {
   std::vector<std::string> vec { "user" };
   std::vector<std::string>::iterator it;
@@ -74,19 +62,23 @@ supported(std::string resetType) {
   }
 }
 
-void
-SubCmdReset::execute(const SubCmdOptions& _options) const
+SubCmdReset::SubCmdReset(bool _isHidden, bool _isDepricated, bool _isPreliminary)
+    : SubCmd("reset", 
+             "Resets the given device")
+    , m_device("")
+    , m_resetType("user")
+    , m_help(false)
 {
-  XBU::verbose("SubCommand: reset");
-  // -- Retrieve and parse the subcommand options -----------------------------
-  std::string device_str;
-  std::string resetType = "user";
-  bool help = false;
+  const std::string longDescription = "Resets the given device.";
+  setLongDescription(longDescription);
+  setExampleSyntax("");
+  setIsHidden(_isHidden);
+  setIsDeprecated(_isDepricated);
+  setIsPreliminary(_isPreliminary);
 
-  po::options_description commonOptions("Common Options");
-  commonOptions.add_options()
-    ("device,d", boost::program_options::value<decltype(device_str)>(&device_str), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest.")
-    ("type,t", boost::program_options::value<decltype(resetType)>(&resetType)->notifier(supported), "The type of reset to perform. Types resets available:\n"
+  m_commonOptions.add_options()
+    ("device,d", boost::program_options::value<decltype(m_device)>(&m_device), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest.")
+    ("type,t", boost::program_options::value<decltype(m_resetType)>(&m_resetType)->notifier(supported)->implicit_value("user"), "The type of reset to perform. Types resets available:\n"
                                                                        "  user         - Hot reset (default)\n"
                                                                        /*"  aie          - Reset Aie array\n"*/
                                                                        /*"  kernel       - Kernel communication links\n"*/
@@ -94,18 +86,22 @@ SubCmdReset::execute(const SubCmdOptions& _options) const
                                                                        /*"  clear-fabric - Clears the accleration fabric with the\n"*/
                                                                        /*"                 shells verify.xclbin image.\n"*/
                                                                        /*"  memory       - Clears the memory block."*/)
-    ("help", boost::program_options::bool_switch(&help), "Help to use this sub-command")
+    ("help", boost::program_options::bool_switch(&m_help), "Help to use this sub-command")
   ;
+}
 
-  po::options_description hiddenOptions("Hidden Options");
+void
+SubCmdReset::execute(const SubCmdOptions& _options) const
+{
+  XBU::verbose("SubCommand: reset");
 
   // Parse sub-command ...
   po::variables_map vm;
-  process_arguments(vm, _options, commonOptions, hiddenOptions);
+  process_arguments(vm, _options);
 
   // Check to see if help was requested or no command was found
-  if (help) {
-    printHelp(commonOptions, hiddenOptions);
+  if (m_help) {
+    printHelp();
     return;
   }
 
@@ -113,14 +109,14 @@ SubCmdReset::execute(const SubCmdOptions& _options) const
   // Find device of interest
   std::shared_ptr<xrt_core::device> device;
   try {
-    device = XBU::get_device(boost::algorithm::to_lower_copy(device_str), true /*inUserDomain*/);
+    device = XBU::get_device(boost::algorithm::to_lower_copy(m_device), true /*inUserDomain*/);
   } catch (const std::runtime_error& e) {
     // Catch only the exceptions that we have generated earlier
     std::cerr << boost::format("ERROR: %s\n") % e.what();
     throw xrt_core::error(std::errc::operation_canceled);
   }
 
-  xrt_core::query::reset_type type = XBU::str_to_reset_obj(resetType);
+  xrt_core::query::reset_type type = XBU::str_to_reset_obj(m_resetType);
   pretty_print_action_list(device.get(), type);
 
   // Ask user for permission

--- a/src/runtime_src/core/tools/xbutil2/SubCmdReset.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdReset.h
@@ -25,6 +25,11 @@ class SubCmdReset : public SubCmd {
 
  public:
   SubCmdReset(bool _isHidden, bool _isDepricated, bool _isPreliminary);
+
+ private:
+  std::string m_device;
+  std::string m_resetType;
+  bool        m_help;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.h
@@ -25,6 +25,15 @@ class SubCmdValidate : public SubCmd {
 
  public:
   SubCmdValidate(bool _isHidden, bool _isDepricated, bool _isPreliminary);
+
+ private:
+  std::string               m_device;
+  std::vector<std::string>  m_tests_to_run;
+  std::string               m_format;
+  std::string               m_output;
+  std::string               m_param;
+  std::string               m_xclbin_location;
+  bool                      m_help;
 };
 
 #endif


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Part one of three regarding the previous PR that was too big. https://github.com/Xilinx/XRT/pull/7085
This PR focuses on changing SubCommands to store their state variables similar to how OptionOption classes do. This allows us to refactor a good deal of code out into the SubCommand base class. Part two will contain the actual fix for the story. Part three will be a formatting fix.

https://jira.xilinx.com/browse/VITIS-6253
Certain subcommands contain options that are mutually exclusive, xbmgmt program as a prime example. To fix this issue those subcommands should be broken into separate options.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
This is part one of three to set the path on how to fix the issue which is help menus did not specify which options are mutually exclusive from one another.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Refactored how SubCommands and OptionOptions classes generate their help menu and store their options.

#### Risks (if any) associated the changes in the commit
This is a major change to how the SubCommands create their options. Everything will be exactly the same as before when using the tools and examining the help menu.

#### What has been tested and how, request additional testing if necessary
Tested each subcommand to make sure the help menu looks the same as before and functions as expected.

#### Documentation impact (if any)
None.