### PR TITLE
VITIS-11369 Improve get xclbin name method

### DIFF
--- a/src/runtime_src/core/common/api/xrt_xclbin.cpp
+++ b/src/runtime_src/core/common/api/xrt_xclbin.cpp
@@ -1,20 +1,6 @@
-/*
- * Copyright (C) 2020-2022 Xilinx, Inc. All rights reserved.
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
- * Xilinx Runtime (XRT) Experimental APIs
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2020-2022 Xilinx, Inc. All rights reserved.
+// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
 
 // This file implements XRT xclbin APIs as declared in
 // core/include/experimental/xrt_xclbin.h
@@ -99,7 +85,7 @@ read_xclbin(const std::string& fnm)
   if (fnm.empty())
     throw std::runtime_error("No xclbin specified");
 
-  auto path = xrt_core::environment::xclbin_path(fnm);
+  auto path = xrt_core::environment::platform_path(fnm);
   return read_file(path.string());
 }
 
@@ -997,7 +983,7 @@ class xclbin_repository_impl
 
 public:
   xclbin_repository_impl()
-    : m_paths(xrt_core::environment::xclbin_repo_paths())
+    : m_paths(xrt_core::environment::platform_repo_paths())
     , m_xclbin_paths(get_xclbin_paths(m_paths))
   {}
   

--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -1,18 +1,6 @@
-/**
- * Copyright (C) 2016-2022 Xilinx, Inc
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2016-2022 Xilinx, Inc. All rights reserved.
+// Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
 
 #ifndef xrtcore_config_reader_h_
 #define xrtcore_config_reader_h_
@@ -412,9 +400,9 @@ get_xclbin_programming()
 }
 
 inline std::string
-get_xclbin_repo()
+get_platform_repo()
 {
-  static std::string value = detail::get_string_value("Runtime.xclbin_repo_path","");
+  static std::string value = detail::get_string_value("Runtime.platform_repo_path","");
   return value;
 }
 

--- a/src/runtime_src/core/common/detail/linux/xilinx_xrt.h
+++ b/src/runtime_src/core/common/detail/linux/xilinx_xrt.h
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+
 #include <filesystem>
 #include <stdexcept>
 #include <string>
@@ -19,9 +20,8 @@ xilinx_xrt()
 }
 
 std::vector<sfs::path>
-xclbin_repo_path()
+platform_repo_path()
 {
-  // current directory
   return {sfs::path("/lib/firmware/amdnpu"), sfs::path("/opt/xilinx/xrt/amdxdna")};
 }
 

--- a/src/runtime_src/core/common/detail/linux/xilinx_xrt.h
+++ b/src/runtime_src/core/common/detail/linux/xilinx_xrt.h
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
 #include <filesystem>
 #include <stdexcept>
 #include <string>
+#include <vector>
 namespace xrt_core::detail {
 
 namespace sfs = std::filesystem;
@@ -17,11 +18,11 @@ xilinx_xrt()
 #endif
 }
 
-sfs::path
+std::vector<sfs::path>
 xclbin_repo_path()
 {
   // current directory
-  return sfs::current_path();
+  return {sfs::path("/lib/firmware/amdnpu"), sfs::path("/opt/xilinx/xrt/amdxdna")};
 }
 
 } // xrt_core::detail

--- a/src/runtime_src/core/common/detail/windows/xilinx_xrt.h
+++ b/src/runtime_src/core/common/detail/windows/xilinx_xrt.h
@@ -251,9 +251,9 @@ xilinx_xrt()
 }
 
 std::vector<sfs::path>
-xclbin_repo_path()
+platform_repo_path()
 {
-  // For time being, xclbin repo is same as xilinx_xrt
+  // For time being, platform repo is same as xilinx_xrt
   return {xilinx_xrt()};
 }
 

--- a/src/runtime_src/core/common/detail/windows/xilinx_xrt.h
+++ b/src/runtime_src/core/common/detail/windows/xilinx_xrt.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
 
 #include "core/common/debug.h"
 #include "core/common/dlfcn.h"
@@ -16,6 +16,7 @@
 #include <string>
 #include <cstring>
 #include <cstdlib>
+#include <vector>
 
 #if defined(XRT_WINDOWS_HAS_WDK)
 namespace xrt_core::detail::windows {
@@ -249,12 +250,11 @@ xilinx_xrt()
 #endif
 }
 
-sfs::path
+std::vector<sfs::path>
 xclbin_repo_path()
 {
   // For time being, xclbin repo is same as xilinx_xrt
-  static auto repo = xilinx_xrt();
-  return repo;
+  return {xilinx_xrt()};
 }
 
 } // xrt_core::detail

--- a/src/runtime_src/core/common/module_loader.cpp
+++ b/src/runtime_src/core/common/module_loader.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2016-2020 Xilinx, Inc
 // Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+
 #define XRT_CORE_COMMON_SOURCE
 #include "core/common/module_loader.h"
 
@@ -101,15 +102,15 @@ xilinx_xrt()
   return xrt;
 }
 
-// Get list of xclbin repository paths from ini file and append
+// Get list of platform repository paths from ini file and append
 // default repository paths
 std::vector<sfs::path>
-get_xclbin_repo_paths()
+get_platform_repo_paths()
 {
   std::vector<sfs::path> paths;
   
-  // Get repo path from ini file if anya
-  auto repo = xrt_core::config::get_xclbin_repo();
+  // Get repo path from ini file if any
+  auto repo = xrt_core::config::get_platform_repo();
   auto token = std::strtok(repo.data(), ":;");
   while (token) {
     paths.push_back(token);
@@ -117,50 +118,47 @@ get_xclbin_repo_paths()
   }
 
   // Append default path(s)
-  const auto default_paths = xrt_core::detail::xclbin_repo_path();
+  const auto default_paths = xrt_core::detail::platform_repo_path();
   paths.insert(paths.end(), default_paths.begin(), default_paths.end());
   return paths;
 }
 
 static const std::vector<sfs::path>&
-xclbin_repo_paths()
+platform_repo_paths()
 {
   // Cache repo paths
-  static std::vector<sfs::path> paths{get_xclbin_repo_paths()};
+  static std::vector<sfs::path> paths{get_platform_repo_paths()};
   return paths;
 }
 
-// Return the full path to the xclbin file if it exists in an xclbin
+// Return the full path to the file if it exists in a platform
 // repository, else throw.
 static sfs::path
-xclbin_repo_path(const std::string& xclbin)
+platform_repo_path(const std::string& file)
 {
-  for (const auto& path : xclbin_repo_paths()) {
-    auto xpath = path / xclbin;
+  for (const auto& path : platform_repo_paths()) {
+    auto xpath = path / file;
     if (sfs::exists(xpath) && sfs::is_regular_file(xpath))
       return xpath;
   }
 
-  throw std::runtime_error("No such xclbin '" + xclbin + "'");
+  throw std::runtime_error("No such file '" + file + "'");
 }
 
-// Return the full path to an xclbin file if it exists, else throw.
-// If the specified path is an absolute path then the function
-// returns this path or throws if file does not exist.  If the path
-// is relative, or just a plain file name, then the function checks
-// first in current directory, then in the platform specific xclbin
-// repository.
+/**
+ * Refer to \ref platform_path(path) in module_loader.h
+ */
 static sfs::path
