### PR TITLE
Support hardware queue dependencies

### DIFF
--- a/src/runtime_src/core/common/api/fence.h
+++ b/src/runtime_src/core/common/api/fence.h
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+#include "xrt/detail/pimpl.h"
+#include "core/common/shim/fence_handle.h"
+
+namespace xrt_core {
+
+// class fence - internal representation of a managed fence_handle
+class fence : public xrt::detail::pimpl<fence_handle>
+{
+public:
+  // Default empty fence
+  fence() = default;
+
+  // Construct from fence_handle.  The ownership is transferred
+  // and managed by this fence object.
+  fence(std::unique_ptr<fence_handle> hdl)
+    : pimpl(std::move(hdl))
+  {}
+
+  // Wait for the fence to be signaled.  Once signaled, a fence
+  // remains signaled until it is deleted.
+  void
+  wait(uint32_t timeout_ms) const
+  {
+    get_handle()->wait(timeout_ms);
+  }
+
+  // Get the underlying fence handle as a cast.
+  // This simplies conversion of container of fence to
+  // container of underlying handles.
+  operator fence_handle* () const
+  {
+    return get_handle().get();
+  }
+};
+
+}

--- a/src/runtime_src/core/common/api/hw_queue.h
+++ b/src/runtime_src/core/common/api/hw_queue.h
@@ -8,6 +8,7 @@
 
 #include <chrono>
 #include <condition_variable>
+#include <vector>
 
 namespace xrt {
 class hw_context;
@@ -17,6 +18,7 @@ namespace xrt_core {
 
 class command;
 class device;
+class fence;
 
 // class hw_queue - internal representation of hw queue for scheduling
 //
@@ -58,6 +60,14 @@ public:
   // and unmanaged commands.
   std::cv_status
   wait(const xrt_core::command* cmd, const std::chrono::milliseconds& timeout_ms) const;
+
+  // Enqueue a command returning a fence that can be waited on
+  xrt_core::fence
+  enqueue(xrt_core::command* cmd);
+
+  // Enqueue a command with dependencies
+  xrt_core::fence
+  enqueue(xrt_core::command* cmd, const std::vector<xrt_core::fence>& waits);
 
   // Wait for one call to exec_wait to return either from
   // some command completing or from a timeout.

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2020-2022 Xilinx, Inc. All rights reserved.
-// Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
 
 // This file implements XRT kernel APIs as declared in
 // core/include/experimental/xrt_kernel.h
@@ -21,6 +21,7 @@
 #include "command.h"
 #include "context_mgr.h"
 #include "device_int.h"
+#include "fence.h"
 #include "handle.h"
 #include "hw_context_int.h"
 #include "hw_queue.h"
@@ -882,6 +883,24 @@ public:
     }
 
     return {get_state_raw(), std::cv_status::no_timeout};
+  }
+
+  xrt_core::fence
+  enqueue(const std::vector<xrt_core::fence>& waits)
+  {
+    {
+      std::lock_guard<std::mutex> lk(m_mutex);
+      if (!m_done)
+        throw std::runtime_error("bad command state, can't enqueue");
+      m_managed = m_done = false;
+    }
+    return m_hwqueue.enqueue(this, waits);
+  }
+
+  xrt_core::fence
+  enqueue()
+  {
+    return enqueue({});
   }
 
   ////////////////////////////////////////////////////////////////
@@ -1952,9 +1971,11 @@ class run_impl
   using callback_function_type = std::function<void(ert_cmd_state)>;
   std::shared_ptr<kernel_impl> kernel;    // shared ownership
   std::vector<ipctx> ips;                 // ips controlled by this run object
+  std::vector<xrt_core::fence> m_waits;   // fence lifetime management
   std::bitset<max_cus> cumask;            // cumask for command execution
   xrt_core::device* core_device;          // convenience, in scope of kernel
   std::shared_ptr<kernel_command> cmd;    // underlying command object
+  xrt_core::fence m_fence;                // fence for current invocation
   uint32_t* data;                         // command argument data payload @0x0
   uint32_t uid;                           // internal unique id for debug
   std::unique_ptr<arg_setter> asetter;    // helper to populate payload data
