### PR TITLE
CR-1155692 - Fix for loading xclbin with ps kernel attached

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
@@ -482,7 +482,7 @@ xocl_resolver(struct xocl_dev *xdev, struct axlf *axlf, xuid_t *xclbin_id,
 	uint32_t s_id = DEFAULT_PL_SLOT;
 	int ret = 0;
 
-	if (xocl_axlf_section_header(xdev, axlf, BITSTREAM_PARTIAL_PDI)) {
+	if (xocl_axlf_section_header(xdev, axlf, BITSTREAM) || xocl_axlf_section_header(xdev, axlf, BITSTREAM_PARTIAL_PDI)) {
 		s_id = DEFAULT_PL_SLOT;
 		if (xclbin_downloaded(xdev, xclbin_id, s_id)) {
 			if (qos & XOCL_AXLF_FORCE_PROGRAM) {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
@@ -2,7 +2,7 @@
  * A GEM style device manager for PCIe based OpenCL accelerators.
  *
  * Copyright (C) 2016-2021 Xilinx, Inc. All rights reserved.
- * Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Authors: Sonal Santan
  *
@@ -482,7 +482,7 @@ xocl_resolver(struct xocl_dev *xdev, struct axlf *axlf, xuid_t *xclbin_id,
 	uint32_t s_id = DEFAULT_PL_SLOT;
 	int ret = 0;
 
-	if (!xocl_axlf_section_header(xdev, axlf, SOFT_KERNEL)) {
+	if (xocl_axlf_section_header(xdev, axlf, BITSTREAM_PARTIAL_PDI)) {
 		s_id = DEFAULT_PL_SLOT;
 		if (xclbin_downloaded(xdev, xclbin_id, s_id)) {
 			if (qos & XOCL_AXLF_FORCE_PROGRAM) {


### PR DESCRIPTION
Any xclbin with partial PDI should be loaded to slot 0

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Multislot change loads any xclbin with PS kernels into slot other than slot 0.
Therefore xclbin with both PL and PS kernels will encounter issues

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1155692 fixed.  Introduced in PR7269 for multi slot support.
Discovered with testing of xclbin that include PS kernel

#### How problem was solved, alternative solutions (if any) and why they were rejected
Check for existence of partial PDI and load it to slot 0.

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Tested with vck5000

#### Documentation impact (if any)
None
