### PR TITLE
CR-1186952 xbutil examine -r all -d BDF failed while another terminal is running program at the same time

### DIFF
--- a/src/runtime_src/core/tools/common/reports/ReportAiePartitions.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportAiePartitions.cpp
@@ -17,7 +17,13 @@ boost::property_tree::ptree
 populate_aie_partition(const xrt_core::device* device)
 {
   boost::property_tree::ptree pt;
-  auto data = xrt_core::device_query_default<xrt_core::query::aie_partition_info>(device, {});
+  xrt_core::query::aie_partition_info::result_type data;
+  try {
+    data = xrt_core::device_query_default<xrt_core::query::aie_partition_info>(device, {});
+  }
+  catch (...) {
+    return pt; //no hw context found
+  }
   // Group the hw contexts based on their which AIE partitions they use
   std::map<std::tuple<uint64_t, uint64_t>, boost::property_tree::ptree> pt_map;
   for (const auto& entry : data) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
When a context is destroyed and xbutil is trying to get information about it, we get an escape call exception. 

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
DSV testing

#### How problem was solved, alternative solutions (if any) and why they were rejected
wrap the call in a try/catch block

#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
Compiled locally

#### Documentation impact (if any)
