### PR TITLE
Merge of late 2023.1 changes and fix to DMA profiling

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_profile/edge/aie_profile.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/edge/aie_profile.cpp
@@ -78,47 +78,61 @@ namespace xdp {
     };
 
     mCoreStartEvents = {
-      {"heat_map",              {XAIE_EVENT_ACTIVE_CORE,               XAIE_EVENT_GROUP_CORE_STALL_CORE,
-                                 XAIE_EVENT_INSTR_VECTOR_CORE,         XAIE_EVENT_GROUP_CORE_PROGRAM_FLOW_CORE}},
-      {"stalls",                {XAIE_EVENT_MEMORY_STALL_CORE,         XAIE_EVENT_STREAM_STALL_CORE,
-                                 XAIE_EVENT_LOCK_STALL_CORE,           XAIE_EVENT_CASCADE_STALL_CORE}},
-      {"execution",             {XAIE_EVENT_INSTR_VECTOR_CORE,         XAIE_EVENT_INSTR_LOAD_CORE,
-                                 XAIE_EVENT_INSTR_STORE_CORE,          XAIE_EVENT_GROUP_CORE_PROGRAM_FLOW_CORE}},
-      {"floating_point",        {XAIE_EVENT_FP_OVERFLOW_CORE,          XAIE_EVENT_FP_UNDERFLOW_CORE,
-                                 XAIE_EVENT_FP_INVALID_CORE,           XAIE_EVENT_FP_DIV_BY_ZERO_CORE}},
-      {"stream_put_get",        {XAIE_EVENT_INSTR_CASCADE_GET_CORE,    XAIE_EVENT_INSTR_CASCADE_PUT_CORE,
-                                 XAIE_EVENT_INSTR_STREAM_GET_CORE,     XAIE_EVENT_INSTR_STREAM_PUT_CORE}},
-      {"write_throughputs",     {XAIE_EVENT_ACTIVE_CORE,               XAIE_EVENT_INSTR_STREAM_PUT_CORE,
-                                 XAIE_EVENT_INSTR_CASCADE_PUT_CORE,    XAIE_EVENT_GROUP_CORE_STALL_CORE}},
-      {"read_throughputs",      {XAIE_EVENT_ACTIVE_CORE,               XAIE_EVENT_INSTR_STREAM_GET_CORE,
-                                 XAIE_EVENT_INSTR_CASCADE_GET_CORE,    XAIE_EVENT_GROUP_CORE_STALL_CORE}},
-      {"aie_trace",             {XAIE_EVENT_PORT_RUNNING_1_CORE,       XAIE_EVENT_PORT_STALLED_1_CORE,
-                                 XAIE_EVENT_PORT_RUNNING_0_CORE,       XAIE_EVENT_PORT_STALLED_0_CORE}},
-      {"events",                {XAIE_EVENT_INSTR_EVENT_0_CORE,        XAIE_EVENT_INSTR_EVENT_1_CORE,
-                                 XAIE_EVENT_USER_EVENT_0_CORE,         XAIE_EVENT_USER_EVENT_1_CORE}}
+      {"heat_map",                {XAIE_EVENT_ACTIVE_CORE,               XAIE_EVENT_GROUP_CORE_STALL_CORE,
+                                   XAIE_EVENT_INSTR_VECTOR_CORE,         XAIE_EVENT_GROUP_CORE_PROGRAM_FLOW_CORE}},
+      {"stalls",                  {XAIE_EVENT_MEMORY_STALL_CORE,         XAIE_EVENT_STREAM_STALL_CORE,
+                                   XAIE_EVENT_LOCK_STALL_CORE,           XAIE_EVENT_CASCADE_STALL_CORE}},
+      {"execution",               {XAIE_EVENT_INSTR_VECTOR_CORE,         XAIE_EVENT_INSTR_LOAD_CORE,
+                                   XAIE_EVENT_INSTR_STORE_CORE,          XAIE_EVENT_GROUP_CORE_PROGRAM_FLOW_CORE}},
+      {"stream_put_get",          {XAIE_EVENT_INSTR_CASCADE_GET_CORE,    XAIE_EVENT_INSTR_CASCADE_PUT_CORE,
+                                   XAIE_EVENT_INSTR_STREAM_GET_CORE,     XAIE_EVENT_INSTR_STREAM_PUT_CORE}},
+      {"write_throughputs",       {XAIE_EVENT_ACTIVE_CORE,               XAIE_EVENT_INSTR_STREAM_PUT_CORE,
+                                   XAIE_EVENT_INSTR_CASCADE_PUT_CORE,    XAIE_EVENT_GROUP_CORE_STALL_CORE}},
+      {"read_throughputs",        {XAIE_EVENT_ACTIVE_CORE,               XAIE_EVENT_INSTR_STREAM_GET_CORE,
+                                   XAIE_EVENT_INSTR_CASCADE_GET_CORE,    XAIE_EVENT_GROUP_CORE_STALL_CORE}},
+      {"aie_trace",               {XAIE_EVENT_PORT_RUNNING_1_CORE,       XAIE_EVENT_PORT_STALLED_1_CORE,
+                                   XAIE_EVENT_PORT_RUNNING_0_CORE,       XAIE_EVENT_PORT_STALLED_0_CORE}},
+      {"events",                  {XAIE_EVENT_INSTR_EVENT_0_CORE,        XAIE_EVENT_INSTR_EVENT_1_CORE,
+                                   XAIE_EVENT_USER_EVENT_0_CORE,         XAIE_EVENT_USER_EVENT_1_CORE}}
     };
