### PR TITLE
Fixing clock rate retrieval in case of zero

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info/pl_constructs.h
+++ b/src/runtime_src/xdp/profile/database/static_info/pl_constructs.h
@@ -252,7 +252,7 @@ namespace xdp {
     inline bool getStreamTraceEnabled() const { return asmIdsWithTrace.size() > 0 ; }
     inline bool getDataflowEnabled() const    { return dataflow ; }
     inline bool getHasFA() const              { return hasFA ; }
-    inline double getClockFrequency()         { return clockFrequency ; }
+    inline double getClockFrequency()         { return clockFrequency > 0 ? clockFrequency : 300 ; }
     inline bool getDataTransferTraceEnabled() const
       { return aimIdsWithTrace.size() > 0 ; }
 


### PR DESCRIPTION
#### Problem solved by the commit
Unexpected and incorrect values in Compute Unit Utilization section of summary.csv

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1191301

#### How problem was solved, alternative solutions (if any) and why they were rejected
When retrieving the clock frequency for the compute unit, a check is placed. If the compute unit's clock frequency is retrieved from the system metadata as zero, then the default pl frequency (300 MHz) is assigned to the compute unit.

