### PR TITLE
CR-1190692 Add method to set read range on xrt::ip

### DIFF
--- a/src/runtime_src/core/common/api/ip_int.h
+++ b/src/runtime_src/core/common/api/ip_int.h
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+//
+#ifndef XRT_COMMON_IP_INT_H_
+#define XRT_COMMON_IP_INT_H_
+
+// This file defines implementation extensions to the XRT BO APIs.
+#include "core/common/config.h"
+#include "core/include/experimental/xrt_ip.h"
+
+namespace xrt_core::ip_int {
+
+XCL_DRIVER_DLLESPEC
+void
+set_read_range(const xrt::ip& ip, uint32_t start, uint32_t size);
+
+} // xrt_core::ip_int
+
+#endif


### PR DESCRIPTION
#### Problem solved by the commit
Add internal API to set the read range of an xrt::ip object.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Access to xclAPIs is being removed and everyone including internal XRT must use native objects for access shim functionality.  For special deadlock detection, IPs have registers outside the advertised address range. In order to read these registers, the address range must be expanded.  

#### How problem was solved, alternative solutions (if any) and why they were rejected
This PR adds support for expanding the read range of an xrt::ip.

#### Risks (if any) associated the changes in the commit
Internal API, currently unused.

#### What has been tested and how, request additional testing if necessary
No testing
