### PR TITLE
VITIS-11503 - Dump instruction bo created from Elf so verification can be done

### DIFF
--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -201,7 +201,7 @@ struct patcher
   }
 };
 
-  void
+  XRT_CORE_UNUSED void
   dump_bo(xrt::bo& bo, const std::string& filename)
   {
     if (!xrt_core::config::get_feature_toggle(Debug_Bo_From_Elf_Feature))

--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -3,6 +3,7 @@
 #define XCL_DRIVER_DLL_EXPORT  // exporting xrt_module.h
 #define XRT_API_SOURCE         // exporting xrt_module.h
 #define XRT_CORE_COMMON_SOURCE // in same dll as core_common
+#include "core/common/config_reader.h"
 #include "experimental/xrt_module.h"
 #include "experimental/xrt_elf.h"
 #include "experimental/xrt_ext.h"
@@ -40,6 +41,9 @@ namespace
 static constexpr size_t column_page_size = AIE_COLUMN_PAGE_SIZE;
 static constexpr uint8_t Elf_Amd_Aie2p  = 69;
 static constexpr uint8_t Elf_Amd_Aie2ps = 64;
+
+// When Debug.dump_bo_from_elf is true in xrt.ini, instruction bo(s) from elf will be dumped
+static std::string Debug_Bo_From_Elf_Feature = "Debug.dump_bo_from_elf";
 
 struct buf
 {
@@ -808,11 +812,42 @@ class module_sram : public module_impl
     // copy instruction into bo
     fill_instr_buf(m_instr_buf, data);
 
+#ifdef _DEBUG
+    if (xrt_core::config::get_feature_toggle(Debug_Bo_From_Elf_Feature)) {
+        std::string filename = "instrBo.bin";
+        std::ofstream ofs(filename, std::ios::out | std::ios::binary);
+
+        if (!ofs.is_open()) {
+            std::cout << "Failure opening file " + filename + " for writing!!" << std::endl;
+            abort();
+        }
+        char* buf = static_cast<char*>(m_instr_buf.map());
+        ofs.write((char*)buf, m_instr_buf.size());
+        ofs.close();
+    }
+#endif
+
     if (m_ctrlpkt_buf) {
       // The current assembler uses "mc_code" to represent control-packet
       // buffer. We should change the name to "control-packet" which is not
       // DPU specific. Will change this once assembler fix it.
       patch_instr("mc_code", m_ctrlpkt_buf);
+
+#ifdef _DEBUG
+      if (xrt_core::config::get_feature_toggle(Debug_Bo_From_Elf_Feature)) {
+          std::string filename = "instrBoPatchedByCtrlPacket.bin";
+          std::ofstream ofs(filename, std::ios::out | std::ios::binary);
+
+          if (!ofs.is_open()) {
+              std::cout << "Failure opening file " + filename + " for writing!!" << std::endl;
+              abort();
+          }
+          char* buf = static_cast<char*>(m_instr_buf.map());
+          ofs.write((char*)buf, m_instr_buf.size());
+          ofs.close();
+      }
+#endif
+
       XRT_PRINTF("<- module_sram::create_instr_buf()\n");
     }
   }
@@ -834,6 +869,22 @@ class module_sram : public module_impl
 
       // copy instruction into bo
       fill_ctrlpkt_buf(m_ctrlpkt_buf, data);
+
+#ifdef _DEBUG
+      if (xrt_core::config::get_feature_toggle(Debug_Bo_From_Elf_Feature)) {
+          std::string filename = "ctrlpktBo.bin";
+          std::ofstream ofs(filename, std::ios::out | std::ios::binary);
+
+          if (!ofs.is_open()) {
+              std::cout << "Failure opening file " + filename + " for writing!!" << std::endl;
+              abort();
+          }
+          char* buf = static_cast<char*>(m_ctrlpkt_buf.map());
+          ofs.write((char*)buf, m_ctrlpkt_buf.size());
+          ofs.close();
+      }
+#endif
+
       XRT_PRINTF("<- module_sram::create_ctrlpkt_buffer()\n");
     }
   }

--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -794,6 +794,22 @@ class module_sram : public module_impl
     bo.sync(XCL_BO_SYNC_BO_TO_DEVICE);
   }
 
