### PR TITLE
VITIS-11024 enable hw_context support for xrt::graph objects 2nd commit

### DIFF
--- a/src/runtime_src/core/edge/common/aie_parser.cpp
+++ b/src/runtime_src/core/edge/common/aie_parser.cpp
@@ -494,9 +494,10 @@ get_trace_gmio(const pt::ptree& aie_meta)
 namespace xrt_core { namespace edge { namespace aie {
 
 adf::driver_config
-get_driver_config(const xrt_core::device* device)
+get_driver_config(const xrt_core::device* device, const zynqaie::hwctx_object* hwctx)
 {
-  auto data = device->get_axlf_section(AIE_METADATA);
+  auto xclbin_uuid = hwctx ? hwctx->get_xclbin_uuid() : uuid();
+  auto data = device->get_axlf_section(AIE_METADATA, xclbin_uuid);
   if (!data.first || !data.second)
     return {};
 
@@ -506,9 +507,10 @@ get_driver_config(const xrt_core::device* device)
 }
 
 adf::aiecompiler_options
-get_aiecompiler_options(const xrt_core::device* device)
+get_aiecompiler_options(const xrt_core::device* device, const zynqaie::hwctx_object* hwctx)
 {
-  auto data = device->get_axlf_section(AIE_METADATA);
+  auto xclbin_uuid = hwctx ? hwctx->get_xclbin_uuid() : uuid();
+  auto data = device->get_axlf_section(AIE_METADATA, xclbin_uuid);
   if (!data.first || !data.second)
     return {};
 
@@ -518,9 +520,10 @@ get_aiecompiler_options(const xrt_core::device* device)
 }
 
 adf::graph_config
-get_graph(const xrt_core::device* device, const std::string& graph_name)
+get_graph(const xrt_core::device* device, const std::string& graph_name, const zynqaie::hwctx_object* hwctx)
 {
-  auto data = device->get_axlf_section(AIE_METADATA);
+  auto xclbin_uuid = hwctx ? hwctx->get_xclbin_uuid() : uuid();
+  auto data = device->get_axlf_section(AIE_METADATA, xclbin_uuid);
   if (!data.first || !data.second)
     return {};
 
@@ -530,9 +533,10 @@ get_graph(const xrt_core::device* device, const std::string& graph_name)
 }
 
 int
-get_graph_id(const xrt_core::device* device, const std::string& graph_name)
+get_graph_id(const xrt_core::device* device, const std::string& graph_name, const zynqaie::hwctx_object* hwctx)
 {
-  auto data = device->get_axlf_section(AIE_METADATA);
+  auto xclbin_uuid = hwctx ? hwctx->get_xclbin_uuid() : uuid();
+  auto data = device->get_axlf_section(AIE_METADATA, xclbin_uuid);
   if (!data.first || !data.second)
     return -1;
 
@@ -542,9 +546,10 @@ get_graph_id(const xrt_core::device* device, const std::string& graph_name)
 }
 
 std::vector<std::string>
-get_graphs(const xrt_core::device* device)
+get_graphs(const xrt_core::device* device, const zynqaie::hwctx_object* hwctx)
 {
-  auto data = device->get_axlf_section(AIE_METADATA);
+  auto xclbin_uuid = hwctx ? hwctx->get_xclbin_uuid() : uuid();
+  auto data = device->get_axlf_section(AIE_METADATA, xclbin_uuid);
   if (!data.first || !data.second)
     return {};
 
@@ -554,9 +559,10 @@ get_graphs(const xrt_core::device* device)
 }
 
 std::vector<tile_type>
-get_tiles(const xrt_core::device* device, const std::string& graph_name)
+get_tiles(const xrt_core::device* device, const std::string& graph_name, const zynqaie::hwctx_object* hwctx)
 {
-  auto data = device->get_axlf_section(AIE_METADATA);
+  auto xclbin_uuid = hwctx ? hwctx->get_xclbin_uuid() : uuid();
+  auto data = device->get_axlf_section(AIE_METADATA, xclbin_uuid);
   if (!data.first || !data.second)
     return {};
 
@@ -567,9 +573,10 @@ get_tiles(const xrt_core::device* device, const std::string& graph_name)
 
 std::vector<tile_type>
 get_event_tiles(const xrt_core::device* device, const std::string& graph_name,
-                module_type type)
+                    module_type type, const zynqaie::hwctx_object* hwctx)
 {
-  auto data = device->get_axlf_section(AIE_METADATA);
+  auto xclbin_uuid = hwctx ? hwctx->get_xclbin_uuid() : uuid();
+  auto data = device->get_axlf_section(AIE_METADATA, xclbin_uuid);
   if (!data.first || !data.second)
     return {};
 
@@ -579,9 +586,10 @@ get_event_tiles(const xrt_core::device* device, const std::string& graph_name,
 }
 
 std::unordered_map<std::string, adf::rtp_config>
-get_rtp(const xrt_core::device* device, int graph_id)
+get_rtp(const xrt_core::device* device, int graph_id, const zynqaie::hwctx_object* hwctx)
 {
-  auto data = device->get_axlf_section(AIE_METADATA);
+  auto xclbin_uuid = hwctx ? hwctx->get_xclbin_uuid() : uuid();
+  auto data = device->get_axlf_section(AIE_METADATA, xclbin_uuid);
   if (!data.first || !data.second)
     return {};
 
@@ -591,9 +599,10 @@ get_rtp(const xrt_core::device* device, int graph_id)
 }
 
 std::unordered_map<std::string, adf::gmio_config>
-get_gmios(const xrt_core::device* device)
+get_gmios(const xrt_core::device* device, const zynqaie::hwctx_object* hwctx)
 {
-  auto data = device->get_axlf_section(AIE_METADATA);
+  auto xclbin_uuid = hwctx ? hwctx->get_xclbin_uuid() : uuid();
+  auto data = device->get_axlf_section(AIE_METADATA, xclbin_uuid);
   if (!data.first || !data.second)
     return {};
 
@@ -603,9 +612,10 @@ get_gmios(const xrt_core::device* device)
 }
 
 std::unordered_map<std::string, adf::plio_config>
-get_plios(const xrt_core::device* device)
+get_plios(const xrt_core::device* device, const zynqaie::hwctx_object* hwctx)
 {
-  auto data = device->get_axlf_section(AIE_METADATA);
+  auto xclbin_uuid = hwctx ? hwctx->get_xclbin_uuid() : uuid();
+  auto data = device->get_axlf_section(AIE_METADATA, xclbin_uuid);
   if (!data.first || !data.second)
     return {};
 
@@ -615,9 +625,10 @@ get_plios(const xrt_core::device* device)
 }
 
 double
-get_clock_freq_mhz(const xrt_core::device* device)
+get_clock_freq_mhz(const xrt_core::device* device, const zynqaie::hwctx_object* hwctx)
 {
-  auto data = device->get_axlf_section(AIE_METADATA);
+  auto xclbin_uuid = hwctx ? hwctx->get_xclbin_uuid() : uuid();
+  auto data = device->get_axlf_section(AIE_METADATA, xclbin_uuid);
   if (!data.first || !data.second)
     return 1000.0;  // magic
 
@@ -627,9 +638,10 @@ get_clock_freq_mhz(const xrt_core::device* device)
 }
 
 std::vector<counter_type>
-get_profile_counters(const xrt_core::device* device)
+get_profile_counters(const xrt_core::device* device, const zynqaie::hwctx_object* hwctx)
 {
-  auto data = device->get_axlf_section(AIE_METADATA);
+  auto xclbin_uuid = hwctx ? hwctx->get_xclbin_uuid() : uuid();
+  auto data = device->get_axlf_section(AIE_METADATA, xclbin_uuid);
   if (!data.first || !data.second)
     return {};
 
@@ -639,9 +651,10 @@ get_profile_counters(const xrt_core::device* device)
 }
 
 std::vector<gmio_type>
-get_trace_gmios(const xrt_core::device* device)
+get_trace_gmios(const xrt_core::device* device, const zynqaie::hwctx_object* hwctx)
 {
-  auto data = device->get_axlf_section(AIE_METADATA);
+  auto xclbin_uuid = hwctx ? hwctx->get_xclbin_uuid() : uuid();
+  auto data = device->get_axlf_section(AIE_METADATA, xclbin_uuid);
   if (!data.first || !data.second)
     return {};
 
@@ -651,9 +664,10 @@ get_trace_gmios(const xrt_core::device* device)
 }
 /* hw_gen represents aie version 1.aie, 2.aie-ml etc */
 uint8_t
-get_hw_gen(const xrt_core::device* device)
+get_hw_gen(const xrt_core::device* device, const zynqaie::hwctx_object* hwctx)
 {
-  auto data = device->get_axlf_section(AIE_METADATA);
+  auto xclbin_uuid = hwctx ? hwctx->get_xclbin_uuid() : uuid();
+  auto data = device->get_axlf_section(AIE_METADATA, xclbin_uuid);
   if (!data.first || !data.second)
     return 1; // default is aie-1
 
@@ -663,9 +677,10 @@ get_hw_gen(const xrt_core::device* device)
 }
 
 uint32_t
-get_partition_id(const xrt_core::device* device)
+get_partition_id(const xrt_core::device* device, const zynqaie::hwctx_object* hwctx)
 {
-  auto data = device->get_axlf_section(AIE_METADATA);
+  auto xclbin_uuid = hwctx ? hwctx->get_xclbin_uuid() : uuid();
+  auto data = device->get_axlf_section(AIE_METADATA, xclbin_uuid);
   if (!data.first || !data.second)
     return 1; 
 

--- a/src/runtime_src/core/edge/common/aie_parser.h
+++ b/src/runtime_src/core/edge/common/aie_parser.h
@@ -20,7 +20,8 @@
 #include <string>
 #include <vector>
 #include <unordered_map>
-#include "../user/aie/common_layer/adf_api_config.h"
+#include "core/edge/user/aie/common_layer/adf_api_config.h"
+#include "core/edge/user/hwctx_object.h"
 
 namespace xrt_core {
 
@@ -59,7 +60,7 @@ const int NON_EXIST_ID = -1;
  * @device: device with loaded meta data
  */
 adf::driver_config
-get_driver_config(const xrt_core::device* device);
+get_driver_config(const xrt_core::device* device, const zynqaie::hwctx_object* hwctx = nullptr);
 
 /**
  * get_aiecompiler_options() - get compiler options from xclbin AIE metadata
@@ -67,7 +68,7 @@ get_driver_config(const xrt_core::device* device);
  * @device: device with loaded meta data
  */
 adf::aiecompiler_options
-get_aiecompiler_options(const xrt_core::device* device);
+get_aiecompiler_options(const xrt_core::device* device, const zynqaie::hwctx_object* hwctx = nullptr);
 
 /**
  * get_graph() - get tile data from xclbin AIE metadata
@@ -77,7 +78,7 @@ get_aiecompiler_options(const xrt_core::device* device);
  * Return: Graph config of given graph name
  */
 adf::graph_config
-get_graph(const xrt_core::device* device, const std::string& graph_name);
+get_graph(const xrt_core::device* device, const std::string& graph_name, const zynqaie::hwctx_object* hwctx = nullptr);
 
 /**
  * get_graph_id() - get graph id from xclbin AIE metadata
@@ -87,7 +88,7 @@ get_graph(const xrt_core::device* device, const std::string& graph_name);
  * Return: Integer graph id or NON_EXIST_ID if given name is not found
  */
 int
-get_graph_id(const xrt_core::device* device, const std::string& graph_name);
+get_graph_id(const xrt_core::device* device, const std::string& graph_name, const zynqaie::hwctx_object* hwctx = nullptr);
 
 /**
  * get_graphs() - get graph names from xclbin AIE metadata
@@ -95,7 +96,7 @@ get_graph_id(const xrt_core::device* device, const std::string& graph_name);
  * @device: device with loaded meta data
  */
 std::vector<std::string>
-get_graphs(const xrt_core::device* device);
+get_graphs(const xrt_core::device* device, const zynqaie::hwctx_object* hwctx = nullptr);
 
 /**
  * get_tiles() - get tile data from xclbin AIE metadata
@@ -105,7 +106,7 @@ get_graphs(const xrt_core::device* device);
  * Return: vector of used tiles in given graph name 
  */
 std::vector<tile_type>
-get_tiles(const xrt_core::device* device, const std::string& graph_name);
+get_tiles(const xrt_core::device* device, const std::string& graph_name, const zynqaie::hwctx_object* hwctx = nullptr);
 
 /**
  * get_event_tiles() - get tiles with active events from xclbin AIE metadata
@@ -117,7 +118,7 @@ get_tiles(const xrt_core::device* device, const std::string& graph_name);
  */
 std::vector<tile_type>
 get_event_tiles(const xrt_core::device* device, const std::string& graph_name,
-                module_type type);
+                module_type type, const zynqaie::hwctx_object* hwctx = nullptr);
 
 /**
  * get_rtp() - get rtp data from xclbin AIE metadata
@@ -125,7 +126,7 @@ get_event_tiles(const xrt_core::device* device, const std::string& graph_name,
  * @device: device with loaded meta data
  */
 std::unordered_map<std::string, adf::rtp_config>
-get_rtp(const xrt_core::device* device, int graph_id);
+get_rtp(const xrt_core::device* device, int graph_id, const zynqaie::hwctx_object* hwctx = nullptr);
 
 /**
  * get_gmios() - get gmio data from xclbin AIE metadata
@@ -133,7 +134,7 @@ get_rtp(const xrt_core::device* device, int graph_id);
  * @device: device with loaded meta data
  */
 std::unordered_map<std::string, adf::gmio_config>
-get_gmios(const xrt_core::device* device);
+get_gmios(const xrt_core::device* device, const zynqaie::hwctx_object* hwctx = nullptr);
 
 /**
  * get_plios() - get plio data from xclbin AIE metadata
@@ -141,7 +142,7 @@ get_gmios(const xrt_core::device* device);
  * @device: device with loaded meta data
  */
 std::unordered_map<std::string, adf::plio_config>
-get_plios(const xrt_core::device* device);
+get_plios(const xrt_core::device* device, const zynqaie::hwctx_object* hwctx = nullptr);
 
 struct counter_type
 {
@@ -163,7 +164,7 @@ struct counter_type
  * @device: device with loaded meta data
  */
 double
-get_clock_freq_mhz(const xrt_core::device* device);
+get_clock_freq_mhz(const xrt_core::device* device, const zynqaie::hwctx_object* hwctx = nullptr);
 
 /**
  * get_profile_counters() - get counter data from xclbin AIE metadata
@@ -171,7 +172,7 @@ get_clock_freq_mhz(const xrt_core::device* device);
  * @device: device with loaded meta data
  */
 std::vector<counter_type>
-get_profile_counters(const xrt_core::device* device);
+get_profile_counters(const xrt_core::device* device, const zynqaie::hwctx_object* hwctx = nullptr);
 
 struct gmio_type
 {
@@ -191,7 +192,7 @@ struct gmio_type
  * @device: device with loaded meta data
  */
 uint8_t
-get_hw_gen(const xrt_core::device* device);
+get_hw_gen(const xrt_core::device* device, const zynqaie::hwctx_object* hwctx = nullptr);
 
 /**
  * get_partition_id - calculate aie_partition_id from xclbin AIE metadata
@@ -199,7 +200,7 @@ get_hw_gen(const xrt_core::device* device);
  * @device: device with loaded meta data
  */
 uint32_t
-get_partition_id(const xrt_core::device* device);
+get_partition_id(const xrt_core::device* device, const zynqaie::hwctx_object* hwctx = nullptr);
 
 /**
  * get_trace_gmios() - get trace gmio data from xclbin AIE metadata
@@ -207,7 +208,7 @@ get_partition_id(const xrt_core::device* device);
  * @device: device with loaded meta data
  */
 std::vector<gmio_type>
-get_trace_gmios(const xrt_core::device* device);
+get_trace_gmios(const xrt_core::device* device, const zynqaie::hwctx_object* hwctx = nullptr);
 
 }}} // aie, edge, xrt_core
 

--- a/src/runtime_src/core/edge/user/aie/aied.h
+++ b/src/runtime_src/core/edge/user/aie/aied.h
@@ -32,19 +32,19 @@
  */
 namespace zynqaie {
 
-class Aied
+class aied
 {
 public:
-  Aied(xrt_core::device* device);
-  ~Aied();
-  void registerGraph(const graph_type *graph);
-  void deregisterGraph(const graph_type *graph);
+  aied(xrt_core::device* device);
+  ~aied();
+  void register_graph(const graph_instance *graph);
+  void deregister_graph(const graph_instance *graph);
 
 private:
   bool done;
-  static void* pollAIE(void *arg);
-  xrt_core::device *mCoreDevice;
-  std::vector<const graph_type*> mGraphs;
+  static void* poll_aie(void *arg);
+  xrt_core::device *m_device;
+  std::vector<const graph_instance*> m_graphs;
   pthread_t ptid;
 };
 } // end namespace

--- a/src/runtime_src/core/edge/user/aie/graph.h
+++ b/src/runtime_src/core/edge/user/aie/graph.h
@@ -22,6 +22,7 @@
 #include "aie.h"
 #include "xrt.h"
 #include "core/edge/common/aie_parser.h"
+#include "core/edge/user/hwctx_object.h"
 #include "core/common/device.h"
 #include "experimental/xrt_graph.h"
 #include "common_layer/adf_api_config.h"
@@ -34,11 +35,12 @@ typedef xclDeviceHandle xrtDeviceHandle;
 
 namespace zynqaie {
 
-class graph_type
+class graph_instance
 {
 public:
-    graph_type(std::shared_ptr<xrt_core::device> device, const uuid_t xclbin_uuid, const std::string& name, xrt::graph::access_mode);
-    ~graph_type();
+    graph_instance(std::shared_ptr<xrt_core::device> device, std::string name,
+                    xrt::graph::access_mode, const zynqaie::hwctx_object* hwctx = nullptr, const xrt_core::uuid uuid=xrt_core::uuid());
+    ~graph_instance();
 
     void
     reset();
@@ -93,6 +95,7 @@ private:
     // has been loaded with an xclbin from which meta data can
     // be extracted
     std::shared_ptr<xrt_core::device> device;
+    const zynqaie::hwctx_object* m_hwctxHandle;
 
     enum class graph_state : unsigned short
     {

--- a/src/runtime_src/core/edge/user/device_linux.cpp
+++ b/src/runtime_src/core/edge/user/device_linux.cpp
@@ -10,6 +10,7 @@
 #include "core/common/query_requests.h"
 #include "core/common/xrt_profiling.h"
 #include "shim.h"
+#include "graph_object.h"
 
 #include <map>
 #include <memory>
@@ -1135,7 +1136,7 @@ std::unique_ptr<xrt_core::graph_handle>
 device_linux::
 open_graph_handle(const xrt::uuid& xclbin_id, const char* name, xrt::graph::access_mode am)
 {
-   return std::make_unique<ZYNQ::shim::graph_object>(
+   return std::make_unique<zynqaie::graph_object>(
                   static_cast<ZYNQ::shim*>(get_device_handle()), xclbin_id, name, am);
 }
 

--- a/src/runtime_src/core/edge/user/graph_object.cpp
+++ b/src/runtime_src/core/edge/user/graph_object.cpp
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+#include "graph_object.h"
+#include "core/edge/user/aie/graph.h"
+#include "core/common/system.h"
+#include <memory>
+
+namespace zynqaie {
+  graph_object::graph_object(ZYNQ::shim* shim, const xrt::uuid& uuid , const char* name,
+                  xrt::graph::access_mode am, const zynqaie::hwctx_object* hwctx)
+    : m_shim{shim}
+  {
+    auto device{xrt_core::get_userpf_device(m_shim)};
+    m_graphInstance = std::make_unique<zynqaie::graph_instance>(device, name, am, hwctx,uuid);
+  }
+
+  void
+  graph_object::reset_graph()
+  {
+    try {
+      m_graphInstance->reset();
+    }
+    catch (const std::exception& e) {
+      xrt_core::send_exception_message(std::string("fail to reset graph: ") + e.what());
+    }
+    catch (...) {
+      xrt_core::send_exception_message(std::string("fail to reset graph"));
+    }
+  }
+
+  uint64_t
+  graph_object::get_timestamp()
+  {
+    try {
+      m_graphInstance->get_timestamp();
+    }
+    catch (const std::exception& e) {
+      xrt_core::send_exception_message(std::string("fail to get graph timestamp: ") + e.what());
+    }
+    catch (...) {
+      xrt_core::send_exception_message(std::string("fail to get graph timestamp"));
+    }
+    return -1;
+  }
+
+  void
+  graph_object::run_graph(int iterations)
+  {
+    try {
+      if (iterations == 0)
+        m_graphInstance->run();
+      else
+        m_graphInstance->run(iterations);
+    }
+    catch (const std::exception& e) {
+      xrt_core::send_exception_message(std::string("fail to run graph: ") + e.what());
+    }
+    catch (...) {
+      xrt_core::send_exception_message(std::string("fail to run graph"));
+    }
+  }
+
+  int
+  graph_object::wait_graph_done(int timeout)
+  {
+    try {
+      m_graphInstance->wait_done(timeout);
+      return 0;
+    }
+    catch (const std::exception& e) {
+      xrt_core::send_exception_message(std::string("fail to wait graph done: ") + e.what());
+    }
+    catch (...) {
+      xrt_core::send_exception_message(std::string("fail to wait graph done"));
+    }
+    return -1;
+  }
+
+  void
+  graph_object::wait_graph(uint64_t cycle)
+  {
+    try {
+      if (cycle == 0)
+        m_graphInstance->wait();
+      else
+        m_graphInstance->wait(cycle);
+    }
+    catch (const std::exception& e) {
+      xrt_core::send_exception_message(std::string("fail to wait graph: ") + e.what());
+    }
+    catch (...) {
+      xrt_core::send_exception_message(std::string("fail to wait graph"));
+    }
+  }
+
+  void
+  graph_object::suspend_graph()
+  {
+    try {
+      m_graphInstance->suspend();
+    }
+    catch (const std::exception& e) {
+      xrt_core::send_exception_message(std::string("fail to suspend graph: ") + e.what());
+    }
+    catch (...) {
+      xrt_core::send_exception_message(std::string("fail to suspend graph"));
+    }
+  }
+
+  void
+  graph_object::resume_graph()
+  {
+    try {
+      m_graphInstance->resume();
+    }
+    catch (const std::exception& e) {
+      xrt_core::send_exception_message(std::string("fail to resume graph: ") + e.what());
+    }
+    catch (...) {
+      xrt_core::send_exception_message(std::string("fail to resume graph"));
+    }
+  }
+
+  void
+  graph_object::end_graph(uint64_t cycle)
+  {
+    try {
+      if (cycle == 0)
+        m_graphInstance->end();
+      else
+        m_graphInstance->end(cycle);
+    }
+    catch (const std::exception& e) {
+      xrt_core::send_exception_message(std::string("fail to end graph: ") + e.what());
+    }
+    catch (...) {
+      xrt_core::send_exception_message(std::string("fail to end graph"));
+    }
+  }
+
+  void
+  graph_object::update_graph_rtp(const char* port, const char* buffer, size_t size)
+  {
+    try {
+      m_graphInstance->update_rtp(port, buffer, size);
+    }
+    catch (const std::exception& e) {
+      xrt_core::send_exception_message(std::string("fail to update graph rtp: ") + e.what());
+    }
+    catch (...) {
+      xrt_core::send_exception_message(std::string("fail to update graph rtp"));
+    }
+  }
+
+  void
+  graph_object::read_graph_rtp(const char* port, char* buffer, size_t size)
+  {
+    try {
+      m_graphInstance->read_rtp(port, buffer, size);
+    }
+    catch (const std::exception& e) {
+      xrt_core::send_exception_message(std::string("fail to read graph rtp: ") + e.what());
+    }
+    catch (...) {
+      xrt_core::send_exception_message(std::string("fail to read graph rtp"));
+    }
+  }
+}

--- a/src/runtime_src/core/edge/user/graph_object.h
+++ b/src/runtime_src/core/edge/user/graph_object.h
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+#ifndef _ZYNQ_GRAPH_OBJECT_H_
+#define _ZYNQ_GRAPH_OBJECT_H_
+
+#include "core/common/message.h"
+#include "core/common/shim/shared_handle.h"
+#include "core/common/shim/graph_handle.h"
+#include "core/include/xrt/xrt_uuid.h"
+#include "xrt/xrt_graph.h"
+
+
+#include <memory>
+
+namespace ZYNQ {
+	class shim;
+}
+namespace zynqaie {
+  // Shim handle for graph object
+  class graph_instance;
+  class hwctx_object;
+  class graph_object : public xrt_core::graph_handle
+  {
+    ZYNQ::shim* m_shim;
+    std::unique_ptr<zynqaie::graph_instance> m_graphInstance;
+
+  public:
+    graph_object(ZYNQ::shim* shim, const xrt::uuid& uuid , const char* name,
+                    xrt::graph::access_mode am, const zynqaie::hwctx_object* hwctx = nullptr);
+
+    void
+    reset_graph() override;
+
+    uint64_t
+    get_timestamp() override;
+
+    void
+    run_graph(int iterations) override;
+
+    int
+    wait_graph_done(int timeout) override;
+
+    void
+    wait_graph(uint64_t cycle) override;
+
+    void
+    suspend_graph() override;
+
+    void
+    resume_graph() override;
+
+    void
+    end_graph(uint64_t cycle) override;
+
+    void
+    update_graph_rtp(const char* port, const char* buffer, size_t size) override;
+
+    void
+    read_graph_rtp(const char* port, char* buffer, size_t size) override;
+  }; // graph_object
+}
+#endif

--- a/src/runtime_src/core/edge/user/hwctx_object.cpp
+++ b/src/runtime_src/core/edge/user/hwctx_object.cpp
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+#include "hwctx_object.h"
+#include "graph_object.h"
+#include "shim.h"
+
+namespace zynqaie {
+  // Shim handle for hardware context Even as hw_emu does not
+  // support hardware context, it still must implement a shim
+  // hardware context handle representing the default slot
+  //
+  //
+  hwctx_object::hwctx_object(ZYNQ::shim* shim, slot_id slotidx, xrt::uuid uuid, xrt::hw_context::access_mode mode)
+	  : m_shim(shim)
+	  , m_uuid(std::move(uuid))
+	  , m_slotidx(slotidx)
+	  , m_mode(mode)
+  {}
+
+  std::unique_ptr<xrt_core::buffer_handle>
+  hwctx_object::alloc_bo(void* userptr, size_t size, uint64_t flags)
+  {
+    // The hwctx is embedded in the flags, use regular shim path
+    return m_shim->xclAllocUserPtrBO(userptr, size, xcl_bo_flags{flags}.flags);
+  }
+
+  std::unique_ptr<xrt_core::buffer_handle>
+  hwctx_object::alloc_bo(size_t size, uint64_t flags)
+  {
+    // The hwctx is embedded in the flags, use regular shim path
+    return m_shim->xclAllocBO(size, xcl_bo_flags{flags}.flags);
+  }
+
+  xrt_core::cuidx_type
+  hwctx_object::open_cu_context(const std::string& cuname)
+  {
+    return m_shim->open_cu_context(this, cuname);
+  }
+
+  void
+  hwctx_object::close_cu_context(xrt_core::cuidx_type cuidx)
+  {
+    m_shim->close_cu_context(this, cuidx);
+  }
+
+  void
+  hwctx_object::exec_buf(xrt_core::buffer_handle* cmd)
+  {
+    m_shim->xclExecBuf(cmd->get_xcl_handle());
+  }
+
+  std::unique_ptr<xrt_core::graph_handle>
+  hwctx_object::open_graph_handle(const char* name, xrt::graph::access_mode am)
+  {
+    return std::make_unique<graph_object>(m_shim, m_uuid, name, am, this);
+  }
+}

--- a/src/runtime_src/core/edge/user/hwctx_object.h
+++ b/src/runtime_src/core/edge/user/hwctx_object.h
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+#ifndef _ZYNQ_HWCTX_OBJECT_H_
+#define _ZYNQ_HWCTX_OBJECT_H_
+
+#include "core/common/shim/hwctx_handle.h"
+#include "core/common/shim/shared_handle.h"
+#include "core/common/shim/graph_handle.h"
+
+// Shim handle for hardware context Even as hw_emu does not
+// support hardware context, it still must implement a shim
+// hardware context handle representing the default slot
+namespace ZYNQ {
+  class shim;
+}
+
+namespace zynqaie {
+  class hwctx_object : public xrt_core::hwctx_handle
+  {
+    ZYNQ::shim* m_shim;
+    xrt::uuid m_uuid;
+    slot_id m_slotidx;
+    xrt::hw_context::access_mode m_mode;
+
+  public:
+    hwctx_object(ZYNQ::shim* shim, slot_id slotidx, xrt::uuid uuid, xrt::hw_context::access_mode mode);
+
+    void
+    update_access_mode(access_mode mode) override
+    {
+      m_mode = mode;
+    }
+
+    slot_id
+    get_slotidx() const override
+    {
+      return m_slotidx;
+    }
+
+    xrt::hw_context::access_mode
+    get_mode() const
+    {
+      return m_mode;
+    }
+
+    xrt::uuid
+    get_xclbin_uuid() const
+    {
+      return m_uuid;
+    }
+
+    xrt_core::hwqueue_handle*
+    get_hw_queue() override
+    {
+      return nullptr;
+    }
+
+    std::unique_ptr<xrt_core::buffer_handle>
+    alloc_bo(void* userptr, size_t size, uint64_t flags) override;
+
+    std::unique_ptr<xrt_core::buffer_handle>
+    alloc_bo(size_t size, uint64_t flags) override;
+
+    xrt_core::cuidx_type
+    open_cu_context(const std::string& cuname) override;
+
+    void
+    close_cu_context(xrt_core::cuidx_type cuidx) override;
+
+    void
+    exec_buf(xrt_core::buffer_handle* cmd) override;
+
+    std::unique_ptr<xrt_core::graph_handle>
+    open_graph_handle(const char* name, xrt::graph::access_mode am) override;
+  }; // class hwctx_object
+}
+#endif

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -3,6 +3,7 @@
 // Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
 #include "shim.h"
 #include "system_linux.h"
+#include "hwctx_object.h"
 
 #include "core/include/shim_int.h"
 #include "core/include/xdp/aim.h"
@@ -1133,7 +1134,7 @@ open_cu_context(const xrt_core::hwctx_handle* hwctx_hdl, const std::string& cuna
   // Edge does not yet support multiple xclbins.  Call
   // regular flow.  Default access mode to shared unless explicitly
   // exclusive.
-  auto hwctx = static_cast<const hwcontext*>(hwctx_hdl);
+  auto hwctx = static_cast<const zynqaie::hwctx_object*>(hwctx_hdl);
   auto shared = (hwctx->get_mode() != xrt::hw_context::access_mode::exclusive);
   auto cuidx = mCoreDevice->get_cuidx(hwctx->get_slotidx(), cuname);
   xclOpenContext(hwctx->get_xclbin_uuid().get(), cuidx.index, shared);
@@ -1146,7 +1147,7 @@ shim::
 close_cu_context(const xrt_core::hwctx_handle* hwctx_hdl, xrt_core::cuidx_type cuidx)
 {
   // To-be-implemented
-  auto hwctx = static_cast<const hwcontext*>(hwctx_hdl);
+  auto hwctx = static_cast<const zynqaie::hwctx_object*>(hwctx_hdl);
   if (xclCloseContext(hwctx->get_xclbin_uuid().get(), cuidx.index))
     throw xrt_core::system_error(errno, "failed to close cu context (" + std::to_string(cuidx.index) + ")");
 }
@@ -1157,7 +1158,7 @@ create_hw_context(const xrt::uuid& xclbin_uuid,
                   const xrt::hw_context::cfg_param_type&,
                   xrt::hw_context::access_mode mode)
 {
-  return std::make_unique<hwcontext>(this, 0, xclbin_uuid, mode);
+  return std::make_unique<zynqaie::hwctx_object>(this, 0, xclbin_uuid, mode);
 }
 
 int
@@ -1728,7 +1729,7 @@ getAieArray()
   return aieArray.get();
 }
 
-zynqaie::Aied*
+zynqaie::aied*
 shim::
 getAied()
 {
@@ -1741,7 +1742,7 @@ registerAieArray()
 {
   delete aieArray.release();
   aieArray = std::make_unique<zynqaie::Aie>(mCoreDevice);
-  aied = std::make_unique<zynqaie::Aied>(mCoreDevice.get());
+  aied = std::make_unique<zynqaie::aied>(mCoreDevice.get());
 }
 
 bool


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

https://jira.xilinx.com/browse/VITIS-11024
currently we can load only one xclbin in graph supported devices , we cannot load multiple xclbins in multiple partitions in device..

This is second commit for VITIS-11024
First commit: https://github.com/Xilinx/XRT/pull/8242

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

N/A

#### How problem was solved, alternative solutions (if any) and why they were rejected

These first set of changes are enabling interface to support multiple xclbins in multiple partitions in device by creating "hardware context" associated with device id and xclbin. Interfaces are created for application developers and driver component owners to load mulitple xclbins in device by creating hardware context with particular device and particualr xclbin. New shim changes (driver changes) are required to fully utilize hardware context interfaces and fullfill actual requirements. currently used old shim by extracting device and xclbin from hardware context (loaded single device id with single xclbin)

#### Risks (if any) associated the changes in the commit

Documentation for this change might be required, should not break old flow where it still supports to load xclbin with device id. And as mentioned in above field new shim changes (driver changes) are required.

#### What has been tested and how, request additional testing if necessary

Used Graph test use case where input array and input factor are provided, ouput array would be generated by muliplying input array with input factor.

Initializing ADF API...
[   99.707868] zocl-drm axi:zyxclmm_drm: zocl_create_client: created KDS client for pid(589), ret: 0
[   99.716043] zocl-drm axi:zyxclmm_drm: zocl_destroy_client: client exits pid(589)
[   99.778415] zocl-drm axi:zyxclmm_drm: zocl_create_client: created KDS client for pid(589), ret: 0
[  108.057897] [drm] Loading xclbin 63723cb0-4f53-4aa2-5ab0-60152b9af36b to slot 0
[  108.058281] [drm] found kind 29(AIE_RESOURCES)
[  108.062967] [drm] skip kind 8(IP_LAYOUT) return code: -22
[  108.065298] [drm] found kind 9(DEBUG_IP_LAYOUT)
[  108.067367] [drm] found kind 25(AIE_METADATA)
[  108.069022] [drm] skip kind 7(CONNECTIVITY) return code: -22
[  108.070547] [drm] found kind 6(MEM_TOPOLOGY)
[  108.073657] [drm] Memory 0 is not reserved in device tree. Will allocate memory from CMA
[  108.403376] [drm] AIE create successfully finished.
XAIEFAL: INFO: Resource group Avail is created.
XAIEFAL: INFO: Resource group Static is created.
XAIEFAL: INFO: Resource group Generic is created.
[  108.404487] [drm] zocl_xclbin_read_axlf 63723cb0-4f53-4aa2-5ab0-60152b9af36b ret: 0
[  108.585794] [drm] bitstream 63723cb0-4f53-4aa2-5ab0-60152b9af36b locked, ref=1
[  108.594516] zocl-drm axi:zyxclmm_drm:  ffff000001f5d410 kds_add_context: Client pid(589) add context Domain(65535) CU(0xffff) shared(true)
[  108.603146] zocl-drm axi:zyxclmm_drm:  ffff000001f5d410 kds_del_context: Client pid(589) del context Domain(65535) CU(0xffff)
graph run completed .....
trying alias 
graph rtp read completed .....
graph end completed .....
output Vector 1 value 3
output Vector 1 value 6
output Vector 1 value 9
output Vector 1 value 12
output Vector 1 value 15
output Vector 1 value 18
output Vector 1 value 21
output Vector 1 value 24
TEST PASSED

#### Documentation impact (if any)

Graph doumentation may needs to be updated with "hwctx" things. And currently both kernel and graph support only c++ API's with "hardware context"
