### PR TITLE
Revert Edge hw context creation hook to XDP plugin

### DIFF
--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -1312,10 +1312,6 @@ int shim::load_hw_axlf(xclDeviceHandle handle, const xclBin *buffer, drm_zocl_cr
     drv->registerAieArray();
   #endif
 
-  // NOTE: Currently XDP plugins are loaded during device::load_xclbin(). To support XDP plugin during
-  // create_hw_context on edge, plugin update calls will need to be moved here.
-  // TODO: XDP plugins will be enabled for  Edge hw_context in a separate commit.
-
   return 0;
 }
 

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -1312,17 +1312,9 @@ int shim::load_hw_axlf(xclDeviceHandle handle, const xclBin *buffer, drm_zocl_cr
     drv->registerAieArray();
   #endif
 
-  #ifndef __HWEM__
-    xdp::hal::update_device(handle);
-    xdp::aie::update_device(handle);
-  #endif
-    xdp::aie::ctr::update_device(handle);
-    xdp::aie::sts::update_device(handle);
-  #ifndef __HWEM__
-    START_DEVICE_PROFILING_CB(handle);
-  #else
-    xdp::hal::hw_emu::update_device(handle);
-  #endif
+  // NOTE: Currently XDP plugins are loaded during device::load_xclbin(). To support XDP plugin during
+  // create_hw_context on edge, plugin update calls will need to be moved here.
+  // TODO: XDP plugins will be enabled for  Edge hw_context in a separate commit.
 
   return 0;
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Recent  hw context support on Edge had also enable all XDP plugins via https://github.com/Xilinx/XRT/pull/8305 

This resulted in calling of plugins twice once during xclbin load and later during hw_context creation. This further resulted in driver related errors because of unavailability of resources.

This will need to be enabled hw_context and disable from xclbin load if needed.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://github.com/Xilinx/XRT/pull/8305 

#### How problem was solved, alternative solutions (if any) and why they were rejected
Removed profiling wrapper from newly added hw_context as we already have for xclbin load.

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
Verified on edge to see no double load of XDP plugins.
No more driver related issues seen.
However, plugins are still running into separate issue i.e. CR-1209732
#### Documentation impact (if any)
