### PR TITLE
CR-1170195: Fixing issue with seg fault in AIE status/profiling/trace

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info_database.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info_database.cpp
@@ -1409,6 +1409,18 @@ namespace xdp {
       // Temp data structures to hold mappings of each CU's argument to memory
       typedef std::pair<std::string, std::string> fullName;
       std::map<fullName, int32_t> argumentToMemoryIndex;
+      std::map<int, std::string> computeUnitIdToName;
+
+      // Keep track of all the compute unit names associated with the id
+      // number so we can make the connection later.
+      for (auto& region : user_regions) {
+        for (auto& compute_unit : region.second.get_child("compute_units")) {
+          auto id = compute_unit.second.get<std::string>("id");
+          auto cuName = compute_unit.second.get<std::string>("cu_name");
+          auto idAsInt = std::stoi(id);
+          computeUnitIdToName[idAsInt] = cuName;
+        }
+      }
 
       // We also need to know which argument goes to which memory
       for (auto& region : user_regions) {
@@ -1422,8 +1434,8 @@ namespace xdp {
           std::string cuName = "";
 
           if (cuId != "") {
-            int cuIdInt = std::stoi(cuId);
-            cuName = currentXclbin->pl.cus[cuIdInt]->getName();
+            int cuIdAsInt = std::stoi(cuId);
+            cuName = computeUnitIdToName[cuIdAsInt];
           }
 
           if (id != "" && arg != "")


### PR DESCRIPTION
#### Problem solved by the commit
Processing the system_metadata section in profiling was crashing on designs that had PL kernels and AIE kernels.  This was because newly introduced code was based on the faulty assumption that only PL kernels and compute units were listed in the specific system_metadata sections that PL profiling was dependent on.  On designs that have AIE kernels in addition to PL kernels, we were going outside the bounds of our internal array.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
This bug was introduced in pull request 7640 and it was discovered with testing on AIE designs.

#### How problem was solved, alternative solutions (if any) and why they were rejected
This pull request no longer accesses the problematic array, but instead creates a local map of compute unit ID to compute unit name based solely on the information in the system_metadata section. 

#### Risks (if any) associated the changes in the commit
Low risk as this fixes the seg fault and still maintains the functionality, but is dependent on the system metadata section format.

#### What has been tested and how, request additional testing if necessary
This has been tested on a mixed AIE + PL design on vek280 and a PL only design on the u200.

#### Documentation impact (if any)
No documentation impact.