+    if (metadata->getHardwareGen() == 1) {
+      mCoreStartEvents["floating_point"] = {XAIE_EVENT_FP_OVERFLOW_CORE, XAIE_EVENT_FP_UNDERFLOW_CORE,
+                                            XAIE_EVENT_FP_INVALID_CORE,  XAIE_EVENT_FP_DIV_BY_ZERO_CORE};
+    }
+    else {
+      mCoreStartEvents["floating_point"] = {XAIE_EVENT_FP_HUGE_CORE,     XAIE_EVENT_INT_FP_0_CORE, 
+                                            XAIE_EVENT_FP_INVALID_CORE,  XAIE_EVENT_FP_INF_CORE};
+    }
     mCoreEndEvents = mCoreStartEvents;
 
     // **** Memory Module Counters ****
     mMemoryStartEvents = {
-      {"conflicts",             {XAIE_EVENT_GROUP_MEMORY_CONFLICT_MEM, XAIE_EVENT_GROUP_ERRORS_MEM}},
-      {"dma_locks",             {XAIE_EVENT_GROUP_DMA_ACTIVITY_MEM,    XAIE_EVENT_GROUP_LOCK_MEM}},
-      {"dma_stalls_s2mm",       {XAIE_EVENT_DMA_S2MM_0_STALLED_LOCK_ACQUIRE_MEM,
-                                 XAIE_EVENT_DMA_S2MM_1_STALLED_LOCK_ACQUIRE_MEM}},
-      {"dma_stalls_mm2s",       {XAIE_EVENT_DMA_MM2S_0_STALLED_LOCK_ACQUIRE_MEM,
-                                 XAIE_EVENT_DMA_MM2S_1_STALLED_LOCK_ACQUIRE_MEM}},
-      {"write_throughputs",     {XAIE_EVENT_DMA_S2MM_0_FINISHED_BD_MEM,
-                                 XAIE_EVENT_DMA_S2MM_1_FINISHED_BD_MEM}},
-      {"read_throughputs",      {XAIE_EVENT_DMA_MM2S_0_FINISHED_BD_MEM,
-                                 XAIE_EVENT_DMA_MM2S_1_FINISHED_BD_MEM}}
+      {"conflicts",               {XAIE_EVENT_GROUP_MEMORY_CONFLICT_MEM, XAIE_EVENT_GROUP_ERRORS_MEM}},
+      {"dma_locks",               {XAIE_EVENT_GROUP_DMA_ACTIVITY_MEM,    XAIE_EVENT_GROUP_LOCK_MEM}},
+      {"write_throughputs",       {XAIE_EVENT_DMA_S2MM_0_FINISHED_BD_MEM,
+                                   XAIE_EVENT_DMA_S2MM_1_FINISHED_BD_MEM}},
+      {"read_throughputs",        {XAIE_EVENT_DMA_MM2S_0_FINISHED_BD_MEM,
+                                   XAIE_EVENT_DMA_MM2S_1_FINISHED_BD_MEM}}
     };
