### PR TITLE
Changes to fix no aie_profile data while running along with Device tr…

### DIFF
--- a/src/runtime_src/xdp/profile/device/utility.cpp
+++ b/src/runtime_src/xdp/profile/device/utility.cpp
@@ -22,6 +22,7 @@
 #include "core/common/query_requests.h"
 
 #include "xdp/profile/device/utility.h"
+#include "xdp/profile/plugin/vp_base/utility.h"
 
 namespace xdp { namespace util {
 
@@ -50,6 +51,19 @@ namespace xdp { namespace util {
       //  xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", "Device query for Debug IP Layout not implemented");
     } catch (const std::exception &) {
       xrt_core::message::send(xrt_core::message::severity_level::error, "XRT", "Failed to retrieve Debug IP Layout path");
+    }
+    if (getFlowMode()==HW_EMU) {
+      if (path!="") {
+        // Full paths to the hardware emulation debug_ip_layout for different
+        //  xclbins on the same device are different.  On disk, they are laid
+        //  out as follows:
+        // .run/<pid>/hw_em/device_0/binary_0/debug_ip_layout
+        // .run/<pid>/hw_em/device_0/binary_1/debug_ip_layout
+        //  Since both of these should refer to the same device, we only use
+        //  the path up to the device name.
+        path = path.substr(0, path.find_last_of("/") - 1) ;// remove debug_ip_layout
+        path = path.substr(0, path.find_last_of("/") - 1) ;// remove binary_x
+      }
     }
     return path;
   }

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_plugin.cpp
@@ -63,7 +63,7 @@ namespace xdp {
   {
     xrt_core::message::send(severity_level::info, "XRT", "Destroying AIE Profiling Plugin.");
     // Stop the polling thread
-    
+
     AieProfilePlugin::live = false;
     endPoll();
 
@@ -240,7 +240,7 @@ auto time = std::time(nullptr);
 
     if (AIEData.thread.joinable())
       AIEData.thread.join();
-    
+
     #ifdef XDP_CLIENT_BUILD
       AIEData.implementation->poll(0, handle);
     #endif
@@ -253,7 +253,7 @@ auto time = std::time(nullptr);
   void AieProfilePlugin::endPoll()
   {
     xrt_core::message::send(severity_level::info, "XRT", "Calling AIE Profile endPoll.");
-    
+
     #ifdef XDP_CLIENT_BUILD
       auto& AIEData = handleToAIEData.begin()->second;
       AIEData.implementation->poll(0, nullptr);

--- a/src/runtime_src/xdp/profile/plugin/device_offload/hw_emu/hw_emu_device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/hw_emu/hw_emu_device_offload_plugin.cpp
@@ -33,18 +33,6 @@ namespace {
   static std::string ProcessHwEmuDebugIpLayoutPath(void* handle)
   {
     std::string path = xdp::util::getDebugIpLayoutPath(handle);
-    if (path == "")
-      return path;
-
-    // Full paths to the hardware emulation debug_ip_layout for different
-    //  xclbins on the same device are different.  On disk, they are laid
-    //  out as follows:
-    // .run/<pid>/hw_em/device_0/binary_0/debug_ip_layout
-    // .run/<pid>/hw_em/device_0/binary_1/debug_ip_layout
-    //  Since both of these should refer to the same device, we only use
-    //  the path up to the device name.
-    path = path.substr(0, path.find_last_of("/") - 1) ;// remove debug_ip_layout
-    path = path.substr(0, path.find_last_of("/") - 1) ;// remove binary_x
     return path ;
   }
 
@@ -84,7 +72,7 @@ namespace xdp {
     std::string path = ProcessHwEmuDebugIpLayoutPath(handle) ;
     if (path == "")
       return ;
-    
+
     uint64_t deviceId = db->addDevice(path) ;
 
     if (offloaders.find(deviceId) != offloaders.end()) {
@@ -110,7 +98,7 @@ namespace xdp {
 
     // Clear out any previous interface we might have had for talking to this
     //  particular device.
-    clearOffloader(deviceId); 
+    clearOffloader(deviceId);
 
     if (!(db->getStaticInfo()).validXclbin(userHandle)) {
       std::string msg =
@@ -123,7 +111,7 @@ namespace xdp {
                               msg) ;
       return ;
     }
-    
+
     // Update the static database with all the information that
     //  will be needed later
     db->getStaticInfo().updateDevice(deviceId, new HalDevice(userHandle), userHandle) ;
@@ -134,7 +122,7 @@ namespace xdp {
       }
     }
 
-    // For the HAL level, we must create a device interface using 
+    // For the HAL level, we must create a device interface using
     //  the xdp::HalDevice to communicate with the physical device
     PLDeviceIntf* devInterface = (db->getStaticInfo()).getDeviceIntf(deviceId);
 
@@ -149,7 +137,7 @@ namespace xdp {
     startContinuousThreads(deviceId) ;
     devInterface->startCounters() ;
 
-    // Once the device has been set up, add additional information to 
+    // Once the device has been set up, add additional information to
     //  the static database
     (db->getStaticInfo()).setHostMaxReadBW(deviceId, devInterface->getHostMaxBwRead()) ;
     (db->getStaticInfo()).setHostMaxWriteBW(deviceId, devInterface->getHostMaxBwWrite());


### PR DESCRIPTION
…ace during hw emu
#### Problem solved by the commit
XCL_EMULATION_MODE=hw_emu variable causing no profiling data. This problem arises when both device_trace and aie_profile is enabled. When just aie_profile is enabled, this issue does not occur.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1199679 . It was discovered by running the regression suiteVITIS_DSV_PROFILING_EDGE_HW_EMU

#### How problem was solved, alternative solutions (if any) and why they were rejected
A workaround would be adding unsetenv ("XCL_EMULATION_MODE") to the top of main in host.cpp. But it is still not a solution.  Because setting XCL_EMULATION_MODE to hw_emu is mandatory for hw_emu flows

#### What has been tested and how, request additional testing if necessary
The code has been tested on an aie1 design on edge hardware emulation. The rpm with the mentioned XRT changes has been installed in the hw_emu QEMU. And the application has been run with aie_profile and device trace enabled in xrt.ini. 
