### PR TITLE
VITIS-11024 enable hw_context support for xrt::graph objects

### DIFF
--- a/src/runtime_src/core/common/api/aie/xrt_graph.cpp
+++ b/src/runtime_src/core/common/api/aie/xrt_graph.cpp
@@ -20,6 +20,7 @@
 #include "core/common/error.h"
 #include "core/common/message.h"
 #include "core/common/system.h"
+#include "core/common/shim/graph_handle.h"
 
 #include <limits>
 #include <memory>
@@ -30,17 +31,22 @@ class graph_impl
 {
 private:
   std::shared_ptr<xrt_core::device> device;
-  xclGraphHandle handle;
+  xrt::hw_context hw_ctx;
+  std::unique_ptr<xrt_core::graph_handle> m_graphHandle;
 
 public:
-  graph_impl(std::shared_ptr<xrt_core::device> dev, xclGraphHandle ghdl)
-    : device(std::move(dev))
-    , handle(ghdl)
+  graph_impl(std::shared_ptr<xrt_core::device> dev, const xrt::uuid& xclbin_id,
+                const std::string& name, graph::access_mode am)
+    : device{std::move(dev)},
+      m_graphHandle{device->open_graph_handle(xclbin_id, name.c_str(), am)}
   {}
 
-  ~graph_impl()
+  graph_impl(xrt::hw_context hwctx, const std::string& name, graph::access_mode am)
+      : device{hwctx.get_device().get_handle()}
+      , hw_ctx{std::move(hwctx)}
   {
-    device->close_graph(handle);
+    auto hwctx_handle{static_cast<xrt_core::hwctx_handle*>(hw_ctx)};
+    m_graphHandle = hwctx_handle->open_graph_handle(name.c_str(),am);
   }
 
   graph_impl() = delete;
@@ -49,70 +55,64 @@ public:
   graph_impl& operator=(const graph_impl&) = delete;
   graph_impl& operator=(graph_impl&&) = delete;
 
-  [[nodiscard]] xclGraphHandle
-  get_handle() const
-  {
-    return handle;
-  }
-
   void
   reset()
   {
-    device->reset_graph(handle);
+    m_graphHandle->reset_graph();
   }
 
   uint64_t
   get_timestamp()
   {
-    return (device->get_timestamp(handle));
+    return (m_graphHandle->get_timestamp());
   }
 
   void
   run(int iterations)
   {
-    device->run_graph(handle, iterations);
+    m_graphHandle->run_graph(iterations);
   }
 
   int
   wait(int timeout)
   {
-    return (device->wait_graph_done(handle, timeout));
+    return (m_graphHandle->wait_graph_done(timeout));
   }
 
   void
   wait(uint64_t cycle)
   {
-    device->wait_graph(handle, cycle);
+    m_graphHandle->wait_graph(cycle);
   }
 
   void
   suspend()
   {
-    device->suspend_graph(handle);
+    m_graphHandle->suspend_graph();
   }
 
   void
   resume()
   {
-    device->resume_graph(handle);
+    m_graphHandle->resume_graph();
   }
 
   void
   end(uint64_t cycle)
   {
-    device->end_graph(handle, cycle);
+    m_graphHandle->end_graph(cycle);
   }
 
   void
   update_rtp(const char* port, const char* buffer, size_t size)
   {
-    device->update_graph_rtp(handle, port, buffer, size);
+    m_graphHandle->update_graph_rtp(port, buffer, size);
   }
 
   void
   read_rtp(const char* port, char* buffer, size_t size)
   {
-    device->read_graph_rtp(handle, port, buffer, size);
+    m_graphHandle->read_graph_rtp(port, buffer, size);
   }
 };
 
