### PR TITLE
CR-1153285 Fix race in bo and device construction 2022.2

### DIFF
--- a/src/runtime_src/core/common/device.cpp
+++ b/src/runtime_src/core/common/device.cpp
@@ -232,7 +232,7 @@ update_cu_info()
     // It assumes that m_xclbin is the single xclbin and that
     // there is only one default slot with number 0.
     auto ip_layout = get_axlf_section<const ::ip_layout*>(IP_LAYOUT);
-    auto& cu2idx = m_cu2idx[0u]; // default slot 0
+    auto& cu2idx = m_cu2idx[0]; // default slot 0
     if (ip_layout != nullptr) {
       m_cus = xclbin::get_cus(ip_layout);
       cu2idx = xclbin::get_cu_indices(ip_layout);

--- a/src/runtime_src/core/common/device.cpp
+++ b/src/runtime_src/core/common/device.cpp
@@ -52,6 +52,7 @@ bool
 device::
 is_nodma() const
 {
+  std::lock_guard lk(m_mutex);
   if (m_nodma != boost::none)
     return *m_nodma;
 
@@ -93,6 +94,7 @@ device::
 record_xclbin(const xrt::xclbin& xclbin)
 {
   register_xclbin(xclbin); // shim level registration
+  std::lock_guard lk(m_mutex);
   m_xclbins.insert(xclbin);
 
   // For single xclbin case, where shim doesn't implement
@@ -158,8 +160,10 @@ get_xclbin(const uuid& xclbin_id) const
   // Allow access to xclbin in process of loading via device::load_xclbin
   if (xclbin_id && xclbin_id == m_xclbin.get_uuid())
     return m_xclbin;
-  if (xclbin_id)
+  if (xclbin_id) {
+    std::lock_guard lk(m_mutex);
     return m_xclbins.get(xclbin_id);
+  }
 
   // Single xclbin case
   return m_xclbin;
@@ -176,6 +180,7 @@ device::
 update_xclbin_info()
 {
   // Update cached slot xclbin uuid mapping
+  std::lock_guard lk(m_mutex);
   try {
     // [slot, xclbin_uuid]+
     auto xclbin_slot_info = xrt_core::device_query<xrt_core::query::xclbin_slots>(this);
@@ -195,6 +200,7 @@ update_cu_info()
   // Compute CU sort order, kernel driver zocl and xocl now assign and
   // control the sort order, which is accessible via a query request.
   // For emulation old xclbin_parser::get_cus is used.
+  std::lock_guard lk(m_mutex);
   m_cus.clear();
   m_cu2idx.clear();
   try {
@@ -226,7 +232,7 @@ update_cu_info()
     // It assumes that m_xclbin is the single xclbin and that
     // there is only one default slot with number 0.
     auto ip_layout = get_axlf_section<const ::ip_layout*>(IP_LAYOUT);
-    auto& cu2idx = m_cu2idx[0]; // default slot 0
+    auto& cu2idx = m_cu2idx[0u]; // default slot 0
     if (ip_layout != nullptr) {
       m_cus = xclbin::get_cus(ip_layout);
       cu2idx = xclbin::get_cu_indices(ip_layout);
@@ -261,6 +267,7 @@ register_axlf(const axlf* top)
     m_xclbin = xrt::xclbin{top};
 
   // Record the xclbin
+  std::lock_guard lk(m_mutex);
   m_xclbins.insert(m_xclbin);
 }
 

--- a/src/runtime_src/core/common/device.h
+++ b/src/runtime_src/core/common/device.h
@@ -471,6 +471,7 @@ public:
   std::vector<uint64_t> m_cus;                // cu base addresses in expeced sort order
   xrt::xclbin m_xclbin;                       // currently loaded xclbin  (single-slot, default)
   xclbin_map m_xclbins;                       // currently loaded xclbins (multi-slot)
+  mutable std::mutex m_mutex;
 };
 
 /**


### PR DESCRIPTION
Signed-off-by: vboggara <vboggara@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Multiple threads competing to construct the very first xrt::bo object can hit a race in a device query for nodma check.  Additionally, multiple threads creating device objects can hit a race in device map access.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
VVAS team is using 2022.2 build for their applications which is using heavy multi threading, seeing segfault sometimes during the run. Found this issue as root cause and fixed it.

#### How problem was solved, alternative solutions (if any) and why they were rejected
The nodma check is cached in a member variable and this variable is subsequently checked.  The check must be under a mutex lock.

Device construction is inserting core device objects into a static map in core util.  This map needs to be protected not only for insertion but also for reading.

Note: same issue fixed in PR https://github.com/Xilinx/XRT/pull/7361 in master branch.
#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
