### PR TITLE
Fix for CR-1178694: Kernel Panic - Parallel XRT Kernels Run

### DIFF
--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -1739,7 +1739,7 @@ void
 shim::
 registerAieArray()
 {
-  std::lock_guard<std::mutex> guard(registerAieLock);
+  std::lock_guard guard(registerAieLock);
   delete aieArray.release();
   aieArray = std::make_unique<zynqaie::Aie>(mCoreDevice);
   aied = std::make_unique<zynqaie::Aied>(mCoreDevice.get());

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -1739,6 +1739,7 @@ void
 shim::
 registerAieArray()
 {
+  std::lock_guard<std::mutex> guard(registerAieLock);
   delete aieArray.release();
   aieArray = std::make_unique<zynqaie::Aie>(mCoreDevice);
   aied = std::make_unique<zynqaie::Aied>(mCoreDevice.get());

--- a/src/runtime_src/core/edge/user/shim.h
+++ b/src/runtime_src/core/edge/user/shim.h
@@ -384,6 +384,7 @@ private:
   int xclRegRW(bool rd, uint32_t cu_index, uint32_t offset, uint32_t *datap);
 
 #ifdef XRT_ENABLE_AIE
+  std::mutex registerAieLock;
   std::unique_ptr<zynqaie::Aie> aieArray;
   std::unique_ptr<zynqaie::Aied> aied;
   xrt::aie::access_mode access_mode = xrt::aie::access_mode::none;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1178694
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Partition fd from AIE driver is same in multithread case which leads to kernel crash as a thread tries to close the fd which is already closed by another thread, added lock before registering aie to handle this case.
#### Risks (if any) associated the changes in the commit
Low
#### What has been tested and how, request additional testing if necessary
tested with a multithread application on vck190 
#### Documentation impact (if any)
NA