### PR TITLE
CR-1149236 Add support to dump APU's dimes and syslog to host (#7318)

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/zocl_rpu_channel.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_rpu_channel.c
@@ -122,19 +122,13 @@ static void zchan_cmd_identify(struct zocl_rpu_channel *chan, struct xgq_cmd_sq_
 	r->minor = ZCHAN_CMD_HANDLER_VER_MINOR;
 }
 
-static void zchan_cmd_log_page(struct zocl_rpu_channel *chan, struct xgq_cmd_sq_hdr *cmd,
-	struct xgq_com_queue_entry *resp)
+static int zchan_cmd_log_page_info(struct zocl_rpu_channel *chan, u32 add_off, u32 size,
+	u32 *total_countp)
 {
-	struct xgq_cmd_sq *sq = (struct xgq_cmd_sq *)cmd;
-	struct xgq_cmd_cq *cq = (struct xgq_cmd_cq *)resp;
-	u32 add_off = sq->log_payload.address;
-	u32 size = sq->log_payload.size;
 	u32 count = 0;
 	u32 total_count = 0;
 	int ret = 0;
-
-	zchan_info(chan, "addr_off 0x%x, size %d", add_off, size);
-
+	
 	count = snprintf(info_buf, sizeof(info_buf), "ZOCL Version:");
 	if (count > size) {
 		zchan_err(chan, "message is trunked to %d len", total_count);
@@ -144,7 +138,8 @@ static void zchan_cmd_log_page(struct zocl_rpu_channel *chan, struct xgq_cmd_sq_
 	memcpy_toio(chan->mem_base + add_off, info_buf, count);
 	total_count += count;
 
-	count = snprintf(info_buf, sizeof(info_buf), "%s%s%s\n", XRT_DRIVER_VERSION, ", ", XRT_HASH);
+	count = snprintf(info_buf, sizeof(info_buf), "%s%s%s\n",
+		XRT_DRIVER_VERSION, ", ", XRT_HASH);
 	if (total_count + count > size) {
 		zchan_err(chan, "message is trunked to %d len", total_count);
 		ret = -EINVAL;
@@ -170,6 +165,72 @@ static void zchan_cmd_log_page(struct zocl_rpu_channel *chan, struct xgq_cmd_sq_
 	}
 	memcpy_toio(chan->mem_base + add_off + total_count, info_buf, count);
 	total_count += count;
+
+done:
+	*total_countp = total_count;
+	return ret;
+}
+
+
+/*
+ * add code here copying data back into chan->mem_base.
+ * note: copy data start from logs data + offset instead of data + 0
+ *       size is the request size, copy data within this range
+ *       set return value as data total size copied out.
+ *
+ */
+static int zchan_cmd_log_apu_log(struct zocl_rpu_channel *chan, u32 add_off, u32 size,
+	u32 offset, u32 *total_countp)
+{
+	u32 count = 0;
+
+	memset(info_buf, 0, sizeof(info_buf));
+	/*
+	 * Example code of collecting data based on request size and offset
+	 */
+	if (offset == 0) {
+		count = snprintf(info_buf, sizeof(info_buf), "first 4096");
+		memcpy_toio(chan->mem_base + add_off, info_buf, count);
+		count = 4096;
+	} else if (offset == 4096) {
+		count = snprintf(info_buf, sizeof(info_buf), "second 4096");
+		memcpy_toio(chan->mem_base + add_off, info_buf, count);
+		count = 4096;
+	} else {
+		count = 0;
+	}
+
+	*total_countp = count;
+	return 0;
+}
+
+static void zchan_cmd_log_page(struct zocl_rpu_channel *chan, struct xgq_cmd_sq_hdr *cmd,
+	struct xgq_com_queue_entry *resp)
+{
+	struct xgq_cmd_sq *sq = (struct xgq_cmd_sq *)cmd;
+	struct xgq_cmd_cq *cq = (struct xgq_cmd_cq *)resp;
+	u32 add_off = sq->log_payload.address;
+	u32 size = sq->log_payload.size;
+	u16 pid = sq->log_payload.pid;
+	u32 offset = sq->log_payload.offset;
+	u32 total_count = 0;
+	int ret = 0;
+
+	zchan_info(chan, "addr_off 0x%x, size %d, offset %d, pid %d",
+		add_off, size, offset, pid);
+
+	switch (pid) {
+	case XGQ_CMD_LOG_INFO:
+		ret = zchan_cmd_log_page_info(chan, add_off, size, &total_count);
+		break;
+	case XGQ_CMD_LOG_APU_LOG:
+		ret = zchan_cmd_log_apu_log(chan, add_off, size, offset, &total_count);
+		break;
+	default:
+		zchan_err(chan, "unsupported pid: %d", pid);
+		ret = -EINVAL;
+		total_count = 0;
+	}
 
 done:
 	init_resp(resp, cmd->cid, ret);

--- a/src/runtime_src/core/include/xgq_cmd_vmr.h
+++ b/src/runtime_src/core/include/xgq_cmd_vmr.h
@@ -125,6 +125,7 @@ enum xgq_cmd_log_page_type {
 	XGQ_CMD_LOG_MEM_STATS	= 0x6,
 	XGQ_CMD_LOG_SYSTEM_DTB	= 0x7,
 	XGQ_CMD_LOG_PLM_LOG	= 0x8,
+	XGQ_CMD_LOG_APU_LOG	= 0x9,
 
 };
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
@@ -1068,7 +1068,8 @@ static int xgq_program_scfw(struct platform_device *pdev)
 
 /* Note: caller is responsibe for vfree(*fw) */
 static int xgq_log_page_fw(struct platform_device *pdev,
-	char **fw, size_t *fw_size, enum xgq_cmd_log_page_type req_pid)
+	char **fw, size_t *fw_size, enum xgq_cmd_log_page_type req_pid,
+	loff_t off, size_t req_size)
 {
 	struct xocl_xgq_vmr *xgq = platform_get_drvdata(pdev);
 	struct xocl_xgq_vmr_cmd *cmd = NULL;
@@ -1094,10 +1095,13 @@ static int xgq_log_page_fw(struct platform_device *pdev,
 		goto acquire_failed;
 	}
 
+	/* adjust requested len based on req_size */
+	len = (req_size && req_size < len) ? req_size : len;
+
 	payload = &(cmd->xgq_cmd_entry.log_payload);
 	payload->address = address;
 	payload->size = len;
-	payload->offset = 0;
+	payload->offset = off;
 	payload->pid = req_pid;
 
 	hdr = &(cmd->xgq_cmd_entry.hdr);
@@ -1175,7 +1179,7 @@ acquire_failed:
 static int xgq_log_page_metadata(struct platform_device *pdev,
 	char **fw, size_t *fw_size)
 {
-	return xgq_log_page_fw(pdev, fw, fw_size, XGQ_CMD_LOG_FW);
+	return xgq_log_page_fw(pdev, fw, fw_size, XGQ_CMD_LOG_FW, 0, 0);
 }
 
 static int xgq_refresh_plm_log(struct xocl_xgq_vmr *xgq)
@@ -1184,7 +1188,7 @@ static int xgq_refresh_plm_log(struct xocl_xgq_vmr *xgq)
 		vfree(xgq->xgq_vmr_plm_log);
 
 	return xgq_log_page_fw(xgq->xgq_pdev, &xgq->xgq_vmr_plm_log,
-		&xgq->xgq_vmr_plm_log_size, XGQ_CMD_LOG_PLM_LOG);
+		&xgq->xgq_vmr_plm_log_size, XGQ_CMD_LOG_PLM_LOG, 0, 0);
 }
 
 static int xgq_refresh_system_dtb(struct xocl_xgq_vmr *xgq)
@@ -1193,7 +1197,14 @@ static int xgq_refresh_system_dtb(struct xocl_xgq_vmr *xgq)
 		vfree(xgq->xgq_vmr_system_dtb);
 
 	return xgq_log_page_fw(xgq->xgq_pdev, &xgq->xgq_vmr_system_dtb,
-		&xgq->xgq_vmr_system_dtb_size, XGQ_CMD_LOG_SYSTEM_DTB);
+		&xgq->xgq_vmr_system_dtb_size, XGQ_CMD_LOG_SYSTEM_DTB, 0, 0);
+}
+
+static int xgq_vmr_apu_log(struct xocl_xgq_vmr *xgq, char **fw, size_t *fw_size,
+	loff_t off, size_t req_size)
+{
+	return xgq_log_page_fw(xgq->xgq_pdev, fw, fw_size, XGQ_CMD_LOG_APU_LOG,
+		off, req_size);
 }
 
 static int xgq_status(struct platform_device *pdev, struct VmrStatus *vmr_status_ptr)
