### PR TITLE
Enhancing mem-bw testcase to print individual bank name and throughput

### DIFF
--- a/src/runtime_src/core/tools/common/tests/TestDMA.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestDMA.cpp
@@ -56,7 +56,7 @@ TestDMA::run(std::shared_ptr<xrt_core::device> dev)
       continue;
 
     std::stringstream run_details;
-    logger(ptree, "Details", (boost::format("Buffer size - '%s'") % xrt_core::utils::unit_convert(m_block_size)).str());
+    logger(ptree, "Details", (boost::format("Buffer size - '%s' Memory Tag - '%s'") % xrt_core::utils::unit_convert(m_block_size) %  mem.m_tag).str());
 
     // check if the bank has enough memory to allocate
     // m_size is in KB so convert block_size (bytes) to KB for comparison

--- a/tests/validate/bandwidth_test/src/host.cpp
+++ b/tests/validate/bandwidth_test/src/host.cpp
@@ -29,6 +29,13 @@ static void printHelp() {
     std::cout << "  -h <help>\n";
 }
 
+double bandwidth_cal (double dnsduration, int data_size) {
+        double dsduration = dnsduration / ((double)1000000000); // Convert the duration from nanoseconds to seconds
+        double bpersec = data_size / dsduration;
+        double mbpersec = (2 * bpersec) / ((double)1024 * 1024); // Convert b/sec to mb/sec
+	return mbpersec;
+}	
+
 int main(int argc, char** argv) {
     std::string dev_id = "0";
     std::string test_path;
@@ -262,11 +269,8 @@ int main(int argc, char** argv) {
             for (int i = 0; i < num_kernel_ddr; i++) {
                cl_ulong start_time = krnl_events[i].getProfilingInfo<CL_PROFILING_COMMAND_START>();
                cl_ulong end_time = krnl_events[i].getProfilingInfo<CL_PROFILING_COMMAND_END>();
-               double dnsduration = (double)(end_time - start_time) / reps; //nanoseconds to seconds
-               double dsduration = dnsduration / ((double)1000000000); // Convert the duration from nanoseconds to seconds
-               double bpersec = (data_size) / dsduration;
-               double mbpersec = (2 * bpersec) / ((double)1024 * 1024); // Convert b/sec to mb/sec
-
+               double dnsduration = (double)(end_time - start_time) / reps; 
+               double mbpersec = bandwidth_cal(dnsduration, data_size);
                if (mbpersec > bank_throughput_values[i]) 
                    bank_throughput_values[i] = mbpersec;
             }
@@ -274,10 +278,7 @@ int main(int argc, char** argv) {
             double usduration =
                 (double)(std::chrono::duration_cast<std::chrono::nanoseconds>(time_end - time_start).count() / reps);
 
-            double dnsduration = (double)usduration;
-            double dsduration = dnsduration / ((double)1000000000); // Convert the duration from nanoseconds to seconds
-            double bpersec = (data_size * num_kernel_ddr) / dsduration;
-            double mbpersec = (2 * bpersec) / ((double)1024 * 1024); // Convert b/sec to mb/sec
+            double mbpersec = num_kernel_ddr * (bandwidth_cal(usduration, data_size)); 
 
             if (mbpersec > max_throughput) max_throughput = mbpersec;
         }
@@ -351,10 +352,7 @@ int main(int argc, char** argv) {
             double usduration =
                 (double)(std::chrono::duration_cast<std::chrono::nanoseconds>(time_end - time_start).count() / reps);
 
-            double dnsduration = (double)usduration;
-            double dsduration = dnsduration / ((double)1000000000); // Convert duration from nanoseconds to seconds
-            double bpersec = data_size / dsduration;
-            double mbpersec = (2 * bpersec) / ((double)1024 * 1024); // Convert b/sec to mb/sec
+            double mbpersec = bandwidth_cal(usduration, data_size);
 
             if (mbpersec > max_throughput) max_throughput = mbpersec;
         }

--- a/tests/validate/bandwidth_test/src/host.cpp
+++ b/tests/validate/bandwidth_test/src/host.cpp
@@ -72,6 +72,7 @@ int main(int argc, char** argv) {
     bool chk_hbm_mem = false;
     std::string filename = "/platform.json";
     auto platform_json = boost::filesystem::path(test_path) / filename;
+    std::vector<std::string> bank_names;
 
     try {
         boost::property_tree::ptree load_ptree_root;
@@ -87,11 +88,19 @@ int main(int argc, char** argv) {
             if (sValue == "HBM") {
                 chk_hbm_mem = true;
             }
-        }
-        if (chk_hbm_mem) {
-            // As HBM is part of platform, number of ddr kernels is total count reduced by 1(single HBM)
-            num_kernel_ddr = num_kernel - 1;
-        }
+	    else if (sValue == "DDR") {
+		auto banks = pt_mem_entry.get_child("banks");
+		for (const auto&bank : banks) {
+		    auto bank_name = bank.second.get<std::string>("name");
+		    bank_names.push_back(bank_name);
+		}
+	    }
+	}
+
+	// As HBM is part of platform, number of ddr kernels is total count reduced by 1(single HBM)
+	if (chk_hbm_mem)
+	    num_kernel_ddr = num_kernel - 1;
+
     } catch (const std::exception& e) {
         std::string msg("ERROR: Bad JSON format detected while marshaling build metadata (");
         msg += e.what();
@@ -108,6 +117,7 @@ int main(int argc, char** argv) {
     cl::Context context;
     std::string krnl_name = "bandwidth";
     std::vector<cl::Kernel> krnls(num_kernel);
+    std::vector<cl::Event> krnl_events(num_kernel);
     cl::CommandQueue q;
 
     // OPENCL HOST CODE AREA START
@@ -161,6 +171,8 @@ int main(int argc, char** argv) {
     }
 
     double max_throughput = 0;
+    std::vector<double> bank_throughput_values(num_kernel_ddr, 0.0);
+
     int reps = stoi(iter_cnt);
     if (num_kernel_ddr) {
         // Starting at 4K and going up to 16M with increments of power of 2
@@ -224,9 +236,9 @@ int main(int argc, char** argv) {
 
             auto time_start = std::chrono::high_resolution_clock::now();
 
-            for (int i = 0; i < num_kernel_ddr; i++) {
-                OCL_CHECK(err, err = q.enqueueTask(krnls[i]));
-            }
+            for (int i = 0; i < num_kernel_ddr; i++)
+                OCL_CHECK(err, err = q.enqueueTask(krnls[i], nullptr, &krnl_events[i]));
+       
             q.finish();
             auto time_end = std::chrono::high_resolution_clock::now();
 
@@ -247,6 +259,18 @@ int main(int argc, char** argv) {
                 }
             }
 
+            for (int i = 0; i < num_kernel_ddr; i++) {
+               cl_ulong start_time = krnl_events[i].getProfilingInfo<CL_PROFILING_COMMAND_START>();
+               cl_ulong end_time = krnl_events[i].getProfilingInfo<CL_PROFILING_COMMAND_END>();
+               double dnsduration = (double)(end_time - start_time) / reps; //nanoseconds to seconds
+               double dsduration = dnsduration / ((double)1000000000); // Convert the duration from nanoseconds to seconds
+               double bpersec = (data_size) / dsduration;
+               double mbpersec = (2 * bpersec) / ((double)1024 * 1024); // Convert b/sec to mb/sec
+
+               if (mbpersec > bank_throughput_values[i]) 
+                   bank_throughput_values[i] = mbpersec;
+            }
+
             double usduration =
                 (double)(std::chrono::duration_cast<std::chrono::nanoseconds>(time_end - time_start).count() / reps);
 
@@ -259,6 +283,8 @@ int main(int argc, char** argv) {
         }
 
         std::cout << "Throughput (Type: DDR) (Bank count: " << num_kernel_ddr << ") : " << max_throughput << "MB/s\n";
+        for (int i = 0; i < num_kernel_ddr; i++)
+            std::cout << " Throughput of Memory Tag: " << bank_names[i] << " is " << bank_throughput_values[i] << "MB/s" << "\n";
     }
     if (chk_hbm_mem) {
         max_throughput = 0;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
[CR-1140621](https://jira.xilinx.com/browse/CR-1140621) Memory bandwidth application prints overall throughput, not that of indiviual DDR. 

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
NA

#### How problem was solved, alternative solutions (if any) and why they were rejected
By adding kernel events we can get the execution time of each DDR. Updateed DMA test to print memory tag
#### Risks (if any) associated the changes in the commit
NA

#### What has been tested and how, request additional testing if necessary
This has been tested on V70 and U250.

#### Documentation impact (if any)
NA

mem_bw test output
<img width="721" alt="mem_bw" src="https://github.com/Xilinx/XRT/assets/133196374/4aeb1b46-6ff8-483c-b2cf-bf6bd2384099">

DMA Test output
<img width="602" alt="dma_test" src="https://github.com/Xilinx/XRT/assets/133196374/e6b147fe-65cf-44c2-acd9-eeb286aa9507">
