### PR TITLE
Fix TCT tests for Linux

### DIFF
--- a/src/runtime_src/core/tools/common/tests/TestTCTAllColumn.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestTCTAllColumn.cpp
@@ -125,7 +125,7 @@ TestTCTAllColumn::run(std::shared_ptr<xrt_core::device> dev)
   auto kernelName = xkernel.get_name();
   logger(ptree, "Details", boost::str(boost::format("Kernel name is '%s'") % kernelName));
 
-  auto working_dev = xrt::device{dev->get_device_id()};
+  auto working_dev = xrt::device(dev);
   working_dev.register_xclbin(xclbin);
   xrt::hw_context hwctx{working_dev, xclbin.get_uuid()};
   xrt::kernel kernel{hwctx, kernelName};

--- a/src/runtime_src/core/tools/common/tests/TestTCTOneColumn.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestTCTOneColumn.cpp
@@ -125,7 +125,7 @@ TestTCTOneColumn::run(std::shared_ptr<xrt_core::device> dev)
   auto kernelName = xkernel.get_name();
   logger(ptree, "Details", boost::str(boost::format("Kernel name is '%s'") % kernelName));
 
-  auto working_dev = xrt::device{dev->get_device_id()};
+  auto working_dev = xrt::device(dev);
   working_dev.register_xclbin(xclbin);
   xrt::hw_context hwctx{working_dev, xclbin.get_uuid()};
   xrt::kernel kernel{hwctx, kernelName};


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
TCT tests are failing on Linux NPU. This is the XRT portion of the fix.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Introduced in https://github.com/Xilinx/XRT/pull/7887 by not properly creating a device reference.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Updated the devices to make a reference and not a new instance.

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Linux NPU
```
dbenusov@xlix-birman-29:/proj/rdi/staff/dbenusov/amd-aie-new$ xbutil validate -d -r tct-all-col tct-one-col --verbose
1187: Created NPU pcidev
Verbose: Enabling Verbosity
340754: Device opened, fd=3
359750: Allocated NPU BO for: userptr=0x7fcf1c000000, size=50331648, flags=0x0
364499: Created NPU device (0000:c3:00.1) ...
------------------------------------------------------------
                        EARLY ACCESS
        This release of xbutil contains early access
         experimental features which may have bugs.
------------------------------------------------------------
Validate Device           : [0000:c3:00.1]
    Platform              : RyzenAI-npu1
-------------------------------------------------------------------------------
[                    ]: Running Test... < 0s >
76039162: Created NPU HW queue
76049848: Creating HW context...
97717994: Bond HW queue to HW context 0
97733429: Created NPU HW context (0)
98004132: Destroying NPU HW context (0)...
98010068: Unbond HW queue from HW context 0
101031736: Destroyed HW context (0)...
Test 1 [0000:c3:00.1]     : tct-one-col

    Description           : Measure average TCT processing time for one column
    Xclbin                : /lib/firmware/amdnpu/1502_00/validate.xclbin
    Details               : Kernel name is 'DPU_PDI_0'
                            tct_1col.txt not available. Skipping validation.
    Test Status           : [SKIPPED]
-------------------------------------------------------------------------------
[                    ]: Running Test... < 0s >
1085414999: Created NPU HW queue
1085441119: Creating HW context...
1091402531: Bond HW queue to HW context 1
1091409655: Created NPU HW context (1)
1091629304: Destroying NPU HW context (1)...
1091635241: Unbond HW queue from HW context 1
1094114314: Destroyed HW context (1)...
Test 2 [0000:c3:00.1]     : tct-all-col

    Description           : Measure average TCT processing time for all columns
    Xclbin                : /lib/firmware/amdnpu/1502_00/validate.xclbin
    Details               : Kernel name is 'DPU_PDI_0'
                            tct_4col.txt not available. Skipping validation.
    Test Status           : [SKIPPED]
-------------------------------------------------------------------------------
Validation completed
2017192753: Destroying NPU device (0000:c3:00.1) ...
2017212937: Freeing NPU BO, type=AMDXDNA_BO_DEV_HEAP, drm_bo=1, size=50331648
2021875447: Destroying NPU pcidev
2022071351: Device closed, fd=3
```

#### Documentation impact (if any)
None