### PR TITLE
Add support for debug buffer object in XRT for internal use

### DIFF
--- a/src/runtime_src/core/common/api/bo_int.h
+++ b/src/runtime_src/core/common/api/bo_int.h
@@ -5,6 +5,7 @@
 #define _XRT_COMMON_BO_INT_H_
 
 // This file defines implementation extensions to the XRT BO APIs.
+#include "core/common/config.h"
 #include "core/include/xrt/xrt_bo.h"
 #include "core/common/shim/buffer_handle.h"
 
@@ -15,6 +16,16 @@ get_buffer_handle(const xrt::bo& bo);
 
 size_t
 get_offset(const xrt::bo& bo);
+
+// create_debug_bo() - Create a debug buffer object within a hwctx
+//  
+// Allocates a debug buffer object within a hwctx. The debug BO
+// is for sharing of driver / firmware data with user space XRT.
+// The shim allocation is through hwctx_handle::alloc_bo with
+// the XRT_BO_USE_DEBUG flag captured in extension flags.
+XRT_CORE_COMMON_EXPORT
+xrt::bo
+create_debug_bo(const xrt::hw_context& hwctx, size_t sz);
 
 } // bo_int, xrt_core
 

--- a/src/runtime_src/core/include/xrt_mem.h
+++ b/src/runtime_src/core/include/xrt_mem.h
@@ -75,7 +75,8 @@ struct xcl_bo_flags
       // extension
       uint32_t access : 2;  // [33-32]
       uint32_t dir    : 2;  // [35-34]
-      uint32_t unused : 28; // [63-36]
+      uint32_t use    : 1;  // [36]
+      uint32_t unused : 27; // [63-35]
     };
   };
 };
@@ -112,6 +113,16 @@ struct xcl_bo_flags
 #define XRT_BO_ACCESS_READ    (1U << 0)
 #define XRT_BO_ACCESS_WRITE   (1U << 1)
 #define XRT_BO_ACCESS_READ_WRITE (XRT_BO_ACCESS_READ | XRT_BO_ACCESS_WRITE)
+
+/**
+ * Shim level BO Flags to distinguish use of BO
+ *
+ * The use flag is for internal use only. A debug BO
+ * is supported only on some platforms to communicate
+ * data from driver / firmware back to user space.
+ */
+#define XRT_BO_USE_NORMAL 0
+#define XRT_BO_USE_DEBUG  1
 
 /**
  * XRT Native BO flags


### PR DESCRIPTION
#### Problem solved by the commit
Allocate a “special” type of BO in a virtual region shared with instruction buffers within a hardware context. The driver will share this buffer object with firmware where the buffer will be populated with data to be shared with user space XRT.

#### How problem was solved, alternative solutions (if any) and why they were rejected
The implementation makes use of a new XRT_BO_USE_DEBUG flag which is ignored for all other use cases.

The allocation of the debug buffer object is through an internal API which takes as argument the xrt::hw_context in which the buffer is to be allocated, plus the size of the debug buffer.

#### Risks (if any) associated the changes in the commit
None, the new API is currently not used.

