### PR TITLE
Fix for CR:1163285: change reserved_row_start and reserved_num_rows to mem_row_start and mem_num_rows in aie_control_config.json

### DIFF
--- a/src/runtime_src/core/edge/common/aie_parser.cpp
+++ b/src/runtime_src/core/edge/common/aie_parser.cpp
@@ -24,6 +24,7 @@
 
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/json_parser.hpp>
+#include <boost/optional.hpp>
 
 namespace {
 
@@ -59,8 +60,15 @@ get_driver_config(const pt::ptree& aie_meta)
   driver_config.num_columns = aie_meta.get<uint8_t>("aie_metadata.driver_config.num_columns");
   driver_config.num_rows = aie_meta.get<uint8_t>("aie_metadata.driver_config.num_rows");
   driver_config.shim_row = aie_meta.get<uint8_t>("aie_metadata.driver_config.shim_row");
-  driver_config.reserved_row_start = aie_meta.get<uint8_t>("aie_metadata.driver_config.reserved_row_start");
-  driver_config.reserved_num_rows = aie_meta.get<uint8_t>("aie_metadata.driver_config.reserved_num_rows");
+  if (!aie_meta.get_optional<uint8_t>("aie_metadata.driver_config.mem_row_start") ||
+      !aie_meta.get_optional<uint8_t>("aie_metadata.driver_config.mem_num_rows")) {
+  	driver_config.mem_row_start = aie_meta.get<uint8_t>("aie_metadata.driver_config.reserved_row_start");
+	driver_config.mem_num_rows = aie_meta.get<uint8_t>("aie_metadata.driver_config.reserved_num_rows");
+  }
+  else {
+	driver_config.mem_row_start = aie_meta.get<uint8_t>("aie_metadata.driver_config.mem_row_start");
+	driver_config.mem_num_rows = aie_meta.get<uint8_t>("aie_metadata.driver_config.mem_num_rows");
+  }
   driver_config.aie_tile_row_start = aie_meta.get<uint8_t>("aie_metadata.driver_config.aie_tile_row_start");
   driver_config.aie_tile_num_rows = aie_meta.get<uint8_t>("aie_metadata.driver_config.aie_tile_num_rows");
   return driver_config;

--- a/src/runtime_src/core/edge/user/aie/aie.cpp
+++ b/src/runtime_src/core/edge/user/aie/aie.cpp
@@ -46,8 +46,8 @@ Aie::Aie(const std::shared_ptr<xrt_core::device>& device)
         driver_config.num_columns,
         driver_config.num_rows,
         driver_config.shim_row,
-        driver_config.reserved_row_start,
-        driver_config.reserved_num_rows,
+        driver_config.mem_row_start,
+        driver_config.mem_num_rows,
         driver_config.aie_tile_row_start,
         driver_config.aie_tile_num_rows);
 
@@ -74,7 +74,7 @@ Aie::Aie(const std::shared_ptr<xrt_core::device>& device)
     devInst = &DevInst;
 
     adf::aiecompiler_options aiecompiler_options = xrt_core::edge::aie::get_aiecompiler_options(device.get());
-    adf::config_manager::initialize(devInst, driver_config.reserved_num_rows, aiecompiler_options.broadcast_enable_core);
+    adf::config_manager::initialize(devInst, driver_config.mem_num_rows, aiecompiler_options.broadcast_enable_core);
 
     fal_util::initialize(devInst); //resource manager initialization
     

--- a/src/runtime_src/core/edge/user/aie/common_layer/adf_api_config.h
+++ b/src/runtime_src/core/edge/user/aie/common_layer/adf_api_config.h
@@ -31,8 +31,8 @@ struct driver_config
     uint8_t num_columns;
     uint8_t num_rows;
     uint8_t shim_row;
-    uint8_t reserved_row_start;
-    uint8_t reserved_num_rows;
+    uint8_t mem_row_start;
+    uint8_t mem_num_rows;
     uint8_t aie_tile_row_start;
     uint8_t aie_tile_num_rows;
     uint8_t partition_num_cols;