@@ -2035,6 +2056,12 @@ public:
   get_kernel() const
   {
     return kernel.get();
+  }
+
+  xrt_core::fence
+  get_fence() const
+  {
+    return m_fence;
   }
 
   template <typename ERT_COMMAND_TYPE>
@@ -2180,9 +2207,8 @@ public:
     encode_cumasks = false;
   }
 
-  // start() - start the run object (execbuf)
-  virtual void
-  start()
+  void
+  prep_start()
   {
     encode_compute_units();
 
@@ -2190,7 +2216,13 @@ public:
     pkt->state = ERT_CMD_STATE_NEW;
 
     XRT_DEBUG_CALL(debug_cmd_packet(kernel->get_name(), pkt));
+  }
 
+  // start() - start the run object (execbuf)
+  virtual void
+  start()
+  {
+    prep_start();
     cmd->run();
   }
 
@@ -2208,6 +2240,21 @@ public:
       value = std::numeric_limits<uint32_t>::max();
     set_offset_value(mailbox_auto_restart_cntr, &value, sizeof(value));
     start();
+  }
+
+  void
+  enqueue()
+  {
+    prep_start();
+    m_fence = cmd->enqueue();
+  }
+
+  void
+  enqueue(const std::vector<xrt_core::fence>& waits)
+  {
+    prep_start();
+    m_waits = waits;
+    m_fence = cmd->enqueue(m_waits);
   }
 
   void
@@ -3032,6 +3079,23 @@ run::
 start(const autostart& iterations)
 {
   handle->start(iterations);
+}
+
+void
+run::
+enqueue()
+{
+  handle->enqueue();
+}
+
+void
+run::
+enqueue(const std::vector<run>& waits)
+{
+  std::vector<xrt_core::fence> fence_waits;
+  std::transform(waits.begin(), waits.end(), std::back_inserter(fence_waits),
+                 [](auto& r) { return r.get_handle()->get_fence(); });
+  handle->enqueue(fence_waits);
 }
 
 void

--- a/src/runtime_src/core/common/shim/buffer_handle.h
+++ b/src/runtime_src/core/common/shim/buffer_handle.h
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+#ifndef XRT_CORE_BUFFER_HANDLE_H
+#define XRT_CORE_BUFFER_HANDLE_H
+
+#include "xrt.h"  // for xrt_buffer_handle
+
+namespace xrt_core {
+
+// To be converted into a class
+using buffer_handle = void;
+
+} // xrt_core
+
+#endif

--- a/src/runtime_src/core/common/shim/fence_handle.h
+++ b/src/runtime_src/core/common/shim/fence_handle.h
@@ -3,6 +3,8 @@
 #ifndef XRT_CORE_FENCE_HANDLE_H
 #define XRT_CORE_FENCE_HANDLE_H
 