+#ifdef _DEBUG
+  void
+  dump_bo(xrt::bo& bo, const std::string& filename)
+  {
+    if (xrt_core::config::get_feature_toggle(Debug_Bo_From_Elf_Feature)) {
+      std::ofstream ofs(filename, std::ios::out | std::ios::binary);
+
+      if (!ofs.is_open())
+        throw std::runtime_error("Failure opening file " + filename + " for writing!");
+
+      auto buf = bo.map<char*>();
+      ofs.write(buf, bo.size());
+    }
+  }
+#endif
+
   void
   create_instr_buf(const module_impl* parent)
   {
@@ -813,16 +829,7 @@ class module_sram : public module_impl
     fill_instr_buf(m_instr_buf, data);
 
 #ifdef _DEBUG
-    if (xrt_core::config::get_feature_toggle(Debug_Bo_From_Elf_Feature)) {
-        std::string filename = "instrBo.bin";
-        std::ofstream ofs(filename, std::ios::out | std::ios::binary);
-
-        if (!ofs.is_open())
-          throw std::runtime_error("Failure opening file " + filename + " for writing!");
-
-        auto buf = m_instr_buf.map<char*>();
-        ofs.write(buf, m_instr_buf.size());
-    }
+    dump_bo(m_instr_buf, "instrBo.bin");
 #endif
 
     if (m_ctrlpkt_buf) {
@@ -832,16 +839,7 @@ class module_sram : public module_impl
       patch_instr("mc_code", m_ctrlpkt_buf);
 
 #ifdef _DEBUG
-      if (xrt_core::config::get_feature_toggle(Debug_Bo_From_Elf_Feature)) {
-          std::string filename = "instrBoPatchedByCtrlPacket.bin";
-          std::ofstream ofs(filename, std::ios::out | std::ios::binary);
-
-          if (!ofs.is_open())
-            throw std::runtime_error("Failure opening file " + filename + " for writing!");
-
-          auto buf = m_instr_buf.map<char*>();
-          ofs.write(buf, m_instr_buf.size());
-      }
+      dump_bo(m_instr_buf, "instrBoPatchedByCtrlPacket.bin");
 #endif
 
       XRT_PRINTF("<- module_sram::create_instr_buf()\n");
@@ -867,16 +865,7 @@ class module_sram : public module_impl
       fill_ctrlpkt_buf(m_ctrlpkt_buf, data);
 
 #ifdef _DEBUG
-      if (xrt_core::config::get_feature_toggle(Debug_Bo_From_Elf_Feature)) {
-          std::string filename = "ctrlpktBo.bin";
-          std::ofstream ofs(filename, std::ios::out | std::ios::binary);
-
-          if (!ofs.is_open())
-            throw std::runtime_error("Failure opening file " + filename + " for writing!");
-
-          auto buf = m_ctrlpkt_buf.map<char*>();
-          ofs.write(buf, m_ctrlpkt_buf.size());
-      }
+      dump_bo(m_ctrlpkt_buf, "ctrlpktBo.bin");
 #endif
 
       XRT_PRINTF("<- module_sram::create_ctrlpkt_buffer()\n");

--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -201,6 +201,19 @@ struct patcher
   }
 };
 
+  void
+  dump_bo(xrt::bo& bo, const std::string& filename)
+  {
+    if (xrt_core::config::get_feature_toggle(Debug_Bo_From_Elf_Feature)) {
+      std::ofstream ofs(filename, std::ios::out | std::ios::binary);
+
+      if (!ofs.is_open())
+        throw std::runtime_error("Failure opening file " + filename + " for writing!");
+
+      auto buf = bo.map<char*>();
+      ofs.write(buf, bo.size());
+    }
+  }
 } // namespace
 
 namespace xrt
@@ -793,22 +806,6 @@ class module_sram : public module_impl
     std::memcpy(ptr, ctrlpktbuf.data(), ctrlpktbuf.size());
     bo.sync(XCL_BO_SYNC_BO_TO_DEVICE);
   }
