### PR TITLE
Fix seg fault when device not available is provided

### DIFF
--- a/src/runtime_src/core/pcie/linux/system_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/system_linux.cpp
@@ -178,9 +178,8 @@ get_device_id(const std::string& bdf) const
   if (bdf.find_first_not_of("0123456789") == std::string::npos)
     return system::get_device_id(bdf);
 
-  unsigned int i = 0;
   try {
-    while (1) {
+    for (unsigned int i = 0;; i++) {
       auto dev = get_pcidev(i);
       // [dddd:bb:dd.f]
       auto dev_bdf = boost::str(boost::format("%04x:%02x:%02x.%01x") % dev->m_domain % dev->m_bus % dev->m_dev % dev->m_func);

--- a/src/runtime_src/core/pcie/linux/system_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/system_linux.cpp
@@ -96,23 +96,23 @@ std::shared_ptr<pci::dev>
 system_linux::
 get_pcidev(unsigned index, bool is_user) const
 {
-  try {
-    if (is_user) {
-      if (index < user_ready_list.size())
-        return user_ready_list[index];
+  if (is_user) {
+    if (index < user_ready_list.size())
+      return user_ready_list[index];
 
-      if ((index - user_ready_list.size()) < user_nonready_list.size())
-        return user_nonready_list.at(index - user_ready_list.size());
-    }
-
+    if ((index - user_ready_list.size()) < user_nonready_list.size())
+      return user_nonready_list.at(index - user_ready_list.size());
+  }
+  else {
     if (index < mgmt_ready_list.size())
       return mgmt_ready_list[index];
 
-    return mgmt_nonready_list.at(index - mgmt_ready_list.size());
+    if ((index - mgmt_ready_list.size()) < mgmt_nonready_list.size())
+      return mgmt_nonready_list.at(index - mgmt_ready_list.size());
   }
-  catch (const std::exception&) {
-    return nullptr;
-  }
+
+  // given index is not present in list
+  throw std::runtime_error(" No such device with index '"+ std::to_string(index) + "'");
 }
 
 size_t
@@ -179,20 +179,24 @@ get_device_id(const std::string& bdf) const
     return system::get_device_id(bdf);
 
   unsigned int i = 0;
-  for (auto dev = get_pcidev(0); dev; dev = get_pcidev(++i)) {
+  try {
+    while (1) {
+      auto dev = get_pcidev(i);
       // [dddd:bb:dd.f]
       auto dev_bdf = boost::str(boost::format("%04x:%02x:%02x.%01x") % dev->m_domain % dev->m_bus % dev->m_dev % dev->m_func);
       if (dev_bdf == bdf)
         return i;
-      //consider default domain as 0000 and try to find a matching device
-      if(dev->m_domain == 0) {
+      // consider default domain as 0000 and try to find a matching device
+      if (dev->m_domain == 0) {
         dev_bdf = boost::str(boost::format("%02x:%02x.%01x") % dev->m_bus % dev->m_dev % dev->m_func);
-        if(dev_bdf == bdf)
+        if (dev_bdf == bdf)
           return i;
       }
+    }
   }
-
-  throw xrt_core::system_error(EINVAL, "No such device '" + bdf + "'");
+  catch (...) {
+    throw xrt_core::system_error(EINVAL, "No such device '" + bdf + "'");
+  }
 }
 
 std::pair<device::id_type, device::id_type>


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
when device id not available is given to xrt::device object creation we get a seg fault, this PR fixes that issue

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
It was discovered while refactoring XDP code to remove xcl apis

This issue can also be reproduced with simple application :
If a system has say 1 device and we try to create 2nd device (index >= 1) we get seg fault
`auto dev = xrt::device(1);`

#### How problem was solved, alternative solutions (if any) and why they were rejected
Fixed the if else condition, now code will not access mgmt list when is_user is true
Also throwing an exception if device with given index is not available as top functions which use get_pcidev directly access ptr returned by this function. 
Checked all the functions whose code flow uses this function and all of them are either 
1. catching exception  (or)
2. expected to throw exception (eg: xrt classes object creation)

#### Risks (if any) associated the changes in the commit
Low but needs further testing

#### What has been tested and how, request additional testing if necessary
Tested on multi device machine for pcie hw flow

#### Documentation impact (if any)
NA