### PR TITLE
VITIS-10910 Separate Ryzen and Alveo devices in ReportHost List

### DIFF
--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -132,6 +132,10 @@ XBUtilities::get_available_devices(bool inUserDomain)
 
     }
     pt_dev.put("is_ready", xrt_core::device_query_default<xrt_core::query::is_ready>(device, true));
+
+    const auto device_class = xrt_core::device_query_default<xrt_core::query::device_class>(device, xrt_core::query::device_class::type::alveo);
+    pt_dev.put("device_class", xrt_core::query::device_class::enum_to_str(device_class));
+
     pt.push_back(std::make_pair("", pt_dev));
   }
   return pt;

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -132,14 +132,14 @@ XBUtilities::get_available_devices(bool inUserDomain)
         // The id wasn't added
       }
 
-    try {
-      auto instance = xrt_core::device_query<xrt_core::query::instance>(device);
-      std::string pf = device->is_userpf() ? "user" : "mgmt";
-      pt_dev.put("instance",boost::str(boost::format("%s(inst=%d)") % pf % instance));
-    }
-    catch(const xrt_core::query::exception&) {
-        // The instance wasn't added
-    }
+      try {
+        auto instance = xrt_core::device_query<xrt_core::query::instance>(device);
+        std::string pf = device->is_userpf() ? "user" : "mgmt";
+        pt_dev.put("instance",boost::str(boost::format("%s(inst=%d)") % pf % instance));
+      }
+      catch(const xrt_core::query::exception&) {
+          // The instance wasn't added
+      }
 
     }
     pt_dev.put("is_ready", xrt_core::device_query_default<xrt_core::query::is_ready>(device, true));

