### PR TITLE
CR-1214337 CR-1210284  : Fix function that checks if xclbin is aie_only xclbin

### DIFF
--- a/src/runtime_src/core/common/xclbin_parser.cpp
+++ b/src/runtime_src/core/common/xclbin_parser.cpp
@@ -1089,18 +1089,14 @@ get_kernels(const axlf* top)
   return get_kernels(xml.first, xml.second);
 }
 
-// PDI only XCLBIN has PDI section only;
-// Or has AIE_METADATA and PDI sections only
+// AIE only xclbin has LOAD_AIE action mask
 bool
-is_pdi_only(const axlf* top)
+is_aie_only(const axlf* top)
 {
-  auto pdi = axlf_section_type<const char*>::get(top, axlf_section_kind::PDI);
-  auto aie_meta = axlf_section_type<const char*>::get(top, axlf_section_kind::AIE_METADATA);
-  auto aie_res = axlf_section_type<const char*>::get(top, axlf_section_kind::AIE_RESOURCES);
+  if ((top->m_header.m_actionMask & AM_LOAD_AIE))
+    return true;
 
-  return ((top->m_header.m_numSections == 1 && pdi != nullptr)
-          || (top->m_header.m_numSections == 2 && pdi != nullptr && aie_meta != nullptr)
-          || (top->m_header.m_numSections == 3 && pdi != nullptr && aie_meta != nullptr && aie_res != nullptr));
+  return false;
 }
 
 std::string

--- a/src/runtime_src/core/common/xclbin_parser.h
+++ b/src/runtime_src/core/common/xclbin_parser.h
@@ -391,11 +391,11 @@ std::vector<kernel_object>
 get_kernels(const axlf* top);
 
 /**
- * is_pdi_only() - If the xclbin has only one section and is PDI
+ * is_aie_only() - check if xclbin passed is aie only xclbin
  */
 XRT_CORE_COMMON_EXPORT
 bool
-is_pdi_only(const axlf* top);
+is_aie_only(const axlf* top);
 
 /**
  * get_vbnv() - Get VBNV of xclbin

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -505,7 +505,7 @@ xclLoadXclBin(const xclBin *buffer)
   auto top = reinterpret_cast<const axlf*>(buffer);
   auto ret = xclLoadAxlf(top);
 
-  if (!ret && !xrt_core::xclbin::is_pdi_only(top))
+  if (!ret && !xrt_core::xclbin::is_aie_only(top))
     mKernelClockFreq = xrt_core::xclbin::get_kernel_freq(top);
 
   xclLog(XRT_INFO, "%s: return %d", __func__, ret);
@@ -747,7 +747,7 @@ xclLoadAxlf(const axlf *buffer)
 
   axlf_obj.kds_cfg.polling = xrt_core::config::get_ert_polling();
   std::vector<char> krnl_binary;
-  if (!xrt_core::xclbin::is_pdi_only(buffer)) {
+  if (!xrt_core::xclbin::is_aie_only(buffer)) {
     auto kernels = xrt_core::xclbin::get_kernels(buffer);
     /* Calculate size of kernels */
     for (auto& kernel : kernels) {
@@ -1239,7 +1239,7 @@ int shim::prepare_hw_axlf(const axlf *buffer, struct drm_zocl_axlf *axlf_obj)
   axlf_obj->kds_cfg.polling = xrt_core::config::get_ert_polling();
 
   std::vector<char> krnl_binary;
-  if (!xrt_core::xclbin::is_pdi_only(buffer)) {
+  if (!xrt_core::xclbin::is_aie_only(buffer)) {
     auto kernels = xrt_core::xclbin::get_kernels(buffer);
     /* Calculate size of kernels */
     for (auto& kernel : kernels) {
@@ -2521,7 +2521,7 @@ xclLoadXclBinImpl(xclDeviceHandle handle, const xclBin *buffer, bool meta)
 #endif
 
     /* If PDI is the only section, return here */
-    if (xrt_core::xclbin::is_pdi_only(buffer)) {
+    if (xrt_core::xclbin::is_aie_only(buffer)) {
         // Update the profiling library with the information on this new AIE xclbin
         // configuration on this device as appropriate (when profiling is enabled).
         xdp::update_device(handle);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Added changes to function that checks if given xclbin is aie only xclbin.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
With latest vitis new section AIE_TRACE_METADATA is added to aie only xclbin and the existing check fails and throws exception when we download aie onky xclbins.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Checking action mask LOAD_AIE for identifying if its aie only xclbin.
The existing solution is not scalable.

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
Tested with the testcases provided in the CR and they work as expected after making this change.

#### Documentation impact (if any)
NA