### PR TITLE
VITIS-13418 Add option to force enable/disable preemption

### DIFF
--- a/src/runtime_src/core/common/info_platform.cpp
+++ b/src/runtime_src/core/common/info_platform.cpp
@@ -159,7 +159,7 @@ add_performance_info(const xrt_core::device* device, ptree_type& pt)
     pt.add("power_mode", "not supported");
   }
     try {
-    const auto mode = (xrt_core::device_query<xq::preemption>(device) == 0) ? "enabled" : "disabled";
+    const auto mode = (xrt_core::device_query<xq::preemption>(device) == 0) ? "disabled" : "enabled";
       pt.add("force_preemption", mode);
   } 
   catch (xrt_core::query::no_such_key&) {

--- a/src/runtime_src/core/common/info_platform.cpp
+++ b/src/runtime_src/core/common/info_platform.cpp
@@ -158,6 +158,13 @@ add_performance_info(const xrt_core::device* device, ptree_type& pt)
   catch (xrt_core::query::no_such_key&) {
     pt.add("power_mode", "not supported");
   }
+    try {
+    const auto mode = (xrt_core::device_query<xq::preemption>(device) == 0) ? "enabled" : "disabled";
+      pt.add("force_preemption", mode);
+  } 
+  catch (xrt_core::query::no_such_key&) {
+    pt.add("force_preemption", "not supported");
+  }
 }
 
 static std::string

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -316,6 +316,7 @@ enum class key_type
   xgq_scaling_power_override,
   xgq_scaling_temp_override,
   performance_mode,
+  preemption,
   debug_ip_layout_path,
   debug_ip_layout,
   num_live_processes,
@@ -3742,6 +3743,21 @@ struct performance_mode : request
         throw xrt_core::system_error(EINVAL, "Invalid performance status: " + std::to_string(status));
     }
   }
+};
+
+struct preemption : request
+{
+  using result_type = uint32_t;  // get value type
+  using value_type = uint32_t;   // put value type
+
+  static const key_type key = key_type::preemption;
+
+  virtual std::any
+  get(const device*) const = 0;
+
+  virtual void
+  put(const device*, const std::any&) const = 0;
+
 };
 
 struct debug_ip_layout_path : request

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -3745,6 +3745,10 @@ struct performance_mode : request
   }
 };
 
