### PR TITLE
Add PID argument to aie mem and reg read/write apis

### DIFF
--- a/src/runtime_src/core/common/api/xrt_device.cpp
+++ b/src/runtime_src/core/common/api/xrt_device.cpp
@@ -387,15 +387,12 @@ namespace xrt::aie {
 // of that partition. Get patition info using the context id passed and
 // convert relative column index to absolute using this info
 static uint16_t
-get_abs_col(const xrt_core::device* device, int32_t pid, uint16_t context_id, uint16_t col)
+get_abs_col(const xrt_core::device* device, pid_t pid, uint16_t context_id, uint16_t col)
 {
   auto data = xrt_core::device_query_default<xrt_core::query::aie_partition_info>(device, {});
   for (const auto& entry : data) {
-    // if PID info is present compare PID's else skip
-    if (entry.pid != -1 && (entry.pid != pid))
-      continue;
-
-    if (std::stoi(entry.metadata.id) != context_id)
+    // compare PID and context id
+    if (entry.pid != pid || std::stoi(entry.metadata.id) != context_id)
       continue;
 
     auto abs_col = col + entry.start_col;
@@ -431,7 +428,7 @@ open_context(xrt::aie::device::access_mode am)
 
 std::vector<char>
 device::
-read_aie_mem(int32_t pid, uint16_t context_id, uint16_t col, uint16_t row, uint32_t offset, uint32_t size) const
+read_aie_mem(pid_t pid, uint16_t context_id, uint16_t col, uint16_t row, uint32_t offset, uint32_t size) const
 {
   return xdp::native::profiling_wrapper("xrt::aie::device::read_aie_mem",
     [this, &col, row, offset, size, context_id, pid] {
@@ -449,7 +446,7 @@ read_aie_mem(int32_t pid, uint16_t context_id, uint16_t col, uint16_t row, uint3
 
 size_t
 device::
-write_aie_mem(int32_t pid, uint16_t context_id, uint16_t col, uint16_t row, uint32_t offset, const std::vector<char>& data)
+write_aie_mem(pid_t pid, uint16_t context_id, uint16_t col, uint16_t row, uint32_t offset, const std::vector<char>& data)
 {
   return xdp::native::profiling_wrapper("xrt::aie::device::write_aie_mem",
     [this, &col, row, offset, &data, context_id, pid] {
@@ -466,7 +463,7 @@ write_aie_mem(int32_t pid, uint16_t context_id, uint16_t col, uint16_t row, uint
 }
 uint32_t
 device::
-read_aie_reg(int32_t pid, uint16_t context_id, uint16_t col, uint16_t row, uint32_t reg_addr) const
+read_aie_reg(pid_t pid, uint16_t context_id, uint16_t col, uint16_t row, uint32_t reg_addr) const
 {
   return xdp::native::profiling_wrapper("xrt::device::read_aie_reg",
     [this, &col, row, reg_addr, context_id, pid] {
@@ -484,7 +481,7 @@ read_aie_reg(int32_t pid, uint16_t context_id, uint16_t col, uint16_t row, uint3
 
 bool
 device::
-write_aie_reg(int32_t pid, uint16_t context_id, uint16_t col, uint16_t row, uint32_t reg_addr, uint32_t reg_val)
+write_aie_reg(pid_t pid, uint16_t context_id, uint16_t col, uint16_t row, uint32_t reg_addr, uint32_t reg_val)
 {
   return xdp::native::profiling_wrapper("xrt::device::write_aie_reg",
     [this, &col, row, reg_addr, &reg_val, context_id, pid] {

--- a/src/runtime_src/core/include/xrt/xrt_aie.h
+++ b/src/runtime_src/core/include/xrt/xrt_aie.h
@@ -111,7 +111,7 @@ public:
    */
   XCL_DRIVER_DLLESPEC
   std::vector<char>
-  read_aie_mem(int32_t pid, uint16_t context_id, uint16_t col, uint16_t row, uint32_t offset, uint32_t size) const;
+  read_aie_mem(pid_t pid, uint16_t context_id, uint16_t col, uint16_t row, uint32_t offset, uint32_t size) const;
 
   /**
    * write_aie_mem() - Write data to AIE tile's memory
@@ -136,7 +136,7 @@ public:
    */
   XCL_DRIVER_DLLESPEC
   size_t
-  write_aie_mem(int32_t pid, uint16_t context_id, uint16_t col, uint16_t row, uint32_t offset, const std::vector<char>& data);
+  write_aie_mem(pid_t pid, uint16_t context_id, uint16_t col, uint16_t row, uint32_t offset, const std::vector<char>& data);
 
   /**
    * read_aie_reg() - Read AIE Tile's register
@@ -159,7 +159,7 @@ public:
    */
   XCL_DRIVER_DLLESPEC
   uint32_t
-  read_aie_reg(int32_t pid, uint16_t context_id, uint16_t col, uint16_t row, uint32_t reg_addr) const;
+  read_aie_reg(pid_t pid, uint16_t context_id, uint16_t col, uint16_t row, uint32_t reg_addr) const;
 
   /**
    * write_aie_reg() - Write AIE Tile's register
@@ -184,7 +184,7 @@ public:
    */
   XCL_DRIVER_DLLESPEC
   bool
-  write_aie_reg(int32_t pid, uint16_t context_id, uint16_t col, uint16_t row, uint32_t reg_addr, uint32_t reg_val);
+  write_aie_reg(pid_t pid, uint16_t context_id, uint16_t col, uint16_t row, uint32_t reg_addr, uint32_t reg_val);
 
 private:
   XCL_DRIVER_DLLESPEC

--- a/src/runtime_src/core/include/xrt/xrt_aie.h
+++ b/src/runtime_src/core/include/xrt/xrt_aie.h
@@ -91,6 +91,8 @@ public:
   /**
    * read_aie_mem() - Read AIE tile's memory
    *
+   * @param pid
+   *   process id of process that opened hw_context
    * @param context_id
    *  context id corresponding to AIE tile
    * @param col
@@ -109,11 +111,13 @@ public:
    */
   XCL_DRIVER_DLLESPEC
   std::vector<char>
-  read_aie_mem(uint16_t context_id, uint16_t col, uint16_t row, uint32_t offset, uint32_t size) const;
+  read_aie_mem(int32_t pid, uint16_t context_id, uint16_t col, uint16_t row, uint32_t offset, uint32_t size) const;
 
   /**
    * write_aie_mem() - Write data to AIE tile's memory
    *
+   * @param pid
+   *   process id of process that opened hw_context
    * @param context_id
    *  context id corresponding to AIE tile
    * @param col
@@ -132,11 +136,13 @@ public:
    */
   XCL_DRIVER_DLLESPEC
   size_t
-  write_aie_mem(uint16_t context_id, uint16_t col, uint16_t row, uint32_t offset, const std::vector<char>& data);
+  write_aie_mem(int32_t pid, uint16_t context_id, uint16_t col, uint16_t row, uint32_t offset, const std::vector<char>& data);
 
   /**
    * read_aie_reg() - Read AIE Tile's register
    *
+   * @param pid
+   *   process id of process that opened hw_context
    * @param context_id
    *  context id corresponding to AIE tile
    * @param col
@@ -153,11 +159,13 @@ public:
    */
   XCL_DRIVER_DLLESPEC
   uint32_t
-  read_aie_reg(uint16_t context_id, uint16_t col, uint16_t row, uint32_t reg_addr) const;
+  read_aie_reg(int32_t pid, uint16_t context_id, uint16_t col, uint16_t row, uint32_t reg_addr) const;
 
   /**
    * write_aie_reg() - Write AIE Tile's register
    *
+   * @param pid
+   *   process id of process that opened hw_context
    * @param context_id
    *  context id corresponding to AIE tile
    * @param col
@@ -176,7 +184,7 @@ public:
    */
   XCL_DRIVER_DLLESPEC
   bool
-  write_aie_reg(uint16_t context_id, uint16_t col, uint16_t row, uint32_t reg_addr, uint32_t reg_val);
+  write_aie_reg(int32_t pid, uint16_t context_id, uint16_t col, uint16_t row, uint32_t reg_addr, uint32_t reg_val);
 
 private:
   XCL_DRIVER_DLLESPEC


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Added PID argument to aie debug apis to uniquely identify hw ctx.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Context ID alone doesn't uniquely identify a hw context as per driver implementation, so added extra PID arg to debug APIs.

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
Tested the flow on both Linux and windows and the apis work as expected.

#### Documentation impact (if any)
Added doxygen comment for the arg added