### PR TITLE
Fix to correct global index for event tiles

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_control_config_filetype.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_control_config_filetype.cpp
@@ -413,6 +413,7 @@ AIEControlConfigFiletype::getEventTiles(const std::string& graph_name,
 
     std::vector<tile_type> tiles;
     auto rowOffset = getAIETileRowOffset();
+    int allTilesIdx = 0;
 
     for (auto& graph : graphsMetadata.get()) {
         auto currGraph = graph.second.get<std::string>("name");
@@ -423,15 +424,17 @@ AIEControlConfigFiletype::getEventTiles(const std::string& graph_name,
         int count = 0;
         for (auto& node : graph.second.get_child(col_name)) {
             tiles.push_back(tile_type());
-            auto& t = tiles.at(count++);
+            auto& t = tiles.at(allTilesIdx);
             t.col = xdp::aie::convertStringToUint8(node.second.data());
             t.is_dma_only = false;
+            allTilesIdx++;
+            count++;
         }
 
         int num_tiles = count;
         count = 0;
         for (auto& node : graph.second.get_child(row_name))
-            tiles.at(count++).row = xdp::aie::convertStringToUint8(node.second.data()) + rowOffset;
+            tiles.at(allTilesIdx-num_tiles+count++).row = xdp::aie::convertStringToUint8(node.second.data()) + rowOffset;
         xdp::aie::throwIfError(count < num_tiles,"rows < num_tiles");
     }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Bug observed during the other feature test. In some cases, consistently tiles (0,0) were returned although it is not available in `aie_control_config.json` .

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
After investigating the overall flow, it is observed that `getEventTiles()` seem to override the globally stored tiles while processing each graph names.
If my understanding of the intended function behavior is correct, it seem to calculate next available index for row & col incorrectly.

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Verified on edge platform.

#### Documentation impact (if any)
