### PR TITLE
CR-1206982 and CR-1206998 fix

### DIFF
--- a/src/runtime_src/core/tools/common/SubCmdConfigureInternal.cpp
+++ b/src/runtime_src/core/tools/common/SubCmdConfigureInternal.cpp
@@ -322,7 +322,7 @@ SubCmdConfigureInternal::execute(const SubCmdOptions& _options) const
   XBU::verbose("SubCommand: configure");
   po::variables_map vm;
   // Used for the suboption arguments.
-  process_arguments(vm, _options, false);
+  const auto unrecognized_options = process_arguments(vm, _options, false);
   // Find the subOption
   auto optionOption = checkForSubOption(vm, XBU::get_device_class(m_device, m_isUserDomain));
 
@@ -334,7 +334,16 @@ SubCmdConfigureInternal::execute(const SubCmdOptions& _options) const
     }
     // If help was not requested and additional options dont match we must throw to prevent
     // invalid positional arguments from passing through without warnings
-    std::cerr << "ERROR: Suboption missing" << std::endl;
+    if (!unrecognized_options.empty()){
+      std::string error_str;
+      error_str.append("Unrecognized arguments:\n");
+      for (const auto& option : unrecognized_options)
+        error_str.append(boost::str(boost::format("  %s\n") % option));
+      std::cerr << error_str <<std::endl;
+    }
+    else {
+      std::cerr << "ERROR: Suboption missing" << std::endl;
+    }
     printHelp(false, "", XBU::get_device_class(m_device, m_isUserDomain));
     throw xrt_core::error(std::errc::operation_canceled);
   }

--- a/src/runtime_src/core/tools/common/SubCmdExamineInternal.cpp
+++ b/src/runtime_src/core/tools/common/SubCmdExamineInternal.cpp
@@ -139,6 +139,7 @@ SubCmdExamineInternal::execute(const SubCmdOptions& _options) const
   // When json is specified, make sure an accompanying output file is also specified
   if (!m_format.empty() && m_output.empty()) {
     std::cerr << "ERROR: Please specify an output file to redirect the json to" << std::endl;
+    print_help_internal();
     throw xrt_core::error(std::errc::operation_canceled);
   }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
[CR-1206982](https://jira.xilinx.com/browse/CR-1206982) xrt-smi configure doesn't have consistent output for invalid argument
[CR-1206998](https://jira.xilinx.com/browse/CR-1206998)xrt-smi does not prints help message when there is no command line option for -o/--output

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
[CR-1206982](https://jira.xilinx.com/browse/CR-1206982) :  Testing by DSV
[CR-1206998](https://jira.xilinx.com/browse/CR-1206998) : Testing by DSV

#### How problem was solved, alternative solutions (if any) and why they were rejected
The problem was solved by putting appropriate checks to handle errors correctly
Output before fix :
```
C:\>xrt-smi configure bad
ERROR: Suboption missing

COMMAND: configure

DESCRIPTION: Device and host configuration.USAGE: xrt-smi configure [ --pmode ] [--help] [-d arg]

OPTIONS:
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest
  --help             - Help to use this sub-command
  --pmode            - Change power mode of the device
GLOBAL OPTIONS:
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
ERROR: operation canceled 
```
Output with the fix :
```
Y:\Repos\XRT-MCDM-FORK\XRT-MCDM\build\WRelease\xilinx\xrt>xrt-smi configure bad
ERROR: Unrecognized arguments:
  bad


COMMAND: configure

DESCRIPTION: Device and host configuration.

USAGE: xrt-smi configure [ --pmode ] [--help] [-d arg]

OPTIONS:
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest
  --help             - Help to use this sub-command
  --pmode            - Change power mode of the device


GLOBAL OPTIONS:
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
ERROR: operation canceled
```

#### Risks (if any) associated the changes in the commit
This change would change the existing xrt-smi behavior

#### What has been tested and how, request additional testing if necessary
Additional testing requested from DSV

#### Documentation impact (if any)
None
