### PR TITLE
VITIS-7999 Update ReportDynamicRegions to use Hardware Contexts

### DIFF
--- a/src/runtime_src/core/common/info_memory.cpp
+++ b/src/runtime_src/core/common/info_memory.cpp
@@ -399,7 +399,7 @@ memory_topology(const xrt_core::device* device)
 }
 
 ptree_type
-xclbin_info(const xrt_core::device * device)
+xclbin_info(const xrt_core::device* device)
 {
   ptree_type pt;
 
@@ -461,7 +461,7 @@ get_cu_status(uint32_t cu_status)
 }
 
 static void
-scheduler_update_stat(const xrt_core::device *device)
+scheduler_update_stat(const xrt_core::device* device)
 {
   // device query and open_context requires a non-cont raw device ptr
   auto dev = const_cast<xrt_core::device *>(device);
@@ -484,7 +484,7 @@ scheduler_update_stat(const xrt_core::device *device)
 }
 
 std::vector<ps_kernel_data> 
-get_ps_kernels(const xrt_core::device *device)
+get_ps_kernels(const xrt_core::device* device)
 {
   std::vector<ps_kernel_data> ps_kernels;
   try {
@@ -506,7 +506,7 @@ get_ps_kernels(const xrt_core::device *device)
 }
 
 ptree_type
-populate_cus(const xrt_core::device *device, std::vector<xq::kds_cu_info::data_type> cu_stats, std::vector<xq::kds_scu_info::data_type> scu_stats)
+populate_cus(const xrt_core::device* device, const std::vector<xq::kds_cu_info::data_type>& cu_stats, const std::vector<xq::kds_scu_info::data_type>& scu_stats)
 {
   scheduler_update_stat(device);
 
@@ -573,7 +573,7 @@ populate_cus(const xrt_core::device *device, std::vector<xq::kds_cu_info::data_t
 }
 
 static ptree_type
-populate_hardware_context(const xrt_core::device *device)
+populate_hardware_context(const xrt_core::device* device)
 {
   ptree_type pt;
   scheduler_update_stat(device);
@@ -630,7 +630,7 @@ populate_hardware_context(const xrt_core::device *device)
 }
 
 ptree_type
-dynamic_regions(const xrt_core::device * device)
+dynamic_regions(const xrt_core::device* device)
 {
   ptree_type pt;
   pt.add_child("dynamic_regions", populate_hardware_context(device));

--- a/src/runtime_src/core/common/info_memory.cpp
+++ b/src/runtime_src/core/common/info_memory.cpp
@@ -572,9 +572,10 @@ populate_cus(const xrt_core::device *device, std::vector<xq::kds_cu_info::data_t
   return pt;
 }
 
-static void
-populate_hardware_context(const xrt_core::device *device, ptree_type& pt)
+static ptree_type
+populate_hardware_context(const xrt_core::device *device)
 {
+  ptree_type pt;
   scheduler_update_stat(device);
 
   std::vector<xq::hw_context_info::data_type> hw_context_stats;
@@ -589,7 +590,7 @@ populate_hardware_context(const xrt_core::device *device, ptree_type& pt)
   }
   catch (const std::exception& ex) {
     pt.put("error_msg", ex.what());
-    return;
+    return pt;
   }
 
   // If hw context info gave nothing try legacy path
@@ -613,7 +614,7 @@ populate_hardware_context(const xrt_core::device *device, ptree_type& pt)
     }
     catch (const std::exception& ex) {
       pt.put("error_msg", ex.what());
-      return;
+      return pt;
     }
 
     hw_context_stats.push_back(hw_context);
@@ -625,15 +626,14 @@ populate_hardware_context(const xrt_core::device *device, ptree_type& pt)
     pt_hw.add_child("compute_units", populate_cus(device, hw.pl_compute_units, hw.ps_compute_units));
     pt.push_back(std::make_pair("", pt_hw));
   }
+  return pt;
 }
 
 ptree_type
 dynamic_regions(const xrt_core::device * device)
 {
   ptree_type pt;
-  ptree_type pt_dynamic_region;
-  populate_hardware_context(device, pt_dynamic_region);
-  pt.add_child("dynamic_regions", pt_dynamic_region);
+  pt.add_child("dynamic_regions", populate_hardware_context(device));
   return pt;
 }
 

--- a/src/runtime_src/core/common/info_memory.cpp
+++ b/src/runtime_src/core/common/info_memory.cpp
@@ -508,8 +508,6 @@ get_ps_kernels(const xrt_core::device* device)
 ptree_type
 populate_cus(const xrt_core::device* device, const std::vector<xq::kds_cu_info::data_type>& cu_stats, const std::vector<xq::kds_scu_info::data_type>& scu_stats)
 {
-  scheduler_update_stat(device);
-
   // Tree that holds all ps and pl objects
   ptree_type pt;
 

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -920,9 +920,24 @@ struct kds_scu_info : request
   get(const device*) const = 0;
 };
 
