### PR TITLE
Remove used header include

### DIFF
--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -41,7 +41,6 @@
 #include "core/common/debug.h"
 #include "core/common/error.h"
 #include "core/common/message.h"
-#include "core/common/span.h"
 #include "core/common/system.h"
 #include "core/common/trace.h"
 #include "core/common/usage_metrics.h"


### PR DESCRIPTION
After recent changes in #8194, inclusion of `core/common/span.h` is no longer needed.
