### PR TITLE
Add export macro for use of function in different dll

### DIFF
--- a/src/runtime_src/core/common/api/bo_int.h
+++ b/src/runtime_src/core/common/api/bo_int.h
@@ -11,7 +11,8 @@
 
 namespace xrt_core::bo_int {
 
-const xrt_core::buffer_handle*
+XRT_CORE_COMMON_EXPORT  
+xrt_core::buffer_handle*
 get_buffer_handle(const xrt::bo& bo);
 
 size_t

--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -1665,7 +1665,7 @@ bo(const xrt::hw_context& hwctx, pid_type pid, xrt::bo::export_handle ehdl)
 ////////////////////////////////////////////////////////////////
 namespace xrt_core::bo_int {
 
-const xrt_core::buffer_handle*
+xrt_core::buffer_handle*
 get_buffer_handle(const xrt::bo& bo)
 {
   auto handle = bo.get_handle();


### PR DESCRIPTION
Export internal function for use in separate dll.
