### PR TITLE
CR-1158827 set aie clock rate correctly for trace

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info_database.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info_database.cpp
@@ -2025,7 +2025,6 @@ namespace xdp {
  
     setDeviceNameFromXclbin(deviceId, xrtXclbin);
     setAIEGeneration(deviceId, xrtXclbin);
-    setAIEClockRateMHz(deviceId, xrtXclbin);
 
     /* Configure AMs if context monitoring is supported
      * else disable alll AMs on this device
@@ -2040,6 +2039,9 @@ namespace xdp {
     devInfo->addXclbin(currentXclbin);
     initializeProfileMonitors(devInfo, xrtXclbin);
     devInfo->isReady = true;
+
+    // Add aie clock to xclbin
+    setAIEClockRateMHz(deviceId, xrtXclbin);
 
     return devInfo;
 

--- a/src/runtime_src/xdp/profile/plugin/aie_trace_new/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace_new/aie_trace_plugin.cpp
@@ -99,16 +99,8 @@ namespace xdp {
 
     auto deviceID = getDeviceIDFromHandle(handle);
     AIEData.deviceID = deviceID;
-    AIEData.metadata = std::make_shared<AieTraceMetadata>(deviceID, handle);
     AIEData.valid = true; // initialize struct
     AIEData.devIntf = nullptr;
-
-#ifdef XRT_X86_BUILD
-    AIEData.implementation = std::make_unique<AieTrace_x86Impl>(db, AIEData.metadata);
-#else
-    AIEData.implementation = std::make_unique<AieTrace_EdgeImpl>(db, AIEData.metadata);
-#endif
-
 
     // Get Device info // Investigate further (isDeviceReady should be always called??)
     if (!(db->getStaticInfo()).isDeviceReady(deviceID)) {
@@ -120,7 +112,15 @@ namespace xdp {
           (db->getStaticInfo()).setDeviceName(deviceID, std::string(info.mName));
       }
     }
-    
+
+    // Metadata depends on static information from the database
+    AIEData.metadata = std::make_shared<AieTraceMetadata>(deviceID, handle);
+#ifdef XRT_X86_BUILD
+    AIEData.implementation = std::make_unique<AieTrace_x86Impl>(db, AIEData.metadata);
+#else
+    AIEData.implementation = std::make_unique<AieTrace_EdgeImpl>(db, AIEData.metadata);
+#endif
+
     // Check for device interface
     DeviceIntf* deviceIntf = (db->getStaticInfo()).getDeviceIntf(deviceID);
     if (deviceIntf == nullptr) 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
AIE trace was using default clock of 1000Mhz instead of getting it from xclbin
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Tested on a lab8 design
#### Documentation impact (if any)
