### PR TITLE
xbutil fix help menu

### DIFF
--- a/src/runtime_src/core/tools/common/XBHelpMenusCore.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenusCore.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2020-2022 Xilinx, Inc
-// Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
 // ------ I N C L U D E   F I L E S -------------------------------------------
 // Local - Include Files
 #include "XBHelpMenusCore.h"

--- a/src/runtime_src/core/tools/common/XBHelpMenusCore.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenusCore.cpp
@@ -415,11 +415,6 @@ print_options(std::stringstream& stream,
   const auto& fh = FormatHelper::instance();
   boost::format fmtOption(fh.fgc_optionName + "  %-18s " + fh.fgc_optionBody + "- %s\n" + fh.fgc_reset);
   for (auto & option : options.options()) {
-    if ( !::isPositional( option->canonical_display_name(po::command_line_style::allow_dash_for_short),
-                         positionals) )  {
-      continue;
-    }
-
     std::string optionDisplayFormat = create_option_format_name(option.get(), report_param, remove_long_dashes);
     const unsigned int optionDescTab = 23;
     auto formattedString = XBU::wrap_paragraphs(option->description(), optionDescTab, m_maxColumnWidth - optionDescTab, false);

--- a/src/runtime_src/core/tools/common/XBHelpMenusCore.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenusCore.cpp
@@ -370,10 +370,10 @@ XBUtilities::report_commands_help( const std::string &_executable,
     }
   }
 
-  report_option_help("OPTIONS", _optionDescription, emptyPOD);
+  report_option_help("OPTIONS", _optionDescription);
 
   if (XBU::getShowHidden())
-    report_option_help(std::string("OPTIONS ") + sHidden, _optionHidden, emptyPOD);
+    report_option_help(std::string("OPTIONS ") + sHidden, _optionHidden);
 }
 
 static std::string
