### PR TITLE
VITIS-11094 Remove device ID and device readiness for Ryzen devices

### DIFF
--- a/src/runtime_src/core/tools/common/reports/ReportHost.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportHost.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2020-2022 Xilinx, Inc
-// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
 
 // Local - Include Files
 #include "ReportHost.h"

--- a/src/runtime_src/core/tools/common/reports/ReportHost.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportHost.cpp
@@ -73,8 +73,10 @@ printAlveoDevices(const boost::property_tree::ptree& available_devices, std::ost
     device_table.addEntry(entry_data);
   }
 
-  if (!device_table.empty())
+  if (!device_table.empty()) {
     _output << boost::str(boost::format("%s\n") % device_table);
+    _output << "* Devices that are not ready will have reduced functionality when using XRT tools\n";
+  }
 }
 
 static void
@@ -83,9 +85,7 @@ printRyzenDevices(const boost::property_tree::ptree& available_devices, std::ost
   const Table2D::HeaderData bdf = {"BDF", Table2D::Justification::left};
   const Table2D::HeaderData colon = {":", Table2D::Justification::left};
   const Table2D::HeaderData name = {"Name", Table2D::Justification::left};
-  const Table2D::HeaderData instance = {"Device ID", Table2D::Justification::left};
-  const Table2D::HeaderData ready = {"Device Ready*", Table2D::Justification::left};
-  const std::vector<Table2D::HeaderData> table_headers = {bdf, colon, name, instance, ready};
+  const std::vector<Table2D::HeaderData> table_headers = {bdf, colon, name};
   Table2D device_table(table_headers);
 
   for (const auto& kd : available_devices) {
@@ -95,8 +95,7 @@ printRyzenDevices(const boost::property_tree::ptree& available_devices, std::ost
       continue;
 
     const std::string bdf_string = "[" + dev.get<std::string>("bdf") + "]";
-    const std::string ready_string = dev.get<bool>("is_ready", false) ? "Yes" : "No";
-    const std::vector<std::string> entry_data = {bdf_string, ":", dev.get<std::string>("name", "n/a"), dev.get<std::string>("instance", "n/a"), ready_string};
+    const std::vector<std::string> entry_data = {bdf_string, ":", dev.get<std::string>("name", "n/a")};
     device_table.addEntry(entry_data);
   }
 
@@ -163,6 +162,4 @@ ReportHost::writeReport(const xrt_core::device* /*_pDevice*/,
 
   printAlveoDevices(available_devices, _output);
   printRyzenDevices(available_devices, _output);
-
-  _output << "* Devices that are not ready will have reduced functionality when using XRT tools\n";
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
To prepare xbutil for production for Ryzen devices we are cleaning up ReportHost.

The device ID and device readiness options are not applicable to Ryzen and must be removed.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
No bugs/issues, just enhancements.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Implemented by modifying the Ryzen device list printout in ReportHost.

#### Risks (if any) associated the changes in the commit
None.

#### What has been tested and how, request additional testing if necessary
Ubuntu 22.04 with Ryzen device (simulated via a u55c)
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ xbutil examine
WARNING: Unexpected xocl version (2.16.0) was found. Expected 2.17.0, to match XRT tools.
System Configuration
  OS Name              : Linux
  Release              : 6.5.0-rc1+
  Version              : #10 SMP PREEMPT_DYNAMIC Wed Aug 16 22:28:12 PDT 2023
  Machine              : x86_64
  CPU Cores            : 16
  Memory               : 63990 MB
  Distribution         : Ubuntu 22.04 LTS
  GLIBC                : 2.35
  Model                : Precision 5820 Tower
  BIOS vendor          : Dell Inc.
  BIOS version         : 2.0.2

XRT
  Version              : 2.17.0
  Branch               : VITIS-11094
  Hash                 : 101f52fce69f04685d25d4711c39fbdc7ec45b01
  Hash Date            : 2024-01-09 14:27:19
  XOCL                 : 2.16.0, 893580509d3f7b0f1fab5a0da6210c709529a740
  XCLMGMT              : 2.16.0, 893580509d3f7b0f1fab5a0da6210c709529a740

Devices present
BDF             :  Name
----------------------------------------------------
[0000:04:00.1]  :  xilinx_u55c_gen3x16_xdma_base_3
```

#### Documentation impact (if any)
None