### PR TITLE
CR-1145299 xbmgmt examine -r vmr outputs more info for status

### DIFF
--- a/src/runtime_src/core/tools/common/ReportVmrStatus.cpp
+++ b/src/runtime_src/core/tools/common/ReportVmrStatus.cpp
@@ -55,13 +55,18 @@ ReportVmrStatus::writeReport( const xrt_core::device* /*_pDevice*/,
     return;
   }
 
-  // list of sorted non-verbose labels
+  // list of non-verbose labels
   std::vector<std::string> non_verbose_labels = { 
       "build flags", 
       "git branch", 
       "git hash",  
       "git hash date",
-      "vitis version" 
+      "vitis version",
+      "boot on default",
+      "boot on backup",
+      "pl is ready",
+      "ps is ready",
+      "sc is ready"
     };
 
   output << "Vmr Status" << std::endl;


### PR DESCRIPTION
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1145299 There is desired info from vmr verbose info that should be displayed in the status.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
The default `xbmgmt examine -r vmr` needs to display more for the user as long as vmr is up.
#### How problem was solved, alternative solutions (if any) and why they were rejected
The requested information was moved from --verbose to non-verbose output (boot on default, boot on backup, pl is ready, ps is ready, sc is ready).
#### Risks (if any) associated the changes in the commit
N/A
#### What has been tested and how, request additional testing if necessary
Examples of output for standard vmr report and when there are issues retrieving all non-verbose information.
```
rchane@xsjsagarw50:/proj/rdi/staff/rchane/XRT$ xbmgmt examine -d b3:00 -r vmr
-----------------------------------------------
[0000:b3:00.0] : xilinx_v70_gen5x8_qdma_base_2
-----------------------------------------------
Vmr Status
  Build flags          :  default full build
  Vitis version        :  installs
  Git hash             :  9ece31633399840763fb7cdfdfcc92fb4ed95098
  Git branch           :  main
  Git hash date        :  Thu, 27 Oct 2022 13:54:05 -0700
  Boot on default      : 1
  Boot on backup       : 0
  Pl is ready          : 1
  Ps is ready          : 0
  Sc is ready          : 1

rchane@xsjsagarw50:/proj/rdi/staff/rchane/XRT$ xbmgmt examine -d b3:00 -r vmr --verbose
Verbose: Enabling Verbosity
Verbose: SubCommand: examine
-----------------------------------------------
[0000:b3:00.0] : xilinx_v70_gen5x8_qdma_base_2
-----------------------------------------------
Vmr Status
  Build flags          :  default full build
  Vitis version        :  installs
  Git hash             :  9ece31633399840763fb7cdfdfcc92fb4ed95098
  Git branch           :  main
  Git hash date        :  Thu, 27 Oct 2022 13:54:05 -0700
  Vmr build date       :  Fri Oct 28 06:44:31 MDT 2022
  Vmr build version    :  202210.2.13.356
  Default image offset :  0x48000
  Default image size   :  0x5dea10
  Default image capacity :  0x5fb8000
  Backup image offset  :  0x6008000
  Backup image size    :  0x5f7f30
  Backup image capacity :  0x5fb8000
  Scfw image size      :  0x36ef8
  Scfw image version   :  8.5.1
  Has fpt              : 1
  Has fpt recovery     : 1
  Boot on default      : 1
  Boot on backup       : 0
  Boot on recovery     : 0
  Current multi boot offset : 0x9
  Boot on offset       : 0x9
  Has extfpt           : 1
  Has ext meta xsabin  : 1
  Has ext sc fw        : 1
  Has ext system dtb   : 1
  Debug level          : 0
  Program progress     : 0
  Pl is ready          : 1
  Ps is ready          : 0
  Sc is ready          : 1

rchane@xsjsagarw50:/proj/rdi/staff/rchane/XRT$ xbmgmt examine -d 65:00 -r vmr
---------------------------------------------------
[0000:65:00.0] : xilinx_vck5000_gen4x8_qdma_base_2
---------------------------------------------------
Vmr Status
  Boot on default      : 1
  Boot on backup       : 0
  Pl is ready          : 1
  Ps is ready          : 0
  Sc is ready          : 0
Vmr
  ERROR: Incomplete Information

rchane@xsjsagarw50:/proj/rdi/staff/rchane/XRT$ xbmgmt examine -d 65:00 -r vmr --verbose
Verbose: Enabling Verbosity
Verbose: SubCommand: examine
---------------------------------------------------
[0000:65:00.0] : xilinx_vck5000_gen4x8_qdma_base_2
---------------------------------------------------
Vmr Status
  Has fpt              : 1
  Has fpt recovery     : 1
  Boot on default      : 1
  Boot on backup       : 0
  Boot on recovery     : 0
  Current multi boot offset : 0x9
  Boot on offset       : 0x9
  Has extfpt           : 1
  Has ext meta xsabin  : 1
  Has ext sc fw        : 1
  Has ext system dtb   : 1
  Debug level          : 0
  Program progress     : 0
  Pl is ready          : 1
  Ps is ready          : 0
  Sc is ready          : 0
Vmr
  ERROR: Incomplete Information
```
#### Documentation impact (if any)
N/A