### PR TITLE
VITIS-6885: Adding buffer descriptor information for core and mem tiles in respective aie reports

### DIFF
--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -124,7 +124,6 @@ enum class key_type
   aie_status_version,
   aie_tiles_stats,
   aie_tiles_status_info,
-  aie_bd_info,
 
   idcode,
   data_retention,
@@ -1417,22 +1416,6 @@ struct aie_tiles_status_info : request
 
   virtual boost::any
   get(const device* device, const boost::any& param) const = 0;
-};
-
-struct aie_bd_info : request
-{
-  enum class tile_type { core, mem, shim };
-   
-  struct parameters {
-    uint8_t row;
-    uint8_t col;
-    tile_type type;
-  };
-
-  using result_type = std::string;
-  static const key_type key = key_type::aie_bd_info;
-  virtual boost::any
-  get(const device* device, const boost::any& parameters) const = 0;
 };
 
 struct clock_freqs_mhz : request

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -124,6 +124,7 @@ enum class key_type
   aie_status_version,
   aie_tiles_stats,
   aie_tiles_status_info,
+  aie_bd_info,
 
   idcode,
   data_retention,
@@ -1416,6 +1417,22 @@ struct aie_tiles_status_info : request
 
   virtual boost::any
   get(const device* device, const boost::any& param) const = 0;
+};
+
+struct aie_bd_info : request
+{
+  enum class tile_type { core, mem, shim };
+   
+  struct parameters {
+    uint8_t row;
+    uint8_t col;
+    tile_type type;
+  };
+
+  using result_type = std::string;
+  static const key_type key = key_type::aie_bd_info;
+  virtual boost::any
+  get(const device* device, const boost::any& parameters) const = 0;
 };
 
 struct clock_freqs_mhz : request

