### PR TITLE
CR-1189791 Update OS Support in XRT Docs

### DIFF
--- a/src/runtime_src/doc/toc/test.rst
+++ b/src/runtime_src/doc/toc/test.rst
@@ -15,7 +15,7 @@ downtime provided you use a few scripts we have created:
 Building XRT
 ~~~~~~~~~~~~
 
-Building XRT is tested on Ubuntu 20.04/22.04, CentOs 7.9+ or RHEL9 host OS.
+Building XRT is tested on Ubuntu 20.04/22.04, CentOs 7.9+ and RHEL9 host OS.
 
 It is probably safest if you keep your Git clone of XRT on a network
 mounted drive that can be accessed from different hosts.  One

--- a/src/runtime_src/doc/toc/test.rst
+++ b/src/runtime_src/doc/toc/test.rst
@@ -15,7 +15,7 @@ downtime provided you use a few scripts we have created:
 Building XRT
 ~~~~~~~~~~~~
 
-Make sure you build XRT on a Ubuntu 20.04 or Ubuntu 22.04 or CentOs 7.9+ or rhel9 host.
+Building XRT is tested on Ubuntu 20.04/22.04, CentOs 7.9+ or RHEL9 host OS.
 
 It is probably safest if you keep your Git clone of XRT on a network
 mounted drive that can be accessed from different hosts.  One

--- a/src/runtime_src/doc/toc/test.rst
+++ b/src/runtime_src/doc/toc/test.rst
@@ -15,7 +15,7 @@ downtime provided you use a few scripts we have created:
 Building XRT
 ~~~~~~~~~~~~
 
-Make sure you build XRT on a Centos7.4+ or Ubuntu16.04 or Ubuntu18.04 host.
+Make sure you build XRT on a Ubuntu 20.04 or Ubuntu 22.04 or CentOs 7.9+ or rhel9 host.
 
 It is probably safest if you keep your Git clone of XRT on a network
 mounted drive that can be accessed from different hosts.  One


### PR DESCRIPTION
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1189791
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
N/A
#### How problem was solved, alternative solutions (if any) and why they were rejected
Updated docs.
#### Risks (if any) associated the changes in the commit
N/A
#### What has been tested and how, request additional testing if necessary
Update shows up in documentation.
```
Building XRT is tested on Ubuntu 20.04/22.04, CentOs 7.9+ and RHEL9 host OS.
```
#### Documentation impact (if any)
This is a documentation update.
