### PR TITLE
ML Timeline support for multipartition design with multiple xclbins

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.cpp
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.cpp
@@ -125,7 +125,7 @@ namespace xdp {
 
     uint32_t numEntries = max_count;
     std::stringstream msg;
-    msg << " A maximum of " << numEntries << " record can be accommodated in given buffer of bytes size "
+    msg << "A maximum of " << numEntries << " record can be accommodated in given buffer of bytes size 0x"
         << std::hex << mBufSz << std::dec << std::endl;
     xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT", msg.str());
 
@@ -142,7 +142,7 @@ namespace xdp {
         ts64 |= (*ptr);
         if (0 == ts64 && 0 == id) {
           // Zero value for Timestamp in cycles (and id too) indicates end of recorded data
-          std::string msgEntries = " Got " + std::to_string(i) + " records in buffer";
+          std::string msgEntries = "Got " + std::to_string(i) + " records in buffer.";
           xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT", msgEntries);
           break;
         }

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.cpp
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.cpp
@@ -92,7 +92,7 @@ namespace xdp {
               "Allocated buffer In MLTimelineClientDevImpl::updateDevice");
   }
 
-  void MLTimelineClientDevImpl::finishflushDevice(void* /*hwCtxImpl*/)
+  void MLTimelineClientDevImpl::finishflushDevice(void* /*hwCtxImpl*/, uint64_t implId)
   {
     xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT", 
               "Using Allocated buffer In MLTimelineClientDevImpl::finishflushDevice");
@@ -167,14 +167,21 @@ namespace xdp {
     std::regex reg("\\\"((-?[0-9]+\\.{0,1}[0-9]*)|(null)|())\\\"(?!\\:)");
     std::string result = std::regex_replace(oss.str(), reg, "$1");
 
+    std::string outFName;
+    if (0 == implId) {
+      outFName = "record_timer_ts.json";
+    } else {
+      outFName = "record_timer_ts_" + std::to_string(implId) + ".json";
+    }
     std::ofstream fOut;
-    fOut.open("record_timer_ts.json");
+    fOut.open(outFName);
     fOut << result;
     fOut.close();
 
-    xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT", 
-              "Finished writing record_timer_ts.json in MLTimelineClientDevImpl::finishflushDevice");
-
+    std::stringstream msg1;
+    msg1 << "Finished writing " << outFName << " in MLTimelineClientDevImpl::finishflushDevice." << std::endl;
+    xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT", msg.str());
+  
     /* Delete the result BO so that AIE Profile/Debug Plugins, if enabled,
      * can use their own Debug BO to capture their data.
      */

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.h
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.h
@@ -32,7 +32,7 @@ namespace xdp {
       ~MLTimelineClientDevImpl() = default;
 
       virtual void updateDevice(void* hwCtxImpl);
-      virtual void finishflushDevice(void* hwCtxImpl, uint64_t implId);
+      virtual void finishflushDevice(void* hwCtxImpl, uint64_t implId = 0);
   };
 
 }

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.h
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.h
@@ -32,7 +32,7 @@ namespace xdp {
       ~MLTimelineClientDevImpl() = default;
 
       virtual void updateDevice(void* hwCtxImpl);
-      virtual void finishflushDevice(void* hwCtxImpl);
+      virtual void finishflushDevice(void* hwCtxImpl, uint64_t implId);
   };
 
 }

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_impl.h
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_impl.h
@@ -40,7 +40,7 @@ namespace xdp {
       virtual ~MLTimelineImpl() {}
 
       virtual void updateDevice(void*) = 0;
-      virtual void finishflushDevice(void*) = 0;
+      virtual void finishflushDevice(void*, uint64_t) = 0;
 
       void setHwContext(xrt::hw_context ctx)
       {

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_plugin.cpp
@@ -53,14 +53,14 @@ namespace xdp {
 
       } catch (const std::exception &e) {
         std::stringstream msg;
-        msg << "Invalid string specified for ML Timeline Buffer Size. "
+        msg << "Invalid string specified for ML Timeline Buffer Size. Using default size of 128KB."
             << e.what() << std::endl;
         xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", msg.str());
       }
 
     } else {
       xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT",
-                "Invalid string specified for ML Timeline Buffer Size");
+                "Invalid string specified for ML Timeline Buffer Size. Using default size of 128KB.");
     }
     return bufSz;
   }
