### PR TITLE
Buffer object experimental extension to support access mode

### DIFF
--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -245,8 +245,12 @@ public:
   // Managed imported handle
   bo_impl(device_type dev, pid_type pid, xrt_core::shared_handle::export_handle ehdl)
     : device(std::move(dev))
-    , handle(device->import_bo(pid.pid, ehdl))
   {
+    auto hwctx = device.get_hwctx_handle();
+    handle = hwctx
+      ? hwctx->import_bo(pid.pid, ehdl)
+      : device->import_bo(pid.pid, ehdl);
+
     auto prop = handle->get_properties();
     size = prop.size;
   }
@@ -1517,6 +1521,11 @@ bo(const xrt::hw_context& hwctx, size_t sz, access_mode access)
 bo::
 bo(const xrt::hw_context& hwctx, size_t sz)
   : bo{hwctx, sz, xrt::ext::bo::access_mode::local}
+{}
+
+bo::
+bo(const xrt::hw_context& hwctx, pid_type pid, xclBufferExportHandle ehdl)
+  : xrt::bo::bo{alloc_import_from_pid(device_type{hwctx}, pid, ehdl)}
 {}
 
 } // xrt::ext

--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -10,6 +10,7 @@
 #include "core/include/xrt/xrt_bo.h"
 #include "core/include/xrt/xrt_aie.h"
 #include "core/include/xrt/xrt_hw_context.h"
+#include "core/include/experimental/xrt_ext.h"
 
 #include "native_profile.h"
 #include "bo.h"
