### PR TITLE
Using right column for broadcasting start core 

### DIFF
--- a/src/runtime_src/core/edge/user/aie/common_layer/adf_api_config.h
+++ b/src/runtime_src/core/edge/user/aie/common_layer/adf_api_config.h
@@ -56,6 +56,7 @@ struct graph_config
     std::vector<short> iterMemRows;
     std::vector<size_t> iterMemAddrs;
     std::vector<bool> triggered;
+    uint32_t broadcast_column;
 };
 
 struct rtp_config

--- a/src/runtime_src/core/edge/user/aie/common_layer/adf_runtime_api.cpp
+++ b/src/runtime_src/core/edge/user/aie/common_layer/adf_runtime_api.cpp
@@ -124,13 +124,13 @@ err_code graph_api::run()
         //Trigger event XAIE_EVENT_BROADCAST_A_8_PL in shim_tile at column 0 by writing to Event_Generate. The resources have been acquired by aiecompiler.
         // In case of multi-partition flow still XAie_TileLoc(0, 0) will be used to generate event trigger, but here (0,0) indicates the relative
         // tile location i.e. absolute bottom left tile post translation by partition start column is always 0,0.
-        XAie_EventGenerate(config_manager::s_pDevInst, XAie_TileLoc(0, 0), XAIE_PL_MOD, XAIE_EVENT_BROADCAST_A_8_PL);
+        XAie_EventGenerate(config_manager::s_pDevInst, XAie_TileLoc(pGraphConfig->broadcast_column, 0), XAIE_PL_MOD, XAIE_EVENT_BROADCAST_A_8_PL);
 
         // Waiting for 150 cycles to reset the core enable event
         unsigned long long StartTime, CurrentTime = 0;
-        driverStatus |= XAie_ReadTimer(config_manager::s_pDevInst, XAie_TileLoc(0, 0), XAIE_PL_MOD, (u64*)(&StartTime));
+        driverStatus |= XAie_ReadTimer(config_manager::s_pDevInst, XAie_TileLoc(pGraphConfig->broadcast_column, 0), XAIE_PL_MOD, (u64*)(&StartTime));
         do {
-            driverStatus |= XAie_ReadTimer(config_manager::s_pDevInst, XAie_TileLoc(0, 0), XAIE_PL_MOD, (u64*)(&CurrentTime));
+            driverStatus |= XAie_ReadTimer(config_manager::s_pDevInst, XAie_TileLoc(pGraphConfig->broadcast_column, 0), XAIE_PL_MOD, (u64*)(&CurrentTime));
         } while ((CurrentTime - StartTime) <= 150);
 
         XAie_StartTransaction(config_manager::s_pDevInst, XAIE_TRANSACTION_ENABLE_AUTO_FLUSH);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
We have hardcoded the broadcast column to "0" eariler as we havent supported multi-partitions

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Getting correct column number and broadcasting the start core event in that column

#### How problem was solved, alternative solutions (if any) and why they were rejected
Getting the correct column in data driven mode

#### Risks (if any) associated the changes in the commit
None. 

#### What has been tested and how, request additional testing if necessary
Verified multiple cases (no partition, single partition starts with "0" column, single partition starts with non-zero column, mutli partition case)
#### Documentation impact (if any)