-
+/**
+ * Return all hardware contexts within a device
+ */
 struct hw_context_info : request
 {
+  /**
+   * A structure to represent a single hardware context on any device type. This
+   * structure must contain all data that makes up a hardware context across
+   * all device types.
+   * 
+   * The only field that must be populated is the xclbin uuid.
+   * All other fields can be populated as required by the appropriate device.
+   * As new compute types are created they must be accounted for here
+   * 
+   * For example:
+   *  Alveo -> populate only the PL compute units
+   *  Versal -> populate PL and PS compute units
+   */
   struct data {
     std::string xclbin_uuid;
     kds_cu_info::result_type pl_compute_units;

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -79,6 +79,7 @@ enum class key_type
   sdm_sensor_info,
   kds_scu_info,
   ps_kernel,
+  hw_context_info,
   xocl_errors,
   xclbin_full,
   ic_enable,
@@ -914,6 +915,23 @@ struct kds_scu_info : request
   using result_type = std::vector<struct data>;
   using data_type = struct data;
   static const key_type key = key_type::kds_scu_info;
+
+  virtual boost::any
+  get(const device*) const = 0;
+};
+
+
+struct hw_context_info : request
+{
+  struct data {
+    std::string xclbin_uuid;
+    kds_cu_info::result_type pl_compute_units;
+    kds_scu_info::result_type ps_compute_units;
+  };
+
+  using result_type = std::vector<struct data>;
+  using data_type = struct data;
+  static const key_type key = key_type::hw_context_info;
 
   virtual boost::any
   get(const device*) const = 0;

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -454,6 +454,22 @@ struct kds_cu_info
   }
 };
 
+struct hw_context_info
+{
+  using result_type = query::hw_context_info::result_type;
+  using data_type = query::hw_context_info::data_type;
+
+  static result_type
+  get(const xrt_core::device* device, key_type)
+  {
+    data_type output;
+    output.xclbin_uuid = xrt_core::device_query<xrt_core::query::xclbin_uuid>(device);
+    output.pl_compute_units = xrt_core::device_query<xrt_core::query::kds_cu_info>(device);
+    output.ps_compute_units = xrt_core::device_query<xrt_core::query::kds_scu_info>(device);
+    return {output};
+  }
+};
+
 struct instance
 {
   using result_type = query::instance::result_type;
@@ -1336,6 +1352,7 @@ initialize_query_table()
   emplace_sysfs_get<query::kds_numcdmas>                       ("", "kds_numcdmas");
   emplace_func0_request<query::kds_cu_info,                    kds_cu_info>();
   emplace_func0_request<query::kds_scu_info,                   kds_scu_info>();
+  emplace_func0_request<query::hw_context_info,                hw_context_info>();
   emplace_func0_request<query::xclbin_slots, 		       xclbin_slots>();
   emplace_sysfs_get<query::ps_kernel>                          ("icap", "ps_kernel");
   emplace_sysfs_get<query::xocl_errors>                        ("", "xocl_errors");

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -1336,7 +1336,6 @@ initialize_query_table()
   emplace_sysfs_get<query::kds_numcdmas>                       ("", "kds_numcdmas");
   emplace_func0_request<query::kds_cu_info,                    kds_cu_info>();
   emplace_func0_request<query::kds_scu_info,                   kds_scu_info>();
-  emplace_func0_request<query::hw_context_info,                hw_context_info>();
   emplace_func0_request<query::xclbin_slots, 		       xclbin_slots>();
   emplace_sysfs_get<query::ps_kernel>                          ("icap", "ps_kernel");
   emplace_sysfs_get<query::xocl_errors>                        ("", "xocl_errors");

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -454,22 +454,6 @@ struct kds_cu_info
   }
 };
 
