### PR TITLE
CR-1206429 xrt-smi output and help menu fixes

### DIFF
--- a/src/runtime_src/core/tools/common/XBMain.cpp
+++ b/src/runtime_src/core/tools/common/XBMain.cpp
@@ -151,6 +151,7 @@ void  main_(int argc, char** argv,
     XBU::report_commands_help( _executable, _description, globalOptions, hiddenOptions, parsedSubCmds);
     if (!bHelp && !sCmd.empty())
       throw xrt_core::error(std::errc::operation_canceled);
+    return;
   }
 
   // -- Prepare the data

--- a/src/runtime_src/core/tools/common/reports/ReportHost.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportHost.cpp
@@ -127,8 +127,8 @@ ReportHost::writeReport(const xrt_core::device* /*_pDevice*/,
           % lib.get<std::string>("version", "N/A");
     }
     _output << boost::format("  %-20s : %s\n") % "Model" % _pt.get<std::string>("host.os.model");
-    _output << boost::format("  %-20s : %s\n") % "BIOS vendor" % _pt.get<std::string>("host.os.bios_vendor");
-    _output << boost::format("  %-20s : %s\n") % "BIOS version" % _pt.get<std::string>("host.os.bios_version");
+    _output << boost::format("  %-20s : %s\n") % "BIOS Vendor" % _pt.get<std::string>("host.os.bios_vendor");
+    _output << boost::format("  %-20s : %s\n") % "BIOS Version" % _pt.get<std::string>("host.os.bios_version");
     _output << std::endl;
     _output << "XRT\n";
     _output << boost::format("  %-20s : %s\n") % "Version" % _pt.get<std::string>("host.xrt.version", "N/A");
@@ -169,7 +169,7 @@ ReportHost::writeReport(const xrt_core::device* /*_pDevice*/,
     //no device available
   }
 
-  _output << std::endl << "Devices present\n";
+  _output << std::endl << "Device(s) Present\n";
   if (available_devices.empty())
     _output << "  0 devices found" << std::endl;
 

