### PR TITLE
LWPAECGDEV-69: Fixed using xrt::error.to_string() triggers an exception

### DIFF
--- a/src/runtime_src/core/common/api/xrt_error.cpp
+++ b/src/runtime_src/core/common/api/xrt_error.cpp
@@ -250,7 +250,7 @@ public:
   to_string()
   {
     if (!m_errcode)
-      return std::string("No async error was detected");
+      return "No async error was detected";
 
     auto fmt = boost::format
       ("%s\n"

--- a/src/runtime_src/core/common/api/xrt_error.cpp
+++ b/src/runtime_src/core/common/api/xrt_error.cpp
@@ -249,6 +249,9 @@ public:
   std::string
   to_string()
   {
+    if (!m_errcode)
+      return std::string("No async error was detected");
+
     auto fmt = boost::format
       ("%s\n"
        "Timestamp: %s")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Using xrt::error.to_string() when there is no async error will throw an exception, but we expect to get some information from the returned string, not triggering exception.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
[LWPAECGDEV-69](https://ontrack-internal.amd.com/browse/LWPAECGDEV-69) 
#### How problem was solved, alternative solutions (if any) and why they were rejected
Check if error code gets a value firstly when calling xrt::error.to_string(), and return "No async error was detected" when error code is still zero.
#### What has been tested and how, request additional testing if necessary
Tested `xrt_run_ert_packet.exe -v 3 --op 1 --xrt-err` on a birman board and the results are shown as below:
 
![use_xrt_error](https://user-images.githubusercontent.com/109250766/225448414-5b97edd2-d719-4c1a-8b52-840473bb0138.png)

