### PR TITLE
VITIS-11639 Small Enhancements to xbutil validate description

### DIFF
--- a/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.cpp
@@ -152,6 +152,10 @@ TestDF_bandwidth::run(std::shared_ptr<xrt_core::device> dev)
   bo_instr.sync(XCL_BO_SYNC_BO_TO_DEVICE);
   bo_ifm.sync(XCL_BO_SYNC_BO_TO_DEVICE);
 
+  //Log
+  logger(ptree, "Details", boost::str(boost::format("Buffer size: '%f'GB") % buffer_size_gb));
+  logger(ptree, "Details", boost::str(boost::format("No. of iterations: '%f'") % itr_count));
+
   XBUtilities::BusyBar busy_bar("Running Test", std::cout); 
   busy_bar.start(XBUtilities::is_escape_codes_disabled());
 
@@ -169,7 +173,7 @@ TestDF_bandwidth::run(std::shared_ptr<xrt_core::device> dev)
     }
   }
   auto end = std::chrono::high_resolution_clock::now();
-    busy_bar.finish();
+  busy_bar.finish();
 
   //map ouput buffer
   bo_ofm.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
@@ -186,7 +190,7 @@ TestDF_bandwidth::run(std::shared_ptr<xrt_core::device> dev)
   float elapsedSecs = std::chrono::duration_cast<std::chrono::duration<float>>(end-start).count();
   //Data is read and written in parallel hence x2
   float bandwidth = (buffer_size_gb*itr_count*2) / elapsedSecs;
-  logger(ptree, "Details", boost::str(boost::format("Total duration: '%f's") % elapsedSecs));
+  logger(ptree, "Details", boost::str(boost::format("Total duration: '%.1f's") % elapsedSecs));
   logger(ptree, "Details", boost::str(boost::format("Average bandwidth per shim DMA: '%.1f' GB/s") % bandwidth));
 
   ptree.put("status", test_token_passed);

--- a/src/runtime_src/core/tools/common/tests/TestIPU.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestIPU.cpp
@@ -19,7 +19,7 @@ static constexpr int itr_count = 10000;
 
 // ----- C L A S S   M E T H O D S -------------------------------------------
 TestIPU::TestIPU()
-  : TestRunner("verify", "Run 'Hello World' test on IPU")
+  : TestRunner("verify", "Run end-to-end latency and throughput test on NPU")
 {}
 
 boost::property_tree::ptree
@@ -82,6 +82,10 @@ TestIPU::run(std::shared_ptr<xrt_core::device> dev)
   bo_ifm.sync(XCL_BO_SYNC_BO_TO_DEVICE);
   bo_param.sync(XCL_BO_SYNC_BO_TO_DEVICE);
   bo_mc.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+
