### PR TITLE
Fix for CR-1178294: XRT AIE Status .json file does not include tile information for a tile where only memory is used

### DIFF
--- a/src/runtime_src/core/common/info_aie.cpp
+++ b/src/runtime_src/core/common/info_aie.cpp
@@ -721,14 +721,14 @@ populate_buffer_only_cores(const boost::property_tree::ptree& pt,
       boost::property_tree::ptree tile;
       tile.put("column", node.second.data());
       tile.put("row", dma_row_it->second.data());
+      if (dma_row_it != g_node.second.end())
+        dma_row_it++;
       // Check whether this core is already added
       if (is_duplicate_core(tile_array, tile))
         continue;
 
       populate_aie_core(core_info, tile);
       tile_array.push_back({"", tile});
-      if (dma_row_it != g_node.second.end())
-        dma_row_it++;
     }
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1178294
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
The iterator will not advance after first iteration so made the change accordingly.
#### Risks (if any) associated the changes in the commit
Low
#### What has been tested and how, request additional testing if necessary
Verified testcase added in the mentioned CR.
#### Documentation impact (if any)
NA