### PR TITLE
Support Linux kernel 6.3+

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-bifurcation-reset.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-bifurcation-reset.c
@@ -84,7 +84,8 @@ static void xclmgmt_reset_pci_post(struct xclmgmt_dev *lro)
 	pcie_capability_write_word(bus->self, PCI_EXP_DEVCTL,
 					   (lro->devctl | PCI_EXP_DEVCTL_FERE));
 
-	pci_enable_device(pdev);
+	if (pci_enable_device(pdev))
+		mgmt_err(lro, "failed to enable pci device");
 
 	xocl_wait_pci_status(pdev, 0, 0, 0);
 
@@ -229,7 +230,7 @@ static long xclmgmt_hot_reset_post(struct xclmgmt_dev *lro, bool force)
  * 3. restore both after SBR
  *
  * Also, during reset, the pcie linkdown will last, in worst case, 3-5s
- * for the u30 card with PS/PL   
+ * for the u30 card with PS/PL
  */
 long xclmgmt_hot_reset_bifurcation(struct xclmgmt_dev *lro,
 	struct xclmgmt_dev *buddy_lro, bool force)

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-utils.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-utils.c
@@ -238,12 +238,12 @@ static int xclmgmt_get_buddy_cb(struct device *dev, void *data)
 	 * 1.non xilinx device
 	 * 2.itself
 	 * 3.other devcies not being droven by same driver. using func id
-	 * may not handle u25 where there is another device on same card 
+	 * may not handle u25 where there is another device on same card
 	 */
 	if (!src_xdev || !dev || to_pci_dev(dev)->vendor != 0x10ee ||
 	   	XOCL_DEV_ID(to_pci_dev(dev)) ==
 		XOCL_DEV_ID(src_xdev->core.pdev) || !dev->driver ||
-		strcmp(dev->driver->name, "xclmgmt")) 
+		strcmp(dev->driver->name, "xclmgmt"))
 		return 0;
 
 	tgt_xdev = dev_get_drvdata(dev);
@@ -611,7 +611,8 @@ static void xclmgmt_reset_pci(struct xclmgmt_dev *lro)
 	pcie_capability_write_word(bus->self, PCI_EXP_DEVCTL, devctl);
 	pci_write_config_word(bus->self, PCI_COMMAND, pci_cmd);
 
-	pci_enable_device(pdev);
+	if (pci_enable_device(pdev))
+		mgmt_err(lro, "failed to enable pci device");
 
 	xocl_wait_pci_status(pdev, 0, 0, 0);
 
