### PR TITLE
Cr 1145449 tolerance freq scaling

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
@@ -1563,19 +1563,20 @@ cid_alloc_failed:
 
 static int set_and_verify_freqs(struct platform_device *pdev,unsigned short *target_freqs, int num_freqs, int verify)
 {
-    int ret = 0,i;
-    u32 clock_freq_counter, request_in_khz, tolerance, lookup_freq;
-    struct xocl_xgq_vmr *xgq = platform_get_drvdata(pdev);
+	int ret = 0,i;
+	u32 clock_freq_counter, request_in_khz, tolerance, lookup_freq;
+	struct xocl_xgq_vmr *xgq = platform_get_drvdata(pdev);
 	enum data_kind kinds[3] = {FREQ_COUNTER_0,FREQ_COUNTER_1,FREQ_COUNTER_2};
 
-    ret = xgq_freq_scaling(pdev, target_freqs, num_freqs,
-		verify);
-    if (ret) {
+	ret = xgq_freq_scaling(pdev, target_freqs, num_freqs,verify);
+	if (ret)
+	{
 		XGQ_ERR(xgq, "ret %d", ret);
-        return ret;
+		return ret;
 	}
 
-    for (i = 0; i < min(XGQ_CLOCK_WIZ_MAX_RES, num_freqs); ++i) {
+	for (i = 0; i < min(XGQ_CLOCK_WIZ_MAX_RES, num_freqs); ++i) 
+	{
 		if (!target_freqs[i])
 			continue;
 
@@ -1584,7 +1585,8 @@ static int set_and_verify_freqs(struct platform_device *pdev,unsigned short *tar
 		lookup_freq = target_freqs[i];
 		request_in_khz = lookup_freq*1000;
 		tolerance = lookup_freq*50;
-		if (tolerance < abs(clock_freq_counter-request_in_khz)) {
+		if (tolerance < abs(clock_freq_counter-request_in_khz)) 
+		{
 			XGQ_ERR(xgq, "Frequency is higher than tolerance value, request %u"
 					"khz, actual %u khz", request_in_khz, clock_freq_counter);
 			ret = -EDOM;
@@ -1604,7 +1606,7 @@ static int xgq_freq_scaling_by_topo(struct platform_device *pdev,
 	int system_clk_count = 0;
 	int clock_type_count = 0;
 	unsigned short target_freqs[4] = {0};
-	int i = 0,ret = 0;
+	int i = 0, ret = 0;
 
 	if (!topo)
 		return -EINVAL;
@@ -1664,14 +1666,13 @@ static int xgq_freq_scaling_by_topo(struct platform_device *pdev,
 	    ARRAY_SIZE(target_freqs), target_freqs[0], target_freqs[1],
 	    target_freqs[2], target_freqs[3]);
 
-    ret = set_and_verify_freqs(pdev, target_freqs, ARRAY_SIZE(target_freqs),
-		verify);
-    if (ret) {
+	ret = set_and_verify_freqs(pdev, target_freqs, ARRAY_SIZE(target_freqs),verify);
+	if (ret) {
 		XGQ_ERR(xgq, "ret %d", ret);
-        goto done;
+		goto done;
 	}
 done:
-    return ret;
+	return ret;
 }
 
 static uint32_t xgq_clock_get_data(struct xocl_xgq_vmr *xgq,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
@@ -1485,10 +1485,11 @@ static int vmr_memory_info_query(struct platform_device *pdev,
 
 static int xgq_freq_verify(struct platform_device *pdev,unsigned short *target_freqs, int num_freqs)
 {
-	int ret = 0,i;
+	int ret = 0, i = 0;
 	u32 clock_freq_counter, request_in_khz, tolerance, lookup_freq;
 	struct xocl_xgq_vmr *xgq = platform_get_drvdata(pdev);
-	enum data_kind kinds[3] = {FREQ_COUNTER_0,FREQ_COUNTER_1,FREQ_COUNTER_2};
+	//TO DO:- Need to enhance the following Hard Coded Part by creating new Interface using Call Backs.
+	enum data_kind kinds[3] = {FREQ_COUNTER_0, FREQ_COUNTER_1, FREQ_COUNTER_2};
 
 	for (i = 0; i < min(XGQ_CLOCK_WIZ_MAX_RES, num_freqs); ++i)
 	{
@@ -1500,6 +1501,7 @@ static int xgq_freq_verify(struct platform_device *pdev,unsigned short *target_f
 		lookup_freq = target_freqs[i];
 		request_in_khz = lookup_freq*1000;
 		tolerance = lookup_freq*50;
+		XGQ_WARN(xgq,"Idx = %d, tolerance = %ul, request_in_khz = %ul",i, tolerance, request_in_khz);
 		if (tolerance < abs(clock_freq_counter-request_in_khz))
 		{
 			XGQ_ERR(xgq, "Frequency is higher than tolerance value, request %u"
@@ -1508,7 +1510,7 @@ static int xgq_freq_verify(struct platform_device *pdev,unsigned short *target_f
 			break;
 		}
 	}
-    return ret;
+	return ret;
 }
 
 /* On versal, verify is enforced. */
@@ -1595,12 +1597,11 @@ static int xgq_freq_scaling(struct platform_device *pdev,
 	int ret = 0;
 	struct xocl_xgq_vmr *xgq = platform_get_drvdata(pdev);
 	ret = xgq_freq_scaling_impl(pdev, freqs, num_freqs);
-	if (ret)
-	{
+	if (ret) {
 		XGQ_ERR(xgq, "ret %d", ret);
 		return ret;
 	}
-	if(verify){
+	if (verify) {
 		ret = xgq_freq_verify(pdev, freqs, num_freqs);
 	}
 	return ret;
@@ -1616,7 +1617,7 @@ static int xgq_freq_scaling_by_topo(struct platform_device *pdev,
 	int system_clk_count = 0;
 	int clock_type_count = 0;
 	unsigned short target_freqs[4] = {0};
-	int i = 0, ret = 0;
+	int i = 0;
 
 	if (!topo)
 		return -EINVAL;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
@@ -1584,7 +1584,7 @@ static int set_and_verify_freqs(struct platform_device *pdev,unsigned short *tar
 		lookup_freq = target_freqs[i];
 		request_in_khz = lookup_freq*1000;
 		tolerance = lookup_freq*50;
-		//XGQ_WARN(xgq,"i = %d, lookup_freq = %lu,request_in_khz = %lu, tolerance = %lu",i,lookup_freq,request_in_khz, tolerance);
+		XGQ_WARN(xgq,"i = %d, lookup_freq = %lu,clock_freq_counter = %lu, tolerance = %lu",i,lookup_freq,clock_freq_counter, tolerance);
 		if (tolerance < abs(clock_freq_counter-request_in_khz)) {
 			XGQ_ERR(xgq, "Frequency is higher than tolerance value, request %u"
 					"khz, actual %u khz", request_in_khz, clock_freq_counter);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
@@ -1501,7 +1501,6 @@ static int xgq_freq_verify(struct platform_device *pdev,unsigned short *target_f
 		lookup_freq = target_freqs[i];
 		request_in_khz = lookup_freq*1000;
 		tolerance = lookup_freq*50;
-		XGQ_WARN(xgq,"Idx = %d, tolerance = %ul, request_in_khz = %ul",i, tolerance, request_in_khz);
 		if (tolerance < abs(clock_freq_counter-request_in_khz))
 		{
 			XGQ_ERR(xgq, "Frequency is higher than tolerance value, request %u"

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
@@ -1584,7 +1584,6 @@ static int set_and_verify_freqs(struct platform_device *pdev,unsigned short *tar
 		lookup_freq = target_freqs[i];
 		request_in_khz = lookup_freq*1000;
 		tolerance = lookup_freq*50;
-		XGQ_WARN(xgq,"i = %d, lookup_freq = %lu,clock_freq_counter = %lu, tolerance = %lu",i,lookup_freq,clock_freq_counter, tolerance);
 		if (tolerance < abs(clock_freq_counter-request_in_khz)) {
 			XGQ_ERR(xgq, "Frequency is higher than tolerance value, request %u"
 					"khz, actual %u khz", request_in_khz, clock_freq_counter);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_xclbin.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_xclbin.c
@@ -153,7 +153,7 @@ static int xgq_xclbin_post_download(xdev_handle_t xdev, void *args)
 		/* after download, update clock freq */
 		topo = (struct clock_freq_topology *)
 		    (((char *)(arg->xclbin)) + hdr->m_sectionOffset);
-		ret = xocl_xgq_freq_scaling_by_topo(xdev, topo, 0);
+		ret = xocl_xgq_freq_scaling_by_topo(xdev, topo, 1);
 	}
 
 	return ret;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Added Tolerance check against frequency counter to report error at dmesg
Change added in xgq driver

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
none

#### How problem was solved, alternative solutions (if any) and why they were rejected
Tolerance is read from VMR and compared with frequency counter for given target frequencies.
There is a COntrol Variable behavioral change to enable Verify functionality and is tested on both VCK5000 and V70.

#### Risks (if any) associated the changes in the commit
There is a false failure reported in dmesg which can be ignored.

#### What has been tested and how, request additional testing if necessary
Tested on VCK5000 and V70

#### Documentation impact (if any)
