### PR TITLE
Larger Debug Buffer Support

### DIFF
--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -246,6 +246,13 @@ get_ml_timeline()
   return value;
 }
 
+inline std::string
+get_ml_timeline_buffer_size()
+{
+  static std::string value = detail::get_string_value("Debug.ml_timeline_buffer_size", "128K");
+  return value;
+}
+
 inline bool
 get_profile_api()
 {

--- a/src/runtime_src/core/tools/common/tests/TestGemm.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestGemm.cpp
@@ -8,6 +8,9 @@
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
+
+#include "core/common/api/bo_int.h"
+
 namespace XBU = XBUtilities;
 
 // System - Include Files
@@ -17,14 +20,7 @@ namespace XBU = XBUtilities;
 
 static constexpr size_t host_app = 1; //opcode
 static constexpr uint32_t num_of_cores = 32;
-static constexpr uint32_t size_4K   = 0x1000;
-static constexpr uint32_t offset_3K = 0x0C00;
-/* Each record timer entry has 32bit ID and 32bit AIE Timer low value.
-* The first 32 bit in the buffer is used to store total number 
-* of record timer entries written so far. So, max_count_in_size_3K is 1 less 
-* than total number of entries possible in 3K buffer section.
-*/ 
-static constexpr uint32_t max_count_in_size_3K = (offset_3K / (2 * sizeof(uint32_t))) - 1;
+
 /*
 * Essentially, we are doing 4 unrolled loop of 8x8_8x8 matmult.
 * Each 8x8_8x8 matmult involves 8x8x8=512 MAC or 512*2 OP=1024 OPs.
@@ -147,14 +143,14 @@ TestGemm::run(std::shared_ptr<xrt_core::device> dev)
     return ptree;
   }
 
-  //Create BOs
+  //Create Instruction BO
   xrt::bo bo_instr(working_dev, instr_size*sizeof(int), XCL_BO_FLAGS_CACHEABLE, kernel.group_id(5));
-  xrt::bo bo_result(working_dev, size_4K, XCL_BO_FLAGS_CACHEABLE, kernel.group_id(5));
-
   init_instr_buf(bo_instr, dpu_instr);
-
-  //Sync BOs
+  //Sync Instruction BO
   bo_instr.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+
+  // Create 128KB Debug BO to capture TOPS data
+  xrt::bo bo_result = xrt_core::bo_int::create_debug_bo(hwctx, 0x20000);
 
   //get current performance mode
   const auto perf_mode = xrt_core::device_query<xrt_core::query::performance_mode>(dev);
@@ -190,10 +186,6 @@ TestGemm::run(std::shared_ptr<xrt_core::device> dev)
   bo_result.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
   auto bo_result_map = bo_result.map<uint8_t*>();
 
-  //Add time delay to wait till the device has transferred data back to the host
-  //To-do: remove this delay after CR-1194803 is fixed
-  std::this_thread::sleep_for(std::chrono::milliseconds(30));
-
   //Calculate TOPS
   if (ipu_hclock == 0) {
     logger(ptree, "Error", "IPU H-clock is 0");
@@ -201,7 +193,8 @@ TestGemm::run(std::shared_ptr<xrt_core::device> dev)
     return ptree;
   }
   double ipu_hclck_period = 1000000000.0 / (ipu_hclock * 1000000); // MHz to ns
-  uint32_t* core_ptr = reinterpret_cast<uint32_t*>(bo_result_map+offset_3K);
+
+  uint32_t* core_ptr = reinterpret_cast<uint32_t*>(bo_result_map);
   double TOPS = 0.0;
   double total_cycle_count = 0.0;
 

--- a/src/runtime_src/xdp/profile/device/common/client_transaction.cpp
+++ b/src/runtime_src/xdp/profile/device/common/client_transaction.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -35,7 +35,7 @@ extern "C" {
 // ***************************************************************
 namespace xdp::aie {
     using severity_level = xrt_core::message::severity_level;
-    static constexpr uint32_t size_4K   = 0x1000;
+
     constexpr std::uint64_t CONFIGURE_OPCODE = std::uint64_t{2};
 
     bool 
@@ -77,25 +77,5 @@ namespace xdp::aie {
       xrt_core::message::send(severity_level::info, "XRT","Successfully scheduled " + transactionName + " instruction buffer.");
       return true;
     }
-
-    xrt::bo 
-    ClientTransaction::syncResults() {
-      // results BO syncs profile result from device
-      xrt::bo result_bo;
-      try {
-        result_bo = xrt::bo(context.get_device(), size_4K, XCL_BO_FLAGS_CACHEABLE, kernel.group_id(1));
-      } catch (std::exception &e) {
-        std::stringstream msg;
-        msg << "Unable to create result buffer for "  << transactionName << ". Cannot get " << transactionName << " Results." << e.what() << std::endl;
-        xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", msg.str());
-        return nullptr;
-      }
-
-      result_bo.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
-
-      return result_bo;
-    }
-
-
 
 } // namespace xdp::aie

--- a/src/runtime_src/xdp/profile/device/common/client_transaction.h
+++ b/src/runtime_src/xdp/profile/device/common/client_transaction.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -29,9 +29,8 @@ namespace xdp::aie {
       ClientTransaction(xrt::hw_context c, std::string tName) : context(c), transactionName(tName) {}
       bool initializeKernel(std::string kernelName);
       bool submitTransaction(uint8_t* txn_ptr);
-      xrt::bo syncResults();
       void setTransactionName(std::string newTransactionName) {transactionName = newTransactionName;}
-      int getGroupID(int id) {return kernel.group_id(id); }
+
     private:
       std::string transactionName;
       xrt::kernel kernel;

--- a/src/runtime_src/xdp/profile/plugin/aie_debug/aie_debug_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_debug/aie_debug_plugin.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
 
 #define XDP_PLUGIN_SOURCE
 
@@ -153,46 +153,6 @@ namespace xdp {
     for (int i = 0; i < op_profile_data.size(); i++)
       op->profile_data[i] = op_profile_data[i];
 
-
-
-    // try {
-    //   mKernel = xrt::kernel(context, "XDP_KERNEL");  
-    // } catch (std::exception &e){
-    //   std::stringstream msg;
-    //   msg << "Unable to find XDP_KERNEL from hardware context. Not configuring AIE Debug. " << e.what() ;
-    //   xrt_core::message::send(severity_level::warning, "XRT", msg.str());
-    //   return;
-    // }
-
-
-
-    // op_buf instr_buf;
-    // instr_buf.addOP(transaction_op(txn_ptr));
-
-    // Initialize instructions
-    // try {
-    //   instr_bo = xrt::bo(context.get_device(), instr_buf.ibuf_.size(), XCL_BO_FLAGS_CACHEABLE, mKernel.group_id(1));
-    // } catch (std::exception &e){
-    //   std::stringstream msg;
-    //   msg << "Unable to create the instruction buffer for polling during AIE Debug. " << e.what() << std::endl;
-    //   xrt_core::message::send(severity_level::warning, "XRT", msg.str());
-    //   return;
-    // }
-    // instr_bo.write(instr_buf.ibuf_.data());
-    // instr_bo.sync(XCL_BO_SYNC_BO_TO_DEVICE);
-
-    // // results BO syncs AIE Debug result from device
-    // try {
-    //   result_bo = xrt::bo(context.get_device(), size_4K, XCL_BO_FLAGS_CACHEABLE, mKernel.group_id(1));
-    // } catch (std::exception &e) {
-    //   std::stringstream msg;
-    //   msg << "Unable to create result buffer for AIE Debug. Cannot get AIE Debug Info." << e.what() << std::endl;
-    //   xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", msg.str());
-    //   return;
-    // }
-
-    XAie_ClearTransaction(&aieDevInst);
-
   #if 0
     /* For larger debug buffer support, only one Debug BO can be aliva at a time.
      * Need ML Timeline Buffer to be created at update device to capture all calls.
@@ -286,12 +246,12 @@ namespace xdp {
       resultBO = xrt_core::bo_int::create_debug_bo(mHwContext, 0x20000);
     } catch (std::exception& e) {
       std::stringstream msg;
-      msg << "Unable to create result buffer for AIE Debug. Cannot get AIE Debug info. " << e.what() << std::endl;
+      msg << "Unable to create 128KB buffer for AIE Debug results. Cannot get AIE Debug info. " << e.what() << std::endl;
       xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", msg.str());
       return;
     }
 
-        XAie_StartTransaction(&aieDevInst, XAIE_TRANSACTION_DISABLE_AUTO_FLUSH);
+    XAie_StartTransaction(&aieDevInst, XAIE_TRANSACTION_DISABLE_AUTO_FLUSH);
     // Profiling is 3rd custom OP
     XAie_RequestCustomTxnOp(&aieDevInst);
     XAie_RequestCustomTxnOp(&aieDevInst);
@@ -302,7 +262,6 @@ namespace xdp {
 
     XAie_AddCustomTxnOp(&aieDevInst, (uint8_t)read_op_code_, (void*)op, op_size);
     txn_ptr = XAie_ExportSerializedTransaction(&aieDevInst, 1, 0);
-
 
     if (!transactionHandler->submitTransaction(txn_ptr))
       return;

--- a/src/runtime_src/xdp/profile/plugin/aie_debug/aie_debug_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_debug/aie_debug_plugin.cpp
@@ -283,7 +283,7 @@ namespace xdp {
 
     xrt::bo resultBO;
     try {
-      resultBO = xrt_core::bo_int::create_debug_bo(mHwContext, 0x2000);
+      resultBO = xrt_core::bo_int::create_debug_bo(mHwContext, 0x20000);
     } catch (std::exception& e) {
       std::stringstream msg;
       msg << "Unable to create result buffer for AIE Debug. Cannot get AIE Debug info. " << e.what() << std::endl;

--- a/src/runtime_src/xdp/profile/plugin/aie_debug/aie_debug_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_debug/aie_debug_plugin.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
 
 #ifndef XDP_AIE_DEBUG_PLUGIN_DOT_H
 #define XDP_AIE_DEBUG_PLUGIN_DOT_H

--- a/src/runtime_src/xdp/profile/plugin/aie_debug/aie_debug_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_debug/aie_debug_plugin.h
@@ -14,7 +14,6 @@
 
 #include "core/include/xrt/xrt_hw_context.h"
 
-
 extern "C" {
   #include <xaiengine.h>
   #include <xaiengine/xaiegbl_params.h>
@@ -46,6 +45,7 @@ namespace xdp {
       {module_type::mem_tile, "Memory Tile"}
     };
     
+    xrt::hw_context mHwContext;
     std::unique_ptr<aie::ClientTransaction> transactionHandler;
     uint8_t* txn_ptr;
     XAie_DevInst aieDevInst = {0};

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/client/aie_profile.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/client/aie_profile.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/client/aie_profile.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/client/aie_profile.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.cpp
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.cpp
@@ -36,53 +36,39 @@ namespace xdp {
   MLTimelineClientDevImpl::MLTimelineClientDevImpl(VPDatabase*dB)
     : MLTimelineImpl(dB)
   {
-    xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT", "Created ML Timeline Plugin for Client Device.");
+    xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT", 
+              "Created ML Timeline Plugin for Client Device.");
   }
 
   void MLTimelineClientDevImpl::updateDevice(void* /*hwCtxImpl*/)
   {
+    xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT", 
+              "In MLTimelineClientDevImpl::updateDevice");
+    try {
+      obj->mResultBO = xrt_core::bo_int::create_debug_bo(mHwContext, mBufSz);
+      
+    } catch (std::exception& e) {
+      std::stringstream msg;
+      msg << "Unable to create result buffer of size "
+          << std::hex << mBufSz << std::dec
+          << " Bytes for Record Timer Values. Cannot get ML Timeline info. " 
+          << e.what() << std::endl;
+      xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", msg.str());
+      return;
+    }
+    xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT", 
+              "Allocated buffer In MLTimelineClientDevImpl::updateDevice");
   }
 
   void MLTimelineClientDevImpl::finishflushDevice(void* /*hwCtxImpl*/)
   {
-    xrt::kernel instKernel;
-    try {
-      // Currently this kernel helps in creating XRT BO connected to SRAM memory
-      instKernel = xrt::kernel(mHwContext, "XDP_KERNEL");
-    }
-    catch (std::exception& e) {
-      std::stringstream msg;
-      msg << "Unable to find XDP_KERNEL kernel from hardware context. Cannot get ML Timeline info. " << e.what();
-      xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", msg.str());
-      return;
-    }
-
-    static constexpr uint32_t size_4K = 0x1000;
-
-    // Read Record Timer TS buffer
-    xrt::bo resultBO;
-    try {
-      resultBO = xrt::bo(mHwContext.get_device(), size_4K, XCL_BO_FLAGS_CACHEABLE, instKernel.group_id(1));
-    }
-    catch (std::exception& e) {
-      std::stringstream msg;
-      msg << "Unable to create result buffer for Record Timer Values. Cannot get ML Timeline info. " << e.what() << std::endl;
-      xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", msg.str());
-      return;
-    }
-
-    auto resultBOMap = resultBO.map<uint8_t*>();
-    resultBO.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
-
+    xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT", 
+              "Using Allocated buffer In MLTimelineClientDevImpl::finishflushDevice");
+    obj->mResultBO.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
+    
+    auto resultBOMap = obj->mResultBO.map<uint8_t*>();
     uint32_t* ptr = reinterpret_cast<uint32_t*>(resultBOMap);
