### PR TITLE
VTITIS-9990 - Removing boost::filesystem Part1

### DIFF
--- a/src/runtime_src/tools/xclbinutil/CMakeLists.txt
+++ b/src/runtime_src/tools/xclbinutil/CMakeLists.txt
@@ -173,7 +173,7 @@ if (GTEST_FOUND)
   add_executable(${UNIT_TEST_NAME} ${XCLBINTEST_SRCS})
 
   if(WIN32)
-    target_link_libraries(${UNIT_TEST_NAME} PRIVATE Boost::filesystem Boost::program_options Boost::system )
+    target_link_libraries(${UNIT_TEST_NAME} PRIVATE Boost::program_options Boost::system )
     target_link_libraries(${UNIT_TEST_NAME} PRIVATE ${GTEST_BOTH_LIBRARIES})
   else()
     target_link_libraries(${UNIT_TEST_NAME} PRIVATE ${Boost_LIBRARIES} ${GTEST_BOTH_LIBRARIES} pthread crypto)

--- a/src/runtime_src/tools/xclbinutil/ElfUtilities.cxx
+++ b/src/runtime_src/tools/xclbinutil/ElfUtilities.cxx
@@ -36,7 +36,7 @@ namespace XUtil = XclBinUtilities;
 static
 auto findExecutablePath(const std::string& executable)
 {
-  boost::filesystem::path executablePath;
+  std::filesystem::path executablePath;
 
 #if 0                       // Only enabled for the Vitis version of xclbinutil
   // -- Check to see if XILINX_VITIS has been set
@@ -46,7 +46,7 @@ auto findExecutablePath(const std::string& executable)
     executablePath = xilinxVitisEnv;
     executablePath = executablePath / "aietools" / "tps" / "lnx64" / "gcc" / "bin" / executable;
     XUtil::TRACE("Step 1: Looking for executable at: '" + executablePath.string() + "'");
-    if (!boost::filesystem::exists(executablePath)) {
+    if (!std::filesystem::exists(executablePath)) {
       executablePath = "";           // Executable doesn't exist
       XUtil::TRACE("Not found");
     }
@@ -57,8 +57,9 @@ auto findExecutablePath(const std::string& executable)
   // -- Check the path
   if (executablePath.string().empty()) {
     XUtil::TRACE("Step 2: Looking for executable path");
-    executablePath = boost::process::search_path(executable);
-    if (!boost::filesystem::exists(executablePath))
+    auto path = boost::process::search_path(executable);
+    executablePath = path.string();
+    if (!std::filesystem::exists(executablePath))
       XUtil::TRACE("Not found");
 
   }
@@ -66,7 +67,7 @@ auto findExecutablePath(const std::string& executable)
 
   // -- Default path /usr/bin
   if (executablePath.string().empty())
-    executablePath = boost::filesystem::path("/usr") / "bin" / executable;
+    executablePath = std::filesystem::path("/usr") / "bin" / executable;
 
   return executablePath;
 }

--- a/src/runtime_src/tools/xclbinutil/SectionAIEPartition.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionAIEPartition.cxx
@@ -159,11 +159,11 @@ process_PDI_uuid(const boost::property_tree::ptree& ptPDI,
 
 static void
 read_file_into_buffer(const std::string& fileName,
-                      const boost::filesystem::path& fromRelativeDir,
+                      const std::filesystem::path& fromRelativeDir,
                       std::vector<char>& buffer)
 {
   // Build the path to our file of interest
-  boost::filesystem::path filePath = fileName;
+  std::filesystem::path filePath = fileName;
 
   if (filePath.is_relative()) {
     filePath = fromRelativeDir;
@@ -195,7 +195,7 @@ read_file_into_buffer(const std::string& fileName,
 
 static void
 process_PDI_file(const boost::property_tree::ptree& ptAIEPartitionPDI,
-                 const boost::filesystem::path& relativeFromDir,
+                 const std::filesystem::path& relativeFromDir,
                  aie_pdi& aiePartitionPDI,
                  SectionHeap& heap)
 {
@@ -314,7 +314,7 @@ process_PDI_cdo_groups(const boost::property_tree::ptree& ptAIEPartitionPDI,
 
 static void
 process_PDIs(const boost::property_tree::ptree& ptAIEPartition,
-             const boost::filesystem::path& relativeFromDir,
+             const std::filesystem::path& relativeFromDir,
              aie_partition& aiePartitionHdr,
              SectionHeap& heap)
 {
@@ -387,7 +387,7 @@ process_partition_info(const boost::property_tree::ptree& ptAIEPartition,
 
 static void
 createAIEPartitionImage(const std::string& sectionIndexName,
-                        const boost::filesystem::path& relativeFromDir,
+                        const std::filesystem::path& relativeFromDir,
                         std::istream& iStream,
                         std::ostringstream& osBuffer)
 {
@@ -454,7 +454,7 @@ SectionAIEPartition::readSubPayload(const char* pOrigDataSection,
 
   // Get the JSON's file parent directory.  This is used later to any
   // relative PDI images that might need need to be read in.
-  boost::filesystem::path p(getPathAndName());
+  std::filesystem::path p(getPathAndName());
   const auto relativeFromDir = p.parent_path();
 
   createAIEPartitionImage(getSectionIndexName(), relativeFromDir, iStream, buffer);
@@ -565,9 +565,9 @@ static void
 write_pdi_image(const char* pBase,
                 const aie_pdi& aiePDI,
                 const std::string& fileName,
-                const boost::filesystem::path& relativeToDir)
+                const std::filesystem::path& relativeToDir)
 {
-  boost::filesystem::path filePath = relativeToDir;
+  std::filesystem::path filePath = relativeToDir;
   filePath /= fileName;
 
   XUtil::TRACE(boost::format("Creating PDI Image: %s") % filePath.string());
@@ -585,7 +585,7 @@ write_pdi_image(const char* pBase,
 // -------------------------------------------------------------------------
 static void
 populate_PDIs(const char* pBase,
-              const boost::filesystem::path& relativeToDir,
+              const std::filesystem::path& relativeToDir,
               const aie_partition& aiePartition,
               boost::property_tree::ptree& ptAiePartition)
 {
@@ -620,7 +620,7 @@ populate_PDIs(const char* pBase,
 static void
 writeAIEPartitionImage(const char* pBuffer,
                        unsigned int bufferSize,
-                       const boost::filesystem::path& relativeToDir,
+                       const std::filesystem::path& relativeToDir,
                        std::ostream& oStream)
 {
   XUtil::TRACE("AIE_PARTITION : Creating JSON IMAGE");
@@ -681,7 +681,7 @@ SectionAIEPartition::writeSubPayload(const std::string& sSubSectionName,
     throw std::runtime_error(errMsg);
   }
 
-  boost::filesystem::path p(getPathAndName());
+  std::filesystem::path p(getPathAndName());
   const auto relativeToDir = p.parent_path();
 
   writeAIEPartitionImage(m_pBuffer, m_bufferSize, relativeToDir, oStream);

--- a/src/runtime_src/tools/xclbinutil/SectionSmartNic.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionSmartNic.cxx
@@ -25,10 +25,10 @@
 #include "ResourcesSmartNic.h"
 #include "XclBinUtilities.h"
 #include <boost/algorithm/hex.hpp>
-#include <boost/filesystem.hpp>
 #include <boost/format.hpp>
 #include <boost/functional/factory.hpp>
 #include <boost/property_tree/json_parser.hpp>
+#include <filesystem>
 #include <fstream>
 #include <rapidjson/stringbuffer.h>
 #include <rapidjson/writer.h>
@@ -95,7 +95,7 @@ read_file_into_buffer(const std::string& fileName,
                       std::vector<char>& buffer)
 {
   // Build the path to our file of interest
-  boost::filesystem::path filePath = fileName;
+  std::filesystem::path filePath = fileName;
 
   if (filePath.is_relative()) {
     filePath = fromRelativeDir;
@@ -265,7 +265,7 @@ SectionSmartNic::marshalFromJSON(const boost::property_tree::ptree& _ptSection,
   XUtil::validate_against_schema(nodeName, document, getSmartNicSchema());
 
   // -- Read in the byte code
-  boost::filesystem::path p(getPathAndName());
+  std::filesystem::path p(getPathAndName());
   std::string fromRelativeDir = p.parent_path().string();
   readAndTransposeByteFiles(document, keyTypeCollection, fromRelativeDir);
 

--- a/src/runtime_src/tools/xclbinutil/XclBinClass.cxx
+++ b/src/runtime_src/tools/xclbinutil/XclBinClass.cxx
@@ -27,11 +27,11 @@
 #include "XclBinUtilities.h"
 #include <algorithm>
 #include <boost/algorithm/string.hpp>
-#include <boost/filesystem.hpp>
 #include <boost/format.hpp>
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/uuid/uuid.hpp>                  // for uuid
 #include <boost/uuid/uuid_io.hpp>               // for to_string
+#include <filesystem>
 #include <random>
 #include <sstream>
 #include <stdexcept>
@@ -847,7 +847,7 @@ XclBin::replaceSection(ParameterSectionData& _PSD)
 
   updateHeaderFromSection(pSection);
 
-  boost::filesystem::path p(sSectionFileName);
+  std::filesystem::path p(sSectionFileName);
   std::string sBaseName = p.stem().string();
   pSection->setName(sBaseName);
 
@@ -949,7 +949,7 @@ XclBin::addSubSection(ParameterSectionData& _PSD)
       throw std::runtime_error(boost::str(errMsg));
     }
 
-    boost::filesystem::path p(_PSD.getFile());
+    std::filesystem::path p(_PSD.getFile());
     std::string sBaseName = p.stem().string();
     pSection->setName(sBaseName);
   }
@@ -1045,7 +1045,7 @@ XclBin::addSection(ParameterSectionData& _PSD)
   pSection->readPayload(iSectionFile, _PSD.getFormatType());
 
   // Post-cleanup
-  boost::filesystem::path p(sSectionFileName);
+  std::filesystem::path p(sSectionFileName);
   std::string sBaseName = p.stem().string();
   pSection->setName(sBaseName);
 

--- a/src/runtime_src/tools/xclbinutil/XclBinUtilMain.cxx
+++ b/src/runtime_src/tools/xclbinutil/XclBinUtilMain.cxx
@@ -28,11 +28,11 @@
 
 // 3rd Party Library - Include Files
 #include <boost/algorithm/string.hpp>
-#include <boost/filesystem.hpp>
 #include <boost/program_options.hpp>
 #include <stdexcept>
 
 // System - Include Files
+#include <filesystem>
 #include <iostream>
 #include <set>
 #include <string>
@@ -56,22 +56,22 @@ void drcCheckFiles(const std::vector<std::string> & _inputFiles,
    std::set<std::string> normalizedInputFiles;
 
    for( auto file : _inputFiles) {
-     if ( !boost::filesystem::exists(file)) {
+     if ( !std::filesystem::exists(file)) {
        std::string errMsg = "ERROR: The following input file does not exist: " + file;
        throw std::runtime_error(errMsg);
      }
-     boost::filesystem::path filePath(file);
+     std::filesystem::path filePath(file);
      normalizedInputFiles.insert(canonical(filePath).string());
    }
 
    std::vector<std::string> normalizedOutputFiles;
    for ( auto file : _outputFiles) {
-     if ( boost::filesystem::exists(file)) {
+     if ( std::filesystem::exists(file)) {
        if (_bForce == false) {
          std::string errMsg = "ERROR: The following output file already exists on disk (use the force option to overwrite): " + file;
          throw std::runtime_error(errMsg);
        } else {
-         boost::filesystem::path filePath(file);
+         std::filesystem::path filePath(file);
          normalizedOutputFiles.push_back(canonical(filePath).string());
        }
      }

--- a/src/runtime_src/tools/xclbinutil/XclBinUtilities.cxx
+++ b/src/runtime_src/tools/xclbinutil/XclBinUtilities.cxx
@@ -25,6 +25,7 @@
 #include <boost/uuid/uuid.hpp>          // for uuid
 #include <boost/uuid/uuid_io.hpp>       // for to_string
 #include <boost/version.hpp>
+#include <filesystem>
 #include <fstream>
 #include <inttypes.h>
 #include <iomanip>
@@ -1009,7 +1010,7 @@ XclBinUtilities::createMemoryBankGrouping(XclBin & xclbin)
 
 #if (BOOST_VERSION >= 106400)
 int 
-XclBinUtilities::exec(const boost::filesystem::path &cmd,
+XclBinUtilities::exec(const std::filesystem::path &cmd,
                       const std::vector<std::string> &args,
                       bool bThrow,
                       std::ostringstream & os_stdout,
@@ -1055,7 +1056,7 @@ XclBinUtilities::exec(const boost::filesystem::path &cmd,
 
 #else
 int 
-XclBinUtilities::exec(const boost::filesystem::path &cmd,
+XclBinUtilities::exec(const std::filesystem::path &cmd,
                       const std::vector<std::string> &args,
                       bool bThrow,
                       std::ostringstream & os_stdout,

--- a/src/runtime_src/tools/xclbinutil/XclBinUtilities.h
+++ b/src/runtime_src/tools/xclbinutil/XclBinUtilities.h
@@ -20,9 +20,9 @@
 // Include files
 #include "xclbin.h"
 
-#include <boost/filesystem.hpp>
 #include <boost/format.hpp>
 #include <boost/property_tree/ptree.hpp>
+#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <memory>
@@ -162,7 +162,7 @@ uint64_t stringToUInt64(const std::string& _sInteger, bool _bForceHex = false);
 void printKinds();
 std::string getUUIDAsString( const unsigned char (&_uuid)[16] );
 
-int exec(const boost::filesystem::path &cmd, const std::vector<std::string> &args, bool bThrow, std::ostringstream & os_stdout, std::ostringstream & os_stderr);
+int exec(const std::filesystem::path &cmd, const std::vector<std::string> &args, bool bThrow, std::ostringstream & os_stdout, std::ostringstream & os_stderr);
 void write_htonl(std::ostream & _buf, uint32_t _word32);
 
 void createMemoryBankGrouping(XclBin & xclbin);

--- a/src/runtime_src/tools/xclbinutil/unittests/TestAddSection.cxx
+++ b/src/runtime_src/tools/xclbinutil/unittests/TestAddSection.cxx
@@ -2,10 +2,11 @@
 #include "XclBinClass.h"
 #include "globals.h"
 #include <gtest/gtest.h>
-#include <boost/filesystem.hpp>
 
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/json_parser.hpp>
+
+#include <filesystem>
 
 // Simple Add Test
 TEST(AddSection, AddClearingBitstream) {
@@ -17,7 +18,7 @@ TEST(AddSection, AddClearingBitstream) {
    Section::translateSectionKindStrToKind(sSection, _eKind);
 
    // Get the file of interest
-   boost::filesystem::path sampleXclbin(TestUtilities::getResourceDir());
+   std::filesystem::path sampleXclbin(TestUtilities::getResourceDir());
    sampleXclbin /= "sample_1_2018.2.xclbin";
 
    xclBin.readXclBinBinary(sampleXclbin.string(), false /* bMigrateForward */);
@@ -46,7 +47,7 @@ TEST(AddSection, AddReplaceClearingBitstream) {
    Section::translateSectionKindStrToKind(sSection, _eKind);
 
    // Load the xclbin image of interest
-   boost::filesystem::path sampleXclbin(TestUtilities::getResourceDir());
+   std::filesystem::path sampleXclbin(TestUtilities::getResourceDir());
    sampleXclbin /= "sample_1_2018.2.xclbin";
    xclBin.readXclBinBinary(sampleXclbin.string(), false /* bMigrateForward */);
 
@@ -56,7 +57,7 @@ TEST(AddSection, AddReplaceClearingBitstream) {
 
    {
       // Add dummy unique data to the "clearning bitstream" section
-      boost::filesystem::path uniqueData1(TestUtilities::getResourceDir());
+      std::filesystem::path uniqueData1(TestUtilities::getResourceDir());
       uniqueData1 /= "unique_data1.bin";
 
       const std::string formattedString = sSection + ":RAW:" + uniqueData1.string();
@@ -74,7 +75,7 @@ TEST(AddSection, AddReplaceClearingBitstream) {
 
    {
       // Replace the contents of the CLEARING_BITSTREAM section
-      boost::filesystem::path uniqueData2(TestUtilities::getResourceDir());
+      std::filesystem::path uniqueData2(TestUtilities::getResourceDir());
       uniqueData2 /= "unique_data2.bin";
 
       const std::string formattedString = sSection + ":RAW:" + uniqueData2.string();
@@ -110,7 +111,7 @@ TEST(AddSection, AddMergeIPLayout) {
 
    {
       // Add an IP_LAYOUT section
-      boost::filesystem::path ip_layoutBase(TestUtilities::getResourceDir());
+      std::filesystem::path ip_layoutBase(TestUtilities::getResourceDir());
       ip_layoutBase /= "ip_layout_base.json";
 
       const std::string formattedString = sSection + ":JSON:" + ip_layoutBase.string();
@@ -124,7 +125,7 @@ TEST(AddSection, AddMergeIPLayout) {
 
    {
       // Merge additional data into the IP_LAYOUT seciton
-      boost::filesystem::path ip_layoutMerge(TestUtilities::getResourceDir());
+      std::filesystem::path ip_layoutMerge(TestUtilities::getResourceDir());
       ip_layoutMerge /= "ip_layout_merge.json";
 
       const std::string formattedString = sSection + ":JSON:" + ip_layoutMerge.string();
@@ -150,7 +151,7 @@ TEST(AddSection, AddMergeIPLayout) {
       boost::property_tree::write_json(obuffer, ptOutput);
    }
 
-   boost::filesystem::path ip_layoutMergeExpect(TestUtilities::getResourceDir());
+   std::filesystem::path ip_layoutMergeExpect(TestUtilities::getResourceDir());
    ip_layoutMergeExpect /= "ip_layout_merged_expected.json";
    std::stringstream ebuffer;
    {

--- a/src/runtime_src/tools/xclbinutil/unittests/TestMetaData.cxx
+++ b/src/runtime_src/tools/xclbinutil/unittests/TestMetaData.cxx
@@ -3,8 +3,8 @@
 #include "ParameterSectionData.h"
 #include "globals.h"
 
+#include <filesystem>
 #include <string>
-#include <boost/filesystem.hpp>
 
 TEST(MetaData, AddingMissingFile) {
   XclBin xclBin;
@@ -16,7 +16,7 @@ TEST(MetaData, AddingMissingFile) {
 
 TEST(MetaData, AddingValidFile) {
   // Get the file of interest
-  boost::filesystem::path sampleMetadata(TestUtilities::getResourceDir());
+  std::filesystem::path sampleMetadata(TestUtilities::getResourceDir());
   sampleMetadata /= "metadata.json";
 
   const std::string formattedString = std::string("BUILD_METADATA:JSON:") + sampleMetadata.string();

--- a/src/runtime_src/tools/xclbinutil/unittests/TestRemoveSection.cxx
+++ b/src/runtime_src/tools/xclbinutil/unittests/TestRemoveSection.cxx
@@ -4,7 +4,7 @@
 #include "globals.h"
 
 
-#include <boost/filesystem.hpp>
+#include <filesystem>
 
 TEST(RemoveSection, RemoveBitstream) {
    XclBin xclBin;
@@ -15,7 +15,7 @@ TEST(RemoveSection, RemoveBitstream) {
    Section::translateSectionKindStrToKind(sSection, _eKind);
 
    // Get the file of interest
-   boost::filesystem::path sampleXclbin(TestUtilities::getResourceDir());
+   std::filesystem::path sampleXclbin(TestUtilities::getResourceDir());
    sampleXclbin /= "sample_1_2018.2.xclbin";
 
    xclBin.readXclBinBinary(sampleXclbin.string(), false /* bMigrateForward */);

--- a/src/runtime_src/tools/xclbinutil/unittests/TestSerialization.cxx
+++ b/src/runtime_src/tools/xclbinutil/unittests/TestSerialization.cxx
@@ -2,14 +2,14 @@
 #include "ParameterSectionData.h"
 #include "XclBinClass.h"
 
+#include <filesystem>
 #include "globals.h"
-#include <boost/filesystem.hpp>
 
 TEST(Serialization, ReadXclbin_2018_2) {
    XclBin xclBin;
   
    // Get the file of interest
-   boost::filesystem::path sampleXclbin(TestUtilities::getResourceDir());
+   std::filesystem::path sampleXclbin(TestUtilities::getResourceDir());
    sampleXclbin /= "sample_1_2018.2.xclbin";
 
    xclBin.readXclBinBinary(sampleXclbin.string(), false /* bMigrateForward */);
@@ -19,7 +19,7 @@ TEST(Serialization, ReadWriteReadXclbin) {
    XclBin xclBin;
   
    // Get the file of interest
-   boost::filesystem::path sampleXclbin(TestUtilities::getResourceDir());
+   std::filesystem::path sampleXclbin(TestUtilities::getResourceDir());
    sampleXclbin /= ("sample_1_2018.2.xclbin");
   
    xclBin.readXclBinBinary(sampleXclbin.string(), false /* bMigrateForward */);

--- a/src/runtime_src/tools/xclbinutil/unittests/main.cxx
+++ b/src/runtime_src/tools/xclbinutil/unittests/main.cxx
@@ -1,9 +1,9 @@
 #include <gtest/gtest.h>
 #include <boost/program_options.hpp>
-#include <boost/filesystem.hpp>
 
 namespace po = boost::program_options;
 
+#include <filesystem>
 #include <iostream>
 #include "globals.h"
 
@@ -14,7 +14,7 @@ int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv); 
 
   // -- Process the remaining arguments
-  std::string resourceDirectory = boost::filesystem::path(boost::filesystem::current_path()).string();
+  std::string resourceDirectory = std::filesystem::path(std::filesystem::current_path()).string();
   bool bQuiet = false;
 
   po::options_description options("Common Options");

--- a/src/runtime_src/xdp/debug/kernel_debug_manager.cpp
+++ b/src/runtime_src/xdp/debug/kernel_debug_manager.cpp
@@ -17,7 +17,7 @@
 #define XDP_SOURCE
 
 #include <cstdlib>
-#include <boost/filesystem/operations.hpp>
+#include <filesystem>
 #include <fstream>
 #include <sstream>
 #include <cstdio>
@@ -99,14 +99,14 @@ namespace xdp {
   
   bool KernelDebugManager::exists(const char* filename)
   {
-    return boost::filesystem::exists(filename) ;
+    return std::filesystem::exists(filename) ;
   }
 
   void KernelDebugManager::createDirectory(const char* filename)
   {
     // If this succeeds or fails, just return.
     try {
-      boost::filesystem::create_directory(filename) ;
+      std::filesystem::create_directory(filename) ;
     }
     catch (...) {
     }

--- a/src/runtime_src/xocl/CMakeLists.txt
+++ b/src/runtime_src/xocl/CMakeLists.txt
@@ -60,7 +60,6 @@ target_link_libraries(xilinxopencl
   PRIVATE
   xrt++
   xrt_coreutil
-  ${Boost_FILESYSTEM_LIBRARY}
   ${Boost_SYSTEM_LIBRARY}
   )
 
@@ -83,7 +82,6 @@ target_link_libraries(xilinxopencl
   PRIVATE
   xrt++
   xrt_coreutil
-  ${Boost_FILESYSTEM_LIBRARY}
   ${Boost_SYSTEM_LIBRARY}
   dl
   pthread

--- a/src/runtime_src/xocl/api/clCreateKernel.cpp
+++ b/src/runtime_src/xocl/api/clCreateKernel.cpp
@@ -29,11 +29,10 @@
 
 #include <CL/opencl.h>
 
-#include <boost/filesystem/path.hpp>
-#include <boost/filesystem/operations.hpp>
+#include <filesystem>
 #include <fstream>
 
-namespace bfs = boost::filesystem;
+namespace sfs = std::filesystem;
 
 #ifdef _WIN32
 # pragma warning ( disable : 4996 4189 4505 )

--- a/src/runtime_src/xocl/core/platform.cpp
+++ b/src/runtime_src/xocl/core/platform.cpp
@@ -21,8 +21,6 @@
 #include "xocl/xclbin/xclbin.h"
 #include "core/common/api/hw_queue.h"
 
-#include <boost/filesystem/operations.hpp>
-#include <boost/filesystem/path.hpp>
 #include <fstream>
 #include <iostream>
 #include <cassert>

--- a/src/runtime_src/xocl/core/program.cpp
+++ b/src/runtime_src/xocl/core/program.cpp
@@ -10,7 +10,6 @@
 
 #include "xocl/api/plugin/xdp/profile_v2.h"
 
-#include <boost/filesystem/operations.hpp>
 #include <vector>
 #include <iostream>
 #include <fstream>

--- a/src/runtime_src/xrt/CMakeLists.txt
+++ b/src/runtime_src/xrt/CMakeLists.txt
@@ -55,7 +55,6 @@ add_library(xrt++_static STATIC
 target_link_libraries(xrt++
   PRIVATE
   xrt_coreutil
-  ${Boost_FILESYSTEM_LIBRARY}
   ${Boost_SYSTEM_LIBRARY}
   )
 

--- a/src/runtime_src/xrt/device/hal.cpp
+++ b/src/runtime_src/xrt/device/hal.cpp
@@ -18,16 +18,16 @@
 
 #include "core/common/dlfcn.h"
 #include "core/common/device.h"
-#include <boost/filesystem/operations.hpp>
-#include <boost/filesystem/path.hpp>
+
+#include <filesystem>
 
 #ifdef _WIN32
 # pragma warning ( disable : 4996 4706 4505 )
 #endif
 
 namespace hal = xrt_xocl::hal;
+namespace sfs = std::filesystem;
 namespace hal2 = xrt_xocl::hal2;
-namespace bfs = boost::filesystem;
 
 namespace {
 
@@ -48,9 +48,9 @@ emptyOrValue(const char* cstr)
 }
 
 static void
-directoryOrError(const bfs::path& path)
+directoryOrError(const sfs::path& path)
 {
-  if (!bfs::is_directory(path))
+  if (!sfs::is_directory(path))
     throw std::runtime_error("No such directory '" + path.string() + "'");
 }
 
@@ -68,27 +68,27 @@ versionFunc()
   return sVersionFunc;
 }
 
-static boost::filesystem::path&
+static std::filesystem::path&
 dllExt()
 {
 #ifdef _WIN32
-  static boost::filesystem::path sDllExt(".dll");
+  static std::filesystem::path sDllExt(".dll");
 #else
-  static boost::filesystem::path sDllExt(".so.2");
+  static std::filesystem::path sDllExt(".so.2");
 #endif
   return sDllExt;
 }
 
 inline bool
-isDLL(const bfs::path& path)
+isDLL(const sfs::path& path)
 {
-  return (bfs::exists(path)
-          && bfs::is_regular_file(path)
+  return (sfs::exists(path)
+          && sfs::is_regular_file(path)
           && ends_with(path.string(), dllExt().string()));
 }
 
-boost::filesystem::path
-dllpath(const boost::filesystem::path& root, const std::string& libnm)
+std::filesystem::path
+dllpath(const std::filesystem::path& root, const std::string& libnm)
 {
 #ifdef _WIN32
   return root / "bin" / (libnm + dllExt().string());
@@ -195,11 +195,11 @@ loadDevices()
   hal::device_list devices;
 #ifndef XRT_STATIC_BUILD
   // xrt
-  bfs::path xrt(emptyOrValue(getenv("XILINX_XRT")));
+  sfs::path xrt(emptyOrValue(getenv("XILINX_XRT")));
 
 #if defined (__aarch64__) || defined (__arm__)
   if (xrt.empty()) {
-    xrt = bfs::path("/usr");
+    xrt = sfs::path("/usr");
   }
 #endif
 


### PR DESCRIPTION
Problem solved by the commit:
The boost::filesystem removed from the XRT code. All the files will be submitted in 3 commits incrementally.

Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
N/A

How problem was solved, alternative solutions (if any) and why they were rejected
Risks (if any) associated the changes in the commit
None

What has been tested and how, request additional testing if necessary
System Configuration
xbutil examine
  OS Name              : Linux
  Release              : 6.5.0-rc1+
  Version              : #10 SMP PREEMPT_DYNAMIC Wed Aug 16 22:28:12 PDT 2023
  Machine              : x86_64
  CPU Cores            : 16
  Memory               : 63990 MB
  Distribution         : Ubuntu 22.04 LTS
  GLIBC                : 2.35
  Model                : Precision 5820 Tower

XRT
  Version              : 2.17.0
  Branch               : master
  Hash                 : 6e920d646b41b0416c408d896f10668f2433592e
  Hash Date            : 2023-10-30 07:36:41
  XOCL                 : 2.16.0, 893580509d3f7b0f1fab5a0da6210c709529a740
  XCLMGMT              : 2.16.0, 893580509d3f7b0f1fab5a0da6210c709529a740

Devices present
BDF             :  Shell                            Logic UUID                            Device ID       Device Ready*
-------------------------------------------------------------------------------------------------------------------------
[0000:04:00.1]  :  xilinx_u55c_gen3x16_xdma_base_3  97088961-FEAE-DA91-52A2-1D9DFD63CCEF  user(inst=129)  Yes