### PR TITLE
VITIS-9658 Update SubCmdValidate

### DIFF
--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -269,28 +269,12 @@ run_test_suite_device( const std::shared_ptr<xrt_core::device>& device,
   std::cout << "-------------------------------------------------------------------------------" << std::endl;
 
   int test_idx = 0;
-  int black_box_tests_skipped = 0;
-  int black_box_tests_counter = 0;
 
   if (testObjectsToRun.size() == 1)
     XBU::setVerbose(true);// setting verbose true for single_case.
 
   for (std::shared_ptr<TestRunner> testPtr : testObjectsToRun) {
-
-    // Hack: Until we have an option in the tests to query SUPP/NOT SUPP
-    // we need to print the test description before running the test
-    auto is_black_box_test = [testPtr]() {
-      std::vector<std::string> black_box_tests = {"verify", "mem-bw", "iops", "vcu", "aie", "dma", "p2p", "ps-aie", "ps-pl-verify", "ps-verify", "ps-iops"};
-      auto test = testPtr->get_name();
-      return std::find(black_box_tests.begin(), black_box_tests.end(), test) != black_box_tests.end() ? true : false;
-    };
-
     auto bdf = xrt_core::device_query<xrt_core::query::pcie_bdf>(device);
-
-    if (is_black_box_test()) {
-        black_box_tests_counter++;
-        pretty_print_test_desc(testPtr->get_test_header(), test_idx, std::cout, xrt_core::query::pcie_bdf::to_string(bdf));
-    }
 
     boost::property_tree::ptree ptTest;
     try {
@@ -301,23 +285,14 @@ run_test_suite_device( const std::shared_ptr<xrt_core::device>& device,
     }
     ptDeviceTestSuite.push_back( std::make_pair("", ptTest) );
 
-    if (!is_black_box_test())
-      pretty_print_test_desc(ptTest, test_idx, std::cout, xrt_core::query::pcie_bdf::to_string(bdf));
-
+    pretty_print_test_desc(ptTest, test_idx, std::cout, xrt_core::query::pcie_bdf::to_string(bdf));
     pretty_print_test_run(ptTest, status, std::cout);
-
-    // consider only when testcase is part of black_box_tests.
-    if (is_black_box_test() && boost::equals(ptTest.get<std::string>("status", ""), test_token_skipped))
-      black_box_tests_skipped++;
 
     // If a test fails, don't test the remaining ones
     if (status == test_status::failed) {
       break;
     }
   }
-
-  if (black_box_tests_counter !=0 && black_box_tests_skipped == black_box_tests_counter)
-    status = test_status::failed;
 
   print_status(status, std::cout);
 


### PR DESCRIPTION
(Reopening due to updated GitHub workflow)
#### Problem solved by the commit
https://jira.xilinx.com/browse/VITIS-9658 Update SubCmdValidate
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
After porting of host code to Test*.cpp and using config JSON for validate, now removing the work-around code for black-box tests in validate.
#### How problem was solved, alternative solutions (if any) and why they were rejected
Removed black-box relevant code (and in the output, you won't see trailing test titles).
#### Risks (if any) associated the changes in the commit
Changes output of SubCmdValidate. Single test runs that used to be black-box that are skipped will show 'Validation completed' along with the verbose explanation instead of 'Validation failed', aligning with output of non-blackbox tests.
#### What has been tested and how, request additional testing if necessary
Tested locally on vck5000, u30, u200. Example Output Below.
```
rchane@xsjrchane50:/proj/rdi/staff/rchane/XRT$ xbutil validate -d 65:00 -r all
WARNING: Unexpected xocl version (2.16.0) was found. Expected 2.17.0, to match XRT tools.
***********************************************************
*        WARNING          WARNING          WARNING        *
*       SC version data missing. Upgrade your shell       *
***********************************************************
***********************************************************
*        WARNING          WARNING          WARNING        *
*       SC version data missing. Upgrade your shell       *
***********************************************************
***********************************************************
*        WARNING          WARNING          WARNING        *
*       SC version data missing. Upgrade your shell       *
***********************************************************
Validate Device           : [0000:65:00.1]
    Platform              : xilinx_vck5000_gen4x8_qdma_base_2
    SC Version            : 4.4.35
    Platform ID           : 05DCA096-76CB-730B-8D19-EC1192FBAE3F
-------------------------------------------------------------------------------
Test 1 [0000:65:00.1]     : pcie-link                                           
    Warning(s)            : Link is active
                            Please make sure that the device is plugged into Gen 4x8,
                            instead of Gen 3x8. Lower performance maybe experienced.
    Test Status           : [PASSED WITH WARNINGS]
-------------------------------------------------------------------------------
Test 2 [0000:65:00.1]     : sc-version                                          
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Test 3 [0000:65:00.1]     : verify                                              
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Test 4 [0000:65:00.1]     : dma                                                 
    Details               : Buffer size - '16 MB' Memory Tag - 'MC_NOC0'
                            Host -> PCIe -> FPGA write bandwidth = 6564.3 MB/s
                            Host <- PCIe <- FPGA read bandwidth = 6634.0 MB/s
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Test 5 [0000:65:00.1]     : iops                                                
    Details               : Overall Commands: 50000, IOPS: 390442 (verify)
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Test 6 [0000:65:00.1]     : mem-bw                                              
    Details               : Throughput (Type: DDR) (Bank count: 1) : 20892.4 MB/s
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Test 7 [0000:65:00.1]     : aie                                                 
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Validation completed, but with warnings. Please run the command '--verbose' option for more details

rchane@xsjrchane50:/proj/rdi/staff/rchane/XRT$ xbutil validate -d 65:00 -r all --verbose
WARNING: Unexpected xocl version (2.16.0) was found. Expected 2.17.0, to match XRT tools.
Verbose: Enabling Verbosity
***********************************************************
*        WARNING          WARNING          WARNING        *
*       SC version data missing. Upgrade your shell       *
***********************************************************
***********************************************************
*        WARNING          WARNING          WARNING        *
*       SC version data missing. Upgrade your shell       *
***********************************************************
***********************************************************
*        WARNING          WARNING          WARNING        *
*       SC version data missing. Upgrade your shell       *
***********************************************************
Validate Device           : [0000:65:00.1]
    Platform              : xilinx_vck5000_gen4x8_qdma_base_2
    SC Version            : 4.4.35
    Platform ID           : 05DCA096-76CB-730B-8D19-EC1192FBAE3F
-------------------------------------------------------------------------------
Test 1 [0000:65:00.1]     : aux-connection                                      

    Description           : Check if auxiliary power is connected
    Details               : Aux power connector is not available on this board
    Test Status           : [SKIPPED]
-------------------------------------------------------------------------------
Test 2 [0000:65:00.1]     : pcie-link                                           
    Description           : Check if PCIE link is active
    Warning(s)            : Link is active
                            Please make sure that the device is plugged into Gen 4x8,
                            instead of Gen 3x8. Lower performance maybe experienced.
    Test Status           : [PASSED WITH WARNINGS]
-------------------------------------------------------------------------------
Test 3 [0000:65:00.1]     : sc-version                                          
    Description           : Check if SC firmware is up-to-date
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Test 4 [0000:65:00.1]     : verify                                              
    Description           : Run 'Hello World' kernel test
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Test 5 [0000:65:00.1]     : dma                                                 
    Description           : Run dma test
    Details               : Buffer size - '16 MB' Memory Tag - 'MC_NOC0'
                            Host -> PCIe -> FPGA write bandwidth = 6570.0 MB/s
                            Host <- PCIe <- FPGA read bandwidth = 6639.1 MB/s
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Test 6 [0000:65:00.1]     : iops                                                
    Description           : Run scheduler performance measure test
    Details               : Overall Commands: 50000, IOPS: 389692 (verify)
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Test 7 [0000:65:00.1]     : mem-bw                                              
    Description           : Run 'bandwidth kernel' and check the throughput
    Details               : Throughput (Type: DDR) (Bank count: 1) : 20892.1 MB/s
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Test 8 [0000:65:00.1]     : p2p                                                 

    Description           : Run P2P test
    Details               : P2P config failed. P2P is not supported. Can't find P2P
                            BAR.
    Test Status           : [SKIPPED]
-------------------------------------------------------------------------------
Test 9 [0000:65:00.1]     : m2m                                                 

    Description           : Run M2M test
    Details               : M2M is not available
    Test Status           : [SKIPPED]
-------------------------------------------------------------------------------
Test 10 [0000:65:00.1]    : hostmem-bw                                          

    Description           : Run 'bandwidth kernel' when host memory is enabled
    Test Status           : [SKIPPED]
-------------------------------------------------------------------------------
Test 11 [0000:65:00.1]    : vcu                                                 

    Description           : Run decoder test
    Details               : Test not supported.
    Test Status           : [SKIPPED]
-------------------------------------------------------------------------------
Test 12 [0000:65:00.1]    : aie                                                 
    Description           : Run AIE PL test
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Validation completed, but with warnings
```