### PR TITLE
CR-1178512 Fix xrt setup script hang on CSH shell

### DIFF
--- a/src/runtime_src/tools/scripts/setup.csh
+++ b/src/runtime_src/tools/scripts/setup.csh
@@ -4,27 +4,23 @@
 # Copyright (C) 2019-2021 Xilinx, Inc. All rights reserved.
 #
 
-#set called=($_)
+set called=($_)
 set script_path=""
 set xrt_dir=""
 
-# revisit if there is a better way than lsof to obtain the script path
-# in non-interactive mode.  If lsof is needed, then revisit why
-# why sbin need to be prepended looks like some environment issue in
-# user shell, e.g. /usr/local/bin/mis_env: No such file or directory.
-# is because user path contain bad directories that are searched when
-# looking of lsof.
-set path=(/usr/sbin $path)
-set called=(`\lsof +p $$ |\grep setup.csh`)
+# check if script is sourced or executed
+if ("$called" != "") then
+# sourced 
+    set script=$called[2]
+else
+# executed
+    set script=$0
+endif
 
-# look for the right cmd component that contains setup.csh
-foreach x ($called)
-    if ( "$x" =~ *setup.csh ) then
-        set script_path=`readlink -f $x`
-        set xrt_dir=`dirname $script_path`
-    endif
-    if ( $xrt_dir =~ */xrt ) break
-end
+set script_rel_rootdir = `dirname $script`
+set script_path = `cd $script_rel_rootdir && pwd`
+
+set xrt_dir = $script_path
 
 if ( $xrt_dir !~ */xrt ) then
     echo "Invalid location: $xrt_dir"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
When xrt setup script is sourced on csh shell sometimes a hang is seen, this is because of the use of lsof command to get path to script.  Made changes to get script path using simpler commands instead.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Reported by user, as described in CR a hang is seen when running setup.csh script. This probably might not be hang but lsof command taking time.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Made changes to get script path when both script is either sourced or executed

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
Tested on csh shell on centos and ubuntu machines and the script works as expected.

#### Documentation impact (if any)
NA