### PR TITLE
VITIS-11824 Consolidate examine and platform reports

### DIFF
--- a/src/runtime_src/core/common/info_platform.cpp
+++ b/src/runtime_src/core/common/info_platform.cpp
@@ -390,26 +390,6 @@ add_mac_info(const xrt_core::device* device, ptree_type& pt)
   }
 }
 
-static void
-add_firmware_info(const xrt_core::device* device, ptree_type& pt)
-{
-  ptree_type pt_firmware;
-
-  const auto fw_ver = xrt_core::device_query_default<xq::firmware_version>(device, {0,0,0,0});
-  std::string version = "N/A";
-  if (fw_ver.major != 0 || fw_ver.minor != 0 || fw_ver.patch != 0 || fw_ver.build != 0) {
-    version = boost::str(boost::format("%u.%u.%u.%u")
-      % fw_ver.major % fw_ver.minor % fw_ver.patch % fw_ver.build);
-    pt_firmware.add("major", fw_ver.major);
-    pt_firmware.add("minor", fw_ver.minor);
-    pt_firmware.add("patch", fw_ver.patch);
-    pt_firmware.add("build", fw_ver.build);
-  }
-  pt_firmware.add("version", version);
-
-  pt.put_child("firmware", pt_firmware);
-}
-
 void
 add_platform_info(const xrt_core::device* device, ptree_type& pt_platform_array)
 {
@@ -434,9 +414,6 @@ add_platform_info(const xrt_core::device* device, ptree_type& pt_platform_array)
     add_config_info(device, pt_platform);
     break;
   }
-  case xrt_core::query::device_class::type::ryzen:
-    add_firmware_info(device, pt_platform);
-    break;
   default:
     break;
   }

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -133,6 +133,19 @@ XBUtilities::get_available_devices(bool inUserDomain)
       }
 
       try {
+        const auto fw_ver = xrt_core::device_query_default<xq::firmware_version>(device, {0,0,0,0});
+        std::string version = "N/A";
+        if (fw_ver.major != 0 || fw_ver.minor != 0 || fw_ver.patch != 0 || fw_ver.build != 0) {
+          version = boost::str(boost::format("%u.%u.%u.%u")
+            % fw_ver.major % fw_ver.minor % fw_ver.patch % fw_ver.build);
+        }
+        pt_dev.put("firmware_version", version);
+      }
+      catch(...) {
+        // The firmware wasn't added
+      }
+
+      try {
         auto instance = xrt_core::device_query<xrt_core::query::instance>(device);
         std::string pf = device->is_userpf() ? "user" : "mgmt";
         pt_dev.put("instance",boost::str(boost::format("%s(inst=%d)") % pf % instance));

--- a/src/runtime_src/core/tools/common/reports/ReportHost.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportHost.cpp
@@ -112,6 +112,7 @@ ReportHost::writeReport(const xrt_core::device* /*_pDevice*/,
   boost::property_tree::ptree empty_ptree;
 
   _output << "System Configuration\n";
+  const boost::property_tree::ptree& available_devices = _pt.get_child("host.devices", empty_ptree);
   try {
     _output << boost::format("  %-20s : %s\n") % "OS Name" % _pt.get<std::string>("host.os.sysname");
     _output << boost::format("  %-20s : %s\n") % "Release" % _pt.get<std::string>("host.os.release");
@@ -151,16 +152,20 @@ ReportHost::writeReport(const xrt_core::device* /*_pDevice*/,
       if (boost::iequals(drv_name, "xclmgmt") && boost::iequals(driver.get<std::string>("version", "N/A"), "unknown"))
         _output << "WARNING: xclmgmt version is unknown. Is xclmgmt driver loaded? Or is MSD/MPD running?" << std::endl;
     }
-    _output << std::endl;
   }
   catch (const boost::property_tree::ptree_error &ex) {
     throw xrt_core::error(boost::str(boost::format("%s. Please contact your Xilinx representative to fix the issue")
          % ex.what()));
   }
 
-  _output << "Devices present\n";
-  const boost::property_tree::ptree& available_devices = _pt.get_child("host.devices", empty_ptree);
+  try {
+    _output << boost::format("  %-20s : %s\n") % "Firmware Version" % available_devices.begin()->second.get<std::string>("firmware_version");
+  }
+  catch (const xrt_core::query::exception&) {
+    //no device available
+  }
 
+  _output << std::endl << "Devices present\n";
   if (available_devices.empty())
     _output << "  0 devices found" << std::endl;
 

--- a/src/runtime_src/core/tools/common/reports/platform/ReportRyzenPlatform.cpp
+++ b/src/runtime_src/core/tools/common/reports/platform/ReportRyzenPlatform.cpp
@@ -49,9 +49,6 @@ ReportRyzenPlatform::writeReport(const xrt_core::device* /*_pDevice*/,
     const boost::property_tree::ptree& pt_static_region = pt_platform.get_child("static_region", empty_ptree);
     _output << boost::format("  %-23s: %s \n") % "Name" % pt_static_region.get<std::string>("name");
 
-    const boost::property_tree::ptree& pt_fw = pt_platform.get_child("firmware");
-    _output << boost::format("  %-23s: %s\n") % "Firmware Version" % pt_fw.get<std::string>("version");
-
     const boost::property_tree::ptree& pt_status = pt_platform.get_child("status");
     _output << boost::format("  %-23s: %s \n") % "Performance Mode" % pt_status.get<std::string>("performance_mode");
 


### PR DESCRIPTION
#### Problem solved by the commit
https://jira.xilinx.com/browse/VITIS-11824
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
N/A
#### How problem was solved, alternative solutions (if any) and why they were rejected
Moved firmware version to host report from platform report.
#### Risks (if any) associated the changes in the commit
N/A; cosmetic changes
#### What has been tested and how, request additional testing if necessary
On MCDM/Strix:
```
C:\Users\sagarw\Desktop\xrt>xbutil examine
System Configuration
  OS Name              : Windows NT
  Release              : 26085.ge_release.240315-1352
  Version              : 6.3
  Machine              : x86_64
  CPU Cores            : 24
  Memory               : 32109 MB
  Distribution         : Windows 10 Pro
  Model                : BIRMANPLUS
  BIOS vendor          : AMD    - 0
  BIOS version         : 3.3

XRT
  Version              : 2.17.0
  Branch               : HEAD
  Hash                 : 6ed717d2a7e9cdcf570ea485e0fc84980bf94161
  Hash Date            : 2024-04-11 10:29:15
  IPUKMDDRV            : 10.1.0.1
  Firmware Version     : 0.7.6.54

Devices present
BDF             :  Name
-------------------------
[00c5:00:01.1]  :  IPU
```
#### Documentation impact (if any)