### PR TITLE
Moving PS Kernel's pscontext to public XRT include area and under XRT namespace

### DIFF
--- a/src/runtime_src/core/edge/common/xrt_pscontext.cpp
+++ b/src/runtime_src/core/edge/common/xrt_pscontext.cpp
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
+
+// This file implements XRT pscontext internals as specified in
+// core/include/experimental/xrt_pscontext.h
+#include "core/include/experimental/xrt_pscontext.h"
+
+namespace xrt {
+
+// class pscontext_impl - XRT internal context for PS kernels
+//
+class pscontext_impl {
+private:
+  bool aie_profile_en = false;
+};
+
+} // xrt

--- a/src/runtime_src/core/edge/include/sk_types.h
+++ b/src/runtime_src/core/edge/include/sk_types.h
@@ -17,6 +17,6 @@
 #ifndef __SK_TYPES_H_
 #define __SK_TYPES_H_
 
-#include "xrt_pscontext.h"
+#include "experimental/xrt_pscontext.h"
 
 #endif

--- a/src/runtime_src/core/edge/include/sk_types.h
+++ b/src/runtime_src/core/edge/include/sk_types.h
@@ -1,8 +1,5 @@
 /**
- * Copyright (C) 2019-2022 Xilinx, Inc
- * Author(s): Min Ma	<min.ma@xilinx.com>
- *          : Larry Liu	<yliu@xilinx.com>
- *          : Jeff Lin	<jeffli@xilinx.com>
+ * Copyright (C) 2023 Advanced Micro Devices, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -20,54 +17,6 @@
 #ifndef __SK_TYPES_H_
 #define __SK_TYPES_H_
 
-#include "xclhal2_mpsoc.h"
-#include <memory>
-
-/*
- * Helper functions for kernel to use.
- * getHostBO : create a BO handle from given physical address.
- * mapBO     : map BO handle to process's memory space.
- * freeBO    : free BO handle.
- * logMsg    : send log messages to XRT driver for saving as per ini settings
- */
-struct sk_operations {
-  unsigned int (* getHostBO)(unsigned long paddr, size_t size);
-  void *(* mapBO)(unsigned int boHandle, bool write);
-  void (* freeBO)(unsigned int boHandle);
-  int (* getBufferFd)(unsigned int boHandle);
-  int (* logMsg)(xrtLogMsgLevel level, const char* tag,
-		       const char* format, ...);
-};
-
-/*
- * Each soft kernel fucntion has two arguments.
- * args: provide reg file (data input, output, size etc.,
- *       for soft kernel to run.
- * ops:  provide help functions for soft kernel to use.
- */
-typedef int (* kernel_t)(void *args, struct sk_operations *ops);
-
-/*
- * PS Context Data Structure included by user PS kernel code
- */
-
-class pscontext {
-public:
- pscontext()
-   : pimpl{std::make_shared<pscontext::impl>()} {}
-  virtual ~pscontext() {}
- 
-protected:
-  struct impl;
-  std::shared_ptr<impl> pimpl;
-};
-
-struct pscontext::impl {
-private:
-  bool aie_profile_en;
-};
-
-typedef pscontext* (* kernel_init_t)(xclDeviceHandle device, const uuid_t &uuid);
-typedef int (* kernel_fini_t)(pscontext *xrtHandles);
+#include "xrt_pscontext.h"
 
 #endif

--- a/src/runtime_src/core/edge/ps_kernels/profiling/aie2_profile_config/aie2_profile_config.cpp
+++ b/src/runtime_src/core/edge/ps_kernels/profiling/aie2_profile_config/aie2_profile_config.cpp
@@ -19,7 +19,7 @@
 #include "xaiengine.h"
 
 #include "core/common/time.h"
-#include "core/edge/include/sk_types.h"
+#include "experimental/xrt_pscontext.h"
 #include "core/edge/common/aie_parser.h"
 #include "core/edge/user/shim.h"
 #include "xaiefal/xaiefal.hpp"
@@ -32,7 +32,7 @@ extern "C"{
 }
 
 // User private data structure container (context object) definition
