### PR TITLE
Made aie_ctx to ZOCL_CTX_NOOPS to support multi partition

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/edge/zocl_aie.c
+++ b/src/runtime_src/core/edge/drm/zocl/edge/zocl_aie.c
@@ -731,7 +731,7 @@ zocl_aie_kds_add_context(struct drm_zocl_dev *zdev, u32 ctx_code,
 		}
 	}
 
-	client->aie_ctx = ctx_code;
+	client->aie_ctx = ZOCL_CTX_NOOPS;
 
 out:
 	mutex_unlock(&kds->lock);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
To run multiple graphs with multiple hwctx (graph1->hwctx1, graph2->hwctx2, etc.) from a single xclbin
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Made aie_ctx to ZOCL_CTX_NOOPS. It enables to open multiple hwctx with a single xclbin with multi partition, multi graph. 
#### Risks (if any) associated the changes in the commit
low
#### What has been tested and how, request additional testing if necessary
Please find the table below.
<html xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:dt="uuid:C2F41010-65B3-11d1-A29F-00AA00C14882"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=OneNote.File>
<meta name=Generator content="Microsoft OneNote 15">
</head>

<body lang=en-US style='font-family:Calibri;font-size:11.0pt'>
<!--StartFragment-->

<div style='direction:ltr'>


Testname | legacy | hwctx
-- | -- | --
complex_graph | passed | passed
simple_gmio | passed | passed
simple_graph | passed | passed
simple_rtp | passed | passed
simple_vadd(opencl) | passed | testcase is n/a
simple_vadd | passed | passed
zynqmp hello   world(opencl) | passed | testcase is n/a
multi hwctx single   xclbin with multi graph simple gmio | testcase is n/a | passed



</div>

<!--EndFragment-->
</body>

</html>

#### Documentation impact (if any)
Once the destruction of objects from the userspace are in order we need to work on this aie_ctx.