### PR TITLE
Add platform specific repository for xclbins

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -3,6 +3,7 @@
 set -e
 
 OSDIST=`grep '^ID=' /etc/os-release | awk -F= '{print $2}' | tr -d '"'`
+VERSION=`grep '^VERSION_ID=' /etc/os-release | awk -F= '{print $2}' | tr -d '"'`
 BUILDDIR=$(readlink -f $(dirname ${BASH_SOURCE[0]}))
 CORE=`grep -c ^processor /proc/cpuinfo`
 CMAKE=cmake
@@ -32,6 +33,12 @@ if [[ $CPU == "aarch64" ]] && [[ $OSDIST == "ubuntu" ]]; then
 	export CC=gcc-8
 	export CXX=g++-8
     fi
+fi
+
+# Use GCC 9 on CentOS 8 for std::filesystem
+# The dependency is installed by xrtdeps.sh
+if [[ $CPU == "x86_64" ]] && [[ $OSDIST == "centos" ]] && [[ $VERSION == 8 ]]; then
+    source /opt/rh/gcc-toolset-9/enable
 fi
 
 usage()

--- a/src/runtime_src/core/common/api/xrt_device.cpp
+++ b/src/runtime_src/core/common/api/xrt_device.cpp
@@ -6,7 +6,7 @@
 // core/include/experimental/xrt_device.h
 #define XCL_DRIVER_DLL_EXPORT  // exporting xrt_device.h
 #define XRT_CORE_COMMON_SOURCE // in same dll as core_common
-
+#define XRT_API_SOURCE         // in same dll as coreutil
 #include "core/include/xrt/xrt_device.h"
 #include "core/include/xrt/xrt_aie.h"
 

--- a/src/runtime_src/core/common/api/xrt_xclbin.cpp
+++ b/src/runtime_src/core/common/api/xrt_xclbin.cpp
@@ -18,7 +18,7 @@
 
 // This file implements XRT xclbin APIs as declared in
 // core/include/experimental/xrt_xclbin.h
-#define XCL_DRIVER_DLL_EXPORT  // exporting xrt_xclbin.h
+#define XRT_API_SOURCE         // exporting xrt_version.h
 #define XRT_CORE_COMMON_SOURCE // in same dll as core_common
 #include "core/include/experimental/xrt_xclbin.h"
 
@@ -41,6 +41,7 @@
 #include <boost/filesystem/path.hpp>
 
 #include <array>
+#include <filesystem>
 #include <fstream>
 #include <numeric>
 #include <regex>
@@ -100,19 +101,8 @@ read_xclbin(const std::string& fnm)
   if (fnm.empty())
     throw std::runtime_error("No xclbin specified");
 
-  namespace bfs = boost::filesystem;
-  if (bfs::exists(fnm) && bfs::is_regular_file(fnm))
-    return read_file(fnm);
-
-  std::string path;
-  try {
-    path = xrt_core::environment::xclbin_path(fnm);
-  }
-  catch (const std::exception&) {
-    throw std::runtime_error("Failed to find xclbin '" + fnm);
-  }
-
-  return read_file(path);
+  auto path = xrt_core::environment::xclbin_path(fnm);
+  return read_file(path.string());
 }
 
 static std::vector<char>
@@ -931,6 +921,119 @@ public:
   }
 };
 
