### PR TITLE
Xrt macro rename

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
@@ -210,7 +210,6 @@ enum {
 
 #define	MGMTPF		0
 #define	USERPF		1
-
 #if PF == MGMTPF
 #define SUBDEV_SUFFIX	".m"
 #elif PF == USERPF
@@ -281,7 +280,8 @@ enum {
 #define XOCL_ERT_CTRL           "ert_ctrl"
 #define XOCL_ERT_CTRL_VERSAL    "ert_ctrl.versal"
 
-#define XOCL_DEVNAME(str)	str SUBDEV_SUFFIX
+#define XOCL_USERPF_DEVICE(str) str ".u"
+#define XOCL_MGMTPF_DEVICE(str) str ".m"
 
 enum subdev_id {
 	XOCL_SUBDEV_FEATURE_ROM,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
@@ -1665,7 +1665,7 @@ static struct pci_driver xclmgmt_driver = {
 	.err_handler = &xclmgmt_err_handler,
 };
 
-static int (*drv_reg_funcs[])(void) __initdata = {
+static int (*drv_reg_funcs[])(bool) __initdata = {
 	xocl_init_feature_rom,
 	xocl_init_version_control,
 	xocl_init_iores,
@@ -1701,7 +1701,7 @@ static int (*drv_reg_funcs[])(void) __initdata = {
 	xocl_init_hwmon_sdm,
 };
 
-static void (*drv_unreg_funcs[])(void) = {
+static void (*drv_unreg_funcs[])(bool) = {
 	xocl_fini_feature_rom,
 	xocl_fini_version_control,
 	xocl_fini_iores,
@@ -1759,7 +1759,7 @@ static int __init xclmgmt_init(void)
 
 	/* Need to init sub device driver before pci driver register */
 	for (i = 0; i < ARRAY_SIZE(drv_reg_funcs); ++i) {
-		res = drv_reg_funcs[i]();
+		res = drv_reg_funcs[i](true);
 		if (res)
 			goto drv_init_err;
 	}
@@ -1773,7 +1773,7 @@ static int __init xclmgmt_init(void)
 drv_init_err:
 reg_err:
 	for (i--; i >= 0; i--)
-		drv_unreg_funcs[i]();
+		drv_unreg_funcs[i](true);
 
 	unregister_chrdev_region(xclmgmt_devnode, XOCL_MAX_DEVICES);
 alloc_err:
@@ -1790,7 +1790,7 @@ static void xclmgmt_exit(void)
 	pci_unregister_driver(&xclmgmt_driver);
 
 	for (i = ARRAY_SIZE(drv_unreg_funcs) - 1; i >= 0; i--)
-		drv_unreg_funcs[i]();
+		drv_unreg_funcs[i](true);
 
 	/* unregister this driver from the PCI bus driver */
 	unregister_chrdev_region(xclmgmt_devnode, XOCL_MAX_DEVICES);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.h
@@ -217,8 +217,8 @@ int xclmgmt_config_pci(struct xclmgmt_dev *lro);
 /* mgmt-xvc.c */
 long xvc_ioctl(struct xclmgmt_dev *lro, const void __user *arg);
 
-int __init xocl_init_nifd(void);
-void xocl_fini_nifd(void);
+int __init xocl_init_nifd(bool);
+void xocl_fini_nifd(bool);
 
 /* mgmt-sysfs.c */
 int mgmt_init_sysfs(struct device *dev);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-utils.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-utils.c
@@ -835,7 +835,7 @@ static int xclmgmt_refresh_fdt_blob(struct xclmgmt_dev *lro, const char *fw_buf)
 	ret = xocl_fdt_blob_input(lro,
 			(char *)fw_buf + dtc_header->m_sectionOffset,
 			dtc_header->m_sectionSize, XOCL_SUBDEV_LEVEL_BLD,
-			bin_axlf->m_header.m_platformVBNV);
+			bin_axlf->m_header.m_platformVBNV, true);
 	if (ret)
 		mgmt_err(lro, "Invalid PARTITION_METADATA");
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/accel_deadlock_detector.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/accel_deadlock_detector.c
@@ -267,7 +267,7 @@ static struct platform_driver  accel_deadlock_detector_driver = {
     .id_table = accel_deadlock_detector_id_table,
 };
 
-int __init xocl_init_accel_deadlock_detector(void)
+int __init xocl_init_accel_deadlock_detector(bool flag)
 {
     int err = 0;
 
@@ -290,7 +290,7 @@ err_chrdev_reg:
     return err;
 }
 
-void xocl_fini_accel_deadlock_detector(void)
+void xocl_fini_accel_deadlock_detector(bool flag)
 {
     unregister_chrdev_region(accel_deadlock_detector_priv.dev, XOCL_MAX_DEVICES);
     platform_driver_unregister(&accel_deadlock_detector_driver);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/accel_deadlock_detector.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/accel_deadlock_detector.c
@@ -254,7 +254,7 @@ struct xocl_drv_private accel_deadlock_detector_priv = {
 };
 
 struct platform_device_id accel_deadlock_detector_id_table[] = {
-    { XOCL_DEVNAME(XOCL_ACCEL_DEADLOCK_DETECTOR), (kernel_ulong_t)&accel_deadlock_detector_priv },
+    { XOCL_USERPF_DEVICE(XOCL_ACCEL_DEADLOCK_DETECTOR), (kernel_ulong_t)&accel_deadlock_detector_priv },
     { },
 };
 
@@ -262,7 +262,7 @@ static struct platform_driver  accel_deadlock_detector_driver = {
     .probe    = accel_deadlock_detector_probe,
     .remove    = accel_deadlock_detector_remove,
     .driver    = {
-            .name = XOCL_DEVNAME(XOCL_ACCEL_DEADLOCK_DETECTOR),
+            .name = XOCL_USERPF_DEVICE(XOCL_ACCEL_DEADLOCK_DETECTOR),
         },
     .id_table = accel_deadlock_detector_id_table,
 };

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/address_translator.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/address_translator.c
@@ -429,12 +429,12 @@ static struct platform_driver	addr_translator_driver = {
 	.id_table = addr_translator_id_table,
 };
 
-int __init xocl_init_addr_translator(void)
+int __init xocl_init_addr_translator(bool flag)
 {
 	return platform_driver_register(&addr_translator_driver);
 }
 
-void xocl_fini_addr_translator(void)
+void xocl_fini_addr_translator(bool flag)
 {
 	platform_driver_unregister(&addr_translator_driver);
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/address_translator.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/address_translator.c
@@ -416,7 +416,7 @@ struct xocl_drv_private addr_translator_priv = {
 };
 
 struct platform_device_id addr_translator_id_table[] = {
-	{ XOCL_DEVNAME(XOCL_ADDR_TRANSLATOR), (kernel_ulong_t)&addr_translator_priv },
+	{ XOCL_USERPF_DEVICE(XOCL_ADDR_TRANSLATOR), (kernel_ulong_t)&addr_translator_priv },
 	{ },
 };
 
@@ -424,7 +424,7 @@ static struct platform_driver	addr_translator_driver = {
 	.probe		= addr_translator_probe,
 	.remove		= addr_translator_remove,
 	.driver		= {
-		.name = XOCL_DEVNAME(XOCL_ADDR_TRANSLATOR),
+		.name = XOCL_USERPF_DEVICE(XOCL_ADDR_TRANSLATOR),
 	},
 	.id_table = addr_translator_id_table,
 };

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/aim.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/aim.c
@@ -453,7 +453,7 @@ static struct platform_driver	aim_driver = {
 	.id_table = aim_id_table,
 };
 
-int __init xocl_init_aim(void)
+int __init xocl_init_aim(bool flag)
 {
 	int err = 0;
 
@@ -473,7 +473,7 @@ err_chrdev_reg:
 	return err;
 }
 
-void xocl_fini_aim(void)
+void xocl_fini_aim(bool flag)
 {
 	unregister_chrdev_region(aim_priv.dev, XOCL_MAX_DEVICES);
 	platform_driver_unregister(&aim_driver);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/aim.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/aim.c
@@ -440,7 +440,7 @@ struct xocl_drv_private aim_priv = {
 };
 
 struct platform_device_id aim_id_table[] = {
-	{ XOCL_DEVNAME(XOCL_AIM), (kernel_ulong_t)&aim_priv },
+	{ XOCL_USERPF_DEVICE(XOCL_AIM), (kernel_ulong_t)&aim_priv },
 	{ },
 };
 
@@ -448,7 +448,7 @@ static struct platform_driver	aim_driver = {
 	.probe		= aim_probe,
 	.remove		= aim_remove,
 	.driver		= {
-		.name = XOCL_DEVNAME(XOCL_AIM),
+		.name = XOCL_USERPF_DEVICE(XOCL_AIM),
 	},
 	.id_table = aim_id_table,
 };

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/am.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/am.c
@@ -445,7 +445,7 @@ static struct platform_driver	am_driver = {
 	.id_table = am_id_table,
 };
 
-int __init xocl_init_am(void)
+int __init xocl_init_am(bool flag)
 {
 	int err = 0;
 
@@ -465,7 +465,7 @@ err_chrdev_reg:
 	return err;
 }
 
-void xocl_fini_am(void)
+void xocl_fini_am(bool flag)
 {
 	unregister_chrdev_region(am_priv.dev, XOCL_MAX_DEVICES);
 	platform_driver_unregister(&am_driver);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/am.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/am.c
@@ -432,7 +432,7 @@ struct xocl_drv_private am_priv = {
 };
 
 struct platform_device_id am_id_table[] = {
-	{ XOCL_DEVNAME(XOCL_AM), (kernel_ulong_t)&am_priv },
+	{ XOCL_USERPF_DEVICE(XOCL_AM), (kernel_ulong_t)&am_priv },
 	{ },
 };
 
@@ -440,7 +440,7 @@ static struct platform_driver	am_driver = {
 	.probe		= am_probe,
 	.remove		= am_remove,
 	.driver		= {
-		.name = XOCL_DEVNAME(XOCL_AM),
+		.name = XOCL_USERPF_DEVICE(XOCL_AM),
 	},
 	.id_table = am_id_table,
 };

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/asm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/asm.c
@@ -366,7 +366,7 @@ struct xocl_drv_private asm_priv = {
 };
 
 struct platform_device_id asm_id_table[] = {
-	{ XOCL_DEVNAME(XOCL_ASM), (kernel_ulong_t)&asm_priv },
+	{ XOCL_USERPF_DEVICE(XOCL_ASM), (kernel_ulong_t)&asm_priv },
 	{ },
 };
 
@@ -374,7 +374,7 @@ static struct platform_driver	asm_driver = {
 	.probe		= asm_probe,
 	.remove		= asm_remove,
 	.driver		= {
-		.name = XOCL_DEVNAME(XOCL_ASM),
+		.name = XOCL_USERPF_DEVICE(XOCL_ASM),
 	},
 	.id_table = asm_id_table,
 };

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/asm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/asm.c
@@ -379,7 +379,7 @@ static struct platform_driver	asm_driver = {
 	.id_table = asm_id_table,
 };
 
-int __init xocl_init_asm(void)
+int __init xocl_init_asm(bool flag)
 {
 	int err = 0;
 
@@ -399,7 +399,7 @@ err_chrdev_reg:
 	return err;
 }
 
-void xocl_fini_asm(void)
+void xocl_fini_asm(bool flag)
 {
 	unregister_chrdev_region(asm_priv.dev, XOCL_MAX_DEVICES);
 	platform_driver_unregister(&asm_driver);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/axigate.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/axigate.c
@@ -258,12 +258,12 @@ static struct platform_driver	axi_gate_driver = {
 	.id_table = axigate_id_table,
 };
 
-int __init xocl_init_axigate(void)
+int __init xocl_init_axigate(bool flag)
 {
 	return platform_driver_register(&axi_gate_driver);
 }
 
-void xocl_fini_axigate(void)
+void xocl_fini_axigate(bool flag)
 {
 	platform_driver_unregister(&axi_gate_driver);
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/axigate.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/axigate.c
@@ -245,7 +245,7 @@ struct xocl_drv_private axigate_priv = {
 };
 
 struct platform_device_id axigate_id_table[] = {
-	{ XOCL_DEVNAME(XOCL_AXIGATE), (kernel_ulong_t)&axigate_priv },
+	{ XOCL_MGMTPF_DEVICE(XOCL_AXIGATE), (kernel_ulong_t)&axigate_priv },
 	{ },
 };
 
@@ -253,7 +253,7 @@ static struct platform_driver	axi_gate_driver = {
 	.probe		= axigate_probe,
 	.remove		= axigate_remove,
 	.driver		= {
-		.name = XOCL_DEVNAME(XOCL_AXIGATE),
+		.name = XOCL_MGMTPF_DEVICE(XOCL_AXIGATE),
 	},
 	.id_table = axigate_id_table,
 };

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/calib_storage.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/calib_storage.c
@@ -195,7 +195,7 @@ struct xocl_drv_private calib_storage_priv = {
 };
 
 struct platform_device_id calib_storage_id_table[] = {
-	{ XOCL_DEVNAME(XOCL_CALIB_STORAGE), (kernel_ulong_t)&calib_storage_priv },
+	{ XOCL_MGMTPF_DEVICE(XOCL_CALIB_STORAGE), (kernel_ulong_t)&calib_storage_priv },
 	{ },
 };
 
@@ -203,7 +203,7 @@ static struct platform_driver	calib_storage_driver = {
 	.probe		= calib_storage_probe,
 	.remove		= calib_storage_remove,
 	.driver		= {
-		.name = XOCL_DEVNAME(XOCL_CALIB_STORAGE),
+		.name = XOCL_MGMTPF_DEVICE(XOCL_CALIB_STORAGE),
 	},
 	.id_table = calib_storage_id_table,
 };

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/calib_storage.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/calib_storage.c
@@ -208,12 +208,12 @@ static struct platform_driver	calib_storage_driver = {
 	.id_table = calib_storage_id_table,
 };
 
-int __init xocl_init_calib_storage(void)
+int __init xocl_init_calib_storage(bool flag)
 {
 	return platform_driver_register(&calib_storage_driver);
 }
 
-void xocl_fini_calib_storage(void)
+void xocl_fini_calib_storage(bool flag)
 {
 	platform_driver_unregister(&calib_storage_driver);
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/cfg_gpio.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/cfg_gpio.c
@@ -182,12 +182,12 @@ static struct platform_driver	config_gpio_driver = {
 	.id_table = config_gpio_id_table,
 };
 
-int __init xocl_init_config_gpio(void)
+int __init xocl_init_config_gpio(bool flag)
 {
 	return platform_driver_register(&config_gpio_driver);
 }
 
-void xocl_fini_config_gpio(void)
+void xocl_fini_config_gpio(bool flag)
 {
 	platform_driver_unregister(&config_gpio_driver);
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/cfg_gpio.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/cfg_gpio.c
@@ -169,7 +169,7 @@ struct xocl_drv_private config_gpio_priv = {
 };
 
 struct platform_device_id config_gpio_id_table[] = {
-	{ XOCL_DEVNAME(XOCL_CFG_GPIO), (kernel_ulong_t)&config_gpio_priv },
+	{ XOCL_USERPF_DEVICE(XOCL_CFG_GPIO), (kernel_ulong_t)&config_gpio_priv },
 	{ },
 };
 
@@ -177,7 +177,7 @@ static struct platform_driver	config_gpio_driver = {
 	.probe		= config_gpio_probe,
 	.remove		= config_gpio_remove,
 	.driver		= {
-		.name = XOCL_DEVNAME(XOCL_CFG_GPIO),
+		.name = XOCL_USERPF_DEVICE(XOCL_CFG_GPIO),
 	},
 	.id_table = config_gpio_id_table,
 };

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/clock_counter.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/clock_counter.c
@@ -346,30 +346,61 @@ failed:
 	return ret;
 }
 
-struct xocl_drv_private clock_counter_priv = {
+struct xocl_drv_private clock_counter_priv_mgmtpf = {
 	.ops = &clock_counter_ops,
 };
 
-struct platform_device_id clock_counter_id_table[] = {
-	{ XOCL_DEVNAME(XOCL_CLOCK_COUNTER), (kernel_ulong_t)&clock_counter_priv },
+struct platform_device_id clock_counter_id_table_mgmtpf[] = {
+	{ XOCL_DEVNAME(XOCL_CLOCK_COUNTER), (kernel_ulong_t)&clock_counter_priv_mgmtpf },
 	{ },
 };
 
-static struct platform_driver clock_counter_driver = {
+static struct platform_driver clock_counter_driver_mgmtpf = {
 	.probe		= clock_counter_probe,
 	.remove		= clock_counter_remove,
 	.driver		= {
 		.name = XOCL_DEVNAME(XOCL_CLOCK_COUNTER),
 	},
-	.id_table = clock_counter_id_table,
+	.id_table = clock_counter_id_table_mgmtpf,
 };
 
-int __init xocl_init_clock_counter(void)
+struct xocl_drv_private clock_counter_priv_userpf = {
+        .ops = &clock_counter_ops,
+};
+
+struct platform_device_id clock_counter_id_table_userpf[] = {
+        { XOCL_DEVNAME(XOCL_CLOCK_COUNTER), (kernel_ulong_t)&clock_counter_priv_userpf },
+        { },
+};
+
+static struct platform_driver clock_counter_driver_userpf = {
+        .probe          = clock_counter_probe,
+        .remove         = clock_counter_remove,
+        .driver         = {
+                .name = XOCL_DEVNAME(XOCL_CLOCK_COUNTER),
+        },
+        .id_table = clock_counter_id_table_userpf,
+};
+
+
+int __init xocl_init_clock_counter(bool flag)
 {
-	return platform_driver_register(&clock_counter_driver);
+	if(flag)
+	{
+            return platform_driver_register(&clock_counter_driver_mgmtpf);
+	}
+	else
+	{
+            return platform_driver_register(&clock_counter_driver_userpf);
+	}
 }
 
-void xocl_fini_clock_counter(void)
+void xocl_fini_clock_counter(bool flag)
 {
-	platform_driver_unregister(&clock_counter_driver);
+    if (flag) {
+	platform_driver_unregister(&clock_counter_driver_mgmtpf);
+    } else {
+	platform_driver_unregister(&clock_counter_driver_userpf);
+    }
+
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/clock_counter.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/clock_counter.c
@@ -351,7 +351,7 @@ struct xocl_drv_private clock_counter_priv_mgmtpf = {
 };
 
 struct platform_device_id clock_counter_id_table_mgmtpf[] = {
-	{ XOCL_DEVNAME(XOCL_CLOCK_COUNTER), (kernel_ulong_t)&clock_counter_priv_mgmtpf },
+	{ XOCL_MGMTPF_DEVICE(XOCL_CLOCK_COUNTER), (kernel_ulong_t)&clock_counter_priv_mgmtpf },
 	{ },
 };
 
@@ -359,7 +359,7 @@ static struct platform_driver clock_counter_driver_mgmtpf = {
 	.probe		= clock_counter_probe,
 	.remove		= clock_counter_remove,
 	.driver		= {
-		.name = XOCL_DEVNAME(XOCL_CLOCK_COUNTER),
+		.name = XOCL_MGMTPF_DEVICE(XOCL_CLOCK_COUNTER),
 	},
 	.id_table = clock_counter_id_table_mgmtpf,
 };
@@ -369,7 +369,7 @@ struct xocl_drv_private clock_counter_priv_userpf = {
 };
 
 struct platform_device_id clock_counter_id_table_userpf[] = {
-        { XOCL_DEVNAME(XOCL_CLOCK_COUNTER), (kernel_ulong_t)&clock_counter_priv_userpf },
+        { XOCL_USERPF_DEVICE(XOCL_CLOCK_COUNTER), (kernel_ulong_t)&clock_counter_priv_userpf },
         { },
 };
 
@@ -377,7 +377,7 @@ static struct platform_driver clock_counter_driver_userpf = {
         .probe          = clock_counter_probe,
         .remove         = clock_counter_remove,
         .driver         = {
-                .name = XOCL_DEVNAME(XOCL_CLOCK_COUNTER),
+                .name = XOCL_USERPF_DEVICE(XOCL_CLOCK_COUNTER),
         },
         .id_table = clock_counter_id_table_userpf,
 };

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/clock_wiz.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/clock_wiz.c
@@ -1323,7 +1323,7 @@ struct xocl_drv_private clock_wiz_priv_mgmtpf = {
 };
 
 struct platform_device_id clock_wiz_id_table_mgmtpf[] = {
-	{ XOCL_DEVNAME(XOCL_CLOCK_WIZ), (kernel_ulong_t)&clock_wiz_priv_mgmtpf },
+	{ XOCL_MGMTPF_DEVICE(XOCL_CLOCK_WIZ), (kernel_ulong_t)&clock_wiz_priv_mgmtpf },
 	{ },
 };
 
@@ -1331,7 +1331,7 @@ static struct platform_driver clock_wiz_driver_mgmtpf = {
 	.probe		= clock_wiz_probe,
 	.remove		= clock_wiz_remove,
 	.driver		= {
-		.name = XOCL_DEVNAME(XOCL_CLOCK_WIZ),
+		.name = XOCL_MGMTPF_DEVICE(XOCL_CLOCK_WIZ),
 	},
 	.id_table = clock_wiz_id_table_mgmtpf,
 };
@@ -1341,7 +1341,7 @@ struct xocl_drv_private clock_wiz_priv_userpf = {
 };
 
 struct platform_device_id clock_wiz_id_table_userpf[] = {
-        { XOCL_DEVNAME(XOCL_CLOCK_WIZ), (kernel_ulong_t)&clock_wiz_priv_userpf },
+        { XOCL_USERPF_DEVICE(XOCL_CLOCK_WIZ), (kernel_ulong_t)&clock_wiz_priv_userpf },
         { },
 };
 
@@ -1349,7 +1349,7 @@ static struct platform_driver clock_wiz_driver_userpf = {
         .probe          = clock_wiz_probe,
         .remove         = clock_wiz_remove,
         .driver         = {
-                .name = XOCL_DEVNAME(XOCL_CLOCK_WIZ),
+                .name = XOCL_USERPF_DEVICE(XOCL_CLOCK_WIZ),
         },
         .id_table = clock_wiz_id_table_userpf,
 };

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/clock_wiz.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/clock_wiz.c
@@ -1318,30 +1318,58 @@ failed:
 	return ret;
 }
 
-struct xocl_drv_private clock_wiz_priv = {
+struct xocl_drv_private clock_wiz_priv_mgmtpf = {
 	.ops = &clock_wiz_ops,
 };
 
-struct platform_device_id clock_wiz_id_table[] = {
-	{ XOCL_DEVNAME(XOCL_CLOCK_WIZ), (kernel_ulong_t)&clock_wiz_priv },
+struct platform_device_id clock_wiz_id_table_mgmtpf[] = {
+	{ XOCL_DEVNAME(XOCL_CLOCK_WIZ), (kernel_ulong_t)&clock_wiz_priv_mgmtpf },
 	{ },
 };
 
-static struct platform_driver clock_wiz_driver = {
+static struct platform_driver clock_wiz_driver_mgmtpf = {
 	.probe		= clock_wiz_probe,
 	.remove		= clock_wiz_remove,
 	.driver		= {
 		.name = XOCL_DEVNAME(XOCL_CLOCK_WIZ),
 	},
-	.id_table = clock_wiz_id_table,
+	.id_table = clock_wiz_id_table_mgmtpf,
 };
 
-int __init xocl_init_clock_wiz(void)
+struct xocl_drv_private clock_wiz_priv_userpf = {
+        .ops = &clock_wiz_ops,
+};
+
+struct platform_device_id clock_wiz_id_table_userpf[] = {
+        { XOCL_DEVNAME(XOCL_CLOCK_WIZ), (kernel_ulong_t)&clock_wiz_priv_userpf },
+        { },
+};
+
+static struct platform_driver clock_wiz_driver_userpf = {
+        .probe          = clock_wiz_probe,
+        .remove         = clock_wiz_remove,
+        .driver         = {
+                .name = XOCL_DEVNAME(XOCL_CLOCK_WIZ),
+        },
+        .id_table = clock_wiz_id_table_userpf,
+};
+
+int __init xocl_init_clock_wiz(bool flag)
 {
-	return platform_driver_register(&clock_wiz_driver);
+	if(flag)
+	{
+	    return platform_driver_register(&clock_wiz_driver_mgmtpf);
+	}
+	else
+	{
+	    return platform_driver_register(&clock_wiz_driver_userpf);
+	}
 }
 
-void xocl_fini_clock_wiz(void)
+void xocl_fini_clock_wiz(bool flag)
 {
-	platform_driver_unregister(&clock_wiz_driver);
+    if (flag) 
+	platform_driver_unregister(&clock_wiz_driver_mgmtpf);
+    else
+	platform_driver_unregister(&clock_wiz_driver_userpf);
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/command_queue.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/command_queue.c
@@ -712,7 +712,7 @@ struct xocl_drv_private command_queue_priv = {
 };
 
 struct platform_device_id command_queue_id_table[] = {
-	{ XOCL_DEVNAME(XOCL_COMMAND_QUEUE), (kernel_ulong_t)&command_queue_priv },
+	{ XOCL_USERPF_DEVICE(XOCL_COMMAND_QUEUE), (kernel_ulong_t)&command_queue_priv },
 	{ },
 };
 
@@ -720,7 +720,7 @@ static struct platform_driver	command_queue_driver = {
 	.probe		= command_queue_probe,
 	.remove		= command_queue_remove,
 	.driver		= {
-		.name = XOCL_DEVNAME(XOCL_COMMAND_QUEUE),
+		.name = XOCL_USERPF_DEVICE(XOCL_COMMAND_QUEUE),
 	},
 	.id_table = command_queue_id_table,
 };

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/command_queue.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/command_queue.c
@@ -725,12 +725,13 @@ static struct platform_driver	command_queue_driver = {
 	.id_table = command_queue_id_table,
 };
 
-int __init xocl_init_command_queue(void)
+int __init xocl_init_command_queue(bool flag)
 {
 	return platform_driver_register(&command_queue_driver);
 }
 
-void xocl_fini_command_queue(void)
-{
+void xocl_fini_command_queue(bool flag)
+
+{     
 	platform_driver_unregister(&command_queue_driver);
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/cu.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/cu.c
@@ -551,7 +551,7 @@ static int cu_remove(struct platform_device *pdev)
 }
 
 static struct platform_device_id cu_id_table[] = {
-	{ XOCL_DEVNAME(XOCL_CU), 0 },
+	{ XOCL_USERPF_DEVICE(XOCL_CU), 0 },
 	{ },
 };
 
@@ -559,7 +559,7 @@ static struct platform_driver cu_driver = {
 	.probe		= cu_probe,
 	.remove		= cu_remove,
 	.driver		= {
-		.name = XOCL_DEVNAME(XOCL_CU),
+		.name = XOCL_USERPF_DEVICE(XOCL_CU),
 	},
 	.id_table	= cu_id_table,
 };

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/cu.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/cu.c
@@ -564,12 +564,12 @@ static struct platform_driver cu_driver = {
 	.id_table	= cu_id_table,
 };
 
-int __init xocl_init_cu(void)
+int __init xocl_init_cu(bool flag)
 {
 	return platform_driver_register(&cu_driver);
 }
 
-void xocl_fini_cu(void)
+void xocl_fini_cu(bool flag)
 {
 	platform_driver_unregister(&cu_driver);
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ddr_srsr.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ddr_srsr.c
@@ -338,7 +338,7 @@ struct xocl_drv_private srsr_priv_mgmtpf = {
 };
 
 struct platform_device_id xocl_ddr_srsr_id_table_mgmtpf[] = {
-	{ XOCL_DEVNAME(XOCL_SRSR), (kernel_ulong_t)&srsr_priv_mgmtpf },
+	{ XOCL_MGMTPF_DEVICE(XOCL_SRSR), (kernel_ulong_t)&srsr_priv_mgmtpf },
 	{ },
 };
 
@@ -346,7 +346,7 @@ static struct platform_driver	xocl_ddr_srsr_driver_mgmtpf = {
 	.probe		= xocl_ddr_srsr_probe,
 	.remove		= xocl_ddr_srsr_remove,
 	.driver		= {
-		.name = XOCL_DEVNAME(XOCL_SRSR),
+		.name = XOCL_MGMTPF_DEVICE(XOCL_SRSR),
 	},
 	.id_table = xocl_ddr_srsr_id_table_mgmtpf,
 };
@@ -356,7 +356,7 @@ struct xocl_drv_private srsr_priv_userpf = {
 };
 
 struct platform_device_id xocl_ddr_srsr_id_table_userpf[] = {
-        { XOCL_DEVNAME(XOCL_SRSR), (kernel_ulong_t)&srsr_priv_userpf },
+        { XOCL_USERPF_DEVICE(XOCL_SRSR), (kernel_ulong_t)&srsr_priv_userpf },
         { },
 };
 
@@ -364,7 +364,7 @@ static struct platform_driver   xocl_ddr_srsr_driver_userpf = {
         .probe          = xocl_ddr_srsr_probe,
         .remove         = xocl_ddr_srsr_remove,
         .driver         = {
-                .name = XOCL_DEVNAME(XOCL_SRSR),
+                .name = XOCL_USERPF_DEVICE(XOCL_SRSR),
         },
         .id_table = xocl_ddr_srsr_id_table_userpf,
 };

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ddr_srsr.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ddr_srsr.c
@@ -333,30 +333,57 @@ static int xocl_ddr_srsr_remove(struct platform_device *pdev)
 	return 0;
 }
 
-struct xocl_drv_private srsr_priv = {
+struct xocl_drv_private srsr_priv_mgmtpf = {
 	.ops = &srsr_ops,
 };
 
-struct platform_device_id xocl_ddr_srsr_id_table[] = {
-	{ XOCL_DEVNAME(XOCL_SRSR), (kernel_ulong_t)&srsr_priv },
+struct platform_device_id xocl_ddr_srsr_id_table_mgmtpf[] = {
+	{ XOCL_DEVNAME(XOCL_SRSR), (kernel_ulong_t)&srsr_priv_mgmtpf },
 	{ },
 };
 
-static struct platform_driver	xocl_ddr_srsr_driver = {
+static struct platform_driver	xocl_ddr_srsr_driver_mgmtpf = {
 	.probe		= xocl_ddr_srsr_probe,
 	.remove		= xocl_ddr_srsr_remove,
 	.driver		= {
 		.name = XOCL_DEVNAME(XOCL_SRSR),
 	},
-	.id_table = xocl_ddr_srsr_id_table,
+	.id_table = xocl_ddr_srsr_id_table_mgmtpf,
 };
 
-int __init xocl_init_srsr(void)
+struct xocl_drv_private srsr_priv_userpf = {
+        .ops = &srsr_ops,
+};
+
+struct platform_device_id xocl_ddr_srsr_id_table_userpf[] = {
+        { XOCL_DEVNAME(XOCL_SRSR), (kernel_ulong_t)&srsr_priv_userpf },
+        { },
+};
+
+static struct platform_driver   xocl_ddr_srsr_driver_userpf = {
+        .probe          = xocl_ddr_srsr_probe,
+        .remove         = xocl_ddr_srsr_remove,
+        .driver         = {
+                .name = XOCL_DEVNAME(XOCL_SRSR),
+        },
+        .id_table = xocl_ddr_srsr_id_table_userpf,
+};
+
+
+int __init xocl_init_srsr(bool flag)
 {
-	return platform_driver_register(&xocl_ddr_srsr_driver);
+       if (flag) {
+	   return platform_driver_register(&xocl_ddr_srsr_driver_mgmtpf);
+       } else {
+	   return platform_driver_register(&xocl_ddr_srsr_driver_userpf);
+       }
+
 }
 
-void xocl_fini_srsr(void)
+void xocl_fini_srsr(bool flag)
 {
-	platform_driver_unregister(&xocl_ddr_srsr_driver);
+    if (flag)
+	platform_driver_unregister(&xocl_ddr_srsr_driver_mgmtpf);
+    else
+	platform_driver_unregister(&xocl_ddr_srsr_driver_userpf);
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/dna.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/dna.c
@@ -489,7 +489,7 @@ struct xocl_drv_private dna_priv = {
 };
 
 struct platform_device_id xlnx_dna_id_table[] = {
-	{ XOCL_DEVNAME(XOCL_DNA), (kernel_ulong_t)&dna_priv },
+	{ XOCL_MGMTPF_DEVICE(XOCL_DNA), (kernel_ulong_t)&dna_priv },
 	{ },
 };
 
@@ -497,7 +497,7 @@ static struct platform_driver	xlnx_dna_driver = {
 	.probe		= xlnx_dna_probe,
 	.remove		= xlnx_dna_remove,
 	.driver		= {
-		.name = XOCL_DEVNAME(XOCL_DNA),
+		.name = XOCL_MGMTPF_DEVICE(XOCL_DNA),
 	},
 	.id_table = xlnx_dna_id_table,
 };
@@ -507,7 +507,7 @@ struct xocl_drv_private dna_priv_userpf = {
 };
 
 struct platform_device_id xlnx_dna_id_table_userpf[] = {
-        { XOCL_DEVNAME(XOCL_DNA), (kernel_ulong_t)&dna_priv_userpf },
+        { XOCL_USERPF_DEVICE(XOCL_DNA), (kernel_ulong_t)&dna_priv_userpf },
         { },
 };
 
@@ -515,7 +515,7 @@ static struct platform_driver   xlnx_dna_driver_userpf = {
         .probe          = xlnx_dna_probe,
         .remove         = xlnx_dna_remove,
         .driver         = {
-                .name = XOCL_DEVNAME(XOCL_DNA),
+                .name = XOCL_USERPF_DEVICE(XOCL_DNA),
         },
         .id_table = xlnx_dna_id_table_userpf,
 };

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/dna.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/dna.c
@@ -502,12 +502,41 @@ static struct platform_driver	xlnx_dna_driver = {
 	.id_table = xlnx_dna_id_table,
 };
 
-int __init xocl_init_dna(void)
+struct xocl_drv_private dna_priv_userpf = {
+        .ops = &dna_ops,
+};
+
+struct platform_device_id xlnx_dna_id_table_userpf[] = {
+        { XOCL_DEVNAME(XOCL_DNA), (kernel_ulong_t)&dna_priv_userpf },
+        { },
+};
+
+static struct platform_driver   xlnx_dna_driver_userpf = {
+        .probe          = xlnx_dna_probe,
+        .remove         = xlnx_dna_remove,
+        .driver         = {
+                .name = XOCL_DEVNAME(XOCL_DNA),
+        },
+        .id_table = xlnx_dna_id_table_userpf,
+};
+
+
+int __init xocl_init_dna(bool flag)
 {
-	return platform_driver_register(&xlnx_dna_driver);
+	if(flag)
+	{
+	    return platform_driver_register(&xlnx_dna_driver);
+	}
+	else
+	{
+	    return platform_driver_register(&xlnx_dna_driver_userpf);
+	}
 }
 
-void xocl_fini_dna(void)
+void xocl_fini_dna(bool flag)
 {
+    if (flag)
 	platform_driver_unregister(&xlnx_dna_driver);
+    else
+	platform_driver_unregister(&xlnx_dna_driver_userpf);
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert.c
@@ -479,7 +479,7 @@ struct xocl_drv_private	ert_priv = {
 };
 
 struct platform_device_id ert_id_table[] = {
-	{ XOCL_DEVNAME(XOCL_ERT), (kernel_ulong_t)&ert_priv },
+	{XOCL_DEVNAME(XOCL_ERT), (kernel_ulong_t)&ert_priv },
 	{ },
 };
 
@@ -492,7 +492,7 @@ static struct platform_driver	ert_driver = {
 	.id_table = ert_id_table,
 };
 
-int __init xocl_init_ert(void)
+int __init xocl_init_ert(bool flag)
 {
 	int err;
 
@@ -504,7 +504,7 @@ int __init xocl_init_ert(void)
 	return 0;
 }
 
-void xocl_fini_ert(void)
+void xocl_fini_ert(bool flag)
 {
 	platform_driver_unregister(&ert_driver);
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert.c
@@ -479,7 +479,7 @@ struct xocl_drv_private	ert_priv = {
 };
 
 struct platform_device_id ert_id_table[] = {
-	{XOCL_DEVNAME(XOCL_ERT), (kernel_ulong_t)&ert_priv },
+	{XOCL_MGMTPF_DEVICE(XOCL_ERT), (kernel_ulong_t)&ert_priv },
 	{ },
 };
 
@@ -487,7 +487,7 @@ static struct platform_driver	ert_driver = {
 	.probe		= ert_probe,
 	.remove		= ert_remove,
 	.driver		= {
-		.name = XOCL_DEVNAME(XOCL_ERT),
+		.name = XOCL_MGMTPF_DEVICE(XOCL_ERT),
 	},
 	.id_table = ert_id_table,
 };

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_ctrl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_ctrl.c
@@ -967,8 +967,8 @@ struct xocl_drv_private ert_ctrl_xgq_drv_priv = {
 };
 
 struct platform_device_id ert_ctrl_id_table[] = {
-	{ XOCL_DEVNAME(XOCL_ERT_CTRL), (kernel_ulong_t)&ert_ctrl_drv_priv },
-	{ XOCL_DEVNAME(XOCL_ERT_CTRL_VERSAL), (kernel_ulong_t)&ert_ctrl_xgq_drv_priv },
+	{ XOCL_USERPF_DEVICE(XOCL_ERT_CTRL), (kernel_ulong_t)&ert_ctrl_drv_priv },
+	{ XOCL_USERPF_DEVICE(XOCL_ERT_CTRL_VERSAL), (kernel_ulong_t)&ert_ctrl_xgq_drv_priv },
 	{},
 };
 
@@ -976,7 +976,7 @@ static struct platform_driver ert_ctrl_driver = {
 	.probe		= ert_ctrl_probe,
 	.remove		= ert_ctrl_remove,
 	.driver		= {
-		.name = XOCL_DEVNAME(XOCL_ERT_CTRL),
+		.name = XOCL_USERPF_DEVICE(XOCL_ERT_CTRL),
 	},
 	.id_table	= ert_ctrl_id_table,
 };

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_ctrl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_ctrl.c
@@ -981,12 +981,11 @@ static struct platform_driver ert_ctrl_driver = {
 	.id_table	= ert_ctrl_id_table,
 };
 
-int __init xocl_init_ert_ctrl(void)
+int __init xocl_init_ert_ctrl(bool flag)
 {
-	return platform_driver_register(&ert_ctrl_driver);
+        return platform_driver_register(&ert_ctrl_driver);
 }
-
-void xocl_fini_ert_ctrl(void)
+void xocl_fini_ert_ctrl(bool flag)
 {
 	platform_driver_unregister(&ert_ctrl_driver);
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_user.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_user.c
@@ -1592,12 +1592,11 @@ static struct platform_driver	ert_user_driver = {
 	.id_table = ert_user_id_table,
 };
 
-int __init xocl_init_ert_user(void)
+int __init xocl_init_ert_user(bool flag)
 {
 	return platform_driver_register(&ert_user_driver);
 }
-
-void xocl_fini_ert_user(void)
+void xocl_fini_ert_user(bool flag)
 {
 	platform_driver_unregister(&ert_user_driver);
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_user.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_user.c
@@ -1579,7 +1579,7 @@ struct xocl_drv_private ert_user_priv = {
 };
 
 struct platform_device_id ert_user_id_table[] = {
-	{ XOCL_DEVNAME(XOCL_ERT_USER), (kernel_ulong_t)&ert_user_priv },
+	{ XOCL_USERPF_DEVICE(XOCL_ERT_USER), (kernel_ulong_t)&ert_user_priv },
 	{ },
 };
 
@@ -1587,7 +1587,7 @@ static struct platform_driver	ert_user_driver = {
 	.probe		= ert_user_probe,
 	.remove		= ert_user_remove,
 	.driver		= {
-		.name = XOCL_DEVNAME(XOCL_ERT_USER),
+		.name = XOCL_USERPF_DEVICE(XOCL_ERT_USER),
 	},
 	.id_table = ert_user_id_table,
 };

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/feature_rom.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/feature_rom.c
@@ -798,7 +798,7 @@ static int feature_rom_probe(struct platform_device *pdev)
 
 	rom->pdev =  pdev;
 	platform_set_drvdata(pdev, rom);
-	
+
 	res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
 	if (res == NULL) {
 		xocl_dbg(&pdev->dev, "Get header from VSEC");
@@ -906,11 +906,11 @@ struct xocl_drv_private rom_priv_userpf = {
 };
 
 struct platform_device_id rom_id_table_mgmtpf[] =  {
-	{ XOCL_DEVNAME(XOCL_FEATURE_ROM), (kernel_ulong_t)&rom_priv_mgmtpf },
+	{ XOCL_MGMTPF_DEVICE(XOCL_FEATURE_ROM), (kernel_ulong_t)&rom_priv_mgmtpf },
 	{ },
 };
 struct platform_device_id rom_id_table_userpf[] =  {
-	{ XOCL_DEVNAME(XOCL_FEATURE_ROM), (kernel_ulong_t)&rom_priv_userpf },
+	{ XOCL_USERPF_DEVICE(XOCL_FEATURE_ROM), (kernel_ulong_t)&rom_priv_userpf },
 	{ },
 };
  
@@ -918,7 +918,7 @@ static struct platform_driver feature_rom_driver_mgmtpf = {
 	.probe		= feature_rom_probe,
 	.remove		= feature_rom_remove,
 	.driver		= {
-	.name = XOCL_DEVNAME(XOCL_FEATURE_ROM),
+	.name = XOCL_MGMTPF_DEVICE(XOCL_FEATURE_ROM),
 	},
 	.id_table = rom_id_table_mgmtpf,
 };
@@ -927,7 +927,7 @@ static struct platform_driver feature_rom_driver_userpf = {
 	.probe		= feature_rom_probe,
 	.remove		= feature_rom_remove,
 	.driver		= {
-	.name =  XOCL_DEVNAME(XOCL_FEATURE_ROM),
+	.name =  XOCL_USERPF_DEVICE(XOCL_FEATURE_ROM),
 	},
 	.id_table = rom_id_table_userpf,
 };

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/firewall.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/firewall.c
@@ -684,30 +684,59 @@ failed:
 	return ret;
 }
 
-struct xocl_drv_private firewall_priv = {
+struct xocl_drv_private firewall_priv_mgmtpf = {
 	.ops = &fw_ops,
 };
 
-struct platform_device_id firewall_id_table[] = {
-	{ XOCL_DEVNAME(XOCL_FIREWALL), (kernel_ulong_t)&firewall_priv },
+struct platform_device_id firewall_id_table_mgmtpf[] = {
+	{ XOCL_DEVNAME(XOCL_FIREWALL), (kernel_ulong_t)&firewall_priv_mgmtpf },
 	{ },
 };
 
-static struct platform_driver	firewall_driver = {
+static struct platform_driver	firewall_driver_mgmtpf = {
 	.probe		= firewall_probe,
 	.remove		= firewall_remove,
 	.driver		= {
 		.name = XOCL_DEVNAME(XOCL_FIREWALL),
 	},
-	.id_table = firewall_id_table,
+	.id_table = firewall_id_table_mgmtpf,
 };
 
-int __init xocl_init_firewall(void)
+struct xocl_drv_private firewall_priv_userpf = {
+        .ops = &fw_ops,
+};
+
+struct platform_device_id firewall_id_table_userpf[] = {
+        { XOCL_DEVNAME(XOCL_FIREWALL), (kernel_ulong_t)&firewall_priv_userpf },
+        { },
+};
+
+static struct platform_driver   firewall_driver_userpf = {
+        .probe          = firewall_probe,
+        .remove         = firewall_remove,
+        .driver         = {
+                .name = XOCL_DEVNAME(XOCL_FIREWALL),
+        },
+        .id_table = firewall_id_table_userpf
+};
+
+
+int __init xocl_init_firewall(bool flag)
 {
-	return platform_driver_register(&firewall_driver);
+	if(flag)
+	{
+	    return platform_driver_register(&firewall_driver_mgmtpf);
+	}
+	else
+	{
+	    return platform_driver_register(&firewall_driver_userpf);
+	}
 }
 
-void xocl_fini_firewall(void)
+void xocl_fini_firewall(bool flag)
 {
-	return platform_driver_unregister(&firewall_driver);
+    if (flag)
+	return platform_driver_unregister(&firewall_driver_mgmtpf);
+    else
+	return platform_driver_unregister(&firewall_driver_userpf);
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/firewall.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/firewall.c
@@ -689,7 +689,7 @@ struct xocl_drv_private firewall_priv_mgmtpf = {
 };
 
 struct platform_device_id firewall_id_table_mgmtpf[] = {
-	{ XOCL_DEVNAME(XOCL_FIREWALL), (kernel_ulong_t)&firewall_priv_mgmtpf },
+	{ XOCL_MGMTPF_DEVICE(XOCL_FIREWALL), (kernel_ulong_t)&firewall_priv_mgmtpf },
 	{ },
 };
 
@@ -697,7 +697,7 @@ static struct platform_driver	firewall_driver_mgmtpf = {
 	.probe		= firewall_probe,
 	.remove		= firewall_remove,
 	.driver		= {
-		.name = XOCL_DEVNAME(XOCL_FIREWALL),
+		.name = XOCL_MGMTPF_DEVICE(XOCL_FIREWALL),
 	},
 	.id_table = firewall_id_table_mgmtpf,
 };
@@ -707,7 +707,7 @@ struct xocl_drv_private firewall_priv_userpf = {
 };
 
 struct platform_device_id firewall_id_table_userpf[] = {
-        { XOCL_DEVNAME(XOCL_FIREWALL), (kernel_ulong_t)&firewall_priv_userpf },
+        { XOCL_USERPF_DEVICE(XOCL_FIREWALL), (kernel_ulong_t)&firewall_priv_userpf },
         { },
 };
 
@@ -715,7 +715,7 @@ static struct platform_driver   firewall_driver_userpf = {
         .probe          = firewall_probe,
         .remove         = firewall_remove,
         .driver         = {
-                .name = XOCL_DEVNAME(XOCL_FIREWALL),
+                .name = XOCL_USERPF_DEVICE(XOCL_FIREWALL),
         },
         .id_table = firewall_id_table_userpf
 };

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/flash.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/flash.c
@@ -1512,7 +1512,7 @@ struct xocl_drv_private flash_priv = {
 };
 
 struct platform_device_id flash_id_table[] = {
-	{ XOCL_DEVNAME(XOCL_FLASH), (kernel_ulong_t)&flash_priv },
+	{XOCL_MGMTPF_DEVICE(XOCL_FLASH), (kernel_ulong_t)&flash_priv },
 	{ },
 };
 
@@ -1520,7 +1520,7 @@ static struct platform_driver	flash_driver = {
 	.probe		= flash_probe,
 	.remove		= flash_remove,
 	.driver		= {
-		.name = XOCL_DEVNAME(XOCL_FLASH),
+		.name = XOCL_MGMTPF_DEVICE(XOCL_FLASH),
 	},
 	.id_table = flash_id_table,
 };

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/flash.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/flash.c
@@ -1525,7 +1525,7 @@ static struct platform_driver	flash_driver = {
 	.id_table = flash_id_table,
 };
 
-int __init xocl_init_flash(void)
+int __init xocl_init_flash(bool flag)
 {
 	int err = alloc_chrdev_region(&flash_priv.dev, 0, XOCL_MAX_DEVICES,
 			XOCL_FLASH);
@@ -1540,7 +1540,7 @@ int __init xocl_init_flash(void)
 	return err;
 }
 
-void xocl_fini_flash(void)
+void xocl_fini_flash(bool flag)
 {
 	unregister_chrdev_region(flash_priv.dev, XOCL_MAX_DEVICES);
 	platform_driver_unregister(&flash_driver);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/fmgr.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/fmgr.c
@@ -229,12 +229,12 @@ static struct platform_driver	fmgr_driver = {
 	.id_table = fmgr_id_table,
 };
 
-int __init xocl_init_fmgr(void)
+int __init xocl_init_fmgr(bool flag)
 {
 	return platform_driver_register(&fmgr_driver);
 }
 
-void xocl_fini_fmgr(void)
+void xocl_fini_fmgr(bool flag)
 {
 	platform_driver_unregister(&fmgr_driver);
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/fmgr.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/fmgr.c
@@ -148,7 +148,7 @@ static const struct fpga_manager_ops xocl_pr_ops = {
 #endif
 
 struct platform_device_id fmgr_id_table[] = {
-	{ XOCL_DEVNAME(XOCL_FMGR), 0 },
+	{ XOCL_MGMTPF_DEVICE(XOCL_FMGR), 0 },
 	{ },
 };
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/hwmon_sdm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/hwmon_sdm.c
@@ -1668,31 +1668,59 @@ static struct xocl_sdm_funcs sdm_ops = {
 	.hwmon_sdm_create_sensors_sysfs = hwmon_sdm_create_sensors_sysfs,
 };
 
-struct xocl_drv_private sdm_priv = {
+struct xocl_drv_private sdm_priv_mgmtpf = {
 	.ops = &sdm_ops,
 	.dev = -1,
 };
 
-struct platform_device_id hwmon_sdm_id_table[] = {
-	{ XOCL_DEVNAME(XOCL_HWMON_SDM), (kernel_ulong_t)&sdm_priv },
+struct platform_device_id hwmon_sdm_id_table_mgmtpf[] = {
+	{ XOCL_DEVNAME(XOCL_HWMON_SDM), (kernel_ulong_t)&sdm_priv_mgmtpf },
 	{ },
 };
 
-static struct platform_driver	hwmon_sdm_driver = {
+static struct platform_driver	hwmon_sdm_driver_mgmtpf = {
 	.probe		= hwmon_sdm_probe,
 	.remove		= hwmon_sdm_remove,
 	.driver		= {
 		.name = XOCL_DEVNAME(XOCL_HWMON_SDM),
 	},
-	.id_table = hwmon_sdm_id_table,
+	.id_table = hwmon_sdm_id_table_mgmtpf,
 };
 
-int __init xocl_init_hwmon_sdm(void)
+struct xocl_drv_private sdm_priv_userpf = {
+        .ops = &sdm_ops,
+        .dev = -1,
+};
+
+struct platform_device_id hwmon_sdm_id_table_userpf[] = {
+        { XOCL_DEVNAME(XOCL_HWMON_SDM), (kernel_ulong_t)&sdm_priv_userpf },
+        { },
+};
+
+static struct platform_driver   hwmon_sdm_driver_userpf = {
+        .probe          = hwmon_sdm_probe,
+        .remove         = hwmon_sdm_remove,
+        .driver         = {
+                .name = XOCL_DEVNAME(XOCL_HWMON_SDM),
+        },
+        .id_table = hwmon_sdm_id_table_userpf,
+};
+
+int __init xocl_init_hwmon_sdm(bool flag)
 {
-	return platform_driver_register(&hwmon_sdm_driver);
+        
+if (flag) {
+        	return platform_driver_register(&hwmon_sdm_driver_mgmtpf);
+           }    
+else {  
+        	return platform_driver_register(&hwmon_sdm_driver_userpf);
 }
 
-void xocl_fini_hwmon_sdm(void)
+}
+void xocl_fini_hwmon_sdm(bool flag)
 {
-	platform_driver_unregister(&hwmon_sdm_driver);
+    if (flag)
+	platform_driver_unregister(&hwmon_sdm_driver_mgmtpf);
+    else
+	platform_driver_unregister(&hwmon_sdm_driver_userpf);
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/hwmon_sdm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/hwmon_sdm.c
@@ -1674,7 +1674,7 @@ struct xocl_drv_private sdm_priv_mgmtpf = {
 };
 
 struct platform_device_id hwmon_sdm_id_table_mgmtpf[] = {
-	{ XOCL_DEVNAME(XOCL_HWMON_SDM), (kernel_ulong_t)&sdm_priv_mgmtpf },
+	{ XOCL_MGMTPF_DEVICE(XOCL_HWMON_SDM), (kernel_ulong_t)&sdm_priv_mgmtpf },
 	{ },
 };
 
@@ -1682,7 +1682,7 @@ static struct platform_driver	hwmon_sdm_driver_mgmtpf = {
 	.probe		= hwmon_sdm_probe,
 	.remove		= hwmon_sdm_remove,
 	.driver		= {
-		.name = XOCL_DEVNAME(XOCL_HWMON_SDM),
+		.name = XOCL_MGMTPF_DEVICE(XOCL_HWMON_SDM),
 	},
 	.id_table = hwmon_sdm_id_table_mgmtpf,
 };
@@ -1693,7 +1693,7 @@ struct xocl_drv_private sdm_priv_userpf = {
 };
 
 struct platform_device_id hwmon_sdm_id_table_userpf[] = {
-        { XOCL_DEVNAME(XOCL_HWMON_SDM), (kernel_ulong_t)&sdm_priv_userpf },
+        { XOCL_USERPF_DEVICE(XOCL_HWMON_SDM), (kernel_ulong_t)&sdm_priv_userpf },
         { },
 };
 
@@ -1701,7 +1701,7 @@ static struct platform_driver   hwmon_sdm_driver_userpf = {
         .probe          = hwmon_sdm_probe,
         .remove         = hwmon_sdm_remove,
         .driver         = {
-                .name = XOCL_DEVNAME(XOCL_HWMON_SDM),
+                .name = XOCL_USERPF_DEVICE(XOCL_HWMON_SDM),
         },
         .id_table = hwmon_sdm_id_table_userpf,
 };

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -4323,11 +4323,11 @@ struct xocl_drv_private icap_drv_priv_userpf = {
 };
 
 struct platform_device_id icap_id_table_userpf[] = {
-	{ XOCL_DEVNAME(XOCL_ICAP), (kernel_ulong_t)&icap_drv_priv_userpf },
+	{ XOCL_USERPF_DEVICE(XOCL_ICAP), (kernel_ulong_t)&icap_drv_priv_userpf },
 	{ },
 };
 struct platform_device_id icap_id_table_mgmtpf[] = {
-	{ XOCL_DEVNAME(XOCL_ICAP), (kernel_ulong_t)&icap_drv_priv_mgmtpf },
+	{ XOCL_MGMTPF_DEVICE(XOCL_ICAP), (kernel_ulong_t)&icap_drv_priv_mgmtpf },
 	{ },
 };
 
@@ -4335,7 +4335,7 @@ static struct platform_driver icap_driver_userpf = {
 	.probe		= icap_probe,
 	.remove		= icap_remove,
 	.driver		= {
-		.name	= XOCL_DEVNAME(XOCL_ICAP),
+		.name	= XOCL_USERPF_DEVICE(XOCL_ICAP),
 	},
 	.id_table = icap_id_table_userpf,
 };
@@ -4345,7 +4345,7 @@ static struct platform_driver icap_driver_mgmtpf = {
 	.probe		= icap_probe,
 	.remove		= icap_remove,
 	.driver		= {
-		.name	= XOCL_DEVNAME(XOCL_ICAP),
+		.name	= XOCL_MGMTPF_DEVICE(XOCL_ICAP),
 	},
 	.id_table = icap_id_table_mgmtpf,
 };

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -1146,6 +1146,11 @@ static int icap_download_rp(struct platform_device *pdev, int level, int flag)
 	struct xcl_mailbox_req mbreq = { 0 };
 	int ret = 0;
 
+	bool is_mgmt = false;
+	if (strcmp(XOCL_MGMTPF_DEVICE(XOCL_ICAP), pdev->name) == 0) {
+		is_mgmt = true;
+	}
+
 	mbreq.req = XCL_MAILBOX_REQ_CHG_SHELL;
 	mutex_lock(&icap->icap_lock);
 	if (flag == RP_DOWNLOAD_CLEAR) {
@@ -1183,7 +1188,7 @@ static int icap_download_rp(struct platform_device *pdev, int level, int flag)
 	}
 
 	ret = xocl_fdt_blob_input(xdev, icap->rp_fdt, icap->rp_fdt_len,
-			XOCL_SUBDEV_LEVEL_PRP, icap->rp_vbnv);
+			XOCL_SUBDEV_LEVEL_PRP, icap->rp_vbnv,is_mgmt);
 	if (ret) {
 		xocl_xdev_err(xdev, "failed to parse fdt %d", ret);
 		goto failed;
@@ -2287,11 +2292,16 @@ static void icap_probe_urpdev(struct platform_device *pdev, struct axlf *xclbin,
 	struct icap *icap = platform_get_drvdata(pdev);
 	xdev_handle_t xdev = xocl_get_xdev(icap->icap_pdev);
 
+	bool is_mgmt = false;
+	if (strcmp(XOCL_MGMTPF_DEVICE(XOCL_ICAP), pdev->name) == 0) {
+		is_mgmt = true;
+	}
+
 	icap_cache_bitstream_axlf_section(pdev, xclbin, PARTITION_METADATA);
 	if (icap->partition_metadata) {
 		*num_urpdev = xocl_fdt_parse_blob(xdev, icap->partition_metadata,
 			icap_get_section_size(icap, PARTITION_METADATA),
-			urpdevs);
+			urpdevs,is_mgmt);
 		ICAP_INFO(icap, "found %d sub devices", *num_urpdev);
 	}
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap_cntrl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap_cntrl.c
@@ -253,12 +253,12 @@ static struct platform_driver	icap_cntrl_driver = {
 	.id_table = icap_cntrl_id_table,
 };
 
-int __init xocl_init_icap_controller(void)
+int __init xocl_init_icap_controller(bool flag)
 {
 	return platform_driver_register(&icap_cntrl_driver);
 }
 
-void xocl_fini_icap_controller(void)
+void xocl_fini_icap_controller(bool flag)
 {
 	platform_driver_unregister(&icap_cntrl_driver);
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap_cntrl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap_cntrl.c
@@ -240,7 +240,7 @@ failed:
 }
 
 struct platform_device_id icap_cntrl_id_table[] = {
-	{ XOCL_DEVNAME(XOCL_ICAP_CNTRL), 0 },
+	{ XOCL_MGMTPF_DEVICE(XOCL_ICAP_CNTRL), 0 },
 	{ },
 };
 
@@ -248,7 +248,7 @@ static struct platform_driver	icap_cntrl_driver = {
 	.probe		= icap_cntrl_probe,
 	.remove		= icap_cntrl_remove,
 	.driver		= {
-		.name = XOCL_DEVNAME(XOCL_ICAP_CNTRL),
+		.name = XOCL_MGMTPF_DEVICE(XOCL_ICAP_CNTRL),
 	},
 	.id_table = icap_cntrl_id_table,
 };

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/intc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/intc.c
@@ -700,12 +700,12 @@ static struct platform_driver intc_driver = {
 	.id_table = intc_id_table,
 };
 
-int __init xocl_init_intc(void)
+int __init xocl_init_intc(bool flag)
 {
 	return platform_driver_register(&intc_driver);
 }
 
-void xocl_fini_intc(void)
+void xocl_fini_intc(bool flag)
 {
 	platform_driver_unregister(&intc_driver);
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/intc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/intc.c
@@ -687,7 +687,7 @@ struct xocl_drv_private intc_priv = {
 };
 
 struct platform_device_id intc_id_table[] = {
-	{ XOCL_DEVNAME(XOCL_INTC), (kernel_ulong_t)&intc_priv },
+	{ XOCL_USERPF_DEVICE(XOCL_INTC), (kernel_ulong_t)&intc_priv },
 	{ },
 };
 
@@ -695,7 +695,7 @@ static struct platform_driver intc_driver = {
 	.probe		= intc_probe,
 	.remove		= intc_remove,
 	.driver		= {
-		.name = XOCL_DEVNAME(XOCL_INTC),
+		.name = XOCL_USERPF_DEVICE(XOCL_INTC),
 	},
 	.id_table = intc_id_table,
 };

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/iores.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/iores.c
@@ -157,17 +157,17 @@ struct xocl_drv_private iores_priv_userpf = {
 };
 
 struct platform_device_id iores_id_table[] = {
-	{ XOCL_DEVNAME(XOCL_IORES0), (kernel_ulong_t)&iores_priv_mgmtpf },
-	{ XOCL_DEVNAME(XOCL_IORES1), (kernel_ulong_t)&iores_priv_mgmtpf },
-	{ XOCL_DEVNAME(XOCL_IORES2), (kernel_ulong_t)&iores_priv_mgmtpf },
-	{ XOCL_DEVNAME(XOCL_IORES3), (kernel_ulong_t)&iores_priv_mgmtpf },
+	{ XOCL_MGMTPF_DEVICE(XOCL_IORES0), (kernel_ulong_t)&iores_priv_mgmtpf },
+	{ XOCL_MGMTPF_DEVICE(XOCL_IORES1), (kernel_ulong_t)&iores_priv_mgmtpf },
+	{ XOCL_MGMTPF_DEVICE(XOCL_IORES2), (kernel_ulong_t)&iores_priv_mgmtpf },
+	{ XOCL_MGMTPF_DEVICE(XOCL_IORES3), (kernel_ulong_t)&iores_priv_mgmtpf },
 	{ },
 };
 struct platform_device_id iores_id_table_userpf[] = {
-	{ XOCL_DEVNAME(XOCL_IORES0), (kernel_ulong_t)&iores_priv_userpf },
-	{ XOCL_DEVNAME(XOCL_IORES1), (kernel_ulong_t)&iores_priv_userpf },
-	{ XOCL_DEVNAME(XOCL_IORES2), (kernel_ulong_t)&iores_priv_userpf },
-	{ XOCL_DEVNAME(XOCL_IORES3), (kernel_ulong_t)&iores_priv_userpf },
+	{ XOCL_USERPF_DEVICE(XOCL_IORES0), (kernel_ulong_t)&iores_priv_userpf },
+	{ XOCL_USERPF_DEVICE(XOCL_IORES1), (kernel_ulong_t)&iores_priv_userpf },
+	{ XOCL_USERPF_DEVICE(XOCL_IORES2), (kernel_ulong_t)&iores_priv_userpf },
+	{ XOCL_USERPF_DEVICE(XOCL_IORES3), (kernel_ulong_t)&iores_priv_userpf },
 	{ },
 };
 
@@ -175,7 +175,7 @@ static struct platform_driver	iores_driver_mgmtpf = {
 	.probe		= iores_probe,
 	.remove		= iores_remove,
 	.driver		= {
-		.name = XOCL_DEVNAME("iores"),
+		.name = XOCL_MGMTPF_DEVICE("iores"),
 	},
 	.id_table = iores_id_table,
 };
@@ -183,7 +183,7 @@ static struct platform_driver	iores_driver_userpf = {
 	.probe		= iores_probe,
 	.remove		= iores_remove,
 	.driver		= {
-		.name = XOCL_DEVNAME("iores"),
+		.name = XOCL_USERPF_DEVICE("iores"),
 	},
 	.id_table = iores_id_table,
 };

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/iores.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/iores.c
@@ -149,19 +149,37 @@ static int iores_probe(struct platform_device *pdev)
 	return 0;
 }
 
-struct xocl_drv_private iores_priv = {
+struct xocl_drv_private iores_priv_mgmtpf = {
+	.ops = &iores_ops,
+};
+struct xocl_drv_private iores_priv_userpf = {
 	.ops = &iores_ops,
 };
 
 struct platform_device_id iores_id_table[] = {
-	{ XOCL_DEVNAME(XOCL_IORES0), (kernel_ulong_t)&iores_priv },
-	{ XOCL_DEVNAME(XOCL_IORES1), (kernel_ulong_t)&iores_priv },
-	{ XOCL_DEVNAME(XOCL_IORES2), (kernel_ulong_t)&iores_priv },
-	{ XOCL_DEVNAME(XOCL_IORES3), (kernel_ulong_t)&iores_priv },
+	{ XOCL_DEVNAME(XOCL_IORES0), (kernel_ulong_t)&iores_priv_mgmtpf },
+	{ XOCL_DEVNAME(XOCL_IORES1), (kernel_ulong_t)&iores_priv_mgmtpf },
+	{ XOCL_DEVNAME(XOCL_IORES2), (kernel_ulong_t)&iores_priv_mgmtpf },
+	{ XOCL_DEVNAME(XOCL_IORES3), (kernel_ulong_t)&iores_priv_mgmtpf },
+	{ },
+};
+struct platform_device_id iores_id_table_userpf[] = {
+	{ XOCL_DEVNAME(XOCL_IORES0), (kernel_ulong_t)&iores_priv_userpf },
+	{ XOCL_DEVNAME(XOCL_IORES1), (kernel_ulong_t)&iores_priv_userpf },
+	{ XOCL_DEVNAME(XOCL_IORES2), (kernel_ulong_t)&iores_priv_userpf },
+	{ XOCL_DEVNAME(XOCL_IORES3), (kernel_ulong_t)&iores_priv_userpf },
 	{ },
 };
 
-static struct platform_driver	iores_driver = {
+static struct platform_driver	iores_driver_mgmtpf = {
+	.probe		= iores_probe,
+	.remove		= iores_remove,
+	.driver		= {
+		.name = XOCL_DEVNAME("iores"),
+	},
+	.id_table = iores_id_table,
+};
+static struct platform_driver	iores_driver_userpf = {
 	.probe		= iores_probe,
 	.remove		= iores_remove,
 	.driver		= {
@@ -170,12 +188,20 @@ static struct platform_driver	iores_driver = {
 	.id_table = iores_id_table,
 };
 
-int __init xocl_init_iores(void)
+int __init xocl_init_iores(bool flag)
 {
-	return platform_driver_register(&iores_driver);
+	if(flag){	
+		return platform_driver_register(&iores_driver_mgmtpf);
+	}
+	else{	
+		return platform_driver_register(&iores_driver_userpf);
+	}
 }
 
-void xocl_fini_iores(void)
+void xocl_fini_iores(bool flag)
 {
-	platform_driver_unregister(&iores_driver);
+	if(flag)
+		platform_driver_unregister(&iores_driver_mgmtpf);
+	else
+		platform_driver_unregister(&iores_driver_userpf);
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/lapc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/lapc.c
@@ -284,7 +284,7 @@ static struct platform_driver	lapc_driver = {
 	.id_table = lapc_id_table,
 };
 
-int __init xocl_init_lapc(void)
+int __init xocl_init_lapc(bool flag)
 {
 	int err = 0;
 
@@ -304,7 +304,7 @@ err_chrdev_reg:
 	return err;
 }
 
-void xocl_fini_lapc(void)
+void xocl_fini_lapc(bool flag)
 {
 	unregister_chrdev_region(lapc_priv.dev, XOCL_MAX_DEVICES);
 	platform_driver_unregister(&lapc_driver);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/lapc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/lapc.c
@@ -271,7 +271,7 @@ struct xocl_drv_private lapc_priv = {
 };
 
 struct platform_device_id lapc_id_table[] = {
-	{ XOCL_DEVNAME(XOCL_LAPC), (kernel_ulong_t)&lapc_priv },
+	{ XOCL_USERPF_DEVICE(XOCL_LAPC), (kernel_ulong_t)&lapc_priv },
 	{ },
 };
 
@@ -279,7 +279,7 @@ static struct platform_driver	lapc_driver = {
 	.probe		= lapc_probe,
 	.remove		= lapc_remove,
 	.driver		= {
-		.name = XOCL_DEVNAME(XOCL_LAPC),
+		.name = XOCL_USERPF_DEVICE(XOCL_LAPC),
 	},
 	.id_table = lapc_id_table,
 };

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/m2m.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/m2m.c
@@ -213,7 +213,7 @@ struct xocl_drv_private m2m_priv = {
 };
 
 struct platform_device_id m2m_id_table[] = {
-	{XOCL_DEVNAME(XOCL_M2M), (kernel_ulong_t)&m2m_priv },
+	{XOCL_USERPF_DEVICE(XOCL_M2M), (kernel_ulong_t)&m2m_priv },
 	{ },
 };
 
@@ -323,7 +323,7 @@ static struct platform_driver	m2m_driver = {
 	.probe		= m2m_probe,
 	.remove		= m2m_remove,
 	.driver		= {
-		.name = XOCL_DEVNAME(XOCL_M2M),
+		.name = XOCL_USERPF_DEVICE(XOCL_M2M),
 	},
 	.id_table = m2m_id_table,
 };

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/m2m.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/m2m.c
@@ -213,7 +213,7 @@ struct xocl_drv_private m2m_priv = {
 };
 
 struct platform_device_id m2m_id_table[] = {
-	{ XOCL_DEVNAME(XOCL_M2M), (kernel_ulong_t)&m2m_priv },
+	{XOCL_DEVNAME(XOCL_M2M), (kernel_ulong_t)&m2m_priv },
 	{ },
 };
 
@@ -328,12 +328,11 @@ static struct platform_driver	m2m_driver = {
 	.id_table = m2m_id_table,
 };
 
-int __init xocl_init_m2m(void)
+int __init xocl_init_m2m(bool flag)
 {
 	return platform_driver_register(&m2m_driver);
 }
-
-void xocl_fini_m2m(void)
+void xocl_fini_m2m(bool flag)
 {
 	platform_driver_unregister(&m2m_driver);
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mailbox.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mailbox.c
@@ -942,7 +942,7 @@ static void chan_worker(struct work_struct *work)
 			 * and achieve fastest transfer speed, then we can do busy
 			 * poll for Rx also when there is data. 
 			 */
-			if(strcmp(XOCL_DEVNAME(XOCL_MAILBOX),ch->mbc_parent->mbx_pdev->name)==0) {
+			if(strcmp(XOCL_USERPF_DEVICE(XOCL_MAILBOX),ch->mbc_parent->mbx_pdev->name)==0) {
 				if (is_rx_chan(ch))
 					chan_sleep(ch, false);
 			}
@@ -2588,7 +2588,7 @@ static int mailbox_enable_intr_mode(struct mailbox *mbx)
 
 	if (mbx->mbx_irq != -1)
 		return 0;
-if(strcmp(pdev->name,XOCL_DEVNAME(XOCL_MAILBOX))==0) {
+if(strcmp(pdev->name,XOCL_MGMTPF_DEVICE(XOCL_MAILBOX))==0) {
 	ret = xocl_subdev_get_resource(xdev, NODE_MAILBOX_MGMT,
 			IORESOURCE_IRQ, &dyn_res);
 }
@@ -3184,12 +3184,12 @@ struct xocl_drv_private mailbox_priv_userpf = {
 };
 
 struct platform_device_id mailbox_id_table_mgmtpf[] = {
-	{ XOCL_DEVNAME(XOCL_MAILBOX), (kernel_ulong_t)&mailbox_priv_mgmtpf },
+	{ XOCL_MGMTPF_DEVICE(XOCL_MAILBOX), (kernel_ulong_t)&mailbox_priv_mgmtpf },
 	{ },
 };
 
 struct platform_device_id mailbox_id_table_userpf[] = {
-	{ XOCL_DEVNAME(XOCL_MAILBOX), (kernel_ulong_t)&mailbox_priv_userpf },
+	{ XOCL_USERPF_DEVICE(XOCL_MAILBOX), (kernel_ulong_t)&mailbox_priv_userpf },
 	{ },
 };
 
@@ -3198,7 +3198,7 @@ static struct platform_driver mailbox_driver_mgmtpf = {
 	.probe		= mailbox_probe,
 	.remove		= mailbox_remove,
 	.driver		= {
-		.name	= XOCL_DEVNAME(XOCL_MAILBOX),
+		.name	= XOCL_MGMTPF_DEVICE(XOCL_MAILBOX),
 	},
 	.id_table = mailbox_id_table_mgmtpf,
 };
@@ -3207,7 +3207,7 @@ static struct platform_driver mailbox_driver_userpf = {
 	.probe		= mailbox_probe,
 	.remove		= mailbox_remove,
 	.driver		= {
-		.name	= XOCL_DEVNAME(XOCL_MAILBOX),
+		.name	= XOCL_USERPF_DEVICE(XOCL_MAILBOX),
 	},
 	.id_table = mailbox_id_table_userpf,
 };

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mailbox_versal.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mailbox_versal.c
@@ -288,7 +288,7 @@ struct xocl_drv_private mailbox_versal_priv = {
 };
 
 struct platform_device_id mailbox_versal_id_table[] = {
-	{ XOCL_DEVNAME(XOCL_MAILBOX_VERSAL),
+	{ XOCL_USERPF_DEVICE(XOCL_MAILBOX_VERSAL),
 	    (kernel_ulong_t)&mailbox_versal_priv },
 	{ },
 };
@@ -297,7 +297,7 @@ static struct platform_driver	mailbox_versal_driver = {
 	.probe		= mailbox_versal_probe,
 	.remove		= mailbox_versal_remove,
 	.driver		= {
-		.name = XOCL_DEVNAME(XOCL_MAILBOX_VERSAL),
+		.name = XOCL_USERPF_DEVICE(XOCL_MAILBOX_VERSAL),
 	},
 	.id_table = mailbox_versal_id_table,
 };

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mailbox_versal.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mailbox_versal.c
@@ -302,12 +302,12 @@ static struct platform_driver	mailbox_versal_driver = {
 	.id_table = mailbox_versal_id_table,
 };
 
-int __init xocl_init_mailbox_versal(void)
+int __init xocl_init_mailbox_versal(bool flag)
 {
 	return platform_driver_register(&mailbox_versal_driver);
 }
 
-void xocl_fini_mailbox_versal(void)
+void xocl_fini_mailbox_versal(bool flag)
 {
 	platform_driver_unregister(&mailbox_versal_driver);
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/memory_hbm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/memory_hbm.c
@@ -600,30 +600,55 @@ static int mem_hbm_remove(struct platform_device *pdev)
 	return 0;
 }
 
-struct xocl_drv_private mem_hbm_priv = {
+struct xocl_drv_private mem_hbm_priv_mgmtpf = {
+	.ops = &mem_hbm_ops,
+};
+struct xocl_drv_private mem_hbm_priv_userpf = {
 	.ops = &mem_hbm_ops,
 };
 
-struct platform_device_id mem_hbm_id_table[] = {
-	{ XOCL_DEVNAME(XOCL_MIG_HBM), (kernel_ulong_t)&mem_hbm_priv },
+struct platform_device_id mem_hbm_id_table_mgmtpf[] = {
+	{ XOCL_DEVNAME(XOCL_MIG_HBM), (kernel_ulong_t)&mem_hbm_priv_mgmtpf },
+	{ },
+};
+struct platform_device_id mem_hbm_id_table_userpf[] = {
+	{ XOCL_DEVNAME(XOCL_MIG_HBM), (kernel_ulong_t)&mem_hbm_priv_userpf },
 	{ },
 };
 
-static struct platform_driver	mem_hbm_driver = {
+static struct platform_driver	mem_hbm_driver_mgmtpf = {
 	.probe		= mem_hbm_probe,
 	.remove		= mem_hbm_remove,
 	.driver		= {
 		.name = XOCL_DEVNAME(XOCL_MIG_HBM),
 	},
-	.id_table = mem_hbm_id_table,
+	.id_table = mem_hbm_id_table_mgmtpf,
+};
+static struct platform_driver	mem_hbm_driver_userpf = {
+	.probe		= mem_hbm_probe,
+	.remove		= mem_hbm_remove,
+	.driver		= {
+		.name = XOCL_DEVNAME(XOCL_MIG_HBM),
+	},
+	.id_table = mem_hbm_id_table_userpf,
 };
 
-int __init xocl_init_mem_hbm(void)
+int __init xocl_init_mem_hbm(bool flag)
 {
-	return platform_driver_register(&mem_hbm_driver);
+	if(flag)
+	{
+		return platform_driver_register(&mem_hbm_driver_mgmtpf);
+	}
+	else
+	{
+		return platform_driver_register(&mem_hbm_driver_userpf);
+	}
 }
 
-void xocl_fini_mem_hbm(void)
+void xocl_fini_mem_hbm(bool flag)
 {
-	platform_driver_unregister(&mem_hbm_driver);
+	if(flag)
+		platform_driver_unregister(&mem_hbm_driver_mgmtpf);
+	else
+		platform_driver_unregister(&mem_hbm_driver_userpf);
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/memory_hbm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/memory_hbm.c
@@ -608,11 +608,11 @@ struct xocl_drv_private mem_hbm_priv_userpf = {
 };
 
 struct platform_device_id mem_hbm_id_table_mgmtpf[] = {
-	{ XOCL_DEVNAME(XOCL_MIG_HBM), (kernel_ulong_t)&mem_hbm_priv_mgmtpf },
+	{ XOCL_MGMTPF_DEVICE(XOCL_MIG_HBM), (kernel_ulong_t)&mem_hbm_priv_mgmtpf },
 	{ },
 };
 struct platform_device_id mem_hbm_id_table_userpf[] = {
-	{ XOCL_DEVNAME(XOCL_MIG_HBM), (kernel_ulong_t)&mem_hbm_priv_userpf },
+	{ XOCL_USERPF_DEVICE(XOCL_MIG_HBM), (kernel_ulong_t)&mem_hbm_priv_userpf },
 	{ },
 };
 
@@ -620,7 +620,7 @@ static struct platform_driver	mem_hbm_driver_mgmtpf = {
 	.probe		= mem_hbm_probe,
 	.remove		= mem_hbm_remove,
 	.driver		= {
-		.name = XOCL_DEVNAME(XOCL_MIG_HBM),
+		.name = XOCL_MGMTPF_DEVICE(XOCL_MIG_HBM),
 	},
 	.id_table = mem_hbm_id_table_mgmtpf,
 };
@@ -628,7 +628,7 @@ static struct platform_driver	mem_hbm_driver_userpf = {
 	.probe		= mem_hbm_probe,
 	.remove		= mem_hbm_remove,
 	.driver		= {
-		.name = XOCL_DEVNAME(XOCL_MIG_HBM),
+		.name = XOCL_USERPF_DEVICE(XOCL_MIG_HBM),
 	},
 	.id_table = mem_hbm_id_table_userpf,
 };

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mgmt_msix.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mgmt_msix.c
@@ -373,12 +373,12 @@ static struct platform_driver	mgmt_msix_driver = {
 	.id_table	= mgmt_msix_id_table,
 };
 
-int __init xocl_init_mgmt_msix(void)
+int __init xocl_init_mgmt_msix(bool flag)
 {
 	return platform_driver_register(&mgmt_msix_driver);
 }
 
-void xocl_fini_mgmt_msix(void)
+void xocl_fini_mgmt_msix(bool flag)
 {
 	return platform_driver_unregister(&mgmt_msix_driver);
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mgmt_msix.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mgmt_msix.c
@@ -360,7 +360,7 @@ struct xocl_drv_private mgmt_msix_priv = {
 };
 
 static struct platform_device_id mgmt_msix_id_table[] = {
-	{ XOCL_DEVNAME(XOCL_DMA_MSIX), (kernel_ulong_t)&mgmt_msix_priv },
+	{ XOCL_MGMTPF_DEVICE(XOCL_DMA_MSIX), (kernel_ulong_t)&mgmt_msix_priv },
 	{ },
 };
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/microblaze.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/microblaze.c
@@ -708,7 +708,7 @@ struct xocl_drv_private mb_priv = {
 };
 
 struct platform_device_id mb_id_table[] = {
-	{ XOCL_DEVNAME(XOCL_MB), (kernel_ulong_t)&mb_priv },
+	{ XOCL_MGMTPF_DEVICE(XOCL_MB), (kernel_ulong_t)&mb_priv },
 	{ },
 };
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/microblaze.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/microblaze.c
@@ -721,12 +721,12 @@ static struct platform_driver	mb_driver = {
 	.id_table = mb_id_table,
 };
 
-int __init xocl_init_mb(void)
+int __init xocl_init_mb(bool flag)
 {
 	return platform_driver_register(&mb_driver);
 }
 
-void xocl_fini_mb(void)
+void xocl_fini_mb(bool flag)
 {
 	platform_driver_unregister(&mb_driver);
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mig.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mig.c
@@ -525,11 +525,11 @@ struct xocl_drv_private mig_priv_userpf = {
 };
 
 struct platform_device_id mig_id_table_mgmtpf[] = {
-	{ XOCL_DEVNAME(XOCL_MIG), (kernel_ulong_t)&mig_priv_mgmtpf },
+	{ XOCL_MGMTPF_DEVICE(XOCL_MIG), (kernel_ulong_t)&mig_priv_mgmtpf },
 	{ },
 };
 struct platform_device_id mig_id_table_userpf[] = {
-	{ XOCL_DEVNAME(XOCL_MIG), (kernel_ulong_t)&mig_priv_userpf },
+	{ XOCL_USERPF_DEVICE(XOCL_MIG), (kernel_ulong_t)&mig_priv_userpf },
 	{ },
 };
 
@@ -537,7 +537,7 @@ static struct platform_driver	mig_driver_mgmtpf = {
 	.probe		= mig_probe,
 	.remove		= mig_remove,
 	.driver		= {
-		.name = XOCL_DEVNAME(XOCL_MIG),
+		.name = XOCL_MGMTPF_DEVICE(XOCL_MIG),
 	},
 	.id_table = mig_id_table_mgmtpf,
 };
@@ -545,7 +545,7 @@ static struct platform_driver	mig_driver_userpf = {
 	.probe		= mig_probe,
 	.remove		= mig_remove,
 	.driver		= {
-		.name = XOCL_DEVNAME(XOCL_MIG),
+		.name = XOCL_USERPF_DEVICE(XOCL_MIG),
 	},
 	.id_table = mig_id_table_userpf,
 };

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mig.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mig.c
@@ -517,30 +517,55 @@ static int mig_remove(struct platform_device *pdev)
 	return 0;
 }
 
-struct xocl_drv_private mig_priv = {
+struct xocl_drv_private mig_priv_mgmtpf = {
+	.ops = &mig_ops,
+};
+struct xocl_drv_private mig_priv_userpf = {
 	.ops = &mig_ops,
 };
 
-struct platform_device_id mig_id_table[] = {
-	{ XOCL_DEVNAME(XOCL_MIG), (kernel_ulong_t)&mig_priv },
+struct platform_device_id mig_id_table_mgmtpf[] = {
+	{ XOCL_DEVNAME(XOCL_MIG), (kernel_ulong_t)&mig_priv_mgmtpf },
+	{ },
+};
+struct platform_device_id mig_id_table_userpf[] = {
+	{ XOCL_DEVNAME(XOCL_MIG), (kernel_ulong_t)&mig_priv_userpf },
 	{ },
 };
 
-static struct platform_driver	mig_driver = {
+static struct platform_driver	mig_driver_mgmtpf = {
 	.probe		= mig_probe,
 	.remove		= mig_remove,
 	.driver		= {
 		.name = XOCL_DEVNAME(XOCL_MIG),
 	},
-	.id_table = mig_id_table,
+	.id_table = mig_id_table_mgmtpf,
+};
+static struct platform_driver	mig_driver_userpf = {
+	.probe		= mig_probe,
+	.remove		= mig_remove,
+	.driver		= {
+		.name = XOCL_DEVNAME(XOCL_MIG),
+	},
+	.id_table = mig_id_table_userpf,
 };
 
-int __init xocl_init_mig(void)
+int __init xocl_init_mig(bool flag)
 {
-	return platform_driver_register(&mig_driver);
+	if(flag)
+	{
+		return platform_driver_register(&mig_driver_mgmtpf);
+	}
+	else
+	{
+		return platform_driver_register(&mig_driver_userpf);
+	}
 }
 
-void xocl_fini_mig(void)
+void xocl_fini_mig(bool flag)
 {
-	platform_driver_unregister(&mig_driver);
+	if(flag)
+		platform_driver_unregister(&mig_driver_mgmtpf);
+	else
+		platform_driver_unregister(&mig_driver_userpf);
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/msix_xdma.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/msix_xdma.c
@@ -308,12 +308,12 @@ static struct platform_driver	msix_xdma_driver = {
 	.id_table	= msix_xdma_id_table,
 };
 
-int __init xocl_init_msix_xdma(void)
+int __init xocl_init_msix_xdma(bool flag)
 {
 	return platform_driver_register(&msix_xdma_driver);
 }
 
-void xocl_fini_msix_xdma(void)
+void xocl_fini_msix_xdma(bool flag)
 {
 	return platform_driver_unregister(&msix_xdma_driver);
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/msix_xdma.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/msix_xdma.c
@@ -295,7 +295,7 @@ struct xocl_drv_private msix_xdma_priv = {
 };
 
 static struct platform_device_id msix_xdma_id_table[] = {
-	{ XOCL_DEVNAME(XOCL_MSIX_XDMA), (kernel_ulong_t)&msix_xdma_priv },
+	{XOCL_USERPF_DEVICE(XOCL_MSIX_XDMA), (kernel_ulong_t)&msix_xdma_priv },
 	{ },
 };
 
@@ -303,7 +303,7 @@ static struct platform_driver	msix_xdma_driver = {
 	.probe		= msix_xdma_probe,
 	.remove		= msix_xdma_remove,
 	.driver		= {
-		.name = XOCL_DEVNAME(XOCL_MSIX_XDMA),
+		.name = XOCL_USERPF_DEVICE(XOCL_MSIX_XDMA),
 	},
 	.id_table	= msix_xdma_id_table,
 };

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/nifd.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/nifd.c
@@ -30,7 +30,7 @@
 #include "../xocl_drv.h"
 #include "xclfeatures.h"
 
-#define NIFD_DEV_NAME "nifd" SUBDEV_SUFFIX
+#define NIFD_DEV_NAME "nifd"
 #define SUPPORTED_NIFD_IP_VERSION 1
 #define SUPPORTED_DRIVER_VERSION 1
 #define MINOR_NAME_MASK 0xffffffff
@@ -665,13 +665,13 @@ static struct platform_driver nifd_driver = {
     .id_table = nifd_id_table,
 };
 
-int __init xocl_init_nifd(void)
+int __init xocl_init_nifd(bool flag)
 {
     int err = 0;
     err = alloc_chrdev_region(&nifd_priv.dev, 
                             0, 
                             XOCL_MAX_DEVICES, 
-                            NIFD_DEV_NAME);
+                            XOCL_DEVNAME(NIFD_DEV_NAME));
     if (err < 0)
         goto err_register_chrdev;
 
@@ -688,7 +688,7 @@ err_register_chrdev:
     return err;
 }
 
-void xocl_fini_nifd(void)
+void xocl_fini_nifd(bool flag)
 {
     unregister_chrdev_region(nifd_priv.dev, XOCL_MAX_DEVICES);
     platform_driver_unregister(&nifd_driver);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/nifd.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/nifd.c
@@ -652,7 +652,7 @@ struct xocl_drv_private nifd_priv = {
 };
 
 struct platform_device_id nifd_id_table[] = {
-    {XOCL_DEVNAME(XOCL_NIFD_PRI), (kernel_ulong_t)&nifd_priv},
+    {XOCL_MGMTPF_DEVICE(XOCL_NIFD_PRI), (kernel_ulong_t)&nifd_priv},
     {},
 };
 
@@ -660,7 +660,7 @@ static struct platform_driver nifd_driver = {
     .probe = nifd_probe,
     .remove = nifd_remove,
     .driver = {
-        .name = XOCL_DEVNAME(NIFD_DEV_NAME),
+        .name = XOCL_MGMTPF_DEVICE(NIFD_DEV_NAME),
     },
     .id_table = nifd_id_table,
 };
@@ -671,7 +671,7 @@ int __init xocl_init_nifd(bool flag)
     err = alloc_chrdev_region(&nifd_priv.dev, 
                             0, 
                             XOCL_MAX_DEVICES, 
-                            XOCL_DEVNAME(NIFD_DEV_NAME));
+                            XOCL_MGMTPF_DEVICE(NIFD_DEV_NAME));
     if (err < 0)
         goto err_register_chrdev;
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ospi_versal.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ospi_versal.c
@@ -82,7 +82,7 @@
 #include "../xocl_drv.h"
 #include "xrt_drv.h"
 
-#define	XFER_VERSAL_DEV_NAME "xfer_versal" SUBDEV_SUFFIX
+#define	XFER_VERSAL_DEV_NAME "xfer_versal"
 
 /* Timer interval of checking OSPI done */
 #define XFER_VERSAL_TIMER_INTERVAL	(1000)
@@ -501,12 +501,12 @@ static struct platform_driver	xfer_versal_driver = {
 	.id_table = xfer_versal_id_table,
 };
 
-int __init xocl_init_xfer_versal(void)
+int __init xocl_init_xfer_versal(bool flag)
 {
 	int err = 0;
 
 	err = alloc_chrdev_region(&xfer_versal_priv.dev, 0, XOCL_MAX_DEVICES,
-	    XFER_VERSAL_DEV_NAME);
+	    XOCL_DEVNAME(XFER_VERSAL_DEV_NAME));
 	if (err < 0)
 		return err;
 
@@ -520,7 +520,7 @@ int __init xocl_init_xfer_versal(void)
 	return 0;
 }
 
-void xocl_fini_xfer_versal(void)
+void xocl_fini_xfer_versal(bool flag)
 {
 	unregister_chrdev_region(xfer_versal_priv.dev, XOCL_MAX_DEVICES);
 	platform_driver_unregister(&xfer_versal_driver);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ospi_versal.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ospi_versal.c
@@ -487,7 +487,7 @@ struct xocl_drv_private xfer_versal_priv = {
 };
 
 struct platform_device_id xfer_versal_id_table[] = {
-	{ XOCL_DEVNAME(XOCL_XFER_VERSAL),
+	{ XOCL_MGMTPF_DEVICE(XOCL_XFER_VERSAL),
 	    (kernel_ulong_t)&xfer_versal_priv },
 	{ },
 };
@@ -496,7 +496,7 @@ static struct platform_driver	xfer_versal_driver = {
 	.probe		= xfer_versal_probe,
 	.remove		= xfer_versal_remove,
 	.driver		= {
-		.name = XOCL_DEVNAME(XOCL_XFER_VERSAL),
+		.name = XOCL_MGMTPF_DEVICE(XOCL_XFER_VERSAL),
 	},
 	.id_table = xfer_versal_id_table,
 };
@@ -506,7 +506,7 @@ int __init xocl_init_xfer_versal(bool flag)
 	int err = 0;
 
 	err = alloc_chrdev_region(&xfer_versal_priv.dev, 0, XOCL_MAX_DEVICES,
-	    XOCL_DEVNAME(XFER_VERSAL_DEV_NAME));
+	    XOCL_MGMTPF_DEVICE(XFER_VERSAL_DEV_NAME));
 	if (err < 0)
 		return err;
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/p2p.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/p2p.c
@@ -1600,7 +1600,7 @@ struct xocl_drv_private p2p_priv = {
 };
 
 struct platform_device_id p2p_id_table[] = {
-	{ XOCL_DEVNAME(XOCL_P2P), (kernel_ulong_t)&p2p_priv },
+	{ XOCL_USERPF_DEVICE(XOCL_P2P), (kernel_ulong_t)&p2p_priv },
 	{ },
 };
 
@@ -1608,7 +1608,7 @@ static struct platform_driver	p2p_driver = {
 	.probe		= p2p_probe,
 	.remove		= p2p_remove,
 	.driver		= {
-		.name = XOCL_DEVNAME(XOCL_P2P),
+		.name = XOCL_USERPF_DEVICE(XOCL_P2P),
 	},
 	.id_table = p2p_id_table,
 };

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/p2p.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/p2p.c
@@ -1613,12 +1613,12 @@ static struct platform_driver	p2p_driver = {
 	.id_table = p2p_id_table,
 };
 
-int __init xocl_init_p2p(void)
+int __init xocl_init_p2p(bool flag)
 {
 	return platform_driver_register(&p2p_driver);
 }
 
-void xocl_fini_p2p(void)
+void xocl_fini_p2p(bool flag)
 {
 	platform_driver_unregister(&p2p_driver);
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/pcie_firewall.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/pcie_firewall.c
@@ -142,7 +142,7 @@ static struct xocl_drv_private firewall_priv = {
 };
 
 static struct platform_device_id firewall_id_table[] = {
-	{ XOCL_DEVNAME(XOCL_PCIE_FIREWALL), (kernel_ulong_t)&firewall_priv },
+	{ XOCL_MGMTPF_DEVICE(XOCL_PCIE_FIREWALL), (kernel_ulong_t)&firewall_priv },
 	{ },
 };
 
@@ -150,7 +150,7 @@ static struct platform_driver   firewall_driver = {
 	.probe		= firewall_probe,
 	.remove		= firewall_remove,
 	.driver		= {
-		.name = XOCL_DEVNAME(XOCL_PCIE_FIREWALL),
+		.name = XOCL_MGMTPF_DEVICE(XOCL_PCIE_FIREWALL),
 	},
 	.id_table = firewall_id_table,
 };

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/pcie_firewall.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/pcie_firewall.c
@@ -155,12 +155,12 @@ static struct platform_driver   firewall_driver = {
 	.id_table = firewall_id_table,
 };
 
-int __init xocl_init_pcie_firewall(void)
+int __init xocl_init_pcie_firewall(bool flag)
 {
 	return platform_driver_register(&firewall_driver);
 }
 
-void xocl_fini_pcie_firewall(void)
+void xocl_fini_pcie_firewall(bool flag)
 {
 	platform_driver_unregister(&firewall_driver);
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/pmc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/pmc.c
@@ -226,12 +226,12 @@ static struct platform_driver pmc_driver = {
 	.id_table = pmc_id_table,
 };
 
-int __init xocl_init_pmc(void)
+int __init xocl_init_pmc(bool flag)
 {
 	return platform_driver_register(&pmc_driver);
 }
 
-void xocl_fini_pmc(void)
+void xocl_fini_pmc(bool flag)
 {
 	platform_driver_unregister(&pmc_driver);
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/pmc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/pmc.c
@@ -213,7 +213,7 @@ struct xocl_drv_private pmc_priv = {
 };
 
 struct platform_device_id pmc_id_table[] = {
-	{ XOCL_DEVNAME(XOCL_PMC), (kernel_ulong_t)&pmc_priv },
+	{ XOCL_MGMTPF_DEVICE(XOCL_PMC), (kernel_ulong_t)&pmc_priv },
 	{ },
 };
 
@@ -221,7 +221,7 @@ static struct platform_driver pmc_driver = {
 	.probe		= pmc_probe,
 	.remove		= pmc_remove,
 	.driver		= {
-		.name = XOCL_DEVNAME(XOCL_PMC),
+		.name = XOCL_MGMTPF_DEVICE(XOCL_PMC),
 	},
 	.id_table = pmc_id_table,
 };

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ps.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ps.c
@@ -429,12 +429,12 @@ static struct platform_driver ps_driver = {
 	.id_table = ps_id_table,
 };
 
-int __init xocl_init_ps(void)
+int __init xocl_init_ps(bool flag)
 {
 	return platform_driver_register(&ps_driver);
 }
 
-void xocl_fini_ps(void)
+void xocl_fini_ps(bool flag)
 {
 	platform_driver_unregister(&ps_driver);
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ps.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ps.c
@@ -416,7 +416,7 @@ failed:
 };
 
 struct platform_device_id ps_id_table[] = {
-	{ XOCL_DEVNAME(XOCL_PS), (kernel_ulong_t)&ps_priv },
+	{ XOCL_MGMTPF_DEVICE(XOCL_PS), (kernel_ulong_t)&ps_priv },
 	{ },
 };
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/qdma.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/qdma.c
@@ -941,7 +941,7 @@ struct xocl_drv_private qdma_priv = {
 };
 
 static struct platform_device_id qdma_id_table[] = {
-	{ XOCL_DEVNAME(XOCL_QDMA), (kernel_ulong_t)&qdma_priv },
+	{ XOCL_USERPF_DEVICE(XOCL_QDMA), (kernel_ulong_t)&qdma_priv },
 	{ },
 };
 
@@ -949,7 +949,7 @@ static struct platform_driver	qdma_driver = {
 	.probe		= qdma_probe,
 	.remove		= qdma_remove,
 	.driver		= {
-		.name = XOCL_DEVNAME(XOCL_QDMA),
+		.name = XOCL_USERPF_DEVICE(XOCL_QDMA),
 	},
 	.id_table	= qdma_id_table,
 };

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/qdma.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/qdma.c
@@ -954,7 +954,7 @@ static struct platform_driver	qdma_driver = {
 	.id_table	= qdma_id_table,
 };
 
-int __init xocl_init_qdma(void)
+int __init xocl_init_qdma(bool flag)
 {
 	int		err = 0;
 
@@ -991,7 +991,7 @@ err_reg_chrdev:
 	return err;
 }
 
-void xocl_fini_qdma(void)
+void xocl_fini_qdma(bool flag)
 {
 	unregister_chrdev_region(str_dev, XOCL_CHARDEV_REG_COUNT);
 	platform_driver_unregister(&qdma_driver);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/scu.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/scu.c
@@ -352,12 +352,12 @@ static struct platform_driver scu_driver = {
 	.id_table	= scu_id_table,
 };
 
-int __init xocl_init_scu(void)
+int __init xocl_init_scu(bool flag)
 {
 	return platform_driver_register(&scu_driver);
 }
 
-void xocl_fini_scu(void)
+void xocl_fini_scu(bool flag)
 {
 	platform_driver_unregister(&scu_driver);
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/scu.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/scu.c
@@ -339,7 +339,7 @@ static int scu_remove(struct platform_device *pdev)
 }
 
 static struct platform_device_id scu_id_table[] = {
-	{ XOCL_DEVNAME(XOCL_SCU), 0 },
+	{ XOCL_USERPF_DEVICE(XOCL_SCU), 0 },
 	{ },
 };
 
@@ -347,7 +347,7 @@ static struct platform_driver scu_driver = {
 	.probe		= scu_probe,
 	.remove		= scu_remove,
 	.driver		= {
-		.name = XOCL_DEVNAME(XOCL_SCU),
+		.name = XOCL_USERPF_DEVICE(XOCL_SCU),
 	},
 	.id_table	= scu_id_table,
 };

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/spc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/spc.c
@@ -252,7 +252,7 @@ struct xocl_drv_private spc_priv = {
 };
 
 struct platform_device_id spc_id_table[] = {
-	{ XOCL_DEVNAME(XOCL_SPC), (kernel_ulong_t)&spc_priv },
+	{ XOCL_USERPF_DEVICE(XOCL_SPC), (kernel_ulong_t)&spc_priv },
 	{ },
 };
 
@@ -260,7 +260,7 @@ static struct platform_driver	spc_driver = {
 	.probe		= spc_probe,
 	.remove		= spc_remove,
 	.driver		= {
-		.name = XOCL_DEVNAME(XOCL_SPC),
+		.name = XOCL_USERPF_DEVICE(XOCL_SPC),
 	},
 	.id_table = spc_id_table,
 };

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/spc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/spc.c
@@ -265,7 +265,7 @@ static struct platform_driver	spc_driver = {
 	.id_table = spc_id_table,
 };
 
-int __init xocl_init_spc(void)
+int __init xocl_init_spc(bool flag)
 {
 	int err = 0;
 
@@ -285,7 +285,7 @@ err_chrdev_reg:
 	return err;
 }
 
-void xocl_fini_spc(void)
+void xocl_fini_spc(bool flag)
 {
 	unregister_chrdev_region(spc_priv.dev, XOCL_MAX_DEVICES);
 	platform_driver_unregister(&spc_driver);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/sysmon.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/sysmon.c
@@ -389,7 +389,7 @@ struct xocl_drv_private sysmon_priv = {
 };
 
 struct platform_device_id sysmon_id_table[] = {
-	{ XOCL_DEVNAME(XOCL_SYSMON), (kernel_ulong_t)&sysmon_priv },
+	{ XOCL_MGMTPF_DEVICE(XOCL_SYSMON), (kernel_ulong_t)&sysmon_priv },
 	{ },
 };
 
@@ -397,7 +397,7 @@ static struct platform_driver	sysmon_driver = {
 	.probe		= sysmon_probe,
 	.remove		= sysmon_remove,
 	.driver		= {
-		.name = XOCL_DEVNAME(XOCL_SYSMON),
+		.name = XOCL_MGMTPF_DEVICE(XOCL_SYSMON),
 	},
 	.id_table = sysmon_id_table,
 };

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/sysmon.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/sysmon.c
@@ -402,12 +402,12 @@ static struct platform_driver	sysmon_driver = {
 	.id_table = sysmon_id_table,
 };
 
-int __init xocl_init_sysmon(void)
+int __init xocl_init_sysmon(bool flag)
 {
 	return platform_driver_register(&sysmon_driver);
 }
 
-void xocl_fini_sysmon(void)
+void xocl_fini_sysmon(bool flag)
 {
 	platform_driver_unregister(&sysmon_driver);
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/trace_fifo_full.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/trace_fifo_full.c
@@ -123,7 +123,7 @@ static struct platform_driver	trace_fifo_full_driver = {
 	.id_table = trace_fifo_full_id_table,
 };
 
-int __init xocl_init_trace_fifo_full(void)
+int __init xocl_init_trace_fifo_full(bool flag)
 {
 	int err = 0;
 
@@ -143,7 +143,7 @@ err_chrdev_reg:
 	return err;
 }
 
-void xocl_fini_trace_fifo_full(void)
+void xocl_fini_trace_fifo_full(bool flag)
 {
 	unregister_chrdev_region(trace_fifo_full_priv.dev, XOCL_MAX_DEVICES);
 	platform_driver_unregister(&trace_fifo_full_driver);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/trace_fifo_full.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/trace_fifo_full.c
@@ -110,7 +110,7 @@ struct xocl_drv_private trace_fifo_full_priv = {
 };
 
 struct platform_device_id trace_fifo_full_id_table[] = {
-	{ XOCL_DEVNAME(XOCL_TRACE_FIFO_FULL), (kernel_ulong_t)&trace_fifo_full_priv },
+	{ XOCL_USERPF_DEVICE(XOCL_TRACE_FIFO_FULL), (kernel_ulong_t)&trace_fifo_full_priv },
 	{ },
 };
 
@@ -118,7 +118,7 @@ static struct platform_driver	trace_fifo_full_driver = {
 	.probe		= trace_fifo_full_probe,
 	.remove		= trace_fifo_full_remove,
 	.driver		= {
-		.name = XOCL_DEVNAME(XOCL_TRACE_FIFO_FULL),
+		.name = XOCL_USERPF_DEVICE(XOCL_TRACE_FIFO_FULL),
 	},
 	.id_table = trace_fifo_full_id_table,
 };

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/trace_fifo_lite.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/trace_fifo_lite.c
@@ -236,7 +236,7 @@ struct xocl_drv_private trace_fifo_lite_priv = {
 };
 
 struct platform_device_id trace_fifo_lite_id_table[] = {
-	{ XOCL_DEVNAME(XOCL_TRACE_FIFO_LITE), (kernel_ulong_t)&trace_fifo_lite_priv },
+	{ XOCL_USERPF_DEVICE(XOCL_TRACE_FIFO_LITE), (kernel_ulong_t)&trace_fifo_lite_priv },
 	{ },
 };
 
@@ -244,7 +244,7 @@ static struct platform_driver	trace_fifo_lite_driver = {
 	.probe		= trace_fifo_lite_probe,
 	.remove		= trace_fifo_lite_remove,
 	.driver		= {
-		.name = XOCL_DEVNAME(XOCL_TRACE_FIFO_LITE),
+		.name = XOCL_USERPF_DEVICE(XOCL_TRACE_FIFO_LITE),
 	},
 	.id_table = trace_fifo_lite_id_table,
 };

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/trace_fifo_lite.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/trace_fifo_lite.c
@@ -249,7 +249,7 @@ static struct platform_driver	trace_fifo_lite_driver = {
 	.id_table = trace_fifo_lite_id_table,
 };
 
-int __init xocl_init_trace_fifo_lite(void)
+int __init xocl_init_trace_fifo_lite(bool flag)
 {
 	int err = 0;
 
@@ -269,7 +269,7 @@ err_chrdev_reg:
 	return err;
 }
 
-void xocl_fini_trace_fifo_lite(void)
+void xocl_fini_trace_fifo_lite(bool flag)
 {
 	unregister_chrdev_region(trace_fifo_lite_priv.dev, XOCL_MAX_DEVICES);
 	platform_driver_unregister(&trace_fifo_lite_driver);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/trace_funnel.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/trace_funnel.c
@@ -239,7 +239,7 @@ struct xocl_drv_private trace_funnel_priv = {
 };
 
 struct platform_device_id trace_funnel_id_table[] = {
-	{ XOCL_DEVNAME(XOCL_TRACE_FUNNEL), (kernel_ulong_t)&trace_funnel_priv },
+	{ XOCL_USERPF_DEVICE(XOCL_TRACE_FUNNEL), (kernel_ulong_t)&trace_funnel_priv },
 	{ },
 };
 
@@ -247,7 +247,7 @@ static struct platform_driver	trace_funnel_driver = {
 	.probe		= trace_funnel_probe,
 	.remove		= trace_funnel_remove,
 	.driver		= {
-		.name = XOCL_DEVNAME(XOCL_TRACE_FUNNEL),
+		.name = XOCL_USERPF_DEVICE(XOCL_TRACE_FUNNEL),
 	},
 	.id_table = trace_funnel_id_table,
 };

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/trace_funnel.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/trace_funnel.c
@@ -252,7 +252,7 @@ static struct platform_driver	trace_funnel_driver = {
 	.id_table = trace_funnel_id_table,
 };
 
-int __init xocl_init_trace_funnel(void)
+int __init xocl_init_trace_funnel(bool flag)
 {
 	int err = 0;
 
@@ -272,7 +272,7 @@ err_chrdev_reg:
 	return err;
 }
 
-void xocl_fini_trace_funnel(void)
+void xocl_fini_trace_funnel(bool flag)
 {
 	unregister_chrdev_region(trace_funnel_priv.dev, XOCL_MAX_DEVICES);
 	platform_driver_unregister(&trace_funnel_driver);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/trace_s2mm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/trace_s2mm.c
@@ -314,7 +314,7 @@ static struct platform_driver	trace_s2mm_driver = {
 	.id_table = trace_s2mm_id_table,
 };
 
-int __init xocl_init_trace_s2mm(void)
+int __init xocl_init_trace_s2mm(bool flag)
 {
 	int err = 0;
 
@@ -334,7 +334,7 @@ err_chrdev_reg:
 	return err;
 }
 
-void xocl_fini_trace_s2mm(void)
+void xocl_fini_trace_s2mm(bool flag)
 {
 	unregister_chrdev_region(trace_s2mm_priv.dev, XOCL_MAX_DEVICES);
 	platform_driver_unregister(&trace_s2mm_driver);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/trace_s2mm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/trace_s2mm.c
@@ -301,7 +301,7 @@ struct xocl_drv_private trace_s2mm_priv = {
 };
 
 struct platform_device_id trace_s2mm_id_table[] = {
-	{ XOCL_DEVNAME(XOCL_TRACE_S2MM), (kernel_ulong_t)&trace_s2mm_priv },
+	{ XOCL_USERPF_DEVICE(XOCL_TRACE_S2MM), (kernel_ulong_t)&trace_s2mm_priv },
 	{ },
 };
 
@@ -309,7 +309,7 @@ static struct platform_driver	trace_s2mm_driver = {
 	.probe		= trace_s2mm_probe,
 	.remove		= trace_s2mm_remove,
 	.driver		= {
-		.name = XOCL_DEVNAME(XOCL_TRACE_S2MM),
+		.name = XOCL_USERPF_DEVICE(XOCL_TRACE_S2MM),
 	},
 	.id_table = trace_s2mm_id_table,
 };

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ulite.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ulite.c
@@ -476,7 +476,7 @@ static struct uart_ops ulite_ops = {
 
 static struct uart_driver xcl_ulite_driver = {
 	.owner		= THIS_MODULE,
-	.driver_name	= XOCL_DEVNAME(XOCL_UARTLITE),
+	.driver_name	= XOCL_MGMTPF_DEVICE(XOCL_UARTLITE),
 	.dev_name	= ULITE_NAME,
 	.nr		= ULITE_NR_UARTS,
 };
@@ -580,7 +580,7 @@ struct xocl_drv_private ulite_priv = {
 };
 
 struct platform_device_id ulite_id_table[] = {
-	{ XOCL_DEVNAME(XOCL_UARTLITE), (kernel_ulong_t)&ulite_priv },
+	{ XOCL_MGMTPF_DEVICE(XOCL_UARTLITE), (kernel_ulong_t)&ulite_priv },
 	{ },
 };
 
@@ -588,7 +588,7 @@ static struct platform_driver ulite_platform_driver = {
 	.probe = ulite_probe,
 	.remove = ulite_remove,
 	.driver = {
-		.name  = XOCL_DEVNAME(XOCL_UARTLITE),
+		.name  = XOCL_MGMTPF_DEVICE(XOCL_UARTLITE),
 	},
 	.id_table = ulite_id_table,
 };

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ulite.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ulite.c
@@ -597,7 +597,7 @@ static struct platform_driver ulite_platform_driver = {
  * Module setup/teardown
  */
 
-int __init xocl_init_ulite(void)
+int __init xocl_init_ulite(bool flag)
 {
 	int ret;
 
@@ -612,7 +612,7 @@ int __init xocl_init_ulite(void)
 	return ret;
 }
 
-void xocl_fini_ulite(void)
+void xocl_fini_ulite(bool flag)
 {
 	platform_driver_unregister(&ulite_platform_driver);
 	uart_unregister_driver(&xcl_ulite_driver);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/version_ctrl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/version_ctrl.c
@@ -192,30 +192,53 @@ failed:
 	return ret;
 }
 
-struct xocl_drv_private version_ctrl_priv = {
+struct xocl_drv_private version_ctrl_priv_mgmtpf = {
+	.ops = &vc_ops,
+};
+struct xocl_drv_private version_ctrl_priv_userpf = {
 	.ops = &vc_ops,
 };
 
-struct platform_device_id version_ctrl_id_table[] = {
-	{ XOCL_DEVNAME(XOCL_VERSION_CTRL), (kernel_ulong_t)&version_ctrl_priv },
+struct platform_device_id version_ctrl_id_table_mgmtpf[] = {
+	{ XOCL_DEVNAME(XOCL_VERSION_CTRL), (kernel_ulong_t)&version_ctrl_priv_mgmtpf },
+	{ },
+};
+struct platform_device_id version_ctrl_id_table_userpf[] = {
+	{ XOCL_DEVNAME(XOCL_VERSION_CTRL), (kernel_ulong_t)&version_ctrl_priv_userpf },
 	{ },
 };
 
-static struct platform_driver	version_ctrl_driver = {
+static struct platform_driver	version_ctrl_driver_mgmtpf = {
 	.probe		= version_ctrl_probe,
 	.remove		= version_ctrl_remove,
 	.driver		= {
 		.name = XOCL_DEVNAME(XOCL_VERSION_CTRL),
 	},
-	.id_table = version_ctrl_id_table,
+	.id_table = version_ctrl_id_table_mgmtpf,
+};
+static struct platform_driver	version_ctrl_driver_userpf = {
+	.probe		= version_ctrl_probe,
+	.remove		= version_ctrl_remove,
+	.driver		= {
+		.name = XOCL_DEVNAME(XOCL_VERSION_CTRL),
+	},
+	.id_table = version_ctrl_id_table_userpf,
 };
 
-int __init xocl_init_version_control(void)
+int __init xocl_init_version_control(bool flag)
 {
-	return platform_driver_register(&version_ctrl_driver);
+	if(flag){
+		return platform_driver_register(&version_ctrl_driver_mgmtpf);
+	}
+	else{
+		return platform_driver_register(&version_ctrl_driver_userpf);
+	}
 }
 
-void xocl_fini_version_control(void)
+void xocl_fini_version_control(bool flag)
 {
-	platform_driver_unregister(&version_ctrl_driver);
+	if(flag)
+		platform_driver_unregister(&version_ctrl_driver_mgmtpf);
+	else
+		platform_driver_unregister(&version_ctrl_driver_userpf);
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/version_ctrl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/version_ctrl.c
@@ -200,11 +200,11 @@ struct xocl_drv_private version_ctrl_priv_userpf = {
 };
 
 struct platform_device_id version_ctrl_id_table_mgmtpf[] = {
-	{ XOCL_DEVNAME(XOCL_VERSION_CTRL), (kernel_ulong_t)&version_ctrl_priv_mgmtpf },
+	{ XOCL_MGMTPF_DEVICE(XOCL_VERSION_CTRL), (kernel_ulong_t)&version_ctrl_priv_mgmtpf },
 	{ },
 };
 struct platform_device_id version_ctrl_id_table_userpf[] = {
-	{ XOCL_DEVNAME(XOCL_VERSION_CTRL), (kernel_ulong_t)&version_ctrl_priv_userpf },
+	{ XOCL_USERPF_DEVICE(XOCL_VERSION_CTRL), (kernel_ulong_t)&version_ctrl_priv_userpf },
 	{ },
 };
 
@@ -212,7 +212,7 @@ static struct platform_driver	version_ctrl_driver_mgmtpf = {
 	.probe		= version_ctrl_probe,
 	.remove		= version_ctrl_remove,
 	.driver		= {
-		.name = XOCL_DEVNAME(XOCL_VERSION_CTRL),
+		.name = XOCL_MGMTPF_DEVICE(XOCL_VERSION_CTRL),
 	},
 	.id_table = version_ctrl_id_table_mgmtpf,
 };
@@ -220,7 +220,7 @@ static struct platform_driver	version_ctrl_driver_userpf = {
 	.probe		= version_ctrl_probe,
 	.remove		= version_ctrl_remove,
 	.driver		= {
-		.name = XOCL_DEVNAME(XOCL_VERSION_CTRL),
+		.name = XOCL_USERPF_DEVICE(XOCL_VERSION_CTRL),
 	},
 	.id_table = version_ctrl_id_table_userpf,
 };

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xdma.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xdma.c
@@ -599,12 +599,12 @@ static struct platform_driver	xdma_driver = {
 	.id_table	= xdma_id_table,
 };
 
-int __init xocl_init_xdma(void)
+int __init xocl_init_xdma(bool flag)
 {
 	return platform_driver_register(&xdma_driver);
 }
 
-void xocl_fini_xdma(void)
+void xocl_fini_xdma(bool flag)
 {
 	return platform_driver_unregister(&xdma_driver);
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xdma.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xdma.c
@@ -586,7 +586,7 @@ struct xocl_drv_private xdma_priv = {
 };
 
 static struct platform_device_id xdma_id_table[] = {
-	{ XOCL_DEVNAME(XOCL_XDMA), (kernel_ulong_t)&xdma_priv },
+	{ XOCL_USERPF_DEVICE(XOCL_XDMA), (kernel_ulong_t)&xdma_priv },
 	{ },
 };
 
@@ -594,7 +594,7 @@ static struct platform_driver	xdma_driver = {
 	.probe		= xdma_probe,
 	.remove		= xdma_remove,
 	.driver		= {
-		.name = XOCL_DEVNAME(XOCL_XDMA),
+		.name = XOCL_USERPF_DEVICE(XOCL_XDMA),
 	},
 	.id_table	= xdma_id_table,
 };

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
@@ -3536,7 +3536,7 @@ struct xocl_drv_private xgq_vmr_priv = {
 };
 
 struct platform_device_id xgq_vmr_id_table[] = {
-	{ XOCL_DEVNAME(XOCL_XGQ_VMR), (kernel_ulong_t)&xgq_vmr_priv },
+	{ XOCL_MGMTPF_DEVICE(XOCL_XGQ_VMR), (kernel_ulong_t)&xgq_vmr_priv },
 	{ },
 };
 
@@ -3544,7 +3544,7 @@ static struct platform_driver	xgq_vmr_driver = {
 	.probe		= xgq_vmr_probe,
 	.remove		= xgq_vmr_remove,
 	.driver		= {
-		.name = XOCL_DEVNAME(XOCL_XGQ_VMR),
+		.name = XOCL_MGMTPF_DEVICE(XOCL_XGQ_VMR),
 	},
 	.id_table = xgq_vmr_id_table,
 };
@@ -3554,7 +3554,7 @@ int __init xocl_init_xgq(bool flag)
 	int err = 0;
 
 	err = alloc_chrdev_region(&xgq_vmr_priv.dev, 0, XOCL_MAX_DEVICES,
-	    XOCL_DEVNAME(XGQ_DEV_NAME));
+	    XOCL_MGMTPF_DEVICE(XGQ_DEV_NAME));
 	if (err < 0)
 		return err;
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
@@ -88,7 +88,7 @@ MODULE_PARM_DESC(vmr_sc_ready_timeout,
 #define	XGQ_DBG(xgq, fmt, arg...)	\
 	xocl_dbg(&(xgq)->xgq_pdev->dev, fmt "\n", ##arg)
 
-#define	XGQ_DEV_NAME "ospi_xgq" SUBDEV_SUFFIX
+#define	XGQ_DEV_NAME "ospi_xgq"
 
 #define XOCL_VMR_INVALID_CID	0xFFFF
 
@@ -3549,12 +3549,12 @@ static struct platform_driver	xgq_vmr_driver = {
 	.id_table = xgq_vmr_id_table,
 };
 
-int __init xocl_init_xgq(void)
+int __init xocl_init_xgq(bool flag)
 {
 	int err = 0;
 
 	err = alloc_chrdev_region(&xgq_vmr_priv.dev, 0, XOCL_MAX_DEVICES,
-	    XGQ_DEV_NAME);
+	    XOCL_DEVNAME(XGQ_DEV_NAME));
 	if (err < 0)
 		return err;
 
@@ -3567,7 +3567,7 @@ int __init xocl_init_xgq(void)
 	return 0;
 }
 
-void xocl_fini_xgq(void)
+void xocl_fini_xgq(bool flag)
 {
 	unregister_chrdev_region(xgq_vmr_priv.dev, XOCL_MAX_DEVICES);
 	platform_driver_unregister(&xgq_vmr_driver);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xiic.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xiic.c
@@ -1055,7 +1055,7 @@ static int xiic_remove(struct platform_device *pdev)
 }
 
 struct platform_device_id xiic_id_table[] = {
-	{ XOCL_DEVNAME(XOCL_XIIC), 0 },
+	{ XOCL_MGMTPF_DEVICE(XOCL_XIIC), 0 },
 	{ },
 };
 
@@ -1063,7 +1063,7 @@ static struct platform_driver xiic_driver = {
 	.probe		= xiic_probe,
 	.remove		= xiic_remove,
 	.driver		= {
-		.name = XOCL_DEVNAME(XOCL_XIIC),
+		.name = XOCL_MGMTPF_DEVICE(XOCL_XIIC),
 	},
 	.id_table = xiic_id_table,
 };

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xiic.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xiic.c
@@ -1068,12 +1068,12 @@ static struct platform_driver xiic_driver = {
 	.id_table = xiic_id_table,
 };
 
-int __init xocl_init_xiic(void)
+int __init xocl_init_xiic(bool flag)
 {
 	return platform_driver_register(&xiic_driver);
 }
 
-void xocl_fini_xiic(void)
+void xocl_fini_xiic(bool flag)
 {
 	platform_driver_unregister(&xiic_driver);
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
@@ -4157,49 +4157,83 @@ failed:
 	xmc_remove(pdev);
 	return err;
 }
+static struct xocl_drv_private  xmc_priv_mgmtpf = {
+        .ops = &xmc_ops,
+        .dev = -1,
+};
 
-static struct xocl_drv_private	xmc_priv = {
+static struct platform_device_id xmc_id_table_mgmtpf[] = {
+        { XOCL_DEVNAME(XOCL_XMC), (kernel_ulong_t)&xmc_priv_mgmtpf },
+        { },
+};
+
+static struct platform_driver   xmc_driver_mgmtpf = {
+        .probe          = xmc_probe,
+        .remove         = xmc_remove,
+        .driver         = {
+                .name = XOCL_DEVNAME(XOCL_XMC),
+        },
+        .id_table = xmc_id_table_mgmtpf,
+};
+
+
+static struct xocl_drv_private	xmc_priv_userpf = {
 	.ops = &xmc_ops,
-#if PF == MGMTPF
-	.fops = &xmc_fops,
-#endif
 	.dev = -1,
 };
 
-static struct platform_device_id xmc_id_table[] = {
-	{ XOCL_DEVNAME(XOCL_XMC), (kernel_ulong_t)&xmc_priv },
+static struct platform_device_id xmc_id_table_userpf[] = {
+	{ XOCL_DEVNAME(XOCL_XMC), (kernel_ulong_t)&xmc_priv_userpf },
 	{ },
 };
 
-static struct platform_driver	xmc_driver = {
+static struct platform_driver	xmc_driver_userpf = {
 	.probe		= xmc_probe,
 	.remove		= xmc_remove,
 	.driver		= {
 		.name = XOCL_DEVNAME(XOCL_XMC),
 	},
-	.id_table = xmc_id_table,
+	.id_table = xmc_id_table_userpf,
 };
 
-int __init xocl_init_xmc(void)
+int __init xocl_init_xmc(bool flag)
 {
-	int err = alloc_chrdev_region(&xmc_priv.dev, 0, XOCL_MAX_DEVICES,
-			XOCL_XMC);
-	if (err)
-		return err;
-
-	err = platform_driver_register(&xmc_driver);
-	if (err) {
-		unregister_chrdev_region(xmc_priv.dev, XOCL_MAX_DEVICES);
-		return err;
-	}
+        if (flag) {
+	    int err = alloc_chrdev_region(&xmc_priv_mgmtpf.dev, 0, XOCL_MAX_DEVICES,
+			    XOCL_XMC);
+	    if (err)
+		    return err;
+    
+	    err = platform_driver_register(&xmc_driver_mgmtpf);
+	    if (err) {
+		    unregister_chrdev_region(xmc_priv_mgmtpf.dev, XOCL_MAX_DEVICES);
+		    return err;
+	    }
+        } else {
+            int err = alloc_chrdev_region(&xmc_priv_userpf.dev, 0, XOCL_MAX_DEVICES,
+                            XOCL_XMC);
+            if (err)
+                    return err;
+    
+            err = platform_driver_register(&xmc_driver_userpf);
+            if (err) {
+                    unregister_chrdev_region(xmc_priv_userpf.dev, XOCL_MAX_DEVICES);
+                    return err;
+            }
+        }
 
 	return 0;
 }
 
-void xocl_fini_xmc(void)
+void xocl_fini_xmc(bool flag)
 {
-	unregister_chrdev_region(xmc_priv.dev, XOCL_MAX_DEVICES);
-	platform_driver_unregister(&xmc_driver);
+        if (flag) {
+	    unregister_chrdev_region(xmc_priv_mgmtpf.dev, XOCL_MAX_DEVICES);
+	    platform_driver_unregister(&xmc_driver_mgmtpf);
+        } else {
+	    unregister_chrdev_region(xmc_priv_userpf.dev, XOCL_MAX_DEVICES);
+	    platform_driver_unregister(&xmc_driver_userpf);
+        }
 }
 
 static int xmc_mailbox_wait(struct xocl_xmc *xmc)

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
@@ -4163,7 +4163,7 @@ static struct xocl_drv_private  xmc_priv_mgmtpf = {
 };
 
 static struct platform_device_id xmc_id_table_mgmtpf[] = {
-        { XOCL_DEVNAME(XOCL_XMC), (kernel_ulong_t)&xmc_priv_mgmtpf },
+        { XOCL_MGMTPF_DEVICE(XOCL_XMC), (kernel_ulong_t)&xmc_priv_mgmtpf },
         { },
 };
 
@@ -4171,7 +4171,7 @@ static struct platform_driver   xmc_driver_mgmtpf = {
         .probe          = xmc_probe,
         .remove         = xmc_remove,
         .driver         = {
-                .name = XOCL_DEVNAME(XOCL_XMC),
+                .name = XOCL_MGMTPF_DEVICE(XOCL_XMC),
         },
         .id_table = xmc_id_table_mgmtpf,
 };
@@ -4183,7 +4183,7 @@ static struct xocl_drv_private	xmc_priv_userpf = {
 };
 
 static struct platform_device_id xmc_id_table_userpf[] = {
-	{ XOCL_DEVNAME(XOCL_XMC), (kernel_ulong_t)&xmc_priv_userpf },
+	{ XOCL_USERPF_DEVICE(XOCL_XMC), (kernel_ulong_t)&xmc_priv_userpf },
 	{ },
 };
 
@@ -4191,7 +4191,7 @@ static struct platform_driver	xmc_driver_userpf = {
 	.probe		= xmc_probe,
 	.remove		= xmc_remove,
 	.driver		= {
-		.name = XOCL_DEVNAME(XOCL_XMC),
+		.name = XOCL_USERPF_DEVICE(XOCL_XMC),
 	},
 	.id_table = xmc_id_table_userpf,
 };

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc_u2.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc_u2.c
@@ -3907,48 +3907,83 @@ failed:
 	return err;
 }
 
-static struct xocl_drv_private	xmc_priv = {
+static struct xocl_drv_private	xmc_priv_mgmtpf = {
 	.ops = &xmc_ops,
-#if PF == MGMTPF
-	.fops = &xmc_fops,
-#endif
 	.dev = -1,
 };
 
-static struct platform_device_id xmc_id_table[] = {
-	{ XOCL_DEVNAME(XOCL_XMC_U2), (kernel_ulong_t)&xmc_priv },
+static struct platform_device_id xmc_id_table_mgmtpf[] = {
+	{ XOCL_DEVNAME(XOCL_XMC_U2), (kernel_ulong_t)&xmc_priv_mgmtpf },
 	{ },
 };
 
-static struct platform_driver	xmc_driver = {
+static struct platform_driver	xmc_driver_mgmtpf = {
 	.probe		= xmc_probe,
 	.remove		= xmc_remove,
 	.driver		= {
 		.name = XOCL_DEVNAME(XOCL_XMC_U2),
 	},
-	.id_table = xmc_id_table,
+	.id_table = xmc_id_table_mgmtpf,
 };
 
-int __init xocl_init_xmc_u2(void)
+static struct xocl_drv_private  xmc_priv_userpf = {
+        .ops = &xmc_ops,
+        .dev = -1,
+};
+
+static struct platform_device_id xmc_id_table_userpf[] = {
+        { XOCL_DEVNAME(XOCL_XMC_U2), (kernel_ulong_t)&xmc_priv_userpf },
+        { },
+};
+
+static struct platform_driver   xmc_driver_userpf = {
+        .probe          = xmc_probe,
+        .remove         = xmc_remove,
+        .driver         = {
+                .name = XOCL_DEVNAME(XOCL_XMC_U2),
+        },
+        .id_table = xmc_id_table_userpf,
+};
+
+int __init xocl_init_xmc_u2(bool flag)
 {
-	int err = alloc_chrdev_region(&xmc_priv.dev, 0, XOCL_MAX_DEVICES,
+   if (flag) {
+	int err = alloc_chrdev_region(&xmc_priv_mgmtpf.dev, 0, XOCL_MAX_DEVICES,
 			XOCL_XMC_U2);
 	if (err)
 		return err;
 
-	err = platform_driver_register(&xmc_driver);
+	err = platform_driver_register(&xmc_driver_mgmtpf);
 	if (err) {
-		unregister_chrdev_region(xmc_priv.dev, XOCL_MAX_DEVICES);
+		unregister_chrdev_region(xmc_priv_mgmtpf.dev, XOCL_MAX_DEVICES);
 		return err;
 	}
+   } else {
+	int err = alloc_chrdev_region(&xmc_priv_userpf.dev, 0, XOCL_MAX_DEVICES,
+			XOCL_XMC_U2);
+	if (err)
+		return err;
+
+	err = platform_driver_register(&xmc_driver_userpf);
+	if (err) {
+		unregister_chrdev_region(xmc_priv_userpf.dev, XOCL_MAX_DEVICES);
+		return err;
+	}
+   }
 
 	return 0;
 }
 
-void xocl_fini_xmc_u2(void)
+void xocl_fini_xmc_u2(bool flag)
 {
-	unregister_chrdev_region(xmc_priv.dev, XOCL_MAX_DEVICES);
-	platform_driver_unregister(&xmc_driver);
+     if (flag)
+     {
+	unregister_chrdev_region(xmc_priv_mgmtpf.dev, XOCL_MAX_DEVICES);
+	platform_driver_unregister(&xmc_driver_mgmtpf);
+     } else {
+	unregister_chrdev_region(xmc_priv_userpf.dev, XOCL_MAX_DEVICES);
+	platform_driver_unregister(&xmc_driver_userpf);
+     }
 }
 
 static int xmc_mailbox_wait(struct xocl_xmc *xmc)

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc_u2.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc_u2.c
@@ -3913,7 +3913,7 @@ static struct xocl_drv_private	xmc_priv_mgmtpf = {
 };
 
 static struct platform_device_id xmc_id_table_mgmtpf[] = {
-	{ XOCL_DEVNAME(XOCL_XMC_U2), (kernel_ulong_t)&xmc_priv_mgmtpf },
+	{ XOCL_MGMTPF_DEVICE(XOCL_XMC_U2), (kernel_ulong_t)&xmc_priv_mgmtpf },
 	{ },
 };
 
@@ -3921,7 +3921,7 @@ static struct platform_driver	xmc_driver_mgmtpf = {
 	.probe		= xmc_probe,
 	.remove		= xmc_remove,
 	.driver		= {
-		.name = XOCL_DEVNAME(XOCL_XMC_U2),
+		.name = XOCL_MGMTPF_DEVICE(XOCL_XMC_U2),
 	},
 	.id_table = xmc_id_table_mgmtpf,
 };
@@ -3932,7 +3932,7 @@ static struct xocl_drv_private  xmc_priv_userpf = {
 };
 
 static struct platform_device_id xmc_id_table_userpf[] = {
-        { XOCL_DEVNAME(XOCL_XMC_U2), (kernel_ulong_t)&xmc_priv_userpf },
+        { XOCL_USERPF_DEVICE(XOCL_XMC_U2), (kernel_ulong_t)&xmc_priv_userpf },
         { },
 };
 
@@ -3940,7 +3940,7 @@ static struct platform_driver   xmc_driver_userpf = {
         .probe          = xmc_probe,
         .remove         = xmc_remove,
         .driver         = {
-                .name = XOCL_DEVNAME(XOCL_XMC_U2),
+                .name = XOCL_USERPF_DEVICE(XOCL_XMC_U2),
         },
         .id_table = xmc_id_table_userpf,
 };

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xvc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xvc.c
@@ -421,20 +421,20 @@ struct xocl_drv_private xvc_pri_userpf = {
 
 
 struct platform_device_id xvc_id_table_mgmtpf[] = {
-	{ XOCL_DEVNAME(XOCL_XVC_PUB), (kernel_ulong_t)&xvc_pub_mgmtpf },
-	{ XOCL_DEVNAME(XOCL_XVC_PRI), (kernel_ulong_t)&xvc_pri_mgmtpf },
+	{ XOCL_MGMTPF_DEVICE(XOCL_XVC_PUB), (kernel_ulong_t)&xvc_pub_mgmtpf },
+	{ XOCL_MGMTPF_DEVICE(XOCL_XVC_PRI), (kernel_ulong_t)&xvc_pri_mgmtpf },
 	{ },
 };
 struct platform_device_id xvc_id_table_userpf[] = {
-	{ XOCL_DEVNAME(XOCL_XVC_PUB), (kernel_ulong_t)&xvc_pub_userpf },
-	{ XOCL_DEVNAME(XOCL_XVC_PRI), (kernel_ulong_t)&xvc_pri_userpf },
+	{ XOCL_USERPF_DEVICE(XOCL_XVC_PUB), (kernel_ulong_t)&xvc_pub_userpf },
+	{ XOCL_USERPF_DEVICE(XOCL_XVC_PRI), (kernel_ulong_t)&xvc_pri_userpf },
 	{ },
 };
 static struct platform_driver	xvc_driver_mgmtpf = {
 	.probe		= xvc_probe,
 	.remove		= xvc_remove,
 	.driver		= {
-		.name = XOCL_DEVNAME(XVC_DEV_NAME),
+		.name = XOCL_MGMTPF_DEVICE(XVC_DEV_NAME),
 	},
 	.id_table = xvc_id_table_mgmtpf,
 };
@@ -442,7 +442,7 @@ static struct platform_driver	xvc_driver_userpf = {
 	.probe		= xvc_probe,
 	.remove		= xvc_remove,
 	.driver		= {
-		.name = XOCL_DEVNAME(XVC_DEV_NAME),
+		.name = XOCL_USERPF_DEVICE(XVC_DEV_NAME),
 	},
 	.id_table = xvc_id_table_userpf,
 };

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
@@ -1867,7 +1867,7 @@ static struct pci_driver userpf_driver = {
 };
 
 /* INIT */
-static int (*xocl_drv_reg_funcs[])(void) __initdata = {
+static int (*xocl_drv_reg_funcs[])(bool) __initdata = {
 	xocl_init_feature_rom,
 	xocl_init_version_control,
 	xocl_init_iores,
@@ -1910,7 +1910,7 @@ static int (*xocl_drv_reg_funcs[])(void) __initdata = {
 	xocl_init_ert_ctrl,
 };
 
-static void (*xocl_drv_unreg_funcs[])(void) = {
+static void (*xocl_drv_unreg_funcs[])(bool) = {
 	xocl_fini_feature_rom,
 	xocl_fini_version_control,
 	xocl_fini_iores,
@@ -1970,7 +1970,7 @@ static int __init xocl_init(void)
 	}
 
 	for (i = 0; i < ARRAY_SIZE(xocl_drv_reg_funcs); ++i) {
-		ret = xocl_drv_reg_funcs[i]();
+		ret = xocl_drv_reg_funcs[i](false);
 		if (ret)
 			goto failed;
 	}
@@ -1983,7 +1983,7 @@ static int __init xocl_init(void)
 
 failed:
 	for (i--; i >= 0; i--)
-		xocl_drv_unreg_funcs[i]();
+		xocl_drv_unreg_funcs[i](false);
 	class_destroy(xrt_class);
 
 err_class_create:
@@ -1997,7 +1997,7 @@ static void __exit xocl_exit(void)
 	pci_unregister_driver(&userpf_driver);
 
 	for (i = ARRAY_SIZE(xocl_drv_unreg_funcs) - 1; i >= 0; i--)
-		xocl_drv_unreg_funcs[i]();
+		xocl_drv_unreg_funcs[i](false);
 
 	xocl_debug_fini();
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
@@ -923,7 +923,7 @@ int xocl_refresh_subdevs(struct xocl_dev *xdev)
 
 	xocl_drvinst_set_offline(xdev->core.drm, true);
 	if (blob) {
-		ret = xocl_fdt_blob_input(xdev, blob, blob_len, -1, NULL);
+		ret = xocl_fdt_blob_input(xdev, blob, blob_len, -1, NULL, false);
 		if (ret) {
 			userpf_err(xdev, "parse blob failed %d", ret);
 			goto failed;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -1256,6 +1256,7 @@ struct xocl_clock_counter_funcs {
 	(SUBDEV_MULTI(xdev, XOCL_SUBDEV_CLOCK_COUNTER, idx) ?		\
 	(struct xocl_clock_counter_funcs *)				\
 	SUBDEV_MULTI(xdev, XOCL_SUBDEV_CLOCK_COUNTER, idx)->ops : NULL)
+
 static inline int xocl_clock_c_ops_level(xdev_handle_t xdev)
 {
 	int i;
@@ -2474,7 +2475,7 @@ static inline int xocl_kds_fini_ert(xdev_handle_t xdev)
 	return kds_fini_ert(&XDEV(xdev)->kds);
 }
 
-#if PF == MGMTPF
+#if PF == MGMTPF 
 static inline int xocl_register_cus(xdev_handle_t xdev, int slot_hdl, xuid_t *uuid,
 		      struct ip_layout *ip_layout,
 		      struct ps_kernel_node *ps_kernel)
@@ -2491,7 +2492,6 @@ int xocl_register_cus(xdev_handle_t xdev, int slot_hdl, xuid_t *uuid,
 		      struct ps_kernel_node *ps_kernel);
 int xocl_unregister_cus(xdev_handle_t xdev, int slot_hdl);
 #endif
-
 /* context helpers */
 extern struct mutex xocl_drvinst_mutex;
 extern struct xocl_drvinst *xocl_drvinst_array[XOCL_MAX_DEVICES * 64];
@@ -2576,174 +2576,173 @@ void xocl_fini_fini_userpf(void);
 int __init xocl_init_drv_user_qdma(void);
 void xocl_fini_drv_user_qdma(void);
 
-int __init xocl_init_feature_rom(void);
-void xocl_fini_feature_rom(void);
+int __init xocl_init_feature_rom(bool);
+void xocl_fini_feature_rom(bool);
+int __init xocl_init_xdma(bool);
+void xocl_fini_xdma(bool);
 
-int __init xocl_init_xdma(void);
-void xocl_fini_xdma(void);
+int __init xocl_init_qdma(bool);
+void xocl_fini_qdma(bool);
 
-int __init xocl_init_qdma(void);
-void xocl_fini_qdma(void);
+int __init xocl_init_xvc(bool);
+void xocl_fini_xvc(bool);
 
-int __init xocl_init_xvc(void);
-void xocl_fini_xvc(void);
+int __init xocl_init_firewall(bool);
+void xocl_fini_firewall(bool);
 
-int __init xocl_init_firewall(void);
-void xocl_fini_firewall(void);
+int __init xocl_init_sysmon(bool);
+void xocl_fini_sysmon(bool);
 
-int __init xocl_init_sysmon(void);
-void xocl_fini_sysmon(void);
+int __init xocl_init_mb(bool);
+void xocl_fini_mb(bool);
 
-int __init xocl_init_mb(void);
-void xocl_fini_mb(void);
+int __init xocl_init_ps(bool);
+void xocl_fini_ps(bool);
 
-int __init xocl_init_ps(void);
-void xocl_fini_ps(void);
+int __init xocl_init_xiic(bool);
+void xocl_fini_xiic(bool);
 
-int __init xocl_init_xiic(void);
-void xocl_fini_xiic(void);
+int __init xocl_init_mailbox(bool);
+void xocl_fini_mailbox(bool);
 
-int __init xocl_init_mailbox(void);
-void xocl_fini_mailbox(void);
+int __init xocl_init_icap(bool);
+void xocl_fini_icap(bool);
 
-int __init xocl_init_icap(void);
-void xocl_fini_icap(void);
+int __init xocl_init_clock_wiz(bool);
+void xocl_fini_clock_wiz(bool);
 
-int __init xocl_init_clock_wiz(void);
-void xocl_fini_clock_wiz(void);
+int __init xocl_init_clock_counter(bool);
+void xocl_fini_clock_counter(bool);
 
-int __init xocl_init_clock_counter(void);
-void xocl_fini_clock_counter(void);
+int __init xocl_init_mig(bool);
+void xocl_fini_mig(bool);
 
-int __init xocl_init_mig(void);
-void xocl_fini_mig(void);
+int __init xocl_init_ert(bool);
+void xocl_fini_ert(bool);
 
-int __init xocl_init_ert(void);
-void xocl_fini_ert(void);
+int __init xocl_init_xmc(bool);
+void xocl_fini_xmc(bool);
 
-int __init xocl_init_xmc(void);
-void xocl_fini_xmc(void);
+int __init xocl_init_xmc_u2(bool);
+void xocl_fini_xmc_u2(bool);
 
-int __init xocl_init_xmc_u2(void);
-void xocl_fini_xmc_u2(void);
+int __init xocl_init_dna(bool);
+void xocl_fini_dna(bool);
 
-int __init xocl_init_dna(void);
-void xocl_fini_dna(void);
+int __init xocl_init_fmgr(bool);
+void xocl_fini_fmgr(bool);
 
-int __init xocl_init_fmgr(void);
-void xocl_fini_fmgr(void);
+int __init xocl_init_mgmt_msix(bool);
+void xocl_fini_mgmt_msix(bool);
 
-int __init xocl_init_mgmt_msix(void);
-void xocl_fini_mgmt_msix(void);
+int __init xocl_init_flash(bool);
+void xocl_fini_flash(bool);
 
-int __init xocl_init_flash(void);
-void xocl_fini_flash(void);
+int __init xocl_init_axigate(bool);
+void xocl_fini_axigate(bool);
 
-int __init xocl_init_axigate(void);
-void xocl_fini_axigate(void);
+int __init xocl_init_iores(bool);
+void xocl_fini_iores(bool);
 
-int __init xocl_init_iores(void);
-void xocl_fini_iores(void);
+int __init xocl_init_mailbox_versal(bool);
+void xocl_fini_mailbox_versal(bool);
 
-int __init xocl_init_mailbox_versal(void);
-void xocl_fini_mailbox_versal(void);
+int __init xocl_init_xfer_versal(bool);
+void xocl_fini_xfer_versal(bool);
 
-int __init xocl_init_xfer_versal(void);
-void xocl_fini_xfer_versal(void);
+int __init xocl_init_aim(bool);
+void xocl_fini_aim(bool);
 
-int __init xocl_init_aim(void);
-void xocl_fini_aim(void);
+int __init xocl_init_am(bool);
+void xocl_fini_am(bool);
 
-int __init xocl_init_am(void);
-void xocl_fini_am(void);
+int __init xocl_init_asm(bool);
+void xocl_fini_asm(bool);
 
-int __init xocl_init_asm(void);
-void xocl_fini_asm(void);
+int __init xocl_init_trace_fifo_lite(bool);
+void xocl_fini_trace_fifo_lite(bool);
 
-int __init xocl_init_trace_fifo_lite(void);
-void xocl_fini_trace_fifo_lite(void);
+int __init xocl_init_trace_fifo_full(bool);
+void xocl_fini_trace_fifo_full(bool);
 
-int __init xocl_init_trace_fifo_full(void);
-void xocl_fini_trace_fifo_full(void);
+int __init xocl_init_trace_funnel(bool);
+void xocl_fini_trace_funnel(bool);
 
-int __init xocl_init_trace_funnel(void);
-void xocl_fini_trace_funnel(void);
+int __init xocl_init_trace_s2mm(bool);
+void xocl_fini_trace_s2mm(bool);
 
-int __init xocl_init_trace_s2mm(void);
-void xocl_fini_trace_s2mm(void);
+int __init xocl_init_accel_deadlock_detector(bool);
+void xocl_fini_accel_deadlock_detector(bool);
 
-int __init xocl_init_accel_deadlock_detector(void);
-void xocl_fini_accel_deadlock_detector(void);
+int __init xocl_init_mem_hbm(bool);
+void xocl_fini_mem_hbm(bool);
 
-int __init xocl_init_mem_hbm(void);
-void xocl_fini_mem_hbm(void);
+int __init xocl_init_srsr(bool);
+void xocl_fini_srsr(bool);
 
-int __init xocl_init_srsr(void);
-void xocl_fini_srsr(void);
+int __init xocl_init_ulite(bool);
+void xocl_fini_ulite(bool);
 
-int __init xocl_init_ulite(void);
-void xocl_fini_ulite(void);
+int __init xocl_init_calib_storage(bool);
+void xocl_fini_calib_storage(bool);
 
-int __init xocl_init_calib_storage(void);
-void xocl_fini_calib_storage(void);
+int __init xocl_init_kds(bool);
+void xocl_fini_kds(bool);
 
-int __init xocl_init_kds(void);
-void xocl_fini_kds(void);
+int __init xocl_init_cu(bool);
+void xocl_fini_cu(bool);
 
-int __init xocl_init_cu(void);
-void xocl_fini_cu(void);
+int __init xocl_init_scu(bool);
+void xocl_fini_scu(bool);
 
-int __init xocl_init_scu(void);
-void xocl_fini_scu(void);
+int __init xocl_init_addr_translator(bool);
+void xocl_fini_addr_translator(bool);
 
-int __init xocl_init_addr_translator(void);
-void xocl_fini_addr_translator(void);
+int __init xocl_init_p2p(bool);
+void xocl_fini_p2p(bool);
 
-int __init xocl_init_p2p(void);
-void xocl_fini_p2p(void);
+int __init xocl_init_spc(bool);
+void xocl_fini_spc(bool);
 
-int __init xocl_init_spc(void);
-void xocl_fini_spc(void);
+int __init xocl_init_lapc(bool);
+void xocl_fini_lapc(bool);
 
-int __init xocl_init_lapc(void);
-void xocl_fini_lapc(void);
+int __init xocl_init_pmc(bool);
+void xocl_fini_pmc(bool);
 
-int __init xocl_init_pmc(void);
-void xocl_fini_pmc(void);
+int __init xocl_init_intc(bool);
+void xocl_fini_intc(bool);
 
-int __init xocl_init_intc(void);
-void xocl_fini_intc(void);
+int __init xocl_init_icap_controller(bool);
+void xocl_fini_icap_controller(bool);
 
-int __init xocl_init_icap_controller(void);
-void xocl_fini_icap_controller(void);
+int __init xocl_init_m2m(bool);
+void xocl_fini_m2m(bool);
 
-int __init xocl_init_m2m(void);
-void xocl_fini_m2m(void);
+int __init xocl_init_version_control(bool);
+void xocl_fini_version_control(bool);
 
-int __init xocl_init_version_control(void);
-void xocl_fini_version_control(void);
+int __init xocl_init_msix_xdma(bool);
+void xocl_fini_msix_xdma(bool);
 
-int __init xocl_init_msix_xdma(void);
-void xocl_fini_msix_xdma(void);
+int __init xocl_init_ert_user(bool);
+void xocl_fini_ert_user(bool);
 
-int __init xocl_init_ert_user(void);
-void xocl_fini_ert_user(void);
+int __init xocl_init_pcie_firewall(bool);
+void xocl_fini_pcie_firewall(bool);
 
-int __init xocl_init_pcie_firewall(void);
-void xocl_fini_pcie_firewall(void);
+int __init xocl_init_command_queue(bool);
+void xocl_fini_command_queue(bool);
 
-int __init xocl_init_command_queue(void);
-void xocl_fini_command_queue(void);
+int __init xocl_init_config_gpio(bool);
+void xocl_fini_config_gpio(bool);
 
-int __init xocl_init_config_gpio(void);
-void xocl_fini_config_gpio(void);
+int __init xocl_init_xgq(bool);
+void xocl_fini_xgq(bool);
 
-int __init xocl_init_xgq(void);
-void xocl_fini_xgq(void);
+int __init xocl_init_hwmon_sdm(bool);
+void xocl_fini_hwmon_sdm(bool);
 
-int __init xocl_init_hwmon_sdm(void);
-void xocl_fini_hwmon_sdm(void);
-
-int __init xocl_init_ert_ctrl(void);
-void xocl_fini_ert_ctrl(void);
+int __init xocl_init_ert_ctrl(bool);
+void xocl_fini_ert_ctrl(bool);
 #endif

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -2516,7 +2516,7 @@ int xocl_thread_stop(xdev_handle_t xdev);
 
 /* subdev blob functions */
 int xocl_fdt_blob_input(xdev_handle_t xdev_hdl, char *blob, u32 blob_sz,
-		int part_level, char *vbnv);
+		int part_level, char *vbnv, bool is_mgmt);
 int xocl_fdt_remove_subdevs(xdev_handle_t xdev_hdl, struct list_head *devlist);
 int xocl_fdt_unlink_node(xdev_handle_t xdev_hdl, void *node);
 int xocl_fdt_overlay(void *fdt, int target, void *fdto, int node, int pf,
@@ -2535,7 +2535,7 @@ int xocl_fdt_get_next_prop_by_name(xdev_handle_t xdev_hdl, void *blob,
 int xocl_fdt_check_uuids(xdev_handle_t xdev_hdl, const void *blob,
 		        const void *subset_blob);
 int xocl_fdt_parse_blob(xdev_handle_t xdev_hdl, char *blob, u32 blob_sz,
-		struct xocl_subdev **subdevs);
+		struct xocl_subdev **subdevs, bool is_mgmt);
 const struct axlf_section_header *xocl_axlf_section_header(
 	xdev_handle_t xdev_hdl, const struct axlf *top,
 	enum axlf_section_kind kind);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_xclbin.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_xclbin.c
@@ -44,7 +44,7 @@ static int versal_xclbin_pre_download(xdev_handle_t xdev, void *args)
 
 	if (metadata) {
 		arg->num_dev = xocl_fdt_parse_blob(xdev, metadata,
-		    size, &(arg->urpdevs));
+		    size, &(arg->urpdevs), true);
 		vfree(metadata);
 	}
 	xocl_subdev_destroy_by_level(xdev, XOCL_SUBDEV_LEVEL_URP);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
In this 2 commits:  
-To avoid conflicts between userpf & mgmtpf at runtime, Added global platform structure and "Boolean" flags.
 
-Created macro names to all subdev device file platform structures to differentiate between userpf and mgmtpf macro functions.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
