### PR TITLE
Making GMIO/External buffers as XRT first class objects

### DIFF
--- a/src/runtime_src/core/common/ishim.h
+++ b/src/runtime_src/core/common/ishim.h
@@ -11,6 +11,7 @@
 #include "core/common/shim/hwctx_handle.h"
 #include "core/include/shim_int.h"
 #include "core/include/xdp/counters.h"
+#include "core/common/shim/aie_buffer_handle.h"
 #include "core/common/shim/graph_handle.h"
 #include "core/common/shim/profile_handle.h"
 
@@ -264,6 +265,11 @@ struct ishim
   virtual bool
   write_aie_reg(uint16_t /*col*/, uint16_t /*row*/, uint32_t /*reg_addr*/, uint32_t /*reg_val*/)
   { throw not_supported_error{__func__}; }
+
+  virtual std::unique_ptr<aie_buffer_handle>
+  open_aie_buffer_handle(const xrt::uuid&, const char*)
+  { throw not_supported_error{__func__}; }
+
 };
 
 template <typename DeviceType>

--- a/src/runtime_src/core/common/shim/aie_buffer_handle.h
+++ b/src/runtime_src/core/common/shim/aie_buffer_handle.h
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+
+#ifndef XRT_CORE_AIE_BUFFER_HANDLE_H
+#define XRT_CORE_AIE_BUFFER_HANDLE_H
+#include <vector>
+#include "xrt.h"
+#include "xrt/xrt_bo.h"
+namespace xrt_core {
+class aie_buffer_handle
+{
+public:
+  virtual ~aie_buffer_handle() {}
+
+  virtual std::string
+  get_name() const
+  {
+    throw xrt_core::error(std::errc::not_supported, __func__);
+  }
+
+  virtual void
+  sync(std::vector<xrt::bo>&, xclBOSyncDirection, size_t, size_t) const
+  {
+    throw xrt_core::error(std::errc::not_supported, __func__);
+  }
+
+};
+
+} // xrt_core
+#endif

--- a/src/runtime_src/core/common/shim/hwctx_handle.h
+++ b/src/runtime_src/core/common/shim/hwctx_handle.h
@@ -5,6 +5,7 @@
 
 #include "core/common/cuidx_type.h"
 #include "core/common/error.h"
+#include "core/common/shim/aie_buffer_handle.h"
 #include "core/common/shim/hwqueue_handle.h"
 #include "core/common/shim/shared_handle.h"
 #include "core/common/shim/graph_handle.h"
@@ -103,6 +104,12 @@ public:
 
   virtual std::unique_ptr<xrt_core::profile_handle>
   open_profile_handle()
+  {
+    throw xrt_core::error(std::errc::not_supported, __func__);
+  }
+
+  virtual std::unique_ptr<xrt_core::aie_buffer_handle>
+  open_aie_buffer_handle(const char*)
   {
     throw xrt_core::error(std::errc::not_supported, __func__);
   }

--- a/src/runtime_src/core/edge/common/aie_parser.cpp
+++ b/src/runtime_src/core/edge/common/aie_parser.cpp
@@ -410,6 +410,7 @@ get_external_buffers(const pt::ptree& aie_meta)
     adf::external_buffer_config buffer_config;
     buffer_config.id = item.second.get<int>("id");
     buffer_config.name = item.second.get<std::string>("name");
+    auto num_bufs = 0;
 
     for (const auto& port : item.second.get_child("shimPortConfigs")) {
       adf::shim_port_config port_config;
@@ -429,9 +430,12 @@ get_external_buffers(const pt::ptree& aie_meta)
         bd_info.offset = bd.second.get<int>("offset");
         bd_info.transaction_size = bd.second.get<int>("transaction_size");
         port_config.shim_bd_infos.push_back(bd_info);
+	num_bufs = std::max(num_bufs, bd_info.buf_idx);
       }
       buffer_config.shim_port_configs.push_back(port_config);
     }
+    // buf_idx starts from 0, we need to add 1 to get number of buffers used
+    buffer_config.num_bufs = num_bufs+1;
     external_buffer_configs[buffer_config.name] = buffer_config;
   }
 