-class xrtHandles : public pscontext
+class xrtHandles : public xrt::pscontext
 {
   public:
     XAie_DevInst* aieDevInst = nullptr;

--- a/src/runtime_src/core/edge/ps_kernels/profiling/aie2_trace_config/aie2_trace_config.cpp
+++ b/src/runtime_src/core/edge/ps_kernels/profiling/aie2_trace_config/aie2_trace_config.cpp
@@ -16,7 +16,7 @@
 #include <cstring>
 #include <vector>
 
-#include "core/edge/include/sk_types.h"
+#include "experimental/xrt_pscontext.h"
 #include "core/edge/user/shim.h"
 #include "event_configuration.h"
 #include "xaiefal/xaiefal.hpp"
@@ -25,7 +25,7 @@
 #include "xdp/profile/plugin/aie_trace/x86/aie_trace_kernel_config.h"
 
 // User private data structure container (context object) definition
-class xrtHandles : public pscontext {
+class xrtHandles : public xrt::pscontext {
  public:
   XAie_DevInst* aieDevInst = nullptr;
   xaiefal::XAieDev* aieDev = nullptr;

--- a/src/runtime_src/core/edge/ps_kernels/profiling/aie_profile_config/aie_profile_config.cpp
+++ b/src/runtime_src/core/edge/ps_kernels/profiling/aie_profile_config/aie_profile_config.cpp
@@ -19,7 +19,7 @@
 #include "xaiengine.h"
 
 #include "core/common/time.h"
-#include "core/edge/include/sk_types.h"
+#include "experimental/xrt_pscontext.h"
 #include "core/edge/common/aie_parser.h"
 #include "core/edge/user/shim.h"
 #include "xaiefal/xaiefal.hpp"
@@ -32,7 +32,7 @@ extern "C"{
 }
 
 // User private data structure container (context object) definition
-class xrtHandles : public pscontext
+class xrtHandles : public xrt::pscontext
 {
   public:
     XAie_DevInst* aieDevInst = nullptr;

--- a/src/runtime_src/core/edge/ps_kernels/profiling/aie_trace_config/aie_trace_config.cpp
+++ b/src/runtime_src/core/edge/ps_kernels/profiling/aie_trace_config/aie_trace_config.cpp
@@ -16,7 +16,7 @@
 #include <cstring>
 #include <vector>
 
-#include "core/edge/include/sk_types.h"
+#include "experimental/xrt_pscontext.h"
 #include "core/edge/user/shim.h"
 #include "event_configuration.h"
 #include "xaiefal/xaiefal.hpp"
@@ -25,7 +25,7 @@
 #include "xdp/profile/plugin/aie_trace/x86/aie_trace_kernel_config.h"
 
 // User private data structure container (context object) definition
-class xrtHandles : public pscontext {
+class xrtHandles : public xrt::pscontext {
  public:
   XAie_DevInst* aieDevInst = nullptr;
   xaiefal::XAieDev* aieDev = nullptr;

--- a/src/runtime_src/core/edge/ps_kernels/profiling/aie_trace_gmio/gmio_config_kernel.cpp
+++ b/src/runtime_src/core/edge/ps_kernels/profiling/aie_trace_gmio/gmio_config_kernel.cpp
@@ -20,7 +20,7 @@
 #include "core/edge/user/shim.h"
 #include "xdp/profile/database/static_info/aie_constructs.h"
 #include "xdp/profile/plugin/aie_trace/x86/aie_trace_kernel_config.h"
-#include "core/edge/include/sk_types.h"
+#include "experimental/xrt_pscontext.h"
 
 struct AIETraceGmioDMAInst{
   XAie_DmaDesc shimDmaInst;
@@ -28,7 +28,7 @@ struct AIETraceGmioDMAInst{
 };
 
 // User private data structure container (context object) definition
-class xrtHandles : public pscontext
+class xrtHandles : public xrt::pscontext
 {
   public:
     XAie_DevInst* aieDevInst = nullptr;

--- a/src/runtime_src/core/edge/ps_kernels/xrt/instance_query/instance_query.cpp
+++ b/src/runtime_src/core/edge/ps_kernels/xrt/instance_query/instance_query.cpp
@@ -21,10 +21,10 @@
 #include <boost/property_tree/ptree.hpp>
 namespace pt = boost::property_tree;
 
-#include "core/edge/include/sk_types.h"
+#include "experimental/xrt_pscontext.h"
 
 // User private data structure container (context object) definition
-class xrtHandles : public pscontext
+class xrtHandles : public xrt::pscontext
 {
 public:
 };

--- a/src/runtime_src/core/edge/ps_kernels/xrt/tests/validate/ps_aie_test/ps_aie.cpp
+++ b/src/runtime_src/core/edge/ps_kernels/xrt/tests/validate/ps_aie_test/ps_aie.cpp
@@ -2,7 +2,7 @@
 // Copyright (C) 2022 Xilinx, Inc
 // Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
 
-#include "core/edge/include/sk_types.h"
+#include "experimental/xrt_pscontext.h"
 #include <cstring>
 #include <fstream>
 #include <iostream>
@@ -22,7 +22,7 @@
 extern "C" {
 #endif
 
-class xrtHandles : public pscontext {
+class xrtHandles : public xrt::pscontext {
    public:
     xrt::device dhdl;
     xrt::graph graphhdl;

--- a/src/runtime_src/core/edge/ps_kernels/xrt/tests/validate/ps_bandwidth_test/ps_bandwidth.cpp
+++ b/src/runtime_src/core/edge/ps_kernels/xrt/tests/validate/ps_bandwidth_test/ps_bandwidth.cpp
@@ -20,10 +20,10 @@ constexpr unsigned long long int operator "" _Mi(unsigned long long int n) {
 #ifdef __cplusplus
 extern "C" {
 #endif
-#include "core/edge/include/sk_types.h"
+#include "experimental/xrt_pscontext.h"
 
 // User private data structure container (context object) definition
-class xrtHandles : public pscontext
+class xrtHandles : public xrt::pscontext
 {
 public:
   xrt::device dhdl;
@@ -36,7 +36,7 @@ public:
 };
 
   __attribute__((visibility("default")))
-  pscontext *bandwidth_kernel_init(xclDeviceHandle dhdl, const xuid_t xclbin_uuid) {
+  xrt::pscontext *bandwidth_kernel_init(xclDeviceHandle dhdl, const xuid_t xclbin_uuid) {
     xrtHandles *handles = new xrtHandles(dhdl, xclbin_uuid);
 
     return(handles);

--- a/src/runtime_src/core/edge/ps_kernels/xrt/tests/validate/ps_validate_test/ps_validate.cpp
+++ b/src/runtime_src/core/edge/ps_kernels/xrt/tests/validate/ps_validate_test/ps_validate.cpp
@@ -2,10 +2,10 @@
 
 #include <cstring>
 
-#include "core/edge/include/sk_types.h"
+#include "experimental/xrt_pscontext.h"
 
 // User private data structure container (context object) definition
-class xrtHandles : public pscontext
+class xrtHandles : public xrt::pscontext
 {
 public:
 };

--- a/src/runtime_src/core/edge/skd/xrt_skd.h
+++ b/src/runtime_src/core/edge/skd/xrt_skd.h
@@ -47,7 +47,7 @@
 #include "core/common/xclbin_parser.h"
 #include "ffi.h"
 #include "ps_kernel.h"
-#include "sk_types.h"
+#include "experimental/xrt_pscontext.h"
 #include "xclbin.h"
 #include "xclhal2_mpsoc.h"
 #include "xrt/xrt_device.h"
@@ -152,6 +152,9 @@ class skd
     int get_return_offset(const std::vector<xrt_core::xclbin::kernel_argument> &args) const;
     ffi_type* convert_to_ffitype(const xrt_core::xclbin::kernel_argument &arg) const;
 };
+
+typedef xrt::pscontext* (* kernel_init_t)(xclDeviceHandle device, const uuid_t &uuid);
+typedef int (* kernel_fini_t)(xrt::pscontext *xrtHandles);
 
 }
 

--- a/src/runtime_src/core/include/experimental/CMakeLists.txt
+++ b/src/runtime_src/core/include/experimental/CMakeLists.txt
@@ -19,6 +19,7 @@ set(XRT_EXPERIMENTAL_HEADER_SRC
   xrt_mailbox.h
   xrt_message.h
   xrt_module.h
+  xrt_pscontext.h
   xrt_profile.h
   xrt_queue.h
   xrt_system.h

--- a/src/runtime_src/core/include/experimental/xrt_pscontext.h
+++ b/src/runtime_src/core/include/experimental/xrt_pscontext.h
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+#ifndef XRT_PSCONTEXT_H_
+#define XRT_PSCONTEXT_H_
+
+#include "xrt/detail/config.h"
+#include "xrt/detail/pimpl.h"
+#include "xclhal2.h"
+
+#ifdef __cplusplus
+#include <memory>
+
+/*
+ * PS Context Data Structure included by user PS kernel code
+ */
+
+namespace xrt {
+
+class pscontext_impl;
+class pscontext : public detail::pimpl<pscontext_impl> {
+public:
+  pscontext() = default;
+};
+
+}
+ 
+#else
+# error xrt_pscontext is only implemented for C++
+#endif // __cplusplus
+
+#endif

--- a/src/runtime_src/core/include/experimental/xrt_pscontext.h
+++ b/src/runtime_src/core/include/experimental/xrt_pscontext.h
@@ -11,7 +11,29 @@
 #include <memory>
 
 /*
- * PS Context Data Structure included by user PS kernel code
+ * PS Context Data Structure to be derived from for user's xrtHandle class
+ * User will need to declare an xrtHandles class derived from xrt::pscontext class
+ * Example:
+ * class xrtHandles : public xrt::pscontext
+ * {
+ * public:
+ *   xrt::device dhdl;
+ *   xrt::kernel kernel;
+ *   xrtHandles(xclDeviceHandle dhdl_in, const xuid_t xclbin_uuid)
+ *     : dhdl(dhdl_in)
+ *     , kernel(dhdl,xclbin_uuid,"kernel name")
+ *   {
+ *   }
+ * };
+ *
+ * This xrtHandles is the return type for kernel_ini function.
+ * xrt::pscontext *kernel_init(xclDeviceHandle dhdl, const xuid_t xclbin_uuid) {
+ *   xrtHandles *handles = new xrtHandles(dhdl, xclbin_uuid);
+ *
+ *   return(handles);
+ * }
+ *
+ * 
  */
 
 namespace xrt {
@@ -20,6 +42,7 @@ class pscontext_impl;
 class pscontext : public detail::pimpl<pscontext_impl> {
 public:
   pscontext() = default;
+  virtual ~pscontext() {}
 };
 
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Moved pscontext class used in PS kernels to XRT's public include areas and under XRT namespace.
Header is now called xrt_pscontext.h, and sk_types.h should no longer be used.
Also updated all the current PS kernels under XRT repo to use this new header file.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit
All the existing PS kernel need to be updated to use the new pscontext class under XRT namespace

#### What has been tested and how, request additional testing if necessary
Tested on v70

#### Documentation impact (if any)
