### PR TITLE
Enabling Async support for External Buffers

### DIFF
--- a/src/runtime_src/core/common/api/aie/xrt_graph.cpp
+++ b/src/runtime_src/core/common/api/aie/xrt_graph.cpp
@@ -204,6 +204,18 @@ public:
   {
     m_buffer_handle->sync(bos, dir, size, offset);
   }
+
+  void
+  async(std::vector<xrt::bo>& bos, xclBOSyncDirection dir, size_t size, size_t offset) const
+  {
+    m_buffer_handle->async(bos, dir, size, offset);
+  }
+
+  void
+  wait() const
+  {
+    m_buffer_handle->wait();
+  }
 };
 
 } // xrt::aie
@@ -475,10 +487,33 @@ sync(const xrt::bo& bo, xclBOSyncDirection dir, size_t size, size_t offset) cons
 
 void
 buffer::
+async(const xrt::bo& bo, xclBOSyncDirection dir, size_t size, size_t offset) const
+{
+  std::vector<xrt::bo> bos {bo};
+  return get_handle()->async(bos, dir, size, offset);
+}
+
+void
+buffer::
 sync(const xrt::bo& ping, const xrt::bo& pong, xclBOSyncDirection dir, size_t size, size_t offset) const
 {
   std::vector<xrt::bo> bos {ping,pong};
   return get_handle()->sync(bos, dir, size, offset);
+}
+
+void
+buffer::
+async(const xrt::bo& ping, const xrt::bo& pong, xclBOSyncDirection dir, size_t size, size_t offset) const
+{
+  std::vector<xrt::bo> bos {ping,pong};
+  return get_handle()->async(bos, dir, size, offset);
+}
+
+void
+buffer::
+wait() const
+{
+  return get_handle()->wait();
 }
 
 } // xrt:aie

--- a/src/runtime_src/core/common/api/aie/xrt_graph.cpp
+++ b/src/runtime_src/core/common/api/aie/xrt_graph.cpp
@@ -479,33 +479,33 @@ buffer(const xrt::hw_context& hwctx, const std::string& name)
 
 void
 buffer::
-sync(const xrt::bo& bo, xclBOSyncDirection dir, size_t size, size_t offset) const
+sync(xrt::bo bo, xclBOSyncDirection dir, size_t size, size_t offset) const
 {
-  std::vector<xrt::bo> bos {bo};
+  std::vector<xrt::bo> bos {std::move(bo)};
   return get_handle()->sync(bos, dir, size, offset);
 }
 
 void
 buffer::
-async(const xrt::bo& bo, xclBOSyncDirection dir, size_t size, size_t offset) const
+async(xrt::bo bo, xclBOSyncDirection dir, size_t size, size_t offset) const
 {
-  std::vector<xrt::bo> bos {bo};
+  std::vector<xrt::bo> bos {std::move(bo)};
   return get_handle()->async(bos, dir, size, offset);
 }
 
 void
 buffer::
-sync(const xrt::bo& ping, const xrt::bo& pong, xclBOSyncDirection dir, size_t size, size_t offset) const
+sync(xrt::bo ping, xrt::bo pong, xclBOSyncDirection dir, size_t size, size_t offset) const
 {
-  std::vector<xrt::bo> bos {ping,pong};
+  std::vector<xrt::bo> bos {std::move(ping),std::move(pong)};
   return get_handle()->sync(bos, dir, size, offset);
 }
 
 void
 buffer::
-async(const xrt::bo& ping, const xrt::bo& pong, xclBOSyncDirection dir, size_t size, size_t offset) const
+async(xrt::bo ping, xrt::bo pong, xclBOSyncDirection dir, size_t size, size_t offset) const
 {
-  std::vector<xrt::bo> bos {ping,pong};
+  std::vector<xrt::bo> bos {std::move(ping),std::move(pong)};
   return get_handle()->async(bos, dir, size, offset);
 }
 

--- a/src/runtime_src/core/common/shim/aie_buffer_handle.h
+++ b/src/runtime_src/core/common/shim/aie_buffer_handle.h
@@ -31,7 +31,7 @@ public:
   }
 
   virtual void
-  wait() const
+  wait()
   {
     throw xrt_core::error(std::errc::not_supported, __func__);
   }

--- a/src/runtime_src/core/common/shim/aie_buffer_handle.h
+++ b/src/runtime_src/core/common/shim/aie_buffer_handle.h
@@ -24,6 +24,18 @@ public:
     throw xrt_core::error(std::errc::not_supported, __func__);
   }
 
