### PR TITLE
driver plug-in should support non-DRM based device node

### DIFF
--- a/src/runtime_src/core/pcie/linux/pcidev.cpp
+++ b/src/runtime_src/core/pcie/linux/pcidev.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2016-2020, 2023 Xilinx, Inc
+// Copyright (C) 2016-2020 Xilinx, Inc
 // Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
 #include "pcidev.h"
 #include "pcidrv.h"

--- a/src/runtime_src/core/pcie/linux/pcidev.cpp
+++ b/src/runtime_src/core/pcie/linux/pcidev.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2016-2020 Xilinx, Inc
-// Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2016-2020, 2023 Xilinx, Inc
+// Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
 #include "pcidev.h"
 #include "pcidrv.h"
 #include "xclbin.h"
@@ -26,7 +26,6 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-#define RENDER_NM       "renderD"
 #define DEV_TIMEOUT	90 // seconds
 
 namespace {
@@ -105,7 +104,7 @@ bar_size(const std::string &dir, unsigned bar)
 }
 
 static int
-get_render_value(const std::string& dir)
+get_render_value(const std::string& dir, const std::string& devnode_prefix)
 {
   struct dirent *entry;
   DIR *dp;
@@ -116,8 +115,9 @@ get_render_value(const std::string& dir)
     return instance_num;
 
   while ((entry = readdir(dp))) {
-    if(strncmp(entry->d_name, RENDER_NM, sizeof (RENDER_NM) - 1) == 0) {
-      sscanf(entry->d_name, RENDER_NM "%d", &instance_num);
+    std::string dirname{entry->d_name};
+    if(dirname.compare(0, devnode_prefix.size(), devnode_prefix) == 0) {
+      instance_num = std::stoi(dirname.substr(devnode_prefix.size()));
       break;
     }
   }
@@ -419,11 +419,8 @@ get_subdev_path(const std::string& subdev, uint idx) const
   // Main devfs path
   if (subdev.empty()) {
     std::string instStr = std::to_string(m_instance);
-    if (m_is_mgmt) {
-      std::string prefixStr = "/dev/xclmgmt";
-      return prefixStr + instStr;
-    }
-    std::string prefixStr = "/dev/dri/" RENDER_NM;
+    std::string prefixStr = "/dev/";
+    prefixStr += m_driver.dev_node_dir() + "/" + m_driver.dev_node_prefix();
     return prefixStr + instStr;
   }
 
@@ -458,7 +455,7 @@ open(const std::string& subdev, int flag) const
 }
 
 dev::
-dev(const drv& driver, const std::string& sysfs) : m_sysfs_name(sysfs)
+dev(const drv& driver, const std::string& sysfs) : m_sysfs_name(sysfs), m_driver(driver)
 {
   std::string err;
 
@@ -467,10 +464,13 @@ dev(const drv& driver, const std::string& sysfs) : m_sysfs_name(sysfs)
 
   m_is_mgmt = !driver.is_user();
 
-  if (m_is_mgmt)
+  if (m_is_mgmt) {
     sysfs_get("", "instance", err, m_instance, static_cast<uint32_t>(INVALID_ID));
-  else
-    m_instance = get_render_value(sysfs::dev_root + sysfs + "/drm");
+  } else {
+    m_instance = get_render_value(
+      sysfs::dev_root + sysfs + "/" + driver.sysfs_dev_node_dir(),
+      driver.dev_node_prefix());
+  }
 
   sysfs_get<int>("", "userbar", err, m_user_bar, 0);
   m_user_bar_size = bar_size(sysfs::dev_root + sysfs, m_user_bar);

--- a/src/runtime_src/core/pcie/linux/pcidev.h
+++ b/src/runtime_src/core/pcie/linux/pcidev.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2016-2020, 2023 Xilinx, Inc
+// Copyright (C) 2016-2020 Xilinx, Inc
 // Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
 #ifndef _XCL_PCIDEV_H_
 #define _XCL_PCIDEV_H_

--- a/src/runtime_src/core/pcie/linux/pcidev.h
+++ b/src/runtime_src/core/pcie/linux/pcidev.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2016-2020 Xilinx, Inc
-// Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2016-2020, 2023 Xilinx, Inc
+// Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
 #ifndef _XCL_PCIDEV_H_
 #define _XCL_PCIDEV_H_
 
@@ -189,6 +189,8 @@ private:
 
   std::mutex m_lock;
   char *m_user_bar_map = reinterpret_cast<char *>(MAP_FAILED);
+
+  const drv& m_driver;
 };
 
 size_t

--- a/src/runtime_src/core/pcie/linux/pcidrv.h
+++ b/src/runtime_src/core/pcie/linux/pcidrv.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
 
 #ifndef _XCL_PCIDRV_H_
 #define _XCL_PCIDRV_H_
@@ -19,6 +19,21 @@ public:
   // If device runs user work load, it is a user pf
   virtual bool
   is_user() const = 0;
+
+  // Prefix of the name of the device node.
+  // E.g., "xclmgmt" as in /dev/xclmgmtxxxxx for Alveo mgmt pcie functions
+  virtual std::string
+  dev_node_prefix() const = 0;
+
+  // Directory name of the device node.
+  // E.g., "dri" as in /dev/dri/renderDxxx for Alveo user pcie functions
+  virtual std::string
+  dev_node_dir() const = 0;
+
+  // Sysfs directory name for the dev node.
+  // E.g., "drm" as in /sys/bus/pci/devices/0000\:61\:00.1/drm
+  virtual std::string
+  sysfs_dev_node_dir() const = 0;
 
   // Scan system, find all supported devices and add them to the list
   void

--- a/src/runtime_src/core/pcie/linux/pcidrv_xclmgmt.h
+++ b/src/runtime_src/core/pcie/linux/pcidrv_xclmgmt.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
 
 #ifndef _XCL_PCIDRV_XCLMGMT_H_
 #define _XCL_PCIDRV_XCLMGMT_H_
@@ -17,6 +17,15 @@ public:
 
   bool
   is_user() const override { return false; }
+
+  std::string
+  dev_node_prefix() const override { return name(); }
+
+  std::string
+  dev_node_dir() const override { return ""; }
+
+  std::string
+  sysfs_dev_node_dir() const override { return ""; }
 };
 
 } } // namespace xrt_core :: pci

--- a/src/runtime_src/core/pcie/linux/pcidrv_xocl.h
+++ b/src/runtime_src/core/pcie/linux/pcidrv_xocl.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
 
 #ifndef _XCL_PCIDRV_XOCL_H_
 #define _XCL_PCIDRV_XOCL_H_
@@ -17,6 +17,15 @@ public:
 
   bool
   is_user() const override { return true; }
+
+  std::string
+  dev_node_prefix() const override { return "renderD"; }
+
+  std::string
+  dev_node_dir() const override { return "dri"; }
+
+  std::string
+  sysfs_dev_node_dir() const override { return "drm"; }
 };
 
 } } // namespace xrt_core :: pci


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
In the future, the driver plug-in will need to support:
- user driver which is under Accel (vs DRM) framework, hence has a different device node path
- mgmt driver which is not called xclmgmt, hence has a different device node path

This pull request makes changes in driver plug-in to make it more flexible for the device node path / name.
