### PR TITLE
CR-1175636 Performance mode not valid for device

### DIFF
--- a/src/runtime_src/core/common/info_platform.cpp
+++ b/src/runtime_src/core/common/info_platform.cpp
@@ -151,8 +151,13 @@ add_p2p_info(const xrt_core::device* device, ptree_type& pt)
 void
 add_performance_info(const xrt_core::device* device, ptree_type& pt)
 {
-  const auto mode = xrt_core::device_query_default<xq::performance_mode>(device, 0);
-  pt.add("performance_mode", xq::performance_mode::parse_status(mode));
+  try {
+    const auto mode = xrt_core::device_query<xq::performance_mode>(device);
+    pt.add("performance_mode", xq::performance_mode::parse_status(mode));
+  } 
+  catch (xrt_core::query::no_such_key&) {
+    pt.add("performance_mode", "not supported");
+  }
 }
 
 static std::string

--- a/src/runtime_src/core/common/info_platform.cpp
+++ b/src/runtime_src/core/common/info_platform.cpp
@@ -151,7 +151,7 @@ add_p2p_info(const xrt_core::device* device, ptree_type& pt)
 void
 add_performance_info(const xrt_core::device* device, ptree_type& pt)
 {
-  const auto mode = xrt_core::device_query_default<xq::performance_mode>(device, 3);
+  const auto mode = xrt_core::device_query_default<xq::performance_mode>(device, 0);
   pt.add("performance_mode", xq::performance_mode::parse_status(mode));
 }
 

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -3347,9 +3347,10 @@ struct xgq_scaling_temp_override : request
 
 struct performance_mode : request
 {
+  // Get and set power mode of device
   enum class power_type
   {
-    basic, //deafult
+    basic, // deafult
     low,
     medium,
     high

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -3347,8 +3347,15 @@ struct xgq_scaling_temp_override : request
 
 struct performance_mode : request
 {
+  enum class power_type
+  {
+    basic, //deafult
+    low,
+    medium,
+    high
+  };
   using result_type = uint32_t;  // get value type
-  using value_type = uint32_t;   // put value type
+  using value_type = power_type;   // put value type
 
   static const key_type key = key_type::performance_mode;
 

--- a/src/runtime_src/core/tools/xbutil2/OO_Performance.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_Performance.cpp
@@ -77,16 +77,16 @@ OO_Performance::execute(const SubCmdOptions& _options) const
 
   try {
     if(boost::iequals(m_action, "DEFAULT")) {
-      xrt_core::device_update<xrt_core::query::performance_mode>(device.get(), 0);
+      xrt_core::device_update<xrt_core::query::performance_mode>(device.get(), xrt_core::query::performance_mode::power_type::basic); //default
     }
     else if(boost::iequals(m_action, "LOW")) {
-      xrt_core::device_update<xrt_core::query::performance_mode>(device.get(), 1);
+      xrt_core::device_update<xrt_core::query::performance_mode>(device.get(), xrt_core::query::performance_mode::power_type::low);
     }
     else if(boost::iequals(m_action, "MEDIUM")) {
-      xrt_core::device_update<xrt_core::query::performance_mode>(device.get(), 2);
+      xrt_core::device_update<xrt_core::query::performance_mode>(device.get(), xrt_core::query::performance_mode::power_type::medium);
     }
     else if(boost::iequals(m_action, "HIGH")) {
-      xrt_core::device_update<xrt_core::query::performance_mode>(device.get(), 3);
+      xrt_core::device_update<xrt_core::query::performance_mode>(device.get(), xrt_core::query::performance_mode::power_type::high);
     }
     else {
       std::cerr << boost::format("ERROR: Invalid action value: '%s'\n") % m_action;

--- a/src/runtime_src/core/tools/xbutil2/OO_Performance.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_Performance.cpp
@@ -76,16 +76,16 @@ OO_Performance::execute(const SubCmdOptions& _options) const
   }
 
   try {
-    if(boost::iequals(m_action, "DEFAULT")) {
-      xrt_core::device_update<xrt_core::query::performance_mode>(device.get(), xrt_core::query::performance_mode::power_type::basic); //default
+    if (boost::iequals(m_action, "DEFAULT")) {
+      xrt_core::device_update<xrt_core::query::performance_mode>(device.get(), xrt_core::query::performance_mode::power_type::basic); // default
     }
-    else if(boost::iequals(m_action, "LOW")) {
+    else if (boost::iequals(m_action, "LOW")) {
       xrt_core::device_update<xrt_core::query::performance_mode>(device.get(), xrt_core::query::performance_mode::power_type::low);
     }
-    else if(boost::iequals(m_action, "MEDIUM")) {
+    else if (boost::iequals(m_action, "MEDIUM")) {
       xrt_core::device_update<xrt_core::query::performance_mode>(device.get(), xrt_core::query::performance_mode::power_type::medium);
     }
-    else if(boost::iequals(m_action, "HIGH")) {
+    else if (boost::iequals(m_action, "HIGH")) {
       xrt_core::device_update<xrt_core::query::performance_mode>(device.get(), xrt_core::query::performance_mode::power_type::high);
     }
     else {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
- While verifying the driver changes to support performance setting, I realized that I missed some code 
- Fix for https://jira.xilinx.com/browse/CR-1175636

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
When performance_mode isn't found, we should show default and not high

#### How problem was solved, alternative solutions (if any) and why they were rejected
Changes have been made in the utilities and MCDM to support the performance setting

#### Risks (if any) associated the changes in the commit
No risks

#### What has been tested and how, request additional testing if necessary
Tested on windows setup by setting different levels and verifying it through platform report
```
> .\xbutil configure --performance -d 00c2:00:01.1 high
Performance mode is set to high


> .\xbutil examine -d 00c2:00:01.1 -r platform

---------------------
[00c2:00:01.1] : IPU
---------------------
Platform
  XSA Name               : IPU
  Logic UUID             : 0x0
  FPGA Name              : N/A
  JTAG ID Code           : N/A
  DDR Size               : 0 Bytes
  DDR Count              : 0
  Mig Calibrated         : true
  P2P Status             : not supported
  Performance Mode       : High

Clocks
  H Clock (System)       : 800 MHz
  MP-IPU Clock (System)  : 400 MHz

> .\xbutil configure --performance -d 00c2:00:01.1 low
Performance mode is set to low


> .\xbutil examine -d 00c2:00:01.1 -r platform

---------------------
[00c2:00:01.1] : IPU
---------------------
Platform
  XSA Name               : IPU
  Logic UUID             : 0x0
  FPGA Name              : N/A
  JTAG ID Code           : N/A
  DDR Size               : 0 Bytes
  DDR Count              : 0
  Mig Calibrated         : true
  P2P Status             : not supported
  Performance Mode       : Low

Clocks
  H Clock (System)       : 800 MHz
  MP-IPU Clock (System)  : 400 MHz
```
On non-AIE devices:
```
$ xbutil examine -d 18:00 -r platform

------------------------------------------
[0000:18:00.1] : xilinx_u30_gen3x4_base_1
------------------------------------------
Platform
  XSA Name               : xilinx_u30_gen3x4_base_1 
  Logic UUID             : 1B5FEB2A-91B6-818D-A3E8-D9867DE17DA0 
  FPGA Name              :  
  JTAG ID Code           : 0x14a5c093 
  DDR Size               : 0 Bytes
  DDR Count              : 0 
  Mig Calibrated         : true 
  P2P Status             : not supported 
  Performance Mode       : not supported 

$ cat x.txt 
{
    "schema_version": {
        "schema": "JSON",
        "creation_date": "Mon Sep 11 23:16:40 2023 GMT"
    },
    "devices": [
        {
            "interface_type": "pcie",
            "device_id": "0000:18:00.1",
            "device_status": "HEALTHY",
            "platforms": [
                {
                    "static_region": {
                        "vbnv": "xilinx_u30_gen3x4_base_1",
                        ...
                    "status": {
                        "mig_calibrated": "true",
                        "p2p_status": "not supported",
                        "performance_mode": "not supported",
                        "host_memory_status": "disabled"
                    },
...
```

#### Documentation impact (if any)
None