### PR TITLE
P1 - Initial changes for removal of xcl apis

### DIFF
--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -298,6 +298,15 @@ enum class key_type
   xgq_scaling_power_override,
   xgq_scaling_temp_override,
   performance_mode,
+  debug_ip_layout_path,
+  debug_ip_layout,
+  num_live_processes,
+  device_clock_freq_MHz,
+  trace_buffer_info,
+  host_max_bandwidth_MBps,
+  kernel_max_bandwidth_MBps,
+  sub_device_path,
+  read_trace_data,
   noop
 };
 
@@ -3411,6 +3420,110 @@ struct performance_mode : request
   }
 };
 
+struct debug_ip_layout_path : request
+{
+  // Get debug ip layout path
+  // Used by xdp code
+  using result_type = std::string; // get value type
+  static const key_type key = key_type::debug_ip_layout_path;
+
+  virtual std::any
+  get(const device*, const std::any&) const = 0;
+};
+
+struct debug_ip_layout : request
+{
+  // Get debug ip layout
+  using result_type = std::vector<char>; // get value type
+  static const key_type key = key_type::debug_ip_layout;
+
+  virtual std::any
+  get(const device*) const = 0;
+};
+
+struct num_live_processes : request
+{
+  // Get the count of number of live processes
+  using result_type = uint32_t; // get value type
+  static const key_type key = key_type::num_live_processes;
+
+  virtual std::any
+  get(const device*) const = 0;
+};
+
+struct device_clock_freq_MHz : request
+{
+  // Get device clock frequency in MHz
+  using result_type = double; // get value type
+  static const key_type key = key_type::device_clock_freq_MHz;
+
+  virtual std::any
+  get(const device*) const = 0;
+};
+
+struct trace_buffer_info : request
+{
+  struct info {
+    uint32_t samples;
+    uint32_t buf_size;
+  };
+  // Get trace buffer info
+  using result_type = info; // get value type
+  static const key_type key = key_type::trace_buffer_info;
+
+  virtual std::any
+  get(const device*, const std::any&) const = 0;
+};
+
+struct host_max_bandwidth_MBps : request
+{
+  // Get Max host bandwidth MBps
+  using result_type = double; // get value type
+  static const key_type key = key_type::host_max_bandwidth_MBps;
+
+  virtual std::any
+  get(const device*, const std::any&) const = 0;
+};
+
+struct kernel_max_bandwidth_MBps : request
+{
+  // Get Max host bandwidth MBps
+  using result_type = double; // get value type
+  static const key_type key = key_type::kernel_max_bandwidth_MBps;
+
+  virtual std::any
+  get(const device*, const std::any&) const = 0;
+};
+
+struct sub_device_path : request
+{
+  struct args {
+    std::string subdev;
+    uint32_t index;
+  };
+  // Get sub device sysfs path
+  using result_type = std::string; // get value type
+  static const key_type key = key_type::sub_device_path;
+
+  virtual std::any
+  get(const device*, const std::any&) const = 0;
+};
+
+struct read_trace_data : request
+{
+  struct args {
+    uint32_t  buf_size;
+    uint32_t  samples;
+    uint64_t  ip_base_addr;
+    uint32_t& words_per_sample;
+  };
+  // Get sub device sysfs path
+  using result_type = std::vector<uint32_t>; // get value type
+  static const key_type key = key_type::read_trace_data;
+
+  virtual std::any
+  get(const device*, const std::any&) const = 0;
+};
 } // query
 
 } // xrt_core

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -301,10 +301,10 @@ enum class key_type
   debug_ip_layout_path,
   debug_ip_layout,
   num_live_processes,
-  device_clock_freq_MHz,
+  device_clock_freq_mhz,
   trace_buffer_info,
-  host_max_bandwidth_MBps,
-  kernel_max_bandwidth_MBps,
+  host_max_bandwidth_mbps,
+  kernel_max_bandwidth_mbps,
   sub_device_path,
   read_trace_data,
   noop
@@ -3451,11 +3451,11 @@ struct num_live_processes : request
   get(const device*) const = 0;
 };
 
