### PR TITLE
CR-1161216 - Always enable GCQ's interrupt to allow compatibility between GCQ v1 and v2

### DIFF
--- a/src/runtime_src/core/include/xgq_impl.h
+++ b/src/runtime_src/core/include/xgq_impl.h
@@ -382,7 +382,6 @@ xgq_init(struct xgq *xgq, uint64_t flags, uint64_t io_hdl, uint64_t ring_addr,
 		sqprod = sq_produced;
 		cqprod = cq_produced;
 		// Write 1 to GCQ interrupt enable register to always enable interrupt
-		xgq_reg_write32(xgq->xq_io_hdl, sqprod + XGQ_INTR_ENABLE_OFFSET, 1);
 		xgq_reg_write32(xgq->xq_io_hdl, cqprod + XGQ_INTR_ENABLE_OFFSET, 1);
 	}
 	xgq_init_ring(xgq, &xgq->xq_sq, sqprod,
@@ -533,7 +532,6 @@ static inline int xgq_attach(struct xgq *xgq, uint64_t flags, uint64_t io_hdl, u
 		cqprod = cq_produced;
 		// Write 1 to GCQ interrupt enable register to always enable interrupt
 		xgq_reg_write32(xgq->xq_io_hdl, sqprod + XGQ_INTR_ENABLE_OFFSET, 1);
-		xgq_reg_write32(xgq->xq_io_hdl, cqprod + XGQ_INTR_ENABLE_OFFSET, 1);
 	}
 	xgq_init_ring(xgq, &xgq->xq_sq, sqprod,
 		      ring_addr + offsetof(struct xgq_header, xh_sq_consumed),

--- a/src/runtime_src/core/include/xgq_impl.h
+++ b/src/runtime_src/core/include/xgq_impl.h
@@ -1,5 +1,6 @@
 /*
  *  Copyright (C) 2021, Xilinx Inc
+ *  Copyright (C) 2023, Advanced Micro Devices, Inc
  *
  *  This file is dual licensed.  It may be redistributed and/or modified
  *  under the terms of the Apache 2.0 License OR version 2 of the GNU
@@ -198,6 +199,7 @@ struct xgq {
 #define XGQ_NEED_DOUBLE_READ(xgq)	(((xgq)->xq_flags & XGQ_DOUBLE_READ) != 0)
 #define XGQ_IS_IN_MEM_PROD(xgq)		(((xgq)->xq_flags & XGQ_IN_MEM_PROD) != 0)
 
+#define XGQ_INTR_ENABLE_OFFSET 12
 
 /*
  * XGQ implementation details and helper routines.
@@ -379,6 +381,9 @@ xgq_init(struct xgq *xgq, uint64_t flags, uint64_t io_hdl, uint64_t ring_addr,
 	} else {
 		sqprod = sq_produced;
 		cqprod = cq_produced;
+		// Write 1 to GCQ interrupt enable register to always enable interrupt
+		xgq_reg_write32(xgq->xq_io_hdl, sqprod + XGQ_INTR_ENABLE_OFFSET, 1);
+		xgq_reg_write32(xgq->xq_io_hdl, cqprod + XGQ_INTR_ENABLE_OFFSET, 1);
 	}
 	xgq_init_ring(xgq, &xgq->xq_sq, sqprod,
 		      ring_addr + offsetof(struct xgq_header, xh_sq_consumed),
@@ -526,6 +531,9 @@ static inline int xgq_attach(struct xgq *xgq, uint64_t flags, uint64_t io_hdl, u
 	} else {
 		sqprod = sq_produced;
 		cqprod = cq_produced;
+		// Write 1 to GCQ interrupt enable register to always enable interrupt
+		xgq_reg_write32(xgq->xq_io_hdl, sqprod + XGQ_INTR_ENABLE_OFFSET, 1);
+		xgq_reg_write32(xgq->xq_io_hdl, cqprod + XGQ_INTR_ENABLE_OFFSET, 1);
 	}
 	xgq_init_ring(xgq, &xgq->xq_sq, sqprod,
 		      ring_addr + offsetof(struct xgq_header, xh_sq_consumed),


### PR DESCRIPTION
Updated xgq_impl.h to always write 1 to GCQ's interrupt enable bit to address CR-1161216.
This is due to default GCQ v2 interrupt enable is set to 0.

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
V70 base3 platform switches to GCQ v2 which has interrupt disabled by default.
Therefore we need to write 1 to enable GCQ interrupts for the default operation with interrupts enabled for GCQ v1 and v2.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Change in behavior from GCQ v1 to GCQ v2

#### How problem was solved, alternative solutions (if any) and why they were rejected
Always write 1 to enable interrupt for XRT operations

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
v70 base3 platform

#### Documentation impact (if any)
None