### PR TITLE
Fixing rw_shared configuration in xgq based flow

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -2259,6 +2259,7 @@ static int xocl_kds_update_xgq(struct xocl_dev *xdev, int slot_hdl,
 		XDEV(xdev)->kds.ert_disable = true;
 		goto create_regular_cu;
 	}
+        XDEV(xdev)->kds.cu_mgmt.rw_shared = cfg.rw_shared;
 
 	// Soft Kernel Info
 	scu_info = kzalloc(MAX_CUS * sizeof(struct xrt_cu_info), GFP_KERNEL);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
rw_shared flag is not propagated to kds properly in xgq based flow

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Passing rw_shared properly to kds now

#### How problem was solved, alternative solutions (if any) and why they were rejected
Passing rw_shared properly to kds now

#### Risks (if any) associated the changes in the commit
NA

#### What has been tested and how, request additional testing if necessary
Verifiied simple case xrt.ini option
#### Documentation impact (if any)
None