### PR TITLE
CR-1150767 Document how to enable platform clock throttling/shutdown via xrt

### DIFF
--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdConfigure.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdConfigure.cpp
@@ -113,6 +113,10 @@ SubCmdConfigure::SubCmdConfigure(bool _isHidden, bool _isDepricated, bool _isPre
   // Options previously under the config command
   configOptions.add_options()
     ("retention", boost::program_options::value<decltype(m_retention)>(&m_retention),"Enables / Disables memory retention.  Valid values are: [ENABLE | DISABLE]")
+    ("clk_throttle", boost::program_options::value<decltype(m_clk_throttle)>(&m_clk_throttle), "Enable/disable the device clock throttling")
+    ("ct_threshold_power_override", boost::program_options::value<decltype(m_power_override)>(&m_power_override), "Update the power threshold in watts")
+    ("ct_threshold_temp_override", boost::program_options::value<decltype(m_temp_override)>(&m_temp_override), "Update the temperature threshold in celsius")
+    ("ct_reset", boost::program_options::value<decltype(m_ct_reset)>(&m_ct_reset), "Reset all throttling options")
   ;
 
   m_commonOptions.add_options()
@@ -128,10 +132,6 @@ SubCmdConfigure::SubCmdConfigure(bool _isHidden, bool _isDepricated, bool _isPre
     ("purge", boost::program_options::bool_switch(&m_purge), "Remove the daemon configuration file")
     ("host", boost::program_options::value<decltype(m_host)>(&m_host), "IP or hostname for device peer")
     ("security", boost::program_options::value<decltype(m_security)>(&m_security), "Update the security level for the device")
-    ("clk_throttle", boost::program_options::value<decltype(m_clk_throttle)>(&m_clk_throttle), "Enable/disable the device clock throttling")
-    ("ct_threshold_power_override", boost::program_options::value<decltype(m_power_override)>(&m_power_override), "Update the power threshold in watts")
-    ("ct_threshold_temp_override", boost::program_options::value<decltype(m_temp_override)>(&m_temp_override), "Update the temperature threshold in celsius")
-    ("ct_reset", boost::program_options::value<decltype(m_ct_reset)>(&m_ct_reset), "Reset all throttling options")
     ("showx", boost::program_options::bool_switch(&m_showx), "Display the device configuration settings")
   ;
 

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdConfigure.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdConfigure.cpp
@@ -113,10 +113,6 @@ SubCmdConfigure::SubCmdConfigure(bool _isHidden, bool _isDepricated, bool _isPre
   // Options previously under the config command
   configOptions.add_options()
     ("retention", boost::program_options::value<decltype(m_retention)>(&m_retention),"Enables / Disables memory retention.  Valid values are: [ENABLE | DISABLE]")
-    ("clk_throttle", boost::program_options::value<decltype(m_clk_throttle)>(&m_clk_throttle), "Enable/disable the device clock throttling")
-    ("ct_threshold_power_override", boost::program_options::value<decltype(m_power_override)>(&m_power_override), "Update the power threshold in watts")
-    ("ct_threshold_temp_override", boost::program_options::value<decltype(m_temp_override)>(&m_temp_override), "Update the temperature threshold in celsius")
-    ("ct_reset", boost::program_options::value<decltype(m_ct_reset)>(&m_ct_reset), "Reset all throttling options")
   ;
 
   m_commonOptions.add_options()
@@ -132,6 +128,10 @@ SubCmdConfigure::SubCmdConfigure(bool _isHidden, bool _isDepricated, bool _isPre
     ("purge", boost::program_options::bool_switch(&m_purge), "Remove the daemon configuration file")
     ("host", boost::program_options::value<decltype(m_host)>(&m_host), "IP or hostname for device peer")
     ("security", boost::program_options::value<decltype(m_security)>(&m_security), "Update the security level for the device")
+    ("clk_throttle", boost::program_options::value<decltype(m_clk_throttle)>(&m_clk_throttle), "Enable/disable the device clock throttling")
+    ("ct_threshold_power_override", boost::program_options::value<decltype(m_power_override)>(&m_power_override), "Update the power threshold in watts")
+    ("ct_threshold_temp_override", boost::program_options::value<decltype(m_temp_override)>(&m_temp_override), "Update the temperature threshold in celsius")
+    ("ct_reset", boost::program_options::value<decltype(m_ct_reset)>(&m_ct_reset), "Reset all throttling options")
     ("showx", boost::program_options::bool_switch(&m_showx), "Display the device configuration settings")
   ;
 

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdConfigure.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdConfigure.cpp
@@ -107,7 +107,7 @@ SubCmdConfigure::SubCmdConfigure(bool _isHidden, bool _isDepricated, bool _isPre
 
   // Options previously under the load config command
   loadConfigOptions.add_options()
-    ("input", boost::program_options::value<decltype(m_path)>(&m_path),"INI file with the memory configuration")
+    ("input", boost::program_options::value<decltype(m_path)>(&m_path),"INI file with configuration details (e.g. memory, clock throttling)")
   ;
 
   // Options previously under the config command

--- a/src/runtime_src/doc/toc/xbmgmt.rst
+++ b/src/runtime_src/doc/toc/xbmgmt.rst
@@ -58,7 +58,7 @@ Enabling/Disabling DDR memory retention on a device
     - <management bdf> : The Bus:Device.Function of the device of interest
 
 
-- The ``--input`` specifies an INI file with configuration details (e.g. clock throttling).
+- The ``--input`` specifies an INI file with configuration details (e.g. memory, clock throttling).
 - The ``--retention`` option enables / disables DDR memory retention.
 
 

--- a/src/runtime_src/doc/toc/xbmgmt.rst
+++ b/src/runtime_src/doc/toc/xbmgmt.rst
@@ -81,7 +81,7 @@ Resetting all clock throttling options
     - <management bdf> : The Bus:Device.Function of the device of interest
 
 
-- The ``--input`` specifies an INI file with the memory configuration.
+- The ``--input`` specifies an INI file with configuration details.
 - The ``--retention`` option enables / disables DDR memory retention.
 - The ``--clk_throttle`` option enables / disables clock throttling.
 - The ``--ct_threshold_power_override`` option updates the clock throttling power threshold in watts.
@@ -104,6 +104,8 @@ Resetting all clock throttling options
     #Enable clock throttling on a supported device
     xbmgmt configure --device 0000:b3:00.0 --clk_throttle true
 
+    #Configure a device using edited output .ini from xbmgmt dump --config (see xbmgmt dump)
+    xbmgmt configure --device 0000:b3:00.0 --input /tmp/config.ini
 
 xbmgmt dump
 ~~~~~~~~~~~
@@ -147,8 +149,17 @@ Dumping the output of programmed system image
     #Dump programmed system image data
     xbmgmt dump --device 0000:b3:00.0 --flash -o /tmp/flash_dump.bin
     
-    #Dump system configaration 
+    #Dump system configuration. This .ini file can be edited and used as input for xbmgmt configure.
     xbmgmt dump --device 0000:b3:00.0 --config -o /tmp/config_dump.ini
+
+    #Example .ini file contents from xbmgmt dump --config
+    mailbox_channel_disable=0x0
+    mailbox_channel_switch=0x0
+    xclbin_change=0
+    cache_xclbin=0
+    throttling_enabled=true
+    throttling_power_override=200
+    throttling_temp_override=90
 
 
 xbmgmt examine
@@ -178,7 +189,7 @@ The ``xbmgmt examine`` command reports detail status information of the specifie
     - ``mailbox``: Mailbox metrics of the device
     - ``mechanical``: Mechanical sensors on and surrounding the device
     - ``platform``: Platform information
-    - ``cmc``: Reports cmc status of the device
+    - ``cmc``: Reports cmc status of the device, such as clock throttling information
 
 - The ``--format`` (or ``-f``) specifies the report format. Note that ``--format`` also needs an ``--output`` to dump the report in json format. If ``--output`` is missing text format will be shown in stdout
     

--- a/src/runtime_src/doc/toc/xbmgmt.rst
+++ b/src/runtime_src/doc/toc/xbmgmt.rst
@@ -50,29 +50,6 @@ Enabling/Disabling DDR memory retention on a device
 
     xbmgmt configure [--device| -d] <management bdf> --retention [ENABLE|DISABLE]
 
-Enabling/Disabling clock throttling on a device
-
-.. code-block:: shell
-
-    xbmgmt configure [--device| -d] <management bdf> --clk_throttle [true|false]
-
-Updating the clock throttling power threshold
-
-.. code-block:: shell
-
-    xbmgmt configure [--device| -d] <management bdf> --ct_threshold_power_override <threshold in Watts>
-
-Updating the clock throttling temperature threshold
-
-.. code-block:: shell
-
-    xbmgmt configure [--device| -d] <management bdf> --ct_threshold_temp_override <threshold in Celsius>
-
-Resetting all clock throttling options
-
-.. code-block:: shell
-
-    xbmgmt configure [--device| -d] <management bdf> --ct_reset [true|false]
 
 **The details of the supported options**
 
@@ -81,12 +58,8 @@ Resetting all clock throttling options
     - <management bdf> : The Bus:Device.Function of the device of interest
 
 
-- The ``--input`` specifies an INI file with configuration details.
+- The ``--input`` specifies an INI file with configuration details (e.g. clock throttling).
 - The ``--retention`` option enables / disables DDR memory retention.
-- The ``--clk_throttle`` option enables / disables clock throttling.
-- The ``--ct_threshold_power_override`` option updates the clock throttling power threshold in watts.
-- The ``--ct_threshold_temp_override`` option updates the clock throttling temperature threshold in celsius.
-- The ``--ct_reset`` option resets all clock throttling options.
 
 
 **Example commands** 
@@ -97,15 +70,12 @@ Resetting all clock throttling options
 
     #Configure a device's memory settings using an image
     xbmgmt configure --device 0000:b3:00.0 --input /tmp/memory_config.ini
-    
-    #Enable a device's DDR memory retention 
-    xbmgmt configure --device 0000:b3:00.0 --retention ENABLE
-
-    #Enable clock throttling on a supported device
-    xbmgmt configure --device 0000:b3:00.0 --clk_throttle true
 
     #Configure a device using edited output .ini from xbmgmt dump --config (see xbmgmt dump)
     xbmgmt configure --device 0000:b3:00.0 --input /tmp/config.ini
+
+    #Enable a device's DDR memory retention
+    xbmgmt configure --device 0000:b3:00.0 --retention ENABLE
 
 xbmgmt dump
 ~~~~~~~~~~~
@@ -157,9 +127,9 @@ Dumping the output of programmed system image
     mailbox_channel_switch=0x0
     xclbin_change=0
     cache_xclbin=0
-    throttling_enabled=true
-    throttling_power_override=200
-    throttling_temp_override=90
+    throttling_enabled=true #true or false to enable/disable clock throttling
+    throttling_power_override=200 #override threshold in Watts
+    throttling_temp_override=90 #override threshold in Celsius
 
 
 xbmgmt examine

--- a/src/runtime_src/doc/toc/xbmgmt.rst
+++ b/src/runtime_src/doc/toc/xbmgmt.rst
@@ -60,6 +60,10 @@ Enabling/Disabling DDR memory retention on a device
 
 - The ``--input`` specifies an INI file with the memory configuration.
 - The ``--retention`` option enables / disables DDR memory retention.
+- The ``--clk_throttle`` option enables / disables clock throttling.
+- The ``--ct_threshold_power_override`` option updates the clock throttling power threshold in watts.
+- The ``--ct_threshold_temp_override`` option updates the clock throttling temperature threshold in celsius.
+- The ``--ct_reset`` option resets all clock throttling options.
 
 
 **Example commands** 
@@ -148,6 +152,7 @@ The ``xbmgmt examine`` command reports detail status information of the specifie
     - ``mailbox``: Mailbox metrics of the device
     - ``mechanical``: Mechanical sensors on and surrounding the device
     - ``platform``: Platform information
+    - ``cmc``: Reports cmc status of the device
 
 - The ``--format`` (or ``-f``) specifies the report format. Note that ``--format`` also needs an ``--output`` to dump the report in json format. If ``--output`` is missing text format will be shown in stdout
     

--- a/src/runtime_src/doc/toc/xbmgmt.rst
+++ b/src/runtime_src/doc/toc/xbmgmt.rst
@@ -37,7 +37,7 @@ The ``xbmgmt configure`` command provides advanced options for configuring a dev
 
 **The supported options**
 
-Configuring a device's memory settings with a premade image
+Configuring a device's memory or clock throttling settings using an .ini file
 
 .. code-block:: shell
 

--- a/src/runtime_src/doc/toc/xbmgmt.rst
+++ b/src/runtime_src/doc/toc/xbmgmt.rst
@@ -50,6 +50,29 @@ Enabling/Disabling DDR memory retention on a device
 
     xbmgmt configure [--device| -d] <management bdf> --retention [ENABLE|DISABLE]
 
+Enabling/Disabling clock throttling on a device
+
+.. code-block:: shell
+
+    xbmgmt configure [--device| -d] <management bdf> --clk_throttle [true|false]
+
+Updating the clock throttling power threshold
+
+.. code-block:: shell
+
+    xbmgmt configure [--device| -d] <management bdf> --ct_threshold_power_override <threshold in Watts>
+
+Updating the clock throttling temperature threshold
+
+.. code-block:: shell
+
+    xbmgmt configure [--device| -d] <management bdf> --ct_threshold_temp_override <threshold in Celsius>
+
+Resetting all clock throttling options
+
+.. code-block:: shell
+
+    xbmgmt configure [--device| -d] <management bdf> --ct_reset [true|false]
 
 **The details of the supported options**
 
@@ -77,6 +100,9 @@ Enabling/Disabling DDR memory retention on a device
     
     #Enable a device's DDR memory retention 
     xbmgmt configure --device 0000:b3:00.0 --retention ENABLE
+
+    #Enable clock throttling on a supported device
+    xbmgmt configure --device 0000:b3:00.0 --clk_throttle true
 
 
 xbmgmt dump

--- a/src/runtime_src/doc/toc/xbutil.rst
+++ b/src/runtime_src/doc/toc/xbutil.rst
@@ -176,7 +176,6 @@ The command ``xbutil examine``  can be used to find the details of the specific 
     - ``platform``: Platforms flashed on the device (default when ``--device`` is provided)
     - ``qspi-status``: QSPI write protection status
     - ``thermal``: Reports thermal sensors present on the device
-    - ``cmc``: Reports cmc status of the device
 
 - The ``--format`` (or ``-f``) specifies the report format. Note that ``--format`` also needs an ``--output`` to dump the report in json format. If ``--output`` is missing text format will be shown in stdout
     


### PR DESCRIPTION
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1150767 Documentation is needed for CTS configuration using .ini in xbmgmt configure
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CTS documentation needed to be updated. In addition, the cmc report was removed from xbutil docs as done in https://jira.xilinx.com/browse/CR-1135808.
#### How problem was solved, alternative solutions (if any) and why they were rejected
CTS configuration examples were added to the documentation.
#### Risks (if any) associated the changes in the commit
N/A
#### What has been tested and how, request additional testing if necessary
N/A
#### Documentation impact (if any)
This is a documentation change.

Xbmgmt Configure:
![Xbmgmt Configure Docs](https://user-images.githubusercontent.com/103678133/224851244-f1504a99-067f-4c66-9dae-e005c7e7e0d3.png)
Updated Example for Xbmgmt Dump:
![Xbmgmt Dump Docs Examples](https://user-images.githubusercontent.com/103678133/224846786-36611700-4ba3-4a7b-bf00-f419107375ac.png)


