### PR TITLE
CR-1182090: Fixing widespread seg fault

### DIFF
--- a/src/runtime_src/core/common/sysinfo.cpp
+++ b/src/runtime_src/core/common/sysinfo.cpp
@@ -22,6 +22,15 @@ get_xrt_info(boost::property_tree::ptree& pt)
 }
 
 void
+get_xrt_build_info(boost::property_tree::ptree& pt)
+{
+  pt.put("version",    xrt_build_version);
+  pt.put("branch",     xrt_build_version_branch);
+  pt.put("hash",       xrt_build_version_hash);
+  pt.put("build_date", xrt_build_version_date);
+}
+
+void
 get_os_info(boost::property_tree::ptree& pt)
 {
   xrt_core::sysinfo::detail::get_os_info(pt);

--- a/src/runtime_src/core/common/sysinfo.h
+++ b/src/runtime_src/core/common/sysinfo.h
@@ -17,6 +17,10 @@ get_xrt_info(boost::property_tree::ptree&);
 
 XRT_CORE_COMMON_EXPORT
 void
+get_xrt_build_info(boost::property_tree::ptree&);
+
+XRT_CORE_COMMON_EXPORT
+void
 get_os_info(boost::property_tree::ptree&);
 
 }

--- a/src/runtime_src/core/common/system.cpp
+++ b/src/runtime_src/core/common/system.cpp
@@ -97,15 +97,6 @@ instance()
 }
 
 void
-get_xrt_build_info(boost::property_tree::ptree& pt)
-{
-  pt.put("version",    xrt_build_version);
-  pt.put("branch",     xrt_build_version_branch);
-  pt.put("hash",       xrt_build_version_hash);
-  pt.put("build_date", xrt_build_version_date);
-}
-
-void
 get_driver_info(boost::property_tree::ptree &pt)
 {
   instance().get_driver_info(pt);

--- a/src/runtime_src/xdp/profile/writer/vp_base/summary_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/summary_writer.cpp
@@ -139,7 +139,7 @@ namespace xdp {
 #endif
 
     boost::property_tree::ptree xrtInfo ;
-    xrt_core::sysinfo::get_xrt_info(xrtInfo) ;
+    xrt_core::sysinfo::get_xrt_build_info(xrtInfo) ;
 
     fout << "Profile Summary\n" ;
     fout << "Generated on: " << getCurrentDateTime() << "\n" ;


### PR DESCRIPTION
#### Problem solved by the commit
When any profiling is enabled, a summary file is generated at the end of application execution.  Recent changes caused this summary generation to seg fault, resulting in a widespread failure on all profiling enabled tests and applications.  This pull request reverts functionality and fixes the crashes.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
The issue was introduced in pull request 7773, and was due to the change in the summary writer to call get_xrt_info instead of get_xrt_build_info.  The function get_xrt_info gets the same information as get_xrt_build_info, but also calls a function to get driver information, which in turn relies on a singleton instance to fetch the information.  As the summary writer is called during the destruction of another singleton object, we cannot rely on the other singleton object still being alive and trying to read from it caused the crash.  The function get_xrt_build_info was created explicitly to guarantee that the profiling summary writer would not access any other singleton object that could have been destroyed.

The issue was discovered when all of our internal regressions tests failed when profiling was enabled.

#### How problem was solved, alternative solutions (if any) and why they were rejected
This reintroduces the get_xrt_build_info function as an exported function from xrt_core, and places it in the sysinfo.h and sysinfo.cpp files.  This function still existed in system.cpp but was not available to the profiling library, so it has been removed.  The profiling library now calls the get_xrt_build_info function instead of get_xrt_info.

#### Risks (if any) associated the changes in the commit
Low risk as this moves a function and reintroduces functionality that was originally called.

#### What has been tested and how, request additional testing if necessary
Tested on profiling designs that were causing seg faults on hardware.

#### Documentation impact (if any)
No documentation impact