### PR TITLE
Starting trace module using a broadcast network for XDP Client

### DIFF
--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -970,6 +970,13 @@ get_aie_trace_settings_periodic_offload()
 }
 
 inline bool
+get_aie_trace_settings_trace_start_broadcast()
+{
+  static bool value = detail::get_bool_value("AIE_trace_settings.trace_start_broadcast", true);
+  return value;
+}
+
+inline bool
 get_aie_trace_settings_reuse_buffer()
 {
   static bool value = detail::get_bool_value("AIE_trace_settings.reuse_buffer", false);

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/client/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/client/aie_trace.cpp
@@ -62,7 +62,8 @@ namespace xdp {
     traceStartBroadcastId1 = 6;
     traceStartBroadcastId2 = 7;
 
-    if(xrt_core::config::get_aie_trace_settings_trace_start_broadcast()) 
+    m_trace_start_broadcast = xrt_core::config::get_aie_trace_settings_trace_start_broadcast();
+    if(m_trace_start_broadcast) 
       coreTraceStartEvent = (XAie_Events) (XAIE_EVENT_BROADCAST_0_CORE + traceStartBroadcastId1);
     else 
       coreTraceStartEvent = XAIE_EVENT_ACTIVE_CORE;
@@ -153,7 +154,7 @@ namespace xdp {
     memoryTileEventSets["mm2s_channels_stalls"] = memoryTileEventSets["output_channels_stalls"];
 
     // Memory tile trace is flushed at end of run
-    if(xrt_core::config::get_aie_trace_settings_trace_start_broadcast())
+    if(m_trace_start_broadcast)
       memoryTileTraceStartEvent = (XAie_Events) (XAIE_EVENT_BROADCAST_0_MEM_TILE + traceStartBroadcastId1);
     else
       memoryTileTraceStartEvent = XAIE_EVENT_TRUE_MEM_TILE;
@@ -200,7 +201,7 @@ namespace xdp {
     interfaceTileEventSets["s2mm_ports_details"]     = interfaceTileEventSets["output_ports_details"];
 
     // Interface tile trace is flushed at end of run
-    if(xrt_core::config::get_aie_trace_settings_trace_start_broadcast())
+    if(m_trace_start_broadcast)
       interfaceTileTraceStartEvent = (XAie_Events) (XAIE_EVENT_BROADCAST_A_0_PL + traceStartBroadcastId2);
     else
       interfaceTileTraceStartEvent = XAIE_EVENT_TRUE_PL;
@@ -1315,14 +1316,14 @@ namespace xdp {
         }
         else if (type == module_type::core) {
           // Broadcast to memory module
-          if(!xrt_core::config::get_aie_trace_settings_trace_start_broadcast())
+          if(!m_trace_start_broadcast)
             if (XAie_EventBroadcast(&aieDevInst, loc, XAIE_CORE_MOD, 8, traceStartEvent) != XAIE_OK)
               break;
           if (XAie_EventBroadcast(&aieDevInst, loc, XAIE_CORE_MOD, 9, traceEndEvent) != XAIE_OK)
             break;
 
           uint8_t phyEvent = 0;
-          if(!xrt_core::config::get_aie_trace_settings_trace_start_broadcast()) {
+          if(!m_trace_start_broadcast) {
             XAie_EventLogicalToPhysicalConv(&aieDevInst, loc, XAIE_CORE_MOD, traceStartEvent, &phyEvent);
             cfgTile->core_trace_config.internal_events_broadcast[8] = phyEvent;
           }
@@ -1339,7 +1340,7 @@ namespace xdp {
             if (XAie_EventBroadcastUnblockDir(&aieDevInst, loc, XAIE_CORE_MOD, XAIE_EVENT_SWITCH_A, i, XAIE_EVENT_BROADCAST_EAST) != XAIE_OK)
               break;
 
-          if(xrt_core::config::get_aie_trace_settings_trace_start_broadcast())
+          if(m_trace_start_broadcast)
             traceStartEvent = (XAie_Events) (XAIE_EVENT_BROADCAST_0_MEM + traceStartBroadcastId1);
           else
             traceStartEvent = XAIE_EVENT_BROADCAST_8_MEM;
@@ -1606,7 +1607,7 @@ namespace xdp {
       (db->getStaticInfo()).addAIECfgTile(deviceId, cfgTile);
     }  // For tiles
 
-    if(xrt_core::config::get_aie_trace_settings_trace_start_broadcast()) {
+    if(m_trace_start_broadcast) {
       build2ChannelBroadcastNetwork(hwCtxImpl, traceStartBroadcastId1, traceStartBroadcastId2, interfaceTileTraceStartEvent);
       XAie_EventGenerate(&aieDevInst, XAie_TileLoc(0, 0), XAIE_PL_MOD,  interfaceTileTraceStartEvent);
     }
@@ -1625,7 +1626,7 @@ namespace xdp {
     XAie_ClearTransaction(&aieDevInst);
 
     // Clearing the broadcast network used for trace start
-    if(xrt_core::config::get_aie_trace_settings_trace_start_broadcast()) {
+    if(m_trace_start_broadcast) {
       XAie_StartTransaction(&aieDevInst, XAIE_TRANSACTION_DISABLE_AUTO_FLUSH);
       reset2ChannelBroadcastNetwork(hwCtxImpl, traceStartBroadcastId1, traceStartBroadcastId2);
       txn_ptr = XAie_ExportSerializedTransaction(&aieDevInst, 1, 0);

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/client/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/client/aie_trace.cpp
@@ -248,7 +248,7 @@ namespace xdp {
     }
 
     XAie_Events bcastEvent2_PL =  (XAie_Events) (XAIE_EVENT_BROADCAST_A_0_PL + broadcastId2);
-    XAie_EventBroadcast(&aieDevInst, XAie_TileLoc(0, 0), XAIE_PL_MOD, broadcastId2, event);
+    XAie_EventBroadcast(&aieDevInst, XAie_TileLoc(startCol, 0), XAIE_PL_MOD, broadcastId2, event);
 
     for(uint8_t col = startCol; col < startCol + numCols; col++) {
       for(uint8_t row = 0; row <= maxRowAtCol[col]; row++) {
@@ -316,7 +316,7 @@ namespace xdp {
       maxRowAtCol[startCol + col] = std::max(maxRowAtCol[col], (uint8_t)row);
     }
 
-    XAie_EventBroadcastReset(&aieDevInst, XAie_TileLoc(0, 0), XAIE_PL_MOD, broadcastId2);
+    XAie_EventBroadcastReset(&aieDevInst, XAie_TileLoc(startCol, 0), XAIE_PL_MOD, broadcastId2);
 
     for(uint8_t col = startCol; col < startCol + numCols; col++) {
       for(uint8_t row = 0; row <= maxRowAtCol[col]; row++) {
@@ -385,8 +385,8 @@ namespace xdp {
     }
 
     if(startLayer != UINT_MAX) {
-      XAie_PerfCounterControlSet(&aieDevInst, XAie_TileLoc(0, 0), XAIE_PL_MOD, 0, XAIE_EVENT_USER_EVENT_0_PL, XAIE_EVENT_USER_EVENT_0_PL);
-      XAie_PerfCounterEventValueSet(&aieDevInst, XAie_TileLoc(0, 0), XAIE_PL_MOD, 0, startLayer);
+      XAie_PerfCounterControlSet(&aieDevInst, XAie_TileLoc(startCol, 0), XAIE_PL_MOD, 0, XAIE_EVENT_USER_EVENT_0_PL, XAIE_EVENT_USER_EVENT_0_PL);
+      XAie_PerfCounterEventValueSet(&aieDevInst, XAie_TileLoc(startCol, 0), XAIE_PL_MOD, 0, startLayer);
     }
 
     build2ChannelBroadcastNetwork(hwCtxImpl, traceStartBroadcastChId1, traceStartBroadcastChId2, XAIE_EVENT_PERF_CNT_0_PL);
@@ -1604,7 +1604,7 @@ namespace xdp {
 
     if(m_trace_start_broadcast) {
       build2ChannelBroadcastNetwork(hwCtxImpl, traceStartBroadcastChId1, traceStartBroadcastChId2, interfaceTileTraceStartEvent);
-      XAie_EventGenerate(&aieDevInst, XAie_TileLoc(0, 0), XAIE_PL_MOD,  interfaceTileTraceStartEvent);
+      XAie_EventGenerate(&aieDevInst, XAie_TileLoc(startCol, 0), XAIE_PL_MOD,  interfaceTileTraceStartEvent);
     }
 
     uint8_t *txn_ptr = XAie_ExportSerializedTransaction(&aieDevInst, 1, 0);

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/client/aie_trace.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/client/aie_trace.h
@@ -99,10 +99,6 @@ namespace xdp {
       EventType interfaceTileTraceStartEvent;
       EventType interfaceTileTraceEndEvent;
 
-      // Broadcast Channels to start trace modules
-      uint8_t traceStartBroadcastId1;
-      uint8_t traceStartBroadcastId2;
-
       bool m_trace_start_broadcast;
 
       // Tile locations to apply trace end and flush

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/client/aie_trace.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/client/aie_trace.h
@@ -103,6 +103,8 @@ namespace xdp {
       uint8_t traceStartBroadcastId1;
       uint8_t traceStartBroadcastId2;
 
+      bool m_trace_start_broadcast;
+
       // Tile locations to apply trace end and flush
       std::vector<XAie_LocType> traceFlushLocs;
       std::vector<XAie_LocType> memoryTileTraceFlushLocs;

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/client/aie_trace.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/client/aie_trace.h
@@ -47,6 +47,7 @@ namespace xdp {
       bool setMetricsSettings(uint64_t deviceId, void* handle);
       bool configureWindowedEventTrace(void* handle);
       void build2ChannelBroadcastNetwork(void *handle, uint8_t broadcastId1, uint8_t broadcastId2, XAie_Events event);
+      void reset2ChannelBroadcastNetwork(void *handle, uint8_t broadcastId1, uint8_t broadcastId2);
       module_type getTileType(uint8_t row);
       uint16_t getRelativeRow(uint16_t absRow);
       uint32_t bcIdToEvent(int bcId);
@@ -97,6 +98,10 @@ namespace xdp {
       EventType memoryTileTraceEndEvent;
       EventType interfaceTileTraceStartEvent;
       EventType interfaceTileTraceEndEvent;
+
+      // Broadcast Channels to start trace modules
+      uint8_t traceStartBroadcastId1;
+      uint8_t traceStartBroadcastId2;
 
       // Tile locations to apply trace end and flush
       std::vector<XAie_LocType> traceFlushLocs;

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/client/resources_def.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/client/resources_def.h
@@ -1,0 +1,2 @@
+#define traceStartBroadcastChId1 6
+#define traceStartBroadcastChId2 7

--- a/src/runtime_src/xdp/profile/writer/vp_base/ini_parameters.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/ini_parameters.cpp
@@ -150,6 +150,9 @@ namespace xdp {
     addParameter("AIE_trace_settings.periodic_offload",
                  xrt_core::config::get_aie_trace_settings_periodic_offload(),
                  "Periodic offloading of AI Engine trace from memory to host");
+    addParameter("AIE_trace_settings.trace_start_broadcast",
+                xrt_core::config::get_aie_trace_settings_trace_start_broadcast(),
+                "Starting event trace modules using broadcast network");
     addParameter("AIE_trace_settings.reuse_buffer",
                  xrt_core::config::get_aie_trace_settings_reuse_buffer(),
                  "Enable use of circular buffer for AI Engine trace");


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Trace modules are being started at different times. Because of this, trace start can't be used to verify timer synchronization.

#### How problem was solved, alternative solutions (if any) and why they were rejected
A broadcast network is used to start the trace modules. Alternative solution is to start trace module using true event sequentially. But the differences between timers of trace modules will be hundreds of cylces. With broadcast network, the difference is too less.

#### What has been tested and how, request additional testing if necessary
On client I have verified one model. The timers were in sync and trace module starts with broadcast event.

