### PR TITLE
Disable -Wpedantic for files using anonymous struct

### DIFF
--- a/src/runtime_src/core/include/ert.h
+++ b/src/runtime_src/core/include/ert.h
@@ -59,6 +59,11 @@
 # pragma warning( disable : 4201 )
 #endif
 
+#if defined(__GNUC__)
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+
 #define to_cfg_pkg(pkg) \
     ((struct ert_configure_cmd *)(pkg))
 #define to_start_krnl_pkg(pkg) \

--- a/src/runtime_src/core/include/xrt_mem.h
+++ b/src/runtime_src/core/include/xrt_mem.h
@@ -38,6 +38,11 @@
 # pragma warning( disable : 4201 )
 #endif
 
+#if defined(__GNUC__)
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+
 #ifdef __cplusplus
 # include <cstdint>
 extern "C" {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
When XRT is linked to projects compiled with GCC and using -Wpedantic, few warnings concerning anonymous structs are fired:
```
...
/opt/xilinx/xrt/include/xrt_mem.h:59:12: warning: ISO C++ prohibits anonymous structs [-Wpedantic]
   59 |     struct {
...
/opt/xilinx/xrt/include/ert.h:93:12: warning: ISO C++ prohibits anonymous structs [-Wpedantic]
   93 |     struct {
...
```
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added 
```
#if defined(__GNUC__)
# pragma GCC diagnostic push
# pragma GCC diagnostic ignored "-Wpedantic"
#endif
```
to disable -Wpedantic in the two headers causing the warning. 

**Note:** Another approach to fix these warning would have been to prefix the structs definition by `__extension__` intrinsic for GCC only as shown in [this](https://github.com/boostorg/winapi/commit/f004b4753d6fee6f68c90cfc65b075fa0a33d092) commit. This have the advantage of not disabling -Wpedantic for the full file but reduces the code readability. I have choosen the above solution as a similar warning silencing seems to be implemented in both file for WIN32.

#### Risks (if any) associated the changes in the commit
-Wpedantic being disabled for these two file, it might silence usefull warning in the future.

#### What has been tested and how, request additional testing if necessary
The warnings are not fired during compilation anymore and the build is successful.
#### Documentation impact (if any)
None that I am aware of.
