### PR TITLE
VITIS-10999 Improve electrical report output

### DIFF
--- a/src/runtime_src/core/common/sensor.cpp
+++ b/src/runtime_src/core/common/sensor.cpp
@@ -210,19 +210,19 @@ read_data_driven_electrical(const std::vector<xq::sdm_sensor_info::data_type>& c
     sensor_array.push_back({"", pt});
   }
 
-  uint64_t bd_power;
+  std::string bd_power = "N/A";
   // iterate over power data, store to ptree by converting to watts.
   for (const auto& tmp : power) {
     if (boost::iequals(tmp.label, "Total Power"))
-      bd_power = tmp.input;
+      bd_power = std::to_string(tmp.input);
   }
   ptree_type root;
 
   root.add_child("power_rails", sensor_array);
 
   root.put("power_consumption_watts", bd_power);
-  root.put("power_consumption_max_watts", "NA");
-  root.put("power_consumption_warning", "NA");
+  root.put("power_consumption_max_watts", "N/A");
+  root.put("power_consumption_warning", "N/A");
 
   return root;
 }

--- a/src/runtime_src/core/common/sensor.cpp
+++ b/src/runtime_src/core/common/sensor.cpp
@@ -211,17 +211,20 @@ read_data_driven_electrical(const std::vector<xq::sdm_sensor_info::data_type>& c
   }
 
   std::string bd_power = "N/A";
+  std::string bd_max_power = "N/A";
   // iterate over power data, store to ptree by converting to watts.
   for (const auto& tmp : power) {
-    if (boost::iequals(tmp.label, "Total Power"))
-      bd_power = std::to_string(tmp.input);
+    if (boost::iequals(tmp.label, "Total Power")) {
+      bd_power = xrt_core::utils::format_base10_shiftdown(tmp.input, tmp.unitm, 3);
+      bd_max_power = xrt_core::utils::format_base10_shiftdown(tmp.max, tmp.unitm, 3);
+    }
   }
   ptree_type root;
 
   root.add_child("power_rails", sensor_array);
 
   root.put("power_consumption_watts", bd_power);
-  root.put("power_consumption_max_watts", "N/A");
+  root.put("power_consumption_max_watts", bd_max_power);
   root.put("power_consumption_warning", "N/A");
 
   return root;

