### PR TITLE
Fix on xocl driver crash during hwmon init on RAVE platform -  CR-1195545

### DIFF
--- a/src/runtime_src/core/include/xclfeatures.h
+++ b/src/runtime_src/core/include/xclfeatures.h
@@ -123,6 +123,7 @@ struct VmrStatus {
 	uint16_t boot_on_default; // 1 If the VMR device is currently running on its "A" or default image
 	uint16_t boot_on_backup; // 1 If the VMR device is currently running on its "B" or backup image
 	uint16_t boot_on_recovery; // 1 If the VMR device is currently running on its recovery image
+	uint16_t sc_is_ready; // 1 If the SC is Ready
 };
 
 #endif // xclfeatures_h_

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
@@ -1238,6 +1238,7 @@ static int xgq_status(struct platform_device *pdev, struct VmrStatus *vmr_status
 	vmr_status_ptr->boot_on_backup = vmr_status->boot_on_backup;
 	vmr_status_ptr->boot_on_recovery = vmr_status->boot_on_recovery;
 	vmr_status_ptr->has_fpt = vmr_status->has_fpt;
+	vmr_status_ptr->sc_is_ready = vmr_status->sc_is_ready;
 
 	return 0;
 }

--- a/src/runtime_src/core/tools/xbmgmt2/OO_UpdateBase.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_UpdateBase.cpp
@@ -617,7 +617,7 @@ find_flash_image_paths(const std::vector<std::string>& image_list)
   for (const auto& img : image_list) {
     // Check if the passed in image is absolute path
     if (std::filesystem::is_regular_file(img)){
-      if (std::filesystem::path(img).extension() == ".xsabin") {
+      if (std::filesystem::path(img).extension() != ".xsabin") {
         std::cout << "Warning: Non-xsabin file detected. Development usage, this may damage the card\n";
         if (!XBU::can_proceed(XBU::getForce()))
           throw xrt_core::error(std::errc::operation_canceled);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
RAVE Platform does not has VMC and hence management driver does not create subdev for hwmon. This is done by verifyingis the paltform has SC. This validation is not handled in xocl driver and with recent changes if xocl driver tries to init hwmon sensor indormation from xclmgmt dev through mailbox, crash occurs.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Fixed to skip hwmon subdev creation is SC is not present.
#### How problem was solved, alternative solutions (if any) and why they were rejected
Fixed to skip hwmon subdev creation is SC is not present.
#### Risks (if any) associated the changes in the commit
Facing a permission denied issue while running xbutil examine command. working on it.
#### What has been tested and how, request additional testing if necessary
Loaded xclmgmt and xocl drivers to verify crash does not occur. verify examine commands and sysfs nodes on both RAVE and v70 platform.
#### Documentation impact (if any)
N/A