### PR TITLE
CR-1161211: [edge-sw_emu] shim driver socket creation thread is sync with device process initiation.

### DIFF
--- a/src/runtime_src/core/edge/sw_emu/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/edge/sw_emu/generic_pcie_hal2/shim.h
@@ -32,6 +32,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <future>
 #include <thread>
 #include <tuple>
 #include <sys/wait.h>
@@ -524,6 +525,8 @@ namespace xclswemuhal2 {
       create_hw_context(const xrt::uuid&, const xrt::hw_context::cfg_param_type&, xrt::hw_context::access_mode);
 
   private:
+      std::future<bool> mSocketThreadFinished_fut;
+      std::promise<bool> mSocketThreadFinished_promise;
       std::shared_ptr<xrt_core::device> mCoreDevice;
       std::mutex mMemManagerMutex;
 


### PR DESCRIPTION
Fix: edge sw_emu shim driver is starting TCP/IP socket creation in a thread which is spawning very lately in a qemu environment. 
device process is really starting & finishing connect() call even before listen() call of shim driver TCP/IP server. Hence a check needs to be added to know whether really socket creation thread started or not. This is handled by using future object.

Risk: Very Low

Tests: Canary run. Results are Clean.

Reviewer: venkatp