### PR TITLE
Add getGroupID for memory port identifier in Txn handler

### DIFF
--- a/src/runtime_src/xdp/profile/device/common/client_transaction.h
+++ b/src/runtime_src/xdp/profile/device/common/client_transaction.h
@@ -30,6 +30,7 @@ namespace xdp::aie {
       bool initializeKernel(std::string kernelName);
       bool submitTransaction(uint8_t* txn_ptr);
       void setTransactionName(std::string newTransactionName) {transactionName = newTransactionName;}
+      int  getGroupID(int id) {return kernel.group_id(id); }
 
     private:
       std::string transactionName;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
getGroupID API in Client Txn handler was removed. But AIE Trace Offloader still uses that for trace BOs. So, we need to add it back.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://github.com/Xilinx/XRT/pull/8231 added the bug

#### How problem was solved, alternative solutions (if any) and why they were rejected
Bring back getGroupID API in Client Txn handler

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
