### PR TITLE
CR-1186958 Fix duplicate busybar in xbutil validate tests

### DIFF
--- a/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.cpp
@@ -5,7 +5,6 @@
 // Local - Include Files
 #include "TestDF_bandwidth.h"
 #include "tools/common/XBUtilities.h"
-#include "tools/common/BusyBar.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_hw_context.h"
@@ -156,9 +155,6 @@ TestDF_bandwidth::run(std::shared_ptr<xrt_core::device> dev)
   logger(ptree, "Details", boost::str(boost::format("Buffer size: '%f'GB") % buffer_size_gb));
   logger(ptree, "Details", boost::str(boost::format("No. of iterations: '%f'") % itr_count));
 
-  XBUtilities::BusyBar busy_bar("Running Test", std::cout); 
-  busy_bar.start(XBUtilities::is_escape_codes_disabled());
-
   auto start = std::chrono::high_resolution_clock::now();
   for (int i = 0; i < itr_count; i++) {
     try {
@@ -173,7 +169,6 @@ TestDF_bandwidth::run(std::shared_ptr<xrt_core::device> dev)
     }
   }
   auto end = std::chrono::high_resolution_clock::now();
-  busy_bar.finish();
 
   //map ouput buffer
   bo_ofm.sync(XCL_BO_SYNC_BO_FROM_DEVICE);

--- a/src/runtime_src/core/tools/common/tests/TestGemm.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestGemm.cpp
@@ -5,7 +5,6 @@
 // Local - Include Files
 #include "TestGemm.h"
 #include "tools/common/XBUtilities.h"
-#include "tools/common/BusyBar.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
@@ -14,6 +13,7 @@ namespace XBU = XBUtilities;
 // System - Include Files
 #include <fstream>
 #include <filesystem>
+#include <thread>
 
 static constexpr size_t host_app = 1; //opcode
 static constexpr uint32_t num_of_cores = 32;
@@ -155,9 +155,6 @@ TestGemm::run(std::shared_ptr<xrt_core::device> dev)
   //Sync BOs
   bo_instr.sync(XCL_BO_SYNC_BO_TO_DEVICE);
 
-  XBUtilities::BusyBar busy_bar("Running Test", std::cout); 
-  busy_bar.start(XBUtilities::is_escape_codes_disabled());
-
   //get current performance mode
   const auto perf_mode = xrt_core::device_query<xrt_core::query::performance_mode>(dev);
 
@@ -218,8 +215,7 @@ TestGemm::run(std::shared_ptr<xrt_core::device> dev)
     total_cycle_count = total_cycle_count + cycle_count;
     TOPS = TOPS + temp_TOPS_per_core;
     core_ptr++;
-    }  
-  busy_bar.finish();
+  }
 
   //reset the performance mode
   xrt_core::device_update<xrt_core::query::performance_mode>(dev.get(), static_cast<xrt_core::query::performance_mode::power_type>(perf_mode));

--- a/src/runtime_src/core/tools/common/tests/TestTCTAllColumn.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestTCTAllColumn.cpp
@@ -5,7 +5,6 @@
 // Local - Include Files
 #include "TestTCTAllColumn.h"
 #include "tools/common/XBUtilities.h"
-#include "tools/common/BusyBar.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
@@ -152,9 +151,6 @@ TestTCTAllColumn::run(std::shared_ptr<xrt_core::device> dev)
   logger(ptree, "Details", boost::str(boost::format("Buffer size: '%f' bytes") % buffer_size));
   logger(ptree, "Details", boost::str(boost::format("No. of iterations: '%f'") % itr_count));
 
-  XBUtilities::BusyBar busy_bar("Running Test", std::cout); 
-  busy_bar.start(XBUtilities::is_escape_codes_disabled());
-
   auto start = std::chrono::high_resolution_clock::now();
   try {
     auto run = kernel(host_app, bo_ifm, NULL, bo_ofm, NULL, bo_instr, instr_size, NULL);
@@ -167,7 +163,6 @@ TestTCTAllColumn::run(std::shared_ptr<xrt_core::device> dev)
     return ptree;
   }
   auto end = std::chrono::high_resolution_clock::now();
-  busy_bar.finish();
 
   //map ouput buffer
   bo_ofm.sync(XCL_BO_SYNC_BO_FROM_DEVICE);

--- a/src/runtime_src/core/tools/common/tests/TestTCTOneColumn.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestTCTOneColumn.cpp
@@ -5,7 +5,6 @@
 // Local - Include Files
 #include "TestTCTOneColumn.h"
 #include "tools/common/XBUtilities.h"
-#include "tools/common/BusyBar.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
@@ -152,9 +151,6 @@ TestTCTOneColumn::run(std::shared_ptr<xrt_core::device> dev)
   logger(ptree, "Details", boost::str(boost::format("Buffer size: '%f'bytes") % buffer_size));
   logger(ptree, "Details", boost::str(boost::format("No. of iterations: '%f'") % itr_count));
 
-  XBUtilities::BusyBar busy_bar("Running Test", std::cout); 
-  busy_bar.start(XBUtilities::is_escape_codes_disabled());
-
   auto start = std::chrono::high_resolution_clock::now();
   try {
     auto run = kernel(host_app, bo_ifm, NULL, bo_ofm, NULL, bo_instr, instr_size, NULL);
@@ -167,7 +163,6 @@ TestTCTOneColumn::run(std::shared_ptr<xrt_core::device> dev)
     return ptree;
   }
   auto end = std::chrono::high_resolution_clock::now();
-  busy_bar.finish();
 
   //map ouput buffer
   bo_ofm.sync(XCL_BO_SYNC_BO_FROM_DEVICE);


### PR DESCRIPTION
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1186958 
There was a duplicate busybar in some of the xbutil validate tests that caused occasional validate failure. It was also a bit confusing to look at.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Discovered when running xbutil validate -r all repeatedly on MCDM.
#### How problem was solved, alternative solutions (if any) and why they were rejected
Removed duplicate busybar from the affected tests (busy bars run at TestRunner level).
#### Risks (if any) associated the changes in the commit
N/A
#### What has been tested and how, request additional testing if necessary
Tested on STX/MCDM. There is only one bar per test now, as desired.
#### Documentation impact (if any)
N/A