+    if (metadata->getHardwareGen() == 1) {
+      mMemoryStartEvents["dma_stalls_s2mm"] = {XAIE_EVENT_DMA_S2MM_0_STALLED_LOCK_ACQUIRE_MEM,
+                                               XAIE_EVENT_DMA_S2MM_1_STALLED_LOCK_ACQUIRE_MEM};
+      mMemoryStartEvents["dma_stalls_mm2s"] = {XAIE_EVENT_DMA_MM2S_0_STALLED_LOCK_ACQUIRE_MEM,
+                                               XAIE_EVENT_DMA_MM2S_1_STALLED_LOCK_ACQUIRE_MEM};
+    }
+    else {
+      mMemoryStartEvents["dma_stalls_s2mm"] = {XAIE_EVENT_DMA_S2MM_0_STALLED_LOCK_MEM,
+                                               XAIE_EVENT_DMA_S2MM_1_STALLED_LOCK_MEM};
+      mMemoryStartEvents["dma_stalls_mm2s"] = {XAIE_EVENT_DMA_MM2S_0_STALLED_LOCK_MEM,
+                                               XAIE_EVENT_DMA_MM2S_1_STALLED_LOCK_MEM};
+    }
     mMemoryEndEvents = mMemoryStartEvents;
 
     // **** Interface Tile Counters ****
     mShimStartEvents = {
-      {"input_throughputs",     {XAIE_EVENT_PORT_RUNNING_0_PL, XAIE_EVENT_PORT_STALLED_0_PL}},
-      {"output_throughputs",    {XAIE_EVENT_PORT_RUNNING_0_PL, XAIE_EVENT_PORT_STALLED_0_PL}},
-      {"packets",               {XAIE_EVENT_PORT_TLAST_0_PL,   XAIE_EVENT_PORT_TLAST_1_PL}}
+      {"input_throughputs",       {XAIE_EVENT_PORT_RUNNING_0_PL, XAIE_EVENT_PORT_STALLED_0_PL}},
+      {"output_throughputs",      {XAIE_EVENT_PORT_RUNNING_0_PL, XAIE_EVENT_PORT_STALLED_0_PL}},
+      {"packets",                 {XAIE_EVENT_PORT_TLAST_0_PL,   XAIE_EVENT_PORT_TLAST_1_PL}}
     };
     mShimEndEvents = mShimStartEvents;
 

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_metadata.cpp
@@ -16,7 +16,7 @@
 
 #define XDP_SOURCE
 
-#include "xdp/profile/plugin/vp_base/vp_base_plugin.h"
+
 
 #include <cstdint>
 #include <boost/algorithm/string.hpp>
@@ -25,14 +25,16 @@
 #include <memory>
 #include <regex>
 
-#include "core/common/device.h"
-#include "core/common/xrt_profiling.h"
 #include "aie_trace_metadata.h"
+
+#include "core/common/device.h"
 #include "core/common/message.h"
+#include "core/common/xrt_profiling.h"
 #include "core/edge/common/aie_parser.h"
 #include "xdp/profile/database/database.h"
-#include "xdp/profile/plugin/vp_base/utility.h"
 #include "xdp/profile/device/tracedefs.h"
