### PR TITLE
install pybind11 in xrtdeps-win22.py

### DIFF
--- a/src/runtime_src/tools/scripts/xrtdeps-win22.py
+++ b/src/runtime_src/tools/scripts/xrtdeps-win22.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (C) 2019-2022 Xilinx, Inc. All rights reserved.
+# Copyright (C) 2019-2023 Xilinx, Inc. All rights reserved.
 #
 # =============================================================================
 # Checks and validates the windows installation environment
@@ -67,7 +67,7 @@ def main():
   parser.add_argument('--icd', action="store_true", help='install Khronos OpenCL icd loader library')
   parser.add_argument('--opencl', action="store_true", help='install Khronos OpenCL header files')
   parser.add_argument('--gtest', action="store_true", help='install gtest libraries')
-  parser.add_argument('--python', action="store_true", help='install python dependencies (pybind11)')
+  parser.add_argument('--pybind11', action="store_true", help='install python dependencies (pybind11)')
   parser.add_argument('--validate_all_requirements', action="store_true", help='validate all XRT dependent libraries and tools are installed')
   parser.add_argument('--verbose', action="store_true", help='enables script verbosity')
   args = parser.parse_args()
@@ -130,13 +130,14 @@ def main():
     return True
 
   # -- Install python packages ----------------------------------------------
-  if args.python:
+  if args.pybind11:
     pybind = pybind11_package()
     if not pybind.installed:
       print("")
       print("ERROR: The Python pybind11 package could not be installed")
       print("        Please make sure you have pip3 installed on your system and try adding it with")
       print("        py.exe -m pip install pybind11=='2.10.4'")
+      return True
 
   return False
 
@@ -754,14 +755,14 @@ class pybind11_package():
         self.expected_version = expected_version
         
         if self.check_installed():
-            print(f"Successfully found pybind11 installation")
+            print("Successfully found pybind11 installation")
             pass
         else: 
-          print(f"Did not find a compatible installation of pybind11")
-          print(f"Trying to install pybind11=={self.expected_version} from pypi...")
+          print("Did not find a compatible installation of pybind11")
+          print(f"Installing pybind11 {self.expected_version} via pypi...")
           self.install()
           
-          print(f"Confirming installation of pybind11 {expected_version}")
+          print(f"Validating pybind11 {expected_version} installation...")
           if self.check_installed():
               print("Pybind11 installed successfully")
     
@@ -769,7 +770,7 @@ class pybind11_package():
         try:
             import pybind11
         except ImportError:
-            print(f"Pybind11: not installed")
+            print("Pybind11: not installed")
             return False
             
         try:

--- a/src/runtime_src/tools/scripts/xrtdeps-win22.py
+++ b/src/runtime_src/tools/scripts/xrtdeps-win22.py
@@ -763,7 +763,9 @@ class pybind11_package():
           self.install()
           
           print(f"Validating pybind11 {expected_version} installation...")
-          if self.check_installed():
+          # 2nd install check as a subprocess, because we can't cleanly reload
+          # the pybind11 module within this script
+          if self.check_installed_subprocess():
               print("Pybind11 installed successfully")
     
     def check_installed(self):
@@ -781,7 +783,16 @@ class pybind11_package():
 
         self.installed = True
         return True
-    
+
+    def check_installed_subprocess(self):
+        result = subprocess.run(["py.exe", "-c", f"import pybind11; assert pybind11.__version__ == '" + self.expected_version + "'"], stderr=subprocess.PIPE)
+        if result.returncode == 0:
+            self.installed = True
+            return True
+        else:
+            print(f"Pybind11: validation failed")
+            return False
+ 
     def install(self):
         result = subprocess.run(["py.exe", "-m", "pip", "install", f"pybind11=={self.expected_version}"], stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
         try:

--- a/src/runtime_src/tools/scripts/xrtdeps-win22.py
+++ b/src/runtime_src/tools/scripts/xrtdeps-win22.py
@@ -760,6 +760,10 @@ class pybind11_package():
           print(f"Did not find a compatible installation of pybind11")
           print(f"Trying to install pybind11=={self.expected_version} from pypi...")
           self.install()
+          
+          print(f"Confirming installation of pybind11 {expected_version}")
+          if self.check_installed():
+              print("Pybind11 installed successfully")
     
     def check_installed(self):
         try:
@@ -781,7 +785,6 @@ class pybind11_package():
         result = subprocess.run(["py.exe", "-m", "pip", "install", f"pybind11=={self.expected_version}"], stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
         try:
             assert result.returncode == 0
-            self.installed = True
             print(f"Pybind11 {self.expected_version} successfully installed")
         except:
             print(result.stdout)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Adds pybind python package installation to xrtdeps-win22.py script

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
N/A

#### How problem was solved, alternative solutions (if any) and why they were rejected
N/A

#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
Tested script in vs 2022 developer prompt on a windows 10 machine, for following scenarios:
* pybind not installed on machine
* pybind installed, but wrong version
* pybind installed with correct version

Sample usage (from vs developer prompt):
```
# normal run
cd src/runtime_src/tools/scripts
py.exe xrtdeps-win22.py --pybind11

# test making sure pybind11 is uninstalled
py.exe -m pip uninstall -y pybind11
py.exe xrtdeps-win22.py --pybind11

# test existing install of wrong version
py.exe -m pip install pybind11==2.6.0
py.exe xrtdeps-win22.py --pybind11
```

Sample expected output:
```
XRT\src\runtime_src\tools\scripts>py.exe xrtdeps-win22.py --pybind11

---------------------------------------------------------------------------
Validating the installation XRT Windows supporting applications.
---------------------------------------------------------------------------
  CL .............................................. [found]
  git ............................................. [found]
  CMAKE ........................................... [found]

---------------------------------------------------------------------------
Examining system for existing library build directories.
---------------------------------------------------------------------------
Pybind11: found version 2.6.0 -- expected 2.10.4
Did not find a compatible installation of pybind11
Installing pybind11 2.10.4 via pypi...
Pybind11 2.10.4 successfully installed
Validating pybind11 2.10.4 installation...
Pybind11 installed successfully
```

#### Documentation impact (if any)
Might need an additional blurb in docs to mention a "--python" flag to setup script if you want to build pyxrt.