### PR TITLE
VITIS-12947 - Decode the mask value which is used for patching a scale value

### DIFF
--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -155,8 +155,8 @@ struct patcher
   {}
 
 // Replace certain bits of *data_to_patch with register_value. Which bits to be replaced is specified by mask
-// For example,   *data_to_patch is 0xbb11aaaa, register_value = 0x55, mask is 0x00ff0000
-// After patching *data_to_patch is 0xbb55aaaa
+// For     *data_to_patch be 0xbb11aaaa and mask be 0x00ff0000
+// To make *data_to_patch be 0xbb55aaaa, register_value must be 0x00550000
   void
   patch32(uint32_t* data_to_patch, uint64_t register_value, uint32_t mask)
   {
@@ -165,16 +165,7 @@ struct patcher
 
     auto new_value = *data_to_patch;
     mask = mask == 0 ? 0xFFFFFFFF : mask;
-    uint32_t clear_mask = ~mask;
-    int shift_count = 0;
-
-    while ((mask & 1) == 0) {
-      mask >>= 1;
-      shift_count++;
-    }
-
-    new_value &= clear_mask;
-    new_value |= static_cast<uint32_t>(register_value << shift_count);
+    new_value = (new_value & ~mask) | (register_value & mask);
     *data_to_patch = new_value;
   }
 

--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -684,9 +684,11 @@ class module_elf : public module_impl
         std::string argnm{ symname, symname + std::min(strlen(symname), dynstr->get_size()) };
 
         auto patch_scheme = static_cast<patcher::symbol_type>(rela->r_addend & schema_mask);
-        auto mask = static_cast<uint32_t>(sym->st_value);
+
         patcher::patch_info pi = patch_scheme == patcher::symbol_type::scalar_32bit_kind ?
-                                 patcher::patch_info{ offset, add_end_higher_28bit, mask } :
+                                 // st_size is is encoded using register value mask for scaler_32
+                                 // for other pacthing scheme it is encoded using size of dma
+                                 patcher::patch_info{ offset, add_end_higher_28bit, static_cast<uint32_t>(sym->st_size) } :
                                  patcher::patch_info{ offset, add_end_higher_28bit, 0 };
 
         std::string key_string = generate_key_string(argnm, buf_type);

--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -28,7 +28,6 @@
 #include <map>
 #include <set>
 #include <string>
-#include <sstream>
 
 #ifndef AIE_COLUMN_PAGE_SIZE
 # define AIE_COLUMN_PAGE_SIZE 8192  // NOLINT

--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -164,7 +164,6 @@ struct patcher
       throw std::runtime_error("address is not 4 byte aligned for patch32");
 
     auto new_value = *data_to_patch;
-    mask = mask == 0 ? 0xFFFFFFFF : mask;
     new_value = (new_value & ~mask) | (register_value & mask);
     *data_to_patch = new_value;
   }
@@ -220,7 +219,8 @@ struct patcher
       switch (m_symbol_type) {
       case symbol_type::scalar_32bit_kind:
         // new_value is a register value
-        patch32(bd_data_ptr, new_value, item.mask);
+        if (!item.mask)
+          patch32(bd_data_ptr, new_value, item.mask);
         break;
       case symbol_type::shim_dma_base_addr_symbol_kind:
         // new_value is a bo address

--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -218,7 +218,7 @@ struct patcher
       switch (m_symbol_type) {
       case symbol_type::scalar_32bit_kind:
         // new_value is a register value
-        if (!item.mask)
+        if (item.mask)
           patch32(bd_data_ptr, new_value, item.mask);
         break;
       case symbol_type::shim_dma_base_addr_symbol_kind:

--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -160,7 +160,7 @@ struct patcher
   patch32(uint32_t* bd_data_ptr, uint64_t register_value, uint32_t mask)
   {
     auto new_value = bd_data_ptr[0];
-    mask == 0 ? 0xFFFFFFFF : mask;
+    mask = mask == 0 ? 0xFFFFFFFF : mask;
     uint32_t clear_mask = ~mask;
     new_value &= clear_mask;
     new_value |= static_cast<uint32_t>(register_value);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Decode the mask value which is used for patching a scale value (Credit to @NishadSaraf  explain to me the local memtile address)
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
The mask value is encoded in the elf file. Read the "value" column and store in the array associated with offset
#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
SimNowLite test **passes** on PHX and StrixB0
#### Documentation impact (if any)
