### PR TITLE
CR-1174069: Catch exceptions when debug/profiling plugins fail to be loaded

### DIFF
--- a/src/runtime_src/core/pcie/linux/plugin/xdp/plugin_loader.cpp
+++ b/src/runtime_src/core/pcie/linux/plugin/xdp/plugin_loader.cpp
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2020-2022 Xilinx, Inc
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -31,46 +32,110 @@
 #include "core/common/message.h"
 #include "core/common/utils.h"
 
-namespace xdp {
-namespace hal_hw_plugins {
+namespace xdp::hal_hw_plugins {
 
 // This function is responsible for loading all of the HAL level HW XDP plugins
 bool load()
 {
-  if (xrt_core::config::get_xrt_trace() ||
-      xrt_core::utils::load_host_trace())
-    xdp::hal::load() ;
+  // If the xrt.ini option is enabled, but the plugin library does not exist
+  // the individual load functions will throw an error that we want to
+  // catch here.  Each of the libraries are independent and an error
+  // loading one should not stop the loading of any of the others.
 
-  if (xrt_core::config::get_device_trace() != "off" ||
-      xrt_core::config::get_device_counters())
-    xdp::hal::device_offload::load();
+  try {
+    if (xrt_core::config::get_xrt_trace() ||
+        xrt_core::utils::load_host_trace())
+      xdp::hal::load();
+  }
+  catch (std::exception& e) {
+    xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT",
+                            e.what());
+  }
 
-  if (xrt_core::config::get_aie_status())
-    xdp::aie::status::load();
+  try {
+    if (xrt_core::config::get_device_trace() != "off" ||
+        xrt_core::config::get_device_counters())
+      xdp::hal::device_offload::load();
+  }
+  catch (std::exception& e) {
+    xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT",
+                            e.what());
+  }
 
-  if (xrt_core::config::get_aie_profile())
-    xdp::aie::profile::load();
 
-  if (xrt_core::config::get_noc_profile())
-    xdp::noc::profile::load();
+  try {
+    if (xrt_core::config::get_aie_status())
+      xdp::aie::status::load();
+  }
+  catch (std::exception& e) {
+    xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT",
+                            e.what());
+  }
 
-  if (xrt_core::config::get_power_profile())
-    xdp::power::profile::load();
+  try {
+    if (xrt_core::config::get_aie_profile())
+      xdp::aie::profile::load();
+  }
+  catch (std::exception& e) {
+    xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT",
+                            e.what());
+  }
 
-  if (xrt_core::config::get_aie_trace())
-    xdp::aie::trace::load();
+  try {
+    if (xrt_core::config::get_noc_profile())
+      xdp::noc::profile::load();
+  }
+  catch (std::exception& e) {
+    xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT",
+                            e.what());
+  }
 
-  if (xrt_core::config::get_sc_profile())
-    xdp::sc::profile::load();
+  try {
+    if (xrt_core::config::get_power_profile())
+      xdp::power::profile::load();
+  }
+  catch (std::exception& e) {
+    xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT",
+                            e.what());
+  }
 
-  if (xrt_core::config::get_vitis_ai_profile())
-    xdp::vart::profile::load();
+  try {
+    if (xrt_core::config::get_aie_trace())
+      xdp::aie::trace::load();
+  }
+  catch (std::exception& e) {
+    xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT",
+                            e.what());
+  }
 
-  if (xrt_core::config::get_pl_deadlock_detection())
-    xdp::pl_deadlock::load();
+  try {
+    if (xrt_core::config::get_sc_profile())
+      xdp::sc::profile::load();
+  }
+  catch (std::exception& e) {
+    xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT",
+                            e.what());
+  }
+
+  try {
+    if (xrt_core::config::get_vitis_ai_profile())
+      xdp::vart::profile::load();
+  }
+  catch (std::exception& e) {
+    xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT",
+                            e.what());
+  }
+
+  try {
+    if (xrt_core::config::get_pl_deadlock_detection())
+      xdp::pl_deadlock::load();
+  }
+  catch (std::exception& e) {
+    xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT",
+                            e.what());
+  }
 
   return true ;
 }
 
-} // end namespace hal_hw_plugins
-} // end namespace xdp
+} // end namespace xdp::hal_hw_plugins


### PR DESCRIPTION
#### Problem solved by the commit
Users can enable profiling functionality through xrt.ini options, and during the application run different plugin modules will be loaded based on what is requested.  If an option like aie_status is requested on platforms that do not have the corresponding plugin then an exception is thrown when the library is not found.  

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
If the exception is thrown when running "xbutil examine," then the exception is caught but from the user's perspective it is not explained and the output of xbutil is incorrect.  The issue was discovered by running xbutil on a machine that did not have AIE and tried to load the aie_status debug module.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added try...catch blocks during the loading of the individual debug/profiling modules.  If the exception is caught at this level, a warning message is issued to the user and the execution continues.

#### Risks (if any) associated the changes in the commit
Low risks as the exceptions that were already being generated now only reports a warning instead of throwing it higher.

#### What has been tested and how, request additional testing if necessary
The original failing test case where the application tries to load a plugin that does not exist on that platform has been tested.

#### Documentation impact (if any)
No documentation changes.