### PR TITLE
CR-1148287

### DIFF
--- a/src/runtime_src/core/edge/ps_kernels/profiling/aie2_profile_config/aie2_profile_config.cpp
+++ b/src/runtime_src/core/edge/ps_kernels/profiling/aie2_profile_config/aie2_profile_config.cpp
@@ -557,7 +557,7 @@ int aie_profile_config(uint8_t* input, uint8_t* output, uint8_t iteration, xrtHa
 
   //Cleanup Iteration
   } else if (iteration == 2) {
-    for (auto& c : mPerfCounters){
+    for (auto& c : constructs->mPerfCounters){
       c->stop();
       c->release();
     }

--- a/src/runtime_src/core/edge/ps_kernels/profiling/aie2_profile_config/aie2_profile_config.cpp
+++ b/src/runtime_src/core/edge/ps_kernels/profiling/aie2_profile_config/aie2_profile_config.cpp
@@ -475,8 +475,6 @@ namespace {
   }
 } // end anonymous namespace
 
-
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -556,6 +554,13 @@ int aie_profile_config(uint8_t* input, uint8_t* output, uint8_t iteration, xrtHa
     uint8_t* out = reinterpret_cast<uint8_t*>(outputcfg);
     std::memcpy(output, out, total_size);   
     free (outputcfg);
+
+  //Cleanup Iteration
+  } else if (iteration == 2) {
+    for (auto& c : mPerfCounters){
+      c->stop();
+      c->release();
+    }
   } 
 
   return 0;

--- a/src/runtime_src/core/edge/ps_kernels/profiling/aie2_profile_config/aie2_profile_config.cpp
+++ b/src/runtime_src/core/edge/ps_kernels/profiling/aie2_profile_config/aie2_profile_config.cpp
@@ -403,12 +403,8 @@ namespace {
 
           outputcfg->counters[counterId] = outputCounter;
           outputcfg->numCounters = counterId;
-      
-          
         }
-
       }
-
       runtimeCounters = true;
     } // modules
 

--- a/src/runtime_src/core/edge/ps_kernels/profiling/aie_profile_config/aie_profile_config.cpp
+++ b/src/runtime_src/core/edge/ps_kernels/profiling/aie_profile_config/aie_profile_config.cpp
@@ -484,6 +484,13 @@ int aie_profile_config(uint8_t* input, uint8_t* output, uint8_t iteration, xrtHa
     uint8_t* out = reinterpret_cast<uint8_t*>(outputcfg);
     std::memcpy(output, out, total_size);   
     free (outputcfg);
+  
+  //Cleanup Iteration
+  } else if (iteration == 2) {
+    for (auto& c : mPerfCounters){
+      c->stop();
+      c->release();
+    }
   } 
 
   return 0;

--- a/src/runtime_src/core/edge/ps_kernels/profiling/aie_profile_config/aie_profile_config.cpp
+++ b/src/runtime_src/core/edge/ps_kernels/profiling/aie_profile_config/aie_profile_config.cpp
@@ -487,7 +487,7 @@ int aie_profile_config(uint8_t* input, uint8_t* output, uint8_t iteration, xrtHa
   
   //Cleanup Iteration
   } else if (iteration == 2) {
-    for (auto& c : mPerfCounters){
+    for (auto& c : constructs->mPerfCounters){
       c->stop();
       c->release();
     }

--- a/src/runtime_src/core/edge/ps_kernels/profiling/aie_profile_config/aie_profile_config.cpp
+++ b/src/runtime_src/core/edge/ps_kernels/profiling/aie_profile_config/aie_profile_config.cpp
@@ -404,8 +404,6 @@ namespace {
   }
 } // end anonymous namespace
 
-
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/runtime_src/xdp/profile/plugin/aie_profile_new/aie_profile_impl.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile_new/aie_profile_impl.h
@@ -43,6 +43,7 @@ namespace xdp {
 
     virtual void updateDevice() = 0;
     virtual void poll(uint32_t index, void* handle) = 0;
+    virtual void freeResources() = 0;
   };
 
 } // namespace xdp

