### PR TITLE
Fixed a issue for AIE context for multiple thread

### DIFF
--- a/src/runtime_src/core/edge/user/aie/aie.h
+++ b/src/runtime_src/core/edge/user/aie/aie.h
@@ -95,8 +95,8 @@ public:
     void
     open_context(const xrt_core::device* device, xrt::aie::access_mode am);
 
-    bool
-    is_context_set();
+    xrt::aie::access_mode
+    get_access_mode();
 
     void
     sync_bo(xrt::bo& bo, const char *dmaID, enum xclBOSyncDirection dir, size_t size, size_t offset);

--- a/src/runtime_src/core/edge/user/aie/graph.cpp
+++ b/src/runtime_src/core/edge/user/aie/graph.cpp
@@ -526,9 +526,7 @@ xclSyncBOAIE(xclDeviceHandle handle, xrt::bo& bo, const char *gmioName, enum xcl
   auto aieArray = getAieArray();
 #endif
 
-  if (!aieArray->is_context_set()) {
-    aieArray->open_context(device.get(), xrt::aie::access_mode::primary);
-  }
+  aieArray->open_context(device.get(), xrt::aie::access_mode::primary);
 
   auto bosize = bo.size();
 
@@ -552,9 +550,7 @@ xclSyncBOAIENB(xclDeviceHandle handle, xrt::bo& bo, const char *gmioName, enum x
   auto aieArray = getAieArray();
 #endif
 
-  if (!aieArray->is_context_set()) {
-    aieArray->open_context(device.get(), xrt::aie::access_mode::primary);
-  }
+  aieArray->open_context(device.get(), xrt::aie::access_mode::primary);
 
   auto bosize = bo.size();
 
@@ -578,9 +574,7 @@ xclGMIOWait(xclDeviceHandle handle, const char *gmioName)
   auto aieArray = getAieArray();
 #endif
 
-  if (!aieArray->is_context_set()) {
-    aieArray->open_context(device.get(), xrt::aie::access_mode::primary);
-  }
+  aieArray->open_context(device.get(), xrt::aie::access_mode::primary);
 
   aieArray->wait_gmio(gmioName);
 }
@@ -596,9 +590,7 @@ xclResetAieArray(xclDeviceHandle handle)
     throw xrt_core::error(-EINVAL, "No AIE presented");
   auto aieArray = drv->getAieArray();
 
-  if (!aieArray->is_context_set()) {
-    aieArray->open_context(device.get(), xrt::aie::access_mode::primary);
-  }
+  aieArray->open_context(device.get(), xrt::aie::access_mode::primary);
 
   aieArray->reset(device.get());
 #else
@@ -621,9 +613,7 @@ xclStartProfiling(xclDeviceHandle handle, int option, const char* port1Name, con
   auto aieArray = getAieArray();
 #endif
 
-  if (!aieArray->is_context_set()) {
-    aieArray->open_context(device.get(), xrt::aie::access_mode::primary);
-  }
+  aieArray->open_context(device.get(), xrt::aie::access_mode::primary);
 
   return aieArray->start_profiling(option, value_or_empty(port1Name), value_or_empty(port2Name), value);
 }
@@ -643,9 +633,7 @@ xclReadProfiling(xclDeviceHandle handle, int phdl)
   auto aieArray = getAieArray();
 #endif
 
-  if (!aieArray->is_context_set()) {
-    aieArray->open_context(device.get(), xrt::aie::access_mode::primary);
-  }
+  aieArray->open_context(device.get(), xrt::aie::access_mode::primary);
 
   return aieArray->read_profiling(phdl);
 }
@@ -665,9 +653,7 @@ xclStopProfiling(xclDeviceHandle handle, int phdl)
   auto aieArray = getAieArray();
 #endif
 
-  if (!aieArray->is_context_set()) {
-    aieArray->open_context(device.get(), xrt::aie::access_mode::primary);
-  }
+  aieArray->open_context(device.get(), xrt::aie::access_mode::primary);
 
   return aieArray->stop_profiling(phdl);
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
-- There is a issue when from multiple thread is opening a AIE context. 
-- AIE context can be open by once, but because of multiple thread it's failing as the current code is not thread safe. 
-- Added a lock guard to make it thread safe. 

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
