### PR TITLE
VITIS-9991 - Removing boost::filesystem P5

### DIFF
--- a/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.cpp
@@ -12,10 +12,10 @@
 namespace XBU = XBUtilities;
 
 // 3rd Party Library - Include Files
-#include <boost/filesystem.hpp>
 
 // System - Include Files
 #include <fstream>
+#include <filesystem>
 
 static constexpr size_t host_app = 1; //opcode
 static constexpr size_t buffer_size_gb = 1;
@@ -88,7 +88,7 @@ TestDF_bandwidth::run(std::shared_ptr<xrt_core::device> dev)
   }
 
   auto xclbin_path = findXclbinPath(dev, ptree);
-  if (!boost::filesystem::exists(xclbin_path)) {
+  if (!std::filesystem::exists(xclbin_path)) {
     return ptree;
   }
   // log xclbin test dir for debugging purposes


### PR DESCRIPTION
Problem solved by the commit:
A file was remained from removing the boost::filesystem.

Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
N/A

How problem was solved, alternative solutions (if any) and why they were rejected
Risks (if any) associated the changes in the commit
None

What has been tested and how, request additional testing if necessary
System Configuration
  OS Name              : Linux
  Release              : 6.5.0-rc1+
  Version              : #10 SMP PREEMPT_DYNAMIC Wed Aug 16 22:28:12 PDT 2023
  Machine              : x86_64
  CPU Cores            : 16
  Memory               : 63990 MB
  Distribution         : Ubuntu 22.04 LTS
  GLIBC                : 2.35
  Model                : Precision 5820 Tower
  BIOS vendor          : Dell Inc.
  BIOS version         : 2.0.2

XRT
  Version              : 2.17.0
  Branch               : amd/dev/haghilin/last_boost_filesystem_removal
  Hash                 : ddbbe34a6ff248b315186ad3d3bf2c35e1b16779
  Hash Date            : 2023-11-22 09:07:58
  XOCL                 : 2.16.0, 893580509d3f7b0f1fab5a0da6210c709529a740
  XCLMGMT              : 2.16.0, 893580509d3f7b0f1fab5a0da6210c709529a740