### PR TITLE
CR-1169187 Disable all PS tests

### DIFF
--- a/tests/validate/ps_aie_test/src/host.cpp
+++ b/tests/validate/ps_aie_test/src/host.cpp
@@ -75,6 +75,8 @@ int main(int argc, char** argv) {
         return EXIT_FAILURE;
     }
 
+    return EOPNOTSUPP;
+
     auto num_devices = xrt::system::enumerate_devices();
 
     auto device = xrt::device {dev_id};

--- a/tests/validate/ps_bandwidth_test/src/host.cpp
+++ b/tests/validate/ps_bandwidth_test/src/host.cpp
@@ -72,6 +72,8 @@ int main(int argc, char** argv) {
         return EXIT_FAILURE;
     }
 
+    return EOPNOTSUPP;
+
     auto num_devices = xrt::system::enumerate_devices();
 
     auto device = xrt::device {dev_id};

--- a/tests/validate/ps_iops_test/CMakeLists.txt
+++ b/tests/validate/ps_iops_test/CMakeLists.txt
@@ -13,7 +13,7 @@ endif()
 if (NOT WIN32)
   include_directories(../common/includes/cmdparser ../common/includes/logger)
   add_executable(${TESTNAME} ../common/includes/cmdparser/cmdlineparser.cpp ../common/includes/logger/logger.cpp src/ps_iops.cpp)
-  target_link_libraries(${TESTNAME} PRIVATE ${uuid_LIBRARY} pthread ${xrt_coreutil_LIBRARY} ${xrt_core_LIBRARY})
+  target_link_libraries(${TESTNAME} PRIVATE ${uuid_LIBRARY} pthread ${xrt_coreutil_LIBRARY} ${xrt_core_LIBRARY} ${Boost_PROGRAM_OPTIONS_LIBRARY} ${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY})
   install(TARGETS ${TESTNAME}
     RUNTIME DESTINATION ${XRT_VALIDATE_DIR})
 endif(NOT WIN32)

--- a/tests/validate/ps_iops_test/src/ps_iops.cpp
+++ b/tests/validate/ps_iops_test/src/ps_iops.cpp
@@ -223,8 +223,6 @@ _main(int argc, char* argv[])
         return EXIT_FAILURE;
     }
 
