### PR TITLE
CR-1191227: Release xma session resources in session destroy

### DIFF
--- a/src/xma/include/lib/xma_utils.hpp
+++ b/src/xma/include/lib/xma_utils.hpp
@@ -40,6 +40,8 @@ int32_t get_default_ddr_index(int32_t dev_index, int32_t cu_index);
 int32_t check_all_execbo(XmaSession s_handle);
 void logmsg(XmaLogLevelType level, const std::string& tag, const std::string& msg);
 
+void xma_session_destroy(XmaSession *xma_session);
+
 } // namespace utils
 } // namespace xma_core
 

--- a/src/xma/src/xmaapi/xma_utils.cpp
+++ b/src/xma/src/xmaapi/xma_utils.cpp
@@ -698,5 +698,55 @@ void logmsg(XmaLogLevelType level, const std::string& tag, const std::string& ms
     return;
 }
 
+void xma_session_destroy(XmaSession *xma_session) {
+
+    int itr = 0, sess_id = xma_session->session_id;
+    /*
+    delete (XmaHwSessionPrivate*)xma_session->hw_session.private_do_not_use;
+    */
+    XmaHwSessionPrivate *priv1 = (XmaHwSessionPrivate*)xma_session->hw_session.private_do_not_use;
+    if(priv1 != nullptr) {
+        priv1->CU_cmds.clear();
+        priv1->CU_error_cmds.clear();
+        priv1->execbo_lru.clear();
+        priv1->execbo_to_check.clear();
+        for(auto& kernel_bo: priv1->kernel_execbos) {
+            xclUnmapBO(priv1->dev_handle, kernel_bo.handle, kernel_bo.data);
+            xclFreeBO(priv1->dev_handle, kernel_bo.handle);
+        }
+        priv1->kernel_execbos.clear();
+        priv1->buffer_pools.clear();
+        priv1->dev_handle = NULL;
+        priv1->kernel_info = NULL;
+        priv1->device = NULL;
+        delete priv1;
+    }
+
+    xma_session->hw_session.private_do_not_use = nullptr;
+    xma_session->plugin_data = nullptr;
+    xma_session->stats = NULL;
+    //do not change kernel in_use as it maybe in use by another plugin
+    xma_session->hw_session.dev_index = -1;
+    xma_session->session_signature = NULL;
+    xma_session->channel_id = -1;
+
+    //Free session from all_sessions_vec
+    int vec_size = g_xma_singleton->all_sessions_vec.size();
+    if(vec_size > 0) {
+        for(auto& itr1: g_xma_singleton->all_sessions_vec) {
+            if(itr1.session_id == sess_id) {
+                itr1.hw_session.dev_index = -1;
+                itr1.channel_id = -1;
+                g_xma_singleton->all_sessions_vec.erase(g_xma_singleton->all_sessions_vec.begin() + itr);
+                if(vec_size == 1)
+                    g_xma_singleton->all_sessions_vec.clear();
+                break;
+            }
+            itr += 1;
+        }
+    }
+    return;
+}
+
 } // namespace utils
 } // namespace xma_core

--- a/src/xma/src/xmaapi/xmaadmin.cpp
+++ b/src/xma/src/xmaapi/xmaadmin.cpp
@@ -243,17 +243,9 @@ xma_admin_session_destroy(XmaAdminSession *session)
     // Clean up the private data
     free(session->base.plugin_data);
 
+    xma_core::utils::xma_session_destroy(&session->base);
+
     // Free the session
-    /*
-    delete (XmaHwSessionPrivate*)session->base.hw_session.private_do_not_use;
-    */
-    session->base.hw_session.private_do_not_use = nullptr;
-    session->base.plugin_data = nullptr;
-    session->base.stats = NULL;
-    session->admin_plugin = NULL;
-    //do not change kernel in_use as it maybe in use by another plugin
-    session->base.hw_session.dev_index = -1;
-    session->base.session_signature = NULL;
     free(session);
     session = nullptr;
 

--- a/src/xma/src/xmaapi/xmadecoder.cpp
+++ b/src/xma/src/xmaapi/xmadecoder.cpp
@@ -287,13 +287,9 @@ xma_dec_session_destroy(XmaDecoderSession *session)
     // Clean up the private data
     free(session->base.plugin_data);
 
