### PR TITLE
CR-1144989: Fixing issue where profiling generated incorrect CSV format

### DIFF
--- a/src/runtime_src/xdp/profile/database/dynamic_event_database.cpp
+++ b/src/runtime_src/xdp/profile/database/dynamic_event_database.cpp
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2016-2020 Xilinx, Inc
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -148,6 +148,16 @@ namespace xdp {
   uint64_t VPDynamicDatabase::matchingXRTUIDStart(uint64_t uid)
   {
     return host->matchingXRTUIDStart(uid);
+  }
+
+  void VPDynamicDatabase::markEventPairStart(uint64_t functionId, const EventPair& events)
+  {
+    host->registerEventPairStart(functionId, events);
+  }
+
+  EventPair VPDynamicDatabase::matchingEventPairStart(uint64_t functionId)
+  {
+    return host->matchingEventPairStart(functionId);
   }
 
   void VPDynamicDatabase::markRange(uint64_t functionID,

--- a/src/runtime_src/xdp/profile/database/dynamic_event_database.h
+++ b/src/runtime_src/xdp/profile/database/dynamic_event_database.h
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2016-2020 Xilinx, Inc
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -122,6 +122,9 @@ namespace xdp {
     //  the plugins, we have a seperate matching of start to end
     XDP_EXPORT void markXRTUIDStart(uint64_t uid, uint64_t eventID) ;
     XDP_EXPORT uint64_t matchingXRTUIDStart(uint64_t uid);
+
+    XDP_EXPORT void markEventPairStart(uint64_t functionId, const EventPair& events);
+    XDP_EXPORT EventPair matchingEventPairStart(uint64_t functionId);
 
     // A lookup into the string table.  If the string isn't already in
     // the string table it will be added

--- a/src/runtime_src/xdp/profile/database/dynamic_info/host_db.h
+++ b/src/runtime_src/xdp/profile/database/dynamic_info/host_db.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -61,6 +61,10 @@ namespace xdp {
     // from the event IDs and the user IDs.
     APIMatch<uint64_t, uint64_t> uidStarts;
 
+    // This object keeps track of matching start events with end events
+    // for situations where we have one callback creating two database events.
+    APIMatch<uint64_t, EventPair> eventPairStarts;
+
     // Different host layers can have dependencies between events
     DependencyManager openclDependencies;
 
@@ -120,6 +124,12 @@ namespace xdp {
 
     inline uint64_t matchingXRTUIDStart(uint64_t uid)
     { return uidStarts.lookupStart(uid); }
+
+    inline void registerEventPairStart(uint64_t functionId, const EventPair& events)
+    { eventPairStarts.registerStart(functionId, events); }
+
+    inline EventPair matchingEventPairStart(uint64_t functionId)
+    { return eventPairStarts.lookupStart(functionId); }
 
     // Functions for handling dependencies
     inline void addOpenCLMapping(uint64_t openclId, uint64_t endXDPEventId,

--- a/src/runtime_src/xdp/profile/database/dynamic_info/types.h
+++ b/src/runtime_src/xdp/profile/database/dynamic_info/types.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -39,6 +39,16 @@ namespace xdp {
     const char* label;
     const char* tooltip;
     uint64_t startTimestamp;
+  };
+
+  // Used for keeping track of a pair of events in the database that
+  // correspond to a single event on the XRT side.  For example, when
+  // keeping track of Native XRT sync calls that we want to display as
+  // both an API event and a data transfer event.
+  struct EventPair
+  {
+    uint64_t APIEventId;
+    uint64_t transferEventId;
   };
 
 } // end namespace xdp

--- a/src/runtime_src/xdp/profile/database/events/native_events.cpp
+++ b/src/runtime_src/xdp/profile/database/events/native_events.cpp
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2016-2021 Xilinx, Inc
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -16,6 +17,7 @@
 
 #define XDP_SOURCE
 
+#include "xdp/profile/database/database.h"
 #include "xdp/profile/database/events/native_events.h"
 
 namespace xdp {
@@ -23,45 +25,36 @@ namespace xdp {
   NativeAPICall::NativeAPICall(uint64_t s_id, double ts, uint64_t name) :
     APICall(s_id, ts, name, NATIVE_API_CALL)
   {
-    
-  }
-
-  NativeAPICall::~NativeAPICall()
-  {
   }
 
   void NativeAPICall::dump(std::ofstream& fout, uint32_t bucket)
   {
-    VTFEvent::dump(fout, bucket) ;
-    fout << "," << functionName << "\n" ;
+    VTFEvent::dump(fout, bucket);
+    fout << "," << functionName << "\n";
   }
 
-  void NativeAPICall::dumpSync(std::ofstream& /*fout*/, uint32_t /*bucket*/)
+  NativeSyncRead::NativeSyncRead(uint64_t s_id, double ts, uint64_t name) :
+    NativeAPICall(s_id, ts, name)
   {
-  }
-
-  NativeSyncRead::NativeSyncRead(uint64_t s_id, double ts, uint64_t name,
-                                 uint64_t r) :
-    NativeAPICall(s_id, ts, name), readStr(r)
-  {
+    readStr = VPDatabase::Instance()->getDynamicInfo().addString("READ");
   }
 
   void NativeSyncRead::dumpSync(std::ofstream& fout, uint32_t bucket)
   {
-    VTFEvent::dump(fout, bucket) ;
-    fout << "," << readStr << "\n" ;
+    VTFEvent::dump(fout, bucket);
+    fout << "," << readStr << "\n";
   }
 
-  NativeSyncWrite::NativeSyncWrite(uint64_t s_id, double ts, uint64_t name,
-                                   uint64_t w) :
-    NativeAPICall(s_id, ts, name), writeStr(w)
+  NativeSyncWrite::NativeSyncWrite(uint64_t s_id, double ts, uint64_t name) :
+    NativeAPICall(s_id, ts, name)
   {
+    writeStr = VPDatabase::Instance()->getDynamicInfo().addString("WRITE");
   }
 
   void NativeSyncWrite::dumpSync(std::ofstream& fout, uint32_t bucket)
   {
-    VTFEvent::dump(fout, bucket) ;
-    fout << "," << writeStr << "\n" ;
+    VTFEvent::dump(fout, bucket);
+    fout << "," << writeStr << "\n";
   }
 
 } // end namespace xdp

--- a/src/runtime_src/xdp/profile/database/events/native_events.h
+++ b/src/runtime_src/xdp/profile/database/events/native_events.h
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2016-2021 Xilinx, Inc
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -24,45 +25,43 @@ namespace xdp {
   class NativeAPICall : public APICall
   {
   public:
-    XDP_EXPORT NativeAPICall(uint64_t s_id, double ts, uint64_t name) ;
-    XDP_EXPORT ~NativeAPICall() ;
+    XDP_EXPORT NativeAPICall(uint64_t s_id, double ts, uint64_t name);
+    XDP_EXPORT ~NativeAPICall() = default;
 
-    XDP_EXPORT virtual bool isNativeHostEvent() { return true ; }
-    XDP_EXPORT virtual bool isWrite() { return false ; }
-    XDP_EXPORT virtual bool isRead()  { return false ; }
+    XDP_EXPORT virtual bool isNativeHostEvent() { return true; }
 
-    XDP_EXPORT virtual void dump(std::ofstream& fout, uint32_t bucket) ;
-
-    // For printing out the event in a different bucket as a different
-    //  type of event, without having to store additional events in the database
-    XDP_EXPORT virtual void dumpSync(std::ofstream& fout, uint32_t bucket);
-  } ;
+    XDP_EXPORT virtual void dump(std::ofstream& fout, uint32_t bucket);
+  };
 
   class NativeSyncRead : public NativeAPICall
   {
   private:
-    uint64_t readStr ;
+    uint64_t readStr;
   public:
-    XDP_EXPORT NativeSyncRead(uint64_t s_id, double ts, uint64_t name,
-                              uint64_t r) ;
-    XDP_EXPORT ~NativeSyncRead() = default ;
+    XDP_EXPORT NativeSyncRead(uint64_t s_id, double ts, uint64_t name);
+    XDP_EXPORT ~NativeSyncRead() = default;
 
-    XDP_EXPORT virtual bool isRead() { return true ; }
-    XDP_EXPORT virtual void dumpSync(std::ofstream& fout, uint32_t bucket) ;
-  } ;
+    XDP_EXPORT virtual bool isNativeRead() override { return true; }
+
+    // For printing out the event in a different bucket as a different
+    //  type of event, without having to store additional events in the database
+    XDP_EXPORT virtual void dumpSync(std::ofstream& fout, uint32_t bucket) override;
+  };
 
   class NativeSyncWrite : public NativeAPICall
   {
   private:
-    uint64_t writeStr ;
+    uint64_t writeStr;
   public:
-    XDP_EXPORT NativeSyncWrite(uint64_t s_id, double ts, uint64_t name,
-                               uint64_t w) ;
-    XDP_EXPORT ~NativeSyncWrite() = default ;
+    XDP_EXPORT NativeSyncWrite(uint64_t s_id, double ts, uint64_t name);
+    XDP_EXPORT ~NativeSyncWrite() = default;
 
-    XDP_EXPORT virtual bool isWrite() { return true ; }
-    XDP_EXPORT virtual void dumpSync(std::ofstream& fout, uint32_t bucket) ;
-  } ;
+    XDP_EXPORT virtual bool isNativeWrite() override { return true; }
+
+    // For printing out the event in a different bucket as a different
+    //  type of event, without having to store additional events in the databaes
+    XDP_EXPORT virtual void dumpSync(std::ofstream& fout, uint32_t bucket) override;
+  };
 
 } // end namespace xdp
 

--- a/src/runtime_src/xdp/profile/database/events/vtf_event.h
+++ b/src/runtime_src/xdp/profile/database/events/vtf_event.h
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2016-2020 Xilinx, Inc
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -107,7 +108,9 @@ namespace xdp {
     virtual bool isLOPAPI()          { return false ; }
     virtual bool isHALAPI()          { return false ; }
     virtual bool isHostEvent()       { return false ; }
-    virtual bool isNativeHostEvent() { return false ; } 
+    virtual bool isNativeHostEvent() { return false ; }
+    virtual bool isNativeRead()      { return false ; }
+    virtual bool isNativeWrite()     { return false ; }
     virtual bool isOpenCLHostEvent()
       { return type == READ_BUFFER  || type == READ_BUFFER_P2P  ||
                type == WRITE_BUFFER || type == WRITE_BUFFER_P2P ||
@@ -131,6 +134,7 @@ namespace xdp {
 
     virtual uint64_t getDevice() { return 0 ; } // CHECK
     XDP_EXPORT virtual void dump(std::ofstream& fout, uint32_t bucket) ;
+    XDP_EXPORT virtual void dumpSync(std::ofstream& fout, uint32_t bucket) {};
   } ;
 
   // Used so the database can sort based on timestamp order

--- a/src/runtime_src/xdp/profile/database/events/vtf_event.h
+++ b/src/runtime_src/xdp/profile/database/events/vtf_event.h
@@ -134,7 +134,7 @@ namespace xdp {
 
     virtual uint64_t getDevice() { return 0 ; } // CHECK
     XDP_EXPORT virtual void dump(std::ofstream& fout, uint32_t bucket) ;
-    XDP_EXPORT virtual void dumpSync(std::ofstream& fout, uint32_t bucket) {};
+    XDP_EXPORT virtual void dumpSync(std::ofstream& /*fout*/, uint32_t /*bucket*/) {};
   } ;
 
   // Used so the database can sort based on timestamp order

--- a/src/runtime_src/xdp/profile/plugin/native/native_cb.cpp
+++ b/src/runtime_src/xdp/profile/plugin/native/native_cb.cpp
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2016-2022 Xilinx, Inc
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -21,98 +21,128 @@
 #define XDP_SOURCE
 
 #include "core/common/time.h"
+#include "xdp/profile/database/dynamic_info/types.h"
 #include "xdp/profile/database/events/native_events.h"
 #include "xdp/profile/plugin/native/native_cb.h"
 #include "xdp/profile/plugin/native/native_plugin.h"
 
 namespace xdp {
 
-  static NativeProfilingPlugin nativePluginInstance ;
+  // The static instance of the plugin that is constructed when the
+  // dynamic library is loaded.  It will be accessed by the callback
+  // functions below.
+  static NativeProfilingPlugin nativePluginInstance;
 
   // For logging statistics: Function ID to start timestamp
-  static std::mutex timestampLock ;
-  static std::map<uint64_t, uint64_t> nativeTimestamps ;
+  static std::mutex timestampLock;
+  static std::map<uint64_t, uint64_t> nativeTimestamps;
 
 } // end namespace xdp
 
+// The functionID is the unique identifier from the XRT side that we
+// can use to match start events with stop events.
 extern "C"
-void native_function_start(const char* functionName, unsigned long long int functionID)
+void native_function_start(const char* functionName,
+                           unsigned long long int functionID)
 {
   if (!xdp::VPDatabase::alive() || !xdp::NativeProfilingPlugin::alive())
     return;
 
   // Don't include the profiling overhead in the time that we show.
-  //  That means there will be "empty gaps" in the timeline trace when
-  //  the profiling overhead exists.
-  xdp::VPDatabase* db = xdp::nativePluginInstance.getDatabase() ;
+  // That means there will be "empty gaps" in the timeline trace when
+  // the profiling overhead exists.  That means we create the event
+  // and add it to the database first, and set the timestamp as close as
+  // possible to the true start of the observed function.
+  xdp::VPDatabase* db = xdp::nativePluginInstance.getDatabase();
 
   xdp::VTFEvent* event =
     new xdp::NativeAPICall(0,
                            0,
-                           (db->getDynamicInfo()).addString(functionName)) ;
-  (db->getDynamicInfo()).addUnsortedEvent(event);
-  (db->getDynamicInfo()).markStart(static_cast<uint64_t>(functionID), event->getEventId()) ;
+                           db->getDynamicInfo().addString(functionName));
+  db->getDynamicInfo().addUnsortedEvent(event);
+  db->getDynamicInfo().markStart(static_cast<uint64_t>(functionID),
+                                 event->getEventId());
 
-  db->getStats().logFunctionCallStart(functionName, static_cast<double>(xrt_core::time_ns()));
-  event->setTimestamp(static_cast<double>(xrt_core::time_ns())) ;
+  db->getStats().logFunctionCallStart(functionName,
+                                      static_cast<double>(xrt_core::time_ns()));
+  event->setTimestamp(static_cast<double>(xrt_core::time_ns()));
 }
 
+// In order to not show profiling overhead in the timeline, we have
+// already captured the timestamp when the observed function ended
+// so any of the events we record do not take the local overhead into
+// consideration.  The timestamp is as close to the true end of the
+// observed function as possible.
 extern "C"
-void native_function_end(const char* functionName, unsigned long long int functionID, unsigned long long int timestamp)
+void native_function_end(const char* functionName,
+                         unsigned long long int functionID,
+                         unsigned long long int timestamp)
 {
   if (!xdp::VPDatabase::alive() || !xdp::NativeProfilingPlugin::alive())
     return;
 
-  xdp::VPDatabase* db = xdp::nativePluginInstance.getDatabase() ;
-  db->getStats().logFunctionCallEnd(functionName, static_cast<double>(timestamp)) ;
+  xdp::VPDatabase* db = xdp::nativePluginInstance.getDatabase();
+  db->getStats().logFunctionCallEnd(functionName,
+                                    static_cast<double>(timestamp));
 
   uint64_t start =
-    (db->getDynamicInfo()).matchingStart(static_cast<uint64_t>(functionID)) ;
+    db->getDynamicInfo().matchingStart(static_cast<uint64_t>(functionID));
 
   xdp::VTFEvent* event =
     new xdp::NativeAPICall(start,
                            static_cast<double>(timestamp),
-                           (db->getDynamicInfo()).addString(functionName)) ;
-  (db->getDynamicInfo()).addUnsortedEvent(event) ;
+                           db->getDynamicInfo().addString(functionName));
+  db->getDynamicInfo().addUnsortedEvent(event);
 }
 
+// Callbacks for sync functions will create two separate events to be displayed
+// on the visualization.  One that is put on the API row to show that
+// xrt::sync was called, and one on the data transfer rows to show when
+// reads and writes were occurring.
 extern "C"
-void native_sync_start(const char* functionName, unsigned long long int functionID, bool isWrite)
+void native_sync_start(const char* functionName,
+                       unsigned long long int functionID,
+                       bool isWrite)
 {
   if (!xdp::VPDatabase::alive() || !xdp::NativeProfilingPlugin::alive())
     return;
 
   // Don't include the profiling overhead in the time that we show.
-  //  That means there will be "empty gaps" in the timeline trace when
-  //  the profiling overhead exists.
-  xdp::VPDatabase* db = xdp::nativePluginInstance.getDatabase() ;
+  // That means there will be "empty gaps" in the timeline trace when
+  // the profiling overhead exists.  We do this by capturing the
+  // timestamp as close to the end of this function as possible
+  xdp::VPDatabase* db = xdp::nativePluginInstance.getDatabase();
 
-  xdp::VTFEvent* event = nullptr ;
-  if (isWrite) {
-    event =
-      new xdp::NativeSyncWrite(0,
-                               0,
-                               db->getDynamicInfo().addString(functionName),
-                               db->getDynamicInfo().addString("WRITE")) ;
-  }
-  else {
-    event =
-      new xdp::NativeSyncRead(0,
-                              0,
-                              db->getDynamicInfo().addString(functionName),
-                              db->getDynamicInfo().addString("READ")) ;
-  }
+  // Create two different events.  One for capturing the API to be put
+  // on the API row, and one for the read/write data transfer rows.
+  xdp::VTFEvent* APIEvent      = nullptr;
+  xdp::VTFEvent* transferEvent = nullptr;
 
-  (db->getDynamicInfo()).addUnsortedEvent(event);
-  (db->getDynamicInfo()).markStart(static_cast<uint64_t>(functionID), event->getEventId()) ;
+  auto functionStr = db->getDynamicInfo().addString(functionName);
+  APIEvent = new xdp::NativeAPICall(0, 0, functionStr);
+  if (isWrite)
+    transferEvent = new xdp::NativeSyncWrite(0, 0, functionStr);
+  else
+    transferEvent = new xdp::NativeSyncRead(0, 0, functionStr);
+
+  db->getDynamicInfo().addUnsortedEvent(APIEvent);
+  db->getDynamicInfo().addUnsortedEvent(transferEvent);
+
+  // We need to store both events for lookup as we will only get one
+  // "stop" event from the XRT side for this particular functionID.
+  xdp::EventPair events = { APIEvent->getEventId(), transferEvent->getEventId() };
+  db->getDynamicInfo().markEventPairStart(static_cast<uint64_t>(functionID), events);
 
   {
-    std::lock_guard<std::mutex> lock(xdp::timestampLock) ;
-    xdp::nativeTimestamps[static_cast<uint64_t>(functionID)] = xrt_core::time_ns() ;
+    // For statistics, also keep track of the start time associated with
+    // this data transfer.
+    std::lock_guard<std::mutex> lock(xdp::timestampLock);
+    xdp::nativeTimestamps[static_cast<uint64_t>(functionID)] = xrt_core::time_ns();
   }
 
   db->getStats().logFunctionCallStart(functionName, static_cast<double>(xrt_core::time_ns()));
-  event->setTimestamp(static_cast<double>(xrt_core::time_ns())) ;
+  APIEvent->setTimestamp(static_cast<double>(xrt_core::time_ns()));
+  transferEvent->setTimestamp(static_cast<double>(xrt_core::time_ns()));
 }
 
 extern "C"
@@ -121,42 +151,48 @@ void native_sync_end(const char* functionName, unsigned long long int functionID
   if (!xdp::VPDatabase::alive() || !xdp::NativeProfilingPlugin::alive())
     return;
 
-  xdp::VPDatabase* db = xdp::nativePluginInstance.getDatabase() ;
-  db->getStats().logFunctionCallEnd(functionName, static_cast<double>(timestamp)) ;
+  xdp::VPDatabase* db = xdp::nativePluginInstance.getDatabase();
+  db->getStats().logFunctionCallEnd(functionName, static_cast<double>(timestamp));
 
-  uint64_t startTimestamp = 0 ;
-  uint64_t transferTime = 0 ;
+  uint64_t startTimestamp = 0;
+  uint64_t transferTime = 0;
   {
-    std::lock_guard<std::mutex> lock(xdp::timestampLock) ;
-    startTimestamp = xdp::nativeTimestamps[static_cast<uint64_t>(functionID)] ;
-    transferTime = timestamp - startTimestamp ;
-    xdp::nativeTimestamps.erase(functionID) ;
+    std::lock_guard<std::mutex> lock(xdp::timestampLock);
+    startTimestamp = xdp::nativeTimestamps[static_cast<uint64_t>(functionID)];
+    transferTime = timestamp - startTimestamp;
+    xdp::nativeTimestamps.erase(functionID);
   }
 
-  uint64_t start =
-    (db->getDynamicInfo()).matchingStart(static_cast<uint64_t>(functionID)) ;
+  // Retrieve the pair of events for this particular functionID.
+  auto startEvents =
+    db->getDynamicInfo().matchingEventPairStart(static_cast<uint64_t>(functionID));
 
-  xdp::VTFEvent* event = nullptr ;
+  xdp::VTFEvent* APIEvent = nullptr;
+  xdp::VTFEvent* transferEvent = nullptr;
+
+  auto functionStr = db->getDynamicInfo().addString(functionName);
+
+  APIEvent = new xdp::NativeAPICall(startEvents.APIEventId,
+                                    static_cast<double>(timestamp),
+                                    functionStr);
+
   if (isWrite) {
-    event =
-      new xdp::NativeSyncWrite(start,
+    transferEvent =
+      new xdp::NativeSyncWrite(startEvents.transferEventId,
                                static_cast<double>(timestamp),
-                               db->getDynamicInfo().addString(functionName),
-                               db->getDynamicInfo().addString("WRITE")) ;
+                               functionStr);
   }
   else {
-    event =
-      new xdp::NativeSyncRead(start,
+    transferEvent =
+      new xdp::NativeSyncRead(startEvents.transferEventId,
                               static_cast<double>(timestamp),
-                              db->getDynamicInfo().addString(functionName),
-                              db->getDynamicInfo().addString("READ")) ;
+                              db->getDynamicInfo().addString(functionName));
   }
-  (db->getDynamicInfo()).addUnsortedEvent(event) ;
+  db->getDynamicInfo().addUnsortedEvent(APIEvent);
+  db->getDynamicInfo().addUnsortedEvent(transferEvent);
 
-  if (isWrite) {
+  if (isWrite)
     db->getStats().logHostWrite(0, 0, size, startTimestamp, transferTime, 0, 0);
-  }
-  else {
+  else
     db->getStats().logHostRead(0, 0, size, startTimestamp, transferTime, 0, 0);
-  }
 }


### PR DESCRIPTION
#### Problem solved by the commit
When native XRT API tracing is turned on, the profiling library captures "sync" calls as both an API call and a data transfer, and generates the events in the native_trace.csv file so post-processing can display both the API call and the data transfer.  The two separate end events in the csv file were using the same start event id and end event id, which is not the correct format supported by the CSV file and the post-processing tools.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
The bug where multiple end events used the same start and end event ID was discovered with internal testing.

#### How problem was solved, alternative solutions (if any) and why they were rejected
The issue is resolved by creating and storing two separate events for calls to "sync."  This allows the infrastructure to correctly track start and end events for both portions that are eventually displayed on the final visualization.

#### Risks (if any) associated the changes in the commit
Low risk, as this is focused on tracing of Native API sync calls.

#### What has been tested and how, request additional testing if necessary
The original design has been verified.

#### Documentation impact (if any)
No documentation impact.