### PR TITLE
Relax user ptr restriction on host only buffer

### DIFF
--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -1046,9 +1046,6 @@ alloc_ubuf(const device_type& device, void* userptr, size_t sz, xrtBufferFlags f
   if (is_nodma(device.get_core_device()))
     throw xrt_core::error(EINVAL, "userptr is not supported for NoDMA platforms");
 
-  if (flags & XRT_BO_FLAGS_HOST_ONLY)
-    throw xrt_core::error(EINVAL, "userptr is not supported for host only buffers");
-
   // error if userptr is not aligned properly
   if (!is_aligned_ptr(userptr))
     throw xrt_core::error(EINVAL, "userptr is not aligned");


### PR DESCRIPTION
#### Problem solved by the commit
Leave it to driver to return error if uptr is not supported.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
While Alveo does not support user ptr on host only buffers other platforms do.  This PR removes the user space check and exception that disallows uptr and hostonly buffer.
