### PR TITLE
Add signal() API to fence_handle

### DIFF
--- a/src/runtime_src/core/common/shim/fence_handle.h
+++ b/src/runtime_src/core/common/shim/fence_handle.h
@@ -4,6 +4,7 @@
 #define XRT_CORE_FENCE_HANDLE_H
 
 #include "core/common/shim/shared_handle.h"
+#include "core/common/error.h"
 
 #include "experimental/xrt_fence.h"
 
@@ -46,6 +47,13 @@ public:
   // This is a blocking call
   virtual void
   wait(uint32_t timeout_ms) const = 0;
+
+  // Signal a fence from host side
+  virtual void
+  signal() const
+  {
+    throw xrt_core::error(std::errc::not_supported, __func__);
+  }
 
   // Return the next state of the fence.  The next state is the value
   // that will be used when the fence is signaled or waited on.  The


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Adding signal() API to fence_handle class. It is good to have this API to make the interface symmetric (we have wait(), but no signal()). For now, we can keep it internal if we don't have use case. But, SHIM level test can leverage it to create test cases without relying on any implementation in driver.
