### PR TITLE
fixing zynqmp build

### DIFF
--- a/src/runtime_src/core/common/CMakeLists.txt
+++ b/src/runtime_src/core/common/CMakeLists.txt
@@ -6,10 +6,10 @@ add_subdirectory(xdp)
 
 if(CMAKE_VERSION VERSION_LESS "3.18.0")
   message(WARNING "CMake version is less than 3.18.0, build of submodule aiebu disabled")
-elseif(DEFINED XRT_AIE_BUILD)
-  message(WARNING "Edge Versal device, build of submodule aiebu disabled")
-else()
+elseif (${XRT_NATIVE_BUILD} STREQUAL "yes")
   add_subdirectory(aiebu)
+else()
+  message(WARNING "Edge device, build of submodule aiebu disabled")
 endif()
 
 add_library(core_common_library_objects OBJECT


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Fixing ZynqMP builds. 

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Whenever aiebu is added as submodule of XRT, zynqmp builds started failing. 

#### How problem was solved, alternative solutions (if any) and why they were rejected
Enabling aiebu builds only for native builds

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Verified zynqmp and versal builds

#### Documentation impact (if any)
None