### PR TITLE
Updated copyright header for the files that are changed in 2021.1

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
@@ -4,6 +4,7 @@
  * OpenCL accelerators.
  *
  * Copyright (C) 2016-2021 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Authors:
  *    Sonal Santan <sonal.santan@xilinx.com>

--- a/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
@@ -3,8 +3,8 @@
  * A GEM style (optionally CMA backed) device manager for ZynQ based
  * OpenCL accelerators.
  *
- * Copyright (C) 2016-2021 Xilinx, Inc. All rights reserved.
- * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2022 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Authors:
  *    Sonal Santan <sonal.santan@xilinx.com>

--- a/src/runtime_src/core/pcie/driver/aws/kernel/mgmt/mgmt-core.h
+++ b/src/runtime_src/core/pcie/driver/aws/kernel/mgmt/mgmt-core.h
@@ -1,6 +1,6 @@
 /*
- *  Copyright (C) 2017-2018, Xilinx Inc
- *  Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights reserved.
+ *  Copyright (C) 2017-2022, Xilinx Inc
+ *  Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by the Free Software Foundation;

--- a/src/runtime_src/core/pcie/driver/aws/kernel/mgmt/mgmt-core.h
+++ b/src/runtime_src/core/pcie/driver/aws/kernel/mgmt/mgmt-core.h
@@ -1,5 +1,6 @@
 /*
  *  Copyright (C) 2017-2018, Xilinx Inc
+ *  Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by the Free Software Foundation;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma/qdma_request.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma/qdma_request.c
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Xilinx DMA IP Core driver for Linux
  *
- * Copyright (c) 2017-present,  Xilinx, Inc.
+ * Copyright (c) 2017-present,  Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * This source code is licensed under both the BSD-style license (found in the

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma/qdma_request.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma/qdma_request.c
@@ -1,7 +1,8 @@
 /*
  * This file is part of the Xilinx DMA IP Core driver for Linux
  *
- * Copyright (c) 2017-present,  Advanced Micro Devices, Inc.
+ * Copyright (C) 2017-2022, Xilinx Inc
+ * Copyright (C) 2022-present Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * This source code is licensed under both the BSD-style license (found in the

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma/qdma_st_c2h.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma/qdma_st_c2h.c
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Xilinx DMA IP Core driver for Linux
  *
- * Copyright (c) 2017-present,  Xilinx, Inc.
+ * Copyright (c) 2017-present,  Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * This source code is free software; you can redistribute it and/or modify it

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma/qdma_st_c2h.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma/qdma_st_c2h.c
@@ -1,7 +1,8 @@
 /*
  * This file is part of the Xilinx DMA IP Core driver for Linux
  *
- * Copyright (c) 2017-present,  Advanced Micro Devices, Inc.
+ * Copyright (C) 2017-2022, Xilinx Inc
+ * Copyright (C) 2022-present Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * This source code is free software; you can redistribute it and/or modify it

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma/xdev.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma/xdev.c
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Xilinx DMA IP Core driver for Linux
  *
- * Copyright (c) 2017-present,  Xilinx, Inc.
+ * Copyright (c) 2017-present,  Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * This source code is free software; you can redistribute it and/or modify it

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma/xdev.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma/xdev.c
@@ -1,7 +1,8 @@
 /*
  * This file is part of the Xilinx DMA IP Core driver for Linux
  *
- * Copyright (c) 2017-present,  Advanced Micro Devices, Inc.
+ * Copyright (C) 2017-2022, Xilinx Inc
+ * Copyright (C) 2022-present Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * This source code is free software; you can redistribute it and/or modify it

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/libqdma_export.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/libqdma_export.c
@@ -1,7 +1,8 @@
 /*
  * This file is part of the Xilinx DMA IP Core driver for Linux
  *
- * Copyright (c) 2017-present, Advanced Micro Devices, Inc.
+ * Copyright (C) 2017-2022, Xilinx Inc
+ * Copyright (C) 2022-present Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * This source code is free software; you can redistribute it and/or modify it

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/libqdma_export.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/libqdma_export.c
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Xilinx DMA IP Core driver for Linux
  *
- * Copyright (c) 2017-2020,  Xilinx, Inc.
+ * Copyright (c) 2017-present, Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * This source code is free software; you can redistribute it and/or modify it

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/qdma_st_c2h.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/qdma_st_c2h.c
@@ -1,7 +1,8 @@
 /*
  * This file is part of the Xilinx DMA IP Core driver for Linux
  *
- * Copyright (c) 2017-present, Advanced Micro Devices, Inc.
+ * Copyright (C) 2017-2022, Xilinx Inc
+ * Copyright (C) 2022-present Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * This source code is free software; you can redistribute it and/or modify it

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/qdma_st_c2h.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/qdma_st_c2h.c
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Xilinx DMA IP Core driver for Linux
  *
- * Copyright (c) 2017-2020,  Xilinx, Inc.
+ * Copyright (c) 2017-present, Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * This source code is free software; you can redistribute it and/or modify it

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/xdev.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/xdev.c
@@ -1,7 +1,8 @@
 /*
  * This file is part of the Xilinx DMA IP Core driver for Linux
  *
- * Copyright (c) 2017-present, Advanced Micro Devices, Inc.
+ * Copyright (C) 2017-2022, Xilinx Inc
+ * Copyright (C) 2022-present Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * This source code is free software; you can redistribute it and/or modify it

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/xdev.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/xdev.c
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Xilinx DMA IP Core driver for Linux
  *
- * Copyright (c) 2017-2020,  Xilinx, Inc.
+ * Copyright (c) 2017-present, Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * This source code is free software; you can redistribute it and/or modify it

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
@@ -1,7 +1,8 @@
 /*
  * Simple Driver for Management PF
  *
- * Copyright (C) 2017-2020 Xilinx, Inc.
+ * Copyright (c) 2017-present, Advanced Micro Devices, Inc.
+ * All rights reserved.
  *
  * Code borrowed from Xilinx SDAccel XDMA driver
  *

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
@@ -1,7 +1,8 @@
 /*
  * Simple Driver for Management PF
  *
- * Copyright (c) 2017-present, Advanced Micro Devices, Inc.
+ * Copyright (C) 2017-2022, Xilinx Inc
+ * Copyright (C) 2022-present Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Code borrowed from Xilinx SDAccel XDMA driver

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/aim.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/aim.c
@@ -1,7 +1,8 @@
 /*
  * A GEM style device manager for PCIe based OpenCL accelerators.
  *
- * Copyright (c) 2020-present, Advanced Micro Devices, Inc.
+ * Copyright (C) 2020-2022, Xilinx Inc
+ * Copyright (C) 2022-present Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Authors: Chien-Wei Lan <chienwei@xilinx.com>

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/aim.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/aim.c
@@ -1,7 +1,8 @@
 /*
  * A GEM style device manager for PCIe based OpenCL accelerators.
  *
- * Copyright (C) 2020 Xilinx, Inc. All rights reserved.
+ * Copyright (c) 2020-present, Advanced Micro Devices, Inc.
+ * All rights reserved.
  *
  * Authors: Chien-Wei Lan <chienwei@xilinx.com>
  *

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/am.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/am.c
@@ -1,7 +1,8 @@
 /*
  * A GEM style device manager for PCIe based OpenCL accelerators.
  *
- * Copyright (c) 2020-present, Advanced Micro Devices, Inc.
+ * Copyright (C) 2020-2022, Xilinx Inc
+ * Copyright (C) 2022-present Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Authors: Chien-Wei Lan <chienwei@xilinx.com>

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/am.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/am.c
@@ -1,7 +1,8 @@
 /*
  * A GEM style device manager for PCIe based OpenCL accelerators.
  *
- * Copyright (C) 2020 Xilinx, Inc. All rights reserved.
+ * Copyright (c) 2020-present, Advanced Micro Devices, Inc.
+ * All rights reserved.
  *
  * Authors: Chien-Wei Lan <chienwei@xilinx.com>
  *

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/asm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/asm.c
@@ -1,7 +1,8 @@
 /*
  * A GEM style device manager for PCIe based OpenCL accelerators.
  *
- * Copyright (c) 2020-present, Advanced Micro Devices, Inc.
+ * Copyright (C) 2020-2022, Xilinx Inc
+ * Copyright (C) 2022-present Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Authors: Chien-Wei Lan <chienwei@xilinx.com>

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/asm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/asm.c
@@ -1,7 +1,8 @@
 /*
  * A GEM style device manager for PCIe based OpenCL accelerators.
  *
- * Copyright (C) 2020 Xilinx, Inc. All rights reserved.
+ * Copyright (c) 2020-present, Advanced Micro Devices, Inc.
+ * All rights reserved.
  *
  * Authors: Chien-Wei Lan <chienwei@xilinx.com>
  *

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/fmgr.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/fmgr.c
@@ -1,7 +1,8 @@
 /*
  * FPGA Manager bindings for XRT driver
  *
- * Copyright (c) 2019-present, Advanced Micro Devices, Inc.
+ * Copyright (C) 2019-2022, Xilinx Inc
+ * Copyright (C) 2022-present Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Authors: Sonal Santan

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/fmgr.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/fmgr.c
@@ -1,7 +1,8 @@
 /*
  * FPGA Manager bindings for XRT driver
  *
- * Copyright (C) 2019 Xilinx, Inc. All rights reserved.
+ * Copyright (c) 2019-present, Advanced Micro Devices, Inc.
+ * All rights reserved.
  *
  * Authors: Sonal Santan
  *          Jan Stephan <j.stephan@hzdr.de>

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/lapc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/lapc.c
@@ -1,7 +1,8 @@
 /*
  * A GEM style device manager for PCIe based OpenCL accelerators.
  *
- * Copyright (c) 2020-present, Advanced Micro Devices, Inc.
+ * Copyright (C) 2020-2022, Xilinx Inc
+ * Copyright (C) 2022-present Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Authors: Chien-Wei Lan <chienwei@xilinx.com>

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/lapc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/lapc.c
@@ -1,7 +1,8 @@
 /*
  * A GEM style device manager for PCIe based OpenCL accelerators.
  *
- * Copyright (C) 2020 Xilinx, Inc. All rights reserved.
+ * Copyright (c) 2020-present, Advanced Micro Devices, Inc.
+ * All rights reserved.
  *
  * Authors: Chien-Wei Lan <chienwei@xilinx.com>
  *

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/qdma.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/qdma.c
@@ -1,7 +1,8 @@
 /*
  * A GEM style device manager for PCIe based OpenCL accelerators.
  *
- * Copyright (c) 2016-present, Advanced Micro Devices, Inc.
+ * Copyright (C) 2016-2022, Xilinx Inc
+ * Copyright (C) 2022-present Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Authors: Lizhi.Hou@Xilinx.com

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/qdma.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/qdma.c
@@ -1,7 +1,8 @@
 /*
  * A GEM style device manager for PCIe based OpenCL accelerators.
  *
- * Copyright (C) 2016-2018 Xilinx, Inc. All rights reserved.
+ * Copyright (c) 2016-present, Advanced Micro Devices, Inc.
+ * All rights reserved.
  *
  * Authors: Lizhi.Hou@Xilinx.com
  *          Jan Stephan <j.stephan@hzdr.de>

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/qdma4.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/qdma4.c
@@ -1,7 +1,8 @@
 /*
  * A GEM style device manager for PCIe based OpenCL accelerators.
  *
- * Copyright (C) 2020- Xilinx, Inc. All rights reserved.
+ * Copyright (c) 2020-present, Advanced Micro Devices, Inc.
+ * All rights reserved.
  *
  * Authors: Lizhi.Hou@Xilinx.com
  *          Jan Stephan <j.stephan@hzdr.de>

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/qdma4.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/qdma4.c
@@ -1,7 +1,8 @@
 /*
  * A GEM style device manager for PCIe based OpenCL accelerators.
  *
- * Copyright (c) 2020-present, Advanced Micro Devices, Inc.
+ * Copyright (C) 2020-2022, Xilinx Inc
+ * Copyright (C) 2022-present Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Authors: Lizhi.Hou@Xilinx.com

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/spc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/spc.c
@@ -1,7 +1,8 @@
 /*
  * A GEM style device manager for PCIe based OpenCL accelerators.
  *
- * Copyright (c) 2020-present, Advanced Micro Devices, Inc.
+ * Copyright (C) 2020-2022, Xilinx Inc
+ * Copyright (C) 2022-present Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Authors: Chien-Wei Lan <chienwei@xilinx.com>

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/spc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/spc.c
@@ -1,7 +1,8 @@
 /*
  * A GEM style device manager for PCIe based OpenCL accelerators.
  *
- * Copyright (C) 2020 Xilinx, Inc. All rights reserved.
+ * Copyright (c) 2020-present, Advanced Micro Devices, Inc.
+ * All rights reserved.
  *
  * Authors: Chien-Wei Lan <chienwei@xilinx.com>
  *

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/trace_fifo_lite.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/trace_fifo_lite.c
@@ -1,7 +1,8 @@
 /*
  * A GEM style device manager for PCIe based OpenCL accelerators.
  *
- * Copyright (c) 2020-present, Advanced Micro Devices, Inc.
+ * Copyright (C) 2020-2022, Xilinx Inc
+ * Copyright (C) 2022-present Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Authors: Chien-Wei Lan <chienwei@xilinx.com>

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/trace_fifo_lite.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/trace_fifo_lite.c
@@ -1,7 +1,8 @@
 /*
  * A GEM style device manager for PCIe based OpenCL accelerators.
  *
- * Copyright (C) 2020 Xilinx, Inc. All rights reserved.
+ * Copyright (c) 2020-present, Advanced Micro Devices, Inc.
+ * All rights reserved.
  *
  * Authors: Chien-Wei Lan <chienwei@xilinx.com>
  *

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/trace_funnel.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/trace_funnel.c
@@ -1,7 +1,8 @@
 /*
  * A GEM style device manager for PCIe based OpenCL accelerators.
  *
- * Copyright (c) 2020-present, Advanced Micro Devices, Inc.
+ * Copyright (C) 2020-2022, Xilinx Inc
+ * Copyright (C) 2022-present Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Authors: Chien-Wei Lan <chienwei@xilinx.com>

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/trace_funnel.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/trace_funnel.c
@@ -1,7 +1,8 @@
 /*
  * A GEM style device manager for PCIe based OpenCL accelerators.
  *
- * Copyright (C) 2020 Xilinx, Inc. All rights reserved.
+ * Copyright (c) 2020-present, Advanced Micro Devices, Inc.
+ * All rights reserved.
  *
  * Authors: Chien-Wei Lan <chienwei@xilinx.com>
  *

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/trace_s2mm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/trace_s2mm.c
@@ -1,7 +1,8 @@
 /*
  * A GEM style device manager for PCIe based OpenCL accelerators.
  *
- * Copyright (c) 2020-present, Advanced Micro Devices, Inc.
+ * Copyright (C) 2020-2022, Xilinx Inc
+ * Copyright (C) 2022-present Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Authors: Chien-Wei Lan <chienwei@xilinx.com>

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/trace_s2mm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/trace_s2mm.c
@@ -1,7 +1,8 @@
 /*
  * A GEM style device manager for PCIe based OpenCL accelerators.
  *
- * Copyright (C) 2020 Xilinx, Inc. All rights reserved.
+ * Copyright (c) 2020-present, Advanced Micro Devices, Inc.
+ * All rights reserved.
  *
  * Authors: Chien-Wei Lan <chienwei@xilinx.com>
  *

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ulite.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ulite.c
@@ -4,6 +4,7 @@
  * Copyright (C) 2006 Peter Korsgaard <jacmet@sunsite.dk>
  * Copyright (C) 2007 Secret Lab Technologies Ltd.
  * Copyright (C) 2020 Chien-Wei Lan <chienwei@xilinx.com>
+ * Copyright (c) 2024, Advanced Micro Devices, Inc.
  *
  * This software is licensed under the terms of the GNU General Public
  * License version 2, as published by the Free Software Foundation, and

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xiic.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xiic.c
@@ -1,6 +1,7 @@
 /**
  *  Copyright (C) 2017 Xilinx, Inc. All rights reserved.
  *  Copyright (c) 2009-2010 Intel Corporation
+ *  Copyright (c) 2024, Advanced Micro Devices, Inc.
  *
  *  I2C driver module
  *

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
@@ -1,7 +1,8 @@
 /*
  * A GEM style device manager for PCIe based OpenCL accelerators.
  *
- * Copyright (c) 2016-present, Advanced Micro Devices, Inc.
+ * Copyright (C) 2016-2022, Xilinx Inc
+ * Copyright (C) 2022-present Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Authors:

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
@@ -1,7 +1,8 @@
 /*
  * A GEM style device manager for PCIe based OpenCL accelerators.
  *
- * Copyright (C) 2016-2019 Xilinx, Inc. All rights reserved.
+ * Copyright (c) 2016-present, Advanced Micro Devices, Inc.
+ * All rights reserved.
  *
  * Authors:
  *    Sonal Santan <sonal.santan@xilinx.com>

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.h
@@ -1,7 +1,8 @@
 /*
  * A GEM style device manager for PCIe based OpenCL accelerators.
  *
- * Copyright (c) 2016-present, Advanced Micro Devices, Inc.
+ * Copyright (C) 2016-2022, Xilinx Inc
+ * Copyright (C) 2022-present Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Authors:

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.h
@@ -1,7 +1,8 @@
 /*
  * A GEM style device manager for PCIe based OpenCL accelerators.
  *
- * Copyright (C) 2016-2018 Xilinx, Inc. All rights reserved.
+ * Copyright (c) 2016-present, Advanced Micro Devices, Inc.
+ * All rights reserved.
  *
  * Authors:
  *

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
@@ -1,7 +1,8 @@
 /*
  * A GEM style device manager for PCIe based OpenCL accelerators.
  *
- * Copyright (c) 2016-present, Advanced Micro Devices, Inc.
+ * Copyright (C) 2016-2022, Xilinx Inc
+ * Copyright (C) 2022-present Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Authors: Jan Stephan <j.stephan@hzdr.de>

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
@@ -1,7 +1,8 @@
 /*
  * A GEM style device manager for PCIe based OpenCL accelerators.
  *
- * Copyright (C) 2016-2021 Xilinx, Inc. All rights reserved.
+ * Copyright (c) 2016-present, Advanced Micro Devices, Inc.
+ * All rights reserved.
  *
  * Authors: Jan Stephan <j.stephan@hzdr.de>
  *

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2016-2020 Xilinx, Inc. All rights reserved.
+ * Copyright (c) 2016-present, Advanced Micro Devices, Inc.
+ * All rights reserved.
  *
  * Authors: Lizhi.Hou@xilinx.com
  *

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2016-present, Advanced Micro Devices, Inc.
+ * Copyright (C) 2016-2022, Xilinx Inc
+ * Copyright (C) 2022-present Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Authors: Lizhi.Hou@xilinx.com

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2016-present, Advanced Micro Devices, Inc.
+ * Copyright (C) 2016-2022, Xilinx Inc
+ * Copyright (C) 2022-present Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Authors: Lizhi.Hou@Xilinx.com

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2016-2021 Xilinx, Inc. All rights reserved.
+ * Copyright (c) 2016-present, Advanced Micro Devices, Inc.
+ * All rights reserved.
  *
  * Authors: Lizhi.Hou@Xilinx.com
  *          Jan Stephan <j.stephan@hzdr.de>

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -1,5 +1,6 @@
 /**
- * Copyright (c) 2019-present, Advanced Micro Devices, Inc.
+ * Copyright (C) 2019-2022, Xilinx Inc
+ * Copyright (C) 2022-present Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -1,5 +1,6 @@
 /**
- * Copyright (C) 2019-2021 Xilinx, Inc
+ * Copyright (c) 2019-present, Advanced Micro Devices, Inc.
+ * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the

--- a/src/xma/include/app/xmabuffers.h
+++ b/src/xma/include/app/xmabuffers.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018, Xilinx Inc - All rights reserved
- * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2018-2022, Xilinx Inc - All rights reserved
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
  * Xilinx SDAccel Media Accelerator API
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/src/xma/include/app/xmabuffers.h
+++ b/src/xma/include/app/xmabuffers.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2018, Xilinx Inc - All rights reserved
+ * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights reserved.
  * Xilinx SDAccel Media Accelerator API
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/src/xma/include/lib/xma_utils.hpp
+++ b/src/xma/include/lib/xma_utils.hpp
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2019 Xilinx, Inc
+ * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the

--- a/src/xma/include/lib/xma_utils.hpp
+++ b/src/xma/include/lib/xma_utils.hpp
@@ -1,6 +1,6 @@
 /**
- * Copyright (C) 2019 Xilinx, Inc
- * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2022 Xilinx, Inc
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the

--- a/src/xma/src/xmaapi/xma_utils.cpp
+++ b/src/xma/src/xmaapi/xma_utils.cpp
@@ -1,6 +1,6 @@
 /**
- * Copyright (C) 2019 Xilinx, Inc
- * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2022 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the

--- a/src/xma/src/xmaapi/xma_utils.cpp
+++ b/src/xma/src/xmaapi/xma_utils.cpp
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2019 Xilinx, Inc
+ * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the

--- a/src/xma/src/xmaapi/xmaadmin.cpp
+++ b/src/xma/src/xmaapi/xmaadmin.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018, Xilinx Inc - All rights reserved
- * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2018-2022, Xilinx Inc - All rights reserved
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
  * Xilinx SDAccel Media Accelerator API
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/src/xma/src/xmaapi/xmaadmin.cpp
+++ b/src/xma/src/xmaapi/xmaadmin.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2018, Xilinx Inc - All rights reserved
+ * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights reserved.
  * Xilinx SDAccel Media Accelerator API
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/src/xma/src/xmaapi/xmadecoder.cpp
+++ b/src/xma/src/xmaapi/xmadecoder.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018, Xilinx Inc - All rights reserved
- * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2018-2022, Xilinx Inc - All rights reserved
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
  * Xilinx SDAccel Media Accelerator API
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/src/xma/src/xmaapi/xmadecoder.cpp
+++ b/src/xma/src/xmaapi/xmadecoder.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2018, Xilinx Inc - All rights reserved
+ * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights reserved.
  * Xilinx SDAccel Media Accelerator API
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/src/xma/src/xmaapi/xmaencoder.cpp
+++ b/src/xma/src/xmaapi/xmaencoder.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018, Xilinx Inc - All rights reserved
- * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2018-2022, Xilinx Inc - All rights reserved
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
  * Xilinx SDAccel Media Accelerator API
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/src/xma/src/xmaapi/xmaencoder.cpp
+++ b/src/xma/src/xmaapi/xmaencoder.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2018, Xilinx Inc - All rights reserved
+ * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights reserved.
  * Xilinx SDAccel Media Accelerator API
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/src/xma/src/xmaapi/xmafilter.cpp
+++ b/src/xma/src/xmaapi/xmafilter.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018, Xilinx Inc - All rights reserved
- * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2018-2022, Xilinx Inc - All rights reserved
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
  * Xilinx SDAccel Media Accelerator API
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/src/xma/src/xmaapi/xmafilter.cpp
+++ b/src/xma/src/xmaapi/xmafilter.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2018, Xilinx Inc - All rights reserved
+ * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights reserved.
  * Xilinx SDAccel Media Accelerator API
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/src/xma/src/xmaapi/xmakernel.cpp
+++ b/src/xma/src/xmaapi/xmakernel.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018, Xilinx Inc - All rights reserved
- * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2018-2022, Xilinx Inc - All rights reserved
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
  * Xilinx SDAccel Media Accelerator API
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/src/xma/src/xmaapi/xmakernel.cpp
+++ b/src/xma/src/xmaapi/xmakernel.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2018, Xilinx Inc - All rights reserved
+ * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights reserved.
  * Xilinx SDAccel Media Accelerator API
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/src/xma/src/xmaapi/xmascaler.cpp
+++ b/src/xma/src/xmaapi/xmascaler.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018, Xilinx Inc - All rights reserved
- * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2018-2022, Xilinx Inc - All rights reserved
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
  * Xilinx SDAccel Media Accelerator API
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/src/xma/src/xmaapi/xmascaler.cpp
+++ b/src/xma/src/xmaapi/xmascaler.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2018, Xilinx Inc - All rights reserved
+ * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights reserved.
  * Xilinx SDAccel Media Accelerator API
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/src/xma/xma_legacy/include/app/xmabuffers.h
+++ b/src/xma/xma_legacy/include/app/xmabuffers.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018, Xilinx Inc - All rights reserved
- * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2018-2022, Xilinx Inc - All rights reserved
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
  * Xilinx SDAccel Media Accelerator API
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/src/xma/xma_legacy/include/app/xmabuffers.h
+++ b/src/xma/xma_legacy/include/app/xmabuffers.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2018, Xilinx Inc - All rights reserved
+ * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights reserved.
  * Xilinx SDAccel Media Accelerator API
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may


### PR DESCRIPTION
Updated the copyright year and company info from Xilinx to AMD. Tried to match with the existing format used in other files of the same module.
