### PR TITLE
VITIS-11710 Fix: Show 0% Utilization Instead of N/A

### DIFF
--- a/src/runtime_src/core/tools/common/reports/ReportAiePartitions.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportAiePartitions.cpp
@@ -87,7 +87,7 @@ calculate_col_utilization(const xrt_core::device* device, boost::property_tree::
   if (total_active_cols > total_device_cols)
     total_active_cols = total_device_cols;
   double total_col_utilization = ((static_cast<double>(total_active_cols) / total_device_cols) * 100);
-  return (total_col_utilization == 0) ? "N/A" : boost::str(boost::format("%.0f%%") % total_col_utilization);
+  return boost::str(boost::format("%.0f%%") % total_col_utilization);
 }
 
 void


### PR DESCRIPTION
#### Problem solved by the commit
After discussing with Pranjal, we want to show 0% total column utilization if it occurs and not "N/A". 
https://jira.xilinx.com/browse/VITIS-11710
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Related to https://github.com/Xilinx/XRT/pull/8396
#### How problem was solved, alternative solutions (if any) and why they were rejected
Changed it so that 0% utilization can be displayed.
#### Risks (if any) associated the changes in the commit
N/A