### PR TITLE
Windows build fix from the previous commit of graph task

### DIFF
--- a/src/runtime_src/core/common/ishim.h
+++ b/src/runtime_src/core/common/ishim.h
@@ -212,7 +212,7 @@ struct ishim
   { throw not_supported_error{__func__}; }
 
   virtual void
-  sync_aie_bo(xrt::bo& bo, const char *gmioName, xclBOSyncDirection dir, size_t size, size_t offset)
+  sync_aie_bo(xrt::bo&, const char*, xclBOSyncDirection, size_t , size_t )
   { throw not_supported_error{__func__}; }
 
   virtual void
@@ -220,23 +220,23 @@ struct ishim
   { throw not_supported_error{__func__}; }
 
   virtual void
-  sync_aie_bo_nb(xrt::bo& bo, const char *gmioName, xclBOSyncDirection dir, size_t size, size_t offset)
+  sync_aie_bo_nb(xrt::bo&, const char*, xclBOSyncDirection, size_t, size_t)
   { throw not_supported_error{__func__}; }
 
   virtual void
-  wait_gmio(const char *gmioName)
+  wait_gmio(const char*)
   { throw not_supported_error{__func__}; }
 
   virtual int
-  start_profiling(int option, const char* port1Name, const char* port2Name, uint32_t value)
+  start_profiling(int, const char*, const char*, uint32_t)
   { throw not_supported_error{__func__}; }
 
   virtual uint64_t
-  read_profiling(int phdl)
+  read_profiling(int)
   { throw not_supported_error{__func__}; }
 
   virtual void
-  stop_profiling(int phdl)
+  stop_profiling(int)
   { throw not_supported_error{__func__}; }
 
   virtual void


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

windows build issues in XRT 

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

Below PR of graph task caused the windows build issues and identified through local windows build
https://github.com/Xilinx/XRT/pull/8292

#### How problem was solved, alternative solutions (if any) and why they were rejected

Removed unused parameters in virtual functions which not using those parameters.

#### Risks (if any) associated the changes in the commit

N/A

#### What has been tested and how, request additional testing if necessary

Local windows build is successful.

![image](https://github.com/user-attachments/assets/705bf640-7d87-4f03-8791-c88ea0aa7777)


#### Documentation impact (if any)

N/A