### PR TITLE
Adjust trace points

### DIFF
--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -1032,6 +1032,7 @@ alloc_bo(const device_type& device, size_t sz, xrtBufferFlags flags, xrtMemoryGr
 static std::shared_ptr<xrt::bo_impl>
 alloc_kbuf(const device_type& device, size_t sz, xrtBufferFlags flags, xrtMemoryGroup grp)
 {
+  XRT_TRACE_POINT_SCOPE(xrt_bo_alloc_kbuf);
   auto handle = alloc_bo(device, sz, flags, grp);
   auto boh = std::make_shared<xrt::buffer_kbuf>(device, std::move(handle), sz);
   return boh;
@@ -1040,6 +1041,7 @@ alloc_kbuf(const device_type& device, size_t sz, xrtBufferFlags flags, xrtMemory
 static std::shared_ptr<xrt::bo_impl>
 alloc_ubuf(const device_type& device, void* userptr, size_t sz, xrtBufferFlags flags, xrtMemoryGroup grp)
 {
+  XRT_TRACE_POINT_SCOPE(xrt_bo_alloc_ubuf);
   // On NoDMA platforms a userptr would require userspace management
   // of specified userptr with extra memcpy on sync and copy.  If
   // supported then it would hide inefficient application code, so
@@ -1060,6 +1062,7 @@ alloc_ubuf(const device_type& device, void* userptr, size_t sz, xrtBufferFlags f
 static std::shared_ptr<xrt::bo_impl>
 alloc_hbuf(const device_type& device, xrt_core::aligned_ptr_type&& hbuf, size_t sz, xrtBufferFlags flags, xrtMemoryGroup grp)
 {
+  XRT_TRACE_POINT_SCOPE(xrt_bo_alloc_hbuf);
   auto handle =  alloc_bo(device, hbuf.get(), sz, flags, grp);
   auto boh = std::make_shared<xrt::buffer_hbuf>(device, std::move(handle), sz, std::move(hbuf));
   return boh;
@@ -1068,6 +1071,7 @@ alloc_hbuf(const device_type& device, xrt_core::aligned_ptr_type&& hbuf, size_t 
 static std::shared_ptr<xrt::bo_impl>
 alloc_dbuf(const device_type& device, size_t sz, xrtBufferFlags, xrtMemoryGroup grp)
 {
+  XRT_TRACE_POINT_SCOPE(xrt_bo_alloc_dbuf);
   auto handle = alloc_bo(device, sz, XCL_BO_FLAGS_DEV_ONLY, grp);
   auto boh = std::make_shared<xrt::buffer_dbuf>(device, std::move(handle), sz);
   return boh;
@@ -1076,6 +1080,7 @@ alloc_dbuf(const device_type& device, size_t sz, xrtBufferFlags, xrtMemoryGroup 
 static std::shared_ptr<xrt::bo_impl>
 alloc_nodma(const device_type& device, size_t sz, xrtBufferFlags, xrtMemoryGroup grp)
 {
+  XRT_TRACE_POINT_SCOPE(xrt_bo_alloc_nodma);
   constexpr size_t align = 64;
   if (sz % align)
     throw xrt_core::error(EINVAL, "Invalid buffer size '" + std::to_string(sz) +
@@ -1090,7 +1095,6 @@ alloc_nodma(const device_type& device, size_t sz, xrtBufferFlags, xrtMemoryGroup
 static std::shared_ptr<xrt::bo_impl>
 alloc(const device_type& device, size_t sz, xrtBufferFlags flags, xrtMemoryGroup grp)
 {
-  XRT_TRACE_POINT_SCOPE(xrt_bo_alloc);
   xcl_bo_flags xflags{flags};
   auto type = xflags.flags & ~XRT_BO_FLAGS_MEMIDX_MASK;
   switch (type) {
@@ -1121,6 +1125,7 @@ alloc(const device_type& device, size_t sz, xrtBufferFlags flags, xrtMemoryGroup
 static std::shared_ptr<xrt::bo_impl>
 alloc_xbuf(const device_type& device, xcl_buffer_handle xhdl)
 {
+  XRT_TRACE_POINT_SCOPE(xrt_bo_alloc_xbuf);
   return std::make_shared<xrt::buffer_xbuf>(device, xhdl);
 }
 
@@ -1156,6 +1161,7 @@ alloc_sub(const std::shared_ptr<xrt::bo_impl>& parent, size_t size, size_t offse
 static std::shared_ptr<xrt::bo_impl>
 alloc_clone(const std::shared_ptr<xrt::bo_impl>& src, xrt::memory_group grp)
 {
+  XRT_TRACE_POINT_SCOPE(xrt_bo_alloc_clone);
   // Same device and flags as src bo
   auto device = src->get_device();
   auto xflags = static_cast<xrtBufferFlags>(src->get_flags());

--- a/src/runtime_src/core/common/api/xrt_hw_context.cpp
+++ b/src/runtime_src/core/common/api/xrt_hw_context.cpp
@@ -67,6 +67,9 @@ public:
     // shared pointer must already exist to call get_shared_ptr(),
     // which is not true at that time.
     xrt_core::xdp::finish_flush_device(this);
+
+    // Reset within scope of dtor for trace point to measure time to reset
+    m_hdl.reset(); 
   }
 
   void


### PR DESCRIPTION
#### Problem solved by the commit
Adjust trace points for buffer object creation and hwctx destruction.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Trace points were missing for BOs and for hwctx did not include the destructin of the underlying hardware context.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Destruction of XRT API implementation classes is still not entirely correct for many objects as shim handles often are managed by smart pointers without any explicit destructor at xrt coreutil level to account for the time to destroy the handle itself.

If tracing through destruction at xrt_core level is necessary, then tracepoints should be inserted in shim.
