### PR TITLE
VITIS-8071 Update ReportMemory to use Hardware Contexts

### DIFF
--- a/src/runtime_src/core/common/info_memory.cpp
+++ b/src/runtime_src/core/common/info_memory.cpp
@@ -190,11 +190,11 @@ struct memory_info_collector
 
     try {
       std::string tag(reinterpret_cast<const char*>(mem.m_tag));
-      auto ecc_st = xrt_core::device_query<xq::mig_ecc_status>(device, xq::request::modifier::subdev, mem.m_tag);
-      auto ce_cnt = xrt_core::device_query<xq::mig_ecc_ce_cnt>(device, xq::request::modifier::subdev, mem.m_tag);
-      auto ue_cnt = xrt_core::device_query<xq::mig_ecc_ue_cnt>(device, xq::request::modifier::subdev, mem.m_tag);
-      auto ce_ffa = xrt_core::device_query<xq::mig_ecc_ce_ffa>(device, xq::request::modifier::subdev, mem.m_tag);
-      auto ue_ffa = xrt_core::device_query<xq::mig_ecc_ue_ffa>(device, xq::request::modifier::subdev, mem.m_tag);
+      auto ecc_st = xrt_core::device_query<xq::mig_ecc_status>(device, xq::request::modifier::subdev, tag);
+      auto ce_cnt = xrt_core::device_query<xq::mig_ecc_ce_cnt>(device, xq::request::modifier::subdev, tag);
+      auto ue_cnt = xrt_core::device_query<xq::mig_ecc_ue_cnt>(device, xq::request::modifier::subdev, tag);
+      auto ce_ffa = xrt_core::device_query<xq::mig_ecc_ce_ffa>(device, xq::request::modifier::subdev, tag);
+      auto ue_ffa = xrt_core::device_query<xq::mig_ecc_ue_ffa>(device, xq::request::modifier::subdev, tag);
 
       pt_mem.put("extended_info.ecc.status", ecc_status2str(ecc_st));
       pt_mem.put("extended_info.ecc.error.correctable.count", ce_cnt);

--- a/src/runtime_src/core/common/info_memory.cpp
+++ b/src/runtime_src/core/common/info_memory.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2021-2022 Xilinx, Inc
-// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
+
 #define XRT_CORE_COMMON_SOURCE
 #include "info_memory.h"
 #include "ps_kernel.h"

--- a/src/runtime_src/core/common/info_memory.cpp
+++ b/src/runtime_src/core/common/info_memory.cpp
@@ -190,11 +190,11 @@ struct memory_info_collector
 
     try {
       std::string tag(reinterpret_cast<const char*>(mem.m_tag));
-      auto ecc_st = xrt_core::device_query<xq::mig_ecc_status>(device, xq::request::modifier::subdev, tag);
-      auto ce_cnt = xrt_core::device_query<xq::mig_ecc_ce_cnt>(device, xq::request::modifier::subdev, tag);
-      auto ue_cnt = xrt_core::device_query<xq::mig_ecc_ue_cnt>(device, xq::request::modifier::subdev, tag);
-      auto ce_ffa = xrt_core::device_query<xq::mig_ecc_ce_ffa>(device, xq::request::modifier::subdev, tag);
-      auto ue_ffa = xrt_core::device_query<xq::mig_ecc_ue_ffa>(device, xq::request::modifier::subdev, tag);
+      auto ecc_st = xrt_core::device_query<xq::mig_ecc_status>(device, xq::request::modifier::subdev, mem.m_tag);
+      auto ce_cnt = xrt_core::device_query<xq::mig_ecc_ce_cnt>(device, xq::request::modifier::subdev, mem.m_tag);
+      auto ue_cnt = xrt_core::device_query<xq::mig_ecc_ue_cnt>(device, xq::request::modifier::subdev, mem.m_tag);
+      auto ce_ffa = xrt_core::device_query<xq::mig_ecc_ce_ffa>(device, xq::request::modifier::subdev, mem.m_tag);
+      auto ue_ffa = xrt_core::device_query<xq::mig_ecc_ue_ffa>(device, xq::request::modifier::subdev, mem.m_tag);
 
       pt_mem.put("extended_info.ecc.status", ecc_status2str(ecc_st));
       pt_mem.put("extended_info.ecc.error.correctable.count", ce_cnt);

--- a/src/runtime_src/core/common/info_memory.cpp
+++ b/src/runtime_src/core/common/info_memory.cpp
@@ -244,8 +244,10 @@ struct memory_info_collector
 
     for (const auto& topology : hw_context_memories) {
       const auto mem_topo = reinterpret_cast<const mem_topology*>(topology.topology.data());
+      
       for (int i = 0; i < mem_topo->m_count; ++i) {
         const auto& mem = mem_topo->m_mem_data[i];
+        
         if (mem.m_type == MEM_STREAMING || mem.m_type == MEM_STREAMING_CONNECTION)
           add_stream_info(&mem, pt_stream_array);
         else {
@@ -328,18 +330,18 @@ public:
     }
 
     // validate the memory topologies for each hardware context
-    for (const auto& topo : hw_context_memories) {
-      const auto mem_topo = reinterpret_cast<const mem_topology*>(topo.topology.data());
-      const auto& mem_stat = topo.statistics;
-      const auto grp_topo = reinterpret_cast<const mem_topology*>(topo.grp_topology.data());
-      const auto mem_temp = reinterpret_cast<const uint32_t*>(topo.temperature.data());
+    for (const auto& memory : hw_context_memories) {
+      const auto mem_topo = reinterpret_cast<const mem_topology*>(memory.topology.data());
+      const auto& mem_stat = memory.statistics;
+      const auto grp_topo = reinterpret_cast<const mem_topology*>(memory.grp_topology.data());
+      const auto mem_temp = reinterpret_cast<const uint32_t*>(memory.temperature.data());
 
       // info gathering functions indexes mem_stat by mem_toplogy entry index
       if (mem_topo && mem_stat.size() < static_cast<size_t>(mem_topo->m_count))
         throw xrt_core::internal_error("incorrect memstat_raw entries");
 
       // info gathering functions indexes mem_temp by mem_topology entry index
-      if (mem_topo && mem_temp && topo.temperature.size() < static_cast<size_t>(mem_topo->m_count))
+      if (mem_topo && mem_temp && memory.temperature.size() < static_cast<size_t>(mem_topo->m_count))
         throw xrt_core::internal_error("incorrect temp_by_mem_topology entries");
 
       // info gathering functions indexes mem_stat by group_toplogy entry index

--- a/src/runtime_src/core/common/info_memory.cpp
+++ b/src/runtime_src/core/common/info_memory.cpp
@@ -211,14 +211,11 @@ struct memory_info_collector
   // This function is shared with group topology, hence need to
   // know where the mem entry is comining from
   void
-  add_mem_usage_info(
-    const size_t idx,
-    const xrt_core::query::memstat_raw::result_type& mem_stat,
-    ptree_type& pt_mem)
+  add_mem_usage_info(const std::string& mem_stat, ptree_type& pt_mem)
   {
     uint64_t memory_usage = 0;
     uint64_t bo_count = 0;
-    std::stringstream {mem_stat[idx]} >> memory_usage >> bo_count; // idx has been validated
+    std::stringstream {mem_stat} >> memory_usage >> bo_count; // idx has been validated
     pt_mem.put("extended_info.usage.allocated_bytes", memory_usage);
     pt_mem.put("extended_info.usage.buffer_objects_count", bo_count);
   }
@@ -257,7 +254,7 @@ struct memory_info_collector
           ptree_type pt_mem;
           add_mem_ecc_info(&mem, pt_mem);
           add_mem_general_info(topology, &mem, pt_mem);
-          add_mem_usage_info(i, topology.statistics, pt_mem);
+          add_mem_usage_info(topology.statistics[i], pt_mem);
           add_mem_temp_info(i, topology.temperature, pt_mem);
           pt_mem_array.push_back(std::make_pair("", pt_mem));
         }
@@ -288,7 +285,7 @@ struct memory_info_collector
       for (int i = mem_topo->m_count; i < grp_topo->m_count; i++) {
         ptree_type pt_grp;
         add_mem_general_info(topology, &grp_topo->m_mem_data[i], pt_grp);
-        add_mem_usage_info(i, topology.statistics, pt_grp);
+        add_mem_usage_info(topology.statistics[i], pt_grp);
         pt_grp_array.push_back(std::make_pair("",pt_grp));
       }
     }

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -728,7 +728,7 @@ struct mem_topology_raw : request
 
 struct mem_topology : request
 {
-  struct mem_data {
+  struct memory_data {
     std::string xclbin_uuid;
     uint32_t hw_context_slot;
     uint8_t m_type;          // enum corresponding to mem_type.
@@ -744,7 +744,7 @@ struct mem_topology : request
     unsigned char m_tag[16]; // DDR: BANK0,1,2,3, has to be null terminated; if streaming then stream0, 1 etc
   };
 
-  using data_type = struct mem_data;
+  using data_type = struct memory_data;
   using result_type = std::vector<data_type>;
   static const key_type key = key_type::mem_topology;
 

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -70,6 +70,7 @@ enum class key_type
   memstat,
   memstat_raw,
   temp_by_mem_topology,
+  mem_topology,
   mem_topology_raw,
   ip_layout_raw,
   debug_ip_layout_raw,
@@ -720,6 +721,32 @@ struct mem_topology_raw : request
 {
   using result_type = std::vector<char>;
   static const key_type key = key_type::mem_topology_raw;
+
+  virtual boost::any
+  get(const device*) const = 0;
+};
+
+struct mem_topology : request
+{
+  struct mem_data {
+    std::string xclbin_uuid;
+    uint32_t hw_context_slot;
+    uint8_t m_type;          // enum corresponding to mem_type.
+    uint8_t m_used;          // if 0 this bank is not present
+    union {
+        uint64_t m_size;     // if mem_type DDR, then size in KB;
+        uint64_t route_id;   // if streaming then "route_id"
+    };
+    union {
+        uint64_t m_base_address; // if DDR then the base address;
+        uint64_t flow_id;        // if streaming then "flow id"
+    };
+    unsigned char m_tag[16]; // DDR: BANK0,1,2,3, has to be null terminated; if streaming then stream0, 1 etc
+  };
+
+  using data_type = struct mem_data;
+  using result_type = std::vector<data_type>;
+  static const key_type key = key_type::mem_topology;
 
   virtual boost::any
   get(const device*) const = 0;

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -724,9 +724,6 @@ struct mem_topology_raw : request
 
   virtual boost::any
   get(const device*) const = 0;
-
-  virtual boost::any
-  get(const device*) const = 0;
 };
 
 struct xclbin_full : request

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -17,7 +17,6 @@
 
 #include "pcidev.h"
 #include "xrt.h"
-#include "xclbin.h"
 
 #include <array>
 #include <fstream>
@@ -1031,35 +1030,6 @@ struct sysfs_fcn<std::vector<VectorValueType>>
   }
 };
 
-struct memory_topology
-{
-  using data_type = query::mem_topology::data_type;
-  using result_type = query::mem_topology::result_type;
-
-  static result_type
-  get(const xrt_core::device* device, key_type)
-  {
-    const auto data = xrt_core::device_query<query::mem_topology_raw>(device);
-    const auto mem_topo = reinterpret_cast<const struct mem_topology*>(data.data());
-    const auto xclbin_uuid = xrt_core::device_query<query::xclbin_uuid>(device);
-    result_type topology;
-    for (int32_t index = 0; index < mem_topo->m_count; index++) {
-      data_type mem_data;
-      mem_data.xclbin_uuid = xclbin_uuid;
-      mem_data.hw_context_slot = 0;
-      mem_data.m_type = mem_topo->m_mem_data[index].m_type;
-      mem_data.m_used = mem_topo->m_mem_data[index].m_used;
-      memcpy(mem_data.m_tag, mem_topo->m_mem_data[index].m_tag, sizeof(mem_topo->m_mem_data[index].m_tag));
-      // The following two entries are unions
-      // Within the union using any name would work. So use the first!
-      mem_data.m_size = mem_topo->m_mem_data[index].m_size;
-      mem_data.m_base_address = mem_topo->m_mem_data[index].m_base_address;
-      topology.push_back(mem_data);
-    }
-    return topology;
-  }
-};
-
 /* Accelerator Deadlock Detector status
  * In PCIe Linux, access the sysfs file for Accelerator Deadlock Detector to retrieve the deadlock status
  */
@@ -1219,7 +1189,6 @@ initialize_query_table()
   emplace_sysfs_getput<query::ic_load_flash_address>           ("icap_controller", "load_flash_addr");
   emplace_sysfs_get<query::memstat>                            ("", "memstat");
   emplace_sysfs_get<query::memstat_raw>                        ("", "memstat_raw");
-  emplace_func0_request<query::mem_topology,                   memory_topology>();
   emplace_sysfs_get<query::mem_topology_raw>                   ("icap", "mem_topology");
   emplace_sysfs_get<query::dma_stream>                         ("dma", "");
   emplace_sysfs_get<query::group_topology>                     ("icap", "group_topology");

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -1042,13 +1042,14 @@ struct memory_topology
     const auto data = xrt_core::device_query<query::mem_topology_raw>(device);
     const auto mem_topo = reinterpret_cast<const struct mem_topology*>(data.data());
     const auto xclbin_uuid = xrt_core::device_query<query::xclbin_uuid>(device);
-    result_type topology(mem_topo->m_count);
+    result_type topology;
     for (int32_t index = 0; index < mem_topo->m_count; index++) {
       data_type mem_data;
       mem_data.xclbin_uuid = xclbin_uuid;
       mem_data.hw_context_slot = 0;
       mem_data.m_type = mem_topo->m_mem_data[index].m_type;
       mem_data.m_used = mem_topo->m_mem_data[index].m_used;
+      memcpy(mem_data.m_tag, mem_topo->m_mem_data[index].m_tag, sizeof(mem_topo->m_mem_data[index].m_tag));
       // The following two entries are unions
       // Within the union using any name would work. So use the first!
       mem_data.m_size = mem_topo->m_mem_data[index].m_size;

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -17,6 +17,7 @@
 
 #include "pcidev.h"
 #include "xrt.h"
+#include "xclbin.h"
 
 #include <array>
 #include <fstream>
@@ -1030,6 +1031,34 @@ struct sysfs_fcn<std::vector<VectorValueType>>
   }
 };
 
+struct memory_topology
+{
+  using data_type = query::mem_topology::data_type;
+  using result_type = query::mem_topology::result_type;
+
+  static result_type
+  get(const xrt_core::device* device, key_type)
+  {
+    const auto data = xrt_core::device_query<query::mem_topology_raw>(device);
+    const auto mem_topo = reinterpret_cast<const struct mem_topology*>(data.data());
+    const auto xclbin_uuid = xrt_core::device_query<query::xclbin_uuid>(device);
+    result_type topology(mem_topo->m_count);
+    for (int32_t index = 0; index < mem_topo->m_count; index++) {
+      data_type mem_data;
+      mem_data.xclbin_uuid = xclbin_uuid;
+      mem_data.hw_context_slot = 0;
+      mem_data.m_type = mem_topo->m_mem_data[index].m_type;
+      mem_data.m_used = mem_topo->m_mem_data[index].m_used;
+      // The following two entries are unions
+      // Within the union using any name would work. So use the first!
+      mem_data.m_size = mem_topo->m_mem_data[index].m_size;
+      mem_data.m_base_address = mem_topo->m_mem_data[index].m_base_address;
+      topology.push_back(mem_data);
+    }
+    return topology;
+  }
+};
+
 /* Accelerator Deadlock Detector status
  * In PCIe Linux, access the sysfs file for Accelerator Deadlock Detector to retrieve the deadlock status
  */
@@ -1189,6 +1218,7 @@ initialize_query_table()
   emplace_sysfs_getput<query::ic_load_flash_address>           ("icap_controller", "load_flash_addr");
   emplace_sysfs_get<query::memstat>                            ("", "memstat");
   emplace_sysfs_get<query::memstat_raw>                        ("", "memstat_raw");
+  emplace_func0_request<query::mem_topology,                   memory_topology>();
   emplace_sysfs_get<query::mem_topology_raw>                   ("icap", "mem_topology");
   emplace_sysfs_get<query::dma_stream>                         ("dma", "");
   emplace_sysfs_get<query::group_topology>                     ("icap", "group_topology");

--- a/src/runtime_src/core/tools/common/ReportMemory.cpp
+++ b/src/runtime_src/core/tools/common/ReportMemory.cpp
@@ -132,10 +132,12 @@ ReportMemory::writeReport( const xrt_core::device* /*_pDevice*/,
     Table2D device_table(table_headers);
 
     try {
-      // Generate map of hw_context/xclbin uuid to the contained memories
+      // Generate map of hw_context/xclbin uuid to a list of formatted memory table entries
       std::map<std::tuple<std::string, std::string>, std::vector<std::vector<std::string>>> memory_map;
-      for (auto& v : _pt.get_child("mem_topology.board.memory.memories",empty_ptree)) {
+
+      for (const auto& v : _pt.get_child("mem_topology.board.memory.memories",empty_ptree)) {
         std::string slot, uuid, tag, size, type, temp, base_addr;
+
         for (auto& subv : v.second) {
           if (subv.first == "type") {
             type = subv.second.get_value<std::string>();
@@ -161,7 +163,8 @@ ReportMemory::writeReport( const xrt_core::device* /*_pDevice*/,
         iter.first->second.push_back(entry_data);
       }
 
-      // Format the output of the memory map generated above into a table
+      // Within each hardware context add an index number to the front
+      // of each memory table entry
       for (auto& hw_context : memory_map) {
         _output << boost::format("    HW Context Slot: %s\n") % std::get<0>(hw_context.first);
         _output << boost::format("      Xclbin UUID: %s\n") % std::get<1>(hw_context.first);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/VITIS-8071
The current memory report does not correlate to how hardware contexts use memory.

If you have any opinions on the report output please let me know. I am happy to make any changes.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
For the hardware context concept, memory is tied into a particular hardware context slot. For Alveo devices this was not an issue. However, for AIE devices with multiple hardware context slots we need a way to store and logically display these memory banks to the user.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Assign to each memory bank the xclbin uuid and hw context slot from which it came. Also updated how ReportMemory displays memory banks.

#### Risks (if any) associated the changes in the commit
The output json has new fields added to each memory item. This will not interfere with any previous parsing scripts.

#### What has been tested and how, request additional testing if necessary
Ubuntu 20.04 U50C
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ xbutil examine -d 04:00 -r memory
WARNING: Unexpected xocl version (2.14.0) was found. Expected 2.15.0, to match XRT tools.

-------------------------------------------------
[0000:04:00.1] : xilinx_u55c_gen3x16_xdma_base_3
-------------------------------------------------

  Memory Topology
    HW Context Slot: 0
      Xclbin UUID: e106e953-cf90-4024-e075-282d1a7d820b
      Index  Tag       Type      Temp(C)  Size    Base Address
      ----------------------------------------------------------
      0      HBM[0]    MEM_HBM   37       512 MB  0x0
      1      HBM[1]    MEM_DRAM  37       512 MB  0x20000000
      2      HBM[2]    MEM_DRAM  37       512 MB  0x40000000
      3      HBM[3]    MEM_DRAM  37       512 MB  0x60000000
      4      HBM[4]    MEM_DRAM  37       512 MB  0x80000000
      5      HBM[5]    MEM_DRAM  37       512 MB  0xa0000000
      6      HBM[6]    MEM_DRAM  37       512 MB  0xc0000000
      7      HBM[7]    MEM_DRAM  37       512 MB  0xe0000000
      8      HBM[8]    MEM_DRAM  37       512 MB  0x100000000
      9      HBM[9]    MEM_DRAM  37       512 MB  0x120000000
      10     HBM[10]   MEM_DRAM  37       512 MB  0x140000000
      11     HBM[11]   MEM_DRAM  37       512 MB  0x160000000
      12     HBM[12]   MEM_DRAM  37       512 MB  0x180000000
      13     HBM[13]   MEM_DRAM  37       512 MB  0x1a0000000
      14     HBM[14]   MEM_DRAM  37       512 MB  0x1c0000000
      15     HBM[15]   MEM_DRAM  37       512 MB  0x1e0000000
      16     HBM[16]   MEM_DRAM  37       512 MB  0x200000000
      17     HBM[17]   MEM_DRAM  37       512 MB  0x220000000
      18     HBM[18]   MEM_DRAM  37       512 MB  0x240000000
      19     HBM[19]   MEM_DRAM  37       512 MB  0x260000000
      20     HBM[20]   MEM_DRAM  37       512 MB  0x280000000
      21     HBM[21]   MEM_DRAM  37       512 MB  0x2a0000000
      22     HBM[22]   MEM_DRAM  37       512 MB  0x2c0000000
      23     HBM[23]   MEM_DRAM  37       512 MB  0x2e0000000
      24     HBM[24]   MEM_DRAM  37       512 MB  0x300000000
      25     HBM[25]   MEM_DRAM  37       512 MB  0x320000000
      26     HBM[26]   MEM_DRAM  37       512 MB  0x340000000
      27     HBM[27]   MEM_DRAM  37       512 MB  0x360000000
      28     HBM[28]   MEM_DRAM  37       512 MB  0x380000000
      29     HBM[29]   MEM_DRAM  37       512 MB  0x3a0000000
      30     HBM[30]   MEM_DRAM  37       512 MB  0x3c0000000
      31     HBM[31]   MEM_DRAM  37       512 MB  0x3e0000000
      32     PLRAM[0]  MEM_DRAM  N/A      0 Byte  0x0
      33     PLRAM[1]  MEM_DRAM  N/A      0 Byte  0x0
      34     PLRAM[2]  MEM_DRAM  N/A      0 Byte  0x0
      35     PLRAM[3]  MEM_DRAM  N/A      0 Byte  0x0
      36     PLRAM[4]  MEM_DRAM  N/A      0 Byte  0x0
      37     PLRAM[5]  MEM_DRAM  N/A      0 Byte  0x0
      38     HOST[0]   MEM_DRAM  N/A      0 Byte  0x0

  DMA Transfer Metrics
    Chan[ 0].h2c:  0 Byte
    Chan[ 0].c2h:  192 Byte
    Chan[ 1].h2c:  0 Byte
    Chan[ 1].c2h:  0 Byte
```

#### Documentation impact (if any)
We may need to add  something about what a hardware context is? Not sure if we have any details in the documentation about it.