### PR TITLE
Fix for CR-1154512: xbmgmt reset does not work

### DIFF
--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdReset.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdReset.cpp
@@ -67,6 +67,9 @@ reset_device(const std::shared_ptr<xrt_core::device>& dev, xrt_core::query::rese
 SubCmdReset::SubCmdReset(bool _isHidden, bool _isDepricated, bool _isPreliminary)
     : SubCmd("reset", 
              "Resets the given device")
+    , m_device("")
+    , m_resetType("hot")
+    , m_help(false)
 {
   const std::string longDescription = "Resets the given device.";
   setLongDescription(longDescription);
@@ -74,6 +77,10 @@ SubCmdReset::SubCmdReset(bool _isHidden, bool _isDepricated, bool _isPreliminary
   setIsHidden(_isHidden);
   setIsDeprecated(_isDepricated);
   setIsPreliminary(_isPreliminary);
+  m_commonOptions.add_options()
+    ("device,d", boost::program_options::value<decltype(m_device)>(&m_device), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest.")
+    ("help", boost::program_options::bool_switch(&m_help), "Help to use this sub-command")
+    ;
 }
 
 void

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdReset.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdReset.cpp
@@ -64,6 +64,16 @@ reset_device(const std::shared_ptr<xrt_core::device>& dev, xrt_core::query::rese
     % xrt_core::query::pcie_bdf::to_string(xrt_core::device_query<xrt_core::query::pcie_bdf>(dev));
 }
 
+void
+supported(std::string resetType) {
+  std::vector<std::string> vec { "hot", "kernel", "ert", "ecc", "soft-kernel", "aie" };
+  std::vector<std::string>::iterator it; 
+  it = std::find (vec.begin(), vec.end(), resetType);
+  if (it == vec.end()) {
+    throw xrt_core::error(-ENODEV, "reset not supported");
+  }
+}
+
 SubCmdReset::SubCmdReset(bool _isHidden, bool _isDepricated, bool _isPreliminary)
     : SubCmd("reset", 
              "Resets the given device")
@@ -81,16 +91,13 @@ SubCmdReset::SubCmdReset(bool _isHidden, bool _isDepricated, bool _isPreliminary
     ("device,d", boost::program_options::value<decltype(m_device)>(&m_device), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest.")
     ("help", boost::program_options::bool_switch(&m_help), "Help to use this sub-command")
     ;
-}
-
-void
-supported(std::string resetType) {
-  std::vector<std::string> vec { "hot", "kernel", "ert", "ecc", "soft-kernel", "aie" };
-  std::vector<std::string>::iterator it;
-  it = std::find (vec.begin(), vec.end(), resetType);
-  if (it == vec.end()) {
-    throw xrt_core::error(-ENODEV, "reset not supported");
-  }
+  m_hiddenOptions.add_options()
+    ("type,t", boost::program_options::value<decltype(m_resetType)>(&m_resetType)->notifier(supported), "The type of reset to perform. Types resets available:\n"
+                                                            "  kernel       - Kernel communication links\n" 
+                                                            "  ert          - Reset management processor\n"
+							    "  ecc          - Reset ecc memory\n"
+							    "  soft-kernel  - Reset soft kernel")
+    ;
 }
 
 void


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1154512
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://github.com/Xilinx/XRT/pull/7293
#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit
na
#### What has been tested and how, request additional testing if necessary
Verified the fix on v70 setup:
bash-4.2# xbmgmt reset -d 0000:3b:00.0
Performing 'HOT Reset' on 
  -[0000:3b:00.0]
WARNING: Please make sure xocl driver is unloaded.
Are you sure you wish to proceed? [Y/n]: y
Successfully reset Device[0000:3b:00.0]

#### Documentation impact (if any)
na