### PR TITLE
CR-1151159, CR-1150787, Fixed CU subdevice issue for legacy case

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -1903,6 +1903,10 @@ static int xocl_kds_update_legacy(struct xocl_dev *xdev, struct drm_xocl_kds cfg
 		return -ENOMEM;
 
 	num_cus = xocl_kds_fill_cu_info(xdev, 0, ip_layout, cu_info, MAX_CUS);
+
+	/* We have to reserve the subdevices before create them */
+	xocl_kds_reserve_cu_subdevices(xdev, cu_info, num_cus);
+
 	xocl_kds_create_cus(xdev, cu_info, num_cus);
 
 	ret = xocl_ert_user_bulletin(xdev, &brd);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
 -- For legacy ERT case when APU is not installed  mem-bw test is failing. 
 -- Fixed this issue. Both the CRs having same issue. 

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
-- CR-1151159
-- CR-1150787,
#### How problem was solved, alternative solutions (if any) and why they were rejected
-- As per the new architecture we need to reserve the CU subdevice indexes before create them 
-- Same is taken care for V70 XGQ case but for legacy case  same is missing. 
-- Added that for both the cases

#### Risks (if any) associated the changes in the commit
-- N/A

#### What has been tested and how, request additional testing if necessary
-- Basic Validation test cases

#### Documentation impact (if any)
-- N/A