--- a/src/runtime_src/core/edge/common/aie_parser.cpp
+++ b/src/runtime_src/core/edge/common/aie_parser.cpp
@@ -435,7 +435,7 @@ get_external_buffers(const pt::ptree& aie_meta)
       buffer_config.shim_port_configs.push_back(port_config);
     }
     // buf_idx starts from 0, we need to add 1 to get number of buffers used
-    buffer_config.num_bufs = num_bufs+1;
+    buffer_config.num_bufs = num_bufs + 1;
     external_buffer_configs[buffer_config.name] = buffer_config;
   }
 

--- a/src/runtime_src/core/edge/user/aie/aie.h
+++ b/src/runtime_src/core/edge/user/aie/aie.h
@@ -106,16 +106,16 @@ public:
     is_context_set();
 
     void
-    sync_external_buffer(xrt::bo& bo, adf::external_buffer_config& ebuf_config, enum xclBOSyncDirection dir, size_t size, size_t offset);
+    sync_external_buffer(std::vector<xrt::bo>& bo, adf::external_buffer_config& ebuf_config, enum xclBOSyncDirection dir, size_t size, size_t offset);
 
     void
     wait_external_buffer(adf::external_buffer_config& ebuf_config);
 
     void
-    sync_bo(xrt::bo& bo, const char *dmaID, enum xclBOSyncDirection dir, size_t size, size_t offset);
+    sync_bo(std::vector<xrt::bo>& bos, const char *dmaID, enum xclBOSyncDirection dir, size_t size, size_t offset);
 
     void
-    sync_bo_nb(xrt::bo& bo, const char *gmioName, enum xclBOSyncDirection dir, size_t size, size_t offset);
+    sync_bo_nb(std::vector<xrt::bo>& bos, const char *gmioName, enum xclBOSyncDirection dir, size_t size, size_t offset);
 
     void
     wait_gmio(const std::string& gmioName);
@@ -137,6 +137,12 @@ public:
 
     void
     clear_bd(BD& bd);
+
+    bool
+    find_gmio(const std::string & port_name);
+
+    bool
+    find_external_buffer(const std::string & port_name);
 
 private:
     int numCols;

