### PR TITLE
Removed check in the xclRegRW to read the offset at value zero.

### DIFF
--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -1442,7 +1442,7 @@ xclRegRW(bool rd, uint32_t ipIndex, uint32_t offset, uint32_t *datap)
     xclLog(XRT_ERROR, "%s: invalid CU index: %d", __func__, ipIndex);
     return -EINVAL;
   }
-  if (offset <= 0  || (offset & (sizeof(uint32_t) - 1)) != 0) {
+  if ((offset & (sizeof(uint32_t) - 1)) != 0) {
     xclLog(XRT_ERROR, "%s: invalid CU offset: %d", __func__, offset);
     return -EINVAL;
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1209732  we are getting Invalid offset value in xclRegRW fucntion.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Removed check in the xclRegRW to read the offset at value zero.

#### Risks (if any) associated the changes in the commit
low

#### What has been tested and how, request additional testing if necessary
Tested with vck190 hw_emu
#### Documentation impact (if any)
NA