### PR TITLE
VITIS-9943 Improve help menu to use JSON file. Use JSON file to filter

### DIFF
--- a/src/runtime_src/core/tools/common/JSONConfigurable.cpp
+++ b/src/runtime_src/core/tools/common/JSONConfigurable.cpp
@@ -6,37 +6,58 @@
 #include "tools/common/JSONConfigurable.h"
 #include "core/common/error.h"
 
-// Find children corresponding to target(s) and return them in a ptree.
-boost::property_tree::ptree
-JSONConfigurable::parse_configuration(
-  const std::vector<std::string>& targets,
+#include <iostream>
+#include <set>
+
+const std::map<std::string, std::string>
+JSONConfigurable::device_type_map = {
+  {"aie", "AIE"},
+  {"alveo", "Alveo"},
+  {"common", "common"}
+};
+
+// Parse configuration for children corresponding to current device categories before parsing for target(s).
+std::map<std::string, boost::property_tree::ptree>
+JSONConfigurable::parse_configuration_tree(
   const boost::property_tree::ptree& configuration)
 {
-  boost::property_tree::ptree output;
-  try {
-    for (const std::string& target: targets) {
-      for (const auto& configTree : configuration) {
-        for (const auto& config : configTree.second.get_child("contents")) {
-          const auto& pt = config.second;
-          if (boost::iequals(target, pt.get<std::string>("name")))
-            output.push_back({ configTree.second.get<std::string>("name"), pt });
+  std::map<std::string, boost::property_tree::ptree> target_mappings;
+  // ptree parsing requires two for loops when iterating through an array
+  // One to access the current element. A second to access the data within said element.
+  for (const auto& device_config_tree : configuration) {
+    for (const auto& [device_name, device_config] : device_config_tree.second) {
+      for (const auto& command_config_tree : device_config) {
+        for (const auto& [command_name, command_config] : command_config_tree.second) {
+          target_mappings[command_name].push_back({device_name, command_config});
         }
       }
     }
-  } catch (const std::exception& e) {
-    throw std::runtime_error(e.what());
   }
-  return output;
+
+  return target_mappings;
 }
 
-// Parse configuration for children corresponding to current device categories before parsing for target(s).
-boost::property_tree::ptree
-JSONConfigurable::parse_configuration_tree(
-  const std::vector<std::string>& targets,
-  const boost::property_tree::ptree& configuration)
+std::set<std::shared_ptr<JSONConfigurable>>
+JSONConfigurable::extract_common_options(std::map<std::string, std::vector<std::shared_ptr<JSONConfigurable>>> device_options)
 {
-  // currentDeviceCategories must be updated to use a query for device categories of cards present.
-  const std::vector<std::string> currentDeviceCategories = {"common", "alveo", "aie"};
-  auto cmdTrees = parse_configuration(currentDeviceCategories, configuration);
-  return parse_configuration(targets, cmdTrees);
+  std::set<std::shared_ptr<JSONConfigurable>> common_options;
+  std::map<std::shared_ptr<JSONConfigurable>, int> config_map;
+  int deviceClassCount = 0;
+  for (const auto& options_pair : device_options) {
+    for (const auto& option : options_pair.second) {
+      const auto it = config_map.find(option);
+      if (it == config_map.end())
+        config_map.emplace(option, 1);
+      else
+        it->second++;
+    }
+    deviceClassCount++;
+  }
+
+  for (const auto& config_pair : config_map) {
+    if (config_pair.second == deviceClassCount)
+      common_options.emplace(config_pair.first);
+  }
+
+  return common_options;
 }

--- a/src/runtime_src/core/tools/common/JSONConfigurable.h
+++ b/src/runtime_src/core/tools/common/JSONConfigurable.h
@@ -1,62 +1,98 @@
-/**
- * Copyright (C) 2023 Advanced Micro Devices, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
 
 #ifndef __JSONConfigurable_h_
 #define __JSONConfigurable_h_
+
+#include "XBUtilitiesCore.h"
 
 #include <boost/algorithm/string.hpp>
 #include <boost/program_options.hpp>
 #include <boost/property_tree/ptree.hpp>
 
+/**
+ * The JSONConfigurable class serves as the base class of all items
+ * that are represented via the device class option JSON file. It allows
+ * for centralized interpretation of the input JSON files and encourages
+ * derived classes to use this class for option display.
+ */
 class JSONConfigurable {
+
 private:
-  static boost::property_tree::ptree
-  parse_configuration( const std::vector<std::string>& targets,
-                       const boost::property_tree::ptree& configuration);
+  static std::map<std::string, boost::property_tree::ptree>
+  extract_device_configs(const boost::property_tree::ptree& config,
+                         const std::string& target)
+  {
+    std::map<std::string, boost::property_tree::ptree> output;
+
+    for (const auto& device_config : config) {
+      for (auto& option_data_tree : device_config.second) {
+        for (const auto& option_data : option_data_tree.second) {
+          if (!boost::iequals(option_data.first, target))
+            continue;
+
+          output[device_config.first] = option_data.second;
+        }
+      }
+    }
+
+    return output;
+  }
+
+  template <class OutputType, class InputType, class = std::enable_if_t<std::is_base_of_v<JSONConfigurable, InputType>>>
+  static std::map<std::string, std::vector<std::shared_ptr<OutputType>>>
+  convert_device_configs(const std::map<std::string, boost::property_tree::ptree>& config,
+                         const std::vector<std::shared_ptr<InputType>>& items)
+  {
+    std::map<std::string, std::vector<std::shared_ptr<OutputType>>> output;
+
+    for (const auto& targetPair : config) {
+      std::vector<std::shared_ptr<OutputType>> matches;
+      for (const auto& option : targetPair.second) {
+        for (const auto& item : items) {
+          if (!boost::iequals(option.second.get_value<std::string>(), item->getConfigName()))
+            continue;
+
+          matches.push_back(item);
+          break;
+        }
+      }
+      output[targetPair.first] = matches;
+    }
+
+    return output;
+  }
 
 public:
   JSONConfigurable() {};
 
   virtual const std::string& getConfigName() const = 0;
+  virtual const std::string& getConfigDescription() const = 0;
+  virtual bool getConfigHidden() const = 0;
+
+  static const std::map<std::string, std::string> device_type_map;
+
+  static std::map<std::string, boost::property_tree::ptree>
+  parse_configuration_tree(const boost::property_tree::ptree& configuration);
+
+  static std::set<std::shared_ptr<JSONConfigurable>>
+  extract_common_options(std::map<std::string, std::vector<std::shared_ptr<JSONConfigurable>>> device_options);
 
   // Parses configuration ptree and returns a map of deviceCategory to items that are in the configuration ptree.
-  template <class T, class = std::enable_if_t<std::is_base_of_v<JSONConfigurable, T>>>
-  static std::map<std::string, std::vector<std::shared_ptr<T>>>
-  extractMatchingConfigurations(const std::vector<std::shared_ptr<T>>& items, const boost::property_tree::ptree& configuration)
+  template <class OutputType, class InputType, class = std::enable_if_t<std::is_base_of_v<JSONConfigurable, InputType>>>
+  static std::map<std::string, std::vector<std::shared_ptr<OutputType>>>
+  extract_subcmd_config(const std::vector<std::shared_ptr<InputType>>& items,
+                        const std::map<std::string, boost::property_tree::ptree>& configuration,
+                        const std::string& subcommand,
+                        const std::string& target)
   {
-    std::map<std::string, std::vector<std::shared_ptr<T>>> output;
-    for (const auto& relevantItem : configuration) {
-      std::vector<std::shared_ptr<T>> matches;
-      for (const auto& contentTree : relevantItem.second.get_child("contents")) {
-        for (const auto& item : items) {
-          if (boost::iequals(contentTree.second.get_value<std::string>(), item->getConfigName())) {
-            matches.push_back(item);
-            break;
-          }
-        }
-      }
-      output.insert(std::make_pair(relevantItem.first, matches));
-    }
+    auto it = configuration.find(subcommand);
+    if (it == configuration.end())
+      return {};
 
-    return output;
+    const auto device_configs = extract_device_configs(it->second, target);
+    return convert_device_configs<OutputType, InputType>(device_configs, items);
   };
-
-  static boost::property_tree::ptree
-  parse_configuration_tree( const std::vector<std::string>& targets,
-                            const boost::property_tree::ptree& configuration);
 };
 
 #endif

--- a/src/runtime_src/core/tools/common/OptionOptions.h
+++ b/src/runtime_src/core/tools/common/OptionOptions.h
@@ -1,19 +1,6 @@
-/**
- * Copyright (C) 2020-2022 Xilinx, Inc
- * Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2020-2022 Xilinx, Inc
+// Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
 
 #ifndef __OptionOptions_h_
 #define __OptionOptions_h_
@@ -44,8 +31,10 @@ class OptionOptions : public JSONConfigurable {
   const std::string &getConfigName() const { return longName(); };
   const std::string optionNameString() const { return m_shortName.empty() ? m_longName : m_longName + "," + m_shortName; };
   const std::string &description() const {return m_description; };
+  const std::string &getConfigDescription() const { return description(); };
   const std::string &extendedHelp() const { return m_extendedHelp; };
   bool isHidden() const { return m_isHidden; };
+  bool getConfigHidden() const {return isHidden();};
 
   void setExecutable( const std::string &_executable) {m_executable = _executable; };
   void setCommand( const std::string & _command) {m_command = _command; };

--- a/src/runtime_src/core/tools/common/Report.h
+++ b/src/runtime_src/core/tools/common/Report.h
@@ -1,18 +1,6 @@
-/**
- * Copyright (C) 2020-2022 Xilinx, Inc
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2020-2022 Xilinx, Inc
+// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
 
 #ifndef __Report_h_
 #define __Report_h_
@@ -57,8 +45,10 @@ class Report : public JSONConfigurable {
   const std::string & getReportName() const { return m_reportName; };
   const std::string & getConfigName() const { return getReportName(); };
   const std::string & getShortDescription() const { return m_shortDescription; };
+  const std::string &getConfigDescription() const { return getShortDescription(); };
   bool isDeviceRequired() const { return m_isDeviceRequired; };
   bool isHidden() const { return m_isHidden; };
+  bool getConfigHidden() const {return isHidden();};
 
   void getFormattedReport(const xrt_core::device *_pDevice, SchemaVersion _schemaVersion, const std::vector<std::string> & _elementFilter, std::ostream & consoleStream, boost::property_tree::ptree & pt) const;
 

--- a/src/runtime_src/core/tools/common/SubCmdConfigureInternal.h
+++ b/src/runtime_src/core/tools/common/SubCmdConfigureInternal.h
@@ -13,7 +13,7 @@ class SubCmdConfigureInternal : public SubCmd {
   virtual void execute(const SubCmdOptions &_options) const;
 
  public:
-  SubCmdConfigureInternal(bool _isHidden, bool _isDepricated, bool _isPreliminary, bool _isUserDomain, const boost::property_tree::ptree configurations);
+  SubCmdConfigureInternal(bool _isHidden, bool _isDepricated, bool _isPreliminary, bool _isUserDomain, const boost::property_tree::ptree& configurations);
 
  public:
   static std::vector<std::shared_ptr<OptionOptions>> optionOptionsCollection;

--- a/src/runtime_src/core/tools/common/SubCmdExamineInternal.cpp
+++ b/src/runtime_src/core/tools/common/SubCmdExamineInternal.cpp
@@ -27,23 +27,12 @@ namespace po = boost::program_options;
 #include <regex>
 
 static ReportCollection fullReportCollection = {};
-static std::map<std::string, std::vector<std::shared_ptr<Report>>> reportMappings;
-
-void
-SubCmdExamineInternal::create_common_options(boost::program_options::options_description& options, const std::string& report_string)
-{
-  static const std::string formatOptionValues = XBU::create_suboption_list_string(Report::getSchemaDescriptionVector());
-  options.add_options()
-    ("device,d", boost::program_options::value<decltype(m_device)>(&m_device), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest")
-    ("report,r", boost::program_options::value<decltype(m_reportNames)>(&m_reportNames)->multitoken(), (std::string("The type of report to be produced. Reports currently available are:\n") + report_string).c_str() )
-    ("format,f", boost::program_options::value<decltype(m_format)>(&m_format), (std::string("Report output format. Valid values are:\n") + formatOptionValues).c_str() )
-    ("output,o", boost::program_options::value<decltype(m_output)>(&m_output), "Direct the output to the given file")
-    ("help", boost::program_options::bool_switch(&m_help), "Help to use this sub-command")
-  ;
-}
+static boost::program_options::options_description common_options;
+static std::map<std::string,std::vector<std::shared_ptr<JSONConfigurable>>> jsonOptions;
+static XBUtilities::VectorPairStrings common_reports;
 
 // ----- C L A S S   M E T H O D S -------------------------------------------
-SubCmdExamineInternal::SubCmdExamineInternal(bool _isHidden, bool _isDepricated, bool _isPreliminary, bool _isUserDomain, const boost::property_tree::ptree configurations)
+SubCmdExamineInternal::SubCmdExamineInternal(bool _isHidden, bool _isDepricated, bool _isPreliminary, bool _isUserDomain, const boost::property_tree::ptree& configurations)
     : SubCmd("examine", 
              _isUserDomain ? "Status of the system and device" : "Returns detail information for the specified device.")
     , m_device("")
@@ -54,6 +43,7 @@ SubCmdExamineInternal::SubCmdExamineInternal(bool _isHidden, bool _isDepricated,
     , m_help(false)
     , m_isUserDomain(_isUserDomain)
 {
+
   const std::string longDescription = "This command will 'examine' the state of the system/device and will"
                                       " generate a report of interest in a text or JSON format.";
   setLongDescription(longDescription);
@@ -64,40 +54,49 @@ SubCmdExamineInternal::SubCmdExamineInternal(bool _isHidden, bool _isDepricated,
   if (m_isUserDomain)
     setIsDefaultDevValid(false);
 
-  // -- Build up the report & format options
-  auto examineDeviceTrees = JSONConfigurable::parse_configuration_tree({getConfigName()}, configurations);
-  reportMappings = JSONConfigurable::extractMatchingConfigurations<Report>(SubCmdExamineInternal::uniqueReportCollection, examineDeviceTrees);
+  m_commandConfig = configurations;
 
-  // Create device specific help menu options
-  for (const auto& report_pair : reportMappings) {
-    // Generate a list of common and relevant mappings for help menu generation
-    ReportCollection reportCollection = report_pair.second;
-    for (const auto& report : reportMappings["common"])
-      reportCollection.push_back(report);
+  for (const auto& option : uniqueReportCollection)
+    fullReportCollection.push_back(option);
 
-    boost::program_options::options_description options;
-    create_common_options(options, XBU::create_suboption_list_string(reportCollection, true));
-    m_deviceSpecificOptions.emplace(report_pair.first, options);
+  const auto& configs = JSONConfigurable::parse_configuration_tree(configurations);
+  jsonOptions = JSONConfigurable::extract_subcmd_config<JSONConfigurable, Report>(fullReportCollection, configs, getConfigName(), std::string("report"));
 
-    // Generate complete list of all possible reports
-    for (const auto& report : report_pair.second) {
-      fullReportCollection.push_back(report);
-    }
-  }
+  common_reports.emplace_back("all", "All known reports are produced");
+  static const std::string reportOptionValues = XBU::create_suboption_list_map("", jsonOptions, common_reports);
+  static const std::string formatOptionValues = XBU::create_suboption_list_string(Report::getSchemaDescriptionVector());
+  common_options.add_options()
+    ("device,d", boost::program_options::value<decltype(m_device)>(&m_device), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest")
+    ("format,f", boost::program_options::value<decltype(m_format)>(&m_format), (std::string("Report output format. Valid values are:\n") + formatOptionValues).c_str() )
+    ("output,o", boost::program_options::value<decltype(m_output)>(&m_output), "Direct the output to the given file")
+    ("help", boost::program_options::bool_switch(&m_help), "Help to use this sub-command")
+  ;
 
-  // Emplace temporary all option until shim upgrade is complete
-  boost::program_options::options_description options;
-  create_common_options(options, XBU::create_suboption_list_string(fullReportCollection, true));
-  m_deviceSpecificOptions.emplace("all", options);
-
-  // Generate the help menu option when a device is not specified
-  static const std::string reportOptionValues = XBU::create_suboption_list_map(reportMappings);
-  create_common_options(m_commonOptions, reportOptionValues);
+  m_commonOptions.add(common_options);
+  m_commonOptions.add_options()
+    ("report,r", boost::program_options::value<decltype(m_reportNames)>(&m_reportNames)->multitoken(), (std::string("The type of report to be produced. Reports currently available are:\n") + reportOptionValues).c_str() )
+  ;
   
   if (m_isUserDomain)
     m_hiddenOptions.add_options()
       ("element,e", boost::program_options::value<decltype(m_elementsFilter)>(&m_elementsFilter)->multitoken(), "Filters individual elements(s) from the report. Format: '/<key>/<key>/...'")
     ;
+}
+
+void
+SubCmdExamineInternal::print_help_internal() const
+{
+  if (m_device.empty())
+    printHelp();
+  else {
+    const std::string deviceClass = XBU::get_device_class(m_device, m_isUserDomain);
+    static const std::string reportOptionValues = XBU::create_suboption_list_map(deviceClass, jsonOptions, common_reports);
+    std::vector<std::string> tempVec;
+    common_options.add_options()
+      ("report,r", boost::program_options::value<decltype(tempVec)>(&tempVec)->multitoken(), (std::string("The type of report to be produced. Reports currently available are:\n") + reportOptionValues).c_str() )
+    ;
+    printHelp(common_options, m_hiddenOptions, deviceClass);
+  }
 }
 
 void
@@ -111,7 +110,7 @@ SubCmdExamineInternal::execute(const SubCmdOptions& _options) const
 
   // Check to see if help was requested
   if (m_help) {
-    printHelp(m_device, m_isUserDomain);
+    print_help_internal();
     return;
   }
   
@@ -141,7 +140,7 @@ SubCmdExamineInternal::execute(const SubCmdOptions& _options) const
   if (schemaVersion == Report::SchemaVersion::unknown) {
     std::cerr << boost::format("ERROR: Unsupported --format option value '%s'") % validated_format << std::endl
               << boost::format("       Supported values can be found in --format's help section below.") << std::endl;
-    printHelp(m_device, m_isUserDomain);
+    print_help_internal();
     throw xrt_core::error(std::errc::operation_canceled);
   }
 
@@ -154,8 +153,12 @@ SubCmdExamineInternal::execute(const SubCmdOptions& _options) const
   // -- Process the options --------------------------------------------
   ReportCollection reportsToProcess;            // Reports of interest
 
+  // Filter out reports that are not compatible for the device
+  const std::string deviceClass = XBU::get_device_class(m_device, m_isUserDomain);
+  ReportCollection runnableReports = validateConfigurables<Report>(deviceClass, std::string("report"), fullReportCollection);
+
   // Collect the reports to be processed
-  XBU::collect_and_validate_reports(fullReportCollection, reportsToRun, reportsToProcess);
+  XBU::collect_and_validate_reports(runnableReports, reportsToRun, reportsToProcess);
 
   // Find device of interest
   std::shared_ptr<xrt_core::device> device;

--- a/src/runtime_src/core/tools/common/SubCmdExamineInternal.h
+++ b/src/runtime_src/core/tools/common/SubCmdExamineInternal.h
@@ -1,18 +1,5 @@
-/**
- * Copyright (C) 2023 Advanced Micro Devices, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
 
 #ifndef __SubCmdExamineInternal_h_
 #define __SubCmdExamineInternal_h_
@@ -25,13 +12,13 @@ class SubCmdExamineInternal : public SubCmd {
   virtual void execute(const SubCmdOptions &_options) const;
 
  public:
-  SubCmdExamineInternal(bool _isHidden, bool _isDepricated, bool _isPreliminary, bool _isUserDomain, const boost::property_tree::ptree configurations);
+  SubCmdExamineInternal(bool _isHidden, bool _isDepricated, bool _isPreliminary, bool _isUserDomain, const boost::property_tree::ptree& configurations);
 
  public:
   static ReportCollection uniqueReportCollection;
 
  private:
-  void create_common_options(boost::program_options::options_description& options, const std::string& report_string);
+  void print_help_internal() const;
 
   std::string               m_device;
   std::vector<std::string>  m_reportNames;

--- a/src/runtime_src/core/tools/common/TestRunner.h
+++ b/src/runtime_src/core/tools/common/TestRunner.h
@@ -1,18 +1,5 @@
-/**
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
 
 #ifndef __TestRunner_h_
 #define __TestRunner_h_
@@ -27,15 +14,17 @@
 // System - Include Files
 #include <string>
 
-class TestRunner {
+class TestRunner : public JSONConfigurable {
   public:
     virtual boost::property_tree::ptree run(std::shared_ptr<xrt_core::device> dev) = 0;
     virtual void set_param(const std::string key, const std::string value){}
-    bool is_explicit() { return m_explicit; };
+    bool is_explicit() const { return m_explicit; };
+    virtual bool getConfigHidden() const { return is_explicit(); };
     const void set_xclbin_path(std::string path) { m_xclbin = path; };
     const std::string & get_name() const { return m_name; };
-    boost::property_tree::ptree get_test_header();
     const std::string & getConfigName() const { return get_name(); };
+    virtual const std::string& getConfigDescription() const { return m_description; };
+    boost::property_tree::ptree get_test_header();
     std::string findXclbinPath( const std::shared_ptr<xrt_core::device>& _dev,
                       boost::property_tree::ptree& _ptTest);
 

--- a/src/runtime_src/core/tools/common/XBHelpMenus.h
+++ b/src/runtime_src/core/tools/common/XBHelpMenus.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2020-2022 Xilinx, Inc
-// Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
 
 #ifndef __XBHelpMenus_h_
 #define __XBHelpMenus_h_
@@ -18,24 +18,20 @@ namespace XBUtilities {
 
   using VectorPairStrings = std::vector< std::pair< std::string, std::string > >;
 
-  std::string 
-    create_suboption_list_map(const std::map<std::string, std::vector<std::shared_ptr<Report>>>& reportCollection);
+  std::string
+    create_suboption_list_map(const std::string& deviceClass,
+                              const std::map<std::string, std::vector<std::shared_ptr<JSONConfigurable>>>& device_options,
+                              const VectorPairStrings& common_options);
 
-  std::string 
-    create_suboption_list_string(const VectorPairStrings &_collection);
-
-  std::string 
-    create_suboption_list_string(const ReportCollection &_reportCollection, bool _addAllOption);
-
-  std::string 
+  std::string
     create_suboption_list_string(const Report::SchemaDescriptionVector &_formatCollection);
 
-  void 
+  void
     collect_and_validate_reports( const ReportCollection & allReportsAvailable,
                                   const std::vector<std::string> &reportNamesToAdd,
                                   ReportCollection & reportsToUse);
 
-  void 
+  void
      produce_reports( const std::shared_ptr<xrt_core::device>& device, 
                       const ReportCollection & reportsToProcess, 
                       const Report::SchemaVersion schema, 

--- a/src/runtime_src/core/tools/common/XBHelpMenusCore.h
+++ b/src/runtime_src/core/tools/common/XBHelpMenusCore.h
@@ -1,19 +1,6 @@
-/**
- * Copyright (C) 2020-2022 Xilinx, Inc
- * Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2020-2022 Xilinx, Inc
+// Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
 
 #ifndef __XBHelpMenusCore_h_
 #define __XBHelpMenusCore_h_
@@ -50,16 +37,22 @@ namespace XBUtilities {
                             boost::program_options::positional_options_description(),
                           const SubCmd::SubOptionOptions& _subOptionOptions = SubCmd::SubOptionOptions(),
                           bool removeLongOptDashes = false,
-                          const std::string& customHelpSection = "");
+                          const std::string& customHelpSection = "",
+                          const std::map<std::string, std::vector<std::shared_ptr<JSONConfigurable>>>& commandConfig =
+                            std::map<std::string, std::vector<std::shared_ptr<JSONConfigurable>>>(),
+                          const std::string& deviceClass = "");
 
-  void 
+  void
     report_option_help( const std::string & _groupName, 
                         const boost::program_options::options_description& _optionDescription,
                         const boost::program_options::positional_options_description & _positionalDescription,
-                        bool _bReportParameter = true,
-                        bool removeLongOptDashes = false);
+                        const bool _bReportParameter = true,
+                        const bool removeLongOptDashes = false,
+                        const std::map<std::string, std::vector<std::shared_ptr<JSONConfigurable>>>& device_options =
+                          std::map<std::string, std::vector<std::shared_ptr<JSONConfigurable>>>(),
+                        const std::string& deviceClass = "");
 
-  std::string 
+  std::string
     create_usage_string( const boost::program_options::options_description &_od,
                          const boost::program_options::positional_options_description & _pod,
                          bool removeLongOptDashes = false);

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2019-2022 Xilinx, Inc
-// Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
 
 // ------ I N C L U D E   F I L E S -------------------------------------------
 #include "XBUtilities.h"
@@ -406,6 +406,30 @@ XBUtilities::collect_devices( const std::set<std::string> &_deviceBDFs,
 
     return device;
   }
+
+// TODO this is a temporary function that will be replaced
+// by something in the shim or device layer.
+static std::string
+tempDeviceMapping(const std::string& deviceName)
+{
+  if (deviceName.empty())
+    return "";
+
+  if (deviceName.find("IPU") != std::string::npos)
+    return "aie";
+
+  return "alveo";
+}
+
+std::string
+XBUtilities::get_device_class(const std::string &deviceBDF, bool in_user_domain)
+{
+  if (deviceBDF.empty()) 
+    return tempDeviceMapping("");
+
+  std::shared_ptr<xrt_core::device> device = get_device(boost::algorithm::to_lower_copy(deviceBDF), in_user_domain);
+  return tempDeviceMapping(xrt_core::device_query_default<xrt_core::query::rom_vbnv>(device, ""));
+}
 
 void
 XBUtilities::can_proceed_or_throw(const std::string& info, const std::string& error)

--- a/src/runtime_src/core/tools/common/XBUtilities.h
+++ b/src/runtime_src/core/tools/common/XBUtilities.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2019-2022 Xilinx, Inc
-// Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
 
 #ifndef __XBUtilities_h_
 #define __XBUtilities_h_
@@ -53,8 +53,9 @@ namespace XBUtilities {
                         bool _inUserDomain,
                         xrt_core::device_collection &_deviceCollection);
 
-  std::shared_ptr<xrt_core::device> get_device ( const std::string &deviceBDF,
-                                                 bool in_user_domain);
+  std::shared_ptr<xrt_core::device> get_device (const std::string& deviceBDF, bool in_user_domain);
+
+  std::string get_device_class(const std::string& deviceBDF, bool in_user_domain);
 
   boost::property_tree::ptree
   get_available_devices(bool inUserDomain);

--- a/src/runtime_src/core/tools/xbflash2/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbflash2/CMakeLists.txt
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (C) 2022 Xilinx, Inc. All rights reserved.
+# Copyright (C) 2022-2023 Xilinx, Inc. All rights reserved.
 #
 
 find_package(Boost
@@ -16,6 +16,7 @@ file(GLOB XBFLASH_BASE_FILES
   "../common/SubCmd.cpp"
   "../common/OptionOptions.cpp"
   "../common/XBHelpMenusCore.cpp"
+  "../common/JSONConfigurable.cpp"
   "../../pcie/tools/xbflash.qspi/firmware_image.cpp"
   "../../pcie/tools/xbflash.qspi/pcidev.cpp"
   "../../pcie/tools/xbflash.qspi/xqspips.cpp"

--- a/src/runtime_src/core/tools/xbflash2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbflash2/SubCmdProgram.cpp
@@ -1,18 +1,6 @@
-/**
- * Copyright (C) 2022 Xilinx, Inc
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2022 Xilinx, Inc
+// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
 
 // ------ I N C L U D E   F I L E S -------------------------------------------
 // Local - Include Files

--- a/src/runtime_src/core/tools/xbflash2/SubCmdProgram.h
+++ b/src/runtime_src/core/tools/xbflash2/SubCmdProgram.h
@@ -1,18 +1,6 @@
-/**
- * Copyright (C) 2022 Xilinx, Inc
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2022 Xilinx, Inc
+// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
 
 #ifndef __SubCmdProgram_h_
 #define __SubCmdProgram_h_
@@ -29,6 +17,7 @@ class SubCmdProgram : public SubCmd {
 
  private:
   bool m_help;
+  std::string m_device;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdAdvanced.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdAdvanced.cpp
@@ -1,19 +1,6 @@
-/**
- * Copyright (C) 2021-2022 Xilinx, Inc
- * Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2021-2022 Xilinx, Inc
+// Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
 
 // ------ I N C L U D E   F I L E S -------------------------------------------
 // Local - Include Files
@@ -42,7 +29,7 @@ namespace po = boost::program_options;
 
 // ----- C L A S S   M E T H O D S -------------------------------------------
 
-SubCmdAdvanced::SubCmdAdvanced(bool _isHidden, bool _isDepricated, bool _isPreliminary)
+SubCmdAdvanced::SubCmdAdvanced(bool _isHidden, bool _isDepricated, bool _isPreliminary, const boost::property_tree::ptree& configurations)
     : SubCmd("advanced", 
              "Low level command operations")
     , m_help(false)
@@ -55,8 +42,11 @@ SubCmdAdvanced::SubCmdAdvanced(bool _isHidden, bool _isDepricated, bool _isPreli
   setIsPreliminary(_isPreliminary);
 
   m_commonOptions.add_options()
+    ("device,d", boost::program_options::value<decltype(m_device)>(&m_device), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest")
     ("help", boost::program_options::bool_switch(&m_help), "Help to use this sub-command")
   ;
+
+  m_commandConfig = configurations;
 
   addSubOption(std::make_shared<OO_Hotplug>("hotplug"));
 }
@@ -79,7 +69,7 @@ SubCmdAdvanced::execute(const SubCmdOptions& _options) const
 
   // No suboption print help
   if (!optionOption) {
-    printHelp();
+    printHelp(false, "", XBU::get_device_class(m_device, true));
     return;
   }
 

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdAdvanced.h
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdAdvanced.h
@@ -1,18 +1,6 @@
-/**
- * Copyright (C) 2020 Xilinx, Inc
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2020 Xilinx, Inc
+// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
 
 #ifndef __SubCmdAdvanced_h_
 #define __SubCmdAdvanced_h_
@@ -24,11 +12,12 @@ class SubCmdAdvanced : public SubCmd {
   virtual void execute(const SubCmdOptions &_options) const;
 
  public:
-  SubCmdAdvanced(bool _isHidden, bool _isDepricated, bool _isPreliminary);
+  SubCmdAdvanced(bool _isHidden, bool _isDepricated, bool _isPreliminary, const boost::property_tree::ptree& configurations);
   virtual ~SubCmdAdvanced() {};
 
   private:
     bool m_help;
+    std::string m_device;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdConfigure.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdConfigure.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2022 Xilinx, Inc
-// Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
 
 // ------ I N C L U D E   F I L E S -------------------------------------------
 // Local - Include Files
@@ -15,7 +15,7 @@ std::vector<std::shared_ptr<OptionOptions>> SubCmdConfigureInternal::optionOptio
   std::make_shared<OO_Retention>("retention"),
 };
 
-SubCmdConfigure::SubCmdConfigure(bool _isHidden, bool _isDepricated, bool _isPreliminary, const boost::property_tree::ptree configurations)
+SubCmdConfigure::SubCmdConfigure(bool _isHidden, bool _isDepricated, bool _isPreliminary, const boost::property_tree::ptree& configurations)
     : SubCmdConfigureInternal(_isHidden, _isDepricated, _isPreliminary, false /*Not isUserDomain*/, configurations)
 {
   // Empty

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdConfigure.h
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdConfigure.h
@@ -1,18 +1,6 @@
-/**
- * Copyright (C) 2022 Xilinx, Inc
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2022 Xilinx, Inc
+// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
 
 #ifndef __SubCmdConfigure_h_
 #define __SubCmdConfigure_h_
@@ -22,7 +10,7 @@
 
 class SubCmdConfigure : public SubCmdConfigureInternal {
  public:
-  SubCmdConfigure(bool _isHidden, bool _isDepricated, bool _isPreliminary, const boost::property_tree::ptree configurations);
+  SubCmdConfigure(bool _isHidden, bool _isDepricated, bool _isPreliminary, const boost::property_tree::ptree& configurations);
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdExamine.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdExamine.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2020-2022 Xilinx, Inc
-// Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
 
 // ------ I N C L U D E   F I L E S -------------------------------------------
 // Local - Include Files
@@ -33,7 +33,7 @@ ReportCollection SubCmdExamineInternal::uniqueReportCollection = {
   #endif
 };
 
-SubCmdExamine::SubCmdExamine(bool _isHidden, bool _isDepricated, bool _isPreliminary, const boost::property_tree::ptree configurations)
+SubCmdExamine::SubCmdExamine(bool _isHidden, bool _isDepricated, bool _isPreliminary, const boost::property_tree::ptree& configurations)
     : SubCmdExamineInternal(_isHidden, _isDepricated, _isPreliminary, false /*Not isUserDomain*/, configurations)
     , m_device("")
     , m_reportNames()

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdExamine.h
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdExamine.h
@@ -1,18 +1,6 @@
-/**
- * Copyright (C) 2020 Xilinx, Inc
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2020 Xilinx, Inc
+// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
 
 #ifndef __SubCmdExamine_h_
 #define __SubCmdExamine_h_
@@ -23,7 +11,7 @@
 
 class SubCmdExamine : public SubCmdExamineInternal {
  public:
-  SubCmdExamine(bool _isHidden, bool _isDepricated, bool _isPreliminary, const boost::property_tree::ptree configurations);
+  SubCmdExamine(bool _isHidden, bool _isDepricated, bool _isPreliminary, const boost::property_tree::ptree& configurations);
 
  private:
   std::string               m_device;

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -13,6 +13,7 @@
 #include "OO_UpdateXclbin.h"
 
 #include "core/common/error.h"
+#include "tools/common/XBUtilities.h"
 #include "tools/common/XBUtilitiesCore.h"
 
 // 3rd Party Library - Include Files
@@ -22,7 +23,7 @@
 #pragma warning(disable : 4996) //std::asctime
 #endif
 
-SubCmdProgram::SubCmdProgram(bool _isHidden, bool _isDepricated, bool _isPreliminary)
+SubCmdProgram::SubCmdProgram(bool _isHidden, bool _isDepricated, bool _isPreliminary, const boost::property_tree::ptree& configurations)
     : SubCmd("program",
              "Update image(s) for a given device")
     , m_device("")
@@ -40,6 +41,8 @@ SubCmdProgram::SubCmdProgram(bool _isHidden, bool _isDepricated, bool _isPrelimi
     ("device,d", boost::program_options::value<decltype(m_device)>(&m_device), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest.")
     ("help", boost::program_options::bool_switch(&m_help), "Help to use this sub-command")
   ;
+
+  m_commandConfig = configurations;
 
   addSubOption(std::make_shared<OO_UpdateBase>("base", "b"));
   addSubOption(std::make_shared<OO_UpdateShell>("shell", "s"));
@@ -74,11 +77,11 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
 
   // Check to see if help was requested or no command was found
   if (m_help) {
-    printHelp();
+    printHelp(false, "", XBUtilities::get_device_class(m_device, true));
     return;
   }
 
   std::cout << "\nERROR: Missing flash operation.  No action taken.\n\n";
-  printHelp();
+  printHelp(false, "", XBUtilities::get_device_class(m_device, true));
   throw xrt_core::error(std::errc::operation_canceled);
 }

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.h
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.h
@@ -12,7 +12,7 @@ class SubCmdProgram : public SubCmd {
   virtual void execute(const SubCmdOptions &_options) const;
 
  public:
-  SubCmdProgram(bool _isHidden, bool _isDepricated, bool _isPreliminary);
+  SubCmdProgram(bool _isHidden, bool _isDepricated, bool _isPreliminary, const boost::property_tree::ptree& configurations);
 
  private:
   std::string               m_device;

--- a/src/runtime_src/core/tools/xbmgmt2/xbmgmt.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/xbmgmt.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2019-2022 Xilinx, Inc
-// Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
 
 // Sub Commands
 #include "SubCmdAdvanced.h"
@@ -29,17 +29,33 @@
 const std::string& command_config = 
 R"(
 [{
-    "name": "cmd_configs",
-    "contents": [{
-        "name": "common",
-        "contents": [{
-            "name": "examine",
-            "contents": ["cmc", "firewall", "host", "mailbox", "mechanical", "platform", "vmr"]
-        },{
-            "name": "configure",
-            "contents": ["input", "retention"]
-        }]
+  "alveo": [{
+    "examine": [{
+      "report": ["cmc", "firewall", "host", "mailbox", "mechanical", "platform", "vmr"]
     }]
+  },{
+    "configure": [{
+      "suboption": ["input", "retention"]
+    }]
+  },{
+    "advanced":[{
+      "suboption": ["hotplug"]
+    }]
+  },{
+    "program":[{
+      "suboption": ["base", "shell", "revert-to-golden", "user", "boot"]
+    }]
+  }]
+},{
+  "aie": [{
+    "examine": [{
+      "report": ["cmc", "firewall", "host", "mailbox", "mechanical", "platform", "vmr"]
+    }]
+  },{
+    "program":[{
+      "suboption": ["user"]
+    }]
+  }]
 }]
 )";
 
@@ -55,9 +71,9 @@ int main( int argc, char** argv )
 
   {
     // Syntax: SubCmdClass( IsHidden, IsDepricated, IsPreliminary)
-    subCommands.emplace_back(std::make_shared<   SubCmdProgram  >(false, false, false));
+    subCommands.emplace_back(std::make_shared<   SubCmdProgram  >(false, false, false, configTree));
     subCommands.emplace_back(std::make_shared<     SubCmdReset  >(false, false, false));
-    subCommands.emplace_back(std::make_shared<  SubCmdAdvanced  >(false, false,  true));
+    subCommands.emplace_back(std::make_shared<  SubCmdAdvanced  >(false, false,  true, configTree));
     subCommands.emplace_back(std::make_shared<   SubCmdExamine  >(false, false, false, configTree));
     subCommands.emplace_back(std::make_shared<      SubCmdDump  >(false, false, false));
     subCommands.emplace_back(std::make_shared< SubCmdConfigure  >(false, false, false, configTree));

--- a/src/runtime_src/core/tools/xbutil2/SubCmdAdvanced.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdAdvanced.cpp
@@ -1,19 +1,6 @@
-/**
- * Copyright (C) 2020-2022 Xilinx, Inc
- * Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2020-2022 Xilinx, Inc
+// Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
 
 // ------ I N C L U D E   F I L E S -------------------------------------------
 // Local - Include Files
@@ -46,7 +33,7 @@ namespace po = boost::program_options;
 
 // ----- C L A S S   M E T H O D S -------------------------------------------
 
-SubCmdAdvanced::SubCmdAdvanced(bool _isHidden, bool _isDepricated, bool _isPreliminary)
+SubCmdAdvanced::SubCmdAdvanced(bool _isHidden, bool _isDepricated, bool _isPreliminary, const boost::property_tree::ptree& configurations)
     : SubCmd("advanced", 
              "Low level command operations")
 {
@@ -58,8 +45,11 @@ SubCmdAdvanced::SubCmdAdvanced(bool _isHidden, bool _isDepricated, bool _isPreli
   setIsPreliminary(_isPreliminary);
 
   m_commonOptions.add_options()
+    ("device,d", boost::program_options::value<decltype(m_device)>(&m_device), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest")
     ("help", boost::program_options::bool_switch(&m_help), "Help to use this sub-command")
   ;
+
+  m_commandConfig = configurations;
 
   addSubOption(std::make_shared<OO_MemRead>("read-mem"));
   addSubOption(std::make_shared<OO_MemWrite>("write-mem"));
@@ -88,7 +78,7 @@ SubCmdAdvanced::execute(const SubCmdOptions& _options) const
 
   // No suboption print help
   if (!optionOption) {
-    printHelp();
+    printHelp(false, "", XBU::get_device_class(m_device, true));
     return;
   }
 

--- a/src/runtime_src/core/tools/xbutil2/SubCmdAdvanced.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdAdvanced.h
@@ -1,18 +1,6 @@
-/**
- * Copyright (C) 2020 Xilinx, Inc
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2020 Xilinx, Inc
+// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
 
 #ifndef __SubCmdAdvanced_h_
 #define __SubCmdAdvanced_h_
@@ -24,11 +12,12 @@ class SubCmdAdvanced : public SubCmd {
   virtual void execute(const SubCmdOptions &_options) const;
 
  public:
-  SubCmdAdvanced(bool _isHidden, bool _isDepricated, bool _isPreliminary);
+  SubCmdAdvanced(bool _isHidden, bool _isDepricated, bool _isPreliminary, const boost::property_tree::ptree& configurations);
   virtual ~SubCmdAdvanced() {};
 
   private:
     bool m_help;
+    std::string m_device;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdConfigure.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdConfigure.cpp
@@ -1,19 +1,6 @@
-/**
- * Copyright (C) 2021-2022 Xilinx, Inc
- * Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2021-2022 Xilinx, Inc
+// Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
 
 // ------ I N C L U D E   F I L E S -------------------------------------------
 // Local - Include Files
@@ -29,7 +16,7 @@ std::vector<std::shared_ptr<OptionOptions>> SubCmdConfigureInternal::optionOptio
   std::make_shared<OO_Performance>("performance"),
 };
 
-SubCmdConfigure::SubCmdConfigure(bool _isHidden, bool _isDepricated, bool _isPreliminary, const boost::property_tree::ptree configurations)
+SubCmdConfigure::SubCmdConfigure(bool _isHidden, bool _isDepricated, bool _isPreliminary, const boost::property_tree::ptree& configurations)
     : SubCmdConfigureInternal(_isHidden, _isDepricated, _isPreliminary, true /*isUserDomain*/, configurations)
 {
   // Empty

--- a/src/runtime_src/core/tools/xbutil2/SubCmdConfigure.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdConfigure.h
@@ -1,18 +1,6 @@
-/**
- * Copyright (C) 2021 Xilinx, Inc
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2021 Xilinx, Inc
+// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
 
 #ifndef __SubCmdConfigure_h_
 #define __SubCmdConfigure_h_
@@ -22,7 +10,7 @@
 
 class SubCmdConfigure : public SubCmdConfigureInternal {
  public:
-  SubCmdConfigure(bool _isHidden, bool _isDepricated, bool _isPreliminary, const boost::property_tree::ptree configurations);
+  SubCmdConfigure(bool _isHidden, bool _isDepricated, bool _isPreliminary, const boost::property_tree::ptree& configurations);
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
@@ -58,7 +58,7 @@
   #endif
   };
 
-SubCmdExamine::SubCmdExamine(bool _isHidden, bool _isDepricated, bool _isPreliminary, const boost::property_tree::ptree configurations)
+SubCmdExamine::SubCmdExamine(bool _isHidden, bool _isDepricated, bool _isPreliminary, const boost::property_tree::ptree& configurations)
     : SubCmdExamineInternal(_isHidden, _isDepricated, _isPreliminary, true /*isUserDomain*/, configurations)
     , m_device("")
     , m_reportNames()

--- a/src/runtime_src/core/tools/xbutil2/SubCmdExamine.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdExamine.h
@@ -1,18 +1,6 @@
-/**
- * Copyright (C) 2020 Xilinx, Inc
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2020 Xilinx, Inc
+// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
 
 #ifndef __SubCmdExamine_h_
 #define __SubCmdExamine_h_
@@ -23,7 +11,7 @@
 
 class SubCmdExamine : public SubCmdExamineInternal {
  public:
-  SubCmdExamine(bool _isHidden, bool _isDepricated, bool _isPreliminary, const boost::property_tree::ptree configurations);
+  SubCmdExamine(bool _isHidden, bool _isDepricated, bool _isPreliminary, const boost::property_tree::ptree& configurations);
 
  private:
   std::string               m_device;

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -10,30 +10,29 @@
 #include "core/common/query_requests.h"
 #include "core/tools/common/EscapeCodes.h"
 #include "core/tools/common/Process.h"
+#include "tools/common/reports/ReportPlatforms.h"
 #include "tools/common/Report.h"
-#include "tools/common//reports/ReportPlatforms.h"
 #include "tools/common/XBHelpMenus.h"
 #include "tools/common/XBHelpMenusCore.h"
 #include "tools/common/XBUtilitiesCore.h"
 #include "tools/common/XBUtilities.h"
-#include "tools/common/TestRunner.h"
-#include "tools/common/tests/TestAuxConnection.h"
-#include "tools/common/tests/TestPcieLink.h"
-#include "tools/common/tests/TestSCVersion.h"
-#include "tools/common/tests/TestVerify.h"
-#include "tools/common/tests/TestDMA.h"
-#include "tools/common/tests/TestIOPS.h"
-#include "tools/common/tests/TestBandwidthKernel.h"
-#include "tools/common/tests/Testp2p.h"
-#include "tools/common/tests/Testm2m.h"
-#include "tools/common/tests/TestHostMemBandwidthKernel.h"
-#include "tools/common/tests/TestBist.h"
-#include "tools/common/tests/TestVcuKernel.h"
 #include "tools/common/tests/TestAiePl.h"
 #include "tools/common/tests/TestAiePs.h"
+#include "tools/common/tests/TestAuxConnection.h"
+#include "tools/common/tests/TestBandwidthKernel.h"
+#include "tools/common/tests/TestBist.h"
+#include "tools/common/tests/TestDMA.h"
+#include "tools/common/tests/TestHostMemBandwidthKernel.h"
+#include "tools/common/tests/TestIOPS.h"
+#include "tools/common/tests/Testm2m.h"
+#include "tools/common/tests/Testp2p.h"
+#include "tools/common/tests/TestPcieLink.h"
 #include "tools/common/tests/TestPsPlVerify.h"
-#include "tools/common/tests/TestPsVerify.h"
 #include "tools/common/tests/TestPsIops.h"
+#include "tools/common/tests/TestPsVerify.h"
+#include "tools/common/tests/TestSCVersion.h"
+#include "tools/common/tests/TestVcuKernel.h"
+#include "tools/common/tests/TestVerify.h"
 namespace XBU = XBUtilities;
 
 // 3rd Party Library - Include Files
@@ -70,16 +69,6 @@ static const std::string test_token_skipped = "SKIPPED";
 static const std::string test_token_failed = "FAILED";
 static const std::string test_token_passed = "PASSED";
 
-void
-doesTestExist(const std::string& userTestName, const XBU::VectorPairStrings& testNameDescription)
-{
-  const auto iter = std::find_if( testNameDescription.begin(), testNameDescription.end(),
-    [&userTestName](const std::pair<std::string, std::string>& pair){ return pair.first == userTestName;} );
-
-  if (iter == testNameDescription.end())
-    throw xrt_core::error((boost::format("Invalid test name: '%s'") % userTestName).str());
-}
-
 std::vector<std::shared_ptr<TestRunner>> testSuite = {
   std::make_shared<TestAuxConnection>(),
   std::make_shared<TestPcieLink>(),
@@ -99,6 +88,16 @@ std::vector<std::shared_ptr<TestRunner>> testSuite = {
   std::make_shared<TestPsVerify>(),
   std::make_shared<TestPsIops>()
 };
+
+void
+doesTestExist(const std::string& userTestName)
+{
+  const auto iter = std::find_if( testSuite.begin(), testSuite.end(),
+    [&userTestName](const std::shared_ptr<TestRunner>& test){ return boost::iequals(userTestName, test->getConfigName());} );
+
+  if (iter == testSuite.end())
+    throw xrt_core::error((boost::format("Invalid test name: '%s'") % userTestName).str());
+}
 
 /*
  * print basic information about a test
@@ -257,8 +256,9 @@ run_test_suite_device( const std::shared_ptr<xrt_core::device>& device,
   boost::property_tree::ptree ptDeviceInfo;
   test_status status = test_status::passed;
 
-  if (testObjectsToRun.empty())
+  if (testObjectsToRun.empty()) {
     throw std::runtime_error("No test given to validate against.");
+  }
 
   get_platform_info(device, ptDeviceInfo, schemaVersion, std::cout);
   std::cout << "-------------------------------------------------------------------------------" << std::endl;
@@ -345,36 +345,16 @@ run_tests_on_devices( std::shared_ptr<xrt_core::device> &device,
   return has_failures;
 }
 
-static XBU::VectorPairStrings
-getTestNameDescriptions(bool addAdditionOptions)
-{
-  XBU::VectorPairStrings reportDescriptionCollection;
-
-  // 'verbose' option
-  if (addAdditionOptions) {
-    reportDescriptionCollection.emplace_back("all", "All applicable validate tests will be executed (default)");
-    reportDescriptionCollection.emplace_back("quick", "Only the first 4 tests will be executed");
-  }
-
-  // report names and description
-  for (const auto & test : testSuite) {
-    std::string testName = boost::algorithm::to_lower_copy(test.get()->getConfigName());
-    reportDescriptionCollection.emplace_back(testName, test.get()->get_test_header().get("description", "<no description>"));
-  }
-
-  return reportDescriptionCollection;
-}
-
 }
 //end anonymous namespace
 
 // ----- C L A S S   M E T H O D S -------------------------------------------
-  // -- Build up the format options
-static const auto formatOptionValues = XBU::create_suboption_list_string(Report::getSchemaDescriptionVector());
-static const auto testNameDescription = getTestNameDescriptions(true /* Add "all" and "quick" options*/);
-static const auto formatRunValues = XBU::create_suboption_list_string(testNameDescription);
+static boost::program_options::options_description common_options;
+static std::map<std::string,std::vector<std::shared_ptr<JSONConfigurable>>> jsonOptions;
+static const std::pair<std::string, std::string> all_test = {"all", "All applicable validate tests will be executed (default)"};
+static const std::pair<std::string, std::string> quick_test = {"quick", "Only the first 4 tests will be executed"};
 
-SubCmdValidate::SubCmdValidate(bool _isHidden, bool _isDepricated, bool _isPreliminary)
+SubCmdValidate::SubCmdValidate(bool _isHidden, bool _isDepricated, bool _isPreliminary, const boost::property_tree::ptree& configurations)
     : SubCmd("validate",
              "Validates the basic shell acceleration functionality")
     , m_device("")
@@ -392,16 +372,29 @@ SubCmdValidate::SubCmdValidate(bool _isHidden, bool _isDepricated, bool _isPreli
   setIsDeprecated(_isDepricated);
   setIsPreliminary(_isPreliminary);
 
-  m_commonOptions.add_options()
-    ("device,d", boost::program_options::value<decltype(m_device)>(&m_device), "The device of interest. This is specified as follows:\n"
-                                                                           "  <BDF> - Bus:Device.Function (e.g., 0000:d8:00.0)")
+  m_commandConfig = configurations;
+
+  const auto& configs = JSONConfigurable::parse_configuration_tree(configurations);
+  jsonOptions = JSONConfigurable::extract_subcmd_config<JSONConfigurable, TestRunner>(testSuite, configs, getConfigName(), std::string("test"));
+
+  // -- Build up the format options
+  static const auto formatOptionValues = XBU::create_suboption_list_string(Report::getSchemaDescriptionVector());
+  XBUtilities::VectorPairStrings common_tests;
+  common_tests.emplace_back(all_test);
+  common_tests.emplace_back(quick_test);
+  static const auto formatRunValues = XBU::create_suboption_list_map("", jsonOptions, common_tests);
+
+  common_options.add_options()
+    ("device,d", boost::program_options::value<decltype(m_device)>(&m_device), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest")
     ("format,f", boost::program_options::value<decltype(m_format)>(&m_format), (std::string("Report output format. Valid values are:\n") + formatOptionValues).c_str() )
-    ("run,r", boost::program_options::value<decltype(m_tests_to_run)>(&m_tests_to_run)->multitoken(), (std::string("Run a subset of the test suite.  Valid options are:\n") + formatRunValues).c_str() )
     ("output,o", boost::program_options::value<decltype(m_output)>(&m_output), "Direct the output to the given file")
-    ("param", boost::program_options::value<decltype(m_param)>(&m_param), "Extended parameter for a given test. Format: <test-name>:<key>:<value>")
-    ("path,p", boost::program_options::value<decltype(m_xclbin_location)>(&m_xclbin_location), "Path to the directory containing validate xclbins")
     ("help", boost::program_options::bool_switch(&m_help), "Help to use this sub-command")
-  ;    
+  ;
+
+  m_commonOptions.add(common_options);
+  m_commonOptions.add_options()
+    ("run,r", boost::program_options::value<decltype(m_tests_to_run)>(&m_tests_to_run)->multitoken(), (std::string("Run a subset of the test suite.  Valid options are:\n") + formatRunValues).c_str() )
+  ;
 }
 
 /*
@@ -446,6 +439,85 @@ extendedKeysOptions()
 }
 
 void
+SubCmdValidate::print_help_internal() const
+{
+  if (m_device.empty()) {
+    printHelp(false, extendedKeysOptions());
+    return;
+  }
+
+  const std::string deviceClass = XBU::get_device_class(m_device, true);
+  auto it = jsonOptions.find(deviceClass);
+
+  XBUtilities::VectorPairStrings help_tests = { all_test };
+  if (it != jsonOptions.end() && it->second.size() > 3)
+    help_tests.emplace_back(quick_test);
+
+  static const std::string testOptionValues = XBU::create_suboption_list_map(deviceClass, jsonOptions, help_tests);
+  std::vector<std::string> tempVec;
+  common_options.add_options()
+    ("report,r", boost::program_options::value<decltype(tempVec)>(&tempVec)->multitoken(), (std::string("The type of report to be produced. Reports currently available are:\n") + testOptionValues).c_str() )
+  ;
+  printHelp(common_options, m_hiddenOptions, deviceClass, false, extendedKeysOptions());
+}
+
+static void
+set_test_data(std::vector<std::shared_ptr<TestRunner>>& collection,
+              std::shared_ptr<TestRunner> test,
+              const std::vector<std::string>& param,
+              const std::string& xclbin_path)
+{
+  if (!param.empty() && boost::equals(param[0], test->get_name()))
+    test->set_param(param[1], param[2]);
+
+  if (!xclbin_path.empty())
+    test->set_xclbin_path(xclbin_path);
+
+  collection.push_back(test);
+}
+
+std::vector<std::shared_ptr<TestRunner>>
+SubCmdValidate::collect_and_validate_tests(const std::vector<std::shared_ptr<TestRunner>>& all_tests,
+                                           const std::vector<std::string>& requested_tests,
+                                           const std::vector<std::string>& param,
+                                           const std::string& xclbin_path) const
+{
+  std::vector<std::shared_ptr<TestRunner>> valid_tests;
+
+  if (std::find(requested_tests.begin(), requested_tests.end(), "all") != requested_tests.end()) {
+    for (const auto& test : all_tests) {
+      if (test->getConfigHidden()) 
+        continue;
+
+      set_test_data(valid_tests, test, param, xclbin_path);
+    }
+  } else if (std::find(requested_tests.begin(), requested_tests.end(), "quick") != requested_tests.end()) {
+    if (all_tests.size() < 4)
+      throw xrt_core::error("No test found for: 'quick'\n");
+
+    // Only the first 4 tests are run for a `quick` test
+    for (size_t i = 0; i < 4; i++) {
+      if (all_tests[i]->getConfigHidden()) 
+        continue;
+
+      set_test_data(valid_tests, all_tests[i], param, xclbin_path);
+    }
+  } else {
+    // Examine each report name for a match
+    for (const auto & test_name : requested_tests) {
+      auto iter = std::find_if(all_tests.begin(), all_tests.end(), 
+                               [&test_name](const std::shared_ptr<TestRunner>& obj) {return obj->getConfigName() == test_name;});
+      if (iter == all_tests.end())
+        throw xrt_core::error((boost::format("No test found for: '%s'\n") % test_name).str());
+
+      set_test_data(valid_tests, *iter, param, xclbin_path);
+    }
+  }
+
+  return valid_tests;
+}
+
+void
 SubCmdValidate::execute(const SubCmdOptions& _options) const
 {
   // Parse sub-command ...
@@ -454,7 +526,7 @@ SubCmdValidate::execute(const SubCmdOptions& _options) const
 
   // Check to see if help was requested or no command was found
   if (m_help) {
-    printHelp(false, extendedKeysOptions());
+    print_help_internal();
     return;
   }
 
@@ -475,21 +547,6 @@ SubCmdValidate::execute(const SubCmdOptions& _options) const
 
     if (m_tests_to_run.empty())
       throw std::runtime_error("No test given to validate against.");
-
-    // Validate the user test requests
-    for (auto &userTestName : m_tests_to_run) {
-      const auto validateTestName = boost::algorithm::to_lower_copy(userTestName);
-
-      if ((validateTestName == "all") && (m_tests_to_run.size() > 1))
-        throw xrt_core::error("The 'all' value for the tests to run cannot be used with any other named tests.");
-
-      if ((validateTestName == "quick") && (m_tests_to_run.size() > 1))
-        throw xrt_core::error("The 'quick' value for the tests to run cannot be used with any other name tests.");
-
-      // Verify the current user test request exists in the test suite
-      doesTestExist(validateTestName, testNameDescription);
-      validatedTests.push_back(validateTestName);
-    }
 
     // check if xclbin folder path is provided
     if (!validateXclbinPath.empty()) {
@@ -512,7 +569,7 @@ SubCmdValidate::execute(const SubCmdOptions& _options) const
         throw xrt_core::error((boost::format("Invalid parameter format (expected 3 positional arguments): '%s'") % m_param).str());
 
       //check test case name
-      doesTestExist(param[0], testNameDescription);
+      doesTestExist(param[0]);
 
       //check parameter name
       auto iter = std::find_if( extendedKeysCollection.begin(), extendedKeysCollection.end(),
@@ -524,7 +581,7 @@ SubCmdValidate::execute(const SubCmdOptions& _options) const
   } catch (const xrt_core::error& e) {
     // Catch only the exceptions that we have generated earlier
     std::cerr << boost::format("ERROR: %s\n") % e.what();
-    printHelp(false, extendedKeysOptions());
+    print_help_internal();
     throw xrt_core::error(std::errc::operation_canceled);
   }
 
@@ -540,49 +597,9 @@ SubCmdValidate::execute(const SubCmdOptions& _options) const
   }
 
   // Collect all of the tests of interests
-  std::vector<std::shared_ptr<TestRunner>> testObjectsToRun;
-
-  for (size_t index = 0; index < testSuite.size(); ++index) {
-    std::string testSuiteName = testSuite[index]->get_name();
-    // The all option enqueues all test suites not marked explicit
-    if (validatedTests[0] == "all") {
-      // Do not queue test suites that must be explicitly passed in
-      if (testSuite[index]->is_explicit())
-        continue;
-      testObjectsToRun.push_back(testSuite[index]);
-      // add custom param to the ptree if available
-      if (!param.empty() && boost::equals(param[0], testSuiteName)) {
-        testSuite[index]->set_param(param[1], param[2]);
-      }
-      if (!validateXclbinPath.empty())
-        testSuite[index]->set_xclbin_path(validateXclbinPath);
-      continue;
-    }
-
-    // The quick test option enqueues only the first three test suites
-    if (validatedTests[0] == "quick") {
-      testObjectsToRun.push_back(testSuite[index]);
-      if (!validateXclbinPath.empty())
-        testSuite[index]->set_xclbin_path(validateXclbinPath);
-      if (index == 3)
-        break;
-    }
-
-    // Logic for individually defined tests
-    // Enqueue the matching test suites to be executed
-    for (const auto & testName : validatedTests) {
-      if (boost::equals(testName, testSuiteName)) {
-        testObjectsToRun.push_back(testSuite[index]);
-        // add custom param to the ptree if available
-        if (!param.empty() && boost::equals(param[0], testSuiteName)) {
-          testSuite[index]->set_param(param[1], param[2]);
-        }
-        if (!validateXclbinPath.empty())
-          testSuite[index]->set_xclbin_path(validateXclbinPath);
-        break;
-      }
-    }
-  }
+  const std::string deviceClass = XBU::get_device_class(m_device, true);
+  std::vector<std::shared_ptr<TestRunner>> runnableTests = validateConfigurables<TestRunner>(deviceClass, std::string("test"), testSuite);
+  std::vector<std::shared_ptr<TestRunner>> testObjectsToRun = collect_and_validate_tests(runnableTests, m_tests_to_run, param, validateXclbinPath);
 
   // -- Run the tests --------------------------------------------------
   std::ostringstream oSchemaOutput;

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.h
@@ -1,30 +1,19 @@
-/**
- * Copyright (C) 2019-2020 Xilinx, Inc
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2019-2020 Xilinx, Inc
+// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
 
 #ifndef __SubCmdValidate_h_
 #define __SubCmdValidate_h_
 
 #include "tools/common/SubCmd.h"
+#include "tools/common/TestRunner.h"
 
 class SubCmdValidate : public SubCmd {
  public:
   virtual void execute(const SubCmdOptions &_options) const;
 
  public:
-  SubCmdValidate(bool _isHidden, bool _isDepricated, bool _isPreliminary);
+  SubCmdValidate(bool _isHidden, bool _isDepricated, bool _isPreliminary, const boost::property_tree::ptree& configurations);
 
  private:
   std::string               m_device;
@@ -34,6 +23,14 @@ class SubCmdValidate : public SubCmd {
   std::string               m_param;
   std::string               m_xclbin_location;
   bool                      m_help;
+
+  void print_help_internal() const;
+
+  std::vector<std::shared_ptr<TestRunner>>
+  collect_and_validate_tests(const std::vector<std::shared_ptr<TestRunner>>& all_tests,
+                             const std::vector<std::string>& requested_tests,
+                             const std::vector<std::string>& param,
+                             const std::string& xclbin_path) const;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbutil2/xbutil.cpp
+++ b/src/runtime_src/core/tools/xbutil2/xbutil.cpp
@@ -30,29 +30,41 @@
 const std::string& command_config = 
 R"(
 [{
-    "name": "cmd_configs",
-    "contents": [{
-        "name": "common",
-        "contents": [{
-            "name": "examine",
-            "contents": ["dynamic-regions", "electrical", "host", "mechanical", "memory", "pcie-info", "platform", "thermal"]
-        },{
-            "name": "configure",
-            "contents": ["host-mem", "p2p", "performance"]
-        }]
-    },{
-        "name": "alveo",
-        "contents": [{
-            "name": "examine",
-            "contents": ["error", "firewall", "mailbox", "debug-ip-status", "qspi-status"]
-        }]
-    },{
-        "name": "aie",
-        "contents": [{
-            "name": "examine",
-            "contents": ["aie", "aiemem", "aieshim", "aie-partitions"]
-        }]
+  "alveo": [{
+    "examine": [{
+      "report": ["dynamic-regions", "electrical", "host", "mechanical", "memory", "pcie-info", "platform", "thermal", "error", "firewall", "mailbox", "debug-ip-status", "qspi-status"]
     }]
+  },{
+    "configure": [{
+      "suboption": ["host-mem", "p2p"]
+    }]
+  },{
+    "advanced":[{
+      "suboption": ["read-mem", "write-mem"]
+    }]
+  },{
+    "validate": [{
+      "test": ["aux-connection", "pcie-link", "sc-version", "verify", "dma", "iops", "mem-bw", "p2p", "m2m", "hostmem-bw", "bist", "vcu", "aie", "ps-aie", "ps-pl-verify", "ps-verify", "ps-iops"]
+    }]
+  }]
+},{
+  "aie": [{
+    "examine": [{
+      "report": ["dynamic-regions", "electrical", "host", "mechanical", "memory", "pcie-info", "platform", "thermal", "aie", "aiemem", "aieshim", "aie-partitions"]
+    }]
+  },{
+    "configure": [{
+      "suboption": ["performance"]
+    }]
+  },{
+    "advanced":[{
+      "suboption": ["read-aie-reg", "aie-clock"]
+    }]
+  },{
+    "validate": [{
+      "test": ["verify"]
+    }]
+  }]
 }]
 )";
 
@@ -78,10 +90,10 @@ int main( int argc, char** argv )
     populateSubCommandsFromJSON(subCommands, executable);
 
 #ifdef ENABLE_NATIVE_SUBCMDS_AND_REPORTS
-    subCommands.emplace_back(std::make_shared< SubCmdValidate >(false,  false, false));
+    subCommands.emplace_back(std::make_shared< SubCmdValidate >(false,  false, false, configTree));
 #endif
 
-    subCommands.emplace_back(std::make_shared< SubCmdAdvanced >(true,  false, true ));
+    subCommands.emplace_back(std::make_shared< SubCmdAdvanced >(true, false, true, configTree));
   }
 
   for (auto & subCommand : subCommands) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/VITIS-8047

With the addition of different device categories, not all options are applicable to all devices as was the case in the past. This PR attempt to fix this issue by using a JSON configuration which states which options are applicable to certain devices.

This also updates SubCmdValidate to use the new JSONConfigurable class to interface with the xbutil JSON file!

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Devices must have the display only the applicable options in the help menu and restrict execution during operation.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Implemented using an existing JSONConfigurable base class and various edites to the Help menu classes to display the options.

#### Risks (if any) associated the changes in the commit
Changes to the help menu may confuse some people. Some options may break (hopefully not I tested them as best I could).

#### What has been tested and how, request additional testing if necessary
Ubuntu 22.04 U55c
OptionOptions Testing

Without device
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov/XRT$ xbutil configure --help

COMMAND: configure

DESCRIPTION: Device and host configuration.

USAGE: xbutil configure [ --host-mem | --p2p | --performance ] [--help] [-d arg]

OPTIONS:
 Common:
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest
  --help             - Help to use this sub-command
 AIE:
  --performance      - Change performance mode of the device
 Alveo:
  --host-mem         - Controls host-mem functionality
  --p2p              - Controls P2P functionality


GLOBAL OPTIONS:
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
```

With device (Alveo)
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov/XRT$ xbutil configure -d --help

COMMAND: configure

DESCRIPTION: Device and host configuration.

USAGE: xbutil configure [ --host-mem | --p2p ] [--help] [-d arg]

OPTIONS:
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest
  --help             - Help to use this sub-command
  --host-mem         - Controls host-mem functionality
  --p2p              - Controls P2P functionality


GLOBAL OPTIONS:
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
```

Report (SubCmdExamine Testing)

Without device
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov/XRT$ xbutil examine --help

COMMAND: examine

DESCRIPTION: This command will 'examine' the state of the system/device and will generate a report of interest
               in a text or JSON format.

USAGE: xbutil examine [--help] [-d arg] [-f arg] [-o arg] [-r arg]

OPTIONS:
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest
  -f, --format       - Report output format. Valid values are:
                         JSON        - Latest JSON schema
                         JSON-2020.2 - JSON 2020.2 schema
  -o, --output       - Direct the output to the given file
  --help             - Help to use this sub-command
  -r, --report       - The type of report to be produced. Reports currently available are:
                       Common:
                         all             - All known reports are produced
                         dynamic-regions - Information about the xclbin and the compute units
                         electrical      - Electrical and power sensors present on the device
                         host            - Host information
                         mechanical      - Mechanical sensors on and surrounding the device
                         memory          - Memory information present on the device
                         pcie-info       - Pcie information of the device
                         platform        - Platforms flashed on the device
                         thermal         - Thermal sensors present on the device
                       AIE:
                         aie             - AIE metadata in xclbin
                         aie-partitions  - AIE partition information
                         aiemem          - AIE memory tile information
                         aieshim         - AIE shim tile status
                       Alveo:
                         debug-ip-status - Status of Debug IPs present in xclbin loaded on device
                         error           - Asyncronus Error present on the device
                         firewall        - Firewall status
                         mailbox         - Mailbox metrics of the device
                         qspi-status     - QSPI write protection status


GLOBAL OPTIONS:
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
```

With device (Alveo)
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov/XRT$ xbutil examine -d --help

COMMAND: examine

DESCRIPTION: This command will 'examine' the state of the system/device and will generate a report of interest
               in a text or JSON format.

USAGE: xbutil examine [--help] [-d arg] [-f arg] [-o arg] [-r arg]

OPTIONS:
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest
  -f, --format       - Report output format. Valid values are:
                         JSON        - Latest JSON schema
                         JSON-2020.2 - JSON 2020.2 schema
  -o, --output       - Direct the output to the given file
  --help             - Help to use this sub-command
  -r, --report       - The type of report to be produced. Reports currently available are:
                         all             - All known reports are produced
                         debug-ip-status - Status of Debug IPs present in xclbin loaded on device
                         dynamic-regions - Information about the xclbin and the compute units
                         electrical      - Electrical and power sensors present on the device
                         error           - Asyncronus Error present on the device
                         firewall        - Firewall status
                         host            - Host information
                         mailbox         - Mailbox metrics of the device
                         mechanical      - Mechanical sensors on and surrounding the device
                         memory          - Memory information present on the device
                         pcie-info       - Pcie information of the device
                         platform        - Platforms flashed on the device
                         qspi-status     - QSPI write protection status
                         thermal         - Thermal sensors present on the device


GLOBAL OPTIONS:
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
```

Case where only one device class applies (Only Alveo)
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov/XRT$ xbmgmt advanced --help

COMMAND: advanced

DESCRIPTION: Low level command operations.

USAGE: xbmgmt advanced [ --hotplug ] [--help] [-d arg]

OPTIONS:
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest
  --help             - Help to use this sub-command
  --hotplug          - Perform hotplug for the given device


GLOBAL OPTIONS:
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
```

Case where some options are common and others are now (`--user` is applicable to AIE if we ever port xbmgmt)
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov/XRT$ xbmgmt program --help

COMMAND: program

DESCRIPTION: Updates the image(s) for a given device.

USAGE: xbmgmt program [ --base | --shell | --revert-to-golden | --user ] [--help] [-d arg]

OPTIONS:
 Common:
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest.
  --help             - Help to use this sub-command
  --user             - Load an xclbin onto the FPGA
 Alveo:
  --base             - Update base partition
  --shell            - Update the shell partition for a 2RP platform
  --revert-to-golden - Reset the FPGA PROM back to the factory image


GLOBAL OPTIONS:
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
```

Validate without device
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov/XRT$ xbutil validate --help

COMMAND: validate

DESCRIPTION: Validates the given device by executing the platform's validate executable.

USAGE: xbutil validate [--help] [-d arg] [-f arg] [-o arg] [-r arg]

OPTIONS:
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest
  -f, --format       - Report output format. Valid values are:
                         JSON        - Latest JSON schema
                         JSON-2020.2 - JSON 2020.2 schema
  -o, --output       - Direct the output to the given file
  --help             - Help to use this sub-command
  -r, --run          - Run a subset of the test suite.  Valid options are:
                       Common:
                         all            - All applicable validate tests will be executed (default)
                         quick          - Only the first 4 tests will be executed
                         verify         - Run 'Hello World' kernel test
                       Alveo:
                         aie            - Run AIE PL test
                         aux-connection - Check if auxiliary power is connected
                         bist           - Run BIST test
                         dma            - Run dma test
                         hostmem-bw     - Run 'bandwidth kernel' when host memory is enabled
                         iops           - Run scheduler performance measure test
                         m2m            - Run M2M test
                         mem-bw         - Run 'bandwidth kernel' and check the throughput
                         p2p            - Run P2P test
                         pcie-link      - Check if PCIE link is active
                         ps-aie         - Run PS controlled AIE test
                         ps-iops        - Run IOPS PS test
                         ps-pl-verify   - Run PS controlled 'Hello World' PL kernel test
                         ps-verify      - Run 'Hello World' PS kernel test
                         sc-version     - Check if SC firmware is up-to-date
                         vcu            - Run decoder test

EXTENDED KEYS:
  dma                - block-size:<value> - Memory transfer size (bytes)


GLOBAL OPTIONS:
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
```

Validate with device
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov/XRT$ xbutil validate -d 04:00 --help

COMMAND: validate

DESCRIPTION: Validates the given device by executing the platform's validate executable.

USAGE: xbutil validate [--help] [-d arg] [-f arg] [-o arg] [-r arg]

OPTIONS:
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest
  -f, --format       - Report output format. Valid values are:
                         JSON        - Latest JSON schema
                         JSON-2020.2 - JSON 2020.2 schema
  -o, --output       - Direct the output to the given file
  --help             - Help to use this sub-command
  -r, --report       - The type of report to be produced. Reports currently available are:
                         aie            - Run AIE PL test
                         all            - All applicable validate tests will be executed (default)
                         aux-connection - Check if auxiliary power is connected
                         bist           - Run BIST test
                         dma            - Run dma test
                         hostmem-bw     - Run 'bandwidth kernel' when host memory is enabled
                         iops           - Run scheduler performance measure test
                         m2m            - Run M2M test
                         mem-bw         - Run 'bandwidth kernel' and check the throughput
                         p2p            - Run P2P test
                         pcie-link      - Check if PCIE link is active
                         ps-aie         - Run PS controlled AIE test
                         ps-iops        - Run IOPS PS test
                         ps-pl-verify   - Run PS controlled 'Hello World' PL kernel test
                         ps-verify      - Run 'Hello World' PS kernel test
                         quick          - Only the first 4 tests will be executed
                         sc-version     - Check if SC firmware is up-to-date
                         vcu            - Run decoder test
                         verify         - Run 'Hello World' kernel test

EXTENDED KEYS:
  dma                - block-size:<value> - Memory transfer size (bytes)


GLOBAL OPTIONS:
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
```

Validate running
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov/XRT$ xbutil validate -d 04:00  -r quick
Validate Device           : [0000:04:00.1]
    Platform              : xilinx_u55c_gen3x16_xdma_base_3
    SC Version            : 7.1.22
    Platform ID           : 97088961-FEAE-DA91-52A2-1D9DFD63CCEF
-------------------------------------------------------------------------------
Test 1 [0000:04:00.1]     : pcie-link
    Warning(s)            : Link is active
                            Please make sure that the device is plugged into Gen 3x16,
                            instead of Gen 3x4. Lower performance maybe experienced.
    Test Status           : [PASSED WITH WARNINGS]
-------------------------------------------------------------------------------
Test 2 [0000:04:00.1]     : sc-version
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Test 3 [0000:04:00.1]     : verify
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Validation completed, but with warnings. Please run the command '--verbose' option for more details
```
#### Documentation impact (if any)
Not needed.