### PR TITLE
Added additional structure variable for MGMTPF.

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
@@ -369,7 +369,7 @@ static int create_char(struct xclmgmt_dev *lro)
 		goto fail_add;
 	}
 
-	lro_char->sys_device = device_create(xrt_class,
+	lro_char->sys_device = device_create(xrt_class_mgmtpf,
 				&lro->core.pdev->dev,
 				lro_char->cdev->dev, NULL,
 				DRV_NAME "%u", lro->instance);
@@ -390,10 +390,10 @@ fail_add:
 static int destroy_sg_char(struct xclmgmt_char *lro_char)
 {
 	BUG_ON(!lro_char);
-	BUG_ON(!xrt_class);
+	BUG_ON(!xrt_class_mgmtpf);
 
 	if (lro_char->sys_device)
-		device_destroy(xrt_class, lro_char->cdev->dev);
+		device_destroy(xrt_class_mgmtpf, lro_char->cdev->dev);
 	cdev_del(lro_char->cdev);
 
 	return 0;
@@ -1436,6 +1436,8 @@ static int xclmgmt_probe(struct pci_dev *pdev, const struct pci_device_id *id)
 		goto err_alloc;
 	}
 
+	lro->core.userpf = false;
+
 	for (i = XOCL_WORK_RESET; i < XOCL_WORK_NUM; i++) {
 		INIT_DELAYED_WORK(&lro->core.works[i].work, xclmgmt_work_cb);
 		lro->core.works[i].op = i;
@@ -1742,9 +1744,9 @@ static int __init xclmgmt_init(void)
 	int res, i;
 
 	pr_info(DRV_NAME " init()\n");
-	xrt_class = class_create(THIS_MODULE, "xrt_mgmt");
-	if (IS_ERR(xrt_class))
-		return PTR_ERR(xrt_class);
+	xrt_class_mgmtpf = class_create(THIS_MODULE, "xrt_mgmt");
+	if (IS_ERR(xrt_class_mgmtpf))
+		return PTR_ERR(xrt_class_mgmtpf);
 
 	res = xocl_debug_init();
 	if (res) {
@@ -1778,7 +1780,7 @@ reg_err:
 	unregister_chrdev_region(xclmgmt_devnode, XOCL_MAX_DEVICES);
 alloc_err:
 	pr_info(DRV_NAME " init() err\n");
-	class_destroy(xrt_class);
+	class_destroy(xrt_class_mgmtpf);
 	return res;
 }
 
@@ -1795,7 +1797,7 @@ static void xclmgmt_exit(void)
 	/* unregister this driver from the PCI bus driver */
 	unregister_chrdev_region(xclmgmt_devnode, XOCL_MAX_DEVICES);
 	xocl_debug_fini();
-	class_destroy(xrt_class);
+	class_destroy(xrt_class_mgmtpf);
 }
 
 module_init(xclmgmt_init);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
@@ -159,16 +159,24 @@ int xocl_register_cus(xdev_handle_t xdev_hdl, int slot_hdl, xuid_t *uuid,
 		      struct ip_layout *ip_layout,
 		      struct ps_kernel_node *ps_kernel)
 {
-	struct xocl_dev *xdev = container_of(XDEV(xdev_hdl), struct xocl_dev, core);
-
-	return xocl_kds_register_cus(xdev, slot_hdl, uuid, ip_layout, ps_kernel);
+	struct xocl_dev_core *core_ptr = (struct xocl_dev_core *)xdev_hdl;
+        if (!core_ptr->userpf)  {
+            return 0;
+        } else {	
+		struct xocl_dev *xdev = container_of(XDEV(xdev_hdl), struct xocl_dev, core);
+		return xocl_kds_register_cus(xdev, slot_hdl, uuid, ip_layout, ps_kernel);
+	}
 }
 
 int xocl_unregister_cus(xdev_handle_t xdev_hdl, int slot_hdl)
 {
-	struct xocl_dev *xdev = container_of(XDEV(xdev_hdl), struct xocl_dev, core);
-
-	return xocl_kds_unregister_cus(xdev, slot_hdl);
+	struct xocl_dev_core *core_ptr = (struct xocl_dev_core *)xdev_hdl;
+        if (!core_ptr->userpf)  {
+            return 0;
+        } else {
+		struct xocl_dev *xdev = container_of(XDEV(xdev_hdl), struct xocl_dev, core);
+		return xocl_kds_unregister_cus(xdev, slot_hdl);
+	}
 }
 
 static int userpf_intr_config(xdev_handle_t xdev_hdl, u32 intr, bool en)
@@ -1685,7 +1693,7 @@ int xocl_userpf_probe(struct pci_dev *pdev,
 
 	/* initialize xocl_errors */
 	xocl_init_errors(&xdev->core);
-
+	xdev->core.userpf = true;
 	ret = xocl_subdev_init(xdev, pdev, &userpf_pci_ops);
 	if (ret) {
 		xocl_err(&pdev->dev, "failed to failed to init subdev");

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -380,6 +380,7 @@ struct xocl_pci_info {
 };
 
 extern struct class *xrt_class;
+extern struct class *xrt_class_mgmtpf;
 
 struct drm_xocl_bo;
 struct client_ctx;
@@ -622,6 +623,7 @@ struct xocl_dev_core {
 	 * Having SN info available also implies there is a working SC
 	 */
 	char			serial_num[SERIAL_NUM_LEN];
+	bool			userpf;
 };
 
 #define XOCL_DRM(xdev_hdl)					\

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_subdev.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_subdev.c
@@ -20,6 +20,8 @@
 #include "xocl_drv.h"
 #include "version.h"
 
+struct class *xrt_class_mgmtpf;
+
 struct xocl_subdev_array {
 	xdev_handle_t xdev_hdl;
 	int id;
@@ -284,6 +286,7 @@ static int xocl_subdev_cdev_create(struct platform_device *pdev,
 	struct device *sysdev;
 	struct cdev *cdevp;
 	int ret;
+	struct class* local_class=NULL;
 
 	if (!XOCL_GET_DRV_PRI(pdev) || !XOCL_GET_DRV_PRI(pdev)->fops)
 		return 0;
@@ -294,6 +297,11 @@ static int xocl_subdev_cdev_create(struct platform_device *pdev,
 	}
 
 	core = xocl_get_xdev(pdev);
+	if(core->userpf)
+		local_class = xrt_class;
+	else
+		local_class = xrt_class_mgmtpf;
+
 	cdevp = cdev_alloc();
 	if (!cdevp) {
 		xocl_err(&pdev->dev, "alloc cdev failed");
@@ -312,11 +320,11 @@ static int xocl_subdev_cdev_create(struct platform_device *pdev,
 	}
 
 	if (XOCL_GET_DRV_PRI(pdev)->cdev_name)
-		sysdev = device_create(xrt_class, &pdev->dev, cdevp->dev,
+		sysdev = device_create(local_class, &pdev->dev, cdevp->dev,
 			NULL, "%s%u.%u", XOCL_GET_DRV_PRI(pdev)->cdev_name,
 			XOCL_DEV_ID(core->pdev), subdev->info.dev_idx);
 	else
-		sysdev = device_create(xrt_class, &pdev->dev, cdevp->dev,
+		sysdev = device_create(local_class, &pdev->dev, cdevp->dev,
 			NULL, "%s/%s%u.%u", XOCL_CDEV_DIR,
 			platform_get_device_id(pdev)->name,
 			XOCL_DEV_ID(core->pdev), subdev->info.dev_idx);
@@ -334,7 +342,7 @@ static int xocl_subdev_cdev_create(struct platform_device *pdev,
 
 failed:
 	if (cdevp) {
-		device_destroy(xrt_class, cdevp->dev);
+		device_destroy(local_class, cdevp->dev);
 		cdev_del(cdevp);
 	}
 
@@ -369,6 +377,12 @@ static void __xocl_subdev_destroy(xdev_handle_t xdev_hdl,
 {
 	struct platform_device *pldev;
 	int state;
+	struct class* local_class=NULL;
+	struct xocl_dev_core *core = (struct xocl_dev_core *)xdev_hdl;
+	if(core->userpf)
+		local_class = xrt_class;
+	else
+		local_class = xrt_class_mgmtpf;
 
 	if (!subdev || subdev->state == XOCL_SUBDEV_STATE_UNINIT)
 		return;
@@ -381,7 +395,7 @@ static void __xocl_subdev_destroy(xdev_handle_t xdev_hdl,
 	xocl_xdev_info(xdev_hdl, "Destroy subdev %s, cdev %p\n",
 			subdev->info.name, subdev->cdev);
 	if (subdev->cdev) {
-		device_destroy(xrt_class, subdev->cdev->dev);
+		device_destroy(local_class, subdev->cdev->dev);
 		cdev_del(subdev->cdev);
 		subdev->cdev = NULL;
 	}
@@ -417,13 +431,20 @@ static int __xocl_subdev_construct(xdev_handle_t xdev_hdl,
 	struct resource *res = NULL;
 	resource_size_t iostart;
 	u64 bar_start, bar_end;
+	char *suffix;
+
+	if (core->userpf){
+		suffix = ".u";
+        } else {
+		suffix = ".m";    
+        }
 
 	if (subdev->info.override_name)
 		snprintf(devname, sizeof(devname) - 1, "%s",
 			subdev->info.override_name);
 	else
 		snprintf(devname, sizeof(devname) - 1, "%s%s",
-			subdev->info.name, SUBDEV_SUFFIX);
+			subdev->info.name, suffix);
 	xocl_xdev_dbg(xdev_hdl, "creating subdev %s multi %d level %d",
 		devname, subdev->info.multi_inst, subdev->info.level);
 
@@ -1031,6 +1052,12 @@ static int __xocl_subdev_offline(xdev_handle_t xdev_hdl,
 	struct xocl_subdev_funcs *subdev_funcs;
 	struct platform_device *pldev;
 	int ret = 0;
+	struct class* local_class=NULL;  
+	struct xocl_dev_core *core = (struct xocl_dev_core *)xdev_hdl; 
+	if(core->userpf)
+		local_class = xrt_class;   
+	else
+		local_class =xrt_class_mgmtpf;
 
 	BUG_ON(!subdev);
 	if (subdev->state < XOCL_SUBDEV_STATE_ACTIVE) {
@@ -1051,7 +1078,7 @@ static int __xocl_subdev_offline(xdev_handle_t xdev_hdl,
 	xocl_xdev_info(xdev_hdl, "offline subdev %s, cdev %p\n",
 			subdev->info.name, subdev->cdev);
 	if (subdev->cdev) {
-		device_destroy(xrt_class, subdev->cdev->dev);
+		device_destroy(local_class, subdev->cdev->dev);
 		cdev_del(subdev->cdev);
 		subdev->cdev = NULL;
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

To differentiate b/w userpf and mgmtpf module function conflicts, we have added structure variable "xrt_class_mgmt" in a mgmt-core.c file.
Added bool flag "userpf" to differentiate the conflicts between mgmtpf & userpf  when register & unregister the module, added one localclass flag to separate between MGMTPF & USERPF functionalities.


#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
