### PR TITLE
Fix for call repo mirror worflow

### DIFF
--- a/.github/workflows/call_mirror.yml
+++ b/.github/workflows/call_mirror.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   run-repository-dispatch:
-    runs-on: self-hosted
+    runs-on: Ubuntu
     steps:
       - name: Trigger Workflow
         run: |

--- a/.github/workflows/call_mirror.yml
+++ b/.github/workflows/call_mirror.yml
@@ -1,8 +1,7 @@
-name: repo-dispatch-mirror
+name: call-repo-mirror
 
 on:
-  workflow_dispatch:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, synchronize]
 
 jobs:
@@ -16,5 +15,5 @@ jobs:
           -H "Accept: application/vnd.github+json" \
           -H "Authorization: Bearer ${{ secrets.CI_DOMAIN_TOKEN }}" \
           "https://${{ secrets.CI_DOMAIN_URL }}/api/v3/repos/${{ secrets.CI_DOMAIN_OWNER }}/${{ secrets.CI_DOMAIN_REPO }}/actions/workflows/${{ secrets.CI_DOMAIN_WORKFLOW }}/dispatches" \
-          -d '{"ref": "main", inputs: { branch_name: ${{ github.event.pull_request.ref }} }}'
+          -d '{"ref": "main", "inputs": { "branch_ref": "${{ github.event.pull_request.head.ref }}", "repo": "${{ github.event.pull_request.head.repo.full_name }}" }}'
           

--- a/.github/workflows/call_mirror.yml
+++ b/.github/workflows/call_mirror.yml
@@ -1,4 +1,4 @@
-name: repository-dispatch-mirror
+name: repo-dispatch-mirror
 
 on:
   workflow_dispatch:

--- a/.github/workflows/call_mirror.yml
+++ b/.github/workflows/call_mirror.yml
@@ -1,0 +1,19 @@
+name: repository-dispatch-mirror
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+jobs:
+  run-repository-dispatch:
+    runs-on: self-hosted
+    steps:
+      - name: Trigger Workflow
+        run: |
+          curl -L \
+          -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{ secrets.CI_DOMAIN_TOKEN }}" \
+          "https://${{ secrets.CI_DOMAIN_URL }}/api/v3/repos/${{ secrets.CI_DOMAIN_OWNER }}/${{ secrets.CI_DOMAIN_REPO }}/actions/workflows/${{ secrets.CI_DOMAIN_WORKFLOW }}/dispatches" \
+          -d '{"ref": "main", inputs: { branch_name: ${{ github.event.pull_request.ref }} }}'

--- a/src/runtime_src/core/tools/common/tests/TestIPU.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestIPU.cpp
@@ -19,12 +19,17 @@ static constexpr size_t buffer_size = 128;
 TestIPU::TestIPU()
   : TestRunner("verify", 
                 "Run 'Hello World' test on IPU",
-                "1x4.xclbin"){}
+                "validate_phx.xclbin"){}
 
 boost::property_tree::ptree
 TestIPU::run(std::shared_ptr<xrt_core::device> dev)
 {
   boost::property_tree::ptree ptree = get_test_header();
+
+  auto device_name = xrt_core::device_query_default<xrt_core::query::rom_vbnv>(dev, "");
+  if (device_name.find("RyzenAI-Strix") != std::string::npos) {
+    ptree.put("xclbin", "validate_stx.xclbin");
+  }
 
   auto xclbin_path = findXclbinPath(dev, ptree);
   if (!std::filesystem::exists(xclbin_path)) {


### PR DESCRIPTION

Github action workflows are not able to access secrets for PR raised from forked repos. This PR fixes that issue for this workflow

https://github.com/Xilinx/XRT/pull/7794