-struct device_clock_freq_MHz : request
+struct device_clock_freq_mhz : request
 {
   // Get device clock frequency in MHz
   using result_type = double; // get value type
-  static const key_type key = key_type::device_clock_freq_MHz;
+  static const key_type key = key_type::device_clock_freq_mhz;
 
   virtual std::any
   get(const device*) const = 0;
@@ -3475,21 +3475,21 @@ struct trace_buffer_info : request
   get(const device*, const std::any&) const = 0;
 };
 
-struct host_max_bandwidth_MBps : request
+struct host_max_bandwidth_mbps : request
 {
   // Get Max host bandwidth MBps
   using result_type = double; // get value type
-  static const key_type key = key_type::host_max_bandwidth_MBps;
+  static const key_type key = key_type::host_max_bandwidth_mbps;
 
   virtual std::any
   get(const device*, const std::any&) const = 0;
 };
 
-struct kernel_max_bandwidth_MBps : request
+struct kernel_max_bandwidth_mbps : request
 {
   // Get Max host bandwidth MBps
   using result_type = double; // get value type
-  static const key_type key = key_type::kernel_max_bandwidth_MBps;
+  static const key_type key = key_type::kernel_max_bandwidth_mbps;
 
   virtual std::any
   get(const device*, const std::any&) const = 0;

--- a/src/runtime_src/core/edge/user/device_linux.cpp
+++ b/src/runtime_src/core/edge/user/device_linux.cpp
@@ -8,6 +8,7 @@
 
 #include "core/common/debug_ip.h"
 #include "core/common/query_requests.h"
+#include "core/common/xrt_profiling.h"
 
 #include <map>
 #include <memory>
@@ -741,6 +742,98 @@ struct dtbo_path
   }
 };
 
+struct debug_ip_layout_path
+{
+  using result_type = xrt_core::query::debug_ip_layout_path::result_type;
+
+  static result_type
+  get(const xrt_core::device* device, key_type key, const std::any& param)
+  {
+    uint32_t size = std::any_cast<uint32_t>(param);
+    std::string path;
+    path.resize(size);
+
+    // Get Debug Ip layout path
+    xclGetDebugIPlayoutPath(device->get_user_handle(), const_cast<char*>(path.data()), size);
+    return path;
+  }
+};
+
+struct device_clock_freq_MHz {
+  using result_type = xrt_core::query::device_clock_freq_MHz::result_type;
+
+  static result_type
+  get(const xrt_core::device* device, key_type key)
+  {
+    return xclGetDeviceClockFreqMHz(device->get_user_handle());
+  }
+};
+
+struct trace_buffer_info
+{
+  using result_type = xrt_core::query::trace_buffer_info::result_type;
+
+  static result_type
+  get(const xrt_core::device* device, key_type key, const std::any& param)
+  {
+    uint32_t input_samples = std::any_cast<uint32_t>(param);
+    result_type buf_info;
+
+    // Get trace buf size and trace samples
+    xclGetTraceBufferInfo(device->get_user_handle(), input_samples, buf_info.samples, buf_info.buf_size);
+    return buf_info;
+  }
+};
+
+struct host_max_bandwidth_MBps
+{
+  using result_type = xrt_core::query::host_max_bandwidth_MBps::result_type;
+
+  static result_type
+  get(const xrt_core::device* device, key_type key, const std::any& param)
+  {
+    bool read = std::any_cast<bool>(param);
+
+    // Get read/write host max bandwidth in MBps
+    return read ? xclGetHostReadMaxBandwidthMBps(device->get_user_handle())
+                : xclGetHostWriteMaxBandwidthMBps(device->get_user_handle());
+  }
+};
+
+struct kernel_max_bandwidth_MBps
+{
+  using result_type = xrt_core::query::kernel_max_bandwidth_MBps::result_type;
+
+  static result_type
+  get(const xrt_core::device* device, key_type key, const std::any& param)
+  {
+    bool read = std::any_cast<bool>(param);
+
+    // Get read/write host max bandwidth in MBps
+    return read ? xclGetKernelReadMaxBandwidthMBps(device->get_user_handle())
+                : xclGetKernelWriteMaxBandwidthMBps(device->get_user_handle());
+  }
+};
+
+struct read_trace_data
+{
+  using result_type = xrt_core::query::read_trace_data::result_type;
+
+  static result_type
+  get(const xrt_core::device* device, key_type key, const std::any& param)
+  {
+    auto args = std::any_cast<xrt_core::query::read_trace_data::args>(param);
+
+    result_type trace_buf;
+    trace_buf.resize(args.buf_size);
+
+    // read trace data
+    xclReadTraceData(device->get_user_handle(), trace_buf.data(),
+                     args.buf_size, args.samples, args.ip_base_addr, args.words_per_sample);
+    return trace_buf;
+  }
+};
+
 // Specialize for other value types.
 template <typename ValueType>
 struct sysfs_fcn
