### PR TITLE
Partial removal of AIE compilation flags in XRT

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -58,8 +58,6 @@ endif()
 
 if (DEFINED ENV{XRT_CLANGTIDY_REVIEW})
   set(XRT_CLANGTIDY_REVIEW "yes")
-  set(XRT_AIE_BUILD "yes")
-  add_compile_options("-DXRT_ENABLE_AIE")
 endif()
 
 if (DISABLE_ABI_CHECK)
@@ -69,15 +67,6 @@ endif()
 if (NOT CMAKE_BUILD_TYPE)
   set (CMAKE_BUILD_TYPE RelWithDebInfo)
 endif (NOT CMAKE_BUILD_TYPE)
-
-# Enable AIE even on x86.  This is POC, once
-# complete we will remove the need for these
-# macros and defines.
-if (${XRT_NATIVE_BUILD} STREQUAL "yes")
-  set(XRT_AIE_BUILD "yes")
-  set(XRT_ENABLE_AIE "yes")
-  add_definitions (-DXRT_ENABLE_AIE -DXRT_AIE_BUILD)
-endif()
 
 # Default component name for any install() command without the COMPONENT argument
 # The default component is the xrt run-time component, if XRT_DEV_COMPONENT is

--- a/src/runtime_src/core/common/api/CMakeLists.txt
+++ b/src/runtime_src/core/common/api/CMakeLists.txt
@@ -20,14 +20,8 @@ add_library(core_common_api_library_objects OBJECT
   xrt_system.cpp
   xrt_version.cpp
   xrt_xclbin.cpp
+  aie/xrt_graph.cpp
   )
-
-if (DEFINED XRT_AIE_BUILD)
-  message("-- enabling api aie build")
-  target_sources(core_common_api_library_objects
-    PRIVATE
-    aie/xrt_graph.cpp)
-endif()
 
 target_include_directories(core_common_api_library_objects
   PRIVATE

--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -430,7 +430,6 @@ public:
     sync(XCL_BO_SYNC_BO_TO_DEVICE, sz, dst_offset);
   }
 
-#ifdef XRT_ENABLE_AIE
   void
   sync(xrt::bo& bo, const std::string& port, xclBOSyncDirection dir, size_t sz, size_t offset)
   {
@@ -439,7 +438,6 @@ public:
 
   xrt::bo::async_handle
   async(xrt::bo& bo, const std::string& port, xclBOSyncDirection dir, size_t sz, size_t offset);
-#endif
 
   xrt::bo::async_handle
   async(xrt::bo& bo, xclBOSyncDirection dir, size_t sz, size_t offset);
@@ -529,7 +527,6 @@ public:
   }
 };
 
-#ifdef XRT_ENABLE_AIE
 class aie::bo::async_handle_impl : public xrt::bo::async_handle_impl
 {
   // class for holding AIE BO Async DMA transfer information
@@ -619,7 +616,6 @@ async(xrt::bo& bo, const std::string& port, xclBOSyncDirection dir, size_t sz, s
 
   return xrt::bo::async_handle{a_bo_impl};
 }
-#endif // XRT_ENABLE_AIE
 
 xrt::bo::async_handle
 bo_impl::
@@ -1696,7 +1692,6 @@ create_debug_bo(const xrt::hw_context& hwctx, size_t sz)
 
 } // xrt_core::bo_int
 
-#ifdef XRT_ENABLE_AIE
 ////////////////////////////////////////////////////////////////
 // xrt_aie_bo C++ API implmentations (xrt_aie.h)
 ////////////////////////////////////////////////////////////////
@@ -1717,7 +1712,6 @@ sync(const std::string& port, xclBOSyncDirection dir, size_t sz, size_t offset)
 }
 
 } // namespace xrt::aie
-#endif
 
 ////////////////////////////////////////////////////////////////
 // xrt_bo API implmentations (xrt_bo.h)

--- a/src/runtime_src/core/common/api/xrt_device.cpp
+++ b/src/runtime_src/core/common/api/xrt_device.cpp
@@ -378,7 +378,6 @@ device::
 
 } // xrt
 
-#ifdef XRT_ENABLE_AIE
 ////////////////////////////////////////////////////////////////
 // xrt_aie_device C++ API implmentations (xrt_aie.h)
 ////////////////////////////////////////////////////////////////
@@ -497,7 +496,6 @@ write_aie_reg(uint16_t context_id, uint16_t col, uint16_t row, uint32_t reg_addr
     });
 }
 } // xrt::aie
-#endif
 
 ////////////////////////////////////////////////////////////////
 // xrt_device API implmentations (xrt_device.h)

--- a/src/runtime_src/core/common/device.cpp
+++ b/src/runtime_src/core/common/device.cpp
@@ -145,7 +145,6 @@ load_xclbin(const uuid& xclbin_id)
   if (uuid_compare(uuid_loaded.get(), xclbin_id.get()))
     throw error(ENODEV, "specified xclbin is not loaded");
 
