### PR TITLE
 CR-1159622_Mfg_Ver_sysfs_Crash_Impl

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-sysfs.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-sysfs.c
@@ -88,7 +88,10 @@ static ssize_t mfg_ver_show(struct device *dev,
 	struct xclmgmt_dev *lro = dev_get_drvdata(dev);
 	struct VmrStatus vmr_header = {};
 
-	/*Checks for Versal VMR availability; returns -EINVALID for Versal VMR based device.*/
+	/*
+	 * Non-Versal Platform:	ret is ENODEV and continue Reg read from PCIE Bar
+	 * Versal Platform:	ret is 0 or any other and return EINVAL.
+	 */
 	if(xocl_vmr_status(lro, &vmr_header) == -ENODEV)
 		return sprintf(buf, "%d\n", MGMT_READ_REG32(lro, _GOLDEN_VER));
 	return -EINVAL;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-sysfs.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-sysfs.c
@@ -86,8 +86,12 @@ static ssize_t mfg_ver_show(struct device *dev,
 	struct device_attribute *attr, char *buf)
 {
 	struct xclmgmt_dev *lro = dev_get_drvdata(dev);
+	struct VmrStatus vmr_header = {};
 
-	return sprintf(buf, "%d\n", MGMT_READ_REG32(lro, _GOLDEN_VER));
+	/*Checks for Versal VMR availability; returns -EINVALID for Versal VMR based device.*/
+	if(xocl_vmr_status(lro, &vmr_header) == -ENODEV)
+		return sprintf(buf, "%d\n", MGMT_READ_REG32(lro, _GOLDEN_VER));
+	return -EINVAL;
 }
 static DEVICE_ATTR_RO(mfg_ver);
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Identified the sysfs node 'mfg_ver' for host crash and enabled condition to handle crash for Veral family devices with VMR.

#### Risks (if any) associated the changes in the commit
Retained the functionality for non-versal based devices so no risks expected.

#### What has been tested and how, request additional testing if necessary
Tested on VCK5000 and found expected result as below. -EINVALID for VMR presence.
![image](https://user-images.githubusercontent.com/111782805/233222776-aa06ad0d-0f28-4fcd-88ec-81e9d9ab4d7f.png)

#### Documentation impact (if any)
