### PR TITLE
Removing unnecessary edge-specific include in profiling

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info/aie_util.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info/aie_util.cpp
@@ -28,7 +28,6 @@
 #include "core/common/device.h"
 #include "core/common/message.h"
 #include "core/common/xrt_profiling.h"
-#include "core/edge/common/aie_parser.h"
 #include "xdp/profile/database/database.h"
 #include "xdp/profile/device/tracedefs.h"
 #include "xdp/profile/plugin/vp_base/utility.h"


### PR DESCRIPTION
#### Problem solved by the commit
A profiling file that is common to all implementations was erroneously including a file from the core/edge section.  As the functionality should be common there should be no edge specific code used in this file.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
This code was recently refactored into a general solution from code that originated in the edge-specific profiling implementation, and the include file was accidentally never removed.

#### Risks (if any) associated the changes in the commit
Low as no functionality changed.

#### What has been tested and how, request additional testing if necessary
Compilation on x86 and edge has been tested.

#### Documentation impact (if any)
None.