### PR TITLE
Add missing xrtErrorModule enums

### DIFF
--- a/src/runtime_src/core/common/api/xrt_error.cpp
+++ b/src/runtime_src/core/common/api/xrt_error.cpp
@@ -112,6 +112,8 @@ error_module_to_string(xrtErrorModule err)
     {XRT_ERROR_MODULE_AIE_CORE,   "MODULE_AIE_CORE"},
     {XRT_ERROR_MODULE_AIE_MEMORY, "MODULE_AIE_MEMORY"},
     {XRT_ERROR_MODULE_AIE_SHIM,   "MODULE_AIE_SHIM"},
+    {XRT_ERROR_MODULE_AIE_NOC,    "MODULE_AIE_NOC"},
+    {XRT_ERROR_MODULE_AIE_PL,     "MODULE_AIE_PL"},
   };
 
   return code_to_string(map, err, "Unknown error module");


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Added missing xrtErrorModule enums to module_to_string
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
N/A
#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit
N/A
#### What has been tested and how, request additional testing if necessary
Tested and verified using xrtErrorGetLast
#### Documentation impact (if any)
