### PR TITLE
CR-1158005 Report if a device is in a bad state

### DIFF
--- a/src/runtime_src/core/common/info_memory.cpp
+++ b/src/runtime_src/core/common/info_memory.cpp
@@ -612,7 +612,7 @@ populate_hardware_context(const xrt_core::device* device)
     ptree_type pt_hw;
     pt_hw.put("id", boost::algorithm::to_upper_copy(hw.id));
     pt_hw.put("xclbin_uuid", boost::algorithm::to_upper_copy(hw.xclbin_uuid));
-    pt_hw.put("status", boost::algorithm::to_upper_copy(hw.status));
+    pt_hw.put("status", std::to_string(hw.status));
     pt_hw.add_child("compute_units", populate_cus(device, hw.pl_compute_units, hw.ps_compute_units));
     pt.push_back(std::make_pair("", pt_hw));
   }

--- a/src/runtime_src/core/common/info_memory.cpp
+++ b/src/runtime_src/core/common/info_memory.cpp
@@ -593,6 +593,7 @@ populate_hardware_context(const xrt_core::device* device)
     }
 
     try {
+      // For legacy devices  mark the single hardware context status as the device status
       hw_context.context_status = xrt_core::device_query<xq::device_status>(device);
       hw_context.pl_compute_units = xrt_core::device_query<xq::kds_cu_info>(device);
       hw_context.ps_compute_units = xrt_core::device_query<xq::kds_scu_info>(device);

--- a/src/runtime_src/core/common/info_memory.cpp
+++ b/src/runtime_src/core/common/info_memory.cpp
@@ -593,7 +593,7 @@ populate_hardware_context(const xrt_core::device* device)
     }
 
     try {
-      hw_context.status = xrt_core::device_query<xq::device_status>(device);
+      hw_context.context_status = xrt_core::device_query<xq::device_status>(device);
       hw_context.pl_compute_units = xrt_core::device_query<xq::kds_cu_info>(device);
       hw_context.ps_compute_units = xrt_core::device_query<xq::kds_scu_info>(device);
     }
@@ -612,7 +612,7 @@ populate_hardware_context(const xrt_core::device* device)
     ptree_type pt_hw;
     pt_hw.put("id", boost::algorithm::to_upper_copy(hw.id));
     pt_hw.put("xclbin_uuid", boost::algorithm::to_upper_copy(hw.xclbin_uuid));
-    pt_hw.put("status", std::to_string(hw.status));
+    pt_hw.put("context_status", xq::device_status::parse_status(hw.context_status));
     pt_hw.add_child("compute_units", populate_cus(device, hw.pl_compute_units, hw.ps_compute_units));
     pt.push_back(std::make_pair("", pt_hw));
   }

--- a/src/runtime_src/core/common/info_memory.cpp
+++ b/src/runtime_src/core/common/info_memory.cpp
@@ -593,8 +593,6 @@ populate_hardware_context(const xrt_core::device* device)
     }
 
     try {
-      // For legacy devices  mark the single hardware context status as the device status
-      hw_context.context_status = xrt_core::device_query<xq::device_status>(device);
       hw_context.pl_compute_units = xrt_core::device_query<xq::kds_cu_info>(device);
       hw_context.ps_compute_units = xrt_core::device_query<xq::kds_scu_info>(device);
     }
@@ -613,10 +611,10 @@ populate_hardware_context(const xrt_core::device* device)
     ptree_type pt_hw;
     pt_hw.put("id", boost::algorithm::to_upper_copy(hw.id));
     pt_hw.put("xclbin_uuid", boost::algorithm::to_upper_copy(hw.xclbin_uuid));
-    pt_hw.put("context_status", xq::device_status::parse_status(hw.context_status));
     pt_hw.add_child("compute_units", populate_cus(device, hw.pl_compute_units, hw.ps_compute_units));
     pt.push_back(std::make_pair("", pt_hw));
   }
+
   return pt;
 }
 

--- a/src/runtime_src/core/common/info_memory.cpp
+++ b/src/runtime_src/core/common/info_memory.cpp
@@ -593,6 +593,7 @@ populate_hardware_context(const xrt_core::device* device)
     }
 
     try {
+      hw_context.status = xrt_core::device_query<xq::device_status>(device);
       hw_context.pl_compute_units = xrt_core::device_query<xq::kds_cu_info>(device);
       hw_context.ps_compute_units = xrt_core::device_query<xq::kds_scu_info>(device);
     }
