### PR TITLE
CR-1174424: empty graph based interface tile trace

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_profile/edge/aie_profile.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/edge/aie_profile.cpp
@@ -324,7 +324,6 @@ namespace xdp {
         else if (type == module_type::shim) {
           // Interface tiles (e.g., PLIO, GMIO)
           // Grab slave/master and stream ID
-          // NOTE: stored in getTilesForProfiling() above
           auto slaveOrMaster = (tile.itr_mem_col == 0) ? XAIE_STRMSW_SLAVE : XAIE_STRMSW_MASTER;
           auto streamPortId  = static_cast<uint8_t>(tile.itr_mem_row);
           switchPortRsc->setPortToSelect(slaveOrMaster, SOUTH, streamPortId);

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/edge/aie_trace.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/edge/aie_trace.h
@@ -47,10 +47,12 @@ namespace xdp {
     module_type getModuleType(uint16_t absRow, XAie_ModuleType mod);
     bool isStreamSwitchPortEvent(const XAie_Events event);
     bool isPortRunningEvent(const XAie_Events event);
-    XAie_Events configStreamSwitchPorts(XAie_DevInst* aieDevInst, const tile_type& tile,
-                                        xaiefal::XAieTile& xaieTile, const XAie_LocType loc,
-                                        const module_type type, const XAie_Events event,
-                                        const std::string metricSet, const uint8_t channel);
+    uint8_t getPortNumberFromEvent(XAie_Events event);
+    void configStreamSwitchPorts(XAie_DevInst* aieDevInst, const tile_type& tile,
+                                 xaiefal::XAieTile& xaieTile, const XAie_LocType loc,
+                                 const module_type type, const std::string metricSet, 
+                                 const uint8_t channel0, const uint8_t channel1,
+                                 std::vector<XAie_Events>& events);
     void configEventSelections(XAie_DevInst* aieDevInst, const XAie_LocType loc, 
                                const XAie_ModuleType mod, const module_type type, 
                                const std::string metricSet, const uint8_t channel0,


### PR DESCRIPTION
**Problem solved by the commit**
interface tile trace was not requesting or configuring stream switch monitor ports correctly

**How problem was solved, alternative solutions (if any) and why they were rejected**
correct how monitor ports are requested using the minimum

**Risks (if any) associated the changes in the commit**
only affects specific metric sets in trace (e.g., interface tiles)

**What has been tested and how, request additional testing if necessary**
tested CR design on vck190; also testing on vek280

**Documentation impact (if any)**
none
