### PR TITLE
Remove Hardcoded register space 64KB in shim and zocl

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/common/zocl_ioctl.c
+++ b/src/runtime_src/core/edge/drm/zocl/common/zocl_ioctl.c
@@ -86,6 +86,8 @@ out:
 	args->paddr = addr;
 	args->apt_idx = apt_idx;
 	args->cu_idx = cu_idx;
+        //update cu size based on the apt_index
+        args->cu_size = apts[apt_idx].size;
 	return 0;
 }
 

--- a/src/runtime_src/core/edge/drm/zocl/edge/zocl_edge_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/edge/zocl_edge_xclbin.c
@@ -373,10 +373,6 @@ zocl_xclbin_read_axlf(struct drm_zocl_dev *zdev, struct drm_zocl_axlf *axlf_obj,
 	if (ret)
 		goto out0;
 
-	ret = zocl_update_apertures(zdev, slot);
-	if (ret)
-		goto out0;
-
 	/* Kernels are slot specific. */
 	if (slot->kernels != NULL) {
 		vfree(slot->kernels);
@@ -398,6 +394,10 @@ zocl_xclbin_read_axlf(struct drm_zocl_dev *zdev, struct drm_zocl_axlf *axlf_obj,
 		slot->ksize = axlf_obj->za_ksize;
 		slot->kernels = kernels;
 	}
+
+        ret = zocl_update_apertures(zdev, slot);
+        if (ret)
+                goto out0;
 
 	zocl_clear_mem_slot(zdev, slot->slot_idx);
 	/* Initialize the memory for the new xclbin */

--- a/src/runtime_src/core/edge/include/zynq_ioctl.h
+++ b/src/runtime_src/core/edge/include/zynq_ioctl.h
@@ -291,6 +291,7 @@ struct drm_zocl_info_cu {
 	uint64_t paddr;
 	int apt_idx;
 	int cu_idx;
+        uint64_t cu_size;
 };
 
 enum drm_zocl_ctx_code {

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -172,16 +172,16 @@ mapKernelControl(const std::vector<std::pair<uint64_t, size_t>>& offsets)
     if ((offset_it->first & (~0xFF)) != (-1UL & ~0xFF)) {
       auto it = mKernelControl.find(offset_it->first);
       if (it == mKernelControl.end()) {
-        drm_zocl_info_cu info = {offset_it->first, -1, -1};
+        drm_zocl_info_cu info = {offset_it->first, -1, -1, 0};
         int result = ioctl(mKernelFD, DRM_IOCTL_ZOCL_INFO_CU, &info);
         if (result) {
           xclLog(XRT_ERROR, "%s: Failed to find CU info 0x%lx", __func__, offset_it->first);
           return -errno;
         }
         size_t psize = getpagesize();
-        ptr = mmap(0, offset_it->second, PROT_READ | PROT_WRITE, MAP_SHARED, mKernelFD, info.apt_idx*psize);
+        ptr = mmap(0, info.cu_size, PROT_READ | PROT_WRITE, MAP_SHARED, mKernelFD, info.apt_idx*psize);
         if (ptr == MAP_FAILED) {
-          xclLog(XRT_ERROR, "%s: Map failed for aperture 0x%lx, size 0x%lx", __func__, offset_it->first, offset_it->second);
+          xclLog(XRT_ERROR, "%s: Map failed for aperture 0x%lx, size 0x%lx", __func__, offset_it->first, info.cu_size);
           return -1;
         }
         mKernelControl.insert(it, std::pair<uint64_t, uint32_t *>(offset_it->first, (uint32_t *)ptr));
@@ -761,7 +761,6 @@ xclLoadAxlf(const axlf *buffer)
       krnl->name[sizeof(krnl->name)-1] = '\0';
       krnl->range = kernel.range;
       krnl->anums = kernel.args.size();
-
       krnl->features = 0;
       if (kernel.sw_reset)
         krnl->features |= KRNL_SW_RESET;
@@ -1191,19 +1190,19 @@ xclRegRW(bool rd, uint32_t ipIndex, uint32_t offset, uint32_t *datap)
     xclLog(XRT_ERROR, "%s: invalid CU index: %d", __func__, ipIndex);
     return -EINVAL;
   }
-  if (offset >= mCuMapSize || (offset & (sizeof(uint32_t) - 1)) != 0) {
+  if (offset <= 0  || (offset & (sizeof(uint32_t) - 1)) != 0) {
     xclLog(XRT_ERROR, "%s: invalid CU offset: %d", __func__, offset);
     return -EINVAL;
   }
 
   if (mCuMaps[ipIndex].first == nullptr) {
-    drm_zocl_info_cu info = {0, -1, (int)ipIndex};
+    drm_zocl_info_cu info = {0, -1, (int)ipIndex, 0};
     int result = ioctl(mKernelFD, DRM_IOCTL_ZOCL_INFO_CU, &info);
-    void *p = mmap(0, mCuMapSize, PROT_READ | PROT_WRITE, MAP_SHARED,
+    void *p = mmap(0, info.cu_size, PROT_READ | PROT_WRITE, MAP_SHARED,
                    mKernelFD, info.apt_idx * getpagesize());
     if (p != MAP_FAILED)
       mCuMaps[ipIndex].first = (uint32_t *)p;
-      mCuMaps[ipIndex].second = mCuMapSize;
+      mCuMaps[ipIndex].second = info.cu_size;
   }
 
   uint32_t *cumap = mCuMaps[ipIndex].first;

--- a/src/runtime_src/core/edge/user/shim.h
+++ b/src/runtime_src/core/edge/user/shim.h
@@ -298,7 +298,7 @@ private:
    * Mapped CU register space for xclRegRead/Write(). We support at most
    * 128 CUs and each map is of 64k bytes. Does not support debug IP access.
    */
-  std::vector<uint32_t*> mCuMaps;
+  std::vector<std::pair<uint32_t*, uint32_t>> mCuMaps;
   const size_t mCuMapSize = 64 * 1024;
   std::mutex mCuMapLock;
   int xclRegRW(bool rd, uint32_t cu_index, uint32_t offset, uint32_t *datap);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
[CR-1185445](https://jira.xilinx.com/browse/CR-1185445) XRT has hardcoded the register space for read/write to 64KB.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
In the zocl side, we are hardcoding CU size as 64KB size, mmap is failing for IP's which has more than 64KB size .

#### How problem was solved, alternative solutions (if any) and why they were rejected
Removed Hardcoded check 0x1000 from the user side and zocl side.

#### Risks (if any) associated the changes in the commit
NA

#### What has been tested and how, request additional testing if necessary
Tested on vck190

#### Documentation impact (if any)
NA