--- a/src/runtime_src/core/edge/user/device_linux.cpp
+++ b/src/runtime_src/core/edge/user/device_linux.cpp
@@ -186,8 +186,16 @@ get_aie_metadata_info(const xrt_core::device* device)
   aie_meta.num_rows = pt.get<uint32_t>("aie_metadata.driver_config.num_rows");
   aie_meta.shim_row = pt.get<uint32_t>("aie_metadata.driver_config.shim_row");
   aie_meta.core_row = pt.get<uint32_t>("aie_metadata.driver_config.aie_tile_row_start");
-  aie_meta.mem_row = pt.get<uint32_t>("aie_metadata.driver_config.reserved_row_start");
-  aie_meta.num_mem_row = pt.get<uint32_t>("aie_metadata.driver_config.reserved_num_rows");
+  if (!pt.get_optional<uint32_t>("aie_metadata.driver_config.mem_row_start") || 
+      !pt.get_optional<uint32_t>("aie_metadata.driver_config.mem_num_rows")) {
+       aie_meta.mem_row = pt.get<uint32_t>("aie_metadata.driver_config.reserved_row_start");
+       aie_meta.num_mem_row = pt.get<uint32_t>("aie_metadata.driver_config.reserved_num_rows");
+  }
+  else {
+       aie_meta.mem_row = pt.get<uint32_t>("aie_metadata.driver_config.mem_row_start");
+       aie_meta.num_mem_row = pt.get<uint32_t>("aie_metadata.driver_config.mem_num_rows");
+  }
+
   return aie_meta;
 }
 
@@ -468,6 +476,17 @@ struct aie_reg_read
 
   XAie_DevInst* devInst;         // AIE Device Instance
 
+  uint8_t mem_row_start, mem_num_rows;
+  if (!pt.get_optional<uint8_t>("aie_metadata.driver_config.mem_row_start") ||
+      !pt.get_optional<uint8_t>("aie_metadata.driver_config.mem_num_rows")) {
+       mem_row_start = pt.get<uint8_t>("aie_metadata.driver_config.reserved_row_start");
+       mem_num_rows = pt.get<uint8_t>("aie_metadata.driver_config.reserved_num_rows");
+  }
+  else {
+       mem_row_start = pt.get<uint8_t>("aie_metadata.driver_config.mem_row_start");
+       mem_num_rows = pt.get<uint8_t>("aie_metadata.driver_config.mem_num_rows");
+  }
+
   XAie_SetupConfig(ConfigPtr,
     pt.get<uint8_t>("aie_metadata.driver_config.hw_gen"),
     pt.get<uint64_t>("aie_metadata.driver_config.base_address"),
@@ -476,8 +495,8 @@ struct aie_reg_read
     pt.get<uint8_t>("aie_metadata.driver_config.num_columns"),
     pt.get<uint8_t>("aie_metadata.driver_config.num_rows"),
     pt.get<uint8_t>("aie_metadata.driver_config.shim_row"),
-    pt.get<uint8_t>("aie_metadata.driver_config.reserved_row_start"),
-    pt.get<uint8_t>("aie_metadata.driver_config.reserved_num_rows"),
+    mem_row_start,
+    mem_num_rows,
     pt.get<uint8_t>("aie_metadata.driver_config.aie_tile_row_start"),
     pt.get<uint8_t>("aie_metadata.driver_config.aie_tile_num_rows"));
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1163285
XRT is now supporting old and new property i.e reserved_row_start , reserved_num_rows as well as mem_row_start and mem_num_rows in driver_config section aie_metadata. Once the aie compiler is updated, we can remove the old property ie. reserved_row_start and reserved_num_rows. 
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
NA
#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit
NA
#### What has been tested and how, request additional testing if necessary
Verified application on aie1 and aie2 with updated xclbins 
#### Documentation impact (if any)
NA