### PR TITLE
Adding 2G host address offset for aie4 host shimbd patching

### DIFF
--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -186,11 +186,13 @@ struct patcher
   void
   patch57_aie4(uint32_t* bd_data_ptr, uint64_t patch)
   {
+    constexpr uint64_t ddr_aie_addr_offset = 0x80000000;
+
     uint64_t base_address =
       ((static_cast<uint64_t>(bd_data_ptr[0]) & 0x1FFFFFF) << 32) |                   // NOLINT
       bd_data_ptr[1];
 
-    base_address += patch;
+    base_address += patch + ddr_aie_addr_offset;  //2G offset
     bd_data_ptr[1] = (uint32_t)(base_address & 0xFFFFFFFF);                           // NOLINT
     bd_data_ptr[0] = (bd_data_ptr[0] & 0xFE000000) | ((base_address >> 32) & 0x1FFFFFF);// NOLINT
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
All host ddr address accessed from cert will have an 2G offset subtracted. So for  ShimBD patched by host, a 2G offset should be added.
CERT PR -  cert/pull/231

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
All host ddr address accessed from cert will have an 2G offset subtracted. So for ShimBD patched by host, a 2G offset should be added.
#### How problem was solved, alternative solutions (if any) and why they were rejected
added 2GB offset during patching 
#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
