### PR TITLE
VITIS-11348 Refactor how the platform path is found per OS

### DIFF
--- a/src/runtime_src/core/tools/common/TestRunner.cpp
+++ b/src/runtime_src/core/tools/common/TestRunner.cpp
@@ -377,15 +377,15 @@ std::string
 TestRunner::findPlatformPath(const std::shared_ptr<xrt_core::device>& dev,
                              boost::property_tree::ptree& ptTest)
 {
-  std::vector<std::string> platform_paths = findPlatformPaths(_dev, _ptTest);
+  std::vector<std::string> platform_paths = findPlatformPaths(dev, ptTest);
 
   for (const auto& path : platform_paths) {
     if (std::filesystem::exists(path))
       return path;
   }
 
-  logger(_ptTest, "Details", boost::str(boost::format("No platform path available. Skipping validation.")));
-  _ptTest.put("status", test_token_skipped);
+  logger(ptTest, "Details", boost::str(boost::format("No platform path available. Skipping validation.")));
+  ptTest.put("status", test_token_skipped);
   return "";
 }
 
@@ -428,9 +428,9 @@ std::string
 TestRunner::findXclbinPath(const std::shared_ptr<xrt_core::device>& dev,
                            boost::property_tree::ptree& ptTest)
 {
-  const std::string xclbin_name = _ptTest.get<std::string>("xclbin", "");
-  std::vector<std::string> platform_paths = findPlatformPaths(_dev, _ptTest);
-  const std::string xclbin_dir = _ptTest.get<std::string>("xclbin_directory", "");
+  const std::string xclbin_name = ptTest.get<std::string>("xclbin", "");
+  std::vector<std::string> platform_paths = findPlatformPaths(dev, ptTest);
+  const std::string xclbin_dir = ptTest.get<std::string>("xclbin_directory", "");
   if (!xclbin_dir.empty())
     platform_paths.push_back(xclbin_dir);
 
@@ -440,22 +440,22 @@ TestRunner::findXclbinPath(const std::shared_ptr<xrt_core::device>& dev,
       return xclbin_path;
   }
 
-  logger(_ptTest, "Details", boost::str(boost::format("%s not available. Skipping validation.") % xclbin_name));
-  _ptTest.put("status", test_token_skipped);
+  logger(ptTest, "Details", boost::str(boost::format("%s not available. Skipping validation.") % xclbin_name));
+  ptTest.put("status", test_token_skipped);
   return "";
 }
 
 std::string