-    session->base.hw_session.private_do_not_use = nullptr;
-    session->base.plugin_data = nullptr;
-    session->base.stats = NULL;
-    session->decoder_plugin = NULL;
-    //do not change kernel in_use as it maybe in use by another plugin
-    session->base.hw_session.dev_index = -1;
-    session->base.session_signature = NULL;
+    xma_core::utils::xma_session_destroy(&session->base);
+
+    // Free the session
     free(session);
     session = nullptr;
 

--- a/src/xma/src/xmaapi/xmaencoder.cpp
+++ b/src/xma/src/xmaapi/xmaencoder.cpp
@@ -335,19 +335,9 @@ xma_enc_session_destroy(XmaEncoderSession *session)
     // Clean up the private data
     free(session->base.plugin_data);
 
+    xma_core::utils::xma_session_destroy(&session->base);
+
     // Free the session
-    //Let's not chnage in_use and num of encoders
-    //It is better to have different session_id for debugging
-    /*
-    delete (XmaHwSessionPrivate*)session->base.hw_session.private_do_not_use;
-    */
-    session->base.hw_session.private_do_not_use = nullptr;
-    session->base.plugin_data = nullptr;
-    session->base.stats = NULL;
-    session->encoder_plugin = NULL;
-    //do not change kernel in_use as it maybe in use by another plugin
-    session->base.hw_session.dev_index = -1;
-    session->base.session_signature = NULL;
     free(session);
     session = nullptr;
 

--- a/src/xma/src/xmaapi/xmafilter.cpp
+++ b/src/xma/src/xmaapi/xmafilter.cpp
@@ -287,17 +287,9 @@ xma_filter_session_destroy(XmaFilterSession *session)
     // Clean up the private data
     free(session->base.plugin_data);
 
+    xma_core::utils::xma_session_destroy(&session->base);
+
     // Free the session
-    /*
-    delete (XmaHwSessionPrivate*)session->base.hw_session.private_do_not_use;
-    */
-    session->base.hw_session.private_do_not_use = nullptr;
-    session->base.plugin_data = nullptr;
-    session->base.stats = NULL;
-    session->filter_plugin = NULL;
-    //do not change kernel in_use as it maybe in use by another plugin
-    session->base.hw_session.dev_index = -1;
-    session->base.session_signature = NULL;
     free(session);
     session = nullptr;
 

--- a/src/xma/src/xmaapi/xmakernel.cpp
+++ b/src/xma/src/xmaapi/xmakernel.cpp
@@ -286,17 +286,9 @@ xma_kernel_session_destroy(XmaKernelSession *session)
     // Clean up the private data
     free(session->base.plugin_data);
 
+    xma_core::utils::xma_session_destroy(&session->base);
+
     // Free the session
-    /*
-    delete (XmaHwSessionPrivate*)session->base.hw_session.private_do_not_use;
-    */
-    session->base.hw_session.private_do_not_use = nullptr;
-    session->base.plugin_data = nullptr;
-    session->base.stats = NULL;
-    session->kernel_plugin = NULL;
-    //do not change kernel in_use as it maybe in use by another plugin
-    session->base.hw_session.dev_index = -1;
-    session->base.session_signature = NULL;
     free(session);
     session = nullptr;
 

--- a/src/xma/src/xmaapi/xmascaler.cpp
+++ b/src/xma/src/xmaapi/xmascaler.cpp
@@ -386,17 +386,9 @@ xma_scaler_session_destroy(XmaScalerSession *session)
     // Clean up the private data
     free(session->base.plugin_data);
 
+    xma_core::utils::xma_session_destroy(&session->base);
+
     // Free the session
-    /*
-    delete (XmaHwSessionPrivate*)session->base.hw_session.private_do_not_use;
-    */
-    session->base.hw_session.private_do_not_use = nullptr;
-    session->base.plugin_data = nullptr;
-    session->base.stats = NULL;
-    session->scaler_plugin = NULL;
-    //do not change kernel in_use as it maybe in use by another plugin
-    session->base.hw_session.dev_index = -1;
-    session->base.session_signature = NULL;
     free(session);
     session = nullptr;
 


### PR DESCRIPTION
**Problem solved by the commit**
Released all the xma session resources in session destroy.

**Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered**
Observed small memory leak when we create and destroy session multiple times without exiting the application/process. In a streaming applications, the process will be live always. During an incoming stream, session creation will be done and session destroy will be called at the end of stream. If we run create and destroy session in a loop, memory gradually increases.

**How problem was solved, alternative solutions (if any) and why they were rejected**
During session destroy all the resources(including init time) are freed.

**What has been tested and how, request additional testing if necessary**
Tested with sample application looping session create and destroy for multiple hours, didn't observed memory increase.