@@ -408,7 +408,6 @@ create_option_format_name(const boost::program_options::option_description * _op
 static void
 print_options(std::stringstream& stream,
               const boost::program_options::options_description& options,
-              const boost::program_options::positional_options_description& positionals,
               const bool report_param,
               const bool remove_long_dashes)
 {
@@ -425,7 +424,6 @@ print_options(std::stringstream& stream,
 void
 XBUtilities::report_option_help(const std::string & _groupName,
                                 const boost::program_options::options_description& _optionDescription,
-                                const boost::program_options::positional_options_description& _positionalDescription,
                                 const bool _bReportParameter,
                                 const bool removeLongOptDashes,
                                 const std::map<std::string, std::vector<std::shared_ptr<JSONConfigurable>>>& all_device_options,
@@ -460,7 +458,7 @@ XBUtilities::report_option_help(const std::string & _groupName,
 
   // Generate the common options
   std::stringstream commonOutput;
-  print_options(commonOutput, common_options, _positionalDescription, _bReportParameter, removeLongOptDashes);
+  print_options(commonOutput, common_options, _bReportParameter, removeLongOptDashes);
 
   if (!printAllOptions) {
     std::cout << commonOutput.str();
@@ -482,7 +480,7 @@ XBUtilities::report_option_help(const std::string & _groupName,
 
       boost::program_options::options_description options;
       options.add_options()(subOption->getConfigName().c_str(), subOption->getConfigDescription().c_str());
-      print_options(deviceSpecificOutput, options, _positionalDescription, _bReportParameter, removeLongOptDashes);
+      print_options(deviceSpecificOutput, options, _bReportParameter, removeLongOptDashes);
     }
 
     const auto deviceSpecificOutputStr = deviceSpecificOutput.str();
@@ -578,10 +576,10 @@ display_subcommand_options(const std::string& executable,
       hiddenJsonOptions.emplace(devicePair.first, hidden);
   }
 
-  report_option_help("OPTIONS", options, positionals, false, false, commonJsonOptions, deviceClass); // Make a new report_option_help that prints the separated by device class?
+  report_option_help("OPTIONS", options, false, false, commonJsonOptions, deviceClass); // Make a new report_option_help that prints the separated by device class?
 
   if (XBU::getShowHidden())
-    report_option_help("OPTIONS (Hidden)", hiddenOptions, positionals, false, false, hiddenJsonOptions, deviceClass);
+    report_option_help("OPTIONS (Hidden)", hiddenOptions, false, false, hiddenJsonOptions, deviceClass);
 }
 
 void
@@ -620,7 +618,7 @@ XBUtilities::report_subcommand_help(const std::string& _executableName,
   std::cout << customHelpSection << "\n";
 
   // -- Global Options
-  report_option_help("GLOBAL OPTIONS", _globalOptions, _positionalDescription, false);
+  report_option_help("GLOBAL OPTIONS", _globalOptions, false);
 
   // Extended help
   {

--- a/src/runtime_src/core/tools/common/XBHelpMenusCore.h
+++ b/src/runtime_src/core/tools/common/XBHelpMenusCore.h
@@ -45,7 +45,6 @@ namespace XBUtilities {
   void
     report_option_help( const std::string & _groupName, 
                         const boost::program_options::options_description& _optionDescription,
-                        const boost::program_options::positional_options_description & _positionalDescription,
                         const bool _bReportParameter = true,
                         const bool removeLongOptDashes = false,
                         const std::map<std::string, std::vector<std::shared_ptr<JSONConfigurable>>>& device_options =


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
the xbuil help menu was not showing any options 

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
introduced while fixing a CR. https://github.com/Xilinx/XRT/pull/7956

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
Locally
```
% xbutil configure --performance --help
WARNING: Unexpected xocl version (2.17.97) was found. Expected 2.17.0, to match XRT tools.

COMMAND: configure

DESCRIPTION: Change performance mode of the device

USAGE:  configure --performance [--help] [-d arg] action

OPTIONS:
  --performance      - Change performance mode of the device
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest
  --action           - Action to perform: DEFAULT, POWERSAVER, BALANCED, PERFORMANCE
  --help             - Help to use this sub-command


% xbutil configure --help
WARNING: Unexpected xocl version (2.17.97) was found. Expected 2.17.0, to match XRT tools.

COMMAND: configure

DESCRIPTION: Device and host configuration.

USAGE: xbutil configure [ --host-mem | --p2p | --performance ] [--help] [-d arg]

OPTIONS:
 Common:
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest
  --help             - Help to use this sub-command
 AIE:
  --performance      - Change performance mode of the device
 Alveo:
  --host-mem         - Controls host-mem functionality
  --p2p              - Controls P2P functionality


GLOBAL OPTIONS:
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation



% xbutil examine --help
WARNING: Unexpected xocl version (2.17.97) was found. Expected 2.17.0, to match XRT tools.

COMMAND: examine

DESCRIPTION: This command will 'examine' the state of the system/device and will generate a report of interest
               in a text or JSON format.

USAGE: xbutil examine [--help] [-d arg] [-f arg] [-o arg] [-r arg]

OPTIONS:
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest
  -f, --format       - Report output format. Valid values are:
                         JSON        - Latest JSON schema
                         JSON-2020.2 - JSON 2020.2 schema
  -o, --output       - Direct the output to the given file
  --help             - Help to use this sub-command
  -r, --report       - The type of report to be produced. Reports currently available are:
                       Common:
                         all             - All known reports are produced
                         electrical      - Electrical and power sensors present on the device
                         host            - Host information
                         memory          - Memory information present on the device
                         platform        - Platforms flashed on the device
                       AIE:
                         aie             - AIE metadata in xclbin
                         aie-partitions  - AIE partition information
                         aiemem          - AIE memory tile information
                         aieshim         - AIE shim tile status
                         telemetry       - Telemetry data for the device
                       Alveo:
                         debug-ip-status - Status of Debug IPs present in xclbin loaded on device
                         dynamic-regions - Information about the xclbin and the compute units
                         error           - Asyncronus Error present on the device
                         firewall        - Firewall status
                         mailbox         - Mailbox metrics of the device
                         mechanical      - Mechanical sensors on and surrounding the device
                         pcie-info       - Pcie information of the device
                         qspi-status     - QSPI write protection status
                         thermal         - Thermal sensors present on the device


GLOBAL OPTIONS:
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
```
#### Documentation impact (if any)
