### PR TITLE
AIE reset support. Slot separation for PL and AIE only XCLBIN

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
@@ -267,6 +267,7 @@ void zocl_update_mem_stat(struct drm_zocl_dev *zdev, u64 size,
 void zocl_init_mem(struct drm_zocl_dev *zdev, struct drm_zocl_slot *slot);
 void zocl_clear_mem(struct drm_zocl_dev *zdev);
 void zocl_clear_mem_slot(struct drm_zocl_dev *zdev, u32 slot_idx);
+int zocl_cleanup_aie(struct drm_zocl_dev *zdev);
 int zocl_create_aie(struct drm_zocl_dev *zdev, struct axlf *axlf,
 		void *aie_res, uint8_t hw_gen);
 void zocl_destroy_aie(struct drm_zocl_dev *zdev);

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_util.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_util.h
@@ -72,23 +72,24 @@ enum zocl_mem_type {
 	ZOCL_MEM_TYPE_STREAMING		= 2,
 };
 
-#define PL_RESET_ADDRESS		0x00F1260330
-#define PL_HOLD_VAL			0xF
-#define PL_RELEASE_VAL			0x0
-#define PL_RESET_ALLIGN_SIZE		_4KB
-
 /* Possible slots Types for ZOCL */
 enum zocl_slot_type {
-	ZOCL_FULL_XCLBIN			= 0,
-	ZOCL_PL_ONLY_XCLBIN			= 1,
-	ZOCL_AIE_ONLY_XCLBIN			= 2,
-	ZOCL_PS_ONLY_XCLBIN			= 3
+	ZOCL_SLOT_TYPE_PHY			= 0,
+	ZOCL_SLOT_TYPE_VIRT			= 1
 };
 
-/* Hard coded XCLBIN slots for ZOCL */
+/* Possible XCLBIN Types that ZOCL supports */
+enum zocl_xclbin_type {
+	ZOCL_XCLBIN_TYPE_FULL			= 0,
+	ZOCL_XCLBIN_TYPE_PL_ONLY		= 1,
+	ZOCL_XCLBIN_TYPE_AIE_ONLY		= 2,
+	ZOCL_XCLBIN_TYPE_PS			= 3
+};
+
+/* Hard coded XCLBIN slot id for AIE in ZOCL */
 enum zocl_xclbin_slot {
 	ZOCL_DEFAULT_XCLBIN_SLOT		= 0,
-	ZOCL_AIE_ONLY_XCLBIN_SLOT		= 1,
+	ZOCL_AIE_ONLY_XCLBIN_SLOT		= 1
 };
 
 /*
@@ -123,6 +124,7 @@ struct aie_metadata {
 struct drm_zocl_slot {
 	u32			 slot_idx;
 	u32			 slot_type;
+	u32			 xclbin_type;
 	struct mem_topology	*topology;
 	struct ip_layout	*ip;
 	struct debug_ip_layout	*debug_ip;

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_util.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_util.h
@@ -72,6 +72,25 @@ enum zocl_mem_type {
 	ZOCL_MEM_TYPE_STREAMING		= 2,
 };
 
+#define PL_RESET_ADDRESS		0x00F1260330
+#define PL_HOLD_VAL			0xF
+#define PL_RELEASE_VAL			0x0
+#define PL_RESET_ALLIGN_SIZE		_4KB
+
+/* Possible slots Types for ZOCL */
+enum zocl_slot_type {
+	ZOCL_FULL_XCLBIN			= 0,
+	ZOCL_PL_ONLY_XCLBIN			= 1,
+	ZOCL_AIE_ONLY_XCLBIN			= 2,
+	ZOCL_PS_ONLY_XCLBIN			= 3
+};
+
+/* Hard coded XCLBIN slots for ZOCL */
+enum zocl_xclbin_slot {
+	ZOCL_DEFAULT_XCLBIN_SLOT		= 0,
+	ZOCL_AIE_ONLY_XCLBIN_SLOT		= 1,
+};
+
 /*
  * Memory structure in zocl driver. There will be an array of this
  * structure where each element is representing each section in

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_xclbin.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_xclbin.h
@@ -42,5 +42,6 @@ int zocl_xclbin_load_pskernel(struct drm_zocl_dev *zdev, void *data, uint32_t sl
 bool zocl_xclbin_accel_adapter(int kds_mask);
 int zocl_xclbin_set_dtbo_path(struct drm_zocl_dev *zdev,
 		      struct drm_zocl_slot *slot, char *dtbo_path, uint32_t len);
+int zocl_pl_only_reset(struct drm_zocl_dev *zdev, const char *buf, size_t count);
 
 #endif /* _ZOCL_XCLBIN_H_ */

--- a/src/runtime_src/core/edge/drm/zocl/zocl_aie.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_aie.c
@@ -225,6 +225,29 @@ done:
 }
 
 int
