### PR TITLE
VITIS-11357 Propogate testcase to xbutil

### DIFF
--- a/src/runtime_src/core/tools/common/tests/TestTCTAllColumn.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestTCTAllColumn.cpp
@@ -2,7 +2,7 @@
 
 // ------ I N C L U D E   F I L E S -------------------------------------------
 // Local - Include Files
-#include "TestTCTOneColumn.h"
+#include "TestTCTAllColumn.h"
 #include "tools/common/XBUtilities.h"
 #include "tools/common/BusyBar.h"
 #include "xrt/xrt_bo.h"
@@ -17,15 +17,15 @@ namespace XBU = XBUtilities;
 static constexpr size_t host_app = 1; //opcode
 static constexpr size_t buffer_size = 4;
 static constexpr size_t word_count = buffer_size/4;
-static constexpr int itr_count = 10000;
+static constexpr int itr_count = 20000;
 
 // ----- C L A S S   M E T H O D S -------------------------------------------
-TestTCTOneColumn::TestTCTOneColumn()
-  : TestRunner("tct-one-col", 
-                "Measure average TCT processing time for one column",
+TestTCTAllColumn::TestTCTAllColumn()
+  : TestRunner("tct-all-col", 
+                "Measure average TCT processing time for all columns",
                 "validate.xclbin")
                 {
-                  m_dpu_name = "tct_1col.txt";
+                  m_dpu_name = "tct_4col.txt";
                 }
 
 namespace {
@@ -73,7 +73,7 @@ get_instr_size(const std::string& dpu_file) {
 } //anonymous namespace
 
 boost::property_tree::ptree
-TestTCTOneColumn::run(std::shared_ptr<xrt_core::device> dev)
+TestTCTAllColumn::run(std::shared_ptr<xrt_core::device> dev)
 {
   boost::property_tree::ptree ptree = get_test_header();
 

--- a/src/runtime_src/core/tools/common/tests/TestTCTAllColumn.h
+++ b/src/runtime_src/core/tools/common/tests/TestTCTAllColumn.h
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+
+#ifndef __TestTCTAllColumn_h_
+#define __TestTCTAllColumn_h_
+
+#include "tools/common/TestRunner.h"
+#include "xrt/xrt_device.h"
+
+class TestTCTAllColumn : public TestRunner {
+  public:
+    boost::property_tree::ptree run(std::shared_ptr<xrt_core::device> dev);
+
+  public:
+    TestTCTAllColumn();
+
+  //variables
+  private:
+    std::string m_dpu_name;
+};
+
+#endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -35,6 +35,7 @@
 #include "tools/common/tests/TestPsIops.h"
 #include "tools/common/tests/TestDF_bandwidth.h"
 #include "tools/common/tests/TestTCTOneColumn.h"
+#include "tools/common/tests/TestTCTAllColumn.h"
 namespace XBU = XBUtilities;
 
 // 3rd Party Library - Include Files
@@ -100,7 +101,8 @@ std::vector<std::shared_ptr<TestRunner>> testSuite = {
   std::make_shared<TestPsVerify>(),
   std::make_shared<TestPsIops>(),
   std::make_shared<TestDF_bandwidth>(),
-  std::make_shared<TestTCTOneColumn>()
+  std::make_shared<TestTCTOneColumn>(),
+  std::make_shared<TestTCTAllColumn>()
 };
 
 /*

--- a/src/runtime_src/core/tools/xbutil2/xbutil.cpp
+++ b/src/runtime_src/core/tools/xbutil2/xbutil.cpp
@@ -62,7 +62,7 @@ R"(
     }]
   },{
     "validate": [{
-      "test": ["verify", "df-bw", "tct-one-col"]
+      "test": ["verify", "df-bw", "tct-one-col", "tct-all-col"]
     }]
   }]
 }]


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Add a new benchmark testcase

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
N/A

#### How problem was solved, alternative solutions (if any) and why they were rejected
N/A

#### Risks (if any) associated the changes in the commit
New feature

#### What has been tested and how, request additional testing if necessary
Tested on MCDM setup. This change requires additional changes in inf file. I'll file the corresponding PR in XRT-MCDM
```
>xbutil validate -d --batch
------------------------------------------------------------
                        EARLY ACCESS
        This release of xbutil contains early access
         experimental features which may have bugs.
------------------------------------------------------------
Validate Device           : [00c3:00:01.1]
    Platform              : RyzenAI-Phoenix
-------------------------------------------------------------------------------
Running Test: ..
Test 1 [00c3:00:01.1]     : verify
    Details               : Kernel name is 'DPU_PDI_0'
                            Total duration: '1.3's
                            Average throughput: '7482.4' ops/s
                            Average latency: '133.6' us
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Test 2 [00c3:00:01.1]     : df-bw
    Details               : Kernel name is 'DPU_PDI_0'
    Details               : Total duration: '79.552643's
                            Average bandwidth per shim DMA: '15.1' GB/s
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Test 3 [00c3:00:01.1]     : tct-one-col
    Details               : Kernel name is 'DPU_PDI_0'
    Details               : Average time for TCT: '3.6' us
                            Average TCT throughput: '281041.8' TCT/s
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Test 4 [00c3:00:01.1]     : tct-all-col
    Details               : Kernel name is 'DPU_PDI_0'
    Details               : Average time for TCT: '2.0' us
                            Average TCT throughput: '494341.0' TCT/s
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Validation completed. Please run the command '--verbose' option for more details
```

#### Documentation impact (if any)
N/A
