### PR TITLE
Memory manger issue fixed for xbtest

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
@@ -1166,8 +1166,6 @@ static int xocl_init_memory_manager(struct xocl_drm *drm_p)
 			mm_end_addr = mem_data->m_base_address + ddr_bank_size;
 	}
 
-	XOCL_PUT_MEM_TOPOLOGY(drm_p->xdev, legacy_slot_id);
-
 	if (drm_p->xocl_mm != NULL) {
 		/* Validate the new memory topology with existing memory manager */
 		if ((drm_p->xocl_mm->start_addr != mm_start_addr) ||
@@ -1187,6 +1185,7 @@ static int xocl_init_memory_manager(struct xocl_drm *drm_p)
 		}
 		else {
 			/* Memory manager initialization is done and consistent */
+			XOCL_PUT_MEM_TOPOLOGY(drm_p->xdev, legacy_slot_id);
 			mutex_unlock(&drm_p->mm_lock);
 			return 0;
 		}
@@ -1204,6 +1203,8 @@ static int xocl_init_memory_manager(struct xocl_drm *drm_p)
 		if (err)
 			goto error;
 	}
+
+	XOCL_PUT_MEM_TOPOLOGY(drm_p->xdev, legacy_slot_id);
 
 	err = xocl_p2p_mem_init(drm_p->xdev);
 	if (err && err != -ENODEV) {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
@@ -1126,6 +1126,7 @@ static int xocl_init_memory_manager(struct xocl_drm *drm_p)
 	}
 
 	if (!topo) {
+		XOCL_PUT_MEM_TOPOLOGY(drm_p->xdev, legacy_slot_id);
 		mutex_unlock(&drm_p->mm_lock);
 		/* Before return check if drm memory manager is initialized already. 
 		 * This is done from platform metadata.
@@ -1165,7 +1166,9 @@ static int xocl_init_memory_manager(struct xocl_drm *drm_p)
 			mm_end_addr = mem_data->m_base_address + ddr_bank_size;
 	}
 
-	if (drm_p->xocl_mm_done && (drm_p->xocl_mm != NULL)) {
+	XOCL_PUT_MEM_TOPOLOGY(drm_p->xdev, legacy_slot_id);
+
+	if (drm_p->xocl_mm != NULL) {
 		/* Validate the new memory topology with existing memory manager */
 		if ((drm_p->xocl_mm->start_addr != mm_start_addr) ||
 				(drm_p->xocl_mm->end_addr != mm_end_addr) ||
@@ -1202,8 +1205,6 @@ static int xocl_init_memory_manager(struct xocl_drm *drm_p)
 			goto error;
 	}
 
-	XOCL_PUT_MEM_TOPOLOGY(drm_p->xdev, legacy_slot_id);
-
 	err = xocl_p2p_mem_init(drm_p->xdev);
 	if (err && err != -ENODEV) {
 		xocl_err(drm_p->ddev->dev,
@@ -1211,7 +1212,6 @@ static int xocl_init_memory_manager(struct xocl_drm *drm_p)
 		goto error;
 	}
 
-	drm_p->xocl_mm_done = true;
 	mutex_unlock(&drm_p->mm_lock);
 
 	return 0;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
@@ -1166,7 +1166,7 @@ static int xocl_init_memory_manager(struct xocl_drm *drm_p)
 			mm_end_addr = mem_data->m_base_address + ddr_bank_size;
 	}
 
-	if (drm_p->xocl_mm != NULL) {
+	if (drm_p->xocl_mm) {
 		/* Validate the new memory topology with existing memory manager */
 		if ((drm_p->xocl_mm->start_addr != mm_start_addr) ||
 				(drm_p->xocl_mm->end_addr != mm_end_addr) ||
@@ -1191,7 +1191,7 @@ static int xocl_init_memory_manager(struct xocl_drm *drm_p)
 		}
 	}
 
-	if (drm_p->xocl_mm == NULL) {
+	if (!drm_p->xocl_mm) {
 		drm_p->xocl_mm = vzalloc(sizeof(struct xocl_mm));
 		if (!drm_p->xocl_mm) {
 			err = -ENOMEM;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drm.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drm.h
@@ -85,7 +85,6 @@ struct xocl_drm {
 	/* Memory manager */
 	struct xocl_mm		*xocl_mm;
 	bool			xocl_drm_mm_done;
-	bool			xocl_mm_done;
 	struct drm_xocl_mm_stat mm_usage_stat[MAX_MEM_BANK_COUNT];
 
 	/* Xocl driver memory list head */


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
 -- There is some extra flag in memory manager because of that one test if failing, 
Actually that flag is not allowing to init the memory manager when the platform memory topology and xclbin topology is not machine and xclbin topology has some extra memory banks  available. 
-- This issue has been found in https://jira.xilinx.com/browse/CR-1145960


#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
-- Multislot memory manager changes introduced this  

#### How problem was solved, alternative solutions (if any) and why they were rejected
-- Removed that flag as this will not be required anymore

#### Risks (if any) associated the changes in the commit
N/A
#### What has been tested and how, request additional testing if necessary
xbtest, validate 
#### Documentation impact (if any)
N/A