### PR TITLE
Vitis 6479 - Changing profiling to use correct clock frequencies for compute units and monitors

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info/pl_constructs.h
+++ b/src/runtime_src/xdp/profile/database/static_info/pl_constructs.h
@@ -129,6 +129,11 @@ namespace xdp {
     //  string comparisons, we check the name in the constructor and set
     //  this boolean.
     bool shellMonitor = false ;
+
+    // A monitor acquires the clock frequency (in MHz) of the compute unit
+    // that it is assigned to
+    double clockFrequency = 300.0;
+
     inline bool isShellMonitor() const { return shellMonitor ; }
 
     Monitor(DEBUG_IP_TYPE ty, uint64_t idx, const char* n,
@@ -218,6 +223,9 @@ namespace xdp {
     // resource
     std::vector<Port> masterPorts;
 
+    //Each compute unit has a specific clock frequency (in MHz)
+    double clockFrequency = 300.0;
+
     // If this compute unit has any AIMs or ASMs attached to its ports,
     //  then these vectors will keep track of the slot IDs inside the
     //  xdp::CounterResults structure for all of the attached monitors.
@@ -244,6 +252,7 @@ namespace xdp {
     inline bool getStreamTraceEnabled() const { return asmIdsWithTrace.size() > 0 ; }
     inline bool getDataflowEnabled() const    { return dataflow ; }
     inline bool getHasFA() const              { return hasFA ; }
+    inline double getClockFrequency()         { return clockFrequency ; }
     inline bool getDataTransferTraceEnabled() const 
       { return aimIdsWithTrace.size() > 0 ; }
 
@@ -254,6 +263,8 @@ namespace xdp {
     inline void setStallEnabled(bool b)    { stall = b ; }
     inline void setDataflowEnabled(bool b) { dataflow = b ; }
     inline void setFaEnabled(bool b)       { hasFA = b ; }
+
+    void setClockFrequency(double clkfreq) { clockFrequency =  clkfreq; }
 
     // Other functions
     inline void addAIM(uint32_t id, bool trace = false)

--- a/src/runtime_src/xdp/profile/database/static_info_database.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info_database.cpp
@@ -1614,7 +1614,6 @@ namespace xdp {
                 if (0 == clockPortName.compare("ap_clk")) {
                   auto tmp_var = clck.second.get<std::string>("requested_frequency");
                   clckfreq = std::stod(tmp_var);
-                  //clckfreq = clck.second.get_child("requested_frequency").data();
                   break;
                 }
               }
@@ -1624,8 +1623,6 @@ namespace xdp {
         }
 
       }catch(...) {
-          // TODO: catch section
-          //fout<<"Default clock frequency assigned to the compute unit \n" ;
           clckfreq = 300.0;
       }
     }
@@ -2290,8 +2287,6 @@ namespace xdp {
 
     // Step 5 -> Fill in the details like the name of the xclbin using
     //           the SYSTEM_METADATA section
-    //std::pair<const char*, size_t> systemMetadata =
-    //   xrt_core::xclbin_int::get_axlf_section(xrtXclbin, SYSTEM_METADATA);
 
     setXclbinName(currentXclbin, systemMetadata.first, systemMetadata.second);
     updateSystemDiagram(systemMetadata.first, systemMetadata.second);

--- a/src/runtime_src/xdp/profile/database/static_info_database.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info_database.cpp
@@ -1533,10 +1533,45 @@ namespace xdp {
   }
 
   void VPStaticDatabase::createComputeUnits(XclbinInfo* currentXclbin,
-                                            const ip_layout* ipLayoutSection)
+                                            const ip_layout* ipLayoutSection,
+                                            const char* systemMetadataSection,
+                                            size_t systemMetadataSz)
   {
     if (currentXclbin == nullptr || ipLayoutSection == nullptr)
       return;
+
+    //---------------------------------------------------------------------
+    
+    bool clockFlag = true;
+    boost::property_tree::ptree pt;
+    boost::property_tree::ptree user_regions;
+
+    if (systemMetadataSection == nullptr || systemMetadataSz <= 0) {
+      clockFlag = false;
+    }
+
+    else {
+
+    // Parse the SYSTEM_METADATA section using boost property trees, which
+    // could throw exceptions in multiple ways.
+    try{
+        std::stringstream ss;
+        ss.write(systemMetadataSection, systemMetadataSz);
+
+        // Create a property tree based off of the JSON
+        boost::property_tree::read_json(ss, pt);
+
+        auto top = pt.get_child("system_diagram_metadata");
+
+        // Parse the xclbin section for compute unit port information
+        auto xclbin = top.get_child("xclbin");
+        user_regions = xclbin.get_child("user_regions");
+    } catch(...) {
+      // TODO: catch section
+      clockFlag = false;
+    }
+    }
+    //---------------------------------------------------------------------
 
     ComputeUnitInstance* cu = nullptr;
     for(int32_t i = 0; i < ipLayoutSection->m_count; ++i) {
@@ -1559,6 +1594,43 @@ namespace xdp {
       if((ipData->properties >> IP_CONTROL_SHIFT) & FAST_ADAPTER) {
         cu->setFaEnabled(true);
       }
+
+      //---------------------------------------------------------------------
+      //asigning clock frequency to each compute unit
+      double clckfreq = 300.0;
+      if (clockFlag) {
+
+        try {
+          // Keep track of all the compute unit names associated with the id
+          // number so we can make the connection later.
+          for (auto& region : user_regions) {
+            for (auto& compute_unit : region.second.get_child("compute_units")) {
+              auto cuNameSysMD = compute_unit.second.get<std::string>("cu_name");
+              if ( 0 == cu->getName().compare(cuNameSysMD)) {
+              for (auto& clck :compute_unit.second.get_child("clocks")) {
+                // If the clock port name is ap clck, that is the frequency we associate
+                // with the compute unit
+                auto clockPortName = clck.second.get<std::string>("port_name");
+                if (0 == clockPortName.compare("ap_clk")) {
+                  auto tmp_var = clck.second.get<std::string>("requested_frequency");
+                  clckfreq = std::stod(tmp_var);
+                  //clckfreq = clck.second.get_child("requested_frequency").data();
+                  break;
+                }
+              }
+              break;
+            }
+          }
+        }
+
+      }catch(...) {
+          // TODO: catch section
+          //fout<<"Default clock frequency assigned to the compute unit \n" ;
+          clckfreq = 300.0;
+      }
+    }
+    cu->setClockFrequency(clckfreq);
+    //---------------------------------------------------------------------
     }
   }
 
@@ -1710,6 +1782,9 @@ namespace xdp {
         if (debugIpData->m_properties & XMON_TRACE_PROPERTY_MASK)
           mon->traceEnabled = true ;
 
+        // Assigning the compute unit's clock frequency to the monitor
+        mon->clockFrequency = cuObj->getClockFrequency();
+
         // Add the monitor to the list of all monitors in this xclbin
         xclbin->pl.ams.push_back(mon);
         // Associate it with this compute unit
@@ -1789,6 +1864,8 @@ namespace xdp {
 
     if (cuObj) {
       mon->cuPort = cuObj->getPort(portName);
+      // Assigning the compute unit's clock frequency to the monitor
+      mon->clockFrequency = cuObj->getClockFrequency();
     }
     if (debugIpData->m_properties & XMON_TRACE_PROPERTY_MASK) {
       mon->traceEnabled = true ;
@@ -1880,8 +1957,10 @@ namespace xdp {
                                index, debugIpData->m_name,
                                cuId);
     //mon->port = portName;
-    if (cuObj)
+    if (cuObj){
       mon->cuPort = cuObj->getPort(portName);
+      mon->clockFrequency = cuObj->getClockFrequency();
+    }
     if (debugIpData->m_properties & 0x2) {
       mon->isStreamRead = true;
     }
@@ -2169,14 +2248,17 @@ namespace xdp {
 
   bool VPStaticDatabase::initializeStructure(XclbinInfo* currentXclbin, xrt::xclbin xrtXclbin)
   {
-    // Step 1 -> Create the compute units based on the IP_LAYOUT section
+    // Step 1 -> Create the compute units based on the IP_LAYOUT and SYSTEM_METADATA section
     const ip_layout* ipLayoutSection =
       reinterpret_cast<const ip_layout*>(xrt_core::xclbin_int::get_axlf_section(xrtXclbin, IP_LAYOUT).first);
+
+    std::pair<const char*, size_t> systemMetadata =
+       xrt_core::xclbin_int::get_axlf_section(xrtXclbin, SYSTEM_METADATA);
 
     if(ipLayoutSection == nullptr)
       return true;
 
-    createComputeUnits(currentXclbin, ipLayoutSection);
+    createComputeUnits(currentXclbin, ipLayoutSection,systemMetadata.first, systemMetadata.second);
 
     // Step 2 -> Create the memory layout based on the MEM_TOPOLOGY section
     const mem_topology* memTopologySection =
@@ -2208,8 +2290,8 @@ namespace xdp {
 
     // Step 5 -> Fill in the details like the name of the xclbin using
     //           the SYSTEM_METADATA section
-    std::pair<const char*, size_t> systemMetadata =
-       xrt_core::xclbin_int::get_axlf_section(xrtXclbin, SYSTEM_METADATA);
+    //std::pair<const char*, size_t> systemMetadata =
+    //   xrt_core::xclbin_int::get_axlf_section(xrtXclbin, SYSTEM_METADATA);
 
     setXclbinName(currentXclbin, systemMetadata.first, systemMetadata.second);
     updateSystemDiagram(systemMetadata.first, systemMetadata.second);

--- a/src/runtime_src/xdp/profile/database/static_info_database.h
+++ b/src/runtime_src/xdp/profile/database/static_info_database.h
@@ -111,7 +111,7 @@ namespace xdp {
     bool resetDeviceInfo(uint64_t deviceId, const std::shared_ptr<xrt_core::device>& device);
 
     // Functions that create the overall structure of the Xclbin's PL region
-    void createComputeUnits(XclbinInfo*, const ip_layout*);
+    void createComputeUnits(XclbinInfo*, const ip_layout*,const char*,size_t);
     void createMemories(XclbinInfo*, const mem_topology*);
     void createConnections(XclbinInfo*, const ip_layout*, const mem_topology*,
                            const connectivity*);

--- a/src/runtime_src/xdp/profile/writer/vp_base/summary_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/summary_writer.cpp
@@ -1124,7 +1124,7 @@ namespace xdp {
             }
             else
             {
-              //fout << ((one_thousand * values.WriteLatency[AIMIndex]) / xclbin->pl.clockRatePLMHz) / (values.WriteTranx[AIMIndex]) << "," << "\n" ;
+              
               fout << ((one_thousand * values.WriteLatency[monitor->slotIndex]) / monitor->clockFrequency) / (values.WriteTranx[monitor->slotIndex]) << "," << "\n" ;
 
             }
@@ -1132,8 +1132,7 @@ namespace xdp {
           if (values.ReadTranx[monitor->slotIndex] > 0)
           {
             uint64_t totalReadBusyCycles = values.ReadBusyCycles[monitor->slotIndex] ;
-            //double totalReadTime =
-            //  (double)(totalReadBusyCycles) / (one_thousand * xclbin->pl.clockRatePLMHz);
+            
             double totalReadTime =
               static_cast<double>(totalReadBusyCycles) / (one_thousand * monitor->clockFrequency);
             double readTransferRate = (totalReadTime == zero) ? 0 :
@@ -1168,12 +1167,12 @@ namespace xdp {
             }
             else
             {
-              //fout << ((one_thousand * values.ReadLatency[AIMIndex]) / xclbin->pl.clockRatePLMHz) / (values.ReadTranx[AIMIndex]) << "," << "\n" ;
+              
               fout << ((one_thousand * values.ReadLatency[monitor->slotIndex]) / monitor->clockFrequency) / (values.ReadTranx[monitor->slotIndex]) << "," << "\n" ;
             }
           }
         }
-        //++AIMIndex ;
+       
       }
       }
     }
@@ -1196,7 +1195,7 @@ namespace xdp {
     printTable = false ;
     for (auto device : infos) {
       for (auto xclbin : device->loadedXclbins) {
-        //uint64_t AIMIndex = 0 ;
+        
         for (auto monitor : xclbin->pl.aims) {
           if (monitor->name.find("Peer to Peer") != std::string::npos) {
             // This is the monitor we're looking for
@@ -1209,7 +1208,7 @@ namespace xdp {
               break ;
             }
           }
-          //++AIMIndex ;
+          
         }
         if (printTable) break ;
       }
@@ -1233,7 +1232,6 @@ namespace xdp {
 
     for (auto device : infos) {
       for (auto xclbin : device->loadedXclbins) {
-        //uint64_t AIMIndex = 0 ;
         for (auto monitor : xclbin->pl.aims) {
           if (monitor->name.find("Peer to Peer") != std::string::npos) {
             // This is the monitor we are looking for
@@ -1242,8 +1240,6 @@ namespace xdp {
                                                      xclbin->uuid) ;
             if (values.WriteTranx[monitor->slotIndex] > 0) {
               uint64_t totalWriteBusyCycles = values.WriteBusyCycles[monitor->slotIndex] ;
-              //double totalWriteTime =
-              //  (double)(totalWriteBusyCycles) / (one_thousand * xclbin->pl.clockRatePLMHz);
               double totalWriteTime =
                 static_cast<double>(totalWriteBusyCycles) / (one_thousand * monitor->clockFrequency);
               double writeTransferRate = (totalWriteTime == zero) ? 0 :
@@ -1271,14 +1267,11 @@ namespace xdp {
                 fout << "N/A" << "," << "\n" ;
               }
               else {
-                //fout << ((one_thousand * values.WriteLatency[AIMIndex]) / xclbin->pl.clockRatePLMHz) / (values.WriteTranx[AIMIndex]) << "," << "\n" ;
                 fout << ((one_thousand * values.WriteLatency[monitor->slotIndex]) / monitor->clockFrequency) / (values.WriteTranx[monitor->slotIndex]) << "," << "\n" ;
               }
             }
             if (values.ReadTranx[monitor->slotIndex] > 0) {
                uint64_t totalReadBusyCycles = values.ReadBusyCycles[monitor->slotIndex] ;
-              //double totalReadTime =
-              //  (double)(totalReadBusyCycles) / (one_thousand * xclbin->pl.clockRatePLMHz);
               double totalReadTime =
                 static_cast<double>(totalReadBusyCycles) / (one_thousand * monitor->clockFrequency);
               double readTransferRate = (totalReadTime == zero) ? 0 :
@@ -1307,12 +1300,10 @@ namespace xdp {
                 fout << "N/A" << "," << "\n" ;
               }
               else {
-                //fout << ((one_thousand * values.ReadLatency[AIMIndex]) / xclbin->pl.clockRatePLMHz) / (values.ReadTranx[AIMIndex]) << "," << "\n" ;
                 fout << ((one_thousand * values.ReadLatency[monitor->slotIndex]) / monitor->clockFrequency) / (values.ReadTranx[monitor->slotIndex]) << "," << "\n" ;
               }
             }
           }
-          //++AIMIndex ;
         }
       }
     }
@@ -1354,7 +1345,6 @@ namespace xdp {
 
     for (auto device : infos) {
       for (auto xclbin : device->loadedXclbins) {
-        //uint64_t AIMIndex = 0;
         xdp::CounterResults values =
           db->getDynamicInfo().getCounterResults(device->deviceId,
                                                  xclbin->uuid) ;
@@ -1365,8 +1355,6 @@ namespace xdp {
 
             if (values.ReadTranx[aim->slotIndex] > 0) {
                uint64_t totalReadBusyCycles = values.ReadBusyCycles[aim->slotIndex] ;
-              //double totalReadTime =
-              //  (double)(totalReadBusyCycles) / (one_thousand * xclbin->pl.clockRatePLMHz);
               double totalReadTime =
                 static_cast<double>(totalReadBusyCycles) / (one_thousand * aim->clockFrequency);
               double readTransferRate = (totalReadTime == zero) ? 0 :
@@ -1380,14 +1368,11 @@ namespace xdp {
               fout << readTransferRate << "," ;
               fout << (static_cast<double>(values.ReadBytes[aim->slotIndex] / one_million)) << "," ;
               fout << (static_cast<double>(values.ReadBytes[aim->slotIndex]) / static_cast<double>(values.ReadTranx[aim->slotIndex])) / one_thousand << "," ;
-              //fout << ((one_thousand * values.ReadLatency[AIMIndex]) / xclbin->pl.clockRatePLMHz) / (values.ReadTranx[AIMIndex]) << ",\n" ;
               fout << ((one_thousand * values.ReadLatency[aim->slotIndex]) / aim->clockFrequency) / (values.ReadTranx[aim->slotIndex]) << ",\n" ;
 
             }
             if (values.WriteTranx[aim->slotIndex] > 0) {
                uint64_t totalWriteBusyCycles = values.WriteBusyCycles[aim->slotIndex] ;
-              //double totalWriteTime =
-              //  (double)(totalWriteBusyCycles) / (one_thousand * xclbin->pl.clockRatePLMHz);
               double totalWriteTime =
                 static_cast<double>(totalWriteBusyCycles) / (one_thousand * aim->clockFrequency);
               double writeTransferRate = (totalWriteTime == zero) ? 0 :
@@ -1400,11 +1385,9 @@ namespace xdp {
               fout << writeTransferRate << "," ;
               fout << (static_cast<double>(values.WriteBytes[aim->slotIndex] / one_million)) << "," ;
               fout << (static_cast<double>(values.WriteBytes[aim->slotIndex]) / static_cast<double>(values.WriteTranx[aim->slotIndex])) / one_thousand << "," ;
-              //fout << ((one_thousand * values.WriteLatency[AIMIndex]) / xclbin->pl.clockRatePLMHz) / (values.WriteTranx[AIMIndex]) << ",\n" ;
               fout << ((one_thousand * values.WriteLatency[aim->slotIndex]) / aim->clockFrequency) / (values.WriteTranx[aim->slotIndex]) << ",\n" ;
             }
           }
-          //++AIMIndex ;
         }
       }
     }
@@ -1419,7 +1402,6 @@ namespace xdp {
     bool printTable = false ;
     for (auto device : infos) {
       for (auto xclbin : device->loadedXclbins) {
-        //uint64_t AIMIndex = 0 ;
         for (auto monitor : xclbin->pl.aims) {
           if (monitor->name.find("Memory to Memory") != std::string::npos) {
             xdp::CounterResults values =
@@ -1431,7 +1413,6 @@ namespace xdp {
               break ;
             }
           }
-          //++AIMIndex ;
         }
         if (printTable) break ;
       }
@@ -1465,8 +1446,6 @@ namespace xdp {
                                                        xclbin->uuid) ;
             if (values.WriteTranx[monitor->slotIndex] > 0) {
               uint64_t totalWriteBusyCycles = values.WriteBusyCycles[monitor->slotIndex] ;
-              //double totalWriteTime =
-              //  (double)(totalWriteBusyCycles) / (one_thousand*xclbin->pl.clockRatePLMHz);
               double totalWriteTime =
                 static_cast<double>(totalWriteBusyCycles) / (one_thousand*monitor->clockFrequency);
 
@@ -1493,14 +1472,11 @@ namespace xdp {
                 fout << "N/A" << "," << "\n" ;
               }
               else {
-                //fout << ((one_thousand * values.WriteLatency[AIMIndex]) / xclbin->pl.clockRatePLMHz) / (values.WriteTranx[AIMIndex]) << "," << "\n" ;
                 fout << ((one_thousand * values.WriteLatency[monitor->slotIndex]) / monitor->clockFrequency) / (values.WriteTranx[monitor->slotIndex]) << "," << "\n" ;
               }
             }
             if (values.ReadTranx[monitor->slotIndex] > 0) {
                 uint64_t totalReadBusyCycles = values.ReadBusyCycles[monitor->slotIndex] ;
-              //double totalReadTime =
-              //  (double)(totalReadBusyCycles) / (one_thousand * xclbin->pl.clockRatePLMHz);
               double totalReadTime =
                 static_cast<double>(totalReadBusyCycles) / (one_thousand * monitor->clockFrequency);
               double readTransferRate = (totalReadTime == zero) ? 0 :
@@ -1529,12 +1505,10 @@ namespace xdp {
                 fout << "N/A" << "," << "\n" ;
               }
               else {
-                //fout << ((one_thousand * values.ReadLatency[AIMIndex]) / xclbin->pl.clockRatePLMHz) / (values.ReadTranx[AIMIndex]) << "," << "\n" ;
                 fout << ((one_thousand * values.ReadLatency[monitor->slotIndex]) / monitor->clockFrequency) / (values.ReadTranx[monitor->slotIndex]) << "," << "\n" ;
               }
             }
           }
-          //++AIMIndex ;
         }
       }
     }
@@ -1754,8 +1728,6 @@ namespace xdp {
               totalDataTransfer = totalReadBytes + totalWriteBytes ;
               auto totalBusyCycles =
                 values.ReadBusyCycles[AIMIndex]+values.WriteBusyCycles[AIMIndex];
-              //double totalTimeMSec =
-              //  (double)(totalBusyCycles) /(one_thousand * xclbin->pl.clockRatePLMHz) ; //Ask JV
               double totalTimeMSec = 
                 static_cast<double>(totalBusyCycles) /(one_thousand * (cu.second->getClockFrequency())) ;
 


### PR DESCRIPTION
#### Problem solved by the commit
The clock frequencies that are specified during compilation was not correctly reflected in the metadata that runtime uses for profiling. This has been updated and this pull request is now aligned with the correct clock frequencies.

#### How problem was solved, alternative solutions (if any) and why they were rejected.
Profiling is now parsing the system metadata section and now assigning each compute unit and monitor with their respective clock frequencies in the profiling data structures.

#### Risks (if any) associated the changes in the commit
Low risk as this is only affecting a few tables in the summary.

#### What has been tested and how, request additional testing if necessary
Tested this on a multiple clocks designs on a VEK 280.

