### PR TITLE
Cleanup clang-tidy warnings

### DIFF
--- a/src/runtime_src/core/common/api/aie/xrt_graph.cpp
+++ b/src/runtime_src/core/common/api/aie/xrt_graph.cpp
@@ -43,7 +43,13 @@ public:
     device->close_graph(handle);
   }
 
-  xclGraphHandle
+  graph_impl() = delete;
+  graph_impl(const graph_impl&) = delete;
+  graph_impl(graph_impl&&) = delete;
+  graph_impl& operator=(const graph_impl&) = delete;
+  graph_impl& operator=(graph_impl&&) = delete;
+
+  [[nodiscard]] xclGraphHandle
   get_handle() const
   {
     return handle;
@@ -112,7 +118,7 @@ public:
 
 }
 
-namespace xrt { namespace aie {
+namespace xrt::aie {
 
 class profiling_impl
 {
@@ -124,7 +130,7 @@ public:
   using handle = int;
   static constexpr handle invalid_handle = -1;
 
-  profiling_impl(std::shared_ptr<xrt_core::device> dev)
+  explicit profiling_impl(std::shared_ptr<xrt_core::device> dev)
     : device(std::move(dev)),
       profiling_hdl(invalid_handle)
   {}
@@ -138,6 +144,13 @@ public:
       // do nothing
     }
   }
+
+  profiling_impl() = delete;
+  profiling_impl(const profiling_impl&) = delete;
+  profiling_impl(profiling_impl&&) = delete;
+  profiling_impl& operator=(const profiling_impl&) = delete;
+  profiling_impl& operator=(profiling_impl&&) = delete;
+  
 
   handle
   start_profiling(int option, const std::string& port1_name, const std::string& port2_name, uint32_t value)
@@ -168,7 +181,7 @@ public:
 
 };
 
-}}
+} // xrt::aie
 
 namespace {
 
@@ -380,7 +393,7 @@ read_port(const std::string& port_name, void* value, size_t bytes)
 ////////////////////////////////////////////////////////////////
 // xrt_aie_profiling C++ API implmentations (xrt_aie.h)
 ////////////////////////////////////////////////////////////////
-namespace xrt { namespace aie {
+namespace xrt::aie {
 
 profiling::
 profiling(const xrt::device& device)
@@ -415,7 +428,7 @@ stop() const
   });
 }
 
-}} //namespace aie, xrt
+} // xrt:aie
 
 ////////////////////////////////////////////////////////////////
 // xrt_aie API implementations (xrt_aie.h, xrt_graph.h)

--- a/src/runtime_src/core/common/api/hw_queue.cpp
+++ b/src/runtime_src/core/common/api/hw_queue.cpp
@@ -107,7 +107,6 @@ private:
   std::mutex work_mutex;
   std::condition_variable work_cond;
   command_queue_type submitted_cmds;
-  uint64_t exec_wait_call_count = 0;
   bool stop = false;
 
   // thread can be constructed only after data members are initialized
@@ -126,7 +125,7 @@ private:
     std::vector<xrt_core::command*> busy_cmds;
     std::vector<xrt_core::command*> running_cmds;
 
-    while (1) {
+    while (true) {
 
       // Larger wait synchronized with launch()
       {
@@ -197,7 +196,7 @@ private:
 
 public:
   // Constructor starts monitor thread
-  command_manager(executor* impl)
+  explicit command_manager(executor* impl)
     : m_impl(impl), monitor_thread(xrt_core::thread(&command_manager::monitor, this))
   {
     XRT_DEBUGF("command_manager::command_manager(0x%x)\n", impl);
@@ -217,6 +216,12 @@ public:
     }
     monitor_thread.join();
   }
+
+  command_manager() = delete;
+  command_manager(const command_manager&) = delete;
+  command_manager(command_manager&&) = delete;
+  command_manager& operator=(const command_manager&) = delete;
+  command_manager& operator=(command_manager&&) = delete;
 
   void
   clear_executor()
@@ -349,13 +354,18 @@ public:
     }
   }
 
+  hw_queue_impl(const hw_queue_impl&) = delete;
+  hw_queue_impl(hw_queue_impl&&) = delete;
+  hw_queue_impl& operator=(const hw_queue_impl&) = delete;
+  hw_queue_impl& operator=(hw_queue_impl&&) = delete;
+
   // Submit command for execution
   virtual void
-  submit(xrt_core::command* cmd) = 0;
+  submit(xrt_core::command* cmd) = 0;  // NOLINT override from base
 
   // Wait for some command to finish
   virtual std::cv_status
-  wait(size_t timeout_ms) = 0;
+  wait(size_t timeout_ms) = 0;         // NOLINT override from base
 
   // Wait for specified command to finish
   virtual std::cv_status
@@ -428,7 +438,7 @@ public:
     // notify_host is not strictly necessary for unmanaged
     // command execution but provides a central place to update
     // and mark commands as done so they can be re-executed.
-    notify_host(const_cast<xrt_core::command*>(cmd), static_cast<ert_cmd_state>(pkt->state));
+    notify_host(const_cast<xrt_core::command*>(cmd), static_cast<ert_cmd_state>(pkt->state)); // NOLINT
 
     return std::cv_status::no_timeout;
   }
@@ -514,18 +524,20 @@ class kds_device : public hw_queue_impl
         // Some other thread is calling device::exec_wait, wait
         // for it complete its work and notify this thread
         auto status = std::cv_status::no_timeout;
-        if (timeout_ms)
+        if (timeout_ms) {
           status = (m_work.wait_for(lk, timeout_ms * 1ms,
                                     [this] {
                                       return thread_exec_wait_call_count != m_exec_wait_call_count;
                                     }))
             ? std::cv_status::no_timeout
             : std::cv_status::timeout;
-        else
+        }
+        else {
           m_work.wait(lk,
                       [this] {
                         return thread_exec_wait_call_count != m_exec_wait_call_count;
                       });
+        }
 
         // The other thread has completed its exec_wait call,
         // sync with current global call count and return
@@ -555,7 +567,8 @@ class kds_device : public hw_queue_impl
     }
     else {
       // wait for ever for some command to complete
-      while (m_device->exec_wait(1000) == 0) {}
+      constexpr size_t default_timeout = 1000;
+      while (m_device->exec_wait(default_timeout) == 0) {}
     }
 
     // Acquire lock before updating shared state
@@ -573,7 +586,7 @@ class kds_device : public hw_queue_impl
   }
 
 public:
-  kds_device(xrt_core::device* device)
+  explicit kds_device(xrt_core::device* device)
     : m_device(device)
   {}
 
@@ -596,7 +609,7 @@ public:
     // notify_host is not strictly necessary for unmanaged
     // command execution but provides a central place to update
     // and mark commands as done so they can be re-executed.
-    notify_host(const_cast<xrt_core::command*>(cmd), static_cast<ert_cmd_state>(pkt->state));
+    notify_host(const_cast<xrt_core::command*>(cmd), static_cast<ert_cmd_state>(pkt->state)); // NOLINT
 
     return std::cv_status::no_timeout;
   }
@@ -651,7 +664,7 @@ exiting()
   return lights_out;
 }
 
-struct uninit
+struct uninit // NOLINT
 {
   ~uninit() { exiting() = true; }
 };
@@ -668,7 +681,7 @@ get_kds_device_nolock(hwc2hwq_type& queues, const xrt_core::device* device)
   auto hwqimpl = queues[nullptr].lock();
   if (!hwqimpl)
     queues[nullptr] = hwqimpl =
