### PR TITLE
Fix for showing Kernels to Global Memory data in Profile Summary

### DIFF
--- a/src/runtime_src/xdp/profile/device/device_intf.cpp
+++ b/src/runtime_src/xdp/profile/device/device_intf.cpp
@@ -592,11 +592,11 @@ DeviceIntf::~DeviceIntf()
               break;
             case HSDP_TRACE :
             {
-	      // 2nd and 1st LSB (not the 0th) indicate AIE only (00) or PL only (01) or AIE+PL (11)
-	      uint8_t bitsForPL = (((map->m_debug_ip_data[i]).m_properties) >> 1) & 3 ;
-	      if (1 == bitsForPL || 3 == bitsForPL) {
+              // 2nd and 1st LSB (not the 0th) indicate AIE only (00) or PL only (01) or AIE+PL (11)
+              uint8_t bitsForPL = (((map->m_debug_ip_data[i]).m_properties) >> 1) & 3 ;
+              if (1 == bitsForPL || 3 == bitsForPL) {
                 mHSDPforPL = true;
-	      }
+              }
               break;
             }
             case AXI_STREAM_PROTOCOL_CHECKER :
@@ -716,11 +716,11 @@ DeviceIntf::~DeviceIntf()
             }
             case HSDP_TRACE :
             {
-	      // 2nd and 1st LSB (not the 0th) indicate AIE only (00) or PL only (01) or AIE+PL (11)
-	      uint8_t bitsForPL = (((map->m_debug_ip_data[i]).m_properties) >> 1) & 3 ;
-	      if (1 == bitsForPL || 3 == bitsForPL) {
+              // 2nd and 1st LSB (not the 0th) indicate AIE only (00) or PL only (01) or AIE+PL (11)
+              uint8_t bitsForPL = (((map->m_debug_ip_data[i]).m_properties) >> 1) & 3 ;
+              if (1 == bitsForPL || 3 == bitsForPL) {
                 mHSDPforPL = true;
-	      }
+              }
               break;
             }
             default :
@@ -827,11 +827,11 @@ DeviceIntf::~DeviceIntf()
             }
             case HSDP_TRACE :
             {
-	      // 2nd and 1st LSB (not the 0th) indicate AIE only (00) or PL only (01) or AIE+PL (11)
-	      uint8_t bitsForPL = (((map->m_debug_ip_data[i]).m_properties) >> 1) & 3 ;
-	      if (1 == bitsForPL || 3 == bitsForPL) {
+              // 2nd and 1st LSB (not the 0th) indicate AIE only (00) or PL only (01) or AIE+PL (11)
+              uint8_t bitsForPL = (((map->m_debug_ip_data[i]).m_properties) >> 1) & 3 ;
+              if (1 == bitsForPL || 3 == bitsForPL) {
                 mHSDPforPL = true;
-	      }
+              }
               break;
             }
             case AXI_STREAM_PROTOCOL_CHECKER :

--- a/src/runtime_src/xdp/profile/device/device_intf.cpp
+++ b/src/runtime_src/xdp/profile/device/device_intf.cpp
@@ -590,8 +590,16 @@ DeviceIntf::~DeviceIntf()
             case ACCEL_DEADLOCK_DETECTOR :
               mDeadlockDetector = new DeadlockDetector(mDevice, i, &(map->m_debug_ip_data[i]));
               break;
-            case AXI_STREAM_PROTOCOL_CHECKER :
             case HSDP_TRACE :
+            {
+	      // 2nd and 1st LSB (not the 0th) indicate AIE only (00) or PL only (01) or AIE+PL (11)
+	      uint8_t bitsForPL = (((map->m_debug_ip_data[i]).m_properties) >> 1) & 3 ;
+	      if (1 == bitsForPL || 3 == bitsForPL) {
+                mHSDPforPL = true;
+	      }
+              break;
+            }
+            case AXI_STREAM_PROTOCOL_CHECKER :
             default : 
               break;
           }
@@ -706,6 +714,15 @@ DeviceIntf::~DeviceIntf()
               }
               break;
             }
+            case HSDP_TRACE :
+            {
+	      // 2nd and 1st LSB (not the 0th) indicate AIE only (00) or PL only (01) or AIE+PL (11)
+	      uint8_t bitsForPL = (((map->m_debug_ip_data[i]).m_properties) >> 1) & 3 ;
+	      if (1 == bitsForPL || 3 == bitsForPL) {
+                mHSDPforPL = true;
+	      }
+              break;
+            }
             default :
               break;
           }
@@ -806,6 +823,15 @@ DeviceIntf::~DeviceIntf()
                 delete mDeadlockDetector;
                 mDeadlockDetector = nullptr;
               }
+              break;
+            }
+            case HSDP_TRACE :
+            {
+	      // 2nd and 1st LSB (not the 0th) indicate AIE only (00) or PL only (01) or AIE+PL (11)
+	      uint8_t bitsForPL = (((map->m_debug_ip_data[i]).m_properties) >> 1) & 3 ;
+	      if (1 == bitsForPL || 3 == bitsForPL) {
+                mHSDPforPL = true;
+	      }
               break;
             }
             case AXI_STREAM_PROTOCOL_CHECKER :

--- a/src/runtime_src/xdp/profile/device/device_intf.h
+++ b/src/runtime_src/xdp/profile/device/device_intf.h
@@ -213,6 +213,8 @@ class DeviceIntf {
     std::string getDeadlockDiagnosis(bool print);
     bool hasDeadlockDetector() {return mDeadlockDetector != nullptr;}
 
+    bool hasHSDPforPL() { return mHSDPforPL; }
+
   private:
     // Turn on/off debug messages to stdout
     bool mVerbose = false;
@@ -220,6 +222,9 @@ class DeviceIntf {
     bool mIsDeviceProfiling = true;
     // Debug IP Layout has been read or not
     bool mIsDebugIPlayoutRead = false;
+
+    // HSDP Trace IP is used for PL Trace offload
+    bool mHSDPforPL = false;
 
     std::mutex traceLock ;
 

--- a/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
@@ -183,9 +183,9 @@ namespace xdp {
   void DeviceOffloadPlugin::addOffloader(uint64_t deviceId,
                                          DeviceIntf* devInterface)
   {
-    if (!devInterface->hasFIFO() && !devInterface->hasTs2mm()) {
+    if (devInterface->hasHSDPforPL()) {
       xrt_core::message::send(xrt_core::message::severity_level::info, "XRT",
-           "No FIFO or PL TS2MM present in the design. So, the trace offload infrastructure must be using HSDP.");
+           "HSDP Infrastructure is used for PL trace offload. So, just initialize PL monitors for trace and skip offload in XRT.");
       return;
     }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
1152474 : When profile monitors are configured for counters only and no FIFO or TS2MM is present, enabling "Debug,device_counters" incorrectly leads to conclusion that HSDP Trace Offload infrastructure is present. So, XRT flow incorrectly just initializes the monitors and skips offload of any device data.

#### How problem was solved, alternative solutions (if any) and why they were rejected
To fix the issue, updates are added in XRT-XDP flow as well as in Vitis Tools. The property field in HSDP Trace IP is now enhanced to indicate whether it is configured for AIE only or PL only or AIE+PL only. Only if HSDP Trace IP is present in debug-ip-layout and if it is configured for PL trace, then only skip offload of device data from profile monitors.

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Unit test reported with CR  and VCK190 test with HSDP Trace IP configured for PL trace offload.

#### Documentation impact (if any)
