### PR TITLE
Vitis-7921 First-class execution buffer

### DIFF
--- a/src/runtime_src/core/common/api/CMakeLists.txt
+++ b/src/runtime_src/core/common/api/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(core_common_api_library_objects OBJECT
   xrt_ip.cpp
   xrt_kernel.cpp
   xrt_message.cpp
+  xrt_module.cpp
   xrt_profile.cpp
   xrt_queue.cpp
   xrt_system.cpp

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -12,8 +12,10 @@
 #include "core/common/shim/buffer_handle.h"
 #include "core/common/shim/hwctx_handle.h"
 
-#include "core/include/experimental/xrt_hw_context.h"
+#include "core/include/xrt/xrt_hw_context.h"
+#include "core/include/experimental/xrt_ext.h"
 #include "core/include/experimental/xrt_mailbox.h"
+#include "core/include/experimental/xrt_module.h"
 #include "core/include/experimental/xrt_xclbin.h"
 #include "core/include/ert.h"
 #include "core/include/ert_fa.h"
@@ -464,8 +466,8 @@ class ip_context
   // @default_connection: default connectivity for an argument
   class connectivity
   {
-    static constexpr int32_t no_memidx = -1;
-    static constexpr size_t max_connections = 64;
+    static constexpr int32_t no_memidx {-1};
+    static constexpr size_t max_connections {64};
     std::vector<encoded_bitset<max_connections>> connections; // indexed by argidx
     std::vector<int32_t> default_connection;                  // indexed by argidx
 
@@ -669,9 +671,6 @@ private:
   uint64_t m_address;         // cache base address for programming
   size_t m_size;              // cache address space size
 };
-
-// Remove when c++17
-constexpr int32_t ip_context::connectivity::no_memidx;
 
 // class kernel_command - Immplements command API expected by schedulers
 //
@@ -1299,6 +1298,7 @@ private:
   std::shared_ptr<ctxmgr_type> ctxmgr; // device context mgr ownership
   xrt::hw_context hwctx;               // context for hw resources if any (can be null)
   xrt_core::hw_queue hwqueue;          // hwqueue for command submission (shared by all runs)
+  xrt::module module;                  // module with instructions for function
   xrt::xclbin xclbin;                  // xclbin with this kernel
   xrt::xclbin::kernel xkernel;         // kernel xclbin metadata
   std::vector<argument> args;          // kernel args sorted by argument index
@@ -1450,14 +1450,14 @@ private:
       kcmd->opcode = (protocol == control_type::fa) ? ERT_START_FA : ERT_START_CU;
       break;
     case kernel_type::dpu :
-      kcmd->opcode = ERT_START_CU;
+      kcmd->opcode = (module ? ERT_START_DPU : ERT_START_CU);
       break;
     case kernel_type::none:
       throw std::runtime_error("Internal error: wrong kernel type can't set cmd opcode");
     }
   }
 
-  void
+  uint32_t*
   initialize_fadesc(uint32_t* data)
   {
     auto desc = reinterpret_cast<ert_fa_descriptor*>(data);
@@ -1466,6 +1466,17 @@ private:
     desc->input_entry_bytes = fa_input_entry_bytes;
     desc->num_output_entries = fa_num_outputs;
     desc->output_entry_bytes = fa_output_entry_bytes;
+    return data;  // no skipping
+  }
+
+  uint32_t*
+  initialize_dpu(uint32_t* data)
+  {
+    auto dpu = reinterpret_cast<ert_dpu_data*>(data);
+    auto bo = module.get_instruction_buffer("tbd");
+    dpu->instruction_buffer = bo.address();
+    dpu->instruction_count = bo.size() / sizeof(int);
+    return dpu->data; // skip to data[1]
   }
 
   static uint32_t
@@ -1494,12 +1505,13 @@ public:
   //
   // The ctxmgr is not directly used by kernel_impl, but its
   // construction and shared ownership must be tied to the kernel_impl
