### PR TITLE
Change device name check from IPU to RyzenAI

### DIFF
--- a/src/runtime_src/core/tools/common/tests/TestVerify.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestVerify.cpp
@@ -20,7 +20,7 @@ TestVerify::run(std::shared_ptr<xrt_core::device> dev)
   auto device_name = xrt_core::device_query_default<xrt_core::query::rom_vbnv>(dev, "");
   boost::property_tree::ptree ptree;
   //to-do: Do it in a cleaner way
-  if (device_name.find("IPU") != std::string::npos) {
+  if (device_name.find("RyzenAI-Strix") != std::string::npos || device_name.find("RyzenAI-Phoenix") != std::string::npos) {
     //run ipu verify
     ptree = TestIPU{}.run(dev);
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
verify test will now look for RyzenAI instead of IPU to run IPU based verify
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
N/A
#### Documentation impact (if any)