@@ -940,6 +1033,13 @@ initialize_query_table()
   emplace_func4_request<query::spc_status,              spc_status>();
   emplace_func4_request<query::accel_deadlock_status,   accel_deadlock_status>();
   emplace_func4_request<query::dtbo_path,               dtbo_path>();
+
+  emplace_func4_request<query::debug_ip_layout_path,    debug_ip_layout_path>();
+  emplace_func0_request<query::device_clock_freq_MHz,   device_clock_freq_MHz>();
+  emplace_func4_request<query::trace_buffer_info,       trace_buffer_info>();
+  emplace_func4_request<query::read_trace_data,         read_trace_data>();
+  emplace_func4_request<query::host_max_bandwidth_MBps, host_max_bandwidth_MBps>();
+  emplace_func4_request<query::kernel_max_bandwidth_MBps, kernel_max_bandwidth_MBps>();
 }
 
 struct X { X() { initialize_query_table(); } };

--- a/src/runtime_src/core/edge/user/device_linux.cpp
+++ b/src/runtime_src/core/edge/user/device_linux.cpp
@@ -759,8 +759,8 @@ struct debug_ip_layout_path
   }
 };
 
-struct device_clock_freq_MHz {
-  using result_type = xrt_core::query::device_clock_freq_MHz::result_type;
+struct device_clock_freq_mhz {
+  using result_type = xrt_core::query::device_clock_freq_mhz::result_type;
 
   static result_type
   get(const xrt_core::device* device, key_type key)
@@ -785,9 +785,9 @@ struct trace_buffer_info
   }
 };
 
-struct host_max_bandwidth_MBps
+struct host_max_bandwidth_mbps
 {
-  using result_type = xrt_core::query::host_max_bandwidth_MBps::result_type;
+  using result_type = xrt_core::query::host_max_bandwidth_mbps::result_type;
 
   static result_type
   get(const xrt_core::device* device, key_type key, const std::any& param)
@@ -800,9 +800,9 @@ struct host_max_bandwidth_MBps
   }
 };
 
-struct kernel_max_bandwidth_MBps
+struct kernel_max_bandwidth_mbps
 {
-  using result_type = xrt_core::query::kernel_max_bandwidth_MBps::result_type;
+  using result_type = xrt_core::query::kernel_max_bandwidth_mbps::result_type;
 
   static result_type
   get(const xrt_core::device* device, key_type key, const std::any& param)
@@ -1035,11 +1035,11 @@ initialize_query_table()
   emplace_func4_request<query::dtbo_path,               dtbo_path>();
 
   emplace_func4_request<query::debug_ip_layout_path,    debug_ip_layout_path>();
-  emplace_func0_request<query::device_clock_freq_MHz,   device_clock_freq_MHz>();
+  emplace_func0_request<query::device_clock_freq_mhz,   device_clock_freq_mhz>();
   emplace_func4_request<query::trace_buffer_info,       trace_buffer_info>();
   emplace_func4_request<query::read_trace_data,         read_trace_data>();
-  emplace_func4_request<query::host_max_bandwidth_MBps, host_max_bandwidth_MBps>();
-  emplace_func4_request<query::kernel_max_bandwidth_MBps, kernel_max_bandwidth_MBps>();
+  emplace_func4_request<query::host_max_bandwidth_mbps, host_max_bandwidth_mbps>();
+  emplace_func4_request<query::kernel_max_bandwidth_mbps, kernel_max_bandwidth_mbps>();
 }
 
 struct X { X() { initialize_query_table(); } };

