### PR TITLE
CR-1156523: only set defaults for current tile type

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_trace_new/aie_trace_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace_new/aie_trace_metadata.cpp
@@ -687,7 +687,7 @@ namespace xdp {
       // Grab channel numbers (if specified; MEM tiles only)
       if (metrics[i].size() == 4) {
         try {
-          for (auto &e : allValidTiles) {
+          for (auto &e : tiles) {
             configChannel0[e] = std::stoi(metrics[i][2]);
             configChannel1[e] = std::stoi(metrics[i][3]);
           }
@@ -845,6 +845,9 @@ namespace xdp {
     std::vector<tile_type> offTiles;
 
     for (auto &tileMetric : configMetrics) {
+      // Ignore other types of tiles
+      if (allValidTiles.find(tileMetric.first) == allValidTiles.end())
+        continue;
       // Save list of "off" tiles
       if (tileMetric.second.empty() || (tileMetric.second.compare("off") == 0)) {
         offTiles.push_back(tileMetric.first);


### PR DESCRIPTION
**Problem solved by the commit**
MEM tile settings were corrupting settings for AIE tiles when both were set

**How problem was solved, alternative solutions (if any) and why they were rejected**
Only operate on currently valid tiles

**Risks (if any) associated the changes in the commit**
None

**What has been tested and how, request additional testing if necessary**
designs on vek280