### PR TITLE
Fix bug in Edge sw_emu flow

### DIFF
--- a/src/runtime_src/core/edge/sw_emu/generic_pcie_hal2/system_swemu.cxx
+++ b/src/runtime_src/core/edge/sw_emu/generic_pcie_hal2/system_swemu.cxx
@@ -54,7 +54,8 @@ std::pair<device::id_type, device::id_type>
 system::
 get_total_devices(bool is_user) const
 {
-  return {0,0};
+  device::id_type num = xclProbe();
+  return std::make_pair(num, num);
 }
 
 std::shared_ptr<xrt_core::device>


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
sw_emu flow of edge returns zero devices available because of bug in code. Fixed it to return proper value.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
When removing xcl apis, in Hal layer I have removed dlopen and dlsym call to xclProbe and used enumerate_devices function which was returning wrong value in sw_emu Edge flow. It was discovered in petalinux team integration testing.

#### How problem was solved, alternative solutions (if any) and why they were rejected
#### Risks (if any) associated the changes in the commit
#### What has been tested and how, request additional testing if necessary
Ran hello world opencl application on vck190 using sw_emu flow and the test passes

#### Documentation impact (if any)
NA