### PR TITLE
CR-1188254 Disable xbutil reset and program in RyzenAI 1.1 ARC2

### DIFF
--- a/src/runtime_src/core/tools/common/XBMain.h
+++ b/src/runtime_src/core/tools/common/XBMain.h
@@ -28,5 +28,6 @@
 void main_(int argc, char** argv, 
            const std::string & _executable,
            const std::string & _description,
-           const SubCmdsCollection & _SubCmds);
+           const SubCmdsCollection & _SubCmds,
+           const boost::property_tree::ptree& configurations);
 #endif

--- a/src/runtime_src/core/tools/xbmgmt2/xbmgmt.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/xbmgmt.cpp
@@ -46,16 +46,10 @@ R"(
     "program":[{
       "suboption": ["base", "shell", "revert-to-golden", "user", "boot"]
     }]
-  }]
-},{
-  "aie": [{
-    "examine": [{
-      "report": ["cmc", "firewall", "host", "mailbox", "mechanical", "platform", "vmr"]
-    }]
   },{
-    "program":[{
-      "suboption": ["user"]
-    }]
+    "reset": [{}]
+  },{
+    "dump": [{}]
   }]
 }]
 )";
@@ -92,7 +86,7 @@ int main( int argc, char** argv )
 
   // -- Ready to execute the code
   try {
-    main_( argc, argv, executable, description, subCommands);
+    main_( argc, argv, executable, description, subCommands, configTree);
     return 0;
   } catch (const xrt_core::error& e) {
     // Clean exception exit

--- a/src/runtime_src/core/tools/xbutil2/xbutil.cpp
+++ b/src/runtime_src/core/tools/xbutil2/xbutil.cpp
@@ -46,6 +46,10 @@ R"(
     "validate": [{
       "test": ["aux-connection", "pcie-link", "sc-version", "verify", "dma", "iops", "mem-bw", "p2p", "m2m", "hostmem-bw", "bist", "vcu", "aie", "ps-aie", "ps-pl-verify", "ps-verify", "ps-iops"]
     }]
+  },{
+    "reset": [{}]
+  },{
+    "program": [{}]
   }]
 },{
   "aie": [{
@@ -111,7 +115,7 @@ int main( int argc, char** argv )
 
   // -- Ready to execute the code
   try {
-    main_( argc, argv, executable, description, subCommands);
+    main_( argc, argv, executable, description, subCommands, configTree);
     return 0;
   } catch (const xrt_core::error& e) {
     // Clean exception exit


### PR DESCRIPTION
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1188254
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
 xbutil reset/program, while not supported or functional, were still showing up in help menu/accepted in cmd line for RyzenAI 1.1 ARC2
#### How problem was solved, alternative solutions (if any) and why they were rejected
Added reset and program to the config json for xbutil. XBMain now takes in the config tree and can parse subcommands for supported subcommands. As a result, xbmgmt's config json was also updated for Alveo to include all relevant subcmds (examine, configure, advanced, program, reset, dump). The aie section was removed from xbmgmt's config json.
#### Risks (if any) associated the changes in the commit
N/A
#### What has been tested and how, request additional testing if necessary
Testing has been done locally on 0, 1, and 2+ device cases. 0 and 2+ cases had the same output, except the "available" devices list would be empty in the 0 case.
[1 Device (AIE).txt](https://github.com/Xilinx/XRT/files/14202082/1.Device.AIE.txt)
[2+ Devices.txt](https://github.com/Xilinx/XRT/files/14202083/2%2B.Devices.txt)
Notably, xbutil --help in the CR's case now no longer includes reset and program, as desired:
```
rchane@xsjdbenusov50:/proj/rdi/staff/rchane/XRT/build/Debug/runtime_src/core/tools/xbutil2$ ./xbutil2 --help
WARNING: Unexpected xocl version (2.16.0) was found. Expected 2.17.0, to match XRT tools.

DESCRIPTION: The Xilinx (R) Board Utility (xbutil) is a standalone command line utility that is
             included with the Xilinx Run Time (XRT) installation package. It includes multiple
             commands to validate and identify the installed card(s) along with additional card
             details including DDR, PCIe (R), shell name (DSA), and system information.

             This information can be used for both card administration and application debugging.

USAGE: xbutil[--help] [--version] [--verbose] [--batch] [--force] [command [commandArgs]]

AVAILABLE COMMANDS:
  configure  - Device and host configuration
  examine    - Status of the system and device
  validate   - Validates the basic shell acceleration functionality

OPTIONS:
  --help             - Help to use this application
  --version          - Report the version of XRT and its drivers
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
```
Running a command like reset will then show:
```
rchane@xsjdbenusov50:/proj/rdi/staff/rchane/XRT/build/Debug/runtime_src/core/tools/xbutil2$ ./xbutil2 reset
WARNING: Unexpected xocl version (2.16.0) was found. Expected 2.17.0, to match XRT tools.
ERROR: Unknown command: 'reset'

DESCRIPTION: The Xilinx (R) Board Utility (xbutil) is a standalone command line utility that is
             included with the Xilinx Run Time (XRT) installation package. It includes multiple
             commands to validate and identify the installed card(s) along with additional card
             details including DDR, PCIe (R), shell name (DSA), and system information.

             This information can be used for both card administration and application debugging.

USAGE: xbutil[--help] [--version] [--verbose] [--batch] [--force] [command [commandArgs]]

AVAILABLE COMMANDS:
  configure  - Device and host configuration
  examine    - Status of the system and device
  validate   - Validates the basic shell acceleration functionality

OPTIONS:
  --help             - Help to use this application
  --version          - Report the version of XRT and its drivers
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
```
#### Documentation impact (if any)
N/A