### PR TITLE
Add an aie trace timestamp binary data format

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -323,7 +323,7 @@ void AieTracePluginUnified::updateAIEDevice(void *handle) {
 #endif
 
     // Writer for timestamp file
-    std::string outputFile = "aie_event_timestamps.csv";
+    std::string outputFile = "aie_event_timestamps.bin";
     auto tsWriter = new AIETraceTimestampsWriter(outputFile.c_str(),
                                                  deviceName.c_str(), deviceID);
     writers.push_back(tsWriter);

--- a/src/runtime_src/xdp/profile/writer/aie_trace/AIEEventTimeStamp.cpp
+++ b/src/runtime_src/xdp/profile/writer/aie_trace/AIEEventTimeStamp.cpp
@@ -14,8 +14,8 @@
  * under the License.
  */
 #include <iostream>
-#include "xdp/profile/writer/vp_base/IBinaryDataWriter.h"
 #include "AIEEventTimeStamp.h"
+#include "xdp/profile/writer/vp_base/IBinaryDataWriter.h"
 
 namespace xdp::AIEBinaryData
 {
@@ -85,9 +85,4 @@ uint32_t AIEEventTimeStamp::EventTypeID()
   return 777;
 };
 
-//---------------------------------------------------------------------------------------------------------------------
-IBinaryDataEvent *AIEEventTimeStamp::create()
-{
-  return new AIEEventTimeStamp();
-}
 } // AIEBinaryData

