### PR TITLE
VITIS-8980 Improve output of electrical and thermal reports

### DIFF
--- a/src/runtime_src/core/tools/common/ReportElectrical.cpp
+++ b/src/runtime_src/core/tools/common/ReportElectrical.cpp
@@ -1,25 +1,10 @@
-/**
- * Copyright (C) 2020-2022 Xilinx, Inc
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2020-2022 Xilinx, Inc
+// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
 
-// ------ I N C L U D E   F I L E S -------------------------------------------
-// Local - Include Files
 #include "ReportElectrical.h"
 #include "Table2D.h"
 
-// 3rd Party Library - Include Files
 #include <boost/property_tree/json_parser.hpp>
 
 void

--- a/src/runtime_src/core/tools/common/ReportElectrical.cpp
+++ b/src/runtime_src/core/tools/common/ReportElectrical.cpp
@@ -17,6 +17,7 @@
 // ------ I N C L U D E   F I L E S -------------------------------------------
 // Local - Include Files
 #include "ReportElectrical.h"
+#include "Table2D.h"
 
 // 3rd Party Library - Include Files
 #include <boost/property_tree/json_parser.hpp>
@@ -57,20 +58,34 @@ ReportElectrical::writeReport( const xrt_core::device* /*_pDevice*/,
   _output << boost::format("  %-23s: %s Watts\n") % "Max Power" % _pt.get<std::string>("electrical.power_consumption_max_watts", "N/A");
   _output << boost::format("  %-23s: %s Watts\n") % "Power" % _pt.get<std::string>("electrical.power_consumption_watts", "N/A");
   _output << boost::format("  %-23s: %s\n\n") % "Power Warning" % _pt.get<std::string>("electrical.power_consumption_warning", "N/A");
-  _output << boost::format("  %-23s: %6s   %6s\n") % "Power Rails" % "Voltage" % "Current";
+  
+  const std::vector<Table2D::HeaderData> table_headers = {
+    {"Power Rails", Table2D::Justification::left},
+    {":", Table2D::Justification::left},
+    {"Voltage", Table2D::Justification::right},
+    {"Current", Table2D::Justification::right}
+  };
+  Table2D elec_table(table_headers);
+
   for(auto& kv : electricals) {
     const boost::property_tree::ptree& pt_sensor = kv.second;
-    std::string name = pt_sensor.get<std::string>("description");
-    auto volts_is_present = pt_sensor.get<bool>("voltage.is_present");
-    auto amps_is_present = pt_sensor.get<bool>("current.is_present");
+    const auto voltage = pt_sensor.get<std::string>("voltage.volts", "N/A");
+    const auto amps = pt_sensor.get<std::string>("current.amps", "N/A");
 
-    if(volts_is_present && amps_is_present)
-      _output << boost::format("  %-23s: %6s V, %6s A\n") % name % pt_sensor.get<std::string>("voltage.volts") % pt_sensor.get<std::string>("current.amps");
-    else if(volts_is_present)
-      _output << boost::format("  %-23s: %6s V\n") % name % pt_sensor.get<std::string>("voltage.volts");
-    else if(amps_is_present)
-      _output << boost::format("  %-23s: %16s A\n") % name % pt_sensor.get<std::string>("current.amps");
+    const std::vector<std::string> entry_data = {
+      pt_sensor.get<std::string>("description"),
+      ":",
+      (voltage == "N/A") ? voltage : voltage + " V",
+      (amps == "N/A") ? amps : amps + " A",
+    };
+    elec_table.addEntry(entry_data);
   }
+
+  if (elec_table.empty())
+    _output << "  No electrical sensors found\n";
+  else
+    _output << elec_table.toString("  ");
+
   _output << std::endl;
 
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/VITIS-8980

The electrical and thermal reports do not properly support non sensors on the device.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Output looks bad if there are no sensors.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Converted the reports to use Table2D to improve the output

#### Risks (if any) associated the changes in the commit
None. Looks almost exactly the same as before

#### What has been tested and how, request additional testing if necessary
Ubuntu 20.04 VCK5000
Electrical
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ xbutil examine -d 17:00 -r electrical

---------------------------------------------------
[0000:17:00.1] : xilinx_vck5000_gen4x8_qdma_base_2
---------------------------------------------------
Electrical
  Max Power              : NA Watts
  Power                  : 34 Watts
  Power Warning          : NA

  Power Rails  :   Voltage   Current
  ------------------------------------
  12v_pex      :  12.234 V   0.972 A
  3v3_pex      :   3.291 V       N/A
  3v3_aux      :   3.312 V       N/A
  12v_aux_0    :  12.253 V   1.100 A
  12v_aux_1    :  12.294 V   0.667 A
  vccint       :   0.799 V  25.200 A
```
Thermal
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ xbutil examine -d 17:00 -r thermal

---------------------------------------------------
[0000:17:00.1] : xilinx_vck5000_gen4x8_qdma_base_2
---------------------------------------------------
Thermals
  Temperature  Celcius
  ----------------------
  PCB          41
  device       75
  vccint       56
```
Windows MCDM Test device
Electrical
```
Z:\XRT-MCDM\build\WDebug\xilinx\xrt>xbutil examine -d 18:00 -r electrical

---------------------
[0000:18:00.1] : IPU
---------------------
Electrical
  Max Power              : NA Watts
  Power                  : 123 Watts
  Power Warning          : NA

  No electrical sensors found
```
Thermal
```
Z:\XRT-MCDM\build\WDebug\xilinx\xrt>xbutil examine -d 18:00 -r thermal

---------------------
[0000:18:00.1] : IPU
---------------------
Thermals
  No temperature sensors are present
```

#### Documentation impact (if any)
None!