--- a/src/runtime_src/core/tools/common/reports/platform/ReportRyzenPlatform.cpp
+++ b/src/runtime_src/core/tools/common/reports/platform/ReportRyzenPlatform.cpp
@@ -50,7 +50,7 @@ ReportRyzenPlatform::writeReport(const xrt_core::device* /*_pDevice*/,
     _output << boost::format("  %-23s: %s \n") % "Name" % pt_static_region.get<std::string>("name");
 
     const boost::property_tree::ptree& pt_status = pt_platform.get_child("status");
-    _output << boost::format("  %-23s: %s \n") % "Performance Mode" % pt_status.get<std::string>("performance_mode");
+    _output << boost::format("  %-23s: %s \n") % "Power Mode" % pt_status.get<std::string>("performance_mode");
 
     const boost::property_tree::ptree& clocks = pt_platform.get_child("clocks", empty_ptree);
     if (!clocks.empty()) {
@@ -63,7 +63,7 @@ ReportRyzenPlatform::writeReport(const xrt_core::device* /*_pDevice*/,
     }
 
     auto watts = pt_platform.get<std::string>("electrical.power_consumption_watts", "N/A");
-    _output << std::endl << boost::format("%-23s: %s Watts\n") % "Power" % watts;
+    _output << std::endl << boost::format("%-23s  : %s Watts\n") % "Power" % watts;
   }
 
   _output << std::endl;

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -286,7 +286,7 @@ get_platform_info(const std::shared_ptr<xrt_core::device>& device,
     oStream << boost::format("    %-22s: %s\n") % "Platform ID" % plat_id;
   const std::string& perf_mode = ptTree.get("performance_mode", "");
   if (!perf_mode.empty())
-    oStream << boost::format("    %-22s: %s\n") % "Performance Mode" % perf_mode;
+    oStream << boost::format("    %-22s: %s\n") % "Power Mode" % perf_mode;
   const std::string& power = ptTree.get("power", "");
   if (!boost::starts_with(power, ""))
     oStream << boost::format("    %-22s: %s Watts\n") % "Power" % power;
@@ -449,7 +449,7 @@ SubCmdValidate::SubCmdValidate(bool _isHidden, bool _isDepricated, bool _isPreli
 
   m_commonOptions.add(common_options);
   m_commonOptions.add_options()
-    ("run,r", boost::program_options::value<decltype(m_tests_to_run)>(&m_tests_to_run)->multitoken(), (std::string("Run a subset of the test suite.  Valid options are:\n") + formatRunValues).c_str() )
+    ("run,r", boost::program_options::value<decltype(m_tests_to_run)>(&m_tests_to_run)->multitoken(), (std::string("Run a subset of the test suite. Valid options are:\n") + formatRunValues).c_str() )
   ;
 }
 
@@ -512,7 +512,7 @@ SubCmdValidate::print_help_internal() const
   static const std::string testOptionValues = XBU::create_suboption_list_map(deviceClass, jsonOptions, help_tests);
   std::vector<std::string> tempVec;
   common_options.add_options()
-    ("report,r", boost::program_options::value<decltype(tempVec)>(&tempVec)->multitoken(), (std::string("The type of report to be produced. Reports currently available are:\n") + testOptionValues).c_str() )
+    ("run,r", boost::program_options::value<decltype(tempVec)>(&tempVec)->multitoken(), (std::string("Run a subset of the test suite. Valid options are:\n") + testOptionValues).c_str() )
   ;
   printHelp(common_options, m_hiddenOptions, deviceClass, false, extendedKeysOptions());
 }


### PR DESCRIPTION
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1206429
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
1) xrt-smi validate help menu showed --report instead of --run, now shows --run
2) xrt-smi did not return from printing help menu (e.g. run `xrt-smi`), instead returning later when attempting to run non-existent subcmd
3) Some small output fixes: 
Host Report: `BIOS vendor` -> `BIOS Vendor`, `BIOS version` -> `BIOS Version`, `Devices present` -> `Device(s) Present`
Platform Report: `Performance Mode` -> `Power Mode`, fix colon spacing for Power field
Validate: `Performance Mode` -> `Power Mode`
#### How problem was solved, alternative solutions (if any) and why they were rejected
Fixed to above.
#### Risks (if any) associated the changes in the commit
N/A
#### What has been tested and how, request additional testing if necessary
```
C:\Users\rchane\Desktop\xrt>xrt-smi validate --help

COMMAND: validate

DESCRIPTION: Validates the given device by executing the platform's validate executable.

USAGE: xrt-smi validate [--help] [-d arg] [-f arg] [-o arg] [-p arg] [-r arg] [--param arg]

OPTIONS:
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest
  -f, --format       - Report output format. Valid values are:
                         JSON        - Latest JSON schema
                         JSON-2020.2 - JSON 2020.2 schema
  -o, --output       - Direct the output to the given file
  --param            - Extended parameter for a given test. Format: <test-name>:<key>:<value>
  -p, --path         - Path to the directory containing validate xclbins
  --help             - Help to use this sub-command
  -r, --run          - Run a subset of the test suite. Valid options are:
                         all                  - All applicable validate tests will be executed
                                                (default)
                         cmd-chain-latency    - Run end-to-end latency test using command chaining
                         cmd-chain-throughput - Run end-to-end throughput test using command
                                                chaining
                         df-bw                - Run bandwidth test on data fabric
                         gemm                 - Measure the TOPS value of GEMM operations
                         latency              - Run end-to-end latency test
                         quick                - Only the first 4 tests will be executed
                         tct-all-col          - Measure average TCT processing time for all
                                                columns
                         tct-one-col          - Measure average TCT processing time for one column
                         throughput           - Run end-to-end throughput test

EXTENDED KEYS:
  dma                - block-size:<value> - Memory transfer size (bytes)


GLOBAL OPTIONS:
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation

C:\Users\rchane\Desktop\xrt>xrt-smi examine
System Configuration
  OS Name              : Windows NT
  Release              : 26046
  Machine              : x86_64
  CPU Cores            : 16
  Memory               : 32109 MB
  Distribution         : Microsoft Windows 11 Enterprise Insider Preview
  Model                : BIRMANPLUS
  BIOS Vendor          : AMD
  BIOS Version         : VXB899825N

XRT
  Version              : 2.18.0
  Branch               : HEAD
  Hash                 : 9048adae9b544fe0b538e37f2abed605baf16961
  Hash Date            : 2024-07-17 16:56:46
  ipukmddrv            : 10.1.0.1
  NPU Firmware Version : 0.7.22.116

Device(s) Present
|BDF             ||Name  |
|----------------||------|
|[00c5:00:01.1]  ||NPU   |

C:\Users\rchane\Desktop\xrt>xrt-smi examine -r platform

---------------------
[00c5:00:01.1] : NPU
---------------------
Platform
  Name                   : NPU
  Power Mode             : Default

Clocks
  H Clock                : 1810 MHz
  MP-IPU Clock           : 1267 MHz

Power                    : 0.000 Watts

C:\Users\rchane\Desktop\xrt>xrt-smi validate
Validate Device           : [00c5:00:01.1]
    Platform              : NPU
    Power Mode            : Default
-------------------------------------------------------------------------------
Test 1 [00c5:00:01.1]     : latency
    Details               : Average latency: '129.7' us
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Test 2 [00c5:00:01.1]     : throughput
    Details               : Average throughput: '8992.5' ops
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Test 3 [00c5:00:01.1]     : cmd-chain-latency
    Details               : Average latency: '9.1' us
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Test 4 [00c5:00:01.1]     : cmd-chain-throughput
    Details               : Average throughput: '109179.1' ops
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Test 5 [00c5:00:01.1]     : df-bw
    Details               : Average bandwidth per shim DMA: '52.8' GB/s
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Test 6 [00c5:00:01.1]     : tct-one-col
    Details               : Average TCT throughput: '405538.0' TCT/s
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Test 7 [00c5:00:01.1]     : tct-all-col
    Details               : Average TCT throughput: '815730.6' TCT/s
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Test 8 [00c5:00:01.1]     : gemm
    Details               : Kernel name is 'DPU_1x4'
                            TOPS: '49.7'
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Validation completed. Please run the command '--verbose' option for more details

```
#### Documentation impact (if any)
N/A