### PR TITLE
Changes to support new trace metadata & some bug fixes

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_control_config_filetype.h
+++ b/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_control_config_filetype.h
@@ -62,7 +62,7 @@ class AIEControlConfigFiletype : public xdp::aie::BaseFiletypeImpl {
         getChildGMIOs(const std::string& childStr) const;
         
         std::unordered_map<std::string, io_config>
-        getGMIOs() const;
+        getGMIOs() const override;
 
         std::vector<tile_type>
         getInterfaceTiles(const std::string& graphName,

--- a/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_trace_config_filetype.h
+++ b/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_trace_config_filetype.h
@@ -34,6 +34,12 @@ class AIETraceConfigFiletype : public AIEControlConfigFiletype {
         std::vector<std::string>
         getValidKernels() const override;
 
+        std::unordered_map<std::string, io_config>
+        getExternalBuffers() const;
+
+        std::unordered_map<std::string, io_config>
+        getGMIOs() const override;
+
         std::vector<tile_type>
         getMemoryTiles(const std::string& graphName,
                        const std::string& bufferName = "all") const override;

--- a/src/runtime_src/xdp/profile/database/static_info/filetypes/base_filetype_impl.h
+++ b/src/runtime_src/xdp/profile/database/static_info/filetypes/base_filetype_impl.h
@@ -54,6 +54,9 @@ class BaseFiletypeImpl {
         virtual std::unordered_map<std::string, io_config>
         getTraceGMIOs() const = 0;
 
+        virtual std::unordered_map<std::string, io_config>
+        getGMIOs() const = 0;
+
         virtual 
         std::vector<tile_type>
         getInterfaceTiles(const std::string& graphName,

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/client/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/client/aie_trace.cpp
@@ -694,7 +694,7 @@ namespace xdp {
 
     std::vector<XAie_Events> comboEvents;
 
-    if (type == module_type::core) {
+    if (mod == XAIE_CORE_MOD) {
       //auto comboEvent = xaieTile.core().comboEvent(4);
       comboEvents.push_back(XAIE_EVENT_COMBO_EVENT_2_CORE);
 
@@ -1115,7 +1115,7 @@ namespace xdp {
           aieConfig = cfgTile->memory_tile_trace_config;
 
         // Configure combo events for metric sets that include DMA events        
-        auto comboEvents = configComboEvents(loc, XAIE_CORE_MOD, module_type::dma, metricSet, aieConfig);
+        auto comboEvents = configComboEvents(loc, mod, type, metricSet, aieConfig);
         if (comboEvents.size() == 2) {
           traceStartEvent = comboEvents.at(0);
           traceEndEvent = comboEvents.at(1);

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/edge/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/edge/aie_trace.cpp
@@ -648,7 +648,7 @@ namespace xdp {
 
         // Configure combo events for metric sets that include DMA events        
         auto comboEvents = aie::trace::configComboEvents(aieDevInst, xaieTile, loc, 
-            XAIE_CORE_MOD, module_type::dma, metricSet, aieConfig);
+            XAIE_MEM_MOD, type, metricSet, aieConfig);
         if (comboEvents.size() == 2) {
           traceStartEvent = comboEvents.at(0);
           traceEndEvent = comboEvents.at(1);

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/util/aie_trace_config.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/util/aie_trace_config.cpp
@@ -159,7 +159,7 @@ namespace xdp::aie::trace {
 
     std::vector<XAie_Events> comboEvents;
 
-    if (type == module_type::core) {
+    if (mod == XAIE_CORE_MOD) {
       auto comboEvent = xaieTile.core().comboEvent(4);
       comboEvents.push_back(XAIE_EVENT_COMBO_EVENT_2_CORE);
 


### PR DESCRIPTION
#### Problem solved by the commit
* GMIO were not getting parsed correctly from new metadata

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
* Bugs were found when specifying s2mm/mm2s metric sets for memory tiles
  
#### How problem was solved, alternative solutions (if any) and why they were rejected
* New metadata parser is now getting GMIO from ExternalBuffer section
* Bugs were fixed in combo event functions
 
#### Risks (if any) associated the changes in the commit
* These changes are reliant on agreed upon changes to new metadata
 
#### What has been tested and how, request additional testing if necessary
* Tested on clients and edge

#### Documentation impact (if any)
* None