### PR TITLE
Modified the profiling plugin to build correctly on certain emulation flows

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_profile/CMakeLists.txt
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/CMakeLists.txt
@@ -28,6 +28,7 @@ if (XDP_MINIMAL_BUILD STREQUAL "yes")
   add_library(xdp_aie_profile_plugin MODULE ${AIE_PROFILE_PLUGIN_FILES})
   add_dependencies(xdp_aie_profile_plugin xdp_core xrt_coreutil)
   target_link_libraries(xdp_aie_profile_plugin PRIVATE xdp_core xrt_coreutil)
+  target_compile_definitions(xdp_aie_profile_plugin PRIVATE XDP_MINIMAL_BUILD=1)
 
   set_target_properties(xdp_aie_profile_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
 

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_plugin.cpp
@@ -36,7 +36,7 @@
 #include "xdp/profile/plugin/vp_base/info.h"
 #include "xdp/profile/writer/aie_profile/aie_writer.h"
 
-#ifdef _WIN32
+#ifdef XDP_MINIMAL_BUILD
 #include "win/aie_profile.h"
 // #include "shim.h"
 #elif defined(XRT_X86_BUILD)
@@ -82,15 +82,15 @@ namespace xdp {
 
   uint64_t AieProfilePlugin::getDeviceIDFromHandle(void* handle)
   {
-    constexpr uint32_t PATH_LENGTH = 512;
-
     auto itr = handleToAIEData.find(handle);
     if (itr != handleToAIEData.end())
       return itr->second.deviceID;
 
-#ifdef _WIN32
+#ifdef XDP_MINIMAL_BUILD
     return 0;
 #else
+    constexpr uint32_t PATH_LENGTH = 512;
+    
     char pathBuf[PATH_LENGTH];
     memset(pathBuf, 0, PATH_LENGTH);
 
@@ -115,7 +115,7 @@ namespace xdp {
     // Update the static database with information from xclbin
     (db->getStaticInfo()).updateDevice(deviceID, handle);
     {
-#ifdef _WIN32
+#ifdef XDP_MINIMAL_BUILD
       (db->getStaticInfo()).setDeviceName(deviceID, "win_device");
 #else
       struct xclDeviceInfo2 info;
@@ -133,7 +133,7 @@ namespace xdp {
     AIEData.deviceID = deviceID;
     AIEData.metadata = std::make_shared<AieProfileMetadata>(deviceID, handle);
 
-#ifdef _WIN32
+#ifdef XDP_MINIMAL_BUILD
     AIEData.implementation = std::make_unique<AieProfile_WinImpl>(db, AIEData.metadata);
 #elif defined(XRT_X86_BUILD)
     AIEData.implementation = std::make_unique<AieProfile_x86Impl>(db, AIEData.metadata);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
The profiling plugin was not building correctly on certain emulation flows

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
The profiling plugin now uses the XDP_MINIMAL BUILD to build correctly.

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Built on Windows and Ubuntu 

#### Documentation impact (if any)
