### PR TITLE
Added compile time variable to only aie profile target

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_profile/CMakeLists.txt
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/CMakeLists.txt
@@ -29,7 +29,7 @@ if (XDP_MINIMAL_BUILD STREQUAL "yes")
   add_dependencies(xdp_aie_profile_plugin xdp_core xrt_coreutil)
   include_directories(xdp_aie_profile_plugin PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/win/transactions)
   target_link_libraries(xdp_aie_profile_plugin PRIVATE xdp_core xrt_coreutil xaiengine)
-  target_compile_definitions(xdp_aie_profile_plugin PRIVATE XDP_MINIMAL_BUILD=1)
+  target_compile_definitions(xdp_aie_profile_plugin PRIVATE XDP_MINIMAL_BUILD=1 -DXAIE_FEATURE_MSVC)
   target_include_directories(xdp_aie_profile_plugin PRIVATE ${AIERT_DIR}/include)
   set_target_properties(xdp_aie_profile_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Fixed an issue where Windows builds would fail to build correctly if this compile time flag is not passed. 


#### How problem was solved, alternative solutions (if any) and why they were rejected
Added Compile time variable specifically to aie_profiling only when XDP_MINIMAL_BUILD is set.