### PR TITLE
Add support for trace event logging at API level

### DIFF
--- a/src/runtime_src/core/common/CMakeLists.txt
+++ b/src/runtime_src/core/common/CMakeLists.txt
@@ -23,6 +23,7 @@ add_library(core_common_library_objects OBJECT
   system.cpp
   thread.cpp
   time.cpp
+  trace.cpp
   utils.cpp
   xclbin_parser.cpp
   xclbin_swemu.cpp

--- a/src/runtime_src/core/common/api/native_profile.cpp
+++ b/src/runtime_src/core/common/api/native_profile.cpp
@@ -1,23 +1,9 @@
-/**
- * Copyright (C) 2016-2022 Xilinx, Inc
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2016-2022 Xilinx, Inc.  All rights reserved.
+// Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
 #define XRT_CORE_COMMON_SOURCE
-
 #include "native_profile.h"
+
 #include "core/common/module_loader.h"
 #include "core/common/utils.h"
 #include "core/common/dlfcn.h"
@@ -25,31 +11,30 @@
 
 namespace xdp::native {
 
-bool load()
+void
+load()
 {
-  static xrt_core::module_loader xdp_native_loader("xdp_native_plugin",
-						   register_functions,
-						   warning_function);
-  return true ;
+  static xrt_core::module_loader
+    xdp_native_loader("xdp_native_plugin",
+                      register_functions,
+                      warning_function);
 }
 
 // Callbacks for generic start/stop function tracking
-std::function<void (const char*, unsigned long long int)> function_start_cb ;
-std::function<void (const char*, unsigned long long int, unsigned long long int)> function_end_cb ;
+std::function<void (const char*, uint64_t)> function_start_cb ;
+std::function<void (const char*, uint64_t, uint64_t)> function_end_cb ;
 
 // Callbacks for individual functions to track start/stop and statistics
-  std::function<void (const char*, unsigned long long int, bool)> sync_start_cb ;
-std::function<void (const char*, unsigned long long int, unsigned long long int, bool, unsigned long long int)> sync_end_cb ;
+std::function<void (const char*, uint64_t, bool)> sync_start_cb ;
+std::function<void (const char*, uint64_t, uint64_t, bool, uint64_t)> sync_end_cb ;
   
-void register_functions(void* handle)
+void
+register_functions(void* handle)
 {
-  using start_type      = void (*)(const char*, unsigned long long int) ;
-  using sync_start_type = void (*)(const char*, unsigned long long int, bool) ;
-  using end_type        = void (*)(const char*, unsigned long long int,
-                                   unsigned long long int) ;
-  using end_sync_type   = void (*)(const char*, unsigned long long int,
-                                   unsigned long long int, bool,
-                                   unsigned long long int) ;
+  using start_type      = void (*)(const char*, uint64_t) ;
+  using sync_start_type = void (*)(const char*, uint64_t, bool) ;
+  using end_type        = void (*)(const char*, uint64_t, uint64_t) ;
+  using end_sync_type   = void (*)(const char*, uint64_t, uint64_t, bool, uint64_t) ;
 
   // Generic callbacks
   function_start_cb =
@@ -71,17 +56,21 @@ void warning_function()
 
 api_call_logger::
 api_call_logger(const char* function)
-  : m_funcid(0), m_fullname(function)
+  : m_funcid(0)
+  , m_fullname(function)
+  , m_trace(xrt_core::config::get_trace_logging() ? xrt_core::get_trace() : nullptr)
 {
   // With the addition of the generic "host_trace" feature, we have to
-  //  check if we should load the plugin.  We only want to load it if
-  //  native_xrt_trace is specified or if we are the topmost layer and
-  //  host_trace was specified
+  // check if we should load the plugin.  We only want to load it if
+  // native_xrt_trace is specified or if we are the topmost layer and
+  // host_trace was specified
   static bool s_load_native =
-    (xrt_core::config::get_native_xrt_trace() ||
-     xrt_core::utils::load_host_trace()) ? load() : false;
-  if (s_load_native) return;
+    (xrt_core::config::get_native_xrt_trace()
+     || xrt_core::utils::load_host_trace())
+    ? (load(), true)
+    : false;
 
+  if (s_load_native) {}
 }
 
 generic_api_call_logger::
@@ -92,16 +81,21 @@ generic_api_call_logger(const char* function)
     m_funcid = xrt_core::utils::issue_id() ;
     function_start_cb(m_fullname, m_funcid) ;
   }
+
+  if (m_trace)
+    m_trace->log_event(m_fullname, "begin");
 }
 
 generic_api_call_logger::
 ~generic_api_call_logger()
 {
-  auto timestamp = static_cast<unsigned long long int>(xrt_core::time_ns());
-
   if (function_end_cb) {
+    auto timestamp = static_cast<uint64_t>(xrt_core::time_ns());
     function_end_cb(m_fullname, m_funcid, timestamp) ;
   }
+
+  if (m_trace)
+    m_trace->log_event(m_fullname, "end");
 }
 
 sync_logger::
@@ -117,10 +111,10 @@ sync_logger(const char* function, bool w, size_t s)
 sync_logger::
 ~sync_logger()
 {
-  auto timestamp = static_cast<unsigned long long int>(xrt_core::time_ns());
+  auto timestamp = static_cast<uint64_t>(xrt_core::time_ns());
 
   if (sync_end_cb) {
-    sync_end_cb(m_fullname, m_funcid, timestamp, m_is_write, static_cast<unsigned long long int>(m_buffer_size)) ;
+    sync_end_cb(m_fullname, m_funcid, timestamp, m_is_write, static_cast<uint64_t>(m_buffer_size)) ;
   }
 }
 

--- a/src/runtime_src/core/common/api/native_profile.cpp
+++ b/src/runtime_src/core/common/api/native_profile.cpp
@@ -58,7 +58,7 @@ api_call_logger::
 api_call_logger(const char* function)
   : m_funcid(0)
   , m_fullname(function)
-  , m_trace(xrt_core::config::get_trace_logging() ? xrt_core::get_trace() : nullptr)
+  , m_trace_logger(xrt_core::trace::get_logger())
 {
   // With the addition of the generic "host_trace" feature, we have to
   // check if we should load the plugin.  We only want to load it if
@@ -82,8 +82,7 @@ generic_api_call_logger(const char* function)
     function_start_cb(m_fullname, m_funcid) ;
   }
 
-  if (m_trace)
-    m_trace->log_event(m_fullname, "begin");
+  m_trace_logger->add_event(m_fullname, "begin");
 }
 
 generic_api_call_logger::
@@ -94,8 +93,7 @@ generic_api_call_logger::
     function_end_cb(m_fullname, m_funcid, timestamp) ;
   }
 
-  if (m_trace)
-    m_trace->log_event(m_fullname, "end");
+  m_trace_logger->add_event(m_fullname, "end");
 }
 
 sync_logger::

--- a/src/runtime_src/core/common/api/native_profile.h
+++ b/src/runtime_src/core/common/api/native_profile.h
@@ -30,7 +30,7 @@ class api_call_logger
  protected:
   uint64_t m_funcid ;
   const char* m_fullname = nullptr ;
-  xrt_core::trace* m_trace = nullptr;
+  xrt_core::trace::logger* m_trace_logger = nullptr;
  public:
   explicit api_call_logger(const char* function);
   virtual ~api_call_logger() = default ;

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -3321,14 +3321,18 @@ void
 run::
 submit_wait(const xrt::fence& fence)
 {
-  handle->submit_wait(fence);
+  return xdp::native::profiling_wrapper("xrt::run::submit_wait", [this, &fence]{
+    handle->submit_wait(fence);
+  });
 }
 
 void
 run::
 submit_signal(const xrt::fence& fence)
 {
-  handle->submit_signal(fence);
+  return xdp::native::profiling_wrapper("xrt::run::submit_signal", [this, &fence]{
+    handle->submit_signal(fence);
+  });
 }
 
 kernel::

--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -340,6 +340,14 @@ get_logging()
   return value;
 }
 
+inline bool
+get_trace_logging()
+{
+  static bool value = detail::get_bool_value("Runtime.trace_logging", false)
+    || detail::get_env_value("XRT_TRACE_LOGGING_ENABLE");
+  return value;
+}
+
 inline unsigned int
 get_verbosity()
 {

--- a/src/runtime_src/core/common/detail/linux/trace.h
+++ b/src/runtime_src/core/common/detail/linux/trace.h
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+
+#include "core/common/trace.h"
+#include <memory>
+
+// Implementation of trace infrastructure for Linux.
+// TBD
+
+namespace xrt_core::detail::trace {
+
+// Trace class definition for Linux
+class trace_linux : public trace
+{
+public:
+  void
+  log_event(const char* id, const char* value) override
+  {}
+};
+
+// Create a trace object for current thread.  This function is called
+// exactly once per thread that leverages tracing.
+std::unique_ptr<xrt_core::trace>
+create_trace_object()
+{
+  return std::make_unique<trace_linux>();
+}
+
+} // xrt_core::detail
+

--- a/src/runtime_src/core/common/detail/linux/trace.h
+++ b/src/runtime_src/core/common/detail/linux/trace.h
@@ -7,24 +7,24 @@
 // Implementation of trace infrastructure for Linux.
 // TBD
 
-namespace xrt_core::detail::trace {
+namespace xrt_core::trace::detail {
 
-// Trace class definition for Linux
-class trace_linux : public trace
+// Trace logger class definition for Linux
+class logger_linux : public logger
 {
 public:
   void
-  log_event(const char* id, const char* value) override
+  add_event(const char* id, const char* value) override
   {}
 };
 
 // Create a trace object for current thread.  This function is called
 // exactly once per thread that leverages tracing.
-std::unique_ptr<xrt_core::trace>
-create_trace_object()
+std::unique_ptr<xrt_core::trace::logger>
+create_logger_object()
 {
-  return std::make_unique<trace_linux>();
+  return std::make_unique<logger_linux>();
 }
 
-} // xrt_core::detail
+} // xrt_core::detail::trace
 

--- a/src/runtime_src/core/common/detail/trace.h
+++ b/src/runtime_src/core/common/detail/trace.h
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+#ifndef core_common_detail_trace_h
+#define core_common_detail_trace_h
+
+#ifdef _WIN32
+# include "core/common/detail/windows/trace.h"
+#else
+# include "core/common/detail/linux/trace.h"
+#endif
+
+#endif

--- a/src/runtime_src/core/common/detail/windows/trace.h
+++ b/src/runtime_src/core/common/detail/windows/trace.h
@@ -33,14 +33,14 @@ TRACELOGGING_DEFINE_PROVIDER(
   "XRT",
   (0xe3e140bd, 0x8a94, 0x50be, 0x22, 0x64, 0x48, 0xe4, 0x44, 0xa7, 0x15, 0xdb));
 
-namespace xrt_core::detail::trace {
+namespace xrt_core::trace::detail {
 
 // Trace class definition for windows to tie into TraceLogging infrastructure  
-class trace_windows : public trace
+class logger_windows : public logger
 {
 public:
   void
-  log_event(const char* id, const char* value) override
+  add_event(const char* id, const char* value) override
   {
     TraceLoggingWrite(g_logging_provider,
                       "XRTTraceEvent", // must be a string literal
@@ -51,8 +51,8 @@ public:
 
 // Create a trace object for current thread.  This function is called
 // exactly once per thread that leverages tracing.
-std::unique_ptr<xrt_core::trace>
-create_trace_object()
+std::unique_ptr<xrt_core::trace::logger>
+create_logger_object()
 {
   // Globally initialize windows tracing infrastructure
   struct init
@@ -68,7 +68,7 @@ create_trace_object()
   };
 
   static init s_init;
-  return std::make_unique<trace_windows>();
+  return std::make_unique<logger_windows>();
 }
 
 } // xrt_core::detail

--- a/src/runtime_src/core/common/detail/windows/trace.h
+++ b/src/runtime_src/core/common/detail/windows/trace.h
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+
+// Implementation of trace infrastructure for MSVC
+// This infrastructure leverage native TraceLogging infrastruture.
+//
+// This header is included in a single (core/common/trace.cpp) compilation
+// unit.  It cannot be included in multiple compilation units.
+//
+// In order to start event tracing enable through xrt.ini or define env:
+//
+// % set XRT_TRACE_LOGGING_ENABLE
+// % tracelog -start <tracename> -guid <guids> -flags <flags> -level <level> -f <file>
+// E.g.
+// % tracelog -start mytrace -guid guids.guid -flags 0x10 -level 5 -f mytrace.etl
+// <run program>
+// % tracelog -stop
+// % tracefmt mytrace.etl -o mytrace.txt
+//
+// % cat guids.guid
+// b7484a37-032d-455a-8dc9-405a5996c422
+// ...
+
+#include "core/common/trace.h"
+#include <memory>
+#include <windows.h>
+#include <TraceLoggingProvider.h>
+
+// b7484a37-032d-455a-8dc9-405a5996c422
+TRACELOGGING_DEFINE_PROVIDER(
+  g_logging_provider,
+  "XRT",
+  (0xb7484a37, 0x032d, 0x455a, 0x8d, 0xc9, 0x40, 0x5a, 0x59, 0x96, 0xc4, 0x22));
+
+namespace xrt_core::detail::trace {
+
+// Trace class definition for windows to tie into TraceLogging infrastructure  
+class trace_windows : public trace
+{
+public:
+  void
+  log_event(const char* id, const char* value) override
+  {
+    TraceLoggingWrite(g_logging_provider,
+                      "XRTTraceEvent", // must be a string literal
+                      TraceLoggingValue(id, "Event"),
+                      TraceLoggingValue(value, "State"));
+  }
+};
+
+// Create a trace object for current thread.  This function is called
+// exactly once per thread that leverages tracing.
+std::unique_ptr<xrt_core::trace>
+create_trace_object()
+{
+  // Globally initialize windows tracing infrastructure
+  struct init
+  {
+    init()
+    {
+      TraceLoggingRegister(g_logging_provider);
+    }
+    ~init()
+    {
+      TraceLoggingUnregister(g_logging_provider);
+    }
+  };
+
+  static init s_init;
+  return std::make_unique<trace_windows>();
+}
+
+} // xrt_core::detail
+

--- a/src/runtime_src/core/common/detail/windows/trace.h
+++ b/src/runtime_src/core/common/detail/windows/trace.h
@@ -18,7 +18,7 @@
 // % tracefmt mytrace.etl -o mytrace.txt
 //
 // % cat guids.guid
-// b7484a37-032d-455a-8dc9-405a5996c422
+// e3e140bd-8a94-50be-2264-48e444a715db
 // ...
 
 #include "core/common/trace.h"
@@ -26,11 +26,12 @@
 #include <windows.h>
 #include <TraceLoggingProvider.h>
 
-// b7484a37-032d-455a-8dc9-405a5996c422
+// [System.Diagnostics.Tracing.EventSource]::new("XRT").Guid
+// e3e140bd-8a94-50be-2264-48e444a715db
 TRACELOGGING_DEFINE_PROVIDER(
   g_logging_provider,
   "XRT",
-  (0xb7484a37, 0x032d, 0x455a, 0x8d, 0xc9, 0x40, 0x5a, 0x59, 0x96, 0xc4, 0x22));
+  (0xe3e140bd, 0x8a94, 0x50be, 0x22, 0x64, 0x48, 0xe4, 0x44, 0xa7, 0x15, 0xdb));
 
 namespace xrt_core::detail::trace {
 

--- a/src/runtime_src/core/common/trace.cpp
+++ b/src/runtime_src/core/common/trace.cpp
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+#include "trace.h"
+#include "detail/trace.h"
+
+#include <memory>
+#include <thread>
+
+namespace xrt_core {
+
+trace*
+get_trace()
+{
+  static thread_local auto trace_object = detail::trace::create_trace_object();
+  return trace_object.get();
+}
+
+} // xrt_core

--- a/src/runtime_src/core/common/trace.cpp
+++ b/src/runtime_src/core/common/trace.cpp
@@ -1,18 +1,36 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+#define XRT_CORE_COMMON_SOURCE
 #include "trace.h"
 #include "detail/trace.h"
+
+#include "config_reader.h"
 
 #include <memory>
 #include <thread>
 
-namespace xrt_core {
+namespace {
 
-trace*
-get_trace()
+// Create specific logger if enabled
+static std::unique_ptr<xrt_core::trace::logger>
+get_logger_object()
 {
-  static thread_local auto trace_object = detail::trace::create_trace_object();
-  return trace_object.get();
+  if (xrt_core::config::get_trace_logging())
+    return xrt_core::trace::detail::create_logger_object();
+
+  return std::make_unique<xrt_core::trace::logger>();
 }
 
-} // xrt_core
+} // namespace
+
+namespace xrt_core::trace {
+
+// Per thread logger object  
+logger*
+get_logger()
+{
+  static thread_local auto logger_object = get_logger_object();
+  return logger_object.get();
+}
+
+} // xrt_core::trace

--- a/src/runtime_src/core/common/trace.h
+++ b/src/runtime_src/core/common/trace.h
@@ -3,15 +3,16 @@
 #ifndef XRT_CORE_TRACE_HANDLE_H
 #define XRT_CORE_TRACE_HANDLE_H
 
-namespace xrt_core {
+namespace xrt_core::trace {
 
-// class trace - base class for managing event tracing
+// class logger - base class for managing trace logging
 //
-// Implementation of class trace is platform specific. Trace objects
+// Implementation of class logging is platform specific. Logging objects
 // are created per thread and logs to platform specific infrastructure.
 //
-// Tracing is instrusive and added specifically where needed.  In order
-// to enable tracing define xrt.ini or set an environment variable
+// Tracing logging is instrusive and added specifically where needed.
+// In order to enable trace logging define xrt.ini or set an environment
+// variable
 //
 // % cat xrt.ini
 // [Runtime]
@@ -19,21 +20,27 @@ namespace xrt_core {
 //
 // To enable through environment variable make sure XRT_TRACE_LOGGING_ENABLE
 // is defined.
-class trace
+class logger
 {
 public:
-  virtual ~trace()
+  virtual ~logger()
   {}
 
   // Log an event 
   virtual void
-  log_event(const char* id, const char* value) = 0;
+  add_event(const char* /*id*/, const char* /*value*/)
+  {}
 };
 