--- a/src/runtime_src/core/pcie/emulation/hw_emu/alveo_shim/device_hwemu.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_emu/alveo_shim/device_hwemu.cxx
@@ -47,8 +47,8 @@ struct debug_ip_layout_path
   }
 };
 
-struct device_clock_freq_MHz {
-  using result_type = xrt_core::query::device_clock_freq_MHz::result_type;
+struct device_clock_freq_mhz {
+  using result_type = xrt_core::query::device_clock_freq_mhz::result_type;
 
   static result_type
   get(const xrt_core::device* device, key_type key)
@@ -73,9 +73,9 @@ struct trace_buffer_info
   }
 };
 
-struct host_max_bandwidth_MBps
+struct host_max_bandwidth_mbps
 {
-  using result_type = xrt_core::query::host_max_bandwidth_MBps::result_type;
+  using result_type = xrt_core::query::host_max_bandwidth_mbps::result_type;
 
   static result_type
   get(const xrt_core::device* device, key_type key, const std::any& param)
@@ -88,9 +88,9 @@ struct host_max_bandwidth_MBps
   }
 };
 
-struct kernel_max_bandwidth_MBps
+struct kernel_max_bandwidth_mbps
 {
-  using result_type = xrt_core::query::kernel_max_bandwidth_MBps::result_type;
+  using result_type = xrt_core::query::kernel_max_bandwidth_mbps::result_type;
 
   static result_type
   get(const xrt_core::device* device, key_type key, const std::any& param)
@@ -170,10 +170,10 @@ initialize_query_table()
   emplace_func0_request<query::nodma, device_query>();
   emplace_func0_request<query::rom_vbnv, xclemulation::query::device_info>();
   emplace_func1_request<query::debug_ip_layout_path, debug_ip_layout_path>();
-  emplace_func0_request<query::device_clock_freq_MHz, device_clock_freq_MHz>();
+  emplace_func0_request<query::device_clock_freq_mhz, device_clock_freq_mhz>();
   emplace_func1_request<query::trace_buffer_info, trace_buffer_info>();
-  emplace_func1_request<query::host_max_bandwidth_MBps, host_max_bandwidth_MBps>();
-  emplace_func1_request<query::kernel_max_bandwidth_MBps, kernel_max_bandwidth_MBps>();
+  emplace_func1_request<query::host_max_bandwidth_mbps, host_max_bandwidth_mbps>();
+  emplace_func1_request<query::kernel_max_bandwidth_mbps, kernel_max_bandwidth_mbps>();
   emplace_func1_request<query::read_trace_data, read_trace_data>();
 }
 

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -976,8 +976,8 @@ struct num_live_processes {
   }
 };
 
-struct device_clock_freq_MHz {
-  using result_type = xrt_core::query::device_clock_freq_MHz::result_type;
+struct device_clock_freq_mhz {
+  using result_type = xrt_core::query::device_clock_freq_mhz::result_type;
 
   static result_type
   get(const xrt_core::device* device, key_type key)
@@ -1021,9 +1021,9 @@ struct sub_device_path
   }
 };
 
-struct host_max_bandwidth_MBps
+struct host_max_bandwidth_mbps
 {
-  using result_type = xrt_core::query::host_max_bandwidth_MBps::result_type;
+  using result_type = xrt_core::query::host_max_bandwidth_mbps::result_type;
 
   static result_type
   get(const xrt_core::device* device, key_type key, const std::any& param)
@@ -1036,9 +1036,9 @@ struct host_max_bandwidth_MBps
   }
 };
 
