### PR TITLE
fix for centos78 issue

### DIFF
--- a/.github/workflows/xrt_ci.yml
+++ b/.github/workflows/xrt_ci.yml
@@ -56,7 +56,7 @@ jobs:
           echo "PATH=/usr/bin:$PATH" >> $GITHUB_ENV     
     
       - name: Checkout PR   
-        uses: actions/checkout@v4 
+        uses: actions/checkout@v3 
         with: 
           repository: "${{ github.event.pull_request.head.repo.full_name }}"
           ref: "${{ github.event.pull_request.head.ref }}"

--- a/.github/workflows/xrt_master.yml
+++ b/.github/workflows/xrt_master.yml
@@ -41,7 +41,7 @@ jobs:
           echo "PATH=/usr/bin:$PATH" >> $GITHUB_ENV     
     
       - name: Checkout PR   
-        uses: actions/checkout@v4 
+        uses: actions/checkout@v3 
         with: 
           # repository: "${{ github.event.pull_request.head.repo.full_name }}"
           # ref: "${{ github.event.pull_request.head.ref }}"


### PR DESCRIPTION
Using checkout version v4 resulting into "fatal: Expected git repo version <= 0, found 1" for centos builds so going back to v3