### PR TITLE
VITIS-5914 - Bug fixes and move to latest implementation

### DIFF
--- a/src/runtime_src/core/common/asd_parser.cpp
+++ b/src/runtime_src/core/common/asd_parser.cpp
@@ -479,7 +479,7 @@ format_status(const std::vector<aie_tiles_status>& aie_status, uint32_t cols, co
               uint32_t cols_filled)
 {
   bpt::ptree pt_array;
-  uint16_t col_count = 0;
+  uint32_t col_count = 0;
 
   for (uint32_t col = 0; col < cols; col++) {
     // check if this col is filled else skip
@@ -575,7 +575,7 @@ format_status(const std::vector<aie_tiles_status>& aie_status, uint32_t cols, co
               uint32_t cols_filled)
 {
   bpt::ptree pt_array;
-  uint16_t col_count = 0;
+  uint32_t col_count = 0;
    
   for (uint32_t col = 0; col < cols; col++) {
     // check if this col is filled else skip
@@ -668,7 +668,7 @@ format_status(const std::vector<aie_tiles_status>& aie_status, uint32_t cols, co
               uint32_t cols_filled)
 {
   bpt::ptree pt_array;
-  uint16_t col_count = 0;
+  uint32_t col_count = 0;
   
   for (uint32_t col = 0; col < cols; col++) {
     // check if this col is filled else skip

--- a/src/runtime_src/core/common/asd_parser.cpp
+++ b/src/runtime_src/core/common/asd_parser.cpp
@@ -94,15 +94,16 @@ static constexpr uint8_t dma_queue_overflow = 0x1;
 static constexpr uint8_t dma_queue_size = 0x7;
 static constexpr uint8_t dma_current_bd = 0x3f;
 static constexpr uint8_t dma_default = 0x1;
+static constexpr uint8_t lock_mask = 0x3f;
 
 /* Internal Functions */
 static aie_dma_int 
 get_dma_mm2s_status(uint32_t status, aie_tile_type tile_type)
 {
-  aie_dma_int dma_status_int;
+  aie_dma_int dma_status_int{};
 
   for (auto flag = static_cast<u32>(dma_mm2s_status::xaie_dma_status_mm2s_status); 
-      flag <= static_cast<u32>(dma_mm2s_status::xaie_dma_status_mm2s_max); flag++) {
+      flag < static_cast<u32>(dma_mm2s_status::xaie_dma_status_mm2s_max); flag++) {
     // Below is for bits  8, 9, 10 in DMA_MM2S mem tile
     if ((tile_type != aie_tile_type::mem) && 
         ((flag == static_cast<u32>(dma_mm2s_status::xaie_dma_status_mm2s_error_lock_access_to_unavail)) || 
@@ -160,10 +161,10 @@ get_dma_mm2s_status(uint32_t status, aie_tile_type tile_type)
 static aie_dma_int 
 get_dma_s2mm_status(uint32_t status, aie_tile_type tile_type)
 {
-  aie_dma_int dma_status_int;
+  aie_dma_int dma_status_int{};
 
   for (auto flag = static_cast<u32>(dma_s2mm_status::xaie_dma_status_s2mm_status); 
-      flag <= static_cast<u32>(dma_s2mm_status::xaie_dma_status_s2mm_max); flag++) {
+      flag < static_cast<u32>(dma_s2mm_status::xaie_dma_status_s2mm_max); flag++) {
     // Below is for bits  8, 9 in DMA_S2MM mem tile
     if ((tile_type != aie_tile_type::mem) && 
         ((flag == static_cast<u32>(dma_s2mm_status::xaie_dma_status_s2mm_error_lock_access_to_unavail)) || 
@@ -241,16 +242,16 @@ populate_dma(const std::vector<aie_dma_status>& dma, aie_tile_type tile_type)
 
     std::string mm2s_channel_status = "";
     for (auto &status : dma_mm2s_status.channel_status)
-      mm2s_channel_status.append(status.append(","));
+      mm2s_channel_status.append(status.append(", "));
 
-    mm2s_channel_status.erase(mm2s_channel_status.length() - 1); //remove last comma
+    mm2s_channel_status.erase(mm2s_channel_status.length() - 2); //remove last comma
     channel_status_mm2s.put("", mm2s_channel_status);
 
     std::string s2mm_channel_status = "";
     for (auto &status : dma_s2mm_status.channel_status)
-      s2mm_channel_status.append(status.append(","));
+      s2mm_channel_status.append(status.append(", "));
 
-    s2mm_channel_status.erase(s2mm_channel_status.length() - 1); //remove last comma
+    s2mm_channel_status.erase(s2mm_channel_status.length() - 2); //remove last comma
     channel_status_s2mm.put("", s2mm_channel_status);
 
     channel_status_mm2s_array.push_back(std::make_pair("", channel_status_mm2s));
@@ -309,7 +310,7 @@ populate_locks(const std::vector<uint8_t>& locks)
     bpt::ptree lock;
     bpt::ptree lock_array;
       
-    lock.put("", locks[i]);
+    lock.put("", locks[i] & lock_mask);
     lock_array.push_back(std::make_pair("", lock));
 
     lock_pt.add_child(std::to_string(i), lock_array);
@@ -330,7 +331,7 @@ core_status_to_string_array(uint32_t status)
   }
 
   for (auto flag = static_cast<u32>(core_status::xaie_core_status_enable_bit); 
-      flag <= static_cast<u32>(core_status::xaie_core_status_max_bit); flag++) {
+      flag < static_cast<u32>(core_status::xaie_core_status_max_bit); flag++) {
     // check for set bits
     if (status & (1 << flag))
       status_vec.push_back(status_map[flag]);
@@ -359,7 +360,7 @@ size(aie_tiles_info& info)
 
 void
 aie_core_tile_status::
-parse_buf(char* buf, aie_tiles_info& info, std::vector<aie_tiles_status>& aie_status)
+parse_buf(const char* buf, aie_tiles_info& info, std::vector<aie_tiles_status>& aie_status)
 {
   for (auto &aie_col_status : aie_status) {
     for (auto &core : aie_col_status.core_tiles) {
@@ -430,19 +431,19 @@ get_core_tile_info(aie_core_tile_status& core)
   core_pt.add_child("status", status_array);
 
   // fill program counter as array
-  tmp.put("", core.program_counter);
+  tmp.put("", (boost::format("0x%08x") % core.program_counter).str());
   tmp_array.push_back(std::make_pair("", tmp));
   core_pt.add_child("pc", tmp_array);
 
   // fill stack pointer as array
   tmp_array = {};
-  tmp.put("", core.stack_ptr);
+  tmp.put("", (boost::format("0x%08x") % core.stack_ptr).str());
   tmp_array.push_back(std::make_pair("", tmp));
   core_pt.add_child("sp", tmp_array);
 
   // fill link register as array
   tmp_array = {};
-  tmp.put("", core.link_reg);
+  tmp.put("", (boost::format("0x%08x") % core.link_reg).str());
   tmp_array.push_back(std::make_pair("", tmp));
   core_pt.add_child("lr", tmp_array);
 
@@ -461,20 +462,26 @@ get_core_tile_info(aie_core_tile_status& core)
 
 bpt::ptree
 aie_core_tile_status::
-format_status(std::vector<aie_tiles_status>& aie_status, uint32_t start_col,
-              uint32_t cols, aie_tiles_info& tiles_info)
+format_status(std::vector<aie_tiles_status>& aie_status, uint32_t cols, aie_tiles_info& tiles_info,
+              uint32_t cols_filled)
 {
   bpt::ptree pt_array;
+  uint16_t col_count = 0;
 
-  for (uint32_t col = start_col; col < cols; col++) {
+  for (uint32_t col = 0; col < cols; col++) {
+    // check if this col is filled else skip
+    if (!(cols_filled & (1 << col)))
+      continue;
+
     for (uint32_t row = 0; row < tiles_info.core_rows; row++) {
-      bpt::ptree pt = get_core_tile_info(aie_status[col].core_tiles[row]);
+      bpt::ptree pt = get_core_tile_info(aie_status[col_count].core_tiles[row]);
       pt.put("col", col);
       pt.put("row", row + tiles_info.core_row_start);
 
       pt_array.push_back(std::make_pair(std::to_string(col) + "_" +
           std::to_string(row + tiles_info.core_row_start), pt));
     }
+    col_count++;
   }
 
   bpt::ptree pt_aie_core;
@@ -501,7 +508,7 @@ size(aie_tiles_info& info)
 
 void
 aie_mem_tile_status::
-parse_buf(char* buf, aie_tiles_info& info, std::vector<aie_tiles_status>& aie_status)
+parse_buf(const char* buf, aie_tiles_info& info, std::vector<aie_tiles_status>& aie_status)
 {
   for (auto &aie_col_status : aie_status) {
     // add core tiles offset
@@ -547,20 +554,26 @@ get_mem_tile_info(aie_mem_tile_status& mem)
 
 bpt::ptree
 aie_mem_tile_status::
-format_status(std::vector<aie_tiles_status>& aie_status, uint32_t start_col,
-              uint32_t cols, aie_tiles_info& tiles_info)
+format_status(std::vector<aie_tiles_status>& aie_status, uint32_t cols, aie_tiles_info& tiles_info,
+              uint32_t cols_filled)
 {
   bpt::ptree pt_array;
+  uint16_t col_count = 0;
    
-  for (uint32_t col = start_col; col < cols; col++) {
+  for (uint32_t col = 0; col < cols; col++) {
+    // check if this col is filled else skip
+    if (!(cols_filled & (1 << col)))
+      continue;
+
     for (uint32_t row = 0; row < tiles_info.mem_rows; row++) {
-      bpt::ptree pt = get_mem_tile_info(aie_status[col].mem_tiles[row]);
+      bpt::ptree pt = get_mem_tile_info(aie_status[col_count].mem_tiles[row]);
       pt.put("col", col);
       pt.put("row", row + tiles_info.mem_row_start);
 
       pt_array.push_back(std::make_pair(std::to_string(col) + "_" + 
           std::to_string(row + tiles_info.mem_row_start), pt));
     }
+    col_count++;
   }
     
   bpt::ptree pt_aie_mem;
@@ -587,12 +600,12 @@ size(aie_tiles_info& info)
 
 void
 aie_shim_tile_status::
-parse_buf(char* buf, aie_tiles_info& info, std::vector<aie_tiles_status>& aie_status)
+parse_buf(const char* buf, aie_tiles_info& info, std::vector<aie_tiles_status>& aie_status)
 {
   for (auto &aie_col_status : aie_status) {
     // add core tiles and mem tiles offsets
-    buf = buf + aie_core_tile_status::size(info) * info.core_rows + aie_mem_tile_status::size(info) * info.mem_rows;
-
+    buf = buf + aie_core_tile_status::size(info) * info.core_rows +
+        aie_mem_tile_status::size(info) * info.mem_rows;
     for (auto &shim : aie_col_status.shim_tiles) {
       // DMA status
       uint32_t size_cal = sizeof(aie_dma_status) * info.shim_dma_channels;
@@ -630,20 +643,26 @@ get_shim_tile_info(aie_shim_tile_status& shim)
 
 bpt::ptree
 aie_shim_tile_status::
-format_status(std::vector<aie_tiles_status>& aie_status, uint32_t start_col,
-              uint32_t cols, aie_tiles_info& tiles_info)
+format_status(std::vector<aie_tiles_status>& aie_status, uint32_t cols, aie_tiles_info& tiles_info,
+              uint32_t cols_filled)
 {
   bpt::ptree pt_array;
+  uint16_t col_count = 0;
   
-  for (uint32_t col = start_col; col < cols; col++) {
+  for (uint32_t col = 0; col < cols; col++) {
+    // check if this col is filled else skip
+    if (!(cols_filled & (1 << col)))
+      continue;
+
     for (uint32_t row = 0; row < tiles_info.shim_rows; row++) {
-      bpt::ptree pt = get_shim_tile_info(aie_status[col].shim_tiles[row]);
+      bpt::ptree pt = get_shim_tile_info(aie_status[col_count].shim_tiles[row]);
       pt.put("col", col);
       pt.put("row", row + tiles_info.shim_row_start);
 
       pt_array.push_back(std::make_pair(std::to_string(col) + "_" + 
                          std::to_string(row + tiles_info.shim_row_start), pt));
     }
+    col_count++;
   }
     
   bpt::ptree pt_aie_shim;
@@ -652,19 +671,16 @@ format_status(std::vector<aie_tiles_status>& aie_status, uint32_t start_col,
 }
 
 /* Common functions*/
-void
+static void
 aie_status_version_check(uint16_t& major_ver, uint16_t& minor_ver)
 {
   if (!((major_ver == asd_parser::aie_status_version_major) && (minor_ver == asd_parser::aie_status_version_minor)))
     throw std::runtime_error("Aie status version mismatch");
 }
 
-void
-aie_info_sanity_check(uint32_t start_col, uint32_t num_cols, aie_tiles_info& info)
+static void
+aie_info_sanity_check(aie_tiles_info& info)
 {
-  if ((start_col + num_cols) > info.cols)
-    throw std::runtime_error("Requested columns exceeds maximum available columns\n");
-
   if (info.col_size == 0)
     throw std::runtime_error("Getting Aie column size info from driver failed\n");
 
@@ -678,7 +694,17 @@ aie_info_sanity_check(uint32_t start_col, uint32_t num_cols, aie_tiles_info& inf
 }
 
 boost::property_tree::ptree
-get_formated_tiles_info(const xrt_core::device* device, aie_tile_type tile_type, aie_tiles_info& info)
+get_formated_tiles_info(const xrt_core::device* device, aie_tile_type tile_type)
+{
+  aie_tiles_info info{0};
+  uint32_t cols_filled = 0;
+
+  return get_formated_tiles_info(device, tile_type, info, cols_filled);
+}
+
+boost::property_tree::ptree
+get_formated_tiles_info(const xrt_core::device* device, aie_tile_type tile_type, aie_tiles_info& info,
+                        uint32_t& cols_filled)
 {
   // Get Aie status version and check compatibility
   auto version = xrt_core::device_query<xrt_core::query::aie_status_version>(device);
@@ -690,41 +716,39 @@ get_formated_tiles_info(const xrt_core::device* device, aie_tile_type tile_type,
   if (!((info.major == asd_parser::aie_tiles_info_version_major) && (info.minor == asd_parser::aie_tiles_info_version_minor)))
     throw std::runtime_error("version mismatch for aie_tiles_info structure");
 
-  // get all columns info for now 
-  // TODO: add argument in function to get start col and num of cols from user
-  uint16_t start_col = 0;
-  uint16_t num_cols = info.cols;
-
   // sanity checks
-  aie_info_sanity_check(start_col, num_cols, info);
+  aie_info_sanity_check(info);
   
   // Get Aie column status from driver
   xrt_core::query::aie_tiles_status_info::parameters arg{0};
-  arg.start_col = start_col;
-  arg.num_cols = num_cols;
+  arg.num_cols = info.cols;
   arg.col_size = info.col_size;
 
-  auto buf = xrt_core::device_query<xrt_core::query::aie_tiles_status_info>(device, arg);
+  auto tiles_status = xrt_core::device_query<xrt_core::query::aie_tiles_status_info>(device, arg);
+  cols_filled = tiles_status.cols_filled;
+
+  if (cols_filled == 0)
+    throw std::runtime_error("No open HW-Context\n");
 
   boost::property_tree::ptree pt;
   std::vector<asd_parser::aie_tiles_status> aie_status;
   // convert buffer into respective structure and format
   switch (tile_type) {
     case aie_tile_type::core :
-      aie_status = parse_data_from_buf<aie_core_tile_status>(buf.data(), info);
-      pt = format_aie_info<aie_core_tile_status>(aie_status, start_col, num_cols, info);
+      aie_status = parse_data_from_buf<aie_core_tile_status>(tiles_status.buf.data(), info, cols_filled);
+      pt = format_aie_info<aie_core_tile_status>(aie_status, info.cols, info, cols_filled);
 
       // fill version info for core tile which is used in top layer
       pt.put("schema_version.major", version.major);
       pt.put("schema_version.minor", version.minor);
       break;
     case aie_tile_type::shim :
-      aie_status = parse_data_from_buf<aie_core_tile_status>(buf.data(), info);
-      pt = format_aie_info<aie_core_tile_status>(aie_status, start_col, num_cols, info);
+      aie_status = parse_data_from_buf<aie_shim_tile_status>(tiles_status.buf.data(), info, cols_filled);
+      pt = format_aie_info<aie_shim_tile_status>(aie_status, info.cols, info, cols_filled);
       break;
     case aie_tile_type::mem :
-      aie_status = parse_data_from_buf<aie_core_tile_status>(buf.data(), info);
-      pt = format_aie_info<aie_core_tile_status>(aie_status, start_col, num_cols, info);
+      aie_status = parse_data_from_buf<aie_mem_tile_status>(tiles_status.buf.data(), info, cols_filled);
+      pt = format_aie_info<aie_mem_tile_status>(aie_status, info.cols, info, cols_filled);
       break;
     default :
       throw std::runtime_error("Unknown tile type in formatting Aie tiles status info");

--- a/src/runtime_src/core/common/asd_parser.h
+++ b/src/runtime_src/core/common/asd_parser.h
@@ -117,14 +117,14 @@ struct aie_core_tile_status
   // size of buffer and offsets info for various data fields is obtained
   // from tiles metadata(aie_tiles_info)
   static void
-  parse_buf(char* buf, aie_tiles_info& info, std::vector<aie_tiles_status>& aie_status);
+  parse_buf(const char* buf, aie_tiles_info& info, std::vector<aie_tiles_status>& aie_status);
 
   // Format the parsed buffer into ptree to be used by tools for reporting
   static boost::property_tree::ptree
   format_status(std::vector<aie_tiles_status>& aie_status,
-                uint32_t start_col,
                 uint32_t cols,
-                aie_tiles_info& tiles_info);
+                aie_tiles_info& tiles_info,
+                uint32_t cols_filled);
 };
   
 // Data structure to capture the mem tile status
@@ -153,14 +153,14 @@ struct aie_mem_tile_status
   // size of buffer and offsets info for various data fields is obtained
   // from tiles metadata(aie_tiles_info)
   static void
-  parse_buf(char* buf, aie_tiles_info& info, std::vector<aie_tiles_status>& aie_status);
+  parse_buf(const char* buf, aie_tiles_info& info, std::vector<aie_tiles_status>& aie_status);
 
   // Format the parsed buffer into ptree to be used by tools for reporting
   static boost::property_tree::ptree
   format_status(std::vector<aie_tiles_status>& aie_status,
-                uint32_t start_col,
                 uint32_t cols,
-                aie_tiles_info& tiles_info);
+                aie_tiles_info& tiles_info,
+                uint32_t cols_filled);
 };
   
 // Data structure to capture the shim tile status
@@ -189,14 +189,14 @@ struct aie_shim_tile_status
   // size of buffer and offsets info for various data fields is obtained
   // from tiles metadata(aie_tiles_info)
   static void
-  parse_buf(char* buf, aie_tiles_info& info, std::vector<aie_tiles_status>& aie_status);
+  parse_buf(const char* buf, aie_tiles_info& info, std::vector<aie_tiles_status>& aie_status);
 
   // Format the parsed buffer into ptree to be used by tools for reporting
   static boost::property_tree::ptree
   format_status(std::vector<aie_tiles_status>& aie_status,
-                uint32_t start_col,
                 uint32_t cols,
-                aie_tiles_info& tiles_info);
+                aie_tiles_info& tiles_info,
+                uint32_t cols_filled);
 };
 
 class aie_tiles_status
@@ -303,20 +303,23 @@ enum class dma_mm2s_status : uint32_t
   xaie_dma_status_mm2s_max
 };
 
-void
-aie_status_version_check(uint16_t& major_ver, uint16_t& minor_ver);
-
-void
-aie_info_sanity_check(uint32_t start_col, uint32_t num_cols, aie_tiles_info& info);
-
 template <typename tile_type>
 std::vector<aie_tiles_status>
-parse_data_from_buf(char* buf, aie_tiles_info& info)
+parse_data_from_buf(const char* buf, aie_tiles_info& info, uint32_t cols_filled)
 {
   std::vector<aie_tiles_status> aie_status;
-  aie_status.reserve(info.cols);
+  uint16_t cols_count = 0;
 
-  for (uint32_t i = 0; i < info.cols; i++) {
+  while (cols_filled) {
+    if (cols_filled & 0x1)
+      ++cols_count;
+
+    cols_filled = cols_filled >> 1;
+  }
+
+  aie_status.reserve(cols_count);
+
+  for (uint32_t i = 0; i < cols_count; i++) {
     aie_status.emplace_back(info);
   }
 
@@ -327,15 +330,19 @@ parse_data_from_buf(char* buf, aie_tiles_info& info)
 template <typename tile_type>
 boost::property_tree::ptree
 format_aie_info(std::vector<aie_tiles_status>& aie_status,
-                uint32_t start_col,
                 uint32_t cols,
-                aie_tiles_info& tiles_info)
+                aie_tiles_info& tiles_info,
+                uint32_t cols_filled)
 {
-  return tile_type::format_status(aie_status, start_col, cols, tiles_info);
+  return tile_type::format_status(aie_status, cols, tiles_info, cols_filled);
 }
 
 boost::property_tree::ptree
-get_formated_tiles_info(const xrt_core::device* device, aie_tile_type tile_type, aie_tiles_info& info); 
+get_formated_tiles_info(const xrt_core::device* device, aie_tile_type tile_type, aie_tiles_info& info,
+                        uint32_t& cols_filled);
+
+boost::property_tree::ptree
+get_formated_tiles_info(const xrt_core::device* device, aie_tile_type tile_type);
 } // asd_parser
 
 #endif

--- a/src/runtime_src/core/common/asd_parser.h
+++ b/src/runtime_src/core/common/asd_parser.h
@@ -104,7 +104,7 @@ struct aie_core_tile_status
 
   // Get the size of this structure using aie tiles metadata
   static uint64_t
-  size(aie_tiles_info& info);
+  size(const aie_tiles_info& info);
 
   // Retrieve corresponding tile type enum value
   static inline aie_tile_type
@@ -117,13 +117,13 @@ struct aie_core_tile_status
   // size of buffer and offsets info for various data fields is obtained
   // from tiles metadata(aie_tiles_info)
   static void
-  parse_buf(const char* buf, aie_tiles_info& info, std::vector<aie_tiles_status>& aie_status);
+  parse_buf(const std::vector<char>& buf, const aie_tiles_info& info, std::vector<aie_tiles_status>& aie_status);
 
   // Format the parsed buffer into ptree to be used by tools for reporting
   static boost::property_tree::ptree
-  format_status(std::vector<aie_tiles_status>& aie_status,
+  format_status(const std::vector<aie_tiles_status>& aie_status,
                 uint32_t cols,
-                aie_tiles_info& tiles_info,
+                const aie_tiles_info& tiles_info,
                 uint32_t cols_filled);
 };
   
@@ -140,7 +140,7 @@ struct aie_mem_tile_status
 
   // Get the size of this structure using aie tiles metadata
   static uint64_t
-  size(aie_tiles_info& info);
+  size(const aie_tiles_info& info);
 
   // Retrieve corresponding tile type enum value
   static inline aie_tile_type
@@ -153,13 +153,13 @@ struct aie_mem_tile_status
   // size of buffer and offsets info for various data fields is obtained
   // from tiles metadata(aie_tiles_info)
   static void
-  parse_buf(const char* buf, aie_tiles_info& info, std::vector<aie_tiles_status>& aie_status);
+  parse_buf(const std::vector<char>& buf, const aie_tiles_info& info, std::vector<aie_tiles_status>& aie_status);
 
   // Format the parsed buffer into ptree to be used by tools for reporting
   static boost::property_tree::ptree
-  format_status(std::vector<aie_tiles_status>& aie_status,
+  format_status(const std::vector<aie_tiles_status>& aie_status,
                 uint32_t cols,
-                aie_tiles_info& tiles_info,
+                const aie_tiles_info& tiles_info,
                 uint32_t cols_filled);
 };
   
@@ -176,7 +176,7 @@ struct aie_shim_tile_status
 
   // Get the size of this structure using aie tiles metadata
   static uint64_t
-  size(aie_tiles_info& info);
+  size(const aie_tiles_info& info);
 
    // Retrieve corresponding tile type enum value
   static inline aie_tile_type
@@ -189,13 +189,13 @@ struct aie_shim_tile_status
   // size of buffer and offsets info for various data fields is obtained
   // from tiles metadata(aie_tiles_info)
   static void
-  parse_buf(const char* buf, aie_tiles_info& info, std::vector<aie_tiles_status>& aie_status);
+  parse_buf(const std::vector<char>& buf, const aie_tiles_info& info, std::vector<aie_tiles_status>& aie_status);
 
   // Format the parsed buffer into ptree to be used by tools for reporting
   static boost::property_tree::ptree
-  format_status(std::vector<aie_tiles_status>& aie_status,
+  format_status(const std::vector<aie_tiles_status>& aie_status,
                 uint32_t cols,
-                aie_tiles_info& tiles_info,
+                const aie_tiles_info& tiles_info,
                 uint32_t cols_filled);
 };
 
@@ -206,7 +206,7 @@ class aie_tiles_status
   std::vector<aie_mem_tile_status> mem_tiles;
   std::vector<aie_shim_tile_status> shim_tiles;
   
-  aie_tiles_status(aie_tiles_info& stats)
+  aie_tiles_status(const aie_tiles_info& stats)
   {
     core_tiles.resize(stats.core_rows);
     mem_tiles.resize(stats.mem_rows);
@@ -305,7 +305,7 @@ enum class dma_mm2s_status : uint32_t
 
 template <typename tile_type>
 std::vector<aie_tiles_status>
-parse_data_from_buf(const char* buf, aie_tiles_info& info, uint32_t cols_filled)
+parse_data_from_buf(const std::vector<char>& buf, const aie_tiles_info& info, uint32_t cols_filled)
 {
   std::vector<aie_tiles_status> aie_status;
   uint16_t cols_count = 0;
@@ -329,9 +329,9 @@ parse_data_from_buf(const char* buf, aie_tiles_info& info, uint32_t cols_filled)
 
 template <typename tile_type>
 boost::property_tree::ptree
-format_aie_info(std::vector<aie_tiles_status>& aie_status,
+format_aie_info(const std::vector<aie_tiles_status>& aie_status,
                 uint32_t cols,
-                aie_tiles_info& tiles_info,
+                const aie_tiles_info& tiles_info,
                 uint32_t cols_filled)
 {
   return tile_type::format_status(aie_status, cols, tiles_info, cols_filled);

--- a/src/runtime_src/core/common/info_aie.cpp
+++ b/src/runtime_src/core/common/info_aie.cpp
@@ -279,9 +279,8 @@ populate_aie_shim(const xrt_core::device *device, const std::string& desc)
   }
 
   try {
-    asd_parser::aie_tiles_info tiles_info{0};
     // On Pcie platforms use driver calls to get AIE Shim info
-    pt_shim = asd_parser::get_formated_tiles_info(device, asd_parser::aie_tile_type::shim, tiles_info);
+    pt_shim = asd_parser::get_formated_tiles_info(device, asd_parser::aie_tile_type::shim);
   }
   catch (const xrt_core::query::no_such_key&) {
     // Not Pcie device
@@ -364,9 +363,8 @@ populate_aie_mem(const xrt_core::device* device, const std::string& desc)
   }
 
   try {
-    asd_parser::aie_tiles_info tiles_info{0};
     // On Pcie platforms use driver calls to get AIE mem info
-    pt_mem = asd_parser::get_formated_tiles_info(device, asd_parser::aie_tile_type::mem, tiles_info);
+    pt_mem = asd_parser::get_formated_tiles_info(device, asd_parser::aie_tile_type::mem);
   }
   catch (const xrt_core::query::no_such_key&) {
     // Not Pcie device
@@ -868,10 +866,16 @@ populate_aie_helper(const xrt_core::device* device, boost::property_tree::ptree&
   try {
     boost::property_tree::ptree tile_array;
     asd_parser::aie_tiles_info tiles_info{0};
+    uint32_t cols_filled = 0;
 
-    core_info = asd_parser::get_formated_tiles_info(device, asd_parser::aie_tile_type::core, tiles_info);
+    core_info = asd_parser::get_formated_tiles_info(device, asd_parser::aie_tile_type::core, tiles_info,
+                                                    cols_filled);
 
     for (uint16_t col = 0; col < tiles_info.cols; col++) {
+      // skip this col if not filled
+      if (!(cols_filled & (1 << col)))
+        continue;
+
       for (uint16_t row = tiles_info.core_row_start; row < tiles_info.core_row_start + tiles_info.core_rows; row++) {
         boost::property_tree::ptree tile;
         tile.put("column", col);

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -1372,7 +1372,13 @@ struct aie_tiles_status_info : request
     uint16_t num_cols;
   };
 
-  using result_type = std::vector<char>;
+  struct result
+  {
+    std::vector<char> buf;
+    uint32_t cols_filled;
+  };
+
+  using result_type = result;
   static const key_type key = key_type::aie_tiles_status_info;
 
   virtual boost::any

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -918,7 +918,7 @@ struct aie_tiles_stats
   get(const xrt_core::device* device, key_type key)
   {
     uint32_t size = sizeof(result_type);
-    std::vector<char> buf(size, 0);
+    std::vector<char> buf(size);
 
     // TODO : Add code to get the data
 
@@ -938,11 +938,14 @@ struct aie_tiles_status_info
     uint32_t cols_filled = 0;
     uint32_t buf_size = data.col_size * data.num_cols;
 
-    std::vector<char> buf(buf_size, 0);
+    std::vector<char> buf(buf_size);
 
     // TODO : Add code to get the data and cols filled info
+    result_type output;
+    output.buf = buf;
+    output.cols_filled = cols_filled;
 
-    return { .buf = buf, .cols_filled = cols_filled };
+    return output;
   }
 };
 

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -929,18 +929,20 @@ struct aie_tiles_stats
 // structure to get aie tiles status raw buffer
 struct aie_tiles_status_info
 {
-  using result_type = boost::any;
+  using result_type = xrt_core::query::aie_tiles_status_info::result_type;
 
   static result_type
   get(const xrt_core::device* device, key_type key, const boost::any& param)
   {
     auto data = boost::any_cast<xrt_core::query::aie_tiles_status_info::parameters>(param);
+    uint32_t cols_filled = 0;
+    uint32_t buf_size = data.col_size * data.num_cols;
 
-    std::vector<char> buf(data.col_size * data.num_cols, 0);
+    std::vector<char> buf(buf_size, 0);
 
-    // TODO : Add code to get the data
+    // TODO : Add code to get the data and cols filled info
 
-    return buf;
+    return {buf, cols_filled};
   }
 };
 

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -942,7 +942,7 @@ struct aie_tiles_status_info
 
     // TODO : Add code to get the data and cols filled info
 
-    return {buf, cols_filled};
+    return { .buf = buf, .cols_filled = cols_filled };
   }
 };
 

--- a/src/runtime_src/core/tools/common/ReportAieMem.h
+++ b/src/runtime_src/core/tools/common/ReportAieMem.h
@@ -9,7 +9,7 @@
 
 class ReportAieMem : public Report {
  public:
-  ReportAieMem() : Report("aie_mem", "AIE memory tile information", true /*deviceRequired*/) { /*empty*/ };
+  ReportAieMem() : Report("aiemem", "AIE memory tile information", true /*deviceRequired*/) { /*empty*/ };
 
  // Child methods that need to be implemented
  public:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Fixed coverity issues and bugs related to printing reports
Driver now returns buffer filled and cols used information when we query for aie tiles status, made changes according to that

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Iterating over cols_filled bit map and parsing buffer for only those columns

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
Tested on IPU and was able to print aie core, mem and shim tiles

#### Documentation impact (if any)
NA