### PR TITLE
XRT OS Support for AlmaLinux 8 and pick correct python3 env if user is in virtualenv

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -36,9 +36,9 @@ if [[ $CPU == "aarch64" ]] && [[ $OSDIST == "ubuntu" ]]; then
     fi
 fi
 
-# Use GCC 9 on CentOS 8 and RHEL 8 for std::filesystem
+# Use GCC 9 on CentOS 8, RHEL 8, AlmaLinux 8 for std::filesystem
 # The dependency is installed by xrtdeps.sh
-if [[ $CPU == "x86_64" ]] && [[ $OSDIST == "centos" || $OSDIST == "rhel" ]] && [[ $MAJOR == 8 ]]; then
+if [[ $CPU == "x86_64" ]] && [[ $OSDIST == "centos" || $OSDIST == "rhel" || $OSDIST == "almalinux" ]] && [[ $MAJOR == 8 ]]; then
     source /opt/rh/gcc-toolset-9/enable
 fi
 

--- a/src/python/pybind11/CMakeLists.txt
+++ b/src/python/pybind11/CMakeLists.txt
@@ -16,6 +16,16 @@ if (CMAKE_VERSION VERSION_LESS "3.12")
   endif(PythonLibs_FOUND)
   set(HAS_PYTHON ${PythonLibs_FOUND})
 else()
+  if (DEFINED ENV{VIRTUAL_ENV})
+    # Virtual environment detected, use its Python
+    set(Python3_EXECUTABLE $ENV{VIRTUAL_ENV}/bin/python3)
+    message(STATUS "Virtual environment detected, using Python3: ${Python3_EXECUTABLE}")
+  else()
+    # No virtual environment, use system Python3
+    # In alma 8.10 python3.11 comes as a dependency but still pybind11 is installed to default python3.
+    set(Python3_EXECUTABLE /usr/bin/python3)
+  endif()
+
   find_package(Python3 COMPONENTS Development Interpreter)
   if (Python3_FOUND)
     message("-- Python libs version: ${Python3_VERSION}")
@@ -32,8 +42,8 @@ if (HAS_PYTHON)
   elseif (${LINUX_FLAVOR} MATCHES "^(rhel|centos|amzn|fedora|sles|almalinux)")
     SET(PKGDIR "site-packages")
   endif(${LINUX_FLAVOR} MATCHES "^(ubuntu|debian)")
+  find_package(pybind11 2.6.0 REQUIRED PATHS "$ENV{VIRTUAL_ENV}/lib/python${PYTHONLIBS_VERSION_MAJOR}.${PYTHONLIBS_VERSION_MINOR}/${PKGDIR}/pybind11" "/usr/local/lib/python${PYTHONLIBS_VERSION_MAJOR}.${PYTHONLIBS_VERSION_MINOR}/${PKGDIR}/pybind11" "/usr/lib/python${PYTHONLIBS_VERSION_MAJOR}.${PYTHONLIBS_VERSION_MINOR}/${PKGDIR}/pybind11")
 
-  find_package(pybind11 2.6.0 REQUIRED PATHS "/usr/local/lib/python${PYTHONLIBS_VERSION_MAJOR}.${PYTHONLIBS_VERSION_MINOR}/${PKGDIR}/pybind11" "/usr/lib/python${PYTHONLIBS_VERSION_MAJOR}.${PYTHONLIBS_VERSION_MINOR}/${PKGDIR}/pybind11")
 endif(HAS_PYTHON)
 
 if (pybind11_FOUND)

--- a/src/runtime_src/tools/scripts/xrtdeps.sh
+++ b/src/runtime_src/tools/scripts/xrtdeps.sh
@@ -624,6 +624,16 @@ prep_sles()
     fi
 }
 
+prep_alma8()
+{
+    echo "Enabling EPEL repository..."
+    yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+    yum check-update
+
+    echo "Enabling PowerTools repo for AlmaLinux8..."
+    dnf config-manager --set-enabled powertools
+}
+
 prep_alma9()
 {
     echo "Enabling EPEL repository..."
@@ -638,6 +648,8 @@ prep_alma()
 {
     if [ $MAJOR -ge 9 ]; then
         prep_alma9
+    elif [ $MAJOR == 8 ]; then
+        prep_alma8
     fi
 }
 
@@ -735,7 +747,7 @@ install()
         fi
     fi
 
-    if [[ $FLAVOR == "centos" || $FLAVOR == "rhel" ]] && [ $MAJOR -eq "8" ]; then
+    if [[ $FLAVOR == "centos" || $FLAVOR == "rhel" || $FLAVOR == "almalinux" ]] && [ $MAJOR -eq "8" ]; then
         yum install -y gcc-toolset-9-toolchain
     fi
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://github.com/Xilinx/XRT/issues/7909 xrtdeps.sh script installs the pybind11 dependency with the default python.  XRT build scripts always pick up the system python3 even if there is activate a virtualenv. In alma8.10 python3.11 comes as dependency while installing libdrm-devel package but still /usr/bin/python3 points to default python3. findpackage(Python3) is directly taking the newest version alothough few packages are not installed like python3.11-pip python3.11-devel, pybind11.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered


#### How problem was solved, alternative solutions (if any) and why they were rejected
setting python3 executable to /usr/bin/python3 as pybind11 is installed with this version. By adding appropiate checks in the build.sh file and modified xrtdeps.sh to identify the version for almalinux.

#### Risks (if any) associated the changes in the commit
low

#### What has been tested and how, request additional testing if necessary
Tested with u250 in ubuntu 22.04  and almalinux 8.10.

#### Documentation impact (if any)
Yes. We have to provide installatoin steps for almalinux