### PR TITLE
Sw Emulation fix for Graph test case

### DIFF
--- a/src/runtime_src/core/pcie/emulation/sw_emu/generic_pcie_hal2/device_swemu.cxx
+++ b/src/runtime_src/core/pcie/emulation/sw_emu/generic_pcie_hal2/device_swemu.cxx
@@ -116,4 +116,12 @@ get_device_info(xclDeviceInfo2 *info)
     throw system_error(ret, "failed to get device info");
 }
 
+std::unique_ptr<xrt_core::graph_handle>
+device::
+open_graph_handle(const xrt::uuid& xclbin_id, const char* name, xrt::graph::access_mode am)
+{
+   return std::make_unique<xclswemuhal2::SwEmuShim::graph_object>(
+                  static_cast<xclswemuhal2::SwEmuShim*>(get_device_handle()), xclbin_id, name, am);
+}
+
 }} // swemu,xrt_core

--- a/src/runtime_src/core/pcie/emulation/sw_emu/generic_pcie_hal2/device_swemu.h
+++ b/src/runtime_src/core/pcie/emulation/sw_emu/generic_pcie_hal2/device_swemu.h
@@ -9,6 +9,7 @@
 #include "core/common/shim/buffer_handle.h"
 #include "core/common/shim/hwctx_handle.h"
 #include "core/common/shim/shared_handle.h"
+#include "core/common/shim/graph_handle.h"
 
 #include "core/pcie/common/device_pcie.h"
 
@@ -46,6 +47,9 @@ public:
 
   void
   get_device_info(xclDeviceInfo2 *info) override;
+
+  std::unique_ptr<xrt_core::graph_handle>
+  open_graph_handle(const xrt::uuid& xclbin_id, const char* name, xrt::graph::access_mode am) override;
 
 private:
   // Private look up function for concrete query::request


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

Sw Emulation test case is getting failed in XRT

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

https://github.com/Xilinx/XRT/pull/8242

#### How problem was solved, alternative solutions (if any) and why they were rejected

Added "open_graph_handle" in SwEmu flow also

#### Risks (if any) associated the changes in the commit

N/A

#### What has been tested and how, request additional testing if necessary

SwEmu test case with multiple kernels and graph has been tested .
Input memory virtual addr 0x0x7f0824000000x
Input memory virtual addr 0x0x7f0424000000x
run mm2s_1
run mm2s_2
Kernel Name: mm2s_1, CU Number: 0, State: Start
Kernel Name: mm2s_1, CU Number: 0, State: Running
Kernel Name: mm2s_1, CU Number: 0, State: Idle
Kernel Name: mm2s_2, CU Number: 1, State: Start
Kernel Name: mm2s_2, CU Number: 1, State: Running
Kernel Name: mm2s_2, CU Number: 1, State: Idle
run s2mm_1
Kernel Name: s2mm_1, CU Number: 2, State: Start
Kernel Name: s2mm_1, CU Number: 2, State: Running
run s2mm_2
Started thread 6 0x7f8cc6ffd640 for mygraph.k1 (ker_i4)
mm2s_1  completed 
mm2s_2  completed 
Kernel Name: s2mm_2, CU Number: 3, State: Start
Kernel Name: s2mm_2, CU Number: 3, State: Running
Kernel Name: s2mm_2, CU Number: 3, State: Idle
Kernel Name: s2mm_1, CU Number: 2, State: Idle
s2mm_1  completed 
s2mm_2  completed 
TEST PASSED

 
#### Documentation impact (if any)
N/A