### PR TITLE
Fix for CR-1203102 : Pl deadlock plugin giving bad weak ptr error 

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/pl_deadlock/pl_deadlock_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/pl_deadlock/pl_deadlock_plugin.cpp
@@ -167,12 +167,7 @@ namespace xdp {
 
   void PLDeadlockPlugin::flushDevice(void* hwCtxImpl)
   {
-    xrt::hw_context hwContext = xrt_core::hw_context_int::create_hw_context_from_implementation(hwCtxImpl);
-    auto coreDevice = xrt_core::hw_context_int::get_core_device(hwContext);
-
-    auto handle = coreDevice->get_device_handle();
-
-    uint64_t deviceId = db->addDevice(util::getDebugIpLayoutPath(handle));
+    uint64_t deviceId = mHwCtxImplToDevIdMap[hwCtxImpl];
 
     mThreadCtrlMap[deviceId] = false;
     auto it = mThreadMap.find(deviceId);
@@ -181,6 +176,7 @@ namespace xdp {
       mThreadMap.erase(it);
       mThreadCtrlMap.erase(deviceId);
     }
+    mHwCtxImplToDevIdMap.erase(hwCtxImpl);
   }
 
   void PLDeadlockPlugin::updateDevice(void* hwCtxImpl)
@@ -191,6 +187,7 @@ namespace xdp {
     auto handle = coreDevice->get_device_handle();
 
     uint64_t deviceId = db->addDevice(util::getDebugIpLayoutPath(handle));
+    mHwCtxImplToDevIdMap[hwCtxImpl] = deviceId;
 
     auto it = mThreadMap.find(deviceId);
     if (it != mThreadMap.end()) {

--- a/src/runtime_src/xdp/profile/plugin/pl_deadlock/pl_deadlock_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/pl_deadlock/pl_deadlock_plugin.h
@@ -42,6 +42,7 @@ namespace xdp {
 
     std::map<uint64_t, std::thread> mThreadMap;
     std::map<uint64_t,std::atomic<bool>> mThreadCtrlMap;
+    std::unordered_map<void*, uint64_t> mHwCtxImplToDevIdMap;
 //    std::map<void*, std::thread> mThreadMap;
 //    std::map<void*,std::atomic<bool>> mThreadCtrlMap;
     std::mutex mWriteLock;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Pl deadlock plugin giving bad weak ptr error for edge devices.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Stopped creating the copy of the shared_ptr in its own destructor which was used to get the device id. Saved the device id in  update device function call at the beginning in an unordered map.

#### Risks (if any) associated the changes in the commit
Tested design with pl_deadlock enabled in xrt.ini, but couldn't test any design with pl_deadlock enabled while compilation as no such design is available in Xoah for edge devices.

#### What has been tested and how, request additional testing if necessary
Tested the design available in the CR

#### Documentation impact (if any)
NA
