### PR TITLE
Removed hw_context flag dependency for edge on xrt.ini

### DIFF
--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -1386,6 +1386,7 @@ void
 shim::
 register_xclbin(const xrt::xclbin&){
   xclLog(XRT_INFO, "%s: xclbin successfully registered for this device without loading the xclbin", __func__);
+  hw_context_enable = true;
 }
 
 void

--- a/src/runtime_src/core/edge/user/shim.h
+++ b/src/runtime_src/core/edge/user/shim.h
@@ -361,7 +361,7 @@ private:
   std::unique_ptr<xrt_core::bo_cache> mCmdBOCache;
   zynq_device *mDev = nullptr;
   size_t mKernelClockFreq;
-  bool hw_context_enable = true;
+  bool hw_context_enable = false;
 
   /*
    * Mapped CU register space for xclRegRead/Write(). We support at most


### PR DESCRIPTION
It avoids any changes on the existing sw pipeline for legacy testcases written with non-hwctx.

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
xrt.ini changes on existing sw pipeline for both the testcases either legacy or hwctx
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
removed the default flow which is hw ctx flow for the edge shim. And by default the flow is legacy flow. Testcases written with hw context will register the xclbin and the flag hw_context_enable will be set to true and it will enable hw context flow.
#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Please find the table below. Tested on hw emu with vck190 xpfm with 2024.2 TA
<html xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:dt="uuid:C2F41010-65B3-11d1-A29F-00AA00C14882"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=OneNote.File>
<meta name=Generator content="Microsoft OneNote 15">
</head>

<body lang=en-US style='font-family:Calibri;font-size:11.0pt'>
<!--StartFragment-->

<div style='direction:ltr'>


testname | legacy | hwctx
-- | -- | --
complex_graph | passed | passed
ind_graph | passed | passed
simple_gmio | passed | passed
simple_graph | passed | passed
simple_rtp | passed | passed
simple_vadd(opencl) | passed | testcase is n/a
simple_vadd(xrt   APIs) | passed | passed
zynqmp(opencl) | passed | testcase is n/a



</div>

<!--EndFragment-->
</body>

</html>

#### Documentation impact (if any)
