### PR TITLE
src/runtime_src/tools/scripts: Add setup.zsh for use with the zsh shell

### DIFF
--- a/src/runtime_src/tools/scripts/setup.sh
+++ b/src/runtime_src/tools/scripts/setup.sh
@@ -30,7 +30,15 @@ if [[ $OSDIST == "centos" ]] || [[ $OSDIST == "rhel"* ]]; then
     fi
 fi
 
-XILINX_XRT=$(readlink -f $(dirname ${BASH_SOURCE[0]:-${(%):-%x}}))
+
+if [ -n "$BASH_VERSION" ]; then
+    XILINX_XRT=$(readlink -f $(dirname ${BASH_SOURCE[0]:-${(%):-%x}}))
+elif [ -n "$ZSH_VERSION" ]; then
+    XILINX_XRT=$(readlink -f $(dirname ${(%):-%N}))
+else
+    echo "ERROR: Unsupported shell. Only bash and zsh are supported"
+    return 1
+fi
 
 if [[ $XILINX_XRT != *"/opt/xilinx/xrt" ]]; then
     echo "Invalid location: $XILINX_XRT"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Provides a setup.zsh that can be used when using the zsh shell.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Fixes #7366

#### How problem was solved, alternative solutions (if any) and why they were rejected
Alternatively, we could modify setup.sh to detect which shell is being used,
to provide a single script.

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
