### PR TITLE
Fixes for seven XDP related Coverity issues

### DIFF
--- a/src/runtime_src/core/common/api/xrt_profile.cpp
+++ b/src/runtime_src/core/common/api/xrt_profile.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2020-2022, Xilinx Inc - All rights reserved
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
  * Xilinx Runtime (XRT) Experimental APIs
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
@@ -24,7 +24,7 @@
 #include "core/include/experimental/xrt_profile.h"
 
 #include "core/common/dlfcn.h"
-#include "core/common/message.h"
+#include "core/common/error.h"
 #include "core/common/module_loader.h"
 #include "core/common/utils.h"
 
@@ -148,7 +148,7 @@ xrtURStart(unsigned int id, const char* label, const char* tooltip)
   }
   catch (const std::exception& ex)
   {
-    xrt_core::message::send(xrt_core::message::severity_level::error, "XRT", ex.what());
+    xrt_core::send_exception_message(ex.what());
   }
 }
 
@@ -162,7 +162,7 @@ xrtUREnd(unsigned int id)
   }
   catch (const std::exception& ex)
   {
-    xrt_core::message::send(xrt_core::message::severity_level::error, "XRT", ex.what());
+    xrt_core::send_exception_message(ex.what());
   }
 }
 
@@ -176,7 +176,7 @@ xrtUEMark(const char* label)
   }
   catch (const std::exception& ex)
   {
-    xrt_core::message::send(xrt_core::message::severity_level::error, "XRT", ex.what());
+    xrt_core::send_exception_message(ex.what());
   }
 }
 
@@ -190,7 +190,7 @@ xrtUEMarkTimeNs(unsigned long long int time_ns, const char* label)
   }
   catch (const std::exception& ex)
   {
-    xrt_core::message::send(xrt_core::message::severity_level::error, "XRT", ex.what());
+    xrt_core::send_exception_message(ex.what());
   }
 }
 

--- a/src/runtime_src/core/pcie/emulation/hw_emu/alveo_shim/plugin/xdp/plugin_loader.cpp
+++ b/src/runtime_src/core/pcie/emulation/hw_emu/alveo_shim/plugin/xdp/plugin_loader.cpp
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2022 Xilinx, Inc
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -30,16 +31,22 @@ namespace xdp::hw_emu {
   //  options and loading the appropriate debug/profile plugins.
   void load()
   {
-    if (xrt_core::config::get_xrt_trace() ||
-        xrt_core::utils::load_host_trace())
-      xdp::hw_emu::trace::load() ;
-    if (xrt_core::config::get_device_trace() != "off" ||
-        xrt_core::config::get_device_counters())
-      xdp::hw_emu::device_offload::load() ;
-    if (xrt_core::config::get_sc_profile())
-      xdp::hw_emu::sc::load();
-    if (xrt_core::config::get_pl_deadlock_detection())
-      xdp::pl_deadlock::load();
+    try {
+      if (xrt_core::config::get_xrt_trace() ||
+          xrt_core::utils::load_host_trace())
+        xdp::hw_emu::trace::load() ;
+      if (xrt_core::config::get_device_trace() != "off" ||
+          xrt_core::config::get_device_counters())
+        xdp::hw_emu::device_offload::load() ;
+      if (xrt_core::config::get_sc_profile())
+        xdp::hw_emu::sc::load();
+      if (xrt_core::config::get_pl_deadlock_detection())
+        xdp::pl_deadlock::load();
+    }
+    catch (...) {
+      // Boost property tree might throw an error.  If that happens
+      // just keep going without loading additional plugins.
+    }
   }
 
 } // end namespace xdp::hw_emu

--- a/src/runtime_src/xdp/profile/database/static_info_database.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info_database.cpp
@@ -1753,13 +1753,19 @@ namespace xdp {
 
     uint64_t index = static_cast<uint64_t>(debugIpData->m_index_lowbyte) |
       (static_cast<uint64_t>(debugIpData->m_index_highbyte) << 8);
-    if (index < min_trace_id_aim) {
-      std::stringstream msg;
-      msg << "AIM with incorrect index: " << index ;
-      xrt_core::message::send(xrt_core::message::severity_level::info, "XRT",
-                              msg.str());
-      index = min_trace_id_aim ;
-    }
+
+    // The current minimum trace ID assigned to AIMs is 0, so this code
+    // currently has no effect and is being marked as incorrect in Coverity.
+    // It should be uncommented if the minimum trace ID assigned in the
+    // hardware ever chagnes.
+
+    //if (index < min_trace_id_aim) {
+    //  std::stringstream msg;
+    //  msg << "AIM with incorrect index: " << index ;
+    //  xrt_core::message::send(xrt_core::message::severity_level::info, "XRT",
+    //                          msg.str());
+    //  index = min_trace_id_aim ;
+    //}
 
     // Parse name to find CU Name and Memory.  We expect the name in
     //  debug_ip_layout to be in the form of "cu_name/memory_name-port_name"

--- a/src/runtime_src/xdp/profile/writer/aie_trace/aie_trace_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/aie_trace/aie_trace_writer.cpp
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2016-2020 Xilinx, Inc
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -15,10 +15,10 @@
  * under the License.
  */
 
-#include "xdp/profile/writer/aie_trace/aie_trace_writer.h"
+#include "core/common/error.h"
 #include "core/common/message.h"
 
-#include <iostream>
+#include "xdp/profile/writer/aie_trace/aie_trace_writer.h"
 
 namespace xdp {
 
@@ -54,7 +54,7 @@ namespace xdp {
       }
     } catch (...){
       std::string msg = "Trace File: " + getcurrentFileName() + " not found.";
-      xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", msg);
+      xrt_core::send_exception_message(msg);
     }
   }
 

