### PR TITLE
fix for aie partition metadata file not found

### DIFF
--- a/src/runtime_src/tools/xclbinutil/XclBinUtilities.cxx
+++ b/src/runtime_src/tools/xclbinutil/XclBinUtilities.cxx
@@ -914,11 +914,12 @@ transformMemoryBankGroupingCollections(const std::vector<boost::property_tree::p
 // because the dpu_kernel_id is the key in mapping between CU and PDI.
 bool
 XclBinUtilities::checkAIEPartitionIPLayoutCompliance(XclBin & xclbin){
-  // Get AIE_PARTITION metadata
+  // Get AIE_PARTITION metadata only when AIE_PARTITION section is just added 
   std::set<std::string> allDpuKernelIDs;
   Section *pAIEPartition = xclbin.findSection(AIE_PARTITION);
   std::string jsonFile = pAIEPartition->getPathAndName();
-  // If the aie partition metadata file is not found, then no-op
+  // If the aie partition metadata file is not found,
+  // then AIE_PARTITION section has already been added hence no-op
   if(jsonFile.empty()){
     return true; 	  
   }

--- a/src/runtime_src/tools/xclbinutil/XclBinUtilities.cxx
+++ b/src/runtime_src/tools/xclbinutil/XclBinUtilities.cxx
@@ -918,6 +918,10 @@ XclBinUtilities::checkAIEPartitionIPLayoutCompliance(XclBin & xclbin){
   std::set<std::string> allDpuKernelIDs;
   Section *pAIEPartition = xclbin.findSection(AIE_PARTITION);
   std::string jsonFile = pAIEPartition->getPathAndName();
+  // If the aie partition metadata file is not found, then no-op
+  if(jsonFile.empty()){
+    return true; 	  
+  }
   boost::property_tree::ptree pt;
   boost::property_tree::read_json(jsonFile, pt);
   const boost::property_tree::ptree& ptAIEPartition = pt.get_child("aie_partition");


### PR DESCRIPTION

#### Problem solved by the commit
Fix for Flexml IVT test failure for aie partition metadata file not found error.
The xclbinutil doesn't save the file path to the AIE Partition metadata file after the session ends. Therefore, trying to access the path to this file after the AIE PARTITION has been added can lead to file not found error.   

