### PR TITLE
Extend xrt::ext::bo with missing constructors

### DIFF
--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -1305,6 +1305,18 @@ bo(const xrt::device& device, size_t sz, memory_group grp)
 {}
 
 bo::
+bo(const xrt::device& device, xrt::bo::export_handle ehdl)
+  : handle(xdp::native::profiling_wrapper("xrt::bo::bo",
+      alloc_import, device_type{device.get_handle()}, ehdl))
+{}
+
+bo::
+bo(const xrt::device& device, pid_type pid, xrt::bo::export_handle ehdl)
+  : handle(xdp::native::profiling_wrapper("xrt::bo::bo",
+      alloc_import_from_pid, device_type{device.get_handle()}, pid , ehdl))
+{}
+
+bo::
 bo(const xrt::hw_context& hwctx, void* userptr, size_t sz, bo::flags flags, memory_group grp)
   : handle(xdp::native::profiling_wrapper("xrt::bo::bo",
       alloc_userptr, device_type{hwctx}, userptr, sz
@@ -1344,12 +1356,14 @@ bo(xclDeviceHandle dhdl, size_t size, bo::flags flags, memory_group grp)
     , adjust_buffer_flags(xcl_to_core_device(dhdl), flags, grp), grp))
 {}
 
+// Deprecated
 bo::
 bo(xclDeviceHandle dhdl, xrt::bo_impl::export_handle ehdl)
   : handle(xdp::native::profiling_wrapper("xrt::bo::bo",
       alloc_import, xcl_to_core_device(dhdl), ehdl))
 {}
 
+// Deprecated
 bo::
 bo(xclDeviceHandle dhdl, pid_type pid, xrt::bo_impl::export_handle ehdl)
   : handle(xdp::native::profiling_wrapper("xrt::bo::bo",
@@ -1410,7 +1424,7 @@ get_flags() const
   });
 }
 
-xclBufferExportHandle
+bo::export_handle
 bo::
 export_buffer()
 {
@@ -1539,8 +1553,23 @@ alloc_kbuf(const device_type& device, void* userptr, size_t sz, xrtBufferFlags f
 }
 
 bo::
+bo(const xrt::device& device, void* userptr, size_t sz, access_mode access)
+  : xrt::bo::bo{alloc_kbuf(device_type{device.get_handle()}, userptr, sz, adjust_buffer_flags(access))}
+{}
+
+bo::
+bo(const xrt::device& device, void* userptr, size_t sz)
+  : bo{device, userptr, sz, xrt::ext::bo::access_mode::local}
+{}
+
+bo::
+bo(const xrt::device& device, pid_type pid, xrt::bo::export_handle ehdl)
+  : xrt::bo::bo{alloc_import_from_pid(device_type{device.get_handle()}, pid, ehdl)}
+{}
+
+bo::
 bo(const xrt::device& device, size_t sz, access_mode access)
-  : xrt::bo::bo{alloc_kbuf(device_type{device.get_handle()}, nullptr, sz, adjust_buffer_flags(access))}
+  : bo{device, nullptr, sz, access}
 {}
 
 bo::
@@ -1559,7 +1588,7 @@ bo(const xrt::hw_context& hwctx, size_t sz)
 {}
 
 bo::
-bo(const xrt::hw_context& hwctx, pid_type pid, xclBufferExportHandle ehdl)
+bo(const xrt::hw_context& hwctx, pid_type pid, xrt::bo::export_handle ehdl)
   : xrt::bo::bo{alloc_import_from_pid(device_type{hwctx}, pid, ehdl)}
 {}
 

--- a/src/runtime_src/core/include/experimental/xrt_ext.h
+++ b/src/runtime_src/core/include/experimental/xrt_ext.h
@@ -105,6 +105,42 @@ public:
   }
 
   /**
+   * bo() - Constructor with user host buffer and access mode
+   *
+   * @param device
+   *  The device on which to allocate this buffer
+   * @param userptr
+   *  The host buffer which must be page aligned
+   * @param sz
+   *  Size of buffer which must in multiple of page size
+   * @param access
+   *  Specific access mode for the buffer (see `enum access_mode`)
+   *
+   * This constructor creates a host_only buffer object with
+   * specified access.
+   */
+  XRT_API_EXPORT
+  bo(const xrt::device& device, void* userptr, size_t sz, access_mode access);
+
+  /**
+   * bo() - Constructor with user host buffer and access mode
+   *
+   * @param device
+   *  The device on which to allocate this buffer
+   * @param userptr
+   *  The host buffer which must be page aligned
+   * @param sz
+   *  Size of buffer which must in multiple of page size
+   * @param access
+   *  Specific access mode for the buffer (see `enum access_mode`)
+   *
+   * This constructor creates a host_only buffer object with local
+   * access and read|write direction.
+   */
+  XRT_API_EXPORT
+  bo(const xrt::device& device, void* userptr, size_t sz);
+
+  /**
    * bo() - Constructor for buffer object with specific access
    *
    * @param device
@@ -129,10 +165,26 @@ public:
    *  Size of buffer
 
    * This constructor creates a host_only buffer object with local
-   * access and in|out direction.
+   * access and read|write direction.
    */
   XRT_API_EXPORT
   bo(const xrt::device& device, size_t sz);
+
+  /**
+   * bo() - Constructor to import an exported buffer from another process
+   *
+   * @param device
+   *  The device that imports this buffer
+   * @param pid
+   *  Process id of exporting process
+   * @param ehdl
+   *  Exported buffer handle, implementation specific type
+   *
+   * The exported buffer handle is obtained from exporting process by
+   * calling `export_buffer()` on the buffer to be exported.
+   */
+  XRT_API_EXPORT
+  bo(const xrt::device& device, pid_type pid, xrt::bo::export_handle ehdl);
 
   /**
    * bo() - Constructor for buffer object
@@ -168,22 +220,11 @@ public:
   XRT_API_EXPORT
   bo(const xrt::hw_context& hwctx, size_t sz);
 
-  /**
-   * bo() - Constructor to import an exported buffer from another process
-   *
-   * @param hwctx
-   *  The hardware context that this buffer object uses for queue
-   *  operations such as syncing and residency operations.
-   * @param pid
-   *  Process id of exporting process
-   * @param ehdl
-   *  Exported buffer handle, implementation specific type
-   *
-   * The exported buffer handle is obtained from exporting process by
-   * calling `export_buffer()` on the buffer to be exported.
-   */
+  /// @cond
+  // Deprecated.  Hardware context specific import is not supported
   XRT_API_EXPORT
-  bo(const xrt::hw_context& hwctx, pid_type pid, xclBufferExportHandle ehdl);
+  bo(const xrt::hw_context& hwctx, pid_type pid, xrt::bo::export_handle ehdl);
+  /// @endcond
 };
 
 


### PR DESCRIPTION
#### Problem solved by the commit
Add missing constructors to xrt::ext::bo

- Add device import BO constructors
- Deprecated hwctx import BO

#### How problem was solved, alternative solutions (if any) and why they were rejected
Deprecate xrt::bo xclDeviceHandle import constructors and replace xclDeviceHandle with xrt::device.

