### PR TITLE
ERT command for IPU and IPU preemption

### DIFF
--- a/src/runtime_src/core/common/api/module_int.h
+++ b/src/runtime_src/core/common/api/module_int.h
@@ -34,7 +34,8 @@ void
 sync(const xrt::module&);
 
 // Get the ERT command opcode in ELF flow
-enum ert_cmd_opcode get_ert_opcode(const xrt::module& module);
+ert_cmd_opcode
+get_ert_opcode(const xrt::module& module);
 
 } // xrt_core::module_int
 

--- a/src/runtime_src/core/common/api/module_int.h
+++ b/src/runtime_src/core/common/api/module_int.h
@@ -14,11 +14,10 @@
 
 namespace xrt_core::module_int {
 
-// Provide access to underlying xrt::bo representing the instruction
-// buffer
-const std::vector<std::pair<uint64_t, uint64_t>>&
-get_ctrlcode_addr_and_size(const xrt::module& module);
-
+// Fill in ERT command payload in ELF flow. The payload is after extra_cu_mask
+// and before CU arguments.
+uint32_t*
+fill_ert_dpu_data(const xrt::module& module, uint32_t *payload);
 
 // Patch buffer object into control code at given argument
 void
@@ -33,6 +32,9 @@ patch(const xrt::module&, const std::string& argnm, size_t index, const void* va
 // patched.
 void
 sync(const xrt::module&);
+
+// Get the ERT command opcode in ELF flow
+enum ert_cmd_opcode get_ert_opcode(const xrt::module& module);
 
 } // xrt_core::module_int
 

--- a/src/runtime_src/core/include/ert.h
+++ b/src/runtime_src/core/include/ert.h
@@ -173,6 +173,68 @@ struct ert_dpu_data {
 };
 
 /**
+ * struct ert_ipu_data - interpretation of data payload for ERT_START_IPU
+ *
+ * @instruction_buffer:       address of instruction buffer
+ * @instruction_buffer_size:  size of instruction buffer in bytes
+ * @instruction_prop_count:   WORD length of property name value pairs
+ *
+ * The ert_ipu_data is prepended to data payload of ert_start_kernel_cmd
+ * after any extra cu masks.  The payload count of the ert packet is
+ * incremented with the size (words) of ert_ipu_data elements
+ * preprended to the data payload.
+ *
+ * The data payload for ERT_START_IPU is interpreted as instruction
+ * buffer address, instruction count along with instruction property,
+ * followed by regular kernel arguments.
+ *
+ * When instruction_prop_count is non-zero, it indicates the length
+ * (in 32 bits WORD) of the instruction buffer properties after this
+ * fields. This count is reserved for future extension. One example
+ * propertiy is the number of actual columns this instruction used.
+ */
+struct ert_ipu_data {
+  uint64_t instruction_buffer;       /* buffer address 2 words */
+  uint32_t instruction_buffer_size;  /* size of buffer in bytes */
+  uint32_t instruction_prop_count;   /* WORD length of following properties nv pairs */
+};
+
+/**
+ * struct ert_ipu_preempt_data - interpretation of data payload for ERT_START_IPU_PREEMPT
+ *
+ * @instruction_buffer:       address of instruction buffer
+ * @save_buffer:              address of save instruction buffer
+ * @restore_buffer:           address of restrore instruction buffer
+ * @instruction_buffer_size:  size of instruction buffer in bytes
+ * @save_buffer_size:         size of save instruction buffer in bytes
+ * @restore_buffer_size:      size of restore instruction buffer in bytes
+ * @instruction_prop_count:   number of property name value pairs
+ *
+ * The ert_ipu_preempt_data is prepended to data payload of ert_start_kernel_cmd
+ * after any extra cu masks.  The payload count of the ert packet is
+ * incremented with the size (words) of ert_ipu_preempt_data elements
+ * preprended to the data payload.
+ *
+ * The data payload for ERT_START_IPU_PREEMPT is interpreted as instruction
+ * buffer, save instruction buffer, restore instruction buffer and their
+ * size, along with instruction property, followed by regular kernel arguments.
+ *
+ * When instruction_prop_count is non-zero, it indicates the length
+ * (in 32 bits WORD) of the instruction buffer properties after this
+ * fields. This count is reserved for future extension. One example
+ * propertiy is the number of actual columns this instruction used.
+ */
+struct ert_ipu_preempt_data {
+  uint64_t instruction_buffer;       /* buffer address 2 words */
+  uint64_t save_buffer;              /* buffer address 2 words */
+  uint64_t restore_buffer;           /* buffer address 2 words */
+  uint32_t instruction_buffer_size;  /* size of buffer in bytes */
+  uint32_t save_buffer_size;         /* size of buffer in bytes */
+  uint32_t restore_buffer_size;      /* size of buffer in bytes */
+  uint32_t instruction_prop_count;   /* DWORD length of following properties nv pairs */
+};
+
+/**
  * struct ert_cmd_chain_data - interpretation of data payload for ERT_CMD_CHAIN
  *
  * @command_count: number of commands in chain
@@ -547,41 +609,45 @@ struct cu_cmd_state_timestamps {
 /**
  * Opcode types for commands
  *
- * @ERT_START_CU:       start a workgroup on a CU
- * @ERT_START_KERNEL:   currently aliased to ERT_START_CU
- * @ERT_CONFIGURE:      configure command scheduler
- * @ERT_EXEC_WRITE:     execute a specified CU after writing
- * @ERT_CU_STAT:        get stats about CU execution
- * @ERT_START_COPYBO:   start KDMA CU or P2P, may be converted to ERT_START_CU
- *                      before cmd reach to scheduler, short-term hack
- * @ERT_SK_CONFIG:      configure soft kernel
- * @ERT_SK_START:       start a soft kernel
- * @ERT_SK_UNCONFIG:    unconfigure a soft kernel
- * @ERT_START_KEY_VAL:  same as ERT_START_CU but with key-value pair flavor
- * @ERT_START_DPU:      instruction buffer command format
- * @ERT_CMD_CHAIN:      command chain
+ * @ERT_START_CU:          start a workgroup on a CU
+ * @ERT_START_KERNEL:      currently aliased to ERT_START_CU
+ * @ERT_CONFIGURE:         configure command scheduler
+ * @ERT_EXEC_WRITE:        execute a specified CU after writing
+ * @ERT_CU_STAT:           get stats about CU execution
+ * @ERT_START_COPYBO:      start KDMA CU or P2P, may be converted to ERT_START_CU
+ *                         before cmd reach to scheduler, short-term hack
+ * @ERT_SK_CONFIG:         configure soft kernel
+ * @ERT_SK_START:          start a soft kernel
+ * @ERT_SK_UNCONFIG:       unconfigure a soft kernel
+ * @ERT_START_KEY_VAL:     same as ERT_START_CU but with key-value pair flavor
+ * @ERT_START_DPU:         instruction buffer command format
+ * @ERT_CMD_CHAIN:         command chain
+ * @ERT_START_IPU:         instruction buffer command format on IPU format
+ * @ERT_START_IPU_PREEMPT: instruction buffer command with preemption format on IPU
  */
 enum ert_cmd_opcode {
-  ERT_START_CU      = 0,
-  ERT_START_KERNEL  = 0,
-  ERT_CONFIGURE     = 2,
-  ERT_EXIT          = 3,
-  ERT_ABORT         = 4,
-  ERT_EXEC_WRITE    = 5,
-  ERT_CU_STAT       = 6,
-  ERT_START_COPYBO  = 7,
-  ERT_SK_CONFIG     = 8,
-  ERT_SK_START      = 9,
-  ERT_SK_UNCONFIG   = 10,
-  ERT_INIT_CU       = 11,
-  ERT_START_FA      = 12,
-  ERT_CLK_CALIB     = 13,
-  ERT_MB_VALIDATE   = 14,
-  ERT_START_KEY_VAL = 15,
-  ERT_ACCESS_TEST_C = 16,
-  ERT_ACCESS_TEST   = 17,
-  ERT_START_DPU     = 18,
-  ERT_CMD_CHAIN     = 19,
+  ERT_START_CU          = 0,
+  ERT_START_KERNEL      = 0,
+  ERT_CONFIGURE         = 2,
+  ERT_EXIT              = 3,
+  ERT_ABORT             = 4,
+  ERT_EXEC_WRITE        = 5,
+  ERT_CU_STAT           = 6,
+  ERT_START_COPYBO      = 7,
+  ERT_SK_CONFIG         = 8,
+  ERT_SK_START          = 9,
+  ERT_SK_UNCONFIG       = 10,
+  ERT_INIT_CU           = 11,
+  ERT_START_FA          = 12,
+  ERT_CLK_CALIB         = 13,
+  ERT_MB_VALIDATE       = 14,
+  ERT_START_KEY_VAL     = 15,
+  ERT_ACCESS_TEST_C     = 16,
+  ERT_ACCESS_TEST       = 17,
+  ERT_START_DPU         = 18,
+  ERT_CMD_CHAIN         = 19,
+  ERT_START_IPU         = 20,
+  ERT_START_IPU_PREEMPT = 21,
 };
 
 /**
@@ -909,6 +975,16 @@ ert_valid_opcode(struct ert_packet *pkt)
     /* header count must match number of commands in payload */
     valid = (pkt->count == (ccdata->command_count * sizeof(uint64_t) + sizeof(struct ert_cmd_chain_data)) / sizeof(uint32_t));
     break;
+  case ERT_START_IPU:
+    skcmd = to_start_krnl_pkg(pkt);
+    /* 1 mandatory cumask + extra_cu_masks + ert_ipu_data */
+    valid = (skcmd->count >= 1+ skcmd->extra_cu_masks + sizeof(struct ert_ipu_data) / sizeof(uint32_t));
+    break;
+   case ERT_START_IPU_PREEMPT:
+    skcmd = to_start_krnl_pkg(pkt);
+    /* 1 mandatory cumask + extra_cu_masks + ert_ipu_preempt_data */
+    valid = (skcmd->count >= 1+ skcmd->extra_cu_masks + sizeof(struct ert_ipu_preempt_data) / sizeof(uint32_t));
+    break;
   case ERT_START_KEY_VAL:
     skcmd = to_start_krnl_pkg(pkt);
     /* 1 cu mask */
@@ -985,7 +1061,7 @@ get_ert_dpu_data_next(struct ert_dpu_data* dpu_data)
 {
   if (dpu_data->chained == 0)
     return NULL;
-  
+
   return dpu_data + 1;
 }
 
@@ -998,16 +1074,48 @@ get_ert_cmd_chain_data(struct ert_packet* pkt)
   return (struct ert_cmd_chain_data*) pkt->data;
 }
 
