### PR TITLE
Update trace logging to support Linux

### DIFF
--- a/build/build_edge.sh
+++ b/build/build_edge.sh
@@ -47,6 +47,7 @@ install_recipes()
         echo "EXTERNALSRC = \"$XRT_REPO_DIR/src\"" >> $XRT_BB
         echo "EXTRA_OECMAKE += \"-DMY_VITIS=$XILINX_VITIS\"" >> $XRT_BB
         echo 'EXTERNALSRC_BUILD = "${WORKDIR}/build"' >> $XRT_BB
+	echo 'DEPENDS += " systemtap"' >> $XRT_BB
         echo 'PACKAGE_CLASSES = "package_rpm"' >> $XRT_BB
         echo 'LICENSE = "GPLv2 & Apache-2.0"' >> $XRT_BB
         echo 'LIC_FILES_CHKSUM = "file://../LICENSE;md5=de2c993ac479f02575bcbfb14ef9b485 \' >> $XRT_BB

--- a/src/runtime_src/core/common/api/native_profile.cpp
+++ b/src/runtime_src/core/common/api/native_profile.cpp
@@ -58,7 +58,6 @@ api_call_logger::
 api_call_logger(const char* function)
   : m_funcid(0)
   , m_fullname(function)
-  , m_trace_logger(xrt_core::trace::get_logger())
 {
   // With the addition of the generic "host_trace" feature, we have to
   // check if we should load the plugin.  We only want to load it if
@@ -81,8 +80,6 @@ generic_api_call_logger(const char* function)
     m_funcid = xrt_core::utils::issue_id() ;
     function_start_cb(m_fullname, m_funcid) ;
   }
-
-  m_trace_logger->add_event(m_fullname, "begin");
 }
 
 generic_api_call_logger::
@@ -92,8 +89,6 @@ generic_api_call_logger::
     auto timestamp = static_cast<uint64_t>(xrt_core::time_ns());
     function_end_cb(m_fullname, m_funcid, timestamp) ;
   }
-
-  m_trace_logger->add_event(m_fullname, "end");
 }
 
 sync_logger::

--- a/src/runtime_src/core/common/api/native_profile.h
+++ b/src/runtime_src/core/common/api/native_profile.h
@@ -30,7 +30,6 @@ class api_call_logger
  protected:
   uint64_t m_funcid ;
   const char* m_fullname = nullptr ;
-  xrt_core::trace::logger* m_trace_logger = nullptr;
  public:
   explicit api_call_logger(const char* function);
   virtual ~api_call_logger() = default ;
