### PR TITLE
VITIS-11103 Hide driver hash if not present

### DIFF
--- a/src/runtime_src/core/tools/common/reports/ReportHost.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportHost.cpp
@@ -143,8 +143,12 @@ ReportHost::writeReport(const xrt_core::device* /*_pDevice*/,
       const boost::property_tree::ptree& driver = drv.second;
       std::string drv_name = driver.get<std::string>("name", "N/A");
       boost::algorithm::to_upper(drv_name);
-      _output << boost::format("  %-20s : %s, %s\n") % drv_name
-          % driver.get<std::string>("version", "N/A") % driver.get<std::string>("hash", "N/A");
+      std::string drv_hash = driver.get<std::string>("hash", "N/A");
+      if (!boost::iequals(drv_hash, "N/A")) {
+        _output << boost::format("  %-20s : %s, %s\n") % drv_name
+            % driver.get<std::string>("version", "N/A") % driver.get<std::string>("hash", "N/A");
+      } else
+        _output << boost::format("  %-20s : %s\n") % drv_name % driver.get<std::string>("version", "N/A");
       if (boost::iequals(drv_name, "xclmgmt") && boost::iequals(driver.get<std::string>("version", "N/A"), "unknown"))
         _output << "WARNING: xclmgmt version is unknown. Is xclmgmt driver loaded? Or is MSD/MPD running?" << std::endl;
     }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/VITIS-11103
Windows drivers do not expose a git hash for display. We still want to display the driver version, but, not display "unknown" for the hash value.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Not a bug or issue.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Modified ReportHost to display the hash of a driver only if a value exists.

#### Risks (if any) associated the changes in the commit
None.

#### What has been tested and how, request additional testing if necessary
Ubuntu 22.04 U55c (Normal operation on Linux)
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ xbutil examine
WARNING: Unexpected xocl version (2.16.0) was found. Expected 2.17.0, to match XRT tools.
System Configuration
  OS Name              : Linux
  Release              : 6.5.0-rc1+
  Version              : #10 SMP PREEMPT_DYNAMIC Wed Aug 16 22:28:12 PDT 2023
  Machine              : x86_64
  CPU Cores            : 16
  Memory               : 63990 MB
  Distribution         : Ubuntu 22.04 LTS
  GLIBC                : 2.35
  Model                : Precision 5820 Tower
  BIOS vendor          : Dell Inc.
  BIOS version         : 2.0.2

XRT
  Version              : 2.17.0
  Branch               : VITIS-11103
  Hash                 : 101f52fce69f04685d25d4711c39fbdc7ec45b01
  Hash Date            : 2024-01-10 16:26:23
  XOCL                 : 2.16.0, 893580509d3f7b0f1fab5a0da6210c709529a740
  XCLMGMT              : 2.16.0, 893580509d3f7b0f1fab5a0da6210c709529a740

Devices present
BDF             :  Shell                            Logic UUID                            Device ID       Device Ready*
-------------------------------------------------------------------------------------------------------------------------
[0000:04:00.1]  :  xilinx_u55c_gen3x16_xdma_base_3  97088961-FEAE-DA91-52A2-1D9DFD63CCEF  user(inst=129)  Yes


* Devices that are not ready will have reduced functionality when using XRT tools
```

Windows MCDM Virtual Machine
```
Z:\XRT-MCDM\build\WDebug\xilinx\xrt>xbutil examine
System Configuration
  OS Name              : Windows NT
  Release              : 26016.rs_sigma_grfx_dev.231212-1700
  Version              : 6.3
  Machine              : x86_64
  CPU Cores            : 1
  Memory               : 2131 MB
  Distribution         : Windows Server 2022 Standard
  Model                : Virtual Machine
  BIOS vendor          : VRTUAL - 12001807
  BIOS version         : 2.3

XRT
  Version              : 2.17.0
  Branch               : HEAD
  Hash                 : a4d3aba39d68550c537a7e7b258d08351f794374
  Hash Date            : 2024-01-10 15:50:22
  IPUKMDDRV            : 10.1.0.1

Devices present
BDF             :  Name             Device ID     Device Ready*
-----------------------------------------------------------------
[0000:18:00.1]  :  RyzenAI-Phoenix  mgmt(inst=1)  Yes


* Devices that are not ready will have reduced functionality when using XRT tools
```

#### Documentation impact (if any)
None