@@ -194,17 +194,9 @@ static std::shared_ptr<xrt::graph_impl>
 open_graph(xrtDeviceHandle dhdl, const xuid_t xclbin_uuid, const char* graph_name, xrt::graph::access_mode am)
 {
   auto core_device = xrt_core::device_int::get_core_device(dhdl);
-  auto handle = core_device->open_graph(xclbin_uuid, graph_name, am);
-  auto ghdl = std::make_shared<xrt::graph_impl>(core_device, handle);
-  return ghdl;
-}
-
-static std::shared_ptr<xrt::graph_impl>
-open_graph(const xrt::device& device, const xrt::uuid& xclbin_id, const std::string& name, xrt::graph::access_mode am)
-{
-  auto core_device = device.get_handle();
-  auto handle = core_device->open_graph(xclbin_id.get(), name.c_str(), am);
-  auto ghdl = std::make_shared<xrt::graph_impl>(core_device, handle);
+  xrt::uuid xclbin_id{xclbin_uuid};
+  std::string name{graph_name};
+  auto ghdl = std::make_shared<xrt::graph_impl>(core_device, xclbin_id, name, am);
   return ghdl;
 }
 
@@ -295,7 +287,12 @@ namespace xrt {
 
 graph::
 graph(const xrt::device& device, const xrt::uuid& xclbin_id, const std::string& name, graph::access_mode am)
-  : handle(open_graph(device, xclbin_id, name, am))
+  : handle{std::make_shared<xrt::graph_impl>(device.get_handle(), xclbin_id, name, am)}
+{}
+
+graph::
+graph(const xrt::hw_context& hwctx, const std::string& name, graph::access_mode am)
+    : handle{std::make_shared<xrt::graph_impl>(hwctx, name, am)}
 {}
 
 void

--- a/src/runtime_src/core/common/ishim.h
+++ b/src/runtime_src/core/common/ishim.h
@@ -11,6 +11,7 @@
 #include "core/common/shim/hwctx_handle.h"
 #include "core/include/shim_int.h"
 #include "core/include/xdp/counters.h"
+#include "core/common/shim/graph_handle.h"
 
 #include "xrt/xrt_aie.h"
 #include "xrt/xrt_bo.h"
@@ -197,45 +198,15 @@ struct ishim
   virtual std::cv_status
   wait_ip_interrupt(xclInterruptNotifyHandle, int32_t)
   { throw not_supported_error{__func__}; }
+
+  virtual std::unique_ptr<graph_handle>
+  open_graph_handle(const xrt::uuid&, const char*, xrt::graph::access_mode)
+  {
+    throw not_supported_error{__func__};
+  }
   ////////////////////////////////////////////////////////////////
 
 #ifdef XRT_ENABLE_AIE
-  virtual xclGraphHandle
-  open_graph(const xrt::uuid&, const char*, xrt::graph::access_mode am) = 0;
-
-  virtual void
-  close_graph(xclGraphHandle handle) = 0;
-
-  virtual void
-  reset_graph(xclGraphHandle handle) = 0;
-
-  virtual uint64_t
-  get_timestamp(xclGraphHandle handle) = 0;
-
-  virtual void
-  run_graph(xclGraphHandle handle, int iterations) = 0;
-
-  virtual int
-  wait_graph_done(xclGraphHandle handle, int timeout) = 0;
-
-  virtual void
-  wait_graph(xclGraphHandle handle, uint64_t cycle) = 0;
-
-  virtual void
-  suspend_graph(xclGraphHandle handle) = 0;
-
-  virtual void
-  resume_graph(xclGraphHandle handle) = 0;
-
-  virtual void
-  end_graph(xclGraphHandle handle, uint64_t cycle) = 0;
-
-  virtual void
-  update_graph_rtp(xclGraphHandle handle, const char* port, const char* buffer, size_t size) = 0;
-
-  virtual void
-  read_graph_rtp(xclGraphHandle handle, const char* port, char* buffer, size_t size) = 0;
-
   virtual void
   open_aie_context(xrt::aie::access_mode) = 0;
 
@@ -435,88 +406,6 @@ struct shim : public DeviceType
   }
 
 #ifdef XRT_ENABLE_AIE
