### PR TITLE
Removed zocl_gem_import function, using drm_gem_prime_import

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/common/zocl_bo.c
+++ b/src/runtime_src/core/edge/drm/zocl/common/zocl_bo.c
@@ -1415,25 +1415,6 @@ void zocl_clear_mem(struct drm_zocl_dev *zdev)
 	mutex_unlock(&zdev->mm_lock);
 }
 
-struct drm_gem_object *zocl_gem_import(struct drm_device *dev,
-				       struct dma_buf *dma_buf)
-{
-	struct drm_gem_object *gem_obj;
-	struct drm_zocl_bo *zocl_bo;
-
-	gem_obj = drm_gem_prime_import(dev, dma_buf);
-	if (!IS_ERR(gem_obj)) {
-		zocl_bo = to_zocl_bo(gem_obj);
-		/* drm_gem_cma_prime_import_sg_table() is used for hook
-		 * gem_prime_import_sg_table. It will check if import buffer
-		 * is a CMA buffer and create CMA object.
-		 */
-		zocl_bo->flags |= ZOCL_BO_FLAGS_CMA;
-	}
-
-	return gem_obj;
-}
-
 void zocl_drm_free_bo(struct drm_zocl_bo *bo)
 {
 	zocl_free_bo(&bo->gem_base);

--- a/src/runtime_src/core/edge/drm/zocl/common/zocl_drv.c
+++ b/src/runtime_src/core/edge/drm/zocl/common/zocl_drv.c
@@ -1042,7 +1042,7 @@ static struct drm_driver zocl_driver = {
 	.prime_fd_to_handle        = drm_gem_prime_fd_to_handle,
         .gem_prime_mmap            = drm_gem_prime_mmap,
 #endif
-	.gem_prime_import          = zocl_gem_import,
+	.gem_prime_import          = drm_gem_prime_import,
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
 	.gem_prime_import_sg_table = drm_gem_dma_prime_import_sg_table,
 #else

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_bo.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_bo.h
@@ -70,9 +70,6 @@ static inline uint32_t zocl_convert_bo_uflags(uint32_t uflags)
 	return zflags;
 }
 
-struct drm_gem_object *
-zocl_gem_import(struct drm_device *dev, struct dma_buf *dma_buf);
-
 struct sg_table *zocl_gem_prime_get_sg_table(struct drm_gem_object *obj);
 
 #endif /* _ZOCL_BO_H */


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
 [CR-1202682](https://jira.xilinx.com/browse/CR-1202682) Importing buffers other than CMA is causing a kernel panic.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
 
#### How problem was solved, alternative solutions (if any) and why they were rejected
Removed the "zocl_gem_import" and using the "drm_gem_prime_import" to import the buffers.

#### Risks (if any) associated the changes in the commit
NA
#### What has been tested and how, request additional testing if necessary
Tested on vck190.
#### Documentation impact (if any)
