### PR TITLE
Fixed X3 platform kernel xclbin load issue

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/zocl_sysfs.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_sysfs.c
@@ -69,7 +69,7 @@ static ssize_t xclbinid_show(struct device *dev,
 	for (i = 0; i < MAX_PR_SLOT_NUM; i++) {
 		zocl_slot = zdev->pr_slot[i];
 		if (!zocl_slot || !zocl_slot->slot_xclbin ||
-		    !zocl_slot->slot_xclbin->zx_dtbo_path)
+		    !zocl_slot->slot_xclbin->zx_uuid)
 			continue;
 
 		count = sprintf(buf+size, raw_fmt, zocl_slot->slot_idx,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
@@ -482,7 +482,9 @@ xocl_resolver(struct xocl_dev *xdev, struct axlf *axlf, xuid_t *xclbin_id,
 	uint32_t s_id = DEFAULT_PL_SLOT;
 	int ret = 0;
 
-	if (xocl_axlf_section_header(xdev, axlf, BITSTREAM) || xocl_axlf_section_header(xdev, axlf, BITSTREAM_PARTIAL_PDI)) {
+	if (xocl_axlf_section_header(xdev, axlf, BITSTREAM) ||
+		xocl_axlf_section_header(xdev, axlf, BITSTREAM_PARTIAL_PDI) ||
+		!xocl_axlf_section_header(xdev, axlf, SOFT_KERNEL)) {
 		s_id = DEFAULT_PL_SLOT;
 		if (xclbin_downloaded(xdev, xclbin_id, s_id)) {
 			if (qos & XOCL_AXLF_FORCE_PROGRAM) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
-- Recently there is change of verify a XCLBIN types by BITSTREAM and PDI. But for X3 device the XCLBIN doesn't context BITSTREAM. Because of that the test is failing  
-- Updated the check so that it will cover more cases. 

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
This is introduced #7450

#### How problem was solved, alternative solutions (if any) and why they were rejected
-- Added more specific checks 
 
#### Risks (if any) associated the changes in the commit
N/A
#### What has been tested and how, request additional testing if necessary
N/A
#### Documentation impact (if any)
