### PR TITLE
CR-1143439: Adding the trace wrapper to XRT AIE graph calls

### DIFF
--- a/src/runtime_src/core/common/api/aie/xrt_graph.cpp
+++ b/src/runtime_src/core/common/api/aie/xrt_graph.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0
 /*
  * Copyright (C) 2020-2021, Xilinx Inc - All rights reserved
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
  * Xilinx Runtime (XRT) Experimental APIs
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
@@ -28,6 +29,7 @@
 
 #include "core/include/experimental/xrt_device.h"
 #include "core/common/api/device_int.h"
+#include "core/common/api/native_profile.h"
 #include "core/common/device.h"
 #include "core/common/error.h"
 #include "core/common/message.h"
@@ -244,73 +246,91 @@ void
 graph::
 reset() const
 {
-  handle->reset();
+  xdp::native::profiling_wrapper("xrt::graph::reset", [=]{
+    handle->reset();
+  });
 }
 
 uint64_t
 graph::
 get_timestamp() const
 {
-  return (handle->get_timestamp());
+  return xdp::native::profiling_wrapper("xrt::graph::get_timestamp", [=]{return (handle->get_timestamp());});
 }
 
 void
 graph::
 run(uint32_t iterations)
 {
-  handle->run(iterations);
+  xdp::native::profiling_wrapper("xrt::graph::run", [=]{
+    handle->run(iterations);
+  });
 }
 
 void
 graph::
 wait(std::chrono::milliseconds timeout_ms)
 {
-  if (timeout_ms.count() == 0)
-    handle->wait(static_cast<uint64_t>(0));
-  else
-    handle->wait(static_cast<int>(timeout_ms.count()));
+  xdp::native::profiling_wrapper("xrt::graph::wait", [=]{
+    if (timeout_ms.count() == 0)
+      handle->wait(static_cast<uint64_t>(0));
+    else
+      handle->wait(static_cast<int>(timeout_ms.count()));
+  });
 }
 
 void
 graph::
 wait(uint64_t cycles)
 {
-  handle->wait(cycles);
+  xdp::native::profiling_wrapper("xrt::graph::wait", [=]{
+    handle->wait(cycles);
+  });
 }
 
 void
 graph::
 suspend()
 {
-  handle->suspend();
+  xdp::native::profiling_wrapper("xrt::graph::suspend", [=]{
+    handle->suspend();
+  });
 }
 
 void
 graph::
 resume()
 {
-  handle->resume();
+  xdp::native::profiling_wrapper("xrt::graph::resume", [=]{
+    handle->resume();
+  });
 }
 
 void
 graph::
 end(uint64_t cycles)
 {
-  handle->end(cycles);
+  xdp::native::profiling_wrapper("xrt::graph::end", [=]{
+    handle->end(cycles);
+  });
 }
 
 void
 graph::
 update_port(const std::string& port_name, const void* value, size_t bytes)
 {
-  handle->update_rtp(port_name.c_str(), reinterpret_cast<const char*>(value), bytes);
+  xdp::native::profiling_wrapper("xrt::graph::update_port", [=]{
+    handle->update_rtp(port_name.c_str(), reinterpret_cast<const char*>(value), bytes);
+  });
 }
 
 void
 graph::
 read_port(const std::string& port_name, void* value, size_t bytes)
 {
-  handle->read_rtp(port_name.c_str(), reinterpret_cast<char *>(value), bytes);
+  xdp::native::profiling_wrapper("xrt::graph::read_port", [=]{
+    handle->read_rtp(port_name.c_str(), reinterpret_cast<char *>(value), bytes);
+  });
 }
 
 } // namespace xrt

--- a/src/runtime_src/xdp/profile/writer/native/native_apis.h
+++ b/src/runtime_src/xdp/profile/writer/native/native_apis.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2022 Advanced Micro Devices, Inc - All rights reserved
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -64,6 +64,15 @@ constexpr const char* APIs[] = {
   "xrt::error::to_string",
   "xrtErrorGetLast",
   "xrtErrorGetString",
+  "xrt::graph::reset",
+  "xrt::graph::get_timestamp",
+  "xrt::graph::run",
+  "xrt::graph::wait",
+  "xrt::graph::suspend",
+  "xrt::graph::resume",
+  "xrt::graph::end",
+  "xrt::graph::update_port",
+  "xrt::graph::read_port",
   "xrt::run::run",
   "xrt::run::start",
   "xrt::run::wait",


### PR DESCRIPTION
#### Problem solved by the commit
This pull request adds tracing capability to the XRT::AIE graph calls, so when the user enables native_trace=true in the xrt.ini then these calls will appear in the timeline trace.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
The XRT graph APIs were not being traced, and when the execution time of a regression test increased it was difficult to determine the cause without a complete picture of these function calls.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added the native profiling wrapper to the current xrt_graph API functions.  An alternative was to not connect the xrt graph functions to the current native API tracing capability and instead create a different profiling plugin and controls, but there would be no quantifiable benefit to separating out the tracing of the graph APIs from the other native XRT API tracing.

#### Risks (if any) associated the changes in the commit
Low risk as there is minimal overhead added if profiling is not enabled.

#### What has been tested and how, request additional testing if necessary
AIE graph call testing is necessary.

#### Documentation impact (if any)
No documentation impact.