@@ -116,8 +116,7 @@ namespace xdp {
     (db->getStaticInfo()).updateDeviceClient(deviceId, coreDevice, false);
     (db->getStaticInfo()).setDeviceName(deviceId, winDeviceName);
 
-    mMultiImpl[hwCtxImpl] = std::make_pair<uint64_t, std::unique_ptr<MLTimelineImpl>>
-                                           (implId, std::make_unique<MLTimelineClientDevImpl>(db));
+    mMultiImpl[hwCtxImpl] = std::make_pair(implId, std::make_unique<MLTimelineClientDevImpl>(db));
     auto mlImpl = mMultiImpl[hwCtxImpl].second.get();
     mlImpl->setHwContext(hwContext);
     mlImpl->setBufSize(mBufSz);
@@ -151,7 +150,7 @@ namespace xdp {
     for (auto &e : mMultiImpl) {
       if (nullptr == e.second.second)
         continue;
-      e.second.second->finishflushDevice(e.first, e.second.first)
+      e.second.second->finishflushDevice(e.first, e.second.first);
     }
     mMultiImpl.clear();
 #endif

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_plugin.cpp
@@ -24,6 +24,7 @@
 #include "core/common/api/hw_context_int.h"
 
 #include "xdp/profile/plugin/ml_timeline/ml_timeline_plugin.h"
+#include "xdp/profile/plugin/ml_timeline/ml_timeline_impl.h"
 #include "xdp/profile/plugin/vp_base/info.h"
 #include "xdp/profile/plugin/vp_base/utility.h"
 
@@ -65,14 +66,13 @@ namespace xdp {
   }
 
   MLTimelinePlugin::MLTimelinePlugin()
-    : XDPPlugin()
+    : XDPPlugin(),
+      mBufSz(0)
   {
     MLTimelinePlugin::live = true;
 
     db->registerPlugin(this);
     db->registerInfo(info::ml_timeline);
-
-    mBufSz = ParseMLTimelineBufferSizeConfig();
   }
 
   MLTimelinePlugin::~MLTimelinePlugin()
@@ -97,53 +97,63 @@ namespace xdp {
   void MLTimelinePlugin::updateDevice(void* hwCtxImpl)
   {
 #ifdef XDP_CLIENT_BUILD
-    if (mHwCtxImpl) {
-      // For client device flow, only 1 device and xclbin is supported now.
+
+    if (0 == mBufSz)
+      mBufSz = ParseMLTimelineBufferSizeConfig();
+
+    if (mMultiImpl.find(hwCtxImpl) != mMultiImpl.end()) {
+      // Same Hardware Context Implementation uses the same impl and buffer
       return;
     }
-    mHwCtxImpl = hwCtxImpl;
 
-    xrt::hw_context hwContext = xrt_core::hw_context_int::create_hw_context_from_implementation(mHwCtxImpl);
+    xrt::hw_context hwContext = xrt_core::hw_context_int::create_hw_context_from_implementation(hwCtxImpl);
     std::shared_ptr<xrt_core::device> coreDevice = xrt_core::hw_context_int::get_core_device(hwContext);
 
-    // Only one device for Client Device flow
-    uint64_t deviceId = db->addDevice("win_device");
-    (db->getStaticInfo()).updateDeviceClient(deviceId, coreDevice, false);
-    (db->getStaticInfo()).setDeviceName(deviceId, "win_device");
+    uint64_t implId = mMultiImpl.size();
 
-    DeviceDataEntry.valid = true;
-    DeviceDataEntry.implementation = std::make_unique<MLTimelineClientDevImpl>(db);
-    DeviceDataEntry.implementation->setHwContext(hwContext);
-    DeviceDataEntry.implementation->setBufSize(mBufSz);
-    DeviceDataEntry.implementation->updateDevice(mHwCtxImpl);
+    std::string winDeviceName = "win_device" + std::to_string(implId);
+    uint64_t deviceId = db->addDevice(winDeviceName);
+    (db->getStaticInfo()).updateDeviceClient(deviceId, coreDevice, false);
+    (db->getStaticInfo()).setDeviceName(deviceId, winDeviceName);
+
+    mMultiImpl[hwCtxImpl] = std::make_pair<uint64_t, std::unique_ptr<MLTimelineImpl>>
+                                           (implId, std::make_unique<MLTimelineClientDevImpl>(db));
+    auto mlImpl = mMultiImpl[hwCtxImpl].second.get();
+    mlImpl->setHwContext(hwContext);
+    mlImpl->setBufSize(mBufSz);
+    mlImpl->updateDevice(hwCtxImpl);
+
 #endif
   }
 
   void MLTimelinePlugin::finishflushDevice(void* hwCtxImpl)
   {
 #ifdef XDP_CLIENT_BUILD
-    if (!mHwCtxImpl || !DeviceDataEntry.valid) {
+    std::map<void* /*hwCtxImpl*/,
+             std::pair<uint64_t /* deviceId */, std::unique_ptr<MLTimelineImpl>>>::iterator itr;
+
+    itr = mMultiImpl.find(hwCtxImpl);
+    if (itr == mMultiImpl.end() || nullptr == itr->second.second) {
+      xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT",
+          "Cannot retrieve ML Timeline data as a new HW Context Implementation is passed.");
       return;
     }
 
-    if (hwCtxImpl != mHwCtxImpl) {
-      xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT", 
-          "Cannot retrieve ML Timeline data as a new HW Context Implementation is passed.");
-      return;
-    } 
-    DeviceDataEntry.valid = false;
-    DeviceDataEntry.implementation->finishflushDevice(mHwCtxImpl);
+    itr->second.second->finishflushDevice(hwCtxImpl, itr->second.first);
+    itr->second.second.reset(nullptr);
+
 #endif
   }
 
   void MLTimelinePlugin::writeAll(bool /*openNewFiles*/)
   {
 #ifdef XDP_CLIENT_BUILD
-    if (!mHwCtxImpl || !DeviceDataEntry.valid) {
-      return;
+    for (auto &e : mMultiImpl) {
+      if (nullptr == e.second.second)
+        continue;
+      e.second.second->finishflushDevice(e.first, e.second.first)
     }
-    DeviceDataEntry.valid = false;
-    DeviceDataEntry.implementation->finishflushDevice(mHwCtxImpl);
+    mMultiImpl.clear();
 #endif
   }
 

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_plugin.h
@@ -17,11 +17,14 @@
 #ifndef XDP_ML_TIMELINE_PLUGIN_H
 #define XDP_ML_TIMELINE_PLUGIN_H
 
-#include "xdp/profile/plugin/ml_timeline/ml_timeline_impl.h"
 #include "xdp/profile/plugin/vp_base/vp_base_plugin.h"
 
+#include <map>
+#include <pair>
 
 namespace xdp {
+
+  class MLTimelineImpl;
 
   class MLTimelinePlugin : public XDPPlugin
   {
@@ -41,14 +44,9 @@ namespace xdp {
     private:
     static bool live;
 
-    struct DeviceData {
-      bool valid;
-      std::unique_ptr<MLTimelineImpl> implementation;
-    } DeviceDataEntry;
-
-    void* mHwCtxImpl = nullptr;
-    uint32_t mBufSz  = 0x20000;
-
+    uint32_t mBufSz;
+    std::map<void* /*hwCtxImpl*/,
+             std::pair<uint64_t /* deviceId */, std::unique_ptr<MLTimelineImpl>>> mMultiImpl;
   };
 
 } // end namespace xdp

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_plugin.h
@@ -20,7 +20,6 @@
 #include "xdp/profile/plugin/vp_base/vp_base_plugin.h"
 
 #include <map>
-#include <pair>
 
 namespace xdp {
 


### PR DESCRIPTION
#### Problem solved by the commit
For design with multiple subgraphs each with a separate xclbin, currently ML Timeline only captures timestamps for the xclbin loaded first.
This PR adds support for generating separate output files with timestamps for separate subgraphs in separate xclbins
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Unit tests
#### Documentation impact (if any)
