### PR TITLE
VITIS-9706: xrt support for adf event apis

### DIFF
--- a/src/runtime_src/core/common/api/aie/xrt_graph.cpp
+++ b/src/runtime_src/core/common/api/aie/xrt_graph.cpp
@@ -130,7 +130,9 @@ public:
   {}
 
   ~profiling_impl()
-  {}
+  {
+    device->stop_profiling(profiling_hdl);
+  }
 
   handle 
   start_profiling(int option, const std::string& port1_name, const std::string& port2_name, uint32_t value)

--- a/src/runtime_src/core/common/api/aie/xrt_graph.cpp
+++ b/src/runtime_src/core/common/api/aie/xrt_graph.cpp
@@ -131,7 +131,12 @@ public:
 
   ~profiling_impl()
   {
-    device->stop_profiling(profiling_hdl);
+    try {
+      device->stop_profiling(profiling_hdl);
+    }
+    catch(...) {
+      // do nothing
+    }
   }
 
   handle 
@@ -379,7 +384,7 @@ namespace xrt { namespace aie {
 
 profiling::
 profiling(const xrt::device& device)
-  : impl(std::move(create_profiling_event(device)))
+  : detail::pimpl<profiling_impl>(std::move(create_profiling_event(device)))
 {}
 
 int 
@@ -388,7 +393,7 @@ start(xrt::aie::profiling::profiling_option option, const std::string& port1_nam
 {
   int opt = static_cast<int>(option);
   return xdp::native::profiling_wrapper("xrt::aie::profiling::start", [this, opt, &port1_name, &port2_name, value] {
-    return impl->start_profiling(opt, port1_name, port2_name, value);
+    return get_handle()->start_profiling(opt, port1_name, port2_name, value);
   });
 }
 
@@ -397,7 +402,7 @@ profiling::
 read() const
 {
   return xdp::native::profiling_wrapper("xrt::aie::profiling::read", [this] {
-    return impl->read_profiling();
+    return get_handle()->read_profiling();
   });
 }
 
@@ -406,7 +411,7 @@ profiling::
 stop() const
 {
   xdp::native::profiling_wrapper("xrt::aie::profiling::stop", [this] {
-    return impl->stop_profiling();
+    return get_handle()->stop_profiling();
   });
 }
 

--- a/src/runtime_src/core/common/ishim.h
+++ b/src/runtime_src/core/common/ishim.h
@@ -540,7 +540,7 @@ struct shim : public DeviceType
   stop_profiling(int phdl) override
   {
     if (auto ret = xclStopProfiling(DeviceType::get_device_handle(), phdl))
-      throw system_error(ret, "fail to wait gmio");
+      throw system_error(ret, "failed to stop profiling");
   }
 
   void

--- a/src/runtime_src/core/include/xrt/xrt_aie.h
+++ b/src/runtime_src/core/include/xrt/xrt_aie.h
@@ -168,7 +168,32 @@ class profiling_impl;
 class profiling : public detail::pimpl<profiling_impl>
 {
 public:
-  enum class profiling_option : int { io_total_stream_running_to_idle_cycles = 0, io_stream_start_to_bytes_transferred_cycles = 1, io_stream_start_difference_cycles = 2, io_stream_running_event_count = 3 };
+  
+  /**
+   * @enum profiliing_options - contains the enumerated options for performance
+   *				profiling using PLIO and GMIO objects.
+   *
+   * @var io_total_stream_running_to_idle_cycles
+   *   Total clock cycles in between the stream running event and the stream 
+   *   idle event of the stream port in the interface tile.
+   * @var io_stream_start_to_bytes_transferred_cycles
+   *   The clock cycles in between the first stream running event to the event that
+   *   the specified bytes are transferred through the stream port in the interface tile.
+   * @var io_stream_start_difference_cycles
+   *   The clock cycles elapsed between the first stream running events of
+   *   the two platform I/O objects.
+   * @var io_stream_running_event_count
+   *   Number of stream running events 
+   *   
+   * Please refer UG1079 for more details.
+   */
+  enum class profiling_option : int 
+  { 
+    io_total_stream_running_to_idle_cycles = 0, 
+    io_stream_start_to_bytes_transferred_cycles = 1,
+    io_stream_start_difference_cycles = 2,
+    io_stream_running_event_count = 3 
+  };
 
   profiling() = default;
 
@@ -194,6 +219,8 @@ public:
    * @param value
    *  The number of bytes to trigger the profiling event.
    *
+   * Please refer UG1079 for more details.
+   *
    * This function configures the performance counters in AI Engine by given
    * port names and value. The port names and value will have different
    * meanings on different options.
@@ -215,9 +242,6 @@ public:
    */
   void
   stop() const;
-
-private:
-  std::shared_ptr<profiling_impl> impl;
 };
 
 }} // aie, xrt

--- a/src/runtime_src/core/include/xrt/xrt_aie.h
+++ b/src/runtime_src/core/include/xrt/xrt_aie.h
@@ -168,14 +168,16 @@ class event
 {
 public:
 
-  event(const xrt::device& device, int option, const std::string& port1_name, const std::string& port2_name, uint32_t value);
+  event(const xrt::device& device);
+
+  int start_profiling(int option, const std::string& port1_name, const std::string& port2_name, uint32_t value) const;
 
   uint64_t read_profiling() const;
 
   void stop_profiling() const;
 
 private:
-    std::shared_ptr<event_impl> handle;
+    std::shared_ptr<event_impl> impl;
 };
 
 }} // aie, xrt
