### PR TITLE
Passing as a separte module of mgmtpf & XOCL to avoid execution confl…

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
@@ -1746,7 +1746,8 @@ static int __init xclmgmt_init(void)
 	if (IS_ERR(xrt_class))
 		return PTR_ERR(xrt_class);
 
-	res = xocl_debug_init();
+	char *module="mgmtpf";
+	res = xocl_debug_init(module);
 	if (res) {
 		pr_err("failed to init debug");
 		goto alloc_err;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
@@ -1956,14 +1956,14 @@ static void (*xocl_drv_unreg_funcs[])(void) = {
 static int __init xocl_init(void)
 {
 	int		ret, i = 0;
-
+	char *module="xocl"; 
 	xrt_class = class_create(THIS_MODULE, "xrt_user");
 	if (IS_ERR(xrt_class)) {
 		ret = PTR_ERR(xrt_class);
 		goto err_class_create;
 	}
 
-	ret = xocl_debug_init();
+	ret = xocl_debug_init(module);
 	if (ret) {
 		pr_err("failed to init debug");
 		goto failed;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_debug.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_debug.c
@@ -259,7 +259,7 @@ void xocl_debug_fini(void)
 	mutex_destroy(&xrt_debug.mod_lock);
 }
 
-int xocl_debug_init(void)
+int xocl_debug_init(char *module)
 {
 	struct xocl_dbg_reg reg = { .name = "global" };
 	int ret;
@@ -276,7 +276,7 @@ int xocl_debug_init(void)
 	xrt_debug.last_char = xrt_debug.buffer;
 	xrt_debug.read_all = true;
 
-	xrt_debug.debugfs_root = debugfs_create_dir(KBUILD_MODNAME, NULL);
+	xrt_debug.debugfs_root = debugfs_create_dir(module, NULL);
 	if (IS_ERR(xrt_debug.debugfs_root)) {
 		pr_info("creating debugfs root failed");
 		return PTR_ERR(xrt_debug.debugfs_root);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -2562,7 +2562,7 @@ enum {
 	XRT_TRACE_LEVEL_VERBOSE,
 };
 
-int xocl_debug_init(void);
+int xocl_debug_init(char *module);
 void xocl_debug_fini(void);
 int xocl_debug_register(struct xocl_dbg_reg *reg);
 int xocl_debug_unreg(unsigned long hdl);


### PR DESCRIPTION
…ict.

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Used separate module string name  for both MGMTPF & XOCL  to avoid macro and  execution at runtime.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
