### PR TITLE
Add noshim to ishim

### DIFF
--- a/src/runtime_src/core/common/ishim.h
+++ b/src/runtime_src/core/common/ishim.h
@@ -552,6 +552,254 @@ struct shim : public DeviceType
 #endif
 };
 
+// Stub out all xrt_core::ishim functions to throw not supported. A
+// small subset of ishim device level functions are overriden
+// and supported by a higher level devices as needed.
+template <typename DeviceType>
+struct noshim : public DeviceType
+{
+  template <typename ...Args>
+  noshim(Args&&... args)
+    : DeviceType(std::forward<Args>(args)...)
+  {}
+
+  void
+  close_device() override
+  {
+    throw ishim::not_supported_error(__func__);
+  }
+
+  void
+  open_context(const xrt::uuid&, unsigned int, bool) override
+  {
+    throw ishim::not_supported_error(__func__);
+  }
+
+  void
+  close_context(const xrt::uuid&, unsigned int) override
+  {
+    throw ishim::not_supported_error(__func__);
+  }
+
+  void
+  reg_read(uint32_t, uint32_t, uint32_t*) const override
+  {
+    throw ishim::not_supported_error(__func__);
+  }
+
+  void
+  reg_write(uint32_t, uint32_t, uint32_t) override
+  {
+    throw ishim::not_supported_error(__func__);
+  }
+
+  void
+  xread(enum xclAddressSpace, uint64_t, void*, size_t) const override
+  {
+    throw ishim::not_supported_error(__func__);
+  }
+
+  void
+  xwrite(enum xclAddressSpace, uint64_t, const void*, size_t) override
+  {
+    throw ishim::not_supported_error(__func__);
+  }
+
+  void
+  unmgd_pread(void*, size_t, uint64_t) override
+  {
+    throw ishim::not_supported_error(__func__);
+  }
+
+  void
+  unmgd_pwrite(const void*, size_t, uint64_t) override
+  {
+    throw ishim::not_supported_error(__func__);
+  }
+
+  void
+  exec_buf(buffer_handle*) override
+  {
+    throw ishim::not_supported_error(__func__);
+  }
+
+  int
+  exec_wait(int) const override
+  {
+    throw ishim::not_supported_error(__func__);
+  }
+
+  void
+  load_axlf(const axlf*) override
+  {
+    throw ishim::not_supported_error(__func__);
+  }
+
+  void
+  reclock(const uint16_t*) override
+  {
+    throw ishim::not_supported_error(__func__);
+  }
+
+  void
+  p2p_enable(bool) override
+  {
+    throw ishim::not_supported_error(__func__);
+  }
+
+  void
+  p2p_disable(bool) override
+  {
+    throw ishim::not_supported_error(__func__);
+  }
+
+  void
+  set_cma(bool, uint64_t) override
+  {
+    throw ishim::not_supported_error(__func__);
+  }
+
+  void
+  update_scheduler_status() override
+  {
+    throw ishim::not_supported_error(__func__);
+  }
+
+  void
+  user_reset(xclResetKind) override
+  {
+    throw ishim::not_supported_error(__func__);
+  }
+
+#ifdef XRT_ENABLE_AIE
+  xclGraphHandle
+  open_graph(const xrt::uuid&, const char*, xrt::graph::access_mode) override
+  {
+    throw ishim::not_supported_error(__func__);
+  }
+
+  void
+  close_graph(xclGraphHandle) override
+  {
+    throw ishim::not_supported_error(__func__);
+  }
+
+  void
+  reset_graph(xclGraphHandle) override
+  {
+    throw ishim::not_supported_error(__func__);
+  }
+
+  uint64_t
+  get_timestamp(xclGraphHandle) override
+  {
+    throw ishim::not_supported_error(__func__);
+  }
+
+  void
+  run_graph(xclGraphHandle, int) override
+  {
+    throw ishim::not_supported_error(__func__);
+  }
+
+  int
+  wait_graph_done(xclGraphHandle, int) override
+  {
+    throw ishim::not_supported_error(__func__);
+  }
+
+  void
+  wait_graph(xclGraphHandle, uint64_t) override
+  {
+    throw ishim::not_supported_error(__func__);
+  }
+
+  void
+  suspend_graph(xclGraphHandle) override
+  {
+    throw ishim::not_supported_error(__func__);
+  }
+
+  void
+  resume_graph(xclGraphHandle) override
+  {
+    throw ishim::not_supported_error(__func__);
+  }
+
+  void
+  end_graph(xclGraphHandle, uint64_t) override
+  {
+    throw ishim::not_supported_error(__func__);
+  }
+
+  void
+  update_graph_rtp(xclGraphHandle, const char*, const char*, size_t) override
+  {
+    throw ishim::not_supported_error(__func__);
+  }
+
+  void
+  read_graph_rtp(xclGraphHandle, const char*, char*, size_t) override
+  {
+    throw ishim::not_supported_error(__func__);
+  }
+
+  void
+  open_aie_context(xrt::aie::access_mode) override
+  {
+    throw ishim::not_supported_error(__func__);
+  }
+
+  void
+  sync_aie_bo(xrt::bo&, const char*, xclBOSyncDirection, size_t, size_t) override
+  {
+    throw ishim::not_supported_error(__func__);
+  }
+
+  void
+  reset_aie() override
+  {
+    throw ishim::not_supported_error(__func__);
+  }
+
+  void
+  sync_aie_bo_nb(xrt::bo&, const char*, xclBOSyncDirection, size_t, size_t) override
+  {
+    throw ishim::not_supported_error(__func__);
+  }
+
+  void
+  wait_gmio(const char*) override
+  {
+    throw ishim::not_supported_error(__func__);
+  }
+
+  int
+  start_profiling(int, const char*, const char*, uint32_t) override
+  {
+    throw ishim::not_supported_error(__func__);
+  }
+
+  uint64_t
+  read_profiling(int) override
+  {
+    throw ishim::not_supported_error(__func__);
+  }
+
+  void
+  stop_profiling(int) override
+  {
+    throw ishim::not_supported_error(__func__);
+  }
+
+  void
+  load_axlf_meta(const axlf*) override
+  {
+    throw ishim::not_supported_error(__func__);
+  }
+#endif
+};
+
 } // xrt_core
 
 #endif


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Due to recent changes in which functions are exported from XRT the amdxdna plugin no longer compiles. I would like to add the noshim implementation used in Windows to XRT and use that in the amdxdna plugin implementation.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
changed caused by https://github.com/Xilinx/XRT/pull/7998. Discovered when amdxdna did not compile anymore.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Replace the shim used by amdxdna with noshim.

