### PR TITLE
Update HIP Module Load APIs

### DIFF
--- a/src/runtime_src/hip/CMakeLists.txt
+++ b/src/runtime_src/hip/CMakeLists.txt
@@ -60,6 +60,7 @@ install(TARGETS xrt_hip
 # Release headers
 install (FILES
   config.h
+  xrt_hip.h
   DESTINATION ${XRT_INSTALL_INCLUDE_DIR}/hip
   COMPONENT ${XRT_DEV_COMPONENT}
 )

--- a/src/runtime_src/hip/api/hip_device.cpp
+++ b/src/runtime_src/hip/api/hip_device.cpp
@@ -207,8 +207,29 @@ hipDeviceGetName(char* name, int len, hipDevice_t device)
   return hipErrorUnknown;
 }
 
+#if HIP_VERSION >= 60000000
+#undef hipGetDeviceProperties
+
 hipError_t
 hipGetDeviceProperties(hipDeviceProp_t* props, hipDevice_t device)
+{
+  return hipErrorNotSupported;
+}
+
+hipError_t
+hipGetDevicePropertiesR0600(hipDeviceProp_tR0600* props, int device)
+#else
+#define hipDeviceProp_tR0600 hipDeviceProp_t
+
+hipError_t
+hipGetDevicePropertiesR0600(hipDeviceProp_tR0600* props, int device)
+{
+  return hipErrorNotSupported;
+}
+
+hipError_t
+hipGetDeviceProperties(hipDeviceProp_t* props, hipDevice_t device)
+#endif
 {
   try {
     throw_invalid_value_if(!props, "arg passed is nullptr");

--- a/src/runtime_src/hip/api/hip_device.cpp
+++ b/src/runtime_src/hip/api/hip_device.cpp
@@ -219,7 +219,7 @@ hipGetDeviceProperties(hipDeviceProp_t* props, hipDevice_t device)
 hipError_t
 hipGetDevicePropertiesR0600(hipDeviceProp_tR0600* props, int device)
 #else
-#define hipDeviceProp_tR0600 hipDeviceProp_t
+using hipDeviceProp_tR0600 = hipDeviceProp_t;
 
 hipError_t
 hipGetDevicePropertiesR0600(hipDeviceProp_tR0600* props, int device)

--- a/src/runtime_src/hip/api/hip_module.cpp
+++ b/src/runtime_src/hip/api/hip_module.cpp
@@ -80,8 +80,11 @@ create_module(const hipModuleData* config)
       return insert_in_map(module_cache,
                            std::make_shared<module_xclbin>(ctx, std::string{static_cast<char*>(config->data), config->size}));
     }
-    // data passed is buffer, validity of buffer is checked during xrt::xclbin construction
-    return insert_in_map(module_cache, std::make_shared<module_xclbin>(ctx, config->data, config->size));
+    else if (config->type == hipModuleDataBuffer) {
+      // data passed is buffer, validity of buffer is checked during xrt::xclbin construction
+      return insert_in_map(module_cache, std::make_shared<module_xclbin>(ctx, config->data, config->size));
+    }
+    throw xrt_core::system_error(hipErrorInvalidValue, "invalid module data type passed");
   }
 
   // elf load
@@ -99,8 +102,11 @@ create_module(const hipModuleData* config)
     return insert_in_map(module_cache,
                          std::make_shared<module_elf>(hip_xclbin_mod.get(), std::string{static_cast<char*>(config->data), config->size}));
   }
-  // data passed is buffer
-  return insert_in_map(module_cache, std::make_shared<module_elf>(hip_xclbin_mod.get(), config->data, config->size));
+  else if (config->type == hipModuleDataBuffer) {
+    // data passed is buffer
+    return insert_in_map(module_cache, std::make_shared<module_elf>(hip_xclbin_mod.get(), config->data, config->size));
+  }
+  throw xrt_core::system_error(hipErrorInvalidValue, "invalid module data type passed");
 }
 
 static module_handle

--- a/src/runtime_src/hip/api/hip_module.cpp
+++ b/src/runtime_src/hip/api/hip_module.cpp
@@ -5,18 +5,9 @@
 #include "hip/core/event.h"
 #include "hip/core/module.h"
 #include "hip/core/stream.h"
