### PR TITLE
CR-1214311 Fix xrt-smi validate crash on alveo due to query

### DIFF
--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -691,7 +691,7 @@ SubCmdValidate::execute(const SubCmdOptions& _options) const
   }
 
   //get current performance mode
-  const auto curr_mode = xrt_core::device_query<xrt_core::query::performance_mode>(device);
+  const auto curr_mode = xrt_core::device_query_default<xrt_core::query::performance_mode>(device, 0);
   //--pmode
   try {
     if (!m_pmode.empty()) {


### PR DESCRIPTION
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1214311
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Crash of xrt-smi validate due to query; discovered while regression testing.
#### How problem was solved, alternative solutions (if any) and why they were rejected
Changed the performance query to use device_query_default to prevent the crash, as asked in CR.
#### Risks (if any) associated the changes in the commit
N/A
#### What has been tested and how, request additional testing if necessary
Tested on my local Linux machine, but as I don't have all the alveo cards in the CR, please test on those cards.
#### Documentation impact (if any)
N/A