### PR TITLE
VITIS-6990:xrt::xclbin API to obtain interface_uuid

### DIFF
--- a/src/runtime_src/core/common/utils.cpp
+++ b/src/runtime_src/core/common/utils.cpp
@@ -28,7 +28,40 @@
 #include <string>
 #include <boost/algorithm/string.hpp>
 
+#ifdef _WIN32
+
+# pragma warning( disable : 4189 4100 )
+# pragma comment(lib, "Ws2_32.lib")
+ /* need to link the lib for the following to work */
+# define be32toh ntohl
+#else
+# include <unistd.h> // SUDO check
+#endif
+
+#define ALIGN(x, a)     (((x) + ((a) - 1)) & ~((a) - 1))
+#define PALIGN(p, a)    ((char *)(ALIGN((unsigned long long)(p), (a))))
+#define GET_CELL(p)     (p += 4, *((const uint32_t *)(p-4)))
+
 namespace {
+
+// ------ C O N S T A N T   V A R I A B L E S ---------------------------------
+static const uint32_t FDT_BEGIN_NODE = 0x1;
+static const uint32_t FDT_PROP = 0x3;
+static const uint32_t FDT_END = 0x9;
+
+// ------ L O C A L  F U N C T I O N S  A N D  S T R U C T S ------------------
+struct fdt_header {
+  uint32_t magic;
+  uint32_t totalsize;
+  uint32_t off_dt_struct;
+  uint32_t off_dt_strings;
+  uint32_t off_mem_rsvmap;
+  uint32_t version;
+  uint32_t last_comp_version;
+  uint32_t boot_cpuid_phys;
+  uint32_t size_dt_strings;
+  uint32_t size_dt_struct;
+};
 
 inline unsigned int
 bit(unsigned int lsh)
@@ -43,7 +76,6 @@ precision(double value, int p)
   stream << std::fixed << std::setprecision(p) << value;
   return stream.str();
 }
-
 
 }
 
@@ -323,6 +355,47 @@ value_to_mac_addr(const uint64_t mac_addr_value)
                                           % ((mac_addr_value >> (0 * 8)) & 0xFF));
 
   return mac_addr;
+}
+
+std::vector<std::string>
+get_uuids(const void* dtbuf)
+{
+  std::vector<std::string> uuidsvec;
+  struct fdt_header* bph = (struct fdt_header*)dtbuf;
+  uint32_t version = be32toh(bph->version);
+  uint32_t off_dt = be32toh(bph->off_dt_struct);
+  const char* p_struct = (const char*)dtbuf + off_dt;
+  uint32_t off_str = be32toh(bph->off_dt_strings);
+  const char* p_strings = (const char*)dtbuf + off_str;
+  const char* p, * s;
+  uint32_t tag;
+  int sz;
+
+  p = p_struct;
+  uuidsvec.clear();
+  while ((tag = be32toh(GET_CELL(p))) != FDT_END) {
+    if (tag == FDT_BEGIN_NODE) {
+        s = p;
+        p = PALIGN(p + strlen(s) + 1, 4);
+        continue;
+    }
+    if (tag != FDT_PROP)
+        continue;
+
+    sz = be32toh(GET_CELL(p));
+    s = p_strings + be32toh(GET_CELL(p));
+    if (version < 16 && sz >= 8)
+        p = PALIGN(p, 8);
+
+    if (!strcmp(s, "logic_uuid")) {
+        uuidsvec.insert(uuidsvec.begin(), std::string(p));
+    }
+    else if (!strcmp(s, "interface_uuid")) {
+        uuidsvec.push_back(std::string(p));
+    }
+    p = PALIGN(p + sz, 4);
+  }
+  return uuidsvec;
 }
 
 }} // utils, xrt_core

--- a/src/runtime_src/core/common/utils.h
+++ b/src/runtime_src/core/common/utils.h
@@ -129,6 +129,13 @@ XRT_CORE_COMMON_EXPORT
 std::string
 value_to_mac_addr(const uint64_t mac_addr_value);
 
+//get_uuids() - Get UUIDs from the axlf section
+//dtbuf: axlf section to be parsed
+//Return: list of UUIDs
+XRT_CORE_COMMON_EXPORT
+std::vector<std::string>
+get_uuids(const void* dtbuf);
+
 }} // utils, xrt_core
 
 #endif

--- a/src/runtime_src/core/include/experimental/xrt_xclbin.h
+++ b/src/runtime_src/core/include/experimental/xrt_xclbin.h
@@ -735,6 +735,18 @@ public:
   get_uuid() const;
 
   /**
+   * get_interface_uuid() - Get the interface uuid of the xclbin and this can be a collection of UUIDs and not just one.
+   *
+   * @return
+   * Collection of UUIDs
+   *
+   * An exception is thrown if the data is missing.
+   */
+  XCL_DRIVER_DLLESPEC
+  std::vector<std::string>
+  get_interface_uuid() const;
+
+  /**
    * get_target_type() - Get the type of this xclbin
    *
    * @return

--- a/src/runtime_src/core/tools/common/XBUtilities.h
+++ b/src/runtime_src/core/tools/common/XBUtilities.h
@@ -69,15 +69,6 @@ namespace XBUtilities {
   std::vector<char>
   get_axlf_section(const std::string& filename, axlf_section_kind section);
 
-  /**
-   * get_uuids() - Get UUIDs from the axlf section
-   *
-   * dtbuf: axlf section to be parsed
-   *
-   * Return: list of UUIDs
-   */
-  std::vector<std::string> get_uuids(const void *dtbuf);
-
   xrt_core::query::reset_type str_to_reset_obj(const std::string& str);
 
   std::string

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -127,7 +127,7 @@ searchSSV2Xclbin(const std::string& logic_uuid,
           ++iter;
           continue;
         }
-        std::vector<std::string> uuids = XBUtilities::get_uuids(dtbbuf.data());
+        std::vector<std::string> uuids = xrt_core::utils::get_uuids(dtbbuf.data());
         if (!uuids.size()) {
           ++iter;
 		    }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Added below API for xrt::xclbin to obtain interface_uuid 
```
//get_interface_uuid() - Get the interface uuid of the xclbin and this can be a collection of UUIDs and not just one.   
//return  - Collection of UUIDs

XCL_DRIVER_DLLESPEC
std::vector<std::string>  get_interface_uuid() const;

//This API returning std::vector<std::string> instead of std::vector<uuid> because 
// interface_uuild which is coming from PARTITION_METADATA  is not in standard UUID format.
```
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://jira.xilinx.com/browse/VITIS-6990
#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit
Low risk as it is new API.
#### What has been tested and how, request additional testing if necessary
Tested locally some cases.
#### Documentation impact (if any)
Yes, Need to add this new API to the XRT::XCLBIN documentation. 