### PR TITLE
Issue-7911 Fix clang issues with query requests

### DIFF
--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -941,7 +941,7 @@ struct device_status : request
       case 2:
         return "UNKNOWN";
       default:
-        throw xrt_core::system_error(EINVAL, "Invalid device status: " + status);
+        throw xrt_core::system_error(EINVAL, "Invalid device status: " + std::to_string(status));
     }
   }
 };
@@ -3435,7 +3435,7 @@ struct performance_mode : request
       case 3:
         return "High";
       default:
-        throw xrt_core::system_error(EINVAL, "Invalid performance status: " + status);
+        throw xrt_core::system_error(EINVAL, "Invalid performance status: " + std::to_string(status));
     }
   }
 };


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://github.com/Xilinx/XRT/issues/7911

Warnings are clogging up the compilation window for the Node.Ai team.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Introduced as two separate PRs: #7507 and #7682 

#### How problem was solved, alternative solutions (if any) and why they were rejected
Rather than appending number to a string (which does not work), convert it to a string. 

#### Risks (if any) associated the changes in the commit
None,

#### What has been tested and how, request additional testing if necessary
Compilation success on Ubuntu 22.04.

#### Documentation impact (if any)
None.