### PR TITLE
Change "failed" to "passed with warning" for xrt-smi validate

### DIFF
--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -1720,8 +1720,6 @@ struct misc_telemetry : request
 {
   struct data {
     uint64_t l1_interrupts;
-    uint64_t preemption_flag_set;
-    uint64_t preemption_flag_unset;
   };
 
   using result_type = data;

--- a/src/runtime_src/core/tools/common/TestRunner.cpp
+++ b/src/runtime_src/core/tools/common/TestRunner.cpp
@@ -508,8 +508,8 @@ TestRunner::result_in_range(double value, double threshold, boost::property_tree
     ptTest.put("status", test_token_passed);
   }
   else {
-    logger(ptTest, "Error", boost::str(boost::format("Benchmark value is not ~%.1f which is the expected value") % threshold));
-    ptTest.put("status", test_token_failed);
+    logger(ptTest, "Warning", boost::str(boost::format("Benchmark value is not ~%.1f which is the expected value") % threshold));
+    ptTest.put("status", test_token_passed);
   }
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Currently, we mark a testcase as failed if the benchmark result doesn't match the threshold level. We would like to change this behavior to pass but with warnings

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Internal testing; needed for RAI1.3 EA

#### How problem was solved, alternative solutions (if any) and why they were rejected
- Need to revert a query_request change so it is in sync with the targeted driver build's shim
- Change failed token to passed token

#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
Tested on Strix/MCDM

#### Documentation impact (if any)
N/A