-xclbin_path(const std::string& xclbin)
+platform_path(const std::string& file_name)
 {
-  sfs::path xpath{xclbin};
+  sfs::path xpath{file_name};
   if (sfs::exists(xpath) && sfs::is_regular_file(xpath))
     return xpath;
 
   if (!xpath.is_absolute())
-    return xclbin_repo_path(xclbin);
+    return platform_repo_path(file_name);
 
-  throw std::runtime_error("No such xclbin '" + xpath.string() + "'");
+  throw std::runtime_error("No such file '" + xpath.string() + "'");
 }
 
 static sfs::path
@@ -283,15 +281,15 @@ xilinx_xrt()
 }
 
 sfs::path
-xclbin_path(const std::string& xclbin_name)
+platform_path(const std::string& file_name)
 {
-  return ::xclbin_path(xclbin_name);
+  return ::platform_path(file_name);
 }
 
 const std::vector<sfs::path>&
-xclbin_repo_paths()
+platform_repo_paths()
 {
-  return ::xclbin_repo_paths();
+  return ::platform_repo_paths();
 }
 
 } // environment

--- a/src/runtime_src/core/common/module_loader.cpp
+++ b/src/runtime_src/core/common/module_loader.cpp
@@ -1,18 +1,6 @@
-/**
- * Copyright (C) 2016-2020 Xilinx, Inc
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2016-2020 Xilinx, Inc
+// Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
 #define XRT_CORE_COMMON_SOURCE
 #include "core/common/module_loader.h"
 
@@ -129,7 +117,8 @@ get_xclbin_repo_paths()
   }
 
   // Append default path(s)
-  paths.emplace_back(xrt_core::detail::xclbin_repo_path());
+  const auto default_paths = xrt_core::detail::xclbin_repo_path();
+  paths.insert(paths.end(), default_paths.begin(), default_paths.end());
   return paths;
 }
 

--- a/src/runtime_src/core/common/module_loader.h
+++ b/src/runtime_src/core/common/module_loader.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2016-2022 Xilinx, Inc. All rights reserved.
-// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
 
 #ifndef xrtcore_util_module_loader_h_
 #define xrtcore_util_module_loader_h_
@@ -95,31 +95,31 @@ const std::filesystem::path&
 xilinx_xrt();
 
 /**
- * xclbin_path() - Get path to xclbin directory
+ * platform_path(path) - Get path to a platform file
  *
- * @xclbin_name : A path relative or absolute to an xclbin file
- * Return: Full path the xclbin file
+ * @file_name : A path relative or absolute to a platform file
+ * Return: Full path to the platform file
  *
  * If the specified path is an absolute path then the function
- * returns this path or throws if file does not exist.  If the path
+ * returns this path or throws if file does not exist. If the path
  * is relative, or just a plain file name, then the function checks
- * first in current directory, then in the platform specific xclbin
+ * first in current directory, then in the platform specific
  * repository.
  *
  * The function throws if the file does not exist.
  */
 XRT_CORE_COMMON_EXPORT
 std::filesystem::path
-xclbin_path(const std::string& xclbin_name);
+platform_path(const std::string& file_name);
 
 /**
- * xclbin_repo_path() - Get path to xclbin repository
+ * platform_repo_paths() - Get paths to the platform repositories
  *
- * Return: Full path to xclbin repository
+ * Return: All full paths to available platform repositories
  */
 XRT_CORE_COMMON_EXPORT
 const std::vector<std::filesystem::path>&
-xclbin_repo_paths();
+platform_repo_paths();
 } // environment
 
 } // end namespace xrt_core

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -56,6 +56,7 @@ enum class key_type
   edge_vendor,
   device_class,
   xclbin_name,
