### PR TITLE
DRM_IOCTL_XOCL_INFO_BO returns wrong size

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
@@ -406,6 +406,7 @@ static struct drm_xocl_bo *xocl_create_bo(struct drm_device *dev,
 
 	xobj->user_flags = user_flags;
 	xobj->flags = bo_type;
+	xobj->actual_bo_size = unaligned_size;
 	mutex_lock(&drm_p->mm_lock);
 	/* Assume there is only 1 HOST bank. We ignore the  memidx
 	 * for host bank. This is required for supporting No flag
@@ -956,7 +957,7 @@ int xocl_info_bo_ioctl(struct drm_device *dev,
 	xobj = to_xocl_bo(gem_obj);
 	BO_ENTER("xobj %p", xobj);
 
-	args->size = xobj->base.size;
+	args->size = xobj->actual_bo_size;
 	args->flags = xobj->user_flags;
 
 	args->paddr = xocl_bo_physical_addr(xobj);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drm.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drm.h
@@ -103,6 +103,8 @@ struct drm_xocl_bo {
 	unsigned              flags;
 	unsigned              mem_idx;
 	unsigned	      user_flags;
+	/* variable to store the actual bo size instead of aligned size*/
+	uint64_t 	      actual_bo_size;
 };
 
 struct drm_xocl_unmgd {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
[CR-1176062](https://jira.xilinx.com/browse/CR-1176062) xocl_info_bo_ioctl function returns the aligned size of bo to the user instead of original size.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
When we export a usrptrBO where the size is not multiple of 4K, the imported buffer gets the aligned size of BO from get_properties(). This is invalid for userptr.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added variable to store the actual buffer size in xobj

#### Risks (if any) associated the changes in the commit
NA
#### What has been tested and how, request additional testing if necessary
Teseted on u250.

#### Documentation impact (if any)
NA