### PR TITLE
Fix for CR-1146345: APU Boot time Duration Minimization

### DIFF
--- a/build/build_edge.sh
+++ b/build/build_edge.sh
@@ -142,6 +142,7 @@ config_versal_project()
 
     # Configure u-boot to pick dtb from address 0x40000
     UBOOT_USER_SCRIPT=$APU_RECIPES_DIR/u-boot_custom.cfg
+    echo "CONFIG_BOOTDELAY=0" >> $UBOOT_USER_SCRIPT
     cp $UBOOT_USER_SCRIPT $VERSAL_PROJECT_DIR/project-spec/meta-user/recipes-bsp/u-boot/files
     echo "SRC_URI += \"file://u-boot_custom.cfg\"" >> $VERSAL_PROJECT_DIR/project-spec/meta-user/recipes-bsp/u-boot/u-boot-xlnx_%.bbappend
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1136757
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
setting CONFIG_BOOTDELAY=0, to autoboot with no delay but you can abort it by key input
#### Risks (if any) associated the changes in the commit
low
#### What has been tested and how, request additional testing if necessary
Built and tested apu package on v70
#### Documentation impact (if any)
NA