### PR TITLE
Up CMake minimum required version

### DIFF
--- a/src/CMake/cpackWin.cmake
+++ b/src/CMake/cpackWin.cmake
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2019-2021 Xilinx, Inc. All rights reserved.
 #
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5.0)
 
 include(CPackComponent)
 


### PR DESCRIPTION
#### Problem solved by the commit
Avoid CMake deprecation warning.

CMake Deprecation Warning at src/xrt/src/CMake/cpackWin.cmake:4 (cmake_minimum_required):

  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
