### PR TITLE
Bug fix - xbmgmt examine reports failure when golden image is present

### DIFF
--- a/src/runtime_src/core/tools/common/reports/ReportHost.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportHost.cpp
@@ -162,7 +162,7 @@ ReportHost::writeReport(const xrt_core::device* /*_pDevice*/,
     if (!available_devices.empty())
       _output << boost::format("  %-20s : %s\n") % "Firmware Version" % available_devices.begin()->second.get<std::string>("firmware_version");
   }
-  catch (const xrt_core::query::exception&) {
+  catch (...) {
     //no device available
   }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
[CR-1202202](https://jira.xilinx.com/browse/CR-1202202)  No such node (firmware_version) in 'xbmgmt examine' output.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
After reverting to golden image, xbmgmt examine is not showing the shell name.

#### How problem was solved, alternative solutions (if any) and why they were rejected
This change will catch all type of exception when firmware info is not present we get no such firmware.

#### Risks (if any) associated the changes in the commit
NA

#### What has been tested and how, request additional testing if necessary
Tested with U250.

#### Documentation impact (if any)
