### PR TITLE
Remove obsolete methods in Static DB

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info_database.h
+++ b/src/runtime_src/xdp/profile/database/static_info_database.h
@@ -111,8 +111,6 @@ namespace xdp {
     bool resetDeviceInfo(uint64_t deviceId, const std::shared_ptr<xrt_core::device>& device);
 
     // Functions that create the overall structure of the Xclbin's PL region
-    bool initializeStructure(XclbinInfo*,
-                             const std::shared_ptr<xrt_core::device>&);
     void createComputeUnits(XclbinInfo*, const ip_layout*);
     void createMemories(XclbinInfo*, const mem_topology*);
     void createConnections(XclbinInfo*, const ip_layout*, const mem_topology*,
@@ -123,7 +121,6 @@ namespace xdp {
     void addPortInfo(XclbinInfo*, const char*, size_t);
 
     // Functions that initialize the structure of the debug/profiling IP
-    bool initializeProfileMonitors(DeviceInfo*, const std::shared_ptr<xrt_core::device>&);
     void initializeAM(DeviceInfo* devInfo, const std::string& name,
                       const struct debug_ip_data* debugIpData) ;
     void initializeAIM(DeviceInfo* devInfo, const std::string& name,
@@ -134,8 +131,6 @@ namespace xdp {
                        const struct debug_ip_data* debugIpData) ;
     void initializeTS2MM(DeviceInfo* devInfo,
                          const struct debug_ip_data* debugIpData) ;
-    double findClockRate(std::shared_ptr<xrt_core::device> device) ;
-    void setAIEClockRateMHz(std::shared_ptr<xrt_core::device> device, uint64_t deviceId) ;
 
     void setDeviceNameFromXclbin(uint64_t deviceId, xrt::xclbin xrtXclbin);
     void setAIEClockRateMHz(uint64_t deviceId, xrt::xclbin xrtXclbin) ;


### PR DESCRIPTION
Signed-off-by: IshitaGhosh <ighosh.account@gmail.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
xrt::xclbin is now used in Static DB methods to retrieve xclbin and device information. Earlier xrt_core::device was used. So, the older methods are now obsolete and need to be removed.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
