### PR TITLE
[2023.1] CR-1161216 - Always enable GCQ's interrupt to allow compatibility bet…

### DIFF
--- a/src/runtime_src/core/include/xgq_impl.h
+++ b/src/runtime_src/core/include/xgq_impl.h
@@ -1,5 +1,6 @@
 /*
  *  Copyright (C) 2021, Xilinx Inc
+ *  Copyright (C) 2023, Advanced Micro Devices, Inc
  *
  *  This file is dual licensed.  It may be redistributed and/or modified
  *  under the terms of the Apache 2.0 License OR version 2 of the GNU
@@ -198,6 +199,7 @@ struct xgq {
 #define XGQ_NEED_DOUBLE_READ(xgq)	(((xgq)->xq_flags & XGQ_DOUBLE_READ) != 0)
 #define XGQ_IS_IN_MEM_PROD(xgq)		(((xgq)->xq_flags & XGQ_IN_MEM_PROD) != 0)
 
+#define XGQ_INTR_ENABLE_OFFSET 12
 
 /*
  * XGQ implementation details and helper routines.
@@ -379,6 +381,8 @@ xgq_init(struct xgq *xgq, uint64_t flags, uint64_t io_hdl, uint64_t ring_addr,
 	} else {
 		sqprod = sq_produced;
 		cqprod = cq_produced;
+		// Write 1 to GCQ interrupt enable register to always enable interrupt
+		xgq_reg_write32(xgq->xq_io_hdl, cqprod + XGQ_INTR_ENABLE_OFFSET, 1);
 	}
 	xgq_init_ring(xgq, &xgq->xq_sq, sqprod,
 		      ring_addr + offsetof(struct xgq_header, xh_sq_consumed),
@@ -526,6 +530,8 @@ static inline int xgq_attach(struct xgq *xgq, uint64_t flags, uint64_t io_hdl, u
 	} else {
 		sqprod = sq_produced;
 		cqprod = cq_produced;
+		// Write 1 to GCQ interrupt enable register to always enable interrupt
+		xgq_reg_write32(xgq->xq_io_hdl, sqprod + XGQ_INTR_ENABLE_OFFSET, 1);
 	}
 	xgq_init_ring(xgq, &xgq->xq_sq, sqprod,
 		      ring_addr + offsetof(struct xgq_header, xh_sq_consumed),


### PR DESCRIPTION
…ween GCQ v1 and v2 (#7566)

* Updated xgq_impl.h to always write 1 to GCQ's interrupt enable bit to address CR-1161216. This is due to default GCQ v2 interrupt enable is set to 0.

Signed-off-by: Jeff Lin <jeffylin@xilinx.com>

* Only write to interrupt enable bit of GCQ for the writable register.

Signed-off-by: Jeff Lin <jeffylin@xilinx.com>

---------

Signed-off-by: Jeff Lin <jeffylin@xilinx.com>
Co-authored-by: Jeff Lin <jeffylin@xilinx.com>
(cherry picked from commit aaf0c1d8073ae82fc8b853b4cadc60e5852756c2)

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
