### PR TITLE
add bind_at() SHIM API

### DIFF
--- a/src/runtime_src/core/common/api/bo_int.h
+++ b/src/runtime_src/core/common/api/bo_int.h
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+//
+#ifndef _XRT_COMMON_BO_INT_H_
+#define _XRT_COMMON_BO_INT_H_
+
+// This file defines implementation extensions to the XRT BO APIs.
+#include "core/include/experimental/xrt_bo.h"
+#include "core/common/shim/buffer_handle.h"
+
+namespace xrt_core::bo_int {
+
+xrt_core::buffer_handle*
+get_buffer_handle(const xrt::bo& bo);
+
+} // bo_int, xrt_core
+
+#endif

--- a/src/runtime_src/core/common/api/bo_int.h
+++ b/src/runtime_src/core/common/api/bo_int.h
@@ -10,8 +10,11 @@
 
 namespace xrt_core::bo_int {
 
-xrt_core::buffer_handle*
+const xrt_core::buffer_handle*
 get_buffer_handle(const xrt::bo& bo);
+
+size_t
+get_offset(const xrt::bo& bo);
 
 } // bo_int, xrt_core
 

--- a/src/runtime_src/core/common/api/bo_int.h
+++ b/src/runtime_src/core/common/api/bo_int.h
@@ -5,7 +5,7 @@
 #define _XRT_COMMON_BO_INT_H_
 
 // This file defines implementation extensions to the XRT BO APIs.
-#include "core/include/experimental/xrt_bo.h"
+#include "core/include/xrt/xrt_bo.h"
 #include "core/common/shim/buffer_handle.h"
 
 namespace xrt_core::bo_int {

--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -1451,15 +1451,6 @@ size() const
   }) ;
 }
 
-size_t
-bo::
-offset() const
-{
-  return xdp::native::profiling_wrapper("xrt::bo::offset", [this]{
-    return handle->get_offset();
-  }) ;
-}
-
 uint64_t
 bo::
 address() const
@@ -1973,11 +1964,18 @@ xrtBOAddress(xrtBufferHandle bhdl)
 
 namespace xrt_core::bo_int {
 
-xrt_core::buffer_handle*
+const xrt_core::buffer_handle*
 get_buffer_handle(const xrt::bo& bo)
 {
   auto handle = bo.get_handle();
   return handle->get_handle();
+}
+
+size_t
+get_offset(const xrt::bo& bo)
+{
+  auto handle = bo.get_handle();
+  return handle->get_offset();
 }
 
 } // xrt_core::bo_int

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2020-2022 Xilinx, Inc. All rights reserved.
-// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
 
 // This file implements XRT kernel APIs as declared in
 // core/include/experimental/xrt_kernel.h
@@ -33,6 +33,7 @@
 #include "native_profile.h"
 #include "xclbin_int.h"
 
+#include "core/common/api/bo_int.h"
 #include "core/common/bo_cache.h"
 #include "core/common/config_reader.h"
 #include "core/common/cuidx_type.h"
@@ -2224,6 +2225,9 @@ public:
   set_arg_value(const argument& arg, const xrt::bo& bo)
   {
     get_arg_setter()->set_arg_value(arg, bo);
+
+    auto bh = xrt_core::bo_int::get_buffer_handle(bo);
+    cmd->get_exec_bo()->bind_at(arg.index(), bh, bo.offset(), bo.size());
 
     if (m_module)
       xrt_core::module_int::patch(m_module, arg.name(), bo);

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -2227,7 +2227,9 @@ public:
     get_arg_setter()->set_arg_value(arg, bo);
 
     auto bh = xrt_core::bo_int::get_buffer_handle(bo);
-    cmd->get_exec_bo()->bind_at(arg.index(), bh, bo.offset(), bo.size());
+    auto off = xrt_core::bo_int::get_offset(bo);
+    auto sz = bo.size();
+    cmd->get_exec_bo()->bind_at(arg.index(), bh, off, sz);
 
     if (m_module)
       xrt_core::module_int::patch(m_module, arg.name(), bo);

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -951,6 +951,15 @@ public:
     }
   }
 
+  void
+  bind_arg_at_index(size_t index, const xrt::bo& bo)
+  {
+    auto bh = xrt_core::bo_int::get_buffer_handle(bo);
+    auto off = xrt_core::bo_int::get_offset(bo);
+    auto sz = bo.size();
+    get_exec_bo()->bind_at(index, bh, off, sz);
+  }
+
 private:
   std::shared_ptr<device_type> m_device;
   xrt_core::hw_queue m_hwqueue;  // hwqueue for command submission
@@ -2225,11 +2234,7 @@ public:
   set_arg_value(const argument& arg, const xrt::bo& bo)
   {
     get_arg_setter()->set_arg_value(arg, bo);
-
-    auto bh = xrt_core::bo_int::get_buffer_handle(bo);
-    auto off = xrt_core::bo_int::get_offset(bo);
-    auto sz = bo.size();
-    cmd->get_exec_bo()->bind_at(arg.index(), bh, off, sz);
+    cmd->bind_arg_at_index(arg.index(), bo);
 
     if (m_module)
       xrt_core::module_int::patch(m_module, arg.name(), bo);

--- a/src/runtime_src/core/common/shim/buffer_handle.h
+++ b/src/runtime_src/core/common/shim/buffer_handle.h
@@ -85,11 +85,6 @@ public:
   virtual void
   bind_at(size_t /*pos*/, const buffer_handle* /*bh*/, size_t /*offset*/, size_t /*size*/)
   {
-    bool is_exec_buf = !!(get_properties().flags & XCL_BO_FLAGS_EXECBUF);
-
-    if (!is_exec_buf)
-      throw std::runtime_error("not supported");
-    // By default, nothing needs to be done for exec buf
   }
 };
 

