### PR TITLE
VITIS-11806 Break runlist into multiple submissions if necessary

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "src/runtime_src/core/common/elf"]
 	path = src/runtime_src/core/common/elf
 	url = https://github.com/serge1/ELFIO.git
+[submodule "src/runtime_src/core/common/gsl"]
+	path = src/runtime_src/core/common/gsl
+	url = https://github.com/microsoft/GSL.git

--- a/NOTICE
+++ b/NOTICE
@@ -80,3 +80,28 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
+
+XRT userspace includes software from Microsoft Inc.
+
+Copyright (c) 2015 Microsoft Corporation. All rights reserved. 
+
+This code is licensed under the MIT License (MIT). 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy 
+of this software and associated documentation files (the "Software"), to deal 
+in the Software without restriction, including without limitation the rights 
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies 
+of the Software, and to permit persons to whom the Software is furnished to do 
+so, subject to the following conditions: 
+
+The above copyright notice and this permission notice shall be included in all 
+copies or substantial portions of the Software. 
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN 
+THE SOFTWARE. 
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,6 +15,7 @@ include(CMake/unitTestSupport.cmake)
 include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}/runtime_src
   ${CMAKE_CURRENT_SOURCE_DIR}/runtime_src/core/include
+  ${CMAKE_CURRENT_SOURCE_DIR}/runtime_src/core/common/gsl/include
   ${XRT_BINARY_DIR}/gen
   ${XRT_BINARY_DIR}
   )

--- a/src/runtime_src/core/common/api/hw_queue.cpp
+++ b/src/runtime_src/core/common/api/hw_queue.cpp
@@ -639,7 +639,7 @@ public:
   }
 
   void
-  submit(const xrt_core::span<xrt_core::buffer_handle*>& runlist) override
+  submit(const xrt_core::span<xrt_core::buffer_handle*>&) override
   {
     throw std::runtime_error("kds_device::submit(runlist) not implemented");
   }

--- a/src/runtime_src/core/common/api/hw_queue.cpp
+++ b/src/runtime_src/core/common/api/hw_queue.cpp
@@ -362,7 +362,7 @@ public:
 
   // Submit list of commands for execution as atomic unit
   virtual void
-  submit(const xrt::runlist& runlist) = 0;
+  submit(const xrt_core::span<xrt_core::buffer_handle*>& runlist) = 0;
 
   // Submit command for execution
   virtual void
@@ -455,9 +455,9 @@ public:
   }
 
   void
-  submit(const xrt::runlist& runlist) override
+  submit(const xrt_core::span<xrt_core::buffer_handle*>& runlist) override
   {
-    m_qhdl->submit_command(xrt_core::kernel_int::get_runlist_buffer_handles(runlist));
+    m_qhdl->submit_command(runlist);
   }
 
   void
@@ -639,7 +639,7 @@ public:
   }
 
   void
-  submit(const xrt::runlist&) override
+  submit(const xrt_core::span<xrt_core::buffer_handle*>& runlist) override
   {
     throw std::runtime_error("kds_device::submit(runlist) not implemented");
   }
@@ -808,7 +808,7 @@ unmanaged_start(xrt_core::command* cmd)
 
 void
 hw_queue::
-submit(const xrt::runlist& runlist)
+submit(const xrt_core::span<xrt_core::buffer_handle*>& runlist)
 {
   get_handle()->submit(runlist);
 }

--- a/src/runtime_src/core/common/api/hw_queue.h
+++ b/src/runtime_src/core/common/api/hw_queue.h
@@ -9,6 +9,9 @@
 #include "experimental/xrt_fence.h"
 #include "experimental/xrt_kernel.h"
 
+#include "core/common/span.h"
+#include "core/common/shim/buffer_handle.h"
+
 #include <chrono>
 #include <condition_variable>
 #include <vector>
@@ -56,7 +59,7 @@ public:
 
   // Submit a runlist for execution
   void
-  submit(const xrt::runlist& runlist);
+  submit(const xrt_core::span<xrt_core::buffer_handle*>& runlist);
 
   // Wait for command completion.  Supports both managed and unmanaged
   // commands.

