### PR TITLE
Only use the XDP Static DB methods supported for Client Flow in ML Timeline Plugin 

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.cpp
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.cpp
@@ -37,7 +37,7 @@ namespace xdp {
   MLTimelineClientDevImpl::MLTimelineClientDevImpl(VPDatabase*dB)
     : MLTimelineImpl(dB)
   {
-    xrt_core::message::send(xrt_core::message::debug, "XRT", "Created ML Timeline for Client Device.");
+    xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT", "Created ML Timeline for Client Device.");
   }
 
   void MLTimelineClientDevImpl::finishflushDevice(void* /*hwCtxImpl*/)

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.cpp
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.cpp
@@ -25,6 +25,7 @@
 
 #include "core/common/device.h"
 #include "core/common/message.h"
+#include "core/common/utils.h"
 #include "core/include/xrt/xrt_bo.h"
 #include "core/include/xrt/xrt_kernel.h"
 
@@ -131,10 +132,12 @@ namespace xdp {
     std::string result = std::regex_replace(oss.str(), reg, "$1");
 
     std::ofstream fOut;
-    fOut.open("record_timer_ts.json");
+    std::string outFName = "record_timer_ts_" + std::to_string(xrt_core::utils::get_pid()) + ".json";
+    fOut.open(outFName);
     fOut << result;
     fOut.close();
-    xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT", "Completed writing recorded timestamps to record_timer_ts.json.");
+    msg = "Completed writing recorded timestamps to " + outFName;
+    xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT", msg);
   }
 }
 

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.cpp
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.cpp
@@ -25,7 +25,6 @@
 
 #include "core/common/device.h"
 #include "core/common/message.h"
-#include "core/common/utils.h"
 #include "core/include/xrt/xrt_bo.h"
 #include "core/include/xrt/xrt_kernel.h"
 
@@ -132,12 +131,10 @@ namespace xdp {
     std::string result = std::regex_replace(oss.str(), reg, "$1");
 
     std::ofstream fOut;
-    std::string outFName = "record_timer_ts_" + std::to_string(xrt_core::utils::get_pid()) + ".json";
-    fOut.open(outFName);
+    fOut.open("record_timer_ts.json");
     fOut << result;
     fOut.close();
-    msg = "Completed writing recorded timestamps to " + outFName;
-    xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT", msg);
+    xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT", "Completed writing recorded timestamps to record_timer_ts.json.");
   }
 }
 

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.cpp
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.cpp
@@ -36,7 +36,7 @@ namespace xdp {
   MLTimelineClientDevImpl::MLTimelineClientDevImpl(VPDatabase*dB)
     : MLTimelineImpl(dB)
   {
-    xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT", "Created ML Timeline for Client Device.");
+    xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT", "Created ML Timeline Plugin for Client Device.");
   }
 
   void MLTimelineClientDevImpl::finishflushDevice(void* /*hwCtxImpl*/)

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.h
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -29,7 +29,7 @@ namespace xdp {
 
       ~MLTimelineClientDevImpl() = default;
 
-      virtual void finishflushDevice(void* handle);
+      virtual void finishflushDevice(void* hwCtxImpl);
   };
 
 }

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_cb.cpp
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_cb.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -23,31 +23,31 @@ namespace xdp {
 
   static MLTimelinePlugin mlTimelinePluginInstance;
 
-  static void updateDeviceMLTmln(void* handle)
+  static void updateDeviceMLTmln(void* hwCtxImpl)
   {
     if (MLTimelinePlugin::alive()) {
-      mlTimelinePluginInstance.updateDevice(handle);
+      mlTimelinePluginInstance.updateDevice(hwCtxImpl);
     } 
   } 
 
-  static void finishflushDeviceMLTmln(void* handle)
+  static void finishflushDeviceMLTmln(void* hwCtxImpl)
   {
     if (MLTimelinePlugin::alive()) {
-      mlTimelinePluginInstance.finishflushDevice(handle);
+      mlTimelinePluginInstance.finishflushDevice(hwCtxImpl);
     } 
   } 
 
 } // end namespace xdp
 
 extern "C"
