### PR TITLE
Added file utility to the ub_package_list() in xrtdeps.sh

### DIFF
--- a/src/runtime_src/tools/scripts/xrtdeps.sh
+++ b/src/runtime_src/tools/scripts/xrtdeps.sh
@@ -174,6 +174,7 @@ ub_package_list()
      cppcheck \
      curl \
      dkms \
+     file \
      g++ \
      gcc \
      gdb \


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
While building XRT on ubuntu 24.04 docker, CPackdeb is failing to create the packages becuse the file utility is not available.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added file utility to the ub_package_list() in xrtdeps.sh

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Tested on ubuntu 24.04

#### Documentation impact (if any)
NA