### PR TITLE
CR-1155266: MEM tile profiling is not showing up in table or graphs

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_profile_new/aie_profile_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile_new/aie_profile_metadata.cpp
@@ -821,7 +821,7 @@ namespace xdp {
       } catch (std::invalid_argument const &e) {
         // 2nd style but expected min column is not an integer, give warning and skip 
         xrt_core::message::send(severity_level::warning, "XRT", 
-            "Minimum column specification in tile_based_interface_tile_metrics is not an integer and hence skipped.");
+           "Minimum column specification in tile_based_interface_tile_metrics is not an integer and hence skipped.");
         continue;
       }
 
@@ -832,7 +832,7 @@ namespace xdp {
         } catch (std::invalid_argument const &e) {
           // Expected channel Id is not an integer, give warning and ignore channelId
           xrt_core::message::send(severity_level::warning, "XRT", 
-              "Channel ID specification in tile_based_interface_tile_metrics is not an integer and hence ignored.");
+             "Channel ID specification in tile_based_interface_tile_metrics is not an integer and hence ignored.");
           channelId = -1;
         }
       }
@@ -862,7 +862,7 @@ namespace xdp {
         } catch (std::invalid_argument const &e) {
           // Expected column specification is not a number. Give warning and skip
           xrt_core::message::send(severity_level::warning, "XRT", 
-            "Column specification in tile_based_interface_tile_metrics is not an integer and hence skipped.");
+             "Column specification in tile_based_interface_tile_metrics is not an integer and hence skipped.");
           continue;
         }
 
@@ -873,7 +873,7 @@ namespace xdp {
           } catch (std::invalid_argument const &e) {
             // Expected channel Id is not an integer, give warning and ignore channelId
             xrt_core::message::send(severity_level::warning, "XRT", 
-              "Channel ID specification in tile_based_interface_tile_metrics is not an integer and hence ignored.");
+               "Channel ID specification in tile_based_interface_tile_metrics is not an integer and hence ignored.");
             channelId = -1;
           }
         }
@@ -885,7 +885,7 @@ namespace xdp {
           configMetrics[moduleIdx][t] = metrics[i][1];
         }
       }
-    } // Pass 3
+    } // Pass 3 
 
     // Set default, check validity, and remove "off" tiles
     auto defaultSet = defaultSets[moduleIdx];

--- a/src/runtime_src/xdp/profile/plugin/aie_profile_new/aie_profile_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile_new/aie_profile_metadata.cpp
@@ -431,7 +431,7 @@ namespace xdp {
                                                const std::vector<std::string>& graphMetricsSettings,
                                                const module_type mod)
   {
-    if ((metricsSettings.empty()) && (graphMetricsSettings.empty()))
+    if ((metricsSettings.empty()) && (graphMetricsSettings.empty())) 
       return;
     if ((getHardwareGen() == 1) && (mod == module_type::mem_tile)) {
       xrt_core::message::send(severity_level::warning, "XRT",
@@ -619,7 +619,7 @@ namespace xdp {
         maxRow = std::stoi(maxTile[1]) + rowOffset;
       } catch (...) {
         xrt_core::message::send(severity_level::warning, "XRT", 
-            "Tile range specification in tile_based_aie_[memory}_metrics is not of valid format and hence skipped.");
+           "Tile range specification in tile_based_aie_[memory}_metrics is not of valid format and hence skipped.");
         continue;
       }
 

--- a/src/runtime_src/xdp/profile/plugin/aie_profile_new/aie_profile_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile_new/aie_profile_metadata.cpp
@@ -725,7 +725,7 @@ namespace xdp {
           xrt_core::message::send(severity_level::warning, "XRT", msg.str());
         }
       }
-    } // Pass 3
+    } // Pass 3 
 
     // Set default, check validity, and remove "off" tiles
     auto defaultSet = defaultSets[moduleIdx];
