### PR TITLE
Fix issue : xclbin program fails after a warm reboot when the APU package is installed

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/zocl_ctrl_ert.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_ctrl_ert.c
@@ -852,6 +852,18 @@ static void zert_cmd_cfg_cu(struct zocl_ctrl_ert *zert, struct xgq_cmd_sq_hdr *c
 	init_resp(resp, cmd->cid, rc);
 }
 
+static void zert_cmd_cleanup_cus(struct zocl_ctrl_ert *zert, struct xgq_cmd_sq_hdr *cmd,
+			    struct xgq_com_queue_entry *resp)
+{
+	/* This is to cleanup all the CUs and SCUs from the zocl. 
+	 * this is the cleanup we need before start the XOCL and ZOCL handshake
+	 * for the first time.
+	 */
+	zert_destroy_cus(zert);
+
+	init_resp(resp, cmd->cid, 0);
+}
+
 static void zert_cmd_uncfg_cu(struct zocl_ctrl_ert *zert, struct xgq_cmd_sq_hdr *cmd,
 			    struct xgq_com_queue_entry *resp)
 {
@@ -957,6 +969,7 @@ struct zert_ops {
 	{ XGQ_CMD_OP_CFG_END, "XGQ_CMD_OP_CFG_END", zert_cmd_cfg_end },
 	{ XGQ_CMD_OP_CFG_CU, "XGQ_CMD_OP_CFG_CU", zert_cmd_cfg_cu },
 	{ XGQ_CMD_OP_UNCFG_CU, "XGQ_CMD_OP_UNCFG_CU", zert_cmd_uncfg_cu },
+	{ XGQ_CMD_OP_CLEANUP_ALL_CU, "XGQ_CMD_OP_CLEANUP_ALL_CU", zert_cmd_cleanup_cus },
 	{ XGQ_CMD_OP_QUERY_CU, "XGQ_CMD_OP_QUERY_CU", zert_cmd_query_cu },
 	{ XGQ_CMD_OP_IDENTIFY, "XGQ_CMD_OP_IDENTIFY", zert_cmd_identify },
 	{ XGQ_CMD_OP_TIMESET, "XGQ_CMD_OP_TIMESET", zert_cmd_timeset }

--- a/src/runtime_src/core/edge/drm/zocl/zocl_ctrl_ert.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_ctrl_ert.c
@@ -852,18 +852,6 @@ static void zert_cmd_cfg_cu(struct zocl_ctrl_ert *zert, struct xgq_cmd_sq_hdr *c
 	init_resp(resp, cmd->cid, rc);
 }
 
-static void zert_cmd_cleanup_cus(struct zocl_ctrl_ert *zert, struct xgq_cmd_sq_hdr *cmd,
-			    struct xgq_com_queue_entry *resp)
-{
-	/* This is to cleanup all the CUs and SCUs from the zocl. 
-	 * this is the cleanup we need before start the XOCL and ZOCL handshake
-	 * for the first time.
-	 */
-	zert_destroy_cus(zert);
-
-	init_resp(resp, cmd->cid, 0);
-}
-
 static void zert_cmd_uncfg_cu(struct zocl_ctrl_ert *zert, struct xgq_cmd_sq_hdr *cmd,
 			    struct xgq_com_queue_entry *resp)
 {
@@ -871,6 +859,15 @@ static void zert_cmd_uncfg_cu(struct zocl_ctrl_ert *zert, struct xgq_cmd_sq_hdr 
 	int idx = 0;
 	struct xgq_cmd_uncfg_cu *c = (struct xgq_cmd_uncfg_cu *)cmd;
 	struct zocl_ctrl_ert_cu *cu = NULL;
+
+	if (c->cu_reset) {
+		/* This is the cleanup request all the CUs and SCUs from the zocl. 
+		 * this is the cleanup we need before start the Host and ZOCL handshake
+		 * for the first time.
+		 */
+		zert_destroy_cus(zert);
+		goto done;
+	}
 
 	cu = (c->cu_domain == DOMAIN_PL) ? &zert->zce_cus[c->cu_idx] :
 		&zert->zce_scus[c->cu_idx];
@@ -969,7 +966,6 @@ struct zert_ops {
 	{ XGQ_CMD_OP_CFG_END, "XGQ_CMD_OP_CFG_END", zert_cmd_cfg_end },
 	{ XGQ_CMD_OP_CFG_CU, "XGQ_CMD_OP_CFG_CU", zert_cmd_cfg_cu },
 	{ XGQ_CMD_OP_UNCFG_CU, "XGQ_CMD_OP_UNCFG_CU", zert_cmd_uncfg_cu },
-	{ XGQ_CMD_OP_CLEANUP_ALL_CU, "XGQ_CMD_OP_CLEANUP_ALL_CU", zert_cmd_cleanup_cus },
 	{ XGQ_CMD_OP_QUERY_CU, "XGQ_CMD_OP_QUERY_CU", zert_cmd_query_cu },
 	{ XGQ_CMD_OP_IDENTIFY, "XGQ_CMD_OP_IDENTIFY", zert_cmd_identify },
 	{ XGQ_CMD_OP_TIMESET, "XGQ_CMD_OP_TIMESET", zert_cmd_timeset }

--- a/src/runtime_src/core/include/xgq_cmd_common.h
+++ b/src/runtime_src/core/include/xgq_cmd_common.h
@@ -112,6 +112,7 @@ enum xgq_cmd_opcode {
 	XGQ_CMD_OP_DATA_INTEGRITY   	= 0x10e,
 	XGQ_CMD_OP_EXIT             	= 0x10f,
 	XGQ_CMD_OP_UNCFG_CU	        = 0x110,
+	XGQ_CMD_OP_CLEANUP_ALL_CU	= 0x111,
 
 	/* Common command type */
 	XGQ_CMD_OP_BARRIER		= 0x200,

--- a/src/runtime_src/core/include/xgq_cmd_common.h
+++ b/src/runtime_src/core/include/xgq_cmd_common.h
@@ -112,7 +112,6 @@ enum xgq_cmd_opcode {
 	XGQ_CMD_OP_DATA_INTEGRITY   	= 0x10e,
 	XGQ_CMD_OP_EXIT             	= 0x10f,
 	XGQ_CMD_OP_UNCFG_CU	        = 0x110,
-	XGQ_CMD_OP_CLEANUP_ALL_CU	= 0x111,
 
 	/* Common command type */
 	XGQ_CMD_OP_BARRIER		= 0x200,

--- a/src/runtime_src/core/include/xgq_cmd_ert.h
+++ b/src/runtime_src/core/include/xgq_cmd_ert.h
@@ -255,7 +255,8 @@ struct xgq_cmd_uncfg_cu {
 	/* word 2 */
 	uint32_t cu_idx:12;
 	uint32_t cu_domain:4;
-	uint32_t rsvd2:16;
+	uint32_t cu_reset:1;
+	uint32_t rsvd2:15;
 };
 
 /**

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -229,7 +229,6 @@ static int icap_slot_init(struct icap *icap, uint32_t slot_id)
 	struct islot_info *islot = icap->slot_info[slot_id];
 	
 	mutex_lock(&icap->icap_lock);
-	if (islot)
 	if (islot) {
 		vfree(islot);
 		icap->slot_info[slot_id] = NULL;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/common.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/common.h
@@ -89,7 +89,7 @@ struct xocl_dev	{
 	struct xocl_dev_core	core;
 
 	bool			is_legacy_ctx;
-	bool			reset_zocl_cus;
+	bool			reset_ert_cus;
 	int                 	ps_slot_id;
 	struct list_head	ctx_list;
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/common.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/common.h
@@ -89,7 +89,8 @@ struct xocl_dev	{
 	struct xocl_dev_core	core;
 
 	bool			is_legacy_ctx;
-    int                 ps_slot_id;
+	bool			reset_zocl_cus;
+	int                 	ps_slot_id;
 	struct list_head	ctx_list;
 
 	/*

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
@@ -171,6 +171,34 @@ int xocl_unregister_cus(xdev_handle_t xdev_hdl, int slot_hdl)
 	return xocl_kds_unregister_cus(xdev, slot_hdl);
 }
 
+static int xocl_unregister_cus_all(struct xocl_dev *xdev)
+{
+	xuid_t *xclbin_id = NULL;
+	int err = 0;
+	int i = 0;
+
+	mutex_lock(&xdev->dev_lock);
+        for (i = 0; i < MAX_SLOT_SUPPORT; i++) {
+                err = XOCL_GET_XCLBIN_ID(xdev, xclbin_id, i);
+                if (err) {
+			mutex_unlock(&xdev->dev_lock);
+                        return err;
+		}
+
+                if (!xclbin_id)
+                        continue;
+
+		xocl_kds_unregister_cus(xdev, i);
+
+                XOCL_PUT_XCLBIN_ID(xdev, i);
+                xclbin_id = NULL;
+        }
+
+	mutex_unlock(&xdev->dev_lock);
+
+	return 0;
+}
+
 static int userpf_intr_config(xdev_handle_t xdev_hdl, u32 intr, bool en)
 {
 	int ret;
@@ -1204,6 +1232,9 @@ void xocl_userpf_remove(struct pci_dev *pdev)
 		return;
 	}
 
+	/* Unregister all the cus subdevices for all the avilable slots */
+	xocl_unregister_cus_all(xdev);
+
 	/* If fast adapter is present in the xclbin, new kds would
 	 * hold a bo for reserve plram bank.
 	 */
@@ -1784,6 +1815,12 @@ int xocl_userpf_probe(struct pci_dev *pdev,
 		xocl_err(&pdev->dev, "mailbox subdev is not created");
 		goto failed;
 	}
+
+	/* When XOCL loading/reloading we should make sure ZOCL
+	 * cleanup all the prior CUs/SCUs if exists. This is because ZOCL doesn't
+	 * get any notification when XOCL reloaded.
+	 */
+	xdev->reset_zocl_cus = true;
 
 	xocl_queue_work(xdev, XOCL_WORK_REFRESH_SUBDEV, 1);
 	/* Waiting for all subdev to be initialized before returning. */

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -2339,13 +2339,12 @@ static int xocl_kds_xgq_cleanup_cus(struct xocl_dev *xdev)
 		return ret;
 
 	if (resp.hdr.cstate != XGQ_CMD_STATE_COMPLETED) {
-		userpf_err(xdev, "Unconfigure CU(%d) failed cstate(%d) rcode(%d)",
-			   cu_idx, resp.hdr.cstate, resp.rcode);
+		userpf_err(xdev, "Cleanup all CUs/SCUs failed cstate(%d) rcode(%d)",
+			   resp.hdr.cstate, resp.rcode);
                 return -EINVAL;
         }
 
-        userpf_info(xdev, "Unconfig CU(%d) of DOMAIN(%d) completed\n",
-                    uncfg_cu->cu_idx, uncfg_cu->cu_domain);
+        userpf_info(xdev, "Cleanup all CUs/SCUs from Peer completed\n");
         return 0;
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1154122
The root cause of this issue is, we need to reset/cleanup all the existing  CUs/SCUs before first load of the XCLBIN download from XOCL side.
As per the current multislot changes CUs/SCUs  are cleanup  based on Slot. Which will be initiated by the XOCL driver. 
but for Rebooting host will force XOCL to reload in host side. But ZOCL doesn't have any notification about it. Hence, it will not cleanup any CUs/SCUs. So we need a mechanism to communicate the same for the first XCLBIN load after XOCL reloaded, So that ZOCL will initiate a cleanup.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
For multislot changes. 

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added a flag in xocl driver to cleanup the zocl CUs/SCUs for the first load of XCLBIN

#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
Basic validate and test case mentioned in the CR

#### Documentation impact (if any)
N/A
