### PR TITLE
VITIS-11235 - Add bo_dump

### DIFF
--- a/src/runtime_src/core/common/api/bo_int.h
+++ b/src/runtime_src/core/common/api/bo_int.h
@@ -27,6 +27,11 @@ XRT_CORE_COMMON_EXPORT
 xrt::bo
 create_debug_bo(const xrt::hw_context& hwctx, size_t sz);
 
+// dump_bo() - Dump bo contents to a file
+XRT_CORE_COMMON_EXPORT
+void
+dump_bo(xrt::bo& bo, const std::string& filename);
+
 } // bo_int, xrt_core
 
 #endif

--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -1522,18 +1522,6 @@ map()
 
 void
 bo::
-dump(const std::string& filename)
-{
-  std::ofstream ofs(filename, std::ios::out | std::ios::binary);
-  if (!ofs.is_open())
-    throw std::runtime_error("Failure opening file " + filename + " for writing!");
-
-  auto buf = map<char*>();
-  ofs.write(buf, size());
-}
-
-void
-bo::
 write(const void* src, size_t size, size_t seek)
 {
   xdp::native::profiling_wrapper("xrt::bo::write", [this, src, size, seek]{
@@ -1701,6 +1689,17 @@ create_debug_bo(const xrt::hw_context& hwctx, size_t sz)
   // buffers, it is still passed in as a default group 1 with no
   // implied correlation to xclbin connectivity or memory group.
   return xrt::bo{alloc(device_type{hwctx}, sz, flags.all, 1)};
+}
+
+void
+dump_bo(xrt::bo& bo, const std::string& filename)
+{
+  std::ofstream ofs(filename, std::ios::out | std::ios::binary);
+  if (!ofs.is_open())
+    throw std::runtime_error("Failure opening file " + filename + " for writing!");
+
+  auto buf = bo.map<char*>();
+  ofs.write(buf, bo.size());
 }
 
 } // xrt_core::bo_int

--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -34,6 +34,7 @@
 #include "core/common/shim/shared_handle.h"
 
 #include <cstdlib>
+#include <fstream>
 #include <map>
 #include <set>
 #include <string>
@@ -1517,6 +1518,18 @@ map()
   return xdp::native::profiling_wrapper("xrt::bo::map", [this]{
     return handle->get_hbuf();
   });
+}
+
+void
+bo::
+dump(const std::string& filename)
+{
+  std::ofstream ofs(filename, std::ios::out | std::ios::binary);
+  if (!ofs.is_open())
+    throw std::runtime_error("Failure opening file " + filename + " for writing!");
+
+  auto buf = map<char*>();
+  ofs.write(buf, size());
 }
 
 void

--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -229,12 +229,7 @@ struct patcher
     if (!xrt_core::config::get_feature_toggle(Debug_Bo_From_Elf_Feature))
       return;
 
-    std::ofstream ofs(filename, std::ios::out | std::ios::binary);
-    if (!ofs.is_open())
-      throw std::runtime_error("Failure opening file " + filename + " for writing!");
-
-    auto buf = bo.map<char*>();
-    ofs.write(buf, bo.size());
+    bo.dump(filename);
   }
 } // namespace
 

--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -8,6 +8,7 @@
 #include "experimental/xrt_elf.h"
 #include "experimental/xrt_ext.h"
 
+#include "core/common/api/bo_int.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_hw_context.h"
 #include "xrt/xrt_uuid.h"
@@ -224,12 +225,12 @@ struct patcher
 };
 
   XRT_CORE_UNUSED void
-  dump_bo(xrt::bo& bo, const std::string& filename)
+  dump_bo_from_elf(xrt::bo& bo, const std::string& filename)
   {
     if (!xrt_core::config::get_feature_toggle(Debug_Bo_From_Elf_Feature))
       return;
 
-    bo.dump(filename);
+    xrt_core::bo_int::dump_bo(bo, filename);
   }
 } // namespace
 
@@ -846,7 +847,7 @@ class module_sram : public module_impl
     fill_instr_buf(m_instr_buf, data);
 
 #ifdef _DEBUG
-    dump_bo(m_instr_buf, "instrBo.bin");
+    dump_bo_from_elf(m_instr_buf, "instrBo.bin");
 #endif
 
     ///// THIS IS A BUG, create_instr_buf is called in constructor
@@ -855,7 +856,7 @@ class module_sram : public module_impl
       patch_instr("control-packet", m_ctrlpkt_buf);
 
 #ifdef _DEBUG
-      dump_bo(m_instr_buf, "instrBoPatchedByCtrlPacket.bin");
+      dump_bo_from_elf(m_instr_buf, "instrBoPatchedByCtrlPacket.bin");
 #endif
       XRT_PRINTF("<- module_sram::create_instr_buf()\n");
     }
@@ -880,7 +881,7 @@ class module_sram : public module_impl
       fill_ctrlpkt_buf(m_ctrlpkt_buf, data);
 
 #ifdef _DEBUG
-      dump_bo(m_ctrlpkt_buf, "ctrlpktBo.bin");
+      dump_bo_from_elf(m_ctrlpkt_buf, "ctrlpktBo.bin");
 #endif
 
       XRT_PRINTF("<- module_sram::create_ctrlpkt_buffer()\n");

--- a/src/runtime_src/core/include/xrt/xrt_bo.h
+++ b/src/runtime_src/core/include/xrt/xrt_bo.h
@@ -587,18 +587,6 @@ public:
   }
 
   /**
-   * dump() - Dump bo contents to a file
-   *
-   * @param filename
-   *  Name of the file for saving bo contents
-   *
-   * Dump bo contenst to a file
-   */
-  XCL_DRIVER_DLLESPEC
-  void
-    dump(const std::string& filename);
-
-  /**
    * map() - Map the host side buffer into application
    *
    * @return

--- a/src/runtime_src/core/include/xrt/xrt_bo.h
+++ b/src/runtime_src/core/include/xrt/xrt_bo.h
@@ -587,6 +587,18 @@ public:
   }
 
   /**
+   * dump() - Dump bo contents to a file
+   *
+   * @param filename
+   *  Name of the file for saving bo contents
+   *
+   * Dump bo contenst to a file
+   */
+  XCL_DRIVER_DLLESPEC
+  void
+    dump(const std::string& filename);
+
+  /**
    * map() - Map the host side buffer into application
    *
    * @return


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
bo like scratchpad which has context-info from aie-tile need to be dumped to a file. A debug buffer containing content from mem-tile also need to be dumped to a file. 
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Adding one function called dump_bo in namespace xrt_core::int.
Alternative solution is adding function dump to class xrt::bo. It is rejected because dump is not a core function.
#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