@@ -611,6 +612,7 @@ populate_hardware_context(const xrt_core::device* device)
     ptree_type pt_hw;
     pt_hw.put("id", boost::algorithm::to_upper_copy(hw.id));
     pt_hw.put("xclbin_uuid", boost::algorithm::to_upper_copy(hw.xclbin_uuid));
+    pt_hw.put("status", boost::algorithm::to_upper_copy(hw.status));
     pt_hw.add_child("compute_units", populate_cus(device, hw.pl_compute_units, hw.ps_compute_units));
     pt.push_back(std::make_pair("", pt_hw));
   }

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -887,6 +887,19 @@ struct device_status : request
 
   virtual boost::any
   get(const device*) const = 0;
+
+  static std::string
+  parse_status(const result_type status)
+  {
+    switch (status) {
+      case 0:
+        return "HEALTHY";
+      case 1:
+        return "HANG";
+      default:
+        throw xrt_core::system_error(EINVAL, "Invalid device status: " + status);
+    }
+  }
 };
 
 struct kds_cu_info : request
@@ -954,7 +967,7 @@ struct hw_context_info : request
   struct data {
     std::string id;
     std::string xclbin_uuid;
-    device_status::result_type status;
+    device_status::result_type context_status;
     kds_cu_info::result_type pl_compute_units;
     kds_scu_info::result_type ps_compute_units;
   };

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -878,7 +878,8 @@ struct sdm_sensor_info : request
 };
 
 /**
- * Extract the status of the device KDS
+ * Extract the status of the device
+ * This states whether or not a device is stuck due to an xclbin issue
  */
 struct device_status : request
 {

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -75,6 +75,7 @@ enum class key_type
   debug_ip_layout_raw,
   clock_freq_topology_raw,
   dma_stream,
+  device_status,
   kds_cu_info,
   sdm_sensor_info,
   kds_scu_info,
@@ -876,6 +877,18 @@ struct sdm_sensor_info : request
   get(const device*, const boost::any& req_type) const = 0;
 };
 
