### PR TITLE
XRT build drops a kernel-doc directory in the PWD

### DIFF
--- a/src/runtime_src/doc/CMakeLists.txt
+++ b/src/runtime_src/doc/CMakeLists.txt
@@ -34,12 +34,12 @@ file(GLOB XRT_MAILBOX_C    ${XRT_RUNTIME_SRC_DIR}/core/pcie/driver/linux/xocl/su
 file(MAKE_DIRECTORY ${DOC_CORE_DIR})
 file(COPY ${XRT_DOC_TOC_DIR} DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
-set(KERNELDOC "kernel-doc")
+set(KERNELDOC "${CMAKE_BINARY_DIR}/kernel-doc")
 set(KERNELDOC_URL "https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git/plain/scripts/kernel-doc?h=v4.14.52")
 
-if (NOT EXISTS ${CMAKE_BINARY_DIR}/${KERNELDOC})
+if (NOT EXISTS ${KERNELDOC})
   MESSAGE(STATUS "${KERNELDOC} downloading")
-  file(DOWNLOAD ${KERNELDOC_URL} "${CMAKE_BINARY_DIR}/${KERNELDOC}")
+  file(DOWNLOAD ${KERNELDOC_URL} ${KERNELDOC})
   execute_process(COMMAND chmod +x ${KERNELDOC})
 endif ()
 

--- a/src/runtime_src/doc/CMakeLists.txt
+++ b/src/runtime_src/doc/CMakeLists.txt
@@ -39,7 +39,7 @@ set(KERNELDOC_URL "https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-
 
 if (NOT EXISTS ${CMAKE_BINARY_DIR}/${KERNELDOC})
   MESSAGE(STATUS "${KERNELDOC} downloading")
-  file(DOWNLOAD ${KERNELDOC_URL} "./${KERNELDOC}")
+  file(DOWNLOAD ${KERNELDOC_URL} "${CMAKE_BINARY_DIR}/${KERNELDOC}")
   execute_process(COMMAND chmod +x ${KERNELDOC})
 endif ()
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://github.com/Xilinx/XRT/issues/7912  XRT build drops a kernel-doc directory in the PWD
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
NA
#### How problem was solved, alternative solutions (if any) and why they were rejected
Added proper path in CMakeLists.txt.
#### Risks (if any) associated the changes in the commit
NA
#### What has been tested and how, request additional testing if necessary
NA
#### Documentation impact (if any)
NA