--- a/src/runtime_src/xdp/profile/writer/aie_trace/AIEEventTimeStamp.cpp
+++ b/src/runtime_src/xdp/profile/writer/aie_trace/AIEEventTimeStamp.cpp
@@ -1,0 +1,93 @@
+/**
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+#include <iostream>
+#include "xdp/profile/writer/vp_base/IBinaryDataWriter.h"
+#include "AIEEventTimeStamp.h"
+
+namespace xdp::AIEBinaryData
+{
+//---------------------------------------------------------------------------------------------------------------------
+AIEEventTimeStamp::AIEEventTimeStamp(): IBinaryDataEvent(EventTypeID())
+{
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+AIEEventTimeStamp::~AIEEventTimeStamp()= default;
+
+//---------------------------------------------------------------------------------------------------------------------
+void AIEEventTimeStamp::setData(IBinaryDataEvent::Time timeStamp1, IBinaryDataEvent::Time timeStamp2,
+                                uint32_t column, uint32_t row, IBinaryDataEvent::Time timer)
+{
+  m_timeStamp1 = timeStamp1;
+  m_timeStamp2 = timeStamp2;
+  m_column     = column;
+  m_row        = row;
+  m_timer      = timer;
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void AIEEventTimeStamp::clear()
+{
+  m_timeStamp1 = 0;
+  m_timeStamp2 = 0;
+  m_timer      = 0;
+  m_column     = 0;
+  m_row        = 0;
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void AIEEventTimeStamp::print() const
+{
+  std::cout << m_timeStamp1 << "," << m_timeStamp2 << ","  ;
+  std::cout << m_column     << "," << m_row << "," ;
+  std::cout << m_timer      << "," << std::endl;
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+uint32_t AIEEventTimeStamp::getSize() const
+{
+  uint32_t eventSize  = IBinaryDataEvent::getTypeIDSize();
+  eventSize += sizeof(m_timeStamp1);
+  eventSize += sizeof(m_timeStamp2);
+  eventSize += sizeof(m_timer);
+  eventSize += sizeof(m_column);
+  eventSize += sizeof(m_row);
+  return eventSize;
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void AIEEventTimeStamp::writeFields(IBinaryDataWriter &writer) const
+{
+  IBinaryDataEvent::writeTypeID(writer);
+  writer.writeField((const char*) &m_timeStamp1, sizeof(IBinaryDataEvent::Time));
+  writer.writeField((const char*) &m_timeStamp2, sizeof(IBinaryDataEvent::Time));
+  writer.writeField((const char*) &m_timer,      sizeof(IBinaryDataEvent::Time));
+  writer.writeField((const char*) &m_column,     sizeof(uint32_t));
+  writer.writeField((const char*) &m_row,        sizeof(uint32_t));
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+uint32_t AIEEventTimeStamp::EventTypeID()
+{
+  return 777;
+};
+
+//---------------------------------------------------------------------------------------------------------------------
+IBinaryDataEvent *AIEEventTimeStamp::create()
+{
+  return new AIEEventTimeStamp();
+}
+} // AIEBinaryData

--- a/src/runtime_src/xdp/profile/writer/aie_trace/AIEEventTimeStamp.h
+++ b/src/runtime_src/xdp/profile/writer/aie_trace/AIEEventTimeStamp.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2024 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the

--- a/src/runtime_src/xdp/profile/writer/aie_trace/AIEEventTimeStamp.h
+++ b/src/runtime_src/xdp/profile/writer/aie_trace/AIEEventTimeStamp.h
@@ -41,7 +41,6 @@ public:
 
 public:
   static uint32_t EventTypeID() ;
-  static IBinaryDataEvent* create();
 
 public:
   IBinaryDataEvent::Time m_timeStamp1 = 0;

--- a/src/runtime_src/xdp/profile/writer/aie_trace/AIEEventTimeStamp.h
+++ b/src/runtime_src/xdp/profile/writer/aie_trace/AIEEventTimeStamp.h
@@ -1,0 +1,56 @@
+/**
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef BINARY_WRITER_XRT_AIEEVENTTIMESTAMP_H
+#define BINARY_WRITER_XRT_AIEEVENTTIMESTAMP_H
+
+#include <string>
+#include "xdp/profile/writer/vp_base/IBinaryDataEvent.h"
+
+namespace xdp::AIEBinaryData
+{
+
+class AIEEventTimeStamp  : public IBinaryDataEvent
+{
+public:
+  AIEEventTimeStamp() ;
+  ~AIEEventTimeStamp() override ;
+
+public:
+  void setData(IBinaryDataEvent::Time timeStamp1, IBinaryDataEvent::Time timeStamp2,
+               uint32_t column, uint32_t row, IBinaryDataEvent::Time timer);
+
+public:
+  void clear() override ;
+  void print() const override ;
+  [[nodiscard]] uint32_t getSize() const override;
+  void writeFields(IBinaryDataWriter& writer) const override ;
+
+public:
+  static uint32_t EventTypeID() ;
+  static IBinaryDataEvent* create();
+
+public:
+  IBinaryDataEvent::Time m_timeStamp1 = 0;
+  IBinaryDataEvent::Time m_timeStamp2 = 0;
+  IBinaryDataEvent::Time m_timer = 0;
+  uint32_t m_column = 0;
+  uint32_t m_row = 0;
+};
+
+} // AIEBinaryData
+
+#endif //BINARY_WRITER_XRT_AIEEVENTTIMESTAMP_H

--- a/src/runtime_src/xdp/profile/writer/aie_trace/aie_trace_timestamps_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/aie_trace/aie_trace_timestamps_writer.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2024 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the

--- a/src/runtime_src/xdp/profile/writer/aie_trace/aie_trace_timestamps_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/aie_trace/aie_trace_timestamps_writer.cpp
@@ -17,10 +17,14 @@
 #include "xdp/profile/writer/aie_trace/aie_trace_timestamps_writer.h"
 #include "xdp/profile/database/static_info/aie_constructs.h"
 #include "xdp/profile/database/database.h"
+#include "xdp/profile/writer/vp_base/IBinaryDataWriter.h"
+#include "xdp/profile/writer/vp_base/BinaryDataWriter.h"
 
 #include <vector>
 #include <iostream>
 #include <iomanip>
+#include <cmath>
+#include "AIEEventTimeStamp.h"
 
 namespace xdp {
 
@@ -33,44 +37,77 @@ namespace xdp {
   {
   }
 
-  AIETraceTimestampsWriter::~AIETraceTimestampsWriter()
-  {
-  }
+  AIETraceTimestampsWriter::~AIETraceTimestampsWriter() = default;
 
   bool AIETraceTimestampsWriter::write(bool)
   {
-    // Report HW generation and clock frequency
-    auto aieGeneration = (db->getStaticInfo()).getAIEGeneration(mDeviceIndex);
-    double aieClockFreqMhz = (db->getStaticInfo()).getClockRateMHz(mDeviceIndex, false);
-
-    std::ofstream fos;
-    fos.open( getcurrentFileName() );
-
-    // Write header
-    fos << "Version: 1.0\n";
-    fos << "Target device: " << mDeviceName << "\n";
-    fos << "Hardware generation: " << static_cast<int>(aieGeneration) << "\n";
-    fos << "Clock frequency (MHz): " << aieClockFreqMhz << "\n";
-    fos << "timestamp1(nsec)" << ","
-        << "timestamp2(nsec)" << ","
-        << "column"           << ","
-        << "row"              << ","
-        << "timer(cycles)"    << ",\n";
-
-    // Write all data elements
-    std::vector<counters::DoubleSample> samples =
-        db->getDynamicInfo().getAIETimerSamples(mDeviceIndex);
-
-    for (auto& sample : samples) {
-      fos << sample.timestamp1 << ","
-          << sample.timestamp2 << ",";
-      for (auto value : sample.values)
-        fos << value << ",";
-      fos << "\n";
-    }
-
-    fos.close();
+    writeBinaryTimestampFile();
     return true;
   }
+
+void AIETraceTimestampsWriter::writeCVSTimestampFile()
+{
+  // Report HW generation and clock frequency
+  auto aieGeneration = (db->getStaticInfo()).getAIEGeneration(mDeviceIndex);
+  double aieClockFreqMhz    = (db->getStaticInfo()).getClockRateMHz(mDeviceIndex, false);
+
+  std::ofstream fos;
+  fos.open( getcurrentFileName() );
+
+  // Write header
+  fos << "Version: 1.0\n";
+  fos << "Target device: " << mDeviceName << "\n";
+  fos << "Hardware generation: " << static_cast<int>(aieGeneration) << "\n";
+  fos << "Clock frequency (MHz): " << aieClockFreqMhz << "\n";
+  fos << "timestamp1(nsec)" << ","
+      << "timestamp2(nsec)" << ","
+      << "column"           << ","
+      << "row"              << ","
+      << "timer(cycles)"    << ",\n";
+
+  // Write all data elements
+  std::vector<counters::DoubleSample> samples =
+      db->getDynamicInfo().getAIETimerSamples(mDeviceIndex);
+
+  for (auto& sample : samples) {
+    fos << sample.timestamp1 << ","
+        << sample.timestamp2 << ",";
+    for (auto value : sample.values)
+      fos << value << ",";
+    fos << "\n";
+  }
+
+  fos.close();
+}
+
+void AIETraceTimestampsWriter::writeBinaryTimestampFile()
+{
+  std::fstream aStream;
+  std::string binaryFileName = getcurrentFileName();
+  aStream.open(binaryFileName.c_str(), std::fstream::in | std::fstream::out
+                             | std::fstream::binary | std::fstream::trunc);
+  aStream.seekp(0, std::ios_base::end);
+
+  const uint32_t PACKETSIZE  = 2048;
+  double aieClockFreqMhz    = (db->getStaticInfo()).getClockRateMHz(mDeviceIndex, false);
+  auto aieGeneration = (db->getStaticInfo()).getAIEGeneration(mDeviceIndex);
+
+  AIEBinaryData::BinaryDataWriter eventWriter(aStream, mDeviceName,
+                                              static_cast<uint32_t>(aieGeneration),
+                                              aieClockFreqMhz,  PACKETSIZE );
+  AIEBinaryData::AIEEventTimeStamp timeStampEvent;
+
+  // Write all data elements
+  std::vector<counters::DoubleSample> samples = db->getDynamicInfo().getAIETimerSamples(mDeviceIndex);
+  for (auto& sample : samples) {
+    if (sample.values.size() == 3) {
+      auto  column = static_cast<uint32_t>(sample.values[0]);
+      auto  row    = static_cast<uint32_t>(sample.values[1]);
+      uint64_t timer  = sample.values[2];
+      timeStampEvent.setData(sample.timestamp1, sample.timestamp2, column, row, timer);
+      eventWriter.writeEvent(sample.timestamp1, timeStampEvent);
+    }
+  }
+}
 
 } // end namespace xdp

--- a/src/runtime_src/xdp/profile/writer/aie_trace/aie_trace_timestamps_writer.h
+++ b/src/runtime_src/xdp/profile/writer/aie_trace/aie_trace_timestamps_writer.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2024 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the

--- a/src/runtime_src/xdp/profile/writer/vp_base/BinaryDataHeader.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/BinaryDataHeader.cpp
@@ -1,0 +1,93 @@
+/**
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#define XDP_CORE_SOURCE
+
+#include <cstring>
+#include <iostream>
+#include "BinaryDataHeader.h"
+
+namespace xdp::AIEBinaryData
+{
+//---------------------------------------------------------------------------------------------------------------------
+void BinaryDataHeader::copyString(const std::string& stdString, char charString[], size_t charLength)
+{
+  std::memset(charString, 0, charLength);
+  auto length = static_cast<size_t>(stdString.length());
+  if (length > charLength)
+    length = charLength;
+  std::memcpy(charString, stdString.c_str(), length);
+}
+//---------------------------------------------------------------------------------------------------------------------
+#define AIE_VERSION_STR "AMD AIE DATA 01"
+BinaryDataHeader::BinaryDataHeader()
+{
+  copyString(AIE_VERSION_STR, m_header, AIE_HEADER_STR_LEN);
+}
+//---------------------------------------------------------------------------------------------------------------------
+bool BinaryDataHeader::isHeaderMatched() const
+{
+  char str[AIE_HEADER_STR_LEN];
+  copyString(AIE_VERSION_STR, str, AIE_HEADER_STR_LEN);
+  return std::memcmp(m_header, str, AIE_HEADER_STR_LEN) == 0;
+}
+//---------------------------------------------------------------------------------------------------------------------
+void BinaryDataHeader::setTargetDevice(const std::string& targetDevice)
+{
+  copyString(targetDevice, m_targetDevice, AIE_HEADER_STR_LEN);
+}
+//---------------------------------------------------------------------------------------------------------------------
+void BinaryDataHeader::print() const
+{
+  std::string targetDevice(m_targetDevice);
+  std::cout << "Binary File Header" << std::endl;
+  std::cout << "targetDevice = "     << targetDevice    << std::endl;
+  std::cout << "m_hwGeneration = "   << m_hwGeneration  << std::endl;
+  std::cout << "fileType = "         << m_fileType      << std::endl;
+  std::cout << "dataVersion = "      << m_dataVersion   << std::endl;
+  std::cout << "frequency = "        << m_frequency     << std::endl;
+  std::cout << "packageSize = "      << m_packageSize   << std::endl;
+  std::cout << "dateStamp = "        << m_dateStamp     << std::endl;
+}
+//---------------------------------------------------------------------------------------------------------------------
+#define MAGIC 0xc1fc1fc1
+PacketHeader::PacketHeader():m_magic(MAGIC)
+{
+}
+//---------------------------------------------------------------------------------------------------------------------
+bool PacketHeader::isMagicNumberMatched() const
+{
+  return m_magic == MAGIC;
+}
+//---------------------------------------------------------------------------------------------------------------------
+void PacketHeader::print() const
+{
+  std::cout << "Binary Packet Header" << std::endl;
+  std::cout << "m_magic = "            << std::hex << m_magic << std::dec << std::endl;
+  std::cout << "m_version = "          << m_version           << std::endl;
+  std::cout << "m_content_size = "     << m_content_size      << std::endl;
+  std::cout << "m_timestamp_begin = "  << m_timestamp_begin   << std::endl;
+  std::cout << "m_timestamp_end = "    << m_timestamp_end     << std::endl;
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+uint32_t PacketHeader::getPacketHeaderSize()
+{
+  static uint32_t packageHeaderSize = sizeof(uint32_t)  + sizeof(uint32_t) + sizeof(uint32_t) +
+                                      sizeof(IBinaryDataEvent::Time) + sizeof(IBinaryDataEvent::Time);
+  return packageHeaderSize;
+}
+} // AIEBinaryData

--- a/src/runtime_src/xdp/profile/writer/vp_base/BinaryDataHeader.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/BinaryDataHeader.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2024 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the

--- a/src/runtime_src/xdp/profile/writer/vp_base/BinaryDataHeader.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/BinaryDataHeader.cpp
@@ -32,7 +32,7 @@ void BinaryDataHeader::copyString(const std::string& stdString, char charString[
   std::memcpy(charString, stdString.c_str(), length);
 }
 //---------------------------------------------------------------------------------------------------------------------
-#define AIE_VERSION_STR "AMD AIE DATA 01"
+constexpr const char* AIE_VERSION_STR =  "AMD AIE DATA 01";
 BinaryDataHeader::BinaryDataHeader()
 {
   copyString(AIE_VERSION_STR, m_header, AIE_HEADER_STR_LEN);
@@ -63,7 +63,7 @@ void BinaryDataHeader::print() const
   std::cout << "dateStamp = "        << m_dateStamp     << std::endl;
 }
 //---------------------------------------------------------------------------------------------------------------------
-#define MAGIC 0xc1fc1fc1
+constexpr uint32_t MAGIC =  0xc1fc1fc1;
 PacketHeader::PacketHeader():m_magic(MAGIC)
 {
 }

--- a/src/runtime_src/xdp/profile/writer/vp_base/BinaryDataHeader.h
+++ b/src/runtime_src/xdp/profile/writer/vp_base/BinaryDataHeader.h
@@ -21,9 +21,10 @@
 #include <string>
 #include "IBinaryDataEvent.h"
 
-#define AIE_HEADER_STR_LEN 32
 namespace xdp::AIEBinaryData
 {
+
+constexpr size_t AIE_HEADER_STR_LEN =  32;
 
 //---------------------------------------------------------------------------------------------------------------------
 struct BinaryDataHeader

--- a/src/runtime_src/xdp/profile/writer/vp_base/BinaryDataHeader.h
+++ b/src/runtime_src/xdp/profile/writer/vp_base/BinaryDataHeader.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2024 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the

--- a/src/runtime_src/xdp/profile/writer/vp_base/BinaryDataHeader.h
+++ b/src/runtime_src/xdp/profile/writer/vp_base/BinaryDataHeader.h
@@ -1,0 +1,68 @@
+/**
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef BINARY_WRITER_XRT_BINARYDATAHEADER_H
+#define BINARY_WRITER_XRT_BINARYDATAHEADER_H
+
+#include "xdp/config.h"
+#include <string>
+#include "IBinaryDataEvent.h"
+
+#define AIE_HEADER_STR_LEN 32
+namespace xdp::AIEBinaryData
+{
+
+//---------------------------------------------------------------------------------------------------------------------
+struct BinaryDataHeader
+{
+  //Note: The struct has to multiple of 8 in order to get 32 and 64 bit machine working
+  char m_header[AIE_HEADER_STR_LEN]       {0}; ///< identifies the format of the AIE DATA file
+  char m_targetDevice[AIE_HEADER_STR_LEN] {0}; ///< identifies the format of the AIE DATA file
+  uint32_t m_hwGeneration = 1;
+  uint32_t m_fileType     = 0;
+  uint32_t m_dataVersion  = 0;
+  double   m_frequency    = 1250.0;
+  uint32_t m_packageSize  = 1024;
+  uint32_t m_dateStamp    = 0;         ///< the time at which the file was created
+
+public:
+  BinaryDataHeader();
+  [[nodiscard]] XDP_CORE_EXPORT bool isHeaderMatched() const;
+  XDP_CORE_EXPORT void print() const;
+  XDP_CORE_EXPORT void setTargetDevice(const std::string& targetDevice);
+
+public:
+  XDP_CORE_EXPORT static void copyString(const std::string& stdString, char charString[], size_t charLength );
+};
+//---------------------------------------------------------------------------------------------------------------------
+struct PacketHeader
+{
+  uint32_t m_magic            = 0;
+  uint32_t m_version          = 1;
+  uint32_t m_content_size     = 0;
+  IBinaryDataEvent::Time m_timestamp_begin = 0;
+  IBinaryDataEvent::Time m_timestamp_end   = 0;
+
+public:
+  XDP_CORE_EXPORT PacketHeader();
+  [[nodiscard]] XDP_CORE_EXPORT bool isMagicNumberMatched() const;
+  XDP_CORE_EXPORT void print() const;
+  XDP_CORE_EXPORT static uint32_t getPacketHeaderSize();
+};
+
+} // AIEBinaryData
+
+#endif //BINARY_WRITER_XRT_BINARYDATAHEADER_H

--- a/src/runtime_src/xdp/profile/writer/vp_base/BinaryDataWriter.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/BinaryDataWriter.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2024 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the

--- a/src/runtime_src/xdp/profile/writer/vp_base/BinaryDataWriter.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/BinaryDataWriter.cpp
@@ -17,12 +17,12 @@
 #define XDP_CORE_SOURCE
 
 #include <cstdlib>
-#include <string>
-#include <memory.h>
 #include <cstring>
 #include <ctime>
-#include "IBinaryDataEvent.h"
+#include <memory.h>
+#include <string>
 #include "BinaryDataWriter.h"
+#include "IBinaryDataEvent.h"
 
 namespace xdp::AIEBinaryData
 {

--- a/src/runtime_src/xdp/profile/writer/vp_base/BinaryDataWriter.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/BinaryDataWriter.cpp
@@ -1,0 +1,122 @@
+/**
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#define XDP_CORE_SOURCE
+
+#include <cstdlib>
+#include <string>
+#include <memory.h>
+#include <cstring>
+#include <ctime>
+#include "IBinaryDataEvent.h"
+#include "BinaryDataWriter.h"
+
+namespace xdp::AIEBinaryData
+{
+//---------------------------------------------------------------------------------------------------------------------
+BinaryDataWriter::BinaryDataWriter(std::fstream& stream,  const std::string& targetDevice, uint32_t hwGeneration,
+                                   double frequency, uint32_t packet_size)
+    : m_stream(stream), m_buffer(std::ios_base::in | std::ios_base::out | std::ios_base::binary),
+      m_packageSize(packet_size)
+{
+  time_t currentTime;
+  m_header.setTargetDevice(targetDevice);
+  m_header.m_hwGeneration = hwGeneration;
+  m_header.m_fileType    = 1;
+  m_header.m_dataVersion = 1;
+  m_header.m_frequency   = frequency;
+  m_header.m_packageSize = packet_size;
+  m_header.m_dateStamp   = static_cast<uint8_t>(time(&currentTime));
+
+  writeHeader();
+}
+//---------------------------------------------------------------------------------------------------------------------
+BinaryDataWriter::~BinaryDataWriter()
+{
+  flush();
+}
+//---------------------------------------------------------------------------------------------------------------------
+void BinaryDataWriter::writeHeader()
+{
+  m_stream.seekg(0, std::ios::beg);
+  m_stream.write( reinterpret_cast<const char *>(&m_header), sizeof(m_header));
+  m_totalEventSize = PacketHeader::getPacketHeaderSize();;
+}
+//---------------------------------------------------------------------------------------------------------------------
+void BinaryDataWriter::writePacket(const char* content, uint32_t content_size, IBinaryDataEvent::Time timestamp_begin,
+                                   IBinaryDataEvent::Time timestamp_end)
+{
+  PacketHeader aPacketHeader;
+  aPacketHeader.m_content_size    = content_size;
+  aPacketHeader.m_timestamp_begin = timestamp_begin;
+  aPacketHeader.m_timestamp_end   = timestamp_end;
+  m_stream.write( reinterpret_cast<const char *>(&aPacketHeader), sizeof(aPacketHeader));
+  if (content_size > 0)
+    m_stream.write(content, content_size);
+
+  uint32_t padding_size = m_packageSize - sizeof(aPacketHeader) - content_size;
+  if (padding_size > 0) {
+    void* pVoid = malloc(padding_size);
+    memset(pVoid, 0, padding_size);
+    m_stream.write((const char*)pVoid, padding_size);
+    free(pVoid);
+  }
+  m_totalEventSize = PacketHeader::getPacketHeaderSize();;
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void BinaryDataWriter::writeEvent(const IBinaryDataEvent::Time current_time, const IBinaryDataEvent& dataEvent)
+{
+  uint32_t eventSize = 0;
+  eventSize += dataEvent.getSize();
+  if ( (m_totalEventSize + eventSize) > m_packageSize ) {
+    writePacket(m_buffer.str().c_str(), static_cast<uint32_t>(m_buffer.tellp()),
+                m_packet_time_begin, m_packet_time_end);
+    m_buffer.str("");
+    m_buffer.clear(); //clear state flags.
+    m_packet_time_begin = m_packet_time_end;
+  }
+  m_packet_time_end = current_time;
+  m_totalEventSize += eventSize;
+  dataEvent.writeFields(*this);
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void BinaryDataWriter::writeField(const char* data, uint32_t size)
+{
+  m_buffer.write(data, size);
+}
+//---------------------------------------------------------------------------------------------------------------------
+void BinaryDataWriter::writeField(const std::string& str)
+{
+  m_buffer.write(str.c_str(), static_cast<std::streamsize>(str.length()));
+  static const char endChar = 0;
+  m_buffer.write((const char*) &endChar, sizeof(char));
+}
+//---------------------------------------------------------------------------------------------------------------------
+void BinaryDataWriter::flush()
+{
+  if ( !m_buffer.str().empty() ) {
+    writePacket(m_buffer.str().c_str(), static_cast<uint32_t>(m_buffer.tellp()),
+                m_packet_time_begin, m_packet_time_end);
+    m_buffer.str("");
+    m_buffer.clear(); //clear state flags.
+    m_packet_time_begin = m_packet_time_end;
+  }
+  m_stream.flush();
+}
+
+} // AIEBinaryData

--- a/src/runtime_src/xdp/profile/writer/vp_base/BinaryDataWriter.h
+++ b/src/runtime_src/xdp/profile/writer/vp_base/BinaryDataWriter.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2024 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the

--- a/src/runtime_src/xdp/profile/writer/vp_base/BinaryDataWriter.h
+++ b/src/runtime_src/xdp/profile/writer/vp_base/BinaryDataWriter.h
@@ -1,0 +1,64 @@
+/**
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef BINARY_WRITER_XRT_BINARYDATAWRITER_H
+#define BINARY_WRITER_XRT_BINARYDATAWRITER_H
+
+#include "xdp/config.h"
+#include <string>
+#include <iostream>
+#include <sstream>
+#include <fstream>
+#include <vector>
+#include "IBinaryDataWriter.h"
+#include "IBinaryDataEvent.h"
+#include "BinaryDataHeader.h"
+
+namespace xdp::AIEBinaryData
+{
+
+//---------------------------------------------------------------------------------------------------------------------
+class BinaryDataWriter : public IBinaryDataWriter
+{
+public:
+  XDP_CORE_EXPORT BinaryDataWriter(std::fstream& channel, const std::string& targetDevice, uint32_t hwGeneration,
+                   double frequency, uint32_t packet_size);
+  XDP_CORE_EXPORT ~BinaryDataWriter() override;
+
+public:
+  XDP_CORE_EXPORT void writeField(const char* data, uint32_t size) override;
+  XDP_CORE_EXPORT void writeField(const std::string& str) override;
+  XDP_CORE_EXPORT void writeEvent(IBinaryDataEvent::Time current_time, const IBinaryDataEvent& event) override;
+  XDP_CORE_EXPORT void flush();
+
+private:
+  XDP_CORE_EXPORT void writeHeader();
+  XDP_CORE_EXPORT void writePacket(const char* content, uint32_t content_size,
+                   IBinaryDataEvent::Time timestamp_begin, IBinaryDataEvent::Time timestamp_end );
+
+private:
+  std::fstream& m_stream;
+  std::stringstream m_buffer;
+  BinaryDataHeader m_header;
+  const uint32_t m_packageSize = 1024;
+  uint32_t m_totalEventSize =0;
+  IBinaryDataEvent::Time m_packet_time_begin =0;
+  IBinaryDataEvent::Time m_packet_time_end   =0;
+};
+
+} // AIEBinaryData
+
+#endif //BINARY_WRITER_XRT_BINARYDATAWRITER_H

--- a/src/runtime_src/xdp/profile/writer/vp_base/BinaryDataWriter.h
+++ b/src/runtime_src/xdp/profile/writer/vp_base/BinaryDataWriter.h
@@ -18,14 +18,14 @@
 #define BINARY_WRITER_XRT_BINARYDATAWRITER_H
 
 #include "xdp/config.h"
-#include <string>
-#include <iostream>
-#include <sstream>
 #include <fstream>
+#include <iostream>
+#include <string>
+#include <sstream>
 #include <vector>
-#include "IBinaryDataWriter.h"
-#include "IBinaryDataEvent.h"
 #include "BinaryDataHeader.h"
+#include "IBinaryDataEvent.h"
+#include "IBinaryDataWriter.h"
 
 namespace xdp::AIEBinaryData
 {

--- a/src/runtime_src/xdp/profile/writer/vp_base/IBinaryDataEvent.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/IBinaryDataEvent.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2024 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the

--- a/src/runtime_src/xdp/profile/writer/vp_base/IBinaryDataEvent.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/IBinaryDataEvent.cpp
@@ -1,0 +1,47 @@
+/**
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#define XDP_CORE_SOURCE
+
+#include "IBinaryDataEvent.h"
+#include "IBinaryDataWriter.h"
+
+namespace xdp::AIEBinaryData
+{
+//---------------------------------------------------------------------------------------------------------------------
+IBinaryDataEvent::IBinaryDataEvent(uint32_t id): m_typeID(id)
+{
+}
+//---------------------------------------------------------------------------------------------------------------------
+IBinaryDataEvent::~IBinaryDataEvent() = default;
+//---------------------------------------------------------------------------------------------------------------------
+uint32_t IBinaryDataEvent::getTypeID() const
+{
+  return m_typeID;
+}
+//---------------------------------------------------------------------------------------------------------------------
+void IBinaryDataEvent::writeTypeID(IBinaryDataWriter &writer) const
+{
+  const uint32_t id = getTypeID();
+  writer.writeField((const char*) &id, sizeof(uint32_t));
+}
+//---------------------------------------------------------------------------------------------------------------------
+uint32_t IBinaryDataEvent::getTypeIDSize() const
+{
+  return sizeof(m_typeID); // TypeID
+}
+
+} // AIEBinaryData

--- a/src/runtime_src/xdp/profile/writer/vp_base/IBinaryDataEvent.h
+++ b/src/runtime_src/xdp/profile/writer/vp_base/IBinaryDataEvent.h
@@ -1,0 +1,54 @@
+/**
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef BINARY_WRITER_XRT_IBINARYDATAEVENT_H
+#define BINARY_WRITER_XRT_IBINARYDATAEVENT_H
+
+#include <cstdint>
+#include "xdp/config.h"
+
+namespace xdp::AIEBinaryData
+{
+
+class IBinaryDataWriter; //class forward
+
+class IBinaryDataEvent
+{
+public:
+  typedef uint64_t Time;
+
+public:
+  XDP_CORE_EXPORT explicit IBinaryDataEvent(uint32_t TypeID);
+  XDP_CORE_EXPORT virtual ~IBinaryDataEvent();
+
+public:
+  [[nodiscard]] XDP_CORE_EXPORT uint32_t getTypeID() const;
+  [[nodiscard]] XDP_CORE_EXPORT uint32_t getTypeIDSize() const;
+  XDP_CORE_EXPORT void writeTypeID(IBinaryDataWriter &writer) const;
+
+public:
+  [[nodiscard]] XDP_CORE_EXPORT virtual uint32_t getSize() const =0;
+  XDP_CORE_EXPORT virtual void writeFields(IBinaryDataWriter &writer) const =0;
+  XDP_CORE_EXPORT virtual void clear() = 0;
+  XDP_CORE_EXPORT virtual void print() const = 0;
+
+private:
+  uint32_t m_typeID;
+};
+
+} // xdp::AIEBinaryData
+
+#endif //BINARY_WRITER_XRT_IBINARYDATAEVENT_H

--- a/src/runtime_src/xdp/profile/writer/vp_base/IBinaryDataEvent.h
+++ b/src/runtime_src/xdp/profile/writer/vp_base/IBinaryDataEvent.h
@@ -17,8 +17,8 @@
 #ifndef BINARY_WRITER_XRT_IBINARYDATAEVENT_H
 #define BINARY_WRITER_XRT_IBINARYDATAEVENT_H
 
-#include <cstdint>
 #include "xdp/config.h"
+#include <cstdint>
 
 namespace xdp::AIEBinaryData
 {

--- a/src/runtime_src/xdp/profile/writer/vp_base/IBinaryDataEvent.h
+++ b/src/runtime_src/xdp/profile/writer/vp_base/IBinaryDataEvent.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2024 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the

--- a/src/runtime_src/xdp/profile/writer/vp_base/IBinaryDataWriter.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/IBinaryDataWriter.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2024 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the

--- a/src/runtime_src/xdp/profile/writer/vp_base/IBinaryDataWriter.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/IBinaryDataWriter.cpp
@@ -14,31 +14,14 @@
  * under the License.
  */
 
