### PR TITLE
Fix Copyright Device -> Devices (#8255)

### DIFF
--- a/src/CMake/config/version.h.in
+++ b/src/CMake/config/version.h.in
@@ -1,7 +1,7 @@
 /**
  * SPDX-License-Identifier: Apache-2.0
  * Copyright (C) 2019-2021 Xilinx, Inc. All rights reserved.
- * Copyright (C) 2023 Advanced Micro Device, Inc. All rights reserved.
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
  */
 
 #ifndef _XRT_VERSION_H_

--- a/src/runtime_src/hip/CMakeLists.txt
+++ b/src/runtime_src/hip/CMakeLists.txt
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (C) 2023 Advanced Micro Device, Inc. All rights reserved.
+# Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
 add_subdirectory(core)
 add_subdirectory(api)
 

--- a/src/runtime_src/hip/api/CMakeLists.txt
+++ b/src/runtime_src/hip/api/CMakeLists.txt
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (C) 2023 Advanced Micro Device, Inc. All rights reserved.
+# Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
 add_library(hip_api_library_objects OBJECT
   hipDeviceGet.cpp
 )

--- a/src/runtime_src/hip/api/hipDeviceGet.cpp
+++ b/src/runtime_src/hip/api/hipDeviceGet.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023 Advanced Micro Device, Inc. All rights reserved.
+// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
 
 #include "hip/config.h"
 #include "hip/hip_runtime_api.h"

--- a/src/runtime_src/hip/config.h
+++ b/src/runtime_src/hip/config.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023 Advanced Micro Device, Inc. All rights reserved.
+// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
 #ifndef xrthip_config_h_
 #define xrthip_config_h_
 

--- a/src/runtime_src/hip/core/CMakeLists.txt
+++ b/src/runtime_src/hip/core/CMakeLists.txt
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (C) 2023 Advanced Micro Device, Inc. All rights reserved.
+# Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
 add_library(hip_core_library_objects OBJECT
   device.cpp
 )

--- a/src/runtime_src/hip/core/device.cpp
+++ b/src/runtime_src/hip/core/device.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023 Advanced Micro Device, Inc. All rights reserved.
+// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
 
 #include "device.h"
 

--- a/src/runtime_src/hip/core/device.h
+++ b/src/runtime_src/hip/core/device.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023 Advanced Micro Device, Inc. All rights reserved.
+// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
 #ifndef xrthip_device_h
 #define xrthip_device_h
 

--- a/tests/hip/device/main.cpp
+++ b/tests/hip/device/main.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023 Advanced Micro Device, Inc. All rights reserved.
+// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
 
 // TODO: set up CMake
 // % g++ -g -std=c++17 -I${XILINX_XRT}/include -L${XILINX_XRT}/lib \


### PR DESCRIPTION
Cherry picked manually from #8255 to exclude files that are not part of this branch.