### PR TITLE
CR 1139245: Flush trace when windowing on PCIe devices

### DIFF
--- a/src/runtime_src/core/edge/ps_kernels/profiling/aie2_trace_config/aie2_trace_config.cpp
+++ b/src/runtime_src/core/edge/ps_kernels/profiling/aie2_trace_config/aie2_trace_config.cpp
@@ -264,7 +264,7 @@ namespace {
                           EventConfiguration& config,
                           const xdp::built_in::TraceInputConfiguration* params,
                           xdp::built_in::TraceOutputConfiguration* tilecfg,
-                          xdp::built_in::MessageConfiguration* msgcfg)
+                          xdp::built_in::MessageConfiguration* msgcfg, std::vector<XAie_LocType>& windowedTraceLocs)
   {
    
     xaiefal::Logger::get().setLogLevel(xaiefal::LogLevel::DEBUG);
@@ -725,9 +725,10 @@ namespace {
      * Flush for trace windowing
      */
     for (const auto& loc : windowedTraceLocs)
-      XAie_EventGenerate(aieDevInst, loc, XAIE_CORE_MOD, config.indowedTraceEndEvent);
-      windowedTraceLocs.clear();
+      XAie_EventGenerate(aieDevInst, loc, XAIE_CORE_MOD, config.windowedTraceEndEvent);
+    windowedTraceLocs.clear();
   }
+  
 
 }
 
@@ -787,13 +788,13 @@ int aie2_trace_config(uint8_t* input, uint8_t* output, uint8_t* messageOutput, i
     tilecfg->numTiles = params->numTiles;
 
     setMetricsSettings(constructs->aieDevInst, constructs->aieDev,
-                            config, params, tilecfg, messageStruct);
+                            config, params, tilecfg, messageStruct, constructs->windowedTraceLocs);
     uint8_t* out = reinterpret_cast<uint8_t*>(tilecfg);
     std::memcpy(output, out, total_size);   
 
     //Clean up
     free(tilecfg); 
-  }
+
   // flush iteraiton
   } else if (iteration == 1) {
     flushAieTileTraceModule(constructs->aieDevInst, config, constructs->windowedTraceLocs);

--- a/src/runtime_src/core/edge/ps_kernels/profiling/aie2_trace_config/aie2_trace_config.cpp
+++ b/src/runtime_src/core/edge/ps_kernels/profiling/aie2_trace_config/aie2_trace_config.cpp
@@ -31,6 +31,7 @@ class xrtHandles : public pscontext
     XAie_DevInst* aieDevInst = nullptr;
     xaiefal::XAieDev* aieDev = nullptr;
     xclDeviceHandle handle = nullptr;
+    std::vector<XAie_LocType> windowedTraceLocs;
 
     xrtHandles() = default;
     ~xrtHandles()
@@ -161,9 +162,7 @@ namespace {
         return false;
 
     config.coreTraceStartEvent = counterEvent;
-    // This is needed because the cores are started/stopped during execution
-    // to get around some hw bugs. We cannot restart tracemodules when that happens
-    config.coreTraceEndEvent = XAIE_EVENT_NONE_CORE;
+    config.coreTraceEndEvent =  config.windowedTraceEndEvent;
 
     return true;
   }
@@ -222,9 +221,7 @@ namespace {
     }
 
     config.coreTraceStartEvent = counterEvent;
-    // This is needed because the cores are started/stopped during execution
-    // to get around some hw bugs. We cannot restart tracemodules when that happens
-    config.coreTraceEndEvent = XAIE_EVENT_NONE_CORE;
+    config.coreTraceEndEvent =  config.windowedTraceEndEvent;
 
     return true;
   }
