### PR TITLE
VITIS-11829 Xbutil: Separate throughput and latency from verify as individual microbenchmarks

### DIFF
--- a/src/runtime_src/core/tools/common/tests/TestNPULatency.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestNPULatency.cpp
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
 
 // ------ I N C L U D E   F I L E S -------------------------------------------
 // Local - Include Files
-#include "TestIPU.h"
+#include "TestNPULatency.h"
 #include "tools/common/XBUtilities.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
@@ -16,14 +16,14 @@ namespace XBU = XBUtilities;
 static constexpr size_t host_app = 1; //opcode
 static constexpr size_t buffer_size = 20;
 static constexpr int itr_count = 10000;
-static constexpr int itr_count_throughput = itr_count/4;
+
 // ----- C L A S S   M E T H O D S -------------------------------------------
-TestIPU::TestIPU()
-  : TestRunner("verify", "Run end-to-end latency and throughput test on NPU")
+TestNPULatency::TestNPULatency()
+  : TestRunner("latency", "Run end-to-end latency test")
 {}
 
 boost::property_tree::ptree
-TestIPU::run(std::shared_ptr<xrt_core::device> dev)
+TestNPULatency::run(std::shared_ptr<xrt_core::device> dev)
 {
   boost::property_tree::ptree ptree = get_test_header();
 
@@ -90,7 +90,7 @@ TestIPU::run(std::shared_ptr<xrt_core::device> dev)
   logger(ptree, "Details", boost::str(boost::format("Instruction size: '%f' bytes") % buffer_size));
   logger(ptree, "Details", boost::str(boost::format("No. of iterations: '%f'") % itr_count));
 
-  // First run the test to compute latency where we submit one job at a time and wait for its completion before
+  // Run the test to compute latency where we submit one job at a time and wait for its completion before
   // we submit the next one
   float elapsedSecs = 0.0;
 
@@ -110,39 +110,8 @@ TestIPU::run(std::shared_ptr<xrt_core::device> dev)
   }
 
   // Calculate end-to-end latency of one job execution
-  // if (elapsedSecs == 0.0) then it means we had an exception and we will report 0.0 for latency
   const float latency = (elapsedSecs / itr_count) * 1000000; //convert s to us
-
-  // Next we run the test to compute throughput where we saturate NPU with jobs and then wait for all
-  // completions at the end
-  std::array<xrt::run, itr_count_throughput> runhandles;
-
-  // A value of 0.0 indicates there was an exception
-  elapsedSecs = 0.0;
-
-  try {
-    auto start = std::chrono::high_resolution_clock::now();
-    for (auto & hand : runhandles)
-      hand = testker(host_app, bo_ifm, bo_param, bo_ofm, bo_inter, bo_instr, buffer_size, bo_mc);
-    for (const auto& hand: runhandles)
-      hand.wait2();
-    auto end = std::chrono::high_resolution_clock::now();
-    elapsedSecs = std::chrono::duration_cast<std::chrono::duration<float>>(end-start).count();
-  }
-  catch (const std::exception& ex) {
-    logger(ptree, "Error", ex.what());
-    ptree.put("status", test_token_failed);
-  }
-
-  // Now compute the throughput
-  // if (elapsedSecs == 0.0) then it means we had an exception and we will report 0.0  for throughput
-  const double throughput = (elapsedSecs != 0.0) ? runhandles.size() / elapsedSecs : 0.0;
-
-  // Do we need to store 'Total duration'?"
-  // logger(ptree, "Details", boost::str(boost::format("Total duration: '%.1f's") % elapsedSecs));
-  logger(ptree, "Details", boost::str(boost::format("Average throughput: '%.1f' ops/s") % throughput));
   logger(ptree, "Details", boost::str(boost::format("Average latency: '%.1f' us") % latency));
-
   ptree.put("status", test_token_passed);
   return ptree;
 }

--- a/src/runtime_src/core/tools/common/tests/TestNPULatency.h
+++ b/src/runtime_src/core/tools/common/tests/TestNPULatency.h
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+
+#ifndef __TestNPULatency_h_
+#define __TestNPULatency_h_
+
+#include "tools/common/TestRunner.h"
+#include "xrt/xrt_device.h"
+
+class TestNPULatency : public TestRunner {
+  public:
+    boost::property_tree::ptree run(std::shared_ptr<xrt_core::device> dev);
+
+  public:
+    TestNPULatency();
+};
+
+#endif

