### PR TITLE
CR-1154325 XRT tools should tell if shell needs to be upgraded

### DIFF
--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -347,7 +347,7 @@ XBUtilities::collect_devices( const std::set<std::string> &_deviceBDFs,
       cur_ver = (boost::equals(cur_ver, zeroes)) ? unavail : cur_ver;
       exp_ver = (boost::equals(exp_ver, zeroes)) ? unavail : exp_ver;
       if (boost::equals(cur_ver, unavail) || boost::equals(exp_ver, unavail))
-        warnings.push_back(boost::str(boost::format("SC version data missing. Upgrade your shell") % exp_ver % cur_ver));
+        warnings.push_back("SC version data missing. Upgrade your shell");
       else if (!boost::equals(cur_ver, exp_ver))
         warnings.push_back(boost::str(boost::format("Invalid SC version. Expected: %s Current: %s") % exp_ver % cur_ver));
     } catch (const xrt_core::error& e) {

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -346,8 +346,9 @@ XBUtilities::collect_devices( const std::set<std::string> &_deviceBDFs,
       auto exp_ver = xrt_core::device_query_default<xrt_core::query::hwmon_sdm_target_msp_ver>(device, unavail);
       cur_ver = (boost::equals(cur_ver, zeroes)) ? unavail : cur_ver;
       exp_ver = (boost::equals(exp_ver, zeroes)) ? unavail : exp_ver;
-      if (boost::equals(cur_ver, unavail) || boost::equals(exp_ver, unavail))
-        warnings.push_back(boost::str(boost::format("SC version data missing. Expected: %s Current: %s") % exp_ver % cur_ver));
+      if (boost::equals(cur_ver, unavail) || boost::equals(exp_ver, unavail)) {
+        warnings.push_back(boost::str(boost::format("SC version data missing. Upgrade your shell") % exp_ver % cur_ver));
+      }
       else if (!boost::equals(cur_ver, exp_ver))
         warnings.push_back(boost::str(boost::format("Invalid SC version. Expected: %s Current: %s") % exp_ver % cur_ver));
     } catch (const xrt_core::error& e) {

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -346,9 +346,8 @@ XBUtilities::collect_devices( const std::set<std::string> &_deviceBDFs,
       auto exp_ver = xrt_core::device_query_default<xrt_core::query::hwmon_sdm_target_msp_ver>(device, unavail);
       cur_ver = (boost::equals(cur_ver, zeroes)) ? unavail : cur_ver;
       exp_ver = (boost::equals(exp_ver, zeroes)) ? unavail : exp_ver;
-      if (boost::equals(cur_ver, unavail) || boost::equals(exp_ver, unavail)) {
+      if (boost::equals(cur_ver, unavail) || boost::equals(exp_ver, unavail))
         warnings.push_back(boost::str(boost::format("SC version data missing. Upgrade your shell") % exp_ver % cur_ver));
-      }
       else if (!boost::equals(cur_ver, exp_ver))
         warnings.push_back(boost::str(boost::format("Invalid SC version. Expected: %s Current: %s") % exp_ver % cur_ver));
     } catch (const xrt_core::error& e) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1154325
Early shell currently has N/A version read out which is very unhelpful. We should let the end user know that they need to upgrade their shell.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Introduced in https://github.com/Xilinx/XRT/pull/7304.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Replaced the "N/A" printout with "Upgrade your shell" printout

#### Risks (if any) associated the changes in the commit
None.

#### What has been tested and how, request additional testing if necessary
Ubuntu 20.04 VCK5000
Modified the code to generate this message
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ xbutil examine -d 17:00
WARNING: Unexpected xocl version (2.14.0) was found. Expected 2.16.0, to match XRT tools.
***********************************************************
*        WARNING          WARNING          WARNING        *
*       SC version data missing. Upgrade your shell       *
***********************************************************

---------------------------------------------------
[0000:17:00.1] : xilinx_vck5000_gen4x8_qdma_base_2
---------------------------------------------------
Platform
  XSA Name               : xilinx_vck5000_gen4x8_qdma_base_2
  Platform UUID          : 05DCA096-76CB-730B-8D19-EC1192FBAE3F
  FPGA Name              :
  JTAG ID Code           : 0x0
  DDR Size               : 0 Bytes
  DDR Count              : 0
  Revision               : A
  MFG Date               : 0xcc344c
  Mig Calibrated         : false
  P2P Status             : not supported

Mac Addresses            : 00:0A:35:0A:7F:AE
                         : 00:0A:35:0A:7F:AF

  Hardware Context ID: 0
    Xclbin UUID:
```

#### Documentation impact (if any)
None.