### PR TITLE
Fix race in bo and device construction

### DIFF
--- a/src/runtime_src/core/common/device.cpp
+++ b/src/runtime_src/core/common/device.cpp
@@ -54,6 +54,7 @@ bool
 device::
 is_nodma() const
 {
+  std::lock_guard lk(m_mutex);
   if (m_nodma != boost::none)
     return *m_nodma;
 

--- a/src/runtime_src/core/common/system.cpp
+++ b/src/runtime_src/core/common/system.cpp
@@ -137,9 +137,12 @@ get_userpf_device(device::id_type id)
 std::shared_ptr<device>
 get_userpf_device(device::handle_type handle)
 {
-  // Look up core device from low level shim handle
-  // The handle is inserted into map as part of
-  // calling xclOpen
+  // Look up core device from low level shim handle The handle is
+  // inserted into map as part of calling xclOpen.  Protect against
+  // multiple threads calling xclOpen at the same time, e.g. one
+  // thread could be in process of inserting some handle while this
+  // thread is looking up another handle.
+  std::lock_guard lk(mutex);
   auto itr = userpf_device_map.find(handle);
   if (itr != userpf_device_map.end())
     return (*itr).second.lock();
@@ -158,7 +161,7 @@ get_userpf_device(device::handle_type handle, device::id_type id)
 
   // Construct a new device object and insert in map.
   auto device = instance().get_userpf_device(handle,id);
-  std::lock_guard<std::mutex> lk(mutex);
+  std::lock_guard lk(mutex);
   userpf_device_map[handle] = device;  // create or replace
   return device;
 }
@@ -167,6 +170,7 @@ std::shared_ptr<device>
 get_mgmtpf_device(device::id_type id)
 {
   // Check cache
+  std::lock_guard lk(mutex);
   auto itr = mgmtpf_device_map.find(id);
   if (itr != mgmtpf_device_map.end())
     if (auto device = (*itr).second.lock())


### PR DESCRIPTION
#### Problem solved by the commit
Multiple threads competing to construct the very first xrt::bo object can hit a race in a device query for nodma check.  Additionally, multiple threads creating device objects can hit a race in device map access.

#### How problem was solved, alternative solutions (if any) and why they were rejected
The nodma check is cached in a member variable and this variable is subsequently checked.  The check must be under a mutex lock.

Device construction is inserting core device objects into a static map in core util.  This map needs to be protected not only for insertion but also for reading.
