### PR TITLE
CRs 1191344 & 1190977 - Bug fixes for AIE profile/trace on Edge

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info/aie_constructs.h
+++ b/src/runtime_src/xdp/profile/database/static_info/aie_constructs.h
@@ -67,6 +67,7 @@ enum class module_type {
     uint8_t stream_id;
     uint8_t is_master;
     uint64_t itr_mem_addr;
+    bool     is_dma_only;
     bool     is_trigger;
     
     bool operator==(const tile_type &tile) const {

--- a/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_control_config_filetype.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_control_config_filetype.cpp
@@ -338,6 +338,7 @@ AIEControlConfigFiletype::getAIETiles(const std::string& graph_name)
             tiles.push_back(tile_type());
             auto& t = tiles.at(count++);
             t.col = xdp::aie::convertStringToUint8(node.second.data());
+            t.is_dma_only = false;
         }
 
         int num_tiles = count;
@@ -396,6 +397,7 @@ AIEControlConfigFiletype::getEventTiles(const std::string& graph_name,
         return {};
     }
 
+    bool is_dma_only = (type == module_type::dma);
     const char* col_name = (type == module_type::core) ? "core_columns" : "dma_columns";
     const char* row_name = (type == module_type::core) ?    "core_rows" :    "dma_rows";
 
@@ -413,6 +415,7 @@ AIEControlConfigFiletype::getEventTiles(const std::string& graph_name,
             tiles.push_back(tile_type());
             auto& t = tiles.at(count++);
             t.col = xdp::aie::convertStringToUint8(node.second.data());
+            t.is_dma_only = is_dma_only;
         }
 
         int num_tiles = count;
@@ -466,6 +469,7 @@ AIEControlConfigFiletype::getTiles(const std::string& graph_name,
         tile_type tile;
         tile.col = mapping.second.get<uint8_t>("column");
         tile.row = mapping.second.get<uint8_t>("row") + rowOffset;
+        tile.is_dma_only = false;
         tiles.emplace_back(std::move(tile));
     }
     return tiles;

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/edge/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/edge/aie_trace.cpp
@@ -329,6 +329,9 @@ namespace xdp {
       auto& xaieTile  = aieDevice->tile(col, row);
       auto loc        = XAie_TileLoc(col, row);
       
+      if ((type == module_type::core) && tile.is_dma_only && !aie::trace::isDmaSet(metricSet))
+        continue;
+
       std::string tileName = (type == module_type::mem_tile) ? "memory" 
                            : ((type == module_type::shim) ? "interface" : "AIE");
       tileName.append(" tile (" + std::to_string(col) + "," + std::to_string(row) + ")");

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/util/aie_trace_config.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/util/aie_trace_config.cpp
@@ -100,8 +100,8 @@ namespace xdp::aie::trace {
           switchPortRsc->setPortToSelect(slaveOrMaster, SOUTH, streamPortId);
 
           // Record for runtime config file
-          config.port_trace_ids[portnum] = channel;
-          config.port_trace_is_master[portnum] = (tile.is_master != 0);
+          config.port_trace_ids[channel] = channel;
+          config.port_trace_is_master[channel] = (tile.is_master != 0);
 
           if (aie::isInputSet(type, metricSet)) {
             config.mm2s_channels[0] = channel0;

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/util/aie_trace_config.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/util/aie_trace_config.cpp
@@ -59,6 +59,7 @@ namespace xdp::aie::trace {
 
       bool newPort = false;
       auto portnum = getPortNumberFromEvent(event);
+      uint8_t channel = (portnum == 0) ? channel0 : channel1;
 
       // New port needed: reserve, configure, and store
       if (switchPortMap.find(portnum) == switchPortMap.end()) {
@@ -99,7 +100,7 @@ namespace xdp::aie::trace {
           switchPortRsc->setPortToSelect(slaveOrMaster, SOUTH, streamPortId);
 
           // Record for runtime config file
-          config.port_trace_ids[portnum] = streamPortId;
+          config.port_trace_ids[portnum] = channel;
           config.port_trace_is_master[portnum] = (tile.is_master != 0);
 
           if (aie::isInputSet(type, metricSet)) {
@@ -115,7 +116,6 @@ namespace xdp::aie::trace {
         }
         else {
           // Memory tiles
-          uint8_t channel = (portnum == 0) ? channel0 : channel1;
           auto slaveOrMaster = isInputSet(type, metricSet) ? XAIE_STRMSW_MASTER : XAIE_STRMSW_SLAVE;
           std::string typeName = (slaveOrMaster == XAIE_STRMSW_MASTER) ? "master" : "slave";
           std::string msg = "Configuring memory tile stream switch to monitor " 


### PR DESCRIPTION
**Problems solved by the commit**
* Ports not reported correctly with interface tile trace
* DMA-only tiles not reported correctly
* Missing or incorrect messages

**How problem was solved, alternative solutions (if any) and why they were rejected**
* Corrected interface tile port reporting in runtime config
* Identify DMA-only tiles and filter so only included when needed

**Risks (if any) associated the changes in the commit**
None

**What has been tested and how, request additional testing if necessary**
Tested two designs on vek280

**Documentation impact (if any)**
Inform user when DMA-only tiles are visualized in trace view