### PR TITLE
Fixing profiling issue with freeze

### DIFF
--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -1555,9 +1555,10 @@ int
 shim::
 xclLoadXclBin(const xclBin *buffer)
 {
-  xdp::hal::flush_device(this);
-  xdp::aie::flush_device(this);
-  xdp::pl_deadlock::flush_device(this);
+  // Retrieve any profiling information still on this device from any previous
+  // configuration before the device is reconfigured with the new xclbin (when
+  // profiling is enabled).
+  xdp::flush_device(this);
 
   auto top = reinterpret_cast<const axlf*>(buffer);
   if (auto ret = xclLoadAxlf(top)) {
@@ -1598,10 +1599,13 @@ xclLoadXclBin(const xclBin *buffer)
   // Success
   mCoreDevice->register_axlf(buffer);
 
-  xdp::hal::update_device(this);
-  xdp::aie::update_device(this);
-  xdp::pl_deadlock::update_device(this);
+  // Update the profiling library with the information on this new xclbin
+  // configuration on this device as appropriate (when profiling is enabled).
+  xdp::update_device(this);
 
+  // Setup the user-accessible HAL API profiling interface so user host
+  // code can call functions to directly read counter values on profiling IP
+  // (if enabled in the xrt.ini).
   START_DEVICE_PROFILING_CB(this);
 
   return 0;
@@ -2436,10 +2440,6 @@ create_hw_context(const xrt::uuid& xclbin_uuid,
     return std::make_unique<xrt_shim::hwcontext>(this, 0, xclbin_uuid, mode);
   }
   else {
-    xdp::hal::flush_device(this);
-    xdp::aie::flush_device(this);
-    xdp::pl_deadlock::flush_device(this);
-
     auto xclbin = mCoreDevice->get_xclbin(xclbin_uuid);
     auto buffer = reinterpret_cast<const axlf*>(xclbin.get_axlf());
     auto top = reinterpret_cast<const axlf*>(buffer);
@@ -2485,12 +2485,6 @@ create_hw_context(const xrt::uuid& xclbin_uuid,
 
     // Success
     mCoreDevice->register_axlf(buffer);
-
-    xdp::hal::update_device(this);
-    xdp::aie::update_device(this);
-    xdp::pl_deadlock::update_device(this);
-
-    START_DEVICE_PROFILING_CB(this);
 
     return std::make_unique<xrt_shim::hwcontext>(this, hw_ctx.hw_context, xclbin_uuid, mode);
   }


### PR DESCRIPTION
#### Problem solved by the commit
Reimplements the refactoring on calling the profiling hooks in the linux shim and removes the hooks in the create_hw_context, which prevents certain test cases from hitting the profiling hooks twice recursively and causing a freeze.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Bug was introduced in Pull Request 7209, and was discovered through internal testing.

#### How problem was solved, alternative solutions (if any) and why they were rejected
The problem was solved by removing the extra profiling hooks and relying on the hooks in xclLoadXclbin.  Other solutions will require a greater understanding of expected usage of create_hw_context on multiple platforms to see if and how profiling hooks can be added there for future designs.

#### Risks (if any) associated the changes in the commit
Low risk to current designs, some risk that future designs that do not call loadXclbin will not have device level profiling enabled.

#### What has been tested and how, request additional testing if necessary
The original profiling and trace test has been verified with the fix.

#### Documentation impact (if any)
No documentation impact