### PR TITLE
CR-1154907: HW generation is not listed in profile csv from XRT

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info/device_info.h
+++ b/src/runtime_src/xdp/profile/database/static_info/device_info.h
@@ -79,6 +79,9 @@ namespace xdp {
     // and memory.  This maximum is the same regardless of the xclbin loaded.
     uint32_t maxConnectionBitWidth = 512;
 
+    // Generation of AI Engine hardware on device, regardless of xclbin loaded.
+    uint8_t aieGeneration = 1;
+
     ~DeviceInfo() ;
 
     // ****** Functions for information on the device ******
@@ -88,6 +91,9 @@ namespace xdp {
     XDP_EXPORT void cleanCurrentXclbinInfo() ;
     inline bool isNoDMA() const { return isNoDMADevice ; }
     double getMaxClockRatePLMHz();
+
+    XDP_EXPORT void setAIEGeneration(uint8_t hw_gen) { aieGeneration = hw_gen; }
+    inline uint8_t getAIEGeneration() const { return aieGeneration ; }
 
     // ****** Functions for information on the currently loaded xclbin *******
     XDP_EXPORT XclbinInfo* currentXclbin() ;

--- a/src/runtime_src/xdp/profile/database/static_info_database.h
+++ b/src/runtime_src/xdp/profile/database/static_info_database.h
@@ -136,6 +136,7 @@ namespace xdp {
     void initializeXrtIP(XclbinInfo* xclbin);
 
     void setDeviceNameFromXclbin(uint64_t deviceId, xrt::xclbin xrtXclbin);
+    void setAIEGeneration(uint64_t deviceId, xrt::xclbin xrtXclbin) ;
     void setAIEClockRateMHz(uint64_t deviceId, xrt::xclbin xrtXclbin) ;
     bool initializeStructure(XclbinInfo*, xrt::xclbin);
     bool initializeProfileMonitors(DeviceInfo*, xrt::xclbin);
@@ -276,8 +277,9 @@ namespace xdp {
 
     // *********************************************************
     // ***** Functions related to AIE specific information *****
-    XDP_EXPORT bool isAIECounterRead(uint64_t deviceId) ;
+    XDP_EXPORT uint8_t getAIEGeneration(uint64_t deviceId) ;
     XDP_EXPORT void setIsAIECounterRead(uint64_t deviceId, bool val) ;
+    XDP_EXPORT bool isAIECounterRead(uint64_t deviceId) ;
     XDP_EXPORT void setIsGMIORead(uint64_t deviceId, bool val) ;
     XDP_EXPORT bool isGMIORead(uint64_t deviceId) ;
     XDP_EXPORT uint64_t getNumAIECounter(uint64_t deviceId) ;

--- a/src/runtime_src/xdp/profile/plugin/aie_trace_new/x86/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace_new/x86/aie_trace.cpp
@@ -255,7 +255,7 @@ namespace xdp {
           (db->getStaticInfo()).addAIECoreEventResources(deviceId, event, cfg->numTileCoreTraceEvents[event]);
         if (cfg->numTileMemoryTraceEvents[event] != 0)
           (db->getStaticInfo()).addAIEMemoryEventResources(deviceId, event, cfg->numTileMemoryTraceEvents[event]);
-        if (cfg->numTileMemoryTraceEvents[event] != 0)
+        if (cfg->numTileMemTileTraceEvents[event] != 0)
           (db->getStaticInfo()).addAIEMemTileEventResources(deviceId, event, cfg->numTileMemTileTraceEvents[event]);
       } 
 

--- a/src/runtime_src/xdp/profile/writer/aie_profile/aie_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/aie_profile/aie_writer.cpp
@@ -37,14 +37,17 @@ namespace xdp {
 
   bool AIEProfilingWriter::write(bool openNewFile)
   {
+    // Report HW generation to inform analysis how to interpret event IDs
+    auto aieGeneration = (db->getStaticInfo()).getAIEGeneration(mDeviceIndex);
+    
     // Grab AIE clock freq from first counter in metadata
     // NOTE: Assumed the same for all tiles
     auto aie = (db->getStaticInfo()).getAIECounter(mDeviceIndex, 0);
-
     double aieClockFreqMhz = (aie != nullptr) ?  aie->clockFreqMhz : 1200.0;
 
     // Write header
     fout << "Target device: " << mDeviceName << "\n";
+    fout << "Hardware generation: " << static_cast<int>(aieGeneration) << "\n";
     fout << "Clock frequency (MHz): " << aieClockFreqMhz << "\n";
     fout << "timestamp"    << ","
          << "column"       << ","


### PR DESCRIPTION
**Problem solved by the commit**
Retrieving and reporting HW generation in AIE profile report for proper analysis of event IDs

**Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered**
Copy and paste bug in AIE trace for x86
Wrapped getting clock freq from AIE metadata with try-catch
 
**What has been tested and how, request additional testing if necessary**
Tested on vek280 and vck190