@@ -457,11 +454,15 @@ namespace {
         // Delay cycles and user control are not compatible with each other
         if (params->useUserControl) {
           config.coreTraceStartEvent = XAIE_EVENT_INSTR_EVENT_0_CORE;
-          config.coreTraceEndEvent = XAIE_EVENT_INSTR_EVENT_1_CORE;
-        } else if (params->useGraphIterator && !configureStartIteration(core, config, params)) {
-          break;
-        } else if (params->useDelay && !configureStartDelay(core, config, params)) {
-          break;
+          config.coreTraceEndEvent = config.windowedTraceEndEvent;
+        } else if (params->useGraphIterator) {
+          if (!configureStartIteration(core, config, params))
+            break;
+          windowedTraceLocs.push_back(loc);
+        } else if (params->useDelay) {
+          if (!configureStartDelay(core, config, params))
+            break;
+          windowedTraceLocs.push_back(loc);
         }
 
         // Set overall start/end for trace capture
@@ -718,6 +719,16 @@ namespace {
     return 0;
   } // end setMetricsSettings
 
+  void flushAieTileTraceModule(XAie_DevInst* aieDevInst, EventConfiguration& config, std::vector<XAie_LocType>& windowedTraceLocs)
+  {
+    /*
+     * Flush for trace windowing
+     */
+    for (const auto& loc : windowedTraceLocs)
+      XAie_EventGenerate(aieDevInst, loc, XAIE_CORE_MOD, config.indowedTraceEndEvent);
+      windowedTraceLocs.clear();
+  }
+
 }
 
 #ifdef __cplusplus
