### PR TITLE
Fixed a issue where same client requested multiple times

### DIFF
--- a/src/runtime_src/core/common/drv/include/kds_client.h
+++ b/src/runtime_src/core/common/drv/include/kds_client.h
@@ -73,6 +73,7 @@ struct kds_client_cu_refcnt {
  */
 struct kds_client {
 	struct list_head	  link;
+	u32                       client_refcnt;
 	struct device	         *dev;
 	struct pid	         *pid;
 	struct mutex		  lock;

--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -1102,6 +1102,8 @@ int kds_init_client(struct kds_sched *kds, struct kds_client *client)
 	}
 
 	client->pid = get_pid(task_pid(current));
+	/* Initialize the Client reference count */
+	client->client_refcnt = 0;
 	mutex_init(&client->lock);
 	mutex_init(&client->refcnt->lock);
 	init_waitqueue_head(&client->waitq);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
-- There is a issue where same client requested the XRT driver multiple time. 
-- In our XRT driver we haven't any check before creating a client or destroying a client. 
-- In this PR I have added such checks based on the PID. If same PID is requested then it just increase a reference count and return, While deleting if the reference count is "0" then only it will cleanup that client. 
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
