### PR TITLE
CR-1185333: Update pts data type to 64-bit signed integer

### DIFF
--- a/src/xma/include/app/xmabuffers.h
+++ b/src/xma/include/app/xmabuffers.h
@@ -164,7 +164,7 @@ typedef struct XmaDataBuffer
     XmaBufferRef    data; /**< description of data buffer*/
     int32_t         alloc_size; /**< allocated size of data buffer */
     int32_t         is_eof; /**< flag to indicate that this buffer is EOF */
-    int32_t         pts; /**< presentation time stamp looping back to application */
+    int64_t         pts; /**< presentation time stamp looping back to application */
     int32_t         poc; /**< Picture order count for current output frame */
 } XmaDataBuffer;
 

--- a/src/xma/xma_legacy/include/app/xmabuffers.h
+++ b/src/xma/xma_legacy/include/app/xmabuffers.h
@@ -111,7 +111,7 @@ typedef struct XmaDataBuffer
     XmaBufferRef    data; /**< description of data buffer*/
     int32_t         alloc_size; /**< allocated size of data buffer */
     int32_t         is_eof; /**< flag to indicate that this buffer is EOF */
-    int32_t         pts; /**< presentation time stamp looping back to application */
+    int64_t         pts; /**< presentation time stamp looping back to application */
     int32_t         poc; /**< Picture order count for current output frame */
 } XmaDataBuffer;
 


### PR DESCRIPTION
**Problem solved by the commit**
This change fixes the PTS overflow issue if the bitstream has 64-bit PTS value.

**Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered**
User reported video and audio getting out of sync after transcoding a bitstream that has >32-bit PTS. The application stack has 64-bit PTS and the XMA has 32-bit PTS value.

**How problem was solved, alternative solutions (if any) and why they were rejected**
Made PTS parameter as 64-bit in XmaDataBuffer.

**Risks (if any) associated the changes in the commit**
None.

**What has been tested and how, request additional testing if necessary**
It has been tested with the bitstream where the sync issue happened and multiple other transcoder commands.
