### PR TITLE
VITIS-11102 Remove device status from Ryzen report

### DIFF
--- a/src/runtime_src/core/tools/common/XBHelpMenus.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenus.cpp
@@ -314,8 +314,17 @@ XBUtilities::produce_reports( const std::shared_ptr<xrt_core::device>& device,
     ptDevice.put("interface_type", "pcie");
     ptDevice.put("device_id", xrt_core::query::pcie_bdf::to_string(bdf));
 
-    const auto device_status = xrt_core::device_query_default<xrt_core::query::device_status>(device, 2);
-    ptDevice.put("device_status", xrt_core::query::device_status::parse_status(device_status));
+    switch (xrt_core::device_query_default<xrt_core::query::device_class>(device, xrt_core::query::device_class::type::alveo)) {
+    case xrt_core::query::device_class::type::alveo:
+    {
+      const auto device_status = xrt_core::device_query_default<xrt_core::query::device_status>(device, 2);
+      ptDevice.put("device_status", xrt_core::query::device_status::parse_status(device_status));
+      break;
+    }
+    case xrt_core::query::device_class::type::ryzen:
+      // Ryzen devices do not have a concept of device status. They work or they dont.
+      break;
+    }
 
     bool is_mfg = false;
     try {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Neither Nvidia SMI nor AMD SMI tool s display any device health for their GPUs. We should not display anything either.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Not a bug.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Only add the device status to alveo devices. Although I believe we can just remove this query entirely.

#### Risks (if any) associated the changes in the commit
None.

#### What has been tested and how, request additional testing if necessary
Linux U55c
```
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov/XRT$ xbutil examine -r platform -o test.json --force
WARNING: Unexpected xocl version (2.16.0) was found. Expected 2.17.0, to match XRT tools.

-------------------------------------------------
[0000:04:00.1] : xilinx_u55c_gen3x16_xdma_base_3
-------------------------------------------------
Platform
  XSA Name               : xilinx_u55c_gen3x16_xdma_base_3
  Logic UUID             : 97088961-FEAE-DA91-52A2-1D9DFD63CCEF
  FPGA Name              :
  JTAG ID Code           : 0x14b7d093
  DDR Size               : 0 Bytes
  DDR Count              : 0
  Mig Calibrated         : true
  P2P Status             : disabled
  P2P IO space required  : 32 GB

Clocks
  DATA_CLK (Data)        : 300 MHz
  KERNEL_CLK (Kernel)    : 500 MHz
  hbm_aclk (System)      : 450 MHz

Mac Addresses            : 00:0A:35:0B:23:98
                         : 00:0A:35:0B:23:99
                         : 00:0A:35:0B:23:9A
                         : 00:0A:35:0B:23:9B
                         : 00:0A:35:0B:23:9C
                         : 00:0A:35:0B:23:9D
                         : 00:0A:35:0B:23:9E
                         : 00:0A:35:0B:23:9F

Successfully wrote the json file: test.json
dbenusov@xsjdbenusov50:/proj/rdi/staff/dbenusov/XRT$ cat test.json
{
    "schema_version": {
        "schema": "JSON",
        "creation_date": "Thu Mar 21 22:26:41 2024 GMT"
    },
    "devices": [
        {
            "interface_type": "pcie",
            "device_id": "0000:04:00.1",
            "device_status": "HEALTHY",
            "platforms": [
```
Device status for alveo is still there!

#### Documentation impact (if any)
None