-#ifndef AIE_TRACE_TIMESTAMPS_WRITER_DOT_H
-#define AIE_TRACE_TIMESTAMPS_WRITER_DOT_H
+#define XDP_CORE_SOURCE
 
-#include <string>
-#include "xdp/profile/writer/vp_base/vp_writer.h"
+#include "IBinaryDataWriter.h"
 
-namespace xdp {
+namespace xdp::AIEBinaryData
+{
 
-  class AIETraceTimestampsWriter : public VPWriter
-  {
-  public:
-    AIETraceTimestampsWriter(const char* fileName, const char* deviceName, 
-                             uint64_t deviceIndex);
-    ~AIETraceTimestampsWriter() override;
+IBinaryDataWriter::IBinaryDataWriter()  = default;
+IBinaryDataWriter::~IBinaryDataWriter() = default;
 
-    bool write(bool openNewFile) override;
-
-  private:
-    void writeCVSTimestampFile();
-    void writeBinaryTimestampFile();
-  private:
-    std::string mDeviceName;
-    uint64_t mDeviceIndex;
-  };
-
-} // end namespace xdp
-
-#endif
+} // AIEBinaryData

--- a/src/runtime_src/xdp/profile/writer/vp_base/IBinaryDataWriter.h
+++ b/src/runtime_src/xdp/profile/writer/vp_base/IBinaryDataWriter.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2024 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the

