### PR TITLE
Clean up Windows export directives in debug/profiling library

### DIFF
--- a/src/runtime_src/xdp/appdebug/appdebug.cpp
+++ b/src/runtime_src/xdp/appdebug/appdebug.cpp
@@ -22,7 +22,7 @@
  * It defines lambda functions that are attached as debug action with the cl_event
  */
 
-#define XDP_SOURCE
+#define XDP_PLUGIN_SOURCE
 
 #include "xdp/appdebug/appdebug.h"
 #include "xdp/appdebug/appdebug_track.h"

--- a/src/runtime_src/xdp/config.h
+++ b/src/runtime_src/xdp/config.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015-2019, Xilinx Inc - All rights reserved
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
  * Xilinx Runtime (XRT) APIs
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
@@ -18,25 +19,44 @@
 #ifndef xdp_config_h_
 #define xdp_config_h_
 
-//------------------Enable dynamic linking on windows-------------------------// 
+//------------------Enable dynamic linking on windows-----------------------// 
 
 #ifdef _WIN32
-  #ifdef XDP_SOURCE
-    #define XDP_EXPORT __declspec(dllexport)
+  #ifdef XDP_CORE_SOURCE
+    #define XDP_CORE_EXPORT __declspec(dllexport)
   #else
-    #define XDP_EXPORT __declspec(dllimport)
+    #define XDP_CORE_EXPORT __declspec(dllimport)
   #endif  
 #endif
 #ifdef __GNUC__
-  #ifdef XDP_SOURCE
-    #define XDP_EXPORT __attribute__ ((visibility("default")))
+  #ifdef XDP_CORE_SOURCE
+    #define XDP_CORE_EXPORT __attribute__ ((visibility("default")))
   #else
-    #define XDP_EXPORT
+    #define XDP_CORE_EXPORT
   #endif
 #endif
 
-#ifndef XDP_EXPORT
-  #define XDP_EXPORT
+#ifndef XDP_CORE_EXPORT
+  #define XDP_CORE_EXPORT
+#endif
+
+#ifdef _WIN32
+  #ifdef XDP_PLUGIN_SOURCE
+    #define XDP_PLUGIN_EXPORT __declspec(dllexport)
+  #else
+    #define XDP_PLUGIN_EXPORT __declspec(dllimport)
+  #endif  
+#endif
+#ifdef __GNUC__
+  #ifdef XDP_PLUGIN_SOURCE
+    #define XDP_PLUGIN_EXPORT __attribute__ ((visibility("default")))
+  #else
+    #define XDP_PLUGIN_EXPORT
+  #endif
+#endif
+
+#ifndef XDP_PLUGIN_EXPORT
+  #define XDP_PLUGIN_EXPORT
 #endif
 
 #endif

--- a/src/runtime_src/xdp/debug/debug_plugin.cpp
+++ b/src/runtime_src/xdp/debug/debug_plugin.cpp
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2016-2020 Xilinx, Inc
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -14,11 +15,11 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_PLUGIN_SOURCE
 
+#include "core/include/xclbin.h"
 #include "xdp/debug/debug_plugin.h"
 #include "xdp/debug/kernel_debug_manager.h"
