### PR TITLE
PS Kernel multislot support

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_sk.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_sk.h
@@ -28,29 +28,6 @@
 #define SK_DONE			1
 #define SK_RUNNING		2
 
-struct soft_cu {
-	void			*sc_vregs;
-	struct drm_gem_object	*gem_obj;
-
-	/*
-	 * This semaphore is used for each soft kernel
-	 * CU to wait for next command. When new command
-	 * for this CU comes in or we are told to abort
-	 * a CU, ert will up this semaphore.
-	 */
-	struct semaphore	sc_sem;
-
-	uint32_t		sc_flags;
-	uint64_t		usage;
-
-	/*
-	 * soft cu pid and parent pid. This can be used to identify if the
-	 * soft cu is still running or not. The parent should never crash
-	 */
-	uint32_t		sc_pid;
-	uint32_t		sc_parent_pid;
-};
-
 struct scu_image {
 	uint32_t		si_start;	/* start instance # */
 	uint32_t		si_end;		/* end instance # */
@@ -62,7 +39,6 @@ struct scu_image {
 struct soft_krnl {
 	struct list_head	sk_cmd_list;
 	struct mutex		sk_lock;
-	struct soft_cu		*sk_cu[MAX_SOFT_KERNEL];
 
 	/*
 	 * sk_ncus is a counter represents how many
@@ -70,10 +46,10 @@ struct soft_krnl {
 	 */
 	uint32_t		sk_ncus;
 
-	int			sk_meta_bohdl;	/* metadata BO handle */
-	struct drm_zocl_bo	*sk_meta_bo;		/* BO to hold metadata */
-	uint32_t		sk_nimg;
-	struct scu_image	*sk_img;
+	int			sk_meta_bohdl[MAX_PR_SLOT_NUM];	/* metadata BO handle */
+	struct drm_zocl_bo	*sk_meta_bo[MAX_PR_SLOT_NUM];		/* BO to hold metadata */
+	uint32_t		sk_nimg[MAX_PR_SLOT_NUM];
+	struct scu_image	*sk_img[MAX_PR_SLOT_NUM];
 	wait_queue_head_t	sk_wait_queue;
 };
 

--- a/src/runtime_src/core/edge/drm/zocl/zocl_sysfs.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_sysfs.c
@@ -125,37 +125,6 @@ static ssize_t kds_numcus_show(struct device *dev,
 }
 static DEVICE_ATTR_RO(kds_numcus);
 
-static ssize_t kds_skstat_show(struct device *dev,
-		struct device_attribute *attr, char *buf)
-{
-	struct drm_zocl_dev *zdev = dev_get_drvdata(dev);
-	struct soft_krnl *sk;
-	struct soft_cu *scu;
-	ssize_t sz = 0;
-	int i;
-
-	if (!zdev || !zdev->soft_kernel)
-		return 0;
-
-	sk = zdev->soft_kernel;
-	mutex_lock(&sk->sk_lock);
-	for (i = 0; i < sk->sk_ncus; i++) {
-		scu = sk->sk_cu[i];
-		if (scu) {
-			sz += sprintf(buf+sz, "SK %d\n", i);
-			sz += sprintf(buf+sz, " flags %d\n", scu->sc_flags);
-			sz += sprintf(buf+sz, " usage %lld\n", scu->usage);
-			sz += sprintf(buf+sz, " vregs[0] 0x%x\n", ((u32*)scu->sc_vregs)[0]);
-		} else {
-			sz += sprintf(buf+sz, "SK %d is released\n", i);
-		}
-	}
-	mutex_unlock(&sk->sk_lock);
-
-	return sz;
-}
-static DEVICE_ATTR_RO(kds_skstat);
-
 static ssize_t
 kds_interval_store(struct device *dev, struct device_attribute *da,
 	       const char *buf, size_t count)
@@ -433,7 +402,6 @@ static DEVICE_ATTR_WO(zocl_reset);
 static struct attribute *zocl_attrs[] = {
 	&dev_attr_xclbinid.attr,
 	&dev_attr_kds_numcus.attr,
-	&dev_attr_kds_skstat.attr,
 	&dev_attr_kds_xrt_version.attr,
 	&dev_attr_kds_echo.attr,
 	&dev_attr_kds_stat.attr,

--- a/src/runtime_src/core/edge/include/xclhal2_mpsoc.h
+++ b/src/runtime_src/core/edge/include/xclhal2_mpsoc.h
@@ -40,6 +40,7 @@ struct xclSKCmd {
     int		bohdl;
     int		meta_bohdl;
     uuid_t      uuid;
+    uint32_t	slot_id;
 };
 
 struct xclAIECmd {

--- a/src/runtime_src/core/edge/include/zynq_ioctl.h
+++ b/src/runtime_src/core/edge/include/zynq_ioctl.h
@@ -476,6 +476,7 @@ struct drm_zocl_sk_getcmd {
 	int		bohdl;
 	int		meta_bohdl;
 	unsigned char	uuid[16];
+	uint32_t	slot_id;
 };
 
 enum aie_info_code {

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -1017,6 +1017,7 @@ xclSKGetCmd(xclSKCmd *cmd)
     cmd->meta_bohdl = scmd.meta_bohdl;
     memcpy(cmd->uuid, &scmd.uuid, sizeof(cmd->uuid));
     snprintf(cmd->krnl_name, ZOCL_MAX_NAME_LENGTH, "%s", scmd.name);
+    cmd->slot_id = scmd.slot_id;
   }
 
   return ret ? -errno : ret;

--- a/src/runtime_src/core/include/ert.h
+++ b/src/runtime_src/core/include/ert.h
@@ -341,6 +341,7 @@ struct config_sk_image_uuid {
   uint32_t num_cus;
   uint32_t sk_name[5];
   unsigned char     sk_uuid[16];
+  uint32_t slot_id;
 };
 
 /**

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -1636,6 +1636,7 @@ xocl_kds_reserve_scu_subdevices(struct xocl_dev *xdev, struct xrt_cu_info *scu_i
 				    scu_info[i].iname);
 
 		scu_info[i].inst_idx = retval;
+		scu_info[i].cu_idx = retval;
 	}
 }
 
@@ -2245,7 +2246,7 @@ static int xocl_kds_update_xgq(struct xocl_dev *xdev, int slot_hdl,
 		struct xgq_cmd_resp_query_cu resp;
 		void *xgq;
 
-		ret = xocl_kds_xgq_query_cu(xdev, i, 0, &resp);
+		ret = xocl_kds_xgq_query_cu(xdev, cu_info[i].cu_idx, 0, &resp);
 		if (ret)
 			goto create_regular_cu;
 
@@ -2265,7 +2266,7 @@ static int xocl_kds_update_xgq(struct xocl_dev *xdev, int slot_hdl,
 		struct xgq_cmd_resp_query_cu resp;
 		void *xgq;
 
-		ret = xocl_kds_xgq_query_cu(xdev, i, DOMAIN_PS, &resp);
+		ret = xocl_kds_xgq_query_cu(xdev, scu_info[i].cu_idx, DOMAIN_PS, &resp);
 		if (ret)
 			goto create_regular_cu;
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Enable multi-slot PS kernels
Remove unused data structure

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Enhancement to support multislot xclbin on Versal DC platforms

#### How problem was solved, alternative solutions (if any) and why they were rejected
Enhance PS kernel's data structure to support multiple PS kernel objects based on the slot id

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Tested on VCK5000

#### Documentation impact (if any)
