### PR TITLE
CR-1172570 : Fix ert_false issue for versal device

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -2472,6 +2472,9 @@ int xocl_kds_unregister_cus(struct xocl_dev *xdev, int slot_hdl)
 		return ret;
 	}
 
+	if (XDEV(xdev)->kds.ert_disable == true)
+		return ret;
+
 	if (!xocl_ert_ctrl_is_version(xdev, 1, 0))
 		return ret;
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
[CR-1172570](https://jira.xilinx.com/browse/CR-1172570)
ASTeR TC 7.02 - v70pq2 base 2 - Disabling ERT and running xbutil validate causes server to stall
 --  Added a check before unregister the Cus/SCus when ert false

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
