### PR TITLE
Fix for CR-1214058

### DIFF
--- a/src/runtime_src/core/tools/common/SubCmdExamineInternal.cpp
+++ b/src/runtime_src/core/tools/common/SubCmdExamineInternal.cpp
@@ -77,7 +77,7 @@ SubCmdExamineInternal::SubCmdExamineInternal(bool _isHidden, bool _isDepricated,
   
   if (m_isUserDomain)
     m_hiddenOptions.add_options()
-      ("element,e", boost::program_options::value<decltype(m_elementsFilter)>(&m_elementsFilter)->multitoken(), "Filters individual elements(s) from the report. Format: '/<key>/<key>/...'")
+      ("element,e", boost::program_options::value<decltype(m_elementsFilter)>(&m_elementsFilter)->multitoken()->zero_tokens(), "Filters individual elements(s) from the report. Format: '/<key>/<key>/...'")
     ;
 }
 

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -480,15 +480,15 @@ SubCmdValidate::SubCmdValidate(bool _isHidden, bool _isDepricated, bool _isPreli
 
   common_options.add_options()
     ("device,d", boost::program_options::value<decltype(m_device)>(&m_device), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest")
-    ("format,f", boost::program_options::value<decltype(m_format)>(&m_format), (std::string("Report output format. Valid values are:\n") + formatOptionValues).c_str() )
-    ("output,o", boost::program_options::value<decltype(m_output)>(&m_output), "Direct the output to the given file")
-    ("pmode", boost::program_options::value<decltype(m_pmode)>(&m_pmode), "Specify which power mode to run the benchmarks in. Note: Some tests might be unavailable for some modes")
+    ("format,f", boost::program_options::value<decltype(m_format)>(&m_format)->implicit_value(""), (std::string("Report output format. Valid values are:\n") + formatOptionValues).c_str() )
+    ("output,o", boost::program_options::value<decltype(m_output)>(&m_output)->implicit_value(""), "Direct the output to the given file")
+    ("pmode", boost::program_options::value<decltype(m_pmode)>(&m_pmode)->implicit_value(""), "Specify which power mode to run the benchmarks in. Note: Some tests might be unavailable for some modes")
     ("help", boost::program_options::bool_switch(&m_help), "Help to use this sub-command")
   ;
 
   m_hiddenOptions.add_options()
     ("path,p", boost::program_options::value<decltype(m_xclbin_location)>(&m_xclbin_location)->implicit_value(""), "Path to the directory containing validate xclbins")
-    ("param", boost::program_options::value<decltype(m_param)>(&m_param), (std::string("Extended parameter for a given test. Format: <test-name>:<key>:<value>\n") + extendedKeysOptions()).c_str())
+    ("param", boost::program_options::value<decltype(m_param)>(&m_param)->implicit_value(""), (std::string("Extended parameter for a given test. Format: <test-name>:<key>:<value>\n") + extendedKeysOptions()).c_str())
   ;
 
   m_commonOptions.add(common_options);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Fixes CR-1214058 
Print before fix :
```
>xrt-smi examine -e
ERROR: the required argument for option '--element' is missing

COMMAND: examine

DESCRIPTION: This command will 'examine' the state of the system/device and will generate a report of interest
               in a text or JSON format.

USAGE: xrt-smi examine [--help] [-d arg] [-f arg] [-o arg] [-r arg]

OPTIONS:
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest
  -f, --format       - Report output format. Valid values are:
                         JSON        - Latest JSON schema
                         JSON-2020.2 - JSON 2020.2 schema
  -o, --output       - Direct the output to the given file
  --help             - Help to use this sub-command
  -r, --report       - The type of report to be produced. Reports currently available are:
                       Common:
                         all             - All known reports are produced
                         host            - Host information
                         platform        - Platforms flashed on the device
                       AIE:
                         aie-partitions  - AIE partition information
                         telemetry       - Telemetry data for the device
                       Alveo:
                         aie             - AIE metadata in xclbin
                         aiemem          - AIE memory tile information
                         aieshim         - AIE shim tile status
                         debug-ip-status - Status of Debug IPs present in xclbin loaded on device
                         dynamic-regions - Information about the xclbin and the compute units
                         electrical      - Electrical and power sensors present on the device
                         error           - Asyncronus Error present on the device
                         firewall        - Firewall status
                         mailbox         - Mailbox metrics of the device
                         mechanical      - Mechanical sensors on and surrounding the device
                         memory          - Memory information present on the device
                         pcie-info       - Pcie information of the device
                         qspi-status     - QSPI write protection status
                         thermal         - Thermal sensors present on the device

GLOBAL OPTIONS:
  -verbose           Turn on verbosity
  -batch             Enable batch mode (disables escape characters)
  -force             When possible, force an operation
ERROR: operation canceled
```
After Fix :
```
Z:\Repos\XRT-MCDM-FORK\XRT-MCDM\build\WRelease\xilinx\xrt>xrt-smi examine -e
System Configuration
  OS Name              : Windows NT
  Release              : 26100
  Machine              : x86_64
  CPU Cores            : 16
  Memory               : 64878 MB
  Distribution         : Microsoft Windows 11 Pro
  Model                : KoratPlus-KRK
  BIOS Vendor          : AMD
  BIOS Version         : WXC4703N

XRT
  Version              : 2.18.0
  Branch               : CR-1214058
  Hash                 : 8c04d6b082ddb934953e1cf18c74ea466f9886ca
  Hash Date            : 2024-10-01 15:23:01
  NPU Driver Version   : 10.1.0.1
  NPU Firmware Version : 0.7.37.42

Device(s) Present
|BDF             ||Name  |
|----------------||------|
|[00c5:00:01.1]  ||NPU   |

```
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://jira.xilinx.com/browse/CR-1214058

#### How problem was solved, alternative solutions (if any) and why they were rejected
The problem was solved by providing implicit empty values to options which are ryzenAI subcmd specific. This was we only print ryzenAI specific help.
This is a similar fix as the PR : https://github.com/Xilinx/XRT/pull/8317

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Tested on strix and kracken boards 

#### Documentation impact (if any)
None