### PR TITLE
VITIS-8979 Improve display of dynamic region report

### DIFF
--- a/src/runtime_src/core/tools/common/ReportDynamicRegion.cpp
+++ b/src/runtime_src/core/tools/common/ReportDynamicRegion.cpp
@@ -47,11 +47,14 @@ ReportDynamicRegion::writeReport( const xrt_core::device* _pDevice,
 
   //check if a valid CU report is generated
   const boost::property_tree::ptree& pt_dfx = _pt.get_child("dynamic_regions", empty_ptree);
-  if(pt_dfx.empty())
-    return;
 
   const auto device_status = xrt_core::device_query_default<xrt_core::query::device_status>(_pDevice, 2);
   _output << boost::format("  Device Status: %s\n") % xrt_core::query::device_status::parse_status(device_status);
+  if(pt_dfx.empty()) {
+    _output << boost::format("  No hardware contexts running on device\n\n");
+    return;
+  }
+
 
   for(auto& k_dfx : pt_dfx) {
     const boost::property_tree::ptree& dfx = k_dfx.second;

--- a/src/runtime_src/core/tools/common/ReportDynamicRegion.cpp
+++ b/src/runtime_src/core/tools/common/ReportDynamicRegion.cpp
@@ -61,15 +61,21 @@ ReportDynamicRegion::writeReport( const xrt_core::device* _pDevice,
     _output << boost::format("  Hardware Context ID: %s\n") % dfx.get<std::string>("id", "N/A");
     
     _output << boost::format("    Xclbin UUID: %s\n") % dfx.get<std::string>("xclbin_uuid", "N/A");
-    const std::vector<Table2D::HeaderData> table_headers = {
+    const std::vector<Table2D::HeaderData> pl_table_headers = {
       {"Index", Table2D::Justification::left},
       {"Name", Table2D::Justification::left},
       {"Base Address", Table2D::Justification::left},
       {"Usage", Table2D::Justification::left},
       {"Status", Table2D::Justification::left}
     };
-    Table2D pl_table(table_headers);
-    Table2D ps_table(table_headers);
+    Table2D pl_table(pl_table_headers);
+    const std::vector<Table2D::HeaderData> ps_table_headers = {
+      {"Index", Table2D::Justification::left},
+      {"Name", Table2D::Justification::left},
+      {"Usage", Table2D::Justification::left},
+      {"Status", Table2D::Justification::left}
+    };
+    Table2D ps_table(ps_table_headers);
 
     const boost::property_tree::ptree& pt_cu = dfx.get_child("compute_units", empty_ptree);
     // Sort compute units into PL and PS groups
@@ -79,12 +85,15 @@ ReportDynamicRegion::writeReport( const xrt_core::device* _pDevice,
         const boost::property_tree::ptree& cu = kv.second;
         const std::string cu_status = cu.get_child("status").get<std::string>("bit_mask");
         const uint32_t status_val = std::stoul(cu_status, nullptr, 16);
-        const std::vector<std::string> entry_data = {std::to_string(index++), cu.get<std::string>("name"), cu.get<std::string>("base_address") , cu.get<std::string>("usage"), xrt_core::utils::parse_cu_status(status_val)};
-        
-        if(boost::iequals(cu.get<std::string>("type"), "PL"))
+
+        if(boost::iequals(cu.get<std::string>("type"), "PL")) {
+          const std::vector<std::string> entry_data = {std::to_string(index++), cu.get<std::string>("name"), cu.get<std::string>("base_address") , cu.get<std::string>("usage"), xrt_core::utils::parse_cu_status(status_val)};
           pl_table.addEntry(entry_data);
-        else if(boost::iequals(cu.get<std::string>("type"), "PS"))
+        }
+        else if(boost::iequals(cu.get<std::string>("type"), "PS")) {
+          const std::vector<std::string> entry_data = {std::to_string(index++), cu.get<std::string>("name"), cu.get<std::string>("usage"), xrt_core::utils::parse_cu_status(status_val)};
           ps_table.addEntry(entry_data);
+        }
       }
     }
     catch( std::exception const& e) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Fix display when xclbin is not loaded on legacy device. Legacy devices would show strange output in the console output.
Clean up populating hardware contexts. 
Improve report output. Add message stating no contexts are on the device. Remove base address column for PS kernels

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Legacy devices would show strange output in the console output.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Refactored how hardware contexts are populated.

#### Risks (if any) associated the changes in the commit
None. Behavior should be identical to before

#### What has been tested and how, request additional testing if necessary
Ubuntu 20.04 U55C
```
// On startup
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ xbutil examine -d 04:00 -r dynamic-regions
WARNING: Unexpected xocl version (2.14.0) was found. Expected 2.16.0, to match XRT tools.

-------------------------------------------------
[0000:04:00.1] : xilinx_u55c_gen3x16_xdma_base_3
-------------------------------------------------
  Device Status: HEALTHY
  No hardware contexts running on device

// Load xclbin
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ xbutil validate -d 04:00 -r verify
WARNING: Unexpected xocl version (2.14.0) was found. Expected 2.16.0, to match XRT tools.
Validate Device           : [0000:04:00.1]
    Platform              : xilinx_u55c_gen3x16_xdma_base_3
    SC Version            : 7.1.22
    Platform ID           : 97088961-FEAE-DA91-52A2-1D9DFD63CCEF
-------------------------------------------------------------------------------
Verbose: Enabling Verbosity
Test 1 [0000:04:00.1]     : verify
    Description           : Run 'Hello World' kernel test
    Xclbin                : /opt/xilinx/firmware/u55c/gen3x16-xdma/base/test
    Testcase              : /opt/xilinx/xrt/test/validate.exe
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Validation completed
// Examine loaded xclbin
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ xbutil examine -d 04:00 -r dynamic-regions
WARNING: Unexpected xocl version (2.14.0) was found. Expected 2.16.0, to match XRT tools.

-------------------------------------------------
[0000:04:00.1] : xilinx_u55c_gen3x16_xdma_base_3
-------------------------------------------------
  Device Status: HEALTHY
  Hardware Context ID: 0
    Xclbin UUID: E106E953-CF90-4024-E075-282D1A7D820B
    PL Compute Units
      Index  Name             Base Address  Usage  Status
      -----------------------------------------------------
      0      verify:verify_1  0x800000      1      (IDLE)


// Reset the device to remove the xclbin
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ xbutil reset -d 04:00
WARNING: Unexpected xocl version (2.14.0) was found. Expected 2.16.0, to match XRT tools.
Performing 'HOT Reset' on '0000:04:00.1'
Are you sure you wish to proceed? [Y/n]: Y
Successfully reset Device[0000:04:00.1]

// Examine the now empty device
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ xbutil examine -d 04:00 -r dynamic-regions
WARNING: Unexpected xocl version (2.14.0) was found. Expected 2.16.0, to match XRT tools.

-------------------------------------------------
[0000:04:00.1] : xilinx_u55c_gen3x16_xdma_base_3
-------------------------------------------------
  Device Status: HEALTHY
  No hardware contexts running on device
```

#### Documentation impact (if any)
None