### PR TITLE
CR-1161534: Adjust profiling tables to not print out incorrect information in certain configurations

### DIFF
--- a/src/runtime_src/xdp/profile/writer/vp_base/summary_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/summary_writer.cpp
@@ -778,6 +778,7 @@ namespace xdp {
       db->getStats().getHostReads();
     if (hostReads.size() == 0)
       return;
+    bool printAverageBWUtilization = db->infoAvailable(info::device_offload);
 
     fout << "TITLE:Host Reads from Global Memory\n";
     fout << "SECTION:Host Data Transfers,Host Reads from Global Memory\n";
@@ -796,9 +797,11 @@ namespace xdp {
       fout << "COLUMN:<html>Transfer<br>Rate (MB/s)</html>,float,"
            << "Rate of host reads (in MB/s): "
            << "Transfer Rate = (Total Bytes) / (Total Time in us),\n";
-      fout << "COLUMN:<html>Average<br>Bandwidth<br>Utilization (%)</html>,"
-           << "float,Average bandwidth of host reads: "
-           << "Bandwidth Utilization (%) = (100 * Transfer Rate) / (Max. Theoretical Rate),\n";
+      if (printAverageBWUtilization) {
+        fout << "COLUMN:<html>Average<br>Bandwidth<br>Utilization (%)</html>,"
+             << "float,Average bandwidth of host reads: "
+             << "Bandwidth Utilization (%) = (100 * Transfer Rate) / (Max. Theoretical Rate),\n";
+      }
       fout << "COLUMN:<html>Maximum<br>Time (ms)</html>,float,"
            << "Maximum time of a single host read,\n";
       fout << "COLUMN:<html>Minimum<br>Time (ms)</html>,float,"
@@ -834,7 +837,8 @@ namespace xdp {
           aveBWUtil = one_hundred;
 
         fout << transferRate << ",";
-        fout << aveBWUtil << ",";
+        if (printAverageBWUtilization)
+          fout << aveBWUtil << ",";
         fout << (stats.maxTime / one_million) << ",";
         fout << (stats.minTime / one_million) << ",";
         fout << (stats.totalTime / one_million) << ",";
@@ -850,6 +854,7 @@ namespace xdp {
       db->getStats().getHostWrites();
     if (hostWrites.size() == 0)
       return;
+    bool printAverageBWUtilization = db->infoAvailable(info::device_offload);
 
     fout << "TITLE:Host Writes to Global Memory\n";
     fout << "SECTION:Host Data Transfers,Host Writes to Global Memory\n";
@@ -867,9 +872,11 @@ namespace xdp {
       fout << "COLUMN:<html>Transfer<br>Rate (MB/s)</html>,float,"
            << "Rate of host writes (in MB/s): "
            << "Transfer Rate = (Total Bytes) / (Total Time in us),\n";
-      fout << "COLUMN:<html>Average<br>Bandwidth<br>Utilization (%)</html>,"
-           << "float,Average bandwidth of host writes: "
-           << "Bandwidth Utilization (%) = (100 * Transfer Rate) / (Max. Theoretical Rate),\n";
+      if (printAverageBWUtilization) {
+        fout << "COLUMN:<html>Average<br>Bandwidth<br>Utilization (%)</html>,"
+             << "float,Average bandwidth of host writes: "
+             << "Bandwidth Utilization (%) = (100 * Transfer Rate) / (Max. Theoretical Rate),\n";
+      }
       fout << "COLUMN:<html>Maximum<br>Time (ms)</html>,float,"
            << "Maximum time of a single host write,\n";
       fout << "COLUMN:<html>Minimum<br>Time (ms)</html>,float,"
@@ -904,7 +911,8 @@ namespace xdp {
           aveBWUtil = one_hundred;
 
         fout << transferRate << ",";
-        fout << aveBWUtil << ",";
+        if (printAverageBWUtilization)
+          fout << aveBWUtil << ",";
         fout << (stats.maxTime / one_million) << ",";
         fout << (stats.minTime / one_million) << ",";
         fout << (stats.totalTime / one_million) << ",";


### PR DESCRIPTION
#### Problem solved by the commit
The profiling summary tables for host reads and host writes to global memory reports the average bandwidth utilization.  The calculation for the bandwidth utilization, however, relies on hardware information such as the maximum possible bandwidth utilization which can differ on different platforms.  The profiling library only has access to this specific hardware information if some type of profiling device offload is enabled (either device_counters=true or device_trace=true in the xrt.ini file).  In situations where the user just enabled host-level profiling information to be collected, profiling was reporting "0" for the average bandwidth utilization in this table, which was misleading.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
The bug was discovered by exhaustive testing of the xrt.ini option configurations and noticing that the number reported was incorrect.

#### How problem was solved, alternative solutions (if any) and why they were rejected
The profiling tables now only output the average bandwidth utilization if profiling has access to device level information.  As an alternative, we considered choosing a default value for the maximum possible bandwidth, but that would have caused problems as each platform has different bandwidth configurations and this information must be queried from the device.

#### Risks (if any) associated the changes in the commit
Low risk, as this only affects one row of two tables in the profiling report.

#### What has been tested and how, request additional testing if necessary
This was tested on a VCK190 design and the tables are now generated without the incorrect rows when device information is not available.

#### Documentation impact (if any)
Slight change to documentation of the tables that appear in Vitis Analyzer as specific entries may not appear in some run configurations.