@@ -1007,7 +1008,7 @@ static const void* xclmgmt_get_interface_uuid(struct xclmgmt_dev *lro) {
 
 	/*
 	 * don't need blp uuid. do we have multiple interface uuid?
-	 */ 
+	 */
 	node = xocl_fdt_get_next_prop_by_name(lro, lro->core.fdt_blob,
 		-1, PROP_INTERFACE_UUID, &uuid, NULL);
 	if (!uuid || node < 0)

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/accel_deadlock_detector.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/accel_deadlock_detector.c
@@ -226,9 +226,17 @@ static int accel_deadlock_detector_mmap(struct file *filp, struct vm_area_struct
 
     // prevent touching the pages (byte access) for swap-in, and prevent the pages from being swapped out
 #ifndef VM_RESERVED
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
     vma->vm_flags |= VM_IO | VM_DONTEXPAND | VM_DONTDUMP;
 #else
+    vm_flags_set(vma, VM_IO | VM_DONTEXPAND | VM_DONTDUMP);
+#endif
+#else
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
     vma->vm_flags |= VM_IO | VM_RESERVED;
+#else
+    vm_flags_set(vma, VM_IO | VM_RESERVED);
+#endif
 #endif
 
     // make MMIO accessible to user space

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/aim.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/aim.c
@@ -413,9 +413,17 @@ static int aim_mmap(struct file *filp, struct vm_area_struct *vma)
 	 * and prevent the pages from being swapped out
 	 */
 #ifndef VM_RESERVED
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
 	vma->vm_flags |= VM_IO | VM_DONTEXPAND | VM_DONTDUMP;
 #else
+	vm_flags_set(vma, VM_IO | VM_DONTEXPAND | VM_DONTDUMP);
+#endif
+#else
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
 	vma->vm_flags |= VM_IO | VM_RESERVED;
+#else
+	vm_flags_set(vma, VM_IO | VM_RESERVED);
+#endif
 #endif
 
 	/* make MMIO accessible to user space */

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/am.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/am.c
@@ -405,9 +405,17 @@ static int am_mmap(struct file *filp, struct vm_area_struct *vma)
 	 * and prevent the pages from being swapped out
 	 */
 #ifndef VM_RESERVED
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
 	vma->vm_flags |= VM_IO | VM_DONTEXPAND | VM_DONTDUMP;
 #else
+	vm_flags_set(vma, VM_IO | VM_DONTEXPAND | VM_DONTDUMP);
+#endif
+#else
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
 	vma->vm_flags |= VM_IO | VM_RESERVED;
+#else
+	vm_flags_set(vma, VM_IO | VM_RESERVED);
+#endif
 #endif
 
 	/* make MMIO accessible to user space */

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/asm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/asm.c
@@ -339,9 +339,17 @@ static int asm_mmap(struct file *filp, struct vm_area_struct *vma)
 	 * and prevent the pages from being swapped out
 	 */
 #ifndef VM_RESERVED
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
 	vma->vm_flags |= VM_IO | VM_DONTEXPAND | VM_DONTDUMP;
 #else
+	vm_flags_set(vma, VM_IO | VM_DONTEXPAND | VM_DONTDUMP);
+#endif
+#else
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
 	vma->vm_flags |= VM_IO | VM_RESERVED;
+#else
+	vm_flags_set(vma, VM_IO | VM_RESERVED);
+#endif
 #endif
 
 	/* make MMIO accessible to user space */

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/lapc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/lapc.c
@@ -143,7 +143,7 @@ static int lapc_probe(struct platform_device *pdev)
 		err = -ENOMEM;
 		goto done;
 	}
-		
+
 
 	xocl_info(&pdev->dev, "IO start: 0x%llx, end: 0x%llx",
 		res->start, res->end);
@@ -244,9 +244,17 @@ static int lapc_mmap(struct file *filp, struct vm_area_struct *vma)
 	 * and prevent the pages from being swapped out
 	 */
 #ifndef VM_RESERVED
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
 	vma->vm_flags |= VM_IO | VM_DONTEXPAND | VM_DONTDUMP;
 #else
+	vm_flags_set(vma, VM_IO | VM_DONTEXPAND | VM_DONTDUMP);
+#endif
+#else
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
 	vma->vm_flags |= VM_IO | VM_RESERVED;
+#else
+	vm_flags_set(vma, VM_IO | VM_RESERVED);
+#endif
 #endif
 
 	/* make MMIO accessible to user space */

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/spc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/spc.c
@@ -124,7 +124,7 @@ static int spc_probe(struct platform_device *pdev)
 		err = -ENOMEM;
 		goto done;
 	}
-		
+
 
 	xocl_info(&pdev->dev, "IO start: 0x%llx, end: 0x%llx",
 		res->start, res->end);
@@ -225,9 +225,17 @@ static int spc_mmap(struct file *filp, struct vm_area_struct *vma)
 	 * and prevent the pages from being swapped out
 	 */
 #ifndef VM_RESERVED
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
 	vma->vm_flags |= VM_IO | VM_DONTEXPAND | VM_DONTDUMP;
 #else
+	vm_flags_set(vma, VM_IO | VM_DONTEXPAND | VM_DONTDUMP);
+#endif
+#else
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
 	vma->vm_flags |= VM_IO | VM_RESERVED;
+#else
+	vm_flags_set(vma, VM_IO | VM_RESERVED);
+#endif
 #endif
 
 	/* make MMIO accessible to user space */

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/trace_fifo_lite.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/trace_fifo_lite.c
@@ -209,9 +209,17 @@ static int trace_fifo_lite_mmap(struct file *filp, struct vm_area_struct *vma)
 	 * and prevent the pages from being swapped out
 	 */
 #ifndef VM_RESERVED
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
 	vma->vm_flags |= VM_IO | VM_DONTEXPAND | VM_DONTDUMP;
 #else
+	vm_flags_set(vma, VM_IO | VM_DONTEXPAND | VM_DONTDUMP);
+#endif
+#else
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
 	vma->vm_flags |= VM_IO | VM_RESERVED;
