### PR TITLE
fixing the location of event time recording

### DIFF
--- a/src/runtime_src/hip/core/event.cpp
+++ b/src/runtime_src/hip/core/event.cpp
@@ -52,6 +52,7 @@ bool event::synchronize()
   }
   //then the event is considered as completed
   set_state(state::completed);
+  ctime = std::chrono::system_clock::now();
 
   //all commands depend on the event start running
   std::lock_guard ch_lock(m_mutex_chain_coms);
@@ -63,7 +64,6 @@ bool event::synchronize()
 
 bool event::wait()
 {
-  ctime = std::chrono::system_clock::now();
   state event_state = get_state();
   if (event_state < state::completed)
   {


### PR DESCRIPTION
Fixed where we stamp the recording time of the event

Problem solved by the commit
Fixed the time stamp point for event

Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
It was discovered during the test

How problem was solved, alternative solutions (if any) and why they were rejected
Changing where we stamp the time for the event

Risks (if any) associated the changes in the commit
None. Code will only be built with switch "-hip".

What has been tested and how, request additional testing if necessary

Documentation impact (if any)
None.