### PR TITLE
Modified CMake files to build xclbinutil seperately

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -65,6 +65,7 @@ usage()
     echo "[-ccache]                   Build using RDI's compile cache"
     echo "[-toolchain <file>]         Extra toolchain file to configure CMake"
     echo "[-driver]                   Include building driver code"
+    echo "[-xclbinutil]               Build xclbinutil only"
     echo "[-checkpatch]               Run checkpatch.pl on driver code"
     echo "[-verbose]                  Turn on verbosity when compiling"
     echo "[-ertbsp <dir>]             Path to directory with pre-downloaded BSP files for building ERT (default: download BSP files during build time)"
@@ -205,6 +206,10 @@ while [ $# -gt 0 ]; do
             ;;
         -pskernel)
             cmake_flags+=" -DXRT_PSKERNEL_BUILD=ON"
+            shift
+            ;;
+        -xclbinutil)
+            cmake_flags+=" -DXCLBINUTIL_ONLY_BUILD=ON"
             shift
             ;;
         -verbose)

--- a/src/CMake/findpackage.cmake
+++ b/src/CMake/findpackage.cmake
@@ -44,18 +44,20 @@ install (
 # This will generate a file that details all targets we have marked for export
 # as part of the xrt-targets export group
 # It will provide information such as the library file names and locations post install
-if (NOT WIN32)
-install(
-  EXPORT xrt-targets
-  NAMESPACE ${PROJECT_NAME}::
-  DESTINATION ${XRT_INSTALL_DIR}/share/cmake/${PROJECT_NAME}
-  )
-endif()
+if (NOT ${XCLBINUTIL_ONLY_BUILD})
+   if (NOT WIN32)
+   install(
+     EXPORT xrt-targets
+     NAMESPACE ${PROJECT_NAME}::
+     DESTINATION ${XRT_INSTALL_DIR}/share/cmake/${PROJECT_NAME}
+     )
+   endif()
 
-if (${XRT_NATIVE_BUILD} STREQUAL "yes")
-install(
-  EXPORT xrt-dev-targets
-  NAMESPACE ${PROJECT_NAME}::
-  DESTINATION ${XRT_INSTALL_DIR}/share/cmake/${PROJECT_NAME}
-  )
+   if (NOT ${XRT_NATIVE_BUILD})
+   install(
+     EXPORT xrt-dev-targets
+     NAMESPACE ${PROJECT_NAME}::
+     DESTINATION ${XRT_INSTALL_DIR}/share/cmake/${PROJECT_NAME}
+     )
+   endif()
 endif()

--- a/src/CMake/nativeLnx.cmake
+++ b/src/CMake/nativeLnx.cmake
@@ -171,47 +171,47 @@ include (CMake/lint.cmake)
 
 xrt_add_subdirectory(runtime_src)
 
-#XMA settings START
-set(XMA_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
-set(XMA_INSTALL_DIR "${XRT_INSTALL_DIR}")
-set(XMA_VERSION_STRING ${XRT_VERSION_MAJOR}.${XRT_VERSION_MINOR}.${XRT_VERSION_PATCH})
-set(XMA_SOVERSION ${XRT_SOVERSION})
-xrt_add_subdirectory(xma)
-#XMA settings END
+if (NOT ${XCLBINUTIL_ONLY_BUILD})
+   #XMA settings START
+   set(XMA_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+   set(XMA_INSTALL_DIR "${XRT_INSTALL_DIR}")
+   set(XMA_VERSION_STRING ${XRT_VERSION_MAJOR}.${XRT_VERSION_MINOR}.${XRT_VERSION_PATCH})
+   set(XMA_SOVERSION ${XRT_SOVERSION})
+   xrt_add_subdirectory(xma)
+   #XMA settings END
 
-# --- Python bindings ---
-xrt_add_subdirectory(python)
+   # --- Python bindings ---
+   xrt_add_subdirectory(python)
 
-# --- Python tests ---
-set(PY_TEST_SRC
-  ../tests/python/22_verify/22_verify.py
-  ../tests/python/utils_binding.py
-  ../tests/python/23_bandwidth/23_bandwidth.py
-  ../tests/python/23_bandwidth/host_mem_23_bandwidth.py
-  ../tests/python/23_bandwidth/versal_23_bandwidth.py)
-install (FILES ${PY_TEST_SRC}
-  PERMISSIONS OWNER_READ OWNER_EXECUTE OWNER_WRITE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
-  DESTINATION ${XRT_INSTALL_DIR}/test)
-
-xrt_add_subdirectory("../tests/validate" "${CMAKE_CURRENT_BINARY_DIR}/validate_build")
-message("-- XRT version: ${XRT_VERSION_STRING}")
-
+   # --- Python tests ---
+   set(PY_TEST_SRC
+     ../tests/python/22_verify/22_verify.py
+     ../tests/python/utils_binding.py
+     ../tests/python/23_bandwidth/23_bandwidth.py
+     ../tests/python/23_bandwidth/host_mem_23_bandwidth.py
+     ../tests/python/23_bandwidth/versal_23_bandwidth.py)
+   install (FILES ${PY_TEST_SRC}
+     PERMISSIONS OWNER_READ OWNER_EXECUTE OWNER_WRITE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
+     DESTINATION ${XRT_INSTALL_DIR}/test)
+   xrt_add_subdirectory("../tests/validate" "${CMAKE_CURRENT_BINARY_DIR}/validate_build")
+   message("-- XRT version: ${XRT_VERSION_STRING}")
+endif()
 # -- CPack
 include (CMake/cpackLin.cmake)
 
-set (XRT_DKMS_DRIVER_SRC_BASE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/runtime_src/core")
-
-include (CMake/dkms.cmake)
-include (CMake/dkms-aws.cmake)
-include (CMake/dkms-azure.cmake)
-include (CMake/dkms-container.cmake)
-
-# --- ICD ---
-include (CMake/icd.cmake)
-
-# --- Change Log ---
-include (CMake/changelog.cmake)
-
+if (NOT ${XCLBINUTIL_ONLY_BUILD})
+   set (XRT_DKMS_DRIVER_SRC_BASE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/runtime_src/core")
+   
+   include (CMake/dkms.cmake)
+   include (CMake/dkms-aws.cmake)
+   include (CMake/dkms-azure.cmake)
+   include (CMake/dkms-container.cmake)
+   # --- ICD ---
+   include (CMake/icd.cmake)
+   
+   # --- Change Log ---
+   include (CMake/changelog.cmake)
+endif()
 # --- Package Config ---
 include (CMake/pkgconfig.cmake)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,6 +5,9 @@ cmake_minimum_required(VERSION 3.5.0)
 project(XRT)
 set(PROJECT_DESCRIPTION "https://github.com/Xilinx/XRT")
 
+option(XCLBINUTIL_ONLY_BUILD "Option to enable and disable build only xclbinutil" OFF)
+
+
 # Include utility functions
 include(CMake/utilities.cmake)
 
@@ -126,7 +129,9 @@ if (${XRT_NATIVE_BUILD} STREQUAL "yes")
   else()
     include(CMake/nativeLnx.cmake)
   endif()
-  xrt_include(CMake/nativeTests.cmake)
+  if (NOT ${XCLBINUTIL_ONLY_BUILD})
+     xrt_include(CMake/nativeTests.cmake)
+  endif()
 else()
   include(CMake/embedded_system.cmake)
 endif()

--- a/src/runtime_src/CMakeLists.txt
+++ b/src/runtime_src/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 if( NOT WIN32)
 
-if(${CMAKE_BUILD_TYPE} STREQUAL "Release" AND ${XRT_NATIVE_BUILD} STREQUAL "yes")
+if (${CMAKE_BUILD_TYPE} STREQUAL "Release" AND ${XRT_NATIVE_BUILD} STREQUAL "yes" AND NOT ${XCLBINUTIL_ONLY_BUILD})
   xrt_add_subdirectory(doc)
 endif()
 
@@ -30,12 +30,15 @@ endif(XRT_ENABLE_WERROR)
 if (${XRT_NATIVE_BUILD} STREQUAL "yes")
   add_compile_options( ${XRT_WARN_OPTS} )
 endif()
-xrt_add_subdirectory(xdp)
+if (NOT ${XCLBINUTIL_ONLY_BUILD})
+   xrt_add_subdirectory(xdp)
+   xrt_add_subdirectory(xocl)
+   xrt_add_subdirectory(xrt)
+   xrt_add_subdirectory(ert)
+endif()
 
 xrt_add_subdirectory(tools/xclbinutil)
-xrt_add_subdirectory(xocl)
-xrt_add_subdirectory(xrt)
-xrt_add_subdirectory(ert)
+
 if (${XRT_NATIVE_BUILD} STREQUAL "yes")
   # Only for host native build.
   # For embedded, headers and libraries are installed in /usr
@@ -47,7 +50,9 @@ endif()
 set (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-Bsymbolic")
 set (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-z,defs")
 
-xrt_add_subdirectory(core)
+if (NOT ${XCLBINUTIL_ONLY_BUILD})
+   xrt_add_subdirectory(core)
+endif()
 
 else()
 # = WINDOWS ===================================================================


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
[CR-1179805](https://jira.xilinx.com/browse/CR-1179805) xclbinutil has to be build seperately from XRT.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
NA

#### How problem was solved, alternative solutions (if any) and why they were rejected
Introduced a new check in the CMake files called XCLBINUTIL_ONLY_BUILD. This determines whether to build xclbinutil only. If check is not specified, build process will proceed as usual including all components. Provided an option in build.sh script

#### Risks (if any) associated the changes in the commit
NA
#### What has been tested and how, request additional testing if necessary
Conducted multiple builds with different checks to ensure thorough verification.
#### Documentation impact (if any)
