### PR TITLE
Fix to remove observed execution stall when aie_trace & host_trace is enabled.

### DIFF
--- a/src/runtime_src/xdp/profile/database/dynamic_info/host_db.cpp
+++ b/src/runtime_src/xdp/profile/database/dynamic_info/host_db.cpp
@@ -18,6 +18,7 @@
 
 #include "xdp/profile/database/dynamic_info/host_db.h"
 #include "xdp/profile/database/events/vtf_event.h"
+#include <algorithm>
 
 namespace xdp {
 
@@ -121,17 +122,17 @@ namespace xdp {
 
     std::vector<VTFEvent*> collected;
 
-    for (auto iter = unsortedEvents.begin();
-         iter != unsortedEvents.end();
-         /* Intentionally blank*/) {
-      auto event = *iter;
-      if (filter(event)) {
-        collected.emplace_back(event);
-        iter = unsortedEvents.erase(iter);
-      }
-      else
-        ++iter;
-    }
+    auto newEnd = std::remove_if(unsortedEvents.begin(), unsortedEvents.end(), [&filter, &collected](VTFEvent* event) {
+        if (filter(event)) {
+            collected.push_back(event);
+            return true;  // Mark the event for removal from unsortedEvents vector
+        }
+        return false; // Keep event in the unsortedEvents vector
+    });
+
+    // Resize the UnsortedEvents vector to keep only the remaining unfiltered events
+    unsortedEvents.erase(newEnd, unsortedEvents.end());
+
     return collected;
   }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
[Debug]
  aie_trace=true
  host_trace=true

With the above plugins enabled, the generated native trace (native_trace.csv) is ~17MB. Also the generated events stored in unsortedEvents vector were also in the order of 500K.
Hence, existing filtering algorithm doesn't scale for the large no of events.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Modified the algorithm to move the the event contents of the vector to the end, so that it can be resized later at once. Since this method avoids the individual event erase and shifting the other events post erase; gains the needed performance.

Execution time before the change:
real    3m1.812s
user    2m55.907s
sys     0m3.915s

Execution time after the change:
real    0m13.913s
user    0m9.121s
sys     0m3.783s
#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Verified that behavior is not seen and have passed all the tests.

#### Documentation impact (if any)
