### PR TITLE
CR-1204356 Fix xbutil wrapper for Windows

### DIFF
--- a/src/runtime_src/core/tools/xbutil2/xbutil.bat
+++ b/src/runtime_src/core/tools/xbutil2/xbutil.bat
@@ -35,26 +35,5 @@ set XRTWRAP_PROG_ARGS=
     goto parseArgs
   :argsParsed
 
-
-REM -- Find the loader from the current directory. If it exists.
-set XRT_LOADER=%~dp0unwrapped\loader.bat
-
-REM -- Find loader from the PATH. If it exists.
-FOR /F "tokens=* USEBACKQ" %%F IN (`where xrt-smi`) DO (
-set XBUTIL_PATH=%%~dpF
-)
-
-REM -- If the loader is not found in the current directory use the PATH.
-if not exist %XRT_LOADER%  (
-  set XRT_LOADER=%XBUTIL_PATH%unwrapped\loader.bat
-)
-
-REM -- Loader is not within the current directory or PATH. All hope is lost.
-if not exist %XRT_LOADER%  (
-  echo ERROR: Could not find 64-bit loader executable.
-  echo ERROR: %XRT_LOADER% does not exist.
-  GOTO:EOF
-)
-
-%XRT_LOADER% -exec %XRT_PROG% %XRTWRAP_PROG_ARGS%
+%XRT_PROG% %XRTWRAP_PROG_ARGS%
 


### PR DESCRIPTION
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1204356 Add xbutil wrapper for Windows
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://github.com/Xilinx/XRT/pull/8246. While the wrapper works when building MCDM on its own, it doesn't work in mcdm_sw_stack artifactory builds because it has a dependency on loader.bat (which isn't there). Thus, while it would print the xbutil deprecation message, xrt-smi would not be properly called afterward and an error would be thrown. 
#### How problem was solved, alternative solutions (if any) and why they were rejected
The loader.bat dependency was removed in xbutil.bat (we already include the unwrapped xrt-smi.exe in the artifactory builds, as well).
#### Risks (if any) associated the changes in the commit
N/A
#### What has been tested and how, request additional testing if necessary
Tested on STX/MCDM by editing the xbutil.bat file in the artifactory build; works as desired.
#### Documentation impact (if any)
N/A