### PR TITLE
Adding a flag o and m

### DIFF
--- a/src/runtime_src/ert/scheduler/CMakeLists.txt
+++ b/src/runtime_src/ert/scheduler/CMakeLists.txt
@@ -53,7 +53,7 @@ function(build_ert_fw version)
   add_custom_command(
    OUTPUT ${version}/bsp.extracted
    COMMAND ${CMAKE_COMMAND} -E make_directory ${version}/bsp
-   COMMAND tar -C ${version}/bsp -jxf ${CMAKE_CURRENT_BINARY_DIR}/${BSP_TAR_NAME}
+   COMMAND tar -C ${version}/bsp -jxomf ${CMAKE_CURRENT_BINARY_DIR}/${BSP_TAR_NAME}
    COMMAND cp ${CMAKE_CURRENT_SOURCE_DIR}/${LSCRIPT_NAME} ${version}/lscript.ld
    COMMAND touch ${version}/bsp.extracted
    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${BSP_TAR_NAME}


### PR DESCRIPTION
Adding a flag o and m for unzipping https://github.com/Xilinx/ERT-BSP/raw/main/BSPs/sched_bsp.tar.bz2 files inside container during the build stages

The above flag is needed to perform cleanup stage in the pipeline once the build is completed. without "o" and "m" flag the ownership of the files and time are preserved which is "jpocock" and  time of file created is 2 years back and when unzipping it's user is same as jpocock and hence we could not delete those files in the pipeline after the build facing permission issue


