### PR TITLE
CR-1206972 Provide help menu when xrt-smi examine is given invalid report

### DIFF
--- a/src/runtime_src/core/tools/common/SubCmdExamineInternal.cpp
+++ b/src/runtime_src/core/tools/common/SubCmdExamineInternal.cpp
@@ -167,7 +167,13 @@ SubCmdExamineInternal::execute(const SubCmdOptions& _options) const
   ReportCollection runnableReports = validateConfigurables<Report>(deviceClass, std::string("report"), fullReportCollection);
 
   // Collect the reports to be processed
-  XBU::collect_and_validate_reports(runnableReports, reportsToRun, reportsToProcess);
+  try {
+    XBU::collect_and_validate_reports(runnableReports, reportsToRun, reportsToProcess);
+  } catch (const xrt_core::error& e) {
+    std::cerr << boost::format("ERROR: %s\n") % e.what();
+    print_help_internal();
+    return;
+  }
 
   // Find device of interest
   std::shared_ptr<xrt_core::device> device;


### PR DESCRIPTION
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1206972
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Discovered in xrt-smi internal testing
#### How problem was solved, alternative solutions (if any) and why they were rejected
Added a try-catch so that xrt-smi would not error-out and instead provide the help menu gracefully.
#### Risks (if any) associated the changes in the commit
N/A
#### What has been tested and how, request additional testing if necessary
Tested on STX/MCDM
```
C:\Users\rchane\Desktop\xrt>xrt-smi examine -r bad
ERROR: No report generator found for report: 'bad'
: invalid argument

COMMAND: examine

DESCRIPTION: This command will 'examine' the state of the system/device and will generate a report of interest
               in a text or JSON format.

USAGE: xrt-smi examine [--help] [-d arg] [-f arg] [-o arg] [-r arg]

OPTIONS:
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest
  -f, --format       - Report output format. Valid values are:
                         JSON        - Latest JSON schema
                         JSON-2020.2 - JSON 2020.2 schema
  -o, --output       - Direct the output to the given file
  --help             - Help to use this sub-command
  -r, --report       - The type of report to be produced. Reports currently available are:
                         aie-partitions - AIE partition information
                         all            - All known reports are produced
                         host           - Host information
                         platform       - Platforms flashed on the device
                         telemetry      - Telemetry data for the device


GLOBAL OPTIONS:
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
```
#### Documentation impact (if any)
N/A