### PR TITLE
fixing aarch64 compilation issue

### DIFF
--- a/src/runtime_src/core/edge/CMakeLists.txt
+++ b/src/runtime_src/core/edge/CMakeLists.txt
@@ -6,6 +6,10 @@ add_subdirectory(common)
 add_subdirectory(user)
 add_subdirectory(common_em)
 add_subdirectory(hw_emu)
-add_subdirectory(ps_kernels)
+# We dont need PS Kernel compilation in non-versal devices.
+# Using XRT_AIE_BUILD flag as it is enabled for all the versal devices.
+if (DEFINED XRT_AIE_BUILD)
+        add_subdirectory(ps_kernels)
+endif()
 add_subdirectory(sw_emu)
 add_subdirectory(skd)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Fixing aarch64 compilation issue

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://github.com/Xilinx/XRT/pull/7594

#### How problem was solved, alternative solutions (if any) and why they were rejected
Adding ps kernel libraries only for Versal devices

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Verified aarch64 build

#### Documentation impact (if any)
None