### PR TITLE
VITIS-10805 update xbutil val to pick up the new changes

### DIFF
--- a/src/runtime_src/core/tools/common/tests/TestIPU.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestIPU.cpp
@@ -19,17 +19,18 @@ static constexpr size_t buffer_size = 128;
 TestIPU::TestIPU()
   : TestRunner("verify", 
                 "Run 'Hello World' test on IPU",
-                "validate_phx.xclbin"){}
+                "validate.xclbin"
+              ){}
 
 boost::property_tree::ptree
 TestIPU::run(std::shared_ptr<xrt_core::device> dev)
 {
   boost::property_tree::ptree ptree = get_test_header();
 
-  auto device_name = xrt_core::device_query_default<xrt_core::query::rom_vbnv>(dev, "");
-  if (device_name.find("RyzenAI-Strix") != std::string::npos) {
-    ptree.put("xclbin", "validate_stx.xclbin");
-  }
+  auto device_id = xrt_core::query::pcie_device::to_string(xrt_core::device_query<xrt_core::query::pcie_device>(dev));
+  std::filesystem::path xpath{device_id};
+  xpath /= m_xclbin;
+  ptree.put("xclbin", xpath.string());
 
   auto xclbin_path = findXclbinPath(dev, ptree);
   if (!std::filesystem::exists(xclbin_path)) {

--- a/src/runtime_src/core/tools/common/tests/TestTCTOneColumn.h
+++ b/src/runtime_src/core/tools/common/tests/TestTCTOneColumn.h
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+
+#ifndef __TestTCTOneColumn_h_
+#define __TestTCTOneColumn_h_
+
+#include "tools/common/TestRunner.h"
+#include "xrt/xrt_device.h"
+
+class TestTCTOneColumn : public TestRunner {
+  public:
+    boost::property_tree::ptree run(std::shared_ptr<xrt_core::device> dev);
+
+  public:
+    TestTCTOneColumn();
+
+  //variables
+  private:
+    std::string m_dpu_name;
+};
+
+#endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -34,6 +34,7 @@
 #include "tools/common/tests/TestPsVerify.h"
 #include "tools/common/tests/TestPsIops.h"
 #include "tools/common/tests/TestDF_bandwidth.h"
+#include "tools/common/tests/TestTCTOneColumn.h"
 namespace XBU = XBUtilities;
 
 // 3rd Party Library - Include Files
@@ -98,7 +99,8 @@ std::vector<std::shared_ptr<TestRunner>> testSuite = {
   std::make_shared<TestPsPlVerify>(),
   std::make_shared<TestPsVerify>(),
   std::make_shared<TestPsIops>(),
-  std::make_shared<TestDF_bandwidth>()
+  std::make_shared<TestDF_bandwidth>(),
+  std::make_shared<TestTCTOneColumn>()
 };
 
 /*

--- a/src/runtime_src/core/tools/xbutil2/xbutil.cpp
+++ b/src/runtime_src/core/tools/xbutil2/xbutil.cpp
@@ -62,7 +62,7 @@ R"(
     }]
   },{
     "validate": [{
-      "test": ["verify", "df-bw"]
+      "test": ["verify", "df-bw", "tct-one-col"]
     }]
   }]
 }]


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
- Changes to existing tests to pick up new xclbins and dpu sequences
- Changes to existing test to find xclbin based on device_id
- Added TCT one column test

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit
- The pipeline needs to upload the xclbins and sequences to the artifactory from where the driverStore needs to pick up and place the files in the correct location
- Currently I have device-id subfolder as "0x1234". This might change

#### What has been tested and how, request additional testing if necessary
Tested on Windows (phx):
```
>xbutil validate -d 00c3:00:01.1 -r tct-one-col
------------------------------------------------------------
                        EARLY ACCESS
        This release of xbutil contains early access
         experimental features which may have bugs.
------------------------------------------------------------
Validate Device           : [00c3:00:01.1]
    Platform              : N/A
-------------------------------------------------------------------------------
Verbose: Enabling Verbosity
Test 1 [00c3:00:01.1]     : tct-one-col
    Description           : Measure average TCT processing time
    Xclbin                : C:\Users\Administrator\Desktop\xclbin\validate.xclbin
    Details               : Kernel name is 'DPU_PDI_0'
    DPU-Sequence          : C:\Users\Administrator\Desktop\test_dpu\tct_1col.txt
    Details               : Average latency: '3.3' us
                            Average TCT throughput: '298652.8' TCT/s
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Validation completed
```

#### Documentation impact (if any)
