### PR TITLE
CR-1196928: Fixing issue where AIE profiling information was incorrectly dumping data

### DIFF
--- a/src/runtime_src/xdp/profile/database/dynamic_event_database.cpp
+++ b/src/runtime_src/xdp/profile/database/dynamic_event_database.cpp
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2016-2020 Xilinx, Inc
- * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -282,6 +282,13 @@ namespace xdp {
   {
     auto device_db = getDeviceDB(deviceId);
     return device_db->getAIESamples();
+  }
+
+  std::vector<counters::Sample>
+  VPDynamicDatabase::moveAIESamples(uint64_t deviceId)
+  {
+    auto device_db = getDeviceDB(deviceId);
+    return device_db->moveAIESamples();
   }
 
   void VPDynamicDatabase::addAIETimerSample(uint64_t deviceId, unsigned long timestamp1,

--- a/src/runtime_src/xdp/profile/database/dynamic_event_database.h
+++ b/src/runtime_src/xdp/profile/database/dynamic_event_database.h
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2016-2020 Xilinx, Inc
- * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -175,6 +175,7 @@ namespace xdp {
     XDP_CORE_EXPORT void addAIESample(uint64_t deviceId, double timestamp,
 				   const std::vector<uint64_t>& values) ;
     XDP_CORE_EXPORT std::vector<counters::Sample> getAIESamples(uint64_t deviceId) ;
+    XDP_CORE_EXPORT std::vector<counters::Sample> moveAIESamples(uint64_t deviceId);
     XDP_CORE_EXPORT void addAIETimerSample(uint64_t deviceId, unsigned long timestamp1,
 				   unsigned long timestamp2, const std::vector<uint64_t>& values) ;
     XDP_CORE_EXPORT std::vector<counters::DoubleSample> getAIETimerSamples(uint64_t deviceId) ;

--- a/src/runtime_src/xdp/profile/database/dynamic_info/aie_db.h
+++ b/src/runtime_src/xdp/profile/database/dynamic_info/aie_db.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -61,6 +61,10 @@ namespace xdp {
     inline
     std::vector<counters::Sample> getAIESamples()
     { return samples.getSamples();  }
+
+    inline
+    std::vector<counters::Sample> moveAIESamples()
+    { return samples.moveSamples(); }
 
     inline
     std::vector<counters::DoubleSample> getAIETimerSamples()

--- a/src/runtime_src/xdp/profile/database/dynamic_info/device_db.h
+++ b/src/runtime_src/xdp/profile/database/dynamic_info/device_db.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -113,6 +113,9 @@ namespace xdp {
 
     inline std::vector<counters::Sample> getAIESamples()
     { return aie_db.getAIESamples();  }
+
+    inline std::vector<counters::Sample> moveAIESamples()
+    { return aie_db.moveAIESamples(); }
 
     inline std::vector<counters::DoubleSample> getAIETimerSamples()
     { return aie_db.getAIETimerSamples();  }

--- a/src/runtime_src/xdp/profile/database/dynamic_info/samples.h
+++ b/src/runtime_src/xdp/profile/database/dynamic_info/samples.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -50,6 +50,11 @@ namespace xdp {
     {
       std::lock_guard<std::mutex> lock(containerLock);
       return samples;
+    }
+    inline std::vector<counters::Sample> moveSamples()
+    {
+      std::lock_guard<std::mutex> lock(containerLock);
+      return std::move(samples);
     }
     inline uint64_t getSamplesSize()
     {

--- a/src/runtime_src/xdp/profile/writer/aie_profile/aie_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/aie_profile/aie_writer.cpp
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2020-2021 Xilinx, Inc
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -70,7 +70,7 @@ namespace xdp {
     
     // Write all data elements
     std::vector<counters::Sample> samples =
-      db->getDynamicInfo().getAIESamples(mDeviceIndex);
+      db->getDynamicInfo().moveAIESamples(mDeviceIndex);
 
     for (auto& sample : samples) {
       fout << sample.timestamp << ",";


### PR DESCRIPTION
#### Problem solved by the commit
AIE profiling recently introduced a flushing mechanism intended to force write all of the samples in memory to disk when it grew too big.  The change, however, was found to dump a copy of the events and not clean up memory as intended due to a copy instead of a move.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Pull request 7803 introduced the issue.  It was discovered through thorough regression testing.

#### How problem was solved, alternative solutions (if any) and why they were rejected
This pull request changes the AIE profiling writer to move profiling samples from our internal database instead of copying them.  This now matches the model we wanted of cleaning up memory and writing to disk only once.

#### Risks (if any) associated the changes in the commit
Low risk as this is only affecting AIE profiling and the model is now correct.

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
No documentation impact.