### PR TITLE
VITIS-11233 Add firmware version to Ryzen platform report

### DIFF
--- a/src/runtime_src/core/common/info_platform.cpp
+++ b/src/runtime_src/core/common/info_platform.cpp
@@ -396,10 +396,16 @@ add_firmware_info(const xrt_core::device* device, ptree_type& pt)
   ptree_type pt_firmware;
 
   const auto fw_ver = xrt_core::device_query_default<xq::firmware_version>(device, {0,0,0,0});
-  pt_firmware.add("major", fw_ver.major);
-  pt_firmware.add("minor", fw_ver.minor);
-  pt_firmware.add("patch", fw_ver.patch);
-  pt_firmware.add("build", fw_ver.build);
+  std::string version = "N/A";
+  if (fw_ver.major != 0 || fw_ver.minor != 0 || fw_ver.patch != 0 || fw_ver.build != 0) {
+    version = boost::str(boost::format("%u.%u.%u.%u")
+      % fw_ver.major % fw_ver.minor % fw_ver.patch % fw_ver.build);
+    pt_firmware.add("major", fw_ver.major);
+    pt_firmware.add("minor", fw_ver.minor);
+    pt_firmware.add("patch", fw_ver.patch);
+    pt_firmware.add("build", fw_ver.build);
+  }
+  pt_firmware.add("version", version);
 
   pt.put_child("firmware", pt_firmware);
 }

--- a/src/runtime_src/core/common/info_platform.cpp
+++ b/src/runtime_src/core/common/info_platform.cpp
@@ -390,6 +390,20 @@ add_mac_info(const xrt_core::device* device, ptree_type& pt)
   }
 }
 
+static void
+add_firmware_info(const xrt_core::device* device, ptree_type& pt)
+{
+  ptree_type pt_firmware;
+
+  const auto fw_ver = xrt_core::device_query_default<xq::firmware_version>(device, {0,0,0,0});
+  pt_firmware.add("major", fw_ver.major);
+  pt_firmware.add("minor", fw_ver.minor);
+  pt_firmware.add("patch", fw_ver.patch);
+  pt_firmware.add("build", fw_ver.build);
+
+  pt.put_child("firmware", pt_firmware);
+}
+
 void
 add_platform_info(const xrt_core::device* device, ptree_type& pt_platform_array)
 {
@@ -414,6 +428,9 @@ add_platform_info(const xrt_core::device* device, ptree_type& pt_platform_array)
     add_config_info(device, pt_platform);
     break;
   }
+  case xrt_core::query::device_class::type::ryzen:
+    add_firmware_info(device, pt_platform);
+    break;
   default:
     break;
   }

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -1556,7 +1556,7 @@ struct firmware_version : request
   };
 
   using result_type = struct data;
-  static const key_type key = key_type::aie_partition_info;
+  static const key_type key = key_type::firmware_version;
 
   virtual std::any
   get(const device* device) const = 0;

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -128,6 +128,8 @@ enum class key_type
   aie_tiles_status_info,
   aie_partition_info,
 
+  firmware_version,
+
   idcode,
   data_retention,
   sec_level,
@@ -1536,6 +1538,24 @@ struct aie_partition_info : request
   };
 
   using result_type = std::vector<struct data>;
