### PR TITLE
Fixed CR-1160856 : Fixed driver crash for CTRL_NONE protocol CUs

### DIFF
--- a/src/runtime_src/core/common/drv/xrt_cu.c
+++ b/src/runtime_src/core/common/drv/xrt_cu.c
@@ -665,6 +665,10 @@ void xrt_cu_hpq_submit(struct xrt_cu *xcu, struct kds_command *xcmd)
 {
 	unsigned long flags;
 
+	/* For CTRL_NONE hpq doesn't exists. Hence return from here */
+	if (xcu->info.protocol == CTRL_NONE)
+		return;
+
 	/* This high priority queue is designed to handle those hight priority
 	 * but low frequency commands. Like abort command.
 	 */


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
-- In this design there are HLS and NONE both protocol exists. 
-- If user is sending a ABORT command, then KDS broadcast it to HPQ of all the existing CUs. But for CTRL_NONE protocol there is no HPQ exists. Hence driver is crashing. 
-- Added a check in before submitting to HPQ for CTRL_NONE protocol. 

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
