### PR TITLE
Add support for LSP for use by emacs/eglot

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,2 @@
+CompileFlags:
+  CompilationDatabase: build/Debug

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,7 @@
+{
+  "extraPaths": [
+      "src/python",
+      "src/python/pybind11/src",
+      "build/Debug/opt/xilinx/xrt/python"
+  ]
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Language server protocol configuration for clangd and pyright for use with IDEs like emacs/eglot, etc.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
NA

#### How problem was solved, alternative solutions (if any) and why they were rejected
Add configuration files for the LSPs so they can resolve all symbols, includes, etc. and give code suggestions.

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Tested code completion and code analysis with eglot built into Emacs 29.1

#### Documentation impact (if any)
