### PR TITLE
Add default ctor for xrt::runlist

### DIFF
--- a/src/runtime_src/core/include/experimental/xrt_kernel.h
+++ b/src/runtime_src/core/include/experimental/xrt_kernel.h
@@ -74,6 +74,13 @@ public:
 
 public:
   /**
+   * runlist() - Construct empty runlist object
+   *
+   * Can be used as lvalue in assignment.
+   */
+  runlist() = default;
+
+  /**
    * runlist - Constructor
    *
    * A runlist is associated with a specific hwctx. All run objects


### PR DESCRIPTION
Allow out of scope default runlist and assignment.