+// class xclbin_repository::iterator_impl - implementation of iterator
+//
+// Iterator over the xclbin files in a repository.  The implementation
+// acts as an opaque handle to exposed xrt::xclbin_repository::iterator.
+class xclbin_repository::iterator_impl
+{
+  std::vector<std::filesystem::path>::const_iterator m_itr;
+public:
+  iterator_impl(std::vector<std::filesystem::path>::const_iterator itr)
+    : m_itr(itr)
+  {}
+
+  iterator_impl(const iterator_impl& rhs)
+    : m_itr(rhs.m_itr)
+  {}
+
+  iterator_impl&
+  operator++()
+  {
+    ++m_itr;
+    return *this;
+  }
+
+  bool
+  operator==(const iterator_impl& rhs) const
+  {
+    return m_itr == rhs.m_itr;
+  }
+
+  xrt::xclbin
+  get_xclbin() const
+  {
+    return xrt::xclbin{get_xclbin_path()};
+  }
+
+  std::string
+  get_xclbin_path() const
+  {
+    return (*m_itr).string();
+  }
+};
+
+// class xclbin_repository_impl - implementation of xclbin_repository
+//
+// Handle class for xrt::xclbin_repository.  The implementation is
+// exposing xclbin files in a directory. The repository can be iterated
+// over to get the indivdual xclbins either as xrt::xclbin objects or
+// as full paths the xclbin files.
+//
+// The implementaton may be extended later to support multiple
+// directories and maybe filtering of the xclbins based on to be
+// defined criteria.
+class xclbin_repository_impl
+{
+  std::vector<std::filesystem::path> m_paths;
+  std::vector<std::filesystem::path> m_xclbin_paths;
+
+  static std::vector<std::filesystem::path>
+  get_xclbin_paths(const std::vector<std::filesystem::path>& dirs)
+  {
+    namespace sfs = std::filesystem;
+    std::vector<sfs::path> xclbin_paths;
+
+    for (const auto& path : dirs) {
+      // Iterate over all files in the directory and collect all xclbin files
+      sfs::directory_iterator p{path};
+      sfs::directory_iterator end;
+      for (; p != end; ++p) {
+        if (sfs::is_regular_file(*p) && p->path().extension() == ".xclbin")
+          xclbin_paths.push_back(p->path().string());
+      }
+    }
+    
+    return xclbin_paths;
+  }
+
+public:
+  xclbin_repository_impl()
+    : m_paths(xrt_core::environment::xclbin_repo_paths())
+    , m_xclbin_paths(get_xclbin_paths(m_paths))
+  {}
+  
+  xclbin_repository_impl(const std::string& path)
+    : m_paths{path}
+    , m_xclbin_paths(get_xclbin_paths(m_paths))
+  {}
+
+  xclbin_repository::iterator
+  begin() const
+  {
+    return std::make_shared<xclbin_repository::iterator_impl>(m_xclbin_paths.begin());
+  }
+
+  xclbin_repository::iterator
+  end() const
+  {
+    return std::make_shared<xclbin_repository::iterator_impl>(m_xclbin_paths.end());
+  }
+
+  xclbin
+  load(const std::string& name) const
+  {
+    namespace sfs = std::filesystem;
+    for (const auto& repo : m_paths) {
+      auto xpath = repo / name;
+      if (sfs::exists(xpath) && sfs::is_regular_file(xpath))
+        return xclbin{xpath.string()};
+    }
+
+    throw std::runtime_error("xclbin file not found: " + name);
+  }
+};
+
 } // xrt
 
 ////////////////////////////////////////////////////////////////
@@ -1018,7 +1121,6 @@ get_fpga_device_name() const
 {
   return handle ? handle->get_fpga_device_name() : "";
 }
-
 
 uuid
 xclbin::
@@ -1354,6 +1456,94 @@ get_operations_per_cycle() const
   return handle->m_aiep->operations_per_cycle;
 }
 
+////////////////////////////////////////////////////////////////
+// xrt::xclbin_repository
+////////////////////////////////////////////////////////////////
+xclbin_repository::
+xclbin_repository()
+  : detail::pimpl<xclbin_repository_impl>(std::make_shared<xclbin_repository_impl>())
+{}
+  
+xclbin_repository::
+xclbin_repository(const std::string& path)
+  : detail::pimpl<xclbin_repository_impl>(std::make_shared<xclbin_repository_impl>(path))
+{}
+
+xclbin_repository::iterator
+xclbin_repository::
+begin() const
+{
+  return handle->begin();
+}
+
+xclbin_repository::iterator
+xclbin_repository::
+end() const
+{
+  return handle->end();
+}
+
+xclbin
+xclbin_repository::
+load(const std::string& name) const
+{
+  return handle->load(name);
+}
+
+////////////////////////////////////////////////////////////////
+// xrt::xclbin_repository::iterator
+////////////////////////////////////////////////////////////////
+xclbin_repository::iterator::
+iterator(const xclbin_repository::iterator& rhs)
+  : detail::pimpl<xclbin_repository::iterator_impl>
+  (std::make_shared<xclbin_repository::iterator_impl>(*(rhs.get_handle().get())))
+{}
+
+xclbin_repository::iterator&
+xclbin_repository::iterator::
+operator++()
+{
+  ++(*handle);
+  return *this;
+}
+
+xclbin_repository::iterator
+xclbin_repository::iterator::
+operator++(int)
+{
+  iterator tmp(*this);
+  ++(*this);
+  return tmp;
+}
+
+bool
+xclbin_repository::iterator::
+operator==(const iterator& rhs) const
+{
+  return (*handle) == (*rhs.handle);
+}
+
+xclbin_repository::iterator::value_type
+xclbin_repository::iterator::
+operator*() const
+{
+  return handle->get_xclbin();
+}
+
+xclbin_repository::iterator::value_type
+xclbin_repository::iterator::
+operator->() const
+{
+  return handle->get_xclbin();
+}
+
+std::string
+xclbin_repository::iterator::
+path() const
+{
+  return handle->get_xclbin_path();
+}
+  
 } // namespace xrt
 
 namespace {

--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -404,6 +404,13 @@ get_xclbin_programming()
   return get_xclbin_programing();
 }
 
