### PR TITLE
fixing symbol collision issue

### DIFF
--- a/src/runtime_src/core/pcie/tools/cloud-daemon/aws/aws_dev.cpp
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/aws/aws_dev.cpp
@@ -47,15 +47,15 @@ static std::thread rescan_thread[16];
  * Functions each plugin needs to provide
  */
 extern "C" {
-int init(mpd_plugin_callbacks *cbs);
-void fini(void *mpc_cookie);
+int xrt_init(mpd_plugin_callbacks *cbs);
+void xrt_fini(void *mpc_cookie);
 }
 
 /*
  * Init function of the plugin that is used to hook the required functions.
  * The cookie is used by fini (see below). Can be NULL if not required.
  */ 
-int init(mpd_plugin_callbacks *cbs)
+int xrt_init(mpd_plugin_callbacks *cbs)
 {
     int ret = 1;
     auto total = pcidev::get_dev_total();
@@ -94,7 +94,7 @@ int init(mpd_plugin_callbacks *cbs)
 /*
  * Fini function of the plugin
  */ 
-void fini(void *mpc_cookie)
+void xrt_fini(void *mpc_cookie)
 {
      syslog(LOG_INFO, "aws mpd plugin fini called\n");
 }

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/azure/azure.cpp
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/azure/azure.cpp
@@ -47,8 +47,8 @@
  * Functions each plugin needs to provide
  */
 extern "C" {
-int init(mpd_plugin_callbacks *cbs);
-void fini(void *mpc_cookie);
+int xrt_init(mpd_plugin_callbacks *cbs);
+void xrt_fini(void *mpc_cookie);
 }
 
 /*
@@ -67,7 +67,7 @@ static std::vector<std::string> fpga_serial_number;
  * Init function of the plugin that is used to hook the required functions.
  * The cookie is used by fini (see below). Can be NULL if not required.
  */
-int init(mpd_plugin_callbacks *cbs)
+int xrt_init(mpd_plugin_callbacks *cbs)
 {
     int ret = 1;
     auto total = pcidev::get_dev_total();
@@ -100,7 +100,7 @@ int init(mpd_plugin_callbacks *cbs)
 /*
  * Fini function of the plugin
  */
-void fini(void *mpc_cookie)
+void xrt_fini(void *mpc_cookie)
 {
      syslog(LOG_INFO, "azure mpd plugin fini called\n");
 }

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/container/container.cpp
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/container/container.cpp
@@ -45,15 +45,15 @@
  * Functions each plugin needs to provide
  */
 extern "C" {
-int init(mpd_plugin_callbacks *cbs);
-void fini(void *mpc_cookie);
+int xrt_init(mpd_plugin_callbacks *cbs);
+void xrt_fini(void *mpc_cookie);
 }
 
 /*
  * Init function of the plugin that is used to hook the required functions.
  * The cookie is used by fini (see below). Can be NULL if not required.
  */ 
-int init(mpd_plugin_callbacks *cbs)
+int xrt_init(mpd_plugin_callbacks *cbs)
 {
     int ret = 1;
     auto total = pcidev::get_dev_total();
@@ -76,7 +76,7 @@ int init(mpd_plugin_callbacks *cbs)
 /*
  * Fini function of the plugin
  */
-void fini(void *mpc_cookie)
+void xrt_fini(void *mpc_cookie)
 {
      syslog(LOG_INFO, "container mpd plugin fini called\n");
 }

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/mpd.cpp
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/mpd.cpp
@@ -278,7 +278,7 @@ void Mpd::start()
         plugin_init = (init_fn) dlsym(plugin_handle, INIT_FN_NAME);
         plugin_fini = (fini_fn) dlsym(plugin_handle, FINI_FN_NAME);
         if (plugin_init == nullptr || plugin_fini == nullptr) {
-            syslog(LOG_ERR, "failed to find init/fini symbols in mpd plugin");
+            syslog(LOG_ERR, "failed to find xrt_init/xrt_fini symbols in mpd plugin");
             return;
         }
         int ret = (*plugin_init)(&plugin_cbs);

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/mpd_plugin.h
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/mpd_plugin.h
@@ -94,8 +94,8 @@ struct mpd_plugin_callbacks {
     } mb_req;
 };
 
-#define INIT_FN_NAME    "init"
-#define FINI_FN_NAME    "fini"
+#define INIT_FN_NAME    "xrt_init"
+#define FINI_FN_NAME    "xrt_fini"
 /*
  * These 2 functions are mandatory for all mpd plugins.
  * init_fn is used to hook all functions the plugin implements.

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/msd_plugin.h
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/msd_plugin.h
@@ -29,8 +29,8 @@ struct msd_plugin_callbacks {
     retrieve_xclbin_fn retrieve_xclbin; 
 };
 
-#define INIT_FN_NAME    "init"
-#define FINI_FN_NAME    "fini"
+#define INIT_FN_NAME    "xrt_init"
+#define FINI_FN_NAME    "xrt_fini"
 typedef int (*init_fn)(struct msd_plugin_callbacks *cbs);
 typedef void (*fini_fn)(void *mpc_cookie);
 

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/msd_plugin_example.c
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/msd_plugin_example.c
@@ -45,8 +45,8 @@
 /*
  * Functions each plguin must provide
  */
-int init(struct msd_plugin_callbacks *cbs);
-void fini(void *mpc_cookie);
+int xrt_init(struct msd_plugin_callbacks *cbs);
+void xrt_fini(void *mpc_cookie);
 void retrieve_xclbin_cb(void *arg, char *xclbin, size_t len);
 int retrieve_xclbin(char *orig_xclbin, size_t orig_xclbin_len,
     char **xclbin, size_t *xclbin_len, retrieve_xclbin_fini_fn *cb, void **arg);
@@ -98,7 +98,7 @@ struct xclbin_repo repo[2] = {
  * So far there is only one hook function required to get real xclbin from the fake one.
  * The cookie is used by fini (see below). Can be NULL if not required.
  */ 
-int init(struct msd_plugin_callbacks *cbs)
+int xrt_init(struct msd_plugin_callbacks *cbs)
 {
     int ret = 1;
     if (cbs) {
@@ -114,7 +114,7 @@ int init(struct msd_plugin_callbacks *cbs)
 /*
  * Fini function of the plugin
  */ 
-void fini(void *mpc_cookie)
+void xrt_fini(void *mpc_cookie)
 {
      syslog(LOG_INFO, "plugin fini called\n");
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Customer is facing an issue of infinite loop while running mpd. Debugged with customer and figured out that there is some symbol collision happening.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Renaming the init/fini functions with xrt_init/xrt_fini

#### How problem was solved, alternative solutions (if any) and why they were rejected
Renaming function names sothat chances of symbol collision is less

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Verified simple mpd/msd case

#### Documentation impact (if any)
None