### PR TITLE
add xrt::elf raw elf data constructor

### DIFF
--- a/src/runtime_src/core/common/api/xrt_elf.cpp
+++ b/src/runtime_src/core/common/api/xrt_elf.cpp
@@ -14,6 +14,7 @@
 #include <stdexcept>
 #include <string>
 #include <vector>
+#include <sstream>
 
 namespace xrt {
 
@@ -26,6 +27,14 @@ public:
   {
     if (!m_elf.load(fnm))
       throw std::runtime_error(fnm + " is not found or is not a valid ELF file");
+  }
+
+  elf_impl(const std::vector<char>& data)
+  {
+    std::string str(data.begin(), data.end());
+    std::istringstream isstr(str);
+    if (!m_elf.load(isstr))
+      throw std::runtime_error("not a valid ELF data");
   }
 
   const ELFIO::elfio&
@@ -83,6 +92,11 @@ namespace xrt {
 elf::
 elf(const std::string& fnm)
   : detail::pimpl<elf_impl>{std::make_shared<elf_impl>(fnm)}
+{}
+
+elf::
+elf(const std::vector<char>& data)
+  : detail::pimpl<elf_impl>{std::make_shared<elf_impl>(data)}
 {}
 
 xrt::uuid

--- a/src/runtime_src/core/common/api/xrt_elf.cpp
+++ b/src/runtime_src/core/common/api/xrt_elf.cpp
@@ -31,8 +31,8 @@ public:
 
   elf_impl(const std::vector<char>& data)
   {
-    const std::string elf_string(data.begin(), data.end());
-    std::istringstream elf_stream(elf_string);
+    std::istringstream elf_stream;
+    elf_stream.rdbuf()->pubsetbuf(const_cast<char*>(data.data()), data.size());
     if (!m_elf.load(elf_stream))
       throw std::runtime_error("not a valid ELF data");
   }

--- a/src/runtime_src/core/common/api/xrt_elf.cpp
+++ b/src/runtime_src/core/common/api/xrt_elf.cpp
@@ -14,7 +14,6 @@
 #include <stdexcept>
 #include <string>
 #include <vector>
-#include <sstream>
 
 namespace xrt {
 
@@ -29,12 +28,10 @@ public:
       throw std::runtime_error(fnm + " is not found or is not a valid ELF file");
   }
 
-  elf_impl(const std::vector<char>& data)
+  elf_impl(std::istream& stream)
   {
-    std::istringstream elf_stream;
-    elf_stream.rdbuf()->pubsetbuf(const_cast<char*>(data.data()), data.size());
-    if (!m_elf.load(elf_stream))
-      throw std::runtime_error("not a valid ELF data");
+    if (!m_elf.load(stream))
+      throw std::runtime_error("not a valid ELF stream");
   }
 
   const ELFIO::elfio&
@@ -95,8 +92,8 @@ elf(const std::string& fnm)
 {}
 
 elf::
-elf(const std::vector<char>& data)
-  : detail::pimpl<elf_impl>{std::make_shared<elf_impl>(data)}
+elf(std::istream& stream)
+  : detail::pimpl<elf_impl>{std::make_shared<elf_impl>(stream)}
 {}
 
 xrt::uuid

--- a/src/runtime_src/core/common/api/xrt_elf.cpp
+++ b/src/runtime_src/core/common/api/xrt_elf.cpp
@@ -31,9 +31,9 @@ public:
 
   elf_impl(const std::vector<char>& data)
   {
-    std::string str(data.begin(), data.end());
-    std::istringstream isstr(str);
-    if (!m_elf.load(isstr))
+    const std::string elf_string(data.begin(), data.end());
+    std::istringstream elf_stream(elf_string);
+    if (!m_elf.load(elf_stream))
       throw std::runtime_error("not a valid ELF data");
   }
 

--- a/src/runtime_src/core/include/experimental/xrt_elf.h
+++ b/src/runtime_src/core/include/experimental/xrt_elf.h
@@ -9,7 +9,7 @@
 
 #ifdef __cplusplus
 # include <string>
-# include <vector>
+# include <istream>
 #endif
 
 #ifdef __cplusplus
@@ -42,7 +42,7 @@ public:
    *
    */
   XRT_API_EXPORT
-  elf(const std::vector<char>& data);
+  elf(std::istream& stream);
 
   XRT_API_EXPORT
   xrt::uuid

--- a/src/runtime_src/core/include/experimental/xrt_elf.h
+++ b/src/runtime_src/core/include/experimental/xrt_elf.h
@@ -9,6 +9,7 @@
 
 #ifdef __cplusplus
 # include <string>
+# include <vector>
 #endif
 
 #ifdef __cplusplus
@@ -32,7 +33,17 @@ class elf : public detail::pimpl<elf_impl>
 public:
   XRT_API_EXPORT
   elf(const std::string& fnm);
-  
+
+  /**
+   * elf() - Constructor from raw ELF data
+   *
+   * @param data
+   *  Raw data of elf
+   *
+   */
+  XRT_API_EXPORT
+  elf(const std::vector<char>& data);
+
   XRT_API_EXPORT
   xrt::uuid
   get_cfg_uuid() const;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Added new xrt::elf constructor to take in-memory buffer as input

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
NA

#### How problem was solved, alternative solutions (if any) and why they were rejected
added new constructor to take memory elf buffer

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
taken multiple efl and check we are able to get correct xrt::elf object
```
 // Sample usage
  aiebu::aiebu_assembler as(aiebu::aiebu_assembler::buffer_type::blob_instr_dpu, v1, v2, patch_data);
  auto e = as.get_elf();

  std::istringstream elf_stream;
  elf_stream.rdbuf()->pubsetbuf(e.data(), e.size());
  xrt::elf elf{elf_stream};
  xrt::module mod{elf};
```

#### Documentation impact (if any)
Yes, we have to update XRT doc