### PR TITLE
[2021.1] Clean up outstanding SK commands when PS is crashed suddenly

### DIFF
--- a/src/runtime_src/core/common/drv/include/kds_command.h
+++ b/src/runtime_src/core/common/drv/include/kds_command.h
@@ -2,7 +2,7 @@
 /*
  * Xilinx Kernel Driver Scheduler
  *
- * Copyright (C) 2020 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2020, 2023 Xilinx, Inc. All rights reserved.
  *
  * Authors: min.ma@xilinx.com
  *
@@ -101,6 +101,9 @@ struct kds_command {
 	void			*gem_obj;
 	/* to notify inkernel exec completion */
 	struct in_kernel_cb	*inkern_cb;
+
+	/* Use this flag to stop printing message when abort */
+	u32			abort_printed;
 };
 
 void set_xcmd_timestamp(struct kds_command *xcmd, enum kds_status s);

--- a/src/runtime_src/core/common/drv/include/kds_stat.h
+++ b/src/runtime_src/core/common/drv/include/kds_stat.h
@@ -2,7 +2,7 @@
 /*
  * Xilinx Kernel Driver Scheduler
  *
- * Copyright (C) 2021 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2021, 2023 Xilinx, Inc. All rights reserved.
  *
  * Authors: min.ma@xilinx.com
  *
@@ -26,6 +26,11 @@ struct client_stats {
 	unsigned long		s_cnt[MAX_CUS];
 	/* Per CU counter that counts when a command is completed or error */
 	unsigned long		c_cnt[MAX_CUS];