+  //Log
+  logger(ptree, "Details", boost::str(boost::format("Instruction size: '%f' bytes") % buffer_size));
+  logger(ptree, "Details", boost::str(boost::format("No. of iterations: '%f'") % itr_count));
 
   auto start = std::chrono::high_resolution_clock::now();
   for (int i = 0; i < itr_count; i++) {

--- a/src/runtime_src/core/tools/common/tests/TestTCTAllColumn.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestTCTAllColumn.cpp
@@ -74,22 +74,6 @@ TestTCTAllColumn::run(std::shared_ptr<xrt_core::device> dev)
 {
   boost::property_tree::ptree ptree = get_test_header();
 
-  #ifdef _WIN32
-  // workaround: can't rename files when copying to driver store
-  // so need to name the files as _phx and _stx
-  // will revisit this after the current release
-  auto device_id = xrt_core::device_query<xrt_core::query::pcie_device>(dev);
-  switch (device_id) {
-  case 5378: // 0x1502
-    ptree.put("xclbin", "validate_phx.xclbin");
-    break;
-  case 6128: // 0x17f0
-    ptree.put("xclbin", "validate_stx.xclbin");
-    break;
-  }
-  #endif
-
-
   const auto xclbin_name = xrt_core::device_query<xrt_core::query::xclbin_name>(dev, xrt_core::query::xclbin_name::type::validate);
   auto xclbin_path = findPlatformFile(xclbin_name, ptree);
   if (!std::filesystem::exists(xclbin_path))
@@ -164,6 +148,10 @@ TestTCTAllColumn::run(std::shared_ptr<xrt_core::device> dev)
   bo_instr.sync(XCL_BO_SYNC_BO_TO_DEVICE);
   bo_ifm.sync(XCL_BO_SYNC_BO_TO_DEVICE);
 
+  //Log
+  logger(ptree, "Details", boost::str(boost::format("Buffer size: '%f' bytes") % buffer_size));
+  logger(ptree, "Details", boost::str(boost::format("No. of iterations: '%f'") % itr_count));
+
   XBUtilities::BusyBar busy_bar("Running Test", std::cout); 
   busy_bar.start(XBUtilities::is_escape_codes_disabled());
 
@@ -179,7 +167,7 @@ TestTCTAllColumn::run(std::shared_ptr<xrt_core::device> dev)
     return ptree;
   }
   auto end = std::chrono::high_resolution_clock::now();
-    busy_bar.finish();
+  busy_bar.finish();
 
   //map ouput buffer
   bo_ofm.sync(XCL_BO_SYNC_BO_FROM_DEVICE);

--- a/src/runtime_src/core/tools/common/tests/TestTCTOneColumn.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestTCTOneColumn.cpp
@@ -74,22 +74,6 @@ TestTCTOneColumn::run(std::shared_ptr<xrt_core::device> dev)
 {
   boost::property_tree::ptree ptree = get_test_header();
 
-  #ifdef _WIN32
-  // workaround: can't rename files when copying to driver store
-  // so need to name the files as _phx and _stx
-  // will revisit this after the current release
-  auto device_id = xrt_core::device_query<xrt_core::query::pcie_device>(dev);
-  switch (device_id) {
-  case 5378: // 0x1502
-    ptree.put("xclbin", "validate_phx.xclbin");
-    break;
-  case 6128: // 0x17f0
-    ptree.put("xclbin", "validate_stx.xclbin");
-    break;
-  }
-  #endif
-
-
   const auto xclbin_name = xrt_core::device_query<xrt_core::query::xclbin_name>(dev, xrt_core::query::xclbin_name::type::validate);
   auto xclbin_path = findPlatformFile(xclbin_name, ptree);
   if (!std::filesystem::exists(xclbin_path))
@@ -164,6 +148,10 @@ TestTCTOneColumn::run(std::shared_ptr<xrt_core::device> dev)
   bo_instr.sync(XCL_BO_SYNC_BO_TO_DEVICE);
   bo_ifm.sync(XCL_BO_SYNC_BO_TO_DEVICE);
 
+  //Log
+  logger(ptree, "Details", boost::str(boost::format("Buffer size: '%f'bytes") % buffer_size));
+  logger(ptree, "Details", boost::str(boost::format("No. of iterations: '%f'") % itr_count));
+
   XBUtilities::BusyBar busy_bar("Running Test", std::cout); 
   busy_bar.start(XBUtilities::is_escape_codes_disabled());
 
@@ -179,7 +167,7 @@ TestTCTOneColumn::run(std::shared_ptr<xrt_core::device> dev)
     return ptree;
   }
   auto end = std::chrono::high_resolution_clock::now();
-    busy_bar.finish();
+  busy_bar.finish();
 
   //map ouput buffer
   bo_ofm.sync(XCL_BO_SYNC_BO_FROM_DEVICE);

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -241,6 +241,9 @@ get_ryzen_platform_info(const std::shared_ptr<xrt_core::device>& device,
                         boost::property_tree::ptree& ptTree)
 {
   ptTree.put("platform", xrt_core::device_query<xrt_core::query::rom_vbnv>(device));
+  const auto mode = xrt_core::device_query_default<xrt_core::query::performance_mode>(device, 0);
+  ptTree.put("performance_mode", xrt_core::query::performance_mode::parse_status(mode));
+  ptTree.put("power", xrt_core::utils::format_base10_shiftdown6(xrt_core::device_query_default<xrt_core::query::power_microwatts>(device, 0)));
 }
 
 static void
@@ -271,6 +274,12 @@ get_platform_info(const std::shared_ptr<xrt_core::device>& device,
   const std::string& plat_id = ptTree.get("platform_id", "");
   if (!plat_id.empty())
     oStream << boost::format("    %-22s: %s\n") % "Platform ID" % plat_id;
+  const std::string& perf_mode = ptTree.get("performance_mode", "");
+  if (!perf_mode.empty())
+    oStream << boost::format("    %-22s: %s\n") % "Performance Mode" % perf_mode;
+  const std::string& power = ptTree.get("power", "");
+  if (!boost::starts_with(power, ""))
+    oStream << boost::format("    %-22s: %s Watts\n") % "Power" % power;
 }
 
 static test_status


### PR DESCRIPTION
#### Problem solved by the commit
https://jira.xilinx.com/browse/VITIS-11639 (Sub-task)
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
N/A
#### How problem was solved, alternative solutions (if any) and why they were rejected
N/A
#### Risks (if any) associated the changes in the commit
N/A; cosmetic changes
#### What has been tested and how, request additional testing if necessary
MCDM/Strix:
```
C:\Users\sagarw\Desktop\xrt>xbutil validate -r verify --batch
Validate Device           : [00c5:00:01.1]
    Platform              : IPU
    SC Version            : Default
-------------------------------------------------------------------------------
Verbose: Enabling Verbosity
Running Test: ...
Test 1 [00c5:00:01.1]     : verify
    Description           : Run end-to-end latency and throughput test on NPU
    Xclbin                : C:\WINDOWS\System32\DriverStore\FileRepository\ipukmddrv.inf_amd64_09389b4bd4c99086\validate_17f0_10.xclbin
    Details               : Kernel name is 'DPU_PDI_0'
                            Instruction size: '20' bytes
                            No. of iterations: '10000'
                            Total duration: '1.1's
                            Average throughput: '9132.3' ops/s
                            Average latency: '109.5' us
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Validation completed

C:\Users\sagarw\Desktop\xrt>xbutil validate -r all --batch
Validate Device           : [00c5:00:01.1]
    Platform              : IPU
    SC Version            : Default
-------------------------------------------------------------------------------
Running Test: ..
Test 1 [00c5:00:01.1]     : verify
    Details               : Kernel name is 'DPU_PDI_0'
                            Instruction size: '20' bytes
                            No. of iterations: '10000'
                            Total duration: '1.1's
                            Average throughput: '8843.4' ops/s
                            Average latency: '113.1' us
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Running Test: ..Running Test: ..............................................................
.
Test 2 [00c5:00:01.1]     : df-bw
    Details               : Kernel name is 'DPU_PDI_0'
    Details               : Buffer size: '1'GB
                            No. of iterations: '600'
                            Total duration: '31.0's
                            Average bandwidth per shim DMA: '38.7' GB/s
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Running Test: Running Test: ..
.
Test 3 [00c5:00:01.1]     : tct-one-col
    Details               : Kernel name is 'DPU_PDI_0'
    Details               : Buffer size: '4'bytes
                            No. of iterations: '10000'
                            Average time for TCT: '2.4' us
                            Average TCT throughput: '421343.6' TCT/s
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Running Test: .Running Test: ..
.
Test 4 [00c5:00:01.1]     : tct-all-col
    Details               : Kernel name is 'DPU_PDI_0'
    Details               : Buffer size: '4'bytes
                            No. of iterations: '20000's
                            Average time for TCT: '1.2' us
                            Average TCT throughput: '846664.8' TCT/s
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Validation completed. Please run the command '--verbose' option for more details
```
#### Documentation impact (if any)