--- a/src/runtime_src/core/common/shim/buffer_handle.h
+++ b/src/runtime_src/core/common/shim/buffer_handle.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
 #ifndef XRT_CORE_BUFFER_HANDLE_H
 #define XRT_CORE_BUFFER_HANDLE_H
 
@@ -76,6 +76,20 @@ public:
   get_xcl_handle() const
   {
     return XRT_NULL_BO;
+  }
+
+  // Indicates to SHIM/driver that bh is going to be used by this BO. With
+  // offset and zie, it can also support using portion of bh (sub-BO).
+  // For now, this is only used when set_arg() is called upon an exec buf
+  // BO where pos is the arg index.
+  virtual void
+  bind_at(size_t pos, buffer_handle* bh, size_t offset, size_t size)
+  {
+    bool is_exec_buf = !!(get_properties().flags & XCL_BO_FLAGS_EXECBUF);
+
+    if (!is_exec_buf)
+      throw std::runtime_error("not supported");
+    // By default, nothing needs to be done for exec buf
   }
 };
 

--- a/src/runtime_src/core/common/shim/buffer_handle.h
+++ b/src/runtime_src/core/common/shim/buffer_handle.h
@@ -83,7 +83,7 @@ public:
   // For now, this is only used when set_arg() is called upon an exec buf
   // BO where pos is the arg index.
   virtual void
-  bind_at(size_t pos, buffer_handle* bh, size_t offset, size_t size)
+  bind_at(size_t /*pos*/, const buffer_handle* /*bh*/, size_t /*offset*/, size_t /*size*/)
   {
     bool is_exec_buf = !!(get_properties().flags & XCL_BO_FLAGS_EXECBUF);
 

--- a/src/runtime_src/core/include/xrt/xrt_bo.h
+++ b/src/runtime_src/core/include/xrt/xrt_bo.h
@@ -1,7 +1,7 @@
-/*
- * Copyright (C) 2020-2022 Xilinx, Inc
- * SPDX-License-Identifier: Apache-2.0
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2020-2022 Xilinx, Inc. All rights reserved.
+// Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+
 #ifndef XRT_BO_H_
 #define XRT_BO_H_
 
@@ -468,6 +468,16 @@ public:
   XCL_DRIVER_DLLESPEC
   size_t
   size() const;
+
+  /**
+   * offset() - Get the offset of this buffer
+   *
+   * @return
+   *  Offset of buffer in bytes
+   */
+  XCL_DRIVER_DLLESPEC
+  size_t
+  offset() const;
 
   /**
    * address() - Get the device address of this buffer

--- a/src/runtime_src/core/include/xrt/xrt_bo.h
+++ b/src/runtime_src/core/include/xrt/xrt_bo.h
@@ -1,7 +1,7 @@
-// SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2020-2022 Xilinx, Inc. All rights reserved.
-// Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
-
+/*
+ * Copyright (C) 2020-2022 Xilinx, Inc
+ * SPDX-License-Identifier: Apache-2.0
+ */
 #ifndef XRT_BO_H_
 #define XRT_BO_H_
 

--- a/src/runtime_src/core/include/xrt/xrt_bo.h
+++ b/src/runtime_src/core/include/xrt/xrt_bo.h
@@ -470,16 +470,6 @@ public:
   size() const;
 
   /**
-   * offset() - Get the offset of this buffer
-   *
-   * @return
-   *  Offset of buffer in bytes
-   */
-  XCL_DRIVER_DLLESPEC
-  size_t
-  offset() const;
-
-  /**
    * address() - Get the device address of this buffer
    *
    * @return


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
When set_arg(BO) is called upon run object, we can call bind_at() SHIM API to notify driver that a BO is now is used by (bond to) the exec buf command BO. This is useful for NPU Linux driver to keep track of BOs used by a particular cmd. Then, when the cmd is submitted to the driver, it can better prepare the BOs (e.g., pin the pages on demand) before it push the cmd to hardware.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
N/A
#### How problem was solved, alternative solutions (if any) and why they were rejected
Alternatively, we could send the list of BO handles together with the exec buf cmd to driver as other drivers are doing. But, it seems to be:
1. more complicated than this solution.
2. less efficient than this solution since the BO handle to DRM BO pointer conversion needs to happen in critical path (v.s. in set_arg code path, which is non-critical).
3. less efficient than this solution since the BO handle to DRM BO pointer conversion needs to happen every time when the command is submitted (v.s. happens only once when set_arg is called).
#### Risks (if any) associated the changes in the commit
N/A
#### What has been tested and how, request additional testing if necessary
Done full build of XRT and installed on a system with U55n. Made sure xbutil validate works.
Also added some debug messages to make sure the newly added function is called properly.
#### Documentation impact (if any)
N/A