### PR TITLE
setting concurrency to 1 if a pr is synchronized

### DIFF
--- a/.github/workflows/xrt_ci.yml
+++ b/.github/workflows/xrt_ci.yml
@@ -8,7 +8,10 @@ env:
 on:
   pull_request_target:
     types: [opened, edited, synchronize]
-  
+
+concurrency:  
+  group: ${{ github.event.pull_request.head.repo.full_name }}-${{ github.event.pull_request.head.ref }}
+  cancel-in-progress: true 
   
 jobs:    
   build:    


### PR DESCRIPTION
If a new change is pushed to the same PR then instead of running both this PR will make sure only the latest push is ran for the PR ensuring build and test resources are not over utilized
