### PR TITLE
VITIS-7949 Add system level request for device pcie data

### DIFF
--- a/src/runtime_src/core/common/system.cpp
+++ b/src/runtime_src/core/common/system.cpp
@@ -111,6 +111,12 @@ get_os_info(boost::property_tree::ptree& pt)
   instance().get_os_info(pt);
 }
 
+boost::property_tree::ptree
+get_pcie_info(device::id_type id)
+{
+  return instance().get_pcie_info(id);
+}
+
 void
 get_devices(boost::property_tree::ptree& pt)
 {

--- a/src/runtime_src/core/common/system.h
+++ b/src/runtime_src/core/common/system.h
@@ -34,6 +34,13 @@ public:
   virtual void
   get_os_info(boost::property_tree::ptree&) {}
 
+    virtual boost::property_tree::ptree
+  get_pcie_info(device::id_type)
+  {
+    boost::property_tree::ptree empty_ptree;
+    return empty_ptree;
+  }
+
   // REMOVE
   virtual void
   get_devices(boost::property_tree::ptree&) const {}
@@ -142,6 +149,12 @@ get_xrt_info(boost::property_tree::ptree& pt);
 XRT_CORE_COMMON_EXPORT
 void
 get_os_info(boost::property_tree::ptree& pt);
+
+/**
+ */
+XRT_CORE_COMMON_EXPORT
+boost::property_tree::ptree
+get_pcie_info(device::id_type id);
 
 /**
  */

--- a/src/runtime_src/core/pcie/windows/alveo/device_windows.cpp
+++ b/src/runtime_src/core/pcie/windows/alveo/device_windows.cpp
@@ -1545,7 +1545,7 @@ initialize_query_table()
 }
 
 struct X { X() { initialize_query_table(); }};
-static X x;
+static X x_xrt;
 
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/VITIS-7949

This change is needed to get device PCIe information from the operating system, rather than going through the driver. For MCDM this is very relevant.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Currently, Linux and Windows force the driver to populate and return PCIe information for a device. However, this information is stored on the host and should be collected without entering the driver.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Add a system level call to facilitate requesting device PCIe data through the system rather than through a device query. 

#### Risks (if any) associated the changes in the commit
There are plans to remove the system specific implementation files. When that occurs this addition must be included.

#### What has been tested and how, request additional testing if necessary
Ubuntu 20.04
XRT builds just fine. No testing required as this adds an implementation path.

#### Documentation impact (if any)
None.