+  sequence_name,
 
   dma_threads_raw,
 
@@ -515,6 +516,12 @@ struct edge_vendor : request
   }
 };
 
+/**
+ * Used to retrieve the path to an xclbin file required for the
+ * current device assuming a valid xclbin "type" is passed. The shim
+ * decides the appropriate path and name to return, absolving XRT of
+ * needing to know where to look.
+ */
 struct xclbin_name : request
 {
   enum class type {
@@ -534,6 +541,42 @@ struct xclbin_name : request
   using result_type = std::string;
   static const key_type key = key_type::xclbin_name;
   static const char* name() { return "xclbin_name"; }
+
+  virtual std::any
+  get(const device*, const std::any& req_type) const = 0;
+};
+
+/**
+ * Used to retrieve the path to the dpu sequence file required for the
+ * current device assuming a valid sequence "type" is passed. The shim
+ * decides the appropriate path and name to return, absolving XRT of
+ * needing to know where to look.
+ */
+struct sequence_name : request
+{
+  enum class type {
+    df_bandwidth,
+    tct_one_column,
+    tct_all_column,
+  };
+
+  static std::string
+  enum_to_str(const type& type)
+  {
+    switch (type) {
+      case type::df_bandwidth:
+        return "df_bandwidth";
+      case type::tct_one_column:
+        return "tct_one_column";
+      case type::tct_all_column:
+        return "tct_all_column";
+    }
+    return "unknown";
+  }
+
+  using result_type = std::string;
+  static const key_type key = key_type::sequence_name;
+  static const char* name() { return "sequence_name"; }
 
   virtual std::any
   get(const device*, const std::any& req_type) const = 0;

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -55,6 +55,7 @@ enum class key_type
   instance,
   edge_vendor,
   device_class,
+  xclbin_name,
 
   dma_threads_raw,
 
@@ -496,13 +497,6 @@ struct pcie_id : request
     // The cast is required. This is a boost bug. https://github.com/boostorg/format/issues/60
     return boost::str(boost::format("%02x") % static_cast<uint16_t>(value.revision_id));
   }
-
-  static std::string
-  to_path(const result_type& value)
-  {
-    // The cast is required. This is a boost bug. https://github.com/boostorg/format/issues/60
-    return boost::str(boost::format("%04x_%02x") % value.device_id % static_cast<uint16_t>(value.revision_id));
-  }
 };
 
 struct edge_vendor : request
@@ -519,6 +513,30 @@ struct edge_vendor : request
   {
     return boost::str(boost::format("0x%x") % val);
   }
+};
+
+struct xclbin_name : request
+{
+  enum class type {
+    validate
+  };
+
+  static std::string
+  enum_to_str(const type& type)
+  {
+    switch (type) {
+      case type::validate:
+        return "validate";
+    }
+    return "unknown";
+  }
+
+  using result_type = std::string;
+  static const key_type key = key_type::xclbin_name;
+  static const char* name() { return "xclbin_name"; }
+
+  virtual std::any
+  get(const device*, const std::any& req_type) const = 0;
 };
 
 struct device_class : request

--- a/src/runtime_src/core/tools/common/TestRunner.cpp
+++ b/src/runtime_src/core/tools/common/TestRunner.cpp
@@ -370,6 +370,13 @@ TestRunner::search_and_program_xclbin(const std::shared_ptr<xrt_core::device>& d
   return true;
 }
 
+/**
+ * @deprecated
+ * This function should be used ONLY for any legacy devices. IE versal/alveo only.
+ * Ideally this will be removed soon.
+ * 
+ * Children of TestRunner should call into something like getXclbinPath or getDPUPath.
+ */
 std::string
 TestRunner::findPlatformPath(const std::shared_ptr<xrt_core::device>& dev,
                              boost::property_tree::ptree& ptTest)

--- a/src/runtime_src/core/tools/common/TestRunner.cpp
+++ b/src/runtime_src/core/tools/common/TestRunner.cpp
@@ -84,18 +84,6 @@ TestRunner::TestRunner (const std::string & test_name,
   //Empty
 }
 