-void updateDeviceMLTmln(void* handle)
+void updateDeviceMLTmln(void* hwCtxImpl)
 {
-  xdp::updateDeviceMLTmln(handle);
+  xdp::updateDeviceMLTmln(hwCtxImpl);
 }
 
 extern "C"
-void finishflushDeviceMLTmln(void* handle)
+void finishflushDeviceMLTmln(void* hwCtxImpl)
 {
-  xdp::finishflushDeviceMLTmln(handle);
+  xdp::finishflushDeviceMLTmln(hwCtxImpl);
 }
 

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_cb.h
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_cb.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -21,8 +21,8 @@
 
 extern "C" {
 
-  XDP_PLUGIN_EXPORT void updateDeviceMLTmln(void* handle);
-  XDP_PLUGIN_EXPORT void finishflushDeviceMLTmln(void* handle);
+  XDP_PLUGIN_EXPORT void updateDeviceMLTmln(void* hwCtxImpl);
+  XDP_PLUGIN_EXPORT void finishflushDeviceMLTmln(void* hwCtxImpl);
 
 }
 #endif

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_impl.h
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_impl.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -18,16 +18,17 @@
 #define XDP_PLUGIN_ML_TIMELINE_IMPL_H
 
 #include "core/include/xrt/xrt_hw_context.h"