@@ -1217,7 +1228,8 @@ static int xgq_status(struct platform_device *pdev, struct VmrStatus *vmr_status
 	return 0;
 }
 
-static int xgq_vmr_healthy_op(struct platform_device *pdev, enum xgq_cmd_log_page_type type_pid)
+static int xgq_vmr_healthy_op(struct platform_device *pdev,
+	enum xgq_cmd_log_page_type type_pid)
 {
 	struct xocl_xgq_vmr *xgq = platform_get_drvdata(pdev);
 	struct xocl_xgq_vmr_cmd *cmd = NULL;
@@ -3089,6 +3101,39 @@ static struct bin_attribute bin_attr_vmr_plm_log = {
 	.size = 0
 };
 
+static ssize_t vmr_apu_log_read(struct file *filp, struct kobject *kobj,
+	struct bin_attribute *attr, char *buf, loff_t off, size_t count)
+{
+	struct xocl_xgq_vmr *xgq =
+		dev_get_drvdata(container_of(kobj, struct device, kobj));
+	char *log_buf = NULL;
+	ssize_t log_size = 0;
+	int ret = 0;
+
+	/* return count should be less or equal to count */
+	ret = xgq_vmr_apu_log(xgq, &log_buf, &log_size, off, count);
+	if (ret)
+		return ret;
+
+	/* adjust log_size to be within requested count range */
+	log_size = log_size > count ? count : log_size;
+
+	memcpy(buf, log_buf, log_size);
+	vfree(log_buf);
+
+	return log_size;
+}
+
+static struct bin_attribute bin_attr_vmr_apu_log = {
+	.attr = {
+		.name = "vmr_apu_log",
+		.mode = 0444
+	},
+	.read = vmr_apu_log_read,
+	.write = NULL,
+	.size = 0
+};
+
 static struct attribute *vmr_attrs[] = {
 	&dev_attr_polling.attr,
 	&dev_attr_boot_from_backup.attr,
@@ -3116,6 +3161,7 @@ static struct attribute *vmr_attrs[] = {
 static struct bin_attribute *vmr_bin_attrs[] = {
 	&bin_attr_vmr_system_dtb,
 	&bin_attr_vmr_plm_log,
+	&bin_attr_vmr_apu_log,
 	NULL,
 };
 static struct attribute_group xgq_attr_group = {


### PR DESCRIPTION
Signed-off-by: David Zhang <davidzha@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Clean backport. This should be added, otherwise vmr_log, plm_log and apu_log won't work on 2022.2 XRT with latest VMR shell.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
