### PR TITLE
CR-1201080 Fix -d requirement for xrt-smi on Linux

### DIFF
--- a/src/runtime_src/core/tools/common/XBMain.cpp
+++ b/src/runtime_src/core/tools/common/XBMain.cpp
@@ -59,7 +59,7 @@ void  main_(int argc, char** argv,
   globalOptions.add(globalSubCmdOptions);
 
   // Hidden Options
-  const std::string device_default = xrt_core::get_total_devices(false).first == 1 ? "default" : "";
+  const std::string device_default = xrt_core::get_total_devices(isUserDomain).first == 1 ? "default" : "";
   po::options_description hiddenOptions("Hidden Options");
   hiddenOptions.add_options()
     ("device,d",    boost::program_options::value<decltype(sDevice)>(&sDevice)->default_value(device_default)->implicit_value("default"), "If specified with no BDF value and there is only 1 device, that device will be automatically selected.\n")


### PR DESCRIPTION
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1201080
Bring Linux xrt-smi cmd line requirements for device to parity with Windows
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Discovered while testing xrt-smi on Linux amdxdna
#### How problem was solved, alternative solutions (if any) and why they were rejected
Fixed how total device check occurred to properly find the single device.
#### Risks (if any) associated the changes in the commit
Double check this on Windows! I have tried on Windows STX myself, but with RAI_1.3 on the horizon, double-check of this basic functionality of xrt-smi is vital.
#### What has been tested and how, request additional testing if necessary
Tested on PHX Linux amdxdna. You can use no "-d", "-d" by itself, and "-d" with the correct BDF.
```
rchane@xlix-birman-29:~$ xrt-smi examine -r platform

------------------------------
[0000:c3:00.1] : RyzenAI-npu1
------------------------------
Platform
  Name                   : RyzenAI-npu1
  Power Mode             : Default

Clocks
  MP-NPU Clock           : 600 MHz
  H Clock                : 1024 MHz

Power                    : 1.234 Watts

rchane@xlix-birman-29:~$ xrt-smi examine -d -r platform

------------------------------
[0000:c3:00.1] : RyzenAI-npu1
------------------------------
Platform
  Name                   : RyzenAI-npu1
  Power Mode             : Default

Clocks
  MP-NPU Clock           : 600 MHz
  H Clock                : 1024 MHz

Power                    : 1.234 Watts

rchane@xlix-birman-29:~$ xrt-smi examine -d c3:00 -r platform

------------------------------
[0000:c3:00.1] : RyzenAI-npu1
------------------------------
Platform
  Name                   : RyzenAI-npu1
  Power Mode             : Default

Clocks
  MP-NPU Clock           : 600 MHz
  H Clock                : 1024 MHz

Power                    : 1.234 Watts
```
All 3 options still work on Windows STX from my testing as well, but as said before, please double check!
#### Documentation impact (if any)
N/A