### PR TITLE
Building Hip in XRT as part of Ubuntu 2204

### DIFF
--- a/.github/workflows/xrt_ci.yml
+++ b/.github/workflows/xrt_ci.yml
@@ -44,7 +44,7 @@ jobs:
             packageType: rpm      
           - os: ubuntu2004      
             packageType: deb      
-          - os: ubuntu2204      
+          - os: hip      
             packageType: deb      
         
     runs-on: [self-hosted, Ubuntu-22.04]

--- a/.github/workflows/xrt_ci.yml
+++ b/.github/workflows/xrt_ci.yml
@@ -230,7 +230,7 @@ jobs:
           token: ${{ secrets.ACCESS_TOKEN }}
           github-server-url: ${{ secrets.SERVER_URL }}      
           path: composite-workflows   
-          ref: xti
+          ref: main
        
       - name: Use composite action for pcie-hw       
         uses: ./composite-workflows/pcie-hw  
@@ -266,7 +266,7 @@ jobs:
           token: ${{ secrets.ACCESS_TOKEN }}
           github-server-url: ${{ secrets.SERVER_URL }}       
           path: composite-workflows   
-          ref: xti
+          ref: main
        
       - name: Use composite action for pcie-hw       
         uses: ./composite-workflows/emulation
@@ -303,7 +303,7 @@ jobs:
           token: ${{ secrets.ACCESS_TOKEN }}
           github-server-url: ${{ secrets.SERVER_URL }}       
           path: composite-workflows  
-          ref: xti
+          ref: main
        
       - name: Use composite action for pcie-hw       
         uses: ./composite-workflows/emulation

--- a/.github/workflows/xrt_ci.yml
+++ b/.github/workflows/xrt_ci.yml
@@ -230,7 +230,7 @@ jobs:
           token: ${{ secrets.ACCESS_TOKEN }}
           github-server-url: ${{ secrets.SERVER_URL }}      
           path: composite-workflows   
-          ref: main
+          ref: xti
        
       - name: Use composite action for pcie-hw       
         uses: ./composite-workflows/pcie-hw  
@@ -266,7 +266,7 @@ jobs:
           token: ${{ secrets.ACCESS_TOKEN }}
           github-server-url: ${{ secrets.SERVER_URL }}       
           path: composite-workflows   
-          ref: main
+          ref: xti
        
       - name: Use composite action for pcie-hw       
         uses: ./composite-workflows/emulation
@@ -303,7 +303,7 @@ jobs:
           token: ${{ secrets.ACCESS_TOKEN }}
           github-server-url: ${{ secrets.SERVER_URL }}       
           path: composite-workflows  
-          ref: main
+          ref: xti
        
       - name: Use composite action for pcie-hw       
         uses: ./composite-workflows/emulation

--- a/.github/workflows/xrt_master.yml
+++ b/.github/workflows/xrt_master.yml
@@ -27,7 +27,7 @@ jobs:
           - os: ubuntu2004      
             packageType: deb
             os_ver: ubuntu_20.04      
-          - os: ubuntu2204      
+          - os: hip      
             packageType: deb
             os_ver: ubuntu_22.04      
         

--- a/.github/workflows/xrt_master.yml
+++ b/.github/workflows/xrt_master.yml
@@ -109,7 +109,7 @@ jobs:
       - name: XRT windows build     
         uses: ./composite-workflows/windows-build
         with:     
-          workspace: ${{ github.workspace }}/${{ env.XRT_VERSION_PATCH }}/build   
+          workspace: ${{ github.workspace }}/${{ github.run_number }}/build   
           buildNumber: ${{ github.run_number }}    
           release: ${{ env.RELEASE }}
           accessToken: ${{ secrets.ACCESS_TOKEN }} 


### PR DESCRIPTION
Replacing Ubuntu 2204 with Hip builds as per the request. cc @chvamshi-xilinx 