### PR TITLE
Xrt mgmtpf class separation & renaming mgmtpf module function calls

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-bifurcation-reset.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-bifurcation-reset.c
@@ -206,7 +206,7 @@ static long xclmgmt_hot_reset_post(struct xclmgmt_dev *lro, bool force)
 	xocl_thread_start(lro);
 
 	xocl_clear_pci_errors(lro);
-	store_pcie_link_info(lro);
+	mgmtpf_store_pcie_link_info(lro);
 
 	/* For legacy case always download to slot 0 */
 	if (lro->preload_xclbin)

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
@@ -203,7 +203,7 @@ uint32_t mgmt_bar_read32(struct xclmgmt_dev *lro, uint32_t bar_off)
 	return val;
 }
 
-void store_pcie_link_info(struct xclmgmt_dev *lro)
+void mgmtpf_store_pcie_link_info(struct xclmgmt_dev *lro)
 {
 	u16 stat = 0;
 	long result;
@@ -234,7 +234,7 @@ void store_pcie_link_info(struct xclmgmt_dev *lro)
 	return;
 }
 
-void get_pcie_link_info(struct xclmgmt_dev *lro,
+void mgmtpf_get_pcie_link_info(struct xclmgmt_dev *lro,
 	unsigned short *link_width, unsigned short *link_speed, bool is_cap)
 {
 	int pos = is_cap ? PCI_EXP_LNKCAP : PCI_EXP_LNKSTA;
@@ -283,7 +283,7 @@ void device_info(struct xclmgmt_dev *lro, struct xclmgmt_ioc_info *obj)
 	memcpy(obj->fpga, rom.FPGAPartName, 64);
 
 	fill_frequency_info(lro, obj);
-	get_pcie_link_info(lro, &obj->pcie_link_width, &obj->pcie_link_speed,
+	mgmtpf_get_pcie_link_info(lro, &obj->pcie_link_width, &obj->pcie_link_speed,
 		false);
 }
 
@@ -1360,7 +1360,7 @@ static void xclmgmt_extended_probe(struct xclmgmt_dev *lro)
 	check_pcie_link_toggle(lro, 1);
 
 	/* Store/cache PCI link width & speed info */
-	store_pcie_link_info(lro);
+	mgmtpf_store_pcie_link_info(lro);
 
 	/* Notify our peer that we're listening. */
 	xclmgmt_connect_notify(lro, true);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.h
@@ -168,11 +168,11 @@ u16 get_dsa_version(struct xclmgmt_dev *lro);
 void fill_frequency_info(struct xclmgmt_dev *lro, struct xclmgmt_ioc_info *obj);
 void device_info(struct xclmgmt_dev *lro, struct xclmgmt_ioc_info *obj);
 long mgmt_ioctl(struct file *filp, unsigned int cmd, unsigned long arg);
-void get_pcie_link_info(struct xclmgmt_dev *lro,
+void mgmtpf_get_pcie_link_info(struct xclmgmt_dev *lro,
 	unsigned short *width, unsigned short *speed, bool is_cap);
 
 void xclmgmt_connect_notify(struct xclmgmt_dev *lro, bool online);
-void store_pcie_link_info(struct xclmgmt_dev *lro);
+void mgmtpf_store_pcie_link_info(struct xclmgmt_dev *lro);
 
 /* utils.c */
 int pci_fundamental_reset(struct xclmgmt_dev *lro);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-sysfs.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-sysfs.c
@@ -140,7 +140,7 @@ static ssize_t link_speed_show(struct device *dev,
 	unsigned short speed, width;
 	struct xclmgmt_dev *lro = dev_get_drvdata(dev);
 
-	get_pcie_link_info(lro, &width, &speed, false);
+	mgmtpf_get_pcie_link_info(lro, &width, &speed, false);
 	return sprintf(buf, "%d\n", speed);
 }
 static DEVICE_ATTR_RO(link_speed);
@@ -151,7 +151,7 @@ static ssize_t link_width_show(struct device *dev,
 	unsigned short speed, width;
 	struct xclmgmt_dev *lro = dev_get_drvdata(dev);
 
-	get_pcie_link_info(lro, &width, &speed, false);
+	mgmtpf_get_pcie_link_info(lro, &width, &speed, false);
 	return sprintf(buf, "%d\n", width);
 }
 static DEVICE_ATTR_RO(link_width);
@@ -162,7 +162,7 @@ static ssize_t link_speed_max_show(struct device *dev,
 	unsigned short speed, width;
 	struct xclmgmt_dev *lro = dev_get_drvdata(dev);
 
-	get_pcie_link_info(lro, &width, &speed, true);
+	mgmtpf_get_pcie_link_info(lro, &width, &speed, true);
 	return sprintf(buf, "%d\n", speed);
 }
 static DEVICE_ATTR_RO(link_speed_max);
@@ -173,7 +173,7 @@ static ssize_t link_width_max_show(struct device *dev,
 	unsigned short speed, width;
 	struct xclmgmt_dev *lro = dev_get_drvdata(dev);
 
-	get_pcie_link_info(lro, &width, &speed, true);
+	mgmtpf_get_pcie_link_info(lro, &width, &speed, true);
 	return sprintf(buf, "%d\n", width);
 }
 static DEVICE_ATTR_RO(link_width_max);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-utils.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-utils.c
@@ -391,7 +391,7 @@ long xclmgmt_hot_reset(struct xclmgmt_dev *lro, bool force)
 	xocl_thread_start(lro);
 
 	xocl_clear_pci_errors(lro);
-	store_pcie_link_info(lro);
+	mgmtpf_store_pcie_link_info(lro);
 
 	/*
 	 * Update the userspace fdt with the current values in the mgmt driver

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
@@ -159,16 +159,24 @@ int xocl_register_cus(xdev_handle_t xdev_hdl, int slot_hdl, xuid_t *uuid,
 		      struct ip_layout *ip_layout,
 		      struct ps_kernel_node *ps_kernel)
 {
-	struct xocl_dev *xdev = container_of(XDEV(xdev_hdl), struct xocl_dev, core);
-
-	return xocl_kds_register_cus(xdev, slot_hdl, uuid, ip_layout, ps_kernel);
+	struct xocl_dev_core *core_ptr = (struct xocl_dev_core *)xdev_hdl;
+        if (!core_ptr->userpf)  {
+            return 0;
+        } else {	
+		struct xocl_dev *xdev = container_of(XDEV(xdev_hdl), struct xocl_dev, core);
+		return xocl_kds_register_cus(xdev, slot_hdl, uuid, ip_layout, ps_kernel);
+	}
 }
 
 int xocl_unregister_cus(xdev_handle_t xdev_hdl, int slot_hdl)
 {
-	struct xocl_dev *xdev = container_of(XDEV(xdev_hdl), struct xocl_dev, core);
-
-	return xocl_kds_unregister_cus(xdev, slot_hdl);
+	struct xocl_dev_core *core_ptr = (struct xocl_dev_core *)xdev_hdl;
+        if (!core_ptr->userpf)  {
+            return 0;
+        } else {
+		struct xocl_dev *xdev = container_of(XDEV(xdev_hdl), struct xocl_dev, core);
+		return xocl_kds_unregister_cus(xdev, slot_hdl);
+	}
 }
 
 static int userpf_intr_config(xdev_handle_t xdev_hdl, u32 intr, bool en)
@@ -1714,7 +1722,7 @@ int xocl_userpf_probe(struct pci_dev *pdev,
 
 	/* initialize xocl_errors */
 	xocl_init_errors(&xdev->core);
-
+	xdev->core.userpf = true;
 	ret = xocl_subdev_init(xdev, pdev, &userpf_pci_ops);
 	if (ret) {
 		xocl_err(&pdev->dev, "failed to failed to init subdev");

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -396,6 +396,7 @@ struct xocl_pci_info {
 };
 
 extern struct class *xrt_class;
+extern struct class *xrt_class_mgmtpf;
 
 struct drm_xocl_bo;
 struct client_ctx;
@@ -653,6 +654,7 @@ struct xocl_dev_core {
 
 	/* XOCL Should cache some of the information shared in IOCTL */
 	struct xocl_axlf_obj_cache *axlf_obj[MAX_SLOT_SUPPORT];
+	bool			userpf;
 };
 
 #define XOCL_DRM(xdev_hdl)					\


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

To differentiate b/w userpf and mgmtpf module function conflicts, we have added structure variable "xrt_class_mgmt" in a mgmt-core.c file.
Added bool flag "userpf" to differentiate the conflicts between mgmtpf & userpf when register & unregister the module, added one localclass flag to separate between MGMTPF & USERPF functionalities & Basic mgmt module core function as renamed mgmtpf_ prefix

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
