### PR TITLE
xbutil aie core tile status report fix due to relative values of column in AIE_METADATA

### DIFF
--- a/src/runtime_src/core/common/info_aie.cpp
+++ b/src/runtime_src/core/common/info_aie.cpp
@@ -839,6 +839,11 @@ populate_aie_from_metadata(const xrt_core::device* device, boost::property_tree:
   pt.put("schema_version.minor", pt_aie.get<uint32_t>("schema_version.minor"));
   pt.put("schema_version.patch", pt_aie.get<uint32_t>("schema_version.patch"));
 
+  auto start_col = 0;
+  auto overlay_start_cols = pt_aie.get_child_optional("aie_metadata.driver_config.partition_overlay_start_cols");
+  if (overlay_start_cols && !overlay_start_cols->empty()) 
+    start_col = overlay_start_cols->begin()->second.get_value<uint8_t>();
+
   // Extract Graphs from aie_metadata and populate the aie
   for (auto& gr: pt_aie.get_child("aie_metadata.graphs", empty_pt)) {
     boost::property_tree::ptree& igraph = gr.second;
@@ -854,9 +859,9 @@ populate_aie_from_metadata(const xrt_core::device* device, boost::property_tree:
     auto memaddr_it = gr.second.get_child("iteration_memory_addresses").begin();
     for (const auto& node : gr.second.get_child("core_columns", empty_pt)) {
       boost::property_tree::ptree tile;
-      tile.put("column", node.second.data());
+      tile.put("column", (std::stoul(node.second.data()) + start_col));
       tile.put("row", row_it->second.data());
-      tile.put("memory_column", memcol_it->second.data());
+      tile.put("memory_column", (std::stoul(memcol_it->second.data()) + start_col));
       tile.put("memory_row", memrow_it->second.data());
       tile.put("memory_address", memaddr_it->second.data());
       populate_aie_core(core_info, tile);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
xbutil aie core tile report will be fixed to report status of correct tile position.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
None
#### How problem was solved, alternative solutions (if any) and why they were rejected
Due to the xclbin AIE_METADATA section reporting relative location of tile, the XRT codebase has been modified to take the values as relative and modify the reports accordingly.
#### Risks (if any) associated the changes in the commit
Low
#### What has been tested and how, request additional testing if necessary
verified using independently compiled graph testcase.
#### Documentation impact (if any)
NA