### PR TITLE
CR-1182298: Fixing seg fault on edge when aie_status is enabled

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.cpp
@@ -393,6 +393,8 @@ namespace xdp {
     if (!xrt_core::config::get_aie_status())
       return;
 
+    localDevice = xrt_core::get_userpf_device(handle);
+
     std::array<char, sysfs_max_path_length> pathBuf = {0};
     xclGetDebugIPlayoutPath(handle, pathBuf.data(), (sysfs_max_path_length-1) ) ;
     std::string sysfspath(pathBuf.data());
@@ -434,7 +436,7 @@ namespace xdp {
 
     // Create and register AIE status writer
     std::string filename = "aie_status_" + devicename + "_" + currentTime + ".json";
-    VPWriter* aieWriter = new AIEStatusWriter(filename.c_str(), devicename.c_str(), deviceID, hwGen);
+    VPWriter* aieWriter = new AIEStatusWriter(filename.c_str(), devicename.c_str(), deviceID, hwGen, localDevice);
     writers.push_back(aieWriter);
     db->getStaticInfo().addOpenedFile(aieWriter->getcurrentFileName(), "AIE_RUNTIME_STATUS");
 

--- a/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.cpp
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2021 Xilinx, Inc
- * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the

--- a/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.cpp
@@ -393,7 +393,7 @@ namespace xdp {
     if (!xrt_core::config::get_aie_status())
       return;
 
-    localDevice = xrt_core::get_userpf_device(handle);
+    mXrtCoreDevice = xrt_core::get_userpf_device(handle);
 
     std::array<char, sysfs_max_path_length> pathBuf = {0};
     xclGetDebugIPlayoutPath(handle, pathBuf.data(), (sysfs_max_path_length-1) ) ;
@@ -436,7 +436,7 @@ namespace xdp {
 
     // Create and register AIE status writer
     std::string filename = "aie_status_" + devicename + "_" + currentTime + ".json";
-    VPWriter* aieWriter = new AIEStatusWriter(filename.c_str(), devicename.c_str(), deviceID, hwGen, localDevice);
+    VPWriter* aieWriter = new AIEStatusWriter(filename.c_str(), devicename.c_str(), deviceID, hwGen, mXrtCoreDevice);
     writers.push_back(aieWriter);
     db->getStaticInfo().addOpenedFile(aieWriter->getcurrentFileName(), "AIE_RUNTIME_STATUS");
 

--- a/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.h
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2021 Xilinx, Inc
- * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -21,16 +21,16 @@
 #include <atomic>
 #include <boost/property_tree/ptree.hpp>
 #include <iostream>
+#include <memory>
 #include <string>
 #include <thread>
 #include <vector>
 
-#include "xdp/profile/plugin/vp_base/vp_base_plugin.h"
-#include "xdp/profile/database/static_info/aie_util.h"
-#include "xdp/profile/database/static_info/filetypes/base_filetype_impl.h"
-
 #include "core/common/device.h"
 #include "xaiefal/xaiefal.hpp"
+#include "xdp/profile/database/static_info/aie_util.h"
+#include "xdp/profile/database/static_info/filetypes/base_filetype_impl.h"
+#include "xdp/profile/plugin/vp_base/vp_base_plugin.h"
 
 extern "C" {
 #include <xaiengine.h>
@@ -64,6 +64,7 @@ namespace xdp {
     uint32_t mPollingInterval;
     boost::property_tree::ptree mAieMeta;
     std::unique_ptr<aie::BaseFiletypeImpl> filetype;
+    std::shared_ptr<xrt_core::device> localDevice;
 
     // Thread control flags for each device handle
     std::map<void*,std::atomic<bool>> mThreadCtrlMap;

--- a/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.h
@@ -64,7 +64,7 @@ namespace xdp {
     uint32_t mPollingInterval;
     boost::property_tree::ptree mAieMeta;
     std::unique_ptr<aie::BaseFiletypeImpl> filetype;
-    std::shared_ptr<xrt_core::device> localDevice;
+    std::shared_ptr<xrt_core::device> mXrtCoreDevice;
 
     // Thread control flags for each device handle
     std::map<void*,std::atomic<bool>> mThreadCtrlMap;

--- a/src/runtime_src/xdp/profile/writer/aie_status/aie_status_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/aie_status/aie_status_writer.cpp
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2021 Xilinx, Inc
- * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -26,25 +26,27 @@ namespace xdp {
    */
 
   AIEStatusWriter::AIEStatusWriter(const char* fileName,
-      const char* deviceName, uint64_t deviceIndex, int hwGen)
+                                   const char* deviceName,
+                                   uint64_t deviceIndex,
+                                   int hwGen,
+                                   std::shared_ptr<xrt_core::device> d)
     : VPWriter(fileName)
     , mDeviceName(deviceName)
     , mDeviceIndex(deviceIndex)
     , mHardwareGen(hwGen)
     , mWroteValidData(false)
+    , mXrtCoreDevice(d)
   {
   }
 
   bool AIEStatusWriter::write(bool openNewFile)
   {
-    auto xrtDevice = xrt::device((int)mDeviceIndex);
-    return writeDevice(openNewFile, xrtDevice);
+    return writeDevice(openNewFile, xrt::device(mXrtCoreDevice));
   }
 
   bool AIEStatusWriter::write(bool openNewFile, void* handle)
   {
-    auto xrtDevice = xrt::device(handle);
-    return writeDevice(openNewFile, xrtDevice);
+    return writeDevice(openNewFile, xrt::device(mXrtCoreDevice));
   }
 
   bool AIEStatusWriter::writeDevice(bool openNewFile, xrt::device xrtDevice)

--- a/src/runtime_src/xdp/profile/writer/aie_status/aie_status_writer.h
+++ b/src/runtime_src/xdp/profile/writer/aie_status/aie_status_writer.h
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2021 Xilinx, Inc
- * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -18,11 +18,13 @@
 #ifndef AIE_STATUS_WRITER_DOT_H
 #define AIE_STATUS_WRITER_DOT_H
 
-#include <string>
-#include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/json_parser.hpp>
-#include "xdp/profile/writer/vp_base/vp_writer.h"
+#include <boost/property_tree/ptree.hpp>
+#include <memory>
+#include <string>
+
 #include "core/include/xrt/xrt_kernel.h"
+#include "xdp/profile/writer/vp_base/vp_writer.h"
 
 namespace bpt = boost::property_tree;
 
@@ -35,7 +37,8 @@ namespace xdp {
   {
   public:
     AIEStatusWriter(const char* fileName, const char* deviceName,
-                    uint64_t deviceIndex, int hwGen);
+                    uint64_t deviceIndex, int hwGen,
+                    std::shared_ptr<xrt_core::device> d);
     ~AIEStatusWriter();
 
     virtual bool write(bool openNewFile);
@@ -50,6 +53,7 @@ namespace xdp {
     uint64_t mDeviceIndex;
     int mHardwareGen;
     bool mWroteValidData;
+    std::shared_ptr<xrt_core::device> mXrtCoreDevice;
   };
 
 } // end namespace xdp


### PR DESCRIPTION
#### Problem solved by the commit
A race condition involving the ordering of the AIE status polling thread and the destruction of the AIE status object when it held the last local copy of a shared pointer was causing a seg fault in some instances on Edge platforms.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
The AIE status plugin creates a thread to periodically poll the AIE as the application runs.  This provides us the capability of detecting when the AIE is hung as well as keeping track of execution over time.

The polling thread was creating an instance of a shared pointer to xrt_core::device every time it dumped to disk.  This lead to a condition at the end of execution where every other shared pointer to the xrt_core::device had already been reclaimed and the thread had the last pointer to the xrt_core::device.  When we joined this thread in our plugin destructor, it triggered the Shim destructor as no other shared pointer existed.  However, this led to problems as we recursively try to flush out any remaining data when the Shim destructor is called and this causes issues if we try to flush as we're in the process of finishing a flush operation.

The issue was discovered through regression testing.

#### How problem was solved, alternative solutions (if any) and why they were rejected
The aie_status plugin module now has a local copy of the shared_ptr to the xrt_core::device.  This way, the Shim will only be destroyed after the aie_status plugin has been destroyed instead of in the middle of the aie_status plugin destructor.  This guarantees that all the threads have already joined and there are no longer any race conditions.

As with all profiling, this plugin instance only exists if the user has actively enabled the profiling feature and it will not affect the execution when aie_status is turned off.

#### Risks (if any) associated the changes in the commit
Low risk as this replaces an already existing instance of the shared pointer with a different instance that is destroyed at a time when all the threads have already been joined.

#### What has been tested and how, request additional testing if necessary
The failing test case has been tested on vck190.

#### Documentation impact (if any)
No documentation impact