### PR TITLE
EDGEML-5898 Search windows PATH for xbutil directory to find loader

### DIFF
--- a/src/runtime_src/core/tools/xbutil2/xbutil.bat
+++ b/src/runtime_src/core/tools/xbutil2/xbutil.bat
@@ -28,9 +28,20 @@ set XRTWRAP_PROG_ARGS=
   :argsParsed
 
 
-REM -- Find and call the loader
-set XRT_LOADER=%~dp0unwrapped/loader.bat
+REM -- Find the loader from the current directory. If it exists.
+set XRT_LOADER=%~dp0unwrapped\loader.bat
 
+REM -- Find loader from the PATH. If it exists.
+FOR /F "tokens=* USEBACKQ" %%F IN (`where xbutil`) DO (
+set XBUTIL_PATH=%%~dpF
+)
+
+REM -- If the loader is not found in the current directory use the PATH.
+if not exist %XRT_LOADER%  (
+  set XRT_LOADER=%XBUTIL_PATH%unwrapped\loader.bat
+)
+
+REM -- Loader is not within the current directory or PATH. All hope is lost.
 if not exist %XRT_LOADER%  (
   echo ERROR: Could not find 64-bit loader executable.
   echo ERROR: %XRT_LOADER% does not exist.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
The Windows loader script fails to find the loader even if XRT is on the PATH.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
The script improperly formats the path to the loader and does not attempt to check the PATH. It only references the directory from which `xbutil` was invoked.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added logic to check the PATH for `xbutil` and use the result to find the loader script.

#### Risks (if any) associated the changes in the commit
None. It didn't work before and it works now.

#### What has been tested and how, request additional testing if necessary
// Not on Path not in Directory
```
Z:\XRT-MCDM\build\WDebug>echo %PATH%
C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\Windows\System32\OpenSSH\;C:\Program Files (x86)\Windows Kits\10\Windows Performance Toolkit\;C:\Users\Administrator\AppData\Local\Microsoft\WindowsApps;Z:\XRT-MCDM\build\WDebug\xilinx\xrt\ext\bin;Z:\remotedebug;

Z:\XRT-MCDM\build\WDebug>xbutil examine
'xbutil' is not recognized as an internal or external command,
operable program or batch file.
```

// Not on Path but in Directory
```
Z:\XRT-MCDM\build\WDebug\xilinx\xrt>echo %PATH%
C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\Windows\System32\OpenSSH\;C:\Program Files (x86)\Windows Kits\10\Windows Performance Toolkit\;C:\Users\Administrator\AppData\Local\Microsoft\WindowsApps;Z:\XRT-MCDM\build\WDebug\xilinx\xrt\ext\bin;Z:\remotedebug;

Z:\XRT-MCDM\build\WDebug\xilinx\xrt>xbutil examine
System Configuration
  OS Name              : Windows NT
  Release              : 25871.rs_onecore_sigma_grfx_dev.230522-1700
  Version              : 6.3
  Machine              : x86_64
  CPU Cores            : 1
  Memory               : 1669 MB
  Distribution         : Windows Server 2022 Standard
  Model                : Virtual Machine

XRT
  Version              : 2.16.0
  Branch               : HEAD
  Hash                 : ae1b2dbcf1230a002e15ea6942c1d48d797ad40f
  Hash Date            : 2023-08-02 14:41:04

Devices present
BDF             :  Shell  Logic UUID  Device ID     Device Ready*
-------------------------------------------------------------------
[0000:18:00.1]  :  IPU    0x0         mgmt(inst=1)  Yes


* Devices that are not ready will have reduced functionality when using XRT tools
```

// On Path not in Directory
```
Z:\XRT-MCDM\build\WDebug\xilinx>xbutil examine
System Configuration
  OS Name              : Windows NT
  Release              : 25871.rs_onecore_sigma_grfx_dev.230522-1700
  Version              : 6.3
  Machine              : x86_64
  CPU Cores            : 1
  Memory               : 1669 MB
  Distribution         : Windows Server 2022 Standard
  Model                : Virtual Machine

XRT
  Version              : 2.16.0
  Branch               : HEAD
  Hash                 : ae1b2dbcf1230a002e15ea6942c1d48d797ad40f
  Hash Date            : 2023-08-02 14:41:04

Devices present
BDF             :  Shell  Logic UUID  Device ID     Device Ready*
-------------------------------------------------------------------
[0000:18:00.1]  :  IPU    0x0         mgmt(inst=1)  Yes


* Devices that are not ready will have reduced functionality when using XRT tools
```

// On Path and in Directory
```
Z:\XRT-MCDM\build\WDebug\xilinx\xrt>echo %PATH%
Z:\XRT-MCDM\build\WDebug\xilinx\xrt\;Z:\XRT-MCDM\build\WDebug\xilinx\xrt\\ext\bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\Windows\System32\OpenSSH\;C:\Program Files (x86)\Windows Kits\10\Windows Performance Toolkit\;C:\Users\Administrator\AppData\Local\Microsoft\WindowsApps;Z:\XRT-MCDM\build\WDebug\xilinx\xrt;Z:\XRT-MCDM\build\WDebug\xilinx\xrt\ext\bin;Z:\remotedebug;

Z:\XRT-MCDM\build\WDebug\xilinx\xrt>xbutil examine
System Configuration
  OS Name              : Windows NT
  Release              : 25871.rs_onecore_sigma_grfx_dev.230522-1700
  Version              : 6.3
  Machine              : x86_64
  CPU Cores            : 1
  Memory               : 1669 MB
  Distribution         : Windows Server 2022 Standard
  Model                : Virtual Machine

XRT
  Version              : 2.16.0
  Branch               : HEAD
  Hash                 : ae1b2dbcf1230a002e15ea6942c1d48d797ad40f
  Hash Date            : 2023-08-02 14:41:04

Devices present
BDF             :  Shell  Logic UUID  Device ID     Device Ready*
-------------------------------------------------------------------
[0000:18:00.1]  :  IPU    0x0         mgmt(inst=1)  Yes


* Devices that are not ready will have reduced functionality when using XRT tools
```

// Not on Path not in Directory with Setup.bat executed
```
Z:\XRT-MCDM\build\WDebug\xilinx\xrt>setup.bat
XILINX_XRT      : Z:\XRT-MCDM\build\WDebug\xilinx\xrt\
PATH            : Z:\XRT-MCDM\build\WDebug\xilinx\xrt\;Z:\XRT-MCDM\build\WDebug\xilinx\xrt\\ext\bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\Windows\System32\OpenSSH\;C:\Program Files (x86)\Windows Kits\10\Windows Performance Toolkit\;C:\Users\Administrator\AppData\Local\Microsoft\WindowsApps;Z:\XRT-MCDM\build\WDebug\xilinx\xrt\ext\bin;Z:\remotedebug;

Z:\XRT-MCDM\build\WDebug\xilinx\xrt>cd ..

Z:\XRT-MCDM\build\WDebug\xilinx>cd ..

Z:\XRT-MCDM\build\WDebug>echo %PATH%
Z:\XRT-MCDM\build\WDebug\xilinx\xrt\;Z:\XRT-MCDM\build\WDebug\xilinx\xrt\\ext\bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\Windows\System32\OpenSSH\;C:\Program Files (x86)\Windows Kits\10\Windows Performance Toolkit\;C:\Users\Administrator\AppData\Local\Microsoft\WindowsApps;Z:\XRT-MCDM\build\WDebug\xilinx\xrt\ext\bin;Z:\remotedebug;

Z:\XRT-MCDM\build\WDebug>xbutil examine
System Configuration
  OS Name              : Windows NT
  Release              : 25871.rs_onecore_sigma_grfx_dev.230522-1700
  Version              : 6.3
  Machine              : x86_64
  CPU Cores            : 1
  Memory               : 1669 MB
  Distribution         : Windows Server 2022 Standard
  Model                : Virtual Machine

XRT
  Version              : 2.16.0
  Branch               : HEAD
  Hash                 : ae1b2dbcf1230a002e15ea6942c1d48d797ad40f
  Hash Date            : 2023-08-02 14:41:04

Devices present
BDF             :  Shell  Logic UUID  Device ID     Device Ready*
-------------------------------------------------------------------
[0000:18:00.1]  :  IPU    0x0         mgmt(inst=1)  Yes


* Devices that are not ready will have reduced functionality when using XRT tools
```

#### Documentation impact (if any)
None