### PR TITLE
Fix printing logs on Windows

### DIFF
--- a/src/runtime_src/core/common/detail/windows/trace.h
+++ b/src/runtime_src/core/common/detail/windows/trace.h
@@ -72,9 +72,9 @@ add_event(Args&&... args)
 
 #define XRT_DETAIL_TOSTRING_(a) #a
 #define XRT_DETAIL_PROBE(a, b) XRT_DETAIL_TOSTRING_(a ## b)
-  
+
 #define XRT_DETAIL_TRACE_POINT_LOG(probe, ...) \
-  xrt_core::trace::detail::add_event(#probe, __VA_ARGS)  // VS++ suppresses trailing comma
+  xrt_core::trace::detail::add_event(#probe, ##__VA_ARGS__)  // VS++ suppresses trailing comma
 
 #define XRT_DETAIL_TRACE_POINT_SCOPE(probe)                                          \
   struct xrt_trace_scope {                                                           \


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
The current macro in windows/trace.h doesn't print logs on Windows.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Modified the macro to make it work.

#### What has been tested and how, request additional testing if necessary
Regression testing