### PR TITLE
Exclude version file generation when running AMD promotion build

### DIFF
--- a/src/CMake/version.cmake
+++ b/src/CMake/version.cmake
@@ -2,6 +2,16 @@
 # Copyright (C) 2019-2021 Xilinx, Inc. All rights reserved.
 # Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
 
+# AMD promotion build works from copied sources with no git
+# repository.  The build cannot query git for git metadata.  The
+# promotion build has explicitly overwritten config/version.h.in and
+# config/version.json.in with pre-generated ones.
+if (DEFINED ENV{DK_ROOT})
+
+message("-- Skipping Git metadata")
+
+else (DEFINED ENV{DK_ROOT})
+
 # Get the branch
 execute_process(
   COMMAND ${GIT_EXECUTABLE} rev-parse --abbrev-ref HEAD
@@ -50,6 +60,8 @@ execute_process(
   OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 string(REPLACE "\n" "," XRT_MODIFIED_FILES "${XRT_MODIFIED_FILES}")
+
+endif(DEFINED ENV{DK_ROOT})
 
 # Get the build date RFC format
 execute_process(


### PR DESCRIPTION
AMD promotion build works from copied sources with no git repository. The build cannot query git for git metadata.  The promotion build has explicitly overwritten config/version.h.in and config/version.json.in with pre-generated ones.

This PR tweaks CMake to prevent version file generation when running a promotion build.
