### PR TITLE
VTITIS-9990 - Removing boost::filesystem P2

### DIFF
--- a/src/runtime_src/core/edge/common_em/CMakeLists.txt
+++ b/src/runtime_src/core/edge/common_em/CMakeLists.txt
@@ -17,7 +17,6 @@ PROTOBUF_GENERATE_CPP(ProtoSources ProtoHeaders ${PROTO_SRC_FILES})
 
 include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}
-  ${BOOST_FILESYSTEM_INCLUDE_DIRS}
   ${BOOST_SYSTEM_INCLUDE_DIRS}
   )
 
@@ -49,7 +48,6 @@ set_target_properties(common_em PROPERTIES VERSION ${XRT_VERSION_STRING}
 
 target_link_libraries(common_em
   PRIVATE
-  ${Boost_FILESYSTEM_LIBRARY}
   ${Boost_SYSTEM_LIBRARY}
   ${PROTOBUF_LIBRARY}
   xrt_coreutil

--- a/src/runtime_src/core/edge/common_em/system_utils.cxx
+++ b/src/runtime_src/core/edge/common_em/system_utils.cxx
@@ -29,18 +29,18 @@ namespace systemUtil {
       case CREATE :
         {
             operationStr = "CREATE";
-          if (boost::filesystem::exists(operand1) == false)
+          if (std::filesystem::exists(operand1) == false)
           {
-            boost::filesystem::create_directories(operand1);
+            std::filesystem::create_directories(operand1);
           }
           break;
         }
       case REMOVE :
         {
             operationStr = "REMOVE";
-          if (boost::filesystem::exists(operand1) )
+          if (std::filesystem::exists(operand1) )
           {
-            boost::filesystem::remove_all(operand1);
+            std::filesystem::remove_all(operand1);
           }
           break;
         }
@@ -49,7 +49,7 @@ namespace systemUtil {
             operationStr = "COPY";
           std::stringstream copyCommand;
           copyCommand <<"cp "<<operand1<<" "<<operand2;
-          if (boost::filesystem::exists(operand1) )
+          if (std::filesystem::exists(operand1) )
           {
             int status = system(copyCommand.str().c_str());
               printErrorMessage(copyCommand.str(),status, LineNo);
@@ -61,7 +61,7 @@ namespace systemUtil {
             operationStr = "APPEND";
           std::stringstream appendCommand;
           appendCommand <<"cat "<<operand1<<">> "<<operand2;
-          if (boost::filesystem::exists(operand1) )
+          if (std::filesystem::exists(operand1) )
           {
             int status = system(appendCommand.str().c_str());
               printErrorMessage(appendCommand.str(),status, LineNo);

--- a/src/runtime_src/core/edge/common_em/system_utils.h
+++ b/src/runtime_src/core/edge/common_em/system_utils.h
@@ -5,6 +5,7 @@
 
 #ifndef __SYSTEM_UTILS_H__
 #define __SYSTEM_UTILS_H__
+#include <filesystem>
 #include <iostream>
 #include <sstream>
 #include <stdio.h>
@@ -12,9 +13,6 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
-
-#include <boost/filesystem/operations.hpp>
-#include <boost/filesystem/path.hpp>
 
 namespace systemUtil {
   

--- a/src/runtime_src/core/edge/hw_emu/CMakeLists.txt
+++ b/src/runtime_src/core/edge/hw_emu/CMakeLists.txt
@@ -11,7 +11,6 @@ include_directories(
   ${EM_SRC_DIR}
   ${DRM_INCLUDE_DIRS}
   ${COMMON_EM_SRC_DIR}
-  ${BOOST_FILESYSTEM_INCLUDE_DIRS}
   ${BOOST_SYSTEM_INCLUDE_DIRS}
   ${CMAKE_BINARY_DIR} # includes version.h
   )
@@ -84,7 +83,6 @@ if (DEFINED XRT_AIE_BUILD)
     rt
     dl
     uuid
-    ${Boost_FILESYSTEM_LIBRARY}
     ${Boost_SYSTEM_LIBRARY}
     xaiengine
     )
@@ -96,7 +94,6 @@ else()
     rt
     dl
     uuid
-    ${Boost_FILESYSTEM_LIBRARY}
     ${Boost_SYSTEM_LIBRARY}
   )
 endif()

--- a/src/runtime_src/core/edge/ps_kernels/xrt/instance_query/CMakeLists.txt
+++ b/src/runtime_src/core/edge/ps_kernels/xrt/instance_query/CMakeLists.txt
@@ -14,7 +14,6 @@ set_target_properties(instance_query PROPERTIES
 
 target_link_libraries(instance_query
   PRIVATE
-  ${Boost_FILESYSTEM_LIBRARY}
   )
 
 install (TARGETS instance_query 

--- a/src/runtime_src/core/edge/ps_kernels/xrt/instance_query/instance_query.cpp
+++ b/src/runtime_src/core/edge/ps_kernels/xrt/instance_query/instance_query.cpp
@@ -3,6 +3,7 @@
 #include "xrt/xrt_kernel.h"
 
 #include <cstring>
+#include <filesystem>
 #include <fstream>
 #include <map>
 #include <set>
@@ -14,7 +15,6 @@
 #include <vector>
 
 #include <boost/algorithm/string.hpp>
-#include <boost/filesystem.hpp>
 #include <boost/format.hpp>
 #include <boost/property_tree/ini_parser.hpp>
 #include <boost/property_tree/json_parser.hpp>
@@ -242,14 +242,14 @@ get_ps_kernel_data( char *output,
   openlog("new_kernel_source", LOG_PID | LOG_CONS | LOG_NDELAY, LOG_NEWS);
   log_info("Stared new kernel\n", enable_debug);
 
-  boost::filesystem::path p("/sys/devices/platform/ert_hw/");
-  boost::filesystem::directory_iterator dir(p);
+  std::filesystem::path p("/sys/devices/platform/ert_hw/");
+  std::filesystem::directory_iterator dir(p);
   pt::ptree all_data;
   add_schema(all_data);
   get_os_release(all_data);
 
   pt::ptree all_ps_data;
-  while (dir != boost::filesystem::directory_iterator()) {
+  while (dir != std::filesystem::directory_iterator()) {
     // Get a copy of the current directories name.
     // Getting a reference cause a undesired change when the
     // the directory updates

--- a/src/runtime_src/core/edge/skd/CMakeLists.txt
+++ b/src/runtime_src/core/edge/skd/CMakeLists.txt
@@ -6,7 +6,6 @@ pkg_check_modules(LIBFFI REQUIRED libffi)
 find_package(libffi REQUIRED)
 
 include_directories(
-  ${BOOST_FILESYSTEM_INCLUDE_DIRS}
   ${BOOST_SYSTEM_INCLUDE_DIRS}
   ${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_CURRENT_SOURCE_DIR}/../include
@@ -32,7 +31,6 @@ add_dependencies(skd
 
 target_link_libraries(skd
   PRIVATE
-  ${Boost_FILESYSTEM_LIBRARY}
   ${Boost_SYSTEM_LIBRARY}
   xrt_core
   xrt_coreutil

--- a/src/runtime_src/core/edge/skd/xrt_skd.cpp
+++ b/src/runtime_src/core/edge/skd/xrt_skd.cpp
@@ -359,13 +359,13 @@ namespace xrt {
 	  return -EINVAL;
       }
 
-      const boost::filesystem::path path(SOFT_KERNEL_FILE_PATH);
+      const std::filesystem::path path(SOFT_KERNEL_FILE_PATH);
       xrt_core::message::send(severity_level::debug, "SKD", path.string());
 
-      boost::filesystem::create_directories(path);
+      std::filesystem::create_directories(path);
 
       // Check if file already exists and is the same size
-      if(boost::filesystem::exists(m_sk_path) && (boost::filesystem::file_size(m_sk_path) == prop.size)) {
+      if(std::filesystem::exists(m_sk_path) && (std::filesystem::file_size(m_sk_path) == prop.size)) {
 	return 0;
       }
 
@@ -408,7 +408,7 @@ namespace xrt {
    */
   int skd::delete_softkernelfile() const
   {
-    return boost::filesystem::remove(m_sk_path);
+    return std::filesystem::remove(m_sk_path);
   }
 
   // Convert argument to ffi_type 

--- a/src/runtime_src/core/edge/skd/xrt_skd.h
+++ b/src/runtime_src/core/edge/skd/xrt_skd.h
@@ -18,13 +18,13 @@
 #ifndef _XRT_SKD_H_
 #define _XRT_SKD_H_
 
-#include <boost/filesystem.hpp>
 #include <boost/format.hpp>
 #include <chrono>
 #include <cstdarg>
 #include <cstdint>
 #include <dlfcn.h>
 #include <execinfo.h>
+#include <filesystem>
 #include <fstream>
 #include <functional>
 #include <iostream>
@@ -115,7 +115,7 @@ class skd
     xrtDeviceHandle m_xrtdhdl = 0;
     uuid m_xclbin_uuid;
     // Path of PS kernel object file constructed from PS kernel path and PS kernel name
-    const boost::filesystem::path m_sk_path;
+    const std::filesystem::path m_sk_path;
     // PS Kernel instance name
     std::string m_sk_name = "";
     // PS Kernel CU Index assigned from host

--- a/src/runtime_src/core/edge/sw_emu/CMakeLists.txt
+++ b/src/runtime_src/core/edge/sw_emu/CMakeLists.txt
@@ -15,7 +15,6 @@ include_directories(
   ${COMMON_SRC_DIR}
   ${COMMON_EM_SRC_DIR}
   ${COMMON_EM_GEN_DIR}
-  ${BOOST_FILESYSTEM_INCLUDE_DIRS}
   ${BOOST_SYSTEM_INCLUDE_DIRS}
   )
 
@@ -49,7 +48,6 @@ set_target_properties(xrt_swemu PROPERTIES VERSION ${XRT_VERSION_STRING}
 
 target_link_libraries(xrt_swemu
   PRIVATE
-  ${Boost_FILESYSTEM_LIBRARY}
   ${Boost_SYSTEM_LIBRARY}
   ${PROTOBUF_LIBRARY}
   xrt_coreutil

--- a/src/runtime_src/core/edge/sw_emu/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/edge/sw_emu/generic_pcie_hal2/shim.cxx
@@ -530,7 +530,7 @@ namespace xclswemuhal2 {
 
        std::string modelDirectory("");
 
-        if (boost::filesystem::exists(xilinxInstall + "/data/emulation/unified/sw_emu/generic_pcie/model/genericpciemodel"))
+        if (std::filesystem::exists(xilinxInstall + "/data/emulation/unified/sw_emu/generic_pcie/model/genericpciemodel"))
           modelDirectory = xilinxInstall + "/data/emulation/unified/sw_emu/generic_pcie/model/genericpciemodel";
         else
           modelDirectory = xilinxInstall + "/data/emulation/unified/cpu_em/generic_pcie/model/genericpciemodel";

--- a/src/runtime_src/core/edge/user/CMakeLists.txt
+++ b/src/runtime_src/core/edge/user/CMakeLists.txt
@@ -73,7 +73,6 @@ if (DEFINED XRT_AIE_BUILD)
     rt
     dl
     uuid
-    ${Boost_FILESYSTEM_LIBRARY}
     ${Boost_SYSTEM_LIBRARY}
     xaiengine
     )
@@ -85,7 +84,6 @@ else()
     rt
     dl
     uuid
-    ${Boost_FILESYSTEM_LIBRARY}
     ${Boost_SYSTEM_LIBRARY}
     )
 

--- a/src/runtime_src/core/edge/user/aie_sys_parser.cpp
+++ b/src/runtime_src/core/edge/user/aie_sys_parser.cpp
@@ -16,8 +16,9 @@
 
 #include "aie_sys_parser.h"
 #include <boost/format.hpp>
-#include <boost/filesystem.hpp>
 #include <boost/property_tree/json_parser.hpp>
+
+#include <filesystem>
 
 std::fstream aie_sys_parser::sysfs_open_path(const std::string& path,
                                              bool write, bool binary)

--- a/src/runtime_src/core/edge/user/plugin/xdp/hal_api_interface.cpp
+++ b/src/runtime_src/core/edge/user/plugin/xdp/hal_api_interface.cpp
@@ -22,7 +22,7 @@
 
 #include "core/include/xdp/hal_api.h"
 
-namespace bfs = boost::filesystem;
+namespace sfs = std::filesystem;
 
 namespace xdphalinterface {
 

--- a/src/runtime_src/core/edge/user/plugin/xdp/hal_api_interface.h
+++ b/src/runtime_src/core/edge/user/plugin/xdp/hal_api_interface.h
@@ -18,8 +18,7 @@
 #define XDP_PROFILE_HAL_INTERFACE_PLUGIN_H_
 
 #include <atomic>
-#include <boost/filesystem/operations.hpp>
-#include <boost/filesystem/path.hpp>
+#include <filesystem>
 #include <functional>
 #include <iostream>
 #include <mutex>

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -28,12 +28,12 @@
 #include <chrono>
 #include <cstdarg>
 #include <cstring>
+#include <filesystem>
 #include <iostream>
 #include <iomanip>
 #include <thread>
 #include <vector>
 
-#include <boost/filesystem.hpp>
 #include <regex>
 
 #include <fcntl.h>
@@ -549,9 +549,9 @@ libdfxHelper(std::shared_ptr<xrt_core::device> core_dev, std::string& dtbo_path,
   }
   else {
     // bitstream is loaded for first time
-    boost::filesystem::directory_iterator end_itr;
+    std::filesystem::directory_iterator end_itr;
     static const std::regex filter{".*_image_[0-9]+"};
-    for (boost::filesystem::directory_iterator itr( dtbo_dir_path ); itr != end_itr; ++itr) {
+    for (std::filesystem::directory_iterator itr( dtbo_dir_path ); itr != end_itr; ++itr) {
       if (!std::regex_match(itr->path().filename().string(), filter))
         continue;
 
@@ -600,8 +600,8 @@ static void
 libdfxClean(const std::string& file_path)
 {
   try {
-    if (boost::filesystem::exists(boost::filesystem::path(file_path)))
-      boost::filesystem::remove_all(boost::filesystem::path(file_path));
+    if (std::filesystem::exists(std::filesystem::path(file_path)))
+      std::filesystem::remove_all(std::filesystem::path(file_path));
   }
   catch(std::exception& ex) {
     xclLog(XRT_WARNING, "%s: unable to remove '%s' folder",__func__,file_path);
@@ -649,7 +649,7 @@ libdfxLoadAxlf(std::shared_ptr<xrt_core::device> core_dev, const axlf *top,
   }
 
   // save dtbo_path as load is successful
-  dtbo_path = boost::filesystem::path(xclbin_dir_path).filename().string()
+  dtbo_path = std::filesystem::path(xclbin_dir_path).filename().string()
 			+ "_image_" + std::to_string(dtbo_id);
 
   // clean tmp files of libdfx
@@ -663,7 +663,7 @@ libdfxLoadAxlf(std::shared_ptr<xrt_core::device> core_dev, const axlf *top,
   std::string zocl_drm_device;
   while (count++ < timeout_sec) {
     zocl_drm_device = render_dev_dir + get_render_devname();
-    if (boost::filesystem::exists(boost::filesystem::path(zocl_drm_device)))
+    if (std::filesystem::exists(std::filesystem::path(zocl_drm_device)))
       break;
     std::this_thread::sleep_for(std::chrono::seconds(1));
   }
@@ -1918,7 +1918,7 @@ xclProbe()
 
   const std::string zocl_drm_device = "/dev/dri/" + get_render_devname();
   int fd;
-  if (boost::filesystem::exists(zocl_drm_device)) {
+  if (std::filesystem::exists(zocl_drm_device)) {
     fd = open(zocl_drm_device.c_str(), O_RDWR);
     if (fd < 0)
       return 0;

--- a/src/runtime_src/core/edge/user/zynq_dev.cpp
+++ b/src/runtime_src/core/edge/user/zynq_dev.cpp
@@ -17,7 +17,7 @@
 #include <iostream>
 #include <sstream>
 #include <cstring>
-#include <boost/filesystem.hpp>
+#include <filesystem>
 #include <regex>
 #include "zynq_dev.h"
 
@@ -165,13 +165,13 @@ get_render_devname()
     try {
         static const std::regex filter{"platform.*zyxclmm_drm-render"};
 
-        boost::filesystem::directory_iterator end_itr;
-        for (boost::filesystem::directory_iterator itr( render_dev_sym_dir ); itr != end_itr; ++itr) {
+        std::filesystem::directory_iterator end_itr;
+        for (std::filesystem::directory_iterator itr( render_dev_sym_dir ); itr != end_itr; ++itr) {
             if (!std::regex_match(itr->path().filename().string(), filter))
 	        continue;
 
-	    if (boost::filesystem::is_symlink(itr->path()))
-	        render_devname = boost::filesystem::read_symlink(itr->path()).filename().string();
+	    if (std::filesystem::is_symlink(itr->path()))
+	        render_devname = std::filesystem::read_symlink(itr->path()).filename().string();
 
 	    break;
 	}

--- a/src/runtime_src/core/pcie/emulation/common_em/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/emulation/common_em/CMakeLists.txt
@@ -17,7 +17,6 @@ PROTOBUF_GENERATE_CPP(ProtoSources ProtoHeaders ${PROTO_SRC_FILES})
 
 include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}
-  ${BOOST_FILESYSTEM_INCLUDE_DIRS}
   ${BOOST_SYSTEM_INCLUDE_DIRS}
   )
 
@@ -42,7 +41,6 @@ set_target_properties(common_em PROPERTIES VERSION ${XRT_VERSION_STRING}
 
 target_link_libraries(common_em
   PRIVATE
-  ${Boost_FILESYSTEM_LIBRARY}
   ${Boost_SYSTEM_LIBRARY}
   ${PROTOBUF_LIBRARY}
   xrt_coreutil

--- a/src/runtime_src/core/pcie/emulation/common_em/config.cxx
+++ b/src/runtime_src/core/pcie/emulation/common_em/config.cxx
@@ -102,16 +102,16 @@ namespace xclemulation{
     return defaultValue;
   }
 
-  static boost::filesystem::path get_file_absolutepath(const std::string& filename) {
+  static std::filesystem::path get_file_absolutepath(const std::string& filename) {
     
-    boost::filesystem::path exe_parent_path {getExecutablePath()};
+    std::filesystem::path exe_parent_path {getExecutablePath()};
     auto filepath = exe_parent_path / filename;
 
-    if (boost::filesystem::exists(filepath) == false) {
-      auto current_path = boost::filesystem::current_path();
+    if (std::filesystem::exists(filepath) == false) {
+      auto current_path = std::filesystem::current_path();
       filepath = current_path / filename;
-      if (boost::filesystem::exists(filepath) == false)
-        return boost::filesystem::path{};
+      if (std::filesystem::exists(filepath) == false)
+        return std::filesystem::path{};
     }
     return filepath;
 
@@ -400,7 +400,7 @@ namespace xclemulation{
       return pathStr;
     }
 
-    return boost::filesystem::absolute(pathStr.c_str(), absBuildDirStr.c_str()).string();
+    return std::filesystem::absolute(pathStr.c_str()).string();
   }
 
   std::string getExecutablePath()
@@ -423,10 +423,10 @@ namespace xclemulation{
   {
     auto filename{"emconfig.json"};
     auto filepath = get_file_absolutepath(filename);
-    boost::filesystem::path emconfig_env {valueOrEmpty(std::getenv("EMCONFIG_PATH"))};
+    std::filesystem::path emconfig_env {valueOrEmpty(std::getenv("EMCONFIG_PATH"))};
     if (emconfig_env.empty() == false) {
       auto filepath_env_value = emconfig_env / "emconfig.json";
-      if (boost::filesystem::exists(filepath_env_value)) {
+      if (std::filesystem::exists(filepath_env_value)) {
         filepath = filepath_env_value;
       }
     }
@@ -461,7 +461,7 @@ namespace xclemulation{
 
   std::string getEmDebugLogFile()
   {
-    auto self_path = boost::filesystem::current_path();
+    auto self_path = std::filesystem::current_path();
     auto em_debug_file_path = self_path / "emulation_debug.log";
     return em_debug_file_path.string();
   }

--- a/src/runtime_src/core/pcie/emulation/common_em/config.h
+++ b/src/runtime_src/core/pcie/emulation/common_em/config.h
@@ -13,8 +13,6 @@
 #endif
 #include <atomic>
 #include <boost/algorithm/string.hpp>
-#include <boost/filesystem.hpp>
-#include "boost/filesystem/path.hpp"
 #include <boost/foreach.hpp>
 #include <boost/locale.hpp>
 #include <boost/property_tree/ini_parser.hpp>
@@ -22,6 +20,7 @@
 #include <boost/property_tree/ptree.hpp>
 #include <chrono>
 #include <cstring>
+#include <filesystem>
 #include <list>
 #include <map>
 #include <sys/stat.h>
@@ -172,7 +171,7 @@ struct sParseLog
     // mFileName might be created/updated by xsim, check its existence always.
     if (not mFileExists.load())
     {
-      if (boost::filesystem::exists(mFileName))
+      if (std::filesystem::exists(mFileName))
       {
         mFileStream.open(mFileName);
         if (mFileStream.is_open())

--- a/src/runtime_src/core/pcie/emulation/common_em/system_utils.cxx
+++ b/src/runtime_src/core/pcie/emulation/common_em/system_utils.cxx
@@ -29,18 +29,18 @@ namespace systemUtil {
         case CREATE :
           {
             operationStr = "CREATE";
-            if (boost::filesystem::exists(operand1) == false)
+            if (std::filesystem::exists(operand1) == false)
             {
-              boost::filesystem::create_directories(operand1);
+              std::filesystem::create_directories(operand1);
             }
             break;
           }
         case REMOVE :
           {
             operationStr = "REMOVE";
-            if (boost::filesystem::exists(operand1) )
+            if (std::filesystem::exists(operand1) )
             {
-              boost::filesystem::remove_all(operand1);
+              std::filesystem::remove_all(operand1);
             }
             break;
           }
@@ -49,7 +49,7 @@ namespace systemUtil {
             operationStr = "COPY";
             std::stringstream copyCommand;
             copyCommand <<"cp "<<operand1<<" "<<operand2;
-            if (boost::filesystem::exists(operand1) )
+            if (std::filesystem::exists(operand1) )
             {
               int status = system(copyCommand.str().c_str());
               printErrorMessage(copyCommand.str(),status, LineNo);
@@ -61,7 +61,7 @@ namespace systemUtil {
             operationStr = "APPEND";
             std::stringstream appendCommand;
             appendCommand <<"cat "<<operand1<<">> "<<operand2;
-            if (boost::filesystem::exists(operand1) )
+            if (std::filesystem::exists(operand1) )
             {
               int status = system(appendCommand.str().c_str());
               printErrorMessage(appendCommand.str(),status, LineNo);

--- a/src/runtime_src/core/pcie/emulation/common_em/system_utils.h
+++ b/src/runtime_src/core/pcie/emulation/common_em/system_utils.h
@@ -5,6 +5,7 @@
 
 #ifndef __SYSTEM_UTILS_H__
 #define __SYSTEM_UTILS_H__
+#include <filesystem>
 #include <iostream>
 #include <sstream>
 #include <stdio.h>
@@ -13,8 +14,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-#include <boost/filesystem/operations.hpp>
-#include <boost/filesystem/path.hpp>
+
 
 namespace systemUtil {
   

--- a/src/runtime_src/core/pcie/emulation/hw_emu/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/emulation/hw_emu/CMakeLists.txt
@@ -11,7 +11,6 @@ include_directories(
   ${EM_SRC_DIR}
   ${COMMON_EM_SRC_DIR}
   ${COMMON_EM_GEN_DIR}
-  ${BOOST_FILESYSTEM_INCLUDE_DIRS}
   ${BOOST_SYSTEM_INCLUDE_DIRS}
   )
 
@@ -46,7 +45,6 @@ set_target_properties(xrt_hwemu PROPERTIES VERSION ${XRT_VERSION_STRING}
 
 target_link_libraries(xrt_hwemu
   PRIVATE
-  ${Boost_FILESYSTEM_LIBRARY}
   ${Boost_SYSTEM_LIBRARY}
   ${PROTOBUF_LIBRARY}
   xrt_coreutil
@@ -57,7 +55,6 @@ target_link_libraries(xrt_hwemu
 
 target_link_libraries(xrt_hwemu_static
   INTERFACE
-  boost_filesystem
   boost_system
   ${PROTOBUF_LIBRARY}
   xrt_coreutil_static

--- a/src/runtime_src/core/pcie/emulation/hw_emu/alveo_shim/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_emu/alveo_shim/shim.cxx
@@ -19,6 +19,7 @@
 #include <cctype>
 #include <cerrno>
 #include <cstring>
+#include <filesystem>
 #include <fstream>
 #include <mutex>
 #include <set>
@@ -67,7 +68,7 @@ namespace xclhwemhal2 {
     };
 
   namespace pt = boost::property_tree;
-  namespace fs = boost::filesystem;
+  namespace bfs = std::filesystem;
 
   std::map<unsigned int, HwEmShim*> devices;
   std::map<std::string, std::string> HwEmShim::mEnvironmentNameValueMap(xclemulation::getEnvironmentByReadingIni());
@@ -265,7 +266,7 @@ namespace xclhwemhal2 {
     if (pPath)
     {
       std::string deadlockReportFile = simPath + "/kernel_deadlock_diagnosis.rpt";
-      if (boost::filesystem::exists(deadlockReportFile))
+      if (std::filesystem::exists(deadlockReportFile))
       {
         std::string destPath = std::string(path) + "/pl_deadlock_diagnosis.txt";
         systemUtil::makeSystemCall(deadlockReportFile, systemUtil::systemOperation::COPY, destPath, std::to_string(__LINE__));
@@ -729,7 +730,7 @@ namespace xclhwemhal2 {
         sim_path = binaryDirectory + "/behav_waveform/" + simulatorType;
         setSimPath(sim_path);
 
-        if (boost::filesystem::exists(sim_path) != false) {
+        if (std::filesystem::exists(sim_path) != false) {
           waveformDebugfilePath = sim_path + "/waveform_debug_enable.txt";
           if (simulatorType == "xsim") {
             cmdLineOption << " -g --wdb " << wdbFileName << ".wdb"
@@ -743,7 +744,7 @@ namespace xclhwemhal2 {
 
         std::string generatedWcfgFileName = sim_path + "/" + bdName + "_behav.wcfg";
         unsetenv("VITIS_LAUNCH_WAVEFORM_BATCH");
-        if (waveformDebugfilePath != "" && boost::filesystem::exists(waveformDebugfilePath) != false) {
+        if (waveformDebugfilePath != "" && std::filesystem::exists(waveformDebugfilePath) != false) {
           setenv("VITIS_WAVEFORM", generatedWcfgFileName.c_str(), true);
           setenv("VITIS_WAVEFORM_WDB_FILENAME", std::string(wdbFileName + ".wdb").c_str(), true);
         } else {
@@ -784,7 +785,7 @@ namespace xclhwemhal2 {
 
         std::string generatedWcfgFileName = sim_path + "/" + bdName + "_behav.wcfg";
         setenv("VITIS_LAUNCH_WAVEFORM_BATCH", "1", true);
-        if (boost::filesystem::exists(waveformDebugfilePath) != false) {
+        if (std::filesystem::exists(waveformDebugfilePath) != false) {
           setenv("VITIS_WAVEFORM", generatedWcfgFileName.c_str(), true);
           setenv("VITIS_WAVEFORM_WDB_FILENAME", std::string(wdbFileName + ".wdb").c_str(), true);
         } else {
@@ -829,7 +830,7 @@ namespace xclhwemhal2 {
         }
 
         // As gdb feature is unsupported for 2021.1, we removed this cross check. We will re-enable it once we have 2 possibilities
-        /*if (boost::filesystem::exists(sim_path) == false)
+        /*if (std::filesystem::exists(sim_path) == false)
         {
           if (lWaveform == xclemulation::debug_mode::gdb) {
             sim_path = binaryDirectory + "/behav_waveform/" + simulatorType;
@@ -847,7 +848,7 @@ namespace xclhwemhal2 {
             launcherArgs = launcherArgs + cmdLineOption.str();
             std::string generatedWcfgFileName = sim_path + "/" + bdName + "_behav.wcfg";
             setenv("VITIS_LAUNCH_WAVEFORM_BATCH", "1", true);
-            if (boost::filesystem::exists(waveformDebugfilePath) != false) {
+            if (std::filesystem::exists(waveformDebugfilePath) != false) {
               setenv("VITIS_WAVEFORM", generatedWcfgFileName.c_str(), true);
               setenv("VITIS_WAVEFORM_WDB_FILENAME", std::string(wdbFileName + ".wdb").c_str(), true);
             }
@@ -906,7 +907,7 @@ namespace xclhwemhal2 {
     }
 
     //launch simulation
-    if (boost::filesystem::exists(sim_path) == true) {
+    if (std::filesystem::exists(sim_path) == true) {
 #ifndef _WINDOWS
       // TODO: Windows build support
       //   pid_t, fork, chdir, execl is defined in unistd.h
@@ -971,12 +972,12 @@ namespace xclhwemhal2 {
           //Assuming that we will have only one AIE Kernel, need to
           //update this logic when we have suport for multiple AIE Kernels
 
-          if (fs::exists(sim_path + "/emulation_data/libsdf/cfg/aie.sim.config.txt"))
+          if (bfs::exists(sim_path + "/emulation_data/libsdf/cfg/aie.sim.config.txt"))
           {
             launcherArgs += " -emuData " + sim_path + "/emulation_data/libsdf/cfg/aie.sim.config.txt";
             launcherArgs += " -aie-sim-config " + sim_path + "/emulation_data/libsdf/cfg/aie.sim.config.txt";
           }
-          else if (fs::exists(sim_path + "/emulation_data/libadf/cfg/aie.sim.config.txt")) {
+          else if (bfs::exists(sim_path + "/emulation_data/libadf/cfg/aie.sim.config.txt")) {
             launcherArgs += " -emuData " + sim_path + "/emulation_data/libadf/cfg/aie.sim.config.txt";
             launcherArgs += " -aie-sim-config " + sim_path + "/emulation_data/libadf/cfg/aie.sim.config.txt";
           } else {
@@ -984,36 +985,36 @@ namespace xclhwemhal2 {
             launcherArgs += " -aie-sim-config " + sim_path + "/emulation_data/cfg/aie.sim.config.txt";
           }
 
-          if (fs::exists(sim_path + "/emulation_data/BOOT_bh.bin")) {
+          if (bfs::exists(sim_path + "/emulation_data/BOOT_bh.bin")) {
             launcherArgs += " -boot-bh " + sim_path + "/emulation_data/BOOT_bh.bin";
           }
 
-          if (fs::exists(sim_path + "/emulation_data/qemu_ospi.bin")) {
+          if (bfs::exists(sim_path + "/emulation_data/qemu_ospi.bin")) {
             launcherArgs += " -ospi-image " + sim_path + "/emulation_data/qemu_ospi.bin";
           }
 
-          if (fs::exists(sim_path + "/emulation_data/qemu_qspi_low.bin")) {
+          if (bfs::exists(sim_path + "/emulation_data/qemu_qspi_low.bin")) {
             launcherArgs += " -qspi-low-image " + sim_path + "/emulation_data/qemu_qspi_low.bin";
           }
 
-          if (fs::exists(sim_path + "/emulation_data/qemu_qspi_high.bin")) {
+          if (bfs::exists(sim_path + "/emulation_data/qemu_qspi_high.bin")) {
             launcherArgs += " -qspi-high-image " + sim_path + "/emulation_data/qemu_qspi_high.bin";
           }
 
           // V70 support: Setting this option, launch_emulator does not set the NOCSIM_DRAM_FILE file, it auto sets the
           // NOCSIM_MULTI_DRAM_FILE
-          if (fs::exists(sim_path + "/emulation_data/noc_memory_config.txt")) {
+          if (bfs::exists(sim_path + "/emulation_data/noc_memory_config.txt")) {
             launcherArgs += " -noc-memory-config " + sim_path + "/emulation_data/noc_memory_config.txt";
           }
 
-          if (fs::exists(sim_path + "/emulation_data/qemu_args.txt")) {
+          if (bfs::exists(sim_path + "/emulation_data/qemu_args.txt")) {
             launcherArgs += " -qemu-args-file " + sim_path + "/emulation_data/qemu_args.txt";
           }
 
-          if (fs::exists(sim_path + "/emulation_data/pmc_args.txt")) {
+          if (bfs::exists(sim_path + "/emulation_data/pmc_args.txt")) {
             launcherArgs += " -pmc-args-file " + sim_path + "/emulation_data/pmc_args.txt";
           }
-          else if (fs::exists(sim_path + "/emulation_data/pmu_args.txt")) {
+          else if (bfs::exists(sim_path + "/emulation_data/pmu_args.txt")) {
             launcherArgs += " -pmc-args-file " + sim_path + "/emulation_data/pmu_args.txt";
           }
           else {
@@ -1057,7 +1058,7 @@ namespace xclhwemhal2 {
           simMode = launcherArgs.c_str();
 
         //if (!xclemulation::file_exists(sim_file))
-        if (!boost::filesystem::exists(sim_file))
+        if (!std::filesystem::exists(sim_file))
           sim_file = "simulate.sh";
 
         if (mLogStream.is_open() )
@@ -1141,7 +1142,7 @@ namespace xclhwemhal2 {
 
   bool HwEmShim::readEmuSettingsJsonFile(const std::string& emuSettingsFilePath) {
 
-    if (emuSettingsFilePath.empty() || !boost::filesystem::exists(emuSettingsFilePath)) {
+    if (emuSettingsFilePath.empty() || !std::filesystem::exists(emuSettingsFilePath)) {
       return false;
     }
 
@@ -1196,7 +1197,7 @@ namespace xclhwemhal2 {
     if (xclemulation::config::getInstance()->isFastNocDDRAccessEnabled())
     {
       std::string nocMemSpecFilePath = simPath + "/emulation_data/noc_memory_config.txt";
-      if (fs::exists(nocMemSpecFilePath))
+      if (bfs::exists(nocMemSpecFilePath))
         this->mNocFastAccess.init(nocMemSpecFilePath, simPath);
     }
   }
@@ -1225,10 +1226,10 @@ namespace xclhwemhal2 {
 
   void HwEmShim::getDtbs(const std::string& emu_data_path, std::string& qemu_dtb, std::string& pmc_dtb)
   {
-    boost::filesystem::path dts_dir = emu_data_path;
-    boost::filesystem::directory_iterator end_itr;
+    std::filesystem::path dts_dir = emu_data_path;
+    std::filesystem::directory_iterator end_itr;
 
-    for (boost::filesystem::directory_iterator itr(dts_dir); itr != end_itr; ++itr)
+    for (std::filesystem::directory_iterator itr(dts_dir); itr != end_itr; ++itr)
     {
       std::string current_file = itr->path().string();
       std::string file_str = itr->path().filename().string();
@@ -1760,7 +1761,7 @@ namespace xclhwemhal2 {
         // Copy waveform database
         if (lWaveform != xclemulation::debug_mode::off) {
           std::string extension = "wdb";
-          if (boost::filesystem::exists(binaryDirectory+"/msim")) {
+          if (std::filesystem::exists(binaryDirectory+"/msim")) {
             extension = "wlf";
           }
           std::string wdbFileName = binaryDirectory + "/" + fileName + "."+extension;
@@ -2156,22 +2157,22 @@ namespace xclhwemhal2 {
     std::string sim_path4 = binaryDirectory + "/behav_waveform/xcelium";
     std::string sim_path5 = binaryDirectory + "/behav_waveform/vcs";
 
-    if (boost::filesystem::exists(sim_path1) || boost::filesystem::exists(sim_path2)) {
+    if (std::filesystem::exists(sim_path1) || std::filesystem::exists(sim_path2)) {
       simulator = "xsim";
     }
-    else if (boost::filesystem::exists(sim_path3)) {
+    else if (std::filesystem::exists(sim_path3)) {
       simulator = "questa";
     }
-    else if (boost::filesystem::exists(sim_path4)) {
+    else if (std::filesystem::exists(sim_path4)) {
       simulator = "xcelium";
     }
-    else if (boost::filesystem::exists(sim_path5)) {
+    else if (std::filesystem::exists(sim_path5)) {
       simulator = "vcs";
     }
 
-    if (!boost::filesystem::exists(sim_path1) && !boost::filesystem::exists(sim_path2)
-      && !boost::filesystem::exists(sim_path3) && !boost::filesystem::exists(sim_path4)
-      && !boost::filesystem::exists(sim_path5)) {
+    if (!std::filesystem::exists(sim_path1) && !std::filesystem::exists(sim_path2)
+      && !std::filesystem::exists(sim_path3) && !std::filesystem::exists(sim_path4)
+      && !std::filesystem::exists(sim_path5)) {
 
       std::string dMsg = "ERROR: [HW-EMU 11] UNZIP operation failed. Not to able to get the required simulation binaries from xclbin";
       logMessage(dMsg, 0);

--- a/src/runtime_src/core/pcie/emulation/sw_emu/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/emulation/sw_emu/CMakeLists.txt
@@ -10,7 +10,6 @@ include_directories(
   ${EM_SRC_DIR}
   ${COMMON_EM_SRC_DIR}
   ${COMMON_EM_GEN_DIR}
-  ${BOOST_FILESYSTEM_INCLUDE_DIRS}
   ${BOOST_SYSTEM_INCLUDE_DIRS}
   )
 
@@ -42,7 +41,6 @@ set_target_properties(xrt_swemu PROPERTIES VERSION ${XRT_VERSION_STRING}
 
 target_link_libraries(xrt_swemu
   PRIVATE
-  ${Boost_FILESYSTEM_LIBRARY}
   ${Boost_SYSTEM_LIBRARY}
   ${PROTOBUF_LIBRARY}
   xrt_coreutil
@@ -53,7 +51,6 @@ target_link_libraries(xrt_swemu
 
 target_link_libraries(xrt_swemu_static
   INTERFACE
-  boost_filesystem
   boost_system
   ${PROTOBUF_LIBRARY}
   xrt_coreutil_static

--- a/src/runtime_src/core/pcie/emulation/sw_emu/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/sw_emu/generic_pcie_hal2/shim.cxx
@@ -33,7 +33,7 @@ namespace xclswemuhal2
 
   std::map<std::string, std::string> SwEmuShim::mEnvironmentNameValueMap(xclemulation::getEnvironmentByReadingIni());
 
-  namespace bf = boost::filesystem;
+  namespace sf = std::filesystem;
 #define PRINTENDFUNC        \
   if (mLogStream.is_open()) \
     mLogStream << __func__ << " ended " << std::endl;
@@ -433,7 +433,7 @@ namespace xclswemuhal2
 
         std::string modelDirectory("");
 
-        if (boost::filesystem::exists(xilinxInstall + "/data/emulation/unified/sw_emu/generic_pcie/model/genericpciemodel"))
+        if (std::filesystem::exists(xilinxInstall + "/data/emulation/unified/sw_emu/generic_pcie/model/genericpciemodel"))
           modelDirectory = xilinxInstall + "/data/emulation/unified/sw_emu/generic_pcie/model/genericpciemodel";
         else
           modelDirectory = xilinxInstall + "/data/emulation/unified/cpu_em/generic_pcie/model/genericpciemodel";
@@ -564,8 +564,8 @@ namespace xclswemuhal2
 
     //Check if device_process.log already exists. Remove if exists.
     auto extIoTxtFile = getDeviceProcessLogPath();
-    if (boost::filesystem::exists(extIoTxtFile))
-      boost::filesystem::remove(extIoTxtFile);
+    if (std::filesystem::exists(extIoTxtFile))
+      std::filesystem::remove(extIoTxtFile);
 
     if (launchDeviceProcess(debuggable, binaryDirectory) == false)
       return -1;
@@ -774,11 +774,11 @@ namespace xclswemuhal2
     if (isVersal)
     {
       std::string aieLibSimPath = binaryDirectory + "/aie/aie.libsim";
-      bf::path fp(aieLibSimPath);
+      sf::path fp(aieLibSimPath);
 
       // Setting the aiesim_sock to null when we have the aie.libsim which is ideally generated only for the x86sim target
       // This determines the whether we are running the sw_emu interacting with the x86sim process or the aiesim process
-      if (bf::exists(fp) && !bf::is_empty(fp))
+      if (sf::exists(fp) && !sf::is_empty(fp))
         aiesim_sock = nullptr;
       else
         aiesim_sock = new unix_socket("AIESIM_SOCKETID");

--- a/src/runtime_src/core/pcie/emulation/sw_emu/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/pcie/emulation/sw_emu/generic_pcie_hal2/shim.h
@@ -37,6 +37,7 @@
 #include <sys/wait.h>
 
 #include <atomic>
+#include <filesystem>
 #include <thread>
 #include <tuple>
 #include <utility>
@@ -820,7 +821,7 @@ namespace xclswemuhal2
     {
       if (!mFileExists)
       {
-        if (boost::filesystem::exists(mFileName))
+        if (std::filesystem::exists(mFileName))
         {
           file.open(mFileName,std::ios::in);
           if (file.is_open())

--- a/src/runtime_src/core/pcie/linux/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/linux/CMakeLists.txt
@@ -47,7 +47,6 @@ set_target_properties(xrt_core PROPERTIES
 target_link_libraries(xrt_core
   PRIVATE
   xrt_coreutil
-  ${Boost_FILESYSTEM_LIBRARY}
   ${Boost_SYSTEM_LIBRARY}
   pthread
   rt
@@ -63,7 +62,6 @@ target_link_libraries(xrt_core
 target_link_libraries(xrt_core_static
   INTERFACE
   xrt_coreutil_static
-  boost_filesystem
   boost_system
   uuid
   dl

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -19,6 +19,7 @@
 #include "xrt.h"
 
 #include <array>
+#include <filesystem>
 #include <fstream>
 #include <functional>
 #include <iostream>
@@ -30,7 +31,6 @@
 
 #include <boost/algorithm/string.hpp>
 #include <boost/format.hpp>
-#include <boost/filesystem.hpp>
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/tokenizer.hpp>
 
@@ -46,12 +46,12 @@ get_render_value(const std::string& dir)
   static const std::string render_name = "renderD";
   int instance_num = INVALID_ID; // argh, what is this?
 
-  boost::filesystem::path render_dirs(dir);
-  if (!boost::filesystem::is_directory(render_dirs))
+  std::filesystem::path render_dirs(dir);
+  if (!std::filesystem::is_directory(render_dirs))
     return instance_num;
 
-  boost::filesystem::recursive_directory_iterator end_iter;
-  for(boost::filesystem::recursive_directory_iterator iter(render_dirs); iter != end_iter; ++iter) {
+  std::filesystem::recursive_directory_iterator end_iter;
+  for(std::filesystem::recursive_directory_iterator iter(render_dirs); iter != end_iter; ++iter) {
     auto path = iter->path().filename().string();
     if (!path.compare(0, render_name.size(), render_name)) {
       auto sub = path.substr(render_name.size());
@@ -312,15 +312,15 @@ struct sdm_sensor_info
      * hwmon sysfs directory has a sysfs node called "name", and it is decision factor.
      * So, the target hwmon sysfs dir is the one whose name contains target_name.
      */
-    boost::filesystem::path render_dirs(parent_path);
-    if (!boost::filesystem::is_directory(render_dirs))
+    std::filesystem::path render_dirs(parent_path);
+    if (!std::filesystem::is_directory(render_dirs))
       return result_type();
 
     //iterate over list of hwmon syfs directory's directories
-    boost::filesystem::directory_iterator iter(render_dirs);
-    while (iter != boost::filesystem::directory_iterator{})
+    std::filesystem::directory_iterator iter(render_dirs);
+    while (iter != std::filesystem::directory_iterator{})
     {
-      if (!boost::filesystem::is_directory(iter->path()))
+      if (!std::filesystem::is_directory(iter->path()))
       {
         ++iter;
         continue;

--- a/src/runtime_src/core/pcie/linux/pcidev.cpp
+++ b/src/runtime_src/core/pcie/linux/pcidev.cpp
@@ -7,13 +7,11 @@
 
 #include "core/common/utils.h"
 
-#include <boost/filesystem/fstream.hpp>
-#include <boost/filesystem.hpp>
-
 #include <algorithm>
 #include <cassert>
 #include <cstring>
 #include <dirent.h>
+#include <filesystem>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
@@ -30,7 +28,7 @@
 
 namespace {
 
-namespace bfs = boost::filesystem;
+namespace sfs = std::filesystem;
 
 static std::string
 get_name(const std::string& dir, const std::string& subdir)
@@ -699,19 +697,19 @@ int
 get_runtime_active_kids(std::string &pci_bridge_path)
 {
   int curr_act_dev = 0;
-  std::vector<bfs::path> vec{bfs::directory_iterator(pci_bridge_path), bfs::directory_iterator()};
+  std::vector<sfs::path> vec{sfs::directory_iterator(pci_bridge_path), sfs::directory_iterator()};
 
   // Check number of Xilinx devices under this bridge.
   for (auto& path : vec) {
-    if (!bfs::is_directory(path))
+    if (!sfs::is_directory(path))
       continue;
 
     path += "/vendor";
-    if(!bfs::exists(path))
+    if(!sfs::exists(path))
 	    continue;
 
     unsigned int vendor_id;
-    bfs::ifstream file(path);
+    std::ifstream file(path);
     file >> std::hex >> vendor_id;
     if (vendor_id != XILINX_ID)
 	    continue;
@@ -781,7 +779,7 @@ shutdown(dev *mgmt_dev, bool remove_user, bool remove_mgmt)
   /* Cache the parent sysfs path before remove the PF */
   std::string parent_path = mgmt_dev->get_sysfs_path("", "dparent");
   /* Get the absolute path from the symbolic link */
-  parent_path = (bfs::canonical(parent_path)).c_str();
+  parent_path = (sfs::canonical(parent_path)).c_str();
 
   int active_dev_num;
   mgmt_dev->sysfs_get<int>("", "dparent/power/runtime_active_kids", errmsg, active_dev_num, EINVAL);
@@ -816,12 +814,12 @@ shutdown(dev *mgmt_dev, bool remove_user, bool remove_mgmt)
   for (int wait = 0; wait < DEV_TIMEOUT; wait++) {
     int curr_act_dev;
     std::string active_kids_path = parent_path + "/power/runtime_active_kids";
-    if (!bfs::exists(active_kids_path)) {
+    if (!sfs::exists(active_kids_path)) {
       // RHEL 8.x specific 
       curr_act_dev = get_runtime_active_kids(parent_path);
     }
     else {
-      bfs::ifstream file(active_kids_path);
+      std::ifstream file(active_kids_path);
       file >> curr_act_dev;
     }
 

--- a/src/runtime_src/core/pcie/linux/pcidrv.cpp
+++ b/src/runtime_src/core/pcie/linux/pcidrv.cpp
@@ -2,7 +2,7 @@
 // Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
 
 #include "pcidrv.h"
-#include <boost/filesystem.hpp>
+#include <filesystem>
 
 namespace xrt_core { namespace pci {
 
@@ -11,15 +11,15 @@ drv::
 scan_devices(std::vector<std::shared_ptr<dev>>& ready_list,
              std::vector<std::shared_ptr<dev>>& nonready_list) const
 {
-  namespace bfs = boost::filesystem;
+  namespace sfs = std::filesystem;
   const std::string drv_root = "/sys/bus/pci/drivers/";
   const std::string drvpath = drv_root + name();
 
-  if (!bfs::exists(drvpath))
+  if (!sfs::exists(drvpath))
     return;
 
   // Gather all sysfs directory and sort
-  std::vector<bfs::path> vec{ bfs::directory_iterator(drvpath), bfs::directory_iterator() };
+  std::vector<sfs::path> vec{ sfs::directory_iterator(drvpath), sfs::directory_iterator() };
   std::sort(vec.begin(), vec.end());
 
   for (auto& path : vec) {
@@ -28,7 +28,7 @@ scan_devices(std::vector<std::shared_ptr<dev>>& ready_list,
 
       // In docker, all host sysfs nodes are available. So, we need to check
       // devnode to make sure the device is really assigned to docker.
-      if (!bfs::exists(pf->get_subdev_path("", -1)))
+      if (!sfs::exists(pf->get_subdev_path("", -1)))
         continue;
 
       // Insert detected device into proper list.

--- a/src/runtime_src/core/pcie/linux/plugin/xdp/hal_api_interface.cpp
+++ b/src/runtime_src/core/pcie/linux/plugin/xdp/hal_api_interface.cpp
@@ -20,7 +20,7 @@
 #include "core/common/message.h"
 #include "core/common/dlfcn.h"
 
-namespace bfs = boost::filesystem;
+namespace sfs = std::filesystem;
 
 namespace xdphalinterface {
 

--- a/src/runtime_src/core/pcie/linux/plugin/xdp/hal_api_interface.h
+++ b/src/runtime_src/core/pcie/linux/plugin/xdp/hal_api_interface.h
@@ -21,8 +21,7 @@
 #include <iostream>
 #include <atomic>
 #include <mutex>
-#include <boost/filesystem/operations.hpp>
-#include <boost/filesystem/path.hpp>
+#include <filesystem>
 #include "core/include/xclhal2.h"
 #include "core/include/xdp/hal_api.h"
 

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/CMakeLists.txt
@@ -22,7 +22,6 @@ target_link_libraries(mpd
   xrt_core_static
   xrt_coreutil_static
   pthread
-  ${Boost_FILESYSTEM_LIBRARY}
   ${Boost_SYSTEM_LIBRARY}
   uuid
   dl
@@ -47,7 +46,6 @@ target_link_libraries(msd
   xrt_core_static
   xrt_coreutil_static
   pthread
-  ${Boost_FILESYSTEM_LIBRARY}
   ${Boost_SYSTEM_LIBRARY}
   uuid
   dl

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/aws/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/aws/CMakeLists.txt
@@ -40,7 +40,6 @@ if(${INTERNAL_TESTING_FOR_AWS})
     xrt_core_static
     xrt_coreutil_static
     uuid
-    ${Boost_FILESYSTEM_LIBRARY}
     ${Boost_SYSTEM_LIBRARY}
     pthread
     rt
@@ -55,7 +54,6 @@ else()
     xrt_core_static
     xrt_coreutil_static
     uuid
-    ${Boost_FILESYSTEM_LIBRARY}
     ${Boost_SYSTEM_LIBRARY}
     pthread
     rt

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/azure/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/azure/CMakeLists.txt
@@ -31,7 +31,6 @@ target_link_libraries(azure_mpd_plugin
   xrt_core_static
   xrt_coreutil_static
   uuid
-  ${Boost_FILESYSTEM_LIBRARY}
   ${Boost_SYSTEM_LIBRARY}
   pthread
   rt

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/container/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/container/CMakeLists.txt
@@ -25,7 +25,6 @@ target_link_libraries(container_mpd_plugin
   xrt_core_static
   xrt_coreutil_static
   uuid
-  ${Boost_FILESYSTEM_LIBRARY}
   ${Boost_SYSTEM_LIBRARY}
   pthread
   rt

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/mpd.cpp
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/mpd.cpp
@@ -19,7 +19,7 @@
 #include <netinet/in.h>
 #include <libudev.h>
 #include <boost/algorithm/string.hpp>
-#include "boost/filesystem.hpp"
+#include <filesystem>
 
 #include <fstream>
 #include <vector>
@@ -109,7 +109,7 @@ std::string Mpd::get_xocl_major_minor(const std::string &sysfs_name)
     if (!file_exist(sysfs_base + sysfs_name + "/drm"))
             return "";
 
-    boost::filesystem::directory_iterator dir(sysfs_base + sysfs_name + "/drm"), end;
+    std::filesystem::directory_iterator dir(sysfs_base + sysfs_name + "/drm"), end;
     while (dir != end) {
         std::string fn = dir->path().filename().string();
         if (fn.find("render") != std::string::npos) {
@@ -169,7 +169,7 @@ bool Mpd::device_in_container(const std::string major_minor, std::string &path)
     for (auto &t : folder) {
         if (!file_exist(cgroup_base + t))
             continue;
-        boost::filesystem::recursive_directory_iterator dir(cgroup_base + t), end;
+        std::filesystem::recursive_directory_iterator dir(cgroup_base + t), end;
         while (dir != end) {
             std::string fn = dir->path().filename().string();
             if (!fn.compare(target)) {


### PR DESCRIPTION
Problem solved by the commit:
The boost::filesystem removed from the XRT code. All the files will be submitted in 3 commits incrementally.

Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
N/A

How problem was solved, alternative solutions (if any) and why they were rejected
Risks (if any) associated the changes in the commit
None

What has been tested and how, request additional testing if necessary
System Configuration
xbutil examine
  OS Name              : Linux
  Release              : 6.5.0-rc1+
  Version              : #10 SMP PREEMPT_DYNAMIC Wed Aug 16 22:28:12 PDT 2023
  Machine              : x86_64
  CPU Cores            : 16
  Memory               : 63990 MB
  Distribution         : Ubuntu 22.04 LTS
  GLIBC                : 2.35
  Model                : Precision 5820 Tower

XRT
  Version              : 2.17.0
  Branch               : master2
  Hash                 : 8bc8242bfea0e4623339a3d0f9a5bd17b5dec0b8
  Hash Date            : 2023-10-31 12:50:57
  XOCL                 : 2.16.0, 893580509d3f7b0f1fab5a0da6210c709529a740
  XCLMGMT              : 2.16.0, 893580509d3f7b0f1fab5a0da6210c709529a740

Devices present
BDF             :  Shell                            Logic UUID                            Device ID       Device Ready* 
-------------------------------------------------------------------------------------------------------------------------
[0000:04:00.1]  :  xilinx_u55c_gen3x16_xdma_base_3  97088961-FEAE-DA91-52A2-1D9DFD63CCEF  user(inst=129)  Yes