### PR TITLE
Catch all the exceptions when firmware version is not present.

### DIFF
--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -762,11 +762,17 @@ fill_xrt_versions(const boost::property_tree::ptree& pt_xrt,
     if (boost::iequals(drv_name, "xclmgmt") && boost::iequals(driver.get<std::string>("version", "N/A"), "unknown"))
       output << "WARNING: xclmgmt version is unknown. Is xclmgmt driver loaded? Or is MSD/MPD running?" << std::endl;
   }
-  if (!available_devices.empty()) {
-    const boost::property_tree::ptree& dev = available_devices.begin()->second;
-    if (dev.get<std::string>("device_class") == xrt_core::query::device_class::enum_to_str(xrt_core::query::device_class::type::ryzen))
-      output << boost::format("  %-20s : %s\n") % "NPU Firmware Version" % available_devices.begin()->second.get<std::string>("firmware_version");
-    else
-      output << boost::format("  %-20s : %s\n") % "Firmware Version" % available_devices.begin()->second.get<std::string>("firmware_version");
+
+  try {
+    if (!available_devices.empty()) {
+       const boost::property_tree::ptree& dev = available_devices.begin()->second;
+       if (dev.get<std::string>("device_class") == xrt_core::query::device_class::enum_to_str(xrt_core::query::device_class::type::ryzen))
+         output << boost::format("  %-20s : %s\n") % "NPU Firmware Version" % available_devices.begin()->second.get<std::string>("firmware_version");
+       else
+         output << boost::format("  %-20s : %s\n") % "Firmware Version" % available_devices.begin()->second.get<std::string>("firmware_version");
+    }
+  }
+  catch (...) {
+    //no device available
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1215698 No such node (firmware_version) in 'xbmgmt examine' output.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
After reverting to golden image, xbmgmt examine is not showing the shell name.

#### How problem was solved, alternative solutions (if any) and why they were rejected
This change will catch all type of exception when firmware info is not present.

#### Risks (if any) associated the changes in the commit
low
#### What has been tested and how, request additional testing if necessary
Tested with U250.

#### Documentation impact (if any)
NA