-      queue_ptr{new xrt_core::kds_device(const_cast<xrt_core::device*>(device))};
+      queue_ptr{new xrt_core::kds_device(const_cast<xrt_core::device*>(device))}; // NOLINT
 
   return hwqimpl;
 }

--- a/src/runtime_src/core/common/api/native_profile.h
+++ b/src/runtime_src/core/common/api/native_profile.h
@@ -54,9 +54,9 @@ profiling_wrapper(const char* function, Callable&& f, Args&&...args)
   if (xrt_core::config::get_native_xrt_trace()
       || xrt_core::config::get_host_trace()) {
     generic_api_call_logger log_object(function) ;
-    return f(std::forward<Args>(args)...) ;
+    return f(std::forward<Args>(args)...) ;  // NOLINT, clang-tidy false positive [potential leak]
   }
-  return f(std::forward<Args>(args)...) ;
+  return f(std::forward<Args>(args)...) ;    // NOLINT, clang-tidy false positive [potential leak]
 }
 
 // Specializations of the logger for capturing different information

--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -124,37 +124,36 @@ class device_type
   xrt::hw_context m_hwctx;
   std::shared_ptr<xrt_core::device> m_device;
 public:
-  device_type()
-  {}
+  device_type() = default;
 
-  device_type(std::shared_ptr<xrt_core::device> device)
+  device_type(std::shared_ptr<xrt_core::device> device) // NOLINT converting ctor
     : m_device(std::move(device))
   {}
 
-  device_type(xrt::hw_context hwctx)
+  device_type(xrt::hw_context hwctx)  // NOLINT converting ctor
     : m_hwctx(std::move(hwctx))
     , m_device(xrt_core::hw_context_int::get_core_device(m_hwctx))
   {}
 
-  bool
+  [[nodiscard]] bool
   is_valid_hwctx() const
   {
     return static_cast<xrt_core::hwctx_handle*>(m_hwctx) != nullptr;
   }
 
-  const xrt_core::device*
+  [[nodiscard]] const xrt_core::device*
   get_core_device() const
   {
     return m_device.get();
   }
 
-  const std::shared_ptr<xrt_core::device>&
+  [[nodiscard]] const std::shared_ptr<xrt_core::device>&
   get_device() const
   {
     return m_device;
   }
 
