### PR TITLE
CR-1172979: Bounding reported maximum transfer rate in the profiling summary file

### DIFF
--- a/src/runtime_src/xdp/profile/writer/vp_base/summary_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/summary_writer.cpp
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2016-2022 Xilinx, Inc
- * Copyright (C) 2022-2023 Advanced Micro Devices, Inc - All rights reserved
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -1860,6 +1860,9 @@ namespace xdp {
         double durationMS = static_cast<double>((iter).duration) / one_million ;
         double rate = (static_cast<double>((iter).size) / one_thousand) / durationMS ;
         fout << durationMS << "," ;
+
+        if (rate > maxHostTransferRate)
+          rate = maxHostTransferRate;
         fout << rate << "," ;
       }
       fout << "\n" ;
@@ -1892,6 +1895,9 @@ namespace xdp {
         double durationMS = static_cast<double>((iter).duration) / one_million ;
         double rate = (static_cast<double>((iter).size) / one_thousand) / durationMS ;
         fout << durationMS << "," ;
+
+        if (rate > maxHostTransferRate)
+          rate = maxHostTransferRate;
         fout << rate << "," ;
       }
       fout << "\n" ;

--- a/src/runtime_src/xdp/profile/writer/vp_base/summary_writer.h
+++ b/src/runtime_src/xdp/profile/writer/vp_base/summary_writer.h
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2016-2022 Xilinx, Inc
- * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -106,6 +106,9 @@ namespace xdp {
     static constexpr double one_thousand = 1000.0 ;
     static constexpr double one_million  = 1.0e06 ;
     static constexpr double one_billion  = 1.0e09 ;
+
+    // Values used for bounding the values we report in tables
+    static constexpr double maxHostTransferRate = 10000.0; // In MB/s
 
   public:
     XDP_CORE_EXPORT SummaryWriter(const char* filename) ;


### PR DESCRIPTION
#### Problem solved by the commit
Profiling uses the time for a bo::sync operation to determine the data transfer rates between global device memory and host memory.  If a buffer object is already resident and the sync occurs, no actual data is transferred and the amount of time in the sync operation is minimal.  If this time is used along with the buffer size, it could sometimes appear that the data transfer bandwidth is extremely high such as TB/s.  This pull request caps the reported bandwidth at 10 GB/s to make sure these specific transfers aren't reporting unreasonable rates.

#### How problem was solved, alternative solutions (if any) and why they were rejected
In order to minimize the amount of data sent over the profiling hooks and keep the simple unobtrusive interface, I avoided adding checks in the XRT side of the code to tell profiling if data transfers actually occurred.  The solution keeps the current methodology of timing all sync operations individually, but caps the reported transfer rate.

#### Risks (if any) associated the changes in the commit
Low risk, as anything over 10 GB/s transfer rate was already reflecting an impossible number.

#### What has been tested and how, request additional testing if necessary
The original test in the CR has been verified to be capped.

#### Documentation impact (if any)
No documentation impact