### PR TITLE
Use 64bit flags when allocationg buffer objects

### DIFF
--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -18,6 +18,7 @@
 #include "handle.h"
 #include "hw_context_int.h"
 #include "kernel_int.h"
+#include "xrt_mem.h"
 #include "core/common/device.h"
 #include "core/common/memalign.h"
 #include "core/common/message.h"
@@ -200,7 +201,7 @@ private:
     addr = prop.paddr;
 
     // Flags are what was used by shim::alloc_bo when the BO was
-    // created What is stored in bo_impl, are the flags that were used
+    // created. What is stored in bo_impl, are the flags that were used
     // to indicate the type of the BO (per xrt::bo::flags). Currrently
     // bo_impl doesn't track or provide access to the extension flags
     // in xcl_bo_flags.
@@ -984,22 +985,32 @@ get_boh(xrtBufferHandle bhdl)
 static std::unique_ptr<xrt_core::buffer_handle>
 alloc_bo(const device_type& device, void* userptr, size_t sz, xrtBufferFlags flags, xrtMemoryGroup grp)
 {
-  flags = (flags & ~XRT_BO_FLAGS_MEMIDX_MASK) | grp;
+  // Embed grp in flags
+  xcl_bo_flags xflags{flags};
+  xcl_bo_flags xgrp{grp};
+  xflags.bank = xgrp.bank;
+  xflags.slot = xgrp.slot;
+
   auto hwctx  = device.get_hwctx_handle();
   return hwctx
-    ? hwctx->alloc_bo(userptr, sz, flags)
-    : device->alloc_bo(userptr, sz, flags);
+    ? hwctx->alloc_bo(userptr, sz, xflags.all)
+    : device->alloc_bo(userptr, sz, xflags.all);
 }
 
 static std::unique_ptr<xrt_core::buffer_handle>
 alloc_bo(const device_type& device, size_t sz, xrtBufferFlags flags, xrtMemoryGroup grp)
 {
-  flags = (flags & ~XRT_BO_FLAGS_MEMIDX_MASK) | grp;
+  // Embed grp in flags
+  xcl_bo_flags xflags{flags};
+  xcl_bo_flags xgrp{grp};
+  xflags.bank = xgrp.bank;
+  xflags.slot = xgrp.slot;
+
   try {
     auto hwctx  = device.get_hwctx_handle();
     return hwctx
-      ? hwctx->alloc_bo(sz, flags)
-      : device->alloc_bo(sz, flags);
+      ? hwctx->alloc_bo(sz, xflags.all)
+      : device->alloc_bo(sz, xflags.all);
   }
   catch (const std::exception& ex) {
     if (flags == XRT_BO_FLAGS_HOST_ONLY) {
@@ -1076,7 +1087,8 @@ alloc_nodma(const device_type& device, size_t sz, xrtBufferFlags, xrtMemoryGroup
 static std::shared_ptr<xrt::bo_impl>
 alloc(const device_type& device, size_t sz, xrtBufferFlags flags, xrtMemoryGroup grp)
 {
-  auto type = flags & ~XRT_BO_FLAGS_MEMIDX_MASK;
+  xcl_bo_flags xflags{flags};
+  auto type = xflags.flags & ~XRT_BO_FLAGS_MEMIDX_MASK;
   switch (type) {
   case 0:
 #ifndef XRT_EDGE

--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -9,7 +9,7 @@
 #define XRT_API_SOURCE         // in same dll as api
 #include "core/include/xrt/xrt_bo.h"
 #include "core/include/xrt/xrt_aie.h"
-#include "core/include/experimental/xrt_hw_context.h"
+#include "core/include/xrt/xrt_hw_context.h"
 
 #include "native_profile.h"
 #include "bo.h"
@@ -198,8 +198,15 @@ private:
   {
     auto prop = handle->get_properties();
     addr = prop.paddr;
-    grpid = prop.flags & XRT_BO_FLAGS_MEMIDX_MASK;
-    flags = static_cast<bo::flags>(prop.flags & ~XRT_BO_FLAGS_MEMIDX_MASK);
+
+    // Flags are what was used by shim::alloc_bo when the BO was
+    // created What is stored in bo_impl, are the flags that were used
+    // to indicate the type of the BO (per xrt::bo::flags). Currrently
+    // bo_impl doesn't track or provide access to the extension flags
+    // in xcl_bo_flags.
+    xcl_bo_flags xflags {prop.flags};
+    grpid = xflags.bank;
+    flags = static_cast<bo::flags>(xflags.flags & ~XRT_BO_FLAGS_MEMIDX_MASK);
   }
 
 protected:

--- a/src/runtime_src/core/common/ishim.h
+++ b/src/runtime_src/core/common/ishim.h
@@ -105,10 +105,10 @@ struct ishim
   // Implemented explicitly by concrete shim device class
   ////////////////////////////////////////////////////////////////
   virtual std::unique_ptr<buffer_handle>
-  alloc_bo(size_t size, unsigned int flags) = 0;
+  alloc_bo(size_t size, uint64_t flags) = 0;
 
   virtual std::unique_ptr<buffer_handle>
-  alloc_bo(void* userptr, size_t size, unsigned int flags) = 0;
+  alloc_bo(void* userptr, size_t size, uint64_t flags) = 0;
 
   // Import an exported BO from another process identified by argument pid.
   // This function is only supported on systems with pidfd kernel support

--- a/src/runtime_src/core/common/shim/buffer_handle.h
+++ b/src/runtime_src/core/common/shim/buffer_handle.h
@@ -33,7 +33,7 @@ public:
   // properties - buffer details
   struct properties
   {
-    uint32_t flags;
+    uint64_t flags;
     uint64_t size;
     uint64_t paddr;
   };

--- a/src/runtime_src/core/common/shim/hwctx_handle.h
+++ b/src/runtime_src/core/common/shim/hwctx_handle.h
@@ -57,11 +57,11 @@ public:
 
   // Context specific buffer allocation
   virtual std::unique_ptr<buffer_handle>
-  alloc_bo(void* userptr, size_t size, unsigned int flags) = 0;
+  alloc_bo(void* userptr, size_t size, uint64_t flags) = 0;
 
   // Context specific buffer allocation
   virtual std::unique_ptr<buffer_handle>
-  alloc_bo(size_t size, unsigned int flags) = 0;
+  alloc_bo(size_t size, uint64_t flags) = 0;
 
   // Legacy XRT may require special handling when opening a context on
   // a compute unit.  Ideally, the hardware context itself should

--- a/src/runtime_src/core/edge/sw_emu/generic_pcie_hal2/device_swemu.h
+++ b/src/runtime_src/core/edge/sw_emu/generic_pcie_hal2/device_swemu.h
@@ -28,15 +28,15 @@ public:
   }
 
   std::unique_ptr<buffer_handle>
-  alloc_bo(size_t size, unsigned int flags) override
+  alloc_bo(size_t size, uint64_t flags) override
   {
-    return xrt::shim_int::alloc_bo(get_device_handle(), size, flags);
+    return xrt::shim_int::alloc_bo(get_device_handle(), size, xcl_bo_flags{flags}.flags);
   }
 
   std::unique_ptr<buffer_handle>
-  alloc_bo(void* userptr, size_t size, unsigned int flags) override
+  alloc_bo(void* userptr, size_t size, uint64_t flags) override
   {
-    return xrt::shim_int::alloc_bo(get_device_handle(), userptr, size, flags);
+    return xrt::shim_int::alloc_bo(get_device_handle(), userptr, size, xcl_bo_flags{flags}.flags);
   }
 
   std::unique_ptr<buffer_handle>

--- a/src/runtime_src/core/edge/sw_emu/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/edge/sw_emu/generic_pcie_hal2/shim.h
@@ -216,17 +216,17 @@ namespace xclswemuhal2 {
       }
 
       std::unique_ptr<xrt_core::buffer_handle>
-      alloc_bo(void* userptr, size_t size, unsigned int flags) override
+      alloc_bo(void* userptr, size_t size, uint64_t flags) override
       {
         // The hwctx is embedded in the flags, use regular shim path
-        return m_shim->xclAllocUserPtrBO(userptr, size, flags);
+        return m_shim->xclAllocUserPtrBO(userptr, size, xcl_bo_flags{flags}.flags);
       }
 
       std::unique_ptr<xrt_core::buffer_handle>
-      alloc_bo(size_t size, unsigned int flags) override
+      alloc_bo(size_t size, uint64_t flags) override
       {
         // The hwctx is embedded in the flags, use regular shim path
-        return m_shim->xclAllocBO(size, flags);
+        return m_shim->xclAllocBO(size, xcl_bo_flags{flags}.flags);
       }
 
       xrt_core::cuidx_type

--- a/src/runtime_src/core/edge/user/device_linux.h
+++ b/src/runtime_src/core/edge/user/device_linux.h
@@ -69,15 +69,15 @@ public:
   }
 
   std::unique_ptr<buffer_handle>
-  alloc_bo(size_t size, unsigned int flags) override
+  alloc_bo(size_t size, uint64_t flags) override
   {
-    return xrt::shim_int::alloc_bo(get_device_handle(), size, flags);
+    return xrt::shim_int::alloc_bo(get_device_handle(), size, xcl_bo_flags{flags}.flags);
   }
 
   std::unique_ptr<buffer_handle>
-  alloc_bo(void* userptr, size_t size, unsigned int flags) override
+  alloc_bo(void* userptr, size_t size, uint64_t flags) override
   {
-    return xrt::shim_int::alloc_bo(get_device_handle(), userptr, size, flags);
+    return xrt::shim_int::alloc_bo(get_device_handle(), userptr, size, xcl_bo_flags{flags}.flags);
   }
 
   std::unique_ptr<buffer_handle>

--- a/src/runtime_src/core/edge/user/shim.h
+++ b/src/runtime_src/core/edge/user/shim.h
@@ -202,17 +202,17 @@ public:
     }
 
     std::unique_ptr<xrt_core::buffer_handle>
-    alloc_bo(void* userptr, size_t size, unsigned int flags) override
+    alloc_bo(void* userptr, size_t size, uint64_t flags) override
     {
       // The hwctx is embedded in the flags, use regular shim path
-      return m_shim->xclAllocUserPtrBO(userptr, size, flags);
+      return m_shim->xclAllocUserPtrBO(userptr, size, xcl_bo_flags{flags}.flags);
     }
 
     std::unique_ptr<xrt_core::buffer_handle>
-    alloc_bo(size_t size, unsigned int flags) override
+    alloc_bo(size_t size, uint64_t flags) override
     {
       // The hwctx is embedded in the flags, use regular shim path
-      return m_shim->xclAllocBO(size, flags);
+      return m_shim->xclAllocBO(size, xcl_bo_flags{flags}.flags);
     }
 
     xrt_core::cuidx_type

--- a/src/runtime_src/core/include/xrt_mem.h
+++ b/src/runtime_src/core/include/xrt_mem.h
@@ -60,11 +60,21 @@ extern "C" {
 struct xcl_bo_flags
 {
   union {
-    uint32_t flags;
+    uint64_t all;           // [63-0]
+
     struct {
-      uint16_t bank;       // [15-0]
-      uint8_t  slot;       // [16-23]
-      uint8_t  boflags;    // [24-31]
+      uint32_t flags;       // [31-0]
+      uint32_t extension;   // [63-32]
+    };
+
+    struct {
+      uint16_t bank;        // [15-0]
+      uint8_t  slot;        // [23-16]
+      uint8_t  boflags;     // [31-24]
+
+      // extension
+      uint32_t access : 2;  // [33-32]
+      uint32_t unused : 30; // [63-34]
     };
   };
 };
@@ -85,6 +95,12 @@ struct xcl_bo_flags
 #define	XCL_BO_FLAGS_HOST_ONLY		(1U << 29)
 #define	XCL_BO_FLAGS_P2P		(1U << 30)
 #define	XCL_BO_FLAGS_EXECBUF		(1U << 31)
+
+/**
+ * Shim level BO Flags for extension
+ */
+#define XRT_BO_ACCESS_SHARED 1
+#define XRT_BO_ACCESS_EXPORTED 2
 
 /**
  * XRT Native BO flags

--- a/src/runtime_src/core/pcie/emulation/hw_emu/alveo_shim/device_hwemu.h
+++ b/src/runtime_src/core/pcie/emulation/hw_emu/alveo_shim/device_hwemu.h
@@ -40,15 +40,15 @@ private:
   }
 
   std::unique_ptr<buffer_handle>
-  alloc_bo(size_t size, unsigned int flags) override
+  alloc_bo(size_t size, uint64_t flags) override
   {
-    return xrt::shim_int::alloc_bo(get_device_handle(), size, flags);
+    return xrt::shim_int::alloc_bo(get_device_handle(), size, xcl_bo_flags{flags}.flags);
   }
 
   std::unique_ptr<buffer_handle>
-  alloc_bo(void* userptr, size_t size, unsigned int flags) override
+  alloc_bo(void* userptr, size_t size, uint64_t flags) override
   {
-    return xrt::shim_int::alloc_bo(get_device_handle(), userptr, size, flags);
+    return xrt::shim_int::alloc_bo(get_device_handle(), userptr, size, xcl_bo_flags{flags}.flags);
   }
 
   std::unique_ptr<buffer_handle>

--- a/src/runtime_src/core/pcie/emulation/hw_emu/alveo_shim/shim.h
+++ b/src/runtime_src/core/pcie/emulation/hw_emu/alveo_shim/shim.h
@@ -267,17 +267,17 @@ using addr_type = uint64_t;
       }
 
       std::unique_ptr<xrt_core::buffer_handle>
-      alloc_bo(void* userptr, size_t size, unsigned int flags) override
+      alloc_bo(void* userptr, size_t size, uint64_t flags) override
       {
         // The hwctx is embedded in the flags, use regular shim path
-        return m_shim->xclAllocUserPtrBO(userptr, size, flags);
+        return m_shim->xclAllocUserPtrBO(userptr, size, xcl_bo_flags{flags}.flags);
       }
 
       std::unique_ptr<xrt_core::buffer_handle>
-      alloc_bo(size_t size, unsigned int flags) override
+      alloc_bo(size_t size, uint64_t flags) override
       {
         // The hwctx is embedded in the flags, use regular shim path
-        return m_shim->xclAllocBO(size, flags);
+        return m_shim->xclAllocBO(size, xcl_bo_flags{flags}.flags);
       }
 
       xrt_core::cuidx_type

--- a/src/runtime_src/core/pcie/emulation/sw_emu/generic_pcie_hal2/device_swemu.h
+++ b/src/runtime_src/core/pcie/emulation/sw_emu/generic_pcie_hal2/device_swemu.h
@@ -30,15 +30,15 @@ public:
   }
 
   std::unique_ptr<buffer_handle>
-  alloc_bo(size_t size, unsigned int flags) override
+  alloc_bo(size_t size, uint64_t flags) override
   {
-    return xrt::shim_int::alloc_bo(get_device_handle(), size, flags);
+    return xrt::shim_int::alloc_bo(get_device_handle(), size, xcl_bo_flags{flags}.flags);
   }
 
   std::unique_ptr<buffer_handle>
-  alloc_bo(void* userptr, size_t size, unsigned int flags) override
+  alloc_bo(void* userptr, size_t size, uint64_t flags) override
   {
-    return xrt::shim_int::alloc_bo(get_device_handle(), userptr, size, flags);
+    return xrt::shim_int::alloc_bo(get_device_handle(), userptr, size, xcl_bo_flags{flags}.flags);
   }
 
   std::unique_ptr<buffer_handle>

--- a/src/runtime_src/core/pcie/emulation/sw_emu/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/pcie/emulation/sw_emu/generic_pcie_hal2/shim.h
@@ -221,17 +221,17 @@ namespace xclswemuhal2
       }
 
       std::unique_ptr<xrt_core::buffer_handle>
-      alloc_bo(void* userptr, size_t size, unsigned int flags) override
+      alloc_bo(void* userptr, size_t size, uint64_t flags) override
       {
         // The hwctx is embedded in the flags, use regular shim path
-        return m_shim->xclAllocUserPtrBO(userptr, size, flags);
+        return m_shim->xclAllocUserPtrBO(userptr, size, xcl_bo_flags{flags}.flags);
       }
 
       std::unique_ptr<xrt_core::buffer_handle>
-      alloc_bo(size_t size, unsigned int flags) override
+      alloc_bo(size_t size, uint64_t flags) override
       {
         // The hwctx is embedded in the flags, use regular shim path
-        return m_shim->xclAllocBO(size, flags);
+        return m_shim->xclAllocBO(size, xcl_bo_flags{flags}.flags);
       }
 
       xrt_core::cuidx_type

--- a/src/runtime_src/core/pcie/linux/device_linux.h
+++ b/src/runtime_src/core/pcie/linux/device_linux.h
@@ -76,15 +76,15 @@ public:
   }
 
   std::unique_ptr<buffer_handle>
-  alloc_bo(size_t size, unsigned int flags) override
+  alloc_bo(size_t size, uint64_t flags) override
   {
-    return xrt::shim_int::alloc_bo(get_device_handle(), size, flags);
+    return xrt::shim_int::alloc_bo(get_device_handle(), size, xcl_bo_flags{flags}.flags);
   }
 
   std::unique_ptr<buffer_handle>
-  alloc_bo(void* userptr, size_t size, unsigned int flags) override
+  alloc_bo(void* userptr, size_t size, uint64_t flags) override
   {
-    return xrt::shim_int::alloc_bo(get_device_handle(), userptr, size, flags);
+    return xrt::shim_int::alloc_bo(get_device_handle(), userptr, size, xcl_bo_flags{flags}.flags);
   }
   ////////////////////////////////////////////////////////////////
 

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -294,17 +294,17 @@ public:
   }
 
   std::unique_ptr<xrt_core::buffer_handle>
-  alloc_bo(void* userptr, size_t size, unsigned int flags) override
+  alloc_bo(void* userptr, size_t size, uint64_t flags) override
   {
     // The hwctx is embedded in the flags, use regular shim path
-    return m_shim->xclAllocUserPtrBO(userptr, size, flags);
+    return m_shim->xclAllocUserPtrBO(userptr, size, xcl_bo_flags{flags}.flags);
   }
 
   std::unique_ptr<xrt_core::buffer_handle>
-  alloc_bo(size_t size, unsigned int flags) override
+  alloc_bo(size_t size, uint64_t flags) override
   {
     // The hwctx is embedded in the flags, use regular shim path
-    return m_shim->xclAllocBO(size, flags);
+    return m_shim->xclAllocBO(size, xcl_bo_flags{flags}.flags);
   }
 
   xrt_core::cuidx_type

--- a/src/runtime_src/core/pcie/noop/device_noop.h
+++ b/src/runtime_src/core/pcie/noop/device_noop.h
@@ -39,15 +39,15 @@ private:
   }
 
   std::unique_ptr<buffer_handle>
-  alloc_bo(size_t size, unsigned int flags) override
+  alloc_bo(size_t size, uint64_t flags) override
   {
-    return xrt::shim_int::alloc_bo(get_device_handle(), size, flags);
+    return xrt::shim_int::alloc_bo(get_device_handle(), size, xcl_bo_flags{flags}.flags);
   }
 
   std::unique_ptr<buffer_handle>
-  alloc_bo(void* userptr, size_t size, unsigned int flags) override
+  alloc_bo(void* userptr, size_t size, uint64_t flags) override
   {
-    return xrt::shim_int::alloc_bo(get_device_handle(), userptr, size, flags);
+    return xrt::shim_int::alloc_bo(get_device_handle(), userptr, size, xcl_bo_flags{flags}.flags);
   }
 };
 

--- a/src/runtime_src/core/pcie/noop/shim.cpp
+++ b/src/runtime_src/core/pcie/noop/shim.cpp
@@ -497,17 +497,17 @@ public:
     }
 
     std::unique_ptr<xrt_core::buffer_handle>
-    alloc_bo(void* userptr, size_t size, unsigned int flags) override
+    alloc_bo(void* userptr, size_t size, uint64_t flags) override
     {
       // The hwctx is embedded in the flags, use regular shim path
-      return m_shim->alloc_userptr_bo(userptr, size, flags);
+      return m_shim->alloc_userptr_bo(userptr, size, xcl_bo_flags{flags}.flags);
     }
 
     std::unique_ptr<xrt_core::buffer_handle>
-    alloc_bo(size_t size, unsigned int flags) override
+    alloc_bo(size_t size, uint64_t flags) override
     {
       // The hwctx is embedded in the flags, use regular shim path
-      return m_shim->alloc_bo(size, flags);
+      return m_shim->alloc_bo(size, xcl_bo_flags{flags}.flags);
     }
 
     xrt_core::cuidx_type

--- a/src/runtime_src/core/pcie/windows/alveo/device_windows.h
+++ b/src/runtime_src/core/pcie/windows/alveo/device_windows.h
@@ -52,15 +52,15 @@ public:
   }
 
   std::unique_ptr<buffer_handle>
-  alloc_bo(size_t size, unsigned int flags) override
+  alloc_bo(size_t size, uint64_t flags) override
   {
-    return xrt::shim_int::alloc_bo(get_device_handle(), size, flags);
+    return xrt::shim_int::alloc_bo(get_device_handle(), size, xcl_bo_flags{flags}.flags);
   }
 
   std::unique_ptr<buffer_handle>
-  alloc_bo(void* userptr, size_t size, unsigned int flags) override
+  alloc_bo(void* userptr, size_t size, uint64_t flags) override
   {
-    return xrt::shim_int::alloc_bo(get_device_handle(), userptr, size, flags);
+    return xrt::shim_int::alloc_bo(get_device_handle(), userptr, size, xcl_bo_flags{flags}.flags);
   }
 
 private:

--- a/src/runtime_src/core/pcie/windows/alveo/shim.cpp
+++ b/src/runtime_src/core/pcie/windows/alveo/shim.cpp
@@ -208,17 +208,17 @@ public:
     }
 
     std::unique_ptr<xrt_core::buffer_handle>
-    alloc_bo(void* userptr, size_t size, unsigned int flags) override
+    alloc_bo(void* userptr, size_t size, uint64_t flags) override
     {
       // The hwctx is embedded in the flags, use regular shim path
-      return m_shim->alloc_user_ptr_bo(userptr, size, flags);
+      return m_shim->alloc_user_ptr_bo(userptr, size, xcl_bo_flags{flags}.flags);
     }
 
     std::unique_ptr<xrt_core::buffer_handle>
-    alloc_bo(size_t size, unsigned int flags) override
+    alloc_bo(size_t size, uint64_t flags) override
     {
       // The hwctx is embedded in the flags, use regular shim path
-      return m_shim->alloc_bo(size, flags);
+      return m_shim->alloc_bo(size, xcl_bo_flags{flags}.flags);
     }
 
     xrt_core::cuidx_type


### PR DESCRIPTION
#### Problem solved by the commit
Move to 64 bit flags for BO allocation to make room for access flags.

#### How problem was solved, alternative solutions (if any) and why they were rejected
This is an internal change, no changes exposed to APIs. Moving to 64bit adds another 32bit for extensions. The xcl_bo_flags structure adds the additional 32 bits as extension flags while ensuring existing 32 bit interpretation remains valid.

Shim implementations that do no care about the newly added access flags can continue to use and interpret the bo flags as 32 bit.

The alloc_bo functions in xrt_core::device and xrt_core::hwctx_handle changes signature for the 64bit flags.  The implementation in existing shims continue to use 32 bits only.

#### Risks (if any) associated the changes in the commit
Minimal as existing code continues to use the original, now lower, 32 bits of the changed flags.

#### What has been tested and how, request additional testing if necessary
OpenCL regressions

