### PR TITLE
Replacing xcl Apis : xclDeviceInfo2 and xclGetSysfsPath

### DIFF
--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -167,6 +167,11 @@ enum class key_type
   cage_temp_2,
   cage_temp_3,
 
+  dimm_temp_0,
+  dimm_temp_1,
+  dimm_temp_2,
+  dimm_temp_3,
+
   v12v_pex_millivolts,
   v12v_pex_milliamps,
 
@@ -2030,6 +2035,66 @@ struct cage_temp_3 : request
 {
   using result_type = uint64_t;
   static const key_type key = key_type::cage_temp_3;
+
+  virtual std::any
+  get(const device*) const = 0;
+
+  static std::string
+  to_string(result_type value)
+  {
+    return std::to_string(value);
+  }
+};
+
+struct dimm_temp_0 : request
+{
+  using result_type = uint64_t;
+  static const key_type key = key_type::dimm_temp_0;
+
+  virtual std::any
+  get(const device*) const = 0;
+
+  static std::string
+  to_string(result_type value)
+  {
+    return std::to_string(value);
+  }
+};
+
+struct dimm_temp_1 : request
+{
+  using result_type = uint64_t;
+  static const key_type key = key_type::dimm_temp_1;
+
+  virtual std::any
+  get(const device*) const = 0;
+
+  static std::string
+  to_string(result_type value)
+  {
+    return std::to_string(value);
+  }
+};
+
+struct dimm_temp_2 : request
+{
+  using result_type = uint64_t;
+  static const key_type key = key_type::dimm_temp_2;
+
+  virtual std::any
+  get(const device*) const = 0;
+
+  static std::string
+  to_string(result_type value)
+  {
+    return std::to_string(value);
+  }
+};
+
+struct dimm_temp_3 : request
+{
+  using result_type = uint64_t;
+  static const key_type key = key_type::dimm_temp_3;
 
   virtual std::any
   get(const device*) const = 0;

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -1341,6 +1341,10 @@ initialize_query_table()
   emplace_sysfs_get<query::cage_temp_1>                        ("xmc", "xmc_cage_temp1");
   emplace_sysfs_get<query::cage_temp_2>                        ("xmc", "xmc_cage_temp2");
   emplace_sysfs_get<query::cage_temp_3>                        ("xmc", "xmc_cage_temp3");
+  emplace_sysfs_get<query::dimm_temp_0>                        ("xmc", "xmc_dimm_temp0");
+  emplace_sysfs_get<query::dimm_temp_1>                        ("xmc", "xmc_dimm_temp1");
+  emplace_sysfs_get<query::dimm_temp_2>                        ("xmc", "xmc_dimm_temp2");
+  emplace_sysfs_get<query::dimm_temp_3>                        ("xmc", "xmc_dimm_temp3");
   emplace_sysfs_get<query::v12v_pex_millivolts>                ("xmc", "xmc_12v_pex_vol");
   emplace_sysfs_get<query::v12v_pex_milliamps>                 ("xmc", "xmc_12v_pex_curr");
   emplace_sysfs_get<query::v12v_aux_millivolts>                ("xmc", "xmc_12v_aux_vol");

--- a/src/runtime_src/xdp/profile/device/utility.cpp
+++ b/src/runtime_src/xdp/profile/device/utility.cpp
@@ -54,6 +54,24 @@ namespace xdp { namespace util {
     return path;
   }
 
+  std::string getDeviceName(void* deviceHandle)
+  {
+    std::string deviceName = "";
+    std::shared_ptr<xrt_core::device> coreDevice = xrt_core::get_userpf_device(deviceHandle);
+    if (!coreDevice) {
+      return deviceName;
+    }
+    try {
+      deviceName = xrt_core::device_query<xrt_core::query::rom_vbnv>(coreDevice);
+      std::cout<<"Debug: Device Name "<<deviceName<<std::endl;
+    } catch (const xrt_core::query::no_such_key&) {
+      //  xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", "Device query for Debug IP Layout not implemented");
+    } catch (const std::exception &) {
+      xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", "Failed to retrieve Device Name");
+    }
+    return deviceName;
+  }
+
 } // end namespace util
 } // end namespace xdp
 

