### PR TITLE
Minor profiling refactoring, and fix issue with identifying AIE applications

### DIFF
--- a/src/runtime_src/xdp/profile/database/database.cpp
+++ b/src/runtime_src/xdp/profile/database/database.cpp
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2016-2022 Xilinx, Inc
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -30,7 +31,7 @@ namespace xdp {
   {
     VPDatabase::live = true ;
 
-    summary = new SummaryWriter("summary.csv", this) ;
+    summary = std::make_unique<SummaryWriter>("summary.csv", this);
   }
 
   // The database and all the plugins are singletons and can be
@@ -50,7 +51,6 @@ namespace xdp {
     if (summary != nullptr) {
       staticdb.addOpenedFile(summary->getcurrentFileName(), "PROFILE_SUMMARY") ;
       summary->write(false) ;
-      delete summary ;
     }
 
     plugins.clear();

--- a/src/runtime_src/xdp/profile/database/database.h
+++ b/src/runtime_src/xdp/profile/database/database.h
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2016-2022 Xilinx, Inc
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -19,6 +20,7 @@
 
 #include <list>
 #include <map>
+#include <memory>
 #include <vector>
 
 #include "xdp/config.h"
@@ -57,7 +59,7 @@ namespace xdp {
     std::list<XDPPlugin*> plugins ;
 
     // The database itself keeps track of the generic summary
-    VPWriter* summary ;
+    std::unique_ptr<VPWriter> summary;
 
     // Additionally, for summary generation, the database must expose
     //  what plugins were loaded and what information is available

--- a/src/runtime_src/xdp/profile/database/dynamic_event_database.cpp
+++ b/src/runtime_src/xdp/profile/database/dynamic_event_database.cpp
@@ -30,19 +30,7 @@ namespace xdp {
   VPDynamicDatabase::VPDynamicDatabase(VPDatabase* d) :
     db(d), eventId(1)
   {
-    host = new HostDB();
-  }
-
-  VPDynamicDatabase::~VPDynamicDatabase()
-  {
-    if (host != nullptr)
-      delete host;
-
-    std::lock_guard<std::mutex> lock(deviceDBLock);
-    for (auto& iter : devices) {
-      auto device = iter.second;
-      delete device;
-    }
+    host = std::make_unique<HostDB>();
   }
 
   // For designs that load multiple xclbins, we add an event into the database
@@ -82,8 +70,8 @@ namespace xdp {
   {
     std::lock_guard<std::mutex> lock(deviceDBLock);
     if (devices.find(deviceId) == devices.end())
-      devices[deviceId] = new DeviceDB;
-    return devices[deviceId];
+      devices[deviceId] = std::make_unique<DeviceDB>();
+    return devices[deviceId].get();
   }
 
   void VPDynamicDatabase::addDeviceEvent(uint64_t deviceId, VTFEvent* event)

--- a/src/runtime_src/xdp/profile/database/dynamic_event_database.h
+++ b/src/runtime_src/xdp/profile/database/dynamic_event_database.h
@@ -57,12 +57,12 @@ namespace xdp {
     // information per execution.  This abstracts the host API event
     // storage and matching of start with end events.  User level events
     // are also stored here as well as dependency information.
-    HostDB* host = nullptr;
+    std::unique_ptr<HostDB> host = nullptr;
 
     // Device related information.  There can be multiple devices active
     // in each execution.  This abstracts the device events and the
     // matching of start with end device events.
-    std::map<uint64_t, DeviceDB*> devices;
+    std::map<uint64_t, std::unique_ptr<DeviceDB>> devices;
     DeviceDB* getDeviceDB(uint64_t deviceId);
 
     // A unique event id for every event added to the database, both host
@@ -82,7 +82,7 @@ namespace xdp {
 
   public:
     XDP_EXPORT VPDynamicDatabase(VPDatabase* d);
-    XDP_EXPORT ~VPDynamicDatabase();
+    XDP_EXPORT ~VPDynamicDatabase() = default;
 
     // For multiple xclbin designs, add a device event that marks the
     // transition from one xclbin to another

--- a/src/runtime_src/xdp/profile/database/dynamic_info/aie_db.cpp
+++ b/src/runtime_src/xdp/profile/database/dynamic_info/aie_db.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -13,6 +13,8 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+
+#define XDP_SOURCE
 
 #include <cstring>
 

--- a/src/runtime_src/xdp/profile/database/dynamic_info/aie_db.h
+++ b/src/runtime_src/xdp/profile/database/dynamic_info/aie_db.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -22,6 +22,7 @@
 #include <mutex>
 #include <vector>
 
+#include "xdp/config.h"
 #include "xdp/profile/database/dynamic_info/samples.h"
 #include "xdp/profile/database/dynamic_info/types.h"
 
@@ -40,7 +41,7 @@ namespace xdp {
 
   public:
     AIEDB() = default;
-    ~AIEDB();
+    XDP_EXPORT ~AIEDB();
 
     void addAIETraceData(uint64_t strmIndex, void* buffer, uint64_t bufferSz,
                          bool copy, uint64_t numTraceStreams);

--- a/src/runtime_src/xdp/profile/database/dynamic_info/host_db.cpp
+++ b/src/runtime_src/xdp/profile/database/dynamic_info/host_db.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -13,6 +13,8 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+
+#define XDP_SOURCE
 
 #include "xdp/profile/database/dynamic_info/host_db.h"
 #include "xdp/profile/database/events/vtf_event.h"

--- a/src/runtime_src/xdp/profile/database/dynamic_info/host_db.h
+++ b/src/runtime_src/xdp/profile/database/dynamic_info/host_db.h
@@ -24,6 +24,7 @@
 #include <mutex>
 #include <vector>
 
+#include "xdp/config.h"
 #include "xdp/profile/database/dynamic_info/dependency_manager.h"
 #include "xdp/profile/database/dynamic_info/mark.h"
 #include "xdp/profile/database/dynamic_info/types.h"
@@ -73,7 +74,7 @@ namespace xdp {
 
   public:
     HostDB() = default;
-    ~HostDB();
+    XDP_EXPORT ~HostDB();
 
     // Functions to add host events to the database
     void addSortedEvent(VTFEvent* event);

--- a/src/runtime_src/xdp/profile/database/static_info_database.h
+++ b/src/runtime_src/xdp/profile/database/static_info_database.h
@@ -69,7 +69,7 @@ namespace xdp {
     // Parent pointer to database so we can issue broadcasts
     VPDatabase* db ;
     // The static database handles the single instance of the run summary
-    VPWriter* runSummary ;
+    std::unique_ptr<VPWriter> runSummary;
 
   private:
     // ********* Information specific to each host execution **********
@@ -94,7 +94,7 @@ namespace xdp {
     std::vector<std::string> softwareEmulationPortBitWidths ;
 
     // Device Specific Information mapped to the Unique Device Id
-    std::map<uint64_t, DeviceInfo*> deviceInfo;
+    std::map<uint64_t, std::unique_ptr<DeviceInfo>> deviceInfo;
 
     // Static info can be accessed via any host thread, so we have
     //  fine grained locks on each of the types of data.
@@ -247,10 +247,8 @@ namespace xdp {
     XDP_EXPORT double getClockRateMHz(uint64_t deviceId, bool PL = true) ;
     XDP_EXPORT void setDeviceName(uint64_t deviceId, const std::string& name) ; 
     XDP_EXPORT std::string getDeviceName(uint64_t deviceId) ;
-    XDP_EXPORT void setDeviceIntf(uint64_t deviceId, DeviceIntf* devIntf) ;
     XDP_EXPORT DeviceIntf* getDeviceIntf(uint64_t deviceId) ;
     XDP_EXPORT DeviceIntf* createDeviceIntf(uint64_t deviceId, xdp::Device* dev);
-    XDP_EXPORT void setKDMACount(uint64_t deviceId, uint64_t num) ;
     XDP_EXPORT uint64_t getKDMACount(uint64_t deviceId) ;
     XDP_EXPORT void setHostMaxReadBW(uint64_t deviceId, double bw) ;
     XDP_EXPORT double getHostMaxReadBW(uint64_t deviceId) ;
@@ -263,9 +261,6 @@ namespace xdp {
     XDP_EXPORT std::string getXclbinName(uint64_t deviceId) ;
     XDP_EXPORT std::vector<XclbinInfo*> getLoadedXclbins(uint64_t deviceId) ;
     XDP_EXPORT ComputeUnitInstance* getCU(uint64_t deviceId, int32_t cuId) ;
-    XDP_EXPORT
-    std::map<int32_t, ComputeUnitInstance*>* getCUs(uint64_t deviceId) ;
-    XDP_EXPORT std::map<int32_t, Memory*>* getMemoryInfo(uint64_t deviceId) ;
     XDP_EXPORT Memory* getMemory(uint64_t deviceId, int32_t memId) ;
     // Reseting device information whenever a new xclbin is added
     XDP_EXPORT void updateDevice(uint64_t deviceId, void* devHandle) ;

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -53,6 +53,7 @@ namespace xdp {
 
     db->registerPlugin(this);
     db->registerInfo(info::aie_trace);
+    db->getStaticInfo().setAieApplication();
   }
 
   AieTracePluginUnified::~AieTracePluginUnified()


### PR DESCRIPTION
#### Problem solved by the commit
Some minor refactoring in the profiling database to replace raw pointers with owned unique_ptrs and to remove unused functions.  Also, this reintroduces a call in the AIE trace plugin that was used to identify in the run summary when AIE profiling/trace/status applications are run.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
The run summary file for recent regression tests were noted to no longer have the "aie" property tag.  This was erroneously removed due to recent changes of the AIE trace files.

#### How problem was solved, alternative solutions (if any) and why they were rejected
The mark function was reintroduced to identify that any application that loads the AIE trace plugin is an AIE application.

#### Risks (if any) associated the changes in the commit
Low risks as the refactoring should not change the functionality and the addition to the AIE trace plugin restores functionality that was mistakenly removed.

#### What has been tested and how, request additional testing if necessary
Tested on hardware emulation example to verify refactoring.

#### Documentation impact (if any)
No documentation impact.