### PR TITLE
fixed bug with finding MEM tile sets

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_trace_new/aie_trace_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace_new/aie_trace_metadata.cpp
@@ -847,7 +847,9 @@ namespace xdp {
       }
 
       // Ensure requested metric set is supported (if not, use default)
-      if (std::find(metricSets.begin(), metricSets.end(), tileMetric.second) == metricSets.end()) {
+      auto metricSetItr = std::find(metricSets.begin(), metricSets.end(), tileMetric.second);
+      auto memTileMetricSetItr = std::find(memTileMetricSets.begin(), memTileMetricSets.end(), tileMetric.second);
+      if ((metricSetItr == metricSets.cend()) && (memTileMetricSetItr == memTileMetricSets.cend())) {
         std::string defaultSet = (type == module_type::mem_tile) ? "input_channels" : "functions";
         if (showWarning) {
           std::stringstream msg;
@@ -957,14 +959,14 @@ namespace xdp {
     return tiles;
   }
 
-   uint8_t AieTraceMetadata::getMetricSetIndex(std::string metricString){    
-
-    //Check if the metricSet is valid for either regular tiles or memtiles, and convert to an index to pass to PS kernel.
+  uint8_t AieTraceMetadata::getMetricSetIndex(std::string metricString) {
+    // Verify metric set is valid for either AIE or MEM tiles, 
+    // and convert to index to pass to PS kernel.
     auto metricSetItr = std::find(metricSets.begin(), metricSets.end(), metricString);
     auto memTileMetricSetItr = std::find(memTileMetricSets.begin(), memTileMetricSets.end(), metricString);
-    if (metricSetItr == metricSets.cend() && memTileMetricSetItr == memTileMetricSets.cend()){
+    if ((metricSetItr == metricSets.cend()) && (memTileMetricSetItr == memTileMetricSets.cend())) {
       return 0; //Default
-    } else if (metricSetItr != metricSets.cend()){
+    } else if (metricSetItr != metricSets.cend()) {
       return std::distance(metricSets.begin(), metricSetItr);
     } else {
       return std::distance(memTileMetricSets.begin(), memTileMetricSetItr);

--- a/src/runtime_src/xdp/profile/plugin/aie_trace_new/aie_trace_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace_new/aie_trace_metadata.cpp
@@ -847,9 +847,10 @@ namespace xdp {
       }
 
       // Ensure requested metric set is supported (if not, use default)
-      auto metricSetItr = std::find(metricSets.begin(), metricSets.end(), tileMetric.second);
-      auto memTileMetricSetItr = std::find(memTileMetricSets.begin(), memTileMetricSets.end(), tileMetric.second);
-      if ((metricSetItr == metricSets.cend()) && (memTileMetricSetItr == memTileMetricSets.cend())) {
+      if (((type != module_type::mem_tile) 
+          && (std::find(metricSets.begin(), metricSets.end(), tileMetric.second) == metricSets.end()))
+          || ((type == module_type::mem_tile) 
+          && (std::find(memTileMetricSets.begin(), memTileMetricSets.end(), tileMetric.second) == memTileMetricSets.end()))) {
         std::string defaultSet = (type == module_type::mem_tile) ? "input_channels" : "functions";
         if (showWarning) {
           std::stringstream msg;


### PR DESCRIPTION
**Problem solved by the commit**
Fixed bug where metric set for MEM tiles was always being replaced with default

What has been tested and how, request additional testing if necessary
Tested on vek280
