### PR TITLE
VITIS-10487 Add throughput and latency no-op test

### DIFF
--- a/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.cpp
@@ -198,7 +198,7 @@ TestDF_bandwidth::run(std::shared_ptr<xrt_core::device> dev)
   float elapsedSecs = std::chrono::duration_cast<std::chrono::duration<float>>(end-start).count();
   float bandwidth = buffer_size_gb / elapsedSecs;
   logger(ptree, "Details", boost::str(boost::format("Total duration: '%f's") % elapsedSecs));
-  logger(ptree, "Details", boost::str(boost::format("Average bandwidth per shim DMA: '%f' GS/s") % bandwidth));
+  logger(ptree, "Details", boost::str(boost::format("Average bandwidth per shim DMA: '%.1f' GB/s") % bandwidth));
 
   ptree.put("status", test_token_passed);
   return ptree;

--- a/src/runtime_src/core/tools/common/tests/TestIPU.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestIPU.cpp
@@ -105,9 +105,9 @@ TestIPU::run(std::shared_ptr<xrt_core::device> dev)
   float elapsedSecs = std::chrono::duration_cast<std::chrono::duration<float>>(end-start).count();
   float throughput = itr_count / elapsedSecs;
   float latency = (elapsedSecs / itr_count) * 1000000; //convert s to us
-  logger(ptree, "Details", boost::str(boost::format("Total duration: '%f's") % elapsedSecs));
-  logger(ptree, "Details", boost::str(boost::format("Average throughput: '%f' GB/s") % throughput));
-  logger(ptree, "Details", boost::str(boost::format("Average latency: '%f' us") % latency));
+  logger(ptree, "Details", boost::str(boost::format("Total duration: '%.1f's") % elapsedSecs));
+  logger(ptree, "Details", boost::str(boost::format("Average throughput: '%.1f' ops/s") % throughput));
+  logger(ptree, "Details", boost::str(boost::format("Average latency: '%.1f' us") % latency));
 
   ptree.put("status", test_token_passed);
   return ptree;

--- a/src/runtime_src/core/tools/common/tests/TestIPU.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestIPU.cpp
@@ -89,7 +89,7 @@ TestIPU::run(std::shared_ptr<xrt_core::device> dev)
   bo_mc.sync(XCL_BO_SYNC_BO_TO_DEVICE);
 
   auto start = std::chrono::high_resolution_clock::now();
-  for (int itr = 0; itr < itr_count; itr++) {
+  for (int i = 0; i < itr_count; i++) {
     try {
       auto run = kernel(host_app, bo_ifm, bo_param, bo_ofm, bo_inter, bo_instr, buffer_size, bo_mc);
       // Wait for kernel to be done

--- a/src/runtime_src/core/tools/common/tests/TestIPU.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestIPU.cpp
@@ -93,7 +93,7 @@ TestIPU::run(std::shared_ptr<xrt_core::device> dev)
     try {
       auto run = kernel(host_app, bo_ifm, bo_param, bo_ofm, bo_inter, bo_instr, buffer_size, bo_mc);
       // Wait for kernel to be done
-      run.wait2();
+      run.wait();
     }
     catch (const std::exception& ex) {
       logger(ptree, "Error", ex.what());

--- a/src/runtime_src/core/tools/common/tests/TestIPU.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestIPU.cpp
@@ -111,4 +111,4 @@ TestIPU::run(std::shared_ptr<xrt_core::device> dev)
 
   ptree.put("status", test_token_passed);
   return ptree;
-}
+} 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
 Add throughput and latency to verify test

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary

```
> xbutil.exe validate -d 00c3:00:01.1 -r verify
------------------------------------------------------------
                        EARLY ACCESS
        This release of xbutil contains early access
         experimental features which may have bugs.
------------------------------------------------------------
Validate Device           : [00c3:00:01.1]
    Platform              : RyzenAI-Phoenix
-------------------------------------------------------------------------------
Verbose: Enabling Verbosity
Test 1 [00c3:00:01.1]     : verify
    Description           : Run 'Hello World' kernel test
    Xclbin                : C:\Windows\System32\DriverStore\FileRepository\ipustack.inf_amd64_cabd6000fc08d7ce\validate_phx.xclbin
    Details               : Kernel name is 'DPU_PDI_0'
                            Average throughput: '6265.9' ops/s
                            Average latency: '159.5' us
   Test Status           : [PASSED]
-------------------------------------------------------------------------------
Validation completed
```

#### Documentation impact (if any)
None
