### PR TITLE
CR-1203967: uninit value and unlocked mutex in icap.c

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -697,7 +697,7 @@ static int icap_xclbin_validate_clock_req(struct platform_device *pdev,
 	struct icap *icap = platform_get_drvdata(pdev);
 	uint32_t slot_id = 0;
 	struct islot_info *islot = NULL;
-	int err;
+	int err = 0;
 
 	mutex_lock(&icap->icap_lock);
 	for (slot_id = 0; slot_id < MAX_SLOT_SUPPORT; slot_id++) {
@@ -708,8 +708,10 @@ static int icap_xclbin_validate_clock_req(struct platform_device *pdev,
 		/* Clock frequence is only related to PL Slots */
 		if (islot->pl_slot) {
 			err = icap_xclbin_validate_clock_req_impl(pdev, freq_obj, slot_id);
-			if (err)
+			if (err) {
+				mutex_unlock(&icap->icap_lock);
 				return err;
+			}
 		}
 	}
 	mutex_unlock(&icap->icap_lock);


### PR DESCRIPTION
for CR-1203967: uninit value and unlocked mutex in icap.c

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
icap.c file had a function with an uninitialized int variable and also had an early exit without unlocking a mutex. 
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Bugs / issues from above fixed, they were discovered by a Coverity scan. 
#### How problem was solved, alternative solutions (if any) and why they were rejected
initialized int variable to 0 and included a line to unlock the mutex if early exit occurred. 