### PR TITLE
CR-1214311 Fix xrt-smi validate crash on Alveo

### DIFF
--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -717,6 +717,9 @@ SubCmdValidate::execute(const SubCmdOptions& _options) const
       xrt_core::device_update<xrt_core::query::performance_mode>(device.get(), xrt_core::query::performance_mode::power_type::performance);
     }
   }
+  catch(const xrt_core::query::no_such_key& e) {
+    // Do nothing, as performance mode setting is not supported
+  }
   catch(const xrt_core::error& e) {
     std::cerr << boost::format("\nERROR: %s\n") % e.what();
     printHelp();
@@ -726,8 +729,12 @@ SubCmdValidate::execute(const SubCmdOptions& _options) const
   std::ostringstream oSchemaOutput;
   bool has_failures = run_tests_on_devices(device, schemaVersion, testObjectsToRun, oSchemaOutput);
 
-  //reset pmode
-  xrt_core::device_update<xrt_core::query::performance_mode>(device.get(), static_cast<xrt_core::query::performance_mode::power_type>(curr_mode));
+  try {
+    //reset pmode
+    xrt_core::device_update<xrt_core::query::performance_mode>(device.get(), static_cast<xrt_core::query::performance_mode::power_type>(curr_mode));
+  } catch(const xrt_core::query::no_such_key& e) {
+    // Do nothing, as performance mode setting is not supported
+  }
 
   // -- Write output file ----------------------------------------------
   if (!m_output.empty()) {

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -717,7 +717,7 @@ SubCmdValidate::execute(const SubCmdOptions& _options) const
       xrt_core::device_update<xrt_core::query::performance_mode>(device.get(), xrt_core::query::performance_mode::power_type::performance);
     }
   }
-  catch(const xrt_core::query::no_such_key& e) {
+  catch (const xrt_core::query::no_such_key&) {
     // Do nothing, as performance mode setting is not supported
   }
   catch(const xrt_core::error& e) {
@@ -732,7 +732,7 @@ SubCmdValidate::execute(const SubCmdOptions& _options) const
   try {
     //reset pmode
     xrt_core::device_update<xrt_core::query::performance_mode>(device.get(), static_cast<xrt_core::query::performance_mode::power_type>(curr_mode));
-  } catch(const xrt_core::query::no_such_key& e) {
+  } catch (const xrt_core::query::no_such_key&) {
     // Do nothing, as performance mode setting is not supported
   }
 


### PR DESCRIPTION
Problem solved by the commit
https://jira.xilinx.com/browse/CR-1214311

Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Crash of xrt-smi validate due to query; discovered while regression testing. Includes more potentional fixes not caught in previous PR.

How problem was solved, alternative solutions (if any) and why they were rejected
Caught no_such_key exception in the device updates for performance mode

Risks (if any) associated the changes in the commit
N/A

What has been tested and how, request additional testing if necessary
As before, please test on the cards in the CR.
```
rchane@xsjrchane50:/proj/rdi/staff/rchane/XRT$ xrt-smi validate --batch -d 17:00 -r quick --verbose
Verbose: Enabling Verbosity
Validate Device           : [0000:17:00.1]
    Platform              : xilinx_u30_gen3x4_base_2
    SC Version            : 6.3.9
    Platform ID           : 7F2A9619-6D07-9610-DEF6-0B81EC18DBAA
-------------------------------------------------------------------------------
Running Test: ..
Test 1 [0000:17:00.1]     : aux-connection 

    Description           : Check if auxiliary power is connected
    Details               : Aux power connector is not available on this board
    Test Status           : [SKIPPED]
-------------------------------------------------------------------------------
Running Test: ..
Test 2 [0000:17:00.1]     : pcie-link 
    Description           : Check if PCIE link is active
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Running Test: .
Test 3 [0000:17:00.1]     : sc-version 
    Description           : Check if SC firmware is up-to-date
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Running Test: .
Test 4 [0000:17:00.1]     : verify 
    Description           : Run 'Hello World' kernel test
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Validation completed
```

Documentation impact (if any)
N/A