### PR TITLE
Add warning exceptions for early returns

### DIFF
--- a/src/runtime_src/core/tools/common/tests/TestAiePs.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestAiePs.cpp
@@ -14,6 +14,10 @@ namespace XBU = XBUtilities;
 #define HEIGHT 8 
 #define SIZE (WIDTH * HEIGHT)
 
+#ifdef _WIN32
+#pragma warning(disable : 4702) //TODO remove when test is implemented properly
+#endif
+
 // ----- C L A S S   M E T H O D S -------------------------------------------
 TestAiePs::TestAiePs()
   : TestRunner("ps-aie", 

--- a/src/runtime_src/core/tools/common/tests/TestHostMemBandwidthKernel.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestHostMemBandwidthKernel.cpp
@@ -15,6 +15,7 @@ namespace XBU = XBUtilities;
 
 #ifdef _WIN32
 #pragma warning(disable : 4996) //std::getenv
+#pragma warning(disable : 4702) //TODO remove when test is implemented properly
 #endif
 
 static const int reps = (std::getenv("XCL_EMULATION_MODE") != nullptr) ? 2 : 10000;

--- a/src/runtime_src/core/tools/common/tests/TestPsIops.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestPsIops.cpp
@@ -17,6 +17,10 @@ namespace XBU = XBUtilities;
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
 
+#ifdef _WIN32
+#pragma warning(disable : 4702) //TODO remove when test is implemented properly
+#endif
+
 using ms_t = std::chrono::microseconds;
 using Clock = std::chrono::high_resolution_clock;
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
The current changes to the validation tests prevents XRT-IPU from compiling.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Introduced in https://github.com/Xilinx/XRT/pull/7746 

#### How problem was solved, alternative solutions (if any) and why they were rejected
Add warning exceptions to ignore the early returns.

#### Risks (if any) associated the changes in the commit
None.

#### What has been tested and how, request additional testing if necessary
Changes compile in XRT-IPU with x64 command prompt and Linux. 

#### Documentation impact (if any)
None.
