### PR TITLE
CR-1155259: Fixed AIE status on AIE2 devices

### DIFF
--- a/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.cpp
+++ b/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.cpp
@@ -131,6 +131,7 @@ bool AIETraceOffload::setupPSKernel() {
   std::string msg = "The aie_trace_gmio PS kernel was successfully scheduled.";
   xrt_core::message::send(xrt_core::message::severity_level::info, "XRT", msg);
 
+  free(input_params); 
   bufferInitialized = true;
   return bufferInitialized;
 }

--- a/src/runtime_src/xdp/profile/plugin/aie_debug/aie_debug_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_debug/aie_debug_plugin.cpp
@@ -17,6 +17,10 @@
 
 #define XDP_SOURCE
 
+#include <boost/property_tree/json_parser.hpp>
+#include <boost/property_tree/ptree.hpp>
+#include <set>
+
 #include "xdp/profile/plugin/aie_debug/aie_debug_plugin.h"
 
 #include "xdp/profile/database/database.h"
@@ -31,8 +35,6 @@
 #include "core/common/config_reader.h"
 #include "core/include/experimental/xrt-next.h"
 #include "core/edge/user/shim.h"
-
-#include <set>
 
 namespace {
   static void* fetchAieDevInst(void* devHandle)
@@ -187,6 +189,7 @@ namespace xdp {
 
     // AIE core register offsets
     constexpr uint64_t AIE_OFFSET_CORE_STATUS = 0x32004;
+    auto offset = getAIETileRowOffset(handle);
 
     // This mask check for following states
     // ECC_Scrubbing_Stall
@@ -256,7 +259,7 @@ namespace xdp {
           // Read core status and PC value
           bool coreUnstalled = false;
           uint32_t coreStatus = 0;
-          auto tileOffset = _XAie_GetTileAddr(aieDevInst, tile.row + 1, tile.col);
+          auto tileOffset = _XAie_GetTileAddr(aieDevInst, tile.row + offset, tile.col);
           XAie_Read32(aieDevInst, tileOffset + AIE_OFFSET_CORE_STATUS, &coreStatus);
 
           auto& coreStallCounter = coreStuckCountMap[tile];
@@ -298,7 +301,7 @@ namespace xdp {
             uint8_t coreErrors0 = 0;
             uint8_t coreErrors1 = 0;
             uint8_t memErrors = 0;
-            auto loc = XAie_TileLoc(tile.col, tile.row + 1);
+            auto loc = XAie_TileLoc(tile.col, tile.row + offset);
             XAie_EventReadStatus(aieDevInst, loc, XAIE_CORE_MOD, 
               XAIE_EVENT_GROUP_ERRORS_0_CORE, &coreErrors0);
             XAie_EventReadStatus(aieDevInst, loc, XAIE_CORE_MOD, 
@@ -331,7 +334,7 @@ namespace xdp {
             // We have a stuck core within this graph
             warningMessage
             << "Potential stuck cores found in AI Engines. Graph : " << graphName << " "
-            << "Tile : " << "(" << stuckTile.col << "," << stuckTile.row + 1 << ") "
+            << "Tile : " << "(" << stuckTile.col << "," << stuckTile.row + offset << ") "
             << "Status 0x" << std::hex << stuckCoreStatus << std::dec
             << " : " << getCoreStatusString(stuckCoreStatus);
 
@@ -346,7 +349,7 @@ namespace xdp {
           for (const auto& tile : graphTilesVec) {
             if (coreStuckCountMap[tile]) {
               msg
-                << "T(" << tile.col <<"," << tile.row + 1 << "):" << "<" << coreStuckCountMap[tile]
+                << "T(" << tile.col <<"," << tile.row + offset << "):" << "<" << coreStuckCountMap[tile]
                 << ":0x" << std::hex << coreStatusMap[tile] << std::dec << "> ";
             }
           }
@@ -479,6 +482,32 @@ namespace xdp {
     mThreadCtrlMap.clear();
     mDeadlockThreadMap.clear();
     mDebugThreadMap.clear();
+  }
+
+  uint16_t AIEDebugPlugin::getAIETileRowOffset(void* handle)
+  {
+    static uint16_t rowOffset = 1;
+    static bool gotValue = false;
+    if (!gotValue) {
+      auto device = xrt_core::get_userpf_device(handle);
+      auto data = device->get_axlf_section(AIE_METADATA);
+      if (!data.first || !data.second) {
+        rowOffset = 1;
+      } else {
+        boost::property_tree::ptree aie_meta;
+        read_aie_metadata(data.first, data.second, aie_meta);
+        rowOffset = aie_meta.get_child("aie_metadata.driver_config.aie_tile_row_start").get_value<uint16_t>();
+      }
+      gotValue = true;
+    }
+    return rowOffset;
+  }
+
+  void AIEDebugPlugin::read_aie_metadata(const char* data, size_t size, boost::property_tree::ptree& aie_project)
+  {
+    std::stringstream aie_stream;
+    aie_stream.write(data,size);
+    boost::property_tree::read_json(aie_stream,aie_project);
   }
 
 } // end namespace xdp

--- a/src/runtime_src/xdp/profile/plugin/aie_debug/aie_debug_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_debug/aie_debug_plugin.h
@@ -18,6 +18,7 @@
 #define XDP_AIE_DEBUG_PLUGIN_DOT_H
 
 #include <atomic>
+#include <boost/property_tree/ptree.hpp>
 #include <iostream>
 #include <string>
 #include <thread>
@@ -57,6 +58,9 @@ namespace xdp {
     void getTilesForDebug(void* handle);
     void endPoll();
     std::string getCoreStatusString(uint32_t status);
+    uint16_t getAIETileRowOffset(void* handle);
+    static void read_aie_metadata(const char* data, size_t size, 
+                                  boost::property_tree::ptree& aie_project);
 
     // Threads used by this plugin
     void pollDeadlock(uint64_t index, void* handle);

--- a/src/runtime_src/xdp/profile/plugin/aie_debug/aie_debug_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_debug/aie_debug_plugin.h
@@ -61,7 +61,6 @@ namespace xdp {
     uint16_t getAIETileRowOffset(void* handle);
     static void read_aie_metadata(const char* data, size_t size, 
                                   boost::property_tree::ptree& aie_project);
-
     // Threads used by this plugin
     void pollDeadlock(uint64_t index, void* handle);
     void writeDebug(uint64_t index, void* handle, VPWriter* aieWriter, VPWriter* aieshimWriter);

--- a/src/runtime_src/xdp/profile/plugin/aie_trace_new/aie_trace_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace_new/aie_trace_metadata.cpp
@@ -914,7 +914,7 @@ namespace xdp {
     read_aie_metadata(data.first, data.second, aie_meta);
 
     aiecompiler_options aiecompiler_options;
-    aiecompiler_options.broadcast_enable_core = aie_meta.get<bool>("aie_metadata.aiecompiler_options.broadcast_enable_core");
+    aiecompiler_options.broadcast_enable_core = aie_meta.get("aie_metadata.aiecompiler_options.broadcast_enable_core", false);
     aiecompiler_options.event_trace = aie_meta.get("aie_metadata.aiecompiler_options.event_trace", "runtime");
     return aiecompiler_options;
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Fixed AIE status on AIE2 Devices

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1155259 found errors when running applications on AIE2 with aie_status = true

#### How problem was solved, alternative solutions (if any) and why they were rejected
Like in trace/profile, we now get the correct row offset based on AIE1 or AIE2 device.

#### What has been tested and how, request additional testing if necessary
Tested on AIE2 device with aie_status =true. 

#### Documentation impact (if any)
