### PR TITLE
CR-1142742 No interface counters mentioned in summary.csv when packet counters are used

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info/device_info.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info/device_info.cpp
@@ -324,8 +324,11 @@ namespace xdp {
     case 1:
       xclbin->aie.aieMemoryCountersMap[numCounters] = numTiles ;
       break ;
-    default:
+    case 2:
       xclbin->aie.aieShimCountersMap[numCounters] = numTiles ;
+      break ;
+    default:
+      xclbin->aie.aieMemTileCountersMap[numCounters] = numTiles ;
       break ;
     }
   }

--- a/src/runtime_src/xdp/profile/database/static_info/xclbin_info.h
+++ b/src/runtime_src/xdp/profile/database/static_info/xclbin_info.h
@@ -128,6 +128,7 @@ namespace xdp {
     std::map<uint32_t, uint32_t> aieCoreCountersMap ;
     std::map<uint32_t, uint32_t> aieMemoryCountersMap ;
     std::map<uint32_t, uint32_t> aieShimCountersMap ;
+    std::map<uint32_t, uint32_t> aieMemTileCountersMap ;
     std::map<uint32_t, uint32_t> aieCoreEventsMap ;
     std::map<uint32_t, uint32_t> aieMemoryEventsMap ;
     std::map<uint32_t, uint32_t> aieShimEventsMap ;

--- a/src/runtime_src/xdp/profile/database/static_info_database.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info_database.cpp
@@ -818,6 +818,21 @@ namespace xdp {
   }
 
   std::map<uint32_t, uint32_t>*
+  VPStaticDatabase::getAIEMemTileCounterResources(uint64_t deviceId)
+  {
+    std::lock_guard<std::mutex> lock(deviceLock) ;
+
+    if (deviceInfo.find(deviceId) == deviceInfo.end())
+      return nullptr ;
+
+    XclbinInfo* xclbin = deviceInfo[deviceId]->currentXclbin() ;
+    if (!xclbin)
+      return nullptr ;
+
+    return &(xclbin->aie.aieMemTileCountersMap) ;
+  }
+
+  std::map<uint32_t, uint32_t>*
   VPStaticDatabase::getAIEShimCounterResources(uint64_t deviceId)
   {
     std::lock_guard<std::mutex> lock(deviceLock) ;
@@ -863,21 +878,6 @@ namespace xdp {
   }
 
   std::map<uint32_t, uint32_t>*
-  VPStaticDatabase::getAIEShimEventResources(uint64_t deviceId)
-  {
-    std::lock_guard<std::mutex> lock(deviceLock) ;
-
-    if (deviceInfo.find(deviceId) == deviceInfo.end())
-      return nullptr ;
-
-    XclbinInfo* xclbin = deviceInfo[deviceId]->currentXclbin() ;
-    if (!xclbin)
-      return nullptr ;
-
-    return &(xclbin->aie.aieShimEventsMap) ;
-  }
-
-  std::map<uint32_t, uint32_t>*
   VPStaticDatabase::getAIEMemTileEventResources(uint64_t deviceId)
   {
     std::lock_guard<std::mutex> lock(deviceLock) ;
@@ -890,6 +890,21 @@ namespace xdp {
       return nullptr ;
 
     return &(xclbin->aie.aieMemTileEventsMap) ;
+  }
+  
+  std::map<uint32_t, uint32_t>*
+  VPStaticDatabase::getAIEShimEventResources(uint64_t deviceId)
+  {
+    std::lock_guard<std::mutex> lock(deviceLock) ;
+
+    if (deviceInfo.find(deviceId) == deviceInfo.end())
+      return nullptr ;
+
+    XclbinInfo* xclbin = deviceInfo[deviceId]->currentXclbin() ;
+    if (!xclbin)
+      return nullptr ;
+
+    return &(xclbin->aie.aieShimEventsMap) ;
   }
 
   std::vector<std::unique_ptr<aie_cfg_tile>>*

--- a/src/runtime_src/xdp/profile/database/static_info_database.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info_database.cpp
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2016-2022 Xilinx, Inc
- * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -37,7 +37,6 @@
 
 #include "core/common/config_reader.h"
 #include "core/common/message.h"
-#include "core/common/api/xclbin_int.h"
 #include "core/include/xclbin.h"
 
 #define XDP_SOURCE
@@ -346,6 +345,33 @@ namespace xdp {
       return xclbin->aie.clockRateAIEMHz ;
   }
   
+  void VPStaticDatabase::setAIEClockRateMHz(std::shared_ptr<xrt_core::device> device, uint64_t deviceId){
+    std::lock_guard<std::mutex> lock(deviceLock) ;
+
+    if (deviceInfo.find(deviceId) == deviceInfo.end())
+      return;
+
+    XclbinInfo* xclbin = deviceInfo[deviceId]->currentXclbin() ;
+    if (!xclbin)
+      return;
+
+    auto data = device->get_axlf_section(AIE_METADATA);
+    if (!data.first || !data.second)
+      return;
+
+    boost::property_tree::ptree aie_meta;
+
+    std::stringstream aie_stream;
+    aie_stream.write(data.first, data.second);
+    boost::property_tree::read_json(aie_stream,aie_meta);
+
+    //read_aie_metadata(data.first, data.second, aie_meta);
+    auto dev_node = aie_meta.get_child("aie_metadata.DeviceData");
+    
+    xclbin->aie.clockRateAIEMHz = dev_node.get<double>("AIEFrequency");
+  }
+
+
   void VPStaticDatabase::setDeviceName(uint64_t deviceId, const std::string& name)
   {
     std::lock_guard<std::mutex> lock(deviceLock) ;
@@ -952,13 +978,13 @@ namespace xdp {
   void VPStaticDatabase::addAIECounterResources(uint64_t deviceId,
                                                 uint32_t numCounters,
                                                 uint32_t numTiles,
-                                                bool isCore)
+                                                uint8_t moduleType)
   {
     std::lock_guard<std::mutex> lock(deviceLock) ;
 
     if (deviceInfo.find(deviceId) == deviceInfo.end())
       return ;
-    deviceInfo[deviceId]->addAIECounterResources(numCounters, numTiles, isCore);
+    deviceInfo[deviceId]->addAIECounterResources(numCounters, numTiles, moduleType);
   }
 
   void VPStaticDatabase::addAIECoreEventResources(uint64_t deviceId,
@@ -1300,6 +1326,68 @@ namespace xdp {
     return true;
   }
 
+  double VPStaticDatabase::findClockRate(std::shared_ptr<xrt_core::device> device)
+  {
+    double defaultClockSpeed = 300.0 ;
+
+    // First, check the clock frequency topology
+    const clock_freq_topology* clockSection =
+      device->get_axlf_section<const clock_freq_topology*>(CLOCK_FREQ_TOPOLOGY);
+
+    if(clockSection) {
+      for(int32_t i = 0; i < clockSection->m_count; i++) {
+        const struct clock_freq* clk = &(clockSection->m_clock_freq[i]);
+        if(clk->m_type != CT_DATA) {
+          continue;
+        }
+        return clk->m_freq_Mhz ;
+      }
+    }
+
+    if (isEdge()) {
+      // On Edge, we can try to get the "DATA_CLK" from the embedded metadata
+      std::pair<const char*, size_t> metadataSection =
+        device->get_axlf_section(EMBEDDED_METADATA) ;
+      const char* rawXml = metadataSection.first ;
+      size_t xmlSize = metadataSection.second ;
+      if (rawXml == nullptr || xmlSize == 0)
+        return defaultClockSpeed ;
+
+      // Convert the raw character stream into a boost::property_tree
+      std::string xmlFile ;
+      xmlFile.assign(rawXml, xmlSize) ;
+      std::stringstream xmlStream ;
+      xmlStream << xmlFile ;
+      boost::property_tree::ptree xmlProject ;
+      boost::property_tree::read_xml(xmlStream, xmlProject) ;
+
+      // Dig in and find all of the kernel clocks
+      for (auto& clock : xmlProject.get_child("project.platform.device.core.kernelClocks")) {
+        if (clock.first != "clock")
+          continue ;
+
+        try {
+          std::string port = clock.second.get<std::string>("<xmlattr>.port") ;
+          if (port != "DATA_CLK")
+            continue ;
+          std::string freq = clock.second.get<std::string>("<xmlattr>.frequency") ;
+          std::string freqNumeral = freq.substr(0, freq.find('M')) ;
+          double frequency = defaultClockSpeed ;
+          std::stringstream convert ;
+          convert << freqNumeral ;
+          convert >> frequency ;
+          return frequency ;
+        }
+        catch (std::exception& /*e*/) {
+          continue ;
+        }
+      }
+    }
+
+    // We didn't find it in any section, so just assume 300 MHz for now
+    return defaultClockSpeed ;
+  }
+
   // This function is called whenever a device is loaded with an 
   //  xclbin.  It has to clear out any previous device information and
   //  reload our information.
@@ -1315,11 +1403,49 @@ namespace xdp {
       return;
     }
     
-    xrt::xclbin xrtXclbin = device->get_xclbin(device->get_xclbin_uuid());
-    DeviceInfo* devInfo   = updateDevice(deviceId, xrtXclbin);
-    if (device->is_nodma())
-      devInfo->isNoDMADevice = true ;
+    // We need to update the device, but if we had an xclbin previously loaded
+    //  then we need to mark it
+    if (deviceInfo.find(deviceId) != deviceInfo.end()) {
+      XclbinInfo* xclbin = deviceInfo[deviceId]->currentXclbin() ;
+      if (xclbin)
+        db->getDynamicInfo().markXclbinEnd(deviceId) ;
+    }
 
+    DeviceInfo* devInfo = nullptr ;
+    auto itr = deviceInfo.find(deviceId);
+    if (itr == deviceInfo.end()) {
+      // This is the first time this device was loaded with an xclbin
+      devInfo = new DeviceInfo();
+      devInfo->deviceId = deviceId ;
+      if (isEdge())
+        devInfo->isEdgeDevice = true ;
+      if (device->is_nodma())
+        devInfo->isNoDMADevice = true ;
+      deviceInfo[deviceId] = devInfo ;
+
+    } else {
+      // This is a previously used device being reloaded with a new xclbin
+      devInfo = itr->second ;
+      devInfo->cleanCurrentXclbinInfo() ;
+    }
+    
+    XclbinInfo* currentXclbin = new XclbinInfo() ;
+    currentXclbin->uuid = device->get_xclbin_uuid() ;
+    currentXclbin->pl.clockRatePLMHz = findClockRate(device) ;  
+    setAIEClockRateMHz(device,deviceId);
+    /* Configure AMs if context monitoring is supported
+     * else disable alll AMs on this device
+     */
+    devInfo->ctxInfo = xrt_core::config::get_kernel_channel_info();
+
+    if (!initializeStructure(currentXclbin, device)) {
+      delete currentXclbin;
+      return;
+    }
+
+    devInfo->addXclbin(currentXclbin);
+    initializeProfileMonitors(devInfo, device);
+    devInfo->isReady = true;
   }
 
   // Return true if we should reset the device information.
@@ -1481,6 +1607,58 @@ namespace xdp {
     } catch(...) {
       // If we catch an exception, leave the rest of the port info as is.
     }
+  }
+
+  bool VPStaticDatabase::initializeStructure(XclbinInfo* currentXclbin,
+                                             const std::shared_ptr<xrt_core::device>& device)
+  {
+    // Step 1 -> Create the compute units based on the IP_LAYOUT section
+    const ip_layout* ipLayoutSection =
+      device->get_axlf_section<const ip_layout*>(IP_LAYOUT);
+
+    if(ipLayoutSection == nullptr)
+      return true;
+
+    createComputeUnits(currentXclbin, ipLayoutSection);
+
+    // Step 2 -> Create the memory layout based on the MEM_TOPOLOGY section
+    const mem_topology* memTopologySection =
+      device->get_axlf_section<const mem_topology*>(MEM_TOPOLOGY);
+
+    if(memTopologySection == nullptr)
+      return false;
+
+    createMemories(currentXclbin, memTopologySection);
+
+    // Step 3 -> Connect the CUs with the memory resources using the
+    //           CONNECTIVITY section
+    const connectivity* connectivitySection =
+      device->get_axlf_section<const connectivity*>(CONNECTIVITY);
+
+    if(connectivitySection == nullptr)
+      return true;
+
+    createConnections(currentXclbin, ipLayoutSection, memTopologySection,
+                      connectivitySection);
+
+    // Step 4 -> Annotate all the compute units with workgroup size using
+    //           the EMBEDDED_METADATA section
+    std::pair<const char*, size_t> embeddedMetadata =
+      device->get_axlf_section(EMBEDDED_METADATA);
+
+    annotateWorkgroupSize(currentXclbin, embeddedMetadata.first,
+                          embeddedMetadata.second);
+
+    // Step 5 -> Fill in the details like the name of the xclbin using
+    //           the SYSTEM_METADATA section
+    std::pair<const char*, size_t> systemMetadata =
+      device->get_axlf_section(SYSTEM_METADATA);
+
+    setXclbinName(currentXclbin, systemMetadata.first, systemMetadata.second);
+    updateSystemDiagram(systemMetadata.first, systemMetadata.second);
+    addPortInfo(currentXclbin, systemMetadata.first, systemMetadata.second);
+
+    return true;
   }
 
   void VPStaticDatabase::createComputeUnits(XclbinInfo* currentXclbin,
@@ -1880,248 +2058,12 @@ namespace xdp {
       xclbin->pl.usesTs2mm = true ;
   }
 
-  void VPStaticDatabase::addCommandQueueAddress(uint64_t a)
-  {
-    std::lock_guard<std::mutex> lock(openCLLock) ;
-
-    commandQueueAddresses.emplace(a) ;
-  }
-
-  // This function is called from "trace_processor" tool 
-  // The tool creates events from raw PL trace data
-  void VPStaticDatabase::updateDevice(uint64_t deviceId, const std::string& xclbinFile)
-  {
-    xrt::xclbin xrtXclbin = xrt::xclbin(xclbinFile);
-
-    updateDevice(deviceId, xrtXclbin);
-  }
-
-  // Methods using xrt::xclbin to retrive static information
-
-  DeviceInfo* VPStaticDatabase::updateDevice(uint64_t deviceId, xrt::xclbin xrtXclbin)
-  {    
-    // We need to update the device, but if we had an xclbin previously loaded
-    //  then we need to mark it
-    if (deviceInfo.find(deviceId) != deviceInfo.end()) {
-      XclbinInfo* xclbin = deviceInfo[deviceId]->currentXclbin() ;
-      if (xclbin)
-        db->getDynamicInfo().markXclbinEnd(deviceId) ;
-    }
-
-    DeviceInfo* devInfo = nullptr ;
-    auto itr = deviceInfo.find(deviceId);
-    if (itr == deviceInfo.end()) {
-      // This is the first time this device was loaded with an xclbin
-      devInfo = new DeviceInfo();
-      devInfo->deviceId = deviceId ;
-      if (isEdge())
-        devInfo->isEdgeDevice = true ;
-      deviceInfo[deviceId] = devInfo ;
-
-    } else {
-      // This is a previously used device being reloaded with a new xclbin
-      devInfo = itr->second ;
-      devInfo->cleanCurrentXclbinInfo() ;
-    }
-    
-    XclbinInfo* currentXclbin = new XclbinInfo() ;
-    currentXclbin->uuid = xrtXclbin.get_uuid();
-    currentXclbin->pl.clockRatePLMHz = findClockRate(xrtXclbin) ; 
- 
-    setDeviceNameFromXclbin(deviceId, xrtXclbin);
-    setAIEClockRateMHz(deviceId, xrtXclbin);
-    /* Configure AMs if context monitoring is supported
-     * else disable alll AMs on this device
-     */
-    devInfo->ctxInfo = xrt_core::config::get_kernel_channel_info();
-
-    if (!initializeStructure(currentXclbin, xrtXclbin)) {
-      delete currentXclbin;
-      return devInfo;
-    }
-
-    devInfo->addXclbin(currentXclbin);
-    initializeProfileMonitors(devInfo, xrtXclbin);
-    devInfo->isReady = true;
-
-    return devInfo;
-
-  }
-
-  void VPStaticDatabase::setDeviceNameFromXclbin(uint64_t deviceId, xrt::xclbin xrtXclbin)
-  {
-    std::lock_guard<std::mutex> lock(deviceLock);
-
-    if (deviceInfo.find(deviceId) == deviceInfo.end())
-      return;
-    if (!deviceInfo[deviceId]->deviceName.empty()) {
-      return;
-    }
-
-    std::pair<const char*, size_t> systemMetadata =
-       xrt_core::xclbin_int::get_axlf_section(xrtXclbin, SYSTEM_METADATA);
-
-    if (systemMetadata.first == nullptr || systemMetadata.second <= 0) {
-      // There is no SYSTEM_METADATA section
-      return;
-    }
-
-    try {
-      std::stringstream ss;
-      ss.write(systemMetadata.first, systemMetadata.second);
-
-      // Create a property tree based off of the JSON
-      boost::property_tree::ptree pt;
-      boost::property_tree::read_json(ss, pt);
-
-      deviceInfo[deviceId]->deviceName = pt.get<std::string>("system_diagram_metadata.xsa.name", "");
-    } catch(...) {
-      return;
-    }
-  }
-  
-  void VPStaticDatabase::setAIEClockRateMHz(uint64_t deviceId, xrt::xclbin xrtXclbin) {
-    std::lock_guard<std::mutex> lock(deviceLock) ;
-
-    if (deviceInfo.find(deviceId) == deviceInfo.end())
-      return;
-
-    XclbinInfo* xclbin = deviceInfo[deviceId]->currentXclbin() ;
-    if (!xclbin)
-      return;
-
-    auto data = xrt_core::xclbin_int::get_axlf_section(xrtXclbin, AIE_METADATA);
-    if (!data.first || !data.second)
-      return;
-
-    boost::property_tree::ptree aie_meta;
-
-    std::stringstream aie_stream;
-    aie_stream.write(data.first, data.second);
-    boost::property_tree::read_json(aie_stream,aie_meta);
-
-    //read_aie_metadata(data.first, data.second, aie_meta);
-    auto dev_node = aie_meta.get_child("aie_metadata.DeviceData");
-    
-    xclbin->aie.clockRateAIEMHz = dev_node.get<double>("AIEFrequency");
-  }
-
-  double VPStaticDatabase::findClockRate(xrt::xclbin xrtXclbin)
-  {
-    double defaultClockSpeed = 300.0 ;
-
-    const clock_freq_topology* clockSection =
-      reinterpret_cast<const clock_freq_topology*>(
-        xrt_core::xclbin_int::get_axlf_section(xrtXclbin, CLOCK_FREQ_TOPOLOGY).first);
-
-    if(clockSection) {
-      for(int32_t i = 0; i < clockSection->m_count; i++) {
-        const struct clock_freq* clk = &(clockSection->m_clock_freq[i]);
-        if(clk->m_type != CT_DATA) {
-          continue;
-        }
-        return clk->m_freq_Mhz ;
-      }
-    }
-
-    if (isEdge()) {
-      // On Edge, we can try to get the "DATA_CLK" from the embedded metadata
-      std::pair<const char*, size_t> embeddedMetadata =
-        xrt_core::xclbin_int::get_axlf_section(xrtXclbin, EMBEDDED_METADATA);
-
-      if (nullptr == embeddedMetadata.first || 0 == embeddedMetadata.second)
-        return defaultClockSpeed;
-
-      std::stringstream ss;
-      ss.write(embeddedMetadata.first, embeddedMetadata.second);
-
-      // Create a property tree based off of the JSON
-      boost::property_tree::ptree pt;
-      boost::property_tree::read_json(ss, pt);
-
-      // Dig in and find all of the kernel clocks
-      for (auto& clock : pt.get_child("project.platform.device.core.kernelClocks")) {
-        if (clock.first != "clock")
-          continue;
-
-        try {
-          std::string port = clock.second.get<std::string>("<xmlattr>.port");
-          if (port != "DATA_CLK")
-            continue;
-          std::string freq = clock.second.get<std::string>("<xmlattr>.frequency");
-          std::string freqNumeral = freq.substr(0, freq.find('M')) ;
-          double frequency = defaultClockSpeed ;
-          std::stringstream convert ;
-          convert << freqNumeral ;
-          convert >> frequency ;
-          return frequency ;
-        }
-        catch (std::exception& /*e*/) {
-          continue ;
-        }
-      }
-    }
-    return defaultClockSpeed;
-  }
-
-  bool VPStaticDatabase::initializeStructure(XclbinInfo* currentXclbin, xrt::xclbin xrtXclbin)
-  {
-    // Step 1 -> Create the compute units based on the IP_LAYOUT section
-    const ip_layout* ipLayoutSection =
-      reinterpret_cast<const ip_layout*>(xrt_core::xclbin_int::get_axlf_section(xrtXclbin, IP_LAYOUT).first);
-
-    if(ipLayoutSection == nullptr)
-      return true;
-
-    createComputeUnits(currentXclbin, ipLayoutSection);
-
-    // Step 2 -> Create the memory layout based on the MEM_TOPOLOGY section
-    const mem_topology* memTopologySection =
-      reinterpret_cast<const mem_topology*>(xrt_core::xclbin_int::get_axlf_section(xrtXclbin, MEM_TOPOLOGY).first);
-
-    if(memTopologySection == nullptr)
-      return false;
-
-    createMemories(currentXclbin, memTopologySection);
-
-    // Step 3 -> Connect the CUs with the memory resources using the
-    //           CONNECTIVITY section
-    const connectivity* connectivitySection =
-      reinterpret_cast<const connectivity*>(xrt_core::xclbin_int::get_axlf_section(xrtXclbin, CONNECTIVITY).first);
-
-    if(connectivitySection == nullptr)
-      return true;
-
-    createConnections(currentXclbin, ipLayoutSection, memTopologySection,
-                      connectivitySection);
-
-    // Step 4 -> Annotate all the compute units with workgroup size using
-    //           the EMBEDDED_METADATA section
-    std::pair<const char*, size_t> embeddedMetadata =
-       xrt_core::xclbin_int::get_axlf_section(xrtXclbin, EMBEDDED_METADATA);
-
-    annotateWorkgroupSize(currentXclbin, embeddedMetadata.first,
-                          embeddedMetadata.second);
-
-    // Step 5 -> Fill in the details like the name of the xclbin using
-    //           the SYSTEM_METADATA section
-    std::pair<const char*, size_t> systemMetadata =
-       xrt_core::xclbin_int::get_axlf_section(xrtXclbin, SYSTEM_METADATA);
-
-    setXclbinName(currentXclbin, systemMetadata.first, systemMetadata.second);
-    updateSystemDiagram(systemMetadata.first, systemMetadata.second);
-    addPortInfo(currentXclbin, systemMetadata.first, systemMetadata.second);
-
-    return true;
-  }
-
-  bool VPStaticDatabase::initializeProfileMonitors(DeviceInfo* devInfo, xrt::xclbin xrtXclbin)
+  bool VPStaticDatabase::initializeProfileMonitors(DeviceInfo* devInfo, const std::shared_ptr<xrt_core::device>& device)
   {
     // Look into the debug_ip_layout section and load information about Profile Monitors
     // Get DEBUG_IP_LAYOUT section
     const debug_ip_layout* debugIpLayoutSection =
-      reinterpret_cast<const debug_ip_layout*>(xrt_core::xclbin_int::get_axlf_section(xrtXclbin, DEBUG_IP_LAYOUT).first);
-
+      device->get_axlf_section<const debug_ip_layout*>(DEBUG_IP_LAYOUT);
     if(debugIpLayoutSection == nullptr) return false;
 
     for(uint16_t i = 0; i < debugIpLayoutSection->m_count; i++) {
@@ -2147,7 +2089,7 @@ namespace xdp {
         break ;
       case AXI_STREAM_MONITOR:
         initializeASM(devInfo, name, debugIpData) ;
-       break ;
+        break ;
       case AXI_NOC:
         initializeNOC(devInfo, debugIpData) ;
         break ;
@@ -2159,7 +2101,14 @@ namespace xdp {
       }
     }
 
-    return true;
-  }  
+    return true; 
+  }
+
+  void VPStaticDatabase::addCommandQueueAddress(uint64_t a)
+  {
+    std::lock_guard<std::mutex> lock(openCLLock) ;
+
+    commandQueueAddresses.emplace(a) ;
+  }
 
 } // end namespace xdp

--- a/src/runtime_src/xdp/profile/database/static_info_database.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info_database.cpp
@@ -818,21 +818,6 @@ namespace xdp {
   }
 
   std::map<uint32_t, uint32_t>*
-  VPStaticDatabase::getAIEMemTileCounterResources(uint64_t deviceId)
-  {
-    std::lock_guard<std::mutex> lock(deviceLock) ;
-
-    if (deviceInfo.find(deviceId) == deviceInfo.end())
-      return nullptr ;
-
-    XclbinInfo* xclbin = deviceInfo[deviceId]->currentXclbin() ;
-    if (!xclbin)
-      return nullptr ;
-
-    return &(xclbin->aie.aieMemTileCountersMap) ;
-  }
-
-  std::map<uint32_t, uint32_t>*
   VPStaticDatabase::getAIEShimCounterResources(uint64_t deviceId)
   {
     std::lock_guard<std::mutex> lock(deviceLock) ;
@@ -845,6 +830,21 @@ namespace xdp {
       return nullptr ;
 
     return &(xclbin->aie.aieShimCountersMap) ;
+  }
+
+  std::map<uint32_t, uint32_t>*
+  VPStaticDatabase::getAIEMemTileCounterResources(uint64_t deviceId)
+  {
+    std::lock_guard<std::mutex> lock(deviceLock) ;
+
+    if (deviceInfo.find(deviceId) == deviceInfo.end())
+      return nullptr ;
+
+    XclbinInfo* xclbin = deviceInfo[deviceId]->currentXclbin() ;
+    if (!xclbin)
+      return nullptr ;
+
+    return &(xclbin->aie.aieMemTileCountersMap) ;
   }
 
   std::map<uint32_t, uint32_t>*
@@ -878,21 +878,6 @@ namespace xdp {
   }
 
   std::map<uint32_t, uint32_t>*
-  VPStaticDatabase::getAIEMemTileEventResources(uint64_t deviceId)
-  {
-    std::lock_guard<std::mutex> lock(deviceLock) ;
-
-    if (deviceInfo.find(deviceId) == deviceInfo.end())
-      return nullptr ;
-
-    XclbinInfo* xclbin = deviceInfo[deviceId]->currentXclbin() ;
-    if (!xclbin)
-      return nullptr ;
-
-    return &(xclbin->aie.aieMemTileEventsMap) ;
-  }
-  
-  std::map<uint32_t, uint32_t>*
   VPStaticDatabase::getAIEShimEventResources(uint64_t deviceId)
   {
     std::lock_guard<std::mutex> lock(deviceLock) ;
@@ -905,6 +890,21 @@ namespace xdp {
       return nullptr ;
 
     return &(xclbin->aie.aieShimEventsMap) ;
+  }
+
+  std::map<uint32_t, uint32_t>*
+  VPStaticDatabase::getAIEMemTileEventResources(uint64_t deviceId)
+  {
+    std::lock_guard<std::mutex> lock(deviceLock) ;
+
+    if (deviceInfo.find(deviceId) == deviceInfo.end())
+      return nullptr ;
+
+    XclbinInfo* xclbin = deviceInfo[deviceId]->currentXclbin() ;
+    if (!xclbin)
+      return nullptr ;
+
+    return &(xclbin->aie.aieMemTileEventsMap) ;
   }
 
   std::vector<std::unique_ptr<aie_cfg_tile>>*
@@ -996,6 +996,17 @@ namespace xdp {
     if (deviceInfo.find(deviceId) == deviceInfo.end())
       return ;
     deviceInfo[deviceId]->addAIEMemoryEventResources(numEvents, numTiles) ;
+  }
+
+  void VPStaticDatabase::addAIEShimEventResources(uint64_t deviceId,
+                                                  uint32_t numEvents,
+                                                  uint32_t numTiles)
+  {
+    std::lock_guard<std::mutex> lock(deviceLock) ;
+
+    if (deviceInfo.find(deviceId) == deviceInfo.end())
+      return ;
+    deviceInfo[deviceId]->addAIEShimEventResources(numEvents, numTiles) ;
   }
 
   void VPStaticDatabase::addAIEMemTileEventResources(uint64_t deviceId,

--- a/src/runtime_src/xdp/profile/database/static_info_database.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info_database.cpp
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2016-2022 Xilinx, Inc
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -37,6 +37,7 @@
 
 #include "core/common/config_reader.h"
 #include "core/common/message.h"
+#include "core/common/api/xclbin_int.h"
 #include "core/include/xclbin.h"
 
 #define XDP_SOURCE
@@ -345,33 +346,6 @@ namespace xdp {
       return xclbin->aie.clockRateAIEMHz ;
   }
   
-  void VPStaticDatabase::setAIEClockRateMHz(std::shared_ptr<xrt_core::device> device, uint64_t deviceId){
-    std::lock_guard<std::mutex> lock(deviceLock) ;
-
-    if (deviceInfo.find(deviceId) == deviceInfo.end())
-      return;
-
-    XclbinInfo* xclbin = deviceInfo[deviceId]->currentXclbin() ;
-    if (!xclbin)
-      return;
-
-    auto data = device->get_axlf_section(AIE_METADATA);
-    if (!data.first || !data.second)
-      return;
-
-    boost::property_tree::ptree aie_meta;
-
-    std::stringstream aie_stream;
-    aie_stream.write(data.first, data.second);
-    boost::property_tree::read_json(aie_stream,aie_meta);
-
-    //read_aie_metadata(data.first, data.second, aie_meta);
-    auto dev_node = aie_meta.get_child("aie_metadata.DeviceData");
-    
-    xclbin->aie.clockRateAIEMHz = dev_node.get<double>("AIEFrequency");
-  }
-
-
   void VPStaticDatabase::setDeviceName(uint64_t deviceId, const std::string& name)
   {
     std::lock_guard<std::mutex> lock(deviceLock) ;
@@ -1326,68 +1300,6 @@ namespace xdp {
     return true;
   }
 
-  double VPStaticDatabase::findClockRate(std::shared_ptr<xrt_core::device> device)
-  {
-    double defaultClockSpeed = 300.0 ;
-
-    // First, check the clock frequency topology
-    const clock_freq_topology* clockSection =
-      device->get_axlf_section<const clock_freq_topology*>(CLOCK_FREQ_TOPOLOGY);
-
-    if(clockSection) {
-      for(int32_t i = 0; i < clockSection->m_count; i++) {
-        const struct clock_freq* clk = &(clockSection->m_clock_freq[i]);
-        if(clk->m_type != CT_DATA) {
-          continue;
-        }
-        return clk->m_freq_Mhz ;
-      }
-    }
-
-    if (isEdge()) {
-      // On Edge, we can try to get the "DATA_CLK" from the embedded metadata
-      std::pair<const char*, size_t> metadataSection =
-        device->get_axlf_section(EMBEDDED_METADATA) ;
-      const char* rawXml = metadataSection.first ;
-      size_t xmlSize = metadataSection.second ;
-      if (rawXml == nullptr || xmlSize == 0)
-        return defaultClockSpeed ;
-
-      // Convert the raw character stream into a boost::property_tree
-      std::string xmlFile ;
-      xmlFile.assign(rawXml, xmlSize) ;
-      std::stringstream xmlStream ;
-      xmlStream << xmlFile ;
-      boost::property_tree::ptree xmlProject ;
-      boost::property_tree::read_xml(xmlStream, xmlProject) ;
-
-      // Dig in and find all of the kernel clocks
-      for (auto& clock : xmlProject.get_child("project.platform.device.core.kernelClocks")) {
-        if (clock.first != "clock")
-          continue ;
-
-        try {
-          std::string port = clock.second.get<std::string>("<xmlattr>.port") ;
-          if (port != "DATA_CLK")
-            continue ;
-          std::string freq = clock.second.get<std::string>("<xmlattr>.frequency") ;
-          std::string freqNumeral = freq.substr(0, freq.find('M')) ;
-          double frequency = defaultClockSpeed ;
-          std::stringstream convert ;
-          convert << freqNumeral ;
-          convert >> frequency ;
-          return frequency ;
-        }
-        catch (std::exception& /*e*/) {
-          continue ;
-        }
-      }
-    }
-
-    // We didn't find it in any section, so just assume 300 MHz for now
-    return defaultClockSpeed ;
-  }
-
   // This function is called whenever a device is loaded with an 
   //  xclbin.  It has to clear out any previous device information and
   //  reload our information.
@@ -1403,49 +1315,11 @@ namespace xdp {
       return;
     }
     
-    // We need to update the device, but if we had an xclbin previously loaded
-    //  then we need to mark it
-    if (deviceInfo.find(deviceId) != deviceInfo.end()) {
-      XclbinInfo* xclbin = deviceInfo[deviceId]->currentXclbin() ;
-      if (xclbin)
-        db->getDynamicInfo().markXclbinEnd(deviceId) ;
-    }
+    xrt::xclbin xrtXclbin = device->get_xclbin(device->get_xclbin_uuid());
+    DeviceInfo* devInfo   = updateDevice(deviceId, xrtXclbin);
+    if (device->is_nodma())
+      devInfo->isNoDMADevice = true ;
 
-    DeviceInfo* devInfo = nullptr ;
-    auto itr = deviceInfo.find(deviceId);
-    if (itr == deviceInfo.end()) {
-      // This is the first time this device was loaded with an xclbin
-      devInfo = new DeviceInfo();
-      devInfo->deviceId = deviceId ;
-      if (isEdge())
-        devInfo->isEdgeDevice = true ;
-      if (device->is_nodma())
-        devInfo->isNoDMADevice = true ;
-      deviceInfo[deviceId] = devInfo ;
-
-    } else {
-      // This is a previously used device being reloaded with a new xclbin
-      devInfo = itr->second ;
-      devInfo->cleanCurrentXclbinInfo() ;
-    }
-    
-    XclbinInfo* currentXclbin = new XclbinInfo() ;
-    currentXclbin->uuid = device->get_xclbin_uuid() ;
-    currentXclbin->pl.clockRatePLMHz = findClockRate(device) ;  
-    setAIEClockRateMHz(device,deviceId);
-    /* Configure AMs if context monitoring is supported
-     * else disable alll AMs on this device
-     */
-    devInfo->ctxInfo = xrt_core::config::get_kernel_channel_info();
-
-    if (!initializeStructure(currentXclbin, device)) {
-      delete currentXclbin;
-      return;
-    }
-
-    devInfo->addXclbin(currentXclbin);
-    initializeProfileMonitors(devInfo, device);
-    devInfo->isReady = true;
   }
 
   // Return true if we should reset the device information.
@@ -1607,58 +1481,6 @@ namespace xdp {
     } catch(...) {
       // If we catch an exception, leave the rest of the port info as is.
     }
-  }
-
-  bool VPStaticDatabase::initializeStructure(XclbinInfo* currentXclbin,
-                                             const std::shared_ptr<xrt_core::device>& device)
-  {
-    // Step 1 -> Create the compute units based on the IP_LAYOUT section
-    const ip_layout* ipLayoutSection =
-      device->get_axlf_section<const ip_layout*>(IP_LAYOUT);
-
-    if(ipLayoutSection == nullptr)
-      return true;
-
-    createComputeUnits(currentXclbin, ipLayoutSection);
-
-    // Step 2 -> Create the memory layout based on the MEM_TOPOLOGY section
-    const mem_topology* memTopologySection =
-      device->get_axlf_section<const mem_topology*>(MEM_TOPOLOGY);
-
-    if(memTopologySection == nullptr)
-      return false;
-
-    createMemories(currentXclbin, memTopologySection);
-
-    // Step 3 -> Connect the CUs with the memory resources using the
-    //           CONNECTIVITY section
-    const connectivity* connectivitySection =
-      device->get_axlf_section<const connectivity*>(CONNECTIVITY);
-
-    if(connectivitySection == nullptr)
-      return true;
-
-    createConnections(currentXclbin, ipLayoutSection, memTopologySection,
-                      connectivitySection);
-
-    // Step 4 -> Annotate all the compute units with workgroup size using
-    //           the EMBEDDED_METADATA section
-    std::pair<const char*, size_t> embeddedMetadata =
-      device->get_axlf_section(EMBEDDED_METADATA);
-
-    annotateWorkgroupSize(currentXclbin, embeddedMetadata.first,
-                          embeddedMetadata.second);
-
-    // Step 5 -> Fill in the details like the name of the xclbin using
-    //           the SYSTEM_METADATA section
-    std::pair<const char*, size_t> systemMetadata =
-      device->get_axlf_section(SYSTEM_METADATA);
-
-    setXclbinName(currentXclbin, systemMetadata.first, systemMetadata.second);
-    updateSystemDiagram(systemMetadata.first, systemMetadata.second);
-    addPortInfo(currentXclbin, systemMetadata.first, systemMetadata.second);
-
-    return true;
   }
 
   void VPStaticDatabase::createComputeUnits(XclbinInfo* currentXclbin,
@@ -2058,12 +1880,248 @@ namespace xdp {
       xclbin->pl.usesTs2mm = true ;
   }
 
-  bool VPStaticDatabase::initializeProfileMonitors(DeviceInfo* devInfo, const std::shared_ptr<xrt_core::device>& device)
+  void VPStaticDatabase::addCommandQueueAddress(uint64_t a)
+  {
+    std::lock_guard<std::mutex> lock(openCLLock) ;
+
+    commandQueueAddresses.emplace(a) ;
+  }
+
+  // This function is called from "trace_processor" tool 
+  // The tool creates events from raw PL trace data
+  void VPStaticDatabase::updateDevice(uint64_t deviceId, const std::string& xclbinFile)
+  {
+    xrt::xclbin xrtXclbin = xrt::xclbin(xclbinFile);
+
+    updateDevice(deviceId, xrtXclbin);
+  }
+
+  // Methods using xrt::xclbin to retrive static information
+
+  DeviceInfo* VPStaticDatabase::updateDevice(uint64_t deviceId, xrt::xclbin xrtXclbin)
+  {    
+    // We need to update the device, but if we had an xclbin previously loaded
+    //  then we need to mark it
+    if (deviceInfo.find(deviceId) != deviceInfo.end()) {
+      XclbinInfo* xclbin = deviceInfo[deviceId]->currentXclbin() ;
+      if (xclbin)
+        db->getDynamicInfo().markXclbinEnd(deviceId) ;
+    }
+
+    DeviceInfo* devInfo = nullptr ;
+    auto itr = deviceInfo.find(deviceId);
+    if (itr == deviceInfo.end()) {
+      // This is the first time this device was loaded with an xclbin
+      devInfo = new DeviceInfo();
+      devInfo->deviceId = deviceId ;
+      if (isEdge())
+        devInfo->isEdgeDevice = true ;
+      deviceInfo[deviceId] = devInfo ;
+
+    } else {
+      // This is a previously used device being reloaded with a new xclbin
+      devInfo = itr->second ;
+      devInfo->cleanCurrentXclbinInfo() ;
+    }
+    
+    XclbinInfo* currentXclbin = new XclbinInfo() ;
+    currentXclbin->uuid = xrtXclbin.get_uuid();
+    currentXclbin->pl.clockRatePLMHz = findClockRate(xrtXclbin) ; 
+ 
+    setDeviceNameFromXclbin(deviceId, xrtXclbin);
+    setAIEClockRateMHz(deviceId, xrtXclbin);
+    /* Configure AMs if context monitoring is supported
+     * else disable alll AMs on this device
+     */
+    devInfo->ctxInfo = xrt_core::config::get_kernel_channel_info();
+
+    if (!initializeStructure(currentXclbin, xrtXclbin)) {
+      delete currentXclbin;
+      return devInfo;
+    }
+
+    devInfo->addXclbin(currentXclbin);
+    initializeProfileMonitors(devInfo, xrtXclbin);
+    devInfo->isReady = true;
+
+    return devInfo;
+
+  }
+
+  void VPStaticDatabase::setDeviceNameFromXclbin(uint64_t deviceId, xrt::xclbin xrtXclbin)
+  {
+    std::lock_guard<std::mutex> lock(deviceLock);
+
+    if (deviceInfo.find(deviceId) == deviceInfo.end())
+      return;
+    if (!deviceInfo[deviceId]->deviceName.empty()) {
+      return;
+    }
+
+    std::pair<const char*, size_t> systemMetadata =
+       xrt_core::xclbin_int::get_axlf_section(xrtXclbin, SYSTEM_METADATA);
+
+    if (systemMetadata.first == nullptr || systemMetadata.second <= 0) {
+      // There is no SYSTEM_METADATA section
+      return;
+    }
+
+    try {
+      std::stringstream ss;
+      ss.write(systemMetadata.first, systemMetadata.second);
+
+      // Create a property tree based off of the JSON
+      boost::property_tree::ptree pt;
+      boost::property_tree::read_json(ss, pt);
+
+      deviceInfo[deviceId]->deviceName = pt.get<std::string>("system_diagram_metadata.xsa.name", "");
+    } catch(...) {
+      return;
+    }
+  }
+  
+  void VPStaticDatabase::setAIEClockRateMHz(uint64_t deviceId, xrt::xclbin xrtXclbin) {
+    std::lock_guard<std::mutex> lock(deviceLock) ;
+
+    if (deviceInfo.find(deviceId) == deviceInfo.end())
+      return;
+
+    XclbinInfo* xclbin = deviceInfo[deviceId]->currentXclbin() ;
+    if (!xclbin)
+      return;
+
+    auto data = xrt_core::xclbin_int::get_axlf_section(xrtXclbin, AIE_METADATA);
+    if (!data.first || !data.second)
+      return;
+
+    boost::property_tree::ptree aie_meta;
+
+    std::stringstream aie_stream;
+    aie_stream.write(data.first, data.second);
+    boost::property_tree::read_json(aie_stream,aie_meta);
+
+    //read_aie_metadata(data.first, data.second, aie_meta);
+    auto dev_node = aie_meta.get_child("aie_metadata.DeviceData");
+    
+    xclbin->aie.clockRateAIEMHz = dev_node.get<double>("AIEFrequency");
+  }
+
+  double VPStaticDatabase::findClockRate(xrt::xclbin xrtXclbin)
+  {
+    double defaultClockSpeed = 300.0 ;
+
+    const clock_freq_topology* clockSection =
+      reinterpret_cast<const clock_freq_topology*>(
+        xrt_core::xclbin_int::get_axlf_section(xrtXclbin, CLOCK_FREQ_TOPOLOGY).first);
+
+    if(clockSection) {
+      for(int32_t i = 0; i < clockSection->m_count; i++) {
+        const struct clock_freq* clk = &(clockSection->m_clock_freq[i]);
+        if(clk->m_type != CT_DATA) {
+          continue;
+        }
+        return clk->m_freq_Mhz ;
+      }
+    }
+
+    if (isEdge()) {
+      // On Edge, we can try to get the "DATA_CLK" from the embedded metadata
+      std::pair<const char*, size_t> embeddedMetadata =
+        xrt_core::xclbin_int::get_axlf_section(xrtXclbin, EMBEDDED_METADATA);
+
+      if (nullptr == embeddedMetadata.first || 0 == embeddedMetadata.second)
+        return defaultClockSpeed;
+
+      std::stringstream ss;
+      ss.write(embeddedMetadata.first, embeddedMetadata.second);
+
+      // Create a property tree based off of the JSON
+      boost::property_tree::ptree pt;
+      boost::property_tree::read_json(ss, pt);
+
+      // Dig in and find all of the kernel clocks
+      for (auto& clock : pt.get_child("project.platform.device.core.kernelClocks")) {
+        if (clock.first != "clock")
+          continue;
+
+        try {
+          std::string port = clock.second.get<std::string>("<xmlattr>.port");
+          if (port != "DATA_CLK")
+            continue;
+          std::string freq = clock.second.get<std::string>("<xmlattr>.frequency");
+          std::string freqNumeral = freq.substr(0, freq.find('M')) ;
+          double frequency = defaultClockSpeed ;
+          std::stringstream convert ;
+          convert << freqNumeral ;
+          convert >> frequency ;
+          return frequency ;
+        }
+        catch (std::exception& /*e*/) {
+          continue ;
+        }
+      }
+    }
+    return defaultClockSpeed;
+  }
+
+  bool VPStaticDatabase::initializeStructure(XclbinInfo* currentXclbin, xrt::xclbin xrtXclbin)
+  {
+    // Step 1 -> Create the compute units based on the IP_LAYOUT section
+    const ip_layout* ipLayoutSection =
+      reinterpret_cast<const ip_layout*>(xrt_core::xclbin_int::get_axlf_section(xrtXclbin, IP_LAYOUT).first);
+
+    if(ipLayoutSection == nullptr)
+      return true;
+
+    createComputeUnits(currentXclbin, ipLayoutSection);
+
+    // Step 2 -> Create the memory layout based on the MEM_TOPOLOGY section
+    const mem_topology* memTopologySection =
+      reinterpret_cast<const mem_topology*>(xrt_core::xclbin_int::get_axlf_section(xrtXclbin, MEM_TOPOLOGY).first);
+
+    if(memTopologySection == nullptr)
+      return false;
+
+    createMemories(currentXclbin, memTopologySection);
+
+    // Step 3 -> Connect the CUs with the memory resources using the
+    //           CONNECTIVITY section
+    const connectivity* connectivitySection =
+      reinterpret_cast<const connectivity*>(xrt_core::xclbin_int::get_axlf_section(xrtXclbin, CONNECTIVITY).first);
+
+    if(connectivitySection == nullptr)
+      return true;
+
+    createConnections(currentXclbin, ipLayoutSection, memTopologySection,
+                      connectivitySection);
+
+    // Step 4 -> Annotate all the compute units with workgroup size using
+    //           the EMBEDDED_METADATA section
+    std::pair<const char*, size_t> embeddedMetadata =
+       xrt_core::xclbin_int::get_axlf_section(xrtXclbin, EMBEDDED_METADATA);
+
+    annotateWorkgroupSize(currentXclbin, embeddedMetadata.first,
+                          embeddedMetadata.second);
+
+    // Step 5 -> Fill in the details like the name of the xclbin using
+    //           the SYSTEM_METADATA section
+    std::pair<const char*, size_t> systemMetadata =
+       xrt_core::xclbin_int::get_axlf_section(xrtXclbin, SYSTEM_METADATA);
+
+    setXclbinName(currentXclbin, systemMetadata.first, systemMetadata.second);
+    updateSystemDiagram(systemMetadata.first, systemMetadata.second);
+    addPortInfo(currentXclbin, systemMetadata.first, systemMetadata.second);
+
+    return true;
+  }
+
+  bool VPStaticDatabase::initializeProfileMonitors(DeviceInfo* devInfo, xrt::xclbin xrtXclbin)
   {
     // Look into the debug_ip_layout section and load information about Profile Monitors
     // Get DEBUG_IP_LAYOUT section
     const debug_ip_layout* debugIpLayoutSection =
-      device->get_axlf_section<const debug_ip_layout*>(DEBUG_IP_LAYOUT);
+      reinterpret_cast<const debug_ip_layout*>(xrt_core::xclbin_int::get_axlf_section(xrtXclbin, DEBUG_IP_LAYOUT).first);
+
     if(debugIpLayoutSection == nullptr) return false;
 
     for(uint16_t i = 0; i < debugIpLayoutSection->m_count; i++) {
@@ -2089,7 +2147,7 @@ namespace xdp {
         break ;
       case AXI_STREAM_MONITOR:
         initializeASM(devInfo, name, debugIpData) ;
-        break ;
+       break ;
       case AXI_NOC:
         initializeNOC(devInfo, debugIpData) ;
         break ;
@@ -2101,14 +2159,7 @@ namespace xdp {
       }
     }
 
-    return true; 
-  }
-
-  void VPStaticDatabase::addCommandQueueAddress(uint64_t a)
-  {
-    std::lock_guard<std::mutex> lock(openCLLock) ;
-
-    commandQueueAddresses.emplace(a) ;
-  }
+    return true;
+  }  
 
 } // end namespace xdp

--- a/src/runtime_src/xdp/profile/database/static_info_database.h
+++ b/src/runtime_src/xdp/profile/database/static_info_database.h
@@ -288,15 +288,18 @@ namespace xdp {
     getAIEMemoryCounterResources(uint64_t deviceId) ;
     XDP_EXPORT
     std::map<uint32_t, uint32_t>*
+    getAIEMemTileCounterResources(uint64_t deviceId) ;
+    XDP_EXPORT
+    std::map<uint32_t, uint32_t>*
     getAIEShimCounterResources(uint64_t deviceId) ;
     XDP_EXPORT
     std::map<uint32_t, uint32_t>* getAIECoreEventResources(uint64_t deviceId) ;
     XDP_EXPORT
-    std::map<uint32_t, uint32_t>* getAIEMemoryEventResources(uint64_t deviceId);
+    std::map<uint32_t, uint32_t>* getAIEMemoryEventResources(uint64_t deviceId) ;
+    XDP_EXPORT
+    std::map<uint32_t, uint32_t>* getAIEMemTileEventResources(uint64_t deviceId) ;
     XDP_EXPORT
     std::map<uint32_t, uint32_t>* getAIEShimEventResources(uint64_t deviceId) ;
-    XDP_EXPORT
-    std::map<uint32_t, uint32_t>* getAIEMemTileEventResources(uint64_t deviceId);
     XDP_EXPORT
     std::vector<std::unique_ptr<aie_cfg_tile>>*
     getAIECfgTiles(uint64_t deviceId) ;

--- a/src/runtime_src/xdp/profile/database/static_info_database.h
+++ b/src/runtime_src/xdp/profile/database/static_info_database.h
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2016-2021 Xilinx, Inc
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -111,8 +111,6 @@ namespace xdp {
     bool resetDeviceInfo(uint64_t deviceId, const std::shared_ptr<xrt_core::device>& device);
 
     // Functions that create the overall structure of the Xclbin's PL region
-    bool initializeStructure(XclbinInfo*,
-                             const std::shared_ptr<xrt_core::device>&);
     void createComputeUnits(XclbinInfo*, const ip_layout*);
     void createMemories(XclbinInfo*, const mem_topology*);
     void createConnections(XclbinInfo*, const ip_layout*, const mem_topology*,
@@ -123,7 +121,6 @@ namespace xdp {
     void addPortInfo(XclbinInfo*, const char*, size_t);
 
     // Functions that initialize the structure of the debug/profiling IP
-    bool initializeProfileMonitors(DeviceInfo*, const std::shared_ptr<xrt_core::device>&);
     void initializeAM(DeviceInfo* devInfo, const std::string& name,
                       const struct debug_ip_data* debugIpData) ;
     void initializeAIM(DeviceInfo* devInfo, const std::string& name,
@@ -134,7 +131,15 @@ namespace xdp {
                        const struct debug_ip_data* debugIpData) ;
     void initializeTS2MM(DeviceInfo* devInfo,
                          const struct debug_ip_data* debugIpData) ;
-    double findClockRate(std::shared_ptr<xrt_core::device> device) ;
+
+    void setDeviceNameFromXclbin(uint64_t deviceId, xrt::xclbin xrtXclbin);
+    void setAIEClockRateMHz(uint64_t deviceId, xrt::xclbin xrtXclbin) ;
+    bool initializeStructure(XclbinInfo*, xrt::xclbin);
+    bool initializeProfileMonitors(DeviceInfo*, xrt::xclbin);
+    double findClockRate(xrt::xclbin);
+    DeviceInfo* updateDevice(uint64_t deviceId, xrt::xclbin xrtXclbin) ;
+
+    
 
   public:
     VPStaticDatabase(VPDatabase* d) ;
@@ -236,7 +241,6 @@ namespace xdp {
     XDP_EXPORT void deleteCurrentlyUsedDeviceInterface(uint64_t deviceId) ;
     XDP_EXPORT bool isDeviceReady(uint64_t deviceId) ;
     XDP_EXPORT double getClockRateMHz(uint64_t deviceId, bool PL = true) ;
-    XDP_EXPORT void setAIEClockRateMHz(std::shared_ptr<xrt_core::device> device, uint64_t deviceId) ;
     XDP_EXPORT void setDeviceName(uint64_t deviceId, const std::string& name) ; 
     XDP_EXPORT std::string getDeviceName(uint64_t deviceId) ;
     XDP_EXPORT void setDeviceIntf(uint64_t deviceId, DeviceIntf* devIntf) ;
@@ -261,6 +265,11 @@ namespace xdp {
     XDP_EXPORT Memory* getMemory(uint64_t deviceId, int32_t memId) ;
     // Reseting device information whenever a new xclbin is added
     XDP_EXPORT void updateDevice(uint64_t deviceId, void* devHandle) ;
+
+    // *********************************************************
+    // ***** Functions related to trace_processor tool *****
+    // ***** which creates events from raw PL trace    *****
+    XDP_EXPORT void updateDevice(uint64_t deviceId, const std::string& xclbinFile);
 
     // *********************************************************
     // ***** Functions related to AIE specific information *****

--- a/src/runtime_src/xdp/profile/database/static_info_database.h
+++ b/src/runtime_src/xdp/profile/database/static_info_database.h
@@ -288,18 +288,18 @@ namespace xdp {
     getAIEMemoryCounterResources(uint64_t deviceId) ;
     XDP_EXPORT
     std::map<uint32_t, uint32_t>*
-    getAIEMemTileCounterResources(uint64_t deviceId) ;
+    getAIEShimCounterResources(uint64_t deviceId) ;
     XDP_EXPORT
     std::map<uint32_t, uint32_t>*
-    getAIEShimCounterResources(uint64_t deviceId) ;
+    getAIEMemTileCounterResources(uint64_t deviceId) ;
     XDP_EXPORT
     std::map<uint32_t, uint32_t>* getAIECoreEventResources(uint64_t deviceId) ;
     XDP_EXPORT
     std::map<uint32_t, uint32_t>* getAIEMemoryEventResources(uint64_t deviceId) ;
     XDP_EXPORT
-    std::map<uint32_t, uint32_t>* getAIEMemTileEventResources(uint64_t deviceId) ;
-    XDP_EXPORT
     std::map<uint32_t, uint32_t>* getAIEShimEventResources(uint64_t deviceId) ;
+    XDP_EXPORT
+    std::map<uint32_t, uint32_t>* getAIEMemTileEventResources(uint64_t deviceId) ;
     XDP_EXPORT
     std::vector<std::unique_ptr<aie_cfg_tile>>*
     getAIECfgTiles(uint64_t deviceId) ;
@@ -321,6 +321,9 @@ namespace xdp {
     XDP_EXPORT void addAIEMemoryEventResources(uint64_t deviceId,
                                                uint32_t numEvents,
                                                uint32_t numTiles) ;
+    XDP_EXPORT void addAIEShimEventResources(uint64_t deviceId,
+                                             uint32_t numEvents,
+                                             uint32_t numTiles) ;
     XDP_EXPORT void addAIEMemTileEventResources(uint64_t deviceId,
                                                 uint32_t numEvents,
                                                 uint32_t numTiles) ;

--- a/src/runtime_src/xdp/profile/database/static_info_database.h
+++ b/src/runtime_src/xdp/profile/database/static_info_database.h
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2016-2021 Xilinx, Inc
- * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -111,6 +111,8 @@ namespace xdp {
     bool resetDeviceInfo(uint64_t deviceId, const std::shared_ptr<xrt_core::device>& device);
 
     // Functions that create the overall structure of the Xclbin's PL region
+    bool initializeStructure(XclbinInfo*,
+                             const std::shared_ptr<xrt_core::device>&);
     void createComputeUnits(XclbinInfo*, const ip_layout*);
     void createMemories(XclbinInfo*, const mem_topology*);
     void createConnections(XclbinInfo*, const ip_layout*, const mem_topology*,
@@ -121,6 +123,7 @@ namespace xdp {
     void addPortInfo(XclbinInfo*, const char*, size_t);
 
     // Functions that initialize the structure of the debug/profiling IP
+    bool initializeProfileMonitors(DeviceInfo*, const std::shared_ptr<xrt_core::device>&);
     void initializeAM(DeviceInfo* devInfo, const std::string& name,
                       const struct debug_ip_data* debugIpData) ;
     void initializeAIM(DeviceInfo* devInfo, const std::string& name,
@@ -131,15 +134,7 @@ namespace xdp {
                        const struct debug_ip_data* debugIpData) ;
     void initializeTS2MM(DeviceInfo* devInfo,
                          const struct debug_ip_data* debugIpData) ;
-
-    void setDeviceNameFromXclbin(uint64_t deviceId, xrt::xclbin xrtXclbin);
-    void setAIEClockRateMHz(uint64_t deviceId, xrt::xclbin xrtXclbin) ;
-    bool initializeStructure(XclbinInfo*, xrt::xclbin);
-    bool initializeProfileMonitors(DeviceInfo*, xrt::xclbin);
-    double findClockRate(xrt::xclbin);
-    DeviceInfo* updateDevice(uint64_t deviceId, xrt::xclbin xrtXclbin) ;
-
-    
+    double findClockRate(std::shared_ptr<xrt_core::device> device) ;
 
   public:
     VPStaticDatabase(VPDatabase* d) ;
@@ -241,6 +236,7 @@ namespace xdp {
     XDP_EXPORT void deleteCurrentlyUsedDeviceInterface(uint64_t deviceId) ;
     XDP_EXPORT bool isDeviceReady(uint64_t deviceId) ;
     XDP_EXPORT double getClockRateMHz(uint64_t deviceId, bool PL = true) ;
+    XDP_EXPORT void setAIEClockRateMHz(std::shared_ptr<xrt_core::device> device, uint64_t deviceId) ;
     XDP_EXPORT void setDeviceName(uint64_t deviceId, const std::string& name) ; 
     XDP_EXPORT std::string getDeviceName(uint64_t deviceId) ;
     XDP_EXPORT void setDeviceIntf(uint64_t deviceId, DeviceIntf* devIntf) ;
@@ -265,11 +261,6 @@ namespace xdp {
     XDP_EXPORT Memory* getMemory(uint64_t deviceId, int32_t memId) ;
     // Reseting device information whenever a new xclbin is added
     XDP_EXPORT void updateDevice(uint64_t deviceId, void* devHandle) ;
-
-    // *********************************************************
-    // ***** Functions related to trace_processor tool *****
-    // ***** which creates events from raw PL trace    *****
-    XDP_EXPORT void updateDevice(uint64_t deviceId, const std::string& xclbinFile);
 
     // *********************************************************
     // ***** Functions related to AIE specific information *****
@@ -311,7 +302,7 @@ namespace xdp {
     XDP_EXPORT void addAIECounterResources(uint64_t deviceId,
                                            uint32_t numCounters,
                                            uint32_t numTiles,
-                                           bool isCore) ;
+                                           uint8_t moduleType) ;
     XDP_EXPORT void addAIECoreEventResources(uint64_t deviceId,
                                              uint32_t numEvents,
                                              uint32_t numTiles) ;

--- a/src/runtime_src/xdp/profile/writer/vp_base/guidance_rules.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/guidance_rules.cpp
@@ -607,6 +607,15 @@ namespace {
         }
       }
 
+      auto memTileCounters =
+        db->getStaticInfo().getAIEMemTileCounterResources(device->deviceId);
+      if (memTileCounters != nullptr) {
+        for (auto const& counter : *memTileCounters) {
+          fout << "AIE_MEM_TILE_COUNTER_RESOURCES," << counter.first << ","
+               << counter.second << ",\n";
+        }
+      }
+
       auto interfaceCounters =
         db->getStaticInfo().getAIEShimCounterResources(device->deviceId);
       if (interfaceCounters != nullptr) {
@@ -648,6 +657,15 @@ namespace {
         for (auto const& memTileEvent : *memTileEvents) {
           fout << "AIE_MEM_TILE_EVENT_RESOURCES," << memTileEvent.first << ","
                << memTileEvent.second << ",\n" ;
+        }
+      }
+
+      auto interfaceEvents =
+        db->getStaticInfo().getAIEShimEventResources(device->deviceId) ;
+      if (interfaceEvents != nullptr) {
+        for (auto const& interfaceEvent : *interfaceEvents) {
+          fout << "AIE_INTERFACE_EVENT_RESOURCES," << interfaceEvent.first << ","
+               << interfaceEvent.second << ",\n" ;
         }
       }
     }

--- a/src/runtime_src/xdp/profile/writer/vp_base/guidance_rules.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/guidance_rules.cpp
@@ -607,20 +607,20 @@ namespace {
         }
       }
 
-      auto memTileCounters =
-        db->getStaticInfo().getAIEMemTileCounterResources(device->deviceId);
-      if (memTileCounters != nullptr) {
-        for (auto const& counter : *memTileCounters) {
-          fout << "AIE_MEM_TILE_COUNTER_RESOURCES," << counter.first << ","
-               << counter.second << ",\n";
-        }
-      }
-
       auto interfaceCounters =
         db->getStaticInfo().getAIEShimCounterResources(device->deviceId);
       if (interfaceCounters != nullptr) {
         for (auto const& counter : *interfaceCounters) {
           fout << "AIE_INTERFACE_COUNTER_RESOURCES," << counter.first << ","
+               << counter.second << ",\n";
+        }
+      }
+      
+      auto memTileCounters =
+        db->getStaticInfo().getAIEMemTileCounterResources(device->deviceId);
+      if (memTileCounters != nullptr) {
+        for (auto const& counter : *memTileCounters) {
+          fout << "AIE_MEM_TILE_COUNTER_RESOURCES," << counter.first << ","
                << counter.second << ",\n";
         }
       }
@@ -651,21 +651,21 @@ namespace {
         }
       }
 
-      auto memTileEvents =
-        db->getStaticInfo().getAIEMemTileEventResources(device->deviceId) ;
-      if (memTileEvents != nullptr) {
-        for (auto const& memTileEvent : *memTileEvents) {
-          fout << "AIE_MEM_TILE_EVENT_RESOURCES," << memTileEvent.first << ","
-               << memTileEvent.second << ",\n" ;
-        }
-      }
-
       auto interfaceEvents =
         db->getStaticInfo().getAIEShimEventResources(device->deviceId) ;
       if (interfaceEvents != nullptr) {
         for (auto const& interfaceEvent : *interfaceEvents) {
           fout << "AIE_INTERFACE_EVENT_RESOURCES," << interfaceEvent.first << ","
                << interfaceEvent.second << ",\n" ;
+        }
+      }
+
+      auto memTileEvents =
+        db->getStaticInfo().getAIEMemTileEventResources(device->deviceId) ;
+      if (memTileEvents != nullptr) {
+        for (auto const& memTileEvent : *memTileEvents) {
+          fout << "AIE_MEM_TILE_EVENT_RESOURCES," << memTileEvent.first << ","
+               << memTileEvent.second << ",\n" ;
         }
       }
     }


### PR DESCRIPTION
**Problem solved by the commit**
Better tracking of AIE resources

**Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered**
AIE counter resources API was using bool instead of uint8_t

**What has been tested and how, request additional testing if necessary**
Lots of testing on vck190