### PR TITLE
VITIS-11112 HIP Binding: Memory Management.

### DIFF
--- a/src/runtime_src/hip/core/event.cpp
+++ b/src/runtime_src/hip/core/event.cpp
@@ -118,14 +118,16 @@ kernel_start::kernel_start(std::shared_ptr<stream> s, std::shared_ptr<function> 
         xrt_core::kernel_int::set_arg_at_index(r, arg->index, args[idx], arg->size);
         break;
       case karg::argtype::global : {
-        auto hip_mem = memory_database::instance().get_hip_mem_from_addr(args[idx]).first;
-        if (!hip_mem)
-          throw std::runtime_error("failed to get memory from arg at index - " + std::to_string(idx));
+        if (args[idx] != 0) {
+          auto hip_mem = memory_database::instance().get_hip_mem_from_addr(args[idx]).first;
+          if (!hip_mem)
+            throw std::runtime_error("failed to get memory from arg at index - " + std::to_string(idx));
 
-        // NPU device is not coherent. We need to sync the buffer objects before launching kernel
-        if (hip_mem->get_type() != memory_type::device)
-          hip_mem->sync(xclBOSyncDirection::XCL_BO_SYNC_BO_TO_DEVICE);
-        r.set_arg(idx, hip_mem->get_xrt_bo());
+          // NPU device is not coherent. We need to sync the buffer objects before launching kernel
+          if (hip_mem->get_type() != memory_type::device)
+            hip_mem->sync(xclBOSyncDirection::XCL_BO_SYNC_BO_TO_DEVICE);
+          r.set_arg(idx, hip_mem->get_xrt_bo());
+        }
         break;
       }
       case karg::argtype::constant :

--- a/src/runtime_src/hip/core/event.cpp
+++ b/src/runtime_src/hip/core/event.cpp
@@ -118,16 +118,17 @@ kernel_start::kernel_start(std::shared_ptr<stream> s, std::shared_ptr<function> 
         xrt_core::kernel_int::set_arg_at_index(r, arg->index, args[idx], arg->size);
         break;
       case karg::argtype::global : {
-        if (args[idx] != 0) {
-          auto hip_mem = memory_database::instance().get_hip_mem_from_addr(args[idx]).first;
-          if (!hip_mem)
-            throw std::runtime_error("failed to get memory from arg at index - " + std::to_string(idx));
+        if (!args[idx])
+          break;
+        
+        auto hip_mem = memory_database::instance().get_hip_mem_from_addr(args[idx]).first;
+        if (!hip_mem)
+          throw std::runtime_error("failed to get memory from arg at index - " + std::to_string(idx));
 
-          // NPU device is not coherent. We need to sync the buffer objects before launching kernel
-          if (hip_mem->get_type() != memory_type::device)
-            hip_mem->sync(xclBOSyncDirection::XCL_BO_SYNC_BO_TO_DEVICE);
-          r.set_arg(idx, hip_mem->get_xrt_bo());
-        }
+        // NPU device is not coherent. We need to sync the buffer objects before launching kernel
+        if (hip_mem->get_type() != memory_type::device)
+          hip_mem->sync(xclBOSyncDirection::XCL_BO_SYNC_BO_TO_DEVICE);
+        r.set_arg(idx, hip_mem->get_xrt_bo());
         break;
       }
       case karg::argtype::constant :

--- a/src/runtime_src/hip/core/memory.cpp
+++ b/src/runtime_src/hip/core/memory.cpp
@@ -185,6 +185,7 @@ namespace xrt::core::hip
   std::pair<std::shared_ptr<xrt::core::hip::memory>, size_t>
   memory_database::get_hip_mem_from_addr(void *addr)
   {
+    std::lock_guard lock(m_mutex);
     auto itr = m_addr_map.find(address_range_key(reinterpret_cast<uint64_t>(addr), 0));
     if (itr == m_addr_map.end()) {
       return std::pair(nullptr, 0);
@@ -198,6 +199,7 @@ namespace xrt::core::hip
   std::pair<std::shared_ptr<xrt::core::hip::memory>, size_t>
   memory_database::get_hip_mem_from_addr(const void *addr)
   {
+    std::lock_guard lock(m_mutex);
     auto itr = m_addr_map.find(address_range_key(reinterpret_cast<uint64_t>(addr), 0));
     if (itr == m_addr_map.end()) {
       return std::pair(nullptr, 0);

--- a/src/runtime_src/hip/core/memory.h
+++ b/src/runtime_src/hip/core/memory.h
@@ -116,7 +116,7 @@ namespace xrt::core::hip
       // a < b retruns false because 0x4000+0x100 < 0x4100
       // b < a returns false because 0x4100+0x100 < 0x4000
       // if we add "-1" then a<b returns true.
-      return (lhs.address + lhs.size - 1  < rhs.address);
+      return (lhs.address + lhs.size < 1) || (lhs.address + lhs.size - 1  < rhs.address);
     }
   };
   


### PR DESCRIPTION
Problem solved by the commit
1) returning wrong hip mem object when input address is 0
2) crash when trying to set xrt::bo object from 0 address as kernel argument

Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
crash was discovered in developing unit test cases

How problem was solved, alternative solutions (if any) and why they were rejected
1) return correct result in hip mem object look up from 0 address.
2) allow host app feed 0 as kernel argument.

Risks (if any) associated the changes in the commit
None. Code will only be built with switch "-hip".

What has been tested and how, request additional testing if necessary
Compiled and tested on Ubuntu 22.04 (running on Ryzen 7840).

Documentation impact (if any)
None.