### PR TITLE
Fix race in obtaining index of CU

### DIFF
--- a/src/runtime_src/core/common/device.cpp
+++ b/src/runtime_src/core/common/device.cpp
@@ -348,6 +348,10 @@ const std::vector<uint64_t>&
 device::
 get_cus() const
 {
+  // This function returns a reference to internal data
+  // that is modified when an xclbin is loaded.  Normally
+  // not an issue since only single xclbin is supported
+  // when using this API.
   if (m_cu2idx.size() > 1)
     throw error(std::errc::not_supported, "multiple xclbins not supported");
 
@@ -358,6 +362,7 @@ cuidx_type
 device::
 get_cuidx(slot_id slot, const std::string& cuname) const
 {
+  std::lock_guard lk(m_mutex);
   auto slot_itr = m_cu2idx.find(slot);
   if (slot_itr == m_cu2idx.end())
     throw error(EINVAL, "No such compute unit '" + cuname + "'");


### PR DESCRIPTION
#### Problem solved by the commit
Add lock around accessing cu index in core device.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Fixes a potential race when a thread access cu indices while another thread is updating the indices after an xclbin was loaded.  The race can only occur when multiple hardware contexts are used because CU contexts are managed per hardware context by XRT coreutil.

xrt_core::device::get_cuidx lazy gathers cu indices from KMD when a thread tries to open a CU as part of creating a kernel object.  The first thread to access the index of a CU can cause all indices to be updated if the requested CU is not yet registered.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Lock around get_cuidx accessing shared data.

#### Risks (if any) associated the changes in the commit
Low risk.  Locking was reviewed for potential deadlock from functions calling get_cuidx

#### What has been tested and how, request additional testing if necessary
OpenCL regressions

