### PR TITLE
Client AIE improvements

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_debug/aie_debug_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_debug/aie_debug_plugin.cpp
@@ -115,7 +115,7 @@ namespace xdp {
     
       std::vector<tile_type> tiles;
       if (type == module_type::shim) {
-        tiles = metadataReader->getInterfaceTiles("all", "all", "", -1);
+        tiles = metadataReader->getInterfaceTiles("all", "all", "input_output");
       } else {
         tiles = metadataReader->getTiles("all", type, "all");
       }

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_metadata.cpp
@@ -469,6 +469,8 @@ namespace xdp {
           tile_type tile;
           tile.col = col;
           tile.row = row;
+          tile.active_core   = true;
+          tile.active_memory = true;
 
           // Make sure tile is used
           if (allValidTiles.find(tile) == allValidTiles.end()) {
@@ -520,6 +522,8 @@ namespace xdp {
       tile_type tile;
       tile.col = col;
       tile.row = row;
+      tile.active_core   = true;
+      tile.active_memory = true;
 
       // Make sure tile is used
       if (allValidTiles.find(tile) == allValidTiles.end()) {

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/client/aie_profile.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/client/aie_profile.cpp
@@ -133,7 +133,7 @@ namespace xdp {
         auto col  = tile.col;
         auto subtype = tile.subtype;
         auto type = aie::getModuleType(row, metadata->getAIETileRowOffset());
-
+        
         // Ignore invalid types and inactive modules
         // NOTE: Inactive core modules are configured when utilizing
         //       stream switch monitor ports to profile DMA channels

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/client/aie_profile.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/client/aie_profile.cpp
@@ -127,16 +127,25 @@ namespace xdp {
       for (auto& tileMetric : metadata->getConfigMetrics(module)) {
         int numCounters  = 0;
 
+        auto& metricSet  = tileMetric.second;
         auto tile = tileMetric.first;
         auto row  = tile.row;
         auto col  = tile.col;
         auto subtype = tile.subtype;
         auto type = aie::getModuleType(row, metadata->getAIETileRowOffset());
 
+        // Ignore invalid types and inactive modules
+        // NOTE: Inactive core modules are configured when utilizing
+        //       stream switch monitor ports to profile DMA channels
         if (!aie::profile::isValidType(type, mod))
           continue;
+        if ((type == module_type::dma) && !tile.active_memory)
+          continue;
+        if ((type == module_type::core) && !tile.active_core) {
+          if (metadata->getPairModuleIndex(metricSet, type) < 0)
+            continue;
+        }
 
-        auto& metricSet  = tileMetric.second;
         auto loc         = XAie_TileLoc(col, row);
         auto startEvents = (type  == module_type::core) ? coreStartEvents[metricSet]
                          : ((type == module_type::dma)  ? memoryStartEvents[metricSet]

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_metadata.cpp
@@ -515,6 +515,8 @@ namespace xdp {
           tile_type tile;
           tile.col = col;
           tile.row = row;
+          tile.active_core   = true;
+          tile.active_memory = true;
 
           // Make sure tile is used
           if (allValidTiles.find(tile) == allValidTiles.end()) {
@@ -564,6 +566,8 @@ namespace xdp {
       tile_type tile;
       tile.col = col;
       tile.row = row;
+      tile.active_core   = true;
+      tile.active_memory = true;
 
       // Make sure tile is used
       if (allValidTiles.find(tile) == allValidTiles.end()) {

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/client/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/client/aie_trace.cpp
@@ -579,7 +579,7 @@ namespace xdp {
           // Record for runtime config file
           config.port_trace_ids[portnum] = channel;
           config.port_trace_is_master[portnum] = (tile.is_master != 0);
-
+          
           if (tile.is_master == 0)
             config.mm2s_channels[channelNum] = channel;
           else


### PR DESCRIPTION
#### Problem solved by the commit
* Not properly filtering tiles in profiling on clients
* Runtime config is not correct sometimes
* Not reporting active_core/memory flags on clients

#### How problem was solved, alternative solutions (if any) and why they were rejected
* Filter AIE tiles in profiling based on active core/memory modules
* Correct runtime config
* Report active_core/memory flags on clients

#### Risks (if any) associated the changes in the commit
* Limited test suite on clients

#### What has been tested and how, request additional testing if necessary
* Tested on clients

#### Documentation impact (if any)
* Core-only and DMA-only tiles may look different in trace view