### PR TITLE
Remove drm_driver.gem_prime_mmap for Linux 6.6

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
@@ -541,7 +541,9 @@ static struct drm_driver mm_drm_driver = {
 	.fops				= &xocl_driver_fops,
 
 	.gem_prime_import_sg_table	= xocl_gem_prime_import_sg_table,
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0)
 	.gem_prime_mmap			= xocl_gem_prime_mmap,
+#endif
 
 	.prime_handle_to_fd		= drm_gem_prime_handle_to_fd,
 	.prime_fd_to_handle		= drm_gem_prime_fd_to_handle,
@@ -562,6 +564,9 @@ const struct drm_gem_object_funcs xocl_gem_object_funcs = {
         .vmap = xocl_gem_prime_vmap,
         .vunmap = xocl_gem_prime_vunmap,
         .export = drm_gem_prime_export,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
+        .mmap = xocl_gem_prime_mmap,
+#endif
 };
 #endif
 


### PR DESCRIPTION
The field `drm_driver.gem_prime_mmap` was removed in Linux 6.6. XRT GEM object uses the function table `drm_gem_object_funcs xocl_gem_object_funcs` which has a field for the mmap function. This field should point to `xocl_gem_prime_mmap` instead.

This is for xocl. The changes for zocl were done in 95db0f31aea965af192e0378c6bc9ea4eb1a6ca7. (by @ManojTakasi )

Details: https://github.com/torvalds/linux/commit/0adec22702d497385dbdc52abb165f379a00efba

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->

I could not test the kernel module. How can I test it?