### PR TITLE
CID-314885,331341,331443

### DIFF
--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -4481,7 +4481,7 @@ xrtRunGetArgV(xrtRunHandle rhdl, int index, void* value, size_t bytes)
 void
 xrtRunGetArgVPP(xrt::run run, int index, void* value, size_t bytes)
 {
-  xdp::native::profiling_wrapper(__func__, [run, index, value, bytes]{
+  xdp::native::profiling_wrapper(__func__, [&run, index, value, bytes]{
     const auto& rimpl = run.get_handle();
     rimpl->get_arg_at_index(index, static_cast<uint32_t*>(value), bytes);
   });

--- a/src/runtime_src/xocl/core/kernel.cpp
+++ b/src/runtime_src/xocl/core/kernel.cpp
@@ -177,7 +177,7 @@ kernel(program* prog, const std::string& name, xrt::xclbin::kernel xk)
     // throws and the kernel should be ignored
     try {
       xrt_core::kernel_int::set_cus(xrun, cumask);
-      m_xruns.emplace(std::make_pair(device, xkr{xkernel, xrun}));
+      m_xruns.emplace(std::make_pair(device, xkr{std::move(xkernel), std::move(xrun)}));
     }
     catch (const std::exception&) {
     }


### PR DESCRIPTION
Fix minor Coverity defects. Use std::move as directed.
