### PR TITLE
Remove 1x4.xclbin dependency from xbutil validate

### DIFF
--- a/src/runtime_src/core/tools/common/tests/TestIPU.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestIPU.cpp
@@ -19,12 +19,17 @@ static constexpr size_t buffer_size = 128;
 TestIPU::TestIPU()
   : TestRunner("verify", 
                 "Run 'Hello World' test on IPU",
-                "1x4.xclbin"){}
+                "validate_phx.xclbin"){}
 
 boost::property_tree::ptree
 TestIPU::run(std::shared_ptr<xrt_core::device> dev)
 {
   boost::property_tree::ptree ptree = get_test_header();
+
+  auto device_name = xrt_core::device_query_default<xrt_core::query::rom_vbnv>(dev, "");
+  if (device_name.find("RyzenAI-Strix") != std::string::npos) {
+    ptree.put("xclbin", "validate_stx.xclbin");
+  }
 
   auto xclbin_path = findXclbinPath(dev, ptree);
   if (!std::filesystem::exists(xclbin_path)) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
We need to pick up xclbin from VTD and remove the dependency from 1x4.xclbin

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
