### PR TITLE
Fixing the map operator logic

### DIFF
--- a/src/runtime_src/hip/api/hip_memory.cpp
+++ b/src/runtime_src/hip/api/hip_memory.cpp
@@ -137,7 +137,8 @@ namespace xrt::core::hip
       throw xrt_core::system_error(hipErrorInvalidValue, "Invalid destination handle in hipMemCpy");
 
     if (hip_mem) {
-      auto address = hip_mem->get_address();
+      // dst is device address. Get device address
+      auto address = hip_mem->get_device_address();
       auto offset = reinterpret_cast<uint64_t>(dst) - reinterpret_cast<uint64_t>(address);
       hip_mem->write(src, size, 0, offset);
     }
@@ -157,7 +158,8 @@ namespace xrt::core::hip
     if (!hip_mem)
       throw xrt_core::system_error(hipErrorInvalidValue, "Invalid src handle in hipMemCpy");
 
-    auto address = hip_mem->get_address();
+    // src is device address. Get device address
+    auto address = hip_mem->get_device_address();
     auto offset = reinterpret_cast<uint64_t>(src) - reinterpret_cast<uint64_t>(address);
     hip_mem->read(dst, size, 0, offset);
   }

--- a/src/runtime_src/hip/core/memory.h
+++ b/src/runtime_src/hip/core/memory.h
@@ -1,4 +1,4 @@
-// S PDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2024 Advanced Micro Device, Inc. All rights reserved.
 #ifndef xrthip_memory_h
 #define xrthip_memory_h

--- a/src/runtime_src/hip/core/memory.h
+++ b/src/runtime_src/hip/core/memory.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0
+// S PDX-License-Identifier: Apache-2.0
 // Copyright (C) 2024 Advanced Micro Device, Inc. All rights reserved.
 #ifndef xrthip_memory_h
 #define xrthip_memory_h
@@ -93,56 +93,64 @@ namespace xrt::core::hip
     init_xrt_bo();
   };
 
-class address_range_key
-{
-public:
+  class address_range_key
+  {
+  public:
     address_range_key() : address(0), size(0) {}
     address_range_key(uint64_t addr, size_t sz) : address(addr), size(sz) {}
 
     uint64_t    address;
     size_t      size;
-};
+  };
 
-struct address_sz_key_compare
-{
+  struct address_sz_key_compare
+  {
     bool operator() (const address_range_key& lhs, const address_range_key& rhs) const
     {
-        return ((lhs.address + lhs.size)  < rhs.address);
+      // The keys a and b are equivalent by definition when neither a < b nor b < a is true
+      if (lhs.address == rhs.address)
+        return false;
+      
+      // Example to explain why "-1" is mandatory in below calculation
+      // if address is 0x4000 and size is 0x100 . If another address is 0x4100
+      // a < b retruns false because 0x4000+0x100 < 0x4100
+      // b < a returns false because 0x4100+0x100 < 0x4000
+      // if we add "-1" then a<b returns true.
+      return (lhs.address + lhs.size - 1  < rhs.address);
     }
-};
-
-using addr_map = std::map<address_range_key, std::shared_ptr<memory>, address_sz_key_compare>;
-
-class memory_database
-{
-private:
+  };
+  
+  using addr_map = std::map<address_range_key, std::shared_ptr<memory>, address_sz_key_compare>;
+  
+  class memory_database
+  {
+  private:
     addr_map m_addr_map;
-
-protected:
+  
+  protected:
     memory_database();
-
+  
     static memory_database* m_memory_database;
-
-public:
+  
+  public:
     ~memory_database();
-
+  
     static memory_database&
     instance();
-
+  
     void
     insert(uint64_t addr, size_t size, std::shared_ptr<memory> hip_mem);
-
+  
     void
     remove(uint64_t addr);
-
+  
     std::shared_ptr<xrt::core::hip::memory>
     get_hip_mem_from_addr(void* addr);
-
+  
     std::shared_ptr<const xrt::core::hip::memory>
     get_hip_mem_from_addr(const void* addr);
-};
-
-
+  };
+  
 } // xrt::core::hip
 
 #endif


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Fixing the map operator logic. Earlier map is not able to insert some of the addresses due to incorrect logic in the map

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Earlier map is not able to insert some of the addresses due to incorrect logic in the map

#### How problem was solved, alternative solutions (if any) and why they were rejected
Fixed the map operator logic

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Verified all the HIP memory tests

#### Documentation impact (if any)
NA