### PR TITLE
CR-1149626 sc warning

### DIFF
--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -332,11 +332,16 @@ XBUtilities::collect_devices( const std::set<std::string> &_deviceBDFs,
     }
 
     try {
-      // Make sure the default values for current and expected are different so a warning is issued
-      const auto current_sc_ver = xrt_core::device_query_default<xrt_core::query::hwmon_sdm_active_msp_ver>(device, "N/A");
-      const auto expected_sc_ver = xrt_core::device_query_default<xrt_core::query::hwmon_sdm_target_msp_ver>(device, "0.0.0");
-      if (!boost::equals(current_sc_ver, expected_sc_ver))
-        warnings.push_back(boost::str(boost::format("Invalid SC version. Expected: %s Current %s") % expected_sc_ver % current_sc_ver));
+      const std::string unavail = "N/A";
+      const std::string zeroes = "0.0.0";
+      auto cur_ver = xrt_core::device_query_default<xrt_core::query::hwmon_sdm_active_msp_ver>(device, unavail);
+      auto exp_ver = xrt_core::device_query_default<xrt_core::query::hwmon_sdm_target_msp_ver>(device, unavail);
+      cur_ver = (boost::equals(cur_ver, zeroes)) ? unavail : cur_ver;
+      exp_ver = (boost::equals(exp_ver, zeroes)) ? unavail : exp_ver;
+      if (boost::equals(cur_ver, unavail) || boost::equals(exp_ver, unavail))
+        warnings.push_back(boost::str(boost::format("SC version data missing. Expected: %s Current: %s") % exp_ver % cur_ver));
+      else if (!boost::equals(cur_ver, exp_ver))
+        warnings.push_back(boost::str(boost::format("Invalid SC version. Expected: %s Current: %s") % exp_ver % cur_ver));
     } catch (const xrt_core::error& e) {
       warnings.push_back(e.what());
     }

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -332,8 +332,9 @@ XBUtilities::collect_devices( const std::set<std::string> &_deviceBDFs,
     }
 
     try {
-      const auto current_sc_ver = xrt_core::device_query<xrt_core::query::hwmon_sdm_active_msp_ver>(device);
-      const auto expected_sc_ver = xrt_core::device_query<xrt_core::query::hwmon_sdm_target_msp_ver>(device);
+      // Make sure the default values for current and expected are different so a warning is issued
+      const auto current_sc_ver = xrt_core::device_query_default<xrt_core::query::hwmon_sdm_active_msp_ver>(device, "N/A");
+      const auto expected_sc_ver = xrt_core::device_query_default<xrt_core::query::hwmon_sdm_target_msp_ver>(device, "0.0.0");
       if (!boost::equals(current_sc_ver, expected_sc_ver))
         warnings.push_back(boost::str(boost::format("Invalid SC version. Expected: %s Current %s") % expected_sc_ver % current_sc_ver));
     } catch (const xrt_core::error& e) {

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -331,6 +331,15 @@ XBUtilities::collect_devices( const std::set<std::string> &_deviceBDFs,
       warnings.push_back(e.what());
     }
 
+    try {
+      const auto current_sc_ver = xrt_core::device_query<xrt_core::query::hwmon_sdm_active_msp_ver>(device);
+      const auto expected_sc_ver = xrt_core::device_query<xrt_core::query::hwmon_sdm_target_msp_ver>(device);
+      if (!boost::equals(current_sc_ver, expected_sc_ver))
+        warnings.push_back(boost::str(boost::format("Invalid SC version. Expected: %s Current %s") % expected_sc_ver % current_sc_ver));
+    } catch (const xrt_core::error& e) {
+      warnings.push_back(e.what());
+    }
+
     if (warnings.empty())
       return;
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
https://jira.xilinx.com/browse/CR-1147768
There is not a CLEAN way that customers can flash a shell on a Versal platform without warnings or errors. After flashing the shell the users are expected to flash the device again to update the SC, but, we make no mention of that requirement in the tooling. As a result, users are confused when their shells fail due to interacting the with incorrect SC.

To deal with this problem we would like to add three features:
1. Add a message when the user flashes a device with `xbmgmt program -d <BDF> -b` to output a warning stating to program again to change the SC (Versal devices only)
2. Update the messages being displayed when programming to device to reflect that either the shell or the SC are being flashed (Versal devices only)
3. Display a more substantial warning then the current `xbmgmt examine -b <BDF> -r platform` warning if the SC version does not match the expected SC version from the shell

There will be 2 PRs for this change.
The first deals with the flashing behavior (Already done)
The second deals with the additional warning message (This PR)

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Users do not see if their SC version is not aligned with their installed shell. This can cause problems when attempting to run programs.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added a warning message after comparing the expected and the target SC version.

#### Risks (if any) associated the changes in the commit
If there is a fault with the hardware and neither sysfs node appears the following message will be displayed:
```
***********************************************************
*        WARNING          WARNING          WARNING        *
*    Invalid SC version. Expected: 0.0.0 Current N/A      *
***********************************************************
```

#### What has been tested and how, request additional testing if necessary
Ubuntu 20.04 VCK5000
Bad SC Version warning
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ xbutil examine -d 17:00
WARNING: Unexpected xocl version (2.14.0) was found. Expected 2.15.0, to match XRT tools.
***********************************************************
*        WARNING          WARNING          WARNING        *
*    Invalid SC version. Expected: 0.0.0 Current 4.4.35   *
***********************************************************

---------------------------------------------------
[0000:17:00.1] : xilinx_vck5000_gen4x8_qdma_base_2
---------------------------------------------------
Platform
  XSA Name               : xilinx_vck5000_gen4x8_qdma_base_2
  Platform UUID          : 05DCA096-76CB-730B-8D19-EC1192FBAE3F
  FPGA Name              :
  JTAG ID Code           : 0x0
  DDR Size               : 0 Bytes
  DDR Count              : 0
  Revision               : A
  MFG Date               : 0xcc344c
  Mig Calibrated         : false
  P2P Status             : not supported

Mac Addresses            : 00:0A:35:0A:7F:AE
                         : 00:0A:35:0A:7F:AF

Xclbin UUID
  00000000-0000-0000-0000-000000000000

Compute Units
  PL Compute Units
    Index   Name                                              Base_Address    Usage   Status

  PS Compute Units
    Index   Name                                              Base_Address    Usage   Status
```	
	
#### Documentation impact (if any)
Platform team needs to notate what the warnings mean.