### PR TITLE
Do not move an r-value

### DIFF
--- a/src/runtime_src/core/common/api/aie/xrt_graph.cpp
+++ b/src/runtime_src/core/common/api/aie/xrt_graph.cpp
@@ -384,10 +384,10 @@ namespace xrt { namespace aie {
 
 profiling::
 profiling(const xrt::device& device)
-  : detail::pimpl<profiling_impl>(std::move(create_profiling_event(device)))
+  : detail::pimpl<profiling_impl>(create_profiling_event(device))
 {}
 
-int 
+int
 profiling::
 start(xrt::aie::profiling::profiling_option option, const std::string& port1_name, const std::string& port2_name, uint32_t value) const
 {


### PR DESCRIPTION
#### Problem solved by the commit

This triggered a warning about pessimistic behavior preventing copy-elision.
It was treated as an error by the normal compilation flow.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

Just trying to compile with a recent compiler.

