### PR TITLE
Fix on client to correct partition info device query request

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info/aie_util.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info/aie_util.cpp
@@ -371,27 +371,26 @@ namespace xdp::aie {
     try {
       xrt::hw_context context = xrt_core::hw_context_int::create_hw_context_from_implementation(handle);
       auto device = xrt_core::hw_context_int::get_core_device(context);
-      if(device==nullptr)
+      if (device==nullptr)
         return std::vector<uint8_t>{0};
 
       auto infoVector = xrt_core::device_query<xrt_core::query::aie_partition_info>(device.get());
       if (infoVector.empty()) {
         xrt_core::message::send(severity_level::info, "XRT", "No AIE partition information found.");
-        startCols.push_back(0);
+        return std::vector<uint8_t>{0};
       }
-      else {
-        for (auto& info : infoVector) {
-          auto startCol = static_cast<uint8_t>(info.start_col);
-          xrt_core::message::send(severity_level::info, "XRT",
-              "Partition shift of " + std::to_string(startCol) + " was found.");
-          startCols.push_back(startCol);
-        }
+
+      for (auto& info : infoVector) {
+        auto startCol = static_cast<uint8_t>(info.start_col);
+        xrt_core::message::send(severity_level::info, "XRT",
+            "Partition shift of " + std::to_string(startCol) + " was found.");
+        startCols.push_back(startCol);
       }
     }
     catch(...) {
       // Query not available
       xrt_core::message::send(severity_level::info, "XRT", "Unable to query AIE partition information.");
-      startCols.push_back(0);
+      return std::vector<uint8_t>{0};
     }
 
     return startCols;

--- a/src/runtime_src/xdp/profile/database/static_info/aie_util.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info/aie_util.cpp
@@ -17,6 +17,7 @@
 #define XDP_CORE_SOURCE
 
 #include "aie_util.h"
+#include "core/common/api/hw_context_int.h"
 #include "core/common/message.h"
 #include "core/common/system.h"
 #include "core/common/device.h"
@@ -363,14 +364,17 @@ namespace xdp::aie {
    * Get AIE partition information
    ***************************************************************************/
   std::vector<uint8_t>
-  getPartitionStartColumns(void* handle)
+  getPartitionStartColumnsClient(void* handle)
   {
     std::vector<uint8_t> startCols;
 
     try {
-      std::shared_ptr<xrt_core::device> dev = xrt_core::get_userpf_device(handle);
-      auto infoVector = xrt_core::device_query<xrt_core::query::aie_partition_info>(dev);
+      xrt::hw_context context = xrt_core::hw_context_int::create_hw_context_from_implementation(handle);
+      auto device = xrt_core::hw_context_int::get_core_device(context);
+      if(device==nullptr)
+        return std::vector<uint8_t>{0};
 
+      auto infoVector = xrt_core::device_query<xrt_core::query::aie_partition_info>(device.get());
       if (infoVector.empty()) {
         xrt_core::message::send(severity_level::info, "XRT", "No AIE partition information found.");
         startCols.push_back(0);

--- a/src/runtime_src/xdp/profile/database/static_info/aie_util.h
+++ b/src/runtime_src/xdp/profile/database/static_info/aie_util.h
@@ -95,7 +95,7 @@ namespace xdp::aie {
   uint8_t convertStringToUint8(const std::string& input);
 
   XDP_CORE_EXPORT
-  std::vector<uint8_t> getPartitionStartColumns(void* handle);
+  std::vector<uint8_t> getPartitionStartColumnsClient(void* handle);
 
 } // namespace xdp::aie
 

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/client/aie_profile.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/client/aie_profile.cpp
@@ -112,8 +112,11 @@ namespace xdp {
 
     // Get partition columns
     // NOTE: for now, assume a single partition
-    auto partitionCols = xdp::aie::getPartitionStartColumns(metadata->getHandle());
-    auto startCol = partitionCols.at(0);
+    uint8_t startCol = 0;
+#ifdef XDP_CLIENT_BUILD
+    auto partitionCols = xdp::aie::getPartitionStartColumnsClient(metadata->getHandle());
+    startCol = partitionCols.at(0);
+#endif
 
     //Start recording the transaction
     XAie_StartTransaction(&aieDevInst, XAIE_TRANSACTION_DISABLE_AUTO_FLUSH);

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/client/aie_profile.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/client/aie_profile.cpp
@@ -112,11 +112,8 @@ namespace xdp {
 
     // Get partition columns
     // NOTE: for now, assume a single partition
-    uint8_t startCol = 0;
-#ifdef XDP_CLIENT_BUILD
     auto partitionCols = xdp::aie::getPartitionStartColumnsClient(metadata->getHandle());
-    startCol = partitionCols.at(0);
-#endif
+    uint8_t startCol = partitionCols.at(0);
 
     //Start recording the transaction
     XAie_StartTransaction(&aieDevInst, XAIE_TRANSACTION_DISABLE_AUTO_FLUSH);

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/client/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/client/aie_trace.cpp
@@ -808,9 +808,11 @@ namespace xdp {
 
     // Get partition columns
     // NOTE: for now, assume a single partition
-    auto partitionCols = xdp::aie::getPartitionStartColumns(handle);
-    auto startCol = partitionCols.at(0);
-
+    uint8_t startCol = 0;
+#ifdef XDP_CLIENT_BUILD
+    auto partitionCols = xdp::aie::getPartitionStartColumnsClient(handle);
+    startCol = partitionCols.at(0);
+#endif
     //Start recording the transaction
     XAie_StartTransaction(&aieDevInst, XAIE_TRANSACTION_DISABLE_AUTO_FLUSH);
 

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/client/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/client/aie_trace.cpp
@@ -540,7 +540,7 @@ namespace xdp {
                           + typeName + " channel " + std::to_string(channelNum);
           xrt_core::message::send(severity_level::debug, "XRT", msg);
           //switchPortRsc->setPortToSelect(slaveOrMaster, DMA, channelNum);
-          XAie_EventSelectStrmPort(&aieDevInst, loc, 0, slaveOrMaster, DMA, channelNum);
+          XAie_EventSelectStrmPort(&aieDevInst, loc, portnum, slaveOrMaster, DMA, channelNum);
 
           // Record for runtime config file
           // NOTE: channel info informs back-end there will be events on that channel
@@ -562,7 +562,7 @@ namespace xdp {
           xrt_core::message::send(severity_level::debug, "XRT", msg);
           
           //switchPortRsc->setPortToSelect(slaveOrMaster, SOUTH, streamPortId);
-          XAie_EventSelectStrmPort(&aieDevInst, loc, 0, slaveOrMaster, SOUTH, streamPortId);
+          XAie_EventSelectStrmPort(&aieDevInst, loc, portnum, slaveOrMaster, SOUTH, streamPortId);
 
           // Record for runtime config file
           config.port_trace_ids[portnum] = streamPortId;
@@ -588,7 +588,7 @@ namespace xdp {
                           + typeName + " stream port " + std::to_string(channel);
           xrt_core::message::send(severity_level::debug, "XRT", msg);
           //switchPortRsc->setPortToSelect(slaveOrMaster, DMA, channel);
-          XAie_EventSelectStrmPort(&aieDevInst, loc, 0, slaveOrMaster, DMA, channel);
+          XAie_EventSelectStrmPort(&aieDevInst, loc, portnum, slaveOrMaster, DMA, channel);
 
           // Record for runtime config file
           config.port_trace_ids[portnum] = channel;
@@ -1144,7 +1144,6 @@ namespace xdp {
               break;
           
             coreToMemBcMask |= (0x1 << bcId);
-            bcId++;
           } 
           else {
             if (XAie_TraceEvent(&aieDevInst, loc, XAIE_MEM_MOD, memoryEvents[i], i) != XAIE_OK)
@@ -1163,6 +1162,7 @@ namespace xdp {
           if (isCoreEvent) {
             cfgTile->core_trace_config.internal_events_broadcast[bcId] = phyEvent;
             cfgTile->memory_trace_config.traced_events[i] = bcIdToEvent(bcId);
+            bcId++;
           }
           else if (type == module_type::mem_tile)
             cfgTile->memory_tile_trace_config.traced_events[i] = phyEvent;

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/client/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/client/aie_trace.cpp
@@ -808,11 +808,9 @@ namespace xdp {
 
     // Get partition columns
     // NOTE: for now, assume a single partition
-    uint8_t startCol = 0;
-#ifdef XDP_CLIENT_BUILD
     auto partitionCols = xdp::aie::getPartitionStartColumnsClient(handle);
-    startCol = partitionCols.at(0);
-#endif
+    uint8_t startCol = partitionCols.at(0);
+    
     //Start recording the transaction
     XAie_StartTransaction(&aieDevInst, XAIE_TRANSACTION_DISABLE_AUTO_FLUSH);
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
On client, evice query was running into errors while fetching the partition info

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Corrected the way to get hardware context on client instead of device handle.

#### Risks (if any) associated the changes in the commit
No risk as it is verified on client MCDM.

#### What has been tested and how, request additional testing if necessary
Verified on client MCDM XRT.

#### Documentation impact (if any)
