### PR TITLE
graph_object constructor with aieArray instance

### DIFF
--- a/src/runtime_src/core/edge/user/aie/graph_object.cpp
+++ b/src/runtime_src/core/edge/user/aie/graph_object.cpp
@@ -17,10 +17,12 @@ namespace zynqaie {
       auto device{xrt_core::get_userpf_device(m_shim)};
       auto drv = ZYNQ::shim::handleCheck(device->get_device_handle());
 
-      if (!drv->isAieRegistered())
-        throw xrt_core::error(-EINVAL, "No AIE presented");
-
-      aieArray = drv->get_aie_array_shared();
+#ifdef XRT_ENABLE_AIE       
+      if (nullptr != m_hwctx)
+        aieArray = m_hwctx->get_aie_array_shared();
+      else if (drv->isAieRegistered())
+        aieArray = drv->get_aie_array_shared();
+#endif
 
       id = xrt_core::edge::aie::get_graph_id(device.get(), name, m_hwctx);
       if (id == xrt_core::edge::aie::NON_EXIST_ID)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

proper aieArray instance (hwctx / device) will be set

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

N/A

#### How problem was solved, alternative solutions (if any) and why they were rejected

proper aieArray instance (hwctx / device) is set

#### Risks (if any) associated the changes in the commit

N/A

#### What has been tested and how, request additional testing if necessary

graph test cases with device / hwctx

#### Documentation impact (if any)

N/A