+
+	/* For counting START_SK and control commands to ERT */
+	u32 __percpu		s_ert_cnt;
+	u32 __percpu		c_ert_cnt;
+
 };
 
 struct cu_stats {

--- a/src/runtime_src/core/common/drv/include/kds_stat.h
+++ b/src/runtime_src/core/common/drv/include/kds_stat.h
@@ -28,9 +28,8 @@ struct client_stats {
 	unsigned long		c_cnt[MAX_CUS];
 
 	/* For counting START_SK and control commands to ERT */
-	u32 __percpu		s_ert_cnt;
-	u32 __percpu		c_ert_cnt;
-
+	unsigned long		s_ert_cnt;
+	unsigned long		c_ert_cnt;
 };
 
 struct cu_stats {

--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -494,8 +494,8 @@ kds_del_ert_context(struct kds_sched *kds, struct kds_client *client)
 
 	/* sub-device that handle command should do abort with a timeout */
 	do {
-		kds_warn(client, "%ld outstanding command(s) on CU(%d)",
-			 submitted - completed, cu_idx);
+		kds_warn(client, "client(%d) %ld outstanding command(s) on CU(%d)",
+			 pid_nr(client->pid), submitted - completed, cu_idx);
 		msleep(500);
 			submitted = client_stat_read(client, s_ert_cnt);
 			completed = client_stat_read(client, c_ert_cnt);

--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -2,7 +2,7 @@
 /*
  * Xilinx Kernel Driver Scheduler
  *
- * Copyright (C) 2020 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2020, 2023 Xilinx, Inc. All rights reserved.
  *
  * Authors: min.ma@xilinx.com
  *
@@ -343,9 +343,12 @@ kds_submit_ert(struct kds_sched *kds, struct kds_command *xcmd)
 			xcmd->cb.free(xcmd);
 			return 0;
 		}
+		client_stat_inc(xcmd->client, s_ert_cnt);
+		break;
+	case OP_START_SK:
+		client_stat_inc(xcmd->client, s_ert_cnt);
 		break;
 	case OP_CONFIG:
-	case OP_START_SK:
 	case OP_CLK_CALIB:
 	case OP_VALIDATE:
 		break;
@@ -472,6 +475,40 @@ skip:
 	mutex_unlock(&cu_mgmt->lock);
 
 	return 0;
+}
+
+static void
+kds_del_ert_context(struct kds_sched *kds, struct kds_client *client)
+{
+	int cu_idx = NO_INDEX;
+	unsigned long submitted;
+	unsigned long completed;
+	bool bad_state = false;
+
+	submitted = client_stat_read(client, s_ert_cnt);
+	completed = client_stat_read(client, c_ert_cnt);
+	if (submitted == completed)
+		return;
+
+	kds->ert->abort(kds->ert, client, cu_idx);
+
+	/* sub-device that handle command should do abort with a timeout */
+	do {
+		kds_warn(client, "%ld outstanding command(s) on CU(%d)",
+			 submitted - completed, cu_idx);
+		msleep(500);
+			submitted = client_stat_read(client, s_ert_cnt);
+			completed = client_stat_read(client, c_ert_cnt);
+	} while (submitted != completed);
+
+	bad_state = kds->ert->abort_done(kds->ert, client, cu_idx);
+
+	if (bad_state) {
+		kds->bad_state = 1;
+		kds_info(client, "CU(%d) hangs, please reset device", cu_idx);
+	}
+
+	return;
 }
 
 int kds_init_sched(struct kds_sched *kds)
@@ -620,6 +657,11 @@ _kds_fini_client(struct kds_sched *kds, struct kds_client *client)
 	while (client->virt_cu_ref) {
 		info.cu_idx = CU_CTX_VIRT_CU;
 		kds_del_context(kds, client, &info);
+	}
+
+	if (client_stat_read(client, s_ert_cnt) !=
+	    client_stat_read(client, c_ert_cnt)) {
+		kds_del_ert_context(kds, client);
 	}
 
 	bit = find_first_bit(client->cu_bitmap, MAX_CUS);

--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -494,8 +494,8 @@ kds_del_ert_context(struct kds_sched *kds, struct kds_client *client)
 
 	/* sub-device that handle command should do abort with a timeout */
 	do {
-		kds_warn(client, "client(%d) %ld outstanding command(s) on CU(%d)",
-			 pid_nr(client->pid), submitted - completed, cu_idx);
+		kds_warn(client, "client(%d) %p %ld outstanding command(s) on CU(%d)",
+			 pid_nr(client->pid), client, submitted - completed, cu_idx);
 		msleep(500);
 			submitted = client_stat_read(client, s_ert_cnt);
 			completed = client_stat_read(client, c_ert_cnt);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_user.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_user.c
@@ -1309,6 +1309,7 @@ static void ert_user_submit(struct kds_ert *ert, struct kds_command *xcmd)
 	struct ert_user_command *ecmd = ert_user_alloc_cmd(xcmd);
 
 	if (!ecmd) {
+		ERTUSER_WARN(ert_user, "%s allocate ert user command failed\n", __func__);
 		xcmd->cb.notify_host(xcmd, KDS_ERROR);
 		xcmd->cb.free(xcmd);
 		return;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_user.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_user.c
@@ -1,7 +1,7 @@
 /*
  * A GEM style device manager for PCIe based OpenCL accelerators.
  *
- * Copyright (C) 2020 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2020, 2023 Xilinx, Inc. All rights reserved.
  *
  * Authors: Chien-Wei Lan <chienwei@xilinx.com>
  *
@@ -1308,8 +1308,11 @@ static void ert_user_submit(struct kds_ert *ert, struct kds_command *xcmd)
 	struct xocl_ert_user *ert_user = container_of(ert, struct xocl_ert_user, ert);
 	struct ert_user_command *ecmd = ert_user_alloc_cmd(xcmd);
 
-	if (!ecmd)
+	if (!ecmd) {
+		xcmd->cb.notify_host(xcmd, KDS_ERROR);
+		xcmd->cb.free(xcmd);
 		return;
+	}
 
 	ERTUSER_DBG(ert_user, "->%s ecmd %llx\n", __func__, (u64)ecmd);
 	spin_lock_irqsave(&ert_user->pq_lock, flags);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -2,7 +2,7 @@
 /*
  * Xilinx Alveo User Function Driver
  *
- * Copyright (C) 2020 Xilinx, Inc.
+ * Copyright (C) 2020, 2023 Xilinx, Inc.
  *
  * Authors: min.ma@xilinx.com
  */
@@ -393,9 +393,13 @@ static void notify_execbuf(struct kds_command *xcmd, int status)
 			/* It is old shell, return code is missing */
 			scmd->return_code = -ENODATA;
 		status = scmd->state;
+		client_stat_inc(client, c_ert_cnt);
 	} else {
-		if (xcmd->opcode == OP_GET_STAT)
+		if (xcmd->opcode == OP_GET_STAT) {
 			read_ert_stat(xcmd);
+			if (xcmd->type == KDS_ERT)
+				client_stat_inc(client, c_ert_cnt);
+		}
 
 		if (status == KDS_COMPLETED)
 			ecmd->state = ERT_CMD_STATE_COMPLETED;


### PR DESCRIPTION
On U30 kind of platform, when PS suddenly crashed, host will be failed to drain outstanding softkernel command and get CU stat command. So, that the ert_user_thread() kthread will be a busy loop. Host system will be in a unstable status until cold reboot.

With this change, the ert_user_thread() will drain those commands and user can kill their application and be able to run xbutil reset.

This is not needed in master branch. Master branch has XGQ and Softkernel CU context. All of those commands are well handled.