### PR TITLE
VITIS-10999 Prevent display of power data

### DIFF
--- a/src/runtime_src/core/tools/common/reports/ReportElectrical.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportElectrical.cpp
@@ -40,10 +40,12 @@ ReportElectrical::writeReport( const xrt_core::device* /*_pDevice*/,
 
   _output << "Electrical\n";
   const boost::property_tree::ptree& electricals = _pt.get_child("electrical.power_rails", empty_ptree);
-  _output << boost::format("  %-23s: %s Watts\n") % "Max Power" % _pt.get<std::string>("electrical.power_consumption_max_watts", "N/A");
-  _output << boost::format("  %-23s: %s Watts\n") % "Power" % _pt.get<std::string>("electrical.power_consumption_watts", "N/A");
-  _output << boost::format("  %-23s: %s\n\n") % "Power Warning" % _pt.get<std::string>("electrical.power_consumption_warning", "N/A");
-  
+  if (!electricals.empty()) {
+    _output << boost::format("  %-23s: %s Watts\n") % "Max Power" % _pt.get<std::string>("electrical.power_consumption_max_watts", "N/A");
+    _output << boost::format("  %-23s: %s Watts\n") % "Power" % _pt.get<std::string>("electrical.power_consumption_watts", "N/A");
+    _output << boost::format("  %-23s: %s\n\n") % "Power Warning" % _pt.get<std::string>("electrical.power_consumption_warning", "N/A");
+  }
+
   const std::vector<Table2D::HeaderData> table_headers = {
     {"Power Rails", Table2D::Justification::left},
     {":", Table2D::Justification::left},


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
The output of the electrical report when power is not available appears as N/A and looks bad.
```
---------------------------------
[0000:18:00.1] : RyzenAI-Phoenix
---------------------------------
Electrical
  Max Power              : N/A Watts
  Power                  : N/A Watts
  Power Warning          : N/A

  No electrical sensors found
```

The sensor information should not be displayed if there are no power sensors.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
This has been present for a long time, only popped up with Ryzen devices.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Check if the power section of the ptree is populated. If it is not do not display the power strings.

#### Risks (if any) associated the changes in the commit
None.

#### What has been tested and how, request additional testing if necessary
Ubuntu 22.04 U55C
Expected to display the power info
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ xbutil examine -d -r electrical
WARNING: Unexpected xocl version (2.16.0) was found. Expected 2.17.0, to match XRT tools.

-------------------------------------------------
[0000:04:00.1] : xilinx_u55c_gen3x16_xdma_base_3
-------------------------------------------------
Electrical
  Max Power              : 225 Watts
  Power                  : 21.445936 Watts
  Power Warning          : false

  Power Rails            :   Voltage  Current  
  ---------------------------------------------
  12 Volts Auxillary     :  12.256 V  0.481 A  
  12 Volts PCI Express   :  12.240 V  0.985 A  
  3.3 Volts PCI Express  :   3.360 V  1.040 A  
  3.3 Volts Auxillary    :   0.000 V  0.000 A  
  Internal FPGA Vcc      :   0.853 V  6.300 A  
  Internal FPGA Vcc IO   :   0.854 V  3.700 A  
  DDR Vpp Bottom         :   0.000 V  0.000 A  
  DDR Vpp Top            :   0.000 V  0.000 A  
  5.5 Volts System       :   5.004 V  0.000 A  
  Vcc 1.2 Volts Top      :   0.000 V  0.000 A  
  Vcc 1.2 Volts Bottom   :   0.000 V  0.000 A  
  1.8 Volts Top          :   1.812 V  0.000 A  
  0.9 Volts Vcc          :   0.898 V  0.000 A  
  12 Volts SW            :   0.000 V  0.000 A  
  Mgt Vtt                :   1.199 V  0.000 A  
  3.3 Volts Vcc          :   3.355 V  0.000 A  
  1.2 Volts HBM          :   1.202 V  0.000 A  
  Vpp 2.5 Volts          :   2.468 V  0.000 A  
  12 Volts Aux1          :   0.000 V  0.000 A  
  Vcc 1.2 Volts i        :   0.000 V  0.000 A  
  V12 in i               :   0.000 V  0.000 A  
  V12 in Aux0 i          :   0.000 V  0.000 A  
  V12 in Aux1 i          :   0.000 V  0.000 A  
  Vcc Auxillary          :   0.000 V  0.000 A  
  Vcc Auxillary Pmc      :   0.000 V  0.000 A  
  Vcc Ram                :   0.000 V  0.000 A  
  0.9 Volts Vcc Vcu      :   0.000 V  0.000 A 
```

Windows MCDM build 26016 Phoenix
Expected to NOT display the data
```
Z:\XRT-MCDM\build\WDebug\xilinx\xrt>xbutil examine -d -r electrical
------------------------------------------------------------
                        EARLY ACCESS
        This release of xbutil contains early access
         experimental features which may have bugs.
------------------------------------------------------------

---------------------------------
[0000:18:00.1] : RyzenAI-Phoenix
---------------------------------
Electrical
  No electrical sensors found
```

#### Documentation impact (if any)
None.