### PR TITLE
CR-1151890 timestamp doesn't work on v70 if xrt-apu installed

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -889,6 +889,8 @@ static int xocl_fill_payload_xgq(struct xocl_dev *xdev, struct kds_command *xcmd
 		break;
 	case ERT_SK_START:
 		kecmd = (struct ert_start_kernel_cmd *)xcmd->execbuf;
+		if (kecmd->stat_enabled)
+			xcmd->timestamp_enabled = 1;
 		xcmd->type = KDS_SCU;
 		xcmd->opcode = OP_START_SK;
 		xcmd->cu_mask[0] = kecmd->cu_mask;
@@ -899,6 +901,8 @@ static int xocl_fill_payload_xgq(struct xocl_dev *xdev, struct kds_command *xcmd
 		break;
 	case ERT_START_CU:
 		kecmd = (struct ert_start_kernel_cmd *)xcmd->execbuf;
+		if (kecmd->stat_enabled)
+			xcmd->timestamp_enabled = 1;
 		xcmd->type = KDS_CU;
 		xcmd->opcode = OP_START;
 		xcmd->cu_mask[0] = kecmd->cu_mask;
@@ -937,6 +941,8 @@ static int xocl_fill_payload_xgq(struct xocl_dev *xdev, struct kds_command *xcmd
 		}
 		print_ecmd_info(ecmd);
 		kecmd = (struct ert_start_kernel_cmd *)xcmd->execbuf;
+		if (kecmd->stat_enabled)
+			xcmd->timestamp_enabled = 1;
 		xcmd->type = KDS_CU;
 		xcmd->opcode = OP_START;
 		xcmd->cu_mask[0] = kecmd->cu_mask;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Timestamp doesn't work on XGQ enabled platforms.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1151890 expose

#### How problem was solved, alternative solutions (if any) and why they were rejected
Check stat_enabled flag in XGQ code path.

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
VCK5000 verify test

#### Documentation impact (if any)
No