### PR TITLE
add new action mask to indicate the driver to program the PDI.

### DIFF
--- a/src/runtime_src/core/include/xclbin.h
+++ b/src/runtime_src/core/include/xclbin.h
@@ -221,8 +221,8 @@ extern "C" {
     };
 
     enum ACTION_MASK {
-      AM_LOAD_AIE = 0x1                     /* Indicates to the driver to load the AIE PID section */
-      AM_LOAD_PDI = 0x2                     /* Indicates to the driver to program the PDI */   	      
+      AM_LOAD_AIE = 0x1,                     /* Indicates to the driver to load the AIE PID section */
+      AM_LOAD_PDI = 0x2,                     /* Indicates to the driver to program the PDI */   	      
     };
 
     struct axlf_section_header {

--- a/src/runtime_src/core/include/xclbin.h
+++ b/src/runtime_src/core/include/xclbin.h
@@ -222,6 +222,7 @@ extern "C" {
 
     enum ACTION_MASK {
       AM_LOAD_AIE = 0x1                     /* Indicates to the driver to load the AIE PID section */
+      AM_LOAD_PDI = 0x2                     /* Indicates to the driver to program the PDI */   	      
     };
 
     struct axlf_section_header {

--- a/src/runtime_src/tools/xclbinutil/FormattedOutput.cxx
+++ b/src/runtime_src/tools/xclbinutil/FormattedOutput.cxx
@@ -343,7 +343,8 @@ reportXclbinInfo(std::ostream& _ostream,
       _ostream << boost::format("   %-23s ") % "Action Mask(s):";
       if (_xclBinHeader.m_header.m_actionMask & AM_LOAD_AIE) 
         _ostream << "LOAD_AIE ";
-
+      if (_xclBinHeader.m_header.m_actionMask & AM_LOAD_PDI)
+	_ostream << "LOAD_PDI ";      
       _ostream << std::endl;
     }
   }

--- a/src/runtime_src/tools/xclbinutil/XclBinClass.cxx
+++ b/src/runtime_src/tools/xclbinutil/XclBinClass.cxx
@@ -94,6 +94,7 @@ XclBin::initializeHeader(axlf& _xclBinHeader)
   memset(_xclBinHeader.m_keyBlock, 0xFF, sizeof(_xclBinHeader.m_keyBlock));
   _xclBinHeader.m_uniqueId = time(nullptr);
   _xclBinHeader.m_header.m_timeStamp = time(nullptr);
+  _xclBinHeader.m_header.m_actionMask = 0;
 
   // Now populate the version information
   getVersionMajorMinorPath(xrt_build_version,
@@ -1548,20 +1549,15 @@ XclBin::setKeyValue(const std::string& _keyValue)
     }
 
     if (sKey == "action_mask") {
-      std::vector<std::string> masks;
-      boost::split(masks, sValue, boost::is_any_of("|"));
-      m_xclBinHeader.m_header.m_actionMask = 0;
-      for (const auto& mask : masks) {
-        if (mask == "LOAD_AIE") {
-          m_xclBinHeader.m_header.m_actionMask |= AM_LOAD_AIE;
-        }
-	else if (mask == "LOAD_PDI") {
-	  m_xclBinHeader.m_header.m_actionMask |= AM_LOAD_PDI; 	
-	}
-	else {
-          auto errMsg = boost::format("ERROR: Unknown bit mask '%s' for the key '%s'. Key-value pair: '%s'.") % mask % sKey % _keyValue;
-          throw std::runtime_error(errMsg.str());
-        }
+      if (sValue == "LOAD_AIE") {
+        m_xclBinHeader.m_header.m_actionMask |= AM_LOAD_AIE;
+      }
+      else if (sValue == "LOAD_PDI") {
+        m_xclBinHeader.m_header.m_actionMask |= AM_LOAD_PDI; 	
+      }
+      else {
+        auto errMsg = boost::format("ERROR: Unknown bit mask '%s' for the key '%s'. Key-value pair: '%s'.") % sValue % sKey % _keyValue;
+        throw std::runtime_error(errMsg.str());
       }
       return; // Key processed
     }   

--- a/src/runtime_src/tools/xclbinutil/XclBinClass.cxx
+++ b/src/runtime_src/tools/xclbinutil/XclBinClass.cxx
@@ -1554,7 +1554,11 @@ XclBin::setKeyValue(const std::string& _keyValue)
       for (const auto& mask : masks) {
         if (mask == "LOAD_AIE") {
           m_xclBinHeader.m_header.m_actionMask |= AM_LOAD_AIE;
-        } else {
+        }
+	else if (mask == "LOAD_PDI") {
+	  m_xclBinHeader.m_header.m_actionMask |= AM_LOAD_PDI; 	
+	}
+	else {
           auto errMsg = boost::format("ERROR: Unknown bit mask '%s' for the key '%s'. Key-value pair: '%s'.") % mask % sKey % _keyValue;
           throw std::runtime_error(errMsg.str());
         }


### PR DESCRIPTION
In this PR, added support for segmented configuration dynamic reload flows via a new --key-value option.
xclbinutil --key-value SYS:action_mask:LOAD_PDI
When XRT encounters that this action mask is set, it will program the PDI.

This is considered low risk change. Implementation similar to the existing LOAD_AIE action mask. 

I tested my changes locally by creating xclbin with the SYS:action_mask:LOAD_PDI option and verified that the output of the --info option on the xclbin contains LOAD_PDI action mask. This confirms that m_actionMask in axlf header is correctly set when SYS:action_mask:LOAD_PDI option is used and reads this LOAD_PDI bit mask from m_actionMask correctly when --info option is used. Further testing would be carried out by XRT to program the PDI.


