### PR TITLE
fix coverity issue - CID 395489:  Null pointer dereferences

### DIFF
--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -1277,12 +1277,14 @@ patch(const xrt::module& module, uint8_t* ibuf, size_t* sz, const std::vector<st
   if (hdl->get_os_abi() == Elf_Amd_Aie2p) {
     const auto& instr_buf = hdl->get_instr();
     inst = &instr_buf;
-  } else if(hdl->get_os_abi() == Elf_Amd_Aie2ps) {
+  }
+  else if(hdl->get_os_abi() == Elf_Amd_Aie2ps) {
     const auto& instr_buf = hdl->get_data();
     if (instr_buf.size() != 1)
       throw std::runtime_error{"Patch failed: only support patching single column"};
     inst = &instr_buf[0];
-  } else {
+  }
+  else {
     throw std::runtime_error{"Patch failed: unsupported ELF ABI"};
   }
 

--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -1280,8 +1280,10 @@ patch(const xrt::module& module, uint8_t* ibuf, size_t* sz, const std::vector<st
   } else if(hdl->get_os_abi() == Elf_Amd_Aie2ps) {
     const auto& instr_buf = hdl->get_data();
     if (instr_buf.size() != 1)
-      throw std::runtime_error{"Only support patching single column"};
+      throw std::runtime_error{"Patch failed: only support patching single column"};
     inst = &instr_buf[0];
+  } else {
+    throw std::runtime_error{"Patch failed: unsupported ELF ABI"};
   }
 
   *sz = inst->size();


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Fixing coverity issue: CID 395489:  Null pointer dereferences (FORWARD_NULL)
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Introduced by PR#8272
#### How problem was solved, alternative solutions (if any) and why they were rejected
Throw in case inst is nullptr, instead of dereferencing it.
