### PR TITLE
Starting Event trace from specific layer

### DIFF
--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -863,6 +863,13 @@ get_aie_trace_settings_start_iteration()
   return value;
 }
 
+inline unsigned int
+get_aie_trace_settings_start_layer()
+{
+  static unsigned int value = detail::get_uint_value("AIE_trace_settings.start_layer", UINT_MAX);
+  return value;
+}
+
 inline std::string
 get_aie_trace_settings_graph_based_aie_tile_metrics()
 {

--- a/src/runtime_src/xdp/profile/database/static_info/aie_util.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info/aie_util.cpp
@@ -397,4 +397,38 @@ namespace xdp::aie {
     return startCols;
   }
 
+  std::vector<uint8_t> getPartitionNumColumsClient(void* handle)
+  {
+    std::vector<uint8_t> numCols;
+
+    try {
+      xrt::hw_context context = xrt_core::hw_context_int::create_hw_context_from_implementation(handle);
+      auto device = xrt_core::hw_context_int::get_core_device(context);
+      if (device==nullptr)
+        return std::vector<uint8_t>{0};
+
+      auto infoVector = xrt_core::device_query<xrt_core::query::aie_partition_info>(device.get());
+      if (infoVector.empty()) {
+        xrt_core::message::send(severity_level::info, "XRT", "No AIE partition information found.");
+        return std::vector<uint8_t>{0};
+      }
+
+      for (auto& info : infoVector) {
+        auto numCol = static_cast<uint8_t>(info.num_cols);
+        auto startCol = static_cast<uint8_t>(info.start_col);
+        xrt_core::message::send(severity_level::info, "XRT",
+            "Partition shift of " + std::to_string(startCol) +
+            " was found, number of columns: " + std::to_string(info.num_cols));
+        numCols.push_back(numCol);
+      }
+    }
+    catch(...) {
+      // Query not available
+      xrt_core::message::send(severity_level::info, "XRT", "Unable to query AIE partition information.");
+      return std::vector<uint8_t>{0};
+    }
+
+    return numCols;
+  }
+
 } // namespace xdp::aie

--- a/src/runtime_src/xdp/profile/database/static_info/aie_util.h
+++ b/src/runtime_src/xdp/profile/database/static_info/aie_util.h
@@ -97,6 +97,9 @@ namespace xdp::aie {
   XDP_CORE_EXPORT
   std::vector<uint8_t> getPartitionStartColumnsClient(void* handle);
 
+  XDP_CORE_EXPORT
+  std::vector<uint8_t> getPartitionNumColumsClient(void* handle);
+
 } // namespace xdp::aie
 
 #endif

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/client/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/client/aie_trace.cpp
@@ -220,6 +220,144 @@ namespace xdp {
     transactionHandler = std::make_unique<aie::ClientTransaction>(context, "AIE Trace Setup");
   }
 
