### PR TITLE
add support for kernel_commit_id in AIE_PARTITION

### DIFF
--- a/src/runtime_src/core/include/xclbin.h
+++ b/src/runtime_src/core/include/xclbin.h
@@ -621,9 +621,20 @@ extern "C" {
         uint8_t padding[4];
         uint64_t inference_fingerprint;     // The unique hash value of the inference function
         uint64_t pre_post_fingerprint;      // The unique hash value of pre post 
+        // 88
         struct aie_partition_info info;     // Partition information
+        // 8
         struct array_offset aie_pdi;        // PDI Array (aie_partition_info)
-        uint8_t reserved[54];               // Reserved
+        //   kernel_commit_id is modeled after mpo_name
+        //     This variable represents a zero terminated string
+        //     that is offseted from the beginning of the section.
+        //
+        //     The pointer to access the string is initialized as follows:
+        //     char * pCharString = (address_of_section) + (mpo value)
+        uint32_t kernel_commit_id;          //  
+        // uint8_t reserved[56];            // Reserved
+        // 56 - 4 = 52
+        uint8_t reserved[52];               // Reserved
     };
     XCLBIN_STATIC_ASSERT(sizeof(struct aie_partition) == 184, "aie_partition structure no longer is 184 bytes in size");
     XCLBIN_STATIC_ASSERT(sizeof(struct aie_partition) % sizeof(uint64_t) == 0, "aie_partition structure needs to be 64-bit word aligned");

--- a/src/runtime_src/core/include/xclbin.h
+++ b/src/runtime_src/core/include/xclbin.h
@@ -629,7 +629,7 @@ extern "C" {
         //
         //     The pointer to access the string is initialized as follows:
         //     char * pCharString = (address_of_section) + (mpo value)
-        uint32_t kernel_commit_id;          //  
+        uint32_t kernel_commit_id;          // The git repo commit id for DPU_PHX_KERNEL 
         uint8_t reserved[52];               // Reserved
     };
     XCLBIN_STATIC_ASSERT(sizeof(struct aie_partition) == 184, "aie_partition structure no longer is 184 bytes in size");

