### PR TITLE
CR-1142798 Platform UUID should be updated in xbmgmt examine report

### DIFF
--- a/src/runtime_src/core/tools/common/ReportHost.cpp
+++ b/src/runtime_src/core/tools/common/ReportHost.cpp
@@ -118,7 +118,7 @@ ReportHost::writeReport(const xrt_core::device* /*_pDevice*/,
   const Table2D::HeaderData bdf = {"BDF", Table2D::Justification::left};
   const Table2D::HeaderData colon = {":", Table2D::Justification::left};
   const Table2D::HeaderData vbnv = {"Shell", Table2D::Justification::left};
-  const Table2D::HeaderData id = {"Platform UUID", Table2D::Justification::left};
+  const Table2D::HeaderData id = {"Logic UUID", Table2D::Justification::left};
   const Table2D::HeaderData instance = {"Device ID", Table2D::Justification::left};
   const Table2D::HeaderData ready = {"Device Ready*", Table2D::Justification::left};
   const std::vector<Table2D::HeaderData> table_headers = {bdf, colon, vbnv, id, instance, ready};

--- a/src/runtime_src/core/tools/common/ReportPlatforms.cpp
+++ b/src/runtime_src/core/tools/common/ReportPlatforms.cpp
@@ -60,7 +60,7 @@ ReportPlatforms::writeReport( const xrt_core::device* /*_pDevice*/,
     const boost::property_tree::ptree& pt_platform = kp.second;
     const boost::property_tree::ptree& pt_static_region = pt_platform.get_child("static_region", empty_ptree);
     _output << boost::format("  %-23s: %s \n") % "XSA Name" % pt_static_region.get<std::string>("vbnv");
-    _output << boost::format("  %-23s: %s \n") % "Platform UUID" % pt_static_region.get<std::string>("logic_uuid");
+    _output << boost::format("  %-23s: %s \n") % "Logic UUID" % pt_static_region.get<std::string>("logic_uuid");
     _output << boost::format("  %-23s: %s \n") % "FPGA Name" % pt_static_region.get<std::string>("fpga_name");
     _output << boost::format("  %-23s: %s \n") % "JTAG ID Code" % pt_static_region.get<std::string>("jtag_idcode");
     

--- a/src/runtime_src/core/tools/xbmgmt2/OO_UpdateBase.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_UpdateBase.cpp
@@ -276,7 +276,7 @@ pretty_print_platform_info(const boost::property_tree::ptree& _ptDevice, const s
   std::cout << boost::format("  %-20s : %s\n") % "SC Version" % platform_to_flash.get<std::string>("sc_version", "N/A");
   auto logic_uuid = platform_to_flash.get<std::string>("logic-uuid", "");
   if (!logic_uuid.empty()) {
-    std::cout << boost::format("  %-20s : %s\n") % "Platform UUID" % logic_uuid;
+    std::cout << boost::format("  %-20s : %s\n") % "Logic UUID" % logic_uuid;
   } else {
     std::cout << boost::format("  %-20s : %s\n") % "Platform ID" % platform_to_flash.get<std::string>("id", "N/A");
   }

--- a/src/runtime_src/core/tools/xbmgmt2/ReportPlatform.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/ReportPlatform.cpp
@@ -362,7 +362,7 @@ ReportPlatform::writeReport( const xrt_core::device* /*_pDevice*/,
   auto logic_uuid = _pt.get<std::string>("platform.current_shell.logic-uuid", "");
   auto interface_uuid = _pt.get<std::string>("platform.current_shell.interface-uuid", "");
   if (!logic_uuid.empty() && !interface_uuid.empty()) {
-    _output << fmtBasic % "Platform UUID" % logic_uuid;
+    _output << fmtBasic % "Logic UUID" % logic_uuid;
     _output << fmtBasic % "Interface UUID" % interface_uuid;
   } else {
     _output << fmtBasic % "Platform ID" % string_or_NA(_pt.get<std::string>("platform.current_shell.id", ""));
@@ -392,9 +392,9 @@ ReportPlatform::writeReport( const xrt_core::device* /*_pDevice*/,
     _output << fmtBasic % "Platform" % string_or_NA(available_shell.get<std::string>("vbnv"));
     _output << fmtBasic % "SC Version" % string_or_NA(available_shell.get<std::string>("sc_version"));
     // print platform ID, for 2RP, platform ID = logic UUID
-    auto platform_uuid = available_shell.get<std::string>("logic-uuid", "");
-    if (!platform_uuid.empty()) {
-      _output << fmtBasic % "Platform UUID" % platform_uuid;
+    auto logic_uuid = available_shell.get<std::string>("logic-uuid", "");
+    if (!logic_uuid.empty()) {
+      _output << fmtBasic % "Logic UUID" % logic_uuid;
     } else {
       _output << fmtBasic % "Platform ID" % string_or_NA(available_shell.get<std::string>("id"));
     }

--- a/src/runtime_src/core/tools/xbmgmt2/ReportPlatform.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/ReportPlatform.cpp
@@ -392,9 +392,9 @@ ReportPlatform::writeReport( const xrt_core::device* /*_pDevice*/,
     _output << fmtBasic % "Platform" % string_or_NA(available_shell.get<std::string>("vbnv"));
     _output << fmtBasic % "SC Version" % string_or_NA(available_shell.get<std::string>("sc_version"));
     // print platform ID, for 2RP, platform ID = logic UUID
-    auto logic_uuid = available_shell.get<std::string>("logic-uuid", "");
-    if (!logic_uuid.empty()) {
-      _output << fmtBasic % "Logic UUID" % logic_uuid;
+    auto available_shell_logic_uuid = available_shell.get<std::string>("logic-uuid", "");
+    if (!available_shell_logic_uuid.empty()) {
+      _output << fmtBasic % "Logic UUID" % available_shell_logic_uuid;
     } else {
       _output << fmtBasic % "Platform ID" % string_or_NA(available_shell.get<std::string>("id"));
     }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1142798

Customers and developers are constantly confused by Platform UUID and Logic UUID.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
N/A

#### How problem was solved, alternative solutions (if any) and why they were rejected
Refactor `Platform UUID` to `Logic UUID`

#### Risks (if any) associated the changes in the commit
None.

#### What has been tested and how, request additional testing if necessary
Ubuntu 20.04 U55C
Host Report
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ xbutil examine
WARNING: Unexpected xocl version (2.14.0) was found. Expected 2.16.0, to match XRT tools.
System Configuration
  OS Name              : Linux
  Release              : 5.4.0-126-generic
  Version              : #142-Ubuntu SMP Fri Aug 26 12:12:57 UTC 2022
  Machine              : x86_64
  CPU Cores            : 16
  Memory               : 64007 MB
  Distribution         : Ubuntu 20.04.1 LTS
  GLIBC                : 2.31
  Model                : Precision 5820 Tower

XRT
  Version              : 2.16.0
  Branch               : CR-1142798
  Hash                 : e45f7d71fd83ae8a4925f311c4bb313a14b43b77
  Hash Date            : 2023-04-20 14:01:55
  XOCL                 : 2.14.0, a3befd1ac0b78555ee7150a3199795ed9b49887a
  XCLMGMT              : 2.14.0, a3befd1ac0b78555ee7150a3199795ed9b49887a

Devices present
BDF             :  Shell                            Logic UUID                            Device ID       Device Ready*
-------------------------------------------------------------------------------------------------------------------------
[0000:04:00.1]  :  xilinx_u55c_gen3x16_xdma_base_3  97088961-FEAE-DA91-52A2-1D9DFD63CCEF  user(inst=129)  Yes


* Devices that are not ready will have reduced functionality when using XRT tools
```
xbutil Platform Report
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ xbutil examine -d 04:00
WARNING: Unexpected xocl version (2.14.0) was found. Expected 2.16.0, to match XRT tools.

-------------------------------------------------
[0000:04:00.1] : xilinx_u55c_gen3x16_xdma_base_3
-------------------------------------------------
Platform
  XSA Name               : xilinx_u55c_gen3x16_xdma_base_3
  Logic UUID             : 97088961-FEAE-DA91-52A2-1D9DFD63CCEF
  FPGA Name              :
  JTAG ID Code           : 0x14b7d093
  DDR Size               : 0 Bytes
  DDR Count              : 0
  Mig Calibrated         : true
  P2P Status             : disabled
  P2P IO space required  : 32 GB

Clocks
  DATA_CLK (Data)        : 300 MHz
  KERNEL_CLK (Kernel)    : 500 MHz
  hbm_aclk (System)      : 450 MHz

Mac Addresses            : 00:0A:35:0B:23:98
                         : 00:0A:35:0B:23:99
                         : 00:0A:35:0B:23:9A
                         : 00:0A:35:0B:23:9B
                         : 00:0A:35:0B:23:9C
                         : 00:0A:35:0B:23:9D
                         : 00:0A:35:0B:23:9E
                         : 00:0A:35:0B:23:9F

  Hardware Context ID: 0
    Xclbin UUID: E106E953-CF90-4024-E075-282D1A7D820B
    PL Compute Units
      Index  Name             Base Address  Usage  Status
      -----------------------------------------------------
      0      verify:verify_1  0x800000      1      (IDLE)
```
xbmgmt platform report
```
root@xsjdbenusov50:~# xbmgmt examine -d 04:00
WARNING: Unexpected xclmgmt version (2.14.0) was found. Expected 2.16.0, to match XRT tools.

-------------------------------------------------
[0000:04:00.0] : xilinx_u55c_gen3x16_xdma_base_3
-------------------------------------------------
Flash properties
  Type                 : spi
  Serial Number        : XFL10MFUZEB2

Device properties
  Type                 : u55c
  Name                 : ALVEO U55C PQ
  Config Mode          : 0x7
  Max Power            : 225W

Flashable partitions running on FPGA
  Platform             : xilinx_u55c_gen3x16_xdma_base_3
  SC Version           : 7.1.22
  Logic UUID           : 97088961-FEAE-DA91-52A2-1D9DFD63CCEF
  Interface UUID       : B7AC1ABE-1E3E-1CB6-86D5-A81232452676

Flashable partitions installed in system
  Platform             : xilinx_u55c_gen3x16_xdma_base_3
  SC Version           : 7.1.22
  Logic UUID           : 97088961-FEAE-DA91-52A2-1D9DFD63CCEF


  Mac Address          : 00:0A:35:0B:23:98
                       : 00:0A:35:0B:23:99
                       : 00:0A:35:0B:23:9A
                       : 00:0A:35:0B:23:9B
                       : 00:0A:35:0B:23:9C
                       : 00:0A:35:0B:23:9D
                       : 00:0A:35:0B:23:9E
                       : 00:0A:35:0B:23:9F
```
xbmgmt program
```
root@xsjdbenusov50:~# xbmgmt program -d 04:00 -b --force
WARNING: Unexpected xclmgmt version (2.14.0) was found. Expected 2.16.0, to match XRT tools.
----------------------------------------------------
Device : [0000:04:00.0]

Current Configuration
  Platform             : xilinx_u55c_gen3x16_xdma_base_3
  SC Version           : 7.1.22
  Platform ID          : 0x97088961feaeda91


Incoming Configuration
  Deployment File      : partition.xsabin
  Deployment Directory : /lib/firmware/xilinx/97088961feaeda9152a21d9dfd63ccef
  Size                 : 128,571,157 bytes
  Timestamp            : Wed Mar  8 11:44:14 2023

  Platform             : xilinx_u55c_gen3x16_xdma_base_3
  SC Version           : 7.1.22
  Logic UUID           : 97088961-FEAE-DA91-52A2-1D9DFD63CCEF
----------------------------------------------------
Actions to perform:
  [0000:04:00.0] : Program base (FLASH) image
  [0000:04:00.0] : Program Satellite Controller (SC) image
----------------------------------------------------
Are you sure you wish to proceed? [Y/n]: Y (Force override)

INFO: Forcing flashing of the Satellite Controller (SC) image (Force flag is set).
[0000:04:00.0] : Updating Satellite Controller (SC) firmware flash image
Stopping user function...
```
#### Documentation impact (if any)
None.