### PR TITLE
ML Timeline Plugin should read timestamp data before AIE Profile/Debug 

### DIFF
--- a/src/runtime_src/xdp/profile/database/database.h
+++ b/src/runtime_src/xdp/profile/database/database.h
@@ -41,7 +41,7 @@ namespace xdp {
   {
   public:
     // For messages sent to specific plugins
-    enum MessageType { READ_COUNTERS, READ_TRACE, DUMP_TRACE, DUMP_AIE_PROFILE } ;
+    enum MessageType { READ_COUNTERS, READ_TRACE, DUMP_TRACE, DUMP_AIE_PROFILE, READ_RECORD_TIMESTAMPS } ;
 
   private:
     // The information stored in the database will be separated into 

--- a/src/runtime_src/xdp/profile/plugin/aie_debug/aie_debug_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_debug/aie_debug_plugin.cpp
@@ -16,6 +16,7 @@
 #include "xdp/profile/database/static_info/aie_util.h"
 #include "xdp/profile/database/database.h"
 #include "xdp/profile/database/static_info/aie_constructs.h"
+#include "xdp/profile/plugin/vp_base/info.h"
 
 namespace xdp {
   using severity_level = xrt_core::message::severity_level;

--- a/src/runtime_src/xdp/profile/plugin/aie_debug/aie_debug_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_debug/aie_debug_plugin.cpp
@@ -281,6 +281,11 @@ namespace xdp {
   {
     xrt_core::message::send(severity_level::debug, "XRT", "Calling AIE Poll.");
 
+    if (db->infoAvailable(xdp::info::ml_timeline)) {
+      db->broadcast(VPDatabase::MessageType::READ_RECORD_TIMESTAMPS, nullptr);
+      xrt_core::message::send(severity_level::debug, "XRT", "Done reading recorded timestamps.");
+    }
+
     if (!transactionHandler->submitTransaction(txn_ptr))
       return;
     auto result_bo = transactionHandler->syncResults();

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/client/aie_profile.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/client/aie_profile.cpp
@@ -292,6 +292,11 @@ namespace xdp {
     if (finishedPoll)
       return;
 
+    if (db->infoAvailable(xdp::info::ml_timeline)) {
+      db->broadcast(VPDatabase::MessageType::READ_RECORD_TIMESTAMPS, nullptr);
+      xrt_core::message::send(severity_level::debug, "XRT", "Done reading recorded timestamps.");
+    }
+
     (void)handle;
     double timestamp = xrt_core::time_ns() / 1.0e6;
 

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/client/aie_profile.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/client/aie_profile.cpp
@@ -36,6 +36,7 @@
 #include "xdp/profile/plugin/aie_profile/aie_profile_defs.h"
 #include "xdp/profile/plugin/aie_profile/util/aie_profile_util.h"
 #include "xdp/profile/plugin/aie_profile/util/aie_profile_config.h"
+#include "xdp/profile/plugin/vp_base/info.h"
 
 // XRT headers
 #include "xrt/xrt_bo.h"

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_plugin.cpp
@@ -110,4 +110,17 @@ namespace xdp {
 #endif
   }
 
+  void MLTimelinePlugin::broadcast(VPDatabase::MessageType msgType, void* /*blob*/)
+  {
+    switch(msgType)
+    {
+      case VPDatabase::READ_RECORD_TIMESTAMPS:
+      {
+        writeAll(false);
+        break;
+      }
+      default:
+        break;
+    }
+  }
 }

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_plugin.h
@@ -34,6 +34,8 @@ namespace xdp {
     void finishflushDevice(void* hwCtxImpl);
     void writeAll(bool openNewFiles);
 
+    virtual void broadcast(VPDatabase::MessageType, void*);
+
     static bool alive();
 
     private:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
When ML Timeline, AIE Profile/Debug starts using debug buffer, they will write/read from the same start address. In ML Timeline, the timestamps are written to device buffer during execution of the design. So, this data must be retrieved before AIE Profile/Debug starts writing to the buffer.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Unit tests 
#### Documentation impact (if any)
