### PR TITLE
More clang-tidy cleanups of HIP code and fix a major bug in new PDI trans…

### DIFF
--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -97,6 +97,8 @@ CheckOptions:
     value:           '16'
   - key:             bugprone-easily-swappable-parameters.NamePrefixSuffixSilenceDissimilarityTreshold
     value:           '1'
+  - key:             bugprone-easily-swappable-parameters.MinimumLength
+    value:	     '3'
   - key:             bugprone-unhandled-self-assignment.WarnOnlyIfThisHasSuspiciousField
     value:           '1'
   - key:             bugprone-unused-return-value.CheckedFunctions

--- a/src/runtime_src/hip/core/device.cpp
+++ b/src/runtime_src/hip/core/device.cpp
@@ -11,6 +11,6 @@ device::
 device(uint32_t device_id)
   : m_device_id{device_id}
   , m_xrt_device{device_id}
+  , m_flags{0}
 {}
 }
-

--- a/src/runtime_src/hip/core/device.h
+++ b/src/runtime_src/hip/core/device.h
@@ -26,16 +26,18 @@ class device
 
 public:
   device() = default;
-  
+
   explicit
   device(uint32_t device_id);
 
+  [[nodiscard]]
   const xrt::device&
   get_xrt_device() const
   {
     return m_xrt_device;
   }
 
+  [[nodiscard]]
   uint32_t
   get_device_id() const
   {
@@ -66,4 +68,3 @@ extern xrt_core::handle_map<device_handle, std::shared_ptr<device>> device_cache
 } // xrt::core::hip
 
 #endif
-

--- a/src/runtime_src/hip/core/event.h
+++ b/src/runtime_src/hip/core/event.h
@@ -44,43 +44,48 @@ public:
 
 protected:
   std::shared_ptr<stream> cstream;
-  type ctype;
+  type ctype = type::event;
   std::chrono::time_point<std::chrono::system_clock> ctime;
-  state cstate;
+  state cstate = state::init;
 
 public:
-  command()
-    : cstate{state::init}
+    command() = default;
+
+  explicit command(std::shared_ptr<stream> s)
+    : cstream{std::move(s)}
   {}
 
-  command(std::shared_ptr<stream> s)
-    : cstream{std::move(s)}
-    , cstate{state::init}
-  {}
+  virtual ~command() = default;
+  command(const command &) = delete;
+  command(command &&) = delete;
+  command& operator =(command const&) = delete;
+  command& operator =(command &&) = delete;
 
   virtual bool submit() = 0;
   virtual bool wait() = 0;
-  
+
+  [[nodiscard]]
   state
-  get_state() const 
+  get_state() const
   {
     return cstate;
   }
 
   std::chrono::time_point<std::chrono::system_clock>
-  get_time() 
+  get_time()
   {
     return ctime;
   }
 
-  void 
-  set_state(state newstate) 
+  void
+  set_state(state newstate)
   {
     cstate = newstate;
   }
 
-  type 
-  get_type() const 
+  [[nodiscard]]
+  type
+  get_type() const
   {
     return ctype;
   }
@@ -101,7 +106,7 @@ public:
   bool wait() override;
   bool synchronize();
   bool query();
-  bool is_recorded() const;
+  [[nodiscard]] bool is_recorded() const;
   std::shared_ptr<stream> get_stream();
   void add_to_chain(std::shared_ptr<command> cmd);
   void add_dependency(std::shared_ptr<command> cmd);

--- a/src/runtime_src/tools/xclbinutil/aie-pdi-transform/src/pdi-parsing-debug.h
+++ b/src/runtime_src/tools/xclbinutil/aie-pdi-transform/src/pdi-parsing-debug.h
@@ -26,12 +26,11 @@ void errorLog(char* filename, uint32_t* pdi, uint32_t errorLen) {
 	FILE* file = fopen(filename, "w+");
 	if(file == NULL) {
 		XCdo_PError("File not opened!\n");
-		fclose(file);
 		return;
 	}
 
 	for(uint32_t i = 0; i <= errorLen; i++) {
-		
+
 		uint32_t CmdId = pdi[i];
 
 		switch(CmdId) {
@@ -68,7 +67,7 @@ void errorLog(char* filename, uint32_t* pdi, uint32_t errorLen) {
 				fprintf(file, " %.08x ", pdi[i]);
 			}
 			fprintf(file, "\n");
-			
+
 			break;
 		default:
 			fprintf(file, "Invalid Command ID\n");
@@ -78,8 +77,7 @@ void errorLog(char* filename, uint32_t* pdi, uint32_t errorLen) {
 
 	}
 
-	
+
 	fclose(file);
 
 }
-


### PR DESCRIPTION
…form error handling path

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

1. Compilation failure on Ubuntu 23.10 due to a bug in the new pdi-transform code
2. More clang-tidy cleanups for HIP code

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://github.com/Xilinx/XRT/pull/8011 introduced the compilation failure bug. clang-tidy changes are ongoing.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Fix the code

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Compile tested

#### Documentation impact (if any)
NA