### PR TITLE
VITIS-8071 Update ReportMemory to use Hardware Contexts

### DIFF
--- a/src/runtime_src/core/common/info_memory.cpp
+++ b/src/runtime_src/core/common/info_memory.cpp
@@ -203,11 +203,11 @@ struct memory_info_collector
 
     try {
       std::string tag(reinterpret_cast<const char*>(mem.m_tag));
-      auto ecc_st = xrt_core::device_query<xq::mig_ecc_status>(device, xq::request::modifier::subdev, tag);
-      auto ce_cnt = xrt_core::device_query<xq::mig_ecc_ce_cnt>(device, xq::request::modifier::subdev, tag);
-      auto ue_cnt = xrt_core::device_query<xq::mig_ecc_ue_cnt>(device, xq::request::modifier::subdev, tag);
-      auto ce_ffa = xrt_core::device_query<xq::mig_ecc_ce_ffa>(device, xq::request::modifier::subdev, tag);
-      auto ue_ffa = xrt_core::device_query<xq::mig_ecc_ue_ffa>(device, xq::request::modifier::subdev, tag);
+      auto ecc_st = xrt_core::device_query<xq::mig_ecc_status>(device, xq::request::modifier::subdev, mem.m_tag);
+      auto ce_cnt = xrt_core::device_query<xq::mig_ecc_ce_cnt>(device, xq::request::modifier::subdev, mem.m_tag);
+      auto ue_cnt = xrt_core::device_query<xq::mig_ecc_ue_cnt>(device, xq::request::modifier::subdev, mem.m_tag);
+      auto ce_ffa = xrt_core::device_query<xq::mig_ecc_ce_ffa>(device, xq::request::modifier::subdev, mem.m_tag);
+      auto ue_ffa = xrt_core::device_query<xq::mig_ecc_ue_ffa>(device, xq::request::modifier::subdev, mem.m_tag);
 
       pt_mem.put("extended_info.ecc.status", ecc_status2str(ecc_st));
       pt_mem.put("extended_info.ecc.error.correctable.count", ce_cnt);

--- a/src/runtime_src/core/common/info_memory.cpp
+++ b/src/runtime_src/core/common/info_memory.cpp
@@ -203,11 +203,11 @@ struct memory_info_collector
 
     try {
       std::string tag(reinterpret_cast<const char*>(mem.m_tag));
-      auto ecc_st = xrt_core::device_query<xq::mig_ecc_status>(device, xq::request::modifier::subdev, mem.m_tag);
-      auto ce_cnt = xrt_core::device_query<xq::mig_ecc_ce_cnt>(device, xq::request::modifier::subdev, mem.m_tag);
-      auto ue_cnt = xrt_core::device_query<xq::mig_ecc_ue_cnt>(device, xq::request::modifier::subdev, mem.m_tag);
-      auto ce_ffa = xrt_core::device_query<xq::mig_ecc_ce_ffa>(device, xq::request::modifier::subdev, mem.m_tag);
-      auto ue_ffa = xrt_core::device_query<xq::mig_ecc_ue_ffa>(device, xq::request::modifier::subdev, mem.m_tag);
+      auto ecc_st = xrt_core::device_query<xq::mig_ecc_status>(device, xq::request::modifier::subdev, tag);
+      auto ce_cnt = xrt_core::device_query<xq::mig_ecc_ce_cnt>(device, xq::request::modifier::subdev, tag);
+      auto ue_cnt = xrt_core::device_query<xq::mig_ecc_ue_cnt>(device, xq::request::modifier::subdev, tag);
+      auto ce_ffa = xrt_core::device_query<xq::mig_ecc_ce_ffa>(device, xq::request::modifier::subdev, tag);
+      auto ue_ffa = xrt_core::device_query<xq::mig_ecc_ue_ffa>(device, xq::request::modifier::subdev, tag);
 
       pt_mem.put("extended_info.ecc.status", ecc_status2str(ecc_st));
       pt_mem.put("extended_info.ecc.error.correctable.count", ce_cnt);

--- a/src/runtime_src/core/common/info_memory.cpp
+++ b/src/runtime_src/core/common/info_memory.cpp
@@ -88,25 +88,13 @@ struct memory_info_collector
 {
   const xrt_core::device* device;          // device to query for info
 
-  const std::vector<char> mem_topo_raw;    // xclbin raw mem topology
   const std::vector<char> grp_topo_raw;    // xclbin raw grp topology
   std::vector<char> mem_temp_raw;    // xclbin temperator raw data
 
-  const mem_topology* mem_topo = nullptr;  // xclbin mem topology from device
+  const std::vector<xrt_core::query::mem_topology::data_type> mem_topo;  // xclbin mem topology from device
   const mem_topology* grp_topo = nullptr;  // xclbin group topology from device
   const std::vector<std::string> mem_stat; // raw memory stat from device
   const uint32_t* mem_temp = nullptr;      // temperature stat from device
-
-  // Get topology index of a mem_data element
-  static decltype(mem_topology::m_count)
-  get_mem_data_index(const mem_topology* mt, const mem_data* mem)
-  {
-    auto idx = std::distance(mt->m_mem_data, mem);
-    if (idx >= 0 && idx < mt->m_count)
-      return static_cast<decltype(mem_topology::m_count)>(idx);
-
-    throw xrt_core::internal_error("add_temp_mem_info: invalid mem_data entry");
-  }
 
   // Add bytes transferred by each PCIe channel to tree
   void
@@ -150,20 +138,20 @@ struct memory_info_collector
   // Append info from a mem topology streaming entry
   // Pre-cond: mem is a streaming entry
   void
-  add_stream_info(const mem_data* mem, ptree_type& pt_stream_array)
+  add_stream_info(const xrt_core::query::mem_topology::data_type& mem, ptree_type& pt_stream_array)
   {
     ptree_type pt_stream;
 
     try {
-      pt_stream.put("tag", mem->m_tag);
+      pt_stream.put("tag", mem.m_tag);
 
       // dma_stream sysfs entry name depends on write or read stream
       // which is indicated by trailing 'w' or 'r' in tag name
-      std::string lname {reinterpret_cast<const char*>(mem->m_tag)};
+      std::string lname {reinterpret_cast<const char*>(mem.m_tag)};
       if (lname.back() == 'w')
-        lname = "route" + std::to_string(mem->route_id) + "/stat";
+        lname = "route" + std::to_string(mem.route_id) + "/stat";
       else if (lname.back() == 'r')
-        lname = "flow" + std::to_string(mem->flow_id) + "/stat";
+        lname = "flow" + std::to_string(mem.flow_id) + "/stat";
 
       // list of "???" strings presenting what?
       auto stream_stat = xrt_core::device_query<xq::dma_stream>(device, xq::request::modifier::entry, lname);
@@ -198,10 +186,9 @@ struct memory_info_collector
   {
     ptree_type pt_stream_array;
 
-    for (int i = 0; i < mem_topo->m_count; ++i) {
-      const auto& mem = mem_topo->m_mem_data[i];
+    for (const auto& mem : mem_topo) {
       if (mem.m_type == MEM_STREAMING || mem.m_type == MEM_STREAMING_CONNECTION)
-        add_stream_info(&mem, pt_stream_array);
+        add_stream_info(mem, pt_stream_array);
     }
 
     pt.add_child("board.memory.data_streams", pt_stream_array);
@@ -209,13 +196,13 @@ struct memory_info_collector
 
   // Add ecc info for specified mem entry
   void
-  add_mem_ecc_info(const mem_data* mem, ptree_type& pt_mem)
+  add_mem_ecc_info(const xrt_core::query::mem_topology::data_type& mem, ptree_type& pt_mem)
   {
-    if (!mem->m_used)
+    if (!mem.m_used)
       return;
 
     try {
-      std::string tag(reinterpret_cast<const char*>(mem->m_tag));
+      std::string tag(reinterpret_cast<const char*>(mem.m_tag));
       auto ecc_st = xrt_core::device_query<xq::mig_ecc_status>(device, xq::request::modifier::subdev, tag);
       auto ce_cnt = xrt_core::device_query<xq::mig_ecc_ce_cnt>(device, xq::request::modifier::subdev, tag);
       auto ue_cnt = xrt_core::device_query<xq::mig_ecc_ue_cnt>(device, xq::request::modifier::subdev, tag);
@@ -238,22 +225,23 @@ struct memory_info_collector
 
   // Add general mem info for specified mem entry
   static void
-  add_mem_general_info(const mem_data* mem, ptree_type& pt_mem)
+  add_mem_general_info(const xrt_core::query::mem_topology::data_type& mem, ptree_type& pt_mem)
   {
-    pt_mem.put("type", memtype2str(mem->m_type));
-    pt_mem.put("tag", mem->m_tag);
-    pt_mem.put("enabled", mem->m_used ? true : false);
-    pt_mem.put("base_address", boost::format("0x%x") % mem->m_base_address);
-    pt_mem.put("range_bytes", boost::format("0x%x") % (mem->m_size * 1024)); // convert KB to bytes
+    pt_mem.put("xclbin_uuid", mem.xclbin_uuid);
+    pt_mem.put("hw_context_slot", boost::format("%u") % mem.hw_context_slot);
+    pt_mem.put("type", memtype2str(mem.m_type));
+    pt_mem.put("tag", mem.m_tag);
+    pt_mem.put("enabled", mem.m_used ? true : false);
+    pt_mem.put("base_address", boost::format("0x%x") % mem.m_base_address);
+    pt_mem.put("range_bytes", boost::format("0x%x") % (mem.m_size * 1024)); // convert KB to bytes
   }
 
   // Add mem usage info for specified mem entry.
   // This function is shared with group topology, hence need to
   // know where the mem entry is comining from
   void
-  add_mem_usage_info(const mem_topology* mtopo, const mem_data* mem, ptree_type& pt_mem)
+  add_mem_usage_info(const size_t idx, ptree_type& pt_mem)
   {
-    auto idx = get_mem_data_index(mtopo, mem);
     uint64_t memory_usage = 0, bo_count = 0;
     std::stringstream {mem_stat[idx]} >> memory_usage >> bo_count; // idx has been validated
     pt_mem.put("extended_info.usage.allocated_bytes", memory_usage);
@@ -262,10 +250,8 @@ struct memory_info_collector
 
   // Add mem temperature info for specified mem entry
   void
-  add_mem_temp_info(const mem_data* mem, ptree_type& pt_mem)
+  add_mem_temp_info(const size_t idx, ptree_type& pt_mem)
   {
-    auto idx = get_mem_data_index(mem_topo, mem);
-
     // temperature is guaranteed to match up with mem_topo entries
     // indexing is safe because idx is validated
     constexpr int invalid_sensor_value = 0;
@@ -275,14 +261,14 @@ struct memory_info_collector
 
   // Add mem info for specified mem data entry
   void
-  add_mem_info(const mem_data* mem, ptree_type& pt_mem_array)
+  add_mem_info(const size_t idx, const xrt_core::query::mem_topology::data_type& mem, ptree_type& pt_mem_array)
   {
     ptree_type pt_mem;
     add_mem_ecc_info(mem, pt_mem);
     add_mem_general_info(mem, pt_mem);
-    add_mem_usage_info(mem_topo, mem, pt_mem);
-    add_mem_temp_info(mem, pt_mem);
-    pt_mem_array.push_back(std::make_pair("",pt_mem));
+    add_mem_usage_info(idx, pt_mem);
+    add_mem_temp_info(idx, pt_mem);
+    pt_mem_array.push_back(std::make_pair("", pt_mem));
   }
 
   // Add mem info for all mem entries in mem_topology section
@@ -291,12 +277,12 @@ struct memory_info_collector
   {
     ptree_type pt_mem_array;
 
-    for (int i = 0; i < mem_topo->m_count; ++i) {
-      const auto& mem = mem_topo->m_mem_data[i];
+    for (size_t i = 0; i < mem_topo.size(); ++i) {
+      const auto& mem = mem_topo[i];
       if (mem.m_type == MEM_STREAMING || mem.m_type == MEM_STREAMING_CONNECTION)
         continue;
 
-      add_mem_info(&mem, pt_mem_array);
+      add_mem_info(i, mem, pt_mem_array);
     }
 
     pt.add_child("board.memory.memories", pt_mem_array );
@@ -307,8 +293,8 @@ struct memory_info_collector
   add_grp_info(const mem_data* mem, ptree_type& pt_grp_array)
   {
     ptree_type pt_grp;
-    add_mem_general_info(mem, pt_grp);
-    add_mem_usage_info(grp_topo, mem, pt_grp);
+    // add_mem_general_info(mem, pt_grp);
+    // add_mem_usage_info(grp_topo, mem, pt_grp);
     pt_grp_array.push_back(std::make_pair("",pt_grp));
   }
 
@@ -323,7 +309,7 @@ struct memory_info_collector
 
     // group_topology prepends all mem_topology entries so groups
     // are following at index mem_topo->m_count
-    for (int i = mem_topo->m_count; i < grp_topo->m_count; i++) {
+    for (int i = mem_topo.size(); i < grp_topo->m_count; i++) {
       const auto& mem = grp_topo->m_mem_data[i];
       add_grp_info(&mem, pt_grp_array);
     }
@@ -336,9 +322,8 @@ public:
   explicit
   memory_info_collector(const xrt_core::device* dev)
     : device(dev)
-    , mem_topo_raw(xrt_core::device_query<xq::mem_topology_raw>(device))
     , grp_topo_raw(xrt_core::device_query<xq::group_topology>(device))
-    , mem_topo(mem_topo_raw.empty() ? nullptr : reinterpret_cast<const mem_topology*>(mem_topo_raw.data()))
+    , mem_topo(xrt_core::device_query<xq::mem_topology>(device))
     , grp_topo(grp_topo_raw.empty() ? nullptr : reinterpret_cast<const mem_topology*>(grp_topo_raw.data()))
     , mem_stat(xrt_core::device_query<xq::memstat_raw>(device))
     , mem_temp(0)
@@ -351,11 +336,11 @@ public:
       //ignore if xmc is not present 
     }
     // info gathering functions indexes mem_stat by mem_toplogy entry index
-    if (mem_topo && mem_stat.size() < static_cast<size_t>(mem_topo->m_count))
+    if (!mem_topo.empty() && mem_stat.size() < mem_topo.size())
       throw xrt_core::internal_error("incorrect memstat_raw entries");
 
     // info gathering functions indexes mem_temp by mem_topology entry index
-    if (mem_topo && mem_temp && mem_temp_raw.size() < static_cast<size_t>(mem_topo->m_count))
+    if (!mem_topo.empty() && mem_temp && mem_temp_raw.size() < mem_topo.size())
       throw xrt_core::internal_error("incorrect temp_by_mem_topology entries");
 
     // info gathering functions indexes mem_stat by group_toplogy entry index
@@ -366,7 +351,7 @@ public:
   void
   collect(ptree_type& pt)
   {
-    if (!mem_topo)
+    if (mem_topo.empty())
       return;
 
     add_channel_info(pt);

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -728,7 +728,7 @@ struct mem_topology_raw : request
 
 struct mem_topology : request
 {
-  struct mem_data {
+  struct memory_data {
     std::string xclbin_uuid;
     uint32_t hw_context_slot;
     uint8_t m_type;          // enum corresponding to mem_type.
@@ -744,7 +744,7 @@ struct mem_topology : request
     unsigned char m_tag[16]; // DDR: BANK0,1,2,3, has to be null terminated; if streaming then stream0, 1 etc
   };
 
-  using data_type = struct mem_data;
+  using data_type = struct memory_data;
   using result_type = std::vector<data_type>;
   static const key_type key = key_type::mem_topology;
 

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -70,6 +70,7 @@ enum class key_type
   memstat,
   memstat_raw,
   temp_by_mem_topology,
+  mem_topology,
   mem_topology_raw,
   ip_layout_raw,
   debug_ip_layout_raw,
@@ -720,6 +721,32 @@ struct mem_topology_raw : request
 {
   using result_type = std::vector<char>;
   static const key_type key = key_type::mem_topology_raw;
+
+  virtual boost::any
+  get(const device*) const = 0;
+};
+
+struct mem_topology : request
+{
+  struct mem_data {
+    std::string xclbin_uuid;
+    uint32_t hw_context_slot;
+    uint8_t m_type;          // enum corresponding to mem_type.
+    uint8_t m_used;          // if 0 this bank is not present
+    union {
+        uint64_t m_size;     // if mem_type DDR, then size in KB;
+        uint64_t route_id;   // if streaming then "route_id"
+    };
+    union {
+        uint64_t m_base_address; // if DDR then the base address;
+        uint64_t flow_id;        // if streaming then "flow id"
+    };
+    unsigned char m_tag[16]; // DDR: BANK0,1,2,3, has to be null terminated; if streaming then stream0, 1 etc
+  };
+
+  using data_type = struct mem_data;
+  using result_type = std::vector<data_type>;
+  static const key_type key = key_type::mem_topology;
 
   virtual boost::any
   get(const device*) const = 0;

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -1042,13 +1042,14 @@ struct memory_topology
     const auto data = xrt_core::device_query<query::mem_topology_raw>(device);
     const auto mem_topo = reinterpret_cast<const struct mem_topology*>(data.data());
     const auto xclbin_uuid = xrt_core::device_query<query::xclbin_uuid>(device);
-    result_type topology(mem_topo->m_count);
+    result_type topology;
     for (int32_t index = 0; index < mem_topo->m_count; index++) {
       data_type mem_data;
       mem_data.xclbin_uuid = xclbin_uuid;
       mem_data.hw_context_slot = 0;
       mem_data.m_type = mem_topo->m_mem_data[index].m_type;
       mem_data.m_used = mem_topo->m_mem_data[index].m_used;
+      memcpy(mem_data.m_tag, mem_topo->m_mem_data[index].m_tag, sizeof(mem_topo->m_mem_data[index].m_tag));
       // The following two entries are unions
       // Within the union using any name would work. So use the first!
       mem_data.m_size = mem_topo->m_mem_data[index].m_size;

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -17,6 +17,7 @@
 
 #include "pcidev.h"
 #include "xrt.h"
+#include "xclbin.h"
 
 #include <array>
 #include <fstream>
@@ -1030,6 +1031,34 @@ struct sysfs_fcn<std::vector<VectorValueType>>
   }
 };
 
+struct memory_topology
+{
+  using data_type = query::mem_topology::data_type;
+  using result_type = query::mem_topology::result_type;
+
+  static result_type
+  get(const xrt_core::device* device, key_type)
+  {
+    const auto data = xrt_core::device_query<query::mem_topology_raw>(device);
+    const auto mem_topo = reinterpret_cast<const struct mem_topology*>(data.data());
+    const auto xclbin_uuid = xrt_core::device_query<query::xclbin_uuid>(device);
+    result_type topology(mem_topo->m_count);
+    for (int32_t index = 0; index < mem_topo->m_count; index++) {
+      data_type mem_data;
+      mem_data.xclbin_uuid = xclbin_uuid;
+      mem_data.hw_context_slot = 0;
+      mem_data.m_type = mem_topo->m_mem_data[index].m_type;
+      mem_data.m_used = mem_topo->m_mem_data[index].m_used;
+      // The following two entries are unions
+      // Within the union using any name would work. So use the first!
+      mem_data.m_size = mem_topo->m_mem_data[index].m_size;
+      mem_data.m_base_address = mem_topo->m_mem_data[index].m_base_address;
+      topology.push_back(mem_data);
+    }
+    return topology;
+  }
+};
+
 /* Accelerator Deadlock Detector status
  * In PCIe Linux, access the sysfs file for Accelerator Deadlock Detector to retrieve the deadlock status
  */
@@ -1189,6 +1218,7 @@ initialize_query_table()
   emplace_sysfs_getput<query::ic_load_flash_address>           ("icap_controller", "load_flash_addr");
   emplace_sysfs_get<query::memstat>                            ("", "memstat");
   emplace_sysfs_get<query::memstat_raw>                        ("", "memstat_raw");
+  emplace_func0_request<query::mem_topology,                   memory_topology>();
   emplace_sysfs_get<query::mem_topology_raw>                   ("icap", "mem_topology");
   emplace_sysfs_get<query::dma_stream>                         ("dma", "");
   emplace_sysfs_get<query::group_topology>                     ("icap", "group_topology");


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/VITIS-8071
The current memory report does not correlate to how hardware contexts use memory.

If you have any opinions on the report output please let me know. I am happy to make any changes.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
For the hardware context concept, memory is tied into a particular hardware context slot. For Alveo devices this was not an issue. However, for AIE devices with multiple hardware context slots we need a way to store and logically display these memory banks to the user.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Assign to each memory bank the xclbin uuid and hw context slot from which it came. Also updated how ReportMemory displays memory banks.

#### Risks (if any) associated the changes in the commit
The output json has new fields added to each memory item. This will not interfere with any previous parsing scripts.

#### What has been tested and how, request additional testing if necessary
Ubuntu 20.04 U50C
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ xbutil examine -d 04:00 -r memory
WARNING: Unexpected xocl version (2.14.0) was found. Expected 2.15.0, to match XRT tools.

-------------------------------------------------
[0000:04:00.1] : xilinx_u55c_gen3x16_xdma_base_3
-------------------------------------------------

  Memory Topology
    HW Context Slot: 0
      Xclbin UUID: e106e953-cf90-4024-e075-282d1a7d820b
      Index  Tag       Type      Temp(C)  Size    Base Address
      ----------------------------------------------------------
      0      HBM[0]    MEM_HBM   37       512 MB  0x0
      1      HBM[1]    MEM_DRAM  37       512 MB  0x20000000
      2      HBM[2]    MEM_DRAM  37       512 MB  0x40000000
      3      HBM[3]    MEM_DRAM  37       512 MB  0x60000000
      4      HBM[4]    MEM_DRAM  37       512 MB  0x80000000
      5      HBM[5]    MEM_DRAM  37       512 MB  0xa0000000
      6      HBM[6]    MEM_DRAM  37       512 MB  0xc0000000
      7      HBM[7]    MEM_DRAM  37       512 MB  0xe0000000
      8      HBM[8]    MEM_DRAM  37       512 MB  0x100000000
      9      HBM[9]    MEM_DRAM  37       512 MB  0x120000000
      10     HBM[10]   MEM_DRAM  37       512 MB  0x140000000
      11     HBM[11]   MEM_DRAM  37       512 MB  0x160000000
      12     HBM[12]   MEM_DRAM  37       512 MB  0x180000000
      13     HBM[13]   MEM_DRAM  37       512 MB  0x1a0000000
      14     HBM[14]   MEM_DRAM  37       512 MB  0x1c0000000
      15     HBM[15]   MEM_DRAM  37       512 MB  0x1e0000000
      16     HBM[16]   MEM_DRAM  37       512 MB  0x200000000
      17     HBM[17]   MEM_DRAM  37       512 MB  0x220000000
      18     HBM[18]   MEM_DRAM  37       512 MB  0x240000000
      19     HBM[19]   MEM_DRAM  37       512 MB  0x260000000
      20     HBM[20]   MEM_DRAM  37       512 MB  0x280000000
      21     HBM[21]   MEM_DRAM  37       512 MB  0x2a0000000
      22     HBM[22]   MEM_DRAM  37       512 MB  0x2c0000000
      23     HBM[23]   MEM_DRAM  37       512 MB  0x2e0000000
      24     HBM[24]   MEM_DRAM  37       512 MB  0x300000000
      25     HBM[25]   MEM_DRAM  37       512 MB  0x320000000
      26     HBM[26]   MEM_DRAM  37       512 MB  0x340000000
      27     HBM[27]   MEM_DRAM  37       512 MB  0x360000000
      28     HBM[28]   MEM_DRAM  37       512 MB  0x380000000
      29     HBM[29]   MEM_DRAM  37       512 MB  0x3a0000000
      30     HBM[30]   MEM_DRAM  37       512 MB  0x3c0000000
      31     HBM[31]   MEM_DRAM  37       512 MB  0x3e0000000
      32     PLRAM[0]  MEM_DRAM  N/A      0 Byte  0x0
      33     PLRAM[1]  MEM_DRAM  N/A      0 Byte  0x0
      34     PLRAM[2]  MEM_DRAM  N/A      0 Byte  0x0
      35     PLRAM[3]  MEM_DRAM  N/A      0 Byte  0x0
      36     PLRAM[4]  MEM_DRAM  N/A      0 Byte  0x0
      37     PLRAM[5]  MEM_DRAM  N/A      0 Byte  0x0
      38     HOST[0]   MEM_DRAM  N/A      0 Byte  0x0

  DMA Transfer Metrics
    Chan[ 0].h2c:  0 Byte
    Chan[ 0].c2h:  192 Byte
    Chan[ 1].h2c:  0 Byte
    Chan[ 1].c2h:  0 Byte
```

#### Documentation impact (if any)
We may need to add  something about what a hardware context is? Not sure if we have any details in the documentation about it.
