### PR TITLE
reduce the number of iterations for throughput test to 1000

### DIFF
--- a/src/runtime_src/core/tools/common/tests/TestIPU.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestIPU.cpp
@@ -75,6 +75,7 @@ TestIPU::run(std::shared_ptr<xrt_core::device> dev)
   xrt::bo bo_ofm(working_dev, buffer_size, XRT_BO_FLAGS_HOST_ONLY, testker.group_id(argno++));
   xrt::bo bo_inter(working_dev, buffer_size, XRT_BO_FLAGS_HOST_ONLY, testker.group_id(argno++));
   xrt::bo bo_instr(working_dev, buffer_size, XCL_BO_FLAGS_CACHEABLE, testker.group_id(argno++));
+  argno++;
   xrt::bo bo_mc(working_dev, buffer_size, XRT_BO_FLAGS_HOST_ONLY, testker.group_id(argno++));
   std::memset(bo_instr.map<char*>(), buffer_size, '0');
 

--- a/src/runtime_src/core/tools/common/tests/TestIPU.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestIPU.cpp
@@ -16,7 +16,7 @@ namespace XBU = XBUtilities;
 static constexpr size_t host_app = 1; //opcode
 static constexpr size_t buffer_size = 20;
 static constexpr int itr_count = 10000;
-static constexpr int itr_count_throughput = itr_count/10;
+static constexpr int itr_count_throughput = itr_count/4;
 // ----- C L A S S   M E T H O D S -------------------------------------------
 TestIPU::TestIPU()
   : TestRunner("verify", "Run end-to-end latency and throughput test on NPU")
@@ -68,7 +68,7 @@ TestIPU::run(std::shared_ptr<xrt_core::device> dev)
   xrt::hw_context hwctx{working_dev, xclbin.get_uuid()};
   xrt::kernel testker{hwctx, kernelName};
 
-  //Create BOs
+  //Create BOs, the values are not initialized as they are not really used by this special test running on the device
   int argno = 1;
   xrt::bo bo_ifm(working_dev, buffer_size, XRT_BO_FLAGS_HOST_ONLY, testker.group_id(argno++));
   xrt::bo bo_param(working_dev, buffer_size, XRT_BO_FLAGS_HOST_ONLY, testker.group_id(argno++));
@@ -77,6 +77,7 @@ TestIPU::run(std::shared_ptr<xrt_core::device> dev)
   xrt::bo bo_instr(working_dev, buffer_size, XCL_BO_FLAGS_CACHEABLE, testker.group_id(argno++));
   argno++;
   xrt::bo bo_mc(working_dev, buffer_size, XRT_BO_FLAGS_HOST_ONLY, testker.group_id(argno++));
+  //Create ctrlcode with NOPs
   std::memset(bo_instr.map<char*>(), 0, buffer_size);
 
   //Sync BOs
@@ -138,7 +139,7 @@ TestIPU::run(std::shared_ptr<xrt_core::device> dev)
   const double throughput = (elapsedSecs != 0.0) ? runhandles.size() / elapsedSecs : 0.0;
 
   // Do we need to store 'Total duration'?"
-  logger(ptree, "Details", boost::str(boost::format("Total duration: '%.1f's") % elapsedSecs));
+  // logger(ptree, "Details", boost::str(boost::format("Total duration: '%.1f's") % elapsedSecs));
   logger(ptree, "Details", boost::str(boost::format("Average throughput: '%.1f' ops/s") % throughput));
   logger(ptree, "Details", boost::str(boost::format("Average latency: '%.1f' us") % latency));
 

--- a/src/runtime_src/core/tools/common/tests/TestIPU.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestIPU.cpp
@@ -77,7 +77,7 @@ TestIPU::run(std::shared_ptr<xrt_core::device> dev)
   xrt::bo bo_instr(working_dev, buffer_size, XCL_BO_FLAGS_CACHEABLE, testker.group_id(argno++));
   argno++;
   xrt::bo bo_mc(working_dev, buffer_size, XRT_BO_FLAGS_HOST_ONLY, testker.group_id(argno++));
-  std::memset(bo_instr.map<char*>(), buffer_size, '0');
+  std::memset(bo_instr.map<char*>(), 0, buffer_size);
 
   //Sync BOs
   bo_instr.sync(XCL_BO_SYNC_BO_TO_DEVICE);

--- a/tests/hip/common/common.h
+++ b/tests/hip/common/common.h
@@ -35,6 +35,8 @@ uuid_unparse_lower(const unsigned char uuid[16], char* str)
 }
 #endif
 
+constexpr size_t mega_byte = 0x100000;
+
 class
 test_hip_error : public std::system_error
 {
@@ -141,20 +143,20 @@ public:
 
   void
   show_info(std::ostream &stream) const {
-    std::array<char, 64> name;
+    std::array<char, 64> name{};
     test_hip_check(hipDeviceGetName(name.data(), sizeof(name), m_device));
     stream << name.data() << std::endl;
 
     hipUUID_t hid{};
     test_hip_check(hipDeviceGetUuid(&hid, m_device));
-    std::array<char, 40> uuid_str;
+    std::array<char, 40> uuid_str{};
     uuid_unparse_lower(reinterpret_cast<unsigned char *>(hid.bytes), uuid_str.data());
     stream << uuid_str.data() << std::endl;
 
     hipDeviceProp_t devProp;
     test_hip_check(hipGetDeviceProperties(&devProp, m_index));
     stream << devProp.name << std::endl;
-    stream << devProp.totalGlobalMem/0x100000 << " MB" << std::endl;
+    stream << devProp.totalGlobalMem/mega_byte << " MB" << std::endl;
     stream << devProp.maxThreadsPerBlock << " Threads" << std::endl;
   }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Resolve out of memory issue with 10000 iterations for throughput test

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://github.com/Xilinx/XRT/pull/8084

#### How problem was solved, alternative solutions (if any) and why they were rejected
Reduce the total number of tests run to 1000 from 10000

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Tested on windows/stx @DPM7
```
>xbutil validate -r verify --batch
Validate Device           : [00c5:00:01.1]
    Platform              : NPU
    Performance Mode      : High
-------------------------------------------------------------------------------
Verbose: Enabling Verbosity
Running Test: ..
Test 1 [00c5:00:01.1]     : verify
    Description           : Run end-to-end latency and throughput test on NPU
    Xclbin                : <...>\validate_17f0_10.xclbin
    Details               : Kernel name is 'DPU_PDI_0'
                            Instruction size: '20' bytes
                            No. of iterations: '10000'
                            Total duration: '1.1's
                            Average throughput: '13243.3' ops/s
                            Average latency: '113.5' us
    Test Status           : [PASSED]
----------------------------------------
```

#### Documentation impact (if any)
NA