### PR TITLE
CR-1206955, 1206964, 1207002 Various xrt-smi output and json fixes

### DIFF
--- a/src/runtime_src/core/tools/common/reports/platform/ReportRyzenPlatform.cpp
+++ b/src/runtime_src/core/tools/common/reports/platform/ReportRyzenPlatform.cpp
@@ -50,7 +50,7 @@ ReportRyzenPlatform::writeReport(const xrt_core::device* /*_pDevice*/,
     _output << boost::format("  %-23s: %s \n") % "Name" % pt_static_region.get<std::string>("name");
 
     const boost::property_tree::ptree& pt_status = pt_platform.get_child("status");
-    _output << boost::format("  %-23s: %s \n") % "Power Mode" % pt_status.get<std::string>("performance_mode");
+    _output << boost::format("  %-23s: %s \n") % "Power Mode" % pt_status.get<std::string>("power_mode");
 
     const boost::property_tree::ptree& clocks = pt_platform.get_child("clocks", empty_ptree);
     if (!clocks.empty()) {
@@ -63,7 +63,10 @@ ReportRyzenPlatform::writeReport(const xrt_core::device* /*_pDevice*/,
     }
 
     auto watts = pt_platform.get<std::string>("electrical.power_consumption_watts", "N/A");
-    _output << std::endl << boost::format("%-23s  : %s Watts\n") % "Power" % watts;
+    if (watts != "N/A")
+      _output << std::endl << boost::format("%-23s  : %s Watts\n") % "Power" % watts;
+    else
+      _output << std::endl << boost::format("%-23s  : %s\n") % "Power" % watts;
   }
 
   _output << std::endl;

--- a/src/runtime_src/core/tools/common/tests/TestCmdChainLatency.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestCmdChainLatency.cpp
@@ -27,6 +27,7 @@ boost::property_tree::ptree
 TestCmdChainLatency::run(std::shared_ptr<xrt_core::device> dev)
 {
   boost::property_tree::ptree ptree = get_test_header();
+  ptree.erase("xclbin");
 
   const auto xclbin_name = xrt_core::device_query<xrt_core::query::xclbin_name>(dev, xrt_core::query::xclbin_name::type::validate);
   auto xclbin_path = findPlatformFile(xclbin_name, ptree);

--- a/src/runtime_src/core/tools/common/tests/TestCmdChainThroughput.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestCmdChainThroughput.cpp
@@ -27,6 +27,7 @@ boost::property_tree::ptree
 TestCmdChainThroughput::run(std::shared_ptr<xrt_core::device> dev)
 {
   boost::property_tree::ptree ptree = get_test_header();
+  ptree.erase("xclbin");
 
   const auto xclbin_name = xrt_core::device_query<xrt_core::query::xclbin_name>(dev, xrt_core::query::xclbin_name::type::validate);
   auto xclbin_path = findPlatformFile(xclbin_name, ptree);

--- a/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.cpp
@@ -76,6 +76,7 @@ boost::property_tree::ptree
 TestDF_bandwidth::run(std::shared_ptr<xrt_core::device> dev)
 {
   boost::property_tree::ptree ptree = get_test_header();
+  ptree.erase("xclbin");
 
   const auto xclbin_name = xrt_core::device_query<xrt_core::query::xclbin_name>(dev, xrt_core::query::xclbin_name::type::validate);
   auto xclbin_path = findPlatformFile(xclbin_name, ptree);

--- a/src/runtime_src/core/tools/common/tests/TestGemm.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestGemm.cpp
@@ -83,6 +83,7 @@ boost::property_tree::ptree
 TestGemm::run(std::shared_ptr<xrt_core::device> dev)
 {
   boost::property_tree::ptree ptree = get_test_header();
+  ptree.erase("xclbin");
 
   const auto xclbin_name = xrt_core::device_query<xrt_core::query::xclbin_name>(dev, xrt_core::query::xclbin_name::type::gemm);
   auto xclbin_path = findPlatformFile(xclbin_name, ptree);

--- a/src/runtime_src/core/tools/common/tests/TestNPULatency.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestNPULatency.cpp
@@ -26,6 +26,7 @@ boost::property_tree::ptree
 TestNPULatency::run(std::shared_ptr<xrt_core::device> dev)
 {
   boost::property_tree::ptree ptree = get_test_header();
+  ptree.erase("xclbin");
 
   const auto xclbin_name = xrt_core::device_query<xrt_core::query::xclbin_name>(dev, xrt_core::query::xclbin_name::type::validate);
   auto xclbin_path = findPlatformFile(xclbin_name, ptree);

--- a/src/runtime_src/core/tools/common/tests/TestNPUThroughput.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestNPUThroughput.cpp
@@ -25,6 +25,7 @@ boost::property_tree::ptree
 TestNPUThroughput::run(std::shared_ptr<xrt_core::device> dev)
 {
   boost::property_tree::ptree ptree = get_test_header();
+  ptree.erase("xclbin");
 
   const auto xclbin_name = xrt_core::device_query<xrt_core::query::xclbin_name>(dev, xrt_core::query::xclbin_name::type::validate);
   auto xclbin_path = findPlatformFile(xclbin_name, ptree);

--- a/src/runtime_src/core/tools/common/tests/TestTCTAllColumn.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestTCTAllColumn.cpp
@@ -72,6 +72,7 @@ boost::property_tree::ptree
 TestTCTAllColumn::run(std::shared_ptr<xrt_core::device> dev)
 {
   boost::property_tree::ptree ptree = get_test_header();
+  ptree.erase("xclbin");
 
   const auto xclbin_name = xrt_core::device_query<xrt_core::query::xclbin_name>(dev, xrt_core::query::xclbin_name::type::validate);
   auto xclbin_path = findPlatformFile(xclbin_name, ptree);

--- a/src/runtime_src/core/tools/common/tests/TestTCTOneColumn.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestTCTOneColumn.cpp
@@ -72,6 +72,7 @@ boost::property_tree::ptree
 TestTCTOneColumn::run(std::shared_ptr<xrt_core::device> dev)
 {
   boost::property_tree::ptree ptree = get_test_header();
+  ptree.erase("xclbin");
 
   const auto xclbin_name = xrt_core::device_query<xrt_core::query::xclbin_name>(dev, xrt_core::query::xclbin_name::type::validate);
   auto xclbin_path = findPlatformFile(xclbin_name, ptree);

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -252,8 +252,22 @@ get_ryzen_platform_info(const std::shared_ptr<xrt_core::device>& device,
 {
   ptTree.put("platform", xrt_core::device_query<xrt_core::query::rom_vbnv>(device));
   const auto mode = xrt_core::device_query_default<xrt_core::query::performance_mode>(device, 0);
-  ptTree.put("performance_mode", xrt_core::query::performance_mode::parse_status(mode));
-  ptTree.put("power", xrt_core::utils::format_base10_shiftdown6(xrt_core::device_query_default<xrt_core::query::power_microwatts>(device, 0)));
+  const std::string pmode = xrt_core::query::performance_mode::parse_status(mode);
+  if (boost::iequals(pmode, "DEFAULT")) {
+    ptTree.put("power_mode", "Default");
+  }
+  else if (boost::iequals(pmode, "LOW")) {
+    ptTree.put("power_mode", "Powersaver");
+  }
+  else if (boost::iequals(pmode, "MEDIUM")) {
+    ptTree.put("power_mode", "Balanced");
+  }
+  else if (boost::iequals(pmode, "HIGH")) {
+    ptTree.put("power_mode", "Performance");
+  }
+  else {
+    ptTree.put("power_mode", "N/A");
+  }
 }
 
 static void
@@ -284,9 +298,9 @@ get_platform_info(const std::shared_ptr<xrt_core::device>& device,
   const std::string& plat_id = ptTree.get("platform_id", "");
   if (!plat_id.empty())
     oStream << boost::format("    %-22s: %s\n") % "Platform ID" % plat_id;
-  const std::string& perf_mode = ptTree.get("performance_mode", "");
-  if (!perf_mode.empty())
-    oStream << boost::format("    %-22s: %s\n") % "Power Mode" % perf_mode;
+  const std::string& power_mode = ptTree.get("power_mode", "");
+  if (!power_mode.empty())
+    oStream << boost::format("    %-22s: %s\n") % "Power Mode" % power_mode;
   const std::string& power = ptTree.get("power", "");
   if (!boost::starts_with(power, ""))
     oStream << boost::format("    %-22s: %s Watts\n") % "Power" % power;


### PR DESCRIPTION
#### Problem solved by the commit
1) https://jira.xilinx.com/browse/CR-1206955 (Invalid power details in platform report json)
2) https://jira.xilinx.com/browse/CR-1206964 (Invalid validate details in validate json)
3) https://jira.xilinx.com/browse/CR-1207002 (Power Mode in output should match value)
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Discovered in xrt-smi internal testing
#### How problem was solved, alternative solutions (if any) and why they were rejected
1) Removed invalid power details from JSON. Only `power_consumption_watts` is used in ReportRyzenPlatform.
2) Removed invalid power detail (we do not display the power here to begin with, just the power mode). HOTFIX: erased empty xclbin entry from ptree in each Ryzen test so it doesn't show up in JSON. A better approach would be changing get_test_header to not include xclbin, but due to time constraints/wanting to minimize risk to Alveo tests, we opted to do this for now.
3) Performance Mode was corrected to Power Mode, and the values are as they should be: default, powersaver, balanced, and performance. This will also show up in the JSONs for the platform and validate jsons.
#### Risks (if any) associated the changes in the commit
N/A
#### What has been tested and how, request additional testing if necessary
Tested on MCDM\Strix. Please test again on a machine with valid BIOS/driver to verify actual power numbers.
CR-1206955
```
"platforms": [
                {
                    "static_region": {
                        "name": "NPU"
                    },
                    "clocks": [
                        {
                            "id": "H Clock",
                            "description": "System",
                            "freq_mhz": "800"
                        },
                        {
                            "id": "MP-IPU Clock",
                            "description": "System",
                            "freq_mhz": "400"
                        }
                    ],
                    "status": {
                        "power_mode": "Default"
                    },
                    "electrical": {
                        "power_consumption_watts": "0.000"
                    }
                }
            ],

```
CR-1206964
```
{
    "logical_devices": [
        {
            "device_id": "00c5:00:01.1",
            "platform": "NPU",
            "power_mode": "Default",
            "tests": [
                {
                    "name": "latency",
                    "description": "Run end-to-end latency test",
                    "explicit": "false",
                    "log": [
                        {
                            "Xclbin": "C:\\Windows\\System32\\DriverStore\\FileRepository\\ipukmddrv.inf_amd64_610833437bf5d1bc\\validate_17f0_10.xclbin"
                        },
                        {
                            "Details": "Average latency: '127.2' us"
                        }
                    ],
                    "status": "PASSED"
                },
                {
                    "name": "throughput",
                    "description": "Run end-to-end throughput test",
                    "explicit": "false",
                    "log": [
                        {
                            "Xclbin": "C:\\Windows\\System32\\DriverStore\\FileRepository\\ipukmddrv.inf_amd64_610833437bf5d1bc\\validate_17f0_10.xclbin"
                        },
                        {
                            "Details": "Average throughput: '9039.3' ops"
                        }
                    ],
                    "status": "PASSED"
                },
                {
                    "name": "cmd-chain-latency",
                    "description": "Run end-to-end latency test using command chaining",
                    "explicit": "false",
                    "log": [
                        {
                            "Xclbin": "C:\\Windows\\System32\\DriverStore\\FileRepository\\ipukmddrv.inf_amd64_610833437bf5d1bc\\validate_17f0_10.xclbin"
                        },
                        {
                            "Details": "Average latency: '9.1' us"
                        }
                    ],
                    "status": "PASSED"
                },
                {
                    "name": "cmd-chain-throughput",
                    "description": "Run end-to-end throughput test using command chaining",
                    "explicit": "false",
                    "log": [
                        {
                            "Xclbin": "C:\\Windows\\System32\\DriverStore\\FileRepository\\ipukmddrv.inf_amd64_610833437bf5d1bc\\validate_17f0_10.xclbin"
                        },
                        {
                            "Details": "Average throughput: '108879.2' ops"
                        }
                    ],
                    "status": "PASSED"
                },
                {
                    "name": "df-bw",
                    "description": "Run bandwidth test on data fabric",
                    "explicit": "false",
                    "log": [
                        {
                            "Xclbin": "C:\\Windows\\System32\\DriverStore\\FileRepository\\ipukmddrv.inf_amd64_610833437bf5d1bc\\validate_17f0_10.xclbin"
                        },
                        {
                            "DPU-Sequence": "C:\\Windows\\System32\\DriverStore\\FileRepository\\ipukmddrv.inf_amd64_610833437bf5d1bc\\DPU_Sequence\/df_bw.txt"
                        },
                        {
                            "Details": "Average bandwidth per shim DMA: '54.5' GB\/s"
                        }
                    ],
                    "status": "PASSED"
                },
                {
                    "name": "tct-one-col",
                    "description": "Measure average TCT processing time for one column",
                    "explicit": "false",
                    "log": [
                        {
                            "Xclbin": "C:\\Windows\\System32\\DriverStore\\FileRepository\\ipukmddrv.inf_amd64_610833437bf5d1bc\\validate_17f0_10.xclbin"
                        },
                        {
                            "DPU-Sequence": "C:\\Windows\\System32\\DriverStore\\FileRepository\\ipukmddrv.inf_amd64_610833437bf5d1bc\\DPU_Sequence\/tct_1col.txt"
                        },
                        {
                            "Details": "Average TCT throughput: '398577.9' TCT\/s"
                        }
                    ],
                    "status": "PASSED"
                },
                {
                    "name": "tct-all-col",
                    "description": "Measure average TCT processing time for all columns",
                    "explicit": "false",
                    "log": [
                        {
                            "Xclbin": "C:\\Windows\\System32\\DriverStore\\FileRepository\\ipukmddrv.inf_amd64_610833437bf5d1bc\\validate_17f0_10.xclbin"
                        },
                        {
                            "DPU-Sequence": "C:\\Windows\\System32\\DriverStore\\FileRepository\\ipukmddrv.inf_amd64_610833437bf5d1bc\\DPU_Sequence\/tct_1col.txt"
                        },
                        {
                            "Details": "Average TCT throughput: '799628.9' TCT\/s"
                        }
                    ],
                    "status": "PASSED"
                },
                {
                    "name": "gemm",
                    "description": "Measure the TOPS value of GEMM operations",
                    "explicit": "false",
                    "log": [
                        {
                            "Xclbin": "C:\\Windows\\System32\\DriverStore\\FileRepository\\ipukmddrv.inf_amd64_610833437bf5d1bc\\gemm_17f0_10.xclbin"
                        },
                        {
                            "Details": "Kernel name is 'DPU_1x4'"
                        },
                        {
                            "Details": "TOPS: '49.7'"
                        }
                    ],
                    "status": "PASSED"
                }
            ]
        }
    ]
}
```
CR-1207002 (Tried w/ all settings of power mode)
```
C:\Users\rchane\Desktop\xrt>xrt-smi configure --pmode performance

Power mode is set to performance

C:\Users\rchane\Desktop\xrt>xrt-smi examine -r platform -f JSON -o a.json --force

---------------------
[00c5:00:01.1] : NPU
---------------------
Platform
  Name                   : NPU
  Power Mode             : Performance

Clocks
  H Clock                : 800 MHz
  MP-IPU Clock           : 400 MHz

Power                    : 0.000 Watts

Successfully wrote the JSON file: a.json

C:\Users\rchane\Desktop\xrt>xrt-smi validate -r latency -f JSON -o a.json --force
Validate Device           : [00c5:00:01.1]
    Platform              : NPU
    Power Mode            : Performance
-------------------------------------------------------------------------------
Verbose: Enabling Verbosity
Test 1 [00c5:00:01.1]     : latency
    Description           : Run end-to-end latency test
    Xclbin                : C:\Windows\System32\DriverStore\FileRepository\ipukmddrv.inf_amd64_610833437bf5d1bc\validate_17f0_10.xclbin
    Details               : Kernel name is 'DPU_PDI_0'
                            Instruction size: '20' bytes
                            No. of iterations: '10000'
                            Average latency: '111.0' us
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Validation completed
Successfully wrote the JSON file: a.json

```
#### Documentation impact (if any)
N/A