### PR TITLE
Change buffer size to decrease throughput for df-bw

### DIFF
--- a/src/runtime_src/core/tools/common/tests/TestIPU.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestIPU.cpp
@@ -14,7 +14,7 @@ namespace XBU = XBUtilities;
 #include <filesystem>
 
 static constexpr size_t host_app = 1; //opcode
-static constexpr size_t buffer_size = 128;
+static constexpr size_t buffer_size = 20;
 static constexpr int itr_count = 10000; 
 
 // ----- C L A S S   M E T H O D S -------------------------------------------


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
128k buffer size was not giving optimal throughput numbers

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Internal testing

#### How problem was solved, alternative solutions (if any) and why they were rejected
With trial and error, I tested out different combinations of buffer sizes and iteration counts and looks like 20 bytes buffer size with 10,000 iteration count, gives expected values

#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
MCDM/PHX windows system:
```
>xbutil validate -r verify
------------------------------------------------------------
                        EARLY ACCESS
        This release of xbutil contains early access
         experimental features which may have bugs.
------------------------------------------------------------
Validate Device           : [00c3:00:01.1]
    Platform              : RyzenAI-Phoenix
-------------------------------------------------------------------------------
Verbose: Enabling Verbosity
Test 1 [00c3:00:01.1]     : verify
    Description           : Run 'Hello World' test on IPU
    Xclbin                : C:\Windows\System32\DriverStore\FileRepository\ipukmddrv.inf_amd64_5a9eda6609fa1686\validate_phx.xclbin
    Details               : Kernel name is 'DPU_PDI_0'
                            Total duration: '1.0's
                            Average throughput: '9968.6' ops/s
                            Average latency: '100.3' us
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Validation completed
```

#### Documentation impact (if any)
N/A