+inline std::string
+get_xclbin_repo()
+{
+  static std::string value = detail::get_string_value("Runtime.xclbin_repo_path","");
+  return value;
+}
+
 /**
  * Enable xma mode. 1 = default (1 cu cmd at a time); 2 = (upto 2 cu cmds at a time);
  *     3 = (upto 8 cu cmds at a time);  4 = (upto 64 cu cmds at a time); Max cu cmds at a time per session

--- a/src/runtime_src/core/common/detail/linux/xilinx_xrt.h
+++ b/src/runtime_src/core/common/detail/linux/xilinx_xrt.h
@@ -1,26 +1,27 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
-#include <boost/filesystem/path.hpp>
+#include <filesystem>
 #include <stdexcept>
 #include <string>
 namespace xrt_core::detail {
 
-namespace bfs = boost::filesystem;
+namespace sfs = std::filesystem;
 
-bfs::path
+sfs::path
 xilinx_xrt()
 {
 #if defined (__aarch64__) || defined (__arm__)
-  return bfs::path("/usr");
+  return sfs::path("/usr");
 #else
-  return bfs::path("/opt/xilinx/xrt");
+  return sfs::path("/opt/xilinx/xrt");
 #endif
 }
 
-bfs::path
-xclbin_path(const std::string& xclbin)
+sfs::path
+xclbin_repo_path()
 {
-  throw std::runtime_error("xclbin repo path not yet implemented on Linux");
+  // current directory
+  return sfs::current_path();
 }
 
 } // xrt_core::detail

--- a/src/runtime_src/core/common/detail/windows/xilinx_xrt.h
+++ b/src/runtime_src/core/common/detail/windows/xilinx_xrt.h
@@ -12,8 +12,7 @@
 # include <d3dkmthk.h>
 #endif
 
-#include <boost/filesystem/operations.hpp>
-#include <boost/filesystem/path.hpp>
+#include <filesystem>
 #include <string>
 #include <cstring>
 #include <cstdlib>
@@ -226,9 +225,9 @@ struct adapter_list
 
 namespace xrt_core::detail {
 
-namespace bfs = boost::filesystem;
+namespace sfs = std::filesystem;
 
-bfs::path
+sfs::path
 xilinx_xrt()
 {
 #if defined(XRT_WINDOWS_HAS_WDK)
@@ -240,26 +239,21 @@ xilinx_xrt()
 
   // If no matching adapter found, return coreutil path (legacy)
   if (!adapter)
-    return bfs::path(xrt_core::dlpath("xrt_coreutil.dll")).parent_path();
+    return sfs::path{xrt_core::dlpath("xrt_coreutil.dll")}.parent_path();
 
   return adapter->driver_store_path();
 #else
   // Without WDK we can't query the driver store path, so return coreutil path
-  return bfs::path(xrt_core::dlpath("xrt_coreutil.dll")).parent_path();
+  return sfs::path{xrt_core::dlpath("xrt_coreutil.dll")}.parent_path();
 #endif
 }
 
-bfs::path
-xclbin_path(const std::string& xclbin)
+sfs::path
+xclbin_repo_path()
 {
   // For time being, xclbin repo is same as xilinx_xrt
   static auto repo = xilinx_xrt();
-  auto xpath = repo / xclbin;
-
-  if (!bfs::exists(xpath))
-    throw std::runtime_error("xclbin not found: " + xpath.string());
-
-  return xpath;
+  return repo;
 }
 
 } // xrt_core::detail

--- a/src/runtime_src/core/common/module_loader.h
+++ b/src/runtime_src/core/common/module_loader.h
@@ -8,6 +8,7 @@
 // This file contains a loader utility class for plugin modules
 //  that are loaded from either OpenCL or XRT level applications.
 
+#include <filesystem>
 #include <functional>
 #include <string>
 
@@ -90,7 +91,7 @@ namespace environment {
  * xilinx_xrt() - Get path to XRT installation
  */
 XRT_CORE_COMMON_EXPORT
-std::string
+const std::filesystem::path&
 xilinx_xrt();
 
 /**
@@ -99,18 +100,26 @@ xilinx_xrt();
  * @xclbin_name : A path relative or absolute to an xclbin file
  * Return: Full path the xclbin file
  *
- * If the specified path is an absolute path then the function returns
- * this path or throws if file does not exist.  If the path is
- * relative, or just a plain file name, then the function prepends the
- * absolute path of a platform specific xclbin repository that
- * contains the specified file.
+ * If the specified path is an absolute path then the function
+ * returns this path or throws if file does not exist.  If the path
+ * is relative, or just a plain file name, then the function checks
+ * first in current directory, then in the platform specific xclbin
+ * repository.
  *
  * The function throws if the file does not exist.
  */
 XRT_CORE_COMMON_EXPORT
-std::string
+std::filesystem::path
 xclbin_path(const std::string& xclbin_name);
 
+/**
+ * xclbin_repo_path() - Get path to xclbin repository
+ *
+ * Return: Full path to xclbin repository
+ */
+XRT_CORE_COMMON_EXPORT
+const std::vector<std::filesystem::path>&
+xclbin_repo_paths();
 } // environment
 
 } // end namespace xrt_core