+/*
+ * this request force enables or disables pre-emption globally
+ * 0: enable; 1: disable
+*/
 struct preemption : request
 {
   using result_type = uint32_t;  // get value type

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -1720,6 +1720,8 @@ struct misc_telemetry : request
 {
   struct data {
     uint64_t l1_interrupts;
+    uint64_t preemption_flag_set;
+    uint64_t preemption_flag_unset;
   };
 
   using result_type = data;

--- a/src/runtime_src/core/tools/common/XBHelpMenusCore.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenusCore.cpp
@@ -431,10 +431,6 @@ XBUtilities::report_option_help(const std::string & _groupName,
 {
   const auto& fh = FormatHelper::instance();
 
-  // Determine if there is anything to report
-  if (_optionDescription.options().empty())
-    return;
-
   // Report option group name (if defined)
   boost::format fmtHeader(fh.fgc_header + "\n%s:\n" + fh.fgc_reset);
   if ( !_groupName.empty() )

--- a/src/runtime_src/core/tools/common/reports/platform/ReportRyzenPlatform.cpp
+++ b/src/runtime_src/core/tools/common/reports/platform/ReportRyzenPlatform.cpp
@@ -51,6 +51,7 @@ ReportRyzenPlatform::writeReport(const xrt_core::device* /*_pDevice*/,
 
     const boost::property_tree::ptree& pt_status = pt_platform.get_child("status");
     _output << boost::format("  %-23s: %s \n") % "Power Mode" % pt_status.get<std::string>("power_mode");
+    _output << boost::format("  %-23s: %s \n") % "Preemption" % pt_status.get<std::string>("force_preemption");
 
     const boost::property_tree::ptree& clocks = pt_platform.get_child("clocks", empty_ptree);
     if (!clocks.empty()) {

--- a/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
@@ -48,6 +48,7 @@ file(GLOB XBUTIL_V2_SUBCMD_FILES
   "OO_AieClockFreq.cpp"
   "OO_HostMem.cpp"
   "OO_Performance.cpp"
+  "OO_Preemption.cpp"
 )
 
 # Merge the files into one collection

--- a/src/runtime_src/core/tools/xbutil2/OO_Preemption.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_Preemption.cpp
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+
+// ------ I N C L U D E   F I L E S -------------------------------------------
+// Local - Include Files
+#include "OO_Preemption.h"
+#include "tools/common/XBUtilitiesCore.h"
+#include "tools/common/XBUtilities.h"
+#include "tools/common/XBHelpMenusCore.h"
+
+// 3rd Party Library - Include Files
+#include <boost/program_options.hpp>
+#include <boost/algorithm/string.hpp>
+namespace po = boost::program_options;
+
+// ----- C L A S S   M E T H O D S -------------------------------------------
+
+OO_Preemption::OO_Preemption( const std::string &_longName, bool _isHidden )
+    : OptionOptions(_longName, _isHidden, "Force enable|disable pre-emption")
+    , m_device("")
+    , m_action("")
+    , m_help(false)
+{
+  m_optionsDescription.add_options()
+    ("device,d", boost::program_options::value<decltype(m_device)>(&m_device), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest")
+    ("help", boost::program_options::bool_switch(&m_help), "Help to use this sub-command")
+  ;
+
+  m_optionsHidden.add_options()
+    ("mode", boost::program_options::value<decltype(m_action)>(&m_action)->required(), "Action to perform: enable, disable")
+  ;
+
+  m_positionalOptions.
+    add("mode", 1 /* max_count */)
+  ;
+}
+
+void
+OO_Preemption::execute(const SubCmdOptions& _options) const
+{
+  XBUtilities::verbose("SubCommand option: Pre-emption");
+
+  XBUtilities::verbose("Option(s):");
+  for (auto & aString : _options)
+    XBUtilities::verbose(std::string(" ") + aString);
+
+  // Honor help option first
+  if (std::find(_options.begin(), _options.end(), "--help") != _options.end()) {
+    printHelp();
+    return;
+  }
+
+  // Parse sub-command ...
+  po::variables_map vm;
+
+  try {
+    po::options_description all_options("All Options");
+    all_options.add(m_optionsDescription);
+    all_options.add(m_optionsHidden);
+    po::command_line_parser parser(_options);
+    XBUtilities::process_arguments(vm, parser, all_options, m_positionalOptions, true);
+  } catch(boost::program_options::error&) {
+      if(m_help) {
+        printHelp();
+        throw xrt_core::error(std::errc::operation_canceled);
+      }
+      // Exit if neither action or device specified
+      if(m_action.empty()) {
+        std::cerr << boost::format("ERROR: the required argument for option '--force-preemption' is missing\n");
+        printHelp();
+        throw xrt_core::error(std::errc::operation_canceled);
+      }
+  }
+
+  // Find device of interest
+  std::shared_ptr<xrt_core::device> device;
+  
+  try {
+    device = XBUtilities::get_device(boost::algorithm::to_lower_copy(m_device), true /*inUserDomain*/);
+  } catch (const std::runtime_error& e) {
+    // Catch only the exceptions that we have generated earlier
+    std::cerr << boost::format("ERROR: %s\n") % e.what();
+    throw xrt_core::error(std::errc::operation_canceled);
+  }
+
+  try {
+    if (boost::iequals(m_action, "enable")) {
+      xrt_core::device_update<xrt_core::query::preemption>(device.get(), 0); // default
+    }
+    else if (boost::iequals(m_action, "disable")) {
+      xrt_core::device_update<xrt_core::query::preemption>(device.get(), 1);
+    }
+    else {
+      throw xrt_core::error(boost::str(boost::format("Invalid force-preemption value: '%s'\n") % m_action));
+    }
+    std::cout << boost::format("\nPreemption has been %sd \n") % (boost::algorithm::to_lower_copy(m_action));
+  }
+  catch(const xrt_core::error& e) {
+    std::cerr << boost::format("\nERROR: %s\n") % e.what();
+    printHelp();
+    throw xrt_core::error(std::errc::operation_canceled);
+  }
+}

--- a/src/runtime_src/core/tools/xbutil2/OO_Preemption.h
+++ b/src/runtime_src/core/tools/xbutil2/OO_Preemption.h
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+
+#ifndef __OO_Preemption_h_
+#define __OO_Preemption_h_
+
+#include "tools/common/OptionOptions.h"
+
+class OO_Preemption : public OptionOptions {
+ public:
+  virtual void execute( const SubCmdOptions &_options ) const;
+
+ public:
+  OO_Preemption( const std::string &_longName, bool _isHidden = true);
+
+ private:
+  std::string m_device;
+  std::string m_action;
+  bool m_help;
+};
+
+#endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdConfigure.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdConfigure.cpp
@@ -9,11 +9,13 @@
 #include "OO_HostMem.h"
 #include "OO_P2P.h"
 #include "OO_Performance.h"
+#include "OO_Preemption.h"
 
 std::vector<std::shared_ptr<OptionOptions>> SubCmdConfigureInternal::optionOptionsCollection = {
   std::make_shared<OO_HostMem>("host-mem"),
   std::make_shared<OO_P2P>("p2p"),
   std::make_shared<OO_Performance>("pmode"),
+  std::make_shared<OO_Preemption>("force-preemption") //hidden
 };
 
 SubCmdConfigure::SubCmdConfigure(bool _isHidden, bool _isDepricated, bool _isPreliminary, const boost::property_tree::ptree& configurations)

--- a/src/runtime_src/core/tools/xbutil2/xbutil.cpp
+++ b/src/runtime_src/core/tools/xbutil2/xbutil.cpp
@@ -58,7 +58,7 @@ R"(
     }]
   },{
     "configure": [{
-      "suboption": ["pmode"]
+      "suboption": ["pmode", "force-preemption"]
     }]
   },{
     "advanced":[{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
[VITIS-13418](https://jira.xilinx.com/browse/VITIS-13418) xrt-smi force-preemption

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
New feature for internal developers

#### How problem was solved, alternative solutions (if any) and why they were rejected
Introducing a new hidden option to force enable or disable pre-emption globally

#### Risks (if any) associated the changes in the commit
Low: EA feature

#### What has been tested and how, request additional testing if necessary
Will be tested with Durga's driver changes. On Strix MCDM, the outputs currently look like:
```
> xrt-smi configure --help --show-hidden

COMMAND: configure

DESCRIPTION: Device and host configuration.

USAGE: xrt-smi configure [ --host-mem | --p2p | --pmode | --force-preemption ] [--help] [-d arg]

OPTIONS:
 Common:
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest
  --help             - Help to use this sub-command
 AIE:
  --pmode            - Modes: default, powersaver, balanced, performance, turbo
 Alveo:
  --host-mem         - Controls host-mem functionality
  --p2p              - Controls P2P functionality

OPTIONS (Hidden):
  --force-preemption - Force enable|disable pre-emption


GLOBAL OPTIONS:
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
```

```
> xrt-smi configure --force-preemption
ERROR: the required argument for option '--force-preemption' is missing

COMMAND: configure

DESCRIPTION: Force enable|disable pre-emption

USAGE:  configure --force-preemption [--help] [-d arg]

OPTIONS:
  --force-preemption - Force enable|disable pre-emption
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest
  --help             - Help to use this sub-command
```

#### Documentation impact (if any)
N/A