--- a/src/runtime_src/xdp/profile/writer/device_trace/device_trace_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/device_trace/device_trace_writer.cpp
@@ -345,7 +345,7 @@ namespace xdp {
           std::make_pair(xclbin, cuId);
         kernelEvent->dump(fout, cuBucketIdMap[index] + eventType - KERNEL);
         // Also output the tool tips
-        for (auto iter : xclbin->pl.cus) {
+        for (const auto& iter : xclbin->pl.cus) {
           ComputeUnitInstance* cu = iter.second;
           if (cu->getAccelMon() == cuId) {
             fout << "," << db->getDynamicInfo().addString(cu->getKernelName());

--- a/src/runtime_src/xdp/profile/writer/vp_base/vp_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/vp_writer.cpp
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2016-2020 Xilinx, Inc
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -26,7 +27,6 @@
 #else
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <unistd.h>
 #endif
 
 namespace xdp {
@@ -45,53 +45,47 @@ namespace xdp {
 #endif
     fileNum(1), db(inst)
   {
+#ifdef _WIN32
+    // On Windows, we are currently always opening the file in the
+    // current directory and do not yet support the user specified
+    // directory
+    fout.open(filename);
+#else
     directory = xrt_core::config::get_profiling_directory() ;
 
     if (!useDir || directory == "") {
       // If no directory was specified, just use the file in
       //  the working directory
-      fout.open(filename) ;
-      return ;
+      fout.open(filename);
+      return;
     }
 
-    // The directory was specified.  Check if it exists and is writable
-    bool dirExists  = false ;
-    bool writeable  = false ;
-#ifdef _WIN32
-#else
-    struct stat buf = {0} ;
-    int result = stat(directory.c_str(), &buf) ;
-    if (!result) {
-      // The file exists.  Is it a directory?
-      dirExists = S_ISDIR(buf.st_mode) ;
-      if (dirExists) {
-        // The directory exists, but can we write to it?
-        writeable = (buf.st_mode & S_IWUSR) != 0 ;
-      }
-      //else {
-        // The file exists, but it is not a directory.  We cannot write to it
-      //}
+    // The directory was specified.  Try to create it (regardless of if
+    // it exists already or not).
+    constexpr mode_t rwx_all = 0777;
+    int result = mkdir(directory.c_str(), rwx_all);
+
+    if (result != 0) {
+      // We could not create the directory, but that doesn't necessarily
+      // mean it doesn't exist and we don't have access to it.  Just send
+      // an informational message.
+      std::string msg =
+        "The user specified profiling directory could not be created.";
+      xrt_core::message::send(xrt_core::message::severity_level::info,
+                              "XRT", msg);
     }
-    else {
-      // The file does not exist at all, so try to create it
-      const mode_t rwx_all = 0777 ;
-      result = mkdir(directory.c_str(), rwx_all) ;
-      if (!result) {
-        dirExists = true ;
-        writeable = true ;
-      }
+
+    // Try to open the file in the directory + filename
+    currentFileName = directory + separator + filename;
+    fout.open(currentFileName);
+
+    if (!fout) {
+      // If we cannot create the file in the user specified directory, then
+      // just open it in the local directory
+      currentFileName = filename;
+      fout.open(currentFileName);
     }
 #endif
-    if (!dirExists || !writeable) {
-      // If we cannot create the directory, or if we cannot write to
-      //  the directory, then just use the filename
-      fout.open(filename) ;
-      return ;
-    }
-
-    // Set the file name to directory + filename
-    currentFileName = directory + separator + basename ;
-    fout.open(currentFileName) ;
   }
 
   VPWriter::~VPWriter()

--- a/src/runtime_src/xdp/profile/writer/vp_base/vp_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/vp_writer.cpp
@@ -50,6 +50,13 @@ namespace xdp {
     // current directory and do not yet support the user specified
     // directory
     fout.open(filename);
+
+    if (useDir) {
+      std::string msg =
+        "The user specified profiling directory is not supported on Windows.";
+      xrt_core::message::send(xrt_core::message::severity_level::info,
+                              "XRT", msg);
+    }
 #else
     directory = xrt_core::config::get_profiling_directory() ;
 

--- a/src/runtime_src/xocl/api/plugin/xdp/profile_trace.cpp
+++ b/src/runtime_src/xocl/api/plugin/xdp/profile_trace.cpp
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2016-2021 Xilinx, Inc
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -601,7 +602,7 @@ namespace xocl {
 		  localWorkDim) ;
       }
 
-      return [workGroupSize, deviceName, kernelName, binaryName, localWorkDim](xocl::event* e, cl_int status) 
+      return [workGroupSize, deviceName, kernelName, binaryName, &localWorkDim](xocl::event* e, cl_int status) 
 	     {
 	       if (!xdp::opencl_trace::ndrange_cb) return ;
 	       if (status != CL_RUNNING && status != CL_COMPLETE) return ;


### PR DESCRIPTION
#### Problem solved by the commit
This addresses Coverity issues 275614, 275206, 250880, 250879, 249251, 237548, and 236707.

This pull request changes an additional "auto" to "const auto&", changes the calls to xrt_core::message::send() inside catch blocks to xrt_core::send_exception_message(), adds a try..catch block to catch an uncaught exception, changes a lambda capture from value to reference, and fixes a TOCTOU issue in opening files.

#### Risks (if any) associated the changes in the commit
Low risk as the only functionality change is in the opening of files and has been tested.  All other changes are minor.

#### What has been tested and how, request additional testing if necessary
The algorithmic change of how files in directories are opened after removing the TOCTOU issue has been tested.

#### Documentation impact (if any)
No documentation impact.