-  kernel_impl(std::shared_ptr<device_type> dev, xrt::hw_context ctx, const std::string& nm)
+  kernel_impl(std::shared_ptr<device_type> dev, xrt::hw_context ctx, xrt::module mod, const std::string& nm)
     : name(nm.substr(0,nm.find(":")))                          // filter instance names
     , device(std::move(dev))                                   // share ownership
     , ctxmgr(xrt_core::context_mgr::create(device->core_device.get())) // owership tied to kernel_impl
     , hwctx(std::move(ctx))                                    // hw context
     , hwqueue(hwctx)                                           // hw queue
+    , module{std::move(mod)}                                   // module if any
     , xclbin(hwctx.get_xclbin())                               // xclbin with kernel
     , xkernel(get_kernel_or_error(xclbin, name))               // kernel meta data managed by xclbin
     , properties(xrt_core::xclbin_int::get_properties(xkernel))// cache kernel properties
@@ -1539,6 +1551,11 @@ public:
     // amend args with computed data based on kernel protocol
     amend_args();
   }
+
+  // Delegating constructor with no module
+  kernel_impl(std::shared_ptr<device_type> dev, xrt::hw_context ctx, const std::string& nm)
+    : kernel_impl{dev, ctx, {}, nm}
+  {}
 
   ~kernel_impl()
   {
@@ -1585,7 +1602,10 @@ public:
     auto data = kcmd->data + kcmd->extra_cu_masks;
 
     if (kcmd->opcode == ERT_START_FA)
-      initialize_fadesc(data);
+      data = initialize_fadesc(data);
+
+    if (kcmd->opcode == ERT_START_DPU)
+      data = initialize_dpu(data);
 
     return data;
   }
@@ -2856,6 +2876,13 @@ alloc_kernel_from_ctx(const std::shared_ptr<device_type>& dev,
   return std::make_shared<xrt::kernel_impl>(dev, hwctx, name);
 }
 
+static std::shared_ptr<xrt::kernel_impl>
+alloc_kernel_from_module(const xrt::module& module, const std::string& name)
+{
+  auto hwctx = module.get_hw_context();
+  return std::make_shared<xrt::kernel_impl>(get_device(hwctx.get_device()), hwctx, module, name);
+}
+
 static std::shared_ptr<xrt::mailbox_impl>
 get_mailbox_impl(const xrt::run& run)
 {
@@ -3408,7 +3435,19 @@ what() const noexcept
   return m_impl->m_message.c_str();
 }
 
-}
+} // xrt
+
+////////////////////////////////////////////////////////////////
+// xrt_ext::bo C++ API implmentations (xrt_ext.h)
+////////////////////////////////////////////////////////////////
+namespace xrt::ext {
+
+kernel::
+kernel(const xrt::module& mod, const std::string& name)
+  : xrt::kernel::kernel{alloc_kernel_from_module(mod, name)}
+{}
+
+} // xrt::ext
 
 ////////////////////////////////////////////////////////////////
 // xrt_kernel API implmentations (xrt_kernel.h)

