### PR TITLE
Implementation of read/write mem and reg of xrt::aie::device 

### DIFF
--- a/src/runtime_src/core/common/api/xrt_device.cpp
+++ b/src/runtime_src/core/common/api/xrt_device.cpp
@@ -380,6 +380,25 @@ operator== (const device& d1, const device& d2)
 ////////////////////////////////////////////////////////////////
 namespace xrt::aie {
 
+// User passes column index relative to the partition and context id
+// of that partition. Get patition info using the context id passed and
+// convert relative column index to absolute using this info
+static uint16_t
+get_abs_col(const xrt_core::device* device, uint16_t context_id, uint16_t col)
+{
+  auto data = xrt_core::device_query_default<xrt_core::query::aie_partition_info>(device, {});
+  for (const auto& entry : data) {
+    if (std::stoi(entry.metadata.id) != context_id)
+      continue;
+
+    auto abs_col = col + entry.start_col;
+    if (abs_col >= entry.num_cols)
+      throw std::out_of_range("col index out of range");
+    return abs_col;
+  }
+  throw std::runtime_error("requested context_id not found");
+}
+
 void
 device::
 reset_array()
@@ -396,21 +415,6 @@ open_context(xrt::aie::device::access_mode am)
   core_device->open_aie_context(am);
 }
 
-static void
-get_abs_col(const xrt_core::device* device, uint16_t context_id, uint16_t& col)
-{
-  auto data = xrt_core::device_query_default<xrt_core::query::aie_partition_info>(device, {});
-  for (const auto& entry : data) {
-    if (std::stoi(entry.metadata.id) == context_id) {
-      col += entry.start_col;
-      if (col >= entry.num_cols)
-        throw std::out_of_range("col index out of range");
-      return;
-    }
-  }
-  throw std::runtime_error("requested context_id not found");
-}
-
 std::vector<char>
 device::
 read_aie_mem(uint16_t context_id, uint16_t col, uint16_t row, uint32_t offset, uint32_t size) const