-TestRunner::TestRunner(const std::string& test_name,
-                       const std::string& description,
-                       const xrt_core::query::xclbin_name::type type,
-                       bool is_explicit)
-    : m_xclbin_type(type)
-    , m_name(test_name)
-    , m_description(description) 
-    , m_explicit(is_explicit)
-{
-  //Empty
-}
-
 boost::property_tree::ptree
 TestRunner::startTest(std::shared_ptr<xrt_core::device> dev)
 {
@@ -239,6 +227,30 @@ TestRunner::searchLegacyXclbin(const uint16_t vendor, const std::string& dev_nam
   return "";
 }
 
+/**
+ * @deprecated
+ * This function should be used ONLY for any legacy devices. IE versal/alveo only.
+ * Ideally this will be removed soon.
+ * 
+ * Children of TestRunner should call into findPlatformFile
+ */
+std::string
+TestRunner::findXclbinPath(const std::shared_ptr<xrt_core::device>& dev,
+                           boost::property_tree::ptree& ptTest)
+{
+  const std::string xclbin_name = ptTest.get<std::string>("xclbin", "");
+  const auto config_dir = ptTest.get<std::string>("xclbin_directory", "");
+  const std::filesystem::path platform_path = !config_dir.empty() ? config_dir : findPlatformPath(dev, ptTest);
+
+  const auto xclbin_path = platform_path / xclbin_name;
+  if (std::filesystem::exists(xclbin_path))
+    return xclbin_path.string();
+
+  logger(ptTest, "Details", boost::str(boost::format("%s not available. Skipping validation.") % xclbin_name));
+  ptTest.put("status", test_token_skipped);
+  return "";
+}
+
 /*
  * helper funtion for kernel and bandwidth python test cases when there is no platform.json
  * Steps:
@@ -252,22 +264,19 @@ TestRunner::runPyTestCase( const std::shared_ptr<xrt_core::device>& _dev, const 
              boost::property_tree::ptree& _ptTest)
 {
   const auto xclbin = _ptTest.get<std::string>("xclbin", "");
-  const auto xclbinPath = findXclbinPath(_dev, _ptTest);
+  const auto xclbin_path = std::filesystem::path(findXclbinPath(_dev, _ptTest));
 
   // 0RP (nonDFX) flat shell support.
   // Currently, there isn't a clean way to determine if a nonDFX shell's interface is truly flat.
   // At this time, this is determined by whether or not it delivers an accelerator (e.g., verify.xclbin)
   const auto logic_uuid = xrt_core::device_query_default<xrt_core::query::logic_uuids>(_dev, {});
-  if (!logic_uuid.empty() && !std::filesystem::exists(xclbinPath)) {
+  if (!logic_uuid.empty() && !std::filesystem::exists(xclbin_path)) {
     logger(_ptTest, "Details", "Verify xclbin not available or shell partition is not programmed. Skipping validation.");
     _ptTest.put("status", test_token_skipped);
     return;
   }
 
-  // log xclbin test dir for debugging purposes
-  std::filesystem::path xclbin_path(xclbinPath);
-  auto xclbin_parent_path = xclbin_path.parent_path().string();
-  logger(_ptTest, "Xclbin", xclbin_parent_path);
+  logger(_ptTest, "Xclbin", xclbin_path.parent_path().string());
 
   std::string platform_path = findPlatformPath(_dev, _ptTest);
 
@@ -298,7 +307,7 @@ TestRunner::runPyTestCase( const std::shared_ptr<xrt_core::device>& _dev, const 
   // log testcase path for debugging purposes
   logger(_ptTest, "Testcase", xrtTestCasePath);
 
-  std::vector<std::string> args = { "-k", xclbinPath,
+  std::vector<std::string> args = { "-k", xclbin_path.string(),
                                     "-d", xrt_core::query::pcie_bdf::to_string(xrt_core::device_query<xrt_core::query::pcie_bdf>(_dev)) };
   int exit_code;
   try {
@@ -356,10 +365,10 @@ TestRunner::search_and_program_xclbin(const std::shared_ptr<xrt_core::device>& d
   xuid_t uuid;
   uuid_parse(xrt_core::device_query<xrt_core::query::xclbin_uuid>(dev).c_str(), uuid);
 
-  std::string xclbinPath = findXclbinPath(dev, ptTest);
+  const std::string xclbin_path = findXclbinPath(dev, ptTest);
 
   try {
-    program_xclbin(dev, xclbinPath);
+    program_xclbin(dev, xclbin_path);
   }
   catch (const std::exception& e) {
     logger(ptTest, "Error", e.what());
@@ -375,89 +384,34 @@ TestRunner::search_and_program_xclbin(const std::shared_ptr<xrt_core::device>& d
  * This function should be used ONLY for any legacy devices. IE versal/alveo only.
  * Ideally this will be removed soon.
  * 
- * Children of TestRunner should call into something like getXclbinPath or getDPUPath.
+ * Children of TestRunner should call into findPlatformFile
  */
 std::string
 TestRunner::findPlatformPath(const std::shared_ptr<xrt_core::device>& dev,
                              boost::property_tree::ptree& ptTest)
 {
-  for (const auto& path : findPlatformPaths(dev, ptTest)) {
-    if (std::filesystem::exists(path))
-      return path.string();
+  const auto logic_uuid = xrt_core::device_query_default<xrt_core::query::logic_uuids>(dev, {});
+  if (!logic_uuid.empty())
+    return searchSSV2Xclbin(logic_uuid.front(), ptTest);
+  else {
+    auto vendor = xrt_core::device_query<xrt_core::query::pcie_vendor>(dev);
+    auto name = xrt_core::device_query<xrt_core::query::rom_vbnv>(dev);
+    return searchLegacyXclbin(vendor, name, ptTest);
   }
-
-  logger(ptTest, "Details", boost::str(boost::format("No platform path available. Skipping validation.")));
-  ptTest.put("status", test_token_skipped);
-  return "";
-}
-
-std::vector<std::filesystem::path>
-TestRunner::findPlatformPaths(const std::shared_ptr<xrt_core::device>& dev,
-                              boost::property_tree::ptree& ptTest)
-{
-  // Check if we need to use the legacy method of getting the platform path
-  if (xrt_core::device_query<xrt_core::query::device_class>(dev) == xrt_core::query::device_class::type::alveo) {
-    const auto logic_uuid = xrt_core::device_query_default<xrt_core::query::logic_uuids>(dev, {});
-    if (!logic_uuid.empty())
-      return {std::filesystem::path(searchSSV2Xclbin(logic_uuid.front(), ptTest))};
-    else {
-      auto vendor = xrt_core::device_query<xrt_core::query::pcie_vendor>(dev);
-      auto name = xrt_core::device_query<xrt_core::query::rom_vbnv>(dev);
-      return {std::filesystem::path(searchLegacyXclbin(vendor, name, ptTest))};
-    }
-  }
-
-  return xrt_core::environment::xclbin_repo_paths();
 }
 
 std::string
-TestRunner::getXclbinName(const std::shared_ptr<xrt_core::device>& dev,
-                           boost::property_tree::ptree& ptTest)
+TestRunner::findPlatformFile(const std::string& file_path,
+                             boost::property_tree::ptree& ptTest)
 {
-  // Legacy devices store the xclbin name within the test ptree
-  if (xrt_core::device_query<xrt_core::query::device_class>(dev) == xrt_core::query::device_class::type::alveo)
-    return ptTest.get<std::string>("xclbin", "");
-
-  return xrt_core::device_query<xrt_core::query::xclbin_name>(dev, m_xclbin_type);
-}
-
-std::string
-TestRunner::findXclbinPath(const std::shared_ptr<xrt_core::device>& dev,
-                           boost::property_tree::ptree& ptTest)
-{
-  const std::string xclbin_name = getXclbinName(dev, ptTest);
-  auto platform_paths = findPlatformPaths(dev, ptTest);
-  const auto xclbin_dir = std::filesystem::path(ptTest.get<std::string>("xclbin_directory", ""));
-  if (!xclbin_dir.empty())
-    platform_paths.push_back(xclbin_dir);
-
-  for (const auto& path : platform_paths) {
-    const auto xclbin_path = path / xclbin_name;
-    if (std::filesystem::exists(xclbin_path))
-      return xclbin_path.string();
+  try {
+    return xrt_core::environment::platform_path(file_path).string();
   }
-
-  logger(ptTest, "Details", boost::str(boost::format("%s not available. Skipping validation.") % xclbin_name));
-  ptTest.put("status", test_token_skipped);
-  return "";
-}
-
-std::string
-TestRunner::findDPUPath(const std::shared_ptr<xrt_core::device>& dev,
-                        boost::property_tree::ptree& ptTest,
-                        const std::string& dpu_name)
-{
-  const auto paths = findPlatformPaths(dev, ptTest);
-
-  for (const auto& path : paths) {
-    const auto dpu_instr = path / "DPU_Sequence" / dpu_name;
-    if (std::filesystem::exists(dpu_instr))
-      return dpu_instr.string();
+  catch (const std::exception&) {
+    logger(ptTest, "Details", boost::str(boost::format("%s not available. Skipping validation.") % file_path));
+    ptTest.put("status", test_token_skipped);
+    return "";
   }
-
-  logger(ptTest, "Details", boost::str(boost::format("%s not available. Skipping validation.") % dpu_name));
-  ptTest.put("status", test_token_skipped);
-  return "";
 }
 
 std::vector<std::string>

--- a/src/runtime_src/core/tools/common/TestRunner.h
+++ b/src/runtime_src/core/tools/common/TestRunner.h
@@ -33,21 +33,17 @@ class TestRunner : public JSONConfigurable {
   // Child class helper methods
   protected:
     TestRunner(const std::string & test_name, const std::string & description,
-            const std::string & xclbin = "", bool is_explicit = false);
-    TestRunner(const std::string & test_name, const std::string & description, 
-            const xrt_core::query::xclbin_name::type type, bool is_explicit = false);
+               const std::string & xclbin = "", bool is_explicit = false);
     void runPyTestCase( const std::shared_ptr<xrt_core::device>& _dev, const std::string& py,
              boost::property_tree::ptree& _ptTest);
     void logger(boost::property_tree::ptree& ptree, const std::string& tag, const std::string& msg);
     bool search_and_program_xclbin(const std::shared_ptr<xrt_core::device>& dev, boost::property_tree::ptree& ptTest);
-    std::string findPlatformPath(const std::shared_ptr<xrt_core::device>& dev,
-                                 boost::property_tree::ptree& ptTest);
-    std::vector<std::string> findDependencies( const std::string& test_path,
-                      const std::string& ps_kernel_name);
+    std::string findPlatformPath(const std::shared_ptr<xrt_core::device>& dev, boost::property_tree::ptree& ptTest);
+    std::string findPlatformFile(const std::string& file_path, boost::property_tree::ptree& ptTest);
     std::string findXclbinPath(const std::shared_ptr<xrt_core::device>& dev,
                                boost::property_tree::ptree& ptTest);
-    std::string findDPUPath(const std::shared_ptr<xrt_core::device>& dev,
-                            boost::property_tree::ptree& ptTest, const std::string& dpu_name);
+    std::vector<std::string> findDependencies( const std::string& test_path,
+                      const std::string& ps_kernel_name);
     int validate_binary_file(const std::string& binaryfile);
 
     const std::string test_token_skipped = "SKIPPED";
@@ -56,10 +52,6 @@ class TestRunner : public JSONConfigurable {
     std::string m_xclbin;
  
   private:
-    std::string getXclbinName(const std::shared_ptr<xrt_core::device>& dev,
-                              boost::property_tree::ptree& ptTest);
-    std::vector<std::filesystem::path> findPlatformPaths(const std::shared_ptr<xrt_core::device>& dev,
-                                                         boost::property_tree::ptree& ptTest);
     std::string searchLegacyXclbin(const uint16_t vendor, const std::string& dev_name, 
                                    boost::property_tree::ptree& _ptTest);
     std::string searchSSV2Xclbin(const std::string& logic_uuid,

--- a/src/runtime_src/core/tools/common/TestRunner.h
+++ b/src/runtime_src/core/tools/common/TestRunner.h
@@ -5,6 +5,7 @@
 #define __TestRunner_h_
 
 // Local - Include Files
+#include "core/common/query_requests.h"
 #include "JSONConfigurable.h"
 #include "xrt/xrt_device.h"
 
@@ -12,6 +13,7 @@
 #include <boost/property_tree/ptree.hpp>
 
 // System - Include Files
+#include <filesystem>
 #include <string>
 #include <vector>
 
@@ -30,8 +32,10 @@ class TestRunner : public JSONConfigurable {
 
   // Child class helper methods
   protected:
-    TestRunner(const std::string & test_name, const std::string & description, 
+    TestRunner(const std::string & test_name, const std::string & description,
             const std::string & xclbin = "", bool is_explicit = false);
+    TestRunner(const std::string & test_name, const std::string & description, 
+            const xrt_core::query::xclbin_name::type type, bool is_explicit = false);
     void runPyTestCase( const std::shared_ptr<xrt_core::device>& _dev, const std::string& py,
              boost::property_tree::ptree& _ptTest);
     void logger(boost::property_tree::ptree& ptree, const std::string& tag, const std::string& msg);
@@ -52,15 +56,18 @@ class TestRunner : public JSONConfigurable {
     std::string m_xclbin;
  
   private:
-    std::vector<std::string> findPlatformPaths(const std::shared_ptr<xrt_core::device>& dev,
-                                               boost::property_tree::ptree& ptTest);
+    std::string getXclbinName(const std::shared_ptr<xrt_core::device>& dev,
+                              boost::property_tree::ptree& ptTest);
+    std::vector<std::filesystem::path> findPlatformPaths(const std::shared_ptr<xrt_core::device>& dev,
+                                                         boost::property_tree::ptree& ptTest);
     std::string searchLegacyXclbin(const uint16_t vendor, const std::string& dev_name, 
-                      boost::property_tree::ptree& _ptTest);
+                                   boost::property_tree::ptree& _ptTest);
     std::string searchSSV2Xclbin(const std::string& logic_uuid,
-                      boost::property_tree::ptree& _ptTest);
+                                 boost::property_tree::ptree& _ptTest);
   
   //variables
   private:
+    xrt_core::query::xclbin_name::type m_xclbin_type;
     std::string m_name;
     std::string m_description;
     bool m_explicit;

--- a/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.cpp
@@ -26,8 +26,7 @@ static constexpr int itr_count = 600;
 
 // ----- C L A S S   M E T H O D S -------------------------------------------
 TestDF_bandwidth::TestDF_bandwidth()
-  : TestRunner("df-bw", "Run bandwidth test on data fabric", xrt_core::query::xclbin_name::type::validate)
-  , m_dpu_name("df_bw.txt")
+  : TestRunner("df-bw", "Run bandwidth test on data fabric")
 {}
 
 namespace {
@@ -79,23 +78,11 @@ TestDF_bandwidth::run(std::shared_ptr<xrt_core::device> dev)
 {
   boost::property_tree::ptree ptree = get_test_header();
 
-  #ifdef _WIN32
-  auto device_id = xrt_core::device_query<xrt_core::query::pcie_device>(dev);
-  switch (device_id) {
-  case 5378: // 0x1502
-    ptree.put("xclbin", "validate_phx.xclbin");
-    break;
-  case 6128: // 0x17f0
-    ptree.put("xclbin", "validate_stx.xclbin");
-    break;
-  }
-  #endif
-
-  auto xclbin_path = findXclbinPath(dev, ptree);
-  if (!std::filesystem::exists(xclbin_path)) {
+  const auto xclbin_name = xrt_core::device_query<xrt_core::query::xclbin_name>(dev, xrt_core::query::xclbin_name::type::validate);
+  auto xclbin_path = findPlatformFile(xclbin_name, ptree);
+  if (!std::filesystem::exists(xclbin_path))
     return ptree;
-  }
-  // log xclbin test dir for debugging purposes
+
   logger(ptree, "Xclbin", xclbin_path);
 
   xrt::xclbin xclbin;
@@ -132,8 +119,8 @@ TestDF_bandwidth::run(std::shared_ptr<xrt_core::device> dev)
   xrt::hw_context hwctx{working_dev, xclbin.get_uuid()};
   xrt::kernel kernel{hwctx, kernelName};
 
-  // Find DPU instruction file
-  std::string dpu_instr = findDPUPath(dev, ptree, m_dpu_name);
+  const auto seq_name = xrt_core::device_query<xrt_core::query::sequence_name>(dev, xrt_core::query::sequence_name::type::df_bandwidth);
+  auto dpu_instr = findPlatformFile(seq_name, ptree);
   if (!std::filesystem::exists(dpu_instr))
     return ptree;
 

--- a/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.cpp
@@ -26,12 +26,9 @@ static constexpr int itr_count = 600;
 
 // ----- C L A S S   M E T H O D S -------------------------------------------
 TestDF_bandwidth::TestDF_bandwidth()
-  : TestRunner("df-bw", 
-                "Run bandwidth test on data fabric",
-                "validate.xclbin")
-                {
-                  m_dpu_name = "df_bw.txt";
-                }
+  : TestRunner("df-bw", "Run bandwidth test on data fabric", xrt_core::query::xclbin_name::type::validate)
+  , m_dpu_name("df_bw.txt")
+{}
 
 namespace {
 

--- a/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.h
+++ b/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.h
@@ -13,10 +13,6 @@ class TestDF_bandwidth : public TestRunner {
 
   public:
     TestDF_bandwidth();
-
-  //variables
-  private:
-    std::string m_dpu_name;
 };
 
 #endif

--- a/src/runtime_src/core/tools/common/tests/TestIPU.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestIPU.cpp
@@ -19,32 +19,18 @@ static constexpr int itr_count = 10000;
 
 // ----- C L A S S   M E T H O D S -------------------------------------------
 TestIPU::TestIPU()
-  : TestRunner("verify", 
-                "Run 'Hello World' test on IPU",
-                "validate.xclbin"
-              ){}
+  : TestRunner("verify", "Run 'Hello World' test on IPU", xrt_core::query::xclbin_name::type::validate)
+{}
 
 boost::property_tree::ptree
 TestIPU::run(std::shared_ptr<xrt_core::device> dev)
 {
   boost::property_tree::ptree ptree = get_test_header();
 
-  #ifdef _WIN32
-  auto device_id = xrt_core::device_query<xrt_core::query::pcie_device>(dev);
-  switch (device_id) {
-  case 5378: // 0x1502
-    ptree.put("xclbin", "validate_phx.xclbin");
-    break;
-  case 6128: // 0x17f0
-    ptree.put("xclbin", "validate_stx.xclbin");
-    break;
-  }
-  #endif
-
   auto xclbin_path = findXclbinPath(dev, ptree);
-  if (!std::filesystem::exists(xclbin_path)) {
+  if (!std::filesystem::exists(xclbin_path))
     return ptree;
-  }
+
   // log xclbin test dir for debugging purposes
   logger(ptree, "Xclbin", xclbin_path);
 

--- a/src/runtime_src/core/tools/common/tests/TestIPU.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestIPU.cpp
@@ -19,7 +19,7 @@ static constexpr int itr_count = 10000;
 
 // ----- C L A S S   M E T H O D S -------------------------------------------
 TestIPU::TestIPU()
-  : TestRunner("verify", "Run 'Hello World' test on IPU", xrt_core::query::xclbin_name::type::validate)
+  : TestRunner("verify", "Run 'Hello World' test on IPU")
 {}
 
 boost::property_tree::ptree
@@ -27,11 +27,11 @@ TestIPU::run(std::shared_ptr<xrt_core::device> dev)
 {
   boost::property_tree::ptree ptree = get_test_header();
 
-  auto xclbin_path = findXclbinPath(dev, ptree);
+  const auto xclbin_name = xrt_core::device_query<xrt_core::query::xclbin_name>(dev, xrt_core::query::xclbin_name::type::validate);
+  auto xclbin_path = findPlatformFile(xclbin_name, ptree);
   if (!std::filesystem::exists(xclbin_path))
     return ptree;
 
-  // log xclbin test dir for debugging purposes
   logger(ptree, "Xclbin", xclbin_path);
 
   xrt::xclbin xclbin;

--- a/src/runtime_src/core/tools/common/tests/TestTCTAllColumn.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestTCTAllColumn.cpp
@@ -22,12 +22,9 @@ static constexpr int itr_count = 20000;
 
 // ----- C L A S S   M E T H O D S -------------------------------------------
 TestTCTAllColumn::TestTCTAllColumn()
-  : TestRunner("tct-all-col", 
-                "Measure average TCT processing time for all columns",
-                "validate.xclbin")
-                {
-                  m_dpu_name = "tct_4col.txt";
-                }
+  : TestRunner("tct-all-col", "Measure average TCT processing time for all columns", xrt_core::query::xclbin_name::type::validate)
+  , m_dpu_name("tct_4col.txt")
+{}
 
 namespace {
 

--- a/src/runtime_src/core/tools/common/tests/TestTCTAllColumn.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestTCTAllColumn.cpp
@@ -22,8 +22,7 @@ static constexpr int itr_count = 20000;
 
 // ----- C L A S S   M E T H O D S -------------------------------------------
 TestTCTAllColumn::TestTCTAllColumn()
-  : TestRunner("tct-all-col", "Measure average TCT processing time for all columns", xrt_core::query::xclbin_name::type::validate)
-  , m_dpu_name("tct_4col.txt")
+  : TestRunner("tct-all-col", "Measure average TCT processing time for all columns")
 {}
 
 namespace {
@@ -91,11 +90,11 @@ TestTCTAllColumn::run(std::shared_ptr<xrt_core::device> dev)
   #endif
 
 
-  auto xclbin_path = findXclbinPath(dev, ptree);
-  if (!std::filesystem::exists(xclbin_path)) {
+  const auto xclbin_name = xrt_core::device_query<xrt_core::query::xclbin_name>(dev, xrt_core::query::xclbin_name::type::validate);
+  auto xclbin_path = findPlatformFile(xclbin_name, ptree);
+  if (!std::filesystem::exists(xclbin_path))
     return ptree;
-  }
-  // log xclbin test dir for debugging purposes
+
   logger(ptree, "Xclbin", xclbin_path);
 
   xrt::xclbin xclbin;
@@ -132,8 +131,8 @@ TestTCTAllColumn::run(std::shared_ptr<xrt_core::device> dev)
   xrt::hw_context hwctx{working_dev, xclbin.get_uuid()};
   xrt::kernel kernel{hwctx, kernelName};
 
-  // Find DPU instruction file
-  std::string dpu_instr = findDPUPath(dev, ptree, m_dpu_name);
+  const auto seq_name = xrt_core::device_query<xrt_core::query::sequence_name>(dev, xrt_core::query::sequence_name::type::tct_one_column);
+  auto dpu_instr = findPlatformFile(seq_name, ptree);
   if (!std::filesystem::exists(dpu_instr))
     return ptree;
 

--- a/src/runtime_src/core/tools/common/tests/TestTCTAllColumn.h
+++ b/src/runtime_src/core/tools/common/tests/TestTCTAllColumn.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
 
 #ifndef __TestTCTAllColumn_h_
 #define __TestTCTAllColumn_h_
@@ -13,10 +13,6 @@ class TestTCTAllColumn : public TestRunner {
 
   public:
     TestTCTAllColumn();
-
-  //variables
-  private:
-    std::string m_dpu_name;
 };
 
 #endif

--- a/src/runtime_src/core/tools/common/tests/TestTCTOneColumn.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestTCTOneColumn.cpp
@@ -22,12 +22,9 @@ static constexpr int itr_count = 10000;
 
 // ----- C L A S S   M E T H O D S -------------------------------------------
 TestTCTOneColumn::TestTCTOneColumn()
-  : TestRunner("tct-one-col", 
-                "Measure average TCT processing time for one column",
-                "validate.xclbin")
-                {
-                  m_dpu_name = "tct_1col.txt";
-                }
+  : TestRunner("tct-one-col", "Measure average TCT processing time for one column", xrt_core::query::xclbin_name::type::validate)
+  , m_dpu_name("tct_1col.txt")
+{}
 
 namespace {
 

--- a/src/runtime_src/core/tools/common/tests/TestTCTOneColumn.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestTCTOneColumn.cpp
@@ -22,8 +22,7 @@ static constexpr int itr_count = 10000;
 
 // ----- C L A S S   M E T H O D S -------------------------------------------
 TestTCTOneColumn::TestTCTOneColumn()
-  : TestRunner("tct-one-col", "Measure average TCT processing time for one column", xrt_core::query::xclbin_name::type::validate)
-  , m_dpu_name("tct_1col.txt")
+  : TestRunner("tct-one-col", "Measure average TCT processing time for one column")
 {}
 
 namespace {
@@ -91,11 +90,11 @@ TestTCTOneColumn::run(std::shared_ptr<xrt_core::device> dev)
   #endif
 
 
-  auto xclbin_path = findXclbinPath(dev, ptree);
-  if (!std::filesystem::exists(xclbin_path)) {
+  const auto xclbin_name = xrt_core::device_query<xrt_core::query::xclbin_name>(dev, xrt_core::query::xclbin_name::type::validate);
+  auto xclbin_path = findPlatformFile(xclbin_name, ptree);
+  if (!std::filesystem::exists(xclbin_path))
     return ptree;
-  }
-  // log xclbin test dir for debugging purposes
+
   logger(ptree, "Xclbin", xclbin_path);
 
   xrt::xclbin xclbin;
@@ -132,8 +131,8 @@ TestTCTOneColumn::run(std::shared_ptr<xrt_core::device> dev)
   xrt::hw_context hwctx{working_dev, xclbin.get_uuid()};
   xrt::kernel kernel{hwctx, kernelName};
 
-  // Find DPU instruction file
-  std::string dpu_instr = findDPUPath(dev, ptree, m_dpu_name);
+  const auto seq_name = xrt_core::device_query<xrt_core::query::sequence_name>(dev, xrt_core::query::sequence_name::type::tct_one_column);
+  auto dpu_instr = findPlatformFile(seq_name, ptree);
   if (!std::filesystem::exists(dpu_instr))
     return ptree;
 

--- a/src/runtime_src/core/tools/common/tests/TestTCTOneColumn.h
+++ b/src/runtime_src/core/tools/common/tests/TestTCTOneColumn.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
 
 #ifndef __TestTCTOneColumn_h_
 #define __TestTCTOneColumn_h_
@@ -13,10 +13,6 @@ class TestTCTOneColumn : public TestRunner {
 
   public:
     TestTCTOneColumn();
-
-  //variables
-  private:
-    std::string m_dpu_name;
 };
 
 #endif


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/VITIS-11369

Currently, there is a division on where and how paths/files are named between Windows and Linux. To solve this issue we utilize the existing `xclbin_repo_paths` function. However, that is no longer sufficient and additional upgrades are necessary.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Not a bug, more of an inconvenience brought upon by the Windows driver store and Linux driver store rules.

#### How problem was solved, alternative solutions (if any) and why they were rejected
There are a few important changes to note:

1. `xclbin_repo_paths` now returns a vector of viable paths. Rather than a single path. On Linux device specific files can be found in multiple locations.
2. Added a device query to allow for the user to query a device for the appropriate xclbin to load. This allows us to dynamically select the xclbin that will do onto the device, rather than forcing the caller to know what xclbin is needed. As a side effect, tests for new devices will now specify an xclbin type they wish to load instead of the xclbin name. The device shim layer can then construct a repository appropriate solution rather than relying on XRT.

#### Risks (if any) associated the changes in the commit
Hopefully none.

#### What has been tested and how, request additional testing if necessary
Tested with Linux NPU
`????` Has replaced information that is not relevant to the change.
```
Test 1 [0000:c3:00.1]     : df-bw
    Description           : Run bandwidth test on data fabric
    Xclbin                : /lib/firmware/amdnpu/??????/validate.xclbin
    Details               : Kernel name is 'DPU_PDI_0'
    DPU-Sequence          : /opt/xilinx/xrt/amdxdna/DPU_Sequence/df_bw.txt
    Details               : Total duration: '??????'s
                            Average bandwidth per shim DMA: '????' GB/s
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Validation completed
```
#### Documentation impact (if any)
None