### PR TITLE
[XDP] Multiple CRs - PLIO messaging and adding channel info to profiling payload

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_control_config_filetype.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_control_config_filetype.cpp
@@ -281,7 +281,7 @@ AIEControlConfigFiletype::getInterfaceTiles(const std::string& graphName,
         tile.subtype = type;
 
         auto it = std::find_if(tiles.begin(), tiles.end(), compareTileByLoc(tile));
-        if ((type == io_type::PLIO) && (it != allValidTiles.end())) {
+        if ((type == io_type::PLIO) && (it != tiles.end())) {
             std::string msg = "Interface tile " + std::to_string(shimCol)
                             + " supports more than one PLIO, but only one can be monitored.";
             xrt_core::message::send(severity_level::warning, "XRT", msg);

--- a/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_control_config_filetype.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_control_config_filetype.cpp
@@ -275,14 +275,21 @@ AIEControlConfigFiletype::getInterfaceTiles(const std::string& graphName,
         if ((specifiedId >= 0) && (specifiedId != idToCheck))
             continue;
 
-        tile_type tile = {0};
+        tile_type tile;
         tile.col = shimCol;
         tile.row = 0;
         tile.subtype = type;
+
+        auto it = std::find_if(tiles.begin(), tiles.end(), compareTileByLoc(tile));
+        if ((type == io_type::PLIO) && (it != allValidTiles.end())) {
+            std::string msg = "Interface tile " + std::to_string(shimCol)
+                            + " supports more than one PLIO, but only one can be monitored.";
+            xrt_core::message::send(severity_level::warning, "XRT", msg);
+        }
+
         // Grab stream ID and slave/master (used in configStreamSwitchPorts())
         tile.is_master = isMaster;
         tile.stream_id = streamId;
-
         tiles.emplace_back(std::move(tile));
     }
 

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_defs.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_defs.h
@@ -21,6 +21,9 @@ constexpr uint16_t BASE_MEMORY_COUNTER   = 1000;
 constexpr uint16_t BASE_SHIM_COUNTER     = 2000;
 constexpr uint16_t BASE_MEM_TILE_COUNTER = 3000;
 
+constexpr uint32_t PAYLOAD_IS_MASTER_SHIFT =  8;
+constexpr uint32_t PAYLOAD_BD_SIZE_SHIFT   = 16;
+
 constexpr uint32_t GROUP_DMA_MASK                   = 0x0000f000;
 constexpr uint32_t GROUP_LOCK_MASK                  = 0x55555555;
 constexpr uint32_t GROUP_CONFLICT_MASK              = 0x000000ff;

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_defs.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_defs.h
@@ -17,12 +17,13 @@
 #ifndef AIE_PROFILE_DEFS_H
 #define AIE_PROFILE_DEFS_H
 
-constexpr uint16_t BASE_MEMORY_COUNTER   = 1000;
-constexpr uint16_t BASE_SHIM_COUNTER     = 2000;
-constexpr uint16_t BASE_MEM_TILE_COUNTER = 3000;
+constexpr uint16_t BASE_MEMORY_COUNTER    = 1000;
+constexpr uint16_t BASE_SHIM_COUNTER      = 2000;
+constexpr uint16_t BASE_MEM_TILE_COUNTER  = 3000;
 
-constexpr uint32_t PAYLOAD_IS_MASTER_SHIFT =  8;
-constexpr uint32_t PAYLOAD_BD_SIZE_SHIFT   = 16;
+constexpr uint32_t PAYLOAD_IS_CHANNEL_SHIFT =  7;
+constexpr uint32_t PAYLOAD_IS_MASTER_SHIFT  =  8;
+constexpr uint32_t PAYLOAD_BD_SIZE_SHIFT    = 16;
 
 constexpr uint32_t GROUP_DMA_MASK                   = 0x0000f000;
 constexpr uint32_t GROUP_LOCK_MASK                  = 0x55555555;

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/edge/aie_profile.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/edge/aie_profile.cpp
@@ -330,31 +330,37 @@ namespace xdp {
                                          const std::string metricSet,
                                          const uint8_t channel)
   {
+    // 1. Profile API specific values
     if (aie::profile::profileAPIMetricSet(metricSet))
       return getAdfProfileAPIPayload(tile, metricSet);
     
-    // 1. Stream IDs for interface tiles
+    // 2. Channel/stream IDs for interface tiles
     if (type == module_type::shim) {
-      // NOTE: value = ((master or slave) << 8) & (stream ID)
-      return ((tile.is_master << 8) | tile.stream_id);
+      // NOTE: value = ((master or slave) << 8) & (channel/stream ID)
+      uint8_t idToReport = (tile.subtype == aie::io_type::GMIO) ? channel : tile.stream_id;
+      return ((tile.is_master << PAYLOAD_IS_MASTER_SHIFT) | idToReport);
     }
 
-    // 2. Channel IDs for memory tiles
+    // 3. Channel IDs for memory tiles
     if (type == module_type::mem_tile) {
       // NOTE: value = ((master or slave) << 8) & (channel ID)
       uint8_t isMaster = aie::isInputSet(type, metricSet) ? 1 : 0;
-      return ((isMaster << 8) | channel);
+      return ((isMaster << PAYLOAD_IS_MASTER_SHIFT) | channel);
     }
 
-    // 3. DMA BD sizes for AIE tiles
-    if ((startEvent != XAIE_EVENT_DMA_S2MM_0_FINISHED_BD_MEM)
+    // 4. DMA BD sizes for AIE tiles
+    // NOTE: value = ((max BD size) << 16) & ((master or slave) << 8) & (channel ID)
+    uint8_t isMaster = aie::isInputSet(type, metricSet) ? 1 : 0;
+    uint32_t payloadValue = ((isMaster << PAYLOAD_IS_MASTER_SHIFT) | channel);
+
+    if ((metadata->getHardwareGen() != 1)
+        || ((startEvent != XAIE_EVENT_DMA_S2MM_0_FINISHED_BD_MEM)
         && (startEvent != XAIE_EVENT_DMA_S2MM_1_FINISHED_BD_MEM)
         && (startEvent != XAIE_EVENT_DMA_MM2S_0_FINISHED_BD_MEM)
-        && (startEvent != XAIE_EVENT_DMA_MM2S_1_FINISHED_BD_MEM))
-      return 0;
+        && (startEvent != XAIE_EVENT_DMA_MM2S_1_FINISHED_BD_MEM)))
+      return payloadValue;
 
-    uint32_t payloadValue = 0;
-
+    // Get average BD size for throughput calculations (AIE1 only)
     constexpr int NUM_BDS = 8;
     constexpr uint32_t BYTES_PER_WORD = 4;
     constexpr uint32_t ACTUAL_OFFSET = 1;
@@ -375,6 +381,7 @@ namespace xdp {
                                  XAIEGBL_MEM_DMABD4CTRL_VALBD_MASK, XAIEGBL_MEM_DMABD5CTRL_VALBD_MASK,
                                  XAIEGBL_MEM_DMABD6CTRL_VALBD_MASK, XAIEGBL_MEM_DMABD7CTRL_VALBD_MASK};
 
+    uint32_t maxBDSize = 0;
     auto tileOffset = XAie_GetTileAddr(aieDevInst, row, column);
     for (int bd = 0; bd < NUM_BDS; ++bd) {
       uint32_t regValue = 0;
@@ -382,10 +389,11 @@ namespace xdp {
       
       if (regValue & valids[bd]) {
         uint32_t bdBytes = BYTES_PER_WORD * (((regValue >> lsbs[bd]) & masks[bd]) + ACTUAL_OFFSET);
-        payloadValue = std::max(bdBytes, payloadValue);
+        maxBDSize = std::max(bdBytes, maxBDSize);
       }
     }
 
+    payloadValue |= (maxBDSize << PAYLOAD_BD_SIZE_SHIFT);
     return payloadValue;
   }
   
@@ -606,14 +614,14 @@ namespace xdp {
           perfCounters.push_back(perfCounter);
 
           // Convert enums to physical event IDs for reporting purposes
-          auto physicalEventIds = getEventPhysicalId(aieDevInst,
-                                     loc, mod, type, metricSet, startEvent, endEvent);
+          auto physicalEventIds  = getEventPhysicalId(aieDevInst, loc, mod, type, 
+                                                      metricSet, startEvent, endEvent);
           uint16_t phyStartEvent = physicalEventIds.first;
           uint16_t phyEndEvent   = physicalEventIds.second;
 
           // Get payload for reporting purposes
           uint64_t payload = getCounterPayload(aieDevInst, tileMetric.first, type, col, row, 
-                                           startEvent, metricSet, channel);
+                                               startEvent, metricSet, channel);
           // Store counter info in database
           std::string counterName = "AIE Counter " + std::to_string(counterId);
           (db->getStaticInfo()).addAIECounter(deviceId, counterId, col, row, i,

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/edge/aie_profile.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/edge/aie_profile.cpp
@@ -339,7 +339,7 @@ namespace xdp {
     // 2. Channel/stream IDs for interface tiles
     if (type == module_type::shim) {
       // NOTE: value = ((master or slave) << 8) & (channel/stream ID)
-      uint8_t idToReport = (tile.subtype == aie::io_type::GMIO) ? channel : tile.stream_id;
+      uint8_t idToReport = (tile.subtype == io_type::GMIO) ? channel : tile.stream_id;
       return ((tile.is_master << PAYLOAD_IS_MASTER_SHIFT) | idToReport);
     }
 

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/edge/aie_profile.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/edge/aie_profile.cpp
@@ -22,6 +22,7 @@
 #include "xdp/profile/plugin/aie_profile/util/aie_profile_config.h"
 
 #include "xdp/profile/database/static_info/aie_util.h"
+#include "xdp/profile/database/static_info/aie_constructs.h"
 
 #include <boost/algorithm/string.hpp>
 #include <cmath>

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/edge/aie_profile.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/edge/aie_profile.cpp
@@ -338,22 +338,28 @@ namespace xdp {
     
     // 2. Channel/stream IDs for interface tiles
     if (type == module_type::shim) {
-      // NOTE: value = ((master or slave) << 8) & (channel/stream ID)
+      // NOTE: value = ((isMaster) << 8) & (isChannel << 7) & (channel/stream ID)
+      uint8_t isChannel  = (tile.subtype == io_type::GMIO) ? 1 : 0;
       uint8_t idToReport = (tile.subtype == io_type::GMIO) ? channel : tile.stream_id;
-      return ((tile.is_master << PAYLOAD_IS_MASTER_SHIFT) | idToReport);
+      return ((tile.is_master << PAYLOAD_IS_MASTER_SHIFT) 
+             | (isChannel << PAYLOAD_IS_CHANNEL_SHIFT) | idToReport);
     }
 
     // 3. Channel IDs for memory tiles
     if (type == module_type::mem_tile) {
-      // NOTE: value = ((master or slave) << 8) & (channel ID)
+      // NOTE: value = ((isMaster) << 8) & (isChannel << 7) & (channel ID)
+      uint8_t isChannel = 1;
       uint8_t isMaster = aie::isInputSet(type, metricSet) ? 1 : 0;
-      return ((isMaster << PAYLOAD_IS_MASTER_SHIFT) | channel);
+      return ((isMaster << PAYLOAD_IS_MASTER_SHIFT) 
+             | (isChannel << PAYLOAD_IS_CHANNEL_SHIFT) | channel);
     }
 
     // 4. DMA BD sizes for AIE tiles
-    // NOTE: value = ((max BD size) << 16) & ((master or slave) << 8) & (channel ID)
-    uint8_t isMaster = aie::isInputSet(type, metricSet) ? 1 : 0;
-    uint32_t payloadValue = ((isMaster << PAYLOAD_IS_MASTER_SHIFT) | channel);
+    // NOTE: value = ((max BD size) << 16) & ((isMaster) << 8) & (isChannel << 7) & (channel ID)
+    uint8_t isChannel = 1;
+    uint8_t isMaster  = aie::isInputSet(type, metricSet) ? 1 : 0;
+    uint32_t payloadValue = ((isMaster << PAYLOAD_IS_MASTER_SHIFT) 
+                            | (isChannel << PAYLOAD_IS_CHANNEL_SHIFT) | channel);
 
     if ((metadata->getHardwareGen() != 1)
         || ((startEvent != XAIE_EVENT_DMA_S2MM_0_FINISHED_BD_MEM)

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/edge/aie_profile.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/edge/aie_profile.cpp
@@ -17,6 +17,7 @@
 #define XDP_PLUGIN_SOURCE 
 
 #include "xdp/profile/plugin/aie_profile/edge/aie_profile.h"
+#include "xdp/profile/plugin/aie_profile/aie_profile_defs.h"
 #include "xdp/profile/plugin/aie_profile/util/aie_profile_util.h"
 #include "xdp/profile/plugin/aie_profile/util/aie_profile_config.h"
 

--- a/src/runtime_src/xdp/profile/plugin/vp_base/utility.cpp
+++ b/src/runtime_src/xdp/profile/plugin/vp_base/utility.cpp
@@ -60,7 +60,7 @@ namespace xdp {
 
   const char* getToolVersion()
   {
-    return "2024.1";
+    return "2024.2";
   }
 
   std::string getXRTVersion()


### PR DESCRIPTION
#### Problem solved by the commit
* No warning was given when a PLIO could not be monitored in tiles that supported more than one
* AIE profiling did not properly report channel number
* Defaults for channel numbers are not applicable for PLIO
* Byte count for start_to_bytes_transferred metric set is not parsed correctly for tile ranges
* Tool version is incorrectly reported as 2024.1

#### How problem was solved, alternative solutions (if any) and why they were rejected
* Issue warning when only one PLIO was monitored
* Include channel numbers in payload
* Correct parsing of channel number and byte count
* Update tool version
 
#### Risks (if any) associated the changes in the commit
* Changing payload also requires changes in back-end analysis tool

#### What has been tested and how, request additional testing if necessary
* Tested on vck190 and vek280

#### Documentation impact (if any)
* N/A