### PR TITLE
Add proper declspec define.  Amend #8242.

### DIFF
--- a/src/runtime_src/core/common/api/aie/xrt_graph.cpp
+++ b/src/runtime_src/core/common/api/aie/xrt_graph.cpp
@@ -7,6 +7,7 @@
 // core/include/experimental/xrt_graph.h -- end user APIs
 // core/include/xcl_graph.h -- shim level APIs
 #define XCL_DRIVER_DLL_EXPORT  // exporting xrt_graph.h
+#define XRT_API_SOURCE         // in same dll as core_common
 #define XRT_CORE_COMMON_SOURCE // in same dll as core_common
 #include "core/include/xrt/xrt_graph.h"
 #include "core/include/xrt/xrt_aie.h"


### PR DESCRIPTION
#### Problem solved by the commit
Amend #8242 to ensure hwctx APIs are exported rather than imported.

Slightly confusing here.  But all sources files in core/common must ensure that they export symbols implemented in core/common.    There are different macros used to export symbols, in particular the definition of XRT_API_EXPORT is controlled by XRT_API_SOURCE for export.   We should change the code to only use XRT_API_EXPORT and remove XRT_DRIVER_DLLSPEC which is legacy and not very clear.
