### PR TITLE
[XDP] Multiple CRs - fixed PLIO verification and refined all_stalls_s2mm metric set

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_control_config_filetype.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_control_config_filetype.cpp
@@ -259,7 +259,7 @@ AIEControlConfigFiletype::getInterfaceTiles(const std::string& graphName,
             continue;
 
         // Make sure stream/channel number is as specified
-        // NOTE: For GMIO we use DMA channel number; for PLIO, we use the SOUTH location
+        // NOTE: For GMIO, we use DMA channel number; for PLIO, we use the SOUTH location
         uint8_t idToCheck = (type == io_type::GMIO) ? channelNum : streamId;
         if ((specifiedId >= 0) && (specifiedId != idToCheck))
             continue;

--- a/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_control_config_filetype.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_control_config_filetype.cpp
@@ -219,9 +219,9 @@ AIEControlConfigFiletype::getInterfaceTiles(const std::string& graphName,
 
     for (auto& io : ios) {
         auto isMaster    = io.second.slaveOrMaster;
-        auto shimCol     = io.second.shimColumn;
         auto streamId    = io.second.streamId;
         auto channelNum  = io.second.channelNum;
+        auto shimCol     = io.second.shimColumn;
         auto logicalName = io.second.logicalName;
         auto name        = io.second.name;
         auto type        = io.second.type;
@@ -260,7 +260,7 @@ AIEControlConfigFiletype::getInterfaceTiles(const std::string& graphName,
 
         // Make sure stream/channel number is as specified
         // NOTE: For GMIO we use DMA channel number; for PLIO, we use the SOUTH location
-        uint8_t idToCheck  = (type == io_type::GMIO) ? channelNum : streamId;
+        uint8_t idToCheck = (type == io_type::GMIO) ? channelNum : streamId;
         if ((specifiedId >= 0) && (specifiedId != idToCheck)) {
             std::string idType = (type == io_type::GMIO) ? "channel" : "stream";
             std::stringstream msg;

--- a/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_control_config_filetype.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_control_config_filetype.cpp
@@ -261,14 +261,8 @@ AIEControlConfigFiletype::getInterfaceTiles(const std::string& graphName,
         // Make sure stream/channel number is as specified
         // NOTE: For GMIO we use DMA channel number; for PLIO, we use the SOUTH location
         uint8_t idToCheck = (type == io_type::GMIO) ? channelNum : streamId;
-        if ((specifiedId >= 0) && (specifiedId != idToCheck)) {
-            std::string idType = (type == io_type::GMIO) ? "channel" : "stream";
-            std::stringstream msg;
-            msg << "Specified " << idType << " ID " << +specifiedId << "doesn't match for "
-                << "interface column " << +shimCol <<" and " << idType << " ID of " << +idToCheck;
-            xrt_core::message::send(severity_level::info, "XRT", msg.str());
+        if ((specifiedId >= 0) && (specifiedId != idToCheck))
             continue;
-        }
 
         tile_type tile = {0};
         tile.col = shimCol;

--- a/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_control_config_filetype.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_control_config_filetype.cpp
@@ -246,7 +246,7 @@ AIEControlConfigFiletype::getInterfaceTiles(const std::string& graphName,
             || (!isMaster && (metricStr.find("input") == std::string::npos)
                 && (metricStr.find("mm2s") == std::string::npos)))
         {
-            // Process this tile for below profile API specific metrics
+            // Catch metric sets that don't follow above naming convention
             if ((metricStr != "packets") &&
                 (metricStr != "interface_tile_latency") &&
                 (metricStr != "start_to_bytes_transferred"))

--- a/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_control_config_filetype.h
+++ b/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_control_config_filetype.h
@@ -68,7 +68,7 @@ class AIEControlConfigFiletype : public xdp::aie::BaseFiletypeImpl {
         getInterfaceTiles(const std::string& graphName,
                           const std::string& portName = "all",
                           const std::string& metricStr = "channels",
-                          int16_t channelId = -1,
+                          int16_t specifiedId = -1,
                           bool useColumn = false, 
                           uint8_t minCol = 0, 
                           uint8_t maxCol = 0) const override;

--- a/src/runtime_src/xdp/profile/database/static_info/filetypes/base_filetype_impl.h
+++ b/src/runtime_src/xdp/profile/database/static_info/filetypes/base_filetype_impl.h
@@ -62,7 +62,7 @@ class BaseFiletypeImpl {
         getInterfaceTiles(const std::string& graphName,
                           const std::string& portName = "all",
                           const std::string& metricStr = "channels",
-                          int16_t channelId = -1,
+                          int16_t specifiedId = -1,
                           bool useColumn = false, 
                           uint8_t minCol = 0, 
                           uint8_t maxCol = 0) const = 0;

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/util/aie_trace_util.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/util/aie_trace_util.cpp
@@ -121,7 +121,7 @@ namespace xdp::aie::trace {
     //   * AIE2+ supports all eight trace events (AIE1 requires one for counter)
     //   * Sets w/ DMA stall/backpressure events not supported on AIE1
     if (hwGen > 1) {
-      eventSets["all_stalls_s2mm"].insert(XAIE_EVENT_CASCADE_STALL_CORE);
+      eventSets["all_stalls_s2mm"].push_back(XAIE_EVENT_CASCADE_STALL_CORE);
 
       eventSets["s2mm_channels_stalls"] =
          {XAIE_EVENT_DMA_S2MM_0_START_TASK_MEM,            XAIE_EVENT_DMA_S2MM_0_FINISHED_BD_MEM,

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/util/aie_trace_util.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/util/aie_trace_util.cpp
@@ -101,6 +101,11 @@ namespace xdp::aie::trace {
          {XAIE_EVENT_INSTR_CALL_CORE,                      XAIE_EVENT_INSTR_RETURN_CORE,
           XAIE_EVENT_PORT_RUNNING_0_CORE,                  XAIE_EVENT_PORT_RUNNING_1_CORE,
           XAIE_EVENT_PORT_RUNNING_2_CORE,                  XAIE_EVENT_PORT_RUNNING_3_CORE}},
+        {"all_stalls_s2mm",
+         {XAIE_EVENT_INSTR_CALL_CORE,                      XAIE_EVENT_INSTR_RETURN_CORE,
+          XAIE_EVENT_MEMORY_STALL_CORE,                    XAIE_EVENT_STREAM_STALL_CORE, 
+          XAIE_EVENT_LOCK_STALL_CORE,                      XAIE_EVENT_PORT_RUNNING_0_CORE,
+          XAIE_EVENT_PORT_RUNNING_1_CORE}},
         {"all_stalls_dma",
          {XAIE_EVENT_INSTR_CALL_CORE,                      XAIE_EVENT_INSTR_RETURN_CORE,
           XAIE_EVENT_GROUP_CORE_STALL_CORE,                XAIE_EVENT_PORT_RUNNING_0_CORE,
@@ -113,19 +118,11 @@ namespace xdp::aie::trace {
     };
 
     // Generation-specific sets
-    //   * AIE1 only supports seven trace events (need one for counter)
-    //   * Sets w/ DMA stall/backpressure events not supported on AIE1 
-    if (hwGen == 1) {
-      eventSets["all_stalls_s2mm"] =
-         {XAIE_EVENT_INSTR_CALL_CORE,                      XAIE_EVENT_INSTR_RETURN_CORE,
-          XAIE_EVENT_GROUP_CORE_STALL_CORE,                XAIE_EVENT_PORT_RUNNING_0_CORE,
-          XAIE_EVENT_PORT_RUNNING_1_CORE};
-    } else {
-      eventSets["all_stalls_s2mm"] =
-         {XAIE_EVENT_INSTR_CALL_CORE,                      XAIE_EVENT_INSTR_RETURN_CORE,
-          XAIE_EVENT_MEMORY_STALL_CORE,                    XAIE_EVENT_STREAM_STALL_CORE, 
-          XAIE_EVENT_CASCADE_STALL_CORE,                   XAIE_EVENT_LOCK_STALL_CORE,
-          XAIE_EVENT_PORT_RUNNING_0_CORE,                  XAIE_EVENT_PORT_RUNNING_1_CORE};
+    //   * AIE2+ supports all eight trace events (AIE1 requires one for counter)
+    //   * Sets w/ DMA stall/backpressure events not supported on AIE1
+    if (hwGen > 1) {
+      eventSets["all_stalls_s2mm"].insert(XAIE_EVENT_CASCADE_STALL_CORE);
+
       eventSets["s2mm_channels_stalls"] =
          {XAIE_EVENT_DMA_S2MM_0_START_TASK_MEM,            XAIE_EVENT_DMA_S2MM_0_FINISHED_BD_MEM,
           XAIE_EVENT_DMA_S2MM_0_FINISHED_TASK_MEM,         XAIE_EVENT_DMA_S2MM_0_STALLED_LOCK_MEM,


### PR DESCRIPTION
#### Problem solved by the commit
* PLIOs were always getting traced, regardless of settings
* The all_stalls_s2mm metric set should use individual stalls

#### How problem was solved, alternative solutions (if any) and why they were rejected
* Verify stream IDs on PLIO match what's specified
* In all_stalls_s2mm set, remove group stalls and only add cascade stalls on AIE2+

#### Risks (if any) associated the changes in the commit
* The all_stalls_s2mm metric set no longer traces cascade stalls on AIE1

#### What has been tested and how, request additional testing if necessary
* Tested on vck190 and vek280

#### Documentation impact (if any)
* Change documentation of all_stalls_s2mm metric set (AIE1 only)