### PR TITLE
CR-1205620: Removing cu_size limitation for pcie

### DIFF
--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -2352,7 +2352,7 @@ int shim::xclRegRW(bool rd, uint32_t ipIndex, uint32_t offset, uint32_t *datap)
   if (cumap.addr == nullptr) {
     auto cu_subdev = "CU[" + std::to_string(ipIndex) + "]";
     auto size = xrt_core::device_query<xq::cu_size>(mCoreDevice, xq::request::modifier::subdev, cu_subdev);
-    if (size <= 0 || size > 0x10000) {
+    if (size <= 0) {
       xrt_logmsg(XRT_ERROR, "%s: incorrect cu size %d", __func__, size);
       return -EINVAL;
     }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
CU size limitation on pcie platforms
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
If hw supports more than 64K cu size then XRT should be able to support it.
#### How problem was solved, alternative solutions (if any) and why they were rejected
Removed the cu size check used to limit hw to not have more than 64K cu size
#### Risks (if any) associated the changes in the commit
n/a
#### What has been tested and how, request additional testing if necessary
Tested xbutil reset, validate, examine on RAVE-IVH and on v70 
#### Documentation impact (if any)
n/a