### PR TITLE
RyzenAI-1.2-Cleanup Various cosmetic changes, removal of aie reports ...

### DIFF
--- a/src/runtime_src/core/tools/common/Table2D.cpp
+++ b/src/runtime_src/core/tools/common/Table2D.cpp
@@ -37,7 +37,7 @@ void
 Table2D::appendToOutput(std::string& output, const std::string& prefix, const std::string& suffix, const ColumnData& column, const std::string& data) const
 {
   // Format for table data
-  boost::format fmt("%s%s%s%s%s");
+  boost::format fmt("%s|%s%s%s%s|");
   size_t left_blanks = 0;
   size_t right_blanks = 0;
   getBlankSizes(column, data.size(), left_blanks, right_blanks);

--- a/src/runtime_src/core/tools/common/reports/ReportAiePartitions.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportAiePartitions.cpp
@@ -107,6 +107,7 @@ writeReport(const xrt_core::device* /*_pDevice*/,
       {"Submissions", Table2D::Justification::left},
       {"Completions", Table2D::Justification::left},
       {"Migrations", Table2D::Justification::left},
+      {"Errors", Table2D::Justification::left},
     };
     Table2D context_table(table_headers);
 
@@ -114,29 +115,20 @@ writeReport(const xrt_core::device* /*_pDevice*/,
     for (const auto& pt_hw_context : partition.get_child("hw_contexts", empty_ptree)) {
       const auto& hw_context = pt_hw_context.second;
 
-      errors.push_back(hw_context.get<uint64_t>("errors"));
+      const std::string error_count = std::to_string(hw_context.get<uint64_t>("errors"));
 
       const std::vector<std::string> entry_data = {
         hw_context.get<std::string>("context_id"),
         hw_context.get<std::string>("command_submissions"),
         hw_context.get<std::string>("command_completions"),
-        hw_context.get<std::string>("migrations")
+        hw_context.get<std::string>("migrations"),
+        error_count
       };
       context_table.addEntry(entry_data);
     }
 
-    // Currently the error counts are per partition vs per context.
-    // Future releases will enable per context error resolution.
-    // In the meantime, each context within a partition must have the same error count.
-    uint64_t error_count = errors.empty() ? 0 : errors[0];
-    for (size_t i = 1; i < errors.size(); i++) {
-      if (errors[i - 1] != errors[i])
-        throw xrt_core::error("Invalid error counts within AIE partition");
-    }
-
     _output << boost::str(boost::format("  Partition Index: %d\n") % partition.get<uint64_t>("partition_index"));
     _output << boost::str(boost::format("    Columns: [%s]\n") % column_string);
-    _output << boost::str(boost::format("    Errors: %lu\n") % error_count);
     _output << "    HW Contexts:\n";
     _output << boost::str(boost::format("%s\n") % context_table.toString("      "));
   }

--- a/src/runtime_src/core/tools/common/reports/ReportAiePartitions.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportAiePartitions.cpp
@@ -115,14 +115,12 @@ writeReport(const xrt_core::device* /*_pDevice*/,
     for (const auto& pt_hw_context : partition.get_child("hw_contexts", empty_ptree)) {
       const auto& hw_context = pt_hw_context.second;
 
-      const std::string error_count = std::to_string(hw_context.get<uint64_t>("errors"));
-
       const std::vector<std::string> entry_data = {
         hw_context.get<std::string>("context_id"),
         hw_context.get<std::string>("command_submissions"),
         hw_context.get<std::string>("command_completions"),
         hw_context.get<std::string>("migrations"),
-        error_count
+        std::to_string(hw_context.get<uint64_t>("errors"))
       };
       context_table.addEntry(entry_data);
     }

--- a/src/runtime_src/core/tools/common/reports/ReportAiePartitions.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportAiePartitions.cpp
@@ -104,11 +104,9 @@ writeReport(const xrt_core::device* /*_pDevice*/,
 
     const std::vector<Table2D::HeaderData> table_headers = {
       {"Context ID", Table2D::Justification::left},
-      {"Xclbin UUID", Table2D::Justification::left},
       {"Submissions", Table2D::Justification::left},
       {"Completions", Table2D::Justification::left},
       {"Migrations", Table2D::Justification::left},
-      {"Preemptions", Table2D::Justification::left},
     };
     Table2D context_table(table_headers);
 
@@ -120,11 +118,9 @@ writeReport(const xrt_core::device* /*_pDevice*/,
 
       const std::vector<std::string> entry_data = {
         hw_context.get<std::string>("context_id"),
-        hw_context.get<std::string>("xclbin_uuid"),
         hw_context.get<std::string>("command_submissions"),
         hw_context.get<std::string>("command_completions"),
-        hw_context.get<std::string>("migrations"),
-        hw_context.get<std::string>("preemptions")
+        hw_context.get<std::string>("migrations")
       };
       context_table.addEntry(entry_data);
     }

--- a/src/runtime_src/core/tools/common/reports/ReportElectrical.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportElectrical.cpp
@@ -61,7 +61,6 @@ ReportElectrical::writeReport( const xrt_core::device* _pDevice,
 
   const std::vector<Table2D::HeaderData> table_headers = {
     {"Power Rails", Table2D::Justification::left},
-    {":", Table2D::Justification::left},
     {"Voltage", Table2D::Justification::right},
     {"Current", Table2D::Justification::right}
   };
@@ -74,7 +73,6 @@ ReportElectrical::writeReport( const xrt_core::device* _pDevice,
 
     const std::vector<std::string> entry_data = {
       pt_sensor.get<std::string>("description"),
-      ":",
       (voltage == "N/A") ? voltage : voltage + " V",
       (amps == "N/A") ? amps : amps + " A",
     };

--- a/src/runtime_src/core/tools/common/reports/ReportHost.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportHost.cpp
@@ -53,12 +53,11 @@ static void
 printAlveoDevices(const boost::property_tree::ptree& available_devices, std::ostream& _output)
 {
   const Table2D::HeaderData bdf = {"BDF", Table2D::Justification::left};
-  const Table2D::HeaderData colon = {":", Table2D::Justification::left};
   const Table2D::HeaderData vbnv = {"Shell", Table2D::Justification::left};
   const Table2D::HeaderData id = {"Logic UUID", Table2D::Justification::left};
   const Table2D::HeaderData instance = {"Device ID", Table2D::Justification::left};
   const Table2D::HeaderData ready = {"Device Ready*", Table2D::Justification::left};
-  const std::vector<Table2D::HeaderData> table_headers = {bdf, colon, vbnv, id, instance, ready};
+  const std::vector<Table2D::HeaderData> table_headers = {bdf, vbnv, id, instance, ready};
   Table2D device_table(table_headers);
 
   for (const auto& kd : available_devices) {
@@ -69,7 +68,7 @@ printAlveoDevices(const boost::property_tree::ptree& available_devices, std::ost
 
     const std::string bdf_string = "[" + dev.get<std::string>("bdf") + "]";
     const std::string ready_string = dev.get<bool>("is_ready", false) ? "Yes" : "No";
-    const std::vector<std::string> entry_data = {bdf_string, ":", dev.get<std::string>("vbnv", "n/a"), dev.get<std::string>("id", "n/a"), dev.get<std::string>("instance", "n/a"), ready_string};
+    const std::vector<std::string> entry_data = {bdf_string, dev.get<std::string>("vbnv", "n/a"), dev.get<std::string>("id", "n/a"), dev.get<std::string>("instance", "n/a"), ready_string};
     device_table.addEntry(entry_data);
   }
 
@@ -83,9 +82,8 @@ static void
 printRyzenDevices(const boost::property_tree::ptree& available_devices, std::ostream& _output)
 {
   const Table2D::HeaderData bdf = {"BDF", Table2D::Justification::left};
-  const Table2D::HeaderData colon = {":", Table2D::Justification::left};
   const Table2D::HeaderData name = {"Name", Table2D::Justification::left};
-  const std::vector<Table2D::HeaderData> table_headers = {bdf, colon, name};
+  const std::vector<Table2D::HeaderData> table_headers = {bdf, name};
   Table2D device_table(table_headers);
 
   for (const auto& kd : available_devices) {
@@ -95,7 +93,7 @@ printRyzenDevices(const boost::property_tree::ptree& available_devices, std::ost
       continue;
 
     const std::string bdf_string = "[" + dev.get<std::string>("bdf") + "]";
-    const std::vector<std::string> entry_data = {bdf_string, ":", dev.get<std::string>("name", "n/a")};
+    const std::vector<std::string> entry_data = {bdf_string, dev.get<std::string>("name", "n/a")};
     device_table.addEntry(entry_data);
   }
 
@@ -142,7 +140,7 @@ ReportHost::writeReport(const xrt_core::device* /*_pDevice*/,
     for(auto& drv : available_drivers) {
       const boost::property_tree::ptree& driver = drv.second;
       std::string drv_name = driver.get<std::string>("name", "N/A");
-      boost::algorithm::to_upper(drv_name);
+      boost::algorithm::to_lower(drv_name);
       std::string drv_hash = driver.get<std::string>("hash", "N/A");
       if (!boost::iequals(drv_hash, "N/A")) {
         _output << boost::format("  %-20s : %s, %s\n") % drv_name
@@ -159,8 +157,14 @@ ReportHost::writeReport(const xrt_core::device* /*_pDevice*/,
   }
 
   try {
-    if (!available_devices.empty())
-      _output << boost::format("  %-20s : %s\n") % "Firmware Version" % available_devices.begin()->second.get<std::string>("firmware_version");
+    if (!available_devices.empty()) {
+      // This check depends on the assumption that if there is a RyzenAI device, it is on its own.
+      const boost::property_tree::ptree& dev = available_devices.begin()->second;
+      if (dev.get<std::string>("device_class") == xrt_core::query::device_class::enum_to_str(xrt_core::query::device_class::type::ryzen))
+        _output << boost::format("  %-20s : %s\n") % "NPU Firmware Version" % available_devices.begin()->second.get<std::string>("firmware_version");
+      else
+        _output << boost::format("  %-20s : %s\n") % "Firmware Version" % available_devices.begin()->second.get<std::string>("firmware_version");
+    }
   }
   catch (...) {
     //no device available

--- a/src/runtime_src/core/tools/xbutil2/SubCmdConfigure.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdConfigure.cpp
@@ -13,7 +13,7 @@
 std::vector<std::shared_ptr<OptionOptions>> SubCmdConfigureInternal::optionOptionsCollection = {
   std::make_shared<OO_HostMem>("host-mem"),
   std::make_shared<OO_P2P>("p2p"),
-  std::make_shared<OO_Performance>("performance"),
+  std::make_shared<OO_Performance>("pmode"),
 };
 
 SubCmdConfigure::SubCmdConfigure(bool _isHidden, bool _isDepricated, bool _isPreliminary, const boost::property_tree::ptree& configurations)

--- a/src/runtime_src/core/tools/xbutil2/xbutil.cpp
+++ b/src/runtime_src/core/tools/xbutil2/xbutil.cpp
@@ -54,11 +54,11 @@ R"(
 },{
   "aie": [{
     "examine": [{
-      "report": ["electrical", "host", "platform", "aie", "aiemem", "aieshim", "aie-partitions"]
+      "report": ["electrical", "host", "platform", "aie-partitions"]
     }]
   },{
     "configure": [{
-      "suboption": ["performance"]
+      "suboption": ["pmode"]
     }]
   },{
     "advanced":[{


### PR DESCRIPTION
…except for aie-partitions, performance option rename

#### Problem solved by the commit
Various xbutil cleanup before RyzenAI 1.2 Code Freeze
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
N/A
#### How problem was solved, alternative solutions (if any) and why they were rejected
Host Report
- lowercase driver name
- "NPU Firmware Version" on RyzenAI, "Firmware Version" on Alveo

Configure Subcommand
- `--pmode` instead of `--performance`

2DTable
- add vertical bars between columns

Aie-Partitions Report
- remove xclbin-uuid field and pre-emptions field

Aie, aiemem, and aiemshim Reports
- disable for now on RyzenAI (reports do not yield valid data)
#### Risks (if any) associated the changes in the commit
N/A
#### What has been tested and how, request additional testing if necessary
Tested on Linux and Windows. Sample output on Windows below: 
```
C:\Users\rchane\Desktop\xilinx\xrt>xbutil examine
System Configuration
  OS Name              : Windows NT
  Release              : 26085.ge_release.240315-1352
  Version              : 6.3
  Machine              : x86_64
  CPU Cores            : 24
  Memory               : 32109 MB
  Distribution         : Windows 10 Pro
  Model                : BIRMANPLUS
  BIOS vendor          : AMD    - 0
  BIOS version         : 3.3

XRT
  Version              : 2.18.0
  Branch               : HEAD
  Hash                 : 72a11a748794e6afb2649b46a82367446b94d9c7
  Hash Date            : 2024-06-05 20:29:38
  ipukmddrv            : 10.1.0.1
  NPU Firmware Version : 0.7.20.106

Devices present
|BDF             ||Name  |
|----------------||------|
|[00c5:00:01.1]  ||NPU   |

C:\Users\rchane\Desktop\xilinx\xrt>xbutil configure --help

COMMAND: configure

DESCRIPTION: Device and host configuration.

USAGE: xbutil configure [ --pmode ] [--help] [-d arg]

OPTIONS:
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest
  --help             - Help to use this sub-command
  --pmode            - Change performance mode of the device


GLOBAL OPTIONS:
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation

C:\Users\rchane\Desktop\xilinx\xrt>xbutil configure --pmode performance

Performance mode is set to performance

C:\Users\rchane\Desktop\xilinx\xrt>xbutil examine -r platform  (while df-bw test is running)

---------------------
[00c5:00:01.1] : NPU
---------------------
Platform
  Name                   : NPU
  Performance Mode       : High

Clocks
  H Clock                : 333 MHz
  MP-IPU Clock           : 167 MHz
  ```
Sample AIE Partitions Report
```
AIE Partitions
  Partition Index: 0
    Columns: [0, 1, 2, 3]
    HW Contexts:
      |Context ID  ||Submissions  ||Completions  ||Migrations  ||Errors  |
      |------------||-------------||-------------||------------||--------|
      |0           ||108          ||107          ||0           ||0       |
```
#### Documentation impact (if any)
N/A