### PR TITLE
Removing unnecessary include file that was causing problems on non-edge builds

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_metadata.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -26,7 +26,7 @@
 
 #include "core/common/device.h"
 #include "core/common/message.h"
-#include "core/edge/common/aie_parser.h"
+
 #include "xdp/profile/database/database.h"
 #include "xdp/profile/device/tracedefs.h"
 #include "xdp/profile/plugin/vp_base/utility.h"


### PR DESCRIPTION
#### Problem solved by the commit
A common profiling file was including an edge specific header file, causing problems when building on some non-edge platforms.

#### How problem was solved, alternative solutions (if any) and why they were rejected
The functionality in the header file is not necessary in the cpp file so the include was removed.

#### Risks (if any) associated the changes in the commit
Little to no risk as this file is not using any of the functionality in the header file.

#### What has been tested and how, request additional testing if necessary
The build has been verified.

#### Documentation impact (if any)
None.