### PR TITLE
[2021.1] Revert xmaapi.h's cpu_mode back to uint32_t to match with original public api

### DIFF
--- a/src/xma/include/lib/xmaapi.h
+++ b/src/xma/include/lib/xmaapi.h
@@ -43,7 +43,7 @@ typedef struct XmaSingleton
     XmaHwCfg          hwcfg;
     bool              xma_initialized;
     bool              kds_old;
-    std::atomic<uint32_t> cpu_mode;
+    uint32_t          cpu_mode;
     std::mutex            m_mutex;
     std::atomic<uint32_t> num_decoders;
     std::atomic<uint32_t> num_encoders;

--- a/src/xma/src/xmaapi/xmaapi.cpp
+++ b/src/xma/src/xmaapi/xmaapi.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2018, Xilinx Inc - All rights reserved
+ * Copyright (C) 2023, Advanced Micro Devices, Inc - All rights reserved
  * Xilinx SDAccel Media Accelerator API
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
@@ -426,7 +427,7 @@ int32_t xma_initialize(XmaXclbinParameter *devXclbins, int32_t num_parms)
     else
         xma_logmsg(XMA_DEBUG_LOG, XMAAPI_MOD, "XMA for KDS 2.0. Default mode.");
     g_xma_singleton->cpu_mode = xrt_core::config::get_xma_cpu_mode();
-    xma_logmsg(XMA_DEBUG_LOG, XMAAPI_MOD, "XMA CPU Mode is: %d", g_xma_singleton->cpu_mode.load());
+    xma_logmsg(XMA_DEBUG_LOG, XMAAPI_MOD, "XMA CPU Mode is: %d", g_xma_singleton->cpu_mode);
 
     g_xma_singleton->xma_thread1 = std::thread(xma_thread1);
     g_xma_singleton->all_thread2.reserve(MAX_XILINX_DEVICES);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Revert back cpu_mode type to uint32_t so it does not break existing application.
Also it is not necessary to make cpu_mode atomic since it is only set once during initialization, and threads are launched after cpu_mode is set.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Introduced with https://github.com/Xilinx/XRT/pull/7360, which came from https://github.com/Xilinx/XRT/pull/7055

#### How problem was solved, alternative solutions (if any) and why they were rejected
Revert back the type of cpu_mode

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
None