--- a/src/runtime_src/core/edge/user/aie/aie.cpp
+++ b/src/runtime_src/core/edge/user/aie/aie.cpp
@@ -102,7 +102,8 @@ Aie::Aie(const std::shared_ptr<xrt_core::device>& device, adf::driver_config& dr
 
 boost::property_tree::ptree
 Aie::
-get_bd_info(uint8_t& row, uint8_t& col) {
+get_bd_info(uint8_t row, uint8_t col)
+{
     XAie_DevInst* devInst = getDevInst();
     if (!devInst)
       throw xrt_core::error(-EINVAL, "AIE is not initialized");
@@ -110,7 +111,7 @@ get_bd_info(uint8_t& row, uint8_t& col) {
     boost::property_tree::ptree bd_ptree; 
     u8 numBds;
     auto ret = XAie_DmaGetNumBds(devInst, tile, &numBds);
-    if(ret != AieRC::XAIE_OK)
+    if (ret != AieRC::XAIE_OK)
 	return bd_ptree;
     
     boost::property_tree::ptree bd; 

--- a/src/runtime_src/core/edge/user/aie/aie.h
+++ b/src/runtime_src/core/edge/user/aie/aie.h
@@ -126,7 +126,7 @@ public:
     void
     clear_bd(BD& bd);
 
-    boost::property_tree::ptree get_bd_info(uint8_t& row, uint8_t& col);
+    boost::property_tree::ptree get_bd_info(uint8_t row, uint8_t col);
 
 private:
     int numCols;

--- a/src/runtime_src/core/edge/user/aie/aie.h
+++ b/src/runtime_src/core/edge/user/aie/aie.h
@@ -81,7 +81,8 @@ class Aie {
 public:
     ~Aie();
     Aie(const std::shared_ptr<xrt_core::device>& device);
-
+    Aie(const std::shared_ptr<xrt_core::device>& device, adf::driver_config& config);
+    void initialize(const std::shared_ptr<xrt_core::device>& device, adf::driver_config& config);
     std::vector<ShimDMA> shim_dma;   // shim DMA // not used anymore, should be cleanedup
 
     /* This is the collections of gmios that are used. */
@@ -124,6 +125,8 @@ public:
 
     void
     clear_bd(BD& bd);
+
+    boost::property_tree::ptree get_bd_info(uint8_t& row, uint8_t& col);
 
 private:
     int numCols;

--- a/src/runtime_src/core/edge/user/device_linux.cpp
+++ b/src/runtime_src/core/edge/user/device_linux.cpp
@@ -19,7 +19,6 @@
 #include "xrt.h"
 #include "zynq_dev.h"
 #include "aie_sys_parser.h"
-#include "aie/aie.h"
 #include "shim.h"
 
 #include "core/common/debug_ip.h"

--- a/src/runtime_src/core/edge/user/device_linux.cpp
+++ b/src/runtime_src/core/edge/user/device_linux.cpp
@@ -211,8 +211,9 @@ get_aie_metadata_info(const xrt_core::device* device)
   return aie_meta;
 }
 
+#ifdef XRT_ENABLE_AIE
 static void 
-add_core_bd(zynqaie::Aie* aie_array, const boost::property_tree::ptree& aie_meta , boost::property_tree::ptree& ptarray, uint8_t& row_offset)
+add_core_bd(zynqaie::Aie* aie_array, const boost::property_tree::ptree& aie_meta, boost::property_tree::ptree& ptarray, uint8_t& row_offset)
 {
    boost::property_tree::ptree empty_pt;
    std::vector<std::pair<int, int>> core_tiles;
@@ -254,7 +255,7 @@ add_core_bd(zynqaie::Aie* aie_array, const boost::property_tree::ptree& aie_meta
 }
 
 static void 
-add_mem_bd(zynqaie::Aie* aie_array, const boost::property_tree::ptree& aie_meta , boost::property_tree::ptree& ptarray, uint8_t& row_offset)
+add_mem_bd(zynqaie::Aie* aie_array, const boost::property_tree::ptree& aie_meta, boost::property_tree::ptree& ptarray, uint8_t& row_offset)
 {
    for (uint8_t i = 0; i < aie_meta.get<uint8_t>("aie_metadata.driver_config.num_columns"); ++i) {
      for (uint8_t j = 0; j < aie_meta.get<uint8_t>("aie_metadat.driver_config.reserved_num_rows"); ++j) {
@@ -383,6 +384,37 @@ struct aie_mem_info_sysfs
     return inifile_text;
   }
 };
+
+#else
+struct aie_core_info_sysfs
+{
+  using result_type = query::aie_core_info_sysfs::result_type;
+  static result_type
+  get(const xrt_core::device* device, key_type key) 
+  {
+    throw xrt_core::error(-EINVAL, "AIE is not enabled for this device");
+  }
+};
+struct aie_shim_info_sysfs
+{
+  using result_type = query::aie_shim_info_sysfs::result_type;
+  static result_type
+  get(const xrt_core::device* device, key_type key) 
+  {
+    throw xrt_core::error(-EINVAL, "AIE is not enabled for this device");
+  }
+};
+
+struct aie_mem_info_sysfs
+{
+  using result_type = query::aie_mem_info_sysfs::result_type;
+  static result_type
+  get(const xrt_core::device* device, key_type key) 
+  {
+    throw xrt_core::error(-EINVAL, "AIE is not enabled for this device");
+  }
+};
+#endif
 
 struct kds_cu_info
 {

--- a/src/runtime_src/core/edge/user/device_linux.cpp
+++ b/src/runtime_src/core/edge/user/device_linux.cpp
@@ -685,12 +685,16 @@ struct aie_bd_info
          row = tile.row + driver_config.reserved_row_start;
       boost::property_tree::ptree bdtree = aieArray->get_bd_info(row, tile.col);
 
-#endif
-#endif
       std::ostringstream oss;
       boost::property_tree::write_json(oss, bdtree);
       std::string inifile_text = oss.str();
       return inifile_text;
+#else 
+      throw xrt_core::error(-EINVAL, "AIE is not enabled for this device");
+#endif
+#else
+      throw xrt_core::error(-EINVAL, "AIE is not enabled for this device");
+#endif
     }
 };
 

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -1738,7 +1738,6 @@ void
 shim::
 registerAieArray(adf::driver_config& config)
 {
-  delete aieArray.release();
   aieArray = std::make_unique<zynqaie::Aie>(mCoreDevice, config);
   aied = std::make_unique<zynqaie::Aied>(mCoreDevice.get());
 }

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -1734,6 +1734,15 @@ registerAieArray()
   aied = std::make_unique<zynqaie::Aied>(mCoreDevice.get());
 }
 
+void
+shim::
+registerAieArray(adf::driver_config& config)
+{
+  delete aieArray.release();
+  aieArray = std::make_unique<zynqaie::Aie>(mCoreDevice, config);
+  aied = std::make_unique<zynqaie::Aied>(mCoreDevice.get());
+}
+
 bool
 shim::
 isAieRegistered()

--- a/src/runtime_src/core/edge/user/shim.h
+++ b/src/runtime_src/core/edge/user/shim.h
@@ -229,6 +229,7 @@ public:
   zynqaie::Aied* getAied();
   int getBOInfo(drm_zocl_info_bo &info);
   void registerAieArray();
+  void registerAieArray(adf::driver_config& config);
   bool isAieRegistered();
   int getPartitionFd(drm_zocl_aie_fd &aiefd);
   int resetAIEArray(drm_zocl_aie_reset &reset);

--- a/src/runtime_src/core/tools/common/ReportAie.cpp
+++ b/src/runtime_src/core/tools/common/ReportAie.cpp
@@ -205,9 +205,43 @@ writeReport(const xrt_core::device* /*_pDevice*/,
           }
           _output << std::endl;
         }
-      }
 
-      const boost::property_tree::ptree& pl_kernel = graph.get_child("pl_kernel");
+	if (tile.second.find("buffer-descriptors") != tile.second.not_found()) {
+	  _output << boost::format("    %s:\n") % "Buffer Descriptor ";
+	  boost::property_tree::ptree bd = tile.second.get_child("buffer-descriptors");
+	  if (bd.find("NumBd") != bd.not_found())
+	    _output << fmt8("%s") % "Number of BDs" % tile.second.get<std::string>("buffer-descriptors.NumBd");
+	  boost::property_tree::ptree empty_pt;
+	  for (const auto& node : bd.get_child("bds", empty_pt)) {
+	    _output << fmt12("%s") % "BD number" % node.second.get<std::string>("name");
+	    _output << fmt12("0x%x") % "Address A" % node.second.get<uint64_t>("AddressA");
+	    _output << fmt12("0x%x") % "Address B" % node.second.get<uint64_t>("AddressB");
+	    _output << fmt12("%s") % "Length" % node.second.get<std::string>("Length");
+	    _output << fmt12("%s") % "Lock Acquire Id A" % node.second.get<std::string>("LockAcqIdA");
+	    _output << fmt12("%s") % "Lock Acquire Value A" % node.second.get<std::string>("LockAcqValA");
+	    _output << fmt12("%s") % "Lock Release Value A" % node.second.get<std::string>("LockRelValA");
+	    _output << fmt12("%s") % "Lock Acquire Id B" % node.second.get<std::string>("LockAcqIdB");
+	    _output << fmt12("%s") % "Lock Acquire Value B" % node.second.get<std::string>("LockAcqValB");
+	    _output << fmt12("%s") % "Lock Release Value B" % node.second.get<std::string>("LockRelValB");
+	    _output << fmt12("%s") % "X Increment" % node.second.get<std::string>("XIncrement");
+	    _output << fmt12("%s") % "X Wrap" % node.second.get<std::string>("XWrap");
+	    _output << fmt12("0x%x") % "X Offset" % node.second.get<uint16_t>("XOffset");
+	    _output << fmt12("%s") % "Y Increment" % node.second.get<std::string>("YIncrement");
+	    _output << fmt12("%s") % "Y Wrap" % node.second.get<std::string>("YWrap");
+	    _output << fmt12("0x%x") % "Y Offset" % node.second.get<uint16_t>("YOffset");
+	    _output << fmt12("%s") % "D0 Stepsize" % node.second.get<std::string>("D0Stepsize");
+	    _output << fmt12("%s") % "D0 Wrap" % node.second.get<std::string>("D0Wrap");
+	    _output << fmt12("%s") % "D1 Stepsize" % node.second.get<std::string>("D1Stepsize");
+	    _output << fmt12("%s") % "D1 Wrap" % node.second.get<std::string>("D1Wrap");
+	    _output << fmt12("%s") % "D2 Stepsize" % node.second.get<std::string>("D2Stepsize");
+	    _output << fmt12("%s") % "D2 Wrap" % node.second.get<std::string>("D2Wrap");
+	    _output << fmt12("%s") % "D3 Stepsize" % node.second.get<std::string>("D3Stepsize");
+	    _output << std::endl;
+	    }
+        }
+    }
+
+    const boost::property_tree::ptree& pl_kernel = graph.get_child("pl_kernel");
       if (!pl_kernel.empty()) {
         _output << boost::format("    %s\n") % "Pl Kernel Instances in Graph:";
         for (auto& node : graph.get_child("pl_kernel"))

--- a/src/runtime_src/core/tools/common/ReportAieMem.cpp
+++ b/src/runtime_src/core/tools/common/ReportAieMem.cpp
@@ -149,6 +149,40 @@ writeReport(const xrt_core::device* /*_pDevice*/,
       }
       _output << std::endl;
     }
+    
+    if (tile.second.find("buffer-descriptors") != tile.second.not_found()) {
+      _output << boost::format("    %s:\n") % "Buffer Descriptor ";
+      boost::property_tree::ptree bd = tile.second.get_child("buffer-descriptors");
+      if (bd.find("NumBd") != bd.not_found())
+        _output << fmt8("%s") % "Number of BDs" % tile.second.get<std::string>("buffer-descriptors.NumBd");
+      boost::property_tree::ptree empty_pt;
+      for (const auto& node : bd.get_child("bds", empty_pt)) {
+        _output << fmt12("%s") % "BD number" % node.second.get<std::string>("name");
+        _output << fmt12("0x%x") % "Address A" % node.second.get<uint64_t>("AddressA");
+        _output << fmt12("0x%x") % "Address B" % node.second.get<uint64_t>("AddressB");
+        _output << fmt12("%s") % "Length" % node.second.get<std::string>("Length");
+        _output << fmt12("%s") % "Lock Acquire Id A" % node.second.get<std::string>("LockAcqIdA");
+        _output << fmt12("%s") % "Lock Acquire Value A" % node.second.get<std::string>("LockAcqValA");
+        _output << fmt12("%s") % "Lock Release Value A" % node.second.get<std::string>("LockRelValA");
+        _output << fmt12("%s") % "Lock Acquire Id B" % node.second.get<std::string>("LockAcqIdB");
+        _output << fmt12("%s") % "Lock Acquire Value B" % node.second.get<std::string>("LockAcqValB");
+        _output << fmt12("%s") % "Lock Release Value B" % node.second.get<std::string>("LockRelValB");
+        _output << fmt12("%s") % "X Increment" % node.second.get<std::string>("XIncrement");
+        _output << fmt12("%s") % "X Wrap" % node.second.get<std::string>("XWrap");
+        _output << fmt12("0x%x") % "X Offset" % node.second.get<uint16_t>("XOffset");
+        _output << fmt12("%s") % "Y Increment" % node.second.get<std::string>("YIncrement");
+        _output << fmt12("%s") % "Y Wrap" % node.second.get<std::string>("YWrap");
+        _output << fmt12("0x%x") % "Y Offset" % node.second.get<uint16_t>("YOffset");
+        _output << fmt12("%s") % "D0 Stepsize" % node.second.get<std::string>("D0Stepsize");
+        _output << fmt12("%s") % "D0 Wrap" % node.second.get<std::string>("D0Wrap");
+        _output << fmt12("%s") % "D1 Stepsize" % node.second.get<std::string>("D1Stepsize");
+        _output << fmt12("%s") % "D1 Wrap" % node.second.get<std::string>("D1Wrap");
+        _output << fmt12("%s") % "D2 Stepsize" % node.second.get<std::string>("D2Stepsize");
+        _output << fmt12("%s") % "D2 Wrap" % node.second.get<std::string>("D2Wrap");
+        _output << fmt12("%s") % "D3 Stepsize" % node.second.get<std::string>("D3Stepsize");
+        _output << std::endl;
+      }
+    }
   }
   _output << std::endl;
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/VITIS-6885
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
N/A
#### How problem was solved, alternative solutions (if any) and why they were rejected
Made user space changes to add all buffer descriptor information for core and mem tiles.
#### Risks (if any) associated the changes in the commit
N/A
#### What has been tested and how, request additional testing if necessary
Adding output of aie report for vck190 (here displaying only two bds info for one of the core tile)

