### PR TITLE
Update xbutil validate paths for xclbins

### DIFF
--- a/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.cpp
@@ -80,10 +80,16 @@ TestDF_bandwidth::run(std::shared_ptr<xrt_core::device> dev)
 {
   boost::property_tree::ptree ptree = get_test_header();
 
+  // workaround: can't rename files when copying to driver store
+  // so need to name the files as _phx and _stx
+  // will revisit this after the current release
   auto device_id = xrt_core::query::pcie_device::to_string(xrt_core::device_query<xrt_core::query::pcie_device>(dev));
-  std::filesystem::path xpath{device_id};
-  xpath /= m_xclbin;
-  ptree.put("xclbin", xpath.string());
+  if (device_id.compare("0x1502") == 0)
+    m_xclbin = "validate_phx.xclbin";
+  else if (device_id.compare("0x17f0") == 0)
+    m_xclbin = "validate_stx.xclbin";
+  ptree.put("xclbin", m_xclbin);
+
 
   auto xclbin_path = findXclbinPath(dev, ptree);
   if (!std::filesystem::exists(xclbin_path)) {

--- a/src/runtime_src/core/tools/common/tests/TestIPU.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestIPU.cpp
@@ -28,10 +28,15 @@ TestIPU::run(std::shared_ptr<xrt_core::device> dev)
 {
   boost::property_tree::ptree ptree = get_test_header();
 
+  // workaround: can't rename files when copying to driver store
+  // so need to name the files as _phx and _stx
+  // will revisit this after the current release
   auto device_id = xrt_core::query::pcie_device::to_string(xrt_core::device_query<xrt_core::query::pcie_device>(dev));
-  std::filesystem::path xpath{device_id};
-  xpath /= m_xclbin;
-  ptree.put("xclbin", xpath.string());
+  if (device_id.compare("0x1502") == 0)
+    m_xclbin = "validate_phx.xclbin";
+  else if (device_id.compare("0x17f0") == 0)
+    m_xclbin = "validate_stx.xclbin";
+  ptree.put("xclbin", m_xclbin);
 
   auto xclbin_path = findXclbinPath(dev, ptree);
   if (!std::filesystem::exists(xclbin_path)) {

--- a/src/runtime_src/core/tools/common/tests/TestTCTOneColumn.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestTCTOneColumn.cpp
@@ -77,10 +77,16 @@ TestTCTOneColumn::run(std::shared_ptr<xrt_core::device> dev)
 {
   boost::property_tree::ptree ptree = get_test_header();
 
+  // workaround: can't rename files when copying to driver store
+  // so need to name the files as _phx and _stx
+  // will revisit this after the current release
   auto device_id = xrt_core::query::pcie_device::to_string(xrt_core::device_query<xrt_core::query::pcie_device>(dev));
-  std::filesystem::path xpath{device_id};
-  xpath /= m_xclbin;
-  ptree.put("xclbin", xpath.string());
+  if (device_id.compare("0x1502") == 0)
+    m_xclbin = "validate_phx.xclbin";
+  else if (device_id.compare("0x17f0") == 0)
+    m_xclbin = "validate_stx.xclbin";
+  ptree.put("xclbin", m_xclbin);
+
 
   auto xclbin_path = findXclbinPath(dev, ptree);
   if (!std::filesystem::exists(xclbin_path)) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
For MCDM, we can't rename the xclbins back to validate.xclbin if the files are being placed in driverstore. So the <device-id>/validate.xclbin solution doesn't work. For the upcoming release, we need to revert back to doing the device check in xbutil

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
with current changes, xbutil validate skips saying "xclbin not found"

#### How problem was solved, alternative solutions (if any) and why they were rejected
Checking device id, and based on that, we set xclbin name

#### Risks (if any) associated the changes in the commit
none

#### What has been tested and how, request additional testing if necessary
tested on MCDM phoenix setup:
```
Test 1 [00c3:00:01.1]     : verify
    Description           : Run 'Hello World' test on IPU
    Xclbin                : C:\Windows\System32\DriverStore\FileRepository\ipukmddrv.inf_amd64_27240dcece074c72\validate_phx.xclbin
    Details               : Kernel name is 'DPU_PDI_0'
                            Total duration: '1.4's
                            Average throughput: '7241.1' ops/s
                            Average latency: '138.1' us
    Test Status           : [PASSED]
```

#### Documentation impact (if any)
N/A
