### PR TITLE
Fixed multi-partition issue where create/destroy/create/destroy hw_context flow is not working

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/edge/zocl_edge_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/edge/zocl_edge_xclbin.c
@@ -192,6 +192,10 @@ zocl_xclbin_read_axlf(struct drm_zocl_dev *zdev, struct drm_zocl_axlf *axlf_obj,
 
 	/* Free sections before load the new xclbin */
 	zocl_free_sections(zdev, slot);
+	
+	/* Destroy the aie information from slot and create new */
+	zocl_destroy_aie(slot);
+
 
 #if KERNEL_VERSION(5, 4, 0) <= LINUX_VERSION_CODE
 	if (xrt_xclbin_get_section_num(axlf, PARTITION_METADATA) &&


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Fixed multi-partition issue where create/destroy/create/destroy hw_context flow is not working

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
This is new test case we are enabling

#### How problem was solved, alternative solutions (if any) and why they were rejected
Destorying the aie before creating new AIE partition

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Verified multiple flows of multi-partition and single partition, with device/hw_context flows

#### Documentation impact (if any)
None