### PR TITLE
CR-1151862 xbutil validate fails testing m2m on OS RH 9.0

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libxdma.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libxdma.c
@@ -1702,7 +1702,6 @@ static void engine_process_requests(struct work_struct *work)
 	rv = xdma_request_desc_init(engine, 0);
 	if (rv < 0)
 		pr_err("Failed to perform descriptor init\n");
-		return;
 }
 
 
@@ -3231,7 +3230,7 @@ static ssize_t fastpath_start(struct xdma_engine *engine, u64 endpoint_addr,
 			      struct scatterlist **sg, u32 *sg_off, u32 *last_adj)
 {
 	dma_addr_t addr;
-	int i, ret = 0;
+	int i;
 	u32 len, rest, adj, desc_num = 0;
 	ssize_t total = 0;
 
@@ -3254,6 +3253,8 @@ static ssize_t fastpath_start(struct xdma_engine *engine, u64 endpoint_addr,
 			desc_num++;
 		}
 	}
+	if (!total)
+		return 0;
 	fastpath_desc_set_last(engine, desc_num);
 	engine->f_submitted_desc_cnt = desc_num;
 
@@ -3269,9 +3270,9 @@ static ssize_t fastpath_start(struct xdma_engine *engine, u64 endpoint_addr,
 		mmiowb();
 		*last_adj = adj;
 	}
-	ret = engine_start_mode_config(engine);
+	engine_start_mode_config(engine);
 
-	return ret ? -EIO : total;
+	return total;
 }
 
 ssize_t xdma_xfer_fastpath(void *dev_hndl, int channel, bool write, u64 ep_addr,
@@ -3320,10 +3321,9 @@ ssize_t xdma_xfer_fastpath(void *dev_hndl, int channel, bool write, u64 ep_addr,
 	while (sg && ret >= 0) {
 		engine->f_fastpath = true;
 		ret = fastpath_start(engine, ep_addr + done_bytes,&sg, &sg_off, &last_adj);
-		if (ret < 0) {
-			engine->f_fastpath = false;
-			break;
-		}
+		if (!ret)
+			continue;
+
 		done_bytes += ret;
 		if (!wait_for_completion_timeout(&engine->f_req_compl,
 						 msecs_to_jiffies(10000))) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
The sg list could have a bunch zero length sg which need to be ignored.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1151862 xbutil validate fails testing m2m on OS RH 9.0
#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
xbutil m2m test on AMD server with IOMMU on
#### Documentation impact (if any)
