### PR TITLE
VITIS-10866 - Patching instruction buffer in XRT

### DIFF
--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -103,10 +103,10 @@ struct patcher
 {
   enum class symbol_type {
     uc_dma_remote_ptr_symbol_kind = 1,
-    shim_dma_base_addr_symbol_kind = 2,
+    shim_dma_base_addr_symbol_kind = 2, // patching scheme needed by AIE2PS firmware
     scalar_32bit_kind = 3,
-    control_packet_48 = 4,
-    shim_dma_48 = 5,
+    control_packet_48 = 4,              // patching scheme needed by IPU firmware to patch control packet
+    shim_dma_48 = 5,                    // patching scheme needed by IPU firmware to patch instruction buffer
     unknown_symbol_kind = 6
   };
 
@@ -146,6 +146,7 @@ struct patcher
   void
   patch_ctrl48(uint32_t* bd_data_ptr, uint64_t patch)
   {
+    // This function is a copy&paste from IPU firmware
     constexpr uint64_t ddr_aie_addr_offset = 0x80000000;
 
     uint64_t base_address =
@@ -159,6 +160,7 @@ struct patcher
 
   void patch_shim48(uint32_t* bd_data_ptr, uint64_t patch)
   {
+    // This function is a copy&paste from IPU firmware
     constexpr uint64_t ddr_aie_addr_offset = 0x80000000;
 
     uint64_t base_address =


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Currently instruction buffer is patched in firmware by using all necessary bo address. This adds additional workload to firmware and it is not optimal to the whole system.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Instruction buffer is patched in XRT.

#### What has been tested and how, request additional testing if necessary
Test result from actual Pheonix board and Simnow-lite are good.
#### Documentation impact (if any)
Firmware and KMD driver needs to be changed in order to make the XRT change effective.