### PR TITLE
Fixed xocl driver issues targeted for master

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
@@ -559,16 +559,20 @@ __xocl_create_bo_ioctl(struct drm_device *dev, struct drm_file *filp,
 	uint32_t slot_id = 0;
 	int ret;
 
-	/* Currently userspace will provide the corresponding hw context id.
-	 * Driver has to map that hw context to the corresponding slot id.
-	 */
-	hw_ctx_id = xocl_bo_slot_idx(args->flags);
-	ret = xocl_get_slot_id_by_hw_ctx_id(xdev, filp, hw_ctx_id);
-	if (ret < 0)
-		return ERR_PTR(ret);
+	if (bo_type != XOCL_BO_EXECBUF) {
+		/* Currently userspace will provide the corresponding hw context id.
+		 * Driver has to map that hw context to the corresponding slot id.
+		 * This is not valid for Host memory.
+		 */
+		hw_ctx_id = xocl_bo_slot_idx(args->flags);
+		ret = xocl_get_slot_id_by_hw_ctx_id(xdev, filp, hw_ctx_id);
+		if (ret < 0)
+			return ERR_PTR(ret);
 
-	slot_id = ret;
-	args->flags = xocl_bo_set_slot_idx(args->flags, slot_id);
+		slot_id = ret;
+		args->flags = xocl_bo_set_slot_idx(args->flags, slot_id);
+	}
+
 	xobj = xocl_create_bo(dev, args->size, args->flags, bo_type);
 	if (IS_ERR(xobj)) {
 		DRM_ERROR("object creation failed idx %d, size 0x%llx\n",

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
@@ -715,7 +715,7 @@ static int xocl_mm_insert_node_range_all(struct xocl_drm *drm_p, uint32_t *mem_i
 
 		phy_bank_exists = true;
 		start_addr = mem_data->m_base_address;
-		end_addr = start_addr + mem_data->m_size;
+		end_addr = start_addr + mem_data->m_size * 1024;
 
 #if defined(XOCL_DRM_FREE_MALLOC)
 		ret = drm_mm_insert_node_in_range(xocl_mm->mm, dnode, size, PAGE_SIZE, 0,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
@@ -744,8 +744,6 @@ xocl_read_axlf_helper(struct xocl_drm *drm_p, struct drm_xocl_axlf *axlf_ptr,
 	}
 
 done:
-	/* Update the slot */
-	*slot = slot_id;
 	if (size < 0)
 		err = size;
 	if (err) {
@@ -766,6 +764,8 @@ done:
 		userpf_info(xdev, "Loaded xclbin %pUb", &bin_obj.m_header.uuid);
 
 out_done:
+	/* Update the slot */
+	*slot = slot_id;
 	vfree(axlf);
 	return err;
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
There are multiple issue fixed by this PR 
1) [CR-1161789](https://jira.xilinx.com/browse/CR-1161789)
     --  Memory allocation failed as for PS kernel the memory size calculation is wrong. We should calculate by byte instead of KB.
2) OOM terminate called after throwing an instance of 'std::bad_alloc
   --  The issue is generic. For execbuf we should not check the slot/hw context id in the driver, 
   -- But current code doesn't check that. As there is always a hw context 0 present we never hit this issue.  
   -- The issue hit now as for the specific test it's closed the hw context 0 and active hw context  are started from 1. 

3) For PS kernel case : If existing xclbin present then it's failing. 
   -- For existing xclbin case we need to return the existing slot it so that  a new hw context has been created 2for the same. 


#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
-- Multiple regression test cases hit this issue. 

#### How problem was solved, alternative solutions (if any) and why they were rejected
-- Fixed all of then 
#### Risks (if any) associated the changes in the commit
-- N/A
#### What has been tested and how, request additional testing if necessary
-- Validation and specific test case 

#### Documentation impact (if any)
-- N/A