### PR TITLE
CR-1207237: Fixing issue where PL trace was not generated when running Edge Hardware Emulation

### DIFF
--- a/src/runtime_src/xdp/profile/device/utility.cpp
+++ b/src/runtime_src/xdp/profile/device/utility.cpp
@@ -52,7 +52,7 @@ namespace xdp { namespace util {
     } catch (const std::exception &) {
       xrt_core::message::send(xrt_core::message::severity_level::error, "XRT", "Failed to retrieve Debug IP Layout path");
     }
-    if (getFlowMode()==HW_EMU) {
+    if (getFlowMode()==HW_EMU && !isEdge()) {
       if (path!="") {
         // Full paths to the hardware emulation debug_ip_layout for different
         //  xclbins on the same device are different.  On disk, they are laid


### PR DESCRIPTION
#### Problem solved by the commit
PL device trace was not showing up in edge hardware emulation runs when the variable XCL_EMULATION_MODE was set to hw_emu.  The issue was due to a difference in where debug_ip_layout is located in Alveo HW emulation runs versus Edge HW emulation runs.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
PR 8260 recently introduced this bug when it solved an issue where two different profiling plugins were retrieving the debug_ip_layout file from different locations by unifying the checks into a single utility function.

#### How problem was solved, alternative solutions (if any) and why they were rejected
The utility function now only makes adjustments on the location of the debug_ip_layout if hardware emulation is set and we are not on Edge.

#### Risks (if any) associated the changes in the commit
Low risk as setting the environment variable in hardware emulation runs has no additional profiling impact at runtime.

#### What has been tested and how, request additional testing if necessary
The failing test cases have been verified.  Full regression on Alveo hardware emulation will have to be reverfied.

#### Documentation impact (if any)
No documentation impact.