--- a/src/runtime_src/xdp/profile/plugin/aie_profile_new/aie_profile_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile_new/aie_profile_plugin.cpp
@@ -190,6 +190,8 @@ namespace xdp {
     AIEData.threadCtrlBool = false;
 
     AIEData.thread.join();
+
+    AIEData.implementation->freeResources();
     handleToAIEData.erase(handle);
   }
 

--- a/src/runtime_src/xdp/profile/plugin/aie_profile_new/edge/aie_profile.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile_new/edge/aie_profile.cpp
@@ -540,65 +540,74 @@ namespace xdp {
     return runtimeCounters;
   }
 
-  void AieProfile_EdgeImpl::poll(uint32_t index, void* handle){
-      // Wait until xclbin has been loaded and device has been updated in database
-      if (!(db->getStaticInfo().isDeviceReady(index)))
-        return;
-      XAie_DevInst* aieDevInst =
-        static_cast<XAie_DevInst*>(db->getStaticInfo().getAieDevInst(fetchAieDevInst, handle)) ;
-      if (!aieDevInst)
-        return;
+  void AieProfile_EdgeImpl::poll(uint32_t index, void* handle)
+  {
+    // Wait until xclbin has been loaded and device has been updated in database
+    if (!(db->getStaticInfo().isDeviceReady(index)))
+      return;
+    XAie_DevInst* aieDevInst =
+      static_cast<XAie_DevInst*>(db->getStaticInfo().getAieDevInst(fetchAieDevInst, handle)) ;
+    if (!aieDevInst)
+      return;
 
-      uint32_t prevColumn = 0;
-      uint32_t prevRow = 0;
-      uint64_t timerValue = 0;
+    uint32_t prevColumn = 0;
+    uint32_t prevRow = 0;
+    uint64_t timerValue = 0;
 
-      // Iterate over all AIE Counters & Timers
-      auto numCounters = db->getStaticInfo().getNumAIECounter(index);
-      for (uint64_t c=0; c < numCounters; c++) {
-        auto aie = db->getStaticInfo().getAIECounter(index, c);
-        if (!aie)
-          continue;
+    // Iterate over all AIE Counters & Timers
+    auto numCounters = db->getStaticInfo().getNumAIECounter(index);
+    for (uint64_t c=0; c < numCounters; c++) {
+      auto aie = db->getStaticInfo().getAIECounter(index, c);
+      if (!aie)
+        continue;
 
-        std::vector<uint64_t> values;
-        values.push_back(aie->column);
-        values.push_back(aie->row);
-        values.push_back(aie->startEvent);
-        values.push_back(aie->endEvent);
-        values.push_back(aie->resetEvent);
+      std::vector<uint64_t> values;
+      values.push_back(aie->column);
+      values.push_back(aie->row);
+      values.push_back(aie->startEvent);
+      values.push_back(aie->endEvent);
+      values.push_back(aie->resetEvent);
 
-        // Read counter value from device
-        uint32_t counterValue;
-        if (mPerfCounters.empty()) {
-          // Compiler-defined counters
-          XAie_LocType tileLocation = XAie_TileLoc(aie->column, aie->row);
-          XAie_PerfCounterGet(aieDevInst, tileLocation, XAIE_CORE_MOD, aie->counterNumber, &counterValue);
-        }
-        else {
-          // Runtime-defined counters
-          auto perfCounter = mPerfCounters.at(c);
-          perfCounter->readResult(counterValue);
-        }
-        values.push_back(counterValue);
-
-        // Read tile timer (once per tile to minimize overhead)
-        if ((aie->column != prevColumn) || (aie->row != prevRow)) {
-          prevColumn = aie->column;
-          prevRow = aie->row;
-          auto moduleType = getModuleType(aie->row, XAIE_CORE_MOD);
-          auto falModuleType =  (moduleType == module_type::core) ? XAIE_CORE_MOD 
-                             : ((moduleType == module_type::shim) ? XAIE_PL_MOD 
-                             : XAIE_MEM_MOD);
-          XAie_LocType tileLocation = XAie_TileLoc(aie->column, aie->row);
-          XAie_ReadTimer(aieDevInst, tileLocation, falModuleType, &timerValue);
-        }
-        values.push_back(timerValue);
-        values.push_back(aie->payload);
-
-        // Get timestamp in milliseconds
-        double timestamp = xrt_core::time_ns() / 1.0e6;
-        db->getDynamicInfo().addAIESample(index, timestamp, values);
+      // Read counter value from device
+      uint32_t counterValue;
+      if (mPerfCounters.empty()) {
+        // Compiler-defined counters
+        XAie_LocType tileLocation = XAie_TileLoc(aie->column, aie->row);
+        XAie_PerfCounterGet(aieDevInst, tileLocation, XAIE_CORE_MOD, aie->counterNumber, &counterValue);
       }
+      else {
+        // Runtime-defined counters
+        auto perfCounter = mPerfCounters.at(c);
+        perfCounter->readResult(counterValue);
+      }
+      values.push_back(counterValue);
+
+      // Read tile timer (once per tile to minimize overhead)
+      if ((aie->column != prevColumn) || (aie->row != prevRow)) {
+        prevColumn = aie->column;
+        prevRow = aie->row;
+        auto moduleType = getModuleType(aie->row, XAIE_CORE_MOD);
+        auto falModuleType =  (moduleType == module_type::core) ? XAIE_CORE_MOD 
+                            : ((moduleType == module_type::shim) ? XAIE_PL_MOD 
+                            : XAIE_MEM_MOD);
+        XAie_LocType tileLocation = XAie_TileLoc(aie->column, aie->row);
+        XAie_ReadTimer(aieDevInst, tileLocation, falModuleType, &timerValue);
+      }
+      values.push_back(timerValue);
+      values.push_back(aie->payload);
+
+      // Get timestamp in milliseconds
+      double timestamp = xrt_core::time_ns() / 1.0e6;
+      db->getDynamicInfo().addAIESample(index, timestamp, values);
+    }
+  }
+
+  void AieProfile_EdgeImpl::freeResources() 
+  {
+    for (auto& c : mPerfCounters){
+      c->stop();
+      c->release();
+    }
   }
 
 }

--- a/src/runtime_src/xdp/profile/plugin/aie_profile_new/edge/aie_profile.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile_new/edge/aie_profile.h
@@ -41,6 +41,7 @@ namespace xdp {
 
       void updateDevice();
       void poll(uint32_t index, void* handle);
+      void freeResources();
       bool checkAieDevice(uint64_t deviceId, void* handle);
 
       bool setMetricsSettings(uint64_t deviceId, void* handle);

--- a/src/runtime_src/xdp/profile/plugin/aie_profile_new/x86/aie_profile.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile_new/x86/aie_profile.cpp
@@ -204,4 +204,25 @@ namespace xdp {
       return;
     }
   }
+
+  void AieProfile_x86Impl::freeResources()
+  {
+    try {
+      auto inbo = xrt::bo(device, INPUT_SIZE, 2);
+      auto inbo_map = inbo.map<uint8_t*>();
+      memset(inbo_map, 0, INPUT_SIZE); 
+   
+      //output bo
+      auto outbo = xrt::bo(device, OUTPUT_SIZE, 2);
+      auto outbo_map = outbo.map<uint8_t*>();
+      memset(outbo_map, 0, OUTPUT_SIZE);
+
+      auto run = aie_profile_kernel(inbo, outbo, 2 /*cleanup iteration*/);
+      run.wait();
+    } catch (...) {
+      std::string msg = "The aie_profile cleanup failed.";
+      xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", msg);
+      return;
+    }
+  }
 }

--- a/src/runtime_src/xdp/profile/plugin/aie_profile_new/x86/aie_profile.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile_new/x86/aie_profile.h
@@ -31,6 +31,7 @@ namespace xdp {
 
       void updateDevice();
       void poll(uint32_t index, void* handle);
+      void freeResources();
       bool setMetricsSettings(uint64_t deviceId, void* handle);
 
     private:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

Allow for profiling plugin to work on consecutive runs without resetting AI Engine.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

CR-1148287 showed no profiling results upon consecutive runs.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Stop and Release counters after finishing profiling plugin. On x86 implementation, a separate PS kernel iteration is called to cleanup the counter values. 

#### What has been tested and how, request additional testing if necessary
Tested on thin VCK shell design. 

#### Documentation impact (if any)
