### PR TITLE
Skeleton directory and build infrastructure for HIP bindings

### DIFF
--- a/build/build-win22.sh
+++ b/build/build-win22.sh
@@ -76,6 +76,8 @@ while [ $# -gt 0 ]; do
 	    BOOST="$1"
 	    shift
 	    ;;
+        -hip)
+            cmake_flags+= " -DXRT_ENABLE_HIP=ON"
         -j)
             shift
             jcore=$1

--- a/build/build.sh
+++ b/build/build.sh
@@ -51,6 +51,7 @@ usage()
     echo "[-dbg]                      Build debug library only (default)"
     echo "[-opt]                      Build optimized library only (default)"
     echo "[-edge]                     Build edge of x64.  Turns off opt and dbg"
+    echo "[-hip]                      Enable hip bindings"
     echo "[-disable-werror]           Disable compilation with warnings as error"
     echo "[-nocmake]                  Skip CMake call"
     echo "[-noert]                    Do not treat missing ERT FW as a build error"
@@ -145,6 +146,10 @@ while [ $# -gt 0 ]; do
             edge=1
             opt=0
             dbg=0
+            ;;
+        -hip)
+            shift
+            cmake_flags+=" -DXRT_ENABLE_HIP=ON"
             ;;
         -opt)
             dbg=0

--- a/src/runtime_src/CMakeLists.txt
+++ b/src/runtime_src/CMakeLists.txt
@@ -36,6 +36,10 @@ xrt_add_subdirectory(tools/xclbinutil)
 xrt_add_subdirectory(xocl)
 xrt_add_subdirectory(xrt)
 xrt_add_subdirectory(ert)
+if (XRT_ENABLE_HIP)
+  xrt_add_subdirectory(hip)
+endif(XRT_ENABLE_HIP)
+
 if (${XRT_NATIVE_BUILD} STREQUAL "yes")
   # Only for host native build.
   # For embedded, headers and libraries are installed in /usr

--- a/src/runtime_src/hip/CMakeLists.txt
+++ b/src/runtime_src/hip/CMakeLists.txt
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2023 Advanced Micro Device, Inc. All rights reserved.
+add_subdirectory(core)
+add_subdirectory(api)
+
+add_library(xrt_hip SHARED
+ $<TARGET_OBJECTS:hip_core_library_objects>
+ $<TARGET_OBJECTS:hip_api_library_objects>
+)
+
+target_include_directories(xrt_hip
+  PRIVATE
+  ${XRT_SOURCE_DIR}/runtime_src
+)
+
+target_link_libraries(xrt_hip
+  PRIVATE
+  xrt_coreutil
+)
+
+set_target_properties(xrt_hip PROPERTIES
+  VERSION ${XRT_VERSION_STRING}
+  SOVERSION ${XRT_SOVERSION}
+)
+
+install(TARGETS xrt_hip
+  EXPORT xrt-targets
+  LIBRARY DESTINATION ${XRT_INSTALL_LIB_DIR} ${XRT_NAMELINK_SKIP}
+  RUNTIME DESTINATION ${XRT_INSTALL_BIN_DIR}
+)
+
+install(TARGETS xrt_hip
+  EXPORT xrt-dev-targets
+  ARCHIVE DESTINATION ${XRT_INSTALL_LIB_DIR} COMPONENT ${XRT_DEV_COMPONENT}
+  LIBRARY DESTINATION ${XRT_INSTALL_LIB_DIR} COMPONENT ${XRT_DEV_COMPONENT} ${XRT_NAMELINK_ONLY}
+)
+
+# Release headers
+install (FILES
+  hip.h
+  config.h
+  DESTINATION ${XRT_INSTALL_INCLUDE_DIR}/hip
+  COMPONENT ${XRT_DEV_COMPONENT}
+)

--- a/src/runtime_src/hip/api/CMakeLists.txt
+++ b/src/runtime_src/hip/api/CMakeLists.txt
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2023 Advanced Micro Device, Inc. All rights reserved.
+add_library(hip_api_library_objects OBJECT
+  hipDeviceGet.cpp
+)
+
+target_include_directories(hip_api_library_objects
+  PRIVATE
+  ${XRT_SOURCE_DIR}/runtime_src
+  )
+

--- a/src/runtime_src/hip/api/hipDeviceGet.cpp
+++ b/src/runtime_src/hip/api/hipDeviceGet.cpp
@@ -5,7 +5,7 @@
 
 #include "core/common/error.h"
 
