### PR TITLE
CR-1150349 move gmio reuse buffer warning

### DIFF
--- a/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.cpp
+++ b/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.cpp
@@ -451,8 +451,10 @@ void AIETraceOffload::checkCircularBufferSupport()
   }
 
   // old datamover not supported for PLIO
-  if (!deviceIntf->supportsCircBufAIE())
+  if (!deviceIntf->supportsCircBufAIE()) {
+    mEnCircularBuf = false;
     return;
+  }
 
   // check for periodic offload
   if (!continuousTrace()) {

--- a/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.cpp
+++ b/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.cpp
@@ -439,19 +439,19 @@ bool AIETraceOffload::isTraceBufferFull()
 
 void AIETraceOffload::checkCircularBufferSupport()
 {
-  if (!deviceIntf->supportsCircBufAIE())
-    return;
-
-  mEnCircularBuf = xrt_core::config::get_aie_trace_settings_reuse_buffer();
-  if (!mEnCircularBuf)
-    return;
-
   // gmio not supported
   if (!isPLIO) {
     mEnCircularBuf = false;
     xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", AIE_TRACE_WARN_REUSE_GMIO);
     return;
   }
+
+  if (!deviceIntf->supportsCircBufAIE())
+    return;
+
+  mEnCircularBuf = xrt_core::config::get_aie_trace_settings_reuse_buffer();
+  if (!mEnCircularBuf)
+    return;
 
   if (!continuousTrace()) {
     mEnCircularBuf = false;

--- a/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.cpp
+++ b/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.cpp
@@ -439,6 +439,10 @@ bool AIETraceOffload::isTraceBufferFull()
 
 void AIETraceOffload::checkCircularBufferSupport()
 {
+  mEnCircularBuf = xrt_core::config::get_aie_trace_settings_reuse_buffer();
+  if (!mEnCircularBuf)
+    return;
+
   // gmio not supported
   if (!isPLIO) {
     mEnCircularBuf = false;
@@ -446,13 +450,11 @@ void AIETraceOffload::checkCircularBufferSupport()
     return;
   }
 
+  // old datamover not supported for PLIO
   if (!deviceIntf->supportsCircBufAIE())
     return;
 
-  mEnCircularBuf = xrt_core::config::get_aie_trace_settings_reuse_buffer();
-  if (!mEnCircularBuf)
-    return;
-
+  // check for periodic offload
   if (!continuousTrace()) {
     mEnCircularBuf = false;
     xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", AIE_TRACE_WARN_REUSE_PERIODIC);


### PR DESCRIPTION
Signed-off-by: Anurag Dubey <anurag6dubey@gmail.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
When using reuse_buffer switch in AIE Trace with GMIO, we were returning too soon from the checkCircularBufferSuppport function and hence this warning was skipped. Moving it in front should fix the issue.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
NA
#### How problem was solved, alternative solutions (if any) and why they were rejected
NA
#### Risks (if any) associated the changes in the commit
NA
#### What has been tested and how, request additional testing if necessary
tested on a vck190 design
#### Documentation impact (if any)
