### PR TITLE
VITIS-11384 - Process elf section "preempt_save" and "preempt_restore"

### DIFF
--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -194,11 +194,8 @@ struct patcher
   }
 
   void
-  patch(uint8_t* base, uint64_t patch, buf_type type)
+  patch(uint8_t* base, uint64_t patch)
   {
-    if (type != m_buf_type)
-      return;
-
     for (auto offset : m_ctrlcode_offset) {
       auto bd_data_ptr = reinterpret_cast<uint32_t*>(base + offset);
       switch (m_symbol_type) {
@@ -471,9 +468,7 @@ class module_elf : public module_impl
 
   // Extract preempt_save buffer from ELF sections
   // return true if section exist
-  bool
-      initialize_save_buf(const ELFIO::elfio& elf,
-                          buf& save_buf)
+  bool initialize_save_buf(const ELFIO::elfio& elf, buf& save_buf)
   {
       for (const auto& sec : elf.sections) {
           auto name = sec->get_name();
@@ -488,9 +483,7 @@ class module_elf : public module_impl
 
   // Extract preempt_restore buffer from ELF sections
   // return true if section exist
-  bool
-      initialize_restore_buf(const ELFIO::elfio& elf,
-          buf& restore_buf)
+  bool initialize_restore_buf(const ELFIO::elfio& elf, buf& restore_buf)
   {
       for (const auto& sec : elf.sections) {
           auto name = sec->get_name();
@@ -719,7 +712,7 @@ class module_elf : public module_impl
     if (it == m_arg2patcher.end())
       return false;
 
-    it->second.patch(base, patch, type);
+    it->second.patch(base, patch);
     return true;
   }
 

--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -124,10 +124,10 @@ struct patcher
        buf_type_count = 4   // total number of buf types
   };
 
-  inline static char*
+  inline static const char*
   section_name_to_string(buf_type bt)
   {
-    static char* Section_Name_Array[static_cast<int>(buf_type::buf_type_count)] = { ".ctrltext",
+    static const char* Section_Name_Array[static_cast<int>(buf_type::buf_type_count)] = { ".ctrltext",
                                                                                     ".ctrldata",
                                                                                     ".preempt_save",
                                                                                     ".preempt_restore" };

--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -692,12 +692,10 @@ class module_elf : public module_impl
 
         // Construct the patcher for the argument with the symbol name
         std::string argnm{ symname, symname + std::min(strlen(symname), dynstr->get_size()) };
-        auto symbol_type = static_cast<patcher::symbol_type>(rela->r_addend);
-
         patcher::buf_type buf_type = patcher::buf_type::ctrltext;
-        std::vector<uint64_t> offsets;
-        offsets.push_back(ctrlcode_offset);
-        arg2patcher.emplace(std::move(argnm), patcher{ symbol_type, offsets, buf_type});
+        std::string key_string = generate_key_string(argnm, buf_type);
+        auto symbol_type = static_cast<patcher::symbol_type>(rela->r_addend);
+        arg2patcher.emplace(std::move(key_string), patcher{ symbol_type, {ctrlcode_offset}, buf_type});
       }
     }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Assembler added new sections in elf file called ".preempt_save" and ".preempt_restore" to support preempt. This PR adds support to process the added new sections. 
Without the new code, exception will happen which says "Invalid section name"
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Adding support in Function initialize_arg_patchers for new sections
#### Risks (if any) associated the changes in the commit
None
#### What has been tested and how, request additional testing if necessary
Compile and run xrt_elf_test
#### Documentation impact (if any)
