### PR TITLE
Fix incorrect return value for xclRead API

### DIFF
--- a/src/runtime_src/core/pcie/emulation/hw_emu/alveo_shim/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_emu/alveo_shim/shim.cxx
@@ -1430,7 +1430,7 @@ namespace xclhwemhal2 {
           //Note: Adding PF and BAR ID valuesas 0, Once original values are avaiaable they get replaced
           xclReadAddrKernelCtrl_RPC_CALL(xclReadAddrKernelCtrl,space,offset,hostBuf,size,0,0);
           PRINTENDFUNC;
-          return -1;
+          return size;
         }
        case XCL_ADDR_SPACE_DEVICE_CHECKER:
          {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
This commit returns the correct value for xclRead API for hw_emu flow. Initially it used to return -1 even on successful xclRead call when reading from XCL_ADDR_SPACE_DEVICE_PERFMON address space.  

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Returned the correct value from xclRead API when reading from XCL_ADDR_SPACE_DEVICE_PERFMON address space.

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
Tested build flow
Ran a test which calls xclRead API and checked the output files.

#### Documentation impact (if any)
NA
