### PR TITLE
Propagate XRT Include Directory in CMake target

### DIFF
--- a/src/runtime_src/core/common/api/CMakeLists.txt
+++ b/src/runtime_src/core/common/api/CMakeLists.txt
@@ -30,7 +30,9 @@ if (DEFINED XRT_AIE_BUILD)
 endif()
 
 target_include_directories(core_common_api_library_objects
-  PRIVATE
-  ${XRT_SOURCE_DIR}/runtime_src
-  ${XRT_SOURCE_DIR}/runtime_src/core/common/elf
+  PUBLIC
+  $<BUILD_INTERFACE:${XRT_SOURCE_DIR}/runtime_src>
+  $<BUILD_INTERFACE:${XRT_SOURCE_DIR}/runtime_src/core/common/elf>
+  $<INSTALL_INTERFACE:${XRT_INSTALL_INCLUDE_DIR}>
   )
+  


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
When foreign CMake projects link against XRT::xrt_coreutil
The target's property INTERFACE_INCLUDE_DIRECTORIES is empty.
Today our customers resolve this by doing
```
add_library(myLib myLib.cpp)
target_include_directories(myLib ${XRT_INCLUDE_DIRS}) # Bring in all the includes
target_link_libraries(myLib XRT::xrt_coreutil)
```

This really shouldn't be necessary, because this library is unusable without header files.
We can allow the include directory to propagate.

This will fix issues where another project creates an interface library that links XRT.

For instance here is a hack I'm having to do:
```
# XRT library target is unaware of its associated include files
 # Get the existing interface include directories
 get_target_property(include_dirs ryzenai::qlinear_2 INTERFACE_INCLUDE_DIRECTORIES)

 # Append the new include directory
 list(APPEND include_dirs "${XRT_INCLUDE_DIRS}")

 # Set the modified include directories back on the target
 set_target_properties(ryzenai::qlinear_2 PROPERTIES
     INTERFACE_INCLUDE_DIRECTORIES "${include_dirs}"
 )
```
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Discovered while trying to create an interface library that links XRT.

#### How problem was solved, alternative solutions (if any) and why they were rejected
See code change

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
I've done no testing, this is my proposed fix to ensure that the include directory property can propagate to the end user.

#### Documentation impact (if any)
None