### PR TITLE
Segmented Config changes

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/edge/zocl_edge_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/edge/zocl_edge_xclbin.c
@@ -79,36 +79,6 @@ zocl_cache_xclbin(struct drm_zocl_dev *zdev, struct drm_zocl_slot *slot,
 	return 0;
 }
 
-static int
-zocl_load_aie_only_pdi(struct drm_zocl_dev *zdev, struct axlf *axlf,
-			char __user *xclbin, struct kds_client *client)
-{
-	uint64_t size = 0;
-	char *pdi_buf = NULL;
-	int ret = 0;
-
-	if (client && client->aie_ctx == ZOCL_CTX_SHARED) {
-		DRM_ERROR("%s Shared context can not load xclbin", __func__);
-		return -EPERM;
-	}
-
-	size = zocl_read_sect(PDI, &pdi_buf, axlf, xclbin);
-	if (size == 0)
-		return 0;
-
-	ret = zocl_fpga_mgr_load(zdev, pdi_buf, size, FPGA_MGR_PARTIAL_RECONFIG);
-	vfree(pdi_buf);
-
-	/* Mark AIE out of reset state after load PDI */
-	if (zdev->aie) {
-		mutex_lock(&zdev->aie_lock);
-		zdev->aie->aie_reset = false;
-		mutex_unlock(&zdev->aie_lock);
-	}
-
-	return ret;
-}
-
 static bool
 is_aie_only(struct axlf *axlf)
 {
@@ -310,7 +280,27 @@ zocl_xclbin_read_axlf(struct drm_zocl_dev *zdev, struct drm_zocl_axlf *axlf_obj,
 
 	} else
 #endif
-	if (slot->pr_isolation_addr) {
+	if (is_aie_only(axlf)) {
+		zocl_cleanup_aie(zdev);
+
+		ret = zocl_load_aie_only_pdi(zdev, axlf, xclbin, client);
+		if (ret)
+			goto out0;
+
+		zocl_cache_xclbin(zdev, slot, axlf, xclbin);
+
+	} else if ((axlf_obj->za_flags & DRM_ZOCL_PLATFORM_FLAT) &&
+		   axlf_head.m_header.m_mode == XCLBIN_FLAT &&
+		   axlf_head.m_header.m_mode != XCLBIN_HW_EMU &&
+		   axlf_head.m_header.m_mode != XCLBIN_HW_EMU_PR) {
+		/*
+		 * Load full bitstream, enabled in xrt runtime config
+		 * and xclbin has full bitstream and its not hw emulation
+		 */
+		ret = zocl_load_sect(zdev, axlf, xclbin, BITSTREAM, slot);
+		if (ret)
+			goto out0;
+	} else {
 		/* For PR support platform, device-tree has configured addr */
 		if (axlf_head.m_header.m_mode != XCLBIN_PR &&
 		    axlf_head.m_header.m_mode != XCLBIN_HW_EMU &&
@@ -352,25 +342,6 @@ zocl_xclbin_read_axlf(struct drm_zocl_dev *zdev, struct drm_zocl_axlf *axlf_obj,
 			if (ret)
 				goto out0;
 		}
-	} else if (is_aie_only(axlf)) {
-		zocl_cleanup_aie(zdev);
-
-		ret = zocl_load_aie_only_pdi(zdev, axlf, xclbin, client);
-		if (ret)
-			goto out0;
-
-		zocl_cache_xclbin(zdev, slot, axlf, xclbin);
-	} else if ((axlf_obj->za_flags & DRM_ZOCL_PLATFORM_FLAT) &&
-		   axlf_head.m_header.m_mode == XCLBIN_FLAT &&
-		   axlf_head.m_header.m_mode != XCLBIN_HW_EMU &&
-		   axlf_head.m_header.m_mode != XCLBIN_HW_EMU_PR) {
-		/*
-		 * Load full bitstream, enabled in xrt runtime config
-		 * and xclbin has full bitstream and its not hw emulation
-		 */
-		ret = zocl_load_sect(zdev, axlf, xclbin, BITSTREAM, slot);
-		if (ret)
-			goto out0;
 	}
 
 	ret = populate_slot_specific_sec(zdev, axlf, xclbin, slot);

--- a/src/runtime_src/core/edge/drm/zocl/edge/zocl_edge_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/edge/zocl_edge_xclbin.c
@@ -301,15 +301,6 @@ zocl_xclbin_read_axlf(struct drm_zocl_dev *zdev, struct drm_zocl_axlf *axlf_obj,
 		if (ret)
 			goto out0;
 	} else {
-		/* For PR support platform, device-tree has configured addr */
-		if (axlf_head.m_header.m_mode != XCLBIN_PR &&
-		    axlf_head.m_header.m_mode != XCLBIN_HW_EMU &&
-		    axlf_head.m_header.m_mode != XCLBIN_HW_EMU_PR) {
-			DRM_ERROR("xclbin m_mod %d is not a PR mode",
-			    axlf_head.m_header.m_mode);
-			ret = -EINVAL;
-			goto out0;
-		}
 
 		if (!(axlf_obj->za_flags & DRM_ZOCL_PLATFORM_PR)) {
 			DRM_INFO("disable partial bitstream download, "

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_xclbin.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_xclbin.h
@@ -63,4 +63,8 @@ bool zocl_bitstream_is_locked(struct drm_zocl_dev *zdev,
 			      struct drm_zocl_slot *slot);
 int zocl_load_partial(struct drm_zocl_dev *zdev, const char *buffer, int length,
 		      struct drm_zocl_slot *slot);
+int
+zocl_load_aie_only_pdi(struct drm_zocl_dev *zdev, struct axlf *axlf,
+			char __user *xclbin, struct kds_client *client);
+
 #endif /* _ZOCL_XCLBIN_H_ */

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -684,12 +684,10 @@ xclLoadAxlf(const axlf *buffer)
   std::string dtbo_path("");
 
 #ifndef __HWEM__
-  auto is_pr_platform = (buffer->m_header.m_mode == XCLBIN_PR ) ? true : false;
+  auto is_pr_platform = (buffer->m_header.m_mode == XCLBIN_PR || buffer->m_header.m_actionMask & AM_LOAD_PDI) ? true : false;
   auto is_flat_enabled = xrt_core::config::get_enable_flat(); //default value is false
   auto force_program = xrt_core::config::get_force_program_xclbin(); //default value is false
   auto overlay_header = xclbin::get_axlf_section(buffer, axlf_section_kind::OVERLAY);
-  //force load PDI if below action mask is set
-  is_pr_platform = (buffer->m_header.m_actionMask & AM_LOAD_PDI) ? true : false;
 
   if (is_pr_platform)
     flags = DRM_ZOCL_PLATFORM_PR;
@@ -1179,12 +1177,10 @@ int shim::prepare_hw_axlf(const axlf *buffer, struct drm_zocl_axlf *axlf_obj)
   std::string dtbo_path("");
 
 #ifndef __HWEM__
-  auto is_pr_platform = (buffer->m_header.m_mode == XCLBIN_PR ) ? true : false;
+  auto is_pr_platform = (buffer->m_header.m_mode == XCLBIN_PR || buffer->m_header.m_actionMask & AM_LOAD_PDI) ? true : false;
   auto is_flat_enabled = xrt_core::config::get_enable_flat(); //default value is false
   auto force_program = xrt_core::config::get_force_program_xclbin(); //default value is false
   auto overlay_header = xclbin::get_axlf_section(buffer, axlf_section_kind::OVERLAY);
-  //force load PDI if below action mask is set
-  is_pr_platform = (buffer->m_header.m_actionMask & AM_LOAD_PDI) ? true : false;
 
   if (is_pr_platform)
     flags = DRM_ZOCL_PLATFORM_PR;

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -1183,6 +1183,8 @@ int shim::prepare_hw_axlf(const axlf *buffer, struct drm_zocl_axlf *axlf_obj)
   auto is_flat_enabled = xrt_core::config::get_enable_flat(); //default value is false
   auto force_program = xrt_core::config::get_force_program_xclbin(); //default value is false
   auto overlay_header = xclbin::get_axlf_section(buffer, axlf_section_kind::OVERLAY);
+  //force load PDI if below action mask is set
+  is_pr_platform = (buffer->m_header.m_actionMask & AM_LOAD_PDI) ? true : false;
 
   if (is_pr_platform)
     flags = DRM_ZOCL_PLATFORM_PR;

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -684,7 +684,7 @@ xclLoadAxlf(const axlf *buffer)
   std::string dtbo_path("");
 
 #ifndef __HWEM__
-  auto is_pr_platform = (buffer->m_header.m_mode == XCLBIN_PR || buffer->m_header.m_actionMask & AM_LOAD_PDI) ? true : false;
+  auto is_pr_platform = (buffer->m_header.m_mode == XCLBIN_PR || buffer->m_header.m_actionMask & AM_LOAD_PDI);
   auto is_flat_enabled = xrt_core::config::get_enable_flat(); //default value is false
   auto force_program = xrt_core::config::get_force_program_xclbin(); //default value is false
   auto overlay_header = xclbin::get_axlf_section(buffer, axlf_section_kind::OVERLAY);
@@ -1177,7 +1177,7 @@ int shim::prepare_hw_axlf(const axlf *buffer, struct drm_zocl_axlf *axlf_obj)
   std::string dtbo_path("");
 
 #ifndef __HWEM__
-  auto is_pr_platform = (buffer->m_header.m_mode == XCLBIN_PR || buffer->m_header.m_actionMask & AM_LOAD_PDI) ? true : false;
+  auto is_pr_platform = (buffer->m_header.m_mode == XCLBIN_PR || buffer->m_header.m_actionMask & AM_LOAD_PDI);
   auto is_flat_enabled = xrt_core::config::get_enable_flat(); //default value is false
   auto force_program = xrt_core::config::get_force_program_xclbin(); //default value is false
   auto overlay_header = xclbin::get_axlf_section(buffer, axlf_section_kind::OVERLAY);

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -688,6 +688,8 @@ xclLoadAxlf(const axlf *buffer)
   auto is_flat_enabled = xrt_core::config::get_enable_flat(); //default value is false
   auto force_program = xrt_core::config::get_force_program_xclbin(); //default value is false
   auto overlay_header = xclbin::get_axlf_section(buffer, axlf_section_kind::OVERLAY);
+  //force load PDI if below action mask is set
+  is_pr_platform = (buffer->m_header.m_actionMask & AM_LOAD_PDI) ? true : false;
 
   if (is_pr_platform)
     flags = DRM_ZOCL_PLATFORM_PR;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
We were relying on pr_isolation address to program the PDI earlier, With segmented config support, we need to relax that check. We will get information from new bitmap entry
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
None
#### How problem was solved, alternative solutions (if any) and why they were rejected
Relaxed all the pr_isolation checks in zocl
#### Risks (if any) associated the changes in the commit
None
#### What has been tested and how, request additional testing if necessary
Verified zynqmp/versal aie/non-aie cases
#### Documentation impact (if any)
None