-    return EOPNOTSUPP;
-
     /* Sanity check */
     // Validate dependency xclbins if any
     for (const auto& path : dependency_paths) {
@@ -258,6 +256,7 @@ _main(int argc, char* argv[])
 int
 main(int argc, char* argv[])
 {
+    return EOPNOTSUPP;
     try {
         _main(argc, argv);
         std::cout << "TEST PASSED" << std::endl;

--- a/tests/validate/ps_iops_test/src/ps_iops.cpp
+++ b/tests/validate/ps_iops_test/src/ps_iops.cpp
@@ -1,26 +1,14 @@
-/**
-* Copyright (C) 2022 Xilinx, Inc
-*
-* Licensed under the Apache License, Version 2.0 (the "License"). You may
-* not use this file except in compliance with the License. A copy of the
-* License is located at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-* License for the specific language governing permissions and limitations
-* under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2022 Xilinx, Inc
+// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+
+#include <boost/program_options.hpp>
 #include <chrono>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
 #include <thread>
 #include <vector>
-
-#include "cmdlineparser.h"
 
 #include "xilutil.hpp"
 #include "xrt/xrt_bo.h"
@@ -179,48 +167,78 @@ testMultiThreads(const std::string& dev, const std::string& xclbin_fn,
     return 0;
 }
 
+static int
+validate_binary_file(const std::string& binaryfile, bool print = false)
+{
+    std::ifstream infile(binaryfile);
+    if (!infile.good()) {
+        if (print)
+            std::cout << "\nNOT SUPPORTED" << std::endl;
+        return EOPNOTSUPP;
+    } else {
+        if (print)
+            std::cout << "\nSUPPORTED" << std::endl;
+        return EXIT_SUCCESS;
+    }
+}
+
 int
 _main(int argc, char* argv[])
 {
-    if (argc < 2) {
-        usage(argv[0]);
-        throw std::runtime_error("Number of argument should not less than 2");
-    }
-
-    // Command Line Parser
-    sda::utils::CmdLineParser parser;
-
-    // Switches
-    //**************
-    //"<Full Arg>",  "<Short Arg>", "<Description>", "<Default>"
-    parser.addSwitch("--kernel", "-k",
-                     "kernel (imply old style verify.xclbin is used)", "");
-    parser.addSwitch("--device", "-d", "device id", "0");
-    parser.addSwitch("--threads", "-t", "number of threads", "2");
-    parser.addSwitch("--length", "-l", "length of queue", "128");
-    parser.addSwitch("--total", "-a", "total amount of commands per thread",
-                     "50000");
-    parser.addSwitch("--verbose", "-v", "verbose output", "", true);
-    parser.parse(argc, argv);
-
     /* Could be BDF or device index */
-    std::string device_str = parser.value("device");
-    int threadNumber = parser.value_to_int("threads");
-    int queueLength = parser.value_to_int("length");
-    int total = parser.value_to_int("total");
-    std::string xclbin_fn = parser.value("kernel");
-    if (xclbin_fn.empty()) {
-        std::string test_path = argv[1];
-        xclbin_fn = test_path + "/ps_validate_bandwidth.xclbin";
-        krnl.name = "hello_world";
-        krnl.new_style = true;
+    std::string device_str;
+    std::string test_path;
+    bool flag_s;
+    int threadNumber;
+    int queueLength;
+    int total;
+    std::string xclbin_fn;
+    std::vector<std::string> dependency_paths;
+
+    boost::program_options::options_description options;
+    options.add_options()
+        ("help,h", "Print help messages")
+        ("xclbin,x", boost::program_options::value<decltype(xclbin_fn)>(&xclbin_fn)->implicit_value("/lib/firmware/xilinx/ps_kernels/ps_bandwidth.xclbin"), "Path to the xclbin file for the test")
+        ("path,p", boost::program_options::value<decltype(test_path)>(&test_path)->required(), "Path to the platform resources")
+        ("device,d", boost::program_options::value<decltype(device_str)>(&device_str)->required(), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest")
+        ("supported,s", boost::program_options::bool_switch(&flag_s), "Print supported or not")
+        ("include,i" , boost::program_options::value<decltype(dependency_paths)>(&dependency_paths)->multitoken(), "Paths to xclbins required for this test")
+        ("threads,t" , boost::program_options::value<decltype(threadNumber)>(&threadNumber)->default_value(2), "Number of threads to run within this test")
+        ("length,l" , boost::program_options::value<decltype(queueLength)>(&queueLength)->default_value(128), "Length of queue")
+        ("total,a" , boost::program_options::value<decltype(total)>(&total)->default_value(50000), "Total amount of commands per thread")
+        ("verbose,v", boost::program_options::bool_switch(&verbose)->default_value(false), "Enable verbose output")
+    ;
+
+    boost::program_options::variables_map vm;
+    try {
+        boost::program_options::store(boost::program_options::parse_command_line(argc, argv, options), vm);
+        if (vm.count("help")) {
+            std::cout << options << std::endl;
+            return EXIT_SUCCESS;
+        }
+        boost::program_options::notify(vm);
+    } catch (boost::program_options::error& e) {
+        std::cerr << "ERROR: " << e.what() << std::endl;
+        std::cout << options << std::endl;
+        return EXIT_FAILURE;
     }
-    verbose = parser.isValid("verbose");
+
+    return EOPNOTSUPP;
 
     /* Sanity check */
-    std::ifstream infile(xclbin_fn);
-    if (!infile.good())
-        throw std::runtime_error("Wrong xclbin file " + xclbin_fn);
+    // Validate dependency xclbins if any
+    for (const auto& path : dependency_paths) {
+        auto retVal = validate_binary_file(path);
+        if (retVal != EXIT_SUCCESS)
+            return retVal;
+    }
+
+    // Validate ps kernel
+    auto retVal = validate_binary_file(xclbin_fn, flag_s);
+    if (flag_s || retVal != EXIT_SUCCESS)
+        return retVal;
+
+    krnl.new_style = true;
 
     if (queueLength <= 0)
         throw std::runtime_error("Negative/Zero queue length");
@@ -231,6 +249,7 @@ _main(int argc, char* argv[])
     if (threadNumber <= 0)
         throw std::runtime_error("Invalid thread number");
 
+    // TODO need to add processing for dependency paths
     testMultiThreads(device_str, xclbin_fn, threadNumber, queueLength, total);
 
     return 0;

--- a/tests/validate/ps_validate_test/src/host.cpp
+++ b/tests/validate/ps_validate_test/src/host.cpp
@@ -61,6 +61,8 @@ int main(int argc, char** argv) {
         return EXIT_FAILURE;
     }
 
+    return EOPNOTSUPP;
+
     auto num_devices = xrt::system::enumerate_devices();
 
     auto device = xrt::device {dev_id};


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1169187?page=com.atlassian.jira.plugin.system.issuetabpanels%3Aall-tabpanel

The PS validate command fails on the ps-iops test as I forgot to update the test case. Additionally there is an issue loading multiple xclbins so I have disabled all ps tests until that is resolved.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
xbutil validate is failing for v70 base3 & base2 platforms. Introduced in https://github.com/Xilinx/XRT/pull/7624

#### How problem was solved, alternative solutions (if any) and why they were rejected
Update all PS testcases to return `Not Supported` error code.

#### Risks (if any) associated the changes in the commit
The tests will not work so no risks!

#### What has been tested and how, request additional testing if necessary
Ubuntu 22.04 vck5000
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ xbutil validate -d 17:00 --verbose
WARNING: Unexpected xocl version (2.14.0) was found. Expected 2.16.0, to match XRT tools.
Verbose: Enabling Verbosity
***********************************************************
*        WARNING          WARNING          WARNING        *
*       SC version data missing. Upgrade your shell       *
***********************************************************
Validate Device           : [0000:17:00.1]
    Platform              : xilinx_vck5000_gen4x8_qdma_base_2
    SC Version            : 4.4.35
    Platform ID           : 05DCA096-76CB-730B-8D19-EC1192FBAE3F
-------------------------------------------------------------------------------
Test 1 [0000:17:00.1]     : aux-connection

    Description           : Check if auxiliary power is connected
    Details               : Aux power connector is not available on this board
    Test Status           : [SKIPPED]
-------------------------------------------------------------------------------
Test 2 [0000:17:00.1]     : pcie-link
    Description           : Check if PCIE link is active
    Warning(s)            : Link is active
                            Please make sure that the device is plugged into Gen 4x8,
                            instead of Gen 3x8. Lower performance maybe experienced.
    Test Status           : [PASSED WITH WARNINGS]
-------------------------------------------------------------------------------
Test 3 [0000:17:00.1]     : sc-version
    Description           : Check if SC firmware is up-to-date
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Test 4 [0000:17:00.1]     : verify
    Description           : Run 'Hello World' kernel test
    Xclbin                : /opt/xilinx/firmware/vck5000/gen4x8-qdma/base/test
    Testcase              : /proj/rdi/staff/dbenusov/XRT/build/Debug/opt/xilinx/xrt/test/validate.exe
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Test 5 [0000:17:00.1]     : dma
    Description           : Run dma test
    Details               : Buffer size - '16 MB'
                            Host -> PCIe -> FPGA write bandwidth = 6586.8 MB/s
                            Host <- PCIe <- FPGA read bandwidth = 6626.3 MB/s
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Test 6 [0000:17:00.1]     : iops
    Description           : Run scheduler performance measure test
    Xclbin                : /opt/xilinx/firmware/vck5000/gen4x8-qdma/base/test
    Testcase              : /proj/rdi/staff/dbenusov/XRT/build/Debug/opt/xilinx/xrt/test/xcl_iops_test.exe
    Details               : IOPS: 400458 (verify)
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Test 7 [0000:17:00.1]     : mem-bw
    Description           : Run 'bandwidth kernel' and check the throughput
    Xclbin                : /opt/xilinx/firmware/vck5000/gen4x8-qdma/base/test
    Testcase              : /proj/rdi/staff/dbenusov/XRT/build/Debug/opt/xilinx/xrt/test/kernel_bw.exe
    Details               : Throughput (Type: DDR) (Bank count: 1) : 20980.2MB/s
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Test 8 [0000:17:00.1]     : p2p
    Description           : Run P2P test
    Details               : P2P config failed. P2P is not supported. Can't find P2P
                            BAR.
    Test Status           : [SKIPPED]
-------------------------------------------------------------------------------
Test 9 [0000:17:00.1]     : m2m

    Description           : Run M2M test
    Details               : M2M is not available
    Test Status           : [SKIPPED]
-------------------------------------------------------------------------------
Test 10 [0000:17:00.1]    : hostmem-bw

    Description           : Run 'bandwidth kernel' when host memory is enabled
    Details               : Host memory is not enabled
    Test Status           : [SKIPPED]
-------------------------------------------------------------------------------
Test 11 [0000:17:00.1]    : vcu
    Description           : Run decoder test
    Details               : /opt/xilinx/firmware/vck5000/gen4x8-qdma/base/test/transcode.xclbin
                            not available. Skipping validation.
                            Verify xclbin not available or shell partition is not
                            programmed. Skipping validation.
    Test Status           : [SKIPPED]
-------------------------------------------------------------------------------
Test 12 [0000:17:00.1]    : aie
    Description           : Run AIE PL test
    Xclbin                : /opt/xilinx/firmware/vck5000/gen4x8-qdma/base/test
    Testcase              : /proj/rdi/staff/dbenusov/XRT/build/Debug/opt/xilinx/xrt/test/aie_pl.exe
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Test 13 [0000:17:00.1]    : ps-aie

    Description           : Run PS controlled AIE test
    Xclbin                : /lib/firmware/xilinx/ps_kernels
    Testcase              : /proj/rdi/staff/dbenusov/XRT/build/Debug/opt/xilinx/xrt/test/ps_aie.exe
    Test Status           : [SKIPPED]
-------------------------------------------------------------------------------
Test 14 [0000:17:00.1]    : ps-pl-verify

    Description           : Run PS controlled 'Hello World' PL kernel test
    Xclbin                : /lib/firmware/xilinx/ps_kernels
    Testcase              : /proj/rdi/staff/dbenusov/XRT/build/Debug/opt/xilinx/xrt/test/ps_bandwidth.exe
    Test Status           : [SKIPPED]
-------------------------------------------------------------------------------
Test 15 [0000:17:00.1]    : ps-verify

    Description           : Run 'Hello World' PS kernel test
    Xclbin                : /lib/firmware/xilinx/ps_kernels
    Testcase              : /proj/rdi/staff/dbenusov/XRT/build/Debug/opt/xilinx/xrt/test/ps_validate.exe
    Test Status           : [SKIPPED]
-------------------------------------------------------------------------------
Test 16 [0000:17:00.1]    : ps-iops
    Description           : Run IOPS PS test
    Xclbin                : /lib/firmware/xilinx/ps_kernels
    Testcase              : /proj/rdi/staff/dbenusov/XRT/build/Debug/opt/xilinx/xrt/test/ps_iops_test.exe
    Test Status           : [SKIPPED]
-------------------------------------------------------------------------------
Validation completed, but with warnings
```

#### Documentation impact (if any)
