### PR TITLE
fixing crash in xbmgmt/xbutil examine

### DIFF
--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -281,20 +281,28 @@ XBUtilities::xrt_version_cmp(bool isUserDomain)
 }
 
 static std::shared_ptr<xrt_core::device>
-get_device_internal(int index, bool in_user_domain)
+get_device_internal(xrt_core::device::id_type index, bool in_user_domain)
 {
   static std::mutex mutex;
   std::lock_guard guard(mutex);
 
   if (in_user_domain) {
-    static std::vector<std::shared_ptr<xrt_core::device>> user_devices(xrt_core::get_total_devices(true).second, nullptr);
+    static std::vector<std::shared_ptr<xrt_core::device>> user_devices(xrt_core::get_total_devices(true).first, nullptr);
+  
+    if (user_devices.size() <= index )
+      throw std::runtime_error("no device present with index " + std::to_string(index));
+    
     if (!user_devices[index])
       user_devices[index] = xrt_core::get_userpf_device(index);
 
     return user_devices[index];
   }
 
-  static std::vector<std::shared_ptr<xrt_core::device>> mgmt_devices(xrt_core::get_total_devices(false).second, nullptr);
+  static std::vector<std::shared_ptr<xrt_core::device>> mgmt_devices(xrt_core::get_total_devices(false).first, nullptr);
+  
+  if (mgmt_devices.size() <= index )
+    throw std::runtime_error("no device present with index " + std::to_string(index));
+
   if (!mgmt_devices[index])
     mgmt_devices[index] = xrt_core::get_mgmtpf_device(index);
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
xbutil/xbmgmt examine is crashing with latest XRT. This happens only for golden images case.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://github.com/Xilinx/XRT/pull/7870 introduced this bug. Sprite caught this issue

#### How problem was solved, alternative solutions (if any) and why they were rejected
Fixed the newly added code. Throwing proper error message

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Verified the overall flow

#### Documentation impact (if any)
None