### PR TITLE
VITIS-9987 xbutil : IPU specific enhancements

### DIFF
--- a/src/runtime_src/core/pcie/linux/system_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/system_linux.cpp
@@ -229,6 +229,23 @@ get_os_info(boost::property_tree::ptree &pt)
       ifs.close();
   }
 
+  // BIOS info
+  std::string bios_vendor("unknown");
+  std::string bios_version("unknown");
+  std::ifstream bios_stream("/sys/class/dmi/id/bios_vendor");
+  if (bios_stream.is_open()) {
+    getline(bios_stream, bios_vendor);
+    pt.put("bios_vendor", bios_vendor);
+    bios_stream.close();
+  }
+
+  std::ifstream ver_stream("/sys/class/dmi/id/bios_version");
+  if (ver_stream.is_open()) {
+    getline(ver_stream, bios_version);
+    pt.put("bios_version", bios_version);
+    ver_stream.close();
+  }
+
   pt.put("model", machine_info());
   pt.put("cores", std::thread::hardware_concurrency());
   pt.put("memory_bytes", (boost::format("0x%lx") % (sysconf(_SC_PHYS_PAGES) * sysconf(_SC_PAGE_SIZE))).str());

--- a/src/runtime_src/core/tools/common/reports/ReportHost.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportHost.cpp
@@ -86,6 +86,8 @@ ReportHost::writeReport(const xrt_core::device* /*_pDevice*/,
           % lib.get<std::string>("version", "N/A");
     }
     _output << boost::format("  %-20s : %s\n") % "Model" % _pt.get<std::string>("host.os.model");
+    _output << boost::format("  %-20s : %s\n") % "BIOS vendor" % _pt.get<std::string>("host.os.bios_vendor");
+    _output << boost::format("  %-20s : %s\n") % "BIOS version" % _pt.get<std::string>("host.os.bios_version");
     _output << std::endl;
     _output << "XRT\n";
     _output << boost::format("  %-20s : %s\n") % "Version" % _pt.get<std::string>("host.xrt.version", "N/A");


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
enhance host report to add BIOS vendor/version

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
N/A

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
```
xbutil examine
System Configuration
  OS Name              : Linux
  Release              : 6.4.0-rc7
  Version              : #2 SMP PREEMPT_DYNAMIC Thu Jun 22 14:12:00 PDT 2023
  Machine              : x86_64
  CPU Cores            : 16
  Memory               : 46830 MB
  Distribution         : Ubuntu 22.04 LTS
  GLIBC                : 2.35
  Model                : Super Server
  BIOS vendor          : American Megatrends Inc.
  BIOS version         : 1.0a

XRT
  Version              : 2.16.0
  Branch               : host-report
  Hash                 : 91d1c9dd34ae48be49a202076cc4658dafb8b015
  Hash Date            : 2023-10-18 16:42:15
  XOCL                 : 2.16.0, 9036de71895c1c2e2184d8ca02a347ff5942bbea
  XCLMGMT              : 2.16.0, 9036de71895c1c2e2184d8ca02a347ff5942bbea

Devices present
BDF             :  Shell                              Logic UUID                            Device ID       Device Ready*  
---------------------------------------------------------------------------------------------------------------------------
[0000:65:00.1]  :  xilinx_vck5000_gen4x8_qdma_base_2  05DCA096-76CB-730B-8D19-EC1192FBAE3F  user(inst=128)  Yes 
```

#### Documentation impact (if any)
N/A