### PR TITLE
VITIS-11415 Remove dynamic region report for Ryzen devices

### DIFF
--- a/src/runtime_src/core/tools/xbutil2/xbutil.cpp
+++ b/src/runtime_src/core/tools/xbutil2/xbutil.cpp
@@ -54,7 +54,7 @@ R"(
 },{
   "aie": [{
     "examine": [{
-      "report": ["dynamic-regions", "electrical", "host", "memory", "platform", "aie", "aiemem", "aieshim", "aie-partitions", "telemetry"]
+      "report": ["electrical", "host", "memory", "platform", "aie", "aiemem", "aieshim", "aie-partitions", "telemetry"]
     }]
   },{
     "configure": [{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
The dynamic region report to prevent future conflict with nonprivileged loading of xclbins. The drivers will no longer have access to the xclbins and their contents, making the retrieval of compute units impossible. As a result, we must disable the dynamic region report for Ryzen.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Change is needed due to a change in driver design.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Remove the ability for end users to invoke the dynamic region report on Ryzen devices.

#### Risks (if any) associated the changes in the commit
None.

#### What has been tested and how, request additional testing if necessary
Windows MCDM
```
Z:\XRT-MCDM\build\WDebug\xilinx\xrt>xbutil examine -d -r dynamic-regions
XRT build version: 2.17.0
Build hash: 41f4221433c6b173316b61cb2e7e3ee5152d8075
Build date: 2024-02-14 14:10:24
Git branch: HEAD
PID: 2576
UID: 0
[Wed Feb 14 22:24:26 2024 GMT]
HOST: WIN-6LRRC5RR5PN
EXE:
[xbutil] ERROR: No report generator found for report: 'dynamic-regions'
: invalid argument
```

#### Documentation impact (if any)
We will need to update the documentation for Ryzen.