### PR TITLE
Updates to Profiling/Trace PS kernels

### DIFF
--- a/src/runtime_src/core/edge/include/pscontext.h
+++ b/src/runtime_src/core/edge/include/pscontext.h
@@ -4,6 +4,8 @@
 #ifndef __PSCONTEXT_H_
 #define __PSCONTEXT_H_
 
+#include <memory> 
+
 /*
  * PS Context Data Structure included by user PS kernel code
  */

--- a/src/runtime_src/core/edge/ps_kernels/profiling/aie2_profile_config/profile_event_configuration.h
+++ b/src/runtime_src/core/edge/ps_kernels/profiling/aie2_profile_config/profile_event_configuration.h
@@ -45,123 +45,249 @@ struct EventConfiguration {
   void initialize()
   {
     mCounterBases = {{xdp::module_type::core, 0},
-                     {xdp::module_type::dma, BASE_MEMORY_COUNTER},
-                     {xdp::module_type::shim, BASE_SHIM_COUNTER},
-                     {xdp::module_type::mem_tile, BASE_MEM_TILE_COUNTER}};
+      {xdp::module_type::dma, BASE_MEMORY_COUNTER},
+      {xdp::module_type::shim, BASE_SHIM_COUNTER},
+      {xdp::module_type::mem_tile, BASE_MEM_TILE_COUNTER}
+    };
 
     mCoreStartEvents = {
-        {xdp::built_in::CoreMetrics::HEAT_MAP,
-         {XAIE_EVENT_ACTIVE_CORE, XAIE_EVENT_GROUP_CORE_STALL_CORE, XAIE_EVENT_INSTR_VECTOR_CORE,
-          XAIE_EVENT_GROUP_CORE_PROGRAM_FLOW_CORE}},
-        {xdp::built_in::CoreMetrics::STALLS,
-         {XAIE_EVENT_MEMORY_STALL_CORE, XAIE_EVENT_STREAM_STALL_CORE, XAIE_EVENT_LOCK_STALL_CORE,
-          XAIE_EVENT_CASCADE_STALL_CORE}},
-        {xdp::built_in::CoreMetrics::EXECUTION,
-         {XAIE_EVENT_INSTR_VECTOR_CORE, XAIE_EVENT_INSTR_LOAD_CORE, XAIE_EVENT_INSTR_STORE_CORE,
-          XAIE_EVENT_GROUP_CORE_PROGRAM_FLOW_CORE}},
-        {xdp::built_in::CoreMetrics::FLOATING_POINT,
-         {XAIE_EVENT_FP_HUGE_CORE, XAIE_EVENT_INT_FP_0_CORE, XAIE_EVENT_FP_INVALID_CORE, XAIE_EVENT_FP_INF_CORE}},
-        {xdp::built_in::CoreMetrics::STREAM_PUT_GET,
-         {XAIE_EVENT_INSTR_CASCADE_GET_CORE, XAIE_EVENT_INSTR_CASCADE_PUT_CORE, XAIE_EVENT_INSTR_STREAM_GET_CORE,
-          XAIE_EVENT_INSTR_STREAM_PUT_CORE}},
-        {xdp::built_in::CoreMetrics::WRITE_BANDWIDTHS,
-         {XAIE_EVENT_ACTIVE_CORE, XAIE_EVENT_INSTR_STREAM_PUT_CORE, XAIE_EVENT_INSTR_CASCADE_PUT_CORE,
-          XAIE_EVENT_GROUP_CORE_STALL_CORE}},
-        {xdp::built_in::CoreMetrics::READ_BANDWIDTHS,
-         {XAIE_EVENT_ACTIVE_CORE, XAIE_EVENT_INSTR_STREAM_GET_CORE, XAIE_EVENT_INSTR_CASCADE_GET_CORE,
-          XAIE_EVENT_GROUP_CORE_STALL_CORE}},
-        {xdp::built_in::CoreMetrics::AIE_TRACE,
-         {XAIE_EVENT_PORT_RUNNING_1_CORE, XAIE_EVENT_PORT_STALLED_1_CORE, XAIE_EVENT_PORT_RUNNING_0_CORE,
-          XAIE_EVENT_PORT_STALLED_0_CORE}},
-        {xdp::built_in::CoreMetrics::EVENTS,
-         {XAIE_EVENT_INSTR_EVENT_0_CORE, XAIE_EVENT_INSTR_EVENT_1_CORE, XAIE_EVENT_USER_EVENT_0_CORE,
-          XAIE_EVENT_USER_EVENT_1_CORE}}};
-    mCoreEndEvents = {{xdp::built_in::CoreMetrics::HEAT_MAP,
-                       {XAIE_EVENT_ACTIVE_CORE, XAIE_EVENT_GROUP_CORE_STALL_CORE, XAIE_EVENT_INSTR_VECTOR_CORE,
-                        XAIE_EVENT_GROUP_CORE_PROGRAM_FLOW_CORE}},
-                      {xdp::built_in::CoreMetrics::STALLS,
-                       {XAIE_EVENT_MEMORY_STALL_CORE, XAIE_EVENT_STREAM_STALL_CORE, XAIE_EVENT_LOCK_STALL_CORE,
-                        XAIE_EVENT_CASCADE_STALL_CORE}},
-                      {xdp::built_in::CoreMetrics::EXECUTION,
-                       {XAIE_EVENT_INSTR_VECTOR_CORE, XAIE_EVENT_INSTR_LOAD_CORE, XAIE_EVENT_INSTR_STORE_CORE,
-                        XAIE_EVENT_GROUP_CORE_PROGRAM_FLOW_CORE}},
-                      {xdp::built_in::CoreMetrics::FLOATING_POINT,
-                       {XAIE_EVENT_FP_OVERFLOW_CORE, XAIE_EVENT_FP_UNDERFLOW_CORE, XAIE_EVENT_FP_INVALID_CORE,
-                        XAIE_EVENT_FP_DIV_BY_ZERO_CORE}},
-                      {xdp::built_in::CoreMetrics::STREAM_PUT_GET,
-                       {XAIE_EVENT_INSTR_CASCADE_GET_CORE, XAIE_EVENT_INSTR_CASCADE_PUT_CORE,
-                        XAIE_EVENT_INSTR_STREAM_GET_CORE, XAIE_EVENT_INSTR_STREAM_PUT_CORE}},
-                      {xdp::built_in::CoreMetrics::WRITE_BANDWIDTHS,
-                       {XAIE_EVENT_ACTIVE_CORE, XAIE_EVENT_INSTR_STREAM_PUT_CORE, XAIE_EVENT_INSTR_CASCADE_PUT_CORE,
-                        XAIE_EVENT_GROUP_CORE_STALL_CORE}},
-                      {xdp::built_in::CoreMetrics::READ_BANDWIDTHS,
-                       {XAIE_EVENT_ACTIVE_CORE, XAIE_EVENT_INSTR_STREAM_GET_CORE, XAIE_EVENT_INSTR_CASCADE_GET_CORE,
-                        XAIE_EVENT_GROUP_CORE_STALL_CORE}},
-                      {xdp::built_in::CoreMetrics::AIE_TRACE,
-                       {XAIE_EVENT_PORT_RUNNING_1_CORE, XAIE_EVENT_PORT_STALLED_1_CORE, XAIE_EVENT_PORT_RUNNING_0_CORE,
-                        XAIE_EVENT_PORT_STALLED_0_CORE}},
-                      {xdp::built_in::CoreMetrics::EVENTS,
-                       {XAIE_EVENT_INSTR_EVENT_0_CORE, XAIE_EVENT_INSTR_EVENT_1_CORE, XAIE_EVENT_USER_EVENT_0_CORE,
-                        XAIE_EVENT_USER_EVENT_1_CORE}}};
+      {
+        xdp::built_in::CoreMetrics::HEAT_MAP,
+        {
+          XAIE_EVENT_ACTIVE_CORE, XAIE_EVENT_GROUP_CORE_STALL_CORE, XAIE_EVENT_INSTR_VECTOR_CORE,
+          XAIE_EVENT_GROUP_CORE_PROGRAM_FLOW_CORE
+        }
+      },
+      {
+        xdp::built_in::CoreMetrics::STALLS,
+        {
+          XAIE_EVENT_MEMORY_STALL_CORE, XAIE_EVENT_STREAM_STALL_CORE, XAIE_EVENT_LOCK_STALL_CORE,
+          XAIE_EVENT_CASCADE_STALL_CORE
+        }
+      },
+      {
+        xdp::built_in::CoreMetrics::EXECUTION,
+        {
+          XAIE_EVENT_INSTR_VECTOR_CORE, XAIE_EVENT_INSTR_LOAD_CORE, XAIE_EVENT_INSTR_STORE_CORE,
+          XAIE_EVENT_GROUP_CORE_PROGRAM_FLOW_CORE
+        }
+      },
+      {
+        xdp::built_in::CoreMetrics::FLOATING_POINT,
+        {XAIE_EVENT_FP_HUGE_CORE, XAIE_EVENT_INT_FP_0_CORE, XAIE_EVENT_FP_INVALID_CORE, XAIE_EVENT_FP_INF_CORE}
+      },
+      {
+        xdp::built_in::CoreMetrics::STREAM_PUT_GET,
+        {
+          XAIE_EVENT_INSTR_CASCADE_GET_CORE, XAIE_EVENT_INSTR_CASCADE_PUT_CORE, XAIE_EVENT_INSTR_STREAM_GET_CORE,
+          XAIE_EVENT_INSTR_STREAM_PUT_CORE
+        }
+      },
+      {
+        xdp::built_in::CoreMetrics::WRITE_BANDWIDTHS,
+        {
+          XAIE_EVENT_ACTIVE_CORE, XAIE_EVENT_INSTR_STREAM_PUT_CORE, XAIE_EVENT_INSTR_CASCADE_PUT_CORE,
+          XAIE_EVENT_GROUP_CORE_STALL_CORE
+        }
+      },
+      {
+        xdp::built_in::CoreMetrics::READ_BANDWIDTHS,
+        {
+          XAIE_EVENT_ACTIVE_CORE, XAIE_EVENT_INSTR_STREAM_GET_CORE, XAIE_EVENT_INSTR_CASCADE_GET_CORE,
+          XAIE_EVENT_GROUP_CORE_STALL_CORE
+        }
+      },
+      {
+        xdp::built_in::CoreMetrics::AIE_TRACE,
+        {
+          XAIE_EVENT_PORT_RUNNING_1_CORE, XAIE_EVENT_PORT_STALLED_1_CORE, XAIE_EVENT_PORT_RUNNING_0_CORE,
+          XAIE_EVENT_PORT_STALLED_0_CORE
+        }
+      },
+      {
+        xdp::built_in::CoreMetrics::EVENTS,
+        {
+          XAIE_EVENT_INSTR_EVENT_0_CORE, XAIE_EVENT_INSTR_EVENT_1_CORE, XAIE_EVENT_USER_EVENT_0_CORE,
+          XAIE_EVENT_USER_EVENT_1_CORE
+        }
+      }
+    };
+    mCoreEndEvents = {{
+        xdp::built_in::CoreMetrics::HEAT_MAP,
+        {
+          XAIE_EVENT_ACTIVE_CORE, XAIE_EVENT_GROUP_CORE_STALL_CORE, XAIE_EVENT_INSTR_VECTOR_CORE,
+          XAIE_EVENT_GROUP_CORE_PROGRAM_FLOW_CORE
+        }
+      },
+      {
+        xdp::built_in::CoreMetrics::STALLS,
+        {
+          XAIE_EVENT_MEMORY_STALL_CORE, XAIE_EVENT_STREAM_STALL_CORE, XAIE_EVENT_LOCK_STALL_CORE,
+          XAIE_EVENT_CASCADE_STALL_CORE
+        }
+      },
+      {
+        xdp::built_in::CoreMetrics::EXECUTION,
+        {
+          XAIE_EVENT_INSTR_VECTOR_CORE, XAIE_EVENT_INSTR_LOAD_CORE, XAIE_EVENT_INSTR_STORE_CORE,
+          XAIE_EVENT_GROUP_CORE_PROGRAM_FLOW_CORE
+        }
+      },
+      {
+        xdp::built_in::CoreMetrics::FLOATING_POINT,
+        {
+          XAIE_EVENT_FP_OVERFLOW_CORE, XAIE_EVENT_FP_UNDERFLOW_CORE, XAIE_EVENT_FP_INVALID_CORE,
+          XAIE_EVENT_FP_DIV_BY_ZERO_CORE
+        }
+      },
+      {
+        xdp::built_in::CoreMetrics::STREAM_PUT_GET,
+        {
+          XAIE_EVENT_INSTR_CASCADE_GET_CORE, XAIE_EVENT_INSTR_CASCADE_PUT_CORE,
+          XAIE_EVENT_INSTR_STREAM_GET_CORE, XAIE_EVENT_INSTR_STREAM_PUT_CORE
+        }
+      },
+      {
+        xdp::built_in::CoreMetrics::WRITE_BANDWIDTHS,
+        {
+          XAIE_EVENT_ACTIVE_CORE, XAIE_EVENT_INSTR_STREAM_PUT_CORE, XAIE_EVENT_INSTR_CASCADE_PUT_CORE,
+          XAIE_EVENT_GROUP_CORE_STALL_CORE
+        }
+      },
+      {
+        xdp::built_in::CoreMetrics::READ_BANDWIDTHS,
+        {
+          XAIE_EVENT_ACTIVE_CORE, XAIE_EVENT_INSTR_STREAM_GET_CORE, XAIE_EVENT_INSTR_CASCADE_GET_CORE,
+          XAIE_EVENT_GROUP_CORE_STALL_CORE
+        }
+      },
+      {
+        xdp::built_in::CoreMetrics::AIE_TRACE,
+        {
+          XAIE_EVENT_PORT_RUNNING_1_CORE, XAIE_EVENT_PORT_STALLED_1_CORE, XAIE_EVENT_PORT_RUNNING_0_CORE,
+          XAIE_EVENT_PORT_STALLED_0_CORE
+        }
+      },
+      {
+        xdp::built_in::CoreMetrics::EVENTS,
+        {
+          XAIE_EVENT_INSTR_EVENT_0_CORE, XAIE_EVENT_INSTR_EVENT_1_CORE, XAIE_EVENT_USER_EVENT_0_CORE,
+          XAIE_EVENT_USER_EVENT_1_CORE
+        }
+      }
+    };
 
     // **** Memory Module Counters ****
     mMemoryStartEvents = {
-        {xdp::built_in::MemoryMetrics::CONFLICTS, {XAIE_EVENT_GROUP_MEMORY_CONFLICT_MEM, XAIE_EVENT_GROUP_ERRORS_MEM}},
-        {xdp::built_in::MemoryMetrics::DMA_LOCKS, {XAIE_EVENT_GROUP_DMA_ACTIVITY_MEM, XAIE_EVENT_GROUP_LOCK_MEM}},
-        {xdp::built_in::MemoryMetrics::DMA_STALLS_S2MM,
-         {XAIE_EVENT_DMA_S2MM_0_STALLED_LOCK_MEM, XAIE_EVENT_DMA_S2MM_1_STALLED_LOCK_MEM}},
-        {xdp::built_in::MemoryMetrics::DMA_STALLS_MM2S,
-         {XAIE_EVENT_DMA_MM2S_0_STALLED_LOCK_MEM, XAIE_EVENT_DMA_MM2S_1_STALLED_LOCK_MEM}},
-        {xdp::built_in::MemoryMetrics::WRITE_BANDWIDTHS,
-         {XAIE_EVENT_DMA_S2MM_0_FINISHED_BD_MEM, XAIE_EVENT_DMA_S2MM_1_FINISHED_BD_MEM}},
-        {xdp::built_in::MemoryMetrics::READ_BANDWIDTHS,
-         {XAIE_EVENT_DMA_MM2S_0_FINISHED_BD_MEM, XAIE_EVENT_DMA_MM2S_1_FINISHED_BD_MEM}}};
+      {xdp::built_in::MemoryMetrics::CONFLICTS, {XAIE_EVENT_GROUP_MEMORY_CONFLICT_MEM, XAIE_EVENT_GROUP_ERRORS_MEM}},
+      {xdp::built_in::MemoryMetrics::DMA_LOCKS, {XAIE_EVENT_GROUP_DMA_ACTIVITY_MEM, XAIE_EVENT_GROUP_LOCK_MEM}},
+      {
+        xdp::built_in::MemoryMetrics::DMA_STALLS_S2MM,
+        {XAIE_EVENT_DMA_S2MM_0_STALLED_LOCK_MEM, XAIE_EVENT_DMA_S2MM_1_STALLED_LOCK_MEM}
+      },
+      {
+        xdp::built_in::MemoryMetrics::DMA_STALLS_MM2S,
+        {XAIE_EVENT_DMA_MM2S_0_STALLED_LOCK_MEM, XAIE_EVENT_DMA_MM2S_1_STALLED_LOCK_MEM}
+      },
+      {
+        xdp::built_in::MemoryMetrics::WRITE_BANDWIDTHS,
+        {XAIE_EVENT_DMA_S2MM_0_FINISHED_BD_MEM, XAIE_EVENT_DMA_S2MM_1_FINISHED_BD_MEM}
+      },
+      {
+        xdp::built_in::MemoryMetrics::READ_BANDWIDTHS,
+        {XAIE_EVENT_DMA_MM2S_0_FINISHED_BD_MEM, XAIE_EVENT_DMA_MM2S_1_FINISHED_BD_MEM}
+      }
+    };
     mMemoryEndEvents = {
-        {xdp::built_in::MemoryMetrics::CONFLICTS, {XAIE_EVENT_GROUP_MEMORY_CONFLICT_MEM, XAIE_EVENT_GROUP_ERRORS_MEM}},
-        {xdp::built_in::MemoryMetrics::DMA_LOCKS, {XAIE_EVENT_GROUP_DMA_ACTIVITY_MEM, XAIE_EVENT_GROUP_LOCK_MEM}},
-        {xdp::built_in::MemoryMetrics::DMA_STALLS_S2MM,
-         {XAIE_EVENT_DMA_S2MM_0_STALLED_LOCK_ACQUIRE_MEM, XAIE_EVENT_DMA_S2MM_1_STALLED_LOCK_ACQUIRE_MEM}},
-        {xdp::built_in::MemoryMetrics::DMA_STALLS_MM2S,
-         {XAIE_EVENT_DMA_MM2S_0_STALLED_LOCK_ACQUIRE_MEM, XAIE_EVENT_DMA_MM2S_1_STALLED_LOCK_ACQUIRE_MEM}},
-        {xdp::built_in::MemoryMetrics::WRITE_BANDWIDTHS,
-         {XAIE_EVENT_DMA_S2MM_0_FINISHED_BD_MEM, XAIE_EVENT_DMA_S2MM_1_FINISHED_BD_MEM}},
-        {xdp::built_in::MemoryMetrics::READ_BANDWIDTHS,
-         {XAIE_EVENT_DMA_MM2S_0_FINISHED_BD_MEM, XAIE_EVENT_DMA_MM2S_1_FINISHED_BD_MEM}}};
+      {xdp::built_in::MemoryMetrics::CONFLICTS, {XAIE_EVENT_GROUP_MEMORY_CONFLICT_MEM, XAIE_EVENT_GROUP_ERRORS_MEM}},
+      {xdp::built_in::MemoryMetrics::DMA_LOCKS, {XAIE_EVENT_GROUP_DMA_ACTIVITY_MEM, XAIE_EVENT_GROUP_LOCK_MEM}},
+      {
+        xdp::built_in::MemoryMetrics::DMA_STALLS_S2MM,
+        {XAIE_EVENT_DMA_S2MM_0_STALLED_LOCK_ACQUIRE_MEM, XAIE_EVENT_DMA_S2MM_1_STALLED_LOCK_ACQUIRE_MEM}
+      },
+      {
+        xdp::built_in::MemoryMetrics::DMA_STALLS_MM2S,
+        {XAIE_EVENT_DMA_MM2S_0_STALLED_LOCK_ACQUIRE_MEM, XAIE_EVENT_DMA_MM2S_1_STALLED_LOCK_ACQUIRE_MEM}
+      },
+      {
+        xdp::built_in::MemoryMetrics::WRITE_BANDWIDTHS,
+        {XAIE_EVENT_DMA_S2MM_0_FINISHED_BD_MEM, XAIE_EVENT_DMA_S2MM_1_FINISHED_BD_MEM}
+      },
+      {
+        xdp::built_in::MemoryMetrics::READ_BANDWIDTHS,
+        {XAIE_EVENT_DMA_MM2S_0_FINISHED_BD_MEM, XAIE_EVENT_DMA_MM2S_1_FINISHED_BD_MEM}
+      }
+    };
 
     // **** PL/Shim Counters ****
     mShimStartEvents = {
-        {xdp::built_in::InterfaceMetrics::INPUT_BANDWIDTHS,
-         {XAIE_EVENT_PORT_RUNNING_0_PL, XAIE_EVENT_PORT_STALLED_0_PL}},
-        {xdp::built_in::InterfaceMetrics::OUTPUT_BANDWIDTHS,
-         {XAIE_EVENT_PORT_RUNNING_0_PL, XAIE_EVENT_PORT_STALLED_0_PL}},
-        {xdp::built_in::InterfaceMetrics::PACKETS, {XAIE_EVENT_PORT_TLAST_0_PL, XAIE_EVENT_PORT_TLAST_1_PL}}};
+      {
+        xdp::built_in::InterfaceMetrics::INPUT_BANDWIDTHS,
+        {XAIE_EVENT_PORT_RUNNING_0_PL, XAIE_EVENT_PORT_STALLED_0_PL}
+      },
+      {
+        xdp::built_in::InterfaceMetrics::OUTPUT_BANDWIDTHS,
+        {XAIE_EVENT_PORT_RUNNING_0_PL, XAIE_EVENT_PORT_STALLED_0_PL}
+      },
+      {xdp::built_in::InterfaceMetrics::PACKETS, {XAIE_EVENT_PORT_TLAST_0_PL, XAIE_EVENT_PORT_TLAST_1_PL}}
+    };
     mShimEndEvents = {
-        {xdp::built_in::InterfaceMetrics::INPUT_BANDWIDTHS,
-         {XAIE_EVENT_PORT_RUNNING_0_PL, XAIE_EVENT_PORT_STALLED_0_PL}},
-        {xdp::built_in::InterfaceMetrics::OUTPUT_BANDWIDTHS,
-         {XAIE_EVENT_PORT_RUNNING_0_PL, XAIE_EVENT_PORT_STALLED_0_PL}},
-        {xdp::built_in::InterfaceMetrics::PACKETS, {XAIE_EVENT_PORT_TLAST_0_PL, XAIE_EVENT_PORT_TLAST_1_PL}}};
+      {
+        xdp::built_in::InterfaceMetrics::INPUT_BANDWIDTHS,
+        {XAIE_EVENT_PORT_RUNNING_0_PL, XAIE_EVENT_PORT_STALLED_0_PL}
+      },
+      {
+        xdp::built_in::InterfaceMetrics::OUTPUT_BANDWIDTHS,
+        {XAIE_EVENT_PORT_RUNNING_0_PL, XAIE_EVENT_PORT_STALLED_0_PL}
+      },
+      {xdp::built_in::InterfaceMetrics::PACKETS, {XAIE_EVENT_PORT_TLAST_0_PL, XAIE_EVENT_PORT_TLAST_1_PL}}
+    };
 
     // **** MEM Tile Counters ****
     mMemTileStartEvents = {
-        {xdp::built_in::MemTileMetrics::INPUT_CHANNELS,
-         {XAIE_EVENT_PORT_RUNNING_0_MEM_TILE, XAIE_EVENT_PORT_STALLED_0_MEM_TILE, XAIE_EVENT_PORT_TLAST_0_MEM_TILE,
-          XAIE_EVENT_DMA_S2MM_SEL0_FINISHED_BD_MEM_TILE}},
-        {xdp::built_in::MemTileMetrics::INPUT_CHANNELS_DETAILS,
-         {XAIE_EVENT_DMA_S2MM_SEL0_STALLED_LOCK_ACQUIRE_MEM_TILE, XAIE_EVENT_DMA_S2MM_SEL0_STREAM_STARVATION_MEM_TILE,
-          XAIE_EVENT_DMA_S2MM_SEL0_MEMORY_BACKPRESSURE_MEM_TILE, XAIE_EVENT_DMA_S2MM_SEL0_FINISHED_BD_MEM_TILE}},
-        {xdp::built_in::MemTileMetrics::OUTPUT_CHANNELS,
-         {XAIE_EVENT_PORT_RUNNING_0_MEM_TILE, XAIE_EVENT_PORT_STALLED_0_MEM_TILE, XAIE_EVENT_PORT_TLAST_0_MEM_TILE,
-          XAIE_EVENT_DMA_MM2S_SEL0_FINISHED_BD_MEM_TILE}},
-        {xdp::built_in::MemTileMetrics::OUTPUT_CHANNELS_DETAILS,
-         {XAIE_EVENT_DMA_MM2S_SEL0_STALLED_LOCK_ACQUIRE_MEM_TILE, XAIE_EVENT_DMA_MM2S_SEL0_STREAM_BACKPRESSURE_MEM_TILE,
-          XAIE_EVENT_DMA_MM2S_SEL0_MEMORY_STARVATION_MEM_TILE, XAIE_EVENT_DMA_MM2S_SEL0_FINISHED_BD_MEM_TILE}},
-        {xdp::built_in::MemTileMetrics::MEMORY_STATS,
-         {XAIE_EVENT_GROUP_MEMORY_CONFLICT_MEM_TILE, XAIE_EVENT_GROUP_ERRORS_MEM_TILE, XAIE_EVENT_GROUP_LOCK_MEM_TILE,
-          XAIE_EVENT_GROUP_WATCHPOINT_MEM_TILE}},
-        {xdp::built_in::MemTileMetrics::MEM_TRACE,
-         {XAIE_EVENT_PORT_RUNNING_0_MEM_TILE, XAIE_EVENT_PORT_STALLED_0_MEM_TILE, XAIE_EVENT_PORT_IDLE_0_MEM_TILE,
-          XAIE_EVENT_PORT_TLAST_0_MEM_TILE}}};
+      {
+        xdp::built_in::MemTileMetrics::INPUT_CHANNELS,
+        {
+          XAIE_EVENT_PORT_RUNNING_0_MEM_TILE, XAIE_EVENT_PORT_STALLED_0_MEM_TILE, XAIE_EVENT_PORT_TLAST_0_MEM_TILE,
+          XAIE_EVENT_DMA_S2MM_SEL0_FINISHED_BD_MEM_TILE
+        }
+      },
+      {
+        xdp::built_in::MemTileMetrics::INPUT_CHANNELS_DETAILS,
+        {
+          XAIE_EVENT_DMA_S2MM_SEL0_STALLED_LOCK_ACQUIRE_MEM_TILE, XAIE_EVENT_DMA_S2MM_SEL0_STREAM_STARVATION_MEM_TILE,
+          XAIE_EVENT_DMA_S2MM_SEL0_MEMORY_BACKPRESSURE_MEM_TILE, XAIE_EVENT_DMA_S2MM_SEL0_FINISHED_BD_MEM_TILE
+        }
+      },
+      {
+        xdp::built_in::MemTileMetrics::OUTPUT_CHANNELS,
+        {
+          XAIE_EVENT_PORT_RUNNING_0_MEM_TILE, XAIE_EVENT_PORT_STALLED_0_MEM_TILE, XAIE_EVENT_PORT_TLAST_0_MEM_TILE,
+          XAIE_EVENT_DMA_MM2S_SEL0_FINISHED_BD_MEM_TILE
+        }
+      },
+      {
+        xdp::built_in::MemTileMetrics::OUTPUT_CHANNELS_DETAILS,
+        {
+          XAIE_EVENT_DMA_MM2S_SEL0_STALLED_LOCK_ACQUIRE_MEM_TILE, XAIE_EVENT_DMA_MM2S_SEL0_STREAM_BACKPRESSURE_MEM_TILE,
+          XAIE_EVENT_DMA_MM2S_SEL0_MEMORY_STARVATION_MEM_TILE, XAIE_EVENT_DMA_MM2S_SEL0_FINISHED_BD_MEM_TILE
+        }
+      },
+      {
+        xdp::built_in::MemTileMetrics::MEMORY_STATS,
+        {
+          XAIE_EVENT_GROUP_MEMORY_CONFLICT_MEM_TILE, XAIE_EVENT_GROUP_ERRORS_MEM_TILE, XAIE_EVENT_GROUP_LOCK_MEM_TILE,
+          XAIE_EVENT_GROUP_WATCHPOINT_MEM_TILE
+        }
+      },
+      {
+        xdp::built_in::MemTileMetrics::MEM_TRACE,
+        {
+          XAIE_EVENT_PORT_RUNNING_0_MEM_TILE, XAIE_EVENT_PORT_STALLED_0_MEM_TILE, XAIE_EVENT_PORT_IDLE_0_MEM_TILE,
+          XAIE_EVENT_PORT_TLAST_0_MEM_TILE
+        }
+      }
+    };
     mMemTileEndEvents = mMemTileStartEvents;
   }
 };

