### PR TITLE
 VITIS-11623 - use same patching scheme for same hardware regardless of firmware code path

### DIFF
--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -314,6 +314,7 @@ public:
   //
   // @param symbol - symbol name
   // @param bo - global argument to patch into ctrlcode
+  // @param buf_type - whether it is control-code, control-packet, preempt-save or preempt-restore
   virtual void
   patch_instr(const std::string&, const xrt::bo&, patcher::buf_type)
   {
@@ -346,6 +347,7 @@ public:
   // @param base - base address of control code buffer object
   // @param symbol - symbol name
   // @param patch - patch value
+  // @param buf_type - whether it is control-code, control-packet, preempt-save or preempt-restore
   // @Return true if symbol was patched, false otherwise  //
   virtual bool
   patch(uint8_t*, const std::string&, uint64_t, patcher::buf_type)
@@ -984,7 +986,7 @@ class module_sram : public module_impl
     auto os_abi = m_parent.get()->get_os_abi();
     if (os_abi == Elf_Amd_Aie2ps) {
       if (m_patched_args.size() != m_parent->number_of_arg_patchers()) {
-          boost::format fmt = boost::format("ctrlcode requires %d patched arguments, but only %d are patched")
+        auto fmt = boost::format("ctrlcode requires %d patched arguments, but only %d are patched")
             % m_parent->number_of_arg_patchers() % m_patched_args.size();
         throw std::runtime_error{ fmt.str() };
       }
@@ -995,11 +997,12 @@ class module_sram : public module_impl
 #ifdef _DEBUG
       dump_bo(m_instr_buf, "instrBoPatched.bin");
 #endif
-      if (m_ctrlpkt_buf)
+      if (m_ctrlpkt_buf) {
         m_ctrlpkt_buf.sync(XCL_BO_SYNC_BO_TO_DEVICE);
 #ifdef _DEBUG
         dump_bo(m_ctrlpkt_buf, "ctrlpktBoPatched.bin");
 #endif
+        }
     }
 
     m_dirty = false;

--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -81,7 +81,7 @@ struct buf
     if (!column_page_size)
       return;
 
-    auto pad = static_cast<size_t>(page + 1) * column_page_size;
+    auto pad = (page + 1) * column_page_size;
 
     if (m_data.size() > pad)
       throw std::runtime_error("Invalid ELF section size");
@@ -315,7 +315,7 @@ public:
   // @param symbol - symbol name
   // @param bo - global argument to patch into ctrlcode
   virtual void
-  patch_instr(const std::string&, const xrt::bo&, const patcher::buf_type)
+  patch_instr(const std::string&, const xrt::bo&, patcher::buf_type)
   {
     throw std::runtime_error("Not supported ");
   }
@@ -844,7 +844,7 @@ class module_sram : public module_impl
   create_instr_buf(const module_impl* parent)
   {
     XRT_PRINTF("-> module_sram::create_instr_buf()\n");
-    const instr_buf& data = parent->get_instr();
+    const auto& data = parent->get_instr();
     size_t sz = data.size();
 
     if (sz == 0) {
@@ -872,7 +872,7 @@ class module_sram : public module_impl
   create_ctrlpkt_buf(const module_impl* parent)
   {
     XRT_PRINTF("-> module_sram::create_ctrlpkt_buf()\n");
-    const control_packet& data = parent->get_ctrlpkt();
+    const auto& data = parent->get_ctrlpkt();
     size_t sz = data.size();
 
     if (sz == 0) {
@@ -900,7 +900,7 @@ class module_sram : public module_impl
   create_instruction_buffer(const module_impl* parent)
   {
     XRT_PRINTF("-> module_sram::create_instruction_buffer()\n");
-    const std::vector<ctrlcode>& data = parent->get_data();
+    const auto& data = parent->get_data();
 
     // create bo combined size of all ctrlcodes
     size_t sz = std::accumulate(data.begin(), data.end(), static_cast<size_t>(0), [](auto acc, const auto& ctrlcode) {
@@ -920,7 +920,7 @@ class module_sram : public module_impl
   }
 
   virtual void
-  patch_instr(const std::string& argnm, const xrt::bo& bo, const patcher::buf_type type) override
+  patch_instr(const std::string& argnm, const xrt::bo& bo, patcher::buf_type type) override
   {
     patch_instr_value(argnm, bo.address(), type);
   }

--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -197,11 +197,10 @@ struct patcher
         patch_shim48(bd_data_ptr, patch);
         break;
       case symbol_type::tansaction_ctrlpkt_48:
-          // Will change "bd_data_ptr - 8" to "bd_data_ptr" once assembler is fixed
-          patch_ctrl48(bd_data_ptr - 8, patch);
+        patch_ctrl48(bd_data_ptr, patch);
         break;
       case symbol_type::tansaction_48:
-        // No patching since transaction buffer firmware does not support
+        patch_shim48(bd_data_ptr, patch);
         break;
       default:
         throw std::runtime_error("Unsupported symbol type");
@@ -841,8 +840,6 @@ class module_sram : public module_impl
     dump_bo(m_instr_buf, "instrBo.bin");
 #endif
 
-    ///// THIS IS A BUG, create_instr_buf is called in constructor
-    // patch_instr is a virtual method, what is actually called here ???
     if (m_ctrlpkt_buf) {
       patch_instr("control-packet", m_ctrlpkt_buf);
     }

--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -131,9 +131,9 @@ struct patcher
   std::vector<uint64_t> m_ctrlcode_offset;
 
   patcher(symbol_type type, std::vector<uint64_t> ctrlcode_offset, buf_type t)
-    : m_symbol_type(type)
+    : m_buf_type(t)
+    , m_symbol_type(type)
     , m_ctrlcode_offset(std::move(ctrlcode_offset))
-    , m_buf_type(t)
   {}
 
   void


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Currently transaction-buffer and dpu-sequence uses different patching scheme. But same hardware should use same patching scheme.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Merge different patching scheme by adjusting offset in assembler. Refer to assembler PR (https://gitenterprise.xilinx.com/XRT/aiebu/pull/22/files)
#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
1. Dump file ctrlpktBoPatched.bin before adjusting offset and after adjusting offset, compare the two files and they are identical
2. With this change, now all 4 test cases from xcompiler-team are working.
Without this change, case-conv1 does not work, This is documented in https://jira.xilinx.com/browse/VITIS-11623
#### Documentation impact (if any)
