### PR TITLE
CR-1153785 Fix library load issues in hw emulation

### DIFF
--- a/src/runtime_src/xdp/profile/device/hal_device/xdp_hal_device.cpp
+++ b/src/runtime_src/xdp/profile/device/hal_device/xdp_hal_device.cpp
@@ -85,7 +85,7 @@ int HalDevice::readXrtIP(uint32_t index, uint32_t offset, uint32_t *data)
   return xclRegRead(mHalDevice, index, offset, data);
 }
 
-#if defined(_WIN32) || defined(XDP_HWEMU_BUILD)
+#if defined(_WIN32) || defined(XDP_HWEMU_USING_HAL_BUILD)
 int HalDevice::initXrtIP(const char * /*name*/, uint64_t /*base*/, uint32_t /*range*/)
 {
   // The required APIs are missing from windows shim

--- a/src/runtime_src/xdp/profile/device/hal_device/xdp_hal_device.cpp
+++ b/src/runtime_src/xdp/profile/device/hal_device/xdp_hal_device.cpp
@@ -88,7 +88,7 @@ int HalDevice::readXrtIP(uint32_t index, uint32_t offset, uint32_t *data)
 #if defined(_WIN32) || defined(XDP_HWEMU_USING_HAL_BUILD)
 int HalDevice::initXrtIP(const char * /*name*/, uint64_t /*base*/, uint32_t /*range*/)
 {
-  // The required APIs are missing from windows shim
+  // The required APIs are missing from windows and hw emulation shim
   return -1;
 }
 #else

--- a/src/runtime_src/xdp/profile/device/hal_device/xdp_hal_device.cpp
+++ b/src/runtime_src/xdp/profile/device/hal_device/xdp_hal_device.cpp
@@ -85,7 +85,13 @@ int HalDevice::readXrtIP(uint32_t index, uint32_t offset, uint32_t *data)
   return xclRegRead(mHalDevice, index, offset, data);
 }
 
-#ifndef _WIN32
+#if defined(_WIN32) || defined(XDP_HWEMU_BUILD)
+int HalDevice::initXrtIP(const char * /*name*/, uint64_t /*base*/, uint32_t /*range*/)
+{
+  // The required APIs are missing from windows shim
+  return -1;
+}
+#else
 int HalDevice::initXrtIP(const char *name, uint64_t base, uint32_t range)
 {
   // We cannot always get index from ip_layout
@@ -106,12 +112,6 @@ int HalDevice::initXrtIP(const char *name, uint64_t base, uint32_t range)
     return ret;
 
   return index;
-}
-#else
-int HalDevice::initXrtIP(const char * /*name*/, uint64_t /*base*/, uint32_t /*range*/)
-{
-  // The required APIs are missing from windows shim
-  return -1;
 }
 #endif
 

--- a/src/runtime_src/xdp/profile/plugin/device_offload/hw_emu/CMakeLists.txt
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/hw_emu/CMakeLists.txt
@@ -23,7 +23,7 @@ file(GLOB HW_EMU_DEVICE_OFFLOAD_PLUGIN_FILES
 add_library(xdp_hw_emu_device_offload_plugin MODULE ${HW_EMU_DEVICE_OFFLOAD_PLUGIN_FILES})
 add_dependencies(xdp_hw_emu_device_offload_plugin xdp_core xrt_coreutil xrt_hwemu)
 target_link_libraries(xdp_hw_emu_device_offload_plugin PRIVATE xdp_core xrt_coreutil xrt_hwemu)
-target_compile_definitions(xdp_hw_emu_device_offload_plugin PRIVATE XDP_HWEMU_BUILD=1)
+target_compile_definitions(xdp_hw_emu_device_offload_plugin PRIVATE XDP_HWEMU_USING_HAL_BUILD=1)
 
 set_target_properties(xdp_hw_emu_device_offload_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
 

--- a/src/runtime_src/xdp/profile/plugin/device_offload/hw_emu/CMakeLists.txt
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/hw_emu/CMakeLists.txt
@@ -23,6 +23,7 @@ file(GLOB HW_EMU_DEVICE_OFFLOAD_PLUGIN_FILES
 add_library(xdp_hw_emu_device_offload_plugin MODULE ${HW_EMU_DEVICE_OFFLOAD_PLUGIN_FILES})
 add_dependencies(xdp_hw_emu_device_offload_plugin xdp_core xrt_coreutil xrt_hwemu)
 target_link_libraries(xdp_hw_emu_device_offload_plugin PRIVATE xdp_core xrt_coreutil xrt_hwemu)
+target_compile_definitions(xdp_hw_emu_device_offload_plugin PRIVATE XDP_HWEMU_BUILD=1)
 
 set_target_properties(xdp_hw_emu_device_offload_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
 

--- a/src/runtime_src/xdp/profile/plugin/pl_deadlock/CMakeLists.txt
+++ b/src/runtime_src/xdp/profile/plugin/pl_deadlock/CMakeLists.txt
@@ -38,6 +38,7 @@ file(GLOB HW_EMU_PL_DEADLOCK_PLUGIN_FILES
 add_library(xdp_hw_emu_pl_deadlock_plugin MODULE ${HW_EMU_PL_DEADLOCK_PLUGIN_FILES})
 add_dependencies(xdp_hw_emu_pl_deadlock_plugin xdp_core xrt_coreutil xrt_hwemu)
 target_link_libraries(xdp_hw_emu_pl_deadlock_plugin PRIVATE xdp_core xrt_coreutil xrt_hwemu)
+target_compile_definitions(xdp_hw_emu_pl_deadlock_plugin PRIVATE XDP_HWEMU_BUILD=1)
 
 set_target_properties(xdp_hw_emu_pl_deadlock_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
 

--- a/src/runtime_src/xdp/profile/plugin/pl_deadlock/CMakeLists.txt
+++ b/src/runtime_src/xdp/profile/plugin/pl_deadlock/CMakeLists.txt
@@ -38,7 +38,6 @@ file(GLOB HW_EMU_PL_DEADLOCK_PLUGIN_FILES
 add_library(xdp_hw_emu_pl_deadlock_plugin MODULE ${HW_EMU_PL_DEADLOCK_PLUGIN_FILES})
 add_dependencies(xdp_hw_emu_pl_deadlock_plugin xdp_core xrt_coreutil xrt_hwemu)
 target_link_libraries(xdp_hw_emu_pl_deadlock_plugin PRIVATE xdp_core xrt_coreutil xrt_hwemu)
-target_compile_definitions(xdp_hw_emu_pl_deadlock_plugin PRIVATE XDP_HWEMU_BUILD=1)
 
 set_target_properties(xdp_hw_emu_pl_deadlock_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
[XRT] ERROR: Failed to open library libxdp_hw_emu_device_offload_plugin.so
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://github.com/Xilinx/XRT/pull/7363
#### How problem was solved, alternative solutions (if any) and why they were rejected
Add compile time guard as the relevant APIs are absent from hw emulation shim. We assumed that all linux shim have all the functions. In case of xclIPISetReadRange, it was only present on hw,linux shim
#### Risks (if any) associated the changes in the commit
low
#### What has been tested and how, request additional testing if necessary
tested on 3 designs. 2 hw emulation design and one pl deadlock design
#### Documentation impact (if any)
