### PR TITLE
[XDP] Fix Freq store & fetch from database

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info/aie_util.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info/aie_util.cpp
@@ -133,6 +133,18 @@ namespace xdp::aie {
     return *hwGen;
   }
 
+  // On Edge devices, AIE clock frequency shouldn't change once execution has started.
+  // On Client devices, this static information from metadata may not be correct.
+  double getAIEClockFreqMHz(const boost::property_tree::ptree& aie_meta,
+                            const std::string& root)
+  {
+    static std::optional<double> clockFreqMHz;
+    if (!clockFreqMHz.has_value()) {
+      clockFreqMHz = aie_meta.get_child(root).get_value<double>();
+    }
+    return *clockFreqMHz;
+  }
+
   /****************************************************************************
    * Get metadata required to configure driver
    ***************************************************************************/

--- a/src/runtime_src/xdp/profile/database/static_info/aie_util.h
+++ b/src/runtime_src/xdp/profile/database/static_info/aie_util.h
@@ -53,22 +53,26 @@ namespace xdp::aie {
 
   XDP_CORE_EXPORT
   int getHardwareGeneration(const boost::property_tree::ptree& aie_meta,
-                          const std::string& root);
+                            const std::string& root);
+
+  XDP_CORE_EXPORT
+  double getAIEClockFreqMHz(const boost::property_tree::ptree& aie_meta,
+                            const std::string& root);
 
   XDP_CORE_EXPORT
   xdp::aie::driver_config
   getDriverConfig(const boost::property_tree::ptree& aie_meta,
-                const std::string& root);
+                  const std::string& root);
   
   XDP_CORE_EXPORT
   uint8_t
   getAIETileRowOffset(const boost::property_tree::ptree& aie_meta,
-                    const std::string& location);
+                      const std::string& location);
   
   XDP_CORE_EXPORT
   std::vector<std::string>
   getValidGraphs(const boost::property_tree::ptree& aie_meta,
-                const std::string& root);
+                 const std::string& root);
 
   XDP_CORE_EXPORT
   bool isInfoVerbosity();

--- a/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_control_config_filetype.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_control_config_filetype.cpp
@@ -49,6 +49,12 @@ AIEControlConfigFiletype::getHardwareGeneration() const
     return xdp::aie::getHardwareGeneration(aie_meta, "aie_metadata.driver_config.hw_gen");
 }
 
+double
+AIEControlConfigFiletype::getAIEClockFreqMHz() const
+{
+    return xdp::aie::getAIEClockFreqMHz(aie_meta, "aie_metadata.DeviceData.AIEFrequency");
+}
+
 aiecompiler_options
 AIEControlConfigFiletype::getAIECompilerOptions() const
 {

--- a/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_control_config_filetype.h
+++ b/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_control_config_filetype.h
@@ -35,6 +35,8 @@ class AIEControlConfigFiletype : public xdp::aie::BaseFiletypeImpl {
 
         int getHardwareGeneration() const override;
 
+        double getAIEClockFreqMHz() const override;
+
         aiecompiler_options
         getAIECompilerOptions() const override;
 

--- a/src/runtime_src/xdp/profile/database/static_info/filetypes/base_filetype_impl.h
+++ b/src/runtime_src/xdp/profile/database/static_info/filetypes/base_filetype_impl.h
@@ -36,6 +36,7 @@ class BaseFiletypeImpl {
         getDriverConfig() const = 0;
         
         virtual int getHardwareGeneration() const = 0;
+        virtual double getAIEClockFreqMHz() const = 0;
         
         virtual aiecompiler_options
         getAIECompilerOptions() const = 0;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Currently XRT runtime plugins wasn't storing the frequency from metadata correctly. This resulted in misalignment of timelines in post-processing like system timeline.
Also added try-catch block of device query to fetch xclbins UUIDs.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
[https://github.com/Xilinx/XRT/pull/8006](https://github.com/Xilinx/XRT/pull/8006/files#diff-ab0236d72c813d03912fcb3166ce5474055f569d19978e2a436267820a07db2e)

#### How problem was solved, alternative solutions (if any) and why they were rejected
Method to  set clock-frequency in database is now moved after configInfo creation.

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
Verified on edge that correct frequency is reported in aie profile plugin report.

#### Documentation impact (if any)
