### PR TITLE
Resolving the XDP Coverity issues related to AUTO_CAUSES_COPY

### DIFF
--- a/src/runtime_src/xdp/appdebug/appdebug.cpp
+++ b/src/runtime_src/xdp/appdebug/appdebug.cpp
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2016-2020 Xilinx, Inc
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -1075,7 +1075,7 @@ std::pair<size_t, size_t> getCUNamePortName (std::vector<std::string>& aSlotName
     //return max length of the cuname and port names
     size_t max1 = 0, max2 = 0;
     char sep = '/';
-    for (auto slotName: aSlotNames) {
+    for (const auto& slotName: aSlotNames) {
         size_t found1;
         size_t start = 0;
         found1 = slotName.find(sep, 0);

--- a/src/runtime_src/xdp/profile/database/static_info/xclbin_info.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info/xclbin_info.cpp
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2021 Xilinx, Inc
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -47,7 +47,7 @@ namespace xdp {
                                    const std::string& portName,
                                    int32_t portWidth)
   {
-    for (auto iter : cus) {
+    for (const auto& iter : cus) {
       auto cu = iter.second;
       if (cu->getKernelName() == kernelName)
         cu->addPort(portName, portWidth);
@@ -58,7 +58,7 @@ namespace xdp {
                             const std::string& argName,
                             const std::string& portName)
   {
-    for (auto iter : cus) {
+    for (const auto& iter : cus) {
       auto cu = iter.second;
       if (cu->getKernelName() == kernelName)
         cu->addArgToPort(argName, portName);
@@ -74,7 +74,7 @@ namespace xdp {
       return;
 
     Memory* mem = memoryInfo[memId];
-    for (auto iter : cus) {
+    for (const auto& iter : cus) {
       auto cu = iter.second;
       if (cu->getKernelName() == kernelName)
         cu->connectArgToMemory(portName, argName, mem);

--- a/src/runtime_src/xdp/profile/database/static_info_database.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info_database.cpp
@@ -83,7 +83,7 @@ namespace xdp {
     if (aieDevice != nullptr && deallocateAieDevice != nullptr)
       deallocateAieDevice(aieDevice) ;
 
-    for (auto iter : deviceInfo) {
+    for (const auto& iter : deviceInfo) {
       delete iter.second ;
     }
   }
@@ -261,7 +261,7 @@ namespace xdp {
     std::vector<std::string> uniqueNames ;
     std::lock_guard<std::mutex> lock(deviceLock) ;
 
-    for (auto device : deviceInfo) {
+    for (const auto& device : deviceInfo) {
       uniqueNames.push_back(device.second->getUniqueDeviceName()) ;
     }
     return uniqueNames ;
@@ -272,7 +272,7 @@ namespace xdp {
     std::vector<DeviceInfo*> infos ;
     std::lock_guard<std::mutex> lock(deviceLock) ;
 
-    for (auto device : deviceInfo) {
+    for (const auto& device : deviceInfo) {
       infos.push_back(device.second) ;
     }
     return infos ;
@@ -282,9 +282,9 @@ namespace xdp {
   {
     std::lock_guard<std::mutex> lock(deviceLock) ;
 
-    for (auto device : deviceInfo) {
+    for (const auto& device : deviceInfo) {
       for (auto xclbin : device.second->getLoadedXclbins()) {
-        for (auto cu : xclbin->pl.cus) {
+        for (const auto& cu : xclbin->pl.cus) {
           if (cu.second->getStallEnabled())
             return true ;
         }
@@ -1653,7 +1653,7 @@ namespace xdp {
     xmlStream.write(embeddedMetadataSection, embeddedMetadataSz);
     boost::property_tree::read_xml(xmlStream, xmlProject);
 
-    for(auto coreItem : xmlProject.get_child("project.platform.device.core")) {
+    for(const auto& coreItem : xmlProject.get_child("project.platform.device.core")) {
       std::string coreItemName = coreItem.first;
       if(0 != coreItemName.compare("kernel")) {  // skip items other than "kernel"
         continue;
@@ -1680,7 +1680,7 @@ namespace xdp {
       }
 
       // Find the ComputeUnitInstance
-      for(auto cuItr : currentXclbin->pl.cus) {
+      for(const auto& cuItr : currentXclbin->pl.cus) {
         if(0 != cuItr.second->getKernelName().compare(kernelName)) {
           continue;
         }
@@ -1704,7 +1704,7 @@ namespace xdp {
       (static_cast<uint64_t>(debugIpData->m_index_highbyte) << 8);
 
     // Find the compute unit that this AM is attached to.
-    for (auto cu : xclbin->pl.cus) {
+    for (const auto& cu : xclbin->pl.cus) {
       ComputeUnitInstance* cuObj = cu.second ;
       int32_t cuId = cu.second->getIndex() ;
 
@@ -1775,14 +1775,14 @@ namespace xdp {
 
     // Find both the compute unit this AIM is attached to (if applicable)
     //  and the memory this AIM is attached to (if applicable).
-    for(auto cu : xclbin->pl.cus) {
+    for(const auto& cu : xclbin->pl.cus) {
       if(0 == monCuName.compare(cu.second->getName())) {
         cuId = cu.second->getIndex();
         cuObj = cu.second;
         break;
       }
     }
-    for(auto mem : xclbin->pl.memoryInfo) {
+    for(const auto& mem : xclbin->pl.memoryInfo) {
       if (0 == memName.compare(mem.second->spTag)) {
         memId = mem.second->index;
         break;
@@ -1845,7 +1845,7 @@ namespace xdp {
     ComputeUnitInstance* cuObj = nullptr ;
     int32_t cuId = -1 ;
 
-    for(auto cu : xclbin->pl.cus) {
+    for(const auto& cu : xclbin->pl.cus) {
       if(0 == monCuName.compare(cu.second->getName())) {
         cuId = cu.second->getIndex();
         cuObj = cu.second;
@@ -1871,7 +1871,7 @@ namespace xdp {
 
         monCuName = monCuName.substr(0, pos);
 
-        for(auto cu : xclbin->pl.cus) {
+        for(const auto& cu : xclbin->pl.cus) {
           if(0 == monCuName.compare(cu.second->getName())) {
             cuId = cu.second->getIndex();
             cuObj = cu.second;

--- a/src/runtime_src/xdp/profile/database/statistics_database.cpp
+++ b/src/runtime_src/xdp/profile/database/statistics_database.cpp
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2016-2020 Xilinx, Inc
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -151,7 +151,7 @@ namespace xdp {
   VPStatisticsDatabase::getComputeUnitExecutionStats(const std::string& cuName)
   {
     std::vector<std::pair<std::string, TimeStatistics>> calls;
-    for (auto element : computeUnitExecutionStats) {
+    for (const auto& element : computeUnitExecutionStats) {
       if (0 == cuName.compare(std::get<0>(element.first))) {
         calls.push_back(std::make_pair(std::get<2>(element.first), element.second));
       }
@@ -428,7 +428,7 @@ namespace xdp {
     //  the number of calls
     std::map<std::string, uint64_t> counts ;
 
-    for (auto c : callCount)
+    for (const auto& c : callCount)
     {
       if (counts.find(c.first.first) == counts.end())
       {
@@ -440,7 +440,7 @@ namespace xdp {
       }
     }
 
-    for (auto i : counts)
+    for (const auto& i : counts)
     {
       fout << i.first << "," << i.second << std::endl ;
     }
@@ -449,7 +449,7 @@ namespace xdp {
   void VPStatisticsDatabase::dumpHALMemory(std::ofstream& fout)
   {
     unsigned int i = 0 ; 
-    for (auto m : memoryStats)
+    for (const auto& m : memoryStats)
     {
       fout << "Device " << i << std::endl ;
 

--- a/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
@@ -360,7 +360,7 @@ namespace xdp {
 
   void DeviceOffloadPlugin::readCounters()
   {
-    for (auto o : offloaders)
+    for (const auto& o : offloaders)
     {
       uint64_t deviceId = o.first ;
       xdp::CounterResults results ;
@@ -411,7 +411,7 @@ namespace xdp {
     //  the plugin object.  At this time, the information in the database
     //  still exists and is viable, so we should flush our devices
     //  and write our writers.
-    for (auto o : offloaders) {
+    for (const auto& o : offloaders) {
       auto offloader = std::get<0>(o.second) ;
       flushTraceOffloader(offloader);
       checkTraceBufferFullness(offloader, o.first);
@@ -473,7 +473,7 @@ namespace xdp {
 
   void DeviceOffloadPlugin::clearOffloaders()
   {
-    for(auto entry : offloaders) {
+    for(const auto& entry : offloaders) {
       auto offloader = std::get<0>(entry.second);
       auto logger    = std::get<1>(entry.second);
 

--- a/src/runtime_src/xdp/profile/plugin/device_offload/hal/hal_device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/hal/hal_device_offload_plugin.cpp
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2016-2022 Xilinx, Inc
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -94,7 +94,7 @@ namespace xdp {
 
   void HALDeviceOffloadPlugin::readTrace()
   {
-    for (auto o : offloaders) {
+    for (const auto& o : offloaders) {
       auto offloader = std::get<0>(o.second) ;
       flushTraceOffloader(offloader);
       checkTraceBufferFullness(offloader, o.first);

--- a/src/runtime_src/xdp/profile/plugin/device_offload/hw_emu/hw_emu_device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/hw_emu/hw_emu_device_offload_plugin.cpp
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2022 Xilinx, Inc
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -76,7 +76,7 @@ namespace xdp {
 
   void HWEmuDeviceOffloadPlugin::readTrace()
   {
-    for (auto o : offloaders) {
+    for (const auto& o : offloaders) {
       auto offloader = std::get<0>(o.second) ;
       flushTraceOffloader(offloader);
       checkTraceBufferFullness(offloader, o.first);

--- a/src/runtime_src/xdp/profile/plugin/device_offload/opencl/opencl_device_info_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/opencl/opencl_device_info_plugin.cpp
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2020-2022 Xilinx, Inc
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -185,7 +185,7 @@ namespace xdp {
     std::set<std::string> bitWidthStrings ;
     for (auto device : platform->get_device_range()) {
       for (auto& cu : xocl::xocl(device)->get_cus()) {
-        for (auto arg : cu->get_args()) {
+        for (const auto& arg : cu->get_args()) {
           if (arg.index == xrt_core::xclbin::kernel_argument::no_index)
             continue;
 

--- a/src/runtime_src/xdp/profile/plugin/hal_api_interface/xdp_api_interface.cpp
+++ b/src/runtime_src/xdp/profile/plugin/hal_api_interface/xdp_api_interface.cpp
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2016-2022 Xilinx, Inc
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -79,7 +79,7 @@ namespace xdp {
 
   void HALAPIInterface::startCounters()
   {
-    for(auto itr : devices) {
+    for(const auto& itr : devices) {
       itr.second->startCounters();
     }
   }
@@ -87,7 +87,7 @@ namespace xdp {
   void HALAPIInterface::readCounters()
   {
     xdp::CounterResults counterResults;
-    for(auto itr : devices) {
+    for(const auto& itr : devices) {
       itr.second->readCounters(counterResults);
     }
   }

--- a/src/runtime_src/xdp/profile/plugin/power/power_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/power/power_plugin.cpp
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2020-2022 Xilinx, Inc
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -139,10 +140,10 @@ namespace xdp {
       // Get timestamp in milliseconds
       double timestamp = xrt_core::time_ns() / 1.0e6 ;
       uint64_t index = 0 ;
-      for (auto device : filePaths)
+      for (const auto& device : filePaths)
       {
         std::vector<uint64_t> values ;
-        for (auto file : device)
+        for (const auto& file : device)
         {
           std::ifstream fs(file) ;
           if (!fs)

--- a/src/runtime_src/xdp/profile/writer/device_trace/device_trace_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/device_trace/device_trace_writer.cpp
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2016-2020 Xilinx, Inc
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -94,7 +94,7 @@ namespace xdp {
                                                      uint32_t& rowCount)
   {
     // Create structure for all CUs in the xclbin
-    for (auto iter : xclbin->pl.cus) {
+    for (const auto& iter : xclbin->pl.cus) {
       ComputeUnitInstance* cu = iter.second;
       fout << "Group_Start,Compute Unit " << cu->getName();
 
@@ -429,7 +429,7 @@ namespace xdp {
       (db->getStaticInfo()).getLoadedXclbins(deviceId);
 
     for (auto xclbin : loadedXclbins) {
-      for (auto iter : xclbin->pl.cus) {
+      for (const auto& iter : xclbin->pl.cus) {
         ComputeUnitInstance* cu = iter.second;
         db->getDynamicInfo().addString(cu->getKernelName());
         db->getDynamicInfo().addString(cu->getName());

--- a/src/runtime_src/xdp/profile/writer/opencl/opencl_trace_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/opencl/opencl_trace_writer.cpp
@@ -55,7 +55,7 @@ namespace xdp {
     ++rowID ;
     copyBucket = rowID ;
     ++rowID ;
-    for (auto e : (db->getStaticInfo()).getEnqueuedKernels())
+    for (auto& e : (db->getStaticInfo()).getEnqueuedKernels())
     {
       enqueueBuckets[e] = rowID ;
       ++rowID ;
@@ -180,7 +180,7 @@ namespace xdp {
 
     std::pair<uint64_t, uint64_t> zero = std::make_pair(0, 0) ;
 
-    for (auto iter : dependencies) {
+    for (auto& iter : dependencies) {
       auto xrtID = iter.first ;
 
       std::pair<uint64_t, uint64_t> mapping =

--- a/src/runtime_src/xdp/profile/writer/vp_base/guidance_rules.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/guidance_rules.cpp
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2016-2022 Xilinx, Inc
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -65,7 +65,7 @@ namespace {
                xdp::TimeStatistics> cuStats =
         db->getStats().getComputeUnitExecutionStats();
 
-      for (auto iter : cuStats) {
+      for (const auto& iter : cuStats) {
         fout << "CU_CALLS,"
              << db->getStaticInfo().getSoftwareEmulationDeviceName()
              << "|" << std::get<0>(iter.first) << ","
@@ -76,12 +76,12 @@ namespace {
       auto deviceInfos = db->getStaticInfo().getDeviceInfos();
       for (auto device : deviceInfos) {
         for (auto xclbin : device->loadedXclbins) {
-          for (auto cu : xclbin->pl.cus) {
+          for (const auto& cu : xclbin->pl.cus) {
             std::string cuName = cu.second->getName();
             std::vector<std::pair<std::string, xdp::TimeStatistics>> cuCalls =
               db->getStats().getComputeUnitExecutionStats(cuName);
             uint64_t execCount = 0;
-            for (auto cuCall : cuCalls) {
+            for (const auto& cuCall : cuCalls) {
               execCount += cuCall.second.numExecutions;
             }
             if (execCount != 0) {
@@ -166,7 +166,7 @@ namespace {
     if (xdp::getFlowMode() == xdp::SW_EMU) {
       std::map<std::string, bool> memUsage =
         db->getStaticInfo().getSoftwareEmulationMemUsage();
-      for (auto iter : memUsage) {
+      for (const auto& iter : memUsage) {
         fout << "MEMORY_USAGE," << iter.first << "," << iter.second << ",\n";
       }
     }
@@ -175,7 +175,7 @@ namespace {
 
       for (auto device : deviceInfos) {
         for (auto xclbin : device->loadedXclbins) {
-          for (auto memory : xclbin->pl.memoryInfo) {
+          for (const auto& memory : xclbin->pl.memoryInfo) {
             std::string memName = memory.second->spTag ;
 
             fout << "MEMORY_USAGE," << device->getUniqueDeviceName() << "|"
@@ -197,7 +197,7 @@ namespace {
       auto deviceInfos = db->getStaticInfo().getDeviceInfos();
       for (auto device : deviceInfos) {
         for (auto xclbin : device->loadedXclbins) {
-          for (auto memory : xclbin->pl.memoryInfo) {
+          for (const auto& memory : xclbin->pl.memoryInfo) {
             if (memory.second->spTag.find("PLRAM") != std::string::npos) {
               hasPLRAM = true ;
               break ;
@@ -230,7 +230,7 @@ namespace {
       auto deviceInfos = db->getStaticInfo().getDeviceInfos() ;
       for (auto device : deviceInfos) {
         for (auto xclbin : device->loadedXclbins) {
-          for (auto memory : xclbin->pl.memoryInfo) {
+          for (const auto& memory : xclbin->pl.memoryInfo) {
             if (memory.second->spTag.find("HBM") != std::string::npos) {
               hasHBM = true ;
               break ;
@@ -319,7 +319,7 @@ namespace {
     if (xdp::getFlowMode() == xdp::SW_EMU) {
       std::vector<std::string> portBitWidths =
         db->getStaticInfo().getSoftwareEmulationPortBitWidths();
-      for (auto width : portBitWidths)
+      for (const auto& width : portBitWidths)
         fout << "PORT_BIT_WIDTH," << width << ",\n";
       return;
     }
@@ -329,7 +329,7 @@ namespace {
     auto deviceInfos = db->getStaticInfo().getDeviceInfos() ;
     for (auto device : deviceInfos) {
       for (auto xclbin : device->loadedXclbins) {
-        for (auto cu : xclbin->pl.cus) {
+        for (const auto& cu : xclbin->pl.cus) {
           std::vector<uint32_t>* aimIds = cu.second->getAIMs() ;
           std::vector<uint32_t>* asmIds = cu.second->getASMs() ;
 
@@ -368,7 +368,7 @@ namespace {
       auto deviceInfos = db->getStaticInfo().getDeviceInfos() ;
       for (auto device : deviceInfos) {
         for (auto xclbin : device->loadedXclbins) {
-          for (auto cu : xclbin->pl.cus) {
+          for (const auto& cu : xclbin->pl.cus) {
             std::string kernelName = cu.second->getKernelName() ;
             if (kernelCounts.find(kernelName) == kernelCounts.end()) {
               kernelCounts[kernelName] = 1 ;
@@ -381,7 +381,7 @@ namespace {
       }
     }
 
-    for (auto kernel : kernelCounts) {
+    for (const auto& kernel : kernelCounts) {
       fout << "KERNEL_COUNT," << kernel.first << "," << kernel.second << ",\n" ;
     }
   }
@@ -434,7 +434,7 @@ namespace {
 
     auto maxExecs = db->getStats().getAllMaxExecutions();
 
-    for (auto mExec : maxExecs) {
+    for (const auto& mExec : maxExecs) {
       fout << "MAX_PARALLEL_KERNEL_ENQUEUES," << mExec.first << ","
            << mExec.second << ",\n" ;
     }
@@ -446,7 +446,7 @@ namespace {
 
     auto commandQueueInfo = db->getStats().getCommandQueuesAreOOO() ;
 
-    for (auto cq : commandQueueInfo) {
+    for (const auto& cq : commandQueueInfo) {
       fout << "COMMAND_QUEUE_OOO," << cq.first << "," << cq.second << ",\n" ;
     }
   }
@@ -458,7 +458,7 @@ namespace {
 
     for (auto device : deviceInfos) {
       for (auto xclbin : device->loadedXclbins) {
-        for (auto memory : xclbin->pl.memoryInfo) {
+        for (const auto& memory : xclbin->pl.memoryInfo) {
           if (memory.second->spTag.find("PLRAM") != std::string::npos) {
             fout << "PLRAM_SIZE_BYTES,"
                  << device->getUniqueDeviceName()

--- a/src/runtime_src/xdp/profile/writer/vp_base/summary_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/summary_writer.cpp
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2016-2022 Xilinx, Inc
- * Copyright (C) 2022 Advanced Micro Devices, Inc - All rights reserved
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -196,7 +196,7 @@ namespace xdp {
              std::vector<std::pair<double, double>>> callCount =
       (db->getStats()).getCallCount() ;
     
-    for (auto call : callCount) {
+    for (const auto& call : callCount) {
       auto callAndThread = call.first ;
       auto APIName = callAndThread.first ;
 
@@ -224,7 +224,7 @@ namespace xdp {
         rows[APIName] = blank ;
       }
 
-      for (auto executionTime : timesOfCalls) {
+      for (const auto& executionTime : timesOfCalls) {
         auto timeTaken = executionTime.second - executionTime.first ;
 
         ++(std::get<0>(rows[APIName])) ;
@@ -236,7 +236,7 @@ namespace xdp {
       }
     }
 
-    for (auto row : rows) {
+    for (const auto& row : rows) {
       auto averageTime = 
         (double)(std::get<1>(row.second)) / (double)(std::get<0>(row.second)) ;
       if (type != OPENCL) fout << "ENTRY:" ;
@@ -313,7 +313,7 @@ namespace xdp {
          << "writeBuffer bytes transferred,\n" ;
 
     auto memStats = db->getStats().getMemoryStats() ;
-    for (auto iter : memStats) {
+    for (const auto& iter : memStats) {
       fout << iter.first                               << ","
            << iter.second.channels[0].transactionCount << ","
            << iter.second.channels[0].totalByteCount   << ","
@@ -351,7 +351,7 @@ namespace xdp {
     fout << "Kernel,Number Of Enqueues,Total Time (ms),Minimum Time (ms),"
          << "Average Time (ms),Maximum Time (ms),\n" ;
 
-    for (auto execution : kernelExecutions) {
+    for (const auto& execution : kernelExecutions) {
       fout << execution.first                         << ","
            << (execution.second).numExecutions        << ","
            << ((execution.second).totalTime / one_million)   << ","
@@ -481,7 +481,7 @@ namespace xdp {
          << "Dataflow Acceleration,Total Time (ms),Minimum Time (ms),"
          << "Average Time (ms),Maximum Time (ms),Clock Frequency (MHz),\n" ;
 
-    for (auto stat : cuStats) {
+    for (const auto& stat : cuStats) {
       std::string cuName          = (std::get<0>(stat.first)) ;
       std::string localWorkGroup  = (std::get<1>(stat.first)) ;
       std::string globalWorkGroup = (std::get<2>(stat.first)) ;
@@ -568,7 +568,7 @@ namespace xdp {
           (db->getDynamicInfo()).getCounterResults(deviceId, xclbin->uuid) ;
 
         // For every compute unit in the xclbin
-        for (auto cuInfo : xclbin->pl.cus)
+        for (const auto& cuInfo : xclbin->pl.cus)
         {
           uint64_t amSlotID = (uint64_t)((cuInfo.second)->getAccelMon()) ;
 
@@ -590,7 +590,7 @@ namespace xdp {
           std::vector<std::pair<std::string, TimeStatistics>> cuCalls = 
             (db->getStats()).getComputeUnitExecutionStats(cuName) ;
 
-          for (auto cuCall : cuCalls)
+          for (const auto& cuCall : cuCalls)
           {
             std::string globalWorkDimensions = cuCall.first ;
 
@@ -653,7 +653,7 @@ namespace xdp {
       {
         xdp::CounterResults values = (db->getDynamicInfo()).getCounterResults(device->deviceId, xclbin->uuid) ;
         uint64_t j = 0 ;      
-        for (auto cu : (xclbin->pl.cus))
+        for (const auto& cu : (xclbin->pl.cus))
         {
           double deviceCyclesMsec = (double)(xclbin->pl.clockRatePLMHz * one_thousand);
 
@@ -696,7 +696,7 @@ namespace xdp {
     uint64_t i = 0;
 
     for (auto& map : { hostReads, hostWrites }) {
-      for (auto entry : map) {
+      for (const auto& entry : map) {
         auto contextID = entry.first.first;
         auto deviceID = entry.first.second;
         auto& stats = entry.second;
@@ -902,7 +902,7 @@ namespace xdp {
         xdp::CounterResults values =
           db->getDynamicInfo().getCounterResults(device->deviceId,
                                                  xclbin->uuid) ;
-        for (auto cu : xclbin->pl.cus) {
+        for (const auto& cu : xclbin->pl.cus) {
           std::vector<uint32_t>* asmMonitors = (cu.second)->getASMs() ;
           
           for (auto asmMonitorId : (*asmMonitors)) {
@@ -941,7 +941,7 @@ namespace xdp {
       for (auto xclbin : device->loadedXclbins)
       {
         xdp::CounterResults values = (db->getDynamicInfo()).getCounterResults(device->deviceId, xclbin->uuid) ;
-        for (auto cu : xclbin->pl.cus)
+        for (const auto& cu : xclbin->pl.cus)
         {
           std::vector<uint32_t>* asmMonitors = (cu.second)->getASMs() ;
           
@@ -1657,7 +1657,7 @@ namespace xdp {
         xdp::CounterResults values =
           (db->getDynamicInfo()).getCounterResults(deviceId, xclbin->uuid) ;
 
-        for (auto cu : xclbin->pl.cus)
+        for (const auto& cu : xclbin->pl.cus)
         {
           // For each CU, we need to find the monitor that has 
           //  the most transactions
@@ -1787,7 +1787,7 @@ namespace xdp {
     fout << "Label,Count,\n" ;
 
     std::map<std::string, uint64_t>& counts = db->getStats().getEventCounts() ;
-    for (auto iter : counts) {
+    for (const auto& iter : counts) {
       fout << iter.first << "," << iter.second << ",\n" ;
     }
   }
@@ -1809,7 +1809,7 @@ namespace xdp {
     std::map<std::pair<const char*, const char*>, uint64_t>& totalDurations =
       (db->getStats()).getTotalRangeDurations() ;
 
-    for (auto iter : counts) {
+    for (const auto& iter : counts) {
       const char* label =
         (iter.first.first == nullptr) ? " " : iter.first.first;
       const char* tooltip =

--- a/src/runtime_src/xdp/profile/writer/vp_base/vp_run_summary.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/vp_run_summary.cpp
@@ -148,7 +148,7 @@ namespace xdp {
     }
 
     boost::property_tree::ptree ptFiles;
-    for (auto f : files) {
+    for (const auto& f : files) {
       boost::property_tree::ptree ptFile;
       ptFile.put("name", f.first.c_str());
       ptFile.put("type", f.second.c_str());


### PR DESCRIPTION
#### Problem solved by the commit
This changes all of the opportunities identified by Coverity to replace auto with const auto& in the XDP owned code in order to avoid an unnecessary copy.

#### Risks (if any) associated the changes in the commit
Low, as the eliminated copy does not effect the usage of the reference.

#### Documentation impact (if any)
No documentation impact