+
+  void AieTrace_WinImpl::build2ChannelBroadcastNetwork(void *handle, uint8_t broadcastId1, uint8_t broadcastId2, XAie_Events event) {
+
+    auto partitionCols = xdp::aie::getPartitionStartColumnsClient(handle);
+    uint8_t startCol = partitionCols[0];
+    auto numColsVec = xdp::aie::getPartitionNumColumsClient(handle);
+    uint8_t numCols = numColsVec[0];
+
+    std::vector<uint8_t> maxRowAtCol(startCol + numCols, 0);
+    for (auto& tileMetric : metadata->getConfigMetrics()) {
+      auto tile       = tileMetric.first;
+      auto col        = tile.col;
+      auto row        = tile.row;
+      maxRowAtCol[startCol + col] = std::max(maxRowAtCol[col], (uint8_t)row);
+    }
+
+    XAie_Events bcastEvent2_PL =  (XAie_Events) (XAIE_EVENT_BROADCAST_A_0_PL + broadcastId2);
+    XAie_EventBroadcast(&aieDevInst, XAie_TileLoc(0, 0), XAIE_PL_MOD, broadcastId2, event);
+
+    for(uint8_t col = startCol; col < startCol + numCols; col++) {
+      for(uint8_t row = 0; row <= maxRowAtCol[col]; row++) {
+        module_type tileType = getTileType(row);
+        auto loc = XAie_TileLoc(col, row);
+
+        if(tileType == module_type::shim) {
+          // first channel is only used to send north
+          if(col == startCol) {
+            XAie_EventBroadcast(&aieDevInst, loc, XAIE_PL_MOD, broadcastId1, event);
+          }
+          else {
+            XAie_EventBroadcast(&aieDevInst, loc, XAIE_PL_MOD, broadcastId1, bcastEvent2_PL);
+          }
+          if(maxRowAtCol[col] != row) {
+            XAie_EventBroadcastBlockDir(&aieDevInst, loc, XAIE_PL_MOD, XAIE_EVENT_SWITCH_A, broadcastId1, XAIE_EVENT_BROADCAST_SOUTH | XAIE_EVENT_BROADCAST_WEST | XAIE_EVENT_BROADCAST_EAST);
+          }
+          else {
+            XAie_EventBroadcastBlockDir(&aieDevInst, loc, XAIE_PL_MOD, XAIE_EVENT_SWITCH_A, broadcastId1, XAIE_EVENT_BROADCAST_SOUTH | XAIE_EVENT_BROADCAST_WEST | XAIE_EVENT_BROADCAST_EAST | XAIE_EVENT_BROADCAST_NORTH);
+          }
+
+          // second channel is only used to send east
+          XAie_EventBroadcastBlockDir(&aieDevInst, loc, XAIE_PL_MOD, XAIE_EVENT_SWITCH_A, broadcastId2, XAIE_EVENT_BROADCAST_SOUTH | XAIE_EVENT_BROADCAST_WEST | XAIE_EVENT_BROADCAST_NORTH);
+          
+          if(col != startCol + numCols - 1) {
+            XAie_EventBroadcastBlockDir(&aieDevInst, loc, XAIE_PL_MOD, XAIE_EVENT_SWITCH_B, broadcastId2, XAIE_EVENT_BROADCAST_SOUTH | XAIE_EVENT_BROADCAST_WEST | XAIE_EVENT_BROADCAST_NORTH);
+          }
+          else {
+            XAie_EventBroadcastBlockDir(&aieDevInst, loc, XAIE_PL_MOD, XAIE_EVENT_SWITCH_B, broadcastId2, XAIE_EVENT_BROADCAST_SOUTH | XAIE_EVENT_BROADCAST_WEST | XAIE_EVENT_BROADCAST_NORTH | XAIE_EVENT_BROADCAST_EAST);
+          }
+        }
+        else if(tileType == module_type::mem_tile) {
+          if(maxRowAtCol[col] != row) {
+            XAie_EventBroadcastBlockDir(&aieDevInst, loc, XAIE_MEM_MOD, XAIE_EVENT_SWITCH_A, broadcastId1, XAIE_EVENT_BROADCAST_SOUTH | XAIE_EVENT_BROADCAST_WEST | XAIE_EVENT_BROADCAST_EAST);
+          }
+          else {
+            XAie_EventBroadcastBlockDir(&aieDevInst, loc, XAIE_MEM_MOD, XAIE_EVENT_SWITCH_A, broadcastId1, XAIE_EVENT_BROADCAST_SOUTH | XAIE_EVENT_BROADCAST_WEST | XAIE_EVENT_BROADCAST_EAST | XAIE_EVENT_BROADCAST_NORTH);
+          }
+        }
+        else { //core tile
+          if(maxRowAtCol[col] != row) {
+            XAie_EventBroadcastBlockDir(&aieDevInst, loc, XAIE_CORE_MOD, XAIE_EVENT_SWITCH_A, broadcastId1, XAIE_EVENT_BROADCAST_SOUTH | XAIE_EVENT_BROADCAST_WEST);
+          }
+          else {
+            XAie_EventBroadcastBlockDir(&aieDevInst, loc, XAIE_CORE_MOD, XAIE_EVENT_SWITCH_A, broadcastId1, XAIE_EVENT_BROADCAST_SOUTH | XAIE_EVENT_BROADCAST_WEST | XAIE_EVENT_BROADCAST_NORTH);
+          }
+          XAie_Events memTraceStartEvent = (XAie_Events)(XAIE_EVENT_BROADCAST_0_MEM + broadcastId1);
+          XAie_EventBroadcastBlockDir(&aieDevInst, loc, XAIE_MEM_MOD,  XAIE_EVENT_SWITCH_A, broadcastId1, XAIE_EVENT_BROADCAST_SOUTH | XAIE_EVENT_BROADCAST_WEST | XAIE_EVENT_BROADCAST_EAST | XAIE_EVENT_BROADCAST_NORTH);
+        }
+      }
+    }
+  }
+
+  bool AieTrace_WinImpl::configureWindowedEventTrace(void* handle) {
+    //Start recording the transaction
+    XAie_StartTransaction(&aieDevInst, XAIE_TRANSACTION_DISABLE_AUTO_FLUSH);
+
+    auto partitionCols = xdp::aie::getPartitionStartColumnsClient(handle);
+    uint8_t startCol = partitionCols[0];
+
+    uint8_t broadcastId1 = 6;
+    uint8_t broadcastId2 = 7;
+
+    XAie_Events bcastEvent2_PL = (XAie_Events) (XAIE_EVENT_BROADCAST_A_0_PL + broadcastId2);
+    XAie_Events shimTraceStartEvent = bcastEvent2_PL;
+    XAie_Events memTileTraceStartEvent = (XAie_Events)(XAIE_EVENT_BROADCAST_0_MEM_TILE + broadcastId1);
+    XAie_Events coreModTraceStartEvent = (XAie_Events)(XAIE_EVENT_BROADCAST_0_CORE + broadcastId1);
+    XAie_Events memTraceStartEvent = (XAie_Events)(XAIE_EVENT_BROADCAST_0_MEM + broadcastId1);
+    
+    unsigned int startLayer = xrt_core::config::get_aie_trace_settings_start_layer();
+
+    // NOTE: rows are stored as absolute as required by resource manager
+    for (auto& tileMetric : metadata->getConfigMetrics()) {
+      auto tile       = tileMetric.first;
+      auto col        = tile.col;
+      auto row        = tile.row;
+      auto tileType       = getTileType(row);
+      auto loc        = XAie_TileLoc(col, row);
+      if(tileType == module_type::shim) {
+        if(startLayer != UINT_MAX) {
+          if(col == startCol) 
+            XAie_TraceStartEvent(&aieDevInst, loc, XAIE_PL_MOD, XAIE_EVENT_PERF_CNT_0_PL);
+          else 
+            XAie_TraceStartEvent(&aieDevInst, loc, XAIE_PL_MOD, shimTraceStartEvent);
+        }
+      }
+      else if(tileType == module_type::mem_tile) {
+        if(startLayer != UINT_MAX)
+          XAie_TraceStartEvent(&aieDevInst, loc, XAIE_MEM_MOD, memTileTraceStartEvent);
+      }
+      else {
+        if(startLayer != UINT_MAX) {
+          XAie_TraceStartEvent(&aieDevInst, loc, XAIE_CORE_MOD, coreModTraceStartEvent);
+          XAie_TraceStartEvent(&aieDevInst, loc, XAIE_MEM_MOD, memTraceStartEvent);
+        }
+      }
+    }
+
+    if(startLayer != UINT_MAX) {
+      XAie_PerfCounterControlSet(&aieDevInst, XAie_TileLoc(0, 0), XAIE_PL_MOD, 0, XAIE_EVENT_USER_EVENT_0_PL, XAIE_EVENT_USER_EVENT_0_PL);
+      XAie_PerfCounterEventValueSet(&aieDevInst, XAie_TileLoc(0, 0), XAIE_PL_MOD, 0, startLayer);
+    }
+
+    build2ChannelBroadcastNetwork(handle, broadcastId1, broadcastId2, XAIE_EVENT_PERF_CNT_0_PL);
+    
+    uint8_t *txn_ptr = XAie_ExportSerializedTransaction(&aieDevInst, 1, 0);
+
+    if (!transactionHandler->initializeKernel("XDP_KERNEL"))
+      return false;
+
+    if (!transactionHandler->submitTransaction(txn_ptr))
+      return false;
+    
+    // Must clear aie state
+    XAie_ClearTransaction(&aieDevInst);
+
+    xrt_core::message::send(severity_level::info, "XRT", "Finished AIE Winodwed Trace Settings. In client aie_trace.cpp");
+    return true;
+  }
+
   void AieTrace_WinImpl::updateDevice()
   {
     xrt_core::message::send(severity_level::info, "XRT", "Calling AIE Trace IPU updateDevice.");
@@ -233,6 +371,13 @@ namespace xdp {
       std::string msg("Unable to configure AIE trace control and events. No trace will be generated.");
       xrt_core::message::send(severity_level::warning, "XRT", msg);
       return;
+    }
+    if(xrt_core::config::get_aie_trace_settings_start_type() == "layer") {
+      if (!configureWindowedEventTrace(metadata->getHandle())) {
+        std::string msg("Unable to configure AIE Windowed event trace");
+        xrt_core::message::send(severity_level::warning, "XRT", msg);
+        return;
+      }
     }
   }
 
