### PR TITLE
Fix to handle input_ports_details and output_ports_details Interface tiles metric for PLIO designs

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info/aie_util.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info/aie_util.cpp
@@ -383,7 +383,8 @@ namespace xdp::aie {
       for (auto& info : infoVector) {
         auto startCol = static_cast<uint8_t>(info.start_col);
         xrt_core::message::send(severity_level::info, "XRT",
-            "Partition shift of " + std::to_string(startCol) + " was found.");
+            "Partition shift of " + std::to_string(startCol) +
+            " was found, number of columns: " + std::to_string(info.num_cols));
         startCols.push_back(startCol);
       }
     }

--- a/src/runtime_src/xdp/profile/device/tracedefs.h
+++ b/src/runtime_src/xdp/profile/device/tracedefs.h
@@ -86,6 +86,7 @@ Please increase trace_buffer_size and trace_buffer_offload_interval together or 
 #define AIE_TRACE_BUF_ALLOC_FAIL              "Allocation of buffer for AIE trace failed. AIE trace will not be available."
 #define AIE_TS2MM_WARN_MSG_BUF_FULL           "AIE Trace Buffer is full. Device trace could be incomplete."
 #define AIE_TS2MM_WARN_MSG_CIRC_BUF_OVERWRITE "Circular buffer overwrite was detected in device trace. AIE trace could be incomplete."
+#define AIE_TRACE_TILES_UNAVAILABLE 		  "No valid tiles fond for the provided configuration and the given design. So, AIE event trace will not be available."
 
 #define AIE_TRACE_BUF_REUSE_WARN              "AIE reuse_buffer may cause overrun. \
 Recommended settings: \

--- a/src/runtime_src/xdp/profile/device/tracedefs.h
+++ b/src/runtime_src/xdp/profile/device/tracedefs.h
@@ -86,7 +86,7 @@ Please increase trace_buffer_size and trace_buffer_offload_interval together or 
 #define AIE_TRACE_BUF_ALLOC_FAIL              "Allocation of buffer for AIE trace failed. AIE trace will not be available."
 #define AIE_TS2MM_WARN_MSG_BUF_FULL           "AIE Trace Buffer is full. Device trace could be incomplete."
 #define AIE_TS2MM_WARN_MSG_CIRC_BUF_OVERWRITE "Circular buffer overwrite was detected in device trace. AIE trace could be incomplete."
-#define AIE_TRACE_TILES_UNAVAILABLE 		  "No valid tiles fond for the provided configuration and the given design. So, AIE event trace will not be available."
+#define AIE_TRACE_TILES_UNAVAILABLE           "No valid tiles found for the provided configuration and design. So, AIE event trace will not be available."
 
 #define AIE_TRACE_BUF_REUSE_WARN              "AIE reuse_buffer may cause overrun. \
 Recommended settings: \

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_metadata.cpp
@@ -498,7 +498,7 @@ namespace xdp {
       }
 
       uint8_t channel0 = 0;
