### PR TITLE
VITIS-11093 Upgrade ReportAiePartitions

### DIFF
--- a/src/runtime_src/core/tools/common/reports/ReportAiePartitions.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportAiePartitions.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
 
 // ------ I N C L U D E   F I L E S -------------------------------------------
 // Local - Include Files
@@ -100,9 +100,8 @@ writeReport(const xrt_core::device* /*_pDevice*/,
     const std::vector<Table2D::HeaderData> table_headers = {
       {"Slot ID", Table2D::Justification::left},
       {"Xclbin UUID", Table2D::Justification::left},
-      {"Usage Count", Table2D::Justification::left},
-      {"Migration Count", Table2D::Justification::left},
-      {"Device BO Sync Count", Table2D::Justification::left}
+      {"Command Submissions", Table2D::Justification::left},
+      {"Migration Count", Table2D::Justification::left}
     };
     Table2D context_table(table_headers);
 
@@ -113,8 +112,7 @@ writeReport(const xrt_core::device* /*_pDevice*/,
         hw_context.get<std::string>("slot_id"),
         hw_context.get<std::string>("xclbin_uuid"),
         hw_context.get<std::string>("usage_count"),
-        hw_context.get<std::string>("migration_count"),
-        hw_context.get<std::string>("device_bo_sync_count")
+        hw_context.get<std::string>("migration_count")
       };
       context_table.addEntry(entry_data);
     }
@@ -150,7 +148,4 @@ writeReport(const xrt_core::device* /*_pDevice*/,
     }
     _output << boost::str(boost::format("%s\n") % verbose_table.toString("  "));
   }
-
-  _output << "\n";
 }
-


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
The aie partitions report displays information that is no longer relevant or misleading.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Drivers were changed, software should reflect what the driver is doing.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Rename usage metrics column to command submissions. Remove device BO metrics column.

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Windows MCDM Virtual Machine Build 26016
```
Z:\XRT-MCDM\build\WDebug\xilinx\xrt>xbutil examine -d -r aie-partitions
------------------------------------------------------------
                        EARLY ACCESS
        This release of xbutil contains early access
         experimental features which may have bugs.
------------------------------------------------------------

---------------------------------
[0000:18:00.1] : RyzenAI-Phoenix
---------------------------------
AIE Partitions
  Partition Index: 0
    Columns: [1]
    HW Contexts:
      Slot ID  Xclbin UUID                             Command Submissions  Migration Count
      ---------------------------------------------------------------------------------------
      4        {c186a256-edec-c7a3-9203-572944446cab}  0                    0
```

#### Documentation impact (if any)
None.