### PR TITLE
[XDP] Skip trace configuration for not applicable metric sets on AIE1

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_trace/edge/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/edge/aie_trace.cpp
@@ -410,6 +410,15 @@ namespace xdp {
         interfaceEvents = interfaceTileEventSets[metricSet];
       }
 
+      // Check ccore and memory events and interfaceEvents are empty & generated warning if so
+      if (coreEvents.empty() && memoryEvents.empty() && interfaceEvents.empty()) {
+        std::stringstream msg;
+        msg << "Event trace is not available for " << tileName << " using metric set "
+            << metricSet << " on hardware generation " << metadata->getHardwareGen() << ".";
+        xrt_core::message::send(severity_level::warning, "XRT", msg.str());
+        continue;
+      }
+
       // Check Resource Availability
       if (!tileHasFreeRsc(aieDevice, loc, type, metricSet)) {
         xrt_core::message::send(severity_level::warning, "XRT",


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
CR-1207551
Interface tiles sets s2mm_channel_stalls and mm2s_channels_stalls are not producing trace on AIE1.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1207551. These metrics are supported on AIE2+. A warning would now be shown to the user.

#### How problem was solved, alternative solutions (if any) and why they were rejected
These metrics are supported on AIE2+. A warning would now be shown to the user.

#### Risks (if any) associated the changes in the commit
Low
#### What has been tested and how, request additional testing if necessary
verified on vck190 that new warning is visible to applicable metric sets.

#### Documentation impact (if any)
