### PR TITLE
VITIS-6990: xrt::xclbin API to obtain interface_uuid

### DIFF
--- a/src/python/xclbin_binding.py
+++ b/src/python/xclbin_binding.py
@@ -1,5 +1,6 @@
 """
- Copyright (C) 2018-2023 Xilinx, Inc
+ Copyright (C) 2020-2022 Xilinx, Inc. All rights reserved.
+ Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
  Author(s): Ryan Radjabi
             Shivangi Agarwal
             Sonal Santan

--- a/src/python/xclbin_binding.py
+++ b/src/python/xclbin_binding.py
@@ -112,11 +112,12 @@ class axlf_header (ctypes.Structure):
     _fields_ = [
         ("m_length", ctypes.c_uint64),
         ("m_timeStamp", ctypes.c_uint64),
-        ("m_reserved1", ctypes.c_uint64),
+        ("m_featureRomTimeStamp", ctypes.c_uint64),
         ("m_versionPatch", ctypes.c_uint16),
         ("m_versionMajor", ctypes.c_uint8),
         ("m_versionMinor", ctypes.c_uint8),
         ("m_mode", ctypes.c_uint32),
+        ("m_actionMask", ctypes.c_uint16),
         ("m_interface_uuid", ctypes.c_ubyte*16),
         ("m_platformVBNV", ctypes.c_ubyte*64),
         ("u2", u2),

--- a/src/python/xclbin_binding.py
+++ b/src/python/xclbin_binding.py
@@ -111,7 +111,7 @@ class s1 (ctypes.Structure):
 class u1 (ctypes.Union):
     _fields_ = [
         ("rom", s1),
-        ("rom_uuid", ctypes.c_ubyte*16)
+        ("m_interface_uuid", ctypes.c_ubyte*16)
     ]
 
 class u2 (ctypes.Union):

--- a/src/python/xclbin_binding.py
+++ b/src/python/xclbin_binding.py
@@ -1,5 +1,5 @@
 """
- Copyright (C) 2018 Xilinx, Inc
+ Copyright (C) 2018-2023 Xilinx, Inc
  Author(s): Ryan Radjabi
             Shivangi Agarwal
             Sonal Santan

--- a/src/python/xclbin_binding.py
+++ b/src/python/xclbin_binding.py
@@ -101,19 +101,7 @@ class axlf_section_header (ctypes.Structure):
         ("m_sectionOffset", ctypes.c_uint64),
         ("m_sectionSize", ctypes.c_uint64)
     ]
-
-class s1 (ctypes.Structure):
-    _fields_ = [
-        ("m_platformId", ctypes.c_uint64),
-        ("m_featureId", ctypes.c_uint64)
-    ]
-
-class u1 (ctypes.Union):
-    _fields_ = [
-        ("rom", s1),
-        ("m_interface_uuid", ctypes.c_ubyte*16)
-    ]
-
+    
 class u2 (ctypes.Union):
     _fields_ = [
         ("m_next_axlf", ctypes.c_char*16),
@@ -121,16 +109,15 @@ class u2 (ctypes.Union):
     ]
 
 class axlf_header (ctypes.Structure):