-namespace xrthip_core {
+namespace xrt::core::hip {
 
 // Returns a handle to compute device
 // Throws on error
@@ -15,14 +15,14 @@ hipDeviceGet(hipDevice_t* device, int ordinal)
   throw std::runtime_error("Not implemented");
 }
   
-} // xrthip_core
+} // xrt::core::hip
 
 
 hipError_t
 hipDeviceGet(hipDevice_t* device, int ordinal)
 {
   try {
-    xrthip_core::hipDeviceGet(device, ordinal);
+    xrt::core::hip::hipDeviceGet(device, ordinal);
     return hipSuccess;
   }
   catch (const std::exception& ex) {

--- a/src/runtime_src/hip/api/hipDeviceGet.cpp
+++ b/src/runtime_src/hip/api/hipDeviceGet.cpp
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2023 Advanced Micro Device, Inc. All rights reserved.
+#include "hip/hip.h"
+#include "hip/core/device.h"
+
+#include "core/common/error.h"
+
+namespace xrthip_core {
+
+// Returns a handle to compute device
+// Throws on error
+static void
+hipDeviceGet(hipDevice_t* device, int ordinal)
+{
+  throw std::runtime_error("Not implemented");
+}
+  
+} // xrthip_core
+
+
+hipError_t
+hipDeviceGet(hipDevice_t* device, int ordinal)
+{
+  try {
+    xrthip_core::hipDeviceGet(device, ordinal);
+    return hipSuccess;
+  }
+  catch (const std::exception& ex) {
+    xrt_core::send_exception_message(ex.what());
+  }
+  return hipErrorInvalidDevice;
+}

--- a/src/runtime_src/hip/config.h
+++ b/src/runtime_src/hip/config.h
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2023 Advanced Micro Device, Inc. All rights reserved.
+#ifndef xrthip_config_h_
+#define xrthip_config_h_
+
+//------------------Enable dynamic linking on windows-------------------------//
+
+#ifdef _WIN32
+# ifdef XRTHIP_SOURCE
+#  define XRTHIP_EXPORT __declspec(dllexport)
+# else
+#  define XRTHIP_EXPORT __declspec(dllimport)
+# endif
+#endif
+#ifdef __GNUC__
+# ifdef XRTHIP_SOURCE
+#  define XRTHIP_EXPORT __attribute__ ((visibility("default")))
+# else
+#  define XRTHIP_EXPORT
+# endif
+#endif
+
+#ifndef XRTHIP_EXPORT
+# define XRTHIP_EXPORT
+#endif
+
+#ifdef __GNUC__
+# define XRT_CORE_UNUSED __attribute__((unused))
+#endif
+
+#ifdef _WIN32
+# define XRT_CORE_UNUSED
+#endif
+
+#endif

--- a/src/runtime_src/hip/core/CMakeLists.txt
+++ b/src/runtime_src/hip/core/CMakeLists.txt
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2023 Advanced Micro Device, Inc. All rights reserved.
+add_library(hip_core_library_objects OBJECT
+  device.cpp
+)
+
+target_include_directories(hip_core_library_objects
+  PRIVATE
+  ${XRT_SOURCE_DIR}/runtime_src
+  )
+

--- a/src/runtime_src/hip/core/device.cpp
+++ b/src/runtime_src/hip/core/device.cpp
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2023 Advanced Micro Device, Inc. All rights reserved.
+#include "device.h"
+
+namespace xrthip_core {
+
+// Implementation  
+  
+}

--- a/src/runtime_src/hip/core/device.cpp
+++ b/src/runtime_src/hip/core/device.cpp
@@ -2,7 +2,7 @@
 // Copyright (C) 2023 Advanced Micro Device, Inc. All rights reserved.
 #include "device.h"
 
-namespace xrthip_core {
+namespace xrt::core::hip {
 
 // Implementation  
   

--- a/src/runtime_src/hip/core/device.h
+++ b/src/runtime_src/hip/core/device.h
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2023 Advanced Micro Device, Inc. All rights reserved.
+#ifndef xrthip_device_h
+#define xrthip_device_h
+
+namespace xrthip_core {
+
+class device
+{
+};
+  
+} // xrthip_core
+
+#endif

--- a/src/runtime_src/hip/core/device.h
+++ b/src/runtime_src/hip/core/device.h
@@ -3,12 +3,12 @@
 #ifndef xrthip_device_h
 #define xrthip_device_h
 
-namespace xrthip_core {
+namespace xrt::core::hip {
 
 class device
 {
 };
   
-} // xrthip_core
+} // xrt::core::hip
 
 #endif

--- a/src/runtime_src/hip/hip.h
+++ b/src/runtime_src/hip/hip.h
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2023 Advanced Micro Device, Inc. All rights reserved.
+
+// For lack of better (standard) place, here are the extern declarations of
+// functions and types.
+#ifndef xrthip_hip_h
+#define xrthip_hip_h
+
+#include "hip/config.h"
+
+typedef int hipDevice_t;
+typedef int hipError_t;
+
+#define hipSuccess 0
+#define hipErrorInvalidDevice 1
+
+XRTHIP_EXPORT
+hipError_t
+hipDeviceGet(hipDevice_t* device, int ordinal);
+
+#endif

--- a/tests/hip/device/main.cpp
+++ b/tests/hip/device/main.cpp
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2023 Advanced Micro Device, Inc. All rights reserved.
+
+// TODO: set up CMake
+// % g++ -g -std=c++17 -I${XILINX_XRT}/include -L${XILINX_XRT}/lib \
+//       -o hip_device.exe main.cpp -lxrt_hip
+
+#include "hip/hip.h"
+
+int main()
+{
+  hipDevice_t device;
+  auto status = hipDeviceGet(&device, 0);
+  return status;
+}


### PR DESCRIPTION
Very preliminary infra for HIP bindings.
Build on linux with `build.sh -hip [other options]`
