### PR TITLE
VITIS-11098 Remove nonapplicable reports for Ryzen

### DIFF
--- a/src/runtime_src/core/tools/xbutil2/xbutil.cpp
+++ b/src/runtime_src/core/tools/xbutil2/xbutil.cpp
@@ -50,7 +50,7 @@ R"(
 },{
   "aie": [{
     "examine": [{
-      "report": ["dynamic-regions", "electrical", "host", "mechanical", "memory", "pcie-info", "platform", "thermal", "aie", "aiemem", "aieshim", "aie-partitions"]
+      "report": ["dynamic-regions", "electrical", "host", "memory", "platform", "aie", "aiemem", "aieshim", "aie-partitions"]
     }]
   },{
     "configure": [{


### PR DESCRIPTION
#### Problem solved by the commit
https://jira.xilinx.com/browse/VITIS-11098
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
After xbutil meeting with Ravinder/team, decided to remove mechanical, thermal, and pcie-info reports for Ryzen.
#### How problem was solved, alternative solutions (if any) and why they were rejected
The 3 reports were removed from the "aie" section in config json.
#### Risks (if any) associated the changes in the commit
Changes supported reports for "aie" section in config json.
#### What has been tested and how, request additional testing if necessary
```
rchane@xsjrchane50:/proj/rdi/staff/rchane/XRT/build/Debug/runtime_src/core/tools/xbutil2$ ./xbutil2 examine --help
WARNING: Unexpected xocl version (2.17.97) was found. Expected 2.17.0, to match XRT tools.

COMMAND: examine

DESCRIPTION: This command will 'examine' the state of the system/device and will generate a report of interest
               in a text or JSON format.

USAGE: xbutil examine [--help] [-d arg] [-f arg] [-o arg] [-r arg]

OPTIONS:
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest
  -f, --format       - Report output format. Valid values are:
                         JSON        - Latest JSON schema
                         JSON-2020.2 - JSON 2020.2 schema
  -o, --output       - Direct the output to the given file
  --help             - Help to use this sub-command
  -r, --report       - The type of report to be produced. Reports currently available are:
                       Common:
                         all             - All known reports are produced
                         dynamic-regions - Information about the xclbin and the compute units
                         electrical      - Electrical and power sensors present on the device
                         host            - Host information
                         memory          - Memory information present on the device
                         platform        - Platforms flashed on the device
                       AIE:
                         aie             - AIE metadata in xclbin
                         aie-partitions  - AIE partition information
                         aiemem          - AIE memory tile information
                         aieshim         - AIE shim tile status
                       Alveo:
                         debug-ip-status - Status of Debug IPs present in xclbin loaded on device
                         error           - Asyncronus Error present on the device
                         firewall        - Firewall status
                         mailbox         - Mailbox metrics of the device
                         mechanical      - Mechanical sensors on and surrounding the device
                         pcie-info       - Pcie information of the device
                         qspi-status     - QSPI write protection status
                         thermal         - Thermal sensors present on the device


GLOBAL OPTIONS:
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
```
#### Documentation impact (if any)
Report Output Change.