+#include "hip/xrt_hip.h"
 
 namespace xrt::core::hip {
-
-// structure that represents the config data passed to hipModuleLoadData
-// xclbin_module - module handle of xclbin loaded
-// elf_file - path to elf file
-
-struct elf_config_data
-{
-  hipModule_t xclbin_module;
-  std::string elf_file;
-};
 
 static void
 hip_module_launch_kernel(hipFunction_t f, uint32_t /*gridDimX*/, uint32_t /*gridDimY*/,
@@ -73,20 +64,43 @@ hip_module_get_function(hipModule_t hmod, const char* name)
 }
 
 static module_handle
-create_elf_module(const elf_config_data* config)
+create_module(const hipModuleData* config)
 {
-  // elf_config_data holds module handle to xclbin loaded previously and file path to elf
-  throw_invalid_resource_if(!config->xclbin_module, "module is nullptr");
-  auto hip_mod = module_cache.get(reinterpret_cast<module_handle>(config->xclbin_module));
+  // this function can be used to load either xclbin or elf based on parent module
+  // if parent module is null then buffer passed has xclbin data else parent module
+  // will point to xclbin module already loaded and buffer passed will have elf data
+
+  if (!config->parent) {
+    // xclbin load
+    auto ctx = get_current_context();
+    throw_context_destroyed_if(!ctx, "context is destroyed, no active context");
+    // create xclbin module and store it in module map
+    if (config->type == hipModuleDataFilePath) {
+      // data passed is file path
+      return insert_in_map(module_cache,
+                           std::make_shared<module_xclbin>(ctx, std::string{static_cast<char*>(config->data), config->size}));
+    }
+    // data passed is buffer, validity of buffer is checked during xrt::xclbin construction
+    return insert_in_map(module_cache, std::make_shared<module_xclbin>(ctx, config->data, config->size));
+  }
+
+  // elf load
+  auto hip_mod = module_cache.get(reinterpret_cast<module_handle>(config->parent));
   throw_invalid_resource_if(!hip_mod, "module not available");
   throw_invalid_resource_if(!hip_mod->is_xclbin_module(), "invalid module handle passed");
 
   auto hip_xclbin_mod = std::dynamic_pointer_cast<module_xclbin>(hip_mod);
   throw_invalid_resource_if(!hip_xclbin_mod, "getting hip module using dynamic pointer cast failed");
 
-  // create xrt::elf and return the module handle
-  // validity of elf_file passed is checked in xrt::elf constructor
-  return insert_in_map(module_cache, std::make_shared<module_elf>(hip_xclbin_mod.get(), config->elf_file));
+  // create elf module and store it in module map
+  // validity of elf_file or buffer passed is checked during xrt::elf construction
+  if (config->type == hipModuleDataFilePath) {
+    // data passed is file path
+    return insert_in_map(module_cache,
+                         std::make_shared<module_elf>(hip_xclbin_mod.get(), std::string{static_cast<char*>(config->data), config->size}));
+  }
+  // data passed is buffer
+  return insert_in_map(module_cache, std::make_shared<module_elf>(hip_xclbin_mod.get(), config->data, config->size));
 }
 
 static module_handle
@@ -163,10 +177,10 @@ hip_module_load_data_helper(hipModule_t* module, const void* image)
   try {
     throw_invalid_resource_if(!module, "module is nullptr");
 
-    // image passed to this call is elf_config_data object pointer
-    auto config_data = static_cast<const xrt::core::hip::elf_config_data*>(image);
-    auto elf_module = xrt::core::hip::create_elf_module(config_data);
-    *module = reinterpret_cast<hipModule_t>(elf_module);
+    // image passed to this call is structure hipModuleData object pointer
+    auto config_data = static_cast<const hipModuleData*>(image);
+    auto mod = xrt::core::hip::create_module(config_data);
+    *module = reinterpret_cast<hipModule_t>(mod);
     return hipSuccess;
   }
   catch (const xrt_core::system_error& ex) {
@@ -196,7 +210,7 @@ hipModuleLoadData(hipModule_t* module, const void* image)
 }
 
 hipError_t
-hipModuleLoad(hipModule_t *module, const char *fname)
+hipModuleLoad(hipModule_t* module, const char* fname)
 {
   try {
     throw_invalid_resource_if(!module, "module is nullptr");

--- a/src/runtime_src/hip/core/module.h
+++ b/src/runtime_src/hip/core/module.h
@@ -26,6 +26,7 @@ class function;
 // objects of module_xclbin/module_elf dervied from base class module
 class module
 {
+protected:
   std::shared_ptr<context> m_ctx;
   bool m_is_xclbin;
 
@@ -61,9 +62,6 @@ public:
   module_xclbin(std::shared_ptr<context> ctx, const std::string& file_name);
 
   module_xclbin(std::shared_ptr<context> ctx, void* data, size_t size);
-
-  void
-  create_hw_context();
 
   function_handle
   add_function(std::shared_ptr<function> f)
@@ -129,4 +127,3 @@ extern xrt_core::handle_map<module_handle, std::shared_ptr<module>> module_cache
 } // xrt::core::hip
 
 #endif
-

--- a/src/runtime_src/hip/core/module.h
+++ b/src/runtime_src/hip/core/module.h
@@ -60,6 +60,8 @@ class module_xclbin : public module
 public:
   module_xclbin(std::shared_ptr<context> ctx, const std::string& file_name);
 
+  module_xclbin(std::shared_ptr<context> ctx, void* data, size_t size);
+
   void
   create_hw_context();
 
@@ -90,6 +92,8 @@ class module_elf : public module
 
 public:
   module_elf(module_xclbin* xclbin_module, const std::string& file_name);
+
+  module_elf(module_xclbin* xclbin_module, void* data, size_t size);
 
   module_xclbin*
   get_xclbin_module() const { return m_xclbin_module; }

--- a/src/runtime_src/hip/hip_config.cmake
+++ b/src/runtime_src/hip/hip_config.cmake
@@ -9,10 +9,10 @@ if (NOT WIN32)
   set(CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH};/usr/lib/x86_64-linux-gnu/cmake/hip;/usr/lib/x86_64-linux-gnu/cmake/amd_comgr;/usr/lib/x86_64-linux-gnu/cmake/hsa-runtime64;/opt/rocm/lib/cmake/hip;/opt/rocm/lib/cmake/amd_comgr;/opt/rocm/lib/cmake/hsa-runtime64")
 else ()
   set(HIP_PLATFORM "amd")
-  # HIP SDK installs hip files to C:/Program Files/AMD/ROCm
-  # Latest version available on windows is 5.7
+  # HIP SDK installs hip files to C:/Program Files/AMD/ROCm in windows
+  # Latest version installed (6.1, 5.7 or whatever available) will be picked
   # Users can set HIP_DIR to location of HIP installation or default path is used
-  set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} $ENV{HIP_DIR} "C:/Program Files/AMD/ROCm/5.7/lib/cmake/hip")
+  set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} $ENV{HIP_DIR} "C:/Program Files/AMD/ROCm/6.1/lib/cmake/hip" "C:/Program Files/AMD/ROCm/5.7/lib/cmake/hip")
 endif ()
 
 include(hip-config)