--- a/src/runtime_src/core/edge/ps_kernels/profiling/aie2_trace_config/aie2_trace_config.cpp
+++ b/src/runtime_src/core/edge/ps_kernels/profiling/aie2_trace_config/aie2_trace_config.cpp
@@ -16,7 +16,7 @@
 #include <cstring>
 #include <vector>
 
-#include "core/edge/include/sk_types.h"
+#include "core/edge/include/pscontext.h"
 #include "core/edge/user/shim.h"
 #include "event_configuration.h"
 #include "xaiefal/xaiefal.hpp"

--- a/src/runtime_src/core/edge/ps_kernels/profiling/aie_profile_config/aie_profile_config.cpp
+++ b/src/runtime_src/core/edge/ps_kernels/profiling/aie_profile_config/aie_profile_config.cpp
@@ -19,7 +19,7 @@
 #include "xaiengine.h"
 
 #include "core/common/time.h"
-#include "core/edge/include/sk_types.h"
+#include "core/edge/include/pscontext.h"
 #include "core/edge/common/aie_parser.h"
 #include "core/edge/user/shim.h"
 #include "xaiefal/xaiefal.hpp"

--- a/src/runtime_src/core/edge/ps_kernels/profiling/aie_trace_config/aie_trace_config.cpp
+++ b/src/runtime_src/core/edge/ps_kernels/profiling/aie_trace_config/aie_trace_config.cpp
@@ -16,7 +16,7 @@
 #include <cstring>
 #include <vector>
 
