### PR TITLE
Bug fix in getting AIE clock frequency using xbutil advanced.

### DIFF
--- a/src/runtime_src/core/tools/xbutil2/OO_AieClockFreq.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_AieClockFreq.cpp
@@ -118,8 +118,8 @@ OO_AieClockFreq::execute(const SubCmdOptions& _options) const
   po::variables_map vm;
   process_arguments(vm, _options);
 
-  // Exit if neither action or device specified
-  if(m_help || m_device.empty()) {
+  // Exit if action is specified
+  if(m_help) {
     printHelp();
     return;
   }

--- a/src/runtime_src/core/tools/xbutil2/OO_AieRegRead.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_AieRegRead.cpp
@@ -413,8 +413,8 @@ OO_AieRegRead::execute(const SubCmdOptions& _options) const
   po::variables_map vm;
   process_arguments(vm, _options);
 
-  // Exit if neither action or device specified
-  if(m_help || m_device.empty()) {
+  // Exit if action is specified
+  if(m_help) {
     printHelp();
     return;
   }

--- a/src/runtime_src/core/tools/xbutil2/SubCmdAdvanced.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdAdvanced.cpp
@@ -44,7 +44,6 @@ SubCmdAdvanced::SubCmdAdvanced(bool _isHidden, bool _isDepricated, bool _isPreli
   setIsPreliminary(_isPreliminary);
 
   m_commonOptions.add_options()
-    ("device,d", boost::program_options::value<decltype(m_device)>(&m_device), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest")
     ("help", boost::program_options::bool_switch(&m_help), "Help to use this sub-command")
   ;
 
@@ -77,7 +76,7 @@ SubCmdAdvanced::execute(const SubCmdOptions& _options) const
 
   // No suboption print help
   if (!optionOption) {
-    printHelp(false, "", XBU::get_device_class(m_device, true));
+    printHelp();
     return;
   }
 

--- a/src/runtime_src/core/tools/xbutil2/SubCmdAdvanced.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdAdvanced.h
@@ -17,7 +17,6 @@ class SubCmdAdvanced : public SubCmd {
 
   private:
     bool m_help;
-    std::string m_device;
 };
 
 #endif


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
[CR-1197325](https://jira.xilinx.com/browse/CR-1197325) getting/setting AIE clock frequency is an suboption in the of xbutil advanced command. xbutil advanced --aie-clock -g is always hitting the printHelp() function as it is m_device as an empty string.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
#### How problem was solved, alternative solutions (if any) and why they were rejected
Removed m_device as it's mentioned in both options and sub options.

#### Risks (if any) associated the changes in the commit
NA

#### What has been tested and how, request additional testing if necessary
Teseted with VCK190.

#### Documentation impact (if any)
NA