### PR TITLE
Cherry-pick commits from master to support build edge deb flow in 2024.1

### DIFF
--- a/build/debian/control
+++ b/build/debian/control
@@ -29,6 +29,7 @@ Build-Depends: cmake,
                pkg-config,
                protobuf-compiler,
                rapidjson-dev,
+               systemtap-sdt-dev,
                uuid-dev,
 Standards-Version: 4.5.0
 

--- a/src/CMake/version.cmake
+++ b/src/CMake/version.cmake
@@ -36,6 +36,11 @@ execute_process(
   OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 
+#Set XRT_HEAD_COMMITS to default value if above command is not executed
+if (NOT XRT_HEAD_COMMITS)
+set (XRT_HEAD_COMMITS -1)
+endif()
+
 # Get number of commits between HEAD and master
 execute_process(
   COMMAND ${GIT_EXECUTABLE} rev-list --count HEAD ^origin/master
@@ -43,6 +48,11 @@ execute_process(
   OUTPUT_VARIABLE XRT_BRANCH_COMMITS
   OUTPUT_STRIP_TRAILING_WHITESPACE
 )
+
+#Set XRT_BRANCH_COMMITS to default value if above command is not executed
+if (NOT XRT_BRANCH_COMMITS)
+set (XRT_BRANCH_COMMITS -1)
+endif()
 
 # Get the latest abbreviated commit hash date of the working branch
 execute_process(

--- a/src/runtime_src/core/edge/drm/zocl/common/zocl_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/common/zocl_xclbin.c
@@ -305,7 +305,7 @@ zocl_update_apertures(struct drm_zocl_dev *zdev, struct drm_zocl_slot *slot)
 	int i = 0;
         char kname[64] = {0};
         char *kname_p = NULL;
-      	struct kernel_info *krnl_info = NULL;
+        struct kernel_info *krnl_info = NULL;
 
 	/* Update aperture should only happen when loading xclbin */
 	if (slot->ip)
@@ -339,7 +339,7 @@ zocl_update_apertures(struct drm_zocl_dev *zdev, struct drm_zocl_slot *slot)
 			apt = &zdev->cu_subdev.apertures[apt_idx];
 
 			apt->addr = ip->m_base_address;
-                        
+
                         strncpy(kname, ip->m_name, sizeof(kname));
 		        kname[sizeof(kname)-1] = '\0';
 		        kname_p = &kname[0];

--- a/src/runtime_src/core/edge/user/aie/common_layer/adf_api_config.h
+++ b/src/runtime_src/core/edge/user/aie/common_layer/adf_api_config.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/src/runtime_src/core/edge/user/zynq_dev.h
+++ b/src/runtime_src/core/edge/user/zynq_dev.h
@@ -17,6 +17,7 @@
 #ifndef _XCL_ZYNQ_DEV_H_
 #define _XCL_ZYNQ_DEV_H_
 
+#include <cstdint>
 #include <fstream>
 #include <string>
 #include <vector>


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Cherry-picked the changes required to build the xrt, zocl debain packages in build_edge_deb flow.

Please refer to [PR-8430](https://github.com/Xilinx/XRT/pull/8430) and [PR-8224](https://github.com/Xilinx/XRT/pull/8224)