--- a/src/runtime_src/xdp/profile/device/utility.cpp
+++ b/src/runtime_src/xdp/profile/device/utility.cpp
@@ -64,7 +64,7 @@ namespace xdp { namespace util {
     try {
       deviceName = xrt_core::device_query<xrt_core::query::rom_vbnv>(coreDevice);
     } catch (const xrt_core::query::no_such_key&) {
-      //  xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", "Device query for Debug IP Layout not implemented");
+      //  xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", "Device query for Device Name not implemented");
     } catch (const std::exception &) {
       xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", "Failed to retrieve Device Name");
     }

--- a/src/runtime_src/xdp/profile/device/utility.cpp
+++ b/src/runtime_src/xdp/profile/device/utility.cpp
@@ -63,7 +63,6 @@ namespace xdp { namespace util {
     }
     try {
       deviceName = xrt_core::device_query<xrt_core::query::rom_vbnv>(coreDevice);
-      std::cout<<"Debug: Device Name "<<deviceName<<std::endl;
     } catch (const xrt_core::query::no_such_key&) {
       //  xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", "Device query for Debug IP Layout not implemented");
     } catch (const std::exception &) {

--- a/src/runtime_src/xdp/profile/device/utility.h
+++ b/src/runtime_src/xdp/profile/device/utility.h
@@ -39,6 +39,9 @@ namespace xdp { namespace util {
   XDP_CORE_EXPORT
   std::string getDebugIpLayoutPath(void* deviceHandle);
 
+  XDP_CORE_EXPORT
+  std::string getDeviceName(void* deviceHandle);
+
 
   // At compile time, each monitor inserted in the PL region is given a set 
   // of trace IDs, regardless of if trace is enabled or not.  This ID is

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_plugin.cpp
@@ -128,9 +128,9 @@ namespace xdp {
       (db->getStaticInfo()).setDeviceName(deviceID, "win_device");
 #else
       (db->getStaticInfo()).updateDevice(deviceID, handle);
-      struct xclDeviceInfo2 info;
-      if (xclGetDeviceInfo2(handle, &info) == 0) {
-        (db->getStaticInfo()).setDeviceName(deviceID, std::string(info.mName));
+      std::string deviceName = util::getDeviceName(handle);
+      if (deviceName != "") {
+        (db->getStaticInfo()).setDeviceName(deviceID, deviceName);
       }
 #endif
     }
@@ -176,9 +176,7 @@ auto time = std::time(nullptr);
     std::string deviceName = "win_device";
 #else
     auto tm = *std::localtime(&time);
-    struct xclDeviceInfo2 info;
-    xclGetDeviceInfo2(handle, &info);
-    std::string deviceName = std::string(info.mName);
+    std::string deviceName = util::getDeviceName(handle);
 #endif
 
     std::ostringstream timeOss;

--- a/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.cpp
@@ -401,9 +401,9 @@ namespace xdp {
       // Update the static database with information from xclbin
       (db->getStaticInfo()).updateDevice(deviceID, handle);
       {
-        struct xclDeviceInfo2 info;
-        if(xclGetDeviceInfo2(handle, &info) == 0) {
-          (db->getStaticInfo()).setDeviceName(deviceID, std::string(info.mName));
+        std::string deviceName = util::getDeviceName(handle);
+        if(deviceName != "") {
+          (db->getStaticInfo()).setDeviceName(deviceID, deviceName);
         }
       }
     }
@@ -418,9 +418,7 @@ namespace xdp {
     getTilesForStatus();
 
     // Open the writer for this device
-    struct xclDeviceInfo2 info;
-    xclGetDeviceInfo2(handle, &info);
-    std::string devicename { info.mName };
+    std::string deviceName = util::getDeviceName(handle);
 
     std::string currentTime = "0000_00_00_0000";
     auto time = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());

--- a/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.cpp
@@ -418,7 +418,7 @@ namespace xdp {
     getTilesForStatus();
 
     // Open the writer for this device
-    std::string deviceName = util::getDeviceName(handle);
+    std::string devicename = util::getDeviceName(handle);
 
     std::string currentTime = "0000_00_00_0000";
     auto time = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -130,10 +130,9 @@ void AieTracePluginUnified::updateAIEDevice(void *handle) {
 #else
   // Update the static database with information from xclbin
   (db->getStaticInfo()).updateDevice(deviceID, handle);
-  struct xclDeviceInfo2 info;
-
-  if (xclGetDeviceInfo2(handle, &info) == 0)
-    (db->getStaticInfo()).setDeviceName(deviceID, std::string(info.mName));
+  std::string deviceName = util::getDeviceName(handle);
+  if (deviceName != "")
+    (db->getStaticInfo()).setDeviceName(deviceID, deviceName);
 
 #endif
 
@@ -313,9 +312,7 @@ void AieTracePluginUnified::updateAIEDevice(void *handle) {
 #ifdef _WIN32
     std::string deviceName = "win_device";
 #else
-    struct xclDeviceInfo2 info;
-    xclGetDeviceInfo2(handle, &info);
-    std::string deviceName = std::string(info.mName);
+    std::string deviceName = util::getDeviceName(handle);
 #endif
 
     // Writer for timestamp file

--- a/src/runtime_src/xdp/profile/plugin/device_offload/hal/hal_device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/hal/hal_device_offload_plugin.cpp
@@ -148,9 +148,9 @@ namespace xdp {
     //  will be needed later
     (db->getStaticInfo()).updateDevice(deviceId, userHandle) ;
     {
-      struct xclDeviceInfo2 info ;
-      if (xclGetDeviceInfo2(userHandle, &info) == 0)
-        (db->getStaticInfo()).setDeviceName(deviceId, std::string(info.mName));
+      std::string deviceName = util::getDeviceName(userHandle);
+      if (deviceName != "")
+        (db->getStaticInfo()).setDeviceName(deviceId, deviceName);
     }
 
     // For the HAL level, we must create a device interface using 

--- a/src/runtime_src/xdp/profile/plugin/device_offload/hal/hal_device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/hal/hal_device_offload_plugin.cpp
@@ -64,6 +64,7 @@ namespace xdp {
       } catch (const std::runtime_error& e) {
         std::string msg = "Could not open device at index " + std::to_string(index) + e.what();
         xrt_core::message::send(xrt_core::message::severity_level::error, "XRT", msg);
+        ++index;
         continue;
       }
     }

--- a/src/runtime_src/xdp/profile/plugin/device_offload/hw_emu/hw_emu_device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/hw_emu/hw_emu_device_offload_plugin.cpp
@@ -130,9 +130,9 @@ namespace xdp {
     //  will be needed later
     (db->getStaticInfo()).updateDevice(deviceId, userHandle) ;
     {
-      struct xclDeviceInfo2 info ;
-      if (xclGetDeviceInfo2(userHandle, &info) == 0) {
-        (db->getStaticInfo()).setDeviceName(deviceId, std::string(info.mName));
+      std::string deviceName = util::getDeviceName(userHandle);
+      if (deviceName != "") {
+        (db->getStaticInfo()).setDeviceName(deviceId, deviceName);
       }
     }
 

--- a/src/runtime_src/xdp/profile/plugin/hal_api_interface/xdp_api_interface.cpp
+++ b/src/runtime_src/xdp/profile/plugin/hal_api_interface/xdp_api_interface.cpp
@@ -115,17 +115,15 @@ namespace xdp {
     
     // readDebugIPlayout called from startProfiling : check other cases
 
-    xclDeviceInfo2 devInfo;
-    if (xclGetDeviceInfo2(deviceHandle, &devInfo) != 0)
+    std::string deviceName = util::getDeviceName(deviceHandle);
+    if (deviceName == "")
     {
       // If we cannot get device information, return an empty profile result
       return ;
     }
     
-    auto deviceNameSz = strlen(devInfo.mName);
-    results->deviceName = (char*)malloc(deviceNameSz+1);
-    memcpy(results->deviceName, devInfo.mName, deviceNameSz);
-    results->deviceName[deviceNameSz] = '\0';
+    results->deviceName = (char*)malloc(deviceName.length()+1);
+    strcpy(results->deviceName, deviceName.c_str());
     
     results->numAIM = currDevice->getNumMonitors(xdp::MonitorType::memory);
     results->numAM  = currDevice->getNumMonitors(xdp::MonitorType::accel);

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_plugin.cpp
@@ -106,9 +106,9 @@ namespace xdp {
       // Update the static database with information from xclbin
       (db->getStaticInfo()).updateDevice(deviceID, handle);
       {
-        struct xclDeviceInfo2 info;
-        if (xclGetDeviceInfo2(handle, &info) == 0)
-          (db->getStaticInfo()).setDeviceName(deviceID, std::string(info.mName));
+        std::string deviceName = util::getDeviceName(handle);
+        if (deviceName != "")
+          (db->getStaticInfo()).setDeviceName(deviceID, deviceName);
       }
     }
 #endif

--- a/src/runtime_src/xdp/profile/plugin/noc/noc_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/noc/noc_plugin.cpp
@@ -46,7 +46,7 @@ namespace xdp {
         auto xrtDevice = std::make_unique<xrt::device>(index);
         auto ownedHandle = xrtDevice->get_handle()->get_device_handle();
         // Determine the name of the device
-        std::string deviceName = util::getDeviceName(handle);
+        std::string deviceName = util::getDeviceName(ownedHandle);
         mDevices.push_back(deviceName);
   
         std::string outputFile = "noc_profile_" + deviceName + ".csv"; 

--- a/src/runtime_src/xdp/profile/plugin/noc/noc_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/noc/noc_plugin.cpp
@@ -27,6 +27,7 @@
 #include "xdp/profile/plugin/noc/noc_plugin.h"
 #include "xdp/profile/writer/noc/noc_writer.h"
 #include "xdp/profile/plugin/vp_base/info.h"
+#include "xdp/profile/device/utility.h"
 
 #include <boost/algorithm/string.hpp>
 
@@ -45,9 +46,7 @@ namespace xdp {
         auto xrtDevice = std::make_unique<xrt::device>(index);
         auto ownedHandle = xrtDevice->get_handle()->get_device_handle();
         // Determine the name of the device
-        struct xclDeviceInfo2 info;
-        xclGetDeviceInfo2(ownedHandle, &info);
-        std::string deviceName = std::string(info.mName);
+        std::string deviceName = util::getDeviceName(handle);
         mDevices.push_back(deviceName);
   
         std::string outputFile = "noc_profile_" + deviceName + ".csv"; 

--- a/src/runtime_src/xdp/profile/plugin/pl_deadlock/pl_deadlock_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/pl_deadlock/pl_deadlock_plugin.cpp
@@ -195,9 +195,9 @@ namespace xdp {
       // Update the static database with information from xclbin
       (db->getStaticInfo()).updateDevice(deviceId, handle);
       {
-        struct xclDeviceInfo2 info;
-        if(xclGetDeviceInfo2(handle, &info) == 0) {
-          (db->getStaticInfo()).setDeviceName(deviceId, std::string(info.mName));
+        std::string deviceName = util::getDeviceName(handle);
+        if(deviceName != "") {
+          (db->getStaticInfo()).setDeviceName(deviceId, deviceName);
         }
       }
     }

--- a/src/runtime_src/xdp/profile/plugin/power/power_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/power/power_plugin.cpp
@@ -30,6 +30,7 @@
 #include "xdp/profile/plugin/power/power_plugin.h"
 #include "xdp/profile/writer/power/power_writer.h"
 #include "xdp/profile/plugin/vp_base/info.h"
+#include "xdp/profile/device/utility.h"
 
 namespace xdp {
 
@@ -91,9 +92,7 @@ namespace xdp {
         filePaths.push_back(paths) ;
   
         // Determine the name of the device
-        struct xclDeviceInfo2 info ;
-        xclGetDeviceInfo2(ownedHandle, &info) ;
-        std::string deviceName = std::string(info.mName) ;
+        std::string deviceName = util::getDeviceName(handle);
   
         if (deviceNumbering.find(deviceName) == deviceNumbering.end()) {
           deviceNumbering[deviceName] = 0 ;

--- a/src/runtime_src/xdp/profile/plugin/power/power_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/power/power_plugin.cpp
@@ -78,6 +78,7 @@ namespace xdp {
       } catch (const std::runtime_error& e) {
         std::string msg = "Could not open device at index " + std::to_string(index) + e.what();
         xrt_core::message::send(xrt_core::message::severity_level::error, "XRT", msg);
+        ++index;
         continue;
       }  
     }
@@ -116,6 +117,7 @@ namespace xdp {
         std::shared_ptr<xrt_core::device> coreDevice = xrtDevice->get_handle();
         
         if (!coreDevice) {
+          ++index;
           continue;
         }
 

--- a/src/runtime_src/xdp/profile/plugin/power/power_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/power/power_plugin.cpp
@@ -25,6 +25,7 @@
 #include "core/common/system.h"
 #include "core/common/time.h"
 #include "core/include/experimental/xrt-next.h"
+#include "core/common/query_requests.h"
 #include "core/include/xrt/xrt_device.h"
 
 #include "xdp/profile/plugin/power/power_plugin.h"
@@ -33,34 +34,6 @@
 #include "xdp/profile/device/utility.h"
 
 namespace xdp {
-
-  const char* PowerProfilingPlugin::powerFiles[] = 
-    {
-      "xmc_12v_aux_curr",
-      "xmc_12v_aux_vol",
-      "xmc_12v_pex_curr",
-      "xmc_12v_pex_vol",
-      "xmc_vccint_curr",
-      "xmc_vccint_vol",
-      "xmc_3v3_pex_curr",
-      "xmc_3v3_pex_vol",
-      "xmc_cage_temp0",
-      "xmc_cage_temp1",
-      "xmc_cage_temp2",
-      "xmc_cage_temp3",
-      "xmc_dimm_temp0",
-      "xmc_dimm_temp1",
-      "xmc_dimm_temp2",
-      "xmc_dimm_temp3",
-      "xmc_fan_temp",
-      "xmc_fpga_temp",
-      "xmc_hbm_temp",
-      "xmc_se98_temp0",
-      "xmc_se98_temp1",
-      "xmc_se98_temp2",
-      "xmc_vccint_temp",
-      "xmc_fan_rpm"      
-    } ;
 
   PowerProfilingPlugin::PowerProfilingPlugin() :
     XDPPlugin(), keepPolling(true), pollingInterval(20)
@@ -80,16 +53,6 @@ namespace xdp {
      try {
        auto xrtDevice = std::make_unique<xrt::device>(index);
        auto ownedHandle = xrtDevice->get_handle()->get_device_handle();
-       
-        // For each device, keep track of the paths to the sysfs files
-        std::vector<std::string> paths ;
-        for (auto f : powerFiles)
-        {
-          char sysfsPath[512] ;
-          xclGetSysfsPath(ownedHandle, "xmc", f, sysfsPath, 512) ;
-          paths.push_back(sysfsPath) ;
-        }
-        filePaths.push_back(paths) ;
   
         // Determine the name of the device
         std::string deviceName = util::getDeviceName(handle);
@@ -137,6 +100,11 @@ namespace xdp {
 
       db->unregisterPlugin(this) ;
     }
+
+    for (auto h : deviceHandles)
+    {
+      xclClose(h) ;
+    }
   }
 
   void PowerProfilingPlugin::pollPower()
@@ -146,31 +114,77 @@ namespace xdp {
       // Get timestamp in milliseconds
       double timestamp = xrt_core::time_ns() / 1.0e6 ;
       uint64_t index = 0 ;
-      for (const auto& device : filePaths)
+
+      for(auto& handle : deviceHandles)
       {
         std::vector<uint64_t> values ;
-        for (const auto& file : device)
-        {
-          std::ifstream fs(file) ;
-          if (!fs)
-          {
-            // When we tried to get the path to this file, we got a bad
-            //  result (like empty string).  So all devices are aligned and
-            //  have the same amount of information we'll just record this
-            //  data element as 0.
-            values.push_back(0) ;
-            continue ;
-          }
-          std::string data ;
-          std::getline(fs, data) ;
-          uint64_t dp = data.empty() ? 0 : std::stoul(data) ;
-          values.push_back(dp) ;
-          fs.close() ;
+        std::shared_ptr<xrt_core::device> coreDevice = xrt_core::get_userpf_device(handle);
+        if (!coreDevice) {
+          continue;
+        }
+
+        try{
+          uint64_t data = 0;
+          data = xrt_core::device_query<xrt_core::query::v12v_aux_milliamps>(coreDevice);
+          values.push_back(data);
+          data = xrt_core::device_query<xrt_core::query::v12v_aux_millivolts>(coreDevice);
+          values.push_back(data);
+          data = xrt_core::device_query<xrt_core::query::v12v_pex_milliamps>(coreDevice);
+          values.push_back(data);
+          data = xrt_core::device_query<xrt_core::query::v12v_pex_millivolts>(coreDevice);
+          values.push_back(data);
+          data = xrt_core::device_query<xrt_core::query::int_vcc_milliamps>(coreDevice);
+          values.push_back(data);
+          data = xrt_core::device_query<xrt_core::query::int_vcc_millivolts>(coreDevice);
+          values.push_back(data);
+          data = xrt_core::device_query<xrt_core::query::v3v3_pex_milliamps>(coreDevice);
+          values.push_back(data);
+          data = xrt_core::device_query<xrt_core::query::v3v3_pex_millivolts>(coreDevice);
+          values.push_back(data);
+          data = xrt_core::device_query<xrt_core::query::cage_temp_0>(coreDevice);
+          values.push_back(data);
+          data = xrt_core::device_query<xrt_core::query::cage_temp_1>(coreDevice);
+          values.push_back(data);
+          data = xrt_core::device_query<xrt_core::query::cage_temp_3>(coreDevice);
+          values.push_back(data);
+          data = xrt_core::device_query<xrt_core::query::cage_temp_3>(coreDevice);
+          values.push_back(data);
+          data = xrt_core::device_query<xrt_core::query::dimm_temp_0>(coreDevice);
+          values.push_back(data);
+          data = xrt_core::device_query<xrt_core::query::dimm_temp_1>(coreDevice);
+          values.push_back(data);
+          data = xrt_core::device_query<xrt_core::query::dimm_temp_2>(coreDevice);
+          values.push_back(data);
+          data = xrt_core::device_query<xrt_core::query::dimm_temp_3>(coreDevice);
+          values.push_back(data);
+          data = xrt_core::device_query<xrt_core::query::fan_trigger_critical_temp>(coreDevice);
+          values.push_back(data);
+          data = xrt_core::device_query<xrt_core::query::temp_fpga>(coreDevice);
+          values.push_back(data);
+          data = xrt_core::device_query<xrt_core::query::hbm_temp>(coreDevice);
+          values.push_back(data);
+          data = xrt_core::device_query<xrt_core::query::temp_card_top_front>(coreDevice);
+          values.push_back(data);
+          data = xrt_core::device_query<xrt_core::query::temp_card_top_rear>(coreDevice);
+          values.push_back(data);
+          data = xrt_core::device_query<xrt_core::query::temp_card_bottom_front>(coreDevice);
+          values.push_back(data);
+          data = xrt_core::device_query<xrt_core::query::int_vcc_temp>(coreDevice);
+          values.push_back(data);
+          data = xrt_core::device_query<xrt_core::query::fan_speed_rpm>(coreDevice); 
+          values.push_back(data);
+        }
+        catch (const xrt_core::query::no_such_key&) {
+          //query is not implemented
+        }
+        catch (const std::exception&) {
+          // error retrieving information
+          std::string msg = "Error while retrieving data from power files. Using default value.";
+          xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", msg);
         }
         (db->getDynamicInfo()).addPowerSample(index, timestamp, values) ;
-        ++index ;	
+        ++index ;
       }
-
       std::this_thread::sleep_for(std::chrono::milliseconds(pollingInterval)) ;
     }
   }

--- a/src/runtime_src/xdp/profile/plugin/power/power_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/power/power_plugin.cpp
@@ -145,7 +145,7 @@ namespace xdp {
           values.push_back(data);
           data = xrt_core::device_query<xrt_core::query::cage_temp_1>(coreDevice);
           values.push_back(data);
-          data = xrt_core::device_query<xrt_core::query::cage_temp_3>(coreDevice);
+          data = xrt_core::device_query<xrt_core::query::cage_temp_2>(coreDevice);
           values.push_back(data);
           data = xrt_core::device_query<xrt_core::query::cage_temp_3>(coreDevice);
           values.push_back(data);

--- a/src/runtime_src/xdp/profile/plugin/power/power_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/power/power_plugin.h
@@ -33,7 +33,7 @@ namespace xdp {
     static const char* powerFiles[] ;
 
   private:
-    std::vector<std::vector<std::string>> filePaths ;
+    std::vector<void*> deviceHandles ;
 
     // Power profiling requires its own thread
     bool keepPolling ;

--- a/src/runtime_src/xdp/profile/plugin/power/power_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/power/power_plugin.h
@@ -33,7 +33,7 @@ namespace xdp {
     static const char* powerFiles[] ;
 
   private:
-    std::vector<void*> deviceHandles ;
+    std::vector<std::unique_ptr<xrt::device>> xrtDevices;
 
     // Power profiling requires its own thread
     bool keepPolling ;


### PR DESCRIPTION
#### Problem solved by the commit
Replaced two xcl apis from Xdp code : xclDeviceInfo2 and xclGetSysfsPath

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Four device queries needed by Xdp code were missing in Xrt code, hence added them in Xrt code as per Rahul Bramandlapalli's suggestion (dimm_temp_0, dimm_temp_1, dimm_temp_2, dimm_temp_3)

#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
Ran unit testcase with all the flags added in xrt.ini flag in whichever plugin the changes were made for both edge and pcie.