-struct kernel_max_bandwidth_MBps
+struct kernel_max_bandwidth_mbps
 {
-  using result_type = xrt_core::query::kernel_max_bandwidth_MBps::result_type;
+  using result_type = xrt_core::query::kernel_max_bandwidth_mbps::result_type;
 
   static result_type
   get(const xrt_core::device* device, key_type key, const std::any& param)
@@ -1509,11 +1509,11 @@ initialize_query_table()
 
   emplace_func4_request<query::debug_ip_layout_path,           debug_ip_layout_path>();
   emplace_func0_request<query::num_live_processes,             num_live_processes>();
-  emplace_func0_request<query::device_clock_freq_MHz,          device_clock_freq_MHz>();
+  emplace_func0_request<query::device_clock_freq_mhz,          device_clock_freq_mhz>();
   emplace_func4_request<query::trace_buffer_info,              trace_buffer_info>();
   emplace_func4_request<query::sub_device_path,                sub_device_path>();
-  emplace_func4_request<query::host_max_bandwidth_MBps,        host_max_bandwidth_MBps>();
-  emplace_func4_request<query::kernel_max_bandwidth_MBps,      kernel_max_bandwidth_MBps>();
+  emplace_func4_request<query::host_max_bandwidth_mbps,        host_max_bandwidth_mbps>();
+  emplace_func4_request<query::kernel_max_bandwidth_mbps,      kernel_max_bandwidth_mbps>();
   emplace_func4_request<query::read_trace_data,                read_trace_data>();
 }
 

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -8,6 +8,8 @@
 #include "core/common/query_requests.h"
 #include "core/common/system.h"
 #include "core/common/utils.h"
+#include "core/common/xrt_profiling.h"
+#include "core/include/experimental/xrt-next.h"
 #include "core/include/xdp/aim.h"
 #include "core/include/xdp/am.h"
 #include "core/include/xdp/asm.h"
@@ -947,6 +949,127 @@ struct aie_tiles_status_info
   }
 };
 
+struct debug_ip_layout_path
+{
+  using result_type = xrt_core::query::debug_ip_layout_path::result_type;
+
+  static result_type
+  get(const xrt_core::device* device, key_type key, const std::any& param)
+  {
+    uint32_t size = std::any_cast<uint32_t>(param);
+    std::string path;
+    path.resize(size);
+
+    // Get Debug Ip layout path
+    xclGetDebugIPlayoutPath(device->get_user_handle(), const_cast<char*>(path.data()), size);
+    return path;
+  }
+};
+
+struct num_live_processes {
+  using result_type = xrt_core::query::num_live_processes::result_type;
+
+  static result_type
+  get(const xrt_core::device* device, key_type key)
+  {
+    return xclGetNumLiveProcesses(device->get_user_handle());
+  }
+};
+
+struct device_clock_freq_MHz {
+  using result_type = xrt_core::query::device_clock_freq_MHz::result_type;
+
+  static result_type
+  get(const xrt_core::device* device, key_type key)
+  {
+    return xclGetDeviceClockFreqMHz(device->get_user_handle());
+  }
+};
+
+struct trace_buffer_info
+{
+  using result_type = xrt_core::query::trace_buffer_info::result_type;
+
+  static result_type
+  get(const xrt_core::device* device, key_type key, const std::any& param)
+  {
+    uint32_t input_samples = std::any_cast<uint32_t>(param);
+    result_type buf_info;
+
+    // Get trace buf size and trace samples
+    xclGetTraceBufferInfo(device->get_user_handle(), input_samples, buf_info.samples, buf_info.buf_size);
+    return buf_info;
+  }
+};
+
+struct sub_device_path
+{
+  using result_type = xrt_core::query::sub_device_path::result_type;
+
+  static result_type
+  get(const xrt_core::device* device, key_type key, const std::any& param)
+  {
+    constexpr size_t max_size = 256;
+    auto info = std::any_cast<xrt_core::query::sub_device_path::args>(param);
+    result_type sub_dev_path;
+    sub_dev_path.resize(max_size);
+
+    // Get sub device path
+    xclGetSubdevPath(device->get_user_handle(), info.subdev.data(),
+		     info.index, const_cast<char*>(sub_dev_path.data()), max_size);
+    return sub_dev_path;
+  }
+};
+
+struct host_max_bandwidth_MBps
+{
+  using result_type = xrt_core::query::host_max_bandwidth_MBps::result_type;
+
+  static result_type
+  get(const xrt_core::device* device, key_type key, const std::any& param)
+  {
+    bool read = std::any_cast<bool>(param);
+
+    // Get read/write host max bandwidth in MBps
+    return read ? xclGetHostReadMaxBandwidthMBps(device->get_user_handle())
+                : xclGetHostWriteMaxBandwidthMBps(device->get_user_handle());
+  }
+};
+
+struct kernel_max_bandwidth_MBps
+{
+  using result_type = xrt_core::query::kernel_max_bandwidth_MBps::result_type;
+
+  static result_type
+  get(const xrt_core::device* device, key_type key, const std::any& param)
+  {
+    bool read = std::any_cast<bool>(param);
+
+    // Get read/write host max bandwidth in MBps
+    return read ? xclGetKernelReadMaxBandwidthMBps(device->get_user_handle())
+                : xclGetKernelWriteMaxBandwidthMBps(device->get_user_handle());
+  }
+};
+
+struct read_trace_data
+{
+  using result_type = xrt_core::query::read_trace_data::result_type;
+
+  static result_type
+  get(const xrt_core::device* device, key_type key, const std::any& param)
+  {
+    auto args = std::any_cast<xrt_core::query::read_trace_data::args>(param);
+
+    result_type trace_buf;
+    trace_buf.resize(args.buf_size);
+
+    // read trace data
+    xclReadTraceData(device->get_user_handle(), trace_buf.data(),
+                     args.buf_size, args.samples, args.ip_base_addr, args.words_per_sample);
+    return trace_buf;
+  }
+};
+
 // Specialize for other value types.
 template <typename ValueType>
 struct sysfs_fcn
