### PR TITLE
Fix windows build

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_trace/client/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/client/aie_trace.cpp
@@ -496,9 +496,6 @@ namespace xdp {
         && (event != XAIE_EVENT_EDGE_DETECTION_EVENT_1_MEM_TILE))
       return;
 
-    // AIE core register offsets
-    constexpr uint64_t AIE_OFFSET_EDGE_CONTROL_MEM_TILE = 0x94408;
-
     // Event is DMA_S2MM_Sel0_stream_starvation or DMA_MM2S_Sel0_stalled_lock
     uint16_t eventNum = isInputSet(type, metricSet)
         ? EVENT_MEM_TILE_DMA_S2MM_SEL0_STREAM_STARVATION


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Windows build is failing with a declaration error. This variable is declared in `tracedefs.h`

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
N/A

#### How problem was solved, alternative solutions (if any) and why they were rejected
N/A

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
By building on windows

#### Documentation impact (if any)
N/A