--- a/src/runtime_src/core/common/api/kernel_int.h
+++ b/src/runtime_src/core/common/api/kernel_int.h
@@ -92,10 +92,6 @@ get_hw_ctx(const xrt::kernel& kernel);
 xrt::kernel
 create_kernel_from_implementation(const xrt::kernel_impl* kernel_impl);
 
-// Get the exec buffers associated with a runlist
-const std::vector<xrt_core::buffer_handle*>&
-get_runlist_buffer_handles(const xrt::runlist& runlist);
-
 }} // kernel_int, xrt_core
 
 #endif

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -2957,7 +2957,7 @@ class runlist_impl
       if (status == std::cv_status::timeout)
         return status;
     }
-    catch (const xrt::run::command_error& ex) {
+    catch (const xrt::run::command_error&) {
       // errors are picked up by caller, here just change state
       m_state = state::error;
     }

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -2913,7 +2913,7 @@ public:
 // class runlist_impl - The internals of a runlist
 class runlist_impl
 {
-  static constexpr size_t submit_size = 25;
+  static constexpr size_t submit_size = 24;
   static constexpr size_t noidx = std::numeric_limits<size_t>::max();
 
   enum class state { idle, closed, running, error };

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -2913,12 +2913,16 @@ public:
 // class runlist_impl - The internals of a runlist
 class runlist_impl
 {
+  static constexpr size_t submit_size = 25;
+  static constexpr size_t noidx = std::numeric_limits<size_t>::max();
+
   enum class state { idle, closed, running, error };
-  state m_state = state::idle;
+  mutable state m_state = state::idle;
   xrt::hw_context m_hwctx;
   xrt_core::hw_queue m_hwqueue;
   std::vector<xrt::run> m_runlist;
   std::vector<xrt_core::buffer_handle*> m_bos;
+  size_t m_last_submitted_idx = noidx;
 
   static const std::string&
   state_to_string(state st)
@@ -2927,24 +2931,105 @@ class runlist_impl
       { state::idle,   "idle" },
       { state::closed, "closed" },
       { state::running,"running" },
-      { state::error,   "error" }
+      { state::error,  "error" }
     };
     return st2str.at(st);
   }
 
-public:
-  // Internal accessor during command list submission
-  const std::vector<xrt_core::buffer_handle*>&
-  get_exec_bos() const
+  void
+  abort_runs(size_t start, size_t end) const
   {
-    // Allow exec bo access only as part of submission
-    // The runlist must have been closed.
-    if (m_state != state::closed)
-      throw std::runtime_error("internal error: wrong state: " + state_to_string(m_state));
-
-    return m_bos;
+    for (size_t idx = start; idx < end; ++idx)
+      m_runlist.at(idx).get_ert_packet()->state = ERT_CMD_STATE_ABORT;
   }
 
+  std::cv_status
+  wait_last_run(const std::chrono::milliseconds& timeout) const
+  {
+    // In case all submission failed
+    if (m_last_submitted_idx == noidx)
+      return std::cv_status::no_timeout;
+
+    auto last_run = m_runlist[m_last_submitted_idx];
+
+    try {
+      auto status = last_run.wait2(timeout);
+      if (status == std::cv_status::timeout)
+        return status;
+    }
+    catch (const xrt::run::command_error& ex) {
+      // errors are picked up by caller, here just change state
+      m_state = state::error;
+    }
+
+    return std::cv_status::no_timeout;
+  }
+
+  size_t
+  find_first_error(size_t start, size_t end) const
+  {
+    for (size_t idx = start; idx < end; ++idx) {
+      auto& run = m_runlist.at(idx);
+      if (auto state = run.state(); state != ERT_CMD_STATE_COMPLETED)
+        return idx;
+    }
+
+    throw xrt_core::error("internal error: no run with error found");
+  }
+
+  std::cv_status
+  wait(const std::chrono::milliseconds& timeout) const
+  {
+    // Wait on very last command that was submitted; this implies all
+    // have finished.
+    if (wait_last_run(timeout) == std::cv_status::timeout)
+      return std::cv_status::timeout;
+
+    // All commands have either have completed (error or not), or they
+    // have not been submitted. If any command failed to complete
+    // successfully, then all subsequent commands are marked aborted
+    // including any unsubmitted commands.
+    for (size_t idx = 0; idx < m_runlist.size(); idx += submit_size) {
+      auto count = std::min(submit_size, m_bos.size() - idx);
+      auto last_idx = idx + count - 1;
+      auto last_run = m_runlist.at(last_idx);
+
+      // If all good, continue to next chunk
+      if (last_run.state() == ERT_CMD_STATE_COMPLETED)
+        continue;
+
+      // First failed run index starting at this chunk
+      auto first_error_idx = find_first_error(idx, last_idx);
+
+      // Mark all subsequent commands as aborted. The state of
+      // the first incomplete run is not changed.
+      abort_runs(first_error_idx + 1, m_runlist.size());
+
+      // Throw command error for first failed command
+      auto run = m_runlist.at(first_error_idx);
+      throw xrt::runlist::command_error(run, run.state(), "runlist failed execution");
+    }
+
+    return std::cv_status::no_timeout;
+  }
+
+  void
+  submit()
+  {
+    // Submit runlist in chunks of submit size.  Make a note of last
+    // submitted command, in case of submit failure at least the last
+    // command must be waited for before the list can be reset
+    // Pre-condition ensured by execute() is that size of runlist > 0
+    m_last_submitted_idx = noidx;
+    xrt_core::span<xrt_core::buffer_handle*> bos {m_bos};
+    for (size_t idx = 0; idx < m_bos.size(); idx += submit_size) {
+      auto count = std::min(submit_size, m_bos.size() - idx);
+      m_hwqueue.submit(bos.subspan(idx, count));
+      m_last_submitted_idx = idx + count - 1; // pre-cond safe
+    }
+  }
+
+public:
   void
   clear_runs() const
   {
@@ -2975,7 +3060,6 @@ public:
   {
     if (m_state != state::idle)
       throw xrt_core::error("runlist must be idle before adding run objects, current state: " + state_to_string(m_state));
-
 
     // Get the potentially throwing action out of the way first
     m_runlist.reserve(m_runlist.size() + 1);
@@ -3014,9 +3098,18 @@ public:
     // Close the command list.
     m_state = state::closed;
 
-    // Submit
-    m_hwqueue.submit(rl);
-
+    try {
+      submit();
+    }
+    catch (const std::exception&) {
+      // Treat submit error as if the runlist is running.  This forces
+      // the user to call wait() even as submit() throws.  The burden
+      // is on application to handle the error properly while at least
+      // giving some hint as to where things failed.
+      m_state = state::running;
+      throw;
+    }
+        
     // The command list is now submitted (running).  It cannot be reset
     // until wait() has been called and state changed to idle or error.
     m_state = state::running;
@@ -3028,37 +3121,19 @@ public:
     if (m_state != state::running)
       return std::cv_status::no_timeout;
 
-    if (m_state == state::error)
-      throw xrt_core::error("runlist is in error state and must be reset");
+    if (wait(timeout) == std::cv_status::no_timeout)
+      m_state = state::idle;
 
-    // Wait on last submitted command
-    auto last = m_runlist.back();
-
-    try {
-      auto status = last.wait2(timeout);
-      if (status == std::cv_status::no_timeout)
-        m_state = state::idle;
-
-      return status;
-    }
-    catch (const xrt::run::command_error& ex) {
-      // The runlist is in error state and must be reset before reuse.
-      m_state = state::error;
-
-      // Find first run with error
-      for (auto& run : m_runlist)
-        if (auto state = run.get_handle()->state(); state != ERT_CMD_STATE_COMPLETED)
-          throw xrt::runlist::command_error(run, state, ex.what());
-
-      throw xrt_core::error("internal error: no run with error found");
-    }
+    return std::cv_status::no_timeout;
   }
 
   void
   reset()
   {
     if (m_state == state::running)
-      throw xrt_core::error("runlist is submitted for execution and cannot be reset");
+      throw xrt_core::error("The runlist is submitted for execution and cannot be reset. "
+                            "Please use wait() to ensure that all commands have completed "
+                            "before calling reset().");
 
     clear_runs();
 
@@ -3437,12 +3512,6 @@ create_kernel_from_implementation(const xrt::kernel_impl* kernel_impl)
     throw std::runtime_error("Invalid kernel context implementation."); 
 
   return xrt::kernel(const_cast<xrt::kernel_impl*>(kernel_impl)->get_shared_ptr()); // NOLINT
-}
-
-const std::vector<xrt_core::buffer_handle*>&
-get_runlist_buffer_handles(const xrt::runlist& runlist)
-{
-  return runlist.get_handle()->get_exec_bos();
 }
 
 } // xrt_core::kernel_int

--- a/src/runtime_src/core/common/shim/hwqueue_handle.h
+++ b/src/runtime_src/core/common/shim/hwqueue_handle.h
@@ -6,6 +6,8 @@
 #include "buffer_handle.h"
 #include "fence_handle.h"
 
+#include "core/common/span.h"
+
 #include <cstdint>
 #include <memory>
 #include <stdexcept>
@@ -30,7 +32,7 @@ public:
 
   // Submit command list for execution
   virtual void
-  submit_command(const std::vector<buffer_handle*>&)
+  submit_command(const xrt_core::span<buffer_handle*>&)
   {
     throw std::runtime_error("not supported");
   }

--- a/src/runtime_src/core/common/span.h
+++ b/src/runtime_src/core/common/span.h
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+#ifndef xrtcore_span_h_
+#define xrtcore_span_h_
+
+#include <gsl/span>
+
+namespace xrt_core {
+template <typename T>
+using span = gsl::span<T>;
+}
+
+#endif

--- a/src/runtime_src/core/include/experimental/xrt_kernel.h
+++ b/src/runtime_src/core/include/experimental/xrt_kernel.h
@@ -113,6 +113,13 @@ public:
    * not executing when this method is called.  This can be done by
    * calling the wait() method on the runlist object.
    *
+   * The state of run objects in a runlist should be ignored.  The
+   * `xrt::run::state()` function is not guaranteed to reflect the
+   * actual run object state and cannot be called for run objects that
+   * are part of a runlist. If any run object fails to complete
+   * successfully, `xrt::runlist::wait()` will throw an exception with
+   * the failed run object and it's fail state.
+   *
    * Throws if the kernel from which the run object was created does
    * not match the hwctx from which the runlist was created.
    *
@@ -151,10 +158,10 @@ public:
    *  prior to all run objects completing.
    *
    * Completion of a runlist execution means that all run objects have
-   * completed succesfully with ERT_CMD_STATE_COMPLETED.  If any run
-   * object in the list fails to complete successfully, the function
-   * throws `xrt::runlist::command_error` with the failed run object
-   * and state.
+   * completed succesfully.  If any run object in the list fails to
+   * complete successfully, the function throws
+   * `xrt::runlist::command_error` with the failed run object and
+   * state.
    */
   XRT_API_EXPORT
   std::cv_status


### PR DESCRIPTION
#### Problem solved by the commit
Break an xrt::runlist into multiple submissions of max fixed size.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Device supports only fixed number of chained commands, so logic is
moved to XRT coreutil to break a runlist into multiple chunks.

#### How problem was solved, alternative solutions (if any) and why they were rejected
The internal hwqueue API for runlist submission is changed to take a
std::span of buffer_handles rather than a vector.  This allows for
easier / cheaper submission as it avoids creating a new vector
every time a chunk is submitted.

To leverage std::span on compilers that do not yet support this, XRT
now includes Microsoft GSL (Guidelines Support Library) as a
submodule.  This library comes with gsl::span which we use until
std::span is supported by all compilers (c++20).


#### Risks (if any) associated the changes in the commit
xrt::runlist is not yet used, so no immediate risk.
This code is more complicated than it should be.  To be revisited.

#### What has been tested and how, request additional testing if necessary
Tested by debugging simple example with multiple run objects in a runlist.  
Induced error via debugger.