--- a/src/runtime_src/core/include/experimental/xrt_xclbin.h
+++ b/src/runtime_src/core/include/experimental/xrt_xclbin.h
@@ -6,12 +6,15 @@
 #ifndef XRT_XCLBIN_H_
 #define XRT_XCLBIN_H_
 
+#include "xrt/detail/config.h"
+
 #include "xrt.h"
 #include "xclbin.h"
 #include "xrt/xrt_uuid.h"
 #include "xrt/detail/pimpl.h"
 
 #ifdef __cplusplus
+# include <iterator>
 # include <utility>
 # include <vector>
 # include <string>
@@ -131,7 +134,7 @@ public:
      * @return
      *   Memory tag name
      */
-    XCL_DRIVER_DLLESPEC
+    XRT_API_EXPORT
     std::string
     get_tag() const;
 
@@ -141,7 +144,7 @@ public:
      * @return
      *  Base address of the memory bank, or -1 for invalid base address
      */
-    XCL_DRIVER_DLLESPEC
+    XRT_API_EXPORT
     uint64_t
     get_base_address() const;
 
@@ -151,7 +154,7 @@ public:
      * @return
      *  Size of memory in KB, or -1 for invalid size
      */
-    XCL_DRIVER_DLLESPEC
+    XRT_API_EXPORT
     uint64_t
     get_size_kb() const;
 
@@ -165,7 +168,7 @@ public:
      * A value of false indicates that no buffer can be allocated
      * in this memory bank.
      */
-    XCL_DRIVER_DLLESPEC
+    XRT_API_EXPORT
     bool
     get_used() const;
 
@@ -176,7 +179,7 @@ public:
      *  Memory type
      *
      */
-    XCL_DRIVER_DLLESPEC
+    XRT_API_EXPORT
     memory_type
     get_type() const;
 
@@ -189,7 +192,7 @@ public:
      * The returned index can be used when allocating buffers using
      * \ref xrt::bo provided the memory bank is connected / used.
      */
-    XCL_DRIVER_DLLESPEC
+    XRT_API_EXPORT
     int32_t
     get_index() const;
   };
@@ -224,7 +227,7 @@ public:
      *  Name of argument.
      *
      */
-    XCL_DRIVER_DLLESPEC
+    XRT_API_EXPORT
     std::string
     get_name() const;
 
@@ -235,7 +238,7 @@ public:
      *  A list of xrt::xclbin::mem objects to which this argument
      *  is connected.
      */
-    XCL_DRIVER_DLLESPEC
+    XRT_API_EXPORT
     std::vector<mem>
     get_mems() const;
 
@@ -245,7 +248,7 @@ public:
      * @return
      *  Port name
      */
-    XCL_DRIVER_DLLESPEC
+    XRT_API_EXPORT
     std::string
     get_port() const;
 
@@ -255,7 +258,7 @@ public:
      * @return
      *   Argument size
      */
-    XCL_DRIVER_DLLESPEC
+    XRT_API_EXPORT
     uint64_t
     get_size() const;
 
@@ -265,7 +268,7 @@ public:
      * @return
      *   Argument offset
      */
-    XCL_DRIVER_DLLESPEC
+    XRT_API_EXPORT
     uint64_t
     get_offset() const;
 
@@ -275,7 +278,7 @@ public:
      * @return
      *   Argument host type
      */
-    XCL_DRIVER_DLLESPEC
+    XRT_API_EXPORT
     std::string
     get_host_type() const;
 
@@ -285,7 +288,7 @@ public:
      * @return
      *   Argument index
      */
-    XCL_DRIVER_DLLESPEC
+    XRT_API_EXPORT
     size_t
     get_index() const;
   };
@@ -334,7 +337,7 @@ public:
      * @return
      *  IP name.
      */
-    XCL_DRIVER_DLLESPEC
+    XRT_API_EXPORT
     std::string
     get_name() const;
 
@@ -344,7 +347,7 @@ public:
      * @return
      *  IP type
      */
-    XCL_DRIVER_DLLESPEC
+    XRT_API_EXPORT
     ip_type
     get_type() const;
 
@@ -354,7 +357,7 @@ public:
      * @return
      *  Control type
      */
-    XCL_DRIVER_DLLESPEC
+    XRT_API_EXPORT
     control_type
     get_control_type() const;
 
@@ -364,7 +367,7 @@ public:
      * @return
      *  Number of arguments for this IP per CONNECTIVITY section
      */
-    XCL_DRIVER_DLLESPEC
+    XRT_API_EXPORT
     size_t
     get_num_args() const;
 
@@ -376,7 +379,7 @@ public:
      *
      * An argument may have multiple memory connections
      */
-    XCL_DRIVER_DLLESPEC
+    XRT_API_EXPORT
     std::vector<arg>
     get_args() const;
 
