### PR TITLE
VITIS-8728 Update skd files to remove xcl apis

### DIFF
--- a/src/runtime_src/core/edge/skd/sk_daemon.cpp
+++ b/src/runtime_src/core/edge/skd/sk_daemon.cpp
@@ -28,11 +28,6 @@
 
 using severity_level = xrt_core::message::severity_level;
 
-xclDeviceHandle initXRTHandle(unsigned deviceIndex)
-{
-  return xclOpen(deviceIndex, nullptr, XCL_QUIET);
-}
-
 static std::unique_ptr<xrt::skd> skd_inst;
 
 /* Define a signal handler for the child to handle signals */
@@ -75,7 +70,7 @@ static void sigLog(const int sig)
 }
 
 #define PNAME_LEN	(16)
-void configSoftKernel(const xclDeviceHandle handle, xclSKCmd *cmd, const int parent_mem_bo, const uint64_t mem_start_paddr, const uint64_t mem_size)
+void configSoftKernel(const xrtDeviceHandle handle, xclSKCmd* cmd, const int parent_mem_bo, const uint64_t mem_start_paddr, const uint64_t mem_size)
 {
   for (int i = cmd->start_cuidx; i < (cmd->start_cuidx + cmd->cu_nums); i++) {
     /*

--- a/src/runtime_src/core/edge/skd/sk_daemon.h
+++ b/src/runtime_src/core/edge/skd/sk_daemon.h
@@ -35,7 +35,6 @@
 #include "xclhal2_mpsoc.h"
 #include "xrt_skd.h"
 
-xclDeviceHandle initXRTHandle(unsigned deviceIndex);
-void configSoftKernel(const xclDeviceHandle handle, xclSKCmd *cmd, const int parent_mem_bo, const uint64_t mem_start_paddr, const uint64_t mem_size);
+void configSoftKernel(const xrtDeviceHandle handle, xclSKCmd* cmd, const int parent_mem_bo, const uint64_t mem_start_paddr, const uint64_t mem_size);
 
 #endif

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -1902,7 +1902,14 @@ import_bo(xclDeviceHandle handle, xrt_core::shared_handle::export_handle ehdl)
   return shim->xclImportBO(ehdl, 0);
 }
 
-
+// Function for converting raw buffer handle returned by some of the
+// shim functions into xrt_core::buffer_handle
+std::unique_ptr<xrt_core::buffer_handle>
+get_buffer_handle(xclDeviceHandle handle, unsigned int bhdl)
+{
+  auto shim = get_shim_object(handle);
+  return std::make_unique<ZYNQ::shim::buffer_object>(shim, bhdl);
+}
 } // xrt::shim_int
 ////////////////////////////////////////////////////////////////
 

--- a/src/runtime_src/core/include/shim_int.h
+++ b/src/runtime_src/core/include/shim_int.h
@@ -94,6 +94,12 @@ wait_command(xclDeviceHandle handle, xrt_core::hwqueue_handle* qhdl, xrt_core::b
 // exec_buf() - Exec Buf with hw ctx handle.
 void
 exec_buf(xclDeviceHandle handle, xrt_core::buffer_handle* bohdl, xrt_core::hwctx_handle* ctxhdl);
+
+// get_buffer_handle - get xrt_core::buffer handle from
+// raw handle returned by shim, this function is implemented
+// only in edge shim
+std::unique_ptr<xrt_core::buffer_handle>
+get_buffer_handle(xclDeviceHandle handle, unsigned int bhdl);
 }} // shim_int, xrt
 
 #endif


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Removed xcl apis from skd flow

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
#### How problem was solved, alternative solutions (if any) and why they were rejected

Conversion of xclBufferHandle to xrtBufferHandle is deprecated
So added internal shim function which converts buffer fd to buffer_handle
This way use of xcl buffer shim apis can be eliminated.

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
Tested pcie and edge  builds by hiding symbols exported by xrt.h header file. Needs additional testing with ps kernels test cases

#### Documentation impact (if any)
NA