+zocl_cleanup_aie(struct drm_zocl_dev *zdev)
+{
+	int ret = 0;
+
+	if (zdev->aie) {
+		/*
+		 * Dont reset if aie is already in reset
+		 * state
+		 */
+		if( !zdev->aie->aie_reset) {
+			ret = zocl_aie_reset(zdev);
+			if (ret)
+				return ret;
+
+		}
+
+		zocl_destroy_aie(zdev);
+	}
+
+	return 0;
+}
+
+int
 zocl_create_aie(struct drm_zocl_dev *zdev, struct axlf *axlf, void *aie_res, uint8_t hw_gen)
 {
 	uint64_t offset;
@@ -311,6 +334,7 @@ zocl_create_aie(struct drm_zocl_dev *zdev, struct axlf *axlf, void *aie_res, uin
 
 	zocl_init_aie(zdev);
 
+	DRM_INFO("AIE create successfully finished.");
 	return 0;
 
 done:
@@ -437,6 +461,7 @@ zocl_aie_reset(struct drm_zocl_dev *zdev)
 
 	mutex_unlock(&zdev->aie_lock);
 
+	DRM_INFO("AIE Reset successfully finished.");
 	return 0;
 }
 

--- a/src/runtime_src/core/edge/drm/zocl/zocl_aie.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_aie.c
@@ -231,14 +231,12 @@ zocl_cleanup_aie(struct drm_zocl_dev *zdev)
 
 	if (zdev->aie) {
 		/*
-		 * Dont reset if aie is already in reset
-		 * state
+		 * Dont reset if aie is already in reset state
 		 */
 		if( !zdev->aie->aie_reset) {
 			ret = zocl_aie_reset(zdev);
 			if (ret)
 				return ret;
-
 		}
 
 		zocl_destroy_aie(zdev);

--- a/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
@@ -123,7 +123,7 @@ static int zocl_pr_slot_init(struct drm_zocl_dev *zdev,
 	 * backward compartability.
 	 */
 	if (zdev->num_pr_slot == 0)
-		zdev->num_pr_slot = 2;
+		zdev->num_pr_slot = 1;
 
 	for (i = 0; i < zdev->num_pr_slot; i++) {
 		zocl_slot = (struct drm_zocl_slot *)
@@ -137,7 +137,7 @@ static int zocl_pr_slot_init(struct drm_zocl_dev *zdev,
 			return ret;
 
 		mutex_init(&zocl_slot->slot_xclbin_lock);
- 
+
 		if (ZOCL_PLATFORM_ARM64) {
 			zocl_slot->pr_isolation_freeze = 0x0;
 			zocl_slot->pr_isolation_unfreeze = 0x3;
@@ -170,7 +170,7 @@ static int zocl_pr_slot_init(struct drm_zocl_dev *zdev,
 
 		zocl_slot->partial_overlay_id = -1;
 		zocl_slot->slot_idx = i;
-		zocl_slot->slot_type = ZOCL_PL_ONLY_XCLBIN;
+		zocl_slot->slot_type = ZOCL_SLOT_TYPE_PHY;
 
 		zdev->pr_slot[i] = zocl_slot;
 	}
@@ -189,7 +189,7 @@ static int zocl_pr_slot_init(struct drm_zocl_dev *zdev,
 		mutex_init(&zocl_slot->slot_xclbin_lock);
 
 		zocl_slot->slot_idx = i;
-		zocl_slot->slot_type = ZOCL_PS_ONLY_XCLBIN;
+		zocl_slot->slot_type = ZOCL_SLOT_TYPE_VIRT;
 
 		zdev->pr_slot[i] = zocl_slot;
 	}

--- a/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
@@ -123,7 +123,7 @@ static int zocl_pr_slot_init(struct drm_zocl_dev *zdev,
 	 * backward compartability.
 	 */
 	if (zdev->num_pr_slot == 0)
-		zdev->num_pr_slot = 1;
+		zdev->num_pr_slot = 2;
 
 	for (i = 0; i < zdev->num_pr_slot; i++) {
 		zocl_slot = (struct drm_zocl_slot *)
@@ -170,7 +170,7 @@ static int zocl_pr_slot_init(struct drm_zocl_dev *zdev,
 
 		zocl_slot->partial_overlay_id = -1;
 		zocl_slot->slot_idx = i;
-		zocl_slot->slot_type = DOMAIN_PL;
+		zocl_slot->slot_type = ZOCL_PL_ONLY_XCLBIN;
 
 		zdev->pr_slot[i] = zocl_slot;
 	}
@@ -189,7 +189,7 @@ static int zocl_pr_slot_init(struct drm_zocl_dev *zdev,
 		mutex_init(&zocl_slot->slot_xclbin_lock);
 
 		zocl_slot->slot_idx = i;
-		zocl_slot->slot_type = DOMAIN_PS;
+		zocl_slot->slot_type = ZOCL_PS_ONLY_XCLBIN;
 
 		zdev->pr_slot[i] = zocl_slot;
 	}

--- a/src/runtime_src/core/edge/drm/zocl/zocl_sysfs.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_sysfs.c
@@ -68,8 +68,8 @@ static ssize_t xclbinid_show(struct device *dev,
 	read_lock(&zdev->attr_rwlock);
 	for (i = 0; i < MAX_PR_SLOT_NUM; i++) {
 		zocl_slot = zdev->pr_slot[i];
-		if (!zocl_slot && (!zocl_slot->slot_xclbin ||
-		    !zocl_slot->slot_xclbin->zx_dtbo_path))
+		if (!zocl_slot || !zocl_slot->slot_xclbin ||
+		    !zocl_slot->slot_xclbin->zx_dtbo_path)
 			continue;
 
 		count = sprintf(buf+size, raw_fmt, zocl_slot->slot_idx,
@@ -95,8 +95,8 @@ static ssize_t dtbo_path_show(struct device *dev,
 	read_lock(&zdev->attr_rwlock);
 	for (i = 0; i < MAX_PR_SLOT_NUM; i++) {
 		zocl_slot = zdev->pr_slot[i];
-		if (!zocl_slot && (!zocl_slot->slot_xclbin ||
-		    !zocl_slot->slot_xclbin->zx_dtbo_path))
+		if (!zocl_slot || !zocl_slot->slot_xclbin ||
+		    !zocl_slot->slot_xclbin->zx_dtbo_path)
 			continue;
 
 		count = sprintf(buf+size, raw_fmt, zocl_slot->slot_idx,
@@ -471,7 +471,7 @@ static ssize_t read_debug_ip_layout(struct file *filp, struct kobject *kobj,
 
 	for (i = 0; i < MAX_PR_SLOT_NUM; i++) {
 		zocl_slot = zdev->pr_slot[i];
-		if (!zocl_slot && !zocl_slot->debug_ip)
+		if (!zocl_slot || !zocl_slot->debug_ip)
 			continue;
 
 		size = sizeof_section(zocl_slot->debug_ip, m_debug_ip_data);
@@ -512,7 +512,7 @@ static ssize_t read_ip_layout(struct file *filp, struct kobject *kobj,
 
 	for (i = 0; i < MAX_PR_SLOT_NUM; i++) {
 		zocl_slot = zdev->pr_slot[i];
-		if (!zocl_slot && !zocl_slot->ip)
+		if (!zocl_slot || !zocl_slot->ip)
 			continue;
 
 		size = sizeof_section(zocl_slot->ip, m_ip_data);
@@ -553,7 +553,7 @@ static ssize_t read_connectivity(struct file *filp, struct kobject *kobj,
 
 	for (i = 0; i < MAX_PR_SLOT_NUM; i++) {
 		zocl_slot = zdev->pr_slot[i];
-		if (!zocl_slot && !zocl_slot->connectivity)
+		if (!zocl_slot || !zocl_slot->connectivity)
 			continue;
 
 		size = sizeof_section(zocl_slot->connectivity, m_connection);
@@ -594,7 +594,7 @@ static ssize_t read_mem_topology(struct file *filp, struct kobject *kobj,
 
 	for (i = 0; i < MAX_PR_SLOT_NUM; i++) {
 		zocl_slot = zdev->pr_slot[i];
-		if (!zocl_slot && !zocl_slot->topology)
+		if (!zocl_slot || !zocl_slot->topology)
 			continue;
 
 		size = sizeof_section(zocl_slot->topology, m_mem_data);
@@ -637,7 +637,7 @@ static ssize_t read_xclbin_full(struct file *filp, struct kobject *kobj,
 
 	for (i = 0; i < MAX_PR_SLOT_NUM; i++) {
 		zocl_slot = zdev->pr_slot[i];
-		if (!zocl_slot && !zocl_slot->axlf)
+		if (!zocl_slot || !zocl_slot->axlf)
 			continue;
 
 		size = zocl_slot->axlf_size;

--- a/src/runtime_src/core/edge/drm/zocl/zocl_sysfs.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_sysfs.c
@@ -66,13 +66,11 @@ static ssize_t xclbinid_show(struct device *dev,
 	int i = 0;
 
 	read_lock(&zdev->attr_rwlock);
-	for (i = 0; i < zdev->num_pr_slot; i++) {
+	for (i = 0; i < MAX_PR_SLOT_NUM; i++) {
 		zocl_slot = zdev->pr_slot[i];
-		if (!zocl_slot || !zocl_slot->slot_xclbin ||
-		    !zocl_slot->slot_xclbin->zx_uuid) {
-			read_unlock(&zdev->attr_rwlock);
-			return 0;
-		}
+		if (!zocl_slot && (!zocl_slot->slot_xclbin ||
+		    !zocl_slot->slot_xclbin->zx_dtbo_path))
+			continue;
 
 		count = sprintf(buf+size, raw_fmt, zocl_slot->slot_idx,
 				zocl_slot->slot_xclbin->zx_uuid);
@@ -95,10 +93,10 @@ static ssize_t dtbo_path_show(struct device *dev,
 	int i = 0;
 
 	read_lock(&zdev->attr_rwlock);
-	for (i = 0; i < zdev->num_pr_slot; i++) {
+	for (i = 0; i < MAX_PR_SLOT_NUM; i++) {
 		zocl_slot = zdev->pr_slot[i];
-		if (!zocl_slot || !zocl_slot->slot_xclbin ||
-		    !zocl_slot->slot_xclbin->zx_dtbo_path)
+		if (!zocl_slot && (!zocl_slot->slot_xclbin ||
+		    !zocl_slot->slot_xclbin->zx_dtbo_path))
 			continue;
 
 		count = sprintf(buf+size, raw_fmt, zocl_slot->slot_idx,
@@ -317,8 +315,10 @@ static ssize_t read_aie_metadata(struct file *filp, struct kobject *kobj,
 
 	read_lock(&zdev->attr_rwlock);
 
-	for (i = 0; i < zdev->num_pr_slot; i++) {
+	for (i = 0; i < MAX_PR_SLOT_NUM; i++) {
 		zocl_slot = zdev->pr_slot[i];
+		if (!zocl_slot)
+			continue;
 
 		size = zocl_slot->aie_data.size;
 
@@ -469,16 +469,12 @@ static ssize_t read_debug_ip_layout(struct file *filp, struct kobject *kobj,
 
 	read_lock(&zdev->attr_rwlock);
 
-	for (i = 0; i < zdev->num_pr_slot; i++) {
+	for (i = 0; i < MAX_PR_SLOT_NUM; i++) {
 		zocl_slot = zdev->pr_slot[i];
-
-		if (!zocl_slot->debug_ip) {
-			read_unlock(&zdev->attr_rwlock);
-			return 0;
-		}
+		if (!zocl_slot && !zocl_slot->debug_ip)
+			continue;
 
 		size = sizeof_section(zocl_slot->debug_ip, m_debug_ip_data);
-
 		if (off >= size) {
 			read_unlock(&zdev->attr_rwlock);
 			return 0;
@@ -514,16 +510,12 @@ static ssize_t read_ip_layout(struct file *filp, struct kobject *kobj,
 
 	read_lock(&zdev->attr_rwlock);
 
-	for (i = 0; i < zdev->num_pr_slot; i++) {
+	for (i = 0; i < MAX_PR_SLOT_NUM; i++) {
 		zocl_slot = zdev->pr_slot[i];
-
-		if (!zocl_slot->ip) {
-			read_unlock(&zdev->attr_rwlock);
-			return 0;
-		}
+		if (!zocl_slot && !zocl_slot->ip)
+			continue;
 
 		size = sizeof_section(zocl_slot->ip, m_ip_data);
-
 		if (off >= size) {
 			read_unlock(&zdev->attr_rwlock);
 			return 0;
@@ -559,16 +551,12 @@ static ssize_t read_connectivity(struct file *filp, struct kobject *kobj,
 
 	read_lock(&zdev->attr_rwlock);
 
-	for (i = 0; i < zdev->num_pr_slot; i++) {
+	for (i = 0; i < MAX_PR_SLOT_NUM; i++) {
 		zocl_slot = zdev->pr_slot[i];
-
-		if (!zocl_slot->connectivity) {
-			read_unlock(&zdev->attr_rwlock);
-			return 0;
-		}
+		if (!zocl_slot && !zocl_slot->connectivity)
+			continue;
 
 		size = sizeof_section(zocl_slot->connectivity, m_connection);
-
 		if (off >= size) {
 			read_unlock(&zdev->attr_rwlock);
 			return 0;
@@ -604,13 +592,10 @@ static ssize_t read_mem_topology(struct file *filp, struct kobject *kobj,
 
 	read_lock(&zdev->attr_rwlock);
 
-	for (i = 0; i < zdev->num_pr_slot; i++) {
+	for (i = 0; i < MAX_PR_SLOT_NUM; i++) {
 		zocl_slot = zdev->pr_slot[i];
-
-		if (!zocl_slot->topology) {
-			read_unlock(&zdev->attr_rwlock);
-			return 0;
-		}
+		if (!zocl_slot && !zocl_slot->topology)
+			continue;
 
 		size = sizeof_section(zocl_slot->topology, m_mem_data);
 
@@ -650,16 +635,12 @@ static ssize_t read_xclbin_full(struct file *filp, struct kobject *kobj,
 
 	read_lock(&zdev->attr_rwlock);
 
-	for (i = 0; i < zdev->num_pr_slot; i++) {
+	for (i = 0; i < MAX_PR_SLOT_NUM; i++) {
 		zocl_slot = zdev->pr_slot[i];
-
-		if (!zocl_slot->axlf) {
-			read_unlock(&zdev->attr_rwlock);
-			return 0;
-		}
+		if (!zocl_slot && !zocl_slot->axlf)
+			continue;
 
 		size = zocl_slot->axlf_size;
-
 		if (off >= size) {
 			read_unlock(&zdev->attr_rwlock);
 			return 0;

--- a/src/runtime_src/core/edge/drm/zocl/zocl_sysfs.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_sysfs.c
@@ -416,6 +416,24 @@ static ssize_t host_mem_size_show(struct device *dev,
 }
 static DEVICE_ATTR_RO(host_mem_size);
 
+static ssize_t
+pl_only_reset_store(struct device *dev, struct device_attribute *da,
+		const char *buf, size_t count)
+{
+	struct drm_zocl_dev *zdev = dev_get_drvdata(dev);
+        u32 val = 0;
+
+	if (kstrtou32(buf, 10, &val) < 0 || val != 1)
+		return -EINVAL;
+
+	write_lock(&zdev->attr_rwlock);
+	count = zocl_pl_only_reset(zdev, buf, count);
+	write_unlock(&zdev->attr_rwlock);
+
+	return count;
+}
+static DEVICE_ATTR_WO(pl_only_reset);
+
 static struct attribute *zocl_attrs[] = {
 	&dev_attr_xclbinid.attr,
 	&dev_attr_kds_numcus.attr,
@@ -431,6 +449,7 @@ static struct attribute *zocl_attrs[] = {
 	&dev_attr_dtbo_path.attr,
 	&dev_attr_host_mem_addr.attr,
 	&dev_attr_host_mem_size.attr,
+	&dev_attr_pl_only_reset.attr,
 	NULL,
 };
 

--- a/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
@@ -998,8 +998,8 @@ zocl_load_aie_only_pdi(struct drm_zocl_dev *zdev, struct axlf *axlf,
 			char __user *xclbin, struct sched_client_ctx *client)
 {
 	uint64_t size = 0;
-	int ret = 0;
 	char *pdi_buf = NULL;
+	int ret = 0;
 
 	if (client && client->aie_ctx == ZOCL_CTX_SHARED) {
 		DRM_ERROR("%s Shared context can not load xclbin", __func__);
@@ -1011,6 +1011,7 @@ zocl_load_aie_only_pdi(struct drm_zocl_dev *zdev, struct axlf *axlf,
 		return 0;
 
 	ret = zocl_fpga_mgr_load(zdev, pdi_buf, size, FPGA_MGR_PARTIAL_RECONFIG);
+	vfree(pdi_buf);
 
 	/* Mark AIE out of reset state after load PDI */
 	if (zdev->aie) {

--- a/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
@@ -916,7 +916,7 @@ zocl_xclbin_load_pskernel(struct drm_zocl_dev *zdev, void *data, uint32_t slot_i
 
         mutex_lock(&slot->slot_xclbin_lock);
 	/* Check unique ID. Avoid duplicate PL xclbin */
-	if ((slot->slot_type == ZOCL_SLOT_TYPE_VIRT) &&
+	if ((slot->slot_type == ZOCL_SLOT_TYPE_PHY) &&
 	    (zocl_xclbin_same_uuid(slot, &axlf_head->m_header.uuid))) {
 		DRM_INFO("%s The XCLBIN already loaded, uuid: %pUb",
 			 __func__, &axlf_head->m_header.uuid);
@@ -1165,7 +1165,7 @@ is_aie_only(struct axlf *axlf)
 {
 	if ((axlf->m_header.m_actionMask & AM_LOAD_AIE) ||
 		(!xrt_xclbin_get_section_num(axlf, IP_LAYOUT) &&
-		xrt_xclbin_get_section_num(axlf, AIE_METADATA))
+		xrt_xclbin_get_section_num(axlf, AIE_METADATA)))
 		return true;
 
 	return false;

--- a/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
@@ -702,7 +702,7 @@ zocl_get_slot(struct drm_zocl_dev *zdev, uuid_t *id)
 	struct drm_zocl_slot *zocl_slot = NULL;
 	int i = 0;
 
-	for (i = 0; i < zdev->num_pr_slot; i++) {
+	for (i = 0; i < MAX_PR_SLOT_NUM; i++) {
 		zocl_slot = zdev->pr_slot[i];
 		if (zocl_slot) {
 			mutex_lock(&zocl_slot->slot_xclbin_lock);
@@ -916,7 +916,7 @@ zocl_xclbin_load_pskernel(struct drm_zocl_dev *zdev, void *data, uint32_t slot_i
 
         mutex_lock(&slot->slot_xclbin_lock);
 	/* Check unique ID. Avoid duplicate PL xclbin */
-	if ((slot->slot_type == DOMAIN_PL) &&
+	if ((slot->slot_type == ZOCL_PL_ONLY_XCLBIN) &&
 	    (zocl_xclbin_same_uuid(slot, &axlf_head->m_header.uuid))) {
 		DRM_INFO("%s The XCLBIN already loaded, uuid: %pUb",
 			 __func__, &axlf_head->m_header.uuid);
@@ -998,8 +998,8 @@ zocl_load_aie_only_pdi(struct drm_zocl_dev *zdev, struct axlf *axlf,
 			char __user *xclbin, struct sched_client_ctx *client)
 {
 	uint64_t size = 0;
-	char *pdi_buf = NULL;
 	int ret = 0;
+	char *pdi_buf = NULL;
 
 	if (client && client->aie_ctx == ZOCL_CTX_SHARED) {
 		DRM_ERROR("%s Shared context can not load xclbin", __func__);
@@ -1011,7 +1011,6 @@ zocl_load_aie_only_pdi(struct drm_zocl_dev *zdev, struct axlf *axlf,
 		return 0;
 
 	ret = zocl_fpga_mgr_load(zdev, pdi_buf, size, FPGA_MGR_PARTIAL_RECONFIG);
-	vfree(pdi_buf);
 
 	/* Mark AIE out of reset state after load PDI */
 	if (zdev->aie) {
@@ -1021,6 +1020,14 @@ zocl_load_aie_only_pdi(struct drm_zocl_dev *zdev, struct axlf *axlf,
 	}
 
 	return ret;
+}
+
+int
+zocl_pl_only_reset(struct drm_zocl_dev *zdev, const char *buf, size_t count)
+{
+	/* TODO */
+	DRM_ERROR("%s PL Reset support doesn't added yet", __func__);
+	return count;
 }
 
 /*
@@ -1166,7 +1173,21 @@ zocl_load_sect(struct drm_zocl_dev *zdev, struct axlf *axlf, char __user *xclbin
 static bool
 is_aie_only(struct axlf *axlf)
 {
-	return (axlf->m_header.m_actionMask & AM_LOAD_AIE);
+	if (!xrt_xclbin_get_section_num(axlf, IP_LAYOUT) &&
+		xrt_xclbin_get_section_num(axlf, AIE_METADATA))
+		return true;
+
+	return false;
+}
+
+static bool
+is_pl_only(struct axlf *axlf)
+{
+	if (xrt_xclbin_get_section_num(axlf, IP_LAYOUT) &&
+		!xrt_xclbin_get_section_num(axlf, AIE_METADATA))
+		return true;
+
+	return false;
 }
 
 int
@@ -1243,6 +1264,80 @@ populate_slot_specific_sec(struct drm_zocl_dev *zdev, struct axlf *axlf,
 	return 0;
 }
 
+static bool
+zocl_bitstream_is_locked(struct drm_zocl_dev *zdev, struct drm_zocl_slot *slot)
+{
+	int ref_cnt = 0;
+
+	/* 1. We locked &zdev->slot_xclbin_lock so that no new contexts
+	 * can be opened and/or closed
+	 * 2. A opened context would lock bitstream and hold it.
+	 * 3. If all contexts are closed, new kds would make sure all
+	 * relative exec BO are released
+	 */
+	ref_cnt = zocl_xclbin_refcount(slot);
+	BUG_ON(ref_cnt < 0);
+
+	return ref_cnt != 0;
+}
+
+
+static int
+zocl_resolver(struct drm_zocl_dev *zdev, struct axlf *axlf, xuid_t *xclbin_id,
+	      uint32_t qos, uint32_t *slot_id)
+{
+	struct drm_zocl_slot *slot = NULL;
+	uint32_t s_id = 0;
+	uint32_t zocl_slot_type = 0;
+
+	/* Slots need to be decided based on interface ID. But currently this
+	 * functionality is not yet ready. Hence we are hard coding the Slots
+	 * based on the type of XCLBIN. This logic need to be updated in future.
+	 */
+	/* Right now the hard coded logic as follows:
+	 * Slot - 0 : FULL XCLBIN (Both PL and AIE) / PL Only XCLBIN
+	 * Slot - 1 : AIE Only XCLBIN
+	 */
+	if (is_aie_only(axlf)) {
+		s_id = ZOCL_AIE_ONLY_XCLBIN;
+		zocl_slot_type = ZOCL_AIE_ONLY_XCLBIN;
+	}
+	else {
+		s_id = ZOCL_DEFAULT_XCLBIN_SLOT;
+		if (is_pl_only(axlf))
+			zocl_slot_type = ZOCL_PL_ONLY_XCLBIN;
+		else
+			zocl_slot_type = ZOCL_FULL_XCLBIN;
+	}
+
+	slot = zdev->pr_slot[s_id];
+	if (!slot && (slot->slot_type != zocl_slot_type)) {
+		DRM_ERROR("Slot[%d] doesn't exists or Invaid slot", s_id);
+		return -EINVAL;
+	}
+
+	mutex_lock(&slot->slot_xclbin_lock);
+	*slot_id = s_id;
+	slot->slot_type = zocl_slot_type;
+	if (zocl_xclbin_same_uuid(slot, xclbin_id)) {
+		if (qos & DRM_ZOCL_FORCE_PROGRAM) {
+			// We come here if user sets force_xclbin_program
+			// option "true" in xrt.ini under [Runtime] section
+			DRM_WARN("%s Force xclbin download", __func__);
+		} else {
+			DRM_INFO("Exists xclbin %pUb to slot %d",
+							xclbin_id, *slot_id);
+			mutex_unlock(&slot->slot_xclbin_lock);
+			return -EEXIST;
+		}
+	}
+
+done:
+	mutex_unlock(&slot->slot_xclbin_lock);
+	DRM_INFO("Loading xclbin %pUb to slot %d", xclbin_id, *slot_id);
+	return 0;
+}
+
 /*
  * This function is the main entry point to load xclbin. It's takes an userspace
  * pointer of xclbin and copy the xclbin data to kernel space. Then load that
@@ -1269,32 +1364,19 @@ zocl_xclbin_read_axlf(struct drm_zocl_dev *zdev, struct drm_zocl_axlf *axlf_obj,
 	void *aie_res = 0;
 	int ret = 0;
 	struct drm_zocl_slot *slot = NULL;
-	int slot_id = axlf_obj->za_slot_id;
+	int slot_id = 0;
+	uint32_t qos = 0;
 	uint8_t hw_gen = axlf_obj->hw_gen;
 
-	if ((slot_id < 0) || (slot_id > zdev->num_pr_slot)) {
-		DRM_ERROR("Invalid Slot[%d]", slot_id);
-		return -EINVAL;
-	}
-
-	slot = zdev->pr_slot[slot_id];
-	if (!slot) {
-		DRM_ERROR("Slot[%d] doesn't exists", slot_id);
-		return -EINVAL;
-	}
-
-	mutex_lock(&slot->slot_xclbin_lock);
-
+	/* Download the XCLBIN from user space to kernel space and validate */
 	if (copy_from_user(&axlf_head, axlf_obj->za_xclbin_ptr,
 	    sizeof(struct axlf))) {
 		DRM_WARN("copy_from_user failed for za_xclbin_ptr");
-		mutex_unlock(&slot->slot_xclbin_lock);
 		return -EFAULT;
 	}
 
 	if (memcmp(axlf_head.m_magic, "xclbin2", 8)) {
 		DRM_WARN("xclbin magic is invalid %s", axlf_head.m_magic);
-		mutex_unlock(&slot->slot_xclbin_lock);
 		return -EINVAL;
 	}
 
@@ -1305,14 +1387,12 @@ zocl_xclbin_read_axlf(struct drm_zocl_dev *zdev, struct drm_zocl_axlf *axlf_obj,
 	axlf = vmalloc(axlf_size);
 	if (!axlf) {
 		DRM_WARN("read xclbin fails: no memory");
-		mutex_unlock(&slot->slot_xclbin_lock);
 		return -ENOMEM;
 	}
 
 	if (copy_from_user(axlf, axlf_obj->za_xclbin_ptr, axlf_size)) {
 		DRM_WARN("read xclbin: fail copy from user memory");
 		vfree(axlf);
-		mutex_unlock(&slot->slot_xclbin_lock);
 		return -EFAULT;
 	}
 
@@ -1321,39 +1401,30 @@ zocl_xclbin_read_axlf(struct drm_zocl_dev *zdev, struct drm_zocl_axlf *axlf_obj,
 	if (ret) {
 		DRM_WARN("read xclbin: fail the access check");
 		vfree(axlf);
-		mutex_unlock(&slot->slot_xclbin_lock);
 		return -EFAULT;
 	}
-	
 
+	/* TODO : qos need to define */
+	qos |= axlf_obj->za_flags;
+	ret = zocl_resolver(zdev, axlf, &axlf_head.m_header.uuid, qos, &slot_id);
+	if (ret) {
+		if (ret == -EEXIST) {
+			vfree(axlf);
+			return 0;
+		}
+
+		DRM_ERROR("Download xclbin failed\n");
+		ret = -EINVAL;
+		goto out0;
+	}
+
+	slot = zdev->pr_slot[slot_id];
+	mutex_lock(&slot->slot_xclbin_lock);
 	/*
 	 * Read AIE_RESOURCES section. aie_res will be NULL if there is no
 	 * such a section.
 	 */
 	zocl_read_sect(AIE_RESOURCES, &aie_res, axlf, xclbin);
-
-	/* Check unique ID */
-	if (zocl_xclbin_same_uuid(slot, &axlf_head.m_header.uuid)) {
-		if (!(axlf_obj->za_flags & DRM_ZOCL_FORCE_PROGRAM)) {
-			if (is_aie_only(axlf)) {
-				ret = zocl_load_aie_only_pdi(zdev, axlf, xclbin,
-							     client);
-				if (ret)
-					DRM_WARN("read xclbin: fail to load AIE");
-				else {
-					zocl_create_aie(zdev, axlf, aie_res, hw_gen);
-					zocl_cache_xclbin(zdev, slot, axlf, xclbin);
-				}
-			} else {
-				DRM_INFO("%s The XCLBIN already loaded", __func__);
-			}
-			goto out0;
-		} else {
-			// We come here if user sets force_xclbin_program
-			// option "true" in xrt.ini under [Runtime] section
-			DRM_WARN("%s The XCLBIN already loaded. Force xclbin download", __func__);
-		}
-	}
 
 	/* 1. We locked &zdev->slot_xclbin_lock so that no new contexts
 	 * can be opened and/or closed
@@ -1361,7 +1432,7 @@ zocl_xclbin_read_axlf(struct drm_zocl_dev *zdev, struct drm_zocl_axlf *axlf_obj,
 	 * 3. If all contexts are closed, new kds would make sure all
 	 * relative exec BO are released
 	 */
-	if (zocl_xclbin_refcount(slot) > 0) {
+	if (zocl_bitstream_is_locked(zdev, slot)) {
 		DRM_ERROR("Current xclbin is in-use, can't change");
 		ret = -EBUSY;
 		goto out0;
@@ -1439,6 +1510,8 @@ zocl_xclbin_read_axlf(struct drm_zocl_dev *zdev, struct drm_zocl_axlf *axlf_obj,
 				goto out0;
 		}
 	} else if (is_aie_only(axlf)) {
+		zocl_cleanup_aie(zdev);
+
 		ret = zocl_load_aie_only_pdi(zdev, axlf, xclbin, client);
 		if (ret)
 			goto out0;

--- a/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
@@ -1163,7 +1163,8 @@ zocl_load_sect(struct drm_zocl_dev *zdev, struct axlf *axlf, char __user *xclbin
 static bool
 is_aie_only(struct axlf *axlf)
 {
-	if (!xrt_xclbin_get_section_num(axlf, IP_LAYOUT) &&
+	if ((axlf->m_header.m_actionMask & AM_LOAD_AIE) ||
+		(!xrt_xclbin_get_section_num(axlf, IP_LAYOUT) &&
 		xrt_xclbin_get_section_num(axlf, AIE_METADATA))
 		return true;
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Whenever there is an issue in AIE array , there is no easy way to reset/reload the AIE array to get AIE Array back to initial state. Customers need  a reliable way to reset and reload AIE array.
For Reset AIE we need PL Only XCLBIN and AIE Only XCLBIN. Both should loaded into different slot. 

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
-- New feature

#### How problem was solved, alternative solutions (if any) and why they were rejected
-- AIE Reset support

#### Risks (if any) associated the changes in the commit
-N/A
#### What has been tested and how, request additional testing if necessary
Basic validation test and specific test case
 
#### Documentation impact (if any)
- N/A