### PR TITLE
Fix Coverity issue 248530 where unsigned value was checked for < 0

### DIFF
--- a/src/runtime_src/core/common/info_memory.cpp
+++ b/src/runtime_src/core/common/info_memory.cpp
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2021, 2022 Xilinx, Inc
+ * Copyright (C) 2023 Advanced Micro Devices, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -491,7 +492,7 @@ get_ps_kernels(const xrt_core::device *device)
     if (buf.empty())
       return ps_kernels;
     const ps_kernel_node *map = reinterpret_cast<ps_kernel_node *>(buf.data());
-    if(map->pkn_count < 0)
+    if(map->pkn_count == 0)
       throw xrt_core::error("'ps_kernel' invalid. Has the PS kernel been loaded? See 'xbutil program'.");
 
     for (unsigned int i = 0; i < map->pkn_count; i++)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Make a validate check for an unsigned value against 0.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Coverity scan found unsigned compared against 0

#### How problem was solved, alternative solutions (if any) and why they were rejected
Just need to compare equal to 0 instead of < 0

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Tested on vck5000

#### Documentation impact (if any)
None
