### PR TITLE
CR-1214559 `xrt-smi validate --verbose` cannot find benchmark_1502_00.json and prints "Details: Threshold is 0.0 us"

### DIFF
--- a/src/runtime_src/core/tools/common/TestRunner.cpp
+++ b/src/runtime_src/core/tools/common/TestRunner.cpp
@@ -530,7 +530,7 @@ TestRunner::set_threshold(const std::shared_ptr<xrt_core::device>& dev,
   const auto pcie_id = xrt_core::device_query<xq::pcie_id>(dev);
 
   //phoenix is not supported
-  if(xq::pcie_id::device_to_string(pcie_id).find("1500") != std::string::npos)
+  if(xq::pcie_id::device_to_string(pcie_id).find("1502") != std::string::npos)
     return;
 
   auto benchmark_fname = boost::str(boost::format("benchmark_%s_%s.json") 

--- a/src/runtime_src/core/tools/common/TestRunner.cpp
+++ b/src/runtime_src/core/tools/common/TestRunner.cpp
@@ -528,6 +528,8 @@ TestRunner::set_threshold(const std::shared_ptr<xrt_core::device>& dev,
 {
   //find the benchmark.json
   const auto pcie_id = xrt_core::device_query<xq::pcie_id>(dev);
+  if(xq::pcie_id::device_to_string(pcie_id).compare("1500") != std::string::npos)
+    return;
   auto benchmark_fname = boost::str(boost::format("benchmark_%s_%s.json") 
                             % xq::pcie_id::device_to_string(pcie_id) % xq::pcie_id::revision_to_string(pcie_id));
   auto json_config = findPlatformFile(benchmark_fname, ptTest);

--- a/src/runtime_src/core/tools/common/TestRunner.cpp
+++ b/src/runtime_src/core/tools/common/TestRunner.cpp
@@ -528,8 +528,11 @@ TestRunner::set_threshold(const std::shared_ptr<xrt_core::device>& dev,
 {
   //find the benchmark.json
   const auto pcie_id = xrt_core::device_query<xq::pcie_id>(dev);
-  if(xq::pcie_id::device_to_string(pcie_id).compare("1500") != std::string::npos)
+
+  //phoenix is not supported
+  if(xq::pcie_id::device_to_string(pcie_id).find("1500") != std::string::npos)
     return;
+
   auto benchmark_fname = boost::str(boost::format("benchmark_%s_%s.json") 
                             % xq::pcie_id::device_to_string(pcie_id) % xq::pcie_id::revision_to_string(pcie_id));
   auto json_config = findPlatformFile(benchmark_fname, ptTest);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
[CR-1214559](https://jira.xilinx.com/browse/CR-1214559) `xrt-smi validate --verbose` cannot find benchmark_1502_00.json and prints "Details: Threshold is 0.0 us"

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
DSV testing

#### How problem was solved, alternative solutions (if any) and why they were rejected
We don't support benchmark.json for phoenix, so we check if it's that. If so, we don't look for benchmark.json

#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
Tested on phx/strix

#### Documentation impact (if any)
N/A