### PR TITLE
CR-1154328 Revert back vck5000's aie-pl test xclbin name

### DIFF
--- a/tests/validate/aie_pl_test/src/host.cpp
+++ b/tests/validate/aie_pl_test/src/host.cpp
@@ -300,7 +300,7 @@ main(int argc, char* argv[])
     // For AIE1 need to use a different xclbin name
     std::string b_file = "pl_controller_aie.xclbin";
     if(hw_gen == 1)
-	b_file  = "vck5000_pcie_pl_controller.xclbin";
+	b_file  = "vck5000_pcie_pl_controller.xclbin.xclbin";
     
     auto binaryFile = boost::filesystem::path(test_path) / b_file;
     std::ifstream infile(binaryFile.string());


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
vck5000 platform's aie-pl xclbin name has not been updated, so revert back the xclbin name to conform to the existing one since there is no plan to make the change

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit
none

#### What has been tested and how, request additional testing if necessary
aie-pl test on vck5000

#### Documentation impact (if any)
None