### PR TITLE
CR-1159385: Finished BD event is missing for memtile trace for AIE-ML designs for input_channels

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_trace_new/aie_trace_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace_new/aie_trace_metadata.cpp
@@ -109,7 +109,7 @@ namespace xdp {
     const std::set<std::string> validSettings {
       "graph_based_aie_tile_metrics", "tile_based_aie_tile_metrics",
       "graph_based_memory_tile_metrics", "tile_based_memory_tile_metrics",
-      "start_type", "start_time", "start_iteration", 
+      "start_type", "start_time", "start_iteration", "end_type",
       "periodic_offload", "reuse_buffer", "buffer_size", 
       "buffer_offload_interval_us", "file_dump_interval_s"
     };

--- a/src/runtime_src/xdp/profile/plugin/aie_trace_new/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace_new/aie_trace_plugin.cpp
@@ -307,8 +307,10 @@ namespace xdp {
   {
     for (const auto& kv : handleToAIEData) {
       auto& AIEData = kv.second;
-      if (AIEData.valid)
+      if (AIEData.valid) {
+        AIEData.implementation->flushAieTileTraceModule();
         flushOffloader(AIEData.offloader, true);
+      }
     }
 
     XDPPlugin::endWrite();

--- a/src/runtime_src/xdp/profile/plugin/aie_trace_new/edge/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace_new/edge/aie_trace.cpp
@@ -1010,12 +1010,13 @@ namespace xdp {
 
   void AieTrace_EdgeImpl::flushAieTileTraceModule()
   {
+    if (mTraceFlushLocs.empty() && mMemTileTraceFlushLocs.empty())
+      return;
+
     auto handle = metadata->getHandle();
     aieDevInst = static_cast<XAie_DevInst*>(db->getStaticInfo().getAieDevInst(fetchAieDevInst, handle));
 
-    // Flush trace if requested or required
-    if (((mTraceFlushLocs.size() > 0) || (mMemTileTraceFlushLocs.size() > 0))
-        && (xrt_core::config::get_verbosity() >= static_cast<uint32_t>(severity_level::info))) {
+    if (xrt_core::config::get_verbosity() >= static_cast<uint32_t>(severity_level::info)) {
       std::stringstream msg;
       msg << "Flushing AIE trace by forcing end event for "
           << mTraceFlushLocs.size() << " AIE tiles";
@@ -1024,6 +1025,8 @@ namespace xdp {
       xrt_core::message::send(severity_level::info, "XRT", msg.str());
     }
 
+    // Flush trace by forcing end event 
+    // NOTE: this informs tiles to output remaining packets (even partial)
     for (const auto& loc : mTraceFlushLocs)
       XAie_EventGenerate(aieDevInst, loc, XAIE_CORE_MOD, mTraceFlushEndEvent);
     for (const auto& loc : mMemTileTraceFlushLocs)


### PR DESCRIPTION
**Problem solved by the commit**
Trace flush was not always performed, especially on AIE2 devices

**How problem was solved, alternative solutions (if any) and why they were rejected**
Ensure trace flush is always performed when needed or requested, including during deconstruction

**Risks (if any) associated the changes in the commit**
Flush may not entirely solve the missing trace problem

**What has been tested and how, request additional testing if necessary**
Various designs on vek280