### PR TITLE
Fixed ERT firmware packaging issue

### DIFF
--- a/src/runtime_src/ert/CMakeLists.txt
+++ b/src/runtime_src/ert/CMakeLists.txt
@@ -26,7 +26,7 @@ file(GLOB ERTFW_FILES
 message("-- ERT firmare files copied from ${ERTFW_FILES}")
 
 install(FILES
-  ${XRTFW_FILES}
+  ${ERTFW_FILES}
   DESTINATION ${ERT_INSTALL_PREFIX}
   )
 


### PR DESCRIPTION
When proving the user's own `sched*.bin` binaries, the `ERTFW_FILES` variable contains the required ERT firmware files but it is only used in one target firmware location in the target install directory structure. This fix ensure it is also added to the directory expected by the xrt base packages.

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
RPM package created does not contain the sched bin files in /opt/xilinx/xrt/share/fw. This causes the xrt base RPM to fail to build the required XSA shells so they in turn silently fail.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Discovered while trying to set up a Xilinx card with XRT for the first time.
