### PR TITLE
VITIS-8128 Update help Menu generator for SubCmds

### DIFF
--- a/src/runtime_src/core/tools/common/SubCmd.cpp
+++ b/src/runtime_src/core/tools/common/SubCmd.cpp
@@ -43,14 +43,16 @@ SubCmd::SubCmd(const std::string & _name,
   // Empty
 }
 
-void 
-SubCmd::printHelp(bool removeLongOptDashes, const std::string& customHelpSection) const
+void
+SubCmd::printHelp(bool removeLongOptDashes,
+                  const std::string& customHelpSection,
+                  const boost::program_options::options_description& common_options) const
 {
   XBUtilities::report_subcommand_help(m_executableName,
                                       m_subCmdName,
                                       m_longDescription,
                                       m_exampleSyntax,
-                                      m_commonOptions,
+                                      common_options,
                                       m_hiddenOptions,
                                       m_globalOptions,
                                       m_positionals,
@@ -60,31 +62,28 @@ SubCmd::printHelp(bool removeLongOptDashes, const std::string& customHelpSection
 }
 
 void 
+SubCmd::printHelp(bool removeLongOptDashes, const std::string& customHelpSection) const
+{
+  printHelp(removeLongOptDashes, customHelpSection, m_commonOptions);
+}
+
+void 
 SubCmd::printHelp(const std::string& device_name,
                   bool is_user_domain,
                   bool removeLongOptDashes,
                   const std::string& customHelpSection) const
 {
+  // If no device is specified revert to using the member variable common options
   if (device_name.empty()) {
     printHelp(removeLongOptDashes, customHelpSection);
     return;
   }
 
-  // Get the device type and validate which reports should be displayed
+  // If a device is specfied get the device type and validate which reports should be displayed
   //auto device = XBU::get_device(boost::algorithm::to_lower_copy(device_name), is_user_domain);
   //auto device_type = device.get_device_type?? This does not exist yet
   //auto options = m_deviceSpecificOptions.at(device_type);
-  XBUtilities::report_subcommand_help(m_executableName,
-                                    m_subCmdName,
-                                    m_longDescription,
-                                    m_exampleSyntax,
-                                    m_deviceSpecificOptions.at("all"),
-                                    m_hiddenOptions,
-                                    m_globalOptions,
-                                    m_positionals,
-                                    m_subOptionOptions,
-                                    removeLongOptDashes,
-                                    customHelpSection);
+  printHelp(removeLongOptDashes, customHelpSection, m_deviceSpecificOptions.at("all"));
 }
 
 std::vector<std::string> 

--- a/src/runtime_src/core/tools/common/SubCmd.cpp
+++ b/src/runtime_src/core/tools/common/SubCmd.cpp
@@ -70,9 +70,10 @@ SubCmd::printHelp(const std::string& device_name,
     return;
   }
 
-  // Get the device and validate which reports should be displayed
+  // Get the device type and validate which reports should be displayed
   //auto device = XBU::get_device(boost::algorithm::to_lower_copy(device_name), is_user_domain);
   //auto device_type = device.get_device_type?? This does not exist yet
+  //auto options = m_deviceSpecificOptions.at(device_type);
   XBUtilities::report_subcommand_help(m_executableName,
                                     m_subCmdName,
                                     m_longDescription,

--- a/src/runtime_src/core/tools/common/SubCmd.cpp
+++ b/src/runtime_src/core/tools/common/SubCmd.cpp
@@ -69,7 +69,7 @@ SubCmd::printHelp(bool removeLongOptDashes, const std::string& customHelpSection
 
 void 
 SubCmd::printHelp(const std::string& device_name,
-                  bool is_user_domain,
+                  bool /*is_user_domain*/,
                   bool removeLongOptDashes,
                   const std::string& customHelpSection) const
 {

--- a/src/runtime_src/core/tools/common/SubCmd.cpp
+++ b/src/runtime_src/core/tools/common/SubCmd.cpp
@@ -60,19 +60,30 @@ SubCmd::printHelp(bool removeLongOptDashes, const std::string& customHelpSection
 }
 
 void 
-SubCmd::printHelp(boost::program_options::options_description common_options) const
+SubCmd::printHelp(const std::string& device_name,
+                  bool is_user_domain,
+                  bool removeLongOptDashes,
+                  const std::string& customHelpSection) const
 {
+  if (device_name.empty()) {
+    printHelp(removeLongOptDashes, customHelpSection);
+    return;
+  }
+
+  // Get the device and validate which reports should be displayed
+  //auto device = XBU::get_device(boost::algorithm::to_lower_copy(device_name), is_user_domain);
+  //auto device_type = device.get_device_type?? This does not exist yet
   XBUtilities::report_subcommand_help(m_executableName,
-                                      m_subCmdName,
-                                      m_longDescription,
-                                      m_exampleSyntax,
-                                      common_options,
-                                      m_hiddenOptions,
-                                      m_globalOptions,
-                                      m_positionals,
-                                      m_subOptionOptions,
-                                      false,
-                                      "");
+                                    m_subCmdName,
+                                    m_longDescription,
+                                    m_exampleSyntax,
+                                    m_deviceSpecificOptions.at("all"),
+                                    m_hiddenOptions,
+                                    m_globalOptions,
+                                    m_positionals,
+                                    m_subOptionOptions,
+                                    removeLongOptDashes,
+                                    customHelpSection);
 }
 
 std::vector<std::string> 

--- a/src/runtime_src/core/tools/common/SubCmd.cpp
+++ b/src/runtime_src/core/tools/common/SubCmd.cpp
@@ -59,6 +59,22 @@ SubCmd::printHelp(bool removeLongOptDashes, const std::string& customHelpSection
                                       customHelpSection);
 }
 
+void 
+SubCmd::printHelp(boost::program_options::options_description common_options) const
+{
+  XBUtilities::report_subcommand_help(m_executableName,
+                                      m_subCmdName,
+                                      m_longDescription,
+                                      m_exampleSyntax,
+                                      common_options,
+                                      m_hiddenOptions,
+                                      m_globalOptions,
+                                      m_positionals,
+                                      m_subOptionOptions,
+                                      false,
+                                      "");
+}
+
 std::vector<std::string> 
 SubCmd::process_arguments( po::variables_map& vm,
                            const SubCmdOptions& _options,

--- a/src/runtime_src/core/tools/common/SubCmd.h
+++ b/src/runtime_src/core/tools/common/SubCmd.h
@@ -68,7 +68,7 @@ public:
   void setLongDescription(const std::string &_longDescription) {m_longDescription = _longDescription; };
   void setExampleSyntax(const std::string& _exampleSyntax) { m_exampleSyntax = _exampleSyntax; };
   void printHelp(bool removeLongOptDashes = false, const std::string& customHelpSection = "") const;
-  void printHelp(boost::program_options::options_description common_options) const;
+  void printHelp(const std::string& device_name, bool is_user_domain, bool removeLongOptDashes = false, const std::string& customHelpSection = "") const;
   std::vector<std::string> process_arguments( boost::program_options::variables_map& vm,
                            const SubCmdOptions& _options,
                            const boost::program_options::options_description& common_options,
@@ -89,6 +89,7 @@ public:
   boost::program_options::options_description m_commonOptions;
   boost::program_options::options_description m_hiddenOptions;
   boost::program_options::positional_options_description m_positionals;
+  std::map<std::string, boost::program_options::options_description> m_deviceSpecificOptions;
 
  private:
   SubCmd() = delete;

--- a/src/runtime_src/core/tools/common/SubCmd.h
+++ b/src/runtime_src/core/tools/common/SubCmd.h
@@ -92,6 +92,7 @@ public:
   std::map<std::string, boost::program_options::options_description> m_deviceSpecificOptions;
 
  private:
+  void printHelp(bool removeLongOptDashes, const std::string& customHelpSection, const boost::program_options::options_description& common_options) const;
   SubCmd() = delete;
 
  // Variables

--- a/src/runtime_src/core/tools/common/SubCmd.h
+++ b/src/runtime_src/core/tools/common/SubCmd.h
@@ -68,6 +68,7 @@ public:
   void setLongDescription(const std::string &_longDescription) {m_longDescription = _longDescription; };
   void setExampleSyntax(const std::string& _exampleSyntax) { m_exampleSyntax = _exampleSyntax; };
   void printHelp(bool removeLongOptDashes = false, const std::string& customHelpSection = "") const;
+  void printHelp(boost::program_options::options_description common_options) const;
   std::vector<std::string> process_arguments( boost::program_options::variables_map& vm,
                            const SubCmdOptions& _options,
                            const boost::program_options::options_description& common_options,

--- a/src/runtime_src/core/tools/common/SubCmdExamineInternal.cpp
+++ b/src/runtime_src/core/tools/common/SubCmdExamineInternal.cpp
@@ -68,6 +68,7 @@ SubCmdExamineInternal::SubCmdExamineInternal(bool _isHidden, bool _isDepricated,
   auto examineDeviceTrees = JSONConfigurable::parse_configuration_tree({getConfigName()}, configurations);
   reportMappings = JSONConfigurable::extractMatchingConfigurations<Report>(SubCmdExamineInternal::uniqueReportCollection, examineDeviceTrees);
 
+  // Create device specific help menu options
   for (const auto& report_pair : reportMappings) {
     // Generate a list of common and relevant mappings for help menu generation
     ReportCollection reportCollection = report_pair.second;
@@ -83,11 +84,13 @@ SubCmdExamineInternal::SubCmdExamineInternal(bool _isHidden, bool _isDepricated,
       fullReportCollection.push_back(report);
     }
   }
+
   // Emplace temporary all option until shim upgrade is complete
   boost::program_options::options_description options;
   create_common_options(options, XBU::create_suboption_list_string(fullReportCollection, true));
   m_deviceSpecificOptions.emplace("all", options);
 
+  // Generate the help menu option when a device is not specified
   static const std::string reportOptionValues = XBU::create_suboption_list_map(reportMappings);
   create_common_options(m_commonOptions, reportOptionValues);
   

--- a/src/runtime_src/core/tools/common/SubCmdExamineInternal.h
+++ b/src/runtime_src/core/tools/common/SubCmdExamineInternal.h
@@ -31,6 +31,9 @@ class SubCmdExamineInternal : public SubCmd {
   static ReportCollection uniqueReportCollection;
 
  private:
+  void create_common_options(boost::program_options::options_description& options, const std::string& report_string);
+  void print_help() const;
+
   std::string               m_device;
   std::vector<std::string>  m_reportNames;
   std::vector<std::string>  m_elementsFilter;

--- a/src/runtime_src/core/tools/common/SubCmdExamineInternal.h
+++ b/src/runtime_src/core/tools/common/SubCmdExamineInternal.h
@@ -32,7 +32,6 @@ class SubCmdExamineInternal : public SubCmd {
 
  private:
   void create_common_options(boost::program_options::options_description& options, const std::string& report_string);
-  void print_help() const;
 
   std::string               m_device;
   std::vector<std::string>  m_reportNames;

--- a/src/runtime_src/core/tools/common/XBHelpMenus.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenus.cpp
@@ -72,7 +72,7 @@ create_suboption_list_map_string(const std::map<std::string, VectorPairStrings>&
   // Print out all other device specific options
   for (const auto& map_pair : workingCollection) {
     std::string device_string = map_pair.first;
-    device_string[0] = std::toupper(device_string[0]);
+    device_string[0] = static_cast<char>(std::toupper(device_string[0]));
     if (!device_string.empty())
       supportedValues += device_string + ":\n";
     // Report names and description

--- a/src/runtime_src/core/tools/common/XBHelpMenus.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenus.cpp
@@ -31,8 +31,8 @@ static unsigned int m_maxColumnWidth = 100;
 static unsigned int m_shortDescriptionColumn = 24;
 
 // ------ F U N C T I O N S ---------------------------------------------------
-std::string 
-XBUtilities::create_suboption_list_string_map(const std::map<std::string, VectorPairStrings>& _collection)
+static std::string 
+create_suboption_list_map_string(const std::map<std::string, VectorPairStrings>& _collection)
 {
   // Working variables
   const unsigned int maxColumnWidth = m_maxColumnWidth - m_shortDescriptionColumn; 
@@ -125,43 +125,16 @@ XBUtilities::create_suboption_list_map(const std::map<std::string, std::vector<s
         { return (a.first.compare(b.first) < 0); });
   }
 
-  return create_suboption_list_string_map(reportDescriptionCollection);
+  return create_suboption_list_map_string(reportDescriptionCollection);
 }
 
 std::string 
 XBUtilities::create_suboption_list_string(const VectorPairStrings &_collection)
 {
-  // Working variables
-  const unsigned int maxColumnWidth = m_maxColumnWidth - m_shortDescriptionColumn; 
-  std::string supportedValues;        // Formatted string of supported values
-                                      
-  // Make a copy of the data (since it is going to be modified)
-  VectorPairStrings workingCollection = _collection;
-
-  // Determine the indention width
-  unsigned int maxStringLength = 0;
-  for (auto & pairs : workingCollection) {
-    // Determine if the keyName needs to have 'quotes', if so add them
-    if (pairs.first.find(' ') != std::string::npos ) {
-      pairs.first.insert(0, 1, '\'');  
-      pairs.first += "\'";     
-    }
-
-    maxStringLength = std::max<unsigned int>(maxStringLength, static_cast<unsigned int>(pairs.first.length()));
-  }
-
-  const unsigned int indention = maxStringLength + 5;  // New line indention after the '-' character (5 extra spaces)
-  boost::format reportFmt(std::string("  %-") + std::to_string(maxStringLength) + "s - %s");  
-  boost::format reportFmtQuotes(std::string(" %-") + std::to_string(maxStringLength + 1) + "s - %s");  
-
-  // Report names and description
-  for (const auto & pairs : workingCollection) {
-    boost::format &reportFormat = pairs.first[0] == '\'' ? reportFmtQuotes : reportFmt;
-    auto formattedString = XBU::wrap_paragraphs(boost::str(reportFormat % pairs.first % pairs.second), indention, maxColumnWidth, false /*indent first line*/);
-    supportedValues += formattedString + "\n";
-  }
-
-  return supportedValues;
+  std::map<std::string, VectorPairStrings> collection = {
+    {"common", _collection}
+  };
+  return create_suboption_list_map_string(collection);
 }
 
 std::string 

--- a/src/runtime_src/core/tools/common/XBHelpMenus.h
+++ b/src/runtime_src/core/tools/common/XBHelpMenus.h
@@ -19,9 +19,6 @@ namespace XBUtilities {
   using VectorPairStrings = std::vector< std::pair< std::string, std::string > >;
 
   std::string 
-    create_suboption_list_string_map(const std::map<std::string, VectorPairStrings>& _collection);
-  
-  std::string 
     create_suboption_list_map(const std::map<std::string, std::vector<std::shared_ptr<Report>>>& reportCollection);
 
   std::string 

--- a/src/runtime_src/core/tools/common/XBHelpMenus.h
+++ b/src/runtime_src/core/tools/common/XBHelpMenus.h
@@ -19,6 +19,12 @@ namespace XBUtilities {
   using VectorPairStrings = std::vector< std::pair< std::string, std::string > >;
 
   std::string 
+    create_suboption_list_string_map(const std::map<std::string, VectorPairStrings>& _collection);
+  
+  std::string 
+    create_suboption_list_map(const std::map<std::string, std::vector<std::shared_ptr<Report>>>& reportCollection);
+
+  std::string 
     create_suboption_list_string(const VectorPairStrings &_collection);
 
   std::string 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/VITIS-8128

The new configuration files are implemented the help menu will need to be formatted differently that reflect the device type being accessed by the user.

This PR focuses on updating SubCmdExamine

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
The current help menu displays all options under a single group. As an example the `examine` help menu shows reports:
```
-r, --report       - The type of report to be produced. Reports currently available are:
                         aie             - AIE metadata in xclbin
                         aiemem          - AIE memory tile information
                         aieshim         - AIE shim tile status
                         all             - All known reports are produced
                         debug-ip-status - Status of Debug IPs present in xclbin loaded on device
                         dynamic-regions - Information about the xclbin and the compute units
                         electrical      - Electrical and power sensors present on the device
                         error           - Asyncronus Error present on the device
                         firewall        - Firewall status
                         host            - Host information
                         mailbox         - Mailbox metrics of the device
                         mechanical      - Mechanical sensors on and surrounding the device
                         memory          - Memory information present on the device
                         pcie-info       - Pcie information of the device
                         platform        - Platforms flashed on the device
                         qspi-status     - QSPI write protection status
                         thermal         - Thermal sensors present on the device
```
However, certain reports are unique to Alveo and others to AIE devices. Displaying them at all times does not make sense and is confusing.
#### How problem was solved, alternative solutions (if any) and why they were rejected
This problem was solved by utilizing the new command configuration json that specifies which reports are associated with certain device types. Within the constructor of the chosen command we construct a help menu unique to that device type. Depending on which device the user specifies we change which help menu is displayed to one of the premade help menus.

In addition, if no device is specified ALL reports are displayed. However, the reports are broken into device specific categories.

At the moment, the device type is not available. We are waiting on the shim upgrade before activating that portion of the filter. The current device specific reports will continue to function as they have in the past.

#### Risks (if any) associated the changes in the commit
This is changing how the help menu appears so some users may be startled by the new menu. However, it is much clearer than the previous iteration and specifies which reports they can run at all.

#### What has been tested and how, request additional testing if necessary
Ubuntu 20.04 u55c
No device specified result
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ xbutil examine --help

COMMAND: examine

DESCRIPTION: This command will 'examine' the state of the system/device and will generate a report of interest
               in a text or JSON format.

USAGE: xbutil examine [--help] [-d arg] [-r arg] [-f arg] [-o arg]

OPTIONS:
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest
  -r, --report       - The type of report to be produced. Reports currently available are:
                         all             - All known reports are produced
                         dynamic-regions - Information about the xclbin and the compute units
                         electrical      - Electrical and power sensors present on the device
                         host            - Host information
                         mechanical      - Mechanical sensors on and surrounding the device
                         memory          - Memory information present on the device
                         pcie-info       - Pcie information of the device
                         platform        - Platforms flashed on the device
                         thermal         - Thermal sensors present on the device
                       AIE Specific:
                         aie             - AIE metadata in xclbin
                         aiemem          - AIE memory tile information
                         aieshim         - AIE shim tile status
                       Alveo Specific:
                         debug-ip-status - Status of Debug IPs present in xclbin loaded on device
                         error           - Asyncronus Error present on the device
                         firewall        - Firewall status
                         mailbox         - Mailbox metrics of the device
                         qspi-status     - QSPI write protection status
  -f, --format       - Report output format. Valid values are:
                         JSON        - Latest JSON schema
                         JSON-2020.2 - JSON 2020.2 schema
  -o, --output       - Direct the output to the given file
  --help             - Help to use this sub-command


GLOBAL OPTIONS:
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
```
device specified result
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ xbutil examine -d 04:00 --help
WARNING: Unexpected xocl version (2.14.0) was found. Expected 2.16.0, to match XRT tools.

COMMAND: examine

DESCRIPTION: This command will 'examine' the state of the system/device and will generate a report of interest
               in a text or JSON format.

USAGE: xbutil examine [--help] [-d arg] [-r arg] [-f arg] [-o arg]

OPTIONS:
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest
  -r, --report       - The type of report to be produced. Reports currently available are:
                         aie             - AIE metadata in xclbin
                         aiemem          - AIE memory tile information
                         aieshim         - AIE shim tile status
                         all             - All known reports are produced
                         debug-ip-status - Status of Debug IPs present in xclbin loaded on device
                         dynamic-regions - Information about the xclbin and the compute units
                         electrical      - Electrical and power sensors present on the device
                         error           - Asyncronus Error present on the device
                         firewall        - Firewall status
                         host            - Host information
                         mailbox         - Mailbox metrics of the device
                         mechanical      - Mechanical sensors on and surrounding the device
                         memory          - Memory information present on the device
                         pcie-info       - Pcie information of the device
                         platform        - Platforms flashed on the device
                         qspi-status     - QSPI write protection status
                         thermal         - Thermal sensors present on the device
  -f, --format       - Report output format. Valid values are:
                         JSON        - Latest JSON schema
                         JSON-2020.2 - JSON 2020.2 schema
  -o, --output       - Direct the output to the given file
  --help             - Help to use this sub-command


GLOBAL OPTIONS:
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
```

#### Documentation impact (if any)
None