--- a/src/runtime_src/core/edge/user/aie/aie_buffer_object.cpp
+++ b/src/runtime_src/core/edge/user/aie/aie_buffer_object.cpp
@@ -11,7 +11,7 @@ namespace zynqaie {
   aie_buffer_object::aie_buffer_object(xrt_core::device* device ,const xrt::uuid uuid, const char* buffer_name, const zynqaie::hwctx_object* hwctx)
     : name{buffer_name}
   {
-    if (nullptr != hwctx) {
+    if (hwctx) {
       m_aie_array = hwctx->get_aie_array_shared();
     }
     else {

--- a/src/runtime_src/core/edge/user/aie/aie_buffer_object.cpp
+++ b/src/runtime_src/core/edge/user/aie/aie_buffer_object.cpp
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+
+#include <memory>
+
+#include "aie_buffer_object.h"
+#include "core/common/system.h"
+#include "core/edge/user/shim.h"
+
+namespace zynqaie {
+  aie_buffer_object::aie_buffer_object(xrt_core::device* device ,const xrt::uuid uuid, const char* buffer_name, const zynqaie::hwctx_object* hwctx)
+    : name{buffer_name}
+  {
+    if (nullptr != hwctx) {
+      m_aie_array = hwctx->get_aie_array_shared();
+    }
+    else {
+      auto drv = ZYNQ::shim::handleCheck(device->get_device_handle());
+      if (drv->isAieRegistered())
+        m_aie_array = drv->get_aie_array_shared();
+    }
+
+    if (!m_aie_array)
+      throw xrt_core::error(-EINVAL, "Aie Array is not registered" );
+
+    auto found_gmio = m_aie_array->find_gmio(name);
+    auto found_ebuf = m_aie_array->find_external_buffer(name);
+
+    if (!found_gmio && !found_ebuf)
+      throw xrt_core::error(-EINVAL, "GMIO/External buffer is not present with name " + name );
+
+    if (found_gmio && found_ebuf)
+      throw xrt_core::error(-EINVAL, "Ambiguous port name '" + name + "'.Both GMIO and External Buffer exists with this name");
+  }
+
+  std::string
+  aie_buffer_object::get_name() const
+  {
+    return name;
+  }
+
+  void
+  aie_buffer_object::sync(std::vector<xrt::bo>& bos, xclBOSyncDirection dir, size_t size, size_t offset) const
+  {
+    return m_aie_array->sync_bo(bos, name.c_str(), dir, size, offset);
+  }
+}

--- a/src/runtime_src/core/edge/user/aie/aie_buffer_object.h
+++ b/src/runtime_src/core/edge/user/aie/aie_buffer_object.h
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+
+#ifndef _ZYNQ_AIE_BUFFER_OBJECT_H_
+#define _ZYNQ_AIE_BUFFER_OBJECT_H_
+
+#include "core/edge/user/aie/aie.h"
+#include "core/edge/user/aie/common_layer/adf_api_config.h"
+#include "core/common/message.h"
+#include "core/common/shim/shared_handle.h"
+#include "core/common/shim/aie_buffer_handle.h"
+#include "core/include/xrt/xrt_uuid.h"
+#include "xrt/xrt_graph.h"
+
+#include <memory>
+
+namespace zynqaie {
+  // Shim handle for graph object
+  class hwctx_object;
+  class aie_buffer_object: public xrt_core::aie_buffer_handle
+  {
+    std::string name;
+    std::shared_ptr<Aie> m_aie_array;
+
+  public:
+    aie_buffer_object(xrt_core::device* device , const xrt::uuid uuid, const char* name, const zynqaie::hwctx_object* hwctx=nullptr);
+
+    void
+    sync(std::vector<xrt::bo>& bos, xclBOSyncDirection dir, size_t size, size_t offset) const;
+
+    std::string
+    get_name() const;
+
+  }; // aie_buffer_object
+}
+#endif

--- a/src/runtime_src/core/edge/user/aie/common_layer/adf_api_config.h
+++ b/src/runtime_src/core/edge/user/aie/common_layer/adf_api_config.h
@@ -174,6 +174,8 @@ struct external_buffer_config
   std::string name;
   // Ports
   std::vector<shim_port_config> shim_port_configs;
+  // Number of buffers needed
+  int num_bufs;
 
   void print() const {
     std::cout << "External Buffer Config: {" << std::endl;

--- a/src/runtime_src/core/edge/user/aie/common_layer/adf_api_config.h
+++ b/src/runtime_src/core/edge/user/aie/common_layer/adf_api_config.h
@@ -169,13 +169,13 @@ struct shim_port_config {
 struct external_buffer_config
 {
   // External buffer instance ID
-  int id;
+  int id = 0;
   // External buffer name
   std::string name;
   // Ports
   std::vector<shim_port_config> shim_port_configs;
   // Number of buffers needed
-  int num_bufs;
+  int num_bufs = 0;
 
   void print() const {
     std::cout << "External Buffer Config: {" << std::endl;

--- a/src/runtime_src/core/edge/user/aie/common_layer/adf_runtime_api.cpp
+++ b/src/runtime_src/core/edge/user/aie/common_layer/adf_runtime_api.cpp
@@ -879,7 +879,7 @@ err_code dma_api::updateBDAddressLin(XAie_MemInst* memInst , uint8_t column, uin
   XAie_LocType tileLoc = XAie_TileLoc(column, relativeToAbsoluteRow(1, row));
 
   // uncomment below line once latest Petalinux is available
-  driverStatus |= XAie_DmaUpdateBdAddrOff(memInst, tileLoc ,offset, bdId);
+//  driverStatus |= XAie_DmaUpdateBdAddrOff(memInst, tileLoc ,offset, bdId);
 
 
   if (driverStatus != AieRC::XAIE_OK)

--- a/src/runtime_src/core/edge/user/aie/common_layer/adf_runtime_api.cpp
+++ b/src/runtime_src/core/edge/user/aie/common_layer/adf_runtime_api.cpp
@@ -879,7 +879,8 @@ err_code dma_api::updateBDAddressLin(XAie_MemInst* memInst , uint8_t column, uin
   XAie_LocType tileLoc = XAie_TileLoc(column, relativeToAbsoluteRow(1, row));
 
   // uncomment below line once latest Petalinux is available
-  //driverStatus |= XAie_DmaUpdateBdAddrOff(memInst, tileLoc ,offset, bdId);
+  driverStatus |= XAie_DmaUpdateBdAddrOff(memInst, tileLoc ,offset, bdId);
+
 
   if (driverStatus != AieRC::XAIE_OK)
     return errorMsg(err_code::aie_driver_error, "ERROR: adf::dma_api::updateBDAddressLin: AIE driver error.");

--- a/src/runtime_src/core/edge/user/aie/graph.cpp
+++ b/src/runtime_src/core/edge/user/aie/graph.cpp
@@ -77,7 +77,8 @@ xclSyncBOAIE(xclDeviceHandle handle, xrt::bo& bo, const char *gmioName, enum xcl
   if (offset + size > bosize)
     throw xrt_core::error(-EINVAL, "Sync AIE Bo fails: exceed BO boundary.");
 
-  aieArray->sync_bo(bo, gmioName, dir, size, offset);
+  std::vector<xrt::bo> bos {bo};
+  aieArray->sync_bo(bos, gmioName, dir, size, offset);
 }
 
 void
@@ -99,7 +100,8 @@ xclSyncBOAIENB(xclDeviceHandle handle, xrt::bo& bo, const char *gmioName, enum x
   if (offset + size > bosize)
     throw xrt_core::error(-EINVAL, "Sync AIE Bo fails: exceed BO boundary.");
 
-  aieArray->sync_bo_nb(bo, gmioName, dir, size, offset);
+  std::vector<xrt::bo> bos {bo};
+  aieArray->sync_bo_nb(bos, gmioName, dir, size, offset);
 }
 
 void

--- a/src/runtime_src/core/edge/user/device_linux.cpp
+++ b/src/runtime_src/core/edge/user/device_linux.cpp
@@ -12,6 +12,7 @@
 #include "shim.h"
 #ifdef XRT_ENABLE_AIE
 #include "core/edge/user/aie/graph_object.h"
+#include "core/edge/user/aie/aie_buffer_object.h"
 #endif
 #include "core/edge/user/aie/profile_object.h"
 #include <map>
@@ -1161,6 +1162,17 @@ open_profile_handle()
 #else
    throw xrt_core::error(std::errc::not_supported, __func__);
 #endif   
+}
+
+std::unique_ptr<xrt_core::aie_buffer_handle>
+device_linux::
+open_aie_buffer_handle(const xrt::uuid& xclbin_id, const char* name)
+{
+#ifdef XRT_ENABLE_AIE
+  return std::make_unique<zynqaie::aie_buffer_object>(this,xclbin_id,name);
+#else
+  throw xrt_core::error(std::errc::not_supported, __func__);;
+#endif
 }
 
 std::unique_ptr<buffer_handle>

--- a/src/runtime_src/core/edge/user/device_linux.h
+++ b/src/runtime_src/core/edge/user/device_linux.h
@@ -6,6 +6,7 @@
 
 #include "xrt.h"
 #include "core/common/ishim.h"
+#include "core/common/shim/aie_buffer_handle.h"
 #include "core/common/shim/buffer_handle.h"
 #include "core/common/shim/hwctx_handle.h"
 #include "core/common/shim/shared_handle.h"
@@ -42,6 +43,9 @@ public:
 
   std::unique_ptr<xrt_core::profile_handle>
   open_profile_handle() override;
+
+  std::unique_ptr<xrt_core::aie_buffer_handle>
+  open_aie_buffer_handle(const xrt::uuid& xclbin_id, const char* name) override;
 
   void
   get_device_info(xclDeviceInfo2 *info) override;

--- a/src/runtime_src/core/edge/user/hwctx_object.cpp
+++ b/src/runtime_src/core/edge/user/hwctx_object.cpp
@@ -4,6 +4,7 @@
 #include "core/edge/user/aie/profile_object.h"
 #ifdef XRT_ENABLE_AIE
 #include "core/edge/user/aie/graph_object.h"
+#include "core/edge/user/aie/aie_buffer_object.h"
 #include "core/edge/user/aie/aie.h"
 #endif
 #include "core/edge/user/shim.h"
@@ -30,7 +31,7 @@ namespace zynqaie {
 
 #ifdef XRT_ENABLE_AIE
   std::shared_ptr<Aie>
-  hwctx_object::get_aie_array_shared()
+  hwctx_object::get_aie_array_shared() const
   {
     return m_aie_array;
   }
@@ -93,6 +94,17 @@ namespace zynqaie {
   {
 #ifdef XRT_ENABLE_AIE    
     return std::make_unique<profile_object>(m_shim, m_aie_array);
+#else
+    throw xrt_core::error(std::errc::not_supported, __func__);
+#endif
+  }
+
+  std::unique_ptr<xrt_core::aie_buffer_handle>
+  hwctx_object::open_aie_buffer_handle(const char* name)
+  {
+#ifdef XRT_ENABLE_AIE
+    auto device{xrt_core::get_userpf_device(m_shim)};
+    return std::make_unique<aie_buffer_object>(device.get(),m_uuid,name,this);
 #else
     throw xrt_core::error(std::errc::not_supported, __func__);
 #endif

--- a/src/runtime_src/core/edge/user/hwctx_object.h
+++ b/src/runtime_src/core/edge/user/hwctx_object.h
@@ -84,9 +84,12 @@ namespace zynqaie {
     std::unique_ptr<xrt_core::profile_handle>
     open_profile_handle() override;
 
+    std::unique_ptr<xrt_core::aie_buffer_handle>
+    open_aie_buffer_handle(const char* name) override;
+
 #ifdef XRT_ENABLE_AIE
     std::shared_ptr<Aie>
-    get_aie_array_shared();
+    get_aie_array_shared() const;
 #endif
 
   }; // class hwctx_object

--- a/src/runtime_src/core/edge/user/shim.h
+++ b/src/runtime_src/core/edge/user/shim.h
@@ -192,7 +192,8 @@ public:
       if (offset + size > bosize)
         throw xrt_core::error(-EINVAL, "Sync AIE BO fails: exceed BO boundary.");
 
-      m_aie_array->sync_bo(bo, gmioName, dir, size, offset);
+      std::vector<xrt::bo> bos {bo};
+      m_aie_array->sync_bo(bos, gmioName, dir, size, offset);
 #endif      
     }
 
@@ -210,7 +211,8 @@ public:
       if (offset + size > bosize)
         throw xrt_core::error(-EINVAL, "Sync AIE NBO fails: exceed BO boundary.");
 
-      m_aie_array->sync_bo_nb(bo, gmioName, dir, size, offset);
+      std::vector<xrt::bo> bos {bo};
+      m_aie_array->sync_bo_nb(bos, gmioName, dir, size, offset);
 #endif      
     }
 

--- a/src/runtime_src/core/include/xrt/xrt_aie.h
+++ b/src/runtime_src/core/include/xrt/xrt_aie.h
@@ -338,6 +338,98 @@ public:
   stop() const;
 };
 
+/*!
+ * @class buffer
+ *
+ * @brief
+ * xrt::aie::buffer represents AIE constructs like GMIO/External Buffers
+ *
+ * @details
+ * GMIO/External Buffers are constructs used in AI Engine( AIE) Programming
+ * They create connections between the AI Engine and the external memory.
+ * It allows data to be transferred between AIE and global memory which is
+ * essential for handling large datasets that cannot fit into local memory
+ * of the AIE tiles.
+ * GMIOs can attach to single buffer whereas External buffers can be
+ * attached to ping/pong buffers to achieve parallelism
+ */
+class buffer_impl;
+class buffer : public detail::pimpl<buffer_impl>
+{
+public:
+
+  /**
+   * buffer() - Constructor for empty buffer
+   */
+  buffer() = default;
+
+  /**
+   * buffer() - Constructor from device , xclbin UUID and name of the buffer
+   *
+   * @param device
+   *  Device on which the buffer should create
+   * @param uuid
+   *  UUID of the xclbin that should be used
+   * @param name
+   *  Name of the buffer which represents GMIO/External Buffer
+   *
+   * This constructor initializes a buffer object with the specified device, xclbin UUID, and string identifier. This throws an exception if no GMIO/External buffer exists with given name
+   */
+  explicit buffer(const xrt::device& device, const xrt::uuid& uuid, const std::string& name);
+
+  /**
+   * buffer() - Constructor from hardware context and name of the buffer
+   *
+   * @param hw_context
+   *  The xrt::hw_context object associated with the buffer
+   * @param name
+   *  A string identifier for the buffer
+   *
+   * This constructor initializes a buffer object with the specified hardware context
+   * and string identifier. This throws an exception if no GMIO/External buffer exists with given name
+   */
+  explicit buffer(const xrt::hw_context& hw_context, const std::string& name);
+
+  /**
+   * sync() - Synchronize buffer with a single xrt::bo object
+   *
+   * @param bo
+   *  The xrt::bo object to synchronize
+   * @param dir
+   *  The direction of synchronization (e.g., host to device or device to host)
+   * @param size
+   *  The size of the data to synchronize
+   * @param offset
+   *  The offset within the buffer to start synchronization
+   *
+   * This function synchronizes the buffer with the specified xrt::bo object.
+   * This configures the required BDs , enqueues the task and wait for
+   * completion
+   */
+  void sync(const xrt::bo& bo, xclBOSyncDirection dir, size_t size, size_t offset) const;
+
+  /**
+   * sync() - Synchronize buffer with two xrt::bo objects (ping-pong)
+   *
+   * @param ping
+   *  The first xrt::bo object to synchronize (ping)
+   * @param pong
+   *  The second xrt::bo object to synchronize (pong)
+   * @param dir
+   *  The direction of synchronization (e.g., host to device or device to host)
+   * @param size
+   *  The size of the data to synchronize
+   * @param offset
+   *  The offset within the buffer to start synchronization
+   *
+   * This function synchronizes the buffer with the specified xrt::bo objects in a ping-pong manner.
+   * This configures the required BDs , enqueues the task and wait for
+   * completion
+   */
+  void sync(const xrt::bo& ping, const xrt::bo& pong, xclBOSyncDirection dir, size_t size, size_t offset) const;
+
+};
+
 }} // aie, xrt
 
 /**

--- a/src/runtime_src/core/include/xrt/xrt_aie.h
+++ b/src/runtime_src/core/include/xrt/xrt_aie.h
@@ -375,7 +375,7 @@ public:
    *
    * This constructor initializes a buffer object with the specified device, xclbin UUID, and string identifier. This throws an exception if no GMIO/External buffer exists with given name
    */
-  explicit buffer(const xrt::device& device, const xrt::uuid& uuid, const std::string& name);
+  buffer(const xrt::device& device, const xrt::uuid& uuid, const std::string& name);
 
   /**
    * buffer() - Constructor from hardware context and name of the buffer
@@ -388,7 +388,7 @@ public:
    * This constructor initializes a buffer object with the specified hardware context
    * and string identifier. This throws an exception if no GMIO/External buffer exists with given name
    */
-  explicit buffer(const xrt::hw_context& hw_context, const std::string& name);
+  buffer(const xrt::hw_context& hw_context, const std::string& name);
 
   /**
    * sync() - Synchronize buffer with a single xrt::bo object


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Making GMIO/External buffers as XRT first class objects. Existing interface is not scalable.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
External buffers can use more than one xrt::bo's for ping/pong usecase. Existing interface cannot be extended

#### How problem was solved, alternative solutions (if any) and why they were rejected
Created a new xrt::aie::buffer class for GMIO/External buffers

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Verified GMIO/External buffer tests

#### Documentation impact (if any)
Yes, Need to update the documentation about these new classes.