+#include <cstdint>
+
 namespace xrt_core {
 
 // class fence_handle - shim base class for fence

--- a/src/runtime_src/core/common/shim/fence_handle.h
+++ b/src/runtime_src/core/common/shim/fence_handle.h
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+#ifndef XRT_CORE_FENCE_HANDLE_H
+#define XRT_CORE_FENCE_HANDLE_H
+
+namespace xrt_core {
+
+// class fence_handle - shim base class for fence
+//
+// Shim level implementation derives off this class to support
+// fence synchronization objects
+//
+// A fence is associated with a command submission to a hw queue.  It
+// is signaled upon command completion and remains signaled until the
+// fence is deleted.
+class fence_handle
+{
+  // Flags that indicate what kind of fence to create
+public:
+  enum class flags { tbd };
+
+#ifdef _WIN32
+  using export_handle = void*;
+#else
+  using export_handle = int;
+#endif
+
+public:
+  // Destruction must destroy the underlying hardware queue
+  virtual ~fence_handle()
+  {}
+
+  // Export a fence for use with another process or device
+  // An exported fence can be imported by a hwqueue.
+  virtual export_handle
+  export_fence() = 0;
+
+  // Wait for a fence to be signaled
+  // This is a blocking call
+  virtual void
+  wait(uint32_t timeout_ms) const = 0;
+};
+
+} // xrt_core
+#endif

--- a/src/runtime_src/core/common/shim/hwqueue_handle.h
+++ b/src/runtime_src/core/common/shim/hwqueue_handle.h
@@ -6,6 +6,8 @@
 #include "buffer_handle.h"
 #include "fence_handle.h"
 
+#include <cstdint>
+#include <memory>
 #include <stdexcept>
 #include <vector>
 

--- a/src/runtime_src/core/common/shim/hwqueue_handle.h
+++ b/src/runtime_src/core/common/shim/hwqueue_handle.h
@@ -3,7 +3,11 @@
 #ifndef XRT_CORE_HWQUEUE_HANDLE_H
 #define XRT_CORE_HWQUEUE_HANDLE_H
 
-#include "xrt.h"
+#include "buffer_handle.h"
+#include "fence_handle.h"
+
+#include <stdexcept>
+#include <vector>
 
 namespace xrt_core {
 
@@ -14,15 +18,13 @@ namespace xrt_core {
 class hwqueue_handle
 {
 public:
-
   // Destruction must destroy the underlying hardware queue
   virtual ~hwqueue_handle()
   {}
 
-
   // Submit command for execution
   virtual void
-  submit_command(xrt_buffer_handle cmd) = 0;
+  submit_command(buffer_handle* cmd) = 0;
 
   // Wait for command completion.
   //
@@ -33,7 +35,38 @@ public:
   // If cmd buffer handle is nullptr, then this function is supposed to wait
   // until any command completes execution.
   virtual int
-  wait_command(xrt_buffer_handle cmd, uint32_t timeout_ms) const = 0;
+  wait_command(buffer_handle* cmd, uint32_t timeout_ms) const = 0;
+
+  // Enqueue a command
+  //
+  // @cmd      Handle to command to enqueue
+  // @return   Fence handle with ownership passed to caller
+  virtual std::unique_ptr<fence_handle>
+  enqueue_command(buffer_handle*)
+  {
+    throw std::runtime_error("not supported");
+  }
+
+  // Enqueue a command along with its dependencies.
+  //
+  // @cmd      Handle to command to enqueue
+  // @waits    List of fence handles that must be signaled prior to execution
+  // @return   Fence handle with ownership passed to caller
+  virtual std::unique_ptr<fence_handle>
+  enqueue_command(buffer_handle*, const std::vector<fence_handle*>&)
+  {
+    throw std::runtime_error("not supported");
+  }
+
+  // Import a fence handle that has been exported from another process
+  // or device.  The imported handle is converted into a fence_handle
+  // with ownership passed to caller.  The imported fence handle can be
+  // used as a dependency with enqueue.
+  virtual std::unique_ptr<fence_handle>
+  import(fence_handle::export_handle)
+  {
+    throw std::runtime_error("not supported");
+  }
 };
 
 } // xrt_core

--- a/src/runtime_src/core/include/xrt/xrt_kernel.h
+++ b/src/runtime_src/core/include/xrt/xrt_kernel.h
@@ -324,6 +324,17 @@ public:
     wait2(std::chrono::milliseconds{0});
   }
 
+  /// @cond
+  /// Experimental in 2023.1
+  XCL_DRIVER_DLLESPEC
+  void
+  enqueue();
+
+  XCL_DRIVER_DLLESPEC
+  void
+  enqueue(const std::vector<run>& waits);
+  /// @endcond
+
   /**
    * state() - Check the current state of a run object
    *


### PR DESCRIPTION
#### Problem solved by the commit
- Add xrt_core::fence and xrt_core::fence_handle internal classes
- Add xrt::run::enqueue() with and without dependencies

#### How problem was solved, alternative solutions (if any) and why they were rejected
New methods xrt::run::enqueue() allows a run object to be enqueued with a dependency on other run objects.  A dependency on a run object is possible only if that run object has itself been enqueued().  In other words, legacy xrt::run::start() has not been changed and a run object started this way cannot be used as dependency on another run object submission.

Basic usage is something like this:
```
xrt::run r1{...};
xrt::run r2{...}
r1.enqueue();
r2.enqueue({r1});  // can be list of dependencies.
```

The second run object is enqueue on hw queue prior to r1 completing execution.

#### Risks (if any) associated the changes in the commit
New flow, no particular risk

