### PR TITLE
Added temporary fix to write ap_start twice on trace S2MM cores (workaround for CR-1181692)

### DIFF
--- a/src/runtime_src/xdp/profile/device/aieTraceS2MM.cpp
+++ b/src/runtime_src/xdp/profile/device/aieTraceS2MM.cpp
@@ -15,8 +15,11 @@
  */
 
 #include "aieTraceS2MM.h"
+#include "core/common/message.h"
+#include <sstream>
 
 namespace xdp {
+using severity_level = xrt_core::message::severity_level;
 
 void AIETraceS2MM::init(uint64_t bo_size, int64_t bufaddr, bool circular)
 {
@@ -42,6 +45,24 @@ void AIETraceS2MM::init(uint64_t bo_size, int64_t bufaddr, bool circular)
 
     // Start Data Mover
     write32(TS2MM_AP_CTRL, TS2MM_AP_START);
+
+    // TEMPORARY: apply second start (CR-1181692)
+    if (xrt_core::config::get_verbosity() >= static_cast<uint32_t>(severity_level::debug)) {
+      uint32_t regValue = 0;
+      read(TS2MM_AP_CTRL, BYTES_PER_WORD, &regValue);
+      std::stringstream msg;
+      msg << "AIE TraceS2MM AP control register after first start: 0x" << std::hex << regValue;
+      xrt_core::message::send(severity_level::debug, "XRT", msg.str());
+    }
+    write32(TS2MM_AP_CTRL, TS2MM_AP_START);
+    if (xrt_core::config::get_verbosity() >= static_cast<uint32_t>(severity_level::debug)) {
+      uint32_t regValue = 0;
+      read(TS2MM_AP_CTRL, BYTES_PER_WORD, &regValue);
+      std::stringstream msg;
+      msg << "AIE TraceS2MM AP control register after first start: 0x" << std::hex << regValue;
+      xrt_core::message::send(severity_level::debug, "XRT", msg.str());
+    }
+    // End of temporary code
 }
 
 uint64_t AIETraceS2MM::getWordCount(bool final)

--- a/src/runtime_src/xdp/profile/device/ioctl_monitors/ioctl_aieTraceS2MM.cpp
+++ b/src/runtime_src/xdp/profile/device/ioctl_monitors/ioctl_aieTraceS2MM.cpp
@@ -85,6 +85,8 @@ void IOCtlAIETraceS2MM::init(uint64_t bo_size, int64_t bufaddr, bool circular)
 
   struct ts2mm_config cfg = { bo_size, static_cast<uint64_t>(bufaddr), circular };
   ioctl(driver_FD, TR_S2MM_IOC_START, &cfg);
+  // TEMPORARY: apply second start (CR-1181692)
+  ioctl(driver_FD, TR_S2MM_IOC_START, &cfg);
 }
 
 void IOCtlAIETraceS2MM::reset()

--- a/src/runtime_src/xdp/profile/device/ioctl_monitors/ioctl_traceS2MM.cpp
+++ b/src/runtime_src/xdp/profile/device/ioctl_monitors/ioctl_traceS2MM.cpp
@@ -78,6 +78,8 @@ void IOCtlTraceS2MM::init(uint64_t bo_size, int64_t bufaddr, bool circular)
 
   struct ts2mm_config cfg = { bo_size, static_cast<uint64_t>(bufaddr), circular };
   ioctl(driver_FD, TR_S2MM_IOC_START, &cfg);
+  // TEMPORARY: apply second start (CR-1181692)
+  ioctl(driver_FD, TR_S2MM_IOC_START, &cfg);
 }
 
 void IOCtlTraceS2MM::reset()


### PR DESCRIPTION
**Problem solved by the commit**
Trace S2MM core does not start after application of a single ap_start

**How problem was solved, alternative solutions (if any) and why they were rejected**
Apply two ap_start calls to AP control register. Eventually, the HW flow will be fixed, but trace needs to be up and running.

**Risks (if any) associated the changes in the commit**
Old xclbins will receive a second unnecessary ap_start but should still work

**What has been tested and how, request additional testing if necessary**
Tested old and new xclbins on vek280

**Documentation impact (if any)**
N/A