-TestRunner::findDPUPath( const std::shared_ptr<xrt_core::device>& _dev,
-                boost::property_tree::ptree& _ptTest,
+TestRunner::findDPUPath( const std::shared_ptr<xrt_core::device>& dev,
+                boost::property_tree::ptree& ptTest,
                 const std::string dpu_name)
 {
   const static std::string dpu_dir = "DPU_Sequence"; 
   std::filesystem::path prefix_path;
 
 #ifdef _WIN32
-  boost::ignore_unused(_dev);
-  prefix_path = xrt_core::environment::xclbin_path(_ptTest.get<std::string>("xclbin", "")).parent_path();
+  boost::ignore_unused(dev);
+  prefix_path = xrt_core::environment::xclbin_path(ptTest.get<std::string>("xclbin", "")).parent_path();
 #else
   prefix_path = std::filesystem::path("/opt/xilinx/xrt/test/");
 #endif
@@ -463,8 +463,8 @@ TestRunner::findDPUPath( const std::shared_ptr<xrt_core::device>& _dev,
   if (std::filesystem::exists(dpu_instr))
     return dpu_instr;
 
-  logger(_ptTest, "Details", boost::str(boost::format("%s not available. Skipping validation.") % dpu_name));
-  _ptTest.put("status", test_token_skipped);
+  logger(ptTest, "Details", boost::str(boost::format("%s not available. Skipping validation.") % dpu_name));
+  ptTest.put("status", test_token_skipped);
   return "";
 }
 

--- a/src/runtime_src/core/tools/common/TestRunner.cpp
+++ b/src/runtime_src/core/tools/common/TestRunner.cpp
@@ -1,18 +1,5 @@
- /**
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
 
 // ------ I N C L U D E   F I L E S -------------------------------------------
 // Local - Include Files
@@ -393,11 +380,11 @@ static std::vector<std::string>
 findRyzenPlatformPaths(const std::shared_ptr<xrt_core::device>& dev)
 {
 #ifdef _WIN32
-  boost::ignore_unused(_dev);
+  boost::ignore_unused(dev);
   std::vector<std::string> paths;
   const auto sys_paths = xrt_core::environment::xclbin_repo_paths();
   for (const auto sys_path : sys_paths)
-    paths.push_back(sys_path.string());
+    paths.push_back(sys_path.string() + "\\");
   return paths;
 #else
   const auto device_id = xrt_core::device_query<xrt_core::query::pcie_device>(dev);
@@ -446,22 +433,24 @@ TestRunner::findXclbinPath(const std::shared_ptr<xrt_core::device>& dev,
 }
 
 std::string
-TestRunner::findDPUPath( const std::shared_ptr<xrt_core::device>& dev,
+TestRunner::findDPUPath( const std::shared_ptr<xrt_core::device>& /*dev*/,
                 boost::property_tree::ptree& ptTest,
-                const std::string dpu_name)
+                const std::string& dpu_name)
 {
   const static std::string dpu_dir = "DPU_Sequence"; 
-  std::filesystem::path prefix_path;
+  std::vector<std::filesystem::path> paths;
 
 #ifdef _WIN32
-  boost::ignore_unused(dev);
-  prefix_path = xrt_core::environment::xclbin_path(ptTest.get<std::string>("xclbin", "")).parent_path();
+  paths = xrt_core::environment::xclbin_repo_paths();
 #else
-  prefix_path = std::filesystem::path("/opt/xilinx/xrt/test/");
+  paths.push_back(std::filesystem::path("/opt/xilinx/xrt/test/"));
 #endif
-  auto dpu_instr = prefix_path / dpu_dir / dpu_name;
-  if (std::filesystem::exists(dpu_instr))
-    return dpu_instr;
+
+  for (const auto& path : paths) {
+    auto dpu_instr = path / dpu_dir / dpu_name;
+    if (std::filesystem::exists(dpu_instr))
+      return dpu_instr.string();
+  }
 
   logger(ptTest, "Details", boost::str(boost::format("%s not available. Skipping validation.") % dpu_name));
   ptTest.put("status", test_token_skipped);

--- a/src/runtime_src/core/tools/common/TestRunner.h
+++ b/src/runtime_src/core/tools/common/TestRunner.h
@@ -38,8 +38,6 @@ class TestRunner : public JSONConfigurable {
     bool search_and_program_xclbin(const std::shared_ptr<xrt_core::device>& dev, boost::property_tree::ptree& ptTest);
     std::string findPlatformPath(const std::shared_ptr<xrt_core::device>& dev,
                                  boost::property_tree::ptree& ptTest);
-    std::vector<std::string> findPlatformPaths(const std::shared_ptr<xrt_core::device>& dev,
-                                               boost::property_tree::ptree& ptTest);
     std::vector<std::string> findDependencies( const std::string& test_path,
                       const std::string& ps_kernel_name);
     std::string findXclbinPath(const std::shared_ptr<xrt_core::device>& dev,
@@ -54,6 +52,8 @@ class TestRunner : public JSONConfigurable {
     std::string m_xclbin;
  
   private:
+    std::vector<std::string> findPlatformPaths(const std::shared_ptr<xrt_core::device>& dev,
+                                               boost::property_tree::ptree& ptTest);
     std::string searchLegacyXclbin(const uint16_t vendor, const std::string& dev_name, 
                       boost::property_tree::ptree& _ptTest);
     std::string searchSSV2Xclbin(const std::string& logic_uuid,

--- a/src/runtime_src/core/tools/common/TestRunner.h
+++ b/src/runtime_src/core/tools/common/TestRunner.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
 
 #ifndef __TestRunner_h_
 #define __TestRunner_h_
@@ -45,7 +45,7 @@ class TestRunner : public JSONConfigurable {
     std::string findXclbinPath(const std::shared_ptr<xrt_core::device>& dev,
                                boost::property_tree::ptree& ptTest);
     std::string findDPUPath(const std::shared_ptr<xrt_core::device>& dev,
-                            boost::property_tree::ptree& ptTest, const std::string dpu_name);
+                            boost::property_tree::ptree& ptTest, const std::string& dpu_name);
     int validate_binary_file(const std::string& binaryfile);
 
     const std::string test_token_skipped = "SKIPPED";

--- a/src/runtime_src/core/tools/common/TestRunner.h
+++ b/src/runtime_src/core/tools/common/TestRunner.h
@@ -13,6 +13,7 @@
 
 // System - Include Files
 #include <string>
+#include <vector>
 
 class TestRunner : public JSONConfigurable {
   public:
@@ -26,10 +27,6 @@ class TestRunner : public JSONConfigurable {
     const std::string & getConfigName() const { return get_name(); };
     virtual const std::string& getConfigDescription() const { return m_description; };
     boost::property_tree::ptree get_test_header();
-    std::string findXclbinPath( const std::shared_ptr<xrt_core::device>& _dev,
-                      boost::property_tree::ptree& _ptTest);
-    std::string findDPUPath( const std::shared_ptr<xrt_core::device>& _dev,
-                              boost::property_tree::ptree& _ptTest, const std::string dpu_name);
 
   // Child class helper methods
   protected:
@@ -39,10 +36,16 @@ class TestRunner : public JSONConfigurable {
              boost::property_tree::ptree& _ptTest);
     void logger(boost::property_tree::ptree& ptree, const std::string& tag, const std::string& msg);
     bool search_and_program_xclbin(const std::shared_ptr<xrt_core::device>& dev, boost::property_tree::ptree& ptTest);
-    std::string findPlatformPath(const std::shared_ptr<xrt_core::device>& _dev,
-                  boost::property_tree::ptree& _ptTest);
+    std::string findPlatformPath(const std::shared_ptr<xrt_core::device>& dev,
+                                 boost::property_tree::ptree& ptTest);
+    std::vector<std::string> findPlatformPaths(const std::shared_ptr<xrt_core::device>& dev,
+                                               boost::property_tree::ptree& ptTest);
     std::vector<std::string> findDependencies( const std::string& test_path,
                       const std::string& ps_kernel_name);
+    std::string findXclbinPath(const std::shared_ptr<xrt_core::device>& dev,
+                               boost::property_tree::ptree& ptTest);
+    std::string findDPUPath(const std::shared_ptr<xrt_core::device>& dev,
+                            boost::property_tree::ptree& ptTest, const std::string dpu_name);
     int validate_binary_file(const std::string& binaryfile);
 
     const std::string test_token_skipped = "SKIPPED";

--- a/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.cpp
@@ -135,15 +135,10 @@ TestDF_bandwidth::run(std::shared_ptr<xrt_core::device> dev)
   xrt::kernel kernel{hwctx, kernelName};
 
   // Find DPU instruction file
-  std::string dpu_instr;
-  try {
-    dpu_instr = findDPUPath(dev, ptree, m_dpu_name);
-  }
-  catch(const std::exception& ex) {
-    logger(ptree, "Error", ex.what());
-    ptree.put("status", test_token_failed);
+  std::string dpu_instr = findDPUPath(dev, ptree, m_dpu_name);
+  if (!std::filesystem::exists(dpu_instr))
     return ptree;
-  }
+
   logger(ptree, "DPU-Sequence", dpu_instr);
 
   size_t instr_size = 0;

--- a/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.cpp
@@ -1,4 +1,5 @@
-// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
 
 // ------ I N C L U D E   F I L E S -------------------------------------------
 // Local - Include Files

--- a/src/runtime_src/core/tools/common/tests/TestIPU.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestIPU.cpp
@@ -1,4 +1,5 @@
-// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
 
 // ------ I N C L U D E   F I L E S -------------------------------------------
 // Local - Include Files

--- a/src/runtime_src/core/tools/common/tests/TestTCTAllColumn.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestTCTAllColumn.cpp
@@ -1,4 +1,5 @@
-// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
 
 // ------ I N C L U D E   F I L E S -------------------------------------------
 // Local - Include Files

--- a/src/runtime_src/core/tools/common/tests/TestTCTAllColumn.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestTCTAllColumn.cpp
@@ -130,15 +130,10 @@ TestTCTAllColumn::run(std::shared_ptr<xrt_core::device> dev)
   xrt::kernel kernel{hwctx, kernelName};
 
   // Find DPU instruction file
-  std::string dpu_instr;
-  try {
-    dpu_instr = findDPUPath(dev, ptree, m_dpu_name);
-  }
-  catch(const std::exception& ex) {
-    logger(ptree, "Error", ex.what());
-    ptree.put("status", test_token_failed);
+  std::string dpu_instr = findDPUPath(dev, ptree, m_dpu_name);
+  if (!std::filesystem::exists(dpu_instr))
     return ptree;
-  }
+
   logger(ptree, "DPU-Sequence", dpu_instr);
 
   size_t instr_size = 0;

--- a/src/runtime_src/core/tools/common/tests/TestTCTOneColumn.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestTCTOneColumn.cpp
@@ -1,4 +1,5 @@
-// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
 
 // ------ I N C L U D E   F I L E S -------------------------------------------
 // Local - Include Files

--- a/src/runtime_src/core/tools/common/tests/TestTCTOneColumn.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestTCTOneColumn.cpp
@@ -130,15 +130,10 @@ TestTCTOneColumn::run(std::shared_ptr<xrt_core::device> dev)
   xrt::kernel kernel{hwctx, kernelName};
 
   // Find DPU instruction file
-  std::string dpu_instr;
-  try {
-    dpu_instr = findDPUPath(dev, ptree, m_dpu_name);
-  }
-  catch(const std::exception& ex) {
-    logger(ptree, "Error", ex.what());
-    ptree.put("status", test_token_failed);
+  std::string dpu_instr = findDPUPath(dev, ptree, m_dpu_name);
+  if (!std::filesystem::exists(dpu_instr))
     return ptree;
-  }
+
   logger(ptree, "DPU-Sequence", dpu_instr);
 
   size_t instr_size = 0;

--- a/src/runtime_src/core/tools/common/tests/TestVerify.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestVerify.cpp
@@ -1,4 +1,5 @@
-// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
 
 // ------ I N C L U D E   F I L E S -------------------------------------------
 // Local - Include Files
@@ -23,16 +24,15 @@ TestVerify::TestVerify()
 boost::property_tree::ptree
 TestVerify::run(std::shared_ptr<xrt_core::device> dev)
 {
-  auto device_name = xrt_core::device_query_default<xrt_core::query::rom_vbnv>(dev, "");
   boost::property_tree::ptree ptree;
-  //to-do: Do it in a cleaner way
-  if (device_name.find("Ryzen") != std::string::npos) {
-    //run ipu verify
+  switch (xrt_core::device_query<xrt_core::query::device_class>(dev)) {
+  case xrt_core::query::device_class::type::ryzen:
     ptree = TestIPU{}.run(dev);
-  }
-  else {
+    break;
+  case xrt_core::query::device_class::type::alveo:
     ptree = get_test_header();
     runTest(dev, ptree);
+    break;
   }
   return ptree;
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
SubCmdValidate had some strange looking code to return the platform path and the dpu sequence path.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Not a bug.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Moved the logic to get the Ryzen platform paths into a single location. Remove any try catch statements to encourage parsing of all possible paths.

#### Risks (if any) associated the changes in the commit
None.

#### What has been tested and how, request additional testing if necessary
Ubuntu 22.04 U55c
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ xbutil validate -r all
WARNING: Unexpected xocl version (2.16.0) was found. Expected 2.17.0, to match XRT tools.
Validate Device           : [0000:04:00.1]
    Platform              : xilinx_u55c_gen3x16_xdma_base_3
    SC Version            : 7.1.22
    Platform ID           : 97088961-FEAE-DA91-52A2-1D9DFD63CCEF
-------------------------------------------------------------------------------
Test 1 [0000:04:00.1]     : pcie-link
    Warning(s)            : Link is active
                            Please make sure that the device is plugged into Gen 3x16,
                            instead of Gen 3x4. Lower performance maybe experienced.
    Test Status           : [PASSED WITH WARNINGS]
-------------------------------------------------------------------------------
Test 2 [0000:04:00.1]     : sc-version
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Test 3 [0000:04:00.1]     : verify
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Test 4 [0000:04:00.1]     : dma
    Details               : Buffer size - '16 MB' Memory Tag - 'HBM[0]'
                            Host -> PCIe -> FPGA write bandwidth = 2803.4 MB/s
                            Host <- PCIe <- FPGA read bandwidth = 2354.5 MB/s
                            ... A bunch of memory regions ...
                            Buffer size - '16 MB' Memory Tag - 'HBM[31]'
                            Host -> PCIe -> FPGA write bandwidth = 2883.6 MB/s
                            Host <- PCIe <- FPGA read bandwidth = 2395.6 MB/s
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Test 5 [0000:04:00.1]     : iops
    Details               : Overall Commands: 50000, IOPS: 437455 (verify)
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Test 6 [0000:04:00.1]     : mem-bw
    Details               : Throughput (Type: HBM) (Bank count: 1) : 12100.6 MB/s
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Validation completed, but with warnings. Please run the command '--verbose' option for more details
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ xbutil validate -r verify --verbose
WARNING: Unexpected xocl version (2.16.0) was found. Expected 2.17.0, to match XRT tools.
Verbose: Enabling Verbosity
Validate Device           : [0000:04:00.1]
    Platform              : xilinx_u55c_gen3x16_xdma_base_3
    SC Version            : 7.1.22
    Platform ID           : 97088961-FEAE-DA91-52A2-1D9DFD63CCEF
-------------------------------------------------------------------------------
Test 1 [0000:04:00.1]     : verify
    Description           : Run 'Hello World' kernel test
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Validation completed
```

#### Documentation impact (if any)
None