### PR TITLE
CR-1153585 - Fix Mpd msd binaries seg faults with latest XRT

### DIFF
--- a/src/runtime_src/core/common/config_reader.cpp
+++ b/src/runtime_src/core/common/config_reader.cpp
@@ -48,7 +48,7 @@ static std::mutex mutex;
 // values are statically cached, they can be changed only until they
 // have been accessed the very first time.  This map tracks first key
 // access.
-static std::set<std::string>
+static std::set<std::string>&
 get_lock_map()
 {
   static std::set<std::string> lock_map;

--- a/src/runtime_src/core/common/config_reader.cpp
+++ b/src/runtime_src/core/common/config_reader.cpp
@@ -43,25 +43,30 @@ namespace {
 
 namespace key {
 
+static std::mutex mutex;
 // Configuration values can be changed programmatically, but because
 // values are statically cached, they can be changed only until they
 // have been accessed the very first time.  This map tracks first key
 // access.
-static std::set<std::string> locked;
-static std::mutex mutex;
+static std::set<std::string>
+get_lock_map()
+{
+  static std::set<std::string> lock_map;
+  return lock_map;
+}
 
 static void
 lock(const std::string& key)
 {
   std::lock_guard<std::mutex> lk(mutex);
-  locked.insert(key);
+  get_lock_map().insert(key);
 }
 
 static bool
 is_locked(const std::string& key)
 {
   std::lock_guard<std::mutex> lk(mutex);
-  return locked.find(key) != locked.end();
+  return get_lock_map().find(key) != get_lock_map().end();
 }
 
 } // key

--- a/src/runtime_src/core/pcie/linux/pcidev.cpp
+++ b/src/runtime_src/core/pcie/linux/pcidev.cpp
@@ -157,21 +157,16 @@ namespace xrt_core { namespace pci {
 
 namespace sysfs {
 
-static std::string
-get_dev_root()
-{
-  static const std::string dev_root = "/sys/bus/pci/devices/";
-  return dev_root;
-}
+static constexpr const char* dev_root = "/sys/bus/pci/devices/";
 
 static std::string
 get_path(const std::string& name, const std::string& subdev, const std::string& entry)
 {
   std::string subdir;
-  if (get_subdev_dir_name(get_dev_root() + name, subdev, subdir) != 0)
+  if (get_subdev_dir_name(dev_root + name, subdev, subdir) != 0)
     return "";
 
-  auto path = get_dev_root();
+  std::string path = dev_root;
   path += name;
   path += "/";
   path += subdir;
@@ -213,7 +208,7 @@ open(const std::string& name,
   if (path.empty()) {
     std::stringstream ss;
     ss << "Failed to find subdirectory for " << subdev
-       << " under " << get_dev_root() + name << std::endl;
+       << " under " << dev_root + name << std::endl;
     err = ss.str();
   } else {
     fs = open_path(path, err, write, binary);
@@ -475,10 +470,10 @@ dev(const drv& driver, const std::string& sysfs) : m_sysfs_name(sysfs)
   if (m_is_mgmt)
     sysfs_get("", "instance", err, m_instance, static_cast<uint32_t>(INVALID_ID));
   else
-    m_instance = get_render_value(sysfs::get_dev_root() + sysfs + "/drm");
+    m_instance = get_render_value(sysfs::dev_root + sysfs + "/drm");
 
   sysfs_get<int>("", "userbar", err, m_user_bar, 0);
-  m_user_bar_size = bar_size(sysfs::get_dev_root() + sysfs, m_user_bar);
+  m_user_bar_size = bar_size(sysfs::dev_root + sysfs, m_user_bar);
   sysfs_get<bool>("", "ready", err, m_is_ready, false);
   m_user_bar_map = reinterpret_cast<char *>(MAP_FAILED);
 }

--- a/src/runtime_src/core/pcie/linux/pcidev.cpp
+++ b/src/runtime_src/core/pcie/linux/pcidev.cpp
@@ -157,16 +157,21 @@ namespace xrt_core { namespace pci {
 
 namespace sysfs {
 
-static const std::string dev_root = "/sys/bus/pci/devices/";
+static std::string
+get_dev_root()
+{
+  static const std::string dev_root = "/sys/bus/pci/devices/";
+  return dev_root;
+}
 
 static std::string
 get_path(const std::string& name, const std::string& subdev, const std::string& entry)
 {
   std::string subdir;
-  if (get_subdev_dir_name(dev_root + name, subdev, subdir) != 0)
+  if (get_subdev_dir_name(get_dev_root() + name, subdev, subdir) != 0)
     return "";
 
-  auto path = dev_root;
+  auto path = get_dev_root();
   path += name;
   path += "/";
   path += subdir;
@@ -208,7 +213,7 @@ open(const std::string& name,
   if (path.empty()) {
     std::stringstream ss;
     ss << "Failed to find subdirectory for " << subdev
-       << " under " << dev_root + name << std::endl;
+       << " under " << get_dev_root() + name << std::endl;
     err = ss.str();
   } else {
     fs = open_path(path, err, write, binary);
@@ -470,10 +475,10 @@ dev(const drv& driver, const std::string& sysfs) : m_sysfs_name(sysfs)
   if (m_is_mgmt)
     sysfs_get("", "instance", err, m_instance, static_cast<uint32_t>(INVALID_ID));
   else
-    m_instance = get_render_value(sysfs::dev_root + sysfs + "/drm");
+    m_instance = get_render_value(sysfs::get_dev_root() + sysfs + "/drm");
 
   sysfs_get<int>("", "userbar", err, m_user_bar, 0);
-  m_user_bar_size = bar_size(sysfs::dev_root + sysfs, m_user_bar);
+  m_user_bar_size = bar_size(sysfs::get_dev_root() + sysfs, m_user_bar);
   sysfs_get<bool>("", "ready", err, m_is_ready, false);
   m_user_bar_map = reinterpret_cast<char *>(MAP_FAILED);
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Fixed segmentation fault issue when running Mpd Msd cloud daemons

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
pr - https://github.com/Xilinx/XRT/pull/7104 introduced this bug. It was caught in regressions.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Mpd and Msd are linked to xrt_core and xrt_coreutil statically and this causes [static initialization order fiasco](http://yosefk.com/c++fqa/fqa.html#fqa-10.12) problem where a global object being built references another global that is not yet built. Solved this problem by lazy initialization i.e: initialization on first use.

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
Tested Mpd Msd connection and ran validate tests on U250 card.

#### Documentation impact (if any)
NA