### PR TITLE
VITIS-11024 enable hw_context support for xrt::graph objects 4th commit

### DIFF
--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -433,7 +433,8 @@ public:
   void
   sync(xrt::bo& bo, const std::string& port, xclBOSyncDirection dir, size_t sz, size_t offset)
   {
-    device->sync_aie_bo(bo, port.c_str(), dir, sz, offset);
+    //call sync & async functions with "Buffer handle" instead of with device, so that it could be handled with both device & hwctx
+    handle->sync_aie_bo(bo, port.c_str(), dir, sz, offset);
   }
 
   xrt::bo::async_handle
@@ -611,7 +612,9 @@ xrt::bo::async_handle
 bo_impl::
 async(xrt::bo& bo, const std::string& port, xclBOSyncDirection dir, size_t sz, size_t offset)
 {
-  device->sync_aie_bo_nb(bo, port.c_str(), dir, sz, offset);
+  //call sync & async functions with "Buffer handle" instead of with device, so that it could be handled with both device & hwctx
+  handle->sync_aie_bo_nb(bo, port.c_str(), dir, sz, offset);
+
   auto a_bo_impl = std::make_shared<xrt::aie::bo::async_handle_impl>(bo, 0, port);
 
   return xrt::bo::async_handle{a_bo_impl};

--- a/src/runtime_src/core/common/ishim.h
+++ b/src/runtime_src/core/common/ishim.h
@@ -12,6 +12,7 @@
 #include "core/include/shim_int.h"
 #include "core/include/xdp/counters.h"
 #include "core/common/shim/graph_handle.h"
+#include "core/common/shim/profile_handle.h"
 
 #include "xrt/xrt_aie.h"
 #include "xrt/xrt_bo.h"
@@ -204,6 +205,12 @@ struct ishim
   {
     throw not_supported_error{__func__};
   }
+
+  virtual std::unique_ptr<profile_handle>
+  open_profile_handle()
+  {
+    throw not_supported_error{__func__};
+  }  
   ////////////////////////////////////////////////////////////////
 
   virtual void

--- a/src/runtime_src/core/common/shim/buffer_handle.h
+++ b/src/runtime_src/core/common/shim/buffer_handle.h
@@ -5,6 +5,8 @@
 
 #include "core/common/shim/shared_handle.h"
 #include "xrt.h"
+#include "xrt/xrt_bo.h"
+#include "core/common/error.h"
 
 #include <cstdint>
 #include <cstddef>
@@ -20,6 +22,8 @@ namespace xrt_core {
 class buffer_handle
 {
 public:
+
+  using bo_direction = xclBOSyncDirection;
   // map_type - determines how a buffer is mapped
   enum class map_type { read, write };
 
@@ -86,6 +90,18 @@ public:
   virtual void
   bind_at(size_t /*pos*/, const buffer_handle* /*bh*/, size_t /*offset*/, size_t /*size*/)
   {
+  }
+
+  virtual void
+  sync_aie_bo(xrt::bo&, const char *, bo_direction, size_t, size_t)
+  {
+    throw xrt_core::error(std::errc::not_supported, __func__);
+  }
+
+  virtual void
+  sync_aie_bo_nb(xrt::bo&, const char *, bo_direction, size_t, size_t)
+  {
+    throw xrt_core::error(std::errc::not_supported, __func__);
   }
 };
 

--- a/src/runtime_src/core/common/shim/hwctx_handle.h
+++ b/src/runtime_src/core/common/shim/hwctx_handle.h
@@ -8,6 +8,7 @@
 #include "core/common/shim/hwqueue_handle.h"
 #include "core/common/shim/shared_handle.h"
 #include "core/common/shim/graph_handle.h"
+#include "profile_handle.h"
 
 #include "xrt/xrt_hw_context.h"
 #include "xrt/xrt_graph.h"
@@ -96,6 +97,12 @@ public:
 
   virtual std::unique_ptr<xrt_core::graph_handle>
   open_graph_handle(const char*, xrt::graph::access_mode)
+  {
+    throw xrt_core::error(std::errc::not_supported, __func__);
+  }
+
+  virtual std::unique_ptr<xrt_core::profile_handle>
+  open_profile_handle()
   {
     throw xrt_core::error(std::errc::not_supported, __func__);
   }

--- a/src/runtime_src/core/common/shim/profile_handle.h
+++ b/src/runtime_src/core/common/shim/profile_handle.h
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+#ifndef XRT_CORE_PROFILE_HANDLE_H
+#define XRT_CORE_PROFILE_HANDLE_H
+
+#include <stdint.h>
+#include "core/common/error.h"
+
+namespace xrt_core {
+
+class profile_handle
+{
+public:
+  virtual int
+  start(int, const char*, const char*, uint32_t)
+  {
+    throw xrt_core::error(std::errc::not_supported, __func__);
+  }
+
+  virtual uint64_t
+  read()
+  {
+    throw xrt_core::error(std::errc::not_supported, __func__);
+  }
+
+  virtual void
+  stop()
+  {
+    throw xrt_core::error(std::errc::not_supported, __func__);
+  }
+  
+}; //profile_handle 
+
+} //namespace xrt_core
+#endif

--- a/src/runtime_src/core/edge/user/aie/profile_object.cpp
+++ b/src/runtime_src/core/edge/user/aie/profile_object.cpp
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+#include "profile_object.h"
+#include "core/edge/user/shim.h"
+
+static inline
+std::string value_or_empty(const char* s)
+{
+  return s == nullptr ? "" : s;
+}
+
+namespace zynqaie {
+		
+profile_object::
+profile_object(ZYNQ::shim* shim, Aie* aie_array)
+  : m_shim{shim},
+    m_aie_array{aie_array},
+    m_profile_id{invalid_profile_id}
+{}
+
+int
+profile_object::
+start(int option, const char* port1Name, const char* port2Name, uint32_t value)
+{	
+  auto device = xrt_core::get_userpf_device(m_shim);
+
+  if (!m_aie_array->is_context_set()) {
+    m_aie_array->open_context(device.get(), xrt::aie::access_mode::primary);
+  }
+  m_profile_id = m_aie_array->start_profiling(option, value_or_empty(port1Name), value_or_empty(port2Name), value);
+  return m_profile_id;
+}
+
+uint64_t
+profile_object::
+read()
+{
+  auto device = xrt_core::get_userpf_device(m_shim);
+
+  if (!m_aie_array->is_context_set()) {
+    m_aie_array->open_context(device.get(), xrt::aie::access_mode::primary);
+  }
+  return m_aie_array->read_profiling(m_profile_id); 
+}
+
+void
+profile_object::
+stop()
+{	
+  auto device = xrt_core::get_userpf_device(m_shim);
+
+  if (!m_aie_array->is_context_set()) {
+    m_aie_array->open_context(device.get(), xrt::aie::access_mode::primary);
+  }
+  m_aie_array->stop_profiling(m_profile_id);	
+}
+
+} //namespace zynqaie

--- a/src/runtime_src/core/edge/user/aie/profile_object.h
+++ b/src/runtime_src/core/edge/user/aie/profile_object.h
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+#ifndef _ZYNQ_PROFILE_OBJECT_H_
+#define _ZYNQ_PROFILE_OBJECT_H_
+
+#include "core/common/shim/profile_handle.h"
+#include <string>
+
+namespace ZYNQ {
+
+class shim;
+
+}
+
+namespace zynqaie {
+
+class Aie;
+
+class profile_object : public xrt_core::profile_handle
+{
+public:
+  static constexpr int invalid_profile_id = -1;
+  ZYNQ::shim* m_shim{nullptr}; 		
+  Aie* m_aie_array{nullptr};
+  int m_profile_id;
+
+  profile_object(ZYNQ::shim* shim, Aie* aie_array);
+
+  int
+  start(int option, const char* port1Name, const char* port2Name, uint32_t value) override;
+
+  uint64_t
+  read() override;
+
+  void
+  stop() override;
+
+}; //profile_object
+
+} // namespace zynqaie
+#endif

--- a/src/runtime_src/core/edge/user/device_linux.cpp
+++ b/src/runtime_src/core/edge/user/device_linux.cpp
@@ -13,6 +13,7 @@
 #ifdef XRT_ENABLE_AIE
 #include "core/edge/user/aie/graph_object.h"
 #endif
+#include "core/edge/user/aie/profile_object.h"
 #include <map>
 #include <memory>
 #include <string>
@@ -1138,7 +1139,27 @@ open_graph_handle(const xrt::uuid& xclbin_id, const char* name, xrt::graph::acce
    return std::make_unique<zynqaie::graph_object>(
                   static_cast<ZYNQ::shim*>(get_device_handle()), xclbin_id, name, am);
 #else
-   return nullptr;
+   throw xrt_core::error(std::errc::not_supported, __func__);;
+#endif   
+}
+
+std::unique_ptr<xrt_core::profile_handle>
+device_linux::
+open_profile_handle()
+{
+#ifdef XRT_ENABLE_AIE
+
+  auto drv = ZYNQ::shim::handleCheck(get_device_handle());
+
+  if (not drv->isAieRegistered())
+    throw xrt_core::error(-EINVAL, "No AIE presented");
+
+  auto aie_array = drv->getAieArray();
+
+  return std::make_unique<zynqaie::profile_object>(static_cast<ZYNQ::shim*>(get_device_handle()), aie_array);
+
+#else
+   throw xrt_core::error(std::errc::not_supported, __func__);
 #endif   
 }
 

--- a/src/runtime_src/core/edge/user/device_linux.h
+++ b/src/runtime_src/core/edge/user/device_linux.h
@@ -11,6 +11,7 @@
 #include "core/common/shim/shared_handle.h"
 #include "core/edge/common/device_edge.h"
 #include "core/common/shim/graph_handle.h"
+#include "core/common/shim/profile_handle.h"
 
 namespace xrt_core {
 
@@ -38,6 +39,9 @@ public:
 
   std::unique_ptr<xrt_core::graph_handle>
   open_graph_handle(const xrt::uuid& xclbin_id, const char* name, xrt::graph::access_mode am) override;
+
+  std::unique_ptr<xrt_core::profile_handle>
+  open_profile_handle() override;
 
   void
   get_device_info(xclDeviceInfo2 *info) override;

--- a/src/runtime_src/core/edge/user/hwctx_object.cpp
+++ b/src/runtime_src/core/edge/user/hwctx_object.cpp
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
 #include "hwctx_object.h"
+#include "core/edge/user/aie/profile_object.h"
 #ifdef XRT_ENABLE_AIE
 #include "core/edge/user/aie/graph_object.h"
+#include "core/edge/user/aie/aie.h"
 #endif
 #include "core/edge/user/shim.h"
 
@@ -17,20 +19,33 @@ namespace zynqaie {
 	  , m_uuid(std::move(uuid))
 	  , m_slotidx(slotidx)
 	  , m_mode(mode)
-  {}
+  {
+#ifdef XRT_ENABLE_AIE
+    auto device{xrt_core::get_userpf_device(m_shim)};
+    m_aie_array = std::make_unique<Aie>(device);
+#endif
+  }
+
+#ifdef XRT_ENABLE_AIE
+  Aie*
+  hwctx_object::get_aie_array_from_hwctx()
+  {
+    return m_aie_array.get();
+  }
+#endif
 
   std::unique_ptr<xrt_core::buffer_handle>
   hwctx_object::alloc_bo(void* userptr, size_t size, uint64_t flags)
   {
     // The hwctx is embedded in the flags, use regular shim path
-    return m_shim->xclAllocUserPtrBO(userptr, size, xcl_bo_flags{flags}.flags);
+    return m_shim->xclAllocUserPtrBO(userptr, size, xcl_bo_flags{flags}.flags, this);
   }
 
   std::unique_ptr<xrt_core::buffer_handle>
   hwctx_object::alloc_bo(size_t size, uint64_t flags)
   {
     // The hwctx is embedded in the flags, use regular shim path
-    return m_shim->xclAllocBO(size, xcl_bo_flags{flags}.flags);
+    return m_shim->xclAllocBO(size, xcl_bo_flags{flags}.flags, this);
   }
 
   xrt_core::cuidx_type
@@ -57,7 +72,18 @@ namespace zynqaie {
 #ifdef XRT_ENABLE_AIE    
     return std::make_unique<graph_object>(m_shim, m_uuid, name, am, this);
 #else
-    return nullptr;
+    throw xrt_core::error(std::errc::not_supported, __func__);
 #endif
   }
+
+  std::unique_ptr<xrt_core::profile_handle>
+  hwctx_object::open_profile_handle()
+  {
+#ifdef XRT_ENABLE_AIE    
+    return std::make_unique<profile_object>(m_shim, m_aie_array.get());
+#else
+    throw xrt_core::error(std::errc::not_supported, __func__);
+#endif
+  }
+
 }

--- a/src/runtime_src/core/edge/user/hwctx_object.h
+++ b/src/runtime_src/core/edge/user/hwctx_object.h
@@ -6,6 +6,7 @@
 #include "core/common/shim/hwctx_handle.h"
 #include "core/common/shim/shared_handle.h"
 #include "core/common/shim/graph_handle.h"
+#include "core/common/shim/profile_handle.h"
 
 // Shim handle for hardware context Even as hw_emu does not
 // support hardware context, it still must implement a shim
@@ -15,12 +16,17 @@ namespace ZYNQ {
 }
 
 namespace zynqaie {
+  class Aie;
+
   class hwctx_object : public xrt_core::hwctx_handle
   {
     ZYNQ::shim* m_shim;
     xrt::uuid m_uuid;
     slot_id m_slotidx;
     xrt::hw_context::access_mode m_mode;
+#ifdef XRT_ENABLE_AIE
+    std::unique_ptr<Aie> m_aie_array;
+#endif
 
   public:
     hwctx_object(ZYNQ::shim* shim, slot_id slotidx, xrt::uuid uuid, xrt::hw_context::access_mode mode);
@@ -72,6 +78,15 @@ namespace zynqaie {
 
     std::unique_ptr<xrt_core::graph_handle>
     open_graph_handle(const char* name, xrt::graph::access_mode am) override;
+
+    std::unique_ptr<xrt_core::profile_handle>
+    open_profile_handle() override;
+
+#ifdef XRT_ENABLE_AIE
+    Aie*
+    get_aie_array_from_hwctx();
+#endif
+
   }; // class hwctx_object
 }
 #endif

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -284,7 +284,7 @@ xclRead(xclAddressSpace space, uint64_t offset, void *hostBuf, size_t size)
 
 std::unique_ptr<xrt_core::buffer_handle>
 shim::
-xclAllocBO(size_t size, unsigned flags)
+xclAllocBO(size_t size, unsigned flags, xrt_core::hwctx_handle* hwctx_hdl)
 {
   drm_zocl_create_bo info = { size, 0xffffffff, flags};
   int result = ioctl(mKernelFD, DRM_IOCTL_ZOCL_CREATE_BO, &info);
@@ -295,12 +295,12 @@ xclAllocBO(size_t size, unsigned flags)
   xclLog(XRT_DEBUG, "%s: size %ld, flags 0x%x", __func__, size, flags);
   xclLog(XRT_INFO, "%s: ioctl return %d, bo handle %d", __func__, result, info.handle);
 
-  return std::make_unique<buffer_object>(this, info.handle);
+  return std::make_unique<buffer_object>(this, info.handle, hwctx_hdl);
 }
 
 std::unique_ptr<xrt_core::buffer_handle>
 shim::
-xclAllocUserPtrBO(void *userptr, size_t size, unsigned flags)
+xclAllocUserPtrBO(void *userptr, size_t size, unsigned flags, xrt_core::hwctx_handle* hwctx_hdl)
 {
   flags |= DRM_ZOCL_BO_FLAGS_USERPTR;
   drm_zocl_userptr_bo info = {reinterpret_cast<uint64_t>(userptr), size, 0xffffffff, flags};
@@ -312,7 +312,7 @@ xclAllocUserPtrBO(void *userptr, size_t size, unsigned flags)
   xclLog(XRT_DEBUG, "%s: userptr %p size %ld, flags 0x%x", __func__, userptr, size, flags);
   xclLog(XRT_INFO, "%s: ioctl return %d, bo handle %d", __func__, result, info.handle);
 
-  return std::make_unique<buffer_object>(this, info.handle);
+  return std::make_unique<buffer_object>(this, info.handle, hwctx_hdl);
 }
 
 unsigned int

--- a/src/runtime_src/core/include/xrt/xrt_aie.h
+++ b/src/runtime_src/core/include/xrt/xrt_aie.h
@@ -298,6 +298,9 @@ public:
   explicit
   profiling(const xrt::device& device);
 
+  explicit
+  profiling(const xrt::hw_context& hwctx);
+
   /**
    * start() - Start AIE performance profiling
    *


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

https://jira.xilinx.com/browse/VITIS-11024
currently we can load only one xclbin in graph supported devices , we cannot load multiple xclbins in multiple partitions in device..

  1) bo function calls sync / async added with hw ctx along with device specific
  2) profiling functions added with hw ctx along with device specific

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

N/A

#### How problem was solved, alternative solutions (if any) and why they were rejected

These third set of changes are enabling interface to support multiple xclbins in multiple partitions in device by creating "hardware context" associated with device id and xclbin. Interfaces are created for application developers and driver component owners to load mulitple xclbins in device by creating hardware context with particular device and particualr xclbin. New shim changes (driver changes) are required to fully utilize hardware context interfaces and fullfill actual requirements. currently used old shim by extracting device and xclbin from hardware context (loaded single device id with single xclbin)

#### Risks (if any) associated the changes in the commit

Documentation for this change might be required, should not break old flow where it still supports to load xclbin with device id. And as mentioned in above field new shim changes (driver changes) are required.

#### What has been tested and how, request additional testing if necessary

1. Tested with HW emulation graph gmio/plio with Device and Hw Context test cases
2. Tested Profile use case with device specific

[XRT] DEBUG: xclAllocBO: size 4096, flags 0x80000000
[XRT] INFO: xclAllocBO: ioctl return 0, bo handle 9
[XRT] INFO: xclMapBO: mmap return 0xffffb3643000
[XRT] DEBUG: xclExecBuf: cmdBO handle 9, ioctl return 0
run polar_clip
xrtGraphOpen lab8
xrtGraphOpen loopback
[XRT] DEBUG: xclAllocBO: size 128, flags 0x0
[XRT] INFO: xclAllocBO: ioctl return 0, bo handle 10
[XRT] INFO: xclMapBO: mmap return 0xffffb3642000
[XRT] DEBUG: xclAllocBO: size 128, flags 0x0
[XRT] INFO: xclAllocBO: ioctl return 0, bo handle 11
[XRT] INFO: xclMapBO: mmap return 0xffffb346f000
lab8 xrtGraphRun for 4 iterations
loopback xrtGraphRun for 1 iterations
[XRT] INFO: xclExportBO: boHandle 10, ioctl return 0, fd 29
[XRT] INFO: xclExportBO: boHandle 11, ioctl return 0, fd 30
mm2s_1 completed
mm2s_2 completed
polar clip completed
s2mm_1 completed
s2mm_2 completed
[XRT] DEBUG: xclSyncBO: boHandle 3, dir 1, size 4096, offset 0
[XRT] INFO: xclSyncBO: ioctl return 0
[XRT] DEBUG: xclSyncBO: boHandle 4, dir 1, size 128, offset 0
[XRT] INFO: xclSyncBO: ioctl return 0
TEST PASSED

#### Documentation impact (if any)

Graph doumentation may needs to be updated with "hwctx" things. And currently both kernel and graph support only c++ API's with "hardware context"