### PR TITLE
Use correct BO handle for export

### DIFF
--- a/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.cpp
+++ b/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.cpp
@@ -216,7 +216,7 @@ bool AIETraceOffload::initReadTrace()
 
       XAie_MemInst memInst;
       XAie_MemCacheProp prop = XAIE_MEM_CACHEABLE;
-      xclBufferExportHandle boExportHandle = xclExportBO(deviceHandle, buffers[i].boHandle);
+      xclBufferExportHandle boExportHandle = deviceIntf->getBufferExportHandle(buffers[i].boHandle);
       if(XRT_NULL_BO_EXPORT == boExportHandle) {
         throw std::runtime_error("Unable to export BO while attaching to AIE Driver");
       }

--- a/src/runtime_src/xdp/profile/device/device_intf.cpp
+++ b/src/runtime_src/xdp/profile/device/device_intf.cpp
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2016-2022 Xilinx, Inc
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -1097,6 +1097,12 @@ DeviceIntf::~DeviceIntf()
       status += ip->getDeadlockDiagnosis(print);
 
     return status;
+  }
+
+  xclBufferExportHandle DeviceIntf::getBufferExportHandle(size_t id)
+  {
+    std::lock_guard<std::mutex> lock(traceLock);
+    return mDevice->getBufferExportHandle(id);
   }
 
 } // namespace xdp

--- a/src/runtime_src/xdp/profile/device/device_intf.h
+++ b/src/runtime_src/xdp/profile/device/device_intf.h
@@ -3,7 +3,7 @@
 
 /**
  * Copyright (C) 2016-2022 Xilinx, Inc
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
  * Author(s): Paul Schumacher
  *          : Anurag Dubey
  *          : Tianhao Zhou
@@ -214,6 +214,9 @@ class DeviceIntf {
     bool hasDeadlockDetector() {return mDeadlockDetector != nullptr;}
 
     bool hasHSDPforPL() { return mHSDPforPL; }
+
+    XDP_EXPORT
+    xclBufferExportHandle getBufferExportHandle(size_t id);
 
   private:
     // Turn on/off debug messages to stdout

--- a/src/runtime_src/xdp/profile/device/hal_device/xdp_hal_device.cpp
+++ b/src/runtime_src/xdp/profile/device/hal_device/xdp_hal_device.cpp
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2019-2022 Xilinx, Inc
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -218,6 +219,14 @@ std::string HalDevice::getSubDevicePath(std::string& subdev, uint32_t index)
   xclGetSubdevPath(mHalDevice, subdev.c_str(), index, buffer, maxSz);
 
   return std::string(buffer);
+}
+
+xclBufferExportHandle HalDevice::getBufferExportHandle(size_t id)
+{
+  if(!id) return XRT_NULL_BO_EXPORT;
+  size_t boIndex = id - 1;
+
+  return (xrt_bos[boIndex].export_buffer());
 }
 
 }

--- a/src/runtime_src/xdp/profile/device/hal_device/xdp_hal_device.h
+++ b/src/runtime_src/xdp/profile/device/hal_device/xdp_hal_device.h
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2019-2022 Xilinx, Inc
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -64,6 +65,8 @@ public:
   virtual double getKernelMaxBwWrite();
 
   virtual std::string getSubDevicePath(std::string& subdev, uint32_t index);
+
+  virtual xclBufferExportHandle getBufferExportHandle(size_t id);
 };
 }
 

--- a/src/runtime_src/xdp/profile/device/xdp_base_device.h
+++ b/src/runtime_src/xdp/profile/device/xdp_base_device.h
@@ -1,6 +1,6 @@
 /**
- * Copyright (C) 2019 Xilinx, Inc
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2019-2022 Xilinx, Inc
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -71,6 +71,8 @@ public:
   virtual void* getRawDevice() = 0 ;
 
   virtual std::string getSubDevicePath(std::string& subdev, uint32_t index) = 0;
+
+  virtual xclBufferExportHandle getBufferExportHandle(size_t id) = 0;
 };
 
 }

--- a/src/runtime_src/xdp/profile/device/xrt_device/xdp_xrt_device.cpp
+++ b/src/runtime_src/xdp/profile/device/xrt_device/xdp_xrt_device.cpp
@@ -1,6 +1,6 @@
 /**
- * Copyright (C) 2019-2021 Xilinx, Inc
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2019-2022 Xilinx, Inc
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -176,6 +176,11 @@ double XrtDevice::getKernelMaxBwWrite()
 std::string XrtDevice::getSubDevicePath(std::string& subdev, uint32_t index)
 {
   return mXrtDevice->getSubdevPath(subdev, index).get();
+}
+
+xclBufferExportHandle XrtDevice::getBufferExportHandle(size_t /*id*/)
+{
+  return XRT_NULL_BO_EXPORT;
 }
 
 }

--- a/src/runtime_src/xdp/profile/device/xrt_device/xdp_xrt_device.h
+++ b/src/runtime_src/xdp/profile/device/xrt_device/xdp_xrt_device.h
@@ -1,6 +1,6 @@
 /**
- * Copyright (C) 2019-2021 Xilinx, Inc
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2019-2022 Xilinx, Inc
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -71,6 +71,8 @@ public:
   virtual double getKernelMaxBwWrite();
 
   virtual std::string getSubDevicePath(std::string& subdev, uint32_t index);
+
+  virtual xclBufferExportHandle getBufferExportHandle(size_t id);
 };
 }
 


### PR DESCRIPTION
#### Problem solved by the commit
When GMIO AIE Trace and PL Device Trace are enabled together, there is a segmentation fault after due to " Unable to export BO while attaching to AIE Driver".

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
The reported fail is caused by use of incorrect buffer handle with "xclExportBO" for trace buffer used in GMIO AIE Trace.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Access to xrt::bo handle to the allocated buffer is not available in aie_trace_offloader where GMIO AIE Trace buffer is managed and set up using AIE APIs. To solve this new methods are added to Device Interface and XDP Device abstractions which help in calling export_buffer on the allocated xrt::bo .
 
#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Reported test now passes with the fix and records AIE trace.

#### Documentation impact (if any)