-
-#ifdef _DEBUG
-  void
-  dump_bo(xrt::bo& bo, const std::string& filename)
-  {
-    if (xrt_core::config::get_feature_toggle(Debug_Bo_From_Elf_Feature)) {
-      std::ofstream ofs(filename, std::ios::out | std::ios::binary);
-
-      if (!ofs.is_open())
-        throw std::runtime_error("Failure opening file " + filename + " for writing!");
-
-      auto buf = bo.map<char*>();
-      ofs.write(buf, bo.size());
-    }
-  }
-#endif
 
   void
   create_instr_buf(const module_impl* parent)

--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -817,13 +817,11 @@ class module_sram : public module_impl
         std::string filename = "instrBo.bin";
         std::ofstream ofs(filename, std::ios::out | std::ios::binary);
 
-        if (!ofs.is_open()) {
-            std::cout << "Failure opening file " + filename + " for writing!!" << std::endl;
-            abort();
-        }
-        char* buf = static_cast<char*>(m_instr_buf.map());
-        ofs.write((char*)buf, m_instr_buf.size());
-        ofs.close();
+        if (!ofs.is_open())
+          throw std::runtime_error("Failure opening file " + filename + " for writing!");
+
+        auto buf = m_instr_buf.map<char*>();
+        ofs.write(buf, m_instr_buf.size());
     }
 #endif
 
@@ -838,13 +836,11 @@ class module_sram : public module_impl
           std::string filename = "instrBoPatchedByCtrlPacket.bin";
           std::ofstream ofs(filename, std::ios::out | std::ios::binary);
 
-          if (!ofs.is_open()) {
-              std::cout << "Failure opening file " + filename + " for writing!!" << std::endl;
-              abort();
-          }
-          char* buf = static_cast<char*>(m_instr_buf.map());
-          ofs.write((char*)buf, m_instr_buf.size());
-          ofs.close();
+          if (!ofs.is_open())
+            throw std::runtime_error("Failure opening file " + filename + " for writing!");
+
+          auto buf = m_instr_buf.map<char*>();
+          ofs.write(buf, m_instr_buf.size());
       }
 #endif
 
@@ -875,13 +871,11 @@ class module_sram : public module_impl
           std::string filename = "ctrlpktBo.bin";
           std::ofstream ofs(filename, std::ios::out | std::ios::binary);
 
-          if (!ofs.is_open()) {
-              std::cout << "Failure opening file " + filename + " for writing!!" << std::endl;
-              abort();
-          }
-          char* buf = static_cast<char*>(m_ctrlpkt_buf.map());
-          ofs.write((char*)buf, m_ctrlpkt_buf.size());
-          ofs.close();
+          if (!ofs.is_open())
+            throw std::runtime_error("Failure opening file " + filename + " for writing!");
+
+          auto buf = m_ctrlpkt_buf.map<char*>();
+          ofs.write(buf, m_ctrlpkt_buf.size());
       }
 #endif
 

--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -204,15 +204,15 @@ struct patcher
   void
   dump_bo(xrt::bo& bo, const std::string& filename)
   {
-    if (xrt_core::config::get_feature_toggle(Debug_Bo_From_Elf_Feature)) {
-      std::ofstream ofs(filename, std::ios::out | std::ios::binary);
+    if (!xrt_core::config::get_feature_toggle(Debug_Bo_From_Elf_Feature))
+      return;
 
-      if (!ofs.is_open())
-        throw std::runtime_error("Failure opening file " + filename + " for writing!");
+    std::ofstream ofs(filename, std::ios::out | std::ios::binary);
+    if (!ofs.is_open())
+      throw std::runtime_error("Failure opening file " + filename + " for writing!");
 
-      auto buf = bo.map<char*>();
-      ofs.write(buf, bo.size());
-    }
+    auto buf = bo.map<char*>();
+    ofs.write(buf, bo.size());
   }
 } // namespace
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Create a mechanism to dump instruction-buffer BO(s) constructed from elf. This is critical to verify the elf's correctness. 
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Only in debug mode, Use the xrt_core::config::get_feature_toggle which reading xrt.ini to decide whether or not dumping instruction-buffer bo. This can avoid any potential performance impact to real applications.
#### Risks (if any) associated the changes in the commit
None
#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
