### PR TITLE
Defining Mailbox Macro for QDMA to fix APU crash on RAVE

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/Makefile
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/Makefile
@@ -120,7 +120,7 @@ PWD	:= $(shell pwd)
 ROOT	:= $(dir $(M))
 XILINXINCLUDE := -I$(ROOT) -I$(ROOT)/../include -I$(ROOT)/../../../../include -I$(ROOT)/../../../../common/drv/include
 
-ccflags-y += $(XILINXINCLUDE) -DPF=USERPF -D__XRT__
+ccflags-y += $(XILINXINCLUDE) -DPF=USERPF -D__XRT__ -DMBOX_INTERRUPT_DISABLE
 ifeq ($(DEBUG),1)
 ccflags-y += -DDEBUG
 endif


### PR DESCRIPTION
    QDMA blindly registers intr for mailbox even if its disabled on the hw.
    NOTE: this is a workaround to move forward with this https://jira.xilinx.com/browse/CR-1193112
    Once QDMA fixes the issue this commit should be reverted

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1193112
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
It avoids QDMA to not register intr for mailbox blindly
#### Risks (if any) associated the changes in the commit
none
#### What has been tested and how, request additional testing if necessary
Tested on RAVE and V70 with "xbutil validate -d"
#### Documentation impact (if any)
none