### PR TITLE
Check for SC existence before checking for SC ready state

### DIFF
--- a/src/runtime_src/core/include/xgq_cmd_vmr.h
+++ b/src/runtime_src/core/include/xgq_cmd_vmr.h
@@ -132,14 +132,14 @@ enum xgq_cmd_log_page_type {
 };
 
 /*
- * VMR SC status defines
+ * XGQ VMR SC status defines
  */
-typedef enum _VMR_CMD_SC_STATUS
+typedef enum _xgq_cmd_sc_status
 {
-    VMR_CMD_SC_PENDING     = 0x0,
-    VMR_CMD_SC_UNAVAILABLE = 0x1,
-    VMR_CMD_SC_READY       = 0x2,
-} VMR_CMD_SC_STATUS;
+    XGQ_CMD_SC_PENDING     = 0x0,
+    XGQ_CMD_SC_UNAVAILABLE = 0x1,
+    XGQ_CMD_SC_READY       = 0x2,
+} xgq_cmd_sc_status;
 
 /**
  * struct xgq_cmd_log_payload: log_page request command

--- a/src/runtime_src/core/include/xgq_cmd_vmr.h
+++ b/src/runtime_src/core/include/xgq_cmd_vmr.h
@@ -131,6 +131,16 @@ enum xgq_cmd_log_page_type {
 	XGQ_CMD_LOG_BACKUP_FPT		 = 0xc,
 };
 
+/*
+ * VMR SC status defines
+ */
+typedef enum _VMR_CMD_SC_STATUS
+{
+    VMR_CMD_SC_PENDING     = 0x0,
+    VMR_CMD_SC_UNAVAILABLE = 0x1,
+    VMR_CMD_SC_READY       = 0x2,
+} VMR_CMD_SC_STATUS;
+
 /**
  * struct xgq_cmd_log_payload: log_page request command
  *

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
@@ -186,7 +186,7 @@ struct xocl_xgq_vmr {
 
 static int vmr_status_query(struct platform_device *pdev);
 static void xgq_offline_service(struct xocl_xgq_vmr *xgq);
-static VMR_CMD_SC_STATUS vmr_get_sc_status(struct xocl_xgq_vmr *xgq);
+static xgq_cmd_sc_status vmr_get_sc_status(struct xocl_xgq_vmr *xgq);
 static uint64_t xgq_get_data(struct platform_device *pdev,
 	enum data_kind kind);
 
@@ -2232,7 +2232,7 @@ static int xgq_collect_sensors(struct platform_device *pdev, int aid, int sid,
 	int ret = 0;
 	int id = 0;
 
-	if (vmr_get_sc_status(xgq) != VMR_CMD_SC_READY) {
+	if (vmr_get_sc_status(xgq) != XGQ_CMD_SC_READY) {
 		XGQ_ERR(xgq, "SC is not ready, skipping sensors request command");
 		return -EAGAIN;
 	}
@@ -3387,21 +3387,21 @@ static int xgq_vmr_remove(struct platform_device *pdev)
 /* Function to query VMR and return the appropriate
  * SC status.
  */ 