+#else
+	vm_flags_set(vma, VM_IO | VM_RESERVED);
+#endif
 #endif
 
 	/* make MMIO accessible to user space */

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/trace_funnel.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/trace_funnel.c
@@ -212,9 +212,17 @@ static int trace_funnel_mmap(struct file *filp, struct vm_area_struct *vma)
 	 * and prevent the pages from being swapped out
 	 */
 #ifndef VM_RESERVED
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
 	vma->vm_flags |= VM_IO | VM_DONTEXPAND | VM_DONTDUMP;
 #else
+	vm_flags_set(vma, VM_IO | VM_DONTEXPAND | VM_DONTDUMP);
+#endif
+#else
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
 	vma->vm_flags |= VM_IO | VM_RESERVED;
+#else
+	vm_flags_set(vma, VM_IO | VM_RESERVED);
+#endif
 #endif
 
 	/* make MMIO accessible to user space */

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/trace_s2mm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/trace_s2mm.c
@@ -274,9 +274,17 @@ static int trace_s2mm_mmap(struct file *filp, struct vm_area_struct *vma)
 	 * and prevent the pages from being swapped out
 	 */
 #ifndef VM_RESERVED
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
 	vma->vm_flags |= VM_IO | VM_DONTEXPAND | VM_DONTDUMP;
 #else
+	vm_flags_set(vma, VM_IO | VM_DONTEXPAND | VM_DONTDUMP);
+#endif
+#else
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
 	vma->vm_flags |= VM_IO | VM_RESERVED;
+#else
+	vm_flags_set(vma, VM_IO | VM_RESERVED);
+#endif
 #endif
 
 	/* make MMIO accessible to user space */

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
@@ -1387,7 +1387,12 @@ int xocl_gem_prime_mmap(struct drm_gem_object *obj, struct vm_area_struct *vma)
 	}
 
 	vma->vm_private_data = obj;
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
 	vma->vm_flags |= VM_MIXEDMAP;
+#else
+	vm_flags_set(vma, VM_MIXEDMAP);
+#endif
 
 	return 0;
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
@@ -744,11 +744,10 @@ int xocl_userptr_bo_ioctl(
 		goto out1;
 	}
 
