### PR TITLE
Fix for crash in xrt-smi validate with ML Timeline enabled

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.h
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.h
@@ -25,7 +25,7 @@ namespace xdp {
   class ResultBOContainer;
   class MLTimelineClientDevImpl : public MLTimelineImpl
   {
-    ResultBOContainer* mResultBOHolder;
+    std::unique_ptr<ResultBOContainer> mResultBOHolder;
     public :
       MLTimelineClientDevImpl(VPDatabase* dB);
 

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_impl.h
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_impl.h
@@ -27,7 +27,6 @@ namespace xdp {
   {
     protected :
       VPDatabase* db = nullptr;
-      xrt::hw_context mHwContext;
       uint32_t mBufSz;
 
     public:
@@ -42,11 +41,6 @@ namespace xdp {
       virtual void updateDevice(void*) = 0;
       virtual void finishflushDevice(void*, uint64_t) = 0;
 
-      void setHwContext(xrt::hw_context ctx)
-      {
-        mHwContext = std::move(ctx);
-      }
-      
       void setBufSize(uint32_t sz)
       {
         mBufSz = sz;

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_plugin.cpp
@@ -160,7 +160,7 @@ namespace xdp {
     }
     mMultiImpl.clear();
     xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT",
-        "In ML Timeline Plugin : All data have been dumped."
+        "In ML Timeline Plugin : All data have been dumped.");
 #endif
   }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Recent enhancement in ML Timeline Plugin to support multi-partition multiple xclbin causes 
xrt-smi validate -r latency to terminate abnormally when ML Timeline is enabled in xrt.ini.
The actual issue looks like due to some race condition between destruction of ML Timeline Plugin static object and Hardware Context, which in turn triggers ML Timeline Plugin data flush hook. This is now fixed with additional checks and preventive status setting in ML Timeline Plugin.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1216436
Unit test running xrt-smi validate -r latency with ML Timeline enabled, started failing in Win Client Pipeline

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
ML tests and xrt-smi validate with ML Timeline enabled

#### Documentation impact (if any)