@@ -738,7 +749,7 @@ xrtHandles* aie2_trace_config_init (xclDeviceHandle handle, const xuid_t xclbin_
 
 // The main PS kernel functionality
 __attribute__((visibility("default")))
-int aie2_trace_config(uint8_t* input, uint8_t* output, uint8_t* messageOutput, xrtHandles* constructs)
+int aie2_trace_config(uint8_t* input, uint8_t* output, uint8_t* messageOutput, int iteration, xrtHandles* constructs)
 {
   if (constructs == nullptr)
     return 0;
@@ -758,29 +769,36 @@ int aie2_trace_config(uint8_t* input, uint8_t* output, uint8_t* messageOutput, x
   if (constructs->aieDev == nullptr)
     constructs->aieDev = new xaiefal::XAieDev(constructs->aieDevInst, false);
 
-  xdp::built_in::TraceInputConfiguration* params =
-    reinterpret_cast<xdp::built_in::TraceInputConfiguration*>(input);
-
   EventConfiguration config;
-  config.initialize(params);
 
-  xdp::built_in::MessageConfiguration* messageStruct = reinterpret_cast<xdp::built_in::MessageConfiguration*> (messageOutput);  
+  if (iteration == 0){
+    xdp::built_in::TraceInputConfiguration* params =
+      reinterpret_cast<xdp::built_in::TraceInputConfiguration*>(input);
+    config.initialize(params);
 
-  // Using malloc/free instead of new/delete because the struct treats the
-  // last element as a variable sized array
-  std::size_t total_size = sizeof(xdp::built_in::TraceOutputConfiguration) + sizeof(xdp::built_in::TileData[params->numTiles - 1]);
-  xdp::built_in::TraceOutputConfiguration* tilecfg =
-    (xdp::built_in::TraceOutputConfiguration*)malloc(total_size);
+    xdp::built_in::MessageConfiguration* messageStruct = reinterpret_cast<xdp::built_in::MessageConfiguration*> (messageOutput);  
 
-  tilecfg->numTiles = params->numTiles;
+    // Using malloc/free instead of new/delete because the struct treats the
+    // last element as a variable sized array
+    std::size_t total_size = sizeof(xdp::built_in::TraceOutputConfiguration) + sizeof(xdp::built_in::TileData[params->numTiles - 1]);
+    xdp::built_in::TraceOutputConfiguration* tilecfg =
+      (xdp::built_in::TraceOutputConfiguration*)malloc(total_size);
 
-  setMetricsSettings(constructs->aieDevInst, constructs->aieDev,
-                           config, params, tilecfg, messageStruct);
-  uint8_t* out = reinterpret_cast<uint8_t*>(tilecfg);
-  std::memcpy(output, out, total_size);   
+    tilecfg->numTiles = params->numTiles;
 
-  //Clean up
-  free(tilecfg); 
+    setMetricsSettings(constructs->aieDevInst, constructs->aieDev,
+                            config, params, tilecfg, messageStruct);
+    uint8_t* out = reinterpret_cast<uint8_t*>(tilecfg);
+    std::memcpy(output, out, total_size);   
+
+    //Clean up
+    free(tilecfg); 
+  }
+  // flush iteraiton
+  } else if (iteration == 1) {
+    flushAieTileTraceModule(constructs->aieDevInst, config, constructs->windowedTraceLocs);
+  }
+
   return 0;
 }
 

--- a/src/runtime_src/core/edge/ps_kernels/profiling/aie2_trace_config/event_configuration.h
+++ b/src/runtime_src/core/edge/ps_kernels/profiling/aie2_trace_config/event_configuration.h
@@ -34,6 +34,14 @@ struct EventConfiguration {
   XAie_Events coreTraceStartEvent = XAIE_EVENT_ACTIVE_CORE;
   XAie_Events coreTraceEndEvent = XAIE_EVENT_DISABLED_CORE; 
 
+   /*
+    * This is needed because the cores are started/stopped during execution
+    * to get around some hw bugs. We cannot restart tracemodules when that happens.
+    * At the end, we need to use event generate register to create this event
+    * to gracefully shut down trace modules.
+    */
+  XAie_Events windowedTraceEndEvent = XAIE_EVENT_INSTR_EVENT_1_CORE;
+
   // MEM tile trace is always on
   XAie_Events memTileTraceStartEvent = XAIE_EVENT_TRUE_MEM_TILE;
   XAie_Events memTileTraceEndEvent   = XAIE_EVENT_NONE_MEM_TILE;

--- a/src/runtime_src/core/edge/ps_kernels/profiling/aie_trace_config/aie_trace_config.cpp
+++ b/src/runtime_src/core/edge/ps_kernels/profiling/aie_trace_config/aie_trace_config.cpp
@@ -31,6 +31,7 @@ class xrtHandles : public pscontext
     XAie_DevInst* aieDevInst = nullptr;
     xaiefal::XAieDev* aieDev = nullptr;
     xclDeviceHandle handle = nullptr;
+    std::vector<XAie_LocType> windowedTraceLocs;
 
     xrtHandles() = default;
     ~xrtHandles()
@@ -168,9 +169,7 @@ bool tileHasFreeRsc(xaiefal::XAieDev* aieDevice, XAie_LocType& loc,
         return false;
 
     config.coreTraceStartEvent = counterEvent;
-    // This is needed because the cores are started/stopped during execution
-    // to get around some hw bugs. We cannot restart tracemodules when that happens
-    config.coreTraceEndEvent = XAIE_EVENT_NONE_CORE;
+    config.coreTraceEndEvent = config.windowedTraceEndEvent;
 
     return true;
   }
@@ -229,9 +228,7 @@ bool tileHasFreeRsc(xaiefal::XAieDev* aieDevice, XAie_LocType& loc,
     }
 
     config.coreTraceStartEvent = counterEvent;
-    // This is needed because the cores are started/stopped during execution
-    // to get around some hw bugs. We cannot restart tracemodules when that happens
-    config.coreTraceEndEvent = XAIE_EVENT_NONE_CORE;
+    config.coreTraceEndEvent = config.windowedTraceEndEvent;
 
     return true;
   }
@@ -411,11 +408,17 @@ bool tileHasFreeRsc(xaiefal::XAieDev* aieDevice, XAie_LocType& loc,
         // Delay cycles and user control are not compatible with each other
         if (params->useUserControl) {
           config.coreTraceStartEvent = XAIE_EVENT_INSTR_EVENT_0_CORE;
-          config.coreTraceEndEvent = XAIE_EVENT_INSTR_EVENT_1_CORE;
-        } else if (params->useGraphIterator && !configureStartIteration(core, config, params)) {
-          break;
-        } else if (params->useDelay && !configureStartDelay(core, config, params)) {
-          break;
+          config.coreTraceEndEvent = config.windowedTraceEndEvent;
+        } else if (params->useGraphIterator()){
+          if (!configureStartIteration(core,config,params)) 
+            break;
+          
+          windowedTraceLocs.push_back(loc);
+
+        } else if (params->useDelay){
+          if (!configureStartDelay(core, config, params))
+            break;
+          windowedTraceLocs.push_back(loc);
         }
 
         // Set overall start/end for trace capture
@@ -609,6 +612,16 @@ bool tileHasFreeRsc(xaiefal::XAieDev* aieDevice, XAie_LocType& loc,
     return 0;
   } // end setMetricsSettings
 
+  void flushAieTileTraceModule(XAie_DevInst* aieDevInst, EventConfiguration& config, std::vector<XAie_LocType>& windowedTraceLocs)
+  {
+    /*
+     * Flush for trace windowing
+     */
+    for (const auto& loc : windowedTraceLocs)
+      XAie_EventGenerate(aieDevInst, loc, XAIE_CORE_MOD, config.indowedTraceEndEvent);
+      windowedTraceLocs.clear();
+  }
+
 }
 
 #ifdef __cplusplus
@@ -629,7 +642,7 @@ xrtHandles* aie_trace_config_init (xclDeviceHandle handle, const xuid_t xclbin_u
 
 // The main PS kernel functionality
 __attribute__((visibility("default")))
-int aie_trace_config(uint8_t* input, uint8_t* output, uint8_t* messageOutput, xrtHandles* constructs)
+int aie_trace_config(uint8_t* input, uint8_t* output, uint8_t* messageOutput, int iteration, xrtHandles* constructs)
 {
   if (constructs == nullptr)
     return 0;
@@ -649,29 +662,38 @@ int aie_trace_config(uint8_t* input, uint8_t* output, uint8_t* messageOutput, xr
   if (constructs->aieDev == nullptr)
     constructs->aieDev = new xaiefal::XAieDev(constructs->aieDevInst, false);
 
-  xdp::built_in::TraceInputConfiguration* params =
-    reinterpret_cast<xdp::built_in::TraceInputConfiguration*>(input);
 
   EventConfiguration config;
-  config.initialize(params);
 
-  xdp::built_in::MessageConfiguration* messageStruct = reinterpret_cast<xdp::built_in::MessageConfiguration*> (messageOutput);  
+  // setup iteration
+  if (iteration == 0) {
+    xdp::built_in::TraceInputConfiguration* params =
+    reinterpret_cast<xdp::built_in::TraceInputConfiguration*>(input);
+    config.initialize(params);
 
-  // Using malloc/free instead of new/delete because the struct treats the
-  // last element as a variable sized array
-  std::size_t total_size = sizeof(xdp::built_in::TraceOutputConfiguration) + sizeof(xdp::built_in::TileData[params->numTiles - 1]);
-  xdp::built_in::TraceOutputConfiguration* tilecfg =
-    (xdp::built_in::TraceOutputConfiguration*)malloc(total_size);
+    xdp::built_in::MessageConfiguration* messageStruct = reinterpret_cast<xdp::built_in::MessageConfiguration*> (messageOutput);  
 
-  tilecfg->numTiles = params->numTiles;
-  setMetricsSettings(constructs->aieDevInst, constructs->aieDev,
-                           config, params, tilecfg, messageStruct);
+    // Using malloc/free instead of new/delete because the struct treats the
+    // last element as a variable sized array
+    std::size_t total_size = sizeof(xdp::built_in::TraceOutputConfiguration) + sizeof(xdp::built_in::TileData[params->numTiles - 1]);
+    xdp::built_in::TraceOutputConfiguration* tilecfg =
+      (xdp::built_in::TraceOutputConfiguration*)malloc(total_size);
 
-  uint8_t* out = reinterpret_cast<uint8_t*>(tilecfg);
-  std::memcpy(output, out, total_size);   
+    tilecfg->numTiles = params->numTiles;
+    setMetricsSettings(constructs->aieDevInst, constructs->aieDev,
+                            config, params, tilecfg, messageStruct);
 
-  //Clean up
-  free(tilecfg); 
+    uint8_t* out = reinterpret_cast<uint8_t*>(tilecfg);
+    std::memcpy(output, out, total_size);   
+
+    //Clean up
+    free(tilecfg); 
+
+  // flush iteraiton
+  } else if (iteration == 1) {
+    flushAieTileTraceModule(constructs->aieDevInst, config, constructs->windowedTraceLocs);
+  }
+
   return 0;
 }
 

--- a/src/runtime_src/core/edge/ps_kernels/profiling/aie_trace_config/aie_trace_config.cpp
+++ b/src/runtime_src/core/edge/ps_kernels/profiling/aie_trace_config/aie_trace_config.cpp
@@ -246,7 +246,7 @@ bool tileHasFreeRsc(xaiefal::XAieDev* aieDevice, XAie_LocType& loc,
                           EventConfiguration& config,
                           const xdp::built_in::TraceInputConfiguration* params,
                           xdp::built_in::TraceOutputConfiguration* tilecfg,
-                          xdp::built_in::MessageConfiguration* msgcfg)
+                          xdp::built_in::MessageConfiguration* msgcfg, std::vector<XAie_LocType>& windowedTraceLocs)
   {
     xaiefal::Logger::get().setLogLevel(xaiefal::LogLevel::DEBUG);
 
@@ -409,7 +409,7 @@ bool tileHasFreeRsc(xaiefal::XAieDev* aieDevice, XAie_LocType& loc,
         if (params->useUserControl) {
           config.coreTraceStartEvent = XAIE_EVENT_INSTR_EVENT_0_CORE;
           config.coreTraceEndEvent = config.windowedTraceEndEvent;
-        } else if (params->useGraphIterator()){
+        } else if (params->useGraphIterator){
           if (!configureStartIteration(core,config,params)) 
             break;
           
@@ -618,8 +618,8 @@ bool tileHasFreeRsc(xaiefal::XAieDev* aieDevice, XAie_LocType& loc,
      * Flush for trace windowing
      */
     for (const auto& loc : windowedTraceLocs)
-      XAie_EventGenerate(aieDevInst, loc, XAIE_CORE_MOD, config.indowedTraceEndEvent);
-      windowedTraceLocs.clear();
+      XAie_EventGenerate(aieDevInst, loc, XAIE_CORE_MOD, config.windowedTraceEndEvent);
+    windowedTraceLocs.clear();
   }
 
 }
@@ -681,7 +681,7 @@ int aie_trace_config(uint8_t* input, uint8_t* output, uint8_t* messageOutput, in
 
     tilecfg->numTiles = params->numTiles;
     setMetricsSettings(constructs->aieDevInst, constructs->aieDev,
-                            config, params, tilecfg, messageStruct);
+                            config, params, tilecfg, messageStruct, constructs->windowedTraceLocs);
 
     uint8_t* out = reinterpret_cast<uint8_t*>(tilecfg);
     std::memcpy(output, out, total_size);   

--- a/src/runtime_src/core/edge/ps_kernels/profiling/aie_trace_config/event_configuration.h
+++ b/src/runtime_src/core/edge/ps_kernels/profiling/aie_trace_config/event_configuration.h
@@ -34,6 +34,13 @@ struct EventConfiguration {
   XAie_Events coreTraceStartEvent = XAIE_EVENT_ACTIVE_CORE;
   XAie_Events coreTraceEndEvent = XAIE_EVENT_DISABLED_CORE; 
 
+  /*
+    * This is needed because the cores are started/stopped during execution
+    * to get around some hw bugs. We cannot restart tracemodules when that happens.
+    * At the end, we need to use event generate register to create this event
+    * to gracefully shut down trace modules.
+    */
+  XAie_Events windowedTraceEndEvent = XAIE_EVENT_INSTR_EVENT_1_CORE;
 
   std::map<xdp::built_in::MetricSet, std::vector<XAie_Events>> coreEventsBase;
   std::map<xdp::built_in::MetricSet, std::vector<XAie_Events>> memoryCrossEventsBase;

--- a/src/runtime_src/xdp/profile/plugin/aie_trace_new/x86/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace_new/x86/aie_trace.cpp
@@ -48,6 +48,20 @@ namespace xdp {
   using MessageConfiguration = xdp::built_in::MessageConfiguration;
   using Messages = xdp::built_in::Messages;
 
+  AieTrace_x86Impl::AieTrace_x86Impl(VPDatabase* database, std::shared_ptr<AieTraceMetadata> metadata)
+      : AieTraceImpl(database, metadata) 
+  {
+    auto spdevice = xrt_core::get_userpf_device(metadata->getHandle());
+    device = xrt::device(spdevice);
+  
+    auto uuid = device.get_xclbin_uuid();
+
+    if (metadata->getHardwareGen() == 1)
+      aie_trace_kernel = xrt::kernel(device, uuid.get(), "aie_trace_config");
+    else 
+      aie_trace_kernel = xrt::kernel(device, uuid.get(), "aie2_trace_config");
+  }
+
   void AieTrace_x86Impl::updateDevice() {
 
     //compile-time trace
@@ -142,42 +156,32 @@ namespace xdp {
 
     //Attempt to schedule the kernel and parse the tile configuration output
     try {
-      auto spdevice = xrt_core::get_userpf_device(handle);
-      auto device = xrt::device(spdevice);
-    
-      auto uuid = device.get_xclbin_uuid();
-      xrt::kernel aie_trace_kernel;
-      if (metadata->getHardwareGen() == 1)
-        aie_trace_kernel = xrt::kernel(device, uuid.get(), "aie_trace_config");
-      else 
-        aie_trace_kernel = xrt::kernel(device, uuid.get(), "aie2_trace_config");
-
       //input bo  
-      auto bo0 = xrt::bo(device, INPUT_SIZE, 2);
-      auto bo0_map = bo0.map<uint8_t*>();
-      std::fill(bo0_map, bo0_map + INPUT_SIZE, 0);
+      auto inbo = xrt::bo(device, INPUT_SIZE, 2);
+      auto inbo_map = inbo.map<uint8_t*>();
+      std::fill(inbo_map, inbo_map + INPUT_SIZE, 0);
    
       //output bo
-      auto outTileConfigbo = xrt::bo(device, OUTPUT_SIZE, 2);
-      auto outTileConfigbomapped = outTileConfigbo.map<uint8_t*>();
-      memset(outTileConfigbomapped, 0, OUTPUT_SIZE);
+      auto outbo = xrt::bo(device, OUTPUT_SIZE, 2);
+      auto outbo_map = outbo.map<uint8_t*>();
+      memset(outbo_map, 0, OUTPUT_SIZE);
 
       //message_output_bo
       auto messagebo = xrt::bo(device, MSG_OUTPUT_SIZE, 2);
-      auto messagebomapped = messagebo.map<uint8_t*>();
-      memset(messagebomapped, 0, MSG_OUTPUT_SIZE);
+      auto messagebo_map = messagebo.map<uint8_t*>();
+      memset(messagebo_map, 0, MSG_OUTPUT_SIZE);
 
-      std::memcpy(bo0_map, input, total_size);
-      bo0.sync(XCL_BO_SYNC_BO_TO_DEVICE, INPUT_SIZE, 0);
+      std::memcpy(inbo_map, input, total_size);
+      inbo.sync(XCL_BO_SYNC_BO_TO_DEVICE, INPUT_SIZE, 0);
 
-      auto run = aie_trace_kernel(bo0, outTileConfigbo, messagebo);
+      auto run = aie_trace_kernel(inbo, outbo, messagebo, 0 /*setup iteration*/);
       run.wait();
 
-      outTileConfigbo.sync(XCL_BO_SYNC_BO_FROM_DEVICE, OUTPUT_SIZE, 0);
-      TraceOutputConfiguration* cfg = reinterpret_cast<TraceOutputConfiguration*>(outTileConfigbomapped);
+      outbo.sync(XCL_BO_SYNC_BO_FROM_DEVICE, OUTPUT_SIZE, 0);
+      TraceOutputConfiguration* cfg = reinterpret_cast<TraceOutputConfiguration*>(outbo_map);
 
       messagebo.sync(XCL_BO_SYNC_BO_FROM_DEVICE, MSG_OUTPUT_SIZE, 0);
-      uint8_t* msgStruct = reinterpret_cast<uint8_t*>(messagebomapped);
+      uint8_t* msgStruct = reinterpret_cast<uint8_t*>(messagebo_map);
       parseMessages(msgStruct);
 
       // Update the config tiles
@@ -270,6 +274,37 @@ namespace xdp {
     
     free(input_params);
     return true; //placeholder
+  }
+
+  void AieTrace_x86Impl::flushAieTileTraceModule (){
+
+    try { 
+      //input bo
+      auto inbo = xrt::bo(device, INPUT_SIZE, 2);
+      auto inbo_map = inbo.map<uint8_t*>();
+      memset(inbo_map, 0, INPUT_SIZE); 
+    
+      //output bo
+      auto outbo = xrt::bo(device, OUTPUT_SIZE, 2);
+      auto outbo_map = outbo.map<uint8_t*>();
+      memset(outbo_map, 0, OUTPUT_SIZE);
+
+      //message_output_bo
+      auto messagebo = xrt::bo(device, MSG_OUTPUT_SIZE, 2);
+      auto messagebo_map = messagebo.map<uint8_t*>();
+      memset(messagebo_map, 0, MSG_OUTPUT_SIZE);
+
+      auto run = aie_trace_kernel(inbo, outbo, messagebo, 1 /*flush iteration*/);
+      run.wait();
+
+    } catch (...) {
+      std::string msg = "The aie_trace_config flush failed.";
+      xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", msg);  
+      return;  
+    } 
+
+    std::string msg = "The aie_trace_config flush was successfully scheduled.";
+    xrt_core::message::send(xrt_core::message::severity_level::info, "XRT", msg);
   }
 
 

--- a/src/runtime_src/xdp/profile/plugin/aie_trace_new/x86/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace_new/x86/aie_trace.cpp
@@ -40,6 +40,7 @@
 constexpr uint32_t MAX_TILES = 400;
 constexpr uint64_t ALIGNMENT_SIZE = 4096;
 
+
 namespace xdp {
   using severity_level = xrt_core::message::severity_level;
   using TraceInputConfiguration = xdp::built_in::TraceInputConfiguration;
@@ -47,6 +48,11 @@ namespace xdp {
   using TraceTileType = xdp::built_in::TraceTileType;
   using MessageConfiguration = xdp::built_in::MessageConfiguration;
   using Messages = xdp::built_in::Messages;
+
+  constexpr uint64_t OUTPUT_SIZE = ALIGNMENT_SIZE * 38; //Calculated maximum output size for all 400 tiles
+  constexpr uint64_t INPUT_SIZE = ALIGNMENT_SIZE; // input/output must be aligned to 4096
+  constexpr uint64_t MSG_OUTPUT_SIZE = ALIGNMENT_SIZE * ((sizeof(MessageConfiguration)%ALIGNMENT_SIZE) > 0 
+  ? (sizeof(MessageConfiguration)/ALIGNMENT_SIZE) + 1 : (sizeof(MessageConfiguration)%ALIGNMENT_SIZE));
 
   AieTrace_x86Impl::AieTrace_x86Impl(VPDatabase* database, std::shared_ptr<AieTraceMetadata> metadata)
       : AieTraceImpl(database, metadata) 
@@ -92,13 +98,7 @@ namespace xdp {
 
   bool AieTrace_x86Impl::setMetricsSettings(uint64_t deviceId, void* handle) {
       
-    constexpr uint64_t OUTPUT_SIZE = ALIGNMENT_SIZE * 38; //Calculated maximum output size for all 400 tiles
-    constexpr uint64_t INPUT_SIZE = ALIGNMENT_SIZE; // input/output must be aligned to 4096
-    constexpr uint64_t MSG_OUTPUT_SIZE = ALIGNMENT_SIZE * ((sizeof(MessageConfiguration)%ALIGNMENT_SIZE) > 0 
-    ? (sizeof(MessageConfiguration)/ALIGNMENT_SIZE) + 1 : (sizeof(MessageConfiguration)%ALIGNMENT_SIZE));
-
     //Gather data to send to PS Kernel
-
     if (!metadata->getIsValidMetrics()) {
       std::string msg("AIE trace metrics were not specified in xrt.ini. AIE event trace will not be available.");
       xrt_core::message::send(severity_level::warning, "XRT", msg);

--- a/src/runtime_src/xdp/profile/plugin/aie_trace_new/x86/aie_trace.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace_new/x86/aie_trace.h
@@ -19,6 +19,7 @@
 
 #include <cstdint>
 
+#include "core/include/xrt/xrt_kernel.h"
 #include "xdp/profile/plugin/aie_trace_new/aie_trace_impl.h"
 
 namespace xdp {

--- a/src/runtime_src/xdp/profile/plugin/aie_trace_new/x86/aie_trace.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace_new/x86/aie_trace.h
@@ -26,17 +26,18 @@ namespace xdp {
   class AieTrace_x86Impl : public AieTraceImpl{
 
     public:
-      AieTrace_x86Impl(VPDatabase* database, std::shared_ptr<AieTraceMetadata> metadata)
-        : AieTraceImpl(database, metadata){}
+      AieTrace_x86Impl(VPDatabase* database, std::shared_ptr<AieTraceMetadata> metadata);
       ~AieTrace_x86Impl() = default;
       virtual void updateDevice();
+      virtual void flushAieTileTraceModule();
       bool setMetricsSettings(uint64_t deviceId, void* handle);
       uint64_t checkTraceBufSize(uint64_t size);
       void parseMessages(uint8_t* messages);
       module_type getTileType(uint16_t absRow);
-
-      public:
-      virtual void flushAieTileTraceModule() {}
+    private:
+      xrt::device device;
+      xrt::kernel aie_trace_kernel;
+    
   };
 
 }   


### PR DESCRIPTION
#### Problem solved by the commit
Generate Event 1 at the end to gracefully shutdown trace module. This helps get complete trace in AIE1 and AIE2 on PCIe devices.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
N/A
#### How problem was solved, alternative solutions (if any) and why they were rejected

Created new PS kernel iteration for AIE1 and AIE2 Trace for flushing.

#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
