### PR TITLE
Fix windows VS22 compilation warnings

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info/aie_util.h
+++ b/src/runtime_src/xdp/profile/database/static_info/aie_util.h
@@ -36,9 +36,10 @@ namespace aie {
   int getHardwareGeneration(const boost::property_tree::ptree& aie_meta);
   uint16_t getAIETileRowOffset(const boost::property_tree::ptree& aie_meta);
   aiecompiler_options getAIECompilerOptions(const boost::property_tree::ptree& aie_meta);
-  std::vector<std::string> getValidGraphs(const boost::property_tree::ptree& aie_meta);
-  std::vector<std::string> getValidKernels(const boost::property_tree::ptree& aie_meta);
-  std::vector<std::string> getValidPorts(const boost::property_tree::ptree& aie_meta);
+
+  XDP_EXPORT std::vector<std::string> getValidGraphs(const boost::property_tree::ptree& aie_meta);
+  XDP_EXPORT std::vector<std::string> getValidKernels(const boost::property_tree::ptree& aie_meta);
+  XDP_EXPORT std::vector<std::string> getValidPorts(const boost::property_tree::ptree& aie_meta);
 
   std::unordered_map<std::string, io_config> getPLIOs(const boost::property_tree::ptree& aie_meta);
   std::unordered_map<std::string, io_config> getGMIOs(const boost::property_tree::ptree& aie_meta);
@@ -46,7 +47,7 @@ namespace aie {
   std::unordered_map<std::string, io_config> getChildGMIOs(const boost::property_tree::ptree& aie_meta,
                                                            const std::string& childStr);
   std::unordered_map<std::string, io_config> getAllIOs(const boost::property_tree::ptree& aie_meta);
-  std::vector<tile_type> getInterfaceTiles(const boost::property_tree::ptree& aie_meta,
+  XDP_EXPORT std::vector<tile_type> getInterfaceTiles(const boost::property_tree::ptree& aie_meta,
                                            const std::string& graphName,
                                            const std::string& portName = "all",
                                            const std::string& metricStr = "channels",

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/CMakeLists.txt
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/CMakeLists.txt
@@ -20,8 +20,6 @@ file(GLOB AIE_PROFILE_PLUGIN_FILES
   "${PROFILE_DIR}/plugin/aie_profile/*.cpp"
   "${PROFILE_DIR}/writer/aie_profile/*.h"
   "${PROFILE_DIR}/writer/aie_profile/*.cpp"
-  "${PROFILE_DIR}/database/static_info/*.h"
-  "${PROFILE_DIR}/database/static_info/*.cpp"
   "${IMPL_DIR}/*.h"
   "${IMPL_DIR}/*.cpp"
 )

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/CMakeLists.txt
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/CMakeLists.txt
@@ -20,6 +20,8 @@ file(GLOB AIE_PROFILE_PLUGIN_FILES
   "${PROFILE_DIR}/plugin/aie_profile/*.cpp"
   "${PROFILE_DIR}/writer/aie_profile/*.h"
   "${PROFILE_DIR}/writer/aie_profile/*.cpp"
+  "${PROFILE_DIR}/database/static_info/*.h"
+  "${PROFILE_DIR}/database/static_info/*.cpp"
   "${IMPL_DIR}/*.h"
   "${IMPL_DIR}/*.cpp"
 )

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_metadata.cpp
@@ -742,8 +742,8 @@ namespace xdp {
       if (graphMetrics[i].size() > 3) {
         try {
           for (auto &e : tiles) {
-            configChannel0[e] = std::stoi(graphMetrics[i][3]);
-            configChannel1[e] = std::stoi(graphMetrics[i].back());
+            configChannel0[e] = static_cast<uint8_t>(std::stoi(graphMetrics[i][3]));
+            configChannel1[e] = static_cast<uint8_t>(std::stoi(graphMetrics[i].back()));
           }
         } catch (...) {
           std::stringstream msg;
@@ -791,8 +791,8 @@ namespace xdp {
       if (graphMetrics[i].size() > 3) {
         try {
           for (auto &e : tiles) {
-            configChannel0[e] = std::stoi(graphMetrics[i][3]);
-            configChannel1[e] = std::stoi(graphMetrics[i].back());
+            configChannel0[e] = static_cast<uint8_t>(std::stoi(graphMetrics[i][3]));
+            configChannel1[e] = static_cast<uint8_t>(std::stoi(graphMetrics[i].back()));
           }
         } catch (...) {
           std::stringstream msg;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Visual Studio 22 compiler fails when building some recent changes due to some warnings and linking issues. This resolves them!

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Added in https://github.com/Xilinx/XRT/pull/7591. Discovered when updating the XRT-IPU submodule.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Fixed the warnings. Added required sources to CMake.

#### Risks (if any) associated the changes in the commit
None.

#### What has been tested and how, request additional testing if necessary
Builds on Windows now!

#### Documentation impact (if any)
None