### PR TITLE
revise API to patch address directly

### DIFF
--- a/src/runtime_src/core/common/api/module_int.h
+++ b/src/runtime_src/core/common/api/module_int.h
@@ -27,8 +27,11 @@ patch(const xrt::module&, const std::string& argnm, size_t index, const xrt::bo&
 // This API may be useful for developing unit test case at SHIM level where
 // you do not have access to device related "xrt::" objects, but still want
 // to obtain a patched control code buffer for device to run.
+// Note that if size passed in is 0, real buffer size required will be returned
+// without any patching. This is useful if caller wishes to discover the exact size
+// of the control code buffer.
 void
-patch(const xrt::module&, uint8_t *, size_t *, const std::vector< std::pair<std::string, uint64_t> > *);
+patch(const xrt::module&, uint8_t*, size_t*, const std::vector<std::pair<std::string, uint64_t>>*);
 
 // Patch scalar into control code at given argument
 void

--- a/src/runtime_src/core/common/api/module_int.h
+++ b/src/runtime_src/core/common/api/module_int.h
@@ -25,8 +25,8 @@ patch(const xrt::module&, const std::string& argnm, size_t index, const xrt::bo&
 
 // Extract control code buffer and patch it with addresses from all arguments.
 // This API may be useful for developing unit test case at SHIM level where
-// you do not have access to any "xrt::" objects, but still want to obtain a
-// patched control code buffer for device to run.
+// you do not have access to device related "xrt::" objects, but still want
+// to obtain a patched control code buffer for device to run.
 void
 patch(const xrt::module&, uint8_t *, size_t *, const std::vector< std::pair<std::string, uint64_t> > *);
 

--- a/src/runtime_src/core/common/api/module_int.h
+++ b/src/runtime_src/core/common/api/module_int.h
@@ -23,11 +23,12 @@ fill_ert_dpu_data(const xrt::module& module, uint32_t *payload);
 void
 patch(const xrt::module&, const std::string& argnm, size_t index, const xrt::bo& bo);
 
-// Patch buffer address into control code at given argument
+// Extract control code buffer and patch it with addresses from all arguments.
 // This API may be useful for developing unit test case at SHIM level where
-// you do not have access to an xrt::bo object.
+// you do not have access to any "xrt::" objects, but still want to obtain a
+// patched control code buffer for device to run.
 void
-patch(const xrt::module&, const std::string& argnm, size_t index, uint64_t address);
+patch(const xrt::module&, uint8_t *, size_t *, const std::vector< std::pair<std::string, uint64_t> > *);
 
 // Patch scalar into control code at given argument
 void

--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -1268,11 +1268,11 @@ patch(const xrt::module& module, const std::string& argnm, size_t index, const x
 }
 
 void
-patch(const xrt::module& module, uint8_t *buf, size_t *sz, const std::vector< std::pair<std::string, uint64_t> > *args)
+patch(const xrt::module& module, uint8_t* ibuf, size_t* sz, const std::vector<std::pair<std::string, uint64_t>>* args)
 {
   auto hdl = module.get_handle();
   size_t orig_sz = *sz;
-  const struct buf *inst = nullptr;
+  const buf* inst = nullptr;
 
   if (hdl->get_os_abi() == Elf_Amd_Aie2p) {
     const auto& instr_buf = hdl->get_instr();
@@ -1290,12 +1290,13 @@ patch(const xrt::module& module, uint8_t *buf, size_t *sz, const std::vector< st
 
   if (orig_sz < *sz)
     throw std::runtime_error{"Control code buffer passed in is too small"}; // Need a bigger buffer.
-  std::memcpy(buf, inst->data(), *sz);
+  std::memcpy(ibuf, inst->data(), *sz);
 
-  for (size_t index = 0; index < args->size(); index++) {
-    auto& arg = (*args)[index];
-    if (!hdl->patch(buf, arg.first, index, arg.second, patcher::buf_type::ctrltext))
-      throw std::runtime_error{"Failed to patch " + arg.first};
+  size_t index = 0;
+  for (auto& [arg_name, arg_addr] : *args) {
+    if (!hdl->patch(ibuf, arg_name, index, arg_addr, patcher::buf_type::ctrltext))
+      throw std::runtime_error{"Failed to patch " + arg_name};
+    index++;
   }
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Revise API introduced in PR#8226 for patching address directly. The original API requires module_sram, which, in turn, requires xrt::hwctx, which is not available for SHIM level test cases. Revising the API to only require module_elf, which is more friendly to SHIM test cases.

#### What has been tested and how, request additional testing if necessary
Run through a SHIM test case which uses this API and make sure the control buffer is patched properly.
