### PR TITLE
aie_profile samples incremental report writer

### DIFF
--- a/src/runtime_src/xdp/profile/database/database.h
+++ b/src/runtime_src/xdp/profile/database/database.h
@@ -41,7 +41,7 @@ namespace xdp {
   {
   public:
     // For messages sent to specific plugins
-    enum MessageType { READ_COUNTERS, READ_TRACE, DUMP_TRACE } ;
+    enum MessageType { READ_COUNTERS, READ_TRACE, DUMP_TRACE, DUMP_AIE_PROFILE } ;
 
   private:
     // The information stored in the database will be separated into 

--- a/src/runtime_src/xdp/profile/database/dynamic_info/aie_db.cpp
+++ b/src/runtime_src/xdp/profile/database/dynamic_info/aie_db.cpp
@@ -18,6 +18,8 @@
 
 #include <cstring>
 
+#include "core/common/message.h"
+#include "xdp/profile/database/database.h"
 #include "xdp/profile/database/dynamic_info/aie_db.h"
 
 namespace xdp {
@@ -64,6 +66,16 @@ namespace xdp {
     auto data = traceData[strmIndex];
     traceData[strmIndex] = new aie::TraceDataType;
     return data;
+  }
+
+  void AIEDB::addAIESample(double timestamp, const std::vector<uint64_t>& values)
+  {
+      samples.addSample({timestamp, values});
+      if (samples.getSamplesSize() > sampleThreshold) {
+        std::string msg = "AIE profile threshold reached, initiiate aie_profile write!";
+        xrt_core::message::send(xrt_core::message::severity_level::info, "XRT", msg);
+        VPDatabase::Instance()->broadcast(VPDatabase::DUMP_AIE_PROFILE);
+      }
   }
 
 } // end namespace xdp

--- a/src/runtime_src/xdp/profile/database/dynamic_info/aie_db.cpp
+++ b/src/runtime_src/xdp/profile/database/dynamic_info/aie_db.cpp
@@ -72,7 +72,7 @@ namespace xdp {
   {
       samples.addSample({timestamp, values});
       if (samples.getSamplesSize() > sampleThreshold) {
-        std::string msg = "AIE profile threshold reached, initiiate aie_profile write!";
+        std::string msg = "AIE profiling sample limit reached, writing data to disk.";
         xrt_core::message::send(xrt_core::message::severity_level::info, "XRT", msg);
         VPDatabase::Instance()->broadcast(VPDatabase::DUMP_AIE_PROFILE);
       }

--- a/src/runtime_src/xdp/profile/database/dynamic_info/aie_db.h
+++ b/src/runtime_src/xdp/profile/database/dynamic_info/aie_db.h
@@ -40,6 +40,9 @@ namespace xdp {
 
     std::mutex traceLock; // Protects "traceData" vector
 
+    // This is the amount of AIESample threshold AIEDB stores before it flushes to the disk
+    static constexpr uint64_t sampleThreshold = 100000;
+
   public:
     AIEDB() = default;
     XDP_CORE_EXPORT ~AIEDB();
@@ -48,9 +51,7 @@ namespace xdp {
                          bool copy, uint64_t numTraceStreams);
     aie::TraceDataType* getAIETraceData(uint64_t strmIndex);
 
-    inline
-    void addAIESample(double timestamp, const std::vector<uint64_t>& values)
-    { samples.addSample({timestamp, values}); }
+    void addAIESample(double timestamp, const std::vector<uint64_t>& values);
 
     inline
     void addAIETimerSample(unsigned long timestamp1, unsigned long timestamp2, 

--- a/src/runtime_src/xdp/profile/database/dynamic_info/pl_db.cpp
+++ b/src/runtime_src/xdp/profile/database/dynamic_info/pl_db.cpp
@@ -16,6 +16,7 @@
 
 #define XDP_CORE_SOURCE
 
+#include "core/common/message.h"
 #include "xdp/profile/database/database.h"
 #include "xdp/profile/database/dynamic_info/pl_db.h"
 #include "xdp/profile/database/events/vtf_event.h"
@@ -34,8 +35,9 @@ namespace xdp {
       if (events.size() > eventThreshold)
         overLimit = true;
     }
-    if (overLimit)
+    if (overLimit) {
       VPDatabase::Instance()->broadcast(VPDatabase::DUMP_TRACE);
+    }
   }
 
   bool PLDB::eventsExist()

--- a/src/runtime_src/xdp/profile/database/dynamic_info/pl_db.cpp
+++ b/src/runtime_src/xdp/profile/database/dynamic_info/pl_db.cpp
@@ -16,7 +16,6 @@
 
 #define XDP_CORE_SOURCE
 
-#include "core/common/message.h"
 #include "xdp/profile/database/database.h"
 #include "xdp/profile/database/dynamic_info/pl_db.h"
 #include "xdp/profile/database/events/vtf_event.h"
@@ -35,9 +34,8 @@ namespace xdp {
       if (events.size() > eventThreshold)
         overLimit = true;
     }
-    if (overLimit) {
+    if (overLimit)
       VPDatabase::Instance()->broadcast(VPDatabase::DUMP_TRACE);
-    }
   }
 
   bool PLDB::eventsExist()

--- a/src/runtime_src/xdp/profile/database/dynamic_info/samples.h
+++ b/src/runtime_src/xdp/profile/database/dynamic_info/samples.h
@@ -51,6 +51,11 @@ namespace xdp {
       std::lock_guard<std::mutex> lock(containerLock);
       return samples;
     }
+    inline uint64_t getSamplesSize()
+    {
+      std::lock_guard<std::mutex> lock(containerLock);
+      return samples.size();
+    }
 
   };
 

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_plugin.cpp
@@ -197,7 +197,6 @@ auto time = std::time(nullptr);
     VPWriter* writer = new AIEProfilingWriter(outputFile.c_str(), deviceName.c_str(), mIndex);
     writers.push_back(writer);
     db->getStaticInfo().addOpenedFile(writer->getcurrentFileName(), "AIE_PROFILE");
-    xrt_core::message::send(severity_level::warning, "XRT", "AIEProfile writer was created!");
 
   // Start the AIE profiling thread
   #ifdef XDP_MINIMAL_BUILD
@@ -215,7 +214,6 @@ auto time = std::time(nullptr);
 
   void AieProfilePlugin::pollAIECounters(uint32_t index, void* handle)
   {
-    xrt_core::message::send(severity_level::warning, "XRT", "AIEProfile: polling thread has started!");
     auto it = handleToAIEData.find(handle);
     if (it == handleToAIEData.end())
       return;
@@ -286,13 +284,11 @@ auto time = std::time(nullptr);
     handleToAIEData.clear();
   }
 
-  void AieProfilePlugin::broadcast(VPDatabase::MessageType msg, void* blob)
+  void AieProfilePlugin::broadcast(VPDatabase::MessageType msg, void* /*blob*/)
   {
      switch(msg) {
       case VPDatabase::MessageType::DUMP_AIE_PROFILE:
         {
-          std::string logMsg = "AIE profile plugin: broadcast msg received & re-broadcasting aie_profile msg type!";
-          xrt_core::message::send(xrt_core::message::severity_level::info, "XRT", logMsg);
           XDPPlugin::trySafeWrite("AIE_PROFILE", false);
         }
         break;

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_plugin.h
@@ -32,6 +32,7 @@ namespace xdp {
     void updateAIEDevice(void* handle);
     void endPollforDevice(void* handle);
     static bool alive();
+    void broadcast(VPDatabase::MessageType msg, void* blob);
 
   private:
     virtual void writeAll(bool openNewFiles) override;

--- a/src/runtime_src/xdp/profile/writer/aie_profile/aie_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/aie_profile/aie_writer.cpp
@@ -17,7 +17,6 @@
 
 #include <vector>
 
-#include "core/common/message.h"
 #include "xdp/profile/database/database.h"
 #include "xdp/profile/database/static_info/aie_constructs.h"
 #include "xdp/profile/writer/aie_profile/aie_writer.h"
@@ -52,14 +51,14 @@ namespace xdp {
     fout << "Hardware generation: " << static_cast<int>(aieGeneration) << "\n";
     fout << "Clock frequency (MHz): " << aieClockFreqMhz << "\n";
     fout << "timestamp"    << ","
-        << "column"       << ","
-        << "row"          << ","
-        << "start"        << ","
-        << "end"          << ","
-        << "reset"        << ","
-        << "value"        << ","
-        << "timer"        << ","
-        << "payload"      << ",\n";
+         << "column"       << ","
+         << "row"          << ","
+         << "start"        << ","
+         << "end"          << ","
+         << "reset"        << ","
+         << "value"        << ","
+         << "timer"        << ","
+         << "payload"      << ",\n";
   }
 
   bool AIEProfilingWriter::write(bool)

--- a/src/runtime_src/xdp/profile/writer/aie_profile/aie_writer.h
+++ b/src/runtime_src/xdp/profile/writer/aie_profile/aie_writer.h
@@ -29,11 +29,13 @@ namespace xdp {
                        uint64_t deviceIndex);
     ~AIEProfilingWriter();
 
+    virtual void writeHeader();
     virtual bool write(bool openNewFile = true);
     
   private:
     std::string mDeviceName;
     uint64_t mDeviceIndex;
+    bool mHeaderWritten;
   };
 
 } // end namespace xdp


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
The host application launches many iterations of application run for AIE_PROFILE plugin. This ultimately was resulting in memory segmentation error as it is running out of memory.


#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
This change introduces the incremental dump of the AIE_PROFILE samples whenever it reaches certain threshold. The tests were done to find the suitable threshold value and 100,000 threshold seems ideal.

#### Risks (if any) associated the changes in the commit
#### What has been tested and how, request additional testing if necessary
Previously it used to fail even for 100K iterations. 
verified the application for 1M iteration & didn't see the segmentation fault and report were generated successfully.
./host.exe a.xclbin 1000000

 
#### Documentation impact (if any)
