### PR TITLE
Added check for cfg_cu payload_size to be within MAX_CQ_SLOT_SIZE in xocl_kds.c

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -1950,6 +1950,10 @@ xocl_kds_xgq_cfg_cus(struct xocl_dev *xdev, xuid_t *xclbin_id, struct xrt_cu_inf
 		 * approach.
 		 */
 		cfg_cu->payload_size = cfg_cu->payload_size * 2;
+		if(cfg_cu->payload_size > MAX_CQ_SLOT_SIZE) {
+			userpf_err(xdev, "CU Argument Size %x > MAX_CQ_SLOT_SIZE, setting it to MAX_CQ_SLOT_SIZE!", cfg_cu->payload_size);
+			cfg_cu->payload_size = MAX_CQ_SLOT_SIZE;
+		}
 
 		scnprintf(cfg_cu->name, sizeof(cfg_cu->name), "%s:%s",
 			  cu_info[i].kname, cu_info[i].iname);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -1941,6 +1941,10 @@ xocl_kds_xgq_cfg_cus(struct xocl_dev *xdev, xuid_t *xclbin_id, struct xrt_cu_inf
 		if (cu_info[i].num_args)
 			max_off_arg_size = cu_info[i].args[max_off_idx].size;
 		cfg_cu->payload_size = max_off + max_off_arg_size + sizeof(struct xgq_cmd_sq_hdr);
+		if(cfg_cu->payload_size > MAX_CQ_SLOT_SIZE) {
+			userpf_err(xdev, "CU Argument Size %x > MAX_CQ_SLOT_SIZE!", cfg_cu->payload_size);
+			return -ENOMEM;
+		}
 		/*
 		 * Times 2 to make sure XGQ slot size is bigger than the size of
 		 * key-value pair commands, eg. ERT_START_KEY_VAL.
@@ -1951,7 +1955,7 @@ xocl_kds_xgq_cfg_cus(struct xocl_dev *xdev, xuid_t *xclbin_id, struct xrt_cu_inf
 		 */
 		cfg_cu->payload_size = cfg_cu->payload_size * 2;
 		if(cfg_cu->payload_size > MAX_CQ_SLOT_SIZE) {
-			userpf_err(xdev, "CU Argument Size %x > MAX_CQ_SLOT_SIZE, setting it to MAX_CQ_SLOT_SIZE!", cfg_cu->payload_size);
+			userpf_err(xdev, "CU Argument Size for Key-Valye Pair of %x > MAX_CQ_SLOT_SIZE, setting it to MAX_CQ_SLOT_SIZE!  Key-Value pair will not be supported!", cfg_cu->payload_size);
 			cfg_cu->payload_size = MAX_CQ_SLOT_SIZE;
 		}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
PR-7178 added a check in zocl_ctrl_ert.c for XGQ payload_size > MAX_CQ_SLOT_SIZE.  
However, in xocl_kds.c there was no such check, and the payload size is also doubled to account for key-value pair command type.  This then exceeded the MAX_CQ_SLOT_SIZE and caused zocl's ERT not to initialize due to size check.
However, the actual arguments are within the valid slot size.
This change caps the payload_size to MAX_CQ_SLOT_SIZE if it's exceeded, and prints out an error message.
But there is probably a need to revisit key-value pair command buffer size calculation.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
PR-7178

#### How problem was solved, alternative solutions (if any) and why they were rejected
Check for payload_size against MAX_CQ_SLOT_SIZE, and set it to MAX_CQ_SLOT_SIZE if it exceeds it.

#### Risks (if any) associated the changes in the commit
If a kernel has a very large key-value pair command it could  run into issues when running the actual kernel

#### What has been tested and how, request additional testing if necessary
V70

#### Documentation impact (if any)
