### PR TITLE
Fix for CR-1143627: ASTeR TC18.01 - ul3x24 - Low DMA Write and Read bandwidth at 1MB Block size, and Low DMA Write bandwidth at 256MB Block size

### DIFF
--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -988,8 +988,11 @@ dmaTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree::ptr
 
     // check if the bank has enough memory to allocate
     // m_size is in KB so convert block_size (bytes) to KB for comparison
-    if (mem.m_size < (block_size/1024))
+    if (mem.m_size < (block_size/1024)) {
+      logger(_ptTest, "Details", boost::str(boost::format(
+	"The bank does not have enough memory to allocate. Use lower '%s' value. \n") % "block-size"));
       continue;
+    }
 
     size_t totalSize = 0;
     if (xrt_core::device_query<xrt_core::query::pcie_vendor>(_dev) == ARISTA_ID)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1143627
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added a readable message for the case when the block-size used is larger than the bank size, so that the reason for XRT skipping the test is clear.
#### Risks (if any) associated the changes in the commit
low
#### What has been tested and how, request additional testing if necessary
Verified by using a block-size larger than the bank memory size:

Verbose: Enabling Verbosity
Test 1 [0000:37:00.1]     : dma 
    Description           : Run dma test
    Details               : Buffer size - '256 GB'                              
                            The bank does not have enough memory to allocate. Use lower
                            'block-size' value. 
                            Buffer size - '256 GB'
                            The bank does not have enough memory to allocate. Use lower
                            'block-size' value. 
                            Buffer size - '256 GB'
                            The bank does not have enough memory to allocate. Use lower
                            'block-size' value. 
                            Buffer size - '256 GB'
                            The bank does not have enough memory to allocate. Use lower
                            'block-size' value. 
    Test Status           : [SKIPPED]
#### Documentation impact (if any)
