### PR TITLE
CR-1204045 Typo in get_tag() function description in 2024.1 XRT githu…

### DIFF
--- a/src/runtime_src/core/include/experimental/xrt_xclbin.h
+++ b/src/runtime_src/core/include/experimental/xrt_xclbin.h
@@ -129,7 +129,7 @@ public:
     {}
 
     /**
-     * get_name() - Get tag name
+     * get_tag() - Get tag name
      *
      * @return
      *   Memory tag name
@@ -149,7 +149,7 @@ public:
     get_base_address() const;
 
     /**
-     * get_size() - Get the size of the memory in KB
+     * get_size_kb() - Get the size of the memory in KB
      *
      * @return
      *  Size of memory in KB, or -1 for invalid size


### PR DESCRIPTION
…b doc

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

correcting typo in function description

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

N/A

#### How problem was solved, alternative solutions (if any) and why they were rejected

correcting typo in function description

#### Risks (if any) associated the changes in the commit

N/A

#### What has been tested and how, request additional testing if necessary

N/A

#### Documentation impact (if any)

N/A