### PR TITLE
CR-1150426

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_profile_new/CMakeLists.txt
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile_new/CMakeLists.txt
@@ -25,8 +25,8 @@ file(GLOB AIE_PROFILE_PLUGIN_FILES
 if (${XRT_NATIVE_BUILD} STREQUAL "yes")
 
   add_library(xdp_aie_profile_plugin MODULE ${AIE_PROFILE_PLUGIN_FILES})
-  add_dependencies(xdp_aie_profile_plugin xdp_core xrt_core)
-  target_link_libraries(xdp_aie_profile_plugin PRIVATE xdp_core xrt_core)
+  add_dependencies(xdp_aie_profile_plugin xdp_core xrt_coreutil)
+  target_link_libraries(xdp_aie_profile_plugin PRIVATE xdp_core xrt_coreutil)
   target_compile_definitions(xdp_aie_profile_plugin PRIVATE XRT_X86_BUILD=1)
 
   set_target_properties(xdp_aie_profile_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
@@ -38,8 +38,8 @@ if (${XRT_NATIVE_BUILD} STREQUAL "yes")
 elseif (DEFINED XRT_AIE_BUILD AND ${XRT_NATIVE_BUILD} STREQUAL "no")
   add_library(xdp_aie_profile_plugin MODULE ${AIE_PROFILE_PLUGIN_FILES})
 
-  add_dependencies(xdp_aie_profile_plugin xdp_core xrt_core)
-  target_link_libraries(xdp_aie_profile_plugin PRIVATE xdp_core xrt_core metal xaiengine)
+  add_dependencies(xdp_aie_profile_plugin xdp_core xrt_coreutil)
+  target_link_libraries(xdp_aie_profile_plugin PRIVATE xdp_core xrt_coreutil metal xaiengine)
   set_target_properties(xdp_aie_profile_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
 
   install (TARGETS xdp_aie_profile_plugin

--- a/src/runtime_src/xdp/profile/plugin/aie_trace_new/CMakeLists.txt
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace_new/CMakeLists.txt
@@ -31,8 +31,8 @@ if (${XRT_NATIVE_BUILD} STREQUAL "yes")
 
   add_library(xdp_aie_trace_plugin MODULE ${AIE_TRACE_PLUGIN_FILES})
 
-  add_dependencies(xdp_aie_trace_plugin xdp_core xrt_core)
-  target_link_libraries(xdp_aie_trace_plugin PRIVATE xdp_core xrt_core)
+  add_dependencies(xdp_aie_trace_plugin xdp_core xrt_coreutil)
+  target_link_libraries(xdp_aie_trace_plugin PRIVATE xdp_core xrt_coreutil)
   target_compile_definitions(xdp_aie_trace_plugin PRIVATE XRT_X86_BUILD=1)
 
   set_target_properties(xdp_aie_trace_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
@@ -45,8 +45,8 @@ elseif (DEFINED XRT_AIE_BUILD AND ${XRT_NATIVE_BUILD} STREQUAL "no")
 
   add_library(xdp_aie_trace_plugin MODULE ${AIE_TRACE_PLUGIN_FILES})
 
-  add_dependencies(xdp_aie_trace_plugin xdp_core xrt_core)
-  target_link_libraries(xdp_aie_trace_plugin PRIVATE xdp_core xrt_core metal xaiengine)
+  add_dependencies(xdp_aie_trace_plugin xdp_core xrt_coreutil)
+  target_link_libraries(xdp_aie_trace_plugin PRIVATE xdp_core xrt_coreutil metal xaiengine)
   set_target_properties(xdp_aie_trace_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
 
   install (TARGETS xdp_aie_trace_plugin


### PR DESCRIPTION
#### Problem solved by the commit
Fixed issues in hw_emu when aie_profile=true is set in xrt.ini

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
hw_emu was crashing when aie_profile was enabled. 

#### How problem was solved, alternative solutions (if any) and why they were rejected
Changed xdp_aie_profile_plugin and xdp_aie_trace_plugin to be linked with xrt_coreutil instead of xrt_core 

#### Risks (if any) associated the changes in the commit
AIE Profile and AIE Trace
