### PR TITLE
CR-1179639 Add early access label for Ryzen AI

### DIFF
--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -405,7 +405,7 @@ XBUtilities::collect_devices( const std::set<std::string> &_deviceBDFs,
       check_versal_boot(device);
 
     const std::string device_name = xrt_core::device_query_default<xrt_core::query::rom_vbnv>(device, "");
-    if (device_name.find("IPU") != std::string::npos) {
+    if (device_name.find("Ryzen") != std::string::npos) {
       std::cout << "------------------------------------------------------------\n";
       std::cout << "                        EARLY ACCESS                        \n";
       std::cout << "        This release of xbutil contains early access        \n";

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -404,6 +404,15 @@ XBUtilities::collect_devices( const std::set<std::string> &_deviceBDFs,
     if (xrt_core::device_query_default<xq::is_versal>(device, false))
       check_versal_boot(device);
 
+    const std::string device_name = xrt_core::device_query_default<xrt_core::query::rom_vbnv>(device, "");
+    if (device_name.find("IPU") != std::string::npos) {
+      std::cout << "------------------------------------------------------------\n";
+      std::cout << "                        EARLY ACCESS                        \n";
+      std::cout << "        This release of xbutil contains early access        \n";
+      std::cout << "         experimental features which may have bugs.         \n";
+      std::cout << "------------------------------------------------------------\n";
+    }
+
     return device;
   }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1179639

The release of xbutil for Windows is an early access release. To support this we are adding a label that will printout whenever a Ryzen AI device is referenced.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
New (temporary) feature.

#### How problem was solved, alternative solutions (if any) and why they were rejected
When a device is created, check if it is an IPU device. If yes then display the early access message.

#### Risks (if any) associated the changes in the commit
None.

#### What has been tested and how, request additional testing if necessary
Ubuntu 22.04
Without device
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov/XRT/build/Debug/runtime_src/core/tools/xbutil2$ ./xbutil2 examine
System Configuration
  OS Name              : Linux
  Release              : 6.5.0-rc1+
  Version              : #10 SMP PREEMPT_DYNAMIC Wed Aug 16 22:28:12 PDT 2023
  Machine              : x86_64
  CPU Cores            : 16
  Memory               : 63990 MB
  Distribution         : Ubuntu 22.04 LTS
  GLIBC                : 2.35
  Model                : Precision 5820 Tower

XRT
  Version              : 2.16.0
  Branch               : CR-1179639-master
  Hash                 : 4b0df56e051cec9517943ac969c9be56dee92634
  Hash Date            : 2023-10-18 09:40:19
  XOCL                 : 2.16.0, 893580509d3f7b0f1fab5a0da6210c709529a740
  XCLMGMT              : 2.16.0, 893580509d3f7b0f1fab5a0da6210c709529a740

Devices present
BDF             :  Shell                            Logic UUID                            Device ID       Device Ready*
-------------------------------------------------------------------------------------------------------------------------
[0000:04:00.1]  :  xilinx_u55c_gen3x16_xdma_base_3  97088961-FEAE-DA91-52A2-1D9DFD63CCEF  user(inst=129)  Yes


* Devices that are not ready will have reduced functionality when using XRT tools
```

With "IPU" device (Forced u55c to look like an IPU device)
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov/XRT/build/Debug/runtime_src/core/tools/xbutil2$ ./xbutil2 examine -d 04:00
------------------------------------------------------------
                       EARLY ACCESS
        This release of xbutil contains early access
         experimental features which may have bugs.
------------------------------------------------------------

-------------------------------------------------
[0000:04:00.1] : xilinx_u55c_gen3x16_xdma_base_3
-------------------------------------------------
Platform
  XSA Name               : xilinx_u55c_gen3x16_xdma_base_3
  Logic UUID             : 97088961-FEAE-DA91-52A2-1D9DFD63CCEF
  FPGA Name              :
  JTAG ID Code           : 0x14b7d093
  DDR Size               : 0 Bytes
  DDR Count              : 0
  Mig Calibrated         : true
  P2P Status             : disabled
  Performance Mode       : not supported
  P2P IO space required  : 32 GB

Clocks
  DATA_CLK (Data)        : 300 MHz
  KERNEL_CLK (Kernel)    : 500 MHz
  hbm_aclk (System)      : 450 MHz

Mac Addresses            : 00:0A:35:0B:23:98
                         : 00:0A:35:0B:23:99
                         : 00:0A:35:0B:23:9A
                         : 00:0A:35:0B:23:9B
                         : 00:0A:35:0B:23:9C
                         : 00:0A:35:0B:23:9D
                         : 00:0A:35:0B:23:9E
                         : 00:0A:35:0B:23:9F

  Device Status: HEALTHY
  Hardware Context ID: 0
    Xclbin UUID: E106E953-CF90-4024-E075-282D1A7D820B
    PL Compute Units
      Index  Name             Base Address  Usage  Status
      -----------------------------------------------------
      0      verify:verify_1  0x800000      7      (IDLE)
```

With Alveo device
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov/XRT/build/Debug/runtime_src/core/tools/xbutil2$ ./xbutil2 examine -d 04:00

-------------------------------------------------
[0000:04:00.1] : xilinx_u55c_gen3x16_xdma_base_3
-------------------------------------------------
Platform
  XSA Name               : xilinx_u55c_gen3x16_xdma_base_3
  Logic UUID             : 97088961-FEAE-DA91-52A2-1D9DFD63CCEF
  FPGA Name              :
  JTAG ID Code           : 0x14b7d093
  DDR Size               : 0 Bytes
  DDR Count              : 0
  Mig Calibrated         : true
  P2P Status             : disabled
  Performance Mode       : not supported
  P2P IO space required  : 32 GB

Clocks
  DATA_CLK (Data)        : 300 MHz
  KERNEL_CLK (Kernel)    : 500 MHz
  hbm_aclk (System)      : 450 MHz

Mac Addresses            : 00:0A:35:0B:23:98
                         : 00:0A:35:0B:23:99
                         : 00:0A:35:0B:23:9A
                         : 00:0A:35:0B:23:9B
                         : 00:0A:35:0B:23:9C
                         : 00:0A:35:0B:23:9D
                         : 00:0A:35:0B:23:9E
                         : 00:0A:35:0B:23:9F

  Device Status: HEALTHY
  Hardware Context ID: 0
    Xclbin UUID: E106E953-CF90-4024-E075-282D1A7D820B
    PL Compute Units
      Index  Name             Base Address  Usage  Status
      -----------------------------------------------------
      0      verify:verify_1  0x800000      7      (IDLE)
```
#### Documentation impact (if any)
None