### PR TITLE
Added release for streamswitches in profiling plugin

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_profile_new/edge/aie_profile.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile_new/edge/aie_profile.cpp
@@ -291,6 +291,8 @@ namespace xdp {
         XAIE_STRMSW_SLAVE : XAIE_STRMSW_MASTER;
       XAie_EventSelectStrmPort(aieDevInst, loc, rscId, slaveOrMaster, DMA, channel);
     }
+
+    mStreamPorts.push_back(switchPortRsc);
   }
 
   void 
@@ -605,6 +607,11 @@ namespace xdp {
   void AieProfile_EdgeImpl::freeResources() 
   {
     for (auto& c : mPerfCounters){
+      c->stop();
+      c->release();
+    }
+
+    for (auto& c : mStreamPorts){
       c->stop();
       c->release();
     }

--- a/src/runtime_src/xdp/profile/plugin/aie_profile_new/edge/aie_profile.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile_new/edge/aie_profile.h
@@ -91,6 +91,8 @@ namespace xdp {
       std::map<std::string, std::vector<XAie_Events>> mMemTileStartEvents;
       std::map<std::string, std::vector<XAie_Events>> mMemTileEndEvents; 
       std::vector<std::shared_ptr<xaiefal::XAiePerfCounter>> mPerfCounters;
+      std::vector<std::shared_ptr<xaiefal::XAieStreamPortSelect>> mStreamPorts;
+
   };
 
 }   


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Stream switches were not released after profiling plugin was completed

#### How problem was solved, alternative solutions (if any) and why they were rejected
Keep track of the stream switches used, and release them at the end of the application.

