### PR TITLE
CI/CD: providing release input to setenv composite action for 2024.1

### DIFF
--- a/.github/workflows/xrt_master.yml
+++ b/.github/workflows/xrt_master.yml
@@ -435,6 +435,7 @@ jobs:
           runNumber: ${{ env.XRT_VERSION_PATCH }}    
           pipeline: ${{ env.PIPELINE }}    
           env: ${{ env.ENV }}
+          release: ${{ env.RELEASE }}
           workspace: ${{ github.workspace }}  
           buildNumber: ${{ env.XRT_VERSION_PATCH }}
           github_sha: ${{ github.sha }}


### PR DESCRIPTION
providing release input to setenv composite action to get inline with the feature added as part of https://github.com/Xilinx/XRT/pull/8320
