### PR TITLE
VITIS-11097 Update AIE Reports

### DIFF
--- a/src/runtime_src/core/tools/common/reports/ReportAie.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportAie.cpp
@@ -129,10 +129,10 @@ writeReport(const xrt_core::device* /*_pDevice*/,
     }
   }
 
-  _output << "Aie\n";
+  _output << "AIE\n";
   // validate and print aie metadata by checking schema_version node
   if (!_pt.get_child_optional("aie_metadata.schema_version")) {
-    _output << "  <AIE information is not available>" << std::endl << std::endl;
+    _output << "  <AIE information unavailable>" << std::endl << std::endl;
     return;
   }
 

--- a/src/runtime_src/core/tools/common/reports/ReportAie.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportAie.cpp
@@ -132,7 +132,7 @@ writeReport(const xrt_core::device* /*_pDevice*/,
   _output << "AIE\n";
   // validate and print aie metadata by checking schema_version node
   if (!_pt.get_child_optional("aie_metadata.schema_version")) {
-    _output << "  <Information unavailable>" << std::endl << std::endl;
+    _output << "  No AIE columns are active on the device" << std::endl << std::endl;
     return;
   }
 

--- a/src/runtime_src/core/tools/common/reports/ReportAie.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportAie.cpp
@@ -132,7 +132,7 @@ writeReport(const xrt_core::device* /*_pDevice*/,
   _output << "AIE\n";
   // validate and print aie metadata by checking schema_version node
   if (!_pt.get_child_optional("aie_metadata.schema_version")) {
-    _output << "  <AIE information unavailable>" << std::endl << std::endl;
+    _output << "  <Information unavailable>" << std::endl << std::endl;
     return;
   }
 

--- a/src/runtime_src/core/tools/common/reports/ReportAieMem.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportAieMem.cpp
@@ -67,7 +67,7 @@ writeReport(const xrt_core::device* /*_pDevice*/,
   const boost::property_tree::ptree ptMemTiles = _pt.get_child("aie_mem_status.tiles", empty_ptree);
 
   if (ptMemTiles.empty()) {
-    _output << "  <Information unavailable>" << std::endl << std::endl;
+    _output << "  No AIE columns are active on the device" << std::endl << std::endl;
     return;
   }
 

--- a/src/runtime_src/core/tools/common/reports/ReportAieMem.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportAieMem.cpp
@@ -50,7 +50,7 @@ writeReport(const xrt_core::device* /*_pDevice*/,
   boost::property_tree::ptree empty_ptree;
   std::vector<std::string> aieTileList;
 
-  _output << "AIE\n";
+  _output << "AIE Memory\n";
 
   // Loop through all the parameters given under _elementsFilter i.e. -e option
   for (auto it = _elementsFilter.begin(); it != _elementsFilter.end(); ++it) {
@@ -67,7 +67,7 @@ writeReport(const xrt_core::device* /*_pDevice*/,
   const boost::property_tree::ptree ptMemTiles = _pt.get_child("aie_mem_status.tiles", empty_ptree);
 
   if (ptMemTiles.empty()) {
-    _output << "  <AIE Mem tiles information unavailable>" << std::endl << std::endl;
+    _output << "  <AIE information unavailable>" << std::endl << std::endl;
     return;
   }
 

--- a/src/runtime_src/core/tools/common/reports/ReportAieMem.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportAieMem.cpp
@@ -67,7 +67,7 @@ writeReport(const xrt_core::device* /*_pDevice*/,
   const boost::property_tree::ptree ptMemTiles = _pt.get_child("aie_mem_status.tiles", empty_ptree);
 
   if (ptMemTiles.empty()) {
-    _output << "  <AIE information unavailable>" << std::endl << std::endl;
+    _output << "  <Information unavailable>" << std::endl << std::endl;
     return;
   }
 

--- a/src/runtime_src/core/tools/common/reports/ReportAiePartitions.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportAiePartitions.cpp
@@ -78,7 +78,7 @@ writeReport(const xrt_core::device* /*_pDevice*/,
   boost::property_tree::ptree empty_ptree;
   const boost::property_tree::ptree pt_partitions = _pt.get_child("aie_partitions.partitions", empty_ptree);
   if (pt_partitions.empty()) {
-    _output << "  AIE Partition information unavailable\n\n";
+    _output << "  No hardware contexts running on device\n\n";
     return;
   }
 

--- a/src/runtime_src/core/tools/common/reports/ReportAieShim.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportAieShim.cpp
@@ -65,7 +65,7 @@ ReportAieShim::writeReport(const xrt_core::device* /*_pDevice*/,
     const boost::property_tree::ptree ptShimTiles = _pt.get_child("aie_shim_status.tiles", empty_ptree);
 
     if (ptShimTiles.empty()) {
-      _output << "  <Information unavailable>" << std::endl << std::endl;
+      _output << "  No AIE columns are active on the device" << std::endl << std::endl;
       return;
     }
 

--- a/src/runtime_src/core/tools/common/reports/ReportAieShim.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportAieShim.cpp
@@ -47,7 +47,7 @@ ReportAieShim::writeReport(const xrt_core::device* /*_pDevice*/,
   boost::property_tree::ptree empty_ptree;
   std::vector<std::string> aieTileList;
 
-  _output << "AIE\n";
+  _output << "AIE Shim\n";
 
   // Loop through all the parameters given under _elementsFilter i.e. -e option
   for (auto it = _elementsFilter.begin(); it != _elementsFilter.end(); ++it) {

--- a/src/runtime_src/core/tools/common/reports/ReportAieShim.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportAieShim.cpp
@@ -65,7 +65,7 @@ ReportAieShim::writeReport(const xrt_core::device* /*_pDevice*/,
     const boost::property_tree::ptree ptShimTiles = _pt.get_child("aie_shim_status.tiles", empty_ptree);
 
     if (ptShimTiles.empty()) {
-      _output << "  <AIE information unavailable>" << std::endl << std::endl;
+      _output << "  <Information unavailable>" << std::endl << std::endl;
       return;
     }
 


### PR DESCRIPTION
#### Problem solved by the commit
https://jira.xilinx.com/browse/VITIS-11097
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Missing Info message for AIE/AIE-Mem/AIE-Shim should be consistent, properly display each report name in printout. 
#### How problem was solved, alternative solutions (if any) and why they were rejected
Did as described above. Also changed info message for AIE-Partitions to be more accurate.
#### Risks (if any) associated the changes in the commit
N/A
#### What has been tested and how, request additional testing if necessary
aie
```
---------------------------------------------------
[0000:65:00.1] : xilinx_vck5000_gen4x8_qdma_base_2
---------------------------------------------------
AIE
  No AIE columns are active on the device
```

aiemem
```
---------------------------------------------------
[0000:65:00.1] : xilinx_vck5000_gen4x8_qdma_base_2
---------------------------------------------------
AIE Memory
  No AIE columns are active on the device
```

aieshim
```
---------------------------------------------------
[0000:65:00.1] : xilinx_vck5000_gen4x8_qdma_base_2
---------------------------------------------------
AIE Shim
  No AIE columns are active on the device
```

aie-partitions
```
---------------------------------------------------
[0000:65:00.1] : xilinx_vck5000_gen4x8_qdma_base_2
---------------------------------------------------
AIE Partitions
  No hardware contexts running on device
```
These outputs were with vck5000, but will be reflected on Ryzen.
#### Documentation impact (if any)
Report Output Change.