### PR TITLE
[2021.1] Changed XMA singleton mutex to shared_mutex to fix timeout issue

### DIFF
--- a/src/xma/include/lib/xmaapi.h
+++ b/src/xma/include/lib/xmaapi.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2018, Xilinx Inc - All rights reserved
+ * Copyright (C) 2023, Advanced Micro Devices, Inc - All rights reserved
  * Xilinx SDAccel Media Accelerator API
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
@@ -25,6 +26,7 @@
 #include <unordered_map>
 #include <thread>
 #include <mutex>
+#include <shared_mutex>
 #include <future>
 #include <chrono>
 
@@ -44,7 +46,7 @@ typedef struct XmaSingleton
     bool              xma_initialized;
     bool              kds_old;
     std::atomic<uint32_t> cpu_mode;
-    std::mutex            m_mutex;
+    std::shared_timed_mutex m_mutex;
     std::atomic<uint32_t> num_decoders;
     std::atomic<uint32_t> num_encoders;
     std::atomic<uint32_t> num_scalers;

--- a/src/xma/include/lib/xmaapi.h
+++ b/src/xma/include/lib/xmaapi.h
@@ -45,7 +45,7 @@ typedef struct XmaSingleton
     XmaHwCfg          hwcfg;
     bool              xma_initialized;
     bool              kds_old;
-    std::atomic<uint32_t> cpu_mode;
+    uint32_t          cpu_mode;
     std::shared_timed_mutex m_mutex;
     std::atomic<uint32_t> num_decoders;
     std::atomic<uint32_t> num_encoders;

--- a/src/xma/src/xmaapi/xmaadmin.cpp
+++ b/src/xma/src/xmaapi/xmaadmin.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2018, Xilinx Inc - All rights reserved
+ * Copyright (C) 2023, Advanced Micro Devices, Inc - All rights reserved
  * Xilinx SDAccel Media Accelerator API
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
@@ -178,7 +179,7 @@ xma_admin_session_create(XmaAdminProperties *props)
     }
 
     //Obtain lock only for a) singleton changes & b) kernel_info changes
-    std::unique_lock<std::mutex> guard1(g_xma_singleton->m_mutex);
+    std::unique_lock<std::shared_timed_mutex> guard1(g_xma_singleton->m_mutex);
     //Singleton lock acquired
 
     session->base.session_id = g_xma_singleton->num_of_sessions + 1;
@@ -214,7 +215,7 @@ xma_admin_session_destroy(XmaAdminSession *session)
     int32_t rc;
 
     xma_logmsg(XMA_DEBUG_LOG, XMA_ADMIN_MOD, "%s()\n", __func__);
