### PR TITLE
Fixed CR-1152499

### DIFF
--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -1018,8 +1018,10 @@ int kds_open_ucu(struct kds_sched *kds, struct kds_client *client, u32 cu_idx)
 	 * For legacy context case assume there is only one hw context present
 	 * of id 0.
 	 */
+	mutex_lock(&client->lock);
 	client->next_hw_ctx_id = 0;
 	hw_ctx = kds_alloc_hw_ctx(client, NULL /* xclbin id*/, 0 /*slot id */);
+	mutex_unlock(&client->lock);
 	if (!hw_ctx) {
 		return -EINVAL;
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
[CR-1152499](https://jira.xilinx.com/browse/CR-1152499)
[Regression] Vitis_accel_examples failing with Segmentation fault for hw_emu flow

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Multi slot check-in introduce this issue. 

#### How problem was solved, alternative solutions (if any) and why they were rejected
Missed a lock for ucu case before createding the default hw context. 

#### Risks (if any) associated the changes in the commit
N/A
#### What has been tested and how, request additional testing if necessary
Basic validation and reported test case

#### Documentation impact (if any)
N/A