### PR TITLE
Apply mask to rela->r_addend to get the patching scheme

### DIFF
--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -408,6 +408,11 @@ public:
 // construct patcher objects for each argument.
 class module_elf : public module_impl
 {
+  // rela->addend have offset to base-bo-addr info along with schema
+  // [0:3] bit are used for patching schema, [4:31] used for base-bo-addr
+  constexpr static uint32_t Addend_Shift = 4;
+  constexpr static uint32_t Addend_Mask = ~((uint32_t)0) << Addend_Shift;
+  constexpr static uint32_t Schema_Mask = ~Addend_Mask;
   xrt::elf m_elf;
   uint8_t m_os_abi = Elf_Amd_Aie2p;
   std::vector<ctrlcode> m_ctrlcodes;
@@ -637,7 +642,7 @@ class module_elf : public module_impl
         if (auto search = arg2patchers.find(key_string); search != arg2patchers.end())
           search->second.m_ctrlcode_offset.emplace_back(offset);
         else {
-          auto symbol_type = static_cast<patcher::symbol_type>(rela->r_addend);
+          auto symbol_type = static_cast<patcher::symbol_type>(rela->r_addend & Schema_Mask);
           arg2patchers.emplace(std::move(key_string), patcher{ symbol_type, {offset}, buf_type });
         }
       }

--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -431,9 +431,9 @@ class module_elf : public module_impl
 {
   // rela->addend have offset to base-bo-addr info along with schema
   // [0:3] bit are used for patching schema, [4:31] used for base-bo-addr
-  constexpr static uint32_t Addend_Shift = 4;
-  constexpr static uint32_t Addend_Mask = ~((uint32_t)0) << Addend_Shift;
-  constexpr static uint32_t Schema_Mask = ~Addend_Mask;
+  constexpr static uint32_t addend_shift = 4;
+  constexpr static uint32_t addend_mask = ~((uint32_t)0) << addend_shift;
+  constexpr static uint32_t schema_mask = ~addend_mask;
   xrt::elf m_elf;
   uint8_t m_os_abi = Elf_Amd_Aie2p;
   std::vector<ctrlcode> m_ctrlcodes;
@@ -663,7 +663,7 @@ class module_elf : public module_impl
         if (auto search = arg2patchers.find(key_string); search != arg2patchers.end())
           search->second.m_ctrlcode_offset.emplace_back(offset);
         else {
-          auto symbol_type = static_cast<patcher::symbol_type>(rela->r_addend & Schema_Mask);
+          auto symbol_type = static_cast<patcher::symbol_type>(rela->r_addend & schema_mask);
           arg2patchers.emplace(std::move(key_string), patcher{ symbol_type, {offset}, buf_type });
         }
       }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Current code base uses all 32 bit of the "rela->r_addend" as patching scheme. However, according to spec, only lower 4 bit means patching scheme
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Apply mask to "rela->r_addend", then store it as patching scheme
#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
