### PR TITLE
VITIS-8985 Refactor hw context metadata field in query requests

### DIFF
--- a/src/runtime_src/core/common/info_memory.cpp
+++ b/src/runtime_src/core/common/info_memory.cpp
@@ -198,8 +198,8 @@ struct memory_info_collector
     const mem_data* mem,
     ptree_type& pt_mem)
   {
-    pt_mem.put("xclbin_uuid", topology.xclbin_uuid);
-    pt_mem.put("hw_context_slot", boost::format("%u") % topology.id);
+    pt_mem.put("xclbin_uuid", topology.metadata.xclbin_uuid);
+    pt_mem.put("hw_context_slot", boost::format("%u") % topology.metadata.id);
     pt_mem.put("type", memtype2str(mem->m_type));
     pt_mem.put("tag", mem->m_tag);
     pt_mem.put("enabled", mem->m_used ? true : false);
@@ -304,32 +304,15 @@ public:
       hw_context_memories = xrt_core::device_query<xq::hw_context_memory_info>(device);
     }
     catch (const xq::exception&) {
-      //ignore if not defined. Try legacy method
-    }
-
-    // If the mem_topo is empty attempt the legacy method
-    if (hw_context_memories.empty()) {
-      xq::hw_context_memory_info::data_type memory_topology;
-      memory_topology.id = "0";
-      memory_topology.topology = xrt_core::device_query<xq::mem_topology_raw>(device);
-      memory_topology.grp_topology = xrt_core::device_query<xq::group_topology>(device);
-      memory_topology.statistics = xrt_core::device_query<xq::memstat_raw>(device);
-
-      try {
-        memory_topology.temperature = xrt_core::device_query<xq::temp_by_mem_topology>(dev);
-      }
-      catch (const xq::exception&) {
-        //ignore if not defined. Try legacy method
-      }
-
-      try {
-        memory_topology.xclbin_uuid = xrt_core::device_query<xq::xclbin_uuid>(device);
-      }
-      catch (const xq::exception&) {
-        // Support noop devices
-      }
-
-      hw_context_memories.push_back(memory_topology);
+      // Try legacy method
+      xq::hw_context_memory_info::data_type hw_context_mem;
+      hw_context_mem.metadata.id = "0";
+      hw_context_mem.metadata.xclbin_uuid = xrt_core::device_query_default<xq::xclbin_uuid>(device, "");
+      hw_context_mem.topology = xrt_core::device_query<xq::mem_topology_raw>(device);
+      hw_context_mem.grp_topology = xrt_core::device_query<xq::group_topology>(device);
+      hw_context_mem.statistics = xrt_core::device_query<xq::memstat_raw>(device);
+      hw_context_mem.temperature = xrt_core::device_query_default<xq::temp_by_mem_topology>(dev, {});
+      hw_context_memories.push_back(hw_context_mem);
     }
 
     // validate the memory topologies for each hardware context
@@ -576,13 +559,13 @@ populate_hardware_context(const xrt_core::device* device)
     // Legacy Case
     xq::hw_context_info::data_type hw_context;
 
-    hw_context.id = "0";
-    hw_context.xclbin_uuid = xrt_core::device_query_default<xq::xclbin_uuid>(device, "");
+    hw_context.metadata.id = "0";
+    hw_context.metadata.xclbin_uuid = xrt_core::device_query_default<xq::xclbin_uuid>(device, "");
     hw_context.pl_compute_units = xrt_core::device_query_default<xq::kds_cu_info>(device, {});
     hw_context.ps_compute_units = xrt_core::device_query_default<xq::kds_scu_info>(device, {});
 
     // Account for devices that do not have an xclbin uuid but have compute units
