### PR TITLE
Fix for Incorrect behavior for xrt-smi examine --report

### DIFF
--- a/src/runtime_src/core/tools/common/SubCmdExamineInternal.cpp
+++ b/src/runtime_src/core/tools/common/SubCmdExamineInternal.cpp
@@ -66,13 +66,14 @@ SubCmdExamineInternal::SubCmdExamineInternal(bool _isHidden, bool _isDepricated,
   common_options.add_options()
     ("device,d", boost::program_options::value<decltype(m_device)>(&m_device), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest")
     ("format,f", boost::program_options::value<decltype(m_format)>(&m_format), (std::string("Report output format. Valid values are:\n") + formatOptionValues).c_str() )
-    ("output,o", boost::program_options::value<decltype(m_output)>(&m_output), "Direct the output to the given file")
+    ("output,o", boost::program_options::value<decltype(m_output)>(&m_output)->implicit_value("<console>"), "Direct the output to the given file")
     ("help", boost::program_options::bool_switch(&m_help), "Help to use this sub-command")
   ;
 
   m_commonOptions.add(common_options);
   m_commonOptions.add_options()
-    ("report,r", boost::program_options::value<decltype(m_reportNames)>(&m_reportNames)->multitoken(), (std::string("The type of report to be produced. Reports currently available are:\n") + reportOptionValues).c_str() )
+    ("report,r", boost::program_options::value<decltype(m_reportNames)>(&m_reportNames)->multitoken()->implicit_value(std::vector<std::string>{std::string("all")}, std::string("all")),
+      (std::string("The type of report to be produced. Reports currently available are:\n") + reportOptionValues).c_str() )
   ;
   
   if (m_isUserDomain)
@@ -219,7 +220,7 @@ SubCmdExamineInternal::execute(const SubCmdOptions& _options) const
   }
 
   // -- Write output file ----------------------------------------------
-  if (!m_output.empty()) {
+  if (!m_output.empty() && m_output != "<console>") {
     std::ofstream fOutput;
     fOutput.open(m_output, std::ios::out | std::ios::binary);
     if (!fOutput.is_open()) {

--- a/src/runtime_src/core/tools/common/SubCmdExamineInternal.cpp
+++ b/src/runtime_src/core/tools/common/SubCmdExamineInternal.cpp
@@ -65,15 +65,14 @@ SubCmdExamineInternal::SubCmdExamineInternal(bool _isHidden, bool _isDepricated,
   static const std::string formatOptionValues = XBU::create_suboption_list_string(Report::getSchemaDescriptionVector());
   common_options.add_options()
     ("device,d", boost::program_options::value<decltype(m_device)>(&m_device), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest")
-    ("format,f", boost::program_options::value<decltype(m_format)>(&m_format), (std::string("Report output format. Valid values are:\n") + formatOptionValues).c_str() )
-    ("output,o", boost::program_options::value<decltype(m_output)>(&m_output)->implicit_value("<console>"), "Direct the output to the given file")
+    ("format,f", boost::program_options::value<decltype(m_format)>(&m_format)->implicit_value(""), (std::string("Report output format. Valid values are:\n") + formatOptionValues).c_str() )
+    ("output,o", boost::program_options::value<decltype(m_output)>(&m_output)->implicit_value(""), "Direct the output to the given file")
     ("help", boost::program_options::bool_switch(&m_help), "Help to use this sub-command")
   ;
 
   m_commonOptions.add(common_options);
   m_commonOptions.add_options()
-    ("report,r", boost::program_options::value<decltype(m_reportNames)>(&m_reportNames)->multitoken()->implicit_value(std::vector<std::string>{std::string("all")}, std::string("all")),
-      (std::string("The type of report to be produced. Reports currently available are:\n") + reportOptionValues).c_str() )
+    ("report,r", boost::program_options::value<decltype(m_reportNames)>(&m_reportNames)->multitoken()->zero_tokens(),(std::string("The type of report to be produced. Reports currently available are:\n") + reportOptionValues).c_str() )
   ;
   
   if (m_isUserDomain)
@@ -104,8 +103,8 @@ SubCmdExamineInternal::execute(const SubCmdOptions& _options) const
   XBU::verbose("SubCommand: examine");
 
   // Parse sub-command ...
+  po::variables_map vm;
   try{
-    po::variables_map vm;
     const auto unrecognized_options = process_arguments(vm, _options, false);
 
     if (!unrecognized_options.empty())
@@ -129,35 +128,38 @@ SubCmdExamineInternal::execute(const SubCmdOptions& _options) const
     print_help_internal();
     return;
   }
-  
-  // Determine report level
-  std::vector<std::string> reportsToRun(m_reportNames);
-  if (reportsToRun.empty()) {
-    reportsToRun.push_back("host");
-  }
-
-  // DRC check
-  // When json is specified, make sure an accompanying output file is also specified
-  if (!m_format.empty() && m_output.empty()) {
-    std::cerr << "ERROR: Please specify an output file to redirect the json to" << std::endl;
-    throw xrt_core::error(std::errc::operation_canceled);
-  }
 
   const auto validated_format = m_format.empty() ? "json" : m_format;
-
-  // DRC: Examine the output format
   Report::SchemaVersion schemaVersion = Report::getSchemaDescription(validated_format).schemaVersion;
-  if (schemaVersion == Report::SchemaVersion::unknown) {
-    std::cerr << boost::format("ERROR: Unsupported --format option value '%s'") % validated_format << std::endl
-              << boost::format("       Supported values can be found in --format's help section below.") << std::endl;
+  try{
+    if (vm.count("output") && m_output.empty())
+      throw xrt_core::error("Output file not specified");
+
+    if (vm.count("report") && m_reportNames.empty())
+      throw xrt_core::error("No report given to be produced");
+
+    // DRC check
+    // When json is specified, make sure an accompanying output file is also specified
+    if (!m_format.empty() && m_output.empty())
+      throw xrt_core::error("Please specify an output file to redirect the json to");
+
+    if (schemaVersion == Report::SchemaVersion::unknown) 
+      throw xrt_core::error((boost::format("ERROR: Unsupported --format option value '%s'. Supported values can be found in --format's help section below.") % validated_format).str());
+
+    if (!m_output.empty() && std::filesystem::exists(m_output) && !XBU::getForce())
+      throw xrt_core::error((boost::format("ERROR: The output file '%s' already exists.  Please either remove it or execute this command again with the '--force' option to overwrite it.") % m_output).str());
+
+  } catch (const xrt_core::error& e) {
+    // Catch only the exceptions that we have generated earlier
+    std::cerr << boost::format("ERROR: %s\n") % e.what();
     print_help_internal();
     throw xrt_core::error(std::errc::operation_canceled);
   }
 
-  // DRC: Output file
-  if (!m_output.empty() && std::filesystem::exists(m_output) && !XBU::getForce()) {
-    std::cerr << boost::format("ERROR: The output file '%s' already exists.  Please either remove it or execute this command again with the '--force' option to overwrite it.") % m_output << std::endl;
-    throw xrt_core::error(std::errc::operation_canceled);
+  // Determine report level
+  std::vector<std::string> reportsToRun(m_reportNames);
+  if (reportsToRun.empty()) {
+    reportsToRun.push_back("host");
   }
 
   // -- Process the options --------------------------------------------
@@ -220,7 +222,7 @@ SubCmdExamineInternal::execute(const SubCmdOptions& _options) const
   }
 
   // -- Write output file ----------------------------------------------
-  if (!m_output.empty() && m_output != "<console>") {
+  if (!m_output.empty()) {
     std::ofstream fOutput;
     fOutput.open(m_output, std::ios::out | std::ios::binary);
     if (!fOutput.is_open()) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Fix for CR-1206943 : Inconsistent output for xrt-smi examine --help and xrt-smi examine --report

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
[CR-1206943](https://jira.xilinx.com/browse/CR-1206943) : Bug found through DSV testing

#### How problem was solved, alternative solutions (if any) and why they were rejected
The problem was solved by assigning an implicit value to all options which can be used illegally by the user. Now if the user forgets to add an option value, its assigned empty implicitly and errors are handles accordingly with correct help.
It was important to add implicit so that the base xrt-smi parser goes through successfully and populates the device info.

Output before fix for examine:
```
C:\Users\kellyhu\test\npu_mcdm_stack_prod_188>xrt-smi examine --report
ERROR: the required argument for option '--report' is missing

COMMAND: examine

DESCRIPTION: This command will 'examine' the state of the system/device and will generate a report of interest
               in a text or JSON format.

USAGE: xrt-smi examine [--help] [-d arg] [-f arg] [-o arg] [-r arg]

OPTIONS:
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest
  -f, --format       - Report output format. Valid values are:
                         JSON        - Latest JSON schema
                         JSON-2020.2 - JSON 2020.2 schema
  -o, --output       - Direct the output to the given file
  --help             - Help to use this sub-command
  -r, --report       - The type of report to be produced. Reports currently available are:
                       Common:
                         all             - All known reports are produced
                         host            - Host information
                         platform        - Platforms flashed on the device
                       AIE:
                         aie-partitions  - AIE partition information
                         telemetry       - Telemetry data for the device
                       Alveo:
                         aie             - AIE metadata in xclbin
                         aiemem          - AIE memory tile information
                         aieshim         - AIE shim tile status
                         debug-ip-status - Status of Debug IPs present in xclbin loaded on device
                         dynamic-regions - Information about the xclbin and the compute units
                         electrical      - Electrical and power sensors present on the device
                         error           - Asyncronus Error present on the device
                         firewall        - Firewall status
                         mailbox         - Mailbox metrics of the device
                         mechanical      - Mechanical sensors on and surrounding the device
                         memory          - Memory information present on the device
                         pcie-info       - Pcie information of the device
                         qspi-status     - QSPI write protection status
                         thermal         - Thermal sensors present on the device
```
Output after fix for examine
```
Z:\Repos\XRT-MCDM-FORK\XRT-MCDM\build\WRelease\xilinx\xrt>xrt-smi examine --report
ERROR: No report given to be produced: invalid argument

COMMAND: examine

DESCRIPTION: This command will 'examine' the state of the system/device and will generate a report of interest
               in a text or JSON format.

USAGE: xrt-smi examine [--help] [-d arg] [-f arg] [-o arg] [-r arg]

OPTIONS:
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest
  -f, --format       - Report output format. Valid values are:
                         JSON        - Latest JSON schema
                         JSON-2020.2 - JSON 2020.2 schema
  -o, --output       - Direct the output to the given file
  --help             - Help to use this sub-command
  -r, --report       - The type of report to be produced. Reports currently available are:
                         aie-partitions - AIE partition information
                         all            - All known reports are produced
                         host           - Host information
                         platform       - Platforms flashed on the device
                         telemetry      - Telemetry data for the device


GLOBAL OPTIONS:
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
ERROR: operation canceled
```
Output before fix for validate
```
C:\Users\kellyhu\test\npu_mcdm_stack_prod_188>xrt-smi validate --run
ERROR: the required argument for option '--run' is missing

COMMAND: validate

DESCRIPTION: This command will 'examine' the state of the system/device and will generate a report of interest
               in a text or JSON format.

USAGE: xrt-smi examine [--help] [-d arg] [-f arg] [-o arg] [-r arg]

OPTIONS:
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest
  -f, --format       - Report output format. Valid values are:
                         JSON        - Latest JSON schema
                         JSON-2020.2 - JSON 2020.2 schema
  -o, --output       - Direct the output to the given file
  --help             - Help to use this sub-command
  -r, --report       - The type of report to be produced. Reports currently available are:
                       Common:
                         all             - All known reports are produced
                         host            - Host information
                         platform        - Platforms flashed on the device
                       AIE:
                         aie-partitions  - AIE partition information
                         telemetry       - Telemetry data for the device
                       Alveo:
                         aie             - AIE metadata in xclbin
                         aiemem          - AIE memory tile information
                         aieshim         - AIE shim tile status
                         debug-ip-status - Status of Debug IPs present in xclbin loaded on device
                         dynamic-regions - Information about the xclbin and the compute units
                         electrical      - Electrical and power sensors present on the device
                         error           - Asyncronus Error present on the device
                         firewall        - Firewall status
                         mailbox         - Mailbox metrics of the device
                         mechanical      - Mechanical sensors on and surrounding the device
                         memory          - Memory information present on the device
                         pcie-info       - Pcie information of the device
                         qspi-status     - QSPI write protection status
                         thermal         - Thermal sensors present on the device
```
output after fix for validate
```
Z:\Repos\XRT-MCDM-FORK\XRT-MCDM\build\WRelease\xilinx\xrt>xrt-smi validate --run
ERROR: No test given to validate against.: invalid argument

COMMAND: validate

DESCRIPTION: Validates the given device by executing the platform's validate executable.

USAGE: xrt-smi validate [--help] [-d arg] [-f arg] [-o arg] [-p arg] [-r arg] [--param arg]

OPTIONS:
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest
  -f, --format       - Report output format. Valid values are:
                         JSON        - Latest JSON schema
                         JSON-2020.2 - JSON 2020.2 schema
  -o, --output       - Direct the output to the given file
  --param            - Extended parameter for a given test. Format: <test-name>:<key>:<value>
  -p, --path         - Path to the directory containing validate xclbins
  --help             - Help to use this sub-command
  -r, --run          - Run a subset of the test suite. Valid options are:
                         all                  - All applicable validate tests will be executed
                                                (default)
                         cmd-chain-latency    - Run end-to-end latency test using command chaining
                         cmd-chain-throughput - Run end-to-end throughput test using command
                                                chaining
                         df-bw                - Run bandwidth test on data fabric
                         gemm                 - Measure the TOPS value of GEMM operations
                         latency              - Run end-to-end latency test
                         quick                - Only the first 4 tests will be executed
                         tct-all-col          - Measure average TCT processing time for all
                                                columns
                         tct-one-col          - Measure average TCT processing time for one column
                         throughput           - Run end-to-end throughput test

EXTENDED KEYS:
  dma                - block-size:<value> - Memory transfer size (bytes)


GLOBAL OPTIONS:
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
ERROR: operation canceled
```
#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Should be additionally tested by DSV

#### Documentation impact (if any)
None
