### PR TITLE
CR-1150547: Disable events are missing for AIE tile trace in runtime mode for AIE-ML

### DIFF
--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -807,6 +807,13 @@ get_aie_trace_settings_start_type()
 }
 
 inline std::string
+get_aie_trace_settings_end_type()
+{
+  static std::string value = detail::get_string_value("AIE_trace_settings.end_type", "disable_event");
+  return value;
+}
+
+inline std::string
 get_aie_trace_settings_start_time()
 {
   static std::string value = detail::get_string_value("AIE_trace_settings.start_time", "0");

--- a/src/runtime_src/xdp/profile/database/static_info/aie_constructs.h
+++ b/src/runtime_src/xdp/profile/database/static_info/aie_constructs.h
@@ -245,8 +245,8 @@ enum class module_type {
   public:
     bool port_trace_is_master[NUM_MEM_TILE_PORTS] = {};
     uint8_t port_trace_ids[NUM_MEM_TILE_PORTS] = {};
-    uint8_t s2mm_channels[NUM_MEM_TILE_CHAN_SEL] = {};
-    uint8_t mm2s_channels[NUM_MEM_TILE_CHAN_SEL] = {};
+    int8_t s2mm_channels[NUM_MEM_TILE_CHAN_SEL] = {-1, -1};
+    int8_t mm2s_channels[NUM_MEM_TILE_CHAN_SEL] = {-1, -1};
     aie_cfg_mem_tile() : aie_cfg_base(4) {}
   };
 

--- a/src/runtime_src/xdp/profile/plugin/aie_profile_new/aie_profile_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile_new/aie_profile_metadata.cpp
@@ -729,10 +729,10 @@ namespace xdp {
 
     // Set default, check validity, and remove "off" tiles
     auto defaultSet = defaultSets[moduleIdx];
-    for (auto &e : allValidTiles) {
-      if (configMetrics[moduleIdx].find(e) == configMetrics[moduleIdx].end())
-        configMetrics[moduleIdx][e] = defaultSet;
-    }
+    //for (auto &e : allValidTiles) {
+    //  if (configMetrics[moduleIdx].find(e) == configMetrics[moduleIdx].end())
+    //    configMetrics[moduleIdx][e] = defaultSet;
+    //}
 
     bool showWarning = true;
     std::vector<tile_type> offTiles;
@@ -889,12 +889,12 @@ namespace xdp {
 
     // Set default, check validity, and remove "off" tiles
     auto defaultSet = defaultSets[moduleIdx];
-    auto totalTiles = get_interface_tiles(device.get(), defaultSet, -1);
-    for (auto &e : totalTiles) {
-      if (configMetrics[moduleIdx].find(e) == configMetrics[moduleIdx].end()) {
-        configMetrics[moduleIdx][e] = defaultSet;
-      }
-    }
+    //auto totalTiles = get_interface_tiles(device.get(), defaultSet, -1);
+    //for (auto &e : totalTiles) {
+    //  if (configMetrics[moduleIdx].find(e) == configMetrics[moduleIdx].end()) {
+    //    configMetrics[moduleIdx][e] = defaultSet;
+    //  }
+    //}
 
     bool showWarning = true;
     std::vector<tile_type> offTiles;

--- a/src/runtime_src/xdp/profile/plugin/aie_trace_new/aie_trace_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace_new/aie_trace_metadata.cpp
@@ -836,10 +836,10 @@ namespace xdp {
 
     // Set default, check validity, and remove "off" tiles
     auto defaultSet = defaultSets[type];
-    for (auto &e : allValidTiles) {
-      if (configMetrics.find(e) == configMetrics.end())
-        configMetrics[e] = defaultSet;
-    }
+    //for (auto &e : allValidTiles) {
+    //  if (configMetrics.find(e) == configMetrics.end())
+    //    configMetrics[e] = defaultSet;
+    //}
 
     bool showWarning = true;
     std::vector<tile_type> offTiles;

--- a/src/runtime_src/xdp/profile/plugin/aie_trace_new/edge/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace_new/edge/aie_trace.cpp
@@ -403,7 +403,9 @@ namespace xdp {
       mCoreTraceEndEvent = mTraceFlushEndEvent;
       mMemTileTraceEndEvent = mMemTileTraceFlushEndEvent;
       useTraceFlush = true;
-      std::cout << "!!!! Using trace flush!" << std::endl;
+
+      if (xrt_core::config::get_verbosity() >= static_cast<uint32_t>(severity_level::info))
+        xrt_core::message::send(severity_level::info, "XRT", "Enabling trace flush");
     }
     
     // Iterate over all used/specified tiles
@@ -477,7 +479,7 @@ namespace xdp {
         for (int i=0; i < mCoreCounterStartEvents.size(); ++i) {
           auto perfCounter = core.perfCounter();
           if (perfCounter->initialize(mod, mCoreCounterStartEvents.at(i),
-                                      mod, mCoreCounterStartEvents.at(i)) != XAIE_OK)
+                                      mod, mCoreCounterEndEvents.at(i)) != XAIE_OK)
             break;
           if (perfCounter->reserve() != XAIE_OK) 
             break;
@@ -534,7 +536,7 @@ namespace xdp {
           XAie_Events counterEvent;
           perfCounter->getCounterEvent(mod, counterEvent);
           int idx = static_cast<int>(counterEvent) - static_cast<int>(XAIE_EVENT_PERF_CNT_0_MEM);
-          perfCounter->changeThreshold(mMemoryCounterEndEvents.at(i));
+          perfCounter->changeThreshold(mMemoryCounterEventValues.at(i));
 
           perfCounter->changeRstEvent(mod, counterEvent);
           memoryEvents.push_back(counterEvent);

--- a/src/runtime_src/xdp/profile/plugin/aie_trace_new/edge/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace_new/edge/aie_trace.cpp
@@ -101,12 +101,12 @@ namespace xdp {
     mCoreTraceEndEvent   = XAIE_EVENT_DISABLED_CORE;
 
     /*
-     * This is needed because the cores are started/stopped during execution
-     * to get around some hw bugs. We cannot restart tracemodules when that happens.
-     * At the end, we need to use event generate register to create this event
-     * to gracefully shut down trace modules.
+     * This is needed because the last trace packet needs to be "flushed".
+     * To output the last packet, we use event generate register to create 
+     * this event and gracefully shut down trace modules.
      */
-    mWindowedTraceEndEvent = XAIE_EVENT_INSTR_EVENT_1_CORE;
+    mTraceFlushEndEvent = XAIE_EVENT_INSTR_EVENT_1_CORE;
+    mMemTileTraceFlushEndEvent = XAIE_EVENT_USER_EVENT_1_MEM_TILE;
 
     // **** Memory Module Trace ****
     // NOTE 1: Core events listed here are broadcast by the resource manager
@@ -392,6 +392,20 @@ namespace xdp {
     auto configChannel0 = metadata->getConfigChannel0();
     auto configChannel1 = metadata->getConfigChannel1();
 
+    // Decide when to use user event for trace end to enable flushing
+    bool useTraceFlush = false;
+    if ((metadata->getUseUserControl())
+        || (metadata->getUseGraphIterator())
+        || (metadata->getUseDelay())
+        || (xrt_core::config::get_aie_trace_settings_end_type() == "event1")) {
+      if (metadata->getUseUserControl())
+        mCoreTraceStartEvent = XAIE_EVENT_INSTR_EVENT_0_CORE;
+      mCoreTraceEndEvent = mTraceFlushEndEvent;
+      mMemTileTraceEndEvent = mMemTileTraceFlushEndEvent;
+      useTraceFlush = true;
+      std::cout << "!!!! Using trace flush!" << std::endl;
+    }
+    
     // Iterate over all used/specified tiles
     // NOTE: rows are stored as absolute as required by resource manager
     for (auto& tileMetric : metadata->getConfigMetrics()) {
@@ -406,6 +420,14 @@ namespace xdp {
         core          = aieDevice->tile(col, row).core();
       auto& memory    = aieDevice->tile(col, row).mem();
       auto loc        = XAie_TileLoc(col, row);
+
+      // Store location to flush at end of run
+      if (useTraceFlush) {
+        if (type == module_type::core)
+          mTraceFlushLocs.push_back(loc);
+        else if (type == module_type::mem_tile)
+          mMemTileTraceFlushLocs.push_back(loc);
+      }
 
       // AIE config object for this tile
       auto cfgTile  = std::make_unique<aie_cfg_tile>(col, row, type);
@@ -427,7 +449,7 @@ namespace xdp {
 
       if (xrt_core::config::get_verbosity() >= static_cast<uint32_t>(severity_level::info)) {
         std::stringstream infoMsg;
-        auto tileName = (type == module_type::mem_tile) ? "MEM" : "AIE";
+        auto tileName = (type == module_type::mem_tile) ? "memory" : "AIE";
         infoMsg << "Configuring " << tileName << " tile (" << col << "," << row
                 << ") for trace using metric set " << metricSet;
         xrt_core::message::send(severity_level::info, "XRT", infoMsg.str());
@@ -560,17 +582,12 @@ namespace xdp {
         auto coreTrace = core.traceControl();
 
         // Delay cycles and user control are not compatible with each other
-        if (metadata->getUseUserControl()) {
-          mCoreTraceStartEvent = XAIE_EVENT_INSTR_EVENT_0_CORE;
-          mCoreTraceEndEvent = mWindowedTraceEndEvent;
-        } else if (metadata->getUseGraphIterator()) {
+        if (metadata->getUseGraphIterator()) {
           if (!configureStartIteration(core))
             break;
-          mWindowedTraceLocs.push_back(loc);
         } else if (metadata->getUseDelay()) {
           if (!configureStartDelay(core))
             break;
-          mWindowedTraceLocs.push_back(loc);
         }
 
         // Set overall start/end for trace capture
@@ -952,8 +969,6 @@ namespace xdp {
     }
 
     mCoreTraceStartEvent = counterEvent;
-    mCoreTraceEndEvent = mWindowedTraceEndEvent;
-
     return true;
   }
 
@@ -988,8 +1003,6 @@ namespace xdp {
     }
 
     mCoreTraceStartEvent = counterEvent;
-    mCoreTraceEndEvent = mWindowedTraceEndEvent;
-
     return true;
   }
 
@@ -999,10 +1012,14 @@ namespace xdp {
     aieDevInst = static_cast<XAie_DevInst*>(db->getStaticInfo().getAieDevInst(fetchAieDevInst, handle));
 
     /*
-     * Flush for trace windowing
+     * Flush trace if requested or required
      */
-    for (const auto& loc : mWindowedTraceLocs)
-      XAie_EventGenerate(aieDevInst, loc, XAIE_CORE_MOD, mWindowedTraceEndEvent);
-    mWindowedTraceLocs.clear();
+    for (const auto& loc : mTraceFlushLocs)
+      XAie_EventGenerate(aieDevInst, loc, XAIE_CORE_MOD, mTraceFlushEndEvent);
+    for (const auto& loc : mTraceFlushLocs)
+      XAie_EventGenerate(aieDevInst, loc, XAIE_MEM_MOD, mMemTileTraceFlushEndEvent);
+
+    mTraceFlushLocs.clear();
+    mMemTileTraceFlushLocs.clear();
   }
 }

--- a/src/runtime_src/xdp/profile/plugin/aie_trace_new/edge/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace_new/edge/aie_trace.cpp
@@ -1013,12 +1013,20 @@ namespace xdp {
     auto handle = metadata->getHandle();
     aieDevInst = static_cast<XAie_DevInst*>(db->getStaticInfo().getAieDevInst(fetchAieDevInst, handle));
 
-    /*
-     * Flush trace if requested or required
-     */
+    // Flush trace if requested or required
+    if (((mTraceFlushLocs.size() > 0) || (mMemTileTraceFlushLocs.size() > 0))
+        && (xrt_core::config::get_verbosity() >= static_cast<uint32_t>(severity_level::info))) {
+      std::stringstream msg;
+      msg << "Flushing AIE trace by forcing end event for "
+          << mTraceFlushLocs.size() << " AIE tiles";
+      if (metadata->getHardwareGen() > 1)
+        msg << " and " << mMemTileTraceFlushLocs.size() << " memory tiles";
+      xrt_core::message::send(severity_level::info, "XRT", msg.str());
+    }
+
     for (const auto& loc : mTraceFlushLocs)
       XAie_EventGenerate(aieDevInst, loc, XAIE_CORE_MOD, mTraceFlushEndEvent);
-    for (const auto& loc : mTraceFlushLocs)
+    for (const auto& loc : mMemTileTraceFlushLocs)
       XAie_EventGenerate(aieDevInst, loc, XAIE_MEM_MOD, mMemTileTraceFlushEndEvent);
 
     mTraceFlushLocs.clear();

--- a/src/runtime_src/xdp/profile/plugin/aie_trace_new/edge/aie_trace.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace_new/edge/aie_trace.h
@@ -87,7 +87,8 @@ namespace xdp {
       EventType   mCoreTraceEndEvent;
       EventType   mMemTileTraceStartEvent;
       EventType   mMemTileTraceEndEvent;
-      EventType   mWindowedTraceEndEvent;
+      EventType   mTraceFlushEndEvent;
+      EventType   mMemTileTraceFlushEndEvent;
 
       EventVector mCoreCounterStartEvents;
       EventVector mCoreCounterEndEvents;
@@ -97,9 +98,9 @@ namespace xdp {
       EventVector mMemoryCounterEndEvents;
       ValueVector mMemoryCounterEventValues;
 
-      // Tile locations using windowed trace
-      std::vector<XAie_LocType> mWindowedTraceLocs;
-
+      // Tile locations to apply trace end and flush
+      std::vector<XAie_LocType> mTraceFlushLocs;
+      std::vector<XAie_LocType> mMemTileTraceFlushLocs;
   };
 
 }   


### PR DESCRIPTION
**Problem solved by the commit**
AIE2 trace can sometimes not include finalize events
 
**How problem was solved, alternative solutions (if any) and why they were rejected**
Force trace "flush" by generating trace end event

**Risks (if any) associated the changes in the commit**
chosen event1 is used by another process or by user
 
**What has been tested and how, request additional testing if necessary**
Tested on vck190 and vek280

**Documentation impact (if any)**
trace end (may be hidden since late in release and unsure of full impact)