-  xclGraphHandle
-  open_graph(const xrt::uuid& uuid, const char *gname, xrt::graph::access_mode am) override
-  {
-    if (auto ghdl = xclGraphOpen(DeviceType::get_device_handle(), uuid.get(), gname, am))
-      return ghdl;
-
-    throw system_error(EINVAL, "failed to open graph");
-  }
-
-  void
-  close_graph(xclGraphHandle handle) override
-  {
-    return xclGraphClose(handle);
-  }
-
-  void
-  reset_graph(xclGraphHandle handle) override
-  {
-    if (auto ret = xclGraphReset(handle))
-      throw system_error(ret, "fail to reset graph");
-  }
-
-  uint64_t
-  get_timestamp(xclGraphHandle handle) override
-  {
-    return xclGraphTimeStamp(handle);
-  }
-
-  void
-  run_graph(xclGraphHandle handle, int iterations) override
-  {
-    if (auto ret = xclGraphRun(handle, iterations))
-      throw system_error(ret, "fail to run graph");
-  }
-
-  int
-  wait_graph_done(xclGraphHandle handle, int timeout) override
-  {
-    return xclGraphWaitDone(handle, timeout);
-  }
-
-  void
-  wait_graph(xclGraphHandle handle, uint64_t cycle) override
-  {
-    if (auto ret = xclGraphWait(handle, cycle))
-      throw system_error(ret, "fail to wait graph");
-  }
-
-  void
-  suspend_graph(xclGraphHandle handle) override
-  {
-    if (auto ret = xclGraphSuspend(handle))
-      throw system_error(ret, "fail to suspend graph");
-  }
-
-  void
-  resume_graph(xclGraphHandle handle) override
-  {
-    if (auto ret = xclGraphResume(handle))
-      throw system_error(ret, "fail to resume graph");
-  }
-
-  void
-  end_graph(xclGraphHandle handle, uint64_t cycle) override
-  {
-    if (auto ret = xclGraphEnd(handle, cycle))
-      throw system_error(ret, "fail to end graph");
-  }
-
-  void
-  update_graph_rtp(xclGraphHandle handle, const char* port, const char* buffer, size_t size) override
-  {
-    if (auto ret = xclGraphUpdateRTP(handle, port, buffer, size))
-      throw system_error(ret, "fail to update graph rtp");
-  }
-
-  void
-  read_graph_rtp(xclGraphHandle handle, const char* port, char* buffer, size_t size) override
-  {
-    if (auto ret = xclGraphReadRTP(handle, port, buffer, size))
-      throw system_error(ret, "fail to read graph rtp");
-  }
 
   void
   open_aie_context(xrt::aie::access_mode am) override
@@ -701,77 +590,6 @@ struct noshim : public DeviceType
   }
 
 #ifdef XRT_ENABLE_AIE
-  xclGraphHandle
-  open_graph(const xrt::uuid&, const char*, xrt::graph::access_mode) override
-  {
-    throw ishim::not_supported_error(__func__);
-  }
-
-  void
-  close_graph(xclGraphHandle) override
-  {
-    throw ishim::not_supported_error(__func__);
-  }
-
-  void
-  reset_graph(xclGraphHandle) override
-  {
-    throw ishim::not_supported_error(__func__);
-  }
-
-  uint64_t
-  get_timestamp(xclGraphHandle) override
-  {
-    throw ishim::not_supported_error(__func__);
-  }
-
-  void
-  run_graph(xclGraphHandle, int) override
-  {
-    throw ishim::not_supported_error(__func__);
-  }
-
-  int
-  wait_graph_done(xclGraphHandle, int) override
-  {
-    throw ishim::not_supported_error(__func__);
-  }
-
-  void
-  wait_graph(xclGraphHandle, uint64_t) override
-  {
-    throw ishim::not_supported_error(__func__);
-  }
-
-  void
-  suspend_graph(xclGraphHandle) override
-  {
-    throw ishim::not_supported_error(__func__);
-  }
-
-  void
-  resume_graph(xclGraphHandle) override
-  {
-    throw ishim::not_supported_error(__func__);
-  }
-
-  void
-  end_graph(xclGraphHandle, uint64_t) override
-  {
-    throw ishim::not_supported_error(__func__);
-  }
-
-  void
-  update_graph_rtp(xclGraphHandle, const char*, const char*, size_t) override
-  {
-    throw ishim::not_supported_error(__func__);
-  }
-
-  void
-  read_graph_rtp(xclGraphHandle, const char*, char*, size_t) override
-  {
-    throw ishim::not_supported_error(__func__);
-  }
 
   void
   open_aie_context(xrt::aie::access_mode) override

