### PR TITLE
Capture and Replay: Fix repeated loading of capture lib via LD_PRELOAD

### DIFF
--- a/src/runtime_src/core/tools/xbtracer/src/lib/capture.cpp
+++ b/src/runtime_src/core/tools/xbtracer/src/lib/capture.cpp
@@ -187,6 +187,11 @@ class router
   {
     load_symbols();
     load_func_addr();
+    /**
+     * Unseting the LD_PRELOAD to avoid the multiple instance of loading same library.
+     */
+    // NOLINTNEXTLINE(concurrency-mt-unsafe)
+    unsetenv("LD_PRELOAD");
   }
 
   ~router()
@@ -226,7 +231,7 @@ static std::string demangle(const char* mangled_name)
               "std::allocator<char> >", "std::string"},
         {"[abi:cxx11]", ""},
         {"std::map<std::string, unsigned int, std::less<std::string >, "
-            "std::allocator<std::pair<std::string const, unsigned int> > >", 
+            "std::allocator<std::pair<std::string const, unsigned int> > >",
             "xrt::hw_context::cfg_param_type"}
       };
 


### PR DESCRIPTION
Issue: xrt_capture.so is getting loaded multiple times since LD_PRELOAD is set in Parent process and then the same environment is passed to child process.  

Fix: In Parent process we need not set the LD_PRELOAD since it is required only for child process and once xrt_capture.so is loaded we unset the LD_PRELOAD variable. 
