### PR TITLE
CR-1155098 Missing host memory status in Platform report

### DIFF
--- a/src/runtime_src/core/common/info_platform.cpp
+++ b/src/runtime_src/core/common/info_platform.cpp
@@ -156,6 +156,35 @@ add_performance_info(const xrt_core::device* device, ptree_type& pt)
 }
 
 void
+add_data_retention_info(const xrt_core::device* device, ptree_type& pt)
+{
+  std::string data_retention_string = "not supported";
+  try {
+    auto value = xrt_core::device_query<xrt_core::query::data_retention>(device);
+    auto data_retention = xrt_core::query::data_retention::to_bool(value);
+    data_retention_string = (data_retention ? "enabled" : "disabled");
+  }
+  catch (xrt_core::query::exception&) {
+    //safe to ignore. These sysfs nodes are not present for vck5000 
+  }
+  pt.add("data_retention_status", data_retention_string);
+}
+
+void
+add_host_mem_info(const xrt_core::device* device, ptree_type& pt)
+{
+  std::string data_retention_string = "not supported";
+  try {
+    auto value = xrt_core::device_query<xrt_core::query::enabled_host_mem>(device);
+    data_retention_string = (value > 0 ? "enabled" : "disabled");
+  }
+  catch (xrt_core::query::exception&) {
+    //safe to ignore. These sysfs nodes are not present for vck5000 
+  }
+  pt.add("host_memory_status", data_retention_string);
+}
+
+void
 add_status_info(const xrt_core::device* device, ptree_type& pt)
 {
   ptree_type pt_status;
@@ -163,6 +192,8 @@ add_status_info(const xrt_core::device* device, ptree_type& pt)
   add_mig_info(device, pt_status);
   add_p2p_info(device, pt_status);
   add_performance_info(device, pt_status);
+  add_data_retention_info(device, pt_status);
+  add_host_mem_info(device, pt_status);
 
   pt.put_child("status", pt_status);
 }

--- a/src/runtime_src/core/common/info_platform.cpp
+++ b/src/runtime_src/core/common/info_platform.cpp
@@ -179,7 +179,7 @@ add_host_mem_info(const xrt_core::device* device, ptree_type& pt)
     data_retention_string = (value > 0 ? "enabled" : "disabled");
   }
   catch (xrt_core::query::exception&) {
-    //safe to ignore. These sysfs nodes are not present for vck5000 
+    // Device does not support host memory features
   }
   pt.add("host_memory_status", data_retention_string);
 }

--- a/src/runtime_src/core/common/info_platform.cpp
+++ b/src/runtime_src/core/common/info_platform.cpp
@@ -156,21 +156,6 @@ add_performance_info(const xrt_core::device* device, ptree_type& pt)
 }
 
 void
-add_data_retention_info(const xrt_core::device* device, ptree_type& pt)
-{
-  std::string data_retention_string = "not supported";
-  try {
-    auto value = xrt_core::device_query<xrt_core::query::data_retention>(device);
-    auto data_retention = xrt_core::query::data_retention::to_bool(value);
-    data_retention_string = (data_retention ? "enabled" : "disabled");
-  }
-  catch (xrt_core::query::exception&) {
-    //safe to ignore. These sysfs nodes are not present for vck5000 
-  }
-  pt.add("data_retention_status", data_retention_string);
-}
-
-void
 add_host_mem_info(const xrt_core::device* device, ptree_type& pt)
 {
   std::string data_retention_string = "not supported";
@@ -192,7 +177,6 @@ add_status_info(const xrt_core::device* device, ptree_type& pt)
   add_mig_info(device, pt_status);
   add_p2p_info(device, pt_status);
   add_performance_info(device, pt_status);
-  add_data_retention_info(device, pt_status);
   add_host_mem_info(device, pt_status);
 
   pt.put_child("status", pt_status);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1155098
Not all supported features of a given card are available through the `xbutil examine` `platform` report. Namely the host memory status!

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Host memory status cannot be seen anywhere through `xbutil`.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added the host memory status into the `platorm` `xbutil examine` report.

#### Risks (if any) associated the changes in the commit
None.

#### What has been tested and how, request additional testing if necessary
Ubuntu 22.04 VCK5000
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ xbutil examine -d 17:00 -r platform -o test.json --force
... console output is unchanged ...
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ cat test.json
{
    "schema_version": {
        "schema": "JSON",
        "creation_date": "Wed Aug 23 23:38:04 2023 GMT"
    },
    "devices": [
        {
            ... Normal stuff ...
                    "status": {
                        "mig_calibrated": "false",
                        "p2p_status": "not supported",
                        "host_memory_status": "not supported"
                    },
           ... Normal stuff ...
        }
    ]
}
```

#### Documentation impact (if any)
None