### PR TITLE
CR-1149619 Add FPT warning message for Versal devices

### DIFF
--- a/src/runtime_src/core/common/info_vmr.cpp
+++ b/src/runtime_src/core/common/info_vmr.cpp
@@ -79,6 +79,9 @@ get_vmr_status(const xrt_core::device* device, vmr_status_type status)
     case vmr_status_type::boot_on_default:
       status_string = "Boot on default";
       break;
+    case vmr_status_type::has_fpt:
+      status_string = "Has fpt";
+      break;
     default:
       throw xrt_core::error(boost::str(boost::format("Unexpected key for VMR Status type %u") % static_cast<uint32_t>(status)));
   }

--- a/src/runtime_src/core/common/info_vmr.h
+++ b/src/runtime_src/core/common/info_vmr.h
@@ -16,7 +16,8 @@ boost::property_tree::ptree
 vmr_info(const xrt_core::device * device);
 
 enum class vmr_status_type {
-  boot_on_default = 0
+  boot_on_default = 0,
+  has_fpt,
 };
 
 XRT_CORE_COMMON_EXPORT

--- a/src/runtime_src/core/include/xclfeatures.h
+++ b/src/runtime_src/core/include/xclfeatures.h
@@ -119,6 +119,7 @@ struct FeatureRomHeader {
 // This struct contains the status of the VMR subdevice found
 // on certain cards like u50s and versal platforms.
 struct VmrStatus {
+	uint16_t has_fpt; // 1 if device metadata is available. If it is not available something is wrong with the card
 	uint16_t boot_on_default; // 1 If the VMR device is currently running on its "A" or default image
 	uint16_t boot_on_backup; // 1 If the VMR device is currently running on its "B" or backup image
 	uint16_t boot_on_recovery; // 1 If the VMR device is currently running on its recovery image

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
@@ -1213,6 +1213,7 @@ static int xgq_status(struct platform_device *pdev, struct VmrStatus *vmr_status
 	vmr_status_ptr->boot_on_default = vmr_status->boot_on_default;
 	vmr_status_ptr->boot_on_backup = vmr_status->boot_on_backup;
 	vmr_status_ptr->boot_on_recovery = vmr_status->boot_on_recovery;
+	vmr_status_ptr->has_fpt = vmr_status->has_fpt;
 
 	return 0;
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_sysfs.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_sysfs.c
@@ -783,6 +783,7 @@ static ssize_t vmr_status_show(struct device *dev,
 		return 0;
 	}
 
+	cnt += sprintf(buf + cnt, "HAS_FPT:%d\n", vmr_status->has_fpt);
 	cnt += sprintf(buf + cnt, "BOOT_ON_DEFAULT:%d\n", vmr_status->boot_on_default);
 	cnt += sprintf(buf + cnt, "BOOT_ON_BACKUP:%d\n", vmr_status->boot_on_backup);
 	cnt += sprintf(buf + cnt, "BOOT_ON_RECOVERY:%d\n", vmr_status->boot_on_recovery);

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -324,6 +324,14 @@ XBUtilities::collect_devices( const std::set<std::string> &_deviceBDFs,
     std::vector<std::string> warnings;
 
     try {
+      const auto is_default = xrt_core::vmr::get_vmr_status(device.get(), xrt_core::vmr::vmr_status_type::has_fpt);
+      if (!is_default)
+        warnings.push_back("Versal Platform is NOT migrated");
+    } catch (const xrt_core::error& e) {
+      warnings.push_back(e.what());
+    }
+
+    try {
       const auto is_default = xrt_core::vmr::get_vmr_status(device.get(), xrt_core::vmr::vmr_status_type::boot_on_default);
       if (!is_default)
         warnings.push_back("Versal Platform is NOT in default boot");


### PR DESCRIPTION
Signed-off-by: Daniel Benusovich <dbenusov@xilinx.com>
https://jira.xilinx.com/browse/CR-1149619
If certain nodes are missing upon a Versal device coming online the card cannot be flashed as it is not migrated. This will prevent the user from flashing and interacting with the device. There is no message that informs the user of this issue.

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Adds a warning message stating that the Versal device is "not migrated".

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Users would attempt to program a device and nothing would work

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added an additional field into the user-space VMR sysfs node to allow for checking the versal boot status.

#### Risks (if any) associated the changes in the commit
Warning message may not be specific enough. Perhaps we should refer them to some documentation?

#### What has been tested and how, request additional testing if necessary
Ubuntu 20.04 VCK5000 (Modified driver to return 0)
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov/XRT$ xbutil examine -d 17:00
WARNING: Unexpected xocl version (2.14.0) was found. Expected 2.15.0, to match XRT tools.
***********************************************************
*        WARNING          WARNING          WARNING        *
*             Versal Platform is NOT migrated             *
***********************************************************

---------------------------------------------------
[0000:17:00.1] : xilinx_vck5000_gen4x8_qdma_base_2
---------------------------------------------------
Platform
  XSA Name               : xilinx_vck5000_gen4x8_qdma_base_2
  Platform UUID          : 05DCA096-76CB-730B-8D19-EC1192FBAE3F
  FPGA Name              :
  JTAG ID Code           : 0x0
  DDR Size               : 0 Bytes
  DDR Count              : 0
  Revision               : A
  MFG Date               : 0xcc344c
  Mig Calibrated         : false
  P2P Status             : not supported

Mac Addresses            : 00:0A:35:0A:7F:AE
                         : 00:0A:35:0A:7F:AF

Xclbin UUID
  20000000-0000-0000-005D-E180DFAA47A7

Compute Units
  PL Compute Units
    Index   Name                                              Base_Address    Usage   Status

  PS Compute Units
    Index   Name
```

Ubuntu 20.04 VCK5000 (Normal operation)
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov/XRT$ xbutil examine -d 17:00
WARNING: Unexpected xocl version (2.14.0) was found. Expected 2.15.0, to match XRT tools.
---------------------------------------------------
[0000:17:00.1] : xilinx_vck5000_gen4x8_qdma_base_2
---------------------------------------------------
Platform
  XSA Name               : xilinx_vck5000_gen4x8_qdma_base_2
  Platform UUID          : 05DCA096-76CB-730B-8D19-EC1192FBAE3F
  FPGA Name              :
  JTAG ID Code           : 0x0
  DDR Size               : 0 Bytes
  DDR Count              : 0
  Revision               : A
  MFG Date               : 0xcc344c
  Mig Calibrated         : false
  P2P Status             : not supported

Mac Addresses            : 00:0A:35:0A:7F:AE
                         : 00:0A:35:0A:7F:AF

Xclbin UUID
  20000000-0000-0000-005D-E180DFAA47A7

Compute Units
  PL Compute Units
    Index   Name                                              Base_Address    Usage   Status

  PS Compute Units
    Index   Name
```
#### Documentation impact (if any)
Maybe add a description about what a non-migrated card is?