### PR TITLE
Remove unexpected warnings metadata for ML Timeline and AIE Halt Plugin 

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info/aie_util.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info/aie_util.cpp
@@ -370,81 +370,14 @@ namespace xdp::aie {
     return std::to_string(static_cast<int>(value));
   }
 
-  /****************************************************************************
-   * Get AIE partition information
-   ****************************************************************************/
-  std::vector<uint8_t>
-  getPartitionStartColumnsClient(void* handle)
-  {
-    std::vector<uint8_t> startCols;
-
-    try {
-      xrt::hw_context context = xrt_core::hw_context_int::create_hw_context_from_implementation(handle);
-      auto device = xrt_core::hw_context_int::get_core_device(context);
-      if (device==nullptr)
-        return std::vector<uint8_t>{0};
-
-      auto infoVector = xrt_core::device_query<xrt_core::query::aie_partition_info>(device.get());
-      if (infoVector.empty()) {
-        xrt_core::message::send(severity_level::info, "XRT", "No AIE partition information found.");
-        return std::vector<uint8_t>{0};
-      }
-
-      for (auto& info : infoVector) {
-        auto startCol = static_cast<uint8_t>(info.start_col);
-        xrt_core::message::send(severity_level::info, "XRT",
-            "Partition shift of " + std::to_string(startCol) +
-            " was found, number of columns: " + std::to_string(info.num_cols));
-        startCols.push_back(startCol);
-      }
-    }
-    catch(...) {
-      // Query not available
-      xrt_core::message::send(severity_level::info, "XRT", "Unable to query AIE partition information.");
-      return std::vector<uint8_t>{0};
-    }
-
-    return startCols;
-  }
-
   bool isDigitString(const std::string& str)
   {
     return std::all_of(str.begin(), str.end(), ::isdigit);
   }
 
-  std::vector<uint8_t> getPartitionNumColumnsClient(void* handle)
-  {
-    std::vector<uint8_t> numCols;
-
-    try {
-      xrt::hw_context context = xrt_core::hw_context_int::create_hw_context_from_implementation(handle);
-      auto device = xrt_core::hw_context_int::get_core_device(context);
-      if (device==nullptr)
-        return std::vector<uint8_t>{0};
-
-      auto infoVector = xrt_core::device_query<xrt_core::query::aie_partition_info>(device.get());
-      if (infoVector.empty()) {
-        xrt_core::message::send(severity_level::info, "XRT", "No AIE partition information found.");
-        return std::vector<uint8_t>{0};
-      }
-
-      for (auto& info : infoVector) {
-        auto numCol = static_cast<uint8_t>(info.num_cols);
-        auto startCol = static_cast<uint8_t>(info.start_col);
-        xrt_core::message::send(severity_level::info, "XRT",
-            "Partition shift of " + std::to_string(startCol) +
-            " was found, number of columns: " + std::to_string(info.num_cols));
-        numCols.push_back(numCol);
-      }
-    }
-    catch(...) {
-      // Query not available
-      xrt_core::message::send(severity_level::info, "XRT", "Unable to query AIE partition information.");
-      return std::vector<uint8_t>{0};
-    }
-
-    return numCols;
-  }
+  /****************************************************************************
+   * Get AIE partition information
+   ****************************************************************************/
 
   boost::property_tree::ptree
   getAIEPartitionInfoClient(void* hwCtxImpl)

