### PR TITLE
libqdma: Updating QDMA to its latest commit (#8197)

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/qdma.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/qdma.c
@@ -50,11 +50,6 @@
 
 #define QDMA_REQ_TIMEOUT_MS	10000
 
-/* This is a temporary workaround in limiting the aperture size
- * until the block size issue in SOFT QDMA IP is fixed.
- */
-#define QDMA_WA_APERTURE_SIZE 0x8000
-
 /* Module Parameters */
 unsigned int qdma_max_channel = 8;
 module_param(qdma_max_channel, uint, 0644);
@@ -488,11 +483,10 @@ static int set_max_chan(struct xocl_qdma *qdma, u32 count)
 	struct platform_device *pdev = qdma->pdev;
 	struct qdma_queue_conf *qconf;
 	struct mm_channel *chan;
-	struct qdma_version_info ver_info;
 	u32	write, qidx;
 	char	ebuf[MM_EBUF_LEN + 1];
-	int	i, ret, rv;
-	bool	reset = false, is_soft_qdma = false;
+	int	i, ret;
+	bool	reset = false;
 
 	if (count > sizeof(qdma->channel_bitmap[0]) * 8) {
 		xocl_info(&pdev->dev, "Invalide number of channels set %d", count);
@@ -525,14 +519,6 @@ static int set_max_chan(struct xocl_qdma *qdma, u32 count)
 		}
 	}
 
-	rv = qdma_device_version_info(qdma->dma_hndl, &ver_info);
-
-	if (rv < 0) {
-		xocl_err(&pdev->dev, "qdma_device_version_info failed: %d", rv);
-		goto failed_create_queue;
-	}
-	is_soft_qdma = (strcmp(ver_info.ip_str, "EQDMA5.0 Soft IP") == 0)? true : false;
-
 	for (i = 0; i < qdma->channel * 2; i++) {
 		write = i / qdma->channel;
 		qidx = i % qdma->channel;
@@ -555,11 +541,6 @@ static int set_max_chan(struct xocl_qdma *qdma, u32 count)
 		qconf->qidx = qidx;
 		qconf->irq_en = (qdma->dev_conf.qdma_drv_mode == POLL_MODE) ?
 					0 : 1;
-		if (is_soft_qdma)
-		{
-			/* This is a temporary workaround to limit aperture size until we have a fix in SOFT IP */
-			qconf->aperture_size = QDMA_WA_APERTURE_SIZE;
-		}
 
 		ret = qdma_queue_add(qdma->dma_hndl, qconf, &chan->queue,
 					ebuf, MM_EBUF_LEN);


### PR DESCRIPTION
* Revert "Workaround to limit Aperture Size Limit as part of QDMA Queues for SOFT QDMA IP.  (#7979)" Reverting the changes since the work around has been handled as part of QDMA driver. This reverts commit cc30690ba0ebf25dccc3b27ad5d0d56f49584ab9.

* reverting QDMA changes in XRT

Signed-off-by: Karthik DMG <karthdmg@amd.com>

---------

Signed-off-by: Karthik DMG <karthdmg@amd.com>
(cherry picked from commit 4cb2c5de7bf31debd841fd1aeb400e5f7441e876)

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
