### PR TITLE
Minor changes in boost.sh script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,11 @@ build/Debug*
 build/WDebug*
 build/Release*
 build/WRelease*
+build/aarch64
+build/versal
+build/deb_arm32
+build/deb_arm64
+build/boost
 docs/.buildinfo
 docs/.doctrees
 tests/xrt/build/Debug*
@@ -23,4 +28,5 @@ a.out
 a.xclbin
 vivado.log
 vivado.jou
-/.vs
+.vs
+.vscode


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Made minor changes in boost.sh script
> By default boost repo cloning and build will happen in <xrt>/build folder if no prefix is specified
> Added changes in .gitignore to ignore the folder created by this script
> using c++17 standard for boost build
> added force option to have non interactive mode

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
#### How problem was solved, alternative solutions (if any) and why they were rejected
#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
Using boost.sh built boost statically and used this boost in compiling xrt source code and build passes

#### Documentation impact (if any)
NA