### PR TITLE
CR-1149236 Enabling passing /var/log/messages through VMR back to host

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/zocl_rpu_channel.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_rpu_channel.c
@@ -199,7 +199,6 @@ static int zchan_cmd_log_apu_log(struct zocl_rpu_channel *chan, u32 add_off, u32
 	}
 
 	fp_size = i_size_read(file_inode(fp));
-	pr_info("kmsg size = %d\n", fp_size);
 	fp_offset = offset;
 	remain_size = fp_size - offset;
 	// Send chunks of log
@@ -242,8 +241,8 @@ static void zchan_cmd_log_page(struct zocl_rpu_channel *chan, struct xgq_cmd_sq_
 	u32 total_count = 0;
 	int ret = 0;
 
-	zchan_info(chan, "addr_off 0x%x, size %d, offset %d, pid %d",
-		add_off, size, offset, pid);
+	//	zchan_info(chan, "addr_off 0x%x, size %d, offset %d, pid %d",
+	//		add_off, size, offset, pid);
 
 	switch (pid) {
 	case XGQ_CMD_LOG_INFO:
@@ -415,7 +414,7 @@ static void zchan_cmd_handler(struct platform_device *pdev, struct xgq_cmd_sq_hd
 	cmd_handler func = opcode2handler(op);
 	struct xgq_com_queue_entry r = {};
 
-	zchan_info(chan, "%s received", opcode2name(op));
+	//	zchan_info(chan, "%s received", opcode2name(op));
 	if (func)
 		func(chan, cmd, &r);
 	else

--- a/src/runtime_src/core/edge/drm/zocl/zocl_rpu_channel.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_rpu_channel.c
@@ -207,6 +207,7 @@ static int zchan_cmd_log_apu_log(struct zocl_rpu_channel *chan, u32 add_off, u32
 		if (!ret) {
 			pr_err("Can't read from /var/log/messages\n");
 			*total_countp = 0;
+			filp_close(fp, NULL);
 			return -EINVAL;
 		}
 		count = size;
@@ -216,6 +217,7 @@ static int zchan_cmd_log_apu_log(struct zocl_rpu_channel *chan, u32 add_off, u32
 			if (!ret) {
 				pr_err("Can't read from /var/log/messages\n");
 				*total_countp = 0;
+				filp_close(fp, NULL);
 				return -EINVAL;
 			}
 		}
@@ -241,8 +243,8 @@ static void zchan_cmd_log_page(struct zocl_rpu_channel *chan, struct xgq_cmd_sq_
 	u32 total_count = 0;
 	int ret = 0;
 
-	//	zchan_info(chan, "addr_off 0x%x, size %d, offset %d, pid %d",
-	//		add_off, size, offset, pid);
+	zchan_dbg(chan, "addr_off 0x%x, size %d, offset %d, pid %d",
+		   add_off, size, offset, pid);
 
 	switch (pid) {
 	case XGQ_CMD_LOG_INFO:
@@ -414,7 +416,7 @@ static void zchan_cmd_handler(struct platform_device *pdev, struct xgq_cmd_sq_hd
 	cmd_handler func = opcode2handler(op);
 	struct xgq_com_queue_entry r = {};
 
-	//	zchan_info(chan, "%s received", opcode2name(op));
+	zchan_dbg(chan, "%s received", opcode2name(op));
 	if (func)
 		func(chan, cmd, &r);
 	else

--- a/src/runtime_src/core/edge/drm/zocl/zocl_rpu_channel.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_rpu_channel.c
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: GPL-2.0 OR Apache-2.0 */
 /*
  * Copyright (C) 2021 Xilinx, Inc. All rights reserved.
- * Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Author(s):
  *        Lizhi Hou <lizhih@xilinx.com>
@@ -37,7 +37,9 @@
 #define ZRPU_CHANNEL_XGQ_SLOT_SIZE	1024
 
 #define MAX_LOG_LEN 80
+#define MAX_PAGE_SIZE 4096
 static char info_buf[MAX_LOG_LEN] = { 0 };
+static char log_buf[MAX_PAGE_SIZE] = { 0 };
 
 struct zocl_rpu_data_entry {
 	struct list_head	entry_list;
@@ -183,22 +185,46 @@ static int zchan_cmd_log_apu_log(struct zocl_rpu_channel *chan, u32 add_off, u32
 	u32 offset, u32 *total_countp)
 {
 	u32 count = 0;
+	struct file *fp;
+	loff_t fp_size = 0;
+	loff_t fp_offset = 0;
+	int ret = 0;
+	u32 remain_size = 0;
 
-	memset(info_buf, 0, sizeof(info_buf));
-	/*
-	 * Example code of collecting data based on request size and offset
-	 */
-	if (offset == 0) {
-		count = snprintf(info_buf, sizeof(info_buf), "first 4096");
-		memcpy_toio(chan->mem_base + add_off, info_buf, count);
-		count = 4096;
-	} else if (offset == 4096) {
-		count = snprintf(info_buf, sizeof(info_buf), "second 4096");
-		memcpy_toio(chan->mem_base + add_off, info_buf, count);
-		count = 4096;
-	} else {
-		count = 0;
+	fp = filp_open("/var/log/messages", O_RDONLY, 0);
+	if (IS_ERR(fp)) {
+		*total_countp = 0;
+		pr_err("Can't open /var/log/messages\n");
+		return -EINVAL;
 	}
+
+	fp_size = i_size_read(file_inode(fp));
+	pr_info("kmsg size = %d\n", fp_size);
+	fp_offset = offset;
+	remain_size = fp_size - offset;
+	// Send chunks of log
+	if (remain_size >= size) {
+		ret = kernel_read(fp, &log_buf, size, &fp_offset);
+		if (!ret) {
+			pr_err("Can't read from /var/log/messages\n");
+			*total_countp = 0;
+			return -EINVAL;
+		}
+		count = size;
+	} else {
+		if(remain_size > 0) {
+			ret = kernel_read(fp, &log_buf, remain_size, &fp_offset);
+			if (!ret) {
+				pr_err("Can't read from /var/log/messages\n");
+				*total_countp = 0;
+				return -EINVAL;
+			}
+		}
+		count = remain_size;
+	}
+	if (count > 0)
+		memcpy_toio(chan->mem_base + add_off, log_buf, count);
+	filp_close(fp, NULL);
 
 	*total_countp = count;
 	return 0;

--- a/src/runtime_src/tools/scripts/apu_recipes/apu-boot
+++ b/src/runtime_src/tools/scripts/apu_recipes/apu-boot
@@ -1,4 +1,7 @@
 #!/bin/sh
 if [ -e /sys/bus/platform/devices/rpu-channel/ready ]; then
 	echo 1 > /sys/bus/platform/devices/rpu-channel/ready
+
+	# Stop sytemd-journald service to have kernel log sent to /var/log/messages
+	systemctl mask systemd-journald
 fi

--- a/src/runtime_src/tools/scripts/apu_recipes/init-apu
+++ b/src/runtime_src/tools/scripts/apu_recipes/init-apu
@@ -12,5 +12,3 @@ echo "verbosity=5" >> /usr/bin/xrt.ini
 echo "runtime_log=syslog" >> /usr/bin/xrt.ini
 echo "enable_aied=false" >> /usr/bin/xrt.ini
 
-# Stop sytemd-journald service to have kernel log sent to /var/log/messages
-systemctl stop systemd-journald

--- a/src/runtime_src/tools/scripts/apu_recipes/init-apu
+++ b/src/runtime_src/tools/scripts/apu_recipes/init-apu
@@ -11,3 +11,6 @@ echo "[Runtime]" >> /usr/bin/xrt.ini
 echo "verbosity=5" >> /usr/bin/xrt.ini
 echo "runtime_log=syslog" >> /usr/bin/xrt.ini
 echo "enable_aied=false" >> /usr/bin/xrt.ini
+
+# Stop sytemd-journald service to have kernel log sent to /var/log/messages
+systemctl stop systemd-journald


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Allow kernel logs to be dumped to /var/log/messages on APU and passed back to host through VMR

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Enhancement [CR-1149236](https://jira.xilinx.com/browse/CR-1149236)

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Tested on V70

#### Documentation impact (if any)
