### PR TITLE
Remove any mention of clock frequencies

### DIFF
--- a/src/runtime_src/core/common/info_platform.cpp
+++ b/src/runtime_src/core/common/info_platform.cpp
@@ -421,7 +421,6 @@ add_platform_info(const xrt_core::device* device, ptree_type& pt_platform_array)
   ptree_type pt_platforms;
 
   add_static_region_info(device, pt_platform);
-  add_clock_info(device, pt_platform);
   add_status_info(device, pt_platform);
 
   const auto device_class = xrt_core::device_query_default<xrt_core::query::device_class>(device, xrt_core::query::device_class::type::alveo);
@@ -434,6 +433,7 @@ add_platform_info(const xrt_core::device* device, ptree_type& pt_platform_array)
     else
       add_controller_info(device, pt_platform);
     add_mac_info(device, pt_platform);
+    add_clock_info(device, pt_platform);
     add_config_info(device, pt_platform);
     break;
   }

--- a/src/runtime_src/core/tools/common/tests/TestGemm.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestGemm.cpp
@@ -191,7 +191,6 @@ TestGemm::run(std::shared_ptr<xrt_core::device> dev)
   if(XBU::getVerbose()) {
     logger(ptree, "Details", boost::str(boost::format("Total Duration: %.1f ns") % (ipu_hclck_period * (total_cycle_count/num_of_cores))));
     logger(ptree, "Details", boost::str(boost::format("Average cycle count: %.1f") % (total_cycle_count/num_of_cores)));
-    logger(ptree, "Details", boost::str(boost::format("NPU H-Clock: %f MHz") % ipu_hclock));
   }
 
   //check if the value is in range


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
We don't want to display clock frequencies anywhere as per customer's request. Removing clock reporting from ryzen platform and GeMM test

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Not a bug. Workaround for the upcoming EA release
Ticket to remove this workaround for GA: https://jira.xilinx.com/browse/VITIS-13557

#### How problem was solved, alternative solutions (if any) and why they were rejected
moved adding clock info to just alveo and removed freq reporting from GeMM

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
Tested on Strix
```
>xrt-smi examine -r platform

---------------------
[00c5:00:01.1] : NPU
---------------------
Platform
  Name                   : NPU
  Power Mode             : Default
  Preemption             : not supported

Power                    : 0.000 Watts


C:\Users\sagarw\Desktop\xrt>xrt-smi validate -r gemm
Validate Device           : [00c5:00:01.1]
    Platform              : NPU
    Power Mode            : Performance
-------------------------------------------------------------------------------
Verbose: Enabling Verbosity
Test 1 [00c5:00:01.1]     : gemm
    Description           : Measure the TOPS value of GEMM operations
    Benchmarks            : <>
    Details               : Threshold is 
    Xclbin                : <>
    Details               : Kernel name is 'DPU_1x4'
    DPU-Sequence          : <>
    Details               : Total Duration: 126.5 ns
                            Average cycle count: 229.0
                            TOPS: <>
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Validation completed
```

#### Documentation impact (if any)
N/A
