### PR TITLE
CR-1151862 Fix bug with incorrect sync direction

### DIFF
--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -652,7 +652,7 @@ m2m_alloc_init_bo(const std::shared_ptr<xrt_core::device>& handle, boost::proper
 
   memset(boptr, pattern, bo_size);
   try {
-    handle->sync_bo(boh, XCL_BO_SYNC_BO_FROM_DEVICE, bo_size, 0);
+    handle->sync_bo(boh, XCL_BO_SYNC_BO_TO_DEVICE, bo_size, 0);
   }
   catch (const std::exception&) {
     _ptTest.put("status", test_token_failed);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1151862
On RH 9.0, 'xbutil validate' is failing at the test m2m with the error - " Error(s)  : Couldn't sync BO". The same 'xbutil validate' with verbose option has passed. Problem is only with the non-verbose form of command execution.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Internal testing
Introduced by https://github.com/Xilinx/XRT/pull/7333

#### How problem was solved, alternative solutions (if any) and why they were rejected
Correct the sync direction

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Ubuntu 20.04 U200
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ xbutil validate -d 17:00 -r m2m
WARNING: Unexpected xocl version (2.14.0) was found. Expected 2.15.0, to match XRT tools.
Validate Device           : [0000:17:00.1]
    Platform              : xilinx_u200_gen3x16_xdma_base_2
    SC Version            : 4.6.21
    Platform ID           : 0B095B81-FA2B-E6BD-4524-72B1C1474F18
-------------------------------------------------------------------------------
Verbose: Enabling Verbosity
Test 1 [0000:17:00.1]     : m2m
    Description           : Run M2M test
    Details               : bank0 -> bank1 M2M bandwidth: 11642.91 MB/s
                            bank0 -> bank2 M2M bandwidth: 12256.12 MB/s
                            bank0 -> bank3 M2M bandwidth: 12268.64 MB/s
                            bank1 -> bank2 M2M bandwidth: 12222.34 MB/s
                            bank1 -> bank3 M2M bandwidth: 12208.01 MB/s
                            bank2 -> bank3 M2M bandwidth: 12204.76 MB/s
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Validation completed
```

#### Documentation impact (if any)
None