### PR TITLE
Fixed aie metadat sysfs issue and xbutil reset for DFX platform

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
@@ -1196,6 +1196,9 @@ zocl_reset(struct drm_zocl_dev *zdev, const char *buf, size_t count)
                 mutex_unlock(&z_slot->slot_xclbin_lock);
         }
 
+	/* Cleanup the AIE here */
+	zocl_cleanup_aie(zdev);
+
 #define PL_RESET_ADDRESS                0x00F1260330
 #define PL_HOLD_VAL                     0xF
 #define PL_RELEASE_VAL                  0x0

--- a/src/runtime_src/core/edge/drm/zocl/zocl_sysfs.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_sysfs.c
@@ -317,7 +317,7 @@ static ssize_t read_aie_metadata(struct file *filp, struct kobject *kobj,
 
 	for (i = 0; i < MAX_PR_SLOT_NUM; i++) {
 		zocl_slot = zdev->pr_slot[i];
-		if (!zocl_slot)
+		if (!zocl_slot || !zocl_slot->aie_data.size)
 			continue;
 
 		size = zocl_slot->aie_data.size;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
For DFX platform before cleanup the AIE, we have a check i.e. 
```
 if (zocl_xclbin_get_uuid(slot) != NULL)  {
   zocl_cleanup_aie(zdev);
 }
```
For reset support we are cleaning up the uuid for all the slots available. In that case we are never going to cleanup AIE for DFX case. Hence, we should cleanup the AIE from the reset only. For aie only case, before loading the XCLBIN we are cleaning up the AIE.  

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
N/A

#### How problem was solved, alternative solutions (if any) and why they were rejected
N/A

#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
Basic validate

#### Documentation impact (if any)
N/A