### PR TITLE
CR-1210069: Hardware emulation AIE profiling information lost

### DIFF
--- a/src/runtime_src/core/edge/user/plugin/xdp/shim_callbacks.h
+++ b/src/runtime_src/core/edge/user/plugin/xdp/shim_callbacks.h
@@ -47,14 +47,12 @@ void update_device(void* handle)
 #ifndef __HWEM__
   hal::update_device(handle);
   aie::update_device(handle);
+#else
+  hal::hw_emu::update_device(handle);
 #endif
 
   aie::ctr::update_device(handle);
   aie::sts::update_device(handle);
-
-#ifdef __HWEM__
-  hal::hw_emu::update_device(handle);
-#endif
 }
 
 // The flush_device callback should be called just before a new xclbin

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -1310,16 +1310,9 @@ int shim::load_hw_axlf(xclDeviceHandle handle, const xclBin *buffer, drm_zocl_cr
     drv->registerAieArray();
   #endif
 
-  #ifndef __HWEM__
-    xdp::hal::update_device(handle);
-    xdp::aie::update_device(handle);
-  #endif
-    xdp::aie::ctr::update_device(handle);
-    xdp::aie::sts::update_device(handle);
+  xdp::update_device(handle);
   #ifndef __HWEM__
     START_DEVICE_PROFILING_CB(handle);
-  #else
-    xdp::hal::hw_emu::update_device(handle);
   #endif
 
   return 0;


### PR DESCRIPTION
#### Problem solved by the commit
In hardware emulation only, when both AIE profiling and PL device trace were turned on some AIE specific information was lost and not reported in the output profiling files.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
The underlying issue was in the profiling libraries collection of data when multiple plugins are activated.  Originally, AIE profiling was processed first, which does not require a PL device interface.  Secondly, PL device offload was processed, and in the processing when the PL device interface was created, the AIE information stored was erroneously removed.

#### How problem was solved, alternative solutions (if any) and why they were rejected
The issue is resolved by changing the order in which the plugins are updated to match the working version in hardware

#### Risks (if any) associated the changes in the commit
Med risk as this is now the same approach as what happened in hardware flows which have been extensively tested, but all combinations of profiling features have not been tested.

#### What has been tested and how, request additional testing if necessary
The original failing hardware emulation tests have been tested both setting XCL_EMULATION_MODE and without.

#### Documentation impact (if any)
No documentation impact.