-#include "core/edge/include/sk_types.h"
+#include "core/edge/include/pscontext.h"
 #include "core/edge/user/shim.h"
 #include "event_configuration.h"
 #include "xaiefal/xaiefal.hpp"

--- a/src/runtime_src/core/edge/ps_kernels/profiling/aie_trace_gmio/gmio_config_kernel.cpp
+++ b/src/runtime_src/core/edge/ps_kernels/profiling/aie_trace_gmio/gmio_config_kernel.cpp
@@ -17,10 +17,10 @@
 #include <sys/mman.h>
 
 #include "xaiefal/xaiefal.hpp"
+#include "core/edge/include/pscontext.h"
 #include "core/edge/user/shim.h"
 #include "xdp/profile/database/static_info/aie_constructs.h"
 #include "xdp/profile/plugin/aie_trace/x86/aie_trace_kernel_config.h"
-#include "core/edge/include/sk_types.h"
 
 struct AIETraceGmioDMAInst{
   XAie_DmaDesc shimDmaInst;

--- a/src/runtime_src/xdp/profile/database/static_info/aie_util.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info/aie_util.cpp
@@ -424,6 +424,8 @@ namespace aie {
 
     // Now search by graph-kernel pairs
     auto kernelToTileMapping = aie_meta.get_child_optional("aie_metadata.TileMapping.AIEKernelToTileMapping");
+    if (!kernelToTileMapping && kernel_name.compare("all") == 0)
+      return getAIETiles(aie_meta, graph_name);
     if (!kernelToTileMapping)
       return {};
 

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_metadata.cpp
@@ -84,34 +84,39 @@ namespace xdp {
   {
     using boost::property_tree::ptree;
     const std::set<std::string> validSettings {
-        "graph_based_aie_metrics",         "graph_based_aie_memory_metrics",
-        "graph_based_memory_tile_metrics", "graph_based_interface_tile_metrics",
-        "tile_based_aie_metrics",          "tile_based_aie_memory_metrics",     
-        "tile_based_memory_tile_metrics",  "tile_based_interface_tile_metrics", 
-        "interval_us"};
+      "graph_based_aie_metrics", "graph_based_aie_memory_metrics",
+      "graph_based_memory_tile_metrics", "graph_based_interface_tile_metrics",
+      "tile_based_aie_metrics", "tile_based_aie_memory_metrics",
+      "tile_based_memory_tile_metrics", "tile_based_interface_tile_metrics",
+      "interval_us"};
     const std::map<std::string, std::string> deprecatedSettings {
-        {"aie_profile_core_metrics",      "AIE_profile_settings.graph_based_aie_metrics or tile_based_aie_metrics"},
-        {"aie_profile_memory_metrics",    "AIE_profile_settings.graph_based_aie_memory_metrics or tile_based_aie_memory_metrics"},
-        {"aie_profile_interface_metrics", "AIE_profile_settings.tile_based_interface_tile_metrics"},
-        {"aie_profile_interval_us",       "AIE_profile_settings.interval_us"}};
+      {"aie_profile_core_metrics", "AIE_profile_settings.graph_based_aie_metrics or tile_based_aie_metrics"},
+      {"aie_profile_memory_metrics", "AIE_profile_settings.graph_based_aie_memory_metrics or tile_based_aie_memory_metrics"},
+      {"aie_profile_interface_metrics", "AIE_profile_settings.tile_based_interface_tile_metrics"},
+      {"aie_profile_interval_us", "AIE_profile_settings.interval_us"}};
 
     // Verify settings in AIE_profile_settings section
     auto tree1 = xrt_core::config::detail::get_ptree_value("AIE_profile_settings");
+
     for (ptree::iterator pos = tree1.begin(); pos != tree1.end(); pos++) {
       if (validSettings.find(pos->first) == validSettings.end()) {
         std::stringstream msg;
         msg << "The setting AIE_profile_settings." << pos->first << " is not recognized. "
             << "Please check the spelling and compare to supported list:";
+
         for (auto it = validSettings.cbegin(); it != validSettings.cend(); it++)
           msg << ((it == validSettings.cbegin()) ? " " : ", ") << *it;
+
         xrt_core::message::send(severity_level::warning, "XRT", msg.str());
       }
     }
 
     // Check for usage of deprecated settings
     auto tree2 = xrt_core::config::detail::get_ptree_value("Debug");
+
     for (ptree::iterator pos = tree2.begin(); pos != tree2.end(); pos++) {
       auto iter = deprecatedSettings.find(pos->first);
+
       if (iter != deprecatedSettings.end()) {
         std::stringstream msg;
         msg << "The setting Debug." << pos->first << " is deprecated. "
@@ -125,18 +130,23 @@ namespace xdp {
   {
     static int hwGen = 1;
     static bool gotValue = false;
+
     if (!gotValue) {
       auto device = xrt_core::get_userpf_device(handle);
       auto data = device->get_axlf_section(AIE_METADATA);
+
       if (!data.first || !data.second) {
         hwGen = 1;
-      } else {
+      }
+      else {
         pt::ptree aie_meta;
         read_aie_metadata(data.first, data.second, aie_meta);
         hwGen = aie_meta.get_child("aie_metadata.driver_config.hw_gen").get_value<int>();
       }
+
       gotValue = true;
     }
+
     return hwGen;
   }
 
@@ -144,18 +154,23 @@ namespace xdp {
   {
     static uint16_t rowOffset = 1;
     static bool gotValue = false;
+
     if (!gotValue) {
       auto device = xrt_core::get_userpf_device(handle);
       auto data = device->get_axlf_section(AIE_METADATA);
+
       if (!data.first || !data.second) {
         rowOffset = 1;
-      } else {
+      }
+      else {
         pt::ptree aie_meta;
         read_aie_metadata(data.first, data.second, aie_meta);
         rowOffset = aie_meta.get_child("aie_metadata.driver_config.aie_tile_row_start").get_value<uint16_t>();
       }
+
       gotValue = true;
     }
+
     return rowOffset;
   }
 
@@ -166,47 +181,58 @@ namespace xdp {
 
     // Each of the metrics can have ; separated multiple values. Process and save all
     std::vector<std::string> settingsVector;
+
     boost::replace_all(settingsString, " ", "");
+
     boost::split(settingsVector, settingsString, boost::is_any_of(";"));
+
     return settingsVector;
   }
 
   // Find all MEM tiles associated with a graph and kernel
-  //   kernel_name = all      : all tiles in graph
-  //   kernel_name = <kernel> : only tiles used by that specific kernel
+  // kernel_name = all      : all tiles in graph
+  // kernel_name = <kernel> : only tiles used by that specific kernel
   std::vector<tile_type> AieProfileMetadata::get_mem_tiles(const xrt_core::device* device,
-                                                           const std::string& graph_name,
-                                                           const std::string& kernel_name)
+      const std::string& graph_name,
+      const std::string& kernel_name)
   {
     if (getHardwareGen() == 1)
       return {};
 
     auto data = device->get_axlf_section(AIE_METADATA);
+
     if (!data.first || !data.second)
       return {};
 
     pt::ptree aie_meta;
+
     read_aie_metadata(data.first, data.second, aie_meta);
 
     // Grab all shared buffers
     auto sharedBufferTree = aie_meta.get_child_optional("aie_metadata.TileMapping.SharedBufferToTileMapping");
+
     if (!sharedBufferTree)
       return {};
 
     std::vector<tile_type> allTiles;
+
     std::vector<tile_type> memTiles;
+
     // Always one row of interface tiles
     uint16_t rowOffset = 1;
 
     // Now parse all shared buffers
     for (auto const& shared_buffer : sharedBufferTree.get()) {
       auto currGraph = shared_buffer.second.get<std::string>("graph");
+
       if ((currGraph.find(graph_name) == std::string::npos) && (graph_name.compare("all") != 0))
         continue;
+
       if (kernel_name.compare("all") != 0) {
         std::vector<std::string> names;
         std::string functionStr = shared_buffer.second.get<std::string>("function");
         boost::split(names, functionStr, boost::is_any_of("."));
+
         if (std::find(names.begin(), names.end(), kernel_name) == names.end())
           continue;
       }
@@ -228,31 +254,39 @@ namespace xdp {
   }
 
   std::vector<tile_type> AieProfileMetadata::get_event_tiles(const xrt_core::device* device,
-                                                             const std::string& graph_name, module_type type)
+      const std::string& graph_name, module_type type)
   {
     auto data = device->get_axlf_section(AIE_METADATA);
+
     if (!data.first || !data.second)
       return {};
 
     pt::ptree aie_meta;
+
     read_aie_metadata(data.first, data.second, aie_meta);
+
     // Interface tiles use different method
     if (type == module_type::shim)
       return {};
 
     const char* col_name = (type == module_type::core) ? "core_columns" : "dma_columns";
+
     const char* row_name = (type == module_type::core) ? "core_rows" : "dma_rows";
 
     std::vector<tile_type> tiles;
+
     auto rowOffset = getAIETileRowOffset();
+
     int startCount = 0;
 
     for (auto& graph : aie_meta.get_child("aie_metadata.EventGraphs")) {
       auto currGraph = graph.second.get<std::string>("name");
+
       if ((currGraph.find(graph_name) == std::string::npos) && (graph_name.compare("all") != 0))
         continue;
 
       int count = startCount;
+
       for (auto& node : graph.second.get_child(col_name)) {
         tiles.push_back(tile_type());
         auto& t = tiles.at(count++);
@@ -261,8 +295,10 @@ namespace xdp {
 
       int num_tiles = count;
       count = startCount;
+
       for (auto& node : graph.second.get_child(row_name))
         tiles.at(count++).row = static_cast<uint16_t>(std::stoul(node.second.data())) + rowOffset;
+
       throw_if_error(count < num_tiles, "rows < num_tiles");
       startCount = count;
     }
@@ -272,47 +308,58 @@ namespace xdp {
 
   // Find all AIE tiles associated with a graph and module type (kernel_name = all)
   std::vector<tile_type> AieProfileMetadata::get_aie_tiles(const xrt_core::device* device,
-                                                           const std::string& graph_name, module_type type)
+      const std::string& graph_name, module_type type)
   {
     std::vector<tile_type> tiles;
     tiles = get_event_tiles(device, graph_name, module_type::core);
+
     if (type == module_type::dma) {
       auto dmaTiles = get_event_tiles(device, graph_name, module_type::dma);
       std::unique_copy(dmaTiles.begin(), dmaTiles.end(), back_inserter(tiles), tileCompare);
     }
+
     return tiles;
   }
 
   std::vector<tile_type> AieProfileMetadata::get_tiles(const xrt_core::device* device, const std::string& graph_name,
-                                                       module_type type, const std::string& kernel_name)
+      module_type type, const std::string& kernel_name)
   {
     if (type == module_type::mem_tile)
       return get_mem_tiles(device, graph_name, kernel_name);
 
     // Now search by graph-kernel pairs
     auto data = device->get_axlf_section(AIE_METADATA);
+
     if (!data.first || !data.second)
       return {};
 
     pt::ptree aie_meta;
+
     read_aie_metadata(data.first, data.second, aie_meta);
 
     // Grab all kernel to tile mappings
     auto kernelToTileMapping = aie_meta.get_child_optional("aie_metadata.TileMapping.AIEKernelToTileMapping");
-    if (!kernelToTileMapping)
+
+    if (!kernelToTileMapping && kernel_name.compare("all") == 0)
+      return get_aie_tiles(device, graph_name, type);
+    else if (!kernelToTileMapping)
       return {};
 
     std::vector<tile_type> tiles;
+
     auto rowOffset = getAIETileRowOffset();
 
     for (auto const& mapping : kernelToTileMapping.get()) {
       auto currGraph = mapping.second.get<std::string>("graph");
+
       if ((currGraph.find(graph_name) == std::string::npos) && (graph_name.compare("all") != 0))
         continue;
+
       if (kernel_name.compare("all") != 0) {
         std::vector<std::string> names;
         std::string functionStr = mapping.second.get<std::string>("function");
         boost::split(names, functionStr, boost::is_any_of("."));
+
         if (std::find(names.begin(), names.end(), kernel_name) == names.end())
           continue;
       }
@@ -322,16 +369,18 @@ namespace xdp {
       tile.row = mapping.second.get<uint16_t>("row") + rowOffset;
       tiles.emplace_back(std::move(tile));
     }
+
     return tiles;
   }
 
   // Resolve metrics for AIE or MEM tiles
   void AieProfileMetadata::getConfigMetricsForTiles(int moduleIdx, const std::vector<std::string>& metricsSettings,
-                                                    const std::vector<std::string>& graphMetricsSettings,
-                                                    const module_type mod)
+      const std::vector<std::string>& graphMetricsSettings,
+      const module_type mod)
   {
     if ((metricsSettings.empty()) && (graphMetricsSettings.empty()))
       return;
+
     if ((getHardwareGen() == 1) && (mod == module_type::mem_tile)) {
       xrt_core::message::send(severity_level::warning, "XRT",
                               "MEM tiles are not available in AIE1. Profile "
@@ -343,7 +392,7 @@ namespace xdp {
     auto data = device->get_axlf_section(AIE_METADATA);
     pt::ptree aie_meta;
     read_aie_metadata(data.first, data.second, aie_meta);
-    
+
     uint16_t rowOffset = (mod == module_type::mem_tile) ? 1 : getAIETileRowOffset();
     auto modName = (mod == module_type::core) ? "aie" : ((mod == module_type::dma) ? "aie_memory" : "memory_tile");
 
@@ -357,15 +406,15 @@ namespace xdp {
 
     // STEP 1 : Parse per-graph or per-kernel settings
 
-    /* AIE_profile_settings config format 
-     * Multiple values can be specified separated with ';' 
+    /* AIE_profile_settings config format
+     * Multiple values can be specified separated with ';'
      *
-     * AI Engine Tiles 
+     * AI Engine Tiles
      * graph_based_aie_metrics = <graph name|all>:<kernel name|all>
      *   :<off|heat_map|stalls|execution|floating_point|write_throughputs|read_throughputs|aie_trace>
      * graph_based_aie_memory_metrics = <graph name|all>:<kernel name|all>
      *   :<off|conflicts|dma_locks|dma_stalls_s2mm|dma_stalls_mm2s|write_throughputs|read_throughputs> MEM Tiles
-     * 
+     *
      * Memory tiles (AIE2 and beyond)
      * graph_based_memory_tile_metrics = <graph name|all>:<buffer name|all>
      *   :<off|input_channels|input_channels_details|output_channels|output_channels_details|memory_stats|mem_trace>[:<channel>]
@@ -381,19 +430,23 @@ namespace xdp {
       // Check if graph is not all or if invalid kernel
       if (graphMetrics[i][0].compare("all") != 0)
         continue;
+
       if ((graphMetrics[i][1].compare("all") != 0) &&
           (std::find(allValidKernels.begin(), allValidKernels.end(), graphMetrics[i][1]) == allValidKernels.end())) {
         std::stringstream msg;
-        msg << "Could not find kernel " << graphMetrics[i][1] 
+        msg << "Could not find kernel " << graphMetrics[i][1]
             << " as specified in graph_based_" << modName << "_metrics setting."
             << " The following kernels are valid : " << allValidKernels[0];
+
         for (size_t j = 1; j < allValidKernels.size(); j++)
           msg << ", " << allValidKernels[j];
+
         xrt_core::message::send(severity_level::warning, "XRT", msg.str());
         continue;
       }
 
       auto tiles = get_tiles(device.get(), graphMetrics[i][0], mod, graphMetrics[i][1]);
+
       for (auto& e : tiles) {
         configMetrics[moduleIdx][e] = graphMetrics[i][2];
       }
@@ -412,27 +465,31 @@ namespace xdp {
           xrt_core::message::send(severity_level::warning, "XRT", msg.str());
         }
       }
-    }  // Graph Pass 1
+    } // Graph Pass 1
 
     // Graph Pass 2 : process per graph metric setting
     for (size_t i = 0; i < graphMetricsSettings.size(); ++i) {
       // Check if already processed or if invalid
       if (graphMetrics[i][0].compare("all") == 0)
         continue;
+
       if ((graphMetrics[i][1].compare("all") != 0) &&
           (std::find(allValidKernels.begin(), allValidKernels.end(), graphMetrics[i][1]) == allValidKernels.end())) {
         std::stringstream msg;
-        msg << "Could not find kernel " << graphMetrics[i][1] 
+        msg << "Could not find kernel " << graphMetrics[i][1]
             << " as specified in graph_based_" << modName << "_metrics setting."
             << " The following kernels are valid : " << allValidKernels[0];
+
         for (size_t j = 1; j < allValidKernels.size(); j++)
           msg << ", " << allValidKernels[j];
+
         xrt_core::message::send(severity_level::warning, "XRT", msg.str());
         continue;
       }
 
       // Capture all tiles in given graph
       auto tiles = get_tiles(device.get(), graphMetrics[i][0], mod, graphMetrics[i][1]);
+
       for (auto& e : tiles) {
         configMetrics[moduleIdx][e] = graphMetrics[i][2];
       }
@@ -451,14 +508,14 @@ namespace xdp {
           xrt_core::message::send(severity_level::warning, "XRT", msg.str());
         }
       }
-    }  // Graph Pass 2
+    } // Graph Pass 2
 
     // STEP 2 : Parse per-tile settings: all, bounding box, and/or single tiles
 
     /* AIE_profile_settings config format
-     * Multiple values can be specified separated with ';' 
+     * Multiple values can be specified separated with ';'
      *
-     * AI Engine Tiles 
+     * AI Engine Tiles
      * Single or all tiles
      * tile_based_aie_metrics = [[{<column>,<row>}|all>
      *     :<off|heat_map|stalls|execution|floating_point|write_throughputs|read_throughputs|aie_trace>]
@@ -490,6 +547,7 @@ namespace xdp {
         continue;
 
       auto tiles = get_tiles(device.get(), metrics[i][0], mod);
+
       for (auto& e : tiles) {
         configMetrics[moduleIdx][e] = metrics[i][1];
       }
@@ -508,7 +566,7 @@ namespace xdp {
           xrt_core::message::send(severity_level::warning, "XRT", msg.str());
         }
       }
-    }  // Pass 1
+    } // Pass 1
 
     // Pass 2 : process only range of tiles metric setting
     for (size_t i = 0; i < metricsSettings.size(); ++i) {
@@ -552,6 +610,7 @@ namespace xdp {
 
       uint8_t channel0 = 0;
       uint8_t channel1 = 1;
+
       if (metrics[i].size() == 5) {
         try {
           channel0 = static_cast<uint8_t>(std::stoul(metrics[i][3]));
@@ -588,7 +647,7 @@ namespace xdp {
           }
         }
       }
-    }  // Pass 2
+    } // Pass 2
 
     // Pass 3 : process only single tile metric setting
     for (size_t i = 0; i < metricsSettings.size(); ++i) {
@@ -642,7 +701,7 @@ namespace xdp {
           xrt_core::message::send(severity_level::warning, "XRT", msg.str());
         }
       }
-    }  // Pass 3
+    } // Pass 3
 
     // Set default, check validity, and remove "off" tiles
     auto defaultSet = defaultSets[moduleIdx];
@@ -666,6 +725,7 @@ namespace xdp {
           xrt_core::message::send(severity_level::warning, "XRT", msg.str());
           showWarning = false;
         }
+
         tileMetric.second = defaultSet;
       }
     }
@@ -678,8 +738,8 @@ namespace xdp {
 
   // Resolve Interface metrics
   void AieProfileMetadata::getConfigMetricsForInterfaceTiles(int moduleIdx,
-                                                             const std::vector<std::string>& metricsSettings,
-                                                             const std::vector<std::string> graphMetricsSettings)
+      const std::vector<std::string>& metricsSettings,
+      const std::vector<std::string> graphMetricsSettings)
   {
     if ((metricsSettings.empty()) && (graphMetricsSettings.empty()))
       return;
@@ -708,34 +768,39 @@ namespace xdp {
       // Check if graph is not all or if invalid port
       if (graphMetrics[i][0].compare("all") != 0)
         continue;
+
       if ((graphMetrics[i][1].compare("all") != 0)
           && (std::find(allValidPorts.begin(), allValidPorts.end(), graphMetrics[i][1]) == allValidPorts.end())) {
         std::stringstream msg;
-        msg << "Could not find port " << graphMetrics[i][1] 
+        msg << "Could not find port " << graphMetrics[i][1]
             << " as specified in graph_based_interface_tile_metrics setting."
             << " The following ports are valid : " << allValidPorts[0];
+
         for (size_t j = 1; j < allValidPorts.size(); j++)
           msg << ", " << allValidPorts[j];
+
         xrt_core::message::send(severity_level::warning, "XRT", msg.str());
         continue;
       }
 
-      auto tiles = aie::getInterfaceTiles(aie_meta, graphMetrics[i][0], graphMetrics[i][1], 
+      auto tiles = aie::getInterfaceTiles(aie_meta, graphMetrics[i][0], graphMetrics[i][1],
                                           graphMetrics[i][2]);
-      for (auto &e : tiles) {
+
+      for (auto& e : tiles) {
         configMetrics[moduleIdx][e] = graphMetrics[i][2];
       }
 
       // Grab channel numbers (if specified; memory tiles only)
       if (graphMetrics[i].size() > 3) {
         try {
-          for (auto &e : tiles) {
+          for (auto& e : tiles) {
             configChannel0[e] = static_cast<uint8_t>(std::stoi(graphMetrics[i][3]));
             configChannel1[e] = static_cast<uint8_t>(std::stoi(graphMetrics[i].back()));
           }
-        } catch (...) {
+        }
+        catch (...) {
           std::stringstream msg;
-          msg << "Channel specifications in graph_based_interface_metrics " 
+          msg << "Channel specifications in graph_based_interface_metrics "
               << "are not valid and hence ignored.";
           xrt_core::message::send(severity_level::warning, "XRT", msg.str());
         }
@@ -747,42 +812,50 @@ namespace xdp {
       // Check if already processed or if invalid
       if (graphMetrics[i][0].compare("all") == 0)
         continue;
+
       if (std::find(allValidGraphs.begin(), allValidGraphs.end(), graphMetrics[i][0]) == allValidGraphs.end()) {
         std::stringstream msg;
-        msg << "Could not find graph " << graphMetrics[i][0] 
+        msg << "Could not find graph " << graphMetrics[i][0]
             << ", as specified in graph_based_interface_tile_metrics setting."
             << " The following graphs are valid : " << allValidGraphs[0];
+
         for (size_t j = 1; j < allValidGraphs.size(); j++)
           msg << ", " << allValidGraphs[j];
+
         xrt_core::message::send(severity_level::warning, "XRT", msg.str());
         continue;
       }
+
       if ((graphMetrics[i][1].compare("all") != 0)
           && (std::find(allValidPorts.begin(), allValidPorts.end(), graphMetrics[i][1]) == allValidPorts.end())) {
         std::stringstream msg;
-        msg << "Could not find port " << graphMetrics[i][1] 
+        msg << "Could not find port " << graphMetrics[i][1]
             << ", as specified in graph_based_interface_tile_metrics setting."
             << " The following ports are valid : " << allValidPorts[0];
+
         for (size_t j = 1; j < allValidPorts.size(); j++)
           msg << ", " << allValidPorts[j];
+
         xrt_core::message::send(severity_level::warning, "XRT", msg.str());
         continue;
       }
 
       auto tiles = aie::getInterfaceTiles(aie_meta, graphMetrics[i][0], graphMetrics[i][1],
                                           graphMetrics[i][2]);
-      for (auto &e : tiles) {
+
+      for (auto& e : tiles) {
         configMetrics[moduleIdx][e] = graphMetrics[i][2];
       }
 
       // Grab channel numbers (if specified; memory tiles only)
       if (graphMetrics[i].size() > 3) {
         try {
-          for (auto &e : tiles) {
+          for (auto& e : tiles) {
             configChannel0[e] = static_cast<uint8_t>(std::stoi(graphMetrics[i][3]));
             configChannel1[e] = static_cast<uint8_t>(std::stoi(graphMetrics[i].back()));
           }
-        } catch (...) {
+        }
+        catch (...) {
           std::stringstream msg;
           msg << "Channel specifications in graph_based_interface_tile_metrics "
               << "are not valid and hence ignored.";
@@ -819,7 +892,7 @@ namespace xdp {
         configMetrics[moduleIdx][t] = metrics[i][1];
         configChannel0[t] = channelId;
       }
-    }  // Pass 1
+    } // Pass 1
 
     // Pass 2 : process only range of tiles metric setting
     for (size_t i = 0; i < metricsSettings.size(); ++i) {
@@ -827,6 +900,7 @@ namespace xdp {
         continue;
 
       uint32_t maxCol = 0;
+
       try {
         maxCol = std::stoi(metrics[i][1]);
       }
@@ -834,7 +908,9 @@ namespace xdp {
         // maxColumn is not an integer i.e either 1st style or wrong format, skip for now
         continue;
       }
+
       uint32_t minCol = 0;
+
       try {
         minCol = std::stoi(metrics[i][0]);
       }
@@ -848,6 +924,7 @@ namespace xdp {
       }
 
       uint8_t channelId = 0;
+
       if (metrics[i].size() == 4) {
         try {
           channelId = static_cast<uint8_t>(std::stoul(metrics[i][3]));
@@ -868,7 +945,7 @@ namespace xdp {
         configMetrics[moduleIdx][t] = metrics[i][2];
         configChannel0[t] = channelId;
       }
-    }  // Pass 2
+    } // Pass 2
 
     // Pass 3 : process only single tile metric setting
     for (size_t i = 0; i < metricsSettings.size(); ++i) {
@@ -877,6 +954,7 @@ namespace xdp {
         continue;
 
       uint32_t col = 0;
+
       try {
         col = std::stoi(metrics[i][1]);
       }
@@ -894,6 +972,7 @@ namespace xdp {
         }
 
         uint8_t channelId = 0;
+
         if (metrics[i].size() == 3) {
           try {
             channelId = static_cast<uint8_t>(std::stoul(metrics[i][2]));
@@ -907,7 +986,7 @@ namespace xdp {
           }
         }
 
-        auto tiles = aie::getInterfaceTiles(aie_meta, "all", "all", metrics[i][1], 
+        auto tiles = aie::getInterfaceTiles(aie_meta, "all", "all", metrics[i][1],
                                             channelId, true, col, col);
 
         for (auto& t : tiles) {
@@ -915,7 +994,7 @@ namespace xdp {
           configChannel0[t] = channelId;
         }
       }
-    }  // Pass 3
+    } // Pass 3
 
     // Set default, check validity, and remove "off" tiles
     auto defaultSet = defaultSets[moduleIdx];
@@ -931,13 +1010,15 @@ namespace xdp {
 
       // Ensure requested metric set is supported (if not, use default)
       auto metricVec = metricStrings[module_type::shim];
+
       if (std::find(metricVec.begin(), metricVec.end(), tileMetric.second) == metricVec.end()) {
         if (showWarning) {
-          std::string msg = "Unable to find interface_tile metric set " + tileMetric.second 
-                          + ". Using default of " + defaultSet + ". ";
+          std::string msg = "Unable to find interface_tile metric set " + tileMetric.second
+                            + ". Using default of " + defaultSet + ". ";
           xrt_core::message::send(severity_level::warning, "XRT", msg);
           showWarning = false;
         }
+
         tileMetric.second = defaultSet;
       }
     }
@@ -960,10 +1041,12 @@ namespace xdp {
     auto stringVector = metricStrings[mod];
 
     auto itr = std::find(stringVector.begin(), stringVector.end(), metricString);
+
     if (itr != stringVector.cend()) {
       return 0;
-    } else {
+    }
+    else {
       return static_cast<uint8_t>(std::distance(stringVector.begin(), itr));
     }
   }
-}  // namespace xdp
+} // namespace xdp

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_metadata.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_metadata.h
@@ -26,93 +26,124 @@
 
 namespace xdp {
 
-constexpr unsigned int NUM_CORE_COUNTERS     = 4;
-constexpr unsigned int NUM_MEMORY_COUNTERS   = 2;
-constexpr unsigned int NUM_SHIM_COUNTERS     = 2;
-constexpr unsigned int NUM_MEM_TILE_COUNTERS = 4;
+  constexpr unsigned int NUM_CORE_COUNTERS = 4;
+  constexpr unsigned int NUM_MEMORY_COUNTERS = 2;
+  constexpr unsigned int NUM_SHIM_COUNTERS = 2;
+  constexpr unsigned int NUM_MEM_TILE_COUNTERS = 4;
 
-class AieProfileMetadata{
-  private:
-    // Currently supporting Core, Memory, Interface Tiles, and MEM Tiles
-    static constexpr int NUM_MODULES = 4;
+  class AieProfileMetadata {
+    private:
+      // Currently supporting Core, Memory, Interface Tiles, and MEM Tiles
+      static constexpr int NUM_MODULES = 4;
 
-    const std::vector<std::string> moduleNames = 
-        {"aie", "aie_memory", "interface_tile", "memory_tile"};
-    const std::string defaultSets[NUM_MODULES] = 
-        {"write_throughputs", "write_throughputs", "input_throughputs", "input_channels"};
-    const int numCountersMod[NUM_MODULES] =
-        {NUM_CORE_COUNTERS, NUM_MEMORY_COUNTERS, NUM_SHIM_COUNTERS, NUM_MEM_TILE_COUNTERS};
-    const module_type moduleTypes[NUM_MODULES] = 
-        {module_type::core, module_type::dma, module_type::shim, module_type::mem_tile};
+      const std::vector<std::string> moduleNames =
+      {"aie", "aie_memory", "interface_tile", "memory_tile"};
+      const std::string defaultSets[NUM_MODULES] =
+      {"write_throughputs", "write_throughputs", "input_throughputs", "input_channels"};
+      const int numCountersMod[NUM_MODULES] =
+      {NUM_CORE_COUNTERS, NUM_MEMORY_COUNTERS, NUM_SHIM_COUNTERS, NUM_MEM_TILE_COUNTERS};
+      const module_type moduleTypes[NUM_MODULES] =
+      {module_type::core, module_type::dma, module_type::shim, module_type::mem_tile};
 
-    uint32_t pollingInterval;
-    uint64_t deviceID;
-    double clockFreqMhz;
-    void* handle;
+      uint32_t pollingInterval;
+      uint64_t deviceID;
+      double clockFreqMhz;
+      void* handle;
 
-    std::map <module_type, std::vector<std::string>> metricStrings {
-      { module_type::core,     {"heat_map", "stalls", "execution",           
-                                "floating_point", "stream_put_get", "write_throughputs",     
-                                "read_throughputs", "aie_trace", "events"} },
-      { module_type::dma,      {"conflicts", "dma_locks", "dma_stalls_s2mm",
-                                "dma_stalls_mm2s", "write_throughputs", "read_throughputs"} },
-      { module_type::shim,     {"input_throughputs", "output_throughputs", "packets"} },
-      { module_type::mem_tile, {"input_channels", "input_channels_details",
-                                "output_channels", "output_channels_details",
-                                "memory_stats", "mem_trace"} }
-    };
+      std::map <module_type, std::vector<std::string>> metricStrings {
+        {
+          module_type::core, {
+            "heat_map", "stalls", "execution",
+            "floating_point", "stream_put_get", "write_throughputs",
+            "read_throughputs", "aie_trace", "events"
+          }
+        },
+        {
+          module_type::dma, {
+            "conflicts", "dma_locks", "dma_stalls_s2mm",
+            "dma_stalls_mm2s", "write_throughputs", "read_throughputs"
+          }
+        },
+        { module_type::shim, {"input_throughputs", "output_throughputs", "packets"} },
+        {
+          module_type::mem_tile, {
+            "input_channels", "input_channels_details",
+            "output_channels", "output_channels_details",
+            "memory_stats", "mem_trace"
+          }
+        }
+      };
 
-    std::vector<std::map<tile_type, std::string>> configMetrics;
-    std::map<tile_type, uint8_t> configChannel0;
-    std::map<tile_type, uint8_t> configChannel1;
+      std::vector<std::map<tile_type, std::string>> configMetrics;
+      std::map<tile_type, uint8_t> configChannel0;
+      std::map<tile_type, uint8_t> configChannel1;
 
-  public:
-    AieProfileMetadata(uint64_t deviceID, void* handle);
-    
-    uint64_t getDeviceID() {return deviceID;}
-    void* getHandle() {return handle;}
-    uint32_t getPollingIntervalVal(){return pollingInterval;}
+    public:
+      AieProfileMetadata(uint64_t deviceID, void* handle);
 
-    void checkSettings();
-    int getHardwareGen();
-    uint16_t getAIETileRowOffset();
-    std::vector<std::string> getSettingsVector(std::string settingsString);
+      uint64_t getDeviceID() {return deviceID;}
+      void* getHandle() {return handle;}
+      uint32_t getPollingIntervalVal() {return pollingInterval;}
 
-    void getConfigMetricsForTiles(int moduleIdx,
-                                  const std::vector<std::string>& metricsSettings,
-                                  const std::vector<std::string>& graphMetricsSettings,
-                                  const module_type mod);
-    void getConfigMetricsForInterfaceTiles(int moduleIdx,
-                                           const std::vector<std::string>& metricsSettings,
-                                           const std::vector<std::string> graphMetricsSettings);
-    uint8_t getMetricSetIndex(std::string metricSet, module_type mod);
-    static void read_aie_metadata(const char* data, size_t size, boost::property_tree::ptree& aie_project);
+      void checkSettings();
+      int getHardwareGen();
+      uint16_t getAIETileRowOffset();
+      std::vector<std::string> getSettingsVector(std::string settingsString);
 
-    std::vector<tile_type> get_mem_tiles(const xrt_core::device* device, 
-                                         const std::string& graph_name,
-                                         const std::string& kernel_name = "all");
-    std::vector<tile_type> get_event_tiles(const xrt_core::device* device, 
-                                           const std::string& graph_name, 
+      void getConfigMetricsForTiles(int moduleIdx,
+                                    const std::vector<std::string>& metricsSettings,
+                                    const std::vector<std::string>& graphMetricsSettings,
+                                    const module_type mod);
+      void getConfigMetricsForInterfaceTiles(int moduleIdx,
+                                             const std::vector<std::string>& metricsSettings,
+                                             const std::vector<std::string> graphMetricsSettings);
+      uint8_t getMetricSetIndex(std::string metricSet, module_type mod);
+      static void read_aie_metadata(const char* data, size_t size, boost::property_tree::ptree& aie_project);
+
+      std::vector<tile_type> get_mem_tiles(const xrt_core::device* device,
+                                           const std::string& graph_name,
+                                           const std::string& kernel_name = "all");
+      std::vector<tile_type> get_event_tiles(const xrt_core::device* device,
+                                             const std::string& graph_name,
+                                             module_type type);
+      std::vector<tile_type> get_aie_tiles(const xrt_core::device* device,
+                                           const std::string& graph_name,
                                            module_type type);
-    std::vector<tile_type> get_aie_tiles(const xrt_core::device* device, 
-                                         const std::string& graph_name,
-                                         module_type type);
-    std::vector<tile_type> get_tiles(const xrt_core::device* device, 
-                                     const std::string& graph_name,
-                                     module_type type, 
-                                     const std::string& kernel_name = "all");
+      std::vector<tile_type> get_tiles(const xrt_core::device* device,
+                                       const std::string& graph_name,
+                                       module_type type,
+                                       const std::string& kernel_name = "all");
 
-    std::map<tile_type, std::string> getConfigMetrics(int module){ return configMetrics[module];}
-    std::map<tile_type, uint8_t> getConfigChannel0() {return configChannel0;}
-    std::map<tile_type, uint8_t> getConfigChannel1() {return configChannel1;}
+      std::map<tile_type, std::string> getConfigMetrics(int module) { return configMetrics[module];}
+      std::map<tile_type, uint8_t> getConfigChannel0() {return configChannel0;}
+      std::map<tile_type, uint8_t> getConfigChannel1() {return configChannel1;}
 
-    double getClockFreqMhz(){return clockFreqMhz;}
-    std::string getModuleName(int module){return moduleNames[module];}
-    int getNumCountersMod(int module){return numCountersMod[module];}
-    module_type getModuleType(int module){return moduleTypes[module];}
-    int getNumModules(){return NUM_MODULES;}
+      bool checkModule(int module) { return (module >= 0 && module < NUM_MODULES);}
+      double getClockFreqMhz() {return clockFreqMhz;}
+      std::string getModuleName(int module)
+      {
+        if (checkModule(module))
+          return moduleNames[module];
+        else
+          return moduleNames[0];
+      }
+
+      int getNumCountersMod(int module)
+      {
+        if (checkModule(module))
+          return numCountersMod[module];
+        else
+          return numCountersMod[0];
+      }
+      module_type getModuleType(int module)
+      {
+        if (checkModule(module))
+          return moduleTypes[module];
+        else
+          return moduleTypes[0];
+      }
+      int getNumModules() {return NUM_MODULES;}
   };
 }
 
 #endif
- 

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/x86/aie_profile.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/x86/aie_profile.h
@@ -37,6 +37,7 @@ namespace xdp {
     private:
       xrt::device device;
       xrt::kernel aie_profile_kernel;
+      int numCountersConfigured = 0;
   };
 
 }   

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/x86/aie_profile.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/x86/aie_profile.h
@@ -37,7 +37,7 @@ namespace xdp {
     private:
       xrt::device device;
       xrt::kernel aie_profile_kernel;
-      int numCountersConfigured = 0;
+      uint32_t numCountersConfigured = 0;
   };
 
 }   


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Fixed small bugs in PS kernel, changed deprecated sk_types.h to pscontext.h in all ps kernels, and modified the metadata to fall back on old metadata section if new 'AIEKernelToTileMapping' section is not found.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Metadata sections were not being parsed correctly, and number of tiles configured was 0, which was causing issues in the setup PS kernel and the host when it tried to poll using the polling PS kernel iteration. 

#### What has been tested and how, request additional testing if necessary
Tested on V70 

#### Documentation impact (if any)
