### PR TITLE
Improvements to parsing AIE trace settings

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_metadata.cpp
@@ -147,7 +147,7 @@ namespace xdp {
 
       if (iter != deprecatedSettings.end()) {
         std::stringstream msg;
-        msg << "The setting Debug." << pos->first << " is deprecated. "
+        msg << "The setting Debug." << pos->first << " is no longer supported. "
             << "Please instead use " << iter->second << ".";
         xrt_core::message::send(severity_level::warning, "XRT", msg.str());
       }

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_metadata.cpp
@@ -538,7 +538,7 @@ namespace xdp {
           configMetrics[tile] = metrics[i][2];
 
           // Grab channel numbers (if specified; memory tiles only)
-          if (metrics[i].size() == 5) {
+          if (metrics[i].size() > 3) {
             configChannel0[tile] = channel0;
             configChannel1[tile] = channel1;
           }

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/edge/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/edge/aie_trace.cpp
@@ -626,8 +626,7 @@ namespace xdp {
           auto iter1 = configChannel1.find(tile);
           uint8_t channel0 = (iter0 == configChannel0.end()) ? 0 : iter0->second;
           uint8_t channel1 = (iter1 == configChannel1.end()) ? 1 : iter1->second;
-          aie::trace::configEventSelections(aieDevInst, loc, XAIE_MEM_MOD, type, 
-                                            metricSet, channel0, channel1);
+          aie::trace::configEventSelections(aieDevInst, loc, type, metricSet, channel0, channel1);
 
           // Record for runtime config file
           cfgTile->memory_tile_trace_config.port_trace_ids[0] = channel0;
@@ -796,8 +795,6 @@ namespace xdp {
         auto iter1 = configChannel1.find(tile);
         uint8_t channel0 = (iter0 == configChannel0.end()) ? 0 : iter0->second;
         uint8_t channel1 = (iter1 == configChannel1.end()) ? 1 : iter1->second;
-        aie::trace::configEventSelections(aieDevInst, loc, XAIE_PL_MOD, type, metricSet, 
-                                          channel0, channel1);
 
         // Modify events as needed
         aie::trace::modifyEvents(type, subtype, metricSet, channel0, interfaceEvents);

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/util/aie_trace_config.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/util/aie_trace_config.cpp
@@ -37,52 +37,6 @@ namespace xdp::aie::trace {
   using severity_level = xrt_core::message::severity_level;
 
   /****************************************************************************
-   * Print out resource usage statistics for a given tile
-   ***************************************************************************/
-  void printTileStats(xaiefal::XAieDev* aieDevice, const tile_type& tile)
-  {
-    if (xrt_core::config::get_verbosity() < static_cast<uint32_t>(severity_level::info))
-      return;
-
-    auto col = tile.col;
-    auto row = tile.row;
-    auto loc = XAie_TileLoc(col, row);
-    std::stringstream msg;
-
-    const std::string groups[3] = {
-      XAIEDEV_DEFAULT_GROUP_GENERIC,
-      XAIEDEV_DEFAULT_GROUP_STATIC, 
-      XAIEDEV_DEFAULT_GROUP_AVAIL
-    };
-
-    msg << "Resource usage stats for Tile : (" << col << "," << row << ") Module : Core" << std::endl;
-    for (auto& g : groups) {
-      auto stats = aieDevice->getRscStat(g);
-      auto pc = stats.getNumRsc(loc, XAIE_CORE_MOD, XAIE_PERFCNT_RSC);
-      auto ts = stats.getNumRsc(loc, XAIE_CORE_MOD, xaiefal::XAIE_TRACE_EVENTS_RSC);
-      auto bc = stats.getNumRsc(loc, XAIE_CORE_MOD, XAIE_BCAST_CHANNEL_RSC);
-      msg << "Resource Group : " << std::left << std::setw(10) << g << " "
-          << "Performance Counters : " << pc << " "
-          << "Trace Slots : " << ts << " "
-          << "Broadcast Channels : " << bc << " " 
-          << std::endl;
-    }
-    msg << "Resource usage stats for Tile : (" << col << "," << row << ") Module : Memory" << std::endl;
-    for (auto& g : groups) {
-      auto stats = aieDevice->getRscStat(g);
-      auto pc = stats.getNumRsc(loc, XAIE_MEM_MOD, XAIE_PERFCNT_RSC);
-      auto ts = stats.getNumRsc(loc, XAIE_MEM_MOD, xaiefal::XAIE_TRACE_EVENTS_RSC);
-      auto bc = stats.getNumRsc(loc, XAIE_MEM_MOD, XAIE_BCAST_CHANNEL_RSC);
-      msg << "Resource Group : " << std::left << std::setw(10) << g << " "
-          << "Performance Counters : " << pc << " "
-          << "Trace Slots : " << ts << " "
-          << "Broadcast Channels : " << bc << " " 
-          << std::endl;
-    }
-    xrt_core::message::send(severity_level::info, "XRT", msg.str());
-  }
-  
-  /****************************************************************************
    * Configure stream switch ports for monitoring purposes
    * NOTE: Used to monitor streams: trace, interfaces, and memory tiles
    ***************************************************************************/

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/util/aie_trace_config.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/util/aie_trace_config.cpp
@@ -132,9 +132,8 @@ namespace xdp::aie::trace {
    * Configure event selection (memory tiles only)
    ***************************************************************************/
   void configEventSelections(XAie_DevInst* aieDevInst, const XAie_LocType loc,
-                             const XAie_ModuleType mod, const module_type type,
-                             const std::string metricSet, const uint8_t channel0,
-                             const uint8_t channel1)
+                             const module_type type, const std::string metricSet, 
+                             const uint8_t channel0, const uint8_t channel1)
   {
     if (type != module_type::mem_tile)
       return;

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/util/aie_trace_config.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/util/aie_trace_config.cpp
@@ -37,6 +37,52 @@ namespace xdp::aie::trace {
   using severity_level = xrt_core::message::severity_level;
 
   /****************************************************************************
+   * Print out resource usage statistics for a given tile
+   ***************************************************************************/
+  void printTileStats(xaiefal::XAieDev* aieDevice, const tile_type& tile)
+  {
+    if (xrt_core::config::get_verbosity() < static_cast<uint32_t>(severity_level::info))
+      return;
+
+    auto col = tile.col;
+    auto row = tile.row;
+    auto loc = XAie_TileLoc(col, row);
+    std::stringstream msg;
+
+    const std::string groups[3] = {
+      XAIEDEV_DEFAULT_GROUP_GENERIC,
+      XAIEDEV_DEFAULT_GROUP_STATIC, 
+      XAIEDEV_DEFAULT_GROUP_AVAIL
+    };
+
+    msg << "Resource usage stats for Tile : (" << col << "," << row << ") Module : Core" << std::endl;
+    for (auto& g : groups) {
+      auto stats = aieDevice->getRscStat(g);
+      auto pc = stats.getNumRsc(loc, XAIE_CORE_MOD, XAIE_PERFCNT_RSC);
+      auto ts = stats.getNumRsc(loc, XAIE_CORE_MOD, xaiefal::XAIE_TRACE_EVENTS_RSC);
+      auto bc = stats.getNumRsc(loc, XAIE_CORE_MOD, XAIE_BCAST_CHANNEL_RSC);
+      msg << "Resource Group : " << std::left << std::setw(10) << g << " "
+          << "Performance Counters : " << pc << " "
+          << "Trace Slots : " << ts << " "
+          << "Broadcast Channels : " << bc << " " 
+          << std::endl;
+    }
+    msg << "Resource usage stats for Tile : (" << col << "," << row << ") Module : Memory" << std::endl;
+    for (auto& g : groups) {
+      auto stats = aieDevice->getRscStat(g);
+      auto pc = stats.getNumRsc(loc, XAIE_MEM_MOD, XAIE_PERFCNT_RSC);
+      auto ts = stats.getNumRsc(loc, XAIE_MEM_MOD, xaiefal::XAIE_TRACE_EVENTS_RSC);
+      auto bc = stats.getNumRsc(loc, XAIE_MEM_MOD, XAIE_BCAST_CHANNEL_RSC);
+      msg << "Resource Group : " << std::left << std::setw(10) << g << " "
+          << "Performance Counters : " << pc << " "
+          << "Trace Slots : " << ts << " "
+          << "Broadcast Channels : " << bc << " " 
+          << std::endl;
+    }
+    xrt_core::message::send(severity_level::info, "XRT", msg.str());
+  }
+  
+  /****************************************************************************
    * Configure stream switch ports for monitoring purposes
    * NOTE: Used to monitor streams: trace, interfaces, and memory tiles
    ***************************************************************************/

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/util/aie_trace_config.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/util/aie_trace_config.h
@@ -21,14 +21,7 @@
 #include "xaiefal/xaiefal.hpp"
 #include "xdp/profile/database/static_info/aie_constructs.h"
 
-namespace xdp::aie::trace {  
-  /**  
-   * @brief Print out usage statistics for specified tile
-   * @param aieDevice AIE device
-   * @param tile      Tile to analyze
-   */
-  void printTileStats(xaiefal::XAieDev* aieDevice, const tile_type& tile);
-
+namespace xdp::aie::trace {
   /**
    * @brief Configure stream switch monitor ports
    * @param aieDevInst AIE device instance

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/util/aie_trace_config.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/util/aie_trace_config.h
@@ -46,16 +46,14 @@ namespace xdp::aie::trace {
    * @brief Configure event selections for DMA channels
    * @param aieDevInst AIE device instance
    * @param loc        Location of tile
-   * @param mod        Module type (used by driver)
    * @param type       Module/tile type
    * @param metricSet  Name of requested metric set
    * @param channel0   First specified channel number
    * @param channel1   Second specified channel number
    */
   void configEventSelections(XAie_DevInst* aieDevInst, const XAie_LocType loc,
-                             const XAie_ModuleType mod, const module_type type,
-                             const std::string metricSet, const uint8_t channel0,
-                             const uint8_t channel);
+                             const module_type type, const std::string metricSet, 
+                             const uint8_t channel0, const uint8_t channel);
 
   /**
    * @brief Configure edge detection events

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/util/aie_trace_config.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/util/aie_trace_config.h
@@ -22,6 +22,13 @@
 #include "xdp/profile/database/static_info/aie_constructs.h"
 
 namespace xdp::aie::trace {  
+  /**  
+   * @brief Print out usage statistics for specified tile
+   * @param aieDevice AIE device
+   * @param tile      Tile to analyze
+   */
+  void printTileStats(xaiefal::XAieDev* aieDevice, const tile_type& tile);
+
   /**
    * @brief Configure stream switch monitor ports
    * @param aieDevInst AIE device instance

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/util/aie_trace_util.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/util/aie_trace_util.cpp
@@ -360,52 +360,6 @@ namespace xdp::aie::trace {
   }
 
   /****************************************************************************
-   * Print out resource usage statistics for a given tile
-   ***************************************************************************/
-  void printTileStats(xaiefal::XAieDev* aieDevice, const tile_type& tile)
-  {
-    if (xrt_core::config::get_verbosity() < static_cast<uint32_t>(severity_level::info))
-      return;
-
-    auto col = tile.col;
-    auto row = tile.row;
-    auto loc = XAie_TileLoc(col, row);
-    std::stringstream msg;
-
-    const std::string groups[3] = {
-      XAIEDEV_DEFAULT_GROUP_GENERIC,
-      XAIEDEV_DEFAULT_GROUP_STATIC, 
-      XAIEDEV_DEFAULT_GROUP_AVAIL
-    };
-
-    msg << "Resource usage stats for Tile : (" << col << "," << row << ") Module : Core" << std::endl;
-    for (auto& g : groups) {
-      auto stats = aieDevice->getRscStat(g);
-      auto pc = stats.getNumRsc(loc, XAIE_CORE_MOD, XAIE_PERFCNT_RSC);
-      auto ts = stats.getNumRsc(loc, XAIE_CORE_MOD, xaiefal::XAIE_TRACE_EVENTS_RSC);
-      auto bc = stats.getNumRsc(loc, XAIE_CORE_MOD, XAIE_BCAST_CHANNEL_RSC);
-      msg << "Resource Group : " << std::left << std::setw(10) << g << " "
-          << "Performance Counters : " << pc << " "
-          << "Trace Slots : " << ts << " "
-          << "Broadcast Channels : " << bc << " " 
-          << std::endl;
-    }
-    msg << "Resource usage stats for Tile : (" << col << "," << row << ") Module : Memory" << std::endl;
-    for (auto& g : groups) {
-      auto stats = aieDevice->getRscStat(g);
-      auto pc = stats.getNumRsc(loc, XAIE_MEM_MOD, XAIE_PERFCNT_RSC);
-      auto ts = stats.getNumRsc(loc, XAIE_MEM_MOD, xaiefal::XAIE_TRACE_EVENTS_RSC);
-      auto bc = stats.getNumRsc(loc, XAIE_MEM_MOD, XAIE_BCAST_CHANNEL_RSC);
-      msg << "Resource Group : " << std::left << std::setw(10) << g << " "
-          << "Performance Counters : " << pc << " "
-          << "Trace Slots : " << ts << " "
-          << "Broadcast Channels : " << bc << " " 
-          << std::endl;
-    }
-    xrt_core::message::send(severity_level::info, "XRT", msg.str());
-  }
-
-  /****************************************************************************
    * Print out reserved trace events
    ***************************************************************************/
   void printTraceEventStats(int m, int numTiles[])

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/util/aie_trace_util.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/util/aie_trace_util.cpp
@@ -360,6 +360,52 @@ namespace xdp::aie::trace {
   }
 
   /****************************************************************************
+   * Print out resource usage statistics for a given tile
+   ***************************************************************************/
+  void printTileStats(xaiefal::XAieDev* aieDevice, const tile_type& tile)
+  {
+    if (xrt_core::config::get_verbosity() < static_cast<uint32_t>(severity_level::info))
+      return;
+
+    auto col = tile.col;
+    auto row = tile.row;
+    auto loc = XAie_TileLoc(col, row);
+    std::stringstream msg;
+
+    const std::string groups[3] = {
+      XAIEDEV_DEFAULT_GROUP_GENERIC,
+      XAIEDEV_DEFAULT_GROUP_STATIC, 
+      XAIEDEV_DEFAULT_GROUP_AVAIL
+    };
+
+    msg << "Resource usage stats for Tile : (" << col << "," << row << ") Module : Core" << std::endl;
+    for (auto& g : groups) {
+      auto stats = aieDevice->getRscStat(g);
+      auto pc = stats.getNumRsc(loc, XAIE_CORE_MOD, XAIE_PERFCNT_RSC);
+      auto ts = stats.getNumRsc(loc, XAIE_CORE_MOD, xaiefal::XAIE_TRACE_EVENTS_RSC);
+      auto bc = stats.getNumRsc(loc, XAIE_CORE_MOD, XAIE_BCAST_CHANNEL_RSC);
+      msg << "Resource Group : " << std::left << std::setw(10) << g << " "
+          << "Performance Counters : " << pc << " "
+          << "Trace Slots : " << ts << " "
+          << "Broadcast Channels : " << bc << " " 
+          << std::endl;
+    }
+    msg << "Resource usage stats for Tile : (" << col << "," << row << ") Module : Memory" << std::endl;
+    for (auto& g : groups) {
+      auto stats = aieDevice->getRscStat(g);
+      auto pc = stats.getNumRsc(loc, XAIE_MEM_MOD, XAIE_PERFCNT_RSC);
+      auto ts = stats.getNumRsc(loc, XAIE_MEM_MOD, xaiefal::XAIE_TRACE_EVENTS_RSC);
+      auto bc = stats.getNumRsc(loc, XAIE_MEM_MOD, XAIE_BCAST_CHANNEL_RSC);
+      msg << "Resource Group : " << std::left << std::setw(10) << g << " "
+          << "Performance Counters : " << pc << " "
+          << "Trace Slots : " << ts << " "
+          << "Broadcast Channels : " << bc << " " 
+          << std::endl;
+    }
+    xrt_core::message::send(severity_level::info, "XRT", msg.str());
+  }
+  
+  /****************************************************************************
    * Print out reserved trace events
    ***************************************************************************/
   void printTraceEventStats(int m, int numTiles[])

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/util/aie_trace_util.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/util/aie_trace_util.h
@@ -18,8 +18,12 @@
 #define AIE_TRACE_UTIL_DOT_H
 
 #include <cstdint>
-#include "xaiefal/xaiefal.hpp"
 #include "xdp/profile/database/static_info/aie_constructs.h"
+
+extern "C" {
+  #include <xaiengine.h>
+  #include <xaiengine/xaiegbl_params.h>
+}
 
 namespace xdp::aie::trace {
   /**
@@ -128,13 +132,6 @@ namespace xdp::aie::trace {
    * @return Port number associated with given event
    */
   uint8_t getPortNumberFromEvent(XAie_Events event);
-
-  /**  
-   * @brief Print out usage statistics for specified tile
-   * @param aieDevice AIE device
-   * @param tile      Tile to analyze
-   */
-  void printTileStats(xaiefal::XAieDev* aieDevice, const tile_type& tile);
 
   /**
    * @brief Print out trace event statistics across multiple tiles

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/util/aie_trace_util.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/util/aie_trace_util.h
@@ -18,12 +18,8 @@
 #define AIE_TRACE_UTIL_DOT_H
 
 #include <cstdint>
+#include "xaiefal/xaiefal.hpp"
 #include "xdp/profile/database/static_info/aie_constructs.h"
-
-extern "C" {
-  #include <xaiengine.h>
-  #include <xaiengine/xaiegbl_params.h>
-}
 
 namespace xdp::aie::trace {
   /**
@@ -132,6 +128,13 @@ namespace xdp::aie::trace {
    * @return Port number associated with given event
    */
   uint8_t getPortNumberFromEvent(XAie_Events event);
+
+  /**  
+   * @brief Print out usage statistics for specified tile
+   * @param aieDevice AIE device
+   * @param tile      Tile to analyze
+   */
+  void printTileStats(xaiefal::XAieDev* aieDevice, const tile_type& tile);
 
   /**
    * @brief Print out trace event statistics across multiple tiles

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/win/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/win/aie_trace.cpp
@@ -34,7 +34,6 @@
 #include "xdp/profile/device/device_intf.h"
 #include "xdp/profile/device/tracedefs.h"
 #include "xdp/profile/plugin/aie_trace/aie_trace_metadata.h"
-#include "xdp/profile/plugin/aie_trace/util/aie_trace_util.h"
 
 constexpr uint32_t MAX_TILES = 400;
 constexpr uint64_t ALIGNMENT_SIZE = 4096;
@@ -1015,7 +1014,7 @@ namespace xdp {
         uint8_t channel1 = (iter1 == configChannel1.end()) ? 1 : iter1->second;
 
         // Modify events as needed
-        aie::trace::modifyEvents(type, subtype, metricSet, channel0, interfaceEvents);
+        modifyEvents(type, subtype, metricSet, channel0, interfaceEvents);
 
         // Record for runtime config file
         // NOTE: input/output designations are different from memory tile channels

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/win/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/win/aie_trace.cpp
@@ -600,7 +600,7 @@ namespace xdp {
 
       std::stringstream cmsg;
       cmsg << "Configuring tile (" << col << "," << row << ") in module type: " << typeInt << ".";
-      xrt_core::message::send(severity_level::warning, "XRT", cmsg.str());
+      xrt_core::message::send(severity_level::info, "XRT", cmsg.str());
 
       // xaiefal::XAieMod core;
       // xaiefal::XAieMod memory;

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/win/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/win/aie_trace.cpp
@@ -207,6 +207,50 @@ namespace xdp {
     return size;
   }
 
+  /****************************************************************************
+   * Modify events in metric set based on type and channel
+   ***************************************************************************/
+  void AieTrace_WinImpl::modifyEvents(module_type type, uint16_t subtype, 
+                                      const std::string metricSet, uint8_t channel, 
+                                      std::vector<XAie_Events>& events)
+  {
+    // Only needed for GMIO DMA channel 1
+    if ((type != module_type::shim) || (subtype == 0) || (channel == 0))
+      return;
+
+    // Check type to minimize replacements
+    if (isInputSet(type, metricSet)) {
+      // Input or MM2S
+      std::replace(events.begin(), events.end(), 
+          XAIE_EVENT_DMA_MM2S_0_START_TASK_PL,          XAIE_EVENT_DMA_MM2S_1_START_TASK_PL);
+      std::replace(events.begin(), events.end(), 
+          XAIE_EVENT_DMA_MM2S_0_FINISHED_BD_PL,         XAIE_EVENT_DMA_MM2S_1_FINISHED_BD_PL);
+      std::replace(events.begin(), events.end(), 
+          XAIE_EVENT_DMA_MM2S_0_FINISHED_TASK_PL,       XAIE_EVENT_DMA_MM2S_1_FINISHED_TASK_PL);
+      std::replace(events.begin(), events.end(), 
+          XAIE_EVENT_DMA_MM2S_0_STALLED_LOCK_PL,        XAIE_EVENT_DMA_MM2S_1_STALLED_LOCK_PL);
+      std::replace(events.begin(), events.end(), 
+          XAIE_EVENT_DMA_MM2S_0_STREAM_BACKPRESSURE_PL, XAIE_EVENT_DMA_MM2S_1_STREAM_BACKPRESSURE_PL);
+      std::replace(events.begin(), events.end(), 
+          XAIE_EVENT_DMA_MM2S_0_MEMORY_STARVATION_PL,   XAIE_EVENT_DMA_MM2S_1_MEMORY_STARVATION_PL);
+    }
+    else {
+      // Output or S2MM
+      std::replace(events.begin(), events.end(), 
+          XAIE_EVENT_DMA_S2MM_0_START_TASK_PL,          XAIE_EVENT_DMA_S2MM_1_START_TASK_PL);
+      std::replace(events.begin(), events.end(), 
+          XAIE_EVENT_DMA_S2MM_0_FINISHED_BD_PL,         XAIE_EVENT_DMA_S2MM_1_FINISHED_BD_PL);
+      std::replace(events.begin(), events.end(), 
+          XAIE_EVENT_DMA_S2MM_0_FINISHED_TASK_PL,       XAIE_EVENT_DMA_S2MM_1_FINISHED_TASK_PL);
+      std::replace(events.begin(), events.end(), 
+          XAIE_EVENT_DMA_S2MM_0_STALLED_LOCK_PL,        XAIE_EVENT_DMA_S2MM_1_STALLED_LOCK_PL);
+      std::replace(events.begin(), events.end(), 
+          XAIE_EVENT_DMA_S2MM_0_STREAM_STARVATION_PL,   XAIE_EVENT_DMA_S2MM_1_STREAM_STARVATION_PL);
+      std::replace(events.begin(), events.end(), 
+          XAIE_EVENT_DMA_S2MM_0_MEMORY_BACKPRESSURE_PL, XAIE_EVENT_DMA_S2MM_1_MEMORY_BACKPRESSURE_PL);
+    }
+  }
+
   void AieTrace_WinImpl::flushTraceModules()
   {
     if (mTraceFlushLocs.empty() && mMemoryTileTraceFlushLocs.empty() 
@@ -460,7 +504,6 @@ namespace xdp {
                                                const std::string metricSet, const uint8_t channel0,
                                                const uint8_t channel1)
   {
-    (void)mod;
     if (type != module_type::mem_tile)
       return;
 

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/win/aie_trace.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/win/aie_trace.h
@@ -49,6 +49,9 @@ namespace xdp {
       virtual void pollTimers(uint64_t index, void* handle);
       virtual uint64_t checkTraceBufSize(uint64_t size);
 
+      void modifyEvents(module_type type, uint16_t subtype, 
+                        const std::string metricSet, uint8_t channel, 
+                        std::vector<XAie_Events>& events);
       bool setMetricsSettings(uint64_t deviceId, void* handle);
       module_type getTileType(uint16_t row);
       uint16_t getRelativeRow(uint16_t absRow);

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/win/aie_trace.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/win/aie_trace.h
@@ -58,14 +58,13 @@ namespace xdp {
       bool isPortRunningEvent(const XAie_Events event);
       uint8_t getPortNumberFromEvent(XAie_Events event);
       void configStreamSwitchPorts(const tile_type& tile,
-                                  /*xaiefal::XAieTile& xaieTile,*/ const XAie_LocType loc,
-                                  const module_type type, const std::string metricSet, 
-                                  const uint8_t channel0, const uint8_t channel1,
+                                   /*xaiefal::XAieTile& xaieTile,*/ const XAie_LocType loc,
+                                   const module_type type, const std::string metricSet, 
+                                   const uint8_t channel0, const uint8_t channel1,
                                   std::vector<XAie_Events>& events);
-      void configEventSelections(const XAie_LocType loc, 
-                                const XAie_ModuleType mod, const module_type type, 
-                                const std::string metricSet, const uint8_t channel0,
-                                const uint8_t channel);
+      void configEventSelections(const XAie_LocType loc, const module_type type, 
+                                 const std::string metricSet, const uint8_t channel0,
+                                 const uint8_t channel);
       void configEdgeEvents(const tile_type& tile, const module_type type,
                             const std::string metricSet, const XAie_Events event);
 


### PR DESCRIPTION
**Problem solved by the commit**
* Trace settings were not getting parsed correctly, especially channel numbers
* Some messages and comments were incorrect
* Channel-specific metric sets for interface tiles was confusing
 
**How problem was solved, alternative solutions (if any) and why they were rejected**
* Corrected parsing of trace settings
* Corrected messages and comments
* Improved modifying channel events
 
**Risks (if any) associated the changes in the commit**
* Many setting formats to consider and test

**What has been tested and how, request additional testing if necessary**
* Tested on vck190 and vek280

**Documentation impact (if any)**
* Ensure setting format options are correct