### PR TITLE
[XDP] Specified tiles not found in all valid tiles.

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info/aie_constructs.h
+++ b/src/runtime_src/xdp/profile/database/static_info/aie_constructs.h
@@ -91,6 +91,26 @@ namespace xdp {
     }
   };
 
+  struct compareTileByLoc {
+    tile_type target_tile;
+    compareTileByLoc(const tile_type& t) : target_tile(t) {}
+
+    bool operator()(const tile_type& src_tile) const {
+      return src_tile.col == target_tile.col && src_tile.row == target_tile.row;
+    }
+  };
+  struct compareTileByLocAndActiveType {
+    tile_type target_tile;
+    compareTileByLocAndActiveType(const tile_type& t) : target_tile(t) {}
+
+    bool operator()(const tile_type& src_tile) const {
+      return src_tile.col == target_tile.col &&
+             src_tile.row == target_tile.row &&
+             src_tile.active_core == target_tile.active_core &&
+             src_tile.active_memory == target_tile.active_memory;
+    }
+  };
+
   struct io_config
   {
     // Object id

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_metadata.cpp
@@ -473,7 +473,9 @@ namespace xdp {
           tile.active_memory = true;
 
           // Make sure tile is used
-          if (allValidTiles.find(tile) == allValidTiles.end()) {
+          auto it = std::find_if(allValidTiles.begin(), allValidTiles.end(),
+            compareTileByLocAndActiveType(tile));
+          if (it == allValidTiles.end()) {
             std::stringstream msg;
             msg << "Specified Tile (" << std::to_string(tile.col) << "," 
                 << std::to_string(tile.row) << ") is not active. Hence skipped.";
@@ -526,7 +528,9 @@ namespace xdp {
       tile.active_memory = true;
 
       // Make sure tile is used
-      if (allValidTiles.find(tile) == allValidTiles.end()) {
+      auto it = std::find_if(allValidTiles.begin(), allValidTiles.end(),
+                             compareTileByLocAndActiveType(tile));
+      if (it == allValidTiles.end()) {
         std::stringstream msg;
         msg << "Specified Tile (" << std::to_string(tile.col) << "," 
             << std::to_string(tile.row) << ") is not active. Hence skipped.";

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_metadata.cpp
@@ -533,7 +533,9 @@ namespace xdp {
           tile.active_memory = true;
 
           // Make sure tile is used
-          if (allValidTiles.find(tile) == allValidTiles.end()) {
+          auto it = std::find_if(allValidTiles.begin(), allValidTiles.end(),
+                                 compareTileByLocAndActiveType(tile));
+          if (it == allValidTiles.end()) {
             std::stringstream msg;
             msg << "Specified Tile {" << std::to_string(tile.col) << ","
                 << std::to_string(tile.row) << "} is not active. Hence skipped.";
@@ -584,7 +586,9 @@ namespace xdp {
       tile.active_memory = true;
 
       // Make sure tile is used
-      if (allValidTiles.find(tile) == allValidTiles.end()) {
+      auto it = std::find_if(allValidTiles.begin(), allValidTiles.end(),
+                             compareTileByLocAndActiveType(tile));
+      if (it == allValidTiles.end()) {
         std::stringstream msg;
         msg << "Specified Tile {" << std::to_string(tile.col) << ","
             << std::to_string(tile.row) << "} is not active. Hence skipped.";


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
CR-1205850 : No valid tiles were found although metadata has mention it valid.
> tile_based_aie_tile_metrics={0,0}:{0,4}:all_stalls_dma

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Issue surfaced when default comparator of `tile_type` needed to be modified to include all fields. This was required as few client designs could use same location tiles were used for both the IO types.

#### How problem was solved, alternative solutions (if any) and why they were rejected
To find a specified tile in `allValidTiles` which is a set uses an existing the default comparator of `tile_type` which compares against fields of `tile_type`.
However, in this use case comparator should only use `col` , `row` , `active_core` & `active_memory` .  Fix now explicitly specifies what comparator to use.
I have also added location based comparator.

#### Risks (if any) associated the changes in the commit
Minimal
#### What has been tested and how, request additional testing if necessary
Verified on edge and client that bound box of tiles works as expected.
 
#### Documentation impact (if any)
