### PR TITLE
enabling rtp updates from alias name also

### DIFF
--- a/src/runtime_src/core/edge/common/aie_parser.cpp
+++ b/src/runtime_src/core/edge/common/aie_parser.cpp
@@ -361,6 +361,7 @@ get_rtp(const pt::ptree& aie_meta, int graph_id)
     rtp.hasLock = rtp_node.second.get<bool>("requires_lock");
 
     rtps[rtp.portName] = rtp;
+    rtps[rtp.aliasName] = rtp;
   }
 
   return rtps;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Customer is asking to provide a mechanism to update the rtp value using port alias also

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
EOU requirement

#### How problem was solved, alternative solutions (if any) and why they were rejected
Provided a mechanism to update the rtp value using port alias also

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Verified multiple rtp tests with alias name

#### Documentation impact (if any)
None