-	ret = XOCL_ACCESS_OK(VERIFY_WRITE, args->addr, args->size);
-
-
+	ret = XOCL_ACCESS_OK(VERIFY_WRITE, (uint64_t *)args->addr, args->size);
 	if (!ret) {
-		ret = XOCL_ACCESS_OK(VERIFY_READ, args->addr, args->size);
+		ret = XOCL_ACCESS_OK(VERIFY_READ, (uint64_t *)args->addr,
+				     args->size);
 		if (!ret)
 			goto out0;
 		else

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
@@ -1324,7 +1324,7 @@ static int xocl_cma_mem_alloc_huge_page_by_idx(struct xocl_dev *xdev, uint32_t i
 	struct xocl_cma_memory *cma_mem = &xdev->cma_bank->cma_mem[idx];
 	struct sg_table *sgt = NULL;
 
-	if (!(XOCL_ACCESS_OK(VERIFY_WRITE, user_addr, page_sz))) {
+	if (!(XOCL_ACCESS_OK(VERIFY_WRITE, (uint64_t *)user_addr, page_sz))) {
 		xocl_err(dev, "Invalid huge page user pointer\n");
 		ret = -ENOMEM;
 		goto done;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
@@ -500,12 +500,12 @@ static int xocl_get_buddy_cb(struct device *dev, void *data)
 	 * 1.non xilinx device
 	 * 2.itself
 	 * 3.other devcies not being droven by same driver. using func id
-	 * may not handle u25 where there is another device on same card 
+	 * may not handle u25 where there is another device on same card
 	 */
 	if (!src_xdev || !dev || to_pci_dev(dev)->vendor != 0x10ee ||
 	   	XOCL_DEV_ID(to_pci_dev(dev)) ==
 		XOCL_DEV_ID(src_xdev->core.pdev) || !dev->driver ||
-		strcmp(dev->driver->name, "xocl")) 
+		strcmp(dev->driver->name, "xocl"))
 		return 0;
 
 	tgt_xdev = dev_get_drvdata(dev);
@@ -526,7 +526,7 @@ static int xocl_get_buddy_cb(struct device *dev, void *data)
  * mutex lock to prevent multile reset from happening simutaniously
  * this is necessary for case where there are multiple FPGAs on same
  * card, and reset one also triggers reset on others.
- * to simplify, just don't allow reset to any multiple FPGAs happen 
+ * to simplify, just don't allow reset to any multiple FPGAs happen
  */
 static DEFINE_MUTEX(xocl_reset_mutex);
 
@@ -721,14 +721,14 @@ static void xocl_mailbox_srv(void *arg, void *data, size_t len,
 		xocl_af_check(xdev, NULL);
 		/* Get the updated xocl firewall status */
 		xocl_af_get_data(xdev, &fw_status);
-		userpf_info(xdev, 
+		userpf_info(xdev,
 			"AXI Firewall %llu tripped", fw_status.err_detected_level);
 		userpf_info(xdev,
 			"Card is in a BAD state, please issue xbutil reset");
 		err_last.pid = 0;
 		err_last.ts = fw_status.err_detected_time;
-		err_last.err_code = XRT_ERROR_CODE_BUILD(XRT_ERROR_NUM_FIRWWALL_TRIP, 
-			XRT_ERROR_DRIVER_XOCL, XRT_ERROR_SEVERITY_CRITICAL, 
+		err_last.err_code = XRT_ERROR_CODE_BUILD(XRT_ERROR_NUM_FIRWWALL_TRIP,
+			XRT_ERROR_DRIVER_XOCL, XRT_ERROR_SEVERITY_CRITICAL,
 			XRT_ERROR_MODULE_FIREWALL, XRT_ERROR_CLASS_HARDWARE);
 		xocl_insert_error_record(&xdev->core, &err_last);
 		xocl_drvinst_set_offline(xdev->core.drm, true);
@@ -1214,7 +1214,7 @@ void xocl_userpf_remove(struct pci_dev *pdev)
 	xocl_drvinst_release(xdev, &hdl);
 
 	xocl_queue_destroy(xdev);
-	
+
 	/* Free pinned pages before call xocl_drm_fini */
 	xocl_cma_bank_free(xdev);
 
@@ -1369,7 +1369,7 @@ static int xocl_cma_mem_alloc_huge_page_by_idx(struct xocl_dev *xdev, uint32_t i
 
 	if (sgt->orig_nents != sgt->nents) {
 		ret =-ENOMEM;
-		goto done;		
+		goto done;
 	}
 
 	cma_mem->size = page_sz;
@@ -1404,7 +1404,7 @@ static int xocl_cma_mem_alloc_huge_page(struct xocl_dev *xdev, struct drm_xocl_a
 	 * rounddown_pow_of_two 255=>>128 63=>>32
 	 */
 	if (rounddown_num != cma_info->entry_num) {
-		DRM_ERROR("Request %lld, round down to power of 2 %lld\n", 
+		DRM_ERROR("Request %lld, round down to power of 2 %lld\n",
 				cma_info->entry_num, rounddown_num);
 		return -EINVAL;
 	}
@@ -1992,7 +1992,12 @@ static int __init xocl_init(void)
 {
 	int		ret, i = 0;
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0)
 	xrt_class = class_create(THIS_MODULE, "xrt_user");
+#else
+	xrt_class = class_create("xrt_user");
+#endif
+
 	if (IS_ERR(xrt_class)) {
 		ret = PTR_ERR(xrt_class);
 		goto err_class_create;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_subdev.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_subdev.c
@@ -54,7 +54,7 @@ void xocl_subdev_fini(xdev_handle_t xdev_hdl)
 			kfree(core->subdevs[i]);
 			core->subdevs[i] = NULL;
 		}
-		
+
 	}
 
 	if (core->dyn_subdev_store) {
@@ -196,7 +196,7 @@ int xocl_subdev_reserve(xdev_handle_t xdev_hdl,
 	}
 
 	xocl_unlock_xdev(xdev_hdl);
-	
+
 	return subdev->info.dev_idx;
 }
 
@@ -413,7 +413,11 @@ static void __xocl_subdev_destroy(xdev_handle_t xdev_hdl,
 		case XOCL_SUBDEV_STATE_ACTIVE:
 		case XOCL_SUBDEV_STATE_OFFLINE:
 			device_release_driver(&pldev->dev);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 4, 0)
+			fallthrough;
+#else
 			/* fall through */
+#endif
 		case XOCL_SUBDEV_STATE_ADDED:
 		default:
 			__xocl_platform_device_unreg(xdev_hdl, pldev, state);
@@ -505,7 +509,7 @@ static int __xocl_subdev_construct(xdev_handle_t xdev_hdl,
 				res[i].end += iostart;
 			/*
 			 * Make sure the resource of subdevice is a
-			 * child of the pci bar resource in the 
+			 * child of the pci bar resource in the
 			 * resource tree.
 			 */
 			res[i].parent = &(core->pdev->resource[bar_idx]);
@@ -614,7 +618,7 @@ static int __xocl_subdev_create(xdev_handle_t xdev_hdl,
 		memcpy(res, sdev_info->res, sizeof(*res) * sdev_info->num_res);
 		for (i = 0; i < sdev_info->num_res; i++) {
 			if (sdev_info->res[i].name) {
-				res[i].name = subdev->res_name + 
+				res[i].name = subdev->res_name +
 					i * XOCL_SUBDEV_RES_NAME_LEN;
 				strncpy(subdev->res_name +
 					i * XOCL_SUBDEV_RES_NAME_LEN,
@@ -1484,7 +1488,7 @@ xocl_subdev_vsec_read32(xdev_handle_t xdev, int bar, u64 offset)
  * |----------------------+-----|
  * | rsvd                       |
  * |----------------------------|
- *   ... start 1st entry ...          
+ *   ... start 1st entry ...
  * +--------------+---+---+-----|
  * |uuid(15:0)    |bar|rev| type|
  * |--------------+---+---+-----|
@@ -1685,7 +1689,11 @@ int xocl_subdev_create_vsec_devs(xdev_handle_t xdev)
 			    (subdev_info.priv_data))->flash_type,
 			    FLASH_TYPE_QSPIPS, strlen(FLASH_TYPE_QSPIPS));
 			/* default is FLASH_TYPE_SPI, thus pass through. */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 4, 0)
+			fallthrough;
+#else
 			/* fall through */
+#endif
 		case XOCL_VSEC_FLASH_TYPE_SPI_IP:
 		case XOCL_VSEC_FLASH_TYPE_SPI_REG:
 			xocl_xdev_dbg(xdev,
@@ -1725,7 +1733,7 @@ int xocl_subdev_create_vsec_devs(xdev_handle_t xdev)
 
 	ret = xocl_subdev_vsec(xdev, XOCL_VSEC_XGQ, &bar, &offset, NULL);
 	if (!ret) {
-		int bar_payload = 0; 
+		int bar_payload = 0;
 		u64 offset_payload = 0;
 		struct xocl_subdev_info subdev_info = XOCL_DEVINFO_XGQ_VMR_VSEC;
 
@@ -1839,7 +1847,7 @@ void xocl_fill_dsa_priv(xdev_handle_t xdev_hdl, struct xocl_board_private *in)
 		xocl_fetch_dynamic_platform(core, &in, -1);
 		vsec = true;
 	}
-		
+
 	/* workaround firewall completer abort issue */
 	cap = pci_find_ext_capability(pdev, PCI_EXT_CAP_ID_ERR);
 	if (cap) {
@@ -1960,10 +1968,10 @@ int xocl_enable_vmr_boot(xdev_handle_t xdev)
 	err = xocl_vmr_enable_multiboot(xdev);
 	if (err && err != -ENODEV) {
 		xocl_xdev_info(xdev, "config vmr multi-boot failed. err: %d. continue to reset.", err);
-	} 
+	}
 
 	/*
-	 * set reset signal 
+	 * set reset signal
 	 */
 	err = xocl_pmc_enable_reset(xdev);
 	if (err && err != -ENODEV) {
@@ -2173,7 +2181,7 @@ int xocl_wait_pci_status(struct pci_dev *pdev, u16 mask, u16 val, int timeout)
 	}
 
 	xocl_dbg(&pdev->dev, "waiting for %d ms", i);
-	if (i == timeout) 
+	if (i == timeout)
 		return -ETIME;
 
 	return 0;


### PR DESCRIPTION
### Problem Addressed by the Commit

This commit includes support for Linux 6.3+ kernels and resolves issues related to compiler warnings.

### Bug/Issue Resolution

No bug or issue was discovered that required fixing. 

### Solution Implemented and Rejected Alternatives

To address the problem, I used conditional preprocessor macros to replace deprecated kernel APIs for the latest kernels.

### Associated Risks

No risks are associated with the changes made in this commit.

### Testing Conducted and Additional Testing Requested

I have tested this pull request using Linux kernel versions 5.15 and 6.4-rc2, and confirmed that the xbutil validate tests pass.

### Documentation Impact

No impact on documentation.