### PR TITLE
Fix for xbutil error for Aie status reports of core, shim and mem tiles.

### DIFF
--- a/src/runtime_src/core/common/info_aie.cpp
+++ b/src/runtime_src/core/common/info_aie.cpp
@@ -424,7 +424,7 @@ populate_aie_mem(const xrt_core::device* device, const std::string& desc)
 
     // Populate the mem tile information such as dma, lock, error, events
     // for each tiles.
-    for (const auto& am: pt_mem.get_child("aie_mem")) {
+    for (const auto& am : pt_mem.get_child("aie_mem")) {
       const boost::property_tree::ptree& imem = am.second;
       boost::property_tree::ptree omem;
       int col = imem.get<uint32_t>("col");
@@ -456,10 +456,10 @@ populate_aie_mem(const xrt_core::device* device, const std::string& desc)
     }
 
     pt.add_child("tiles", tile_array);
-
+    
   }
   catch (const std::exception& ex) {
-    pt.put("error_msg", (boost::format("%s %s") % ex.what() % "found in the AIE shim"));
+    pt.put("error_msg", (boost::format("%s %s") % ex.what() % "found in the AIE mem"));
   }
 
   return pt;

--- a/src/runtime_src/core/edge/user/device_linux.cpp
+++ b/src/runtime_src/core/edge/user/device_linux.cpp
@@ -138,6 +138,8 @@ struct dev_info
     }
     case key_type::rom_time_since_epoch:
       return static_cast<uint64_t>(deviceInfo.mTimeStamp);
+    case key_type::device_class:
+            return xrt_core::query::device_class::type::alveo;
     default:
       throw query::no_such_key(key);
     }
@@ -265,8 +267,6 @@ struct aie_mem_info_sysfs
     aie_metadata_info aie_meta = get_aie_metadata_info(device);
     const std::string aiepart = std::to_string(aie_meta.shim_row) + "_" + std::to_string(aie_meta.num_cols);
 
-    ptarray.put("hw_gen",std::to_string(aie_meta.hw_gen));
-
     /* Loop all mem tiles and collect all dma, events, errors, locks status */
     for (int i = 0; i < aie_meta.num_cols; ++i)
       for (int j = 0; j < (aie_meta.num_mem_row-1); ++j)
@@ -275,6 +275,7 @@ struct aie_mem_info_sysfs
 
     boost::property_tree::ptree pt;
     pt.add_child("aie_mem",ptarray);
+    pt.put("hw_gen",std::to_string(aie_meta.hw_gen));
     std::ostringstream oss;
     boost::property_tree::write_json(oss, pt);
     std::string inifile_text = oss.str();
@@ -999,6 +1000,7 @@ initialize_query_table()
   emplace_func0_request<query::rom_time_since_epoch,    dev_info>();
 
   emplace_func0_request<query::clock_freqs_mhz,         dev_info>();
+  emplace_func0_request<query::device_class,            dev_info>();
   emplace_func0_request<query::aie_core_info_sysfs,     aie_core_info_sysfs>();
   emplace_func0_request<query::aie_shim_info_sysfs,     aie_shim_info_sysfs>();
   emplace_func0_request<query::aie_mem_info_sysfs,      aie_mem_info_sysfs>();

--- a/src/runtime_src/core/tools/xbutil2/xbutil.cpp
+++ b/src/runtime_src/core/tools/xbutil2/xbutil.cpp
@@ -32,7 +32,7 @@ R"(
 [{
   "alveo": [{
     "examine": [{
-      "report": ["dynamic-regions", "electrical", "host", "mechanical", "memory", "pcie-info", "platform", "thermal", "error", "firewall", "mailbox", "debug-ip-status", "qspi-status"]
+      "report": ["dynamic-regions", "electrical", "host", "mechanical", "memory", "pcie-info", "platform", "thermal", "error", "firewall", "mailbox", "debug-ip-status", "qspi-status", "aie", "aiemem", "aieshim"]
     }]
   },{
     "configure": [{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
This PR resolves following CRs:
[CR-1192771](https://jira.xilinx.com/browse/CR-1192771)
[CR-1178746](https://jira.xilinx.com/browse/CR-1178746)
[CR-1178785](https://jira.xilinx.com/browse/CR-1178785)
[CR-1178294](https://jira.xilinx.com/browse/CR-1178294)
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
VITIS-11100 Display all AIE columns: https://github.com/Xilinx/XRT/pull/8015
#### How problem was solved, alternative solutions (if any) and why they were rejected
Device class query was added for edge to resolve [CR-1192771](https://jira.xilinx.com/browse/CR-1192771)
For mem tile status, aie_mem ptree was getting filled incorrectly so the same has now been changed.
#### Risks (if any) associated the changes in the commit
Low
#### What has been tested and how, request additional testing if necessary
Verified aie reports for core, shim and mem tiles on vek280
#### Documentation impact (if any)
NA