### PR TITLE
Create file with unique name to dump usage metrics

### DIFF
--- a/src/runtime_src/core/common/message.cpp
+++ b/src/runtime_src/core/common/message.cpp
@@ -34,24 +34,12 @@
 # include <linux/limits.h>
 # include <sys/stat.h>
 # include <sys/types.h>
-#include <unistd.h>
 #endif
 #ifdef _WIN32
-# include <process.h>
 # include <winsock.h>
 #endif
 
 namespace {
-
-static int
-get_processid()
-{
-#ifdef _WIN32
-  return _getpid();
-#else
-  return getpid();
-#endif
-}
 
 static unsigned int
 get_userid()
@@ -206,7 +194,7 @@ file_dispatch(const std::string &file)
   handle << "Build date: " << xrt_build_version_date << "\n";
   handle << "Git branch: " << xrt_build_version_branch<< "\n";
   handle << "[" << xrt_core::timestamp() << "]" << "\n";
-  handle << "PID: " << get_processid() << "\n";
+  handle << "PID: " << xrt_core::utils::get_pid() << "\n";
   handle << "UID: " << get_userid() << "\n";
   handle << "HOST: " <<  xrt_core::utils::get_hostname() << "\n";
   handle << "EXE: " << get_exe_path() << std::endl;
@@ -235,7 +223,7 @@ console_dispatch()
   std::cerr << "Build hash: " << xrt_build_version_hash << "\n";
   std::cerr << "Build date: " << xrt_build_version_date << "\n";
   std::cerr << "Git branch: " << xrt_build_version_branch<< "\n";
-  std::cerr << "PID: " << get_processid() << "\n";
+  std::cerr << "PID: " << xrt_core::utils::get_pid() << "\n";
   std::cerr << "UID: " << get_userid() << "\n";
   std::cerr << "[" << xrt_core::timestamp() << "]\n";
   std::cerr << "HOST: " << xrt_core::utils::get_hostname() << "\n";

--- a/src/runtime_src/core/common/usage_metrics.cpp
+++ b/src/runtime_src/core/common/usage_metrics.cpp
@@ -13,6 +13,7 @@
 #include "core/common/query_requests.h"
 #include "core/common/shim/buffer_handle.h"
 #include "core/common/shim/hwctx_handle.h"
+#include "core/common/utils.h"
 #include "core/include/xrt/xrt_uuid.h"
 
 #include <algorithm>
@@ -173,7 +174,8 @@ print_json(const bpt::ptree& pt)
   time_stamp << std::put_time(std::localtime(&time), "%Y-%m-%d_%H-%M-%S");
 
   // create json in pwd
-  std::string file_name{"XRT_usage_metrics_" + time_stamp.str() + ".json"};
+  // file name format - XRT_usage_metrics_##pid_YY-MM-DD_H-M-S.json
+  std::string file_name{"XRT_usage_metrics_" + std::to_string(xrt_core::utils::get_pid()) + "_" + time_stamp.str() + ".json"};
   std::ofstream out_file{file_name};
 
   if (out_file.is_open()) {

--- a/src/runtime_src/core/common/utils.cpp
+++ b/src/runtime_src/core/common/utils.cpp
@@ -28,6 +28,13 @@
 #include <string>
 #include <boost/algorithm/string.hpp>
 
+#ifdef __linux__
+#include <unistd.h>
+#endif
+#ifdef _WIN32
+# include <process.h>
+#endif
+
 namespace {
 
 inline unsigned int
@@ -323,6 +330,16 @@ value_to_mac_addr(const uint64_t mac_addr_value)
                                           % ((mac_addr_value >> (0 * 8)) & 0xFF));
 
   return mac_addr;
+}
+
+int
+get_pid()
+{
+#ifdef _WIN32
+  return _getpid();
+#else
+  return getpid();
+#endif
 }
 
 }} // utils, xrt_core

--- a/src/runtime_src/core/common/utils.cpp
+++ b/src/runtime_src/core/common/utils.cpp
@@ -29,7 +29,7 @@
 #include <boost/algorithm/string.hpp>
 
 #ifdef __linux__
-#include <unistd.h>
+# include <unistd.h>
 #endif
 #ifdef _WIN32
 # include <process.h>

--- a/src/runtime_src/core/common/utils.h
+++ b/src/runtime_src/core/common/utils.h
@@ -129,6 +129,10 @@ XRT_CORE_COMMON_EXPORT
 std::string
 value_to_mac_addr(const uint64_t mac_addr_value);
 
+XRT_CORE_COMMON_EXPORT
+int
+get_pid();
+
 }} // utils, xrt_core
 
 #endif


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
When dumping usage metrics into JSON file, the file name is not unique. Including pid in the file name to create unique file as the log is dumped per process.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
PR - https://github.com/Xilinx/XRT/pull/7788 introduced the bug
This bug was detected when debugging CR - https://jira.xilinx.com/browse/CR-1181804. Files names matched for processes exiting at same time and there was issue of files being overwritten.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Problem was solved by adding pid in file name as log is dumped per process and it will be unique

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
Tested with the application that is attached with CR and things are working as expected

#### Documentation impact (if any)
NA