### PR TITLE
Further support of memory module DMA events on Edge devices

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info/aie_constructs.h
+++ b/src/runtime_src/xdp/profile/database/static_info/aie_constructs.h
@@ -206,13 +206,17 @@ enum class module_type {
       std::map<uint32_t, uint32_t> group_event_config = {};
       uint32_t combo_event_input[NUM_COMBO_EVENT_INPUT] = {};
       uint32_t combo_event_control[NUM_COMBO_EVENT_CONTROL] = {};
+
       uint32_t broadcast_mask_south = BROADCAST_MASK_DEFAULT;
       uint32_t broadcast_mask_north = BROADCAST_MASK_DEFAULT;
       uint32_t broadcast_mask_west = BROADCAST_MASK_DEFAULT;
       uint32_t broadcast_mask_east = BROADCAST_MASK_DEFAULT;
       uint32_t internal_events_broadcast[NUM_BROADCAST_EVENTS] = {};
+      
       bool port_trace_is_master[NUM_SWITCH_MONITOR_PORTS];
       int8_t port_trace_ids[NUM_SWITCH_MONITOR_PORTS];
+      int8_t s2mm_channels[NUM_CHANNEL_SELECTS] = {-1, -1};
+      int8_t mm2s_channels[NUM_CHANNEL_SELECTS] = {-1, -1};
       std::vector<aie_cfg_counter> pc;
 
       aie_cfg_base(uint32_t count) : pc(count) {
@@ -226,8 +230,7 @@ enum class module_type {
   /*
    * Core Module has 4 Performance counters
    * Group events 2,15,22,32,46,47,73,106,123 are defined in AIE architecture spec.
-   * Core trace uses pc trace mode so we just set that as default.
-   * "null" is a dummy string as port trace doesn't exist today.
+   * Core trace uses PC packets so we set that as default.
    */
   class aie_cfg_core : public aie_cfg_base
   {
@@ -251,8 +254,8 @@ enum class module_type {
 
   /*
    * Memory Module has 2 Performance counters.
-   * Group events exist for memory module but don't need to be defined.
-   * Memory trace uses time trace mode.
+   * Group events exist but don't need to be defined.
+   * Memory trace uses time packets.
    */
   class aie_cfg_memory : public aie_cfg_base
   {
@@ -261,15 +264,25 @@ enum class module_type {
   };
 
   /*
-   * Interface or memory tiles
-   * Uses up to 2 channel selections and 8 stream switch monitor ports
+   * Memory Tiles have 4 Performance counters.
+   * Group events exist but don't need to be defined.
+   * Memory tile trace uses time packets.
    */
-  class aie_cfg_peripheral_tile : public aie_cfg_base
+  class aie_cfg_memory_tile : public aie_cfg_base
   {
   public:
-    int8_t s2mm_channels[NUM_CHANNEL_SELECTS] = {-1, -1};
-    int8_t mm2s_channels[NUM_CHANNEL_SELECTS] = {-1, -1};
-    aie_cfg_peripheral_tile() : aie_cfg_base(4) {}
+    aie_cfg_memory_tile() : aie_cfg_base(4) {};
+  };
+
+  /*
+   * Interface Tiles have 2 Performance counters.
+   * Group events exist but don't need to be defined.
+   * Interface tile trace uses time packets.
+   */
+  class aie_cfg_interface_tile : public aie_cfg_base
+  {
+  public:
+    aie_cfg_interface_tile() : aie_cfg_base(2) {};
   };
 
   /*
@@ -284,12 +297,12 @@ enum class module_type {
     std::string trace_metric_set;
     aie_cfg_core core_trace_config;
     aie_cfg_memory memory_trace_config;
-    aie_cfg_peripheral_tile memory_tile_trace_config;
-    aie_cfg_peripheral_tile interface_tile_trace_config;
+    aie_cfg_memory_tile memory_tile_trace_config;
+    aie_cfg_interface_tile interface_tile_trace_config;
     aie_cfg_tile(uint32_t c, uint32_t r, module_type t) : column(c), row(r), type(t) {}
   };
 
-  // Used by by IPU profiling/debug on Windows
+  // Used by client profiling/debug
   typedef struct {
     uint64_t perf_address;
   } profile_data_t;

--- a/src/runtime_src/xdp/profile/device/tracedefs.h
+++ b/src/runtime_src/xdp/profile/device/tracedefs.h
@@ -1,6 +1,7 @@
 /**
- * Copyright (C) 2016-2017 Xilinx, Inc
- *
+ * Copyright (C) 2016-2022 Xilinx, Inc
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. - All rights reserved
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
  * License is located at

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_metadata.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_metadata.h
@@ -146,7 +146,9 @@ class AieTraceMetadata {
     std::map <module_type, std::vector<std::string>> metricSets {
       { module_type::core,     {"functions", "functions_partial_stalls", 
                                 "functions_all_stalls", "partial_stalls",
-                                "all_stalls", "all_dma", "all_stalls_dma", 
+                                "all_stalls", "all_dma", "all_stalls_dma",
+                                "all_stalls_s2mm", "all_stalls_mm2s",
+                                "s2mm_channels", "mm2s_channels",
                                 "s2mm_channels_stalls", "mm2s_channels_stalls"} },
       { module_type::mem_tile, {"input_channels", "input_channels_stalls", 
                                 "output_channels", "output_channels_stalls",

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/edge/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/edge/aie_trace.cpp
@@ -610,7 +610,7 @@ namespace xdp {
         auto traceStartEvent = (type == module_type::core) ? coreTraceStartEvent : memoryTileTraceStartEvent;
         auto traceEndEvent = (type == module_type::core) ? coreTraceEndEvent : memoryTileTraceEndEvent;
         
-        aie_cfg_base aieConfig = cfgTile->core_trace_config;
+        aie_cfg_base& aieConfig = cfgTile->core_trace_config;
         if (type == module_type::mem_tile)
           aieConfig = cfgTile->memory_tile_trace_config;
 
@@ -650,34 +650,19 @@ namespace xdp {
           auto iter1 = configChannel1.find(tile);
           uint8_t channel0 = (iter0 == configChannel0.end()) ? 0 : iter0->second;
           uint8_t channel1 = (iter1 == configChannel1.end()) ? 1 : iter1->second;
-          aie::trace::configEventSelections(aieDevInst, loc, type, metricSet, channel0, channel1);
-
-          // Record for runtime config file
-          cfgTile->memory_tile_trace_config.port_trace_ids[0] = channel0;
-          cfgTile->memory_tile_trace_config.port_trace_ids[1] = channel1;
-          if (aie::isInputSet(type, metricSet)) {
-            cfgTile->memory_tile_trace_config.port_trace_is_master[0] = true;
-            cfgTile->memory_tile_trace_config.port_trace_is_master[1] = true;
-            cfgTile->memory_tile_trace_config.s2mm_channels[0] = channel0;
-            if (channel0 != channel1)
-              cfgTile->memory_tile_trace_config.s2mm_channels[1] = channel1;
-          } 
-          else {
-            cfgTile->memory_tile_trace_config.port_trace_is_master[0] = false;
-            cfgTile->memory_tile_trace_config.port_trace_is_master[1] = false;
-            cfgTile->memory_tile_trace_config.mm2s_channels[0] = channel0;
-            if (channel0 != channel1)
-              cfgTile->memory_tile_trace_config.mm2s_channels[1] = channel1;
-          }
+          aie::trace::configEventSelections(aieDevInst, loc, type, metricSet, channel0, 
+                                            channel1, cfgTile->memory_tile_trace_config);
         }
         else {
-          // For simplicity, just check first event
-          // NOTE: for now, assume a single channel is monitored
+          // Record if these are channel-specific events
+          // NOTE: for now, check first event and assume single channel
           auto channelNum = aie::trace::getChannelNumberFromEvent(memoryEvents.at(0));
-          if (aie::isInputSet(type, metricSet))
-            cfgTile->memory_trace_config.mm2s_channels[0] = channelNum;
-          else
-            cfgTile->memory_trace_config.s2mm_channels[0] = channelNum;
+          if (channelNum > 0) {
+            if (aie::isInputSet(type, metricSet))
+              cfgTile->core_trace_config.mm2s_channels[0] = channelNum;
+            else
+              cfgTile->core_trace_config.s2mm_channels[0] = channelNum;
+          }
         }
 
         // Configure memory trace events
@@ -822,23 +807,9 @@ namespace xdp {
         // Modify events as needed
         aie::trace::modifyEvents(type, subtype, metricSet, channel0, interfaceEvents);
 
-        // Record for runtime config file
-        if (type == module_type::shim) {
-          if (aie::isInputSet(type, metricSet)) {
-            cfgTile->interface_tile_trace_config.mm2s_channels[0] = channel0;
-            if (channel0 != channel1)
-              cfgTile->interface_tile_trace_config.mm2s_channels[1] = channel1;
-          } 
-          else {
-            cfgTile->interface_tile_trace_config.s2mm_channels[0] = channel0;
-            if (channel0 != channel1)
-              cfgTile->interface_tile_trace_config.s2mm_channels[1] = channel1;
-          }
-        }
-
-        streamPorts = aie::trace::configStreamSwitchPorts(aieDevInst, tile, 
-                                                          xaieTile, loc, type, metricSet, 
-                                                          channel0, channel1, interfaceEvents, cfgTile->interface_tile_trace_config);
+        streamPorts = aie::trace::configStreamSwitchPorts(aieDevInst, tile, xaieTile, loc, type, metricSet, 
+                                                          channel0, channel1, interfaceEvents, 
+                                                          cfgTile->interface_tile_trace_config);
 
         // Configure interface tile trace events
         for (int i = 0; i < interfaceEvents.size(); i++) {

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/edge/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/edge/aie_trace.cpp
@@ -670,6 +670,15 @@ namespace xdp {
               cfgTile->memory_tile_trace_config.mm2s_channels[1] = channel1;
           }
         }
+        else {
+          // For simplicity, just check first event
+          // NOTE: for now, assume a single channel is monitored
+          auto channelNum = aie::trace::getChannelNumberFromEvent(memoryEvents.at(0));
+          if (aie::isInputSet(type, metricSet))
+            cfgTile->memory_trace_config.s2mm_channels[0] = channelNum;
+          else
+            cfgTile->memory_trace_config.s2mm_channels[0] = channelNum;
+        }
 
         // Configure memory trace events
         for (int i = 0; i < memoryEvents.size(); i++) {
@@ -705,9 +714,10 @@ namespace xdp {
             cfgTile->core_trace_config.internal_events_broadcast[bcId] = phyEvent;
             cfgTile->memory_trace_config.traced_events[S] = aie::bcIdToEvent(bcId);
           }
-          else {
+          else if (type == xdp::module_type::mem_tile)
             cfgTile->memory_tile_trace_config.traced_events[S] = phyEvent;
-          }
+          else
+            cfgTile->memory_trace_config.traced_events[S] = phyEvent;
         }
 
         // Add trace control events to config file
@@ -720,8 +730,8 @@ namespace xdp {
             coreToMemBcMask |= (1 << bcId);
 
             XAie_EventLogicalToPhysicalConv(aieDevInst, loc, XAIE_CORE_MOD, traceStartEvent, &phyEvent);
-            cfgTile->memory_trace_config.start_event = aie::bcIdToEvent(bcId);
             cfgTile->core_trace_config.internal_events_broadcast[bcId] = phyEvent;
+            cfgTile->memory_trace_config.start_event = aie::bcIdToEvent(bcId);
           }
           else {
             XAie_EventLogicalToPhysicalConv(aieDevInst, loc, XAIE_MEM_MOD, traceStartEvent, &phyEvent);
@@ -737,8 +747,8 @@ namespace xdp {
             coreToMemBcMask |= (1 << bcId);
           
             XAie_EventLogicalToPhysicalConv(aieDevInst, loc, XAIE_CORE_MOD, traceEndEvent, &phyEvent);
-            cfgTile->memory_trace_config.stop_event = aie::bcIdToEvent(bcId);
             cfgTile->core_trace_config.internal_events_broadcast[bcId] = phyEvent;
+            cfgTile->memory_trace_config.stop_event = aie::bcIdToEvent(bcId);
 
             // Use east broadcasting for AIE2+ or odd absolute rows of AIE1 checkerboard
             if ((row % 2) || (metadata->getHardwareGen() > 1))

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/edge/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/edge/aie_trace.cpp
@@ -657,7 +657,7 @@ namespace xdp {
           // Record if these are channel-specific events
           // NOTE: for now, check first event and assume single channel
           auto channelNum = aie::trace::getChannelNumberFromEvent(memoryEvents.at(0));
-          if (channelNum > 0) {
+          if (channelNum >= 0) {
             if (aie::isInputSet(type, metricSet))
               cfgTile->core_trace_config.mm2s_channels[0] = channelNum;
             else

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/edge/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/edge/aie_trace.cpp
@@ -675,7 +675,7 @@ namespace xdp {
           // NOTE: for now, assume a single channel is monitored
           auto channelNum = aie::trace::getChannelNumberFromEvent(memoryEvents.at(0));
           if (aie::isInputSet(type, metricSet))
-            cfgTile->memory_trace_config.s2mm_channels[0] = channelNum;
+            cfgTile->memory_trace_config.mm2s_channels[0] = channelNum;
           else
             cfgTile->memory_trace_config.s2mm_channels[0] = channelNum;
         }

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/util/aie_trace_config.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/util/aie_trace_config.cpp
@@ -84,15 +84,16 @@ namespace xdp::aie::trace {
           else {
             // Monitor DMA channels
             uint8_t channelNum = portnum % 2;
-            auto slaveOrMaster = (portnum < 2) ? XAIE_STRMSW_SLAVE : XAIE_STRMSW_MASTER;
-            std::string typeName = (portnum < 2) ? "MM2S" : "S2MM";
+            bool isMaster = ((portnum >= 2) || (metricSet.find("s2mm") != std::string::npos));
+            auto slaveOrMaster = isMaster ? XAIE_STRMSW_MASTER : XAIE_STRMSW_SLAVE;
+            std::string typeName = isMaster ? "S2MM" : "MM2S";
             std::string msg = "Configuring core module stream switch to monitor DMA " 
                             + typeName + " channel " + std::to_string(channelNum);
             xrt_core::message::send(severity_level::debug, "XRT", msg);
             switchPortRsc->setPortToSelect(slaveOrMaster, DMA, channelNum);
 
             config.port_trace_ids[portnum] = channelNum;
-            config.port_trace_is_master[portnum] = (slaveOrMaster == XAIE_STRMSW_MASTER);
+            config.port_trace_is_master[portnum] = isMaster;
           }
         }
         else if (type == module_type::shim) {

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/util/aie_trace_config.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/util/aie_trace_config.h
@@ -80,10 +80,12 @@ namespace xdp::aie::trace {
    * @param metricSet  Name of requested metric set
    * @param channel0   First specified channel number
    * @param channel1   Second specified channel number
+   * @param config     Class used to document configuration
    */
   void configEventSelections(XAie_DevInst* aieDevInst, const XAie_LocType loc,
                              const module_type type, const std::string metricSet, 
-                             const uint8_t channel0, const uint8_t channel);
+                             const uint8_t channel0, const uint8_t channel1,
+                             aie_cfg_base& config);
 
   /**
    * @brief Configure edge detection events

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/util/aie_trace_util.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/util/aie_trace_util.cpp
@@ -427,6 +427,43 @@ namespace xdp::aie::trace {
   }
 
   /****************************************************************************
+   * Get channel number based on event
+   ***************************************************************************/
+  int8_t getChannelNumberFromEvent(XAie_Events event)
+  {
+    switch (event) {
+    case XAIE_EVENT_DMA_S2MM_0_START_TASK_MEM:
+    case XAIE_EVENT_DMA_S2MM_0_FINISHED_BD_MEM:
+    case XAIE_EVENT_DMA_S2MM_0_FINISHED_TASK_MEM:
+    case XAIE_EVENT_DMA_S2MM_0_STALLED_LOCK_MEM:
+    case XAIE_EVENT_DMA_S2MM_0_STREAM_STARVATION_MEM:
+    case XAIE_EVENT_DMA_S2MM_0_MEMORY_BACKPRESSURE_MEM:
+    case XAIE_EVENT_DMA_MM2S_0_START_TASK_MEM:
+    case XAIE_EVENT_DMA_MM2S_0_FINISHED_BD_MEM:
+    case XAIE_EVENT_DMA_MM2S_0_FINISHED_TASK_MEM:
+    case XAIE_EVENT_DMA_MM2S_0_STALLED_LOCK_MEM:
+    case XAIE_EVENT_DMA_MM2S_0_STREAM_BACKPRESSURE_MEM:
+    case XAIE_EVENT_DMA_MM2S_0_MEMORY_STARVATION_MEM:
+      return 0;
+    case XAIE_EVENT_DMA_S2MM_1_START_TASK_MEM:
+    case XAIE_EVENT_DMA_S2MM_1_FINISHED_BD_MEM:
+    case XAIE_EVENT_DMA_S2MM_1_FINISHED_TASK_MEM:
+    case XAIE_EVENT_DMA_S2MM_1_STALLED_LOCK_MEM:
+    case XAIE_EVENT_DMA_S2MM_1_STREAM_STARVATION_MEM:
+    case XAIE_EVENT_DMA_S2MM_1_MEMORY_BACKPRESSURE_MEM:
+    case XAIE_EVENT_DMA_MM2S_1_START_TASK_MEM:
+    case XAIE_EVENT_DMA_MM2S_1_FINISHED_BD_MEM:
+    case XAIE_EVENT_DMA_MM2S_1_FINISHED_TASK_MEM:
+    case XAIE_EVENT_DMA_MM2S_1_STALLED_LOCK_MEM:
+    case XAIE_EVENT_DMA_MM2S_1_STREAM_BACKPRESSURE_MEM:
+    case XAIE_EVENT_DMA_MM2S_1_MEMORY_STARVATION_MEM:
+      return 1;
+    default:
+      return -1;
+    }
+  }
+
+  /****************************************************************************
    * Print out resource usage statistics for a given tile
    ***************************************************************************/
   void printTileStats(xaiefal::XAieDev* aieDevice, const tile_type& tile)

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/util/aie_trace_util.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/util/aie_trace_util.cpp
@@ -59,6 +59,11 @@ namespace xdp::aie::trace {
     eventSets["all_stalls"]               = eventSets["functions"];
     eventSets["all_dma"]                  = eventSets["functions"];
     eventSets["all_stalls_dma"]           = eventSets["functions"];
+    eventSets["s2mm_channels"]            = eventSets["functions"];
+    eventSets["mm2s_channels"]            = eventSets["functions"];
+    eventSets["all_stalls_s2mm"]          = eventSets["functions"];
+    eventSets["all_stalls_mm2s"]          = eventSets["functions"];
+
     if (hwGen > 1) {
       eventSets["s2mm_channels_stalls"]   = eventSets["functions"];
       eventSets["mm2s_channels_stalls"]   = eventSets["functions"];
@@ -100,8 +105,18 @@ namespace xdp::aie::trace {
          {XAIE_EVENT_INSTR_CALL_CORE,                      XAIE_EVENT_INSTR_RETURN_CORE,
           XAIE_EVENT_GROUP_CORE_STALL_CORE,                XAIE_EVENT_PORT_RUNNING_0_CORE,
           XAIE_EVENT_PORT_RUNNING_1_CORE,                  XAIE_EVENT_PORT_RUNNING_2_CORE,
-          XAIE_EVENT_PORT_RUNNING_3_CORE}}
-    };
+          XAIE_EVENT_PORT_RUNNING_3_CORE}},
+        {"s2mm_channels",
+         {XAIE_EVENT_INSTR_CALL_CORE,                      XAIE_EVENT_INSTR_RETURN_CORE,
+          XAIE_EVENT_PORT_RUNNING_0_CORE,                  XAIE_EVENT_PORT_RUNNING_1_CORE}},
+        {"all_stalls_s2mm",
+         {XAIE_EVENT_INSTR_CALL_CORE,                      XAIE_EVENT_INSTR_RETURN_CORE,
+          XAIE_EVENT_MEMORY_STALL_CORE,                    XAIE_EVENT_STREAM_STALL_CORE, 
+          XAIE_EVENT_CASCADE_STALL_CORE,                   XAIE_EVENT_LOCK_STALL_CORE,
+          XAIE_EVENT_PORT_RUNNING_0_CORE,                  XAIE_EVENT_PORT_RUNNING_1_CORE}}
+     };
+    eventSets["mm2s_channels"]   = eventSets["s2mm_channels"];
+    eventSets["all_stalls_mm2s"] = eventSets["all_stalls_s2mm"];
 
     // Sets w/ DMA stall/backpressure events not supported on AIE1 
     if (hwGen > 1) {

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/util/aie_trace_util.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/util/aie_trace_util.h
@@ -142,9 +142,16 @@ namespace xdp::aie::trace {
   /**
    * @brief  Get port number from event
    * @param  event Event ID to check
-   * @return Port number associated with given event
+   * @return Port number associated with given event (default: 0)
    */
   uint8_t getPortNumberFromEvent(XAie_Events event);
+
+  /**
+   * @brief  Get channel number from event
+   * @param  event Event ID to check
+   * @return Channel number associated with given event (default: -1)
+   */
+  int8_t getChannelNumberFromEvent(XAie_Events event);
 
   /**  
    * @brief Print out usage statistics for specified tile

--- a/src/runtime_src/xdp/profile/writer/aie_trace/aie_trace_config_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/aie_trace/aie_trace_config_writer.cpp
@@ -149,6 +149,25 @@ namespace xdp {
           }
 
           {
+            bpt::ptree sel_trace_config;
+            bpt::ptree s2mm_channels;
+            bpt::ptree mm2s_channels;
+
+            for (uint32_t i=0; i < NUM_CHANNEL_SELECTS; ++i) {
+              bpt::ptree chan1;
+              bpt::ptree chan2;
+              chan1.put("", tile->core_trace_config.s2mm_channels[i]);
+              chan2.put("", tile->core_trace_config.mm2s_channels[i]);
+              s2mm_channels.push_back(std::make_pair("", chan1));
+              mm2s_channels.push_back(std::make_pair("", chan2));
+            }
+            
+            sel_trace_config.add_child("s2mm_channels", s2mm_channels);
+            sel_trace_config.add_child("mm2s_channels", mm2s_channels);
+            core_trace_config.add_child("SelTraceConfig", sel_trace_config);
+          }
+
+          {
             bpt::ptree BroadcastTraceConfig;
             BroadcastTraceConfig.put("broadcast_mask_south", tile->core_trace_config.broadcast_mask_south);
             BroadcastTraceConfig.put("broadcast_mask_north", tile->core_trace_config.broadcast_mask_north);
@@ -247,25 +266,6 @@ namespace xdp {
             }
             BroadcastTraceConfig.add_child("internal_events_broadcast",  internal_events_broadcast);
             memory_trace_config.add_child("BroadcastTraceConfig", BroadcastTraceConfig);
-          }
-
-          {
-            bpt::ptree sel_trace_config;
-            bpt::ptree s2mm_channels;
-            bpt::ptree mm2s_channels;
-
-            for (uint32_t i=0; i < NUM_CHANNEL_SELECTS; ++i) {
-              bpt::ptree chan1;
-              bpt::ptree chan2;
-              chan1.put("", tile->memory_trace_config.s2mm_channels[i]);
-              chan2.put("", tile->memory_trace_config.mm2s_channels[i]);
-              s2mm_channels.push_back(std::make_pair("", chan1));
-              mm2s_channels.push_back(std::make_pair("", chan2));
-            }
-            
-            sel_trace_config.add_child("s2mm_channels", s2mm_channels);
-            sel_trace_config.add_child("mm2s_channels", mm2s_channels);
-            memory_trace_config.add_child("SelTraceConfig", sel_trace_config);
           }
 
           /*

--- a/src/runtime_src/xdp/profile/writer/aie_trace/aie_trace_config_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/aie_trace/aie_trace_config_writer.cpp
@@ -249,6 +249,25 @@ namespace xdp {
             memory_trace_config.add_child("BroadcastTraceConfig", BroadcastTraceConfig);
           }
 
+          {
+            bpt::ptree sel_trace_config;
+            bpt::ptree s2mm_channels;
+            bpt::ptree mm2s_channels;
+
+            for (uint32_t i=0; i < NUM_CHANNEL_SELECTS; ++i) {
+              bpt::ptree chan1;
+              bpt::ptree chan2;
+              chan1.put("", tile->memory_trace_config.s2mm_channels[i]);
+              chan2.put("", tile->memory_trace_config.mm2s_channels[i]);
+              s2mm_channels.push_back(std::make_pair("", chan1));
+              mm2s_channels.push_back(std::make_pair("", chan2));
+            }
+            
+            sel_trace_config.add_child("s2mm_channels", s2mm_channels);
+            sel_trace_config.add_child("mm2s_channels", mm2s_channels);
+            memory_trace_config.add_child("SelTraceConfig", sel_trace_config);
+          }
+
           /*
           * End Tile
           */
@@ -258,8 +277,9 @@ namespace xdp {
           AieTileTraceConfig.push_back(std::make_pair("", AieTileTraceConfig_C));
         }
         else if ((tile->type == module_type::mem_tile) || (tile->type == module_type::shim)) {
-          aie_cfg_peripheral_tile tile_trace_config = (tile->type == module_type::mem_tile) ? 
-              tile->memory_tile_trace_config : tile->interface_tile_trace_config;
+          aie_cfg_base tile_trace_config = tile->memory_tile_trace_config;
+          if (tile->type == module_type::shim) 
+            tile_trace_config = tile->interface_tile_trace_config;
 
           bpt::ptree TileTraceConfig_C;
           TileTraceConfig_C.put("column", tile->column);


### PR DESCRIPTION
**Problem solved by the commit**
* There were bugs when using trace metric sets that contain memory module DMA events
* Some metric sets were prone to overruns, especially on client devices
* Plugin was becoming overweight with config settings

**How problem was solved, alternative solutions (if any) and why they were rejected**
* Expanded metric sets including DMA events from memory module
* Corrected bugs in DMA portion of AIE trace plugin, including runtime config
* Streamlined plugin by moving config settings into helper functions

**Risks (if any) associated the changes in the commit**
Support for new metric sets on client/x86 devices is coming soon

**What has been tested and how, request additional testing if necessary**
Tested on vck190 and vek280

**Documentation impact (if any)**
Potential new metric sets