Aie
  Aie_Metadata
  GRAPH[ 0] Name      : clipgraph
            Status    : unknown
    SNo.  Core [C:R]          Iteration_Memory [C:R]        Iteration_Memory_Addresses    
    [ 0]   24:0                24:1                          12100                         
    [ 1]   25:0                24:0                          7012                          

Core [ 0]
    Column                : 24
    Row                   : 0
    Core:
        Status                : enabled, north_lock_stall
        Program Counter       : 0x00000282
        Link Register         : 0x000000b0
        Stack Pointer         : 0x00033000
    DMA:
        MM2S:
            Channel:
                Id                    : 0
                Channel Status        : stalled_on_requesting_lock
                Queue Size            : 0
                Queue Status          : okay
                Current BD            : 0

                Id                    : 1
                Channel Status        : idle
                Queue Size            : 0
                Queue Status          : okay
                Current BD            : 0

        S2MM:
            Channel:
                Id                    : 0
                Channel Status        : idle
                Queue Size            : 0
                Queue Status          : okay
                Current BD            : 0

                Id                    : 1
                Channel Status        : idle
                Queue Size            : 0
                Queue Status          : okay
                Current BD            : 0

    Locks:
        0                     : acquired_for_write
        1                     : released_for_write
        2                     : released_for_write
        3                     : released_for_write
        4                     : released_for_write
        5                     : released_for_write
        6                     : released_for_write
        7                     : released_for_write
        8                     : released_for_write
        9                     : released_for_write
        10                    : released_for_write
        11                    : released_for_write
        12                    : released_for_write
        13                    : released_for_write
        14                    : released_for_write
        15                    : released_for_write

    Events:
        core                  : 1, 2, 5, 22, 26, 28, 29, 32, 35, 38, 39, 44
        memory                : 1, 20, 23, 35, 43, 44, 106, 113

    Buffer Descriptor :
        Number of BDs         : 16
            BD number             : bd0
            Address A             : 0x800
            Address B             : 0x0
            Length                : 255
            Lock Acquire Id A     : 0
            Lock Acquire Value A  : 1
            Lock Release Value A  : 0
            Lock Acquire Id B     : 0
            Lock Acquire Value B  : 0
            Lock Release Value B  : 0
            X Increment           : 0
            X Wrap                : 255
            X Offset              : 0x1
            Y Increment           : 255
            Y Wrap                : 0
            Y Offset              : 0x100
            D0 Stepsize           : 0
            D0 Wrap               : 0
            D1 Stepsize           : 0
            D1 Wrap               : 0
            D2 Stepsize           : 0
            D2 Wrap               : 0
            D3 Stepsize           : 0

            BD number             : bd1
            Address A             : 0x1100
            Address B             : 0x0
            Length                : 255
            Lock Acquire Id A     : 1
            Lock Acquire Value A  : 1
            Lock Release Value A  : 0
            Lock Acquire Id B     : 0
            Lock Acquire Value B  : 0
            Lock Release Value B  : 0
            X Increment           : 0
            X Wrap                : 255
            X Offset              : 0x1
            Y Increment           : 255
            Y Wrap                : 0
            Y Offset              : 0x100
            D0 Stepsize           : 0
            D0 Wrap               : 0
            D1 Stepsize           : 0
            D1 Wrap               : 0
            D2 Stepsize           : 0
            D2 Wrap               : 0
            D3 Stepsize           : 0

#### Documentation impact (if any)
