### PR TITLE
CR-1152339: Add flow to run summary file

### DIFF
--- a/src/runtime_src/xdp/profile/writer/vp_base/vp_run_summary.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/vp_run_summary.cpp
@@ -144,31 +144,28 @@ namespace xdp {
         flags.push_back(std::make_pair("", empty));
       }
       ptGeneration.add_child("flags", flags);
-      ptRunSummary.add_child("generation", ptGeneration) ;
+      ptRunSummary.add_child("generation", ptGeneration);
     }
 
-    boost::property_tree::ptree ptFiles ;
-    for (auto f : files)
-    {
-      boost::property_tree::ptree ptFile ;
-      ptFile.put("name", f.first.c_str()) ;
-      ptFile.put("type", f.second.c_str()) ;
-      ptFiles.push_back(std::make_pair("", ptFile)) ;
+    boost::property_tree::ptree ptFiles;
+    for (auto f : files) {
+      boost::property_tree::ptree ptFile;
+      ptFile.put("name", f.first.c_str());
+      ptFile.put("type", f.second.c_str());
+      ptFiles.push_back(std::make_pair("", ptFile));
     }
-    ptRunSummary.add_child("files", ptFiles) ;
+    ptRunSummary.add_child("files", ptFiles);
 
     // Add the system diagram information if available
-    std::string systemDiagram = (db->getStaticInfo()).getSystemDiagram() ;
-    if (systemDiagram != "")
-    {
-      boost::property_tree::ptree ptSystemDiagram ;
-      ptSystemDiagram.put("payload_16bitEnc", systemDiagram.c_str()) ;
-      ptRunSummary.add_child("system_diagram", ptSystemDiagram) ;
+    std::string systemDiagram = (db->getStaticInfo()).getSystemDiagram();
+    if (systemDiagram != "") {
+      boost::property_tree::ptree ptSystemDiagram;
+      ptSystemDiagram.put("payload_16bitEnc", systemDiagram.c_str());
+      ptRunSummary.add_child("system_diagram", ptSystemDiagram);
     }
 
-    boost::property_tree::write_json(fout, ptRunSummary, true) ;
+    boost::property_tree::write_json(fout, ptRunSummary, true);
     return true;
   }
 
 } // end namespace xdp
-


### PR DESCRIPTION
#### Problem solved by the commit
This pull request ups the version of the run summary file and adds the flow to the generated run summary file, so that downstream tools can identify if software emulation, hardware emulation, or system runs generated the run summary file.

#### Risks (if any) associated the changes in the commit
Low risk as post-processing tools should ignore added fields and recognize the new version.

#### What has been tested and how, request additional testing if necessary
A hardware emulation test case generates a correct run summary and the post processing tools open it correctly.

#### Documentation impact (if any)
No documentation impact.