### PR TITLE
Refactor qos_type to cfg_param_type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ a.out
 a.xclbin
 vivado.log
 vivado.jou
+/.vs

--- a/src/runtime_src/core/common/api/xrt_hw_context.cpp
+++ b/src/runtime_src/core/common/api/xrt_hw_context.cpp
@@ -21,22 +21,23 @@ namespace xrt {
 //
 class hw_context_impl
 {
-  using qos_type = xrt::hw_context::qos_type;
+  using cfg_param_type = xrt::hw_context::cfg_param_type;
+  using qos_type = cfg_param_type;
   using access_mode = xrt::hw_context::access_mode;
 
   std::shared_ptr<xrt_core::device> m_core_device;
   xrt::xclbin m_xclbin;
-  qos_type m_qos;
+  cfg_param_type m_cfg_param;
   access_mode m_mode;
   std::unique_ptr<xrt_core::hwctx_handle> m_hdl;
 
 public:
-  hw_context_impl(std::shared_ptr<xrt_core::device> device, const xrt::uuid& xclbin_id, const qos_type& qos)
+  hw_context_impl(std::shared_ptr<xrt_core::device> device, const xrt::uuid& xclbin_id, const cfg_param_type& cfg_param)
     : m_core_device(std::move(device))
     , m_xclbin(m_core_device->get_xclbin(xclbin_id))
-    , m_qos(qos)
+    , m_cfg_param(cfg_param)
     , m_mode(xrt::hw_context::access_mode::shared)
-    , m_hdl{m_core_device->create_hw_context(xclbin_id, m_qos, m_mode)}
+    , m_hdl{m_core_device->create_hw_context(xclbin_id, m_cfg_param, m_mode)}
   {
   }
 
@@ -44,7 +45,7 @@ public:
     : m_core_device{std::move(device)}
     , m_xclbin{m_core_device->get_xclbin(xclbin_id)}
     , m_mode{mode}
-    , m_hdl{m_core_device->create_hw_context(xclbin_id, m_qos, m_mode)}
+    , m_hdl{m_core_device->create_hw_context(xclbin_id, m_cfg_param, m_mode)}
   {}
 
 void
@@ -117,8 +118,8 @@ set_exclusive(xrt::hw_context& hwctx)
 namespace xrt {
 
 hw_context::
-hw_context(const xrt::device& device, const xrt::uuid& xclbin_id, const xrt::hw_context::qos_type& qos)
-  : detail::pimpl<hw_context_impl>(std::make_shared<hw_context_impl>(device.get_handle(), xclbin_id, qos))
+hw_context(const xrt::device& device, const xrt::uuid& xclbin_id, const xrt::hw_context::cfg_param_type& cfg_param)
+  : detail::pimpl<hw_context_impl>(std::make_shared<hw_context_impl>(device.get_handle(), xclbin_id, cfg_param))
 {}
 
 

--- a/src/runtime_src/core/common/ishim.h
+++ b/src/runtime_src/core/common/ishim.h
@@ -150,7 +150,7 @@ struct ishim
   // was explicitly loaded using load_xclbin
   virtual std::unique_ptr<hwctx_handle>
   create_hw_context(const xrt::uuid& /*xclbin_uuid*/,
-                    const xrt::hw_context::qos_type& /*qos*/,
+                    const xrt::hw_context::cfg_param_type& /*cfg_params*/,
                     xrt::hw_context::access_mode /*mode*/) const = 0;
 
   // Registers an xclbin with shim, but does not load it.

--- a/src/runtime_src/core/edge/sw_emu/generic_pcie_hal2/device_swemu.h
+++ b/src/runtime_src/core/edge/sw_emu/generic_pcie_hal2/device_swemu.h
@@ -33,10 +33,10 @@ public:
 
   virtual std::unique_ptr<hwctx_handle>
   create_hw_context(const xrt::uuid& xclbin_uuid,
-                    const xrt::hw_context::qos_type& qos,
+                    const xrt::hw_context::cfg_param_type& cfg_param,
                     xrt::hw_context::access_mode mode) const override
   {
-    return xrt::shim_int::create_hw_context(get_device_handle(), xclbin_uuid, qos, mode);
+    return xrt::shim_int::create_hw_context(get_device_handle(), xclbin_uuid, cfg_param, mode);
   }
 
 private:

--- a/src/runtime_src/core/edge/sw_emu/generic_pcie_hal2/halapi.cxx
+++ b/src/runtime_src/core/edge/sw_emu/generic_pcie_hal2/halapi.cxx
@@ -30,11 +30,11 @@ namespace xrt::shim_int {
 std::unique_ptr<xrt_core::hwctx_handle>
 create_hw_context(xclDeviceHandle handle,
                   const xrt::uuid& xclbin_uuid,
-                  const xrt::hw_context::qos_type& qos,
-                  xrt::hw_context::access_mode mode)
+                  const xrt::hw_context::cfg_param_type& cfg_param,
+    xrt::hw_context::access_mode mode)
 {
-  auto shim = get_shim_object(handle);
-  return shim->create_hw_context(xclbin_uuid, qos, mode);
+    auto shim = get_shim_object(handle);
+    return shim->create_hw_context(xclbin_uuid, cfg_param, mode);
 }
 
 } // xrt::shim_int

--- a/src/runtime_src/core/edge/sw_emu/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/edge/sw_emu/generic_pcie_hal2/shim.cxx
@@ -2207,7 +2207,7 @@ close_cu_context(const xrt_core::hwctx_handle* hwctx_hdl, xrt_core::cuidx_type c
 std::unique_ptr<xrt_core::hwctx_handle>
 SwEmuShim::
 create_hw_context(const xrt::uuid& xclbin_uuid,
-                  const xrt::hw_context::qos_type&,
+                  const xrt::hw_context::cfg_param_type&,
                   xrt::hw_context::access_mode mode)
 {
   return std::make_unique<hwcontext>(this, 0, xclbin_uuid, mode);

--- a/src/runtime_src/core/edge/sw_emu/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/edge/sw_emu/generic_pcie_hal2/shim.h
@@ -396,7 +396,7 @@ namespace xclswemuhal2 {
       close_cu_context(const xrt_core::hwctx_handle* hwctx_hdl, xrt_core::cuidx_type cuidx);
 
       std::unique_ptr<xrt_core::hwctx_handle>
-      create_hw_context(const xrt::uuid&, const xrt::hw_context::qos_type&, xrt::hw_context::access_mode);
+      create_hw_context(const xrt::uuid&, const xrt::hw_context::cfg_param_type&, xrt::hw_context::access_mode);
 
   private:
       std::shared_ptr<xrt_core::device> mCoreDevice;

--- a/src/runtime_src/core/edge/user/device_linux.h
+++ b/src/runtime_src/core/edge/user/device_linux.h
@@ -73,10 +73,10 @@ public:
 
   virtual std::unique_ptr<hwctx_handle>
   create_hw_context(const xrt::uuid& xclbin_uuid,
-                    const xrt::hw_context::qos_type& qos,
+                    const xrt::hw_context::cfg_param_type& cfg_param,
                     xrt::hw_context::access_mode mode) const override
   {
-    return xrt::shim_int::create_hw_context(get_device_handle(), xclbin_uuid, qos, mode);
+    return xrt::shim_int::create_hw_context(get_device_handle(), xclbin_uuid, cfg_param, mode);
   }
   ////////////////////////////////////////////////////////////////
 

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -1144,7 +1144,7 @@ close_cu_context(const xrt_core::hwctx_handle* hwctx_hdl, xrt_core::cuidx_type c
 std::unique_ptr<xrt_core::hwctx_handle>
 shim::
 create_hw_context(const xrt::uuid& xclbin_uuid,
-                  const xrt::hw_context::qos_type&,
+                  const xrt::hw_context::cfg_param_type&,
                   xrt::hw_context::access_mode mode)
 {
   return std::make_unique<hwcontext>(this, 0, xclbin_uuid, mode);
@@ -1847,11 +1847,11 @@ namespace xrt::shim_int {
 std::unique_ptr<xrt_core::hwctx_handle>
 create_hw_context(xclDeviceHandle handle,
                   const xrt::uuid& xclbin_uuid,
-                  const xrt::hw_context::qos_type& qos,
+                  const xrt::hw_context::cfg_param_type& cfg_param,
                   xrt::hw_context::access_mode mode)
 {
   auto shim = get_shim_object(handle);
-  return shim->create_hw_context(xclbin_uuid, qos, mode);
+  return shim->create_hw_context(xclbin_uuid, cfg_param, mode);
 }
 
 } // xrt::shim_int

--- a/src/runtime_src/core/edge/user/shim.h
+++ b/src/runtime_src/core/edge/user/shim.h
@@ -159,7 +159,7 @@ public:
   close_cu_context(const xrt_core::hwctx_handle* hwctx_hdl, xrt_core::cuidx_type cuidx);
 
   std::unique_ptr<xrt_core::hwctx_handle>
-  create_hw_context(const xrt::uuid&, const xrt::hw_context::qos_type&, xrt::hw_context::access_mode);
+  create_hw_context(const xrt::uuid&, const xrt::hw_context::cfg_param_type&, xrt::hw_context::access_mode);
 ////////////////////////////////////////////////////////////////
 
   int xclOpenContext(const uuid_t xclbinId, unsigned int ipIndex, bool shared);

--- a/src/runtime_src/core/include/shim_int.h
+++ b/src/runtime_src/core/include/shim_int.h
@@ -58,7 +58,7 @@ close_cu_context(xclDeviceHandle handle, const xrt::hw_context& hwctx, xrt_core:
 std::unique_ptr<xrt_core::hwctx_handle>
 create_hw_context(xclDeviceHandle handle,
                   const xrt::uuid& xclbin_uuid,
-                  const xrt::hw_context::qos_type& qos,
+                  const xrt::hw_context::cfg_param_type& cfg_param,
                   xrt::hw_context::access_mode mode);
 
 // create_hw_queue() -

--- a/src/runtime_src/core/include/xrt/xrt_hw_context.h
+++ b/src/runtime_src/core/include/xrt/xrt_hw_context.h
@@ -51,7 +51,7 @@ public:
    * Currently ignored for legacy platforms
    */
   using cfg_param_type = std::map<std::string, uint32_t>;
-  using qos_type = cfg_param_type //alias to old type
+  using qos_type = cfg_param_type; //alias to old type
 
   /**
    * @enum access_mode - legacy access mode

--- a/src/runtime_src/core/include/xrt/xrt_hw_context.h
+++ b/src/runtime_src/core/include/xrt/xrt_hw_context.h
@@ -34,7 +34,7 @@ class hw_context : public detail::pimpl<hw_context_impl>
 public:
 
   /**
-   * Experimental specification of QoS requirements
+   * Experimental specification of Configuration Parameters which contains QoS and Communication Channel requirements
    *
    * Free formed key-value entry.
    *
@@ -45,10 +45,13 @@ public:
    *  - latency                // ??
    *  - frame_execution_time   // ??
    *  - priority               // ??
+   *  - enable_isp_channel     // toggle isp communication
+   *  - enable_acp_channel     // toggle acp communication
    *
    * Currently ignored for legacy platforms
    */
-  using qos_type = std::map<std::string, uint32_t>;
+  using cfg_param_type = std::map<std::string, uint32_t>;
+  using qos_type = cfg_param_type //alias to old type
 
   /**
    * @enum access_mode - legacy access mode
@@ -80,14 +83,14 @@ public:
    *  Device where context is created
    * @param xclbin_id
    *  UUID of xclbin that should be assigned to HW resources
-   * @qos
-   *  Quality of service request that should be fulfilled by the context
+   * @cfg_param
+   *  Configuration Parameters (incl. Quality of Service)
    *
    * The QoS definition is subject to change, so this API is not guaranteed
    * to be ABI compatible in future releases.
    */
   XRT_API_EXPORT
-  hw_context(const xrt::device& device, const xrt::uuid& xclbin_id, const qos_type& qos);
+  hw_context(const xrt::device& device, const xrt::uuid& xclbin_id, const cfg_param_type& cfg_param);
 
   /**
    * hw_context() - Construct with specific access control

--- a/src/runtime_src/core/pcie/emulation/hw_emu/alveo_shim/device_hwemu.h
+++ b/src/runtime_src/core/pcie/emulation/hw_emu/alveo_shim/device_hwemu.h
@@ -38,10 +38,10 @@ private:
 
   std::unique_ptr<hwctx_handle>
   create_hw_context(const xrt::uuid& xclbin_uuid,
-                    const xrt::hw_context::qos_type& qos,
+                    const xrt::hw_context::cfg_param_type& cfg_param,
                     xrt::hw_context::access_mode mode) const override
   {
-    return xrt::shim_int::create_hw_context(get_device_handle(), xclbin_uuid, qos, mode);
+    return xrt::shim_int::create_hw_context(get_device_handle(), xclbin_uuid, cfg_param, mode);
   }
 
   void

--- a/src/runtime_src/core/pcie/emulation/hw_emu/alveo_shim/halapi.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_emu/alveo_shim/halapi.cxx
@@ -33,11 +33,11 @@ namespace xrt::shim_int {
 std::unique_ptr<xrt_core::hwctx_handle>
 create_hw_context(xclDeviceHandle handle,
                   const xrt::uuid& xclbin_uuid,
-                  const xrt::hw_context::qos_type& qos,
+                  const xrt::hw_context::cfg_param_type& cfg_param,
                   xrt::hw_context::access_mode mode)
 {
   auto shim = get_shim_object(handle);
-  return shim->create_hw_context(xclbin_uuid, qos, mode);
+  return shim->create_hw_context(xclbin_uuid, cfg_param, mode);
 }
 
 void

--- a/src/runtime_src/core/pcie/emulation/hw_emu/alveo_shim/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_emu/alveo_shim/shim.cxx
@@ -3438,7 +3438,7 @@ close_cu_context(const xrt_core::hwctx_handle* hwctx_hdl, xrt_core::cuidx_type c
 std::unique_ptr<xrt_core::hwctx_handle>
 HwEmShim::
 create_hw_context(const xrt::uuid& xclbin_uuid,
-                  const xrt::hw_context::qos_type&,
+                  const xrt::hw_context::cfg_param_type&,
                   xrt::hw_context::access_mode mode)
 {
   return std::make_unique<hwcontext>(this, 0, xclbin_uuid, mode);

--- a/src/runtime_src/core/pcie/emulation/hw_emu/alveo_shim/shim.h
+++ b/src/runtime_src/core/pcie/emulation/hw_emu/alveo_shim/shim.h
@@ -227,7 +227,7 @@ using addr_type = uint64_t;
 
       // aka xclCreateHWContext, internal shim API for native C++ applications only
       std::unique_ptr<xrt_core::hwctx_handle>
-      create_hw_context(const xrt::uuid&, const xrt::hw_context::qos_type&, xrt::hw_context::access_mode);
+      create_hw_context(const xrt::uuid&, const xrt::hw_context::cfg_param_type&, xrt::hw_context::access_mode);
 
       // aka xclRegisterXclbin, internal shim API for native C++ applications only
       void

--- a/src/runtime_src/core/pcie/emulation/sw_emu/generic_pcie_hal2/device_swemu.h
+++ b/src/runtime_src/core/pcie/emulation/sw_emu/generic_pcie_hal2/device_swemu.h
@@ -31,10 +31,10 @@ public:
 
   std::unique_ptr<hwctx_handle>
   create_hw_context(const xrt::uuid& xclbin_uuid,
-                    const xrt::hw_context::qos_type& qos,
+                    const xrt::hw_context::cfg_param_type& cfg_param,
                     xrt::hw_context::access_mode mode) const override
   {
-    return xrt::shim_int::create_hw_context(get_device_handle(), xclbin_uuid, qos, mode);
+    return xrt::shim_int::create_hw_context(get_device_handle(), xclbin_uuid, cfg_param, mode);
   }
 
 private:

--- a/src/runtime_src/core/pcie/emulation/sw_emu/generic_pcie_hal2/halapi.cxx
+++ b/src/runtime_src/core/pcie/emulation/sw_emu/generic_pcie_hal2/halapi.cxx
@@ -31,11 +31,11 @@ namespace xrt::shim_int {
 std::unique_ptr<xrt_core::hwctx_handle>
 create_hw_context(xclDeviceHandle handle,
                   const xrt::uuid& xclbin_uuid,
-                  const xrt::hw_context::qos_type& qos,
+                  const xrt::hw_context::cfg_param_type& cfg_param,
                   const xrt::hw_context::access_mode mode)
 {
   auto shim = get_shim_object(handle);
-  return shim->create_hw_context(xclbin_uuid, qos, mode);
+  return shim->create_hw_context(xclbin_uuid, cfg_param, mode);
 }
 
 } // xrt::shim_int

--- a/src/runtime_src/core/pcie/emulation/sw_emu/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/sw_emu/generic_pcie_hal2/shim.cxx
@@ -2564,7 +2564,7 @@ namespace xclswemuhal2
   std::unique_ptr<xrt_core::hwctx_handle>
   SwEmuShim::
   create_hw_context(const xrt::uuid& xclbin_uuid,
-                    const xrt::hw_context::qos_type& qos,
+                    const xrt::hw_context::cfg_param_type& cfg_param,
                     xrt::hw_context::access_mode mode)
   {
     return std::make_unique<hwcontext>(this, 0, xclbin_uuid, mode);

--- a/src/runtime_src/core/pcie/emulation/sw_emu/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/pcie/emulation/sw_emu/generic_pcie_hal2/shim.h
@@ -497,7 +497,7 @@ namespace xclswemuhal2
 
     std::unique_ptr<xrt_core::hwctx_handle>
     create_hw_context(const xrt::uuid& xclbin_uuid,
-                      const xrt::hw_context::qos_type& qos,
+                      const xrt::hw_context::cfg_param_type& cfg_param,
                       xrt::hw_context::access_mode mode);
 
   private:

--- a/src/runtime_src/core/pcie/linux/device_linux.h
+++ b/src/runtime_src/core/pcie/linux/device_linux.h
@@ -62,10 +62,10 @@ public:
 
   std::unique_ptr<hwctx_handle>
   create_hw_context(const xrt::uuid& xclbin_uuid,
-                    const xrt::hw_context::qos_type& qos,
+                    const xrt::hw_context::cfg_param_type& cfg_param,
                     xrt::hw_context::access_mode mode) const override
   {
-    return xrt::shim_int::create_hw_context(get_device_handle(), xclbin_uuid, qos, mode);
+    return xrt::shim_int::create_hw_context(get_device_handle(), xclbin_uuid, cfg_param, mode);
   }
 
   void

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -2432,7 +2432,7 @@ close_cu_context(const xrt_core::hwctx_handle* hwctx_hdl, xrt_core::cuidx_type c
 std::unique_ptr<xrt_core::hwctx_handle>
 shim::
 create_hw_context(const xrt::uuid& xclbin_uuid,
-                  const xrt::hw_context::qos_type& qos,
+                  const xrt::hw_context::cfg_param_type& cfg_param,
                   xrt::hw_context::access_mode mode)
 {
   const static int qos_val = 0; // TBD qos;
@@ -2555,11 +2555,11 @@ open_by_bdf(const std::string& bdf)
 std::unique_ptr<xrt_core::hwctx_handle>
 create_hw_context(xclDeviceHandle handle,
                   const xrt::uuid& xclbin_uuid,
-                  const xrt::hw_context::qos_type& qos,
+                  const xrt::hw_context::cfg_param_type& cfg_param,
                   const xrt::hw_context::access_mode mode)
 {
   auto shim = get_shim_object(handle);
-  return shim->create_hw_context(xclbin_uuid, qos, mode);
+  return shim->create_hw_context(xclbin_uuid, cfg_param, mode);
 }
 
 void

--- a/src/runtime_src/core/pcie/linux/shim.h
+++ b/src/runtime_src/core/pcie/linux/shim.h
@@ -148,7 +148,7 @@ public:
   close_cu_context(const xrt_core::hwctx_handle* hwctx_hdl, xrt_core::cuidx_type cuidx);
 
   std::unique_ptr<xrt_core::hwctx_handle>
-  create_hw_context(const xrt::uuid&, const xrt::hw_context::qos_type&, xrt::hw_context::access_mode);
+  create_hw_context(const xrt::uuid&, const xrt::hw_context::cfg_param_type&, xrt::hw_context::access_mode);
 
   void
   destroy_hw_context(xrt_core::hwctx_handle::slot_id slotidx);

--- a/src/runtime_src/core/pcie/noop/device_noop.h
+++ b/src/runtime_src/core/pcie/noop/device_noop.h
@@ -26,10 +26,10 @@ private:
 
   std::unique_ptr<hwctx_handle>
   create_hw_context(const xrt::uuid& xclbin_uuid,
-                    const xrt::hw_context::qos_type& qos,
+                    const xrt::hw_context::cfg_param_type& cfg_param,
                     xrt::hw_context::access_mode mode) const override
   {
-    return xrt::shim_int::create_hw_context(get_device_handle(), xclbin_uuid, qos, mode);
+    return xrt::shim_int::create_hw_context(get_device_handle(), xclbin_uuid, cfg_param, mode);
   }
 
   void

--- a/src/runtime_src/core/pcie/noop/shim.cpp
+++ b/src/runtime_src/core/pcie/noop/shim.cpp
@@ -686,7 +686,7 @@ namespace xrt::shim_int {
 std::unique_ptr<xrt_core::hwctx_handle>
 create_hw_context(xclDeviceHandle handle,
                   const xrt::uuid& xclbin_uuid,
-                  const xrt::hw_context::qos_type&,
+                  const xrt::hw_context::cfg_param_type&,
                   xrt::hw_context::access_mode)
 {
   auto shim = get_shim_object(handle);

--- a/src/runtime_src/core/pcie/windows/alveo/device_windows.h
+++ b/src/runtime_src/core/pcie/windows/alveo/device_windows.h
@@ -45,10 +45,10 @@ public:
 
   virtual std::unique_ptr<hwctx_handle>
   create_hw_context(const xrt::uuid& xclbin_uuid,
-                    const xrt::hw_context::qos_type& qos,
+                    const xrt::hw_context::cfg_param_type& cfg_param,
                     xrt::hw_context::access_mode mode) const override
   {
-    return xrt::shim_int::create_hw_context(get_device_handle(), xclbin_uuid, qos, mode);
+    return xrt::shim_int::create_hw_context(get_device_handle(), xclbin_uuid, cfg_param, mode);
   }
 
 private:

--- a/src/runtime_src/core/pcie/windows/alveo/shim.cpp
+++ b/src/runtime_src/core/pcie/windows/alveo/shim.cpp
@@ -1490,7 +1490,7 @@ done:
   std::unique_ptr<xrt_core::hwctx_handle>
   shim::
   create_hw_context(const xrt::uuid& xclbin_uuid,
-                    const xrt::hw_context::qos_type&,
+                    const xrt::hw_context::cfg_param_type&,
                     xrt::hw_context::access_mode mode)
   {
     return std::make_unique<hwcontext>(this, 0, xclbin_uuid, mode);
@@ -1652,11 +1652,11 @@ namespace xrt::shim_int {
 std::unique_ptr<xrt_core::hwctx_handle>
 create_hw_context(xclDeviceHandle handle,
                   const xrt::uuid& xclbin_uuid,
-                  const xrt::hw_context::qos_type& qos,
+                  const xrt::hw_context::cfg_param_type& cfg_param,
                   xrt::hw_context::access_mode mode)
 {
   auto shim = get_shim_object(handle);
-  return shim->create_hw_context(xclbin_uuid, qos, mode);
+  return shim->create_hw_context(xclbin_uuid, cfg_param, mode);
 }
 
 } // namespace xrt::shim_int


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
The map 'cfg_param_type' acts as a more general set of parameters for the context to fulfil, including the QoS parameters.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
All references to qos_type were replaced with cfg_param_type. An alias was left for the old type

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Testcases using qos_type will need to be refactored to accommodate these changes

#### Documentation impact (if any)
References to qos_type will need to be renamed to cfg_param_type