### PR TITLE
Fixing issue in capturing OpenCL-level data transfer profiling information in Edge hardware emulation

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/device_offload/opencl/opencl_device_info_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/opencl/opencl_device_info_plugin.cpp
@@ -48,7 +48,7 @@ namespace {
     if (path == "")
       return path ;
 
-    if (xdp::getFlowMode() == xdp::HW_EMU) {
+    if (xdp::getFlowMode() == xdp::HW_EMU && !xdp::isEdge()) {
       // Full paths to the hardware emulation debug_ip_layout for different
       //  xclbins on the same device are different.  On disk, they are laid
       //  out as follows:


### PR DESCRIPTION
#### Problem solved by the commit
Edge hardware emulation test cases that have host code written at the OpenCL level and turned on device level information were losing the counter information we report on data transfers.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Pull request 8341 fixed an issue in device trace, but exposed an issue in the counters that are collected at the OpenCL level.  This was discovered when the regression test suite triggered a change in the summary file that profiling generates.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Since the OpenCL callbacks have different constructs passed to them than native XRT callbacks, there are separate functions for fetching the debug_ip_layout file.  The OpenCL version needed to be updated just as the native XRT version was in the previous pull request.

#### Risks (if any) associated the changes in the commit
Low, as the only impact should be on the memory transfer tables in the summary file.

#### What has been tested and how, request additional testing if necessary
The original failing design has been retested and both device trace and OpenCL level counter information are once again correctly captured.  The full regression suite should be run to capture any other descrepencies.

#### Documentation impact (if any)
No documentation impact.