### PR TITLE
[XDP] Multiple CRs - Correct parsing of buffer names and channel IDs

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_control_config_filetype.h
+++ b/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_control_config_filetype.h
@@ -54,6 +54,9 @@ class AIEControlConfigFiletype : public xdp::aie::BaseFiletypeImpl {
         std::vector<std::string>
         getValidKernels() const override;
 
+        std::vector<std::string>
+        getValidBuffers() const override;
+
         std::unordered_map<std::string, io_config>
         getTraceGMIOs() const;
 

--- a/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_trace_config_filetype.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_trace_config_filetype.cpp
@@ -154,7 +154,8 @@ AIETraceConfigFiletype::getMemoryTiles(const std::string& graph_name,
             // Verify this entry has desired graph/buffer combo
             for (uint32_t i=0; i < std::min(graphs.size(), buffers.size()); ++i) {
                 foundGraph  |= (graphs.at(i).find(graph_name) != std::string::npos);
-                foundBuffer |= (buffers.at(i).find(buffer_name) != std::string::npos);
+                auto currBuf = buffers.at(i).substr(buffers.at(i).find_last_of(".") + 1);
+                foundBuffer |= (currBuf == buffer_name);
                 if (foundGraph && foundBuffer)
                     break;
             }

--- a/src/runtime_src/xdp/profile/database/static_info/filetypes/base_filetype_impl.h
+++ b/src/runtime_src/xdp/profile/database/static_info/filetypes/base_filetype_impl.h
@@ -55,6 +55,9 @@ class BaseFiletypeImpl {
         virtual std::vector<std::string>
         getValidKernels() const = 0;
 
+        virtual std::vector<std::string>
+        getValidBuffers() const = 0;
+
         virtual std::unordered_map<std::string, io_config>
         getTraceGMIOs() const = 0;
 

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_metadata.cpp
@@ -261,12 +261,14 @@ namespace xdp {
       return;
     }
     
-    uint8_t rowOffset  = (mod == module_type::mem_tile) ? 1 : metadataReader->getAIETileRowOffset();
-    std::string modName = (mod == module_type::core) ? "aie" 
-                        : ((mod == module_type::dma) ? "aie_memory" : "memory_tile");
+    uint8_t rowOffset     = (mod == module_type::mem_tile) ? 1 : metadataReader->getAIETileRowOffset();
+    std::string entryName = (mod == module_type::mem_tile) ? "buffer" : "kernel";
+    std::string modName   = (mod == module_type::core) ? "aie" 
+                          : ((mod == module_type::dma) ? "aie_memory" : "memory_tile");
 
-    auto allValidGraphs = metadataReader->getValidGraphs();
-    auto allValidKernels = metadataReader->getValidKernels();
+    auto allValidGraphs  = metadataReader->getValidGraphs();
+    std::vector<std::string> allValidEntries = (mod == module_type::mem_tile) ?
+      metadataReader->getValidBuffers() : metadataReader->getValidKernels();
 
     std::set<tile_type> allValidTiles;
     auto validTilesVec = metadataReader->getTiles("all", mod, "all");
@@ -302,14 +304,14 @@ namespace xdp {
         continue;
 
       if ((graphMetrics[i][1].compare("all") != 0) &&
-          (std::find(allValidKernels.begin(), allValidKernels.end(), graphMetrics[i][1]) == allValidKernels.end())) {
+          (std::find(allValidEntries.begin(), allValidEntries.end(), graphMetrics[i][1]) == allValidEntries.end())) {
         std::stringstream msg;
-        msg << "Could not find kernel " << graphMetrics[i][1]
+        msg << "Could not find " << entryName << " " << graphMetrics[i][1]
             << " as specified in graph_based_" << modName << "_metrics setting."
-            << " The following kernels are valid : " << allValidKernels[0];
+            << " The following " << entryName << "s are valid : " << allValidEntries[0];
 
-        for (size_t j = 1; j < allValidKernels.size(); j++)
-          msg << ", " << allValidKernels[j];
+        for (size_t j = 1; j < allValidEntries.size(); j++)
+          msg << ", " << allValidEntries[j];
 
         xrt_core::message::send(severity_level::warning, "XRT", msg.str());
         continue;
@@ -343,14 +345,14 @@ namespace xdp {
         continue;
 
       if ((graphMetrics[i][1].compare("all") != 0) &&
-          (std::find(allValidKernels.begin(), allValidKernels.end(), graphMetrics[i][1]) == allValidKernels.end())) {
+          (std::find(allValidEntries.begin(), allValidEntries.end(), graphMetrics[i][1]) == allValidEntries.end())) {
         std::stringstream msg;
-        msg << "Could not find kernel " << graphMetrics[i][1]
+        msg << "Could not find " << entryName << " " << graphMetrics[i][1]
             << " as specified in graph_based_" << modName << "_metrics setting."
-            << " The following kernels are valid : " << allValidKernels[0];
+            << " The following " << entryName << "s are valid : " << allValidEntries[0];
 
-        for (size_t j = 1; j < allValidKernels.size(); j++)
-          msg << ", " << allValidKernels[j];
+        for (size_t j = 1; j < allValidEntries.size(); j++)
+          msg << ", " << allValidEntries[j];
 
         xrt_core::message::send(severity_level::warning, "XRT", msg.str());
         continue;

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_metadata.cpp
@@ -926,12 +926,9 @@ namespace xdp {
         }
       }
 
-      std::vector<tile_type> tiles;
-      if (foundChannels)
-        tiles = metadataReader->getInterfaceTiles("all", "all", metrics[i][2], channelId0, true, minCol, maxCol);
-      else
-        tiles = metadataReader->getInterfaceTiles("all", "all", metrics[i][2], -1, true, minCol, maxCol);
-
+      int16_t channelNum = (foundChannels) ? channelId0 : -1;
+      auto tiles = metadataReader->getInterfaceTiles("all", "all", metrics[i][2], channelNum, true, minCol, maxCol);
+      
       for (auto& t : tiles) {
         configMetrics[moduleIdx][t] = metrics[i][2];
         configChannel0[t] = channelId0;
@@ -967,30 +964,33 @@ namespace xdp {
         }
 
         // By-default select both the channels
+        bool foundChannels = false;
         uint8_t channelId0 = 0;
         uint8_t channelId1 = 1;
         uint32_t bytes = defaultTransferBytes;
-        if (metrics[i].size() >= 3) {
+        if (metrics[i].size() > 2) {
           if (profileAPIMetricSet(metrics[i][1])) {
             bytes = processUserSpecifiedBytes(metrics[i][2]);
           }
           else {
             try {
+              foundChannels = true;
               channelId0 = aie::convertStringToUint8(metrics[i][2]);
               channelId1 = (metrics[i].size() == 3) ? channelId0 : aie::convertStringToUint8(metrics[i][3]);
             }
             catch (std::invalid_argument const&) {
               // Expected channel Id is not an integer, give warning and ignore
+              foundChannels = false;
               xrt_core::message::send(severity_level::warning, "XRT",
-                                      "Channel ID specification in "
-                                      "tile_based_interface_tile_metrics is not an integer "
-                                      "and hence ignored.");
+                                      "Column specification in tile_based_interface_tile_metrics "
+                                      "is not an integer and hence skipped.");
             }
           }
         }
 
-        auto tiles = metadataReader->getInterfaceTiles("all", "all", metrics[i][1], channelId0, true, col, col);
-
+        int16_t channelNum = (foundChannels) ? channelId0 : -1;
+        auto tiles = metadataReader->getInterfaceTiles("all", "all", metrics[i][1], channelNum, true, col, col);
+        
         for (auto& t : tiles) {
           configMetrics[moduleIdx][t] = metrics[i][1];
           configChannel0[t] = channelId0;

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_metadata.cpp
@@ -981,9 +981,8 @@ namespace xdp {
             catch (std::invalid_argument const&) {
               // Expected channel Id is not an integer, give warning and ignore
               foundChannels = false;
-              xrt_core::message::send(severity_level::warning, "XRT",
-                                      "Column specification in tile_based_interface_tile_metrics "
-                                      "is not an integer and hence skipped.");
+              xrt_core::message::send(severity_level::warning, "XRT", "Channel ID specification "
+                "in tile_based_interface_tile_metrics is not an integer and hence ignored.");
             }
           }
         }


### PR DESCRIPTION
#### Problem solved by the commit
* Buffer names were not verified correctly in graph-based memory tile settings
* Channel IDs in single-tile settings were not parsed correctly

#### How problem was solved, alternative solutions (if any) and why they were rejected
* Gather and use valid set of buffers (instead of kernels)
* Correctly parse channel IDs from single tile settings

#### Risks (if any) associated the changes in the commit
* None

#### What has been tested and how, request additional testing if necessary
* Tested on vck190 and vek280

#### Documentation impact (if any)
* Verify that docs already describe buffer name usage