### PR TITLE
Vitis-7923 HW context independent buffer objects

### DIFF
--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -1495,10 +1495,21 @@ adjust_buffer_flags(xrt::ext::bo::access_mode access)
   return flags.all;
 }
 
+// xrt::ext::bo is always a host only BO and group is not used default
+// to sentinel that can be special cased when BOs are validated as
+// part of setting kernel arguments.
+static int
+no_group_id()
+{
+  xcl_bo_flags grp {};
+  grp.bank = XRT_BO_BANK_NOT_USED;
+  return static_cast<int>(grp.flags);
+}
+
 static std::shared_ptr<xrt::bo_impl>
 alloc_kbuf(const device_type& device, void* userptr, size_t sz, xrtBufferFlags flags)
 {
-  auto handle = userptr ? alloc_bo(device, userptr, sz, flags, 0) : alloc_bo(device, sz, flags, 0);
+  auto handle = userptr ? alloc_bo(device, userptr, sz, flags, 0) : alloc_bo(device, sz, flags, no_group_id());
   auto boh = std::make_shared<xrt::buffer_kbuf>(device, std::move(handle), sz);
   return boh;
 }

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -1945,6 +1945,9 @@ class run_impl
   validate_bo_at_index(size_t index, const xrt::bo& bo)
   {
     xcl_bo_flags grp {xrt_core::bo::group_id(bo)};
+    if (grp.bank == XRT_BO_BANK_NOT_USED)
+      return bo;
+
     if (validate_ip_arg_connectivity(index, grp.bank))
       return bo;
 

--- a/src/runtime_src/core/include/xrt_mem.h
+++ b/src/runtime_src/core/include/xrt_mem.h
@@ -103,6 +103,11 @@ struct xcl_bo_flags
 #define XRT_BO_ACCESS_EXPORTED 2
 
 /**
+ * Sentinel for bank when it is not used
+ */
+#define XRT_BO_BANK_NOT_USED 0xFFFF
+
+/**
  * XRT Native BO flags
  *
  * These flags are simple aliases for use with XRT native BO APIs.


### PR DESCRIPTION
#### Problem solved by the commit
Default group id to sentinel for host only buffers allocated with xrt::ext::bo consructors.

#### How problem was solved, alternative solutions (if any) and why they were rejected
xrt::ext::bo allocates host only buffers that should not be validated against xclbin metadata when setting these BOs as kernel arguments. By using a sentinel, the validation check performed as part of xrt::run::set_arg can be special cased to not error out.

```
// Allocate a buffer object on a device
xrt::ext::bo bo{device, size, access_mode};

// Allocate a buffer object specific to a hwcxt
xrt::ext::bo bo{hwctx, size, access_mode};
```

#### Risks (if any) associated the changes in the commit
The code path in xrt::ext::bo is experimental per
https://github.com/Xilinx/XRT/pull/7517, the changes in this PR do not affect existing code paths.
