### PR TITLE
VTITIS-9990 - Removing boost::filesystem P3

### DIFF
--- a/src/runtime_src/core/common/CMakeLists.txt
+++ b/src/runtime_src/core/common/CMakeLists.txt
@@ -69,7 +69,6 @@ set_target_properties(xrt_coreutil PROPERTIES
 # Private dependencies for fully resolved dynamic xrt_coreutil
 target_link_libraries(xrt_coreutil
   PRIVATE
-  ${Boost_FILESYSTEM_LIBRARY}
   ${Boost_SYSTEM_LIBRARY}
   )
 
@@ -80,7 +79,6 @@ target_link_libraries(xrt_coreutil
 # libraries of boost
 target_link_libraries(xrt_coreutil_static
   INTERFACE
-  boost_filesystem
   boost_system
   )
 

--- a/src/runtime_src/core/common/api/xrt_xclbin.cpp
+++ b/src/runtime_src/core/common/api/xrt_xclbin.cpp
@@ -37,8 +37,6 @@
 #include "xclbin_int.h"
 
 #include <boost/algorithm/string.hpp>
-#include <boost/filesystem/operations.hpp>
-#include <boost/filesystem/path.hpp>
 
 #include <array>
 #include <filesystem>

--- a/src/runtime_src/core/common/config_reader.cpp
+++ b/src/runtime_src/core/common/config_reader.cpp
@@ -19,15 +19,14 @@
 #include "message.h"
 #include "error.h"
 
-#include <set>
-#include <iostream>
-#include <mutex>
+#include <filesystem>
 #include <cstdlib>
+#include <iostream>
+#include <set>
+#include <mutex>
 
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/ini_parser.hpp>
-#include <boost/filesystem/path.hpp>
-#include <boost/filesystem/operations.hpp>
 #include <boost/format.hpp>
 
 #ifdef __linux__
@@ -99,14 +98,14 @@ get_self_path()
  * Look for xrt.ini and if not found look for legacy sdaccel.ini.
  */
 static std::string
-verify_ini_path(const boost::filesystem::path& dir)
+verify_ini_path(const std::filesystem::path& dir)
 {
   auto file_path = dir / "xrt.ini";
-  if (boost::filesystem::exists(file_path))
+  if (std::filesystem::exists(file_path))
     return file_path.string();
 
   file_path = dir / "sdaccel.ini";
-  if (boost::filesystem::exists(file_path))
+  if (std::filesystem::exists(file_path))
     return file_path.string();
 
   return "";
@@ -118,27 +117,27 @@ get_ini_path()
   std::string full_path;
   try {
     //The env variable should be the full path which includes xrt.ini
-    auto xrt_path = boost::filesystem::path(value_or_empty(std::getenv("XRT_INI_PATH")));
-    if (boost::filesystem::exists(xrt_path))
+    auto xrt_path = std::filesystem::path(value_or_empty(std::getenv("XRT_INI_PATH")));
+    if (std::filesystem::exists(xrt_path))
       return xrt_path.string();
 
     //The env variable should be the full path which includes sdaccel.ini
-    auto sda_path = boost::filesystem::path(value_or_empty(std::getenv("SDACCEL_INI_PATH")));
-    if (boost::filesystem::exists(sda_path))
+    auto sda_path = std::filesystem::path(value_or_empty(std::getenv("SDACCEL_INI_PATH")));
+    if (std::filesystem::exists(sda_path))
       return sda_path.string();
 
-    auto exe_path = boost::filesystem::path(get_self_path()).parent_path();
+    auto exe_path = std::filesystem::path(get_self_path()).parent_path();
     full_path = verify_ini_path(exe_path);
     if (!full_path.empty())
       return full_path;
 
-    auto self_path = boost::filesystem::current_path();
+    auto self_path = std::filesystem::current_path();
     full_path = verify_ini_path(self_path);
     if (!full_path.empty())
       return full_path;
 
   }
-  catch (const boost::filesystem::filesystem_error&) {
+  catch (const std::filesystem::filesystem_error&) {
   }
   return full_path;
 }

--- a/src/runtime_src/core/tools/common/Process.cpp
+++ b/src/runtime_src/core/tools/common/Process.cpp
@@ -54,8 +54,10 @@
 #endif
 
 // System - Include Files
+#include <filesystem>
 #include <iostream>
 #include <thread>
+
 // ------ S T A T I C   V A R I A B L E S -------------------------------------
 
 // ------ F U N C T I O N S ---------------------------------------------------
@@ -190,16 +192,17 @@ XBUtilities::runScript( const std::string & env,
 
 
 
-boost::filesystem::path
+std::filesystem::path
 findEnvPath(const std::string & env)
 {
-  boost::filesystem::path absPath;
+  std::filesystem::path absPath;
   if (env.compare("python") == 0) {
     // Find the python executable
-    absPath = boost::process::search_path("py");
+    auto path = boost::process::search_path("py");
+    absPath = path.string();
     // Find python3 path on linux
     if (absPath.string().empty()) 
-      absPath = boost::process::search_path("python3");   
+      absPath = boost::process::search_path("python3").string();   
 
     if (absPath.string().empty()) 
       throw std::runtime_error("Error: Python executable not found in search path.");
@@ -219,7 +222,7 @@ XBUtilities::runScript( const std::string & env,
   auto envPath = findEnvPath(env);
   
   // Make sure the script exists
-  if ( !boost::filesystem::exists( script ) ) {
+  if ( !std::filesystem::exists( script ) ) {
     std::string errMsg = (boost::format("Error: Given python script does not exist: '%s'") % script).str();
     throw std::runtime_error(errMsg);
   }
@@ -242,7 +245,7 @@ XBUtilities::runScript( const std::string & env,
   // Execute the python script and capture the outputs
   boost::process::ipstream ip_stdout;
   boost::process::ipstream ip_stderr;
-  boost::process::child runningProcess( envPath, 
+  boost::process::child runningProcess( envPath.string(), 
                                         cmdArgs, 
                                         boost::process::std_out > ip_stdout,
                                         boost::process::std_err > ip_stderr,

--- a/src/runtime_src/core/tools/common/SubCmdConfigureInternal.cpp
+++ b/src/runtime_src/core/tools/common/SubCmdConfigureInternal.cpp
@@ -15,14 +15,14 @@ namespace XBU = XBUtilities;
 #include "common/device.h"
 
 // 3rd Party Library - Include Files
-#include <boost/filesystem.hpp>
 #include <boost/program_options.hpp>
 #include <boost/property_tree/ptree.hpp>
 namespace po = boost::program_options;
 
 // System - Include Files
-#include <iostream>
+#include <filesystem>
 #include <fstream>
+#include <iostream>
 
 #include "common/system.h"
 #include "common/device.h"
@@ -252,11 +252,11 @@ remove_daemon_config()
     throw xrt_core::error(std::errc::operation_canceled);
 
   try {
-    if (boost::filesystem::remove(config_file))
+    if (std::filesystem::remove(config_file))
       std::cout << boost::format("Succesfully removed the Daemon configuration file.\n");
     else
       std::cout << boost::format("WARNING: Daemon configuration file does not exist.\n");
-  } catch (const boost::filesystem::filesystem_error &e) {
+  } catch (const std::filesystem::filesystem_error &e) {
       std::cerr << boost::format("ERROR: %s\n") % e.what();
       throw xrt_core::error(std::errc::operation_canceled);
   }

--- a/src/runtime_src/core/tools/common/SubCmdExamineInternal.cpp
+++ b/src/runtime_src/core/tools/common/SubCmdExamineInternal.cpp
@@ -15,15 +15,15 @@
 namespace XBU = XBUtilities;
 
 // 3rd Party Library - Include Files
-#include <boost/filesystem.hpp>
 #include <boost/format.hpp>
 #include <boost/program_options.hpp>
 #include <boost/algorithm/string.hpp>
 namespace po = boost::program_options;
 
 // System - Include Files
-#include <iostream>
+#include <filesystem>
 #include <fstream>
+#include <iostream>
 #include <regex>
 
 static ReportCollection fullReportCollection = {};
@@ -137,7 +137,7 @@ SubCmdExamineInternal::execute(const SubCmdOptions& _options) const
   }
 
   // DRC: Output file
-  if (!m_output.empty() && boost::filesystem::exists(m_output) && !XBU::getForce()) {
+  if (!m_output.empty() && std::filesystem::exists(m_output) && !XBU::getForce()) {
     std::cerr << boost::format("ERROR: The output file '%s' already exists.  Please either remove it or execute this command again with the '--force' option to overwrite it.") % m_output << std::endl;
     throw xrt_core::error(std::errc::operation_canceled);
   }

--- a/src/runtime_src/core/tools/common/SubCmdJSON.cpp
+++ b/src/runtime_src/core/tools/common/SubCmdJSON.cpp
@@ -30,7 +30,6 @@ namespace XBU = XBUtilities;
 
 // 3rd Party Library - Include Files
 #include <boost/algorithm/string.hpp>
-#include <boost/filesystem.hpp>
 #include <boost/format.hpp>
 #include <boost/program_options.hpp>
 #include <boost/property_tree/json_parser.hpp>
@@ -41,6 +40,7 @@ namespace pt = boost::property_tree;
 
 // System - Include Files
 #include <cstdlib>
+#include <filesystem>
 #include <fstream>
 #include <iostream>
 
@@ -199,7 +199,7 @@ void populateSubCommandsFromJSON(SubCmdsCollection &subCmds, const std::string& 
 
     for(auto &path : jsonPaths)
     {
-        if(boost::filesystem::is_regular_file(path))
+        if(std::filesystem::is_regular_file(path))
             populateSubCommandsFromJSONHelper(subCmds, path, exeName);
     }
 }

--- a/src/runtime_src/core/tools/common/XBMain.cpp
+++ b/src/runtime_src/core/tools/common/XBMain.cpp
@@ -26,14 +26,13 @@
 namespace XBU = XBUtilities;
 
 // 3rd Party Library - Include Files
-#include <boost/filesystem.hpp>
 #include <boost/format.hpp>
 #include <boost/program_options.hpp>
-#include <cstdlib>
 
 namespace po = boost::program_options;
 
 // System - Include Files
+#include <filesystem>
 #include <iostream>
 
 // ------ Program entry point -------------------------------------------------

--- a/src/runtime_src/core/tools/common/tests/TestIPU.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestIPU.cpp
@@ -10,7 +10,7 @@
 #include "xrt/xrt_kernel.h"
 namespace XBU = XBUtilities;
 
-#include <boost/filesystem.hpp>
+#include <filesystem>
 
 static constexpr size_t host_app = 1; //opcode
 static constexpr size_t buffer_size = 128;
@@ -27,7 +27,7 @@ TestIPU::run(std::shared_ptr<xrt_core::device> dev)
   boost::property_tree::ptree ptree = get_test_header();
 
   auto xclbin_path = findXclbinPath(dev, ptree);
-  if (!boost::filesystem::exists(xclbin_path)) {
+  if (!std::filesystem::exists(xclbin_path)) {
     return ptree;
   }
   // log xclbin test dir for debugging purposes

--- a/src/runtime_src/core/tools/xbflash2/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbflash2/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 
 find_package(Boost
-  REQUIRED COMPONENTS filesystem system program_options)
+  REQUIRED COMPONENTS system program_options)
 
 include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}
@@ -37,7 +37,6 @@ add_executable(${XBFLASH_NAME} ${XBFLASH_QSPI_SRC})
 set(Boost_USE_STATIC_LIBS ON)
 target_link_libraries(${XBFLASH_NAME}
       PRIVATE
-      boost_filesystem
       boost_system
       boost_program_options
       )

--- a/src/runtime_src/core/tools/xbflash2/OO_Dump_Qspips.cpp
+++ b/src/runtime_src/core/tools/xbflash2/OO_Dump_Qspips.cpp
@@ -25,13 +25,13 @@
 namespace XBU = XBUtilities;
 
 // 3rd Party Library - Include Files
-#include <boost/filesystem.hpp>
 #include <boost/format.hpp>
 #include <boost/program_options.hpp>
 
 namespace po = boost::program_options;
 
 // System - Include Files
+#include <filesystem>
 #include <iostream>
 
 namespace {

--- a/src/runtime_src/core/tools/xbflash2/xbflash.cpp
+++ b/src/runtime_src/core/tools/xbflash2/xbflash.cpp
@@ -23,8 +23,8 @@
 #include "XBFMain.h"
 
 // System include files
-#include <boost/filesystem.hpp>
 #include <exception>
+#include <filesystem>
 #include <iostream>
 #include <string>
 

--- a/src/runtime_src/core/tools/xbmgmt2/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbmgmt2/CMakeLists.txt
@@ -76,7 +76,6 @@ if (XRT_STATIC_BUILD)
     PRIVATE
     xrt_coreutil_static
     boost_system
-    boost_filesystem
     boost_program_options
     -Wl,--whole-archive rt pthread -Wl,--no-whole-archive
     uuid

--- a/src/runtime_src/core/tools/xbmgmt2/OO_Hotplug.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_Hotplug.cpp
@@ -12,12 +12,12 @@
 #include "core/common/system.h"
 
 // 3rd Party Library - Include Files
-#include <boost/filesystem.hpp>
 #include <boost/program_options.hpp>
 #include <boost/algorithm/string.hpp>
 namespace po = boost::program_options;
 
 // System - Include Files
+#include <filesystem>
 #include <fstream>
 // =============================================================================
 
@@ -27,7 +27,7 @@ hotplug_online()
 {
   static const std::string  rescan_path = "/sys/bus/pci/rescan";
 
-  if (!boost::filesystem::exists(rescan_path))
+  if (!std::filesystem::exists(rescan_path))
     throw xrt_core::error((boost::format("Invalid sysfs file path '%s'.") % rescan_path).str());
 
   std::ofstream rescan_file(rescan_path);

--- a/src/runtime_src/core/tools/xbmgmt2/OO_Input.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_Input.cpp
@@ -11,11 +11,11 @@ namespace XBU = XBUtilities;
 // 3rd Party Library - Include Files
 #include <boost/program_options.hpp>
 #include <boost/algorithm/string.hpp>
-#include <boost/filesystem.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/ini_parser.hpp>
 namespace po = boost::program_options;
 
+#include <filesystem>
 #include <iostream> 
 
 OO_Input::OO_Input( const std::string &_longName, bool _isHidden )
@@ -137,12 +137,12 @@ OO_Input::execute(const SubCmdOptions& _options) const
   // Load Config commands
   // -- process "input" option -----------------------------------------------
   if (!m_path.empty()) {
-    if (!boost::filesystem::exists(m_path)) {
+    if (!std::filesystem::exists(m_path)) {
       std::cerr << boost::format("ERROR: Input file does not exist: '%s'") % m_path << "\n\n";
       throw xrt_core::error(std::errc::operation_canceled);
     }
 
-    if (boost::filesystem::extension(m_path).compare(".ini") != 0) {
+    if (std::filesystem::path(m_path).extension().string() == ".ini") {
       std::cerr << boost::format("ERROR: Input file should be an INI file: '%s'") % m_path << "\n\n";
       throw xrt_core::error(std::errc::operation_canceled);
     }

--- a/src/runtime_src/core/tools/xbmgmt2/OO_Retention.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_Retention.cpp
@@ -11,9 +11,9 @@ namespace XBU = XBUtilities;
 // 3rd Party Library - Include Files
 #include <boost/program_options.hpp>
 #include <boost/algorithm/string.hpp>
-#include <boost/filesystem.hpp>
 namespace po = boost::program_options;
 
+#include <filesystem>
 #include <iostream> 
 
 OO_Retention::OO_Retention( const std::string &_longName, bool _isHidden )

--- a/src/runtime_src/core/tools/xbmgmt2/OO_UpdateShell.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_UpdateShell.cpp
@@ -14,12 +14,12 @@
 namespace XBU = XBUtilities;
 
 // 3rd Party Library - Include Files
-#include <boost/filesystem.hpp>
 #include <boost/format.hpp>
 #include <boost/program_options.hpp>
 namespace po = boost::program_options;
 
 // System - Include Files
+#include <filesystem>
 #include <fstream>
 #include <iostream>
 
@@ -113,7 +113,7 @@ OO_UpdateShell::execute(const SubCmdOptions& _options) const
                             " is installed.");
 
     // Check if file exists
-    if (!boost::filesystem::exists(m_plp))
+    if (!std::filesystem::exists(m_plp))
       throw xrt_core::error("File not found. Please specify the correct path");
 
     DSAInfo dsa(m_plp);

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdDump.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdDump.cpp
@@ -15,13 +15,13 @@ namespace XBU = XBUtilities;
 // 3rd Party Library - Include Files
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/ini_parser.hpp>
-#include <boost/filesystem.hpp>
 #include <boost/program_options.hpp>
 namespace po = boost::program_options;
 
 // System - Include Files
-#include <iostream>
+#include <filesystem>
 #include <fstream>
+#include <iostream>
 
 // ------ L O C A L   F U N C T I O N S ---------------------------------------
 
@@ -180,7 +180,7 @@ SubCmdDump::execute(const SubCmdOptions& _options) const
     printHelp();
     throw xrt_core::error(std::errc::operation_canceled);
   }
-  if (!m_output.empty() && boost::filesystem::exists(m_output) && !XBU::getForce()) {
+  if (!m_output.empty() && std::filesystem::exists(m_output) && !XBU::getForce()) {
     std::cerr << boost::format("m_output file already exists: '%s'") % m_output << "\n\n";
     throw xrt_core::error(std::errc::operation_canceled);
   }

--- a/src/runtime_src/core/tools/xbmgmt2/flash/firmware_image.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/firmware_image.cpp
@@ -22,10 +22,10 @@
 // 3rd Party Library - Include Files
 #include <boost/format.hpp>
 #include <boost/algorithm/string.hpp>
-#include "boost/filesystem.hpp"
 #include <boost/tokenizer.hpp>
 
 #include <iostream>
+#include <filesystem>
 #include <fstream>
 #include <algorithm>
 #include <climits>
@@ -423,7 +423,7 @@ std::vector<DSAInfo> firmwareImage::getIntalledDSAs()
     // Obtain installed DSA info.
     for (auto root : FIRMWARE_DIRS) {
       try {
-        if (!boost::filesystem::exists(root) || !boost::filesystem::is_directory(root))
+        if (!std::filesystem::exists(root) || !std::filesystem::is_directory(root))
             continue;
       }
       catch (const std::exception&) {
@@ -432,9 +432,9 @@ std::vector<DSAInfo> firmwareImage::getIntalledDSAs()
         continue;
       }
 
-      boost::filesystem::recursive_directory_iterator end_iter;
-      // for (auto const & iter : boost::filesystem::recursive_directory_iterator(root)) {
-      for(boost::filesystem::recursive_directory_iterator iter(root); iter != end_iter; ++iter) {
+      std::filesystem::recursive_directory_iterator end_iter;
+      // for (auto const & iter : std::filesystem::recursive_directory_iterator(root)) {
+      for(std::filesystem::recursive_directory_iterator iter(root); iter != end_iter; ++iter) {
         if ((iter->path().extension() == ".xsabin" || iter->path().extension() == ".dsabin")) {
           DSAInfo dsa(iter->path().string());
           installedDSA.push_back(dsa);

--- a/src/runtime_src/core/tools/xbmgmt2/flash/flasher.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/flasher.cpp
@@ -25,12 +25,12 @@
 #include <limits>
 #include <cstddef>
 #include <cassert>
+#include <filesystem>
 #include <vector>
 #include <cstring>
 #include <cstdarg>
 #include "boost/format.hpp"
 #include <boost/algorithm/string.hpp>
-#include "boost/filesystem.hpp"
 
 #define INVALID_ID      0xffff
 
@@ -501,7 +501,7 @@ std::string Flasher::getQspiGolden()
     std::string start = FORMATTED_FW_DIR;
     start += "/";
     start += board_name;
-    boost::filesystem::recursive_directory_iterator dir(start), end;
+    std::filesystem::recursive_directory_iterator dir(start), end;
     while (dir != end) {
         std::string fn = dir->path().filename().string();
         if (!fn.compare(QSPI_GOLDEN_IMAGE)) {

--- a/src/runtime_src/core/tools/xbmgmt2/xbmgmt.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/xbmgmt.cpp
@@ -19,12 +19,13 @@
 #include "xrt.h"
 
 // System include files
-#include <boost/filesystem.hpp>
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
-#include <string>
-#include <iostream>
 #include <exception>
+#include <filesystem>
+#include <iostream>
+#include <string>
+
 
 const std::string& command_config = 
 R"(

--- a/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
@@ -78,7 +78,6 @@ if (XRT_STATIC_BUILD)
     PRIVATE
     xrt_coreutil_static
     boost_system
-    boost_filesystem
     boost_program_options
     -Wl,--whole-archive rt pthread -Wl,--no-whole-archive
     uuid

--- a/src/runtime_src/core/tools/xbutil2/OO_MemRead.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_MemRead.cpp
@@ -14,12 +14,12 @@
 namespace XBU = XBUtilities;
 
 // 3rd Party Library - Include Files
-#include <boost/filesystem.hpp>
 #include <boost/format.hpp>
 #include <boost/program_options.hpp>
 namespace po = boost::program_options;
 
 // System - Include Files
+#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <vector>
@@ -74,7 +74,7 @@ OO_MemRead::execute(const SubCmdOptions& _options) const
     device = XBU::get_device(boost::algorithm::to_lower_copy(m_device), true /*inUserDomain*/);
 
     //-- Output file
-    if (!m_outputFile.empty() && boost::filesystem::exists(m_outputFile) && !XBU::getForce())
+    if (!m_outputFile.empty() && std::filesystem::exists(m_outputFile) && !XBU::getForce())
       throw xrt_core::error((boost::format("Output file already exists: '%s'") % m_outputFile).str());
 
   } catch (const xrt_core::error&) {

--- a/src/runtime_src/core/tools/xbutil2/OO_MemWrite.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_MemWrite.cpp
@@ -13,12 +13,12 @@
 namespace XBU = XBUtilities;
 
 // 3rd Party Library - Include Files
-#include <boost/filesystem.hpp>
 #include <boost/format.hpp>
 #include <boost/program_options.hpp>
 namespace po = boost::program_options;
 
 // System - Include Files
+#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <math.h>
@@ -114,7 +114,7 @@ OO_MemWrite::execute(const SubCmdOptions& _options) const
   // Parse the input option path
   if (!m_inputFile.empty()) {
     // Verify that the file exists and is not a directory
-    if (!boost::filesystem::exists(m_inputFile) && boost::filesystem::is_regular_file(m_inputFile))
+    if (!std::filesystem::exists(m_inputFile) && std::filesystem::is_regular_file(m_inputFile))
       XBU::throw_cancel(boost::format("Input file does not exist: '%s'") % m_inputFile);
 
     // Open the input file stream after validating the file path and name

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -37,13 +37,13 @@ namespace XBU = XBUtilities;
 
 // 3rd Party Library - Include Files
 #include <boost/format.hpp>
-#include <boost/filesystem.hpp>
 #include <boost/program_options.hpp>
 #include <boost/property_tree/json_parser.hpp>
 namespace po = boost::program_options;
 
 // System - Include Files
 #include <algorithm>
+#include <filesystem>
 #ifdef __linux__
 #include <sys/mman.h> //munmap
 #endif
@@ -516,7 +516,7 @@ SubCmdValidate::execute(const SubCmdOptions& _options) const
       throw xrt_core::error((boost::format("Unknown output format: '%s'") % m_format).str());
 
     // Output file
-    if (!m_output.empty() && !XBU::getForce() && boost::filesystem::exists(m_output))
+    if (!m_output.empty() && !XBU::getForce() && std::filesystem::exists(m_output))
         throw xrt_core::error((boost::format("Output file already exists: '%s'") % m_output).str());
 
     if (m_tests_to_run.empty())
@@ -540,10 +540,10 @@ SubCmdValidate::execute(const SubCmdOptions& _options) const
     // check if xclbin folder path is provided
     if (!validateXclbinPath.empty()) {
       XBU::verbose("Sub command: --path");
-      if (!boost::filesystem::exists(validateXclbinPath) || !boost::filesystem::is_directory(validateXclbinPath))
+      if (!std::filesystem::exists(validateXclbinPath) || !std::filesystem::is_directory(validateXclbinPath))
         throw xrt_core::error((boost::format("Invalid directory path : '%s'") % validateXclbinPath).str());
       if (validateXclbinPath.compare(".") == 0 || validateXclbinPath.compare("./") == 0)
-        validateXclbinPath = boost::filesystem::current_path().string();
+        validateXclbinPath = std::filesystem::current_path().string();
       if (validateXclbinPath.back() != '/')
         validateXclbinPath.append("/");
     }

--- a/src/runtime_src/core/tools/xbutil2/xbutil.cpp
+++ b/src/runtime_src/core/tools/xbutil2/xbutil.cpp
@@ -20,10 +20,10 @@
 
 // System include files
 #include <exception>
+#include <filesystem>
 #include <iostream>
 #include <string>
 
-#include <boost/filesystem.hpp>
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
 


### PR DESCRIPTION
Problem solved by the commit:
The boost::filesystem removed from the XRT code. All the files will be submitted in 3 commits incrementally.

Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
N/A

How problem was solved, alternative solutions (if any) and why they were rejected
Risks (if any) associated the changes in the commit
None

What has been tested and how, request additional testing if necessary
System Configuration
xbutil examine
System Configuration
  OS Name              : Linux
  Release              : 6.5.0-rc1+
  Version              : #10 SMP PREEMPT_DYNAMIC Wed Aug 16 22:28:12 PDT 2023
  Machine              : x86_64
  CPU Cores            : 16
  Memory               : 63990 MB
  Distribution         : Ubuntu 22.04 LTS
  GLIBC                : 2.35
  Model                : Precision 5820 Tower

XRT
  Version              : 2.17.0
  Branch               : master3
  Hash                 : 80c1a9c7f1ec277705c96c49a1a6abd60500ca49
  Hash Date            : 2023-11-01 13:38:36
  XOCL                 : 2.16.0, 893580509d3f7b0f1fab5a0da6210c709529a740
  XCLMGMT              : 2.16.0, 893580509d3f7b0f1fab5a0da6210c709529a740

Devices present
BDF             :  Shell                            Logic UUID                            Device ID       Device Ready* 
-------------------------------------------------------------------------------------------------------------------------
[0000:04:00.1]  :  xilinx_u55c_gen3x16_xdma_base_3  97088961-FEAE-DA91-52A2-1D9DFD63CCEF  user(inst=129)  Yes  