--- a/src/runtime_src/core/common/shim/graph_handle.h
+++ b/src/runtime_src/core/common/shim/graph_handle.h
@@ -1,0 +1,42 @@
+#ifndef XRT_CORE_GRAPH_HANDLE_H
+#define XRT_CORE_GRAPH_HANDLE_H
+
+namespace xrt_core {
+class graph_handle
+{
+public:
+  virtual ~graph_handle() {}
+
+  virtual void
+  reset_graph() = 0;
+
+  virtual uint64_t
+  get_timestamp() = 0;
+
+  virtual void
+  run_graph(int iterations) = 0;
+
+  virtual int
+  wait_graph_done(int timeout) = 0;
+
+  virtual void
+  wait_graph(uint64_t cycle) = 0;
+
+  virtual void
+  suspend_graph() = 0;
+
+  virtual void
+  resume_graph() = 0;
+
+  virtual void
+  end_graph(uint64_t cycle) = 0;
+
+  virtual void
+  update_graph_rtp(const char* port, const char* buffer, size_t size) = 0;
+
+  virtual void
+  read_graph_rtp(const char* port, char* buffer, size_t size) = 0;
+};
+
+} // xrt_core
+#endif

--- a/src/runtime_src/core/common/shim/hwctx_handle.h
+++ b/src/runtime_src/core/common/shim/hwctx_handle.h
@@ -7,8 +7,10 @@
 #include "core/common/error.h"
 #include "core/common/shim/hwqueue_handle.h"
 #include "core/common/shim/shared_handle.h"
+#include "core/common/shim/graph_handle.h"
 
 #include "xrt/xrt_hw_context.h"
+#include "xrt/xrt_graph.h"
 
 #include <memory>
 
@@ -91,6 +93,12 @@ public:
   // hardware queues
   virtual void
   exec_buf(buffer_handle* cmd) = 0;
+
+  virtual std::unique_ptr<xrt_core::graph_handle>
+  open_graph_handle(const char*, xrt::graph::access_mode)
+  {
+    throw xrt_core::error(std::errc::not_supported, __func__);
+  }
 };
 
 } // xrt_core

--- a/src/runtime_src/core/edge/user/device_linux.cpp
+++ b/src/runtime_src/core/edge/user/device_linux.cpp
@@ -9,6 +9,7 @@
 #include "core/common/debug_ip.h"
 #include "core/common/query_requests.h"
 #include "core/common/xrt_profiling.h"
+#include "shim.h"
 
 #include <map>
 #include <memory>
@@ -1128,6 +1129,14 @@ set_cu_read_range(cuidx_type cuidx, uint32_t start, uint32_t size)
 {
   if (auto ret = xclIPSetReadRange(get_device_handle(), cuidx.index, start, size))
     throw xrt_core::error(ret, "failed to set cu read range");
+}
+
+std::unique_ptr<xrt_core::graph_handle>
+device_linux::
+open_graph_handle(const xrt::uuid& xclbin_id, const char* name, xrt::graph::access_mode am)
+{
+   return std::make_unique<ZYNQ::shim::graph_object>(
+                  static_cast<ZYNQ::shim*>(get_device_handle()), xclbin_id, name, am);
 }
 
 std::unique_ptr<buffer_handle>

--- a/src/runtime_src/core/edge/user/device_linux.h
+++ b/src/runtime_src/core/edge/user/device_linux.h
@@ -10,6 +10,7 @@
 #include "core/common/shim/hwctx_handle.h"
 #include "core/common/shim/shared_handle.h"
 #include "core/edge/common/device_edge.h"
