### PR TITLE
Integrate aiebu as a submodule into XRT

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "src/runtime_src/core/common/gsl"]
 	path = src/runtime_src/core/common/gsl
 	url = https://github.com/microsoft/GSL.git
+[submodule "src/runtime_src/core/common/aiebu"]
+	path = src/runtime_src/core/common/aiebu
+	url = https://github.com/Xilinx/aiebu.git

--- a/src/runtime_src/core/common/CMakeLists.txt
+++ b/src/runtime_src/core/common/CMakeLists.txt
@@ -6,6 +6,8 @@ add_subdirectory(xdp)
 
 if(CMAKE_VERSION VERSION_LESS "3.18.0")
   message(WARNING "CMake version is less than 3.18.0, build of submodule aiebu disabled")
+elseif(DEFINED XRT_AIE_BUILD)
+  message(WARNING "Edge Versal device, build of submodule aiebu disabled")
 else()
   add_subdirectory(aiebu)
 endif()

--- a/src/runtime_src/core/common/CMakeLists.txt
+++ b/src/runtime_src/core/common/CMakeLists.txt
@@ -4,6 +4,12 @@
 add_subdirectory(api)
 add_subdirectory(xdp)
 
+if(CMAKE_VERSION VERSION_LESS "3.18.0")
+  message(WARNING "CMake version is less than 3.18.0, build of submodule aiebu disabled")
+else()
+  add_subdirectory(aiebu)
+endif()
+
 add_library(core_common_library_objects OBJECT
   config_reader.cpp
   debug.cpp


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Integration aiebu as a submodule to provide AIE specific services to XRT. At the moment we merely compile aiebu without using any of its APIs from XRT.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
None

#### How problem was solved, alternative solutions (if any) and why they were rejected
Add aiebu as submodule and enable condition build (requires cmake >= 3.18.0)

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Build tested on Linux

#### Documentation impact (if any)
NA