### PR TITLE
CR-1183009 Fix xbutil validate bugs in mem-bw and verify

### DIFF
--- a/src/runtime_src/core/tools/common/tests/TestBandwidthKernel.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestBandwidthKernel.cpp
@@ -165,7 +165,7 @@ test_bandwidth_ddr(xrt::device device, std::vector<xrt::kernel> krnls, int num_k
     }
 
     auto time_start = std::chrono::high_resolution_clock::now();
-    xrt::run runs[num_kernel_ddr];
+    std::vector<xrt::run> runs(num_kernel_ddr);
     for (int i = 0; i < num_kernel_ddr; i++)
       runs[i] = krnls[i](input_buffer[i], output_buffer[i], data_size, reps);
     for (int i = 0; i < num_kernel_ddr; i++)

--- a/src/runtime_src/core/tools/common/tests/TestBandwidthKernel.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestBandwidthKernel.cpp
@@ -17,7 +17,7 @@ namespace XBU = XBUtilities;
 #pragma warning(disable : 4996) //std::getenv
 #endif
 
-static const int reps = (std::getenv("XCL_EMULATION_MODE") != nullptr) ? 2 : 10000;
+static const int reps = (std::getenv("XCL_EMULATION_MODE") != nullptr) ? 2 : 1000;
 
 // ----- C L A S S   M E T H O D S -------------------------------------------
 TestBandwidthKernel::TestBandwidthKernel()
@@ -119,9 +119,8 @@ initialize_output_host_hbm(unsigned int data_size)
 static double
 calculate_max_throughput(std::chrono::time_point<std::chrono::high_resolution_clock> time_end,
                           std::chrono::time_point<std::chrono::high_resolution_clock> time_start,
-                          unsigned int data_size, int num_bank)
+                          unsigned int data_size, int num_bank, double max_throughput)
 {
-  double max_throughput = 0;
   double usduration =
     (double)(std::chrono::duration_cast<std::chrono::nanoseconds>(time_end - time_start).count() / reps);
 
@@ -186,7 +185,7 @@ test_bandwidth_ddr(xrt::device device, std::vector<xrt::kernel> krnls, int num_k
       }
     }
 
-    max_throughput = calculate_max_throughput(time_end, time_start, data_size, num_kernel_ddr);
+    max_throughput = calculate_max_throughput(time_end, time_start, data_size, num_kernel_ddr, max_throughput);
   }
   return max_throughput;
 }
@@ -230,7 +229,7 @@ test_bandwidth_hbm(xrt::device device, std::vector<xrt::kernel> krnls, int num_k
       }
     }
 
-    max_throughput = calculate_max_throughput(time_end, time_start, data_size, 1);
+    max_throughput = calculate_max_throughput(time_end, time_start, data_size, 1, max_throughput);
   }
   return max_throughput;
 }

--- a/src/runtime_src/core/tools/common/tests/TestBandwidthKernel.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestBandwidthKernel.cpp
@@ -17,7 +17,7 @@ namespace XBU = XBUtilities;
 #pragma warning(disable : 4996) //std::getenv
 #endif
 
-static const int reps = (std::getenv("XCL_EMULATION_MODE") != nullptr) ? 2 : 1000;
+static const int reps = (std::getenv("XCL_EMULATION_MODE") != nullptr) ? 2 : 10000;
 
 // ----- C L A S S   M E T H O D S -------------------------------------------
 TestBandwidthKernel::TestBandwidthKernel()
@@ -165,10 +165,11 @@ test_bandwidth_ddr(xrt::device device, std::vector<xrt::kernel> krnls, int num_k
     }
 
     auto time_start = std::chrono::high_resolution_clock::now();
-    for (int i = 0; i < num_kernel_ddr; i++) {
-      auto run = krnls[i](input_buffer[i], output_buffer[i], data_size, reps);
-      run.wait();
-    }
+    xrt::run runs[num_kernel_ddr];
+    for (int i = 0; i < num_kernel_ddr; i++)
+      runs[i] = krnls[i](input_buffer[i], output_buffer[i], data_size, reps);
+    for (int i = 0; i < num_kernel_ddr; i++)
+      runs[i].wait();
     auto time_end = std::chrono::high_resolution_clock::now();
 
     for (int i = 0; i < num_kernel_ddr; i++) {

--- a/src/runtime_src/core/tools/common/tests/TestVerify.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestVerify.cpp
@@ -61,9 +61,20 @@ TestVerify::runTest(std::shared_ptr<xrt_core::device> dev, boost::property_tree:
   }
   auto xclbin_uuid = device.load_xclbin(b_file);
 
-  auto krnl = xrt::kernel(device, xclbin_uuid, "verify");
+  xrt::kernel krnl;
+  try {
+    krnl = xrt::kernel(device, xclbin_uuid, "verify");
+  } catch (const std::exception&) {
+    try {
+      krnl = xrt::kernel(device, xclbin_uuid, "hello");
+    } catch (const std::exception&) {
+      logger(ptree, "Error", "Kernel could not be found.");
+      ptree.put("status", test_token_failed);
+      return;
+    }
+  }
 
-  // Allocate the output buffer to hold the kernel ooutput
+  // Allocate the output buffer to hold the kernel output
   auto output_buffer = xrt::bo(device, sizeof(char) * LENGTH, krnl.group_id(0));
 
   // Run the kernel and store its contents within the allocated output buffer

--- a/src/runtime_src/core/tools/common/tests/TestVerify.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestVerify.cpp
@@ -7,6 +7,7 @@
 #include "tools/common/XBUtilities.h"
 namespace XBU = XBUtilities;
 
+#include <filesystem>
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
@@ -49,6 +50,15 @@ TestVerify::runTest(std::shared_ptr<xrt_core::device> dev, boost::property_tree:
   }
 
   const std::string b_file = findXclbinPath(dev, ptree);
+  // 0RP (nonDFX) flat shell support.
+  // Currently, there isn't a clean way to determine if a nonDFX shell's interface is truly flat.
+  // At this time, this is determined by whether or not it delivers an accelerator (e.g., verify.xclbin)
+  const auto logic_uuid = xrt_core::device_query_default<xrt_core::query::logic_uuids>(dev, {});
+  if (!logic_uuid.empty() && !std::filesystem::exists(b_file)) {
+    logger(ptree, "Details", "Verify xclbin not available or shell partition is not programmed. Skipping validation.");
+    ptree.put("status", test_token_skipped);
+    return;
+  }
   auto xclbin_uuid = device.load_xclbin(b_file);
 
   auto krnl = xrt::kernel(device, xclbin_uuid, "verify");


### PR DESCRIPTION
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1183009
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
After https://github.com/Xilinx/XRT/pull/7746, mem-bw was taking much longer even though it was still running under the timeout (noticed via an xbutil validate run on u200, which had a shorter timeout). Verify was failing on u250 due to absence of verify kernel in verify.xclbin.
#### How problem was solved, alternative solutions (if any) and why they were rejected
Fixed a bug in max-throughput calculation in mem-bw test. Fixed mem-bw to wait after running all kernels. Re-added a verify xclbin check in the verify test and checked for "hello" kernel.
#### Risks (if any) associated the changes in the commit
N/A
#### What has been tested and how, request additional testing if necessary
Tested on u200/vck5000/u30, mem-bw runtime is significantly more reasonable. Tested a mock-version of verify test on u250, will double-check on CR poster's machine following merge.
#### Documentation impact (if any)
N/A