--- a/src/runtime_src/core/tools/common/reports/ReportHost.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportHost.cpp
@@ -82,10 +82,10 @@ printRyzenDevices(const boost::property_tree::ptree& available_devices, std::ost
 {
   const Table2D::HeaderData bdf = {"BDF", Table2D::Justification::left};
   const Table2D::HeaderData colon = {":", Table2D::Justification::left};
-  const Table2D::HeaderData vbnv = {"Name", Table2D::Justification::left};
+  const Table2D::HeaderData name = {"Name", Table2D::Justification::left};
   const Table2D::HeaderData instance = {"Device ID", Table2D::Justification::left};
   const Table2D::HeaderData ready = {"Device Ready*", Table2D::Justification::left};
-  const std::vector<Table2D::HeaderData> table_headers = {bdf, colon, vbnv, instance, ready};
+  const std::vector<Table2D::HeaderData> table_headers = {bdf, colon, name, instance, ready};
   Table2D device_table(table_headers);
 
   for (const auto& kd : available_devices) {
@@ -96,7 +96,7 @@ printRyzenDevices(const boost::property_tree::ptree& available_devices, std::ost
 
     const std::string bdf_string = "[" + dev.get<std::string>("bdf") + "]";
     const std::string ready_string = dev.get<bool>("is_ready", false) ? "Yes" : "No";
-    const std::vector<std::string> entry_data = {bdf_string, ":", dev.get<std::string>("vbnv", "n/a"), dev.get<std::string>("instance", "n/a"), ready_string};
+    const std::vector<std::string> entry_data = {bdf_string, ":", dev.get<std::string>("name", "n/a"), dev.get<std::string>("instance", "n/a"), ready_string};
     device_table.addEntry(entry_data);
   }
 

--- a/src/runtime_src/core/tools/common/reports/ReportHost.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportHost.cpp
@@ -1,20 +1,7 @@
-/**
- * Copyright (C) 2020-2022 Xilinx, Inc
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2020-2022 Xilinx, Inc
+// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
 
-// ------ I N C L U D E   F I L E S -------------------------------------------
 // Local - Include Files
 #include "ReportHost.h"
 #include "tools/common/XBUtilitiesCore.h"
@@ -62,11 +49,66 @@ ReportHost::getPropertyTree20202( const xrt_core::device * /*_pDevice*/,
   _pt.add_child("host", pt);
 }
 
+static void
+printAlveoDevices(const boost::property_tree::ptree& available_devices, std::ostream& _output)
+{
+  const Table2D::HeaderData bdf = {"BDF", Table2D::Justification::left};
+  const Table2D::HeaderData colon = {":", Table2D::Justification::left};
+  const Table2D::HeaderData vbnv = {"Shell", Table2D::Justification::left};
+  const Table2D::HeaderData id = {"Logic UUID", Table2D::Justification::left};
+  const Table2D::HeaderData instance = {"Device ID", Table2D::Justification::left};
+  const Table2D::HeaderData ready = {"Device Ready*", Table2D::Justification::left};
+  const std::vector<Table2D::HeaderData> table_headers = {bdf, colon, vbnv, id, instance, ready};
+  Table2D device_table(table_headers);
+
+  for (const auto& kd : available_devices) {
+    const boost::property_tree::ptree& dev = kd.second;
+
+    if (dev.get<std::string>("device_class") != xrt_core::query::device_class::enum_to_str(xrt_core::query::device_class::type::alveo))
+      continue;
+
+    const std::string bdf_string = "[" + dev.get<std::string>("bdf") + "]";
+    const std::string ready_string = dev.get<bool>("is_ready", false) ? "Yes" : "No";
+    const std::vector<std::string> entry_data = {bdf_string, ":", dev.get<std::string>("vbnv", "n/a"), dev.get<std::string>("id", "n/a"), dev.get<std::string>("instance", "n/a"), ready_string};
+    device_table.addEntry(entry_data);
+  }
+
+  if (!device_table.empty())
+    _output << boost::str(boost::format("%s\n") % device_table);
+}
+
+static void
+printRyzenDevices(const boost::property_tree::ptree& available_devices, std::ostream& _output)
+{
+  const Table2D::HeaderData bdf = {"BDF", Table2D::Justification::left};
+  const Table2D::HeaderData colon = {":", Table2D::Justification::left};
+  const Table2D::HeaderData vbnv = {"Name", Table2D::Justification::left};
+  const Table2D::HeaderData instance = {"Device ID", Table2D::Justification::left};
+  const Table2D::HeaderData ready = {"Device Ready*", Table2D::Justification::left};
+  const std::vector<Table2D::HeaderData> table_headers = {bdf, colon, vbnv, instance, ready};
+  Table2D device_table(table_headers);
+
+  for (const auto& kd : available_devices) {
+    const boost::property_tree::ptree& dev = kd.second;
+
+    if (dev.get<std::string>("device_class") != xrt_core::query::device_class::enum_to_str(xrt_core::query::device_class::type::ryzen))
+      continue;
+
+    const std::string bdf_string = "[" + dev.get<std::string>("bdf") + "]";
+    const std::string ready_string = dev.get<bool>("is_ready", false) ? "Yes" : "No";
+    const std::vector<std::string> entry_data = {bdf_string, ":", dev.get<std::string>("vbnv", "n/a"), dev.get<std::string>("instance", "n/a"), ready_string};
+    device_table.addEntry(entry_data);
+  }
+
+  if (!device_table.empty())
+    _output << boost::str(boost::format("%s\n") % device_table);
+}
+
 void
 ReportHost::writeReport(const xrt_core::device* /*_pDevice*/,
                         const boost::property_tree::ptree& _pt,
                         const std::vector<std::string>& /*_elementsFilter*/,
-                        std::ostream & _output) const
+                        std::ostream& _output) const
 {
   boost::property_tree::ptree empty_ptree;
 
@@ -119,23 +161,8 @@ ReportHost::writeReport(const xrt_core::device* /*_pDevice*/,
   if (available_devices.empty())
     _output << "  0 devices found" << std::endl;
 
-  const Table2D::HeaderData bdf = {"BDF", Table2D::Justification::left};
-  const Table2D::HeaderData colon = {":", Table2D::Justification::left};
-  const Table2D::HeaderData vbnv = {"Shell", Table2D::Justification::left};
-  const Table2D::HeaderData id = {"Logic UUID", Table2D::Justification::left};
-  const Table2D::HeaderData instance = {"Device ID", Table2D::Justification::left};
-  const Table2D::HeaderData ready = {"Device Ready*", Table2D::Justification::left};
-  const std::vector<Table2D::HeaderData> table_headers = {bdf, colon, vbnv, id, instance, ready};
-  Table2D device_table(table_headers);
+  printAlveoDevices(available_devices, _output);
+  printRyzenDevices(available_devices, _output);
 
-  for (const auto& kd : available_devices) {
-    const boost::property_tree::ptree& dev = kd.second;
-    const std::string bdf_string = "[" + dev.get<std::string>("bdf") + "]";
-    const std::string ready_string = dev.get<bool>("is_ready", false) ? "Yes" : "No";
-    const std::vector<std::string> entry_data = {bdf_string, ":", dev.get<std::string>("vbnv", "n/a"), dev.get<std::string>("id", "n/a"), dev.get<std::string>("instance", "n/a"), ready_string};
-    device_table.addEntry(entry_data);
-  }
-
-  _output << boost::str(boost::format("%s\n") % device_table);
   _output << "* Devices that are not ready will have reduced functionality when using XRT tools\n";
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
The Ryzen and Alveo devices currently share the same list in the ReportHost output. This contains misleading information for Ryzen devices.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Remove misleading information display for RyzenAI devices.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Separated the Ryzen and Alveo devices lists in the ReportHost output. If one of each device is present there will be two lists.

#### Risks (if any) associated the changes in the commit
None.

#### What has been tested and how, request additional testing if necessary
Ubuntu 22.04

Alveo
```
dbenusov@xsjdbenusov50:~$ xbutil examine
System Configuration
  OS Name              : Linux
  Release              : 6.5.0-rc1+
  Version              : #10 SMP PREEMPT_DYNAMIC Wed Aug 16 22:28:12 PDT 2023
  Machine              : x86_64
  CPU Cores            : 16
  Memory               : 63990 MB
  Distribution         : Ubuntu 22.04 LTS
  GLIBC                : 2.35
  Model                : Precision 5820 Tower

XRT
  Version              : 2.16.0
  Branch               : master
  Hash                 : 893580509d3f7b0f1fab5a0da6210c709529a740
  Hash Date            : 2023-09-14 11:23:31
  XOCL                 : 2.16.0, 893580509d3f7b0f1fab5a0da6210c709529a740
  XCLMGMT              : 2.16.0, 893580509d3f7b0f1fab5a0da6210c709529a740

Devices present
BDF             :  Shell                            Logic UUID                            Device ID       Device Ready*
-------------------------------------------------------------------------------------------------------------------------
[0000:04:00.1]  :  xilinx_u55c_gen3x16_xdma_base_3  97088961-FEAE-DA91-52A2-1D9DFD63CCEF  user(inst=129)  Yes


* Devices that are not ready will have reduced functionality when using XRT tools
```

Ryzen (simulated Ryzen device)
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ xbutil examine
WARNING: Unexpected xocl version (2.16.0) was found. Expected 2.17.0, to match XRT tools.
System Configuration
  OS Name              : Linux
  Release              : 6.5.0-rc1+
  Version              : #10 SMP PREEMPT_DYNAMIC Wed Aug 16 22:28:12 PDT 2023
  Machine              : x86_64
  CPU Cores            : 16
  Memory               : 63990 MB
  Distribution         : Ubuntu 22.04 LTS
  GLIBC                : 2.35
  Model                : Precision 5820 Tower
  BIOS vendor          : Dell Inc.
  BIOS version         : 2.0.2

XRT
  Version              : 2.17.0
  Branch               : VITIS-10910
  Hash                 : 862cfaded934ef254fbe91e480c991345177eca5
  Hash Date            : 2023-12-11 16:56:50
  XOCL                 : 2.16.0, 893580509d3f7b0f1fab5a0da6210c709529a740
  XCLMGMT              : 2.16.0, 893580509d3f7b0f1fab5a0da6210c709529a740

Devices present
BDF             :  Name                             Device ID       Device Ready*
-----------------------------------------------------------------------------------
[0000:04:00.1]  :  xilinx_u55c_gen3x16_xdma_base_3  user(inst=129)  Yes


* Devices that are not ready will have reduced functionality when using XRT tools
```

#### Documentation impact (if any)
None