@@ -277,7 +279,7 @@ xrtAIEStartProfiling(xrtDeviceHandle handle, int option, const char *port1Name, 
 uint64_t
 xrtAIEReadProfiling(int pHandle);
 
-int
+void
 xrtAIEStopProfiling(int pHandle);
 /// @endcond
 

--- a/src/runtime_src/core/include/xrt/xrt_aie.h
+++ b/src/runtime_src/core/include/xrt/xrt_aie.h
@@ -163,29 +163,29 @@ public:
   }
 };
 
-class event_impl;
-class event 
+class profiling_impl;
+class profiling 
 {
 public:
-
+  enum class profiling_option : int { io_total_stream_running_to_idle_cycles = 0, io_stream_start_to_bytes_transferred_cycles = 1, io_stream_start_difference_cycles = 2, io_stream_running_event_count = 3 };
   /**
    * event() - Constructor from a device
    *
    * @param device
-   *  The device on which the profiling event should start
+   *  The device on which the profiling should start
    *
    */
-  event(const xrt::device& device);
+  profiling(const xrt::device& device);
 
   /**
-   * start_profiling() - Start AIE performance profiling
+   * start() - Start AIE performance profiling
    *
    * @param option
    *  Profiling option
    * @param port1_name
-   *  Profiling port 1 name.
+   *  PLIO/GMIO port 1 name.
    * @param port2_name
-   *  Profiling port 2 name.
+   *  PLIO/GMIO port 2 name.
    * @param value
    *  The number of bytes to trigger the profiling event.
    *
@@ -194,25 +194,25 @@ public:
    * meanings on different options.
    */
   int 
-  start_profiling(int option, const std::string& port1_name, const std::string& port2_name, uint32_t value) const;
+  start(profiling_option option, const std::string& port1_name, const std::string& port2_name, uint32_t value) const;
 
   /**
-   * read_profiling() - Read the current performance counter value
-   *                    associated with the profiling handle
+   * read() - Read the current performance counter value
+   *          associated with the profiling handle
    */
   uint64_t
-  read_profiling() const;
+  read() const;
 
   /**
-   * stop_profiling() - Stop the current performance profiling
-   *                    associated with the profiling handle and
-   *                    release the corresponding hardware resources.
+   * stop() - Stop the current performance profiling
+   *          associated with the profiling handle and
+   *          release the corresponding hardware resources.
    */
   void
-  stop_profiling() const;
+  stop() const;
 
 private:
-    std::shared_ptr<event_impl> impl;
+    std::shared_ptr<profiling_impl> impl;
 };
 
 }} // aie, xrt

--- a/src/runtime_src/core/include/xrt/xrt_aie.h
+++ b/src/runtime_src/core/include/xrt/xrt_aie.h
@@ -163,6 +163,21 @@ public:
   }
 };
 
+class event_impl;
+class event 
+{
+public:
+
+  event(const xrt::device& device, int option, const std::string& port1_name, const std::string& port2_name, uint32_t value);
+
+  uint64_t read_profiling() const;
+
+  void stop_profiling() const;
+
+private:
+    std::shared_ptr<event_impl> handle;
+};
+
 }} // aie, xrt
 
 /// @cond
