### PR TITLE
CR-1206957, CR-1206959 & CR-1206962

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_types.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_types.h
@@ -1,8 +1,6 @@
 /*
  * Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
  *
- * Authors: daniel.benusovich@amd.com
- *
  * This software is licensed under the terms of the GNU General Public
  * License version 2, as published by the Free Software Foundation, and
  * may be copied, distributed, and modified under those terms.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
- [CR-1206959](https://jira.xilinx.com/browse/CR-1206959) Remove options for param (-param) from xrt-smi validate
- [CR-1206957](https://jira.xilinx.com/browse/CR-1206957) Remove options for path (-p) from xrt-smi validate
- [CR-1206962](https://jira.xilinx.com/browse/CR-1206962) Remove options for ExtendedKeys (dma) from xrt-smi validate
- Remove internal author email (requested by legal scan)

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
DSV testing: unused options

#### How problem was solved, alternative solutions (if any) and why they were rejected
Moved these alveo specific options to hidden commands so they don't show up on ryzen

#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
Tested on linux:
```
xbutil validate --help
----------------------------------------------------------------------
                              WARNING:
                xbutil has been renamed to xrt-smi
        Please migrate to using xrt-smi instead of xbutil.

    Commands, options, arguments and their descriptions can also be 
                    reported via the --help option.
----------------------------------------------------------------------

COMMAND: validate

DESCRIPTION: Validates the given device by executing the platform's validate executable.

USAGE: xrt-smi validate [--help] [-d arg] [-f arg] [-o arg] [-r arg]

OPTIONS:
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest
  -f, --format       - Report output format. Valid values are:
                         JSON        - Latest JSON schema
                         JSON-2020.2 - JSON 2020.2 schema
  -o, --output       - Direct the output to the given file
  --help             - Help to use this sub-command
  -r, --run          - Run a subset of the test suite. Valid options are:
                       Common:
                         all                  - All applicable validate tests will be executed
                                                (default)
                         quick                - Only the first 4 tests will be executed
                       AIE:
                         cmd-chain-latency    - Run end-to-end latency test using command chaining
                         cmd-chain-throughput - Run end-to-end throughput test using command
                                                chaining
                         df-bw                - Run bandwidth test on data fabric
                         gemm                 - Measure the TOPS value of GEMM operations
                         latency              - Run end-to-end latency test
                         tct-all-col          - Measure average TCT processing time for all
                                                columns
                         tct-one-col          - Measure average TCT processing time for one column
                         throughput           - Run end-to-end throughput test
                       Alveo:
                         aie                  - Run AIE PL test
                         aux-connection       - Check if auxiliary power is connected
                         dma                  - Run dma test
                         hostmem-bw           - Run 'bandwidth kernel' when host memory is enabled
                         iops                 - Run scheduler performance measure test
                         m2m                  - Run M2M test
                         mem-bw               - Run 'bandwidth kernel' and check the throughput
                         p2p                  - Run P2P test
                         pcie-link            - Check if PCIE link is active
                         sc-version           - Check if SC firmware is up-to-date
                         vcu                  - Run decoder test
                         verify               - Run 'Hello World' kernel test


GLOBAL OPTIONS:
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
```

#### Documentation impact (if any)
N/A
