### PR TITLE
CR-1211410 : Fix xbutil/xrt-smi wrapper script to find loader

### DIFF
--- a/src/runtime_src/core/tools/xbutil2/xbutil
+++ b/src/runtime_src/core/tools/xbutil2/xbutil
@@ -43,7 +43,7 @@ XRT_LOADER_DIR="`dirname \"$0\"`"
 
 # For edge platforms loader is not required as tools are in standard location(/usr).
 # So calling unwrapped tool from this script itself.
-if [[ $XRT_LOADER_DIR =~ "/usr" ]]; then
+if [[ $XRT_LOADER_DIR =~ "/usr" || $XRT_LOADER_DIR =~ "/bin" ]]; then
     "${XRT_LOADER_DIR}/unwrapped/${XRT_PROG}" "${XRTWRAP_PROG_ARGS[@]}"
     exit 0
 fi

--- a/src/runtime_src/core/tools/xbutil2/xrt-smi
+++ b/src/runtime_src/core/tools/xbutil2/xrt-smi
@@ -35,7 +35,7 @@ XRT_LOADER_DIR="`dirname \"$0\"`"
 
 # For edge platforms loader is not required as tools are in standard location(/usr).
 # So calling unwrapped tool from this script itself.
-if [[ $XRT_LOADER_DIR =~ "/usr" ]]; then
+if [[ $XRT_LOADER_DIR =~ "/usr" || $XRT_LOADER_DIR =~ "/bin" ]]; then
     "${XRT_LOADER_DIR}/unwrapped/${XRT_PROG}" "${XRTWRAP_PROG_ARGS[@]}"
     exit 0
 fi


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
With latest Petalinux (2024.2) executables bin path is mounted to /bin instead of /usr/bin and when user tries to run xbutil/xrt-smi we are not able to find unwrapped xbutil script which loads loader script. This PR fixes this issue.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
This issue got introduced because of latest petalinux changes

#### How problem was solved, alternative solutions (if any) and why they were rejected
checking XRT_LOADER_DIR path contains either /usr or /bin

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
Tested the changes on hw_emu flow using vck190_base platform

#### Documentation impact (if any)
NA