### PR TITLE
Modified zocl_free_bo and zocl_gem_prime_get_sg_table functions to check for mm_node.

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/common/zocl_bo.c
+++ b/src/runtime_src/core/edge/drm/zocl/common/zocl_bo.c
@@ -400,7 +400,7 @@ free:
 struct sg_table *zocl_gem_prime_get_sg_table(struct drm_gem_object *obj)
 {
         struct drm_zocl_bo *zocl_obj = to_zocl_bo(obj);
-	if (zocl_obj && (zocl_obj->flags & ZOCL_BO_FLAGS_CMA)) {
+	if (zocl_obj && !(zocl_obj->mm_node)) {
 		return drm_gem_dma_get_sg_table(&zocl_obj->cma_base);
 	}
         struct drm_device *drm = obj->dev;

--- a/src/runtime_src/core/edge/drm/zocl/common/zocl_drv.c
+++ b/src/runtime_src/core/edge/drm/zocl/common/zocl_drv.c
@@ -586,7 +586,7 @@ void zocl_free_bo(struct drm_gem_object *obj)
 			zocl_free_userptr_bo(obj);
 		else if (zocl_obj->flags & ZOCL_BO_FLAGS_HOST_BO)
 			zocl_free_host_bo(obj);
-		else if (zocl_obj->flags & ZOCL_BO_FLAGS_CMA) {
+		else if (!zocl_obj->mm_node) {
 			/* Update memory usage statistics */
 			zocl_update_mem_stat(zdev, obj->size, -1,
 			    zocl_obj->mem_index);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
 In this [PR-259](https://github.com/Xilinx/XRT/pull/8259) zocl_gem_import funciton is removed which updates ZOCL_BO_FLAGS_CMA. we need to update few funcitons to check for mm_node instead of ZOCL_BO_FLAGS_CMA.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Modified zocl_free_bo and zocl_gem_prime_get_sg_table functions to check for mm_node.

#### Risks (if any) associated the changes in the commit
low

#### What has been tested and how, request additional testing if necessary
Tested on vek280.

#### Documentation impact (if any)