### PR TITLE
Changing default slot for PS kernels to Zero

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-bifurcation-reset.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-bifurcation-reset.c
@@ -157,7 +157,7 @@ done:
 static long xclmgmt_hot_reset_post(struct xclmgmt_dev *lro, bool force)
 {
 	long err = 0;
-	uint32_t legacy_slot_id = DEFAULT_PL_SLOT;
+	uint32_t legacy_slot_id = DEFAULT_PL_PS_SLOT;
 	struct xocl_board_private *dev_info = &lro->core.priv;
 	int retry = 0;
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
@@ -891,7 +891,7 @@ void xclmgmt_mailbox_srv(void *arg, void *data, size_t len,
 	u64 msgid, int err, bool sw_ch)
 {
 	int ret = 0;
-	uint32_t legacy_slot_id = DEFAULT_PL_SLOT;
+	uint32_t legacy_slot_id = DEFAULT_PL_PS_SLOT;
 	uint64_t ch_switch = 0;
 	struct xclmgmt_dev *lro = (struct xclmgmt_dev *)arg;
 	struct xcl_mailbox_req *req = (struct xcl_mailbox_req *)data;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-ioctl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-ioctl.c
@@ -99,7 +99,7 @@ static int bitstream_ioctl_axlf(struct xclmgmt_dev *lro, const void __user *arg)
 	}
 
 	/* Currently we are hard coding it to 0 */
-	ret = xocl_xclbin_download(lro, copy_buffer, DEFAULT_PL_SLOT);
+	ret = xocl_xclbin_download(lro, copy_buffer, DEFAULT_PL_PS_SLOT);
 	if (ret) {
 		vfree(copy_buffer);
 		return ret;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
@@ -2649,7 +2649,7 @@ static ssize_t read_temp_by_mem_topology(struct file *filp,
 	uint32_t *temp = NULL;
 	xdev_handle_t xdev = xocl_get_xdev(xmc->pdev);
 	struct xocl_drm *drm = XDEV(xdev)->drm;
-	uint32_t slot_id = DEFAULT_PL_SLOT;
+	uint32_t slot_id = DEFAULT_PL_PS_SLOT;
 
         if (!drm)
                 return 0;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc_u2.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc_u2.c
@@ -2475,7 +2475,7 @@ static ssize_t read_temp_by_mem_topology(struct file *filp,
 	size_t size = 0;
 	int ret = 0;
 	u32 i;
-	uint32_t slot_id = DEFAULT_PL_SLOT;
+	uint32_t slot_id = DEFAULT_PL_PS_SLOT;
 	struct mem_topology *memtopo = NULL;
 	struct xocl_xmc *xmc =
 		dev_get_drvdata(container_of(kobj, struct device, kobj));

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
@@ -1541,7 +1541,7 @@ int xocl_usage_stat_ioctl(struct drm_device *dev, void *data,
 	int	i;
 
 	/* Use default slot id for DMA information */
-	args->mm_channel_count = XOCL_DDR_COUNT(xdev, DEFAULT_PL_SLOT);
+	args->mm_channel_count = XOCL_DDR_COUNT(xdev, DEFAULT_PL_PS_SLOT);
 	if (args->mm_channel_count > 8)
 		args->mm_channel_count = 8;
 	for (i = 0; i < args->mm_channel_count; i++)

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
@@ -207,7 +207,7 @@ void xocl_reset_notify(struct pci_dev *pdev, bool prepare)
 {
 	struct xocl_dev *xdev = pci_get_drvdata(pdev);
 	int ret;
-	uint32_t slot_id = DEFAULT_PL_SLOT;
+	uint32_t slot_id = DEFAULT_PL_PS_SLOT;
 	xuid_t *xclbin_id = NULL;
 
 	xocl_info(&pdev->dev, "PCI reset NOTIFY, prepare %d", prepare);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_hwctx.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_hwctx.c
@@ -19,7 +19,7 @@ int xocl_get_slot_id_by_hw_ctx_id(struct xocl_dev *xdev,
         struct kds_client *client = filp->driver_priv;
 
 		if (xdev->is_legacy_ctx)
-			return DEFAULT_PL_SLOT;
+			return DEFAULT_PL_PS_SLOT;
 
         mutex_lock(&client->lock);
         hw_ctx = kds_get_hw_ctx_by_id(client, hw_ctx_id);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -186,7 +186,7 @@ static int xocl_add_context(struct xocl_dev *xdev, struct kds_client *client,
 			    struct drm_xocl_ctx *args)
 {
 	xuid_t *uuid;
-	uint32_t slot_id = DEFAULT_PL_SLOT;
+	uint32_t slot_id = DEFAULT_PL_PS_SLOT;
 	struct kds_client_hw_ctx *hw_ctx = NULL;
 	struct kds_client_cu_ctx *cu_ctx = NULL;
 	struct kds_client_cu_info cu_info = {};

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_sysfs.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_sysfs.c
@@ -147,7 +147,7 @@ static ssize_t xocl_mm_stat(struct xocl_dev *xdev, char *buf, bool raw)
 	struct drm_xocl_mm_stat stat;
 	const char *bo_txt_fmt = "[%s] %lluKB %dBOs\n";
 	const char *bo_types[XOCL_BO_USAGE_TOTAL];
-	uint32_t legacy_slot_id = DEFAULT_PL_SLOT;
+	uint32_t legacy_slot_id = DEFAULT_PL_PS_SLOT;
 
 	mutex_lock(&xdev->dev_lock);
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -356,7 +356,7 @@ static inline void xocl_memcpy_toio(void *iomem, void *buf, u32 size)
 #define	GB(x)			((uint64_t)(x) * 1024 * 1024 * 1024)
 
 #define MULTISLOT_VERSION	    0x80 // 128 Slots Support
-#define DEFAULT_PL_SLOT	    	    0
+#define DEFAULT_PL_PS_SLOT		0
 
 #define XOCL_VSEC_UUID_ROM          0x50
 #define XOCL_VSEC_FLASH_CONTROLER   0x51
@@ -1568,13 +1568,13 @@ static inline int xocl_get_pl_slot(xdev_handle_t xdev_hdl, uint32_t *slot_id)
 	uuid_t *xclbin_id = NULL;
 	int ret = 0;
 
-	/* Check if DEFAULT_PL_SLOT has a xclbin loaded */
-	ret = XOCL_GET_XCLBIN_ID(xdev_hdl, xclbin_id, DEFAULT_PL_SLOT);
+	/* Check if DEFAULT_PL_PS_SLOT has a xclbin loaded */
+	ret = XOCL_GET_XCLBIN_ID(xdev_hdl, xclbin_id, DEFAULT_PL_PS_SLOT);
 	if (ret)
 		return ret;
 
-	/* As of now we have single PL slot and hard coded to slot 0 */
-	*slot_id = DEFAULT_PL_SLOT;
+	/* As of now we have single PL/PS slot and hard coded to slot 0 */
+	*slot_id = DEFAULT_PL_PS_SLOT;
 
 	return 0;
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
The existing zocl driver assumes the default slot for ps kernels to be zero but this is not aligned with the logic
implemented in host XRT driver code.
Changing host XRT logic such that both PS and PL kernel slots are downloaded to slot 0 by default.
This solution persist until we have a clear implementation for multi slot functionality.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Changing host XRT logic such that both PS and PL kernel slots are downloaded to slot 0 by default.
This solution persist until we have a clear implementation for multi slot functionality.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Changing host XRT logic such that both PS and PL kernel slots are downloaded to slot 0 by default.
This solution persist until we have a clear implementation for multi slot functionality.

#### Risks (if any) associated the changes in the commit
NA
#### What has been tested and how, request additional testing if necessary
1. Program and Run PL and PL-AIE Kernels.
2. Program and Run  PS-AIE Kernels.

#### Documentation impact (if any)
xocl_resolver implementation document