### PR TITLE
Replace xclOpen/Close in XDP

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/device_offload/hal/hal_device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/hal/hal_device_offload_plugin.cpp
@@ -40,12 +40,14 @@ namespace xdp {
 
   HALDeviceOffloadPlugin::HALDeviceOffloadPlugin() : DeviceOffloadPlugin()
   {
+std::cout << " Num of devices " << (int) xrt_core::get_total_devices(true/*is_user*/).second << std::endl;
+    uint32_t numDevices = xrt_core::get_total_devices(true/*is_user*/).second;
     db->registerInfo(info::device_offload) ;
 
     // Open all existing devices so that XDP can access the owned handles
 
     uint32_t index = 0;
-    while (1) {
+    while (index < numDevices) {
       try {
         xrtDevices.push_back(std::make_unique<xrt::device>(index));
 

--- a/src/runtime_src/xdp/profile/plugin/device_offload/hal/hal_device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/hal/hal_device_offload_plugin.cpp
@@ -62,7 +62,7 @@ namespace xdp {
         // Move on to the next device
         ++index;
       } catch (const std::runtime_error& e) {
-        std::string msg = "Could not open device at index " + std::to_string(index);
+        std::string msg = "Could not open device at index " + std::to_string(index) + e.what();
         xrt_core::message::send(xrt_core::message::severity_level::error, "XRT", msg);
         continue;
       }

--- a/src/runtime_src/xdp/profile/plugin/device_offload/hal/hal_device_offload_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/hal/hal_device_offload_plugin.h
@@ -41,7 +41,6 @@ namespace xdp {
     //  handles) we need to open all the devices and keep our own handles
     //  to them.
     std::vector<std::unique_ptr<xrt::device>> xrtDevices ;
-//    std::vector<void*> deviceHandles ;
     std::map<uint64_t, void*> deviceIdToHandle ;
 
     virtual void readTrace() ;

--- a/src/runtime_src/xdp/profile/plugin/device_offload/hal/hal_device_offload_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/hal/hal_device_offload_plugin.h
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2016-2022 Xilinx, Inc
- * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -18,10 +18,15 @@
 #ifndef HAL_DEVICE_OFFLOAD_PLUGIN_DOT_H
 #define HAL_DEVICE_OFFLOAD_PLUGIN_DOT_H
 
-#include <vector>
 #include <map>
+#include <memory>
+#include <vector>
 
 #include "xdp/profile/plugin/device_offload/device_offload_plugin.h"
+
+namespace xrt {
+  class device;
+}
 
 namespace xdp {
 
@@ -35,7 +40,8 @@ namespace xdp {
     //  from a device at any time (even if the user has closed their
     //  handles) we need to open all the devices and keep our own handles
     //  to them.
-    std::vector<void*> deviceHandles ;
+    std::vector<std::unique_ptr<xrt::device>> xrtDevices ;
+//    std::vector<void*> deviceHandles ;
     std::map<uint64_t, void*> deviceIdToHandle ;
 
     virtual void readTrace() ;

--- a/src/runtime_src/xdp/profile/plugin/noc/noc_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/noc/noc_plugin.cpp
@@ -56,7 +56,7 @@ namespace xdp {
                                                   index) ;
         writers.push_back(writer);
         db->getStaticInfo().addOpenedFile(writer->getcurrentFileName(), "NOC_PROFILE") ;
-      } catch (const std::runtime_error &e) {
+      } catch (const std::runtime_error &) {
         break;
       }
       ++index; 

--- a/src/runtime_src/xdp/profile/plugin/noc/noc_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/noc/noc_plugin.cpp
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2020-2021 Xilinx, Inc
- * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -17,15 +17,16 @@
 
 #define XDP_PLUGIN_SOURCE
 
-#include "xdp/profile/database/static_info/aie_constructs.h"
-#include "xdp/profile/plugin/noc/noc_plugin.h"
-#include "xdp/profile/writer/noc/noc_writer.h"
-#include "xdp/profile/plugin/vp_base/info.h"
-
 #include "core/common/system.h"
 #include "core/common/time.h"
 #include "core/common/config_reader.h"
 #include "core/include/experimental/xrt-next.h"
+#include "core/include/xrt/xrt_device.h"
+
+#include "xdp/profile/database/static_info/aie_constructs.h"
+#include "xdp/profile/plugin/noc/noc_plugin.h"
+#include "xdp/profile/writer/noc/noc_writer.h"
+#include "xdp/profile/plugin/vp_base/info.h"
 
 #include <boost/algorithm/string.hpp>
 
@@ -36,28 +37,29 @@ namespace xdp {
   {
     db->registerPlugin(this);
     db->registerInfo(info::noc);
-    // Just like HAL and power profiling, go through devices 
-    //  that exist and open a file for each
-    uint64_t index = 0;
-    void* handle = xclOpen(index, "/dev/null", XCL_INFO);
-    while (handle != nullptr) {
-      // Determine the name of the device
-      struct xclDeviceInfo2 info;
-      xclGetDeviceInfo2(handle, &info);
-      std::string deviceName = std::string(info.mName);
-      mDevices.push_back(deviceName);
 
-      std::string outputFile = "noc_profile_" + deviceName + ".csv"; 
-      VPWriter* writer = new NOCProfilingWriter(outputFile.c_str(),
-                                                deviceName.c_str(),
-                                                index) ;
-      writers.push_back(writer);
-      db->getStaticInfo().addOpenedFile(writer->getcurrentFileName(), "NOC_PROFILE") ;
-
-      // Move on to next device
-      xclClose(handle);
-      ++index;
-      handle = xclOpen(index, "/dev/null", XCL_INFO);
+    uint32_t numDevices = xrt_core::get_total_devices(true).second;
+    uint32_t index = 0;
+    while (index < numDevices) {
+      try {
+        auto xrtDevice = std::make_unique<xrt::device>(index);
+        auto ownedHandle = xrtDevice->get_handle()->get_device_handle();
+        // Determine the name of the device
+        struct xclDeviceInfo2 info;
+        xclGetDeviceInfo2(ownedHandle, &info);
+        std::string deviceName = std::string(info.mName);
+        mDevices.push_back(deviceName);
+  
+        std::string outputFile = "noc_profile_" + deviceName + ".csv"; 
+        VPWriter* writer = new NOCProfilingWriter(outputFile.c_str(),
+                                                  deviceName.c_str(),
+                                                  index) ;
+        writers.push_back(writer);
+        db->getStaticInfo().addOpenedFile(writer->getcurrentFileName(), "NOC_PROFILE") ;
+      } catch (const std::runtime_error &e) {
+        break;
+      }
+      ++index; 
     }
 
     // Get polling interval (in msec)

--- a/src/runtime_src/xdp/profile/plugin/power/power_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/power/power_plugin.cpp
@@ -114,7 +114,7 @@ namespace xdp {
         // Move on to the next device
         ++index;
       } catch (const std::runtime_error& e) {
-        std::string msg = "Could not open device at index " + std::to_string(index);
+        std::string msg = "Could not open device at index " + std::to_string(index) + e.what();
         xrt_core::message::send(xrt_core::message::severity_level::error, "XRT", msg);
         continue;
       }  

--- a/src/runtime_src/xdp/profile/plugin/power/power_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/power/power_plugin.cpp
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2020-2022 Xilinx, Inc
- * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -18,14 +18,18 @@
 #define XDP_PLUGIN_SOURCE
 
 #include <map>
+#include <string>
+
+#include "core/common/config_reader.h"
+#include "core/common/message.h"
+#include "core/common/system.h"
+#include "core/common/time.h"
+#include "core/include/experimental/xrt-next.h"
+#include "core/include/xrt/xrt_device.h"
 
 #include "xdp/profile/plugin/power/power_plugin.h"
 #include "xdp/profile/writer/power/power_writer.h"
 #include "xdp/profile/plugin/vp_base/info.h"
-#include "core/common/system.h"
-#include "core/common/time.h"
-#include "core/common/config_reader.h"
-#include "core/include/experimental/xrt-next.h"
 
 namespace xdp {
 
@@ -69,49 +73,52 @@ namespace xdp {
     //  different boards.  We number them all individually.
     std::map<std::string, uint64_t> deviceNumbering ;
 
-    // Just like HAL level device profiling, go through the devices 
-    //  that exist in order to find all of the sysfs paths
-    uint64_t index = 0 ;
-    void* handle = xclOpen(index, "/dev/null", XCL_INFO) ;
-    while (handle != nullptr)
-    {
-      // For each device, keep track of the paths to the sysfs files
-      std::vector<std::string> paths ;
-      for (auto f : powerFiles)
-      {
-        char sysfsPath[512] ;
-        xclGetSysfsPath(handle, "xmc", f, sysfsPath, 512) ;
-        paths.push_back(sysfsPath) ;
-      }
-      filePaths.push_back(paths) ;
+   uint32_t numDevices = xrt_core::get_total_devices(true).second;
+   uint32_t index = 0;
+   while (index < numDevices) {
+     try {
+       auto xrtDevice = std::make_unique<xrt::device>(index);
+       auto ownedHandle = xrtDevice->get_handle()->get_device_handle();
+       
+        // For each device, keep track of the paths to the sysfs files
+        std::vector<std::string> paths ;
+        for (auto f : powerFiles)
+        {
+          char sysfsPath[512] ;
+          xclGetSysfsPath(ownedHandle, "xmc", f, sysfsPath, 512) ;
+          paths.push_back(sysfsPath) ;
+        }
+        filePaths.push_back(paths) ;
+  
+        // Determine the name of the device
+        struct xclDeviceInfo2 info ;
+        xclGetDeviceInfo2(ownedHandle, &info) ;
+        std::string deviceName = std::string(info.mName) ;
+  
+        if (deviceNumbering.find(deviceName) == deviceNumbering.end()) {
+          deviceNumbering[deviceName] = 0 ;
+        }
+        deviceName += "-" ;
+        deviceName += std::to_string(deviceNumbering[deviceName]) ;
+        deviceNumbering[deviceName]++ ;
 
-      // Determine the name of the device
-      struct xclDeviceInfo2 info ;
-      xclGetDeviceInfo2(handle, &info) ;
-      std::string deviceName = std::string(info.mName) ;
-
-      if (deviceNumbering.find(deviceName) == deviceNumbering.end()) {
-        deviceNumbering[deviceName] = 0 ;
-      }
-      deviceName += "-" ;
-      deviceName += std::to_string(deviceNumbering[deviceName]) ;
-      deviceNumbering[deviceName]++ ;
-
-      std::string outputFile = "power_profile_" + deviceName + ".csv" ; 
-
-      VPWriter* writer = new PowerProfilingWriter(outputFile.c_str(),
-                                                  deviceName.c_str(),
-                                                  index) ;
-      writers.push_back(writer) ;
-      (db->getStaticInfo()).addOpenedFile(writer->getcurrentFileName(), 
+        std::string outputFile = "power_profile_" + deviceName + ".csv" ; 
+  
+        VPWriter* writer = new PowerProfilingWriter(outputFile.c_str(),
+                                                    deviceName.c_str(),
+                                                    index) ;
+        writers.push_back(writer) ;
+        (db->getStaticInfo()).addOpenedFile(writer->getcurrentFileName(), 
                                           "XRT_POWER_PROFILE") ;
 
-      // Move on to the next device
-      xclClose(handle) ;
-      ++index ;
-      handle = xclOpen(index, "/dev/null", XCL_INFO) ;
+        // Move on to the next device
+        ++index;
+      } catch (const std::runtime_error& e) {
+        std::string msg = "Could not open device at index " + std::to_string(index);
+        xrt_core::message::send(xrt_core::message::severity_level::error, "XRT", msg);
+        continue;
+      }  
     }
-
     // Start the power profiling thread
     pollingThread = std::thread(&PowerProfilingPlugin::pollPower, this) ;
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
xclOpen is used in XDP Hal Device Offload, NOC, Power Profile Plugins to get handle to available devices. This can be replaced by using xrt::device instead.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
First, use device query to get total number of available devices. Then create xrt::Device instances for all the available devices and use them and their device handles in XDP Plugins.

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
PCIE Hw, Client
#### Documentation impact (if any)
