### PR TITLE
CR-1213812: Adding poll_timers_interval_us as a new valid option to AIE trace

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_metadata.cpp
@@ -141,7 +141,7 @@ namespace xdp {
       "start_type", "start_time", "start_iteration", "end_type",
       "periodic_offload", "reuse_buffer", "buffer_size", 
       "buffer_offload_interval_us", "file_dump_interval_s",
-      "enable_system_timeline"
+      "enable_system_timeline", "poll_timers_interval_us"
     };
     const std::map<std::string, std::string> deprecatedSettings {
       {"aie_trace_metrics", "AIE_trace_settings.graph_based_aie_tile_metrics or tile_based_aie_tile_metrics"},


### PR DESCRIPTION
#### Problem solved by the commit
The EA feature System Timeline takes in an optional control in the xrt.ini to control how often timestamps are polled from the AIE.  This option was not identified as a valid option and was giving an unnecessary warning.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Identify the new option as a valid setting and not emit the warning.

#### How problem was solved, alternative solutions (if any) and why they were rejected
The option was added to the list of valid settings.

#### Risks (if any) associated the changes in the commit
No risk as this merely removes a warning.

#### Documentation impact (if any)
This new option should be documented for the EA system timeline feature.