### PR TITLE
Amend #7773 to add back missing include

### DIFF
--- a/src/runtime_src/core/common/system.cpp
+++ b/src/runtime_src/core/common/system.cpp
@@ -7,11 +7,18 @@
 #include "device.h"
 #include "module_loader.h"
 
+#include "gen/version.h"
+
+
 // System - Include Files
-#include <vector>
+#include <boost/property_tree/ptree.hpp>
+
 #include <map>
 #include <memory>
 #include <mutex>
+#include <stdexcept>
+#include <string>
+#include <vector>
 
 namespace {
 


### PR DESCRIPTION
#### Problem solved by the commit
Add back include of gen/version.h to core/common/system.cpp.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
The #include of gen/version.h was removed from system.cpp in #7773, but this header is used by system::get_xrt_build_info().  At least on my system it breaks the build. I really bumped it passed the pipeline, and mystified why it is failing to build on my ubuntu20.04 system. I am adding it back in.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Add back the missing include along with others that should included but were relied on indirectly.
