### PR TITLE
CR-1158565 update_access_mode: Operation not supported

### DIFF
--- a/src/runtime_src/core/edge/sw_emu/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/edge/sw_emu/generic_pcie_hal2/shim.h
@@ -65,6 +65,12 @@ namespace xclswemuhal2 {
         , m_mode(mode)
       {}
 
+      void
+      update_access_mode(access_mode mode) override
+      {
+        m_mode = mode;
+      }
+
       slot_id
       get_slotidx() const override
       {

--- a/src/runtime_src/core/edge/user/shim.h
+++ b/src/runtime_src/core/edge/user/shim.h
@@ -53,6 +53,12 @@ public:
       , m_mode(mode)
     {}
 
+    void
+    update_access_mode(access_mode mode) override
+    {
+      m_mode = mode;
+    }
+
     slot_id
     get_slotidx() const override
     {

--- a/src/runtime_src/core/pcie/emulation/hw_emu/alveo_shim/shim.h
+++ b/src/runtime_src/core/pcie/emulation/hw_emu/alveo_shim/shim.h
@@ -117,6 +117,12 @@ using addr_type = uint64_t;
         , m_mode(mode)
       {}
 
+      void
+      update_access_mode(access_mode mode) override
+      {
+        m_mode = mode;
+      }
+
       slot_id
       get_slotidx() const override
       {

--- a/src/runtime_src/core/pcie/emulation/sw_emu/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/pcie/emulation/sw_emu/generic_pcie_hal2/shim.h
@@ -71,6 +71,12 @@ namespace xclswemuhal2
         , m_mode(mode)
       {}
 
+      void
+      update_access_mode(access_mode mode) override
+      {
+        m_mode = mode;
+      }
+
       slot_id
       get_slotidx() const override
       {

--- a/src/runtime_src/core/pcie/windows/alveo/shim.cpp
+++ b/src/runtime_src/core/pcie/windows/alveo/shim.cpp
@@ -70,6 +70,12 @@ struct shim
       , m_mode(mode)
     {}
 
+    void
+    update_access_mode(access_mode mode) override
+    {
+      m_mode = mode;
+    }
+
     slot_id
     get_slotidx() const override
     {


### PR DESCRIPTION
Amend #7470 with updates to all shims in XRT to support update_access_mode which is used for HLS mailbox feature.
