### PR TITLE
CR-1151706 XRT service bundle for collecting analytics data

### DIFF
--- a/src/runtime_src/tools/scripts/CMakeLists.txt
+++ b/src/runtime_src/tools/scripts/CMakeLists.txt
@@ -11,6 +11,7 @@ set(XRT_LOADER_SCRIPTS
   loader)
 
 set (XRT_SCRIPTS
+  service_bundle.sh
   plp_program.sh)
 
 else()

--- a/src/runtime_src/tools/scripts/service_bundle.sh
+++ b/src/runtime_src/tools/scripts/service_bundle.sh
@@ -1,0 +1,159 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2019-2021 Xilinx, Inc. All rights reserved.
+#
+# This script program plp based on input xclbin
+# This will be obsoleted after plp auto download is fully impletmented
+
+TIME=`date +%F-%T`
+ID=`id -un`
+FULL_CMD=${BASH_SOURCE[0]}
+BASE_CMD=`basename "$0"`
+
+progress() {
+	echo "running: $func - progress: $(($1+1))/$2"
+	#echo -ne "running: $func - progress: \b\b\b$(($1+1))/$(($2+1))\b\b\b"
+}
+
+usage() {
+    echo "Usage: $BASE_CMD [options]"
+    echo "  options:"
+    echo "  --out, -o           output directory"
+    echo "  --device, -d        card device bdf"
+    echo "  --verbose, -v       verbose output"
+    exit $1
+}
+
+while [ $# -gt 0 ]; do
+	case "$1" in
+		-help)
+			usage 0
+			;;
+		-o | --out)
+			shift
+			PATH_TO_OUTPUT=$1
+			;;
+		-d | --device)
+			shift
+			DEVICE_BDF=$1
+			;;
+		-v | --verbose)
+			VERBOSE=1
+			;;
+		* | -* | --*)
+			echo "$1 invalid argument."
+			usage 1
+			;;
+	esac
+	shift
+done
+
+
+#############################
+# Funcs start here
+#############################
+xbutil_output()
+{
+	xbutil examine -d $DEVICE_BDF:0 > $1/xbutil_examine.txt
+	xbutil examine -d $DEVICE_BDF:0 -r all > $1/xbutil_examine_all.txt
+	xbutil validate -d $DEVICE_BDF:0 --verbose> $1/xbutil_validate.txt
+}
+
+xbmgmt_output()
+{
+	xbmgmt examine > $1/xbmgmt_examine.txt
+	xbmgmt examine -d $DEVICE_BDF:0 >> $1/xbmgmt_examine.txt
+
+	xbmgmt examine -d $DEVICE_BDF:0 -r all > $1/xbmgmt_examine_all.txt
+}
+
+debug_logs()
+{
+	dmesg -T > $1/dmesg_current.txt
+	cp /var/log/dmesg* $1/
+	cp /var/log/syslog* $1/
+	cat /sys/kernel/debug/xclmgmt/trace > $1/sys_kernel_debug_xclmgmt.txt &
+	PID1=$!
+	cat /sys/kernel/debug/xocl/trace > $1/sys_kernel_debug_xocl.txt &
+	PID2=$!
+	sleep 2
+	kill $PID1
+	kill $PID2
+}
+
+vmr_logs()
+{
+	xbmgmt examine -d $DEVICE_BDF:0 -r vmr --verbose > $1/xbmgmt_vmr_verbose.txt
+	
+	VMR_SYSFS="/sys/bus/pci/devices/0000\:$DEVICE_BDF\:00.0/xgq_vmr.m.*/"
+
+	nodeArray=(
+		vmr_endpoint
+		vmr_log
+		vmr_mem_stats
+		vmr_plm_log
+		vmr_status
+		vmr_system_dtb
+		vmr_task_stats
+		vmr_verbose_info
+	)
+
+	for node in "${nodeArray[@]}"
+	do
+		sys_node=`ls $VMR_SYSFS/$node`
+		cp $sys_node $1/
+	done
+}
+
+funcArray=(
+	vmr_logs
+	debug_logs
+	xbmgmt_output
+	xbutil_output
+)
+#############################
+# Read program starts here
+#############################
+
+if [ -z $DEVICE_BDF ];then
+	echo "Please select one device"
+	usage 0
+fi
+
+XRT_PATH=`which xbmgmt > /dev/null`
+if [ $? -ne 0 ];then
+	echo "XRT is not found, using default XRT"
+	source /opt/xilinx/xrt/setup.sh > /dev/null
+	XRT_PATH=`which xbmgmt > /dev/null`
+else
+	echo "using configured XRT"
+fi
+echo "$XRT_PATH"
+
+if [ -z $PATH_TO_OUTPUT];then
+	PATH_TO_OUTPUT="."
+fi
+
+PATH_TO_OUTPUT=$PATH_TO_OUTPUT/xrt_bundle
+
+#a=${!funcArray[@]}
+total=${#funcArray[@]}
+index=0
+for func in "${funcArray[@]}"
+do
+	progress $index $total $func
+
+	if [ ! -d $PATH_TO_OUTPUT/$func ];then
+		mkdir -p "$PATH_TO_OUTPUT/$func"
+	fi
+
+	$func "$PATH_TO_OUTPUT/$func"
+
+	((index++))
+done
+
+echo "$BASE_CMD finished"
+if [ ! -z $VERBOSE ];then
+	tree $PATH_TO_OUTPUT
+fi

--- a/src/runtime_src/tools/scripts/service_bundle.sh
+++ b/src/runtime_src/tools/scripts/service_bundle.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (C) 2019-2021 Xilinx, Inc. All rights reserved.
+# Copyright (C) 2019-2023 Xilinx, Inc. All rights reserved.
 #
 # This script collects debugging logs for XRT managed sub-systems
 
@@ -10,9 +10,9 @@ ID=`id -un`
 FULL_CMD=${BASH_SOURCE[0]}
 BASE_CMD=`basename "$0"`
 
+# $1 index, $2 total, $3 func name
 progress() {
-	echo -n "running: $func - progress: $(($1+1))/$2"
-	#echo -ne "running: $func - progress: \b\b\b$(($1+1))/$(($2+1))\b\b\b"
+	echo -n "running: $3 - progress: $(($1+1))/$2"
 }
 
 usage() {
@@ -57,6 +57,8 @@ done
 #############################
 # Funcs start here
 #############################
+
+# $1 output directory
 core_dumps()
 {
 	if [ -z $ALL_LOG ];then
@@ -79,6 +81,7 @@ core_dumps()
 	fi
 }
 
+# $1 output directory
 xbutil_output()
 {
 	xbutil examine -d $DEVICE_BDF:0 > $1/xbutil_examine.txt
@@ -86,6 +89,7 @@ xbutil_output()
 	xbutil validate -d $DEVICE_BDF:0 -r quick --verbose> $1/xbutil_validate.txt
 }
 
+# $1 output directory
 xbmgmt_output()
 {
 	xbmgmt examine > $1/xbmgmt_examine.txt
@@ -94,6 +98,7 @@ xbmgmt_output()
 	xbmgmt examine -d $DEVICE_BDF:0 -r all > $1/xbmgmt_examine_all.txt
 }
 
+# $1 output directory
 debug_logs()
 {
 	mkdir -p $1/var/log/
@@ -121,6 +126,7 @@ debug_logs()
 	kill -s 2 $PID2
 }
 
+# $1 output directory
 vmr_logs()
 {
 	xbmgmt examine -d $DEVICE_BDF:0 -r vmr --verbose > $1/xbmgmt_vmr_verbose.txt
@@ -145,6 +151,7 @@ vmr_logs()
 	done
 }
 
+# $1 output directory
 host_info()
 {
 	cat /proc/iomem > $1/proc_iomem.txt
@@ -165,6 +172,9 @@ host_info()
 	kill -s 2 $PID3
 }
 
+#
+# all collecting methods should be defined in this array
+#
 funcArray=(
 	host_info
 	xbmgmt_output

--- a/src/runtime_src/tools/scripts/service_bundle.sh
+++ b/src/runtime_src/tools/scripts/service_bundle.sh
@@ -214,7 +214,6 @@ fi
 PATH_TO_BUNDLE=$PATH_TO_OUTPUT/xrt_bundle
 echo "dump into: $PATH_TO_BUNDLE"
 
-#a=${!funcArray[@]}
 total=${#funcArray[@]}
 index=0
 for func in "${funcArray[@]}"

--- a/src/runtime_src/tools/scripts/service_bundle.sh
+++ b/src/runtime_src/tools/scripts/service_bundle.sh
@@ -11,7 +11,7 @@ FULL_CMD=${BASH_SOURCE[0]}
 BASE_CMD=`basename "$0"`
 
 progress() {
-	echo "running: $func - progress: $(($1+1))/$2"
+	echo -n "running: $func - progress: $(($1+1))/$2"
 	#echo -ne "running: $func - progress: \b\b\b$(($1+1))/$(($2+1))\b\b\b"
 }
 
@@ -22,6 +22,7 @@ usage() {
     echo "  --device, -d        card device bdf"
     echo "  --all, -a           collect all, including large size system core dump"
     echo "  --verbose, -v       verbose output"
+    echo "Example: $BASE_CMD -d 9f"
     exit $1
 }
 
@@ -56,11 +57,33 @@ done
 #############################
 # Funcs start here
 #############################
+core_dumps()
+{
+	if [ -z $ALL_LOG ];then
+		echo -n " - skipped: -a to enable"
+		return 0
+	fi
+
+	mkdir -p $1/var/crash/
+	cp -r /var/crash/** $1/var/crash/
+	
+	mkdir -p $1/cores/
+	ls *.core > /dev/null 2>&1
+	if [ $? -eq 0 ];then
+		cp *.core $1/cores/
+	fi
+
+	ls /opt/xilinx/xrt/bin/*.core > /dev/null 2>&1
+	if [ $? -eq 0 ];then
+		cp /opt/xilinx/xrt/bin/*.core $1/cores/
+	fi
+}
+
 xbutil_output()
 {
 	xbutil examine -d $DEVICE_BDF:0 > $1/xbutil_examine.txt
 	xbutil examine -d $DEVICE_BDF:0 -r all > $1/xbutil_examine_all.txt
-	xbutil validate -d $DEVICE_BDF:0 --verbose> $1/xbutil_validate.txt
+	xbutil validate -d $DEVICE_BDF:0 -r quick --verbose> $1/xbutil_validate.txt
 }
 
 xbmgmt_output()
@@ -73,8 +96,21 @@ xbmgmt_output()
 
 debug_logs()
 {
+	mkdir -p $1/var/log/
+	cp -r /var/log/** $1/var/log/
+
+	for xclmgmt in `ls /sys/module/xclmgmt/parameters/`
+	do
+		cat /sys/module/xclmgmt/parameters/$xclmgmt > $1/xclmgmt_parameters_$xclmgmt.txt
+	done
+
+	for xocl in `ls /sys/module/xocl/parameters/`
+	do
+		cat /sys/module/xocl/parameters/$xocl > $1/xocl_parameters_$xocl.txt
+	done
+
 	dmesg -T > $1/dmesg_current.txt
-	cp -r /var/log/** $1/
+
 	cat /sys/kernel/debug/xclmgmt/trace > $1/sys_kernel_debug_xclmgmt.txt &
 	PID1=$!
 	cat /sys/kernel/debug/xocl/trace > $1/sys_kernel_debug_xocl.txt &
@@ -109,11 +145,33 @@ vmr_logs()
 	done
 }
 
+host_info()
+{
+	cat /proc/iomem > $1/proc_iomem.txt
+	cat /proc/interrupts > $1/proc_interrupts.txt
+
+	uname -a > $1/uname_a.txt
+	lsb_release -d > $1/lsb_release_d.txt
+	lscpu > $1/lscpu.txt
+	lsmem > $1/lsmem.txt
+	lspci > $1/lspci.txt
+	lspci -vvv > $1/lspci_vvv.txt
+	lsblk > $1/lsblk.txt
+	vmstat -s > $1/vmstat_s.txt
+
+	top -b > $1/top.txt &
+	PID3=$!
+	sleep 2
+	kill -s 2 $PID3
+}
+
 funcArray=(
-	vmr_logs
-	debug_logs
+	host_info
 	xbmgmt_output
 	xbutil_output
+	vmr_logs
+	debug_logs
+	core_dumps
 )
 
 #############################
@@ -123,23 +181,28 @@ funcArray=(
 if [ -z $DEVICE_BDF ];then
 	echo "Please select one device"
 	usage 0
-fi
-
-XRT_PATH=`which xbmgmt > /dev/null`
-if [ $? -ne 0 ];then
-	echo "XRT is not found, using default XRT"
-	source /opt/xilinx/xrt/setup.sh > /dev/null
-	XRT_PATH=`which xbmgmt > /dev/null`
 else
-	echo "using configured XRT"
+	if [[ "$DEVICE_BDF" == *":"* ]] || [[ "$DEVICE_BDF" == *"."* ]];then
+		echo "only support single bdf without : or . now"
+		usage 0
+	fi
+	echo "card: $DEVICE_BDF"
 fi
-echo "$XRT_PATH"
 
-if [ -z $PATH_TO_OUTPUT];then
+which xbmgmt > /dev/null
+if [ $? -ne 0 ];then
+	echo "XRT is not found, use default XRT"
+	source /opt/xilinx/xrt/setup.sh > /dev/null
+else
+	echo "use configured XRT"
+fi
+
+if [ -z $PATH_TO_OUTPUT ];then
 	PATH_TO_OUTPUT="."
 fi
 
-PATH_TO_OUTPUT=$PATH_TO_OUTPUT/xrt_bundle
+PATH_TO_BUNDLE=$PATH_TO_OUTPUT/xrt_bundle
+echo "dump into: $PATH_TO_BUNDLE"
 
 #a=${!funcArray[@]}
 total=${#funcArray[@]}
@@ -148,16 +211,26 @@ for func in "${funcArray[@]}"
 do
 	progress $index $total $func
 
-	if [ ! -d $PATH_TO_OUTPUT/$func ];then
-		mkdir -p "$PATH_TO_OUTPUT/$func"
+	if [ ! -d $PATH_TO_BUNDLE/$func ];then
+		mkdir -p "$PATH_TO_BUNDLE/$func"
 	fi
 
-	$func "$PATH_TO_OUTPUT/$func"
+	$func "$PATH_TO_BUNDLE/$func"
+	echo "."
 
 	((index++))
 done
 
-echo "$BASE_CMD finished"
+echo "packaging data..."
+FROMSIZE=`du -sk --apparent-size $PATH_TO_BUNDLE |cut -f 1`;
+CHECKPOINT=`echo ${FROMSIZE}/50 |bc`
+echo "Estimated: [==================================================]"
+echo -n "Progress:  [";
+tar --record-size=1K --checkpoint="${CHECKPOINT}" --checkpoint-action="ttyout=>" -czf $PATH_TO_OUTPUT/xrt_bundle.tar.gz --absolute-names $PATH_TO_BUNDLE
+echo "]"
+realpath $PATH_TO_OUTPUT/xrt_bundle.tar.gz
+du -sh $PATH_TO_OUTPUT/xrt_bundle.tar.gz|cut -f1
+
 if [ ! -z $VERBOSE ];then
-	tree $PATH_TO_OUTPUT
+	tree $PATH_TO_BUNDLE
 fi


### PR DESCRIPTION
Signed-off-by: David Zhang <davidzha@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

More work needed to make sure this script works across different OS versions.
example of a typical service bundle

```
# /proj/rdi/staff/davidzha/XRT_ssh/src/runtime_src/tools/scripts/service_bundle.sh -d d9
card: d9
use configured XRT
dump into: ./xrt_bundle
running: host_info - progress: 1/6.
running: xbmgmt_output - progress: 2/6.
running: xbutil_output - progress: 3/6.
running: vmr_logs - progress: 4/6.
running: debug_logs - progress: 5/6.
running: core_dumps - progress: 6/6 - skipped: -a to enable.
packaging data...
Estimated: [==================================================]
Progress:  [>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>]
/root/xrt_bundle.tar.gz
11M

[root@xsjyliu51 ~]# tree xrt_bundle
xrt_bundle
├── core_dumps
├── debug_logs
│   ├── dmesg_current.txt
│   ├── sys_kernel_debug_xclmgmt.txt
│   ├── sys_kernel_debug_xocl.txt
│   ├── var
│   │   └── log
│   │       ├── anaconda
│   │       │   ├── anaconda.log
│   │       │   ├── dbus.log
│   │       │   ├── dnf.librepo.log
[trimmed]
│   ├── xclmgmt_parameters_health_check.txt
│   ├── xclmgmt_parameters_health_interval.txt
│   ├── xclmgmt_parameters_mailbox_no_intr.txt
│   ├── xclmgmt_parameters_mailbox_test_mode.txt
│   ├── xclmgmt_parameters_minimum_initialization.txt
│   ├── xclmgmt_parameters_rom_uuid.txt
│   ├── xclmgmt_parameters_vmr_sc_ready_timeout.txt
│   ├── xclmgmt_parameters_xrt_debug_bufsize.txt
│   ├── xclmgmt_parameters_xrt_reset_syncup.txt
│   ├── xocl_parameters_desc_blen_max.txt
│   ├── xocl_parameters_desc_set_depth.txt
│   ├── xocl_parameters_enable_credit_mp.txt
│   ├── xocl_parameters_interrupt_mode.txt
│   ├── xocl_parameters_mailbox_no_intr.txt
│   ├── xocl_parameters_mailbox_test_mode.txt
│   ├── xocl_parameters_p2p_max_bar_size.txt
│   ├── xocl_parameters_poll_mode.txt
│   ├── xocl_parameters_qdma_interrupt_mode.txt
│   ├── xocl_parameters_qdma_max_channel.txt
│   ├── xocl_parameters_rom_uuid.txt
│   ├── xocl_parameters_xrt_debug_bufsize.txt
│   └── xocl_parameters_xrt_reset_syncup.txt
├── host_info
│   ├── lsblk.txt
│   ├── lsb_release_d.txt
│   ├── lsb_release.txt
│   ├── lscpu.txt
│   ├── lsmem.txt
│   ├── lspci.txt
│   ├── lspci_vvv.txt
│   ├── proc_interrupts.txt
│   ├── proc_iomem.txt
│   ├── top.txt
│   ├── uname_a.txt
│   └── vmstat_s.txt
├── vmr_logs
│   ├── vmr_endpoint
│   ├── vmr_log
│   ├── vmr_mem_stats
│   ├── vmr_plm_log
│   ├── vmr_status
│   ├── vmr_system_dtb
│   ├── vmr_task_stats
│   ├── vmr_verbose_info
│   └── xbmgmt_vmr_verbose.txt
├── xbmgmt_output
│   ├── xbmgmt_examine_all.txt
│   └── xbmgmt_examine.txt
└── xbutil_output
    ├── xbutil_examine_all.txt
    ├── xbutil_examine.txt
    └── xbutil_validate.txt
```
example of a run with core dump
```
# /proj/rdi/staff/davidzha/XRT_ssh/src/runtime_src/tools/scripts/service_bundle.sh -d 81 -o /root/test1 -a
card: 81
XRT is not found, use default XRT
dump into: /root/test1/xrt_bundle
running: host_info - progress: 1/6.
running: xbmgmt_output - progress: 2/6.
running: xbutil_output - progress: 3/6.
running: vmr_logs - progress: 4/6.
running: debug_logs - progress: 5/6.
running: core_dumps - progress: 6/6.
packaging data...
Estimated: [==================================================]
Progress:  [>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>]
/root/test1/xrt_bundle.tar.gz
340M

oot@xsjdavidz01:~# tree test1
test1
├── xrt_bundle
│   ├── core_dumps
│   │   ├── cores
│   │   │   └── test.core
│   │   └── var
│   │       └── crash
│   │           └── _opt_xilinx_xrt_test_validate.exe.0.crash
│   ├── debug_logs
│   │   ├── dmesg_current.txt
│   │   ├── sys_kernel_debug_xclmgmt.txt
│   │   ├── sys_kernel_debug_xocl.txt

[trimmed]
```
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
