### PR TITLE
Dont throw an exception if there are no PL Kernels in xclbin

### DIFF
--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -1235,49 +1235,55 @@ int shim::prepare_hw_axlf(const axlf *buffer, struct drm_zocl_axlf *axlf_obj)
   axlf_obj->partition_id = partition_id,
   axlf_obj->kds_cfg.polling = xrt_core::config::get_ert_polling();
 
-  std::vector<char> krnl_binary;
-  if (!xrt_core::xclbin::is_aie_only(buffer)) {
-    auto kernels = xrt_core::xclbin::get_kernels(buffer);
-    /* Calculate size of kernels */
-    for (auto& kernel : kernels) {
-      axlf_obj->za_ksize += sizeof(kernel_info) + sizeof(argument_info) * kernel.args.size();
-    }
-
-    /* Check PCIe's shim.cpp for details of kernels binary */
-    krnl_binary.resize(axlf_obj->za_ksize);
-    axlf_obj->za_kernels = krnl_binary.data();
-    for (auto& kernel : kernels) {
-      auto krnl = reinterpret_cast<kernel_info *>(axlf_obj->za_kernels + off);
-      if (kernel.name.size() > sizeof(krnl->name))
-          return -EINVAL;
-      std::strncpy(krnl->name, kernel.name.c_str(), sizeof(krnl->name)-1);
-      krnl->name[sizeof(krnl->name)-1] = '\0';
-      krnl->range = kernel.range;
-      krnl->anums = kernel.args.size();
-
-      krnl->features = 0;
-      if (kernel.sw_reset)
-        krnl->features |= KRNL_SW_RESET;
-
-      int ai = 0;
-      for (auto& arg : kernel.args) {
-        if (arg.name.size() > sizeof(krnl->args[ai].name)) {
-          xclLog(XRT_ERROR, "%s: Argument name length %d>%d", __func__, arg.name.size(), sizeof(krnl->args[ai].name));
-          return -EINVAL;
-        }
-        std::strncpy(krnl->args[ai].name, arg.name.c_str(), sizeof(krnl->args[ai].name)-1);
-        krnl->args[ai].name[sizeof(krnl->args[ai].name)-1] = '\0';
-        krnl->args[ai].offset = arg.offset;
-        krnl->args[ai].size   = arg.size;
-        // XCLBIN doesn't define argument direction yet and it only support
-        // input arguments.
-        // Driver use 1 for input argument and 2 for output.
-        // Let's refine this line later.
-        krnl->args[ai].dir    = 1;
-        ai++;
+  // there may not be PL Kernels in the xclbin. dont throw an exception if no pl
+  // kernels
+  try {
+    std::vector<char> krnl_binary;
+    if (!xrt_core::xclbin::is_aie_only(buffer)) {
+      auto kernels = xrt_core::xclbin::get_kernels(buffer);
+      /* Calculate size of kernels */
+      for (auto& kernel : kernels) {
+        axlf_obj->za_ksize += sizeof(kernel_info) + sizeof(argument_info) * kernel.args.size();
       }
-      off += sizeof(kernel_info) + sizeof(argument_info) * kernel.args.size();
+
+      /* Check PCIe's shim.cpp for details of kernels binary */
+      krnl_binary.resize(axlf_obj->za_ksize);
+      axlf_obj->za_kernels = krnl_binary.data();
+      for (auto& kernel : kernels) {
+        auto krnl = reinterpret_cast<kernel_info *>(axlf_obj->za_kernels + off);
+        if (kernel.name.size() > sizeof(krnl->name))
+            return -EINVAL;
+        std::strncpy(krnl->name, kernel.name.c_str(), sizeof(krnl->name)-1);
+        krnl->name[sizeof(krnl->name)-1] = '\0';
+        krnl->range = kernel.range;
+        krnl->anums = kernel.args.size();
+
+        krnl->features = 0;
+        if (kernel.sw_reset)
+          krnl->features |= KRNL_SW_RESET;
+
+        int ai = 0;
+        for (auto& arg : kernel.args) {
+          if (arg.name.size() > sizeof(krnl->args[ai].name)) {
+            xclLog(XRT_ERROR, "%s: Argument name length %d>%d", __func__, arg.name.size(), sizeof(krnl->args[ai].name));
+            return -EINVAL;
+          }
+          std::strncpy(krnl->args[ai].name, arg.name.c_str(), sizeof(krnl->args[ai].name)-1);
+          krnl->args[ai].name[sizeof(krnl->args[ai].name)-1] = '\0';
+          krnl->args[ai].offset = arg.offset;
+          krnl->args[ai].size   = arg.size;
+          // XCLBIN doesn't define argument direction yet and it only support
+          // input arguments.
+          // Driver use 1 for input argument and 2 for output.
+          // Let's refine this line later.
+          krnl->args[ai].dir    = 1;
+          ai++;
+        }
+        off += sizeof(kernel_info) + sizeof(argument_info) * kernel.args.size();
+      }
     }
+  } 
+  catch (...) {
   }
 
   return 0;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Dont throw an exception if there are no PL Kernels. There are xclbins with only AIE information

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
None

#### How problem was solved, alternative solutions (if any) and why they were rejected
Catching an exception within the code to move forward.

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Verified multiple tests with AIE only sections

#### Documentation impact (if any)
None