### PR TITLE
fixing aie only xclbin check

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
@@ -1163,9 +1163,7 @@ zocl_load_sect(struct drm_zocl_dev *zdev, struct axlf *axlf, char __user *xclbin
 static bool
 is_aie_only(struct axlf *axlf)
 {
-	if ((axlf->m_header.m_actionMask & AM_LOAD_AIE) ||
-		(!xrt_xclbin_get_section_num(axlf, IP_LAYOUT) &&
-		xrt_xclbin_get_section_num(axlf, AIE_METADATA)))
+	if ((axlf->m_header.m_actionMask & AM_LOAD_AIE))
 		return true;
 
 	return false;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Changing the AIE only xclbin condition.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
We shouldnt consider an xclbin as AIE only xclbin if it doesnt contain ip_layout etc. There may be cases where PL kernels may not exist, but PL dynamic region exist.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Fixed the aie only xclbin condition

#### Risks (if any) associated the changes in the commit
NA

#### What has been tested and how, request additional testing if necessary
Verified basic functionality on hw_emu.

#### Documentation impact (if any)
NA