### PR TITLE
VITIS-10245 Prevent additional device creation instances

### DIFF
--- a/src/runtime_src/core/tools/common/tests/TestAiePl.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestAiePl.cpp
@@ -230,7 +230,7 @@ bool run_pl_controller_aie2(xrt::device device, xrt::uuid uuid, std::string aie_
 void
 TestAiePl::runTest(std::shared_ptr<xrt_core::device> dev, boost::property_tree::ptree& ptree)
 {
-  xrt::device device(dev->get_device_id());
+  xrt::device device(dev);
 
   const std::string test_path = findPlatformPath(dev, ptree);
   const std::string aie_control_file = "aie_control_config.json";

--- a/src/runtime_src/core/tools/common/tests/TestAiePs.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestAiePs.cpp
@@ -37,7 +37,7 @@ TestAiePs::run(std::shared_ptr<xrt_core::device> dev)
 void
 TestAiePs::runTest(std::shared_ptr<xrt_core::device> dev, boost::property_tree::ptree& ptree)
 {
-  xrt::device device(dev->get_device_id());
+  xrt::device device(dev);
 
   logger(ptree, "Details", "Test not supported.");
   ptree.put("status", test_token_skipped);

--- a/src/runtime_src/core/tools/common/tests/TestBandwidthKernel.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestBandwidthKernel.cpp
@@ -238,7 +238,7 @@ test_bandwidth_hbm(xrt::device device, std::vector<xrt::kernel> krnls, int num_k
 void
 TestBandwidthKernel::runTest(std::shared_ptr<xrt_core::device> dev, boost::property_tree::ptree& ptree)
 {
-  xrt::device device(dev->get_device_id());
+  xrt::device device(dev);
 
   const std::string test_path = findPlatformPath(dev, ptree);
   if (test_path.empty()) {

--- a/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.cpp
@@ -123,7 +123,7 @@ TestDF_bandwidth::run(std::shared_ptr<xrt_core::device> dev)
   auto kernelName = xkernel.get_name();
   logger(ptree, "Details", boost::str(boost::format("Kernel name is '%s'") % kernelName));
 
-  auto working_dev = xrt::device{dev->get_device_id()};
+  auto working_dev = xrt::device{dev};
   working_dev.register_xclbin(xclbin);
   xrt::hw_context hwctx{working_dev, xclbin.get_uuid()};
   xrt::kernel kernel{hwctx, kernelName};

--- a/src/runtime_src/core/tools/common/tests/TestHostMemBandwidthKernel.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestHostMemBandwidthKernel.cpp
@@ -56,7 +56,7 @@ TestHostMemBandwidthKernel::run(std::shared_ptr<xrt_core::device> dev)
 void
 TestHostMemBandwidthKernel::runTest(std::shared_ptr<xrt_core::device> dev, boost::property_tree::ptree& ptree)
 {
-  xrt::device device(dev->get_device_id());
+  xrt::device device(dev);
 
   const std::string test_path = findPlatformPath(dev, ptree);
   if (test_path.empty()) {

--- a/src/runtime_src/core/tools/common/tests/TestIPU.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestIPU.cpp
@@ -68,7 +68,7 @@ TestIPU::run(std::shared_ptr<xrt_core::device> dev)
   auto kernelName = xkernel.get_name();
   logger(ptree, "Details", boost::str(boost::format("Kernel name is '%s'") % kernelName));
 
-  auto working_dev = xrt::device{dev->get_device_id()};
+  auto working_dev = xrt::device{dev};
   working_dev.register_xclbin(xclbin);
   xrt::hw_context hwctx{working_dev, xclbin.get_uuid()};
   xrt::kernel kernel{hwctx, kernelName};

--- a/src/runtime_src/core/tools/common/tests/TestPsIops.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestPsIops.cpp
@@ -175,7 +175,7 @@ TestPsIops::runTest(std::shared_ptr<xrt_core::device> dev, boost::property_tree:
   ptree.put("status", test_token_skipped);
   return;
 
-  xrt::device device(dev->get_device_id());
+  xrt::device device(dev);
 
   const std::string test_path = findPlatformPath(dev, ptree);
   const std::vector<std::string> dependency_paths = findDependencies(test_path, m_xclbin);

--- a/src/runtime_src/core/tools/common/tests/TestPsPlVerify.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestPsPlVerify.cpp
@@ -41,7 +41,7 @@ TestPsPlVerify::runTest(std::shared_ptr<xrt_core::device> dev, boost::property_t
   const std::vector<std::string> dependency_paths = findDependencies(test_path, m_xclbin);
   bool flag_s = false;
 
-  xrt::device device(dev->get_device_id());
+  xrt::device device(dev);
 
   // Load dependency xclbins onto device if any
   for (const auto& path : dependency_paths) {

--- a/src/runtime_src/core/tools/common/tests/TestPsVerify.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestPsVerify.cpp
@@ -31,7 +31,7 @@ TestPsVerify::run(std::shared_ptr<xrt_core::device> dev)
 void
 TestPsVerify::runTest(std::shared_ptr<xrt_core::device> dev, boost::property_tree::ptree& ptree)
 {
-  xrt::device device(dev->get_device_id());
+  xrt::device device(dev);
 
   const std::string test_path = findPlatformPath(dev, ptree);
   const std::vector<std::string> dependency_paths = findDependencies(test_path, m_xclbin);

--- a/src/runtime_src/core/tools/common/tests/TestVerify.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestVerify.cpp
@@ -40,7 +40,7 @@ TestVerify::run(std::shared_ptr<xrt_core::device> dev)
 void
 TestVerify::runTest(std::shared_ptr<xrt_core::device> dev, boost::property_tree::ptree& ptree)
 {
-  xrt::device device(dev->get_device_id());
+  xrt::device device(dev);
 
   const std::string test_path = findPlatformPath(dev, ptree);
   if (test_path.empty()) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
XRT should only create one device instance and maintain is for the life of the application. The validation tests create additional device instances.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
This has been around for a while since we refactored the tests to contain the source executables.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Update the code to pass the device handle which prevents the construction of a new device,

#### Risks (if any) associated the changes in the commit
None.

#### What has been tested and how, request additional testing if necessary
Ubuntu 22.04 U55c
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov/XRT$ xbutil validate -d -r all
WARNING: Unexpected xocl version (2.16.0) was found. Expected 2.17.0, to match XRT tools.
Validate Device           : [0000:04:00.1]
    Platform              : xilinx_u55c_gen3x16_xdma_base_3
    SC Version            : 7.1.22
    Platform ID           : 97088961-FEAE-DA91-52A2-1D9DFD63CCEF
-------------------------------------------------------------------------------
Test 1 [0000:04:00.1]     : pcie-link                                           
    Warning(s)            : Link is active
                            Please make sure that the device is plugged into Gen 3x16,
                            instead of Gen 3x4. Lower performance maybe experienced.
    Test Status           : [PASSED WITH WARNINGS]
-------------------------------------------------------------------------------
Test 2 [0000:04:00.1]     : sc-version                                          
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Test 3 [0000:04:00.1]     : verify 
    Test Status           : [PASSED]                                            
-------------------------------------------------------------------------------
Test 4 [0000:04:00.1]     : dma 
    Details               : Buffer size - '16 MB' Memory Tag - 'HBM[0]'         
                            Host -> PCIe -> FPGA write bandwidth = 2971.8 MB/s
                            Host <- PCIe <- FPGA read bandwidth = 2563.3 MB/s
                            Buffer size - '16 MB' Memory Tag - 'HBM[1]'
                            Host -> PCIe -> FPGA write bandwidth = 2970.8 MB/s
                            Host <- PCIe <- FPGA read bandwidth = 2437.1 MB/s
                            Buffer size - '16 MB' Memory Tag - 'HBM[2]'
                            Host -> PCIe -> FPGA write bandwidth = 2971.8 MB/s
                            Host <- PCIe <- FPGA read bandwidth = 2491.9 MB/s
                            Buffer size - '16 MB' Memory Tag - 'HBM[3]'
                            Host -> PCIe -> FPGA write bandwidth = 2972.5 MB/s
                            Host <- PCIe <- FPGA read bandwidth = 2514.8 MB/s
                            Buffer size - '16 MB' Memory Tag - 'HBM[4]'
                            Host -> PCIe -> FPGA write bandwidth = 2971.9 MB/s
                            Host <- PCIe <- FPGA read bandwidth = 2496.5 MB/s
                            Buffer size - '16 MB' Memory Tag - 'HBM[5]'
                            Host -> PCIe -> FPGA write bandwidth = 2971.4 MB/s
                            Host <- PCIe <- FPGA read bandwidth = 2495.4 MB/s
                            Buffer size - '16 MB' Memory Tag - 'HBM[6]'
                            Host -> PCIe -> FPGA write bandwidth = 2970.7 MB/s
                            Host <- PCIe <- FPGA read bandwidth = 2434.7 MB/s
                            Buffer size - '16 MB' Memory Tag - 'HBM[7]'
                            Host -> PCIe -> FPGA write bandwidth = 2971.3 MB/s
                            Host <- PCIe <- FPGA read bandwidth = 2454.2 MB/s
                            Buffer size - '16 MB' Memory Tag - 'HBM[8]'
                            Host -> PCIe -> FPGA write bandwidth = 2972.9 MB/s
                            Host <- PCIe <- FPGA read bandwidth = 2485.7 MB/s
                            Buffer size - '16 MB' Memory Tag - 'HBM[9]'
                            Host -> PCIe -> FPGA write bandwidth = 2969.7 MB/s
                            Host <- PCIe <- FPGA read bandwidth = 2472.0 MB/s
                            Buffer size - '16 MB' Memory Tag - 'HBM[10]'
                            Host -> PCIe -> FPGA write bandwidth = 2970.2 MB/s
                            Host <- PCIe <- FPGA read bandwidth = 2490.4 MB/s
                            Buffer size - '16 MB' Memory Tag - 'HBM[11]'
                            Host -> PCIe -> FPGA write bandwidth = 2965.4 MB/s
                            Host <- PCIe <- FPGA read bandwidth = 2469.9 MB/s
                            Buffer size - '16 MB' Memory Tag - 'HBM[12]'
                            Host -> PCIe -> FPGA write bandwidth = 2970.9 MB/s
                            Host <- PCIe <- FPGA read bandwidth = 2598.0 MB/s
                            Buffer size - '16 MB' Memory Tag - 'HBM[13]'
                            Host -> PCIe -> FPGA write bandwidth = 2974.7 MB/s
                            Host <- PCIe <- FPGA read bandwidth = 2513.6 MB/s
                            Buffer size - '16 MB' Memory Tag - 'HBM[14]'
                            Host -> PCIe -> FPGA write bandwidth = 2973.1 MB/s
                            Host <- PCIe <- FPGA read bandwidth = 2473.3 MB/s
                            Buffer size - '16 MB' Memory Tag - 'HBM[15]'
                            Host -> PCIe -> FPGA write bandwidth = 2974.1 MB/s
                            Host <- PCIe <- FPGA read bandwidth = 2471.9 MB/s
                            Buffer size - '16 MB' Memory Tag - 'HBM[16]'
                            Host -> PCIe -> FPGA write bandwidth = 2973.5 MB/s
                            Host <- PCIe <- FPGA read bandwidth = 2473.3 MB/s
                            Buffer size - '16 MB' Memory Tag - 'HBM[17]'
                            Host -> PCIe -> FPGA write bandwidth = 2975.0 MB/s
                            Host <- PCIe <- FPGA read bandwidth = 2470.5 MB/s
                            Buffer size - '16 MB' Memory Tag - 'HBM[18]'
                            Host -> PCIe -> FPGA write bandwidth = 2977.5 MB/s
                            Host <- PCIe <- FPGA read bandwidth = 2546.4 MB/s
                            Buffer size - '16 MB' Memory Tag - 'HBM[19]'
                            Host -> PCIe -> FPGA write bandwidth = 2976.7 MB/s
                            Host <- PCIe <- FPGA read bandwidth = 2491.0 MB/s
                            Buffer size - '16 MB' Memory Tag - 'HBM[20]'
                            Host -> PCIe -> FPGA write bandwidth = 2976.2 MB/s
                            Host <- PCIe <- FPGA read bandwidth = 2545.7 MB/s
                            Buffer size - '16 MB' Memory Tag - 'HBM[21]'
                            Host -> PCIe -> FPGA write bandwidth = 2977.9 MB/s
                            Host <- PCIe <- FPGA read bandwidth = 2526.3 MB/s
                            Buffer size - '16 MB' Memory Tag - 'HBM[22]'
                            Host -> PCIe -> FPGA write bandwidth = 2976.8 MB/s
                            Host <- PCIe <- FPGA read bandwidth = 2468.6 MB/s
                            Buffer size - '16 MB' Memory Tag - 'HBM[23]'
                            Host -> PCIe -> FPGA write bandwidth = 2972.8 MB/s
                            Host <- PCIe <- FPGA read bandwidth = 2473.9 MB/s
                            Buffer size - '16 MB' Memory Tag - 'HBM[24]'
                            Host -> PCIe -> FPGA write bandwidth = 2977.5 MB/s
                            Host <- PCIe <- FPGA read bandwidth = 2497.5 MB/s
                            Buffer size - '16 MB' Memory Tag - 'HBM[25]'
                            Host -> PCIe -> FPGA write bandwidth = 2974.6 MB/s
                            Host <- PCIe <- FPGA read bandwidth = 2486.1 MB/s
                            Buffer size - '16 MB' Memory Tag - 'HBM[26]'
                            Host -> PCIe -> FPGA write bandwidth = 2974.6 MB/s
                            Host <- PCIe <- FPGA read bandwidth = 2501.9 MB/s
                            Buffer size - '16 MB' Memory Tag - 'HBM[27]'
                            Host -> PCIe -> FPGA write bandwidth = 2971.9 MB/s
                            Host <- PCIe <- FPGA read bandwidth = 2451.3 MB/s
                            Buffer size - '16 MB' Memory Tag - 'HBM[28]'
                            Host -> PCIe -> FPGA write bandwidth = 2976.1 MB/s
                            Host <- PCIe <- FPGA read bandwidth = 2483.5 MB/s
                            Buffer size - '16 MB' Memory Tag - 'HBM[29]'
                            Host -> PCIe -> FPGA write bandwidth = 2972.4 MB/s
                            Host <- PCIe <- FPGA read bandwidth = 2451.0 MB/s
                            Buffer size - '16 MB' Memory Tag - 'HBM[30]'
                            Host -> PCIe -> FPGA write bandwidth = 2972.3 MB/s
                            Host <- PCIe <- FPGA read bandwidth = 2486.5 MB/s
                            Buffer size - '16 MB' Memory Tag - 'HBM[31]'
                            Host -> PCIe -> FPGA write bandwidth = 2974.3 MB/s
                            Host <- PCIe <- FPGA read bandwidth = 2517.4 MB/s
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Test 5 [0000:04:00.1]     : iops 
    Details               : Overall Commands: 50000, IOPS: 437279 (verify)      
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Test 6 [0000:04:00.1]     : mem-bw 
    Details               : Throughput (Type: HBM) (Bank count: 1) : 12100.6 MB/s
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Test 7 [0000:04:00.1]     : p2p 
Test 8 [0000:04:00.1]     : vcu                                                 
Test 9 [0000:04:00.1]     : aie                                                 
Validation completed, but with warnings. Please run the command '--verbose' option for more details
```

Ubuntu 22.04 IPU
```
dbenusov@xlix-birman-29:/proj/rdi/staff/dbenusov/amd-aie-new$ xbutil validate -d -r verify
------------------------------------------------------------
                        EARLY ACCESS
        This release of xbutil contains early access
         experimental features which may have bugs.
------------------------------------------------------------
Validate Device           : [0000:c3:00.1]
    Platform              : RyzenAI-Phoenix
-------------------------------------------------------------------------------
Verbose: Enabling Verbosity
Test 1 [0000:c3:00.1]     : verify
    Description           : Run 'Hello World' kernel test
    Xclbin                : /opt/xilinx/xrt/amdaie/validate_phx.xclbin
    Details               : Kernel name is 'DPU_PDI_0'
                            Total duration: '1.5's
                            Average throughput: '6465.8' ops/s
                            Average latency: '154.7' us
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
```

#### Documentation impact (if any)
None