### PR TITLE
Export functions from module_int.h to use in shim tests

### DIFF
--- a/src/runtime_src/core/common/api/module_int.h
+++ b/src/runtime_src/core/common/api/module_int.h
@@ -20,6 +20,7 @@ uint32_t*
 fill_ert_dpu_data(const xrt::module& module, uint32_t *payload);
 
 // Patch buffer object into control code at given argument
+XRT_CORE_COMMON_EXPORT
 void
 patch(const xrt::module&, const std::string& argnm, size_t index, const xrt::bo& bo);
 
@@ -30,10 +31,12 @@ patch(const xrt::module&, const std::string& argnm, size_t index, const xrt::bo&
 // Note that if size passed in is 0, real buffer size required will be returned
 // without any patching. This is useful if caller wishes to discover the exact size
 // of the control code buffer.
+XRT_CORE_COMMON_EXPORT
 void
 patch(const xrt::module&, uint8_t*, size_t*, const std::vector<std::pair<std::string, uint64_t>>*);
 
 // Patch scalar into control code at given argument
+XRT_CORE_COMMON_EXPORT
 void
 patch(const xrt::module&, const std::string& argnm, size_t index, const void* value, size_t size);
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
shim tests in xdna driver uses functions from module_int.h, these tests were earlier used in linux flow and now being ported to windows and windows needs functions to be exported to be used in application that imports them. so making this change

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Discovered in local testing when trying using windows

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added macro for required functions

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
Tested by building application in windows

#### Documentation impact (if any)
NA
