### PR TITLE
Fix for junk values in ML Timeline data when AIE Trace is enabled

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_debug/aie_debug_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_debug/aie_debug_plugin.cpp
@@ -242,8 +242,11 @@ namespace xdp {
     }
 
     xrt::bo resultBO;
+    uint32_t* output = nullptr;
     try {
       resultBO = xrt_core::bo_int::create_debug_bo(mHwContext, 0x20000);
+      output = resultBO.map<uint32_t*>();
+      memset(output, 0, 0x20000);
     } catch (std::exception& e) {
       std::stringstream msg;
       msg << "Unable to create 128KB buffer for AIE Debug results. Cannot get AIE Debug info. " << e.what() << std::endl;
@@ -265,8 +268,6 @@ namespace xdp {
     XAie_ClearTransaction(&aieDevInst);
 
     resultBO.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
-    auto resultBOMap = resultBO.map<uint8_t*>();
-    uint32_t* output = reinterpret_cast<uint32_t*>(resultBOMap);
 
     for (uint32_t i = 0; i < op->count; i++) {
       std::stringstream msg;

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/client/aie_profile.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/client/aie_profile.cpp
@@ -310,8 +310,11 @@ namespace xdp {
 
     auto context = metadata->getHwContext();
     xrt::bo resultBO;
+    uint32_t* output = nullptr;
     try {
       resultBO = xrt_core::bo_int::create_debug_bo(context, 0x20000);
+      output = resultBO.map<uint32_t*>();
+      memset(output, 0, 0x20000);
     } catch (std::exception& e) {
       std::stringstream msg;
       msg << "Unable to create 128KB buffer for AIE Profile results. Cannot get AIE Profile info. " << e.what() << std::endl;
@@ -337,8 +340,6 @@ namespace xdp {
     XAie_ClearTransaction(&aieDevInst);
 
     resultBO.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
-    auto resultBOMap = resultBO.map<uint8_t*>();
-    uint32_t* output = reinterpret_cast<uint32_t*>(resultBOMap);
 
     for (uint32_t i = 0; i < op->count; i++) {
       std::stringstream msg;

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.cpp
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.cpp
@@ -77,10 +77,11 @@ namespace xdp {
        * can use their own Debug BO to capture their data.
        */
       mResultBOHolder = new ResultBOContainer(mHwContext, mBufSz);
+      memset(mResultBOHolder->map(), 0, mBufSz);
 
     } catch (std::exception& e) {
       std::stringstream msg;
-      msg << "Unable to create result buffer of size "
+      msg << "Unable to create/initialize result buffer of size "
           << std::hex << mBufSz << std::dec
           << " Bytes for Record Timer Values. Cannot get ML Timeline info. " 
           << e.what() << std::endl;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
When AIE Trace plugin is enabled at runtime and configured for trace, it causes junk values at the end of record timer data captured by ML Timeline.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
For ML Timeline plugin, all the good expected values are captured in generated record_timer_ts.json. But when aie_trace is also enabled and configured, unexpected junk values appear after good values in record_timer-ts.json.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Initializing the debug buffer with zeroes helps bypass the junk value issue. When debug buffer was introduced, it was told to be always initialized with zero. However, when AIE Trace is enabled, it somehow corrupts debug bo for record timer. This needs further investigation. For now, initializing debug bo helps mitigate junk value issue. So, we can add it for now.

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
ML designs with ml_timeline and aie_trace

#### Documentation impact (if any)
