### PR TITLE
Enhance tile_type comparator to consider all fields

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info/aie_constructs.h
+++ b/src/runtime_src/xdp/profile/database/static_info/aie_constructs.h
@@ -75,7 +75,15 @@ enum class module_type {
       return (col == tile.col) && (row == tile.row);
     }
     bool operator<(const tile_type &tile) const {
-      return (col < tile.col) || ((col == tile.col) && (row < tile.row));
+      if(col != tile.col) return col<tile.col;
+      if(row != tile.row) return row<tile.row;
+      if(subtype != tile.subtype) return subtype < tile.subtype;
+      if(stream_id != tile.stream_id) return stream_id < tile.stream_id;
+      if(is_master != tile.is_master) return is_master < tile.is_master;
+      if(itr_mem_addr != tile.itr_mem_addr) return itr_mem_addr < tile.itr_mem_addr;
+      if(active_core != tile.active_core) return active_core < tile.active_core;
+      if(active_memory != tile.active_memory) return active_memory < tile.active_memory;
+      return is_trigger < tile.is_trigger;
     }
   };
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
`output_ports_details` isn't listing s2mm channels details in run time event config for one of DPU design on client .

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
It is observed that the same tile (col, row) could be mapped to a different IO types in metadata. Current comparison of `tile_type` was causing collision for keys in map storing `tile_type`  to metric settings.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Enhanced comparator of `struct tile_type` to consider all fields within it. This would make keys unique even if some other fields are varying apart from (col, row).

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
Verified on client that now correct s2mm channels details are emitted.

#### Documentation impact (if any)
