### PR TITLE
Add warning exception for early return

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -46,6 +46,10 @@
 #include "aie_trace_impl.h"
 #include "aie_trace_plugin.h"
 
+#ifdef _WIN32
+#pragma warning(disable : 4702) //TODO remove when test is implemented properly
+#endif
+
 namespace xdp {
 using severity_level = xrt_core::message::severity_level;
 bool AieTracePluginUnified::live = false;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
XRT-IPU does not compile with Visual Studio 2022 with the the changes from https://github.com/Xilinx/XRT/pull/7802. We really need to add VS2022 as a compilation check to pipeline.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Introduced in https://github.com/Xilinx/XRT/pull/7802. I attempted to compile with Visual Studio 2022 and encountered an early return warning.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added a warning exception for early returns with a TODO comment.

#### Risks (if any) associated the changes in the commit
None.

#### What has been tested and how, request additional testing if necessary
With this change XRT-IPU will compile.

#### Documentation impact (if any)
None.