### PR TITLE
Moving to 2023.1 petalinux

### DIFF
--- a/build/petalinux.build
+++ b/build/petalinux.build
@@ -1,3 +1,3 @@
 # When updating Petalinux build please file a SH ticket to retain the build
 # https://jira.xilinx.com/secure/CreateIssue!default.jspa
-PETALINUX="/proj/petalinux/2023.2/petalinux-v2023.2_07181252/tool/petalinux-v2023.2-final"
+PETALINUX="/proj/petalinux/2023.1/petalinux-v2023.1_05012318/tool/petalinux-v2023.1-final"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
With Petalinux 2023.2, APU pkg is not coming up so downgrading petalinux for now.
https://jira.xilinx.com/browse/SH-2262 to retain this TA
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit
Low
#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
NA