### PR TITLE
Change export_handle type to uint64_t for Windows

### DIFF
--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -1603,7 +1603,7 @@ xrtBOExport(xrtBufferHandle bhdl)
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
   }
-  return XRT_NULL_BO_EXPORT;
+  return static_cast<xclBufferExportHandle>(XRT_NULL_BO_EXPORT);
 }
 
 xrtBufferHandle

--- a/src/runtime_src/core/common/shim/shared_handle.h
+++ b/src/runtime_src/core/common/shim/shared_handle.h
@@ -21,7 +21,7 @@ class shared_handle
 {
 public:
 #ifdef _WIN32
-  using export_handle = void*;
+  using export_handle = uint64_t;
 #else
   using export_handle = int;
 #endif

--- a/src/runtime_src/core/include/deprecated/xrt.h
+++ b/src/runtime_src/core/include/deprecated/xrt.h
@@ -87,8 +87,8 @@ typedef unsigned int xclBufferHandle;
  * that can be passed between processes.
  */
 #ifdef _WIN32
-typedef void* xclBufferExportHandle;  // TBD
-#define NULLBOEXPORT INVALID_HANDLE_VALUE
+typedef uint64_t xclBufferExportHandle;  // TBD
+#define NULLBOEXPORT -1
 #else
 typedef int32_t xclBufferExportHandle;
 #define NULLBOEXPORT -1

--- a/src/runtime_src/core/pcie/windows/alveo/shim.cpp
+++ b/src/runtime_src/core/pcie/windows/alveo/shim.cpp
@@ -1960,7 +1960,7 @@ xclExportBO(xclDeviceHandle handle, xclBufferHandle boHandle)
 {
   xrt_core::message::
     send(xrt_core::message::severity_level::debug, "XRT", "xclExportBO() NOT IMPLEMENTED");
-  return INVALID_HANDLE_VALUE;
+  return static_cast<xclBufferExportHandle>(XRT_NULL_BO_EXPORT);
 }
 
 xclBufferHandle

--- a/src/runtime_src/xdp/profile/device/hal_device/xdp_hal_device.cpp
+++ b/src/runtime_src/xdp/profile/device/hal_device/xdp_hal_device.cpp
@@ -223,11 +223,10 @@ std::string HalDevice::getSubDevicePath(std::string& subdev, uint32_t index)
 
 xclBufferExportHandle HalDevice::getBufferExportHandle(size_t id)
 {
-  if(!id) return XRT_NULL_BO_EXPORT;
+  if(!id) return static_cast<xclBufferExportHandle>(XRT_NULL_BO_EXPORT);
   size_t boIndex = id - 1;
 
   return (xrt_bos[boIndex].export_buffer());
 }
 
 }
-

--- a/src/runtime_src/xdp/profile/device/xrt_device/xdp_xrt_device.cpp
+++ b/src/runtime_src/xdp/profile/device/xrt_device/xdp_xrt_device.cpp
@@ -180,8 +180,7 @@ std::string XrtDevice::getSubDevicePath(std::string& subdev, uint32_t index)
 
 xclBufferExportHandle XrtDevice::getBufferExportHandle(size_t /*id*/)
 {
-  return XRT_NULL_BO_EXPORT;
+  return static_cast<xclBufferExportHandle>(XRT_NULL_BO_EXPORT);
 }
 
 }
-


### PR DESCRIPTION
#### Problem solved by the commit
Change `xrt_core::shared_handle::export_handle` to `uint64_t` on Windows

#### How problem was solved, alternative solutions (if any) and why they were rejected
While the underlying export handle is an NT handle, the type exported to host application is integral uint64_t.  Under the hood the windows implementation manages conversion between integral and NT handle.

An integral type is easier to manage for the host application, e.g. there will be no explicit casting necessary for transfer between processes.

#### Risks (if any) associated the changes in the commit
None, exporting is not supported on Alveo windows.