--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -1,0 +1,182 @@
+// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+#define XCL_DRIVER_DLL_EXPORT  // exporting xrt_module.h
+#define XRT_API_SOURCE         // exporting xrt_module.h
+#define XRT_CORE_COMMON_SOURCE // in same dll as core_common
+#include "experimental/xrt_module.h"
+#include "experimental/xrt_elf.h"
+
+#include "xrt/xrt_bo.h"
+#include "xrt/xrt_uuid.h"
+
+#include "core/common/error.h"
+
+#include <cstring>
+
+namespace {
+
+} // namespace
+
+namespace xrt {
+
+// class module_impl - Base class for different implementations
+//
+// An xrt::bo buffer object that represents the instructions and is
+// passed to hw execution.  This buffer object is constructed in
+// context of the kernel object that will use it.
+class module_impl
+{
+protected:
+  xrt::hw_context m_hwctx;
+  xrt::uuid m_cfg_uuid;     // matching hw configuration id
+
+public:
+  module_impl(xrt::hw_context hwctx)
+    : m_hwctx(std::move(hwctx))
+    , m_cfg_uuid(m_hwctx.get_xclbin_uuid())
+  {}
+
+  module_impl(const module_impl* parent)
+    : m_hwctx(parent->m_hwctx)
+    , m_cfg_uuid(parent->m_cfg_uuid)
+  {}
+
+  virtual
+  ~module_impl()
+  {}
+
+  xrt::uuid
+  get_cfg_uuid() const
+  {
+    return m_hwctx.get_xclbin_uuid();
+  }
+
+  xrt::hw_context
+  get_hw_context() const
+  {
+    return m_hwctx;
+  }
+
+  virtual xrt::bo
+  get_instruction_buffer(const std::string& nm) const = 0;
+};
+
+// class module_elf - Elf provided by application
+class module_elf : public module_impl
+{
+  xrt::elf m_elf;
+  // TBD...
+public:
+  module_elf(xrt::hw_context hwctx, xrt::elf elf)
+    : module_impl(hwctx)
+    , m_elf(elf)
+  {}
+
+  xrt::bo
+  get_instruction_buffer(const std::string&) const override
+  {
+    throw std::runtime_error("elf instruction buffer not implemented");
+  }
+};
+
+// class module_userptr - Opaque userptr provided by application
+class module_userptr : public module_impl
+{
+  xrt::bo m_buffer;    // instruction parent bufffer
+
+  xrt::bo
+  create_instruction_buffer(const void* userptr, size_t bytes)
+  {
+    xrt::bo bo{m_hwctx, bytes, xrt::bo::flags::cacheable, 0};
+    std::memcpy(bo.map(), userptr, bytes);
+    bo.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+    return bo;
+  }
+
+public:
+  module_userptr(xrt::hw_context hwctx, void* userptr, size_t sz, xrt::uuid uuid)
+    : module_impl{hwctx}
+    , m_buffer{create_instruction_buffer(userptr, sz)}
+  {
+    if (m_cfg_uuid != uuid)
+      throw xrt_core::error("Instruction buffer is not compatible with configured hardware");
+  }
+
+  xrt::bo
+  get_instruction_buffer(const std::string&) const override
+  {
+    return m_buffer;
+  }
+};
+
+// class module_sub - Create a sub module from parent
+class module_sub : public module_impl
+{
+  std::shared_ptr<module_impl> m_parent;
+  xrt::bo m_buffer;
+public:
+  module_sub(std::shared_ptr<module_impl> parent, size_t size, size_t offset)
+    : module_impl{parent.get()}
+    , m_parent{parent}
+    , m_buffer{m_parent->get_instruction_buffer("tbd"), size, offset}
+  {}
+
+  xrt::bo
+  get_instruction_buffer(const std::string&) const override
+  {
+    return m_buffer;
+  }
+};
+
+} // namespace xrt
+
+////////////////////////////////////////////////////////////////
+// XRT implmentation access to internal module APIs
+////////////////////////////////////////////////////////////////
+namespace xrt_core::module_int {
+
+} // xrt_core::module_int
+
+////////////////////////////////////////////////////////////////
+// xrt_module C++ API implementation (xrt_module.h)
+////////////////////////////////////////////////////////////////
+namespace xrt {
+
+module::
+module(const xrt::hw_context& hwctx, const xrt::elf& elf)
+  //  : detail::pimpl<module_impl>(std::make_shared<module_impl>(elf))
+  : detail::pimpl<module_impl>{std::make_shared<module_elf>(hwctx, elf)}
+{}
+
+module::
+module(const xrt::hw_context& hwctx, void* userptr, size_t sz, const xrt::uuid& uuid)
+  : detail::pimpl<module_impl>{std::make_shared<module_userptr>(hwctx, userptr, sz, uuid)}
+{}
+
+module::
+module(const xrt::module& parent, size_t size, size_t offset)
+  : detail::pimpl<module_impl>{std::make_shared<module_sub>(parent.handle, size, offset)}
+{}
+
+xrt::uuid
+module::
+get_cfg_uuid() const
+{
+  return handle->get_cfg_uuid();
+}
+
+xrt::bo
+module::
+get_instruction_buffer(const std::string& nm) const
+{
+  return handle->get_instruction_buffer(nm);
+}
+
+xrt::hw_context
+module::
+get_hw_context() const
+{
+  return handle->get_hw_context();
+}
+
+} // namespace xrt