@@ -990,6 +991,7 @@ alloc_bo(const device_type& device, void* userptr, size_t sz, xrtBufferFlags fla
   xcl_bo_flags xgrp{grp};
   xflags.bank = xgrp.bank;
   xflags.slot = xgrp.slot;
+
   auto hwctx  = device.get_hwctx_handle();
   return hwctx
     ? hwctx->alloc_bo(userptr, sz, xflags.all)
@@ -1004,6 +1006,7 @@ alloc_bo(const device_type& device, size_t sz, xrtBufferFlags flags, xrtMemoryGr
   xcl_bo_flags xgrp{grp};
   xflags.bank = xgrp.bank;
   xflags.slot = xgrp.slot;
+
   try {
     auto hwctx  = device.get_hwctx_handle();
     return hwctx
@@ -1470,6 +1473,53 @@ copy(const bo& src, size_t sz, size_t src_offset, size_t dst_offset)
 }
 
 } // xrt
+
+////////////////////////////////////////////////////////////////
+// xrt_ext::bo C++ API implmentations (xrt_ext.h)
+////////////////////////////////////////////////////////////////
+namespace xrt::ext {
+
+static xrtBufferFlags
+adjust_buffer_flags(xrt::ext::bo::access_mode access)
+{
+  // xrt::ext::bo is always a host only BO
+  // instruction buffers are allocated as regular xrt::bo objects
+  // or to-be new first-class instruction buffer
+  xcl_bo_flags flags {0};
+  flags.flags = XRT_BO_FLAGS_HOST_ONLY;
+  flags.access = static_cast<uint32_t>(access);
+  return flags.all;
+}
+
+static std::shared_ptr<xrt::bo_impl>
+alloc_kbuf(const device_type& device, void* userptr, size_t sz, xrtBufferFlags flags)
+{
+  auto handle = userptr ? alloc_bo(device, userptr, sz, flags, 0) : alloc_bo(device, sz, flags, 0);
+  auto boh = std::make_shared<xrt::buffer_kbuf>(device, std::move(handle), sz);
+  return boh;
+}
+
+bo::
+bo(const xrt::device& device, size_t sz, access_mode access)
+  : xrt::bo::bo{alloc_kbuf(device_type{device.get_handle()}, nullptr, sz, adjust_buffer_flags(access))}
+{}
+
+bo::
+bo(const xrt::device& device, size_t sz)
+  : bo{device, sz, xrt::ext::bo::access_mode::local}
+{}
+
+bo::
+bo(const xrt::hw_context& hwctx, size_t sz, access_mode access)
+  : xrt::bo::bo{alloc_kbuf(device_type{hwctx}, nullptr, sz, adjust_buffer_flags(access))}
+{}
+
+bo::
+bo(const xrt::hw_context& hwctx, size_t sz)
+  : bo{hwctx, sz, xrt::ext::bo::access_mode::local}
+{}
+
+} // xrt::ext
 
 #ifdef XRT_ENABLE_AIE
 ////////////////////////////////////////////////////////////////

--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -990,7 +990,6 @@ alloc_bo(const device_type& device, void* userptr, size_t sz, xrtBufferFlags fla
   xcl_bo_flags xgrp{grp};
   xflags.bank = xgrp.bank;
   xflags.slot = xgrp.slot;
-
   auto hwctx  = device.get_hwctx_handle();
   return hwctx
     ? hwctx->alloc_bo(userptr, sz, xflags.all)
@@ -1005,7 +1004,6 @@ alloc_bo(const device_type& device, size_t sz, xrtBufferFlags flags, xrtMemoryGr
   xcl_bo_flags xgrp{grp};
   xflags.bank = xgrp.bank;
   xflags.slot = xgrp.slot;
-
   try {
     auto hwctx  = device.get_hwctx_handle();
     return hwctx

--- a/src/runtime_src/core/common/shim/hwctx_handle.h
+++ b/src/runtime_src/core/common/shim/hwctx_handle.h
@@ -6,6 +6,7 @@
 #include "core/common/cuidx_type.h"
 #include "core/common/error.h"
 #include "core/common/shim/hwqueue_handle.h"
+#include "core/common/shim/shared_handle.h"
 
 #include "xrt/xrt_hw_context.h"
 
@@ -62,6 +63,13 @@ public:
   // Context specific buffer allocation
   virtual std::unique_ptr<buffer_handle>
   alloc_bo(size_t size, uint64_t flags) = 0;
+
+  // Import an exported BO from another process identified by argument pid.
+  virtual std::unique_ptr<buffer_handle>
+  import_bo(pid_t, shared_handle::export_handle)
+  {
+    throw xrt_core::error(std::errc::not_supported, __func__);
+  }
 
   // Legacy XRT may require special handling when opening a context on
   // a compute unit.  Ideally, the hardware context itself should

--- a/src/runtime_src/core/include/experimental/CMakeLists.txt
+++ b/src/runtime_src/core/include/experimental/CMakeLists.txt
@@ -9,6 +9,7 @@ set(XRT_EXPERIMENTAL_HEADER_SRC
   xrt_device.h
   xrt_error.h
   xrt_exception.h
+  xrt_ext.h
   xrt_hw_context.h
   xrt_ini.h
   xrt_ip.h

--- a/src/runtime_src/core/include/experimental/xrt_ext.h
+++ b/src/runtime_src/core/include/experimental/xrt_ext.h
@@ -8,6 +8,7 @@
 
 #include "xrt/detail/config.h"
 #include "xrt/xrt_bo.h"
+#include "xrt/xrt_hw_context.h"
 
 #ifdef __cplusplus
 # include <cstdint>
@@ -63,13 +64,56 @@ public:
   XRT_API_EXPORT
   bo(const xrt::device& device, size_t sz);
 
-  // To be removed when device level BOs can be shared between ctx
+  /**
+   * bo() - Constructor for buffer object
+   *
+   * @param hwctx
+   *  The hardware context that this buffer object uses for queue
+   *  operations such as syncing and residency operations.
+   * @param sz
+   *  Size of buffer
+   * @param access
+   *  Specific access mode for the buffer (see `enum access_mode`)
+   *
+   * This constructor creates a host_only buffer object with specified
+   * access mode.  The hardware context is used for syncing of data
+   * to from device and residency operations, which are all enqueued
+   * operations that are synchronized on fence objects.
+   */
   XRT_API_EXPORT
   bo(const xrt::hw_context& hwctx, size_t sz, access_mode access);
 
-  // To be removed when device level BOs can be shared between ctx
+  /**
+   * bo() - Constructor for buffer object
+   *
+   * @param hwctx
+   *  The hardware context that this buffer object uses for queue
+   *  operations such as syncing and residency operations.
+   * @param sz
+   *  Size of buffer
+   *
+   * This constructor creates a host_only buffer object with local
+   * access.
+   */
   XRT_API_EXPORT
   bo(const xrt::hw_context& hwctx, size_t sz);
+
+  /**
+   * bo() - Constructor to import an exported buffer from another process
+   *
+   * @param hwctx
+   *  The hardware context that this buffer object uses for queue
+   *  operations such as syncing and residency operations.
+   * @param pid
+   *  Process id of exporting process
+   * @param ehdl
+   *  Exported buffer handle, implementation specific type
+   *
+   * The exported buffer handle is obtained from exporting process by
+   * calling `export_buffer()` on the buffer to be exported.
+   */
+  XRT_API_EXPORT
+  bo(const xrt::hw_context& hwctx, pid_type pid, xclBufferExportHandle ehdl);
 };
 
 } // xrt::ext

--- a/src/runtime_src/core/include/experimental/xrt_ext.h
+++ b/src/runtime_src/core/include/experimental/xrt_ext.h
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+#ifndef XRT_EXT_H_
+#define XRT_EXT_H_
+
+// XRT extensions to XRT coreutil
+// These extensions are experimental
+
+#include "xrt/detail/config.h"
+#include "xrt/xrt_bo.h"
+
+#ifdef __cplusplus
+# include <cstdint>
+#endif
+
+#ifdef __cplusplus
+namespace xrt::ext {
+
+///
+class bo : public xrt::bo
+{
+public:
+
+  /**
+   * @enum access_mode - buffer object accessibility
+   *
+   * @var local
+   *   Access is local to process and device on which it is allocated
+   * @var shared
+   *   Access is shared between devices within process
+   * @var process
+   *   Access is shared between processes and devices
+   */
+  enum class access_mode : uint8_t { local, shared, process };
+
+  /**
+   * bo() - Constructor for buffer object with specific access
+   *
+   * @param device
+   *  The device on which to allocate this buffer
+   * @param sz
+   *  Size of buffer
+   * @param access
+   *  Specific access mode for the buffer (see `enum access_mode`)
+   *
+   * This constructor creates a host_only buffer object with
+   * specified access.
+   */
+  XRT_API_EXPORT
+  bo(const xrt::device& device, size_t sz, access_mode access);
+
+  /**
+   * bo() - Constructor for buffer object
+   *
+   * @param device
+   *  The device on which to allocate this buffer
+   * @param sz
+   *  Size of buffer
+
+   * This constructor creates a host_only buffer object with local
+   * access.
+   */
+  XRT_API_EXPORT
+  bo(const xrt::device& device, size_t sz);
+
+  // To be removed when device level BOs can be shared between ctx
+  XRT_API_EXPORT
+  bo(const xrt::hw_context& hwctx, size_t sz, access_mode access);
+
+  // To be removed when device level BOs can be shared between ctx
+  XRT_API_EXPORT
+  bo(const xrt::hw_context& hwctx, size_t sz);
+};
+
+} // xrt::ext
+
+#else
+# error xrt::ext is only implemented for C++
+#endif // __cplusplus
+
+#endif


### PR DESCRIPTION
#### Problem solved by the commit
Provide simpler xrt::bo constructors that support access mode.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Some AIE platforms support only a limited set of buffer types. This
extension provides a simpler bo construction interface that supports
allocating host_only buffers exclusively.

In addition the extension allows bo construction to specify how the
buffer object can be access.  Support is added for sharing between
devices within process or sharing between processes.  At least on some
implementation, the access decision must be made when the bo is first
constructed.

This extension is experimental for now.

#### Risks (if any) associated the changes in the commit
The extension is unused in mainstream XRT

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
