### PR TITLE
aie status dump support for vek280

### DIFF
--- a/src/runtime_src/core/edge/user/aie_sys_parser.cpp
+++ b/src/runtime_src/core/edge/user/aie_sys_parser.cpp
@@ -143,7 +143,7 @@ aie_sys_parser::addrecursive(const int col, const int row, const std::string& ta
  * If present, reads and parse the content of each sysfs.
  */
 boost::property_tree::ptree
-aie_sys_parser::aie_sys_read(const int col,const int row)
+aie_sys_parser::aie_sys_read(const int col, const int row)
 {
     const static std::vector<std::string> tags{"core","dma","lock","errors","event"};
     std::vector<std::string> data;
@@ -159,10 +159,10 @@ aie_sys_parser::aie_sys_read(const int col,const int row)
     return pt;	
 }
 
-aie_sys_parser *aie_sys_parser::get_parser()
+aie_sys_parser *aie_sys_parser::get_parser(const std::string& aiepart)
 {
-    //TODO: get partition id from xclbin but its not supported currently.
-    static aie_sys_parser dev("/sys/class/aie/aiepart_0_50/");
+    const std::string sroot = "/sys/class/aie/aiepart_" + aiepart + "/";
+    static aie_sys_parser dev(sroot);
     return &dev;
 }
 

--- a/src/runtime_src/core/edge/user/aie_sys_parser.h
+++ b/src/runtime_src/core/edge/user/aie_sys_parser.h
@@ -36,7 +36,7 @@ private:
     aie_sys_parser& operator=(const aie_sys_parser& s) = delete;
 
 public:
-    static aie_sys_parser *get_parser();
+    static aie_sys_parser *get_parser(const std::string& aiepart);
     boost::property_tree::ptree aie_sys_read(const int col, const int row);
 
 };

--- a/src/runtime_src/core/edge/user/device_linux.cpp
+++ b/src/runtime_src/core/edge/user/device_linux.cpp
@@ -213,7 +213,7 @@ struct aie_core_info_sysfs
   {
     boost::property_tree::ptree ptarray;
     aie_metadata_info aie_meta = get_aie_metadata_info(device);
-    std::string aiepart = std::to_string(aie_meta.shim_row) + "_" + std::to_string(aie_meta.num_cols);
+    const std::string aiepart = std::to_string(aie_meta.shim_row) + "_" + std::to_string(aie_meta.num_cols);
 
     /* Loop each all aie core tiles and collect core, dma, events, errors, locks status. */
     for (int i = 0; i < aie_meta.num_cols; ++i)
@@ -240,7 +240,7 @@ struct aie_shim_info_sysfs
   {
     boost::property_tree::ptree ptarray;
     aie_metadata_info aie_meta = get_aie_metadata_info(device);
-    std::string aiepart = std::to_string(aie_meta.shim_row) + "_" + std::to_string(aie_meta.num_cols);
+    const std::string aiepart = std::to_string(aie_meta.shim_row) + "_" + std::to_string(aie_meta.num_cols);
 
     /* Loop all shim tiles and collect all dma, events, errors, locks status */
     for (int i=0; i < aie_meta.num_cols; ++i) {
@@ -265,7 +265,7 @@ struct aie_mem_info_sysfs
   {
     boost::property_tree::ptree ptarray;
     aie_metadata_info aie_meta = get_aie_metadata_info(device);
-    std::string aiepart = std::to_string(aie_meta.shim_row) + "_" + std::to_string(aie_meta.num_cols);
+    const std::string aiepart = std::to_string(aie_meta.shim_row) + "_" + std::to_string(aie_meta.num_cols);
 						
     /* Loop all mem tiles and collect all dma, events, errors, locks status */
     for (int i = 0; i < aie_meta.num_cols; ++i)

--- a/src/runtime_src/core/edge/user/device_linux.cpp
+++ b/src/runtime_src/core/edge/user/device_linux.cpp
@@ -157,9 +157,18 @@ struct dev_info
   }
 };
 
+struct aie_metadata_info{
+  uint32_t num_cols;
+  uint32_t num_rows;
+  uint32_t shim_row;
+  uint32_t core_row;
+  uint32_t mem_row;
+  uint32_t num_mem_row;
+};
+
 // Function to get aie max rows and cols by parsing aie_metadata sysfs node
-static void
-get_aie_row_col(const xrt_core::device* device, uint32_t &row, uint32_t &col)
+static aie_metadata_info 
+get_aie_metadata_info(const xrt_core::device* device)
 {
   std::string err;
   std::string value;
@@ -167,6 +176,7 @@ get_aie_row_col(const xrt_core::device* device, uint32_t &row, uint32_t &col)
   constexpr uint32_t major = 1;
   constexpr uint32_t minor = 0;
   constexpr uint32_t patch = 0;
+  aie_metadata_info aie_meta;
 
   auto dev = get_edgedev(device);
 
@@ -186,8 +196,13 @@ get_aie_row_col(const xrt_core::device* device, uint32_t &row, uint32_t &col)
         % pt.get<uint32_t>("schema_version.minor")
         % pt.get<uint32_t>("schema_version.patch")));
 
-  col = pt.get<uint32_t>("aie_metadata.driver_config.num_columns");
-  row = pt.get<uint32_t>("aie_metadata.driver_config.num_rows");
+  aie_meta.num_cols = pt.get<uint32_t>("aie_metadata.driver_config.num_columns");
+  aie_meta.num_rows = pt.get<uint32_t>("aie_metadata.driver_config.num_rows");
+  aie_meta.shim_row = pt.get<uint32_t>("aie_metadata.driver_config.shim_row");
+  aie_meta.core_row = pt.get<uint32_t>("aie_metadata.driver_config.aie_tile_row_start");
+  aie_meta.mem_row = pt.get<uint32_t>("aie_metadata.driver_config.reserved_row_start");
+  aie_meta.num_mem_row = pt.get<uint32_t>("aie_metadata.driver_config.reserved_num_rows");
+  return aie_meta;
 }
 
 struct aie_core_info_sysfs
