### PR TITLE
CR-1206430 xrt-smi validate -r gemm generates wrong message on PHX

### DIFF
--- a/src/runtime_src/core/tools/common/TestRunner.cpp
+++ b/src/runtime_src/core/tools/common/TestRunner.cpp
@@ -408,7 +408,8 @@ TestRunner::findPlatformFile(const std::string& file_path,
     return xrt_core::environment::platform_path(file_path).string();
   }
   catch (const std::exception&) {
-    logger(ptTest, "Details", boost::str(boost::format("%s not available. Skipping validation.") % file_path));
+    logger(ptTest, "Details", boost::str(boost::format("%s not available") % file_path));
+    logger(ptTest, "Details", "The test is not supported on this device.");
     ptTest.put("status", test_token_skipped);
     return "";
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
[CR-1206430](https://jira.xilinx.com/browse/CR-1206430) xrt-smi validate -r gemm generates wrong message on PHX

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
DSV testing: Misleading message

#### How problem was solved, alternative solutions (if any) and why they were rejected
The messaging was improved to explicitly mention that test is not supported. 
Note: This is a hot-fix. In future we would like to not display tests which are not supported on a device

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Tested in phx:
```
>xrt-smi.exe validate -r gemm
Validate Device           : [00c3:00:01.1]
    Platform              : NPU
    Power Mode            : Default
-------------------------------------------------------------------------------
Verbose: Enabling Verbosity
Test 1 [00c3:00:01.1]     : gemm

    Description           : Measure the TOPS value of GEMM operations
    Details               : gemm_1502_00.xclbin not available
                            The test is not supported on this device.
    Test Status           : [SKIPPED]
-------------------------------------------------------------------------------
Validation completed
```

#### Documentation impact (if any)
None
