### PR TITLE
Updating trace clock for PL

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info_database.h
+++ b/src/runtime_src/xdp/profile/database/static_info_database.h
@@ -76,7 +76,7 @@ namespace xdp {
     int pid ;
     uint64_t applicationStartTime = 0 ;
     bool aieApplication = false;
-    
+
     // The files that need to be included in the run summary for
     //  consumption by Vitis_Analyzer
     std::vector<std::pair<std::string, std::string> > openedFiles ;
@@ -84,11 +84,11 @@ namespace xdp {
 
     // ***** OpenCL Information ******
     std::set<uint64_t> commandQueueAddresses ;
-    std::set<std::string> enqueuedKernels ; 
+    std::set<std::string> enqueuedKernels ;
     std::map<uint64_t, uint64_t> contextIdToNumDevices ;
 
     // For OpenCL software emulation, we need a tiny bit of device info
-    std::string softwareEmulationDeviceName ; 
+    std::string softwareEmulationDeviceName ;
     std::map<std::string, uint64_t> softwareEmulationCUCounts ;
     std::map<std::string, bool> softwareEmulationMemUsage ;
     std::vector<std::string> softwareEmulationPortBitWidths ;
@@ -143,7 +143,7 @@ namespace xdp {
     double findClockRate(xrt::xclbin);
     DeviceInfo* updateDevice(uint64_t deviceId, xrt::xclbin xrtXclbin) ;
 
-    
+
 
   public:
     VPStaticDatabase(VPDatabase* d) ;
@@ -245,7 +245,8 @@ namespace xdp {
     XDP_CORE_EXPORT void deleteCurrentlyUsedDeviceInterface(uint64_t deviceId) ;
     XDP_CORE_EXPORT bool isDeviceReady(uint64_t deviceId) ;
     XDP_CORE_EXPORT double getClockRateMHz(uint64_t deviceId, bool PL = true) ;
-    XDP_CORE_EXPORT void setDeviceName(uint64_t deviceId, const std::string& name) ; 
+    XDP_CORE_EXPORT double getPLMaxClockRateMHz(uint64_t deviceId);
+    XDP_CORE_EXPORT void setDeviceName(uint64_t deviceId, const std::string& name) ;
     XDP_CORE_EXPORT std::string getDeviceName(uint64_t deviceId) ;
     XDP_CORE_EXPORT DeviceIntf* getDeviceIntf(uint64_t deviceId) ;
     XDP_CORE_EXPORT DeviceIntf* createDeviceIntf(uint64_t deviceId, xdp::Device* dev);
@@ -381,7 +382,7 @@ namespace xdp {
                           uint64_t slotID) ;
     XDP_CORE_EXPORT
     NoCNode* getNOC(uint64_t deviceId, XclbinInfo* xclbin, uint64_t idx) ;
-    // This function takes a pre-allocated array of bools to fill with 
+    // This function takes a pre-allocated array of bools to fill with
     //  the status of each compute unit's AM dataflow enabled status
     XDP_CORE_EXPORT
     void getDataflowConfiguration(uint64_t deviceId, bool* config, size_t size);

--- a/src/runtime_src/xdp/profile/device/device_trace_logger.cpp
+++ b/src/runtime_src/xdp/profile/device/device_trace_logger.cpp
@@ -38,7 +38,9 @@ namespace xdp {
       traceClockRateMHz(0),
       clockTrainSlope(0)
   {
-    traceClockRateMHz = db->getStaticInfo().getClockRateMHz(deviceId);
+    //This trace logger function is for PL only
+
+    traceClockRateMHz = db->getStaticInfo().getPLMaxClockRateMHz(deviceId);
     clockTrainSlope = 1000.0/traceClockRateMHz;
 
     xclbin = (db->getStaticInfo()).getCurrentlyLoadedXclbin(devId);
@@ -301,7 +303,7 @@ namespace xdp {
       if(isSingle || matchingStart.type == UNKNOWN_EVENT) {
         // add dummy start event
         strmEvent = new DeviceStreamAccess(0, hostTimestamp, streamEventType, deviceId, slot, cuId);
-        strmEvent->setDeviceTimestamp(deviceTimestamp); 
+        strmEvent->setDeviceTimestamp(deviceTimestamp);
         db->getDynamicInfo().addEvent(strmEvent);
         matchingStart.type = strmEvent->getEventType();
         matchingStart.eventID = strmEvent->getEventId();
@@ -311,7 +313,7 @@ namespace xdp {
       }
       // add end event
       strmEvent = new DeviceStreamAccess(matchingStart.eventID, hostTimestamp, streamEventType, deviceId, slot, cuId);
-      strmEvent->setDeviceTimestamp(deviceTimestamp); 
+      strmEvent->setDeviceTimestamp(deviceTimestamp);
       db->getDynamicInfo().addEvent(strmEvent);
       asmLastTrans[slot] = deviceTimestamp;
     }
@@ -383,13 +385,13 @@ namespace xdp {
           // The times are different, so we need to end the matching start
           //  and then create an additional pulse
           memEvent = new DeviceMemoryAccess(matchingStart.eventID,
-                                            hostTimestamp, ty, 
+                                            hostTimestamp, ty,
                                             deviceId, slot, cuId, memStrId);
           memEvent->setDeviceTimestamp(deviceTimestamp);
           db->getDynamicInfo().addEvent(memEvent);
 
           // Now create the dummy start
-          memEvent = new DeviceMemoryAccess(0, hostTimestamp, ty, 
+          memEvent = new DeviceMemoryAccess(0, hostTimestamp, ty,
                                             deviceId, slot, cuId, memStrId);
           memEvent->setDeviceTimestamp(deviceTimestamp);
           db->getDynamicInfo().addEvent(memEvent);
@@ -404,7 +406,7 @@ namespace xdp {
 
       // The true end event we observed
       memEvent = new DeviceMemoryAccess(matchingStart.eventID,
-                                        hostTimestamp, ty, 
+                                        hostTimestamp, ty,
                                         deviceId, slot, cuId, memStrId);
       memEvent->setDeviceTimestamp(deviceTimestamp);
       db->getDynamicInfo().addEvent(memEvent);
@@ -660,7 +662,7 @@ namespace xdp {
     }
   }
 
-  void DeviceTraceLogger::addApproximateStreamEndEvent(uint64_t asmIndex, uint64_t asmTraceID, VTFEventType streamEventType, 
+  void DeviceTraceLogger::addApproximateStreamEndEvent(uint64_t asmIndex, uint64_t asmTraceID, VTFEventType streamEventType,
                                                                  int32_t cuId, int32_t  amId, uint64_t cuLastTimestamp,
                                                                  uint64_t &asmAppxLastTransTimeStamp, bool &unfinishedASMevents)
   {


### PR DESCRIPTION
#### Problem solved by the commit
When adjusting device trace timestamps, the trace clock is used for calculations. Until now, the default value for PL design (300 MHz) was used as the trace clock frequency. Now, by the changes of this commit, the trace clock is determined by choosing the fastest compute unit clock. Also, some code cleanup has been done by removing trailing whitespaces.

#### How problem was solved, alternative solutions (if any) and why they were rejected
The clock frequency for every Compute Unit in the design, is retrieved and the maximum frequency is calculated from them.

#### What has been tested and how, request additional testing if necessary
The logic has been tested on a PL design having compute units with different clock frequencies, run on an edge board VEK280 .
