### PR TITLE
fix for channel numbers in MEM tiles

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_trace_new/aie_trace_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace_new/aie_trace_metadata.cpp
@@ -581,11 +581,11 @@ namespace xdp {
       }
 
       // Grab channel numbers (if specified; MEM tiles only)
-      if (graphMetrics[i].size() == 5) {
+      if (graphMetrics[i].size() > 3) {
         try {
           for (auto &e : tiles) {
             configChannel0[e] = std::stoi(graphMetrics[i][3]);
-            configChannel1[e] = std::stoi(graphMetrics[i][4]);
+            configChannel1[e] = std::stoi(graphMetrics[i].back());
           }
         } catch (...) {
           std::stringstream msg;
@@ -638,11 +638,11 @@ namespace xdp {
       }
 
       // Grab channel numbers (if specified; MEM tiles only)
-      if (graphMetrics[i].size() == 5) {
+      if (graphMetrics[i].size() > 3) {
         try {
           for (auto &e : tiles) {
             configChannel0[e] = std::stoi(graphMetrics[i][3]);
-            configChannel1[e] = std::stoi(graphMetrics[i][4]);
+            configChannel1[e] = std::stoi(graphMetrics[i].back());
           }
         } catch (...) {
           std::stringstream msg;
@@ -685,11 +685,11 @@ namespace xdp {
       }
 
       // Grab channel numbers (if specified; MEM tiles only)
-      if (metrics[i].size() == 4) {
+      if (metrics[i].size() > 2) {
         try {
           for (auto &e : tiles) {
             configChannel0[e] = std::stoi(metrics[i][2]);
-            configChannel1[e] = std::stoi(metrics[i][3]);
+            configChannel1[e] = std::stoi(metrics[i].back());
           }
         } catch (...) {
           std::stringstream msg;
@@ -741,10 +741,10 @@ namespace xdp {
 
       uint8_t channel0 = 0;
       uint8_t channel1 = 1;
-      if (metrics[i].size() == 5) {
+      if (metrics[i].size() > 3) {
         try {
           channel0 = std::stoi(metrics[i][3]);
-          channel1 = std::stoi(metrics[i][4]);
+          channel1 = std::stoi(metrics[i].back());
         } catch (...) {
           std::stringstream msg;
           msg << "Channel specifications in tile_based_" << tileName
@@ -821,10 +821,10 @@ namespace xdp {
       configMetrics[tile] = metrics[i][1];
       
       // Grab channel numbers (if specified; MEM tiles only)
-      if (metrics[i].size() == 4) {
+      if (metrics[i].size() > 2) {
         try {
           configChannel0[tile] = std::stoi(metrics[i][2]);
-          configChannel1[tile] = std::stoi(metrics[i][3]);
+          configChannel1[tile] = std::stoi(metrics[i].back());
         } catch (...) {
           std::stringstream msg;
           msg << "Channel specifications in tile_based_" << tileName

--- a/src/runtime_src/xdp/profile/plugin/aie_trace_new/edge/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace_new/edge/aie_trace.cpp
@@ -682,13 +682,15 @@ namespace xdp {
             cfgTile->mem_tile_trace_config.port_trace_is_master[0] = true;
             cfgTile->mem_tile_trace_config.port_trace_is_master[1] = true;
             cfgTile->mem_tile_trace_config.s2mm_channels[0] = channel0;
-            cfgTile->mem_tile_trace_config.s2mm_channels[1] = channel1;
+            // For now, only one channel is monitored at a time
+            //cfgTile->mem_tile_trace_config.s2mm_channels[1] = channel1;
           }
           else {
             cfgTile->mem_tile_trace_config.port_trace_is_master[0] = false;
             cfgTile->mem_tile_trace_config.port_trace_is_master[1] = false;
             cfgTile->mem_tile_trace_config.mm2s_channels[0] = channel0;
-            cfgTile->mem_tile_trace_config.mm2s_channels[1] = channel1;
+            // For now, only one channel is monitored at a time
+            //cfgTile->mem_tile_trace_config.mm2s_channels[1] = channel1;
           }
         }
         


### PR DESCRIPTION
**Problem solved by the commit**
Fixed issues with parsing and reporting MEM tile channels

**How problem was solved, alternative solutions (if any) and why they were rejected**
For now, metric sets report a single channel, so we should only report one

**Risks (if any) associated the changes in the commit**
None

**What has been tested and how, request additional testing if necessary**
Designs on vek280

**Documentation impact (if any)**
MEM tile metric settings only need up to one channel
 