### PR TITLE
[XDP] CR-1215560 - Report column shift in static data of profile report

### DIFF
--- a/build/petalinux.build
+++ b/build/petalinux.build
@@ -1,3 +1,4 @@
 # When updating Petalinux build please file a SH ticket to retain the build
 # https://jira.xilinx.com/secure/CreateIssue!default.jspa
+#PETALINUX="/proj/petalinux/2024.2/petalinux-v2024.2_08282319/tool/petalinux-v2024.2-final"
 PETALINUX=/proj/petalinux/2024.2/petalinux-v2024.2_10031251/tool/petalinux-v2024.2-final

--- a/build/petalinux.build
+++ b/build/petalinux.build
@@ -1,4 +1,3 @@
 # When updating Petalinux build please file a SH ticket to retain the build
 # https://jira.xilinx.com/secure/CreateIssue!default.jspa
-#PETALINUX="/proj/petalinux/2024.2/petalinux-v2024.2_08282319/tool/petalinux-v2024.2-final"
 PETALINUX=/proj/petalinux/2024.2/petalinux-v2024.2_10031251/tool/petalinux-v2024.2-final

--- a/src/runtime_src/xdp/profile/writer/aie_profile/aie_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/aie_profile/aie_writer.cpp
@@ -57,8 +57,7 @@ namespace xdp {
   void AIEProfilingWriter::writeMetricSettings()
   {
     auto metadataReader = (db->getStaticInfo()).getAIEmetadataReader();
-    uint8_t col_partition_shift = metadataReader->getPartitionOverlayStartCols().front();
-    std::cout << "!!! col_partition_shift: " << +col_partition_shift << std::endl;
+    uint8_t col_shift = metadataReader->getPartitionOverlayStartCols().front();
     auto validConfig = (db->getStaticInfo()).getProfileConfig();
 
     std::map<module_type, std::vector<std::string>> filteredConfig;
@@ -72,7 +71,7 @@ namespace xdp {
 
       const auto& validMetrics = configMetrics[i];
       for(auto &elm : validMetrics) {
-        metrics.push_back(std::to_string(+elm.first.col+col_partition_shift) + "," + \
+        metrics.push_back(std::to_string(+(elm.first.col+col_shift)) + "," + \
                           aie::getRelativeRowStr(elm.first.row, validConfig.tileRowOffset) \
                           + "," + elm.second);
         if (i == module_type::shim && elm.second == METRIC_BYTE_COUNT) {

--- a/src/runtime_src/xdp/profile/writer/aie_profile/aie_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/aie_profile/aie_writer.cpp
@@ -56,6 +56,9 @@ namespace xdp {
 
   void AIEProfilingWriter::writeMetricSettings()
   {
+    auto metadataReader = (db->getStaticInfo()).getAIEmetadataReader();
+    uint8_t col_partition_shift = metadataReader->getPartitionOverlayStartCols().front();
+    std::cout << "!!! col_partition_shift: " << +col_partition_shift << std::endl;
     auto validConfig = (db->getStaticInfo()).getProfileConfig();
 
     std::map<module_type, std::vector<std::string>> filteredConfig;
@@ -69,7 +72,7 @@ namespace xdp {
 
       const auto& validMetrics = configMetrics[i];
       for(auto &elm : validMetrics) {
-        metrics.push_back(std::to_string(+elm.first.col) + "," + \
+        metrics.push_back(std::to_string(+elm.first.col+col_partition_shift) + "," + \
                           aie::getRelativeRowStr(elm.first.row, validConfig.tileRowOffset) \
                           + "," + elm.second);
         if (i == module_type::shim && elm.second == METRIC_BYTE_COUNT) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
CR-1215560 - column shift in static data of profile report is missing. This was further causing vitis analyzer to not display any columns.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1215560

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added column partition for report static data.

#### Risks (if any) associated the changes in the commit
Low
#### What has been tested and how, request additional testing if necessary
Verified on vck190.
I will verify for XSDB as well & make it uniform if not already.

#### Documentation impact (if any)
