### PR TITLE
Fix issue in AIE metadata parsing for profiling

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info/aie_util.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info/aie_util.cpp
@@ -111,32 +111,49 @@ xdp::aie::driver_config
 getDriverConfig(const boost::property_tree::ptree& aie_meta,
               const std::string& root)
 {
-xdp::aie::driver_config config;
-auto meta_config = aie_meta.get_child(root);
+  xdp::aie::driver_config config;
+  auto meta_config = aie_meta.get_child(root);
 
-config.hw_gen =
-  meta_config.get_child("hw_gen").get_value<uint8_t>();
-config.base_address =
-  meta_config.get_child("base_address").get_value<uint64_t>();
-config.column_shift =
-  meta_config.get_child("column_shift").get_value<uint8_t>();
-config.row_shift =
-  meta_config.get_child("row_shift").get_value<uint8_t>();
-config.num_rows =
-  meta_config.get_child("num_rows").get_value<uint8_t>();
-config.num_columns =
-  meta_config.get_child("num_columns").get_value<uint8_t>();
-config.shim_row =
-  meta_config.get_child("shim_row").get_value<uint8_t>();
-config.mem_row_start =
-  meta_config.get_child("mem_row_start").get_value<uint8_t>();
-config.mem_num_rows =
-  meta_config.get_child("mem_num_rows").get_value<uint8_t>();
-config.aie_tile_row_start =
-  meta_config.get_child("aie_tile_row_start").get_value<uint8_t>();
-config.aie_tile_num_rows =
-  meta_config.get_child("aie_tile_num_rows").get_value<uint8_t>();
-return config;
+  config.hw_gen =
+    meta_config.get_child("hw_gen").get_value<uint8_t>();
+  config.base_address =
+    meta_config.get_child("base_address").get_value<uint64_t>();
+  config.column_shift =
+    meta_config.get_child("column_shift").get_value<uint8_t>();
+  config.row_shift =
+    meta_config.get_child("row_shift").get_value<uint8_t>();
+  config.num_rows =
+    meta_config.get_child("num_rows").get_value<uint8_t>();
+  config.num_columns =
+    meta_config.get_child("num_columns").get_value<uint8_t>();
+  config.shim_row =
+    meta_config.get_child("shim_row").get_value<uint8_t>();
+
+  // For backward compatability, look for both the old and new fields
+  bool found = false;
+  try {
+    config.mem_row_start =
+      meta_config.get_child("mem_tile_row_start").get_value<uint8_t>();
+    config.mem_num_rows =
+      meta_config.get_child("mem_tile_num_rows").get_value<uint8_t>();
+    found = true;
+  }
+  catch (std::exception& /*e*/) {
+    // For older xclbins, it is not an error if we don't find the
+    // mem_tile entries, so just catch the exception and ignore it.
+  }
+  if (!found) {
+    config.mem_row_start =
+      meta_config.get_child("reserved_row_start").get_value<uint8_t>();
+    config.mem_num_rows =
+      meta_config.get_child("reserved_num_rows").get_value<uint8_t>();
+  }
+
+  config.aie_tile_row_start =
+    meta_config.get_child("aie_tile_row_start").get_value<uint8_t>();
+  config.aie_tile_num_rows =
+    meta_config.get_child("aie_tile_num_rows").get_value<uint8_t>();
+  return config;
 }
 
 uint16_t


### PR DESCRIPTION
#### Problem solved by the commit
Parsing of aie_control_config.json files was failing due to not finding certain field.  This commit fixes the parsing to look for the correct names of the rows "mem_tile_num_rows" and "mem_tile_row_start" as well as adds backward compatibility to older aie_control_config.json files.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
The bug was recently introduced in PR 7798 when the metadata parsing was refactored.  It was discovered via testing on client devices.

#### What has been tested and how, request additional testing if necessary
The parsing has been tested on a passing and failing metadata file.

#### Documentation impact (if any)
No documentation impact.
