### PR TITLE
Fix for CR-1183009 mem-bw test failing without platform.json

### DIFF
--- a/src/runtime_src/core/tools/common/Process.h
+++ b/src/runtime_src/core/tools/common/Process.h
@@ -24,8 +24,6 @@ namespace XBUtilities {
   runScript(const std::string & env,
             const std::string & script,
             const std::vector<std::string> & args,
-            const std::string & running_description,
-            const std::chrono::seconds& max_running_duration,
             std::ostringstream & os_stdout,
             std::ostringstream & os_stderr);
 };

--- a/src/runtime_src/core/tools/common/TestRunner.cpp
+++ b/src/runtime_src/core/tools/common/TestRunner.cpp
@@ -305,10 +305,7 @@ TestRunner::runPyTestCase( const std::shared_ptr<xrt_core::device>& _dev, const 
                                     "-d", xrt_core::query::pcie_bdf::to_string(xrt_core::device_query<xrt_core::query::pcie_bdf>(_dev)) };
   int exit_code;
   try {
-    if (py.find(".exe") != std::string::npos)
-      exit_code = XBU::runScript("", xrtTestCasePath, args, "Running Test", max_test_duration, os_stdout, os_stderr);
-    else
-      exit_code = XBU::runScript("python", xrtTestCasePath, args, "Running Test", max_test_duration, os_stdout, os_stderr);
+    exit_code = XBU::runScript("python", xrtTestCasePath, args, os_stdout, os_stderr);
 
     if (exit_code == EOPNOTSUPP) {
       _ptTest.put("status", test_token_skipped);

--- a/src/runtime_src/core/tools/common/TestRunner.h
+++ b/src/runtime_src/core/tools/common/TestRunner.h
@@ -35,7 +35,7 @@ class TestRunner : public JSONConfigurable {
   protected:
     TestRunner(const std::string & test_name, const std::string & description, 
             const std::string & xclbin = "", bool is_explicit = false);
-    void runTestCase( const std::shared_ptr<xrt_core::device>& _dev, const std::string& py,
+    void runPyTestCase( const std::shared_ptr<xrt_core::device>& _dev, const std::string& py,
              boost::property_tree::ptree& _ptTest);
     void logger(boost::property_tree::ptree& ptree, const std::string& tag, const std::string& msg);
     bool search_and_program_xclbin(const std::shared_ptr<xrt_core::device>& dev, boost::property_tree::ptree& ptTest);

--- a/src/runtime_src/core/tools/common/tests/TestBandwidthKernel.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestBandwidthKernel.cpp
@@ -246,6 +246,16 @@ TestBandwidthKernel::runTest(std::shared_ptr<xrt_core::device> dev, boost::prope
     ptree.put("status", test_token_failed);
     return;
   }
+  auto json_exists = [test_path]() {
+    const static std::string platform_metadata = "/platform.json";
+    std::string platform_json_path(test_path + platform_metadata);
+    return std::filesystem::exists(platform_json_path) ? true : false;
+  };
+  if (!json_exists()) {
+    // Without a platform.json, we need to run the python test file.
+    runPyTestCase(dev, "23_bandwidth.py", ptree);
+    return;
+  }
 
   int num_kernel = 0;
   int num_kernel_ddr = 0;


### PR DESCRIPTION
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1183009
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://github.com/Xilinx/XRT/pull/7746/ introduced the bug.
#### How problem was solved, alternative solutions (if any) and why they were rejected
We will use runTestCase from TestRunner (what we used to do before PR 7746) when we see that there is no platform.json in mem-bw. runTestCase has been simplified to be runPyTestCase, as it is only used to run py test for this situation. Removed the busybar from runScript as the busybar is now started at a higher level in TestRunner.
#### Risks (if any) associated the changes in the commit
N/A
#### What has been tested and how, request additional testing if necessary
Testing on u250, CR poster's machine
```
rchane@xcosda156:/scratch/rchane/temp/xrt/bin$ ./xbutil examine
WARNING: Unexpected xocl version (2.17.98) was found. Expected 2.17.0, to match XRT tools.
System Configuration
  OS Name              : Linux
  Release              : 5.15.0-87-generic
  Version              : #97-Ubuntu SMP Mon Oct 2 21:09:21 UTC 2023
  Machine              : x86_64
  CPU Cores            : 12
  Memory               : 46719 MB
  Distribution         : Ubuntu 22.04.2 LTS
  GLIBC                : 2.35
  Model                : PowerEdge R740
  BIOS vendor          : Dell Inc.
  BIOS version         : 2.3.10

XRT
  Version              : 2.17.0
  Branch               : Fix-CR-1183009
  Hash                 : c2f98bd9ed1df10355d841e5e3df1e2d385cea9e
  Hash Date            : 2023-12-13 13:49:00
  XOCL                 : 2.17.98, ea1043caf175630f2bd8c3c63cc97c0e0fdf6841
  XCLMGMT              : 2.17.98, ea1043caf175630f2bd8c3c63cc97c0e0fdf6841

Devices present
BDF             :  Shell                               Logic UUID                            Device ID       Device Ready*
----------------------------------------------------------------------------------------------------------------------------
[0000:3b:00.1]  :  xilinx_u250_gen3x16_xdma_shell_2_1  C3AD6B03-7144-8CA9-494E-D5B672C7092A  user(inst=128)  Yes


* Devices that are not ready will have reduced functionality when using XRT tools
rchane@xcosda156:/scratch/rchane/temp/xrt/bin$ ./xbutil validate -d 3b:00 -r mem-bw
WARNING: Unexpected xocl version (2.17.98) was found. Expected 2.17.0, to match XRT tools.
Validate Device           : [0000:3b:00.1]
    Platform              : xilinx_u250_gen3x16_xdma_shell_2_1
    SC Version            : 4.5
    Platform ID           : C3AD6B03-7144-8CA9-494E-D5B672C7092A
-------------------------------------------------------------------------------
Verbose: Enabling Verbosity
Test 1 [0000:3b:00.1]     : mem-bw
    Description           : Run 'bandwidth kernel' and check the throughput
    Xclbin                : /opt/xilinx/firmware/u250/gen3x16/xdma-shell/test
    Testcase              : /opt/xilinx/xrt/test/23_bandwidth.py
    Details               : Maximum throughput: 52096 MB/s
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Validation completed
```
#### Documentation impact (if any)
N/A