### PR TITLE
Fix xbmgmt reset. Fix Coverity bugs.

### DIFF
--- a/src/runtime_src/core/common/device.h
+++ b/src/runtime_src/core/common/device.h
@@ -420,7 +420,7 @@ public:
    */
   virtual void write(uint64_t, const void*, uint64_t) const {}
 
-  virtual void reset(query::reset_type&) const {}
+  virtual void reset(const query::reset_type&) const {}
 
   /**
    * xclmgmt_load_xclbin() - loads the xclbin through the mgmt pf

--- a/src/runtime_src/core/common/query_reset.h
+++ b/src/runtime_src/core/common/query_reset.h
@@ -49,7 +49,7 @@ class reset_type {
   std::string mValue;
 
 public:
-  reset_type(reset_key key, std::string name, std::string subdev, std::string entry, std::string warning, std::string value)
+  reset_type(reset_key key, const std::string& name, const std::string& subdev, const std::string& entry, const std::string& warning, const std::string& value)
     : mKey(key), mName(name), mSubdev(subdev), mEntry(entry), mWarning(warning), mValue(value)
   {
   }
@@ -70,11 +70,11 @@ public:
     return mEntry;
   }
 
-  void set_subdev(std::string str) {
+  void set_subdev(const std::string& str) {
     mSubdev = str;
   }
 
-  void set_entry(std::string str) {
+  void set_entry(const std::string& str) {
     mEntry = str;
   }
 

--- a/src/runtime_src/core/edge/user/device_linux.cpp
+++ b/src/runtime_src/core/edge/user/device_linux.cpp
@@ -981,7 +981,7 @@ write(uint64_t offset, const void* buf, uint64_t len) const
 
 void
 device_linux::
-reset(query::reset_type key) const
+reset(const query::reset_type& key) const
 {
   switch(key.get_key()) {
   case query::reset_key::hot:

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -1447,7 +1447,7 @@ write(uint64_t offset, const void* buf, uint64_t len) const
 
 void
 device_linux::
-reset(query::reset_type& key) const
+reset(const query::reset_type& key) const
 {
   std::string err;
   xrt_core::pci::get_dev(get_device_id(), false)->sysfs_put(

--- a/src/runtime_src/core/pcie/linux/device_linux.h
+++ b/src/runtime_src/core/pcie/linux/device_linux.h
@@ -25,7 +25,7 @@ public:
   virtual void write(uint64_t addr, const void* buf, uint64_t len) const override;
   virtual int  open(const std::string& subdev, int flag) const override;
   virtual void close(int dev_handle) const override;
-  virtual void reset(query::reset_type&) const override;
+  virtual void reset(const query::reset_type&) const override;
   virtual void xclmgmt_load_xclbin(const char* buffer) const override;
   virtual void device_shutdown() const override;
   virtual void device_online() const override;

--- a/src/runtime_src/core/tools/common/OptionOptions.cpp
+++ b/src/runtime_src/core/tools/common/OptionOptions.cpp
@@ -56,6 +56,7 @@ OptionOptions::OptionOptions(const std::string& longName,
   , m_isHidden(isHidden)
   , m_description(optionDescription)
   , m_extendedHelp("")
+  , m_defaultOptionValue(false)
 {
   m_selfOption.add_options()(optionNameString().c_str(), optionValue, valueDescription.c_str());
   m_optionsDescription.add(m_selfOption);

--- a/src/runtime_src/core/tools/xbutil2/SubCmdReset.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdReset.cpp
@@ -20,7 +20,7 @@ namespace po = boost::program_options;
 
 // ----- C L A S S   M E T H O D S -------------------------------------------
 static void
-pretty_print_action_list(xrt_core::device* dev, xrt_core::query::reset_type reset)
+pretty_print_action_list(xrt_core::device* dev, const xrt_core::query::reset_type& reset)
 {
   std::cout << boost::format("Performing '%s' on '%s'\n") % reset.get_name()
                   % xrt_core::query::pcie_bdf::to_string(xrt_core::device_query<xrt_core::query::pcie_bdf>(dev));


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Fixing xbmgmt reset not accepting options.
Fixing a few Coverity bugs that are in the userspace code.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
`xbmgmt reset` was not properly configured in https://github.com/Xilinx/XRT/pull/7293 and no longer works. That must be fixed.

Coverity:
OptionsOptions.cpp -> Did not initialize all member variables.
xbutil SubCmdReset.cpp -> Passed class without reference
xbmgmt SubCmdReset.cpp -> Did not initialize all member variables.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Formatted `xbmgmt reset` to have the correct option formatting

OptionsOptions.cpp -> Initialize all member variables.
xbutil SubCmdReset.cpp -> Pass class as reference.
xbmgmt SubCmdReset.cpp -> Initialize all member variables. Also did some refactoring here to prevent passing a modifiable class and make things a bit cleaner.

#### Risks (if any) associated the changes in the commit
None.

#### What has been tested and how, request additional testing if necessary
Ubuntu 20.04 U55C

xbutil reset
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ xbutil validate -d 04:00 -r verify
WARNING: Unexpected xocl version (2.14.0) was found. Expected 2.15.0, to match XRT tools.
Validate Device           : [0000:04:00.1]
    Platform              : xilinx_u55c_gen3x16_xdma_base_3
    SC Version            : 7.1.22
    Platform ID           : 97088961-FEAE-DA91-52A2-1D9DFD63CCEF
-------------------------------------------------------------------------------
Verbose: Enabling Verbosity
Test 1 [0000:04:00.1]     : verify
    Description           : Run 'Hello World' kernel test
    Xclbin                : /opt/xilinx/firmware/u55c/gen3x16-xdma/base/test
    Testcase              : /opt/xilinx/xrt/test/validate.exe
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Validation completed
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ xbutil examine -d 04:00 -r dynamic-regions
WARNING: Unexpected xocl version (2.14.0) was found. Expected 2.15.0, to match XRT tools.

-------------------------------------------------
[0000:04:00.1] : xilinx_u55c_gen3x16_xdma_base_3
-------------------------------------------------
Xclbin UUID
  E106E953-CF90-4024-E075-282D1A7D820B

Compute Units
  PL Compute Units
    Index   Name                                              Base_Address    Usage   Status
    0       verify:verify_1                                   0x800000        1       (IDLE)

  PS Compute Units
    Index   Name                                              Base_Address    Usage   Status

dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ xbutil reset -d 04:00
WARNING: Unexpected xocl version (2.14.0) was found. Expected 2.15.0, to match XRT tools.
Performing 'HOT Reset' on '0000:04:00.1'
Are you sure you wish to proceed? [Y/n]: Y
Successfully reset Device[0000:04:00.1]
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ xbutil examine -d 04:00 -r dynamic-regions
WARNING: Unexpected xocl version (2.14.0) was found. Expected 2.15.0, to match XRT tools.

-------------------------------------------------
[0000:04:00.1] : xilinx_u55c_gen3x16_xdma_base_3
-------------------------------------------------
Xclbin UUID
  00000000-0000-0000-0000-000000000000

Compute Units
  PL Compute Units
    Index   Name                                              Base_Address    Usage   Status

  PS Compute Units
    Index   Name                                              Base_Address    Usage   Status

dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$
```
xbmgmt reset
```
root@xsjdbenusov50:~# xbmgmt reset -d 04:00
WARNING: Unexpected xclmgmt version (2.14.0) was found. Expected 2.15.0, to match XRT tools.
Performing 'HOT Reset' on
  -[0000:04:00.0]
WARNING: Please make sure xocl driver is unloaded.
Are you sure you wish to proceed? [Y/n]: Y
Successfully reset Device[0000:04:00.0]
```
dmesg for xbmgmt reset
```
[11541.020740] xclmgmt 0000:04:00.0: xclmgmt_hot_reset: Trying to reset card 1024 in slot PCI Bus 0000:04:00:0
[11542.349726] xclmgmt 0000:04:00.0:  ffff8c9317acd0b0 xocl_thread: xclmgmt health thread exit.
[11542.349768] xclmgmt 0000:04:00.0:  ffff8c9317acd0b0 xocl_thread_stop: xclmgmt health thread stop ret = 0
[11542.349778] xclmgmt 0000:04:00.0:  ffff8c9317acd0b0 xocl_thread_stop: xclmgmt health thread has terminated
[11542.349810] xclmgmt 0000:04:00.0:  ffff8c9317acd0b0 __xocl_subdev_offline: offline subdev ulite, cdev 0000000000000000
[11542.350127] xclmgmt 0000:04:00.0:  ffff8c9317acd0b0 __xocl_subdev_offline: offline subdev flash, cdev 00000000a9a0e200
[11542.350261] xclmgmt 0000:04:00.0:  ffff8c9317acd0b0 __xocl_subdev_offline: offline subdev icap, cdev 00000000b5654649
[11542.350316] xclmgmt 0000:04:00.0: icap.m.22020096 ffff8c930f9f3010 xocl_drvinst_kill_proc: return 0
[11542.350343] xclmgmt 0000:04:00.0:  ffff8c9317acd0b0 __xocl_subdev_offline: offline subdev mailbox, cdev 00000000182a577e
[11542.350746] xclmgmt 0000:04:00.0:  ffff8c9317acd0b0 __xocl_subdev_offline: offline subdev firewall, cdev 0000000000000000
[11542.350754] xclmgmt 0000:04:00.0:  ffff8c9317acd0b0 __xocl_subdev_offline: offline subdev axigate, cdev 0000000000000000
[11542.350802] xclmgmt 0000:04:00.0: ert.m.18874368 ffff8c930c1a1010 stop_ert: Stop Microblaze...
[11542.350808] xclmgmt 0000:04:00.0: xmc.m.18874369 ffff8c930c1bbc10 stop_xmc: Stop Microblaze...
[11542.351065] xclmgmt 0000:04:00.0:  ffff8c9317acd0b0 raptor_cmc_access: Release CMC succeeded.
[11542.351072] xclmgmt 0000:04:00.0: xmc.m.18874369 ffff8c930c1bbc10 stop_xmc_nolock: MB Reset GPIO 0x1
[11542.351079] xclmgmt 0000:04:00.0: xmc.m.18874369 ffff8c930c1bbc10 stop_xmc_nolock: XMC info, version 0xc010519, status 0x19000801, id 0x74736574
[11542.351087] xclmgmt 0000:04:00.0: xmc.m.18874369 ffff8c930c1bbc10 stop_xmc_nolock: Stopping XMC...
[11542.457635] xclmgmt 0000:04:00.0: xmc.m.18874369 ffff8c930c1bbc10 stop_xmc_nolock: XMC Stopped, retry 2
[11542.457647] xclmgmt 0000:04:00.0: xmc.m.18874369 ffff8c930c1bbc10 stop_xmc_nolock: XMC info, version 0xc010519, status 0x19000803, id 0x74736574
[11542.457657] xclmgmt 0000:04:00.0: xclmgmt_reset_pci: Reset PCI
[11543.597739] xclmgmt 0000:04:00.0:  ffff8c9317acd0b0 __xocl_subdev_online: online subdev axigate, cdev 0000000000000000
[11543.601982] xclmgmt 0000:04:00.0: ert.m.18874368 ffff8c930c1a1010 ert_reset: Reset ERT...
[11543.601990] xclmgmt 0000:04:00.0: ert.m.18874368 ffff8c930c1a1010 load_image: ERT Reset GPIO 0x0
[11543.601996] xclmgmt 0000:04:00.0: ert.m.18874368 ffff8c930c1a1010 load_image: Copying scheduler image len 14420
[11543.603303] xclmgmt 0000:04:00.0: ert.m.18874368 ffff8c930c1a1010 load_image: ERT Reset GPIO 0x1
[11543.603308] xclmgmt 0000:04:00.0: xmc.m.18874369 ffff8c930c1bbc10 xmc_reset: Reset Microblaze...
[11543.603316] xclmgmt 0000:04:00.0:  ffff8c9317acd0b0 raptor_cmc_access: Release CMC succeeded.
[11543.603322] xclmgmt 0000:04:00.0: xmc.m.18874369 ffff8c930c1bbc10 stop_xmc_nolock: MB Reset GPIO 0x0
[11543.603330] xclmgmt 0000:04:00.0: xmc.m.18874369 ffff8c930c1bbc10 stop_xmc_nolock: XMC info, version 0xc010519, status 0x19000803, id 0x74736574
[11543.603340] xclmgmt 0000:04:00.0: xmc.m.18874369 ffff8c930c1bbc10 load_xmc: MB Reset GPIO 0x0
[11543.603344] xclmgmt 0000:04:00.0: xmc.m.18874369 ffff8c930c1bbc10 load_xmc: Copying XMC image len 101800
[11543.611003] xclmgmt 0000:04:00.0: xmc.m.18874369 ffff8c930c1bbc10 load_xmc: MB Reset GPIO 0x1
[11543.717645] xclmgmt 0000:04:00.0: xmc.m.18874369 ffff8c930c1bbc10 xmc_sense_ready: REGMAP ready.
[11543.717657] xclmgmt 0000:04:00.0: xmc.m.18874369 ffff8c930c1bbc10 xmc_sense_ready: Core Version 0xc01002b
[11543.825616] xclmgmt 0000:04:00.0: xmc.m.18874369 ffff8c930c1bbc10 xmc_sense_ready: Sensor Data ready.
[11543.825625] xclmgmt 0000:04:00.0: xmc.m.18874369 ffff8c930c1bbc10 load_xmc: XMC and scheduler Enabled, retry 0
[11543.825634] xclmgmt 0000:04:00.0: xmc.m.18874369 ffff8c930c1bbc10 load_xmc: XMC info, version 0xc010519, status 0x19000801, id 0x74736574
[11543.825646] xclmgmt 0000:04:00.0: xmc.m.18874369 ffff8c930c1bbc10 xmc_enable_mailbox: XMC mailbox offset read during probe: 0x1000
[11543.825764] xclmgmt 0000:04:00.0: hwmon_device_register() is deprecated. Please convert the driver to use hwmon_device_register_with_info().
[11543.826043] xclmgmt 0000:04:00.0:  ffff8c9317acd0b0 __xocl_subdev_online: online subdev firewall, cdev 0000000000000000
[11543.826064] xclmgmt 0000:04:00.0:  ffff8c9317acd0b0 __xocl_subdev_online: online subdev mailbox, cdev 0000000000000000
[11543.826075] xclmgmt 0000:04:00.0: mailbox.m.9437184 ffff8c9315d00410 mailbox_start: Starting Mailbox channels
[11543.826424] xclmgmt 0000:04:00.0: mailbox.m.9437184 ffff8c9315d00410 mailbox_start: Enabled timer-driven mode
[11543.826578] xclmgmt 0000:04:00.0:  ffff8c9317acd0b0 __xocl_subdev_online: online subdev icap, cdev 0000000000000000
[11543.826589] xclmgmt 0000:04:00.0: icap.m.22020096 ffff8c930f9f3010 icap_refresh_addrs: memcalib @ ffffa7ae803eb000
[11543.826596] xclmgmt 0000:04:00.0: icap.m.22020096 ffff8c930f9f3010 icap_refresh_addrs: icap_reset @ ffffa7ae8041f000
[11543.826707] xclmgmt 0000:04:00.0:  ffff8c9317acd0b0 __xocl_subdev_online: online subdev flash, cdev 0000000000000000
[11543.827477] xclmgmt 0000:04:00.0: flash.m.8388608 ffff8c930c1eb410 qspi_probe: QSPI FIFO depth is: 256
[11543.827530] xclmgmt 0000:04:00.0: flash.m.8388608 ffff8c930c1eb410 qspi_probe: Number of slave chips is: 1
[11543.827566] xclmgmt 0000:04:00.0: flash.m.8388608 ffff8c930c1eb410 flash_get_info: Flash vendor: micron
[11543.827571] xclmgmt 0000:04:00.0: flash.m.8388608 ffff8c930c1eb410 flash_get_info: Flash size: 128MB
[11543.827747] xclmgmt 0000:04:00.0:  ffff8c9317acd0b0 __xocl_subdev_online: online subdev ulite, cdev 0000000000000000
[11543.827897] ulite.m.37748736: ttyXRTUL0 at MMIO 0x380032003000 (irq = 0, base_baud = 0) is a uartlite
[11543.853648] xclmgmt 0000:04:00.0:  ffff8c9317acd0b0 xocl_thread_start: init xclmgmt health thread
[11549.101630] xclmgmt 0000:04:00.0: check_pcie_link_toggle: PCI link toggle was detected
```
#### Documentation impact (if any)
None