### PR TITLE
Update dependency installation, build and packaging scripts for AlmaLinux9

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -12,7 +12,7 @@ CMAKE_MAJOR_VERSION=`cmake --version | head -n 1 | awk '{print $3}' |awk -F. '{p
 CPU=`uname -m`
 
 if [[ $CMAKE_MAJOR_VERSION != 3 ]]; then
-    if [[ $OSDIST == "centos" ]] || [[ $OSDIST == "amzn" ]] || [[ $OSDIST == "rhel" ]] || [[ $OSDIST == "fedora" ]] || [[ $OSDIST == "mariner" ]]; then
+    if [[ $OSDIST == "centos" ]] || [[ $OSDIST == "amzn" ]] || [[ $OSDIST == "rhel" ]] || [[ $OSDIST == "fedora" ]] || [[ $OSDIST == "mariner" ]] || [[ $OSDIST == "almalinux" ]]; then
         CMAKE=cmake3
         if [[ ! -x "$(command -v $CMAKE)" ]]; then
             echo "$CMAKE is not installed, please run xrtdeps.sh"

--- a/src/CMake/cpackLin.cmake
+++ b/src/CMake/cpackLin.cmake
@@ -103,7 +103,7 @@ if (${LINUX_FLAVOR} MATCHES "^(ubuntu|debian)")
     SET(CPACK_DEBIAN_PACKAGE_DEPENDS ${CPACK_DEBIAN_XRT_PACKAGE_DEPENDS})
   endif()
 
-elseif (${LINUX_FLAVOR} MATCHES "^(rhel|centos|amzn|fedora|sles|mariner)")
+elseif (${LINUX_FLAVOR} MATCHES "^(rhel|centos|amzn|fedora|sles|mariner|almalinux)")
   execute_process(
     COMMAND uname -m
     OUTPUT_VARIABLE CPACK_ARCH

--- a/src/CMake/pkgconfig.cmake
+++ b/src/CMake/pkgconfig.cmake
@@ -5,7 +5,7 @@ message("-- Preparing XRT pkg-config")
 
 if (${LINUX_FLAVOR} MATCHES "^(ubuntu)")
   set(XRT_PKG_CONFIG_DIR "/usr/lib/pkgconfig")
-elseif (${LINUX_FLAVOR} MATCHES "^(rhel|centos|amzn|fedora|sles)")
+elseif (${LINUX_FLAVOR} MATCHES "^(rhel|centos|amzn|fedora|sles|almalinux)")
   set(XRT_PKG_CONFIG_DIR "/usr/lib64/pkgconfig")
 else ()
   set(XRT_PKG_CONFIG_DIR "/usr/share/pkgconfig")

--- a/src/python/pybind11/CMakeLists.txt
+++ b/src/python/pybind11/CMakeLists.txt
@@ -29,7 +29,7 @@ endif(CMAKE_VERSION VERSION_LESS "3.12")
 if (HAS_PYTHON)
   if (${LINUX_FLAVOR} MATCHES "^(ubuntu|debian)")
     SET(PKGDIR "dist-packages")
-  elseif (${LINUX_FLAVOR} MATCHES "^(rhel|centos|amzn|fedora|sles)")
+  elseif (${LINUX_FLAVOR} MATCHES "^(rhel|centos|amzn|fedora|sles|almalinux)")
     SET(PKGDIR "site-packages")
   endif(${LINUX_FLAVOR} MATCHES "^(ubuntu|debian)")
 

--- a/src/runtime_src/tools/scripts/xrtdeps.sh
+++ b/src/runtime_src/tools/scripts/xrtdeps.sh
@@ -421,7 +421,7 @@ update_package_list()
 {
     if [ $FLAVOR == "ubuntu" ] || [ $FLAVOR == "debian" ]; then
         ub_package_list
-    elif [ $FLAVOR == "centos" ] || [ $FLAVOR == "rhel" ] || [ $FLAVOR == "amzn" ]; then
+    elif [ $FLAVOR == "centos" ] || [ $FLAVOR == "rhel" ] || [ $FLAVOR == "amzn" ] || [ $FLAVOR == "almalinux" ]; then
         rh_package_list
     elif [ $FLAVOR == "fedora" ]; then
         fd_package_list
@@ -446,7 +446,7 @@ validate()
         fi
     fi
 
-    if [ $FLAVOR == "centos" ] || [ $FLAVOR == "rhel" ] || [ $FLAVOR == "amzn" ]; then
+    if [ $FLAVOR == "centos" ] || [ $FLAVOR == "rhel" ] || [ $FLAVOR == "amzn" ] || [ $FLAVOR == "almalinux" ]; then
         rpm -q "${RH_LIST[@]}"
         if [ $? == 0 ] ; then
             # Validate we have OpenCL 2.X headers installed
@@ -624,6 +624,23 @@ prep_sles()
     fi
 }
 
+prep_alma9()
+{
+    echo "Enabling EPEL repository..."
+    yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+    yum check-update
+
+    echo "Enabling CodeReady-Builder repository..."
+    dnf config-manager --set-enabled crb
+}
+
+prep_alma()
+{
+    if [ $MAJOR -ge 9 ]; then
+        prep_alma9
+    fi
+}
+
 install()
 {
     if [ $FLAVOR == "ubuntu" ] || [ $FLAVOR == "debian" ]; then
@@ -648,9 +665,11 @@ install()
         prep_mariner
     elif [ $FLAVOR == "sles" ]; then
         prep_sles
+    elif [ $FLAVOR == "almalinux" ]; then
+        prep_alma
     fi
 
-    if [ $FLAVOR == "rhel" ] || [ $FLAVOR == "centos" ] || [ $FLAVOR == "amzn" ]; then
+    if [ $FLAVOR == "rhel" ] || [ $FLAVOR == "centos" ] || [ $FLAVOR == "amzn" ] || [ $FLAVOR == "almalinux" ]; then
         echo "Installing RHEL/CentOS packages..."
         yum install -y "${RH_LIST[@]}"
         if [ $ds9 == 1 ]; then


### PR DESCRIPTION
#### Problem solved by the commit
While not a supported OS, XRT can be built and used on AlmaLinux 9, but there is some checks for specific linux flavors which forbid to run dependency installation script and packaging (Build is mostly ok, except for location of pybind11).

#### How problem was solved, alternative solutions (if any) and why they were rejected
With the proposed modifications, dependency installation script, build and packaging works on AlmaLinux9

#### What has been tested and how, request additional testing if necessary
Tested on almalinux:latest docker and a fresh almalinux-minimal native install.

Caveat: on docker image, the `curl-minimal` clash with the installation of `curl` until `--allowerasing` is used during yum install. As this change would be more invasive and probably controversial, it have been left out and using `yum install curl --allowerasing` before running the `xrtdeps.sh` script is an easy workaround.

#### Documentation impact (if any)
This is not an attempt to add AlmaLinux 9 to the supported OS lists, thus no documentation modification is required.