@@ -390,7 +393,7 @@ public:
      *
      * The argument may have multiple memory connections
      */
-    XCL_DRIVER_DLLESPEC
+    XRT_API_EXPORT
     arg
     get_arg(int32_t index) const;
 
@@ -400,7 +403,7 @@ public:
      * @return
      *  The base address of the IP
      */
-    XCL_DRIVER_DLLESPEC
+    XRT_API_EXPORT
     uint64_t
     get_base_address() const;
 
@@ -416,7 +419,7 @@ public:
      * For IPs that are not associated with a kernel, the
      * size return is 0.
      */
-    XCL_DRIVER_DLLESPEC
+    XRT_API_EXPORT
     size_t
     get_size() const;
   };
@@ -458,7 +461,7 @@ public:
      * @return
      *  The name of the kernel
      */
-    XCL_DRIVER_DLLESPEC
+    XRT_API_EXPORT
     std::string
     get_name() const;
 
@@ -468,7 +471,7 @@ public:
      * @return
      *  The type of the kernel
      */
-    XCL_DRIVER_DLLESPEC
+    XRT_API_EXPORT
     kernel_type
     get_type() const;
 
@@ -479,7 +482,7 @@ public:
      *  A list of xrt::xclbin::ip objects corresponding the compute units
      *  for this kernel object.
      */
-    XCL_DRIVER_DLLESPEC
+    XRT_API_EXPORT
     std::vector<ip>
     get_cus() const;
 
@@ -495,7 +498,7 @@ public:
      * The kernel name can optionally specify which kernel instance(s) to
      * match "kernel:{cu1,cu2,...} syntax.
      */
-    XCL_DRIVER_DLLESPEC
+    XRT_API_EXPORT
     std::vector<ip>
     get_cus(const std::string& name) const;
 
@@ -506,7 +509,7 @@ public:
      *  The xct::xclbin::ip object matching the specified name, or error if
      *  not present.
      */
-    XCL_DRIVER_DLLESPEC
+    XRT_API_EXPORT
     ip
     get_cu(const std::string& name) const;
 
@@ -516,7 +519,7 @@ public:
      * @return
      *  Number of arguments for this kernel.
      */
-    XCL_DRIVER_DLLESPEC
+    XRT_API_EXPORT
     size_t
     get_num_args() const;
 
@@ -528,7 +531,7 @@ public:
      *
      * An argument may have multiple memory connections
      */
-    XCL_DRIVER_DLLESPEC
+    XRT_API_EXPORT
     std::vector<arg>
     get_args() const;
 
@@ -544,7 +547,7 @@ public:
      * by ``get_arg()`` there is at least one compute unit that has
      * that connection.
      */
-    XCL_DRIVER_DLLESPEC
+    XRT_API_EXPORT
     arg
     get_arg(int32_t index) const;
   };
@@ -560,15 +563,15 @@ public:
       : detail::pimpl<aie_partition_impl>(std::move(handle))
     {}
 
-    XCL_DRIVER_DLLESPEC
+    XRT_API_EXPORT
     uint64_t
     get_inference_fingerprint() const;
 
-    XCL_DRIVER_DLLESPEC
+    XRT_API_EXPORT
     uint64_t
     get_pre_post_fingerprint() const;
 
-    XCL_DRIVER_DLLESPEC
+    XRT_API_EXPORT
     uint32_t
     get_operations_per_cycle() const;
   };
@@ -604,7 +607,7 @@ public:
    *
    * Throws if file could not be found.
    */
-  XCL_DRIVER_DLLESPEC
+  XRT_API_EXPORT
   explicit
   xclbin(const std::string& filename);
 
@@ -617,7 +620,7 @@ public:
    * The raw data of the xclbin can be deleted after calling the
    * constructor.
    */
-  XCL_DRIVER_DLLESPEC
+  XRT_API_EXPORT
   explicit
   xclbin(const std::vector<char>& data);
 
@@ -629,7 +632,7 @@ public:
    *
    * The argument axlf is copied by the constructor.
    */
-  XCL_DRIVER_DLLESPEC
+  XRT_API_EXPORT
   explicit
   xclbin(const axlf* top);
 
@@ -643,7 +646,7 @@ public:
    * A kernel groups one or more compute units. A kernel has arguments
    * from which offset, type, etc can be retrived.
    */
-  XCL_DRIVER_DLLESPEC
+  XRT_API_EXPORT
   std::vector<kernel>
   get_kernels() const;
 
@@ -660,7 +663,7 @@ public:
    * xclbin.  A kernel groups one or more compute units. A kernel has
    * arguments from which offset, type, etc can be retrived.
    */
-  XCL_DRIVER_DLLESPEC
+  XRT_API_EXPORT
   kernel
   get_kernel(const std::string& name) const;
 
