### PR TITLE
VITIS-10247 Refactor device name mapping to use device class query

### DIFF
--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -416,28 +416,28 @@ XBUtilities::collect_devices( const std::set<std::string> &_deviceBDFs,
     return device;
   }
 
-// TODO this is a temporary function that will be replaced
-// by something in the shim or device layer.
 static std::string
-tempDeviceMapping(const std::string& deviceName)
+deviceMapping(const xrt_core::query::device_class::type type)
 {
-  if (deviceName.empty())
-    return "";
-
-  if (deviceName.find("Ryzen") != std::string::npos)
+  switch (type) {
+  case xrt_core::query::device_class::type::alveo:
+    return "alveo";
+  case xrt_core::query::device_class::type::ryzen:
     return "aie";
+  }
 
-  return "alveo";
+  return "";
 }
 
 std::string
 XBUtilities::get_device_class(const std::string &deviceBDF, bool in_user_domain)
 {
   if (deviceBDF.empty()) 
-    return tempDeviceMapping("");
+    return "";
 
   std::shared_ptr<xrt_core::device> device = get_device(boost::algorithm::to_lower_copy(deviceBDF), in_user_domain, false);
-  return tempDeviceMapping(xrt_core::device_query_default<xrt_core::query::rom_vbnv>(device, ""));
+  auto device_class = xrt_core::device_query_default<xrt_core::query::device_class>(device, xrt_core::query::device_class::type::alveo);
+  return deviceMapping(device_class);
 }
 
 void


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Instead of using the name of the device, it is much preferable to use the device query we have recently implemented.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
TODO function was introduced in https://github.com/Xilinx/XRT/pull/7766. It is not being replaced with a more permanent option.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Replaced searching the `RyzenAi` in the name with a device class query.

#### Risks (if any) associated the changes in the commit
None.

#### What has been tested and how, request additional testing if necessary
Tested on Windows IPU, Linux IPU, and Linux Alveo

Windows IPU
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ xbutil examine -d --help
WARNING: Unexpected xocl version (2.16.0) was found. Expected 2.17.0, to match XRT tools.

COMMAND: examine

DESCRIPTION: This command will 'examine' the state of the system/device and will generate a report of interest
               in a text or JSON format.

USAGE: xbutil examine [--help] [-d arg] [-f arg] [-o arg] [-r arg]

OPTIONS:
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest
  -f, --format       - Report output format. Valid values are:
                         JSON        - Latest JSON schema
                         JSON-2020.2 - JSON 2020.2 schema
  -o, --output       - Direct the output to the given file
  --help             - Help to use this sub-command
  -r, --report       - The type of report to be produced. Reports currently available are:
                         all             - All known reports are produced
                         debug-ip-status - Status of Debug IPs present in xclbin loaded on device
                         dynamic-regions - Information about the xclbin and the compute units
                         electrical      - Electrical and power sensors present on the device
                         error           - Asyncronus Error present on the device
                         firewall        - Firewall status
                         host            - Host information
                         mailbox         - Mailbox metrics of the device
                         mechanical      - Mechanical sensors on and surrounding the device
                         memory          - Memory information present on the device
                         pcie-info       - Pcie information of the device
                         platform        - Platforms flashed on the device
                         qspi-status     - QSPI write protection status
                         thermal         - Thermal sensors present on the device


GLOBAL OPTIONS:
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
```

Linux IPU
```
COMMAND: examine

DESCRIPTION: This command will 'examine' the state of the system/device and will generate a report of interest
               in a text or JSON format.

USAGE: xbutil examine [--help] [-d arg] [-f arg] [-o arg] [-r arg]

OPTIONS:
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest
  -f, --format       - Report output format. Valid values are:
                         JSON        - Latest JSON schema
                         JSON-2020.2 - JSON 2020.2 schema
  -o, --output       - Direct the output to the given file
  --help             - Help to use this sub-command
  -r, --report       - The type of report to be produced. Reports currently available are:
                         aie             - AIE metadata in xclbin
                         aie-partitions  - AIE partition information
                         aiemem          - AIE memory tile information
                         aieshim         - AIE shim tile status
                         all             - All known reports are produced
                         dynamic-regions - Information about the xclbin and the compute units
                         electrical      - Electrical and power sensors present on the device
                         host            - Host information
                         mechanical      - Mechanical sensors on and surrounding the device
                         memory          - Memory information present on the device
                         pcie-info       - Pcie information of the device
                         platform        - Platforms flashed on the device
                         thermal         - Thermal sensors present on the device


GLOBAL OPTIONS:
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
```

Linux Alveo
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ xbutil examine -d --help
WARNING: Unexpected xocl version (2.16.0) was found. Expected 2.17.0, to match XRT tools.

COMMAND: examine

DESCRIPTION: This command will 'examine' the state of the system/device and will generate a report of interest
               in a text or JSON format.

USAGE: xbutil examine [--help] [-d arg] [-f arg] [-o arg] [-r arg]

OPTIONS:
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest
  -f, --format       - Report output format. Valid values are:
                         JSON        - Latest JSON schema
                         JSON-2020.2 - JSON 2020.2 schema
  -o, --output       - Direct the output to the given file
  --help             - Help to use this sub-command
  -r, --report       - The type of report to be produced. Reports currently available are:
                         all             - All known reports are produced
                         debug-ip-status - Status of Debug IPs present in xclbin loaded on device
                         dynamic-regions - Information about the xclbin and the compute units
                         electrical      - Electrical and power sensors present on the device
                         error           - Asyncronus Error present on the device
                         firewall        - Firewall status
                         host            - Host information
                         mailbox         - Mailbox metrics of the device
                         mechanical      - Mechanical sensors on and surrounding the device
                         memory          - Memory information present on the device
                         pcie-info       - Pcie information of the device
                         platform        - Platforms flashed on the device
                         qspi-status     - QSPI write protection status
                         thermal         - Thermal sensors present on the device


GLOBAL OPTIONS:
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
```
#### Documentation impact (if any)
None