### PR TITLE
Modified the if loops to check for mm_node

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/common/zocl_drv.c
+++ b/src/runtime_src/core/edge/drm/zocl/common/zocl_drv.c
@@ -708,7 +708,7 @@ zocl_gem_mmap(struct file *filp, struct vm_area_struct *vma)
 		 */
 		vma->vm_page_prot = prot;
 
-	if (bo->flags & ZOCL_BO_FLAGS_CMA) {
+	if (!bo->mm_node) {
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
 		dma_obj = to_drm_gem_dma_obj(gem_obj);
 		paddr = dma_obj->dma_addr;
@@ -719,8 +719,8 @@ zocl_gem_mmap(struct file *filp, struct vm_area_struct *vma)
 	} else
 		paddr = bo->mm_node->start;
 
-	if ((!(bo->flags & ZOCL_BO_FLAGS_CMA)) ||
-	    (bo->flags & ZOCL_BO_FLAGS_CMA &&
+	if (bo->mm_node ||
+	    (!bo->mm_node &&
 	    bo->flags & ZOCL_BO_FLAGS_CACHEABLE)) {
 		/* Map PL-DDR and cacheable CMA */
 		rc = remap_pfn_range(vma, vma->vm_start,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1210171 zocl driver gives kerenl OOPS messages while running gstreamer pipeline

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Modified the if loops to check for mm_node if buffers are created on DMA

#### Risks (if any) associated the changes in the commit
low

#### What has been tested and how, request additional testing if necessary
Tested pl and graph testcases on vck190 hw_emu.

#### Documentation impact (if any)
NA