### PR TITLE
Remove leftover link dependencies on boost

### DIFF
--- a/src/runtime_src/core/common/CMakeLists.txt
+++ b/src/runtime_src/core/common/CMakeLists.txt
@@ -69,22 +69,6 @@ set_target_properties(xrt_coreutil PROPERTIES
   SOVERSION ${XRT_SOVERSION}
   )
 
-# Private dependencies for fully resolved dynamic xrt_coreutil
-target_link_libraries(xrt_coreutil
-  PRIVATE
-  ${Boost_SYSTEM_LIBRARY}
-  )
-
-# Targets linking with xrt_coreutil_static must also link with boost
-# libraries used by coreutil.  These type of link dependencies are
-# known as INTERFACE dependencies.  Here the libraries are specified
-# by their system name so that static of target can pick static link
-# libraries of boost
-target_link_libraries(xrt_coreutil_static
-  INTERFACE
-  boost_system
-  )
-
 if (NOT WIN32)
   # Additional link dependencies for xrt_coreutil
   # xrt_uuid.h depends on uuid

--- a/src/runtime_src/core/edge/common_em/CMakeLists.txt
+++ b/src/runtime_src/core/edge/common_em/CMakeLists.txt
@@ -17,7 +17,6 @@ PROTOBUF_GENERATE_CPP(ProtoSources ProtoHeaders ${PROTO_SRC_FILES})
 
 include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}
-  ${BOOST_SYSTEM_INCLUDE_DIRS}
   )
 
 add_custom_target(edge_emulation_generated_code DEPENDS ${ProtoSources} ${ProtoHeaders})
@@ -48,7 +47,6 @@ set_target_properties(common_em PROPERTIES VERSION ${XRT_VERSION_STRING}
 
 target_link_libraries(common_em
   PRIVATE
-  ${Boost_SYSTEM_LIBRARY}
   ${PROTOBUF_LIBRARY}
   xrt_coreutil
   dl

--- a/src/runtime_src/core/edge/hw_emu/CMakeLists.txt
+++ b/src/runtime_src/core/edge/hw_emu/CMakeLists.txt
@@ -11,7 +11,6 @@ include_directories(
   ${EM_SRC_DIR}
   ${DRM_INCLUDE_DIRS}
   ${COMMON_EM_SRC_DIR}
-  ${BOOST_SYSTEM_INCLUDE_DIRS}
   ${CMAKE_BINARY_DIR} # includes version.h
   )
 
@@ -83,7 +82,6 @@ if (DEFINED XRT_AIE_BUILD)
     rt
     dl
     uuid
-    ${Boost_SYSTEM_LIBRARY}
     xaiengine
     )
 else()
@@ -94,7 +92,6 @@ else()
     rt
     dl
     uuid
-    ${Boost_SYSTEM_LIBRARY}
   )
 endif()
 

