### PR TITLE
CR-1191367 Use PCI revision ID and deivce ID to identify device

### DIFF
--- a/src/runtime_src/core/common/info_platform.cpp
+++ b/src/runtime_src/core/common/info_platform.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2021-2022 Xilinx, Inc
-// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
 #define XRT_CORE_COMMON_SOURCE
 #include "info_platform.h"
 #include "query_requests.h"
@@ -464,7 +464,9 @@ pcie_info(const xrt_core::device * device)
 
   try {
     ptree.add("vendor", xq::pcie_vendor::to_string(xrt_core::device_query<xq::pcie_vendor>(device)));
-    ptree.add("device", xq::pcie_device::to_string(xrt_core::device_query<xq::pcie_device>(device)));
+    const auto pcie_id = xrt_core::device_query<xq::pcie_id>(device);
+    ptree.add("device", xq::pcie_id::device_to_string(pcie_id));
+    ptree.add("revision", xq::pcie_id::revision_to_string(pcie_id));
     ptree.add("sub_device", xq::pcie_subsystem_id::to_string(xrt_core::device_query<xq::pcie_subsystem_id>(device)));
     ptree.add("sub_vendor", xq::pcie_subsystem_vendor::to_string(xrt_core::device_query<xq::pcie_subsystem_vendor>(device)));
     ptree.add("link_speed_gbit_sec", xrt_core::device_query<xq::pcie_link_speed>(device));

--- a/src/runtime_src/core/common/info_telemetry.cpp
+++ b/src/runtime_src/core/common/info_telemetry.cpp
@@ -116,12 +116,7 @@ telemetry_info(const xrt_core::device* device)
     return telemetry_pt;
   case xrt_core::query::device_class::type::ryzen:
   {
-    auto device_id = xrt_core::device_query<xrt_core::query::pcie_device>(device); // Telemetry is platform specific for Ryzen devices
-    switch (device_id) {
-    case 5378: // phoenix
-    case 6128: // strix
-      telemetry_pt.add_child("telemetry", aie2_telemetry_info(device));
-    }
+    telemetry_pt.add_child("telemetry", aie2_telemetry_info(device));
     return telemetry_pt;
   }
   }

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -50,6 +50,7 @@ enum class key_type
   pcie_express_lane_width,
   pcie_express_lane_width_max,
   pcie_bdf,
+  pcie_id,
 
   instance,
   edge_vendor,
@@ -463,6 +464,44 @@ struct pcie_bdf : request
     return boost::str
       (boost::format("%04x:%02x:%02x.%01x") % std::get<0>(value) %
        std::get<1>(value) % std::get<2>(value) % std::get<3>(value));
+  }
+};
+
+/**
+ *  Useful for identifying devices that utilize revision numbers. Prefer this request over pcie_device.
+ */
+struct pcie_id : request
+{
+  struct data {
+    uint16_t device_id;
+    uint8_t revision_id;
+  };
+
+  using result_type = data;
+  static const key_type key = key_type::pcie_id;
+  static const char* name() { return "pcie_id"; }
+
+  virtual std::any
+  get(const device*) const = 0;
+
+  static std::string
+  device_to_string(const result_type& value)
+  {
+    return boost::str(boost::format("%04x") % value.device_id);
+  }
+
+  static std::string
+  revision_to_string(const result_type& value)
+  {
+    // The cast is required. This is a boost bug. https://github.com/boostorg/format/issues/60
+    return boost::str(boost::format("%02x") % (uint16_t) value.revision_id);
+  }
+
+  static std::string
+  to_path(const result_type& value)
+  {
+    // The cast is required. This is a boost bug. https://github.com/boostorg/format/issues/60
+    return boost::str(boost::format("%04x_%02x") % value.device_id % (uint16_t) value.revision_id);
   }
 };
 

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -494,14 +494,14 @@ struct pcie_id : request
   revision_to_string(const result_type& value)
   {
     // The cast is required. This is a boost bug. https://github.com/boostorg/format/issues/60
-    return boost::str(boost::format("%02x") % (uint16_t) value.revision_id);
+    return boost::str(boost::format("%02x") % static_cast<uint16_t>(value.revision_id));
   }
 
   static std::string
   to_path(const result_type& value)
   {
     // The cast is required. This is a boost bug. https://github.com/boostorg/format/issues/60
-    return boost::str(boost::format("%04x_%02x") % value.device_id % (uint16_t) value.revision_id);
+    return boost::str(boost::format("%04x_%02x") % value.device_id % static_cast<uint16_t>(value.revision_id));
   }
 };
 

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -208,7 +208,7 @@ struct bdf
   }
 };
 
