### PR TITLE
Added checks to xrt::version api's to throw exception when information is not available

### DIFF
--- a/build/debian/control
+++ b/build/debian/control
@@ -29,6 +29,7 @@ Build-Depends: cmake,
                pkg-config,
                protobuf-compiler,
                rapidjson-dev,
+               systemtap-sdt-dev,
                uuid-dev,
 Standards-Version: 4.5.0
 

--- a/src/CMake/version.cmake
+++ b/src/CMake/version.cmake
@@ -36,6 +36,11 @@ execute_process(
   OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 
+#Set XRT_HEAD_COMMITS to default value if above command is not executed
+if (NOT XRT_HEAD_COMMITS)
+set (XRT_HEAD_COMMITS -1)
+endif()
+
 # Get number of commits between HEAD and master
 execute_process(
   COMMAND ${GIT_EXECUTABLE} rev-list --count HEAD ^origin/master
@@ -43,6 +48,11 @@ execute_process(
   OUTPUT_VARIABLE XRT_BRANCH_COMMITS
   OUTPUT_STRIP_TRAILING_WHITESPACE
 )
+
+#Set XRT_BRANCH_COMMITS to default value if above command is not executed
+if (NOT XRT_BRANCH_COMMITS)
+set (XRT_BRANCH_COMMITS -1)
+endif()
 
 # Get the latest abbreviated commit hash date of the working branch
 execute_process(


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
In canonical/debian build for embedded platforms, we create achieve file of our source code and remove all .git files (this is standard process and .git files will not be archieved in their flow). xrt_version.cpp file we are returning typed values like uint from #def 's in xrt_version.h file which would be empty in this case because of lack of .git files.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Modified cmake to set the defualt value as 0 and added checks to version api's to throw exception when information is not available.

#### Risks (if any) associated the changes in the commit
low
#### What has been tested and how, request additional testing if necessary
tested with u250 and build_edge_deb flow

#### Documentation impact (if any)
NA