### PR TITLE
Change windows typedef of ssize_t to int64_t

### DIFF
--- a/src/runtime_src/core/include/windows/types.h
+++ b/src/runtime_src/core/include/windows/types.h
@@ -17,7 +17,9 @@
 #ifndef core_include_windows_types_h_
 #define core_include_windows_types_h_
 
-typedef size_t ssize_t;
+#include <stdint.h>
+
+typedef int64_t ssize_t;
 typedef int pid_t;
 
 #endif


### PR DESCRIPTION
#### Problem solved by the commit
Replace incorrect typedef of ssize_t with int64_t to avoid conflict with other libraries.