+#include "core/common/shim/graph_handle.h"
 
 namespace xrt_core {
 
@@ -34,6 +35,9 @@ public:
   ////////////////////////////////////////////////////////////////
   void
   set_cu_read_range(cuidx_type ip_index, uint32_t start, uint32_t size) override;
+
+  std::unique_ptr<xrt_core::graph_handle>
+  open_graph_handle(const xrt::uuid& xclbin_id, const char* name, xrt::graph::access_mode am) override;
 
   void
   get_device_info(xclDeviceInfo2 *info) override;

--- a/src/runtime_src/core/edge/user/shim.h
+++ b/src/runtime_src/core/edge/user/shim.h
@@ -17,6 +17,8 @@
 #include "core/common/shim/hwctx_handle.h"
 #include "core/common/shim/shared_handle.h"
 #include "core/include/xdp/app_debug.h"
+#include "core/common/shim/graph_handle.h"
+#include "core/common/error.h"
 
 #include <cstdint>
 #include <fstream>
@@ -232,7 +234,98 @@ public:
     {
       m_shim->xclExecBuf(cmd->get_xcl_handle());
     }
+    std::unique_ptr<xrt_core::graph_handle>
+    open_graph_handle(const char* name, xrt::graph::access_mode am) override
+    {
+      return std::make_unique<graph_object>(m_shim, m_uuid, name, am);
+    }
   }; // class hwcontext
+
+  // Shim handle for graph object
+  class graph_object : public xrt_core::graph_handle
+  {
+    shim* m_shim;
+    xclGraphHandle m_xclGraphHandle;
+
+  public:
+    graph_object(shim* shim, const xrt::uuid& uuid , const char* name, xrt::graph::access_mode am)
+      : m_shim{shim},
+        m_xclGraphHandle{xclGraphOpen(m_shim, uuid.get(), name, am)}
+    {}
+
+    ~graph_object()
+    {
+       xclGraphClose(m_xclGraphHandle);
+    }
+
+    void
+    reset_graph() override
+    {
+      if (auto ret = xclGraphReset(m_xclGraphHandle))
+        throw xrt_core::system_error(ret, "fail to reset graph");
+    }
+
+    uint64_t
+    get_timestamp() override
+    {
+      return xclGraphTimeStamp(m_xclGraphHandle);
+    }
+
+    void
+    run_graph(int iterations) override
+    {
+      if (auto ret = xclGraphRun(m_xclGraphHandle, iterations))
+        throw xrt_core::system_error(ret, "fail to run graph");
+    }
+
+    int
+    wait_graph_done(int timeout) override
+    {
+      return xclGraphWaitDone(m_xclGraphHandle, timeout);
+    }
+
+    void
+    wait_graph(uint64_t cycle) override
+    {
+      if (auto ret = xclGraphWait(m_xclGraphHandle, cycle))
+        throw xrt_core::system_error(ret, "fail to wait graph");
+    }
+
+    void
+    suspend_graph() override
+    {
+      if (auto ret = xclGraphSuspend(m_xclGraphHandle))
+        throw xrt_core::system_error(ret, "fail to suspend graph");
+    }
+
+    void
+    resume_graph() override
+    {
+      if (auto ret = xclGraphResume(m_xclGraphHandle))
+        throw xrt_core::system_error(ret, "fail to resume graph");
+    }
+
+    void
+    end_graph(uint64_t cycle) override
+    {
+      if (auto ret = xclGraphEnd(m_xclGraphHandle, cycle))
+        throw xrt_core::system_error(ret, "fail to end graph");
+    }
+
+    void
+    update_graph_rtp(const char* port, const char* buffer, size_t size) override
+    {
+      if (auto ret = xclGraphUpdateRTP(m_xclGraphHandle, port, buffer, size))
+        throw xrt_core::system_error(ret, "fail to update graph rtp");
+    }
+
+    void
+    read_graph_rtp(const char* port, char* buffer, size_t size) override
+    {
+      if (auto ret = xclGraphReadRTP(m_xclGraphHandle, port, buffer, size))
+        throw xrt_core::system_error(ret, "fail to read graph rtp");
+    }
+  }; // graph_object
 
   ~shim();
   shim(unsigned index);

--- a/src/runtime_src/core/include/xrt/xrt_graph.h
+++ b/src/runtime_src/core/include/xrt/xrt_graph.h
@@ -28,6 +28,7 @@
 # include <chrono>
 # include <string>
 # include <cstdint>
+# include "xrt/xrt_hw_context.h"
 #endif
 
 typedef void *xrtGraphHandle;