@@ -874,6 +1019,8 @@ namespace xdp {
     // NOTE: for now, assume a single partition
     auto partitionCols = xdp::aie::getPartitionStartColumnsClient(handle);
     uint8_t startCol = partitionCols.at(0);
+    std::string startType = xrt_core::config::get_aie_trace_settings_start_type();
+    unsigned int startLayer = xrt_core::config::get_aie_trace_settings_start_layer();
     
     //Start recording the transaction
     XAie_StartTransaction(&aieDevInst, XAIE_TRANSACTION_DISABLE_AUTO_FLUSH);
@@ -968,7 +1115,8 @@ namespace xdp {
         XAie_TraceModeConfig(&aieDevInst, loc, XAIE_CORE_MOD, XAIE_TRACE_INST_EXEC);
         XAie_TracePktConfig(&aieDevInst, loc, XAIE_CORE_MOD, pkt);
 
-        XAie_TraceStartEvent(&aieDevInst, loc, XAIE_CORE_MOD, coreTraceStartEvent);
+        if(startType != "layer" || startLayer ==  UINT_MAX)
+          XAie_TraceStartEvent(&aieDevInst, loc, XAIE_CORE_MOD, coreTraceStartEvent);
         (db->getStaticInfo()).addAIECfgTile(deviceId, cfgTile);
         continue;
       }
@@ -1089,7 +1237,8 @@ namespace xdp {
           break;
         if (XAie_TracePktConfig(&aieDevInst, loc, mod, pkt) != XAIE_OK)
           break;
-        XAie_TraceStartEvent(&aieDevInst, loc, mod, coreTraceStartEvent);
+        if(startType != "layer" || startLayer ==  UINT_MAX)
+          XAie_TraceStartEvent(&aieDevInst, loc, mod, coreTraceStartEvent);
       } // Core modules
 
       //
@@ -1274,8 +1423,10 @@ namespace xdp {
         //   break;
         if (XAie_TracePktConfig(&aieDevInst, loc, mod, pkt) != XAIE_OK)
           break;
-        if (XAie_TraceStartEvent(&aieDevInst, loc, mod, traceStartEvent) != XAIE_OK)
-          break;
+        if(startType != "layer" || startLayer ==  UINT_MAX) {
+          if (XAie_TraceStartEvent(&aieDevInst, loc, mod, traceStartEvent) != XAIE_OK)
+            break;
+        }
 
         // Update memory packet type in config file
         if (type == module_type::mem_tile)
@@ -1370,8 +1521,10 @@ namespace xdp {
         //   break;
         if (XAie_TracePktConfig(&aieDevInst, loc, mod, pkt) != XAIE_OK)
           break;
-        if (XAie_TraceStartEvent(&aieDevInst, loc, mod, interfaceTileTraceStartEvent) != XAIE_OK)
-          break;
+        if(startType != "layer" || startLayer ==  UINT_MAX) {
+          if (XAie_TraceStartEvent(&aieDevInst, loc, mod, interfaceTileTraceStartEvent) != XAIE_OK)
+            break;
+        }
         if (XAie_TraceStopEvent(&aieDevInst, loc, mod, interfaceTileTraceEndEvent) != XAIE_OK)
           break;
         cfgTile->interface_tile_trace_config.packet_type = packetType;

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/client/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/client/aie_trace.cpp
@@ -284,7 +284,6 @@ namespace xdp {
           else {
             XAie_EventBroadcastBlockDir(&aieDevInst, loc, XAIE_CORE_MOD, XAIE_EVENT_SWITCH_A, broadcastId1, XAIE_EVENT_BROADCAST_SOUTH | XAIE_EVENT_BROADCAST_WEST | XAIE_EVENT_BROADCAST_NORTH);
           }
-          XAie_Events memTraceStartEvent = (XAie_Events)(XAIE_EVENT_BROADCAST_0_MEM + broadcastId1);
           XAie_EventBroadcastBlockDir(&aieDevInst, loc, XAIE_MEM_MOD,  XAIE_EVENT_SWITCH_A, broadcastId1, XAIE_EVENT_BROADCAST_SOUTH | XAIE_EVENT_BROADCAST_WEST | XAIE_EVENT_BROADCAST_EAST | XAIE_EVENT_BROADCAST_NORTH);
         }
       }

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/client/aie_trace.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/client/aie_trace.h
@@ -45,6 +45,8 @@ namespace xdp {
                         const std::string metricSet, uint8_t channel, 
                         std::vector<XAie_Events>& events);
       bool setMetricsSettings(uint64_t deviceId, void* handle);
+      bool configureWindowedEventTrace(void* handle);
+      void build2ChannelBroadcastNetwork(void *handle, uint8_t broadcastId1, uint8_t broadcastId2, XAie_Events event);
       module_type getTileType(uint8_t row);
       uint16_t getRelativeRow(uint16_t absRow);
       uint32_t bcIdToEvent(int bcId);

--- a/src/runtime_src/xdp/profile/writer/vp_base/ini_parameters.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/ini_parameters.cpp
@@ -114,6 +114,9 @@ namespace xdp {
     addParameter("AIE_trace_settings.start_iteration",
                  xrt_core::config::get_aie_trace_settings_start_iteration(),
                  "Iteration count when graph type delay is used in AI Engine Trace");
+    addParameter("AIE_trace_settings.start_layer",
+                 xrt_core::config::get_aie_trace_settings_start_layer(),
+                 "layer wise windowed AI Engine Trace");
     addParameter("AIE_trace_settings.graph_based_aie_tile_metrics",
                  xrt_core::config::get_aie_trace_settings_graph_based_aie_tile_metrics(),
                  "Configuration level used for AI Engine trace per graph");


### PR DESCRIPTION
#### Problem solved by the commit
Overrun: While running an ML design, if there is any overrun of trace events in between, then there won't be any trace after the overrun. Instead of starting trace when the design starts, user can specify from which ML layer they want to start the trace. So that they can get the trace for layers which they were not able to before.
External Buffer size: For large ML designs, we need more space to store trace data. By only tracing range of layers, external buffer size for trace can be decreased.

#### How problem was solved, alternative solutions (if any) and why they were rejected
1.  A user event will be generated in shim tile (0,0) by controller after each layer end and start of the run.
2. Performance counter at shim (0,0) is configured to count the above event.
3. Through xrt.ini, user passes start layer.
4. An event broadcast network is used to broadcast an event to all tiles when performance counter reaches the start layer.
5. All the trace modules are configured to start when the broadcast event reaches them.

#### Risks (if any) associated the changes in the commit
No. Code will be executed only if user passes start_type=layer in xrt.ini
#### What has been tested and how, request additional testing if necessary
Tested resnet50 design on strix windows and partial resnet50 design on phoenix windows.