### PR TITLE
Always set chained in struct ert_dpu_data as 0 for aie2p

### DIFF
--- a/src/runtime_src/core/common/api/module_int.h
+++ b/src/runtime_src/core/common/api/module_int.h
@@ -14,7 +14,7 @@
 
 namespace xrt_core::module_int {
 
-void
+uint32_t*
 fill_ert_dpu_data(const xrt::module& module, uint32_t* payload);
 
 

--- a/src/runtime_src/core/common/api/module_int.h
+++ b/src/runtime_src/core/common/api/module_int.h
@@ -19,6 +19,12 @@ namespace xrt_core::module_int {
 const std::vector<std::pair<uint64_t, uint64_t>>&
 get_ctrlcode_addr_and_size(const xrt::module& module);
 
+static constexpr uint8_t elf_amd_aie2p = 69;
+static constexpr uint8_t elf_amd_aie2ps = 64;
+
+// Return control code type such as aie2p or aie2ps
+const uint8_t
+get_os_abi(const xrt::module& module);
 
 // Patch buffer object into control code at given argument
 void

--- a/src/runtime_src/core/common/api/module_int.h
+++ b/src/runtime_src/core/common/api/module_int.h
@@ -14,17 +14,9 @@
 
 namespace xrt_core::module_int {
 
-// Provide access to underlying xrt::bo representing the instruction
-// buffer
-const std::vector<std::pair<uint64_t, uint64_t>>&
-get_ctrlcode_addr_and_size(const xrt::module& module);
+void
+get_ctrlcode_addr_and_size(const xrt::module& module, uint32_t* payload);
 
-static constexpr uint8_t elf_amd_aie2p = 69;
-static constexpr uint8_t elf_amd_aie2ps = 64;
-
-// Return control code type such as aie2p or aie2ps
-const uint8_t
-get_os_abi(const xrt::module& module);
 
 // Patch buffer object into control code at given argument
 void

--- a/src/runtime_src/core/common/api/module_int.h
+++ b/src/runtime_src/core/common/api/module_int.h
@@ -15,7 +15,7 @@
 namespace xrt_core::module_int {
 
 void
-get_ctrlcode_addr_and_size(const xrt::module& module, uint32_t* payload);
+fill_ert_dpu_data(const xrt::module& module, uint32_t* payload);
 
 
 // Patch buffer object into control code at given argument

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -2056,7 +2056,9 @@ class run_impl
       auto dpu = reinterpret_cast<ert_dpu_data*>(payload);
       dpu->instruction_buffer = addr;
       dpu->instruction_buffer_size = size;
-      dpu->chained = --ert_dpu_data_count;
+      dpu->chained = xrt_core::module_int::get_os_abi(m_module) == xrt_core::module_int::elf_amd_aie2p ?
+                     0 : // Always set chained as 0 for aie2p
+                     --ert_dpu_data_count;
       payload += sizeof(ert_dpu_data) / sizeof(uint32_t);
     }
 

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -2049,18 +2049,7 @@ class run_impl
   uint32_t*
   initialize_dpu(uint32_t* payload)
   {
-    auto addr_and_size = xrt_core::module_int::get_ctrlcode_addr_and_size(m_module);
-
-    size_t ert_dpu_data_count = addr_and_size.size();
-    for (auto [addr, size] : addr_and_size) {
-      auto dpu = reinterpret_cast<ert_dpu_data*>(payload);
-      dpu->instruction_buffer = addr;
-      dpu->instruction_buffer_size = size;
-      dpu->chained = xrt_core::module_int::get_os_abi(m_module) == xrt_core::module_int::elf_amd_aie2p ?
-                     0 : // Always set chained as 0 for aie2p
-                     --ert_dpu_data_count;
-      payload += sizeof(ert_dpu_data) / sizeof(uint32_t);
-    }
+    xrt_core::module_int::get_ctrlcode_addr_and_size(m_module, payload);
 
     // Return payload past the ert_dpu_data structures
     return payload;

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -2049,7 +2049,7 @@ class run_impl
   uint32_t*
   initialize_dpu(uint32_t* payload)
   {
-    xrt_core::module_int::get_ctrlcode_addr_and_size(m_module, payload);
+    xrt_core::module_int::fill_ert_dpu_data(m_module, payload);
 
     // Return payload past the ert_dpu_data structures
     return payload;

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -2049,10 +2049,8 @@ class run_impl
   uint32_t*
   initialize_dpu(uint32_t* payload)
   {
-    xrt_core::module_int::fill_ert_dpu_data(m_module, payload);
-
-    // Return payload past the ert_dpu_data structures
-    return payload;
+    // Return the memory address after payload is filled past the ert_dpu_data structures
+    return xrt_core::module_int::fill_ert_dpu_data(m_module, payload);
   }
 
   // Initialize the command packet with special case for DPU kernels

--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -332,7 +332,7 @@ public:
   // that are used when populating ert_dpu_data elements embedded
   // in an ert_packet.
   [[nodiscard]] virtual void
-  get_ctrlcode_addr_and_size(uint32_t*)
+  fill_ert_dpu_data(uint32_t*)
   {
     throw std::runtime_error("Not supported");
   }
@@ -1169,7 +1169,7 @@ public:
   }
 
   [[nodiscard]] void
-  get_ctrlcode_addr_and_size(uint32_t* payload) override
+  fill_ert_dpu_data(uint32_t* payload) override
   {
     auto os_abi = m_parent.get()->get_os_abi();
     if (os_abi == Elf_Amd_Aie2p) {
@@ -1208,9 +1208,9 @@ public:
 namespace xrt_core::module_int {
 
 void
-get_ctrlcode_addr_and_size(const xrt::module& module, uint32_t* payload)
+fill_ert_dpu_data(const xrt::module& module, uint32_t* payload)
 {
-  return module.get_handle()->get_ctrlcode_addr_and_size(payload);
+  return module.get_handle()->fill_ert_dpu_data(payload);
 }
 
 void

--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -1171,6 +1171,12 @@ public:
     return m_column_bo_address;
   }
 
+  [[nodiscard]] const uint8_t&
+      get_os_abi() const override
+  {
+      return m_parent.get()->get_os_abi();
+  }
+
   [[nodiscard]] virtual xrt::bo&
       get_scratchmem() override
   {

--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -39,8 +39,6 @@ namespace
 // 0 if no padding is required.   The page size should be
 // embedded as ELF metadata in the future.
 static constexpr size_t column_page_size = AIE_COLUMN_PAGE_SIZE;
-static constexpr uint8_t Elf_Amd_Aie2p  = 69;
-static constexpr uint8_t Elf_Amd_Aie2ps = 64;
 
 // When Debug.dump_bo_from_elf is true in xrt.ini, instruction bo(s) from elf will be dumped
 static const char* Debug_Bo_From_Elf_Feature = "Debug.dump_bo_from_elf";
@@ -430,7 +428,7 @@ class module_elf : public module_impl
   constexpr static uint32_t addend_mask = ~((uint32_t)0) << addend_shift;
   constexpr static uint32_t schema_mask = ~addend_mask;
   xrt::elf m_elf;
-  uint8_t m_os_abi = Elf_Amd_Aie2p;
+  uint8_t m_os_abi = xrt_core::module_int::elf_amd_aie2p;
   std::vector<ctrlcode> m_ctrlcodes;
   std::map<std::string, patcher> m_arg2patcher;
   instr_buf m_instr_buf;
@@ -764,11 +762,11 @@ public:
     , m_elf(std::move(elf))
     , m_os_abi{ xrt_core::elf_int::get_elfio(m_elf).get_os_abi() }
   {
-    if (m_os_abi == Elf_Amd_Aie2ps) {
+    if (m_os_abi == xrt_core::module_int::elf_amd_aie2ps) {
       m_ctrlcodes = initialize_column_ctrlcode(xrt_core::elf_int::get_elfio(m_elf));
       m_arg2patcher = initialize_arg_patchers(xrt_core::elf_int::get_elfio(m_elf), m_ctrlcodes);
     }
-    else if (m_os_abi == Elf_Amd_Aie2p) {
+    else if (m_os_abi == xrt_core::module_int::elf_amd_aie2p) {
       m_instr_buf = initialize_instr_buf(xrt_core::elf_int::get_elfio(m_elf));
       m_ctrl_packet_exist = initialize_ctrl_packet(xrt_core::elf_int::get_elfio(m_elf), m_ctrl_packet);
       m_save_buf_exist = initialize_save_buf(xrt_core::elf_int::get_elfio(m_elf), m_save_buf);
@@ -915,12 +913,10 @@ class module_sram : public module_impl
   }
 
   void
-  fill_bo_addresses()
+  aie2p_fill_bo_addresses()
   {
     m_column_bo_address.clear();
     m_column_bo_address.push_back({ m_instr_bo.address(), m_instr_bo.size() }); // NOLINT
-    if (m_ctrlpkt_bo)
-      m_column_bo_address.push_back({ m_ctrlpkt_bo.address(), m_ctrlpkt_bo.size() }); // NOLINT
 
     if (m_preempt_save_bo)
       m_column_bo_address.push_back({ m_preempt_save_bo.address(), m_preempt_save_bo.size() }); // NOLINT
@@ -1064,7 +1060,7 @@ class module_sram : public module_impl
   patch_value(const std::string& argnm, size_t index, uint64_t value)
   {
     bool patched = false;
-    if (m_parent->get_os_abi() == Elf_Amd_Aie2p) {
+    if (m_parent->get_os_abi() == xrt_core::module_int::elf_amd_aie2p) {
       // patch control-packet buffer
       if (m_ctrlpkt_bo) {
         if (m_parent->patch(m_ctrlpkt_bo.map<uint8_t*>(), argnm, index, value, patcher::buf_type::ctrldata))
@@ -1118,7 +1114,7 @@ class module_sram : public module_impl
       return;
 
     auto os_abi = m_parent.get()->get_os_abi();
-    if (os_abi == Elf_Amd_Aie2ps) {
+    if (os_abi == xrt_core::module_int::elf_amd_aie2ps) {
       if (m_patched_args.size() != m_parent->number_of_arg_patchers()) {
         auto fmt = boost::format("ctrlcode requires %d patched arguments, but only %d are patched")
             % m_parent->number_of_arg_patchers() % m_patched_args.size();
@@ -1126,7 +1122,7 @@ class module_sram : public module_impl
       }
       m_buffer.sync(XCL_BO_SYNC_BO_TO_DEVICE);
     }
-    else if (os_abi == Elf_Amd_Aie2p) {
+    else if (os_abi == xrt_core::module_int::elf_amd_aie2p) {
       m_instr_bo.sync(XCL_BO_SYNC_BO_TO_DEVICE);
 #ifdef _DEBUG
       dump_bo(m_instr_bo, "instrBoPatched.bin");
@@ -1156,14 +1152,14 @@ public:
   {
     auto os_abi = m_parent.get()->get_os_abi();
 
-    if (os_abi == Elf_Amd_Aie2p) {
+    if (os_abi == xrt_core::module_int::elf_amd_aie2p) {
       // make sure to create control-packet buffer frist because we may
       // need to patch control-packet address to instruction buffer
       create_ctrlpkt_buf(m_parent.get());
       create_instr_buf(m_parent.get());
-      fill_bo_addresses();
+      aie2p_fill_bo_addresses();
     }
-    else if (os_abi == Elf_Amd_Aie2ps) {
+    else if (os_abi == xrt_core::module_int::elf_amd_aie2ps) {
       create_instruction_buffer(m_parent.get());
       fill_column_bo_address(m_parent->get_data());
     }
@@ -1193,6 +1189,12 @@ const std::vector<std::pair<uint64_t, uint64_t>>&
 get_ctrlcode_addr_and_size(const xrt::module& module)
 {
   return module.get_handle()->get_ctrlcode_addr_and_size();
+}
+
+const uint8_t
+get_os_abi(const xrt::module& module)
+{
+    return module.get_handle()->get_os_abi();
 }
 
 void

--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -331,7 +331,7 @@ public:
   // or for a single partition.  The returned vector has elements
   // that are used when populating ert_dpu_data elements embedded
   // in an ert_packet.
-  [[nodiscard]] virtual void
+  virtual void
   fill_ert_dpu_data(uint32_t*)
   {
     throw std::runtime_error("Not supported");
@@ -1168,7 +1168,7 @@ public:
     }
   }
 
-  [[nodiscard]] void
+  void
   fill_ert_dpu_data(uint32_t* payload) override
   {
     auto os_abi = m_parent.get()->get_os_abi();

--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -327,11 +327,10 @@ public:
     return {};
   }
 
-  // Get the address and size of the control code for all columns
-  // or for a single partition.  The returned vector has elements
-  // that are used when populating ert_dpu_data elements embedded
-  // in an ert_packet.
-  virtual void
+  // Using the address and size of the control code for all columns to fill ert_epu_data
+  // return a pointer to the payload after it is filled
+  // @param payload pointing to the memory before payload is filled
+  [[nodiscard]] virtual uint32_t*
   fill_ert_dpu_data(uint32_t*)
   {
     throw std::runtime_error("Not supported");
@@ -1168,7 +1167,10 @@ public:
     }
   }
 
-  void
+  // Using the address and size of the control code for all columns to fill ert_epu_data
+  // return a pointer to the payload after it is filled and offsetted
+  // @param payload pointing to the memory before payload is filled
+  [[nodiscard]] virtual uint32_t*
   fill_ert_dpu_data(uint32_t* payload) override
   {
     auto os_abi = m_parent.get()->get_os_abi();
@@ -1191,6 +1193,7 @@ public:
         payload += sizeof(ert_dpu_data) / sizeof(uint32_t);
       }
     }
+    return payload;
   }
 
   [[nodiscard]] virtual xrt::bo&
@@ -1207,7 +1210,7 @@ public:
 ////////////////////////////////////////////////////////////////
 namespace xrt_core::module_int {
 
-void
+uint32_t*
 fill_ert_dpu_data(const xrt::module& module, uint32_t* payload)
 {
   return module.get_handle()->fill_ert_dpu_data(payload);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Linux driver has an issue with chained field in ert_dpu_data for aie2p.
Control-packet address and size in ert_dpu_data is redundant in Windows KMD driver
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Always set chained in struct ert_dpu_data as 0 for aie2p
#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Test using DPU sequence passed on PHX
#### Documentation impact (if any)