-struct id
+struct pcie_id
 {
   using result_type = query::pcie_id::result_type;
 
@@ -1444,7 +1444,7 @@ initialize_query_table()
   emplace_sysfs_get<query::xocl_errors>                        ("", "xocl_errors");
 
   emplace_func0_request<query::pcie_bdf,                       bdf>();
-  emplace_func0_request<query::pcie_id,                        id>();
+  emplace_func0_request<query::pcie_id,                        pcie_id>();
   emplace_func0_request<query::instance,                       instance>();
   emplace_func0_request<query::hotplug_offline,                hotplug_offline>();
   emplace_func0_request<query::clk_scaling_info,               clk_scaling_info>();

--- a/src/runtime_src/core/tools/common/TestRunner.cpp
+++ b/src/runtime_src/core/tools/common/TestRunner.cpp
@@ -387,8 +387,8 @@ findRyzenPlatformPaths(const std::shared_ptr<xrt_core::device>& dev)
     paths.push_back(sys_path.string() + "\\");
   return paths;
 #else
-  const auto device_id = xrt_core::device_query<xrt_core::query::pcie_device>(dev);
-  return {"/lib/firmware/amdnpu/" + boost::str(boost::format("%x") % device_id) + "/"};
+  const auto device_id = xrt_core::device_query<xrt_core::query::pcie_id>(dev);
+  return {"/lib/firmware/amdnpu/" + xrt_core::query::pcie_id::to_path(device_id) + "/"};
 #endif
 }
 

