### PR TITLE
Temporarily disable telemetry report for RyzenAI

### DIFF
--- a/src/runtime_src/core/tools/xbutil2/xbutil.cpp
+++ b/src/runtime_src/core/tools/xbutil2/xbutil.cpp
@@ -54,7 +54,7 @@ R"(
 },{
   "aie": [{
     "examine": [{
-      "report": ["electrical", "host", "platform", "aie", "aiemem", "aieshim", "aie-partitions", "telemetry"]
+      "report": ["electrical", "host", "platform", "aie", "aiemem", "aieshim", "aie-partitions"]
     }]
   },{
     "configure": [{


### PR DESCRIPTION
#### Problem solved by the commit
Telemetry Report needs to be temporarily disabled in XRT. Raj's firmware changes have not been merged yet in last Friday's release.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
N/A
#### How problem was solved, alternative solutions (if any) and why they were rejected
N/A
#### Risks (if any) associated the changes in the commit
N/A
#### What has been tested and how, request additional testing if necessary
Telemetry report will not show up in help menu/examine -r telemetry is disabled.
#### Documentation impact (if any)