### PR TITLE
CR-1175173: Metric ID 155 not found in AIE profile tile 24,1

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_metadata.cpp
@@ -326,6 +326,8 @@ namespace xdp {
   {
     if (type == module_type::mem_tile)
       return get_mem_tiles(device, graph_name, kernel_name);
+    if (kernel_name.compare("all") == 0)
+      return get_aie_tiles(device, graph_name, type);
 
     // Now search by graph-kernel pairs
     auto data = device->get_axlf_section(AIE_METADATA);
@@ -334,19 +336,14 @@ namespace xdp {
       return {};
 
     pt::ptree aie_meta;
-
     read_aie_metadata(data.first, data.second, aie_meta);
 
     // Grab all kernel to tile mappings
     auto kernelToTileMapping = aie_meta.get_child_optional("aie_metadata.TileMapping.AIEKernelToTileMapping");
-
-    if (!kernelToTileMapping && kernel_name.compare("all") == 0)
-      return get_aie_tiles(device, graph_name, type);
-    else if (!kernelToTileMapping)
+    if (!kernelToTileMapping)
       return {};
 
     std::vector<tile_type> tiles;
-
     auto rowOffset = getAIETileRowOffset();
 
     for (auto const& mapping : kernelToTileMapping.get()) {


### PR DESCRIPTION
**Problem solved by the commit**
DMA-only tiles were not getting included when parsing tile list

**How problem was solved, alternative solutions (if any) and why they were rejected**
Parse different portion of metadata to get DMA-only tiles

**Risks (if any) associated the changes in the commit**
The function is different for profiling than for trace, as we don't trace events that affect DMA-only tiles. This will affect a future merge of metadata APIs.

**What has been tested and how, request additional testing if necessary**
tested on vck190

**Documentation impact (if any)**
Regression fix so no impact