### PR TITLE
VITIS-6327 xbutil valdiate changes to support ps kernel testing

### DIFF
--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -347,7 +347,8 @@ runTestCase(const std::shared_ptr<xrt_core::device>& _dev,
     // log testcase path for debugging purposes
     logger(_ptTest, "Testcase", xrtTestCasePath);
 
-    std::vector<std::string> args = { "-p", platform_path,
+    std::vector<std::string> args = { "-x", xclbinPath,
+                                      "-p", platform_path,
                                       "-d", xrt_core::query::pcie_bdf::to_string(xrt_core::device_query<xrt_core::query::pcie_bdf>(_dev)) };
 
     if (!dependency_args.empty()) {

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -338,7 +338,7 @@ runTestCase(const std::shared_ptr<xrt_core::device>& _dev,
       test_name = test_map.find(py)->second;
 
     // Parse if the file exists here
-    std::string  xrtTestCasePath = "/proj/rdi/staff/dbenusov/XRT/build/Debug/opt/xilinx/xrt/test/" + test_name;
+    std::string  xrtTestCasePath = "/opt/xilinx/xrt/test/" + test_name;
     boost::filesystem::path xrt_path(xrtTestCasePath);
     if (!boost::filesystem::exists(xrt_path)) {
       logger(_ptTest, "Error", boost::str(boost::format("Failed to find %s") % xrtTestCasePath));

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -233,7 +233,6 @@ findXclbinPath( const std::shared_ptr<xrt_core::device>& _dev,
     const auto fmt = boost::format("%s not available. Skipping validation.") % xclbin_path;
     logger(_ptTest, "Details", boost::str(fmt));
     _ptTest.put("status", test_token_skipped);
-    XBUtilities::throw_cancel(fmt);
   }
   return xclbin_path;
 }
@@ -243,6 +242,10 @@ findDependencies( const std::string& test_path,
                   const std::string& ps_kernel_name)
 {
     const std::string dependency_json = "/lib/firmware/xilinx/ps_kernels/test_dependencies.json";
+    boost::filesystem::path dep_path(dependency_json);
+    if (!boost::filesystem::exists(dep_path))
+      return {};
+
     std::vector<std::string> dependencies;
     try {
         boost::property_tree::ptree pt;
@@ -335,7 +338,7 @@ runTestCase(const std::shared_ptr<xrt_core::device>& _dev,
       test_name = test_map.find(py)->second;
 
     // Parse if the file exists here
-    std::string  xrtTestCasePath = "/opt/xilinx/xrt/test/" + test_name;
+    std::string  xrtTestCasePath = "/proj/rdi/staff/dbenusov/XRT/build/Debug/opt/xilinx/xrt/test/" + test_name;
     boost::filesystem::path xrt_path(xrtTestCasePath);
     if (!boost::filesystem::exists(xrt_path)) {
       logger(_ptTest, "Error", boost::str(boost::format("Failed to find %s") % xrtTestCasePath));
@@ -716,7 +719,7 @@ search_and_program_xclbin(const std::shared_ptr<xrt_core::device>& dev, boost::p
   uuid_parse(xrt_core::device_query<xrt_core::query::xclbin_uuid>(dev).c_str(), uuid);
   std::string xclbin = ptTest.get<std::string>("xclbin", "");
 
-  std::string xclbinPath = findXclbinPath(dev, xclbin, ptTest) + xclbin;
+  std::string xclbinPath = findXclbinPath(dev, xclbin, ptTest);
 
   try {
     program_xclbin(dev, xclbinPath);

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -335,7 +335,7 @@ runTestCase(const std::shared_ptr<xrt_core::device>& _dev,
       test_name = test_map.find(py)->second;
 
     // Parse if the file exists here
-    std::string  xrtTestCasePath = "/proj/rdi/staff/dbenusov/XRT/build/Debug/opt/xilinx/xrt/test/" + test_name;
+    std::string  xrtTestCasePath = "/opt/xilinx/xrt/test/" + test_name;
     boost::filesystem::path xrt_path(xrtTestCasePath);
     if (!boost::filesystem::exists(xrt_path)) {
       logger(_ptTest, "Error", boost::str(boost::format("Failed to find %s") % xrtTestCasePath));

--- a/tests/validate/aie_pl_test/src/host.cpp
+++ b/tests/validate/aie_pl_test/src/host.cpp
@@ -258,14 +258,12 @@ main(int argc, char* argv[])
                      boost::program_options::bool_switch(&bSupported),
                      "Supported")("help,h", "Prints this help menu.");
 
-    po::positional_options_description positionals;
-
     // Parse sub-command ...
     po::variables_map vm;
     try {
         po::store(po::command_line_parser(argc, argv)
                       .options(desc)
-                      .positional(positionals)
+                      .allow_unregistered()
                       .run(),
                   vm);
         // Print out the help menu

--- a/tests/validate/ps_aie_test/CMakeLists.txt
+++ b/tests/validate/ps_aie_test/CMakeLists.txt
@@ -17,7 +17,7 @@ add_executable(${TESTNAME}
   ../common/includes/logger/logger.cpp src/host.cpp
   )
 
-target_link_libraries(${TESTNAME} PRIVATE ${xrt_coreutil_LIBRARY})
+target_link_libraries(${TESTNAME} PRIVATE ${xrt_coreutil_LIBRARY} ${Boost_PROGRAM_OPTIONS_LIBRARY} ${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY})
 
 if (NOT WIN32)
   target_link_libraries(${TESTNAME} PRIVATE ${uuid_LIBRARY}  pthread ${xrt_coreutil_LIBRARY} ${xrt_core_LIBRARY})

--- a/tests/validate/ps_aie_test/src/host.cpp
+++ b/tests/validate/ps_aie_test/src/host.cpp
@@ -14,6 +14,7 @@
 * under the License.
 */
 #include <algorithm>
+#include <boost/program_options.hpp>
 #include <cstring>
 #include <fstream>
 #include <iostream>
@@ -28,46 +29,50 @@
 #define HEIGHT 8 
 #define SIZE (WIDTH * HEIGHT)
 
-static void printHelp() {
-    std::cout << "usage: %s <options>\n";
-    std::cout << "  -p <path>\n";
-    std::cout << "  -d <device> \n";
-    std::cout << "  -s <supported>\n";
-    std::cout << "  -h <help>\n";
+static int
+validate_binary_file(const std::string& binaryfile, bool print = false)
+{
+    std::ifstream infile(binaryfile);
+    if (!infile.good()) {
+        if (print)
+            std::cout << "\nNOT SUPPORTED" << std::endl;
+        return EOPNOTSUPP;
+    } else {
+        if (print)
+            std::cout << "\nSUPPORTED" << std::endl;
+        return EXIT_SUCCESS;
+    }
 }
 
 int main(int argc, char** argv) {
     std::string dev_id = "0";
     std::string test_path;
-    std::string b_file = "/ps_aie.xclbin";
-    bool flag_s = false;
-    for (int i = 1; i < argc; i++) {
-        if ((strcmp(argv[i], "-p") == 0) || (strcmp(argv[i], "--path") == 0)) {
-            test_path = argv[i + 1];
-        } else if ((strcmp(argv[i], "-d") == 0) || (strcmp(argv[i], "--device") == 0)) {
-            dev_id = argv[i + 1];
-        } else if ((strcmp(argv[i], "-s") == 0) || (strcmp(argv[i], "--supported") == 0)) {
-            flag_s = true;
-        } else if ((strcmp(argv[i], "-h") == 0) || (strcmp(argv[i], "--help") == 0)) {
-            printHelp();
-            return 1;
-        }
-    }
+    std::string b_file;
+    std::vector<std::string> depedency_paths;
+    bool flag_s;
 
-    if (test_path.empty()) {
-        std::cout << "ERROR : please provide the platform test path to -p option\n";
-        return EXIT_FAILURE;
-    }
-    std::string binaryfile = test_path + b_file;
-    std::ifstream infile(binaryfile);
-    if (flag_s) {
-        if (!infile.good()) {
-            std::cout << "\nNOT SUPPORTED" << std::endl;
-            return EOPNOTSUPP;
-        } else {
-            std::cout << "\nSUPPORTED" << std::endl;
+    boost::program_options::options_description options;
+    options.add_options()
+        ("help,h", "Print help messages")
+        ("xclbin,x", boost::program_options::value<decltype(b_file)>(&b_file)->implicit_value("/lib/firmware/xilinx/ps_kernels/ps_aie.xclbin"), "Path to the xclbin file for the test")
+        ("path,p", boost::program_options::value<decltype(test_path)>(&test_path)->required(), "Path to the platform resources")
+        ("device,d", boost::program_options::value<decltype(dev_id)>(&dev_id)->required(), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest")
+        ("supported,s", boost::program_options::bool_switch(&flag_s), "Print supported or not")
+        ("include,i" , boost::program_options::value<decltype(depedency_paths)>(&depedency_paths)->multitoken(), "Paths to xclbins required for this test")
+    ;
+
+    boost::program_options::variables_map vm;
+    try {
+        boost::program_options::store(boost::program_options::parse_command_line(argc, argv, options), vm);
+        if (vm.count("help")) {
+            std::cout << options << std::endl;
             return EXIT_SUCCESS;
         }
+        boost::program_options::notify(vm);
+    } catch (boost::program_options::error& e) {
+        std::cerr << "ERROR: " << e.what() << std::endl;
+        std::cout << options << std::endl;
+        return EXIT_FAILURE;
     }
 
     if (!infile.good()) {
@@ -79,12 +84,25 @@ int main(int argc, char** argv) {
 
     auto device = xrt::device {dev_id};
 
+    // Load dependency xclbins onto device if any
+    for (const auto& path : depedency_paths) {
+        auto retVal = validate_binary_file(path);
+        if (retVal != EXIT_SUCCESS)
+            return retVal;
+        auto uuid = device.load_xclbin(path);
+    }
+
+    // Load ps kernel onto device
+    auto retVal = validate_binary_file(b_file, flag_s);
+    if (flag_s || retVal != EXIT_SUCCESS)
+        return retVal;
+
     const int input_size_in_bytes = SIZE * sizeof(float);
     const int output_size_in_bytes = SIZE * sizeof(float);
     const int input_size_allocated = ((input_size_in_bytes / 4096) + ((input_size_in_bytes % 4096) > 0)) * 4096;
     const int output_size_allocated = ((output_size_in_bytes / 4096) + ((output_size_in_bytes % 4096) > 0)) * 4096;
 
-    auto uuid = device.load_xclbin(binaryfile);
+    auto uuid = device.load_xclbin(b_file);
     auto aie_kernel = xrt::kernel(device,uuid, "aie_kernel");
     auto out_bo= xrt::bo(device, output_size_allocated, aie_kernel.group_id(2));
     auto out_bomapped = out_bo.map<float*>();

--- a/tests/validate/ps_aie_test/src/host.cpp
+++ b/tests/validate/ps_aie_test/src/host.cpp
@@ -48,7 +48,7 @@ int main(int argc, char** argv) {
     std::string dev_id = "0";
     std::string test_path;
     std::string b_file;
-    std::vector<std::string> depedency_paths;
+    std::vector<std::string> dependency_paths;
     bool flag_s;
 
     boost::program_options::options_description options;
@@ -58,7 +58,7 @@ int main(int argc, char** argv) {
         ("path,p", boost::program_options::value<decltype(test_path)>(&test_path)->required(), "Path to the platform resources")
         ("device,d", boost::program_options::value<decltype(dev_id)>(&dev_id)->required(), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest")
         ("supported,s", boost::program_options::bool_switch(&flag_s), "Print supported or not")
-        ("include,i" , boost::program_options::value<decltype(depedency_paths)>(&depedency_paths)->multitoken(), "Paths to xclbins required for this test")
+        ("include,i" , boost::program_options::value<decltype(dependency_paths)>(&dependency_paths)->multitoken(), "Paths to xclbins required for this test")
     ;
 
     boost::program_options::variables_map vm;
@@ -80,7 +80,7 @@ int main(int argc, char** argv) {
     auto device = xrt::device {dev_id};
 
     // Load dependency xclbins onto device if any
-    for (const auto& path : depedency_paths) {
+    for (const auto& path : dependency_paths) {
         auto retVal = validate_binary_file(path);
         if (retVal != EXIT_SUCCESS)
             return retVal;

--- a/tests/validate/ps_aie_test/src/host.cpp
+++ b/tests/validate/ps_aie_test/src/host.cpp
@@ -75,11 +75,6 @@ int main(int argc, char** argv) {
         return EXIT_FAILURE;
     }
 
-    if (!infile.good()) {
-        std::cout << "\nNOT SUPPORTED" << std::endl;
-        return EOPNOTSUPP;
-    }
-
     auto num_devices = xrt::system::enumerate_devices();
 
     auto device = xrt::device {dev_id};

--- a/tests/validate/ps_bandwidth_test/CMakeLists.txt
+++ b/tests/validate/ps_bandwidth_test/CMakeLists.txt
@@ -17,7 +17,7 @@ add_executable(${TESTNAME}
   ../common/includes/logger/logger.cpp src/host.cpp
   )
 
-target_link_libraries(${TESTNAME} PRIVATE ${xrt_coreutil_LIBRARY})
+target_link_libraries(${TESTNAME} PRIVATE ${xrt_coreutil_LIBRARY} ${Boost_PROGRAM_OPTIONS_LIBRARY} ${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY})
 
 if (NOT WIN32)
   target_link_libraries(${TESTNAME} PRIVATE ${uuid_LIBRARY}  pthread ${xrt_coreutil_LIBRARY} ${xrt_core_LIBRARY})

--- a/tests/validate/ps_bandwidth_test/src/host.cpp
+++ b/tests/validate/ps_bandwidth_test/src/host.cpp
@@ -13,73 +13,69 @@
 * License for the specific language governing permissions and limitations
 * under the License.
 */
+#include <boost/program_options.hpp>
 #include <cstring>
 #include <fstream>
 #include <iostream>
+#include <vector>
 // XRT includes
 #include "experimental/xrt_system.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
 #include "xrt/xrt_bo.h"
 
-static void printHelp() {
-    std::cout << "usage: %s <options>\n";
-    std::cout << "  -p <path>\n";
-    std::cout << "  -d <device> \n";
-    std::cout << "  -l <loop_iter_cnt> \n";
-    std::cout << "  -s <supported>\n";
-    std::cout << "  -h <help>\n";
+static int
+validate_binary_file(const std::string& binaryfile, bool print = false)
+{
+    std::ifstream infile(binaryfile);
+    if (!infile.good()) {
+        if (print)
+            std::cout << "\nNOT SUPPORTED" << std::endl;
+        return EOPNOTSUPP;
+    } else {
+        if (print)
+            std::cout << "\nSUPPORTED" << std::endl;
+        return EXIT_SUCCESS;
+    }
 }
 
 int main(int argc, char** argv) {
     std::string dev_id = "0";
     std::string test_path;
-    std::string iter_cnt = "10000";
-    std::string b_file = "/ps_bandwidth.xclbin";
-    bool flag_s = false;
+    std::string iter_cnt;
+    std::string b_file;
+    bool flag_s;
 
-    for (int i = 1; i < argc; i++) {
-        if ((strcmp(argv[i], "-p") == 0) || (strcmp(argv[i], "--path") == 0)) {
-            test_path = argv[i + 1];
-        } else if ((strcmp(argv[i], "-d") == 0) || (strcmp(argv[i], "--device") == 0)) {
-            dev_id = argv[i + 1];
-        } else if ((strcmp(argv[i], "-l") == 0) || (strcmp(argv[i], "--loop_iter_cnt") == 0)) {
-            iter_cnt = argv[i + 1];
-        } else if ((strcmp(argv[i], "-s") == 0) || (strcmp(argv[i], "--supported") == 0)) {
-            flag_s = true;
-        } else if ((strcmp(argv[i], "-h") == 0) || (strcmp(argv[i], "--help") == 0)) {
-            printHelp();
-            return 1;
-        }
-    }
+    boost::program_options::options_description options;
+    options.add_options()
+        ("help,h", "Print help messages")
+        ("xclbin,x", boost::program_options::value<decltype(b_file)>(&b_file)->implicit_value("/lib/firmware/xilinx/ps_kernels/ps_bandwidth.xclbin"), "Path to the xclbin file for the test")
+        ("path,p", boost::program_options::value<decltype(test_path)>(&test_path)->required(), "Path to the platform resources")
+        ("device,d", boost::program_options::value<decltype(dev_id)>(&dev_id)->required(), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest")
+        ("supported,s", boost::program_options::bool_switch(&flag_s), "Print supported or not")
+        ("include,i" , boost::program_options::value<decltype(depedency_paths)>(&depedency_paths)->multitoken(), "Paths to xclbins required for this test")
+        ("loop_iter_cnt,l", boost::program_options::value<decltype(iter_cnt)>(&iter_cnt)->implicit_value("10000"), "The number of iterations the test will sample over")
+    ;
 
-    if (test_path.empty()) {
-        std::cout << "ERROR : please provide the platform test path to -p option\n";
-        return EXIT_FAILURE;
-    }
-
-    std::string binaryfile = test_path + b_file;
-    std::ifstream infile(binaryfile);
-    if (flag_s) {
-        if (!infile.good()) {
-            std::cout << "\nNOT SUPPORTED" << std::endl;
-            return EOPNOTSUPP;
-        } else {
-            std::cout << "\nSUPPORTED" << std::endl;
+    boost::program_options::variables_map vm;
+    try {
+        boost::program_options::store(boost::program_options::parse_command_line(argc, argv, options), vm);
+        if (vm.count("help")) {
+            std::cout << options << std::endl;
             return EXIT_SUCCESS;
         }
-    }
-
-    if (!infile.good()) {
-        std::cout << "\nNOT SUPPORTED" << std::endl;
-        return EOPNOTSUPP;
+        boost::program_options::notify(vm);
+    } catch (boost::program_options::error& e) {
+        std::cerr << "ERROR: " << e.what() << std::endl;
+        std::cout << options << std::endl;
+        return EXIT_FAILURE;
     }
 
     auto num_devices = xrt::system::enumerate_devices();
 
     auto device = xrt::device {dev_id};
 
-    auto uuid = device.load_xclbin(binaryfile);
+    auto uuid = device.load_xclbin(b_file);
     auto bandwidth_kernel = xrt::kernel(device, uuid, "bandwidth_kernel");
 
     auto max_throughput_bo = xrt::bo(device, 4096, bandwidth_kernel.group_id(1));

--- a/tests/validate/ps_bandwidth_test/src/host.cpp
+++ b/tests/validate/ps_bandwidth_test/src/host.cpp
@@ -44,6 +44,7 @@ int main(int argc, char** argv) {
     std::string test_path;
     std::string iter_cnt;
     std::string b_file;
+    std::vector<std::string> depedency_paths;
     bool flag_s;
 
     boost::program_options::options_description options;
@@ -74,6 +75,19 @@ int main(int argc, char** argv) {
     auto num_devices = xrt::system::enumerate_devices();
 
     auto device = xrt::device {dev_id};
+
+    // Load dependency xclbins onto device if any
+    for (const auto& path : depedency_paths) {
+        auto retVal = validate_binary_file(path);
+        if (retVal != EXIT_SUCCESS)
+            return retVal;
+        auto uuid = device.load_xclbin(path);
+    }
+
+    // Load ps kernel onto device
+    auto retVal = validate_binary_file(b_file, flag_s);
+    if (flag_s || retVal != EXIT_SUCCESS)
+        return retVal;
 
     auto uuid = device.load_xclbin(b_file);
     auto bandwidth_kernel = xrt::kernel(device, uuid, "bandwidth_kernel");

--- a/tests/validate/ps_bandwidth_test/src/host.cpp
+++ b/tests/validate/ps_bandwidth_test/src/host.cpp
@@ -44,7 +44,7 @@ int main(int argc, char** argv) {
     std::string test_path;
     std::string iter_cnt;
     std::string b_file;
-    std::vector<std::string> depedency_paths;
+    std::vector<std::string> dependency_paths;
     bool flag_s;
 
     boost::program_options::options_description options;
@@ -54,7 +54,7 @@ int main(int argc, char** argv) {
         ("path,p", boost::program_options::value<decltype(test_path)>(&test_path)->required(), "Path to the platform resources")
         ("device,d", boost::program_options::value<decltype(dev_id)>(&dev_id)->required(), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest")
         ("supported,s", boost::program_options::bool_switch(&flag_s), "Print supported or not")
-        ("include,i" , boost::program_options::value<decltype(depedency_paths)>(&depedency_paths)->multitoken(), "Paths to xclbins required for this test")
+        ("include,i" , boost::program_options::value<decltype(dependency_paths)>(&dependency_paths)->multitoken(), "Paths to xclbins required for this test")
         ("loop_iter_cnt,l", boost::program_options::value<decltype(iter_cnt)>(&iter_cnt)->implicit_value("10000"), "The number of iterations the test will sample over")
     ;
 
@@ -77,7 +77,7 @@ int main(int argc, char** argv) {
     auto device = xrt::device {dev_id};
 
     // Load dependency xclbins onto device if any
-    for (const auto& path : depedency_paths) {
+    for (const auto& path : dependency_paths) {
         auto retVal = validate_binary_file(path);
         if (retVal != EXIT_SUCCESS)
             return retVal;

--- a/tests/validate/ps_validate_test/CMakeLists.txt
+++ b/tests/validate/ps_validate_test/CMakeLists.txt
@@ -18,7 +18,7 @@ add_executable(${TESTNAME}
   ../common/includes/logger/logger.cpp src/host.cpp
   )
 
-target_link_libraries(${TESTNAME} PRIVATE ${xrt_coreutil_LIBRARY}   ${Boost_PROGRAM_OPTIONS_LIBRARY} ${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY})
+target_link_libraries(${TESTNAME} PRIVATE ${xrt_coreutil_LIBRARY} ${Boost_PROGRAM_OPTIONS_LIBRARY} ${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY})
 
 if (NOT WIN32)
   target_link_libraries(${TESTNAME} PRIVATE ${uuid_LIBRARY}  pthread ${xrt_coreutil_LIBRARY} ${xrt_core_LIBRARY})

--- a/tests/validate/ps_validate_test/CMakeLists.txt
+++ b/tests/validate/ps_validate_test/CMakeLists.txt
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2022 Xilinx, Inc. All rights reserved.
+# Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
 #
 set(TESTNAME "ps_validate.exe")
 
@@ -17,7 +18,7 @@ add_executable(${TESTNAME}
   ../common/includes/logger/logger.cpp src/host.cpp
   )
 
-target_link_libraries(${TESTNAME} PRIVATE ${xrt_coreutil_LIBRARY})
+target_link_libraries(${TESTNAME} PRIVATE ${xrt_coreutil_LIBRARY} ${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY})
 
 if (NOT WIN32)
   target_link_libraries(${TESTNAME} PRIVATE ${uuid_LIBRARY}  pthread ${xrt_coreutil_LIBRARY} ${xrt_core_LIBRARY})

--- a/tests/validate/ps_validate_test/CMakeLists.txt
+++ b/tests/validate/ps_validate_test/CMakeLists.txt
@@ -18,7 +18,7 @@ add_executable(${TESTNAME}
   ../common/includes/logger/logger.cpp src/host.cpp
   )
 
-target_link_libraries(${TESTNAME} PRIVATE ${xrt_coreutil_LIBRARY} ${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY})
+target_link_libraries(${TESTNAME} PRIVATE ${xrt_coreutil_LIBRARY}   ${Boost_PROGRAM_OPTIONS_LIBRARY} ${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY})
 
 if (NOT WIN32)
   target_link_libraries(${TESTNAME} PRIVATE ${uuid_LIBRARY}  pthread ${xrt_coreutil_LIBRARY} ${xrt_core_LIBRARY})

--- a/tests/validate/ps_validate_test/src/host.cpp
+++ b/tests/validate/ps_validate_test/src/host.cpp
@@ -34,7 +34,7 @@ int main(int argc, char** argv) {
     std::string dev_id = "0";
     std::string test_path;
     std::string b_file;
-    std::vector<std::string> depedency_paths;
+    std::vector<std::string> dependency_paths;
     bool flag_s = false;
 
     boost::program_options::options_description options;
@@ -44,7 +44,7 @@ int main(int argc, char** argv) {
         ("path,p", boost::program_options::value<decltype(test_path)>(&test_path)->required(), "Path to the platform resources")
         ("device,d", boost::program_options::value<decltype(dev_id)>(&dev_id)->required(), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest")
         ("supported,s", boost::program_options::bool_switch(&flag_s), "Print supported or not")
-        ("include,i" , boost::program_options::value<decltype(depedency_paths)>(&depedency_paths)->multitoken(), "Paths to xclbins required for this test")
+        ("include,i" , boost::program_options::value<decltype(dependency_paths)>(&dependency_paths)->multitoken(), "Paths to xclbins required for this test")
     ;
 
     boost::program_options::variables_map vm;
@@ -66,7 +66,7 @@ int main(int argc, char** argv) {
     auto device = xrt::device {dev_id};
 
     // Load dependency xclbins onto device if any
-    for (const auto& path : depedency_paths) {
+    for (const auto& path : dependency_paths) {
         auto retVal = validate_binary_file(path);
         if (retVal != EXIT_SUCCESS)
             return retVal;

--- a/tests/validate/ps_validate_test/src/host.cpp
+++ b/tests/validate/ps_validate_test/src/host.cpp
@@ -1,18 +1,9 @@
-/**
-* Copyright (C) 2022 Xilinx, Inc
-*
-* Licensed under the Apache License, Version 2.0 (the "License"). You may
-* not use this file except in compliance with the License. A copy of the
-* License is located at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-* License for the specific language governing permissions and limitations
-* under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2022 Xilinx, Inc
+// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+
+#include <boost/property_tree/json_parser.hpp>
+#include <boost/algorithm/string.hpp>
 #include <algorithm>
 #include <cstring>
 #include <fstream>
@@ -25,6 +16,8 @@
 #include "xrt/xrt_bo.h"
 static const int COUNT = 1024;
 
+static std::string ps_kernel_path = "/lib/firmware/xilinx/ps_kernels/";
+
 static void printHelp() {
     std::cout << "usage: %s <options>\n";
     std::cout << "  -p <path>\n";
@@ -33,10 +26,65 @@ static void printHelp() {
     std::cout << "  -h <help>\n";
 }
 
+static int
+validate_binary_file(const std::string& binaryfile, bool print = false)
+{
+    std::ifstream infile(binaryfile);
+    if (!infile.good()) {
+        if (print)
+            std::cout << "\nNOT SUPPORTED" << std::endl;
+        return EOPNOTSUPP;
+    } else {
+        if (print)
+            std::cout << "\nSUPPORTED" << std::endl;
+        return EXIT_SUCCESS;
+    }
+}
+
+static int
+load_dependencies(  xrt::device& device,
+                    const std::string& test_path,
+                    const std::string& ps_kernel_name,
+                    std::map<std::string, xrt::uuid>& uuid_map)
+{
+    std::string dependency_name = "test_dependencies.json";
+    std::string dependency_json = ps_kernel_path + dependency_name;
+
+    try {
+        boost::property_tree::ptree load_ptree_root;
+        boost::property_tree::read_json(dependency_json, load_ptree_root);
+
+        auto ps_kernels = load_ptree_root.get_child("ps_kernel_mappings");
+        for (const auto& ps_kernel : ps_kernels) {
+            boost::property_tree::ptree ps_kernel_pt = ps_kernel.second;
+            if (!boost::equals(ps_kernel_name, ps_kernel_pt.get<std::string>("name")))
+                continue;
+
+            auto dependencies = ps_kernel_pt.get_child("dependencies");
+            for (const auto& dependency : dependencies) {
+                std::string dependency_name = dependency.second.get_value<std::string>();
+                std::string binaryfile = test_path + dependency_name;
+                auto retVal = validate_binary_file(binaryfile);
+                if (retVal != EXIT_SUCCESS)
+                    return retVal;
+                auto uuid = device.load_xclbin(binaryfile);
+                uuid_map.emplace(dependency_name, uuid);
+            }
+        }
+    } catch (const std::exception& e) {
+        std::string msg("ERROR: Bad JSON format detected while marshaling dependency metadata (");
+        msg += e.what();
+        msg += ").";
+        std::cerr << msg << std::endl;
+        return EXIT_FAILURE;
+    }
+    return EXIT_SUCCESS;
+}
+
 int main(int argc, char** argv) {
     std::string dev_id = "0";
     std::string test_path;
-    std::string b_file = "/ps_validate_bandwidth.xclbin";
+    std::string b_file = "ps_validate.xclbin";
     bool flag_s = false;
     for (int i = 1; i < argc; i++) {
         if ((strcmp(argv[i], "-p") == 0) || (strcmp(argv[i], "--path") == 0)) {
@@ -55,26 +103,21 @@ int main(int argc, char** argv) {
         std::cout << "ERROR : please provide the platform test path to -p option\n";
         return EXIT_FAILURE;
     }
-    std::string binaryfile = test_path + b_file;
-    std::ifstream infile(binaryfile);
-    if (flag_s) {
-        if (!infile.good()) {
-            std::cout << "\nNOT SUPPORTED" << std::endl;
-            return EOPNOTSUPP;
-        } else {
-            std::cout << "\nSUPPORTED" << std::endl;
-            return EXIT_SUCCESS;
-        }
-    }
-
-    if (!infile.good()) {
-        std::cout << "\nNOT SUPPORTED" << std::endl;
-        return EOPNOTSUPP;
-    }
 
     auto num_devices = xrt::system::enumerate_devices();
 
     auto device = xrt::device {dev_id};
+
+    std::map<std::string, xrt::uuid> uuid_map;
+    auto dependencyLoad = load_dependencies(device, test_path, b_file, uuid_map);
+    if (dependencyLoad != EXIT_SUCCESS)
+        return dependencyLoad;
+
+    // Load ps kernel onto device
+    std::string binaryfile = ps_kernel_path + b_file;
+    auto retVal = validate_binary_file(binaryfile, flag_s);
+    if (flag_s || retVal != EXIT_SUCCESS)
+        return retVal;
 
     auto uuid = device.load_xclbin(binaryfile);
     auto hello_world = xrt::kernel(device, uuid.get(), "hello_world");


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/VITIS-6327
Part two of this ticket

Previously the ps kernels were added into the APU package. In this PR we are adding the XRT changes required to make use of the newly added ps kernels.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
New feature.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Upgrade the host executables to accept more parameters that enable the passing of dependency paths for loading. This will allow us to move in the direction of having data driven tests in the future.
Upgrade SubCmdValidate to read the ps kernel dependency file and pass those arguments into the host executables.

#### Risks (if any) associated the changes in the commit
This does not affect existing tests.

#### What has been tested and how, request additional testing if necessary
Ubuntu 20.04
Help Menu
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ xbutil validate -d 17:00 --help

COMMAND: validate

DESCRIPTION: Validates the given device by executing the platform's validate executable.

USAGE: xbutil validate [--help] [-d arg] [-f arg] [-r arg] [-o arg] [-p arg] [--param arg]

OPTIONS:
  -d, --device       - The device of interest. This is specified as follows:
                         <BDF> - Bus:Device.Function (e.g., 0000:d8:00.0)
  -f, --format       - Report output format. Valid values are:
                         JSON        - Latest JSON schema
                         JSON-2020.2 - JSON 2020.2 schema
  -r, --run          - Run a subset of the test suite.  Valid options are:
                         all            - All applicable validate tests will be executed (default)
                         quick          - Only the first 4 tests will be executed
                         aux-connection - Check if auxiliary power is connected
                         pcie-link      - Check if PCIE link is active
                         sc-version     - Check if SC firmware is up-to-date
                         verify         - Run 'Hello World' kernel test
                         dma            - Run dma test
                         iops           - Run scheduler performance measure test
                         mem-bw         - Run 'bandwidth kernel' and check the throughput
                         p2p            - Run P2P test
                         m2m            - Run M2M test
                         hostmem-bw     - Run 'bandwidth kernel' when host memory is enabled
                         bist           - Run BIST test
                         vcu            - Run decoder test
                         aie            - Run AIE PL test
                         ps-aie         - Run PS controlled AIE test
                         ps-pl-verify   - Run PS controlled 'Hello World' PL kernel test
                         ps-verify      - Run 'Hello World' PS kernel test
                         ps-iops        - Run IOPS PS test
  -o, --output       - Direct the output to the given file
  --param            - Extended parameter for a given test. Format: <test-name>:<key>:<value>
  -p, --path         - Path to the directory containing validate xclbins
  --help             - Help to use this sub-command

EXTENDED KEYS:
  dma                - block-size:<value> - Memory transfer size (bytes)


GLOBAL OPTIONS:
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
```

The new tests are currently non functional and skip unless the APU package is installed. These will be addressed in https://jira.xilinx.com/browse/VITIS-9385.
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ xbutil validate -d 17:00 -r all --verbose
Verbose: Enabling Verbosity
***********************************************************
*        WARNING          WARNING          WARNING        *
*       SC version data missing. Upgrade your shell       *
***********************************************************
Validate Device           : [0000:17:00.1]
    Platform              : xilinx_vck5000_gen4x8_qdma_base_2
    SC Version            : 4.4.35
    Platform ID           : 05DCA096-76CB-730B-8D19-EC1192FBAE3F
-------------------------------------------------------------------------------
Test 1 [0000:17:00.1]     : aux-connection

    Description           : Check if auxiliary power is connected
    Details               : Aux power connector is not available on this board
    Test Status           : [SKIPPED]
-------------------------------------------------------------------------------
Test 2 [0000:17:00.1]     : pcie-link
    Description           : Check if PCIE link is active
    Warning(s)            : Link is active
                            Please make sure that the device is plugged into Gen 4x8,
                            instead of Gen 3x8. Lower performance maybe experienced.
    Test Status           : [PASSED WITH WARNINGS]
-------------------------------------------------------------------------------
Test 3 [0000:17:00.1]     : sc-version
    Description           : Check if SC firmware is up-to-date
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Test 4 [0000:17:00.1]     : verify
    Description           : Run 'Hello World' kernel test
    Xclbin                : /opt/xilinx/firmware/vck5000/gen4x8-qdma/base/test
    Testcase              : /proj/rdi/staff/dbenusov/XRT/build/Debug/opt/xilinx/xrt/test/validate.exe
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Test 5 [0000:17:00.1]     : dma
    Description           : Run dma test
    Details               : Buffer size - '16 MB'
                            Host -> PCIe -> FPGA write bandwidth = 6540.6 MB/s
                            Host <- PCIe <- FPGA read bandwidth = 6601.2 MB/s
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Test 6 [0000:17:00.1]     : iops
    Description           : Run scheduler performance measure test
    Xclbin                : /opt/xilinx/firmware/vck5000/gen4x8-qdma/base/test
    Testcase              : /proj/rdi/staff/dbenusov/XRT/build/Debug/opt/xilinx/xrt/test/xcl_iops_test.exe
    Details               : IOPS: 482151 (verify)
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Test 7 [0000:17:00.1]     : mem-bw
    Description           : Run 'bandwidth kernel' and check the throughput
    Xclbin                : /opt/xilinx/firmware/vck5000/gen4x8-qdma/base/test
    Testcase              : /proj/rdi/staff/dbenusov/XRT/build/Debug/opt/xilinx/xrt/test/kernel_bw.exe
    Details               : Throughput (Type: DDR) (Bank count: 1) : 21154.2MB/s
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Test 8 [0000:17:00.1]     : p2p
    Description           : Run P2P test
    Details               : P2P config failed. P2P is not supported. Can't find P2P
                            BAR.
    Test Status           : [SKIPPED]
-------------------------------------------------------------------------------
Test 9 [0000:17:00.1]     : m2m

    Description           : Run M2M test
    Details               : M2M is not available
    Test Status           : [SKIPPED]
-------------------------------------------------------------------------------
Test 10 [0000:17:00.1]    : hostmem-bw

    Description           : Run 'bandwidth kernel' when host memory is enabled
    Details               : Host memory is not enabled
    Test Status           : [SKIPPED]
-------------------------------------------------------------------------------
Test 11 [0000:17:00.1]    : vcu
    Description           : Run decoder test
    Details               : /opt/xilinx/firmware/vck5000/gen4x8-qdma/base/test/transcode.xclbin
                            not available. Skipping validation.
                            Verify xclbin not available or shell partition is not
                            programmed. Skipping validation.
    Test Status           : [SKIPPED]
-------------------------------------------------------------------------------
Test 12 [0000:17:00.1]    : aie
    Description           : Run AIE PL test
    Xclbin                : /opt/xilinx/firmware/vck5000/gen4x8-qdma/base/test
    Testcase              : /proj/rdi/staff/dbenusov/XRT/build/Debug/opt/xilinx/xrt/test/aie_pl.exe
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Test 13 [0000:17:00.1]    : ps-aie

    Description           : Run PS controlled AIE test
    Details               : /lib/firmware/xilinx/ps_kernels/ps_aie.xclbin not
                            available. Skipping validation.
                            Verify xclbin not available or shell partition is not
                            programmed. Skipping validation.
    Test Status           : [SKIPPED]
-------------------------------------------------------------------------------
Test 14 [0000:17:00.1]    : ps-pl-verify

    Description           : Run PS controlled 'Hello World' PL kernel test
    Details               : /lib/firmware/xilinx/ps_kernels/ps_bandwidth.xclbin not
                            available. Skipping validation.
                            Verify xclbin not available or shell partition is not
                            programmed. Skipping validation.
    Test Status           : [SKIPPED]
-------------------------------------------------------------------------------
Test 15 [0000:17:00.1]    : ps-verify

    Description           : Run 'Hello World' PS kernel test
    Details               : /lib/firmware/xilinx/ps_kernels/ps_validate.xclbin not
                            available. Skipping validation.
                            Verify xclbin not available or shell partition is not
                            programmed. Skipping validation.
    Test Status           : [SKIPPED]
-------------------------------------------------------------------------------
Test 16 [0000:17:00.1]    : ps-iops

    Description           : Run IOPS PS test
    Details               : /lib/firmware/xilinx/ps_kernels/ps_validate.xclbin not
                            available. Skipping validation.
                            Verify xclbin not available or shell partition is not
                            programmed. Skipping validation.
    Test Status           : [SKIPPED]
-------------------------------------------------------------------------------
Validation completed, but with warnings
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ echo $?
0
```
#### Documentation impact (if any)
Need to add the new tests into the documentation.