### PR TITLE
Various Cleanup of xbutil with xrt-smi, Help Menu Fix

### DIFF
--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -1051,7 +1051,7 @@ alloc_bo(const device_type& device, size_t sz, xrtBufferFlags flags, xrtMemoryGr
   catch (const std::exception& ex) {
     if (flags == XRT_BO_FLAGS_HOST_ONLY) {
       auto fmt = boost::format("Failed to allocate host memory buffer (%s), make sure host bank is enabled "
-                               "(see xbutil configure --host-mem)") % ex.what();
+                               "(see xrt-smi configure --host-mem)") % ex.what();
       send_exception_message(fmt.str());
     }
     throw;

--- a/src/runtime_src/core/common/info_memory.cpp
+++ b/src/runtime_src/core/common/info_memory.cpp
@@ -465,7 +465,7 @@ get_ps_kernels(const xrt_core::device* device)
       return ps_kernels;
     const ps_kernel_node *map = reinterpret_cast<ps_kernel_node *>(buf.data());
     if(map->pkn_count == 0)
-      throw xrt_core::error("'ps_kernel' invalid. Has the PS kernel been loaded? See 'xbutil program'.");
+      throw xrt_core::error("'ps_kernel' invalid. Has the PS kernel been loaded? See 'xrt-smi program'.");
 
     for (unsigned int i = 0; i < map->pkn_count; i++)
       ps_kernels.emplace_back(map->pkn_data[i]);

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -1714,7 +1714,7 @@ xclLoadXclBin(const xclBin *buffer)
     }
     else if (ret == -EDEADLK) {
       xrt_logmsg(XRT_ERROR, "CU was deadlocked? Hardware is not stable");
-      xrt_logmsg(XRT_ERROR, "Please reset device with 'xbutil reset'");
+      xrt_logmsg(XRT_ERROR, "Please reset device with 'xrt-smi reset'");
     }
     xrt_logmsg(XRT_ERROR, "See dmesg log for details. err = %d", ret);
     return ret;
@@ -2606,7 +2606,7 @@ create_hw_context(const xrt::uuid& xclbin_uuid,
       }
       else if (ret == -EDEADLK) {
         xrt_logmsg(XRT_ERROR, "CU was deadlocked? Hardware is not stable");
-        xrt_logmsg(XRT_ERROR, "Please reset device with 'xbutil reset'");
+        xrt_logmsg(XRT_ERROR, "Please reset device with 'xrt-smi reset'");
       }
       xrt_logmsg(XRT_ERROR, "See dmesg log for details. err = %d", ret);
 

--- a/src/runtime_src/core/tools/common/SubCmdJSON.cpp
+++ b/src/runtime_src/core/tools/common/SubCmdJSON.cpp
@@ -153,7 +153,7 @@ static void populateSubCommandsFromJSONHelper(SubCmdsCollection &subCmds, const 
         pt::read_json(jsonPath,jtree);
 
 	pt::ptree exetree;
-	// check exsistence of tree node for execuatble passed(eg: xbutil)
+	// check exsistence of tree node for execuatble passed(eg: xrt-smi)
 	try {
             exetree = jtree.get_child(exeName);
 	} catch (std::exception &e) {

--- a/src/runtime_src/core/tools/common/XBMain.cpp
+++ b/src/runtime_src/core/tools/common/XBMain.cpp
@@ -146,10 +146,11 @@ void  main_(int argc, char** argv,
   }
 
   if (!subCommand) {
-    if (!bHelp)
+    if (!bHelp && !sCmd.empty())
       std::cerr << "ERROR: " << "Unknown command: '" << sCmd << "'" << std::endl;
     XBU::report_commands_help( _executable, _description, globalOptions, hiddenOptions, parsedSubCmds);
-    throw xrt_core::error(std::errc::operation_canceled);
+    if (!bHelp && !sCmd.empty())
+      throw xrt_core::error(std::errc::operation_canceled);
   }
 
   // -- Prepare the data

--- a/src/runtime_src/core/tools/common/xball
+++ b/src/runtime_src/core/tools/common/xball
@@ -42,7 +42,7 @@ while [ $# -gt 0 ]; do
             ;;
 
         # Application tool
-        xbutil|xbmgmt )
+        xrt-smi|xbmgmt )
             xrt_app=$1
             shift
 
@@ -55,9 +55,9 @@ while [ $# -gt 0 ]; do
                         exit 1
                     ;;
 
-                    # Duplicate xbutil & xbmgmt options detected
-                    xbutil|xbmgmt)
-                         echo "Error: Mulitple xbutil and/or xbmgmt definitions detected."
+                    # Duplicate xrt-smi & xbmgmt options detected
+                    xrt-smi|xbmgmt)
+                         echo "Error: Mulitple xrt-smi and/or xbmgmt definitions detected."
                          exit 1
                     ;;
 
