### PR TITLE
Updating petalinux to stable version

### DIFF
--- a/build/petalinux.build
+++ b/build/petalinux.build
@@ -1,3 +1,3 @@
 # When updating Petalinux build please file a SH ticket to retain the build
 # https://jira.xilinx.com/secure/CreateIssue!default.jspa
-PETALINUX="/proj/petalinux/2023.2/petalinux-v2023.2_08071442/tool/petalinux-v2023.2-final"
+PETALINUX="/proj/petalinux/2023.2/petalinux-v2023.2_08011357/tool/petalinux-v2023.2-final"


### PR DESCRIPTION
apu package failure resolution ( related to https://github.com/Xilinx/XRT/pull/7673 )
Updating petalinux to stable version as apu_package fails with the version specified in this PR https://github.com/Xilinx/XRT/pull/7673