@@ -197,15 +212,14 @@ struct aie_core_info_sysfs
   get(const xrt_core::device* device, key_type key)
   {
     boost::property_tree::ptree ptarray;
-    uint32_t max_col = 0, max_row = 0;
-
-    get_aie_row_col(device, max_row, max_col);
+    aie_metadata_info aie_meta = get_aie_metadata_info(device);
+    std::string aiepart = std::to_string(aie_meta.shim_row) + "_" + std::to_string(aie_meta.num_cols);
 
     /* Loop each all aie core tiles and collect core, dma, events, errors, locks status. */
-    for(int i=0;i<max_col;i++)
-      for(int j=0; j<(max_row-1);j++)
-        ptarray.push_back(std::make_pair(std::to_string(i)+"_"+std::to_string(j),
-                          aie_sys_parser::get_parser()->aie_sys_read(i,(j+1))));
+    for (int i = 0; i < aie_meta.num_cols; ++i)
+      for (int j = 0; j < (aie_meta.num_rows-1); ++j)
+        ptarray.push_back(std::make_pair(std::to_string(i) + "_" + std::to_string(j),
+                          aie_sys_parser::get_parser(aiepart)->aie_sys_read(i,(j + aie_meta.core_row))));
 
     boost::property_tree::ptree pt;
     pt.add_child("aie_core",ptarray);
@@ -225,19 +239,44 @@ struct aie_shim_info_sysfs
   get(const xrt_core::device* device, key_type key)
   {
     boost::property_tree::ptree ptarray;
-    uint32_t max_col = 0, max_row = 0;
-
-    get_aie_row_col(device, max_row, max_col);
+    aie_metadata_info aie_meta = get_aie_metadata_info(device);
+    std::string aiepart = std::to_string(aie_meta.shim_row) + "_" + std::to_string(aie_meta.num_cols);
 
     /* Loop all shim tiles and collect all dma, events, errors, locks status */
-    for(int i=0;i<max_col;i++) {
-      ptarray.push_back(std::make_pair("", aie_sys_parser::get_parser()->aie_sys_read(i,0)));
+    for (int i=0; i < aie_meta.num_cols; ++i) {
+      ptarray.push_back(std::make_pair("", aie_sys_parser::get_parser(aiepart)->aie_sys_read(i, aie_meta.shim_row)));
     }
 
     boost::property_tree::ptree pt;
     pt.add_child("aie_shim",ptarray);
     std::ostringstream oss;
     boost::property_tree::write_json(oss, pt);
+    std::string inifile_text = oss.str();
+    return inifile_text;
+  }
+};
+
+struct aie_mem_info_sysfs
+{
+  using result_type = query::aie_mem_info_sysfs::result_type;
+	  
+  static result_type
+  get(const xrt_core::device* device, key_type key) 
+  {
+    boost::property_tree::ptree ptarray;
+    aie_metadata_info aie_meta = get_aie_metadata_info(device);
+    std::string aiepart = std::to_string(aie_meta.shim_row) + "_" + std::to_string(aie_meta.num_cols);
+						
+    /* Loop all mem tiles and collect all dma, events, errors, locks status */
+    for (int i = 0; i < aie_meta.num_cols; ++i)
+      for (int j = 0; j < (aie_meta.num_mem_row-1); ++j)
+	ptarray.push_back(std::make_pair(std::to_string(i) + "_" + std::to_string(j),
+			  aie_sys_parser::get_parser(aiepart)->aie_sys_read(i,(j + aie_meta.mem_row))));
+	 
+    boost::property_tree::ptree pt;
+    pt.add_child("aie_mem",ptarray);
+    std::ostringstream oss; 
+    boost::property_tree::write_json(oss, pt); 
     std::string inifile_text = oss.str();
     return inifile_text;
   }
@@ -859,6 +898,7 @@ initialize_query_table()
   emplace_func0_request<query::clock_freqs_mhz,         dev_info>();
   emplace_func0_request<query::aie_core_info_sysfs,     aie_core_info_sysfs>();
   emplace_func0_request<query::aie_shim_info_sysfs,     aie_shim_info_sysfs>();
+  emplace_func0_request<query::aie_mem_info_sysfs,      aie_mem_info_sysfs>();
   emplace_func3_request<query::aie_reg_read,            aie_reg_read>();
   emplace_func4_request<query::aie_get_freq,            aie_get_freq>();
   emplace_func2_request<query::aie_set_freq,            aie_set_freq>();


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Enabling aie status dump support for vek280
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Tested aie and aie_mem report on vek280 (attaching the output of 1 mem tile below)

> versal-rootfs-common-20231:/mnt# xbutil examine -r aie -d 
Aie
  Aie_Metadata
  GRAPH[ 0] Name      : aie_graph
            Status    : unknown
    SNo.  Core [C:R]          Iteration_Memory [C:R]        Iteration_Memory_Addresses    
    [ 0]   18:0                18:0                          4                             

Core [ 0]
    Column                : 18
    Row                   : 0
    Core:
        Status                : enable, reset
        Program Counter       : 0x00000000
        Link Register         : 0x00000000
        Stack Pointer         : 0x00000000
    DMA:
        MM2S:
            Channel:
                Id                    : 0
                Channel Status        : idle
                Queue Size            : 0
                Queue Status          : okay
                Current BD            : 0

                Id                    : 1
                Channel Status        : idle
                Queue Size            : 0
                Queue Status          : okay
                Current BD            : 0

        S2MM:
            Channel:
                Id                    : 0
                Channel Status        : idle
                Queue Size            : 0
                Queue Status          : okay
                Current BD            : 0

                Id                    : 1
                Channel Status        : idle
                Queue Size            : 0
                Queue Status          : okay
                Current BD            : 0

    Locks:
        0                     : 0
        1                     : 0
        2                     : 0
        3                     : 0
        4                     : 0
        5                     : 0
        6                     : 0
        7                     : 0
        8                     : 0
        9                     : 0
        10                    : 0
        11                    : 0
        12                    : 0
        13                    : 0
        14                    : 0
        15                    : 0

    Events:
        core                  : 1
        memory                : 1

versal-rootfs-common-20231:/mnt# xbutil examine -r aie_mem -d

> AIE
  Mem Status
Tile[ 0]
    Column                : 0
    Row                   : 1
    DMA:
        FIFO:
        MM2S:
            Channel:
                Id                    : 0
                Channel Status        : idle
                Queue Size            : 0
                Queue Status          : okay
                Current BD            : 0

                Id                    : 1
                Channel Status        : idle
                Queue Size            : 0
                Queue Status          : okay
                Current BD            : 0

                Id                    : 2
                Channel Status        : idle
                Queue Size            : 0
                Queue Status          : okay
                Current BD            : 0

                Id                    : 3
                Channel Status        : idle
                Queue Size            : 0
                Queue Status          : okay
                Current BD            : 0

                Id                    : 4
                Channel Status        : idle
                Queue Size            : 0
                Queue Status          : okay
                Current BD            : 0

                Id                    : 5
                Channel Status        : idle
                Queue Size            : 0
                Queue Status          : okay
                Current BD            : 0

        S2MM:
            Channel:
                Id                    : 0
                Channel Status        : idle
                Queue Size            : 0
                Queue Status          : okay
                Current BD            : 0

                Id                    : 1
                Channel Status        : idle
                Queue Size            : 0
                Queue Status          : okay
                Current BD            : 0

                Id                    : 2
                Channel Status        : idle
                Queue Size            : 0
                Queue Status          : okay
                Current BD            : 0

                Id                    : 3
                Channel Status        : idle
                Queue Size            : 0
                Queue Status          : okay
                Current BD            : 0

                Id                    : 4
                Channel Status        : idle
                Queue Size            : 0
                Queue Status          : okay
                Current BD            : 0

                Id                    : 5
                Channel Status        : idle
                Queue Size            : 0
                Queue Status          : okay
                Current BD            : 0

    Locks:
        0                     : 0
        1                     : 0
        2                     : 0
        3                     : 0
        4                     : 0
        5                     : 0
        6                     : 0
        7                     : 0
        8                     : 0
        9                     : 0
        10                    : 0
        11                    : 0
        12                    : 0
        13                    : 0
        14                    : 0
        15                    : 0
        16                    : 0
        17                    : 0
        18                    : 0
        19                    : 0
        20                    : 0
        21                    : 0
        22                    : 0
        23                    : 0
        24                    : 0
        25                    : 0
        26                    : 0
        27                    : 0
        28                    : 0
        29                    : 0
        30                    : 0
        31                    : 0
        32                    : 0
        33                    : 0
        34                    : 0
        35                    : 0
        36                    : 0
        37                    : 0
        38                    : 0
        39                    : 0
        40                    : 0
        41                    : 0
        42                    : 0
        43                    : 0
        44                    : 0
        45                    : 0
        46                    : 0
        47                    : 0
        48                    : 0
        49                    : 0
        50                    : 0
        51                    : 0
        52                    : 0
        53                    : 0
        54                    : 0
        55                    : 0
        56                    : 0
        57                    : 0
        58                    : 0
        59                    : 0
        60                    : 0
        61                    : 0
        62                    : 0
        63                    : 0

    Events:
        memory_tile           : 


#### Documentation impact (if any)
