### PR TITLE
Yielding CPU from poll AIE thread

### DIFF
--- a/src/runtime_src/core/edge/user/aie/aied.cpp
+++ b/src/runtime_src/core/edge/user/aie/aied.cpp
@@ -34,6 +34,7 @@ Aied::Aied(xrt_core::device* device): mCoreDevice(device)
 {
   done = false;
   pthread_create(&ptid, NULL, &Aied::pollAIE, this);
+  pthread_setname_np(ptid, "Graph Status");
 }
 
 Aied::~Aied()
@@ -60,6 +61,9 @@ Aied::pollAIE(void* arg)
 
   /* Ever running thread */
   while (1) {
+    /* Give up the cpu to the other threads. We are running this in an
+     * infinite for loop */
+    sleep(1);
     /* Calling XRT interface to wait for commands */
     if (ai->mGraphs.empty() || drv->xclAIEGetCmd(&cmd) != 0) {
       /* break if destructor called */


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Customer reported that one of the XRT thread is taking 100% cpu. which inturn causing "CPU time limit reached (core dump)"

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Yielding CPU from poll AIE thread by sleeping 1 second. When Graphs are not there in xclbin, pollAIE thread is taking 100% CPU

#### How problem was solved, alternative solutions (if any) and why they were rejected
Sleeping for a second to yield CPU

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Verified multiple edge tests

#### Documentation impact (if any)
None