### PR TITLE
update mb-gcc path for building ERT

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -261,7 +261,7 @@ fi
 
 # we pick microblaze toolchain from Vitis install
 if [[ -z ${XILINX_VITIS:+x} ]] || [[ ! -d ${XILINX_VITIS} ]]; then
-    export XILINX_VITIS=/proj/xbuilds/2019.2_released/installs/lin64/Vitis/2019.2
+    export XILINX_VITIS=/proj/xbuilds/2023.1_released/installs/lin64/Vitis/HEAD
     if [[ ! -d ${XILINX_VITIS} ]]; then
         echo "****************************************************************"
         echo "* XILINX_VITIS is undefined or not accessible                  *"

--- a/build/build.sh
+++ b/build/build.sh
@@ -261,7 +261,7 @@ fi
 
 # we pick microblaze toolchain from Vitis install
 if [[ -z ${XILINX_VITIS:+x} ]] || [[ ! -d ${XILINX_VITIS} ]]; then
-    export XILINX_VITIS=/proj/xbuilds/2023.1_released/installs/lin64/Vitis/HEAD
+    export XILINX_VITIS=/proj/xbuilds/2023.1_released/installs/lin64/Vitis/2023.1
     if [[ ! -d ${XILINX_VITIS} ]]; then
         echo "****************************************************************"
         echo "* XILINX_VITIS is undefined or not accessible                  *"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Update the path for obtaining tool chain for building ERT. The original path has been removed from TA already.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Pipeline build has failed because of this issue.
#### How problem was solved, alternative solutions (if any) and why they were rejected
Update to a newer path on TA.
#### Risks (if any) associated the changes in the commit
Risk is low since no code logic change.
#### What has been tested and how, request additional testing if necessary
Build and installed XRT package. Ran xbutil validate and examined the IOPS result:
Test 5 [0000:61:00.1]     : iops 
    Details               : IOPS: **553517** (verify)                               
    Test Status           : [PASSED]
The IOPS result looks good, which indicates that the new mb-gcc works fine.
#### Documentation impact (if any)
N/A