### PR TITLE
Fixing adf::event crash. Regression from last release

### DIFF
--- a/src/runtime_src/core/common/api/aie/xrt_graph.cpp
+++ b/src/runtime_src/core/common/api/aie/xrt_graph.cpp
@@ -868,7 +868,9 @@ xrtAIEStartProfiling(xrtDeviceHandle handle, int option, const char *port1Name, 
     auto event = create_profiling_event(handle);
     if (option < 0 || option > 3)
       throw xrt_core::error(-EINVAL, "Not a valid profiling option");
-    auto hdl = event->start_profiling(option, port1Name, port2Name, value);
+    const std::string port1 = port1Name ? port1Name : "";
+    const std::string port2 = port2Name ? port2Name : "";
+    auto hdl = event->start_profiling(option, port1, port2, value);
     if (hdl != xrt::aie::profiling_impl::invalid_handle) {
       profiling_cache[hdl] = event;
       return hdl;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
adf::event calls the xrtProfiling APIs under the hood. When it is called with null, XRT APIs are crashing.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://github.com/Xilinx/XRT/pull/7926 

#### How problem was solved, alternative solutions (if any) and why they were rejected
Sending proper values to c++ API.

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Verified all event APIs

#### Documentation impact (if any)
None