-    if (!hw_context.xclbin_uuid.empty() || !hw_context.pl_compute_units.empty() || !hw_context.ps_compute_units.empty())
+    if (!hw_context.metadata.xclbin_uuid.empty() || !hw_context.pl_compute_units.empty() || !hw_context.ps_compute_units.empty())
       hw_context_stats.push_back(hw_context);
   }
   catch (const std::exception& ex) {
@@ -592,8 +575,8 @@ populate_hardware_context(const xrt_core::device* device)
 
   for (const auto& hw : hw_context_stats) {
     ptree_type pt_hw;
-    pt_hw.put("id", boost::algorithm::to_upper_copy(hw.id));
-    pt_hw.put("xclbin_uuid", boost::algorithm::to_upper_copy(hw.xclbin_uuid));
+    pt_hw.put("id", boost::algorithm::to_upper_copy(hw.metadata.id));
+    pt_hw.put("xclbin_uuid", boost::algorithm::to_upper_copy(hw.metadata.xclbin_uuid));
     pt_hw.add_child("compute_units", populate_cus(device, hw.pl_compute_units, hw.ps_compute_units));
     pt.push_back(std::make_pair("", pt_hw));
   }

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -1489,8 +1489,7 @@ struct aie_partition_info : request
 {
   struct data
   {
-    std::string xclbin_uuid;
-    uint64_t    slot_id;
+    hw_context_info::metadata metadata;
     uint64_t    start_col;
     uint64_t    num_cols;
     uint64_t    usage_count;

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -956,6 +956,11 @@ struct kds_scu_info : request
  */
 struct hw_context_info : request
 {
+  struct metadata {
+    std::string id;
+    std::string xclbin_uuid;
+  };
+
   /**
    * A structure to represent a single hardware context on any device type. This
    * structure must contain all data that makes up a hardware context across
@@ -970,8 +975,7 @@ struct hw_context_info : request
    *  Versal -> populate PL and PS compute units
    */
   struct data {
-    std::string id;
-    std::string xclbin_uuid;
+    struct metadata metadata;
     kds_cu_info::result_type pl_compute_units;
     kds_scu_info::result_type ps_compute_units;
   };
@@ -995,8 +999,7 @@ struct hw_context_memory_info : request
    * hardware context memory structure across all device types.
    */
   struct data {
-    std::string id;
-    std::string xclbin_uuid;
+    hw_context_info::metadata metadata;
     mem_topology_raw::result_type topology;
     group_topology::result_type grp_topology;
     memstat_raw::result_type statistics;

--- a/src/runtime_src/core/tools/common/ReportAiePartitions.cpp
+++ b/src/runtime_src/core/tools/common/ReportAiePartitions.cpp
@@ -24,8 +24,8 @@ populate_aie_partition(const xrt_core::device* device)
     auto partition = pt_map.emplace(std::make_tuple(entry.start_col, entry.num_cols), boost::property_tree::ptree());
 
     boost::property_tree::ptree pt_entry;
-    pt_entry.put("xclbin_uuid", entry.xclbin_uuid);
-    pt_entry.put("slot_id", entry.slot_id);
+    pt_entry.put("xclbin_uuid", entry.metadata.xclbin_uuid);
+    pt_entry.put("slot_id", entry.metadata.id);
     pt_entry.put("usage_count", entry.usage_count);
     pt_entry.put("migration_count", entry.migration_count);
     pt_entry.put("device_bo_sync_count", entry.bo_sync_count);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/VITIS-8985

Clean up try/catch for memory report ptree creation.

Each hardware context report used different fields when accessing context metadata. It should use a single structure that is common to prevent confusion and allow passing of parameters.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
All hardware context reports must use the same data structure when referring to their ID and xclbin UUIDs.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Made a common structure. Update the data parsing to use the new structures.

#### Risks (if any) associated the changes in the commit
Need to update MCDM to match the changes.

#### What has been tested and how, request additional testing if necessary
Ubuntu 20.04 VCK5000
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ xbutil reset -d 17:00
WARNING: Unexpected xocl version (2.14.0) was found. Expected 2.16.0, to match XRT tools.
***********************************************************
*        WARNING          WARNING          WARNING        *
*       SC version data missing. Upgrade your shell       *
***********************************************************
Performing 'HOT Reset' on '0000:17:00.1'
Are you sure you wish to proceed? [Y/n]: Y
Successfully reset Device[0000:17:00.1]
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ xbutil examine -d 17:00 -r memory
WARNING: Unexpected xocl version (2.14.0) was found. Expected 2.16.0, to match XRT tools.
***********************************************************
*        WARNING          WARNING          WARNING        *
*       SC version data missing. Upgrade your shell       *
***********************************************************

---------------------------------------------------
[0000:17:00.1] : xilinx_vck5000_gen4x8_qdma_base_2
---------------------------------------------------

  DMA Transfer Metrics
    Chan[ 0].h2c:  0 Byte
    Chan[ 0].c2h:  0 Byte
    Chan[ 1].h2c:  0 Byte
    Chan[ 1].c2h:  0 Byte
    Chan[ 2].h2c:  0 Byte
    Chan[ 2].c2h:  0 Byte
    Chan[ 3].h2c:  0 Byte
    Chan[ 3].c2h:  0 Byte
    Chan[ 4].h2c:  0 Byte
    Chan[ 4].c2h:  0 Byte
    Chan[ 5].h2c:  0 Byte
    Chan[ 5].c2h:  0 Byte
    Chan[ 6].h2c:  0 Byte
    Chan[ 6].c2h:  0 Byte
    Chan[ 7].h2c:  0 Byte
    Chan[ 7].c2h:  0 Byte

dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ xbutil validate -d 17:00 -r verify
WARNING: Unexpected xocl version (2.14.0) was found. Expected 2.16.0, to match XRT tools.
***********************************************************
*        WARNING          WARNING          WARNING        *
*       SC version data missing. Upgrade your shell       *
***********************************************************
Validate Device           : [0000:17:00.1]
    Platform              : xilinx_vck5000_gen4x8_qdma_base_2
    SC Version            : 4.4.35
    Platform ID           : 05DCA096-76CB-730B-8D19-EC1192FBAE3F
-------------------------------------------------------------------------------
Verbose: Enabling Verbosity
Test 1 [0000:17:00.1]     : verify
    Description           : Run 'Hello World' kernel test
    Xclbin                : /opt/xilinx/firmware/vck5000/gen4x8-qdma/base/test
    Testcase              : /opt/xilinx/xrt/test/validate.exe
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Validation completed
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ xbutil examine -d 17:00 -r memory
WARNING: Unexpected xocl version (2.14.0) was found. Expected 2.16.0, to match XRT tools.
***********************************************************
*        WARNING          WARNING          WARNING        *
*       SC version data missing. Upgrade your shell       *
***********************************************************

---------------------------------------------------
[0000:17:00.1] : xilinx_vck5000_gen4x8_qdma_base_2
---------------------------------------------------

  Memory Topology
    HW Context Slot: 0
      Xclbin UUID: dbce0895-5e2b-70bb-4ff7-9f03227d71df
      Index  Tag      Type      Temp(C)  Size      Base Address
      ------------------------------------------------------------
      0      MC_NOC0  MEM_DDR4  N/A      12288 MB  0xc100000000
      1      BRAM     MEM_DRAM  N/A      128 KB    0x20204000000

  DMA Transfer Metrics
    Chan[ 0].h2c:  0 Byte
    Chan[ 0].c2h:  64 Byte
    Chan[ 1].h2c:  0 Byte
    Chan[ 1].c2h:  0 Byte
    Chan[ 2].h2c:  0 Byte
    Chan[ 2].c2h:  0 Byte
    Chan[ 3].h2c:  0 Byte
    Chan[ 3].c2h:  0 Byte
    Chan[ 4].h2c:  0 Byte
    Chan[ 4].c2h:  0 Byte
    Chan[ 5].h2c:  0 Byte
    Chan[ 5].c2h:  0 Byte
    Chan[ 6].h2c:  0 Byte
    Chan[ 6].c2h:  0 Byte
    Chan[ 7].h2c:  0 Byte
    Chan[ 7].c2h:  0 Byte
```

#### Documentation impact (if any)
None. JSON output is the same.