-#ifdef XRT_ENABLE_AIE
   auto xclbin_full = xrt_core::device_query<xrt_core::query::xclbin_full>(this);
   if (xclbin_full.empty())
     throw error(ENODEV, "no cached xclbin data");
@@ -160,9 +159,6 @@ load_xclbin(const uuid& xclbin_id)
     m_xclbin = {};
     throw;
   }
-#else
-  throw error(ENOTSUP, "load xclbin by uuid is not supported");
-#endif
 }
 
 xrt::xclbin

--- a/src/runtime_src/core/common/ishim.h
+++ b/src/runtime_src/core/common/ishim.h
@@ -206,7 +206,6 @@ struct ishim
   }
   ////////////////////////////////////////////////////////////////
 
-#ifdef XRT_ENABLE_AIE
   virtual void
   open_aie_context(xrt::aie::access_mode)
   { throw not_supported_error{__func__}; }
@@ -258,7 +257,6 @@ struct ishim
   virtual bool
   write_aie_reg(uint16_t /*col*/, uint16_t /*row*/, uint32_t /*reg_addr*/, uint32_t /*reg_val*/)
   { throw not_supported_error{__func__}; }
-#endif
 };
 
 template <typename DeviceType>
@@ -533,63 +531,6 @@ struct noshim : public DeviceType
   {
     throw ishim::not_supported_error(__func__);
   }
-
-#ifdef XRT_ENABLE_AIE
-
-  void
-  open_aie_context(xrt::aie::access_mode) override
-  {
-    throw ishim::not_supported_error(__func__);
-  }
-
-  void
-  sync_aie_bo(xrt::bo&, const char*, xclBOSyncDirection, size_t, size_t) override
-  {
-    throw ishim::not_supported_error(__func__);
-  }
-
-  void
-  reset_aie() override
-  {
-    throw ishim::not_supported_error(__func__);
-  }
-
-  void
-  sync_aie_bo_nb(xrt::bo&, const char*, xclBOSyncDirection, size_t, size_t) override
-  {
-    throw ishim::not_supported_error(__func__);
-  }
-
-  void
-  wait_gmio(const char*) override
-  {
-    throw ishim::not_supported_error(__func__);
-  }
-
-  int
-  start_profiling(int, const char*, const char*, uint32_t) override
-  {
-    throw ishim::not_supported_error(__func__);
-  }
-
-  uint64_t
-  read_profiling(int) override
-  {
-    throw ishim::not_supported_error(__func__);
-  }
-
-  void
-  stop_profiling(int) override
-  {
-    throw ishim::not_supported_error(__func__);
-  }
-
-  void
-  load_axlf_meta(const axlf*) override
-  {
-    throw ishim::not_supported_error(__func__);
-  }
-#endif
 };
 
 } // xrt_core

--- a/src/runtime_src/core/pcie/emulation/sw_emu/generic_pcie_hal2/device_swemu.cxx
+++ b/src/runtime_src/core/pcie/emulation/sw_emu/generic_pcie_hal2/device_swemu.cxx
@@ -124,8 +124,6 @@ open_graph_handle(const xrt::uuid& xclbin_id, const char* name, xrt::graph::acce
                   static_cast<xclswemuhal2::SwEmuShim*>(get_device_handle()), xclbin_id, name, am);
 }
 
-#ifdef XRT_ENABLE_AIE
- 
 void
 device::
 open_aie_context(xrt::aie::access_mode am)
@@ -195,7 +193,5 @@ load_axlf_meta(const axlf* buffer)
   if (auto ret = xclLoadXclBinMeta(get_device_handle(), buffer))
     throw system_error(ret, "failed to load xclbin");
 }
-
-#endif
 
 }} // swemu,xrt_core

--- a/src/runtime_src/core/pcie/emulation/sw_emu/generic_pcie_hal2/device_swemu.h
+++ b/src/runtime_src/core/pcie/emulation/sw_emu/generic_pcie_hal2/device_swemu.h
@@ -51,8 +51,6 @@ public:
   std::unique_ptr<xrt_core::graph_handle>
   open_graph_handle(const xrt::uuid& xclbin_id, const char* name, xrt::graph::access_mode am) override;
 
-#ifdef XRT_ENABLE_AIE
-  
   void
   open_aie_context(xrt::aie::access_mode am) override;
 
@@ -79,8 +77,6 @@ public:
 
   void
   load_axlf_meta(const axlf* buffer) override;
-
-#endif  
 
 private:
   // Private look up function for concrete query::request


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

Removing unnecessary AIE flags partially in XRT

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

N/A

#### How problem was solved, alternative solutions (if any) and why they were rejected

Cleaning up XRT code to remove / minimize unnecessary compilation flags

#### Risks (if any) associated the changes in the commit

N/A

#### What has been tested and how, request additional testing if necessary

Builds of versal and non-versal (zynq) are successful.

#### Documentation impact (if any)

N/A
