### PR TITLE
CR-1172341 XRT Test Code fails with 202320.2.16.175 packages

### DIFF
--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -2110,7 +2110,7 @@ public:
     , core_device(kernel->get_core_device())
     , cmd(std::make_shared<kernel_command>(kernel->get_device(), m_hwqueue, kernel->get_hw_context()))
     , data(initialize_command(cmd.get()))
-    , m_header(cmd->get_ert_packet()->header)
+    , m_header(0)
     , uid(create_uid())
   {
     XRT_DEBUGF("run_impl::run_impl(%d)\n" , uid);
@@ -2307,6 +2307,12 @@ public:
     encode_compute_units();
 
     auto pkt = cmd->get_ert_packet();
+
+    // Very first start() of this run object caches the command header
+    if (!m_header)
+      m_header = pkt->header;
+
+    // The cached command header is used for all subsequent starts
     pkt->header = m_header;
     pkt->state = ERT_CMD_STATE_NEW;
 


### PR DESCRIPTION
#### Problem solved by the commit
Move caching of command header to the very first start() of a run object.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
In #7608 the internally initialized ert command header is cached as part of a run object.  The caching is done for repeated invocation of same run object to reset the header to a known good initial state. However, caching during construction of the run object is to early for some use cases where the header is changed in the host code to support legacy command opcodes.

#### How problem was solved, alternative solutions (if any) and why they were rejected
This PR fixes the problem by delaying caching until the very first invocation of xrt::run::start().  This allows for host code to manipulate the underlying command packet, which is necessary for support of legacy ERT_EXEC_WRITE.

#### Risks (if any) associated the changes in the commit
No risk, affects only existing failing use cases where command packet is manipulated in host code prior to first xrt::run invocation.  Repeated use of same xrt::run object must not change the command header after first invocation.

