### PR TITLE
Fix syntax errors in some pre-removal and post-installation scripts

### DIFF
--- a/src/CMake/config/postinst.in
+++ b/src/CMake/config/postinst.in
@@ -80,12 +80,12 @@ done
 rmmodules
 
 DRACUT_CONF_PATH=/etc/dracut.conf.d
-if [ -e $DRACUT_CONF_PATH ] && [ $alveo == 1]; then
+if [ -e $DRACUT_CONF_PATH ] && [ $alveo -eq 1 ]; then
     install -m 644 /usr/src/xrt-@XRT_VERSION_STRING@/driver/xocl/userpf/xocl.dracut.conf $DRACUT_CONF_PATH
     install -m 644 /usr/src/xrt-@XRT_VERSION_STRING@/driver/xocl/mgmtpf/xclmgmt.dracut.conf $DRACUT_CONF_PATH
 fi
 
-if [ $alveo == 0]; then
+if [ $alveo -eq 0 ]; then
     echo "Skipping XRT Alveo driver install"
     exit 0
 fi

--- a/src/CMake/config/prerm-azure.in
+++ b/src/CMake/config/prerm-azure.in
@@ -30,7 +30,7 @@
 # configuration of the components and hence we want to handle the configuration
 # in postinst script.
 
-DIR=@@CMAKE_INSTALL_PREFIX@@/xrt
+DIR=@CMAKE_INSTALL_PREFIX@/xrt
 
 #In case prerm is called after postinst on centos, make sure not to stop mpd
 awk -F= '$1=="ID" {print $2}' /etc/os-release | tr -d '"' | awk '{print tolower($1)}' | grep -Eq "^rhel|^centos"

--- a/src/CMake/config/prerm-container.in
+++ b/src/CMake/config/prerm-container.in
@@ -38,7 +38,7 @@ if [ $? -eq 0 ] && [ $1 -ge 1 ]; then
 fi
 
 echo "Remove mpd plugin"
-rm -rf @@CMAKE_INSTALL_PREFIX@@/xrt/lib/libmpd_plugin.so > /dev/null 2>&1
+rm -rf @CMAKE_INSTALL_PREFIX@/xrt/lib/libmpd_plugin.so > /dev/null 2>&1
 systemctl disable mpd > /dev/null 2>&1
 systemctl stop mpd > /dev/null 2>&1
 

--- a/src/CMake/config/prerm.in
+++ b/src/CMake/config/prerm.in
@@ -57,7 +57,7 @@ rm -rf /etc/systemd/system/msd.service
 rm -rf /etc/systemd/system/mpd.service
 systemctl daemon-reload
 # Remove config file for MSD as well
-@@CMAKE_INSTALL_PREFIX@@/xrt/bin/xbmgmt --legacy config --purge 2>&1 > /dev/null
+@CMAKE_INSTALL_PREFIX@/xrt/bin/xbmgmt --legacy config --purge 2>&1 > /dev/null
 
 echo "Unloading old XRT Linux kernel modules"
 rmmod xocl
@@ -79,7 +79,7 @@ rm -f /etc/dracut.conf.d/xocl.dracut.conf
 rm -f /etc/dracut.conf.d/xclmgmt.dracut.conf
 
 echo "Cleaning up python..."
-rm -f @@CMAKE_INSTALL_PREFIX@@/xrt/python/*.pyc
-rm -f @@CMAKE_INSTALL_PREFIX@@/xrt/test/*.pyc
+rm -f @CMAKE_INSTALL_PREFIX@/xrt/python/*.pyc
+rm -f @CMAKE_INSTALL_PREFIX@/xrt/test/*.pyc
 
 exit 0


### PR DESCRIPTION
This was introduced with commit
2b870279f68f7f2b3d08315b7269acbdc1c6033c from
https://github.com/Xilinx/XRT/pull/8008