### PR TITLE
EDGEML-4839 load xrt_core.dll from where xrt_coreutil.dll is

### DIFF
--- a/src/runtime_src/core/common/dlfcn.h
+++ b/src/runtime_src/core/common/dlfcn.h
@@ -80,6 +80,15 @@ dlsym(void* handle, const char* symbol)
   return ::GetProcAddress(HMODULE(handle),symbol);
 }
 
+inline std::string
+dlpath(const char* dllname) {
+    TCHAR dll_path[MAX_PATH];
+    if (!::GetModuleFileName(::GetModuleHandle(dllname), dll_path, MAX_PATH)) {
+        throw std::runtime_error("Get handle of " + std::string(dllname) + " failed");
+    }
+    return dll_path;
+}
+
 #endif
 
 } // xrt_core

--- a/src/runtime_src/core/common/module_loader.cpp
+++ b/src/runtime_src/core/common/module_loader.cpp
@@ -103,7 +103,7 @@ xilinx_xrt()
 #if defined (__aarch64__) || defined (__arm__)
     xrt = bfs::path("/usr");
 #elif defined (_WIN32)
-    xrt = bfs::path("C:/Windows/System32/AMD");
+    xrt = boost::dll::this_line_location().parent_path();
 #else
     throw std::runtime_error("XILINX_XRT not set");
 #endif

--- a/src/runtime_src/core/common/module_loader.cpp
+++ b/src/runtime_src/core/common/module_loader.cpp
@@ -103,7 +103,7 @@ xilinx_xrt()
 #if defined (__aarch64__) || defined (__arm__)
     xrt = bfs::path("/usr");
 #elif defined (_WIN32)
-    xrt = boost::dll::this_line_location().parent_path();
+    xrt = bfs::path(xrt_core::dlpath("xrt_coreutil.dll")).parent_path();
 #else
     throw std::runtime_error("XILINX_XRT not set");
 #endif


### PR DESCRIPTION
#### Problem solved by the commit
By default, load xrt_core.dll in the same folder as xrt_coreutil.dll, instead of C:/Windows/System32/AMD folder.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Not a bug fix, required by usage.  Jira ID: EDGEML-4839

#### How problem was solved, alternative solutions (if any) and why they were rejected
Look for the current executing code(xrt_coreutil.dll) folder. 

#### Risks (if any) associated the changes in the commit
XILINX_XRT environment variable can still be used to set xrt_core.dll.  

#### What has been tested and how, request additional testing if necessary
test with VAI-RT test app by put DLLs in a specific folder other than C:/Windows/System32/AMD.
