### PR TITLE
Fix missing include

### DIFF
--- a/src/runtime_src/core/tools/common/EscapeCodes.h
+++ b/src/runtime_src/core/tools/common/EscapeCodes.h
@@ -16,6 +16,7 @@
 
 // Include files
 // Please keep these to the bare minimum
+#include <cstdint>
 #include <string>
 
 namespace EscapeCodes {


### PR DESCRIPTION
#### Problem solved by the commit
Probably in the trail of #7841 , it seems that there is still a missing `#include <cstdint>`.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
While compiling XRT master on Alma9 with GCC 13.1.0 and CMake 3.27.5 (I know, unsupported os), I encountered the following error:

```
[ 56%] Building CXX object runtime_src/core/tools/xbmgmt2/CMakeFiles/xbmgmt2.dir/__/common/reports/ReportAiePartitions.cpp.o
In file included from /home/qberthet/devel/atlasexternals/XRT/src/runtime_src/core/tools/common/Process.cpp:37:
/home/qberthet/devel/atlasexternals/XRT/src/runtime_src/core/tools/common/EscapeCodes.h:26:22: error: expected ')' before '_color'
   26 |       fgcolor(uint8_t _color) : m_color(_color) {};
      |              ~       ^~~~~~~
      |                      )
/home/qberthet/devel/atlasexternals/XRT/src/runtime_src/core/tools/common/EscapeCodes.h:32:6: error: 'uint8_t' does not name a type
   32 |      uint8_t m_color;
      |      ^~~~~~~
```

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added the missing include in `EscapeCodes.h` and compilation succeed.