-    _anonymous_ = ("u1","u2")
     _fields_ = [
         ("m_length", ctypes.c_uint64),
         ("m_timeStamp", ctypes.c_uint64),
-        ("m_featureRomTimeStamp", ctypes.c_uint64),
+        ("m_reserved1", ctypes.c_uint64),
         ("m_versionPatch", ctypes.c_uint16),
         ("m_versionMajor", ctypes.c_uint8),
         ("m_versionMinor", ctypes.c_uint8),
         ("m_mode", ctypes.c_uint32),
-        ("u1", u1),
+        ("m_interface_uuid", ctypes.c_ubyte*16),
         ("m_platformVBNV", ctypes.c_ubyte*64),
         ("u2", u2),
         ("m_debug_bin", ctypes.c_char*16),

--- a/src/runtime_src/core/common/api/xrt_xclbin.cpp
+++ b/src/runtime_src/core/common/api/xrt_xclbin.cpp
@@ -795,7 +795,7 @@ class xclbin_full : public xclbin_impl
     m_top = tmp;
 
     m_uuid = uuid(m_top->m_header.uuid);
-    m_intf_uuid = uuid(m_top->m_header.rom_uuid);
+    m_intf_uuid = uuid(m_top->m_header.m_interface_uuid);
 
     for (auto kind : kinds) {
       auto hdr = xrt_core::xclbin::get_axlf_section(m_top, kind);

--- a/src/runtime_src/core/common/api/xrt_xclbin.cpp
+++ b/src/runtime_src/core/common/api/xrt_xclbin.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2020-2023, Xilinx Inc - All rights reserved
+ * Copyright (C) 2020-2022 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
  * Xilinx Runtime (XRT) Experimental APIs
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/src/runtime_src/core/common/api/xrt_xclbin.cpp
+++ b/src/runtime_src/core/common/api/xrt_xclbin.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2022, Xilinx Inc - All rights reserved
+ * Copyright (C) 2020-2023, Xilinx Inc - All rights reserved
  * Xilinx Runtime (XRT) Experimental APIs
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/src/runtime_src/core/common/api/xrt_xclbin.cpp
+++ b/src/runtime_src/core/common/api/xrt_xclbin.cpp
@@ -642,6 +642,13 @@ public:
   }
 
   virtual
+  uuid
+  get_interface_uuid() const
+  {
+      throw std::runtime_error("not implemented");
+  }
+
+  virtual
   std::string
   get_xsa_name() const
   {
@@ -757,6 +764,7 @@ class xclbin_full : public xclbin_impl
   std::vector<char> m_axlf;    // complete copy of xclbin raw data
   const axlf* m_top = nullptr; // axlf pointer to the raw data
   uuid m_uuid;                 // uuid of xclbin
+  uuid m_intf_uuid;
 
   // sections within this xclbin
   std::multimap<axlf_section_kind, std::vector<char>> m_axlf_sections;
@@ -787,6 +795,7 @@ class xclbin_full : public xclbin_impl
     m_top = tmp;
 
     m_uuid = uuid(m_top->m_header.uuid);
+    m_intf_uuid = uuid(m_top->m_header.rom_uuid);
 
     for (auto kind : kinds) {
       auto hdr = xrt_core::xclbin::get_axlf_section(m_top, kind);
@@ -834,6 +843,12 @@ public:
   get_uuid() const override
   {
     return m_uuid;
+  }
+
+  uuid
+  get_interface_uuid() const override
+  {
+    return m_intf_uuid;
   }
 
   std::string
@@ -991,6 +1006,13 @@ xclbin::
 get_uuid() const
 {
   return handle ? handle->get_uuid() : uuid{};
+}
+
+uuid
+xclbin::
+get_interface_uuid() const
+{
+  return handle ? handle->get_interface_uuid() : uuid{};
 }
 
 xclbin::target_type

--- a/src/runtime_src/core/include/experimental/xrt_xclbin.h
+++ b/src/runtime_src/core/include/experimental/xrt_xclbin.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2022 Xilinx, Inc
+ * Copyright (C) 2020-2023 Xilinx, Inc
  * SPDX-License-Identifier: Apache-2.0
  */
 #ifndef XRT_XCLBIN_H_

--- a/src/runtime_src/core/include/experimental/xrt_xclbin.h
+++ b/src/runtime_src/core/include/experimental/xrt_xclbin.h
@@ -735,6 +735,18 @@ public:
   get_uuid() const;
 
   /**
+  * get_interface_uuid() - Get the interface uuid of the xclbin
+  *
+  * @return
+  *  Interface uuid of the xclbin
+  *
+  * An exception is thrown if the data is missing.
+  */
+  XCL_DRIVER_DLLESPEC
+  uuid
+  get_interface_uuid() const;
+
+  /**
    * get_target_type() - Get the type of this xclbin
    *
    * @return

--- a/src/runtime_src/core/include/experimental/xrt_xclbin.h
+++ b/src/runtime_src/core/include/experimental/xrt_xclbin.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2020-2023 Xilinx, Inc
+ * Copyright (C) 2020-2022 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #ifndef XRT_XCLBIN_H_

--- a/src/runtime_src/core/include/xclbin.h
+++ b/src/runtime_src/core/include/xclbin.h
@@ -220,19 +220,13 @@ extern "C" {
     struct axlf_header {
         uint64_t m_length;                  /* Total size of the xclbin file */
         uint64_t m_timeStamp;               /* Number of seconds since epoch when xclbin was created */
-        uint64_t m_featureRomTimeStamp;     /* TimeSinceEpoch of the featureRom */
+        uint64_t m_reserved1;               /* Reserved*/
         uint16_t m_versionPatch;            /* Patch Version */
         uint8_t m_versionMajor;             /* Major Version - Version: 2.1.0*/
         uint8_t m_versionMinor;             /* Minor Version */
         uint16_t m_mode;                    /* XCLBIN_MODE */
         uint16_t m_actionMask;              /* Bit Mask */
-	union {
-	    struct {
-		uint64_t m_platformId;      /* 64 bit platform ID: vendor-device-subvendor-subdev */
-		uint64_t m_featureId;       /* 64 bit feature id */
-	    } rom;
-	    unsigned char m_interface_uuid[16];     /* Interface uuid of this xclbin */
-	};
+        unsigned char m_interface_uuid[16];     /* Interface uuid of this xclbin */
         unsigned char m_platformVBNV[64];   /* e.g. xilinx:xil-accel-rd-ku115:4ddr-xpr:3.4: null terminated */
 	union {
 	    char m_next_axlf[16];           /* Name of next xclbin file in the daisy chain */

--- a/src/runtime_src/core/include/xclbin.h
+++ b/src/runtime_src/core/include/xclbin.h
@@ -220,7 +220,7 @@ extern "C" {
     struct axlf_header {
         uint64_t m_length;                  /* Total size of the xclbin file */
         uint64_t m_timeStamp;               /* Number of seconds since epoch when xclbin was created */
-        uint64_t m_reserved1;               /* Reserved*/
+        uint64_t m_featureRomTimeStamp;     /* TimeSinceEpoch of the featureRom */
         uint16_t m_versionPatch;            /* Patch Version */
         uint8_t m_versionMajor;             /* Major Version - Version: 2.1.0*/
         uint8_t m_versionMinor;             /* Minor Version */

--- a/src/runtime_src/core/include/xclbin.h
+++ b/src/runtime_src/core/include/xclbin.h
@@ -231,7 +231,7 @@ extern "C" {
 		uint64_t m_platformId;      /* 64 bit platform ID: vendor-device-subvendor-subdev */
 		uint64_t m_featureId;       /* 64 bit feature id */
 	    } rom;
-	    unsigned char rom_uuid[16];     /* feature ROM UUID for which this xclbin was generated */
+	    unsigned char m_interface_uuid[16];     /* Interface uuid of this xclbin */
 	};
         unsigned char m_platformVBNV[64];   /* e.g. xilinx:xil-accel-rd-ku115:4ddr-xpr:3.4: null terminated */
 	union {

--- a/src/runtime_src/tools/xclbinutil/FormattedOutput.cxx
+++ b/src/runtime_src/tools/xclbinutil/FormattedOutput.cxx
@@ -38,9 +38,9 @@ FormattedOutput::getTimeStampAsString(const axlf& _xclBinHeader)
 }
 
 std::string
-FormattedOutput::getReserved1AsString(const axlf& _xclBinHeader)
+FormattedOutput::getFeatureRomTimeStampAsString(const axlf& _xclBinHeader)
 {
-  return boost::str(boost::format("%d") % _xclBinHeader.m_header.m_reserved1);
+  return boost::str(boost::format("%d") % _xclBinHeader.m_header.m_featureRomTimeStamp);
 }
 
 std::string
@@ -586,7 +586,7 @@ reportHardwarePlatform(std::ostream& _ostream,
 
   // TimeStamp
   {
-    _ostream << boost::format("   %-23s %ld\n") % "Feature ROM TimeStamp:" % _xclBinHeader.m_header.m_reserved1;
+    _ostream << boost::format("   %-23s %ld\n") % "Feature ROM TimeStamp:" % _xclBinHeader.m_header.m_featureRomTimeStamp;
   }
 
 

--- a/src/runtime_src/tools/xclbinutil/FormattedOutput.cxx
+++ b/src/runtime_src/tools/xclbinutil/FormattedOutput.cxx
@@ -125,7 +125,7 @@ std::string
 FormattedOutput::getFeatureRomUuidAsString(const axlf& _xclBinHeader)
 {
   std::string sTemp("");
-  XUtil::binaryBufferToHexString(_xclBinHeader.m_header.rom_uuid, sizeof(axlf_header::rom_uuid), sTemp);
+  XUtil::binaryBufferToHexString(_xclBinHeader.m_header.m_interface_uuid, sizeof(axlf_header::m_interface_uuid), sTemp);
   return sTemp;
 }
 
@@ -580,7 +580,7 @@ reportHardwarePlatform(std::ostream& _ostream,
 
   // Static UUID
   {
-    std::string sStaticUUID = XUtil::getUUIDAsString(_xclBinHeader.m_header.rom_uuid);
+    std::string sStaticUUID = XUtil::getUUIDAsString(_xclBinHeader.m_header.m_interface_uuid);
     _ostream << boost::format("   %-23s %s\n") % "Static UUID:" % sStaticUUID;
   }
 

--- a/src/runtime_src/tools/xclbinutil/FormattedOutput.cxx
+++ b/src/runtime_src/tools/xclbinutil/FormattedOutput.cxx
@@ -1,5 +1,6 @@
 /**
- * Copyright (C) 2018-2023 Xilinx, Inc
+ * Copyright (C) 2020-2022 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the

--- a/src/runtime_src/tools/xclbinutil/FormattedOutput.cxx
+++ b/src/runtime_src/tools/xclbinutil/FormattedOutput.cxx
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018, 2022 Xilinx, Inc
+ * Copyright (C) 2018-2023 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the

--- a/src/runtime_src/tools/xclbinutil/FormattedOutput.cxx
+++ b/src/runtime_src/tools/xclbinutil/FormattedOutput.cxx
@@ -38,9 +38,9 @@ FormattedOutput::getTimeStampAsString(const axlf& _xclBinHeader)
 }
 
 std::string
-FormattedOutput::getFeatureRomTimeStampAsString(const axlf& _xclBinHeader)
+FormattedOutput::getReserved1AsString(const axlf& _xclBinHeader)
 {
-  return boost::str(boost::format("%d") % _xclBinHeader.m_header.m_featureRomTimeStamp);
+  return boost::str(boost::format("%d") % _xclBinHeader.m_header.m_reserved1);
 }
 
 std::string
@@ -122,7 +122,7 @@ getModeAsPrettyString(const axlf& _xclBinHeader)
 }
 
 std::string
-FormattedOutput::getFeatureRomUuidAsString(const axlf& _xclBinHeader)
+FormattedOutput::getInterfaceUuidAsString(const axlf& _xclBinHeader)
 {
   std::string sTemp("");
   XUtil::binaryBufferToHexString(_xclBinHeader.m_header.m_interface_uuid, sizeof(axlf_header::m_interface_uuid), sTemp);
@@ -586,7 +586,7 @@ reportHardwarePlatform(std::ostream& _ostream,
 
   // TimeStamp
   {
-    _ostream << boost::format("   %-23s %ld\n") % "Feature ROM TimeStamp:" % _xclBinHeader.m_header.m_featureRomTimeStamp;
+    _ostream << boost::format("   %-23s %ld\n") % "Feature ROM TimeStamp:" % _xclBinHeader.m_header.m_reserved1;
   }
 
 

--- a/src/runtime_src/tools/xclbinutil/FormattedOutput.h
+++ b/src/runtime_src/tools/xclbinutil/FormattedOutput.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Xilinx, Inc
+ * Copyright (C) 2018-2023 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the

--- a/src/runtime_src/tools/xclbinutil/FormattedOutput.h
+++ b/src/runtime_src/tools/xclbinutil/FormattedOutput.h
@@ -1,5 +1,6 @@
 /**
- * Copyright (C) 2018-2023 Xilinx, Inc
+ * Copyright (C) 2020-2022 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the

--- a/src/runtime_src/tools/xclbinutil/FormattedOutput.h
+++ b/src/runtime_src/tools/xclbinutil/FormattedOutput.h
@@ -38,7 +38,7 @@ void getKernelDDRMemory(const std::string& _sKernelInstanceName, const std::vect
 void reportVersion(bool _bShort = false);
 
 std::string getTimeStampAsString(const axlf& _xclBinHeader);
-std::string getReserved1AsString(const axlf& _xclBinHeader);
+std::string getFeatureRomTimeStampAsString(const axlf& _xclBinHeader);
 std::string getVersionAsString(const axlf& _xclBinHeader);
 std::string getMagicAsString(const axlf& _xclBinHeader);
 std::string getSignatureLengthAsString(const axlf& _xclBinHeader);

--- a/src/runtime_src/tools/xclbinutil/FormattedOutput.h
+++ b/src/runtime_src/tools/xclbinutil/FormattedOutput.h
@@ -38,14 +38,14 @@ void getKernelDDRMemory(const std::string& _sKernelInstanceName, const std::vect
 void reportVersion(bool _bShort = false);
 
 std::string getTimeStampAsString(const axlf& _xclBinHeader);
-std::string getFeatureRomTimeStampAsString(const axlf& _xclBinHeader);
+std::string getReserved1AsString(const axlf& _xclBinHeader);
 std::string getVersionAsString(const axlf& _xclBinHeader);
 std::string getMagicAsString(const axlf& _xclBinHeader);
 std::string getSignatureLengthAsString(const axlf& _xclBinHeader);
 std::string getKeyBlockAsString(const axlf& _xclBinHeader);
 std::string getUniqueIdAsString(const axlf& _xclBinHeader);
 std::string getModeAsString(const axlf& _xclBinHeader);
-std::string getFeatureRomUuidAsString(const axlf& _xclBinHeader);
+std::string getInterfaceUuidAsString(const axlf& _xclBinHeader);
 std::string getPlatformVbnvAsString(const axlf& _xclBinHeader);
 std::string getXclBinUuidAsString(const axlf& _xclBinHeader);
 std::string getDebugBinAsString(const axlf& _xclBinHeader);

--- a/src/runtime_src/tools/xclbinutil/XclBinClass.cxx
+++ b/src/runtime_src/tools/xclbinutil/XclBinClass.cxx
@@ -1245,9 +1245,9 @@ XclBin::appendSections(ParameterSectionData& _PSD)
         // Updated header rom_uuid with interface_uuid from partition_metadata
         for (const auto& kv : ptInterfaces) {
             boost::property_tree::ptree ptInterface = kv.second;
-            auto sFeatureRomUUID = ptInterface.get<std::string>("interface_uuid", "00000000000000000000000000000000");
-            sFeatureRomUUID.erase(std::remove(sFeatureRomUUID.begin(), sFeatureRomUUID.end(), '-'), sFeatureRomUUID.end()); // Remove the '-'
-            XUtil::hexStringToBinaryBuffer(sFeatureRomUUID, (unsigned char*)&m_xclBinHeader.m_header.rom_uuid, sizeof(axlf_header::rom_uuid));
+            auto sInterfaceUUID = ptInterface.get<std::string>("interface_uuid", "00000000000000000000000000000000");
+            sInterfaceUUID.erase(std::remove(sInterfaceUUID.begin(), sInterfaceUUID.end(), '-'), sInterfaceUUID.end()); // Remove the '-'
+            XUtil::hexStringToBinaryBuffer(sInterfaceUUID, (unsigned char*)&m_xclBinHeader.m_header.rom_uuid, sizeof(axlf_header::rom_uuid));
         }
     }
 

--- a/src/runtime_src/tools/xclbinutil/XclBinClass.cxx
+++ b/src/runtime_src/tools/xclbinutil/XclBinClass.cxx
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2022 Xilinx, Inc Copyright (C) 2022 
+ * Copyright (C) 2018-2023 Xilinx, Inc Copyright (C) 2023 
  * Advanced Micro Devices, Inc. 
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/src/runtime_src/tools/xclbinutil/XclBinClass.cxx
+++ b/src/runtime_src/tools/xclbinutil/XclBinClass.cxx
@@ -1,5 +1,6 @@
 /**
- * Copyright (C) 2018-2023 Xilinx, Inc Copyright (C) 2023 
+ * Copyright (C) 2020-2022 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
  * Advanced Micro Devices, Inc. 
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/src/runtime_src/tools/xclbinutil/XclBinClass.h
+++ b/src/runtime_src/tools/xclbinutil/XclBinClass.h
@@ -1,5 +1,6 @@
 /**
- * Copyright (C) 2018-2023 Xilinx, Inc
+ * Copyright (C) 2020-2022 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the

--- a/src/runtime_src/tools/xclbinutil/XclBinClass.h
+++ b/src/runtime_src/tools/xclbinutil/XclBinClass.h
@@ -59,6 +59,7 @@ class XclBin {
   void addSection(Section* _pSection);
   void addPsKernel(const std::string &encodedString);
   void addKernels(const std::string &jsonFile);
+  void updateInterfaceuuid();
 
   public:
     // Helper method to take given encoded keyValue and break it down to its individual values (e.g., domain, key, and value)

--- a/src/runtime_src/tools/xclbinutil/XclBinClass.h
+++ b/src/runtime_src/tools/xclbinutil/XclBinClass.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2022 Xilinx, Inc
+ * Copyright (C) 2018-2023 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the

--- a/src/runtime_src/tools/xclbinutil/XclBinUtilMain.cxx
+++ b/src/runtime_src/tools/xclbinutil/XclBinUtilMain.cxx
@@ -533,6 +533,9 @@ int main_(int argc, const char** argv) {
   for (const auto &keyValue : keyValuePairs) 
     xclBin.setKeyValue(keyValue);
 
+  // -- Update Interface uuid in xclbin --
+  xclBin.updateInterfaceuuid();
+
   // -- Dump Sections --
   for (const auto &section : sectionsToDump) {
     ParameterSectionData psd(section);
@@ -543,9 +546,6 @@ int main_(int argc, const char** argv) {
       xclBin.dumpSection(psd);
     }
   }
-
-  // -- Update Interface uuid in xclbin --
-  xclBin.updateInterfaceuuid();
 
   // -- Write out new xclbin image --
   if (!sOutputFile.empty()) {

--- a/src/runtime_src/tools/xclbinutil/XclBinUtilMain.cxx
+++ b/src/runtime_src/tools/xclbinutil/XclBinUtilMain.cxx
@@ -1,5 +1,6 @@
 /**
- * Copyright (C) 2018-2023 Xilinx, Inc
+ * Copyright (C) 2020-2022 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the

--- a/src/runtime_src/tools/xclbinutil/XclBinUtilMain.cxx
+++ b/src/runtime_src/tools/xclbinutil/XclBinUtilMain.cxx
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2022 Xilinx, Inc
+ * Copyright (C) 2018-2023 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the

--- a/src/runtime_src/tools/xclbinutil/XclBinUtilMain.cxx
+++ b/src/runtime_src/tools/xclbinutil/XclBinUtilMain.cxx
@@ -544,6 +544,9 @@ int main_(int argc, const char** argv) {
     }
   }
 
+  // -- Update Interface uuid in xclbin --
+  xclBin.updateInterfaceuuid();
+
   // -- Write out new xclbin image --
   if (!sOutputFile.empty()) {
     xclBin.writeXclBinBinary(sOutputFile, bSkipUUIDInsertion);

--- a/tests/python/00_hello/main.py
+++ b/tests/python/00_hello/main.py
@@ -3,7 +3,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-# Copyright (C) 2019-2023 Xilinx, Inc
+# Copyright (C) 2020-2022 Xilinx, Inc. All rights reserved.
+# Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
 #
 
 import os

--- a/tests/python/00_hello/main.py
+++ b/tests/python/00_hello/main.py
@@ -48,7 +48,8 @@ def runTest(opt):
 
 def main(args):
     opt = Options()
-    Options.getOptions(opt, args)
+    b_file= "kernel.xclbin"
+    Options.getOptions(opt, args, b_file)
     opt.first_mem = 0
 
     try:

--- a/tests/python/00_hello/main.py
+++ b/tests/python/00_hello/main.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-# Copyright (C) 2019-2021 Xilinx, Inc
+# Copyright (C) 2019-2023 Xilinx, Inc
 #
 
 import os


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Added below API for xrt::xclbin to obtain interface_uuid 
```
//get_interface_uuid() - Get the Interface UUID of the xclbin. 
//return  - Interface UUID of the xclbin

XCL_DRIVER_DLLESPEC
uuid
get_interface_uuid() const;
```
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://jira.xilinx.com/browse/VITIS-6990
#### How problem was solved, alternative solutions (if any) and why they were rejected
1. xclbin generation : updating xclbin header content rom_uuid with interface_uuid from partition_metadata.
2. In xrt::xclbin, reading rom_uuid from axlf header and return it in new api( get_interface_uuid)
#### Risks (if any) associated the changes in the commit
Low risk as it is new API.
#### What has been tested and how, request additional testing if necessary
Tested locally some cases.
#### Documentation impact (if any)
Yes, Need to add this new API to the XRT::XCLBIN documentation. 