### PR TITLE
VITIS-11418 Upgrade AIE partition report

### DIFF
--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -1538,10 +1538,12 @@ struct aie_partition_info : request
     hw_context_info::metadata metadata;
     uint64_t    start_col;
     uint64_t    num_cols;
-    uint64_t    usage_count;
-    uint64_t    migration_count;
-    uint64_t    bo_sync_count;
-
+    int         pid;
+    uint64_t    command_submissions;
+    uint64_t    command_completions;
+    uint64_t    migrations;
+    uint64_t    preemptions;
+    uint64_t    errors;
   };
 
   using result_type = std::vector<struct data>;

--- a/src/runtime_src/core/tools/common/reports/ReportAiePartitions.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportAiePartitions.cpp
@@ -24,11 +24,14 @@ populate_aie_partition(const xrt_core::device* device)
     auto partition = pt_map.emplace(std::make_tuple(entry.start_col, entry.num_cols), boost::property_tree::ptree());
 
     boost::property_tree::ptree pt_entry;
+    pt_entry.put("pid", entry.pid);
+    pt_entry.put("context_id", entry.metadata.id);
     pt_entry.put("xclbin_uuid", entry.metadata.xclbin_uuid);
-    pt_entry.put("slot_id", entry.metadata.id);
-    pt_entry.put("usage_count", entry.usage_count);
-    pt_entry.put("migration_count", entry.migration_count);
-    pt_entry.put("device_bo_sync_count", entry.bo_sync_count);
+    pt_entry.put("command_submissions", entry.command_submissions);
+    pt_entry.put("command_completions", entry.command_completions);
+    pt_entry.put("migrations", entry.migrations);
+    pt_entry.put("preemptions", entry.preemptions);
+    pt_entry.put("errors", entry.errors);
 
     partition.first->second.push_back(std::make_pair("", pt_entry));
   }
@@ -85,8 +88,6 @@ writeReport(const xrt_core::device* /*_pDevice*/,
   for (const auto& pt_partition : pt_partitions) {
     const auto& partition = pt_partition.second;
 
-    _output << boost::str(boost::format("  Partition Index: %d\n") % partition.get<uint64_t>("partition_index"));
-
     const auto start_col = partition.get<uint64_t>("start_col");
     const auto num_cols = partition.get<uint64_t>("num_cols");
     std::string column_string;
@@ -95,27 +96,49 @@ writeReport(const xrt_core::device* /*_pDevice*/,
       if (i < num_cols - 1)
         column_string += ", ";
     }
-    _output << boost::str(boost::format("    Columns: [%s]\n") % column_string);
 
     const std::vector<Table2D::HeaderData> table_headers = {
-      {"Slot ID", Table2D::Justification::left},
+      {"PID", Table2D::Justification::left},
+      {"Context ID", Table2D::Justification::left},
       {"Xclbin UUID", Table2D::Justification::left},
-      {"Command Submissions", Table2D::Justification::left},
-      {"Migration Count", Table2D::Justification::left}
+      {"Submissions", Table2D::Justification::left},
+      {"Completions", Table2D::Justification::left},
+      {"Migrations", Table2D::Justification::left},
+      {"Preemptions", Table2D::Justification::left},
     };
     Table2D context_table(table_headers);
 
-    _output << "    HW Contexts:\n";
+    std::vector<uint64_t> errors;
     for (const auto& pt_hw_context : partition.get_child("hw_contexts", empty_ptree)) {
       const auto& hw_context = pt_hw_context.second;
+
+      errors.push_back(hw_context.get<uint64_t>("errors"));
+
       const std::vector<std::string> entry_data = {
-        hw_context.get<std::string>("slot_id"),
+        hw_context.get<std::string>("pid"),
+        hw_context.get<std::string>("context_id"),
         hw_context.get<std::string>("xclbin_uuid"),
-        hw_context.get<std::string>("usage_count"),
-        hw_context.get<std::string>("migration_count")
+        hw_context.get<std::string>("command_submissions"),
+        hw_context.get<std::string>("command_completions"),
+        hw_context.get<std::string>("migrations"),
+        hw_context.get<std::string>("preemptions")
       };
       context_table.addEntry(entry_data);
     }
+
+    // Currently the error counts are per partition vs per context.
+    // Future releases will enable per context error resolution.
+    // In the meantime, each context within a partition must have the same error count.
+    uint64_t error_count = errors.empty() ? 0 : errors[0];
+    for (size_t i = 1; i < errors.size(); i++) {
+      if (errors[i - 1] != errors[i])
+        throw xrt_core::error("Invalid error counts within AIE partition");
+    }
+
+    _output << boost::str(boost::format("  Partition Index: %d\n") % partition.get<uint64_t>("partition_index"));
+    _output << boost::str(boost::format("    Columns: [%s]\n") % column_string);
+    _output << boost::str(boost::format("    Errors: %lu\n") % error_count);
+    _output << "    HW Contexts:\n";
     _output << boost::str(boost::format("%s\n") % context_table.toString("      "));
   }
 
@@ -137,7 +160,7 @@ writeReport(const xrt_core::device* /*_pDevice*/,
         uint64_t col = start_col + i;
         std::string context_string;
         for (const auto& pt_hw_context : partition.get_child("hw_contexts", empty_ptree))
-          context_string += pt_hw_context.second.get<std::string>("slot_id") + ", ";
+          context_string += pt_hw_context.second.get<std::string>("context_id") + ", ";
         context_string.erase(context_string.end() - 2, context_string.end());
         const std::vector<std::string> entry_data = {
           std::to_string(col),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/VITIS-11418
Changes within our devices necessitate a change to what we display in the aie partition report.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
New feature.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Updated the query request structure to better represent the direction the hardware context object is moving towards.

#### Risks (if any) associated the changes in the commit
None.

#### What has been tested and how, request additional testing if necessary
Tested in Windows:

The PID, Submissions, Completions, Migrations, and Preemption columns are all not implemented in the driver and return invalid values.
```
C:\Users\dbenusov\Documents\dbenusov\xrt>xbutil examine -r aie-partitions
------------------------------------------------------------
                        EARLY ACCESS
        This release of xbutil contains early access
         experimental features which may have bugs.
------------------------------------------------------------

---------------------------------
[00c3:00:01.1] : RyzenAI-Phoenix
---------------------------------
AIE Partitions
  Partition Index: 0
    Columns: [1, 2, 3, 4]
    Errors: 0
    HW Contexts:
      PID  Context ID  Xclbin UUID                             Submissions  Completions  Migrations  Preemptions
      ------------------------------------------------------------------------------------------------------------
      -1   2           {6155b87c-6fd5-5da7-fc56-53a9fa82d158}  0            0            0           0
```

#### Documentation impact (if any)
None.