### PR TITLE
VITIS-8730: documentation of read, write device memory directly

### DIFF
--- a/src/runtime_src/doc/toc/xrt_native_apis.rst
+++ b/src/runtime_src/doc/toc/xrt_native_apis.rst
@@ -223,7 +223,7 @@ Note the C++ ``xrt::bo::sync``, ``xrt::bo::write``, ``xrt::bo::read`` etc has ov
 
 Also note that if the buffer is created through the user-pointer, the ``xrt::bo::write`` or ``xrt::bo::read`` is not required before or after the ``xrt::bo::sync`` call. 
 
-For Device only buffers, to avoid host memcpy with the usage of ``xrt::bo::sync()``, ``xrt::bo::read()`` and ``xrt::bo::write()`` API's  perform PCIe DMA data transfer between host and device to achieve better performance.
+For the device only buffers (created with ``xrt::bo::flags::device_only`` flag) the ``xrt::bo::sync()`` operation is not required, only ``xrt::bo::write()`` (or ``xrt::bo::read()``) is sufficient for DMA operation. As for the device only buffer there is no host backing storage, the ``xrt::bo::write()`` (or ``xrt::bo::read()``) directly performs DMA operation to (or from) the device memory.
 
 Below is the example for creation of device only buffers.
 
@@ -233,7 +233,7 @@ Below is the example for creation of device only buffers.
            xrt::bo::flags device_flags = xrt::bo::flags::device_only;
            auto device_only_buffer = xrt::bo(device, size_in_bytes, device_flags, bank_grp_arg0);
 
-Here is how xrt::bo::read and xrt::bo::write API's to read/write directly from/to device buffer if buffer object has not host backing storage.
+Here is how ``xrt::bo::read()`` and ``xrt::bo::write()`` API's to read/write directly from/to device only buffer there is no host backing storage.
 
 - ``xrt::bo::write(const void* src, size_t size, size_t seek)``: Copies data from src to device buffer directly.
 - ``xrt::bo::read(void* dst, size_t size, size_t skip)``: Copies data from device buffer to dst.

--- a/src/runtime_src/doc/toc/xrt_native_apis.rst
+++ b/src/runtime_src/doc/toc/xrt_native_apis.rst
@@ -223,6 +223,21 @@ Note the C++ ``xrt::bo::sync``, ``xrt::bo::write``, ``xrt::bo::read`` etc has ov
 
 Also note that if the buffer is created through the user-pointer, the ``xrt::bo::write`` or ``xrt::bo::read`` is not required before or after the ``xrt::bo::sync`` call. 
 
+For Device only buffers, to avoid host memcpy with the usage of ``xrt::bo::sync()``, ``xrt::bo::read()`` and ``xrt::bo::write()`` API's  perform PCIe DMA data transfer between host and device to achieve better performance.
+
+Below is the example for creation of device only buffers.
+
+.. code:: c++
+      :number-lines: 18
+
+           xrt::bo::flags device_flags = xrt::bo::flags::device_only;
+           auto device_only_buffer = xrt::bo(device, size_in_bytes, device_flags, bank_grp_arg0);
+
+Here is how xrt::bo::read and xrt::bo::write API's to read/write directly from/to device buffer if buffer object has not host backing storage.
+
+- ``xrt::bo::write(const void* src, size_t size, size_t seek)``: Copies data from src to device buffer directly.
+- ``xrt::bo::read(void* dst, size_t size, size_t skip)``: Copies data from device buffer to dst.
+
 II. Data transfer between host and device by Buffer map API
 ***********************************************************
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Added documentation of read/write device memory directly
https://github.com/Xilinx/XRT/pull/7615 - Closed
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://jira.xilinx.com/browse/VITIS-8730
#### How problem was solved, alternative solutions (if any) and why they were rejected
For the device only buffers (created with ``xrt::bo::flags::device_only`` flag) the ``xrt::bo::sync()`` operation is not required, only ``xrt::bo::write()`` (or ``xrt::bo::read()``) is sufficient for DMA operation. As for the device only buffer there is no host backing storage, the ``xrt::bo::write()`` (or ``xrt::bo::read()``) directly performs DMA operation to (or from) the device memory.

Below is the example for creation of device only buffers.

           xrt::bo::flags device_flags = xrt::bo::flags::device_only;
           auto device_only_buffer = xrt::bo(device, size_in_bytes, device_flags, bank_grp_arg0);

Here is how ``xrt::bo::read()`` and ``xrt::bo::write()`` API's to read/write directly from/to device only buffer there is no host backing storage.

- ``xrt::bo::write(const void* src, size_t size, size_t seek)``: Copies data from src to device buffer directly.
- ``xrt::bo::read(void* dst, size_t size, size_t skip)``: Copies data from device buffer to dst.

#### Risks (if any) associated the changes in the commit
Low
#### What has been tested and how, request additional testing if necessary
n/a
#### Documentation impact (if any)
Yes