@@ -673,7 +676,7 @@ public:
    * The returned xrt::xclbin::ip objects are extracted from the
    * IP_LAYOUT section of the xclbin.
    */
-  XCL_DRIVER_DLLESPEC
+  XRT_API_EXPORT
   std::vector<ip>
   get_ips() const;
 
@@ -689,7 +692,7 @@ public:
    * The kernel name can optionally specify which kernel instance(s) to
    * match "kernel:{ip1,ip2,...} syntax.
    */
-  XCL_DRIVER_DLLESPEC
+  XRT_API_EXPORT
   std::vector<ip>
   get_ips(const std::string& name) const;
 
@@ -702,7 +705,7 @@ public:
    * The returned xrt::xclbin::ip object is extracted from the
    * IP_LAYOUT section of the xclbin.
    */
-  XCL_DRIVER_DLLESPEC
+  XRT_API_EXPORT
   ip
   get_ip(const std::string& name) const;
 
@@ -715,12 +718,12 @@ public:
    * The returned xrt::xclbin::mem objects are extracted from
    * the xclbin.
    */
-  XCL_DRIVER_DLLESPEC
+  XRT_API_EXPORT
   std::vector<mem>
   get_mems() const;
 
   /// @cond
-  XCL_DRIVER_DLLESPEC
+  XRT_API_EXPORT
   std::vector<aie_partition>
   get_aie_partitions() const;
   /// @endcond
@@ -733,7 +736,7 @@ public:
    *
    * An exception is thrown if the data is missing.
    */
-  XCL_DRIVER_DLLESPEC
+  XRT_API_EXPORT
   std::string
   get_xsa_name() const;
 
@@ -743,7 +746,7 @@ public:
    * @return
    *  Name of fpga device per XML metadata.
    */
-  XCL_DRIVER_DLLESPEC
+  XRT_API_EXPORT
   std::string
   get_fpga_device_name() const;
 
@@ -755,7 +758,7 @@ public:
    *
    * An exception is thrown if the data is missing.
    */
-  XCL_DRIVER_DLLESPEC
+  XRT_API_EXPORT
   uuid
   get_uuid() const;
 
@@ -767,7 +770,7 @@ public:
   *
   * An exception is thrown if the data is missing.
   */
-  XCL_DRIVER_DLLESPEC
+  XRT_API_EXPORT
   uuid
   get_interface_uuid() const;
 
@@ -777,7 +780,7 @@ public:
    * @return
    *  Target type, which can be hw, sw_emu, or hw_emu
    */
-  XCL_DRIVER_DLLESPEC
+  XRT_API_EXPORT
   target_type
   get_target_type() const;
 
@@ -790,7 +793,7 @@ public:
    *
    * An exception is thrown if the data is missing.
    */
-  XCL_DRIVER_DLLESPEC
+  XRT_API_EXPORT
   const axlf*
   get_axlf() const;
 
@@ -818,10 +821,162 @@ public:
   /// @endcond
 
 private:
-  XCL_DRIVER_DLLESPEC
+  XRT_API_EXPORT
   std::pair<const char*, size_t>
   get_axlf_section(axlf_section_kind section) const;
 };
