### PR TITLE
Add changes to support xbutil reset on Edge Platforms

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
@@ -1103,6 +1103,8 @@ static int zocl_drm_platform_probe(struct platform_device *pdev)
 	int year, mon, day;
 
 	id = of_match_node(zocl_drm_of_match, pdev->dev.of_node);
+	if (!id)
+		return -EINVAL;
 	DRM_INFO("Probing for %s\n", id->compatible);
 
 	/* Create zocl device and initial */

--- a/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
@@ -1165,6 +1165,9 @@ zocl_reset(struct drm_zocl_dev *zdev, const char *buf, size_t count)
 	mutex_lock(&kds->lock);
         /* Find out number of active client and send a signal to it. */
         list_for_each_entry_safe(client, tmp_client, &kds->clients, link) {
+                if (pid_nr(client->pid) == pid_nr(task_tgid(current)))
+                        continue;
+
                 ret = kill_pid(client->pid, SIGTERM, 1);
                 if (ret) {
                         DRM_WARN("Failed to terminate Client pid %d."

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -1697,16 +1697,15 @@ int
 shim::
 resetDevice(xclResetKind kind)
 {
-  int ret;
   std::string errmsg{""};
 
   if (kind == XCL_USER_RESET) {
     mDev->sysfs_put("zocl_reset", errmsg, "1\n");
     if (!errmsg.empty())
-      throw std::runtime_error("Failed to reset zocl, err : " + errmsg);
+      throw std::runtime_error("Failed to reset zocl, err : " + errmsg + "\n");
   }
   else
-    return -EINVAL; // other kinds of reset are not supported
+    throw std::runtime_error("Invalid reset type\n"); // other kinds of reset are not supported
 
   return 0;
 }
@@ -2746,6 +2745,8 @@ xclResetDevice(xclDeviceHandle handle, xclResetKind kind)
 int
 xclInternalResetDevice(xclDeviceHandle handle, xclResetKind kind)
 {
+  // NOTE: until xclResetDevice is made completely internal,
+  // this wrapper is being used to limit the pragma use to this file
   ZYNQ::shim *drv = ZYNQ::shim::handleCheck(handle);
   return drv ? drv->resetDevice(kind) : -ENODEV;
 }

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -1693,6 +1693,24 @@ xclErrorClear()
   return ret ? -errno : ret;
 }
 
+int
+shim::
+resetDevice(xclResetKind kind)
+{
+  int ret;
+  std::string errmsg{""};
+
+  if (kind == XCL_USER_RESET) {
+    mDev->sysfs_put("zocl_reset", errmsg, "1\n");
+    if (!errmsg.empty())
+      throw std::runtime_error("Failed to reset zocl, err : " + errmsg);
+  }
+  else
+    return -EINVAL; // other kinds of reset are not supported
+
+  return 0;
+}
+
 #ifdef XRT_ENABLE_AIE
 zynqaie::Aie*
 shim::
@@ -2722,13 +2740,14 @@ xclUpdateSchedulerStat(xclDeviceHandle handle)
 int
 xclResetDevice(xclDeviceHandle handle, xclResetKind kind)
 {
-  return -ENOSYS;
+  return xclInternalResetDevice(handle, kind);
 }
 
 int
 xclInternalResetDevice(xclDeviceHandle handle, xclResetKind kind)
 {
-  return -ENOSYS;
+  ZYNQ::shim *drv = ZYNQ::shim::handleCheck(handle);
+  return drv ? drv->resetDevice(kind) : -ENODEV;
 }
 
 int

--- a/src/runtime_src/core/edge/user/shim.h
+++ b/src/runtime_src/core/edge/user/shim.h
@@ -148,6 +148,7 @@ public:
                                   xclBOProperties *properties);
   int xclExecBuf(unsigned int cmdBO);
   int xclExecWait(int timeoutMilliSec);
+  int resetDevice(xclResetKind kind);
 
   ////////////////////////////////////////////////////////////////
   // Context handling


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Added shim changes to support `xbutil reset ` on edge platforms
PR - https://github.com/Xilinx/XRT/pull/7455 added driver changes to support reset on zocl, this PR is an extension which adds shim level changes to support it

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
zocl exports sysfs entry zocl_reset and writing '1' to it to initiate reset

#### Risks (if any) associated the changes in the commit
Low 

#### What has been tested and how, request additional testing if necessary
Tested reset functionality on vck190 device

#### Documentation impact (if any)
NA