### PR TITLE
[XDP] Fix warnings for mcdm build 

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info/aie_util.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info/aie_util.cpp
@@ -437,4 +437,22 @@ namespace xdp::aie {
     }
   }
 
+  /****************************************************************************
+   * Get the stream width in bits for specified hw_gen
+   ***************************************************************************/
+  uint32_t getStreamWidth(uint8_t hw_gen)
+  {
+    // Stream width in bits
+    static const std::unordered_map<uint8_t, uint8_t> streamWidthMap = {
+      {static_cast<uint8_t>(XDP_DEV_GEN_AIE),     static_cast<uint8_t>(32)},
+      {static_cast<uint8_t>(XDP_DEV_GEN_AIEML),   static_cast<uint8_t>(32)}
+    };
+    uint32_t default_width = 32;
+    
+    if (streamWidthMap.find(hw_gen) == streamWidthMap.end())
+      return default_width;
+    
+    return streamWidthMap.at(hw_gen);
+  }
+
 } // namespace xdp::aie

--- a/src/runtime_src/xdp/profile/database/static_info/aie_util.h
+++ b/src/runtime_src/xdp/profile/database/static_info/aie_util.h
@@ -114,6 +114,9 @@ namespace xdp::aie {
   XDP_CORE_EXPORT
   void displayColShiftInfo(uint8_t colShift);
 
+  XDP_CORE_EXPORT
+  uint32_t getStreamWidth(uint8_t hw_gen);
+
 } // namespace xdp::aie
 
 #endif

--- a/src/runtime_src/xdp/profile/device/tracedefs.h
+++ b/src/runtime_src/xdp/profile/device/tracedefs.h
@@ -147,6 +147,9 @@ constexpr uint32_t GROUP_STREAM_SWITCH_RUNNING_MASK = 0x00002222;
 constexpr uint64_t AIE_OFFSET_EDGE_CONTROL_MEM_TILE = 0x94408;
 constexpr uint64_t AIE_OFFSET_EDGE_CONTROL_MEM      = 0x14408;
 
+#define XDP_DEV_GEN_AIE     1U
+#define XDP_DEV_GEN_AIEML   2U
+
 }
 
 #endif

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/util/aie_profile_util.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/util/aie_profile_util.cpp
@@ -449,17 +449,7 @@ namespace xdp::aie::profile {
     return bcPair;
   }
 
-  /****************************************************************************
-   * Get the stream width in bits for specified hw_gen
-   ***************************************************************************/
-  uint32_t getStreamWidth(uint8_t hw_gen)
-  {
-    uint32_t default_width = 32;
-    if (streamWidthMap.find(hw_gen) == streamWidthMap.end())
-      return default_width;
-    
-    return streamWidthMap.at(hw_gen);
-  }
+
 
   /****************************************************************************
    * Convert user specified bytes to beats for provided metric set
@@ -469,7 +459,7 @@ namespace xdp::aie::profile {
     if (metricSet != "start_to_bytes_transferred")
       return bytes;
 
-    uint32_t streamWidth = getStreamWidth(hw_gen);
+    uint32_t streamWidth = aie::getStreamWidth(hw_gen);
     uint32_t total_beats = static_cast<uint32_t>(std::ceil((static_cast<double>(bytes)*8) / streamWidth));
     return total_beats; 
   }

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/util/aie_profile_util.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/util/aie_profile_util.cpp
@@ -470,7 +470,7 @@ namespace xdp::aie::profile {
       return bytes;
 
     uint32_t streamWidth = getStreamWidth(hw_gen);
-    uint32_t total_beats = std::ceil((static_cast<double>(bytes)*8) / streamWidth);
+    uint32_t total_beats = static_cast<uint32_t>(std::ceil((static_cast<double>(bytes)*8) / streamWidth));
     return total_beats; 
   }
 

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/util/aie_profile_util.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/util/aie_profile_util.h
@@ -44,13 +44,7 @@ namespace xdp::aie::profile {
     XAIE_MEM_MOD
   };
 
-  // Stream width in bits
-  const std::unordered_map<uint8_t, uint8_t> streamWidthMap = {
-    {XAIE_DEV_GEN_AIE,     32},
-    {XAIE_DEV_GEN_AIEML,   32}
-    // {XAIE_DEV_GEN_AIE2P,   64}
-    // {XAIE_DEV_GEN_AIE2PS,  64}
-  };
+
 
 
   #define START_TO_BYTES_TRANSFERRED_REPORT_EVENT_ID 3600
@@ -169,7 +163,6 @@ namespace xdp::aie::profile {
   inline bool adfAPILatencyConfigEvent(uint32_t eventID) { return INTF_TILE_LATENCY_REPORT_EVENT_ID==eventID; }
   std::pair<int, XAie_Events> getPLBroadcastChannel();
 
-  uint32_t getStreamWidth(int8_t hw_gen);
   uint32_t convertToBeats(const std::string& metricSet, uint32_t bytes, uint8_t hw_gen);
 
 }  // namespace xdp::aie::profile


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
mcdm build was failing because of recent changes.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://github.com/Xilinx/XRT/pull/8444 

#### How problem was solved, alternative solutions (if any) and why they were rejected
added an explicit static cast from double to uint32_t.
Also moved functions to edge specific files.

#### Risks (if any) associated the changes in the commit
Low
#### What has been tested and how, request additional testing if necessary
verified that mcdm/edge build passes.

#### Documentation impact (if any)
