### PR TITLE
CR-1152824: Fixing trace buffer allocation to not use full memory resources when user over allocates

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
@@ -225,6 +225,8 @@ namespace xdp {
           // reduce it to a reasonable size so it fits
           auto eightyPercent =
             static_cast<uint64_t>(static_cast<double>(memorySz) * 0.8);
+          eightyPercent =
+            devInterface->getAlignedTraceBufferSize(eightyPercent, 1);
 
           buf_sizes[i] = eightyPercent;
           std::string msg = "Trace buffer size for TS2MM " + std::to_string(i)

--- a/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
@@ -220,15 +220,16 @@ namespace xdp {
         }
 
         uint64_t memorySz = (memory->size) * 1024;
-        // If we are requesting over 80% of the total memory, then cut it
-        // down so it fits.
-        auto eightyPercent =
-          static_cast<uint64_t>(static_cast<double>(memorySz) * 0.8);
-        if (memorySz > 0 && each_buffer_size >= eightyPercent) {
-            buf_sizes[i] = eightyPercent;
-            std::string msg = "Trace buffer size for TS2MM " + std::to_string(i)
-                              + " is too big for memory resource.  Using " + std::to_string(eightyPercent) + " (80% of total resource) instead.";
-            xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", msg);
+        if (memorySz > 0 && each_buffer_size > memorySz) {
+          // If we are requesting more than the total available memory, then
+          // reduce it to a reasonable size so it fits
+          auto eightyPercent =
+            static_cast<uint64_t>(static_cast<double>(memorySz) * 0.8);
+
+          buf_sizes[i] = eightyPercent;
+          std::string msg = "Trace buffer size for TS2MM " + std::to_string(i)
+                            + " is too big for memory resource.  Using " + std::to_string(eightyPercent) + " (80% of total resource) instead.";
+          xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", msg);
         }
       }
     }

--- a/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2020-2022 Xilinx, Inc
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -193,28 +193,42 @@ namespace xdp {
     std::vector<uint64_t> buf_sizes;
 
     if (devInterface->hasTs2mm()) {
+
       size_t num_ts2mm = devInterface->getNumberTS2MM();
       trace_buffer_size = GetTS2MMBufSize();
+
       uint64_t each_buffer_size = devInterface->getAlignedTraceBufferSize(trace_buffer_size, static_cast<unsigned int>(num_ts2mm));
 
+      // Initialize all of the buffers with the size requested by
+      // the user.
       buf_sizes.resize(num_ts2mm, each_buffer_size);
-      for(size_t i = 0; i < num_ts2mm; i++) {
-        Memory* memory = (db->getStaticInfo()).getMemory(deviceId, devInterface->getTS2MmMemIndex(i));
+
+      // Now go through each of the memories connected to the TS2MM
+      // and verify that we have enough space to allocate the buffer
+      for(size_t i = 0; i < num_ts2mm; ++i) {
+        Memory* memory =
+          db->getStaticInfo().getMemory(deviceId,
+                                        devInterface->getTS2MmMemIndex(i));
         if(nullptr == memory) {
-          std::string msg = "Information about memory index " + std::to_string(devInterface->getTS2MmMemIndex(i)) 
-                             + " not found in given xclbin. So, cannot check availability of memory resource for "
+          std::string msg = "Information about memory index " +
+                            std::to_string(devInterface->getTS2MmMemIndex(i)) + 
+                             " not found in given xclbin. So, cannot check availability of memory resource for "
                              + std::to_string(i) +
                              + "th. TS2MM for device trace offload.";
           xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", msg);
           return;
-        } else {
-          uint64_t memorySz = (memory->size) * 1024 ;
-          if (memorySz > 0 && each_buffer_size > memorySz) {
-            buf_sizes[i] = memorySz ;
-            std::string msg = "Trace buffer size for " + std::to_string(i)
-                              + "th. TS2MM is too big for memory resource.  Using " + std::to_string(memorySz) + " instead." ;
-            xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", msg) ;
-          }
+        }
+
+        uint64_t memorySz = (memory->size) * 1024;
+        // If we are requesting over 80% of the total memory, then cut it
+        // down so it fits.
+        auto eightyPercent =
+          static_cast<uint64_t>(static_cast<double>(memorySz) * 0.8);
+        if (memorySz > 0 && each_buffer_size >= eightyPercent) {
+            buf_sizes[i] = eightyPercent;
+            std::string msg = "Trace buffer size for TS2MM " + std::to_string(i)
+                              + " is too big for memory resource.  Using " + std::to_string(eightyPercent) + " (80% of total resource) instead.";
+            xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", msg);
         }
       }
     }


### PR DESCRIPTION
#### Problem solved by the commit
On some configurations, the requested buffer size for device trace information is not able to fit in the memory resources connected to the trace offload infrastructure.  This pull request fixes the warning message emitted and also restricts the total size of the buffer trace allocates to 80% of the total memory resource.  This does not prevent users from overallocating additional buffers on the memory resource, but does leave some room for host buffers if the user has overallocated trace.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
This issue was discovered by full regression testing on multiple platforms.

#### Risks (if any) associated the changes in the commit
Low risk, as this adjusts a warning message and only changes the amount of trace buffer allocated on designs that were already overallocating the resource.

#### Documentation impact (if any)
No documentation impact.