### PR TITLE
Adjustments to identifying, handling, and reporting active core/memory modules in AIE profile & trace

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info/aie_constructs.h
+++ b/src/runtime_src/xdp/profile/database/static_info/aie_constructs.h
@@ -61,13 +61,14 @@ enum class module_type {
 
   struct tile_type
   { 
-    uint8_t row;
-    uint8_t col;
-    uint8_t subtype;
-    uint8_t stream_id;
-    uint8_t is_master;
+    uint8_t  row;
+    uint8_t  col;
+    uint8_t  subtype;
+    uint8_t  stream_id;
+    uint8_t  is_master;
     uint64_t itr_mem_addr;
-    bool     is_dma_only;
+    bool     active_core;
+    bool     active_memory;
     bool     is_trigger;
     
     bool operator==(const tile_type &tile) const {

--- a/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_control_config_filetype.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_control_config_filetype.cpp
@@ -341,7 +341,7 @@ AIEControlConfigFiletype::getAIETiles(const std::string& graph_name) const
             tiles.push_back(tile_type());
             auto& t = tiles.at(count++);
             t.col = xdp::aie::convertStringToUint8(node.second.data());
-            t.is_dma_only = false;
+            t.active_core = true;
         }
 
         int num_tiles = count;
@@ -360,8 +360,7 @@ AIEControlConfigFiletype::getAIETiles(const std::string& graph_name) const
             tiles.at(count++).stream_id = xdp::aie::convertStringToUint8(node.second.data());
         xdp::aie::throwIfError(count < num_tiles,"iteration_memory_rows < num_tiles");
 
-        count = startCount;
-        for (auto& node : graph.second.get_child("iteration_memory_addresses"))
+        count = startCount;        for (auto& node : graph.second.get_child("iteration_memory_addresses"))
             tiles.at(count++).itr_mem_addr = std::stoul(node.second.data());
         xdp::aie::throwIfError(count < num_tiles,"iteration_memory_addresses < num_tiles");
 
@@ -384,12 +383,17 @@ AIEControlConfigFiletype::getAllAIETiles(const std::string& graph_name) const
     tiles = getEventTiles(graph_name, module_type::core);
     auto dmaTiles = getEventTiles(graph_name, module_type::dma);
 
+    // Specify if active core tiles also have active DMAs
+    for (auto& tile : tiles)
+        tile.active_memory = (std::find(dmaTiles.begin(), dmaTiles.end(), tile) != dmaTiles.end());
+
     // Identify and add DMA-only tiles to list
     for (auto& tile : dmaTiles) {
-      if (std::find(tiles.begin(), tiles.end(), tile) == tiles.end()) {
-        tile.is_dma_only = true;
-        tiles.push_back(tile);
-      }
+        if (std::find(tiles.begin(), tiles.end(), tile) == tiles.end()) {
+            tile.active_core = false;
+            tile.active_memory = true;
+            tiles.push_back(tile);
+        }
     }
     //std::unique_copy(dmaTiles.begin(), dmaTiles.end(), back_inserter(tiles), xdp::aie::tileCompare);
     return tiles;
@@ -425,7 +429,10 @@ AIEControlConfigFiletype::getEventTiles(const std::string& graph_name,
             tiles.push_back(tile_type());
             auto& t = tiles.at(count++);
             t.col = xdp::aie::convertStringToUint8(node.second.data());
-            t.is_dma_only = false;
+            if (type == module_type::core)
+              t.active_core = true;
+            else
+              t.active_memory = true;
         }
 
         int num_tiles = count;
@@ -479,7 +486,8 @@ AIEControlConfigFiletype::getTiles(const std::string& graph_name,
         tile_type tile;
         tile.col = mapping.second.get<uint8_t>("column");
         tile.row = mapping.second.get<uint8_t>("row") + rowOffset;
-        tile.is_dma_only = false;
+        tile.active_core = true;
+        tile.active_memory = true;
         tiles.emplace_back(std::move(tile));
     }
     return tiles;

--- a/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_control_config_filetype.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_control_config_filetype.cpp
@@ -360,7 +360,8 @@ AIEControlConfigFiletype::getAIETiles(const std::string& graph_name) const
             tiles.at(count++).stream_id = xdp::aie::convertStringToUint8(node.second.data());
         xdp::aie::throwIfError(count < num_tiles,"iteration_memory_rows < num_tiles");
 
-        count = startCount;        for (auto& node : graph.second.get_child("iteration_memory_addresses"))
+        count = startCount;
+        for (auto& node : graph.second.get_child("iteration_memory_addresses"))
             tiles.at(count++).itr_mem_addr = std::stoul(node.second.data());
         xdp::aie::throwIfError(count < num_tiles,"iteration_memory_addresses < num_tiles");
 

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/edge/aie_profile.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/edge/aie_profile.cpp
@@ -409,10 +409,14 @@ namespace xdp {
         auto row         = tile.row;
         auto subtype     = tile.subtype;
         auto type        = aie::getModuleType(row, metadata->getAIETileRowOffset());
-        
-        if (mod == XAIE_MEM_MOD && type == module_type::core)
+        if ((mod == XAIE_MEM_MOD) && (type == module_type::core))
           type = module_type::dma;
+
+        // Ignore invalid types and inactive modules
         if (!aie::profile::isValidType(type, mod))
+          continue;
+        if (((type == module_type::core) && !tile.active_core)
+            || ((type == module_type::dma) && !tile.active_memory))
           continue;
 
         auto& metricSet  = tileMetric.second;

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/edge/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/edge/aie_trace.cpp
@@ -329,8 +329,14 @@ namespace xdp {
       auto& xaieTile  = aieDevice->tile(col, row);
       auto loc        = XAie_TileLoc(col, row);
       
-      if ((type == module_type::core) && tile.is_dma_only && !aie::trace::isDmaSet(metricSet))
-        continue;
+      if ((type == module_type::core) && !aie::trace::isDmaSet(metricSet)) {
+        // If we're not looking at DMA events, then don't display the DMA
+        // If core is not active (i.e., DMA-only tile), then ignore this tile
+        if (tile.active_core)
+          tile.active_memory = false;
+        else
+          continue;
+      }
 
       std::string tileName = (type == module_type::mem_tile) ? "memory" 
                            : ((type == module_type::shim) ? "interface" : "AIE");
@@ -361,7 +367,8 @@ namespace xdp {
       auto cfgTile = std::make_unique<aie_cfg_tile>(col, row, type);
       cfgTile->type = type;
       cfgTile->trace_metric_set = metricSet;
-      cfgTile->active_core = (tile.is_dma_only == false);
+      cfgTile->active_core = tile.active_core;
+      cfgTile->active_memory = tile.active_memory;
 
       // Get vector of pre-defined metrics for this set
       // NOTE: these are local copies as we are adding tile/counter-specific events


### PR DESCRIPTION
**Problem solved by the commit**
* Profiling and trace were not handling different active core/memory module combos correctly

**How problem was solved, alternative solutions (if any) and why they were rejected**
* Label active modules when parsing metadata
* Honor metadata and guard against combos that are don't care based on settings

**Risks (if any) associated the changes in the commit**
* Graph/kernel-based metadata only tells us active core, not DMA

**What has been tested and how, request additional testing if necessary**
* Tested on vek280

**Documentation impact (if any)**
* Display of Core and/or DMA subsections per tile in AIE trace
* Reporting of tiles based on metric sets in AIE profiling