### PR TITLE
Add hybrid access to xrt::ext:bo for cross-adapter allocations

### DIFF
--- a/src/runtime_src/core/include/experimental/xrt_ext.h
+++ b/src/runtime_src/core/include/experimental/xrt_ext.h
@@ -57,6 +57,8 @@ public:
    *   Access is shared between devices within process
    * @var process
    *   Access is shared between processes and devices
+   * @var hybrid
+   *   Access is shared between drivers (cross-adapter)
    *
    * The access mode is used to specify how the buffer is used by
    * device and process.
@@ -80,18 +82,20 @@ public:
    * is specified.
    *
    * Friend operators are provided for bitwise operations on access
-   * mode.
+   * mode.  It is invalid to combine local, shared, proces, and hybrid.
    */
   enum class access_mode : uint64_t
   {
     none    = 0,
 
-    read  = 1 << 0, 
+    read  = 1 << 0,
     write = 1 << 1,
+    read_write = read | write,
 
     local   = 0,
     shared  = 1 << 2,
     process = 1 << 3,
+    hybrid  = 1 << 4, 
   };
 
   friend constexpr access_mode operator&(access_mode lhs, access_mode rhs)

--- a/src/runtime_src/core/include/xrt_mem.h
+++ b/src/runtime_src/core/include/xrt_mem.h
@@ -100,8 +100,10 @@ struct xcl_bo_flags
 /**
  * Shim level BO Flags for extension
  */
-#define XRT_BO_ACCESS_SHARED 1
-#define XRT_BO_ACCESS_EXPORTED 2
+#define XRT_BO_ACCESS_LOCAL         0
+#define XRT_BO_ACCESS_SHARED        1
+#define XRT_BO_ACCESS_PROCESS       2
+#define XRT_BO_ACCESS_HYBRID        3
 
 /**
  * Shim level BO Flags for direction of data transfer


### PR DESCRIPTION
#### Problem solved by the commit
Support allocating buffer objects that are shared between hybrid devices. On Windows / MCDM this is a cross-adapter allocation.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Add new access mode `xrt::ext::bo::access_mode::hybrid` and encode in bo flags passed to shim for allocatng BO.

This PR changes the encoded BO flags for access extension removing old XRT_BO_ACCESS_EXPORTED and instead keeps a 1:1 mapping from xrt::ext::bo:access::mode to these access flags.

It is an error to bitwise or the access mode local, shared, process, and hybrid and an exception is thrown if the access mode is not exactly one of these 4 values.

This PR is a pre-requisite for MCDM / UMD changes to support creating cross adapter allocations.