### PR TITLE
Fixed a issue which is causing lsf error

### DIFF
--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -621,8 +621,9 @@ kds_submit_ert(struct kds_sched *kds, struct kds_command *xcmd)
 		return -EINVAL;
 	}
 
-	ert->submit(ert, xcmd);
 	set_xcmd_timestamp(xcmd, KDS_QUEUED);
+	ert->submit(ert, xcmd);
+
 	return 0;
 }
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -2261,6 +2261,8 @@ static int xocl_kds_update_xgq(struct xocl_dev *xdev, int slot_hdl,
 		XDEV(xdev)->kds.ert_disable = true;
 		goto create_regular_cu;
 	}
+        else
+                XDEV(xdev)->kds.ert_disable = false;
 
 	// Soft Kernel Info
 	scu_info = kzalloc(MAX_CUS * sizeof(struct xrt_cu_info), GFP_KERNEL);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

-- Once ert_disable is set for a test case, we are not resetting again. Because of the XGQ allocation/deallocation are not properly maintained.
-- Adding this changes to master. 

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
