### PR TITLE
VITIS-11517 Remove ReportMemory from Ryzen in XRT

### DIFF
--- a/src/runtime_src/core/tools/xbutil2/xbutil.cpp
+++ b/src/runtime_src/core/tools/xbutil2/xbutil.cpp
@@ -54,7 +54,7 @@ R"(
 },{
   "aie": [{
     "examine": [{
-      "report": ["electrical", "host", "memory", "platform", "aie", "aiemem", "aieshim", "aie-partitions", "telemetry"]
+      "report": ["electrical", "host", "platform", "aie", "aiemem", "aieshim", "aie-partitions", "telemetry"]
     }]
   },{
     "configure": [{


### PR DESCRIPTION
#### Problem solved by the commit
https://jira.xilinx.com/browse/VITIS-11517
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
As discussed with Max and Pranjal, ReportMemory was deemed irrelevant on NPU.
#### How problem was solved, alternative solutions (if any) and why they were rejected
Removed memory report from xbutil config json for "aie" device class.
#### Risks (if any) associated the changes in the commit
N/A (May need to remove from documentation if ReportMemory was included in docs)