### PR TITLE
EDGEML-6881 Random test failure when looking for driver store path

### DIFF
--- a/src/runtime_src/core/common/detail/windows/xilinx_xrt.h
+++ b/src/runtime_src/core/common/detail/windows/xilinx_xrt.h
@@ -164,8 +164,9 @@ struct adapter
     if (query_info->Status != D3DDDI_QUERYREGISTRY_STATUS_SUCCESS)
       throw std::runtime_error("D3DDDI_QUERYREGISTRY_STATUS_SUCCESS failed");
 
-    // Return the driver path
-    std::wstring wstr{query_info->OutputString, query_info->OutputString + output_value_size};
+    // Return the driver path.
+    // Account for OutputString being WCHAR[], whereas OutputValueSize is bytes
+    std::wstring wstr{query_info->OutputString, query_info->OutputString + output_value_size / sizeof(wchar_t)};
     return replace_systemroot(utf8(wstr));
   }
 };


### PR DESCRIPTION
#### Problem solved by the commit
Adjust copying of wchar[] array into std::wstring accounting for bytes vs wchar.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
This bug was introduced in #7679 and is present in MCDM drops starting M6.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Code queries windows adpater for driver store path.  The driver store path is returned as array of wchar but was copied as bytes, resulting in copying from unallocated memory.
