### PR TITLE
Support polling for runlist completion

### DIFF
--- a/src/runtime_src/core/common/api/hw_queue.h
+++ b/src/runtime_src/core/common/api/hw_queue.h
@@ -75,6 +75,18 @@ public:
   std::cv_status
   wait(const xrt_core::command* cmd, const std::chrono::milliseconds& timeout) const;
 
+  // Poll for command state. A return value of 0 indicates the command
+  // is still running. Any other return value implies the command
+  // state must be checked.
+  int
+  poll(const xrt_core::command*) const;
+
+  // Poll raw command for its state. A return value of 0 indicates the
+  // command is still running. Any other return value implies the
+  // command state must be checked.
+  int
+  poll(xrt_core::buffer_handle*) const;
+
   // Enqueue a command dependency
   void
   submit_wait(const xrt::fence& fence);

--- a/src/runtime_src/core/common/shim/hwqueue_handle.h
+++ b/src/runtime_src/core/common/shim/hwqueue_handle.h
@@ -28,6 +28,21 @@ public:
   virtual void
   submit_command(buffer_handle* cmd) = 0;
 
+  // Poll for command completion
+  //
+  // @cmd    Handle to command to poll for
+  // @return 0 indicates pending, anything else may indicate completion
+  //
+  // Note that a return value different from 0 does not guarantee that
+  // the command has completed.  The command state still has to be checked
+  // in order to determine completion. For shim implementations where
+  // command state is live, this function does not have to be implemented.
+  virtual int
+  poll_command(buffer_handle*) const
+  {
+    return 1;
+  }
+
   // Wait for command completion.
   //
   // @cmd        Handle to command to wait for

--- a/src/runtime_src/core/include/experimental/xrt_kernel.h
+++ b/src/runtime_src/core/include/experimental/xrt_kernel.h
@@ -180,6 +180,22 @@ public:
   {
     wait(std::chrono::milliseconds(0));
   }
+
+  /**
+   * Poll the runlist for completion.
+   *
+   * @return 0 if command list is still running, any other value
+   *  indicates completion.
+   *
+   * Completion of a runlist execution means that all run objects have
+   * completed succesfully.  If any run object in the list fails to
+   * complete successfully, the function throws
+   * `xrt::runlist::command_error` with the failed run object and
+   * state.
+   */
+  XRT_API_EXPORT
+  int
+  poll() const;
   
   /**
    * reset() - Reset the runlist


### PR DESCRIPTION
#### Problem solved by the commit
Per side band request implement polling for xrt::runlist completion as well as polling for xrt::run completion.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
This change also closes a minor bug in xrt::run::state() which was not supported properly on Windows (MCDM) where command state is lazy updated only as part of calling xrt::run::wait().

#### How problem was solved, alternative solutions (if any) and why they were rejected
xrt::run::state() is implemented to invoke polling which is a noop on Linux where the state is updated automatically.  On Windows polling will check the fence associated with the command and complete the command if the fence is signaled.

In addition this PR implements xrt::runlist::poll() which polls for completion of the last chained command submitted for execution. As for get_state(), polling either returns immediately if command is still running, or completes/updats the state of the command if it has finished.

There is no explicit poll() function for xrt::run, here xrt::run::state() is polling for the run state.

A new API xrt::runlist::poll() was added to poll for runlist completion.

#### What has been tested and how, request additional testing if necessary
Testing was manual in MCDM.

#### Risks (if any) associated the changes in the commit
There is no risk here, as functionality doesn't intersect existing APIs.