### PR TITLE
CR-1152356 Remove xmc from V70 subdev resource list

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
@@ -1,5 +1,6 @@
 /*
  *  Copyright (C) 2018-2022, Xilinx Inc
+ *  Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  *  This file is dual licensed.  It may be redistributed and/or modified
  *  under the terms of the Apache 2.0 License OR version 2 of the GNU
@@ -2649,6 +2650,12 @@ struct xocl_subdev_map {
 		XOCL_DEVINFO_XMC_USER,					\
 	 })
 
+#define RES_USER_V70_VSEC						\
+	((struct xocl_subdev_info []) {					\
+		XOCL_DEVINFO_FEATURE_ROM_USER_DYN,			\
+		XOCL_DEVINFO_ICAP_USER,					\
+	 })
+
 #define RES_MGMT_U2_VSEC						\
 	((struct xocl_subdev_info []) {					\
 		XOCL_DEVINFO_FEATURE_ROM_MGMT_DYN,			\
@@ -2931,8 +2938,8 @@ struct xocl_subdev_map {
 		.flags = XOCL_DSAFLAG_DYNAMIC_IP |			\
 			XOCL_DSAFLAG_VERSAL_ES3 |			\
 			XOCL_DSAFLAG_VERSAL,				\
-		.subdev_info = RES_USER_VERSAL_VSEC,			\
-		.subdev_num = ARRAY_SIZE(RES_USER_VERSAL_VSEC),		\
+		.subdev_info = RES_USER_V70_VSEC,			\
+		.subdev_num = ARRAY_SIZE(RES_USER_V70_VSEC),		\
 		.board_name = "v70",				\
 		.vbnv       = "xilinx_v70"				\
 	}


### PR DESCRIPTION
Signed-off-by: Rajkumar Rampelli <rampelli@amd.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
xmc subdev is getting initialized on v70 devices, but it is not expected behavior. XMC shouldn't be invoked for v70 case.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1152356
#### How problem was solved, alternative solutions (if any) and why they were rejected
Removed xmc from v70 subdev resource list.
#### Risks (if any) associated the changes in the commit
NA
#### What has been tested and how, request additional testing if necessary
verified it on v70, xmc is not invoked.
#### Documentation impact (if any)
NA