### PR TITLE
Improve compatibility with other Compilers like MinGW

### DIFF
--- a/src/runtime_src/core/common/config.h
+++ b/src/runtime_src/core/common/config.h
@@ -27,7 +27,7 @@
 #  define XRT_CORE_COMMON_EXPORT __declspec(dllimport)
 # endif
 #endif
-#ifdef __GNUC__
+#ifdef __linux__
 # ifdef XRT_CORE_COMMON_SOURCE
 #  define XRT_CORE_COMMON_EXPORT __attribute__ ((visibility("default")))
 # else
@@ -39,7 +39,7 @@
 # define XRT_CORE_COMMON_EXPORT
 #endif
 
-#ifdef __GNUC__
+#ifdef __linux__
 # define XRT_CORE_UNUSED __attribute__((unused))
 #endif
 

--- a/src/runtime_src/core/common/config_reader.cpp
+++ b/src/runtime_src/core/common/config_reader.cpp
@@ -85,7 +85,7 @@ is_true(const std::string& str)
 static std::string
 get_self_path()
 {
-#ifdef __GNUC__
+#ifdef __linux__
   char buf[PATH_MAX] = {0};
   auto len = ::readlink("/proc/self/exe", buf, PATH_MAX);
   return std::string(buf, (len>0) ? len : 0);

--- a/src/runtime_src/core/common/unistd.h
+++ b/src/runtime_src/core/common/unistd.h
@@ -20,7 +20,7 @@
 #ifndef _WIN32
 #include <unistd.h>
 #else
-#include <Shlobj.h>
+#include <shlobj.h>
 #endif
 
 namespace xrt_core {

--- a/src/runtime_src/core/include/windows/types.h
+++ b/src/runtime_src/core/include/windows/types.h
@@ -19,7 +19,9 @@
 
 #include <stdint.h>
 
+#ifndef __GNU__
 typedef int64_t ssize_t;
 typedef int pid_t;
+#endif
 
 #endif

--- a/src/runtime_src/core/include/xrt/detail/config.h
+++ b/src/runtime_src/core/include/xrt/detail/config.h
@@ -12,7 +12,7 @@
 #  define XRT_API_EXPORT __declspec(dllimport)
 # endif
 #endif
-#ifdef __GNUC__
+#ifdef __linux__
 # ifdef XRT_API_SOURCE
 #  define XRT_API_EXPORT __attribute__ ((visibility("default")))
 # else

--- a/src/runtime_src/core/pcie/noop/config.h
+++ b/src/runtime_src/core/pcie/noop/config.h
@@ -27,7 +27,7 @@
 #  define XRT_CORE_PCIE_NOOP_EXPORT __declspec(dllimport)
 # endif
 #endif
-#ifdef __GNUC__
+#ifdef __linux__
 # ifdef XRT_CORE_PCIE_NOOP_SOURCE
 #  define XRT_CORE_PCIE_NOOP_EXPORT __attribute__ ((visibility("default")))
 # else

--- a/src/runtime_src/core/pcie/windows/alveo/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/windows/alveo/CMakeLists.txt
@@ -36,6 +36,13 @@ target_link_libraries(xrt_core
   xrt_coreutil
   )
 
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  target_link_libraries(xrt_core
+    PRIVATE
+    setupapi
+  )
+endif()
+
 # For DLL platforms the DLL part of a shared library is treated as a
 # RUNTIME target and the corresponding import library is treated as an
 # ARCHIVE target. All Windows-based systems including Cygwin are DLL

--- a/src/runtime_src/core/pcie/windows/alveo/config.h
+++ b/src/runtime_src/core/pcie/windows/alveo/config.h
@@ -14,7 +14,7 @@
 #  define XRT_CORE_PCIE_WINDOWS_EXPORT __declspec(dllimport)
 # endif
 #endif
-#ifdef __GNUC__
+#ifdef __linux__
 # ifdef XRT_CORE_PCIE_WINDOWS_SOURCE
 #  define XRT_CORE_PCIE_WINDOWS_EXPORT __attribute__ ((visibility("default")))
 # else

--- a/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
@@ -100,6 +100,10 @@ target_link_libraries(${XBUTIL2_NAME}
 
 if (NOT WIN32)
   target_link_libraries(${XBUTIL2_NAME} PRIVATE pthread uuid dl)
+else()
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    target_link_libraries(${XBUTIL2_NAME} PRIVATE ws2_32)
+  endif()
 endif()
 
 # Package xrt sub commands json file for embedded builds

--- a/src/runtime_src/tools/xclbinutil/CMakeLists.txt
+++ b/src/runtime_src/tools/xclbinutil/CMakeLists.txt
@@ -136,6 +136,11 @@ if(NOT WIN32)
    target_link_libraries(${XCLBINUTIL_NAME} PRIVATE transformcdo)
 endif()
 
+# Link required windows specific libraries with MinGW
+if(WIN32 AND (CMAKE_CXX_COMPILER_ID STREQUAL "GNU"))
+  target_link_libraries(${XCLBINUTIL_NAME} PRIVATE wsock32 ws2_32)
+endif()
+
 install (TARGETS ${XCLBINUTIL_NAME} RUNTIME DESTINATION ${XRT_INSTALL_UNWRAPPED_DIR})
 install (PROGRAMS ${XRT_LOADER_SCRIPTS} DESTINATION ${XRT_INSTALL_BIN_DIR})
 

--- a/src/runtime_src/xdp/config.h
+++ b/src/runtime_src/xdp/config.h
@@ -28,7 +28,7 @@
     #define XDP_CORE_EXPORT __declspec(dllimport)
   #endif  
 #endif
-#ifdef __GNUC__
+#ifdef __linux__
   #ifdef XDP_CORE_SOURCE
     #define XDP_CORE_EXPORT __attribute__ ((visibility("default")))
   #else
@@ -47,7 +47,7 @@
     #define XDP_PLUGIN_EXPORT __declspec(dllimport)
   #endif  
 #endif
-#ifdef __GNUC__
+#ifdef __linux__
   #ifdef XDP_PLUGIN_SOURCE
     #define XDP_PLUGIN_EXPORT __attribute__ ((visibility("default")))
   #else

--- a/src/runtime_src/xdp/profile/database/events/device_events.h
+++ b/src/runtime_src/xdp/profile/database/events/device_events.h
@@ -72,7 +72,7 @@ namespace xdp {
                            uint64_t devId, uint32_t monId, int32_t cuIdx);
     XDP_CORE_EXPORT ~KernelEvent();
 
-    XDP_CORE_EXPORT virtual int32_t getCUId() { return cuId; }
+    virtual int32_t getCUId() { return cuId; }
     XDP_CORE_EXPORT virtual void dump(std::ofstream& fout, uint32_t bucket) ;
   };
 

--- a/src/runtime_src/xdp/profile/database/events/native_events.h
+++ b/src/runtime_src/xdp/profile/database/events/native_events.h
@@ -28,7 +28,7 @@ namespace xdp {
     XDP_CORE_EXPORT NativeAPICall(uint64_t s_id, double ts, uint64_t name);
     XDP_CORE_EXPORT ~NativeAPICall() = default;
 
-    XDP_CORE_EXPORT virtual bool isNativeHostEvent() { return true; }
+    virtual bool isNativeHostEvent() { return true; }
 
     XDP_CORE_EXPORT virtual void dump(std::ofstream& fout, uint32_t bucket);
   };
@@ -41,7 +41,7 @@ namespace xdp {
     XDP_CORE_EXPORT NativeSyncRead(uint64_t s_id, double ts, uint64_t name);
     XDP_CORE_EXPORT ~NativeSyncRead() = default;
 
-    XDP_CORE_EXPORT virtual bool isNativeRead() override { return true; }
+    virtual bool isNativeRead() override { return true; }
 
     // For printing out the event in a different bucket as a different
     //  type of event, without having to store additional events in the database
@@ -56,7 +56,7 @@ namespace xdp {
     XDP_CORE_EXPORT NativeSyncWrite(uint64_t s_id, double ts, uint64_t name);
     XDP_CORE_EXPORT ~NativeSyncWrite() = default;
 
-    XDP_CORE_EXPORT virtual bool isNativeWrite() override { return true; }
+    virtual bool isNativeWrite() override { return true; }
 
     // For printing out the event in a different bucket as a different
     //  type of event, without having to store additional events in the databaes

--- a/src/runtime_src/xdp/profile/database/events/vtf_event.h
+++ b/src/runtime_src/xdp/profile/database/events/vtf_event.h
@@ -135,7 +135,7 @@ namespace xdp {
 
     virtual uint64_t getDevice() { return 0 ; } // CHECK
     XDP_CORE_EXPORT virtual void dump(std::ofstream& fout, uint32_t bucket) ;
-    XDP_CORE_EXPORT virtual void dumpSync(std::ofstream& /*fout*/, uint32_t /*bucket*/) {};
+    virtual void dumpSync(std::ofstream& /*fout*/, uint32_t /*bucket*/) {};
   } ;
 
   // Used so the database can sort based on timestamp order

--- a/src/runtime_src/xdp/profile/database/static_info/device_info.h
+++ b/src/runtime_src/xdp/profile/database/static_info/device_info.h
@@ -101,7 +101,7 @@ namespace xdp {
     inline bool isNoDMA() const { return isNoDMADevice ; }
     double getMaxClockRatePLMHz();
 
-    XDP_CORE_EXPORT void setAIEGeneration(uint8_t hw_gen) { aieGeneration = hw_gen; }
+    void setAIEGeneration(uint8_t hw_gen) { aieGeneration = hw_gen; }
     inline uint8_t getAIEGeneration() const { return aieGeneration ; }
 
     // ****** Functions for information on the currently loaded xclbin *******

--- a/src/runtime_src/xocl/config.h
+++ b/src/runtime_src/xocl/config.h
@@ -29,7 +29,7 @@
 # endif
 #endif
 
-#ifdef __GNUC__
+#ifdef __linux__
 # ifdef XRT_XOCL_SOURCE
 #  define XRT_XOCL_EXPORT __attribute__ ((visibility("default")))
 # else

--- a/src/runtime_src/xrt/config.h
+++ b/src/runtime_src/xrt/config.h
@@ -26,7 +26,7 @@
 #  define XRT_EXPORT __declspec(dllimport)
 # endif
 #endif
-#ifdef __GNUC__
+#ifdef __linux__
 # ifdef XRT_SOURCE
 #  define XRT_EXPORT __attribute__ ((visibility("default")))
 # else
@@ -38,7 +38,7 @@
 # define XRT_EXPORT
 #endif
 
-#ifdef __GNUC__
+#ifdef __linux__
 # define XRT_UNUSED __attribute__((unused))
 #endif
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
I am working on an integration of [XRT into Julia](https://github.com/JuliaPackaging/Yggdrasil/pull/9290). However, the current Windows build does only support MSVC and the packages for Julia are build using MinGW, so I XRT to improve the compatibility with MinGW. I ported back some of the patches because they should not affect the currently supported toolchains and could be useful to support further toolchains in the future. No features are added or removed to XRT with this PR - it only affects the build process.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Currently, some preprocessor defines are used in non-standard ways, increasing the difficulty to compile the code on Windows with GCC. Also, some library dependencies seem to be missing for some of the Windows binaries.

#### How problem was solved, alternative solutions (if any) and why they were rejected
 I changed some occurrences of `__GNU__` to `__linux__` because the contained codes rather depend on the used OS than on the compiler.
The missing libraries were added as link dependency.

#### Risks (if any) associated the changes in the commit
I was not able to test the build on a native Windows machine with MSVC, because I have no access to one.
The proposed changes should only affect the build and linking of binaries, and not the functionality.

#### What has been tested and how, request additional testing if necessary
Build on Red Head Enterprise Linux and Alpine Linux using GCC 9.1 as well as MinGW on Alpine Linux with GCC 9.1 and some [additional minor patches](https://github.com/JuliaPackaging/Yggdrasil/pull/9290).

#### Documentation impact (if any)
Should not affect documentation, because this PR only applies changes to the build process.