+#include "xdp/profile/plugin/vp_base/utility.h"
+#include "xdp/profile/plugin/vp_base/vp_base_plugin.h"
 
 namespace xdp {
   namespace pt = boost::property_tree;

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_metadata.cpp
@@ -16,8 +16,6 @@
 
 #define XDP_SOURCE
 
-
-
 #include <cstdint>
 #include <boost/algorithm/string.hpp>
 #include <boost/property_tree/json_parser.hpp>

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_metadata.cpp
@@ -16,6 +16,8 @@
 
 #define XDP_SOURCE
 
+#include "xdp/profile/plugin/vp_base/vp_base_plugin.h"
+
 #include <cstdint>
 #include <boost/algorithm/string.hpp>
 #include <boost/property_tree/json_parser.hpp>
@@ -23,16 +25,14 @@
 #include <memory>
 #include <regex>
 
-#include "aie_trace_metadata.h"
-
 #include "core/common/device.h"
-#include "core/common/message.h"
 #include "core/common/xrt_profiling.h"
+#include "aie_trace_metadata.h"
+#include "core/common/message.h"
 #include "core/edge/common/aie_parser.h"
 #include "xdp/profile/database/database.h"
-#include "xdp/profile/device/tracedefs.h"
 #include "xdp/profile/plugin/vp_base/utility.h"
-#include "xdp/profile/plugin/vp_base/vp_base_plugin.h"
+#include "xdp/profile/device/tracedefs.h"
 
 namespace xdp {
   namespace pt = boost::property_tree;
@@ -109,7 +109,7 @@ namespace xdp {
     const std::set<std::string> validSettings {
       "graph_based_aie_tile_metrics", "tile_based_aie_tile_metrics",
       "graph_based_memory_tile_metrics", "tile_based_memory_tile_metrics",
-      "start_type", "start_time", "start_iteration", 
+      "start_type", "start_time", "start_iteration", "end_type",
       "periodic_offload", "reuse_buffer", "buffer_size", 
       "buffer_offload_interval_us", "file_dump_interval_s"
     };
@@ -581,11 +581,11 @@ namespace xdp {
       }
 
       // Grab channel numbers (if specified; MEM tiles only)
-      if (graphMetrics[i].size() == 5) {
+      if (graphMetrics[i].size() > 3) {
         try {
           for (auto &e : tiles) {
             configChannel0[e] = std::stoi(graphMetrics[i][3]);
-            configChannel1[e] = std::stoi(graphMetrics[i][4]);
+            configChannel1[e] = std::stoi(graphMetrics[i].back());
           }
         } catch (...) {
           std::stringstream msg;
@@ -638,11 +638,11 @@ namespace xdp {
       }
 
       // Grab channel numbers (if specified; MEM tiles only)
-      if (graphMetrics[i].size() == 5) {
+      if (graphMetrics[i].size() > 3) {
         try {
           for (auto &e : tiles) {
             configChannel0[e] = std::stoi(graphMetrics[i][3]);
-            configChannel1[e] = std::stoi(graphMetrics[i][4]);
+            configChannel1[e] = std::stoi(graphMetrics[i].back());
           }
         } catch (...) {
           std::stringstream msg;
@@ -685,11 +685,11 @@ namespace xdp {
       }
 
       // Grab channel numbers (if specified; MEM tiles only)
-      if (metrics[i].size() == 4) {
+      if (metrics[i].size() > 2) {
         try {
           for (auto &e : tiles) {
             configChannel0[e] = std::stoi(metrics[i][2]);
-            configChannel1[e] = std::stoi(metrics[i][3]);
+            configChannel1[e] = std::stoi(metrics[i].back());
           }
         } catch (...) {
           std::stringstream msg;
@@ -741,10 +741,10 @@ namespace xdp {
 
       uint8_t channel0 = 0;
       uint8_t channel1 = 1;
-      if (metrics[i].size() == 5) {
+      if (metrics[i].size() > 3) {
         try {
           channel0 = std::stoi(metrics[i][3]);
-          channel1 = std::stoi(metrics[i][4]);
+          channel1 = std::stoi(metrics[i].back());
         } catch (...) {
           std::stringstream msg;
           msg << "Channel specifications in tile_based_" << tileName
@@ -821,10 +821,10 @@ namespace xdp {
       configMetrics[tile] = metrics[i][1];
       
       // Grab channel numbers (if specified; MEM tiles only)
-      if (metrics[i].size() == 4) {
+      if (metrics[i].size() > 2) {
         try {
           configChannel0[tile] = std::stoi(metrics[i][2]);
-          configChannel1[tile] = std::stoi(metrics[i][3]);
+          configChannel1[tile] = std::stoi(metrics[i].back());
         } catch (...) {
           std::stringstream msg;
           msg << "Channel specifications in tile_based_" << tileName

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -307,8 +307,10 @@ namespace xdp {
   {
     for (const auto& kv : handleToAIEData) {
       auto& AIEData = kv.second;
-      if (AIEData.valid)
+      if (AIEData.valid) {
+        AIEData.implementation->flushAieTileTraceModule();
         flushOffloader(AIEData.offloader, true);
+      }
     }
 
     XDPPlugin::endWrite();

--- a/src/runtime_src/xdp/profile/writer/aie_trace/aie_trace_config_writer.h
+++ b/src/runtime_src/xdp/profile/writer/aie_trace/aie_trace_config_writer.h
@@ -43,11 +43,10 @@ namespace xdp {
     std::ostringstream oss;
     bpt::write_json(oss, ptree);
 
-    // Patterns matching "12" "null" "100.0" ""
-    //Patterns ignored "12":  "100.0":
-    std::regex reg("\\\"(([0-9]+\\.{0,1}[0-9]*)|(null)|())\\\"(?!\\:)");
-    //std::regex reg("\\\"([0-9]+\\.{0,1}[0-9]*)\\\"(?!\\:)");
-    //std::regex reg("\\\"([0-9]+\\.{0,1}[0-9]*)\\\"");
+    // Remove quotes from value strings
+    //   Patterns matched - "12" "null" "100.0" "-1" ""
+    //   Patterns ignored - "12": "100.0":
+    std::regex reg("\\\"((-?[0-9]+\\.{0,1}[0-9]*)|(null)|())\\\"(?!\\:)");
     std::string result = std::regex_replace(oss.str(), reg, "$1");
 
     std::ofstream file;


### PR DESCRIPTION
**Problem solved by the commit**
* MEM tile profiling can be incorrect
* Events are different for AIE1 and AIE2

**How problem was solved, alternative solutions (if any) and why they were rejected**
* Support monitoring of one or two MEM tile channels
* Report channels correctly in runtime config
* Use HW generation-specific events

**Risks (if any) associated the changes in the commit**
HW generation-specific events can be error prone

**What has been tested and how, request additional testing if necessary**
various designs on vek280

**Documentation impact (if any)**
dma_stalls_s2mm and dma_stalls_mm2s supported