### PR TITLE
Fixing a few Coverity issues found in a couple files in /src/runtime_src/core/pcie/driver/linux/xocl/userpf

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_hwctx.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_hwctx.c
@@ -115,8 +115,8 @@ xocl_cu_ctx_to_info(struct xocl_dev *xdev, struct drm_xocl_open_cu_ctx *cu_args,
         char kname[CU_NAME_MAX_LEN];
         int i = 0;
 
-        strcpy(kname, strsep(&kname_p, ":"));
-        strcpy(iname, strsep(&kname_p, ":"));
+        strlcpy(kname, strsep(&kname_p, ":"), sizeof(kname);
+        strlcpy(iname, strsep(&kname_p, ":"), sizeof(iname);
 
         /* Retrieve the CU index from the given slot */
         for (i = 0; i < MAX_CUS; i++) {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
@@ -546,7 +546,7 @@ xocl_read_axlf_helper(struct xocl_drm *drm_p, struct drm_xocl_axlf *axlf_ptr,
 	struct axlf *axlf = NULL;
 	struct axlf bin_obj;
 	size_t size = 0;
-	uint32_t slot_id;
+	uint32_t slot_id = 0;
 	int preserve_mem = 0;
 	struct mem_topology *new_topology = NULL;
 	struct xocl_dev *xdev = drm_p->xdev;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_sysfs.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_sysfs.c
@@ -33,7 +33,7 @@ static ssize_t xclbinuuid_show(struct device *dev,
 		if (!xclbin_id)
 			continue;
 
-		cnt += sprintf(buf + cnt, "%pUb\n", xclbin_id ? xclbin_id : 0);
+		cnt += sprintf(buf + cnt, "%pUb\n", xclbin_id);
 
 		XOCL_PUT_XCLBIN_ID(xdev, i);
 		xclbin_id = NULL;
@@ -112,7 +112,7 @@ static ssize_t kdsstat_show(struct device *dev,
 			continue;
 
 		size += sprintf(buf + size, "xclbin:\t\t\t%pUb\n",
-				xclbin_id ? xclbin_id : 0);
+				xclbin_id);
 		
 		XOCL_PUT_XCLBIN_ID(xdev, i);
 		xclbin_id = NULL;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
A few issues found by the Coverity scan that could cause problems. 
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Copy into fixed size buffer, uninitialized scalar variable, and logically dead code in xocl_hwctx.c, xocl_ioctl.c, and xocl_sysfs.c, respectively.  
#### How problem was solved, alternative solutions (if any) and why they were rejected
Use strlcpy() instead of strcpy(), initialized uninit variable to 0 (as is consistent with rest of code), and removed conditional that was logically dead. 
