### PR TITLE
Remove multiple printout of early access message

### DIFF
--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -387,7 +387,7 @@ XBUtilities::collect_devices( const std::set<std::string> &_deviceBDFs,
   }
 
   std::shared_ptr<xrt_core::device>
-  XBUtilities::get_device( const std::string &deviceBDF, bool in_user_domain)
+  XBUtilities::get_device( const std::string &deviceBDF, bool in_user_domain, bool print_warning)
   {
     // -- If the deviceBDF is empty then do nothing
     if (deviceBDF.empty())
@@ -405,7 +405,7 @@ XBUtilities::collect_devices( const std::set<std::string> &_deviceBDFs,
       check_versal_boot(device);
 
     const std::string device_name = xrt_core::device_query_default<xrt_core::query::rom_vbnv>(device, "");
-    if (device_name.find("Ryzen") != std::string::npos) {
+    if (device_name.find("Ryzen") != std::string::npos && print_warning) {
       std::cout << "------------------------------------------------------------\n";
       std::cout << "                        EARLY ACCESS                        \n";
       std::cout << "        This release of xbutil contains early access        \n";
@@ -436,7 +436,7 @@ XBUtilities::get_device_class(const std::string &deviceBDF, bool in_user_domain)
   if (deviceBDF.empty()) 
     return tempDeviceMapping("");
 
-  std::shared_ptr<xrt_core::device> device = get_device(boost::algorithm::to_lower_copy(deviceBDF), in_user_domain);
+  std::shared_ptr<xrt_core::device> device = get_device(boost::algorithm::to_lower_copy(deviceBDF), in_user_domain, false);
   return tempDeviceMapping(xrt_core::device_query_default<xrt_core::query::rom_vbnv>(device, ""));
 }
 

--- a/src/runtime_src/core/tools/common/XBUtilities.h
+++ b/src/runtime_src/core/tools/common/XBUtilities.h
@@ -53,7 +53,7 @@ namespace XBUtilities {
                         bool _inUserDomain,
                         xrt_core::device_collection &_deviceCollection);
 
-  std::shared_ptr<xrt_core::device> get_device (const std::string& deviceBDF, bool in_user_domain);
+  std::shared_ptr<xrt_core::device> get_device (const std::string& deviceBDF, bool in_user_domain, bool print_warning = true);
 
   std::string get_device_class(const std::string& deviceBDF, bool in_user_domain);
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
When testing on an AIE system the early access Ryzen message appears more than once. It should only print once!

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Combination of two PRs to create the issue. https://github.com/Xilinx/XRT/pull/7766 and https://github.com/Xilinx/XRT/pull/7754. Issue only occurred when both appeared together on an AIE machine!

#### How problem was solved, alternative solutions (if any) and why they were rejected
When getting the device add a flag to not printout the warning message.

#### Risks (if any) associated the changes in the commit
None.

#### What has been tested and how, request additional testing if necessary
Ubuntu with Alveo
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ xbutil validate -d -r verify
WARNING: Unexpected xocl version (2.16.0) was found. Expected 2.17.0, to match XRT tools.
Validate Device           : [0000:04:00.1]
    Platform              : xilinx_u55c_gen3x16_xdma_base_3
    SC Version            : 7.1.22
    Platform ID           : 97088961-FEAE-DA91-52A2-1D9DFD63CCEF
-------------------------------------------------------------------------------
Verbose: Enabling Verbosity
Test 1 [0000:04:00.1]     : verify
    Description           : Run 'Hello World' kernel test
    Xclbin                : /opt/xilinx/firmware/u55c/gen3x16-xdma/base/test
    Testcase              : /opt/xilinx/xrt/test/validate.exe
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Validation completed
```
Windows
```
PS C:\Users\Administrator\Desktop\xrt> .\xbutil validate -d -r verify
------------------------------------------------------------
                        EARLY ACCESS
        This release of xbutil contains early access
         experimental features which may have bugs.
------------------------------------------------------------
Validate Device           : [00c3:00:01.1]
    Platform              : RyzenAI-Phoenix
    SC Version            :
    Platform ID           : 0x0
-------------------------------------------------------------------------------
Verbose: Enabling Verbosity
Test 1 [00c3:00:01.1]     : verify
    Description           : Run 'Hello World' kernel test
    Xclbin                : C:\Windows\System32\DriverStore\FileRepository\ipukmddrv.inf_amd64_bf1a83090a615044\1x4.xclbin
    Details               : Kernel name is 'DPU_1x4'
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Validation completed
```
#### Documentation impact (if any)
None