### PR TITLE
Providing more detailed info and warning messages for AIE profiling f…

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_control_config_filetype.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_control_config_filetype.cpp
@@ -224,10 +224,6 @@ AIEControlConfigFiletype::getInterfaceTiles(const std::string& graphName,
                                             uint8_t minCol,
                                             uint8_t maxCol) const
 {
-    std::stringstream msg;
-    msg << "Fetching Interface tiles' specifics and details for AIE Profiling." ;
-    xrt_core::message::send(severity_level::info, "XRT", msg.str());
-
     std::vector<tile_type> tiles;
 
     auto ios = getAllIOs();
@@ -292,7 +288,7 @@ AIEControlConfigFiletype::getInterfaceTiles(const std::string& graphName,
 
     if (tiles.empty() && (specifiedId >= 0)) {
         std::string msg = "No shim tiles used specified ID " + std::to_string(specifiedId) 
-                        + ". Please specify a valid ID.";
+                        + ". Please specify a valid ID for AIE Profiling. ";
         xrt_core::message::send(severity_level::warning, "XRT", msg);
     }
 

--- a/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_control_config_filetype.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_control_config_filetype.cpp
@@ -224,6 +224,10 @@ AIEControlConfigFiletype::getInterfaceTiles(const std::string& graphName,
                                             uint8_t minCol,
                                             uint8_t maxCol) const
 {
+    std::stringstream msg;
+    msg << "Fetching Interface tiles' specifics and details for AIE Profiling." ;
+    xrt_core::message::send(severity_level::info, "XRT", msg.str());
+
     std::vector<tile_type> tiles;
 
     auto ios = getAllIOs();
@@ -287,7 +291,7 @@ AIEControlConfigFiletype::getInterfaceTiles(const std::string& graphName,
     }
 
     if (tiles.empty() && (specifiedId >= 0)) {
-        std::string msg = "No tiles used specified ID " + std::to_string(specifiedId) 
+        std::string msg = "No shim tiles used specified ID " + std::to_string(specifiedId) 
                         + ". Please specify a valid ID.";
         xrt_core::message::send(severity_level::warning, "XRT", msg);
     }


### PR DESCRIPTION
…or better understanding of users

#### Problem solved by the commit
When despite using interface tile metric sets, if there is no interface tile data showing up in the aie profile CSV. But there are no error or warning messages, which specified that the problem was with setting the interface tiles specifications for AIE Profiling. This led to difficult debugging.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Not a bug. But [CR-1196402] pointed out this inconvenience.

#### How problem was solved, alternative solutions (if any) and why they were rejected
An additional info message was included to let the user know that the problem arose during fetching the details for interface tiles for AIE Profiling.
