### PR TITLE
CR-1164853_Linux_Coding_Style_Adjust

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
@@ -307,7 +307,7 @@ static bool xgq_submitted_cmd_check(struct xocl_xgq_vmr *xgq)
 		xgq_cmd = list_entry(pos, struct xocl_xgq_vmr_cmd, xgq_cmd_list);
 
 		/* Finding timed out cmds */
-		if (xgq_cmd->xgq_cmd_timeout_jiffies < jiffies) {
+		if (time_after(jiffies, xgq_cmd->xgq_cmd_timeout_jiffies)) {
 			XGQ_ERR(xgq, "cmd id: %d op: 0x%x timed out, hot reset is required!",
 				xgq_cmd->xgq_cmd_entry.hdr.cid,
 				xgq_cmd->xgq_cmd_entry.hdr.opcode);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
@@ -330,7 +330,7 @@ static void xgq_submitted_cmds_drain(struct xocl_xgq_vmr *xgq)
 		xgq_cmd = list_entry(pos, struct xocl_xgq_vmr_cmd, xgq_cmd_list);
 
 		/* Finding timed out cmds */
-		if (xgq_cmd->xgq_cmd_timeout_jiffies < jiffies) {
+		if (time_after(jiffies, xgq_cmd->xgq_cmd_timeout_jiffies)) {
 			list_del(pos);
 
 			xgq_cmd->xgq_cmd_rcode = -ETIME;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
There is a variable called 'jiffies' which records timer ticks to keep track of timeout used in xgq_vmr.c.
Changed the direct comparison of this by using time_after  the Linux latest coding standards.

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
This change is made in command queue interface; and tested Opcode base sysfs nodes on V70.

#### Documentation impact (if any)
