### PR TITLE
VITIS-12055 Remove PID from aie-partitions report

### DIFF
--- a/src/runtime_src/core/tools/common/reports/ReportAiePartitions.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportAiePartitions.cpp
@@ -30,7 +30,6 @@ populate_aie_partition(const xrt_core::device* device)
     auto partition = pt_map.emplace(std::make_tuple(entry.start_col, entry.num_cols), boost::property_tree::ptree());
 
     boost::property_tree::ptree pt_entry;
-    pt_entry.put("pid", entry.pid);
     pt_entry.put("context_id", entry.metadata.id);
     pt_entry.put("xclbin_uuid", entry.metadata.xclbin_uuid);
     pt_entry.put("command_submissions", entry.command_submissions);
@@ -104,7 +103,6 @@ writeReport(const xrt_core::device* /*_pDevice*/,
     }
 
     const std::vector<Table2D::HeaderData> table_headers = {
-      {"PID", Table2D::Justification::left},
       {"Context ID", Table2D::Justification::left},
       {"Xclbin UUID", Table2D::Justification::left},
       {"Submissions", Table2D::Justification::left},
@@ -121,7 +119,6 @@ writeReport(const xrt_core::device* /*_pDevice*/,
       errors.push_back(hw_context.get<uint64_t>("errors"));
 
       const std::vector<std::string> entry_data = {
-        hw_context.get<std::string>("pid"),
         hw_context.get<std::string>("context_id"),
         hw_context.get<std::string>("xclbin_uuid"),
         hw_context.get<std::string>("command_submissions"),


### PR DESCRIPTION
#### Problem solved by the commit
https://jira.xilinx.com/browse/VITIS-12055
Invalid PID in aie-partitions report
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
PID was negative in aie-partitions report on MCDM
#### How problem was solved, alternative solutions (if any) and why they were rejected
After discussion, it was decided to remove PID until we have an implementation on Windows side. 
#### Risks (if any) associated the changes in the commit
N/A
#### What has been tested and how, request additional testing if necessary
Tested on MCDM/Strix.
```
C:\Users\rchane\Desktop\xilinx\xrt>xbutil examine -r aie-partitions

---------------------
[00c5:00:01.1] : NPU
---------------------
AIE Partitions
  Partition Index: 0
    Columns: [0, 1, 2, 3]
    Errors: 0
    HW Contexts:
      Context ID  Xclbin UUID                             Submissions  Completions  Migrations  Preemptions
      -------------------------------------------------------------------------------------------------------
      15          {4782e00b-8bbc-3db8-9909-d8cd6007d77f}  0            0            0           0
```
#### Documentation impact (if any)
N/A