### PR TITLE
add interface uuid into xgq_vmr host driver for linux upstream project

### DIFF
--- a/src/runtime_src/core/include/xgq_cmd_vmr.h
+++ b/src/runtime_src/core/include/xgq_cmd_vmr.h
@@ -126,7 +126,7 @@ enum xgq_cmd_log_page_type {
 	XGQ_CMD_LOG_SYSTEM_DTB	= 0x7,
 	XGQ_CMD_LOG_PLM_LOG	= 0x8,
 	XGQ_CMD_LOG_APU_LOG	= 0x9,
-
+	XGQ_CMD_LOG_SHELL_INTERFACE_UUID	= 0xa,
 };
 
 /**

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
@@ -177,6 +177,8 @@ struct xocl_xgq_vmr {
 	size_t			xgq_vmr_system_dtb_size;
 	char			*xgq_vmr_plm_log;
 	size_t			xgq_vmr_plm_log_size;
+	char			*xgq_vmr_shell_int_uuid;
+	size_t			xgq_vmr_shell_int_uuid_size;
 	u16			pwr_scaling_threshold_limit;
 	u8			temp_scaling_threshold_limit;
 	u16			pwr_scaling_limit;
@@ -1198,6 +1200,15 @@ static int xgq_refresh_system_dtb(struct xocl_xgq_vmr *xgq)
 
 	return xgq_log_page_fw(xgq->xgq_pdev, &xgq->xgq_vmr_system_dtb,
 		&xgq->xgq_vmr_system_dtb_size, XGQ_CMD_LOG_SYSTEM_DTB, 0, 0);
+}
+
+static int xgq_refresh_shell_int_uuid(struct xocl_xgq_vmr *xgq)
+{
+	if (xgq->xgq_vmr_shell_int_uuid)
+		vfree(xgq->xgq_vmr_shell_init_uuid);
+
+	return xgq_log_page_fw(xgq->xgq_pdev, &xgq->xgq_vmr_shell_int_uuid,
+		&xgq->xgq_vmr_shell_int_uuid_size, XGQ_CMD_LOG_SHELL_INTERFACE_UUID, 0, 0);
 }
 
 static int xgq_vmr_apu_log(struct xocl_xgq_vmr *xgq, char **fw, size_t *fw_size,
@@ -3289,6 +3300,8 @@ static int xgq_vmr_remove(struct platform_device *pdev)
 		vfree(xgq->xgq_vmr_system_dtb);
 	if (xgq->xgq_vmr_plm_log)
 		vfree(xgq->xgq_vmr_plm_log);
+	if (xgq->xgq_vmr_shell_int_uuid)
+		vfree(xgq->xgq_vmr_shell_int_uuid);
 
 	xgq_stop_services(xgq);
 	fini_worker(&xgq->xgq_complete_worker);
@@ -3418,6 +3431,8 @@ static int xgq_vmr_probe(struct platform_device *pdev)
 	xgq->xgq_vmr_system_dtb_size = 0;
 	xgq->xgq_vmr_plm_log = NULL;
 	xgq->xgq_vmr_plm_log_size = 0;
+	xgq->xgq_vmr_shell_int_uuid = NULL;
+	xgq->xgq_vmr_shell_int_uuid_size = 0;
 
 	mutex_init(&xgq->xgq_lock);
 	mutex_init(&xgq->clk_scaling_lock);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
@@ -3381,6 +3381,11 @@ static int vmr_services_probe(struct platform_device *pdev)
 		return 0;
 	}
 
+	/* try refresh shell interface uuid, only newer shell has this info */
+	ret = xgq_refresh_shell_int_uuid(struct xocl_xgq_vmr *xgq);
+	if (ret)
+		XGQ_WARN(xgq, "shell interface uuid is not available, ret: %d", ret);
+
 	/* try to download APU PDI, user can check APU status later */
 	ret = xgq_download_apu_firmware(pdev);
 	if (ret)

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
@@ -1205,7 +1205,7 @@ static int xgq_refresh_system_dtb(struct xocl_xgq_vmr *xgq)
 static int xgq_refresh_shell_int_uuid(struct xocl_xgq_vmr *xgq)
 {
 	if (xgq->xgq_vmr_shell_int_uuid)
-		vfree(xgq->xgq_vmr_shell_init_uuid);
+		vfree(xgq->xgq_vmr_shell_int_uuid);
 
 	return xgq_log_page_fw(xgq->xgq_pdev, &xgq->xgq_vmr_shell_int_uuid,
 		&xgq->xgq_vmr_shell_int_uuid_size, XGQ_CMD_LOG_SHELL_INTERFACE_UUID, 0, 0);
@@ -3382,7 +3382,7 @@ static int vmr_services_probe(struct platform_device *pdev)
 	}
 
 	/* try refresh shell interface uuid, only newer shell has this info */
-	ret = xgq_refresh_shell_int_uuid(struct xocl_xgq_vmr *xgq);
+	ret = xgq_refresh_shell_int_uuid(xgq);
 	if (ret)
 		XGQ_WARN(xgq, "shell interface uuid is not available, ret: %d", ret);
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

For linux upstreaming effort of versal host driver, we cannot use device tree fdt source code. 
Even though we have the fdt metadata sent back to host, we cannot use any fdt source code to decode it.

Luckly, the VMR has already decoded it in the firmware.

Thus, we can add this additional sub-opcode which can retrieve current interface uuid from current shell.
This will benefit the mailbox request from xocl to compare it with incoming xclbin.

We would like to bring up xgq_vmr.c up-to-date with every ops that we support, that's why we also need this code in xgq_vmr.c.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