--- a/src/runtime_src/core/include/ert.h
+++ b/src/runtime_src/core/include/ert.h
@@ -146,6 +146,19 @@ struct ert_start_kernel_cmd {
   uint32_t data[1];            /* count-1 number of words */
 };
 
+/**
+ * struct ert_dpu_data - interpretation of data payload for ERT_START_DPU
+ *
+ * The data payload for ERT_START_DPU is interpreted as fixed instruction
+ * buffer address along with instruction count, followed by regular kernel
+ * arguments.
+ */
+struct ert_dpu_data {
+  uint64_t instruction_buffer;  /* buffer address 2 words */
+  uint32_t instruction_count;   /* number of instructions */
+  uint32_t data[1];             /* count-4 number of words */
+};
+
 #ifndef U30_DEBUG
 #define ert_write_return_code(cmd, value) \
 do { \
@@ -473,7 +486,7 @@ struct ert_access_valid_cmd {
  * @ERT_CMD_STATE_QUEUED:      Internal scheduler state
  * @ERT_CMD_STATE_SUBMITTED:   Internal scheduler state
  * @ERT_CMD_STATE_RUNNING:     Internal scheduler state
- * @ERT_CMD_STATE_COMPLETED:   Set by scheduler when command completes 
+ * @ERT_CMD_STATE_COMPLETED:   Set by scheduler when command completes
  * @ERT_CMD_STATE_ERROR:       Set by scheduler if command failed
  * @ERT_CMD_STATE_ABORT:       Set by scheduler if command abort
  * @ERT_CMD_STATE_TIMEOUT:     Set by scheduler if command timeout and reset
@@ -513,6 +526,7 @@ struct cu_cmd_state_timestamps {
  * @ERT_SK_START:       start a soft kernel
  * @ERT_SK_UNCONFIG:    unconfigure a soft kernel
  * @ERT_START_KEY_VAL:  same as ERT_START_CU but with key-value pair flavor
+ * @ERT_START_DPU:      instruction buffer command format
  */
 enum ert_cmd_opcode {
   ERT_START_CU      = 0,
@@ -533,6 +547,7 @@ enum ert_cmd_opcode {
   ERT_START_KEY_VAL = 15,
   ERT_ACCESS_TEST_C = 16,
   ERT_ACCESS_TEST   = 17,
+  ERT_START_DPU     = 18,
 };
 
 /**

--- a/src/runtime_src/core/include/experimental/CMakeLists.txt
+++ b/src/runtime_src/core/include/experimental/CMakeLists.txt
@@ -7,6 +7,7 @@ set(XRT_EXPERIMENTAL_HEADER_SRC
   xrt_graph.h
   xrt_bo.h
   xrt_device.h
+  xrt_elf.h
   xrt_error.h
   xrt_exception.h
   xrt_ext.h
@@ -16,6 +17,7 @@ set(XRT_EXPERIMENTAL_HEADER_SRC
   xrt_kernel.h
   xrt_mailbox.h
   xrt_message.h
+  xrt_module.h
   xrt_profile.h
   xrt_queue.h
   xrt_system.h

--- a/src/runtime_src/core/include/experimental/xrt_elf.h
+++ b/src/runtime_src/core/include/experimental/xrt_elf.h
@@ -1,0 +1,44 @@
+// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+#ifndef XRT_ELF_H_
+#define XRT_ELF_H_
+
+#include "xrt/detail/pimpl.h"
+#include "xrt/xrt_uuid.h"
+
+#ifdef __cplusplus
+# include <utility>
+# include <vector>
+# include <string>
+#endif
+
+#ifdef __cplusplus
+namespace xrt {
+
+/*!
+ * @class elf
+ *
+ * @brief
+ * An elf contains instructions for functions to execute in some
+ * pre-configured hardware.  The xrt::elf class provides APIs to mine
+ * the elf itself for relevant data.
+ *
+ * An xclbin is used to configure the hardware and an elf object is
+ * always associated with exactly one xclbin, meaning the instructions
+ * are for a specific hardware configuration.
+ */
+class elf_impl;
+class elf : public detail::pimpl<elf_impl>
+{
+public:
+  xrt::uuid
+  get_cfg_uuid() const;
+};
+
+} // namespace xrt
+
+#else
+# error xrt::elf is only implemented for C++
+#endif // __cplusplus
+
+#endif

--- a/src/runtime_src/core/include/experimental/xrt_ext.h
+++ b/src/runtime_src/core/include/experimental/xrt_ext.h
@@ -9,6 +9,8 @@
 #include "xrt/detail/config.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_hw_context.h"
+#include "xrt/xrt_kernel.h"
+#include "experimental/xrt_module.h"
 
 #ifdef __cplusplus
 # include <cstdint>
@@ -114,6 +116,29 @@ public:
    */
   XRT_API_EXPORT
   bo(const xrt::hw_context& hwctx, pid_type pid, xclBufferExportHandle ehdl);
+};
+
+
+class kernel : public xrt::kernel
+{
+public:
+  /**
+   * kernel() - Constructor from module
+   *
+   * @param module
+   *   A module with elf binary instruction code which the
+   *   kernel function will execute
+   * @param name
+   *  Name of kernel function to construct
+   *
+   * The module contains an elf binary with instructions for maybe
+   * multiple functions.  When the kernel is constructed, the
+   * corresponding function is located in the module.  The
+   * instructions for the function are sent to the kernel mode driver
+   * in an ERT packet along with the kernel function arguments.
+   */
+  XRT_API_EXPORT
+  kernel(const xrt::module& mod, const std::string& name);
 };
 
 } // xrt::ext

--- a/src/runtime_src/core/include/experimental/xrt_module.h
+++ b/src/runtime_src/core/include/experimental/xrt_module.h
@@ -1,0 +1,150 @@
+// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+#ifndef XRT_MODULE_H_
+#define XRT_MODULE_H_
+
+#include "xrt/detail/config.h"
+#include "xrt/xrt_bo.h"
+#include "xrt/xrt_hw_context.h"
+#include "xrt/xrt_uuid.h"
+#include "xrt/detail/pimpl.h"
+#include "experimental/xrt_elf.h"
+
+#ifdef __cplusplus
+# include <cstdint>
+# include <string>
+#endif
+
+#ifdef __cplusplus
+namespace xrt {
+
+/*!
+ * @class module
+ *
+ * @brief
+ * An xrt::module contains functions an application will execute in
+ * hardware.  In Alveo the xclbin is the container that configures the
+ * hardware and provides the functions.  In AIE the functions are a
+ * set of instructions that are run on configured hardware, the
+ * instructions are embedded in an elf file, which is parsed for meta
+ * data determining how the functions are invoked.
+ *
+ * An xrt::module is constructed from the object that contains the
+ * functions to execute.  In the case of Alveo, the module is
+ * definitely constructed from an xrt::xclbin , in case of AIE the
+ * module is constructed from an xrt::elf or from a user pointer.
+ */
+class module_impl;
+class module : public detail::pimpl<module_impl>
+{
+public:
+  /**
+   */
+  module()
+  {}
+
+  /**
+   * module() - Constructor from elf
+   *
+   * @param hwctx
+   *   Hardware context that can execute the module functions
+   * @param elf
+   *   An elf binary with functions to execute within the hwctx
+   *
+   * The elf binary contains instructions for functions to be executed
+   * in the specified hardware context.  The elf binary has text
+   * segments with meta data to be mined for function arguments and
+   * type.
+   *
+   * The constructor allocates an instruction buffer object within the
+   * hardware context.  When extracting a function from the module a
+   * sub-buffer into the instruction buffer is created and returned.
+   *
+   * Throws an exception if the elf cannot be used with specified
+   * hardware context.
+   */
+  XRT_API_EXPORT
+  module(const xrt::hw_context& hwctx, const xrt::elf& elf);
+
+  /**
+   * module() - Constructor from user ptr
+   *
+   * @param hwctx
+   *   Hardware context that can execute the module functions
+   * @param userptr
+   *   A pointer to an opaque representation of the instructions
+   *   to execute on hardware configured by an xclbin with uuid
+   * @param sz
+   *   Size in bytes of the userptr buffer
+   * @param uuid
+   *   Unique id of the hardware configuration.  Must match the
+   *   xclbin uuid use to configure the hardware.
+   *
+   * The user pointer is an opaque representation of the instructions
+   * to execute on hardware configured by xclbin.
+   *
+   * The constructor allocates an instruction buffer object within
+   * the hardware context.  When extracting a function from the module
+   * a sub-buffer into the instruction buffer is created and returned.
+   *
+   * Throws an exception if the specified uuid doesn't match the uuid
+   * of the hardware context configuration.
+   */
+  XRT_API_EXPORT
+  module(const xrt::hw_context& hwctx, void* userptr, size_t sz, const xrt::uuid& uuid);
+
+  /**
+   * module() - Sub module
+   *
+   * @param parent
+   *   Parent module to dissect
+   * @param size
+   *   Size of new sub module
+   * @param offset
+   *   Offset from base of parent module
+   *
+   * Create a module carved out of the instruction buffer associated
+   * with the parent module.
+   */
+  XRT_API_EXPORT
+  module(const xrt::module& parent, size_t size, size_t offset);
+
+  /**
+   * get_cfg_uuid() - Get the uuid of the hardware configuration
+   *
+   * @return
+   *   UUID of matching hardware configuration
+   *
+   * An module is associated with exactly one hardware configuration.
+   * This function returns the uuid that identifies the configuration.
+   */
+  XRT_API_EXPORT
+  xrt::uuid
+  get_cfg_uuid() const;
+
+  /**
+   * get_symbol() - Returns instruction buffer for symbol
+   *
+   * @param nm
+   *   Name of symbol to get instructions for
+   * @return
+   *   Instruction buffer for the specified symbol
+   */
+  XRT_API_EXPORT
+  xrt::bo
+  get_instruction_buffer(const std::string& nm) const;
+
+  XRT_API_EXPORT
+  xrt::hw_context
+  get_hw_context() const;
+
+private:
+};
+
+} // namespace xrt
+
+#else
+# error xrt::module is only implemented for C++
+#endif // __cplusplus
+
+#endif

--- a/src/runtime_src/core/include/xrt/xrt_kernel.h
+++ b/src/runtime_src/core/include/xrt/xrt_kernel.h
@@ -16,6 +16,7 @@
 #ifdef __cplusplus
 # include "experimental/xrt_exception.h"
 # include "experimental/xrt_hw_context.h"
+# include "experimental/xrt_module.h"
 # include <chrono>
 # include <condition_variable>
 # include <cstdint>
@@ -694,7 +695,7 @@ public:
 
 
   /// @cond
-  /// Experimental in 2022.2
+  /// Experimental in 2022.2, 2023.1, 2023.3
   XCL_DRIVER_DLLESPEC
   kernel(const xrt::hw_context& ctx, const std::string& name);
   /// @endcond
@@ -793,6 +794,10 @@ public:
   {
     return handle;
   }
+
+  kernel(std::shared_ptr<kernel_impl> impl)
+    : handle(std::move(impl))
+  {}
   /// @endcond
 
 private:


### PR DESCRIPTION
#### Problem solved by the commit
Add first-class concept to represent instructions used by a function to execute on some configured hardware.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
In some scenarios, an xclbin configures the hardware with an overlay that is used to execute control code / instructions specific to a function, or put another way, the function executes instructions on the overlay.

Without a first-class instruction buffer, the host code is passing instructions as a semi-random regular kernel argument under the assumption that firmware can locate the instructions from the arguments.

#### How problem was solved, alternative solutions (if any) and why they were rejected
This PR introduces `xrt::module` for representing a binary that contains instructions for one or more functions.  The module is used to create instruction buffers for specific functions and kernel execution will populate an ERT packet for a function with the instruction buffer address explicitly defined.

The ERT packet for kernel execution is the standard `ert_start_kernel_cmd`, but the data payload is reinterpreted as a `ert_dpu_data` struct, which has explicit fields for instruction buffer address and size.

Additional this PR add `xrt::elf` for managing an elf binary that in turn can be used to create an `xrt::module`.  The `xrt::elf` will eventually provide APIs for extracting elf meta-data, like function names, arguments and more.

#### Risks (if any) associated the changes in the commit
None.  Added code is new and not currently used.

