### PR TITLE
RAVE: Fix PCI Link down issue during EEMI PMC reset

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
@@ -608,7 +608,12 @@ static int xclmgmt_reset(xdev_handle_t xdev_hdl)
 {
 	struct xclmgmt_dev *lro = (struct xclmgmt_dev *)xdev_hdl;
 
-	return xclmgmt_hot_reset(lro, true);
+	if (XOCL_DSA_EEMI_API_SRST(lro)) {
+		return xclmgmt_eemi_pmc_reset(lro);
+	}
+	else {
+		return xclmgmt_hot_reset(lro, true);
+	}
 }
 
 struct xocl_pci_funcs xclmgmt_pci_ops = {
@@ -1414,12 +1419,24 @@ static void xclmgmt_work_cb(struct work_struct *work)
 
 	switch (_work->op) {
 	case XOCL_WORK_RESET:
-		ret = (int) xclmgmt_hot_reset(lro, false);
+		if (XOCL_DSA_EEMI_API_SRST(lro)) {
+			ret = (int) xclmgmt_eemi_pmc_reset(lro);
+		}
+		else {
+			ret = (int) xclmgmt_hot_reset(lro, false);
+		}
+
 		if (!ret)
 			xocl_drvinst_set_offline(lro, false);
 		break;
 	case XOCL_WORK_FORCE_RESET:
-		ret = (int) xclmgmt_hot_reset(lro, true);
+		if (XOCL_DSA_EEMI_API_SRST(lro)) {
+			ret = (int) xclmgmt_eemi_pmc_reset(lro);
+		}
+		else {
+			ret = (int) xclmgmt_hot_reset(lro, false);
+		}
+
 		if (!ret)
 			xocl_drvinst_set_offline(lro, false);
 		break;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.h
@@ -178,6 +178,7 @@ void store_pcie_link_info(struct xclmgmt_dev *lro);
 int pci_fundamental_reset(struct xclmgmt_dev *lro);
 
 long xclmgmt_hot_reset(struct xclmgmt_dev *lro, bool force);
+long xclmgmt_eemi_pmc_reset(struct xclmgmt_dev *lro);
 int xocl_wait_master_off(struct xclmgmt_dev *lro);
 int xocl_set_master_on(struct xclmgmt_dev *lro);
 void xocl_pci_save_config_all(struct xclmgmt_dev *lro);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-sysfs.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-sysfs.c
@@ -434,7 +434,13 @@ static ssize_t mgmt_reset_store(struct device *dev,
 	 */
 	switch(val) {
 	case 1:
-		ret = (int) xclmgmt_hot_reset(lro, true);
+		if (XOCL_DSA_EEMI_API_SRST(lro)) {
+			ret = (int) xclmgmt_eemi_pmc_reset(lro);
+		}
+		else {
+			ret = (int) xclmgmt_hot_reset(lro, false);
+		}
+
 		if (ret < 0)
 			return ret;
 		break;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
During RAVE EEMI based PMC device reset, device reports AER errors due to POR and further leading pci subsystem toggles the device pci link down and up.
This results in aborting XRT reset functionality when pci link goes down and reprobing of XRT  driver  upon link up.
This is not a clean solution as the state of XRT is unknown after the reset command is issued to VMR.
Problem solved by this commit is to avoid the device reporting correctable errors during reset operation.
XRT then has control to perform cleanup and reconfig the sub devices during the device reset. 

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Inconsitent behavior of XRT during device reset functionality.
#### How problem was solved, alternative solutions (if any) and why they were rejected
Problem solved by this commit is to avoid the device reporting correctable errors during reset operation.
XRT then has control to perform cleanup and reconfig the sub devices during the device reset. 
#### Risks (if any) associated the changes in the commit
None
#### What has been tested and how, request additional testing if necessary
Xbutil and xbmgmt reset functionality.
#### Documentation impact (if any)
EEMI API Reset functionality.