### PR TITLE
fixing an ISR issue in ctrl_none case

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/common/cu.c
+++ b/src/runtime_src/core/edge/drm/zocl/common/cu.c
@@ -395,7 +395,7 @@ static int cu_probe(struct platform_device *pdev)
 
 	sprintf(zcu->irq_name, "zocl_cu[%d]", info->intr_id);
 
-	if (info->intr_enable) {
+	if (info->intr_enable && info->protocol != CTRL_NONE) {
 		intc = zocl_find_pdev(ERT_CU_INTC_DEV_NAME);
 		if (intc)
 			err = zocl_ert_intc_add(intc, info->intr_id, cu_isr, zcu);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
There is an issue in one of the design where interrupts are continuously triggered by IP.  This IP follows Control none protocol. XRT shouldnt registering ISR for this protocol

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
NA

#### How problem was solved, alternative solutions (if any) and why they were rejected
Not registering ISR for control none protocol

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
verified speicific usecase where control none protocol is present

#### Documentation impact (if any)
None