### PR TITLE
fix hipMalloc() issue when running in multithreads.

### DIFF
--- a/src/runtime_src/hip/api/hip_device.cpp
+++ b/src/runtime_src/hip/api/hip_device.cpp
@@ -17,7 +17,7 @@ device_init();
 }
 
 namespace {
-std::once_flag device_init_flag;
+thread_local std::once_flag device_init_flag;
 
 // Creates devices at library load
 // User may not explicitly call init or device create
@@ -44,6 +44,8 @@ device_init()
   // create all devices ahead
   // Used when user doesn't explicitly create device
   for (uint32_t i = 0; i < dev_count; i++) {
+    if (device_cache.count(static_cast<device_handle>(i)) > 0)
+      continue;
     auto dev = std::make_shared<xrt::core::hip::device>(i);
     device_cache.add(i, std::move(dev));
   }

--- a/src/runtime_src/hip/core/memory.cpp
+++ b/src/runtime_src/hip/core/memory.cpp
@@ -171,12 +171,14 @@ namespace xrt::core::hip
   void
   memory_database::insert(uint64_t addr, size_t size, std::shared_ptr<xrt::core::hip::memory> hip_mem)
   {
+    std::lock_guard<std::mutex> lock(m_mutex);
     m_addr_map.insert({address_range_key(addr, size), hip_mem});
   }
 
   void
   memory_database::remove(uint64_t addr)
   {
+    std::lock_guard<std::mutex> lock(m_mutex);
     m_addr_map.erase(address_range_key(addr, 0));
   }
 

--- a/src/runtime_src/hip/core/memory.cpp
+++ b/src/runtime_src/hip/core/memory.cpp
@@ -171,14 +171,14 @@ namespace xrt::core::hip
   void
   memory_database::insert(uint64_t addr, size_t size, std::shared_ptr<xrt::core::hip::memory> hip_mem)
   {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::lock_guard lock(m_mutex);
     m_addr_map.insert({address_range_key(addr, size), hip_mem});
   }
 
   void
   memory_database::remove(uint64_t addr)
   {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::lock_guard lock(m_mutex);
     m_addr_map.erase(address_range_key(addr, 0));
   }
 

--- a/src/runtime_src/hip/core/memory.h
+++ b/src/runtime_src/hip/core/memory.h
@@ -126,6 +126,7 @@ namespace xrt::core::hip
   {
   private:
     addr_map m_addr_map;
+    std::mutex m_mutex;
   
   protected:
     memory_database();


### PR DESCRIPTION
fix hipMalloc() issue when running in multithreads.

Problem solved by the commit
crash on calling hipMalloc() from multiple threads.

Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Issue was found during developing unit testing case.

How problem was solved, alternative solutions (if any) and why they were rejected
Add lock for memory_database::remove() and  memory_database::insert(). Allow device_init() be called once per thread.

Risks (if any) associated the changes in the commit
None. Code will only be built with switch "-hip".

What has been tested and how, request additional testing if necessary
Compiled and tested on Ubuntu 22.04 running on Ryzen 7840.

Documentation impact (if any)
None.