-      uint8_t channel1 = 1;  // TODO : Check if default value should be 0 same as channel0
+      uint8_t channel1 = 1;
       if (metrics[i].size() > 3) {
         try {
           channel0 = aie::convertStringToUint8(metrics[i][3]);
@@ -929,15 +929,18 @@ namespace xdp {
           xrt_core::message::send(severity_level::warning, "XRT", msg);
           showWarningGMIOMetric = false;
         }
-        std::stringstream msg;
-        msg <<"Configured interface_tile metric set "<< tileMetric.second
-            <<"is not applicable for GMIO type tile: ("<<+tileMetric.first.col<<", "
-            <<+tileMetric.first.row<<").";
-        xrt_core::message::send(severity_level::debug, "XRT", msg.str());
 
-        offTiles.push_back(tileMetric.first);
-        continue;
-      }
+        if(boost::algorithm::ends_with(tileMetric.second, "_details")) {
+            std::stringstream msg;
+            msg << "Replacing metric set "<< tileMetric.second << " with complementary set ";
+            boost::algorithm::replace_last(tileMetric.second, "_details", "_stalls");
+            msg << tileMetric.second <<" for tile ("<<+tileMetric.first.col<<", "<<+tileMetric.first.row<<").";
+            xrt_core::message::send(severity_level::warning, "XRT", msg.str());
+        }else {
+          offTiles.push_back(tileMetric.first);
+          continue;
+        }
+     }
 
       // Ensure requested metric set is supported (if not, use default)
       if (std::find(metricVec.begin(), metricVec.end(), tileMetric.second) == metricVec.end()) {

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_metadata.cpp
@@ -919,7 +919,7 @@ namespace xdp {
       }
 
       // Check for PLIO tiles and it's compatible metric settings
-      if (tileMetric.first.subtype == 0 && isGMIOMetric(tileMetric.second)) {
+      if ((tileMetric.first.subtype == 0) && isGMIOMetric(tileMetric.second)) {
         if (showWarningGMIOMetric) {
           std::string msg = "Configured interface_tile metric set " + tileMetric.second 
                           + " is only applicable for GMIO type tiles.";
@@ -928,8 +928,8 @@ namespace xdp {
         }
 
         std::stringstream msg;
-        msg << "Configured interface_tile metric set metric set "<< tileMetric.second;
-        msg <<" skipped for tile ("<<+tileMetric.first.col<<", "<<+tileMetric.first.row<<").";
+        msg << "Configured interface_tile metric set metric set " << tileMetric.second;
+        msg << " skipped for tile (" << +tileMetric.first.col << ", " << +tileMetric.first.row << ").";
         xrt_core::message::send(severity_level::warning, "XRT", msg.str());
         offTiles.push_back(tileMetric.first);
         continue;

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_metadata.cpp
@@ -108,7 +108,6 @@ namespace xdp {
       getConfigMetricsForTiles(aieTileMetricsSettings, aieGraphMetricsSettings, module_type::dma);
       getConfigMetricsForTiles(memTileMetricsSettings, memGraphMetricsSettings, module_type::mem_tile);
       getConfigMetricsForInterfaceTiles(shimTileMetricsSettings, shimGraphMetricsSettings);
-      std::cout<<"!!! getConfigMetrics().size(): "<<getConfigMetrics().size()<<std::endl;
       setTraceStartControl(compilerOptions.graph_iterator_event);
     }
   }

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_metadata.cpp
@@ -927,17 +927,13 @@ namespace xdp {
           showWarningGMIOMetric = false;
         }
 
-        if(boost::algorithm::ends_with(tileMetric.second, "_details")) {
-            std::stringstream msg;
-            msg << "Replacing metric set "<< tileMetric.second << " with complementary set ";
-            boost::algorithm::replace_last(tileMetric.second, "_details", "_stalls");
-            msg << tileMetric.second <<" for tile ("<<+tileMetric.first.col<<", "<<+tileMetric.first.row<<").";
-            xrt_core::message::send(severity_level::warning, "XRT", msg.str());
-        }else {
-          offTiles.push_back(tileMetric.first);
-          continue;
-        }
-     }
+        std::stringstream msg;
+        msg << "Configured interface_tile metric set metric set "<< tileMetric.second;
+        msg <<" skipped for tile ("<<+tileMetric.first.col<<", "<<+tileMetric.first.row<<").";
+        xrt_core::message::send(severity_level::warning, "XRT", msg.str());
+        offTiles.push_back(tileMetric.first);
+        continue;
+      }
 
       // Ensure requested metric set is supported (if not, use default)
       if (std::find(metricVec.begin(), metricVec.end(), tileMetric.second) == metricVec.end()) {

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_metadata.cpp
@@ -919,9 +919,7 @@ namespace xdp {
         continue;
       }
 
-      // TODO : Add code here to check if metric is GMIO (DMA only) & tiles are of PLIO type.
-      // If so, push it to offtiles.
-      // TODO : Also test simple sets for PLIO testcases if that works.
+      // Check for PLIO tiles and it's compatible metric settings
       if (tileMetric.first.subtype == 0 && isGMIOMetric(tileMetric.second)) {
         if (showWarningGMIOMetric) {
           std::string msg = "Configured interface_tile metric set " + tileMetric.second 
@@ -958,7 +956,6 @@ namespace xdp {
     for (auto& t : offTiles) {
       configMetrics.erase(t);
     }
-
   }
 
   aie::driver_config 

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_metadata.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_metadata.h
@@ -108,6 +108,11 @@ class AieTraceMetadata {
       hwContext = std::move(c);
     }
 
+    bool isGMIOMetric(const std::string metric) {
+      return gmioMetricSets.find(metric) != gmioMetricSets.end();
+    }
+    bool configMetricsEmpty() const { return configMetrics.empty(); }
+
   private:
     bool useDelay = false;
     bool useUserControl = false;
@@ -157,10 +162,14 @@ class AieTraceMetadata {
                                 "input_ports_details", "output_ports_details",
                                 "mm2s_ports", "s2mm_ports",
                                 "mm2s_ports_stalls", "s2mm_ports_stalls", 
-                                "mms2_ports_details", "s2mm_ports_details",
+                                "mm2s_ports_details", "s2mm_ports_details",
                                 "input_output_ports", "mm2s_s2mm_ports",
                                 "input_output_ports_stalls", "mm2s_s2mm_ports_stalls"} }
     };
+
+    std::set<std::string> gmioMetricSets {
+                                "input_ports_details", "output_ports_details",
+                                "mm2s_ports_details", "s2mm_ports_details" };
 
     void* handle;
     xrt::hw_context hwContext;

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_metadata.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_metadata.h
@@ -108,7 +108,7 @@ class AieTraceMetadata {
       hwContext = std::move(c);
     }
 
-    bool isGMIOMetric(const std::string metric) {
+    bool isGMIOMetric(const std::string& metric) const {
       return gmioMetricSets.find(metric) != gmioMetricSets.end();
     }
     bool configMetricsEmpty() const { return configMetrics.empty(); }

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -141,7 +141,7 @@ void AieTracePluginUnified::updateAIEDevice(void *handle) {
     AIEData.valid = false;
     xrt_core::message::send(severity_level::warning, "XRT",
                             AIE_TRACE_TILES_UNAVAILABLE);
-    // return;
+    return;
   }
 
 #ifdef XDP_CLIENT_BUILD

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -137,6 +137,12 @@ void AieTracePluginUnified::updateAIEDevice(void *handle) {
 
   // Metadata depends on static information from the database
   AIEData.metadata = std::make_shared<AieTraceMetadata>(deviceID, handle);
+  if (AIEData.metadata->configMetricsEmpty()) {
+    AIEData.valid = false;
+    xrt_core::message::send(severity_level::warning, "XRT",
+                            AIE_TRACE_TILES_UNAVAILABLE);
+    // return;
+  }
 
 #ifdef XDP_CLIENT_BUILD
   AIEData.metadata->setHwContext(context);

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/util/aie_trace_util.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/util/aie_trace_util.cpp
@@ -247,9 +247,7 @@ namespace xdp::aie::trace {
   {
     if ((metricSet.find("dma") != std::string::npos)
         || (metricSet.find("s2mm") != std::string::npos)
-        || (metricSet.find("mm2s") != std::string::npos)
-        || (metricSet.find("input") != std::string::npos)
-        || (metricSet.find("output") != std::string::npos))
+        || (metricSet.find("mm2s") != std::string::npos))
       return true;
     return false;
   }

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/util/aie_trace_util.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/util/aie_trace_util.cpp
@@ -247,7 +247,9 @@ namespace xdp::aie::trace {
   {
     if ((metricSet.find("dma") != std::string::npos)
         || (metricSet.find("s2mm") != std::string::npos)
-        || (metricSet.find("mm2s") != std::string::npos))
+        || (metricSet.find("mm2s") != std::string::npos)
+        || (metricSet.find("input") != std::string::npos)
+        || (metricSet.find("output") != std::string::npos))
       return true;
     return false;
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Interface tiles input_ports_details or output_ports_details were causing runtime configuration errors with PLIO designs.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1195465 - The root cause is, above metric settings are only supported for GMIO design.

#### How problem was solved, alternative solutions (if any) and why they were rejected
In 2024.1 We now identify such scenario &  issue appropriate warning to the user.

In 2024.2, via [CR-1197261] we would change such metric setting with an equivalent _stalls metric.

#### Risks (if any) associated the changes in the commit
User might see new warnings in runtime logs.

#### What has been tested and how, request additional testing if necessary
VEK280 & Vck190

#### Documentation impact (if any)
