### PR TITLE
VITIS-11824 Consolidate examine reports, xrt-smi cleanup

### DIFF
--- a/src/runtime_src/core/common/info_platform.cpp
+++ b/src/runtime_src/core/common/info_platform.cpp
@@ -4,6 +4,7 @@
 #define XRT_CORE_COMMON_SOURCE
 #include "info_platform.h"
 #include "query_requests.h"
+#include "sensor.h"
 #include "utils.h"
 #include "xclbin.h"
 
@@ -352,6 +353,17 @@ add_clock_info(const xrt_core::device* device, ptree_type& pt)
 }
 
 void
+add_electrical_info(const xrt_core::device* device, ptree_type& pt)
+{
+  try {
+    pt.put_child("electrical", xrt_core::sensor::read_electrical(device));
+  }
+  catch (const xq::exception&) {
+    // ignoring if not available: Edge Case
+  }
+}
+
+void
 add_mac_info(const xrt_core::device* device, ptree_type& pt)
 {
   ptree_type pt_mac;
@@ -412,6 +424,11 @@ add_platform_info(const xrt_core::device* device, ptree_type& pt_platform_array)
     add_clock_info(device, pt_platform);
     add_mac_info(device, pt_platform);
     add_config_info(device, pt_platform);
+    break;
+  }
+  case xrt_core::query::device_class::type::ryzen:
+  {
+    add_electrical_info(device, pt_platform);
     break;
   }
   default:

--- a/src/runtime_src/core/tools/common/reports/ReportAiePartitions.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportAiePartitions.cpp
@@ -31,11 +31,9 @@ populate_aie_partition(const xrt_core::device* device)
 
     boost::property_tree::ptree pt_entry;
     pt_entry.put("context_id", entry.metadata.id);
-    pt_entry.put("xclbin_uuid", entry.metadata.xclbin_uuid);
     pt_entry.put("command_submissions", entry.command_submissions);
     pt_entry.put("command_completions", entry.command_completions);
     pt_entry.put("migrations", entry.migrations);
-    pt_entry.put("preemptions", entry.preemptions);
     pt_entry.put("errors", entry.errors);
 
     partition.first->second.push_back(std::make_pair("", pt_entry));

--- a/src/runtime_src/core/tools/common/reports/ReportElectrical.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportElectrical.cpp
@@ -5,7 +5,6 @@
 #include "ReportElectrical.h"
 #include "tools/common/Table2D.h"
 #include "core/common/sensor.h"
-#include "core/common/query_requests.h"
 
 #include <boost/property_tree/json_parser.hpp>
 
@@ -27,7 +26,7 @@ ReportElectrical::getPropertyTree20202( const xrt_core::device * _pDevice,
 }
 
 void