@@ -79,6 +80,19 @@ public:
    *  Open the graph with specified access (default primary)
    */
   graph(const xrt::device& device, const xrt::uuid& xclbin_id, const std::string& name,
+        access_mode am = access_mode::primary);
+
+  /**
+   * graph() - Constructor from a hw context and graph name
+   *
+   * @param ctx
+   *  hw context on which the graph should execute
+   * @param name
+   *  Name of graph to construct
+   * @param am
+   *  Open the graph with specified access (default primary)
+   */
+  graph(const xrt::hw_context& ctx, const std::string& name,
         access_mode am = access_mode::primary);
 
   /**


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

https://jira.xilinx.com/browse/VITIS-11024
currently we can load only one xclbin in graph supported devices , we cannot load multiple xclbins in multiple partitions in device..

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

N/A

#### How problem was solved, alternative solutions (if any) and why they were rejected

These first set of changes are enabling interface to support multiple xclbins in multiple partitions in device by creating "hardware context" associated with device id and xclbin. Interfaces are created for application developers and driver component owners to load mulitple xclbins in device by creating hardware context with particular device and particualr xclbin. New shim changes (driver changes) are required to fully utilize hardware context interfaces and fullfill actual requirements. currently used old shim by extracting device and xclbin from hardware context (loaded single device id with single xclbin)

#### Risks (if any) associated the changes in the commit

Documentation for this change might be required, should not break old flow where it still supports to load xclbin with device id. And as mentioned in above field new shim changes (driver changes) are required.

#### What has been tested and how, request additional testing if necessary

Used Graph test use case where input array and input factor are provided, ouput array would be generated by muliplying input array with input factor.

Initializing ADF API...
[ 611.693563] zocl-drm axi:zyxclmm_drm: zocl_create_client: created KDS client for pid(598), ret: 0
[ 611.699710] zocl-drm axi:zyxclmm_drm: zocl_destroy_client: client exits pid(598)
[ 611.774761] zocl-drm axi:zyxclmm_drm: zocl_create_client: created KDS client for pid(598), ret: 0
[ 620.614085] [drm] Loading xclbin 1482d52e-6e09-f433-e081-3e5e84b5c99f to slot 0
[ 620.614352] [drm] found kind 29(AIE_RESOURCES)
[ 620.616651] [drm] skip kind 8(IP_LAYOUT) return code: -22
[ 620.617634] [drm] found kind 9(DEBUG_IP_LAYOUT)
[ 620.618947] [drm] found kind 25(AIE_METADATA)
[ 620.619933] [drm] skip kind 7(CONNECTIVITY) return code: -22
[ 620.621097] [drm] found kind 6(MEM_TOPOLOGY)
[ 620.623921] [drm] Memory 0 is not reserved in device tree. Will allocate memory from CMA
[ 620.884871] [drm] AIE create successfully finished.
XAIEFAL: INFO: Resource group Avail is created.
XAIEFAL: INFO: Resource group Static is created.
XAIEFAL: INFO: Resource group Generic is created.
[ 620.886708] [drm] zocl_xclbin_read_axlf 1482d52e-6e09-f433-e081-3e5e84b5c99f ret: 0
[ 621.133162] [drm] bitstream 1482d52e-6e09-f433-e081-3e5e84b5c99f locked, ref=1
[ 621.137693] zocl-drm axi:zyxclmm_drm: ffff000001f45410 kds_add_context: Client pid(598) add context Domain(65535) CU(0xffff) shared(true)
[ 621.149018] zocl-drm axi:zyxclmm_drm: ffff000001f45410 kds_del_context: Client pid(598) del context Domain(65535) CU(0xffff)
graph run completed .....
trying alias
[ 621.153148] [drm] bitstream 1482d52e-6e09-f433-e081-3e5e84b5c99f unlocked, ref=0
[ 622.304419] hrtimer: interrupt took 90673930 ns
graph rtp read completed .....
graph end completed .....
output Vector 1 value 3
output Vector 1 value 6
output Vector 1 value 9
output Vector 1 value 12
output Vector 1 value 15
output Vector 1 value 18
output Vector 1 value 21
output Vector 1 value 24
TEST PASSED

#### Documentation impact (if any)

Graph doumentation may needs to be updated with "hwctx" things. And currently both kernel and graph support only c++ API's with "hardware context"