### PR TITLE
Fixes for CR-1167717, CR-1173167, and CR-1173061 

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info/aie_constructs.h
+++ b/src/runtime_src/xdp/profile/database/static_info/aie_constructs.h
@@ -28,6 +28,7 @@ namespace xdp {
   struct aiecompiler_options
   {
     bool broadcast_enable_core;
+    bool graph_iterator_event;
     std::string event_trace;
   };
 

--- a/src/runtime_src/xdp/profile/database/static_info/aie_util.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info/aie_util.cpp
@@ -90,8 +90,12 @@ namespace aie {
   aiecompiler_options getAIECompilerOptions(const boost::property_tree::ptree& aie_meta)
   {
     aiecompiler_options aiecompiler_options;
-    aiecompiler_options.broadcast_enable_core = aie_meta.get("aie_metadata.aiecompiler_options.broadcast_enable_core", false);
-    aiecompiler_options.event_trace = aie_meta.get("aie_metadata.aiecompiler_options.event_trace", "runtime");
+    aiecompiler_options.broadcast_enable_core = 
+        aie_meta.get("aie_metadata.aiecompiler_options.broadcast_enable_core", false);
+    aiecompiler_options.graph_iterator_event = 
+        aie_meta.get("aie_metadata.aiecompiler_options.graph_iterator_event", false);
+    aiecompiler_options.event_trace = 
+        aie_meta.get("aie_metadata.aiecompiler_options.event_trace", "runtime");
     return aiecompiler_options;
   }
 

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/edge/aie_profile.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/edge/aie_profile.cpp
@@ -271,60 +271,98 @@ namespace xdp {
     return (runningEvents.find(event) != runningEvents.end());
   }
 
+  uint8_t AieProfile_EdgeImpl::getPortNumberFromEvent(XAie_Events event)
+  {
+    switch (event) {
+    case XAIE_EVENT_PORT_RUNNING_1_CORE:
+    case XAIE_EVENT_PORT_STALLED_1_CORE:
+    case XAIE_EVENT_PORT_TLAST_1_PL:
+      return 1;
+    default:
+      return 0;
+    }
+  }
+
   // Configure stream switch ports for monitoring purposes
   // NOTE: Used to monitor streams: trace, interfaces, and memory tiles
-  XAie_Events
+  void
   AieProfile_EdgeImpl::configStreamSwitchPorts(XAie_DevInst* aieDevInst, const tile_type& tile,
                                                xaiefal::XAieTile& xaieTile, const XAie_LocType loc,
-                                               const module_type type, const XAie_Events event,
-                                               const std::string metricSet, const uint8_t channel)
+                                               const module_type type, const uint32_t numCounters,
+                                               const std::string metricSet, const uint8_t channel0, 
+                                               const uint8_t channel1, std::vector<XAie_Events>& startEvents, 
+                                               std::vector<XAie_Events>& endEvents)
   {
-    // Only configure as needed: must be applicable event and only need at most two
-    if (!isStreamSwitchPortEvent(event))
-      return event;
+    std::map<uint8_t, XAieStreamPortSelect> switchPortMap;
 
-    auto switchPortRsc = xaieTile.sswitchPort();
-    auto ret = switchPortRsc->reserve();
-    if (ret != AieRC::XAIE_OK)
-      return event;
+    // Traverse all counters and request monitor ports as needed
+    for (int i=0; i < numCounters; ++i) {
+      // Ensure applicable event
+      auto startEvent = startEvents.at(i);
+      auto endEvent = endEvents.at(i);
+      if (!isStreamSwitchPortEvent(startEvent))
+        continue;
 
-    if (type == module_type::core) {
-      // AIE Tiles (e.g., trace streams)
-      // Define stream switch port to monitor core or memory trace
-      uint8_t traceSelect = (event == XAIE_EVENT_PORT_RUNNING_0_CORE) ? 0 : 1;
-      switchPortRsc->setPortToSelect(XAIE_STRMSW_SLAVE, TRACE, traceSelect);
-    }
-    else if (type == module_type::shim) {
-      // Interface tiles (e.g., PLIO, GMIO)
-      // Grab slave/master and stream ID
-      // NOTE: stored in getTilesForProfiling() above
-      auto slaveOrMaster = (tile.itr_mem_col == 0) ? XAIE_STRMSW_SLAVE : XAIE_STRMSW_MASTER;
-      auto streamPortId  = static_cast<uint8_t>(tile.itr_mem_row);
-      switchPortRsc->setPortToSelect(slaveOrMaster, SOUTH, streamPortId);
-    }
-    else {
-      // Memory tiles
-      if (metricSet.find("trace") != std::string::npos) {
-        switchPortRsc->setPortToSelect(XAIE_STRMSW_SLAVE, TRACE, 0);
+      bool newPort = false;
+      auto portnum = getPortNumberFromEvent(startEvent);
+      auto portIter = switchPortMap.find(portnum);
+      XAieStreamPortSelect switchPortRsc;
+      if (iter == switchPortMap.end()) {
+        switchPortRsc = xaieTile.sswitchPort();
+        auto ret = switchPortRsc->reserve();
+        if (ret != AieRC::XAIE_OK)
+          continue;
+        newPort = true;
+        switchPortMap.at(portnum) = switchPortRsc;
+      } 
+      else {
+        switchPortRsc = (*portIter).second;
+      }
+
+      if (type == module_type::core) {
+        // AIE Tiles (e.g., trace streams)
+        // Define stream switch port to monitor core or memory trace
+        uint8_t traceSelect = (event == XAIE_EVENT_PORT_RUNNING_0_CORE) ? 0 : 1;
+        switchPortRsc->setPortToSelect(XAIE_STRMSW_SLAVE, TRACE, traceSelect);
+      }
+      else if (type == module_type::shim) {
+        // Interface tiles (e.g., PLIO, GMIO)
+        // Grab slave/master and stream ID
+        // NOTE: stored in getTilesForProfiling() above
+        auto slaveOrMaster = (tile.itr_mem_col == 0) ? XAIE_STRMSW_SLAVE : XAIE_STRMSW_MASTER;
+        auto streamPortId  = static_cast<uint8_t>(tile.itr_mem_row);
+        switchPortRsc->setPortToSelect(slaveOrMaster, SOUTH, streamPortId);
       }
       else {
-        auto slaveOrMaster = (metricSet.find("output") != std::string::npos) ?
-          XAIE_STRMSW_SLAVE : XAIE_STRMSW_MASTER;
-        switchPortRsc->setPortToSelect(slaveOrMaster, DMA, channel);
+        // Memory tiles
+        if (metricSet.find("trace") != std::string::npos) {
+          switchPortRsc->setPortToSelect(XAIE_STRMSW_SLAVE, TRACE, 0);
+        }
+        else {
+          uint8_t channel = (portnum == 0) ? channel0 : channel1;
+          auto slaveOrMaster = (metricSet.find("output") != std::string::npos) ?
+            XAIE_STRMSW_SLAVE : XAIE_STRMSW_MASTER;
+          switchPortRsc->setPortToSelect(slaveOrMaster, DMA, channel);
+        }
+      }
+
+      // Event options:
+      //   getSSIdleEvent, getSSRunningEvent, getSSStalledEvent, & getSSTlastEvent
+      XAie_Events ssEvent;
+      if (isPortRunningEvent(event))
+        switchPortRsc->getSSRunningEvent(ssEvent);
+      else
+        switchPortRsc->getSSStalledEvent(ssEvent);
+      startEvents.at(i) = ssEvent;
+      endEvents.at(i) = ssEvent;
+
+      if (newPort) {
+        switchPortRsc->start();
+        mStreamPorts.push_back(switchPortRsc);
       }
     }
 
-    // Event options:
-    //   getSSIdleEvent, getSSRunningEvent, getSSStalledEvent, & getSSTlastEvent
-    XAie_Events ssEvent;
-    if (isPortRunningEvent(event))
-      switchPortRsc->getSSRunningEvent(ssEvent);
-    else
-	    switchPortRsc->getSSStalledEvent(ssEvent);
-
-    switchPortRsc->start();
-    mStreamPorts.push_back(switchPortRsc);
-    return ssEvent;
+    switchPortMap.clear();
   }
 
   void 
@@ -530,7 +568,10 @@ namespace xdp {
         auto iter1 = configChannel1.find(tile);
         uint8_t channel0 = (iter0 == configChannel0.end()) ? 0 : iter0->second;
         uint8_t channel1 = (iter1 == configChannel1.end()) ? 1 : iter1->second;
+        
         configEventSelections(aieDevInst, loc, XAIE_MEM_MOD, type, metricSet, channel0, channel1);
+        configStreamSwitchPorts(aieDevInst, tileMetric.first, xaieTile, loc, type, numFreeCtr, 
+                                metricSet, channel0, channel1, startEvents, endEvents);
 
         // Request and configure all available counters for this tile
         for (int i=0; i < numFreeCtr; ++i) {
@@ -538,16 +579,8 @@ namespace xdp {
           auto endEvent      = endEvents.at(i);
           uint8_t resetEvent = 0;
 
-          // Channel number is based on monitoring port 0 or 1
-          auto channel = (startEvent <= XAIE_EVENT_PORT_TLAST_0_MEM_TILE) ? channel0 : channel1;
-
+          // Configure group event before reserving and starting counter
           configGroupEvents(aieDevInst, loc, mod, startEvent, metricSet);
-          auto event = configStreamSwitchPorts(aieDevInst, tileMetric.first, xaieTile, loc, type,
-                                               startEvent, metricSet, channel);
-          if (event != startEvent) {
-            endEvent = (endEvent == startEvent) ? event : endEvent;
-            startEvent = event;
-          }
 
           // Request counter from resource manager
           auto perfCounter = xaieModule.perfCounter();
@@ -556,7 +589,7 @@ namespace xdp {
           ret = perfCounter->reserve();
           if (ret != XAIE_OK) break;
 
-          // Start the counters after group events have been configured
+          // Start the counter
           ret = perfCounter->start();
           if (ret != XAIE_OK) break;
           mPerfCounters.push_back(perfCounter);
@@ -568,6 +601,10 @@ namespace xdp {
           XAie_EventLogicalToPhysicalConv(aieDevInst, loc, mod,   endEvent, &tmpEnd);
           uint16_t phyStartEvent = tmpStart + mCounterBases[type];
           uint16_t phyEndEvent   = tmpEnd   + mCounterBases[type];
+
+          // Get payload for reporting purposes
+          auto portnum = getPortNumberFromEvent(startEvent);
+          uint8_t channel = (portnum == 0) ? channel0 : channel1;
           auto payload = getCounterPayload(aieDevInst, tileMetric.first, type, col, row, 
                                            startEvent, metricSet, channel);
 

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/edge/aie_profile.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/edge/aie_profile.h
@@ -50,6 +50,7 @@ namespace xdp {
       bool isValidType(module_type type, XAie_ModuleType mod);
       bool isStreamSwitchPortEvent(const XAie_Events event);
       bool isPortRunningEvent(const XAie_Events event);
+      uint8_t getPortNumberFromEvent(XAie_Events event);
       void printTileModStats(xaiefal::XAieDev* aieDevice, 
                              const tile_type& tile, 
                              const XAie_ModuleType mod);
@@ -58,14 +59,17 @@ namespace xdp {
                              const XAie_ModuleType mod,
                              const XAie_Events event,
                              const std::string metricSet);
-      XAie_Events configStreamSwitchPorts(XAie_DevInst* aieDevInst,
-                                          const tile_type& tile,
-                                          xaiefal::XAieTile& xaieTile,
-                                          const XAie_LocType loc,
-                                          const module_type type,
-                                          const XAie_Events event,
-                                          const std::string metricSet,
-                                          const uint8_t channel);
+      void configStreamSwitchPorts(XAie_DevInst* aieDevInst,
+                                   const tile_type& tile,
+                                   xaiefal::XAieTile& xaieTile,
+                                   const XAie_LocType loc,
+                                   const module_type type,
+                                   const uint32_t numCounters,
+                                   const std::string metricSet,
+                                   const uint8_t channel0,
+                                   const uint8_t channel1,
+                                   std::vector<XAie_Events>& startEvents,
+                                   std::vector<XAie_Events>& endEvents);
       void configEventSelections(XAie_DevInst* aieDevInst,
                                  const XAie_LocType loc,
                                  const XAie_ModuleType mod,
@@ -81,6 +85,7 @@ namespace xdp {
                                  uint16_t startEvent,
                                  const std::string metricSet,
                                  const uint8_t channel);
+
     private:
       XAie_DevInst*     aieDevInst = nullptr;
       xaiefal::XAieDev* aieDevice  = nullptr;    

--- a/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.cpp
@@ -104,9 +104,9 @@ namespace xdp {
   {
     // Capture all tiles across all graphs
     // Note: in the future, we could support user-defined tile sets
-    auto graphs = aie::getValidGraphs(aieMeta);
+    auto graphs = aie::getValidGraphs(mAieMeta);
     for (auto& graph : graphs) {
-      mGraphCoreTilesMap[graph] = aie::getEventTiles(aieMeta, graph, module_type::core);
+      mGraphCoreTilesMap[graph] = aie::getEventTiles(mAieMeta, graph, module_type::core);
     }
 
     // Report tiles (debug only)
@@ -186,8 +186,8 @@ namespace xdp {
 
     // AIE core register offsets
     constexpr uint64_t AIE_OFFSET_CORE_STATUS = 0x32004;
-    auto offset = aie::getAIETileRowOffset(aieMeta);
-    auto hwGen = aie::getHardwareGeneration(aieMeta);
+    auto offset = aie::getAIETileRowOffset(mAieMeta);
+    auto hwGen = aie::getHardwareGeneration(mAieMeta);
 
     // This mask check for following states
     // ECC_Scrubbing_Stall
@@ -218,10 +218,6 @@ namespace xdp {
     // Reset values
     constexpr uint32_t CORE_RESET_STATUS  = 0x2;
     constexpr uint32_t CORE_ENABLE_MASK  = 0x1;
-    // Group error masks
-    constexpr uint64_t AIE_OFFSET_GROUP_ERRORS0_ENABLE = 0x34510;
-    constexpr uint64_t AIE_OFFSET_GROUP_ERRORS1_ENABLE = 0x34514;
-    constexpr uint32_t CORE_GROUP_ERROR_INSTR_EVENT_2_MASK = (1 << 20);
 
     // Tiles already reported with error(s)
     std::set<tile_type> errorTileSet;
@@ -236,15 +232,6 @@ namespace xdp {
       for (const auto& tile : kv.second) {
         coreStuckCountMap[tile] = 0;
         coreStatusMap[tile] = CORE_RESET_STATUS;
-
-        
-        //if (hwGen == 1) {
-        //  auto tileOffset = _XAie_GetTileAddr(aieDevInst, tile.row + offset, tile.col);
-        //  XAie_MaskWrite32(aieDevInst, tileOffset + AIE_OFFSET_GROUP_ERRORS0_ENABLE, 
-        //                   CORE_GROUP_ERROR_INSTR_EVENT_2_MASK, 0);
-        //  XAie_MaskWrite32(aieDevInst, tileOffset + AIE_OFFSET_GROUP_ERRORS1_ENABLE, 
-        //                   CORE_GROUP_ERROR_INSTR_EVENT_2_MASK, 0);
-        //}
       }
     }
 
@@ -425,7 +412,7 @@ namespace xdp {
     // Grab AIE metadata
     auto device = xrt_core::get_userpf_device(handle);
     auto data = device->get_axlf_section(AIE_METADATA);
-    aie::readAIEMetadata(data.first, data.second, aieMeta);
+    aie::readAIEMetadata(data.first, data.second, mAieMeta);
 
     // Update list of tiles to debug
     getTilesForStatus();

--- a/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.h
@@ -65,7 +65,7 @@ namespace xdp {
   private:
     static bool live;
     uint32_t mPollingInterval;
-    boost::property_tree::ptree aieMeta;
+    boost::property_tree::ptree mAieMeta;
 
     // Thread control flags for each device handle
     std::map<void*,std::atomic<bool>> mThreadCtrlMap;

--- a/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.h
@@ -26,10 +26,10 @@
 #include <vector>
 
 #include "xdp/profile/plugin/vp_base/vp_base_plugin.h"
+#include "xdp/profile/database/static_info/aie_util.h"
 #include "xdp/config.h"
 
 #include "core/common/device.h"
-#include "core/edge/common/aie_parser.h"
 #include "xaiefal/xaiefal.hpp"
 
 extern "C" {
@@ -38,8 +38,6 @@ extern "C" {
 }
 
 namespace xdp {
-
-  using tile_type = xrt_core::edge::aie::tile_type;
 
   class AIEStatusPlugin : public XDPPlugin
   {
@@ -56,21 +54,18 @@ namespace xdp {
     static bool alive();
 
   private:
-    void getTilesForStatus(void* handle);
+    void getTilesForStatus();
     void endPoll();
     std::string getCoreStatusString(uint32_t status);
-    uint16_t getAIETileRowOffset(void* handle);
-    static void read_aie_metadata(const char* data, size_t size, 
-                                  boost::property_tree::ptree& aie_project);
+    
     // Threads used by this plugin
     void pollDeadlock(uint64_t index, void* handle);
     void writeStatus(uint64_t index, void* handle, VPWriter* aieWriter);
 
   private:
-
     static bool live;
-
     uint32_t mPollingInterval;
+    boost::property_tree::ptree aieMeta;
 
     // Thread control flags for each device handle
     std::map<void*,std::atomic<bool>> mThreadCtrlMap;

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_metadata.cpp
@@ -219,8 +219,8 @@ namespace xdp {
     } else if (startType == "iteration") {
       // Verify AIE was compiled with the proper setting
       if (!graphIteratorEvent) {
-        std::string msg("Unable to use graph iteration as trace start type.\
-            Please re-compile AI Engine with --graph-iterator-event true.");
+        std::string msg = "Unable to use graph iteration as trace start type. ";
+        msg.append("Please re-compile AI Engine with --graph-iterator-event=true.");
         xrt_core::message::send(severity_level::warning, "XRT", msg);
       }
       else {

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_metadata.cpp
@@ -103,7 +103,7 @@ namespace xdp {
       getConfigMetricsForTiles(aieTileMetricsSettings, aieGraphMetricsSettings, module_type::core);
       getConfigMetricsForTiles(memTileMetricsSettings, memGraphMetricsSettings, module_type::mem_tile);
       getConfigMetricsForInterfaceTiles(shimTileMetricsSettings, shimGraphMetricsSettings);
-      setTraceStartControl();
+      setTraceStartControl(compilerOptions.graph_iterator_event);
     }
   }
 
@@ -158,7 +158,7 @@ namespace xdp {
   }
 
   // Parse trace start time or events
-  void AieTraceMetadata::setTraceStartControl()
+  void AieTraceMetadata::setTraceStartControl(bool graphIteratorEvent)
   {
     useDelay = false;
     useGraphIterator = false;
@@ -217,9 +217,17 @@ namespace xdp {
       useDelay = (cycles != 0);
       delayCycles = cycles;
     } else if (startType == "iteration") {
-      // Start trace when graph iterator reaches a threshold
-      iterationCount = xrt_core::config::get_aie_trace_settings_start_iteration();
-      useGraphIterator = (iterationCount != 0);
+      // Verify AIE was compiled with the proper setting
+      if (!graphIteratorEvent) {
+        std::string msg("Unable to use graph iteration as trace start type.\
+            Please re-compile AI Engine with --graph-iterator-event true.");
+        xrt_core::message::send(severity_level::warning, "XRT", msg);
+      }
+      else {
+        // Start trace when graph iterator reaches a threshold
+        iterationCount = xrt_core::config::get_aie_trace_settings_start_iteration();
+        useGraphIterator = (iterationCount != 0);
+      }
     } else if (startType == "kernel_event0") {
       // Start trace using user events
       useUserControl = true;

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_metadata.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_metadata.h
@@ -37,7 +37,7 @@ class AieTraceMetadata {
     AieTraceMetadata(uint64_t deviceID, void* handle);
 
     void checkSettings();
-    void setTraceStartControl();
+    void setTraceStartControl(bool graphIteratorEvent);
     std::vector<std::string> getSettingsVector(std::string settingsString);
     uint8_t getMetricSetIndex(std::string metricString);
     


### PR DESCRIPTION
**Problem solved by the commit**
* Don't poll core errors in status on AIE1 devices as it's unreliable
* Cleaned up AIE status to use local utilities
* Issue warning when user requests graph iterator-based trace start but design was not compiled to support that
* Streamlined and fixed bugs in stream switch port requests

**Risks (if any) associated the changes in the commit**
* AIE1 users no longer get runtime analysis of errors (but it wasn't reliable anyway)
* Old xclbins (without graph iterator metadata) will not support graph iterator-based trace start

**What has been tested and how, request additional testing if necessary**
* Tested on vck190 and vek280

**Documentation impact (if any)**
* AIE1 caveat on status?