### PR TITLE
CR-1158428 xbmgmt examine -r cmc has misleading output

### DIFF
--- a/src/runtime_src/core/tools/common/ReportCmcStatus.cpp
+++ b/src/runtime_src/core/tools/common/ReportCmcStatus.cpp
@@ -53,7 +53,7 @@ ReportCmcStatus::getPropertyTree20202( const xrt_core::device * _pDevice,
   catch(const xrt_core::query::sysfs_error&) {}
 
   try {
-    runtime_tree.put("Description", "Clock Throttling and Shutdown");
+    runtime_tree.put("Description", "Runtime Clock Throttling");
     auto clk_scaling_data = xrt_core::device_query<xrt_core::query::clk_scaling_info>(_pDevice);
     for (const auto& pt : clk_scaling_data) {
       runtime_tree.put("supported", pt.support);


### PR DESCRIPTION
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1158428 
xbmgmt examine -r cmc "clock throttling and shutdown" field, if displayed as "not enabled," misleads user to think shutdown is not enabled (though it is by default) 
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
The issue was first introduced when renaming clock scaling to clock throttling.
#### How problem was solved, alternative solutions (if any) and why they were rejected
The "Clock Throttling and Shutdown:" field has been renamed to "Runtime Clock Throttling:" as suggested.
#### Risks (if any) associated the changes in the commit
N/A
#### What has been tested and how, request additional testing if necessary
```
rchane@xsjsagarw50:/proj/rdi/staff/rchane/XRT$ xbmgmt examine -d 65:00 -r cmc
---------------------------------------------------
[0000:65:00.0] : xilinx_vck5000_gen4x8_qdma_base_2
---------------------------------------------------
CMC
  Heartbeat information unavailable
  Runtime Clock Throttling:
    Not enabled
    Critical threshold (clock shutdown) limits:
      Power : 300 W
      Temperature : 100 C
    Throttling threshold limits:
      Power : 291 W
      Temperature : 95 C
    Power threshold override:
      Override : false
      Override limit : 0 W
    Temperature threshold override:
      Override : false
      Override limit : 0 C
```
#### Documentation impact (if any)
N/A