### PR TITLE
Fixed DMA validation test for new hw context

### DIFF
--- a/src/runtime_src/core/include/xrt_mem.h
+++ b/src/runtime_src/core/include/xrt_mem.h
@@ -69,6 +69,8 @@ struct xcl_bo_flags
   };
 };
 
+#define XRT_BO_FLAGS_SLOTIDX_SHIFT	16
+
 /**
  * XCL BO Flags bits layout
  *

--- a/src/runtime_src/core/include/xrt_mem.h
+++ b/src/runtime_src/core/include/xrt_mem.h
@@ -69,8 +69,6 @@ struct xcl_bo_flags
   };
 };
 
-#define XRT_BO_FLAGS_SLOTIDX_SHIFT	16
-
 /**
  * XCL BO Flags bits layout
  *

--- a/src/runtime_src/core/pcie/common/dmatest.h
+++ b/src/runtime_src/core/pcie/common/dmatest.h
@@ -134,7 +134,7 @@ namespace xcldev {
 	    mhwCtxHandle = mHandle->create_hw_context(mHandle->get_xclbin_uuid().get(), {}, xrt::hw_context::access_mode::shared);
 	    xcl_bo_flags xflags{mFlags};
 	    xflags.slot = mhwCtxHandle->get_slotidx();
-	    mFlags = xFlags.flags;
+	    mFlags = xflags.flags;
 
             for (long long i = 0; i < count; i++) {
                 // This can throw and callers of DMARunner are supposed to catch this.
@@ -151,6 +151,8 @@ namespace xcldev {
 
         ~DMARunner()
         {
+	    // This explicit call is to make sure BOs get free before hw context
+	    // handler (mhwCtxHandle) destructed.
 	    mBOList.clear();
 	}
 

--- a/src/runtime_src/core/pcie/common/dmatest.h
+++ b/src/runtime_src/core/pcie/common/dmatest.h
@@ -131,9 +131,11 @@ namespace xcldev {
             if (count > 0x40000)
                 count = 0x40000;
 
-	    xrt::hw_context::cfg_param_type cfg_param;
-	    mhwCtxHandle = mHandle->create_hw_context(mHandle->get_xclbin_uuid().get(), cfg_param, xrt::hw_context::access_mode::shared);
-	    mFlags |= ((mFlags & ~XRT_BO_FLAGS_MEMIDX_MASK) | (mhwCtxHandle->get_slotidx() << XRT_BO_FLAGS_SLOTIDX_SHIFT));
+	    mhwCtxHandle = mHandle->create_hw_context(mHandle->get_xclbin_uuid().get(), {}, xrt::hw_context::access_mode::shared);
+	    xcl_bo_flags xflags{mFlags};
+	    xflags.slot = mhwCtxHandle->get_slotidx();
+	    mFlags = xFlags.flags;
+
             for (long long i = 0; i < count; i++) {
                 // This can throw and callers of DMARunner are supposed to catch this.
                 xrt_core::aligned_ptr_type buf = xrt_core::aligned_alloc(xrt_core::getpagesize(), mSize);

--- a/src/runtime_src/core/pcie/common/dmatest.h
+++ b/src/runtime_src/core/pcie/common/dmatest.h
@@ -133,7 +133,7 @@ namespace xcldev {
 
 	    mhwCtxHandle = mHandle->create_hw_context(mHandle->get_xclbin_uuid().get(), {}, xrt::hw_context::access_mode::shared);
 	    xcl_bo_flags xflags{mFlags};
-	    xflags.slot = mhwCtxHandle->get_slotidx();
+	    xflags.slot = static_cast<uint8_t>(mhwCtxHandle->get_slotidx());
 	    mFlags = xflags.flags;
 
             for (long long i = 0; i < count; i++) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
[CR-1159505](https://jira.xilinx.com/browse/CR-1159505) system crash during xrt stress test
-- The root cause of the issue is, as per the current design BO should be associated with a hw context. 
    If a BO is created without a context and there is a chance that the xclbin is replaced then Driver will through a error that BO is present while XCLBIN is replacing.  

-- This issue only happen for stress test. Single validation will not hit this issue.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
-- Generic issue of stress test. 
-- Hw context & Multislot design is introduced this issue. 

#### How problem was solved, alternative solutions (if any) and why they were rejected
-- Added hw context creation before allocating a BO. 
-- All legacy APIs need to update/remove. 

#### Risks (if any) associated the changes in the commit
-- N/A

#### What has been tested and how, request additional testing if necessary
xbutil validation  and stress test script 

#### Documentation impact (if any)
N/A