### PR TITLE
Petalinux: moving to latest petalinux for 2024.1

### DIFF
--- a/build/petalinux.build
+++ b/build/petalinux.build
@@ -1,3 +1,3 @@
 # When updating Petalinux build please file a SH ticket to retain the build
 # https://jira.xilinx.com/secure/CreateIssue!default.jspa
-PETALINUX="/proj/petalinux/2024.1/petalinux-v2024.1_03142213/tool/petalinux-v2024.1-final"
+PETALINUX="/proj/petalinux/2024.1/petalinux-v2024.1_05202009/tool/petalinux-v2024.1-final"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Moving to latest 2024.1 petalinux for XRT 2024.1
The sh ticket https://jira.xilinx.com/browse/SH-2467 to retain this build 
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit
Low
#### What has been tested and how, request additional testing if necessary
Built apu package and tested on v70pq2 (xbutil validate, reset, program)
#### Documentation impact (if any)
