### PR TITLE
Add DRC for dpu_kernel_id of AIE_PARTITION section and m_kernel_id of IP_LAYOUT section. 

### DIFF
--- a/src/runtime_src/tools/xclbinutil/XclBinUtilMain.cxx
+++ b/src/runtime_src/tools/xclbinutil/XclBinUtilMain.cxx
@@ -522,7 +522,12 @@ int main_(int argc, const char** argv) {
     if (xclBin.findSection(ASK_GROUP_CONNECTIVITY) != nullptr)
       xclBin.removeSection("GROUP_CONNECTIVITY");
   }
-
+  
+  if (xclBin.findSection(IP_LAYOUT) != nullptr && xclBin.findSection(AIE_PARTITION) != nullptr){
+    if(!XUtil::checkAIEPartitionIPLayoutCompliance(xclBin)){
+      throw std::runtime_error("ERROR: The AIE_PARTITION section in the xclbin is not compliant with IP_LAYOUT section");
+    }
+  } 
   // Auto add GROUP_TOPOLOGY and/or GROUP_CONNECTIVITY
   if ((bSkipBankGrouping == false) &&
       (xclBin.findSection(ASK_GROUP_TOPOLOGY) == nullptr) &&

--- a/src/runtime_src/tools/xclbinutil/XclBinUtilities.cxx
+++ b/src/runtime_src/tools/xclbinutil/XclBinUtilities.cxx
@@ -32,6 +32,7 @@
 #include <iostream>
 #include <memory>
 #include <vector>
+#include <set>
 
 #if (BOOST_VERSION >= 106400)
 
@@ -909,7 +910,44 @@ transformMemoryBankGroupingCollections(const std::vector<boost::property_tree::p
   createMemoryBankGroupEntries(possibleGroupConnections, groupTopology, groupConnectivity);
 }
   
-
+bool
+XclBinUtilities::checkAIEPartitionIPLayoutCompliance(XclBin & xclbin){
+  // Get AIE_PARTITION metadata
+  std::set<std::string> allDpuKernelIDs;
+  Section *pAIEPartition = xclbin.findSection(AIE_PARTITION);
+  std::string jsonFile = pAIEPartition->getPathAndName();
+  boost::property_tree::ptree pt;
+  boost::property_tree::read_json(jsonFile, pt);
+  const boost::property_tree::ptree& ptAIEPartition = pt.get_child("aie_partition");
+  std::vector<boost::property_tree::ptree> ptPDIs = XUtil::as_vector<boost::property_tree::ptree>(ptAIEPartition, "PDIs");
+  for (const auto& pdi : ptPDIs) {
+    std::vector<boost::property_tree::ptree> ptCDOs = XUtil::as_vector<boost::property_tree::ptree>(pdi, "cdo_groups");
+    for (const auto& cdo_group : ptCDOs) {
+      std::vector<std::string> dpuKernelIDs = XUtil::as_vector_simple<std::string>(cdo_group, "dpu_kernel_ids");
+      allDpuKernelIDs.insert(dpuKernelIDs.begin(), dpuKernelIDs.end());
+    }
+  }
+                                             
+  // Get IP_LAYOUT metadata
+  Section *pIPLayout = xclbin.findSection(IP_LAYOUT);
+  boost::property_tree::ptree ptIPLayout;
+  pIPLayout->getPayload(ptIPLayout);
+  boost::property_tree::ptree ptIPData = ptIPLayout.get_child("ip_layout");
+  boost::property_tree::ptree ipDatas = ptIPData.get_child("m_ip_data");
+  for (const auto& element : ipDatas) {
+    boost::property_tree::ptree ptIPData = element.second;
+    std::string sm_type = ptIPData.get<std::string>("m_type");
+    std::string sSubType = ptIPData.get<std::string>("m_subtype", "");
+    // Check if each m_kernel_id is present in the set of all dpu_kernel_ids
+    if(sm_type == "IP_PS_KERNEL" && sSubType == "DPU"){
+      std::string sKernelId = ptIPData.get<std::string>("m_kernel_id", "");
+      if(allDpuKernelIDs.find(sKernelId) == allDpuKernelIDs.end()){
+        return false;
+      }
+    }
+  }
+  return true;   
+}
 
 void 
 XclBinUtilities::createMemoryBankGrouping(XclBin & xclbin)

--- a/src/runtime_src/tools/xclbinutil/XclBinUtilities.cxx
+++ b/src/runtime_src/tools/xclbinutil/XclBinUtilities.cxx
@@ -942,6 +942,7 @@ XclBinUtilities::checkAIEPartitionIPLayoutCompliance(XclBin & xclbin){
     if(sm_type == "IP_PS_KERNEL" && sSubType == "DPU"){
       std::string sKernelId = ptIPData.get<std::string>("m_kernel_id", "");
       if(allDpuKernelIDs.find(sKernelId) == allDpuKernelIDs.end()){
+	XUtil::TRACE("There is no matching dpu_kernel_id in AIE_PARTITION for m_kernel_id " + sKernelId + " in IP_LAYOUT");    
         return false;
       }
     }

--- a/src/runtime_src/tools/xclbinutil/XclBinUtilities.cxx
+++ b/src/runtime_src/tools/xclbinutil/XclBinUtilities.cxx
@@ -909,7 +909,9 @@ transformMemoryBankGroupingCollections(const std::vector<boost::property_tree::p
   // Group the memories
   createMemoryBankGroupEntries(possibleGroupConnections, groupTopology, groupConnectivity);
 }
-  
+
+// CR1176455: DRC to check if dpu_kernel_ids of AIE_PARTITION section matches with the m_kernel_ids of IP_LAYOUT section 
+// because the dpu_kernel_id is the key in mapping between CU and PDI.
 bool
 XclBinUtilities::checkAIEPartitionIPLayoutCompliance(XclBin & xclbin){
   // Get AIE_PARTITION metadata

--- a/src/runtime_src/tools/xclbinutil/XclBinUtilities.cxx
+++ b/src/runtime_src/tools/xclbinutil/XclBinUtilities.cxx
@@ -932,8 +932,8 @@ XclBinUtilities::checkAIEPartitionIPLayoutCompliance(XclBin & xclbin){
   Section *pIPLayout = xclbin.findSection(IP_LAYOUT);
   boost::property_tree::ptree ptIPLayout;
   pIPLayout->getPayload(ptIPLayout);
-  boost::property_tree::ptree ptIPData = ptIPLayout.get_child("ip_layout");
-  boost::property_tree::ptree ipDatas = ptIPData.get_child("m_ip_data");
+  boost::property_tree::ptree ptIPlayout = ptIPLayout.get_child("ip_layout");
+  boost::property_tree::ptree ipDatas = ptIPlayout.get_child("m_ip_data");
   for (const auto& element : ipDatas) {
     boost::property_tree::ptree ptIPData = element.second;
     std::string sm_type = ptIPData.get<std::string>("m_type");

--- a/src/runtime_src/tools/xclbinutil/XclBinUtilities.h
+++ b/src/runtime_src/tools/xclbinutil/XclBinUtilities.h
@@ -166,6 +166,7 @@ std::string getUUIDAsString( const unsigned char (&_uuid)[16] );
 int exec(const std::filesystem::path &cmd, const std::vector<std::string> &args, bool bThrow, std::ostringstream & os_stdout, std::ostringstream & os_stderr);
 void write_htonl(std::ostream & _buf, uint32_t _word32);
 
+bool checkAIEPartitionIPLayoutCompliance(XclBin & xclbin);
 void createMemoryBankGrouping(XclBin & xclbin);
 
 // temporary for 2024.1, https://jira.xilinx.com/browse/SDXFLO-6890


### PR DESCRIPTION

#### Problem solved by the commit
Need a DRC to check if dpu_kernel_ids of AIE_PARTITION section matches with the m_kernel_ids of IP_LAYOUT section because the dpu_kernel_id is the key in mapping between CU and PDI.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
For more info, refer to Tom's comments in [CR-1176455](https://jira.xilinx.com/browse/CR-1176455).

#### What has been tested and how, request additional testing if necessary
Testcases attached in [CR-1176455](https://jira.xilinx.com/browse/CR-1176455) were used to test if the DRC is triggered when the dpu_kernel_id of AIE_PARTITION metadata and m_kernel_id of IP_LAYOUT metadata are not compliant.
