### PR TITLE
CR-1160311 xbflash2 tool doc update

### DIFF
--- a/src/runtime_src/doc/toc/xbflash2.rst
+++ b/src/runtime_src/doc/toc/xbflash2.rst
@@ -15,9 +15,11 @@ This tool supported for all Alveo platforms.
 
 This tool doesn't require XRT Package and it doesn't come with XRT package, it comes as separate xbflash package.
 
-``xbflah2`` tool is available in the Alveo card web page, getting started session, xbflash2 tab.
+``xbflash2`` tool is available in the Alveo card web page, getting started session, xbflash2 tab.
 
 For example: https://www.xilinx.com/products/boards-and-kits/alveo/u50.html#xbflash2
+
+After xbflash package installation, content goes to ``/usr/local/bin``
 
 This tool is verified and supported only on XDMA PCIe DMA designs.
 

--- a/src/runtime_src/doc/toc/xbflash2.rst
+++ b/src/runtime_src/doc/toc/xbflash2.rst
@@ -11,9 +11,13 @@ The Xilinx (R) Board Flash utility (xbflash2) is a standalone command line utili
 
 In 2022.1 release, this utility is Early Access with limited validation.
 
-This tool supported for all Alveo platforms, U2 and U30 platforms.
+This tool supported for all Alveo platforms.
 
-This tool doesn't come with XRT package, it comes as separate xbflash package.
+This tool doesn't require XRT Package and it doesn't come with XRT package, it comes as separate xbflash package.
+
+``xbflah2`` tool is available in the below Alveo cards wesite under respective card pages.
+
+https://www.xilinx.com/products/boards-and-kits/alveo.html
 
 This tool is verified and supported only on XDMA PCIe DMA designs.
 

--- a/src/runtime_src/doc/toc/xbflash2.rst
+++ b/src/runtime_src/doc/toc/xbflash2.rst
@@ -15,9 +15,9 @@ This tool supported for all Alveo platforms.
 
 This tool doesn't require XRT Package and it doesn't come with XRT package, it comes as separate xbflash package.
 
-``xbflah2`` tool is available in the below Alveo cards wesite under respective card pages.
+``xbflah2`` tool is available in the Alveo card web page, getting started session, xbflash2 tab.
 
-https://www.xilinx.com/products/boards-and-kits/alveo.html
+For example: https://www.xilinx.com/products/boards-and-kits/alveo/u50.html#xbflash2
 
 This tool is verified and supported only on XDMA PCIe DMA designs.
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
CR-1160311 xbflash2 tool doc update

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://jira.xilinx.com/browse/CR-1160311

#### How problem was solved, alternative solutions (if any) and why they were rejected

Improve xbflash2 documentation by:

Defining the software requirements.  From the xbflash2 XRT doc page xbflash2 — XRT Master documentation (xilinx.github.io), it's not clear whether xbflash2 requires XRT or not. It only says xbflash2 package doesn't include XRT.
> doesnt require XRT packages, updated in documentation.

Provide link to download xbflash2, or mention generally where one can get it -> currently in the Alveo Lounge, however this may become public under the respective card pages.
> updated in documentation.

Define all supported cards - currently it is strangely worded - "This tool supported for all Alveo platforms, U2 and U30 platforms.".  
> This tool supported for all Alveo platforms. 
>updated in documentation.

Be clear on supported platforms and suggested to reference UG1120.  Current wording is ambiguous and refers to designs instead of platforms - "This tool is verified and supported only on XDMA PCIe DMA designs."
> we don't need platform to flash it. just need vivado designs

It mentions golden image - recommend to provide link to these images
> whatever is in the board is golden image.

Define how to obtain the BAR offset
> This tool is for advance users, they should know how to get bar-offset, lspci would give them bar-offset. 

Provide an example of 'xbflash dump' option
> dump would be an .mcs file which is in binary file. 
> already provided example command for dump in the documentation.

#### Risks (if any) associated the changes in the commit
Low
#### What has been tested and how, request additional testing if necessary
Documentation update
#### Documentation impact (if any)
Yes