### PR TITLE
Adding PCI IDs for AWS F2

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
@@ -286,6 +286,13 @@ enum {
 
 #define XOCL_DEVNAME(str)	str SUBDEV_SUFFIX
 
+/* AWS SHELL NAME Defines */
+#define AWS_F1_XDMA_SHELL_NAME "xilinx_aws-vu9p-f1_shell-v04261818_201920_3"
+#define AWS_F1_NODMA_SHELL_NAME "xilinx_aws-vu9p-f1_nodma-shell-v09142114_202120_1"
+#define AWS_F1_DYNAMIC_SHELL_NAME "xilinx_aws-vu9p-f1_dynamic-shell"
+
+#define AWS_F2_XDMA_SHELL_NAME "xilinx_aws-vu47p-f2_xdma-shell-v04052421_202410_1"
+
 enum subdev_id {
 	XOCL_SUBDEV_FEATURE_ROM,
 	XOCL_SUBDEV_VERSION_CTRL,
@@ -1933,6 +1940,14 @@ struct xocl_subdev_map {
 			XOCL_DEVINFO_ERT_CTRL,                          \
 		})
 
+#define USER_RES_AWS_F2_XDMA						\
+		((struct xocl_subdev_info []) {				\
+			XOCL_DEVINFO_FEATURE_ROM,			\
+			XOCL_DEVINFO_XDMA,				\
+			XOCL_DEVINFO_MAILBOX_USER_SOFTWARE,		\
+			XOCL_DEVINFO_ICAP_USER,				\
+		})
+
 #define USER_RES_AWS_XDMA						\
 		((struct xocl_subdev_info []) {				\
 			XOCL_DEVINFO_FEATURE_ROM,			\
@@ -2018,6 +2033,13 @@ struct xocl_subdev_map {
 		.flags		= 0,					\
 		.subdev_info	= USER_RES_AWS_XDMA,			\
 		.subdev_num = ARRAY_SIZE(USER_RES_AWS_XDMA),		\
+	}
+
+#define XOCL_BOARD_USER_AWS_F2_XDMA					\
+	(struct xocl_board_private){					\
+		.flags		= 0,					\
+		.subdev_info	= USER_RES_AWS_F2_XDMA,			\
+		.subdev_num = ARRAY_SIZE(USER_RES_AWS_F2_XDMA),		\
 	}
 
 #define XOCL_BOARD_USER_AWS_NODMA					\
@@ -3485,6 +3507,8 @@ struct xocl_subdev_map {
 	{ XOCL_PCI_DEVID(0x1D0F, 0x1042, PCI_ANY_ID, USER_AWS_XDMA) },	\
 	{ XOCL_PCI_DEVID(0x1D0F, 0xF010, PCI_ANY_ID, USER_AWS_XDMA) },	\
 	{ XOCL_PCI_DEVID(0x1D0F, 0xF011, PCI_ANY_ID, USER_AWS_NODMA) },	\
+	{ XOCL_PCI_DEVID(0x1D0F, 0x9048, PCI_ANY_ID, USER_AWS_F2_XDMA) },	\
+	{ XOCL_PCI_DEVID(0x1D0F, 0x9248, PCI_ANY_ID, USER_AWS_F2_XDMA) },	\
 	{ XOCL_PCI_DEVID(0x10EE, 0x5031, PCI_ANY_ID, USER_SMARTN) },	\
 	{ XOCL_PCI_DEVID(0x10EE, 0x5086, PCI_ANY_ID, X3522PV_USER_RAPTOR2) },	\
 	{ XOCL_PCI_DEVID(0x10EE, 0x5029, PCI_ANY_ID, USER_XDMA_VERSAL) },\

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/feature_rom.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/feature_rom.c
@@ -725,10 +725,7 @@ static int get_header_from_iomem(struct feature_rom *rom)
 	if (val != MAGIC_NUM) {
 		vendor = XOCL_PL_TO_PCI_DEV(pdev)->vendor;
 		did = XOCL_PL_TO_PCI_DEV(pdev)->device;
-		if (vendor == 0x1d0f && (did == 0x1042 || did == 0xf010 || did == 0xf011)) { // MAGIC, we should define elsewhere
-#define AWS_F1_XDMA_SHELL_NAME "xilinx_aws-vu9p-f1_shell-v04261818_201920_3"
-#define AWS_F1_NODMA_SHELL_NAME "xilinx_aws-vu9p-f1_nodma-shell-v09142114_202120_1"
-#define AWS_F1_DYNAMIC_SHELL_NAME "xilinx_aws-vu9p-f1_dynamic-shell"
+		if (vendor == 0x1d0f && (did == 0x1042 || did == 0xf010 || did == 0xf011 || did == 0x9048 || did == 0x9248)) {
 			xocl_dbg(&pdev->dev,
 				"Found AWS VU9P Device without featureROM");
 			/*
@@ -749,6 +746,9 @@ static int get_header_from_iomem(struct feature_rom *rom)
 			else if (did == 0xf011)
 				strncpy(rom->header.VBNVName,
 					AWS_F1_NODMA_SHELL_NAME, strlen(AWS_F1_NODMA_SHELL_NAME));
+			else if (did == 0x9048 || did == 0x9248)
+				strncpy(rom->header.VBNVName,
+					AWS_F2_XDMA_SHELL_NAME, strlen(AWS_F2_XDMA_SHELL_NAME));
 			else
 				strncpy(rom->header.VBNVName,
 					AWS_F1_DYNAMIC_SHELL_NAME, strlen(AWS_F1_DYNAMIC_SHELL_NAME));


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Add the new two PFs to support AWS F2.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Update the XOCL driver to support F2 IDs. The F2 PFs are 1d0f:9048 and 1d0f:9248.
#### How problem was solved, alternative solutions (if any) and why they were rejected
Update the XOCL driver to support F2 IDs. The F2 PFs are 1d0f:9048 and 1d0f:9248.
#### Risks (if any) associated the changes in the commit
None
#### What has been tested and how, request additional testing if necessary
On AWS Instance, verified the F2 device discovery in pci list of devices.
Run Hello world application to verify the functionality.
#### Documentation impact (if any)
None