### PR TITLE
add cmake definition for linux builds of profiling modules

### DIFF
--- a/src/runtime_src/core/edge/ps_kernels/profiling/aie2_profile_config/CMakeLists.txt
+++ b/src/runtime_src/core/edge/ps_kernels/profiling/aie2_profile_config/CMakeLists.txt
@@ -19,6 +19,7 @@ target_compile_definitions(aie2_profile_config PRIVATE
   __PS_ENABLE_AIE__
   XCLHAL_MAJOR_VER=1
   XCLHAL_MINOR_VER=0
+  FAL_LINUX="on"
 )
 
 target_link_libraries(aie2_profile_config

--- a/src/runtime_src/core/edge/ps_kernels/profiling/aie2_trace_config/CMakeLists.txt
+++ b/src/runtime_src/core/edge/ps_kernels/profiling/aie2_trace_config/CMakeLists.txt
@@ -19,6 +19,7 @@ target_compile_definitions(aie2_trace_config PRIVATE
   __PS_ENABLE_AIE__
   XCLHAL_MAJOR_VER=1
   XCLHAL_MINOR_VER=0
+  FAL_LINUX="on"
 )
 
 target_link_libraries(aie2_trace_config

--- a/src/runtime_src/core/edge/ps_kernels/profiling/aie_profile_config/CMakeLists.txt
+++ b/src/runtime_src/core/edge/ps_kernels/profiling/aie_profile_config/CMakeLists.txt
@@ -19,6 +19,7 @@ target_compile_definitions(aie_profile_config PRIVATE
   __PS_ENABLE_AIE__
   XCLHAL_MAJOR_VER=1
   XCLHAL_MINOR_VER=0
+  FAL_LINUX="on"
 )
 
 target_link_libraries(aie_profile_config

--- a/src/runtime_src/core/edge/ps_kernels/profiling/aie_trace_config/CMakeLists.txt
+++ b/src/runtime_src/core/edge/ps_kernels/profiling/aie_trace_config/CMakeLists.txt
@@ -19,6 +19,7 @@ target_compile_definitions(aie_trace_config PRIVATE
   __PS_ENABLE_AIE__
   XCLHAL_MAJOR_VER=1
   XCLHAL_MINOR_VER=0
+  FAL_LINUX="on"
 )
 
 target_link_libraries(aie_trace_config

--- a/src/runtime_src/core/edge/ps_kernels/profiling/aie_trace_gmio/CMakeLists.txt
+++ b/src/runtime_src/core/edge/ps_kernels/profiling/aie_trace_gmio/CMakeLists.txt
@@ -19,6 +19,7 @@ target_compile_definitions(aie_trace_gmio PRIVATE
   __PS_ENABLE_AIE__
   XCLHAL_MAJOR_VER=1
   XCLHAL_MINOR_VER=0
+  FAL_LINUX="on"
 )
 
 target_link_libraries(aie_trace_gmio

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/CMakeLists.txt
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/CMakeLists.txt
@@ -60,10 +60,11 @@ elseif (${XRT_NATIVE_BUILD} STREQUAL "yes")
   )
 
 elseif (DEFINED XRT_AIE_BUILD AND ${XRT_NATIVE_BUILD} STREQUAL "no")
-  add_library(xdp_aie_profile_plugin MODULE ${AIE_PROFILE_PLUGIN_FILES} ${AIE_PROFILE_UTIL_FILES})
 
+  add_library(xdp_aie_profile_plugin MODULE ${AIE_PROFILE_PLUGIN_FILES} ${AIE_PROFILE_UTIL_FILES})
   add_dependencies(xdp_aie_profile_plugin xdp_core xrt_coreutil)
   target_link_libraries(xdp_aie_profile_plugin PRIVATE xdp_core xrt_coreutil xaiengine)
+  target_compile_definitions(xdp_aie_profile_plugin PRIVATE FAL_LINUX="on")
   set_target_properties(xdp_aie_profile_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
 
   install (TARGETS xdp_aie_profile_plugin

--- a/src/runtime_src/xdp/profile/plugin/aie_status/CMakeLists.txt
+++ b/src/runtime_src/xdp/profile/plugin/aie_status/CMakeLists.txt
@@ -19,6 +19,7 @@ file(GLOB AIE_STATUS_PLUGIN_FILES
 add_library(xdp_aie_status_plugin MODULE ${AIE_STATUS_PLUGIN_FILES})
 add_dependencies(xdp_aie_status_plugin xdp_core)
 target_link_libraries(xdp_aie_status_plugin PRIVATE xdp_core xaiengine)
+target_compile_definitions(xdp_aie_status_plugin PRIVATE FAL_LINUX="on")
 
 set_target_properties(xdp_aie_status_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
 

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/CMakeLists.txt
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/CMakeLists.txt
@@ -75,6 +75,8 @@ elseif (DEFINED XRT_AIE_BUILD AND ${XRT_NATIVE_BUILD} STREQUAL "no")
 
   add_dependencies(xdp_aie_trace_plugin xdp_core xrt_coreutil)
   target_link_libraries(xdp_aie_trace_plugin PRIVATE xdp_core xrt_coreutil xaiengine)
+  target_compile_definitions(xdp_aie_trace_plugin PRIVATE FAL_LINUX="on")
+
   set_target_properties(xdp_aie_trace_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
 
   install (TARGETS xdp_aie_trace_plugin


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Designs using profiling, trace hang with new AIE Fal changes
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://github.com/Xilinx/XRT/commit/4806f6fbf3a8ad7317c63e647a6b598b513fe87d
#### How problem was solved, alternative solutions (if any) and why they were rejected
Added the appropriate cmake flags
#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Tested on a design on vck190
#### Documentation impact (if any)
