### PR TITLE
Add build.sh option to force error if ERT FW cannot be build

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -40,6 +40,7 @@ usage()
     echo
     echo "[-help]                     List this help"
     echo "[clean|-clean]              Remove build directories"
+    echo "[-ci]                       Build is initiated by CI"
     echo "[-dbg]                      Build debug library only (default)"
     echo "[-opt]                      Build optimized library only (default)"
     echo "[-edge]                     Build edge of x64.  Turns off opt and dbg"
@@ -77,6 +78,7 @@ usage()
 
 clean=0
 ccache=0
+ci=0
 docs=0
 verbose=""
 driver=0
@@ -102,6 +104,10 @@ while [ $# -gt 0 ]; do
             ;;
         clean|-clean)
             clean=1
+            shift
+            ;;
+        -ci)
+            ci=1
             shift
             ;;
         -dbg)
@@ -267,6 +273,14 @@ if [[ -z ${XILINX_VITIS:+x} ]] || [[ ! -d ${XILINX_VITIS} ]]; then
         echo "* XILINX_VITIS is undefined or not accessible                  *"
         echo "* MicroBlaze firmware will not be built                        *"
         echo "****************************************************************"
+
+        # When the build is initiated by CI, it is an error to build
+        # XRT without MicroBlaze firmware. The FW is needed when
+        # platform packages are installed and creates xsabin files.
+        # CI validates install of platform packages with XRT build.
+        if [[ $ci == 1 ]]; then
+            exit 1
+        fi
     fi
 fi
 


### PR DESCRIPTION
#### Problem solved by the commit
When the build is initiated by CI system, it is an error to build XRT without MicroBlaze firmware. The FW is needed when platform packages are installed in order to create xsabin.

#### How problem was solved, alternative solutions (if any) and why they were rejected
This PR add `-ci` build option to be set by CI when building XRT on Linux.  The option is used to error out if ERT FW cannot be built.
