### PR TITLE
Xbutil windows wrapper

### DIFF
--- a/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
@@ -56,7 +56,7 @@ set(XBUTIL_V2_SRCS ${XBUTIL_V2_BASE_FILES} ${XBUTIL_V2_SUBCMD_FILES})
 set(XBUTIL2_NAME "xrt-smi") 
 # Determine any helper scripts
 if(WIN32)
-  set(XRT_HELPER_SCRIPTS "xrt-smi" "xrt-smi.bat")
+  set(XRT_HELPER_SCRIPTS "xbutil" "xbutil.bat" "xrt-smi" "xrt-smi.bat")
 else()
   set(XRT_HELPER_SCRIPTS "xbutil" "xrt-smi")
 endif()

--- a/src/runtime_src/core/tools/xbutil2/xbutil.bat
+++ b/src/runtime_src/core/tools/xbutil2/xbutil.bat
@@ -40,7 +40,7 @@ REM -- Find the loader from the current directory. If it exists.
 set XRT_LOADER=%~dp0unwrapped\loader.bat
 
 REM -- Find loader from the PATH. If it exists.
-FOR /F "tokens=* USEBACKQ" %%F IN (`where xbutil`) DO (
+FOR /F "tokens=* USEBACKQ" %%F IN (`where xrt-smi`) DO (
 set XBUTIL_PATH=%%~dpF
 )
 

--- a/src/runtime_src/core/tools/xbutil2/xbutil.bat
+++ b/src/runtime_src/core/tools/xbutil2/xbutil.bat
@@ -1,0 +1,60 @@
+@echo off
+setlocal
+
+REM Working variables
+set XRT_PROG=xrt-smi
+echo ----------------------------------------------------------------------
+echo                               WARNING:
+echo                xbutil has been renamed to xrt-smi
+echo        Please migrate to using xrt-smi instead of xbutil.
+echo:
+echo    Commands, options, arguments and their descriptions can also be 
+echo                    reported via the --help option.
+echo ----------------------------------------------------------------------
+
+REM -- Examine the options
+set XRTWRAP_PROG_ARGS=
+  :parseArgs
+    if [%1] == [] (
+      goto argsParsed
+    ) else (
+      REM New option
+      if [%1] == [-new] ( 
+        echo INFO: The 'new' option is only valid for the linux version of xbmgmt
+        shift
+      ) else (
+      if [%1] == [--new] ( 
+        echo INFO: The 'new' option is only valid for the linux version of xbmgmt
+        shift
+      ) else (
+        REM Unknown option, must be associated with the program
+        set XRTWRAP_PROG_ARGS=%XRTWRAP_PROG_ARGS% %1
+        shift
+      )
+    ))
+    goto parseArgs
+  :argsParsed
+
+
+REM -- Find the loader from the current directory. If it exists.
+set XRT_LOADER=%~dp0unwrapped\loader.bat
+
+REM -- Find loader from the PATH. If it exists.
+FOR /F "tokens=* USEBACKQ" %%F IN (`where xbutil`) DO (
+set XBUTIL_PATH=%%~dpF
+)
+
+REM -- If the loader is not found in the current directory use the PATH.
+if not exist %XRT_LOADER%  (
+  set XRT_LOADER=%XBUTIL_PATH%unwrapped\loader.bat
+)
+
+REM -- Loader is not within the current directory or PATH. All hope is lost.
+if not exist %XRT_LOADER%  (
+  echo ERROR: Could not find 64-bit loader executable.
+  echo ERROR: %XRT_LOADER% does not exist.
+  GOTO:EOF
+)
+
+%XRT_LOADER% -exec %XRT_PROG% %XRTWRAP_PROG_ARGS%
+

--- a/src/runtime_src/core/tools/xbutil2/xrt-smi.bat
+++ b/src/runtime_src/core/tools/xbutil2/xrt-smi.bat
@@ -32,7 +32,7 @@ REM -- Find the loader from the current directory. If it exists.
 set XRT_LOADER=%~dp0unwrapped\loader.bat
 
 REM -- Find loader from the PATH. If it exists.
-FOR /F "tokens=* USEBACKQ" %%F IN (`where xbutil`) DO (
+FOR /F "tokens=* USEBACKQ" %%F IN (`where xrt-smi`) DO (
 set XBUTIL_PATH=%%~dpF
 )
 


### PR DESCRIPTION
#### Problem solved by the commit
We have been asked to add an xbutil wrapper for Windows.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://github.com/Xilinx/XRT/pull/8191 made it so only xrt-smi can be used on Windows.
#### How problem was solved, alternative solutions (if any) and why they were rejected
Added xbutil script and xbutil.bat to Windows side. Also updated alternate PATH finding for loader.bat for both xbutil.bat and xrt-smi.bat.
#### Risks (if any) associated the changes in the commit
N/A
#### What has been tested and how, request additional testing if necessary
Tested MCDM.
```
C:\Users\rchane\Desktop\xrt>xbutil examine
----------------------------------------------------------------------
                              WARNING:
               xbutil has been renamed to xrt-smi
       Please migrate to using xrt-smi instead of xbutil.

   Commands, options, arguments and their descriptions can also be
                   reported via the --help option.
----------------------------------------------------------------------
System Configuration
  OS Name              : Windows NT
  Release              : 26085
  Machine              : x86_64
  CPU Cores            : 24
  Memory               : 32109 MB
  Distribution         : Microsoft Windows 11 Pro
  Model                : BIRMANPLUS
  BIOS vendor          : AMD
  BIOS version         : WXB4424N

XRT
  Version              : 2.18.0
  Branch               : HEAD
  Hash                 : 44193d7d42d91223d2c12595209fef9abf310886
  Hash Date            : 2024-06-17 10:09:22
  ipukmddrv            : 32.0.202.178
  NPU Firmware Version : 0.7.22.110

Devices present
|BDF             ||Name  |
|----------------||------|
|[00c5:00:01.1]  ||NPU   |

```
#### Documentation impact (if any)
N/A
