### PR TITLE
VITIS-8049 Refactor SubCmdExamine

### DIFF
--- a/src/runtime_src/core/tools/common/SubCmdExamineInternal.cpp
+++ b/src/runtime_src/core/tools/common/SubCmdExamineInternal.cpp
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2020-2022 Xilinx, Inc
+// Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+
+// ------ I N C L U D E   F I L E S -------------------------------------------
+// Local - Include Files
+#include "SubCmdExamineInternal.h"
+#include "core/common/error.h"
+
+// Utilities
+#include "tools/common/XBHelpMenusCore.h"
+#include "tools/common/XBUtilitiesCore.h"
+#include "tools/common/XBUtilities.h"
+#include "tools/common/XBHelpMenus.h"
+namespace XBU = XBUtilities;
+
+// 3rd Party Library - Include Files
+#include <boost/filesystem.hpp>
+#include <boost/format.hpp>
+#include <boost/program_options.hpp>
+#include <boost/algorithm/string.hpp>
+namespace po = boost::program_options;
+
+// System - Include Files
+#include <iostream>
+#include <fstream>
+#include <regex>
+
+// Common reports here. Add unique reports in constructor below.
+static ReportCollection fullReportCollection = {};
+
+// ----- C L A S S   M E T H O D S -------------------------------------------
+SubCmdExamineInternal::SubCmdExamineInternal(bool _isHidden, bool _isDepricated, bool _isPreliminary, bool _isUserDomain)
+    : SubCmd("examine", 
+             _isUserDomain ? "Status of the system and device" : "Returns detail information for the specified device.")
+    , m_device("")
+    , m_reportNames()
+    , m_elementsFilter()
+    , m_format("")
+    , m_output("")
+    , m_help(false)
+    , m_isUserDomain(_isUserDomain)
+{
+  const std::string longDescription = "This command will 'examine' the state of the system/device and will"
+                                      " generate a report of interest in a text or JSON format.";
+  setLongDescription(longDescription);
+  setExampleSyntax("");
+  setIsHidden(_isHidden);
+  setIsDeprecated(_isDepricated);
+  setIsPreliminary(_isPreliminary);
+  if (m_isUserDomain)
+    setIsDefaultDevValid(false);
+
+  // -- Build up the report & format options
+  fullReportCollection.insert(fullReportCollection.end(), SubCmdExamineInternal::uniqueReportCollection.begin(), SubCmdExamineInternal::uniqueReportCollection.end());
+  static const std::string reportOptionValues = XBU::create_suboption_list_string(fullReportCollection, true /*add 'all' option*/);
+  static const std::string formatOptionValues = XBU::create_suboption_list_string(Report::getSchemaDescriptionVector());
+
+  m_commonOptions.add_options()
+    ("device,d", boost::program_options::value<decltype(m_device)>(&m_device), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest")
+    ("report,r", boost::program_options::value<decltype(m_reportNames)>(&m_reportNames)->multitoken(), (std::string("The type of report to be produced. Reports currently available are:\n") + reportOptionValues).c_str() )
+    ("format,f", boost::program_options::value<decltype(m_format)>(&m_format), (std::string("Report output format. Valid values are:\n") + formatOptionValues).c_str() )
+    ("output,o", boost::program_options::value<decltype(m_output)>(&m_output), "Direct the output to the given file")
+    ("help", boost::program_options::bool_switch(&m_help), "Help to use this sub-command")
+  ;
+  
+  if (m_isUserDomain)
+    m_hiddenOptions.add_options()
+      ("element,e", boost::program_options::value<decltype(m_elementsFilter)>(&m_elementsFilter)->multitoken(), "Filters individual elements(s) from the report. Format: '/<key>/<key>/...'")
+    ;
+}
+
+void
+SubCmdExamineInternal::execute(const SubCmdOptions& _options) const
+{
+  XBU::verbose("SubCommand: examine");
+
+  // Parse sub-command ...
+  po::variables_map vm;
+  process_arguments(vm, _options);
+
+  // Check to see if help was requested
+  if (m_help) {
+    printHelp();
+    return;
+  }
+  
+  // Determine report level
+  std::vector<std::string> reportsToRun(m_reportNames);
+  if (reportsToRun.empty()) {
+    if (m_device.empty())
+      reportsToRun.push_back("host");
+    else {
+      reportsToRun.push_back("platform");
+      if (m_isUserDomain)
+        reportsToRun.push_back("dynamic-regions");
+    }
+  }
+
+  // DRC check
+  // When json is specified, make sure an accompanying output file is also specified
+  if (!m_format.empty() && m_output.empty()) {
+    std::cerr << "ERROR: Please specify an output file to redirect the json to" << std::endl;
+    throw xrt_core::error(std::errc::operation_canceled);
+  }
+
+  const auto validated_format = m_format.empty() ? "json" : m_format;
+
+  // DRC: Examine the output format
+  Report::SchemaVersion schemaVersion = Report::getSchemaDescription(validated_format).schemaVersion;
+  if (schemaVersion == Report::SchemaVersion::unknown) {
+    std::cerr << boost::format("ERROR: Unsupported --format option value '%s'") % validated_format << std::endl
+              << boost::format("       Supported values can be found in --format's help section below.") << std::endl;
+    printHelp();
+    throw xrt_core::error(std::errc::operation_canceled);
+  }
+
+  // DRC: Output file
+  if (!m_output.empty() && boost::filesystem::exists(m_output) && !XBU::getForce()) {
+    std::cerr << boost::format("ERROR: The output file '%s' already exists.  Please either remove it or execute this command again with the '--force' option to overwrite it.") % m_output << std::endl;
+    throw xrt_core::error(std::errc::operation_canceled);
+  }
+
+  // -- Process the options --------------------------------------------
+  ReportCollection reportsToProcess;            // Reports of interest
+
+  // Collect the reports to be processed
+  XBU::collect_and_validate_reports(fullReportCollection, reportsToRun, reportsToProcess);
+
+  // Find device of interest
+  std::shared_ptr<xrt_core::device> device;
+  
+  try {
+    if(reportsToProcess.size() > 1 || reportsToRun.front().compare("host") != 0)
+      device = XBU::get_device(boost::algorithm::to_lower_copy(m_device), m_isUserDomain /*inUserDomain*/);
+  } catch (const std::runtime_error& e) {
+    // Catch only the exceptions that we have generated earlier
+    std::cerr << boost::format("ERROR: %s\n") % e.what();
+    throw xrt_core::error(std::errc::operation_canceled);
+  }
+
+  bool is_report_output_valid = true;
+  // DRC check on devices and reports
+  if (!device) {
+    std::vector<std::string> missingReports;
+    for (const auto & report : reportsToProcess) {
+      if (report->isDeviceRequired())
+        missingReports.push_back(report->getReportName());
+    }
+
+    if (!missingReports.empty()) {
+      // Exception is thrown at the end of this function to allow for report writing
+      is_report_output_valid = false;
+      // Print error message
+      std::cerr << boost::format("Error: The following report(s) require specifying a device using the --device option:\n");
+      for (const auto & report : missingReports)
+        std::cout << boost::format("         - %s\n") % report;
+
+      // Print available devices
+      const auto dev_pt = XBU::get_available_devices(true);
+      if(dev_pt.empty())
+        std::cout << "0 devices found" << std::endl;
+      else
+        std::cout << "Device list" << std::endl;
+
+      for(auto& kd : dev_pt) {
+        const boost::property_tree::ptree& dev = kd.second;
+        const std::string note = dev.get<bool>("is_ready") ? "" : "NOTE: Device not ready for use";
+        std::cout << boost::format("  [%s] : %s %s\n") % dev.get<std::string>("bdf") % dev.get<std::string>("vbnv") % note;
+      }
+    }
+  }
+
+  // Create the report
+  std::ostringstream oSchemaOutput;
+  try {
+    XBU::produce_reports(device, reportsToProcess, schemaVersion, m_elementsFilter, std::cout, oSchemaOutput);
+  } catch (const std::exception&) {
+    // Exception is thrown at the end of this function to allow for report writing
+    is_report_output_valid = false;
+  }
+
+  // -- Write output file ----------------------------------------------
+  if (!m_output.empty()) {
+    std::ofstream fOutput;
+    fOutput.open(m_output, std::ios::out | std::ios::binary);
+    if (!fOutput.is_open()) {
+      std::cerr << boost::format("Unable to open the file '%s' for writing.") % m_output << std::endl;
+      throw xrt_core::error(std::errc::operation_canceled);
+    }
+
+    fOutput << oSchemaOutput.str();
+
+    std::cout << boost::format("Successfully wrote the %s file: %s") % validated_format % m_output << std::endl;
+  }
+
+  if (!is_report_output_valid)
+    throw xrt_core::error(std::errc::operation_canceled);
+}

--- a/src/runtime_src/core/tools/common/SubCmdExamineInternal.h
+++ b/src/runtime_src/core/tools/common/SubCmdExamineInternal.h
@@ -14,15 +14,21 @@
  * under the License.
  */
 
-#ifndef __SubCmdExamine_h_
-#define __SubCmdExamine_h_
+#ifndef __SubCmdExamineInternal_h_
+#define __SubCmdExamineInternal_h_
 
+#include "tools/common/Report.h"
 #include "tools/common/SubCmd.h"
-#include "tools/common/SubCmdExamineInternal.h"
 
-class SubCmdExamine : public SubCmdExamineInternal {
+class SubCmdExamineInternal : public SubCmd {
  public:
-  SubCmdExamine(bool _isHidden, bool _isDepricated, bool _isPreliminary);
+  virtual void execute(const SubCmdOptions &_options) const;
+
+ public:
+  SubCmdExamineInternal(bool _isHidden, bool _isDepricated, bool _isPreliminary, bool _isUserDomain);
+
+ public:
+  static ReportCollection uniqueReportCollection;
 
  private:
   std::string               m_device;
@@ -31,6 +37,7 @@ class SubCmdExamine : public SubCmdExamineInternal {
   std::string               m_format;
   std::string               m_output;
   bool                      m_help;
+  bool                      m_isUserDomain;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbmgmt2/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbmgmt2/CMakeLists.txt
@@ -9,6 +9,7 @@ file(GLOB XBMGMT_V2_BASE_FILES
   "../common/XBUtilitiesCore.cpp"
   "../common/XBUtilities.cpp"
   "../common/SubCmd.cpp"
+  "../common/SubCmdExamineInternal.cpp"
   "../common/XBHelpMenusCore.cpp"
   "../common/XBHelpMenus.cpp"
   "../common/OptionOptions.cpp"

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdExamine.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdExamine.cpp
@@ -6,23 +6,7 @@
 // Local - Include Files
 #include "SubCmdExamine.h"
 #include "core/common/error.h"
-
-// Utilities
-#include "tools/common/XBHelpMenusCore.h"
-#include "tools/common/XBUtilitiesCore.h"
-#include "tools/common/XBUtilities.h"
-#include "tools/common/XBHelpMenus.h"
-namespace XBU = XBUtilities;
-
-// 3rd Party Library - Include Files
-#include <boost/filesystem.hpp>
-#include <boost/format.hpp>
-#include <boost/program_options.hpp>
-namespace po = boost::program_options;
-
-// System - Include Files
-#include <iostream>
-#include <fstream>
+#include "tools/common/SubCmdExamineInternal.h"
 
 // ---- Reports ------
 #include "tools/common/Report.h"
@@ -35,7 +19,7 @@ namespace po = boost::program_options;
 #include "ReportPlatform.h"
 
 // Note: Please insert the reports in the order to be displayed (current alphabetical)
-static const ReportCollection fullReportCollection = {
+ReportCollection SubCmdExamineInternal::uniqueReportCollection = {
   // Common reports
     std::make_shared<ReportHost>(false),
     std::make_shared<ReportPlatform>(),
@@ -49,14 +33,8 @@ static const ReportCollection fullReportCollection = {
   #endif
 };
 
-// ----- C L A S S   M E T H O D S -------------------------------------------
-// -- Build up the report & format options
-static const std::string reportOptionValues = XBU::create_suboption_list_string(fullReportCollection, true /*add 'all' option*/);
-static const std::string formatOptionValues = XBU::create_suboption_list_string(Report::getSchemaDescriptionVector());
-
 SubCmdExamine::SubCmdExamine(bool _isHidden, bool _isDepricated, bool _isPreliminary)
-    : SubCmd("examine", 
-             "Returns detail information for the specified device.")
+    : SubCmdExamineInternal(_isHidden, _isDepricated, _isPreliminary, false /*Not isUserDomain*/)
     , m_device("")
     , m_reportNames()
     , m_elementsFilter()
@@ -64,133 +42,5 @@ SubCmdExamine::SubCmdExamine(bool _isHidden, bool _isDepricated, bool _isPrelimi
     , m_output("")
     , m_help(false)
 {
-  const std::string longDescription = "This command will 'examine' the state of the system/device and will"
-                                      " generate a report of interest in a text or JSON format.";
-  setLongDescription(longDescription);
-  setExampleSyntax("");
-  setIsHidden(_isHidden);
-  setIsDeprecated(_isDepricated);
-  setIsPreliminary(_isPreliminary);
-
-  m_commonOptions.add_options()
-    ("device,d", boost::program_options::value<decltype(m_device)>(&m_device), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest")
-    ("report,r", boost::program_options::value<decltype(m_reportNames)>(&m_reportNames)->multitoken(), (std::string("The type of report to be produced. Reports currently available are:\n") + reportOptionValues).c_str() )
-    ("format,f", boost::program_options::value<decltype(m_format)>(&m_format), (std::string("Report output format. Valid values are:\n") + formatOptionValues).c_str() )
-    ("output,o", boost::program_options::value<decltype(m_output)>(&m_output), "Direct the output to the given file")
-    ("help", boost::program_options::bool_switch(&m_help), "Help to use this sub-command")
-  ;
-}
-
-void
-SubCmdExamine::execute(const SubCmdOptions& _options) const
-{
-  XBU::verbose("SubCommand: examine");
-
-  // Parse sub-command ...
-  po::variables_map vm;
-  process_arguments(vm, _options);
-
-  // Check to see if help was requested 
-  if (m_help) {
-    printHelp();
-    return;
-  }
-
-  // Determine report level
-  std::vector<std::string> reportsToRun(m_reportNames);
-  if (reportsToRun.empty()) {
-    if (m_device.empty())
-      reportsToRun.push_back("host");
-    else
-      reportsToRun.push_back("platform");
-  }
-
-  // -- Process the options --------------------------------------------
-  ReportCollection reportsToProcess;            // Reports of interest
-
-  // Collect the reports to be processed
-  XBU::collect_and_validate_reports(fullReportCollection, reportsToRun, reportsToProcess);
-
-  // when json is specified, make sure an accompanying output file is also specified
-  if (!m_format.empty() && m_output.empty())
-    throw xrt_core::error("Please specify an output file to redirect the json to");
-
-  const auto validated_format = m_format.empty() ? "json" : m_format;
-
-  // Output Format
-  Report::SchemaVersion schemaVersion = Report::getSchemaDescription(validated_format).schemaVersion;
-  if (schemaVersion == Report::SchemaVersion::unknown) 
-    throw xrt_core::error((boost::format("Unknown output format: '%s'") % validated_format).str());
-
-  // Output file
-  if (!m_output.empty() && boost::filesystem::exists(m_output) && !XBU::getForce()) 
-      throw xrt_core::error((boost::format("Output file already exists: '%s'") % m_output).str());
-
-  // Find device of interest
-  std::shared_ptr<xrt_core::device> device;
-  
-  try {
-    if(reportsToProcess.size() > 1 || reportsToRun.front().compare("host") != 0)
-      device = XBU::get_device(boost::algorithm::to_lower_copy(m_device), false /*inUserDomain*/);
-  } catch (const std::runtime_error& e) {
-    // Catch only the exceptions that we have generated earlier
-    std::cerr << boost::format("ERROR: %s\n") % e.what();
-    throw xrt_core::error(std::errc::operation_canceled);
-  }
-
-  bool is_report_output_valid = true;
-  // DRC check on devices and reports
-  if (!device) {
-    std::vector<std::string> missingReports;
-    for (const auto & report : reportsToProcess) {
-      if (report->isDeviceRequired())
-        missingReports.push_back(report->getReportName());
-    }
-
-    if (!missingReports.empty()) {
-      // Exception is thrown at the end of this function to allow for report writing
-      is_report_output_valid = false;
-      // Print error message
-      std::cerr << boost::format("Error: The following report(s) require specifying a device using the --device option:\n");
-      for (const auto & report : missingReports)
-        std::cout << boost::format("         - %s\n") % report;
-
-      // Print available devices
-      const auto dev_pt = XBU::get_available_devices(true);
-      if(dev_pt.empty())
-        std::cout << "0 devices found" << std::endl;
-      else
-        std::cout << "Device list" << std::endl;
-
-      for(const auto& kd : dev_pt) {
-        const boost::property_tree::ptree& dev = kd.second;
-        const std::string note = dev.get<bool>("is_ready") ? "" : "NOTE: Device not ready for use";
-        std::cout << boost::format("  [%s] : %s %s\n") % dev.get<std::string>("bdf") % dev.get<std::string>("vbnv") % note;
-      }
-    }
-  }
-
-  // Create the report
-  std::ostringstream oSchemaOutput;
-  try {
-    XBU::produce_reports(device, reportsToProcess, schemaVersion, m_elementsFilter, std::cout, oSchemaOutput);
-  } catch (const std::exception&) {
-    // Exception is thrown at the end of this function to allow for report writing
-    is_report_output_valid = false;
-  }
-
-  // -- Write output file ----------------------------------------------
-  if (!m_output.empty()) {
-    std::ofstream fOutput;
-    fOutput.open(m_output, std::ios::out | std::ios::binary);
-    if (!fOutput.is_open()) 
-      throw xrt_core::error((boost::format("Unable to open the file '%s' for writing.") % m_output).str());
-
-    fOutput << oSchemaOutput.str();
-
-    std::cout << boost::format("Successfully wrote the %s file: %s") % validated_format % m_output << std::endl;
-  }
-
-  if (!is_report_output_valid)
-    throw xrt_core::error(std::errc::operation_canceled);
+  // Empty
 }

--- a/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
@@ -9,6 +9,7 @@ file(GLOB XBUTIL_V2_BASE_FILES
   "../common/XBUtilitiesCore.cpp"
   "../common/XBUtilities.cpp"
   "../common/SubCmd.cpp"
+  "../common/SubCmdExamineInternal.cpp"
   "../common/OptionOptions.cpp"
   "../common/XBHelpMenusCore.cpp"
   "../common/XBHelpMenus.cpp"

--- a/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
@@ -6,26 +6,7 @@
 // Local - Include Files
 #include "SubCmdExamine.h"
 #include "core/common/error.h"
-
-// Utilities
-#include "tools/common/XBHelpMenusCore.h"
-#include "tools/common/XBUtilitiesCore.h"
-#include "tools/common/XBUtilities.h"
-#include "tools/common/XBHelpMenus.h"
-
-namespace XBU = XBUtilities;
-
-// 3rd Party Library - Include Files
-#include <boost/filesystem.hpp>
-#include <boost/format.hpp>
-#include <boost/program_options.hpp>
-#include <boost/algorithm/string.hpp>
-namespace po = boost::program_options;
-
-// System - Include Files
-#include <iostream>
-#include <fstream>
-#include <regex>
+#include "tools/common/SubCmdExamineInternal.h"
 
 // ---- Reports ------
 #include "tools/common/Report.h"
@@ -50,7 +31,7 @@ namespace po = boost::program_options;
 #include "tools/common/ReportThermal.h"
 
 // Note: Please insert the reports in the order to be displayed (alphabetical)
-  static ReportCollection fullReportCollection = {
+  ReportCollection SubCmdExamineInternal::uniqueReportCollection = {
   // Common reports
     std::make_shared<ReportAie>(),
     std::make_shared<ReportAieShim>(),
@@ -75,13 +56,8 @@ namespace po = boost::program_options;
   #endif
   };
 
-// ----- C L A S S   M E T H O D S -------------------------------------------
-static const std::string reportOptionValues = XBU::create_suboption_list_string(fullReportCollection, true /*add 'all' option*/);
-static const std::string formatOptionValues = XBU::create_suboption_list_string(Report::getSchemaDescriptionVector());
-
 SubCmdExamine::SubCmdExamine(bool _isHidden, bool _isDepricated, bool _isPreliminary)
-    : SubCmd("examine",
-             "Status of the system and device")
+    : SubCmdExamineInternal(_isHidden, _isDepricated, _isPreliminary, true /*isUserDomain*/)
     , m_device("")
     , m_reportNames()
     , m_elementsFilter()
@@ -89,153 +65,5 @@ SubCmdExamine::SubCmdExamine(bool _isHidden, bool _isDepricated, bool _isPrelimi
     , m_output("")
     , m_help(false)
 {
-  const std::string longDescription = "This command will 'examine' the state of the system/device and will"
-                                      " generate a report of interest in a text or JSON format.";
-  setLongDescription(longDescription);
-  setExampleSyntax("");
-  setIsHidden(_isHidden);
-  setIsDeprecated(_isDepricated);
-  setIsPreliminary(_isPreliminary);
-  setIsDefaultDevValid(false);
-
-  m_commonOptions.add_options()
-    ("device,d", boost::program_options::value<decltype(m_device)>(&m_device), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest.\n")
-    ("report,r", boost::program_options::value<decltype(m_reportNames)>(&m_reportNames)->multitoken(), (std::string("The type of report to be produced. Reports currently available are:\n") + reportOptionValues).c_str() )
-    ("format,f", boost::program_options::value<decltype(m_format)>(&m_format), (std::string("Report output format. Valid values are:\n") + formatOptionValues).c_str() )
-    ("output,o", boost::program_options::value<decltype(m_output)>(&m_output), "Direct the output to the given file")
-    ("help", boost::program_options::bool_switch(&m_help), "Help to use this sub-command")
-  ;
-
-  m_hiddenOptions.add_options()
-    ("element,e", boost::program_options::value<decltype(m_elementsFilter)>(&m_elementsFilter)->multitoken(), "Filters individual elements(s) from the report. Format: '/<key>/<key>/...'")
-  ;
-}
-
-void
-SubCmdExamine::execute(const SubCmdOptions& _options) const
-{
-  XBU::verbose("SubCommand: examine");
-
-  // Parse sub-command ...
-  po::variables_map vm;
-  process_arguments(vm, _options);
-
-  // Check to see if help was requested
-  if (m_help) {
-    printHelp();
-    return;
-  }
-
-  // -- Determine default values --
-  
-  // Report default value
-  std::vector<std::string> reportsToRun(m_reportNames);
-  if (m_reportNames.empty()) {
-    if (m_device.empty())
-      reportsToRun.push_back("host");
-    else {
-      reportsToRun.push_back("platform");
-      reportsToRun.push_back("dynamic-regions");
-    }
-  }
-
-  // DRC check
-  // When  is specified, make sure an accompanying output file is also specified
-  if (!m_format.empty() && m_output.empty()) {
-    std::cerr << "ERROR: Please specify an output file to redirect the json to" << std::endl;
-    throw xrt_core::error(std::errc::operation_canceled);
-  }
-
-  const auto validated_format = m_format.empty() ? "json" : m_format;
-
-  // DRC: Examine the output format
-  Report::SchemaVersion schemaVersion = Report::getSchemaDescription(validated_format).schemaVersion;
-  if (schemaVersion == Report::SchemaVersion::unknown) {
-    std::cerr << boost::format("ERROR: Unsupported --format option value '%s'") % validated_format << std::endl
-              << boost::format("       Supported values can be found in --format's help section below.") << std::endl;
-    printHelp();
-    throw xrt_core::error(std::errc::operation_canceled);
-  }
-
-  // DRC: Output file
-  if (!m_output.empty() && boost::filesystem::exists(m_output) && !XBU::getForce()) {
-    std::cerr << boost::format("ERROR: The output file '%s' already exists.  Please either remove it or execute this command again with the '--force' option to overwrite it.") % m_output << std::endl;
-    throw xrt_core::error(std::errc::operation_canceled);
-  }
-
-// -- Process the options --------------------------------------------
-  ReportCollection reportsToProcess;            // Reports of interest
-
-  bool is_report_output_valid = true;
-  // Collect the reports to be processed
-  XBU::collect_and_validate_reports(fullReportCollection, reportsToRun, reportsToProcess);
-
-  // Find device of interest
-  std::shared_ptr<xrt_core::device> device;
-  
-  try {
-    if(reportsToProcess.size() > 1 || reportsToRun.front().compare("host") != 0)
-      device = XBU::get_device(boost::algorithm::to_lower_copy(m_device), true /*inUserDomain*/);
-  } catch (const std::runtime_error& e) {
-    // Catch only the exceptions that we have generated earlier
-    std::cerr << boost::format("ERROR: %s\n") % e.what();
-    throw xrt_core::error(std::errc::operation_canceled);
-  }
-
-  // DRC check on devices and reports
-  if (!device) {
-    std::vector<std::string> missingReports;
-    for (const auto & report : reportsToProcess) {
-      if (report->isDeviceRequired())
-        missingReports.push_back(report->getReportName());
-    }
-
-    if (!missingReports.empty()) {
-      // Exception is thrown at the end of this function to allow for report writing
-      is_report_output_valid = false;
-      // Print error message
-      std::cerr << boost::format("Error: The following report(s) require specifying a device using the --device option:\n");
-      for (const auto & report : missingReports)
-        std::cout << boost::format("         - %s\n") % report;
-
-      // Print available devices
-      const auto dev_pt = XBU::get_available_devices(true);
-      if(dev_pt.empty())
-        std::cout << "0 devices found" << std::endl;
-      else
-        std::cout << "Device list" << std::endl;
-
-      for(auto& kd : dev_pt) {
-        const boost::property_tree::ptree& dev = kd.second;
-        const std::string note = dev.get<bool>("is_ready") ? "" : "NOTE: Device not ready for use";
-        std::cout << boost::format("  [%s] : %s %s\n") % dev.get<std::string>("bdf") % dev.get<std::string>("vbnv") % note;
-      }
-    }
-  }
-
-  // Create the report
-  std::ostringstream oSchemaOutput;
-  try {
-    XBU::produce_reports(device, reportsToProcess, schemaVersion, m_elementsFilter, std::cout, oSchemaOutput);
-  } catch (const std::exception&) {
-    // Exception is thrown at the end of this function to allow for report writing
-    is_report_output_valid = false;
-  }
-
-  // -- Write output file ----------------------------------------------
-  if (!m_output.empty()) {
-    std::ofstream fOutput;
-    fOutput.open(m_output, std::ios::out | std::ios::binary);
-    if (!fOutput.is_open()) {
-      std::cerr << boost::format("Unable to open the file '%s' for writing.") % m_output << std::endl;
-      throw xrt_core::error(std::errc::operation_canceled);
-    }
-
-    fOutput << oSchemaOutput.str();
-
-    std::cout << boost::format("Successfully wrote the %s file: %s") % validated_format % m_output << std::endl;
-  }
-
-  if (!is_report_output_valid)
-    throw xrt_core::error(std::errc::operation_canceled);
+  // Empty
 }

--- a/src/runtime_src/core/tools/xbutil2/SubCmdExamine.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdExamine.h
@@ -18,11 +18,9 @@
 #define __SubCmdExamine_h_
 
 #include "tools/common/SubCmd.h"
+#include "tools/common/SubCmdExamineInternal.h"
 
-class SubCmdExamine : public SubCmd {
- public:
-  virtual void execute(const SubCmdOptions &_options) const;
-
+class SubCmdExamine : public SubCmdExamineInternal {
  public:
   SubCmdExamine(bool _isHidden, bool _isDepricated, bool _isPreliminary);
 


### PR DESCRIPTION
#### Problem solved by the commit
https://jira.xilinx.com/browse/VITIS-8049 Refactor SubCmdExamine to use common file.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Refactored SubCmdExamine for xbutil and xbmgmt to use a common SubCmdExamine file.
#### How problem was solved, alternative solutions (if any) and why they were rejected
SubCmdExamineInternal.cpp & SubCmdExamineInternal.h have been added under src/runtime_src/core/tools/common. The SubCmdExamine files in xbutil and xbmgmt now inherit from SubCmdExamineInternal, which itself inherits from SubCmd. xbutil's SubCmdExamine.cpp now gives its report list to SubCmdExamineInternal through the `static ReportCollection uniqueReportCollection`, and xbmgmt does likewise in its own file with its report list. 
#### Risks (if any) associated the changes in the commit
This code refactor restructures SubCmdExamine.
#### What has been tested and how, request additional testing if necessary
I have tested various xbutil/xbmgmt examine reports to check if they work the same now as before the refactor. Functionality should be tested thoroughly to ensure that it is indeed still the same through pipeline.
```
rchane@xsjsagarw50:/proj/rdi/staff/rchane/XRT$ xbutil examine --help
COMMAND: examine

DESCRIPTION: This command will 'examine' the state of the system/device and will generate a report of interest
               in a text or JSON format.

USAGE: xbutil examine [--help] [-d arg] [-r arg] [-f arg] [-o arg]

OPTIONS:
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest
  -r, --report       - The type of report to be produced. Reports currently available are:
                         aie             - AIE metadata in xclbin
                         aiemem          - AIE memory tile information
                         aieshim         - AIE shim tile status
                         all             - All known reports are produced
                         debug-ip-status - Status of Debug IPs present in xclbin loaded on device
                         dynamic-regions - Information about the xclbin and the compute units
                         electrical      - Electrical and power sensors present on the device
                         error           - Asyncronus Error present on the device
                         firewall        - Firewall status
                         host            - Host information
                         mailbox         - Mailbox metrics of the device
                         mechanical      - Mechanical sensors on and surrounding the device
                         memory          - Memory information present on the device
                         pcie-info       - Pcie information of the device
                         platform        - Platforms flashed on the device
                         qspi-status     - QSPI write protection status
                         thermal         - Thermal sensors present on the device
  -f, --format       - Report output format. Valid values are:
                         JSON        - Latest JSON schema
                         JSON-2020.2 - JSON 2020.2 schema
  -o, --output       - Direct the output to the given file
  --help             - Help to use this sub-command


GLOBAL OPTIONS:
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
```
```
rchane@xsjsagarw50:/proj/rdi/staff/rchane/XRT$ xbmgmt examine --help
COMMAND: examine

DESCRIPTION: This command will 'examine' the state of the system/device and will generate a report of interest
               in a text or JSON format.

USAGE: xbmgmt examine [--help] [-d arg] [-r arg] [-f arg] [-o arg]

OPTIONS:
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest
  -r, --report       - The type of report to be produced. Reports currently available are:
                         all        - All known reports are produced
                         cmc        - CMC status of the device
                         firewall   - Firewall status
                         host       - Host information
                         mailbox    - Mailbox metrics of the device
                         mechanical - Mechanical sensors on and surrounding the device
                         platform   - Platform information
                         vmr        - Vmr status on the device
  -f, --format       - Report output format. Valid values are:
                         JSON        - Latest JSON schema
                         JSON-2020.2 - JSON 2020.2 schema
  -o, --output       - Direct the output to the given file
  --help             - Help to use this sub-command


GLOBAL OPTIONS:
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
```
#### Documentation impact (if any)
N/A
