### PR TITLE
Added support for compile time trace for edge devices in XDP

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -153,7 +153,8 @@ void AieTracePluginUnified::updateAIEDevice(void *handle) {
   if(!AIEData.metadata->getRuntimeMetrics())
   {
     xrt_core::message::send(severity_level::warning, "XRT",
-                            "All the event-trace arguments are deprecated except 'runtime'. We recommend to use --event-trace=runtime");
+                            "AI Engine compile time event-trace arguments will be deprecated. "
+                            "Please plan to use runtime event trace by re-compiling AI Engine with --event-trace=runtime.");
   }
 
 #ifdef XDP_CLIENT_BUILD

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -141,13 +141,20 @@ void AieTracePluginUnified::updateAIEDevice(void *handle) {
     xrt_core::message::send(severity_level::warning, "XRT", "AIE Metadata is empty for AIE Trace");
     return;
   }
-  if (AIEData.metadata->configMetricsEmpty()) {
+  if (AIEData.metadata->configMetricsEmpty() && AIEData.metadata->getRuntimeMetrics()) {
     AIEData.valid = false;
     xrt_core::message::send(severity_level::warning, "XRT",
                             AIE_TRACE_TILES_UNAVAILABLE);
     return;
   }
   AIEData.valid = true; // initialize struct
+
+  //TODO: Should be removed in 2025.1 release.
+  if(!AIEData.metadata->getRuntimeMetrics())
+  {
+    xrt_core::message::send(severity_level::warning, "XRT",
+                            "All the event-trace arguments are deprecated except 'runtime'. We recommend to use --event-trace=runtime");
+  }
 
 #ifdef XDP_CLIENT_BUILD
   AIEData.metadata->setHwContext(context);


### PR DESCRIPTION
#### Problem solved by the commit
Added support for compile time trace for edge devices in XDP

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added checks to generate trace for compile time event trace also

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
Tested compile time trace test on vck190 design

#### Documentation impact (if any)
NA