--- a/src/runtime_src/hip/xrt_hip.def
+++ b/src/runtime_src/hip/xrt_hip.def
@@ -13,6 +13,7 @@ EXPORTS
   hipDeviceGet
   hipDeviceGetName
   hipGetDeviceProperties
+  hipGetDevicePropertiesR0600
   hipDeviceGetUuid
   hipDeviceGetAttribute
   hipDrvGetErrorName

--- a/src/runtime_src/hip/xrt_hip.h
+++ b/src/runtime_src/hip/xrt_hip.h
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+#ifndef xrthip_h
+#define xrthip_h
+
+#include "hip/hip_runtime_api.h"
+
+enum hipModuleDataType {
+  hipModuleDataFilePath = 0,
+  hipModuleDataBuffer
+};
+
+// structure that represents the config data passed to hipModuleLoadData
+struct hipModuleData
+{
+  hipModuleDataType type;  // type of data passed
+  hipModule_t parent;      // parent module to establish link b/w xclbin and elf
+                           // parent is null for xclbin creation, parent will point
+                           // to xclbin module for elf creation
+  void* data;              // pointer to file path or buffer based on type
+  size_t size;             // size of data buffer passed 
+};
+
+#endif
+


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Updated hipModuleLoadData API according to spec mentioned in page - https://confluence.amd.com/display/AIE/HIP+Architecture#HIPArchitecture-Elfbasedflow
Earlier in HIP there was only support for loading xclbin and elf using file path passed as string. This change extends the load of xclbin/elf using buffer also.

Also added support for latest HIP release (6.1) in windows

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
This was ask from IREE team to load xclbin and elf data using buffer.

#### How problem was solved, alternative solutions (if any) and why they were rejected
hipModuleLoadData argument void* image is used to pass object to structure hipModuleData which has the required fields to take xclbin/elf data as buffer along with its size. New header file xrt_hip.h is created and shipped with xrt package that has above mentioned structure. This header file can also be used in future to have more structures and APIs according to usecase.

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
Tested build of XRT along with hip library on both Linux and Windows
Tested HIP Elf flow test on NPU

#### Documentation impact (if any)
Updated confluence page and added example to demonstrate the use case. XRT doc update is NA.