### PR TITLE
VITIS-8980 Improve sensor reports

### DIFF
--- a/src/runtime_src/core/common/sensor.cpp
+++ b/src/runtime_src/core/common/sensor.cpp
@@ -477,7 +477,7 @@ read_thermals(const xrt_core::device * device)
   try {
     output = xrt_core::device_query<xq::sdm_sensor_info>(device, xq::sdm_sensor_info::sdr_req_type::thermal);
     if (output.empty()) {
-      thermal_array.put("error_msg", "Information unavailable");
+      thermal_array.put("msg", "No sensors present");
       root.add_child("thermals", thermal_array);
       return root;
     }
@@ -512,7 +512,7 @@ read_mechanical(const xrt_core::device * device)
   try {
     output = xrt_core::device_query<xq::sdm_sensor_info>(device, xq::sdm_sensor_info::sdr_req_type::mechanical);
     if (output.empty()) {
-      fan_array.put("error_msg", "Information unavailable");
+      fan_array.put("msg", "No sensors present");
       root.add_child("fans", fan_array);
       return root;
     }

--- a/src/runtime_src/core/common/sensor.cpp
+++ b/src/runtime_src/core/common/sensor.cpp
@@ -445,8 +445,10 @@ read_electrical(const xrt_core::device * device)
     //Check for any of these data is available
     if (!current.empty() || !voltage.empty() || !power.empty())
       return read_data_driven_electrical(current, voltage, power);
-    else
+    else {
+      sensor_array.put("msg", "No sensors present");
       return sensor_array;
+    }
   }
   catch(const xrt_core::query::no_such_key&) {
     is_data_driven = false;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
The output json displays an error message if no sensors are present. Even if it is true! This will scare users.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Found during testing within MCDM

#### How problem was solved, alternative solutions (if any) and why they were rejected
Changed the message that is passed back to something informative.

#### Risks (if any) associated the changes in the commit
This may throw off some tests which rely on thermals returning "Information Unavailable" if the sensors are broken. Rather unlikely though.

#### What has been tested and how, request additional testing if necessary
Windows MCDM
```
{
    "schema_version": {
        "schema": "JSON",
        "creation_date": "Wed Jul 12 22:09:06 2023 GMT"
    },
    "devices": [
        {
            "interface_type": "pcie",
            "device_id": "0000:18:00.1",
            "device_status": "HEALTHY",
            "thermals": {
                "msg": "No sensors present"
            },
            "mechanical": {
                "fans": {
                    "msg": "No sensors present"
                }
            },
            "electrical": {
                "msg": "No sensors present"
            }
        }
    ]
}
```
#### Documentation impact (if any)
None.