### PR TITLE
CR-1176493 : Fixed xbutil validate after ps test added

### DIFF
--- a/src/runtime_src/core/common/device.h
+++ b/src/runtime_src/core/common/device.h
@@ -469,6 +469,7 @@ public:
 
   using name2idx_type = std::map<std::string, cuidx_type>;
   std::map<slot_id, name2idx_type> m_cu2idx;  // slot -> cu name mapping to cuidx
+  std::map<slot_id, name2idx_type> m_scu2idx;  // slot -> scu name mapping to scuidx
   std::vector<uint64_t> m_cus;                // cu base addresses in expeced sort order
   xrt::xclbin m_xclbin;                       // currently loaded xclbin  (single-slot, default)
   xclbin_map m_xclbins;                       // currently loaded xclbins (multi-slot)

--- a/src/runtime_src/core/pcie/driver/linux/include/xocl_xgq.h
+++ b/src/runtime_src/core/pcie/driver/linux/include/xocl_xgq.h
@@ -41,6 +41,7 @@ void xocl_xgq_notify(struct xocl_xgq *xgq_handle);
 int xocl_xgq_check_response(struct xocl_xgq *xgq_handle, int client_id, int *status);
 struct kds_command *xocl_xgq_get_command(struct xocl_xgq *xgq_handle, int client_id);
 int xocl_xgq_attach(struct xocl_xgq *xgq_handle, void *client, struct semaphore *sem, u32 prot, int *client_id);
+void xocl_xgq_detach(struct xocl_xgq *xgq_handle, int client_id);
 int xocl_xgq_abort(struct xocl_xgq *xgq_handle, int client_id, void *cond,
 		   bool (*match)(struct kds_command *xcmd, void *cond));
 
@@ -48,5 +49,7 @@ irqreturn_t xgq_isr(int irq, void *arg);
 struct xocl_xgq *xocl_xgq_init(struct xocl_xgq_info *info);
 void xocl_xgq_fini(struct xocl_xgq *xgq_handle);
 int xocl_get_xgq_id(struct xocl_xgq *xgq);
+int xocl_incr_xgq_ref_cnt(struct xocl_xgq *xgq);
+int xocl_decr_xgq_ref_cnt(struct xocl_xgq *xgq);
 
 #endif /* _XOCL_XGQ_H_ */

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/cu_xgq.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/cu_xgq.c
@@ -182,6 +182,8 @@ void xrt_cu_xgq_fini(struct xrt_cu *xcu)
 
 	xrt_cu_fini(xcu);
 
+	xocl_xgq_detach(core->xgq, core->xgq_client_id);
+
 	if (core->vaddr)
 		iounmap(core->vaddr);
 	kfree(xcu->core);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_ctrl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_ctrl.c
@@ -616,7 +616,7 @@ static void ert_ctrl_xgq_fini(struct ert_ctrl *ec)
 		if (ec->ec_exgq[i] == NULL)
 			continue;
 
-		xocl_xgq_fini(ec->ec_exgq[i]);
+		xocl_decr_xgq_ref_cnt(ec->ec_exgq[i]);
 		ec->ec_exgq[i] = NULL;
 	}
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_ctrl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_ctrl.c
@@ -565,6 +565,12 @@ static void ert_ctrl_unset_xgq(struct platform_device *pdev, void *xgq_handle)
 
 	BUG_ON(xgq_id == -EINVAL);
 
+	/* Check whether any further CUs/SCUs are still refering this XGQ.
+	 * If yes, then don't cleanup and return from here.
+	 */
+	if (xocl_decr_xgq_ref_cnt(ec->ec_exgq[xgq_id]) != 0)
+		return;
+
 	xgq_ips = &ec->ec_xgq_ips[xgq_id];
 	if ((xgq_id < ec->ec_num_xgq_ips) && xgq_ips) {
 		xocl_user_interrupt_config(xdev, xgq_ips->ecxc_xgq_irq, false);
@@ -746,6 +752,7 @@ static void *ert_ctrl_setup_xgq(struct platform_device *pdev, int id, u64 offset
 	}
 
 done:
+	xocl_incr_xgq_ref_cnt(ec->ec_exgq[id]);
 	return ec->ec_exgq[id];
 }
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_ctrl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_ctrl.c
@@ -582,7 +582,7 @@ static void ert_ctrl_unset_xgq(struct platform_device *pdev, void *xgq_handle)
 			xocl_intc_ert_config(xdev, xgq_id, false);
 			xocl_intc_ert_request(xdev, xgq_id, NULL, NULL);
 		}
-		xocl_xgq_fini(ec->ec_exgq[xgq_id]);
+		
 		ec->ec_exgq[xgq_id] = NULL;
 	}
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
@@ -658,7 +658,7 @@ xocl_read_axlf_helper(struct xocl_drm *drm_p, struct drm_xocl_axlf *axlf_ptr,
 	}
 
 	/* Cache some axlf data which shared in ioctl */
-	axlf_obj = vmalloc(sizeof(struct xocl_axlf_obj_cache));
+	axlf_obj = vzalloc(sizeof(struct xocl_axlf_obj_cache));
 	if (!axlf_obj) {
 		err = -ENOMEM;
 		goto done;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
[CR-1176493](https://jira.xilinx.com/browse/CR-1176493)
While running 'xbutil validate', it's passing on first attempt and failing the second one. After device reset first run works fine.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
-- There are two issues : 
   1) Userspace XRT is not updated for OpenCL application. The new ps_bandwidth test is implemented based on the OpenCL way. Hence need to add one more entry for SCU kernels
  2) There is an issue for XGQ. We are actually removing XGQ while reloading a xclbin to a slot in XOCL side. But there can a situation that same XGQ can be shared between multiple SLOT as there are only limited slots available. 
       i) Added a ref_count  for XGQ if multiple CUs/SCUs are sharing the same. If oef_count is   "0" then only removing that XGQ. 

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
