### PR TITLE
Fix issue where AIE profiling and PL device trace were not working together

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info_database.h
+++ b/src/runtime_src/xdp/profile/database/static_info_database.h
@@ -114,7 +114,8 @@ namespace xdp {
     boost::property_tree::ptree aieMetadata;
     std::unique_ptr<aie::BaseFiletypeImpl> metadataReader = nullptr;
 
-    bool resetDeviceInfo(uint64_t deviceId, const std::shared_ptr<xrt_core::device>& device);
+    // When loading a new xclbin, should we reset our internal data structures?
+    bool resetDeviceInfo(uint64_t deviceId, const std::shared_ptr<xrt_core::device>& device, xdp::Device* xdpDevice);
 
     // Functions that create the overall structure of the Xclbin's PL region
     void createComputeUnits(XclbinInfo*, const ip_layout*,const char*,size_t);
@@ -150,7 +151,7 @@ namespace xdp {
     // pointer to handle any connection to the PL side as necessary.
     // Some plugins do not require any PL control and will pass in nullptr
     DeviceInfo* updateDevice(uint64_t deviceId, xrt::xclbin xrtXclbin,
-                             xdp::Device* xdpDevice, bool clientBuild) ;
+                             std::unique_ptr<xdp::Device> xdpDevice, bool clientBuild) ;
 
   public:
     VPStaticDatabase(VPDatabase* d) ;
@@ -260,7 +261,7 @@ namespace xdp {
     XDP_CORE_EXPORT void setDeviceName(uint64_t deviceId, const std::string& name) ;
     XDP_CORE_EXPORT std::string getDeviceName(uint64_t deviceId) ;
     XDP_CORE_EXPORT PLDeviceIntf* getDeviceIntf(uint64_t deviceId) ;
-    XDP_CORE_EXPORT void createPLDeviceIntf(uint64_t deviceId, xdp::Device* xdpDevice);
+    XDP_CORE_EXPORT void createPLDeviceIntf(uint64_t deviceId, std::unique_ptr<xdp::Device> xdpDevice);
     XDP_CORE_EXPORT uint64_t getKDMACount(uint64_t deviceId) ;
     XDP_CORE_EXPORT void setHostMaxReadBW(uint64_t deviceId, double bw) ;
     XDP_CORE_EXPORT double getHostMaxReadBW(uint64_t deviceId) ;
@@ -275,7 +276,7 @@ namespace xdp {
     XDP_CORE_EXPORT ComputeUnitInstance* getCU(uint64_t deviceId, int32_t cuId) ;
     XDP_CORE_EXPORT Memory* getMemory(uint64_t deviceId, int32_t memId) ;
     // Reseting device information whenever a new xclbin is added
-    XDP_CORE_EXPORT void updateDevice(uint64_t deviceId, xdp::Device* xdpDevice, void* devHandle) ;
+    XDP_CORE_EXPORT void updateDevice(uint64_t deviceId, std::unique_ptr<xdp::Device> xdpDevice, void* devHandle) ;
     XDP_CORE_EXPORT void updateDeviceClient(uint64_t deviceId, std::shared_ptr<xrt_core::device> device);
 
     // *********************************************************

--- a/src/runtime_src/xdp/profile/device/pl_device_intf.cpp
+++ b/src/runtime_src/xdp/profile/device/pl_device_intf.cpp
@@ -218,8 +218,6 @@ PLDeviceIntf::~PLDeviceIntf() {
   delete mFifoCtrl;
   delete mFifoRead;
   delete mDeadlockDetector;
-
-  //  delete mDevice;
 }
 
 void PLDeviceIntf::setDevice(std::unique_ptr<xdp::Device> devHandle) {

--- a/src/runtime_src/xdp/profile/device/pl_device_intf.cpp
+++ b/src/runtime_src/xdp/profile/device/pl_device_intf.cpp
@@ -219,17 +219,17 @@ PLDeviceIntf::~PLDeviceIntf() {
   delete mFifoRead;
   delete mDeadlockDetector;
 
-  delete mDevice;
+  //  delete mDevice;
 }
 
-void PLDeviceIntf::setDevice(xdp::Device *devHandle) {
+void PLDeviceIntf::setDevice(std::unique_ptr<xdp::Device> devHandle) {
   if (mDevice && mDevice != devHandle) {
     // ERROR : trying to set device when it is already populated with some other
     // device
     return;
   }
 
-  mDevice = devHandle;
+  mDevice = std::move(devHandle);
 
   // Once the device is connected, update the bandwidth numbers
   setHostMaxBwRead();
@@ -604,28 +604,28 @@ void PLDeviceIntf::readDebugIPlayout() {
       for (uint64_t i = 0; i < map->m_count; i++) {
         switch (map->m_debug_ip_data[i].m_type) {
         case AXI_MM_MONITOR:
-          mAimList.push_back(new AIM(mDevice, i, &(map->m_debug_ip_data[i])));
+          mAimList.push_back(new AIM(mDevice.get(), i, &(map->m_debug_ip_data[i])));
           break;
 
         case ACCEL_MONITOR:
-          mAmList.push_back(new AM(mDevice, i, &(map->m_debug_ip_data[i])));
+          mAmList.push_back(new AM(mDevice.get(), i, &(map->m_debug_ip_data[i])));
           break;
 
         case AXI_STREAM_MONITOR:
-          mAsmList.push_back(new ASM(mDevice, i, &(map->m_debug_ip_data[i])));
+          mAsmList.push_back(new ASM(mDevice.get(), i, &(map->m_debug_ip_data[i])));
           break;
 
         case AXI_MONITOR_FIFO_LITE:
-          mFifoCtrl = new TraceFifoLite(mDevice, i, &(map->m_debug_ip_data[i]));
+          mFifoCtrl = new TraceFifoLite(mDevice.get(), i, &(map->m_debug_ip_data[i]));
           break;
 
         case AXI_MONITOR_FIFO_FULL:
-          mFifoRead = new TraceFifoFull(mDevice, i, &(map->m_debug_ip_data[i]));
+          mFifoRead = new TraceFifoFull(mDevice.get(), i, &(map->m_debug_ip_data[i]));
           break;
 
         case AXI_TRACE_FUNNEL:
           mTraceFunnelList.push_back(
-              new TraceFunnel(mDevice, i, &(map->m_debug_ip_data[i])));
+				     new TraceFunnel(mDevice.get(), i, &(map->m_debug_ip_data[i])));
           break;
 
         case TRACE_S2MM:
@@ -634,20 +634,20 @@ void PLDeviceIntf::readDebugIPlayout() {
           // requirements)
           if (map->m_debug_ip_data[i].m_properties & TS2MM_AIE_TRACE_MASK)
             mAieTraceDmaList.push_back(
-                new AIETraceS2MM(mDevice, i, &(map->m_debug_ip_data[i])));
+				       new AIETraceS2MM(mDevice.get(), i, &(map->m_debug_ip_data[i])));
           else
             mPlTraceDmaList.push_back(
-                new TraceS2MM(mDevice, i, &(map->m_debug_ip_data[i])));
+				      new TraceS2MM(mDevice.get(), i, &(map->m_debug_ip_data[i])));
 
           break;
 
         case AXI_NOC:
-          nocList.push_back(new NOC(mDevice, i, &(map->m_debug_ip_data[i])));
+          nocList.push_back(new NOC(mDevice.get(), i, &(map->m_debug_ip_data[i])));
           break;
 
         case ACCEL_DEADLOCK_DETECTOR:
           mDeadlockDetector =
-              new DeadlockDetector(mDevice, i, &(map->m_debug_ip_data[i]));
+	    new DeadlockDetector(mDevice.get(), i, &(map->m_debug_ip_data[i]));
           break;
 
         case HSDP_TRACE: {
@@ -675,7 +675,7 @@ void PLDeviceIntf::readDebugIPlayout() {
       for (uint64_t i = 0; i < map->m_count; i++) {
         switch (map->m_debug_ip_data[i].m_type) {
         case AXI_MM_MONITOR: {
-          MMappedAIM *pMon = new MMappedAIM(mDevice, i, mAimList.size(),
+          MMappedAIM *pMon = new MMappedAIM(mDevice.get(), i, mAimList.size(),
                                             &(map->m_debug_ip_data[i]));
 
           if (pMon->isMMapped()) {
@@ -689,7 +689,7 @@ void PLDeviceIntf::readDebugIPlayout() {
         }
 
         case ACCEL_MONITOR: {
-          MMappedAM *pMon = new MMappedAM(mDevice, i, mAmList.size(),
+          MMappedAM *pMon = new MMappedAM(mDevice.get(), i, mAmList.size(),
                                           &(map->m_debug_ip_data[i]));
 
           if (pMon->isMMapped()) {
@@ -703,7 +703,7 @@ void PLDeviceIntf::readDebugIPlayout() {
         }
 
         case AXI_STREAM_MONITOR: {
-          MMappedASM *pMon = new MMappedASM(mDevice, i, mAsmList.size(),
+          MMappedASM *pMon = new MMappedASM(mDevice.get(), i, mAsmList.size(),
                                             &(map->m_debug_ip_data[i]));
 
           if (pMon->isMMapped()) {
@@ -718,7 +718,7 @@ void PLDeviceIntf::readDebugIPlayout() {
 
         case AXI_MONITOR_FIFO_LITE: {
           mFifoCtrl =
-              new MMappedTraceFifoLite(mDevice, i, &(map->m_debug_ip_data[i]));
+	    new MMappedTraceFifoLite(mDevice.get(), i, &(map->m_debug_ip_data[i]));
 
           if (!mFifoCtrl->isMMapped()) {
             delete mFifoCtrl;
@@ -730,7 +730,7 @@ void PLDeviceIntf::readDebugIPlayout() {
 
         case AXI_MONITOR_FIFO_FULL: {
           mFifoRead =
-              new MMappedTraceFifoFull(mDevice, i, &(map->m_debug_ip_data[i]));
+	    new MMappedTraceFifoFull(mDevice.get(), i, &(map->m_debug_ip_data[i]));
 
           if (!mFifoRead->isMMapped()) {
             delete mFifoRead;
@@ -742,7 +742,7 @@ void PLDeviceIntf::readDebugIPlayout() {
 
         case AXI_TRACE_FUNNEL: {
           MMappedTraceFunnel *pMon = new MMappedTraceFunnel(
-              mDevice, i, mTraceFunnelList.size(), &(map->m_debug_ip_data[i]));
+							    mDevice.get(), i, mTraceFunnelList.size(), &(map->m_debug_ip_data[i]));
 
           if (pMon->isMMapped()) {
             mTraceFunnelList.push_back(pMon);
@@ -759,7 +759,7 @@ void PLDeviceIntf::readDebugIPlayout() {
           // requirements)
           if (map->m_debug_ip_data[i].m_properties & TS2MM_AIE_TRACE_MASK) {
             TraceS2MM *aieTraceDma =
-                new MMappedAIETraceS2MM(mDevice, i, mAieTraceDmaList.size(),
+	      new MMappedAIETraceS2MM(mDevice.get(), i, mAieTraceDmaList.size(),
                                         &(map->m_debug_ip_data[i]));
 
             if (aieTraceDma->isMMapped()) {
@@ -769,7 +769,7 @@ void PLDeviceIntf::readDebugIPlayout() {
             }
           } else {
             TraceS2MM *plTraceDma = new MMappedTraceS2MM(
-                mDevice, i, mPlTraceDmaList.size(), &(map->m_debug_ip_data[i]));
+							 mDevice.get(), i, mPlTraceDmaList.size(), &(map->m_debug_ip_data[i]));
 
             if (plTraceDma->isMMapped()) {
               mPlTraceDmaList.push_back(plTraceDma);
@@ -783,7 +783,7 @@ void PLDeviceIntf::readDebugIPlayout() {
 
         // case AXI_NOC :
         //{
-        // MMappedNOC* pNoc = new MMappedNOC(mDevice, i, nocList.size(),
+        // MMappedNOC* pNoc = new MMappedNOC(mDevice.get(), i, nocList.size(),
         // &(map->m_debug_ip_data[i])); if(pNoc->isMMapped()) {
         // nocList.push_back(pNoc);
         // } else {
@@ -794,7 +794,7 @@ void PLDeviceIntf::readDebugIPlayout() {
         //}
         case ACCEL_DEADLOCK_DETECTOR: {
           mDeadlockDetector = new MMappedDeadlockDetector(
-              mDevice, i, &(map->m_debug_ip_data[i]));
+							  mDevice.get(), i, &(map->m_debug_ip_data[i]));
 
           if (!mDeadlockDetector->isMMapped()) {
             delete mDeadlockDetector;
@@ -828,7 +828,7 @@ void PLDeviceIntf::readDebugIPlayout() {
       for (uint64_t i = 0; i < map->m_count; i++) {
         switch (map->m_debug_ip_data[i].m_type) {
         case AXI_MM_MONITOR: {
-          IOCtlAIM *pMon = new IOCtlAIM(mDevice, i, mAimList.size(),
+          IOCtlAIM *pMon = new IOCtlAIM(mDevice.get(), i, mAimList.size(),
                                         &(map->m_debug_ip_data[i]));
 
           if (pMon->isOpened()) {
@@ -842,7 +842,7 @@ void PLDeviceIntf::readDebugIPlayout() {
         }
 
         case ACCEL_MONITOR: {
-          IOCtlAM *pMon = new IOCtlAM(mDevice, i, mAmList.size(),
+          IOCtlAM *pMon = new IOCtlAM(mDevice.get(), i, mAmList.size(),
                                       &(map->m_debug_ip_data[i]));
 
           if (pMon->isOpened()) {
@@ -856,7 +856,7 @@ void PLDeviceIntf::readDebugIPlayout() {
         }
 
         case AXI_STREAM_MONITOR: {
-          IOCtlASM *pMon = new IOCtlASM(mDevice, i, mAsmList.size(),
+          IOCtlASM *pMon = new IOCtlASM(mDevice.get(), i, mAsmList.size(),
                                         &(map->m_debug_ip_data[i]));
 
           if (pMon->isOpened()) {
@@ -871,7 +871,7 @@ void PLDeviceIntf::readDebugIPlayout() {
 
         case AXI_MONITOR_FIFO_LITE: {
           mFifoCtrl =
-              new IOCtlTraceFifoLite(mDevice, i, &(map->m_debug_ip_data[i]));
+	    new IOCtlTraceFifoLite(mDevice.get(), i, &(map->m_debug_ip_data[i]));
 
           if (!mFifoCtrl->isOpened()) {
             delete mFifoCtrl;
@@ -883,7 +883,7 @@ void PLDeviceIntf::readDebugIPlayout() {
 
         case AXI_MONITOR_FIFO_FULL: {
           mFifoRead =
-              new IOCtlTraceFifoFull(mDevice, i, &(map->m_debug_ip_data[i]));
+	    new IOCtlTraceFifoFull(mDevice.get(), i, &(map->m_debug_ip_data[i]));
 
           if (!mFifoRead->isOpened()) {
             delete mFifoRead;
@@ -895,7 +895,7 @@ void PLDeviceIntf::readDebugIPlayout() {
 
         case AXI_TRACE_FUNNEL: {
           IOCtlTraceFunnel *pMon = new IOCtlTraceFunnel(
-              mDevice, i, mTraceFunnelList.size(), &(map->m_debug_ip_data[i]));
+							mDevice.get(), i, mTraceFunnelList.size(), &(map->m_debug_ip_data[i]));
 
           if (pMon->isOpened()) {
             mTraceFunnelList.push_back(pMon);
@@ -912,7 +912,7 @@ void PLDeviceIntf::readDebugIPlayout() {
           // requirements)
           if (map->m_debug_ip_data[i].m_properties & TS2MM_AIE_TRACE_MASK) {
             TraceS2MM *aieTraceDma =
-                new IOCtlAIETraceS2MM(mDevice, i, mAieTraceDmaList.size(),
+	      new IOCtlAIETraceS2MM(mDevice.get(), i, mAieTraceDmaList.size(),
                                       &(map->m_debug_ip_data[i]));
 
             if (aieTraceDma->isOpened()) {
@@ -922,7 +922,7 @@ void PLDeviceIntf::readDebugIPlayout() {
             }
           } else {
             TraceS2MM *plTraceDma = new IOCtlTraceS2MM(
-                mDevice, i, mPlTraceDmaList.size(), &(map->m_debug_ip_data[i]));
+						       mDevice.get(), i, mPlTraceDmaList.size(), &(map->m_debug_ip_data[i]));
 
             if (plTraceDma->isOpened()) {
               mPlTraceDmaList.push_back(plTraceDma);
@@ -936,7 +936,7 @@ void PLDeviceIntf::readDebugIPlayout() {
 
         case ACCEL_DEADLOCK_DETECTOR: {
           mDeadlockDetector =
-              new IOCtlDeadlockDetector(mDevice, i, &(map->m_debug_ip_data[i]));
+	    new IOCtlDeadlockDetector(mDevice.get(), i, &(map->m_debug_ip_data[i]));
 
           if (!mDeadlockDetector->isOpened()) {
             delete mDeadlockDetector;

--- a/src/runtime_src/xdp/profile/device/pl_device_intf.h
+++ b/src/runtime_src/xdp/profile/device/pl_device_intf.h
@@ -206,8 +206,6 @@ class PLDeviceIntf {
     XDP_CORE_EXPORT
     uint32_t getDeadlockStatus();
 
-    //inline xdp::Device* getAbstractDevice() {return mDevice;}
-
     bool hasDeadlockDetector() {return mDeadlockDetector != nullptr;}
 
     bool hasHSDPforPL() { return mHSDPforPL; }

--- a/src/runtime_src/xdp/profile/device/pl_device_intf.h
+++ b/src/runtime_src/xdp/profile/device/pl_device_intf.h
@@ -71,7 +71,7 @@ class PLDeviceIntf {
     // Set device handle
     // NOTE: this is used by write, read, & traceRead
     XDP_CORE_EXPORT
-    void setDevice(xdp::Device* );
+    void setDevice(std::unique_ptr<xdp::Device>);
 
     // Debug IP layout
     XDP_CORE_EXPORT
@@ -206,7 +206,7 @@ class PLDeviceIntf {
     XDP_CORE_EXPORT
     uint32_t getDeadlockStatus();
 
-    inline xdp::Device* getAbstractDevice() {return mDevice;}
+    //inline xdp::Device* getAbstractDevice() {return mDevice;}
 
     bool hasDeadlockDetector() {return mDeadlockDetector != nullptr;}
 
@@ -225,8 +225,8 @@ class PLDeviceIntf {
 
     std::mutex traceLock ;
 
-    // Depending on OpenCL or HAL flow, "mDevice" is populated with xrt_xocl::device handle or HAL handle
-    xdp::Device* mDevice = nullptr;
+    std::unique_ptr<xdp::Device> mDevice = nullptr;
+    //xdp::Device* mDevice = nullptr;
 
     std::vector<AIM*> mAimList;
     std::vector<AM*>  mAmList;

--- a/src/runtime_src/xdp/profile/device/pl_device_intf.h
+++ b/src/runtime_src/xdp/profile/device/pl_device_intf.h
@@ -224,7 +224,6 @@ class PLDeviceIntf {
     std::mutex traceLock ;
 
     std::unique_ptr<xdp::Device> mDevice = nullptr;
-    //xdp::Device* mDevice = nullptr;
 
     std::vector<AIM*> mAimList;
     std::vector<AM*>  mAmList;

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_plugin.cpp
@@ -32,6 +32,7 @@
 #include "xdp/profile/database/database.h"
 #include "xdp/profile/database/static_info/aie_constructs.h"
 #include "xdp/profile/device/utility.h"
+#include "xdp/profile/device/xdp_base_device.h"
 #include "xdp/profile/plugin/vp_base/info.h"
 #include "xdp/profile/writer/aie_profile/aie_writer.h"
 

--- a/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.cpp
@@ -25,6 +25,7 @@
 
 #include "xdp/profile/database/database.h"
 #include "xdp/profile/device/utility.h"
+#include "xdp/profile/device/xdp_base_device.h"
 #include "xdp/profile/plugin/vp_base/info.h"
 #include "xdp/profile/plugin/vp_base/utility.h"
 #include "xdp/profile/writer/aie_status/aie_status_writer.h"

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -126,7 +126,7 @@ void AieTracePluginUnified::updateAIEDevice(void *handle) {
   (db->getStaticInfo()).setDeviceName(deviceID, "win_device");
 #else
   // Update the static database with information from xclbin
-  (db->getStaticInfo()).updateDevice(deviceID, new HalDevice(handle), handle);
+  (db->getStaticInfo()).updateDevice(deviceID, std::move(std::make_unique<HalDevice>(handle)), handle);
   std::string deviceName = util::getDeviceName(handle);
   if (deviceName != "")
     (db->getStaticInfo()).setDeviceName(deviceID, deviceName);

--- a/src/runtime_src/xdp/profile/plugin/device_offload/hal/hal_device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/hal/hal_device_offload_plugin.cpp
@@ -145,7 +145,7 @@ namespace xdp {
     
     // Update the static database with all the information that
     //  will be needed later
-    db->getStaticInfo().updateDevice(deviceId, new HalDevice(ownedHandle), userHandle) ;
+    db->getStaticInfo().updateDevice(deviceId, std::move(std::make_unique<HalDevice>(ownedHandle)), userHandle) ;
     {
       std::string deviceName = util::getDeviceName(userHandle);
       if (deviceName != "")

--- a/src/runtime_src/xdp/profile/plugin/device_offload/hw_emu/hw_emu_device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/hw_emu/hw_emu_device_offload_plugin.cpp
@@ -126,7 +126,7 @@ namespace xdp {
     
     // Update the static database with all the information that
     //  will be needed later
-    db->getStaticInfo().updateDevice(deviceId, new HalDevice(userHandle), userHandle) ;
+    db->getStaticInfo().updateDevice(deviceId, std::move(std::make_unique<HalDevice>(userHandle)), userHandle) ;
     {
       std::string deviceName = util::getDeviceName(userHandle);
       if (deviceName != "") {

--- a/src/runtime_src/xdp/profile/plugin/hal_api_interface/xdp_api_interface.cpp
+++ b/src/runtime_src/xdp/profile/plugin/hal_api_interface/xdp_api_interface.cpp
@@ -71,7 +71,7 @@ namespace xdp {
       devices[handle] = dev;
     }
     
-    dev->setDevice(new xdp::HalDevice(handle));
+    dev->setDevice(std::make_unique<xdp::HalDevice>(handle));
     dev->readDebugIPlayout();
     
     dev->startCounters();

--- a/src/runtime_src/xdp/profile/plugin/pl_deadlock/pl_deadlock_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/pl_deadlock/pl_deadlock_plugin.cpp
@@ -192,7 +192,7 @@ namespace xdp {
 
     if (!(db->getStaticInfo()).isDeviceReady(deviceId)) {
       // Update the static database with information from xclbin
-      (db->getStaticInfo()).updateDevice(deviceId, new HalDevice(handle), handle);
+      (db->getStaticInfo()).updateDevice(deviceId,std::move(std::make_unique<HalDevice>(handle)), handle);
       {
         std::string deviceName = util::getDeviceName(handle);
         if(deviceName != "") {


### PR DESCRIPTION
#### Problem solved by the commit
AIE profiling and PL device trace were working independently, but not when both were enabled.  Additionally, change the recently introduced raw pointers into unique_ptrs to prevent possible memory leaks.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
When multiple plugins are active, each will attempt to register profiling metadata when an xclbin is loaded.  If the second plugin tries to register the same metadata, it will return early and not update any data structures.  The bug happens when the first plugin to register metadata doesn't need a connection to PL but the second plugin does.  The early return had to be adjusted to make sure cases where the PL interface was needed are covered correctly

PR 8241 introduced the bug.  This was discovered while debugging a separate issue in hardware emulation.

#### How problem was solved, alternative solutions (if any) and why they were rejected
The bug was resolved by changing the function that determines if we need to refresh the profiling metadata to take into account the case where a PL interface is necessary but doesn't currently exist.

#### What has been tested and how, request additional testing if necessary
The test case on hardware emulation has been verified.  Full regression testing is necessary.

#### Documentation impact (if any)
No documentation impact