+static inline struct ert_ipu_data*
+get_ert_ipu_data(struct ert_start_kernel_cmd* pkt)
+{
+  if (pkt->opcode != ERT_START_IPU)
+    return NULL;
+
+  // past extra cu_masks embedded in the packet data
+  return (struct ert_ipu_data*) (pkt->data + pkt->extra_cu_masks);
+}
+
+static inline struct ert_ipu_preempt_data*
+get_ert_ipu_preempt_data(struct ert_start_kernel_cmd* pkt)
+{
+  if (pkt->opcode != ERT_START_IPU)
+    return NULL;
+
+  // past extra cu_masks embedded in the packet data
+  return (struct ert_ipu_preempt_data*) (pkt->data + pkt->extra_cu_masks);
+}
+
 static inline uint32_t*
 get_ert_regmap_begin(struct ert_start_kernel_cmd* pkt)
 {
-  if (pkt->opcode == ERT_START_DPU)
-    // skip past extra cu masks and ert_dpu_data
+  switch (pkt->opcode) {
+  case ERT_START_DPU:
     return pkt->data + pkt->extra_cu_masks
       + (get_ert_dpu_data(pkt)->chained + 1) * sizeof(struct ert_dpu_data) / sizeof(uint32_t);
-  else
+
+  case ERT_START_IPU:
+    return pkt->data + pkt->extra_cu_masks
+      + sizeof(struct ert_ipu_data) / sizeof(uint32_t)
+      + get_ert_ipu_data(pkt)->instruction_prop_count;
+
+  case ERT_START_IPU_PREEMPT:
+    return pkt->data + pkt->extra_cu_masks
+      + sizeof(struct ert_ipu_preempt_data) / sizeof(uint32_t)
+      + get_ert_ipu_preempt_data(pkt)->instruction_prop_count;
+
+  default:
     // skip past embedded extra cu_masks
     return pkt->data + pkt->extra_cu_masks;
+  }
 }
 
 static inline uint32_t*


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
1. Define two new ERT command 
  ERT_START_IPU
  ERT_START_IPU_PREEMPT
 and their payloads.
2. Enhance xrt_module.cpp to construct payloads for both commands on IPU and IPU preemption instead of reuse ERT_START_DPU, which is now dedicated for AIE2PS.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Tested ELF non-control-packet and ELF control-packet flow on SNL PHX

#### Documentation impact (if any)
