### PR TITLE
Add hotfix for Linux xbutil validation implementation

### DIFF
--- a/src/runtime_src/core/tools/common/TestRunner.cpp
+++ b/src/runtime_src/core/tools/common/TestRunner.cpp
@@ -374,21 +374,21 @@ TestRunner::search_and_program_xclbin(const std::shared_ptr<xrt_core::device>& d
 }
 
 std::string
-TestRunner::findPlatformPath(const std::shared_ptr<xrt_core::device>& _dev,
-                 boost::property_tree::ptree& _ptTest)
+TestRunner::findPlatformPath(const std::shared_ptr<xrt_core::device>& dev,
+                             boost::property_tree::ptree& ptTest)
 {
   //check if a 2RP platform
-  const auto logic_uuid = xrt_core::device_query_default<xrt_core::query::logic_uuids>(_dev, {});
-  const auto device_name = xrt_core::device_query_default<xrt_core::query::rom_vbnv>(_dev, "");
-  if (device_name.find("Ryzen") != std::string::npos) {
-    return "/opt/xilinx/xrt/amdaie/";
+  const auto logic_uuid = xrt_core::device_query_default<xrt_core::query::logic_uuids>(dev, {});
+  if (xrt_core::device_query<xrt_core::query::device_class>(dev) == xrt_core::query::device_class::type::ryzen) {
+    const auto device_id = xrt_core::device_query<xrt_core::query::pcie_device>(dev);
+    return "/lib/firmware/amdnpu/" + boost::str(boost::format("%x") % device_id) + "/";
   }
   if (!logic_uuid.empty())
-    return searchSSV2Xclbin(logic_uuid.front(), _ptTest);
+    return searchSSV2Xclbin(logic_uuid.front(), ptTest);
   else {
-    auto vendor = xrt_core::device_query<xrt_core::query::pcie_vendor>(_dev);
-    auto name = xrt_core::device_query<xrt_core::query::rom_vbnv>(_dev);
-    return searchLegacyXclbin(vendor, name, _ptTest);
+    auto vendor = xrt_core::device_query<xrt_core::query::pcie_vendor>(dev);
+    auto name = xrt_core::device_query<xrt_core::query::rom_vbnv>(dev);
+    return searchLegacyXclbin(vendor, name, ptTest);
   }
 }
 

--- a/src/runtime_src/core/tools/common/TestRunner.cpp
+++ b/src/runtime_src/core/tools/common/TestRunner.cpp
@@ -432,9 +432,7 @@ TestRunner::findDPUPath( const std::shared_ptr<xrt_core::device>& _dev,
   boost::ignore_unused(_dev);
   prefix_path = xrt_core::environment::xclbin_path(_ptTest.get<std::string>("xclbin", "")).parent_path();
 #else
-  boost::property_tree::ptree ptree; //ignore
-  const auto platform_path = findPlatformPath(_dev, ptree);
-  prefix_path = std::filesystem::path(platform_path);
+  prefix_path = std::filesystem::path("/opt/xilinx/xrt/test/");
 #endif
   auto dpu_instr = prefix_path / dpu_dir / dpu_name;
   if (!std::filesystem::exists(dpu_instr)) {

--- a/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.cpp
@@ -85,6 +85,7 @@ TestDF_bandwidth::run(std::shared_ptr<xrt_core::device> dev)
   switch (device_id) {
   case 5378: // 0x1502
     ptree.put("xclbin", "validate_phx.xclbin");
+    break;
   case 6128: // 0x17f0
     ptree.put("xclbin", "validate_stx.xclbin");
     break;

--- a/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.cpp
@@ -80,16 +80,16 @@ TestDF_bandwidth::run(std::shared_ptr<xrt_core::device> dev)
 {
   boost::property_tree::ptree ptree = get_test_header();
 
-  // workaround: can't rename files when copying to driver store
-  // so need to name the files as _phx and _stx
-  // will revisit this after the current release
-  auto device_id = xrt_core::query::pcie_device::to_string(xrt_core::device_query<xrt_core::query::pcie_device>(dev));
-  if (device_id.compare("0x1502") == 0)
-    m_xclbin = "validate_phx.xclbin";
-  else if (device_id.compare("0x17f0") == 0)
-    m_xclbin = "validate_stx.xclbin";
-  ptree.put("xclbin", m_xclbin);
-
+  #ifdef _WIN32
+  auto device_id = xrt_core::device_query<xrt_core::query::pcie_device>(dev);
+  switch (device_id) {
+  case 5378: // 0x1502
+    ptree.put("xclbin", "validate_phx.xclbin");
+  case 6128: // 0x17f0
+    ptree.put("xclbin", "validate_stx.xclbin");
+    break;
+  }
+  #endif
 
   auto xclbin_path = findXclbinPath(dev, ptree);
   if (!std::filesystem::exists(xclbin_path)) {
@@ -127,7 +127,7 @@ TestDF_bandwidth::run(std::shared_ptr<xrt_core::device> dev)
   auto kernelName = xkernel.get_name();
   logger(ptree, "Details", boost::str(boost::format("Kernel name is '%s'") % kernelName));
 
-  auto working_dev = xrt::device{dev};
+  auto working_dev = xrt::device(dev);
   working_dev.register_xclbin(xclbin);
   xrt::hw_context hwctx{working_dev, xclbin.get_uuid()};
   xrt::kernel kernel{hwctx, kernelName};

--- a/src/runtime_src/core/tools/common/tests/TestIPU.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestIPU.cpp
@@ -28,15 +28,16 @@ TestIPU::run(std::shared_ptr<xrt_core::device> dev)
 {
   boost::property_tree::ptree ptree = get_test_header();
 
-  // workaround: can't rename files when copying to driver store
-  // so need to name the files as _phx and _stx
-  // will revisit this after the current release
-  auto device_id = xrt_core::query::pcie_device::to_string(xrt_core::device_query<xrt_core::query::pcie_device>(dev));
-  if (device_id.compare("0x1502") == 0)
-    m_xclbin = "validate_phx.xclbin";
-  else if (device_id.compare("0x17f0") == 0)
-    m_xclbin = "validate_stx.xclbin";
-  ptree.put("xclbin", m_xclbin);
+  #ifdef _WIN32
+  auto device_id = xrt_core::device_query<xrt_core::query::pcie_device>(dev);
+  switch (device_id) {
+  case 5378: // 0x1502
+    ptree.put("xclbin", "validate_phx.xclbin");
+  case 6128: // 0x17f0
+    ptree.put("xclbin", "validate_stx.xclbin");
+    break;
+  }
+  #endif
 
   auto xclbin_path = findXclbinPath(dev, ptree);
   if (!std::filesystem::exists(xclbin_path)) {
@@ -74,7 +75,7 @@ TestIPU::run(std::shared_ptr<xrt_core::device> dev)
   auto kernelName = xkernel.get_name();
   logger(ptree, "Details", boost::str(boost::format("Kernel name is '%s'") % kernelName));
 
-  auto working_dev = xrt::device{dev};
+  auto working_dev = xrt::device(dev);
   working_dev.register_xclbin(xclbin);
   xrt::hw_context hwctx{working_dev, xclbin.get_uuid()};
   xrt::kernel kernel{hwctx, kernelName};

--- a/src/runtime_src/core/tools/common/tests/TestIPU.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestIPU.cpp
@@ -33,6 +33,7 @@ TestIPU::run(std::shared_ptr<xrt_core::device> dev)
   switch (device_id) {
   case 5378: // 0x1502
     ptree.put("xclbin", "validate_phx.xclbin");
+    break;
   case 6128: // 0x17f0
     ptree.put("xclbin", "validate_stx.xclbin");
     break;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1189208

`xbutil validate` is currently non functional for Linux NPU. This needs to be fixed quickly.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
`xbutil validate` never worked before so technically a new feature!

#### How problem was solved, alternative solutions (if any) and why they were rejected
There is no consensus on how to fix the Windows side, so this implementation separates how the xclbin name is selected depending on the operating system. Once everything settles down this fix can and should be removed.

The most important change here is the addition of the `#ifdef` into TestIPU and TestDf_bandwidth paired with the Platform path update searching in `/lib/firmware/amdnpu/<device_id>/`.

#### Risks (if any) associated the changes in the commit
This is a hotfix only for Linux, it will not affect the operating on Windows.

#### What has been tested and how, request additional testing if necessary
Tested on Linux NPU (Phoenix) and both tests are functional.

#### Documentation impact (if any)
None.