@@ -89,9 +89,9 @@ if [ "$help_arg" = "true" ]; then
     echo
     echo "DESCRIPTION: This script will discover the installed card(s) in the system,"
     echo "             optionally filter the cards of interest, and execute the given"
-    echo "             command options for either the 'xbutil' or 'xbmgmt' applications."
+    echo "             command options for either the 'xrt-smi' or 'xbmgmt' applications."
     echo 
-    echo "USAGE: xball [--help] [--device-filter arg] <xbutil | xbmgmt> <utility arguments>"
+    echo "USAGE: xball [--help] [--device-filter arg] <xrt-smi | xbmgmt> <utility arguments>"
     echo 
     echo "OPTIONS:"
     echo "  --help          - Help to use this script."
@@ -101,7 +101,7 @@ if [ "$help_arg" = "true" ]; then
     echo "                      '^xilinx_u250' - Shell names starting with xilnx_u250"
     echo 
     echo "Additionally, the 'utility arguments' are the arguments that will be sent to"
-    echo "the given XRT utility (e.g., xbutil or xbmgmt)"
+    echo "the given XRT utility (e.g., xrt-smi or xbmgmt)"
     echo
     exit
 fi

--- a/src/runtime_src/core/tools/nagios/nagios_plugin.sh
+++ b/src/runtime_src/core/tools/nagios/nagios_plugin.sh
@@ -6,7 +6,7 @@
 """:" # Hide bash from python
 # Generate the output JSON file. Ignore both error and standard output
 temp_json_file=$(mktemp -u --suffix=.nagios.json)
-/opt/xilinx/xrt/bin/xbutil examine $@ -o $temp_json_file &> /dev/null
+/opt/xilinx/xrt/bin/xrt-smi examine $@ -o $temp_json_file &> /dev/null
 # Depending on command status return OK or FAILURE
 EXIT_CODE=0
 case $? in

--- a/src/runtime_src/core/tools/xbutil2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdProgram.cpp
@@ -88,7 +88,7 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
       XBUtilities::throw_cancel(boost::format("Could not program device %s : %s") % bdf % e.what());
     }
 
-    std::cout << "INFO: xbutil program succeeded on " << bdf << std::endl;
+    std::cout << "INFO: xrt-smi program succeeded on " << bdf << std::endl;
     return;
   }
 

--- a/src/runtime_src/core/tools/xbutil2/xbutil.cpp
+++ b/src/runtime_src/core/tools/xbutil2/xbutil.cpp
@@ -106,11 +106,10 @@ int main( int argc, char** argv )
 
   // -- Program Description
   const std::string description = 
-  "The Xilinx (R) Board Utility (xbutil) is a standalone command line utility that"
-  " is included with the Xilinx Run Time (XRT) installation package. It includes"
-  " multiple commands to validate and identify the installed card(s) along with"
-  " additional card details including DDR, PCIe (R), shell name (DSA), and system"
-  " information.\n\nThis information can be used for both card administration and"
+  "The Xilinx (R) Run Time - System Management Interface (xrt-smi) is a standalone"
+  " command line utility that is included with the Xilinx Run Time (XRT) installation"
+  " package. It includes multiple commands to identify and validate the installed"
+  " card(s).\n\n This information can be used for both card administration and"
   " application debugging.";
 
   // -- Ready to execute the code

--- a/src/runtime_src/core/tools/xbutil2/xbutil.cpp
+++ b/src/runtime_src/core/tools/xbutil2/xbutil.cpp
@@ -109,7 +109,7 @@ int main( int argc, char** argv )
   "The Xilinx (R) Run Time - System Management Interface (xrt-smi) is a standalone"
   " command line utility that is included with the Xilinx Run Time (XRT) installation"
   " package. It includes multiple commands to identify and validate the installed"
-  " card(s).\n\n This information can be used for both card administration and"
+  " card(s).\n\nThis information can be used for both card administration and"
   " application debugging.";
 
   // -- Ready to execute the code

--- a/src/runtime_src/xdp/profile/writer/aie_status/aie_status_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/aie_status/aie_status_writer.cpp
@@ -140,7 +140,7 @@ namespace xdp {
   AIEStatusWriter::~AIEStatusWriter()
   {
     if (!mWroteValidData) {
-      std::string msg("No valid data found for AIE status. Please run xbutil.");
+      std::string msg("No valid data found for AIE status. Please run xrt-smi.");
       xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", msg);
     }
   }


### PR DESCRIPTION
#### Problem solved by the commit
There were some mentions of xbutil in xrt-smi still, including in the help menu program description. In addition, `xrt-smi` and `xrt-smi --help` were throwing errors after printing the help menu.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Discovered while testing
#### How problem was solved, alternative solutions (if any) and why they were rejected
The aforementioned commands now only print the help menu without the error. Mentions of xbutil in output and some comments/scripts were replaced with xrt-smi, including xball script and nagios_plugin.sh.
#### Risks (if any) associated the changes in the commit
N/A
#### What has been tested and how, request additional testing if necessary
Tested on STX\MCDM.
```
C:\Users\rchane\Desktop\xrt>xrt-smi

DESCRIPTION: The Xilinx (R) Run Time - System Management Interface (xrt-smi) is a standalone
             command line utility that is included with the Xilinx Run Time (XRT) installation
             package. It includes multiple commands to identify and validate the installed card(s).

              This information can be used for both card administration and application debugging.

USAGE: xrt-smi[--help] [--version] [--verbose] [--batch] [--force] [command [commandArgs]]

AVAILABLE COMMANDS:
  configure  - Device and host configuration
  examine    - Status of the system and device
  validate   - Validates the basic shell acceleration functionality

OPTIONS:
  --help             - Help to use this application
  --version          - Report the version of XRT and its drivers
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation

C:\Users\rchane\Desktop\xrt>xrt-smi --help

DESCRIPTION: The Xilinx (R) Run Time - System Management Interface (xrt-smi) is a standalone
             command line utility that is included with the Xilinx Run Time (XRT) installation
             package. It includes multiple commands to identify and validate the installed card(s).

              This information can be used for both card administration and application debugging.

USAGE: xrt-smi[--help] [--version] [--verbose] [--batch] [--force] [command [commandArgs]]

AVAILABLE COMMANDS:
  configure  - Device and host configuration
  examine    - Status of the system and device
  validate   - Validates the basic shell acceleration functionality

OPTIONS:
  --help             - Help to use this application
  --version          - Report the version of XRT and its drivers
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation

C:\Users\rchane\Desktop\xrt>xrt-smi blah
ERROR: Unknown command: 'blah'

DESCRIPTION: The Xilinx (R) Run Time - System Management Interface (xrt-smi) is a standalone
             command line utility that is included with the Xilinx Run Time (XRT) installation
             package. It includes multiple commands to identify and validate the installed card(s).

              This information can be used for both card administration and application debugging.

USAGE: xrt-smi[--help] [--version] [--verbose] [--batch] [--force] [command [commandArgs]]

AVAILABLE COMMANDS:
  configure  - Device and host configuration
  examine    - Status of the system and device
  validate   - Validates the basic shell acceleration functionality

OPTIONS:
  --help             - Help to use this application
  --version          - Report the version of XRT and its drivers
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
ERROR: operation canceled
```
#### Documentation impact (if any)
N/A