### PR TITLE
Fix gcc12.1 optimization error

### DIFF
--- a/src/runtime_src/xocl/api/clReleaseCommandQueue.cpp
+++ b/src/runtime_src/xocl/api/clReleaseCommandQueue.cpp
@@ -37,7 +37,7 @@ static cl_int
 clReleaseCommandQueue(cl_command_queue command_queue)
 {
   validOrError(command_queue);
-  if (xocl(command_queue)->release())
+  if (xocl_or_error(command_queue)->release())
     delete xocl(command_queue);
   return CL_SUCCESS;
 }

--- a/src/runtime_src/xocl/api/clReleaseContext.cpp
+++ b/src/runtime_src/xocl/api/clReleaseContext.cpp
@@ -36,7 +36,7 @@ static cl_int
 clReleaseContext(cl_context  context )
 {
   validOrError(context);
-  if (xocl(context)->release())
+  if (xocl_or_error(context)->release())
     delete xocl(context);
   return CL_SUCCESS;
 }

--- a/src/runtime_src/xocl/api/clReleaseKernel.cpp
+++ b/src/runtime_src/xocl/api/clReleaseKernel.cpp
@@ -37,7 +37,7 @@ static cl_int
 clReleaseKernel(cl_kernel kernel)
 {
   validOrError(kernel);
-  if (xocl(kernel)->release())
+  if (xocl_or_error(kernel)->release())
     delete xocl(kernel);
   return CL_SUCCESS;
 }

--- a/src/runtime_src/xocl/api/clReleaseMemObject.cpp
+++ b/src/runtime_src/xocl/api/clReleaseMemObject.cpp
@@ -39,7 +39,7 @@ clReleaseMemObject(cl_mem memobj)
 {
   validOrError(memobj);
 
-  if (!xocl(memobj)->release())
+  if (!xocl_or_error(memobj)->release())
     return CL_SUCCESS;
 
   delete xocl(memobj);

--- a/src/runtime_src/xocl/api/clReleaseProgram.cpp
+++ b/src/runtime_src/xocl/api/clReleaseProgram.cpp
@@ -37,7 +37,7 @@ clReleaseProgram(cl_program program)
 {
   validOrError(program);
 
-  if (xocl::xocl(program)->release())
+  if (xocl_or_error(program)->release())
     delete xocl::xocl(program);
 
   return CL_SUCCESS;
@@ -61,7 +61,4 @@ clReleaseProgram(cl_program program)
     xocl::send_exception_message(ex.what());
     return CL_OUT_OF_HOST_MEMORY;
   }
-}  
-
-
-
+}

--- a/src/runtime_src/xocl/api/clReleaseSampler.cpp
+++ b/src/runtime_src/xocl/api/clReleaseSampler.cpp
@@ -36,7 +36,7 @@ static cl_int
 clReleaseSampler(cl_sampler sampler)
 {
   validOrError(sampler);
-  if (xocl(sampler)->release())
+  if (xocl_or_error(sampler)->release())
     delete xocl(sampler);
   return CL_SUCCESS;
 }

--- a/src/runtime_src/xocl/core/object.h
+++ b/src/runtime_src/xocl/core/object.h
@@ -1,19 +1,6 @@
-/**
- * Copyright (C) 2016-2017 Xilinx, Inc
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2016-2017 Xilinx, Inc
+// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
 #ifndef xocl_core_object_h_
 #define xocl_core_object_h_
 
@@ -41,9 +28,7 @@ class memory;
 class stream;
 class stream_mem;
 
-/**
- * Base class for all CL API object types
- */
+// Base class for all CL API object types
 template <typename XOCLTYPE, typename CLTYPE>
 class object
 {
@@ -75,22 +60,34 @@ struct cl_object_traits<CLTYPE*>
 
 }
 
-/**
- * Get an xocl object from a CL API object
- *
- * Example:
- *  cl_platform_id cp = ...;
- *  xocl::platform* xp = obj(cp);
- *
- * This function simply does a static downcast of the API object.
- * The static downcast is safe as long as the CL API object is a
- * standard layout object.
- */
+// Get an xocl object from a CL API object
+// Example:
+//  cl_platform_id cp = ...;
+//  xocl::platform* xp = obj(cp);
+//
+// This function simply does a static downcast of the API object.
+// The static downcast is safe as long as the CL API object is a
+// standard layout object.
 template <typename CLTYPE>
 typename detail::cl_object_traits<CLTYPE>::xocl_type*
 xocl(CLTYPE c)
 {
   return detail::cl_object_traits<CLTYPE>::get_xocl(c);
+}
+
+// Get an xocl object from a CL API object
+// Provided as a work-around for GCC too aggressive optimization
+// GCC Bugzilla – Bug 104475
+template <typename CLTYPE>
+typename detail::cl_object_traits<CLTYPE>::xocl_type*
+xocl_or_error(CLTYPE c)
+{
+  auto x = detail::cl_object_traits<CLTYPE>::get_xocl(c);
+#ifdef __GNUC__
+  if (!x)
+    __builtin_unreachable();
+#endif
+  return x;
 }
 
 template <typename CLTYPE>


### PR DESCRIPTION
#### Problem solved by the commit
Implement suggested work-around from #6984 to prevent GCC aggressive optimization warning stringop-overflow.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Per notes in the #6984, the OpenCL implementation already has a nullptr check in validOrError() and if user disables OpenCL error checking, then a nullptr is desirably a segmentation fault.

#### How problem was solved, alternative solutions (if any) and why they were rejected
This PR preserves the behavior but works around the incorrect(?) optimization (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=104475)

Signed-off-by: Soren Soe <2106410+stsoe@users.noreply.github.com>