+
+/**
+ * xclbin_repository - Repository of xclbins
+ *
+ * A repository of xclbins is a collection of xclbins that can be
+ * searched for a specific xclbin through iteration.
+ *
+ * The location of a repository is specified by a directory or it
+ * can be implementations and platform specific.
+ */
+class xclbin_repository_impl;
+class xclbin_repository : public detail::pimpl<xclbin_repository_impl>
+{
+public:
+  /**
+   * xclbin_repository - Default constructor
+   *
+   * Create repository from builtin platform specific repository
+   * path or paths.
+   */
+  XRT_API_EXPORT
+  xclbin_repository();
+
+  /**
+   * xclbin_repository - 
+   *
+   * Create repository from specified path.
+   *
+   * The specified directory can be an absolute path to a directory or
+   * it can be a relative path to a directory rooted at the current
+   * working directory.
+   */
+  XRT_API_EXPORT
+  explicit
+  xclbin_repository(const std::string& dir);
+
+  /**
+   * iterator - Iterator over xclbins in repository
+   *
+   * The iterator is a forward iterator that iterates over the
+   * xclbins in the repository.  The iterator dereferences to an
+   * xrt::xclbin object by value.
+   */
+  class iterator_impl;
+  class iterator : public detail::pimpl<iterator_impl>
+  {
+  public:
+    using iterator_category = std::forward_iterator_tag;
+    using difference_type   = std::ptrdiff_t;
+    using value_type        = xclbin;
+    using pointer           = value_type;
+    using reference         = value_type;
+
+  public:
+    /**
+     * iterator - Default constructor from implmentation
+     */
+    iterator(std::shared_ptr<iterator_impl> handle)
+      : detail::pimpl<iterator_impl>(std::move(handle))
+    {}
+
+    /**
+     * iterator - Copy constructor
+     *
+     * Create a copy of an iterator
+     */
+    XRT_API_EXPORT
+    iterator(const iterator&);
+
+    /**
+     * Advance iterator to next xclbin
+     */
+    XRT_API_EXPORT
+    iterator&
+    operator++();
+
+    /**
+     * Advance iterator to next xclbin return old iterator
+     *
+     * This is a relatively expensive operation that duplicates
+     * the internal representation of the original iterator.
+     */
+    XRT_API_EXPORT
+    iterator
+    operator++(int);
+
+    /**
+     * Compare iterators
+     */
+    XRT_API_EXPORT
+    bool
+    operator==(const iterator& rhs) const;
+
+    /**
+     * Compare iterators
+     */
+    bool
+    operator!=(const iterator& rhs) const
+    {
+      return !(*this == rhs);
+    }
+
+    /**
+     * Dereference iterator
+     *
+     * Returns xrt::xclbin object by value.  The xclbin object
+     * is constructed on the fly.
+     */
+    XRT_API_EXPORT
+    value_type
+    operator*() const;
+
+    /**
+     * Dereference iterator
+     *
+     * Returns xrt::xclbin object by value.  The xclbin object
+     * is constructed on the fly.
+     */
+    XRT_API_EXPORT
+    value_type
+    operator->() const;
+
+    /**
+     * Get path to xclbin file path in repository for this iterator
+     */
+    XRT_API_EXPORT
+    std::string
+    path() const;
+  };
+
+  /**
+   * begin() - Get iterator to first xclbin in repository
+   */
+  XRT_API_EXPORT
+  iterator
+  begin() const;
+
+  /**
+   * end() - Get iterator to end of xclbin repository
+   */
+  XRT_API_EXPORT
+  iterator
+  end() const;
+
+  /**
+   * load() - Load xclbin from repository
+   */
+  XRT_API_EXPORT
+  xclbin
+  load(const std::string& name) const;
+};
+
 } // namespace xrt
 
 /// @cond
