### PR TITLE
CR-1173328 xbmgmt configure does not detect bad arguments

### DIFF
--- a/src/runtime_src/core/tools/common/SubCmdConfigureInternal.cpp
+++ b/src/runtime_src/core/tools/common/SubCmdConfigureInternal.cpp
@@ -348,6 +348,10 @@ SubCmdConfigureInternal::execute(const SubCmdOptions& _options) const
     return;
   }
 
+  // If no OptionOption was selected reprocess the arguments, but, validate
+  // them to catch unwanted options
+  process_arguments(vm, _options);
+
   // Take care of executing hidden options for xbmgmt.
   if (!m_isUserDomain) {
     // -- process "help" option -----------------------------------------------


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1173328
 `xbmgmt configure` does not report incorrect options.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Introduced in https://github.com/Xilinx/XRT/pull/7571

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added an additional argument check that validates the arguments after validating no suboptions have been invoked. Since SubCmdConfigure is somewhat of a special case, this is the simplest solution!

#### Risks (if any) associated the changes in the commit
None. This is a bug fix.

#### What has been tested and how, request additional testing if necessary
Ubuntu 22.04 VCK5000
```
root@xsjdbenusov50:/proj/rdi/staff/dbenusov# xbmgmt configure --output
WARNING: Unexpected xclmgmt version (2.14.0) was found. Expected 2.16.0, to match XRT tools.
ERROR: Unrecognized arguments:
  --output


COMMAND: configure

DESCRIPTION: Advanced options for configuring a device

USAGE: xbmgmt configure [ --input arg | [--retention arg] ] [--help] [-d arg]

OPTIONS:
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest
  --help             - Help to use this sub-command
  --input            - Takes an INI file with configuration details (e.g. memory, clock throttling)
                       and loads them onto the device
  --retention        - Enables / Disables memory retention. Valid values are: [ENABLE | DISABLE]


GLOBAL OPTIONS:
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
```

#### Documentation impact (if any)
None