### PR TITLE
Fix for CR-1182821: AIE Status was unable to get good data and was ou…

### DIFF
--- a/src/runtime_src/core/edge/user/aie_sys_parser.cpp
+++ b/src/runtime_src/core/edge/user/aie_sys_parser.cpp
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2021 Xilinx, Inc
+ * Copyright (C) 2024 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -20,8 +21,8 @@
 
 #include <filesystem>
 
-std::fstream aie_sys_parser::sysfs_open_path(const std::string& path,
-                                             bool write, bool binary)
+std::fstream
+aie_sys_parser::sysfs_open_path(const std::string& path, bool write, bool binary) const
 {   
     std::fstream fs;
     std::ios::openmode mode = write ? std::ios::out : std::ios::in;
@@ -41,13 +42,14 @@ std::fstream aie_sys_parser::sysfs_open_path(const std::string& path,
     return fs;
 }
 
-std::fstream aie_sys_parser::sysfs_open(const std::string& entry,
-                                        bool write, bool binary)
+std::fstream
+aie_sys_parser::sysfs_open(const std::string& entry, bool write, bool binary) const
 {
     return sysfs_open_path(entry, write, binary);
 }
 
-void aie_sys_parser::sysfs_get(const std::string& entry, std::vector<std::string>& sv)
+void
+aie_sys_parser::sysfs_get(const std::string& entry, std::vector<std::string>& sv) const
 {
     sv.clear();
     std::fstream fs = sysfs_open(entry, false, false);
@@ -88,8 +90,7 @@ Function parse the above input content for given row and column and generate abo
 Input is in non-standard format, where ':', '|', and "," are the delimiters.
 */
 void
-aie_sys_parser::addrecursive(const int col, const int row, const std::string& tag, const std::string& line,
-    boost::property_tree::ptree &pt)
+aie_sys_parser::addrecursive(const int col, const int row, const std::string& tag, const std::string& line, boost::property_tree::ptree &pt) const
 {
     std::string n(tag); 
     boost::property_tree::ptree value;
@@ -144,9 +145,9 @@ aie_sys_parser::addrecursive(const int col, const int row, const std::string& ta
  * If present, reads and parse the content of each sysfs.
  */
 boost::property_tree::ptree
-aie_sys_parser::aie_sys_read(const int col, const int row)
+aie_sys_parser::aie_sys_read(const int col, const int row) const
 {
-    const static std::vector<std::string> tags{"core","dma","lock","errors","event","bd"};
+    const std::vector<std::string> tags{"core","dma","lock","errors","event","bd"};
     std::vector<std::string> data;
     boost::property_tree::ptree pt;
     for(auto& tag:tags) {
@@ -160,13 +161,6 @@ aie_sys_parser::aie_sys_read(const int col, const int row)
     return pt;	
 }
 
-aie_sys_parser *aie_sys_parser::get_parser(const std::string& aiepart)
-{
-    const std::string sroot = "/sys/class/aie/aiepart_" + aiepart + "/";
-    static aie_sys_parser dev(sroot);
-    return &dev;
-}
-
-aie_sys_parser::aie_sys_parser(const std::string& root) : sysfs_root(root)
+aie_sys_parser::aie_sys_parser(const std::string& root) : sysfs_root("sys/class/aie/aiepart_" + root + "/")
 {
 }

--- a/src/runtime_src/core/edge/user/aie_sys_parser.h
+++ b/src/runtime_src/core/edge/user/aie_sys_parser.h
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2021 Xilinx, Inc
+ * Copyright (C) 2024 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -24,20 +25,19 @@
 class aie_sys_parser {
 
 private:
-    std::fstream sysfs_open_path(const std::string& path, bool write, bool binary);
-    std::fstream sysfs_open(const std::string& entry, bool write, bool binary);
-    void sysfs_get(const std::string& entry, std::vector<std::string>& sv);
+    std::fstream sysfs_open_path(const std::string& path, bool write, bool binary) const;
+    std::fstream sysfs_open(const std::string& entry, bool write, bool binary) const;
+    void sysfs_get(const std::string& entry, std::vector<std::string>& sv) const;
     void addrecursive(const int col, const int row, const std::string& tag, const std::string& line,
-                      boost::property_tree::ptree &pt);
+                      boost::property_tree::ptree &pt) const;
 
     std::string sysfs_root;
-    aie_sys_parser(const std::string& sysfs_base);
     aie_sys_parser(const aie_sys_parser& s) = delete;
     aie_sys_parser& operator=(const aie_sys_parser& s) = delete;
 
 public:
-    static aie_sys_parser *get_parser(const std::string& aiepart);
-    boost::property_tree::ptree aie_sys_read(const int col, const int row);
+    aie_sys_parser(const std::string& sysfs_base);
+    boost::property_tree::ptree aie_sys_read(const int col, const int row) const;
 
 };
 

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -141,7 +141,6 @@ shim::
   xdp::aie::finish_flush_device(this);
 #endif
   xdp::aie::ctr::end_poll(this);
-  xdp::aie::sts::end_poll(this);
 
   // The BO cache unmaps and releases all execbo, but this must
   // be done before the device (mKernelFD) is closed.

--- a/src/runtime_src/core/edge/user/zynq_dev.cpp
+++ b/src/runtime_src/core/edge/user/zynq_dev.cpp
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2019-2022 Xilinx, Inc
+ * Copyright (C) 2024 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -20,6 +21,8 @@
 #include <filesystem>
 #include <regex>
 #include "zynq_dev.h"
+
+#include "plugin/xdp/aie_status.h"
 
 static std::fstream sysfs_open_path(const std::string& path, std::string& err,
     bool write, bool binary)
@@ -151,6 +154,11 @@ zynq_device *zynq_device::get_dev()
 
 zynq_device::zynq_device(const std::string& root) : sysfs_root(root)
 {
+}
+
+zynq_device::~zynq_device()
+{
+  xdp::aie::sts::end_poll(nullptr);
 }
 
 std::string

--- a/src/runtime_src/core/edge/user/zynq_dev.h
+++ b/src/runtime_src/core/edge/user/zynq_dev.h
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2019-2022 Xilinx, Inc
+ * Copyright (C) 2024 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -58,6 +59,7 @@ private:
     zynq_device(const std::string& sysfs_base);
     zynq_device(const zynq_device& s) = delete;
     zynq_device& operator=(const zynq_device& s) = delete;
+    ~zynq_device();
 };
 
 std::string get_render_devname();

--- a/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.cpp
@@ -447,7 +447,16 @@ namespace xdp {
     // Last chance at writing status reports
     for (auto w : writers)
       w->write(false, handle);
- 
+
+    // When ending polling for a device, if we are on edge we must instead
+    // shut down all of the threads and not just a single one in order
+    // to avoid race conditions between the zynq driver destructor and our own.
+    //
+    // Currently, Edge is the only supported type of platform so we can
+    // safely end all threads here, but this must be revisited if we extend
+    // AIE status functionality to other types of platforms.
+    endPoll();
+    /* 
     // Ask threads to stop
     mThreadCtrlMap[handle] = false;
 
@@ -468,6 +477,7 @@ namespace xdp {
     }
 
     mThreadCtrlMap.erase(handle);
+    */
   }
 
   void AIEStatusPlugin::endPoll()


### PR DESCRIPTION
…tputting empty files (#8178)

* Fix for CR-1182821.  The issue was race conditions between destructors of global static objects that was exposed with upgrades to petalinux.

Signed-off-by: Jason Villarreal <jvillar@xilinx.com>

* Removing unintentional space

Signed-off-by: Jason Villarreal <jvillar@xilinx.com>

---------

Signed-off-by: Jason Villarreal <jvillar@xilinx.com>
(cherry picked from commit e21cee00bb1ae480f106d80ae9cfaa10bcc3e074)

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