-  xrt_core::hwctx_handle*
+  [[nodiscard]] xrt_core::hwctx_handle*
   get_hwctx_handle() const
   {
     return (m_hwctx)
@@ -226,7 +225,7 @@ protected:
   mutable uint64_t addr = no_addr;                 // NOLINT bo device address
   mutable uint32_t grpid = no_group;               // NOLINT memory group index
   mutable bo::flags flags = no_flags;              // NOLINT flags per bo properties
-  mutable std::unique_ptr<xrt_core::shared_handle> shared_handle;
+  mutable std::unique_ptr<xrt_core::shared_handle> shared_handle; // NOLINT
 
 public:
   // No handle
@@ -277,9 +276,7 @@ public:
     , size(sz)
   {}
 
-  virtual
-  ~bo_impl()
-  {}
+  virtual ~bo_impl() = default;
 
   bo_impl(const bo_impl&) = delete;
   bo_impl(bo_impl&&) = delete;
@@ -512,9 +509,17 @@ public:
 
 public:
   // async_bo_impl() - Construct async_bo_obj
-  async_handle_impl(xrt::bo bo)
+  explicit async_handle_impl(xrt::bo bo)
     : m_bo(std::move(bo))
   {}
+
+  virtual ~async_handle_impl() = default;
+
+  async_handle_impl() = delete;
+  async_handle_impl(const async_handle_impl&) = delete;
+  async_handle_impl(async_handle_impl&&) = delete;
+  async_handle_impl& operator=(const async_handle_impl&) = delete;
+  async_handle_impl& operator=(async_handle_impl&&) = delete;
 
   // wait() - Wait for async to complete
   virtual void
@@ -1132,11 +1137,11 @@ alloc(const device_type& device, size_t sz, xrtBufferFlags flags, xrtMemoryGroup
 #ifndef XRT_EDGE
     if (is_nodma(device.get_core_device()))
       return alloc_nodma(device, sz, flags, grp);
-    else if (is_sw_emulation())
+    else if (is_sw_emulation()) // NOLINT hicpp-braces-around-statements
       // In DC scenario, for sw_emu, use the xclAllocBO and xclMapBO instead of xclAllocUserPtrBO,
       // which helps to remove the extra copy in sw_emu.
       return alloc_kbuf(device, sz, flags, grp);
-    else
+    else  // NOLINT hicpp-braces-around-statements
       return alloc_hbuf(device, xrt_core::aligned_alloc(get_alignment(), sz), sz, flags, grp);
 #endif
   case XCL_BO_FLAGS_CACHEABLE:
@@ -1263,7 +1268,7 @@ adjust_buffer_flags(const device_type& dev, xrt::bo::flags flags, xrt::memory_gr
 ////////////////////////////////////////////////////////////////
 // xrt_bo implementation of extension APIs not exposed to end-user
 ////////////////////////////////////////////////////////////////
-namespace xrt_core { namespace bo {
+namespace xrt_core::bo {
 
 uint64_t
 address(const xrt::bo& bo)
@@ -1320,7 +1325,7 @@ alignment()
   return ::get_alignment();
 }
 
-}} // namespace bo, xrt_core
+} // xrt_core::bo
 
 
 ////////////////////////////////////////////////////////////////
@@ -1691,7 +1696,7 @@ create_debug_bo(const xrt::hw_context& hwctx, size_t sz)
 ////////////////////////////////////////////////////////////////
 // xrt_aie_bo C++ API implmentations (xrt_aie.h)
 ////////////////////////////////////////////////////////////////
-namespace xrt { namespace aie {
+namespace xrt::aie {
 
 xrt::bo::async_handle
 bo::
@@ -1707,7 +1712,7 @@ sync(const std::string& port, xclBOSyncDirection dir, size_t sz, size_t offset)
   get_handle()->sync(*this, port, dir, sz, offset);
 }
 
-}} // namespace aie, xrt
+} // namespace xrt::aie
 #endif
 
 ////////////////////////////////////////////////////////////////

--- a/src/runtime_src/core/common/api/xrt_device.cpp
+++ b/src/runtime_src/core/common/api/xrt_device.cpp
@@ -201,7 +201,7 @@ get_info(const xrt_core::device* device, xrt::info::device param, const xrt::det
 
 } // unnamed namespace
 
-namespace xrt_core { namespace device_int {
+namespace xrt_core::device_int {
 
 std::shared_ptr<xrt_core::device>
 get_core_device(xrtDeviceHandle dhdl)
@@ -222,7 +222,7 @@ exec_wait(const xrt::device& device, const std::chrono::milliseconds& timeout_ms
   return xrt_core::hw_queue::exec_wait(device.get_handle().get(), timeout_ms);
 }
 
-}} // device_int, xrt_core
+} // xrt_core::device_int
 
 namespace xrt {
 
@@ -378,7 +378,7 @@ operator== (const device& d1, const device& d2)
 ////////////////////////////////////////////////////////////////
 // xrt_aie_device C++ API implmentations (xrt_aie.h)
 ////////////////////////////////////////////////////////////////
-namespace xrt { namespace aie {
+namespace xrt::aie {
 
 void
 device::
@@ -396,7 +396,7 @@ open_context(xrt::aie::device::access_mode am)
   core_device->open_aie_context(am);
 }
 
-}} // namespace aie, xrt
+} // xrt::aie
 #endif
 
 ////////////////////////////////////////////////////////////////

--- a/src/runtime_src/core/common/api/xrt_elf.cpp
+++ b/src/runtime_src/core/common/api/xrt_elf.cpp
@@ -22,25 +22,25 @@ class elf_impl
 {
   ELFIO::elfio m_elf;
 public:
-  elf_impl(const std::string& fnm)
+  explicit elf_impl(const std::string& fnm)
   {
     if (!m_elf.load(fnm))
       throw std::runtime_error(fnm + " is not found or is not a valid ELF file");
   }
 
-  elf_impl(std::istream& stream)
+  explicit elf_impl(std::istream& stream)
   {
     if (!m_elf.load(stream))
       throw std::runtime_error("not a valid ELF stream");
   }
 
-  const ELFIO::elfio&
+  [[nodiscard]] const ELFIO::elfio&
   get_elfio() const
   {
     return m_elf;
   }
 
-  xrt::uuid
+  [[nodiscard]] xrt::uuid
   get_cfg_uuid() const
   {
     return {}; // tbd

--- a/src/runtime_src/core/common/api/xrt_error.cpp
+++ b/src/runtime_src/core/common/api/xrt_error.cpp
@@ -185,7 +185,7 @@ alloc_error_from_code(xrtErrorCode ecode, xrtErrorTime timestamp)
 
 } // namespace
 
-namespace xrt_core { namespace error_int {
+namespace xrt_core::error_int {
 
 void
 get_error_code_to_json(xrtErrorCode ecode, boost::property_tree::ptree &pt)
@@ -193,7 +193,7 @@ get_error_code_to_json(xrtErrorCode ecode, boost::property_tree::ptree &pt)
   return error_code_to_json(ecode, pt);
 }
 
-}} // namespace error_int, xrt_core
+} // xrt_core::error_int
 
 namespace xrt {
 
@@ -236,13 +236,13 @@ public:
     : m_errcode(ecode), m_timestamp(timestamp)
   {}
 
-  xrtErrorCode
+  [[nodiscard]] xrtErrorCode
   get_error_code() const
   {
     return m_errcode;
   }
 
-  xrtErrorTime
+  [[nodiscard]] xrtErrorTime
   get_timestamp() const
   {
     return m_timestamp;

--- a/src/runtime_src/core/common/api/xrt_fence.cpp
+++ b/src/runtime_src/core/common/api/xrt_fence.cpp
@@ -33,7 +33,7 @@ public:
     , m_access(access)
   {}
 
-  fence_impl(std::unique_ptr<xrt_core::fence_handle> fhdl)
+  explicit fence_impl(std::unique_ptr<xrt_core::fence_handle> fhdl)
     : m_handle(std::move(fhdl))
   {}
 
@@ -46,6 +46,13 @@ public:
     : m_handle(other.m_handle->clone())
     , m_access(other.m_access)
   {}
+
+  ~fence_impl() = default;
+  
+  fence_impl() = delete;
+  fence_impl(fence_impl&&) = delete;
+  fence_impl& operator=(const fence_impl&) = delete;
+  fence_impl& operator=(fence_impl&&) = delete;
 
   fence::export_handle
   export_fence()
@@ -63,19 +70,19 @@ public:
     return std::cv_status::no_timeout; // TBD
   }
 
-  xrt_core::fence_handle*
+  [[nodiscard]] xrt_core::fence_handle*
   get_fence_handle() const
   {
     return m_handle.get();
   }
 
-  xrt::fence::access_mode
+  [[nodiscard]] xrt::fence::access_mode
   get_access_mode() const 
   {
     return m_access;
   }
 
-  uint64_t
+  [[nodiscard]] uint64_t
   get_next_state() const
   {
     return m_handle->get_next_state();

--- a/src/runtime_src/core/common/api/xrt_ini.cpp
+++ b/src/runtime_src/core/common/api/xrt_ini.cpp
@@ -24,7 +24,7 @@
 #include "core/common/config_reader.h"
 #include "core/common/error.h"
 
-namespace xrt { namespace ini {
+namespace xrt::ini {
 
 void
 set(const std::string& key, const std::string& value)
@@ -32,7 +32,7 @@ set(const std::string& key, const std::string& value)
   xrt_core::config::detail::set(key, value);
 }
 
-}} // namespace ini,xrt
+} // namespace xrt::ini
 
 ////////////////////////////////////////////////////////////////
 // xrt_ini C API implmentations (xrt_ini.h)

--- a/src/runtime_src/core/common/api/xrt_ip.cpp
+++ b/src/runtime_src/core/common/api/xrt_ip.cpp
@@ -115,7 +115,7 @@ public:
     enable(); // re-enable interrupts
   }
 
-  std::cv_status
+  [[nodiscard]] std::cv_status
   wait(const std::chrono::milliseconds& timeout) const
   {
     // Waits for interrupt, or return on timeout
@@ -144,6 +144,7 @@ class ip_impl
     ip_context(xrt::hw_context xhwctx, const std::string& nm)
       : m_device(xrt_core::hw_context_int::get_core_device(xhwctx))
       , m_hwctx(std::move(xhwctx))
+      , m_idx{0} // intialized in ctor
     {
       auto xclbin = m_hwctx.get_xclbin();
 
@@ -188,19 +189,19 @@ class ip_impl
     ip_context& operator=(ip_context&) = delete;
     ip_context& operator=(ip_context&&) = delete;
 
-    unsigned int
+    [[nodiscard]] unsigned int
     get_idx() const
     {
       return m_idx.index;
     }
 
-    uint64_t
+    [[nodiscard]] uint64_t
     get_address() const
     {
       return m_ip.get_base_address();
     }
 
-    uint64_t
+    [[nodiscard]] uint64_t
     get_size() const
     {
       return m_size;
@@ -214,7 +215,7 @@ class ip_impl
     }
   };
 
-  unsigned int
+  [[nodiscard]] unsigned int
   get_cuidx_or_error(size_t offset) const
   {
     if ((offset + sizeof(uint32_t)) > m_ipctx.get_size())
@@ -268,7 +269,7 @@ public:
   ip_impl& operator=(ip_impl&) = delete;
   ip_impl& operator=(ip_impl&&) = delete;
 
-  uint32_t
+  [[nodiscard]] uint32_t
   read_register(uint32_t offset) const
   {
     auto idx = get_cuidx_or_error(offset);

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -237,31 +237,31 @@ public:
     , words(validate_bytes(bytes) / sizeof(ValueType))
   {}
 
-  const ValueType*
+  [[nodiscard]] const ValueType*
   begin() const
   {
     return uval;
   }
 
-  const ValueType*
+  [[nodiscard]] const ValueType*
   end() const
   {
     return uval + words;
   }
 
-  size_t
+  [[nodiscard]] size_t
   size() const
   {
     return words;
   }
 
-  size_t
+  [[nodiscard]] size_t
   bytes() const
   {
     return words * sizeof(ValueType);
   }
 
-  const ValueType*
+  [[nodiscard]] const ValueType*
   data() const
   {
     return uval;
@@ -276,7 +276,7 @@ to_uint64_t(ValueType value)
 {
   uint64_t ret = 0;
   auto data = reinterpret_cast<uint8_t*>(&ret);
-  arg_range<uint8_t> range{&value, sizeof(ValueType)};
+  arg_range<uint8_t> range{&value, sizeof(ValueType)}; // NOLINT
   std::copy_n(range.begin(), std::min<size_t>(sizeof(ret), range.size()), data);
   return ret;
 }
@@ -398,13 +398,13 @@ struct device_type
     return exec_buffer_cache.alloc<CommandType>();
   }
 
-  xrt_core::device*
+  [[nodiscard]] xrt_core::device*
   get_core_device() const
   {
     return core_device.get();
   }
 
-  xrt::device
+  [[nodiscard]] xrt::device
   get_xrt_device() const
   {
     return xrt::device{core_device};
@@ -440,7 +440,7 @@ public:
     m_bitset.set(m_encoding ? m_encoding->at(idx) : idx);
   }
 
-  bool
+  [[nodiscard]] bool
   test(size_t idx) const
   {
     return m_bitset.test(m_encoding ? m_encoding->at(idx) : idx);
@@ -521,7 +521,7 @@ class ip_context
 
     // Get default memory index of an argument.  The default index is
     // the the largest memory index of a connection for specified argument.
-    int32_t
+    [[nodiscard]] int32_t
     get_arg_memidx(size_t argidx) const
     {
       return default_connection.at(argidx);
@@ -529,7 +529,7 @@ class ip_context
 
     // Validate that specified memory index is a valid connection for
     // argument identified by 'argidx'
-    bool
+    [[nodiscard]] bool
     valid_arg_connection(size_t argidx, size_t memidx) const
     {
       return connections[argidx].test(memidx);
@@ -586,7 +586,7 @@ public:
     return ipctx;
   }
 
-  access_mode
+  [[nodiscard]] access_mode
   get_access_mode() const
   {
     return cu_access_mode(m_hwctx.get_mode());
@@ -597,31 +597,31 @@ public:
   close()
   {}
 
-  size_t
+  [[nodiscard]] size_t
   get_size() const
   {
     return m_size;
   }
 
-  uint64_t
+  [[nodiscard]] uint64_t
   get_address() const
   {
     return m_address;
   }
 
-  xrt_core::cuidx_type
+  [[nodiscard]] xrt_core::cuidx_type
   get_index() const
   {
     return m_idx;
   }
 
-  unsigned int
+  [[nodiscard]] unsigned int
   get_cuidx() const
   {
     return m_idx.domain_index; // index used for execution cumask
   }
 
-  slot_id
+  [[nodiscard]] slot_id
   get_slot() const
   {
     auto hwctx_hdl = static_cast<xrt_core::hwctx_handle*>(m_hwctx);
@@ -638,7 +638,7 @@ public:
   // Get default memory bank for argument at specified index The
   // default memory bank is the connection with the highest group
   // connectivity index
-  int32_t
+  [[nodiscard]] int32_t
   arg_memidx(size_t argidx) const
   {
     return m_args.get_arg_memidx(argidx);
@@ -658,7 +658,7 @@ public:
   ip_context& operator=(ip_context&) = delete;
   ip_context& operator=(ip_context&&) = delete;
 
-  std::pair<uint32_t, uint32_t> m_readrange = {0,0};  // start address, size
+  std::pair<uint32_t, uint32_t> m_readrange = {0,0};  // NOLINT start address, size
 
 private:
   // regular CU
@@ -766,8 +766,8 @@ public:
   get_return_code() const
   {
     auto pkt = get_ert_packet();
-    uint32_t ret;
-    ert_read_return_code(pkt, ret);
+    uint32_t ret = 0;
+    ert_read_return_code(pkt, ret); // NOLINT
     return ret;
   }
 
@@ -1144,8 +1144,8 @@ public:
   {}
 
   explicit
-  argument(const xarg& karg)
-    : arg(karg)
+  argument(xarg karg)
+    : arg(std::move(karg))
   {
     // Determine type
     switch (arg.type) {
@@ -1192,7 +1192,7 @@ public:
   argument& operator=(argument&) = delete;
   argument& operator=(argument&&) = delete;
 
-  const xarg&
+  [[nodiscard]] const xarg&
   get_xarg() const
   {
     return arg;
@@ -1229,39 +1229,39 @@ public:
   set_fa_desc_offset(size_t offset)
   { arg.fa_desc_offset = offset; }
 
-  size_t
+  [[nodiscard]] size_t
   fa_desc_offset() const
   { return arg.fa_desc_offset; }
 
-  size_t
+  [[nodiscard]] size_t
   index() const
   { return arg.index; }
 
-  size_t
+  [[nodiscard]] size_t
   offset() const
   { return arg.offset; }
 
-  size_t
+  [[nodiscard]] size_t
   size() const
   { return arg.size; }
 
-  const std::string&
+  [[nodiscard]] const std::string&
   name() const
   { return arg.name; }
 
-  direction
+  [[nodiscard]] direction
   dir() const
   { return arg.dir; }
 
-  bool
+  [[nodiscard]] bool
   is_input() const
   { return arg.dir == direction::input; }
 
-  bool
+  [[nodiscard]] bool
   is_output() const
   { return arg.dir == direction::output; }
 
-  xarg::argtype
+  [[nodiscard]] xarg::argtype
   type() const
   { return arg.type; }
 };
@@ -1525,7 +1525,7 @@ public:
   //
   // The ctxmgr is not directly used by kernel_impl, but its
   // construction and shared ownership must be tied to the kernel_impl
-  kernel_impl(std::shared_ptr<device_type> dev, xrt::hw_context ctx, const xrt::module& mod, const std::string& nm)
+  kernel_impl(std::shared_ptr<device_type> dev, xrt::hw_context ctx, xrt::module mod, const std::string& nm)
     : name(nm.substr(0,nm.find(":")))                          // filter instance names
     , device(std::move(dev))                                   // share ownership
     , ctxmgr(xrt_core::context_mgr::create(device->core_device.get())) // owership tied to kernel_impl
@@ -1923,7 +1923,7 @@ class run_impl
     void
     set_arg_value(const argument& arg, const xrt::bo& bo) override
     {
-      uint64_t value[2] = {bo.address(), bo.size()};
+      uint64_t value[2] = {bo.address(), bo.size()}; // NOLINT
       hs_arg_setter::set_arg_value(arg, arg_range<uint8_t>{value, sizeof(value)});
     }
   };
@@ -2098,7 +2098,7 @@ class run_impl
       xrt_core::usage_metrics::get_usage_metrics_logger();
 
 public:
-  uint32_t
+  [[nodiscard]] uint32_t
   get_uid() const
   {
     return uid;
@@ -2174,7 +2174,7 @@ public:
   run_impl& operator=(run_impl&) = delete;
   run_impl& operator=(run_impl&&) = delete;
 
-  kernel_impl*
+  [[nodiscard]] kernel_impl*
   get_kernel() const
   {
     return kernel.get();
@@ -2212,7 +2212,7 @@ public:
     encode_cumasks = true;
   }
 
-  const std::bitset<max_cus>&
+  [[nodiscard]] const std::bitset<max_cus>&
   get_cumask() const
   {
     return cumask;
@@ -2308,7 +2308,7 @@ public:
     }
   }
 
-  int
+  [[nodiscard]] int
   get_arg_index(const std::string& argnm) const
   {
     for (const auto& arg : kernel->get_args())
@@ -2411,7 +2411,7 @@ public:
     cmd->wait();
   }
 
-  ert_cmd_state
+  [[nodiscard]] ert_cmd_state
   abort() const
   {
     // don't bother if command is done by the time abort is called
@@ -2441,7 +2441,7 @@ public:
   // Deprecated wait() semantics.
   // Return ERT_CMD_STATE_TIMEOUT on API timeout (bad!)
   // Return ert cmd state otherwise
-  ert_cmd_state
+  [[nodiscard]] ert_cmd_state
   wait(const std::chrono::milliseconds& timeout_ms) const
   {
     ert_cmd_state state {ERT_CMD_STATE_NEW}; // initial value doesn't matter
@@ -2466,7 +2466,7 @@ public:
   // Return std::cv_status::timeout on timeout
   // Return std::cv_status::no_timeout on successful completion
   // Throw on abnormal command termination
-  std::cv_status
+  [[nodiscard]] std::cv_status
   wait_throw_on_error(const std::chrono::milliseconds& timeout_ms) const
   {
     ert_cmd_state state {ERT_CMD_STATE_NEW}; // initial value doesn't matter
@@ -2491,14 +2491,14 @@ public:
   }
 
   // state() - get current execution state
-  ert_cmd_state
+  [[nodiscard]] ert_cmd_state
   state() const
   {
     return cmd->get_state();
   }
 
   // return_code() - get kernel execution return code
-  uint32_t
+  [[nodiscard]] uint32_t
   return_code() const
   {
     auto ktype = kernel->get_kernel_type();
@@ -2507,7 +2507,7 @@ public:
     return 0;
   }
 
-  ert_packet*
+  [[nodiscard]] ert_packet*
   get_ert_packet() const
   {
     return cmd->get_ert_packet();
@@ -2673,7 +2673,7 @@ public:
   }
 
   //Aquring mailbox read and write if not acquired already.
-  ~mailbox_impl()
+  ~mailbox_impl() override
   {
     try {
       if (!m_aquire_write) {
@@ -2690,6 +2690,12 @@ public:
       // resulting in terminate.
     }
   }
+
+  mailbox_impl() = delete;
+  mailbox_impl(const mailbox_impl&) = delete;
+  mailbox_impl(mailbox_impl&&) = delete;
+  mailbox_impl& operator=(const mailbox_impl&) = delete;
+  mailbox_impl& operator=(mailbox_impl&&) = delete;
 
   // write mailbox to hw
   void
@@ -2868,8 +2874,8 @@ public:
   ert_cmd_state m_state;
   std::string m_message;
 
-  command_error_impl(ert_cmd_state state, const std::string& msg)
-    : m_state(state), m_message(msg)
+  command_error_impl(ert_cmd_state state, std::string msg)
+    : m_state(state), m_message(std::move(msg))
   {}
 };
 
@@ -3043,7 +3049,7 @@ xrtRunHandle
 xrtRunOpen(xrtKernelHandle khdl)
 {
   const auto& kernel = kernels.get_or_error(khdl);
-  auto run = alloc_run(kernel);
+  auto run = alloc_run(kernel);  // NOLINT, clang-tidy false leak
   auto handle = run.get();
   runs.add(handle, std::move(run));
   return handle;
@@ -3102,7 +3108,7 @@ send_exception_message(const char* msg)
 ////////////////////////////////////////////////////////////////
 // XRT implmentation access to internal kernel APIs
 ////////////////////////////////////////////////////////////////
-namespace xrt_core { namespace kernel_int {
+namespace xrt_core::kernel_int {
 
 void
 copy_bo_with_kdma(const std::shared_ptr<xrt_core::device>& core_device,
@@ -3226,10 +3232,10 @@ create_kernel_from_implementation(const xrt::kernel_impl* kernel_impl)
   if (!kernel_impl)
     throw std::runtime_error("Invalid kernel context implementation."); 
 
-  return xrt::kernel(const_cast<xrt::kernel_impl*>(kernel_impl)->get_shared_ptr());
+  return xrt::kernel(const_cast<xrt::kernel_impl*>(kernel_impl)->get_shared_ptr()); // NOLINT
 }
 
-}} // kernel_int, xrt_core
+} // xrt_core::kernel_int
 
 
 ////////////////////////////////////////////////////////////////

--- a/src/runtime_src/core/common/api/xrt_message.cpp
+++ b/src/runtime_src/core/common/api/xrt_message.cpp
@@ -10,7 +10,7 @@
 #include "core/common/config_reader.h"
 #include "core/common/message.h"
 
-namespace xrt { namespace message {
+namespace xrt::message {
 
 namespace detail {
   
@@ -28,7 +28,7 @@ log(level lvl, const std::string& tag, const std::string& msg)
   xrt_core::message::send(lvl, tag, msg);
 }
 
-}} // namespace ini,xrt
+} // namespace xrt::message
 
 ////////////////////////////////////////////////////////////////
 // xrt_message C API implmentations (xrt_message.h)

--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -29,7 +29,7 @@
 #include <string>
 
 #ifndef AIE_COLUMN_PAGE_SIZE
-# define AIE_COLUMN_PAGE_SIZE 8192
+# define AIE_COLUMN_PAGE_SIZE 8192  // NOLINT
 #endif
 
 namespace
@@ -43,7 +43,7 @@ static constexpr uint8_t Elf_Amd_Aie2p  = 69;
 static constexpr uint8_t Elf_Amd_Aie2ps = 64;
 
 // When Debug.dump_bo_from_elf is true in xrt.ini, instruction bo(s) from elf will be dumped
-static std::string Debug_Bo_From_Elf_Feature = "Debug.dump_bo_from_elf";
+static const char* Debug_Bo_From_Elf_Feature = "Debug.dump_bo_from_elf";
 
 struct buf
 {
@@ -57,13 +57,13 @@ struct buf
     m_data.insert(m_data.end(), sdata, sdata + sz);
   }
 
-  size_t
+  [[nodiscard]] size_t
   size() const
   {
     return m_data.size();
   }
 
-  const uint8_t*
+  [[nodiscard]] const uint8_t*
   data() const
   {
     return m_data.data();
@@ -76,7 +76,7 @@ struct buf
   }
 
   void
-  pad_to_page(int page)
+  pad_to_page(uint32_t page)
   {
     if (!column_page_size)
       return;
@@ -130,21 +130,21 @@ struct patcher
   {
     uint64_t base_address = bd_data_ptr[0];
     base_address += patch;
-    bd_data_ptr[0] = (uint32_t)(base_address & 0xFFFFFFFF);
+    bd_data_ptr[0] = (uint32_t)(base_address & 0xFFFFFFFF);                           // NOLINT
   }
 
   void
   patch57(uint32_t* bd_data_ptr, uint64_t patch)
   {
     uint64_t base_address =
-      ((static_cast<uint64_t>(bd_data_ptr[8]) & 0x1FF) << 48) |
-      ((static_cast<uint64_t>(bd_data_ptr[2]) & 0xFFFF) << 32) |
+      ((static_cast<uint64_t>(bd_data_ptr[8]) & 0x1FF) << 48) |                       // NOLINT
+      ((static_cast<uint64_t>(bd_data_ptr[2]) & 0xFFFF) << 32) |                      // NOLINT
       bd_data_ptr[1];
 
     base_address += patch;
-    bd_data_ptr[1] = (uint32_t)(base_address & 0xFFFFFFFF);
-    bd_data_ptr[2] = (bd_data_ptr[2] & 0xFFFF0000) | ((base_address >> 32) & 0xFFFF);
-    bd_data_ptr[8] = (bd_data_ptr[8] & 0xFFFFFE00) | ((base_address >> 48) & 0x1FF);
+    bd_data_ptr[1] = (uint32_t)(base_address & 0xFFFFFFFF);                           // NOLINT
+    bd_data_ptr[2] = (bd_data_ptr[2] & 0xFFFF0000) | ((base_address >> 32) & 0xFFFF); // NOLINT
+    bd_data_ptr[8] = (bd_data_ptr[8] & 0xFFFFFE00) | ((base_address >> 48) & 0x1FF);  // NOLINT
   }
 
   void
@@ -154,12 +154,12 @@ struct patcher
     constexpr uint64_t ddr_aie_addr_offset = 0x80000000;
 
     uint64_t base_address =
-      ((static_cast<uint64_t>(bd_data_ptr[3]) & 0xFFF) << 32) |
+      ((static_cast<uint64_t>(bd_data_ptr[3]) & 0xFFF) << 32) |                       // NOLINT
       ((static_cast<uint64_t>(bd_data_ptr[2])));
 
     base_address = base_address + patch + ddr_aie_addr_offset;
-    bd_data_ptr[2] = (uint32_t)(base_address & 0xFFFFFFFC);
-    bd_data_ptr[3] = (bd_data_ptr[3] & 0xFFFF0000) | (base_address >> 32);
+    bd_data_ptr[2] = (uint32_t)(base_address & 0xFFFFFFFC);                           // NOLINT
+    bd_data_ptr[3] = (bd_data_ptr[3] & 0xFFFF0000) | (base_address >> 32);            // NOLINT
   }
 
   void patch_shim48(uint32_t* bd_data_ptr, uint64_t patch)
@@ -168,12 +168,12 @@ struct patcher
     constexpr uint64_t ddr_aie_addr_offset = 0x80000000;
 
     uint64_t base_address =
-      ((static_cast<uint64_t>(bd_data_ptr[2]) & 0xFFF) << 32) |
+      ((static_cast<uint64_t>(bd_data_ptr[2]) & 0xFFF) << 32) |                       // NOLINT
       ((static_cast<uint64_t>(bd_data_ptr[1])));
 
     base_address = base_address + patch + ddr_aie_addr_offset;
-    bd_data_ptr[1] = (uint32_t)(base_address & 0xFFFFFFFC);
-    bd_data_ptr[2] = (bd_data_ptr[2] & 0xFFFF0000) | (base_address >> 32);
+    bd_data_ptr[1] = (uint32_t)(base_address & 0xFFFFFFFC);                           // NOLINT
+    bd_data_ptr[2] = (bd_data_ptr[2] & 0xFFFF0000) | (base_address >> 32);            // NOLINT
   }
 
   void
@@ -222,23 +222,26 @@ namespace xrt
 // class module_impl - Base class for different implementations
 class module_impl
 {
-protected:
   xrt::uuid m_cfg_uuid;   // matching hw configuration id
 
 public:
-  module_impl(xrt::uuid cfg_uuid)
+  explicit module_impl(xrt::uuid cfg_uuid)
     : m_cfg_uuid(std::move(cfg_uuid))
   {}
 
-  module_impl(const module_impl* parent)
+  explicit module_impl(const module_impl* parent)
     : m_cfg_uuid(parent->m_cfg_uuid)
   {}
 
-  virtual
-  ~module_impl()
-  {}
+  virtual ~module_impl() = default;
 
-  xrt::uuid
+  module_impl() = delete;
+  module_impl(const module_impl&) = delete;
+  module_impl(module_impl&&) = delete;
+  module_impl& operator=(const module_impl&) = delete;
+  module_impl& operator=(module_impl&&) = delete;
+
+  [[nodiscard]] xrt::uuid
   get_cfg_uuid() const
   {
     return m_cfg_uuid;
@@ -247,25 +250,25 @@ public:
   // Get raw instruction buffer data for all columns or for
   // single partition.  The returned vector has the control
   // code as extracted from ELF or userptr.
-  virtual const std::vector<ctrlcode>&
+  [[nodiscard]] virtual const std::vector<ctrlcode>&
   get_data() const
   {
     throw std::runtime_error("Not supported");
   }
 
-  virtual const instr_buf&
+  [[nodiscard]] virtual const instr_buf&
   get_instr() const
   {
     throw std::runtime_error("Not supported");
   }
 
-  virtual const control_packet&
+  [[nodiscard]] virtual const control_packet&
   get_ctrlpkt() const
   {
     throw std::runtime_error("Not supported");
   }
 
-  virtual xrt::hw_context
+  [[nodiscard]] virtual xrt::hw_context
   get_hw_context() const
   {
     return {};
@@ -275,13 +278,13 @@ public:
   // or for a single partition.  The returned vector has elements
   // that are used when populating ert_dpu_data elements embedded
   // in an ert_packet.
-  virtual const std::vector<std::pair<uint64_t, uint64_t>>&
+  [[nodiscard]] virtual const std::vector<std::pair<uint64_t, uint64_t>>&
   get_ctrlcode_addr_and_size() const
   {
     throw std::runtime_error("Not supported");
   }
 
-  virtual const uint8_t&
+  [[nodiscard]] virtual const uint8_t&
   get_os_abi() const
   {
     throw std::runtime_error("Not supported");
@@ -329,7 +332,7 @@ public:
   // Get the number of patchers for arguments.  The returned
   // value is the number of arguments that must be patched before
   // the control code can be executed.
-  virtual size_t
+  [[nodiscard]] virtual size_t
   number_of_arg_patchers() const
   {
     return 0;
@@ -526,7 +529,7 @@ class module_elf : public module_impl
 
         auto secname = section->get_name();
         auto offset = rela->r_offset;
-        size_t sec_size;
+        size_t sec_size = 0;
         if (secname.compare(".ctrltext") == 0)
           sec_size = instrbuf.size();
         else if (secname.compare(".ctrldata") == 0)
@@ -590,7 +593,7 @@ class module_elf : public module_impl
         auto [col, page] = get_column_and_page(ctrl_sec->get_name());
 
         auto column_ctrlcode_size = ctrlcodes.at(col).size();
-        auto column_ctrlcode_offset = page * column_page_size + rela->r_offset + 16; // magic number 16??
+        auto column_ctrlcode_offset = page * column_page_size + rela->r_offset + 16; // NOLINT magic number 16??
         if (column_ctrlcode_offset >= column_ctrlcode_size)
           throw std::runtime_error("Invalid ctrlcode offset " + std::to_string(column_ctrlcode_offset));
 
@@ -629,14 +632,14 @@ class module_elf : public module_impl
     return true;
   }
 
-  const uint8_t&
+  [[nodiscard]] const uint8_t&
   get_os_abi() const override
   {
     return m_os_abi;
   }
 
 public:
-  module_elf(xrt::elf elf)
+  explicit module_elf(xrt::elf elf)
     : module_impl{ elf.get_cfg_uuid() }
     , m_elf(std::move(elf))
     , m_os_abi{ xrt_core::elf_int::get_elfio(m_elf).get_os_abi() }
@@ -652,25 +655,25 @@ public:
     }
   }
 
-  const std::vector<ctrlcode>&
+  [[nodiscard]] const std::vector<ctrlcode>&
   get_data() const override
   {
     return m_ctrlcodes;
   }
 
-  const instr_buf&
+  [[nodiscard]] const instr_buf&
   get_instr() const override
   {
     return m_instr_buf;
   }
 
-  const control_packet&
+  [[nodiscard]] const control_packet&
   get_ctrlpkt() const override
   {
     return m_ctrl_packet;
   }
 
-  size_t
+  [[nodiscard]] size_t
   number_of_arg_patchers() const override
   {
     return m_arg2patcher.size();
@@ -704,19 +707,19 @@ public:
     : module_userptr(static_cast<const char*>(userptr), sz, uuid)
   {}
 
-  const std::vector<ctrlcode>&
+  [[nodiscard]] const std::vector<ctrlcode>&
   get_data() const override
   {
     return m_ctrlcode;
   }
 
-  const instr_buf&
+  [[nodiscard]] const instr_buf&
   get_instr() const override
   {
     return m_instr_buf;
   }
 
-  const control_packet&
+  [[nodiscard]] const control_packet&
   get_ctrlpkt() const override
   {
     return m_ctrl_pkt;
@@ -763,7 +766,7 @@ class module_sram : public module_impl
     m_column_bo_address.clear();
     auto base_addr = m_buffer.address();
     for (const auto& ctrlcode : ctrlcodes) {
-      m_column_bo_address.push_back({ base_addr, ctrlcode.size() });
+      m_column_bo_address.push_back({ base_addr, ctrlcode.size() }); // NOLINT
       base_addr += ctrlcode.size();
     }
   }
@@ -772,9 +775,9 @@ class module_sram : public module_impl
   fill_bo_addresses()
   {
     m_column_bo_address.clear();
-    m_column_bo_address.push_back({ m_instr_buf.address(), m_instr_buf.size() });
+    m_column_bo_address.push_back({ m_instr_buf.address(), m_instr_buf.size() }); // NOLINT
     if (m_ctrlpkt_buf) {
-      m_column_bo_address.push_back({ m_ctrlpkt_buf.address(), m_ctrlpkt_buf.size() });
+      m_column_bo_address.push_back({ m_ctrlpkt_buf.address(), m_ctrlpkt_buf.size() }); // NOLINT
     }
   }
 
@@ -829,6 +832,8 @@ class module_sram : public module_impl
     dump_bo(m_instr_buf, "instrBo.bin");
 #endif
 
+    ///// THIS IS A BUG, create_instr_buf is called in constructor
+    // patch_instr is a virtual method, what is actually called here ???
     if (m_ctrlpkt_buf) {
       patch_instr("control-packet", m_ctrlpkt_buf);
 
@@ -938,7 +943,7 @@ class module_sram : public module_impl
   void
   patch(const std::string& argnm, const void* value, size_t size) override
   {
-    if (size > 8)
+    if (size > 8) // NOLINT
       throw std::runtime_error{ "patch_value() only supports 64-bit values or less" };
 
     patch_value(argnm, *static_cast<const uint64_t*>(value));
@@ -991,7 +996,7 @@ public:
     }
   }
 
-  const std::vector<std::pair<uint64_t, uint64_t>>&
+  [[nodiscard]] const std::vector<std::pair<uint64_t, uint64_t>>&
   get_ctrlcode_addr_and_size() const override
   {
     return m_column_bo_address;

--- a/src/runtime_src/core/common/api/xrt_profile.cpp
+++ b/src/runtime_src/core/common/api/xrt_profile.cpp
@@ -31,7 +31,7 @@
 #include <functional>
 #include <mutex>
 
-namespace xrt { namespace profile {
+namespace xrt::profile {
 
 user_range::
 user_range(const char* label, const char* tooltip)
@@ -78,12 +78,10 @@ end()
 }
 
 user_event::
-user_event()
-{}
+user_event() = default;
 
 user_event::
-~user_event()
-{}
+~user_event() = default;
 
 void user_event::
 mark(const char* label)
@@ -97,7 +95,7 @@ mark_time_ns(const std::chrono::nanoseconds& time_ns, const char* label)
   xrtUEMarkTimeNs(static_cast<unsigned long long int>(time_ns.count()), label);
 }
 
-}} // end namespaces profile and xrt
+} // xrt::profile
 
 
 // Anonymous namespace for dynamic loading and connection

--- a/src/runtime_src/core/common/api/xrt_queue.cpp
+++ b/src/runtime_src/core/common/api/xrt_queue.cpp
@@ -76,6 +76,11 @@ public:
     m_worker.join();
   }
 
+  queue_impl(const queue_impl&) = delete;
+  queue_impl(queue_impl&&) = delete;
+  queue_impl& operator=(const queue_impl&) = delete;
+  queue_impl& operator=(queue_impl&&) = delete;
+
   // Enqueue a task and notify worker
   void
   enqueue(queue::task&& t)

--- a/src/runtime_src/core/common/api/xrt_system.cpp
+++ b/src/runtime_src/core/common/api/xrt_system.cpp
@@ -9,7 +9,7 @@
 
 #include "core/common/system.h"
 
-namespace xrt { namespace system {
+namespace xrt::system {
 
 unsigned int
 enumerate_devices()
@@ -17,7 +17,7 @@ enumerate_devices()
   return static_cast<unsigned int>(xrt_core::get_total_devices(true/*is_user*/).second);
 }
 
-}} // namespace ini,xrt
+} // xrt::system
 
 ////////////////////////////////////////////////////////////////
 // xrt_message C API implmentations (xrt_message.h)

--- a/src/runtime_src/core/common/api/xrt_xclbin.cpp
+++ b/src/runtime_src/core/common/api/xrt_xclbin.cpp
@@ -211,7 +211,7 @@ class xclbin::ip_impl
 public: // purposely not a struct to match decl in xrt_xclbin.h
   const ::ip_data* m_ip;            //
   int32_t m_ip_layout_idx;          // index in IP_LAYOUT seciton
-  size_t m_size = 64_kb;            // address range of this ip (a kernel property)
+  size_t m_size = 64_kb;            // NOLINT address range of this ip (a kernel property)
   std::vector<xclbin::arg> m_args;  // index by argument index
 
   void
@@ -257,13 +257,13 @@ public:
     return m_args[argidx];
   }
 
-  xrt::xclbin::ip::ip_type
+  [[nodiscard]] xrt::xclbin::ip::ip_type
   get_type() const
   {
     return static_cast<xrt::xclbin::ip::ip_type>(m_ip->m_type);
   }
 
-  xrt::xclbin::ip::control_type
+  [[nodiscard]] xrt::xclbin::ip::control_type
   get_control_type() const
   {
     return static_cast<xrt::xclbin::ip::control_type>((m_ip->properties & IP_CONTROL_MASK) >> IP_CONTROL_SHIFT);
@@ -364,7 +364,7 @@ class xclbin::aie_partition_impl
 public: // purposely not a struct to match decl in xrt_xclbin.h
   const ::aie_partition* m_aiep;
 
-  aie_partition_impl(const ::aie_partition* aiep)
+  explicit aie_partition_impl(const ::aie_partition* aiep)
     : m_aiep(aiep)
   {}
 };
@@ -913,12 +913,8 @@ class xclbin_repository::iterator_impl
 {
   std::vector<std::filesystem::path>::const_iterator m_itr;
 public:
-  iterator_impl(std::vector<std::filesystem::path>::const_iterator itr)
+  explicit iterator_impl(std::vector<std::filesystem::path>::const_iterator itr)
     : m_itr(itr)
-  {}
-
-  iterator_impl(const iterator_impl& rhs)
-    : m_itr(rhs.m_itr)
   {}
 
   iterator_impl&
@@ -934,13 +930,13 @@ public:
     return m_itr == rhs.m_itr;
   }
 
-  xrt::xclbin
+  [[nodiscard]] xrt::xclbin
   get_xclbin() const
   {
     return xrt::xclbin{get_xclbin_path()};
   }
 
-  std::string
+  [[nodiscard]] std::string
   get_xclbin_path() const
   {
     return (*m_itr).string();
@@ -974,7 +970,7 @@ class xclbin_repository_impl
       sfs::directory_iterator end;
       for (; p != end; ++p) {
         if (sfs::is_regular_file(*p) && p->path().extension() == ".xclbin")
-          xclbin_paths.push_back(p->path().string());
+          xclbin_paths.emplace_back(p->path().string());
       }
     }
     
@@ -987,24 +983,24 @@ public:
     , m_xclbin_paths(get_xclbin_paths(m_paths))
   {}
   
-  xclbin_repository_impl(const std::string& path)
+  explicit xclbin_repository_impl(const std::string& path)
     : m_paths{path}
     , m_xclbin_paths(get_xclbin_paths(m_paths))
   {}
 
-  xclbin_repository::iterator
+  [[nodiscard]] xclbin_repository::iterator
   begin() const
   {
     return std::make_shared<xclbin_repository::iterator_impl>(m_xclbin_paths.begin());
   }
 
-  xclbin_repository::iterator
+  [[nodiscard]] xclbin_repository::iterator
   end() const
   {
     return std::make_shared<xclbin_repository::iterator_impl>(m_xclbin_paths.end());
   }
 
-  xclbin
+  [[nodiscard]] xclbin
   load(const std::string& name) const
   {
     namespace sfs = std::filesystem;
@@ -1245,7 +1241,7 @@ get_type() const
 {
   return handle
     ? handle->get_type()
-    : static_cast<xclbin::ip::ip_type>(std::numeric_limits<uint8_t>::max());
+    : static_cast<xclbin::ip::ip_type>(std::numeric_limits<uint8_t>::max()); // NOLINT
 }
 
 xclbin::ip::control_type
@@ -1254,7 +1250,7 @@ get_control_type() const
 {
   return handle
     ? handle->get_control_type()
-    : static_cast<xclbin::ip::control_type>(std::numeric_limits<uint8_t>::max());
+    : static_cast<xclbin::ip::control_type>(std::numeric_limits<uint8_t>::max()); // NOLINT
 }
 
 size_t
@@ -1397,6 +1393,7 @@ xclbin::mem::memory_type
 xclbin::mem::
 get_type() const
 {
+  // NOLINTNEXTLINE
   return handle ? static_cast<memory_type>(handle->m_mem->m_type) : static_cast<memory_type>(-1);
 }
 
@@ -1491,7 +1488,7 @@ operator++()
   return *this;
 }
 
-xclbin_repository::iterator
+xclbin_repository::iterator    // NOLINT non const return value is valid iterator
 xclbin_repository::iterator::
 operator++(int)
 {
@@ -1552,7 +1549,7 @@ send_exception_message(const char* msg)
 // handle is valid Needed when the C API for device tries to load an
 // xclbin using C pointer to xclbin
 ////////////////////////////////////////////////////////////////
-namespace xrt_core { namespace xclbin_int {
+namespace xrt_core::xclbin_int {
 
 const axlf*
 get_axlf(xrtXclbinHandle handle)
@@ -1609,7 +1606,7 @@ get_project_name(const xrt::xclbin& xclbin)
   return xclbin.get_handle()->get_project_name();
 }
 
-}} // namespace xclbin_int, core_core
+} // xrt_core::xclbin_int
 
 ////////////////////////////////////////////////////////////////
 // xrt_xclbin C API implmentations (xrt_xclbin.h)

--- a/src/runtime_src/core/common/debug.h
+++ b/src/runtime_src/core/common/debug.h
@@ -86,17 +86,17 @@ xassert(const std::string& file, const std::string& line, const std::string& fun
 } // xrt_core
 
 #ifdef XRT_VERBOSE
-# define XRT_DEBUG(...) xrt_core::debug(__VA_ARGS__)
-# define XRT_PRINT(...) xrt_core::debug(__VA_ARGS__)
-# define XRT_DEBUGF(format,...) xrt_core::debugf(format, ##__VA_ARGS__)
-# define XRT_PRINTF(format,...) xrt_core::debugf(format, ##__VA_ARGS__)
+# define XRT_DEBUG(...) xrt_core::debug(__VA_ARGS__) // NOLINT
+# define XRT_PRINT(...) xrt_core::debug(__VA_ARGS__) // NOLINT
+# define XRT_DEBUGF(format,...) xrt_core::debugf(format, ##__VA_ARGS__) // NOLINT
+# define XRT_PRINTF(format,...) xrt_core::debugf(format, ##__VA_ARGS__) // NOLINT
 # define XRT_DEBUG_CALL(...) xrt_core::sink(__VA_ARGS__);
 # define XRT_CALL(...) xrt_core::sink(__VA_ARGS__);
 #else
 # define XRT_DEBUG(...)
-# define XRT_PRINT(...) xrt_core::debug(__VA_ARGS__)
+# define XRT_PRINT(...) xrt_core::debug(__VA_ARGS__) // NOLINT
 # define XRT_DEBUGF(...)
-# define XRT_PRINTF(format,...) xrt_core::debugf(format, ##__VA_ARGS__)
+# define XRT_PRINTF(format,...) xrt_core::debugf(format, ##__VA_ARGS__) // NOLINT
 # define XRT_DEBUG_CALL(...)
 # define XRT_CALL(...) xrt_core::sink(__VA_ARGS__);
 #endif

--- a/src/runtime_src/core/common/detail/linux/trace.h
+++ b/src/runtime_src/core/common/detail/linux/trace.h
@@ -9,11 +9,11 @@
   STAP_PROBEV(xrt, probe##_log, ##__VA_ARGS__)
 
 #define XRT_DETAIL_TRACE_POINT_SCOPE(probe)                             \
-  struct xrt_trace_scope {                                              \
-    xrt_trace_scope()                                                   \
-    { DTRACE_PROBE(xrt, probe##_enter); }                               \
-    ~xrt_trace_scope()                                                  \
-    { DTRACE_PROBE(xrt, probe##_exit); }                                \
+  struct xrt_trace_scope {                  /* NOLINT */                \
+    xrt_trace_scope()                       /* NOLINT */                \
+    { DTRACE_PROBE(xrt, probe##_enter); }   /* NOLINT */                \
+    ~xrt_trace_scope()                      /* NOLINT */                \
+    { DTRACE_PROBE(xrt, probe##_exit); }    /* NOLINT */                \
   } xrt_trace_scope_instance
 
 #define XRT_DETAIL_TRACE_POINT_SCOPE1(probe, arg1)                      \

--- a/src/runtime_src/core/include/xrt/detail/bitmask.h
+++ b/src/runtime_src/core/include/xrt/detail/bitmask.h
@@ -40,7 +40,7 @@ constexpr std::enable_if_t<std::is_enum_v<T>, T>
 operator~(T rhs)
 {
   using U = std::underlying_type_t<T>;
-  return static_cast<T>(~static_cast<U>(rhs));
+  return static_cast<T>(~static_cast<U>(rhs)); // NOLINT
 }
 
 template <typename T>


### PR DESCRIPTION
#### Problem solved by the commit
Relatively benign fixes to core/common/api to satisyfy clang-tidy.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Enable clang-tidy and fix all  warnings.
Need to revisit xrt_module.cpp per comment in file.

#### What has been tested and how, request additional testing if necessary
Regression testing