#### Risks (if any) associated the changes in the commit
None.

#### What has been tested and how, request additional testing if necessary
Linux amdxdna machine
```
dbenusov@xlix-birman-29:/proj/rdi/staff/dbenusov/amd-aie-new/core/xrt$ ls
build  CHANGELOG.rst  CMakeLists.txt  CONTRIBUTING.rst  LICENSE  NOTICE  pyrightconfig.json  README.rst  src  tests
dbenusov@xlix-birman-29:/proj/rdi/staff/dbenusov/amd-aie-new/core/xrt$ xbutil examine
1187: Created KMQ pcidev
1512614: Device opened, fd=3
1530423: Allocated KMQ BO for: userptr=0x7f1e0c000000, size=50331648, flags=0x0
1535173: Created KMQ device (0000:c3:00.1) ...
System Configuration
  OS Name              : Linux
  Release              : 6.8.0-rc5-20240219t184641.5f07e31
  Version              : #1 SMP PREEMPT_DYNAMIC Mon Feb 19 18:56:02 UTC 2024
  Machine              : x86_64
  CPU Cores            : 12
  Memory               : 14411 MB
  Distribution         : Ubuntu 22.04 LTS
  GLIBC                : 2.35
  Model                : Birman-PHX
  BIOS vendor          : INSYDE Corp.
  BIOS version         : TBI1001aA

XRT
  Version              : 2.17.0
  Branch               : master
  Hash                 : 2b870279f68f7f2b3d08315b7269acbdc1c6033c
  Hash Date            : 2024-03-19 10:20:05
  XOCL                 : unknown, unknown
  XCLMGMT              : unknown, unknown
WARNING: xclmgmt version is unknown. Is xclmgmt driver loaded? Or is MSD/MPD running?
  AMDXDNA              : 0.1, unknown

Devices present
BDF             :  Name
---------------------------------
[0000:c3:00.1]  :  RyzenAI-npu1


2114573: Destroying KMQ device (0000:c3:00.1) ...
2119322: Freeing KMQ BO, type=AMDXDNA_BO_DEV_HEAP, drm_bo=1, size=50331648
2230928: Destroying KMQ pcidev
2258235: Device closed, fd=3
```

#### Documentation impact (if any)
None.
