### PR TITLE
elf flow for transaction buffer

### DIFF
--- a/src/runtime_src/core/common/api/module_int.h
+++ b/src/runtime_src/core/common/api/module_int.h
@@ -22,11 +22,11 @@ get_ctrlcode_addr_and_size(const xrt::module& module);
 
 // Patch buffer object into control code at given argument
 void
-patch(const xrt::module&, const std::string& argnm, const xrt::bo& bo);
+patch(const xrt::module&, const std::string& argnm, size_t index, const xrt::bo& bo);
 
 // Patch scalar into control code at given argument
 void
-patch(const xrt::module&, const std::string& argnm, const void* value, size_t size);
+patch(const xrt::module&, const std::string& argnm, size_t index, const void* value, size_t size);
 
 // Check that all arguments have been patched and sync the buffer
 // to device if necessary.  Throw if not all arguments have been


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Transaction buffer does not use CU argument name as patch symbol. Instead it uses argument index as patch symbol. This is different from dpu-sequence. This PR is trying to solve this issue.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
1) Transaction buffer uses different host app code from dpu-sequence. The opcode for transaction buffer is always set when index is 0. This is the first assumption used to solve this issue.
2) Once a transaction buffer opcode is detected, Patcher uses string generated by index to search the patch method.
#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Transaction_buffer_Test is used to test this PR.
#### Documentation impact (if any)