--- a/src/runtime_src/core/tools/common/tests/TestTCTAllColumn.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestTCTAllColumn.cpp
@@ -78,15 +78,20 @@ TestTCTAllColumn::run(std::shared_ptr<xrt_core::device> dev)
 {
   boost::property_tree::ptree ptree = get_test_header();
 
+  #ifdef _WIN32
   // workaround: can't rename files when copying to driver store
   // so need to name the files as _phx and _stx
   // will revisit this after the current release
-  auto device_id = xrt_core::query::pcie_device::to_string(xrt_core::device_query<xrt_core::query::pcie_device>(dev));
-  if (device_id.compare("0x1502") == 0)
-    m_xclbin = "validate_phx.xclbin";
-  else if (device_id.compare("0x17f0") == 0)
-    m_xclbin = "validate_stx.xclbin";
-  ptree.put("xclbin", m_xclbin);
+  auto device_id = xrt_core::device_query<xrt_core::query::pcie_device>(dev);
+  switch (device_id) {
+  case 5378: // 0x1502
+    ptree.put("xclbin", "validate_phx.xclbin");
+    break;
+  case 6128: // 0x17f0
+    ptree.put("xclbin", "validate_stx.xclbin");
+    break;
+  }
+  #endif
 
 
   auto xclbin_path = findXclbinPath(dev, ptree);

--- a/src/runtime_src/core/tools/common/tests/TestTCTOneColumn.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestTCTOneColumn.cpp
@@ -78,15 +78,20 @@ TestTCTOneColumn::run(std::shared_ptr<xrt_core::device> dev)
 {
   boost::property_tree::ptree ptree = get_test_header();
 
+  #ifdef _WIN32
   // workaround: can't rename files when copying to driver store
   // so need to name the files as _phx and _stx
   // will revisit this after the current release
-  auto device_id = xrt_core::query::pcie_device::to_string(xrt_core::device_query<xrt_core::query::pcie_device>(dev));
-  if (device_id.compare("0x1502") == 0)
-    m_xclbin = "validate_phx.xclbin";
-  else if (device_id.compare("0x17f0") == 0)
-    m_xclbin = "validate_stx.xclbin";
-  ptree.put("xclbin", m_xclbin);
+  auto device_id = xrt_core::device_query<xrt_core::query::pcie_device>(dev);
+  switch (device_id) {
+  case 5378: // 0x1502
+    ptree.put("xclbin", "validate_phx.xclbin");
+    break;
+  case 6128: // 0x17f0
+    ptree.put("xclbin", "validate_stx.xclbin");
+    break;
+  }
+  #endif
 
 
   auto xclbin_path = findXclbinPath(dev, ptree);


### PR DESCRIPTION
Package revision ID with device ID for better device categorization.

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1191367

This is an enhancement to the original PR: https://github.com/Xilinx/XRT/pull/7968

Various files may be different for devices that share a device ID but have different PCI Revision IDs.

The "xbutil validate" command is looking for validate.xclbin based on the device ID. This CR is to add support of revision id in XRT.

After the change, the validate.xclbin path on Linux system will be,
/lib/firmware/amdnpu/<device_id>_<revision_id>/validate.xclbin

The device_id is a 4 char length hex number, such as, 17f0.
The revision_id is a 2 char length hex number, such as, 00.


Below is the final validate xclbin path for Phoenix (device id 1502, revision id 00)
/lib/firmware/amdnpu/1502_00/validate.xclbin

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Found internally.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Solved by adding a new query request that packages the device id and revision id into a single structure. Additionally various helper functions are included to make our lives a bit easier.

#### Risks (if any) associated the changes in the commit
This should not impact windows NPU or alveo. This change is focused on the Linux implementation.

#### What has been tested and how, request additional testing if necessary
Tested on Ubuntu 22.04 U55c
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ xbutil examine -r pcie-info -o test.json --force
WARNING: Unexpected xocl version (2.16.0) was found. Expected 2.17.0, to match XRT tools.

-------------------------------------------------
[0000:04:00.1] : xilinx_u55c_gen3x16_xdma_base_3
-------------------------------------------------
Pcie Info
  Vendor                 : 0x10ee
  Device                 : 505d
  Sub Device             : 0x000e
  Sub Vendor             : 0x10ee
  PCIe                   : Gen3x4
  DMA Thread Count       : 2
  CPU Affinity           : 0-15
  Shared Host Memory     : 0 Byte
  Max Shared Host Memory : 0 Byte
  Enabled Host Memory    : 0 Byte

Successfully wrote the json file: test.json
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov$ cat test.json
{
    "schema_version": {
        "schema": "JSON",
        "creation_date": "Tue Feb 27 00:33:31 2024 GMT"
    },
    "devices": [
        {
            "interface_type": "pcie",
            "device_id": "0000:04:00.1",
            "device_status": "HEALTHY",
            "pcie_info": {
                "vendor": "0x10ee",
                "device": "505d",
                "revision": "00",
                "sub_device": "0x000e",
                "sub_vendor": "0x10ee",
                "link_speed_gbit_sec": "3",
                "expected_link_speed_gbit_sec": "3",
                "express_lane_width_count": "4",
                "expected_express_lane_width_count": "16",
                "dma_thread_count": "2",
                "cpu_affinity": "0-15",
                "max_shared_host_mem_aperture_bytes": "0 Byte",
                "shared_host_mem_size_bytes": "0 Byte",
                "enabled_host_mem_size_bytes": "0 Byte"
            }
        }
    ]
}
```

Ubuntu 22.04 U55C (Change to look like a NPU device)
The output of the firmware files are in
```
/lib/firmware/amdnpu/505d_00/
```
Where 505d is the device ID for a u55c and 00 is the revision number.

#### Documentation impact (if any)
None