+  virtual void
+  async(std::vector<xrt::bo>&, xclBOSyncDirection, size_t, size_t)
+  {
+    throw xrt_core::error(std::errc::not_supported, __func__);
+  }
+
+  virtual void
+  wait() const
+  {
+    throw xrt_core::error(std::errc::not_supported, __func__);
+  }
+
 };
 
 } // xrt_core

--- a/src/runtime_src/core/edge/user/aie/aie_buffer_object.cpp
+++ b/src/runtime_src/core/edge/user/aie/aie_buffer_object.cpp
@@ -56,11 +56,12 @@ namespace zynqaie {
   }
 
   void
-  aie_buffer_object::wait() const
+  aie_buffer_object::wait()
   {
     if (!async_started)
       throw xrt_core::error(-EINVAL, "Asynchronous operation is not initiated. Please call 'wait' after 'async' call");
 
-    return m_aie_array->wait_gmio(name);
+    m_aie_array->wait_gmio(name);
+    async_started = false;
   }
 }

--- a/src/runtime_src/core/edge/user/aie/aie_buffer_object.cpp
+++ b/src/runtime_src/core/edge/user/aie/aie_buffer_object.cpp
@@ -48,7 +48,7 @@ namespace zynqaie {
   void
   aie_buffer_object::async(std::vector<xrt::bo>& bos, xclBOSyncDirection dir, size_t size, size_t offset)
   {
-    //TODO do we need to support multi threaded? if yes, we need to acquire lock
+    std::lock_guard<std::mutex> lock(mtx);
     if (async_started)
       throw xrt_core::error(-EINVAL, "Asynchronous operation is already initiated. Multiple 'async' calls are not supported");
 
@@ -59,6 +59,7 @@ namespace zynqaie {
   void
   aie_buffer_object::wait()
   {
+    std::lock_guard<std::mutex> lock(mtx);
     if (!async_started)
       throw xrt_core::error(-EINVAL, "Asynchronous operation is not initiated. Please call 'wait' after 'async' call");
 

--- a/src/runtime_src/core/edge/user/aie/aie_buffer_object.cpp
+++ b/src/runtime_src/core/edge/user/aie/aie_buffer_object.cpp
@@ -44,4 +44,23 @@ namespace zynqaie {
   {
     return m_aie_array->sync_bo(bos, name.c_str(), dir, size, offset);
   }
+
+  void
+  aie_buffer_object::async(std::vector<xrt::bo>& bos, xclBOSyncDirection dir, size_t size, size_t offset)
+  {
+    if (async_started)
+      throw xrt_core::error(-EINVAL, "Asynchronous operation is already initiated. Multiple 'async' calls are not supported");
+
+    async_started = true;
+    return m_aie_array->sync_bo_nb(bos, name.c_str(), dir, size, offset);
+  }
+
+  void
+  aie_buffer_object::wait() const
+  {
+    if (!async_started)
+      throw xrt_core::error(-EINVAL, "Asynchronous operation is not initiated. Please call 'wait' after 'async' call");
+
+    return m_aie_array->wait_gmio(name);
+  }
 }

--- a/src/runtime_src/core/edge/user/aie/aie_buffer_object.cpp
+++ b/src/runtime_src/core/edge/user/aie/aie_buffer_object.cpp
@@ -48,11 +48,12 @@ namespace zynqaie {
   void
   aie_buffer_object::async(std::vector<xrt::bo>& bos, xclBOSyncDirection dir, size_t size, size_t offset)
   {
+    //TODO do we need to support multi threaded? if yes, we need to acquire lock
     if (async_started)
       throw xrt_core::error(-EINVAL, "Asynchronous operation is already initiated. Multiple 'async' calls are not supported");
 
+    m_aie_array->sync_bo_nb(bos, name.c_str(), dir, size, offset);
     async_started = true;
-    return m_aie_array->sync_bo_nb(bos, name.c_str(), dir, size, offset);
   }
 
   void

--- a/src/runtime_src/core/edge/user/aie/aie_buffer_object.h
+++ b/src/runtime_src/core/edge/user/aie/aie_buffer_object.h
@@ -21,12 +21,19 @@ namespace zynqaie {
   {
     std::string name;
     std::shared_ptr<aie_array> m_aie_array;
+    bool async_started = false;
 
   public:
     aie_buffer_object(xrt_core::device* device , const xrt::uuid uuid, const char* name, const zynqaie::hwctx_object* hwctx=nullptr);
 
     void
     sync(std::vector<xrt::bo>& bos, xclBOSyncDirection dir, size_t size, size_t offset) const;
+
+    void
+    async(std::vector<xrt::bo>& bos, xclBOSyncDirection dir, size_t size, size_t offset);
+
+    void
+    wait() const;
 
     std::string
     get_name() const;

--- a/src/runtime_src/core/edge/user/aie/aie_buffer_object.h
+++ b/src/runtime_src/core/edge/user/aie/aie_buffer_object.h
@@ -21,6 +21,7 @@ namespace zynqaie {
   {
     std::string name;
     std::shared_ptr<aie_array> m_aie_array;
+    std::mutex mtx;
     bool async_started = false;
 
   public:

--- a/src/runtime_src/core/edge/user/aie/aie_buffer_object.h
+++ b/src/runtime_src/core/edge/user/aie/aie_buffer_object.h
@@ -33,7 +33,7 @@ namespace zynqaie {
     async(std::vector<xrt::bo>& bos, xclBOSyncDirection dir, size_t size, size_t offset);
 
     void
-    wait() const;
+    wait();
 
     std::string
     get_name() const;

--- a/src/runtime_src/core/include/xrt/xrt_aie.h
+++ b/src/runtime_src/core/include/xrt/xrt_aie.h
@@ -409,6 +409,23 @@ public:
   void sync(const xrt::bo& bo, xclBOSyncDirection dir, size_t size, size_t offset) const;
 
   /**
+   * async() - This function initiates an asynchronize operation to synchronize the buffer with a single xrt::bo object
+   *
+   * @param bo
+   *  The xrt::bo object to synchronize
+   * @param dir
+   *  The direction of synchronization (e.g., host to device or device to host)
+   * @param size
+   *  The size of the data to synchronize
+   * @param offset
+   *  The offset within the buffer to start synchronization
+   *
+   * This function synchronizes the buffer with the specified xrt::bo object.
+   * This configures the required BDs , enqueues the task
+   */
+  void async(const xrt::bo& bo, xclBOSyncDirection dir, size_t size, size_t offset) const;
+
+  /**
    * sync() - Synchronize buffer with two xrt::bo objects (ping-pong)
    *
    * @param ping
@@ -427,6 +444,30 @@ public:
    * completion
    */
   void sync(const xrt::bo& ping, const xrt::bo& pong, xclBOSyncDirection dir, size_t size, size_t offset) const;
+
+  /**
+   * async() - This function initiates an asynchronize operation to synchronize buffer with two xrt::bo objects (ping-pong)
+   *
+   * @param ping
+   *  The first xrt::bo object to synchronize (ping)
+   * @param pong
+   *  The second xrt::bo object to synchronize (pong)
+   * @param dir
+   *  The direction of synchronization (e.g., host to device or device to host)
+   * @param size
+   *  The size of the data to synchronize
+   * @param offset
+   *  The offset within the buffer to start synchronization
+   *
+   * This function synchronizes the buffer with the specified xrt::bo objects in a ping-pong manner.
+   * This configures the required BDs , enqueues the task
+   */
+  void async(const xrt::bo& ping, const xrt::bo& pong, xclBOSyncDirection dir, size_t size, size_t offset) const;
+
+  /**
+   * wait() - This function waits for the previously initiated async operation
+   */
+  void wait() const;
 
 };
 

--- a/src/runtime_src/core/include/xrt/xrt_aie.h
+++ b/src/runtime_src/core/include/xrt/xrt_aie.h
@@ -406,7 +406,7 @@ public:
    * This configures the required BDs , enqueues the task and wait for
    * completion
    */
-  void sync(const xrt::bo& bo, xclBOSyncDirection dir, size_t size, size_t offset) const;
+  void sync(xrt::bo bo, xclBOSyncDirection dir, size_t size, size_t offset) const;
 
   /**
    * async() - This function initiates an asynchronize operation to synchronize the buffer with a single xrt::bo object
@@ -423,7 +423,7 @@ public:
    * This function synchronizes the buffer with the specified xrt::bo object.
    * This configures the required BDs , enqueues the task
    */
-  void async(const xrt::bo& bo, xclBOSyncDirection dir, size_t size, size_t offset) const;
+  void async(xrt::bo bo, xclBOSyncDirection dir, size_t size, size_t offset) const;
 
   /**
    * sync() - Synchronize buffer with two xrt::bo objects (ping-pong)
@@ -443,7 +443,7 @@ public:
    * This configures the required BDs , enqueues the task and wait for
    * completion
    */
-  void sync(const xrt::bo& ping, const xrt::bo& pong, xclBOSyncDirection dir, size_t size, size_t offset) const;
+  void sync(xrt::bo ping, xrt::bo pong, xclBOSyncDirection dir, size_t size, size_t offset) const;
 
   /**
    * async() - This function initiates an asynchronize operation to synchronize buffer with two xrt::bo objects (ping-pong)
@@ -462,7 +462,7 @@ public:
    * This function synchronizes the buffer with the specified xrt::bo objects in a ping-pong manner.
    * This configures the required BDs , enqueues the task
    */
-  void async(const xrt::bo& ping, const xrt::bo& pong, xclBOSyncDirection dir, size_t size, size_t offset) const;
+  void async(xrt::bo ping, xrt::bo pong, xclBOSyncDirection dir, size_t size, size_t offset) const;
 
   /**
    * wait() - This function waits for the previously initiated async operation

--- a/src/runtime_src/doc/toc/xrt_native_apis.rst
+++ b/src/runtime_src/doc/toc/xrt_native_apis.rst
@@ -791,6 +791,42 @@ The following code shows a sample example with a single input/output GMIO/Extern
            auto xrt::aie::buffer out_buffer  = xrt::aie::buffer(device, uuid,"gr.out1");
            out_buffer.sync(out_bo, XCL_BO_SYNC_BO_AIE_TO_GMIO, SIZE * sizeof(float),0); 
 
+This class has overloaded member function ``xrt::aie::buffer::async(...)`` that can be used to initiate an asynchronize operation to synchronize the xrt::bo buffer object
+
+xrt::aie::buffer::async(xrt::bo bo, ...) initiate an asynchronize operation between xrt::aie::buffer (GMIO/External Buffer) & xrt::bo (Global Memory)
+
+xrt::aie::buffer::async(xrt::bo ping,xrt::bo pong, ...) initiate an asynchronize operation between xrt::aie::buffer (GMIO/External Buffer) & ping/pong xrt::bo objects
+
+xrt::aie::buffer::wait() waits for the asynchronize operation to complete
+
+The following code shows a sample example with a single input/output GMIO/External Buffer. Data gets transferred from global buffer "in_bo" to "gr.in1"
+
+.. code:: c++
+        :number-lines: 1
+
+           auto device = xrt::aie::device(0);
+           auto uuid = device.load_xclbin(xclbin-filename);
+       
+           // Create Buffer in DDR/Global memory & prepare input
+           auto in_bo  = xrt::aie::bo (device, SIZE * sizeof (float), 0, 0);
+           auto inp_bo_map = in_bo.map<float *>(); 
+           std::copy(my_float_array,my_float_array+SIZE,inp_bo_map);
+       
+           // Create Buffer in DDR/Global memory to store output
+           auto out_bo  = xrt::aie::bo (device, SIZE * sizeof (float), 0, 0);
+           auto out_bo_map = out_bo.map<float *>();
+           
+           // create GMIO/External Buffer object for input & sync from in_bo
+           auto xrt::aie::buffer in_buffer = xrt::aie::buffer(device, uuid,"gr.in1");
+           in_buffer.async(in_bo, XCL_BO_SYNC_BO_GMIO_TO_AIE, SIZE * sizeof(float),0); 
+
+           //run your graphs which uses output GMIO/External buffer
+           
+           // create GMIO/External Buffer object for output & sync from out_bo
+           auto xrt::aie::buffer out_buffer  = xrt::aie::buffer(device, uuid,"gr.out1");
+           out_buffer.async(out_bo, XCL_BO_SYNC_BO_AIE_TO_GMIO, SIZE * sizeof(float),0); 
+           out_buffer.wait();
+
 Ping Pong buffers
 ~~~~~~~~~~~~~~~~~
 The following code shows ping-pong buffer example.This shows an example with a ping/ping buffer being set on one of External buffer


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Enabling Async support for External buffers. This is a new feature.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
None

#### How problem was solved, alternative solutions (if any) and why they were rejected
We have added an Async and Wait calls on AIE buffer handle to support asynchronous buffer transfer from DDR to AIE memory

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Verified GMIO/External Buffer test cases

#### Documentation impact (if any)
Need an update to the document & Example