-struct hw_context_info
-{
-  using result_type = query::hw_context_info::result_type;
-  using data_type = query::hw_context_info::data_type;
-
-  static result_type
-  get(const xrt_core::device* device, key_type)
-  {
-    data_type output;
-    output.xclbin_uuid = xrt_core::device_query<xrt_core::query::xclbin_uuid>(device);
-    output.pl_compute_units = xrt_core::device_query<xrt_core::query::kds_cu_info>(device);
-    output.ps_compute_units = xrt_core::device_query<xrt_core::query::kds_scu_info>(device);
-    return {output};
-  }
-};
-
 struct instance
 {
   using result_type = query::instance::result_type;

--- a/src/runtime_src/core/tools/common/ReportDynamicRegion.cpp
+++ b/src/runtime_src/core/tools/common/ReportDynamicRegion.cpp
@@ -62,7 +62,7 @@ ReportDynamicRegion::writeReport( const xrt_core::device* /*_pDevice*/,
 
   for(auto& k_dfx : pt_dfx) {
     const boost::property_tree::ptree& dfx = k_dfx.second;
-    _output << "Xclbin UUID" << std::endl;
+    _output << "\nXclbin UUID\n";
     _output << "  " + dfx.get<std::string>("xclbin_uuid", "N/A") << std::endl;
     _output << std::endl;
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/VITIS-7999

Newer devices are able to support multiple xclbins, each taking up a single hardware context slot. The current report will only display the information for a single xclbin. Upgrade the report to allow the display multiple contexts while maintaining compatibility with older devices that do not have the concept of a hardware context.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Alveo devices only supported a single xclbin at any time. Newer devices like Versal and AIE support multiple xclbins. The current dynamic report will display only the first xclbin!

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added a new query to gather all hardware contexts on a device. Refactored how the output json is generated to support multiple xclbins. Added support for legacy devices through the traditional queries.

#### Risks (if any) associated the changes in the commit
None. This change must be backward compatible.

#### What has been tested and how, request additional testing if necessary\
Ubuntu 20.04 U55C (Legacy path)
Command line output
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ xbutil examine -d 04:00 -r dynamic-regions -o json.json
WARNING: Unexpected xocl version (2.14.0) was found. Expected 2.15.0, to match XRT tools.

-------------------------------------------------
[0000:04:00.1] : xilinx_u55c_gen3x16_xdma_base_3
-------------------------------------------------

Xclbin UUID
  E106E953-CF90-4024-E075-282D1A7D820B

Compute Units
  PL Compute Units
    Index   Name                                              Base_Address    Usage   Status  
    0       verify:verify_1                                   0x800000        1       (IDLE)  

  PS Compute Units
    Index   Name                                              Base_Address    Usage   Status  

Successfully wrote the json file: json.json
```
json.json
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ cat json.json 
{
    "schema_version": {
        "schema": "JSON",
        "creation_date": "Thu Mar  9 18:49:07 2023 GMT"
    },
    "devices": [
        {
            "interface_type": "pcie",
            "device_id": "0000:04:00.1",
            "dynamic_regions": [
                {
                    "xclbin_uuid": "E106E953-CF90-4024-E075-282D1A7D820B",
                    "compute_units": [
                        {
                            "name": "verify:verify_1",
                            "base_address": "0x800000",
                            "usage": "1",
                            "type": "PL",
                            "status": {
                                "bit_mask": "0x4",
                                "bits_set": [
                                    "IDLE"
                                ]
                            }
                        }
                    ]
                }
            ]
        }
    ]
}
```
Ubuntu 20.04 U55C (New path (Result was achieved by modifying the device query)
Command line output
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ xbutil examine -d 04:00 -r dynamic-regions -o json.json
WARNING: Unexpected xocl version (2.14.0) was found. Expected 2.15.0, to match XRT tools.

-------------------------------------------------
[0000:04:00.1] : xilinx_u55c_gen3x16_xdma_base_3
-------------------------------------------------

Xclbin UUID
  E106E953-CF90-4024-E075-282D1A7D820B

Compute Units
  PL Compute Units
    Index   Name                                              Base_Address    Usage   Status  
    0       verify:verify_1                                   0x800000        1       (IDLE)  

  PS Compute Units
    Index   Name                                              Base_Address    Usage   Status  

Xclbin UUID
  E106E953-CF90-4024-E075-282D1A7D820B

Compute Units
  PL Compute Units
    Index   Name                                              Base_Address    Usage   Status  
    0       verify:verify_1                                   0x800000        1       (IDLE)  

  PS Compute Units
    Index   Name                                              Base_Address    Usage   Status  

Successfully wrote the json file: json.json
```
json.json
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ cat json.json 
{
    "schema_version": {
        "schema": "JSON",
        "creation_date": "Thu Mar  9 19:12:58 2023 GMT"
    },
    "devices": [
        {
            "interface_type": "pcie",
            "device_id": "0000:04:00.1",
            "dynamic_regions": [
                {
                    "xclbin_uuid": "E106E953-CF90-4024-E075-282D1A7D820B",
                    "compute_units": [
                        {
                            "name": "verify:verify_1",
                            "base_address": "0x800000",
                            "usage": "1",
                            "type": "PL",
                            "status": {
                                "bit_mask": "0x4",
                                "bits_set": [
                                    "IDLE"
                                ]
                            }
                        }
                    ]
                },
                {
                    "xclbin_uuid": "E106E953-CF90-4024-E075-282D1A7D820B",
                    "compute_units": [
                        {
                            "name": "verify:verify_1",
                            "base_address": "0x800000",
                            "usage": "1",
                            "type": "PL",
                            "status": {
                                "bit_mask": "0x4",
                                "bits_set": [
                                    "IDLE"
                                ]
                            }
                        }
                    ]
                }
            ]
        }
    ]
}
```
#### Documentation impact (if any)
None