@@ -419,8 +423,8 @@ read_aie_mem(uint16_t context_id, uint16_t col, uint16_t row, uint32_t offset, u
     [this, &col, row, offset, size, context_id] {
       try {
         // calculate absolute col index
-        get_abs_col(get_handle().get(), context_id, col);
-        return get_handle()->read_aie_mem(col, row, offset, size);
+        auto abs_col = get_abs_col(get_handle().get(), context_id, col);
+        return get_handle()->read_aie_mem(abs_col, row, offset, size);
       }
       catch (const xrt_core::query::no_such_key&) {
         throw std::runtime_error("read_aie_mem is not supported on this platform");
@@ -430,14 +434,14 @@ read_aie_mem(uint16_t context_id, uint16_t col, uint16_t row, uint32_t offset, u
 
 size_t
 device::
-write_aie_mem(uint16_t context_id, uint16_t col, uint16_t row, uint32_t offset, std::vector<char>& data)
+write_aie_mem(uint16_t context_id, uint16_t col, uint16_t row, uint32_t offset, const std::vector<char>& data)
 {
   return xdp::native::profiling_wrapper("xrt::aie::device::write_aie_mem",
     [this, &col, row, offset, &data, context_id] {
       try {
         // calculate absolute col index
-        get_abs_col(get_handle().get(), context_id, col);
-        return get_handle()->write_aie_mem(col, row, offset, data);
+        auto abs_col = get_abs_col(get_handle().get(), context_id, col);
+        return get_handle()->write_aie_mem(abs_col, row, offset, data);
       }
       catch (const xrt_core::query::no_such_key&) {
         throw std::runtime_error("write_aie_mem is not supported on this platform");
@@ -452,8 +456,8 @@ read_aie_reg(uint16_t context_id, uint16_t col, uint16_t row, uint32_t reg_addr)
     [this, &col, row, reg_addr, context_id] {
       try {
         // calculate absolute col index
-        get_abs_col(get_handle().get(), context_id, col);;
-        return get_handle()->read_aie_reg(col, row, reg_addr);
+        auto abs_col = get_abs_col(get_handle().get(), context_id, col);
+        return get_handle()->read_aie_reg(abs_col, row, reg_addr);
       }
       catch (const xrt_core::query::no_such_key&) {
         throw std::runtime_error("read_aie_reg is not supported on this platform");
@@ -469,8 +473,8 @@ write_aie_reg(uint16_t context_id, uint16_t col, uint16_t row, uint32_t reg_addr
     [this, &col, row, reg_addr, &reg_val, context_id] {
       try {
         // calculate absolute col index
-        get_abs_col(get_handle().get(), context_id, col);
-        return get_handle()->write_aie_reg(col, row, reg_addr, reg_val);
+        auto abs_col = get_abs_col(get_handle().get(), context_id, col);
+        return get_handle()->write_aie_reg(abs_col, row, reg_addr, reg_val);
       }
       catch (const xrt_core::query::no_such_key&) {
         throw std::runtime_error("write_aie_reg is not supported on this platform");

--- a/src/runtime_src/core/common/ishim.h
+++ b/src/runtime_src/core/common/ishim.h
@@ -268,7 +268,7 @@ struct ishim
   { throw not_supported_error{__func__}; }
 
   virtual size_t
-  write_aie_mem(uint16_t /*col*/, uint16_t /*row*/, uint32_t /*offset*/, std::vector<char>& /*data*/)
+  write_aie_mem(uint16_t /*col*/, uint16_t /*row*/, uint32_t /*offset*/, const std::vector<char>& /*data*/)
   { throw not_supported_error{__func__}; }
 
   virtual uint32_t

--- a/src/runtime_src/core/common/ishim.h
+++ b/src/runtime_src/core/common/ishim.h
@@ -262,6 +262,22 @@ struct ishim
 
   virtual void
   load_axlf_meta(const axlf*) = 0;
+
+  virtual std::vector<char>
+  read_aie_mem(uint16_t /*col*/, uint16_t /*row*/, uint32_t /*offset*/, uint32_t /*size*/)
+  { throw not_supported_error{__func__}; }
+
+  virtual size_t
+  write_aie_mem(uint16_t /*col*/, uint16_t /*row*/, uint32_t /*offset*/, std::vector<char>& /*data*/)
+  { throw not_supported_error{__func__}; }
+
+  virtual uint32_t
+  read_aie_reg(uint16_t /*col*/, uint16_t /*row*/, uint32_t /*reg_addr*/)
+  { throw not_supported_error{__func__}; }
+
+  virtual bool
+  write_aie_reg(uint16_t /*col*/, uint16_t /*row*/, uint32_t /*reg_addr*/, uint32_t /*reg_val*/)
+  { throw not_supported_error{__func__}; }
 #endif
 };
 

--- a/src/runtime_src/core/include/xrt/xrt_aie.h
+++ b/src/runtime_src/core/include/xrt/xrt_aie.h
@@ -132,7 +132,7 @@ public:
    */
   XCL_DRIVER_DLLESPEC
   size_t
-  write_aie_mem(uint16_t context_id, uint16_t col, uint16_t row, uint32_t offset, std::vector<char>& data);
+  write_aie_mem(uint16_t context_id, uint16_t col, uint16_t row, uint32_t offset, const std::vector<char>& data);
 
   /**
    * read_aie_reg() - Read AIE Tile's register

--- a/src/runtime_src/core/include/xrt/xrt_aie.h
+++ b/src/runtime_src/core/include/xrt/xrt_aie.h
@@ -88,7 +88,98 @@ public:
   void
   reset_array();
 
+  /**
+   * read_aie_mem() - Read AIE tile's memory
+   *
+   * @param context_id
+   *  context id corresponding to AIE tile
+   * @param col
+   *  column number of AIE tile
+   * @param row
+   *  row number of AIE tile
+   * @param offset
+   *  memory offset to be read from
+   * @param size
+   *  number of bytes to be read
+   * @return
+   *  vector of bytes read
+   *
+   * This function reads data from L1/L2 memory of AIE tile within a context
+   * ** This function works only in Admin mode **
+   */
+  XCL_DRIVER_DLLESPEC
+  std::vector<char>
+  read_aie_mem(uint16_t context_id, uint16_t col, uint16_t row, uint32_t offset, uint32_t size) const;
+
+  /**
+   * write_aie_mem() - Write data to AIE tile's memory
+   *
+   * @param context_id
+   *  context id corresponding to AIE tile
+   * @param col
+   *  column number of AIE tile
+   * @param row
+   *  row number of AIE tile
+   * @param offset
+   *  memory offset to write
+   * @param data
+   *  vector of bytes to be written
+   * @return
+   *  number of bytes written
+   *
+   * This function writes data to L1/L2 memory of AIE tile within a context
+   * ** This function works only in Admin mode **
+   */
+  XCL_DRIVER_DLLESPEC
+  size_t
+  write_aie_mem(uint16_t context_id, uint16_t col, uint16_t row, uint32_t offset, std::vector<char>& data);
+
+  /**
+   * read_aie_reg() - Read AIE Tile's register
+   *
+   * @param context_id
+   *  context id corresponding to AIE tile
+   * @param col
+   *  column number of AIE tile
+   * @param row
+   *  row number of AIE tile
+   * @param reg_addr
+   *  address offset of register
+   * @return
+   *  register value
+   *
+   * This function reads register of AIE tile within a context
+   * ** This function works only in Admin mode **
+   */
+  XCL_DRIVER_DLLESPEC
+  uint32_t
+  read_aie_reg(uint16_t context_id, uint16_t col, uint16_t row, uint32_t reg_addr) const;
+
+  /**
+   * write_aie_reg() - Write AIE Tile's register
+   *
+   * @param context_id
+   *  context id corresponding to AIE tile
+   * @param col
+   *  column number of AIE tile
+   * @param row
+   *  row number of AIE tile
+   * @param reg_addr
+   *  address offset of register
+   * @param reg_val
+   * value to be written to register
+   * @return
+   *  register value
+   *
+   * This function writes to register of AIE tile within a context
+   * ** This function works only in Admin mode **
+   */
+  XCL_DRIVER_DLLESPEC
+  bool
+  write_aie_reg(uint16_t context_id, uint16_t col, uint16_t row, uint32_t reg_addr, uint32_t reg_val);
+
 private:
+  XCL_DRIVER_DLLESPEC
   void
   open_context(access_mode mode);
 };


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Added new apis for reading/writing AIE memory and registers in xrt::aie::device class

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
#### How problem was solved, alternative solutions (if any) and why they were rejected
Added these new apis in xrt::aie::device class as the functions are related to aie device
These apis can be used only in admin mode
Logic for checking admin/root user will be added in corresponding shim layer that support these apis

#### Risks (if any) associated the changes in the commit
Low as apis work only in admin mode

#### What has been tested and how, request additional testing if necessary
Tested on phoenix class of devices using MCDM flow

#### Documentation impact (if any)
Documented the apis in the function signature