### PR TITLE
time_after needs unsigned long instead of u64

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
@@ -131,7 +131,7 @@ struct xocl_xgq_vmr_cmd {
 	void			*xgq_cmd_arg;
 	struct timer_list	xgq_cmd_timer;
 	struct xocl_xgq_vmr	*xgq_vmr;
-	u64			xgq_cmd_timeout_jiffies; /* timout till */
+	unsigned long		xgq_cmd_timeout_jiffies; /* for time_after */
 	int			xgq_cmd_rcode;
 	/* xgq complete command can return in-line data via payload */
 	struct xgq_cmd_cq_default_payload	xgq_cmd_cq_payload;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

Resolve make lint warnings and potential non-atomic operation with u64. 

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
