### PR TITLE
CR-1203991: On Windows, don't issue incorrect profiling warning

### DIFF
--- a/src/runtime_src/xdp/profile/writer/vp_base/vp_writer.h
+++ b/src/runtime_src/xdp/profile/writer/vp_base/vp_writer.h
@@ -34,6 +34,12 @@ namespace xdp {
   //  and any others.
   class VPWriter 
   {
+#ifdef _WIN32
+  static constexpr bool profDirDefault = false;
+#else
+  static constexpr bool profDirDefault = true;
+#endif
+
   private:
     // The base name of all files created by this writer
     std::string basename ;
@@ -64,7 +70,9 @@ namespace xdp {
     XDP_CORE_EXPORT virtual void refreshFile() ;
   public:
     XDP_CORE_EXPORT VPWriter(const char* filename) ;
-    XDP_CORE_EXPORT VPWriter(const char* filename, VPDatabase* inst, bool useDir = true) ;
+    XDP_CORE_EXPORT VPWriter(const char* filename, VPDatabase* inst,
+                             bool useDir = profDirDefault);
+
     XDP_CORE_EXPORT virtual ~VPWriter() ;
 
     XDP_CORE_EXPORT virtual std::string getcurrentFileName() ;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
On Windows, profiling was issuing a warning stating that a profiling option is invalid, even if the user didn't specify that particular option.  This pull request makes it so that on Windows we don't use that option by default so the warning message won't be output unless the user specifically turns it on.  The option is still not supported on Windows.

#### How problem was solved, alternative solutions (if any) and why they were rejected
On Windows, change the default of the option to false so the user must explicitly try to create a profiling writer instance with the option enabled before they see the warning message.

#### Risks (if any) associated the changes in the commit
Low risk as the default behavior on Linux remains the same (where the option is supported).

#### What has been tested and how, request additional testing if necessary
Testing needed on client.

#### Documentation impact (if any)
No documentation impact