### PR TITLE
Add hybrid access to xrt::fence for cross-adapter sharing

### DIFF
--- a/src/runtime_src/core/include/experimental/xrt_fence.h
+++ b/src/runtime_src/core/include/experimental/xrt_fence.h
@@ -70,8 +70,10 @@ public:
    *   Access is shared between devices within process
    * @var process
    *   Access is shared between processes and devices
+   * @var hybrid
+   *   Access is shared between drivers (cross-adapater)
    */
-  enum class access_mode : uint8_t { local, shared, process };
+  enum class access_mode : uint8_t { local, shared, process, hybrid };
 
   /**
    * fence() - Default constructor


### PR DESCRIPTION
#### Problem solved by the commit
Support allocating fence objects that are shared between hybrid devices. On Windows / MCDM this a cross-adapter fence.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Add new access mode `xrt::fence::access_mode::hybrid`.