-// Get trace object for current thread, creates the object if
-// necessary
-trace*
-get_trace();
+// get_logger() - Return trace logger object for current thread
+//
+// Creates the logger object if necessary as thread local object.
+// It is undefined behavior to delete the returned object.
+//
+// Access to underlying trace object is to facilitate caching
+// to avoid repeated calls to get_logger() where applicable.  
+logger*
+get_logger();
 
-} // xrt_core
+} // xrt_core::trace
 #endif

--- a/src/runtime_src/core/common/trace.h
+++ b/src/runtime_src/core/common/trace.h
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+#ifndef XRT_CORE_TRACE_HANDLE_H
+#define XRT_CORE_TRACE_HANDLE_H
+
+namespace xrt_core {
+
+// class trace - base class for managing event tracing
+//
+// Implementation of class trace is platform specific. Trace objects
+// are created per thread and logs to platform specific infrastructure.
+//
+// Tracing is instrusive and added specifically where needed.  In order
+// to enable tracing define xrt.ini or set an environment variable
+//
+// % cat xrt.ini
+// [Runtime]
+// trace_logging = true
+//
+// To enable through environment variable make sure XRT_TRACE_LOGGING_ENABLE
+// is defined.
+class trace
+{
+public:
+  virtual ~trace()
+  {}
+
+  // Log an event 
+  virtual void
+  log_event(const char* id, const char* value) = 0;
+};
+
+// Get trace object for current thread, creates the object if
+// necessary
+trace*
+get_trace();
+
+} // xrt_core
+#endif


### PR DESCRIPTION
#### Problem solved by the commit
Log calls to APIs at begin and end using native platform logging infrastructure.  On windows event tracing is using WPP software tracing.

#### How problem was solved, alternative solutions (if any) and why they were rejected
This PR adds a base trace class that is instantiated into platform specific objects. The windows platform specific implementation is added in a detail directory.

Tracing is integrated into the existing native profiling XDP infrastructure but is enabled using Runtime ini or env variable.

xrt.ini:
[Runtime]
trace_logging = true

or with environment variable XRT_TRACE_LOGGING_ENABLE defined.

#### What has been tested and how, request additional testing if necessary
Manual testing on windows

