### PR TITLE
CR-1149236 Add support to dump APU's dimes and syslog to host

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
@@ -1148,7 +1148,7 @@ static int xgq_log_page_fw(struct platform_device *pdev,
 				fw_result->count);
 			ret = -ENOSPC;
 		} else if (fw_result->count == 0) {
-			XGQ_ERR(xgq, "fw size cannot be zero");
+			XGQ_WARN(xgq, "fw size is zero");
 			ret = -EINVAL;
 		} else {
 			*fw_size = fw_result->count;
@@ -3114,7 +3114,7 @@ static ssize_t vmr_apu_log_read(struct file *filp, struct kobject *kobj,
 	/* return count should be less or equal to count */
 	ret = xgq_vmr_apu_log(xgq, &log_buf, &log_size, off, count);
 	if (ret)
-		return ret;
+		return (ret == -EINVAL) ? 0 : ret;;
 
 	/* adjust log_size to be within requested count range */
 	log_size = log_size > count ? count : log_size;


### PR DESCRIPTION
additional fix for edge case

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Hi @jeffli-xilinx ,please use this PR to verify your APU_LOG enhancement.
When request 4096 but return is less than 4096, the sysfs will request again and we return 0 back which should be handled by return 0 instead of return -EINVAL.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
