### PR TITLE
CR-1181687 Fix hwctx_handle::create_hw_queue() to return shared queue

### DIFF
--- a/src/runtime_src/core/common/shim/hwctx_handle.h
+++ b/src/runtime_src/core/common/shim/hwctx_handle.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
 #ifndef XRT_CORE_HWCTX_HANDLE_H
 #define XRT_CORE_HWCTX_HANDLE_H
 
@@ -51,10 +51,12 @@ public:
   virtual slot_id
   get_slotidx() const = 0;
 
-  // Create a hardware queue.  The return value is allowed to be
-  // nullptr if the shim does not support hardware queues.
-  virtual std::unique_ptr<hwqueue_handle>
-  create_hw_queue() = 0;
+  // Get a hardware queue for this context.  The return value is
+  // allowed to be nullptr if the shim does not support hardware
+  // queues.  The returned hwqueue is owned by the hwctx, it is
+  // an error to use the hwqueue after the hwctx has been destroyed
+  virtual hwqueue_handle*
+  get_hw_queue() = 0;
 
   // Context specific buffer allocation
   virtual std::unique_ptr<buffer_handle>

--- a/src/runtime_src/core/edge/sw_emu/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/edge/sw_emu/generic_pcie_hal2/shim.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2016-2022 Xilinx, Inc. All rights reserved.
-// Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
 #ifndef _SW_EMU_SHIM_H_
 #define _SW_EMU_SHIM_H_
 
@@ -210,8 +210,8 @@ namespace xclswemuhal2 {
         return m_uuid;
       }
 
-      std::unique_ptr<xrt_core::hwqueue_handle>
-      create_hw_queue() override
+      xrt_core::hwqueue_handle*
+      get_hw_queue() override
       {
         return nullptr;
       }

--- a/src/runtime_src/core/edge/user/shim.h
+++ b/src/runtime_src/core/edge/user/shim.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2016-2022 Xilinx, Inc. All rights reserved.
-// Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
 #ifndef _ZYNQ_SHIM_H_
 #define _ZYNQ_SHIM_H_
 
@@ -195,8 +195,8 @@ public:
       return m_uuid;
     }
 
-    std::unique_ptr<xrt_core::hwqueue_handle>
-    create_hw_queue() override
+    xrt_core::hwqueue_handle*
+    get_hw_queue() override
     {
       return nullptr;
     }

--- a/src/runtime_src/core/include/shim_int.h
+++ b/src/runtime_src/core/include/shim_int.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2021-2022 Xilinx, Inc. All rights reserved.
-// Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
 #ifndef SHIM_INT_H_
 #define SHIM_INT_H_
 
@@ -75,9 +75,9 @@ create_hw_context(xclDeviceHandle handle,
                   const xrt::hw_context::cfg_param_type& cfg_param,
                   xrt::hw_context::access_mode mode);
 
-// create_hw_queue() -
-std::unique_ptr<xrt_core::hwqueue_handle>
-create_hw_queue(xclDeviceHandle handle, xrt_core::hwctx_handle* ctxhdl);
+// get_hw_queue() -
+xrt_core::hwqueue_handle*
+get_hw_queue(xclDeviceHandle handle, xrt_core::hwctx_handle* ctxhdl);
 
 // register_xclbin() -
 void

--- a/src/runtime_src/core/pcie/emulation/hw_emu/alveo_shim/shim.h
+++ b/src/runtime_src/core/pcie/emulation/hw_emu/alveo_shim/shim.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2016-2022 Xilinx, Inc. All rights reserved.
-// Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
 #ifndef _HW_EM_SHIM_H_
 #define _HW_EM_SHIM_H_
 
@@ -260,8 +260,8 @@ using addr_type = uint64_t;
         return m_uuid;
       }
 
-      std::unique_ptr<xrt_core::hwqueue_handle>
-      create_hw_queue() override
+      xrt_core::hwqueue_handle*
+      get_hw_queue() override
       {
         return nullptr;
       }

--- a/src/runtime_src/core/pcie/emulation/sw_emu/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/pcie/emulation/sw_emu/generic_pcie_hal2/shim.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2016-2022 Xilinx, Inc. All rights reserved.
-// Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
 #ifndef _SW_EMU_SHIM_H_
 #define _SW_EMU_SHIM_H_
 
@@ -215,8 +215,8 @@ namespace xclswemuhal2
         return m_uuid;
       }
 
-      std::unique_ptr<xrt_core::hwqueue_handle>
-      create_hw_queue() override
+      xrt_core::hwqueue_handle*
+      get_hw_queue() override
       {
         return nullptr;
       }

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2016-2022 Xilinx, Inc
-// Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
 
 #include "shim.h"  // This file implements shim.h
 #include "xrt.h"   // This file implements xrt.h
@@ -287,8 +287,8 @@ public:
     return m_uuid;
   }
 
-  std::unique_ptr<xrt_core::hwqueue_handle>
-  create_hw_queue() override
+  xrt_core::hwqueue_handle*
+  get_hw_queue() override
   {
     return nullptr;
   }

--- a/src/runtime_src/core/pcie/noop/shim.cpp
+++ b/src/runtime_src/core/pcie/noop/shim.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2021-2022 Xilinx, Inc. All rights reserved.
-// Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
 
 // This file implements a dummy (no-op) shim level driver that is
 // used exclusively for debugging user space XRT with HW xclbins
@@ -490,8 +490,8 @@ public:
       return m_uuid;
     }
 
-    std::unique_ptr<xrt_core::hwqueue_handle>
-    create_hw_queue() override
+    xrt_core::hwqueue_handle*
+    get_hw_queue() override
     {
       return nullptr;
     }

--- a/src/runtime_src/core/pcie/windows/alveo/shim.cpp
+++ b/src/runtime_src/core/pcie/windows/alveo/shim.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2016-2022 Xilinx, Inc. All rights reserved.
 // Copyright (C) 2019 Samsung Semiconductor, Inc
-// Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
 #define XCL_DRIVER_DLL_EXPORT
 #define XRT_CORE_PCIE_WINDOWS_SOURCE
 #include "shim.h"
@@ -201,8 +201,8 @@ public:
       return m_uuid;
     }
 
-    std::unique_ptr<xrt_core::hwqueue_handle>
-    create_hw_queue() override
+    xrt_core::hwqueue_handle*
+    get_hw_queue() override
     {
       return nullptr;
     }


### PR DESCRIPTION
#### Problem solved by the commit
Share the ownership of xrt_core::hwqueue_handle with shim.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
A hwqueue is managed by hwctx (today 1:1), and used by coreutil XRT for submitting commands for execution and more. XRT shim may itself use the hwqueue for miscellaneous commands and as such the underlying queue is actually owned by shim (hwctx_handle) but shared with coreutil.

#### How problem was solved, alternative solutions (if any) and why they were rejected
This PR makes it explicit that the hwqueue ownership is with the hwctx_handle. XRT coreutil no longer creates a hwqueue but instead gets a hwqueue_handle from the hwctx_handle (`hwctx::handle::get_hw_queue()`).   XRT coreutil does not participate in the lifetime of the hwqueue_handle obtained from a hwctx_handle it is the responsibility of XRT coreutil implementation to ensure that lifetime of a hwctx exceeds the use of the hwqueue_handle that was obtained from the hwctx_handle.

Prior to this change there were strange hacks at shim level to return a unique_ptr to something that is actually shared.  This strange logic can now be changed.