--- a/src/runtime_src/core/tools/common/tests/TestNPUThroughput.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestNPUThroughput.cpp
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+
+// ------ I N C L U D E   F I L E S -------------------------------------------
+// Local - Include Files
+#include "TestNPUThroughput.h"
+#include "tools/common/XBUtilities.h"
+#include "xrt/xrt_bo.h"
+#include "xrt/xrt_device.h"
+#include "xrt/xrt_hw_context.h"
+#include "xrt/xrt_kernel.h"
+namespace XBU = XBUtilities;
+
+#include <filesystem>
+
+static constexpr size_t host_app = 1; //opcode
+static constexpr size_t buffer_size = 20;
+static constexpr int itr_count_throughput = 2500;
+// ----- C L A S S   M E T H O D S -------------------------------------------
+TestNPUThroughput::TestNPUThroughput()
+  : TestRunner("throughput", "Run end-to-end throughput test")
+{}
+
+boost::property_tree::ptree
+TestNPUThroughput::run(std::shared_ptr<xrt_core::device> dev)
+{
+  boost::property_tree::ptree ptree = get_test_header();
+
+  const auto xclbin_name = xrt_core::device_query<xrt_core::query::xclbin_name>(dev, xrt_core::query::xclbin_name::type::validate);
+  auto xclbin_path = findPlatformFile(xclbin_name, ptree);
+  if (!std::filesystem::exists(xclbin_path))
+    return ptree;
+
+  logger(ptree, "Xclbin", xclbin_path);
+
+  xrt::xclbin xclbin;
+  try {
+    xclbin = xrt::xclbin(xclbin_path);
+  }
+  catch (const std::runtime_error& ex) {
+    logger(ptree, "Error", ex.what());
+    ptree.put("status", test_token_failed);
+    return ptree;
+  }
+
+  // Determine The DPU Kernel Name
+  auto xkernels = xclbin.get_kernels();
+
+  auto itr = std::find_if(xkernels.begin(), xkernels.end(), [](xrt::xclbin::kernel& k) {
+    auto name = k.get_name();
+    return name.rfind("DPU",0) == 0; // Starts with "DPU"
+  });
+
+  xrt::xclbin::kernel xkernel;
+  if (itr!=xkernels.end())
+    xkernel = *itr;
+  else {
+    logger(ptree, "Error", "No kernel with `DPU` found in the xclbin");
+    ptree.put("status", test_token_failed);
+    return ptree;
+  }
+  auto kernelName = xkernel.get_name();
+  logger(ptree, "Details", boost::str(boost::format("Kernel name is '%s'") % kernelName));
+
+  auto working_dev = xrt::device(dev);
+  working_dev.register_xclbin(xclbin);
+  xrt::hw_context hwctx{working_dev, xclbin.get_uuid()};
+  xrt::kernel testker{hwctx, kernelName};
+
+  //Create BOs, the values are not initialized as they are not really used by this special test running on the device
+  int argno = 1;
+  xrt::bo bo_ifm(working_dev, buffer_size, XRT_BO_FLAGS_HOST_ONLY, testker.group_id(argno++));
+  xrt::bo bo_param(working_dev, buffer_size, XRT_BO_FLAGS_HOST_ONLY, testker.group_id(argno++));
+  xrt::bo bo_ofm(working_dev, buffer_size, XRT_BO_FLAGS_HOST_ONLY, testker.group_id(argno++));
+  xrt::bo bo_inter(working_dev, buffer_size, XRT_BO_FLAGS_HOST_ONLY, testker.group_id(argno++));
+  xrt::bo bo_instr(working_dev, buffer_size, XCL_BO_FLAGS_CACHEABLE, testker.group_id(argno++));
+  argno++;
+  xrt::bo bo_mc(working_dev, buffer_size, XRT_BO_FLAGS_HOST_ONLY, testker.group_id(argno++));
+  //Create ctrlcode with NOPs
+  std::memset(bo_instr.map<char*>(), 0, buffer_size);
+
+  //Sync BOs
+  bo_instr.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+  bo_ifm.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+  bo_param.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+  bo_mc.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+
+  //Log
+  logger(ptree, "Details", boost::str(boost::format("Instruction size: '%f' bytes") % buffer_size));
+  logger(ptree, "Details", boost::str(boost::format("No. of iterations: '%f'") % itr_count_throughput));
+
+  // Run the test to compute throughput where we saturate NPU with jobs and then wait for all
+  // completions at the end
+  float elapsedSecs = 0.0;
+  std::array<xrt::run, itr_count_throughput> runhandles;
+
+  try {
+    auto start = std::chrono::high_resolution_clock::now();
+    for (auto & hand : runhandles)
+      hand = testker(host_app, bo_ifm, bo_param, bo_ofm, bo_inter, bo_instr, buffer_size, bo_mc);
+    for (const auto& hand: runhandles)
+      hand.wait2();
+    auto end = std::chrono::high_resolution_clock::now();
+    elapsedSecs = std::chrono::duration_cast<std::chrono::duration<float>>(end-start).count();
+  }
+  catch (const std::exception& ex) {
+    logger(ptree, "Error", ex.what());
+    ptree.put("status", test_token_failed);
+  }
+
+  // Compute the throughput
+  const double throughput = (elapsedSecs != 0.0) ? runhandles.size() / elapsedSecs : 0.0;
+
+  logger(ptree, "Details", boost::str(boost::format("Average throughput: '%.1f' ops/s") % throughput));
+  ptree.put("status", test_token_passed);
+  return ptree;
+}