@@ -769,7 +769,7 @@ namespace xdp {
                                                         const std::vector<std::string>& metricsSettings,
                                                         const std::vector<std::string> graphMetricsSettings)
   {
-    if ((metricsSettings.empty()) && (graphMetricsSettings.empty()))
+    if ((metricsSettings.empty()) && (graphMetricsSettings.empty())) 
       return;
 
     std::shared_ptr<xrt_core::device> device = xrt_core::get_userpf_device(handle);

--- a/src/runtime_src/xdp/profile/plugin/aie_profile_new/aie_profile_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile_new/aie_profile_metadata.cpp
@@ -431,7 +431,7 @@ namespace xdp {
                                                const std::vector<std::string>& graphMetricsSettings,
                                                const module_type mod)
   {
-    if (metricsSettings.empty() && graphMetricsSettings.empty())
+    if ((metricsSettings.empty()) && (graphMetricsSettings.empty()))
       return;
     if ((getHardwareGen() == 1) && (mod == module_type::mem_tile)) {
       xrt_core::message::send(severity_level::warning, "XRT",
@@ -619,7 +619,7 @@ namespace xdp {
         maxRow = std::stoi(maxTile[1]) + rowOffset;
       } catch (...) {
         xrt_core::message::send(severity_level::warning, "XRT", 
-          "Tile range specification in tile_based_aie_[memory}_metrics is not of valid format and hence skipped.");
+            "Tile range specification in tile_based_aie_[memory}_metrics is not of valid format and hence skipped.");
         continue;
       }
 
@@ -769,7 +769,7 @@ namespace xdp {
                                                         const std::vector<std::string>& metricsSettings,
                                                         const std::vector<std::string> graphMetricsSettings)
   {
-    if (metricsSettings.empty() && graphMetricsSettings.empty())
+    if ((metricsSettings.empty()) && (graphMetricsSettings.empty()))
       return;
 
     std::shared_ptr<xrt_core::device> device = xrt_core::get_userpf_device(handle);
@@ -784,7 +784,7 @@ namespace xdp {
      * Range of tiles
      * tile_based_interface_tile_metrics = [<mincolumn>:<maxcolumn>:<off|input_throughputs|output_throughputs|packets>[:<channel>]]]
      */
-    
+
     std::vector<std::vector<std::string>> metrics(metricsSettings.size());
 
     // Pass 1 : process only "all" metric setting 
@@ -793,7 +793,7 @@ namespace xdp {
       boost::split(metrics[i], metricsSettings[i], boost::is_any_of(":"));
 
       if (metrics[i][0].compare("all") != 0)
-      continue;
+        continue;
 
       int16_t channelId = (metrics[i].size() < 3) ? -1 : std::stoi(metrics[i][2]);
       auto tiles = get_interface_tiles(device.get(), metrics[i][1], channelId);
@@ -807,7 +807,7 @@ namespace xdp {
     for (size_t i = 0; i < metricsSettings.size(); ++i) {
       if ((metrics[i][0].compare("all") == 0) || (metrics[i].size() < 3))
         continue;
-    
+
       uint32_t maxCol = 0;
       try {
         maxCol = std::stoi(metrics[i][1]);
@@ -821,7 +821,7 @@ namespace xdp {
       } catch (std::invalid_argument const &e) {
         // 2nd style but expected min column is not an integer, give warning and skip 
         xrt_core::message::send(severity_level::warning, "XRT", 
-          "Minimum column specification in tile_based_interface_tile_metrics is not an integer and hence skipped.");
+            "Minimum column specification in tile_based_interface_tile_metrics is not an integer and hence skipped.");
         continue;
       }
 
@@ -832,13 +832,13 @@ namespace xdp {
         } catch (std::invalid_argument const &e) {
           // Expected channel Id is not an integer, give warning and ignore channelId
           xrt_core::message::send(severity_level::warning, "XRT", 
-            "Channel ID specification in tile_based_interface_tile_metrics is not an integer and hence ignored.");
+              "Channel ID specification in tile_based_interface_tile_metrics is not an integer and hence ignored.");
           channelId = -1;
         }
       }
       
       auto tiles = get_interface_tiles(device.get(), metrics[i][2], channelId,
-                                      true, minCol, maxCol);
+                                       true, minCol, maxCol);
 
       for (auto &t : tiles) {
         configMetrics[moduleIdx][t] = metrics[i][2];

--- a/src/runtime_src/xdp/profile/plugin/aie_profile_new/aie_profile_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile_new/aie_profile_metadata.cpp
@@ -431,11 +431,11 @@ namespace xdp {
                                                const std::vector<std::string>& graphMetricsSettings,
                                                const module_type mod)
   {
+    if (metricsSettings.empty() && graphMetricsSettings.empty())
+      return;
     if ((getHardwareGen() == 1) && (mod == module_type::mem_tile)) {
-      if (!metricsSettings.empty() || !graphMetricsSettings.empty()) {
-        xrt_core::message::send(severity_level::warning, "XRT",
-          "MEM tiles are not available in AIE1. Profile settings will be ignored.");
-      }
+      xrt_core::message::send(severity_level::warning, "XRT",
+        "MEM tiles are not available in AIE1. Profile settings will be ignored.");
       return;
     }
 
@@ -461,90 +461,89 @@ namespace xdp {
      * MEM Tiles
      * graph_based_mem_tile_metrics = <graph name|all>:<kernel name|all>:<off|input_channels|output_channels|memory_stats>[:<channel>]
      */
-    if (graphMetricsSettings.size() > 0) {
-      std::vector<std::vector<std::string>> graphMetrics(graphMetricsSettings.size());
 
-      // Graph Pass 1 : process only "all" metric setting 
-      for (size_t i = 0; i < graphMetricsSettings.size(); ++i) {
-        // Split done only in Pass 1
-        boost::split(graphMetrics[i], graphMetricsSettings[i], boost::is_any_of(":"));
+    std::vector<std::vector<std::string>> graphMetrics(graphMetricsSettings.size());
 
-        // Check if graph is not all or if invalid kernel
-        if (graphMetrics[i][0].compare("all") != 0)
-          continue;
-        if ((graphMetrics[i][1].compare("all") != 0)
-            && (std::find(allValidKernels.begin(), allValidKernels.end(), graphMetrics[i][1]) == allValidKernels.end())) {
-          std::stringstream msg;
-          msg << "Kernel " << graphMetrics[i][1] << " not found. The graph_based_" << modName
-              << "_metrics setting " << graphMetricsSettings[i] << " will be ignored.";
-          xrt_core::message::send(severity_level::warning, "XRT", msg.str());
-          continue;
-        }
+    // Graph Pass 1 : process only "all" metric setting 
+    for (size_t i = 0; i < graphMetricsSettings.size(); ++i) {
+      // Split done only in Pass 1
+      boost::split(graphMetrics[i], graphMetricsSettings[i], boost::is_any_of(":"));
 
-        auto tiles = get_tiles(device.get(), graphMetrics[i][0], mod, graphMetrics[i][1]);
-        for (auto &e : tiles) {
-          configMetrics[moduleIdx][e] = graphMetrics[i][2];
-        }
+      // Check if graph is not all or if invalid kernel
+      if (graphMetrics[i][0].compare("all") != 0)
+        continue;
+      if ((graphMetrics[i][1].compare("all") != 0)
+          && (std::find(allValidKernels.begin(), allValidKernels.end(), graphMetrics[i][1]) == allValidKernels.end())) {
+        std::stringstream msg;
+        msg << "Kernel " << graphMetrics[i][1] << " not found. The graph_based_" << modName
+            << "_metrics setting " << graphMetricsSettings[i] << " will be ignored.";
+        xrt_core::message::send(severity_level::warning, "XRT", msg.str());
+        continue;
+      }
 
-        // Grab channel numbers (if specified; MEM tiles only)
-        if (graphMetrics[i].size() == 5) {
-          try {
-            for (auto &e : tiles) {
-              configChannel0[e] = std::stoi(graphMetrics[i][3]);
-              configChannel1[e] = std::stoi(graphMetrics[i][4]);
-            }
-          } catch (...) {
-            std::stringstream msg;
-            msg << "Channel specifications in graph_based_" << modName 
-                << "_metrics are not valid and hence ignored.";
-            xrt_core::message::send(severity_level::warning, "XRT", msg.str());
+      auto tiles = get_tiles(device.get(), graphMetrics[i][0], mod, graphMetrics[i][1]);
+      for (auto &e : tiles) {
+        configMetrics[moduleIdx][e] = graphMetrics[i][2];
+      }
+
+      // Grab channel numbers (if specified; MEM tiles only)
+      if (graphMetrics[i].size() == 5) {
+        try {
+          for (auto &e : tiles) {
+            configChannel0[e] = std::stoi(graphMetrics[i][3]);
+            configChannel1[e] = std::stoi(graphMetrics[i][4]);
           }
-        }
-      }  // Graph Pass 1
-
-      // Graph Pass 2 : process per graph metric setting 
-      for (size_t i = 0; i < graphMetricsSettings.size(); ++i) {
-        // Check if already processed or if invalid
-        if (graphMetrics[i][0].compare("all") == 0)
-          continue;
-        if (std::find(allValidGraphs.begin(), allValidGraphs.end(), graphMetrics[i][0]) == allValidGraphs.end()) {
+        } catch (...) {
           std::stringstream msg;
-          msg << "Graph " << graphMetrics[i][0] << " not found. The graph_based_" << modName
-              << "_metrics setting " << graphMetricsSettings[i] << " will be ignored.";
+          msg << "Channel specifications in graph_based_" << modName 
+              << "_metrics are not valid and hence ignored.";
           xrt_core::message::send(severity_level::warning, "XRT", msg.str());
-          continue;
         }
-        if ((graphMetrics[i][1].compare("all") != 0)
-            && (std::find(allValidKernels.begin(), allValidKernels.end(), graphMetrics[i][1]) == allValidKernels.end())) {
-          std::stringstream msg;
-          msg << "Kernel " << graphMetrics[i][1] << " not found. The graph_based_" << modName
-              << "_metrics setting " << graphMetricsSettings[i] << " will be ignored.";
-          xrt_core::message::send(severity_level::warning, "XRT", msg.str());
-          continue;
-        }
+      }
+    }  // Graph Pass 1
 
-        // Capture all tiles in given graph
-        auto tiles = get_tiles(device.get(), graphMetrics[i][0], mod, graphMetrics[i][1]);
-        for (auto &e : tiles) {
-          configMetrics[moduleIdx][e] = graphMetrics[i][2];
-        }
+    // Graph Pass 2 : process per graph metric setting 
+    for (size_t i = 0; i < graphMetricsSettings.size(); ++i) {
+      // Check if already processed or if invalid
+      if (graphMetrics[i][0].compare("all") == 0)
+        continue;
+      if (std::find(allValidGraphs.begin(), allValidGraphs.end(), graphMetrics[i][0]) == allValidGraphs.end()) {
+        std::stringstream msg;
+        msg << "Graph " << graphMetrics[i][0] << " not found. The graph_based_" << modName
+            << "_metrics setting " << graphMetricsSettings[i] << " will be ignored.";
+        xrt_core::message::send(severity_level::warning, "XRT", msg.str());
+        continue;
+      }
+      if ((graphMetrics[i][1].compare("all") != 0)
+          && (std::find(allValidKernels.begin(), allValidKernels.end(), graphMetrics[i][1]) == allValidKernels.end())) {
+        std::stringstream msg;
+        msg << "Kernel " << graphMetrics[i][1] << " not found. The graph_based_" << modName
+            << "_metrics setting " << graphMetricsSettings[i] << " will be ignored.";
+        xrt_core::message::send(severity_level::warning, "XRT", msg.str());
+        continue;
+      }
 
-        // Grab channel numbers (if specified; MEM tiles only)
-        if (graphMetrics[i].size() == 5) {
-          try {
-            for (auto &e : tiles) {
-              configChannel0[e] = std::stoi(graphMetrics[i][3]);
-              configChannel1[e] = std::stoi(graphMetrics[i][4]);
-            }
-          } catch (...) {
-            std::stringstream msg;
-            msg << "Channel specifications in graph_based_" << modName
-                << "_metrics are not valid and hence ignored.";
-            xrt_core::message::send(severity_level::warning, "XRT", msg.str());
+      // Capture all tiles in given graph
+      auto tiles = get_tiles(device.get(), graphMetrics[i][0], mod, graphMetrics[i][1]);
+      for (auto &e : tiles) {
+        configMetrics[moduleIdx][e] = graphMetrics[i][2];
+      }
+
+      // Grab channel numbers (if specified; MEM tiles only)
+      if (graphMetrics[i].size() == 5) {
+        try {
+          for (auto &e : tiles) {
+            configChannel0[e] = std::stoi(graphMetrics[i][3]);
+            configChannel1[e] = std::stoi(graphMetrics[i][4]);
           }
+        } catch (...) {
+          std::stringstream msg;
+          msg << "Channel specifications in graph_based_" << modName
+              << "_metrics are not valid and hence ignored.";
+          xrt_core::message::send(severity_level::warning, "XRT", msg.str());
         }
-      }  // Graph Pass 2
-    }
+      }
+    }  // Graph Pass 2
 
     // STEP 2 : Parse per-tile settings: all, bounding box, and/or single tiles
 
@@ -563,171 +562,170 @@ namespace xdp {
      * Range of tiles
      * tile_based_mem_tile_metrics = [{<mincolumn,<minrow>}:{<maxcolumn>,<maxrow>}:<off|input_channels|output_channels|memory_stats>[:<channel>]]]
      */
-    if (metricsSettings.size() > 0) {
-      std::vector<std::vector<std::string>> metrics(metricsSettings.size());
 
-      // Pass 1 : process only "all" metric setting 
-      for (size_t i = 0; i < metricsSettings.size(); ++i) {
-        // Split done only in Pass 1
-        boost::split(metrics[i], metricsSettings[i], boost::is_any_of(":"));
+    std::vector<std::vector<std::string>> metrics(metricsSettings.size());
 
-        if ((metrics[i][0].compare("all") != 0) || (metrics[i].size() < 2))
-          continue;
+    // Pass 1 : process only "all" metric setting 
+    for (size_t i = 0; i < metricsSettings.size(); ++i) {
+      // Split done only in Pass 1
+      boost::split(metrics[i], metricsSettings[i], boost::is_any_of(":"));
 
-        auto tiles = get_tiles(device.get(), metrics[i][0], mod);
-        for (auto &e : tiles) {
-          configMetrics[moduleIdx][e] = metrics[i][1];
-        }
+      if ((metrics[i][0].compare("all") != 0) || (metrics[i].size() < 2))
+        continue;
 
-        // Grab channel numbers (if specified; MEM tiles only)
-        if (metrics[i].size() == 4) {
-          try {
-            for (auto &e : tiles) {
-              configChannel0[e] = std::stoi(metrics[i][2]);
-              configChannel1[e] = std::stoi(metrics[i][3]);
-            }
-          } catch (...) {
-            std::stringstream msg;
-            msg << "Channel specifications in tile_based_" << modName
-                << "_metrics are not valid and hence ignored.";
-            xrt_core::message::send(severity_level::warning, "XRT", msg.str());
-          }
-        }
-      } // Pass 1 
+      auto tiles = get_tiles(device.get(), metrics[i][0], mod);
+      for (auto &e : tiles) {
+        configMetrics[moduleIdx][e] = metrics[i][1];
+      }
 
-      // Pass 2 : process only range of tiles metric setting 
-      for (size_t i = 0; i < metricsSettings.size(); ++i) {
-        if ((metrics[i].size() != 3) && (metrics[i].size() != 5))
-          continue;
-        
-        uint16_t minRow = 0, minCol = 0;
-        uint16_t maxRow = 0, maxCol = 0;
-
+      // Grab channel numbers (if specified; MEM tiles only)
+      if (metrics[i].size() == 4) {
         try {
-          for (size_t j = 0; j < metrics[i].size(); ++j) {
-            boost::replace_all(metrics[i][j], "{", "");
-            boost::replace_all(metrics[i][j], "}", "");
+          for (auto &e : tiles) {
+            configChannel0[e] = std::stoi(metrics[i][2]);
+            configChannel1[e] = std::stoi(metrics[i][3]);
           }
-
-          std::vector<std::string> minTile;
-          boost::split(minTile, metrics[i][0], boost::is_any_of(","));
-          minCol = std::stoi(minTile[0]);
-          minRow = std::stoi(minTile[1]) + rowOffset;
-
-          std::vector<std::string> maxTile;
-          boost::split(maxTile, metrics[i][1], boost::is_any_of(","));
-          maxCol = std::stoi(maxTile[0]);
-          maxRow = std::stoi(maxTile[1]) + rowOffset;
-        } catch (...) {
-          xrt_core::message::send(severity_level::warning, "XRT", 
-            "Tile range specification in tile_based_aie_[memory}_metrics is not of valid format and hence skipped.");
-          continue;
-        }
-
-        // Ensure range is valid 
-        if ((minCol > maxCol) || (minRow > maxRow)) {
-          std::stringstream msg;
-          msg << "Tile range specification in tile_based_" << modName 
-              << "_metrics is not of valid format and hence skipped.";
-          xrt_core::message::send(severity_level::warning, "XRT", msg.str());
-          continue;
-        }
-
-        uint8_t channel0 = 0;
-        uint8_t channel1 = 1;
-        if (metrics[i].size() == 5) {
-          try {
-            channel0 = std::stoi(metrics[i][3]);
-            channel1 = std::stoi(metrics[i][4]);
-          } catch (...) {
-            std::stringstream msg;
-            msg << "Channel specifications in tile_based_" << modName
-                << "_metrics are not valid and hence ignored.";
-            xrt_core::message::send(severity_level::warning, "XRT", msg.str());
-          }
-        }
-
-        for (uint16_t col = minCol; col <= maxCol; ++col) {
-          for (uint16_t row = minRow; row <= maxRow; ++row) {
-            tile_type tile;
-            tile.col = col;
-            tile.row = row;
-
-            // Make sure tile is used
-            if (allValidTiles.find(tile) == allValidTiles.end()) {
-              std::stringstream msg;
-              msg << "Specified Tile {" << std::to_string(tile.col) << ","
-                  << std::to_string(tile.row) << "} is not active. Hence skipped.";
-              xrt_core::message::send(severity_level::warning, "XRT", msg.str());
-              continue;
-            }
-        
-            configMetrics[moduleIdx][tile] = metrics[i][2];
-
-            // Grab channel numbers (if specified; MEM tiles only)
-            if (metrics[i].size() == 5) {
-              configChannel0[tile] = channel0;
-              configChannel1[tile] = channel1;
-            }
-          }
-        }
-      } // Pass 2 
-
-      // Pass 3 : process only single tile metric setting 
-      for (size_t i = 0; i < metricsSettings.size(); ++i) {
-        // Check if already processed
-        if ((metrics[i][0].compare("all") == 0) || (metrics[i].size() == 3)
-            || (metrics[i].size() == 5))
-          continue;
-
-        uint16_t col = 0;
-        uint16_t row = 0;
-
-        try {
-          boost::replace_all(metrics[i][0], "{", "");
-          boost::replace_all(metrics[i][0], "}", "");
-
-          std::vector<std::string> tilePos;
-          boost::split(tilePos, metrics[i][0], boost::is_any_of(","));
-          col = std::stoi(tilePos[0]);
-          row = std::stoi(tilePos[1]) + rowOffset;
         } catch (...) {
           std::stringstream msg;
-          msg << "Tile specification in tile_based_" << modName
-              << "_metrics is not valid format and hence skipped.";
+          msg << "Channel specifications in tile_based_" << modName
+              << "_metrics are not valid and hence ignored.";
           xrt_core::message::send(severity_level::warning, "XRT", msg.str());
-          continue;
+        }
+      }
+    } // Pass 1 
+
+    // Pass 2 : process only range of tiles metric setting 
+    for (size_t i = 0; i < metricsSettings.size(); ++i) {
+      if ((metrics[i].size() != 3) && (metrics[i].size() != 5))
+        continue;
+      
+      uint16_t minRow = 0, minCol = 0;
+      uint16_t maxRow = 0, maxCol = 0;
+
+      try {
+        for (size_t j = 0; j < metrics[i].size(); ++j) {
+          boost::replace_all(metrics[i][j], "{", "");
+          boost::replace_all(metrics[i][j], "}", "");
         }
 
-        tile_type tile;
-        tile.col = col;
-        tile.row = row;
+        std::vector<std::string> minTile;
+        boost::split(minTile, metrics[i][0], boost::is_any_of(","));
+        minCol = std::stoi(minTile[0]);
+        minRow = std::stoi(minTile[1]) + rowOffset;
 
-        // Make sure tile is used
-        if (allValidTiles.find(tile) == allValidTiles.end()) {
+        std::vector<std::string> maxTile;
+        boost::split(maxTile, metrics[i][1], boost::is_any_of(","));
+        maxCol = std::stoi(maxTile[0]);
+        maxRow = std::stoi(maxTile[1]) + rowOffset;
+      } catch (...) {
+        xrt_core::message::send(severity_level::warning, "XRT", 
+          "Tile range specification in tile_based_aie_[memory}_metrics is not of valid format and hence skipped.");
+        continue;
+      }
+
+      // Ensure range is valid 
+      if ((minCol > maxCol) || (minRow > maxRow)) {
+        std::stringstream msg;
+        msg << "Tile range specification in tile_based_" << modName 
+            << "_metrics is not of valid format and hence skipped.";
+        xrt_core::message::send(severity_level::warning, "XRT", msg.str());
+        continue;
+      }
+
+      uint8_t channel0 = 0;
+      uint8_t channel1 = 1;
+      if (metrics[i].size() == 5) {
+        try {
+          channel0 = std::stoi(metrics[i][3]);
+          channel1 = std::stoi(metrics[i][4]);
+        } catch (...) {
           std::stringstream msg;
-          msg << "Specified Tile {" << std::to_string(tile.col) << ","
-              << std::to_string(tile.row) << "} is not active. Hence skipped.";
+          msg << "Channel specifications in tile_based_" << modName
+              << "_metrics are not valid and hence ignored.";
           xrt_core::message::send(severity_level::warning, "XRT", msg.str());
-          continue;
         }
+      }
 
-        configMetrics[moduleIdx][tile] = metrics[i][1];
-        
-        // Grab channel numbers (if specified; MEM tiles only)
-        if (metrics[i].size() == 4) {
-          try {
-            configChannel0[tile] = std::stoi(metrics[i][2]);
-            configChannel1[tile] = std::stoi(metrics[i][3]);
-          } catch (...) {
+      for (uint16_t col = minCol; col <= maxCol; ++col) {
+        for (uint16_t row = minRow; row <= maxRow; ++row) {
+          tile_type tile;
+          tile.col = col;
+          tile.row = row;
+
+          // Make sure tile is used
+          if (allValidTiles.find(tile) == allValidTiles.end()) {
             std::stringstream msg;
-            msg << "Channel specifications in tile_based_" << modName
-                << "_metrics are not valid and hence ignored.";
+            msg << "Specified Tile {" << std::to_string(tile.col) << ","
+                << std::to_string(tile.row) << "} is not active. Hence skipped.";
             xrt_core::message::send(severity_level::warning, "XRT", msg.str());
+            continue;
+          }
+      
+          configMetrics[moduleIdx][tile] = metrics[i][2];
+
+          // Grab channel numbers (if specified; MEM tiles only)
+          if (metrics[i].size() == 5) {
+            configChannel0[tile] = channel0;
+            configChannel1[tile] = channel1;
           }
         }
-      } // Pass 3 
-    }
+      }
+    } // Pass 2 
+
+    // Pass 3 : process only single tile metric setting 
+    for (size_t i = 0; i < metricsSettings.size(); ++i) {
+      // Check if already processed
+      if ((metrics[i][0].compare("all") == 0) || (metrics[i].size() == 3)
+          || (metrics[i].size() == 5))
+        continue;
+
+      uint16_t col = 0;
+      uint16_t row = 0;
+
+      try {
+        boost::replace_all(metrics[i][0], "{", "");
+        boost::replace_all(metrics[i][0], "}", "");
+
+        std::vector<std::string> tilePos;
+        boost::split(tilePos, metrics[i][0], boost::is_any_of(","));
+        col = std::stoi(tilePos[0]);
+        row = std::stoi(tilePos[1]) + rowOffset;
+      } catch (...) {
+        std::stringstream msg;
+        msg << "Tile specification in tile_based_" << modName
+            << "_metrics is not valid format and hence skipped.";
+        xrt_core::message::send(severity_level::warning, "XRT", msg.str());
+        continue;
+      }
+
+      tile_type tile;
+      tile.col = col;
+      tile.row = row;
+
+      // Make sure tile is used
+      if (allValidTiles.find(tile) == allValidTiles.end()) {
+        std::stringstream msg;
+        msg << "Specified Tile {" << std::to_string(tile.col) << ","
+            << std::to_string(tile.row) << "} is not active. Hence skipped.";
+        xrt_core::message::send(severity_level::warning, "XRT", msg.str());
+        continue;
+      }
+
+      configMetrics[moduleIdx][tile] = metrics[i][1];
+      
+      // Grab channel numbers (if specified; MEM tiles only)
+      if (metrics[i].size() == 4) {
+        try {
+          configChannel0[tile] = std::stoi(metrics[i][2]);
+          configChannel1[tile] = std::stoi(metrics[i][3]);
+        } catch (...) {
+          std::stringstream msg;
+          msg << "Channel specifications in tile_based_" << modName
+              << "_metrics are not valid and hence ignored.";
+          xrt_core::message::send(severity_level::warning, "XRT", msg.str());
+        }
+      }
+    } // Pass 3
 
     // Set default, check validity, and remove "off" tiles
     auto defaultSet = defaultSets[moduleIdx];
@@ -771,6 +769,9 @@ namespace xdp {
                                                         const std::vector<std::string>& metricsSettings,
                                                         const std::vector<std::string> graphMetricsSettings)
   {
+    if (metricsSettings.empty() && graphMetricsSettings.empty())
+      return;
+
     std::shared_ptr<xrt_core::device> device = xrt_core::get_userpf_device(handle);
 
     // TODO: Add support for graph metrics
@@ -783,51 +784,92 @@ namespace xdp {
      * Range of tiles
      * tile_based_interface_tile_metrics = [<mincolumn>:<maxcolumn>:<off|input_throughputs|output_throughputs|packets>[:<channel>]]]
      */
-    if (metricsSettings.size() > 0) {
-      std::vector<std::vector<std::string>> metrics(metricsSettings.size());
+    
+    std::vector<std::vector<std::string>> metrics(metricsSettings.size());
 
-      // Pass 1 : process only "all" metric setting 
-      for (size_t i = 0; i < metricsSettings.size(); ++i) {
-        // Split done only in Pass 1
-        boost::split(metrics[i], metricsSettings[i], boost::is_any_of(":"));
+    // Pass 1 : process only "all" metric setting 
+    for (size_t i = 0; i < metricsSettings.size(); ++i) {
+      // Split done only in Pass 1
+      boost::split(metrics[i], metricsSettings[i], boost::is_any_of(":"));
 
-        if (metrics[i][0].compare("all") != 0)
+      if (metrics[i][0].compare("all") != 0)
+      continue;
+
+      int16_t channelId = (metrics[i].size() < 3) ? -1 : std::stoi(metrics[i][2]);
+      auto tiles = get_interface_tiles(device.get(), metrics[i][1], channelId);
+
+      for (auto &e : tiles) {
+        configMetrics[moduleIdx][e] = metrics[i][1];
+      }
+    } // Pass 1 
+
+    // Pass 2 : process only range of tiles metric setting 
+    for (size_t i = 0; i < metricsSettings.size(); ++i) {
+      if ((metrics[i][0].compare("all") == 0) || (metrics[i].size() < 3))
         continue;
+    
+      uint32_t maxCol = 0;
+      try {
+        maxCol = std::stoi(metrics[i][1]);
+      } catch (std::invalid_argument const &e) {
+        // maxColumn is not an integer i.e either 1st style or wrong format, skip for now
+        continue;
+      }
+      uint32_t minCol = 0;
+      try {
+        minCol = std::stoi(metrics[i][0]);
+      } catch (std::invalid_argument const &e) {
+        // 2nd style but expected min column is not an integer, give warning and skip 
+        xrt_core::message::send(severity_level::warning, "XRT", 
+          "Minimum column specification in tile_based_interface_tile_metrics is not an integer and hence skipped.");
+        continue;
+      }
 
-        int16_t channelId = (metrics[i].size() < 3) ? -1 : std::stoi(metrics[i][2]);
-        auto tiles = get_interface_tiles(device.get(), metrics[i][1], channelId);
-
-        for (auto &e : tiles) {
-          configMetrics[moduleIdx][e] = metrics[i][1];
-        }
-      } // Pass 1 
-
-      // Pass 2 : process only range of tiles metric setting 
-      for (size_t i = 0; i < metricsSettings.size(); ++i) {
-        if ((metrics[i][0].compare("all") == 0) || (metrics[i].size() < 3))
-          continue;
-      
-        uint32_t maxCol = 0;
+      int16_t channelId = 0;
+      if (metrics[i].size() == 4) {
         try {
-          maxCol = std::stoi(metrics[i][1]);
+          channelId = std::stoi(metrics[i][3]);
         } catch (std::invalid_argument const &e) {
-          // maxColumn is not an integer i.e either 1st style or wrong format, skip for now
-          continue;
-        }
-        uint32_t minCol = 0;
-        try {
-          minCol = std::stoi(metrics[i][0]);
-        } catch (std::invalid_argument const &e) {
-          // 2nd style but expected min column is not an integer, give warning and skip 
+          // Expected channel Id is not an integer, give warning and ignore channelId
           xrt_core::message::send(severity_level::warning, "XRT", 
-            "Minimum column specification in tile_based_interface_tile_metrics is not an integer and hence skipped.");
+            "Channel ID specification in tile_based_interface_tile_metrics is not an integer and hence ignored.");
+          channelId = -1;
+        }
+      }
+      
+      auto tiles = get_interface_tiles(device.get(), metrics[i][2], channelId,
+                                      true, minCol, maxCol);
+
+      for (auto &t : tiles) {
+        configMetrics[moduleIdx][t] = metrics[i][2];
+      }
+    } // Pass 2 
+
+    // Pass 3 : process only single tile metric setting 
+    for (size_t i = 0; i < metricsSettings.size(); ++i) {
+      // Skip range specification, invalid format, or already processed
+      if ((metrics[i].size() == 4) || (metrics[i].size() < 2)
+          || (metrics[i][0].compare("all") == 0))
+        continue;
+      
+      uint32_t col = 0;
+      try {
+        col = std::stoi(metrics[i][1]);
+      } catch (std::invalid_argument const &e) {
+        // max column is not a number, so the expected single column specification. Handle this here
+        try {
+          col = std::stoi(metrics[i][0]);
+        } catch (std::invalid_argument const &e) {
+          // Expected column specification is not a number. Give warning and skip
+          xrt_core::message::send(severity_level::warning, "XRT", 
+            "Column specification in tile_based_interface_tile_metrics is not an integer and hence skipped.");
           continue;
         }
 
-        int16_t channelId = 0;
-        if (metrics[i].size() == 4) {
+        int16_t channelId = -1;
+        if (metrics[i].size() == 3) {
           try {
-            channelId = std::stoi(metrics[i][3]);
+            channelId = std::stoi(metrics[i][2]);
           } catch (std::invalid_argument const &e) {
             // Expected channel Id is not an integer, give warning and ignore channelId
             xrt_core::message::send(severity_level::warning, "XRT", 
@@ -835,57 +877,15 @@ namespace xdp {
             channelId = -1;
           }
         }
-        
-        auto tiles = get_interface_tiles(device.get(), metrics[i][2], channelId,
-                                        true, minCol, maxCol);
+
+        auto tiles = get_interface_tiles(device.get(), metrics[i][1], channelId,
+                                        true, col, col);
 
         for (auto &t : tiles) {
-          configMetrics[moduleIdx][t] = metrics[i][2];
+          configMetrics[moduleIdx][t] = metrics[i][1];
         }
-      } // Pass 2 
-
-      // Pass 3 : process only single tile metric setting 
-      for (size_t i = 0; i < metricsSettings.size(); ++i) {
-        // Skip range specification, invalid format, or already processed
-        if ((metrics[i].size() == 4) || (metrics[i].size() < 2)
-            || (metrics[i][0].compare("all") == 0))
-          continue;
-        
-        uint32_t col = 0;
-        try {
-          col = std::stoi(metrics[i][1]);
-        } catch (std::invalid_argument const &e) {
-          // max column is not a number, so the expected single column specification. Handle this here
-          try {
-            col = std::stoi(metrics[i][0]);
-          } catch (std::invalid_argument const &e) {
-            // Expected column specification is not a number. Give warning and skip
-            xrt_core::message::send(severity_level::warning, "XRT", 
-              "Column specification in tile_based_interface_tile_metrics is not an integer and hence skipped.");
-            continue;
-          }
-
-          int16_t channelId = -1;
-          if (metrics[i].size() == 3) {
-            try {
-              channelId = std::stoi(metrics[i][2]);
-            } catch (std::invalid_argument const &e) {
-              // Expected channel Id is not an integer, give warning and ignore channelId
-              xrt_core::message::send(severity_level::warning, "XRT", 
-                "Channel ID specification in tile_based_interface_tile_metrics is not an integer and hence ignored.");
-              channelId = -1;
-            }
-          }
-
-          auto tiles = get_interface_tiles(device.get(), metrics[i][1], channelId,
-                                          true, col, col);
-
-          for (auto &t : tiles) {
-            configMetrics[moduleIdx][t] = metrics[i][1];
-          }
-        }
-      } // Pass 3 
-    }
+      }
+    } // Pass 3
 
     // Set default, check validity, and remove "off" tiles
     auto defaultSet = defaultSets[moduleIdx];

--- a/src/runtime_src/xdp/profile/plugin/aie_profile_new/aie_profile_metadata.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile_new/aie_profile_metadata.h
@@ -39,7 +39,7 @@ class AieProfileMetadata{
     const std::vector<std::string> moduleNames = 
         {"aie", "aie_memory", "interface_tile", "mem_tile"};
     const std::string defaultSets[NUM_MODULES] = 
-        {"heat_map", "conflicts", "input_throughputs", "input_channels"};
+        {"write_throughputs", "write_throughputs", "input_throughputs", "input_channels"};
     const int numCountersMod[NUM_MODULES] =
         {NUM_CORE_COUNTERS, NUM_MEMORY_COUNTERS, NUM_SHIM_COUNTERS, NUM_MEM_TILE_COUNTERS};
     const module_type moduleTypes[NUM_MODULES] = 

--- a/src/runtime_src/xdp/profile/plugin/aie_profile_new/edge/aie_profile.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile_new/edge/aie_profile.cpp
@@ -336,7 +336,7 @@ namespace xdp {
       return ((isMaster << 8) | channel);
     }
 
-    // 3. DMA BD sizes
+    // 3. DMA BD sizes for AIE tiles
     if ((startEvent != XAIE_EVENT_DMA_S2MM_0_FINISHED_BD_MEM)
         && (startEvent != XAIE_EVENT_DMA_S2MM_1_FINISHED_BD_MEM)
         && (startEvent != XAIE_EVENT_DMA_MM2S_0_FINISHED_BD_MEM)
@@ -349,21 +349,21 @@ namespace xdp {
     constexpr uint32_t BYTES_PER_WORD = 4;
     constexpr uint32_t ACTUAL_OFFSET = 1;
     uint64_t offsets[NUM_BDS] = {XAIEGBL_MEM_DMABD0CTRL,            XAIEGBL_MEM_DMABD1CTRL,
-                                XAIEGBL_MEM_DMABD2CTRL,            XAIEGBL_MEM_DMABD3CTRL,
-                                XAIEGBL_MEM_DMABD4CTRL,            XAIEGBL_MEM_DMABD5CTRL,
-                                XAIEGBL_MEM_DMABD6CTRL,            XAIEGBL_MEM_DMABD7CTRL};
+                                 XAIEGBL_MEM_DMABD2CTRL,            XAIEGBL_MEM_DMABD3CTRL,
+                                 XAIEGBL_MEM_DMABD4CTRL,            XAIEGBL_MEM_DMABD5CTRL,
+                                 XAIEGBL_MEM_DMABD6CTRL,            XAIEGBL_MEM_DMABD7CTRL};
     uint32_t lsbs[NUM_BDS]    = {XAIEGBL_MEM_DMABD0CTRL_LEN_LSB,    XAIEGBL_MEM_DMABD1CTRL_LEN_LSB,
-                                XAIEGBL_MEM_DMABD2CTRL_LEN_LSB,    XAIEGBL_MEM_DMABD3CTRL_LEN_LSB,
-                                XAIEGBL_MEM_DMABD4CTRL_LEN_LSB,    XAIEGBL_MEM_DMABD5CTRL_LEN_LSB,
-                                XAIEGBL_MEM_DMABD6CTRL_LEN_LSB,    XAIEGBL_MEM_DMABD7CTRL_LEN_LSB};
+                                 XAIEGBL_MEM_DMABD2CTRL_LEN_LSB,    XAIEGBL_MEM_DMABD3CTRL_LEN_LSB,
+                                 XAIEGBL_MEM_DMABD4CTRL_LEN_LSB,    XAIEGBL_MEM_DMABD5CTRL_LEN_LSB,
+                                 XAIEGBL_MEM_DMABD6CTRL_LEN_LSB,    XAIEGBL_MEM_DMABD7CTRL_LEN_LSB};
     uint32_t masks[NUM_BDS]   = {XAIEGBL_MEM_DMABD0CTRL_LEN_MASK,   XAIEGBL_MEM_DMABD1CTRL_LEN_MASK,
-                                XAIEGBL_MEM_DMABD2CTRL_LEN_MASK,   XAIEGBL_MEM_DMABD3CTRL_LEN_MASK,
-                                XAIEGBL_MEM_DMABD4CTRL_LEN_MASK,   XAIEGBL_MEM_DMABD5CTRL_LEN_MASK,
-                                XAIEGBL_MEM_DMABD6CTRL_LEN_MASK,   XAIEGBL_MEM_DMABD7CTRL_LEN_MASK};
+                                 XAIEGBL_MEM_DMABD2CTRL_LEN_MASK,   XAIEGBL_MEM_DMABD3CTRL_LEN_MASK,
+                                 XAIEGBL_MEM_DMABD4CTRL_LEN_MASK,   XAIEGBL_MEM_DMABD5CTRL_LEN_MASK,
+                                 XAIEGBL_MEM_DMABD6CTRL_LEN_MASK,   XAIEGBL_MEM_DMABD7CTRL_LEN_MASK};
     uint32_t valids[NUM_BDS]  = {XAIEGBL_MEM_DMABD0CTRL_VALBD_MASK, XAIEGBL_MEM_DMABD1CTRL_VALBD_MASK,
-                                XAIEGBL_MEM_DMABD2CTRL_VALBD_MASK, XAIEGBL_MEM_DMABD3CTRL_VALBD_MASK,
-                                XAIEGBL_MEM_DMABD4CTRL_VALBD_MASK, XAIEGBL_MEM_DMABD5CTRL_VALBD_MASK,
-                                XAIEGBL_MEM_DMABD6CTRL_VALBD_MASK, XAIEGBL_MEM_DMABD7CTRL_VALBD_MASK};
+                                 XAIEGBL_MEM_DMABD2CTRL_VALBD_MASK, XAIEGBL_MEM_DMABD3CTRL_VALBD_MASK,
+                                 XAIEGBL_MEM_DMABD4CTRL_VALBD_MASK, XAIEGBL_MEM_DMABD5CTRL_VALBD_MASK,
+                                 XAIEGBL_MEM_DMABD6CTRL_VALBD_MASK, XAIEGBL_MEM_DMABD7CTRL_VALBD_MASK};
 
     auto tileOffset = _XAie_GetTileAddr(aieDevInst, row, column);
     for (int bd = 0; bd < NUM_BDS; ++bd) {

--- a/src/runtime_src/xdp/profile/plugin/aie_profile_new/edge/aie_profile.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile_new/edge/aie_profile.cpp
@@ -411,6 +411,16 @@ namespace xdp {
     xrt_core::message::send(severity_level::info, "XRT", msg.str());
   }
 
+  uint16_t AieProfile_EdgeImpl::getRelativeRow(uint16_t absRow)
+  {
+    auto rowOffset = metadata->getAIETileRowOffset();
+    if (absRow == 0)
+      return 0;
+    if (absRow < rowOffset)
+      return (absRow - 1);
+    return (absRow - rowOffset);
+  }
+
   module_type 
   AieProfile_EdgeImpl::getModuleType(uint16_t absRow, XAie_ModuleType mod)
   {
@@ -578,7 +588,7 @@ namespace xdp {
 
       std::vector<uint64_t> values;
       values.push_back(aie->column);
-      values.push_back(aie->row);
+      values.push_back(getRelativeRow(aie->row));
       values.push_back(aie->startEvent);
       values.push_back(aie->endEvent);
       values.push_back(aie->resetEvent);

--- a/src/runtime_src/xdp/profile/plugin/aie_profile_new/edge/aie_profile.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile_new/edge/aie_profile.h
@@ -74,9 +74,12 @@ namespace xdp {
                                  const uint8_t channel1);
       uint32_t getCounterPayload(XAie_DevInst* aieDevInst,
                                  const tile_type& tile,
+                                 const module_type type,
                                  uint16_t column, 
                                  uint16_t row, 
-                                 uint16_t startEvent);
+                                 uint16_t startEvent,
+                                 const std::string metricSet,
+                                 const uint8_t channel);
     private:
       XAie_DevInst*     aieDevInst = nullptr;
       xaiefal::XAieDev* aieDevice  = nullptr;    

--- a/src/runtime_src/xdp/profile/plugin/aie_profile_new/edge/aie_profile.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile_new/edge/aie_profile.h
@@ -45,6 +45,7 @@ namespace xdp {
       bool checkAieDevice(uint64_t deviceId, void* handle);
 
       bool setMetricsSettings(uint64_t deviceId, void* handle);
+      uint16_t getRelativeRow(uint16_t absRow);
       module_type getModuleType(uint16_t absRow, XAie_ModuleType mod);
       bool isValidType(module_type type, XAie_ModuleType mod);
       bool isStreamSwitchPortEvent(const XAie_Events event);

--- a/src/runtime_src/xdp/profile/plugin/aie_trace_new/aie_trace_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace_new/aie_trace_metadata.cpp
@@ -528,6 +528,7 @@ namespace xdp {
                                              std::vector<std::string>& graphMetricsSettings,
                                              module_type type)
   {
+    // Make sure settings are available and appropriate
     if (metricsSettings.empty() && graphMetricsSettings.empty())
       return;
     if ((getHardwareGen() == 1) && (type == module_type::mem_tile)) {
@@ -554,7 +555,7 @@ namespace xdp {
      * MEM Tiles (AIE2 and beyond)
      * graph_based_mem_tile_metrics = <graph name|all>:<kernel name|all>:<off|input_channels|input_channels_stalls|output_channels|output_channels_stalls>[:<channel 1>][:<channel 2>]
      */
-    
+
     std::vector<std::vector<std::string>> graphMetrics(graphMetricsSettings.size());
 
     // Graph Pass 1 : process only "all" metric setting
@@ -667,7 +668,7 @@ namespace xdp {
      * Range of tiles
      * tile_based_mem_tile_metrics = {<mincolumn,<minrow>}:{<maxcolumn>,<maxrow>}:<off|input_channels|input_channels_stalls|output_channels|output_channels_stalls>[:<channel 1>][:<channel 2>]
      */
-    
+
     std::vector<std::vector<std::string>> metrics(metricsSettings.size());
 
     // Pass 1 : process only "all" metric setting 
@@ -831,7 +832,7 @@ namespace xdp {
           xrt_core::message::send(severity_level::warning, "XRT", msg.str());
         }
       }
-    } // Pass 3
+    } // Pass 3 
 
     // Set default, check validity, and remove "off" tiles
     auto defaultSet = defaultSets[type];

--- a/src/runtime_src/xdp/profile/plugin/aie_trace_new/aie_trace_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace_new/aie_trace_metadata.cpp
@@ -528,12 +528,11 @@ namespace xdp {
                                              std::vector<std::string>& graphMetricsSettings,
                                              module_type type)
   {
-    // MEM tiles are not supported in AIE1
+    if (metricsSettings.empty() && graphMetricsSettings.empty())
+      return;
     if ((getHardwareGen() == 1) && (type == module_type::mem_tile)) {
-      if (!metricsSettings.empty() || !graphMetricsSettings.empty()) {
-        xrt_core::message::send(severity_level::warning, "XRT",
-          "MEM tiles are not available in AIE1. Trace settings will be ignored.");
-      }
+      xrt_core::message::send(severity_level::warning, "XRT",
+        "MEM tiles are not available in AIE1. Trace settings will be ignored.");
       return;
     }
       
@@ -555,104 +554,103 @@ namespace xdp {
      * MEM Tiles (AIE2 and beyond)
      * graph_based_mem_tile_metrics = <graph name|all>:<kernel name|all>:<off|input_channels|input_channels_stalls|output_channels|output_channels_stalls>[:<channel 1>][:<channel 2>]
      */
-    if (graphMetricsSettings.size() > 0) {
-      std::vector<std::vector<std::string>> graphMetrics(graphMetricsSettings.size());
+    
+    std::vector<std::vector<std::string>> graphMetrics(graphMetricsSettings.size());
 
-      // Graph Pass 1 : process only "all" metric setting
-      for (size_t i = 0; i < graphMetricsSettings.size(); ++i) {
-        // Split done only in Pass 1
-        boost::split(graphMetrics[i], graphMetricsSettings[i], boost::is_any_of(":"));
+    // Graph Pass 1 : process only "all" metric setting
+    for (size_t i = 0; i < graphMetricsSettings.size(); ++i) {
+      // Split done only in Pass 1
+      boost::split(graphMetrics[i], graphMetricsSettings[i], boost::is_any_of(":"));
 
-        // Check if graph is not all or if invalid kernel
-        if (graphMetrics[i][0].compare("all") != 0)
-          continue;
-        if ((graphMetrics[i][1].compare("all") != 0)
-            && (std::find(allValidKernels.begin(), allValidKernels.end(), graphMetrics[i][1]) == allValidKernels.end())) {
-          std::stringstream msg;
-          msg << "Kernel " << graphMetrics[i][1] << " not found. The graph_based_" << tileName
-              << "_metrics setting " << graphMetricsSettings[i] << " will be ignored.";
-          xrt_core::message::send(severity_level::warning, "XRT", msg.str());
-          continue;
-        }
+      // Check if graph is not all or if invalid kernel
+      if (graphMetrics[i][0].compare("all") != 0)
+        continue;
+      if ((graphMetrics[i][1].compare("all") != 0)
+          && (std::find(allValidKernels.begin(), allValidKernels.end(), graphMetrics[i][1]) == allValidKernels.end())) {
+        std::stringstream msg;
+        msg << "Kernel " << graphMetrics[i][1] << " not found. The graph_based_" << tileName
+            << "_metrics setting " << graphMetricsSettings[i] << " will be ignored.";
+        xrt_core::message::send(severity_level::warning, "XRT", msg.str());
+        continue;
+      }
 
-        auto tiles = get_tiles(device.get(), graphMetrics[i][0], type, graphMetrics[i][1]);
-        for (auto &e : tiles) {
-          configMetrics[e] = graphMetrics[i][2];
-        }
+      auto tiles = get_tiles(device.get(), graphMetrics[i][0], type, graphMetrics[i][1]);
+      for (auto &e : tiles) {
+        configMetrics[e] = graphMetrics[i][2];
+      }
 
-        // Grab channel numbers (if specified; MEM tiles only)
-        if (graphMetrics[i].size() == 5) {
-          try {
-            for (auto &e : tiles) {
-              configChannel0[e] = std::stoi(graphMetrics[i][3]);
-              configChannel1[e] = std::stoi(graphMetrics[i][4]);
-            }
-          } catch (...) {
-            std::stringstream msg;
-            msg << "Channel specifications in graph_based_" << tileName 
-                << "_tile_metrics are not valid and hence ignored.";
-            xrt_core::message::send(severity_level::warning, "XRT", msg.str());
+      // Grab channel numbers (if specified; MEM tiles only)
+      if (graphMetrics[i].size() == 5) {
+        try {
+          for (auto &e : tiles) {
+            configChannel0[e] = std::stoi(graphMetrics[i][3]);
+            configChannel1[e] = std::stoi(graphMetrics[i][4]);
           }
-        }
-      } // Graph Pass 1
-
-      // Graph Pass 2 : process per graph metric setting
-      for (size_t i = 0; i < graphMetricsSettings.size(); ++i) {
-        // Check if already processed or if invalid
-        if (graphMetrics[i][0].compare("all") == 0)
-          continue;
-        if (std::find(allValidGraphs.begin(), allValidGraphs.end(), graphMetrics[i][0]) == allValidGraphs.end()) {
+        } catch (...) {
           std::stringstream msg;
-          msg << "Graph " << graphMetrics[i][0] << " not found. The graph_based_" << tileName
-              << "_metrics setting " << graphMetricsSettings[i] << " will be ignored.";
+          msg << "Channel specifications in graph_based_" << tileName 
+              << "_tile_metrics are not valid and hence ignored.";
           xrt_core::message::send(severity_level::warning, "XRT", msg.str());
-          continue;
         }
-        if ((graphMetrics[i][1].compare("all") != 0)
-            && (std::find(allValidKernels.begin(), allValidKernels.end(), graphMetrics[i][1]) == allValidKernels.end())) {
-          std::stringstream msg;
-          msg << "Kernel " << graphMetrics[i][1] << " not found. The graph_based_" << tileName
-              << "_metrics setting " << graphMetricsSettings[i] << " will be ignored.";
-          xrt_core::message::send(severity_level::warning, "XRT", msg.str());
-          continue;
-        }
+      }
+    } // Graph Pass 1
 
-        // Check if specified graph exists
-        auto graphs = get_graphs(device.get());
-        if (!graphs.empty() && (std::find(graphs.begin(), graphs.end(), graphMetrics[i][0]) == graphs.end())) {
-          std::stringstream msg;
-          msg << "Could not find graph named " << graphMetrics[i][0] 
-              << ", as specified in graph_based_" << tileName << "_tile_metrics configuration."
-              << " Following graphs are present in the design : " << graphs[0];
-          for (size_t j = 1; j < graphs.size(); j++) {
-            msg << ", " + graphs[j];
+    // Graph Pass 2 : process per graph metric setting
+    for (size_t i = 0; i < graphMetricsSettings.size(); ++i) {
+      // Check if already processed or if invalid
+      if (graphMetrics[i][0].compare("all") == 0)
+        continue;
+      if (std::find(allValidGraphs.begin(), allValidGraphs.end(), graphMetrics[i][0]) == allValidGraphs.end()) {
+        std::stringstream msg;
+        msg << "Graph " << graphMetrics[i][0] << " not found. The graph_based_" << tileName
+            << "_metrics setting " << graphMetricsSettings[i] << " will be ignored.";
+        xrt_core::message::send(severity_level::warning, "XRT", msg.str());
+        continue;
+      }
+      if ((graphMetrics[i][1].compare("all") != 0)
+          && (std::find(allValidKernels.begin(), allValidKernels.end(), graphMetrics[i][1]) == allValidKernels.end())) {
+        std::stringstream msg;
+        msg << "Kernel " << graphMetrics[i][1] << " not found. The graph_based_" << tileName
+            << "_metrics setting " << graphMetricsSettings[i] << " will be ignored.";
+        xrt_core::message::send(severity_level::warning, "XRT", msg.str());
+        continue;
+      }
+
+      // Check if specified graph exists
+      auto graphs = get_graphs(device.get());
+      if (!graphs.empty() && (std::find(graphs.begin(), graphs.end(), graphMetrics[i][0]) == graphs.end())) {
+        std::stringstream msg;
+        msg << "Could not find graph named " << graphMetrics[i][0] 
+            << ", as specified in graph_based_" << tileName << "_tile_metrics configuration."
+            << " Following graphs are present in the design : " << graphs[0];
+        for (size_t j = 1; j < graphs.size(); j++) {
+          msg << ", " + graphs[j];
+        }
+        msg << ".";
+        xrt_core::message::send(severity_level::warning, "XRT", msg.str());
+        continue;
+      }
+
+      auto tiles = get_tiles(device.get(), graphMetrics[i][0], type, graphMetrics[i][1]);
+      for (auto &e : tiles) {
+        configMetrics[e] = graphMetrics[i][2];
+      }
+
+      // Grab channel numbers (if specified; MEM tiles only)
+      if (graphMetrics[i].size() == 5) {
+        try {
+          for (auto &e : tiles) {
+            configChannel0[e] = std::stoi(graphMetrics[i][3]);
+            configChannel1[e] = std::stoi(graphMetrics[i][4]);
           }
-          msg << ".";
+        } catch (...) {
+          std::stringstream msg;
+          msg << "Channel specifications in graph_based_" << tileName
+              << "_tile_metrics are not valid and hence ignored.";
           xrt_core::message::send(severity_level::warning, "XRT", msg.str());
-          continue;
         }
-
-        auto tiles = get_tiles(device.get(), graphMetrics[i][0], type, graphMetrics[i][1]);
-        for (auto &e : tiles) {
-          configMetrics[e] = graphMetrics[i][2];
-        }
-
-        // Grab channel numbers (if specified; MEM tiles only)
-        if (graphMetrics[i].size() == 5) {
-          try {
-            for (auto &e : tiles) {
-              configChannel0[e] = std::stoi(graphMetrics[i][3]);
-              configChannel1[e] = std::stoi(graphMetrics[i][4]);
-            }
-          } catch (...) {
-            std::stringstream msg;
-            msg << "Channel specifications in graph_based_" << tileName
-                << "_tile_metrics are not valid and hence ignored.";
-            xrt_core::message::send(severity_level::warning, "XRT", msg.str());
-          }
-        }
-      } // Graph Pass 2
-    }
+      }
+    } // Graph Pass 2
 
     // STEP 2 : Parse per-tile settings: all, bounding box, and/or single tiles
 
@@ -669,172 +667,171 @@ namespace xdp {
      * Range of tiles
      * tile_based_mem_tile_metrics = {<mincolumn,<minrow>}:{<maxcolumn>,<maxrow>}:<off|input_channels|input_channels_stalls|output_channels|output_channels_stalls>[:<channel 1>][:<channel 2>]
      */
-    if (metricsSettings.size() > 0) {
-      std::vector<std::vector<std::string>> metrics(metricsSettings.size());
+    
+    std::vector<std::vector<std::string>> metrics(metricsSettings.size());
 
-      // Pass 1 : process only "all" metric setting 
-      for (size_t i = 0; i < metricsSettings.size(); ++i) {
-        // Split done only in Pass 1
-        boost::split(metrics[i], metricsSettings[i], boost::is_any_of(":"));
+    // Pass 1 : process only "all" metric setting 
+    for (size_t i = 0; i < metricsSettings.size(); ++i) {
+      // Split done only in Pass 1
+      boost::split(metrics[i], metricsSettings[i], boost::is_any_of(":"));
 
-        if ((metrics[i][0].compare("all") != 0) || (metrics[i].size() < 2))
-          continue;
+      if ((metrics[i][0].compare("all") != 0) || (metrics[i].size() < 2))
+        continue;
 
-        auto tiles = get_tiles(device.get(), metrics[i][0], type);
-        for (auto &e : tiles) {
-          configMetrics[e] = metrics[i][1];
-        }
+      auto tiles = get_tiles(device.get(), metrics[i][0], type);
+      for (auto &e : tiles) {
+        configMetrics[e] = metrics[i][1];
+      }
 
-        // Grab channel numbers (if specified; MEM tiles only)
-        if (metrics[i].size() == 4) {
-          try {
-            for (auto &e : allValidTiles) {
-              configChannel0[e] = std::stoi(metrics[i][2]);
-              configChannel1[e] = std::stoi(metrics[i][3]);
-            }
-          } catch (...) {
-            std::stringstream msg;
-            msg << "Channel specifications in tile_based_" << tileName
-                << "_tile_metrics are not valid and hence ignored.";
-            xrt_core::message::send(severity_level::warning, "XRT", msg.str());
-          }
-        }
-      } // Pass 1 
-
-      // Pass 2 : process only range of tiles metric setting 
-      for (size_t i = 0; i < metricsSettings.size(); ++i) {
-        if ((metrics[i].size() != 3) && (metrics[i].size() != 5))
-          continue;
-        
-        uint32_t minCol = 0, minRow = 0;
-        uint32_t maxCol = 0, maxRow = 0;
-
+      // Grab channel numbers (if specified; MEM tiles only)
+      if (metrics[i].size() == 4) {
         try {
-          for (size_t j = 0; j < metrics[i].size(); ++j) {
-            boost::replace_all(metrics[i][j], "{", "");
-            boost::replace_all(metrics[i][j], "}", "");
+          for (auto &e : allValidTiles) {
+            configChannel0[e] = std::stoi(metrics[i][2]);
+            configChannel1[e] = std::stoi(metrics[i][3]);
           }
-
-          std::vector<std::string> minTile;
-          boost::split(minTile, metrics[i][0], boost::is_any_of(","));
-          minCol = std::stoi(minTile[0]);
-          minRow = std::stoi(minTile[1]) + rowOffset;
-
-          std::vector<std::string> maxTile;
-          boost::split(maxTile, metrics[i][1], boost::is_any_of(","));
-          maxCol = std::stoi(maxTile[0]);
-          maxRow = std::stoi(maxTile[1]) + rowOffset;
         } catch (...) {
           std::stringstream msg;
-          msg << "Tile range specification in tile_based_" << tileName
-              << "_tile_metrics is not of valid format and hence skipped.";
-          xrt_core::message::send(severity_level::warning, "XRT", msg.str());           
-        }
-
-        // Ensure range is valid 
-        if ((minCol > maxCol) || (minRow > maxRow)) {
-          std::stringstream msg;
-          msg << "Tile range specification in tile_based_" << tileName 
-              << "_tile_metrics is not of valid format and hence skipped.";
+          msg << "Channel specifications in tile_based_" << tileName
+              << "_tile_metrics are not valid and hence ignored.";
           xrt_core::message::send(severity_level::warning, "XRT", msg.str());
-          continue;
+        }
+      }
+    } // Pass 1 
+
+    // Pass 2 : process only range of tiles metric setting 
+    for (size_t i = 0; i < metricsSettings.size(); ++i) {
+      if ((metrics[i].size() != 3) && (metrics[i].size() != 5))
+        continue;
+      
+      uint32_t minCol = 0, minRow = 0;
+      uint32_t maxCol = 0, maxRow = 0;
+
+      try {
+        for (size_t j = 0; j < metrics[i].size(); ++j) {
+          boost::replace_all(metrics[i][j], "{", "");
+          boost::replace_all(metrics[i][j], "}", "");
         }
 
-        uint8_t channel0 = 0;
-        uint8_t channel1 = 1;
-        if (metrics[i].size() == 5) {
-          try {
-            channel0 = std::stoi(metrics[i][3]);
-            channel1 = std::stoi(metrics[i][4]);
-          } catch (...) {
-            std::stringstream msg;
-            msg << "Channel specifications in tile_based_" << tileName
-                << "_tile_metrics are not valid and hence ignored.";
-            xrt_core::message::send(severity_level::warning, "XRT", msg.str());
-          }
-        }
+        std::vector<std::string> minTile;
+        boost::split(minTile, metrics[i][0], boost::is_any_of(","));
+        minCol = std::stoi(minTile[0]);
+        minRow = std::stoi(minTile[1]) + rowOffset;
 
-        for (uint32_t col = minCol; col <= maxCol; ++col) {
-          for (uint32_t row = minRow; row <= maxRow; ++row) {
-            tile_type tile;
-            tile.col = col;
-            tile.row = row;
+        std::vector<std::string> maxTile;
+        boost::split(maxTile, metrics[i][1], boost::is_any_of(","));
+        maxCol = std::stoi(maxTile[0]);
+        maxRow = std::stoi(maxTile[1]) + rowOffset;
+      } catch (...) {
+        std::stringstream msg;
+        msg << "Tile range specification in tile_based_" << tileName
+            << "_tile_metrics is not of valid format and hence skipped.";
+        xrt_core::message::send(severity_level::warning, "XRT", msg.str());           
+      }
 
-            // Make sure tile is used
-            if (allValidTiles.find(tile) == allValidTiles.end()) {
-              std::stringstream msg;
-              msg << "Specified Tile {" << std::to_string(tile.col) << ","
-                  << std::to_string(tile.row) << "} is not active. Hence skipped.";
-              xrt_core::message::send(severity_level::warning, "XRT", msg.str());
-              continue;
-            }
-            
-            configMetrics[tile] = metrics[i][2];
+      // Ensure range is valid 
+      if ((minCol > maxCol) || (minRow > maxRow)) {
+        std::stringstream msg;
+        msg << "Tile range specification in tile_based_" << tileName 
+            << "_tile_metrics is not of valid format and hence skipped.";
+        xrt_core::message::send(severity_level::warning, "XRT", msg.str());
+        continue;
+      }
 
-            // Grab channel numbers (if specified; MEM tiles only)
-            if (metrics[i].size() == 5) {
-              configChannel0[tile] = channel0;
-              configChannel1[tile] = channel1;
-            }
-          }
-        }
-      } // Pass 2
-
-      // Pass 3 : process only single tile metric setting 
-      for (size_t i = 0; i < metricsSettings.size(); ++i) {
-        // Check if already processed
-        if ((metrics[i][0].compare("all") == 0) || (metrics[i].size() == 3)
-            || (metrics[i].size() == 5))
-          continue;
-
-        uint16_t col = 0;
-        uint16_t row = 0;
-
+      uint8_t channel0 = 0;
+      uint8_t channel1 = 1;
+      if (metrics[i].size() == 5) {
         try {
-          boost::replace_all(metrics[i][0], "{", "");
-          boost::replace_all(metrics[i][0], "}", "");
-
-          std::vector<std::string> tilePos;
-          boost::split(tilePos, metrics[i][0], boost::is_any_of(","));
-          col = std::stoi(tilePos[0]);
-          row = std::stoi(tilePos[1]) + rowOffset;
+          channel0 = std::stoi(metrics[i][3]);
+          channel1 = std::stoi(metrics[i][4]);
         } catch (...) {
           std::stringstream msg;
-          msg << "Tile specification in tile_based_" << tileName
-              << "_tile_metrics is not valid format and hence skipped.";
+          msg << "Channel specifications in tile_based_" << tileName
+              << "_tile_metrics are not valid and hence ignored.";
           xrt_core::message::send(severity_level::warning, "XRT", msg.str());
-          continue;
         }
+      }
 
-        tile_type tile;
-        tile.col = col;
-        tile.row = row;
+      for (uint32_t col = minCol; col <= maxCol; ++col) {
+        for (uint32_t row = minRow; row <= maxRow; ++row) {
+          tile_type tile;
+          tile.col = col;
+          tile.row = row;
 
-        // Make sure tile is used
-        if (allValidTiles.find(tile) == allValidTiles.end()) {
-          std::stringstream msg;
-          msg << "Specified Tile {" << std::to_string(tile.col) << ","
-              << std::to_string(tile.row) << "} is not active. Hence skipped.";
-          xrt_core::message::send(severity_level::warning, "XRT", msg.str());
-          continue;
-        }
-
-        configMetrics[tile] = metrics[i][1];
-        
-        // Grab channel numbers (if specified; MEM tiles only)
-        if (metrics[i].size() == 4) {
-          try {
-            configChannel0[tile] = std::stoi(metrics[i][2]);
-            configChannel1[tile] = std::stoi(metrics[i][3]);
-          } catch (...) {
+          // Make sure tile is used
+          if (allValidTiles.find(tile) == allValidTiles.end()) {
             std::stringstream msg;
-            msg << "Channel specifications in tile_based_" << tileName
-                << "_tile_metrics are not valid and hence ignored.";
+            msg << "Specified Tile {" << std::to_string(tile.col) << ","
+                << std::to_string(tile.row) << "} is not active. Hence skipped.";
             xrt_core::message::send(severity_level::warning, "XRT", msg.str());
+            continue;
+          }
+          
+          configMetrics[tile] = metrics[i][2];
+
+          // Grab channel numbers (if specified; MEM tiles only)
+          if (metrics[i].size() == 5) {
+            configChannel0[tile] = channel0;
+            configChannel1[tile] = channel1;
           }
         }
-      } // Pass 3 
-    }
+      }
+    } // Pass 2
+
+    // Pass 3 : process only single tile metric setting 
+    for (size_t i = 0; i < metricsSettings.size(); ++i) {
+      // Check if already processed
+      if ((metrics[i][0].compare("all") == 0) || (metrics[i].size() == 3)
+          || (metrics[i].size() == 5))
+        continue;
+
+      uint16_t col = 0;
+      uint16_t row = 0;
+
+      try {
+        boost::replace_all(metrics[i][0], "{", "");
+        boost::replace_all(metrics[i][0], "}", "");
+
+        std::vector<std::string> tilePos;
+        boost::split(tilePos, metrics[i][0], boost::is_any_of(","));
+        col = std::stoi(tilePos[0]);
+        row = std::stoi(tilePos[1]) + rowOffset;
+      } catch (...) {
+        std::stringstream msg;
+        msg << "Tile specification in tile_based_" << tileName
+            << "_tile_metrics is not valid format and hence skipped.";
+        xrt_core::message::send(severity_level::warning, "XRT", msg.str());
+        continue;
+      }
+
+      tile_type tile;
+      tile.col = col;
+      tile.row = row;
+
+      // Make sure tile is used
+      if (allValidTiles.find(tile) == allValidTiles.end()) {
+        std::stringstream msg;
+        msg << "Specified Tile {" << std::to_string(tile.col) << ","
+            << std::to_string(tile.row) << "} is not active. Hence skipped.";
+        xrt_core::message::send(severity_level::warning, "XRT", msg.str());
+        continue;
+      }
+
+      configMetrics[tile] = metrics[i][1];
+      
+      // Grab channel numbers (if specified; MEM tiles only)
+      if (metrics[i].size() == 4) {
+        try {
+          configChannel0[tile] = std::stoi(metrics[i][2]);
+          configChannel1[tile] = std::stoi(metrics[i][3]);
+        } catch (...) {
+          std::stringstream msg;
+          msg << "Channel specifications in tile_based_" << tileName
+              << "_tile_metrics are not valid and hence ignored.";
+          xrt_core::message::send(severity_level::warning, "XRT", msg.str());
+        }
+      }
+    } // Pass 3
 
     // Set default, check validity, and remove "off" tiles
     auto defaultSet = defaultSets[type];

--- a/src/runtime_src/xdp/profile/plugin/aie_trace_new/aie_trace_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace_new/aie_trace_metadata.cpp
@@ -528,13 +528,12 @@ namespace xdp {
                                              std::vector<std::string>& graphMetricsSettings,
                                              module_type type)
   {
-    // Make sure settings are available and appropriate
-    if (metricsSettings.empty() && graphMetricsSettings.empty()) {
-      return;
-    }
+    // MEM tiles are not supported in AIE1
     if ((getHardwareGen() == 1) && (type == module_type::mem_tile)) {
-      xrt_core::message::send(severity_level::warning, "XRT",
-        "MEM tiles are not available in AIE1. Trace settings will be ignored.");
+      if (!metricsSettings.empty() || !graphMetricsSettings.empty()) {
+        xrt_core::message::send(severity_level::warning, "XRT",
+          "MEM tiles are not available in AIE1. Trace settings will be ignored.");
+      }
       return;
     }
       
@@ -556,103 +555,104 @@ namespace xdp {
      * MEM Tiles (AIE2 and beyond)
      * graph_based_mem_tile_metrics = <graph name|all>:<kernel name|all>:<off|input_channels|input_channels_stalls|output_channels|output_channels_stalls>[:<channel 1>][:<channel 2>]
      */
+    if (graphMetricsSettings.size() > 0) {
+      std::vector<std::vector<std::string>> graphMetrics(graphMetricsSettings.size());
 
-    std::vector<std::vector<std::string>> graphMetrics(graphMetricsSettings.size());
+      // Graph Pass 1 : process only "all" metric setting
+      for (size_t i = 0; i < graphMetricsSettings.size(); ++i) {
+        // Split done only in Pass 1
+        boost::split(graphMetrics[i], graphMetricsSettings[i], boost::is_any_of(":"));
 
-    // Graph Pass 1 : process only "all" metric setting
-    for (size_t i = 0; i < graphMetricsSettings.size(); ++i) {
-      // Split done only in Pass 1
-      boost::split(graphMetrics[i], graphMetricsSettings[i], boost::is_any_of(":"));
-
-      // Check if graph is not all or if invalid kernel
-      if (graphMetrics[i][0].compare("all") != 0)
-        continue;
-      if ((graphMetrics[i][1].compare("all") != 0)
-          && (std::find(allValidKernels.begin(), allValidKernels.end(), graphMetrics[i][1]) == allValidKernels.end())) {
-        std::stringstream msg;
-        msg << "Kernel " << graphMetrics[i][1] << " not found. The graph_based_" << tileName
-            << "_metrics setting " << graphMetricsSettings[i] << " will be ignored.";
-        xrt_core::message::send(severity_level::warning, "XRT", msg.str());
-        continue;
-      }
-
-      auto tiles = get_tiles(device.get(), graphMetrics[i][0], type, graphMetrics[i][1]);
-      for (auto &e : tiles) {
-        configMetrics[e] = graphMetrics[i][2];
-      }
-
-      // Grab channel numbers (if specified; MEM tiles only)
-      if (graphMetrics[i].size() == 5) {
-        try {
-          for (auto &e : tiles) {
-            configChannel0[e] = std::stoi(graphMetrics[i][3]);
-            configChannel1[e] = std::stoi(graphMetrics[i][4]);
-          }
-        } catch (...) {
+        // Check if graph is not all or if invalid kernel
+        if (graphMetrics[i][0].compare("all") != 0)
+          continue;
+        if ((graphMetrics[i][1].compare("all") != 0)
+            && (std::find(allValidKernels.begin(), allValidKernels.end(), graphMetrics[i][1]) == allValidKernels.end())) {
           std::stringstream msg;
-          msg << "Channel specifications in graph_based_" << tileName 
-              << "_tile_metrics are not valid and hence ignored.";
+          msg << "Kernel " << graphMetrics[i][1] << " not found. The graph_based_" << tileName
+              << "_metrics setting " << graphMetricsSettings[i] << " will be ignored.";
           xrt_core::message::send(severity_level::warning, "XRT", msg.str());
+          continue;
         }
-      }
-    } // Graph Pass 1
 
-    // Graph Pass 2 : process per graph metric setting
-    for (size_t i = 0; i < graphMetricsSettings.size(); ++i) {
-      // Check if already processed or if invalid
-      if (graphMetrics[i][0].compare("all") == 0)
-        continue;
-      if (std::find(allValidGraphs.begin(), allValidGraphs.end(), graphMetrics[i][0]) == allValidGraphs.end()) {
-        std::stringstream msg;
-        msg << "Graph " << graphMetrics[i][0] << " not found. The graph_based_" << tileName
-            << "_metrics setting " << graphMetricsSettings[i] << " will be ignored.";
-        xrt_core::message::send(severity_level::warning, "XRT", msg.str());
-        continue;
-      }
-      if ((graphMetrics[i][1].compare("all") != 0)
-          && (std::find(allValidKernels.begin(), allValidKernels.end(), graphMetrics[i][1]) == allValidKernels.end())) {
-        std::stringstream msg;
-        msg << "Kernel " << graphMetrics[i][1] << " not found. The graph_based_" << tileName
-            << "_metrics setting " << graphMetricsSettings[i] << " will be ignored.";
-        xrt_core::message::send(severity_level::warning, "XRT", msg.str());
-        continue;
-      }
-
-      // Check if specified graph exists
-      auto graphs = get_graphs(device.get());
-      if (!graphs.empty() && (std::find(graphs.begin(), graphs.end(), graphMetrics[i][0]) == graphs.end())) {
-        std::stringstream msg;
-        msg << "Could not find graph named " << graphMetrics[i][0] 
-            << ", as specified in graph_based_" << tileName << "_tile_metrics configuration."
-            << " Following graphs are present in the design : " << graphs[0];
-        for (size_t j = 1; j < graphs.size(); j++) {
-          msg << ", " + graphs[j];
+        auto tiles = get_tiles(device.get(), graphMetrics[i][0], type, graphMetrics[i][1]);
+        for (auto &e : tiles) {
+          configMetrics[e] = graphMetrics[i][2];
         }
-        msg << ".";
-        xrt_core::message::send(severity_level::warning, "XRT", msg.str());
-        continue;
-      }
 
-      auto tiles = get_tiles(device.get(), graphMetrics[i][0], type, graphMetrics[i][1]);
-      for (auto &e : tiles) {
-        configMetrics[e] = graphMetrics[i][2];
-      }
-
-      // Grab channel numbers (if specified; MEM tiles only)
-      if (graphMetrics[i].size() == 5) {
-        try {
-          for (auto &e : tiles) {
-            configChannel0[e] = std::stoi(graphMetrics[i][3]);
-            configChannel1[e] = std::stoi(graphMetrics[i][4]);
+        // Grab channel numbers (if specified; MEM tiles only)
+        if (graphMetrics[i].size() == 5) {
+          try {
+            for (auto &e : tiles) {
+              configChannel0[e] = std::stoi(graphMetrics[i][3]);
+              configChannel1[e] = std::stoi(graphMetrics[i][4]);
+            }
+          } catch (...) {
+            std::stringstream msg;
+            msg << "Channel specifications in graph_based_" << tileName 
+                << "_tile_metrics are not valid and hence ignored.";
+            xrt_core::message::send(severity_level::warning, "XRT", msg.str());
           }
-        } catch (...) {
-          std::stringstream msg;
-          msg << "Channel specifications in graph_based_" << tileName
-              << "_tile_metrics are not valid and hence ignored.";
-          xrt_core::message::send(severity_level::warning, "XRT", msg.str());
         }
-      }
-    } // Graph Pass 2
+      } // Graph Pass 1
+
+      // Graph Pass 2 : process per graph metric setting
+      for (size_t i = 0; i < graphMetricsSettings.size(); ++i) {
+        // Check if already processed or if invalid
+        if (graphMetrics[i][0].compare("all") == 0)
+          continue;
+        if (std::find(allValidGraphs.begin(), allValidGraphs.end(), graphMetrics[i][0]) == allValidGraphs.end()) {
+          std::stringstream msg;
+          msg << "Graph " << graphMetrics[i][0] << " not found. The graph_based_" << tileName
+              << "_metrics setting " << graphMetricsSettings[i] << " will be ignored.";
+          xrt_core::message::send(severity_level::warning, "XRT", msg.str());
+          continue;
+        }
+        if ((graphMetrics[i][1].compare("all") != 0)
+            && (std::find(allValidKernels.begin(), allValidKernels.end(), graphMetrics[i][1]) == allValidKernels.end())) {
+          std::stringstream msg;
+          msg << "Kernel " << graphMetrics[i][1] << " not found. The graph_based_" << tileName
+              << "_metrics setting " << graphMetricsSettings[i] << " will be ignored.";
+          xrt_core::message::send(severity_level::warning, "XRT", msg.str());
+          continue;
+        }
+
+        // Check if specified graph exists
+        auto graphs = get_graphs(device.get());
+        if (!graphs.empty() && (std::find(graphs.begin(), graphs.end(), graphMetrics[i][0]) == graphs.end())) {
+          std::stringstream msg;
+          msg << "Could not find graph named " << graphMetrics[i][0] 
+              << ", as specified in graph_based_" << tileName << "_tile_metrics configuration."
+              << " Following graphs are present in the design : " << graphs[0];
+          for (size_t j = 1; j < graphs.size(); j++) {
+            msg << ", " + graphs[j];
+          }
+          msg << ".";
+          xrt_core::message::send(severity_level::warning, "XRT", msg.str());
+          continue;
+        }
+
+        auto tiles = get_tiles(device.get(), graphMetrics[i][0], type, graphMetrics[i][1]);
+        for (auto &e : tiles) {
+          configMetrics[e] = graphMetrics[i][2];
+        }
+
+        // Grab channel numbers (if specified; MEM tiles only)
+        if (graphMetrics[i].size() == 5) {
+          try {
+            for (auto &e : tiles) {
+              configChannel0[e] = std::stoi(graphMetrics[i][3]);
+              configChannel1[e] = std::stoi(graphMetrics[i][4]);
+            }
+          } catch (...) {
+            std::stringstream msg;
+            msg << "Channel specifications in graph_based_" << tileName
+                << "_tile_metrics are not valid and hence ignored.";
+            xrt_core::message::send(severity_level::warning, "XRT", msg.str());
+          }
+        }
+      } // Graph Pass 2
+    }
 
     // STEP 2 : Parse per-tile settings: all, bounding box, and/or single tiles
 
@@ -669,176 +669,183 @@ namespace xdp {
      * Range of tiles
      * tile_based_mem_tile_metrics = {<mincolumn,<minrow>}:{<maxcolumn>,<maxrow>}:<off|input_channels|input_channels_stalls|output_channels|output_channels_stalls>[:<channel 1>][:<channel 2>]
      */
+    if (metricsSettings.size() > 0) {
+      std::vector<std::vector<std::string>> metrics(metricsSettings.size());
 
-    std::vector<std::vector<std::string>> metrics(metricsSettings.size());
+      // Pass 1 : process only "all" metric setting 
+      for (size_t i = 0; i < metricsSettings.size(); ++i) {
+        // Split done only in Pass 1
+        boost::split(metrics[i], metricsSettings[i], boost::is_any_of(":"));
 
-    // Pass 1 : process only "all" metric setting 
-    for (size_t i = 0; i < metricsSettings.size(); ++i) {
-      // Split done only in Pass 1
-      boost::split(metrics[i], metricsSettings[i], boost::is_any_of(":"));
+        if ((metrics[i][0].compare("all") != 0) || (metrics[i].size() < 2))
+          continue;
 
-      if ((metrics[i][0].compare("all") != 0) || (metrics[i].size() < 2))
-        continue;
-
-      auto tiles = get_tiles(device.get(), metrics[i][0], type);
-      for (auto &e : tiles) {
-        configMetrics[e] = metrics[i][1];
-      }
-
-      // Grab channel numbers (if specified; MEM tiles only)
-      if (metrics[i].size() == 4) {
-        try {
-          for (auto &e : allValidTiles) {
-            configChannel0[e] = std::stoi(metrics[i][2]);
-            configChannel1[e] = std::stoi(metrics[i][3]);
-          }
-        } catch (...) {
-          std::stringstream msg;
-          msg << "Channel specifications in tile_based_" << tileName
-              << "_tile_metrics are not valid and hence ignored.";
-          xrt_core::message::send(severity_level::warning, "XRT", msg.str());
-        }
-      }
-    } // Pass 1 
-
-    // Pass 2 : process only range of tiles metric setting 
-    for (size_t i = 0; i < metricsSettings.size(); ++i) {
-      if ((metrics[i].size() != 3) && (metrics[i].size() != 5))
-        continue;
-      
-      uint32_t minCol = 0, minRow = 0;
-      uint32_t maxCol = 0, maxRow = 0;
-
-      try {
-        for (size_t j = 0; j < metrics[i].size(); ++j) {
-          boost::replace_all(metrics[i][j], "{", "");
-          boost::replace_all(metrics[i][j], "}", "");
+        auto tiles = get_tiles(device.get(), metrics[i][0], type);
+        for (auto &e : tiles) {
+          configMetrics[e] = metrics[i][1];
         }
 
-        std::vector<std::string> minTile;
-        boost::split(minTile, metrics[i][0], boost::is_any_of(","));
-        minCol = std::stoi(minTile[0]);
-        minRow = std::stoi(minTile[1]) + rowOffset;
-
-        std::vector<std::string> maxTile;
-        boost::split(maxTile, metrics[i][1], boost::is_any_of(","));
-        maxCol = std::stoi(maxTile[0]);
-        maxRow = std::stoi(maxTile[1]) + rowOffset;
-      } catch (...) {
-        std::stringstream msg;
-        msg << "Tile range specification in tile_based_" << tileName
-            << "_tile_metrics is not of valid format and hence skipped.";
-        xrt_core::message::send(severity_level::warning, "XRT", msg.str());           
-      }
-
-      // Ensure range is valid 
-      if ((minCol > maxCol) || (minRow > maxRow)) {
-        std::stringstream msg;
-        msg << "Tile range specification in tile_based_" << tileName 
-            << "_tile_metrics is not of valid format and hence skipped.";
-        xrt_core::message::send(severity_level::warning, "XRT", msg.str());
-        continue;
-      }
-
-      uint8_t channel0 = 0;
-      uint8_t channel1 = 1;
-      if (metrics[i].size() == 5) {
-        try {
-          channel0 = std::stoi(metrics[i][3]);
-          channel1 = std::stoi(metrics[i][4]);
-        } catch (...) {
-          std::stringstream msg;
-          msg << "Channel specifications in tile_based_" << tileName
-              << "_tile_metrics are not valid and hence ignored.";
-          xrt_core::message::send(severity_level::warning, "XRT", msg.str());
-        }
-      }
-
-      for (uint32_t col = minCol; col <= maxCol; ++col) {
-        for (uint32_t row = minRow; row <= maxRow; ++row) {
-          tile_type tile;
-          tile.col = col;
-          tile.row = row;
-
-          // Make sure tile is used
-          if (allValidTiles.find(tile) == allValidTiles.end()) {
+        // Grab channel numbers (if specified; MEM tiles only)
+        if (metrics[i].size() == 4) {
+          try {
+            for (auto &e : allValidTiles) {
+              configChannel0[e] = std::stoi(metrics[i][2]);
+              configChannel1[e] = std::stoi(metrics[i][3]);
+            }
+          } catch (...) {
             std::stringstream msg;
-            msg << "Specified Tile {" << std::to_string(tile.col) << ","
-                << std::to_string(tile.row) << "} is not active. Hence skipped.";
+            msg << "Channel specifications in tile_based_" << tileName
+                << "_tile_metrics are not valid and hence ignored.";
             xrt_core::message::send(severity_level::warning, "XRT", msg.str());
-            continue;
-          }
-          
-          configMetrics[tile] = metrics[i][2];
-
-          // Grab channel numbers (if specified; MEM tiles only)
-          if (metrics[i].size() == 5) {
-            configChannel0[tile] = channel0;
-            configChannel1[tile] = channel1;
           }
         }
-      }
-    } // Pass 2
+      } // Pass 1 
 
-    // Pass 3 : process only single tile metric setting 
-    for (size_t i = 0; i < metricsSettings.size(); ++i) {
-      // Check if already processed
-      if ((metrics[i][0].compare("all") == 0) || (metrics[i].size() == 3)
-          || (metrics[i].size() == 5))
-        continue;
+      // Pass 2 : process only range of tiles metric setting 
+      for (size_t i = 0; i < metricsSettings.size(); ++i) {
+        if ((metrics[i].size() != 3) && (metrics[i].size() != 5))
+          continue;
+        
+        uint32_t minCol = 0, minRow = 0;
+        uint32_t maxCol = 0, maxRow = 0;
 
-      uint16_t col = 0;
-      uint16_t row = 0;
-
-      try {
-        boost::replace_all(metrics[i][0], "{", "");
-        boost::replace_all(metrics[i][0], "}", "");
-
-        std::vector<std::string> tilePos;
-        boost::split(tilePos, metrics[i][0], boost::is_any_of(","));
-        col = std::stoi(tilePos[0]);
-        row = std::stoi(tilePos[1]) + rowOffset;
-      } catch (...) {
-        std::stringstream msg;
-        msg << "Tile specification in tile_based_" << tileName
-            << "_tile_metrics is not valid format and hence skipped.";
-        xrt_core::message::send(severity_level::warning, "XRT", msg.str());
-        continue;
-      }
-
-      tile_type tile;
-      tile.col = col;
-      tile.row = row;
-
-      // Make sure tile is used
-      if (allValidTiles.find(tile) == allValidTiles.end()) {
-        std::stringstream msg;
-        msg << "Specified Tile {" << std::to_string(tile.col) << ","
-            << std::to_string(tile.row) << "} is not active. Hence skipped.";
-        xrt_core::message::send(severity_level::warning, "XRT", msg.str());
-        continue;
-      }
-
-      configMetrics[tile] = metrics[i][1];
-      
-      // Grab channel numbers (if specified; MEM tiles only)
-      if (metrics[i].size() == 4) {
         try {
-          configChannel0[tile] = std::stoi(metrics[i][2]);
-          configChannel1[tile] = std::stoi(metrics[i][3]);
+          for (size_t j = 0; j < metrics[i].size(); ++j) {
+            boost::replace_all(metrics[i][j], "{", "");
+            boost::replace_all(metrics[i][j], "}", "");
+          }
+
+          std::vector<std::string> minTile;
+          boost::split(minTile, metrics[i][0], boost::is_any_of(","));
+          minCol = std::stoi(minTile[0]);
+          minRow = std::stoi(minTile[1]) + rowOffset;
+
+          std::vector<std::string> maxTile;
+          boost::split(maxTile, metrics[i][1], boost::is_any_of(","));
+          maxCol = std::stoi(maxTile[0]);
+          maxRow = std::stoi(maxTile[1]) + rowOffset;
         } catch (...) {
           std::stringstream msg;
-          msg << "Channel specifications in tile_based_" << tileName
-              << "_tile_metrics are not valid and hence ignored.";
-          xrt_core::message::send(severity_level::warning, "XRT", msg.str());
+          msg << "Tile range specification in tile_based_" << tileName
+              << "_tile_metrics is not of valid format and hence skipped.";
+          xrt_core::message::send(severity_level::warning, "XRT", msg.str());           
         }
-      }
-    } // Pass 3 
 
-    // Check validity and remove "off" tiles
-    std::vector<tile_type> offTiles;
+        // Ensure range is valid 
+        if ((minCol > maxCol) || (minRow > maxRow)) {
+          std::stringstream msg;
+          msg << "Tile range specification in tile_based_" << tileName 
+              << "_tile_metrics is not of valid format and hence skipped.";
+          xrt_core::message::send(severity_level::warning, "XRT", msg.str());
+          continue;
+        }
+
+        uint8_t channel0 = 0;
+        uint8_t channel1 = 1;
+        if (metrics[i].size() == 5) {
+          try {
+            channel0 = std::stoi(metrics[i][3]);
+            channel1 = std::stoi(metrics[i][4]);
+          } catch (...) {
+            std::stringstream msg;
+            msg << "Channel specifications in tile_based_" << tileName
+                << "_tile_metrics are not valid and hence ignored.";
+            xrt_core::message::send(severity_level::warning, "XRT", msg.str());
+          }
+        }
+
+        for (uint32_t col = minCol; col <= maxCol; ++col) {
+          for (uint32_t row = minRow; row <= maxRow; ++row) {
+            tile_type tile;
+            tile.col = col;
+            tile.row = row;
+
+            // Make sure tile is used
+            if (allValidTiles.find(tile) == allValidTiles.end()) {
+              std::stringstream msg;
+              msg << "Specified Tile {" << std::to_string(tile.col) << ","
+                  << std::to_string(tile.row) << "} is not active. Hence skipped.";
+              xrt_core::message::send(severity_level::warning, "XRT", msg.str());
+              continue;
+            }
+            
+            configMetrics[tile] = metrics[i][2];
+
+            // Grab channel numbers (if specified; MEM tiles only)
+            if (metrics[i].size() == 5) {
+              configChannel0[tile] = channel0;
+              configChannel1[tile] = channel1;
+            }
+          }
+        }
+      } // Pass 2
+
+      // Pass 3 : process only single tile metric setting 
+      for (size_t i = 0; i < metricsSettings.size(); ++i) {
+        // Check if already processed
+        if ((metrics[i][0].compare("all") == 0) || (metrics[i].size() == 3)
+            || (metrics[i].size() == 5))
+          continue;
+
+        uint16_t col = 0;
+        uint16_t row = 0;
+
+        try {
+          boost::replace_all(metrics[i][0], "{", "");
+          boost::replace_all(metrics[i][0], "}", "");
+
+          std::vector<std::string> tilePos;
+          boost::split(tilePos, metrics[i][0], boost::is_any_of(","));
+          col = std::stoi(tilePos[0]);
+          row = std::stoi(tilePos[1]) + rowOffset;
+        } catch (...) {
+          std::stringstream msg;
+          msg << "Tile specification in tile_based_" << tileName
+              << "_tile_metrics is not valid format and hence skipped.";
+          xrt_core::message::send(severity_level::warning, "XRT", msg.str());
+          continue;
+        }
+
+        tile_type tile;
+        tile.col = col;
+        tile.row = row;
+
+        // Make sure tile is used
+        if (allValidTiles.find(tile) == allValidTiles.end()) {
+          std::stringstream msg;
+          msg << "Specified Tile {" << std::to_string(tile.col) << ","
+              << std::to_string(tile.row) << "} is not active. Hence skipped.";
+          xrt_core::message::send(severity_level::warning, "XRT", msg.str());
+          continue;
+        }
+
+        configMetrics[tile] = metrics[i][1];
+        
+        // Grab channel numbers (if specified; MEM tiles only)
+        if (metrics[i].size() == 4) {
+          try {
+            configChannel0[tile] = std::stoi(metrics[i][2]);
+            configChannel1[tile] = std::stoi(metrics[i][3]);
+          } catch (...) {
+            std::stringstream msg;
+            msg << "Channel specifications in tile_based_" << tileName
+                << "_tile_metrics are not valid and hence ignored.";
+            xrt_core::message::send(severity_level::warning, "XRT", msg.str());
+          }
+        }
+      } // Pass 3 
+    }
+
+    // Set default, check validity, and remove "off" tiles
+    auto defaultSet = defaultSets[type];
+    for (auto &e : allValidTiles) {
+      if (configMetrics.find(e) == configMetrics.end())
+        configMetrics[e] = defaultSet;
+    }
 
     bool showWarning = true;
+    std::vector<tile_type> offTiles;
+
     for (auto &tileMetric : configMetrics) {
       // Save list of "off" tiles
       if (tileMetric.second.empty() || (tileMetric.second.compare("off") == 0)) {
@@ -851,7 +858,6 @@ namespace xdp {
           && (std::find(metricSets.begin(), metricSets.end(), tileMetric.second) == metricSets.end()))
           || ((type == module_type::mem_tile) 
           && (std::find(memTileMetricSets.begin(), memTileMetricSets.end(), tileMetric.second) == memTileMetricSets.end()))) {
-        std::string defaultSet = (type == module_type::mem_tile) ? "input_channels" : "functions";
         if (showWarning) {
           std::stringstream msg;
           msg << "Unable to find AIE trace metric set " << tileMetric.second 

--- a/src/runtime_src/xdp/profile/plugin/aie_trace_new/aie_trace_metadata.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace_new/aie_trace_metadata.h
@@ -46,8 +46,8 @@ class AieTraceMetadata{
     uint32_t iterationCount = 0;
     uint64_t delayCycles = 0;
     uint64_t deviceID;
-    uint64_t numAIETraceOutput;
-    uint64_t offloadIntervalUs;
+    uint64_t numAIETraceOutput = 0;
+    uint64_t offloadIntervalUs = 0;
     unsigned int aie_trace_file_dump_int_s;
 
     std::string counterScheme;

--- a/src/runtime_src/xdp/profile/plugin/aie_trace_new/aie_trace_metadata.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace_new/aie_trace_metadata.h
@@ -58,6 +58,11 @@ class AieTraceMetadata{
     std::map<tile_type, uint8_t> configChannel0;
     std::map<tile_type, uint8_t> configChannel1;
 
+    std::map<module_type, std::string> defaultSets {
+      { module_type::core,     "functions"},
+      { module_type::mem_tile, "input_channels"}
+    };
+
     void* handle;
 
   public:


### PR DESCRIPTION
**Problem solved by the commit**
* Fixed MEM tiles payload in profiling
* Reporting relative rows in profile csv
* Setting default metric set for trace

**Risks (if any) associated the changes in the commit**
Trace changed behavior by using default set when only partially specified

**What has been tested and how, request additional testing if necessary**
Tested on vek280 and vck190

**Documentation impact (if any)**
Default metric sets changed