-    std::lock_guard<std::mutex> guard1(g_xma_singleton->m_mutex);
+    std::unique_lock<std::shared_timed_mutex> guard1(g_xma_singleton->m_mutex);
     //Singleton lock acquired
 
     if (session == NULL) {

--- a/src/xma/src/xmaapi/xmaapi.cpp
+++ b/src/xma/src/xmaapi/xmaapi.cpp
@@ -271,6 +271,7 @@ void xma_thread2(uint32_t hw_dev_index) {
             xclExecWait(dev_handle, 100);
         }
 
+	std::shared_lock<std::shared_timed_mutex> lock(g_xma_singleton->m_mutex);
         for (auto& itr1: g_xma_singleton->all_sessions_vec) {
             if (g_xma_singleton->xma_exit) {
                 break;
@@ -426,7 +427,7 @@ int32_t xma_initialize(XmaXclbinParameter *devXclbins, int32_t num_parms)
     else
         xma_logmsg(XMA_DEBUG_LOG, XMAAPI_MOD, "XMA for KDS 2.0. Default mode.");
     g_xma_singleton->cpu_mode = xrt_core::config::get_xma_cpu_mode();
-    xma_logmsg(XMA_DEBUG_LOG, XMAAPI_MOD, "XMA CPU Mode is: %d", g_xma_singleton->cpu_mode.load());
+    xma_logmsg(XMA_DEBUG_LOG, XMAAPI_MOD, "XMA CPU Mode is: %d", g_xma_singleton->cpu_mode);
 
     g_xma_singleton->xma_thread1 = std::thread(xma_thread1);
     g_xma_singleton->all_thread2.reserve(MAX_XILINX_DEVICES);

--- a/src/xma/src/xmaapi/xmaapi.cpp
+++ b/src/xma/src/xmaapi/xmaapi.cpp
@@ -270,7 +270,6 @@ void xma_thread2(uint32_t hw_dev_index) {
             xclExecWait(dev_handle, 100);
         }
 
-        std::lock_guard<std::mutex> lock(g_xma_singleton->m_mutex);
         for (auto& itr1: g_xma_singleton->all_sessions_vec) {
             if (g_xma_singleton->xma_exit) {
                 break;

--- a/src/xma/src/xmaapi/xmaapi.cpp
+++ b/src/xma/src/xmaapi/xmaapi.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2018, Xilinx Inc - All rights reserved
+ * Copyright (C) 2023, Advanced Micro Devices, Inc - All rights reserved
  * Xilinx SDAccel Media Accelerator API
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
@@ -53,7 +54,7 @@ int32_t xma_get_default_ddr_index(int32_t dev_index, int32_t cu_index, char* cu_
         expected = false;
     }
 */
-    std::lock_guard<std::mutex> guard1(g_xma_singleton->m_mutex);
+    std::shared_lock<std::shared_timed_mutex> guard1(g_xma_singleton->m_mutex);
     //Singleton lock acquired
 
     if (cu_index < 0) {
@@ -108,7 +109,7 @@ void xma_thread1() {
             //bool desired = true;
             XmaHwSessionPrivate *slowest_session = nullptr;
             uint32_t session_cmd_busiest_val = 0;
-            std::lock_guard<std::mutex> lock(g_xma_singleton->m_mutex);
+            std::shared_lock<std::shared_timed_mutex> lock(g_xma_singleton->m_mutex);
 
             for (auto& itr1: g_xma_singleton->all_sessions_vec) {
                 if (g_xma_singleton->xma_exit) {
@@ -211,7 +212,7 @@ void xma_thread1() {
         }
     }
     //Print all stats here
-    std::lock_guard<std::mutex> lock(g_xma_singleton->m_mutex);
+    std::shared_lock<std::shared_timed_mutex> lock(g_xma_singleton->m_mutex);
 
     xclLogMsg(NULL, XRT_INFO, "XMA-Session-Stats", "=== Session CU Command Relative Stats: ===");
     for (auto& itr1: g_xma_singleton->all_sessions_vec) {
@@ -331,7 +332,7 @@ int32_t xma_initialize(XmaXclbinParameter *devXclbins, int32_t num_parms)
         return XMA_ERROR;
     }
 
-    std::lock_guard<std::mutex> guard1(g_xma_singleton->m_mutex);
+    std::unique_lock<std::shared_timed_mutex> guard1(g_xma_singleton->m_mutex);
     //Singleton lock acquired
 
     if (g_xma_singleton->xma_initialized) {

--- a/src/xma/src/xmaapi/xmadecoder.cpp
+++ b/src/xma/src/xmaapi/xmadecoder.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2018, Xilinx Inc - All rights reserved
+ * Copyright (C) 2023, Advanced Micro Devices, Inc - All rights reserved
  * Xilinx SDAccel Media Accelerator API
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
@@ -204,7 +205,7 @@ xma_dec_session_create(XmaDecoderProperties *dec_props)
     }
 
     //Obtain lock only for a) singleton changes & b) kernel_info changes
-    std::unique_lock<std::mutex> guard1(g_xma_singleton->m_mutex);
+    std::unique_lock<std::shared_timed_mutex> guard1(g_xma_singleton->m_mutex);
     //Singleton lock acquired
 
     if (!kernel_info->soft_kernel && !kernel_info->in_use && !kernel_info->context_opened) {
@@ -258,7 +259,7 @@ xma_dec_session_destroy(XmaDecoderSession *session)
 
     xma_logmsg(XMA_DEBUG_LOG, XMA_DECODER_MOD, "%s()\n", __func__);
 
-    std::lock_guard<std::mutex> guard1(g_xma_singleton->m_mutex);
+    std::lock_guard<std::shared_timed_mutex> guard1(g_xma_singleton->m_mutex);
     //Singleton lock acquired
 
     if (session == NULL) {

--- a/src/xma/src/xmaapi/xmadecoder.cpp
+++ b/src/xma/src/xmaapi/xmadecoder.cpp
@@ -259,7 +259,7 @@ xma_dec_session_destroy(XmaDecoderSession *session)
 
     xma_logmsg(XMA_DEBUG_LOG, XMA_DECODER_MOD, "%s()\n", __func__);
 
-    std::lock_guard<std::shared_timed_mutex> guard1(g_xma_singleton->m_mutex);
+    std::unique_lock<std::shared_timed_mutex> guard1(g_xma_singleton->m_mutex);
     //Singleton lock acquired
 
     if (session == NULL) {

--- a/src/xma/src/xmaapi/xmaencoder.cpp
+++ b/src/xma/src/xmaapi/xmaencoder.cpp
@@ -304,7 +304,7 @@ xma_enc_session_destroy(XmaEncoderSession *session)
 
     xma_logmsg(XMA_DEBUG_LOG, XMA_ENCODER_MOD, "%s()\n", __func__);
 
-    std::lock_guard<std::shared_timed_mutex> guard1(g_xma_singleton->m_mutex);
+    std::unique_lock<std::shared_timed_mutex> guard1(g_xma_singleton->m_mutex);
     //Singleton lock acquired
 
     if (session == NULL) {

--- a/src/xma/src/xmaapi/xmaencoder.cpp
+++ b/src/xma/src/xmaapi/xmaencoder.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2018, Xilinx Inc - All rights reserved
+ * Copyright (C) 2023, Advanced Micro Devices, Inc - All rights reserved
  * Xilinx SDAccel Media Accelerator API
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
@@ -246,7 +247,7 @@ xma_enc_session_create(XmaEncoderProperties *enc_props)
     xma_enc_session_statsfile_init(enc_session);
 
     //Obtain lock only for a) singleton changes & b) kernel_info changes
-    std::unique_lock<std::mutex> guard1(g_xma_singleton->m_mutex);
+    std::unique_lock<std::shared_timed_mutex> guard1(g_xma_singleton->m_mutex);
     //Singleton lock acquired
 
     if (!kernel_info->soft_kernel && !kernel_info->in_use && !kernel_info->context_opened) {
@@ -303,7 +304,7 @@ xma_enc_session_destroy(XmaEncoderSession *session)
 
     xma_logmsg(XMA_DEBUG_LOG, XMA_ENCODER_MOD, "%s()\n", __func__);
 
-    std::lock_guard<std::mutex> guard1(g_xma_singleton->m_mutex);
+    std::lock_guard<std::shared_timed_mutex> guard1(g_xma_singleton->m_mutex);
     //Singleton lock acquired
 
     if (session == NULL) {

--- a/src/xma/src/xmaapi/xmafilter.cpp
+++ b/src/xma/src/xmaapi/xmafilter.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2018, Xilinx Inc - All rights reserved
+ * Copyright (C) 2023, Advanced Micro Devices, Inc - All rights reserved
  * Xilinx SDAccel Media Accelerator API
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
@@ -203,7 +204,7 @@ xma_filter_session_create(XmaFilterProperties *filter_props)
     }
 
     //Obtain lock only for a) singleton changes & b) kernel_info changes
-    std::unique_lock<std::mutex> guard1(g_xma_singleton->m_mutex);
+    std::unique_lock<std::shared_timed_mutex> guard1(g_xma_singleton->m_mutex);
     //Singleton lock acquired
 
     if (!kernel_info->soft_kernel && !kernel_info->in_use && !kernel_info->context_opened) {
@@ -258,7 +259,7 @@ xma_filter_session_destroy(XmaFilterSession *session)
     int32_t rc;
 
     xma_logmsg(XMA_DEBUG_LOG, XMA_FILTER_MOD, "%s()\n", __func__);
-    std::lock_guard<std::mutex> guard1(g_xma_singleton->m_mutex);
+    std::lock_guard<std::shared_timed_mutex> guard1(g_xma_singleton->m_mutex);
     //Singleton lock acquired
 
     if (session == NULL) {

--- a/src/xma/src/xmaapi/xmafilter.cpp
+++ b/src/xma/src/xmaapi/xmafilter.cpp
@@ -259,7 +259,7 @@ xma_filter_session_destroy(XmaFilterSession *session)
     int32_t rc;
 
     xma_logmsg(XMA_DEBUG_LOG, XMA_FILTER_MOD, "%s()\n", __func__);
-    std::lock_guard<std::shared_timed_mutex> guard1(g_xma_singleton->m_mutex);
+    std::unique_lock<std::shared_timed_mutex> guard1(g_xma_singleton->m_mutex);
     //Singleton lock acquired
 
     if (session == NULL) {

--- a/src/xma/src/xmaapi/xmakernel.cpp
+++ b/src/xma/src/xmaapi/xmakernel.cpp
@@ -258,7 +258,7 @@ xma_kernel_session_destroy(XmaKernelSession *session)
 
     xma_logmsg(XMA_DEBUG_LOG, XMA_KERNEL_MOD, "%s()\n", __func__);
 
-    std::lock_guard<std::shared_timed_mutex> guard1(g_xma_singleton->m_mutex);
+    std::unique_lock<std::shared_timed_mutex> guard1(g_xma_singleton->m_mutex);
     //Singleton lock acquired
 
     if (session == NULL) {

--- a/src/xma/src/xmaapi/xmakernel.cpp
+++ b/src/xma/src/xmaapi/xmakernel.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2018, Xilinx Inc - All rights reserved
+ * Copyright (C) 2023, Advanced Micro Devices, Inc - All rights reserved
  * Xilinx SDAccel Media Accelerator API
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
@@ -202,7 +203,7 @@ xma_kernel_session_create(XmaKernelProperties *props)
     }
 
     //Obtain lock only for a) singleton changes & b) kernel_info changes
-    std::unique_lock<std::mutex> guard1(g_xma_singleton->m_mutex);
+    std::unique_lock<std::shared_timed_mutex> guard1(g_xma_singleton->m_mutex);
     //Singleton lock acquired
 
     if (!kernel_info->soft_kernel && !kernel_info->in_use && !kernel_info->context_opened) {
@@ -257,7 +258,7 @@ xma_kernel_session_destroy(XmaKernelSession *session)
 
     xma_logmsg(XMA_DEBUG_LOG, XMA_KERNEL_MOD, "%s()\n", __func__);
 
-    std::lock_guard<std::mutex> guard1(g_xma_singleton->m_mutex);
+    std::lock_guard<std::shared_timed_mutex> guard1(g_xma_singleton->m_mutex);
     //Singleton lock acquired
 
     if (session == NULL) {

--- a/src/xma/src/xmaapi/xmascaler.cpp
+++ b/src/xma/src/xmaapi/xmascaler.cpp
@@ -358,7 +358,7 @@ xma_scaler_session_destroy(XmaScalerSession *session)
     int32_t rc;
 
     xma_logmsg(XMA_DEBUG_LOG, XMA_SCALER_MOD, "%s()\n", __func__);
-    std::lock_guard<std::shared_timed_mutex> guard1(g_xma_singleton->m_mutex);
+    std::unique_lock<std::shared_timed_mutex> guard1(g_xma_singleton->m_mutex);
     //Singleton lock acquired
 
     if (session == NULL) {

--- a/src/xma/src/xmaapi/xmascaler.cpp
+++ b/src/xma/src/xmaapi/xmascaler.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2018, Xilinx Inc - All rights reserved
+ * Copyright (C) 2023, Advanced Micro Devices, Inc - All rights reserved
  * Xilinx SDAccel Media Accelerator API
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
@@ -302,7 +303,7 @@ xma_scaler_session_create(XmaScalerProperties *sc_props)
     }
 
     //Obtain lock only for a) singleton changes & b) kernel_info changes
-    std::unique_lock<std::mutex> guard1(g_xma_singleton->m_mutex);
+    std::unique_lock<std::shared_timed_mutex> guard1(g_xma_singleton->m_mutex);
     //Singleton lock acquired
 
     if (!kernel_info->soft_kernel && !kernel_info->in_use && !kernel_info->context_opened) {
@@ -357,7 +358,7 @@ xma_scaler_session_destroy(XmaScalerSession *session)
     int32_t rc;
 
     xma_logmsg(XMA_DEBUG_LOG, XMA_SCALER_MOD, "%s()\n", __func__);
-    std::lock_guard<std::mutex> guard1(g_xma_singleton->m_mutex);
+    std::lock_guard<std::shared_timed_mutex> guard1(g_xma_singleton->m_mutex);
     //Singleton lock acquired
 
     if (session == NULL) {

--- a/src/xma/src/xmaplugin/xmaplugin.cpp
+++ b/src/xma/src/xmaplugin/xmaplugin.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2018, Xilinx Inc - All rights reserved
+ * Copyright (C) 2023, Advanced Micro Devices, Inc - All rights reserved
  * Xilinx SDAccel Media Accelerator API
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
@@ -736,7 +737,7 @@ XmaCUCmdObj xma_plg_schedule_cu_cmd(XmaSession s_handle,
     
         if (!kernel_tmp1->soft_kernel && !kernel_tmp1->in_use && !kernel_tmp1->context_opened) {
 	    //Obtain lock only for a) singleton changes & b) kernel_info changes
-            std::unique_lock<std::mutex> guard1(g_xma_singleton->m_mutex);
+            std::unique_lock<std::shared_timed_mutex> guard1(g_xma_singleton->m_mutex);
             //Singleton lock acquired
 
             if (xclOpenContext(dev_tmp1->handle, dev_tmp1->uuid, kernel_tmp1->cu_index_ert, true) != 0) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
video QA testing was seeing video kernel timeouts
The issue was due to xma_thread2 locking the mutex for all threads, leading to timeouts.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
video QA testing

#### How problem was solved, alternative solutions (if any) and why they were rejected
Removed std::lock_guard in xma_thread2

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
video QA tests

#### Documentation impact (if any)
