### PR TITLE
VITIS-11503 - change elf section name from mc_code to control-packet

### DIFF
--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -809,10 +809,7 @@ class module_sram : public module_impl
     fill_instr_buf(m_instr_buf, data);
 
     if (m_ctrlpkt_buf) {
-      // The current assembler uses "mc_code" to represent control-packet
-      // buffer. We should change the name to "control-packet" which is not
-      // DPU specific. Will change this once assembler fix it.
-      patch_instr("mc_code", m_ctrlpkt_buf);
+      patch_instr("control-packet", m_ctrlpkt_buf);
       XRT_PRINTF("<- module_sram::create_instr_buf()\n");
     }
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Section name mc_code is specific for dpu-sequence. In order to make it generic so that it also supports transaction-buffer,
change the name to control-packet according to specification (https://confluence.amd.com/display/AIE/IPU+Execution+Buffer+ELF+Specification#IPUExecutionBufferELFSpecification-ResolvesymbolswithELF)
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
