### PR TITLE
VITIS-9909	Bundle AIE microbenchmarks with xbutil validate

### DIFF
--- a/src/runtime_src/core/tools/common/TestRunner.cpp
+++ b/src/runtime_src/core/tools/common/TestRunner.cpp
@@ -443,17 +443,17 @@ TestRunner::findXclbinPath( const std::shared_ptr<xrt_core::device>& _dev,
 
 std::string
 TestRunner::findDPUPath( const std::shared_ptr<xrt_core::device>& _dev,
-                boost::property_tree::ptree& _ptTest)
+                const std::string dpu_name)
 {
   const static std::string dpu_dir = "DPU_Sequence"; 
-  auto dpu_name = _ptTest.get<std::string>("DPU-Sequence", "");
   boost::filesystem::path prefix_path;
 
 #ifdef _WIN32
   boost::ignore_unused(_dev);
   prefix_path = xrt_core::environment::xilinx_xrt();
 #else
-  const auto platform_path = findPlatformPath(_dev, _ptTest);
+  boost::property_tree::ptree ptree; //ignore
+  const auto platform_path = findPlatformPath(_dev, ptree);
   prefix_path = boost::filesystem::path(platform_path);
 #endif
   auto dpu_instr = prefix_path / dpu_dir / dpu_name;

--- a/src/runtime_src/core/tools/common/TestRunner.cpp
+++ b/src/runtime_src/core/tools/common/TestRunner.cpp
@@ -401,7 +401,7 @@ TestRunner::findPlatformPath(const std::shared_ptr<xrt_core::device>& _dev,
   //check if a 2RP platform
   const auto logic_uuid = xrt_core::device_query_default<xrt_core::query::logic_uuids>(_dev, {});
   const auto device_name = xrt_core::device_query_default<xrt_core::query::rom_vbnv>(_dev, "");
-  if (device_name.find("RyzenAI-Strix") != std::string::npos || device_name.find("RyzenAI-Phoenix") != std::string::npos) {
+  if (device_name.find("Ryzen") != std::string::npos) {
     return "/opt/xilinx/xrt/amdaie/";
   }
   if (!logic_uuid.empty())

--- a/src/runtime_src/core/tools/common/TestRunner.cpp
+++ b/src/runtime_src/core/tools/common/TestRunner.cpp
@@ -443,6 +443,7 @@ TestRunner::findXclbinPath( const std::shared_ptr<xrt_core::device>& _dev,
 
 std::string
 TestRunner::findDPUPath( const std::shared_ptr<xrt_core::device>& _dev,
+                boost::property_tree::ptree& _ptTest,
                 const std::string dpu_name)
 {
   const static std::string dpu_dir = "DPU_Sequence"; 
@@ -450,7 +451,7 @@ TestRunner::findDPUPath( const std::shared_ptr<xrt_core::device>& _dev,
 
 #ifdef _WIN32
   boost::ignore_unused(_dev);
-  prefix_path = xrt_core::environment::xilinx_xrt();
+  prefix_path = xrt_core::environment::xclbin_path(_ptTest.get<std::string>("xclbin", "")).parent_path();
 #else
   boost::property_tree::ptree ptree; //ignore
   const auto platform_path = findPlatformPath(_dev, ptree);

--- a/src/runtime_src/core/tools/common/TestRunner.cpp
+++ b/src/runtime_src/core/tools/common/TestRunner.cpp
@@ -446,7 +446,7 @@ TestRunner::findDPUPath( const std::shared_ptr<xrt_core::device>& _dev,
                 const std::string dpu_name)
 {
   const static std::string dpu_dir = "DPU_Sequence"; 
-  boost::filesystem::path prefix_path;
+  std::filesystem::path prefix_path;
 
 #ifdef _WIN32
   boost::ignore_unused(_dev);
@@ -454,10 +454,10 @@ TestRunner::findDPUPath( const std::shared_ptr<xrt_core::device>& _dev,
 #else
   boost::property_tree::ptree ptree; //ignore
   const auto platform_path = findPlatformPath(_dev, ptree);
-  prefix_path = boost::filesystem::path(platform_path);
+  prefix_path = std::filesystem::path(platform_path);
 #endif
   auto dpu_instr = prefix_path / dpu_dir / dpu_name;
-  if (!boost::filesystem::exists(dpu_instr)) {
+  if (!std::filesystem::exists(dpu_instr)) {
     throw std::runtime_error(boost::str(boost::format("DPU sequence file not found: '%s'") % dpu_instr));
   }
 

--- a/src/runtime_src/core/tools/common/TestRunner.h
+++ b/src/runtime_src/core/tools/common/TestRunner.h
@@ -28,7 +28,7 @@ class TestRunner : public JSONConfigurable {
     std::string findXclbinPath( const std::shared_ptr<xrt_core::device>& _dev,
                       boost::property_tree::ptree& _ptTest);
     std::string findDPUPath( const std::shared_ptr<xrt_core::device>& _dev,
-                      const std::string dpu_name);
+                              boost::property_tree::ptree& _ptTest, const std::string dpu_name);
 
   // Child class helper methods
   protected:

--- a/src/runtime_src/core/tools/common/TestRunner.h
+++ b/src/runtime_src/core/tools/common/TestRunner.h
@@ -27,6 +27,8 @@ class TestRunner : public JSONConfigurable {
     boost::property_tree::ptree get_test_header();
     std::string findXclbinPath( const std::shared_ptr<xrt_core::device>& _dev,
                       boost::property_tree::ptree& _ptTest);
+    std::string findDPUPath( const std::shared_ptr<xrt_core::device>& _dev,
+                      boost::property_tree::ptree& _ptTest);
 
   // Child class helper methods
   protected:

--- a/src/runtime_src/core/tools/common/TestRunner.h
+++ b/src/runtime_src/core/tools/common/TestRunner.h
@@ -28,7 +28,7 @@ class TestRunner : public JSONConfigurable {
     std::string findXclbinPath( const std::shared_ptr<xrt_core::device>& _dev,
                       boost::property_tree::ptree& _ptTest);
     std::string findDPUPath( const std::shared_ptr<xrt_core::device>& _dev,
-                      boost::property_tree::ptree& _ptTest);
+                      const std::string dpu_name);
 
   // Child class helper methods
   protected:

--- a/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.cpp
@@ -1,0 +1,192 @@
+// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+
+// ------ I N C L U D E   F I L E S -------------------------------------------
+// Local - Include Files
+#include "TestDF_bandwidth.h"
+#include "tools/common/XBUtilities.h"
+#include "xrt/xrt_bo.h"
+#include "xrt/xrt_device.h"
+#include "xrt/xrt_hw_context.h"
+#include "xrt/xrt_kernel.h"
+namespace XBU = XBUtilities;
+
+#include <boost/filesystem.hpp>
+
+static constexpr size_t host_app = 1; //opcode
+static constexpr size_t buffer_size = 1024 * 1024 * 1024; //1 GB
+static constexpr size_t word_count = buffer_size/4;
+
+// ----- C L A S S   M E T H O D S -------------------------------------------
+TestDF_bandwidth::TestDF_bandwidth()
+  : TestRunner("df-bw", 
+                "Run bandwidth test on data fabric"){}
+
+namespace {
+
+// Copy values from text files into buff, expecting values are ascii encoded hex
+static void 
+init_instr_buf(xrt::bo &bo_instr, const std::string& dpu_file) {
+  std::ifstream dpu_stream(dpu_file);
+  if (!dpu_stream.is_open()) {
+    throw std::runtime_error(boost::str(boost::format("Failed to open %s for reading") % dpu_file));
+  }
+
+  auto instr = bo_instr.map<int*>();
+  std::string line;
+  while (getline(dpu_stream, line)) {
+    if (line.at(0) == '#') {
+      continue;
+    }
+    std::stringstream ss(line);
+    unsigned int word = 0;
+    ss >> std::hex >> word;
+    *(instr++) = word;
+  }
+}
+
+static size_t 
+get_instr_size(const std::string& dpu_file) {
+  std::ifstream file(dpu_file);
+  if (!file.is_open()) {
+    throw std::runtime_error(boost::str(boost::format("Failed to open %s for reading") % dpu_file));
+  }
+  size_t size = 0;
+  std::string line;
+  while (getline(file, line)) {
+    if (line.at(0) != '#') {
+      size++;
+    }
+  }
+  if (size == 0) {
+    throw std::runtime_error("Invalid DPU instruction length");
+  }
+  return size;
+}
+
+} //anonymous namespace
+
+boost::property_tree::ptree
+TestDF_bandwidth::run(std::shared_ptr<xrt_core::device> dev)
+{
+  boost::property_tree::ptree ptree = get_test_header();
+
+  auto device_name = xrt_core::device_query_default<xrt_core::query::rom_vbnv>(dev, "");
+  if (device_name.find("RyzenAI-Strix") != std::string::npos) {
+    ptree.put("xclbin", "validate_stx.xclbin");
+  }
+  else if (device_name.find("RyzenAI-Phoenix") != std::string::npos) {
+    ptree.put("xclbin", "validate_phx.xclbin");
+  }
+
+  auto xclbin_path = findXclbinPath(dev, ptree);
+  if (!boost::filesystem::exists(xclbin_path)) {
+    return ptree;
+  }
+  // log xclbin test dir for debugging purposes
+  logger(ptree, "Xclbin", xclbin_path);
+
+  xrt::xclbin xclbin;
+  try {
+    xclbin = xrt::xclbin(xclbin_path);
+  }
+  catch (const std::runtime_error& ex) {
+    logger(ptree, "Error", ex.what());
+    ptree.put("status", test_token_failed);
+    return ptree;
+  }
+
+  // Determine The DPU Kernel Name
+  auto xkernels = xclbin.get_kernels();
+
+  auto itr = std::find_if(xkernels.begin(), xkernels.end(), [](xrt::xclbin::kernel& k) {
+    auto name = k.get_name();
+    return name.rfind("DPU",0) == 0; // Starts with "DPU"
+  });
+
+  xrt::xclbin::kernel xkernel;
+  if (itr!=xkernels.end())
+    xkernel = *itr;
+  else {
+    logger(ptree, "Error", "No kernel with `DPU` found in the xclbin");
+    ptree.put("status", test_token_failed);
+    return ptree;
+  }
+  auto kernelName = xkernel.get_name();
+  logger(ptree, "Details", boost::str(boost::format("Kernel name is '%s'") % kernelName));
+
+  auto working_dev = xrt::device{dev->get_device_id()};
+  working_dev.register_xclbin(xclbin);
+  xrt::hw_context hwctx{working_dev, xclbin.get_uuid()};
+  xrt::kernel kernel{hwctx, kernelName};
+
+  // Find DPU instruction file
+  std::string dpu_instr;
+  try {
+    dpu_instr = findDPUPath(dev, ptree);
+  }
+  catch(const std::exception& ex) {
+    logger(ptree, "Error", ex.what());
+    ptree.put("status", test_token_failed);
+    return ptree;
+  }
+  logger(ptree, "DPU-Sequence", dpu_instr);
+
+  size_t instr_size = 0;
+  try {
+    get_instr_size(dpu_instr); 
+  }
+  catch(const std::exception& ex) {
+    logger(ptree, "Error", ex.what());
+    ptree.put("status", test_token_failed);
+    return ptree;
+  }
+
+  //Create BOs
+  xrt::bo bo_ifm(working_dev, buffer_size, XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(1));
+  xrt::bo bo_ofm(working_dev, buffer_size, XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(3));
+  xrt::bo bo_instr(working_dev, instr_size*sizeof(int), XCL_BO_FLAGS_CACHEABLE, kernel.group_id(5));
+
+  init_instr_buf(bo_instr, dpu_instr);
+
+  // map input buffer
+  auto ifm_mapped = bo_ifm.map<int*>();
+	for (size_t i = 0; i < word_count; i++)
+		ifm_mapped[i] = rand() % 4096;
+
+  //Sync BOs
+  bo_instr.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+  bo_ifm.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+
+  auto start = std::chrono::high_resolution_clock::now();
+  try {
+    auto run = kernel(host_app, bo_ifm, NULL, bo_ofm, NULL, bo_instr, buffer_size, NULL);
+    // Wait for kernel to be done
+    run.wait();
+  }
+  catch (const std::exception& ex) {
+    logger(ptree, "Error", ex.what());
+    ptree.put("status", test_token_failed);
+    return ptree;
+  }
+  auto end = std::chrono::high_resolution_clock::now();
+
+  //map ouput buffer
+  bo_ofm.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
+  auto ofm_mapped = bo_ofm.map<int*>();
+  for (size_t i = 0; i < word_count; i++) {
+    if (ofm_mapped[i] != ifm_mapped[i]) {
+      auto msg = boost::str(boost::format("Data mismatch at out buffer[%d]") % i);
+      logger(ptree, "Error", msg);
+      return ptree;
+    }
+  }
+
+  //Calculate bandwidth
+  float elapsedSecs = std::chrono::duration_cast<std::chrono::duration<float>>(end-start).count();
+  float bandwidth = buffer_size / elapsedSecs;
+  logger(ptree, "Details", boost::str(boost::format("Total duration: '%f's") % elapsedSecs));
+  logger(ptree, "Details", boost::str(boost::format("Average bandwidth per shim DMA: '%f' GS/s") % bandwidth));
+
+  ptree.put("status", test_token_passed);
+  return ptree;
+}

--- a/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.cpp
@@ -10,7 +10,11 @@
 #include "xrt/xrt_kernel.h"
 namespace XBU = XBUtilities;
 
+// 3rd Party Library - Include Files
 #include <boost/filesystem.hpp>
+
+// System - Include Files
+#include <fstream>
 
 static constexpr size_t host_app = 1; //opcode
 static constexpr size_t buffer_size = 1024 * 1024 * 1024; //1 GB
@@ -36,7 +40,7 @@ init_instr_buf(xrt::bo &bo_instr, const std::string& dpu_file) {
 
   auto instr = bo_instr.map<int*>();
   std::string line;
-  while (getline(dpu_stream, line)) {
+  while (std::getline(dpu_stream, line)) {
     if (line.at(0) == '#') {
       continue;
     }
@@ -55,7 +59,7 @@ get_instr_size(const std::string& dpu_file) {
   }
   size_t size = 0;
   std::string line;
-  while (getline(file, line)) {
+  while (std::getline(file, line)) {
     if (line.at(0) != '#') {
       size++;
     }

--- a/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.cpp
@@ -25,7 +25,7 @@ TestDF_bandwidth::TestDF_bandwidth()
   : TestRunner("df-bw", 
                 "Run bandwidth test on data fabric")
                 {
-                  m_dpu_name = "df_bw.txt";
+                  m_dpu_name = "df_bw_dpu.txt";
                 }
 
 namespace {

--- a/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.cpp
@@ -19,7 +19,10 @@ static constexpr size_t word_count = buffer_size/4;
 // ----- C L A S S   M E T H O D S -------------------------------------------
 TestDF_bandwidth::TestDF_bandwidth()
   : TestRunner("df-bw", 
-                "Run bandwidth test on data fabric"){}
+                "Run bandwidth test on data fabric")
+                {
+                  m_dpu_name = "df_bw.txt";
+                }
 
 namespace {
 
@@ -122,7 +125,7 @@ TestDF_bandwidth::run(std::shared_ptr<xrt_core::device> dev)
   // Find DPU instruction file
   std::string dpu_instr;
   try {
-    dpu_instr = findDPUPath(dev, ptree);
+    dpu_instr = findDPUPath(dev, m_dpu_name);
   }
   catch(const std::exception& ex) {
     logger(ptree, "Error", ex.what());

--- a/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.h
+++ b/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.h
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+
+#ifndef __TestDF_bandwidth_h_
+#define __TestDF_bandwidth_h_
+
+#include "tools/common/TestRunner.h"
+#include "xrt/xrt_device.h"
+
+class TestDF_bandwidth : public TestRunner {
+  public:
+    boost::property_tree::ptree run(std::shared_ptr<xrt_core::device> dev);
+
+  public:
+    TestDF_bandwidth();
+};
+
+#endif

--- a/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.h
+++ b/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.h
@@ -13,6 +13,10 @@ class TestDF_bandwidth : public TestRunner {
 
   public:
     TestDF_bandwidth();
+
+  //variables
+  private:
+    std::string m_dpu_name;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -33,6 +33,7 @@
 #include "tools/common/tests/TestPsPlVerify.h"
 #include "tools/common/tests/TestPsVerify.h"
 #include "tools/common/tests/TestPsIops.h"
+#include "tools/common/tests/TestDF_bandwidth.h"
 namespace XBU = XBUtilities;
 
 // 3rd Party Library - Include Files
@@ -96,7 +97,8 @@ std::vector<std::shared_ptr<TestRunner>> testSuite = {
   std::make_shared<TestAiePs>(),
   std::make_shared<TestPsPlVerify>(),
   std::make_shared<TestPsVerify>(),
-  std::make_shared<TestPsIops>()
+  std::make_shared<TestPsIops>(),
+  std::make_shared<TestDF_bandwidth>()
 };
 
 /*
@@ -140,7 +142,7 @@ pretty_print_test_run(const boost::property_tree::ptree& test,
   // if supported and xclbin/testcase: verbose
   // if not supported: verbose
   auto redirect_log = [&](const std::string& tag, const std::string& log_str) {
-    std::vector<std::string> verbose_tags = {"Xclbin", "Testcase"};
+    std::vector<std::string> verbose_tags = {"Xclbin", "Testcase", "DPU-Sequence"};
     if (boost::equals(_status, test_token_skipped) || (std::find(verbose_tags.begin(), verbose_tags.end(), tag) != verbose_tags.end())) {
       if (XBU::getVerbose())
         XBU::message(log_str, false, _ostream);

--- a/src/runtime_src/core/tools/xbutil2/xbutil.cpp
+++ b/src/runtime_src/core/tools/xbutil2/xbutil.cpp
@@ -62,7 +62,7 @@ R"(
     }]
   },{
     "validate": [{
-      "test": ["verify"]
+      "test": ["verify", "df-bw"]
     }]
   }]
 }]


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Added first benchmark test - df bandwidth

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
tested on windows:
```
>xbutil validate -d 00c3:00:01.1 -r df-bw
------------------------------------------------------------
                        EARLY ACCESS
        This release of xbutil contains early access
         experimental features which may have bugs.
------------------------------------------------------------
Validate Device           : [00c3:00:01.1]
    Platform              : RyzenAI-Phoenix
    SC Version            :
    Platform ID           : 0x0
-------------------------------------------------------------------------------
Verbose: Enabling Verbosity
Test 1 [00c3:00:01.1]     : df-bw
    Description           : Run bandwidth test on data fabric
    Xclbin                : C:\Windows\System32\DriverStore\FileRepository\ipukmddrv.inf_amd64_9daec39ccef14b08\validate_phx.xclbin
    Details               : Kernel name is 'DPU_PDI_0'
    DPU-Sequence          : C:\Windows\System32\DriverStore\FileRepository\ipukmddrv.inf_amd64_9daec39ccef14b08\DPU_Sequence\df_bw_dpu.txt
    Details               : Total duration: '0.312758's
                            Average bandwidth per shim DMA: '3.197358' GB/s
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Validation completed
```

#### Documentation impact (if any)
