### PR TITLE
Cleaning up build artifacts in the end of the build

### DIFF
--- a/.github/workflows/xrt_ci.yml
+++ b/.github/workflows/xrt_ci.yml
@@ -185,7 +185,8 @@ jobs:
         with:    
           runNumber: ${{ github.run_number }}    
           pipeline: ${{ env.PIPELINE }}    
-          env: ${{ env.ENV }}  
+          env: ${{ env.ENV }}
+          release: ${{ env.RELEASE }}  
           sshKey: ${{ secrets.CI_PRIVATE_SSH_KEY }}    
           accessToken: ${{ secrets.ACCESS_TOKEN }}
           NPATH: ${{ secrets.NPATH }}
@@ -357,4 +358,30 @@ jobs:
       - name: Print test summary URL 
         run: |    
           # echo "test summary URL: ${{ steps.summary.outputs.url }}" >> $GITHUB_STEP_SUMMARY    
-          echo '### [tests logs summary](${{ steps.summary.outputs.url }})' >> $GITHUB_STEP_SUMMARY      
+          echo '### [tests logs summary](${{ steps.summary.outputs.url }})' >> $GITHUB_STEP_SUMMARY 
+
+  cleanup-build:    
+    needs: test-summary    
+    runs-on: [self-hosted, Ubuntu-22.04]    
+    steps:    
+      - name: Checkout private repository    
+        uses: actions/checkout@v3 
+        with:    
+          repository: actions-int/composite-workflows    
+          token: ${{ secrets.ACCESS_TOKEN }}
+          github-server-url: ${{ secrets.SERVER_URL }}    
+          path: composite-workflows 
+          ref: main
+    
+      - name: Use composite action package download     
+        uses: ./composite-workflows/cleanup   
+        with:    
+          runNumber: ${{ github.run_number }}    
+          pipeline: ${{ env.PIPELINE }}    
+          env: ${{ env.ENV }}
+          release: ${{ env.RELEASE }}  
+          sshKey: ${{ secrets.CI_PRIVATE_SSH_KEY }}    
+          accessToken: ${{ secrets.ACCESS_TOKEN }}
+          NPATH: ${{ secrets.NPATH }}
+          USER: ${{ secrets.USER }}
+          github-server-url: ${{ secrets.SERVER_URL }}     

--- a/.github/workflows/xrt_master_2024.2.yml
+++ b/.github/workflows/xrt_master_2024.2.yml
@@ -56,7 +56,7 @@ jobs:
           github-server-url: ${{ secrets.SERVER_URL }}      
           token: ${{ secrets.ACCESS_TOKEN }}      
           path: composite-workflows 
-          ref: copy-packages-feature
+          ref: main
        
       - name: XRT build     
         uses: ./composite-workflows/build
@@ -104,7 +104,7 @@ jobs:
           github-server-url: ${{ secrets.SERVER_URL }}      
           token: ${{ secrets.ACCESS_TOKEN }}      
           path: composite-workflows 
-          ref: copy-packages-feature
+          ref: main
        
       - name: XRT windows build     
         uses: ./composite-workflows/windows-build
@@ -149,7 +149,7 @@ jobs:
           token: ${{ secrets.ACCESS_TOKEN }}
           github-server-url: ${{ secrets.SERVER_URL }}       
           path: composite-workflows  
-          ref: copy-packages-feature
+          ref: main
        
       - name: Apu package build for XRT     
         uses: ./composite-workflows/apu-package
@@ -184,14 +184,15 @@ jobs:
           token: ${{ secrets.ACCESS_TOKEN }}
           github-server-url: ${{ secrets.SERVER_URL }}    
           path: composite-workflows 
-          ref: copy-packages-feature
+          ref: main
     
       - name: Use composite action package download     
         uses: ./composite-workflows/package-download   
         with:    
           runNumber: ${{ env.XRT_VERSION_PATCH }}    
           pipeline: ${{ env.PIPELINE }}    
-          env: ${{ env.ENV }}  
+          env: ${{ env.ENV }}
+          release_branch: ${{ env.RELEASE }}  
           sshKey: ${{ secrets.CI_PRIVATE_SSH_KEY }}    
           accessToken: ${{ secrets.ACCESS_TOKEN }}
           NPATH: ${{ secrets.NPATH }}
