### PR TITLE
Vitis-8819 First-class execution buffer basic elf support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma"]
 	path = src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma
 	url = https://github.com/Xilinx/dma_ip_drivers.git
+[submodule "src/runtime_src/core/common/elf"]
+	path = src/runtime_src/core/common/elf
+	url = https://github.com/serge1/ELFIO.git

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,8 @@
-All userspace code authored by Xilinx is released under the following license:
+All userspace code authored by Xilinx or Advanced Micro Devices is
+released under the following license:
 
-Copyright (C) 2016-2020 Xilinx, Inc
+Copyright (C) 2016-2022 Xilinx, Inc
+Copyright (C) 2022-2023 Advanced Micro Devices, Inc
 
 Licensed under the Apache License, Version 2.0 (the "License"). You may
 not use this file except in compliance with the License. A copy of the
@@ -17,7 +19,8 @@ under the License.
 All Linux kernel driver code included in "xocl" or "xclmgmt" authored by
 Xilinx is released under the terms of GNU General Public License version 2:
 
-Copyright (C) 2016-2020 Xilinx, Inc. All rights reserved.
+Copyright (C) 2016-2022 Xilinx, Inc. All rights reserved.
+Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
 
 This software is licensed under the terms of the GNU General Public
 License version 2, as published by the Free Software Foundation, and
@@ -35,6 +38,7 @@ or alternatively under the terms of the GNU General Public License
 version 2:
 
 Copyright (C) 2016-2020 Xilinx, Inc. All rights reserved.
+Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
 
 This software is licensed under the terms of the GNU General Public
 License version 2, as published by the Free Software Foundation, and

--- a/NOTICE
+++ b/NOTICE
@@ -56,3 +56,27 @@ XRT userspace includes software from Khronos Group Inc.
    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
    TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
    MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+XRT userspace includes software developed by Serge Lamikhov-Center (MIT)
+MIT License
+
+Copyright (C) 2001-present by Serge Lamikhov-Center
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+

--- a/build/build_edge.sh
+++ b/build/build_edge.sh
@@ -49,7 +49,7 @@ install_recipes()
         echo 'EXTERNALSRC_BUILD = "${WORKDIR}/build"' >> $XRT_BB
         echo 'PACKAGE_CLASSES = "package_rpm"' >> $XRT_BB
         echo 'LICENSE = "GPLv2 & Apache-2.0"' >> $XRT_BB
-        echo 'LIC_FILES_CHKSUM = "file://../LICENSE;md5=da5408f748bce8a9851dac18e66f4bcf \' >> $XRT_BB
+        echo 'LIC_FILES_CHKSUM = "file://../LICENSE;md5=de2c993ac479f02575bcbfb14ef9b485 \' >> $XRT_BB
         echo '                    file://runtime_src/core/edge/drm/zocl/LICENSE;md5=7d040f51aae6ac6208de74e88a3795f8 "' >> $XRT_BB
     fi
 

--- a/src/runtime_src/core/common/api/CMakeLists.txt
+++ b/src/runtime_src/core/common/api/CMakeLists.txt
@@ -31,4 +31,5 @@ endif()
 target_include_directories(core_common_api_library_objects
   PRIVATE
   ${XRT_SOURCE_DIR}/runtime_src
+  ${XRT_SOURCE_DIR}/runtime_src/core/common/elf
   )

--- a/src/runtime_src/core/common/api/elf_int.h
+++ b/src/runtime_src/core/common/api/elf_int.h
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+#ifndef _XRT_COMMON_ELF_INT_H_
+#define _XRT_COMMON_ELF_INT_H_
+
+// This file defines implementation extensions to the XRT ELF APIs.
+#include "core/include/experimental/xrt_elf.h"
+#include <cstdint>
+#include <string>
+#include <vector>
+
+// Provide access to xrt::elf data that is not directly exposed
+// to end users via xrt::elf.   These functions are used by
+// XRT core implementation.
+namespace xrt_core { namespace elf_int {
+
+// Extract section data from ELF file
+std::vector<uint8_t>
+get_section(const xrt::elf& elf, const std::string& sname);
+
+}} // xclbin_int, xrt_core
+
+#endif

--- a/src/runtime_src/core/common/api/xrt_elf.cpp
+++ b/src/runtime_src/core/common/api/xrt_elf.cpp
@@ -4,24 +4,46 @@
 #define XRT_API_SOURCE         // exporting xrt_elf.h
 #define XRT_CORE_COMMON_SOURCE // in same dll as core_common
 #include "experimental/xrt_elf.h"
-
 #include "xrt/xrt_uuid.h"
 
+#include "elf_int.h"
 #include "core/common/error.h"
+
+#include <elfio/elfio.hpp>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
 
 namespace xrt {
 
 // class elf_impl - Implementation
 class elf_impl
 {
+  ELFIO::elfio m_elf;
 public:
-  elf_impl(const std::string&)
-  {}
+  elf_impl(const std::string& fnm)
+  {
+    if (!m_elf.load(fnm))
+      throw std::runtime_error(fnm + " is not found or is not a valid ELF file");
+  }
 
   xrt::uuid
   get_cfg_uuid() const
   {
     return {}; // tbd
+  }
+
+  std::vector<uint8_t>
+  get_section(const std::string& sname)
+  {
+    auto sec = m_elf.sections[sname];
+    if (!sec)
+      throw std::runtime_error("Failed to find section: " + sname);
+
+    auto data = sec->get_data();
+    std::vector<uint8_t> vec(data, data + sec->get_size());
+    return vec;
   }
 };
 
@@ -31,6 +53,13 @@ public:
 // XRT implmentation access to internal elf APIs
 ////////////////////////////////////////////////////////////////
 namespace xrt_core::elf_int {
+
+// Extract section data from ELF file
+std::vector<uint8_t>
+get_section(const xrt::elf& elf, const std::string& sname)
+{
+  return elf.get_handle()->get_section(sname);
+}
 
 } // xrt_core::elf_int
 


### PR DESCRIPTION
#### Problem solved by the commit
- Add ELFIO submodule for basic elf parsing.
- Extract instruction buffer from assembled elf object.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Add https://github.com/serge1/ELFIO as submodule.  Fix at Release_3.11.

Modify xrt::module to leverage ELFIO in extracting ctrltext section from elf.