--- a/src/runtime_src/core/tools/common/reports/ReportElectrical.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportElectrical.cpp
@@ -40,13 +40,16 @@ ReportElectrical::writeReport( const xrt_core::device* /*_pDevice*/,
 
   _output << "Electrical\n";
   const boost::property_tree::ptree& electricals = _pt.get_child("electrical.power_rails", empty_ptree);
+
   auto max_watts = _pt.get<std::string>("electrical.power_consumption_max_watts", "N/A");
   if (max_watts != "N/A")
     _output << boost::format("  %-23s: %s Watts\n") % "Max Power" % max_watts;
+
   auto watts = _pt.get<std::string>("electrical.power_consumption_watts", "N/A");
   if (watts != "N/A")
     _output << boost::format("  %-23s: %s Watts\n") % "Power" % watts;
-  auto power_warn = _pt.get<std::string>("electrical.power_consumption_max_watts", "N/A");
+
+  auto power_warn = _pt.get<std::string>("electrical.power_consumption_warning", "N/A");
   if (power_warn != "N/A")
     _output << boost::format("  %-23s: %s\n\n") % "Power Warning" % power_warn;
 

--- a/src/runtime_src/core/tools/common/reports/ReportElectrical.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportElectrical.cpp
@@ -40,11 +40,15 @@ ReportElectrical::writeReport( const xrt_core::device* /*_pDevice*/,
 
   _output << "Electrical\n";
   const boost::property_tree::ptree& electricals = _pt.get_child("electrical.power_rails", empty_ptree);
-  if (!electricals.empty()) {
-    _output << boost::format("  %-23s: %s Watts\n") % "Max Power" % _pt.get<std::string>("electrical.power_consumption_max_watts", "N/A");
-    _output << boost::format("  %-23s: %s Watts\n") % "Power" % _pt.get<std::string>("electrical.power_consumption_watts", "N/A");
-    _output << boost::format("  %-23s: %s\n\n") % "Power Warning" % _pt.get<std::string>("electrical.power_consumption_warning", "N/A");
-  }
+  auto max_watts = _pt.get<std::string>("electrical.power_consumption_max_watts", "N/A");
+  if (max_watts != "N/A")
+    _output << boost::format("  %-23s: %s Watts\n") % "Max Power" % max_watts;
+  auto watts = _pt.get<std::string>("electrical.power_consumption_watts", "N/A");
+  if (watts != "N/A")
+    _output << boost::format("  %-23s: %s Watts\n") % "Power" % watts;
+  auto power_warn = _pt.get<std::string>("electrical.power_consumption_max_watts", "N/A");
+  if (power_warn != "N/A")
+    _output << boost::format("  %-23s: %s\n\n") % "Power Warning" % power_warn;
 
   const std::vector<Table2D::HeaderData> table_headers = {
     {"Power Rails", Table2D::Justification::left},
@@ -68,9 +72,9 @@ ReportElectrical::writeReport( const xrt_core::device* /*_pDevice*/,
     elec_table.addEntry(entry_data);
   }
 
-  if (elec_table.empty())
+  if (watts == "N/A" && max_watts == "N/A" && power_warn == "N/A" && elec_table.empty())
     _output << "  No electrical sensors found\n";
-  else
+  else if (!elec_table.empty())
     _output << elec_table.toString("  ");
 
   _output << std::endl;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/VITIS-10999

Data does not populate for certain devices due to bad condition for power display.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Introduced in https://github.com/Xilinx/XRT/pull/7862.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Checked the status of each power output individually and output if valid.

#### Risks (if any) associated the changes in the commit
None.

#### What has been tested and how, request additional testing if necessary
Ubuntu 22.04 u55c
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ xbutil examine -d -r electrical
WARNING: Unexpected xocl version (2.16.0) was found. Expected 2.17.0, to match XRT tools.

-------------------------------------------------
[0000:04:00.1] : xilinx_u55c_gen3x16_xdma_base_3
-------------------------------------------------
Electrical
  Max Power              : 225 Watts
  Power                  : 21.445936 Watts
  Power Warning          : 225

  Power Rails            :   Voltage  Current
  ---------------------------------------------
  12 Volts Auxillary     :  12.256 V  0.481 A
  12 Volts PCI Express   :  12.240 V  0.985 A
  3.3 Volts PCI Express  :   3.360 V  1.040 A
  3.3 Volts Auxillary    :   0.000 V  0.000 A
  Internal FPGA Vcc      :   0.852 V  6.100 A
  Internal FPGA Vcc IO   :   0.855 V  3.600 A
  DDR Vpp Bottom         :   0.000 V  0.000 A
  DDR Vpp Top            :   0.000 V  0.000 A
  5.5 Volts System       :   5.003 V  0.000 A
  Vcc 1.2 Volts Top      :   0.000 V  0.000 A
  Vcc 1.2 Volts Bottom   :   0.000 V  0.000 A
  1.8 Volts Top          :   1.812 V  0.000 A
  0.9 Volts Vcc          :   0.898 V  0.000 A
  12 Volts SW            :   0.000 V  0.000 A
  Mgt Vtt                :   1.200 V  0.000 A
  3.3 Volts Vcc          :   3.354 V  0.000 A
  1.2 Volts HBM          :   1.203 V  0.000 A
  Vpp 2.5 Volts          :   2.468 V  0.000 A
  12 Volts Aux1          :   0.000 V  0.000 A
  Vcc 1.2 Volts i        :   0.000 V  0.000 A
  V12 in i               :   0.000 V  0.000 A
  V12 in Aux0 i          :   0.000 V  0.000 A
  V12 in Aux1 i          :   0.000 V  0.000 A
  Vcc Auxillary          :   0.000 V  0.000 A
  Vcc Auxillary Pmc      :   0.000 V  0.000 A
  Vcc Ram                :   0.000 V  0.000 A
  0.9 Volts Vcc Vcu      :   0.000 V  0.000 A
```

Windows VM Virtual device build 26016 (Phoenix)
```
Z:\XRT-MCDM\build\WDebug\xilinx\xrt>xbutil examine -d -r electrical
------------------------------------------------------------
                        EARLY ACCESS
        This release of xbutil contains early access
         experimental features which may have bugs.
------------------------------------------------------------

---------------------------------
[0000:18:00.1] : RyzenAI-Phoenix
---------------------------------
Electrical
  No electrical sensors found
```

Windows VM Virtual device build 26016 (Strix)
```
Z:\XRT-MCDM\build\WDebug\xilinx\xrt>xbutil examine -d -r electrical
------------------------------------------------------------
                        EARLY ACCESS
        This release of xbutil contains early access
         experimental features which may have bugs.
------------------------------------------------------------

-------------------------------
[0000:18:00.1] : RyzenAI-Strix
-------------------------------
Electrical
  Power                  : 123 Watts
```
#### Documentation impact (if any)
None