### PR TITLE
CID 310956: Fix coverity bug in XVC driver

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xvc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xvc.c
@@ -172,8 +172,8 @@ static long xvc_ioctl_helper(struct xocl_xvc *xvc, const void __user *arg)
 
 	total_bits = xvc_obj.length;
 	if (total_bits == 0) {
-		pr_info("%s: received invalid obj len %d bits for op 0x%x.\n",
-			total_bits, opcode);
+		pr_err("%s: received invalid obj len %u bits for op 0x%x.\n",
+		       __func__, total_bits, opcode);
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
printf arguments mismatch
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Coverity Bug CID 310956
#### How problem was solved, alternative solutions (if any) and why they were rejected
Fixed printf arguements
#### Risks (if any) associated the changes in the commit
NA
#### What has been tested and how, request additional testing if necessary
compile
#### Documentation impact (if any)
NA