### PR TITLE
Add missing include

### DIFF
--- a/src/runtime_src/core/common/shim/shared_handle.h
+++ b/src/runtime_src/core/common/shim/shared_handle.h
@@ -3,6 +3,8 @@
 #ifndef XRT_CORE_SHARED_HANDLE_H
 #define XRT_CORE_SHARED_HANDLE_H
 
+#include <cstdint>
+
 namespace xrt_core {
 
 // shared_handle - Representation of a shared object.


### PR DESCRIPTION
Compilation of header file requires inclusion of cstdint.
