### PR TITLE
Not able to kill application and driver keep printing outstanding command message

### DIFF
--- a/src/runtime_src/core/common/drv/xrt_cu.c
+++ b/src/runtime_src/core/common/drv/xrt_cu.c
@@ -3,7 +3,7 @@
  * Xilinx Unify CU Model
  *
  * Copyright (C) 2020-2022 Xilinx, Inc. All rights reserved.
- * Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Authors: min.ma@xilinx.com
  *
@@ -358,6 +358,7 @@ static inline void process_sq(struct xrt_cu *xcu)
 static inline int process_rq(struct xrt_cu *xcu)
 {
 	struct kds_command *xcmd;
+	struct kds_command *tmp;
 	struct kds_client *ev_client;
 	struct list_head *dst_q;
 	int *dst_len;
@@ -365,15 +366,23 @@ static inline int process_rq(struct xrt_cu *xcu)
 	if (!xcu->num_rq)
 		return 0;
 
-	xcmd = list_first_entry(&xcu->rq, struct kds_command, list);
-
+	/* A client is closing and it has outstanding commands */
 	ev_client = first_event_client_or_null(xcu);
-	if (unlikely(xcu->bad_state || (ev_client == xcmd->client))) {
-		xcmd->status = KDS_ABORT;
-		dst_q = &xcu->cq;
-		dst_len = &xcu->num_cq;
-		goto move_cmd;
+	if (ev_client) {
+		list_for_each_entry_safe(xcmd, tmp, &xcu->rq, list) {
+			if ((ev_client != xcmd->client) && !xcu->bad_state)
+				continue;
+
+			xcmd->status = KDS_ABORT;
+			dst_q = &xcu->cq;
+			dst_len = &xcu->num_cq;
+			move_to_queue(xcmd, dst_q, dst_len);
+			--xcu->num_rq;
+		}
+		return 0;
 	}
+
+	xcmd = list_first_entry(&xcu->rq, struct kds_command, list);
 
 	if (!xrt_cu_get_credit(xcu))
 		return 0;
@@ -392,6 +401,10 @@ static inline int process_rq(struct xrt_cu *xcu)
 	set_xcmd_timestamp(xcmd, KDS_RUNNING);
 	xrt_cu_circ_produce(xcu, CU_LOG_STAGE_RQ, (uintptr_t)xcmd);
 
+	/*
+	 * We move submit queue to CU impl level. The xrt_cu.c only need to
+	 * count how many commands are moved. Thus use NULL.
+	 */
 	dst_q = NULL;
 	dst_len = &xcu->num_sq;
 	/* ktime_get_* is still heavy. This impact ~20% of IOPS on echo mode.
@@ -401,7 +414,6 @@ static inline int process_rq(struct xrt_cu *xcu)
 	 * specific thread if needed.
 	 */
 	//xcmd->start = ktime_get_raw_fast_ns();
-move_cmd:
 	move_to_queue(xcmd, dst_q, dst_len);
 	--xcu->num_rq;
 	if (xcu->stats.max_sq_length < xcu->num_sq)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
When abort command from xrt CU's rq, it will check if this CU is bad status or if the first command's client match the aborting client.
In some case, if there are a lot of user processes and the aborting client has no command in the sq (which means this CU will not be marked as bad status), xrt cu is not able to abort command and not able to make progress.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
This exposed in recent U30 debug. We see similar issue on V70's video application.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Iterating rq when abort commands.

#### Risks (if any) associated the changes in the commit
Low. the change will only impact error handling path.

#### What has been tested and how, request additional testing if necessary
@jeffli-xilinx  has video test setup and he can help on verify this change.

#### Documentation impact (if any)
No