### PR TITLE
CR-1139245 Flush trace when windowing in AIE1

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_trace_new/aie_trace_impl.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace_new/aie_trace_impl.h
@@ -46,6 +46,12 @@ namespace xdp {
 
     virtual void updateDevice() = 0;
     virtual uint64_t checkTraceBufSize(uint64_t size) = 0;
+    /*
+     * If trace module is running, it might buffer partial trace.
+     * This leftover trace needs to be force flushed at the end using a custom end event.
+     * This applies to trace windowing on AIE1 and all scenarios on AIE2.
+     */
+    virtual void flushAieTileTraceModule() = 0;
   };
 
 } // namespace xdp

--- a/src/runtime_src/xdp/profile/plugin/aie_trace_new/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace_new/aie_trace_plugin.cpp
@@ -276,6 +276,8 @@ namespace xdp {
     if (!AIEData.valid)
       return;
 
+    // Flush AIE then datamovers
+    AIEData.implementation->flushAieTileTraceModule();
     flushOffloader(AIEData.offloader, false);
   }
 
@@ -292,6 +294,8 @@ namespace xdp {
     if (!AIEData.valid)
       return;
 
+    // Flush AIE then datamovers
+    AIEData.implementation->flushAieTileTraceModule();
     flushOffloader(AIEData.offloader, true);
     XDPPlugin::endWrite();
     (db->getStaticInfo()).deleteCurrentlyUsedDeviceInterface(AIEData.deviceID);

--- a/src/runtime_src/xdp/profile/plugin/aie_trace_new/edge/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace_new/edge/aie_trace.cpp
@@ -80,7 +80,6 @@ namespace xdp {
   
   constexpr double AIE_DEFAULT_FREQ_MHZ = 1000.0; // should be changed
 
-
   AieTrace_EdgeImpl::AieTrace_EdgeImpl(VPDatabase* database, std::shared_ptr<AieTraceMetadata> metadata)
       : AieTraceImpl(database, metadata) {
     // Pre-defined metric sets
@@ -100,7 +99,15 @@ namespace xdp {
     // These are also broadcast to memory module
     mCoreTraceStartEvent = XAIE_EVENT_ACTIVE_CORE;
     mCoreTraceEndEvent   = XAIE_EVENT_DISABLED_CORE;
-    
+
+    /*
+     * This is needed because the cores are started/stopped during execution
+     * to get around some hw bugs. We cannot restart tracemodules when that happens.
+     * At the end, we need to use event generate register to create this event
+     * to gracefully shut down trace modules.
+     */
+    mWindowedTraceEndEvent = XAIE_EVENT_INSTR_EVENT_1_CORE;
+
     // **** Memory Module Trace ****
     // NOTE 1: Core events listed here are broadcast by the resource manager
     // NOTE 2: These are supplemented with counter events as those are dependent on counter #
@@ -386,7 +393,7 @@ namespace xdp {
     auto configChannel1 = metadata->getConfigChannel1();
 
     // Iterate over all used/specified tiles
-    // NOTE: rows are stored as absolute as requred by resource manager
+    // NOTE: rows are stored as absolute as required by resource manager
     for (auto& tileMetric : metadata->getConfigMetrics()) {
       auto& metricSet = tileMetric.second;
       auto tile       = tileMetric.first;
@@ -555,11 +562,15 @@ namespace xdp {
         // Delay cycles and user control are not compatible with each other
         if (metadata->getUseUserControl()) {
           mCoreTraceStartEvent = XAIE_EVENT_INSTR_EVENT_0_CORE;
-          mCoreTraceEndEvent = XAIE_EVENT_INSTR_EVENT_1_CORE;
-        } else if (metadata->getUseGraphIterator() && !configureStartIteration(core)) {
-          break;
-        } else if (metadata->getUseDelay() && !configureStartDelay(core)) {
-          break;
+          mCoreTraceEndEvent = mWindowedTraceEndEvent;
+        } else if (metadata->getUseGraphIterator()) {
+          if (!configureStartIteration(core))
+            break;
+          mWindowedTraceLocs.push_back(loc);
+        } else if (metadata->getUseDelay()) {
+          if (!configureStartDelay(core))
+            break;
+          mWindowedTraceLocs.push_back(loc);
         }
 
         // Set overall start/end for trace capture
@@ -941,9 +952,7 @@ namespace xdp {
     }
 
     mCoreTraceStartEvent = counterEvent;
-    // This is needed because the cores are started/stopped during execution
-    // to get around some hw bugs. We cannot restart tracemodules when that happens
-    mCoreTraceEndEvent = XAIE_EVENT_NONE_CORE;
+    mCoreTraceEndEvent = mWindowedTraceEndEvent;
 
     return true;
   }
@@ -979,10 +988,21 @@ namespace xdp {
     }
 
     mCoreTraceStartEvent = counterEvent;
-    // This is needed because the cores are started/stopped during execution
-    // to get around some hw bugs. We cannot restart tracemodules when that happens
-    mCoreTraceEndEvent = XAIE_EVENT_NONE_CORE;
+    mCoreTraceEndEvent = mWindowedTraceEndEvent;
 
     return true;
+  }
+
+  void AieTrace_EdgeImpl::flushAieTileTraceModule()
+  {
+    auto handle = metadata->getHandle();
+    aieDevInst = static_cast<XAie_DevInst*>(db->getStaticInfo().getAieDevInst(fetchAieDevInst, handle));
+
+    /*
+     * Flush for trace windowing
+     */
+    for (const auto& loc : mWindowedTraceLocs)
+      XAie_EventGenerate(aieDevInst, loc, XAIE_CORE_MOD, mWindowedTraceEndEvent);
+    mWindowedTraceLocs.clear();
   }
 }

--- a/src/runtime_src/xdp/profile/plugin/aie_trace_new/edge/aie_trace.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace_new/edge/aie_trace.h
@@ -34,6 +34,8 @@ namespace xdp {
       
       XDP_EXPORT
       virtual void updateDevice();
+      XDP_EXPORT
+      virtual void flushAieTileTraceModule();
 
     private: 
       typedef XAie_Events            EventType;
@@ -85,6 +87,7 @@ namespace xdp {
       EventType   mCoreTraceEndEvent;
       EventType   mMemTileTraceStartEvent;
       EventType   mMemTileTraceEndEvent;
+      EventType   mWindowedTraceEndEvent;
 
       EventVector mCoreCounterStartEvents;
       EventVector mCoreCounterEndEvents;
@@ -93,6 +96,9 @@ namespace xdp {
       EventVector mMemoryCounterStartEvents;
       EventVector mMemoryCounterEndEvents;
       ValueVector mMemoryCounterEventValues;
+
+      // Tile locations using windowed trace
+      std::vector<XAie_LocType> mWindowedTraceLocs;
 
   };
 

--- a/src/runtime_src/xdp/profile/plugin/aie_trace_new/x86/aie_trace.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace_new/x86/aie_trace.h
@@ -24,8 +24,8 @@
 namespace xdp {
 
   class AieTrace_x86Impl : public AieTraceImpl{
-    public:
 
+    public:
       AieTrace_x86Impl(VPDatabase* database, std::shared_ptr<AieTraceMetadata> metadata)
         : AieTraceImpl(database, metadata){}
       ~AieTrace_x86Impl() = default;
@@ -34,6 +34,9 @@ namespace xdp {
       uint64_t checkTraceBufSize(uint64_t size);
       void parseMessages(uint8_t* messages);
       module_type getTileType(uint16_t absRow);
+
+      public:
+      virtual void flushAieTileTraceModule() {}
   };
 
 }   


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Generate  Event 1  at the end to gracefully shutdown trace module. This helps get complete trace in AIE1 with windowing.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
N/A
#### How problem was solved, alternative solutions (if any) and why they were rejected
N/A
#### Risks (if any) associated the changes in the commit
N/A
#### What has been tested and how, request additional testing if necessary
Tested on a board
#### Documentation impact (if any)
