### PR TITLE
Don't call explicit reset for aie array in shim destruction

### DIFF
--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -130,10 +130,6 @@ shim(unsigned index)
 shim::
 ~shim()
 {
-#ifdef XRT_ENABLE_AIE
-  if (m_aie_array)  // Aie cleanup should be done before shim destroyed
-    m_aie_array.reset();
-#endif
 
   xclLog(XRT_INFO, "%s", __func__);
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Not calling explicit reset for aie array in shim destruction

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Explicit destruction is causing some regressions. Will fix the ownership in next PR

#### How problem was solved, alternative solutions (if any) and why they were rejected
Not calling explicit reset for aie array in shim destruction

#### Risks (if any) associated the changes in the commit
None
#### What has been tested and how, request additional testing if necessary
Verified profiling cases and basic emulation cases

#### Documentation impact (if any)
None