### PR TITLE
Add API for updating the QoS of an existing hardware context

### DIFF
--- a/src/runtime_src/core/common/api/xrt_hw_context.cpp
+++ b/src/runtime_src/core/common/api/xrt_hw_context.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
 
 // This file implements XRT xclbin APIs as declared in
 // core/include/experimental/xrt_queue.h
@@ -48,7 +48,13 @@ public:
     , m_hdl{m_core_device->create_hw_context(xclbin_id, m_cfg_param, m_mode)}
   {}
 
-void
+  void
+  update_qos(const qos_type& qos)
+  {
+    m_hdl->update_qos(qos);
+  }
+
+  void
   set_exclusive()
   {
     m_mode = xrt::hw_context::access_mode::exclusive;
@@ -127,6 +133,13 @@ hw_context::
 hw_context(const xrt::device& device, const xrt::uuid& xclbin_id, access_mode mode)
   : detail::pimpl<hw_context_impl>(std::make_shared<hw_context_impl>(device.get_handle(), xclbin_id, mode))
 {}
+
+void
+hw_context::
+update_qos(const qos_type& qos)
+{
+  get_handle()->update_qos(qos);
+}
 
 xrt::device
 hw_context::

--- a/src/runtime_src/core/common/shim/hwctx_handle.h
+++ b/src/runtime_src/core/common/shim/hwctx_handle.h
@@ -4,7 +4,10 @@
 #define XRT_CORE_HWCTX_HANDLE_H
 
 #include "core/common/cuidx_type.h"
+#include "core/common/error.h"
 #include "core/common/shim/hwqueue_handle.h"
+
+#include "xrt/xrt_hw_context.h"
 
 #include <memory>
 
@@ -16,12 +19,22 @@ namespace xrt_core {
 // hardware context.
 class hwctx_handle
 {
+  using qos_type = xrt::hw_context::cfg_param_type;
+
 public:
   using slot_id = uint32_t;
 
   // Destruction must destroy the underlying hardware context
   virtual ~hwctx_handle()
   {}
+
+  // Update QoS of an existing hwardware context.  This is in response
+  // to experimental user facing xrt::hw_context::update_qos()
+  virtual void
+  update_qos(const qos_type&)
+  {
+    throw xrt_core::error(std::errc::not_supported, __func__);
+  }
 
   // The slotidx is used to encode buffer objects flags for legacy
   // shims and host applications that do not use context specific

--- a/src/runtime_src/core/include/xrt/xrt_hw_context.h
+++ b/src/runtime_src/core/include/xrt/xrt_hw_context.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
 #ifndef XRT_HW_CONTEXT_H_
 #define XRT_HW_CONTEXT_H_
 
@@ -112,6 +112,14 @@ public:
     : hw_context{device, xclbin_id, access_mode::shared}
   {}
   /// @endcond
+
+  ///@cond
+  // Undocument experimental API to change the QoS of a hardware context
+  // Subject to change or removal
+  XRT_API_EXPORT
+  void
+  update_qos(const qos_type& qos);
+  ///@endcond
 
   /**
    * get_device() - Device from which context was created


### PR DESCRIPTION
#### Problem solved by the commit
New API for dynamic update of QoS supported by a hardware context

#### How problem was solved, alternative solutions (if any) and why they were rejected
Dynamic QoS update is experimental and subject to removal.  The API is supported only on select platforms and by default throws an unsupported exception.    If requested QoS cannot be met, the API must throw an exception.

#### Risks (if any) associated the changes in the commit
No risk, unused API.

