### PR TITLE
CR-1178158: AIE Tile Status, PC is 0 for all AIE1 designs, Status is always Disabled (2023.2)

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.cpp
@@ -413,6 +413,7 @@ namespace xdp {
     auto device = xrt_core::get_userpf_device(handle);
     auto data = device->get_axlf_section(AIE_METADATA);
     aie::readAIEMetadata(data.first, data.second, mAieMeta);
+    auto hwGen = aie::getHardwareGeneration(mAieMeta);
 
     // Update list of tiles to debug
     getTilesForStatus();
@@ -433,7 +434,7 @@ namespace xdp {
 
     // Create and register AIE status writer
     std::string filename = "aie_status_" + devicename + "_" + currentTime + ".json";
-    VPWriter* aieWriter = new AIEStatusWriter(filename.c_str(), devicename.c_str(), deviceID);
+    VPWriter* aieWriter = new AIEStatusWriter(filename.c_str(), devicename.c_str(), deviceID, hwGen);
     writers.push_back(aieWriter);
     db->getStaticInfo().addOpenedFile(aieWriter->getcurrentFileName(), "AIE_RUNTIME_STATUS");
 

--- a/src/runtime_src/xdp/profile/writer/aie_status/aie_status_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/aie_status/aie_status_writer.cpp
@@ -26,10 +26,11 @@ namespace xdp {
    */
 
   AIEStatusWriter::AIEStatusWriter(const char* fileName,
-               const char* deviceName, uint64_t deviceIndex)
+      const char* deviceName, uint64_t deviceIndex, int hwGen)
     : VPWriter(fileName)
     , mDeviceName(deviceName)
     , mDeviceIndex(deviceIndex)
+    , mHardwareGen(hwGen)
     , mWroteValidData(false)
   {
   }
@@ -72,7 +73,9 @@ namespace xdp {
       return true;
 
     // Now that we're valid, let's read the report the rest
-    auto memoryInfoStr = xrtDevice.get_info<xrt::info::device::aie_mem>();
+    std::string memoryInfoStr;
+    if (mHardwareGen > 1)
+      memoryInfoStr = xrtDevice.get_info<xrt::info::device::aie_mem>();
     auto interfaceInfoStr = xrtDevice.get_info<xrt::info::device::aie_shim>();
     
     bpt::ptree pt_memory;

--- a/src/runtime_src/xdp/profile/writer/aie_status/aie_status_writer.h
+++ b/src/runtime_src/xdp/profile/writer/aie_status/aie_status_writer.h
@@ -35,7 +35,7 @@ namespace xdp {
   {
   public:
     AIEStatusWriter(const char* fileName, const char* deviceName,
-                   uint64_t deviceIndex);
+                    uint64_t deviceIndex, int hwGen);
     ~AIEStatusWriter();
 
     virtual bool write(bool openNewFile);
@@ -48,6 +48,7 @@ namespace xdp {
   private:
     std::string mDeviceName;
     uint64_t mDeviceIndex;
+    int mHardwareGen;
     bool mWroteValidData;
   };
 


### PR DESCRIPTION
**Problem solved by the commit**
AIE status hangs/blocks when requesting aie_mem device info report on AIE1 devices

**How problem was solved, alternative solutions (if any) and why they were rejected**
Disregard aie_mem report on AIE1 since memory tiles are non-existent anyway

**Risks (if any) associated the changes in the commit**
aie_mem info is still invalid for AIE2

**What has been tested and how, request additional testing if necessary**
tested on vck190 and vek280 using various settings

**Documentation impact (if any)**
memory tile info in AIE status is not correct for AIE2