### PR TITLE
CID271556 untrusted loop bound

### DIFF
--- a/src/runtime_src/core/common/xclbin_parser.cpp
+++ b/src/runtime_src/core/common/xclbin_parser.cpp
@@ -868,7 +868,7 @@ get_aie_partition(const axlf* top)
     auto aiepdip = reinterpret_cast<const aie_pdi*>(topbase + aiep->aie_pdi.offset + i * sizeof(aie_pdi));
 
     if (aiepdip->pdi_image.size > PDI_IMAGE_MAX_SIZE)
-      return {};
+      throw std::runtime_error("PDI image size too big");
 
     pdiobj.uuid = aiepdip->uuid;
     pdiobj.pdi.resize(aiepdip->pdi_image.size);

--- a/src/runtime_src/core/common/xclbin_parser.cpp
+++ b/src/runtime_src/core/common/xclbin_parser.cpp
@@ -867,6 +867,9 @@ get_aie_partition(const axlf* top)
     aie_pdi_obj pdiobj;
     auto aiepdip = reinterpret_cast<const aie_pdi*>(topbase + aiep->aie_pdi.offset + i * sizeof(aie_pdi));
 
+    if (aiepdip->pdi_image.size > PDI_IMAGE_MAX_SIZE)
+      return {};
+
     pdiobj.uuid = aiepdip->uuid;
     pdiobj.pdi.resize(aiepdip->pdi_image.size);
     memcpy(pdiobj.pdi.data(), topbase + aiepdip->pdi_image.offset, pdiobj.pdi.size());

--- a/src/runtime_src/core/include/xclbin.h
+++ b/src/runtime_src/core/include/xclbin.h
@@ -572,7 +572,8 @@ extern "C" {
     XCLBIN_STATIC_ASSERT(sizeof(struct cdo_group) == 96, "cdo_group structure no longer is 96 bytes in size");
     XCLBIN_STATIC_ASSERT(sizeof(struct cdo_group) % sizeof(uint64_t) == 0, "cdo_group structure needs to be 64-bit word aligned");
 
-
+    // 32KB per tile, 64 rows * 64 columns
+    #define PDI_IMAGE_MAX_SIZE 32*1024*64*64
     struct aie_pdi {
         xuid_t uuid;                        // PDI container UUID (16 bytes)
         struct array_offset pdi_image;      // PDI Image (uint8_t)


### PR DESCRIPTION
#### Problem solved by the commit
Untrusted loop bound, unscrutinized value used as a loop bound
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Coverity
