### PR TITLE
VITIS-10045 - Fix a crash in xclbinUtil on windows platform

### DIFF
--- a/src/runtime_src/tools/xclbinutil/SectionBMC.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionBMC.cxx
@@ -79,7 +79,7 @@ SectionBMC::getSubSectionEnum(const std::string& sSubSectionName)
 const std::string&
 SectionBMC::getSubSectionName(SectionBMC::SubSection eSubSection)
 {
-  auto subSectionTable = getSubSectionTable();
+  const auto& subSectionTable = getSubSectionTable();
   auto iter = std::find_if(subSectionTable.begin(), subSectionTable.end(), [&](const auto& entry) {return entry.second == eSubSection;});
 
   if (iter == subSectionTable.end())

--- a/src/runtime_src/tools/xclbinutil/SectionFlash.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionFlash.cxx
@@ -81,7 +81,7 @@ SectionFlash::getSubSectionEnum(const std::string& sSubSectionName)
 const std::string&
 SectionFlash::getSubSectionName(SectionFlash::SubSection eSubSection)
 {
-  auto subSectionTable = getSubSectionTable();
+  const auto& subSectionTable = getSubSectionTable();
   auto iter = std::find_if(subSectionTable.begin(), subSectionTable.end(), [&](const auto& entry) {return entry.second == eSubSection;});
 
   if (iter == subSectionTable.end())

--- a/src/runtime_src/tools/xclbinutil/SectionMCS.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionMCS.cxx
@@ -79,7 +79,7 @@ SectionMCS::getSubSectionEnum(const std::string& sSubSectionName)
 const std::string&
 SectionMCS::getSubSectionName(MCS_TYPE eSubSection)
 {
-  auto subSectionTable = getSubSectionTable();
+  const auto& subSectionTable = getSubSectionTable();
   auto iter = std::find_if(subSectionTable.begin(), subSectionTable.end(), [&](const auto& entry) {return entry.second == eSubSection;});
 
   if (iter == subSectionTable.end())

--- a/src/runtime_src/tools/xclbinutil/SectionSoftKernel.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionSoftKernel.cxx
@@ -81,7 +81,7 @@ SectionSoftKernel::getSubSectionEnum(const std::string& sSubSectionName)
 const std::string&
 SectionSoftKernel::getSubSectionName(SectionSoftKernel::SubSection eSubSection)
 {
-  auto subSectionTable = getSubSectionTable();
+  const auto& subSectionTable = getSubSectionTable();
   auto iter = std::find_if(subSectionTable.begin(), subSectionTable.end(), [&](const auto& entry) {return entry.second == eSubSection;});
 
   if (iter == subSectionTable.end())


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Fix a crash in xclbinUtil
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
When running
xclbinutil --dump-section :json:json.txt --input vadd.xclbin
on windows OS, application crash
#### How problem was solved, alternative solutions (if any) and why they were rejected
The root cause is that a local variable inside a function which will be released when out-of-scope is used as a return value by reference

Signed-off-by: Dezhi Liao [dezhi.liao@amd.com](mailto:dezhi.liao@amd.com)