### PR TITLE
Deprecate sk_types.h and move pscontext class to a separate file pscontext.h

### DIFF
--- a/src/runtime_src/core/edge/include/CMakeLists.txt
+++ b/src/runtime_src/core/edge/include/CMakeLists.txt
@@ -3,10 +3,11 @@
 #
 set(MPSOC_HEADER_SRC
   xclhal2_mpsoc.h
+  pscontext.h
   sk_types.h)
 
 install (FILES ${MPSOC_HEADER_SRC} DESTINATION ${XRT_INSTALL_INCLUDE_DIR})
 
 message("-- XRT header files for MPSoC only")
 message("-- xclhal2_mpsoc.h")
-message("-- sk_types.h")
+message("-- pscontext.h")

--- a/src/runtime_src/core/edge/include/pscontext.h
+++ b/src/runtime_src/core/edge/include/pscontext.h
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+
+#ifndef __PSCONTEXT_H_
+#define __PSCONTEXT_H_
+
+/*
+ * PS Context Data Structure included by user PS kernel code
+ */
+
+class pscontext {
+public:
+ pscontext()
+   : pimpl{std::make_shared<pscontext::impl>()} {}
+  virtual ~pscontext() {}
+ 
+protected:
+  struct impl;
+  std::shared_ptr<impl> pimpl;
+};
+
+struct pscontext::impl {
+private:
+  bool aie_profile_en;
+};
+
+#endif

--- a/src/runtime_src/core/edge/include/sk_types.h
+++ b/src/runtime_src/core/edge/include/sk_types.h
@@ -52,6 +52,10 @@ typedef int (* kernel_t)(void *args, struct sk_operations *ops);
 
 #pragma message ("sk_types.h is deprecated and will be removed from the distribution directory in a future release.  Please use pscontext.h instead.")
 
+/*
+ * Including pscontext.h for backward compatibility with 
+ * PS kernels that were using sk_types.h
+ */
 #include "pscontext.h"
 
 #endif

--- a/src/runtime_src/core/edge/include/sk_types.h
+++ b/src/runtime_src/core/edge/include/sk_types.h
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2019-2022 Xilinx, Inc
+ * Copyright (C) 2023 Advanced Micro Devices, Inc
  * Author(s): Min Ma	<min.ma@xilinx.com>
  *          : Larry Liu	<yliu@xilinx.com>
  *          : Jeff Lin	<jeffli@xilinx.com>
@@ -30,7 +31,8 @@
  * freeBO    : free BO handle.
  * logMsg    : send log messages to XRT driver for saving as per ini settings
  */
-struct sk_operations {
+struct XRT_DEPRECATED
+sk_operations {
   unsigned int (* getHostBO)(unsigned long paddr, size_t size);
   void *(* mapBO)(unsigned int boHandle, bool write);
   void (* freeBO)(unsigned int boHandle);
@@ -45,29 +47,11 @@ struct sk_operations {
  *       for soft kernel to run.
  * ops:  provide help functions for soft kernel to use.
  */
+XRT_DEPRECATED
 typedef int (* kernel_t)(void *args, struct sk_operations *ops);
 
-/*
- * PS Context Data Structure included by user PS kernel code
- */
+#pragma message ("sk_types.h is deprecated and will be removed from the distribution directory in a future release.  Please use pscontext.h instead.")
 
-class pscontext {
-public:
- pscontext()
-   : pimpl{std::make_shared<pscontext::impl>()} {}
-  virtual ~pscontext() {}
- 
-protected:
-  struct impl;
-  std::shared_ptr<impl> pimpl;
-};
-
-struct pscontext::impl {
-private:
-  bool aie_profile_en;
-};
-
-typedef pscontext* (* kernel_init_t)(xclDeviceHandle device, const uuid_t &uuid);
-typedef int (* kernel_fini_t)(pscontext *xrtHandles);
+#include "pscontext.h"
 
 #endif

--- a/src/runtime_src/core/edge/skd/xrt_skd.h
+++ b/src/runtime_src/core/edge/skd/xrt_skd.h
@@ -47,10 +47,13 @@
 #include "core/common/xclbin_parser.h"
 #include "ffi.h"
 #include "ps_kernel.h"
-#include "sk_types.h"
+#include "pscontext.h"
 #include "xclbin.h"
 #include "xclhal2_mpsoc.h"
 #include "xrt/xrt_device.h"
+
+typedef pscontext* (* kernel_init_t)(xclDeviceHandle device, const uuid_t &uuid);
+typedef int (* kernel_fini_t)(pscontext *xrtHandles);
 
 namespace xrt {
 


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Move pscontext class out of sk_types.h and make sk_types.h to be deprecated

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