@@ -1383,6 +1506,15 @@ initialize_query_table()
 
   emplace_func0_request<query::aie_tiles_stats,                aie_tiles_stats>();
   emplace_func4_request<query::aie_tiles_status_info,          aie_tiles_status_info>();
+
+  emplace_func4_request<query::debug_ip_layout_path,           debug_ip_layout_path>();
+  emplace_func0_request<query::num_live_processes,             num_live_processes>();
+  emplace_func0_request<query::device_clock_freq_MHz,          device_clock_freq_MHz>();
+  emplace_func4_request<query::trace_buffer_info,              trace_buffer_info>();
+  emplace_func4_request<query::sub_device_path,                sub_device_path>();
+  emplace_func4_request<query::host_max_bandwidth_MBps,        host_max_bandwidth_MBps>();
+  emplace_func4_request<query::kernel_max_bandwidth_MBps,      kernel_max_bandwidth_MBps>();
+  emplace_func4_request<query::read_trace_data,                read_trace_data>();
 }
 
 struct X { X() { initialize_query_table(); }};

--- a/src/runtime_src/core/pcie/windows/alveo/device_windows.cpp
+++ b/src/runtime_src/core/pcie/windows/alveo/device_windows.cpp
@@ -1270,6 +1270,70 @@ struct accel_deadlock_status
   }
 };
 
+struct trace_buffer_info
+{
+  using result_type = xrt_core::query::trace_buffer_info::result_type;
+
+  static result_type
+  get(const xrt_core::device* device, key_type key, const std::any& param)
+  {
+    uint32_t input_samples = std::any_cast<uint32_t>(param);
+    result_type buf_info;
+
+    // Get trace buf size and trace samples
+    xclGetTraceBufferInfo(device->get_user_handle(), input_samples, buf_info.samples, buf_info.buf_size);
+    return buf_info;
+  }
+};
+
+struct host_max_bandwidth_MBps
+{
+  using result_type = xrt_core::query::host_max_bandwidth_MBps::result_type;
+
+  static result_type
+  get(const xrt_core::device* device, key_type key, const std::any& param)
+  {
+    bool read = std::any_cast<bool>(param);
+
+    // Get read/write host max bandwidth in MBps
+    return read ? xclGetHostReadMaxBandwidthMBps(device->get_user_handle())
+                : xclGetHostWriteMaxBandwidthMBps(device->get_user_handle());
+  }
+};
+
+struct kernel_max_bandwidth_MBps
+{
+  using result_type = xrt_core::query::kernel_max_bandwidth_MBps::result_type;
+
+  static result_type
+  get(const xrt_core::device* device, key_type key, const std::any& param)
+  {
+    bool read = std::any_cast<bool>(param);
+
+    // Get read/write host max bandwidth in MBps
+    return read ? xclGetKernelReadMaxBandwidthMBps(device->get_user_handle())
+                : xclGetKernelWriteMaxBandwidthMBps(device->get_user_handle());
+  }
+};
+
+struct read_trace_data
+{
+  using result_type = xrt_core::query::read_trace_data::result_type;
+
+  static result_type
+  get(const xrt_core::device* device, key_type key, const std::any& param)
+  {
+    auto args = std::any_cast<xrt_core::query::read_trace_data::args>(param);
+
+    result_type trace_buf;
+    trace_buf.resize(args.buf_size);
+
+    // read trace data
+    xclReadTraceData(device->get_user_handle(), trace_buf.data(),
+                     args.buf_size, args.samples, args.ip_base_addr, args.words_per_sample);
+    return trace_buf;
+  }
+};
 
 template <typename QueryRequestType, typename Getter>
 struct function0_getput : QueryRequestType