@@ -425,7 +426,7 @@ jobs:
           token: ${{ secrets.ACCESS_TOKEN }}
           github-server-url: ${{ secrets.SERVER_URL }}    
           path: composite-workflows 
-          ref: copy-packages-feature
+          ref: main
     
       - name: Use composite action package download     
         uses: ./composite-workflows/setenv   
@@ -468,7 +469,7 @@ jobs:
           token: ${{ secrets.ACCESS_TOKEN }}
           github-server-url: ${{ secrets.SERVER_URL }}    
           path: composite-workflows 
-          ref: copy-packages-feature
+          ref: main
     
       - name: Use composite action release-all-sites download     
         uses: ./composite-workflows/release-all-sites   
@@ -510,7 +511,7 @@ jobs:
           token: ${{ secrets.ACCESS_TOKEN }}
           github-server-url: ${{ secrets.SERVER_URL }}    
           path: composite-workflows 
-          ref: copy-packages-feature
+          ref: main
     
       - name: Use composite action release-all-sites download     
         uses: ./composite-workflows/release-all-sites   
@@ -545,7 +546,7 @@ jobs:
           token: ${{ secrets.ACCESS_TOKEN }}
           github-server-url: ${{ secrets.SERVER_URL }}    
           path: composite-workflows 
-          ref: copy-packages-feature
+          ref: main
 
       - name: Use composite action artifactory upload     
         uses: ./composite-workflows/artifactory-upload   
@@ -587,7 +588,7 @@ jobs:
           token: ${{ secrets.ACCESS_TOKEN }}
           github-server-url: ${{ secrets.SERVER_URL }}    
           path: composite-workflows 
-          ref: copy-packages-feature
+          ref: main
     
       - name: Use composite action package download     
         uses: ./composite-workflows/gradle-artifactory-upload   

--- a/.github/workflows/xrt_master_2024.2.yml
+++ b/.github/workflows/xrt_master_2024.2.yml
@@ -192,7 +192,7 @@ jobs:
           runNumber: ${{ env.XRT_VERSION_PATCH }}    
           pipeline: ${{ env.PIPELINE }}    
           env: ${{ env.ENV }}
-          release_branch: ${{ env.RELEASE }}  
+          release: ${{ env.RELEASE }}  
           sshKey: ${{ secrets.CI_PRIVATE_SSH_KEY }}    
           accessToken: ${{ secrets.ACCESS_TOKEN }}
           NPATH: ${{ secrets.NPATH }}
@@ -603,6 +603,32 @@ jobs:
           github-server-url: ${{ secrets.SERVER_URL }}
           sshKey: ${{ secrets.CI_PRIVATE_SSH_KEY }}
           runnerName: ${{ runner.name }}
+
+  cleanup-build:    
+    needs: [Release_to_all_sites, gradle-artifactory-upload]    
+    runs-on: [self-hosted, Ubuntu-22.04]    
+    steps:    
+      - name: Checkout private repository    
+        uses: actions/checkout@v3 
+        with:    
+          repository: actions-int/composite-workflows    
+          token: ${{ secrets.ACCESS_TOKEN }}
+          github-server-url: ${{ secrets.SERVER_URL }}    
+          path: composite-workflows 
+          ref: main
+    
+      - name: Use composite action package download     
+        uses: ./composite-workflows/cleanup   
+        with:    
+          runNumber: ${{ github.run_number }}    
+          pipeline: ${{ env.PIPELINE }}    
+          env: ${{ env.ENV }}
+          release: ${{ env.RELEASE }}  
+          sshKey: ${{ secrets.CI_PRIVATE_SSH_KEY }}    
+          accessToken: ${{ secrets.ACCESS_TOKEN }}
+          NPATH: ${{ secrets.NPATH }}
+          USER: ${{ secrets.USER }}
+          github-server-url: ${{ secrets.SERVER_URL }}
 
   notify-slack:  
     needs: [Release_to_all_sites, gradle-artifactory-upload]  


### PR DESCRIPTION

This issue address the SR-956183 by cleaning up the build artifacts at the end of the build and using fully qualified path name for the artifacts location avoiding duplicate artifacts to be present in the TA