### PR TITLE
VTITIS-9990 - Removing boost::filesystem P4

### DIFF
--- a/src/xma/src/xmaapi/CMakeLists.txt
+++ b/src/xma/src/xmaapi/CMakeLists.txt
@@ -24,7 +24,6 @@ target_link_libraries(xma2api
   dl
   gcc_s
   stdc++
-  ${Boost_FILESYSTEM_LIBRARY}
   ${Boost_SYSTEM_LIBRARY}
   )
 

--- a/src/xma/src/xmaapi/xma_utils.cpp
+++ b/src/xma/src/xmaapi/xma_utils.cpp
@@ -16,8 +16,7 @@
 #include "core/common/api/bo.h"
 #include "core/common/device.h"
 #include <dlfcn.h>
-#include <boost/filesystem/operations.hpp>
-#include <boost/filesystem/path.hpp>
+#include <filesystem>
 #include <iostream>
 #include <sstream>
 #include <bitset>
@@ -142,7 +141,7 @@ namespace xma_core {
 namespace xma_core { namespace utils {
 
 constexpr std::uint64_t cu_base_min = 0x1800000;
-namespace bfs = boost::filesystem;
+namespace sfs = std::filesystem;
 
 static const char*
 emptyOrValue(const char* cstr)
@@ -151,26 +150,26 @@ emptyOrValue(const char* cstr)
 }
 
 int32_t
-directoryOrError(const bfs::path& path)
+directoryOrError(const sfs::path& path)
 {
-  if (!bfs::is_directory(path))
+  if (!sfs::is_directory(path))
       return XMA_ERROR;
 
    return XMA_SUCCESS;
 }
 
-static boost::filesystem::path&
+static std::filesystem::path&
 dllExt()
 {
-  static boost::filesystem::path sDllExt(".so");
+  static std::filesystem::path sDllExt(".so");
   return sDllExt;
 }
 
 inline bool
-isDLL(const bfs::path& path)
+isDLL(const sfs::path& path)
 {
-  return (bfs::exists(path)
-          && bfs::is_regular_file(path)
+  return (sfs::exists(path)
+          && sfs::is_regular_file(path)
           && path.extension()==dllExt());
 }
 
@@ -196,10 +195,10 @@ load_libxrt()
     dlerror();    /* Clear any existing error */
 
     // xrt
-    bfs::path xrt(emptyOrValue(std::getenv("XILINX_XRT")));
+    sfs::path xrt(emptyOrValue(std::getenv("XILINX_XRT")));
     if (xrt.empty()) {
         std::cout << "XMA INFO: XILINX_XRT env variable not set. Trying default /opt/xilinx/xrt" << std::endl;
-        xrt = bfs::path("/opt/xilinx/xrt");
+        xrt = sfs::path("/opt/xilinx/xrt");
     }
     if (directoryOrError(xrt) != XMA_SUCCESS) {
         std::cout << "XMA FATAL: XILINX_XRT env variable is not a directory: " << xrt.string() << std::endl;
@@ -207,7 +206,7 @@ load_libxrt()
     }
 
     // Load the xmaplugin library as it is a dependency for all plugins
-    bfs::path xma2plugin_lib(xrt / "lib/libxma2plugin.so");
+    sfs::path xma2plugin_lib(xrt / "lib/libxma2plugin.so");
     if (!isDLL(xma2plugin_lib)) {
         std::cout << "XMA FATAL: xma2plugin lib not found. Lib: " << xma2plugin_lib.string() << std::endl;
         return XMA_ERROR;
@@ -221,7 +220,7 @@ load_libxrt()
     }
 
     if (!isEmulationMode()) {
-        bfs::path p1(xrt / "lib/libxrt_core.so");
+        sfs::path p1(xrt / "lib/libxrt_core.so");
         if (isDLL(p1)) {
             void* xrthandle = dlopen(p1.string().c_str(), RTLD_NOW | RTLD_GLOBAL);
             if (!xrthandle)
@@ -234,7 +233,7 @@ load_libxrt()
             return 1;
         }
 
-        bfs::path p2(xrt / "lib/libxrt_aws.so");
+        sfs::path p2(xrt / "lib/libxrt_aws.so");
         if (isDLL(p2)) {
             void* xrthandle = dlopen(p2.string().c_str(), RTLD_NOW | RTLD_GLOBAL);
             if (!xrthandle)
@@ -269,7 +268,7 @@ load_libxrt()
             return XMA_ERROR;
         }
 
-        bfs::path p2(xrt / "lib/libxrt_swemu.so");
+        sfs::path p2(xrt / "lib/libxrt_swemu.so");
         sw_em_driver = p2.string();
 
         if (isDLL(sw_em_driver)) {
@@ -304,7 +303,7 @@ load_libxrt()
         return XMA_ERROR;
     }
 
-    bfs::path p1(xrt / "lib/libxrt_hwemu.so");
+    sfs::path p1(xrt / "lib/libxrt_hwemu.so");
     hw_em_driver = p1.string();
 
     if (isDLL(hw_em_driver)) {

--- a/tests/validate/aie_pl_test/CMakeLists.txt
+++ b/tests/validate/aie_pl_test/CMakeLists.txt
@@ -20,7 +20,7 @@ add_executable(${TESTNAME}
   src/host.cpp
   )
 
-target_link_libraries(${TESTNAME} PRIVATE ${xrt_coreutil_LIBRARY} ${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY} ${Boost_PROGRAM_OPTIONS_LIBRARY})
+target_link_libraries(${TESTNAME} PRIVATE ${xrt_coreutil_LIBRARY} ${Boost_SYSTEM_LIBRARY} ${Boost_PROGRAM_OPTIONS_LIBRARY})
 
 if (NOT WIN32)
   target_link_libraries(${TESTNAME} PRIVATE ${uuid_LIBRARY}  pthread ${xrt_coreutil_LIBRARY} ${xrt_core_LIBRARY})

--- a/tests/validate/aie_pl_test/src/host.cpp
+++ b/tests/validate/aie_pl_test/src/host.cpp
@@ -28,7 +28,7 @@
 #include <boost/program_options.hpp>
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
-#include <boost/filesystem.hpp>
+#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <stdlib.h>
@@ -281,7 +281,7 @@ main(int argc, char* argv[])
     }
 
     std::string aie_control_file = "aie_control_config.json";
-    auto aie_control = boost::filesystem::path(test_path) / aie_control_file;
+    auto aie_control = std::filesystem::path(test_path) / aie_control_file;
 
     std::ifstream aiefile(aie_control.string());
     if (!aiefile.good()) {
@@ -300,7 +300,7 @@ main(int argc, char* argv[])
     if(hw_gen == 1)
 	b_file  = "vck5000_pcie_pl_controller.xclbin.xclbin";
     
-    auto binaryFile = boost::filesystem::path(test_path) / b_file;
+    auto binaryFile = std::filesystem::path(test_path) / b_file;
     std::ifstream infile(binaryFile.string());
 
     if (!infile.good()) {
@@ -319,7 +319,7 @@ main(int argc, char* argv[])
 
     // instance of plController
     std::string dma_lock_file = "dma_lock_report.json";
-    auto dma_lock = boost::filesystem::path(test_path) / dma_lock_file;
+    auto dma_lock = std::filesystem::path(test_path) / dma_lock_file;
 
     bool match = false;
     // Check for AIE Hardware Generation

--- a/tests/validate/bandwidth_test/CMakeLists.txt
+++ b/tests/validate/bandwidth_test/CMakeLists.txt
@@ -15,7 +15,7 @@ endif(WIN32)
 
 include_directories(../../../src/include/1_2 ../../../src/runtime_src/core/include src/ ../common/includes/xcl2 ../common/includes/cmdparser ../common/includes/logger )
 add_executable(${TESTNAME} ../common/includes/xcl2/xcl2.cpp ../common/includes/cmdparser/cmdlineparser.cpp ../common/includes/logger/logger.cpp src/host.cpp)
-target_link_libraries(${TESTNAME} PRIVATE ${xrt_coreutil_LIBRARY} ${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY})
+target_link_libraries(${TESTNAME} PRIVATE ${xrt_coreutil_LIBRARY} ${Boost_SYSTEM_LIBRARY})
 
 if (NOT WIN32)
   target_link_libraries(${TESTNAME} PRIVATE ${uuid_LIBRARY} pthread ${OpenCL_LIBRARY} ) 

--- a/tests/validate/bandwidth_test/src/host.cpp
+++ b/tests/validate/bandwidth_test/src/host.cpp
@@ -15,7 +15,7 @@
 */
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
-#include <boost/filesystem.hpp>
+#include <filesystem>
 #include <math.h>
 #include <sys/time.h>
 #include <xcl2.hpp>
@@ -63,7 +63,7 @@ int main(int argc, char** argv) {
         return EXIT_FAILURE;
     }
 
-    auto binaryFile = boost::filesystem::path(test_path) / b_file;
+    auto binaryFile = std::filesystem::path(test_path) / b_file;
     std::ifstream infile(binaryFile.string());
     if (flag_s) {
         if (!infile.good()) {
@@ -78,7 +78,7 @@ int main(int argc, char** argv) {
     int num_kernel = 0, num_kernel_ddr = 0;
     bool chk_hbm_mem = false;
     std::string filename = "/platform.json";
-    auto platform_json = boost::filesystem::path(test_path) / filename;
+    auto platform_json = std::filesystem::path(test_path) / filename;
     std::vector<std::string> bank_names;
 
     try {

--- a/tests/validate/hostmemory_test/CMakeLists.txt
+++ b/tests/validate/hostmemory_test/CMakeLists.txt
@@ -15,7 +15,7 @@ endif(WIN32)
 
 include_directories(../../../src/include/1_2 ../../../src/runtime_src/core/include src/ ../common/includes/xcl2 ../common/includes/cmdparser ../common/includes/logger )
 add_executable(${TESTNAME} ../common/includes/xcl2/xcl2.cpp ../common/includes/cmdparser/cmdlineparser.cpp ../common/includes/logger/logger.cpp src/host.cpp)
-target_link_libraries(${TESTNAME} PRIVATE ${xrt_coreutil_LIBRARY} ${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY})
+target_link_libraries(${TESTNAME} PRIVATE ${xrt_coreutil_LIBRARY} ${Boost_SYSTEM_LIBRARY})
 
 if (NOT WIN32)
   target_link_libraries(${TESTNAME} PRIVATE ${uuid_LIBRARY} pthread ${OpenCL_LIBRARY} )

--- a/tests/validate/hostmemory_test/src/host.cpp
+++ b/tests/validate/hostmemory_test/src/host.cpp
@@ -15,7 +15,7 @@
 */
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
-#include <boost/filesystem.hpp>
+#include <filesystem>
 #include <math.h>
 #include <sys/time.h>
 #include <xcl2.hpp>
@@ -55,10 +55,10 @@ int main(int argc, char** argv) {
         std::cout << "ERROR : please provide the platform test path to -p option\n";
         return EXIT_FAILURE;
     }
-    auto binary_file = boost::filesystem::path(test_path) / b_file;
+    auto binary_file = std::filesystem::path(test_path) / b_file;
     std::ifstream infile(binary_file.string());
     // This is for backward compatibility support when older platforms still having slavebridge.xclbin.
-    auto old_binary_file = boost::filesystem::path(test_path) / old_b_file;
+    auto old_binary_file = std::filesystem::path(test_path) / old_b_file;
     std::ifstream old_infile(old_binary_file.string());
     if (flag_s) {
         if (!infile.good()) {
@@ -77,7 +77,7 @@ int main(int argc, char** argv) {
 
     int num_kernel;
     std::string filename = "/platform.json";
-    auto platform_json = boost::filesystem::path(test_path) / filename;
+    auto platform_json = std::filesystem::path(test_path) / filename;
 
     try {
         boost::property_tree::ptree load_ptree_root;

--- a/tests/validate/ps_aie_test/CMakeLists.txt
+++ b/tests/validate/ps_aie_test/CMakeLists.txt
@@ -17,7 +17,7 @@ add_executable(${TESTNAME}
   ../common/includes/logger/logger.cpp src/host.cpp
   )
 
-target_link_libraries(${TESTNAME} PRIVATE ${xrt_coreutil_LIBRARY} ${Boost_PROGRAM_OPTIONS_LIBRARY} ${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY})
+target_link_libraries(${TESTNAME} PRIVATE ${xrt_coreutil_LIBRARY} ${Boost_PROGRAM_OPTIONS_LIBRARY} ${Boost_SYSTEM_LIBRARY})
 
 if (NOT WIN32)
   target_link_libraries(${TESTNAME} PRIVATE ${uuid_LIBRARY}  pthread ${xrt_coreutil_LIBRARY} ${xrt_core_LIBRARY})

--- a/tests/validate/ps_bandwidth_test/CMakeLists.txt
+++ b/tests/validate/ps_bandwidth_test/CMakeLists.txt
@@ -17,7 +17,7 @@ add_executable(${TESTNAME}
   ../common/includes/logger/logger.cpp src/host.cpp
   )
 
-target_link_libraries(${TESTNAME} PRIVATE ${xrt_coreutil_LIBRARY} ${Boost_PROGRAM_OPTIONS_LIBRARY} ${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY})
+target_link_libraries(${TESTNAME} PRIVATE ${xrt_coreutil_LIBRARY} ${Boost_PROGRAM_OPTIONS_LIBRARY} ${Boost_SYSTEM_LIBRARY})
 
 if (NOT WIN32)
   target_link_libraries(${TESTNAME} PRIVATE ${uuid_LIBRARY}  pthread ${xrt_coreutil_LIBRARY} ${xrt_core_LIBRARY})

--- a/tests/validate/ps_iops_test/CMakeLists.txt
+++ b/tests/validate/ps_iops_test/CMakeLists.txt
@@ -13,7 +13,7 @@ endif()
 if (NOT WIN32)
   include_directories(../common/includes/cmdparser ../common/includes/logger)
   add_executable(${TESTNAME} ../common/includes/cmdparser/cmdlineparser.cpp ../common/includes/logger/logger.cpp src/ps_iops.cpp)
-  target_link_libraries(${TESTNAME} PRIVATE ${uuid_LIBRARY} pthread ${xrt_coreutil_LIBRARY} ${xrt_core_LIBRARY} ${Boost_PROGRAM_OPTIONS_LIBRARY} ${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY})
+  target_link_libraries(${TESTNAME} PRIVATE ${uuid_LIBRARY} pthread ${xrt_coreutil_LIBRARY} ${xrt_core_LIBRARY} ${Boost_PROGRAM_OPTIONS_LIBRARY} ${Boost_SYSTEM_LIBRARY})
   install(TARGETS ${TESTNAME}
     RUNTIME DESTINATION ${XRT_VALIDATE_DIR})
 endif(NOT WIN32)

--- a/tests/validate/ps_validate_test/CMakeLists.txt
+++ b/tests/validate/ps_validate_test/CMakeLists.txt
@@ -18,7 +18,7 @@ add_executable(${TESTNAME}
   ../common/includes/logger/logger.cpp src/host.cpp
   )
 
-target_link_libraries(${TESTNAME} PRIVATE ${xrt_coreutil_LIBRARY} ${Boost_PROGRAM_OPTIONS_LIBRARY} ${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY})
+target_link_libraries(${TESTNAME} PRIVATE ${xrt_coreutil_LIBRARY} ${Boost_PROGRAM_OPTIONS_LIBRARY} ${Boost_SYSTEM_LIBRARY})
 
 if (NOT WIN32)
   target_link_libraries(${TESTNAME} PRIVATE ${uuid_LIBRARY}  pthread ${xrt_coreutil_LIBRARY} ${xrt_core_LIBRARY})


### PR DESCRIPTION
  Problem solved by the commit:
The boost::filesystem removed from the XRT code. All the files will be submitted in 4 commits incrementally.

Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
N/A

How problem was solved, alternative solutions (if any) and why they were rejected
Risks (if any) associated the changes in the commit
None

What has been tested and how, request additional testing if necessary
System Configuration

OS Name              : Linux
  Release              : 6.5.0-rc1+
  Version              : #10 SMP PREEMPT_DYNAMIC Wed Aug 16 22:28:12 PDT 2023
  Machine              : x86_64
  CPU Cores            : 16
  Memory               : 63990 MB
  Distribution         : Ubuntu 22.04 LTS
  GLIBC                : 2.35
  Model                : Precision 5820 Tower

XRT
  Version              : 2.17.0
  Branch               : master3
  Hash                 : e9e97ee254651986b121e970eee239c53bcf4073
  Hash Date            : 2023-11-02 13:51:44
  XOCL                 : 2.16.0, 893580509d3f7b0f1fab5a0da6210c709529a740
  XCLMGMT              : 2.16.0, 893580509d3f7b0f1fab5a0da6210c709529a740

Devices present
BDF             :  Shell                            Logic UUID                            Device ID       Device Ready* 
-------------------------------------------------------------------------------------------------------------------------
[0000:04:00.1]  :  xilinx_u55c_gen3x16_xdma_base_3  97088961-FEAE-DA91-52A2-1D9DFD63CCEF  user(inst=129)  Yes           