### PR TITLE
CR-1137357 Remove libxrt_core from xbutil/xbmgmt 

### DIFF
--- a/src/CMake/nativeTests.cmake
+++ b/src/CMake/nativeTests.cmake
@@ -18,9 +18,15 @@ add_test(NAME xbutil2
   COMMAND ${XRT_BINARY_DIR}/runtime_src/core/tools/xbutil2/xbutil2 examine
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
+set_tests_properties(xbutil2 PROPERTIES ENVIRONMENT
+  "XILINX_XRT=${XRT_BUILD_INSTALL_DIR}")
+
 add_test(NAME xbmgmt2
   COMMAND ${XRT_BINARY_DIR}/runtime_src/core/tools/xbmgmt2/xbmgmt2 examine -r host
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+set_tests_properties(xbmgmt2 PROPERTIES ENVIRONMENT
+  "XILINX_XRT=${XRT_BUILD_INSTALL_DIR}")
 
 add_test(NAME python_binding
   COMMAND ${PYTHON_EXECUTABLE} "${XRT_SOURCE_DIR}/../tests/python/200_binding/200_main.py"

--- a/src/runtime_src/core/pcie/common/dmatest.h
+++ b/src/runtime_src/core/pcie/common/dmatest.h
@@ -56,7 +56,8 @@ namespace xcldev {
             while (b < e) {
                 try {
                     mHandle->sync_bo(b->first, dir, mSize, 0);
-                } catch (const std::exception&) {
+                }
+                catch (const std::exception&) {
                     throw xrt_core::error(result, "DMA failed");
                     break;
                 }

--- a/src/runtime_src/core/pcie/common/dmatest.h
+++ b/src/runtime_src/core/pcie/common/dmatest.h
@@ -65,7 +65,7 @@ namespace xcldev {
             return result;
         }
 
-        int runSync(xclBOSyncDirection dir, unsigned int count) const {
+        int runSync(xclBOSyncDirection dir, size_t count) const {
             auto b = mBOList.begin();
             const auto e = mBOList.end();
             if (count == 1) {
@@ -82,9 +82,9 @@ namespace xcldev {
              * --------------------------------------
              *          4        |   2   |     b+4
              */
-            unsigned int len = (((unsigned int)(e - b)) < count) ? 1 : ((unsigned int)(e - b))/count;
-            auto bo_cnt = static_cast<unsigned int>(e - b);
-            const auto adjust_e = b + len * ((len == 1) ? bo_cnt : std::min<unsigned int>(count, len));
+            size_t len = (((size_t)(e - b)) < count) ? 1 : ((size_t)(e - b))/count;
+            auto bo_cnt = static_cast<size_t>(e - b);
+            const auto adjust_e = b + len * ((len == 1) ? bo_cnt : std::min<size_t>(count, len));
 
             std::vector<std::future<int>> threads;
             while (b < adjust_e) {
@@ -150,11 +150,11 @@ namespace xcldev {
             if (dma_threads.empty())
                 throw xrt_core::error(-EINVAL, "Unable to determine number of DMA channels.");
 
-            size_t result = 0;
+            int result = 0;
             Timer timer;
             result = runSync(XCL_BO_SYNC_BO_TO_DEVICE, dma_threads.size());
             if (result)
-                throw xrt_core::error(static_cast<int>(result), "DMA from host to device failed.");
+                throw xrt_core::error(result, "DMA from host to device failed.");
 
             auto timer_stop = timer.stop();
             double rate = static_cast<double>(mBOList.size() * mSize);
@@ -166,7 +166,7 @@ namespace xcldev {
             timer.reset();
             result = runSync(XCL_BO_SYNC_BO_FROM_DEVICE, dma_threads.size());
             if (result)
-                throw xrt_core::error(static_cast<int>(result), "DMA from device to host failed.");
+                throw xrt_core::error(result, "DMA from device to host failed.");
 
             timer_stop = timer.stop();
             rate = static_cast<double>(mBOList.size() * mSize);

--- a/src/runtime_src/core/tools/xbmgmt2/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbmgmt2/CMakeLists.txt
@@ -63,7 +63,6 @@ if (XRT_STATIC_BUILD)
   # The -static link option will pick the static libraries. 
   target_link_libraries(${XBMGMT2_NAME}_static
     PRIVATE
-    xrt_core_static
     xrt_coreutil_static
     boost_system
     boost_filesystem
@@ -78,7 +77,6 @@ endif()
 
 target_link_libraries(${XBMGMT2_NAME}
   PRIVATE
-  xrt_core
   xrt_coreutil
   ${Boost_FILESYSTEM_LIBRARY}
   ${Boost_SYSTEM_LIBRARY}

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -22,10 +22,6 @@ namespace XBU = XBUtilities;
 #include "core/common/utils.h"
 #include "flash/flasher.h"
 #include "core/common/info_vmr.h"
-// Remove linux specific code
-#ifdef __linux__
-#include "core/pcie/linux/pcidev.cpp"
-#endif
 
 // 3rd Party Library - Include Files
 #include <boost/format.hpp>

--- a/src/runtime_src/core/tools/xbmgmt2/xbmgmt.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/xbmgmt.cpp
@@ -27,14 +27,6 @@
 // Program entry
 int main( int argc, char** argv )
 {
-  // force linking with libxrt_core
-  // find a way in CMake to specify -undef <symbol>
-  try{
-    xclProbe();
-  } catch (...) {
-    xrt_core::send_exception_message("xclProbe failed");
-  }
-
   // -- Build the supported subcommands
   SubCmdsCollection subCommands;
 

--- a/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
@@ -69,7 +69,6 @@ if (XRT_STATIC_BUILD)
   # The -static link option will pick the static libraries.
   target_link_libraries(${XBUTIL2_NAME}_static
     PRIVATE
-    xrt_core_static
     xrt_coreutil_static
     boost_system
     boost_filesystem
@@ -84,7 +83,6 @@ endif()
 
 target_link_libraries(${XBUTIL2_NAME}
   PRIVATE
-  xrt_core
   xrt_coreutil
   ${Boost_FILESYSTEM_LIBRARY}
   ${Boost_SYSTEM_LIBRARY}

--- a/src/runtime_src/core/tools/xbutil2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdProgram.cpp
@@ -9,7 +9,6 @@
 #include "tools/common/XBUtilities.h"
 namespace XBU = XBUtilities;
 
-#include "xrt.h"
 #include "core/common/system.h"
 #include "core/common/device.h"
 #include "core/common/error.h"

--- a/src/runtime_src/core/tools/xbutil2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdProgram.cpp
@@ -87,7 +87,8 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
     auto xclbin_obj = xrt::xclbin{xclbin};
     try {
       device->load_xclbin(xclbin_obj);
-    } catch (const std::exception& e) {
+    }
+    catch (const std::exception& e) {
       XBUtilities::throw_cancel(boost::format("Could not program device %s : %s") % bdf % e.what());
     }
 

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -460,7 +460,8 @@ p2ptest_chunk(const std::shared_ptr<xrt_core::device>& handle, char *boptr, uint
   p2ptest_set_or_cmp(buf, buf_size, valid_data, true);
   try {
     handle->unmgd_pwrite(buf, buf_size, dev_addr);
-  } catch (const std::exception&) {
+  }
+  catch (const std::exception&) {
     return false;
   }
   if (!p2ptest_set_or_cmp(boptr, buf_size, valid_data, false))
@@ -472,7 +473,8 @@ p2ptest_chunk(const std::shared_ptr<xrt_core::device>& handle, char *boptr, uint
   p2ptest_set_or_cmp(buf, size, valid_data, true);
   try {
     handle->unmgd_pwrite(buf, buf_size, dev_addr);
-  } catch (const std::exception&) {
+  }
+  catch (const std::exception&) {
     return false;
   }
   if (!p2ptest_set_or_cmp(boptr, size, valid_data, false))
@@ -483,7 +485,8 @@ p2ptest_chunk(const std::shared_ptr<xrt_core::device>& handle, char *boptr, uint
   p2ptest_set_or_cmp(boptr, size, valid_data, true);
   try {
     handle->unmgd_pread(buf, buf_size, dev_addr);
-  } catch (const std::exception&) {
+  }
+  catch (const std::exception&) {
     return false;
   }
   if (!p2ptest_set_or_cmp(buf, size, valid_data, false))
@@ -514,14 +517,16 @@ p2ptest_chunk_no_dma(const std::shared_ptr<xrt_core::device>& handle, xrt_buffer
 
   try {
     handle->copy_bo(bop2p, boh, bo_size, 0, 0);
-  } catch (const std::exception&) {
+  }
+  catch (const std::exception&) {
     free_unmap_bo(handle, boh, boptr, bo_size);
     return false;
   }
 
   try {
     handle->sync_bo(boh, XCL_BO_SYNC_BO_TO_DEVICE, bo_size, 0);
-  } catch (const std::exception&) {
+  }
+  catch (const std::exception&) {
     free_unmap_bo(handle, boh, boptr, bo_size);
     return false;
   }
@@ -550,14 +555,16 @@ p2ptest_chunk_no_dma(const std::shared_ptr<xrt_core::device>& handle, xrt_buffer
 
   try {
     handle->copy_bo(bop2p, boh, bo_size, 0, 0);
-  } catch (const std::exception&) {
+  }
+  catch (const std::exception&) {
     free_unmap_bo(handle, boh, boptr, bo_size);
     return false;
   }
 
   try {
     handle->sync_bo(boh, XCL_BO_SYNC_BO_FROM_DEVICE, bo_size, 0);
-  } catch (const std::exception&) {
+  }
+  catch (const std::exception&) {
     free_unmap_bo(handle, boh, boptr, bo_size);
     return false;
   }
@@ -646,7 +653,8 @@ m2m_alloc_init_bo(const std::shared_ptr<xrt_core::device>& handle, boost::proper
   memset(boptr, pattern, bo_size);
   try {
     handle->sync_bo(boh, XCL_BO_SYNC_BO_FROM_DEVICE, bo_size, 0);
-  } catch (const std::exception&) {
+  }
+  catch (const std::exception&) {
     _ptTest.put("status", test_token_failed);
     logger(_ptTest, "Error", "Couldn't sync BO");
     free_unmap_bo(handle, boh, boptr, bo_size);
@@ -680,14 +688,16 @@ m2mtest_bank(const std::shared_ptr<xrt_core::device>& handle, boost::property_tr
   XBU::Timer timer;
   try {
     handle->copy_bo(bo_tgt, bo_src, bo_size, 0, 0);
-  } catch (const std::exception&) {
+  }
+  catch (const std::exception&) {
     return bandwidth;
   }
   double timer_duration_sec = timer.get_elapsed_time().count();
 
   try {
     handle->sync_bo(bo_tgt, XCL_BO_SYNC_BO_FROM_DEVICE, bo_size, 0);
-  } catch (const std::exception&) {
+  }
+  catch (const std::exception&) {
     free_unmap_bo(handle, bo_src, bo_src_ptr, bo_size);
     free_unmap_bo(handle, bo_tgt, bo_tgt_ptr, bo_size);
     _ptTest.put("status", test_token_failed);
@@ -719,7 +729,8 @@ program_xclbin(const std::shared_ptr<xrt_core::device>& device, const std::strin
   auto xclbin_obj = xrt::xclbin{xclbin};
   try {
     device->load_xclbin(xclbin_obj);
-  } catch (const std::exception& e) {
+  }
+  catch (const std::exception& e) {
     XBUtilities::throw_cancel(boost::format("Could not program device %s : %s") % bdf % e.what());
   }
 }
@@ -759,7 +770,8 @@ search_and_program_xclbin(const std::shared_ptr<xrt_core::device>& dev, boost::p
 
   try {
     program_xclbin(dev, xclbinPath, ptTest);
-  } catch (const std::exception&) {
+  }
+  catch (const std::exception&) {
     ptTest.put("status", test_token_failed);
     return false;
   }
@@ -796,7 +808,8 @@ bist_alloc_execbuf_and_wait(const std::shared_ptr<xrt_core::device>& handle, enu
 
   try {
     handle->exec_buf(boh);
-  } catch (const std::exception&) {
+  }
+  catch (const std::exception&) {
     logger(_ptTest, "Error", "Couldn't map BO");
     return false;
   }

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -472,7 +472,7 @@ p2ptest_chunk(const std::shared_ptr<xrt_core::device>& handle, char *boptr, uint
   valid_data.push_back('A');
   p2ptest_set_or_cmp(buf, size, valid_data, true);
   try {
-    handle->unmgd_pwrite(buf, buf_size, dev_addr);
+    handle->unmgd_pwrite(buf, size, dev_addr);
   }
   catch (const std::exception&) {
     return false;
@@ -484,7 +484,7 @@ p2ptest_chunk(const std::shared_ptr<xrt_core::device>& handle, char *boptr, uint
   valid_data.push_back('B');
   p2ptest_set_or_cmp(boptr, size, valid_data, true);
   try {
-    handle->unmgd_pread(buf, buf_size, dev_addr);
+    handle->unmgd_pread(buf, size, dev_addr);
   }
   catch (const std::exception&) {
     return false;

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -723,7 +723,7 @@ m2mtest_bank(const std::shared_ptr<xrt_core::device>& handle, boost::property_tr
 }
 
 static void
-program_xclbin(const std::shared_ptr<xrt_core::device>& device, const std::string& xclbin, boost::property_tree::ptree& _ptTest)
+program_xclbin(const std::shared_ptr<xrt_core::device>& device, const std::string& xclbin)
 {
   auto bdf = xrt_core::query::pcie_bdf::to_string(xrt_core::device_query<xrt_core::query::pcie_bdf>(device));
   auto xclbin_obj = xrt::xclbin{xclbin};
@@ -769,9 +769,10 @@ search_and_program_xclbin(const std::shared_ptr<xrt_core::device>& dev, boost::p
   }
 
   try {
-    program_xclbin(dev, xclbinPath, ptTest);
+    program_xclbin(dev, xclbinPath);
   }
-  catch (const std::exception&) {
+  catch (const std::exception& e) {
+    logger(ptTest, "Error", e.what());
     ptTest.put("status", test_token_failed);
     return false;
   }

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -1040,7 +1040,7 @@ dmaTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree::ptr
     else
       totalSize = std::min((mem.m_size * 1024), 2_gb); // minimum of mem size in bytes and 2 GB
 
-    xcldev::DMARunner runner(_dev->get_device_handle(), block_size, static_cast<unsigned int>(midx), totalSize);
+    xcldev::DMARunner runner(_dev, block_size, static_cast<unsigned int>(midx), totalSize);
     try {
       runner.run(run_details);
       _ptTest.put("status", test_token_passed);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
MCDM and future repository implementations will not provide libxrt_core for compilation. xbutil/xbmgmt should rely only on libxrt_coreutil, and libxrt_coreutil communicates with libxrt_core. Before integrating XRT into MCDM and others we must remove this dependency first.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
XRT-MCDM does not export xrt_core functions and it should not. As a result, xbutil cannot compile in that environment even though it should,

#### How problem was solved, alternative solutions (if any) and why they were rejected
Removed xrt_core from xbutil/xbmgmt CMake files. Replace xrt_core function calls with xrt_coreutil functions calls.

#### Risks (if any) associated the changes in the commit
None, assuming I did it right

#### What has been tested and how, request additional testing if necessary
Ubuntu 20.04 
xbutil examine
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov/XRT$ xbutil examine
WARNING: Unexpected xocl version (2.14.0) was found. Expected 2.15.0, to match XRT tools.
System Configuration
  OS Name              : Linux
  Release              : 5.4.0-126-generic
  Version              : #142-Ubuntu SMP Fri Aug 26 12:12:57 UTC 2022
  Machine              : x86_64
  CPU Cores            : 16
  Memory               : 64007 MB
  Distribution         : Ubuntu 20.04.1 LTS
  GLIBC                : 2.31
  Model                : Precision 5820 Tower

XRT
  Version              : 2.15.0
  Branch               : remove-libxrtcore
  Hash                 : c56f8615c7ae3b908b3f3a15f4e3b1fd9562c95f
  Hash Date            : 2023-02-01 15:37:07
  XOCL                 : 2.14.0, a3befd1ac0b78555ee7150a3199795ed9b49887a
  XCLMGMT              : 2.14.0, a3befd1ac0b78555ee7150a3199795ed9b49887a

Devices present
BDF             :  Shell                              Platform UUID                         Device ID       Device Ready*
---------------------------------------------------------------------------------------------------------------------------
[0000:17:00.1]  :  xilinx_vck5000_gen4x8_qdma_base_2  05DCA096-76CB-730B-8D19-EC1192FBAE3F  user(inst=129)  Yes
```
xbutil validate
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov/XRT$ xbutil validate -d 17:00
WARNING: Unexpected xocl version (2.14.0) was found. Expected 2.15.0, to match XRT tools.
***********************************************************
*        WARNING          WARNING          WARNING        *
*  SC version data missing. Expected: N/A Current: 4.4.35 *
***********************************************************
Validate Device           : [0000:17:00.1]
    Platform              : xilinx_vck5000_gen4x8_qdma_base_2
    SC Version            : 4.4.35
    Platform ID           : 05DCA096-76CB-730B-8D19-EC1192FBAE3F
-------------------------------------------------------------------------------
Test 1 [0000:17:00.1]     : pcie-link
    Warning(s)            : Link is active
                            Please make sure that the device is plugged into Gen 4x8,
                            instead of Gen 3x8. Lower performance maybe experienced.
    Test Status           : [PASSED WITH WARNINGS]
-------------------------------------------------------------------------------
Test 2 [0000:17:00.1]     : sc-version
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Test 3 [0000:17:00.1]     : verify
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Test 4 [0000:17:00.1]     : dma
    Details               : Buffer size - '16 MB'
                            Host -> PCIe -> FPGA write bandwidth = 6527.5 MB/s
                            Host <- PCIe <- FPGA read bandwidth = 6616.9 MB/s
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Test 5 [0000:17:00.1]     : iops
    Details               : IOPS: 132921 (verify)
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Test 6 [0000:17:00.1]     : mem-bw
    Details               : Throughput (Type: DDR) (Bank count: 1) : 20729.7MB/s
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Test 7 [0000:17:00.1]     : p2p
Test 8 [0000:17:00.1]     : vcu
Test 9 [0000:17:00.1]     : aie-pl
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Validation completed, but with warnings. Please run the command '--verbose' option for more details
```
xbmgmt examine
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov/XRT$ xbmgmt examine
WARNING: Unexpected xclmgmt version (2.14.0) was found. Expected 2.15.0, to match XRT tools.
System Configuration
  OS Name              : Linux
  Release              : 5.4.0-126-generic
  Version              : #142-Ubuntu SMP Fri Aug 26 12:12:57 UTC 2022
  Machine              : x86_64
  CPU Cores            : 16
  Memory               : 64007 MB
  Distribution         : Ubuntu 20.04.1 LTS
  GLIBC                : 2.31
  Model                : Precision 5820 Tower

XRT
  Version              : 2.15.0
  Branch               : remove-libxrtcore
  Hash                 : c56f8615c7ae3b908b3f3a15f4e3b1fd9562c95f
  Hash Date            : 2023-02-01 15:37:07
  XOCL                 : 2.14.0, a3befd1ac0b78555ee7150a3199795ed9b49887a
  XCLMGMT              : 2.14.0, a3befd1ac0b78555ee7150a3199795ed9b49887a

Devices present
BDF             :  Shell                              Platform UUID                         Device ID        Device Ready*
----------------------------------------------------------------------------------------------------------------------------
[0000:17:00.0]  :  xilinx_vck5000_gen4x8_qdma_base_2  05DCA096-76CB-730B-8D19-EC1192FBAE3F  mgmt(inst=5888)  Yes
```
#### Documentation impact (if any)
None