### PR TITLE
Fix ptree having multiple roots

### DIFF
--- a/src/runtime_src/core/tools/common/ReportAiePartitions.cpp
+++ b/src/runtime_src/core/tools/common/ReportAiePartitions.cpp
@@ -61,8 +61,10 @@ ReportAiePartitions::
 getPropertyTree20202(const xrt_core::device* _pDevice, 
                      boost::property_tree::ptree &_pt) const
 {
-  _pt.put("description", "AIE Partition Information");
-  _pt.add_child("aie_partitions", populate_aie_partition(_pDevice));
+  boost::property_tree::ptree pt;
+  pt.put("description", "AIE Partition Information");
+  pt.add_child("partitions", populate_aie_partition(_pDevice));
+  _pt.add_child("aie_partitions", pt);
 }
 
 void 
@@ -74,7 +76,7 @@ writeReport(const xrt_core::device* /*_pDevice*/,
 {
   _output << "AIE Partitions\n";
   boost::property_tree::ptree empty_ptree;
-  const boost::property_tree::ptree pt_partitions = _pt.get_child("aie_partitions", empty_ptree);
+  const boost::property_tree::ptree pt_partitions = _pt.get_child("aie_partitions.partitions", empty_ptree);
   if (pt_partitions.empty()) {
     _output << "  AIE Partition information unavailable\n\n";
     return;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
AIE partition json generation failed due to having multiple roots

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
JSON output does not work

#### How problem was solved, alternative solutions (if any) and why they were rejected
Modified the tree to have one root

#### Risks (if any) associated the changes in the commit
None. This is a fix

#### What has been tested and how, request additional testing if necessary
Ubuntu 20.04
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ xbutil examine -d 17:00 -r aie-partitions -o test.json --force
***********************************************************
*        WARNING          WARNING          WARNING        *
*       SC version data missing. Upgrade your shell       *
***********************************************************

---------------------------------------------------
[0000:17:00.1] : xilinx_vck5000_gen4x8_qdma_base_2
---------------------------------------------------
AIE Partitions
  AIE Partition information unavailable

Successfully wrote the json file: test.json
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ echo $?
0
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ cat test.json
{
    "schema_version": {
        "schema": "JSON",
        "creation_date": "Tue Jul 11 22:42:29 2023 GMT"
    },
    "devices": [
        {
            "interface_type": "pcie",
            "device_id": "0000:17:00.1",
            "device_status": "HEALTHY",
            "aie_partitions": {
                "description": "AIE Partition Information",
                "partitions": ""
            }
        }
    ]
}
```

#### Documentation impact (if any)
None