-#include "xdp/profile/plugin/vp_base/vp_base_plugin.h"
 
 namespace xdp {
+
+  class VPDatabase;
 
   class MLTimelineImpl
   {
 
     protected :
       VPDatabase* db = nullptr;
-      xrt::hw_context hwContext;
+      xrt::hw_context mHwContext;
 
     public:
       MLTimelineImpl(VPDatabase* dB)
@@ -42,7 +43,7 @@ namespace xdp {
 
       void setHwContext(xrt::hw_context ctx)
       {
-        hwContext = std::move(ctx);
+        mHwContext = std::move(ctx);
       }
   };
 

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_plugin.cpp
@@ -63,8 +63,7 @@ namespace xdp {
   {
 #ifdef XDP_CLIENT_BUILD
     if (mHwCtxImpl) {
-      xrt_core::message::send(xrt_core::message::severity_level::error, "XRT",
-        "ML Timeline feature does not yet support multiple applications running simultaneously.");
+      // For client device flow, only 1 device and xclbin is supported now.
       return;
     }
     mHwCtxImpl = hwCtxImpl;

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_plugin.cpp
@@ -16,20 +16,15 @@
 
 #define XDP_PLUGIN_SOURCE
 
-#include <array>
-
 #include "core/common/device.h"
 #include "core/common/message.h"
-#include "core/common/system.h"
 #include "core/common/api/hw_context_int.h"
 
-#include "xdp/profile/device/utility.h"
 #include "xdp/profile/plugin/ml_timeline/ml_timeline_plugin.h"
-#include "xdp/profile/plugin/vp_base/utility.h"
 #include "xdp/profile/plugin/vp_base/info.h"
 
 #ifdef XDP_CLIENT_BUILD
-  #include "xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.h"
+#include "xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.h"
 #endif
 
 namespace xdp {
@@ -64,90 +59,56 @@ namespace xdp {
     return MLTimelinePlugin::live;
   }
 
-  uint64_t MLTimelinePlugin::getDeviceIDFromHandle(void* handle)
-  { 
-    auto itr = handleToDeviceData.find(handle);
-    if (itr != handleToDeviceData.end())
-      return itr->second.deviceID;
-
-#ifdef XDP_CLIENT_BUILD
-    return db->addDevice("win_device");
-#else
-    return db->addDevice(""); // Not supported for non-client device 
-#endif
-  }
-
-  void MLTimelinePlugin::updateDevice(void* handle)
+  void MLTimelinePlugin::updateDevice(void* hwCtxImpl)
   {
-    if (!handle)
+#ifdef XDP_CLIENT_BUILD
+    if (mHwCtxImpl) {
+      xrt_core::message::send(xrt_core::message::severity_level::error, "XRT",
+        "ML Timeline feature does not yet support multiple applications running simultaneously.");
       return;
-
-    uint64_t deviceID = getDeviceIDFromHandle(handle);
-
-    (db->getStaticInfo()).updateDevice(deviceID, handle);
-#ifdef XDP_CLIENT_BUILD
-    (db->getStaticInfo()).setDeviceName(deviceID, "win_device");
-#endif
-
-    // Clean out old data every time xclbin gets updated
-    if (handleToDeviceData.find(handle) != handleToDeviceData.end())
-      handleToDeviceData.erase(handle);
-
-    //Setting up struct 
-    auto& DeviceDataEntry = handleToDeviceData[handle];
-
-    DeviceDataEntry.deviceID = deviceID;
-    DeviceDataEntry.valid = true; // initialize struct
-
-#ifndef XDP_CLIENT_BUILD
-    // Get Device info // Investigate further (isDeviceReady should be always called??)
-    if (!(db->getStaticInfo()).isDeviceReady(deviceID)) {
-      // Update the static database with information from xclbin
-      (db->getStaticInfo()).updateDevice(deviceID, handle);
-      {
-        std::string deviceName = util::getDeviceName(handle);
-        if (deviceName != "")
-          (db->getStaticInfo()).setDeviceName(deviceID, deviceName);
-      }
     }
-#endif
+    mHwCtxImpl = hwCtxImpl;
 
+    xrt::hw_context hwContext   = xrt_core::hw_context_int::create_hw_context_from_implementation(mHwCtxImpl);
+    xrt_core::device coreDevice = xrt_core::hw_context_int::get_core_device(hwContext);
 
-#ifdef XDP_CLIENT_BUILD
+    // Only one device for Client Device flow
+    uint64_t deviceId = db->addDevice("win_device");
+    (db->getStaticInfo())->updateDeviceClient(deviceId, coreDevice);
+    (db->getStaticInfo())->setDeviceName(deviceId, "win_device");
+
+    DeviceDataEntry.valid = true;
     DeviceDataEntry.implementation = std::make_unique<MLTimelineClientDevImpl>(db);
-    DeviceDataEntry.implementation->setHwContext(xrt_core::hw_context_int::create_hw_context_from_implementation(handle));
+    DeviceDataEntry.implementation->setHwContext(hwContext);
 #endif
   }
 
-  void MLTimelinePlugin::finishflushDevice(void* handle)
+  void MLTimelinePlugin::finishflushDevice(void* hwCtxImpl)
   {
-    if (!handle)
-      return;
-
-    auto itr = handleToDeviceData.find(handle);
-    if (itr == handleToDeviceData.end()) {
+#ifdef XDP_CLIENT_BUILD
+    if (!mHwCtxImpl || !DeviceDataEntry.valid) {
       return;
     }
-    auto& DeviceDataEntry = itr->second;
-    if (!DeviceDataEntry.valid)
-      return;
 
-    DeviceDataEntry.implementation->finishflushDevice(handle);
-    handleToDeviceData.erase(handle);
+    if (hwCtxImpl != mHwCtxImpl) {
+      xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT", 
+          "Cannot retrieve ML Timeline data as a new HW Context Implementation is passed.");
+      return;
+    } 
+    DeviceDataEntry.valid = false;
+    DeviceDataEntry.implementation->finishFlushDevice(mHwCtxImpl);
+#endif
   }
 
   void MLTimelinePlugin::writeAll(bool /*openNewFiles*/)
   {
-    for (const auto& entry : handleToDeviceData) {
-      auto& DeviceDataEntry = entry.second;
-
-      if (!DeviceDataEntry.valid) {
-        continue;
-      }
-      DeviceDataEntry.implementation->finishflushDevice(entry.first);
-      handleToDeviceData.erase(entry.first);
+#ifdef XDP_CLIENT_BUILD
+    if (!mHwCtxImpl || !DeviceDataEntry.valid) {
+      return;
     }
-    handleToDeviceData.clear();
+    DeviceDataEntry.valid = false;
+    DeviceDataEntry.implementation->finishFlushDevice(mHwCtxImpl);
+#endif
   }
 
 }

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_plugin.cpp
@@ -68,13 +68,13 @@ namespace xdp {
     }
     mHwCtxImpl = hwCtxImpl;
 
-    xrt::hw_context hwContext   = xrt_core::hw_context_int::create_hw_context_from_implementation(mHwCtxImpl);
-    xrt_core::device coreDevice = xrt_core::hw_context_int::get_core_device(hwContext);
+    xrt::hw_context hwContext = xrt_core::hw_context_int::create_hw_context_from_implementation(mHwCtxImpl);
+    std::shared_ptr<xrt_core::device> coreDevice = xrt_core::hw_context_int::get_core_device(hwContext);
 
     // Only one device for Client Device flow
     uint64_t deviceId = db->addDevice("win_device");
-    (db->getStaticInfo())->updateDeviceClient(deviceId, coreDevice);
-    (db->getStaticInfo())->setDeviceName(deviceId, "win_device");
+    (db->getStaticInfo()).updateDeviceClient(deviceId, coreDevice);
+    (db->getStaticInfo()).setDeviceName(deviceId, "win_device");
 
     DeviceDataEntry.valid = true;
     DeviceDataEntry.implementation = std::make_unique<MLTimelineClientDevImpl>(db);
@@ -95,7 +95,7 @@ namespace xdp {
       return;
     } 
     DeviceDataEntry.valid = false;
-    DeviceDataEntry.implementation->finishFlushDevice(mHwCtxImpl);
+    DeviceDataEntry.implementation->finishflushDevice(mHwCtxImpl);
 #endif
   }
 
@@ -106,7 +106,7 @@ namespace xdp {
       return;
     }
     DeviceDataEntry.valid = false;
-    DeviceDataEntry.implementation->finishFlushDevice(mHwCtxImpl);
+    DeviceDataEntry.implementation->finishflushDevice(mHwCtxImpl);
 #endif
   }
 

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_plugin.h
@@ -42,7 +42,7 @@ namespace xdp {
     struct DeviceData {
       bool valid;
       std::unique_ptr<MLTimelineImpl> implementation;
-    };
+    } DeviceDataEntry;
 
     void* mHwCtxImpl = nullptr;
 

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_plugin.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -30,25 +30,21 @@ namespace xdp {
     MLTimelinePlugin();
     ~MLTimelinePlugin();
 
-    void updateDevice(void* handle);
-    void finishflushDevice(void* handle);
+    void updateDevice(void* hwCtxImpl);
+    void finishflushDevice(void* hwCtxImpl);
     void writeAll(bool openNewFiles);
 
     static bool alive();
-
-    private:
-    uint64_t getDeviceIDFromHandle(void* handle);
 
     private:
     static bool live;
 
     struct DeviceData {
       bool valid;
-      uint64_t deviceID;
       std::unique_ptr<MLTimelineImpl> implementation;
     };
- 
-    std::map<void*, DeviceData>  handleToDeviceData;
+
+    void* mHwCtxImpl = nullptr;
 
   };
 


### PR DESCRIPTION
#### Problem solved by the commit
Some Static DB methods which are not supported for Client Device Flow were added in ML Timeline Plugin but were controlled by XDP_CLIENT_BUILD macro. As they will never be used, these are now removed. Only Client Device Flow specific code should be present.
Also, add some debug and info messages to help in failing scenario.

#### What has been tested and how, request additional testing if necessary
ML Timeline Plugin tested with XRT_MCDM.
#### Documentation impact (if any)
