### PR TITLE
VITIS-11095 ReportPlatform Upgrade

### DIFF
--- a/src/runtime_src/core/tools/common/reports/platform/ReportRyzenPlatform.cpp
+++ b/src/runtime_src/core/tools/common/reports/platform/ReportRyzenPlatform.cpp
@@ -57,7 +57,7 @@ ReportRyzenPlatform::writeReport(const xrt_core::device* /*_pDevice*/,
       _output << std::endl << "Clocks" << std::endl;
       for (const auto& kc : clocks) {
         const boost::property_tree::ptree& pt_clock = kc.second;
-        std::string clock_name_type = pt_clock.get<std::string>("id") + " (" + pt_clock.get<std::string>("description") + ")";
+        std::string clock_name_type = pt_clock.get<std::string>("id");
         _output << boost::format("  %-23s: %3s MHz\n") % clock_name_type % pt_clock.get<std::string>("freq_mhz");
       }
     }


### PR DESCRIPTION
#### Problem solved by the commit
https://jira.xilinx.com/browse/VITIS-11095 Update ReportRyzenPlatform Output
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Remove (System) from next to clock name, as it was misleading
#### How problem was solved, alternative solutions (if any) and why they were rejected
Removed clock description from printout in ReportRyzenPlatform.
#### Risks (if any) associated the changes in the commit
Report Output Change.
#### What has been tested and how, request additional testing if necessary
```
---------------------------------------------------
[0000:65:00.1] : xilinx_vck5000_gen4x8_qdma_base_2
---------------------------------------------------
Platform
  Name                   : xilinx_vck5000_gen4x8_qdma_base_2 
  Performance Mode       : not supported



Clocks
  DATA_CLK               : 250 MHz
  KERNEL_CLK             : 500 MHz
```
Above output is using vck5000, but the printout changes will be reflected for Ryzen. Test on Ryzen.
Below output is to show output on Alveo (clocks still have description next to them here).
```
---------------------------------------------------
[0000:65:00.1] : xilinx_vck5000_gen4x8_qdma_base_2
---------------------------------------------------
Platform
  XSA Name               : xilinx_vck5000_gen4x8_qdma_base_2 
  Logic UUID             : 05DCA096-76CB-730B-8D19-EC1192FBAE3F 
  FPGA Name              :  
  JTAG ID Code           : 0x0 
  DDR Size               : 0 Bytes
  DDR Count              : 0 
  Revision               : 1 
  MFG Date               : 0xcee875 
  Mig Calibrated         : false 
  P2P Status             : not supported 

Clocks
  DATA_CLK (Data)        : 250 MHz
  KERNEL_CLK (Kernel)    : 500 MHz

Mac Addresses            : 00:0A:35:0D:55:8E
                         : 00:0A:35:0D:55:8F
rchane@xsjrchane50:/proj/rdi/staff/rchane/XRT$ xbutil examine -d b3:00 -r platform
WARNING: Unexpected xocl version (2.17.97) was found. Expected 2.17.0, to match XRT tools.

-------------------------------------------------
[0000:b3:00.1] : xilinx_u200_gen3x16_xdma_base_2
-------------------------------------------------
Platform
  XSA Name               : xilinx_u200_gen3x16_xdma_base_2 
  Logic UUID             : 0B095B81-FA2B-E6BD-4524-72B1C1474F18 
  FPGA Name              :  
  JTAG ID Code           : 0x14b37093 
  DDR Size               : 0 Bytes
  DDR Count              : 0 
  Mig Calibrated         : true 
  P2P Status             : disabled 
  P2P IO space required  : 128 GB

Clocks
  DATA_CLK (Data)        : 300 MHz
  KERNEL_CLK (Kernel)    : 500 MHz

Mac Addresses            : 00:0A:35:05:C2:96
```
#### Documentation impact (if any)
Report Output Change.