### PR TITLE
[1168602]: Accessing device memory from host is enabled now in emulation

### DIFF
--- a/src/runtime_src/core/pcie/emulation/hw_emu/alveo_shim/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_emu/alveo_shim/shim.cxx
@@ -3462,14 +3462,18 @@ ssize_t HwEmShim::xclUnmgdPwrite(unsigned flags, const void *buf, size_t count, 
 {
   if (flags)
     return -EINVAL;
-  return xclCopyBufferHost2Device(offset, buf, count, 0 ,0);
+  // xclCopyBufferHost2Device returns the size of bytes transferred to device
+  size_t ret = xclCopyBufferHost2Device(offset, buf, count, 0 ,0);
+  return (ret == count) ? 0: -1;
 }
 
 ssize_t HwEmShim::xclUnmgdPread(unsigned flags, void *buf, size_t count, uint64_t offset)
 {
   if (flags)
     return -EINVAL;
-  return xclCopyBufferDevice2Host(buf, offset, count, 0 , 0);
+  // xclCopyBufferDevice2Host returns the size of bytes transferred from device
+  size_t ret = xclCopyBufferDevice2Host(buf, offset, count, 0 , 0);
+  return (ret == count) ? 0: -1;
 }
 
 

--- a/src/runtime_src/core/pcie/emulation/sw_emu/generic_pcie_hal2/halapi.cxx
+++ b/src/runtime_src/core/pcie/emulation/sw_emu/generic_pcie_hal2/halapi.cxx
@@ -564,12 +564,18 @@ int xclGetBOProperties(xclDeviceHandle handle, unsigned int boHandle, xclBOPrope
 
 ssize_t xclUnmgdPread(xclDeviceHandle handle, unsigned flags, void *buf, size_t count, uint64_t offset)
 {
-  return -ENOSYS;
+  xclswemuhal2::SwEmuShim *drv = xclswemuhal2::SwEmuShim::handleCheck(handle);
+  if (!drv)
+    return -ENOSYS;
+  return drv->xclUnmgdPread(flags, buf, count, offset);
 }
 
 ssize_t xclUnmgdPwrite(xclDeviceHandle handle, unsigned flags, const void *buf, size_t count, uint64_t offset)
 {
-  return -ENOSYS;
+  xclswemuhal2::SwEmuShim *drv = xclswemuhal2::SwEmuShim::handleCheck(handle);
+  if (!drv)
+    return -ENOSYS;
+  return drv->xclUnmgdPwrite(flags, buf, count, offset);
 }
 
 /*

--- a/src/runtime_src/core/pcie/emulation/sw_emu/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/sw_emu/generic_pcie_hal2/shim.cxx
@@ -923,6 +923,20 @@ namespace xclswemuhal2
     return;
   }
 
+  ssize_t SwEmuShim::xclUnmgdPread(unsigned flags, void *buf, size_t count, uint64_t offset)
+  {
+     // xclCopyBufferDevice2Host returns number bytes read from device
+     size_t ret = xclCopyBufferDevice2Host(buf,offset,count,0);
+     return (ret == count) ? 0 : -1;
+  }
+
+  ssize_t SwEmuShim::xclUnmgdPwrite(unsigned flags, const void *buf, size_t count, uint64_t offset)
+  {
+     // xclCopyBufferHost2Device returns number bytes written to device
+     size_t ret = xclCopyBufferHost2Device(offset,buf,count,0);
+     return (ret == count) ? 0 : -1;
+  }
+
   size_t SwEmuShim::xclWrite(xclAddressSpace space, uint64_t offset, const void *hostBuf, size_t size)
   {
     std::lock_guard lk(mApiMtx);

--- a/src/runtime_src/core/pcie/emulation/sw_emu/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/pcie/emulation/sw_emu/generic_pcie_hal2/shim.h
@@ -324,6 +324,8 @@ namespace xclswemuhal2
     void xclFreeDeviceBuffer(uint64_t buf);
     size_t xclCopyBufferHost2Device(uint64_t dest, const void *src, size_t size, size_t seek);
     size_t xclCopyBufferDevice2Host(void *dest, uint64_t src, size_t size, size_t skip);
+    ssize_t xclUnmgdPwrite(unsigned flags, const void *buf, size_t count, uint64_t offset);
+    ssize_t xclUnmgdPread(unsigned flags, void *buf, size_t count, uint64_t offset);
 
     // Performance monitoring
     // Control


### PR DESCRIPTION
Fix: The device memory can be accessed from host code in emulation environment now. The functions are implemented in emulation drivers respectively.

Risk: very low

Tests: Canary run. Results are clean.

Reviewer: venkatp, chvamshi