### PR TITLE
VITIS-11806 Support runlist submission as chained command objects

### DIFF
--- a/src/runtime_src/core/common/api/CMakeLists.txt
+++ b/src/runtime_src/core/common/api/CMakeLists.txt
@@ -1,5 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+
+# if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+#   find_program(CLANG_TIDY "clang-tidy" HINT /home/stsoe/git-nobkup/llvm-project/build)
+#   if(NOT CLANG_TIDY)
+#     message(WARNING "-- clang-tidy not found, cannot enable static analysis")
+#   else()
+#     message("-- Enabling clang-tidy")
+#     set(CMAKE_CXX_CLANG_TIDY "/home/stsoe/git-nobkup/llvm-project/build/bin/clang-tidy")
+#   endif()
+# endif()
+
 add_library(core_common_api_library_objects OBJECT
   context_mgr.cpp
   hw_queue.cpp

--- a/src/runtime_src/core/common/api/hw_queue.h
+++ b/src/runtime_src/core/common/api/hw_queue.h
@@ -9,7 +9,6 @@
 #include "experimental/xrt_fence.h"
 #include "experimental/xrt_kernel.h"
 
-#include "core/common/span.h"
 #include "core/common/shim/buffer_handle.h"
 
 #include <chrono>
@@ -57,9 +56,13 @@ public:
   void
   unmanaged_start(xrt_core::command* cmd);
 
-  // Submit a runlist for execution
+  // Submit a raw cmd for execution
   void
-  submit(const xrt_core::span<xrt_core::buffer_handle*>& runlist);
+  submit(xrt_core::buffer_handle* cmd);
+
+  // Wait for raw cmd to complete
+  std::cv_status
+  wait(xrt_core::buffer_handle* cmd, const std::chrono::milliseconds& timeout) const;
 
   // Wait for command completion.  Supports both managed and unmanaged
   // commands.
@@ -70,7 +73,7 @@ public:
   // Wait for command completion with timeout.  Supports both managed
   // and unmanaged commands.
   std::cv_status
-  wait(const xrt_core::command* cmd, const std::chrono::milliseconds& timeout_ms) const;
+  wait(const xrt_core::command* cmd, const std::chrono::milliseconds& timeout) const;
 
   // Enqueue a command dependency
   void
@@ -84,7 +87,7 @@ public:
   // some command completing or from a timeout.
   XRT_CORE_COMMON_EXPORT
   static std::cv_status
-  exec_wait(const xrt_core::device* device, const std::chrono::milliseconds& timeout_ms);
+  exec_wait(const xrt_core::device* device, const std::chrono::milliseconds& timeout);
 
   // Cleanup after device object is no longer valid
   // Static data is cached per xrt_core::device object, this function

--- a/src/runtime_src/core/common/bo_cache.h
+++ b/src/runtime_src/core/common/bo_cache.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2019 Xilinx, Inc
-// Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
 
 #ifndef core_common_bo_cache_h_
 #define core_common_bo_cache_h_
@@ -23,7 +23,8 @@ namespace xrt_core {
 
 // Create a cache of CMD BO objects -- for now only used for M2M -- to reduce
 // the overhead of BO life cycle management.
-class bo_cache {
+template <size_t BoSize>
+class bo_cache_t {
 public:
   // Helper typedef for std::pair. Note the elements are const so that the
   // pair is immutable. The clients should not change the contents of cmd_bo.
@@ -34,23 +35,27 @@ private:
   // We are really allocating a page size as that is what xocl/zocl do. Note on
   // POWER9 pagesize maybe more than 4K, xocl would upsize the allocation to the
   // correct pagesize. unmap always unmaps the full page.
-  static const size_t mBOSize = 4096;
-  std::shared_ptr<device> mDevice;
+  static constexpr size_t m_bo_size = BoSize;
+  std::shared_ptr<device> m_device;
   // Maximum number of BOs that can be cached in the pool. Value of 0 indicates
   // caching should be disabled.
-  const unsigned int mCacheMaxSize;
-  std::vector<cmd_bo<void>> mCmdBOCache;
-  std::mutex mCacheMutex;
+  const unsigned int m_cache_max_size;
+  std::vector<cmd_bo<void>> m_cmd_bo_cache;
+  std::mutex m_mutex;
 
 public:
-  bo_cache(xclDeviceHandle handle, unsigned int max_size)
-    : mDevice(get_userpf_device(handle)), mCacheMaxSize(max_size)
+  bo_cache_t(std::shared_ptr<xrt_core::device> device, unsigned int max_size)
+    : m_device(std::move(device)), m_cache_max_size(max_size)
   {}
 
-  ~bo_cache()
+  bo_cache_t(xclDeviceHandle handle, unsigned int max_size)
+    : m_device(get_userpf_device(handle)), m_cache_max_size(max_size)
+  {}
+
+  ~bo_cache_t()
   {
-    std::lock_guard<std::mutex> lock(mCacheMutex);
-    for (auto& bo : mCmdBOCache)
+    std::lock_guard<std::mutex> lock(m_mutex);
+    for (auto& bo : m_cmd_bo_cache)
       destroy(bo);
   }
 
@@ -73,17 +78,17 @@ private:
   cmd_bo<void>
   alloc_impl()
   {
-    if (mCacheMaxSize) {
+    if (m_cache_max_size) {
       // If caching is enabled first look up in the BO cache
-      std::lock_guard<std::mutex> lock(mCacheMutex);
-      if (!mCmdBOCache.empty()) {
-        auto bo = std::move(mCmdBOCache.back());
-        mCmdBOCache.pop_back();
+      std::lock_guard lock(m_mutex);
+      if (!m_cmd_bo_cache.empty()) {
+        auto bo = std::move(m_cmd_bo_cache.back());
+        m_cmd_bo_cache.pop_back();
         return bo;
       }
     }
 
-    auto execHandle = mDevice->alloc_bo(mBOSize, XCL_BO_FLAGS_EXECBUF);
+    auto execHandle = m_device->alloc_bo(m_bo_size, XCL_BO_FLAGS_EXECBUF);
     auto map = execHandle->map(buffer_handle::map_type::write);
     return std::make_pair(std::move(execHandle), map);
   }
@@ -91,11 +96,11 @@ private:
   void
   release_impl(cmd_bo<void>&& bo)
   {
-    if (mCacheMaxSize) {
+    if (m_cache_max_size) {
       // If caching is enabled and BO cache is not fully populated add this the cache
-      std::lock_guard<std::mutex> lock(mCacheMutex);
-      if (mCmdBOCache.size() < mCacheMaxSize) {
-        mCmdBOCache.push_back(std::move(bo));
+      std::lock_guard lock(m_mutex);
+      if (m_cmd_bo_cache.size() < m_cache_max_size) {
+        m_cmd_bo_cache.push_back(std::move(bo));
         return;
       }
     }
@@ -108,6 +113,8 @@ private:
     bo.first->unmap(bo.second);
   }
 };
+
+using bo_cache = bo_cache_t<4096>;
 
 } // xrt_core
 

--- a/src/runtime_src/core/common/shim/buffer_handle.h
+++ b/src/runtime_src/core/common/shim/buffer_handle.h
@@ -33,9 +33,10 @@ public:
   // properties - buffer details
   struct properties
   {
-    uint64_t flags;
-    uint64_t size;
-    uint64_t paddr;
+    uint64_t flags;  // flags of bo
+    uint64_t size;   // size of bo
+    uint64_t paddr;  // physical address
+    uint64_t kmhdl;  // kernel mode handle
   };
 
 public:

--- a/src/runtime_src/core/common/shim/hwqueue_handle.h
+++ b/src/runtime_src/core/common/shim/hwqueue_handle.h
@@ -6,8 +6,6 @@
 #include "buffer_handle.h"
 #include "fence_handle.h"
 
-#include "core/common/span.h"
-
 #include <cstdint>
 #include <memory>
 #include <stdexcept>
@@ -29,13 +27,6 @@ public:
   // Submit command for execution
   virtual void
   submit_command(buffer_handle* cmd) = 0;
-
-  // Submit command list for execution
-  virtual void
-  submit_command(const xrt_core::span<buffer_handle*>&)
-  {
-    throw std::runtime_error("not supported");
-  }
 
   // Wait for command completion.
   //

--- a/src/runtime_src/core/include/ert.h
+++ b/src/runtime_src/core/include/ert.h
@@ -60,7 +60,7 @@
 
 #ifdef _WIN32
 # pragma warning( push )
-# pragma warning( disable : 4201 )
+# pragma warning( disable : 4200 4201 )
 #endif
 
 #if defined(__GNUC__)
@@ -170,6 +170,24 @@ struct ert_dpu_data {
   uint64_t instruction_buffer;       /* buffer address 2 words */
   uint32_t instruction_buffer_size;  /* size of buffer in bytes */
   uint32_t chained;                  /* number of following ert_dpu_data elements */
+};
+
+/**
+ * struct ert_cmd_chain_data - interpretation of data payload for ERT_CMD_CHAIN
+ *
+ * @command_count: number of commands in chain
+ * @submit_index:  index of last successfully submitted command in chain
+ * @error_index:   index of failing command if cmd status is not completed
+ * @data[]:        address of each command in chain
+ *
+ * This is the payload of an *ert_packet* when the opcode is ERT_CMD_CHAIN
+ */
+struct ert_cmd_chain_data {
+  uint32_t command_count;
+  uint32_t submit_index;
+  uint32_t error_index;
+  uint32_t reserved[3];
+  uint64_t data[];
 };
 
 #ifndef U30_DEBUG
@@ -541,6 +559,7 @@ struct cu_cmd_state_timestamps {
  * @ERT_SK_UNCONFIG:    unconfigure a soft kernel
  * @ERT_START_KEY_VAL:  same as ERT_START_CU but with key-value pair flavor
  * @ERT_START_DPU:      instruction buffer command format
+ * @ERT_CMD_CHAIN:      command chain
  */
 enum ert_cmd_opcode {
   ERT_START_CU      = 0,
@@ -562,6 +581,7 @@ enum ert_cmd_opcode {
   ERT_ACCESS_TEST_C = 16,
   ERT_ACCESS_TEST   = 17,
   ERT_START_DPU     = 18,
+  ERT_CMD_CHAIN     = 19,
 };
 
 /**
@@ -870,6 +890,7 @@ ert_valid_opcode(struct ert_packet *pkt)
   struct ert_start_copybo_cmd *sccmd;
   struct ert_configure_cmd *ccmd;
   struct ert_configure_sk_cmd *cscmd;
+  struct ert_cmd_chain_data *ccdata;
   bool valid;
 
   switch (pkt->opcode) {
@@ -882,6 +903,11 @@ ert_valid_opcode(struct ert_packet *pkt)
     skcmd = to_start_krnl_pkg(pkt);
     /* 1 mandatory cumask + extra_cu_masks + size (in words) of ert_dpu_data */
     valid = (skcmd->count >= 1+ skcmd->extra_cu_masks + sizeof(struct ert_dpu_data) / sizeof(uint32_t));
+    break;
+  case ERT_CMD_CHAIN:
+    ccdata = (struct ert_cmd_chain_data*) pkt->data;
+    /* header count must match number of commands in payload */
+    valid = (pkt->count == (ccdata->command_count * sizeof(uint64_t) + sizeof(struct ert_cmd_chain_data)) / sizeof(uint32_t));
     break;
   case ERT_START_KEY_VAL:
     skcmd = to_start_krnl_pkg(pkt);
@@ -961,6 +987,15 @@ get_ert_dpu_data_next(struct ert_dpu_data* dpu_data)
     return NULL;
   
   return dpu_data + 1;
+}
+
+static inline struct ert_cmd_chain_data*
+get_ert_cmd_chain_data(struct ert_packet* pkt)
+{
+  if (pkt->opcode != ERT_CMD_CHAIN)
+    return NULL;
+
+  return (struct ert_cmd_chain_data*) pkt->data;
 }
 
 static inline uint32_t*

--- a/src/runtime_src/core/pcie/linux/shim.h
+++ b/src/runtime_src/core/pcie/linux/shim.h
@@ -7,6 +7,7 @@
 #include "pcidev.h"
 #include "xclhal2.h"
 
+#include "core/common/bo_cache.h"
 #include "core/common/device.h"
 #include "core/common/system.h"
 #include "core/common/xrt_profiling.h"
@@ -28,11 +29,6 @@
 #include <memory>
 #include <mutex>
 #include <vector>
-
-// Forward declaration
-namespace xrt_core {
-    class bo_cache;
-}
 
 namespace xocl {
 


### PR DESCRIPTION
#### Problem solved by the commit
Add new ERT_CMD_CHAIN opcode for chained command submssion of a runlist.  A runlist is broken into multiple chained commands if necessary.

#### How problem was solved, alternative solutions (if any) and why they were rejected
This PR reworks #8171 and replaces disjoint set submission of individual command buffers with submission of a single ert_packet command buffer that chains individual commands.

The chained command is represented as an `ert_packet` where the payload is interpreted as `ert_cmd_chain_data` per ert.h.  The pay holds an array of buffer_handles that are to be submitted atomically for execution.

This chained command submission is somewhat easier to manage and is a step towards supporting command fusing where multiple run objects are stiched together into a single command without managing individual run objects.

This PR also parameterizes bo_cache with the size of bos needed. This is done because runlist will not currently need a 4K buffer for the chained ert packet.  This may change in future when runlist fuses the individual commands.  It is understood that 4K may in fact be the minimum underlying allocation size, but that is unbeknowst to the code that uses the bo cache.

#### Risks (if any) associated the changes in the commit
No immediate risk as runlist use is a new feature

#### What has been tested and how, request additional testing if necessary
Extensive testing through debugger induced error conditions.  Tested on MCDM.

#### Documentation impact (if any)