### PR TITLE
Enabling external buffer support. AIE driver change is now available in latest Petalinux

### DIFF
--- a/build/petalinux.build
+++ b/build/petalinux.build
@@ -1,3 +1,3 @@
 # When updating Petalinux build please file a SH ticket to retain the build
 # https://jira.xilinx.com/secure/CreateIssue!default.jspa
-PETALINUX=/proj/petalinux/2024.2/petalinux-v2024.2_10031251/tool/petalinux-v2024.2-final
+PETALINUX=/proj/petalinux/2024.2/petalinux-v2024.2_10101427/tool/petalinux-v2024.2-final

--- a/src/runtime_src/core/edge/user/aie/common_layer/adf_runtime_api.cpp
+++ b/src/runtime_src/core/edge/user/aie/common_layer/adf_runtime_api.cpp
@@ -920,9 +920,7 @@ err_code dma_api::updateBDAddressLin(XAie_MemInst* memInst , uint8_t column, uin
   int driverStatus = XAIE_OK;
   XAie_LocType tileLoc = XAie_TileLoc(column, relativeToAbsoluteRow(1, row));
 
-  // uncomment below line once latest Petalinux is available
-//  driverStatus |= XAie_DmaUpdateBdAddrOff(memInst, tileLoc ,offset, bdId);
-
+  driverStatus |= XAie_DmaUpdateBdAddrOff(memInst, tileLoc ,offset, bdId);
 
   if (driverStatus != AieRC::XAIE_OK)
     return errorMsg(err_code::aie_driver_error, "ERROR: adf::dma_api::updateBDAddressLin: AIE driver error.");


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Uncommenting the core logic of external buffers as AIE driver change is now available in latest Petalinux

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
None. This is new feature

#### How problem was solved, alternative solutions (if any) and why they were rejected
Enabled the external buffer core logic

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Verified external buffers/gmio tests

#### Documentation impact (if any)
None. Already documented