### PR TITLE
Update ulite function to match newer Linux kernel

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ulite.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ulite.c
@@ -573,7 +573,7 @@ static int ulite_remove(struct platform_device *pdev)
 	if (pdata->thread)
 		kthread_stop(pdata->thread);
 
-	ret = uart_remove_one_port(pdata->xcl_ulite_driver, port);
+	uart_remove_one_port(pdata->xcl_ulite_driver, port);
 	platform_set_drvdata(pdev, NULL);
 	port->mapbase = 0;
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ulite.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ulite.c
@@ -554,20 +554,29 @@ done:
 	return ret;
 }
 
+/*
+ * Sometime in Kernel version 6.5+ the platform_driver probe function will have
+ * its return code changed from `int` to `void`. This is to enforce the notion
+ * that the returned error code does nothing.
+ * For now, older drivers should handle the error within this function and return
+ * anything. Once the conversion of the return type is complete we must update
+ * the return type from int to void and change all instances of `return 0` to
+ * `return`.
+ * https://elixir.bootlin.com/linux/latest/source/include/linux/platform_device.h#L211
+ */
 static int ulite_remove(struct platform_device *pdev)
 {
 	struct uart_port *port = platform_get_drvdata(pdev);
-	int ret = 0;
 	struct uartlite_data *pdata;
 
 	if (!port)
-		return ret;
+		return 0;
 
 	sysfs_remove_group(&pdev->dev.kobj, &ulite_attr_group);
 
 	pdata = port->private_data;
 	if (!pdata)
-		return ret;
+		return 0;
 
 	atomic_set(&pdata->console_opened, 0);
 	if (pdata->thread)
@@ -577,7 +586,7 @@ static int ulite_remove(struct platform_device *pdev)
 	platform_set_drvdata(pdev, NULL);
 	port->mapbase = 0;
 
-	return ret;
+	return 0;
 }
 
 struct xocl_drv_private ulite_priv = {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
In the newest kernel (6.5.1+) the definition of `uart_remove_one_port` has changed to no longer have a return code.

In ulite.c we store that return code. Apparently we should not.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Tried installing the newest package onto my machine and it failed with
```
ERROR (dkms apport): kernel package linux-headers-6.5.0-rc1+ is not supported
Error!  Build of xclmgmt.ko failed for: 6.5.0-rc1+ (x86_64)
Make sure the name of the generated module is correct and at the root of the
build directory, or consult make.log in the build directory
/var/lib/dkms/xrt/2.16.188/build/ for more information.
****************************************************************
* DKMS failed to install XRT drivers.
* Please check if kernel development headers are installed for OS variant used.
*
* Check build logs in /var/lib/dkms/xrt/2.16.188
****************************************************************
Installing MSD / MPD daemons
| Components                   |      Status        |
|------------------------------|--------------------|
| XOCL & XCLMGMT Kernel Driver | Failed. Check build log : /var/lib/dkms/xrt/2.16.188/build/make.log
| XRT USERSPACE                | Success            |
| MPD/MSD                      | Success            |
```
Investigating the build log I found:
```
/var/lib/dkms/xrt/2.16.188/build/driver/xocl/mgmtpf/../subdev/ulite.c: In function ‘ulite_remove’:
/var/lib/dkms/xrt/2.16.188/build/driver/xocl/mgmtpf/../subdev/ulite.c:576:13: error: void value not ignored as it ought to be
  576 |         ret = uart_remove_one_port(pdata->xcl_ulite_driver, port);
      |             ^
make[4]: *** [scripts/Makefile.build:243: /var/lib/dkms/xrt/2.16.188/build/driver/xocl/mgmtpf/../subdev/ulite.o] Error 1
make[3]: *** [/usr/src/linux-headers-6.5.0-rc1+/Makefile:2020: /var/lib/dkms/xrt/2.16.188/build/driver/xocl/mgmtpf] Error 2
```
#### How problem was solved, alternative solutions (if any) and why they were rejected
I removed the storage of the return code.

#### Risks (if any) associated the changes in the commit
None.

#### What has been tested and how, request additional testing if necessary
Tested the compilation on `6.5.0-rc1+` and `5.4.0-144-generic`

#### Documentation impact (if any)
None
