### PR TITLE
CR-1159280: Fixing profiling table to correctly associate argument with connection

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info/pl_constructs.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info/pl_constructs.cpp
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2021 Xilinx, Inc
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -45,6 +45,12 @@ namespace {
   static bool compare(const std::string& spTag, const std::string& memory)
   {
     if (spTag == memory)
+      return true;
+
+    // On platforms that have HOST bridge enabled, the spTag and memory
+    // are hardcoded to specific values that don't match the rest of the
+    // algorithm.
+    if (spTag == "HOST[0]" && memory == "HOST")
       return true;
 
     // On some platforms, the memory name is still formatted as "bank0"

--- a/src/runtime_src/xdp/profile/database/static_info/xclbin_info.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info/xclbin_info.cpp
@@ -43,6 +43,19 @@ namespace xdp {
     }
   }
 
+  std::vector<ComputeUnitInstance*>
+  PLInfo::collectCUs(const std::string& kernelName)
+  {
+    std::vector<ComputeUnitInstance*> collected;
+
+    for (auto& iter : cus) {
+      auto instance = iter.second;
+      if (instance->getKernelName() == kernelName)
+        collected.push_back(instance);
+    }
+    return collected;
+  }
+
   void PLInfo::addComputeUnitPorts(const std::string& kernelName,
                                    const std::string& portName,
                                    int32_t portWidth)
@@ -65,7 +78,7 @@ namespace xdp {
     }
   }
 
-  void PLInfo::connectArgToMemory(const std::string& kernelName,
+  void PLInfo::connectArgToMemory(const std::string& cuName,
                                   const std::string& portName,
                                   const std::string& argName,
                                   int32_t memId)
@@ -76,7 +89,7 @@ namespace xdp {
     Memory* mem = memoryInfo[memId];
     for (const auto& iter : cus) {
       auto cu = iter.second;
-      if (cu->getKernelName() == kernelName)
+      if (cu->getName() == cuName)
         cu->connectArgToMemory(portName, argName, mem);
     }
   }

--- a/src/runtime_src/xdp/profile/database/static_info/xclbin_info.h
+++ b/src/runtime_src/xdp/profile/database/static_info/xclbin_info.h
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2021 Xilinx, Inc
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -95,10 +95,12 @@ namespace xdp {
     void addArgToPort(const std::string& kernelName,
                       const std::string& argName,
                       const std::string& portName);
-    void connectArgToMemory(const std::string& kernelName,
+    void connectArgToMemory(const std::string& cuName,
                             const std::string& portName,
                             const std::string& argName,
                             int32_t memId);
+    // Collect all compute units of a kernel
+    std::vector<ComputeUnitInstance*> collectCUs(const std::string& kernelName);
   } ;
 
   // The AIEInfo struct keeps track of all of the information associated

--- a/src/runtime_src/xdp/profile/database/static_info_database.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info_database.cpp
@@ -1406,8 +1406,9 @@ namespace xdp {
       auto xclbin = top.get_child("xclbin");
       auto user_regions = xclbin.get_child("user_regions");
 
-      // Temp data structure to hold mappings
-      std::map<std::string, int32_t> argumentToMemoryIndex;
+      // Temp data structures to hold mappings of each CU's argument to memory
+      typedef std::pair<std::string, std::string> fullName;
+      std::map<fullName, int32_t> argumentToMemoryIndex;
 
       // We also need to know which argument goes to which memory
       for (auto& region : user_regions) {
@@ -1416,10 +1417,17 @@ namespace xdp {
           auto node2 = connection.second.get_child("node2");
 
           auto arg = node1.get<std::string>("arg_name");
+          auto cuId = node1.get<std::string>("id");
           auto id = node2.get<std::string>("id");
+          std::string cuName = "";
+
+          if (cuId != "") {
+            int cuIdInt = std::stoi(cuId);
+            cuName = currentXclbin->pl.cus[cuIdInt]->getName();
+          }
 
           if (id != "" && arg != "")
-            argumentToMemoryIndex[arg] = std::stoi(id);
+            argumentToMemoryIndex[{cuName, arg}] = std::stoi(id);
         }
       }
 
@@ -1452,13 +1460,22 @@ namespace xdp {
             std::transform(portName.begin(), portName.end(), portName.begin(),
                            tolower);
             auto argName = arg.second.get<std::string>("name");
-            if (argumentToMemoryIndex.find(argName) == argumentToMemoryIndex.end())
-              continue; // Skip streams not connected to memory
-            auto memId = argumentToMemoryIndex[argName];
 
+            // All of the compute units have the same mapping of arguments
+            // to ports.
             currentXclbin->pl.addArgToPort(kernelName, argName, portName);
-            currentXclbin->pl.connectArgToMemory(kernelName, portName,
-                                                 argName, memId);
+
+            // Go through all of the compute units for this kernel
+            auto cus = currentXclbin->pl.collectCUs(kernelName);
+            for (auto cu : cus) {
+	      std::string cuName = cu->getName();
+              if (argumentToMemoryIndex.find({cuName, argName}) == argumentToMemoryIndex.end())
+                continue; // Skip streams not connected to memory
+              auto memId = argumentToMemoryIndex[{cuName, argName}];
+
+              currentXclbin->pl.connectArgToMemory(cuName, portName,
+                                                   argName, memId);
+            }
           }
         }
       }


### PR DESCRIPTION
#### Problem solved by the commit
Profiling tables that report data movement between kernels and memory report the original kernel arguments associated with the connection.  With connections to host memory via host bridge, this association was not correctly made and the tables had empty entries.  Additionally, if multiple kernels were present in a design and had arguments with the same name, they were incorrectly being reported as attached to the wrong memory component.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
The issue was discovered through comprehensive regression testing.

#### How problem was solved, alternative solutions (if any) and why they were rejected
This change explicitly adds a check for host bridge connections.  Additionally, it changes the argument to memory mapping data structure to make the connection on a compute unit basis rather than a kernel basis, so multiple kernels with identical named arguments don't overwrite each other.

#### Risks (if any) associated the changes in the commit
Low risk as this should only affect information reported in a single table.

#### What has been tested and how, request additional testing if necessary
Tested on original failing test case.

#### Documentation impact (if any)
No documentation impact