### PR TITLE
CR-1167063 Fix hwqueue_handle::wait_command() API comment

### DIFF
--- a/src/runtime_src/core/common/api/hw_queue.cpp
+++ b/src/runtime_src/core/common/api/hw_queue.cpp
@@ -399,7 +399,7 @@ public:
   {}
 
   std::cv_status
-  wait(size_t timeout_ms) override
+  wait(size_t /*timeout_ms*/) override
   {
     // OpenCL uses this function, but it is not implemented for
     // platforms that implement hwqueue_handle.  Rework this if OpenCL

--- a/src/runtime_src/core/common/api/hw_queue.cpp
+++ b/src/runtime_src/core/common/api/hw_queue.cpp
@@ -401,9 +401,12 @@ public:
   std::cv_status
   wait(size_t timeout_ms) override
   {
-    return m_qhdl->wait_command(nullptr, static_cast<int>(timeout_ms))
-      ? std::cv_status::no_timeout
-      : std::cv_status::timeout;
+    // OpenCL uses this function, but it is not implemented for
+    // platforms that implement hwqueue_handle.  Rework this if OpenCL
+    // needs to support shim hw queues.  Probably use a combination of
+    // counters or cached commands, or change command monitor to track
+    // order of submitted commands.
+    throw std::runtime_error("qds_device::wait() not implemented");
   }
 
   std::cv_status

--- a/src/runtime_src/core/common/shim/hwqueue_handle.h
+++ b/src/runtime_src/core/common/shim/hwqueue_handle.h
@@ -33,9 +33,6 @@ public:
   // @cmd        Handle to command to wait for
   // @timeout_ms Timout in ms, 0 implies infinite wait.
   // @return     0 indicates timeout, anything else indicates completion
-  //
-  // If cmd buffer handle is nullptr, then this function is supposed to wait
-  // until any command completes execution.
   virtual int
   wait_command(buffer_handle* cmd, uint32_t timeout_ms) const = 0;
 


### PR DESCRIPTION
#### Problem solved by the commit
Remove comment about cmd nullptr waiting for any command to complete.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Throw if nullptr is passed.  This means that OpenCL is not supported with platforms that implement hwqueue. If OpenCL support is needed, the command monitor needs to track order of submitted commands and wait on first submitted command before checking status of all running commands.
