### PR TITLE
Remove sysroot generation by default in apu package creation

### DIFF
--- a/build/build_edge.sh
+++ b/build/build_edge.sh
@@ -250,7 +250,7 @@ XRT_REPO_DIR=`readlink -f ${THIS_SCRIPT_DIR}/..`
 clean=0
 apu_package=0
 archiver=0
-gen_sysroot=1
+gen_sysroot=0
 SSTATE_CACHE=""
 SETTINGS_FILE="${THIS_SCRIPT_DIR}/petalinux.build"
 while [ $# -gt 0 ]; do


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Apu package creation time increased and pipeline builds are failing with time out. Removing sysroot generation by default while creating apu packages to minimize build time for apu packages.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
