### PR TITLE
CR-1158312 XRT regression : xclRegRW: can't map CU

### DIFF
--- a/src/runtime_src/core/common/api/xrt_hw_context.cpp
+++ b/src/runtime_src/core/common/api/xrt_hw_context.cpp
@@ -58,6 +58,7 @@ public:
   set_exclusive()
   {
     m_mode = xrt::hw_context::access_mode::exclusive;
+    m_hdl->update_access_mode(m_mode);
   }
 
   const std::shared_ptr<xrt_core::device>&

--- a/src/runtime_src/core/common/shim/hwctx_handle.h
+++ b/src/runtime_src/core/common/shim/hwctx_handle.h
@@ -19,9 +19,9 @@ namespace xrt_core {
 // hardware context.
 class hwctx_handle
 {
-  using qos_type = xrt::hw_context::cfg_param_type;
-
 public:
+  using qos_type = xrt::hw_context::cfg_param_type;
+  using access_mode = xrt::hw_context::access_mode;
   using slot_id = uint32_t;
 
   // Destruction must destroy the underlying hardware context
@@ -32,6 +32,14 @@ public:
   // to experimental user facing xrt::hw_context::update_qos()
   virtual void
   update_qos(const qos_type&)
+  {
+    throw xrt_core::error(std::errc::not_supported, __func__);
+  }
+
+  // Update access mode for platforms that care.  This is used
+  // for Alveo mailbox where CUs are changed to be exclusive mode
+  virtual void
+  update_access_mode(access_mode)
   {
     throw xrt_core::error(std::errc::not_supported, __func__);
   }

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -152,6 +152,12 @@ public:
     }
   }
 
+  void
+  update_access_mode(access_mode mode) override
+  {
+    m_mode = mode;
+  }
+
   slot_id
   get_slotidx() const override
   {


### PR DESCRIPTION
#### Problem solved by the commit
Make sure dynamic update of hwctx accces_mode is reflected in shim specialization that care.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
The bug was introduced when the hwctx_handle was added #7280.

#### How problem was solved, alternative solutions (if any) and why they were rejected
This PR is specific for design that use mailbox. XRT under the hood changes CU access mode to exclusive because mailbox require register read/write which is only supported for exclusive mode CUs.  This update of access_mode was not being reflected in the shim specialization of hwctx_handle.  The fix adds a new optional virtual function to hwctx_handle that is used to reflect the access_mode change.

#### Risks (if any) associated the changes in the commit
Low if any.  The PR assumes that we only support mailbox on Alveo since only Linux was updated to reflect the access mode change.

#### What has been tested and how, request additional testing if necessary
The CR test case.

