### PR TITLE
Fix for CR-1150166 & CR-1150159: adding checks to avoid out of bound heap access

### DIFF
--- a/src/runtime_src/core/common/drv/xrt_xclbin.c
+++ b/src/runtime_src/core/common/drv/xrt_xclbin.c
@@ -207,7 +207,9 @@ xrt_xclbin_get_section_hdr(const struct axlf *xclbin, enum axlf_section_kind kin
 		return NULL;
 
 	for (i = 0; i < xclbin->m_header.m_numSections; i++) {
-		if (xclbin->m_sections[i].m_sectionKind == kind)
+		if (xclbin->m_sections[i].m_sectionKind == kind && 
+		   (xclbin->m_sections[i].m_sectionSize + xclbin->m_sections[i].m_sectionOffset < xclbin->m_header.m_length) && 
+		   (xclbin->m_sections[i].m_sectionOffset < xclbin->m_header.m_length))
 			return &xclbin->m_sections[i];
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1150166
https://jira.xilinx.com/browse/CR-1150159
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
added necessary checks on header data like sectionOffset to avoid out of bound heap access 
#### Risks (if any) associated the changes in the commit
na
#### What has been tested and how, request additional testing if necessary
tested using poc application provided by CR filer.
#### Documentation impact (if any)
na