### PR TITLE
CR-1172747: changing the dt names of versal nodes.

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/common/zocl_drv.c
+++ b/src/runtime_src/core/edge/drm/zocl/common/zocl_drv.c
@@ -1063,10 +1063,12 @@ const struct drm_gem_object_funcs zocl_cma_default_funcs = {
 #endif
 static const struct zdev_data zdev_data_mpsoc = {
 	.fpga_driver_name = "pcap",
+	.fpga_driver_new_name = "pcap"
 };
 
 static const struct zdev_data zdev_data_versal = {
-	.fpga_driver_name = "versal_fpga"
+	.fpga_driver_name = "versal_fpga",
+	.fpga_driver_new_name = "versal-fpga"
 };
 
 static const struct of_device_id zocl_drm_of_match[] = {
@@ -1188,6 +1190,11 @@ static int zocl_drm_platform_probe(struct platform_device *pdev)
 		 */
 		fnode = of_find_node_by_name(NULL,
 				     zdev->zdev_data_info->fpga_driver_name);
+		if(!fnode) {
+			fnode = of_find_node_by_name(NULL,
+				     zdev->zdev_data_info->fpga_driver_new_name);
+		}
+
 		if (fnode) {
 			zdev->fpga_mgr = of_fpga_mgr_get(fnode);
 			if (IS_ERR(zdev->fpga_mgr))

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_util.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_util.h
@@ -114,6 +114,7 @@ struct zocl_mem {
  */
 struct zdev_data {
 	char fpga_driver_name[64];
+	char fpga_driver_new_name[64];
 };
 
 struct aie_metadata {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
CR-1172747: AIE-OOB failed to load xclbin, DT team has changed the auto generated device tree names. XRT need to update its code to support both new and old names

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
AIE OOB tests are failing as XRT is not able to find the new dt node

#### How problem was solved, alternative solutions (if any) and why they were rejected
Looking for both new and old DT names in XRT

#### Risks (if any) associated the changes in the commit
No

#### What has been tested and how, request additional testing if necessary
Verified edge/v70 flows

#### Documentation impact (if any)
None