### PR TITLE
Add pcie revision id support

### DIFF
--- a/src/runtime_src/core/common/info_platform.cpp
+++ b/src/runtime_src/core/common/info_platform.cpp
@@ -465,6 +465,7 @@ pcie_info(const xrt_core::device * device)
   try {
     ptree.add("vendor", xq::pcie_vendor::to_string(xrt_core::device_query<xq::pcie_vendor>(device)));
     ptree.add("device", xq::pcie_device::to_string(xrt_core::device_query<xq::pcie_device>(device)));
+    ptree.add("revision", xq::pcie_device::to_string(xrt_core::device_query<xq::pcie_revision>(device)));
     ptree.add("sub_device", xq::pcie_subsystem_id::to_string(xrt_core::device_query<xq::pcie_subsystem_id>(device)));
     ptree.add("sub_vendor", xq::pcie_subsystem_vendor::to_string(xrt_core::device_query<xq::pcie_subsystem_vendor>(device)));
     ptree.add("link_speed_gbit_sec", xrt_core::device_query<xq::pcie_link_speed>(device));

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -43,6 +43,7 @@ enum class key_type
 {
   pcie_vendor,
   pcie_device,
+  pcie_revision,
   pcie_subsystem_vendor,
   pcie_subsystem_id,
   pcie_link_speed,
@@ -340,6 +341,23 @@ struct pcie_device : request
   using result_type = uint16_t;
   static const key_type key = key_type::pcie_device;
   static const char* name() { return "device"; }
+
+  virtual std::any
+  get(const device*) const = 0;
+
+
+  static std::string
+  to_string(result_type val)
+  {
+    return boost::str(boost::format("0x%x") % val);
+  }
+};
+
+struct pcie_revision : request
+{
+  using result_type = uint16_t;
+  static const key_type key = key_type::pcie_revision;
+  static const char* name() { return "revision"; }
 
   virtual std::any
   get(const device*) const = 0;


### PR DESCRIPTION
pcie revision id support is needed for new platforms.

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
It's not a bug. I'm adding the support to query the PCI device revision id. 

#### How problem was solved, alternative solutions (if any) and why they were rejected
There was no provision to query the revision id

#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
Validate the existing platform functionality and the shim_tests

#### Documentation impact (if any)
N/A