### PR TITLE
[XDP] Fix the incorrect xclbin type deduction & add safe check

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info_database.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info_database.cpp
@@ -2261,6 +2261,8 @@ namespace xdp {
         is_aie_available = true;
 
     data = xrt_core::xclbin_int::get_axlf_section(xclbin, IP_LAYOUT);
+    if (!data.first || !data.second)
+      data = xrt_core::xclbin_int::get_axlf_section(xclbin, DEBUG_IP_LAYOUT);
     if (data.first && data.second)
         is_pl_available = true;
 

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -238,7 +238,10 @@ void AieTracePluginUnified::updateAIEDevice(void *handle) {
 
   // First, check against memory bank size
   // NOTE: Check first buffer for PLIO; assume bank 0 for GMIO
-  uint8_t memIndex = (isPLIO && (deviceIntf != nullptr))? deviceIntf->getAIETs2mmMemIndex(0) : 0;
+  uint8_t memIndex = 0;
+  if (isPLIO && (deviceIntf != nullptr))
+   memIndex = deviceIntf->getAIETs2mmMemIndex(0);
+
   Memory *memory = (db->getStaticInfo()).getMemory(deviceID, memIndex);
 
   if (memory != nullptr) {

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -238,7 +238,7 @@ void AieTracePluginUnified::updateAIEDevice(void *handle) {
 
   // First, check against memory bank size
   // NOTE: Check first buffer for PLIO; assume bank 0 for GMIO
-  uint8_t memIndex = isPLIO ? deviceIntf->getAIETs2mmMemIndex(0) : 0;
+  uint8_t memIndex = (isPLIO && (deviceIntf != nullptr))? deviceIntf->getAIETs2mmMemIndex(0) : 0;
   Memory *memory = (db->getStaticInfo()).getMemory(deviceID, memIndex);
 
   if (memory != nullptr) {

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -240,7 +240,7 @@ void AieTracePluginUnified::updateAIEDevice(void *handle) {
   // NOTE: Check first buffer for PLIO; assume bank 0 for GMIO
   uint8_t memIndex = 0;
   if (isPLIO && (deviceIntf != nullptr))
-   memIndex = deviceIntf->getAIETs2mmMemIndex(0);
+    memIndex = deviceIntf->getAIETs2mmMemIndex(0);
 
   Memory *memory = (db->getStaticInfo()).getMemory(deviceID, memIndex);
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
CR-1208980 : PLIO designs mentioned in the CR are running into segfaults.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
code flow incorrectly deduce the xclbin type is of AIE Only type and doesn't create PLIO interface.

#### How problem was solved, alternative solutions (if any) and why they were rejected
To correctly check if xclbin type specially PL part of xclbin , now we rely on both `IP_LAYOUT` and `DEBUG_IP_LAYOUT`.
These both sections are not packaged in AIE only xclbin.

#### Risks (if any) associated the changes in the commit
minimal

#### What has been tested and how, request additional testing if necessary
Testing pending on vck190. Local changes are not being packaged along with latest petalinux image.
Update:
Verified on VCK190 by falling back to older label and petalinux image. Confirmed that  mentioned crash is not seen & trace is generated.
However, we do see lof messages emitted from driver like below during execution which needs to be triaged separately.
`xrtSyncBOAIENB: name gr.gm_out0, bo 0xaaaaaab3da40, XCL_BO_SYNC_BO_AIE_TO_GMIO, transaction size 128, offset 262016`

#### Documentation impact (if any)
