### PR TITLE
Additional profiling Coverity fixes

### DIFF
--- a/src/runtime_src/xdp/profile/writer/vp_base/vp_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/vp_writer.cpp
@@ -51,11 +51,17 @@ namespace xdp {
     // directory
     fout.open(filename);
 
-    if (useDir) {
-      std::string msg =
-        "The user specified profiling directory is not supported on Windows.";
-      xrt_core::message::send(xrt_core::message::severity_level::info,
-                              "XRT", msg);
+    try {
+      if (useDir) {
+        std::string msg =
+          "The user specified profiling directory is not supported on Windows.";
+        xrt_core::message::send(xrt_core::message::severity_level::info,
+                                "XRT", msg);
+      }
+    }
+    catch (...) {
+      // The message sending could throw a boost::property_tree exception.
+      // If we catch it, just ignore it and move on.
     }
 #else
     directory = xrt_core::config::get_profiling_directory() ;
@@ -72,14 +78,20 @@ namespace xdp {
     constexpr mode_t rwx_all = 0777;
     int result = mkdir(directory.c_str(), rwx_all);
 
-    if (result != 0) {
-      // We could not create the directory, but that doesn't necessarily
-      // mean it doesn't exist and we don't have access to it.  Just send
-      // an informational message.
-      std::string msg =
-        "The user specified profiling directory could not be created.";
-      xrt_core::message::send(xrt_core::message::severity_level::info,
-                              "XRT", msg);
+    try {
+      if (result != 0) {
+        // We could not create the directory, but that doesn't necessarily
+        // mean it doesn't exist and we don't have access to it.  Just send
+        // an informational message.
+        std::string msg =
+          "The user specified profiling directory could not be created.";
+        xrt_core::message::send(xrt_core::message::severity_level::info,
+                                "XRT", msg);
+      }
+    }
+    catch (...) {
+      // Sending the message could throw a boost::property_tree exception.
+      // If we catch it, just ignore it and move on
     }
 
     // Try to open the file in the directory + filename


### PR DESCRIPTION
#### Problem solved by the commit
Resolve recently introduced Coverity issues in profiling code.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
The coverity issues 3109492, 310950, 310951, 310952, 310954, and 310956 were all introduced in pull request 7423 and are related to the addition of xrt_core::message::send in a base profiling class, which could throw an exception in some conditions.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added try...catch blocks around the sending of the message to catch the possible exception.

#### Risks (if any) associated the changes in the commit
Low risk as if the exception is thrown and caught, the only thing is an info message will not be displayed.
