### PR TITLE
Release Python GIL during slow load I/O

### DIFF
--- a/src/python/pybind11/src/pyxrt.cpp
+++ b/src/python/pybind11/src/pyxrt.cpp
@@ -129,9 +129,11 @@ PYBIND11_MODULE(pyxrt, m) {
                           return new xrt::device(bfd);
                       }))
         .def("load_xclbin", [](xrt::device& d, const std::string& xclbin) {
+                                py::gil_scoped_release release;
                                 return d.load_xclbin(xclbin);
                             }, "Load an xclbin given the path to the device")
         .def("load_xclbin", [](xrt::device& d, const xrt::xclbin& xclbin) {
+                                py::gil_scoped_release release;
                                 return d.load_xclbin(xclbin);
                             }, "Load the xclbin to the device")
         .def("register_xclbin", [](xrt::device& d, const xrt::xclbin& xclbin) {


### PR DESCRIPTION
#### Problem solved by the commit
When using multiple FPGAs in multiple threads, loading XCLBINs cannot be performed concurrently as pyxrt holds the Python Global Interpreter Lock for the duration of the loading process.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
See AMD WTS support case 00410749

#### How problem was solved, alternative solutions (if any) and why they were rejected
GIL released during slow load operation. [This fix was suggested by AMD support](https://github.com/Xilinx/XRT/commit/7ba034a7600d0ce5c7314288d9c5c727217530dc) in November 2023, but was seemingly never submitted to the code base.

#### Risks (if any) associated the changes in the commit
Believed to be safe

#### What has been tested and how, request additional testing if necessary
AMD support said they have tested it.
A Python snippet to demonstrate the original issue (and prove the fix) is available - https://gitlab.com/ska-telescope/low-cbf/ska-low-cbf-fpga/-/snippets/3613095

#### Documentation impact (if any)
None