### PR TITLE
Add xrt::ext::bo support for specifying read/write direction

### DIFF
--- a/src/runtime_src/core/include/experimental/xrt_ext.h
+++ b/src/runtime_src/core/include/experimental/xrt_ext.h
@@ -7,6 +7,7 @@
 // These extensions are experimental
 
 #include "xrt/detail/config.h"
+#include "xrt/detail/bitmask.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_hw_context.h"
 #include "xrt/xrt_kernel.h"
@@ -19,7 +20,24 @@
 #ifdef __cplusplus
 namespace xrt::ext {
 
-///
+/*!
+ * @class bo
+ *
+ * @brief Buffer object extension
+ * xrt::ext::bo is an extension of xrt::bo with additional functionality
+ *
+ * @details
+ * An extension buffer amends the contruction of an xrt::bo with
+ * additional simplified constructors for specifying access mode of
+ * host only buffers.
+ *
+ * Once constructed, the object must be assigned to an xrt::bo object
+ * before use.  This is becayse XRT relies on templated kernel
+ * argument assignment and the templated assignment operator is not
+ * specialized for xrt::ext::bo.
+ *
+ * Ultimately the extension will be merged into class xrt::bo.
+ */
 class bo : public xrt::bo
 {
 public:
@@ -27,14 +45,64 @@ public:
   /**
    * @enum access_mode - buffer object accessibility
    *
+   * @var none
+   *   No access is specified, same as read|write|local
+   * @var read
+   *   The buffer is read by device, the cpu writes to the buffer
+   * @var write
+   *   The buffer is written by device, the host reads from the buffer
    * @var local
    *   Access is local to process and device on which it is allocated
    * @var shared
    *   Access is shared between devices within process
    * @var process
    *   Access is shared between processes and devices
+   *
+   * The access mode is used to specify how the buffer is used by
+   * device and process.
+   *
+   * A buffer can be specified as local, meaning it is only used by
+   * the process and device on which it is allocated.  A buffer can
+   * also be specified as shared, meaning it is shared between devices
+   * within the process.  Finally a buffer can be specified as
+   * process, meaning it is shared between processes and devices. If
+   * neither local, shared, or process is specified, the default is
+   * local.  Only one of local, shared, or process can be specified.
+   *
+   * A buffer can be opened for read, meaning the device will read the
+   * content written by host, or it can be opened for write, meaning
+   * the device will write to the buffer and the host will read. To
+   * specify that a buffer is used for both read and write, the access
+   * flags can be ORed.  If neither read or write is specified, the
+   * default is read|write.
+   *
+   * The default access mode is read|write|local when no access mode
+   * is specified.
+   *
+   * Friend operators are provided for bitwise operations on access
+   * mode.
    */
-  enum class access_mode : uint8_t { local, shared, process };
+  enum class access_mode : uint64_t
+  {
+    none    = 0,
+
+    read  = 1 << 0, 
+    write = 1 << 1,
+
+    local   = 0,
+    shared  = 1 << 2,
+    process = 1 << 3,
+  };
+
+  friend constexpr access_mode operator&(access_mode lhs, access_mode rhs)
+  {
+    return xrt::detail::operator&(lhs, rhs);
+  }
+
+  friend constexpr access_mode operator|(access_mode lhs, access_mode rhs)
+  {
+    return xrt::detail::operator|(lhs, rhs);
+  }
 
   /**
    * bo() - Constructor for buffer object with specific access
@@ -61,7 +129,7 @@ public:
    *  Size of buffer
 
    * This constructor creates a host_only buffer object with local
-   * access.
+   * access and in|out direction.
    */
   XRT_API_EXPORT
   bo(const xrt::device& device, size_t sz);
@@ -95,7 +163,7 @@ public:
    *  Size of buffer
    *
    * This constructor creates a host_only buffer object with local
-   * access.
+   * access and in|out direction.
    */
   XRT_API_EXPORT
   bo(const xrt::hw_context& hwctx, size_t sz);

--- a/src/runtime_src/core/include/xrt/CMakeLists.txt
+++ b/src/runtime_src/core/include/xrt/CMakeLists.txt
@@ -16,6 +16,7 @@ install (FILES ${XRT_XRT_HEADER_SRC} DESTINATION ${XRT_INSTALL_INCLUDE_DIR}/xrt 
 set(XRT_XRT_DETAIL_HEADER_SRC
   detail/abi.h
   detail/any.h
+  detail/bitmask.h
   detail/config.h
   detail/param_traits.h
   detail/pimpl.h)

--- a/src/runtime_src/core/include/xrt/detail/bitmask.h
+++ b/src/runtime_src/core/include/xrt/detail/bitmask.h
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+#ifndef XRT_DETAIL_BITMASK_H
+#define XRT_DETAIL_BITMASK_H
+
+#ifdef __cplusplus
+# include <type_traits>
+#endif
+
+#ifdef __cplusplus
+// Allow enum classes to be used at bitmasks
+namespace xrt::detail {
+
+template <typename T>
+constexpr std::enable_if_t<std::is_enum_v<T>, T>
+operator|(T lhs, T rhs)
+{
+  using U = std::underlying_type_t<T>;
+  return static_cast<T>(static_cast<U>(lhs) | static_cast<U>(rhs));
+}
+
+template <typename T>
+constexpr std::enable_if_t<std::is_enum_v<T>, T>
+operator&(T lhs, T rhs)
+{
+  using U = std::underlying_type_t<T>;
+  return static_cast<T>(static_cast<U>(lhs) & static_cast<U>(rhs));
+}
+
+template <typename T>
+constexpr std::enable_if_t<std::is_enum_v<T>, T>
+operator^(T lhs, T rhs)
+{
+  using U = std::underlying_type_t<T>;
+  return static_cast<T>(static_cast<U>(lhs) ^ static_cast<U>(rhs));
+}
+
+template <typename T>
+constexpr std::enable_if_t<std::is_enum_v<T>, T>
+operator~(T rhs)
+{
+  using U = std::underlying_type_t<T>;
+  return static_cast<T>(~static_cast<U>(rhs));
+}
+
+template <typename T>
+constexpr std::enable_if_t<std::is_enum_v<T>, T&>
+operator|=(T& lhs, T rhs)
+{
+  using U = std::underlying_type_t<T>;
+  lhs = static_cast<T>(static_cast<U>(lhs) | static_cast<U>(rhs));
+  return lhs;
+}
+
+template <typename T>
+constexpr std::enable_if_t<std::is_enum_v<T>, T&>
+operator&=(T& lhs, T rhs)
+{
+  using U = std::underlying_type_t<T>;
+  lhs = static_cast<T>(static_cast<U>(lhs) & static_cast<U>(rhs));
+  return lhs;
+}
+
+template <typename T>
+constexpr std::enable_if_t<std::is_enum_v<T>, T&>
+operator^=(T& lhs, T rhs)
+{
+  using U = std::underlying_type_t<T>;
+  lhs = static_cast<T>(static_cast<U>(lhs) ^ static_cast<U>(rhs));
+  return lhs;
+}
+
+template <typename T>
+constexpr std::enable_if_t<std::is_enum_v<T>, bool> operator!(T rhs)
+{
+  return !static_cast<bool>(static_cast<std::underlying_type_t<T>>(rhs));
+}
+ 
+} // xrt::detail
+
+#endif
+
+#endif

--- a/src/runtime_src/core/include/xrt_mem.h
+++ b/src/runtime_src/core/include/xrt_mem.h
@@ -74,7 +74,8 @@ struct xcl_bo_flags
 
       // extension
       uint32_t access : 2;  // [33-32]
-      uint32_t unused : 30; // [63-34]
+      uint32_t dir    : 2;  // [35-34]
+      uint32_t unused : 28; // [63-36]
     };
   };
 };
@@ -101,6 +102,14 @@ struct xcl_bo_flags
  */
 #define XRT_BO_ACCESS_SHARED 1
 #define XRT_BO_ACCESS_EXPORTED 2
+
+/**
+ * Shim level BO Flags for direction of data transfer
+ * as seen from device.
+ */
+#define XRT_BO_ACCESS_READ    (1U << 0)
+#define XRT_BO_ACCESS_WRITE   (1U << 1)
+#define XRT_BO_ACCESS_READ_WRITE (XRT_BO_ACCESS_READ | XRT_BO_ACCESS_WRITE)
 
 /**
  * XRT Native BO flags


### PR DESCRIPTION
#### Problem solved by the commit
Amend xrt::ext::bo::access_mode with `read` and `write` enumerators. Treat mode as bitflags.

#### How problem was solved, alternative solutions (if any) and why they were rejected
A buffer can be opened for read, meaning the device will read the content written by host, or it can be opened for write, meaning the device will write the content that will be read by host. To specify that a buffer is used for both read and write, the access flags can be ORed.  If neither read or write is specified, the default is read|write.

#### What has been tested and how, request additional testing if necessary
The xrt::ext::bo API is currently used by a different project where the changes have been tested.

