### PR TITLE
Rename xrt_core to amd_xrt_core

### DIFF
--- a/src/runtime_src/core/common/module_loader.cpp
+++ b/src/runtime_src/core/common/module_loader.cpp
@@ -73,7 +73,11 @@ static std::string
 shim_name()
 {
   if (!is_emulation())
+#ifdef _WIN32
     return "amd_xrt_core";
+#else
+    return "xrt_core";
+#endif
 
   if (is_hw_emulation()) {
     auto hw_em_driver_path = xrt_core::config::get_hw_em_driver();

--- a/src/runtime_src/core/common/module_loader.cpp
+++ b/src/runtime_src/core/common/module_loader.cpp
@@ -73,7 +73,7 @@ static std::string
 shim_name()
 {
   if (!is_emulation())
-    return "xrt_core";
+    return "amd_xrt_core";
 
   if (is_hw_emulation()) {
     auto hw_em_driver_path = xrt_core::config::get_hw_em_driver();


### PR DESCRIPTION
Current version of XRT codebase reflects QoS changes.  This makes xrt_core
incompatible with legacy customer application.

Customer application carries a version of xrt_coreutil that looks for xrt_core at run
time. By renaming xrt_core to amd_xrt_core and keeping a copy of old
xrt_core (manual process) in AMD's installation, legacy customer application will
continue to work and pick up legacy xrt_core.

With this PR, xrt_coreutil with pick up compatible amd_xrt_core at run time, while
customer application's legacy xrt_coreutil will pick up legacy xrt_core.

