### PR TITLE
Added 6.6 kernel support for zocl

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/common/zocl_bo.c
+++ b/src/runtime_src/core/edge/drm/zocl/common/zocl_bo.c
@@ -89,8 +89,13 @@ int zocl_iommu_map_bo(struct drm_device *dev, struct drm_zocl_bo *bo)
 	}
 
 	/* MAP user's VA to pages table into IOMMU */
-	err = iommu_map_sg(zdev->domain, bo->uaddr, bo->sgt->sgl,
-			bo->sgt->nents, prot);
+        #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0)
+                err = iommu_map_sg(zdev->domain, bo->uaddr, bo->sgt->sgl,
+                        bo->sgt->nents, prot, GFP_KERNEL);
+        #else
+                err = iommu_map_sg(zdev->domain, bo->uaddr, bo->sgt->sgl,
+                        bo->sgt->nents, prot);
+        #endif
 	if (err < 0) {
 		/* If IOMMU map failed forget user's VA */
 		bo->uaddr = 0;

--- a/src/runtime_src/core/edge/drm/zocl/common/zocl_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/common/zocl_xclbin.c
@@ -674,7 +674,11 @@ zocl_load_sect(struct drm_zocl_dev *zdev, struct axlf *axlf, char __user *xclbin
 		flags = zdev->fpga_mgr->flags;
 		zdev->fpga_mgr->flags |= FPGA_MGR_CONFIG_DMA_BUF;
 		zdev->fpga_mgr->dmabuf = drm_gem_prime_export(&bo->gem_base, 0);
-		err = of_overlay_fdt_apply((void *)section_buffer, size, &id);
+                #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
+                         err = of_overlay_fdt_apply((void *)section_buffer, size, &id, NULL);
+                #else
+                         err = of_overlay_fdt_apply((void *)section_buffer, size, &id);
+                #endif
 		if (err < 0) {
 			DRM_WARN("Failed to create overlay (err=%d)\n", err);
 			zdev->fpga_mgr->flags = flags;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Fixed build failures on zocl when compiled using 6.6 kernel

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Petalinux is moving to 6.6 kernel, so adding support for this kernel version

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added preprocessor checks to fix the build issue.

#### Risks (if any) associated the changes in the commit
NA

#### What has been tested and how, request additional testing if necessary
Tested compiling zocl against 6.6 kernel.

#### Documentation impact (if any)
NA