-ReportElectrical::writeReport( const xrt_core::device* _pDevice,
+ReportElectrical::writeReport( const xrt_core::device* /*_pDevice*/,
                                const boost::property_tree::ptree& _pt,
                                const std::vector<std::string>& /*_elementsFilter*/,
                                std::ostream & _output) const
@@ -37,19 +36,9 @@ ReportElectrical::writeReport( const xrt_core::device* _pDevice,
   _output << "Electrical\n";
   const boost::property_tree::ptree& electricals = _pt.get_child("electrical.power_rails", empty_ptree);
 
-  std::string max_watts = "N/A";
-  switch (xrt_core::device_query_default<xrt_core::query::device_class>(_pDevice, xrt_core::query::device_class::type::alveo)) {
-  case xrt_core::query::device_class::type::alveo:
-  {
-    max_watts = _pt.get<std::string>("electrical.power_consumption_max_watts", "N/A");
-    if (max_watts != "N/A")
-      _output << boost::format("  %-23s: %s Watts\n") % "Max Power" % max_watts;
-    break;
-  }
-  case xrt_core::query::device_class::type::ryzen:
-    // We currently do not have Max Power from Ryzen devices.
-    break;
-  }
+  auto max_watts = _pt.get<std::string>("electrical.power_consumption_max_watts", "N/A");
+  if (max_watts != "N/A")
+    _output << boost::format("  %-23s: %s Watts\n") % "Max Power" % max_watts;
 
   auto watts = _pt.get<std::string>("electrical.power_consumption_watts", "N/A");
   if (watts != "N/A")

--- a/src/runtime_src/core/tools/common/reports/ReportHost.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportHost.cpp
@@ -114,7 +114,6 @@ ReportHost::writeReport(const xrt_core::device* /*_pDevice*/,
   try {
     _output << boost::format("  %-20s : %s\n") % "OS Name" % _pt.get<std::string>("host.os.sysname");
     _output << boost::format("  %-20s : %s\n") % "Release" % _pt.get<std::string>("host.os.release");
-    _output << boost::format("  %-20s : %s\n") % "Version" % _pt.get<std::string>("host.os.version");
     _output << boost::format("  %-20s : %s\n") % "Machine" % _pt.get<std::string>("host.os.machine");
     _output << boost::format("  %-20s : %s\n") % "CPU Cores" % _pt.get<std::string>("host.os.cores");
     _output << boost::format("  %-20s : %lld MB\n") % "Memory" % (std::strtoll(_pt.get<std::string>("host.os.memory_bytes").c_str(),nullptr,16) / BYTES_TO_MEGABYTES);

--- a/src/runtime_src/core/tools/common/reports/platform/ReportRyzenPlatform.cpp
+++ b/src/runtime_src/core/tools/common/reports/platform/ReportRyzenPlatform.cpp
@@ -29,7 +29,7 @@ ReportRyzenPlatform::getPropertyTree20202(const xrt_core::device* dev,
   std::stringstream ss;
   ss << device.get_info<xrt::info::device::platform>();
   boost::property_tree::read_json(ss, pt_platform);
- 
+
   // There can only be 1 root node
   pt = pt_platform;
 }
@@ -61,6 +61,9 @@ ReportRyzenPlatform::writeReport(const xrt_core::device* /*_pDevice*/,
         _output << boost::format("  %-23s: %3s MHz\n") % clock_name_type % pt_clock.get<std::string>("freq_mhz");
       }
     }
+
+    auto watts = pt_platform.get<std::string>("electrical.power_consumption_watts", "N/A");
+    _output << std::endl << boost::format("%-23s: %s Watts\n") % "Power" % watts;
   }
 
   _output << std::endl;

--- a/src/runtime_src/core/tools/xbutil2/OO_Performance.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_Performance.cpp
@@ -15,7 +15,7 @@ namespace po = boost::program_options;
 // ----- C L A S S   M E T H O D S -------------------------------------------
 
 OO_Performance::OO_Performance( const std::string &_longName, bool _isHidden )
-    : OptionOptions(_longName, _isHidden, "Change performance mode of the device")
+    : OptionOptions(_longName, _isHidden, "Change power mode of the device")
     , m_device("")
     , m_action("")
     , m_help(false)
@@ -34,7 +34,7 @@ OO_Performance::OO_Performance( const std::string &_longName, bool _isHidden )
 void
 OO_Performance::execute(const SubCmdOptions& _options) const
 {
-  XBUtilities::verbose("SubCommand option: Performance");
+  XBUtilities::verbose("SubCommand option: Power Mode");
 
   XBUtilities::verbose("Option(s):");
   for (auto & aString : _options)
@@ -93,7 +93,7 @@ OO_Performance::execute(const SubCmdOptions& _options) const
       printHelp();
       throw xrt_core::error(std::errc::operation_canceled);
     }
-    std::cout << boost::format("\nPerformance mode is set to %s \n") % (boost::algorithm::to_lower_copy(m_action));
+    std::cout << boost::format("\nPower mode is set to %s \n") % (boost::algorithm::to_lower_copy(m_action));
   }
   catch(const xrt_core::error& e) {
     std::cerr << boost::format("\nERROR: %s\n") % e.what();

--- a/src/runtime_src/core/tools/xbutil2/xbutil.cpp
+++ b/src/runtime_src/core/tools/xbutil2/xbutil.cpp
@@ -54,7 +54,7 @@ R"(
 },{
   "aie": [{
     "examine": [{
-      "report": ["electrical", "host", "platform", "aie-partitions"]
+      "report": ["host", "platform", "aie-partitions"]
     }]
   },{
     "configure": [{


### PR DESCRIPTION
#### Problem solved by the commit
https://jira.xilinx.com/browse/VITIS-11824: On RyzenAI, move electrical info to platform report and remove electrical report
https://jira.xilinx.com/browse/CR-1201177: Fix/refine xrt-smi examine host report
Cleanup the removed fields in aie-partitions report from json output, clarified pmode as "power mode" in configure subcmd
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Above issues were brought up in xrt-smi review/suggestions.
#### How problem was solved, alternative solutions (if any) and why they were rejected
Implemented as asked. Note that Distribution in host report still says Windows 10 Enterprise; we are using the registry we were given. Also reverted https://github.com/Xilinx/XRT/pull/8088 now that RyzenAI does not have a dedicated electrical report any longer.
#### Risks (if any) associated the changes in the commit
N/A
#### What has been tested and how, request additional testing if necessary
Host Report Output:
```
C:\Users\rchane\Desktop\xrt>xrt-smi examine
System Configuration
  OS Name              : Windows NT
  Release              : 26085
  Machine              : x86_64
  CPU Cores            : 24
  Memory               : 32109 MB
  Distribution         : Windows 10 Enterprise
  Model                : BIRMANPLUS
  BIOS vendor          : AMD
  BIOS version         : WXB4424N

XRT
  Version              : 2.18.0
  Branch               : HEAD
  Hash                 : 51fc7e796f818979183ffe39428b4a6f164ebdd9
  Hash Date            : 2024-06-11 13:50:49
  ipukmddrv            : 10.1.0.1
  NPU Firmware Version : 0.7.21.108

Devices present
|BDF             ||Name  |
|----------------||------|
|[00c5:00:01.1]  ||NPU   |
```

Electrical info is now in the platform report for RyzenAI.
```
C:\Users\rchane\Desktop\xrt>xrt-smi examine -r platform

---------------------
[00c5:00:01.1] : NPU
---------------------
Platform
  Name                   : NPU
  Performance Mode       : Default

Clocks
  H Clock                : 1810 MHz
  MP-IPU Clock           : 1267 MHz

Power                  : 1.272 Watts
```

Electrical report has been removed for RyzenAI.
```
C:\Users\rchane\Desktop\xrt>xrt-smi examine --help

COMMAND: examine

DESCRIPTION: This command will 'examine' the state of the system/device and will generate a report of interest
               in a text or JSON format.

USAGE: xrt-smi examine [--help] [-d arg] [-f arg] [-o arg] [-r arg]

OPTIONS:
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest
  -f, --format       - Report output format. Valid values are:
                         JSON        - Latest JSON schema
                         JSON-2020.2 - JSON 2020.2 schema
  -o, --output       - Direct the output to the given file
  --help             - Help to use this sub-command
  -r, --report       - The type of report to be produced. Reports currently available are:
                         aie-partitions - AIE partition information
                         all            - All known reports are produced
                         host           - Host information
                         platform       - Platforms flashed on the device


GLOBAL OPTIONS:
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
```

Configure updates.
```
C:\Users\rchane\Desktop\xrt>xrt-smi configure --help

COMMAND: configure

DESCRIPTION: Device and host configuration.

USAGE: xrt-smi configure [ --pmode ] [--help] [-d arg]

OPTIONS:
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest
  --help             - Help to use this sub-command
  --pmode            - Change power mode of the device


GLOBAL OPTIONS:
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation

C:\Users\rchane\Desktop\xrt>xrt-smi configure --pmode performance

Power mode is set to performance
```
#### Documentation impact (if any)
N/A