### PR TITLE
Seperated bar mapping from probe in the xbmgmt driver.

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
@@ -288,78 +288,12 @@ void device_info(struct xclmgmt_dev *lro, struct xclmgmt_ioc_info *obj)
 }
 
 /*
- * Maps the PCIe BAR into user space for memory-like access using mmap().
- * Callable even when lro->ready == false.
- */
-static int bridge_mmap(struct file *file, struct vm_area_struct *vma)
-{
-	int rc;
-	struct xclmgmt_dev *lro;
-	unsigned long off;
-	unsigned long phys;
-	unsigned long vsize;
-	unsigned long psize;
-
-	if (!capable(CAP_SYS_ADMIN))
-		return -EACCES;
-
-	lro = (struct xclmgmt_dev *)file->private_data;
-	BUG_ON(!lro);
-
-	off = vma->vm_pgoff << PAGE_SHIFT;
-	/* BAR physical address */
-	phys = pci_resource_start(lro->core.pdev, lro->core.bar_idx) + off;
-	vsize = vma->vm_end - vma->vm_start;
-	/* complete resource */
-	psize = pci_resource_end(lro->core.pdev, lro->core.bar_idx) -
-		pci_resource_start(lro->core.pdev, lro->core.bar_idx) + 1 - off;
-
-	mgmt_info(lro, "mmap(): bar %d, phys:0x%lx, vsize:%ld, psize:%ld",
-		lro->core.bar_idx, phys, vsize, psize);
-
-	if (vsize > psize)
-		return -EINVAL;
-
-	/*
-	 * pages must not be cached as this would result in cache line sized
-	 * accesses to the end point
-	 */
-	vma->vm_page_prot = pgprot_noncached(vma->vm_page_prot);
-	/*
-	 * prevent touching the pages (byte access) for swap-in,
-	 * and prevent the pages from being swapped out
-	 */
-#ifndef VM_RESERVED
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
-	vma->vm_flags |= VM_IO | VM_DONTEXPAND | VM_DONTDUMP;
-#else
-	vm_flags_set(vma, VM_IO | VM_DONTEXPAND | VM_DONTDUMP);
-#endif
-#else
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
-	vma->vm_flags |= VM_IO | VM_RESERVED;
-#else
-	vm_flags_set(vma, VM_IO | VM_RESERVED);
-#endif
-#endif
-
-	/* make MMIO accessible to user space */
-	rc = io_remap_pfn_range(vma, vma->vm_start, phys >> PAGE_SHIFT,
-				vsize, vma->vm_page_prot);
-	if (rc)
-		return -EAGAIN;
-
-	return rc;
-}
-
-/*
  * character device file operations for control bus (through control bridge)
  */
 static const struct file_operations ctrl_fops = {
 	.owner = THIS_MODULE,
 	.open = char_open,
 	.release = char_close,
-	.mmap = bridge_mmap,
 	.unlocked_ioctl = mgmt_ioctl,
 };
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.h
@@ -55,13 +55,6 @@
 
 #define DRV_NAME "xclmgmt"
 
-#define	MGMT_READ_REG32(lro, off)	\
-	ioread32(lro->core.bar_addr + off)
-#define	MGMT_WRITE_REG32(lro, off, val)	\
-	iowrite32(val, lro->core.bar_addr + off)
-#define	MGMT_WRITE_REG8(lro, off, val)	\
-	iowrite8(val, lro->core.bar_addr + off)
-
 #define	mgmt_err(lro, fmt, args...)	\
 	dev_err(&lro->core.pdev->dev, "%s: "fmt, __func__, ##args)
 #define	mgmt_warn(lro, fmt, args...)	\
@@ -231,4 +224,6 @@ void mgmt_fini_mb(struct xclmgmt_dev *lro);
 int mgmt_start_mb(struct xclmgmt_dev *lro);
 int mgmt_stop_mb(struct xclmgmt_dev *lro);
 
+uint32_t mgmt_bar_read32(struct xclmgmt_dev *lro, uint32_t bar_off);
+#define	MGMT_READ_REG32(lro, off) mgmt_bar_read32(lro, off)
 #endif

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
@@ -3517,12 +3517,12 @@ static int xgq_vmr_probe(struct platform_device *pdev)
 	    res = platform_get_resource(pdev, IORESOURCE_MEM, ++i)) {
 		XGQ_INFO(xgq, "res : %s %pR", res->name, res);
 		if (!strncmp(res->name, NODE_XGQ_SQ_BASE, strlen(NODE_XGQ_SQ_BASE))) {
-			xgq->xgq_sq_base = ioremap_nocache(res->start,
+			xgq->xgq_sq_base = ioremap(res->start,
 				res->end - res->start + 1);
 		}
 		if (!strncmp(res->name, NODE_XGQ_VMR_PAYLOAD_BASE,
 			strlen(NODE_XGQ_VMR_PAYLOAD_BASE))) {
-			xgq->xgq_payload_base = ioremap_nocache(res->start,
+			xgq->xgq_payload_base = ioremap(res->start,
 				res->end - res->start + 1);
 		}
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
[VITIS-9318](https://jira.xilinx.com/browse/VITIS-9318), bridge_mmap is not used by current code, we can remove it safely. Replaced ioremap_nocache() with ioremap() as it is deprecated. With recent liux kernel, the performance is to downlaod the apu is ~3 seconds. 

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Removed mapping the bar in the time of probe itself.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added mgmt_bar_read32() function to map,read and unmap the bar. Removed bridge_mmap cpmpletely from the mgmt-core.c

#### Risks (if any) associated the changes in the commit
NA

#### What has been tested and how, request additional testing if necessary
Tested with v70, u250.
#### Documentation impact (if any)
NA