### PR TITLE
VITIS-11334 Update XRT to remove Early Access label for Ryzen

### DIFF
--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -438,7 +438,7 @@ XBUtilities::collect_devices( const std::set<std::string> &_deviceBDFs,
   }
 
   std::shared_ptr<xrt_core::device>
-  XBUtilities::get_device( const std::string &deviceBDF, bool in_user_domain, bool print_warning)
+  XBUtilities::get_device( const std::string &deviceBDF, bool in_user_domain)
   {
     // -- If the deviceBDF is empty then do nothing
     if (deviceBDF.empty())
@@ -451,15 +451,6 @@ XBUtilities::collect_devices( const std::set<std::string> &_deviceBDFs,
 
     if (xrt_core::device_query_default<xq::is_versal>(device, false))
       check_versal_boot(device);
-
-    const std::string device_name = xrt_core::device_query_default<xrt_core::query::rom_vbnv>(device, "");
-    if (device_name.find("Ryzen") != std::string::npos && print_warning) {
-      std::cout << "------------------------------------------------------------\n";
-      std::cout << "                        EARLY ACCESS                        \n";
-      std::cout << "        This release of xbutil contains early access        \n";
-      std::cout << "         experimental features which may have bugs.         \n";
-      std::cout << "------------------------------------------------------------\n";
-    }
 
     return device;
   }
@@ -483,7 +474,7 @@ XBUtilities::get_device_class(const std::string &deviceBDF, bool in_user_domain)
   if (deviceBDF.empty()) 
     return "";
 
-  std::shared_ptr<xrt_core::device> device = get_device(boost::algorithm::to_lower_copy(deviceBDF), in_user_domain, false);
+  std::shared_ptr<xrt_core::device> device = get_device(boost::algorithm::to_lower_copy(deviceBDF), in_user_domain);
   auto device_class = xrt_core::device_query_default<xrt_core::query::device_class>(device, xrt_core::query::device_class::type::alveo);
   return deviceMapping(device_class);
 }

--- a/src/runtime_src/core/tools/common/XBUtilities.h
+++ b/src/runtime_src/core/tools/common/XBUtilities.h
@@ -53,7 +53,7 @@ namespace XBUtilities {
                         bool _inUserDomain,
                         xrt_core::device_collection &_deviceCollection);
 
-  std::shared_ptr<xrt_core::device> get_device (const std::string& deviceBDF, bool in_user_domain, bool print_warning = true);
+  std::shared_ptr<xrt_core::device> get_device (const std::string& deviceBDF, bool in_user_domain);
 
   std::string get_device_class(const std::string& deviceBDF, bool in_user_domain);
 


### PR DESCRIPTION
#### Problem solved by the commit
https://jira.xilinx.com/browse/VITIS-11334 It's time to remove the Early Access label for Ryzen devices. Requested for Ryzen 1.2.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
The Early Access label was first added in https://github.com/Xilinx/XRT/pull/7754 and edited in https://github.com/Xilinx/XRT/pull/7774.
#### How problem was solved, alternative solutions (if any) and why they were rejected
Removed the printout and the associated print_warning variable.
#### Risks (if any) associated the changes in the commit
N/A
