### PR TITLE
Use find_package for OpenCL

### DIFF
--- a/src/CMake/nativeLnx.cmake
+++ b/src/CMake/nativeLnx.cmake
@@ -23,7 +23,7 @@ ENDIF(DRM_FOUND)
 
 
 # --- OpenCL header files ---
-pkg_check_modules(OPENCL REQUIRED OpenCL)
+find_package(OpenCL)
 IF(OPENCL_FOUND)
   MESSAGE(STATUS "Looking for OPENCL - found at ${OPENCL_PREFIX} ${OPENCL_VERSION} ${OPENCL_INCLUDEDIR}")
   INCLUDE_DIRECTORIES(${OPENCL_INCLUDEDIR})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Used find_package for finding OpenCL package instead of pkg_check_modules
find_package is is generally preferred for better integration with CMake’s ecosystem and also with latest yocto release pkg_check_modules doesn't work properly to find opencl-headers, so replacing it  

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Discovered while building xrt natively(for x86) using petalinux/yocto, occurs only when we move to latest versions of petalinux/yocto

#### How problem was solved, alternative solutions (if any) and why they were rejected
#### Risks (if any) associated the changes in the commit
None as replaced with similar functionality

#### What has been tested and how, request additional testing if necessary
Tested build for x86 and OpenCL headers are found, build passes

#### Documentation impact (if any)
NA