### PR TITLE
Add xrt::runlist::state() to return runlist ERT command state

### DIFF
--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -758,7 +758,7 @@ public:
   get_state() const
   {
     // For lazy state update the command must be polled. Polling
-    // is a no-op on platforms where command status is live.
+    // is a no-op on platforms where command state is live.
     m_hwqueue.poll(this);
     
     auto state = get_state_raw();
@@ -3037,16 +3037,23 @@ class runlist_impl
   // command has comleted (error or not), then in-order execution
   // guarantees that all prior command have completed (error or not).
   //
-  // This funtion returns 0 to indicate that last command is still
-  // running.  Any other return value implies completion.
-  int
+  // This funtion returns the ert command packet state of the last
+  // command or ERT_CMD_STATE_COMPLETED if no commands have been
+  // submitted.
+  ert_cmd_state
   poll_last_cmd() const
   {
+    // Treat empty runlist as completed
     if (m_submitted_cmds.empty())
-      return 1;
+      return ERT_CMD_STATE_COMPLETED;
 
     auto [cmd, pkt] = unpack(m_submitted_cmds.back());
-    return m_hwqueue.poll(cmd);
+
+    // For lazy state update the command must be polled. Polling
+    // is a no-op on platforms where command state is live.
+    m_hwqueue.poll(cmd);
+    
+    return static_cast<ert_cmd_state>(pkt->state);
   }
 
   // Wait for runlist to complete, then check each chained command
@@ -3248,12 +3255,18 @@ public:
     if (m_state != state::running)
       return 1;
 
-    if (!poll_last_cmd())
+    if (poll_last_cmd() < ERT_CMD_STATE_COMPLETED)
       return 0;
 
     // All commands have completed.  Handle errors.
     wait_throw_on_error(std::chrono::milliseconds(0));
     return 1;
+  }
+
+  ert_cmd_state
+  get_ert_state() const
+  {
+    return poll_last_cmd();
   }
 
   void
@@ -3953,6 +3966,13 @@ wait(const std::chrono::milliseconds& timeout) const
 {
   XRT_TRACE_POINT_SCOPE(xrt_runlist_wait);
   return handle->wait_throw_on_error(timeout);
+}
+
+ert_cmd_state
+runlist::
+state() const
+{
+  return handle->get_ert_state();
 }
 
 int

--- a/src/runtime_src/core/include/experimental/xrt_kernel.h
+++ b/src/runtime_src/core/include/experimental/xrt_kernel.h
@@ -189,6 +189,24 @@ public:
   }
 
   /**
+   * state() - Check the current state of a runlist object
+   *
+   * @return
+   *  Current state of this run object.
+   *
+   * The state values are defined in ``include/ert.h``
+   * The state of an empty runlist is ERT_CMD_STATE_COMPLETED.
+   *
+   * This function is the preferred way to poll a runlist for
+   * for completion.
+   */
+  XRT_API_EXPORT
+  ert_cmd_state
+  state() const;
+
+  /**
+   * DEPRECATED, prefer `state()`.
+   *
    * Poll the runlist for completion.
    *
    * @return 0 if command list is still running, any other value


### PR DESCRIPTION
#### Problem solved by the commit
The xrt::runlist::state() API mirrors xrt::run::state() and is the preferred method for polling a runlist for completion.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Except for return value, the xrt::runlist::poll() API is functionally the same, but is now deprecated.

#### How problem was solved, alternative solutions (if any) and why they were rejected
The state() function returns ERT_CMD_STATE_COMPLETED for an empty runlist.  It otherwise reflects the 
ert command state of the runlist itself.

