### PR TITLE
cleanup of closeAIEcontext

### DIFF
--- a/src/runtime_src/core/edge/user/aie/graph_object.cpp
+++ b/src/runtime_src/core/edge/user/aie/graph_object.cpp
@@ -18,10 +18,14 @@ namespace zynqaie {
       auto drv = ZYNQ::shim::handleCheck(device->get_device_handle());
 
 #ifdef XRT_ENABLE_AIE       
-      if (nullptr != m_hwctx)
+      if (m_hwctx) {
         aieArray = m_hwctx->get_aie_array_shared();
-      else if (drv->isAieRegistered())
+        m_hwctx->getAied()->register_graph(this);
+      }
+      else if (drv->isAieRegistered()) {
         aieArray = drv->get_aie_array_shared();
+        drv->getAied()->register_graph(this);
+      }
 #endif
 
       id = xrt_core::edge::aie::get_graph_id(device.get(), name, m_hwctx);
@@ -37,22 +41,20 @@ namespace zynqaie {
       rtps = xrt_core::edge::aie::get_rtp(device.get(), graph_config.id, m_hwctx);
       aie_config_api = std::make_shared<adf::graph_api>(&graph_config);
       aie_config_api->configure();
-      state = graph_state::reset;
-      drv->getAied()->register_graph(this);
+      state = graph_state::reset;    
   }
 
   graph_object::~graph_object()
   {
     auto device{xrt_core::get_userpf_device(m_shim)};
     auto drv = ZYNQ::shim::handleCheck(device->get_device_handle());
-    if (!drv || !drv->getAied()) {
-      std::stringstream warnMsg;
-      warnMsg << "There is no active device open. Unable to close Graph `" << name << "`";
-      xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", warnMsg.str());
-      return;
-    }
+
     drv->close_graph_context(m_hwctx, id);
-    drv->getAied()->deregister_graph(this);
+
+    if (m_hwctx) // hwctx specific
+      m_hwctx->getAied()->deregister_graph(this);
+    else   // device specific
+      drv->getAied()->deregister_graph(this);
   }
 
   std::string

--- a/src/runtime_src/core/edge/user/hwctx_object.cpp
+++ b/src/runtime_src/core/edge/user/hwctx_object.cpp
@@ -20,22 +20,7 @@ namespace zynqaie {
 	  , m_uuid(std::move(uuid))
 	  , m_slotidx(slotidx)
 	  , m_mode(mode)
-  {
-#ifdef XRT_ENABLE_AIE
-    auto device{xrt_core::get_userpf_device(m_shim)};
-    auto data = device->get_axlf_section(AIE_METADATA, m_uuid);
-    if (data.first && data.second)
-      m_aie_array = std::make_shared<Aie>(device, this);
-#endif
-  }
-
-#ifdef XRT_ENABLE_AIE
-  std::shared_ptr<Aie>
-  hwctx_object::get_aie_array_shared() const
-  {
-    return m_aie_array;
-  }
-#endif
+  {}
 
   hwctx_object::~hwctx_object()
   {
@@ -45,6 +30,33 @@ namespace zynqaie {
     catch (const std::exception& ex) {
       xrt_core::send_exception_message(ex.what());
     }
+  }
+
+#ifdef XRT_ENABLE_AIE
+  std::shared_ptr<Aie>
+  hwctx_object::get_aie_array_shared()
+  {
+    return m_aie_array;
+  }
+    
+  aied*
+  hwctx_object::getAied()
+  {
+    return m_aied.get();
+  }
+#endif
+  
+  void 
+  hwctx_object::initAie()
+  {
+#ifdef XRT_ENABLE_AIE
+    auto device{xrt_core::get_userpf_device(m_shim)};
+    auto data = device->get_axlf_section(AIE_METADATA, m_uuid);
+    if (data.first && data.second)
+      m_aie_array = std::make_shared<Aie>(device, this);
+
+    m_aied = std::make_unique<zynqaie::aied>(device.get());
+#endif
   }
 
   std::unique_ptr<xrt_core::buffer_handle>

--- a/src/runtime_src/core/edge/user/hwctx_object.h
+++ b/src/runtime_src/core/edge/user/hwctx_object.h
@@ -16,7 +16,9 @@ namespace ZYNQ {
 }
 
 namespace zynqaie {
+
   class Aie;
+  class aied;
 
   class hwctx_object : public xrt_core::hwctx_handle
   {
@@ -26,12 +28,16 @@ namespace zynqaie {
     xrt::hw_context::access_mode m_mode;
 #ifdef XRT_ENABLE_AIE
     std::shared_ptr<Aie> m_aie_array;
+    std::unique_ptr<zynqaie::aied> m_aied;
 #endif
 
   public:
     hwctx_object(ZYNQ::shim* shim, slot_id slotidx, xrt::uuid uuid, xrt::hw_context::access_mode mode);
 
     ~hwctx_object();
+
+    void
+    initAie();
 
     void
     update_access_mode(access_mode mode) override
@@ -89,7 +95,10 @@ namespace zynqaie {
 
 #ifdef XRT_ENABLE_AIE
     std::shared_ptr<Aie>
-    get_aie_array_shared() const;
+    get_aie_array_shared();
+
+    aied*
+    getAied();
 #endif
 
   }; // class hwctx_object

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -132,6 +132,11 @@ shim::
 {
   xclLog(XRT_INFO, "%s", __func__);
 
+#ifdef XRT_ENABLE_AIE
+  if(aieArray)  // Aie cleanup should be done before shim destroyed
+    aieArray.reset();
+#endif
+
   // Flush all of the profiling information from the device to the profiling
   // library before the device is closed (when profiling is enabled).
   xdp::finish_flush_device(this);
@@ -1304,12 +1309,6 @@ int shim::load_hw_axlf(xclDeviceHandle handle, const xclBin *buffer, drm_zocl_cr
   bool checkDrmFD = xrt_core::config::get_enable_flat() ? false : true;
   ZYNQ::shim *drv = ZYNQ::shim::handleCheck(handle, checkDrmFD);
 
-  #ifdef XRT_ENABLE_AIE
-  auto data = core_device->get_axlf_section(AIE_METADATA);
-  if(data.first && data.second)
-    drv->registerAieArray();
-  #endif
-
   #ifndef __HWEM__
     xdp::hal::update_device(handle);
     xdp::aie::update_device(handle);
@@ -1357,7 +1356,11 @@ create_hw_context(xclDeviceHandle handle,
     }
     //success
     mCoreDevice->register_axlf(buffer);
-    return std::make_unique<zynqaie::hwctx_object>(this, hw_ctx.hw_context, xclbin_uuid, mode);
+
+    auto hwctx_obj_ptr{std::make_unique<zynqaie::hwctx_object>(this, hw_ctx.hw_context, xclbin_uuid, mode)};
+    hwctx_obj_ptr->initAie(); // just to make sure Aie instance created only once
+
+    return std::move(hwctx_obj_ptr);
   }
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

shim is getting destroyed before Aie

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

N/A

#### How problem was solved, alternative solutions (if any) and why they were rejected

resetting Aie in shim's destructor

#### Risks (if any) associated the changes in the commit

N/A

#### What has been tested and how, request additional testing if necessary

graph test cases with device / hwcontext

#### Documentation impact (if any)

N/A