### PR TITLE
CR-1159512: fixed reporting of 1 or 2 MEM tile channels in config file

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_trace_new/edge/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace_new/edge/aie_trace.cpp
@@ -682,15 +682,15 @@ namespace xdp {
             cfgTile->mem_tile_trace_config.port_trace_is_master[0] = true;
             cfgTile->mem_tile_trace_config.port_trace_is_master[1] = true;
             cfgTile->mem_tile_trace_config.s2mm_channels[0] = channel0;
-            // For now, only one channel is monitored at a time
-            //cfgTile->mem_tile_trace_config.s2mm_channels[1] = channel1;
+            if (channel0 != channel1)
+              cfgTile->mem_tile_trace_config.s2mm_channels[1] = channel1;
           }
           else {
             cfgTile->mem_tile_trace_config.port_trace_is_master[0] = false;
             cfgTile->mem_tile_trace_config.port_trace_is_master[1] = false;
             cfgTile->mem_tile_trace_config.mm2s_channels[0] = channel0;
-            // For now, only one channel is monitored at a time
-            //cfgTile->mem_tile_trace_config.mm2s_channels[1] = channel1;
+            if (channel0 != channel1)
+              cfgTile->mem_tile_trace_config.mm2s_channels[1] = channel1;
           }
         }
         


### PR DESCRIPTION
**Problem solved by the commit**
Config file only listed one s2mm/mm2s channel when we could potentially be monitoring two

**How problem was solved, alternative solutions (if any) and why they were rejected**
List either one or two channels based on user settings

**Risks (if any) associated the changes in the commit**
none

**What has been tested and how, request additional testing if necessary**
Various designs on vek280

**Documentation impact (if any)**
User can specify one or two channels depending on metric set