--- a/src/runtime_src/xdp/profile/database/static_info/aie_util.h
+++ b/src/runtime_src/xdp/profile/database/static_info/aie_util.h
@@ -98,13 +98,7 @@ namespace xdp::aie {
   std::string uint8ToStr(const uint8_t& value);
 
   XDP_CORE_EXPORT
-  std::vector<uint8_t> getPartitionStartColumnsClient(void* handle);
-
-  XDP_CORE_EXPORT
   bool isDigitString(const std::string& str);
-
-  XDP_CORE_EXPORT
-  std::vector<uint8_t> getPartitionNumColumnsClient(void* handle);
 
   XDP_CORE_EXPORT
   boost::property_tree::ptree

--- a/src/runtime_src/xdp/profile/database/static_info_database.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info_database.cpp
@@ -1487,11 +1487,11 @@ namespace xdp {
       devInfo->isNoDMADevice = true;
   }
 
-  void VPStaticDatabase::updateDeviceClient(uint64_t deviceId, std::shared_ptr<xrt_core::device> device)
+  void VPStaticDatabase::updateDeviceClient(uint64_t deviceId, std::shared_ptr<xrt_core::device> device, bool readAIEMetadata)
   {
     xrt::xclbin xrtXclbin = device->get_xclbin(device->get_xclbin_uuid());
     // Client should have no PL interface
-    updateDevice(deviceId, xrtXclbin, nullptr, true);
+    updateDevice(deviceId, xrtXclbin, nullptr, true, readAIEMetadata);
   }
 
   // Return true if we should reset the device information.
@@ -2286,7 +2286,7 @@ namespace xdp {
 
   // Methods using xrt::xclbin to retrive static information
 
-  DeviceInfo* VPStaticDatabase::updateDevice(uint64_t deviceId, xrt::xclbin xrtXclbin, std::unique_ptr<xdp::Device> xdpDevice, bool clientBuild)
+  DeviceInfo* VPStaticDatabase::updateDevice(uint64_t deviceId, xrt::xclbin xrtXclbin, std::unique_ptr<xdp::Device> xdpDevice, bool clientBuild, bool readAIEdata)
   {
     XclbinInfoType xclbinType = getXclbinType(xrtXclbin);
     // We need to update the device, but if we had an xclbin previously loaded
@@ -2327,9 +2327,11 @@ namespace xdp {
     currentXclbin->pl.clockRatePLMHz = findClockRate(xrtXclbin) ;
 
     setDeviceNameFromXclbin(deviceId, xrtXclbin);
-    readAIEMetadata(xrtXclbin, clientBuild);
-    setAIEGeneration(deviceId, xrtXclbin);
-    setAIEClockRateMHz(deviceId, xrtXclbin);
+    if (readAIEdata) {
+      readAIEMetadata(xrtXclbin, clientBuild);
+      setAIEGeneration(deviceId, xrtXclbin);
+      setAIEClockRateMHz(deviceId, xrtXclbin);
+    }
 
     /* Configure AMs if context monitoring is supported
      * else disable alll AMs on this device

--- a/src/runtime_src/xdp/profile/database/static_info_database.h
+++ b/src/runtime_src/xdp/profile/database/static_info_database.h
@@ -158,7 +158,7 @@ namespace xdp {
     // pointer to handle any connection to the PL side as necessary.
     // Some plugins do not require any PL control and will pass in nullptr
     DeviceInfo* updateDevice(uint64_t deviceId, xrt::xclbin xrtXclbin,
-                             std::unique_ptr<xdp::Device> xdpDevice, bool clientBuild) ;
+                             std::unique_ptr<xdp::Device> xdpDevice, bool clientBuild, bool readAIEdata = true) ;
 
   public:
     VPStaticDatabase(VPDatabase* d) ;
@@ -283,7 +283,7 @@ namespace xdp {
     XDP_CORE_EXPORT Memory* getMemory(uint64_t deviceId, int32_t memId) ;
     // Reseting device information whenever a new xclbin is added
     XDP_CORE_EXPORT void updateDevice(uint64_t deviceId, std::unique_ptr<xdp::Device> xdpDevice, void* devHandle) ;
-    XDP_CORE_EXPORT void updateDeviceClient(uint64_t deviceId, std::shared_ptr<xrt_core::device> device);
+    XDP_CORE_EXPORT void updateDeviceClient(uint64_t deviceId, std::shared_ptr<xrt_core::device> device, bool readAIEMetadata = true);
 
     // *********************************************************
     // ***** Functions related to trace_processor tool *****

--- a/src/runtime_src/xdp/profile/plugin/aie_halt/aie_halt_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_halt/aie_halt_plugin.cpp
@@ -78,7 +78,7 @@ namespace xdp {
 
     // Only one device for Client Device flow
     uint64_t deviceId = db->addDevice("win_device");
-    (db->getStaticInfo()).updateDeviceClient(deviceId, coreDevice);
+    (db->getStaticInfo()).updateDeviceClient(deviceId, coreDevice, false);
     (db->getStaticInfo()).setDeviceName(deviceId, "win_device");
 
     DeviceDataEntry.valid = true;

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/client/aie_profile.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/client/aie_profile.cpp
@@ -114,8 +114,13 @@ namespace xdp {
 
     // Get partition columns
     // NOTE: for now, assume a single partition
-    auto partitionCols = xdp::aie::getPartitionStartColumnsClient(metadata->getHandle());
-    uint8_t startCol = partitionCols.at(0);
+    uint8_t startCol = 0;
+    boost::property_tree::ptree aiePartitionPt = xdp::aie::getAIEPartitionInfoClient(hwCtxImpl);
+    for (const auto& e : aiePartitionPt) {
+      startCol = static_cast<uint8_t>(e.second.get<uint64_t>("start_col"));
+      // Currently, assuming only one Hw Context is alive at a time
+      break;
+    }
 
     //Start recording the transaction
     XAie_StartTransaction(&aieDevInst, XAIE_TRANSACTION_DISABLE_AUTO_FLUSH);

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/client/aie_profile.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/client/aie_profile.cpp
@@ -115,7 +115,7 @@ namespace xdp {
     // Get partition columns
     // NOTE: for now, assume a single partition
     uint8_t startCol = 0;
-    boost::property_tree::ptree aiePartitionPt = xdp::aie::getAIEPartitionInfoClient(hwCtxImpl);
+    boost::property_tree::ptree aiePartitionPt = xdp::aie::getAIEPartitionInfoClient(metadata->getHandle());
     for (const auto& e : aiePartitionPt) {
       startCol = static_cast<uint8_t>(e.second.get<uint64_t>("start_col"));
       // Currently, assuming only one Hw Context is alive at a time

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/client/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/client/aie_trace.cpp
@@ -223,10 +223,14 @@ namespace xdp {
 
   void AieTrace_WinImpl::build2ChannelBroadcastNetwork(void *handle, uint8_t broadcastId1, uint8_t broadcastId2, XAie_Events event) {
 
-    auto partitionCols = xdp::aie::getPartitionStartColumnsClient(handle);
-    uint8_t startCol = partitionCols[0];
-    auto numColsVec = xdp::aie::getPartitionNumColumnsClient(handle);
-    uint8_t numCols = numColsVec[0];
+    uint8_t startCol = 0, numCols = 0;
+    boost::property_tree::ptree aiePartitionPt = xdp::aie::getAIEPartitionInfoClient(hwCtxImpl);
+    for (const auto& e : aiePartitionPt) {
+      startCol = static_cast<uint8_t>(e.second.get<uint64_t>("start_col"));
+      numCols  = static_cast<uint8_t>(e.second.get<uint64_t>("num_cols"));
+      // Currently, assuming only one Hw Context is alive at a time
+      break;
+    }
 
     std::vector<uint8_t> maxRowAtCol(startCol + numCols, 0);
     for (auto& tileMetric : metadata->getConfigMetrics()) {
@@ -294,8 +298,13 @@ namespace xdp {
     //Start recording the transaction
     XAie_StartTransaction(&aieDevInst, XAIE_TRANSACTION_DISABLE_AUTO_FLUSH);
 
-    auto partitionCols = xdp::aie::getPartitionStartColumnsClient(handle);
-    uint8_t startCol = partitionCols[0];
+    uint8_t startCol = 0;
+    boost::property_tree::ptree aiePartitionPt = xdp::aie::getAIEPartitionInfoClient(hwCtxImpl);
+    for (const auto& e : aiePartitionPt) {
+      startCol = static_cast<uint8_t>(e.second.get<uint64_t>("start_col"));
+      // Currently, assuming only one Hw Context is alive at a time
+      break;
+    }
 
     uint8_t broadcastId1 = 6;
     uint8_t broadcastId2 = 7;
@@ -1016,8 +1025,14 @@ namespace xdp {
 
     // Get partition columns
     // NOTE: for now, assume a single partition
-    auto partitionCols = xdp::aie::getPartitionStartColumnsClient(handle);
-    uint8_t startCol = partitionCols.at(0);
+    uint8_t startCol = 0;
+    boost::property_tree::ptree aiePartitionPt = xdp::aie::getAIEPartitionInfoClient(hwCtxImpl);
+    for (const auto& e : aiePartitionPt) {
+      startCol = static_cast<uint8_t>(e.second.get<uint64_t>("start_col"));
+      // Currently, assuming only one Hw Context is alive at a time
+      break;
+    }
+
     std::string startType = xrt_core::config::get_aie_trace_settings_start_type();
     unsigned int startLayer = xrt_core::config::get_aie_trace_settings_start_layer();
     

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/client/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/client/aie_trace.cpp
@@ -221,7 +221,7 @@ namespace xdp {
   }
 
 
-  void AieTrace_WinImpl::build2ChannelBroadcastNetwork(void *handle, uint8_t broadcastId1, uint8_t broadcastId2, XAie_Events event) {
+  void AieTrace_WinImpl::build2ChannelBroadcastNetwork(void *hwCtxImpl, uint8_t broadcastId1, uint8_t broadcastId2, XAie_Events event) {
 
     uint8_t startCol = 0, numCols = 0;
     boost::property_tree::ptree aiePartitionPt = xdp::aie::getAIEPartitionInfoClient(hwCtxImpl);
@@ -294,7 +294,7 @@ namespace xdp {
     }
   }
 
-  bool AieTrace_WinImpl::configureWindowedEventTrace(void* handle) {
+  bool AieTrace_WinImpl::configureWindowedEventTrace(void* hwCtxImpl {
     //Start recording the transaction
     XAie_StartTransaction(&aieDevInst, XAIE_TRANSACTION_DISABLE_AUTO_FLUSH);
 
@@ -349,7 +349,7 @@ namespace xdp {
       XAie_PerfCounterEventValueSet(&aieDevInst, XAie_TileLoc(0, 0), XAIE_PL_MOD, 0, startLayer);
     }
 
-    build2ChannelBroadcastNetwork(handle, broadcastId1, broadcastId2, XAIE_EVENT_PERF_CNT_0_PL);
+    build2ChannelBroadcastNetwork(hwCtxImpl, broadcastId1, broadcastId2, XAIE_EVENT_PERF_CNT_0_PL);
     
     uint8_t *txn_ptr = XAie_ExportSerializedTransaction(&aieDevInst, 1, 0);
 
@@ -1017,11 +1017,9 @@ namespace xdp {
   /****************************************************************************
    * Configure requested tiles with trace metrics and settings
    ***************************************************************************/
-  bool AieTrace_WinImpl::setMetricsSettings(uint64_t deviceId, void* handle)
+  bool AieTrace_WinImpl::setMetricsSettings(uint64_t deviceId, void* hwCtxImpl)
   {
-    // Gather data to send to PS Kernel
     (void)deviceId;
-    (void)handle;
 
     // Get partition columns
     // NOTE: for now, assume a single partition

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/client/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/client/aie_trace.cpp
@@ -294,7 +294,7 @@ namespace xdp {
     }
   }
 
-  bool AieTrace_WinImpl::configureWindowedEventTrace(void* hwCtxImpl {
+  bool AieTrace_WinImpl::configureWindowedEventTrace(void* hwCtxImpl) {
     //Start recording the transaction
     XAie_StartTransaction(&aieDevInst, XAIE_TRANSACTION_DISABLE_AUTO_FLUSH);
 

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_plugin.cpp
@@ -108,7 +108,7 @@ namespace xdp {
 
     // Only one device for Client Device flow
     uint64_t deviceId = db->addDevice("win_device");
-    (db->getStaticInfo()).updateDeviceClient(deviceId, coreDevice);
+    (db->getStaticInfo()).updateDeviceClient(deviceId, coreDevice, false);
     (db->getStaticInfo()).setDeviceName(deviceId, "win_device");
 
     DeviceDataEntry.valid = true;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
ML Timeline and AIE Halt Plugin gives unexpected (but harmless) warnings when aie metadata json files for Client are not found in run dir. As they dont use the json files, the warnings should  be removed.
Also, remove some duplicate methods in aie util and their usages.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Unit test
#### Documentation impact (if any)
