### PR TITLE
XRT OS Support for Ubuntu 24.04. Removed one element arrays in the driver code

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/include/mailbox_proto.h
+++ b/src/runtime_src/core/pcie/driver/linux/include/mailbox_proto.h
@@ -392,7 +392,7 @@ struct xcl_mailbox_clock_freqscaling {
 struct xcl_mailbox_req {
 	uint64_t flags;
 	int32_t req;
-	int32_t data[1]; /* variable length of payload from now on */
+	int32_t data[]; /* variable length of payload from now on */
 };
 
 /**

--- a/src/runtime_src/core/pcie/driver/linux/include/mailbox_proto.h
+++ b/src/runtime_src/core/pcie/driver/linux/include/mailbox_proto.h
@@ -286,7 +286,7 @@ struct xcl_subdev {
 	uint64_t checksum;
 	uint64_t size;
 	uint64_t offset;
-	uint64_t data[1];
+	uint64_t data[];
 };
 /**
  * struct mailbox_subdev_peer - MAILBOX_REQ_PEER_DATA payload type

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
@@ -571,7 +571,7 @@ reset:
 		if (!lro->reset_requested) {
 			mgmt_err(lro, "Card is in a Bad state, notify userpf");
 			mbreq.req = XCL_MAILBOX_REQ_FIREWALL;
-			err = xocl_peer_notify(lro, &mbreq, sizeof(mbreq));
+			err = xocl_peer_notify(lro, &mbreq, sizeof(mbreq) + sizeof(int32_t));
 			if (!err)
 				lro->reset_requested = true;
 		} else
@@ -898,11 +898,11 @@ void xclmgmt_mailbox_srv(void *arg, void *data, size_t len,
 	bool is_sw = false;
 	size_t payload_len;
 
-	if (len < sizeof(*req)) {
+	if (len < struct_size(req, data, 1)) {
 		mgmt_err(lro, "peer request dropped due to wrong size\n");
 		return;
 	}
-	payload_len = len - sizeof(*req);
+	payload_len = len - struct_size(req, data, 1);
 
 	mgmt_dbg(lro, "received request (%d) from peer sw_ch %d\n",
 		req->req, sw_ch);
@@ -1258,7 +1258,7 @@ void xclmgmt_connect_notify(struct xclmgmt_dev *lro, bool online)
 	size_t data_len = 0, reqlen = 0;
 
 	data_len = sizeof(struct xcl_mailbox_peer_state);
-	reqlen = sizeof(struct xcl_mailbox_req) + data_len;
+	reqlen = struct_size(mb_req, data, 1) + data_len;
 	mb_req = vzalloc(reqlen);
 	if (!mb_req)
 		return;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
@@ -725,7 +725,7 @@ static void xclmgmt_subdev_get_data(struct xclmgmt_dev *lro, size_t offset,
 
 	if (lro->rp_program == XOCL_RP_PROGRAM_REQ) {
 		/* previous request is missed */
-		data_sz = sizeof(*hdr);
+		data_sz = struct_size(hdr, data, 1);
 		rtn_code = XOCL_MSG_SUBDEV_RTN_PENDINGPLP;
 	} else {
 		fdt_sz = lro->userpf_blob ? fdt_totalsize(lro->userpf_blob) : 0;
@@ -737,13 +737,13 @@ static void xclmgmt_subdev_get_data(struct xclmgmt_dev *lro, size_t offset,
 		else
 			rtn_code = XOCL_MSG_SUBDEV_RTN_COMPLETE;
 
-		data_sz += sizeof(*hdr);
+		data_sz += struct_size(hdr, data, 1);
 	}
 
 	*actual_sz = min_t(size_t, buf_sz, data_sz);
 
 	/* if it is invalid req, do nothing */
-	if (*actual_sz < sizeof(*hdr)) {
+	if (*actual_sz < struct_size(hdr, data, 1)) {
 		mgmt_err(lro, "Req buffer is too small");
 		return;
 	}
@@ -756,7 +756,7 @@ static void xclmgmt_subdev_get_data(struct xclmgmt_dev *lro, size_t offset,
 
 	hdr = *resp;
 	hdr->ver = XOCL_MSG_SUBDEV_VER;
-	hdr->size = *actual_sz - sizeof(*hdr);
+	hdr->size = *actual_sz - struct_size(hdr, data, 1);
 	hdr->offset = offset;
 	hdr->rtncode = rtn_code;
 	//hdr->checksum = csum_partial(hdr->data, hdr->size, 0);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
@@ -571,7 +571,7 @@ reset:
 		if (!lro->reset_requested) {
 			mgmt_err(lro, "Card is in a Bad state, notify userpf");
 			mbreq.req = XCL_MAILBOX_REQ_FIREWALL;
-			err = xocl_peer_notify(lro, &mbreq, sizeof(mbreq) + sizeof(int32_t));
+			err = xocl_peer_notify(lro, &mbreq, struct_size(&mbreq, data, 1));
 			if (!err)
 				lro->reset_requested = true;
 		} else

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/dna.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/dna.c
@@ -86,7 +86,7 @@ static void xlnx_dna_read_from_peer(struct platform_device *pdev)
 	size_t resp_len = sizeof(struct xcl_dna);
 	size_t data_len = sizeof(struct xcl_mailbox_subdev_peer);
 	struct xcl_mailbox_req *mb_req = NULL;
-	size_t reqlen = sizeof(struct xcl_mailbox_req) + data_len;
+	size_t reqlen = struct_size(mb_req, data, 1) + data_len;
 	xdev_handle_t xdev = xocl_get_xdev(pdev);
 
 	mb_req = vmalloc(reqlen);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/firewall.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/firewall.c
@@ -175,7 +175,7 @@ static void request_firewall_status(struct platform_device *pdev)
 	size_t resp_len = sizeof(struct xcl_firewall);
 	size_t data_len = sizeof(struct xcl_mailbox_subdev_peer);
 	struct xcl_mailbox_req *mb_req = NULL;
-	size_t reqlen = sizeof(struct xcl_mailbox_req) + data_len;
+	size_t reqlen = struct_size(mb_req, data, 1) + data_len;
 	XOCL_TIMESPEC time;
 	xdev_handle_t xdev = xocl_get_xdev(pdev);
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/hwmon_sdm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/hwmon_sdm.c
@@ -234,10 +234,10 @@ static int hwmon_sdm_read_from_peer(struct platform_device *pdev, int repo_type,
                                     uint64_t data_args)
 {
 	size_t data_len = sizeof(struct xcl_mailbox_subdev_peer);
-	size_t reqlen = sizeof(struct xcl_mailbox_req) + data_len;
 	struct xcl_mailbox_subdev_peer subdev_peer = {0};
 	xdev_handle_t xdev = xocl_get_xdev(pdev);
 	struct xcl_mailbox_req *mb_req = NULL;
+	size_t reqlen = struct_size(mb_req, data, 1) + data_len;
 	int ret = 0;
 
 	mb_req = vmalloc(reqlen);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -369,7 +369,7 @@ static uint32_t icap_multislot_version_from_peer(struct platform_device *pdev)
 	size_t resp_len = sizeof(struct xcl_multislot_info);
 	size_t data_len = sizeof(struct xcl_mailbox_subdev_peer);
 	struct xcl_mailbox_req *mb_req = NULL;
-	size_t reqlen = sizeof(struct xcl_mailbox_req) + data_len;
+	size_t reqlen = struct_size(mb_req, data, 1) + data_len;
 	xdev_handle_t xdev = xocl_get_xdev(pdev);
 
 	ICAP_INFO(icap, "reading from peer");
@@ -402,7 +402,7 @@ static void icap_read_from_peer(struct platform_device *pdev)
 	size_t resp_len = sizeof(struct xcl_pr_region);
 	size_t data_len = sizeof(struct xcl_mailbox_subdev_peer);
 	struct xcl_mailbox_req *mb_req = NULL;
-	size_t reqlen = sizeof(struct xcl_mailbox_req) + data_len;
+	size_t reqlen = struct_size(mb_req, data, 1) + data_len;
 	xdev_handle_t xdev = xocl_get_xdev(pdev);
 
 	ICAP_INFO(icap, "reading from peer");
@@ -1328,7 +1328,7 @@ static int icap_download_rp(struct platform_device *pdev, int level, int flag)
 
 	else if (flag == RP_DOWNLOAD_NORMAL) {
 		(void) xocl_peer_notify(xocl_get_xdev(icap->icap_pdev), &mbreq,
-				sizeof(struct xcl_mailbox_req));
+				sizeof(mbreq) + sizeof(int32_t));
 		ICAP_INFO(icap, "Notified userpf to program rp");
 		goto end;
 	}
@@ -1946,7 +1946,7 @@ static int icap_peer_xclbin_prepare(struct icap *icap, struct axlf *xclbin,
 	if ((ch_state & XCL_MB_PEER_SAME_DOMAIN) != 0) {
 		if (icap_ver == MULTISLOT_VERSION) {
 			struct xcl_mailbox_bitstream_slot_kaddr slot_mb_addr = {0};
-			datalen = sizeof(struct xcl_mailbox_req) +
+			datalen = struct_size(mb_ptr, data, 1) +
 				sizeof(struct xcl_mailbox_bitstream_slot_kaddr);
 			mb_ptr = vmalloc(datalen);
 			if (!mb_ptr) {
@@ -1961,7 +1961,7 @@ static int icap_peer_xclbin_prepare(struct icap *icap, struct axlf *xclbin,
 		}
 		else {
 			struct xcl_mailbox_bitstream_kaddr mb_addr = {0};
-			datalen = sizeof(struct xcl_mailbox_req) +
+			datalen = struct_size(mb_ptr, data, 1) +
 				sizeof(struct xcl_mailbox_bitstream_kaddr);
 			mb_ptr = vmalloc(datalen);
 			if (!mb_ptr) {
@@ -1977,7 +1977,7 @@ static int icap_peer_xclbin_prepare(struct icap *icap, struct axlf *xclbin,
 		if (icap_ver == MULTISLOT_VERSION) {
 			struct xcl_mailbox_bitstream_slot_xclbin slot_xclbin = {0};
 			void *data_ptr = NULL;
-			datalen = sizeof(struct xcl_mailbox_req) +
+			datalen =  struct_size(mb_ptr, data, 1) +
 				sizeof(struct xcl_mailbox_bitstream_slot_xclbin) +
 				xclbin->m_header.m_length;
 			mb_ptr = vmalloc(datalen);
@@ -2000,7 +2000,7 @@ static int icap_peer_xclbin_prepare(struct icap *icap, struct axlf *xclbin,
 			memcpy(data_ptr, xclbin, xclbin->m_header.m_length);
 		}
 		else {
-			datalen = sizeof(struct xcl_mailbox_req) +
+			datalen = struct_size(mb_ptr, data, 1) +
 				xclbin->m_header.m_length;
 			mb_ptr = vmalloc(datalen);
 			if (!mb_ptr) {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -1328,7 +1328,7 @@ static int icap_download_rp(struct platform_device *pdev, int level, int flag)
 
 	else if (flag == RP_DOWNLOAD_NORMAL) {
 		(void) xocl_peer_notify(xocl_get_xdev(icap->icap_pdev), &mbreq,
-				sizeof(mbreq) + sizeof(int32_t));
+				struct_size(&mbreq, data, 1));
 		ICAP_INFO(icap, "Notified userpf to program rp");
 		goto end;
 	}

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mailbox.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mailbox.c
@@ -1775,7 +1775,7 @@ static ssize_t mailbox_show(struct device *dev,
 	int ret = 0;
 
 	req.req = XCL_MAILBOX_REQ_TEST_READ;
-	ret = mailbox_request(to_platform_device(dev), &req, sizeof(req),
+	ret = mailbox_request(to_platform_device(dev), &req, sizeof(req) + sizeof(int32_t),
 		mbx->mbx_tst_rx_msg, &respsz, NULL, NULL, 0, 0);
 	if (ret) {
 		MBX_ERR(mbx, "failed to read test msg from peer: %d", ret);
@@ -1803,7 +1803,7 @@ static ssize_t mailbox_store(struct device *dev,
 	(void) memcpy(mbx->mbx_tst_tx_msg, buf, count);
 	mbx->mbx_tst_tx_msg_len = count;
 	req.req = XCL_MAILBOX_REQ_TEST_READY;
-	(void) mailbox_post_notify(mbx->mbx_pdev, &req, sizeof(req));
+	(void) mailbox_post_notify(mbx->mbx_pdev, &req, sizeof(req) + sizeof(int32_t));
 
 	return count;
 }
@@ -1880,7 +1880,7 @@ static void mailbox_send_test_load_xclbin_kaddr(struct mailbox *mbx)
 	mbx->mbx_recv_body_len = sizeof (int);
 
 	data_len = sizeof(struct xcl_mailbox_bitstream_kaddr);
-	reqlen = sizeof(struct xcl_mailbox_req) + data_len;
+	reqlen =  sizeof(req) + sizeof(int32_t) + data_len;
 	req = kzalloc(reqlen, GFP_KERNEL);
 	if (!req) {
 		mbx->mbx_test_send_status = -ENOMEM;
@@ -1917,7 +1917,7 @@ static void _mailbox_send_test(struct mailbox *mbx, size_t data_len, size_t resp
 		mbx->mbx_recv_body_len = resp_len;
 	}
 
-	reqlen = sizeof(struct xcl_mailbox_req) + data_len;
+	reqlen = sizeof(req) + sizeof(int32_t) + data_len;
 	req = vzalloc(reqlen);
 	if (!req) {
 		mbx->mbx_test_send_status = -ENOMEM;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mailbox.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mailbox.c
@@ -1775,7 +1775,7 @@ static ssize_t mailbox_show(struct device *dev,
 	int ret = 0;
 
 	req.req = XCL_MAILBOX_REQ_TEST_READ;
-	ret = mailbox_request(to_platform_device(dev), &req, sizeof(req) + sizeof(int32_t),
+	ret = mailbox_request(to_platform_device(dev), &req, struct_size(&req, data, 1),
 		mbx->mbx_tst_rx_msg, &respsz, NULL, NULL, 0, 0);
 	if (ret) {
 		MBX_ERR(mbx, "failed to read test msg from peer: %d", ret);
@@ -1803,7 +1803,7 @@ static ssize_t mailbox_store(struct device *dev,
 	(void) memcpy(mbx->mbx_tst_tx_msg, buf, count);
 	mbx->mbx_tst_tx_msg_len = count;
 	req.req = XCL_MAILBOX_REQ_TEST_READY;
-	(void) mailbox_post_notify(mbx->mbx_pdev, &req, sizeof(req) + sizeof(int32_t));
+	(void) mailbox_post_notify(mbx->mbx_pdev, &req, struct_size(&req, data, 1));
 
 	return count;
 }
@@ -1880,7 +1880,7 @@ static void mailbox_send_test_load_xclbin_kaddr(struct mailbox *mbx)
 	mbx->mbx_recv_body_len = sizeof (int);
 
 	data_len = sizeof(struct xcl_mailbox_bitstream_kaddr);
-	reqlen =  sizeof(req) + sizeof(int32_t) + data_len;
+	reqlen =  struct_size(req, data, 1) + data_len;
 	req = kzalloc(reqlen, GFP_KERNEL);
 	if (!req) {
 		mbx->mbx_test_send_status = -ENOMEM;
@@ -1917,7 +1917,7 @@ static void _mailbox_send_test(struct mailbox *mbx, size_t data_len, size_t resp
 		mbx->mbx_recv_body_len = resp_len;
 	}
 
-	reqlen = sizeof(req) + sizeof(int32_t) + data_len;
+	reqlen =  struct_size(req, data, 1) + data_len;
 	req = vzalloc(reqlen);
 	if (!req) {
 		mbx->mbx_test_send_status = -ENOMEM;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/p2p.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/p2p.c
@@ -502,7 +502,7 @@ static void p2p_read_addr_mgmtpf(struct p2p *p2p)
 		return;
 
 	mb_p2p_len = sizeof(struct xcl_mailbox_p2p_bar_addr);
-	reqlen = sizeof(struct xcl_mailbox_req) + mb_p2p_len;
+	reqlen = struct_size(mb_req, data, 1) + mb_p2p_len;
 	mb_req = vzalloc(reqlen);
 	if (!mb_req) {
 		p2p_err(p2p, "dropped request (%d), mem alloc issue",

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
@@ -553,7 +553,7 @@ static void xmc_read_from_peer(struct platform_device *pdev)
 	size_t resp_len = sizeof(struct xcl_sensor);
 	size_t data_len = sizeof(struct xcl_mailbox_subdev_peer);
 	struct xcl_mailbox_req *mb_req = NULL;
-	size_t reqlen = sizeof(struct xcl_mailbox_req) + data_len;
+	size_t reqlen = struct_size(mb_req, data, 1) + data_len;
 	xdev_handle_t xdev = xocl_get_xdev(pdev);
 
 	xocl_info(&pdev->dev, "reading from peer");
@@ -987,7 +987,7 @@ static void read_bdinfo_from_peer(struct platform_device *pdev)
 	size_t resp_len = sizeof(struct xcl_board_info);
 	size_t data_len = sizeof(struct xcl_mailbox_subdev_peer);
 	struct xcl_mailbox_req *mb_req = NULL;
-	size_t reqlen = sizeof(struct xcl_mailbox_req) + data_len;
+	size_t reqlen = struct_size(mb_req, data, 1) + data_len;
 	xdev_handle_t xdev = xocl_get_xdev(pdev);
 	int ret = 0;
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc_u2.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc_u2.c
@@ -488,7 +488,7 @@ static void xmc_read_from_peer(struct platform_device *pdev)
 	size_t resp_len = sizeof(struct xcl_sensor);
 	size_t data_len = sizeof(struct xcl_mailbox_subdev_peer);
 	struct xcl_mailbox_req *mb_req = NULL;
-	size_t reqlen = sizeof(struct xcl_mailbox_req) + data_len;
+	size_t reqlen = struct_size(mb_req, data, 1) + data_len;
 	xdev_handle_t xdev = xocl_get_xdev(pdev);
 
 	xocl_info(&pdev->dev, "reading from peer");
@@ -892,7 +892,7 @@ static void read_bdinfo_from_peer(struct platform_device *pdev)
 	size_t resp_len = sizeof(struct xcl_board_info);
 	size_t data_len = sizeof(struct xcl_mailbox_subdev_peer);
 	struct xcl_mailbox_req *mb_req = NULL;
-	size_t reqlen = sizeof(struct xcl_mailbox_req) + data_len;
+	size_t reqlen = struct_size(mb_req, data, 1) + data_len;
 	xdev_handle_t xdev = xocl_get_xdev(pdev);
 	int ret = 0;
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
@@ -569,9 +569,6 @@ const struct drm_gem_object_funcs xocl_gem_object_funcs = {
         .vmap = xocl_gem_prime_vmap,
         .vunmap = xocl_gem_prime_vunmap,
         .export = drm_gem_prime_export,
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
-        .mmap = xocl_gem_prime_mmap,
-#endif
 };
 #endif
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
@@ -674,7 +674,7 @@ int xocl_reclock(struct xocl_dev *xdev, void *data)
 	req = kzalloc(reqlen, GFP_KERNEL);
 	req->req = XCL_MAILBOX_REQ_RECLOCK;
 	memcpy(req->data, data, data_len);
- 
+
 	if (get_live_clients(xdev, NULL)) {
 		userpf_err(xdev, "device is in use, can't reset");
 		err = -EBUSY;
@@ -829,7 +829,7 @@ int xocl_refresh_subdevs(struct xocl_dev *xdev)
 	struct xcl_mailbox_req	*mb_req = NULL;
 	size_t reqlen = struct_size(mb_req, data, 1) + data_len;
 	struct xcl_subdev	*resp = NULL;
-	size_t resp_len = sizeof(*resp) + XOCL_MSG_SUBDEV_DATA_LEN;
+	size_t resp_len = struct_size(resp, data, 1) + XOCL_MSG_SUBDEV_DATA_LEN;
 	char *blob = NULL;
 	char *tmp = NULL;
 	u32 blob_len = 0;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
@@ -114,7 +114,7 @@ static void xocl_mig_cache_read_from_peer(struct xocl_dev *xdev)
 	size_t resp_len = sizeof(struct xcl_mig_ecc)*MAX_M_COUNT;
 	size_t data_len = sizeof(struct xcl_mailbox_subdev_peer);
 	struct xcl_mailbox_req *mb_req = NULL;
-	size_t reqlen = sizeof(struct xcl_mailbox_req) + data_len;
+	size_t reqlen = struct_size(mb_req, data, 1) + data_len;
 	int ret = 0;
 
 	mb_req = vmalloc(reqlen);
@@ -327,7 +327,7 @@ int xocl_program_shell(struct xocl_dev *xdev, bool force)
 		goto failed;
 
 	userpf_info(xdev, "request mgmtpf to program prp");
-	mbret = xocl_peer_request(xdev, &mbreq, sizeof(struct xcl_mailbox_req),
+	mbret = xocl_peer_request(xdev, &mbreq, sizeof(mbreq) + sizeof(int32_t),
 		&ret, &resplen, NULL, NULL, 0, 0);
 	if (mbret)
 		ret = mbret;
@@ -403,7 +403,7 @@ int xocl_hot_reset(struct xocl_dev *xdev, u32 flag)
 		if (flag & XOCL_RESET_NO)
 			return 0;
 
-		mbret = xocl_peer_request(xdev, &mbreq, sizeof(struct xcl_mailbox_req),
+		mbret = xocl_peer_request(xdev, &mbreq, sizeof(mbreq) + sizeof(int32_t),
 			&ret, &resplen, NULL, NULL, 0, 6);
 		/*
 		 * Check the return values mbret & ret (mpd (peer) side response) and confirm
@@ -426,7 +426,7 @@ int xocl_hot_reset(struct xocl_dev *xdev, u32 flag)
 		return 0;
 	}
 
-	mbret = xocl_peer_request(xdev, &mbreq, sizeof(struct xcl_mailbox_req),
+	mbret = xocl_peer_request(xdev, &mbreq, sizeof(mbreq) + sizeof(int32_t),
 		&ret, &resplen, NULL, NULL, 0, 0);
 
 	xocl_reset_notify(xdev->core.pdev, true);
@@ -607,7 +607,7 @@ static void xocl_mb_connect(struct xocl_dev *xdev)
 		goto done;
 
 	data_len = sizeof(struct xcl_mailbox_conn);
-	reqlen = sizeof(struct xcl_mailbox_req) + data_len;
+	reqlen = struct_size(mb_req, data, 1) + data_len;
 	mb_req = vzalloc(reqlen);
 	if (!mb_req)
 		goto done;
@@ -652,7 +652,7 @@ int xocl_reclock(struct xocl_dev *xdev, void *data)
 	struct xcl_mailbox_req *req = NULL;
 	size_t resplen = sizeof(msg);
 	size_t data_len = sizeof(struct xcl_mailbox_clock_freqscaling);
-	size_t reqlen = sizeof(struct xcl_mailbox_req)+data_len;
+	size_t reqlen = struct_size(req, data, 1) + data_len;
 	struct drm_xocl_reclock_info *freqs = (struct drm_xocl_reclock_info *)data;
 	struct xcl_mailbox_clock_freqscaling mb_freqs = {0};
 
@@ -674,7 +674,7 @@ int xocl_reclock(struct xocl_dev *xdev, void *data)
 	req = kzalloc(reqlen, GFP_KERNEL);
 	req->req = XCL_MAILBOX_REQ_RECLOCK;
 	memcpy(req->data, data, data_len);
-
+ 
 	if (get_live_clients(xdev, NULL)) {
 		userpf_err(xdev, "device is in use, can't reset");
 		err = -EBUSY;
@@ -827,7 +827,7 @@ int xocl_refresh_subdevs(struct xocl_dev *xdev)
 	struct xcl_mailbox_subdev_peer subdev_peer = {0};
 	size_t data_len = sizeof(struct xcl_mailbox_subdev_peer);
 	struct xcl_mailbox_req	*mb_req = NULL;
-	size_t reqlen = sizeof(struct xcl_mailbox_req) + data_len;
+	size_t reqlen = struct_size(mb_req, data, 1) + data_len;
 	struct xcl_subdev	*resp = NULL;
 	size_t resp_len = sizeof(*resp) + XOCL_MSG_SUBDEV_DATA_LEN;
 	char *blob = NULL;
@@ -1036,7 +1036,7 @@ static int xocl_hwmon_sdm_init_sysfs(struct xocl_dev *xdev, enum xcl_group_kind 
 	size_t data_len = sizeof(struct xcl_mailbox_subdev_peer);
 	struct xcl_mailbox_req *mb_req = NULL;
 	char *in_buf = NULL;
-	size_t reqlen = sizeof(struct xcl_mailbox_req) + data_len;
+	size_t reqlen = struct_size(mb_req, data, 1) + data_len;
 	int ret = 0;
 
 	mb_req = vmalloc(reqlen);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
@@ -327,7 +327,7 @@ int xocl_program_shell(struct xocl_dev *xdev, bool force)
 		goto failed;
 
 	userpf_info(xdev, "request mgmtpf to program prp");
-	mbret = xocl_peer_request(xdev, &mbreq, sizeof(mbreq) + sizeof(int32_t),
+	mbret = xocl_peer_request(xdev, &mbreq, struct_size(&mbreq, data, 1),
 		&ret, &resplen, NULL, NULL, 0, 0);
 	if (mbret)
 		ret = mbret;
@@ -403,7 +403,7 @@ int xocl_hot_reset(struct xocl_dev *xdev, u32 flag)
 		if (flag & XOCL_RESET_NO)
 			return 0;
 
-		mbret = xocl_peer_request(xdev, &mbreq, sizeof(mbreq) + sizeof(int32_t),
+		mbret = xocl_peer_request(xdev, &mbreq, struct_size(&mbreq, data, 1),
 			&ret, &resplen, NULL, NULL, 0, 6);
 		/*
 		 * Check the return values mbret & ret (mpd (peer) side response) and confirm
@@ -426,7 +426,7 @@ int xocl_hot_reset(struct xocl_dev *xdev, u32 flag)
 		return 0;
 	}
 
-	mbret = xocl_peer_request(xdev, &mbreq, sizeof(mbreq) + sizeof(int32_t),
+	mbret = xocl_peer_request(xdev, &mbreq, struct_size(&mbreq, data, 1),
 		&ret, &resplen, NULL, NULL, 0, 0);
 
 	xocl_reset_notify(xdev->core.pdev, true);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -444,7 +444,7 @@ struct xocl_subdev_priv {
 	unsigned long		debug_hdl;
 	u32			inst_idx;
 	u32			data_sz;
-	u64			data[1];
+	u64			data[];
 };
 
 #define INVALID_INST_INDEX	0xFFFF
@@ -462,7 +462,7 @@ static inline void *xocl_subdev_priv_alloc(u32 size)
 {
 	struct xocl_subdev_priv *priv;
 
-	priv = vzalloc(sizeof(*priv) + size);
+	priv = vzalloc(struct_size(priv, data, 1) + size);
 	if (!priv)
 		return NULL;
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_subdev.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_subdev.c
@@ -534,7 +534,7 @@ static int __xocl_subdev_construct(xdev_handle_t xdev_hdl,
 	}
 
 	if (!priv_data) {
-		priv_data = vzalloc(subdev->info.data_len + sizeof(*priv_data));
+		priv_data = vzalloc(subdev->info.data_len + struct_size(priv_data, data, 1));
 		if (!priv_data) {
 			retval = -ENOMEM;
 			goto error;
@@ -555,7 +555,7 @@ static int __xocl_subdev_construct(xdev_handle_t xdev_hdl,
 	priv_data->inst_idx = subdev->info.override_idx;
 
 	retval = platform_device_add_data(subdev->pldev, priv_data,
-			sizeof(*priv_data) + data_len);
+			struct_size(priv_data, data, 1) + data_len);
 	if (retval) {
 		xocl_xdev_err(xdev_hdl, "failed to add data");
 		goto error;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/VITIS-12053 XRT OS Support for Ubuntu 24.04

This is an intial PR to move to flexible arrays instead of one length array in structures. Reference: https://www.kernel.org/doc/html/latest/process/deprecated.html#zero-length-and-one-element-arrays

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Removed mmap xocl_gem_prime_mmap function as drm_gem_mmap() function  is capible of setting flags before mmap.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Removed the xocl_gem_prime_mmap and changed some structures into flexible arrays as one-legth arrays are throwing call trace while using memcpy() function.

#### Risks (if any) associated the changes in the commit
low

#### What has been tested and how, request additional testing if necessary
Tested with u250 in ubuntu 22.04 and 24.04

#### Documentation impact (if any)
Yes