### PR TITLE
[XDP] Fix to manage stream port ID detection in profile for client

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_profile/client/aie_profile.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/client/aie_profile.h
@@ -44,7 +44,7 @@ namespace xdp {
     void configStreamSwitchPorts(
       const tile_type& tile, const XAie_LocType& loc,
       const module_type& type, const std::string& metricSet,
-      const uint8_t channel
+      const uint8_t channel, const XAie_Events startEvent
     );
    private:
       const std::vector<XAie_ModuleType> falModuleTypes = {

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/edge/aie_profile.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/edge/aie_profile.cpp
@@ -262,6 +262,8 @@ namespace xdp {
           auto slaveOrMaster = (tile.is_master == 0) ? XAIE_STRMSW_SLAVE : XAIE_STRMSW_MASTER;
           uint8_t streamPortId = (portnum >= tile.stream_ids.size()) ?
               0 : static_cast<uint8_t>(tile.stream_ids.at(portnum));
+
+
           switchPortRsc->setPortToSelect(slaveOrMaster, SOUTH, streamPortId);
 
           if (aie::isDebugVerbosity()) {

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/edge/aie_profile.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/edge/aie_profile.cpp
@@ -262,8 +262,6 @@ namespace xdp {
           auto slaveOrMaster = (tile.is_master == 0) ? XAIE_STRMSW_SLAVE : XAIE_STRMSW_MASTER;
           uint8_t streamPortId = (portnum >= tile.stream_ids.size()) ?
               0 : static_cast<uint8_t>(tile.stream_ids.at(portnum));
-
-
           switchPortRsc->setPortToSelect(slaveOrMaster, SOUTH, streamPortId);
 
           if (aie::isDebugVerbosity()) {

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/util/aie_profile_util.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/util/aie_profile_util.cpp
@@ -362,6 +362,65 @@ namespace xdp::aie::profile {
 
     return (tlastEvents.find(event) != tlastEvents.end());
   }
+
+  uint8_t getPortNumberFromEvent(const XAie_Events event)
+  {
+    switch (event) {
+    case XAIE_EVENT_PORT_RUNNING_7_CORE:
+    case XAIE_EVENT_PORT_STALLED_7_CORE:
+    case XAIE_EVENT_PORT_IDLE_7_CORE:
+    case XAIE_EVENT_PORT_RUNNING_7_PL:
+    case XAIE_EVENT_PORT_STALLED_7_PL:
+    case XAIE_EVENT_PORT_IDLE_7_PL:
+      return 7;
+    case XAIE_EVENT_PORT_RUNNING_6_CORE:
+    case XAIE_EVENT_PORT_STALLED_6_CORE:
+    case XAIE_EVENT_PORT_IDLE_6_CORE:
+    case XAIE_EVENT_PORT_RUNNING_6_PL:
+    case XAIE_EVENT_PORT_STALLED_6_PL:
+    case XAIE_EVENT_PORT_IDLE_6_PL:
+      return 6;
+    case XAIE_EVENT_PORT_RUNNING_5_CORE:
+    case XAIE_EVENT_PORT_STALLED_5_CORE:
+    case XAIE_EVENT_PORT_IDLE_5_CORE:
+    case XAIE_EVENT_PORT_RUNNING_5_PL:
+    case XAIE_EVENT_PORT_STALLED_5_PL:
+    case XAIE_EVENT_PORT_IDLE_5_PL:
+      return 5;
+    case XAIE_EVENT_PORT_RUNNING_4_CORE:
+    case XAIE_EVENT_PORT_STALLED_4_CORE:
+    case XAIE_EVENT_PORT_IDLE_4_CORE:
+    case XAIE_EVENT_PORT_RUNNING_4_PL:
+    case XAIE_EVENT_PORT_STALLED_4_PL:
+    case XAIE_EVENT_PORT_IDLE_4_PL:
+      return 4;
+    case XAIE_EVENT_PORT_RUNNING_3_CORE:
+    case XAIE_EVENT_PORT_STALLED_3_CORE:
+    case XAIE_EVENT_PORT_IDLE_3_CORE:
+    case XAIE_EVENT_PORT_RUNNING_3_PL:
+    case XAIE_EVENT_PORT_STALLED_3_PL:
+    case XAIE_EVENT_PORT_IDLE_3_PL:
+      return 3;
+    case XAIE_EVENT_PORT_RUNNING_2_CORE:
+    case XAIE_EVENT_PORT_STALLED_2_CORE:
+    case XAIE_EVENT_PORT_IDLE_2_CORE:
+    case XAIE_EVENT_PORT_RUNNING_2_PL:
+    case XAIE_EVENT_PORT_STALLED_2_PL:
+    case XAIE_EVENT_PORT_IDLE_2_PL:
+      return 2;
+    case XAIE_EVENT_PORT_RUNNING_1_CORE:
+    case XAIE_EVENT_PORT_STALLED_1_CORE:
+    case XAIE_EVENT_PORT_IDLE_1_CORE:
+    case XAIE_EVENT_PORT_RUNNING_1_PL:
+    case XAIE_EVENT_PORT_STALLED_1_PL:
+    case XAIE_EVENT_PORT_IDLE_1_PL:
+      return 1;
+    default:
+      return 0;
+    }
+  }
+
+
   /****************************************************************************
    * Get XAie module enum at the module index 
    ***************************************************************************/

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/util/aie_profile_util.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/util/aie_profile_util.h
@@ -134,6 +134,8 @@ namespace xdp::aie::profile {
    */
   bool isPortTlastEvent(const XAie_Events event);
 
+  uint8_t getPortNumberFromEvent(const XAie_Events event);
+  
   /**
    * @brief Get XAie module enum at the module index 
    * @param moduleIndex module index


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
MCDM build is seeing error with the latest commit to support multi stream IDs.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
(https://github.com/Xilinx/XRT/pull/8509)

#### How problem was solved, alternative solutions (if any) and why they were rejected
We use equivalent logic in client as well similar to what we have for edge.
startEvent is used to determine portID which further decides on streamPortID to use.

#### Risks (if any) associated the changes in the commit
Medium- verification is pending on client.

#### What has been tested and how, request additional testing if necessary
MCDM build is not failing anymore.
Testing of AIE Profile on client is verified with @IshitaGhosh 's help.

#### Documentation impact (if any)