-static VMR_CMD_SC_STATUS vmr_get_sc_status(struct xocl_xgq_vmr *xgq)
+static xgq_cmd_sc_status vmr_get_sc_status(struct xocl_xgq_vmr *xgq)
 {
 	struct xgq_cmd_cq_vmr_payload *vmr_status =
 		(struct xgq_cmd_cq_vmr_payload *)&xgq->xgq_cq_payload;
 	int ret = vmr_status_query(xgq->xgq_pdev);
-	VMR_CMD_SC_STATUS sc_status = VMR_CMD_SC_PENDING;
+	xgq_cmd_sc_status sc_status = XGQ_CMD_SC_PENDING;
 
 	if (ret)
 		XGQ_ERR(xgq, "received error %d for vmr_status_query xgq request", ret);
 
 	if (!vmr_status->has_ext_scfw) {
-		sc_status = VMR_CMD_SC_UNAVAILABLE;
+		sc_status = XGQ_CMD_SC_UNAVAILABLE;
 	}
 	else if (vmr_status->sc_is_ready) {
-		sc_status = VMR_CMD_SC_READY;
+		sc_status = XGQ_CMD_SC_READY;
 	}
 
 	return sc_status;
@@ -3413,15 +3413,16 @@ static bool vmr_wait_for_sc_ready(struct xocl_xgq_vmr *xgq)
 	const unsigned int loop_counter = vmr_sc_ready_timeout *
 		(1000 / SC_WAIT_INTERVAL_MSEC);
 	unsigned int i = 0;
-	VMR_CMD_SC_STATUS sc_status = vmr_get_sc_status(xgq);
+	xgq_cmd_sc_status sc_status;
 
 	for (i = 1; i <= loop_counter; i++) {
 		msleep(SC_WAIT_INTERVAL_MSEC);
-		if(sc_status == VMR_CMD_SC_UNAVAILABLE) {
+		sc_status = vmr_get_sc_status(xgq);
+		if(sc_status == XGQ_CMD_SC_UNAVAILABLE) {
 		    XGQ_ERR(xgq, "No SC firmware as part of ext fpt");
 			return false;
 		}
-		if (sc_status == VMR_CMD_SC_READY) {
+		if (sc_status == XGQ_CMD_SC_READY) {
 			XGQ_INFO(xgq, "SC is ready after %d sec", i);
 			return true;
 		}

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
@@ -186,7 +186,6 @@ struct xocl_xgq_vmr {
 
 static int vmr_status_query(struct platform_device *pdev);
 static void xgq_offline_service(struct xocl_xgq_vmr *xgq);
-static bool vmr_check_sc_is_ready(struct xocl_xgq_vmr *xgq);
 static uint64_t xgq_get_data(struct platform_device *pdev,
 	enum data_kind kind);
 
@@ -2231,8 +2230,13 @@ static int xgq_collect_sensors(struct platform_device *pdev, int aid, int sid,
 	u32 length = 0;
 	int ret = 0;
 	int id = 0;
+	struct xgq_cmd_cq_vmr_payload *vmr_status = (struct xgq_cmd_cq_vmr_payload *)&xgq->xgq_cq_payload;
 
-	if (!vmr_check_sc_is_ready(xgq)) {
+    ret = vmr_status_query(xgq->xgq_pdev);
+	if (ret)
+		XGQ_ERR(xgq, "received error %d for vmr_status_query xgq request", ret);
+
+	if (!vmr_status->sc_is_ready) {
 		XGQ_ERR(xgq, "SC is not ready, skipping sensors request command");
 		return -EAGAIN;
 	}
@@ -3385,31 +3389,28 @@ static int xgq_vmr_remove(struct platform_device *pdev)
 	return 0;
 }
 
-static bool vmr_check_sc_is_ready(struct xocl_xgq_vmr *xgq)
-{
-	struct xgq_cmd_cq_vmr_payload *vmr_status =
-		(struct xgq_cmd_cq_vmr_payload *)&xgq->xgq_cq_payload;
-	int ret = vmr_status_query(xgq->xgq_pdev);
-
-	if (ret)
-		XGQ_ERR(xgq, "received error %d for vmr_status_query xgq request", ret);
-
-	if (vmr_status->sc_is_ready)
-		return true;
-
-	return false;
-}
-
 /* Wait for SC is fully ready during driver init (in reset) */
 static bool vmr_wait_for_sc_ready(struct xocl_xgq_vmr *xgq)
 {
 	const unsigned int loop_counter = vmr_sc_ready_timeout *
 		(1000 / SC_WAIT_INTERVAL_MSEC);
 	unsigned int i = 0;
+	struct xgq_cmd_cq_vmr_payload *vmr_status = (struct xgq_cmd_cq_vmr_payload *)&xgq->xgq_cq_payload;
+	int ret = 0;
+
+	vmr_status_query(xgq->xgq_pdev);
+	if (ret)
+		XGQ_ERR(xgq, "received error %d for vmr_status_query xgq request", ret);
+
+	if (!vmr_status->has_ext_scfw)
+	{
+		XGQ_ERR(xgq, "No SC firmware as part of ext fpt");
+		return false;
+	}
 
 	for (i = 1; i <= loop_counter; i++) {
 		msleep(SC_WAIT_INTERVAL_MSEC);
-		if (vmr_check_sc_is_ready(xgq)) {
+	if (vmr_status->sc_is_ready) {
 			XGQ_INFO(xgq, "SC is ready after %d sec", i);
 			return true;
 		}
@@ -3471,7 +3472,7 @@ static int vmr_services_probe(struct platform_device *pdev)
 		if (ret)
 			XGQ_WARN(xgq, "unable to create HWMON_SDM subdev, ret: %d", ret);
 	} else {
-		XGQ_ERR(xgq, "SC is not ready and inactive, some user functions may not work properly");
+		XGQ_ERR(xgq, "No communication established with SC, some user functions may not work properly");
 	}
 
 	return 0;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
mgmt driver performs retries without checking for SC existence.
Added check to validate for SC existence before checking for SC ready state.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Bug found during Rave board bring up
#### How problem was solved, alternative solutions (if any) and why they were rejected
Added check to validate for SC existence before checking for SC ready state.

#### Risks (if any) associated the changes in the commit
No
#### What has been tested and how, request additional testing if necessary
1. Verified SC Ready state validation behavior on both V70 and Rave boards.
2. Verified collect sensors functionality on V70 card.
#### Documentation impact (if any)
No