### PR TITLE
CR-1211324 Hw_Emulation failing with XRT error for design with event …

### DIFF
--- a/src/runtime_src/core/common/api/aie/xrt_graph.cpp
+++ b/src/runtime_src/core/common/api/aie/xrt_graph.cpp
@@ -126,6 +126,7 @@ class profiling_impl
 {
 private:
   std::unique_ptr<xrt_core::profile_handle> m_profile_handle{nullptr};
+  bool is_stopped{false};
 
 public:
   static constexpr int invalid_handle = -1;
@@ -144,7 +145,6 @@ public:
   {
     stop();
   }
-
   profiling_impl() = delete;
   profiling_impl(const profiling_impl&) = delete;
   profiling_impl(profiling_impl&&) = delete;
@@ -166,7 +166,10 @@ public:
   void
   stop()
   {
-    return m_profile_handle->stop();
+    if(is_stopped == false)
+      m_profile_handle->stop();
+
+    is_stopped = true;
   }
 };
 

--- a/src/runtime_src/core/edge/user/aie/graph.cpp
+++ b/src/runtime_src/core/edge/user/aie/graph.cpp
@@ -66,7 +66,7 @@ xclSyncBOAIE(xclDeviceHandle handle, xrt::bo& bo, const char *gmioName, enum xcl
 
   if (!drv->isAieRegistered())
     throw xrt_core::error(-EINVAL, "No AIE presented");
-  auto aieArray = drv->getAieArray();
+  auto aieArray = drv->get_aie_array_shared();
 
   if (!aieArray->is_context_set()) {
     aieArray->open_context(device.get(), xrt::aie::access_mode::primary);
@@ -88,7 +88,7 @@ xclSyncBOAIENB(xclDeviceHandle handle, xrt::bo& bo, const char *gmioName, enum x
 
   if (!drv->isAieRegistered())
     throw xrt_core::error(-EINVAL, "No AIE presented");
-  auto aieArray = drv->getAieArray();
+  auto aieArray = drv->get_aie_array_shared();
 
   if (!aieArray->is_context_set()) {
     aieArray->open_context(device.get(), xrt::aie::access_mode::primary);
@@ -110,7 +110,7 @@ xclGMIOWait(xclDeviceHandle handle, const char *gmioName)
 
   if (!drv->isAieRegistered())
     throw xrt_core::error(-EINVAL, "No AIE presented");
-  auto aieArray = drv->getAieArray();
+  auto aieArray = drv->get_aie_array_shared();
 
   if (!aieArray->is_context_set()) {
     aieArray->open_context(device.get(), xrt::aie::access_mode::primary);
@@ -127,7 +127,7 @@ xclResetAieArray(xclDeviceHandle handle)
 
   if (!drv->isAieRegistered())
     throw xrt_core::error(-EINVAL, "No AIE presented");
-  auto aieArray = drv->getAieArray();
+  auto aieArray = drv->get_aie_array_shared();
 
   if (!aieArray->is_context_set()) {
     aieArray->open_context(device.get(), xrt::aie::access_mode::primary);
@@ -144,7 +144,7 @@ xclStartProfiling(xclDeviceHandle handle, int option, const char* port1Name, con
   if (!drv->isAieRegistered())
     throw xrt_core::error(-EINVAL, "No AIE presented");
 
-  auto aieArray = drv->getAieArray();
+  auto aieArray = drv->get_aie_array_shared();
 
   if (!aieArray->is_context_set()) {
     aieArray->open_context(device.get(), xrt::aie::access_mode::primary);
@@ -162,7 +162,7 @@ xclReadProfiling(xclDeviceHandle handle, int phdl)
   if (!drv->isAieRegistered())
     throw xrt_core::error(-EINVAL, "No AIE presented");
 
-  auto aieArray = drv->getAieArray();
+  auto aieArray = drv->get_aie_array_shared();
 
   if (!aieArray->is_context_set()) {
     aieArray->open_context(device.get(), xrt::aie::access_mode::primary);
@@ -180,7 +180,7 @@ xclStopProfiling(xclDeviceHandle handle, int phdl)
   if (!drv->isAieRegistered())
     throw xrt_core::error(-EINVAL, "No AIE presented");
 
-  auto aieArray = drv->getAieArray();
+  auto aieArray = drv->get_aie_array_shared();
 
   if (!aieArray->is_context_set()) {
     aieArray->open_context(device.get(), xrt::aie::access_mode::primary);

--- a/src/runtime_src/core/edge/user/aie/graph_object.cpp
+++ b/src/runtime_src/core/edge/user/aie/graph_object.cpp
@@ -19,7 +19,7 @@ namespace zynqaie {
       if (!drv->isAieRegistered())
         throw xrt_core::error(-EINVAL, "No AIE presented");
 
-      aieArray = drv->getAieArray();
+      aieArray = drv->get_aie_array_shared();
 
       id = xrt_core::edge::aie::get_graph_id(device.get(), name, hwctx);
       if (id == xrt_core::edge::aie::NON_EXIST_ID)

--- a/src/runtime_src/core/edge/user/aie/graph_object.h
+++ b/src/runtime_src/core/edge/user/aie/graph_object.h
@@ -41,7 +41,7 @@ namespace zynqaie {
      * the graph resides. The Aie is an obect that holds the whole
      * AIE resources, configurations etc.
      */
-    Aie* aieArray;
+    std::shared_ptr<Aie> aieArray;
 
     /**
      * This is the collections of tiles that this graph uses.

--- a/src/runtime_src/core/edge/user/aie/profile_object.cpp
+++ b/src/runtime_src/core/edge/user/aie/profile_object.cpp
@@ -12,9 +12,9 @@ std::string value_or_empty(const char* s)
 namespace zynqaie {
 		
 profile_object::
-profile_object(ZYNQ::shim* shim, Aie* aie_array)
+profile_object(ZYNQ::shim* shim, std::shared_ptr<Aie> aie_array)
   : m_shim{shim},
-    m_aie_array{aie_array},
+    m_aie_array{std::move(aie_array)},
     m_profile_id{invalid_profile_id}
 {}
 

--- a/src/runtime_src/core/edge/user/aie/profile_object.h
+++ b/src/runtime_src/core/edge/user/aie/profile_object.h
@@ -5,6 +5,7 @@
 
 #include "core/common/shim/profile_handle.h"
 #include <string>
+#include <memory>
 
 namespace ZYNQ {
 
@@ -21,10 +22,10 @@ class profile_object : public xrt_core::profile_handle
 public:
   static constexpr int invalid_profile_id = -1;
   ZYNQ::shim* m_shim{nullptr}; 		
-  Aie* m_aie_array{nullptr};
+  std::shared_ptr<Aie> m_aie_array;
   int m_profile_id;
 
-  profile_object(ZYNQ::shim* shim, Aie* aie_array);
+  profile_object(ZYNQ::shim* shim, std::shared_ptr<Aie> aie_array);
 
   int
   start(int option, const char* port1Name, const char* port2Name, uint32_t value) override;

--- a/src/runtime_src/core/edge/user/device_linux.cpp
+++ b/src/runtime_src/core/edge/user/device_linux.cpp
@@ -1154,7 +1154,7 @@ open_profile_handle()
   if (not drv->isAieRegistered())
     throw xrt_core::error(-EINVAL, "No AIE presented");
 
-  auto aie_array = drv->getAieArray();
+  auto aie_array = drv->get_aie_array_shared();
 
   return std::make_unique<zynqaie::profile_object>(static_cast<ZYNQ::shim*>(get_device_handle()), aie_array);
 

--- a/src/runtime_src/core/edge/user/hwctx_object.cpp
+++ b/src/runtime_src/core/edge/user/hwctx_object.cpp
@@ -24,15 +24,15 @@ namespace zynqaie {
     auto device{xrt_core::get_userpf_device(m_shim)};
     auto data = device->get_axlf_section(AIE_METADATA, m_uuid);
     if (data.first && data.second)
-      m_aie_array = std::make_unique<Aie>(device, this);
+      m_aie_array = std::make_shared<Aie>(device, this);
 #endif
   }
 
 #ifdef XRT_ENABLE_AIE
-  Aie*
-  hwctx_object::get_aie_array_from_hwctx()
+  std::shared_ptr<Aie>
+  hwctx_object::get_aie_array_shared()
   {
-    return m_aie_array.get();
+    return m_aie_array;
   }
 #endif
 
@@ -92,7 +92,7 @@ namespace zynqaie {
   hwctx_object::open_profile_handle()
   {
 #ifdef XRT_ENABLE_AIE    
-    return std::make_unique<profile_object>(m_shim, m_aie_array.get());
+    return std::make_unique<profile_object>(m_shim, m_aie_array);
 #else
     throw xrt_core::error(std::errc::not_supported, __func__);
 #endif

--- a/src/runtime_src/core/edge/user/hwctx_object.h
+++ b/src/runtime_src/core/edge/user/hwctx_object.h
@@ -25,7 +25,7 @@ namespace zynqaie {
     slot_id m_slotidx;
     xrt::hw_context::access_mode m_mode;
 #ifdef XRT_ENABLE_AIE
-    std::unique_ptr<Aie> m_aie_array;
+    std::shared_ptr<Aie> m_aie_array;
 #endif
 
   public:
@@ -85,8 +85,8 @@ namespace zynqaie {
     open_profile_handle() override;
 
 #ifdef XRT_ENABLE_AIE
-    Aie*
-    get_aie_array_from_hwctx();
+    std::shared_ptr<Aie>
+    get_aie_array_shared();
 #endif
 
   }; // class hwctx_object

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -1968,6 +1968,14 @@ resetDevice(xclResetKind kind)
 }
 
 #ifdef XRT_ENABLE_AIE
+
+std::shared_ptr<zynqaie::Aie>
+shim::
+get_aie_array_shared()
+{
+  return aieArray;
+}
+
 zynqaie::Aie*
 shim::
 getAieArray()
@@ -1986,8 +1994,9 @@ void
 shim::
 registerAieArray()
 {
-  delete aieArray.release();
-  aieArray = std::make_unique<zynqaie::Aie>(mCoreDevice);
+  if(aieArray == nullptr)
+      aieArray = std::make_shared<zynqaie::Aie>(mCoreDevice);
+
   aied = std::make_unique<zynqaie::aied>(mCoreDevice.get());
 }
 

--- a/src/runtime_src/core/edge/user/shim.h
+++ b/src/runtime_src/core/edge/user/shim.h
@@ -81,7 +81,7 @@ public:
     zynqaie::hwctx_object* m_hwctx_obj{nullptr};
 
 #ifdef XRT_ENABLE_AIE    
-    zynqaie::Aie* m_aie_array{nullptr};
+    std::shared_ptr<zynqaie::Aie> m_aie_array;
 #endif    
 
   public:
@@ -94,14 +94,14 @@ public:
         m_hwctx_obj = dynamic_cast<zynqaie::hwctx_object*>(hwctx_hdl);
 
         if (nullptr != m_hwctx_obj) {
-          m_aie_array = m_hwctx_obj->get_aie_array_from_hwctx();
+          m_aie_array = m_hwctx_obj->get_aie_array_shared();
         }
       }
       else {
         auto device = xrt_core::get_userpf_device(m_shim);
         auto drv = ZYNQ::shim::handleCheck(device->get_device_handle());
         if (drv->isAieRegistered())
-          m_aie_array = drv->getAieArray();
+          m_aie_array = drv->get_aie_array_shared();
       }
 #endif
     }
@@ -340,6 +340,7 @@ public:
 
 #ifdef XRT_ENABLE_AIE
   zynqaie::Aie* getAieArray();
+  std::shared_ptr<zynqaie::Aie> get_aie_array_shared();
   zynqaie::aied* getAied();
   int getBOInfo(drm_zocl_info_bo &info);
   void registerAieArray();
@@ -375,7 +376,7 @@ private:
   int xclRegRW(bool rd, uint32_t cu_index, uint32_t offset, uint32_t *datap);
 
 #ifdef XRT_ENABLE_AIE
-  std::unique_ptr<zynqaie::Aie> aieArray;
+  std::shared_ptr<zynqaie::Aie> aieArray;
   std::unique_ptr<zynqaie::aied> aied;
   xrt::aie::access_mode access_mode = xrt::aie::access_mode::none;
 #endif


### PR DESCRIPTION
…api usage for latency check

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

[CR-1211324] Hw_Emulation failing with XRT error for design with event api usage for latency check

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

Profile handle related changes

#### How problem was solved, alternative solutions (if any) and why they were rejected

1) Now using shared_ptr instead of unique_ptr and passing shared_ptr across to avoid using raw pointer
2) Duplicate "stop profiling" is getting called from "profile_impl" class destructor, removed such call now.

#### Risks (if any) associated the changes in the commit

N/A

#### What has been tested and how, request additional testing if necessary

Profile hw-emu use case

#### Documentation impact (if any)

N/A
