### PR TITLE
Fix hang in AIE Profile Plugin due to Win issue in static objects retrieving host info using WMI

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_plugin.cpp
@@ -52,7 +52,6 @@ namespace xdp {
 
   AieProfilePlugin::AieProfilePlugin() : XDPPlugin()
   {
-    xrt_core::message::send(severity_level::info, "XRT", "Instantiating AIE Profiling Plugin.");
     AieProfilePlugin::live = true;
 
     db->registerPlugin(this);

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/client/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/client/aie_trace.cpp
@@ -25,6 +25,7 @@
 #include "xdp/profile/database/database.h"
 #include "xdp/profile/database/events/creator/aie_trace_data_logger.h"
 #include "xdp/profile/database/static_info/aie_constructs.h"
+#include "xdp/profile/database/static_info/aie_util.h"
 #include "xdp/profile/database/static_info/pl_constructs.h"
 #include "xdp/profile/device/pl_device_intf.h"
 #include "xdp/profile/device/tracedefs.h"
@@ -924,7 +925,7 @@ namespace xdp {
       auto loc        = XAie_TileLoc(col, row);
 
       std::stringstream cmsg;
-      cmsg << "Configuring tile (" << +col << "," << +row << ") in module type: " << getModuleName(type) << ".";
+      cmsg << "Configuring tile (" << +col << "," << +row << ") in module type: " << aie::getModuleName(type) << ".";
       xrt_core::message::send(severity_level::info, "XRT", cmsg.str());
 
       // xaiefal::XAieMod core;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Recently there is a change in xrt core to retrieve host OS info using WMI instead of reg keys. This is used when xrt core message system is constructed for the first message output. 
However, due to a known limitation in use of WMI in static objects, the AIE Profile Plugin hits a hang. The singleton static instance of AIE Profile Plugin outputs an info msg in its constructor. When this is the first output message in an execution, it hits a hang while retrieving host OS info using WMI.
This PR removes the info msg from the AIE Profile Plugin constructor to bypass the hang issue on Win Client.
This PR also adds fix for build failure in xdp/aie_trace for Client introduced by PR 8244.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
The hang issue in AIE Profile Plugin on Win Client is a side effect of PR 8240.
The build failure is introduced with PR 8244
 
#### How problem was solved, alternative solutions (if any) and why they were rejected
The current PR is a workaround.

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Unit test on Client.

#### Documentation impact (if any)
