### PR TITLE
Dump instruction and control packet (Do not merge)

### DIFF
--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -808,6 +808,19 @@ class module_sram : public module_impl
     // copy instruction into bo
     fill_instr_buf(m_instr_buf, data);
 
+    {
+        std::string filename = "m_instr_buf.bin";
+        std::ofstream ofs(filename, std::ios::out | std::ios::binary);
+
+        if (!ofs.is_open()) {
+            std::cout << "Failure opening file " + filename + " for writing!!" << std::endl;
+            abort();
+        }
+        char* buf = static_cast<char*>(m_instr_buf.map());
+        ofs.write((char*)buf, m_instr_buf.size());
+        ofs.close();
+    }
+
     if (m_ctrlpkt_buf) {
       // The current assembler uses "mc_code" to represent control-packet
       // buffer. We should change the name to "control-packet" which is not
@@ -834,6 +847,19 @@ class module_sram : public module_impl
 
       // copy instruction into bo
       fill_ctrlpkt_buf(m_ctrlpkt_buf, data);
+      {
+          std::string filename = "m_ctrlpkt_buf.bin";
+          std::ofstream ofs(filename, std::ios::out | std::ios::binary);
+
+          if (!ofs.is_open()) {
+              std::cout << "Failure opening file " + filename + " for writing!!" << std::endl;
+              abort();
+          }
+          char* buf = static_cast<char*>(m_ctrlpkt_buf.map());
+          ofs.write((char*)buf, m_ctrlpkt_buf.size());
+          ofs.close();
+      }
+
       XRT_PRINTF("<- module_sram::create_ctrlpkt_buffer()\n");
     }
   }


### PR DESCRIPTION
This is for discussion.
It used to compare the dumped binary file from this request: 
https://gitenterprise.xilinx.com/XRT/testcases/pull/380/

Compare 
bo_instr.bin with m_instr_buf.bin
bo_mc.bin with m_ctrlpkt_buf.bin

