### PR TITLE
Ubuntu 22.04 kernel 6.2 Changes

### DIFF
--- a/src/runtime_src/core/pcie/driver/aws/kernel/mgmt/mgmt-core.h
+++ b/src/runtime_src/core/pcie/driver/aws/kernel/mgmt/mgmt-core.h
@@ -26,7 +26,7 @@
 
 /* Ensure compatibility with newer Linux kernels. */
 /* access_ok lost its first parameter with Linux 5.0. */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,0,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0)
 	#define AWSMGMT_ACCESS_OK(TYPE, ADDR, SIZE) access_ok(ADDR, SIZE)
 #else
 	#define AWSMGMT_ACCESS_OK(TYPE, ADDR, SIZE) access_ok(TYPE, ADDR, SIZE)

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma/qdma_request.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma/qdma_request.c
@@ -240,7 +240,7 @@ void qdma_request_unmap(struct pci_dev *pdev, struct qdma_request *req)
 						DMA_FROM_DEVICE;
 
 	if (req->use_sgt) {
-		pci_unmap_sg(pdev, req->sgt->sgl, req->sgt->orig_nents, dir);
+		dma_unmap_sg(&pdev->dev, req->sgt->sgl, req->sgt->orig_nents, dir);
 	} else {
 		struct qdma_sw_sg *sg = req->sgl;
 		unsigned int sgcnt = req->sgcnt;
@@ -250,7 +250,7 @@ void qdma_request_unmap(struct pci_dev *pdev, struct qdma_request *req)
 			if (!sg->pg)
 				break;
 			if (sg->dma_addr) {
-				pci_unmap_page(pdev, sg->dma_addr - sg->offset,
+				dma_unmap_page(&pdev->dev, sg->dma_addr - sg->offset,
 						PAGE_SIZE, dir);
 				sg->dma_addr = 0UL;
 			}
@@ -274,7 +274,7 @@ int qdma_request_map(struct pci_dev *pdev, struct qdma_request *req)
 						DMA_FROM_DEVICE;
 
 	if (req->use_sgt) {
-		int nents = pci_map_sg(pdev, req->sgt->sgl,
+		int nents = dma_map_sg(&pdev->dev, req->sgt->sgl,
 					req->sgt->orig_nents, dir);
 
 		if (!nents) {
@@ -290,9 +290,9 @@ int qdma_request_map(struct pci_dev *pdev, struct qdma_request *req)
 
 		for (i = 0; i < sgcnt; i++, sg++) {
 			/* !! TODO  page size !! */
-			sg->dma_addr = pci_map_page(pdev, sg->pg, 0,
+			sg->dma_addr = dma_map_page(&pdev->dev, sg->pg, 0,
 						PAGE_SIZE, dir);
-			if (unlikely(pci_dma_mapping_error(pdev,
+			if (unlikely(dma_mapping_error(&pdev->dev,
 							sg->dma_addr))) {
 				pr_info("map sgl failed, sg %d, %u.\n",
 					i, sg->len);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma/qdma_st_c2h.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma/qdma_st_c2h.c
@@ -95,7 +95,7 @@ static inline int flq_fill_one(struct qdma_sw_sg *sdesc,
 	}
 
 	mapping = dma_map_page(dev, pg, 0, PAGE_SIZE << pg_order,
-				PCI_DMA_FROMDEVICE);
+				DMA_FROM_DEVICE);
 	if (unlikely(dma_mapping_error(dev, mapping))) {
 		dev_err(dev, "page 0x%p mapping error 0x%llx.\n",
 			pg, (unsigned long long)mapping);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma/xdev.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma/xdev.c
@@ -538,12 +538,12 @@ static struct xlnx_dma_dev *xdev_alloc(struct qdma_dev_conf *conf)
 static int pci_dma_mask_set(struct pci_dev *pdev)
 {
 	/** 64-bit addressing capability for XDMA? */
-	if (!pci_set_dma_mask(pdev, DMA_BIT_MASK(64))) {
+	if (!dma_set_mask(&pdev->dev, DMA_BIT_MASK(64))) {
 		/** use 32-bit DMA for descriptors */
-		pci_set_consistent_dma_mask(pdev, DMA_BIT_MASK(32));
+		dma_set_coherent_mask(&pdev->dev, DMA_BIT_MASK(32));
 		/** use 64-bit DMA, 32-bit for consistent */
-	} else if (!pci_set_dma_mask(pdev, DMA_BIT_MASK(32))) {
-		pci_set_consistent_dma_mask(pdev, DMA_BIT_MASK(32));
+	} else if (!dma_set_mask(&pdev->dev, DMA_BIT_MASK(32))) {
+		dma_set_coherent_mask(&pdev->dev, DMA_BIT_MASK(32));
 		/** use 32-bit DMA */
 		dev_info(&pdev->dev, "Using a 32-bit DMA mask.\n");
 	} else {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/libqdma_export.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/libqdma_export.c
@@ -2243,7 +2243,7 @@ void sgl_unmap(struct pci_dev *pdev, struct qdma_sw_sg *sg, unsigned int sgcnt,
 		if (!sg->pg)
 			break;
 		if (sg->dma_addr) {
-			pci_unmap_page(pdev, sg->dma_addr - sg->offset,
+			dma_unmap_page(&pdev->dev, sg->dma_addr - sg->offset,
 							PAGE_SIZE, dir);
 			sg->dma_addr = 0UL;
 		}
@@ -2275,8 +2275,8 @@ int sgl_map(struct pci_dev *pdev, struct qdma_sw_sg *sgl, unsigned int sgcnt,
 	 */
 	for (i = 0; i < sgcnt; i++, sg++) {
 		/* !! TODO  page size !! */
-		sg->dma_addr = pci_map_page(pdev, sg->pg, 0, PAGE_SIZE, dir);
-		if (unlikely(pci_dma_mapping_error(pdev, sg->dma_addr))) {
+		sg->dma_addr = dma_map_page(&pdev->dev, sg->pg, 0, PAGE_SIZE, dir);
+		if (unlikely(dma_mapping_error(&pdev->dev, sg->dma_addr))) {
 			pr_err("map sgl failed, sg %d, %u.\n", i, sg->len);
 			if (i)
 				sgl_unmap(pdev, sgl, i, dir);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/qdma_st_c2h.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/qdma_st_c2h.c
@@ -204,7 +204,7 @@ static inline int flq_fill_page_one(struct qdma_sw_pg_sg *pg_sdesc,
 	}
 
 	mapping = dma_map_page(dev, pg, 0, (PAGE_SIZE << pg_order),
-				PCI_DMA_FROMDEVICE);
+				DMA_FROM_DEVICE);
 	if (unlikely(dma_mapping_error(dev, mapping))) {
 		dev_err(dev, "page 0x%p mapping error 0x%llx.\n",
 			pg, (unsigned long long)mapping);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/xdev.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/xdev.c
@@ -91,12 +91,12 @@ struct qdma_resource_lock {
 static int pci_dma_mask_set(struct pci_dev *pdev)
 {
 	/** 64-bit addressing capability for XDMA? */
-	if (!pci_set_dma_mask(pdev, DMA_BIT_MASK(64))) {
+	if (!dma_set_mask(&pdev->dev, DMA_BIT_MASK(64))) {
 		/** use 64-bit DMA for descriptors */
-		pci_set_consistent_dma_mask(pdev, DMA_BIT_MASK(64));
+		dma_set_coherent_mask(&pdev->dev, DMA_BIT_MASK(64));
 		/** use 64-bit DMA, 32-bit for consistent */
-	} else if (!pci_set_dma_mask(pdev, DMA_BIT_MASK(32))) {
-		pci_set_consistent_dma_mask(pdev, DMA_BIT_MASK(32));
+	} else if (!dma_set_mask(&pdev->dev, DMA_BIT_MASK(32))) {
+		dma_set_coherent_mask(&pdev->dev, DMA_BIT_MASK(32));
 		/** use 32-bit DMA */
 		dev_info(&pdev->dev, "Using a 32-bit DMA mask.\n");
 	} else {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libxdma.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libxdma.h
@@ -574,7 +574,7 @@ struct xdma_dev {
 	int irq_line;		/* flag if irq allocated successfully */
 	int msi_enabled;	/* flag if msi was enabled for the device */
 	int msix_enabled;	/* flag if msi-x was enabled for the device */
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4,12,0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 12, 0)
 	struct msix_entry entry[32];	/* msi-x vector/entry table */
 #endif
 	struct xdma_user_irq user_irq[16];	/* user IRQ management */

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
@@ -319,9 +319,17 @@ static int bridge_mmap(struct file *file, struct vm_area_struct *vma)
 	 * and prevent the pages from being swapped out
 	 */
 #ifndef VM_RESERVED
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
 	vma->vm_flags |= VM_IO | VM_DONTEXPAND | VM_DONTDUMP;
 #else
+	vm_flags_set(vma, VM_IO | VM_DONTEXPAND | VM_DONTDUMP);
+#endif
+#else
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
 	vma->vm_flags |= VM_IO | VM_RESERVED;
+#else
+	vm_flags_set(vma, VM_IO | VM_RESERVED);
+#endif
 #endif
 
 	/* make MMIO accessible to user space */
@@ -1547,7 +1555,11 @@ static int __init xclmgmt_init(void)
 	int res, i;
 
 	pr_info(DRV_NAME " init()\n");
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0)
 	xrt_class = class_create(THIS_MODULE, "xrt_mgmt");
+#else
+	xrt_class = class_create("xrt_mgmt");
+#endif
 	if (IS_ERR(xrt_class))
 		return PTR_ERR(xrt_class);
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/aim.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/aim.c
@@ -409,9 +409,17 @@ static int aim_mmap(struct file *filp, struct vm_area_struct *vma)
 	 * and prevent the pages from being swapped out
 	 */
 #ifndef VM_RESERVED
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
 	vma->vm_flags |= VM_IO | VM_DONTEXPAND | VM_DONTDUMP;
 #else
+	vm_flags_set(vma, VM_IO | VM_DONTEXPAND | VM_DONTDUMP);
+#endif
+#else
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
 	vma->vm_flags |= VM_IO | VM_RESERVED;
+#else
+	vm_flags_set(vma, VM_IO | VM_RESERVED);
+#endif
 #endif
 
 	/* make MMIO accessible to user space */

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/am.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/am.c
@@ -401,9 +401,17 @@ static int am_mmap(struct file *filp, struct vm_area_struct *vma)
 	 * and prevent the pages from being swapped out
 	 */
 #ifndef VM_RESERVED
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
 	vma->vm_flags |= VM_IO | VM_DONTEXPAND | VM_DONTDUMP;
 #else
+	vm_flags_set(vma, VM_IO | VM_DONTEXPAND | VM_DONTDUMP);
+#endif
+#else
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
 	vma->vm_flags |= VM_IO | VM_RESERVED;
+#else
+	vm_flags_set(vma, VM_IO | VM_RESERVED);
+#endif
 #endif
 
 	/* make MMIO accessible to user space */

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/asm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/asm.c
@@ -322,9 +322,17 @@ static int asm_mmap(struct file *filp, struct vm_area_struct *vma)
 	 * and prevent the pages from being swapped out
 	 */
 #ifndef VM_RESERVED
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
 	vma->vm_flags |= VM_IO | VM_DONTEXPAND | VM_DONTDUMP;
 #else
+	vm_flags_set(vma, VM_IO | VM_DONTEXPAND | VM_DONTDUMP);
+#endif
+#else
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
 	vma->vm_flags |= VM_IO | VM_RESERVED;
+#else
+	vm_flags_set(vma, VM_IO | VM_RESERVED);
+#endif
 #endif
 
 	/* make MMIO accessible to user space */

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/fmgr.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/fmgr.c
@@ -21,7 +21,7 @@
  * kernels do not support FPGA Mgr yet.
  */
 #include <linux/version.h>
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,15,0) && defined(ENABLE_FPGA_MGR_SUPPORT)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0) && defined(ENABLE_FPGA_MGR_SUPPORT)
 #define FPGA_MGR_SUPPORT
 #include <linux/fpga/fpga-mgr.h>
 #endif
@@ -167,7 +167,7 @@ static int fmgr_probe(struct platform_device *pdev)
 	 */
 #if defined(FPGA_MGR_SUPPORT)
 	obj->state = FPGA_MGR_STATE_UNKNOWN;
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,18,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 18, 0)
 	{
 	struct fpga_manager *mgr = fpga_mgr_create(&pdev->dev,
 						   obj->name,
@@ -205,7 +205,7 @@ static int fmgr_remove(struct platform_device *pdev)
 	/* TODO: Remove old fpga_mgr_unregister as soon as Linux < 4.18 is no
 	 * longer supported.
 	 */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,18,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 18, 0)
 	fpga_mgr_unregister(mgr);
 #else
 	fpga_mgr_unregister(&pdev->dev);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/lapc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/lapc.c
@@ -244,9 +244,17 @@ static int lapc_mmap(struct file *filp, struct vm_area_struct *vma)
 	 * and prevent the pages from being swapped out
 	 */
 #ifndef VM_RESERVED
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
 	vma->vm_flags |= VM_IO | VM_DONTEXPAND | VM_DONTDUMP;
 #else
+	vm_flags_set(vma, VM_IO | VM_DONTEXPAND | VM_DONTDUMP);
+#endif
+#else
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
 	vma->vm_flags |= VM_IO | VM_RESERVED;
+#else
+	vm_flags_set(vma, VM_IO | VM_RESERVED);
+#endif
 #endif
 
 	/* make MMIO accessible to user space */

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/qdma4.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/qdma4.c
@@ -522,7 +522,7 @@ static ssize_t qdma_migrate_bo(struct platform_device *pdev,
 	chan = &qdma->chans[write][channel];
 
 	dir = write ? DMA_TO_DEVICE : DMA_FROM_DEVICE;
-	nents = pci_map_sg(XDEV(xdev)->pdev, sgt->sgl, sgt->orig_nents, dir);
+	nents = dma_map_sg(&(XDEV(xdev)->pdev->dev), sgt->sgl, sgt->orig_nents, dir);
         if (!nents) {
 		xocl_err(&pdev->dev, "map sgl failed, sgt 0x%p.\n", sgt);
 		return -EIO;
@@ -555,7 +555,7 @@ static ssize_t qdma_migrate_bo(struct platform_device *pdev,
 		dump_sgtable(&pdev->dev, sgt);
 	}
 
-	pci_unmap_sg(XDEV(xdev)->pdev, sgt->sgl, nents, dir);
+	dma_unmap_sg(&(XDEV(xdev)->pdev->dev), sgt->sgl, nents, dir);
 	kfree(req);
 
 	return ret;
@@ -910,7 +910,9 @@ static void queue_req_free(struct qdma_stream_queue *queue,
 static void inline cmpl_aio(struct kiocb *kiocb, unsigned int done_bytes,
 		int error)
 {
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,16,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 16, 0)
+	kiocb->ki_complete(kiocb, done_bytes);
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(3, 16, 0)
 	kiocb->ki_complete(kiocb, done_bytes, error);
 #else
 	struct qdma_stream_iocb *iocb;
@@ -942,7 +944,7 @@ static void queue_req_release_resource(struct qdma_stream_queue *queue,
 	if (reqcb->is_unmgd) {
 		xdev_handle_t xdev = xocl_get_xdev(queue->qdma->pdev);
 
-		pci_unmap_sg(XDEV(xdev)->pdev, reqcb->unmgd.sgt->sgl,
+		dma_unmap_sg(&(XDEV(xdev)->pdev->dev), reqcb->unmgd.sgt->sgl,
 			     reqcb->nsg, queue->qconf.q_type == Q_C2H ?  DMA_FROM_DEVICE :
 			    				     DMA_TO_DEVICE);
 		xocl_finish_unmgd(&reqcb->unmgd);
@@ -1140,7 +1142,7 @@ static ssize_t queue_rw(struct xocl_qdma *qdma, struct qdma_stream_queue *queue,
 			goto error_out;
 		}
 
-		nents = pci_map_sg(XDEV(xdev)->pdev, unmgd.sgt->sgl,
+		nents = dma_map_sg(&(XDEV(xdev)->pdev->dev), unmgd.sgt->sgl,
 			unmgd.sgt->orig_nents, dir);
 		if (!nents) {
 			xocl_err(&qdma->pdev->dev, "map sgl failed");
@@ -1294,7 +1296,7 @@ static ssize_t queue_aio_write(struct kiocb *kiocb, const struct iovec *iov,
 	return queue_rw(qdma, queue, true, iov, nr, kiocb);
 }
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,16,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 16, 0)
 static ssize_t queue_write_iter(struct kiocb *kiocb, struct iov_iter *io)
 {
 	struct qdma_stream_queue *queue;
@@ -1311,10 +1313,18 @@ static ssize_t queue_write_iter(struct kiocb *kiocb, struct iov_iter *io)
 	}
 
 	if (!is_sync_kiocb(kiocb)) {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0)
+		return queue_aio_write(kiocb, io->__iov, nr, io->iov_offset);
+#else
 		return queue_aio_write(kiocb, io->iov, nr, io->iov_offset);
+#endif
 	}
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0)
+	return queue_rw(qdma, queue, true, io->__iov, nr, NULL);
+#else
 	return queue_rw(qdma, queue, true, io->iov, nr, NULL);
+#endif
 }
 
 static ssize_t queue_read_iter(struct kiocb *kiocb, struct iov_iter *io)
@@ -1333,9 +1343,17 @@ static ssize_t queue_read_iter(struct kiocb *kiocb, struct iov_iter *io)
 	}
 
 	if (!is_sync_kiocb(kiocb)) {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0)
+		return queue_aio_read(kiocb, io->__iov, nr, io->iov_offset);
+#else
 		return queue_aio_read(kiocb, io->iov, nr, io->iov_offset);
+#endif
 	}
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0)
+	return queue_rw(qdma, queue, false, io->__iov, nr, NULL);
+#else
 	return queue_rw(qdma, queue, false, io->iov, nr, NULL);
+#endif
 }
 #endif
 
@@ -1451,7 +1469,7 @@ static int queue_close(struct inode *inode, struct file *file)
 
 static struct file_operations queue_fops = {
 		.owner = THIS_MODULE,
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,16,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 16, 0)
 		.write_iter = queue_write_iter,
 		.read_iter = queue_read_iter,
 #else
@@ -1681,8 +1699,8 @@ static long qdma4_stream_ioctl_alloc_buffer(struct xocl_qdma *qdma,
 		goto failed;
 	}
 
-	xobj->dma_nsg = pci_map_sg(XDEV(xdev)->pdev, xobj->sgt->sgl,
-	xobj->sgt->orig_nents, PCI_DMA_BIDIRECTIONAL);
+	xobj->dma_nsg = dma_map_sg(&(XDEV(xdev)->pdev->dev), xobj->sgt->sgl,
+	xobj->sgt->orig_nents, DMA_BIDIRECTIONAL);
 	if (!xobj->dma_nsg) {
 		xocl_err(&qdma->pdev->dev, "map sgl failed, sgt");
 		ret = -EIO;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/spc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/spc.c
@@ -225,9 +225,17 @@ static int spc_mmap(struct file *filp, struct vm_area_struct *vma)
 	 * and prevent the pages from being swapped out
 	 */
 #ifndef VM_RESERVED
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
 	vma->vm_flags |= VM_IO | VM_DONTEXPAND | VM_DONTDUMP;
 #else
+	vm_flags_set(vma, VM_IO | VM_DONTEXPAND | VM_DONTDUMP);
+#endif
+#else
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
 	vma->vm_flags |= VM_IO | VM_RESERVED;
+#else
+	vm_flags_set(vma, VM_IO | VM_RESERVED);
+#endif
 #endif
 
 	/* make MMIO accessible to user space */

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/trace_fifo_lite.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/trace_fifo_lite.c
@@ -205,9 +205,17 @@ static int trace_fifo_lite_mmap(struct file *filp, struct vm_area_struct *vma)
 	 * and prevent the pages from being swapped out
 	 */
 #ifndef VM_RESERVED
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
 	vma->vm_flags |= VM_IO | VM_DONTEXPAND | VM_DONTDUMP;
 #else
+	vm_flags_set(vma, VM_IO | VM_DONTEXPAND | VM_DONTDUMP);
+#endif
+#else
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
 	vma->vm_flags |= VM_IO | VM_RESERVED;
+#else
+	vm_flags_set(vma, VM_IO | VM_RESERVED);
+#endif
 #endif
 
 	/* make MMIO accessible to user space */

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/trace_funnel.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/trace_funnel.c
@@ -208,9 +208,17 @@ static int trace_funnel_mmap(struct file *filp, struct vm_area_struct *vma)
 	 * and prevent the pages from being swapped out
 	 */
 #ifndef VM_RESERVED
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
 	vma->vm_flags |= VM_IO | VM_DONTEXPAND | VM_DONTDUMP;
 #else
+	vm_flags_set(vma, VM_IO | VM_DONTEXPAND | VM_DONTDUMP);
+#endif
+#else
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
 	vma->vm_flags |= VM_IO | VM_RESERVED;
+#else
+	vm_flags_set(vma, VM_IO | VM_RESERVED);
+#endif
 #endif
 
 	/* make MMIO accessible to user space */

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/trace_s2mm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/trace_s2mm.c
@@ -270,9 +270,17 @@ static int trace_s2mm_mmap(struct file *filp, struct vm_area_struct *vma)
 	 * and prevent the pages from being swapped out
 	 */
 #ifndef VM_RESERVED
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
 	vma->vm_flags |= VM_IO | VM_DONTEXPAND | VM_DONTDUMP;
 #else
+	vm_flags_set(vma, VM_IO | VM_DONTEXPAND | VM_DONTDUMP);
+#endif
+#else
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
 	vma->vm_flags |= VM_IO | VM_RESERVED;
+#else
+	vm_flags_set(vma, VM_IO | VM_RESERVED);
+#endif
 #endif
 
 	/* make MMIO accessible to user space */

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ulite.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ulite.c
@@ -338,8 +338,13 @@ static void ulite_shutdown(struct uart_port *port)
 	mutex_unlock(&pdata->lock);
 }
 
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(6, 1, 0)) || defined(RHEL_9_2_GE)
+static void ulite_set_termios(struct uart_port *port, struct ktermios *termios,
+			      const struct ktermios *old)
+#else
 static void ulite_set_termios(struct uart_port *port, struct ktermios *termios,
 			      struct ktermios *old)
+#endif
 {
 	unsigned long flags;
 	unsigned int baud;
@@ -549,30 +554,39 @@ done:
 	return ret;
 }
 
+/*
+ * Sometime in Kernel version 6.5+ the platform_driver probe function will have
+ * its return code changed from `int` to `void`. This is to enforce the notion
+ * that the returned error code does nothing.
+ * For now, older drivers should handle the error within this function and return
+ * anything. Once the conversion of the return type is complete we must update
+ * the return type from int to void and change all instances of `return 0` to
+ * `return`.
+ * https://elixir.bootlin.com/linux/latest/source/include/linux/platform_device.h#L211
+ */
 static int ulite_remove(struct platform_device *pdev)
 {
 	struct uart_port *port = platform_get_drvdata(pdev);
-	int ret = 0;
 	struct uartlite_data *pdata;
 
 	if (!port)
-		return ret;
+		return 0;
 
 	sysfs_remove_group(&pdev->dev.kobj, &ulite_attr_group);
 
 	pdata = port->private_data;
 	if (!pdata)
-		return ret;
+		return 0;
 
 	atomic_set(&pdata->console_opened, 0);
 	if (pdata->thread)
 		kthread_stop(pdata->thread);
 
-	ret = uart_remove_one_port(pdata->xcl_ulite_driver, port);
+	uart_remove_one_port(pdata->xcl_ulite_driver, port);
 	platform_set_drvdata(pdev, NULL);
 	port->mapbase = 0;
 
-	return ret;
+	return 0;
 }
 
 struct xocl_drv_private ulite_priv = {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xiic.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xiic.c
@@ -1012,7 +1012,7 @@ static int xiic_probe(struct platform_device *pdev)
 		I2C_SMBUS_BYTE_DATA, &data);
 
 cont:
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,8,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 8, 0)
 	i2c->lm63 = i2c_new_client_device(&i2c->adap, &lm96163_board_info);
 #else
 	i2c->lm63 = i2c_new_device(&i2c->adap, &lm96163_board_info);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.h
@@ -83,7 +83,7 @@ static inline struct drm_gem_object *xocl_gem_object_lookup(struct drm_device *d
 							    struct drm_file *filp,
 							    u32 handle)
 {
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,7,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 7, 0)
 	return drm_gem_object_lookup(filp, handle);
 #elif defined(RHEL_RELEASE_CODE)
 #if RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(7,4)
@@ -182,9 +182,12 @@ struct drm_gem_object *xocl_gem_prime_import_sg_table(struct drm_device *dev,
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 11, 0)
 void *xocl_gem_prime_vmap(struct drm_gem_object *obj);
 void xocl_gem_prime_vunmap(struct drm_gem_object *obj, void *vaddr);
-#else
+#elif LINUX_VERSION_CODE < KERNEL_VERSION(6, 2, 0)
 int xocl_gem_prime_vmap(struct drm_gem_object *obj, struct dma_buf_map *map);
 void xocl_gem_prime_vunmap(struct drm_gem_object *obj, struct dma_buf_map *map);
+#else
+int xocl_gem_prime_vmap(struct drm_gem_object *obj, struct iosys_map *map);
+void xocl_gem_prime_vunmap(struct drm_gem_object *obj, struct iosys_map *map);
 #endif
 
 int xocl_gem_prime_mmap(struct drm_gem_object *obj, struct vm_area_struct *vma);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -85,7 +85,7 @@
 /* The fix for the y2k38 bug was introduced with Linux 3.17 and backported to
  * Red Hat 7.2.
  */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 17, 0)
 	#define XOCL_TIMESPEC struct timespec64
 	#define XOCL_GETTIME ktime_get_real_ts64
 	#define XOCL_USEC tv_nsec / NSEC_PER_USEC
@@ -109,10 +109,10 @@
  * drm_gem_object_put_unlocked and drm_gem_object_get were introduced with Linux
  * 4.12 and backported to Red Hat 7.5. drm_gem_object_put_unlocked is gone since 5.9.
  */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,9,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 9, 0)
 	#define XOCL_DRM_GEM_OBJECT_PUT_UNLOCKED drm_gem_object_put
 	#define XOCL_DRM_GEM_OBJECT_GET drm_gem_object_get
-#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 12, 0)
 	#define XOCL_DRM_GEM_OBJECT_PUT_UNLOCKED drm_gem_object_put_unlocked
 	#define XOCL_DRM_GEM_OBJECT_GET drm_gem_object_get
 #elif defined(RHEL_RELEASE_CODE)
@@ -129,7 +129,7 @@
 #endif
 
 /* drm_dev_put was introduced with Linux 4.15 and backported to Red Hat 7.6. */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,15,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0)
 	#define XOCL_DRM_DEV_PUT drm_dev_put
 #elif defined(RHEL_RELEASE_CODE) && !defined(__PPC64__)
 	#if RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(7,6)
@@ -142,7 +142,7 @@
 #endif
 
 /* access_ok lost its first parameter with Linux 5.0. */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,0,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0)
 	#define XOCL_ACCESS_OK(TYPE, ADDR, SIZE) access_ok(ADDR, SIZE)
 #elif defined(RHEL_RELEASE_CODE)
         #if RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(8,1)
@@ -156,7 +156,7 @@
 
 #ifdef CONFIG_SUSE_KERNEL
 #ifndef SLE_VERSION
-#define SLE_VERSION(a,b,c) KERNEL_VERSION(a,b,c)
+#define SLE_VERSION(a,b,c) KERNEL_VERSION(a, b, c)
 #endif
 #endif
 

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -254,7 +254,7 @@ runTestCase( const std::shared_ptr<xrt_core::device>& _dev, const std::string& p
   std::ostringstream os_stderr;
   constexpr static int MAX_TEST_DURATION = 300; //5 minutes
 
-  if(json_exists()) {
+  if(json_exists() && (py != "22_verify.py")) {
     //map old testcase names to new testcase names
     static const std::map<std::string, std::string> test_map = {
       { "22_verify.py",             "validate.exe"    },


### PR DESCRIPTION
XRT-changes-to-support-kernel-6.2 and 6.5

**Problem solved by the commit**
Updated XRT 2021.1 branch to build on kernel 6.5

**How problem was solved, alternative solutions (if any) and why they were rejected**
Updated kernel interfaces that were changed. Alternate solution is to use master or latest branch of XRT, but this needs the host application and the U30 shell to be changed.

**What has been tested and how, request additional testing if necessary**
Tested multiple transcoder commands on Kernel 6.2, 6.5 and 5.11
