### PR TITLE
VITIS-9224 Xbutil Enhancements for Power Management

### DIFF
--- a/src/runtime_src/core/common/info_platform.cpp
+++ b/src/runtime_src/core/common/info_platform.cpp
@@ -149,12 +149,20 @@ add_p2p_info(const xrt_core::device* device, ptree_type& pt)
 }
 
 void
+add_performance_info(const xrt_core::device* device, ptree_type& pt)
+{
+  const auto mode = xrt_core::device_query_default<xq::performance_mode>(device, 3);
+  pt.add("performance_mode", xq::performance_mode::parse_status(mode));
+}
+
+void
 add_status_info(const xrt_core::device* device, ptree_type& pt)
 {
   ptree_type pt_status;
 
   add_mig_info(device, pt_status);
   add_p2p_info(device, pt_status);
+  add_performance_info(device, pt_status);
 
   pt.put_child("status", pt_status);
 }

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -297,6 +297,7 @@ enum class key_type
   xgq_scaling_enabled,
   xgq_scaling_power_override,
   xgq_scaling_temp_override,
+  performance_mode,
   noop
 };
 
@@ -3342,6 +3343,37 @@ struct xgq_scaling_temp_override : request
 
   virtual void
   put(const device*, const boost::any&) const = 0;
+};
+
+struct performance_mode : request
+{
+  using result_type = uint32_t;  // get value type
+  using value_type = uint32_t;   // put value type
+
+  static const key_type key = key_type::performance_mode;
+
+  virtual boost::any
+  get(const device*) const = 0;
+
+  virtual void
+  put(const device*, const boost::any&) const = 0;
+
+  static std::string
+  parse_status(const result_type status)
+  {
+    switch(status) {
+      case 0:
+        return "Low";
+      case 1:
+        return "Medium";
+      case 2:
+        return "High";
+      case 3:
+        return "Default";
+      default:
+        throw xrt_core::system_error(EINVAL, "Invalid performance status: " + status);
+    }
+  }
 };
 
 } // query

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -3363,13 +3363,13 @@ struct performance_mode : request
   {
     switch(status) {
       case 0:
-        return "Low";
-      case 1:
-        return "Medium";
-      case 2:
-        return "High";
-      case 3:
         return "Default";
+      case 1:
+        return "Low";
+      case 2:
+        return "Medium";
+      case 3:
+        return "High";
       default:
         throw xrt_core::system_error(EINVAL, "Invalid performance status: " + status);
     }

--- a/src/runtime_src/core/tools/common/reports/ReportPlatforms.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportPlatforms.cpp
@@ -76,6 +76,7 @@ ReportPlatforms::writeReport( const xrt_core::device* /*_pDevice*/,
     const boost::property_tree::ptree& pt_status = pt_platform.get_child("status");
     _output << boost::format("  %-23s: %s \n") % "Mig Calibrated" % pt_status.get<std::string>("mig_calibrated");
     _output << boost::format("  %-23s: %s \n") % "P2P Status" % pt_status.get<std::string>("p2p_status");
+    _output << boost::format("  %-23s: %s \n") % "Performance Mode" % pt_status.get<std::string>("performance_mode");
 
     const boost::property_tree::ptree ptEmpty; 
     const boost::property_tree::ptree& pt_config = pt_platform.get_child("config.p2p", ptEmpty); 

--- a/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
@@ -43,6 +43,7 @@ file(GLOB XBUTIL_V2_SUBCMD_FILES
   "OO_AieRegRead.cpp"
   "OO_AieClockFreq.cpp"
   "OO_HostMem.cpp"
+  "OO_Performance.cpp"
 )
 
 # Merge the files into one collection

--- a/src/runtime_src/core/tools/xbutil2/OO_Performance.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_Performance.cpp
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+
+// ------ I N C L U D E   F I L E S -------------------------------------------
+// Local - Include Files
+#include "OO_Performance.h"
+#include "tools/common/XBUtilitiesCore.h"
+#include "tools/common/XBUtilities.h"
+
+// 3rd Party Library - Include Files
+#include <boost/program_options.hpp>
+#include <boost/algorithm/string.hpp>
+namespace po = boost::program_options;
+
+// ----- C L A S S   M E T H O D S -------------------------------------------
+
+OO_Performance::OO_Performance( const std::string &_longName, bool _isHidden )
+    : OptionOptions(_longName, _isHidden, "Change performance mode of the device")
+    , m_device("")
+    , m_action("")
+    , m_help(false)
+{
+  m_optionsDescription.add_options()
+    ("device,d", boost::program_options::value<decltype(m_device)>(&m_device), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest")
+    ("action", boost::program_options::value<decltype(m_action)>(&m_action)->required(), "Action to perform: DEFAULT, LOW, MEDIUM or HIGH")
+    ("help", boost::program_options::bool_switch(&m_help), "Help to use this sub-command")
+  ;
+
+  m_positionalOptions.
+    add("action", 1 /* max_count */)
+  ;
+}
+
+void
+OO_Performance::execute(const SubCmdOptions& _options) const
+{
+  XBUtilities::verbose("SubCommand option: Performance");
+
+  XBUtilities::verbose("Option(s):");
+  for (auto & aString : _options)
+    XBUtilities::verbose(std::string(" ") + aString);
+
+  // Honor help option first
+  if (std::find(_options.begin(), _options.end(), "--help") != _options.end()) {
+    printHelp();
+    return;
+  }
+
+  // Parse sub-command ...
+  po::variables_map vm;
+  process_arguments(vm, _options);
+
+  if(m_help) {
+    printHelp();
+    throw xrt_core::error(std::errc::operation_canceled);
+  }
+  // Exit if neither action or device specified
+  if(m_action.empty()) {
+    printHelp();
+    throw xrt_core::error(std::errc::operation_canceled);
+  }
+  if(m_device.empty()) {
+    std::cerr << boost::format("ERROR: A device needs to be specified.\n");
+    throw xrt_core::error(std::errc::operation_canceled);
+  }
+
+  // Find device of interest
+  std::shared_ptr<xrt_core::device> device;
+  
+  try {
+    device = XBUtilities::get_device(boost::algorithm::to_lower_copy(m_device), true /*inUserDomain*/);
+  } catch (const std::runtime_error& e) {
+    // Catch only the exceptions that we have generated earlier
+    std::cerr << boost::format("ERROR: %s\n") % e.what();
+    throw xrt_core::error(std::errc::operation_canceled);
+  }
+
+  try {
+    if(boost::iequals(m_action, "LOW")) {
+      xrt_core::device_update<xrt_core::query::performance_mode>(device.get(), 0);
+    }
+    else if(boost::iequals(m_action, "MEDIUM")) {
+      xrt_core::device_update<xrt_core::query::performance_mode>(device.get(), 1);
+    }
+    else if(boost::iequals(m_action, "HIGH")) {
+      xrt_core::device_update<xrt_core::query::performance_mode>(device.get(), 2);
+    }
+    else if(boost::iequals(m_action, "DEFAULT")) {
+      xrt_core::device_update<xrt_core::query::performance_mode>(device.get(), 3);
+    }
+    else {
+      std::cerr << boost::format("ERROR: Invalid action value: '%s'\n") % m_action;
+      printHelp();
+      throw xrt_core::error(std::errc::operation_canceled);
+    }
+    std::cout << boost::format("\nPerformance mode is set to %s \n") % (boost::algorithm::to_lower_copy(m_action));
+  }
+  catch(const xrt_core::error& e) {
+    std::cerr << boost::format("\nERROR: %s\n") % e.what();
+    throw xrt_core::error(std::errc::operation_canceled);
+  }
+  catch (const std::runtime_error& e) {
+    std::cerr << boost::format("\nERROR: %s\n") % e.what();
+    throw xrt_core::error(std::errc::operation_canceled);
+  }
+}

--- a/src/runtime_src/core/tools/xbutil2/OO_Performance.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_Performance.cpp
@@ -76,16 +76,16 @@ OO_Performance::execute(const SubCmdOptions& _options) const
   }
 
   try {
-    if(boost::iequals(m_action, "LOW")) {
+    if(boost::iequals(m_action, "DEFAULT")) {
       xrt_core::device_update<xrt_core::query::performance_mode>(device.get(), 0);
     }
-    else if(boost::iequals(m_action, "MEDIUM")) {
+    else if(boost::iequals(m_action, "LOW")) {
       xrt_core::device_update<xrt_core::query::performance_mode>(device.get(), 1);
     }
-    else if(boost::iequals(m_action, "HIGH")) {
+    else if(boost::iequals(m_action, "MEDIUM")) {
       xrt_core::device_update<xrt_core::query::performance_mode>(device.get(), 2);
     }
-    else if(boost::iequals(m_action, "DEFAULT")) {
+    else if(boost::iequals(m_action, "HIGH")) {
       xrt_core::device_update<xrt_core::query::performance_mode>(device.get(), 3);
     }
     else {

--- a/src/runtime_src/core/tools/xbutil2/OO_Performance.h
+++ b/src/runtime_src/core/tools/xbutil2/OO_Performance.h
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+
+#ifndef __OO_Performance_h_
+#define __OO_Performance_h_
+
+#include "tools/common/OptionOptions.h"
+
+class OO_Performance : public OptionOptions {
+ public:
+  virtual void execute( const SubCmdOptions &_options ) const;
+
+ public:
+  OO_Performance( const std::string &_longName, bool _isHidden = false);
+
+ private:
+  std::string m_device;
+  std::string m_action;
+  bool m_help;
+};
+
+#endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdConfigure.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdConfigure.cpp
@@ -21,10 +21,12 @@
 #include "tools/common/SubCmdConfigureInternal.h"
 #include "OO_HostMem.h"
 #include "OO_P2P.h"
+#include "OO_Performance.h"
 
 std::vector<std::shared_ptr<OptionOptions>> SubCmdConfigureInternal::optionOptionsCollection = {
   std::make_shared<OO_HostMem>("host-mem"),
   std::make_shared<OO_P2P>("p2p"),
+  std::make_shared<OO_Performance>("performance"),
 };
 
 SubCmdConfigure::SubCmdConfigure(bool _isHidden, bool _isDepricated, bool _isPreliminary, const boost::property_tree::ptree configurations)

--- a/src/runtime_src/core/tools/xbutil2/xbutil.cpp
+++ b/src/runtime_src/core/tools/xbutil2/xbutil.cpp
@@ -38,7 +38,7 @@ R"(
             "contents": ["dynamic-regions", "electrical", "host", "mechanical", "memory", "pcie-info", "platform", "thermal"]
         },{
             "name": "configure",
-            "contents": ["host-mem", "p2p"]
+            "contents": ["host-mem", "p2p", "performance"]
         }]
     },{
         "name": "alveo",

--- a/src/runtime_src/doc/toc/xbutil.rst
+++ b/src/runtime_src/doc/toc/xbutil.rst
@@ -211,7 +211,7 @@ Command ``xbutil configure`` is used to configure specific settings based on the
 
 .. code-block:: shell 
 
-    xbutil configure [--device| -d] <user bdf> [--host-mem|--p2p] <action> [--size <size>]
+    xbutil configure [ --host-mem | --p2p | --performance ] [--help]
 
 
 **The details of the supported options**
@@ -226,6 +226,12 @@ Command ``xbutil configure`` is used to configure specific settings based on the
 - The ``--size`` is used in conjuction with ``xbutil configure --host-mem enable`` to specify the host-memory size to be enabled
     
     - ``<size>``: Size and unit specified as a combined string 
+- The ``--performance`` select specific configuration for benchmarking tests
+    
+    - ``low``: Set performance mode to low
+    - ``medium``: Set performance mode to medium
+    - ``high``: Set performance mode to high
+    - ``default``: Set performance mode to default
     
  
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Plumbing for
- [VITIS-9561](https://jira.xilinx.com/browse/VITIS-9561) Set high, medium and low performance mode
- [VITIS-9562](https://jira.xilinx.com/browse/VITIS-9562) Report current frequencies and performance mode

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
N/A
#### How problem was solved, alternative solutions (if any) and why they were rejected
Created a new subcommand to set performance and display which mode it is in platform report

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Tested with simulated values:
```
$ xbutil examine -d b3:00 -r platform

---------------------------------------------------
[0000:b3:00.1] : xilinx_vck5000_gen4x8_qdma_base_2
---------------------------------------------------
Platform
  XSA Name               : xilinx_vck5000_gen4x8_qdma_base_2 
  Logic UUID             : 05DCA096-76CB-730B-8D19-EC1192FBAE3F 
  FPGA Name              :  
  JTAG ID Code           : 0x0 
  DDR Size               : 0 Bytes
  DDR Count              : 0 
  Revision               : 1 
  MFG Date               : 0xcee875 
  Mig Calibrated         : false 
  P2P Status             : not supported 
  Performance Mode       : Default

Clocks
  DATA_CLK (Data)        : 300 MHz
  KERNEL_CLK (Kernel)    : 500 MHz

Mac Addresses            : 00:0A:35:0D:55:8E
                         : 00:0A:35:0D:55:8F
```
```
$ xbutil configure --performance -d b3:00 low

Performance mode is set to low 

```

Negative test:
```
$ xbutil configure --performance -d b3:00 lo
ERROR: Invalid action value: 'lo'

COMMAND: configure

DESCRIPTION: Change performance mode of the device

USAGE:  configure --performance [--help] [-d arg] action

OPTIONS:
  --performance      - Change performance mode of the device
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest
  --help             - Help to use this sub-command


ERROR: : Operation canceled
```

#### Documentation impact (if any)
Added the new command usage to github.io