### PR TITLE
Add 1ms delay in ML Timeline, AIE Profile/Debug Plugin to avoid BO sync issue

### DIFF
--- a/src/runtime_src/xdp/profile/device/common/client_transaction.cpp
+++ b/src/runtime_src/xdp/profile/device/common/client_transaction.cpp
@@ -16,7 +16,9 @@
 
 #define XDP_PLUGIN_SOURCE
 
+#include <chrono>
 #include <sstream>
+#include <thread>
 
 #include "client_transaction.h"
 #include "core/common/message.h"
@@ -92,6 +94,8 @@ namespace xdp::aie {
       }
 
       result_bo.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
+
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
 
       return result_bo;
     }

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.cpp
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.cpp
@@ -22,6 +22,7 @@
 #include <chrono>
 #include <fstream>
 #include <regex>
+#include <thread>
 
 #include "core/common/device.h"
 #include "core/common/message.h"
@@ -70,6 +71,8 @@ namespace xdp {
     auto resultBOMap = resultBO.map<uint8_t*>();
     resultBO.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
 
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    
     uint32_t* ptr = reinterpret_cast<uint32_t*>(resultBOMap);
 
     // Assuming correct Stub has been called and Write Buffer contains valid data


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Issue with BO sync (CR-1194803) is still under investigation. This commit adds 1 ms delay between bo sync and use of its contents as a workaround.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
This is a workaround. Correct fix should be in sync_bo implementation.

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit
The XRT run time for any application will increase by 1ms with each of ML Timeline, AIE Profile and AIE debug plugin enabled.

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