--- a/src/runtime_src/core/edge/skd/CMakeLists.txt
+++ b/src/runtime_src/core/edge/skd/CMakeLists.txt
@@ -6,7 +6,6 @@ pkg_check_modules(LIBFFI REQUIRED libffi)
 find_package(libffi REQUIRED)
 
 include_directories(
-  ${BOOST_SYSTEM_INCLUDE_DIRS}
   ${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_CURRENT_SOURCE_DIR}/../include
   ${LIBFFI_INCLUDE_DIR}
@@ -31,7 +30,6 @@ add_dependencies(skd
 
 target_link_libraries(skd
   PRIVATE
-  ${Boost_SYSTEM_LIBRARY}
   xrt_core
   xrt_coreutil
   dl

--- a/src/runtime_src/core/edge/sw_emu/CMakeLists.txt
+++ b/src/runtime_src/core/edge/sw_emu/CMakeLists.txt
@@ -15,7 +15,6 @@ include_directories(
   ${COMMON_SRC_DIR}
   ${COMMON_EM_SRC_DIR}
   ${COMMON_EM_GEN_DIR}
-  ${BOOST_SYSTEM_INCLUDE_DIRS}
   )
 
 
@@ -48,7 +47,6 @@ set_target_properties(xrt_swemu PROPERTIES VERSION ${XRT_VERSION_STRING}
 
 target_link_libraries(xrt_swemu
   PRIVATE
-  ${Boost_SYSTEM_LIBRARY}
   ${PROTOBUF_LIBRARY}
   xrt_coreutil
   common_em

--- a/src/runtime_src/core/edge/user/CMakeLists.txt
+++ b/src/runtime_src/core/edge/user/CMakeLists.txt
@@ -73,7 +73,6 @@ if (DEFINED XRT_AIE_BUILD)
     rt
     dl
     uuid
-    ${Boost_SYSTEM_LIBRARY}
     xaiengine
     )
 else()
@@ -84,7 +83,6 @@ else()
     rt
     dl
     uuid
-    ${Boost_SYSTEM_LIBRARY}
     )
 
 endif()

--- a/src/runtime_src/core/edge/user/system_linux.cpp
+++ b/src/runtime_src/core/edge/user/system_linux.cpp
@@ -107,11 +107,8 @@ get_total_devices(bool is_user) const
 
 void
 system_linux::
-scan_devices(bool verbose, bool json) const
+scan_devices(bool /*verbose*/, bool /*json*/) const
 {
-  std::cout << "TO-DO: scan_devices\n";
-  verbose = verbose;
-  json = json;
 }
 
 std::shared_ptr<device>

--- a/src/runtime_src/core/pcie/emulation/common_em/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/emulation/common_em/CMakeLists.txt
@@ -17,7 +17,6 @@ PROTOBUF_GENERATE_CPP(ProtoSources ProtoHeaders ${PROTO_SRC_FILES})
 
 include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}
-  ${BOOST_SYSTEM_INCLUDE_DIRS}
   )
 
 add_custom_target(pcie_emulation_generated_code DEPENDS ${ProtoSources} ${ProtoHeaders})
@@ -41,7 +40,6 @@ set_target_properties(common_em PROPERTIES VERSION ${XRT_VERSION_STRING}
 
 target_link_libraries(common_em
   PRIVATE
-  ${Boost_SYSTEM_LIBRARY}
   ${PROTOBUF_LIBRARY}
   xrt_coreutil
   dl

--- a/src/runtime_src/core/pcie/emulation/hw_emu/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/emulation/hw_emu/CMakeLists.txt
@@ -11,7 +11,6 @@ include_directories(
   ${EM_SRC_DIR}
   ${COMMON_EM_SRC_DIR}
   ${COMMON_EM_GEN_DIR}
-  ${BOOST_SYSTEM_INCLUDE_DIRS}
   )
 
 file(GLOB EM_SRC_FILES
@@ -45,7 +44,6 @@ set_target_properties(xrt_hwemu PROPERTIES VERSION ${XRT_VERSION_STRING}
 
 target_link_libraries(xrt_hwemu
   PRIVATE
-  ${Boost_SYSTEM_LIBRARY}
   ${PROTOBUF_LIBRARY}
   xrt_coreutil
   common_em
@@ -55,7 +53,6 @@ target_link_libraries(xrt_hwemu
 
 target_link_libraries(xrt_hwemu_static
   INTERFACE
-  boost_system
   ${PROTOBUF_LIBRARY}
   xrt_coreutil_static
   rt

--- a/src/runtime_src/core/pcie/emulation/hw_emu/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/emulation/hw_emu/CMakeLists.txt
@@ -44,6 +44,7 @@ set_target_properties(xrt_hwemu PROPERTIES VERSION ${XRT_VERSION_STRING}
 
 target_link_libraries(xrt_hwemu
   PRIVATE
+  ${Boost_SYSTEM_LIBRARY}
   ${PROTOBUF_LIBRARY}
   xrt_coreutil
   common_em
@@ -53,6 +54,7 @@ target_link_libraries(xrt_hwemu
 
 target_link_libraries(xrt_hwemu_static
   INTERFACE
+  boost_system
   ${PROTOBUF_LIBRARY}
   xrt_coreutil_static
   rt

--- a/src/runtime_src/core/pcie/emulation/sw_emu/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/emulation/sw_emu/CMakeLists.txt
@@ -10,7 +10,6 @@ include_directories(
   ${EM_SRC_DIR}
   ${COMMON_EM_SRC_DIR}
   ${COMMON_EM_GEN_DIR}
-  ${BOOST_SYSTEM_INCLUDE_DIRS}
   )
 
 file(GLOB EM_SRC_FILES
@@ -41,7 +40,6 @@ set_target_properties(xrt_swemu PROPERTIES VERSION ${XRT_VERSION_STRING}
 
 target_link_libraries(xrt_swemu
   PRIVATE
-  ${Boost_SYSTEM_LIBRARY}
   ${PROTOBUF_LIBRARY}
   xrt_coreutil
   common_em
@@ -51,7 +49,6 @@ target_link_libraries(xrt_swemu
 
 target_link_libraries(xrt_swemu_static
   INTERFACE
-  boost_system
   ${PROTOBUF_LIBRARY}
   xrt_coreutil_static
   rt

--- a/src/runtime_src/core/pcie/linux/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/linux/CMakeLists.txt
@@ -47,7 +47,6 @@ set_target_properties(xrt_core PROPERTIES
 target_link_libraries(xrt_core
   PRIVATE
   xrt_coreutil
-  ${Boost_SYSTEM_LIBRARY}
   pthread
   rt
   dl
@@ -62,7 +61,6 @@ target_link_libraries(xrt_core
 target_link_libraries(xrt_core_static
   INTERFACE
   xrt_coreutil_static
-  boost_system
   uuid
   dl
   rt

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/CMakeLists.txt
@@ -22,7 +22,6 @@ target_link_libraries(mpd
   xrt_core_static
   xrt_coreutil_static
   pthread
-  ${Boost_SYSTEM_LIBRARY}
   uuid
   dl
   udev
@@ -46,7 +45,6 @@ target_link_libraries(msd
   xrt_core_static
   xrt_coreutil_static
   pthread
-  ${Boost_SYSTEM_LIBRARY}
   uuid
   dl
   )

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/aws/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/aws/CMakeLists.txt
@@ -40,7 +40,6 @@ if(${INTERNAL_TESTING_FOR_AWS})
     xrt_core_static
     xrt_coreutil_static
     uuid
-    ${Boost_SYSTEM_LIBRARY}
     pthread
     rt
     dl
@@ -54,7 +53,6 @@ else()
     xrt_core_static
     xrt_coreutil_static
     uuid
-    ${Boost_SYSTEM_LIBRARY}
     pthread
     rt
     dl

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/azure/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/azure/CMakeLists.txt
@@ -31,7 +31,6 @@ target_link_libraries(azure_mpd_plugin
   xrt_core_static
   xrt_coreutil_static
   uuid
-  ${Boost_SYSTEM_LIBRARY}
   pthread
   rt
   dl

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/container/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/container/CMakeLists.txt
@@ -25,7 +25,6 @@ target_link_libraries(container_mpd_plugin
   xrt_core_static
   xrt_coreutil_static
   uuid
-  ${Boost_SYSTEM_LIBRARY}
   pthread
   rt
   crypto

--- a/src/runtime_src/xocl/CMakeLists.txt
+++ b/src/runtime_src/xocl/CMakeLists.txt
@@ -60,7 +60,6 @@ target_link_libraries(xilinxopencl
   PRIVATE
   xrt++
   xrt_coreutil
-  ${Boost_SYSTEM_LIBRARY}
   )
 
 else ()
@@ -82,7 +81,6 @@ target_link_libraries(xilinxopencl
   PRIVATE
   xrt++
   xrt_coreutil
-  ${Boost_SYSTEM_LIBRARY}
   dl
   pthread
   crypt


### PR DESCRIPTION
#### Problem solved by the commit
Remove not needed link libraries

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Stray links were left even after we replace boost::filesystem with std::filesystem, these are now removed in this PR.

#### How problem was solved, alternative solutions (if any) and why they were rejected
xbutil2 and xbmgmt2 depend on legacy boost::process which in turn requires boost::filesystem, so these tools still explicitly link with boost.
