### PR TITLE
Bug fix in abs column calculation

### DIFF
--- a/src/runtime_src/core/common/api/xrt_device.cpp
+++ b/src/runtime_src/core/common/api/xrt_device.cpp
@@ -392,7 +392,7 @@ get_abs_col(const xrt_core::device* device, uint16_t context_id, uint16_t col)
       continue;
 
     auto abs_col = col + entry.start_col;
-    if (abs_col >= entry.num_cols)
+    if (abs_col >= entry.start_col + entry.num_cols)
       throw std::out_of_range("col index out of range");
     return abs_col;
   }

--- a/src/runtime_src/core/common/api/xrt_device.cpp
+++ b/src/runtime_src/core/common/api/xrt_device.cpp
@@ -400,7 +400,7 @@ get_abs_col(const xrt_core::device* device, uint16_t context_id, uint16_t col)
 }
 
 static void
-is_4byte_aligned(uint32_t offset)
+is_4byte_aligned_or_throw(uint32_t offset)
 {
   if ((offset & 0x3) != 0)
     throw std::runtime_error("address is not 4 byte aligned");
@@ -431,7 +431,7 @@ read_aie_mem(uint16_t context_id, uint16_t col, uint16_t row, uint32_t offset, u
       try {
         // calculate absolute col index
         auto abs_col = get_abs_col(get_handle().get(), context_id, col);
-        is_4byte_aligned(offset); // DRC check
+        is_4byte_aligned_or_throw(offset); // DRC check
         return get_handle()->read_aie_mem(abs_col, row, offset, size);
       }
       catch (const xrt_core::query::no_such_key&) {
@@ -449,7 +449,7 @@ write_aie_mem(uint16_t context_id, uint16_t col, uint16_t row, uint32_t offset, 
       try {
         // calculate absolute col index
         auto abs_col = get_abs_col(get_handle().get(), context_id, col);
-        is_4byte_aligned(offset); // DRC check
+        is_4byte_aligned_or_throw(offset); // DRC check
         return get_handle()->write_aie_mem(abs_col, row, offset, data);
       }
       catch (const xrt_core::query::no_such_key&) {
@@ -466,7 +466,7 @@ read_aie_reg(uint16_t context_id, uint16_t col, uint16_t row, uint32_t reg_addr)
       try {
         // calculate absolute col index
         auto abs_col = get_abs_col(get_handle().get(), context_id, col);
-        is_4byte_aligned(reg_addr); // DRC check
+        is_4byte_aligned_or_throw(reg_addr); // DRC check
         return get_handle()->read_aie_reg(abs_col, row, reg_addr);
       }
       catch (const xrt_core::query::no_such_key&) {
@@ -484,7 +484,7 @@ write_aie_reg(uint16_t context_id, uint16_t col, uint16_t row, uint32_t reg_addr
       try {
         // calculate absolute col index
         auto abs_col = get_abs_col(get_handle().get(), context_id, col);
-        is_4byte_aligned(reg_addr); // DRC check
+        is_4byte_aligned_or_throw(reg_addr); // DRC check
         return get_handle()->write_aie_reg(abs_col, row, reg_addr, reg_val);
       }
       catch (const xrt_core::query::no_such_key&) {

--- a/src/runtime_src/core/common/api/xrt_device.cpp
+++ b/src/runtime_src/core/common/api/xrt_device.cpp
@@ -399,6 +399,13 @@ get_abs_col(const xrt_core::device* device, uint16_t context_id, uint16_t col)
   throw std::runtime_error("requested context_id not found");
 }
 
+static void
+is_4byte_aligned(uint32_t offset)
+{
+  if ((offset & 0x3) != 0)
+    throw std::runtime_error("address is not 4 byte aligned");
+}
+
 void
 device::
 reset_array()
@@ -424,6 +431,7 @@ read_aie_mem(uint16_t context_id, uint16_t col, uint16_t row, uint32_t offset, u
       try {
         // calculate absolute col index
         auto abs_col = get_abs_col(get_handle().get(), context_id, col);
+        is_4byte_aligned(offset); // DRC check
         return get_handle()->read_aie_mem(abs_col, row, offset, size);
       }
       catch (const xrt_core::query::no_such_key&) {
@@ -441,6 +449,7 @@ write_aie_mem(uint16_t context_id, uint16_t col, uint16_t row, uint32_t offset, 
       try {
         // calculate absolute col index
         auto abs_col = get_abs_col(get_handle().get(), context_id, col);
+        is_4byte_aligned(offset); // DRC check
         return get_handle()->write_aie_mem(abs_col, row, offset, data);
       }
       catch (const xrt_core::query::no_such_key&) {
@@ -457,6 +466,7 @@ read_aie_reg(uint16_t context_id, uint16_t col, uint16_t row, uint32_t reg_addr)
       try {
         // calculate absolute col index
         auto abs_col = get_abs_col(get_handle().get(), context_id, col);
+        is_4byte_aligned(reg_addr); // DRC check
         return get_handle()->read_aie_reg(abs_col, row, reg_addr);
       }
       catch (const xrt_core::query::no_such_key&) {
@@ -474,6 +484,7 @@ write_aie_reg(uint16_t context_id, uint16_t col, uint16_t row, uint32_t reg_addr
       try {
         // calculate absolute col index
         auto abs_col = get_abs_col(get_handle().get(), context_id, col);
+        is_4byte_aligned(reg_addr); // DRC check
         return get_handle()->write_aie_reg(abs_col, row, reg_addr, reg_val);
       }
       catch (const xrt_core::query::no_such_key&) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Fixed bug in validating abs column calculated
Added check in apis to throw when address provided is not 4 bytes aligned

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
pr - https://github.com/Xilinx/XRT/pull/8166 added wrong check

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
Tested by running local application with aie read/write apis and test works as expected

#### Documentation impact (if any)
NA