### PR TITLE
[CR-1161728]: emconfig.json path issue if host code is in python.

### DIFF
--- a/src/runtime_src/core/pcie/emulation/common_em/config.cxx
+++ b/src/runtime_src/core/pcie/emulation/common_em/config.cxx
@@ -102,7 +102,7 @@ namespace xclemulation{
     return defaultValue;
   }
 
-  static boost::filesystem::path get_file_absolutepath(std::string& filename) {
+  static boost::filesystem::path get_file_absolutepath(const std::string& filename) {
     
     boost::filesystem::path exe_parent_path {getExecutablePath()};
     auto filepath = exe_parent_path / filename;
@@ -421,23 +421,16 @@ namespace xclemulation{
 
   static std::string getEmConfigFilePath()
   {
-    std::string executablePath = getExecutablePath();
-    std::string emConfigPath = valueOrEmpty(std::getenv("EMCONFIG_PATH"));
-    if (!emConfigPath.empty()) {
-      executablePath = emConfigPath;
+    auto filename{"emconfig.json"};
+    auto filepath = get_file_absolutepath(filename);
+    boost::filesystem::path emconfig_env {valueOrEmpty(std::getenv("EMCONFIG_PATH"))};
+    if (emconfig_env.empty() == false) {
+      auto filepath_env_value = emconfig_env / "emconfig.json";
+      if (boost::filesystem::exists(filepath_env_value)) {
+        filepath = filepath_env_value;
+      }
     }
-    std::string xclEmConfigfile = executablePath.empty()? "emconfig.json" :executablePath+ "/emconfig.json";
-    if (boost::filesystem::exists(xclEmConfigfile))
-      return xclEmConfigfile;
-    // Probably executablePath pointing to invalid absolute path. 
-    auto self_path = boost::filesystem::current_path();
-    auto EmConfigfile = self_path / "emconfig.json";
-
-    if (boost::filesystem::exists(EmConfigfile))
-      return EmConfigfile.string();
-
-    // Cannont find the emconfig.json path
-    return "";
+    return filepath.string();
   }
 
   bool isXclEmulationModeHwEmuOrSwEmu()

--- a/src/runtime_src/core/pcie/emulation/common_em/config.cxx
+++ b/src/runtime_src/core/pcie/emulation/common_em/config.cxx
@@ -397,8 +397,11 @@ namespace xclemulation{
     // the host code might be python script.
     auto substrvalue = hostBinaryPath.substr(0,5);
     if (substrvalue == "/usr/") {
-      //if (hostBinaryPath.find("pthon") != std::string::npos )
+      // Try if the argv[0] is python only
+      if (hostBinaryPath.find("python") != std::string::npos ) {
         hostBinaryPath = boost::filesystem::current_path().string();
+        return hostBinaryPath;
+      }
     }
     
     std::string directory;

--- a/src/runtime_src/core/pcie/emulation/common_em/config.cxx
+++ b/src/runtime_src/core/pcie/emulation/common_em/config.cxx
@@ -392,6 +392,15 @@ namespace xclemulation{
     {
       std::cout<<"unable to findout the host binary path in emulation driver "<<std::endl;
     }
+    // Get the process binary name
+    // If hostBinaryPath is starting with /usr/ then it is very likely that
+    // the host code might be python script.
+    auto substrvalue = hostBinaryPath.substr(0,5);
+    if (substrvalue == "/usr/") {
+      //if (hostBinaryPath.find("pthon") != std::string::npos )
+        hostBinaryPath = boost::filesystem::current_path().string();
+    }
+    
     std::string directory;
     const size_t last_slash_idx = hostBinaryPath.rfind("/");
     if (std::string::npos != last_slash_idx)
@@ -405,16 +414,11 @@ namespace xclemulation{
 
     std::string xclEmConfigfile = executablePath.empty()? "emconfig.json" :executablePath+ "/emconfig.json";
     if (boost::filesystem::exists(xclEmConfigfile) == false) {
-      std::cout << "\n INFO: [EMU 01-01] emconfig json is not present at "<< xclEmConfigfile << ".\n";
-    }
-
-    executablePath = boost::filesystem::current_path().string() + "/emconfig.json";
-    if (boost::filesystem::exists(executablePath) == false) {
-      std::cout << "\n INFO: [EMU 01-02] emconfig json is not present at "<< executablePath << " as well!\n";
+      std::cout << "\n CRITICAL WARNING: [EMU 01-01] emconfig json is not present at "<< executablePath << ". Please ensure EMCONFIG_PATH is set.\n";
       return "";
     }
 
-    return executablePath;
+    return xclEmConfigfile;
   }
 
   static std::string getEmConfigFilePath()

--- a/src/runtime_src/core/pcie/emulation/common_em/config.cxx
+++ b/src/runtime_src/core/pcie/emulation/common_em/config.cxx
@@ -401,16 +401,16 @@ namespace xclemulation{
     return directory;
   }
 
-  static std::string verifi_emconfig_json(std::string& executablePath) {
+  static std::string verify_emconfig_json(std::string& executablePath) {
 
     std::string xclEmConfigfile = executablePath.empty()? "emconfig.json" :executablePath+ "/emconfig.json";
     if (boost::filesystem::exists(xclEmConfigfile) == false) {
-      std::cerr << "\n file does not exists at "<< xclEmConfigfile << ".\n";
+      std::cout << "\n INFO: [EMU 01-01] emconfig json is not present at "<< xclEmConfigfile << ".\n";
     }
 
     executablePath = boost::filesystem::current_path().string() + "/emconfig.json";
     if (boost::filesystem::exists(executablePath) == false) {
-      std::cerr << "\n file does not exists at "<< executablePath << " as well!\n";
+      std::cout << "\n INFO: [EMU 01-02] emconfig json is not present at "<< executablePath << " as well!\n";
       return "";
     }
 
@@ -424,7 +424,7 @@ namespace xclemulation{
     if (!emConfigPath.empty()) {
       executablePath = emConfigPath;
     }
-    return verifi_emconfig_json(executablePath);
+    return verify_emconfig_json(executablePath);
   }
 
   bool isXclEmulationModeHwEmuOrSwEmu()

--- a/src/runtime_src/core/pcie/emulation/common_em/config.cxx
+++ b/src/runtime_src/core/pcie/emulation/common_em/config.cxx
@@ -396,12 +396,8 @@ namespace xclemulation{
     // If hostBinaryPath is starting with /usr/ then it is very likely that
     // the host code might be python script.
     auto substrvalue = hostBinaryPath.substr(0,5);
-    if (substrvalue == "/usr/") {
-      // Try if the argv[0] is python only
-      if (hostBinaryPath.find("python") != std::string::npos ) {
-        hostBinaryPath = boost::filesystem::current_path().string();
-        return hostBinaryPath;
-      }
+    if ((substrvalue == "/usr/") && (hostBinaryPath.find("python") != std::string::npos )) {
+      return boost::filesystem::current_path().string();
     }
     
     std::string directory;

--- a/src/runtime_src/core/pcie/emulation/common_em/config.cxx
+++ b/src/runtime_src/core/pcie/emulation/common_em/config.cxx
@@ -392,13 +392,6 @@ namespace xclemulation{
     {
       std::cout<<"unable to findout the host binary path in emulation driver "<<std::endl;
     }
-
-    if (hostBinaryPath.find("python") != std::string::npos) 
-    {
-      auto fullpath = boost::filesystem::current_path();
-      auto fullpathstr = fullpath.c_str();
-      return fullpathstr;
-    }
     std::string directory;
     const size_t last_slash_idx = hostBinaryPath.rfind("/");
     if (std::string::npos != last_slash_idx)
@@ -408,6 +401,22 @@ namespace xclemulation{
     return directory;
   }
 
+  static std::string verifi_emconfig_json(std::string& executablePath) {
+
+    std::string xclEmConfigfile = executablePath.empty()? "emconfig.json" :executablePath+ "/emconfig.json";
+    if (boost::filesystem::exists(xclEmConfigfile) == false) {
+      std::cerr << "\n file does not exists at "<< xclEmConfigfile << ".\n";
+    }
+
+    executablePath = boost::filesystem::current_path().string() + "/emconfig.json";
+    if (boost::filesystem::exists(executablePath) == false) {
+      std::cerr << "\n file does not exists at "<< executablePath << " as well!\n";
+      return "";
+    }
+
+    return executablePath;
+  }
+
   static std::string getEmConfigFilePath()
   {
     std::string executablePath = getExecutablePath();
@@ -415,8 +424,7 @@ namespace xclemulation{
     if (!emConfigPath.empty()) {
       executablePath = emConfigPath;
     }
-    std::string xclEmConfigfile = executablePath.empty()? "emconfig.json" :executablePath+ "/emconfig.json";
-    return xclEmConfigfile;
+    return verifi_emconfig_json(executablePath);
   }
 
   bool isXclEmulationModeHwEmuOrSwEmu()

--- a/src/runtime_src/core/pcie/emulation/common_em/config.cxx
+++ b/src/runtime_src/core/pcie/emulation/common_em/config.cxx
@@ -392,6 +392,13 @@ namespace xclemulation{
     {
       std::cout<<"unable to findout the host binary path in emulation driver "<<std::endl;
     }
+
+    if (hostBinaryPath.find("python") != std::string::npos) 
+    {
+      auto fullpath = boost::filesystem::current_path();
+      auto fullpathstr = fullpath.c_str();
+      return fullpathstr;
+    }
     std::string directory;
     const size_t last_slash_idx = hostBinaryPath.rfind("/");
     if (std::string::npos != last_slash_idx)


### PR DESCRIPTION
Fix:  emconfig.json file path is wrongly deduced with getSelfPath API especially if host code is python script. The current fix ensures the proper current path is chosen if the exe name contains /usr/*/python in it.

Risk: very low

Tests: Canary Run. Results are Clean.

Reviewer: venkatp
