### PR TITLE
CR: 1150426

### DIFF
--- a/src/runtime_src/core/edge/ps_kernels/profiling/aie2_profile_config/aie2_profile_config.cpp
+++ b/src/runtime_src/core/edge/ps_kernels/profiling/aie2_profile_config/aie2_profile_config.cpp
@@ -250,6 +250,18 @@ namespace {
     return payloadValue;
   }
 
+  bool isValidType(xdp::module_type type, XAie_ModuleType mod)
+  {
+    if ((mod == XAIE_CORE_MOD) && ((type == xdp::module_type::core) 
+        || (type == xdp::module_type::dma)))
+      return true;
+    if ((mod == XAIE_MEM_MOD) && ((type == xdp::module_type::dma) 
+        || (type == xdp::module_type::mem_tile)))
+      return true;
+    if ((mod == XAIE_PL_MOD) && (type == xdp::module_type::shim)) 
+      return true;
+    return false;
+  }
 
   bool 
   setMetricsSettings(XAie_DevInst* aieDevInst, xaiefal::XAieDev* aieDevice,
@@ -305,7 +317,8 @@ namespace {
         auto row = tileMetric.first.row;
 
         auto type = getModuleType(row, params->offset, mod);
-
+        if (!isValidType(type, mod))
+                  continue;
 
         // NOTE: resource manager requires absolute row number
         auto loc        = XAie_TileLoc(col, row);

--- a/src/runtime_src/core/edge/ps_kernels/profiling/aie2_trace_config/aie2_trace_config.cpp
+++ b/src/runtime_src/core/edge/ps_kernels/profiling/aie2_trace_config/aie2_trace_config.cpp
@@ -58,10 +58,7 @@ namespace {
     }
   }
 
-
-  
-
-bool tileHasFreeRsc(xaiefal::XAieDev* aieDevice, XAie_LocType& loc,
+  bool tileHasFreeRsc(xaiefal::XAieDev* aieDevice, XAie_LocType& loc,
    EventConfiguration& config, const xdp::built_in::TraceInputConfiguration* params,
    xdp::built_in::MessageConfiguration* msgcfg, xdp::module_type type, const xdp::built_in::MetricSet metricSet)
   {

--- a/src/runtime_src/core/edge/ps_kernels/profiling/aie_profile_config/aie_profile_config.cpp
+++ b/src/runtime_src/core/edge/ps_kernels/profiling/aie_profile_config/aie_profile_config.cpp
@@ -213,6 +213,19 @@ namespace {
   }
 
 
+  bool isValidType(xdp::module_type type, XAie_ModuleType mod)
+  {
+    if ((mod == XAIE_CORE_MOD) && ((type == xdp::module_type::core) 
+        || (type == xdp::module_type::dma)))
+      return true;
+    if ((mod == XAIE_MEM_MOD) && ((type == xdp::module_type::dma) 
+        || (type == xdp::module_type::mem_tile)))
+      return true;
+    if ((mod == XAIE_PL_MOD) && (type == xdp::module_type::shim)) 
+      return true;
+    return false;
+  }
+
   bool 
   setMetricsSettings(XAie_DevInst* aieDevInst, xaiefal::XAieDev* aieDevice,
                  EventConfiguration& config,
@@ -254,7 +267,8 @@ namespace {
         auto row = tileMetric.first.row;
 
         auto type = getModuleType(row, params->offset, mod);
-
+        if (!isValidType(type, mod))
+          continue;
 
         // NOTE: resource manager requires absolute row number
         auto loc        = XAie_TileLoc(col, row);

--- a/src/runtime_src/xdp/profile/database/static_info/aie_constructs.h
+++ b/src/runtime_src/xdp/profile/database/static_info/aie_constructs.h
@@ -25,6 +25,11 @@
 #include "xdp/profile/device/tracedefs.h"
 
 namespace xdp {
+  struct aiecompiler_options
+  {
+    bool broadcast_enable_core;
+    std::string event_trace;
+  };
 
 enum class module_type {
     core = 0,

--- a/src/runtime_src/xdp/profile/plugin/aie_trace_new/aie_trace_metadata.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace_new/aie_trace_metadata.h
@@ -91,6 +91,7 @@ class AieTraceMetadata{
     std::vector<std::string> get_kernels(const xrt_core::device* device);
     double get_clock_freq_mhz(const xrt_core::device* device);
     std::vector<gmio_type> get_trace_gmios(const xrt_core::device* device);
+    aiecompiler_options get_aiecompiler_options(const xrt_core::device* device);
 
     void getConfigMetricsForTiles(std::vector<std::string>& metricsSettings,
                                   std::vector<std::string>& graphMetricsSettings,

--- a/src/runtime_src/xdp/profile/plugin/aie_trace_new/edge/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace_new/edge/aie_trace.cpp
@@ -191,18 +191,11 @@ namespace xdp {
       return false;
     }
 
-    // Catch when compile-time trace is specified (e.g., --event-trace=functions)
-    std::shared_ptr<xrt_core::device> device = xrt_core::get_userpf_device(handle);
-    auto compilerOptions = xrt_core::edge::aie::get_aiecompiler_options(device.get());
-    metadata->setRuntimeMetrics(compilerOptions.event_trace == "runtime");
-
+    // compile-time trace
     if (!metadata->getRuntimeMetrics()) {
-      std::stringstream msg;
-      msg << "Found compiler trace option of " << compilerOptions.event_trace
-          << ". No runtime AIE metrics will be changed.";
-      xrt_core::message::send(severity_level::info, "XRT", msg.str());
       return true;
     }
+    
     return true;
   }
 

--- a/src/runtime_src/xdp/profile/plugin/aie_trace_new/x86/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace_new/x86/aie_trace.cpp
@@ -49,6 +49,12 @@ namespace xdp {
   using Messages = xdp::built_in::Messages;
 
   void AieTrace_x86Impl::updateDevice() {
+
+    //compile-time trace
+    if (!metadata->getRuntimeMetrics()) {
+      return;
+    }
+
     // Set metrics for counters and trace events 
     if (!setMetricsSettings(metadata->getDeviceID(), metadata->getHandle())) {
       std::string msg("Unable to configure AIE trace control and events. No trace will be generated.");


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
 Fixed compile-time metrics on VCK5000 boards.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Compile-time metrics were not processed for x86 flows.

#### How problem was solved, alternative solutions (if any) and why they were rejected
We now check for runtimemetrics on both edge and x86 flows.

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