+  static const key_type key = key_type::aie_partition_info;
+
+  virtual std::any
+  get(const device* device) const = 0;
+};
+
+// Retrieves the firmware version of the device.
+struct firmware_version : request
+{
+  struct data
+  {
+    uint32_t major;
+    uint32_t minor;
+    uint32_t patch;
+    uint32_t build;
+  };
+
+  using result_type = struct data;
   static const key_type key = key_type::aie_partition_info;
 
   virtual std::any

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -135,7 +135,7 @@ struct dev_info
   {
     switch (key) {
     case key_type::device_class:
-      return xrt_core::query::device_class::type::ryzen;
+      return xrt_core::query::device_class::type::alveo;
     default:
       throw query::no_such_key(key);
     }

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -135,7 +135,7 @@ struct dev_info
   {
     switch (key) {
     case key_type::device_class:
-      return xrt_core::query::device_class::type::alveo;
+      return xrt_core::query::device_class::type::ryzen;
     default:
       throw query::no_such_key(key);
     }

--- a/src/runtime_src/core/tools/common/reports/platform/ReportRyzenPlatform.cpp
+++ b/src/runtime_src/core/tools/common/reports/platform/ReportRyzenPlatform.cpp
@@ -49,6 +49,11 @@ ReportRyzenPlatform::writeReport(const xrt_core::device* /*_pDevice*/,
     const boost::property_tree::ptree& pt_static_region = pt_platform.get_child("static_region", empty_ptree);
     _output << boost::format("  %-23s: %s \n") % "Name" % pt_static_region.get<std::string>("name");
 
+    const boost::property_tree::ptree& pt_fw = pt_platform.get_child("firmware");
+    _output << boost::format("  %-23s: %u.%u.%u.%u\n") % "Firmware Version"
+      % pt_fw.get<uint32_t>("major") % pt_fw.get<uint32_t>("minor")
+      % pt_fw.get<uint32_t>("patch") % pt_fw.get<uint32_t>("build");
+
     const boost::property_tree::ptree& pt_status = pt_platform.get_child("status");
     _output << boost::format("  %-23s: %s \n") % "Performance Mode" % pt_status.get<std::string>("performance_mode");
 

--- a/src/runtime_src/core/tools/common/reports/platform/ReportRyzenPlatform.cpp
+++ b/src/runtime_src/core/tools/common/reports/platform/ReportRyzenPlatform.cpp
@@ -50,9 +50,7 @@ ReportRyzenPlatform::writeReport(const xrt_core::device* /*_pDevice*/,
     _output << boost::format("  %-23s: %s \n") % "Name" % pt_static_region.get<std::string>("name");
 
     const boost::property_tree::ptree& pt_fw = pt_platform.get_child("firmware");
-    _output << boost::format("  %-23s: %u.%u.%u.%u\n") % "Firmware Version"
-      % pt_fw.get<uint32_t>("major") % pt_fw.get<uint32_t>("minor")
-      % pt_fw.get<uint32_t>("patch") % pt_fw.get<uint32_t>("build");
+    _output << boost::format("  %-23s: %s\n") % "Firmware Version" % pt_fw.get<std::string>("version");
 
     const boost::property_tree::ptree& pt_status = pt_platform.get_child("status");
     _output << boost::format("  %-23s: %s \n") % "Performance Mode" % pt_status.get<std::string>("performance_mode");


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/VITIS-11103
Need to add firmware version output to Ryzen report.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
New feature! No bugs yet.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Add firmware version query and hooks into platform report.

#### Risks (if any) associated the changes in the commit
None.

#### What has been tested and how, request additional testing if necessary
It is expected that the default output values will be all zero. On an actual Ryzen device these values will be populated.

Ubuntu 22.04 U55C pretending to be a Ryzen device
With temporary firmware query definition
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ xbutil examine -d -r platform -o /tmp/test.json --force
WARNING: Unexpected xocl version (2.16.0) was found. Expected 2.17.0, to match XRT tools.

-------------------------------------------------
[0000:04:00.1] : xilinx_u55c_gen3x16_xdma_base_3
-------------------------------------------------
Platform
  Name                   : xilinx_u55c_gen3x16_xdma_base_3
  Firmware Version       : 1.2.3.4
  Performance Mode       : not supported

Clocks
  DATA_CLK               : 300 MHz
  KERNEL_CLK             : 500 MHz
  hbm_aclk               : 450 MHz

Successfully wrote the json file: /tmp/test.json
```
JSON output
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ cat /tmp/test.json
{
    "schema_version": {
        "schema": "JSON",
        "creation_date": "Wed Jan 24 20:48:09 2024 GMT"
    },
    "devices": [
        {
            "interface_type": "pcie",
            "device_id": "0000:04:00.1",
            "device_status": "HEALTHY",
            "platforms": [
                {
                    "static_region": {
                        "name": "xilinx_u55c_gen3x16_xdma_base_3"
                    },
                    "clocks": [
                        {
                            "id": "DATA_CLK",
                            "description": "Data",
                            "freq_mhz": "300"
                        },
                        {
                            "id": "KERNEL_CLK",
                            "description": "Kernel",
                            "freq_mhz": "500"
                        },
                        {
                            "id": "hbm_aclk",
                            "description": "System",
                            "freq_mhz": "450"
                        }
                    ],
                    "status": {
                        "performance_mode": "not supported"
                    },
                    "firmware": {
                        "major": "1",
                        "minor": "2",
                        "patch": "3",
                        "build": "4",
                        "version": "1.2.3.4"
                    }
                }
            ]
        }
    ]
}
```

Without temporary firmware query definition
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ xbutil examine -d -r platform -o /tmp/test.json --force
WARNING: Unexpected xocl version (2.16.0) was found. Expected 2.17.0, to match XRT tools.

-------------------------------------------------
[0000:04:00.1] : xilinx_u55c_gen3x16_xdma_base_3
-------------------------------------------------
Platform
  Name                   : xilinx_u55c_gen3x16_xdma_base_3
  Firmware Version       : N/A
  Performance Mode       : not supported

Clocks
  DATA_CLK               : 300 MHz
  KERNEL_CLK             : 500 MHz
  hbm_aclk               : 450 MHz

Successfully wrote the json file: /tmp/test.json
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ cat /tmp/test.json
{
    "schema_version": {
        "schema": "JSON",
        "creation_date": "Wed Jan 24 20:53:33 2024 GMT"
    },
    "devices": [
        {
            "interface_type": "pcie",
            "device_id": "0000:04:00.1",
            "device_status": "HEALTHY",
            "platforms": [
                {
                    "static_region": {
                        "name": "xilinx_u55c_gen3x16_xdma_base_3"
                    },
                    "clocks": [
                        {
                            "id": "DATA_CLK",
                            "description": "Data",
                            "freq_mhz": "300"
                        },
                        {
                            "id": "KERNEL_CLK",
                            "description": "Kernel",
                            "freq_mhz": "500"
                        },
                        {
                            "id": "hbm_aclk",
                            "description": "System",
                            "freq_mhz": "450"
                        }
                    ],
                    "status": {
                        "performance_mode": "not supported"
                    },
                    "firmware": {
                        "version": "N\/A"
                    }
                }
            ]
        }
    ]
}
```
#### Documentation impact (if any)
None