### PR TITLE
VITIS-11106 Remove --device requirement for single device system

### DIFF
--- a/src/runtime_src/core/tools/common/XBMain.cpp
+++ b/src/runtime_src/core/tools/common/XBMain.cpp
@@ -4,6 +4,7 @@
 
 // ------ I N C L U D E   F I L E S -------------------------------------------
 // Local - Include Files
+#include "core/common/system.h"
 #include "SubCmd.h"
 #include "XBHelpMenusCore.h"
 #include "XBUtilitiesCore.h"
@@ -56,9 +57,10 @@ void  main_(int argc, char** argv,
   globalOptions.add(globalSubCmdOptions);
 
   // Hidden Options
+  const std::string device_default = xrt_core::get_total_devices(false).first == 1 ? "default" : "";
   po::options_description hiddenOptions("Hidden Options");
   hiddenOptions.add_options()
-    ("device,d",    boost::program_options::value<decltype(sDevice)>(&sDevice)->default_value("")->implicit_value("default"), "If specified with no BDF value and there is only 1 device, that device will be automatically selected.\n")
+    ("device,d",    boost::program_options::value<decltype(sDevice)>(&sDevice)->default_value(device_default)->implicit_value("default"), "If specified with no BDF value and there is only 1 device, that device will be automatically selected.\n")
     ("trace",       boost::program_options::bool_switch(&bTrace), "Enables code flow tracing")
     ("show-hidden", boost::program_options::bool_switch(&bShowHidden), "Shows hidden options and commands")
     ("subCmd",      po::value<std::string>(), "Command to execute")

--- a/src/runtime_src/doc/toc/xbmgmt.rst
+++ b/src/runtime_src/doc/toc/xbmgmt.rst
@@ -29,6 +29,8 @@ Currently supported ``xbmgmt`` commands are
     - ``xbmgmt program``
     - ``xbmgmt reset``
 
+**Note**: For applicable commands, if only one device is present on the system ``--device`` (or ``-d``) is not required. If more than one device is present in the system, ``--device`` (or ``-d``) is required.
+
 
 xbmgmt configure
 ~~~~~~~~~~~

--- a/src/runtime_src/doc/toc/xbutil.rst
+++ b/src/runtime_src/doc/toc/xbutil.rst
@@ -31,6 +31,8 @@ Currently supported ``xbutil`` commands are
     - ``xbutil configure``
     - ``xbutil reset``
 
+**Note**: For applicable commands, if only one device is present on the system ``--device`` (or ``-d``) is not required. If more than one device is present in the system, ``--device`` (or ``-d``) is required.
+
 
 xbutil program
 ~~~~~~~~~~~~~~


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
For single device systems like RyzenAI it is desirable to not have to specify `-d` or `--device`.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
New feature not a bug fix.

#### How problem was solved, alternative solutions (if any) and why they were rejected
When setting the default value for the device option, check if only one device is on the system. If yes, then allow the default value to be populated.

#### Risks (if any) associated the changes in the commit
Other commands may start to function differently. I tested with multiple commands and multiple device counts and everything should work smoothly, but, you never know.

#### What has been tested and how, request additional testing if necessary
Ubuntu 22.04 Multiple devices
```
dbenusov@xsjrchane50:/proj/rdi/staff/dbenusov$ xbutil examine
WARNING: Unexpected xocl version (2.17.97) was found. Expected 2.17.0, to match XRT tools.
System Configuration
  OS Name              : Linux
  Release              : 6.4.0-rc7
  Version              : #2 SMP PREEMPT_DYNAMIC Thu Jun 22 14:12:00 PDT 2023
  Machine              : x86_64
  CPU Cores            : 16
  Memory               : 46830 MB
  Distribution         : Ubuntu 22.04 LTS
  GLIBC                : 2.35
  Model                : Super Server
  BIOS vendor          : American Megatrends Inc.
  BIOS version         : 1.0a

XRT
  Version              : 2.17.0
  Branch               : VITIS-11106
  Hash                 : 862642c6e920f5d2d6a7dbf354c458da61a3bb77
  Hash Date            : 2024-01-23 10:13:08
  XOCL                 : 2.17.97, 22bb71bccc9038fe0bd434e4442f76f467da5351
  XCLMGMT              : 2.17.97, 22bb71bccc9038fe0bd434e4442f76f467da5351

Devices present
BDF             :  Shell                              Logic UUID                            Device ID       Device Ready*
---------------------------------------------------------------------------------------------------------------------------
[0000:17:00.1]  :  xilinx_u30_gen3x4_base_1           1B5FEB2A-91B6-818D-A3E8-D9867DE17DA0  user(inst=128)  Yes
[0000:18:00.1]  :  xilinx_u30_gen3x4_base_1           1B5FEB2A-91B6-818D-A3E8-D9867DE17DA0  user(inst=129)  Yes
[0000:65:00.1]  :  xilinx_vck5000_gen4x8_qdma_base_2  05DCA096-76CB-730B-8D19-EC1192FBAE3F  user(inst=130)  Yes
[0000:b3:00.1]  :  xilinx_u200_gen3x16_xdma_base_2    0B095B81-FA2B-E6BD-4524-72B1C1474F18  user(inst=131)  Yes


* Devices that are not ready will have reduced functionality when using XRT tools
dbenusov@xsjrchane50:/proj/rdi/staff/dbenusov$ xbutil examine -d -r platform
WARNING: Unexpected xocl version (2.17.97) was found. Expected 2.17.0, to match XRT tools.

ERROR: Multiple devices found. Please specify a single device using the --device option

List of available devices:
  [0000:17:00.1] : xilinx_u30_gen3x4_base_1
  [0000:18:00.1] : xilinx_u30_gen3x4_base_1
  [0000:65:00.1] : xilinx_vck5000_gen4x8_qdma_base_2
  [0000:b3:00.1] : xilinx_u200_gen3x16_xdma_base_2

dbenusov@xsjrchane50:/proj/rdi/staff/dbenusov$ xbutil examine -r platform
WARNING: Unexpected xocl version (2.17.97) was found. Expected 2.17.0, to match XRT tools.
ERROR: Please specify a device using --device option
 Available devices:
  [0000:17:00.1] : xilinx_u30_gen3x4_base_1
  [0000:18:00.1] : xilinx_u30_gen3x4_base_1
  [0000:65:00.1] : xilinx_vck5000_gen4x8_qdma_base_2
  [0000:b3:00.1] : xilinx_u200_gen3x16_xdma_base_2
```

Ubuntu 22.04 Single device
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov/XRT$ xbutil examine 
WARNING: Unexpected xocl version (2.16.0) was found. Expected 2.17.0, to match XRT tools.
System Configuration
  OS Name              : Linux
  Release              : 6.5.0-rc1+
  Version              : #10 SMP PREEMPT_DYNAMIC Wed Aug 16 22:28:12 PDT 2023
  Machine              : x86_64
  CPU Cores            : 16
  Memory               : 63990 MB
  Distribution         : Ubuntu 22.04 LTS
  GLIBC                : 2.35
  Model                : Precision 5820 Tower
  BIOS vendor          : Dell Inc.
  BIOS version         : 2.0.2

XRT
  Version              : 2.17.0
  Branch               : VITIS-11106
  Hash                 : 862642c6e920f5d2d6a7dbf354c458da61a3bb77
  Hash Date            : 2024-01-23 10:13:08
  XOCL                 : 2.16.0, 893580509d3f7b0f1fab5a0da6210c709529a740
  XCLMGMT              : 2.16.0, 893580509d3f7b0f1fab5a0da6210c709529a740

Devices present
BDF             :  Shell                            Logic UUID                            Device ID       Device Ready*  
-------------------------------------------------------------------------------------------------------------------------
[0000:04:00.1]  :  xilinx_u55c_gen3x16_xdma_base_3  97088961-FEAE-DA91-52A2-1D9DFD63CCEF  user(inst=129)  Yes            


* Devices that are not ready will have reduced functionality when using XRT tools
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov/XRT$ xbutil examine -d -r platform
WARNING: Unexpected xocl version (2.16.0) was found. Expected 2.17.0, to match XRT tools.

-------------------------------------------------
[0000:04:00.1] : xilinx_u55c_gen3x16_xdma_base_3
-------------------------------------------------
Platform
  XSA Name               : xilinx_u55c_gen3x16_xdma_base_3 
  Logic UUID             : 97088961-FEAE-DA91-52A2-1D9DFD63CCEF 
  FPGA Name              :  
  JTAG ID Code           : 0x14b7d093 
  DDR Size               : 0 Bytes
  DDR Count              : 0 
  Mig Calibrated         : true 
  P2P Status             : disabled 
  P2P IO space required  : 32 GB

Clocks
  DATA_CLK (Data)        : 300 MHz
  KERNEL_CLK (Kernel)    : 500 MHz
  hbm_aclk (System)      : 450 MHz

Mac Addresses            : 00:0A:35:0B:23:98
                         : 00:0A:35:0B:23:99
                         : 00:0A:35:0B:23:9A
                         : 00:0A:35:0B:23:9B
                         : 00:0A:35:0B:23:9C
                         : 00:0A:35:0B:23:9D
                         : 00:0A:35:0B:23:9E
                         : 00:0A:35:0B:23:9F

dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov/XRT$ xbutil examine -r platform
WARNING: Unexpected xocl version (2.16.0) was found. Expected 2.17.0, to match XRT tools.

-------------------------------------------------
[0000:04:00.1] : xilinx_u55c_gen3x16_xdma_base_3
-------------------------------------------------
Platform
  XSA Name               : xilinx_u55c_gen3x16_xdma_base_3 
  Logic UUID             : 97088961-FEAE-DA91-52A2-1D9DFD63CCEF 
  FPGA Name              :  
  JTAG ID Code           : 0x14b7d093 
  DDR Size               : 0 Bytes
  DDR Count              : 0 
  Mig Calibrated         : true 
  P2P Status             : disabled 
  P2P IO space required  : 32 GB

Clocks
  DATA_CLK (Data)        : 300 MHz
  KERNEL_CLK (Kernel)    : 500 MHz
  hbm_aclk (System)      : 450 MHz

Mac Addresses            : 00:0A:35:0B:23:98
                         : 00:0A:35:0B:23:99
                         : 00:0A:35:0B:23:9A
                         : 00:0A:35:0B:23:9B
                         : 00:0A:35:0B:23:9C
                         : 00:0A:35:0B:23:9D
                         : 00:0A:35:0B:23:9E
                         : 00:0A:35:0B:23:9F

```

Ubuntu 22.04 Alternate command Single Device
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov/XRT$ xbutil examine 
WARNING: Unexpected xocl version (2.16.0) was found. Expected 2.17.0, to match XRT tools.
System Configuration
  OS Name              : Linux
  Release              : 6.5.0-rc1+
  Version              : #10 SMP PREEMPT_DYNAMIC Wed Aug 16 22:28:12 PDT 2023
  Machine              : x86_64
  CPU Cores            : 16
  Memory               : 63990 MB
  Distribution         : Ubuntu 22.04 LTS
  GLIBC                : 2.35
  Model                : Precision 5820 Tower
  BIOS vendor          : Dell Inc.
  BIOS version         : 2.0.2

XRT
  Version              : 2.17.0
  Branch               : VITIS-11106
  Hash                 : 862642c6e920f5d2d6a7dbf354c458da61a3bb77
  Hash Date            : 2024-01-23 10:13:08
  XOCL                 : 2.16.0, 893580509d3f7b0f1fab5a0da6210c709529a740
  XCLMGMT              : 2.16.0, 893580509d3f7b0f1fab5a0da6210c709529a740

Devices present
BDF             :  Shell                            Logic UUID                            Device ID       Device Ready*  
-------------------------------------------------------------------------------------------------------------------------
[0000:04:00.1]  :  xilinx_u55c_gen3x16_xdma_base_3  97088961-FEAE-DA91-52A2-1D9DFD63CCEF  user(inst=129)  Yes            


* Devices that are not ready will have reduced functionality when using XRT tools
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov/XRT$ xbutil reset
WARNING: Unexpected xocl version (2.16.0) was found. Expected 2.17.0, to match XRT tools.
Performing 'HOT Reset' on '0000:04:00.1'
Are you sure you wish to proceed? [Y/n]: n
Action canceled.
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov/XRT$ xbutil reset -d
WARNING: Unexpected xocl version (2.16.0) was found. Expected 2.17.0, to match XRT tools.
Performing 'HOT Reset' on '0000:04:00.1'
Are you sure you wish to proceed? [Y/n]: n
Action canceled.
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov/XRT$ xbutil reset -d 04:00
WARNING: Unexpected xocl version (2.16.0) was found. Expected 2.17.0, to match XRT tools.
Performing 'HOT Reset' on '0000:04:00.1'
Are you sure you wish to proceed? [Y/n]: n
Action canceled.
```
#### Documentation impact (if any)
We should add into the docs that -d and --device are not needed if only one device is present on the system.