### PR TITLE
Add inline specifier to xrt::ini::set(const string&, unsigned int)

### DIFF
--- a/src/runtime_src/core/include/experimental/xrt_ini.h
+++ b/src/runtime_src/core/include/experimental/xrt_ini.h
@@ -56,7 +56,7 @@ set(const std::string& key, const std::string& value);
  *
  * Throws if key value cannot be changed.
  */
-void
+inline void
 set(const std::string& key, unsigned int value)
 {
   set(key, std::to_string(value));


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Defining a function in a header file causes a multiple definition linker error when the header in included in multiple files which are to be linked together.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Mark the function as inline to avoid this issue.