### PR TITLE
Templatize internal utility aligned_alloc

### DIFF
--- a/src/runtime_src/core/common/AlignedAllocator.h
+++ b/src/runtime_src/core/common/AlignedAllocator.h
@@ -24,30 +24,32 @@
 
 namespace xrt_core {
 
-  // Memory alignment for DDR and AXI-MM trace access
-  template <typename T> class AlignedAllocator {
-      void *mBuffer;
-      size_t mCount;
-  public:
-      T *getBuffer() {
-          return (T *)mBuffer;
-      }
+// Memory alignment for DDR and AXI-MM trace access
+template <typename T>
+class AlignedAllocator
+{
+  void *mBuffer;
+  size_t mCount;
+public:
+  T *getBuffer() {
+    return (T *)mBuffer;
+  }
 
-      size_t size() const {
-          return mCount * sizeof(T);
-      }
+  size_t size() const {
+    return mCount * sizeof(T);
+  }
 
-      AlignedAllocator(size_t alignment, size_t count) : mBuffer(0), mCount(count) {
-        if (xrt_core::posix_memalign(&mBuffer, alignment, count * sizeof(T))) {
-              mBuffer = 0;
-          }
-      }
-      ~AlignedAllocator() {
-        if (mBuffer) {
-          xrt_core::aligned_ptr_deleter pDel;
-          pDel(mBuffer);
-        }
-      }
-  };
+  AlignedAllocator(size_t alignment, size_t count) : mBuffer(0), mCount(count) {
+    if (xrt_core::posix_memalign(&mBuffer, alignment, count * sizeof(T))) {
+      mBuffer = 0;
+    }
+  }
+  ~AlignedAllocator() {
+    if (mBuffer) {
+      xrt_core::detail::aligned_ptr_deleter<void> pDel;
+      pDel(mBuffer);
+    }
+  }
+};
 }
 #endif


### PR DESCRIPTION
#### Problem solved by the commit
Make aligned alloc return managed ptr of specified type.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Preserve existing usage of default void and exposed deleter, but hide the deleter for specified types.
Feels like this could be more elegant with better use of C++ features.