--- a/src/runtime_src/xdp/profile/writer/vp_base/IBinaryDataWriter.h
+++ b/src/runtime_src/xdp/profile/writer/vp_base/IBinaryDataWriter.h
@@ -16,8 +16,8 @@
 #ifndef BINARY_WRITER_XRT_IBINARYDATAWRITER_H
 #define BINARY_WRITER_XRT_IBINARYDATAWRITER_H
 
-#include <string>
 #include "xdp/config.h"
+#include <string>
 #include "IBinaryDataEvent.h"
 
 namespace xdp::AIEBinaryData

--- a/src/runtime_src/xdp/profile/writer/vp_base/IBinaryDataWriter.h
+++ b/src/runtime_src/xdp/profile/writer/vp_base/IBinaryDataWriter.h
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+#ifndef BINARY_WRITER_XRT_IBINARYDATAWRITER_H
+#define BINARY_WRITER_XRT_IBINARYDATAWRITER_H
+
+#include <string>
+#include "xdp/config.h"
+#include "IBinaryDataEvent.h"
+
+namespace xdp::AIEBinaryData
+{
+class IBinaryDataWriter
+{
+public:
+  XDP_CORE_EXPORT IBinaryDataWriter();
+  XDP_CORE_EXPORT virtual ~IBinaryDataWriter();
+
+public:
+  XDP_CORE_EXPORT virtual void writeField(const char* data, uint32_t size)  =0;
+  XDP_CORE_EXPORT virtual void writeField(const std::string& str)           =0;
+  XDP_CORE_EXPORT virtual void writeEvent(IBinaryDataEvent::Time current_time, const IBinaryDataEvent& event) =0;
+};
+
+} // xdp::AIEBinaryData
+
+#endif //BINARY_WRITER_XRT_IBINARYDATAWRITER_H


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

The AI trace timestamp files, currently in CSV format, can become quite sizable. 

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

VITIS-9742 System Level Trace – PL+AIE+host

#### How problem was solved, alternative solutions (if any) and why they were rejected

To address this, the plan is to convert the files into a binary data format, thereby significantly reducing their size.

#### Risks (if any) associated the changes in the commit

The modification is contained within the AI timestamp writer, and the associated risk is minimal.

#### What has been tested and how, request additional testing if necessary

The code change is compiled on both Linux and Windows platforms and executed with an AIE test case to produce an AIE trace and trace timestamp. The resulting data is then analyzed by hwanalyze and vp_analyze to generate the trace waveform, which is subsequently viewed in Vitis Analyzer.

#### Documentation impact (if any)
