### PR TITLE
Fix dll import/export warning

### DIFF
--- a/src/runtime_src/core/include/xrt/xrt_hw_context.h
+++ b/src/runtime_src/core/include/xrt/xrt_hw_context.h
@@ -133,7 +133,7 @@ public:
   /**
    * ~hw_context() - Destructor
    */
-  XCL_DRIVER_DLLESPEC
+  XRT_API_EXPORT
   ~hw_context();
 
   /**


### PR DESCRIPTION
Replace wrong macro for dllexport