@@ -1542,6 +1606,10 @@ initialize_query_table()
   emplace_func4_request<query::lapc_status,                  lapc_status>();
   emplace_func4_request<query::spc_status,                   spc_status>();
   emplace_func4_request<query::accel_deadlock_status,        accel_deadlock_status>();
+  emplace_func4_request<query::trace_buffer_info,            trace_buffer_info>();
+  emplace_func4_request<query::host_max_bandwidth_MBps,      host_max_bandwidth_MBps>();
+  emplace_func4_request<query::kernel_max_bandwidth_MBps,    kernel_max_bandwidth_MBps>();
+  emplace_func4_request<query::read_trace_data,              read_trace_data>();
 }
 
 struct X { X() { initialize_query_table(); }};

--- a/src/runtime_src/core/pcie/windows/alveo/device_windows.cpp
+++ b/src/runtime_src/core/pcie/windows/alveo/device_windows.cpp
@@ -1287,9 +1287,9 @@ struct trace_buffer_info
   }
 };
 
-struct host_max_bandwidth_MBps
+struct host_max_bandwidth_mbps
 {
-  using result_type = xrt_core::query::host_max_bandwidth_MBps::result_type;
+  using result_type = xrt_core::query::host_max_bandwidth_mbps::result_type;
 
   static result_type
   get(const xrt_core::device* device, key_type key, const std::any& param)
@@ -1302,9 +1302,9 @@ struct host_max_bandwidth_MBps
   }
 };
 
-struct kernel_max_bandwidth_MBps
+struct kernel_max_bandwidth_mbps
 {
-  using result_type = xrt_core::query::kernel_max_bandwidth_MBps::result_type;
+  using result_type = xrt_core::query::kernel_max_bandwidth_mbps::result_type;
 
   static result_type
   get(const xrt_core::device* device, key_type key, const std::any& param)
@@ -1608,8 +1608,8 @@ initialize_query_table()
   emplace_func4_request<query::spc_status,                   spc_status>();
   emplace_func4_request<query::accel_deadlock_status,        accel_deadlock_status>();
   emplace_func4_request<query::trace_buffer_info,            trace_buffer_info>();
-  emplace_func4_request<query::host_max_bandwidth_MBps,      host_max_bandwidth_MBps>();
-  emplace_func4_request<query::kernel_max_bandwidth_MBps,    kernel_max_bandwidth_MBps>();
+  emplace_func4_request<query::host_max_bandwidth_mbps,      host_max_bandwidth_mbps>();
+  emplace_func4_request<query::kernel_max_bandwidth_mbps,    kernel_max_bandwidth_mbps>();
   emplace_func4_request<query::read_trace_data,              read_trace_data>();
 }
 

--- a/src/runtime_src/core/pcie/windows/alveo/device_windows.cpp
+++ b/src/runtime_src/core/pcie/windows/alveo/device_windows.cpp
@@ -9,6 +9,7 @@
 #include "core/common/query_requests.h"
 #include "core/common/utils.h"
 #include "core/common/system.h"
+#include "core/common/xrt_profiling.h"
 #include "core/include/xrt.h"
 #include "core/include/xclfeatures.h"
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
This commit adds new queries which will be used in XDP code base. XDP code will be moved from using xcl apis to query calls to fetch information. Confluence page capturing this work - https://confluence.xilinx.com/display/XSW/Vitis-9976+Work 

This change is part of series of changes which aim to remove release of xcl apis

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
New queries are added, XDP code will now link to xrt_coreutil which will be platform independent

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
Tested build flows (PCIE - Linux/Windows, Edge)
After XDP code adds these queries they will do functionality test with their test cases

#### Documentation impact (if any)
NA