-
-    // Assuming correct Stub has been called and Write Buffer contains valid data
-    uint32_t numEntries = *ptr;    // First 32bits contains the total num of entries
-
-    std::string msg = "Found " + std::to_string(numEntries) + " ML timestamps have been recorded.";
-    xrt_core::message::send(xrt_core::message::severity_level::info, "XRT", msg);
-
-    // Record Timer TS in JSON
+      
     boost::property_tree::ptree ptTop;
     boost::property_tree::ptree ptHeader;
     boost::property_tree::ptree ptRecordTimerTS;
@@ -100,25 +86,35 @@ namespace xdp {
     ptHeader.put("clock_freq_MHz", 1000);
     ptTop.add_child("header", ptHeader);
 
-    /* Each record timer entry has 32bit ID and 32bit AIE Timer low value.
-     * Also, the first 32 bit in the buffer is used to store total number 
-     * of record timer entries written so far. So, max_count_in_size_3K is 1 less 
-     * than total number of entries possible in 3K buffer section.
-     */ 
-    static constexpr uint32_t max_count_in_size_3K = (0x0C00 / (2 * sizeof(uint32_t))) - 1;
+    // Record Timer TS in JSON
+    // Assuming correct Stub has been called and Write Buffer contains valid data
+    
+    uint32_t max_count = mBufSz / (2*sizeof(uint32_t));
+    // Each record timer entry has 32bit ID and 32bit AIE Timer low value.
 
-    if (numEntries <= max_count_in_size_3K) {
-      ptr++;
+    uint32_t numEntries = max_count;    // First 32bits contains the total num of entries
+    std::stringstream msg;
+    msg << " A maximum of " << numEntries << " record can be accommodated in given buffer of bytes size"
+        << std::hex << mBufSz << std::dec << std::endl;
+    xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT", msg.str());
+
+    if (numEntries <= max_count) {
       for (uint32_t i = 0 ; i < numEntries; i++) {
         boost::property_tree::ptree ptIdTS;
         ptIdTS.put("id", *ptr);
         ptr++;
+        if (0 == *ptr) {
+          // Zero value for Timestamp in cycles indicates end of recorded data
+          std::string msgEntries = " Got " + std::to_string(i) + " records in buffer";
+          xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT", msgEntries);
+          break;
+        }
         ptIdTS.put("cycle", *ptr);
         ptr++;
 
         ptRecordTimerTS.push_back(std::make_pair("", ptIdTS));
       }
-    }
+    }    
 
     if (ptRecordTimerTS.empty()) {
       boost::property_tree::ptree ptEmpty;
@@ -138,7 +134,10 @@ namespace xdp {
     fOut.open("record_timer_ts.json");
     fOut << result;
     fOut.close();
-    xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT", "Completed writing recorded timestamps to record_timer_ts.json.");
+
+    xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT", 
+              "Finished writing record_timer_ts.json in MLTimelineClientDevImpl::finishflushDevice");
+
   }
 }
 

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.cpp
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.cpp
@@ -53,7 +53,7 @@ namespace xdp {
       uint32_t*
       map()
       {
-        return mBO.map<uint32_t>();
+        return mBO.map<uint32_t*>();
       }
   };
 

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.cpp
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.cpp
@@ -71,6 +71,11 @@ namespace xdp {
               "In MLTimelineClientDevImpl::updateDevice");
     try {
 
+      /* Use a container for Debug BO for results to control its lifetime.
+       * The result BO should be deleted after reading out recorded data in
+       * finishFlushDevice so that AIE Profile/Debug Plugins, if enabled,
+       * can use their own Debug BO to capture their data.
+       */
       mResultBOHolder = new ResultBOContainer(mHwContext, mBufSz);
 
     } catch (std::exception& e) {
@@ -117,7 +122,7 @@ namespace xdp {
     uint32_t max_count = mBufSz / (2*sizeof(uint32_t));
     // Each record timer entry has 32bit ID and 32bit AIE Timer low value.
 
-    uint32_t numEntries = max_count;    // First 32bits contains the total num of entries
+    uint32_t numEntries = max_count;
     std::stringstream msg;
     msg << " A maximum of " << numEntries << " record can be accommodated in given buffer of bytes size"
         << std::hex << mBufSz << std::dec << std::endl;
@@ -163,7 +168,9 @@ namespace xdp {
     xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT", 
               "Finished writing record_timer_ts.json in MLTimelineClientDevImpl::finishflushDevice");
 
-    // Destroy the Result BO
+    /* Delete the result BO so that AIE Profile/Debug Plugins, if enabled,
+     * can use their own Debug BO to capture their data.
+     */
     delete mResultBOHolder;
     mResultBOHolder = nullptr;
   }

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.cpp
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.cpp
@@ -39,6 +39,10 @@ namespace xdp {
     xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT", "Created ML Timeline Plugin for Client Device.");
   }
 
+  void MLTimelineClientDevImpl::updateDevice(void* /*hwCtxImpl*/)
+  {
+  }
+
   void MLTimelineClientDevImpl::finishflushDevice(void* /*hwCtxImpl*/)
   {
     xrt::kernel instKernel;

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.h
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.h
@@ -29,6 +29,7 @@ namespace xdp {
 
       ~MLTimelineClientDevImpl() = default;
 
+      virtual void updateDevice(void* hwCtxImpl);
       virtual void finishflushDevice(void* hwCtxImpl);
   };
 

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.h
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.h
@@ -17,6 +17,8 @@
 #ifndef XDP_PLUGIN_ML_TIMELINE_CLIENTDEV_IMPL_H
 #define XDP_PLUGIN_ML_TIMELINE_CLIENTDEV_IMPL_H
 
+#include "core/common/api/bo_int.h"
+
 #include "xdp/config.h"
 #include "xdp/profile/plugin/ml_timeline/ml_timeline_impl.h"
 
@@ -24,6 +26,8 @@ namespace xdp {
 
   class MLTimelineClientDevImpl : public MLTimelineImpl
   {
+    xrt::bo  mResultBO;
+
     public :
       MLTimelineClientDevImpl(VPDatabase* dB);
 

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.h
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.h
@@ -17,17 +17,15 @@
 #ifndef XDP_PLUGIN_ML_TIMELINE_CLIENTDEV_IMPL_H
 #define XDP_PLUGIN_ML_TIMELINE_CLIENTDEV_IMPL_H
 
-#include "core/common/api/bo_int.h"
-
 #include "xdp/config.h"
 #include "xdp/profile/plugin/ml_timeline/ml_timeline_impl.h"
 
 namespace xdp {
 
+  class ResultBOContainer;
   class MLTimelineClientDevImpl : public MLTimelineImpl
   {
-    xrt::bo  mResultBO;
-
+    ResultBOContainer* mResultBOHolder;
     public :
       MLTimelineClientDevImpl(VPDatabase* dB);
 

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_impl.h
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_impl.h
@@ -39,6 +39,7 @@ namespace xdp {
 
       virtual ~MLTimelineImpl() {}
 
+      virtual void updateDevice(void*) = 0;
       virtual void finishflushDevice(void*) = 0;
 
       void setHwContext(xrt::hw_context ctx)

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_impl.h
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_impl.h
@@ -25,10 +25,10 @@ namespace xdp {
 
   class MLTimelineImpl
   {
-
     protected :
       VPDatabase* db = nullptr;
       xrt::hw_context mHwContext;
+      uint32_t mBufSz;
 
     public:
       MLTimelineImpl(VPDatabase* dB)
@@ -45,6 +45,11 @@ namespace xdp {
       void setHwContext(xrt::hw_context ctx)
       {
         mHwContext = std::move(ctx);
+      }
+      
+      void setBufSize(uint32_t sz)
+      {
+        mBufSz = sz;
       }
   };
 

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_plugin.cpp
@@ -79,6 +79,7 @@ namespace xdp {
     DeviceDataEntry.valid = true;
     DeviceDataEntry.implementation = std::make_unique<MLTimelineClientDevImpl>(db);
     DeviceDataEntry.implementation->setHwContext(hwContext);
+    DeviceDataEntry.implementation->setBufSize(0x20000);  // 128KB
     DeviceDataEntry.implementation->updateDevice(mHwCtxImpl);
 #endif
   }

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_plugin.cpp
@@ -79,6 +79,7 @@ namespace xdp {
     DeviceDataEntry.valid = true;
     DeviceDataEntry.implementation = std::make_unique<MLTimelineClientDevImpl>(db);
     DeviceDataEntry.implementation->setHwContext(hwContext);
+    DeviceDataEntry.implementation->updateDevice(mHwCtxImpl);
 #endif
   }
 

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_plugin.cpp
@@ -16,6 +16,9 @@
 
 #define XDP_PLUGIN_SOURCE
 
+#include<regex>
+#include<string>
+
 #include "core/common/device.h"
 #include "core/common/message.h"
 #include "core/common/api/hw_context_int.h"
@@ -34,7 +37,7 @@ namespace xdp {
 
   uint32_t ParseMLTimelineBufferSizeConfig()
   {
-    uint32_t bufSz = 0;
+    uint32_t bufSz = 0x20000;
     std::string szCfgStr = xrt_core::config::get_ml_timeline_buffer_size();
     std::smatch subStr;
 
@@ -58,6 +61,7 @@ namespace xdp {
       xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT",
                 "Invalid string specified for ML Timeline Buffer Size");
     }
+    return bufSz;
   }
 
   MLTimelinePlugin::MLTimelinePlugin()

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_plugin.h
@@ -47,6 +47,7 @@ namespace xdp {
     } DeviceDataEntry;
 
     void* mHwCtxImpl = nullptr;
+    uint32_t mBufSz  = 0x20000;
 
   };
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Enable use of larger debug buffer in ML Timeline, AIE Profile and AIE Debug on Client devices.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Due to limited buffer size on device, we could only get few hundred timestamps for ML Timeline feature which is far short of requirement for most ML designs.
With help of support in driver and ert, we can now sync from device to host when device buffer is full. This facilitates larger debug buffer sufficient to hold data from ML designs.

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Unit and large models on device

#### Documentation impact (if any)
