### PR TITLE
VITIS-13050 and VITIS-9682

### DIFF
--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -1651,6 +1651,16 @@ struct aie_tiles_status_info : request
 // Hardware contexts may share the same aie partition.
 struct aie_partition_info : request
 {
+
+  struct qos_info {
+    uint64_t    gops;           // Giga operations per second
+    uint64_t    egops;          // Effective giga operations per second
+    uint64_t    fps;            // Frames per second
+    uint64_t    dma_bandwidth;  // DMA bandwidth
+    uint64_t    latency;        // Frame response latency
+    uint64_t    frame_exec_time;// Frame execution time
+    uint64_t    priority;       // Request priority
+  };
   struct data
   {
     hw_context_info::metadata metadata;
@@ -1662,6 +1672,7 @@ struct aie_partition_info : request
     uint64_t    migrations;
     uint64_t    preemptions;
     uint64_t    errors;
+    qos_info    QoS;
   };
 
   using result_type = std::vector<struct data>;

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -1667,6 +1667,7 @@ struct aie_partition_info : request
     uint64_t    start_col;
     uint64_t    num_cols;
     int         pid;
+    uint64_t    instruction_mem;
     uint64_t    command_submissions;
     uint64_t    command_completions;
     uint64_t    migrations;

--- a/src/runtime_src/core/tools/common/reports/ReportAiePartitions.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportAiePartitions.cpp
@@ -6,6 +6,7 @@
 #include "ReportAiePartitions.h"
 
 #include "core/common/query_requests.h"
+#include "core/common/utils.h"
 #include "tools/common/Table2D.h"
 #include "tools/common/XBUtilitiesCore.h"
 
@@ -31,6 +32,7 @@ populate_aie_partition(const xrt_core::device* device)
 
     boost::property_tree::ptree pt_entry;
     pt_entry.put("context_id", entry.metadata.id);
+    pt_entry.put("instr_bo_mem", entry.instruction_mem);
     pt_entry.put("command_submissions", entry.command_submissions);
     pt_entry.put("command_completions", entry.command_completions);
     pt_entry.put("migrations", entry.migrations);
@@ -109,6 +111,7 @@ writeReport(const xrt_core::device* /*_pDevice*/,
 
     const std::vector<Table2D::HeaderData> table_headers = {
       {"Ctx ID", Table2D::Justification::left},
+      {"Instr BO", Table2D::Justification::left},
       {"Sub", Table2D::Justification::left},
       {"Compl", Table2D::Justification::left},
       {"Migr", Table2D::Justification::left},
@@ -127,6 +130,7 @@ writeReport(const xrt_core::device* /*_pDevice*/,
 
       const std::vector<std::string> entry_data = {
         hw_context.get<std::string>("context_id"),
+        xrt_core::utils::unit_convert(hw_context.get<uint64_t>("instr_bo_mem")),
         hw_context.get<std::string>("command_submissions"),
         hw_context.get<std::string>("command_completions"),
         hw_context.get<std::string>("migrations"),

--- a/src/runtime_src/core/tools/common/reports/ReportAiePartitions.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportAiePartitions.cpp
@@ -36,6 +36,13 @@ populate_aie_partition(const xrt_core::device* device)
     pt_entry.put("migrations", entry.migrations);
     pt_entry.put("errors", entry.errors);
 
+    xrt_core::query::aie_partition_info::qos_info qos = entry.QoS;
+    pt_entry.put("gops", qos.gops);
+    pt_entry.put("egops", qos.egops);
+    pt_entry.put("fps", qos.fps);
+    pt_entry.put("latency", qos.latency);
+    pt_entry.put("priority", qos.priority);
+
     partition.first->second.push_back(std::make_pair("", pt_entry));
   }
 
@@ -101,11 +108,16 @@ writeReport(const xrt_core::device* /*_pDevice*/,
     }
 
     const std::vector<Table2D::HeaderData> table_headers = {
-      {"Context ID", Table2D::Justification::left},
-      {"Submissions", Table2D::Justification::left},
-      {"Completions", Table2D::Justification::left},
-      {"Migrations", Table2D::Justification::left},
-      {"Errors", Table2D::Justification::left},
+      {"Ctx ID", Table2D::Justification::left},
+      {"Sub", Table2D::Justification::left},
+      {"Compl", Table2D::Justification::left},
+      {"Migr", Table2D::Justification::left},
+      {"Err", Table2D::Justification::left},
+      {"Prio", Table2D::Justification::left},
+      {"GOPS", Table2D::Justification::left},
+      {"EGOPS", Table2D::Justification::left},
+      {"FPS", Table2D::Justification::left},
+      {"Latency", Table2D::Justification::left}
     };
     Table2D context_table(table_headers);
 
@@ -118,7 +130,12 @@ writeReport(const xrt_core::device* /*_pDevice*/,
         hw_context.get<std::string>("command_submissions"),
         hw_context.get<std::string>("command_completions"),
         hw_context.get<std::string>("migrations"),
-        std::to_string(hw_context.get<uint64_t>("errors"))
+        std::to_string(hw_context.get<uint64_t>("errors")),
+        std::to_string(hw_context.get<uint64_t>("priority")),
+        std::to_string(hw_context.get<uint64_t>("gops")),
+        std::to_string(hw_context.get<uint64_t>("egops")),
+        std::to_string(hw_context.get<uint64_t>("fps")),
+        std::to_string(hw_context.get<uint64_t>("latency"))
       };
       context_table.addEntry(entry_data);
     }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
[VITIS-13050](https://jira.xilinx.com/browse/VITIS-13050) Add context QOS to xrt-smi
[VITIS-9682](https://jira.xilinx.com/browse/VITIS-9682) Add instruction buffer footprint in aie-partitions report

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
New feature

#### How problem was solved, alternative solutions (if any) and why they were rejected
Adding qos information and instruc bo mem usage to aie-partitions report

#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
Tested on strix/windows:
```
>xrt-smi examine -r aie-partitions

---------------------
[00c5:00:01.1] : NPU
---------------------
AIE Partitions
  Partition Index: 0
    Columns: [0, 1, 2, 3]
    HW Contexts:
      |Ctx ID  ||Instr BO  ||Sub  ||Compl  ||Migr  ||Err  ||Prio  ||GOPS  ||EGOPS  ||FPS  ||Latency  |
      |--------||----------||-----||-------||------||-----||------||------||-------||-----||---------|
      |1       ||0 Byte    ||86   ||85     ||0     ||0    ||6144  ||0     ||0      ||0    ||0        |

  Partition Index: 1
    Columns: [4, 5, 6, 7]
    HW Contexts:
      |Ctx ID  ||Instr BO  ||Sub  ||Compl  ||Migr  ||Err  ||Prio  ||GOPS  ||EGOPS  ||FPS  ||Latency  |
      |--------||----------||-----||-------||------||-----||------||------||-------||-----||---------|
      |2       ||0 Byte    ||30   ||29     ||0     ||0    ||6144  ||0     ||0      ||0    ||0        |

```

#### Documentation impact (if any)
N/A
