### PR TITLE
CR-1150169 mgmt-ioctl: fix lower bound check on xclbin size

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-ioctl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-ioctl.c
@@ -85,8 +85,8 @@ static int bitstream_ioctl_axlf(struct xclmgmt_dev *lro, const void __user *arg)
 		return -EINVAL;
 
 	copy_buffer_size = xclbin_obj.m_header.m_length;
-	/* Assuming xclbin is not over 1G */
-	if (copy_buffer_size > 1024 * 1024 * 1024)
+	/* Assuming xclbin is not over 1G & not less than size of struct axlf */
+	if (copy_buffer_size < sizeof(xclbin_obj) || copy_buffer_size > 1024 * 1024 * 1024)
 		return -EINVAL;
 	copy_buffer = vmalloc(copy_buffer_size);
 	if (copy_buffer == NULL)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Add minimum xclbin size condition check
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1150169
#### How problem was solved, alternative solutions (if any) and why they were rejected
Added lower bound check for xclbin size.
#### Risks (if any) associated the changes in the commit
NA
#### What has been tested and how, request additional testing if necessary
compile, validate tests
#### Documentation impact (if any)
NA