### PR TITLE
CR-1160935 : Fixed a issue for xbtest invalid card BDF

### DIFF
--- a/src/runtime_src/core/pcie/linux/system_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/system_linux.cpp
@@ -127,20 +127,23 @@ std::shared_ptr<pci::dev>
 system_linux::
 get_pcidev(unsigned index, bool is_user) const
 {
-  if (is_user) {
-    if (index < user_ready_list.size())
-      return user_ready_list[index];
+  try {
+    if (is_user) {
+      if (index < user_ready_list.size())
+        return user_ready_list[index];
 
-    if ((index - user_ready_list.size()) < user_nonready_list.size())
-      return user_nonready_list[index - user_ready_list.size()];
+      if ((index - user_ready_list.size()) < user_nonready_list.size())
+        return user_nonready_list.at(index - user_ready_list.size());
+    }
 
+    if (index < mgmt_ready_list.size())
+      return mgmt_ready_list[index];
+
+    return mgmt_nonready_list.at(index - mgmt_ready_list.size());
+  }
+  catch (const std::exception&) {
     return nullptr;
   }
-
-  if (index < mgmt_ready_list.size())
-    return mgmt_ready_list[index];
-
-  return mgmt_nonready_list[index - mgmt_ready_list.size()];
 }
 
 size_t

--- a/src/runtime_src/core/pcie/linux/system_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/system_linux.cpp
@@ -131,7 +131,8 @@ get_pcidev(unsigned index, bool is_user) const
     if (index < user_ready_list.size())
       return user_ready_list[index];
 
-    return user_nonready_list[index - user_ready_list.size()];
+    return !user_nonready_list.size() ? NULL : 
+        user_nonready_list[index - user_ready_list.size()];
   }
 
   if (index < mgmt_ready_list.size())

--- a/src/runtime_src/core/pcie/linux/system_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/system_linux.cpp
@@ -131,8 +131,10 @@ get_pcidev(unsigned index, bool is_user) const
     if (index < user_ready_list.size())
       return user_ready_list[index];
 
-    return !user_nonready_list.size() ? NULL : 
-        user_nonready_list[index - user_ready_list.size()];
+    if ((index - user_ready_list.size()) < user_nonready_list.size())
+      return user_nonready_list[index - user_ready_list.size()];
+
+    return nullptr;
   }
 
   if (index < mgmt_ready_list.size())


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
[CR-1160935](https://jira.xilinx.com/browse/CR-1160935)
xbtest VVT - Issuing an xbtest command with an invalid BDF triggers a segmentation fault

-- This is a minor issue. If we issue an xbtest command such as verify with an invalid bdf, we observe the test failing but with a segmentation_fault 

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
N/A

#### How problem was solved, alternative solutions (if any) and why they were rejected
-- Added a check before accessing the invalid entry of PCI device  vector.

#### Risks (if any) associated the changes in the commit
N/A
#### What has been tested and how, request additional testing if necessary
Basic Validation and xbtest 

#### Documentation impact (if any)
N/A