### PR TITLE
CR-1187549 WDF : xbutil configure --help does not provide supported actions

### DIFF
--- a/src/runtime_src/core/tools/common/XBHelpMenusCore.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenusCore.cpp
@@ -415,7 +415,7 @@ print_options(std::stringstream& stream,
   const auto& fh = FormatHelper::instance();
   boost::format fmtOption(fh.fgc_optionName + "  %-18s " + fh.fgc_optionBody + "- %s\n" + fh.fgc_reset);
   for (auto & option : options.options()) {
-    if ( ::isPositional( option->canonical_display_name(po::command_line_style::allow_dash_for_short),
+    if ( !::isPositional( option->canonical_display_name(po::command_line_style::allow_dash_for_short),
                          positionals) )  {
       continue;
     }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
--help doesn't show the valid options "action" 

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Locally:
```
% xbutil configure --performance --help
WARNING: Unexpected xocl version (2.17.97) was found. Expected 2.17.0, to match XRT tools.

COMMAND: configure

DESCRIPTION: Change performance mode of the device

USAGE:  configure --performance [--help] [-d arg] action

OPTIONS:
  --action           - Action to perform: DEFAULT, POWERSAVER, BALANCED, PERFORMANCE
```

#### Documentation impact (if any)
