### PR TITLE
Port kernel driver to Linux 6.8

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/common/zocl_drv.c
+++ b/src/runtime_src/core/edge/drm/zocl/common/zocl_drv.c
@@ -952,6 +952,11 @@ const struct vm_operations_struct zocl_bo_vm_ops = {
 	.close = drm_gem_vm_close,
 };
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0)
+/* This was removed in 6.8 */
+#define DRM_UNLOCKED 0
+#endif
+
 static const struct drm_ioctl_desc zocl_ioctls[] = {
 	DRM_IOCTL_DEF_DRV(ZOCL_CREATE_BO, zocl_create_bo_ioctl,
 			DRM_AUTH|DRM_UNLOCKED|DRM_RENDER_ALLOW),

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/feature_rom.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/feature_rom.c
@@ -389,18 +389,15 @@ static bool is_valid_firmware(struct platform_device *pdev,
 	return true;
 }
 
+/* Return the length of the string or -E2BIG in case of error */
 static int get_vendor_firmware_dir(u16 vendor, char *buf, size_t len) {
-	size_t ret;
 	switch (vendor) {
 		case XOCL_ARISTA_VEN:
-			ret = strlcpy(buf, "arista", len);
-			break;
+			return strscpy(buf, "arista", len);
 		default:
 		case XOCL_XILINX_VEN:
-			ret = strlcpy(buf, "xilinx", len);
-			break;
+			return strscpy(buf, "xilinx", len);
 	}
-	return (ret >= len) ? -E2BIG : 0;
 }
 
 static int load_firmware_from_flash(struct platform_device *pdev,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/msix_xdma.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/msix_xdma.c
@@ -90,7 +90,11 @@ static irqreturn_t msix_xdma_isr(int irq, void *arg)
 		ret = irq_entry->handler(irq, irq_entry->arg);
 
 	if (!IS_ERR_OR_NULL(irq_entry->event_ctx)) {
+#if KERNEL_VERSION(6, 8, 0) <= LINUX_VERSION_CODE
+		eventfd_signal(irq_entry->event_ctx);
+#else
 		eventfd_signal(irq_entry->event_ctx, 1);
+#endif
 	}
 
 	return ret;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xdma.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xdma.c
@@ -294,7 +294,11 @@ static irqreturn_t xdma_isr(int irq, void *arg)
 		ret = irq_entry->handler(irq, irq_entry->arg);
 
 	if (!IS_ERR_OR_NULL(irq_entry->event_ctx)) {
+#if KERNEL_VERSION(6, 8, 0) <= LINUX_VERSION_CODE
+		eventfd_signal(irq_entry->event_ctx);
+#else
 		eventfd_signal(irq_entry->event_ctx, 1);
+#endif
 	}
 
 	return ret;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
@@ -407,6 +407,11 @@ static uint xocl_poll(struct file *filp, poll_table *wait)
 	return xocl_poll_client(filp, wait, priv->driver_priv);
 }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0)
+/* This was removed in 6.8 */
+#define DRM_UNLOCKED 0
+#endif
+
 static const struct drm_ioctl_desc xocl_ioctls[] = {
 	DRM_IOCTL_DEF_DRV(XOCL_CREATE_BO, xocl_create_bo_ioctl,
 			  DRM_AUTH|DRM_UNLOCKED|DRM_RENDER_ALLOW),

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
@@ -1583,7 +1583,7 @@ static int xocl_cma_mem_alloc(struct xocl_dev *xdev, uint64_t size)
 		return -EINVAL;
 	}
 
-	if (page_sz > (PAGE_SIZE << (MAX_ORDER-1))) {
+	if (page_sz > (PAGE_SIZE*MAX_ORDER_NR_PAGES)) {
 		DRM_WARN("Unable to allocate with page size 0x%llx", page_sz);
 		return -EINVAL;
 	}


### PR DESCRIPTION
To be rebased on `main` once https://github.com/Xilinx/XRT/pull/8003 has landed.
I think the code would benefit from some review by DRM experts because I have 0 expertise. @superm1 @airlied
This is to have https://github.com/amd/xdna-driver working along 
https://github.com/amd/xdna-driver/issues/3