### PR TITLE
CR-1170456 PS tests improperly parsed within XRT

### DIFF
--- a/tests/validate/ps_aie_test/src/host.cpp
+++ b/tests/validate/ps_aie_test/src/host.cpp
@@ -75,6 +75,7 @@ int main(int argc, char** argv) {
         return EXIT_FAILURE;
     }
 
+    std::cout << "\nNOT SUPPORTED" << std::endl;
     return EOPNOTSUPP;
 
     auto num_devices = xrt::system::enumerate_devices();

--- a/tests/validate/ps_bandwidth_test/src/host.cpp
+++ b/tests/validate/ps_bandwidth_test/src/host.cpp
@@ -72,6 +72,7 @@ int main(int argc, char** argv) {
         return EXIT_FAILURE;
     }
 
+    std::cout << "\nNOT SUPPORTED" << std::endl;
     return EOPNOTSUPP;
 
     auto num_devices = xrt::system::enumerate_devices();

--- a/tests/validate/ps_iops_test/src/ps_iops.cpp
+++ b/tests/validate/ps_iops_test/src/ps_iops.cpp
@@ -256,6 +256,7 @@ _main(int argc, char* argv[])
 int
 main(int argc, char* argv[])
 {
+    std::cout << "\nNOT SUPPORTED" << std::endl;
     return EOPNOTSUPP;
     try {
         _main(argc, argv);

--- a/tests/validate/ps_validate_test/src/host.cpp
+++ b/tests/validate/ps_validate_test/src/host.cpp
@@ -61,6 +61,7 @@ int main(int argc, char** argv) {
         return EXIT_FAILURE;
     }
 
+    std::cout << "\nNOT SUPPORTED" << std::endl;
     return EOPNOTSUPP;
 
     auto num_devices = xrt::system::enumerate_devices();


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Running 'xbutil validate' on latest 2023.2 based V70PQ2 Base2 packages with latest XRT/APU 2.16.162 packages installed, it's fails for all PS kernel tests on CentOs.

Although other operating systems are not affected, this is a coincidence.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Tests are improperly skipped for PS additions. Introduced in https://github.com/Xilinx/XRT/pull/7639.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Add NOT SUPPORTED print out to all ps tests.

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
```
bash-4.2$ cat /etc/os-release
NAME="CentOS Linux"
VERSION="7 (Core)"
ID="centos"
ID_LIKE="rhel fedora"
VERSION_ID="7"
PRETTY_NAME="CentOS Linux 7 (Core)"
ANSI_COLOR="0;31"
CPE_NAME="cpe:/o:centos:centos:7"
HOME_URL="https://www.centos.org/"
BUG_REPORT_URL="https://bugs.centos.org/"

CENTOS_MANTISBT_PROJECT="CentOS-7"
CENTOS_MANTISBT_PROJECT_VERSION="7"
REDHAT_SUPPORT_PRODUCT="centos"
REDHAT_SUPPORT_PRODUCT_VERSION="7"
bash-4.2$ whoami
dbenusov
bash-4.2$ hostname
xniengxbb35


bash-4.2$ xbutil validate -d c1:00 -r ps-aie
WARNING: Unexpected xocl version (2.16.173) was found. Expected 2.16.0, to match XRT tools.
Validate Device           : [0000:c1:00.1]
    Platform              : xilinx_v70pq2_gen5x8_qdma_base_2
    SC Version            : 8.5.2
    Platform ID           : 2A79840E-59FC-B193-76BE-AA7DC3FD08BE
-------------------------------------------------------------------------------
Verbose: Enabling Verbosity
Test 1 [0000:c1:00.1]     : ps-aie
    Description           : Run PS controlled AIE test
    Xclbin                : /lib/firmware/xilinx/ps_kernels
    Testcase              : /scratch/dbenusov/XRT/build/Debug/opt/xilinx/xrt/test/ps_aie.exe
    Test Status           : [SKIPPED]
-------------------------------------------------------------------------------
Validation failed
bash-4.2$ xbutil validate -d c1:00 -r ps-verify
WARNING: Unexpected xocl version (2.16.173) was found. Expected 2.16.0, to match XRT tools.
Validate Device           : [0000:c1:00.1]
    Platform              : xilinx_v70pq2_gen5x8_qdma_base_2
    SC Version            : 8.5.2
    Platform ID           : 2A79840E-59FC-B193-76BE-AA7DC3FD08BE
-------------------------------------------------------------------------------
Verbose: Enabling Verbosity
Test 1 [0000:c1:00.1]     : ps-verify
    Description           : Run 'Hello World' PS kernel test
    Xclbin                : /lib/firmware/xilinx/ps_kernels
    Testcase              : /scratch/dbenusov/XRT/build/Debug/opt/xilinx/xrt/test/ps_validate.exe
    Test Status           : [SKIPPED]
-------------------------------------------------------------------------------
Validation failed
bash-4.2$ xbutil validate -d c1:00 -r ps-iops
WARNING: Unexpected xocl version (2.16.173) was found. Expected 2.16.0, to match XRT tools.
Validate Device           : [0000:c1:00.1]
    Platform              : xilinx_v70pq2_gen5x8_qdma_base_2
    SC Version            : 8.5.2
    Platform ID           : 2A79840E-59FC-B193-76BE-AA7DC3FD08BE
-------------------------------------------------------------------------------
Verbose: Enabling Verbosity
Test 1 [0000:c1:00.1]     : ps-iops
    Description           : Run IOPS PS test
    Xclbin                : /lib/firmware/xilinx/ps_kernels
    Testcase              : /scratch/dbenusov/XRT/build/Debug/opt/xilinx/xrt/test/ps_iops_test.exe
    Test Status           : [SKIPPED]
-------------------------------------------------------------------------------
Validation failed
bash-4.2$ xbutil validate -d c1:00 -r ps-pl-verify
WARNING: Unexpected xocl version (2.16.173) was found. Expected 2.16.0, to match XRT tools.
Validate Device           : [0000:c1:00.1]
    Platform              : xilinx_v70pq2_gen5x8_qdma_base_2
    SC Version            : 8.5.2
    Platform ID           : 2A79840E-59FC-B193-76BE-AA7DC3FD08BE
-------------------------------------------------------------------------------
Verbose: Enabling Verbosity
Test 1 [0000:c1:00.1]     : ps-pl-verify
    Description           : Run PS controlled 'Hello World' PL kernel test
    Xclbin                : /lib/firmware/xilinx/ps_kernels
    Testcase              : /scratch/dbenusov/XRT/build/Debug/opt/xilinx/xrt/test/ps_bandwidth.exe
    Test Status           : [SKIPPED]
-------------------------------------------------------------------------------
Validation failed
```

Full Validation test
```
bash-4.2$ xbutil validate -d c1:00
WARNING: Unexpected xocl version (2.16.173) was found. Expected 2.16.0, to match XRT tools.
Validate Device           : [0000:c1:00.1]
    Platform              : xilinx_v70pq2_gen5x8_qdma_base_2
    SC Version            : 8.5.2
    Platform ID           : 2A79840E-59FC-B193-76BE-AA7DC3FD08BE
-------------------------------------------------------------------------------
Test 1 [0000:c1:00.1]     : pcie-link
    Warning(s)            : Link is active
                            Please make sure that the device is plugged into Gen 5x8,
                            instead of Gen 4x8. Lower performance maybe experienced.
    Test Status           : [PASSED WITH WARNINGS]
-------------------------------------------------------------------------------
Test 2 [0000:c1:00.1]     : sc-version
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Test 3 [0000:c1:00.1]     : verify
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Test 4 [0000:c1:00.1]     : dma
    Details               : Buffer size - '16 MB'
                            Host -> PCIe -> FPGA write bandwidth = 13458.8 MB/s
                            Host <- PCIe <- FPGA read bandwidth = 14044.0 MB/s
                            Buffer size - '16 MB'
                            Host -> PCIe -> FPGA write bandwidth = 11273.5 MB/s
                            Host <- PCIe <- FPGA read bandwidth = 12929.5 MB/s
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Test 5 [0000:c1:00.1]     : iops
    Details               : IOPS: 361545 (verify)
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Test 6 [0000:c1:00.1]     : mem-bw
    Details               : Throughput (Type: DDR) (Bank count: 2) : 25361.4MB/s
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Test 7 [0000:c1:00.1]     : p2p
Test 8 [0000:c1:00.1]     : vcu
Test 9 [0000:c1:00.1]     : aie
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Test 10 [0000:c1:00.1]    : ps-aie
Test 11 [0000:c1:00.1]    : ps-pl-verify
Test 12 [0000:c1:00.1]    : ps-verify
Test 13 [0000:c1:00.1]    : ps-iops
Validation completed, but with warnings. Please run the command '--verbose' option for more details
bash-4.2$ echo $?
0
```
#### Documentation impact (if any)
None