### PR TITLE
CR-1156343: payload is incorrect for MEM tile counters 1-3 in XRT

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_profile_new/edge/aie_profile.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile_new/edge/aie_profile.cpp
@@ -509,7 +509,9 @@ namespace xdp {
           ret = perfCounter->reserve();
           if (ret != XAIE_OK) break;
         
-          auto channel = (i == 0) ? channel0 : channel1;
+          // Channel number is based on monitoring port 0 or 1
+          auto channel = (startEvent <= XAIE_EVENT_PORT_TLAST_0_MEM_TILE) ? channel0 : channel1;
+
           configGroupEvents(aieDevInst, loc, mod, startEvent, metricSet);
           configStreamSwitchPorts(aieDevInst, tileMetric.first, xaieTile, loc, type,
                                   startEvent, i, metricSet, channel);


### PR DESCRIPTION
**Problem solved by the commit**
Fixed payload for MEM tile counters

**How problem was solved, alternative solutions (if any) and why they were rejected**
Derive channel based on event ID since better differentiator 

**Risks (if any) associated the changes in the commit**
None

**What has been tested and how, request additional testing if necessary**
Tested on vek280
