### PR TITLE
CRs 1153404, 1154045: report incorrect settings and better handle compile-time trace

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_profile_new/aie_profile_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile_new/aie_profile_metadata.cpp
@@ -106,7 +106,7 @@ namespace xdp {
     for (ptree::iterator pos = tree1.begin(); pos != tree1.end(); pos++) {
       if (validSettings.find(pos->first) == validSettings.end()) {
         std::stringstream msg;
-        msg << "The setting " << pos->first << " is not recognized. "
+        msg << "The setting AIE_profile_settings." << pos->first << " is not recognized. "
             << "Please check the spelling and compare to supported list:";
         for (auto it = validSettings.cbegin(); it != validSettings.cend(); it++)
           msg << ((it == validSettings.cbegin()) ? " " : ", ") << *it;
@@ -120,8 +120,8 @@ namespace xdp {
       auto iter = deprecatedSettings.find(pos->first);
       if (iter != deprecatedSettings.end()) {
         std::stringstream msg;
-        msg << "The setting " << pos->first << " is deprecated. "
-            << "Please use " << iter->second << " instead.";
+        msg << "The setting Debug." << pos->first << " is deprecated. "
+            << "Please instead use " << iter->second << ".";
         xrt_core::message::send(severity_level::warning, "XRT", msg.str());
       }
     }

--- a/src/runtime_src/xdp/profile/plugin/aie_profile_new/aie_profile_metadata.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile_new/aie_profile_metadata.h
@@ -73,6 +73,7 @@ class AieProfileMetadata{
     void* getHandle() {return handle;}
     uint32_t getPollingIntervalVal(){return pollingInterval;}
 
+    void checkSettings();
     int getHardwareGen();
     uint16_t getAIETileRowOffset();
     std::vector<std::string> getSettingsVector(std::string settingsString);

--- a/src/runtime_src/xdp/profile/plugin/aie_trace_new/aie_trace_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace_new/aie_trace_metadata.cpp
@@ -39,17 +39,13 @@ namespace xdp {
   using severity_level = xrt_core::message::severity_level;
   constexpr double AIE_DEFAULT_FREQ_MHZ = 1000.0;
   
-  void AieTraceMetadata::read_aie_metadata(const char* data, size_t size, pt::ptree& aie_project)
-  {
-    std::stringstream aie_stream;
-    aie_stream.write(data,size);
-    pt::read_json(aie_stream,aie_project);
-  }
-
   AieTraceMetadata::AieTraceMetadata(uint64_t deviceID, void* handle)
   : deviceID(deviceID)
   , handle(handle)
   {
+    // Verify settings from xrt.ini
+    checkSettings();
+
     counterScheme = xrt_core::config::get_aie_trace_settings_counter_scheme();
     
     // Check whether continuous trace is enabled in xrt.ini
@@ -72,15 +68,9 @@ namespace xdp {
 
     // Catch when compile-time trace is specified (e.g., --event-trace=functions)
     auto device = xrt_core::get_userpf_device(handle);
-    auto compilerOptions = get_aiecompiler_options(device.get());
-    setRuntimeMetrics(compilerOptions.event_trace == "runtime");
-
-    if (!getRuntimeMetrics()){
-      std::stringstream msg;
-        msg << "Found compiler trace option of " << compilerOptions.event_trace
-            << ". No runtime AIE metrics will be changed.";
-      xrt_core::message::send(severity_level::info, "XRT", msg.str());
-    }
+    // auto compilerOptions = get_aiecompiler_options(device.get());
+    // runtimeMetrics = (compilerOptions.event_trace == "runtime");
+    runtimeMetrics = true;
     
     // Process AIE_trace_settings metrics
     auto aieTileMetricsSettings = 
@@ -105,6 +95,30 @@ namespace xdp {
   bool tileCompare(tile_type tile1, tile_type tile2) 
   {
     return ((tile1.col == tile2.col) && (tile1.row == tile2.row));
+  }
+
+  void AieTraceMetadata::checkSettings()
+  {
+    using boost::property_tree::ptree;
+    const std::set<std::string> validSettings {
+      "graph_based_aie_tile_metrics", "tile_based_aie_tile_metrics",
+      "graph_based_mem_tile_metrics", "tile_based_mem_tile_metrics",
+      "start_type", "start_time", "start_iteration", 
+      "periodic_offload", "reuse_buffer", "buffer_size", 
+      "buffer_offload_interval_us", "file_dump_interval_s"
+    };
+
+    auto tree = xrt_core::config::detail::get_ptree_value("AIE_trace_settings");
+    for (ptree::iterator pos = tree.begin(); pos != tree.end(); pos++) {
+      if (validSettings.find(pos->first) == validSettings.end()) {
+        std::stringstream msg;
+        msg << "The setting " << pos->first << " is not recognized. "
+            << "Please check the spelling and compare to supported list:";
+        for (auto it = validSettings.cbegin(); it != validSettings.cend(); it++)
+          msg << ((it == validSettings.cbegin()) ? " " : ", ") << *it;
+        xrt_core::message::send(severity_level::warning, "XRT", msg.str());
+      }
+    }
   }
 
   int AieTraceMetadata::getHardwareGen()
@@ -265,6 +279,13 @@ namespace xdp {
       useUserControl = true;
     }
 
+  }
+
+  void AieTraceMetadata::read_aie_metadata(const char* data, size_t size, pt::ptree& aie_project)
+  {
+    std::stringstream aie_stream;
+    aie_stream.write(data,size);
+    pt::read_json(aie_stream,aie_project);
   }
 
   std::vector<std::string> 
@@ -853,21 +874,6 @@ namespace xdp {
     }
 
     return gmios;
-  }
-
-  aiecompiler_options AieTraceMetadata::get_aiecompiler_options(const xrt_core::device* device)
-  {
-    auto data = device->get_axlf_section(AIE_METADATA);
-    if (!data.first || !data.second)
-      return {};
-
-    pt::ptree aie_meta;
-    read_aie_metadata(data.first, data.second, aie_meta);
-
-    aiecompiler_options aiecompiler_options;
-    aiecompiler_options.broadcast_enable_core = aie_meta.get<bool>("aie_metadata.aiecompiler_options.broadcast_enable_core");
-    aiecompiler_options.event_trace = aie_meta.get("aie_metadata.aiecompiler_options.event_trace", "runtime");
-    return aiecompiler_options;
   }
 
   std::vector<tile_type>

--- a/src/runtime_src/xdp/profile/plugin/aie_trace_new/aie_trace_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace_new/aie_trace_metadata.cpp
@@ -125,7 +125,7 @@ namespace xdp {
     for (ptree::iterator pos = tree1.begin(); pos != tree1.end(); pos++) {
       if (validSettings.find(pos->first) == validSettings.end()) {
         std::stringstream msg;
-        msg << "The setting " << pos->first << " is not recognized. "
+        msg << "The setting AIE_trace_settings." << pos->first << " is not recognized. "
             << "Please check the spelling and compare to supported list:";
         for (auto it = validSettings.cbegin(); it != validSettings.cend(); it++)
           msg << ((it == validSettings.cbegin()) ? " " : ", ") << *it;
@@ -139,8 +139,8 @@ namespace xdp {
       auto iter = deprecatedSettings.find(pos->first);
       if (iter != deprecatedSettings.end()) {
         std::stringstream msg;
-        msg << "The setting " << pos->first << " is deprecated. "
-            << "Please use " << iter->second << " instead.";
+        msg << "The setting Debug." << pos->first << " is deprecated. "
+            << "Please instead use " << iter->second << ".";
         xrt_core::message::send(severity_level::warning, "XRT", msg.str());
       }
     }

--- a/src/runtime_src/xdp/profile/plugin/aie_trace_new/aie_trace_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace_new/aie_trace_metadata.cpp
@@ -68,9 +68,15 @@ namespace xdp {
 
     // Catch when compile-time trace is specified (e.g., --event-trace=functions)
     auto device = xrt_core::get_userpf_device(handle);
-    // auto compilerOptions = get_aiecompiler_options(device.get());
-    // runtimeMetrics = (compilerOptions.event_trace == "runtime");
-    runtimeMetrics = true;
+    auto compilerOptions = get_aiecompiler_options(device.get());
+    setRuntimeMetrics(compilerOptions.event_trace == "runtime");
+
+    if (!getRuntimeMetrics()) {
+      std::stringstream msg;
+      msg << "Found compiler trace option of " << compilerOptions.event_trace
+          << ". No runtime AIE metrics will be changed.";
+      xrt_core::message::send(severity_level::info, "XRT", msg.str());
+    }
     
     // Process AIE_trace_settings metrics
     auto aieTileMetricsSettings = 
@@ -138,6 +144,13 @@ namespace xdp {
         xrt_core::message::send(severity_level::warning, "XRT", msg.str());
       }
     }
+  }
+
+  void AieTraceMetadata::read_aie_metadata(const char* data, size_t size, pt::ptree& aie_project)
+  {
+    std::stringstream aie_stream;
+    aie_stream.write(data,size);
+    pt::read_json(aie_stream,aie_project);
   }
 
   int AieTraceMetadata::getHardwareGen()
@@ -298,13 +311,6 @@ namespace xdp {
       useUserControl = true;
     }
 
-  }
-
-  void AieTraceMetadata::read_aie_metadata(const char* data, size_t size, pt::ptree& aie_project)
-  {
-    std::stringstream aie_stream;
-    aie_stream.write(data,size);
-    pt::read_json(aie_stream,aie_project);
   }
 
   std::vector<std::string> 
@@ -893,6 +899,21 @@ namespace xdp {
     }
 
     return gmios;
+  }
+
+  aiecompiler_options AieTraceMetadata::get_aiecompiler_options(const xrt_core::device* device)
+  {
+    auto data = device->get_axlf_section(AIE_METADATA);
+    if (!data.first || !data.second)
+      return {};
+
+    pt::ptree aie_meta;
+    read_aie_metadata(data.first, data.second, aie_meta);
+
+    aiecompiler_options aiecompiler_options;
+    aiecompiler_options.broadcast_enable_core = aie_meta.get<bool>("aie_metadata.aiecompiler_options.broadcast_enable_core");
+    aiecompiler_options.event_trace = aie_meta.get("aie_metadata.aiecompiler_options.event_trace", "runtime");
+    return aiecompiler_options;
   }
 
   std::vector<tile_type>

--- a/src/runtime_src/xdp/profile/plugin/aie_trace_new/aie_trace_metadata.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace_new/aie_trace_metadata.h
@@ -66,6 +66,7 @@ class AieTraceMetadata{
 
     std::string getMetricSet(const std::string& metricsStr);
 
+    void checkSettings();
     int getHardwareGen();
     uint16_t getAIETileRowOffset();
     std::vector<std::string> getSettingsVector(std::string settingsString); 
@@ -91,7 +92,6 @@ class AieTraceMetadata{
     std::vector<std::string> get_kernels(const xrt_core::device* device);
     double get_clock_freq_mhz(const xrt_core::device* device);
     std::vector<gmio_type> get_trace_gmios(const xrt_core::device* device);
-    aiecompiler_options get_aiecompiler_options(const xrt_core::device* device);
 
     void getConfigMetricsForTiles(std::vector<std::string>& metricsSettings,
                                   std::vector<std::string>& graphMetricsSettings,

--- a/src/runtime_src/xdp/profile/plugin/aie_trace_new/aie_trace_metadata.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace_new/aie_trace_metadata.h
@@ -92,7 +92,8 @@ class AieTraceMetadata{
     std::vector<std::string> get_kernels(const xrt_core::device* device);
     double get_clock_freq_mhz(const xrt_core::device* device);
     std::vector<gmio_type> get_trace_gmios(const xrt_core::device* device);
-
+    aiecompiler_options get_aiecompiler_options(const xrt_core::device* device);
+    
     void getConfigMetricsForTiles(std::vector<std::string>& metricsSettings,
                                   std::vector<std::string>& graphMetricsSettings,
                                   module_type type);

--- a/src/runtime_src/xdp/profile/plugin/aie_trace_new/aie_trace_metadata.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace_new/aie_trace_metadata.h
@@ -93,7 +93,7 @@ class AieTraceMetadata{
     double get_clock_freq_mhz(const xrt_core::device* device);
     std::vector<gmio_type> get_trace_gmios(const xrt_core::device* device);
     aiecompiler_options get_aiecompiler_options(const xrt_core::device* device);
-    
+
     void getConfigMetricsForTiles(std::vector<std::string>& metricsSettings,
                                   std::vector<std::string>& graphMetricsSettings,
                                   module_type type);

--- a/src/runtime_src/xdp/profile/plugin/aie_trace_new/edge/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace_new/edge/aie_trace.cpp
@@ -191,9 +191,9 @@ namespace xdp {
       return false;
     }
 
-    // compile-time trace
+    // Check compile-time trace
     if (!metadata->getRuntimeMetrics()) {
-      return true;
+      return false;
     }
     
     return true;


### PR DESCRIPTION
**Problem solved by the commit**
* Issue warnings if user uses old AIE profile/trace settings or if incorrect settings are found
* Correct handling of compile-time trace
 
**Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered**
It is easy to provide incorrect settings in an xrt.ini file. This has been a long-standing issue.

**How problem was solved, alternative solutions (if any) and why they were rejected**
We ask for a ptree from the config reader, traverse all provided settings, and compare to supported/expected.

**What has been tested and how, request additional testing if necessary**
Many incorrect settings were tested on vck190.

**Documentation impact (if any)**
List of supported and deprecated settings.