### PR TITLE
Fix AIE trace crashes on client

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info/aie_util.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info/aie_util.cpp
@@ -58,45 +58,36 @@ namespace xdp::aie {
   std::unique_ptr<xdp::aie::BaseFiletypeImpl>
   determineFileType(boost::property_tree::ptree& aie_project)
   {
-    //
-    // Check if it is the known compiler_report.json format
-    //
+    // aie_control_config.json format
     try {
-      std::string schema;
-      schema = aie_project.get_child("schema").get_value<std::string>();
-      if (schema == "MEGraphSchema-0.4")
-        // For now, always try to parse aie_control_config.json
+      auto c = aie_project.get_child_optional("aie_metadata.aiecompiler_options");
+      if (c)
         return std::make_unique<xdp::aie::AIEControlConfigFiletype>(aie_project);
+    }
+    catch(...) {
+      // Most likely not an aie_control_config
+    }
+
+    try {
+      auto c = aie_project.get_child_optional("schema");
+      if (c) {
+        auto schema = c.get().get_value<std::string>();
+        // compiler_report.json format
+        if (schema == "MEGraphSchema-0.4")
+          return std::make_unique<xdp::aie::AIEControlConfigFiletype>(aie_project);
+        // Known handwritten format
+        if (schema == "handwritten")
+          return std::make_unique<xdp::aie::AIEControlConfigFiletype>(aie_project);
+      }
     }
     catch (...) {
-      // Something went wrong, so it most likely is not a "compiler_report.json"
+      // Most likely an invalid format
     }
 
-    //
-    // Check if it is the known aie_control_config.json format
-    //
-    try {
-      std::string major;
-      major = aie_project.get_child("aie_metadata.aiecompiler_options").get_value<std::string>();
-      if (major == "1")
-        return std::make_unique<xdp::aie::AIEControlConfigFiletype>(aie_project);
-    }
-    catch(...) {
-      // Something went wrong, so it most likely is not an aie_control_config
-    }
-
-    //
-    // Check if it is the known handwritten format
-    //
-    try {
-      auto schema = aie_project.get_child("schema").get_value<std::string>();
-      if (schema == "handwritten")
-        // For now, always try to parse aie_control_config.json
-        return std::make_unique<xdp::aie::AIEControlConfigFiletype>(aie_project);
-    }
-    catch(...) {
-      // Something went wrong, so it most likely is not the handwritten format
-    }
+    std::stringstream msg;
+    msg << "Unable to determine AIE Metadata file type. "
+        << "Profiling and trace features might not work.";
+    xrt_core::message::send(severity_level::debug, "XRT", msg.str());
 
     // We could not determine the type
     return nullptr;

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_metadata.cpp
@@ -922,7 +922,9 @@ namespace xdp {
   aie::driver_config 
   AieTraceMetadata::getAIEConfigMetadata() 
   {
-    return metadataReader->getDriverConfig();
+    if (metadataReader)
+      return metadataReader->getDriverConfig();
+    return {};
   }
   
 }

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_metadata.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_metadata.h
@@ -81,6 +81,7 @@ class AieTraceMetadata {
     uint32_t getIterationCount(){return iterationCount;}
     uint64_t getNumStreams() {return numAIETraceOutput;}
     uint64_t getContinuousTrace() {return continuousTrace;}
+    void resetContinuousTrace() {continuousTrace = false;}
     uint64_t getOffloadIntervalUs() {return offloadIntervalUs;}
     uint64_t getDeviceID() {return deviceID;}
     bool getIsValidMetrics() {return isValidMetrics;}

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_metadata.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_metadata.h
@@ -52,14 +52,20 @@ class AieTraceMetadata {
     
    public:
     int getHardwareGen() {
-      return metadataReader->getHardwareGeneration();
+      if (metadataReader)
+        return metadataReader->getHardwareGeneration();
+      return 0;
     }
     uint16_t getRowOffset() {
-      return metadataReader->getAIETileRowOffset();
+      if (metadataReader)
+        return metadataReader->getAIETileRowOffset();
+      return 0;
     }
     std::unordered_map<std::string, io_config> 
     get_trace_gmios() {
-      return metadataReader->getTraceGMIOs();
+      if (metadataReader)
+        return metadataReader->getTraceGMIOs();
+      return {};
     }
     std::string getMetricString(uint8_t index) {
       if (index < metricSets[module_type::core].size())

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/win/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/win/aie_trace.cpp
@@ -178,9 +178,8 @@ namespace xdp {
     };
 
     auto RC = XAie_CfgInitialize(&aieDevInst, &cfg);
-    if (RC != XAIE_OK) {
+    if (RC != XAIE_OK)
       xrt_core::message::send(severity_level::warning, "XRT", "AIE Driver Initialization Failed.");
-    }
   }
 
   void AieTrace_WinImpl::updateDevice()
@@ -188,9 +187,8 @@ namespace xdp {
     xrt_core::message::send(severity_level::info, "XRT", "Calling AIE Trace IPU updateDevice.");
 
     // compile-time trace
-    if (!metadata->getRuntimeMetrics()) {
+    if (!metadata->getRuntimeMetrics())
       return;
-    }
 
     // Set metrics for trace events
     if (!setMetricsSettings(metadata->getDeviceID(), metadata->getHandle())) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
1. Pick AIE Metadata file types correctly now
2. Fix Nullpointer access related crashes with invalid metadata formats
3. Turn off periodic offload
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Tested on a phoenix design
#### Documentation impact (if any)
