### PR TITLE
SC warning fix on RAVE and xsabin extension warning fix on Versal

### DIFF
--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -384,7 +384,7 @@ XBUtilities::collect_devices( const std::set<std::string> &_deviceBDFs,
       auto exp_ver = xrt_core::device_query_default<xrt_core::query::hwmon_sdm_target_msp_ver>(device, unavail);
       cur_ver = (boost::equals(cur_ver, zeroes)) ? unavail : cur_ver;
       exp_ver = (boost::equals(exp_ver, zeroes)) ? unavail : exp_ver;
-      if (boost::equals(cur_ver, unavail) || boost::equals(exp_ver, unavail))
+      if ((boost::equals(cur_ver, unavail) || boost::equals(exp_ver, unavail)) && !boost::equals(cur_ver, exp_ver))
         warnings.push_back("SC version data missing. Upgrade your shell");
       else if (!boost::equals(cur_ver, exp_ver))
         warnings.push_back(boost::str(boost::format("Invalid SC version. Expected: %s Current: %s") % exp_ver % cur_ver));

--- a/src/runtime_src/core/tools/xbmgmt2/OO_UpdateBase.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_UpdateBase.cpp
@@ -617,7 +617,7 @@ find_flash_image_paths(const std::vector<std::string>& image_list)
   for (const auto& img : image_list) {
     // Check if the passed in image is absolute path
     if (std::filesystem::is_regular_file(img)){
-      if (std::filesystem::path(img).extension() == ".xsabin") {
+      if (std::filesystem::path(img).extension() != ".xsabin") {
         std::cout << "Warning: Non-xsabin file detected. Development usage, this may damage the card\n";
         if (!XBU::can_proceed(XBU::getForce()))
           throw xrt_core::error(std::errc::operation_canceled);


### PR DESCRIPTION
On rave we dont have SC. Added extra checks to handle unnecessary warnings. Updated the checks to check the xsabin extension for the flash images

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
SC warning on RAVE(CR-1193872) and xsabin extension warning on Versal (CR-1195412)
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit
None
#### What has been tested and how, request additional testing if necessary
Tested with "xbutil command_name" and "xbmgmt command_name" on both RAVE & V70
#### Documentation impact (if any)
None