### PR TITLE
Fix for CR:1163285-changing field name

### DIFF
--- a/src/runtime_src/core/edge/common/aie_parser.cpp
+++ b/src/runtime_src/core/edge/common/aie_parser.cpp
@@ -60,14 +60,14 @@ get_driver_config(const pt::ptree& aie_meta)
   driver_config.num_columns = aie_meta.get<uint8_t>("aie_metadata.driver_config.num_columns");
   driver_config.num_rows = aie_meta.get<uint8_t>("aie_metadata.driver_config.num_rows");
   driver_config.shim_row = aie_meta.get<uint8_t>("aie_metadata.driver_config.shim_row");
-  if (!aie_meta.get_optional<uint8_t>("aie_metadata.driver_config.mem_row_start") ||
-      !aie_meta.get_optional<uint8_t>("aie_metadata.driver_config.mem_num_rows")) {
+  if (!aie_meta.get_optional<uint8_t>("aie_metadata.driver_config.mem_tile_row_start") ||
+      !aie_meta.get_optional<uint8_t>("aie_metadata.driver_config.mem_tile_num_rows")) {
   	driver_config.mem_row_start = aie_meta.get<uint8_t>("aie_metadata.driver_config.reserved_row_start");
 	driver_config.mem_num_rows = aie_meta.get<uint8_t>("aie_metadata.driver_config.reserved_num_rows");
   }
   else {
-	driver_config.mem_row_start = aie_meta.get<uint8_t>("aie_metadata.driver_config.mem_row_start");
-	driver_config.mem_num_rows = aie_meta.get<uint8_t>("aie_metadata.driver_config.mem_num_rows");
+	driver_config.mem_row_start = aie_meta.get<uint8_t>("aie_metadata.driver_config.mem_tile_row_start");
+	driver_config.mem_num_rows = aie_meta.get<uint8_t>("aie_metadata.driver_config.mem_tile_num_rows");
   }
   driver_config.aie_tile_row_start = aie_meta.get<uint8_t>("aie_metadata.driver_config.aie_tile_row_start");
   driver_config.aie_tile_num_rows = aie_meta.get<uint8_t>("aie_metadata.driver_config.aie_tile_num_rows");

--- a/src/runtime_src/core/edge/user/device_linux.cpp
+++ b/src/runtime_src/core/edge/user/device_linux.cpp
@@ -187,14 +187,14 @@ get_aie_metadata_info(const xrt_core::device* device)
   aie_meta.num_rows = pt.get<uint32_t>("aie_metadata.driver_config.num_rows");
   aie_meta.shim_row = pt.get<uint32_t>("aie_metadata.driver_config.shim_row");
   aie_meta.core_row = pt.get<uint32_t>("aie_metadata.driver_config.aie_tile_row_start");
-  if (!pt.get_optional<uint32_t>("aie_metadata.driver_config.mem_row_start") || 
-      !pt.get_optional<uint32_t>("aie_metadata.driver_config.mem_num_rows")) {
+  if (!pt.get_optional<uint32_t>("aie_metadata.driver_config.mem_tile_row_start") || 
+      !pt.get_optional<uint32_t>("aie_metadata.driver_config.mem_tile_num_rows")) {
        aie_meta.mem_row = pt.get<uint32_t>("aie_metadata.driver_config.reserved_row_start");
        aie_meta.num_mem_row = pt.get<uint32_t>("aie_metadata.driver_config.reserved_num_rows");
   }
   else {
-       aie_meta.mem_row = pt.get<uint32_t>("aie_metadata.driver_config.mem_row_start");
-       aie_meta.num_mem_row = pt.get<uint32_t>("aie_metadata.driver_config.mem_num_rows");
+       aie_meta.mem_row = pt.get<uint32_t>("aie_metadata.driver_config.mem_tile_row_start");
+       aie_meta.num_mem_row = pt.get<uint32_t>("aie_metadata.driver_config.mem_tile_num_rows");
   }
   aie_meta.hw_gen = pt.get<uint8_t>("aie_metadata.driver_config.hw_gen");
   return aie_meta;
@@ -482,14 +482,14 @@ struct aie_reg_read
   XAie_DevInst* devInst;         // AIE Device Instance
 
   uint8_t mem_row_start, mem_num_rows;
-  if (!pt.get_optional<uint8_t>("aie_metadata.driver_config.mem_row_start") ||
-      !pt.get_optional<uint8_t>("aie_metadata.driver_config.mem_num_rows")) {
+  if (!pt.get_optional<uint8_t>("aie_metadata.driver_config.mem_tile_row_start") ||
+      !pt.get_optional<uint8_t>("aie_metadata.driver_config.mem_tile_num_rows")) {
        mem_row_start = pt.get<uint8_t>("aie_metadata.driver_config.reserved_row_start");
        mem_num_rows = pt.get<uint8_t>("aie_metadata.driver_config.reserved_num_rows");
   }
   else {
-       mem_row_start = pt.get<uint8_t>("aie_metadata.driver_config.mem_row_start");
-       mem_num_rows = pt.get<uint8_t>("aie_metadata.driver_config.mem_num_rows");
+       mem_row_start = pt.get<uint8_t>("aie_metadata.driver_config.mem_tile_row_start");
+       mem_num_rows = pt.get<uint8_t>("aie_metadata.driver_config.mem_tile_num_rows");
   }
 
   XAie_SetupConfig(ConfigPtr,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1163285.
Changing old property name to mem_tile_row_start and mem_tile_num_rows in driver_config section aie_metadata. 
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
NA
#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit
Low
#### What has been tested and how, request additional testing if necessary
Verified application on aie1 with updated xclbins
#### Documentation impact (if any)
NA