@@ -834,7 +989,7 @@ extern "C" {
  * @filename:      path to the xclbin file
  * Return:         xrtXclbinHandle on success or NULL with errno set
  */
-XCL_DRIVER_DLLESPEC
+XRT_API_EXPORT
 xrtXclbinHandle
 xrtXclbinAllocFilename(const char* filename);
 
@@ -845,7 +1000,7 @@ xrtXclbinAllocFilename(const char* filename);
  * @top_axlf:      an axlf
  * Return:         xrtXclbinHandle on success or NULL with errno set
  */
-XCL_DRIVER_DLLESPEC
+XRT_API_EXPORT
 xrtXclbinHandle
 xrtXclbinAllocAxlf(const struct axlf* top_axlf);
 
@@ -856,7 +1011,7 @@ xrtXclbinAllocAxlf(const struct axlf* top_axlf);
  * @size:          size (in bytes) of raw data buffer of xclbin
  * Return:         xrtXclbinHandle on success or NULL with errno set
  */
-XCL_DRIVER_DLLESPEC
+XRT_API_EXPORT
 xrtXclbinHandle
 xrtXclbinAllocRawData(const char* data, int size);
 
@@ -866,7 +1021,7 @@ xrtXclbinAllocRawData(const char* data, int size);
  * @xhdl:          xclbin handle
  * Return:         0 on success, -1 on error
  */
-XCL_DRIVER_DLLESPEC
+XRT_API_EXPORT
 int
 xrtXclbinFreeHandle(xrtXclbinHandle xhdl);
 
@@ -883,7 +1038,7 @@ xrtXclbinFreeHandle(xrtXclbinHandle xhdl);
  *              Otherwise, the the content of this value will be populated.
  * Return:  0 on success or appropriate error number
  */
-XCL_DRIVER_DLLESPEC
+XRT_API_EXPORT
 int
 xrtXclbinGetXSAName(xrtXclbinHandle xhdl, char* name, int size, int* ret_size);
 
@@ -894,7 +1049,7 @@ xrtXclbinGetXSAName(xrtXclbinHandle xhdl, char* name, int size, int* ret_size);
  * @ret_uuid: Return xclbin id in this uuid_t struct
  * Return:    0 on success or appropriate error number
  */
-XCL_DRIVER_DLLESPEC
+XRT_API_EXPORT
 int
 xrtXclbinGetUUID(xrtXclbinHandle xhdl, xuid_t ret_uuid);
 
@@ -908,7 +1063,7 @@ xrtXclbinGetUUID(xrtXclbinHandle xhdl, xuid_t ret_uuid);
  * A kernel groups one or more compute units. A kernel has arguments
  * from which offset, type, etc can be retrived.
  */
-XCL_DRIVER_DLLESPEC
+XRT_API_EXPORT
 size_t
 xrtXclbinGetNumKernels(xrtXclbinHandle xhdl);
 
@@ -922,7 +1077,7 @@ xrtXclbinGetNumKernels(xrtXclbinHandle xhdl);
  * the total number of compute units as the sum of compute units over
  * all kernels.
  */
-XCL_DRIVER_DLLESPEC
+XRT_API_EXPORT
 size_t
 xrtXclbinGetNumKernelComputeUnits(xrtXclbinHandle xhdl);
 
@@ -939,7 +1094,7 @@ xrtXclbinGetNumKernelComputeUnits(xrtXclbinHandle xhdl);
  *              Otherwise, the the content of this value will be populated.
  * Return:  0 on success or appropriate error number
  */
-XCL_DRIVER_DLLESPEC
+XRT_API_EXPORT
 int
 xrtXclbinGetData(xrtXclbinHandle xhdl, char* data, int size, int* ret_size);
 
@@ -950,7 +1105,7 @@ xrtXclbinGetData(xrtXclbinHandle xhdl, char* data, int size, int* ret_size);
  * @out:    Return xclbin id in this uuid_t struct
  * Return:  0 on success or appropriate error number
  */
-XCL_DRIVER_DLLESPEC
+XRT_API_EXPORT
 int
 xrtXclbinUUID(xclDeviceHandle dhdl, xuid_t out);
 

--- a/src/runtime_src/core/tools/common/TestRunner.cpp
+++ b/src/runtime_src/core/tools/common/TestRunner.cpp
@@ -422,7 +422,7 @@ TestRunner::findXclbinPath( const std::shared_ptr<xrt_core::device>& _dev,
 #ifdef _WIN32
   boost::ignore_unused(_dev);
   try {
-    xclbin_path = xrt_core::environment::xclbin_path(xclbin_name);
+    xclbin_path = xrt_core::environment::xclbin_path(xclbin_name).string();
   }
   catch(const std::exception) {
     const auto fmt = boost::format("%s not available. Skipping validation.") % xclbin_name;

--- a/src/runtime_src/tools/scripts/xrtdeps.sh
+++ b/src/runtime_src/tools/scripts/xrtdeps.sh
@@ -579,7 +579,11 @@ install()
                 yum install -y centos-release-scl-rh
             fi
             yum install -y devtoolset-9
-	fi
+        fi
+    fi
+
+    if [ $FLAVOR == "centos" ] && [ $MAJOR -eq "8" ]; then
+        yum install -y gcc-toolset-9-toolchain
     fi
 
     if [ $FLAVOR == "fedora" ]; then

--- a/tests/xrt/56_xclbin/main.cpp
+++ b/tests/xrt/56_xclbin/main.cpp
@@ -156,6 +156,22 @@ operator << (std::ostream& ostr, const xrt::xclbin::aie_partition& aiep)
   return ostr;
 }
 
+static void
+list_xclbins_in_repo()
+{
+  // List all xclbins
+  std::cout << "============================ XCLBINS ==========================\n";
+  xrt::xclbin_repository repo{}; // repository, current directory, or ini
+  auto end = repo.end();
+  std::cout << "number of xclbins: " << std::distance(repo.begin(), end) << '\n';
+  for (auto itr = repo.begin(); itr != end; ++itr) {
+    std::cout << "xclbin: " << itr.path() << '\n';
+    auto xclbin = (*itr);
+    std::cout << "xsa(" << xclbin.get_xsa_name() << ")\n";
+    std::cout << "uuid(" << xclbin.get_uuid().to_string() << ")\n";
+  }
+}
+
 void
 run_cpp(const std::string& xclbin_fnm)
 {
@@ -225,6 +241,7 @@ run(int argc, char** argv)
   if (xclbin_fnm.empty())
     throw std::runtime_error("FAILED_TEST\nNo xclbin specified");
 
+  list_xclbins_in_repo();
   run_cpp(xclbin_fnm);
   run_c(xclbin_fnm);
 


### PR DESCRIPTION
#### Problem solved by the commit
For some use flows xclbins are not provided by the application but instead dynamically loaded from a repository created at sw stack install time.  This PR adds support for repository of xclbins though the xrt::xclbin_repository first class object.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Support repository of xclbins, where repository path(s) are one of
- explicit directory path
- platform specific directory where xclbins are installed
- configuration option via xrt.ini

The repository can be iterated for all xclbins is available in the repo or it can be asked to load a specific xclbin.
The built-in repository path is platform specific. 

The PR also changes the behavior of xrt::xclbin constructed from std::string.  The constructor now checks for specified xclbin either as (1) absolute path, (2) relative path to current directory, (3) relative path under user configured repository, or (4) relative path under built-in repository.

#### What has been tested and how, request additional testing if necessary
- Standard OpenCL tests on Alveo.
- Hand picked windows tests on MCDM.
- Debugging.

See tests/xrt/56_xclbin/main.cpp for sample use.
