### PR TITLE
CR-1151107: Correcting warning message for too large PL trace buffers on Edge

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/vp_base/utility.cpp
+++ b/src/runtime_src/xdp/profile/plugin/vp_base/utility.cpp
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2016-2020 Xilinx, Inc
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -16,10 +17,13 @@
 
 #define XDP_SOURCE
 
+#include <boost/algorithm/string.hpp>
+#include <boost/property_tree/ptree.hpp>
 #include <chrono>
 #include <ctime>
 #include <cstring>
-#include <boost/property_tree/ptree.hpp>
+#include <fstream>
+#include <sstream>
 
 #include "core/common/system.h"
 
@@ -48,20 +52,21 @@ namespace xdp {
 
   const char* getToolVersion()
   {
-    return "2022.2" ;
+    return "2022.2";
   }
 
   std::string getXRTVersion()
   {
-    static std::string version = "" ;
-    if (version != "") return version ;
+    static std::string version = "";
+    if (version != "")
+      return version;
 
-    boost::property_tree::ptree xrtInfo ;
-    xrt_core::get_xrt_build_info(xrtInfo) ;
+    boost::property_tree::ptree xrtInfo;
+    xrt_core::get_xrt_build_info(xrtInfo);
 
-    version = xrtInfo.get<std::string>("version", "N/A") ;
+    version = xrtInfo.get<std::string>("version", "N/A");
 
-    return version ;
+    return version;
   }
 
   // This function can only be called after the system singleton has
@@ -69,14 +74,23 @@ namespace xdp {
   //  plugin constructor.
   bool isEdge()
   {
-    boost::property_tree::ptree pt ;
-    xrt_core::get_xrt_info(pt) ;
+    static bool initialized = false;
+    static bool storedValue = false;
+
+    if (initialized)
+      return storedValue;
+
+    initialized = true;
+
+    boost::property_tree::ptree pt;
+    xrt_core::get_xrt_info(pt);
 
     try {
       for (boost::property_tree::ptree::value_type& info : pt.get_child("drivers")) {
         try {
           std::string str = info.second.get<std::string>("name");
           if(0 == str.compare("zocl")) {
+            storedValue = true;
             return true;
           }
         } catch (const boost::property_tree::ptree_error&) {
@@ -87,6 +101,36 @@ namespace xdp {
       return false;
     }
     return false;
+  }
+
+  // Get the size of the physical device memory (in bytes) when running
+  // on the PS of Edge boards.  If called on x86 or Windows this should
+  // return 0.
+  uint64_t getPSMemorySize()
+  {
+#ifndef _WIN32
+    if (!isEdge())
+      return 0;
+
+    try {
+      std::string line;
+      std::ifstream ifs;
+      ifs.open("/proc/meminfo");
+      while (getline(ifs, line)) {
+        if (line.find("CmaTotal") == std::string::npos)
+          continue;
+
+        // Memory sizes are always expressed in kB
+        std::vector<std::string> cmaVector;
+        boost::split(cmaVector, line, boost::is_any_of(":"));
+        return std::stoull(cmaVector.at(1)) * 1024;
+      }
+    }
+    catch (...) {
+      // Do nothing
+    }
+#endif
+    return 0;
   }
 
   Flow getFlowMode()

--- a/src/runtime_src/xdp/profile/plugin/vp_base/utility.h
+++ b/src/runtime_src/xdp/profile/plugin/vp_base/utility.h
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2016-2020 Xilinx, Inc
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -24,10 +25,11 @@
 
 namespace xdp {
 
-  XDP_EXPORT std::string getCurrentDateTime() ;
-  XDP_EXPORT const char* getToolVersion() ;
-  XDP_EXPORT std::string getXRTVersion() ;
-  XDP_EXPORT bool isEdge() ;
+  XDP_EXPORT std::string getCurrentDateTime();
+  XDP_EXPORT const char* getToolVersion();
+  XDP_EXPORT std::string getXRTVersion();
+  XDP_EXPORT bool isEdge();
+  XDP_EXPORT uint64_t getPSMemorySize();
 
   enum Flow {
     SW_EMU  = 0,
@@ -50,7 +52,7 @@ namespace xdp {
     constexpr double ddr4_2400_bandwidth = 19250.00;
   }
 
-  XDP_EXPORT Flow getFlowMode() ;
+  XDP_EXPORT Flow getFlowMode();
 
 } // end namespace xdp
 


### PR DESCRIPTION
#### Problem solved by the commit
On Edge systems with limited available memory, it was possible to ask for a PL trace buffer in memory via xrt.ini options that was too big for the available memory yet too small to trigger our warning messages, resulting in a bad alloc.  This pull request adjusts the code so both AIE and PL buffer sizes are checked against the size of the memory available on the device when running on edge instead of using predefined hard coded values.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
The issue was discovered through internal testing.

#### How problem was solved, alternative solutions (if any) and why they were rejected
The problem was solved by refactoring the current code used to check if enough space was available for AIE buffers and applying it to the PL buffer portion of the code as well.

#### Risks (if any) associated the changes in the commit
Low risk, as it fixes a bad alloc error that only applies when a buffer is requested that is too large.  In the worst case, if we cannot determine the available memory, we will not change the current behavior.

#### What has been tested and how, request additional testing if necessary
The original failing test has been tested on a vck190 board.

#### Documentation impact (if any)
No documentation impact.