### PR TITLE
Update dynamic regions to better display PL and PS kernels

### DIFF
--- a/src/runtime_src/core/common/info_memory.cpp
+++ b/src/runtime_src/core/common/info_memory.cpp
@@ -1,19 +1,6 @@
-/**
- * Copyright (C) 2021, 2022 Xilinx, Inc
- * Copyright (C) 2023 Advanced Micro Devices, Inc
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2021-2022 Xilinx, Inc
+// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
 #define XRT_CORE_COMMON_SOURCE
 #include "info_memory.h"
 #include "ps_kernel.h"
@@ -596,6 +583,8 @@ populate_hardware_context(const xrt_core::device* device)
   if (hw_context_stats.empty()) {
     xq::hw_context_info::data_type hw_context;
 
+    hw_context.id = "0";
+
     try {
       hw_context.xclbin_uuid = xrt_core::device_query<xq::xclbin_uuid>(device);
     }
@@ -620,7 +609,8 @@ populate_hardware_context(const xrt_core::device* device)
 
   for (const auto& hw : hw_context_stats) {
     ptree_type pt_hw;
-    pt_hw.put( "xclbin_uuid", boost::algorithm::to_upper_copy(hw.xclbin_uuid));
+    pt_hw.put("id", boost::algorithm::to_upper_copy(hw.id));
+    pt_hw.put("xclbin_uuid", boost::algorithm::to_upper_copy(hw.xclbin_uuid));
     pt_hw.add_child("compute_units", populate_cus(device, hw.pl_compute_units, hw.ps_compute_units));
     pt.push_back(std::make_pair("", pt_hw));
   }

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -939,6 +939,7 @@ struct hw_context_info : request
    *  Versal -> populate PL and PS compute units
    */
   struct data {
+    std::string id;
     std::string xclbin_uuid;
     kds_cu_info::result_type pl_compute_units;
     kds_scu_info::result_type ps_compute_units;

--- a/src/runtime_src/core/tools/common/ReportDynamicRegion.cpp
+++ b/src/runtime_src/core/tools/common/ReportDynamicRegion.cpp
@@ -54,12 +54,13 @@ ReportDynamicRegion::writeReport( const xrt_core::device* /*_pDevice*/,
     const boost::property_tree::ptree& dfx = k_dfx.second;
     _output << boost::format("  Hardware Context ID: %s\n") % dfx.get<std::string>("id", "N/A");
     _output << boost::format("    Xclbin UUID: %s\n") % dfx.get<std::string>("xclbin_uuid", "N/A");
-    const Table2D::HeaderData index = {"Index", Table2D::Justification::left};
-    const Table2D::HeaderData name = {"Name", Table2D::Justification::left};
-    const Table2D::HeaderData address = {"Base Address", Table2D::Justification::left};
-    const Table2D::HeaderData usage = {"Usage", Table2D::Justification::left};
-    const Table2D::HeaderData status = {"Status", Table2D::Justification::left};
-    const std::vector<Table2D::HeaderData> table_headers = {index, name, address, usage, status};
+    const std::vector<Table2D::HeaderData> table_headers = {
+      {"Index", Table2D::Justification::left},
+      {"Name", Table2D::Justification::left},
+      {"Base Address", Table2D::Justification::left},
+      {"Usage", Table2D::Justification::left},
+      {"Status", Table2D::Justification::left}
+    };
     Table2D pl_table(table_headers);
     Table2D ps_table(table_headers);
 

--- a/src/runtime_src/core/tools/common/ReportDynamicRegion.cpp
+++ b/src/runtime_src/core/tools/common/ReportDynamicRegion.cpp
@@ -52,7 +52,8 @@ ReportDynamicRegion::writeReport( const xrt_core::device* /*_pDevice*/,
 
   for(auto& k_dfx : pt_dfx) {
     const boost::property_tree::ptree& dfx = k_dfx.second;
-    _output << "  Compute Units" << std::endl;
+    _output << boost::format("  Hardware Context ID: %s\n") % dfx.get<std::string>("id", "N/A");
+    _output << boost::format("    Xclbin UUID: %s\n") % dfx.get<std::string>("xclbin_uuid", "N/A");
     const Table2D::HeaderData index = {"Index", Table2D::Justification::left};
     const Table2D::HeaderData name = {"Name", Table2D::Justification::left};
     const Table2D::HeaderData address = {"Base Address", Table2D::Justification::left};
@@ -84,12 +85,12 @@ ReportDynamicRegion::writeReport( const xrt_core::device* /*_pDevice*/,
 
     if (!pl_table.empty()) {
       _output << "    PL Compute Units\n";
-      _output << pl_table.toString("    ") << "\n";
+      _output << pl_table.toString("      ") << "\n";
     }
 
     if (!ps_table.empty()) {
       _output << "    PS Compute Units\n";
-      _output << ps_table.toString("    ") << "\n";
+      _output << ps_table.toString("      ") << "\n";
     }
   }
 

--- a/src/runtime_src/core/tools/common/Table2D.h
+++ b/src/runtime_src/core/tools/common/Table2D.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2022 Xilinx, Inc
-// Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
 
 #ifndef __Table2D_h_
 #define __Table2D_h_
@@ -39,6 +39,19 @@ class Table2D {
     std::string toString(const std::string& prefix = "") const;
 
     size_t getTableCharacterLength() const;
+
+    bool empty() const
+    {
+        // Check if headers have been added
+        if (m_table.empty())
+            return true;
+
+        // Check if anything other than headers have been added
+        if (m_table[0].data.empty())
+            return true;
+
+        return false;
+    }
 
  private:
     typedef struct ColumnData {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Update the dynamic regions report to display hardware context ID. Prevent printout of compute unit headers if no units of that type are present

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
After the display discussion we determined we should add a hardware context ID to the dynamic report output. The code has been refactored to use the common table logic for displaying correlated data.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added hardware context id into dynamic region report.

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Ubuntu 20.04 U55C
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov/XRT$ xbutil examine -d 04:00 -r dynamic-regions
WARNING: Unexpected xocl version (2.14.0) was found. Expected 2.15.0, to match XRT tools.

-------------------------------------------------
[0000:04:00.1] : xilinx_u55c_gen3x16_xdma_base_3
-------------------------------------------------
  Hardware Context ID: 0
    Xclbin UUID: E106E953-CF90-4024-E075-282D1A7D820B
    PL Compute Units
      Index  Name             Base Address  Usage  Status
      -----------------------------------------------------
      0      verify:verify_1  0x800000      4      (IDLE)
```

#### Documentation impact (if any)
None