### PR TITLE
CID-369005, CID-369006: Amend #8198 with missing essential operators

### DIFF
--- a/src/runtime_src/core/common/api/CMakeLists.txt
+++ b/src/runtime_src/core/common/api/CMakeLists.txt
@@ -1,16 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
-
-# if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-#   find_program(CLANG_TIDY "clang-tidy" HINT /home/stsoe/git-nobkup/llvm-project/build)
-#   if(NOT CLANG_TIDY)
-#     message(WARNING "-- clang-tidy not found, cannot enable static analysis")
-#   else()
-#     message("-- Enabling clang-tidy")
-#     set(CMAKE_CXX_CLANG_TIDY "/home/stsoe/git-nobkup/llvm-project/build/bin/clang-tidy")
-#   endif()
-# endif()
-
 add_library(core_common_api_library_objects OBJECT
   context_mgr.cpp
   hw_queue.cpp

--- a/src/runtime_src/core/include/xrt/xrt_hw_context.h
+++ b/src/runtime_src/core/include/xrt/xrt_hw_context.h
@@ -77,12 +77,6 @@ public:
   hw_context() = default;
 
   /**
-   * ~hw_context() - Destructor
-   */
-  XCL_DRIVER_DLLESPEC
-  ~hw_context();
-
-  /**
    * hw_context() - Constructor with QoS control
    *
    * @param device
@@ -125,6 +119,34 @@ public:
     : detail::pimpl<hw_context_impl>(std::move(impl))
   {}
   /// @endcond
+
+  /**
+   * hw_context() - Copy ctor
+   */
+  hw_context(const hw_context&) = default;
+
+  /**
+   * hw_context() - Move ctor
+   */
+  hw_context(hw_context&&) = default;
+
+  /**
+   * ~hw_context() - Destructor
+   */
+  XCL_DRIVER_DLLESPEC
+  ~hw_context();
+
+  /**
+   * operator= () - Copy assignment
+   */
+  hw_context&
+  operator=(const hw_context&) = default;
+
+  /**
+   * operator= () - Move assignment
+   */
+  hw_context&
+  operator=(hw_context&&) = default;
 
   ///@cond
   // Undocument experimental API to change the QoS of a hardware context

--- a/src/runtime_src/core/include/xrt/xrt_kernel.h
+++ b/src/runtime_src/core/include/xrt/xrt_kernel.h
@@ -131,12 +131,6 @@ public:
   run() = default;
 
   /**
-   * ~run() - Destruct run object
-   */
-  XCL_DRIVER_DLLESPEC
-  ~run();
-
-  /**
    * run() - Construct run object from a kernel object
    *
    * @param krnl: Kernel object representing the kernel to execute
@@ -144,6 +138,34 @@ public:
   XCL_DRIVER_DLLESPEC
   explicit
   run(const kernel& krnl);
+
+  /**
+   * run() - Copy ctor
+   */
+  run(const run&) = default;
+
+  /**
+   * run() - Move ctor
+   */
+  run(run&&) = default;
+
+  /**
+   * ~run() - Destruct run object
+   */
+  XCL_DRIVER_DLLESPEC
+  ~run();
+
+  /**
+   * operator= () - Copy assignment
+   */
+  run&
+  operator=(const run&) = default;
+
+  /**
+   * operator= () - Move assignment
+   */
+  run&
+  operator=(run&&) = default;
 
   /**
    * start() - Start one execution of a run.
@@ -677,12 +699,6 @@ public:
   kernel() = default;
 
   /**
-   * Destructor for kernel - needed for tracing
-   */
-  XCL_DRIVER_DLLESPEC
-  ~kernel();
-
-  /**
    * kernel() - Constructor from a device and xclbin
    *
    * @param device
@@ -726,6 +742,34 @@ public:
   kernel(xclDeviceHandle dhdl, const xrt::uuid& xclbin_id, const std::string& name,
          cu_access_mode mode = cu_access_mode::shared);
   /// @endcond
+
+  /**
+   * kernel() - Copy ctor
+   */
+  kernel(const kernel&) = default;
+
+  /**
+   * kernel() - Move ctor
+   */
+  kernel(kernel&&) = default;
+
+  /**
+   * Destructor for kernel - needed for tracing
+   */
+  XCL_DRIVER_DLLESPEC
+  ~kernel();
+
+  /**
+   * operator= () - Copy assignment
+   */
+  kernel&
+  operator=(const kernel&) = default;
+
+  /**
+   * operator= () - Move assignment
+   */
+  kernel&
+  operator=(kernel&&) = default;
 
   /**
    * operator() - Invoke the kernel function


### PR DESCRIPTION
#### Problem solved by the commit
Add default copy, move ctor and assignment to classes where explicit dtor was added in #8198.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
An explicit dtor implies the object is not trivially destructed, hence compiler cannot assume the object can be trivially moved or maybe even assigned.  Alas, full slew of essential operators must be explicitly defined.

#### How problem was solved, alternative solutions (if any) and why they were rejected
PR #8198 added explicit dtor to bo, device, hw_context, kernel, and run. This PR adds the essential operators to those that did not already have them.
