### PR TITLE
Add change to support runlist test on simnowlite flow

### DIFF
--- a/src/runtime_src/core/common/api/hw_queue.cpp
+++ b/src/runtime_src/core/common/api/hw_queue.cpp
@@ -675,15 +675,18 @@ public:
   }
 
   void
-  submit(xrt_core::buffer_handle*) override
+  submit(xrt_core::buffer_handle* cmd) override
   {
-    throw std::runtime_error("kds_device::submit(buffer_handle) not implemented");
+    m_device->exec_buf(cmd);
   }
 
   std::cv_status
-  wait(xrt_core::buffer_handle*, size_t) const override
+  wait(xrt_core::buffer_handle* cmd, size_t timeout_ms) const override
   {
-    throw std::runtime_error("kds_device::wait(buffer_handle) not implemented");
+    if (const_cast<kds_device *>(this)->exec_wait(timeout_ms) == std::cv_status::timeout)
+      return std::cv_status::timeout;
+
+    return std::cv_status::no_timeout;
   }
 
   // Poll for command completion


### PR DESCRIPTION
**Problem solved by the commit**
This is for simnowlite flow test to test the firmware command chain support for xrt runlist. 

**Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered**
Planned feature.

**How problem was solved, alternative solutions (if any) and why they were rejected**
New feature.

The simnowlite flow is using a legacy hw_emu flow that does not use hwqueue_handle interface so support for runlist must be wired into through the legacy `kds_device` used by Alveo flows.  This is done by implementing newly added virtual interfaces in xrt_core::hw_queue that were previously throwing unsupported exception.

Likely this implementation should be revisited and xrt::runlist should be supported in Alveo flows, albeit reverting to one-by-one submission at the discretion of the shim layer.

**Risks (if any) associated the changes in the commit**
Low (Not currently use at this point)

**What has been tested and how, request additional testing if necessary**
Verified on simnowlite flow.

**Documentation impact (if any)**