### PR TITLE
Pass in correct type for force-preemption

### DIFF
--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -3750,7 +3750,7 @@ struct performance_mode : request
 
 /*
  * this request force enables or disables pre-emption globally
- * 0: enable; 1: disable
+ * 1: enable; 0: disable
 */
 struct preemption : request
 {

--- a/src/runtime_src/core/tools/xbutil2/OO_Preemption.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_Preemption.cpp
@@ -85,10 +85,10 @@ OO_Preemption::execute(const SubCmdOptions& _options) const
 
   try {
     if (boost::iequals(m_action, "enable")) {
-      xrt_core::device_update<xrt_core::query::preemption>(device.get(), 0); // default
+      xrt_core::device_update<xrt_core::query::preemption>(device.get(), static_cast<uint32_t>(1)); // default
     }
     else if (boost::iequals(m_action, "disable")) {
-      xrt_core::device_update<xrt_core::query::preemption>(device.get(), 1);
+      xrt_core::device_update<xrt_core::query::preemption>(device.get(), static_cast<uint32_t>(0));
     }
     else {
       throw xrt_core::error(boost::str(boost::format("Invalid force-preemption value: '%s'\n") % m_action));


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Simply passing int was not working as the driver and shim layer needs uint32_t

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Internal

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
Tested on Strix

#### Documentation impact (if any)
N/A