### PR TITLE
Return ENODATA Error code if bitstream is not present

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -1111,6 +1111,10 @@ static int icap_download_hw(struct icap *icap, const struct axlf *axlf)
 		primaryFirmwareOffset = primaryHeader->m_sectionOffset;
 		primaryFirmwareLength = primaryHeader->m_sectionSize;
 	}
+        else{
+                ICAP_ERR(icap,"invalied xclbin failed to read bitstream");
+                err = -ENODATA;
+                goto done;
 
 	if ((primaryFirmwareOffset + primaryFirmwareLength) > length) {
 		ICAP_ERR(icap, "Invalid BITSTREAM size");

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -1115,6 +1115,7 @@ static int icap_download_hw(struct icap *icap, const struct axlf *axlf)
                 ICAP_ERR(icap,"invalied xclbin failed to read bitstream");
                 err = -ENODATA;
                 goto done;
+	}
 
 	if ((primaryFirmwareOffset + primaryFirmwareLength) > length) {
 		ICAP_ERR(icap, "Invalid BITSTREAM size");

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -1112,7 +1112,7 @@ static int icap_download_hw(struct icap *icap, const struct axlf *axlf)
 		primaryFirmwareLength = primaryHeader->m_sectionSize;
 	}
         else{
-                ICAP_ERR(icap,"invalied xclbin failed to read bitstream");
+                ICAP_ERR(icap,"Invalid xclbin. Bitstream is not present in xclbin");
                 err = -ENODATA;
                 goto done;
 	}

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -1111,7 +1111,7 @@ static int icap_download_hw(struct icap *icap, const struct axlf *axlf)
 		primaryFirmwareOffset = primaryHeader->m_sectionOffset;
 		primaryFirmwareLength = primaryHeader->m_sectionSize;
 	}
-        else{
+        else {
                 ICAP_ERR(icap,"Invalid xclbin. Bitstream is not present in xclbin");
                 err = -ENODATA;
                 goto done;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
[CR-1128292](https://jira.xilinx.com/browse/CR-1128292) If bitstream is not present in the xclbin. We need to give different error code instead of EINVAL.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
NA
#### How problem was solved, alternative solutions (if any) and why they were rejected
Added check in the icap_download_hw() function. If the bitstream is not present we are returning the ENODATA code and printing it is dmesg log.
#### Risks (if any) associated the changes in the commit
No
#### What has been tested and how, request additional testing if necessary
Teseted on U250.
#### Documentation impact (if any)
No