### PR TITLE
VITIS-12882 Add limits for benchmarks to specify pass criteria

### DIFF
--- a/src/runtime_src/core/tools/common/TestRunner.cpp
+++ b/src/runtime_src/core/tools/common/TestRunner.cpp
@@ -450,7 +450,6 @@ TestRunner::findPlatformFile(const std::string& file_path,
   }
   catch (const std::exception&) {
     logger(ptTest, "Details", boost::str(boost::format("%s not available") % file_path));
-    logger(ptTest, "Details", "The test is not supported on this device.");
     ptTest.put("status", test_token_skipped);
     return "";
   }
@@ -532,7 +531,7 @@ TestRunner::find_threshold(const std::shared_ptr<xrt_core::device>& dev,
                             % xq::pcie_id::device_to_string(pcie_id) % xq::pcie_id::revision_to_string(pcie_id));
   auto json_config = findPlatformFile(benchmark_fname, ptTest);
   if (!std::filesystem::exists(json_config)) {
-    logger(ptTest, "Warning", "%s was not found. The results are not compared to expected numbers.");
+    logger(ptTest, "Warning", "The results are not compared to expected numbers.");
     return 0.0;
   }
 

--- a/src/runtime_src/core/tools/common/TestRunner.cpp
+++ b/src/runtime_src/core/tools/common/TestRunner.cpp
@@ -503,7 +503,7 @@ TestRunner::get_test_header()
 void 
 TestRunner::result_in_range(double value, double threshold, boost::property_tree::ptree& ptTest)
 {
-  if (((((0.95*threshold) <= value) && (value <=(1.05*threshold))) || threshold == 0.0)) {
+  if (((((0.90*threshold) <= value) && (value <=(1.10*threshold))) || threshold == 0.0)) {
     ptTest.put("status", test_token_passed);
   }
   else {

--- a/src/runtime_src/core/tools/common/TestRunner.cpp
+++ b/src/runtime_src/core/tools/common/TestRunner.cpp
@@ -521,8 +521,8 @@ TestRunner::result_in_range(double value, double threshold, boost::property_tree
  * Case 3: json and the corresponding pmode is found - testcase will compare the
  *         result against the json value
  */
-double 
-TestRunner::find_threshold(const std::shared_ptr<xrt_core::device>& dev, 
+void 
+TestRunner::set_threshold(const std::shared_ptr<xrt_core::device>& dev, 
                            boost::property_tree::ptree& ptTest)
 {
   //find the benchmark.json
@@ -532,7 +532,8 @@ TestRunner::find_threshold(const std::shared_ptr<xrt_core::device>& dev,
   auto json_config = findPlatformFile(benchmark_fname, ptTest);
   if (!std::filesystem::exists(json_config)) {
     logger(ptTest, "Warning", "The results are not compared to expected numbers.");
-    return 0.0;
+    m_threshold = 0.0;
+    return;
   }
 
   logger(ptTest, "Benchmarks", json_config);
@@ -554,7 +555,8 @@ TestRunner::find_threshold(const std::shared_ptr<xrt_core::device>& dev,
     for (const auto& kb : benchmarks) {
       const boost::property_tree::ptree& pt_benchmark = kb.second;
       if(boost::iequals(curr_pmode, pt_benchmark.get<std::string>("pmode"))) {
-        return pt_benchmark.get<double>("threshold");
+        m_threshold = pt_benchmark.get<double>("threshold");
+        return;
       }
     }
   }

--- a/src/runtime_src/core/tools/common/TestRunner.cpp
+++ b/src/runtime_src/core/tools/common/TestRunner.cpp
@@ -503,7 +503,8 @@ TestRunner::get_test_header()
 void 
 TestRunner::result_in_range(double value, double threshold, boost::property_tree::ptree& ptTest)
 {
-  if (((((0.90*threshold) <= value) && (value <=(1.10*threshold))) || threshold == 0.0)) {
+  //have a 40% tolerance until we can nail down consistent numbers
+  if (((((0.60*threshold) <= value) && (value <=(1.40*threshold))) || threshold == 0.0)) {
     ptTest.put("status", test_token_passed);
   }
   else {

--- a/src/runtime_src/core/tools/common/TestRunner.cpp
+++ b/src/runtime_src/core/tools/common/TestRunner.cpp
@@ -11,6 +11,7 @@
 #include "tools/common/XBUtilities.h"
 #include "tools/common/XBUtilitiesCore.h"
 namespace XBU = XBUtilities;
+namespace xq = xrt_core::query;
 
 // 3rd Party Library - Include Files
 #include <boost/format.hpp>
@@ -60,7 +61,7 @@ getXsaPath(const uint16_t vendor)
 static void
 program_xclbin(const std::shared_ptr<xrt_core::device>& device, const std::string& xclbin)
 {
-  auto bdf = xrt_core::query::pcie_bdf::to_string(xrt_core::device_query<xrt_core::query::pcie_bdf>(device));
+  auto bdf = xq::pcie_bdf::to_string(xrt_core::device_query<xq::pcie_bdf>(device));
   auto xclbin_obj = xrt::xclbin{xclbin};
   try {
     device->load_xclbin(xclbin_obj);
@@ -270,7 +271,7 @@ TestRunner::runPyTestCase( const std::shared_ptr<xrt_core::device>& _dev, const 
   // 0RP (nonDFX) flat shell support.
   // Currently, there isn't a clean way to determine if a nonDFX shell's interface is truly flat.
   // At this time, this is determined by whether or not it delivers an accelerator (e.g., verify.xclbin)
-  const auto logic_uuid = xrt_core::device_query_default<xrt_core::query::logic_uuids>(_dev, {});
+  const auto logic_uuid = xrt_core::device_query_default<xq::logic_uuids>(_dev, {});
   if (!logic_uuid.empty() && !std::filesystem::exists(xclbin_path)) {
     logger(_ptTest, "Details", "Verify xclbin not available or shell partition is not programmed. Skipping validation.");
     _ptTest.put("status", test_token_skipped);
@@ -309,7 +310,7 @@ TestRunner::runPyTestCase( const std::shared_ptr<xrt_core::device>& _dev, const 
   logger(_ptTest, "Testcase", xrtTestCasePath);
 
   std::vector<std::string> args = { "-k", xclbin_path.string(),
-                                    "-d", xrt_core::query::pcie_bdf::to_string(xrt_core::device_query<xrt_core::query::pcie_bdf>(_dev)) };
+                                    "-d", xq::pcie_bdf::to_string(xrt_core::device_query<xq::pcie_bdf>(_dev)) };
   int exit_code;
   try {
     exit_code = XBU::runScript("python", xrtTestCasePath, args, os_stdout, os_stderr);
@@ -403,7 +404,7 @@ bool
 TestRunner::search_and_program_xclbin(const std::shared_ptr<xrt_core::device>& dev, boost::property_tree::ptree& ptTest)
 {
   xuid_t uuid;
-  uuid_parse(xrt_core::device_query<xrt_core::query::xclbin_uuid>(dev).c_str(), uuid);
+  uuid_parse(xrt_core::device_query<xq::xclbin_uuid>(dev).c_str(), uuid);
 
   const std::string xclbin_path = findXclbinPath(dev, ptTest);
 
@@ -430,12 +431,12 @@ std::string
 TestRunner::findPlatformPath(const std::shared_ptr<xrt_core::device>& dev,
                              boost::property_tree::ptree& ptTest)
 {
-  const auto logic_uuid = xrt_core::device_query_default<xrt_core::query::logic_uuids>(dev, {});
+  const auto logic_uuid = xrt_core::device_query_default<xq::logic_uuids>(dev, {});
   if (!logic_uuid.empty())
     return searchSSV2Xclbin(logic_uuid.front(), ptTest);
   else {
-    auto vendor = xrt_core::device_query<xrt_core::query::pcie_vendor>(dev);
-    auto name = xrt_core::device_query<xrt_core::query::rom_vbnv>(dev);
+    auto vendor = xrt_core::device_query<xq::pcie_vendor>(dev);
+    auto name = xrt_core::device_query<xq::rom_vbnv>(dev);
     return searchLegacyXclbin(vendor, name, ptTest);
   }
 }
@@ -498,4 +499,65 @@ TestRunner::get_test_header()
     ptree.put("xclbin", m_xclbin);
     ptree.put("explicit", m_explicit);
     return ptree;
+}
+
+void 
+TestRunner::result_in_range(double value, double threshold, boost::property_tree::ptree& ptTest)
+{
+  if (((((0.95*threshold) <= value) && (value <=(1.05*threshold))) || threshold == 0.0)) {
+    ptTest.put("status", test_token_passed);
+  }
+  else {
+    logger(ptTest, "Error", boost::str(boost::format("Benchmark value is not ~%.1f which is the expected value") % threshold));
+    ptTest.put("status", test_token_failed);
+  }
+}
+
+/*
+ * This function finds the benchmark_devid_revid.json file in the driverstore and 
+ * iterates through it to find the golden threshold value for a given test.
+ * Case 1: json is not found - the testcase will show a warning and pass the test
+ * Case 2: json is found, but the corresponding pmode is not - testcase will throw
+ *         an exception
+ * Case 3: json and the corresponding pmode is found - testcase will compare the
+ *         result against the json value
+ */
+double 
+TestRunner::find_threshold(const std::shared_ptr<xrt_core::device>& dev, 
+                           boost::property_tree::ptree& ptTest)
+{
+  //find the benchmark.json
+  const auto pcie_id = xrt_core::device_query<xq::pcie_id>(dev);
+  auto benchmark_fname = boost::str(boost::format("benchmark_%s_%s.json") 
+                            % xq::pcie_id::device_to_string(pcie_id) % xq::pcie_id::revision_to_string(pcie_id));
+  auto json_config = findPlatformFile(benchmark_fname, ptTest);
+  if (!std::filesystem::exists(json_config)) {
+    logger(ptTest, "Warning", "%s was not found. The results are not compared to expected numbers.");
+    return 0.0;
+  }
+
+  logger(ptTest, "Benchmarks", json_config);
+
+  //open file
+  boost::property_tree::ptree validate_json;
+  boost::property_tree::read_json(json_config, validate_json);
+
+  //find curr pmode
+  const auto curr_pmode = xq::performance_mode::parse_status(xrt_core::device_query<xq::performance_mode>(dev));
+
+  //iterate tests array to find test_name
+  const boost::property_tree::ptree& tests = validate_json.get_child("tests");
+  for (const auto& kt : tests) {
+    const boost::property_tree::ptree& pt_test = kt.second;
+    if(!boost::iequals(pt_test.get<std::string>("test_name"), ptTest.get<std::string>("name")))
+      continue;
+    const boost::property_tree::ptree& benchmarks = pt_test.get_child("benchmarks");
+    for (const auto& kb : benchmarks) {
+      const boost::property_tree::ptree& pt_benchmark = kb.second;
+      if(boost::iequals(curr_pmode, pt_benchmark.get<std::string>("pmode"))) {
+        return pt_benchmark.get<double>("threshold");
+      }
+    }
+  }
+  throw std::runtime_error(boost::str(boost::format("Test is not supported for %s mode") % curr_pmode));
 }

--- a/src/runtime_src/core/tools/common/TestRunner.h
+++ b/src/runtime_src/core/tools/common/TestRunner.h
@@ -49,7 +49,8 @@ class TestRunner : public JSONConfigurable {
     void init_instr_buf(xrt::bo &bo_instr, const std::string& dpu_file);
     size_t get_instr_size(const std::string& dpu_file);
     void result_in_range(double value, double threshold, boost::property_tree::ptree& ptTest);
-    double find_threshold(const std::shared_ptr<xrt_core::device>& dev, boost::property_tree::ptree& ptTest);
+    void set_threshold(const std::shared_ptr<xrt_core::device>& dev, boost::property_tree::ptree& ptTest);
+    double get_threshold(){return m_threshold;};
 
     const std::string test_token_skipped = "SKIPPED";
     const std::string test_token_failed = "FAILED";
@@ -68,6 +69,7 @@ class TestRunner : public JSONConfigurable {
     std::string m_name;
     std::string m_description;
     bool m_explicit;
+    double m_threshold;
 
 };
   

--- a/src/runtime_src/core/tools/common/TestRunner.h
+++ b/src/runtime_src/core/tools/common/TestRunner.h
@@ -48,6 +48,8 @@ class TestRunner : public JSONConfigurable {
     int validate_binary_file(const std::string& binaryfile);
     void init_instr_buf(xrt::bo &bo_instr, const std::string& dpu_file);
     size_t get_instr_size(const std::string& dpu_file);
+    void result_in_range(double value, double threshold, boost::property_tree::ptree& ptTest);
+    double find_threshold(const std::shared_ptr<xrt_core::device>& dev, boost::property_tree::ptree& ptTest);
 
     const std::string test_token_skipped = "SKIPPED";
     const std::string test_token_failed = "FAILED";

--- a/src/runtime_src/core/tools/common/tests/TestAIEReconfigOverhead.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestAIEReconfigOverhead.cpp
@@ -30,6 +30,18 @@ TestAIEReconfigOverhead::run(std::shared_ptr<xrt_core::device> dev)
   boost::property_tree::ptree ptree = get_test_header();
   ptree.erase("xclbin");
 
+  double m_threshold = 0.0;
+  try {
+    m_threshold = find_threshold(dev, ptree);
+    if(XBUtilities::getVerbose())
+      logger(ptree, "Deatils", boost::str(boost::format("Threshold is %.1f ms") % m_threshold));
+  }
+  catch (const std::runtime_error& ex) {
+    logger(ptree, "Details", ex.what());
+    ptree.put("status", test_token_skipped);
+    return ptree;
+  }
+
   const auto xclbin_name = xrt_core::device_query<xrt_core::query::xclbin_name>(dev, xrt_core::query::xclbin_name::type::validate);
   auto xclbin_path = findPlatformFile(xclbin_name, ptree);
   if (!std::filesystem::exists(xclbin_path))
@@ -127,8 +139,8 @@ TestAIEReconfigOverhead::run(std::shared_ptr<xrt_core::device> dev)
 
   //Log
   if(XBUtilities::getVerbose()) { 
-    logger(ptree, "Details", boost::str(boost::format("Buffer size: '%f'MB") % buffer_size_mb));
-    logger(ptree, "Details", boost::str(boost::format("No. of iterations: '%f'") % itr_count));
+    logger(ptree, "Details", boost::str(boost::format("Buffer size: %f MB") % buffer_size_mb));
+    logger(ptree, "Details", boost::str(boost::format("No. of iterations: %f") % itr_count));
   }
 
   auto start = std::chrono::high_resolution_clock::now();
@@ -172,11 +184,12 @@ TestAIEReconfigOverhead::run(std::shared_ptr<xrt_core::device> dev)
   }
 
   end = std::chrono::high_resolution_clock::now();
-  float elapsedSecsAverage = std::chrono::duration_cast<std::chrono::duration<float>>(end-start).count();
+  auto elapsedSecsAverage = std::chrono::duration_cast<std::chrono::duration<double>>(end-start).count();
   elapsedSecsAverage /= itr_count;
-  float overhead = elapsedSecsAverage - elapsedSecsNoOpAverage; 
-  logger(ptree, "Details", boost::str(boost::format("Array reconfiguration overhead: '%.1f'ms") % (overhead * 1000)));
+  double overhead = (elapsedSecsAverage - elapsedSecsNoOpAverage)*1000; //in ms
 
-  ptree.put("status", test_token_passed);
+  //check if the value is in range
+  result_in_range(overhead, m_threshold, ptree);
+  logger(ptree, "Details", boost::str(boost::format("Array reconfiguration overhead: %.1f ms") % overhead));
   return ptree;
 }

--- a/src/runtime_src/core/tools/common/tests/TestAIEReconfigOverhead.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestAIEReconfigOverhead.cpp
@@ -30,11 +30,10 @@ TestAIEReconfigOverhead::run(std::shared_ptr<xrt_core::device> dev)
   boost::property_tree::ptree ptree = get_test_header();
   ptree.erase("xclbin");
 
-  double m_threshold = 0.0;
   try {
-    m_threshold = find_threshold(dev, ptree);
+    set_threshold(dev, ptree);
     if(XBUtilities::getVerbose())
-      logger(ptree, "Deatils", boost::str(boost::format("Threshold is %.1f ms") % m_threshold));
+      logger(ptree, "Deatils", boost::str(boost::format("Threshold is %.1f ms") % get_threshold()));
   }
   catch (const std::runtime_error& ex) {
     logger(ptree, "Details", ex.what());
@@ -191,7 +190,7 @@ TestAIEReconfigOverhead::run(std::shared_ptr<xrt_core::device> dev)
   double overhead = (elapsedSecsAverage - elapsedSecsNoOpAverage)*1000; //in ms
 
   //check if the value is in range
-  result_in_range(overhead, m_threshold, ptree);
+  result_in_range(overhead, get_threshold(), ptree);
   logger(ptree, "Details", boost::str(boost::format("Array reconfiguration overhead: %.1f ms") % overhead));
   return ptree;
 }

--- a/src/runtime_src/core/tools/common/tests/TestAIEReconfigOverhead.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestAIEReconfigOverhead.cpp
@@ -44,8 +44,10 @@ TestAIEReconfigOverhead::run(std::shared_ptr<xrt_core::device> dev)
 
   const auto xclbin_name = xrt_core::device_query<xrt_core::query::xclbin_name>(dev, xrt_core::query::xclbin_name::type::validate);
   auto xclbin_path = findPlatformFile(xclbin_name, ptree);
-  if (!std::filesystem::exists(xclbin_path))
+  if (!std::filesystem::exists(xclbin_path)){
+    logger(ptree, "Details", "The test is not supported on this device.");
     return ptree;
+  }
 
   logger(ptree, "Xclbin", xclbin_path);
 

--- a/src/runtime_src/core/tools/common/tests/TestAIEReconfigOverhead.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestAIEReconfigOverhead.cpp
@@ -33,7 +33,7 @@ TestAIEReconfigOverhead::run(std::shared_ptr<xrt_core::device> dev)
   try {
     set_threshold(dev, ptree);
     if(XBUtilities::getVerbose())
-      logger(ptree, "Deatils", boost::str(boost::format("Threshold is %.1f ms") % get_threshold()));
+      logger(ptree, "Details", boost::str(boost::format("Threshold is %.1f ms") % get_threshold()));
   }
   catch (const std::runtime_error& ex) {
     logger(ptree, "Details", ex.what());

--- a/src/runtime_src/core/tools/common/tests/TestCmdChainLatency.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestCmdChainLatency.cpp
@@ -32,7 +32,7 @@ TestCmdChainLatency::run(std::shared_ptr<xrt_core::device> dev)
   try {
     set_threshold(dev, ptree);
     if(XBU::getVerbose())
-      logger(ptree, "Deatils", boost::str(boost::format("Threshold is %.1f us") % get_threshold()));
+      logger(ptree, "Details", boost::str(boost::format("Threshold is %.1f us") % get_threshold()));
   }
   catch (const std::runtime_error& ex) {
     logger(ptree, "Details", ex.what());

--- a/src/runtime_src/core/tools/common/tests/TestCmdChainLatency.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestCmdChainLatency.cpp
@@ -29,6 +29,18 @@ TestCmdChainLatency::run(std::shared_ptr<xrt_core::device> dev)
   boost::property_tree::ptree ptree = get_test_header();
   ptree.erase("xclbin");
 
+  double m_threshold = 0.0;
+  try {
+    m_threshold = find_threshold(dev, ptree);
+    if(XBU::getVerbose())
+      logger(ptree, "Deatils", boost::str(boost::format("Threshold is %.1f us") % m_threshold));
+  }
+  catch (const std::runtime_error& ex) {
+    logger(ptree, "Details", ex.what());
+    ptree.put("status", test_token_skipped);
+    return ptree;
+  }
+
   const auto xclbin_name = xrt_core::device_query<xrt_core::query::xclbin_name>(dev, xrt_core::query::xclbin_name::type::validate);
   auto xclbin_path = findPlatformFile(xclbin_name, ptree);
   if (!std::filesystem::exists(xclbin_path))
@@ -125,8 +137,8 @@ TestCmdChainLatency::run(std::shared_ptr<xrt_core::device> dev)
 
   //Log
   if(XBU::getVerbose()) {
-    logger(ptree, "Details", boost::str(boost::format("Instruction size: '%f' bytes") % buffer_size));
-    logger(ptree, "Details", boost::str(boost::format("No. of commands: '%f'") % (itr_count*run_count)));
+    logger(ptree, "Details", boost::str(boost::format("Instruction size: %f bytes") % buffer_size));
+    logger(ptree, "Details", boost::str(boost::format("No. of commands: %f") % (itr_count*run_count)));
   }
 
   // Start via runlist
@@ -153,11 +165,13 @@ TestCmdChainLatency::run(std::shared_ptr<xrt_core::device> dev)
     }
   }
   auto end = std::chrono::high_resolution_clock::now();
-  auto elapsedSecs = std::chrono::duration_cast<std::chrono::duration<float>>(end-start).count();
+  auto elapsedSecs = std::chrono::duration_cast<std::chrono::duration<double>>(end-start).count();
 
   // Calculate end-to-end latency of one job execution
-  const float latency = (elapsedSecs / (itr_count*run_count)) * 1000000; //convert s to us
-  logger(ptree, "Details", boost::str(boost::format("Average latency: '%.1f' us") % latency));
-  ptree.put("status", test_token_passed);
+  const double latency = (elapsedSecs / (itr_count*run_count)) * 1000000; //convert s to us
+
+  //check if the value is in range
+  result_in_range(latency, m_threshold, ptree);
+  logger(ptree, "Details", boost::str(boost::format("Average latency: %.1f us") % latency));
   return ptree;
 }

--- a/src/runtime_src/core/tools/common/tests/TestCmdChainLatency.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestCmdChainLatency.cpp
@@ -29,11 +29,10 @@ TestCmdChainLatency::run(std::shared_ptr<xrt_core::device> dev)
   boost::property_tree::ptree ptree = get_test_header();
   ptree.erase("xclbin");
 
-  double m_threshold = 0.0;
   try {
-    m_threshold = find_threshold(dev, ptree);
+    set_threshold(dev, ptree);
     if(XBU::getVerbose())
-      logger(ptree, "Deatils", boost::str(boost::format("Threshold is %.1f us") % m_threshold));
+      logger(ptree, "Deatils", boost::str(boost::format("Threshold is %.1f us") % get_threshold()));
   }
   catch (const std::runtime_error& ex) {
     logger(ptree, "Details", ex.what());
@@ -173,7 +172,7 @@ TestCmdChainLatency::run(std::shared_ptr<xrt_core::device> dev)
   const double latency = (elapsedSecs / (itr_count*run_count)) * 1000000; //convert s to us
 
   //check if the value is in range
-  result_in_range(latency, m_threshold, ptree);
+  result_in_range(latency, get_threshold(), ptree);
   logger(ptree, "Details", boost::str(boost::format("Average latency: %.1f us") % latency));
   return ptree;
 }

--- a/src/runtime_src/core/tools/common/tests/TestCmdChainLatency.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestCmdChainLatency.cpp
@@ -43,8 +43,10 @@ TestCmdChainLatency::run(std::shared_ptr<xrt_core::device> dev)
 
   const auto xclbin_name = xrt_core::device_query<xrt_core::query::xclbin_name>(dev, xrt_core::query::xclbin_name::type::validate);
   auto xclbin_path = findPlatformFile(xclbin_name, ptree);
-  if (!std::filesystem::exists(xclbin_path))
+  if (!std::filesystem::exists(xclbin_path)){
+    logger(ptree, "Details", "The test is not supported on this device.");
     return ptree;
+  }
 
   logger(ptree, "Xclbin", xclbin_path);
 

--- a/src/runtime_src/core/tools/common/tests/TestCmdChainThroughput.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestCmdChainThroughput.cpp
@@ -32,7 +32,7 @@ TestCmdChainThroughput::run(std::shared_ptr<xrt_core::device> dev)
   try {
     set_threshold(dev, ptree);
     if(XBU::getVerbose())
-      logger(ptree, "Deatils", boost::str(boost::format("Threshold is %.1f ops") % get_threshold()));
+      logger(ptree, "Details", boost::str(boost::format("Threshold is %.1f ops") % get_threshold()));
   }
   catch (const std::runtime_error& ex) {
     logger(ptree, "Details", ex.what());

--- a/src/runtime_src/core/tools/common/tests/TestCmdChainThroughput.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestCmdChainThroughput.cpp
@@ -29,11 +29,10 @@ TestCmdChainThroughput::run(std::shared_ptr<xrt_core::device> dev)
   boost::property_tree::ptree ptree = get_test_header();
   ptree.erase("xclbin");
 
-  double m_threshold = 0.0;
   try {
-    m_threshold = find_threshold(dev, ptree);
+    set_threshold(dev, ptree);
     if(XBU::getVerbose())
-      logger(ptree, "Deatils", boost::str(boost::format("Threshold is %.1f ops") % m_threshold));
+      logger(ptree, "Deatils", boost::str(boost::format("Threshold is %.1f ops") % get_threshold()));
   }
   catch (const std::runtime_error& ex) {
     logger(ptree, "Details", ex.what());
@@ -173,7 +172,7 @@ TestCmdChainThroughput::run(std::shared_ptr<xrt_core::device> dev)
   const double throughput = ((itr_count*run_count) / elapsedSecs);
 
   //check if the value is in range
-  result_in_range(throughput, m_threshold, ptree);
+  result_in_range(throughput, get_threshold(), ptree);
   logger(ptree, "Details", boost::str(boost::format("Average throughput: %.1f ops") % throughput));
   return ptree;
 }

--- a/src/runtime_src/core/tools/common/tests/TestCmdChainThroughput.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestCmdChainThroughput.cpp
@@ -43,8 +43,10 @@ TestCmdChainThroughput::run(std::shared_ptr<xrt_core::device> dev)
 
   const auto xclbin_name = xrt_core::device_query<xrt_core::query::xclbin_name>(dev, xrt_core::query::xclbin_name::type::validate);
   auto xclbin_path = findPlatformFile(xclbin_name, ptree);
-  if (!std::filesystem::exists(xclbin_path))
+  if (!std::filesystem::exists(xclbin_path)){
+    logger(ptree, "Details", "The test is not supported on this device.");
     return ptree;
+  }
 
   logger(ptree, "Xclbin", xclbin_path);
 

--- a/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.cpp
@@ -48,8 +48,10 @@ TestDF_bandwidth::run(std::shared_ptr<xrt_core::device> dev)
 
   const auto xclbin_name = xrt_core::device_query<xrt_core::query::xclbin_name>(dev, xrt_core::query::xclbin_name::type::validate);
   auto xclbin_path = findPlatformFile(xclbin_name, ptree);
-  if (!std::filesystem::exists(xclbin_path))
+  if (!std::filesystem::exists(xclbin_path)){
+    logger(ptree, "Details", "The test is not supported on this device.");
     return ptree;
+  }
 
   logger(ptree, "Xclbin", xclbin_path);
 

--- a/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.cpp
@@ -37,7 +37,7 @@ TestDF_bandwidth::run(std::shared_ptr<xrt_core::device> dev)
   try {
     set_threshold(dev, ptree);
     if(XBU::getVerbose())
-      logger(ptree, "Deatils", boost::str(boost::format("Threshold is %.1f GB/s") % get_threshold()));
+      logger(ptree, "Details", boost::str(boost::format("Threshold is %.1f GB/s") % get_threshold()));
   }
   catch (const std::runtime_error& ex) {
     logger(ptree, "Details", ex.what());

--- a/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.cpp
@@ -34,6 +34,18 @@ TestDF_bandwidth::run(std::shared_ptr<xrt_core::device> dev)
   boost::property_tree::ptree ptree = get_test_header();
   ptree.erase("xclbin");
 
+  double m_threshold = 0.0;
+  try {
+    m_threshold = find_threshold(dev, ptree);
+    if(XBU::getVerbose())
+      logger(ptree, "Deatils", boost::str(boost::format("Threshold is %.1f GB/s") % m_threshold));
+  }
+  catch (const std::runtime_error& ex) {
+    logger(ptree, "Details", ex.what());
+    ptree.put("status", test_token_skipped);
+    return ptree;
+  }
+
   const auto xclbin_name = xrt_core::device_query<xrt_core::query::xclbin_name>(dev, xrt_core::query::xclbin_name::type::validate);
   auto xclbin_path = findPlatformFile(xclbin_name, ptree);
   if (!std::filesystem::exists(xclbin_path))
@@ -121,8 +133,8 @@ TestDF_bandwidth::run(std::shared_ptr<xrt_core::device> dev)
 
   //Log
   if(XBU::getVerbose()) { 
-    logger(ptree, "Details", boost::str(boost::format("Buffer size: '%f'GB") % buffer_size_gb));
-    logger(ptree, "Details", boost::str(boost::format("No. of iterations: '%f'") % itr_count));
+    logger(ptree, "Details", boost::str(boost::format("Buffer size: %f GB") % buffer_size_gb));
+    logger(ptree, "Details", boost::str(boost::format("No. of iterations: %f") % itr_count));
   }
 
   auto start = std::chrono::high_resolution_clock::now();
@@ -152,13 +164,16 @@ TestDF_bandwidth::run(std::shared_ptr<xrt_core::device> dev)
   }
 
   //Calculate bandwidth
-  float elapsedSecs = std::chrono::duration_cast<std::chrono::duration<float>>(end-start).count();
+  auto elapsedSecs = std::chrono::duration_cast<std::chrono::duration<double>>(end-start).count();
   //Data is read and written in parallel hence x2
-  float bandwidth = (buffer_size_gb*itr_count*2) / elapsedSecs;
-  if(XBU::getVerbose())
-    logger(ptree, "Details", boost::str(boost::format("Total duration: '%.1f's") % elapsedSecs));
-  logger(ptree, "Details", boost::str(boost::format("Average bandwidth per shim DMA: '%.1f' GB/s") % bandwidth));
+  double bandwidth = (buffer_size_gb*itr_count*2) / elapsedSecs;
 
-  ptree.put("status", test_token_passed);
+  //check if the value is in range
+  result_in_range(bandwidth, m_threshold, ptree);
+
+  if(XBU::getVerbose())
+    logger(ptree, "Details", boost::str(boost::format("Total duration: %.1fs") % elapsedSecs));
+  logger(ptree, "Details", boost::str(boost::format("Average bandwidth per shim DMA: %.1f GB/s") % bandwidth));
+
   return ptree;
 }

--- a/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.cpp
@@ -34,11 +34,10 @@ TestDF_bandwidth::run(std::shared_ptr<xrt_core::device> dev)
   boost::property_tree::ptree ptree = get_test_header();
   ptree.erase("xclbin");
 
-  double m_threshold = 0.0;
   try {
-    m_threshold = find_threshold(dev, ptree);
+    set_threshold(dev, ptree);
     if(XBU::getVerbose())
-      logger(ptree, "Deatils", boost::str(boost::format("Threshold is %.1f GB/s") % m_threshold));
+      logger(ptree, "Deatils", boost::str(boost::format("Threshold is %.1f GB/s") % get_threshold()));
   }
   catch (const std::runtime_error& ex) {
     logger(ptree, "Details", ex.what());
@@ -171,7 +170,7 @@ TestDF_bandwidth::run(std::shared_ptr<xrt_core::device> dev)
   double bandwidth = (buffer_size_gb*itr_count*2) / elapsedSecs;
 
   //check if the value is in range
-  result_in_range(bandwidth, m_threshold, ptree);
+  result_in_range(bandwidth, get_threshold(), ptree);
 
   if(XBU::getVerbose())
     logger(ptree, "Details", boost::str(boost::format("Total duration: %.1fs") % elapsedSecs));

--- a/src/runtime_src/core/tools/common/tests/TestGemm.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestGemm.cpp
@@ -41,11 +41,10 @@ TestGemm::run(std::shared_ptr<xrt_core::device> dev)
   boost::property_tree::ptree ptree = get_test_header();
   ptree.erase("xclbin");
 
-  double m_threshold = 0.0;
   try {
-    m_threshold = find_threshold(dev, ptree);
+    set_threshold(dev, ptree);
     if(XBU::getVerbose())
-      logger(ptree, "Deatils", boost::str(boost::format("Threshold is %.1f TOPS") % m_threshold));
+      logger(ptree, "Deatils", boost::str(boost::format("Threshold is %.1f TOPS") % get_threshold()));
   }
   catch (const std::runtime_error& ex) {
     logger(ptree, "Details", ex.what());
@@ -196,7 +195,7 @@ TestGemm::run(std::shared_ptr<xrt_core::device> dev)
   }
 
   //check if the value is in range
-  result_in_range(TOPS, m_threshold, ptree);
+  result_in_range(TOPS, get_threshold(), ptree);
 
   logger(ptree, "Details", boost::str(boost::format("TOPS: %.1f") % TOPS));
 

--- a/src/runtime_src/core/tools/common/tests/TestGemm.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestGemm.cpp
@@ -55,8 +55,10 @@ TestGemm::run(std::shared_ptr<xrt_core::device> dev)
 
   const auto xclbin_name = xrt_core::device_query<xrt_core::query::xclbin_name>(dev, xrt_core::query::xclbin_name::type::gemm);
   auto xclbin_path = findPlatformFile(xclbin_name, ptree);
-  if (!std::filesystem::exists(xclbin_path))
+  if (!std::filesystem::exists(xclbin_path)){
+    logger(ptree, "Details", "The test is not supported on this device.");
     return ptree;
+  }
 
   logger(ptree, "Xclbin", xclbin_path);
 

--- a/src/runtime_src/core/tools/common/tests/TestGemm.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestGemm.cpp
@@ -44,7 +44,7 @@ TestGemm::run(std::shared_ptr<xrt_core::device> dev)
   try {
     set_threshold(dev, ptree);
     if(XBU::getVerbose())
-      logger(ptree, "Deatils", boost::str(boost::format("Threshold is %.1f TOPS") % get_threshold()));
+      logger(ptree, "Details", boost::str(boost::format("Threshold is %.1f TOPS") % get_threshold()));
   }
   catch (const std::runtime_error& ex) {
     logger(ptree, "Details", ex.what());

--- a/src/runtime_src/core/tools/common/tests/TestNPULatency.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestNPULatency.cpp
@@ -29,6 +29,18 @@ TestNPULatency::run(std::shared_ptr<xrt_core::device> dev)
   boost::property_tree::ptree ptree = get_test_header();
   ptree.erase("xclbin");
 
+  double m_threshold = 0.0;
+  try {
+    m_threshold = find_threshold(dev, ptree);
+    if(XBU::getVerbose())
+      logger(ptree, "Deatils", boost::str(boost::format("Threshold is %.1f us") % m_threshold));
+  }
+  catch (const std::runtime_error& ex) {
+    logger(ptree, "Details", ex.what());
+    ptree.put("status", test_token_skipped);
+    return ptree;
+  }
+
   const auto xclbin_name = xrt_core::device_query<xrt_core::query::xclbin_name>(dev, xrt_core::query::xclbin_name::type::validate);
   auto xclbin_path = findPlatformFile(xclbin_name, ptree);
   if (!std::filesystem::exists(xclbin_path))
@@ -115,13 +127,13 @@ TestNPULatency::run(std::shared_ptr<xrt_core::device> dev)
 
   //Log
   if(XBU::getVerbose()) {
-    logger(ptree, "Details", boost::str(boost::format("Instruction size: '%f' bytes") % buffer_size));
-    logger(ptree, "Details", boost::str(boost::format("No. of iterations: '%f'") % itr_count));
+    logger(ptree, "Details", boost::str(boost::format("Instruction size: %f bytes") % buffer_size));
+    logger(ptree, "Details", boost::str(boost::format("No. of iterations: %f") % itr_count));
   }
 
   // Run the test to compute latency where we submit one job at a time and wait for its completion before
   // we submit the next one
-  float elapsed_secs = 0.0;
+  double elapsed_secs = 0.0;
 
   try {
     auto start = std::chrono::high_resolution_clock::now();
@@ -130,7 +142,7 @@ TestNPULatency::run(std::shared_ptr<xrt_core::device> dev)
       run.wait2();
     }
     auto end = std::chrono::high_resolution_clock::now();
-    elapsed_secs = std::chrono::duration_cast<std::chrono::duration<float>>(end-start).count();
+    elapsed_secs = std::chrono::duration_cast<std::chrono::duration<double>>(end-start).count();
   }
   catch (const std::exception& ex) {
     logger(ptree, "Error", ex.what());
@@ -138,8 +150,11 @@ TestNPULatency::run(std::shared_ptr<xrt_core::device> dev)
   }
 
   // Calculate end-to-end latency of one job execution
-  const float latency = (elapsed_secs / itr_count) * 1000000; //convert s to us
-  logger(ptree, "Details", boost::str(boost::format("Average latency: '%.1f' us") % latency));
-  ptree.put("status", test_token_passed);
+  const double latency = (elapsed_secs / itr_count) * 1000000; //convert s to us
+
+  //check if the value is in range
+  result_in_range(latency, m_threshold, ptree);
+
+  logger(ptree, "Details", boost::str(boost::format("Average latency: %.1f us") % latency));
   return ptree;
 }

--- a/src/runtime_src/core/tools/common/tests/TestNPULatency.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestNPULatency.cpp
@@ -43,8 +43,10 @@ TestNPULatency::run(std::shared_ptr<xrt_core::device> dev)
 
   const auto xclbin_name = xrt_core::device_query<xrt_core::query::xclbin_name>(dev, xrt_core::query::xclbin_name::type::validate);
   auto xclbin_path = findPlatformFile(xclbin_name, ptree);
-  if (!std::filesystem::exists(xclbin_path))
+  if (!std::filesystem::exists(xclbin_path)){
+    logger(ptree, "Details", "The test is not supported on this device.");
     return ptree;
+  }
 
   logger(ptree, "Xclbin", xclbin_path);
 

--- a/src/runtime_src/core/tools/common/tests/TestNPULatency.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestNPULatency.cpp
@@ -32,7 +32,7 @@ TestNPULatency::run(std::shared_ptr<xrt_core::device> dev)
   try {
     set_threshold(dev, ptree);
     if(XBU::getVerbose())
-      logger(ptree, "Deatils", boost::str(boost::format("Threshold is %.1f us") % get_threshold()));
+      logger(ptree, "Details", boost::str(boost::format("Threshold is %.1f us") % get_threshold()));
   }
   catch (const std::runtime_error& ex) {
     logger(ptree, "Details", ex.what());

--- a/src/runtime_src/core/tools/common/tests/TestNPULatency.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestNPULatency.cpp
@@ -29,11 +29,10 @@ TestNPULatency::run(std::shared_ptr<xrt_core::device> dev)
   boost::property_tree::ptree ptree = get_test_header();
   ptree.erase("xclbin");
 
-  double m_threshold = 0.0;
   try {
-    m_threshold = find_threshold(dev, ptree);
+    set_threshold(dev, ptree);
     if(XBU::getVerbose())
-      logger(ptree, "Deatils", boost::str(boost::format("Threshold is %.1f us") % m_threshold));
+      logger(ptree, "Deatils", boost::str(boost::format("Threshold is %.1f us") % get_threshold()));
   }
   catch (const std::runtime_error& ex) {
     logger(ptree, "Details", ex.what());
@@ -155,7 +154,7 @@ TestNPULatency::run(std::shared_ptr<xrt_core::device> dev)
   const double latency = (elapsed_secs / itr_count) * 1000000; //convert s to us
 
   //check if the value is in range
-  result_in_range(latency, m_threshold, ptree);
+  result_in_range(latency, get_threshold(), ptree);
 
   logger(ptree, "Details", boost::str(boost::format("Average latency: %.1f us") % latency));
   return ptree;

--- a/src/runtime_src/core/tools/common/tests/TestNPUThroughput.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestNPUThroughput.cpp
@@ -29,11 +29,10 @@ TestNPUThroughput::run(std::shared_ptr<xrt_core::device> dev)
   boost::property_tree::ptree ptree = get_test_header();
   ptree.erase("xclbin");
 
-  double m_threshold = 0.0;
   try {
-    m_threshold = find_threshold(dev, ptree);
+    set_threshold(dev, ptree);
     if(XBU::getVerbose())
-      logger(ptree, "Deatils", boost::str(boost::format("Threshold is %.1f ops") % m_threshold));
+      logger(ptree, "Deatils", boost::str(boost::format("Threshold is %.1f ops") % get_threshold()));
   }
   catch (const std::runtime_error& ex) {
     logger(ptree, "Details", ex.what());
@@ -164,7 +163,7 @@ TestNPUThroughput::run(std::shared_ptr<xrt_core::device> dev)
   const double throughput = (elapsedSecs != 0.0) ? itr_count_throughput / elapsedSecs : 0.0;
 
   //check if the value is in range
-  result_in_range(throughput, m_threshold, ptree);
+  result_in_range(throughput, get_threshold(), ptree);
 
   logger(ptree, "Details", boost::str(boost::format("Average throughput: %.1f ops") % throughput));
   return ptree;

--- a/src/runtime_src/core/tools/common/tests/TestNPUThroughput.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestNPUThroughput.cpp
@@ -43,8 +43,10 @@ TestNPUThroughput::run(std::shared_ptr<xrt_core::device> dev)
 
   const auto xclbin_name = xrt_core::device_query<xrt_core::query::xclbin_name>(dev, xrt_core::query::xclbin_name::type::validate);
   auto xclbin_path = findPlatformFile(xclbin_name, ptree);
-  if (!std::filesystem::exists(xclbin_path))
+  if (!std::filesystem::exists(xclbin_path)){
+    logger(ptree, "Details", "The test is not supported on this device.");
     return ptree;
+  }
 
   logger(ptree, "Xclbin", xclbin_path);
 

--- a/src/runtime_src/core/tools/common/tests/TestNPUThroughput.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestNPUThroughput.cpp
@@ -32,7 +32,7 @@ TestNPUThroughput::run(std::shared_ptr<xrt_core::device> dev)
   try {
     set_threshold(dev, ptree);
     if(XBU::getVerbose())
-      logger(ptree, "Deatils", boost::str(boost::format("Threshold is %.1f ops") % get_threshold()));
+      logger(ptree, "Details", boost::str(boost::format("Threshold is %.1f ops") % get_threshold()));
   }
   catch (const std::runtime_error& ex) {
     logger(ptree, "Details", ex.what());

--- a/src/runtime_src/core/tools/common/tests/TestTCTAllColumn.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestTCTAllColumn.cpp
@@ -44,8 +44,10 @@ TestTCTAllColumn::run(std::shared_ptr<xrt_core::device> dev)
 
   const auto xclbin_name = xrt_core::device_query<xrt_core::query::xclbin_name>(dev, xrt_core::query::xclbin_name::type::validate);
   auto xclbin_path = findPlatformFile(xclbin_name, ptree);
-  if (!std::filesystem::exists(xclbin_path))
+  if (!std::filesystem::exists(xclbin_path)){
+    logger(ptree, "Details", "The test is not supported on this device.");
     return ptree;
+  }
 
   logger(ptree, "Xclbin", xclbin_path);
 

--- a/src/runtime_src/core/tools/common/tests/TestTCTAllColumn.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestTCTAllColumn.cpp
@@ -33,7 +33,7 @@ TestTCTAllColumn::run(std::shared_ptr<xrt_core::device> dev)
   try {
     set_threshold(dev, ptree);
     if(XBU::getVerbose())
-      logger(ptree, "Deatils", boost::str(boost::format("Threshold is %.1f TCT/s") % get_threshold()));
+      logger(ptree, "Details", boost::str(boost::format("Threshold is %.1f TCT/s") % get_threshold()));
   }
   catch (const std::runtime_error& ex) {
     logger(ptree, "Details", ex.what());

--- a/src/runtime_src/core/tools/common/tests/TestTCTAllColumn.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestTCTAllColumn.cpp
@@ -30,6 +30,18 @@ TestTCTAllColumn::run(std::shared_ptr<xrt_core::device> dev)
   boost::property_tree::ptree ptree = get_test_header();
   ptree.erase("xclbin");
 
+  double m_threshold = 0.0;
+  try {
+    m_threshold = find_threshold(dev, ptree);
+    if(XBU::getVerbose())
+      logger(ptree, "Deatils", boost::str(boost::format("Threshold is %.1f TCT/s") % m_threshold));
+  }
+  catch (const std::runtime_error& ex) {
+    logger(ptree, "Details", ex.what());
+    ptree.put("status", test_token_skipped);
+    return ptree;
+  }
+
   const auto xclbin_name = xrt_core::device_query<xrt_core::query::xclbin_name>(dev, xrt_core::query::xclbin_name::type::validate);
   auto xclbin_path = findPlatformFile(xclbin_name, ptree);
   if (!std::filesystem::exists(xclbin_path))
@@ -118,8 +130,8 @@ TestTCTAllColumn::run(std::shared_ptr<xrt_core::device> dev)
 
   //Log
   if(XBU::getVerbose()) {
-    logger(ptree, "Details", boost::str(boost::format("Buffer size: '%f' bytes") % buffer_size));
-    logger(ptree, "Details", boost::str(boost::format("No. of iterations: '%f'") % itr_count));
+    logger(ptree, "Details", boost::str(boost::format("Buffer size: %f bytes") % buffer_size));
+    logger(ptree, "Details", boost::str(boost::format("No. of iterations: %f") % itr_count));
   }
 
   auto start = std::chrono::high_resolution_clock::now();
@@ -147,13 +159,16 @@ TestTCTAllColumn::run(std::shared_ptr<xrt_core::device> dev)
   }
 
   //Calculate throughput
-  float elapsedSecs = std::chrono::duration_cast<std::chrono::duration<float>>(end-start).count();
-  float throughput = itr_count / elapsedSecs;
-  float latency = (elapsedSecs / itr_count) * 1000000; //convert s to us
-  if(XBU::getVerbose())
-    logger(ptree, "Details", boost::str(boost::format("Average time for TCT: '%.1f' us") % latency));
-  logger(ptree, "Details", boost::str(boost::format("Average TCT throughput: '%.1f' TCT/s") % throughput));
+  auto elapsedSecs = std::chrono::duration_cast<std::chrono::duration<double>>(end-start).count();
+  double throughput = itr_count / elapsedSecs;
+  double latency = (elapsedSecs / itr_count) * 1000000; //convert s to us
 
-  ptree.put("status", test_token_passed);
+  //check if the value is in range
+  result_in_range(throughput, m_threshold, ptree);
+
+  if(XBU::getVerbose())
+    logger(ptree, "Details", boost::str(boost::format("Average time for TCT: %.1f us") % latency));
+  logger(ptree, "Details", boost::str(boost::format("Average TCT throughput: %.1f TCT/s") % throughput));
+
   return ptree;
 }

--- a/src/runtime_src/core/tools/common/tests/TestTCTAllColumn.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestTCTAllColumn.cpp
@@ -30,11 +30,10 @@ TestTCTAllColumn::run(std::shared_ptr<xrt_core::device> dev)
   boost::property_tree::ptree ptree = get_test_header();
   ptree.erase("xclbin");
 
-  double m_threshold = 0.0;
   try {
-    m_threshold = find_threshold(dev, ptree);
+    set_threshold(dev, ptree);
     if(XBU::getVerbose())
-      logger(ptree, "Deatils", boost::str(boost::format("Threshold is %.1f TCT/s") % m_threshold));
+      logger(ptree, "Deatils", boost::str(boost::format("Threshold is %.1f TCT/s") % get_threshold()));
   }
   catch (const std::runtime_error& ex) {
     logger(ptree, "Details", ex.what());
@@ -166,7 +165,7 @@ TestTCTAllColumn::run(std::shared_ptr<xrt_core::device> dev)
   double latency = (elapsedSecs / itr_count) * 1000000; //convert s to us
 
   //check if the value is in range
-  result_in_range(throughput, m_threshold, ptree);
+  result_in_range(throughput, get_threshold(), ptree);
 
   if(XBU::getVerbose())
     logger(ptree, "Details", boost::str(boost::format("Average time for TCT: %.1f us") % latency));

--- a/src/runtime_src/core/tools/common/tests/TestTCTOneColumn.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestTCTOneColumn.cpp
@@ -30,11 +30,10 @@ TestTCTOneColumn::run(std::shared_ptr<xrt_core::device> dev)
   boost::property_tree::ptree ptree = get_test_header();
   ptree.erase("xclbin");
 
-  double m_threshold = 0.0;
   try {
-    m_threshold = find_threshold(dev, ptree);
+    set_threshold(dev, ptree);
     if(XBU::getVerbose())
-      logger(ptree, "Deatils", boost::str(boost::format("Threshold is %.1f TCT/s") % m_threshold));
+      logger(ptree, "Deatils", boost::str(boost::format("Threshold is %.1f TCT/s") % get_threshold()));
   }
   catch (const std::runtime_error& ex) {
     logger(ptree, "Details", ex.what());
@@ -165,7 +164,7 @@ TestTCTOneColumn::run(std::shared_ptr<xrt_core::device> dev)
   double latency = (elapsedSecs / itr_count) * 1000000; //convert s to us
 
   //check if the value is in range
-  result_in_range(throughput, m_threshold, ptree);
+  result_in_range(throughput, get_threshold(), ptree);
 
   if(XBU::getVerbose())
     logger(ptree, "Details", boost::str(boost::format("Average time for TCT: %.1f us") % latency));

--- a/src/runtime_src/core/tools/common/tests/TestTCTOneColumn.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestTCTOneColumn.cpp
@@ -30,6 +30,18 @@ TestTCTOneColumn::run(std::shared_ptr<xrt_core::device> dev)
   boost::property_tree::ptree ptree = get_test_header();
   ptree.erase("xclbin");
 
+  double m_threshold = 0.0;
+  try {
+    m_threshold = find_threshold(dev, ptree);
+    if(XBU::getVerbose())
+      logger(ptree, "Deatils", boost::str(boost::format("Threshold is %.1f TCT/s") % m_threshold));
+  }
+  catch (const std::runtime_error& ex) {
+    logger(ptree, "Details", ex.what());
+    ptree.put("status", test_token_skipped);
+    return ptree;
+  }
+
   const auto xclbin_name = xrt_core::device_query<xrt_core::query::xclbin_name>(dev, xrt_core::query::xclbin_name::type::validate);
   auto xclbin_path = findPlatformFile(xclbin_name, ptree);
   if (!std::filesystem::exists(xclbin_path))
@@ -118,8 +130,8 @@ TestTCTOneColumn::run(std::shared_ptr<xrt_core::device> dev)
 
   //Log
   if(XBU::getVerbose()) {
-    logger(ptree, "Details", boost::str(boost::format("Buffer size: '%f'bytes") % buffer_size));
-    logger(ptree, "Details", boost::str(boost::format("No. of iterations: '%f'") % itr_count));
+    logger(ptree, "Details", boost::str(boost::format("Buffer size: %f bytes") % buffer_size));
+    logger(ptree, "Details", boost::str(boost::format("No. of iterations: %f") % itr_count));
   }
   auto start = std::chrono::high_resolution_clock::now();
   try {
@@ -146,13 +158,16 @@ TestTCTOneColumn::run(std::shared_ptr<xrt_core::device> dev)
   }
 
   //Calculate throughput
-  float elapsedSecs = std::chrono::duration_cast<std::chrono::duration<float>>(end-start).count();
-  float throughput = itr_count / elapsedSecs;
-  float latency = (elapsedSecs / itr_count) * 1000000; //convert s to us
-  if(XBU::getVerbose())
-    logger(ptree, "Details", boost::str(boost::format("Average time for TCT: '%.1f' us") % latency));
-  logger(ptree, "Details", boost::str(boost::format("Average TCT throughput: '%.1f' TCT/s") % throughput));
+  auto elapsedSecs = std::chrono::duration_cast<std::chrono::duration<double>>(end-start).count();
+  double throughput = itr_count / elapsedSecs;
+  double latency = (elapsedSecs / itr_count) * 1000000; //convert s to us
 
-  ptree.put("status", test_token_passed);
+  //check if the value is in range
+  result_in_range(throughput, m_threshold, ptree);
+
+  if(XBU::getVerbose())
+    logger(ptree, "Details", boost::str(boost::format("Average time for TCT: %.1f us") % latency));
+  logger(ptree, "Details", boost::str(boost::format("Average TCT throughput: %.1f TCT/s") % throughput));
+
   return ptree;
 }

--- a/src/runtime_src/core/tools/common/tests/TestTCTOneColumn.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestTCTOneColumn.cpp
@@ -33,7 +33,7 @@ TestTCTOneColumn::run(std::shared_ptr<xrt_core::device> dev)
   try {
     set_threshold(dev, ptree);
     if(XBU::getVerbose())
-      logger(ptree, "Deatils", boost::str(boost::format("Threshold is %.1f TCT/s") % get_threshold()));
+      logger(ptree, "Details", boost::str(boost::format("Threshold is %.1f TCT/s") % get_threshold()));
   }
   catch (const std::runtime_error& ex) {
     logger(ptree, "Details", ex.what());

--- a/src/runtime_src/core/tools/common/tests/TestTCTOneColumn.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestTCTOneColumn.cpp
@@ -44,8 +44,10 @@ TestTCTOneColumn::run(std::shared_ptr<xrt_core::device> dev)
 
   const auto xclbin_name = xrt_core::device_query<xrt_core::query::xclbin_name>(dev, xrt_core::query::xclbin_name::type::validate);
   auto xclbin_path = findPlatformFile(xclbin_name, ptree);
-  if (!std::filesystem::exists(xclbin_path))
+  if (!std::filesystem::exists(xclbin_path)){
+    logger(ptree, "Details", "The test is not supported on this device.");
     return ptree;
+  }
 
   logger(ptree, "Xclbin", xclbin_path);
 

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.h
@@ -22,6 +22,7 @@ class SubCmdValidate : public SubCmd {
   std::string               m_output;
   std::string               m_param;
   std::string               m_xclbin_location;
+  std::string               m_pmode;
   bool                      m_help;
 
   void print_help_internal() const;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
[VITIS-12882](https://jira.xilinx.com/browse/VITIS-12882) Add limits for benchmarks to specify pass criteria
Spec page can be found [here](https://confluence.amd.com/x/4QcRW)

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
New feature
Currently, we pass all the benchmarks in validate. This PR compares the benchmark value to the threshold/expected value for a given device and based on that decides if the test has passed or failed. 

#### How problem was solved, alternative solutions (if any) and why they were rejected
A json will be added per platform to VTD (benchmark_devid_rev_id.json) which will be used for comparison

#### Risks (if any) associated the changes in the commit
Low: might print out some unexpected messages, but the functionality will not be compromised

#### What has been tested and how, request additional testing if necessary
Tested all possible scenarios on Strix/MCDM. Please refer to the spec page for expected behavior

#### Documentation impact (if any)
N/A