@@ -256,6 +271,14 @@ xrtSyncBOAIE(xrtDeviceHandle handle, xrtBufferHandle bohdl, const char *gmioName
 int
 xrtResetAIEArray(xrtDeviceHandle handle);
 
+int
+xrtAIEStartProfiling(xrtDeviceHandle handle, int option, const char *port1Name, const char *port2Name, uint32_t value);
+
+uint64_t
+xrtAIEReadProfiling(int pHandle);
+
+int
+xrtAIEStopProfiling(int pHandle);
 /// @endcond
 
 #ifdef __cplusplus

--- a/src/runtime_src/core/include/xrt/xrt_aie.h
+++ b/src/runtime_src/core/include/xrt/xrt_aie.h
@@ -168,13 +168,48 @@ class event
 {
 public:
 
+  /**
+   * event() - Constructor from a device
+   *
+   * @param device
+   *  The device on which the profiling event should start
+   *
+   */
   event(const xrt::device& device);
 
-  int start_profiling(int option, const std::string& port1_name, const std::string& port2_name, uint32_t value) const;
+  /**
+   * start_profiling() - Start AIE performance profiling
+   *
+   * @param option
+   *  Profiling option
+   * @param port1_name
+   *  Profiling port 1 name.
+   * @param port2_name
+   *  Profiling port 2 name.
+   * @param value
+   *  The number of bytes to trigger the profiling event.
+   *
+   * This function configures the performance counters in AI Engine by given
+   * port names and value. The port names and value will have different
+   * meanings on different options.
+   */
+  int 
+  start_profiling(int option, const std::string& port1_name, const std::string& port2_name, uint32_t value) const;
 
-  uint64_t read_profiling() const;
+  /**
+   * read_profiling() - Read the current performance counter value
+   *                    associated with the profiling handle
+   */
+  uint64_t
+  read_profiling() const;
 
-  void stop_profiling() const;
+  /**
+   * stop_profiling() - Stop the current performance profiling
+   *                    associated with the profiling handle and
+   *                    release the corresponding hardware resources.
+   */
+  void
+  stop_profiling() const;
 
 private:
     std::shared_ptr<event_impl> impl;
@@ -273,12 +308,45 @@ xrtSyncBOAIE(xrtDeviceHandle handle, xrtBufferHandle bohdl, const char *gmioName
 int
 xrtResetAIEArray(xrtDeviceHandle handle);
 
+/**
+ * xrtAIEStartProfiling() - Start AIE performance profiling
+ *
+ * @handle:          Handle to the device
+ * @option:          Profiling option.
+ * @port1Name:       Profiling port 1 name
+ * @port2Name:       Profiling port 2 name
+ * @value:           The number of bytes to trigger the profiling event
+ *
+ * Return:         An integer profiling handle on success,
+ *                 or appropriate error number.
+ *
+ * This function configures the performance counters in AI Engine by given
+ * port names and value. The port names and value will have different
+ * meanings on different options.
+ */
 int
 xrtAIEStartProfiling(xrtDeviceHandle handle, int option, const char *port1Name, const char *port2Name, uint32_t value);
 
+/**
+ * xrtAIEReadProfiling() - Read the current performance counter value
+ *                         associated with the profiling handle.
+ *
+ * @pHandle:         Profiling handle.
+ *
+ * Return:         The performance counter value, or appropriate error number.
+ */
 uint64_t
 xrtAIEReadProfiling(int pHandle);
 
+/**
+ * xrtAIEStopProfiling() - Stop the current performance profiling
+ *                         associated with the profiling handle and
+ *                         release the corresponding hardware resources.
+ *
+ * @pHandle:         Profiling handle.
+ *
+ * Return:         0 on success, or appropriate error number.
+ */
 void
 xrtAIEStopProfiling(int pHandle);
 /// @endcond

--- a/src/runtime_src/core/include/xrt/xrt_aie.h
+++ b/src/runtime_src/core/include/xrt/xrt_aie.h
@@ -24,6 +24,7 @@
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_graph.h"
+#include "xrt/detail/pimpl.h"
 
 #ifdef __cplusplus
 # include <cstdint>
@@ -164,10 +165,13 @@ public:
 };
 
 class profiling_impl;
-class profiling 
+class profiling : public detail::pimpl<profiling_impl>
 {
 public:
   enum class profiling_option : int { io_total_stream_running_to_idle_cycles = 0, io_stream_start_to_bytes_transferred_cycles = 1, io_stream_start_difference_cycles = 2, io_stream_running_event_count = 3 };
+
+  profiling() = default;
+
   /**
    * event() - Constructor from a device
    *
@@ -175,6 +179,7 @@ public:
    *  The device on which the profiling should start
    *
    */
+  explicit
   profiling(const xrt::device& device);
 
   /**
@@ -212,7 +217,7 @@ public:
   stop() const;
 
 private:
-    std::shared_ptr<profiling_impl> impl;
+  std::shared_ptr<profiling_impl> impl;
 };
 
 }} // aie, xrt
@@ -313,8 +318,8 @@ xrtResetAIEArray(xrtDeviceHandle handle);
  *
  * @handle:          Handle to the device
  * @option:          Profiling option.
- * @port1Name:       Profiling port 1 name
- * @port2Name:       Profiling port 2 name
+ * @port1Name:       PLIO/GMIO port 1 name
+ * @port2Name:       PLIO/GMIO port 2 name
  * @value:           The number of bytes to trigger the profiling event
  *
  * Return:         An integer profiling handle on success,

--- a/src/runtime_src/doc/toc/xrt_native_apis.rst
+++ b/src/runtime_src/doc/toc/xrt_native_apis.rst
@@ -800,65 +800,63 @@ The above code shows
 
 
 
-Event Profile
--------------
+Profiling
+---------
 
-In Versal ACAPs with AI Engines, the XRT Event class (``xrt::aie::event``) and its member functions can be used to configure AI Engine hardware resources for performance profiling and event tracing.
+In Versal ACAPs with AI Engines, the XRT Profiling class (``xrt::aie::profiling``) and its member functions can be used to configure AI Engine hardware resources for performance profiling and event tracing.
 
-Create Event
-~~~~~~~~~~~~
+Create Profiling Event
+~~~~~~~~~~~~~~~~~~~~~~
 
-The class constructor ``xrt::aie::event`` is used to create event object as shown below 
+The class constructor ``xrt::aie::profiling`` is used to create profiling event object as shown below 
 
 .. code:: c
       :number-lines: 35
            
-           auto event = xrt::aie::event(device);
+           auto event = xrt::aie::profiling(device);
            
-
-The event object can be used to execute the profiling functions and collect profile statistics by calling event APIs.
+The profling object can be used to execute the profiling functions and collect profile statistics by calling profiling APIs.
 
 Start Profiling
 ~~~~~~~~~~~~~~~
 
-The member function ``xrt::aie::event::start_profiling()`` is used to start performance counters in AI Engine as per the profiling option passed as an argument. This function configures the performance counters in the AI Engine and starts profiling.
+The member function ``xrt::aie::profiling::start()`` is used to start performance counters in AI Engine as per the profiling option passed as an argument. This function configures the performance counters in the AI Engine and starts profiling.
 
 
 .. code:: c
       :number-lines: 45
            
            auto graph = xrt::graph(device, xclbin_uuid, "graph_name");
-           auto handle = event.start_profiling(int option, std::string& port1, std::string& port2, int value);
+           auto handle = event.start(xrt::aie::profiling::profiling_option option, std::string& port1, std::string& port2, int value);
            
            // run graph 
            ...
            s2mm_run.wait();
            
-It returns a handle to be used by read_profiling and stop_profiling.
+It returns a handle to be used by read and stop.
 
 Read Profiling
 ~~~~~~~~~~~~~~
 
-The ``xrt::aie::event::read_profiling`` function will return the current performance counter value associated with the event handle. It can be used using event object as shown below
+The ``xrt::aie::profiling::read`` function will return the current performance counter value associated with the profiling handle. It can be used using profiling event object as shown below
 
 .. code:: c
       :number-lines: 35
            
-           long long cycle_count = event.read_profiling();
+           long long cycle_count = profile.read();
            
-
 Stop Profiling
 ~~~~~~~~~~~~~~
 
-The ``xrt::aie::event::stop_profiling`` function stops the performance profiling associated with the event handle and releases the corresponding hardware resources.
+The ``xrt::aie::profiling::stop`` function stops the performance profiling associated with the profiling handle and releases the corresponding hardware resources.
 
 .. code:: c
       :number-lines: 35
            
-        event.stop_profiling();
+        event.stop();
         double throughput = (double)output_size_in_bytes / (cycle_count *0.8 * 1e-3); 
-        //Every AIE cycle is 0.8ns in production board
-        std::cout<<"Throughput of the graph: "<<throughput<<" MB/s"<<std::endl;
+        // Every AIE cycle is 0.8ns in production board
+        std::cout << "Throughput of the graph: " << throughput << " MB/s" << std::endl;
            
 
 

--- a/src/runtime_src/doc/toc/xrt_native_apis.rst
+++ b/src/runtime_src/doc/toc/xrt_native_apis.rst
@@ -854,7 +854,7 @@ The ``xrt::aie::profiling::stop`` function stops the performance profiling assoc
       :number-lines: 35
            
         event.stop();
-        double throughput = (double)output_size_in_bytes / (cycle_count *0.8 * 1e-3); 
+        double throughput = output_size_in_bytes / (cycle_count *0.8 * 1e-3); 
         // Every AIE cycle is 0.8ns in production board
         std::cout << "Throughput of the graph: " << throughput << " MB/s" << std::endl;
            

--- a/src/runtime_src/doc/toc/xrt_native_apis.rst
+++ b/src/runtime_src/doc/toc/xrt_native_apis.rst
@@ -800,6 +800,68 @@ The above code shows
 
 
 
+Event Profile
+-------------
+
+In Versal ACAPs with AI Engines, the XRT Event class (``xrt::aie::event``) and its member functions can be used to configure AI Engine hardware resources for performance profiling and event tracing.
+
+Create Event
+~~~~~~~~~~~~
+
+The class constructor ``xrt::aie::event`` is used to create event object as shown below 
+
+.. code:: c
+      :number-lines: 35
+           
+           auto event = xrt::aie::event(device);
+           
+
+The event object can be used to execute the profiling functions and collect profile statistics by calling event APIs.
+
+Start Profiling
+~~~~~~~~~~~~~~~
+
+The member function ``xrt::aie::event::start_profiling()`` is used to start performance counters in AI Engine as per the profiling option passed as an argument. This function configures the performance counters in the AI Engine and starts profiling.
+
+
+.. code:: c
+      :number-lines: 45
+           
+           auto graph = xrt::graph(device, xclbin_uuid, "graph_name");
+           auto handle = event.start_profiling(int option, std::string& port1, std::string& port2, int value);
+           
+           // run graph 
+           ...
+           s2mm_run.wait();
+           
+It returns a handle to be used by read_profiling and stop_profiling.
+
+Read Profiling
+~~~~~~~~~~~~~~
+
+The ``xrt::aie::event::read_profiling`` function will return the current performance counter value associated with the event handle. It can be used using event object as shown below
+
+.. code:: c
+      :number-lines: 35
+           
+           long long cycle_count = event.read_profiling();
+           
+
+Stop Profiling
+~~~~~~~~~~~~~~
+
+The ``xrt::aie::event::stop_profiling`` function stops the performance profiling associated with the event handle and releases the corresponding hardware resources.
+
+.. code:: c
+      :number-lines: 35
+           
+        event.stop_profiling();
+        double throughput = (double)output_size_in_bytes / (cycle_count *0.8 * 1e-3); 
+        //Every AIE cycle is 0.8ns in production board
+        std::cout<<"Throughput of the graph: "<<throughput<<" MB/s"<<std::endl;
+           
+
+
 Asynchornous Programming with XRT (experimental)
 ------------------------------------------------
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/VITIS-9706
Providing XRT support for Event APIs. 
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
None
#### How problem was solved, alternative solutions (if any) and why they were rejected
Implemented an Event class whose constructor xrt::aie::event is used to create event object.
The member function start_profiling() is used to start performance counters in AI Engine as per the profiling option passed as an argument.
The read_profiling() member function will return the current performance counter value associated with the event handle.
The stop_profiling() member function stops the performance profiling associated with the event handle.
#### Risks (if any) associated the changes in the commit
Low
#### What has been tested and how, request additional testing if necessary
Tested for an application that calculates throughout
#### Documentation impact (if any)
NA