+/**
+ * Extract the status of the device KDS
+ */
+struct device_status : request
+{
+  using result_type = uint32_t;
+  static const key_type key = key_type::device_status;
+
+  virtual boost::any
+  get(const device*) const = 0;
+};
+
 struct kds_cu_info : request
 {
   struct data {
@@ -941,6 +954,7 @@ struct hw_context_info : request
   struct data {
     std::string id;
     std::string xclbin_uuid;
+    device_status::result_type status;
     kds_cu_info::result_type pl_compute_units;
     kds_scu_info::result_type ps_compute_units;
   };

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -897,6 +897,8 @@ struct device_status : request
         return "HEALTHY";
       case 1:
         return "HANG";
+      case 2:
+        return "UNKNOWN";
       default:
         throw xrt_core::system_error(EINVAL, "Invalid device status: " + status);
     }
@@ -968,7 +970,6 @@ struct hw_context_info : request
   struct data {
     std::string id;
     std::string xclbin_uuid;
-    device_status::result_type context_status;
     kds_cu_info::result_type pl_compute_units;
     kds_scu_info::result_type ps_compute_units;
   };

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -1308,6 +1308,7 @@ initialize_query_table()
   emplace_sysfs_get<query::mig_ecc_ce_ffa>                     ("mig", "ecc_ce_ffa");
   emplace_sysfs_get<query::mig_ecc_ue_ffa>                     ("mig", "ecc_ue_ffa");
   emplace_sysfs_get<query::flash_bar_offset>                   ("flash", "bar_off");
+  emplace_sysfs_get<query::device_status>                      ("", "device_bad_state");
   emplace_sysfs_get<query::is_mfg>                             ("", "mfg");
   emplace_sysfs_get<query::mfg_ver>                            ("", "mfg_ver");
   emplace_sysfs_get<query::is_recovery>                        ("", "recovery");

--- a/src/runtime_src/core/tools/common/ReportDynamicRegion.cpp
+++ b/src/runtime_src/core/tools/common/ReportDynamicRegion.cpp
@@ -37,7 +37,7 @@ ReportDynamicRegion::getPropertyTree20202( const xrt_core::device * _pDevice,
 }
 
 void 
-ReportDynamicRegion::writeReport( const xrt_core::device* /*_pDevice*/,
+ReportDynamicRegion::writeReport( const xrt_core::device* _pDevice,
                        const boost::property_tree::ptree& _pt, 
                        const std::vector<std::string>& /*_elementsFilter*/,
                        std::ostream & _output) const
@@ -50,10 +50,13 @@ ReportDynamicRegion::writeReport( const xrt_core::device* /*_pDevice*/,
   if(pt_dfx.empty())
     return;
 
+  const auto device_status = xrt_core::device_query_default<xrt_core::query::device_status>(_pDevice, 2);
+  _output << boost::format("  Device Status: %s\n") % xrt_core::query::device_status::parse_status(device_status);
+
   for(auto& k_dfx : pt_dfx) {
     const boost::property_tree::ptree& dfx = k_dfx.second;
     _output << boost::format("  Hardware Context ID: %s\n") % dfx.get<std::string>("id", "N/A");
-    _output << boost::format("    Context Status: %s\n") % dfx.get<std::string>("context_status", "Unknown");
+    
     _output << boost::format("    Xclbin UUID: %s\n") % dfx.get<std::string>("xclbin_uuid", "N/A");
     const std::vector<Table2D::HeaderData> table_headers = {
       {"Index", Table2D::Justification::left},

--- a/src/runtime_src/core/tools/common/ReportDynamicRegion.cpp
+++ b/src/runtime_src/core/tools/common/ReportDynamicRegion.cpp
@@ -53,7 +53,7 @@ ReportDynamicRegion::writeReport( const xrt_core::device* /*_pDevice*/,
   for(auto& k_dfx : pt_dfx) {
     const boost::property_tree::ptree& dfx = k_dfx.second;
     _output << boost::format("  Hardware Context ID: %s\n") % dfx.get<std::string>("id", "N/A");
-    _output << boost::format("    Status: %s\n") % dfx.get<std::string>("status", "Unknown");
+    _output << boost::format("    Context Status: %s\n") % dfx.get<std::string>("context_status", "Unknown");
     _output << boost::format("    Xclbin UUID: %s\n") % dfx.get<std::string>("xclbin_uuid", "N/A");
     const std::vector<Table2D::HeaderData> table_headers = {
       {"Index", Table2D::Justification::left},

--- a/src/runtime_src/core/tools/common/ReportDynamicRegion.cpp
+++ b/src/runtime_src/core/tools/common/ReportDynamicRegion.cpp
@@ -53,6 +53,7 @@ ReportDynamicRegion::writeReport( const xrt_core::device* /*_pDevice*/,
   for(auto& k_dfx : pt_dfx) {
     const boost::property_tree::ptree& dfx = k_dfx.second;
     _output << boost::format("  Hardware Context ID: %s\n") % dfx.get<std::string>("id", "N/A");
+    _output << boost::format("    Status: %s\n") % dfx.get<std::string>("status", "Unknown");
     _output << boost::format("    Xclbin UUID: %s\n") % dfx.get<std::string>("xclbin_uuid", "N/A");
     const std::vector<Table2D::HeaderData> table_headers = {
       {"Index", Table2D::Justification::left},

--- a/src/runtime_src/core/tools/common/XBHelpMenus.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenus.cpp
@@ -213,6 +213,9 @@ XBUtilities::produce_reports( const std::shared_ptr<xrt_core::device>& device,
     ptDevice.put("interface_type", "pcie");
     ptDevice.put("device_id", xrt_core::query::pcie_bdf::to_string(bdf));
 
+    const auto device_status = xrt_core::device_query_default<xrt_core::query::device_status>(device, 2);
+    ptDevice.put("device_status", xrt_core::query::device_status::parse_status(device_status));
+
     bool is_mfg = false;
     try {
       is_mfg = xrt_core::device_query<xrt_core::query::is_mfg>(device);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1158005

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Not a bug.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Use the sysfs node added in https://github.com/Xilinx/XRT/pull/7501 and associate that status with a hardware context. For legacy devices the status is associated with the single hardware context that represents the device. For devices with multiple hardware contexts the driver will populate the context status.

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Ubuntu 20.04 U55C
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ xbutil examine -d 04:00 -r dynamic-regions
WARNING: Unexpected xocl version (2.14.0) was found. Expected 2.16.0, to match XRT tools.

-------------------------------------------------
[0000:04:00.1] : xilinx_u55c_gen3x16_xdma_base_3
-------------------------------------------------
  Hardware Context ID: 0
    Context Status: HEALTHY
    Xclbin UUID: E106E953-CF90-4024-E075-282D1A7D820B
    PL Compute Units
      Index  Name             Base Address  Usage  Status
      -----------------------------------------------------
      0      verify:verify_1  0x800000      1      (IDLE)
```

#### Documentation impact (if any)
None.