@@ -54,8 +53,7 @@ auto
 profiling_wrapper(const char* function, Callable&& f, Args&&...args)
 {
   if (xrt_core::config::get_native_xrt_trace()
-      || xrt_core::config::get_host_trace()
-      || xrt_core::config::get_trace_logging()) {
+      || xrt_core::config::get_host_trace()) {
     generic_api_call_logger log_object(function) ;
     return f(std::forward<Args>(args)...) ;
   }

--- a/src/runtime_src/core/common/api/native_profile.h
+++ b/src/runtime_src/core/common/api/native_profile.h
@@ -5,7 +5,6 @@
 #define NATIVE_PROFILE_DOT_H
 #include "core/common/config.h"
 #include "core/common/config_reader.h"
-#include "core/common/trace.h"
 #include "core/include/xrt.h"
 
 // This file contains the callback mechanisms for connecting the

--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -25,6 +25,7 @@
 #include "core/common/message.h"
 #include "core/common/query_requests.h"
 #include "core/common/system.h"
+#include "core/common/trace.h"
 #include "core/common/unistd.h"
 #include "core/common/xclbin_parser.h"
 
@@ -1089,6 +1090,7 @@ alloc_nodma(const device_type& device, size_t sz, xrtBufferFlags, xrtMemoryGroup
 static std::shared_ptr<xrt::bo_impl>
 alloc(const device_type& device, size_t sz, xrtBufferFlags flags, xrtMemoryGroup grp)
 {
+  XRT_TRACE_POINT_SCOPE(xrt_bo_alloc);
   xcl_bo_flags xflags{flags};
   auto type = xflags.flags & ~XRT_BO_FLAGS_MEMIDX_MASK;
   switch (type) {
@@ -1125,24 +1127,28 @@ alloc_xbuf(const device_type& device, xcl_buffer_handle xhdl)
 static std::shared_ptr<xrt::bo_impl>
 alloc_userptr(const device_type& device, void* userptr, size_t sz, xrtBufferFlags flags, xrtMemoryGroup grp)
 {
+  XRT_TRACE_POINT_SCOPE(xrt_bo_alloc_userptr);
   return alloc_ubuf(device, userptr, sz, flags, grp);
 }
 
 static std::shared_ptr<xrt::bo_impl>
 alloc_import(const device_type& device, xrt::bo_impl::export_handle ehdl)
 {
+  XRT_TRACE_POINT_SCOPE(xrt_bo_alloc_import);
   return std::make_shared<xrt::buffer_import>(device, ehdl);
 }
 
 static std::shared_ptr<xrt::bo_impl>
 alloc_import_from_pid(const device_type& device, xrt::pid_type pid, xrt::bo_impl::export_handle ehdl)
 {
+  XRT_TRACE_POINT_SCOPE(xrt_bo_alloc_import_from_pid);
   return std::make_shared<xrt::buffer_import>(device, pid, ehdl);
 }
 
 static std::shared_ptr<xrt::bo_impl>
 alloc_sub(const std::shared_ptr<xrt::bo_impl>& parent, size_t size, size_t offset)
 {
+  XRT_TRACE_POINT_SCOPE(xrt_bo_alloc_sub);
   return std::make_shared<xrt::buffer_sub>(parent, size, offset);
 }
 

--- a/src/runtime_src/core/common/api/xrt_device.cpp
+++ b/src/runtime_src/core/common/api/xrt_device.cpp
@@ -19,6 +19,7 @@
 #include "core/common/query_requests.h"
 #include "core/common/sensor.h"
 #include "core/common/system.h"
+#include "core/common/trace.h"
 
 #include "device_int.h"
 #include "handle.h"
@@ -53,6 +54,7 @@ send_exception_message(const char* msg)
 static std::shared_ptr<xrt_core::device>
 alloc_device_index(unsigned int index)
 {
+  XRT_TRACE_POINT_SCOPE(xrt_device_alloc_index);
   return xrt_core::get_userpf_device(index) ;
 }
 
@@ -244,6 +246,7 @@ uuid
 device::
 load_xclbin(const struct axlf* top)
 {
+  XRT_TRACE_POINT_SCOPE(xrt_device_load_xclbin);
   return xdp::native::profiling_wrapper("xrt::device::load_xclbin", [this, top]{
     xrt::xclbin xclbin{top};
     handle->load_xclbin(xclbin);
@@ -255,6 +258,7 @@ uuid
 device::
 load_xclbin(const std::string& fnm)
 {
+  XRT_TRACE_POINT_SCOPE(xrt_device_load_xclbin);
   return xdp::native::profiling_wrapper("xrt::device::load_xclbin", [this, &fnm]{
     xrt::xclbin xclbin{fnm};
     handle->load_xclbin(xclbin);
@@ -266,6 +270,7 @@ uuid
 device::
 load_xclbin(const xclbin& xclbin)
 {
+  XRT_TRACE_POINT_SCOPE(xrt_device_load_xclbin);
   return xdp::native::profiling_wrapper("xrt::device::load_xclbin",
   [this, &xclbin]{
     handle->load_xclbin(xclbin);
@@ -277,6 +282,7 @@ uuid
 device::
 register_xclbin(const xclbin& xclbin)
 {
+  XRT_TRACE_POINT_SCOPE(xrt_device_register_xclbin);
   return xdp::native::profiling_wrapper("xrt::device::register_xclbin",
   [this, &xclbin]{
     handle->record_xclbin(xclbin);

--- a/src/runtime_src/core/common/api/xrt_hw_context.cpp
+++ b/src/runtime_src/core/common/api/xrt_hw_context.cpp
@@ -8,9 +8,9 @@
 #define XRT_CORE_COMMON_SOURCE // in same dll as coreutil
 #include "core/include/xrt/xrt_hw_context.h"
 #include "hw_context_int.h"
-#include "native_profile.h"
 
 #include "core/common/device.h"
+#include "core/common/trace.h"
 #include "core/common/shim/hwctx_handle.h"
 #include "core/common/xdp/profile.h"
 
@@ -58,6 +58,9 @@ public:
 
   ~hw_context_impl()
   {
+    // This trace point measures the time to tear down a hw context on the device
+    XRT_TRACE_POINT_SCOPE(xrt_hw_context_dtor);
+
     // finish_flush_device should only be called when the underlying 
     // hw_context_impl is destroyed. The xdp::update_device cannot exist
     // in the hw_context_impl constructor because an existing
@@ -155,47 +158,49 @@ namespace xrt {
 static std::shared_ptr<hw_context_impl>
 alloc_hwctx_from_cfg(const xrt::device& device, const xrt::uuid& xclbin_id, const xrt::hw_context::cfg_param_type& cfg_param)
 {
-  return std::make_shared<hw_context_impl>(device.get_handle(), xclbin_id, cfg_param);
+  XRT_TRACE_POINT_SCOPE(xrt_hw_context);
+  auto handle = std::make_shared<hw_context_impl>(device.get_handle(), xclbin_id, cfg_param);
+
+  // Update device is called with a raw pointer to dyanamically
+  // link to callbacks that exist in XDP via a C-style interface
+  // The create_hw_context_from_implementation function is then 
+  // called in XDP create a hw_context to the underlying implementation
+  xrt_core::xdp::update_device(handle.get());
+
+  return handle;
 }
 
 static std::shared_ptr<hw_context_impl>
 alloc_hwctx_from_mode(const xrt::device& device, const xrt::uuid& xclbin_id, xrt::hw_context::access_mode mode)
 {
-  return std::make_shared<hw_context_impl>(device.get_handle(), xclbin_id, mode);
+  XRT_TRACE_POINT_SCOPE(xrt_hw_context);
+  auto handle = std::make_shared<hw_context_impl>(device.get_handle(), xclbin_id, mode);
+
+  // Update device is called with a raw pointer to dyanamically
+  // link to callbacks that exist in XDP via a C-style interface
+  // The create_hw_context_from_implementation function is then 
+  // called in XDP create a hw_context to the underlying implementation
+  xrt_core::xdp::update_device(handle.get());
+
+  return handle;
 }
 
 hw_context::
 hw_context(const xrt::device& device, const xrt::uuid& xclbin_id, const xrt::hw_context::cfg_param_type& cfg_param)
-  : detail::pimpl<hw_context_impl>(xdp::native::profiling_wrapper("xrt::hw_context::hw_context",
-      alloc_hwctx_from_cfg, device, xclbin_id, cfg_param))
-{
-  // Update device is called with a raw pointer to dyanamically
-  // link to callbacks that exist in XDP via a C-style interface
-  // The create_hw_context_from_implementation function is then 
-  // called in XDP create a hw_context to the underlying implementation
-  xrt_core::xdp::update_device(get_handle().get());
-}
-
+  : detail::pimpl<hw_context_impl>(alloc_hwctx_from_cfg(device, xclbin_id, cfg_param))
+{}
 
 hw_context::
 hw_context(const xrt::device& device, const xrt::uuid& xclbin_id, access_mode mode)
-  : detail::pimpl<hw_context_impl>(xdp::native::profiling_wrapper("xrt::hw_context::hw_context",
-      alloc_hwctx_from_mode, device, xclbin_id, mode))
-{
-  // Update device is called with a raw pointer to dyanamically
-  // link to callbacks that exist in XDP via a C-style interface
-  // The create_hw_context_from_implementation function is then 
-  // called in XDP create a hw_context to the underlying implementation
-  xrt_core::xdp::update_device(get_handle().get());
-}
+  : detail::pimpl<hw_context_impl>(alloc_hwctx_from_mode(device, xclbin_id, mode))
+{}
 
 void
 hw_context::
 update_qos(const qos_type& qos)
 {
-  xdp::native::profiling_wrapper("xrt::hw_context::update_qos", [this, &qos] {
-    get_handle()->update_qos(qos);
-  });
+  XRT_TRACE_POINT_SCOPE(xrt_hw_context_update_qos);
+  get_handle()->update_qos(qos);
 }
 
 xrt::device

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -3188,9 +3188,10 @@ void
 run::
 start()
 {
+  XRT_TRACE_POINT_SCOPE(xrt_run_start);
   xdp::native::profiling_wrapper
-    ("xrt::run::start", [this]{
-    handle->start();
+    ("xrt::run::start", [this] {
+      handle->start();
     });
 }
 
@@ -3219,6 +3220,7 @@ ert_cmd_state
 run::
 wait(const std::chrono::milliseconds& timeout_ms) const
 {
+  XRT_TRACE_POINT_SCOPE(xrt_run_wait);
   return xdp::native::profiling_wrapper("xrt::run::wait",
     [this, &timeout_ms] {
       return handle->wait(timeout_ms);
@@ -3229,6 +3231,7 @@ std::cv_status
 run::
 wait2(const std::chrono::milliseconds& timeout_ms) const
 {
+  XRT_TRACE_POINT_SCOPE(xrt_run_wait2);
   return xdp::native::profiling_wrapper("xrt::run::wait",
     [this, &timeout_ms] {
       return handle->wait_throw_on_error(timeout_ms);
@@ -3321,6 +3324,7 @@ void
 run::
 submit_wait(const xrt::fence& fence)
 {
+  XRT_TRACE_POINT_SCOPE(xrt_submit_wait);
   return xdp::native::profiling_wrapper("xrt::run::submit_wait", [this, &fence]{
     handle->submit_wait(fence);
   });
@@ -3330,6 +3334,7 @@ void
 run::
 submit_signal(const xrt::fence& fence)
 {
+  XRT_TRACE_POINT_SCOPE(xrt_submit_signal);
   return xdp::native::profiling_wrapper("xrt::run::submit_signal", [this, &fence]{
     handle->submit_signal(fence);
   });

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -40,6 +40,7 @@
 #include "core/common/error.h"
 #include "core/common/message.h"
 #include "core/common/system.h"
+#include "core/common/trace.h"
 #include "core/common/xclbin_parser.h"
 
 #include <boost/format.hpp>

--- a/src/runtime_src/core/common/detail/linux/trace.h
+++ b/src/runtime_src/core/common/detail/linux/trace.h
@@ -3,11 +3,11 @@
 #include "core/common/trace.h"
 
 #include <memory>
+#include <stdexcept>
 
 #define SDT_USE_VARIADIC
 #include <sys/sdt.h>
 
-// % cat core/common/detail/linux/trace.h
 #define XRT_DETAIL_TRACE_POINT_LOG(probe, ...) \
   STAP_PROBEV(xrt, probe##_log, ##__VA_ARGS__)
 

--- a/src/runtime_src/core/common/detail/linux/trace.h
+++ b/src/runtime_src/core/common/detail/linux/trace.h
@@ -1,11 +1,44 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
-
 #include "core/common/trace.h"
+
 #include <memory>
 
-// Implementation of trace infrastructure for Linux.
-// TBD
+#define SDT_USE_VARIADIC
+#include <sys/sdt.h>
+
+// % cat core/common/detail/linux/trace.h
+#define XRT_DETAIL_TRACE_POINT_LOG(probe, ...) \
+  STAP_PROBEV(xrt, probe##_log, ##__VA_ARGS__)
+
+#define XRT_DETAIL_TRACE_POINT_SCOPE(probe)                             \
+  struct xrt_trace_scope {                                              \
+    xrt_trace_scope()                                                   \
+    { DTRACE_PROBE(xrt, probe##_enter); }                               \
+    ~xrt_trace_scope()                                                  \
+    { DTRACE_PROBE(xrt, probe##_exit); }                                \
+  } xrt_trace_scope_instance
+
+#define XRT_DETAIL_TRACE_POINT_SCOPE1(probe, arg1)                      \
+  struct xrt_trace_scope1 {                                             \
+    decltype(arg1) a1;                                                  \
+    xrt_trace_scope1(decltype(a1) aa1)                                  \
+      : a1{aa1}                                                         \
+    { DTRACE_PROBE1(xrt, probe##_enter, a1); }                          \
+    ~xrt_trace_scope1()                                                 \
+    { DTRACE_PROBE1(xrt, probe##_exit, a1); }                           \
+  } xrt_trace_scope_instance{arg1}
+
+#define XRT_DETAIL_TRACE_POINT_SCOPE2(probe, arg1, arg2)                \
+  struct xrt_trace_scope2 {                                             \
+    decltype(arg1) a1;                                                  \
+    decltype(arg2) a2;                                                  \
+    xrt_trace_scope2(decltype(a1) aa1, decltype(a2) aa2)                \
+      : a1{aa1}, a2{aa2}                                                \
+    { DTRACE_PROBE2(xrt, probe##_enter, a1, a2); }                      \
+    ~xrt_trace_scope2()                                                 \
+    { DTRACE_PROBE2(xrt, probe##_exit, a1, a2);  }                      \
+  } xrt_trace_scope_instance{arg1, arg2}
 
 namespace xrt_core::trace::detail {
 
@@ -13,17 +46,42 @@ namespace xrt_core::trace::detail {
 class logger_linux : public logger
 {
 public:
-  void
-  add_event(const char* id, const char* value) override
-  {}
 };
 
 // Create a trace object for current thread.  This function is called
 // exactly once per thread that leverages tracing.
-std::unique_ptr<xrt_core::trace::logger>
+inline std::unique_ptr<xrt_core::trace::logger>
 create_logger_object()
 {
   return std::make_unique<logger_linux>();
+}
+
+template <typename ProbeType>
+inline void
+add_event(ProbeType&& p)
+{
+  throw std::runtime_error("xrt_core::trace::add_event() not supported on Linux");
+}
+
+template <typename ProbeType, typename A1>
+inline void
+add_event(ProbeType&& p, A1&& a1)
+{
+  throw std::runtime_error("xrt_core::trace::add_event() not supported on Linux");
+}
+
+template <typename ProbeType, typename A1, typename A2>
+inline void
+add_event(ProbeType&& p, A1&& a1, A2&& a2)
+{
+  throw std::runtime_error("xrt_core::trace::add_event() not supported on Linux");
+}
+
+template<typename ...Args>
+inline void
+add_event(Args&&... args)
+{
+  static_assert(sizeof...(args) < 4, "Max 3 arguments supported for add_event");
 }
 
 } // xrt_core::detail::trace

--- a/src/runtime_src/core/common/detail/linux/trace_init.h
+++ b/src/runtime_src/core/common/detail/linux/trace_init.h
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+
+// ****************************************************************
+// * This header is included in a single (core/common/trace.cpp) compilation
+// * unit.  It CANNOT be included in multiple compilation units.
+// ****************************************************************
+//
+// In order to start event tracing enable through xrt.ini or define env:
+// % cat xrt.ini
+// [Runtime]
+// trace_logging = true
+//
+// % export XRT_TRACE_LOGGING_ENABLE=1
+
+namespace xrt_core::trace::detail {
+
+// Initialize trace logging.  This function is called exactly once
+// from common/trace.cpp during static initialization.
+inline void
+init_trace_logging()
+{
+}
+  
+// Deinitialize trace logging.  This function is called exactly once
+// from common/trace.cpp during static destruction.
+inline void
+deinit_trace_logging()
+{
+}
+
+} // namespace xrt_core::trace::detail

--- a/src/runtime_src/core/common/detail/trace_init.h
+++ b/src/runtime_src/core/common/detail/trace_init.h
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+#ifndef core_common_detail_trace_init_h
+#define core_common_detail_trace_init_h
+
+#ifdef _WIN32
+# include "core/common/detail/windows/trace_init.h"
+#else
+# include "core/common/detail/linux/trace_init.h"
+#endif
+
+#endif

--- a/src/runtime_src/core/common/detail/windows/trace_init.h
+++ b/src/runtime_src/core/common/detail/windows/trace_init.h
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+
+// Initialization of trace infrastructure for MSVC.
+// This infrastructure leverage native TraceLogging infrastruture.
+//
+// ****************************************************************
+// * This header is included in a single (core/common/trace.cpp) compilation
+// * unit.  It CANNOT be included in multiple compilation units.
+// ****************************************************************
+//
+// In order to start event tracing enable through xrt.ini or define env:
+// % cat xrt.ini
+// [Runtime]
+// trace_logging = true
+//
+// % set XRT_TRACE_LOGGING_ENABLE=1
+// % tracelog -start <tracename> -guid <guids> -flags <flags> -level <level> -f <file>
+// E.g.
+// % tracelog -start mytrace -guid guids.guid -flags 0x10 -level 5 -f mytrace.etl
+// <run program>
+// % tracelog -stop
+// % tracefmt mytrace.etl -o mytrace.txt
+//
+// % cat guids.guid
+// e3e140bd-8a94-50be-2264-48e444a715db
+// ...
+
+#include <windows.h>
+#include <TraceLoggingProvider.h>
+
+// [System.Diagnostics.Tracing.EventSource]::new("XRT").Guid
+// e3e140bd-8a94-50be-2264-48e444a715db
+TRACELOGGING_DEFINE_PROVIDER(
+  g_logging_provider,
+  "XRT",
+  (0xe3e140bd, 0x8a94, 0x50be, 0x22, 0x64, 0x48, 0xe4, 0x44, 0xa7, 0x15, 0xdb));
+
+namespace xrt_core::trace::detail {
+
+// Initialize trace logging.  This function is called exactly once
+// from common/trace.cpp during static initialization.
+inline void
+init_trace_logging()
+{
+  TraceLoggingRegister(g_logging_provider);
+}
+  
+// Deinitialize trace logging.  This function is called exactly once
+// from common/trace.cpp during static destruction.
+inline void
+deinit_trace_logging()
+{
+  TraceLoggingUnregister(g_logging_provider);
+}
+
+} // namespace xrt_core::trace::detail

--- a/src/runtime_src/core/common/trace.cpp
+++ b/src/runtime_src/core/common/trace.cpp
@@ -3,6 +3,7 @@
 #define XRT_CORE_COMMON_SOURCE
 #include "trace.h"
 #include "detail/trace.h"
+#include "detail/trace_init.h"
 
 #include "config_reader.h"
 
@@ -10,6 +11,32 @@
 #include <thread>
 
 namespace {
+
+// Static global initialization of trace logging.  
+struct init
+{
+  init()
+  {
+    if (!xrt_core::config::get_trace_logging())
+      return;
+
+    xrt_core::trace::detail::init_trace_logging();
+  }
+
+  ~init()
+  {
+    try {
+      if (!xrt_core::config::get_trace_logging())
+        return;
+
+      xrt_core::trace::detail::deinit_trace_logging();
+    }
+    catch (...) {
+    }
+  }
+};
+
+static init s_init;
 
 // Create specific logger if enabled
 static std::unique_ptr<xrt_core::trace::logger>

--- a/src/runtime_src/core/common/trace.h
+++ b/src/runtime_src/core/common/trace.h
@@ -3,6 +3,25 @@
 #ifndef XRT_CORE_TRACE_HANDLE_H
 #define XRT_CORE_TRACE_HANDLE_H
 
+#include <utility>
+
+////////////////////////////////////////////////////////////////
+// namespace xrt_core::trace
+//
+// Trace logging for XRT.  Implementation is platform specific.
+//
+// Trace logging is instrusive and added specifically where needed.
+//
+// The trace infrastructure must be initialized before launching the
+// application (platform specific requirement). Enable using xrt.ini
+// or environment variable:
+//
+// % cat xrt.ini
+// [Runtime]
+// trace_logging = true
+//
+// % set XRT_TRACE_LOGGING_ENABLE=1
+////////////////////////////////////////////////////////////////
 namespace xrt_core::trace {
 
 // class logger - base class for managing trace logging
@@ -10,26 +29,15 @@ namespace xrt_core::trace {
 // Implementation of class logging is platform specific. Logging objects
 // are created per thread and logs to platform specific infrastructure.
 //
-// Tracing logging is instrusive and added specifically where needed.
-// In order to enable trace logging define xrt.ini or set an environment
-// variable
-//
-// % cat xrt.ini
-// [Runtime]
-// trace_logging = true
-//
-// To enable through environment variable make sure XRT_TRACE_LOGGING_ENABLE
-// is defined.
+// The trace logging class collects statistics from all threads using
+// XRT. The statistics are collected in a thread safe manner.
 class logger
 {
 public:
   virtual ~logger()
   {}
 
-  // Log an event 
-  virtual void
-  add_event(const char* /*id*/, const char* /*value*/)
-  {}
+  // TBD
 };
 
 // get_logger() - Return trace logger object for current thread
@@ -43,4 +51,75 @@ logger*
 get_logger();
 
 } // xrt_core::trace
+
+
+#include "core/common/detail/trace.h"
+
+////////////////////////////////////////////////////////////////
+// Platform specific trace point logging
+//
+// Windows:
+// Uses WPP tracing infrastructure on Windows.  The trace infrastructure
+// must be initialized before launching the application.
+// Enable using xrt.ini or environment variable
+// % cat xrt.ini
+// [Runtime]
+// trace_logging = true
+//
+// % set XRT_TRACE_LOGGING_ENABLE=1
+//
+// Linux:
+// Uses DTRACE on Linux
+// Enable and record with perf tool
+////////////////////////////////////////////////////////////////
+namespace xrt_core::trace {
+
+// add_event() - Add a trace event
+//
+// @args - variadic arguments, where first argument is the event name
+//
+// Example:
+// xrt_core::trace::add_event(__func__, ...);
+//
+// Platform specific implementation
+// Integrated into WPP tracing on Windows
+// Not implemented on Linux
+//
+// This function can only be used in windows specific code (shim)
+template <typename ...Args>
+void
+add_event(Args&&... args)
+{
+  detail::add_event(std::forward<Args>(args)...);
+}
+
+} // xrt_core::trace
+
+////////////////////////////////////////////////////////////////
+// Trace point macros
+// Windows:
+// Uses WPP tracing infrastructure on Windows.
+// Requires initialization of trace infrastructure before launching.
+//
+// Linux:
+// Uses DTRACE on Linux
+// Enable and record with perf tool
+////////////////////////////////////////////////////////////////
+
+// Add a single trace point 
+#define XRT_TRACE_POINT_LOG(probe, ...) \
+  XRT_DETAIL_TRACE_POINT_LOG(probe, ##__VA_ARGS__)
+
+// Scoped trace points
+// Create a scoped object that that a tracepoint when created
+// and when destroyed.  The variants support 0, 1, or 2 arguments.
+#define XRT_TRACE_POINT_SCOPE(probe) \
+  XRT_DETAIL_TRACE_POINT_SCOPE(probe)
+
+#define XRT_TRACE_POINT_SCOPE1(probe, a1) \
+  XRT_DETAIL_TRACE_POINT_SCOPE1(probe, a1)
+
+#define XRT_TRACE_POINT_SCOPE2(probe, a1, a2) \
+  XRT_DETAIL_TRACE_POINT_SCOPE2(probe, a1, a2)
+
 #endif

--- a/src/runtime_src/tools/scripts/xrtdeps.sh
+++ b/src/runtime_src/tools/scripts/xrtdeps.sh
@@ -102,6 +102,7 @@ rh_package_list()
      rapidjson-devel \
      rpm-build \
      strace \
+     systemtap-sdt-devel \
      unzip \
      zlib-static \
     )
@@ -220,6 +221,7 @@ ub_package_list()
      python3-sphinx-rtd-theme \
      sphinx-common \
      strace \
+     systemtab-sdt-dev \
      unzip \
      uuid-dev \
     )
@@ -303,6 +305,7 @@ fd_package_list()
      strace \
      systemd-devel \
      systemd-devel \
+     systemtap-sdt-devel \
      unzip \
      zlib-static \
     )
@@ -350,6 +353,7 @@ suse_package_list()
      python3-pip \
      rpm-build \
      strace \
+     systemtap-sdt-devel \
      unzip \
      zlib-devel-static \
    )

--- a/src/runtime_src/tools/scripts/xrtdeps.sh
+++ b/src/runtime_src/tools/scripts/xrtdeps.sh
@@ -221,7 +221,7 @@ ub_package_list()
      python3-sphinx-rtd-theme \
      sphinx-common \
      strace \
-     systemtab-sdt-dev \
+     systemtap-sdt-dev \
      unzip \
      uuid-dev \
     )


### PR DESCRIPTION
#### Problem solved by the commit
Change how events are logged, the logger class is no longer needed for events, but may be used later for collecting stats.

#### How problem was solved, alternative solutions (if any) and why they were rejected
On Linux trace point logging uses DTRACE events enabled via perf. 
On Windows trace point logging uses WPP enabled via xrt.ini or env.

Macros are used to interface with the platform specific logging infrastructure.  XRT code is agnostic to the underlying trace point infrastructure used.

Windows requires specific enablement via xrt.ini or environment variable.  This is documented in code.

The infrastructure itself is not exposed to applications, but of course usage require action from the user to enable and / or collect the trace point data
