### PR TITLE
CR-1174490: Fixing crash when turning on aie_profile on systems without AIE

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_plugin.cpp
@@ -210,7 +210,8 @@ namespace xdp {
     if (AIEData.thread.joinable())
       AIEData.thread.join();
 
-    AIEData.implementation->freeResources();
+    if (AIEData.implementation)
+      AIEData.implementation->freeResources();
     handleToAIEData.erase(handle);
   }
 

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_plugin.cpp
@@ -207,7 +207,8 @@ namespace xdp {
     auto& AIEData = handleToAIEData[handle];
     AIEData.threadCtrlBool = false;
 
-    AIEData.thread.join();
+    if (AIEData.thread.joinable())
+      AIEData.thread.join();
 
     AIEData.implementation->freeResources();
     handleToAIEData.erase(handle);
@@ -216,9 +217,14 @@ namespace xdp {
   void AieProfilePlugin::endPoll()
   {
     // Ask all threads to end
-    for (auto& p : handleToAIEData) p.second.threadCtrlBool = false;
+    for (auto& p : handleToAIEData)
+      p.second.threadCtrlBool = false;
 
-    for (auto& p : handleToAIEData) p.second.thread.join();
+    for (auto& p : handleToAIEData) {
+      auto& data = p.second;
+      if (data.thread.joinable())
+        data.thread.join();
+    }
 
     handleToAIEData.clear();
   }


### PR DESCRIPTION
#### Problem solved by the commit
When AIE profiling is enabled via the xrt.ini file, the profiling plugin is loaded even if the device doesn't have an AIE.  If the application completes without loading an xclbin that has an AIE component, various parts of the AIE profiling plugin are not setup.  At cleanup at the end of the execution, there were some unguarded calls to remove objects that may not have been setup in this code path.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
This fixes a crash at the end of execution when the AIE profiling plugin is loaded but not used, due to the application not loading an xclbin with AIE components.  This was discovered through calling xbutil while also enabling AIE profiling through the xrt.ini file, and is related to some of the recent refactoring of the AIE profiling plugin to support various back ends to different platforms.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added guards to only clean up AIE profiling objects if they exist.

#### Risks (if any) associated the changes in the commit
Low as it still cleans up objects at end of execution if they exist.

#### What has been tested and how, request additional testing if necessary
Tested on original crashing xbutil calls.

#### Documentation impact (if any)
No documentation changes necessary.