### PR TITLE
Fix for xclbin load failure when device_trace, aie_trace/profile are enabled

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info_database.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info_database.cpp
@@ -2105,9 +2105,9 @@ namespace xdp {
       std::stringstream ss;
       ss.write(embeddedMetadata.first, embeddedMetadata.second);
 
-      // Create a property tree based off of the JSON
+      // Create a property tree based off of the XML
       boost::property_tree::ptree pt;
-      boost::property_tree::read_json(ss, pt);
+      boost::property_tree::read_xml(ss, pt);
 
       // Dig in and find all of the kernel clocks
       for (auto& clock : pt.get_child("project.platform.device.core.kernelClocks")) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://github.com/Xilinx/XRT/pull/7341 wrongly added read_json for Embedded Metadata when the section is in XML format. This caused an exception during population static DB reading static info from xclbin.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Embedded metadata section is now read as XML instead of JSON. This rules out the exception and xclbin gets loaded successfully even if device_trace, aie_trace/profile are enabled

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Xclbins targeted for Edge (vck190)

#### Documentation impact (if any)
