### PR TITLE
CR-1187827 Fix bad BDF not displaying list of device options

### DIFF
--- a/src/runtime_src/core/tools/common/SubCmdExamineInternal.cpp
+++ b/src/runtime_src/core/tools/common/SubCmdExamineInternal.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
 
 // ------ I N C L U D E   F I L E S -------------------------------------------
 // Local - Include Files
@@ -188,11 +188,7 @@ SubCmdExamineInternal::execute(const SubCmdOptions& _options) const
       else
         std::cout << "Device list" << std::endl;
 
-      for(auto& kd : dev_pt) {
-        const boost::property_tree::ptree& dev = kd.second;
-        const std::string note = dev.get<bool>("is_ready") ? "" : "NOTE: Device not ready for use";
-        std::cout << boost::format("  [%s] : %s %s\n") % dev.get<std::string>("bdf") % dev.get<std::string>("vbnv") % note;
-      }
+      std::cout << XBUtilities::str_available_devs(m_isUserDomain) << std::endl;
     }
   }
 

--- a/src/runtime_src/core/tools/common/XBMain.cpp
+++ b/src/runtime_src/core/tools/common/XBMain.cpp
@@ -1,19 +1,6 @@
-/**
- * Copyright (C) 2019-2022 Xilinx, Inc
- * Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2019-2022 Xilinx, Inc
+// Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
 
 // ------ I N C L U D E   F I L E S -------------------------------------------
 // Local - Include Files
@@ -148,11 +135,7 @@ void  main_(int argc, char** argv,
     // DRC: Are there multiple devices, if so then no default device can be found.
     if (available_devices.size() > 1) {
       std::cerr << "\nERROR: Multiple devices found. Please specify a single device using the --device option\n\n";
-      std::cerr << "List of available devices:" << std::endl;
-      for (auto &kd : available_devices) {
-        boost::property_tree::ptree& dev = kd.second;
-        std::cerr << boost::format("  [%s] : %s\n") % dev.get<std::string>("bdf") % dev.get<std::string>("vbnv");
-      }
+      std::cerr << XBUtilities::str_available_devs(isUserDomain) << std::endl;
 
       std::cout << std::endl;
       throw xrt_core::error(std::errc::operation_canceled);

--- a/src/runtime_src/core/tools/common/XBUtilities.h
+++ b/src/runtime_src/core/tools/common/XBUtilities.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2019-2022 Xilinx, Inc
-// Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
 
 #ifndef __XBUtilities_h_
 #define __XBUtilities_h_
@@ -59,6 +59,9 @@ namespace XBUtilities {
 
   boost::property_tree::ptree
   get_available_devices(bool inUserDomain);
+
+  std::string
+  str_available_devs(bool _inUserDomain);
 
    /**
    * get_axlf_section() - Get section from the file passed in


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Entering an invalid BDF or an index larger than the number of available devices causes xbutil to fail. The index issues causes a segfault.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Introduced in https://github.com/Xilinx/XRT/pull/7870
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ xbutil reset -d 1234
WARNING: Unexpected xocl version (2.16.0) was found. Expected 2.17.0, to match XRT tools.
/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt/bin/unwrapped/loader: line 61: 397202 Segmentation fault      (core dumped) "${XRT_PROG_UNWRAPPED}" "${XRT_LOADER_ARGS[@]}"
```

#### How problem was solved, alternative solutions (if any) and why they were rejected
Refactor available devices to use a single location to simplify the display of available devices.
Fix segfault by using correct device allocation function.

#### Risks (if any) associated the changes in the commit
Critical fix.

#### What has been tested and how, request additional testing if necessary
Ubuntu 22.04
Single Device
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ xbutil reset -d 1234:12:12.1
WARNING: Unexpected xocl version (2.16.0) was found. Expected 2.17.0, to match XRT tools.
ERROR: Specified device BDF '1234:12:12.1' not found
 Available devices:
  [0000:04:00.1] : xilinx_u55c_gen3x16_xdma_base_3

dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ xbutil reset -d 1234
WARNING: Unexpected xocl version (2.16.0) was found. Expected 2.17.0, to match XRT tools.
ERROR: Invalid BDF '1234'. Please spcify the BDF using 'DDDD:BB:DD.F' format
 Available devices:
  [0000:04:00.1] : xilinx_u55c_gen3x16_xdma_base_3

dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ xbutil reset -d 0
WARNING: Unexpected xocl version (2.16.0) was found. Expected 2.17.0, to match XRT tools.
ERROR: Invalid BDF '0'. Please spcify the BDF using 'DDDD:BB:DD.F' format
 Available devices:
  [0000:04:00.1] : xilinx_u55c_gen3x16_xdma_base_3

dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ xbutil reset -d 00:04
WARNING: Unexpected xocl version (2.16.0) was found. Expected 2.17.0, to match XRT tools.
ERROR: Specified device BDF '00:04' not found
 Available devices:
  [0000:04:00.1] : xilinx_u55c_gen3x16_xdma_base_3

dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ xbutil reset -d 00:04.1
WARNING: Unexpected xocl version (2.16.0) was found. Expected 2.17.0, to match XRT tools.
ERROR: Specified device BDF '00:04.1' not found
 Available devices:
  [0000:04:00.1] : xilinx_u55c_gen3x16_xdma_base_3

dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ xbutil reset -d 03:00
WARNING: Unexpected xocl version (2.16.0) was found. Expected 2.17.0, to match XRT tools.
ERROR: Specified device BDF '03:00' not found
 Available devices:
  [0000:04:00.1] : xilinx_u55c_gen3x16_xdma_base_3

dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ xbutil reset -d 04:00
WARNING: Unexpected xocl version (2.16.0) was found. Expected 2.17.0, to match XRT tools.
Performing 'HOT Reset' on '0000:04:00.1'
Are you sure you wish to proceed? [Y/n]: n
Action canceled.
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ xbutil reset -d 04:00.4
WARNING: Unexpected xocl version (2.16.0) was found. Expected 2.17.0, to match XRT tools.
ERROR: Specified device BDF '04:00.4' not found
 Available devices:
  [0000:04:00.1] : xilinx_u55c_gen3x16_xdma_base_3
```
Multiple Devices
```
dbenusov@xsjrchane50:/proj/rdi/staff/dbenusov$ xbutil examine -d
WARNING: Unexpected xocl version (2.17.97) was found. Expected 2.17.0, to match XRT tools.

ERROR: Multiple devices found. Please specify a single device using the --device option


 Available devices:
  [0000:17:00.1] : xilinx_u30_gen3x4_base_1
  [0000:18:00.1] : xilinx_u30_gen3x4_base_1
  [0000:65:00.1] : xilinx_vck5000_gen4x8_qdma_base_2
  [0000:b3:00.1] : xilinx_u200_gen3x16_xdma_base_2


dbenusov@xsjrchane50:/proj/rdi/staff/dbenusov$ xbutil examine -d 1234:567
WARNING: Unexpected xocl version (2.17.97) was found. Expected 2.17.0, to match XRT tools.
XRT build version: 2.17.0
Build hash: 862642c6e920f5d2d6a7dbf354c458da61a3bb77
Build date: 2024-01-24 13:57:24
Git branch: CR-1187827
PID: 42598
UID: 90228
[Wed Jan 24 22:05:42 2024 GMT]
HOST: xsjrchane50
EXE: /proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt/bin/unwrapped/xbutil2
[xbutil] ERROR: Specified device BDF '1234:567' not found
 Available devices:
  [0000:17:00.1] : xilinx_u30_gen3x4_base_1
  [0000:18:00.1] : xilinx_u30_gen3x4_base_1
  [0000:65:00.1] : xilinx_vck5000_gen4x8_qdma_base_2
  [0000:b3:00.1] : xilinx_u200_gen3x16_xdma_base_2

dbenusov@xsjrchane50:/proj/rdi/staff/dbenusov$ xbutil examine -d 123
WARNING: Unexpected xocl version (2.17.97) was found. Expected 2.17.0, to match XRT tools.
XRT build version: 2.17.0
Build hash: 862642c6e920f5d2d6a7dbf354c458da61a3bb77
Build date: 2024-01-24 13:57:24
Git branch: CR-1187827
PID: 42623
UID: 90228
[Wed Jan 24 22:05:45 2024 GMT]
HOST: xsjrchane50
EXE: /proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt/bin/unwrapped/xbutil2
[xbutil] ERROR: Invalid BDF '123'. Please spcify the BDF using 'DDDD:BB:DD.F' format
 Available devices:
  [0000:17:00.1] : xilinx_u30_gen3x4_base_1
  [0000:18:00.1] : xilinx_u30_gen3x4_base_1
  [0000:65:00.1] : xilinx_vck5000_gen4x8_qdma_base_2
  [0000:b3:00.1] : xilinx_u200_gen3x16_xdma_base_2

dbenusov@xsjrchane50:/proj/rdi/staff/dbenusov$ xbutil examine -d 123
WARNING: Unexpected xocl version (2.17.97) was found. Expected 2.17.0, to match XRT tools.
XRT build version: 2.17.0
Build hash: 1a16a62fd929cde1205c7eb1bd9fdfe9f6a8e31b
Build date: 2024-01-24 14:07:29
Git branch: CR-1187827
PID: 42669
UID: 90228
[Wed Jan 24 22:11:18 2024 GMT]
HOST: xsjrchane50
EXE: /proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt/bin/unwrapped/xbutil2
[xbutil] ERROR: Invalid BDF '123'. Please spcify the BDF using 'DDDD:BB:DD.F' format
 Available devices:
  [0000:17:00.1] : xilinx_u30_gen3x4_base_1
  [0000:18:00.1] : xilinx_u30_gen3x4_base_1
  [0000:65:00.1] : xilinx_vck5000_gen4x8_qdma_base_2
  [0000:b3:00.1] : xilinx_u200_gen3x16_xdma_base_2
```
#### Documentation impact (if any)
None