### PR TITLE
Fix PCI Link down issue during EEMI PMC reset (#8208)

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
@@ -608,7 +608,17 @@ static int xclmgmt_reset(xdev_handle_t xdev_hdl)
 {
 	struct xclmgmt_dev *lro = (struct xclmgmt_dev *)xdev_hdl;
 
-	return xclmgmt_hot_reset(lro, true);
+	return xclmgmt_reset_device(lro, true);
+}
+
+long xclmgmt_reset_device(struct xclmgmt_dev *lro, bool force)
+{
+	if (XOCL_DSA_EEMI_API_SRST(lro)) {
+		return xclmgmt_eemi_pmc_reset(lro);
+	}
+	else {
+		return xclmgmt_hot_reset(lro, force);
+	}
 }
 
 struct xocl_pci_funcs xclmgmt_pci_ops = {
@@ -1414,12 +1424,14 @@ static void xclmgmt_work_cb(struct work_struct *work)
 
 	switch (_work->op) {
 	case XOCL_WORK_RESET:
-		ret = (int) xclmgmt_hot_reset(lro, false);
+		ret = (int) xclmgmt_reset_device(lro, false);
+
 		if (!ret)
 			xocl_drvinst_set_offline(lro, false);
 		break;
 	case XOCL_WORK_FORCE_RESET:
-		ret = (int) xclmgmt_hot_reset(lro, true);
+		ret = (int) xclmgmt_reset_device(lro, true);
+
 		if (!ret)
 			xocl_drvinst_set_offline(lro, false);
 		break;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.h
@@ -177,7 +177,10 @@ void store_pcie_link_info(struct xclmgmt_dev *lro);
 /* utils.c */
 int pci_fundamental_reset(struct xclmgmt_dev *lro);
 
+
+long xclmgmt_reset_device(struct xclmgmt_dev *lro, bool force);
 long xclmgmt_hot_reset(struct xclmgmt_dev *lro, bool force);
+long xclmgmt_eemi_pmc_reset(struct xclmgmt_dev *lro);
 int xocl_wait_master_off(struct xclmgmt_dev *lro);
 int xocl_set_master_on(struct xclmgmt_dev *lro);
 void xocl_pci_save_config_all(struct xclmgmt_dev *lro);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-sysfs.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-sysfs.c
@@ -434,7 +434,8 @@ static ssize_t mgmt_reset_store(struct device *dev,
 	 */
 	switch(val) {
 	case 1:
-		ret = (int) xclmgmt_hot_reset(lro, true);
+		ret = (int) xclmgmt_reset_device(lro, true);
+
 		if (ret < 0)
 			return ret;
 		break;


### PR DESCRIPTION
* reset_fix

Signed-off-by: karthdmg <karthdmg@amd.com>

* defined new function xclmgmt_reset_device

Signed-off-by: karthdmg <karthdmg@amd.com>

* fix errors

Signed-off-by: karthdmg <karthdmg@amd.com>

---------

Signed-off-by: karthdmg <karthdmg@amd.com>
(cherry picked from commit f3169ab3cc02cf6f8736e0243cfaf9b934063114)

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
