### PR TITLE
CR-1153791 RH9.0 system with U280 flashed xilinx_u280_xdma_201920_3 crash during stress test

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/cu.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/cu.c
@@ -529,8 +529,8 @@ static int cu_remove(struct platform_device *pdev)
 	if (!xcu)
 		return -EINVAL;
 
-	write_lock(&xcu->attr_rwlock);
 	(void) sysfs_remove_group(&pdev->dev.kobj, &cu_attrgroup);
+	write_lock(&xcu->attr_rwlock);
 	info = &xcu->base.info;
 	write_unlock(&xcu->attr_rwlock);
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/scu.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/scu.c
@@ -335,8 +335,8 @@ static int scu_remove(struct platform_device *pdev)
 	if (!xcu)
 		return -EINVAL;
 
-	write_lock(&xcu->attr_rwlock);
 	(void) sysfs_remove_group(&pdev->dev.kobj, &scu_attrgroup);
+	write_lock(&xcu->attr_rwlock);
 	info = &xcu->base.info;
 	write_unlock(&xcu->attr_rwlock);
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
 -- RH9.0 system with U280 flashed xilinx_u280_xdma_201920_3 crash during stress test
 -- Stress test is failing for all the platform
 -- During the stress test (Running several process at the same time, each process running xbutil validate, xbutil program, xbutil examine, etc, at the same time), the system crashed in the middle.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
 -- There are two issues:
1) BUG: scheduling while atomic: 
```
 __schedule_bug.cold+0x47/0x53
 __schedule+0x3fb/0x560
 schedule+0x43/0xb0
 rwsem_down_write_slowpath+0x257/0x4a0
 kernfs_remove_by_name_ns+0x24/0x90
 remove_files+0x2b/0x60
 sysfs_remove_group+0x38/0x80
 cu_remove+0x45/0x170 [xocl]
```
2) Cleanup for failure is not correct. 
```
Trying to vfree() nonexistent vm area (00000000b8a7d659)
WARNING: CPU: 2 PID: 312081 at mm/vmalloc.c:2605 __vunmap+0x6f/0x280
```

#### How problem was solved, alternative solutions (if any) and why they were rejected
-- sysfs_remove_group : remove from atomic context
-- Fixed the cleanup for failure case

#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
N/A
#### Documentation impact (if any)
N/A