### PR TITLE
Fix memory report crashing on device with no xclbin

### DIFF
--- a/src/runtime_src/core/common/info_memory.cpp
+++ b/src/runtime_src/core/common/info_memory.cpp
@@ -244,7 +244,10 @@ struct memory_info_collector
 
     for (const auto& topology : hw_context_memories) {
       const auto mem_topo = reinterpret_cast<const mem_topology*>(topology.topology.data());
-      
+
+      if (!mem_topo)
+        continue;
+
       for (int i = 0; i < mem_topo->m_count; ++i) {
         const auto& mem = mem_topo->m_mem_data[i];
         
@@ -275,7 +278,7 @@ struct memory_info_collector
       const auto mem_topo = reinterpret_cast<const mem_topology*>(topology.topology.data());
       const auto grp_topo = reinterpret_cast<const mem_topology*>(topology.grp_topology.data());
 
-      if (!grp_topo)
+      if (!mem_topo || !grp_topo)
         continue;
 
       // group_topology prepends all mem_topology entries so groups


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
When no xclbin is loaded on a device the memory report issues a segfault.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Introduced in https://github.com/Xilinx/XRT/pull/7499

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added null pointer checks

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Ubuntu 20.04 U55C
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ xbutil reset -d 04:00
Performing 'HOT Reset' on '0000:04:00.1'
Are you sure you wish to proceed? [Y/n]: Y
Successfully reset Device[0000:04:00.1]

dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ xbutil examine -d 04:00 -r memory

-------------------------------------------------
[0000:04:00.1] : xilinx_u55c_gen3x16_xdma_base_3
-------------------------------------------------

  DMA Transfer Metrics
    Chan[ 0].h2c:  0 Byte
    Chan[ 0].c2h:  0 Byte
    Chan[ 1].h2c:  0 Byte
    Chan[ 1].c2h:  0 Byte
```
#### Documentation impact (if any)
None