### PR TITLE
CR-1154650 Remove SC update message when SC is the same

### DIFF
--- a/src/runtime_src/core/tools/xbmgmt2/OO_UpdateBase.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_UpdateBase.cpp
@@ -544,10 +544,10 @@ auto_flash(std::shared_ptr<xrt_core::device> & device, Flasher::E_FlasherType fl
       if (xrt_core::device_query<xrt_core::query::is_mfg>(device.get()) || xrt_core::device_query<xrt_core::query::is_recovery>(device.get()))
         report_stream << boost::format("  [%s] : Factory or Recovery image detected. Reflash the device after the reboot to update the SC firmware.\n") % getBDF(p.first);
       // Versal devices cannot flash the SC in the same cycle as the shell
-      else if (is_versal && !same_shell)
+      else if (is_versal && !same_shell && !same_sc)
         report_stream << boost::format("  [%s] : Reflash the device after the reboot to update the SC firmware.\n") % getBDF(p.first);
       else {
-        if (update_sc(p.first, p.second) == true)  {
+        if (update_sc(p.first, p.second) == true) {
           report_stream << boost::format("  [%s] : Successfully flashed the Satellite Controller (SC) image\n") % getBDF(p.first);\
           // Versal devices require a cold reboot to initialize the SC firmware
           reboot = is_versal ? reboot_type::COLD_REBOOT : reboot_type::WARM_REBOOT;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1154650
When a platform has the Base image different but the SC version is the same and we still see the "Reflash the device after the reboot to update the SC firmware" message. This is misleading as in this scenario we do not need to do any additional flashing after the reboot.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Caused by a missing condition
Introduced in: https://github.com/Xilinx/XRT/pull/7285

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added the required condition

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Ubuntu 20.04 v70
Outputwhen SC versions are mismatched after shell update
```
root@xsjdbenusov50:~# xbmgmt examine -d 02:00
WARNING: Unexpected xclmgmt version (2.14.0) was found. Expected 2.15.0, to match XRT tools.

-----------------------------------------------
[0000:02:00.0] : xilinx_v70_gen5x8_qdma_base_2
-----------------------------------------------
Flash properties
  Type                 : ospi_xgq
  Serial Number        : 51171B22AK6K

Device properties
  Type                 : v70
  Name                 : ALVEO V70 ENG

Flashable partitions running on FPGA
  Platform             : xilinx_v70_gen5x8_qdma_base_2
  SC Version           : 8.5.2
  Platform UUID        : C56DE598-76F3-467D-2D82-0328EBA1C95A
  Interface UUID       : 9C8AD72A-C838-E988-9BC6-D6D13B28965E

Flashable partitions installed in system
  Platform             : xilinx_v70_gen5x8_qdma_base_2
  SC Version           : 8.5.1
  Platform UUID        : 553297E5-6D4A-F051-3AAF-C9534B8C844C

Bootable Partitions:
  Default              : ACTIVE
  Backup               : INACTIVE


  Mac Address          : 00:00:00:00:00:00

WARNING  : Device is not up-to-date.

root@xsjdbenusov50:~# xbmgmt program -d 02:00 --base
WARNING: Unexpected xclmgmt version (2.14.0) was found. Expected 2.15.0, to match XRT tools.
----------------------------------------------------
Device : [0000:02:00.0]

Current Configuration
  Platform             : xilinx_v70_gen5x8_qdma_base_2
  SC Version           : 8.5.2
  Platform ID          : 0xc56de59876f3467d


Incoming Configuration
  Deployment File      : partition.xsabin
  Deployment Directory : /lib/firmware/xilinx/553297e56d4af0513aafc9534b8c844c
  Size                 : 6,534,582 bytes
  Timestamp            : Mon Oct  3 14:24:32 2022

  Platform             : xilinx_v70_gen5x8_qdma_base_2
  SC Version           : 8.5.1
  Platform UUID        : 553297E5-6D4A-F051-3AAF-C9534B8C844C
----------------------------------------------------
Actions to perform:
  [0000:02:00.0] : Program base (FLASH) image
----------------------------------------------------
Are you sure you wish to proceed? [Y/n]: Y

[0000:02:00.0] : Updating base (e.g., shell) flash image...
PDI dsabin supports only primary bitstream: /lib/firmware/xilinx/553297e56d4af0513aafc9534b8c844c/partition.xsabin
INFO: ***xsabin has 6534582 bytes
INFO: ***Write 6534582 bytes
INFO     : Base flash image has been programmed successfully.
----------------------------------------------------
Report
  [0000:02:00.0] : Reflash the device after the reboot to update the SC firmware.
  [0000:02:00.0] : Successfully flashed the base (e.g., shell) image

Device flashed successfully.
****************************************************
Cold reboot machine to load the new image on device.
****************************************************
```

Output when SC versions match after shell update
```
root@xsjdbenusov50:/proj/xbuilds/2023.1_daily_latest/xbb/packages/internal_platforms/v70/gen5x8_qdma/base# xbmgmt examine -d 02:00
WARNING: Unexpected xclmgmt version (2.14.0) was found. Expected 2.15.0, to match XRT tools.

-----------------------------------------------
[0000:02:00.0] : xilinx_v70_gen5x8_qdma_base_2
-----------------------------------------------
Flash properties
  Type                 : ospi_xgq
  Serial Number        : 51171B22AK6K

Device properties
  Type                 : v70
  Name                 : ALVEO V70 ENG

Flashable partitions running on FPGA
  Platform             : xilinx_v70_gen5x8_qdma_base_2
  SC Version           : 8.5.2
  Platform UUID        : 56B80853-34D6-5BF2-8537-2EF76178CF95
  Interface UUID       : 1A7ED514-B3E1-70EC-3852-E11C40C84479

Flashable partitions installed in system
  Platform             : xilinx_v70_gen5x8_qdma_base_2
  SC Version           : 8.5.2
  Platform UUID        : C56DE598-76F3-467D-2D82-0328EBA1C95A

Bootable Partitions:
  Default              : ACTIVE
  Backup               : INACTIVE


  Mac Address          : 00:00:00:00:00:00

WARNING  : Device is not up-to-date.

root@xsjdbenusov50:/proj/xbuilds/2023.1_daily_latest/xbb/packages/internal_platforms/v70/gen5x8_qdma/base# xbmgmt program -d 02:00 -b
WARNING: Unexpected xclmgmt version (2.14.0) was found. Expected 2.15.0, to match XRT tools.
----------------------------------------------------
Device : [0000:02:00.0]

Current Configuration
  Platform             : xilinx_v70_gen5x8_qdma_base_2
  SC Version           : 8.5.2
  Platform ID          : 0x56b8085334d65bf2


Incoming Configuration
  Deployment File      : partition.xsabin
  Deployment Directory : /lib/firmware/xilinx/c56de59876f3467d2d820328eba1c95a
  Size                 : 6,382,634 bytes
  Timestamp            : Thu Jan 26 10:31:57 2023

  Platform             : xilinx_v70_gen5x8_qdma_base_2
  SC Version           : 8.5.2
  Platform UUID        : C56DE598-76F3-467D-2D82-0328EBA1C95A
----------------------------------------------------
Actions to perform:
  [0000:02:00.0] : Program base (FLASH) image
----------------------------------------------------
Are you sure you wish to proceed? [Y/n]: Y

INFO: Satellite Controller (SC) images are the same.
[0000:02:00.0] : Updating base (e.g., shell) flash image...
PDI dsabin supports only primary bitstream: /lib/firmware/xilinx/c56de59876f3467d2d820328eba1c95a/partition.xsabin
INFO: ***xsabin has 6382634 bytes
INFO: ***Write 6382634 bytes
INFO     : Base flash image has been programmed successfully.
----------------------------------------------------
Report
  [0000:02:00.0] : Satellite Controller (SC) is either up-to-date, fixed, or not installed. No actions taken.
  [0000:02:00.0] : Successfully flashed the base (e.g., shell) image

Device flashed successfully.
****************************************************
Cold reboot machine to load the new image on device.
****************************************************
```
#### Documentation impact (if any)
None