--- a/src/runtime_src/core/include/xclbin.h
+++ b/src/runtime_src/core/include/xclbin.h
@@ -621,9 +621,7 @@ extern "C" {
         uint8_t padding[4];
         uint64_t inference_fingerprint;     // The unique hash value of the inference function
         uint64_t pre_post_fingerprint;      // The unique hash value of pre post 
-        // 88
         struct aie_partition_info info;     // Partition information
-        // 8
         struct array_offset aie_pdi;        // PDI Array (aie_partition_info)
         //   kernel_commit_id is modeled after mpo_name
         //     This variable represents a zero terminated string
@@ -632,8 +630,6 @@ extern "C" {
         //     The pointer to access the string is initialized as follows:
         //     char * pCharString = (address_of_section) + (mpo value)
         uint32_t kernel_commit_id;          //  
-        // uint8_t reserved[56];            // Reserved
-        // 56 - 4 = 52
         uint8_t reserved[52];               // Reserved
     };
     XCLBIN_STATIC_ASSERT(sizeof(struct aie_partition) == 184, "aie_partition structure no longer is 184 bytes in size");

--- a/src/runtime_src/tools/xclbinutil/SectionAIEPartition.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionAIEPartition.cxx
@@ -376,9 +376,7 @@ process_partition_info(const boost::property_tree::ptree& ptAIEPartition,
 
   // Write out the 16-bit array.
   partitionInfo.start_columns.offset = static_cast<decltype(partitionInfo.start_columns.offset)>(heap.getNextBufferOffset());
-// #if 0
-  XUtil::TRACE(boost::str(boost::format("  start_column (0x%lx)") % partitionInfo.start_columns.offset));
-// #endif
+  // XUtil::TRACE(boost::str(boost::format("  start_column (0x%lx)") % partitionInfo.start_columns.offset));
   for (const auto element : startColumns)
     heap.write(reinterpret_cast<const char*>(&element), sizeof(uint16_t), false /*align*/);
 
@@ -417,14 +415,12 @@ createAIEPartitionImage(const std::string& sectionIndexName,
   aie_partitionHdr.operations_per_cycle = ptAIEPartition.get<uint32_t>("operations_per_cycle", 0);
   aie_partitionHdr.inference_fingerprint = ptAIEPartition.get<uint64_t>("inference_fingerprint", 0);
   aie_partitionHdr.pre_post_fingerprint = ptAIEPartition.get<uint64_t>("pre_post_fingerprint", 0);
-// #if 0
+
   // kernel_commit_id (modeled after mpo_name)
   aie_partitionHdr.kernel_commit_id = static_cast<decltype(aie_partitionHdr.kernel_commit_id)>(heap.getNextBufferOffset());
   auto sKernelCommitId = ptAIEPartition.get<std::string>("kernel_commit_id", "");
-  XUtil::TRACE(boost::str(boost::format("  kernel_commit_id (0x%lx): '%s'") % aie_partitionHdr.kernel_commit_id % sKernelCommitId));
+  // XUtil::TRACE(boost::str(boost::format("  kernel_commit_id (0x%lx): '%s'") % aie_partitionHdr.kernel_commit_id % sKernelCommitId));
   heap.write(sKernelCommitId.c_str(), sKernelCommitId.size() + 1 /*Null char*/);
-// #endif
-
 
   //  Process the nodes
   process_partition_info(ptAIEPartition, aie_partitionHdr.info, heap);
@@ -540,7 +536,6 @@ populate_cdo_groups(const char* pBase,
 
     // Name
     auto sName = reinterpret_cast<const char*>(pBase + element.mpo_name); 
-    // ptElement.put("name", reinterpret_cast<const char*>(pBase + element.mpo_name));
     ptElement.put("name", sName);
     XUtil::TRACE("Populating CDO group: " + std::string(sName));
 
@@ -656,7 +651,6 @@ writeAIEPartitionImage(const char* pBuffer,
   ptAiePartition.put("inference_fingerprint", (boost::format("%d") % pHdr->inference_fingerprint).str());
   ptAiePartition.put("pre_post_fingerprint", (boost::format("%d") % pHdr->pre_post_fingerprint).str());
 
-// #if 0
   // kernel_commit_id (modeled after mpo_name)
   // in order to be backward compatible with old xclbin which doesn't have
   // kernel_commit_id, we should make sure the offset is NOT 0
@@ -667,7 +661,6 @@ writeAIEPartitionImage(const char* pBuffer,
     XUtil::TRACE(boost::format("Open an existing xclbin: kernel_commit_id is 0x%lx") % pHdr->kernel_commit_id);
   }
   ptAiePartition.put("kernel_commit_id", sKernelCommitId);
-// #endif
 
   // Partition info
   populate_partition_info(pBuffer, pHdr->info, ptAiePartition);

--- a/src/runtime_src/tools/xclbinutil/unittests/AIEPartition/aie_partition.json
+++ b/src/runtime_src/tools/xclbinutil/unittests/AIEPartition/aie_partition.json
@@ -1,58 +1,59 @@
 {
-	"aie_partition": {
-        "operations_per_cycle": "135",
-        "inference_fingerprint": "23423",
-        "pre_post_fingerprint": "12345",
-		"partition": {
-			"column_width": 1,
-			"start_columns": [1, 2, 3, 4]
-		},
-		"PDIs": [{
-				"uuid": "00000000-0000-0000-0000-000000001110",
-				"file_name": "./1110.txt",
-				"cdo_groups": [{
-						"name": "DPU",
-						"type": "PRIMARY",
-						"pdi_id": "0xF0",
-						"dpu_kernel_ids": ["0x100"],
-						"pre_cdo_groups": ["0xC0"]
-					},
-					{
-						"name": "PP0",
-						"type": "LITE",
-						"pdi_id": "0xF1",
-						"dpu_kernel_ids": ["0x101"],
-						"pre_cdo_groups": ["0xC0"]
+  "aie_partition": {
+    "operations_per_cycle": "135",
+    "inference_fingerprint": "23423",
+    "pre_post_fingerprint": "12345",
+    "kernel_commit_id": "0123456789abcdef",
+    "partition": {
+      "column_width": 1,
+      "start_columns": [1, 2, 3, 4]
+    },
+    "PDIs": [{
+        "uuid": "00000000-0000-0000-0000-000000001110",
+        "file_name": "./1110.txt",
+        "cdo_groups": [{
+            "name": "DPU",
+            "type": "PRIMARY",
+            "pdi_id": "0xF0",
+            "dpu_kernel_ids": ["0x100"],
+            "pre_cdo_groups": ["0xC0"]
+          },
+          {
+            "name": "PP0",
+            "type": "LITE",
+            "pdi_id": "0xF1",
+            "dpu_kernel_ids": ["0x101"],
+            "pre_cdo_groups": ["0xC0"]
 
-					},
-					{
-						"name": "PP1",
-						"type": "LITE",
-						"pdi_id": "0xF2",
-						"dpu_kernel_ids": ["0x102"],
-						"pre_cdo_groups": ["0xC0"]
-					},
-					{
-						"name": "shared",
-						"pdi_id": "0xC0",
-						"pre_cdo_groups": ["0xC1"]
-					},
-					{
-						"name": "routing",
-						"pdi_id": "0xC1"
-					}
-				]
-			},
-			{
-				"uuid": "00000000-0000-0000-0000-000000001111",
-				"file_name": "./1111.txt",
-				"cdo_groups": [{
-					"name": "PP3",
-					"type": "LITE",
-					"pdi_id": "0xF1",
-					"dpu_kernel_ids": ["0x104", "0x105"]
-				}]
-			}
-		]
-	}
+          },
+          {
+            "name": "PP1",
+            "type": "LITE",
+            "pdi_id": "0xF2",
+            "dpu_kernel_ids": ["0x102"],
+            "pre_cdo_groups": ["0xC0"]
+          },
+          {
+            "name": "shared",
+            "pdi_id": "0xC0",
+            "pre_cdo_groups": ["0xC1"]
+          },
+          {
+            "name": "routing",
+            "pdi_id": "0xC1"
+          }
+        ]
+      },
+      {
+        "uuid": "00000000-0000-0000-0000-000000001111",
+        "file_name": "./1111.txt",
+        "cdo_groups": [{
+          "name": "PP3",
+          "type": "LITE",
+          "pdi_id": "0xF1",
+          "dpu_kernel_ids": ["0x104", "0x105"]
+        }]
+      }
+    ]
+  }
 }

--- a/src/runtime_src/tools/xclbinutil/unittests/AIEPartition/aie_partition_expected.json
+++ b/src/runtime_src/tools/xclbinutil/unittests/AIEPartition/aie_partition_expected.json
@@ -4,6 +4,7 @@
         "operations_per_cycle": "135",
         "inference_fingerprint": "23423",
         "pre_post_fingerprint": "12345",
+        "kernel_commit_id": "0123456789abcdef",
         "partition": {
             "column_width": "1",
             "start_columns": [


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1198828
The "kernel_commit_id" is for debug for xclbin. It is git repo commit for DPU_PHX_KERNEL repo that is the source code of xclbin generation. https://gitenterprise.xilinx.com/IPU/DPU_PHX_KERNEL.git

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
N/A

#### How problem was solved, alternative solutions (if any) and why they were rejected
Add a new field "kernel_commit_id" in AIE_PARTITION as requested

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Unit test and manual test

#### Documentation impact (if any)
None
