### PR TITLE
CR-1145201 Update GitHub documentation for xbmgmt dump

### DIFF
--- a/src/runtime_src/doc/toc/xbmgmt.rst
+++ b/src/runtime_src/doc/toc/xbmgmt.rst
@@ -78,7 +78,7 @@ Enabling/Disabling DDR memory retention on a device
 xbmgmt dump
 ~~~~~~~~~~~
 
-The ``xbmgmt dump`` command dump out content of the specified option 
+The ``xbmgmt dump`` command dumps out content of the specified option
 
 **The supported options**
 
@@ -86,14 +86,14 @@ Dumping the output of system configuration.
 
 .. code-block:: shell
 
-    xbmgmt dump [--device| -d] <management bdf> [--config| -c] [--output| -o] <filename>
+    xbmgmt dump [--device| -d] <management bdf> [--config| -c] [--output| -o] <filename with .ini extension>
     
 
 Dumping the output of programmed system image
 
 .. code-block:: shell
 
-    xbmgmt dump [--device| -d] <management bdf> [--flash| -f] [--output| -o] <filename with .ini extension>
+    xbmgmt dump [--device| -d] <management bdf> [--flash| -f] [--output| -o] <filename with .bin extension>
 
 
 **The details of the supported options**
@@ -103,9 +103,9 @@ Dumping the output of programmed system image
     - <management bdf> : The Bus:Device.Function of the device of interest
 
 
-- The ``--flash`` (or ``-f``) option dumps the output of programmed system image.
-- The ``--config`` (or ``-c``) option dumps the output of system configuration.
-- The ``--output`` (or ``-o``) specifies the output file to direct the dumped output. For ``--config`` the output file must have extension .ini
+- The ``--flash`` (or ``-f``) option dumps the output of programmed system image. Requires a .bin output file by ``-o`` option.
+- The ``--config`` (or ``-c``) option dumps the output of system configuration. Requires a .ini output file by ``-o`` option.
+- The ``--output`` (or ``-o``) specifies the output file to direct the dumped output.
     
 
 **Example commands** 
@@ -115,7 +115,7 @@ Dumping the output of programmed system image
 
       
     #Dump programmed system image data
-    xbmgmt dump --device 0000:b3:00.0 --flash -o /tmp/flash_dump.txt
+    xbmgmt dump --device 0000:b3:00.0 --flash -o /tmp/flash_dump.bin
     
     #Dump system configaration 
     xbmgmt dump --device 0000:b3:00.0 --config -o /tmp/config_dump.ini


### PR DESCRIPTION
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1145201 Documentation for xbmgmt dump was inconsistent with cmd line help printout.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
xbmgmt dump with the `flash` option requires .bin file extension.
#### How problem was solved, alternative solutions (if any) and why they were rejected
Documentation for xbmgmt dump now matches the cmd line help printout.
#### Risks (if any) associated the changes in the commit
N/A
#### What has been tested and how, request additional testing if necessary
Please see the screenshot below.
![Documentation](https://user-images.githubusercontent.com/103678133/220733655-4a082cac-1f80-4916-8faf-0a37a0a3934a.png)

#### Documentation impact (if any)
This is a documentation change. 