### PR TITLE
CR_1158638_Sysfs node size overflow fix

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
@@ -431,13 +431,14 @@ static size_t xgq_vmr_log_dump(struct xocl_xgq_vmr *xgq, int num_recs, char *buf
 				sizeof(log));
 			log_idx = (log_idx + 1) % VMR_LOG_MAX_RECS;
 
-			/* calling call back function */
-			count += dump_cb(xgq, buf ? buf + count : NULL, log.log_buf);
-			if (count > PAGE_SIZE) {
-				XGQ_WARN(xgq, "message size %ld exceeds page %ld",
+			if((PAGE_SIZE) - count < VMR_LOG_ENTRY_SIZE){
+				XGQ_WARN(xgq, "Ignoring messages size %ld exceeds page %ld",
 					count, PAGE_SIZE);
 				break;
 			}
+
+			/* calling call back function */
+			count += dump_cb(xgq, buf ? buf + count : NULL, log.log_buf);
 		}
 	} else {
 		XGQ_WARN(xgq, "vmr payload partition table is not available");

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
@@ -430,8 +430,7 @@ static size_t xgq_vmr_log_dump(struct xocl_xgq_vmr *xgq, int num_recs, char *buf
 				sizeof(log) * log_idx,
 				sizeof(log));
 			log_idx = (log_idx + 1) % VMR_LOG_MAX_RECS;
-
-			if((PAGE_SIZE) - count < VMR_LOG_ENTRY_SIZE){
+			if((PAGE_SIZE - count) < sizeof(log.log_buf)){
 				XGQ_WARN(xgq, "Ignoring messages size %ld exceeds page %ld",
 					count, PAGE_SIZE);
 				break;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Boundary case check improvised to trim the max size of data at sysfs node to be 4K.

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Tested and verified on VCK5000 and found the size is within limit.

#### Documentation impact (if any)
