### PR TITLE
CR-1206951 Replace ipukmddrv with NPU Driver Version in xrt-smi host report

### DIFF
--- a/src/runtime_src/core/tools/common/reports/ReportHost.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportHost.cpp
@@ -139,13 +139,17 @@ ReportHost::writeReport(const xrt_core::device* /*_pDevice*/,
     for(auto& drv : available_drivers) {
       const boost::property_tree::ptree& driver = drv.second;
       std::string drv_name = driver.get<std::string>("name", "N/A");
-      boost::algorithm::to_lower(drv_name);
+      // This check depends on the assumption that ipukmddrv is the name given to NPU drivers.
+      if (boost::iequals(drv_name, "ipukmddrv")) 
+        drv_name = "NPU Driver";
       std::string drv_hash = driver.get<std::string>("hash", "N/A");
       if (!boost::iequals(drv_hash, "N/A")) {
         _output << boost::format("  %-20s : %s, %s\n") % drv_name
             % driver.get<std::string>("version", "N/A") % driver.get<std::string>("hash", "N/A");
-      } else
-        _output << boost::format("  %-20s : %s\n") % drv_name % driver.get<std::string>("version", "N/A");
+      } else {
+        std::string drv_version = boost::iequals(drv_name, "N/A") ? drv_name : drv_name.append(" Version");
+        _output << boost::format("  %-20s : %s\n") % drv_version % driver.get<std::string>("version", "N/A");
+      }
       if (boost::iequals(drv_name, "xclmgmt") && boost::iequals(driver.get<std::string>("version", "N/A"), "unknown"))
         _output << "WARNING: xclmgmt version is unknown. Is xclmgmt driver loaded? Or is MSD/MPD running?" << std::endl;
     }

--- a/src/runtime_src/core/tools/common/reports/ReportHost.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportHost.cpp
@@ -139,9 +139,6 @@ ReportHost::writeReport(const xrt_core::device* /*_pDevice*/,
     for(auto& drv : available_drivers) {
       const boost::property_tree::ptree& driver = drv.second;
       std::string drv_name = driver.get<std::string>("name", "N/A");
-      // This check depends on the assumption that ipukmddrv is the name given to NPU drivers.
-      if (boost::iequals(drv_name, "ipukmddrv")) 
-        drv_name = "NPU Driver";
       std::string drv_hash = driver.get<std::string>("hash", "N/A");
       if (!boost::iequals(drv_hash, "N/A")) {
         _output << boost::format("  %-20s : %s, %s\n") % drv_name


### PR DESCRIPTION
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1206951
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
We want to cleanup examine output for host report to show "NPU Driver Version" to be consistent with "NPU Firmware Version" and not show "ipukmddrv"
#### How problem was solved, alternative solutions (if any) and why they were rejected
This change is in conjunction with PR#887 in XRT-MCDM. This change simply appends "Version" to whatever driver name is supplied.
#### Risks (if any) associated the changes in the commit
N/A
#### What has been tested and how, request additional testing if necessary
On STX\MCDM: (ipukmddrv will be replaced with NPU Driver on MCDM side)
```
C:\Users\rchane\Desktop\xrt>xrt-smi examine
System Configuration
  OS Name              : Windows NT
  Release              : 26046
  Machine              : x86_64
  CPU Cores            : 16
  Memory               : 32109 MB
  Distribution         : Microsoft Windows 11 Enterprise Insider Preview
  Model                : BIRMANPLUS
  BIOS Vendor          : AMD
  BIOS Version         : VXB899825N

XRT
  Version              : 2.18.0
  Branch               : HEAD
  Hash                 : 9048adae9b544fe0b538e37f2abed605baf16961
  Hash Date            : 2024-07-21 20:29:20
  ipukmddrv Version    : 10.1.0.1
  NPU Firmware Version : 0.7.22.120

Device(s) Present
|BDF             ||Name  |
|----------------||------|
|[00c5:00:01.1]  ||NPU   |
```
#### Documentation impact (if any)
N/A