### PR TITLE
Fixing incorrect copyrights on XDP files

### DIFF
--- a/src/runtime_src/core/edge/user/plugin/xdp/hal_device_offload.cpp
+++ b/src/runtime_src/core/edge/user/plugin/xdp/hal_device_offload.cpp
@@ -1,3 +1,19 @@
+/**
+ * Copyright (C) 2020 Xilinx, Inc
+ * Copyright (C) 2024 Advanced Micro Devices, Inc. - All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 
 #include <functional>
 

--- a/src/runtime_src/core/edge/user/plugin/xdp/plugin_loader.cpp
+++ b/src/runtime_src/core/edge/user/plugin/xdp/plugin_loader.cpp
@@ -1,5 +1,6 @@
 /**
- * Copyright (C) 2020-2024 Xilinx, Inc
+ * Copyright (C) 2020-2022 Xilinx, Inc
+ * Copyright (C) 2024 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the

--- a/src/runtime_src/core/pcie/linux/plugin/xdp/hal_device_offload.cpp
+++ b/src/runtime_src/core/pcie/linux/plugin/xdp/hal_device_offload.cpp
@@ -1,3 +1,19 @@
+/**
+ * Copyright (C) 2020 Xilinx, Inc
+ * Copyright (C) 2024 Advanced Micro Devices, Inc. - All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 
 #include <functional>
 

--- a/src/runtime_src/xdp/doxygen.config
+++ b/src/runtime_src/xdp/doxygen.config
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved
+#
+
 # Doxyfile 1.8.5
 
 # This file describes the settings to be used by the documentation system


### PR DESCRIPTION
#### Problem solved by the commit
Fixing incorrect copyright formats and adding copyright to files where it was missing.

#### Risks (if any) associated the changes in the commit
Low risk as this just adds comments with copyright information.

#### What has been tested and how, request additional testing if necessary
Building has been tested but no functionality impact expected.

#### Documentation impact (if any)
No documentation impact.