-#include "core/include/xclbin.h"
 #include "xocl/api/plugin/xdp/debug.h"
 
 namespace xdp {

--- a/src/runtime_src/xdp/debug/debug_plugin.h
+++ b/src/runtime_src/xdp/debug/debug_plugin.h
@@ -21,7 +21,7 @@
 #include "core/include/xclbin.h"
 
 extern "C" {
-  XDP_EXPORT void cb_debug_reset(const axlf* xclbin) ;
+  XDP_PLUGIN_EXPORT void cb_debug_reset(const axlf* xclbin) ;
 }
 
 #endif

--- a/src/runtime_src/xdp/debug/kernel_debug_manager.cpp
+++ b/src/runtime_src/xdp/debug/kernel_debug_manager.cpp
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2016-2020 Xilinx, Inc
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -14,7 +15,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_PLUGIN_SOURCE
 
 #include <cstdlib>
 #include <filesystem>

--- a/src/runtime_src/xdp/profile/database/database.cpp
+++ b/src/runtime_src/xdp/profile/database/database.cpp
@@ -15,7 +15,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_CORE_SOURCE
 
 #include "core/common/config_reader.h"
 #include "xdp/profile/database/database.h"

--- a/src/runtime_src/xdp/profile/database/database.h
+++ b/src/runtime_src/xdp/profile/database/database.h
@@ -75,9 +75,9 @@ namespace xdp {
     static bool live ;
 
   public:
-    XDP_EXPORT ~VPDatabase() ;
-    XDP_EXPORT static VPDatabase* Instance() ;
-    XDP_EXPORT static bool alive() ;
+    XDP_CORE_EXPORT ~VPDatabase() ;
+    XDP_CORE_EXPORT static VPDatabase* Instance() ;
+    XDP_CORE_EXPORT static bool alive() ;
 
     // Access to the three different types of information
     inline VPStatisticsDatabase& getStats()       { return stats ; }
@@ -90,11 +90,11 @@ namespace xdp {
     inline void registerInfo(uint64_t info)    { pluginInfo |= info ; }
     inline bool infoAvailable(uint64_t info)   { return (pluginInfo&info)!=0; }
 
-    XDP_EXPORT uint64_t addDevice(const std::string&);
-    XDP_EXPORT uint64_t getDeviceId(const std::string&);
+    XDP_CORE_EXPORT uint64_t addDevice(const std::string&);
+    XDP_CORE_EXPORT uint64_t getDeviceId(const std::string&);
 
     // Functions that send messages to registered plugins
-    XDP_EXPORT void broadcast(MessageType msg, void* blob = nullptr);
+    XDP_CORE_EXPORT void broadcast(MessageType msg, void* blob = nullptr);
   } ;
 }
 

--- a/src/runtime_src/xdp/profile/database/dynamic_event_database.cpp
+++ b/src/runtime_src/xdp/profile/database/dynamic_event_database.cpp
@@ -15,7 +15,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_CORE_SOURCE
 
 #include "xdp/profile/database/database.h"
 #include "xdp/profile/database/dynamic_event_database.h"

--- a/src/runtime_src/xdp/profile/database/dynamic_event_database.h
+++ b/src/runtime_src/xdp/profile/database/dynamic_event_database.h
@@ -81,50 +81,50 @@ namespace xdp {
     void addDeviceEvent(uint64_t deviceId, VTFEvent* event);
 
   public:
-    XDP_EXPORT VPDynamicDatabase(VPDatabase* d);
-    XDP_EXPORT ~VPDynamicDatabase() = default;
+    XDP_CORE_EXPORT VPDynamicDatabase(VPDatabase* d);
+    XDP_CORE_EXPORT ~VPDynamicDatabase() = default;
 
     // For multiple xclbin designs, add a device event that marks the
     // transition from one xclbin to another
-    XDP_EXPORT void markXclbinEnd(uint64_t deviceId);
+    XDP_CORE_EXPORT void markXclbinEnd(uint64_t deviceId);
 
     // Add an event in sorted order in the database
-    XDP_EXPORT void addEvent(VTFEvent* event);
+    XDP_CORE_EXPORT void addEvent(VTFEvent* event);
 
     // Add an event to the database to be sorted later when we write
-    XDP_EXPORT void addUnsortedEvent(VTFEvent* event);
+    XDP_CORE_EXPORT void addUnsortedEvent(VTFEvent* event);
 
     // For API events, find the event id of the start event for an end event
-    XDP_EXPORT void markStart(uint64_t functionID, uint64_t eventID) ;
-    XDP_EXPORT uint64_t matchingStart(uint64_t functionID) ;
+    XDP_CORE_EXPORT void markStart(uint64_t functionID, uint64_t eventID) ;
+    XDP_CORE_EXPORT uint64_t matchingStart(uint64_t functionID) ;
 
     // For user level events, find the label and tooltip associated
-    XDP_EXPORT void markRange(uint64_t functionID,
+    XDP_CORE_EXPORT void markRange(uint64_t functionID,
 			      std::pair<const char*, const char*> desc,
 			      uint64_t startTimestamp) ;
-    XDP_EXPORT UserRangeInfo matchingRange(uint64_t functionID) ;
+    XDP_CORE_EXPORT UserRangeInfo matchingRange(uint64_t functionID) ;
 
     // For Device Events, find matching start for end event
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     void markDeviceEventStart(uint64_t deviceId,
                               uint64_t monitorId,
                               DeviceEventInfo& info) ;
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     DeviceEventInfo
     matchingDeviceEventStart(uint64_t deviceId,
                              uint64_t monitorId,
                              VTFEventType type) ;
-    XDP_EXPORT bool hasMatchingDeviceEventStart(uint64_t deviceId,
+    XDP_CORE_EXPORT bool hasMatchingDeviceEventStart(uint64_t deviceId,
                                                 uint64_t monitiorId,
                                                 VTFEventType type) ;
 
     // For API events that we cannot guarantee have unique IDs across all
     //  the plugins, we have a seperate matching of start to end
-    XDP_EXPORT void markXRTUIDStart(uint64_t uid, uint64_t eventID) ;
-    XDP_EXPORT uint64_t matchingXRTUIDStart(uint64_t uid);
+    XDP_CORE_EXPORT void markXRTUIDStart(uint64_t uid, uint64_t eventID) ;
+    XDP_CORE_EXPORT uint64_t matchingXRTUIDStart(uint64_t uid);
 
-    XDP_EXPORT void markEventPairStart(uint64_t functionId, const EventPair& events);
-    XDP_EXPORT EventPair matchingEventPairStart(uint64_t functionId);
+    XDP_CORE_EXPORT void markEventPairStart(uint64_t functionId, const EventPair& events);
+    XDP_CORE_EXPORT EventPair matchingEventPairStart(uint64_t functionId);
 
     // A lookup into the string table.  If the string isn't already in
     // the string table it will be added
@@ -133,22 +133,22 @@ namespace xdp {
 
     // A function that iterates on the dynamic events and returns
     // copies of the events based upon the filter passed in
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     std::vector<VTFEvent*>
     copySortedHostEvents(std::function<bool(VTFEvent*)> filter);
 
     // Erase events from db and transfer ownership to caller
-    XDP_EXPORT std::vector<std::unique_ptr<VTFEvent>> moveSortedHostEvents(std::function<bool(VTFEvent*)> filter);
-    XDP_EXPORT std::vector<VTFEvent*> moveUnsortedHostEvents(std::function<bool(VTFEvent*)> filter);
-    XDP_EXPORT std::vector<std::unique_ptr<VTFEvent>> moveDeviceEvents(uint64_t deviceId);
+    XDP_CORE_EXPORT std::vector<std::unique_ptr<VTFEvent>> moveSortedHostEvents(std::function<bool(VTFEvent*)> filter);
+    XDP_CORE_EXPORT std::vector<VTFEvent*> moveUnsortedHostEvents(std::function<bool(VTFEvent*)> filter);
+    XDP_CORE_EXPORT std::vector<std::unique_ptr<VTFEvent>> moveDeviceEvents(uint64_t deviceId);
 
-    XDP_EXPORT bool deviceEventsExist(uint64_t deviceId);
-    XDP_EXPORT bool hostEventsExist(std::function<bool(VTFEvent*)> filter);
+    XDP_CORE_EXPORT bool deviceEventsExist(uint64_t deviceId);
+    XDP_CORE_EXPORT bool hostEventsExist(std::function<bool(VTFEvent*)> filter);
 
-    XDP_EXPORT void setCounterResults(uint64_t deviceId,
+    XDP_CORE_EXPORT void setCounterResults(uint64_t deviceId,
 				      xrt_core::uuid uuid,
 				      xdp::CounterResults& values) ;
-    XDP_EXPORT xdp::CounterResults getCounterResults(uint64_t deviceId,
+    XDP_CORE_EXPORT xdp::CounterResults getCounterResults(uint64_t deviceId,
                                                      xrt_core::uuid uuid) ;
 
     // A function that each writer calls to dump the string table
@@ -156,36 +156,36 @@ namespace xdp {
     { stringTable.dumpTable(fout); }
 
     // OpenCL mappings and dependencies
-    XDP_EXPORT void addOpenCLMapping(uint64_t openclID, uint64_t eventID, uint64_t startID) ;
-    XDP_EXPORT std::pair<uint64_t, uint64_t>
+    XDP_CORE_EXPORT void addOpenCLMapping(uint64_t openclID, uint64_t eventID, uint64_t startID) ;
+    XDP_CORE_EXPORT std::pair<uint64_t, uint64_t>
     lookupOpenCLMapping(uint64_t openclID) ;
 
-    XDP_EXPORT void addDependency(uint64_t id, uint64_t dependency) ;
-    XDP_EXPORT std::map<uint64_t, std::vector<uint64_t>> getDependencyMap() ;
+    XDP_CORE_EXPORT void addDependency(uint64_t id, uint64_t dependency) ;
+    XDP_CORE_EXPORT std::map<uint64_t, std::vector<uint64_t>> getDependencyMap() ;
 
     // Add and get AIE Trace Data Buffer 
-    XDP_EXPORT void addAIETraceData(uint64_t deviceId, uint64_t strmIndex, void* buffer, uint64_t bufferSz, bool copy);
-    XDP_EXPORT aie::TraceDataType* getAIETraceData(uint64_t deviceId, uint64_t strmIndex);
+    XDP_CORE_EXPORT void addAIETraceData(uint64_t deviceId, uint64_t strmIndex, void* buffer, uint64_t bufferSz, bool copy);
+    XDP_CORE_EXPORT aie::TraceDataType* getAIETraceData(uint64_t deviceId, uint64_t strmIndex);
 
     // Functions that are used by counter-based plugins
-    XDP_EXPORT void addPowerSample(uint64_t deviceId, double timestamp,
+    XDP_CORE_EXPORT void addPowerSample(uint64_t deviceId, double timestamp,
 				   const std::vector<uint64_t>& values) ;
-    XDP_EXPORT std::vector<counters::Sample> getPowerSamples(uint64_t deviceId) ;
+    XDP_CORE_EXPORT std::vector<counters::Sample> getPowerSamples(uint64_t deviceId) ;
 
-    XDP_EXPORT void addAIESample(uint64_t deviceId, double timestamp,
+    XDP_CORE_EXPORT void addAIESample(uint64_t deviceId, double timestamp,
 				   const std::vector<uint64_t>& values) ;
-    XDP_EXPORT std::vector<counters::Sample> getAIESamples(uint64_t deviceId) ;
-    XDP_EXPORT void addAIETimerSample(uint64_t deviceId, unsigned long timestamp1,
+    XDP_CORE_EXPORT std::vector<counters::Sample> getAIESamples(uint64_t deviceId) ;
+    XDP_CORE_EXPORT void addAIETimerSample(uint64_t deviceId, unsigned long timestamp1,
 				   unsigned long timestamp2, const std::vector<uint64_t>& values) ;
-    XDP_EXPORT std::vector<counters::DoubleSample> getAIETimerSamples(uint64_t deviceId) ;
+    XDP_CORE_EXPORT std::vector<counters::DoubleSample> getAIETimerSamples(uint64_t deviceId) ;
 
     // Device Trace Buffer Fullness Status - PL
-    XDP_EXPORT void setPLTraceBufferFull(uint64_t deviceId, bool val);
-    XDP_EXPORT bool isPLTraceBufferFull(uint64_t deviceId);
+    XDP_CORE_EXPORT void setPLTraceBufferFull(uint64_t deviceId, bool val);
+    XDP_CORE_EXPORT bool isPLTraceBufferFull(uint64_t deviceId);
 
     // Deadlock Diagnosis metadata
-    XDP_EXPORT void setPLDeadlockInfo(uint64_t deviceId, const std::string& str);
-    XDP_EXPORT std::string getPLDeadlockInfo();
+    XDP_CORE_EXPORT void setPLDeadlockInfo(uint64_t deviceId, const std::string& str);
+    XDP_CORE_EXPORT std::string getPLDeadlockInfo();
   } ;
   
 }

--- a/src/runtime_src/xdp/profile/database/dynamic_info/aie_db.cpp
+++ b/src/runtime_src/xdp/profile/database/dynamic_info/aie_db.cpp
@@ -14,7 +14,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_CORE_SOURCE
 
 #include <cstring>
 

--- a/src/runtime_src/xdp/profile/database/dynamic_info/aie_db.h
+++ b/src/runtime_src/xdp/profile/database/dynamic_info/aie_db.h
@@ -42,7 +42,7 @@ namespace xdp {
 
   public:
     AIEDB() = default;
-    XDP_EXPORT ~AIEDB();
+    XDP_CORE_EXPORT ~AIEDB();
 
     void addAIETraceData(uint64_t strmIndex, void* buffer, uint64_t bufferSz,
                          bool copy, uint64_t numTraceStreams);

--- a/src/runtime_src/xdp/profile/database/dynamic_info/host_db.cpp
+++ b/src/runtime_src/xdp/profile/database/dynamic_info/host_db.cpp
@@ -14,7 +14,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_CORE_SOURCE
 
 #include "xdp/profile/database/dynamic_info/host_db.h"
 #include "xdp/profile/database/events/vtf_event.h"

--- a/src/runtime_src/xdp/profile/database/dynamic_info/host_db.h
+++ b/src/runtime_src/xdp/profile/database/dynamic_info/host_db.h
@@ -74,7 +74,7 @@ namespace xdp {
 
   public:
     HostDB() = default;
-    XDP_EXPORT ~HostDB();
+    XDP_CORE_EXPORT ~HostDB();
 
     // Functions to add host events to the database
     void addSortedEvent(VTFEvent* event);

--- a/src/runtime_src/xdp/profile/database/dynamic_info/pl_db.cpp
+++ b/src/runtime_src/xdp/profile/database/dynamic_info/pl_db.cpp
@@ -14,7 +14,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_CORE_SOURCE
 
 #include "xdp/profile/database/database.h"
 #include "xdp/profile/database/dynamic_info/pl_db.h"

--- a/src/runtime_src/xdp/profile/database/dynamic_info/string_table.cpp
+++ b/src/runtime_src/xdp/profile/database/dynamic_info/string_table.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -14,7 +14,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_CORE_SOURCE
 
 #include "xdp/profile/database/dynamic_info/string_table.h"
 

--- a/src/runtime_src/xdp/profile/database/dynamic_info/string_table.h
+++ b/src/runtime_src/xdp/profile/database/dynamic_info/string_table.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -38,8 +38,8 @@ namespace xdp {
     StringTable() = default;
     ~StringTable() = default;
 
-    XDP_EXPORT uint64_t addString(const std::string& value);
-    XDP_EXPORT void dumpTable(std::ofstream& fout);
+    XDP_CORE_EXPORT uint64_t addString(const std::string& value);
+    XDP_CORE_EXPORT void dumpTable(std::ofstream& fout);
   };
 
 } // end namespace xdp

--- a/src/runtime_src/xdp/profile/database/events/creator/aie_trace_data_logger.cpp
+++ b/src/runtime_src/xdp/profile/database/events/creator/aie_trace_data_logger.cpp
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2020 Xilinx, Inc
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -14,7 +15,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_CORE_SOURCE
 
 #include "xdp/profile/database/events/creator/aie_trace_data_logger.h"
 

--- a/src/runtime_src/xdp/profile/database/events/creator/aie_trace_data_logger.h
+++ b/src/runtime_src/xdp/profile/database/events/creator/aie_trace_data_logger.h
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2020 Xilinx, Inc
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -30,12 +31,12 @@ class AIETraceDataLogger : public AIETraceLogger
 
 public:
 
-  XDP_EXPORT
+  XDP_CORE_EXPORT
   AIETraceDataLogger(uint64_t devId);
-  XDP_EXPORT
+  XDP_CORE_EXPORT
   virtual ~AIETraceDataLogger();
 
-  XDP_EXPORT
+  XDP_CORE_EXPORT
   virtual void addAIETraceData(uint64_t strmIndex, void* buffer, uint64_t bufferSz, bool copy);
 };
 

--- a/src/runtime_src/xdp/profile/database/events/device_events.cpp
+++ b/src/runtime_src/xdp/profile/database/events/device_events.cpp
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2016-2022 Xilinx, Inc
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -16,7 +17,7 @@
 
 #include <iomanip>
 
-#define XDP_SOURCE
+#define XDP_CORE_SOURCE
 
 #include "xdp/profile/database/events/device_events.h"
 #include "xdp/profile/database/static_info_database.h"

--- a/src/runtime_src/xdp/profile/database/events/device_events.h
+++ b/src/runtime_src/xdp/profile/database/events/device_events.h
@@ -43,11 +43,11 @@ namespace xdp {
     virtual void dumpTimestamp(std::ofstream& fout) ;
 
   public:
-    XDP_EXPORT VTFDeviceEvent(uint64_t s_id, double ts, VTFEventType ty,
+    XDP_CORE_EXPORT VTFDeviceEvent(uint64_t s_id, double ts, VTFEventType ty,
                               uint64_t devId, uint32_t monId);
-    XDP_EXPORT ~VTFDeviceEvent() ;
+    XDP_CORE_EXPORT ~VTFDeviceEvent() ;
 
-    XDP_EXPORT virtual void dump(std::ofstream& fout, uint32_t bucket);
+    XDP_CORE_EXPORT virtual void dump(std::ofstream& fout, uint32_t bucket);
 
     virtual bool     isDeviceEvent() { return true ; }
     virtual uint64_t getDevice()     { return deviceId ; }
@@ -66,12 +66,12 @@ namespace xdp {
 
     KernelEvent() = delete ;
   public:
-    XDP_EXPORT KernelEvent(uint64_t s_id, double ts, VTFEventType ty,
+    XDP_CORE_EXPORT KernelEvent(uint64_t s_id, double ts, VTFEventType ty,
                            uint64_t devId, uint32_t monId, int32_t cuIdx);
-    XDP_EXPORT ~KernelEvent();
+    XDP_CORE_EXPORT ~KernelEvent();
 
-    XDP_EXPORT virtual int32_t getCUId() { return cuId; }
-    XDP_EXPORT virtual void dump(std::ofstream& fout, uint32_t bucket) ;
+    XDP_CORE_EXPORT virtual int32_t getCUId() { return cuId; }
+    XDP_CORE_EXPORT virtual void dump(std::ofstream& fout, uint32_t bucket) ;
   };
 
   class KernelStall : public KernelEvent
@@ -81,10 +81,10 @@ namespace xdp {
 
     KernelStall() = delete ;
   public:
-    XDP_EXPORT KernelStall(uint64_t s_id, double ts, VTFEventType ty,
+    XDP_CORE_EXPORT KernelStall(uint64_t s_id, double ts, VTFEventType ty,
                            uint64_t devId, uint32_t monId, int32_t cuIdx);
-    XDP_EXPORT ~KernelStall();
-    XDP_EXPORT virtual void dump(std::ofstream& fout, uint32_t bucket);
+    XDP_CORE_EXPORT ~KernelStall();
+    XDP_CORE_EXPORT virtual void dump(std::ofstream& fout, uint32_t bucket);
   } ;
 
   class DeviceMemoryAccess : public VTFDeviceEvent
@@ -99,12 +99,12 @@ namespace xdp {
 
     DeviceMemoryAccess() = delete ;
   public:
-    XDP_EXPORT DeviceMemoryAccess(uint64_t s_id, double ts, VTFEventType ty,
+    XDP_CORE_EXPORT DeviceMemoryAccess(uint64_t s_id, double ts, VTFEventType ty,
                                   uint64_t devId, uint32_t monId, int32_t cuIdx = -1,
                                   uint64_t memStrId = 0);
-    XDP_EXPORT ~DeviceMemoryAccess();
+    XDP_CORE_EXPORT ~DeviceMemoryAccess();
 
-    XDP_EXPORT virtual void dump(std::ofstream& fout, uint32_t bucket);
+    XDP_CORE_EXPORT virtual void dump(std::ofstream& fout, uint32_t bucket);
 
     virtual int32_t getCUId() { return cuId; }
 
@@ -121,9 +121,9 @@ namespace xdp {
 
     DeviceStreamAccess() = delete ;
   public:
-    XDP_EXPORT DeviceStreamAccess(uint64_t s_id, double ts, VTFEventType ty,
+    XDP_CORE_EXPORT DeviceStreamAccess(uint64_t s_id, double ts, VTFEventType ty,
                                   uint64_t devId, uint32_t monId, int32_t cuIdx = -1);
-    XDP_EXPORT ~DeviceStreamAccess();
+    XDP_CORE_EXPORT ~DeviceStreamAccess();
 
     virtual int32_t getCUId() { return cuId; }
   } ;
@@ -133,8 +133,8 @@ namespace xdp {
   private:
     HostRead() = delete ;
   public:
-    XDP_EXPORT HostRead(uint64_t s_id, double ts, uint64_t devId, uint32_t monId) ;
-    XDP_EXPORT ~HostRead() ;
+    XDP_CORE_EXPORT HostRead(uint64_t s_id, double ts, uint64_t devId, uint32_t monId) ;
+    XDP_CORE_EXPORT ~HostRead() ;
   } ;
 
   class HostWrite : public VTFDeviceEvent
@@ -142,8 +142,8 @@ namespace xdp {
   private:
     HostWrite() = delete ;
   public:
-    XDP_EXPORT HostWrite(uint64_t s_id, double ts, uint64_t devId, uint32_t monId) ;
-    XDP_EXPORT ~HostWrite() ;
+    XDP_CORE_EXPORT HostWrite(uint64_t s_id, double ts, uint64_t devId, uint32_t monId) ;
+    XDP_CORE_EXPORT ~HostWrite() ;
   } ;
 
   class XclbinEnd : public VTFDeviceEvent
@@ -151,8 +151,8 @@ namespace xdp {
   private:
     XclbinEnd() = delete ;
   public:
-    XDP_EXPORT XclbinEnd(uint64_t s_id, double ts, uint64_t devId, uint32_t monId) ;
-    XDP_EXPORT ~XclbinEnd() ;
+    XDP_CORE_EXPORT XclbinEnd(uint64_t s_id, double ts, uint64_t devId, uint32_t monId) ;
+    XDP_CORE_EXPORT ~XclbinEnd() ;
   } ;
 
 } // end namespace xdp

--- a/src/runtime_src/xdp/profile/database/events/hal_api_calls.cpp
+++ b/src/runtime_src/xdp/profile/database/events/hal_api_calls.cpp
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2016-2020 Xilinx, Inc
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -14,7 +15,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_CORE_SOURCE
 
 #include "xdp/profile/database/events/hal_api_calls.h"
 

--- a/src/runtime_src/xdp/profile/database/events/hal_api_calls.h
+++ b/src/runtime_src/xdp/profile/database/events/hal_api_calls.h
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2016-2020 Xilinx, Inc
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -30,13 +31,13 @@ namespace xdp {
   private:
     HALAPICall() = delete ;
   public:
-    XDP_EXPORT HALAPICall(uint64_t s_id, double ts, uint64_t name) ;
-    XDP_EXPORT ~HALAPICall() ;
+    XDP_CORE_EXPORT HALAPICall(uint64_t s_id, double ts, uint64_t name) ;
+    XDP_CORE_EXPORT ~HALAPICall() ;
 
     virtual bool isHALAPI()       { return true ; }
     virtual bool isHALHostEvent() { return true ; }
 
-    XDP_EXPORT virtual void dump(std::ofstream& fout, uint32_t bucket) ;
+    XDP_CORE_EXPORT virtual void dump(std::ofstream& fout, uint32_t bucket) ;
   } ;
 
   class AllocBoCall : public HALAPICall
@@ -44,10 +45,10 @@ namespace xdp {
   private:
     AllocBoCall() = delete ;
   public:
-    XDP_EXPORT AllocBoCall(uint64_t s_id, double ts, uint64_t name) ;
-    XDP_EXPORT ~AllocBoCall() ;
+    XDP_CORE_EXPORT AllocBoCall(uint64_t s_id, double ts, uint64_t name) ;
+    XDP_CORE_EXPORT ~AllocBoCall() ;
 
-    XDP_EXPORT virtual void dump(std::ofstream& fout, uint32_t bucket) ;
+    XDP_CORE_EXPORT virtual void dump(std::ofstream& fout, uint32_t bucket) ;
   } ;
 
 } // end namespace xdp

--- a/src/runtime_src/xdp/profile/database/events/native_events.cpp
+++ b/src/runtime_src/xdp/profile/database/events/native_events.cpp
@@ -15,7 +15,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_CORE_SOURCE
 
 #include "xdp/profile/database/database.h"
 #include "xdp/profile/database/events/native_events.h"

--- a/src/runtime_src/xdp/profile/database/events/native_events.h
+++ b/src/runtime_src/xdp/profile/database/events/native_events.h
@@ -25,12 +25,12 @@ namespace xdp {
   class NativeAPICall : public APICall
   {
   public:
-    XDP_EXPORT NativeAPICall(uint64_t s_id, double ts, uint64_t name);
-    XDP_EXPORT ~NativeAPICall() = default;
+    XDP_CORE_EXPORT NativeAPICall(uint64_t s_id, double ts, uint64_t name);
+    XDP_CORE_EXPORT ~NativeAPICall() = default;
 
-    XDP_EXPORT virtual bool isNativeHostEvent() { return true; }
+    XDP_CORE_EXPORT virtual bool isNativeHostEvent() { return true; }
 
-    XDP_EXPORT virtual void dump(std::ofstream& fout, uint32_t bucket);
+    XDP_CORE_EXPORT virtual void dump(std::ofstream& fout, uint32_t bucket);
   };
 
   class NativeSyncRead : public NativeAPICall
@@ -38,14 +38,14 @@ namespace xdp {
   private:
     uint64_t readStr;
   public:
-    XDP_EXPORT NativeSyncRead(uint64_t s_id, double ts, uint64_t name);
-    XDP_EXPORT ~NativeSyncRead() = default;
+    XDP_CORE_EXPORT NativeSyncRead(uint64_t s_id, double ts, uint64_t name);
+    XDP_CORE_EXPORT ~NativeSyncRead() = default;
 
-    XDP_EXPORT virtual bool isNativeRead() override { return true; }
+    XDP_CORE_EXPORT virtual bool isNativeRead() override { return true; }
 
     // For printing out the event in a different bucket as a different
     //  type of event, without having to store additional events in the database
-    XDP_EXPORT virtual void dumpSync(std::ofstream& fout, uint32_t bucket) override;
+    XDP_CORE_EXPORT virtual void dumpSync(std::ofstream& fout, uint32_t bucket) override;
   };
 
   class NativeSyncWrite : public NativeAPICall
@@ -53,14 +53,14 @@ namespace xdp {
   private:
     uint64_t writeStr;
   public:
-    XDP_EXPORT NativeSyncWrite(uint64_t s_id, double ts, uint64_t name);
-    XDP_EXPORT ~NativeSyncWrite() = default;
+    XDP_CORE_EXPORT NativeSyncWrite(uint64_t s_id, double ts, uint64_t name);
+    XDP_CORE_EXPORT ~NativeSyncWrite() = default;
 
-    XDP_EXPORT virtual bool isNativeWrite() override { return true; }
+    XDP_CORE_EXPORT virtual bool isNativeWrite() override { return true; }
 
     // For printing out the event in a different bucket as a different
     //  type of event, without having to store additional events in the databaes
-    XDP_EXPORT virtual void dumpSync(std::ofstream& fout, uint32_t bucket) override;
+    XDP_CORE_EXPORT virtual void dumpSync(std::ofstream& fout, uint32_t bucket) override;
   };
 
 } // end namespace xdp

--- a/src/runtime_src/xdp/profile/database/events/opencl_api_calls.cpp
+++ b/src/runtime_src/xdp/profile/database/events/opencl_api_calls.cpp
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2016-2020 Xilinx, Inc
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -14,7 +15,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_CORE_SOURCE
 
 #include "xdp/profile/database/events/opencl_api_calls.h"
 

--- a/src/runtime_src/xdp/profile/database/events/opencl_api_calls.h
+++ b/src/runtime_src/xdp/profile/database/events/opencl_api_calls.h
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2016-2020 Xilinx, Inc
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -31,15 +32,15 @@ namespace xdp {
 
     OpenCLAPICall() = delete ;
   public:
-    XDP_EXPORT OpenCLAPICall(uint64_t s_id, double ts, uint64_t f_id, uint64_t name, uint64_t q, bool l = false);
-    XDP_EXPORT ~OpenCLAPICall() ;
+    XDP_CORE_EXPORT OpenCLAPICall(uint64_t s_id, double ts, uint64_t f_id, uint64_t name, uint64_t q, bool l = false);
+    XDP_CORE_EXPORT ~OpenCLAPICall() ;
 
     inline uint64_t getQueueAddress() { return queueAddress ; } 
 
     virtual bool isOpenCLAPI() { return true ; }
     virtual bool isLOPAPI() { return isLOP ; }
     virtual bool isOpenCLHostEvent() { return !isLOP ; }
-    XDP_EXPORT virtual void dump(std::ofstream& fout, uint32_t bucket) ;
+    XDP_CORE_EXPORT virtual void dump(std::ofstream& fout, uint32_t bucket) ;
   } ;
 
 } // end namespace xdp

--- a/src/runtime_src/xdp/profile/database/events/opencl_host_events.cpp
+++ b/src/runtime_src/xdp/profile/database/events/opencl_host_events.cpp
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2016-2020 Xilinx, Inc
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -14,7 +15,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_CORE_SOURCE
 
 #include "xdp/profile/database/events/opencl_host_events.h"
 

--- a/src/runtime_src/xdp/profile/database/events/opencl_host_events.h
+++ b/src/runtime_src/xdp/profile/database/events/opencl_host_events.h
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2016-2020 Xilinx, Inc
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -42,19 +43,19 @@ namespace xdp {
 
     KernelEnqueue() = delete ;
   public:
-    XDP_EXPORT KernelEnqueue(uint64_t s_id, double ts, 
+    XDP_CORE_EXPORT KernelEnqueue(uint64_t s_id, double ts, 
 			     uint64_t dName, uint64_t bName, uint64_t kName,
 			     uint64_t wgc, size_t wgs,
 			     const char* enqueueId) ;
 
-    XDP_EXPORT ~KernelEnqueue() ;
+    XDP_CORE_EXPORT ~KernelEnqueue() ;
 
     inline std::string getIdentifier() { return identifier ; }
 
     virtual bool isHostEvent() { return true ; }
     virtual bool isOpenCLHostEvent() { return true ; }
     
-    XDP_EXPORT virtual void dump(std::ofstream& fout, uint32_t bucket) ;
+    XDP_CORE_EXPORT virtual void dump(std::ofstream& fout, uint32_t bucket) ;
   } ;
 
   class LOPKernelEnqueue : public VTFEvent
@@ -62,13 +63,13 @@ namespace xdp {
   private:
     LOPKernelEnqueue() = delete ;
   public:
-    XDP_EXPORT LOPKernelEnqueue(uint64_t s_id, double ts) ;
-    XDP_EXPORT ~LOPKernelEnqueue() ;
+    XDP_CORE_EXPORT LOPKernelEnqueue(uint64_t s_id, double ts) ;
+    XDP_CORE_EXPORT ~LOPKernelEnqueue() ;
 
     virtual bool isHostEvent() { return true ; }
     virtual bool isLOPHostEvent() { return true ; }
 
-    XDP_EXPORT virtual void dump(std::ofstream& fout, uint32_t bucket) ;
+    XDP_CORE_EXPORT virtual void dump(std::ofstream& fout, uint32_t bucket) ;
   } ;
 
   /*
@@ -87,8 +88,8 @@ namespace xdp {
 
     CUEnqueue() = delete ;
   public:
-    XDP_EXPORT CUEnqueue(uint64_t s_id, double ts) ;
-    XDP_EXPORT ~CUEnqueue() ;
+    XDP_CORE_EXPORT CUEnqueue(uint64_t s_id, double ts) ;
+    XDP_CORE_EXPORT ~CUEnqueue() ;
 
     virtual bool isHostEvent() { return true ; } 
   } ;
@@ -100,13 +101,13 @@ namespace xdp {
 
     BufferTransfer() = delete ;
   public:
-    XDP_EXPORT BufferTransfer(uint64_t s_id, double ts, VTFEventType ty,
+    XDP_CORE_EXPORT BufferTransfer(uint64_t s_id, double ts, VTFEventType ty,
                               size_t bufSz = 0);
-    XDP_EXPORT ~BufferTransfer() ;
+    XDP_CORE_EXPORT ~BufferTransfer() ;
 
     virtual bool isHostEvent() { return true ; } 
 
-    XDP_EXPORT virtual void dump(std::ofstream& fout, uint32_t bucket) ;
+    XDP_CORE_EXPORT virtual void dump(std::ofstream& fout, uint32_t bucket) ;
   } ;
 
   class OpenCLBufferTransfer : public VTFEvent
@@ -119,15 +120,15 @@ namespace xdp {
 
     OpenCLBufferTransfer() = delete ;
   public:
-    XDP_EXPORT OpenCLBufferTransfer(uint64_t s_id, double ts, VTFEventType ty,
+    XDP_CORE_EXPORT OpenCLBufferTransfer(uint64_t s_id, double ts, VTFEventType ty,
 				    uint64_t address, uint64_t resource,
 				    size_t size) ;
-    XDP_EXPORT ~OpenCLBufferTransfer() ;
+    XDP_CORE_EXPORT ~OpenCLBufferTransfer() ;
 
     virtual bool isHostEvent()       { return true ; }
     virtual bool isOpenCLHostEvent() { return true ; }
 
-    XDP_EXPORT virtual void dump(std::ofstream& fout, uint32_t bucket) ;
+    XDP_CORE_EXPORT virtual void dump(std::ofstream& fout, uint32_t bucket) ;
   } ;
 
   class OpenCLCopyBuffer : public VTFEvent
@@ -142,16 +143,16 @@ namespace xdp {
 
     OpenCLCopyBuffer() = delete ;
   public:
-    XDP_EXPORT OpenCLCopyBuffer(uint64_t s_id, double ts, VTFEventType ty,
+    XDP_CORE_EXPORT OpenCLCopyBuffer(uint64_t s_id, double ts, VTFEventType ty,
 				uint64_t srcAddress, uint64_t srcResource,
 				uint64_t dstAddress, uint64_t dstResource,
 				size_t size) ;
-    XDP_EXPORT ~OpenCLCopyBuffer() ;
+    XDP_CORE_EXPORT ~OpenCLCopyBuffer() ;
 
     virtual bool isHostEvent()       { return true ; }
     virtual bool isOpenCLHostEvent() { return true ; }
 
-    XDP_EXPORT virtual void dump(std::ofstream& fout, uint32_t bucket) ;
+    XDP_CORE_EXPORT virtual void dump(std::ofstream& fout, uint32_t bucket) ;
   } ;
 
   class LOPBufferTransfer : public VTFEvent
@@ -159,13 +160,13 @@ namespace xdp {
   private:
     std::thread::id threadId ;
   public:
-    XDP_EXPORT LOPBufferTransfer(uint64_t s_id, double ts, VTFEventType ty) ;
-    XDP_EXPORT ~LOPBufferTransfer() ;
+    XDP_CORE_EXPORT LOPBufferTransfer(uint64_t s_id, double ts, VTFEventType ty) ;
+    XDP_CORE_EXPORT ~LOPBufferTransfer() ;
 
     virtual bool isHostEvent() { return true ; }
     virtual bool isLOPHostEvent() { return true ; }
 
-    XDP_EXPORT virtual void dump(std::ofstream& fout, uint32_t bucket) ;
+    XDP_CORE_EXPORT virtual void dump(std::ofstream& fout, uint32_t bucket) ;
   } ;
 
   class StreamRead : public VTFEvent
@@ -173,8 +174,8 @@ namespace xdp {
   private:
     StreamRead() = delete ;
   public:
-    XDP_EXPORT StreamRead(uint64_t s_id, double ts) ;
-    XDP_EXPORT ~StreamRead() ;
+    XDP_CORE_EXPORT StreamRead(uint64_t s_id, double ts) ;
+    XDP_CORE_EXPORT ~StreamRead() ;
 
     virtual bool isHostEvent() { return true ; } 
   } ;
@@ -184,8 +185,8 @@ namespace xdp {
   private:
     StreamWrite() = delete ;
   public:
-    XDP_EXPORT StreamWrite(uint64_t s_id, double ts) ;
-    XDP_EXPORT ~StreamWrite() ;
+    XDP_CORE_EXPORT StreamWrite(uint64_t s_id, double ts) ;
+    XDP_CORE_EXPORT ~StreamWrite() ;
 
     virtual bool isHostEvent() { return true ; } 
   } ;

--- a/src/runtime_src/xdp/profile/database/events/user_events.cpp
+++ b/src/runtime_src/xdp/profile/database/events/user_events.cpp
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2016-2020 Xilinx, Inc
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -14,7 +15,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_CORE_SOURCE
 
 #include "xdp/profile/database/events/user_events.h"
 

--- a/src/runtime_src/xdp/profile/database/events/user_events.h
+++ b/src/runtime_src/xdp/profile/database/events/user_events.h
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2016-2020 Xilinx, Inc
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -36,10 +37,10 @@ namespace xdp {
 
   public:
     virtual bool isUserEvent() { return true ; } 
-    XDP_EXPORT UserMarker(uint64_t s_id, double ts, uint64_t l = 0) ;
-    XDP_EXPORT ~UserMarker() ;
+    XDP_CORE_EXPORT UserMarker(uint64_t s_id, double ts, uint64_t l = 0) ;
+    XDP_CORE_EXPORT ~UserMarker() ;
 
-    XDP_EXPORT virtual void dump(std::ofstream& fout, uint32_t bucket) ;
+    XDP_CORE_EXPORT virtual void dump(std::ofstream& fout, uint32_t bucket) ;
   } ;
 
   class UserRange : public VTFEvent
@@ -55,11 +56,11 @@ namespace xdp {
   public:
     virtual bool isUserEvent() { return true ; } 
 
-    XDP_EXPORT UserRange(uint64_t s_id, double ts, bool s, 
+    XDP_CORE_EXPORT UserRange(uint64_t s_id, double ts, bool s, 
 			 uint64_t l = 0, uint64_t tt = 0) ;
-    XDP_EXPORT ~UserRange() ;
+    XDP_CORE_EXPORT ~UserRange() ;
 
-    XDP_EXPORT virtual void dump(std::ofstream& fout, uint32_t bucket) ;
+    XDP_CORE_EXPORT virtual void dump(std::ofstream& fout, uint32_t bucket) ;
   } ;
 
 } // end namespace xdp

--- a/src/runtime_src/xdp/profile/database/events/vtf_event.cpp
+++ b/src/runtime_src/xdp/profile/database/events/vtf_event.cpp
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2016-2020 Xilinx, Inc
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -17,7 +18,7 @@
 #include <fstream>
 #include <iomanip>
 
-#define XDP_SOURCE
+#define XDP_CORE_SOURCE
 
 #include "xdp/profile/database/events/vtf_event.h"
 

--- a/src/runtime_src/xdp/profile/database/events/vtf_event.h
+++ b/src/runtime_src/xdp/profile/database/events/vtf_event.h
@@ -92,8 +92,8 @@ namespace xdp {
     void dumpType(std::ofstream& fout, bool humanReadable) ;
 
   public:
-    XDP_EXPORT VTFEvent(uint64_t s_id, double ts, VTFEventType ty) ;
-    XDP_EXPORT virtual ~VTFEvent() ;
+    XDP_CORE_EXPORT VTFEvent(uint64_t s_id, double ts, VTFEventType ty) ;
+    XDP_CORE_EXPORT virtual ~VTFEvent() ;
 
     // Getters and Setters
     inline double       getTimestamp()    const { return timestamp ; }
@@ -133,8 +133,8 @@ namespace xdp {
 	                                    type == LOP_KERNEL_ENQUEUE ; }
 
     virtual uint64_t getDevice() { return 0 ; } // CHECK
-    XDP_EXPORT virtual void dump(std::ofstream& fout, uint32_t bucket) ;
-    XDP_EXPORT virtual void dumpSync(std::ofstream& /*fout*/, uint32_t /*bucket*/) {};
+    XDP_CORE_EXPORT virtual void dump(std::ofstream& fout, uint32_t bucket) ;
+    XDP_CORE_EXPORT virtual void dumpSync(std::ofstream& /*fout*/, uint32_t /*bucket*/) {};
   } ;
 
   // Used so the database can sort based on timestamp order
@@ -154,8 +154,8 @@ namespace xdp {
 
     APICall() = delete ;
   public:
-    XDP_EXPORT APICall(uint64_t s_id, double ts, uint64_t name, VTFEventType ty);
-    XDP_EXPORT ~APICall() ;
+    XDP_CORE_EXPORT APICall(uint64_t s_id, double ts, uint64_t name, VTFEventType ty);
+    XDP_CORE_EXPORT ~APICall() ;
 
     virtual bool isHostEvent() { return true ; } 
   } ;

--- a/src/runtime_src/xdp/profile/database/static_info/aie_util.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info/aie_util.cpp
@@ -14,7 +14,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_CORE_SOURCE
 
 #include <cstdint>
 #include <boost/property_tree/json_parser.hpp>

--- a/src/runtime_src/xdp/profile/database/static_info/aie_util.h
+++ b/src/runtime_src/xdp/profile/database/static_info/aie_util.h
@@ -28,41 +28,41 @@
 
 namespace xdp::aie {
 
-  XDP_EXPORT
+  XDP_CORE_EXPORT
   bool 
   tileCompare(xdp::tile_type tile1, xdp::tile_type tile2); 
 
-  XDP_EXPORT 
+  XDP_CORE_EXPORT 
   void 
   throwIfError(bool err, const char* msg);
 
   // A function to read the JSON from an axlf section inside the xclbin and
   // return the type of the file
-  XDP_EXPORT
+  XDP_CORE_EXPORT
   std::unique_ptr<BaseFiletypeImpl>
   readAIEMetadata(const char* data, size_t size,
                   boost::property_tree::ptree& aie_project);
 
   // A function to read the JSON from a file on disk and return the type of
   // the file
-  XDP_EXPORT
+  XDP_CORE_EXPORT
   std::unique_ptr<BaseFiletypeImpl>
   readAIEMetadata(const char* filename,
                   boost::property_tree::ptree& aie_project);
 
-  XDP_EXPORT
+  XDP_CORE_EXPORT
   int getHardwareGeneration(const boost::property_tree::ptree& aie_meta,
                           const std::string& root);
 
-  XDP_EXPORT
+  XDP_CORE_EXPORT
   xdp::aie::driver_config
   getDriverConfig(const boost::property_tree::ptree& aie_meta,
                 const std::string& root);
-  XDP_EXPORT
+  XDP_CORE_EXPORT
   uint16_t
   getAIETileRowOffset(const boost::property_tree::ptree& aie_meta,
                     const std::string& location);
-  XDP_EXPORT
+  XDP_CORE_EXPORT
   std::vector<std::string>
   getValidGraphs(const boost::property_tree::ptree& aie_meta,
                 const std::string& root);

--- a/src/runtime_src/xdp/profile/database/static_info/device_info.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info/device_info.cpp
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2021 Xilinx, Inc
- * Copyright (C) 2022 Advanced Micro Devices, Inc - All rights reserved.
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc - All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -15,7 +15,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_CORE_SOURCE
 
 #include "xdp/profile/database/static_info/device_info.h"
 #include "xdp/profile/database/static_info/pl_constructs.h"

--- a/src/runtime_src/xdp/profile/database/static_info/device_info.h
+++ b/src/runtime_src/xdp/profile/database/static_info/device_info.h
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2021-2022 Xilinx, Inc
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -85,71 +85,71 @@ namespace xdp {
     ~DeviceInfo() ;
 
     // ****** Functions for information on the device ******
-    XDP_EXPORT std::string getUniqueDeviceName() const ;
-    XDP_EXPORT xrt_core::uuid currentXclbinUUID() ;
+    XDP_CORE_EXPORT std::string getUniqueDeviceName() const ;
+    XDP_CORE_EXPORT xrt_core::uuid currentXclbinUUID() ;
     inline std::vector<XclbinInfo*> getLoadedXclbins() { return loadedXclbins ;}
-    XDP_EXPORT void cleanCurrentXclbinInfo() ;
+    XDP_CORE_EXPORT void cleanCurrentXclbinInfo() ;
     inline bool isNoDMA() const { return isNoDMADevice ; }
     double getMaxClockRatePLMHz();
 
-    XDP_EXPORT void setAIEGeneration(uint8_t hw_gen) { aieGeneration = hw_gen; }
+    XDP_CORE_EXPORT void setAIEGeneration(uint8_t hw_gen) { aieGeneration = hw_gen; }
     inline uint8_t getAIEGeneration() const { return aieGeneration ; }
 
     // ****** Functions for information on the currently loaded xclbin *******
-    XDP_EXPORT XclbinInfo* currentXclbin() ;
-    XDP_EXPORT void addXclbin(XclbinInfo* xclbin) ;
-    XDP_EXPORT bool hasDMAMonitor() ;
-    XDP_EXPORT bool hasDMABypassMonitor() ;
-    XDP_EXPORT bool hasKDMAMonitor() ;
-    XDP_EXPORT bool hasAIMNamed(const std::string& name) ;
+    XDP_CORE_EXPORT XclbinInfo* currentXclbin() ;
+    XDP_CORE_EXPORT void addXclbin(XclbinInfo* xclbin) ;
+    XDP_CORE_EXPORT bool hasDMAMonitor() ;
+    XDP_CORE_EXPORT bool hasDMABypassMonitor() ;
+    XDP_CORE_EXPORT bool hasKDMAMonitor() ;
+    XDP_CORE_EXPORT bool hasAIMNamed(const std::string& name) ;
 
     // ****** Functions for PL information on a specific xclbin ******
-    XDP_EXPORT bool hasFloatingAIMWithTrace(XclbinInfo* xclbin) const ;
-    XDP_EXPORT bool hasFloatingASMWithTrace(XclbinInfo* xclbin) const ;
-    XDP_EXPORT uint64_t getNumAM(XclbinInfo* xclbin) const ;
-    XDP_EXPORT uint64_t getNumUserAMWithTrace(XclbinInfo* xclbin) const ;
-    XDP_EXPORT uint64_t getNumAIM(XclbinInfo* xclbin) const ;
-    XDP_EXPORT uint64_t getNumUserAIM(XclbinInfo* xclbin) const ;
-    XDP_EXPORT uint64_t getNumUserAIMWithTrace(XclbinInfo* xclbin) const ;
-    XDP_EXPORT uint64_t getNumASM(XclbinInfo* xclbin) const ;
-    XDP_EXPORT uint64_t getNumUserASM(XclbinInfo* xclbin) const ;
-    XDP_EXPORT uint64_t getNumUserASMWithTrace(XclbinInfo* xclbin) const ;
+    XDP_CORE_EXPORT bool hasFloatingAIMWithTrace(XclbinInfo* xclbin) const ;
+    XDP_CORE_EXPORT bool hasFloatingASMWithTrace(XclbinInfo* xclbin) const ;
+    XDP_CORE_EXPORT uint64_t getNumAM(XclbinInfo* xclbin) const ;
+    XDP_CORE_EXPORT uint64_t getNumUserAMWithTrace(XclbinInfo* xclbin) const ;
+    XDP_CORE_EXPORT uint64_t getNumAIM(XclbinInfo* xclbin) const ;
+    XDP_CORE_EXPORT uint64_t getNumUserAIM(XclbinInfo* xclbin) const ;
+    XDP_CORE_EXPORT uint64_t getNumUserAIMWithTrace(XclbinInfo* xclbin) const ;
+    XDP_CORE_EXPORT uint64_t getNumASM(XclbinInfo* xclbin) const ;
+    XDP_CORE_EXPORT uint64_t getNumUserASM(XclbinInfo* xclbin) const ;
+    XDP_CORE_EXPORT uint64_t getNumUserASMWithTrace(XclbinInfo* xclbin) const ;
 
     // Functions that get specific information on monitors
-    XDP_EXPORT Monitor* getAMonitor(XclbinInfo* xclbin, uint64_t slotId) ;
-    XDP_EXPORT Monitor* getAIMonitor(XclbinInfo* xclbin, uint64_t slotId) ;
-    XDP_EXPORT Monitor* getASMonitor(XclbinInfo* xclbin, uint64_t slotId) ;
+    XDP_CORE_EXPORT Monitor* getAMonitor(XclbinInfo* xclbin, uint64_t slotId) ;
+    XDP_CORE_EXPORT Monitor* getAIMonitor(XclbinInfo* xclbin, uint64_t slotId) ;
+    XDP_CORE_EXPORT Monitor* getASMonitor(XclbinInfo* xclbin, uint64_t slotId) ;
 
-    XDP_EXPORT std::vector<Monitor*>* getAIMonitors(XclbinInfo* xclbin) ;
-    XDP_EXPORT std::vector<Monitor*>* getASMonitors(XclbinInfo* xclbin) ;
-    XDP_EXPORT std::vector<Monitor*> getUserAIMsWithTrace(XclbinInfo* xclbin) ;
-    XDP_EXPORT std::vector<Monitor*> getUserASMsWithTrace(XclbinInfo* xclbin) ;
+    XDP_CORE_EXPORT std::vector<Monitor*>* getAIMonitors(XclbinInfo* xclbin) ;
+    XDP_CORE_EXPORT std::vector<Monitor*>* getASMonitors(XclbinInfo* xclbin) ;
+    XDP_CORE_EXPORT std::vector<Monitor*> getUserAIMsWithTrace(XclbinInfo* xclbin) ;
+    XDP_CORE_EXPORT std::vector<Monitor*> getUserASMsWithTrace(XclbinInfo* xclbin) ;
     
     // ****** Functions for AIE information on a specific xclbin ******
-    XDP_EXPORT uint64_t getNumNOC(XclbinInfo* xclbin) const ;
-    XDP_EXPORT NoCNode* getNOC(XclbinInfo* xclbin, uint64_t idx) ;
+    XDP_CORE_EXPORT uint64_t getNumNOC(XclbinInfo* xclbin) const ;
+    XDP_CORE_EXPORT NoCNode* getNOC(XclbinInfo* xclbin, uint64_t idx) ;
 
     // ****** Functions for AIE information on the current xclbin ******
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     void addTraceGMIO(uint32_t i, uint16_t col, uint16_t num, uint16_t stream,
                       uint16_t len) ;
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     void addAIECounter(uint32_t i, uint16_t col, uint16_t r, uint8_t num,
                        uint16_t start, uint16_t end, uint8_t reset,
                        uint32_t load, double freq, const std::string& mod,
                        const std::string& aieName) ;
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     void addAIECounterResources(uint32_t numCounters, uint32_t numTiles,
                                 uint8_t moduleType) ;
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     void addAIECoreEventResources(uint32_t numEvents, uint32_t numTiles) ;
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     void addAIEMemoryEventResources(uint32_t numEvents, uint32_t numTiles) ;
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     void addAIEShimEventResources(uint32_t numEvents, uint32_t numTiles) ;
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     void addAIEMemTileEventResources(uint32_t numEvents, uint32_t numTiles) ;
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     void addAIECfgTile(std::unique_ptr<aie_cfg_tile>& tile) ;
   } ;
 

--- a/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_control_config_filetype.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_control_config_filetype.cpp
@@ -14,7 +14,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_CORE_SOURCE
 
 #include <boost/algorithm/string.hpp>
 #include <boost/property_tree/json_parser.hpp>

--- a/src/runtime_src/xdp/profile/database/static_info/pl_constructs.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info/pl_constructs.cpp
@@ -17,7 +17,7 @@
 
 #include <string>
 
-#define XDP_SOURCE
+#define XDP_CORE_SOURCE
 
 #include "core/common/message.h"
 

--- a/src/runtime_src/xdp/profile/database/static_info/pl_constructs.h
+++ b/src/runtime_src/xdp/profile/database/static_info/pl_constructs.h
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2021-2022 Xilinx, Inc
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -261,20 +261,20 @@ namespace xdp {
     inline void addASM(uint32_t id, bool trace = false)
       { asmIds.push_back(id) ; if (trace) asmIdsWithTrace.push_back(id) ; }
 
-    XDP_EXPORT std::string getDim() ; // Construct a string from the dimensions
-    XDP_EXPORT void addConnection(int32_t argIdx, int32_t memIdx) ;
+    XDP_CORE_EXPORT std::string getDim() ; // Construct a string from the dimensions
+    XDP_CORE_EXPORT void addConnection(int32_t argIdx, int32_t memIdx) ;
 
-    XDP_EXPORT void addPort(const std::string& n, int32_t w);
-    XDP_EXPORT void addArgToPort(const std::string& arg,
+    XDP_CORE_EXPORT void addPort(const std::string& n, int32_t w);
+    XDP_CORE_EXPORT void addArgToPort(const std::string& arg,
                                  const std::string& portName);
-    XDP_EXPORT void addMemoryToPort(Memory* mem, const std::string& portName);
-    XDP_EXPORT void connectArgToMemory(const std::string& portName,
+    XDP_CORE_EXPORT void addMemoryToPort(Memory* mem, const std::string& portName);
+    XDP_CORE_EXPORT void connectArgToMemory(const std::string& portName,
                                        const std::string& arg,
                                        Memory* mem);
-    XDP_EXPORT Port* getPort(const std::string& portName);
+    XDP_CORE_EXPORT Port* getPort(const std::string& portName);
 
-    XDP_EXPORT explicit ComputeUnitInstance(int32_t i, const std::string& n) ;
-    XDP_EXPORT ~ComputeUnitInstance() = default ;
+    XDP_CORE_EXPORT explicit ComputeUnitInstance(int32_t i, const std::string& n) ;
+    XDP_CORE_EXPORT ~ComputeUnitInstance() = default ;
   } ;
 
   // The Memory struct collects all of the information on a single

--- a/src/runtime_src/xdp/profile/database/static_info/xclbin_info.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info/xclbin_info.cpp
@@ -15,7 +15,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_CORE_SOURCE
 
 #include "xdp/profile/database/static_info/aie_constructs.h"
 #include "xdp/profile/database/static_info/pl_constructs.h"

--- a/src/runtime_src/xdp/profile/database/static_info_database.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info_database.cpp
@@ -40,7 +40,7 @@
 #include "core/common/api/xclbin_int.h"
 #include "core/include/xclbin.h"
 
-#define XDP_SOURCE
+#define XDP_CORE_SOURCE
 
 #include "xdp/profile/database/database.h"
 #include "xdp/profile/database/static_info/device_info.h"

--- a/src/runtime_src/xdp/profile/database/static_info_database.h
+++ b/src/runtime_src/xdp/profile/database/static_info_database.h
@@ -151,17 +151,17 @@ namespace xdp {
 
     // ********************************************************
     // ***** Functions related to the running application *****
-    XDP_EXPORT int getPid() const ;
+    XDP_CORE_EXPORT int getPid() const ;
 
     // The first profiling plugin loaded sets the application start time.
     //  It does not capture the true application start time, but rather
     //  the earliest time our constructs can capture when the shared libraries
     //  are loaded.
-    XDP_EXPORT uint64_t getApplicationStartTime() const ;
-    XDP_EXPORT void setApplicationStartTime(uint64_t t) ;
+    XDP_CORE_EXPORT uint64_t getApplicationStartTime() const ;
+    XDP_CORE_EXPORT void setApplicationStartTime(uint64_t t) ;
 
-    XDP_EXPORT bool getAieApplication() const ;
-    XDP_EXPORT void setAieApplication() ;
+    XDP_CORE_EXPORT bool getAieApplication() const ;
+    XDP_CORE_EXPORT void setAieApplication() ;
 
     // Due to changes in hardware IP, we can only support profiling on
     // xclbins built using 2019.2 or later tools.  Each xclbin is stamped
@@ -170,7 +170,7 @@ namespace xdp {
     constexpr double   earliestSupportedToolVersion() const { return 2019.2; }
     constexpr uint16_t earliestSupportedXRTVersionMajor() const { return 2; }
     constexpr uint16_t earliestSupportedXRTVersionMinor() const { return 5; }
-    XDP_EXPORT bool validXclbin(void* devHandle) ;
+    XDP_CORE_EXPORT bool validXclbin(void* devHandle) ;
 
     // ****************************************************
     // ***** Functions related to OpenCL information. *****
@@ -180,40 +180,40 @@ namespace xdp {
     // OpenCL applications can create and destroy any number of command
     //  queues.  We keep track of the ones that were used (not every
     //  one that was created).
-    XDP_EXPORT std::set<uint64_t>& getCommandQueueAddresses() ;
-    XDP_EXPORT void addCommandQueueAddress(uint64_t a) ;
+    XDP_CORE_EXPORT std::set<uint64_t>& getCommandQueueAddresses() ;
+    XDP_CORE_EXPORT void addCommandQueueAddress(uint64_t a) ;
 
     // For every OpenCL EnqueueNDRange or EnqueueTask call, we keep
     //  track of the device:binary:kernel information so we can display
     //  it in the trace as a separate row.  The names are specific
     //  to the OpenCL layer.
-    XDP_EXPORT std::set<std::string>& getEnqueuedKernels() ;
-    XDP_EXPORT void addEnqueuedKernel(const std::string& identifier) ;
+    XDP_CORE_EXPORT std::set<std::string>& getEnqueuedKernels() ;
+    XDP_CORE_EXPORT void addEnqueuedKernel(const std::string& identifier) ;
 
     // OpenCL can group devices into contexts.  These functions keep
     //  track of this information
-    XDP_EXPORT void setNumDevices(uint64_t contextId, uint64_t numDevices) ;
-    XDP_EXPORT uint64_t getNumDevices(uint64_t contextId) ;
+    XDP_CORE_EXPORT void setNumDevices(uint64_t contextId, uint64_t numDevices) ;
+    XDP_CORE_EXPORT uint64_t getNumDevices(uint64_t contextId) ;
 
     // We do not have device information for software emulation, so
     //  we pick up the name of the device in OpenCL when a kernel is executed.
     //  We assume there is only one device in software emulation.
-    XDP_EXPORT std::string getSoftwareEmulationDeviceName() ;
-    XDP_EXPORT void setSoftwareEmulationDeviceName(const std::string& name) ;
+    XDP_CORE_EXPORT std::string getSoftwareEmulationDeviceName() ;
+    XDP_CORE_EXPORT void setSoftwareEmulationDeviceName(const std::string& name) ;
 
     // In software emulation, we can pick up information on exactly which
     //  compute units are used in each kernel purely from OpenCL calls
     //  (without any hardware monitors).  We collect this information
     //  to summarize CU usage and provide guidance.
-    XDP_EXPORT std::map<std::string, uint64_t> getSoftwareEmulationCUCounts() ;
-    XDP_EXPORT void addSoftwareEmulationCUInstance(const std::string& kernelName) ;
+    XDP_CORE_EXPORT std::map<std::string, uint64_t> getSoftwareEmulationCUCounts() ;
+    XDP_CORE_EXPORT void addSoftwareEmulationCUInstance(const std::string& kernelName) ;
 
     // We provide guidance on what memory resources are used on each device.
     //  For software emulation, since we do not have device information,
     //  we need to dig into the xclbin from OpenCL constructs.  We store
     //  that information here since there is no DeviceInfo.
-    XDP_EXPORT std::map<std::string, bool>& getSoftwareEmulationMemUsage() ;
-    XDP_EXPORT
+    XDP_CORE_EXPORT std::map<std::string, bool>& getSoftwareEmulationMemUsage() ;
+    XDP_CORE_EXPORT
     void addSoftwareEmulationMemUsage(const std::string& mem, bool used) ;
 
     // We provide guidance on the bit width of all of the compute unit
@@ -221,175 +221,175 @@ namespace xdp {
     //  performance.  For software emulation, since we do not have device
     //  information, we need to dig into the xclbin from OpenCL constructs.
     //  We store that information here since there is no DeviceInfo.
-    XDP_EXPORT std::vector<std::string>& getSoftwareEmulationPortBitWidths() ;
-    XDP_EXPORT void addSoftwareEmulationPortBitWidth(const std::string& s) ;
+    XDP_CORE_EXPORT std::vector<std::string>& getSoftwareEmulationPortBitWidths() ;
+    XDP_CORE_EXPORT void addSoftwareEmulationPortBitWidth(const std::string& s) ;
 
     // ************************************************
     // ***** Functions related to the run summary *****
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     std::vector<std::pair<std::string, std::string>>& getOpenedFiles() ;
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     void addOpenedFile(const std::string& name, const std::string& type) ;
-    XDP_EXPORT std::string getSystemDiagram() ;
+    XDP_CORE_EXPORT std::string getSystemDiagram() ;
 
     // ***************************************************************
     // ***** Functions related to information on all the devices *****
-    XDP_EXPORT uint64_t getNumDevices() ;
-    XDP_EXPORT DeviceInfo* getDeviceInfo(uint64_t deviceId) ;
-    XDP_EXPORT std::vector<std::string> getDeviceNames() ;
-    XDP_EXPORT std::vector<DeviceInfo*> getDeviceInfos() ;
+    XDP_CORE_EXPORT uint64_t getNumDevices() ;
+    XDP_CORE_EXPORT DeviceInfo* getDeviceInfo(uint64_t deviceId) ;
+    XDP_CORE_EXPORT std::vector<std::string> getDeviceNames() ;
+    XDP_CORE_EXPORT std::vector<DeviceInfo*> getDeviceInfos() ;
     // If any compute unit on any xclbin on any device has stall enabled,
     //  then we output a table of stall information.
-    XDP_EXPORT bool hasStallInfo() ;
-    XDP_EXPORT XclbinInfo* getCurrentlyLoadedXclbin(uint64_t deviceId) ;
-    XDP_EXPORT void deleteCurrentlyUsedDeviceInterface(uint64_t deviceId) ;
-    XDP_EXPORT bool isDeviceReady(uint64_t deviceId) ;
-    XDP_EXPORT double getClockRateMHz(uint64_t deviceId, bool PL = true) ;
-    XDP_EXPORT void setDeviceName(uint64_t deviceId, const std::string& name) ; 
-    XDP_EXPORT std::string getDeviceName(uint64_t deviceId) ;
-    XDP_EXPORT DeviceIntf* getDeviceIntf(uint64_t deviceId) ;
-    XDP_EXPORT DeviceIntf* createDeviceIntf(uint64_t deviceId, xdp::Device* dev);
-    XDP_EXPORT uint64_t getKDMACount(uint64_t deviceId) ;
-    XDP_EXPORT void setHostMaxReadBW(uint64_t deviceId, double bw) ;
-    XDP_EXPORT double getHostMaxReadBW(uint64_t deviceId) ;
-    XDP_EXPORT void setHostMaxWriteBW(uint64_t deviceId, double bw) ;
-    XDP_EXPORT double getHostMaxWriteBW(uint64_t deviceId) ;
-    XDP_EXPORT void setKernelMaxReadBW(uint64_t deviceId, double bw) ;
-    XDP_EXPORT double getKernelMaxReadBW(uint64_t deviceId) ;
-    XDP_EXPORT void setKernelMaxWriteBW(uint64_t deviceId, double bw) ;
-    XDP_EXPORT double getKernelMaxWriteBW(uint64_t deviceId) ;
-    XDP_EXPORT std::string getXclbinName(uint64_t deviceId) ;
-    XDP_EXPORT std::vector<XclbinInfo*> getLoadedXclbins(uint64_t deviceId) ;
-    XDP_EXPORT ComputeUnitInstance* getCU(uint64_t deviceId, int32_t cuId) ;
-    XDP_EXPORT Memory* getMemory(uint64_t deviceId, int32_t memId) ;
+    XDP_CORE_EXPORT bool hasStallInfo() ;
+    XDP_CORE_EXPORT XclbinInfo* getCurrentlyLoadedXclbin(uint64_t deviceId) ;
+    XDP_CORE_EXPORT void deleteCurrentlyUsedDeviceInterface(uint64_t deviceId) ;
+    XDP_CORE_EXPORT bool isDeviceReady(uint64_t deviceId) ;
+    XDP_CORE_EXPORT double getClockRateMHz(uint64_t deviceId, bool PL = true) ;
+    XDP_CORE_EXPORT void setDeviceName(uint64_t deviceId, const std::string& name) ; 
+    XDP_CORE_EXPORT std::string getDeviceName(uint64_t deviceId) ;
+    XDP_CORE_EXPORT DeviceIntf* getDeviceIntf(uint64_t deviceId) ;
+    XDP_CORE_EXPORT DeviceIntf* createDeviceIntf(uint64_t deviceId, xdp::Device* dev);
+    XDP_CORE_EXPORT uint64_t getKDMACount(uint64_t deviceId) ;
+    XDP_CORE_EXPORT void setHostMaxReadBW(uint64_t deviceId, double bw) ;
+    XDP_CORE_EXPORT double getHostMaxReadBW(uint64_t deviceId) ;
+    XDP_CORE_EXPORT void setHostMaxWriteBW(uint64_t deviceId, double bw) ;
+    XDP_CORE_EXPORT double getHostMaxWriteBW(uint64_t deviceId) ;
+    XDP_CORE_EXPORT void setKernelMaxReadBW(uint64_t deviceId, double bw) ;
+    XDP_CORE_EXPORT double getKernelMaxReadBW(uint64_t deviceId) ;
+    XDP_CORE_EXPORT void setKernelMaxWriteBW(uint64_t deviceId, double bw) ;
+    XDP_CORE_EXPORT double getKernelMaxWriteBW(uint64_t deviceId) ;
+    XDP_CORE_EXPORT std::string getXclbinName(uint64_t deviceId) ;
+    XDP_CORE_EXPORT std::vector<XclbinInfo*> getLoadedXclbins(uint64_t deviceId) ;
+    XDP_CORE_EXPORT ComputeUnitInstance* getCU(uint64_t deviceId, int32_t cuId) ;
+    XDP_CORE_EXPORT Memory* getMemory(uint64_t deviceId, int32_t memId) ;
     // Reseting device information whenever a new xclbin is added
-    XDP_EXPORT void updateDevice(uint64_t deviceId, void* devHandle) ;
-    XDP_EXPORT void updateDeviceClient(uint64_t deviceId, std::shared_ptr<xrt_core::device> device);
+    XDP_CORE_EXPORT void updateDevice(uint64_t deviceId, void* devHandle) ;
+    XDP_CORE_EXPORT void updateDeviceClient(uint64_t deviceId, std::shared_ptr<xrt_core::device> device);
 
     // *********************************************************
     // ***** Functions related to trace_processor tool *****
     // ***** which creates events from raw PL trace    *****
-    XDP_EXPORT void updateDevice(uint64_t deviceId, const std::string& xclbinFile);
+    XDP_CORE_EXPORT void updateDevice(uint64_t deviceId, const std::string& xclbinFile);
 
     // *********************************************************
     // ***** Functions related to AIE specific information *****
-    XDP_EXPORT uint8_t getAIEGeneration(uint64_t deviceId) ;
-    XDP_EXPORT void setIsAIECounterRead(uint64_t deviceId, bool val) ;
-    XDP_EXPORT bool isAIECounterRead(uint64_t deviceId) ;
-    XDP_EXPORT void setIsGMIORead(uint64_t deviceId, bool val) ;
-    XDP_EXPORT bool isGMIORead(uint64_t deviceId) ;
-    XDP_EXPORT uint64_t getNumAIECounter(uint64_t deviceId) ;
-    XDP_EXPORT uint64_t getNumTraceGMIO(uint64_t deviceId) ;
-    XDP_EXPORT AIECounter* getAIECounter(uint64_t deviceId, uint64_t idx) ;
-    XDP_EXPORT
+    XDP_CORE_EXPORT uint8_t getAIEGeneration(uint64_t deviceId) ;
+    XDP_CORE_EXPORT void setIsAIECounterRead(uint64_t deviceId, bool val) ;
+    XDP_CORE_EXPORT bool isAIECounterRead(uint64_t deviceId) ;
+    XDP_CORE_EXPORT void setIsGMIORead(uint64_t deviceId, bool val) ;
+    XDP_CORE_EXPORT bool isGMIORead(uint64_t deviceId) ;
+    XDP_CORE_EXPORT uint64_t getNumAIECounter(uint64_t deviceId) ;
+    XDP_CORE_EXPORT uint64_t getNumTraceGMIO(uint64_t deviceId) ;
+    XDP_CORE_EXPORT AIECounter* getAIECounter(uint64_t deviceId, uint64_t idx) ;
+    XDP_CORE_EXPORT
     std::map<uint32_t, uint32_t>*
     getAIECoreCounterResources(uint64_t deviceId) ;
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     std::map<uint32_t, uint32_t>*
     getAIEMemoryCounterResources(uint64_t deviceId) ;
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     std::map<uint32_t, uint32_t>*
     getAIEShimCounterResources(uint64_t deviceId) ;
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     std::map<uint32_t, uint32_t>*
     getAIEMemTileCounterResources(uint64_t deviceId) ;
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     std::map<uint32_t, uint32_t>* getAIECoreEventResources(uint64_t deviceId) ;
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     std::map<uint32_t, uint32_t>* getAIEMemoryEventResources(uint64_t deviceId) ;
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     std::map<uint32_t, uint32_t>* getAIEShimEventResources(uint64_t deviceId) ;
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     std::map<uint32_t, uint32_t>* getAIEMemTileEventResources(uint64_t deviceId) ;
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     std::vector<std::unique_ptr<aie_cfg_tile>>*
     getAIECfgTiles(uint64_t deviceId) ;
-    XDP_EXPORT TraceGMIO* getTraceGMIO(uint64_t deviceId, uint64_t idx) ;
-    XDP_EXPORT void addTraceGMIO(uint64_t deviceId, uint32_t i, uint16_t col,
+    XDP_CORE_EXPORT TraceGMIO* getTraceGMIO(uint64_t deviceId, uint64_t idx) ;
+    XDP_CORE_EXPORT void addTraceGMIO(uint64_t deviceId, uint32_t i, uint16_t col,
                                  uint16_t num, uint16_t stream, uint16_t len) ;
-    XDP_EXPORT void addAIECounter(uint64_t deviceId, uint32_t i, uint16_t col,
+    XDP_CORE_EXPORT void addAIECounter(uint64_t deviceId, uint32_t i, uint16_t col,
                                   uint16_t r, uint8_t num, uint16_t start,
                                   uint16_t end, uint8_t reset, uint32_t load,
                                   double freq, const std::string& mod,
                                   const std::string& aieName) ;
-    XDP_EXPORT void addAIECounterResources(uint64_t deviceId,
+    XDP_CORE_EXPORT void addAIECounterResources(uint64_t deviceId,
                                            uint32_t numCounters,
                                            uint32_t numTiles,
                                            uint8_t moduleType) ;
-    XDP_EXPORT void addAIECoreEventResources(uint64_t deviceId,
+    XDP_CORE_EXPORT void addAIECoreEventResources(uint64_t deviceId,
                                              uint32_t numEvents,
                                              uint32_t numTiles) ;
-    XDP_EXPORT void addAIEMemoryEventResources(uint64_t deviceId,
+    XDP_CORE_EXPORT void addAIEMemoryEventResources(uint64_t deviceId,
                                                uint32_t numEvents,
                                                uint32_t numTiles) ;
-    XDP_EXPORT void addAIEShimEventResources(uint64_t deviceId,
+    XDP_CORE_EXPORT void addAIEShimEventResources(uint64_t deviceId,
                                              uint32_t numEvents,
                                              uint32_t numTiles) ;
-    XDP_EXPORT void addAIEMemTileEventResources(uint64_t deviceId,
+    XDP_CORE_EXPORT void addAIEMemTileEventResources(uint64_t deviceId,
                                                 uint32_t numEvents,
                                                 uint32_t numTiles) ;
-    XDP_EXPORT void addAIECfgTile(uint64_t deviceId,
+    XDP_CORE_EXPORT void addAIECfgTile(uint64_t deviceId,
                                   std::unique_ptr<aie_cfg_tile>& tile) ;
-    XDP_EXPORT uint64_t getNumTracePLIO(uint64_t deviceId) ;
-    XDP_EXPORT uint64_t getNumAIETraceStream(uint64_t deviceId) ;
-    XDP_EXPORT void* getAieDevInst(std::function<void* (void*)> fetch,
+    XDP_CORE_EXPORT uint64_t getNumTracePLIO(uint64_t deviceId) ;
+    XDP_CORE_EXPORT uint64_t getNumAIETraceStream(uint64_t deviceId) ;
+    XDP_CORE_EXPORT void* getAieDevInst(std::function<void* (void*)> fetch,
                                    void* devHandle) ;
-    XDP_EXPORT void* getAieDevice(std::function<void* (void*)> allocate,
+    XDP_CORE_EXPORT void* getAieDevice(std::function<void* (void*)> allocate,
                                   std::function<void (void*)> deallocate,
                                   void* devHandle) ;
 
     // ************************************************************************
     // ***** Functions for information from a specific xclbin on a device *****
-    XDP_EXPORT uint64_t getNumAM(uint64_t deviceId, XclbinInfo* xclbin) ;
-    XDP_EXPORT
+    XDP_CORE_EXPORT uint64_t getNumAM(uint64_t deviceId, XclbinInfo* xclbin) ;
+    XDP_CORE_EXPORT
     uint64_t getNumUserAMWithTrace(uint64_t deviceId, XclbinInfo* xclbin) ;
-    XDP_EXPORT uint64_t getNumAIM(uint64_t deviceId, XclbinInfo* xclbin) ;
-    XDP_EXPORT uint64_t getNumUserAIM(uint64_t deviceId, XclbinInfo* xclbin) ;
-    XDP_EXPORT
+    XDP_CORE_EXPORT uint64_t getNumAIM(uint64_t deviceId, XclbinInfo* xclbin) ;
+    XDP_CORE_EXPORT uint64_t getNumUserAIM(uint64_t deviceId, XclbinInfo* xclbin) ;
+    XDP_CORE_EXPORT
     uint64_t getNumUserAIMWithTrace(uint64_t deviceId, XclbinInfo* xclbin) ;
-    XDP_EXPORT uint64_t getNumASM(uint64_t deviceId, XclbinInfo* xclbin) ;
-    XDP_EXPORT uint64_t getNumUserASM(uint64_t deviceId, XclbinInfo* xclbin) ;
-    XDP_EXPORT
+    XDP_CORE_EXPORT uint64_t getNumASM(uint64_t deviceId, XclbinInfo* xclbin) ;
+    XDP_CORE_EXPORT uint64_t getNumUserASM(uint64_t deviceId, XclbinInfo* xclbin) ;
+    XDP_CORE_EXPORT
     uint64_t getNumUserASMWithTrace(uint64_t deviceId, XclbinInfo* xclbin) ;
-    XDP_EXPORT uint64_t getNumNOC(uint64_t deviceId, XclbinInfo* xclbin) ;
+    XDP_CORE_EXPORT uint64_t getNumNOC(uint64_t deviceId, XclbinInfo* xclbin) ;
     // Functions that get all of a certain type of monitor
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     std::vector<Monitor*>* getAIMonitors(uint64_t deviceId, XclbinInfo* xclbin);
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     std::vector<Monitor*>  getUserAIMsWithTrace(uint64_t deviceId,
                                                 XclbinInfo* xclbin) ;
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     std::vector<Monitor*>* getASMonitors(uint64_t deviceId, XclbinInfo* xclbin);
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     std::vector<Monitor*>  getUserASMsWithTrace(uint64_t deviceId,
                                                 XclbinInfo* xclbin) ;
-    XDP_EXPORT bool hasFloatingAIMWithTrace(uint64_t deviceId,
+    XDP_CORE_EXPORT bool hasFloatingAIMWithTrace(uint64_t deviceId,
                                             XclbinInfo* xclbin) ;
-    XDP_EXPORT bool hasFloatingASMWithTrace(uint64_t deviceId,
+    XDP_CORE_EXPORT bool hasFloatingASMWithTrace(uint64_t deviceId,
                                             XclbinInfo* xclbin) ;
 
     // ********************************************************************
     // ***** Functions for single monitors from an xclbin on a device *****
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     Monitor* getAMonitor(uint64_t deviceId, XclbinInfo* xclbin,
                          uint64_t slotId) ;
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     Monitor* getAIMonitor(uint64_t deviceId, XclbinInfo* xclbin,
                           uint64_t slotId) ;
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     Monitor* getASMonitor(uint64_t deviceId, XclbinInfo* xclbin,
                           uint64_t slotID) ;
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     NoCNode* getNOC(uint64_t deviceId, XclbinInfo* xclbin, uint64_t idx) ;
     // This function takes a pre-allocated array of bools to fill with 
     //  the status of each compute unit's AM dataflow enabled status
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     void getDataflowConfiguration(uint64_t deviceId, bool* config, size_t size);
     // This fuction taks a pre-allocated array of bools to fill with
     //  information if each compute unit has a fast adapter or not.
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     void getFaConfiguration(uint64_t deviceId, bool* config, size_t size) ;
-    XDP_EXPORT std::string getCtxInfo(uint64_t deviceId) ;
+    XDP_CORE_EXPORT std::string getCtxInfo(uint64_t deviceId) ;
   } ;
 
 }

--- a/src/runtime_src/xdp/profile/database/statistics_database.cpp
+++ b/src/runtime_src/xdp/profile/database/statistics_database.cpp
@@ -19,7 +19,7 @@
 #include <thread>
 #include <iostream>
 
-#define XDP_SOURCE
+#define XDP_CORE_SOURCE
 
 #include "xdp/profile/database/statistics_database.h"
 

--- a/src/runtime_src/xdp/profile/database/statistics_database.h
+++ b/src/runtime_src/xdp/profile/database/statistics_database.h
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2016-2020 Xilinx, Inc
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -249,8 +249,8 @@ namespace xdp {
     void addTopKernelExecution(KernelExecutionStats& exec) ;
 
   public:
-    XDP_EXPORT VPStatisticsDatabase(VPDatabase* d) ;
-    XDP_EXPORT ~VPStatisticsDatabase() ;
+    XDP_CORE_EXPORT VPStatisticsDatabase(VPDatabase* d) ;
+    XDP_CORE_EXPORT ~VPStatisticsDatabase() ;
 
     // Getters and setters
     inline const std::map<std::pair<std::string, std::thread::id>,
@@ -303,19 +303,19 @@ namespace xdp {
       { return commandQueuesAreOOO ; }
     inline void setCommandQueueOOO(uint64_t cq, bool value)
       { commandQueuesAreOOO[cq] = value ; }
-    XDP_EXPORT uint64_t getDeviceActiveTime(const std::string& deviceName) ;
+    XDP_CORE_EXPORT uint64_t getDeviceActiveTime(const std::string& deviceName) ;
 
     // Functions specific to compute unit executions
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     std::vector<std::pair<std::string, TimeStatistics>> 
     getComputeUnitExecutionStats(const std::string& cuName) ;
 
     // User level event functions
     inline bool eventInformationPresent() { return eventCounts.size() != 0 ; }
     inline bool rangeInformationPresent() { return rangeCounts.size() != 0 ; }
-    XDP_EXPORT void addEventCount(const char* label);
-    XDP_EXPORT void addRangeCount(std::pair<const char*, const char*> desc);
-    XDP_EXPORT void recordRangeDuration(std::pair<const char*, const char*> desc, uint64_t duration) ;
+    XDP_CORE_EXPORT void addEventCount(const char* label);
+    XDP_CORE_EXPORT void addRangeCount(std::pair<const char*, const char*> desc);
+    XDP_CORE_EXPORT void recordRangeDuration(std::pair<const char*, const char*> desc, uint64_t duration) ;
     inline std::map<std::string, uint64_t>& getEventCounts()
       { return eventCounts; }
     inline std::map<std::pair<const char*, const char*>, uint64_t>&
@@ -332,20 +332,20 @@ namespace xdp {
       { return totalRangeDurations; }
 
     // Logging Functions
-    XDP_EXPORT void logFunctionCallStart(const std::string& name, 
+    XDP_CORE_EXPORT void logFunctionCallStart(const std::string& name, 
                                          double timestamp) ;
-    XDP_EXPORT void logFunctionCallEnd(const std::string& name, 
+    XDP_CORE_EXPORT void logFunctionCallEnd(const std::string& name, 
                                        double timestamp) ;
 
-    XDP_EXPORT void logMemoryTransfer(uint64_t deviceId, 
+    XDP_CORE_EXPORT void logMemoryTransfer(uint64_t deviceId, 
                                       DeviceMemoryStatistics::ChannelType channelType,
                                       size_t byteCount) ;
 
     // OpenCL level statistic logging
-    XDP_EXPORT void logDeviceActiveTime(const std::string& deviceName,
+    XDP_CORE_EXPORT void logDeviceActiveTime(const std::string& deviceName,
                                         uint64_t startTime,
                                         uint64_t endTime) ;
-    XDP_EXPORT void logKernelExecution(const std::string& kernelName, 
+    XDP_CORE_EXPORT void logKernelExecution(const std::string& kernelName, 
                                        uint64_t executionTime,
                                        uint64_t kernelInstanceAddress,
                                        uint64_t contextId,
@@ -356,35 +356,35 @@ namespace xdp {
                                        const std::string& localWorkSize,
                                        const char** buffers,
                                        uint64_t numBuffers) ;
-    XDP_EXPORT void logComputeUnitExecution(const std::string& computeUnitName,
+    XDP_CORE_EXPORT void logComputeUnitExecution(const std::string& computeUnitName,
                                             const std::string& kernelName,
                                             const std::string& localWorkGroup,
                                             const std::string& globalWorkGroup,
                                             uint64_t executionTime) ;
-    XDP_EXPORT void logHostRead(uint64_t contextId, uint64_t deviceId,
+    XDP_CORE_EXPORT void logHostRead(uint64_t contextId, uint64_t deviceId,
                                 uint64_t size, uint64_t startTime,
                                 uint64_t transferTime,
                                 uint64_t address,
                                 uint64_t commandQueueId) ;
-    XDP_EXPORT void logHostWrite(uint64_t contextId, uint64_t deviceId,
+    XDP_CORE_EXPORT void logHostWrite(uint64_t contextId, uint64_t deviceId,
                                  uint64_t size, uint64_t startTime,
                                  uint64_t transferTime,
                                  uint64_t address,
                                  uint64_t commandQueueId) ;
 
-    XDP_EXPORT void updateCounters(uint64_t deviceId, 
+    XDP_CORE_EXPORT void updateCounters(uint64_t deviceId, 
                                    xdp::CounterResults& counters) ;
-    XDP_EXPORT void updateCounters(xdp::CounterResults& counters) ;
+    XDP_CORE_EXPORT void updateCounters(xdp::CounterResults& counters) ;
 
     // Getters and setters on statistical information
-    XDP_EXPORT void setFirstKernelStartTime(double startTime) ;
+    XDP_CORE_EXPORT void setFirstKernelStartTime(double startTime) ;
     inline double getFirstKernelStartTime() { return firstKernelStartTime ; }
     inline void setLastKernelEndTime(double endTime) { lastKernelEndTime = endTime ; }
     inline double getLastKernelEndTime() { return lastKernelEndTime ; }
 
     // Helper functions for printing out summary information temporarily
-    XDP_EXPORT void dumpCallCount(std::ofstream& fout) ;
-    XDP_EXPORT void dumpHALMemory(std::ofstream& fout) ;    
+    XDP_CORE_EXPORT void dumpCallCount(std::ofstream& fout) ;
+    XDP_CORE_EXPORT void dumpHALMemory(std::ofstream& fout) ;    
   } ;
 }
 

--- a/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.cpp
+++ b/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.cpp
@@ -15,7 +15,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_PLUGIN_SOURCE
 
 #include <iostream>
 

--- a/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.h
+++ b/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.h
@@ -90,7 +90,7 @@ enum class AIEOffloadThreadStatus {
 class AIETraceOffload 
 {
   public:
-    XDP_EXPORT
+    XDP_PLUGIN_EXPORT
     AIETraceOffload(void* handle, uint64_t id,
                     DeviceIntf*, AIETraceLogger*,
                     bool     isPlio,
@@ -98,19 +98,19 @@ class AIETraceOffload
                     uint64_t numStrm
                    );
 
-    XDP_EXPORT
+    XDP_PLUGIN_EXPORT
     virtual ~AIETraceOffload();
 
 public:
-    XDP_EXPORT
+    XDP_PLUGIN_EXPORT
     bool initReadTrace();
-    XDP_EXPORT
+    XDP_PLUGIN_EXPORT
     void endReadTrace();
-    XDP_EXPORT
+    XDP_PLUGIN_EXPORT
     bool isTraceBufferFull();
-    XDP_EXPORT
+    XDP_PLUGIN_EXPORT
     void startOffload();
-    XDP_EXPORT
+    XDP_PLUGIN_EXPORT
     void stopOffload();
 
     inline AIETraceLogger* getAIETraceLogger() { return traceLogger; }

--- a/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.h
+++ b/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.h
@@ -18,7 +18,6 @@
 #ifndef XDP_PROFILE_AIE_TRACE_OFFLOAD_H_
 #define XDP_PROFILE_AIE_TRACE_OFFLOAD_H_
 
-#include "xdp/config.h"
 #include "xdp/profile/device/tracedefs.h"
 
 /*
@@ -90,7 +89,6 @@ enum class AIEOffloadThreadStatus {
 class AIETraceOffload 
 {
   public:
-    XDP_PLUGIN_EXPORT
     AIETraceOffload(void* handle, uint64_t id,
                     DeviceIntf*, AIETraceLogger*,
                     bool     isPlio,
@@ -98,19 +96,13 @@ class AIETraceOffload
                     uint64_t numStrm
                    );
 
-    XDP_PLUGIN_EXPORT
     virtual ~AIETraceOffload();
 
 public:
-    XDP_PLUGIN_EXPORT
     bool initReadTrace();
-    XDP_PLUGIN_EXPORT
     void endReadTrace();
-    XDP_PLUGIN_EXPORT
     bool isTraceBufferFull();
-    XDP_PLUGIN_EXPORT
     void startOffload();
-    XDP_PLUGIN_EXPORT
     void stopOffload();
 
     inline AIETraceLogger* getAIETraceLogger() { return traceLogger; }

--- a/src/runtime_src/xdp/profile/device/aim.cpp
+++ b/src/runtime_src/xdp/profile/device/aim.cpp
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2019-2022 Xilinx, Inc
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -15,7 +15,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_CORE_SOURCE
 
 #include "core/include/xdp/aim.h"
 #include "xdp/profile/device/aim.h"

--- a/src/runtime_src/xdp/profile/device/aim.h
+++ b/src/runtime_src/xdp/profile/device/aim.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2019-2022 Xilinx Inc - All rights reserved
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
  * Xilinx Debug & Profile (XDP) APIs
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
@@ -66,11 +66,11 @@ public:
     virtual size_t stopCounter();
     virtual size_t readCounter(xdp::CounterResults& counterResult);
 
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     bool isHostMonitor() const ;
     bool isShellMonitor();
     bool has64bit() const ;
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     bool hasCoarseMode() const ;
 
     virtual size_t triggerTrace(uint32_t traceOption /*startTrigger*/);

--- a/src/runtime_src/xdp/profile/device/am.cpp
+++ b/src/runtime_src/xdp/profile/device/am.cpp
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2019-2022 Xilinx, Inc
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -15,7 +15,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_CORE_SOURCE
 #include "core/include/xdp/am.h"
 #include "xdp/profile/device/am.h"
 #include "xdp/profile/device/tracedefs.h"

--- a/src/runtime_src/xdp/profile/device/asm.cpp
+++ b/src/runtime_src/xdp/profile/device/asm.cpp
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2019-2022 Xilinx, Inc
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -15,7 +15,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_CORE_SOURCE
 #include "core/include/xdp/asm.h"
 #include "xdp/profile/device/asm.h"
 #include "xdp/profile/device/utility.h"

--- a/src/runtime_src/xdp/profile/device/device_intf.cpp
+++ b/src/runtime_src/xdp/profile/device/device_intf.cpp
@@ -15,7 +15,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_CORE_SOURCE
 
 #include <chrono>
 #include <cmath>

--- a/src/runtime_src/xdp/profile/device/device_intf.h
+++ b/src/runtime_src/xdp/profile/device/device_intf.h
@@ -52,7 +52,7 @@ namespace xdp {
 
 // Helper methods
 
-XDP_EXPORT
+XDP_CORE_EXPORT
 uint64_t GetTS2MMBufSize(bool isAIETrace = false);
 
 
@@ -61,24 +61,24 @@ class DeviceIntf {
 
     DeviceIntf() {}
 
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     ~DeviceIntf();
 
   public:
     // Set device handle
     // NOTE: this is used by write, read, & traceRead
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     void setDevice(xdp::Device* );
 
     // Debug IP layout
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     void readDebugIPlayout();
 
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     uint32_t getNumMonitors(xdp::MonitorType type);
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     std::string getMonitorName(xdp::MonitorType type, uint32_t index);
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     uint64_t getFifoSize();
 
     // Axi Interface Monitor
@@ -95,46 +95,46 @@ class DeviceIntf {
     }
 
     // Counters
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     size_t startCounters();
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     size_t stopCounters();
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     size_t readCounters(xdp::CounterResults& counterResults);
 
     // Accelerator Monitor
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     void configureDataflow(bool* ipConfig);
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     void configureFa(bool* ipConfig);
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     void configAmContext(const std::string& ctx_info);
 
     // Underlying Device APIs
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     size_t allocTraceBuf(uint64_t sz ,uint8_t memIdx);
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     void freeTraceBuf(size_t id);
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     void* syncTraceBuf(size_t id ,uint64_t offset, uint64_t bytes);
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     xclBufferExportHandle exportTraceBuf(size_t id);
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     uint64_t getTraceBufDeviceAddr(size_t id);
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     uint64_t getAlignedTraceBufSize(uint64_t total_bytes, unsigned int num_chunks);
 
     // Trace FIFO Management
     bool hasFIFO() {return (mFifoCtrl != nullptr);};
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     uint32_t getTraceCount();
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     size_t startTrace(uint32_t startTrigger);
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     void clockTraining(bool force = true);
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     size_t stopTrace();
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     size_t readTrace(uint32_t*& traceData) ;
 
     /** Trace S2MM Management
@@ -165,53 +165,53 @@ class DeviceIntf {
       return false;
     }
 
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     void resetTS2MM(uint64_t index);
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     void initTS2MM(uint64_t index, uint64_t bufferSz, uint64_t bufferAddr, bool circular); 
 
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     uint64_t getWordCountTs2mm(uint64_t index, bool final);
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     uint8_t  getTS2MmMemIndex(uint64_t index);
-    XDP_EXPORT
+    XDP_CORE_EXPORT
       void parseTraceData(uint64_t index, void* traceData, uint64_t bytes, std::vector<xdp::TraceEvent>& traceVector);
 
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     void resetAIETs2mm(uint64_t index);
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     void initAIETs2mm(uint64_t bufferSz, uint64_t bufferAddr, uint64_t index, bool circular);
 
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     uint64_t getWordCountAIETs2mm(uint64_t index, bool final);
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     uint8_t  getAIETs2mmMemIndex(uint64_t index);
     
     double getHostMaxBwRead() const {return mHostMaxReadBW;}
     double getHostMaxBwWrite() const {return mHostMaxWriteBW;}
     double getKernelMaxBwRead() const {return mKernelMaxReadBW;}
     double getKernelMaxBwWrite() const {return mKernelMaxWriteBW;}
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     void setHostMaxBwRead();
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     void setHostMaxBwWrite();
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     void setKernelMaxBwRead();
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     void setKernelMaxBwWrite();
 
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     uint32_t getDeadlockStatus();
 
     inline xdp::Device* getAbstractDevice() {return mDevice;}
 
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     void createXrtIP
     (
       const std::unique_ptr<ip_metadata>& ip_metadata_section,
       const std::string& fullname
     );
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     std::string getDeadlockDiagnosis(bool print);
     bool hasDeadlockDetector() {return mDeadlockDetector != nullptr;}
 

--- a/src/runtime_src/xdp/profile/device/device_trace_logger.cpp
+++ b/src/runtime_src/xdp/profile/device/device_trace_logger.cpp
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2020-2022 Xilinx, Inc
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -15,7 +15,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_CORE_SOURCE
 
 #include "xdp/profile/database/static_info/pl_constructs.h"
 #include "xdp/profile/device/device_trace_logger.h"

--- a/src/runtime_src/xdp/profile/device/device_trace_logger.h
+++ b/src/runtime_src/xdp/profile/device/device_trace_logger.h
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2020-2022 Xilinx, Inc
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -110,12 +110,12 @@ namespace xdp {
 
   public:
 
-    XDP_EXPORT DeviceTraceLogger(uint64_t devId);
-    XDP_EXPORT ~DeviceTraceLogger();
+    XDP_CORE_EXPORT DeviceTraceLogger(uint64_t devId);
+    XDP_CORE_EXPORT ~DeviceTraceLogger();
 
-    XDP_EXPORT void processTraceData(void* data, uint64_t numBytes) ;
-    XDP_EXPORT void endProcessTraceData();
-    XDP_EXPORT void addEventMarkers(bool isFIFOFull, bool isTS2MMFull);
+    XDP_CORE_EXPORT void processTraceData(void* data, uint64_t numBytes) ;
+    XDP_CORE_EXPORT void endProcessTraceData();
+    XDP_CORE_EXPORT void addEventMarkers(bool isFIFOFull, bool isTS2MMFull);
   } ;
 
 }

--- a/src/runtime_src/xdp/profile/device/device_trace_offload.cpp
+++ b/src/runtime_src/xdp/profile/device/device_trace_offload.cpp
@@ -15,7 +15,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_CORE_SOURCE
 
 #include "xdp/profile/device/device_trace_offload.h"
 #include "xdp/profile/device/device_trace_logger.h"

--- a/src/runtime_src/xdp/profile/device/device_trace_offload.h
+++ b/src/runtime_src/xdp/profile/device/device_trace_offload.h
@@ -109,24 +109,24 @@ if(!m_debug); else std::cout
 
 class DeviceTraceOffload {
 public:
-  XDP_EXPORT
+  XDP_CORE_EXPORT
   DeviceTraceOffload(DeviceIntf* dInt, DeviceTraceLogger* dTraceLogger,
                      uint64_t offload_sleep_ms, uint64_t trbuf_sz);
-  XDP_EXPORT
+  XDP_CORE_EXPORT
   virtual ~DeviceTraceOffload();
-  XDP_EXPORT
+  XDP_CORE_EXPORT
   void start_offload(OffloadThreadType type);
-  XDP_EXPORT
+  XDP_CORE_EXPORT
   void stop_offload();
-  XDP_EXPORT
+  XDP_CORE_EXPORT
   virtual bool read_trace_init(bool circ_buf, const std::vector<uint64_t>&);
-  XDP_EXPORT
+  XDP_CORE_EXPORT
   virtual void read_trace_end();
-  XDP_EXPORT
+  XDP_CORE_EXPORT
   void train_clock();
-  XDP_EXPORT
+  XDP_CORE_EXPORT
   void process_trace();
-  XDP_EXPORT
+  XDP_CORE_EXPORT
   bool trace_buffer_full();
 
 public:

--- a/src/runtime_src/xdp/profile/device/profile_ip_access.cpp
+++ b/src/runtime_src/xdp/profile/device/profile_ip_access.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2019-2022, Xilinx Inc - All rights reserved
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
  * Xilinx Debug & Profile (XDP) APIs
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
@@ -15,7 +16,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_CORE_SOURCE
 #include "profile_ip_access.h"
 #include "xdp/profile/plugin/vp_base/utility.h"
 

--- a/src/runtime_src/xdp/profile/device/utility.cpp
+++ b/src/runtime_src/xdp/profile/device/utility.cpp
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2022 Xilinx, Inc
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -15,7 +15,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_CORE_SOURCE
 
 #include "xdp/profile/device/utility.h"
 

--- a/src/runtime_src/xdp/profile/device/utility.h
+++ b/src/runtime_src/xdp/profile/device/utility.h
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2022 Xilinx, Inc
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -25,13 +25,13 @@
 
 namespace xdp {
 
-  XDP_EXPORT
+  XDP_CORE_EXPORT
   uint64_t getAIMSlotId(uint64_t idx);
 
-  XDP_EXPORT
+  XDP_CORE_EXPORT
   uint64_t getAMSlotId(uint64_t idx);
 
-  XDP_EXPORT
+  XDP_CORE_EXPORT
   uint64_t getASMSlotId(uint64_t idx);
 
   // At compile time, each monitor inserted in the PL region is given a set 

--- a/src/runtime_src/xdp/profile/plugin/aie_debug/aie_debug_cb.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_debug/aie_debug_cb.cpp
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-#define XDP_SOURCE
+#define XDP_PLUGIN_SOURCE
 
 #include "aie_debug_cb.h"
 #include "aie_debug_plugin.h"

--- a/src/runtime_src/xdp/profile/plugin/aie_debug/aie_debug_cb.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_debug/aie_debug_cb.h
@@ -20,11 +20,11 @@
 #include "xdp/config.h"
 
 extern "C"
-XDP_EXPORT
+XDP_PLUGIN_EXPORT
 void updateAIEDebugDevice(void* handle);
 
 extern "C"
-XDP_EXPORT
+XDP_PLUGIN_EXPORT
 void endAIEDebugRead(void* handle);
 
 #endif

--- a/src/runtime_src/xdp/profile/plugin/aie_debug/aie_debug_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_debug/aie_debug_plugin.cpp
@@ -14,7 +14,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_PLUGIN_SOURCE
 
 #include "xdp/profile/plugin/aie_debug/aie_debug_plugin.h"
 

--- a/src/runtime_src/xdp/profile/plugin/aie_debug/aie_debug_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_debug/aie_debug_plugin.h
@@ -37,11 +37,11 @@ namespace xdp {
   class AieDebugPlugin : public XDPPlugin
   {
   public:
-    XDP_EXPORT AieDebugPlugin();
-    XDP_EXPORT ~AieDebugPlugin();
-    XDP_EXPORT void updateAIEDevice(void* handle);
-    XDP_EXPORT void endAIEDebugRead(void* handle);
-    XDP_EXPORT static bool alive();
+    XDP_PLUGIN_EXPORT AieDebugPlugin();
+    XDP_PLUGIN_EXPORT ~AieDebugPlugin();
+    XDP_PLUGIN_EXPORT void updateAIEDevice(void* handle);
+    XDP_PLUGIN_EXPORT void endAIEDebugRead(void* handle);
+    XDP_PLUGIN_EXPORT static bool alive();
 
   private:
     uint64_t getDeviceIDFromHandle(void* handle);

--- a/src/runtime_src/xdp/profile/plugin/aie_debug/aie_debug_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_debug/aie_debug_plugin.h
@@ -37,11 +37,11 @@ namespace xdp {
   class AieDebugPlugin : public XDPPlugin
   {
   public:
-    XDP_PLUGIN_EXPORT AieDebugPlugin();
-    XDP_PLUGIN_EXPORT ~AieDebugPlugin();
-    XDP_PLUGIN_EXPORT void updateAIEDevice(void* handle);
-    XDP_PLUGIN_EXPORT void endAIEDebugRead(void* handle);
-    XDP_PLUGIN_EXPORT static bool alive();
+    AieDebugPlugin();
+    ~AieDebugPlugin();
+    void updateAIEDevice(void* handle);
+    void endAIEDebugRead(void* handle);
+    static bool alive();
 
   private:
     uint64_t getDeviceIDFromHandle(void* handle);

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_cb.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_cb.cpp
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-#define XDP_SOURCE
+#define XDP_PLUGIN_SOURCE
 
 #include "aie_profile_cb.h"
 #include "aie_profile_plugin.h"

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_cb.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_cb.h
@@ -20,11 +20,11 @@
 #include "xdp/config.h"
 
 extern "C"
-XDP_EXPORT
+XDP_PLUGIN_EXPORT
 void updateAIECtrDevice(void* handle);
 
 extern "C"
-XDP_EXPORT
+XDP_PLUGIN_EXPORT
 void endAIECtrPoll(void* handle);
 
 #endif

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_metadata.cpp
@@ -14,7 +14,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_PLUGIN_SOURCE
 
 #include "aie_profile_metadata.h"
 

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_plugin.cpp
@@ -14,7 +14,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_PLUGIN_SOURCE
 
 #include "xdp/profile/plugin/aie_profile/aie_profile_plugin.h"
 

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_plugin.h
@@ -27,11 +27,11 @@ namespace xdp {
   class AieProfilePlugin : public XDPPlugin
   {
   public:
-    XDP_PLUGIN_EXPORT AieProfilePlugin();
-    XDP_PLUGIN_EXPORT ~AieProfilePlugin();
-    XDP_PLUGIN_EXPORT void updateAIEDevice(void* handle);
-    XDP_PLUGIN_EXPORT void endPollforDevice(void* handle);
-    XDP_PLUGIN_EXPORT static bool alive();
+    AieProfilePlugin();
+    ~AieProfilePlugin();
+    void updateAIEDevice(void* handle);
+    void endPollforDevice(void* handle);
+    static bool alive();
 
   private:
     virtual void writeAll(bool openNewFiles) override;

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_plugin.h
@@ -27,11 +27,11 @@ namespace xdp {
   class AieProfilePlugin : public XDPPlugin
   {
   public:
-    XDP_EXPORT AieProfilePlugin();
-    XDP_EXPORT ~AieProfilePlugin();
-    XDP_EXPORT void updateAIEDevice(void* handle);
-    XDP_EXPORT void endPollforDevice(void* handle);
-    XDP_EXPORT static bool alive();
+    XDP_PLUGIN_EXPORT AieProfilePlugin();
+    XDP_PLUGIN_EXPORT ~AieProfilePlugin();
+    XDP_PLUGIN_EXPORT void updateAIEDevice(void* handle);
+    XDP_PLUGIN_EXPORT void endPollforDevice(void* handle);
+    XDP_PLUGIN_EXPORT static bool alive();
 
   private:
     virtual void writeAll(bool openNewFiles) override;

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/edge/aie_profile.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/edge/aie_profile.cpp
@@ -14,7 +14,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE 
+#define XDP_PLUGIN_SOURCE 
 
 #include "xdp/profile/plugin/aie_profile/edge/aie_profile.h"
 #include "xdp/profile/database/static_info/aie_util.h"

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/win/aie_profile.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/win/aie_profile.cpp
@@ -14,7 +14,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_PLUGIN_SOURCE
 
 #include "aie_profile.h"
 

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/x86/aie_profile.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/x86/aie_profile.cpp
@@ -14,7 +14,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_PLUGIN_SOURCE
 
 #include "aie_profile.h"
 

--- a/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.cpp
@@ -15,7 +15,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_PLUGIN_SOURCE
 
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>

--- a/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.h
@@ -29,8 +29,6 @@
 #include "xdp/profile/database/static_info/aie_util.h"
 #include "xdp/profile/database/static_info/filetypes/base_filetype_impl.h"
 
-#include "xdp/config.h"
-
 #include "core/common/device.h"
 #include "xaiefal/xaiefal.hpp"
 
@@ -47,12 +45,9 @@ namespace xdp {
     AIEStatusPlugin();
     ~AIEStatusPlugin();
 
-    XDP_PLUGIN_EXPORT
     void updateAIEDevice(void* handle);
-    XDP_PLUGIN_EXPORT
     void endPollforDevice(void* handle);
 
-    XDP_PLUGIN_EXPORT
     static bool alive();
 
   private:

--- a/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.h
@@ -47,12 +47,12 @@ namespace xdp {
     AIEStatusPlugin();
     ~AIEStatusPlugin();
 
-    XDP_EXPORT
+    XDP_PLUGIN_EXPORT
     void updateAIEDevice(void* handle);
-    XDP_EXPORT
+    XDP_PLUGIN_EXPORT
     void endPollforDevice(void* handle);
 
-    XDP_EXPORT
+    XDP_PLUGIN_EXPORT
     static bool alive();
 
   private:

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_cb.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_cb.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -14,7 +14,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_PLUGIN_SOURCE
 
 #include "aie_trace_cb.h"
 #include "aie_trace_plugin.h"

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_cb.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_cb.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -21,9 +21,9 @@
 
 extern "C" {
 
-  XDP_EXPORT void updateAIEDevice(void* handle);
-  XDP_EXPORT void flushAIEDevice(void* handle);
-  XDP_EXPORT void finishFlushAIEDevice(void* handle);
+  XDP_PLUGIN_EXPORT void updateAIEDevice(void* handle);
+  XDP_PLUGIN_EXPORT void flushAIEDevice(void* handle);
+  XDP_PLUGIN_EXPORT void finishFlushAIEDevice(void* handle);
 
 }
 #endif

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_metadata.cpp
@@ -14,7 +14,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_PLUGIN_SOURCE
 
 #include "aie_trace_metadata.h"
 

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -14,7 +14,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_PLUGIN_SOURCE
 
 #include <memory>
 

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/edge/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/edge/aie_trace.cpp
@@ -14,7 +14,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_PLUGIN_SOURCE
 
 #include "xdp/profile/plugin/aie_trace/edge/aie_trace.h"
 #include "xdp/profile/database/static_info/aie_util.h"

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/edge/aie_trace.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/edge/aie_trace.h
@@ -26,13 +26,13 @@ namespace xdp {
 
   class AieTrace_EdgeImpl : public AieTraceImpl {
    public:
-    XDP_EXPORT
+    XDP_PLUGIN_EXPORT
     AieTrace_EdgeImpl(VPDatabase* database, std::shared_ptr<AieTraceMetadata> metadata);
     ~AieTrace_EdgeImpl() = default;
 
-    XDP_EXPORT
+    XDP_PLUGIN_EXPORT
     virtual void updateDevice();
-    XDP_EXPORT
+    XDP_PLUGIN_EXPORT
     virtual void flushAieTileTraceModule();
     void pollTimers(uint32_t index, void* handle);
     void freeResources();

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/edge/aie_trace.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/edge/aie_trace.h
@@ -26,13 +26,10 @@ namespace xdp {
 
   class AieTrace_EdgeImpl : public AieTraceImpl {
    public:
-    XDP_PLUGIN_EXPORT
     AieTrace_EdgeImpl(VPDatabase* database, std::shared_ptr<AieTraceMetadata> metadata);
     ~AieTrace_EdgeImpl() = default;
 
-    XDP_PLUGIN_EXPORT
     virtual void updateDevice();
-    XDP_PLUGIN_EXPORT
     virtual void flushAieTileTraceModule();
     void pollTimers(uint32_t index, void* handle);
     void freeResources();

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/x86/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/x86/aie_trace.cpp
@@ -14,7 +14,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_PLUGIN_SOURCE
 
 #include "aie_trace.h"
 

--- a/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
@@ -15,7 +15,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_PLUGIN_SOURCE
 
 #include <string>
 #include <sstream>

--- a/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.h
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2016-2022 Xilinx, Inc
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -61,22 +61,22 @@ namespace xdp {
 
     std::map<uint64_t, DeviceData> offloaders;
 
-    XDP_EXPORT void addDevice(const std::string& sysfsPath) ;
-    XDP_EXPORT void configureDataflow(uint64_t deviceId, DeviceIntf* devInterface) ;
-    XDP_EXPORT void configureFa(uint64_t deviceId, DeviceIntf* devInterface) ;
-    XDP_EXPORT void configureCtx(uint64_t deviceId, DeviceIntf* devInterface) ;
-    XDP_EXPORT void addOffloader(uint64_t deviceId, DeviceIntf* devInterface) ;
-    XDP_EXPORT void configureTraceIP(DeviceIntf* devInterface) ;
-    XDP_EXPORT void startContinuousThreads(uint64_t deviceId) ;
+    XDP_PLUGIN_EXPORT void addDevice(const std::string& sysfsPath) ;
+    XDP_PLUGIN_EXPORT void configureDataflow(uint64_t deviceId, DeviceIntf* devInterface) ;
+    XDP_PLUGIN_EXPORT void configureFa(uint64_t deviceId, DeviceIntf* devInterface) ;
+    XDP_PLUGIN_EXPORT void configureCtx(uint64_t deviceId, DeviceIntf* devInterface) ;
+    XDP_PLUGIN_EXPORT void addOffloader(uint64_t deviceId, DeviceIntf* devInterface) ;
+    XDP_PLUGIN_EXPORT void configureTraceIP(DeviceIntf* devInterface) ;
+    XDP_PLUGIN_EXPORT void startContinuousThreads(uint64_t deviceId) ;
 
-    XDP_EXPORT void readCounters() ;
-    XDP_EXPORT virtual void readTrace() = 0 ;
-    XDP_EXPORT void checkTraceBufferFullness(DeviceTraceOffload* offloader, uint64_t deviceId) ;
-    XDP_EXPORT bool flushTraceOffloader(DeviceTraceOffload* offloader);
+    XDP_PLUGIN_EXPORT void readCounters() ;
+    XDP_PLUGIN_EXPORT virtual void readTrace() = 0 ;
+    XDP_PLUGIN_EXPORT void checkTraceBufferFullness(DeviceTraceOffload* offloader, uint64_t deviceId) ;
+    XDP_PLUGIN_EXPORT bool flushTraceOffloader(DeviceTraceOffload* offloader);
 
   public:
-    XDP_EXPORT DeviceOffloadPlugin() ;
-    XDP_EXPORT virtual ~DeviceOffloadPlugin() = default ;
+    XDP_PLUGIN_EXPORT DeviceOffloadPlugin() ;
+    XDP_PLUGIN_EXPORT virtual ~DeviceOffloadPlugin() = default ;
 
     virtual void writeAll(bool openNewFiles) ;
 

--- a/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.h
@@ -61,22 +61,22 @@ namespace xdp {
 
     std::map<uint64_t, DeviceData> offloaders;
 
-    XDP_PLUGIN_EXPORT void addDevice(const std::string& sysfsPath) ;
-    XDP_PLUGIN_EXPORT void configureDataflow(uint64_t deviceId, DeviceIntf* devInterface) ;
-    XDP_PLUGIN_EXPORT void configureFa(uint64_t deviceId, DeviceIntf* devInterface) ;
-    XDP_PLUGIN_EXPORT void configureCtx(uint64_t deviceId, DeviceIntf* devInterface) ;
-    XDP_PLUGIN_EXPORT void addOffloader(uint64_t deviceId, DeviceIntf* devInterface) ;
-    XDP_PLUGIN_EXPORT void configureTraceIP(DeviceIntf* devInterface) ;
-    XDP_PLUGIN_EXPORT void startContinuousThreads(uint64_t deviceId) ;
+    void addDevice(const std::string& sysfsPath) ;
+    void configureDataflow(uint64_t deviceId, DeviceIntf* devInterface) ;
+    void configureFa(uint64_t deviceId, DeviceIntf* devInterface) ;
+    void configureCtx(uint64_t deviceId, DeviceIntf* devInterface) ;
+    void addOffloader(uint64_t deviceId, DeviceIntf* devInterface) ;
+    void configureTraceIP(DeviceIntf* devInterface) ;
+    void startContinuousThreads(uint64_t deviceId) ;
 
-    XDP_PLUGIN_EXPORT void readCounters() ;
-    XDP_PLUGIN_EXPORT virtual void readTrace() = 0 ;
-    XDP_PLUGIN_EXPORT void checkTraceBufferFullness(DeviceTraceOffload* offloader, uint64_t deviceId) ;
-    XDP_PLUGIN_EXPORT bool flushTraceOffloader(DeviceTraceOffload* offloader);
+    void readCounters() ;
+    virtual void readTrace() = 0 ;
+    void checkTraceBufferFullness(DeviceTraceOffload* offloader, uint64_t deviceId) ;
+    bool flushTraceOffloader(DeviceTraceOffload* offloader);
 
   public:
-    XDP_PLUGIN_EXPORT DeviceOffloadPlugin() ;
-    XDP_PLUGIN_EXPORT virtual ~DeviceOffloadPlugin() = default ;
+    DeviceOffloadPlugin() ;
+    virtual ~DeviceOffloadPlugin() = default ;
 
     virtual void writeAll(bool openNewFiles) ;
 

--- a/src/runtime_src/xdp/profile/plugin/device_offload/hal/hal_device_offload_cb.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/hal/hal_device_offload_cb.cpp
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2016-2020 Xilinx, Inc
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -14,7 +15,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_PLUGIN_SOURCE
 
 #include "xdp/profile/plugin/device_offload/hal/hal_device_offload_cb.h"
 #include "xdp/profile/plugin/device_offload/hal/hal_device_offload_plugin.h"

--- a/src/runtime_src/xdp/profile/plugin/device_offload/hal/hal_device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/hal/hal_device_offload_plugin.cpp
@@ -15,7 +15,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_PLUGIN_SOURCE
 
 #include <array>
 #include <string>

--- a/src/runtime_src/xdp/profile/plugin/device_offload/hal/hal_device_offload_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/hal/hal_device_offload_plugin.h
@@ -38,7 +38,7 @@ namespace xdp {
     std::vector<void*> deviceHandles ;
     std::map<uint64_t, void*> deviceIdToHandle ;
 
-    XDP_PLUGIN_EXPORT virtual void readTrace() ;
+    virtual void readTrace() ;
 
     // When trying to determine the path to the debug_ip_layout file,
     //  we need to call the C-interface function xclGetDebugIPlayoutPath
@@ -46,12 +46,12 @@ namespace xdp {
     constexpr static int maxPathLength = 512 ;
 
   public:
-    XDP_PLUGIN_EXPORT HALDeviceOffloadPlugin() ;
-    XDP_PLUGIN_EXPORT ~HALDeviceOffloadPlugin() ;
+    HALDeviceOffloadPlugin() ;
+    ~HALDeviceOffloadPlugin() ;
 
     // Virtual functions from DeviceOffloadPlugin
-    XDP_PLUGIN_EXPORT virtual void flushDevice(void* device) ;
-    XDP_PLUGIN_EXPORT virtual void updateDevice(void* device) ;
+    virtual void flushDevice(void* device) ;
+    virtual void updateDevice(void* device) ;
   } ;
 
 } // end namespace xdp

--- a/src/runtime_src/xdp/profile/plugin/device_offload/hal/hal_device_offload_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/hal/hal_device_offload_plugin.h
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2016-2022 Xilinx, Inc
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -37,7 +38,7 @@ namespace xdp {
     std::vector<void*> deviceHandles ;
     std::map<uint64_t, void*> deviceIdToHandle ;
 
-    XDP_EXPORT virtual void readTrace() ;
+    XDP_PLUGIN_EXPORT virtual void readTrace() ;
 
     // When trying to determine the path to the debug_ip_layout file,
     //  we need to call the C-interface function xclGetDebugIPlayoutPath
@@ -45,12 +46,12 @@ namespace xdp {
     constexpr static int maxPathLength = 512 ;
 
   public:
-    XDP_EXPORT HALDeviceOffloadPlugin() ;
-    XDP_EXPORT ~HALDeviceOffloadPlugin() ;
+    XDP_PLUGIN_EXPORT HALDeviceOffloadPlugin() ;
+    XDP_PLUGIN_EXPORT ~HALDeviceOffloadPlugin() ;
 
     // Virtual functions from DeviceOffloadPlugin
-    XDP_EXPORT virtual void flushDevice(void* device) ;
-    XDP_EXPORT virtual void updateDevice(void* device) ;
+    XDP_PLUGIN_EXPORT virtual void flushDevice(void* device) ;
+    XDP_PLUGIN_EXPORT virtual void updateDevice(void* device) ;
   } ;
 
 } // end namespace xdp

--- a/src/runtime_src/xdp/profile/plugin/device_offload/hw_emu/hw_emu_device_offload_cb.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/hw_emu/hw_emu_device_offload_cb.cpp
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2022 Xilinx, Inc
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -14,7 +15,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_PLUGIN_SOURCE
 
 #include "xdp/profile/plugin/device_offload/hw_emu/hw_emu_device_offload_cb.h"
 #include "xdp/profile/plugin/device_offload/hw_emu/hw_emu_device_offload_plugin.h"

--- a/src/runtime_src/xdp/profile/plugin/device_offload/hw_emu/hw_emu_device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/hw_emu/hw_emu_device_offload_plugin.cpp
@@ -15,7 +15,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_PLUGIN_SOURCE
 
 #include <string>
 

--- a/src/runtime_src/xdp/profile/plugin/device_offload/hw_emu/hw_emu_device_offload_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/hw_emu/hw_emu_device_offload_plugin.h
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2022 Xilinx, Inc
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -36,13 +37,13 @@ namespace xdp {
     //  to keep track of when we create new writers.
     std::set<uint64_t> devicesSeen ;
 
-    XDP_EXPORT virtual void readTrace() override ;
+    XDP_PLUGIN_EXPORT virtual void readTrace() override ;
   public:
-    XDP_EXPORT HWEmuDeviceOffloadPlugin() ;
-    XDP_EXPORT ~HWEmuDeviceOffloadPlugin() override ;
+    XDP_PLUGIN_EXPORT HWEmuDeviceOffloadPlugin() ;
+    XDP_PLUGIN_EXPORT ~HWEmuDeviceOffloadPlugin() override ;
 
-    XDP_EXPORT virtual void flushDevice(void* device) override ;
-    XDP_EXPORT virtual void updateDevice(void* device) override ;
+    XDP_PLUGIN_EXPORT virtual void flushDevice(void* device) override ;
+    XDP_PLUGIN_EXPORT virtual void updateDevice(void* device) override ;
   } ;
 
 } // end namespace xdp

--- a/src/runtime_src/xdp/profile/plugin/device_offload/hw_emu/hw_emu_device_offload_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/hw_emu/hw_emu_device_offload_plugin.h
@@ -20,7 +20,6 @@
 
 #include <set>
 
-#include "xdp/config.h"
 #include "xdp/profile/plugin/device_offload/device_offload_plugin.h"
 
 namespace xdp {
@@ -37,13 +36,13 @@ namespace xdp {
     //  to keep track of when we create new writers.
     std::set<uint64_t> devicesSeen ;
 
-    XDP_PLUGIN_EXPORT virtual void readTrace() override ;
+    virtual void readTrace() override ;
   public:
-    XDP_PLUGIN_EXPORT HWEmuDeviceOffloadPlugin() ;
-    XDP_PLUGIN_EXPORT ~HWEmuDeviceOffloadPlugin() override ;
+    HWEmuDeviceOffloadPlugin() ;
+    ~HWEmuDeviceOffloadPlugin() override ;
 
-    XDP_PLUGIN_EXPORT virtual void flushDevice(void* device) override ;
-    XDP_PLUGIN_EXPORT virtual void updateDevice(void* device) override ;
+    virtual void flushDevice(void* device) override ;
+    virtual void updateDevice(void* device) override ;
   } ;
 
 } // end namespace xdp

--- a/src/runtime_src/xdp/profile/plugin/device_offload/opencl/opencl_device_info_cb.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/opencl/opencl_device_info_cb.cpp
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2016-2020 Xilinx, Inc
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -14,7 +15,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_PLUGIN_SOURCE
 
 #include "xocl/core/platform.h"
 #include "xocl/core/device.h"

--- a/src/runtime_src/xdp/profile/plugin/device_offload/opencl/opencl_device_info_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/opencl/opencl_device_info_plugin.cpp
@@ -15,7 +15,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_PLUGIN_SOURCE
 
 #include <string>
 

--- a/src/runtime_src/xdp/profile/plugin/device_offload/opencl/opencl_device_info_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/opencl/opencl_device_info_plugin.h
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2016-2022 Xilinx, Inc
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -43,18 +44,18 @@ namespace xdp {
     void updateOpenCLInfo(uint64_t deviceId) ;
     void updateSWEmulationGuidance() ;
 
-    XDP_EXPORT virtual void readTrace() override;
+    XDP_PLUGIN_EXPORT virtual void readTrace() override;
 
   public:
-    XDP_EXPORT OpenCLDeviceInfoPlugin() ;
-    XDP_EXPORT virtual ~OpenCLDeviceInfoPlugin() override ;
+    XDP_PLUGIN_EXPORT OpenCLDeviceInfoPlugin() ;
+    XDP_PLUGIN_EXPORT virtual ~OpenCLDeviceInfoPlugin() override ;
 
     // Virtual functions from XDPPlugin
-    XDP_EXPORT virtual void writeAll(bool openNewFiles) override;
+    XDP_PLUGIN_EXPORT virtual void writeAll(bool openNewFiles) override;
 
     // Virtual functions from DeviceOffloadPlugin
-    XDP_EXPORT virtual void flushDevice(void* device) override;
-    XDP_EXPORT virtual void updateDevice(void* device) override;
+    XDP_PLUGIN_EXPORT virtual void flushDevice(void* device) override;
+    XDP_PLUGIN_EXPORT virtual void updateDevice(void* device) override;
   } ;
 
 } // end namespace xdp

--- a/src/runtime_src/xdp/profile/plugin/device_offload/opencl/opencl_device_info_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/opencl/opencl_device_info_plugin.h
@@ -22,7 +22,6 @@
 
 #include "xocl/core/platform.h"
 
-#include "xdp/config.h"
 #include "xdp/profile/plugin/device_offload/device_offload_plugin.h"
 
 namespace xdp {
@@ -44,18 +43,18 @@ namespace xdp {
     void updateOpenCLInfo(uint64_t deviceId) ;
     void updateSWEmulationGuidance() ;
 
-    XDP_PLUGIN_EXPORT virtual void readTrace() override;
+    virtual void readTrace() override;
 
   public:
-    XDP_PLUGIN_EXPORT OpenCLDeviceInfoPlugin() ;
-    XDP_PLUGIN_EXPORT virtual ~OpenCLDeviceInfoPlugin() override ;
+    OpenCLDeviceInfoPlugin() ;
+    virtual ~OpenCLDeviceInfoPlugin() override ;
 
     // Virtual functions from XDPPlugin
-    XDP_PLUGIN_EXPORT virtual void writeAll(bool openNewFiles) override;
+    virtual void writeAll(bool openNewFiles) override;
 
     // Virtual functions from DeviceOffloadPlugin
-    XDP_PLUGIN_EXPORT virtual void flushDevice(void* device) override;
-    XDP_PLUGIN_EXPORT virtual void updateDevice(void* device) override;
+    virtual void flushDevice(void* device) override;
+    virtual void updateDevice(void* device) override;
   } ;
 
 } // end namespace xdp

--- a/src/runtime_src/xdp/profile/plugin/hal/hal_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/hal/hal_plugin.cpp
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2016-2022 Xilinx, Inc
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -14,7 +15,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_PLUGIN_SOURCE
 
 #include <cstring>
 

--- a/src/runtime_src/xdp/profile/plugin/hal/hal_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/hal/hal_plugin.h
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2016-2022 Xilinx, Inc
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -26,13 +27,13 @@ namespace xdp {
   private:
     static bool live;
   public:
-    XDP_EXPORT
+    XDP_PLUGIN_EXPORT
     HALPlugin() ;
 
-    XDP_EXPORT
+    XDP_PLUGIN_EXPORT
     ~HALPlugin() ;
 
-    XDP_EXPORT
+    XDP_PLUGIN_EXPORT
     virtual void writeAll(bool openNewFiles) ;
 
     static bool alive() { return HALPlugin::live; }

--- a/src/runtime_src/xdp/profile/plugin/hal/hal_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/hal/hal_plugin.h
@@ -27,13 +27,9 @@ namespace xdp {
   private:
     static bool live;
   public:
-    XDP_PLUGIN_EXPORT
     HALPlugin() ;
-
-    XDP_PLUGIN_EXPORT
     ~HALPlugin() ;
 
-    XDP_PLUGIN_EXPORT
     virtual void writeAll(bool openNewFiles) ;
 
     static bool alive() { return HALPlugin::live; }

--- a/src/runtime_src/xdp/profile/plugin/hal/xdp_hal_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/hal/xdp_hal_plugin.cpp
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2016-2022 Xilinx, Inc
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -16,7 +17,7 @@
 
 #include <iostream>
 
-#define XDP_SOURCE
+#define XDP_PLUGIN_SOURCE
 
 #include "xdp_hal_plugin_interface.h"
 

--- a/src/runtime_src/xdp/profile/plugin/hal/xdp_hal_plugin_interface.h
+++ b/src/runtime_src/xdp/profile/plugin/hal/xdp_hal_plugin_interface.h
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2016-2020 Xilinx, Inc
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -22,11 +23,11 @@
 extern "C" {
 
 // Generic start/stop callbacks
-XDP_EXPORT
+XDP_PLUGIN_EXPORT
 void hal_generic_cb(bool isStart, const char* name, unsigned long long int id) ;
 
 // Specialization start/stop callbacks
-XDP_EXPORT
+XDP_PLUGIN_EXPORT
 void buffer_transfer_cb(bool isWrite, 
                         bool isStart,
                         const char* name,

--- a/src/runtime_src/xdp/profile/plugin/hal_api_interface/xdp_api_interface_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/hal_api_interface/xdp_api_interface_plugin.cpp
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2016-2022 Xilinx, Inc
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -19,7 +19,7 @@
 //  to the dynamically loaded library.  The actual implementations
 //  are abstracted in the HALAPIInterface object
 
-#define XDP_SOURCE
+#define XDP_PLUGIN_SOURCE
 
 #include "core/include/xdp/hal_api.h"
 #include "xdp/profile/plugin/hal_api_interface/xdp_api_interface_plugin.h"

--- a/src/runtime_src/xdp/profile/plugin/hal_api_interface/xdp_api_interface_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/hal_api_interface/xdp_api_interface_plugin.h
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2016-2020 Xilinx, Inc
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -26,7 +26,7 @@
 //  Instead, it just directly communicates with the counters in hardware.
 
 extern "C" {
-  XDP_EXPORT
+  XDP_PLUGIN_EXPORT
   void hal_api_interface_cb_func(xdp::HalInterfaceCallbackType cb_type,
                                  void* payload) ;
 }

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.cpp
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.cpp
@@ -14,7 +14,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_PLUGIN_SOURCE
 
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/json_parser.hpp>

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.h
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.h
@@ -25,11 +25,11 @@ namespace xdp {
   class MLTimelineClientDevImpl : public MLTimelineImpl
   {
     public :
-      XDP_EXPORT MLTimelineClientDevImpl(VPDatabase* dB);
+      XDP_PLUGIN_EXPORT MLTimelineClientDevImpl(VPDatabase* dB);
 
       ~MLTimelineClientDevImpl() = default;
 
-      XDP_EXPORT virtual void finishflushDevice(void* handle);
+      XDP_PLUGIN_EXPORT virtual void finishflushDevice(void* handle);
   };
 
 }

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.h
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.h
@@ -25,11 +25,11 @@ namespace xdp {
   class MLTimelineClientDevImpl : public MLTimelineImpl
   {
     public :
-      XDP_PLUGIN_EXPORT MLTimelineClientDevImpl(VPDatabase* dB);
+      MLTimelineClientDevImpl(VPDatabase* dB);
 
       ~MLTimelineClientDevImpl() = default;
 
-      XDP_PLUGIN_EXPORT virtual void finishflushDevice(void* handle);
+      virtual void finishflushDevice(void* handle);
   };
 
 }

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_cb.cpp
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_cb.cpp
@@ -14,7 +14,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_PLUGIN_SOURCE
 
 #include "xdp/profile/plugin/ml_timeline/ml_timeline_cb.h"
 #include "xdp/profile/plugin/ml_timeline/ml_timeline_plugin.h"

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_cb.h
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_cb.h
@@ -21,8 +21,8 @@
 
 extern "C" {
 
-  XDP_EXPORT void updateDeviceMLTmln(void* handle);
-  XDP_EXPORT void finishflushDeviceMLTmln(void* handle);
+  XDP_PLUGIN_EXPORT void updateDeviceMLTmln(void* handle);
+  XDP_PLUGIN_EXPORT void finishflushDeviceMLTmln(void* handle);
 
 }
 #endif

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_plugin.cpp
@@ -14,7 +14,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_PLUGIN_SOURCE
 
 #include <array>
 

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_plugin.h
@@ -27,14 +27,14 @@ namespace xdp {
   {
     public:
 
-    XDP_PLUGIN_EXPORT MLTimelinePlugin();
-    XDP_PLUGIN_EXPORT ~MLTimelinePlugin();
+    MLTimelinePlugin();
+    ~MLTimelinePlugin();
 
-    XDP_PLUGIN_EXPORT void updateDevice(void* handle);
-    XDP_PLUGIN_EXPORT void finishflushDevice(void* handle);
-    XDP_PLUGIN_EXPORT void writeAll(bool openNewFiles);
+    void updateDevice(void* handle);
+    void finishflushDevice(void* handle);
+    void writeAll(bool openNewFiles);
 
-    XDP_PLUGIN_EXPORT static bool alive();
+    static bool alive();
 
     private:
     uint64_t getDeviceIDFromHandle(void* handle);

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_plugin.h
@@ -27,14 +27,14 @@ namespace xdp {
   {
     public:
 
-    XDP_EXPORT MLTimelinePlugin();
-    XDP_EXPORT ~MLTimelinePlugin();
+    XDP_PLUGIN_EXPORT MLTimelinePlugin();
+    XDP_PLUGIN_EXPORT ~MLTimelinePlugin();
 
-    XDP_EXPORT void updateDevice(void* handle);
-    XDP_EXPORT void finishflushDevice(void* handle);
-    XDP_EXPORT void writeAll(bool openNewFiles);
+    XDP_PLUGIN_EXPORT void updateDevice(void* handle);
+    XDP_PLUGIN_EXPORT void finishflushDevice(void* handle);
+    XDP_PLUGIN_EXPORT void writeAll(bool openNewFiles);
 
-    XDP_EXPORT static bool alive();
+    XDP_PLUGIN_EXPORT static bool alive();
 
     private:
     uint64_t getDeviceIDFromHandle(void* handle);

--- a/src/runtime_src/xdp/profile/plugin/native/native_cb.cpp
+++ b/src/runtime_src/xdp/profile/plugin/native/native_cb.cpp
@@ -18,7 +18,7 @@
 #include <map>
 #include <mutex>
 
-#define XDP_SOURCE
+#define XDP_PLUGIN_SOURCE
 
 #include "core/common/time.h"
 #include "xdp/profile/database/dynamic_info/types.h"

--- a/src/runtime_src/xdp/profile/plugin/native/native_cb.h
+++ b/src/runtime_src/xdp/profile/plugin/native/native_cb.h
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2016-2021 Xilinx, Inc
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -23,19 +23,19 @@
 // These are the functions that are visible when the plugin is dynamically
 //  linked in.  XRT should call them directly
 extern "C"
-XDP_EXPORT
+XDP_PLUGIN_EXPORT
 void native_function_start(const char* functionName, unsigned long long int functionID) ;
 
 extern "C"
-XDP_EXPORT
+XDP_PLUGIN_EXPORT
 void native_function_end(const char* functionName, unsigned long long int functionID, unsigned long long int timestamp) ;
 
 extern "C"
-XDP_EXPORT
+XDP_PLUGIN_EXPORT
 void native_sync_start(const char* functionName, unsigned long long int functionID, bool isWrite) ;
 
 extern "C"
-XDP_EXPORT
+XDP_PLUGIN_EXPORT
 void native_sync_end(const char* functionName, unsigned long long int functionID, unsigned long long int timestamp, bool isWrite, unsigned long long int size);
 
 #endif

--- a/src/runtime_src/xdp/profile/plugin/native/native_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/native/native_plugin.cpp
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2016-2022 Xilinx, Inc
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -14,7 +15,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_PLUGIN_SOURCE
 
 #include "xdp/profile/plugin/native/native_plugin.h"
 #include "xdp/profile/writer/native/native_writer.h"

--- a/src/runtime_src/xdp/profile/plugin/noc/noc_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/noc/noc_plugin.cpp
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2020-2021 Xilinx, Inc
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -15,7 +15,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_PLUGIN_SOURCE
 
 #include "xdp/profile/database/static_info/aie_constructs.h"
 #include "xdp/profile/plugin/noc/noc_plugin.h"

--- a/src/runtime_src/xdp/profile/plugin/opencl/counters/opencl_counters_cb.cpp
+++ b/src/runtime_src/xdp/profile/plugin/opencl/counters/opencl_counters_cb.cpp
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2016-2022 Xilinx, Inc
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -14,7 +15,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_PLUGIN_SOURCE
 
 #include <map>
 #include <queue>

--- a/src/runtime_src/xdp/profile/plugin/opencl/counters/opencl_counters_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/opencl/counters/opencl_counters_plugin.cpp
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2016-2022 Xilinx, Inc
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -14,7 +15,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_PLUGIN_SOURCE
 
 #include "core/common/config_reader.h"
 

--- a/src/runtime_src/xdp/profile/plugin/pl_deadlock/hw_emu/hw_emu_pl_deadlock_cb.cpp
+++ b/src/runtime_src/xdp/profile/plugin/pl_deadlock/hw_emu/hw_emu_pl_deadlock_cb.cpp
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2016-2021 Xilinx, Inc
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -15,7 +15,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_PLUGIN_SOURCE
 
 #include "hw_emu_pl_deadlock_cb.h"
 #include "hw_emu_pl_deadlock_plugin.h"

--- a/src/runtime_src/xdp/profile/plugin/pl_deadlock/hw_emu/hw_emu_pl_deadlock_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/pl_deadlock/hw_emu/hw_emu_pl_deadlock_plugin.cpp
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2016-2021 Xilinx, Inc
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -15,7 +15,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_PLUGIN_SOURCE
 
 #include "xdp/profile/database/database.h"
 

--- a/src/runtime_src/xdp/profile/plugin/pl_deadlock/hw_emu/hw_emu_pl_deadlock_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/pl_deadlock/hw_emu/hw_emu_pl_deadlock_plugin.h
@@ -25,11 +25,10 @@ namespace xdp {
 class HwEmuPLDeadlockPlugin : public XDPPlugin {
 
   public:
-    XDP_PLUGIN_EXPORT HwEmuPLDeadlockPlugin();
-    XDP_PLUGIN_EXPORT ~HwEmuPLDeadlockPlugin();
-    XDP_PLUGIN_EXPORT virtual void updateDevice(void* handle);
-    XDP_PLUGIN_EXPORT virtual void writeAll(bool openNewFiles);
-
+    HwEmuPLDeadlockPlugin();
+    ~HwEmuPLDeadlockPlugin();
+    virtual void updateDevice(void* handle);
+    virtual void writeAll(bool openNewFiles);
   };
 
 }

--- a/src/runtime_src/xdp/profile/plugin/pl_deadlock/hw_emu/hw_emu_pl_deadlock_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/pl_deadlock/hw_emu/hw_emu_pl_deadlock_plugin.h
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2016-2021 Xilinx, Inc
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -25,10 +25,10 @@ namespace xdp {
 class HwEmuPLDeadlockPlugin : public XDPPlugin {
 
   public:
-    XDP_EXPORT HwEmuPLDeadlockPlugin();
-    XDP_EXPORT ~HwEmuPLDeadlockPlugin();
-    XDP_EXPORT virtual void updateDevice(void* handle);
-    XDP_EXPORT virtual void writeAll(bool openNewFiles);
+    XDP_PLUGIN_EXPORT HwEmuPLDeadlockPlugin();
+    XDP_PLUGIN_EXPORT ~HwEmuPLDeadlockPlugin();
+    XDP_PLUGIN_EXPORT virtual void updateDevice(void* handle);
+    XDP_PLUGIN_EXPORT virtual void writeAll(bool openNewFiles);
 
   };
 

--- a/src/runtime_src/xdp/profile/plugin/pl_deadlock/pl_deadlock_cb.cpp
+++ b/src/runtime_src/xdp/profile/plugin/pl_deadlock/pl_deadlock_cb.cpp
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2016-2021 Xilinx, Inc
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -14,7 +15,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_PLUGIN_SOURCE
 
 #include "pl_deadlock_cb.h"
 #include "pl_deadlock_plugin.h"

--- a/src/runtime_src/xdp/profile/plugin/pl_deadlock/pl_deadlock_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/pl_deadlock/pl_deadlock_plugin.cpp
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2016-2021 Xilinx, Inc
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -15,7 +15,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_PLUGIN_SOURCE
 
 #include <array>
 #include <iostream>

--- a/src/runtime_src/xdp/profile/plugin/pl_deadlock/pl_deadlock_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/pl_deadlock/pl_deadlock_plugin.h
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2016-2021 Xilinx, Inc
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -27,7 +28,7 @@ namespace xdp {
   class PLDeadlockPlugin : public XDPPlugin
   {
   private:
-    XDP_EXPORT virtual void pollDeadlock(void* handle, uint64_t index);
+    XDP_PLUGIN_EXPORT virtual void pollDeadlock(void* handle, uint64_t index);
     void forceWrite();
   
   private:
@@ -38,14 +39,14 @@ namespace xdp {
     std::mutex writeLock;
 
   public:
-    XDP_EXPORT PLDeadlockPlugin();
-    XDP_EXPORT ~PLDeadlockPlugin();
+    XDP_PLUGIN_EXPORT PLDeadlockPlugin();
+    XDP_PLUGIN_EXPORT ~PLDeadlockPlugin();
 
-    XDP_EXPORT virtual void updateDevice(void* handle);
-    XDP_EXPORT virtual void flushDevice(void* handle);
+    XDP_PLUGIN_EXPORT virtual void updateDevice(void* handle);
+    XDP_PLUGIN_EXPORT virtual void flushDevice(void* handle);
 
     // Virtual functions from XDPPlugin
-    XDP_EXPORT virtual void writeAll(bool openNewFiles);
+    XDP_PLUGIN_EXPORT virtual void writeAll(bool openNewFiles);
   };
 
 } // end namespace xdp

--- a/src/runtime_src/xdp/profile/plugin/pl_deadlock/pl_deadlock_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/pl_deadlock/pl_deadlock_plugin.h
@@ -28,7 +28,7 @@ namespace xdp {
   class PLDeadlockPlugin : public XDPPlugin
   {
   private:
-    XDP_PLUGIN_EXPORT virtual void pollDeadlock(void* handle, uint64_t index);
+    virtual void pollDeadlock(void* handle, uint64_t index);
     void forceWrite();
   
   private:
@@ -39,14 +39,14 @@ namespace xdp {
     std::mutex writeLock;
 
   public:
-    XDP_PLUGIN_EXPORT PLDeadlockPlugin();
-    XDP_PLUGIN_EXPORT ~PLDeadlockPlugin();
+    PLDeadlockPlugin();
+    ~PLDeadlockPlugin();
 
-    XDP_PLUGIN_EXPORT virtual void updateDevice(void* handle);
-    XDP_PLUGIN_EXPORT virtual void flushDevice(void* handle);
+    virtual void updateDevice(void* handle);
+    virtual void flushDevice(void* handle);
 
     // Virtual functions from XDPPlugin
-    XDP_PLUGIN_EXPORT virtual void writeAll(bool openNewFiles);
+    virtual void writeAll(bool openNewFiles);
   };
 
 } // end namespace xdp

--- a/src/runtime_src/xdp/profile/plugin/power/power_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/power/power_plugin.cpp
@@ -15,7 +15,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_PLUGIN_SOURCE
 
 #include <map>
 

--- a/src/runtime_src/xdp/profile/plugin/power/power_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/power/power_plugin.h
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2020 Xilinx, Inc
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -44,7 +45,7 @@ namespace xdp {
     PowerProfilingPlugin() ;
     ~PowerProfilingPlugin() ;
 
-    XDP_EXPORT void addDevice(void* handle) ;
+    XDP_PLUGIN_EXPORT void addDevice(void* handle) ;
   } ;
 
 } // end namespace xdp

--- a/src/runtime_src/xdp/profile/plugin/power/power_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/power/power_plugin.h
@@ -23,7 +23,6 @@
 #include <thread>
 
 #include "xdp/profile/plugin/vp_base/vp_base_plugin.h"
-#include "xdp/config.h"
 
 namespace xdp {
 
@@ -45,7 +44,7 @@ namespace xdp {
     PowerProfilingPlugin() ;
     ~PowerProfilingPlugin() ;
 
-    XDP_PLUGIN_EXPORT void addDevice(void* handle) ;
+    void addDevice(void* handle) ;
   } ;
 
 } // end namespace xdp

--- a/src/runtime_src/xdp/profile/plugin/system_compiler/system_compiler_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/system_compiler/system_compiler_plugin.cpp
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2021 Xilinx, Inc
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -14,7 +15,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_PLUGIN_SOURCE
 
 #include "xdp/profile/plugin/system_compiler/system_compiler_plugin.h"
 #include "xdp/profile/plugin/vp_base/info.h"

--- a/src/runtime_src/xdp/profile/plugin/user/user_cb.cpp
+++ b/src/runtime_src/xdp/profile/plugin/user/user_cb.cpp
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2020 Xilinx, Inc
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -15,7 +15,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_PLUGIN_SOURCE
 
 #include "core/common/time.h"
 

--- a/src/runtime_src/xdp/profile/plugin/user/user_cb.h
+++ b/src/runtime_src/xdp/profile/plugin/user/user_cb.h
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2020 Xilinx, Inc
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -23,20 +23,20 @@
 // These are the functions that are visible when the plugin is dynamically
 // linked in.  XRT should call them directly
 extern "C"
-XDP_EXPORT
+XDP_PLUGIN_EXPORT
 void user_event_start_cb(unsigned int functionID,
                          const char* label,
                          const char* tooltip);
 extern "C"
-XDP_EXPORT
+XDP_PLUGIN_EXPORT
 void user_event_end_cb(unsigned int functionID);
 
 extern "C"
-XDP_EXPORT
+XDP_PLUGIN_EXPORT
 void user_event_happened_cb(const char* label);
 
 extern "C"
-XDP_EXPORT
+XDP_PLUGIN_EXPORT
 void user_event_time_ns_cb(unsigned long long int time_ns, const char* label);
 
 #endif

--- a/src/runtime_src/xdp/profile/plugin/vart/vart_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/vart/vart_plugin.cpp
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2016-2020 Xilinx, Inc
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -14,7 +15,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_PLUGIN_SOURCE
 
 #include <cstring>
 #include "xdp/profile/plugin/vart/vart_plugin.h"

--- a/src/runtime_src/xdp/profile/plugin/vart/vart_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/vart/vart_plugin.h
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2016-2020 Xilinx, Inc
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -26,10 +27,10 @@ namespace xdp {
   private:
 
   public:
-    XDP_EXPORT
+    XDP_PLUGIN_EXPORT
     VARTPlugin();
 
-    XDP_EXPORT
+    XDP_PLUGIN_EXPORT
     ~VARTPlugin();
   };
   

--- a/src/runtime_src/xdp/profile/plugin/vart/vart_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/vart/vart_plugin.h
@@ -27,10 +27,8 @@ namespace xdp {
   private:
 
   public:
-    XDP_PLUGIN_EXPORT
     VARTPlugin();
 
-    XDP_PLUGIN_EXPORT
     ~VARTPlugin();
   };
   

--- a/src/runtime_src/xdp/profile/plugin/vp_base/utility.cpp
+++ b/src/runtime_src/xdp/profile/plugin/vp_base/utility.cpp
@@ -15,7 +15,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_CORE_SOURCE
 
 #include <boost/algorithm/string.hpp>
 #include <boost/property_tree/ptree.hpp>

--- a/src/runtime_src/xdp/profile/plugin/vp_base/utility.h
+++ b/src/runtime_src/xdp/profile/plugin/vp_base/utility.h
@@ -25,12 +25,12 @@
 
 namespace xdp {
 
-  XDP_EXPORT std::string getCurrentDateTime();
-  XDP_EXPORT std::string getMsecSinceEpoch();
-  XDP_EXPORT const char* getToolVersion();
-  XDP_EXPORT std::string getXRTVersion();
-  XDP_EXPORT bool isEdge();
-  XDP_EXPORT uint64_t getPSMemorySize();
+  XDP_CORE_EXPORT std::string getCurrentDateTime();
+  XDP_CORE_EXPORT std::string getMsecSinceEpoch();
+  XDP_CORE_EXPORT const char* getToolVersion();
+  XDP_CORE_EXPORT std::string getXRTVersion();
+  XDP_CORE_EXPORT bool isEdge();
+  XDP_CORE_EXPORT uint64_t getPSMemorySize();
 
   enum Flow {
     SW_EMU  = 0,
@@ -53,7 +53,7 @@ namespace xdp {
     constexpr double ddr4_2400_bandwidth = 19250.00;
   }
 
-  XDP_EXPORT Flow getFlowMode();
+  XDP_CORE_EXPORT Flow getFlowMode();
 
 } // end namespace xdp
 

--- a/src/runtime_src/xdp/profile/plugin/vp_base/vp_base_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/vp_base/vp_base_plugin.cpp
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2016-2020 Xilinx, Inc
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -14,7 +15,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_CORE_SOURCE
 
 #include <cstdlib>
 

--- a/src/runtime_src/xdp/profile/plugin/vp_base/vp_base_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/vp_base/vp_base_plugin.h
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2016-2020 Xilinx, Inc
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -66,28 +67,28 @@ namespace xdp {
 
     // If there is something that is common amongst all plugins when
     //  dealing with emulation flows.
-    XDP_EXPORT virtual void emulationSetup() ;
+    XDP_CORE_EXPORT virtual void emulationSetup() ;
 
-    XDP_EXPORT void startWriteThread(unsigned int interval, std::string type, bool openNewFiles = true);
-    XDP_EXPORT void endWrite();
-    XDP_EXPORT void trySafeWrite(const std::string& type, bool openNewFiles);
+    XDP_CORE_EXPORT void startWriteThread(unsigned int interval, std::string type, bool openNewFiles = true);
+    XDP_CORE_EXPORT void endWrite();
+    XDP_CORE_EXPORT void trySafeWrite(const std::string& type, bool openNewFiles);
 
   public:
-    XDP_EXPORT XDPPlugin() ;
-    XDP_EXPORT virtual ~XDPPlugin() ;
+    XDP_CORE_EXPORT XDPPlugin() ;
+    XDP_CORE_EXPORT virtual ~XDPPlugin() ;
     
     inline VPDatabase* getDatabase() { return db ; }
 
     // When the database gets reset or at the end of execution,
     //  the plugins must make sure all of their writers dump a complete file
-    XDP_EXPORT virtual void writeAll(bool openNewFiles = true) ;
+    XDP_CORE_EXPORT virtual void writeAll(bool openNewFiles = true) ;
 
     // Messages may be broadcast from the database to all plugins using
     //  this function
-    XDP_EXPORT virtual void broadcast(VPDatabase::MessageType msg,
+    XDP_CORE_EXPORT virtual void broadcast(VPDatabase::MessageType msg,
 				      void* blob = nullptr) ;
 
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     static unsigned int get_trace_file_dump_int_s ();
   } ;
 

--- a/src/runtime_src/xdp/profile/writer/device_trace/device_trace_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/device_trace/device_trace_writer.cpp
@@ -15,7 +15,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_PLUGIN_SOURCE
 
 #include "xdp/profile/database/database.h"
 #include "xdp/profile/database/events/device_events.h"

--- a/src/runtime_src/xdp/profile/writer/native/native_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/native/native_writer.cpp
@@ -15,7 +15,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_PLUGIN_SOURCE
 
 #include "xdp/profile/database/database.h"
 #include "xdp/profile/database/events/native_events.h"

--- a/src/runtime_src/xdp/profile/writer/vp_base/guidance_rules.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/guidance_rules.cpp
@@ -15,7 +15,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_CORE_SOURCE
 
 #include <memory>
 #include <map>

--- a/src/runtime_src/xdp/profile/writer/vp_base/ini_parameters.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/ini_parameters.cpp
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2016-2022 Xilinx, Inc
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -15,7 +15,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_CORE_SOURCE
 
 #include "xdp/profile/writer/vp_base/ini_parameters.h"
 #include "core/common/config_reader.h"

--- a/src/runtime_src/xdp/profile/writer/vp_base/summary_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/summary_writer.cpp
@@ -15,7 +15,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_CORE_SOURCE
 
 #include "core/common/config_reader.h"
 #include "core/common/sysinfo.h"

--- a/src/runtime_src/xdp/profile/writer/vp_base/summary_writer.h
+++ b/src/runtime_src/xdp/profile/writer/vp_base/summary_writer.h
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2016-2022 Xilinx, Inc
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -108,11 +108,11 @@ namespace xdp {
     static constexpr double one_billion  = 1.0e09 ;
 
   public:
-    XDP_EXPORT SummaryWriter(const char* filename) ;
-    XDP_EXPORT SummaryWriter(const char* filename, VPDatabase* inst) ;
-    XDP_EXPORT ~SummaryWriter() = default ;
+    XDP_CORE_EXPORT SummaryWriter(const char* filename) ;
+    XDP_CORE_EXPORT SummaryWriter(const char* filename, VPDatabase* inst) ;
+    XDP_CORE_EXPORT ~SummaryWriter() = default ;
 
-    XDP_EXPORT virtual bool write(bool openNewFile) ;
+    XDP_CORE_EXPORT virtual bool write(bool openNewFile) ;
   } ;
 
 } // end namespace xdp

--- a/src/runtime_src/xdp/profile/writer/vp_base/vp_run_summary.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/vp_run_summary.cpp
@@ -22,7 +22,7 @@
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/json_parser.hpp>
 
-#define XDP_SOURCE
+#define XDP_CORE_SOURCE
 
 #ifdef _WIN32
 #include <direct.h>

--- a/src/runtime_src/xdp/profile/writer/vp_base/vp_run_summary.h
+++ b/src/runtime_src/xdp/profile/writer/vp_base/vp_run_summary.h
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2016-2020 Xilinx, Inc
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -31,12 +32,12 @@ namespace xdp {
   protected:
     virtual void switchFiles() ;
   public:
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     VPRunSummaryWriter(const char* filename, VPDatabase* inst) ;
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     ~VPRunSummaryWriter() ;
 
-    XDP_EXPORT
+    XDP_CORE_EXPORT
     virtual bool write(bool openNewFile) ;
 
     virtual bool isRunSummaryWriter() { return true ; }

--- a/src/runtime_src/xdp/profile/writer/vp_base/vp_summary_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/vp_summary_writer.cpp
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2016-2020 Xilinx, Inc
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -16,7 +17,7 @@
 
 #include <cstdio>
 
-#define XDP_SOURCE
+#define XDP_CORE_SOURCE
 
 #include "xdp/profile/writer/vp_base/vp_summary_writer.h"
 #include "core/common/message.h"

--- a/src/runtime_src/xdp/profile/writer/vp_base/vp_summary_writer.h
+++ b/src/runtime_src/xdp/profile/writer/vp_base/vp_summary_writer.h
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2016-2020 Xilinx, Inc
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -29,11 +30,11 @@ namespace xdp {
     VPSummaryWriter() = delete ;
 
   protected:
-    XDP_EXPORT virtual void switchFiles() ;
+    XDP_CORE_EXPORT virtual void switchFiles() ;
   public:
-    XDP_EXPORT VPSummaryWriter(const char* filename) ;
-    XDP_EXPORT VPSummaryWriter(const char* filename, VPDatabase* inst);
-    XDP_EXPORT ~VPSummaryWriter() ;
+    XDP_CORE_EXPORT VPSummaryWriter(const char* filename) ;
+    XDP_CORE_EXPORT VPSummaryWriter(const char* filename, VPDatabase* inst);
+    XDP_CORE_EXPORT ~VPSummaryWriter() ;
   } ;
   
 }

--- a/src/runtime_src/xdp/profile/writer/vp_base/vp_trace_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/vp_trace_writer.cpp
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2016-2020 Xilinx, Inc
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -15,7 +15,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_CORE_SOURCE
 
 #include <iostream>
 

--- a/src/runtime_src/xdp/profile/writer/vp_base/vp_trace_writer.h
+++ b/src/runtime_src/xdp/profile/writer/vp_base/vp_trace_writer.h
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2016-2020 Xilinx, Inc
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -40,7 +40,7 @@ namespace xdp {
     
   protected:
     // Each new trace CSV file has the following sections
-    XDP_EXPORT virtual void writeHeader() ;
+    XDP_CORE_EXPORT virtual void writeHeader() ;
     virtual void writeStructure() = 0 ;
     virtual void writeStringTable() = 0 ;
     virtual void writeTraceEvents() = 0 ;
@@ -55,12 +55,12 @@ namespace xdp {
     virtual bool isKernel() { return false ; } 
 
     // Return a unique ID everytime we're called
-    XDP_EXPORT void setUniqueTraceID();
+    XDP_CORE_EXPORT void setUniqueTraceID();
 
   public:
-    XDP_EXPORT VPTraceWriter(const char* filename, const std::string& v,
+    XDP_CORE_EXPORT VPTraceWriter(const char* filename, const std::string& v,
                              const std::string& c, uint16_t r) ;
-    XDP_EXPORT ~VPTraceWriter() ;
+    XDP_CORE_EXPORT ~VPTraceWriter() ;
   } ;
   
 }

--- a/src/runtime_src/xdp/profile/writer/vp_base/vp_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/vp_writer.cpp
@@ -15,7 +15,7 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#define XDP_CORE_SOURCE
 
 #include "xdp/profile/database/database.h"
 #include "xdp/profile/writer/vp_base/vp_writer.h"

--- a/src/runtime_src/xdp/profile/writer/vp_base/vp_writer.h
+++ b/src/runtime_src/xdp/profile/writer/vp_base/vp_writer.h
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2016-2020 Xilinx, Inc
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -58,14 +59,14 @@ namespace xdp {
     VPWriter() = delete ;
 
     inline const char* getRawBasename() { return basename.c_str() ; } 
-    XDP_EXPORT virtual void switchFiles() ;
-    XDP_EXPORT virtual void refreshFile() ;
+    XDP_CORE_EXPORT virtual void switchFiles() ;
+    XDP_CORE_EXPORT virtual void refreshFile() ;
   public:
-    XDP_EXPORT VPWriter(const char* filename) ;
-    XDP_EXPORT VPWriter(const char* filename, VPDatabase* inst, bool useDir = true) ;
-    XDP_EXPORT virtual ~VPWriter() ;
+    XDP_CORE_EXPORT VPWriter(const char* filename) ;
+    XDP_CORE_EXPORT VPWriter(const char* filename, VPDatabase* inst, bool useDir = true) ;
+    XDP_CORE_EXPORT virtual ~VPWriter() ;
 
-    XDP_EXPORT virtual std::string getcurrentFileName() ;
+    XDP_CORE_EXPORT virtual std::string getcurrentFileName() ;
 
     virtual bool isRunSummaryWriter() { return false ; }
     // Return false to indicate no data was written


### PR DESCRIPTION
#### Problem solved by the commit
The debug/profiling libraries are built as multiple shared libraries, and functions must be exported on Windows to be used.  Previously, the xdp_core library and the individual plugins were all using the same directives to specify when to export functions, which made it confusing as to what was exported from where.  This pull request changes the names of the export directives so that the source code of the xdp_core library is distinct from the source code of the individual xdp plugins and it is clear what is being imported versus exported.

#### Risks (if any) associated the changes in the commit
No risk to Linux, but some risk to Windows as some functions are no longer exported from the individual plugins.

#### What has been tested and how, request additional testing if necessary
This has been built on Linux and Windows and all compile-time linking issues resolved.  Additional testing on Windows is required.

#### Documentation impact (if any)
No documentation impact