### PR TITLE
Search for specified xclbin in cwd and repo if available

### DIFF
--- a/src/runtime_src/core/include/experimental/xrt_xclbin.h
+++ b/src/runtime_src/core/include/experimental/xrt_xclbin.h
@@ -593,10 +593,16 @@ public:
   /**
    * xclbin() - Constructor from an xclbin filename
    *
-   * @param filename
-   *  Path to the xclbin file
    *
-   * Throws if file not found.
+   * @param filename : A path relative or absolute to an xclbin file
+   *
+   * If the specified path is an absolute path then the function
+   * returns this path or throws if file does not exist.  If the path
+   * is relative, or just a plain file name, then the function check
+   * first in current directory, then in the platform specific xclbin
+   * repository. 
+   *
+   * Throws if file could not be found.
    */
   XCL_DRIVER_DLLESPEC
   explicit

--- a/tests/xrt/import_bo/expimp.cpp
+++ b/tests/xrt/import_bo/expimp.cpp
@@ -105,7 +105,7 @@ parent(const std::string& device_id, const std::string& xclbin_fnm, xrt::bo::fla
   xrt::device device{device_id};
   auto uuid = device.load_xclbin(xclbin_fnm);
   xrt::kernel hello(device, uuid, "hello");
-  xrt::bo bo(device, 1024, flags, hello.group_id(0)); // 1K buffer is somewhat arbitrary
+  xrt::bo bo(device, 1024*4, flags, hello.group_id(0)); // 1K buffer is somewhat arbitrary
   auto bo_data = bo.map<char*>();
 
   // clear device data


### PR DESCRIPTION
#### Problem solved by the commit
Change the xrt::xclbin::xclbin(const std::string& fnm) constructor to look for specified file in current directory first (or absolute path) or else in xclbin repository (platform specific feature).

