### PR TITLE
CR-1144576 progress bar for xbmgmt program -b shell

### DIFF
--- a/src/runtime_src/core/tools/xbmgmt2/flash/flasher.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/flasher.cpp
@@ -22,8 +22,6 @@
 #include "flasher.h"
 #include "core/common/error.h"
 #include "core/common/query_requests.h"
-#include "core/tools/common/BusyBar.h"
-#include "tools/common/XBUtilitiesCore.h"
 #include <limits>
 #include <cstddef>
 #include <cassert>
@@ -199,12 +197,8 @@ int Flasher::upgradeFirmware(E_FlasherType flash_type,
             std::cout << "ERROR: OSPI XGQ mode does not support reverting to MFG." << std::endl;
         else if(secondary != nullptr)
             std::cout << "ERROR: OSPI XGQ mode does not support two mcs files." << std::endl;
-        else {
-            XBUtilities::BusyBar busy_bar("Working...", std::cout);
-            busy_bar.start(XBUtilities::is_escape_codes_disabled());
+        else
             retVal = xgq_flasher.xclUpgradeFirmware(*primary);
-            busy_bar.finish();
-        }
         break;
     }
     default:

--- a/src/runtime_src/core/tools/xbmgmt2/flash/flasher.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/flasher.cpp
@@ -22,6 +22,8 @@
 #include "flasher.h"
 #include "core/common/error.h"
 #include "core/common/query_requests.h"
+#include "core/tools/common/BusyBar.h"
+#include "tools/common/XBUtilitiesCore.h"
 #include <limits>
 #include <cstddef>
 #include <cassert>
@@ -197,8 +199,12 @@ int Flasher::upgradeFirmware(E_FlasherType flash_type,
             std::cout << "ERROR: OSPI XGQ mode does not support reverting to MFG." << std::endl;
         else if(secondary != nullptr)
             std::cout << "ERROR: OSPI XGQ mode does not support two mcs files." << std::endl;
-        else
+        else {
+            XBUtilities::BusyBar busy_bar("Working...", std::cout);
+            busy_bar.start(XBUtilities::is_escape_codes_disabled());
             retVal = xgq_flasher.xclUpgradeFirmware(*primary);
+            busy_bar.finish();
+        }
         break;
     }
     default:


### PR DESCRIPTION
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1144576 `xbmgmt program -b shell` should have a progress bar
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
`xbmgmt program -b shell` did not have a progress bar/indication of progress on some flash types (e.g. XGQ_VMR_Flasher and XOSPIVER_Flasher), leaving developers to wait in the dark while the associated card was flashed.
#### How problem was solved, alternative solutions (if any) and why they were rejected
A busy bar with time elapsed was added to such flash types to fix the issue.
#### Risks (if any) associated the changes in the commit
N/A
#### What has been tested and how, request additional testing if necessary
I tested on vck5000 with xilinx_vck5000_gen4x8_qdma_base_2. The shell was successfully programmed, and the busy bar appeared during flashing.

Output while Flashing:
```
root@xsjsagarw50:~# xbmgmt program -b shell -d 65:00 --image xilinx_vck5000_gen4x8_qdma_base_2
***********************************************************
*        WARNING          WARNING          WARNING        *
*  SC version data missing. Expected: N/A Current: 4.4.35 *
***********************************************************
INFO: ***xsabin has 6963555 bytes
[           <->      ]: Working...... < 8s >
```
Output after Flashing:
```
root@xsjsagarw50:~# xbmgmt program -b shell -d 65:00 --image xilinx_vck5000_gen4x8_qdma_base_2
***********************************************************
*        WARNING          WARNING          WARNING        *
*  SC version data missing. Expected: N/A Current: 4.4.35 *
***********************************************************
INFO: ***xsabin has 6963555 bytes
INFO: ***Write 6963555 bytes
INFO     : Base flash image has been programmed successfully. 
****************************************************
Cold reboot machine to load the new image on device.
****************************************************
```
#### Documentation impact (if any)
N/A