### PR TITLE
Fix for CR-1206995 : Inconsistency between the version printed by xrt-smi --version and xrt-smi examine

### DIFF
--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -731,13 +731,16 @@ get_xrt_pretty_version()
   std::stringstream ss;
   boost::property_tree::ptree pt_xrt;
   xrt_core::sysinfo::get_xrt_info(pt_xrt);
-  XBUtilities::fill_xrt_version(pt_xrt, ss);
+  const boost::property_tree::ptree available_devices = XBUtilities::get_available_devices(true);
+  XBUtilities::fill_xrt_versions(pt_xrt, ss, available_devices);
   return ss.str();
 }
 
 void 
 XBUtilities::
-fill_xrt_version(const boost::property_tree::ptree& pt_xrt, std::stringstream& output)
+fill_xrt_versions(const boost::property_tree::ptree& pt_xrt, 
+                 std::stringstream& output, 
+                 const boost::property_tree::ptree& available_devices)
 {
   boost::property_tree::ptree empty_ptree;
   output << boost::format("  %-20s : %s\n") % "Version" % pt_xrt.get<std::string>("version", "N/A");
@@ -759,7 +762,6 @@ fill_xrt_version(const boost::property_tree::ptree& pt_xrt, std::stringstream& o
     if (boost::iequals(drv_name, "xclmgmt") && boost::iequals(driver.get<std::string>("version", "N/A"), "unknown"))
       output << "WARNING: xclmgmt version is unknown. Is xclmgmt driver loaded? Or is MSD/MPD running?" << std::endl;
   }
-  const boost::property_tree::ptree available_devices = XBUtilities::get_available_devices(true);
   if (!available_devices.empty()) {
     const boost::property_tree::ptree& dev = available_devices.begin()->second;
     if (dev.get<std::string>("device_class") == xrt_core::query::device_class::enum_to_str(xrt_core::query::device_class::type::ryzen))

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -750,7 +750,7 @@ fill_xrt_version(const boost::property_tree::ptree& pt_xrt, std::stringstream& o
     std::string drv_name = driver.get<std::string>("name", "N/A");
     std::string drv_hash = driver.get<std::string>("hash", "N/A");
     if (!boost::iequals(drv_hash, "N/A")) {
-      output << boost::format("%-20s : %s, %s\n") % drv_name
+      output << boost::format("  %-20s : %s, %s\n") % drv_name
           % driver.get<std::string>("version", "N/A") % driver.get<std::string>("hash", "N/A");
     } else {
       std::string drv_version = boost::iequals(drv_name, "N/A") ? drv_name : drv_name.append(" Version");

--- a/src/runtime_src/core/tools/common/XBUtilities.h
+++ b/src/runtime_src/core/tools/common/XBUtilities.h
@@ -88,7 +88,9 @@ namespace XBUtilities {
   get_xrt_pretty_version();
 
   void
-  fill_xrt_version(const boost::property_tree::ptree& pt_xrt, std::stringstream &ss);
+  fill_xrt_versions(const boost::property_tree::ptree&, 
+                    std::stringstream&, 
+                    const boost::property_tree::ptree&);
 
   /**
    * OEM ID is a unique number called as the

--- a/src/runtime_src/core/tools/common/XBUtilities.h
+++ b/src/runtime_src/core/tools/common/XBUtilities.h
@@ -87,6 +87,9 @@ namespace XBUtilities {
   std::string
   get_xrt_pretty_version();
 
+  void
+  fill_xrt_version(const boost::property_tree::ptree& pt_xrt, std::stringstream &ss);
+
   /**
    * OEM ID is a unique number called as the
    * Private Enterprise Number (PEN) maintained by IANA

--- a/src/runtime_src/core/tools/common/reports/ReportHost.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportHost.cpp
@@ -132,7 +132,7 @@ ReportHost::writeReport(const xrt_core::device* /*_pDevice*/,
     _output << std::endl;
     _output << "XRT\n";
     std::stringstream xrt_version_ss;
-    XBUtilities::fill_xrt_version(_pt.get_child("host.xrt", empty_ptree), xrt_version_ss);
+    XBUtilities::fill_xrt_versions(_pt.get_child("host.xrt", empty_ptree), xrt_version_ss, available_devices);
     _output << xrt_version_ss.str();
   }
   catch (const boost::property_tree::ptree_error &ex) {

--- a/src/runtime_src/core/tools/common/reports/ReportHost.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportHost.cpp
@@ -131,45 +131,14 @@ ReportHost::writeReport(const xrt_core::device* /*_pDevice*/,
     _output << boost::format("  %-20s : %s\n") % "BIOS Version" % _pt.get<std::string>("host.os.bios_version");
     _output << std::endl;
     _output << "XRT\n";
-    _output << boost::format("  %-20s : %s\n") % "Version" % _pt.get<std::string>("host.xrt.version", "N/A");
-    _output << boost::format("  %-20s : %s\n") % "Branch" % _pt.get<std::string>("host.xrt.branch", "N/A");
-    _output << boost::format("  %-20s : %s\n") % "Hash" % _pt.get<std::string>("host.xrt.hash", "N/A");
-    _output << boost::format("  %-20s : %s\n") % "Hash Date" % _pt.get<std::string>("host.xrt.build_date", "N/A");
-    const boost::property_tree::ptree& available_drivers = _pt.get_child("host.xrt.drivers", empty_ptree);
-    for(auto& drv : available_drivers) {
-      const boost::property_tree::ptree& driver = drv.second;
-      std::string drv_name = driver.get<std::string>("name", "N/A");
-      std::string drv_hash = driver.get<std::string>("hash", "N/A");
-      if (!boost::iequals(drv_hash, "N/A")) {
-        _output << boost::format("  %-20s : %s, %s\n") % drv_name
-            % driver.get<std::string>("version", "N/A") % driver.get<std::string>("hash", "N/A");
-      } else {
-        std::string drv_version = boost::iequals(drv_name, "N/A") ? drv_name : drv_name.append(" Version");
-        _output << boost::format("  %-20s : %s\n") % drv_version % driver.get<std::string>("version", "N/A");
-      }
-      if (boost::iequals(drv_name, "xclmgmt") && boost::iequals(driver.get<std::string>("version", "N/A"), "unknown"))
-        _output << "WARNING: xclmgmt version is unknown. Is xclmgmt driver loaded? Or is MSD/MPD running?" << std::endl;
-    }
+    std::stringstream xrt_version_ss;
+    XBUtilities::fill_xrt_version(_pt.get_child("host.xrt", empty_ptree), xrt_version_ss);
+    _output << xrt_version_ss.str();
   }
   catch (const boost::property_tree::ptree_error &ex) {
     throw xrt_core::error(boost::str(boost::format("%s. Please contact your Xilinx representative to fix the issue")
          % ex.what()));
   }
-
-  try {
-    if (!available_devices.empty()) {
-      // This check depends on the assumption that if there is a RyzenAI device, it is on its own.
-      const boost::property_tree::ptree& dev = available_devices.begin()->second;
-      if (dev.get<std::string>("device_class") == xrt_core::query::device_class::enum_to_str(xrt_core::query::device_class::type::ryzen))
-        _output << boost::format("  %-20s : %s\n") % "NPU Firmware Version" % available_devices.begin()->second.get<std::string>("firmware_version");
-      else
-        _output << boost::format("  %-20s : %s\n") % "Firmware Version" % available_devices.begin()->second.get<std::string>("firmware_version");
-    }
-  }
-  catch (...) {
-    //no device available
-  }
-
   _output << std::endl << "Device(s) Present\n";
   if (available_devices.empty())
     _output << "  0 devices found" << std::endl;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Fixes https://jira.xilinx.com/browse/CR-1206995 : 
Inconsistency between the version printed by **xrt-smi --version** and **xrt-smi examine**

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://jira.xilinx.com/browse/CR-1206995 
https://jira.xilinx.com/browse/CR-1213621
Discovered through DSV testing

#### How problem was solved, alternative solutions (if any) and why they were rejected
The problem was solved via creating a common API for xrt-smi examine report and xrt-smi --version so they both have same behavior. Also cleans up the code
Output before fix :
```
Z:\Repos\XRT-MCDM-FORK\XRT-MCDM\build\WRelease\xilinx\xrt>xrt-smi --version
Version              : 2.18.0
Branch               : HEAD
Hash                 : 7d9b1dad15013b82fba70b16c9b03f7b3bf769e2
Hash Date            : 2024-09-21 23:06:09
NPU DRIVER           : 10.1.0.1, N/A
```
Following is the ouput after fix :
```
Z:\Repos\XRT-MCDM-FORK\XRT-MCDM\build\WRelease\xilinx\xrt>xrt-smi --version
Version              : 2.18.0
Branch               : HEAD
Hash                 : 7d9b1dad15013b82fba70b16c9b03f7b3bf769e2
Hash Date            : 2024-09-21 23:06:09
NPU Driver Version   : 10.1.0.1
NPU Firmware Version : 0.7.37.42
```

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Tested on strix and kracken boards. Needs more testing from DSV

#### Documentation impact (if any)
None