--- a/src/runtime_src/core/tools/common/tests/TestNPUThroughput.h
+++ b/src/runtime_src/core/tools/common/tests/TestNPUThroughput.h
@@ -1,18 +1,18 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
 
-#ifndef __TestIPU_h_
-#define __TestIPU_h_
+#ifndef __TestNPUThroughput_h_
+#define __TestNPUThroughput_h_
 
 #include "tools/common/TestRunner.h"
 #include "xrt/xrt_device.h"
 
-class TestIPU : public TestRunner {
+class TestNPUThroughput : public TestRunner {
   public:
     boost::property_tree::ptree run(std::shared_ptr<xrt_core::device> dev);
 
   public:
-    TestIPU();
+    TestNPUThroughput();
 };
 
 #endif

--- a/src/runtime_src/core/tools/common/tests/TestVerify.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestVerify.cpp
@@ -4,7 +4,6 @@
 // ------ I N C L U D E   F I L E S -------------------------------------------
 // Local - Include Files
 #include "TestVerify.h"
-#include "TestIPU.h"
 #include "tools/common/XBUtilities.h"
 namespace XBU = XBUtilities;
 
@@ -12,7 +11,8 @@ namespace XBU = XBUtilities;
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#define LENGTH 64
+
+static constexpr size_t buffer_size = 64;
 
 // ----- C L A S S   M E T H O D S -------------------------------------------
 TestVerify::TestVerify()
@@ -25,28 +25,13 @@ boost::property_tree::ptree
 TestVerify::run(std::shared_ptr<xrt_core::device> dev)
 {
   boost::property_tree::ptree ptree;
-  switch (xrt_core::device_query<xrt_core::query::device_class>(dev)) {
-  case xrt_core::query::device_class::type::ryzen:
-    ptree = TestIPU{}.run(dev);
-    break;
-  case xrt_core::query::device_class::type::alveo:
-    ptree = get_test_header();
-    runTest(dev, ptree);
-    break;
-  }
-  return ptree;
-}
-
-void
-TestVerify::runTest(std::shared_ptr<xrt_core::device> dev, boost::property_tree::ptree& ptree)
-{
   xrt::device device(dev);
 
   const std::string test_path = findPlatformPath(dev, ptree);
   if (test_path.empty()) {
     logger(ptree, "Error", "Platform test path was not found.");
     ptree.put("status", test_token_failed);
-    return;
+    return ptree;
   }
 
   const std::string b_file = findXclbinPath(dev, ptree);
@@ -57,7 +42,7 @@ TestVerify::runTest(std::shared_ptr<xrt_core::device> dev, boost::property_tree:
   if (!logic_uuid.empty() && !std::filesystem::exists(b_file)) {
     logger(ptree, "Details", "Verify xclbin not available or shell partition is not programmed. Skipping validation.");
     ptree.put("status", test_token_skipped);
-    return;
+    return ptree;
   }
   auto xclbin_uuid = device.load_xclbin(b_file);
 
@@ -70,19 +55,19 @@ TestVerify::runTest(std::shared_ptr<xrt_core::device> dev, boost::property_tree:
     } catch (const std::exception&) {
       logger(ptree, "Error", "Kernel could not be found.");
       ptree.put("status", test_token_failed);
-      return;
+      return ptree;
     }
   }
 
   // Allocate the output buffer to hold the kernel output
-  auto output_buffer = xrt::bo(device, sizeof(char) * LENGTH, krnl.group_id(0));
+  auto output_buffer = xrt::bo(device, sizeof(char) * buffer_size, krnl.group_id(0));
 
   // Run the kernel and store its contents within the allocated output buffer
   auto run = krnl(output_buffer);
   run.wait();
 
   // Prepare local buffer
-  char received_data[LENGTH] = {};
+  char received_data[buffer_size] = {};
 
   // Acquire and read the buffer data
   output_buffer.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
@@ -96,4 +81,5 @@ TestVerify::runTest(std::shared_ptr<xrt_core::device> dev, boost::property_tree:
   }
 
   ptree.put("status", test_token_passed);
+  return ptree;
 }

--- a/src/runtime_src/core/tools/common/tests/TestVerify.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestVerify.cpp
@@ -25,6 +25,7 @@ boost::property_tree::ptree
 TestVerify::run(std::shared_ptr<xrt_core::device> dev)
 {
   boost::property_tree::ptree ptree;
+  ptree = get_test_header();
   xrt::device device(dev);
 
   const std::string test_path = findPlatformPath(dev, ptree);

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -37,6 +37,8 @@
 #include "tools/common/tests/TestTCTOneColumn.h"
 #include "tools/common/tests/TestTCTAllColumn.h"
 #include "tools/common/tests/TestGemm.h"
+#include "tools/common/tests/TestNPUThroughput.h"
+#include "tools/common/tests/TestNPULatency.h"
 namespace XBU = XBUtilities;
 
 // 3rd Party Library - Include Files
@@ -104,7 +106,9 @@ std::vector<std::shared_ptr<TestRunner>> testSuite = {
   std::make_shared<TestDF_bandwidth>(),
   std::make_shared<TestTCTOneColumn>(),
   std::make_shared<TestTCTAllColumn>(),
-  std::make_shared<TestGemm>()
+  std::make_shared<TestGemm>(),
+  std::make_shared<TestNPUThroughput>(),
+  std::make_shared<TestNPULatency>()
 };
 
 /*

--- a/src/runtime_src/core/tools/xbutil2/xbutil.cpp
+++ b/src/runtime_src/core/tools/xbutil2/xbutil.cpp
@@ -66,7 +66,7 @@ R"(
     }]
   },{
     "validate": [{
-      "test": ["verify", "df-bw", "tct-one-col", "tct-all-col", "gemm"]
+      "test": ["latency", "throughput", "df-bw", "tct-one-col", "tct-all-col", "gemm"]
     }]
   }]
 }]


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
throughput and latency are 2 different tests with different calculations so it is better to separate them out

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
N/A

#### How problem was solved, alternative solutions (if any) and why they were rejected
Created 2 new tests: throughput and latency and removed verify as it is no longer applicable for NPU

#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
Tested on Strix/MCDM:
```
>xbutil validate --batch
Validate Device           : [<>]
    Platform              : NPU
    Performance Mode      : Default
-------------------------------------------------------------------------------
Running Test: ..
Test 1 [00c5:00:01.1]     : latency
    Details               : Kernel name is 'DPU_PDI_0'
                            Instruction size: '20' bytes
                            No. of iterations: '10000'
                            Average latency: '<>' us
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Running Test: .
Test 2 [00c5:00:01.1]     : throughput
    Details               : Kernel name is 'DPU_PDI_0'
                            Instruction size: '20' bytes
                            No. of iterations: '2500'
                            Average throughput: '<>' ops/s
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Running Test: ..................................
Test 3 [00c5:00:01.1]     : df-bw
    Details               : Kernel name is 'DPU_PDI_0'
    Details               : Buffer size: '1'GB
                            No. of iterations: '600'
                            Total duration: '31.3's
                            Average bandwidth per shim DMA: '<>' GB/s
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Running Test: ..
Test 4 [00c5:00:01.1]     : tct-one-col
    Details               : Kernel name is 'DPU_PDI_0'
    Details               : Buffer size: '4'bytes
                            No. of iterations: '10000'
                            Average time for TCT: '<>' us
                            Average TCT throughput: '<>' TCT/s
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Running Test: ..
Test 5 [00c5:00:01.1]     : tct-all-col
    Details               : Kernel name is 'DPU_PDI_0'
    Details               : Buffer size: '4' bytes
                            No. of iterations: '20000'
                            Average time for TCT: '<>' us
                            Average TCT throughput: '<>' TCT/s
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Running Test: ......
Test 6 [00c5:00:01.1]     : gemm
    Details               : Kernel name is 'DPU_1x4'
    Details               : Total Duration: '126.5' ns
                            Average cycle count: '229.0'
                            IPU H-Clock: '1810' MHz
                            TOPS: '<>'
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Validation completed. Please run the command '--verbose' option for more details
```

#### Documentation impact (if any)
N/A
