### PR TITLE
When HSDP is used, monitors are only initialized for trace 

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
@@ -183,6 +183,12 @@ namespace xdp {
   void DeviceOffloadPlugin::addOffloader(uint64_t deviceId,
                                          DeviceIntf* devInterface)
   {
+    if (!devInterface->hasFIFO() && !devInterface->hasTs2mm()) {
+      xrt_core::message::send(xrt_core::message::severity_level::info, "XRT",
+           "No FIFO or PL TS2MM present in the design. So, the trace offload infrastructure must be using HSDP.");
+      return;
+    }
+
     uint64_t trace_buffer_size = 0;
     std::vector<uint64_t> buf_sizes;
 


### PR DESCRIPTION
Signed-off-by: IshitaGhosh <ighosh.account@gmail.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
When HSDP is used for PL trace offload, we only need to initialize PL monitors to generate trace. But we dont need to read the trace. 

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Tested with design with HSDP trace  offload infrastructure.

#### Documentation impact (if any)
