### PR TITLE
VITIS-13441 : Allow shim to read a special flag from xrt.ini for dummy app

### DIFF
--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -712,9 +712,9 @@ get_force_program_xclbin()
 }
 
 inline std::string
-get_dummy_app_context_type()
+get_hardware_context_type()
 {
-  static std::string value = detail::get_string_value("Runtime.dummy_app_context_type", "default");
+  static std::string value = detail::get_string_value("Runtime.hardware_context_type", "default");
   return value;
 }
 

--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -711,6 +711,13 @@ get_force_program_xclbin()
   return value;
 }
 
+inline std::string
+get_dummy_app_context_type()
+{
+  static std::string value = detail::get_string_value("Runtime.dummy_app_context_type", "default");
+  return value;
+}
+
 inline bool
 get_is_enable_prep_target()
 {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/VITIS-13441 : Read "special" flag from xrt.ini for dummy app

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
[Read "special" flag from xrt.ini for dummy app](https://jira.xilinx.com/browse/VITIS-13441)
Special request from HP

#### How problem was solved, alternative solutions (if any) and why they were rejected
Problem was solved by introducing a new parameter in xrt.ini which can be queried by shim

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
**Scenario 1** tested by Programmatically setting ini parameter through xrt::ini API and querying within the host app.
**Scenario 2** tested via the xrt_flow (https://gitenterprise.xilinx.com/XRT/testcases/tree/master/xrt_flow) app by giving a dummy xrt.ini in the directory and printing out the parameter value at run-time :
**Test Scenario 1 (Setting through xrt.ini):**
```
Z:\Repos\XRT-MCDM-FORK\XRT-MCDM\build\WRelease\xilinx\xrt>xrt_flow_test_pause.exe -x Dec23_CE1_CD1_MT1_1x4_c0d7b_opt_config2_w8_c0_dummy.xclbin -w mem_to_core_transfer\dpu_seq -p -s 1
Open ddr init successfully!
Host test code start...
Host test code is creating device object...
Host test code is loading xclbin object...Dec23_CE1_CD1_MT1_1x4_c0d7b_opt_config2_w8_c0_dummy.xclbin
Host test code found kernel: DPU_1x4
Host code is registering xclbin to the device...
Host code is creating hw_context...
**Runtime.dummy_app_context_type value is proxy**
```
xrt.ini:
```
[Debug]
 debug = true
 profile = false
 
[Runtime]
 dummy_app_context_type = proxy
```
**Test Scenario 2 (Setting programmatically through host app):**
Added the set API to df-bw testcase within xrt-smi to test correct setting of 'ini' parameter at run-time
```
xrt::ini::set("Runtime.dummy_app_context_type", "proxy"); 
logger(ptree, " Runtime.dummy_app_context_type", boost::str(boost::format("The value of Runtime.dummy_app_context_type is '%s'") % xrt_core::config::get_dummy_app_context_type()));
```
```
 Runtime.dummy_app_context_type                : The value of Runtime.dummy_app_context_type is 'proxy'
```
#### Documentation impact (if any)
None