### PR TITLE
Add explicit dependency on absl for xrt_swemu abd xrt_hwemu targets

### DIFF
--- a/src/runtime_src/core/pcie/emulation/hw_emu/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/emulation/hw_emu/CMakeLists.txt
@@ -43,10 +43,14 @@ add_library(xrt_hwemu_static STATIC ${CURR_SOURCE}
 set_target_properties(xrt_hwemu PROPERTIES VERSION ${XRT_VERSION_STRING}
   SOVERSION ${XRT_SOVERSION})
 
+find_package(absl REQUIRED)
+
 target_link_libraries(xrt_hwemu
   PRIVATE
   ${Boost_SYSTEM_LIBRARY}
   ${PROTOBUF_LIBRARY}
+  absl::log
+  absl::check
   xrt_coreutil
   common_em
   rt
@@ -57,6 +61,8 @@ target_link_libraries(xrt_hwemu_static
   INTERFACE
   boost_system
   ${PROTOBUF_LIBRARY}
+  absl::log
+  absl::check
   xrt_coreutil_static
   rt
   uuid

--- a/src/runtime_src/core/pcie/emulation/sw_emu/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/emulation/sw_emu/CMakeLists.txt
@@ -39,10 +39,14 @@ add_library(xrt_swemu_static STATIC ${CURR_SOURCE}
 set_target_properties(xrt_swemu PROPERTIES VERSION ${XRT_VERSION_STRING}
   SOVERSION ${XRT_SOVERSION})
 
+find_package(absl REQUIRED)
+
 target_link_libraries(xrt_swemu
   PRIVATE
   ${Boost_SYSTEM_LIBRARY}
   ${PROTOBUF_LIBRARY}
+  absl::log
+  absl::check
   xrt_coreutil
   common_em
   rt
@@ -53,6 +57,8 @@ target_link_libraries(xrt_swemu_static
   INTERFACE
   boost_system
   ${PROTOBUF_LIBRARY}
+  absl::log
+  absl::check
   xrt_coreutil_static
   rt
   uuid


### PR DESCRIPTION
#### Problem solved by the commit

Fixes linkage of `xrt_swemu` and `xrt_hwemu` targets from `runtime_src/core/pcie/emulation/`

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

Mentioned components won't link on NixOS 23.11 (gcc 13.2.0, cmake 3.28.3):
```
...
/nix/store/...-binutils-2.41/bin/ld: /nix/store/...-protobuf-24.4/include/google/protobuf/repeated_ptr_field.h:704:(.text._ZN6google8protobuf8internal20RepeatedPtrFieldBase13ClearNonEmptyINS0_16RepeatedPtrFieldI45xclPerfMonReadTrace_Streaming_response_eventsE11TypeHandlerEEEvv[_ZN6google8protobuf8internal20RepeatedPtrFieldBase13ClearNonEmptyINS0_16RepeatedPtrFieldI45xclPerfMonReadTrace_Streaming_response_eventsE11TypeHandlerEEEvv]+0xc1): undefined reference to `absl::lts_20240116::log_internal::LogMessageFatal::~LogMessageFatal()
...
```
claiming undefined references to abseil-cpp library.

Corresponding `CMakeFiles/xrt_[s|h]wemu.dir/link.txt` files won't mention absl either.

#### How problem was solved, alternative solutions (if any) and why they were rejected

Explicit dependency on `absl::log` and `absl::check` was introduced into relevant `CMakeLists.txt` files

I'm aware NixOS is not supported, still not sure how this even works on Ubuntu / RHEL.
Hopefully being a bit more clear re dependencies won't hurt.

#### Risks (if any) associated the changes in the commit

The commit was not tested on any of the officially supported distros

#### What has been tested and how, request additional testing if necessary

The build was only tested locally.
It is required to make sure the build passes on all the supported systems.

#### Documentation impact (if any)

None