### PR TITLE
Add cstdint as necessary

### DIFF
--- a/src/runtime_src/core/edge/user/aie/common_layer/adf_api_config.h
+++ b/src/runtime_src/core/edge/user/aie/common_layer/adf_api_config.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/src/runtime_src/core/edge/user/zynq_dev.h
+++ b/src/runtime_src/core/edge/user/zynq_dev.h
@@ -17,6 +17,7 @@
 #ifndef _XCL_ZYNQ_DEV_H_
 #define _XCL_ZYNQ_DEV_H_
 
+#include <cstdint>
 #include <fstream>
 #include <string>
 #include <vector>


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
In GCC 13.1 usage of uint64 and similar will result in an error without #include <cstdint>