### PR TITLE
Enabling default flushing of trace module for Core tile

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_trace/client/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/client/aie_trace.cpp
@@ -893,22 +893,14 @@ namespace xdp {
         mNumTileTraceEvents[m][n] = 0;
     }
 
-    // Decide when to use user event for trace end to enable flushing
-    // NOTE: This is needed to "flush" the last trace packet.
-    //       We use the event generate register to create this 
-    //       event and gracefully shut down trace modules.
-    bool useTraceFlush = false;
-    if ((metadata->getUseUserControl()) || (metadata->getUseGraphIterator()) || (metadata->getUseDelay()) ||
-        (xrt_core::config::get_aie_trace_settings_end_type() == "event1")) {
-      if (metadata->getUseUserControl())
-        coreTraceStartEvent = XAIE_EVENT_INSTR_EVENT_0_CORE;
-      coreTraceEndEvent = XAIE_EVENT_INSTR_EVENT_1_CORE;
-      useTraceFlush = true;
+    // Using user event for trace end to enable flushing
+    // NOTE: Flush trace module always at the end because for some applications
+    //       core might be running infinitely.
+    if (metadata->getUseUserControl())
+      coreTraceStartEvent = XAIE_EVENT_INSTR_EVENT_0_CORE;
+    coreTraceEndEvent = XAIE_EVENT_INSTR_EVENT_1_CORE;
 
-      if (xrt_core::config::get_verbosity() >= static_cast<uint32_t>(severity_level::info))
-        xrt_core::message::send(severity_level::info, "XRT", "Enabling trace flush");
-    }
-
+    
     // Iterate over all used/specified tiles
     // NOTE: rows are stored as absolute as required by resource manager
     //std::cout << "Config Metrics Size: " << metadata->getConfigMetrics().size() << std::endl;
@@ -938,7 +930,7 @@ namespace xdp {
       //   memory = xaieTile.mem();
 
       // Store location to flush at end of run
-      if (useTraceFlush || (type == module_type::mem_tile) 
+      if (type == module_type::core || (type == module_type::mem_tile) 
           || (type == module_type::shim)) {
         if (type == module_type::core)
           traceFlushLocs.push_back(loc);

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/edge/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/edge/aie_trace.cpp
@@ -301,19 +301,13 @@ namespace xdp {
         mNumTileTraceEvents[m][n] = 0;
     }
 
-    // Decide when to use user event for trace end to enable flushing
-    // NOTE: This is needed to "flush" the last trace packet.
-    //       We use the event generate register to create this 
-    //       event and gracefully shut down trace modules.
-    bool useTraceFlush = false;
-    if ((metadata->getUseUserControl()) || (metadata->getUseGraphIterator()) || (metadata->getUseDelay()) ||
-        (xrt_core::config::get_aie_trace_settings_end_type() == "event1")) {
-      if (metadata->getUseUserControl())
-        coreTraceStartEvent = XAIE_EVENT_INSTR_EVENT_0_CORE;
-      coreTraceEndEvent = XAIE_EVENT_INSTR_EVENT_1_CORE;
-      useTraceFlush = true;
-      xrt_core::message::send(severity_level::info, "XRT", "Enabling trace flush");
-    }
+    // Using user event for trace end to enable flushing
+    // NOTE: Flush trace module always at the end because for some applications
+    //       core might be running infinitely.
+    
+    if (metadata->getUseUserControl())
+      coreTraceStartEvent = XAIE_EVENT_INSTR_EVENT_0_CORE;
+    coreTraceEndEvent = XAIE_EVENT_INSTR_EVENT_1_CORE;
 
     // Iterate over all used/specified tiles
     // NOTE: rows are stored as absolute as required by resource manager
@@ -358,7 +352,7 @@ namespace xdp {
         memory = xaieTile.mem();
 
       // Store location to flush at end of run
-      if (useTraceFlush || (type == module_type::mem_tile) 
+      if (type == module_type::core || (type == module_type::mem_tile) 
           || (type == module_type::shim)) {
         if (type == module_type::core)
           traceFlushLocs.push_back(loc);


### PR DESCRIPTION
#### Problem solved by the commit
End core trace was missing because core module were not flushed at the end by default.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Started flushing the core tile by default at the end using user instruction event.

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
Verified trace for core tile on client.

#### Documentation impact (if any)
NA