### PR TITLE
VITIS-11096 Add report name printout to ReportDynamicRegions

### DIFF
--- a/src/runtime_src/core/tools/common/reports/ReportDynamicRegion.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportDynamicRegion.cpp
@@ -46,6 +46,7 @@ ReportDynamicRegion::writeReport( const xrt_core::device* _pDevice,
   //check if a valid CU report is generated
   const boost::property_tree::ptree& pt_dfx = _pt.get_child("dynamic_regions", empty_ptree);
 
+  _output << "Dynamic Regions\n";
   const auto device_status = xrt_core::device_query_default<xrt_core::query::device_status>(_pDevice, 2);
   _output << boost::format("  Device Status: %s\n") % xrt_core::query::device_status::parse_status(device_status);
   if(pt_dfx.empty()) {


### PR DESCRIPTION
#### Problem solved by the commit
https://jira.xilinx.com/browse/VITIS-11096
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Report Name was missing in printout.
#### How problem was solved, alternative solutions (if any) and why they were rejected
Added report name.
#### Risks (if any) associated the changes in the commit
N/A
#### What has been tested and how, request additional testing if necessary
```
---------------------------------------------------
[0000:65:00.1] : xilinx_vck5000_gen4x8_qdma_base_2
---------------------------------------------------
Dynamic Regions
  Device Status: HEALTHY
  Hardware Context ID: 0
    Xclbin UUID: 61DD9C55-CD60-FEBA-9754-15C04EF77D60
    PL Compute Units
      Index  Name                               Base Address   Usage  Status             
      -----------------------------------------------------------------------------------
      0      pl_controller_kernel:controller_1  0x20200010000  1      (DONE|IDLE|READY)  
      1      sender_receiver:sender_receiver_1  0x20200020000  1      (DONE|IDLE|READY)  
```
#### Documentation impact (if any)
Report Output Change.
