### PR TITLE
Fix boost library link issue when using static boost

### DIFF
--- a/src/CMake/nativeLnx.cmake
+++ b/src/CMake/nativeLnx.cmake
@@ -108,6 +108,11 @@ if (DEFINED ENV{XRT_BOOST_INSTALL})
     set (Boost_LIBRARY_DIRS $ENV{XRT_BOOST_INSTALL}/lib)
   endif()
 
+  # Targets linked with xrt static libraries on CentOS/RHEL somehow
+  # link with dynamic library of boost_system even when Boost_USE_STATIC_LIBS
+  # is set. So explicitly adding boost install path to linker search paths
+  link_directories($ENV{XRT_BOOST_INSTALL}/lib)
+
 else()
   find_package(Boost
     REQUIRED COMPONENTS system filesystem program_options)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
When using boost static build the package generated still has dependency on boost dynamic library (eg: libboost_system.so)
added changes to fix this issue

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Issue raised by customer

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added boost static libraries path to the search path for libraries using link_directories
This way required static boost library is found when target_link_libraries is used and wrong dependency is not added

Ideal fix would be to remove boost_system dependency as we have moved to std::filesystem and this lib dependency is not needed any more. Same fix has been sent to master. But to keep things simpler going through this route

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
Tested dependencies on xrt packages generated and dependencies are as expected

#### Documentation impact (if any)
NA