### PR TITLE
Added explicit destructor

### DIFF
--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -1547,6 +1547,10 @@ copy(const bo& src, size_t sz, size_t src_offset, size_t dst_offset)
     });
 }
 
+bo::
+~bo()
+{}
+
 } // xrt
 
 ////////////////////////////////////////////////////////////////

--- a/src/runtime_src/core/common/api/xrt_device.cpp
+++ b/src/runtime_src/core/common/api/xrt_device.cpp
@@ -372,6 +372,10 @@ operator== (const device& d1, const device& d2)
   return d1.get_handle()->get_device_id() == d2.get_handle()->get_device_id();
 }
 
+device::
+~device()
+{}
+
 } // xrt
 
 #ifdef XRT_ENABLE_AIE

--- a/src/runtime_src/core/common/api/xrt_hw_context.cpp
+++ b/src/runtime_src/core/common/api/xrt_hw_context.cpp
@@ -259,4 +259,8 @@ operator xrt_core::hwctx_handle* () const
   return get_handle()->get_hwctx_handle();
 }
 
+hw_context::
+~hw_context()
+{}
+
 } // xrt

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -3792,6 +3792,10 @@ submit_signal(const xrt::fence& fence)
   });
 }
 
+run::
+~run()
+{}
+
 kernel::
 kernel(const xrt::device& xdev, const xrt::uuid& xclbin_id, const std::string& name, cu_access_mode mode)
   : handle(xdp::native::profiling_wrapper("xrt::kernel::kernel",
@@ -3859,6 +3863,10 @@ get_xclbin() const
 {
   return handle->get_xclbin();
 }
+
+kernel::
+~kernel()
+{}
 
 // Experimental API
 // This function defines the read-only register range on a compute unit

--- a/src/runtime_src/core/include/xrt/xrt_bo.h
+++ b/src/runtime_src/core/include/xrt/xrt_bo.h
@@ -723,6 +723,12 @@ public:
     copy(src, src.size());
   }
 
+  /**
+   * ~bo() - Destructor for bo object
+   */
+  XCL_DRIVER_DLLESPEC
+  ~bo();
+
 public:
   /// @cond
   const std::shared_ptr<bo_impl>&

--- a/src/runtime_src/core/include/xrt/xrt_device.h
+++ b/src/runtime_src/core/include/xrt/xrt_device.h
@@ -147,9 +147,10 @@ public:
   device() = default;
 
   /**
-   * device() - Dtor
+   * ~device() - Destructor for device object
    */
-  ~device() = default;
+  XCL_DRIVER_DLLESPEC
+  ~device();
 
   /**
    * device() - Constructor from device index

--- a/src/runtime_src/core/include/xrt/xrt_hw_context.h
+++ b/src/runtime_src/core/include/xrt/xrt_hw_context.h
@@ -77,6 +77,12 @@ public:
   hw_context() = default;
 
   /**
+   * ~hw_context() - Destructor
+   */
+  XCL_DRIVER_DLLESPEC
+  ~hw_context();
+
+  /**
    * hw_context() - Constructor with QoS control
    *
    * @param device

--- a/src/runtime_src/core/include/xrt/xrt_kernel.h
+++ b/src/runtime_src/core/include/xrt/xrt_kernel.h
@@ -131,6 +131,12 @@ public:
   run() = default;
 
   /**
+   * ~run() - Destruct run object
+   */
+  XCL_DRIVER_DLLESPEC
+  ~run();
+
+  /**
    * run() - Construct run object from a kernel object
    *
    * @param krnl: Kernel object representing the kernel to execute
@@ -669,6 +675,12 @@ public:
    * kernel() - Construct for empty kernel
    */
   kernel() = default;
+
+  /**
+   * Destructor for kernel - needed for tracing
+   */
+  XCL_DRIVER_DLLESPEC
+  ~kernel();
 
   /**
    * kernel() - Constructor from a device and xclbin


### PR DESCRIPTION
#### Problem solved by the commit
Added explicit destructor for following classes
  - device
  - bo
  - kernel
  - run
  - hw_context

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
While the destructor body is empty, explicit destructors are needed for tracing where functions
are intercepted before being routed to actual implementation.

#### Risks (if any) associated the changes in the commit
The destructors were previously default compiler generated.   Now they are symbols in the xrt_coreutil library.  For ABI compatibility this is fine as existing binaries will keep utilizing the default inlined destructors.   Only issue is that existing 
application binaries cannot be traced accurately without recompile.


