### PR TITLE
CR-1216849, CR-1217061 FIX : xrt-smi configure --pmode default --help` does not print global options

### DIFF
--- a/src/runtime_src/core/tools/common/SubCmdConfigureInternal.cpp
+++ b/src/runtime_src/core/tools/common/SubCmdConfigureInternal.cpp
@@ -349,6 +349,7 @@ SubCmdConfigureInternal::execute(const SubCmdOptions& _options) const
   }
 
   if (optionOption) {
+    optionOption->setGlobalOptions(getGlobalOptions());
     optionOption->execute(_options);
     return;
   }

--- a/src/runtime_src/core/tools/xbutil2/SubCmdAdvanced.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdAdvanced.cpp
@@ -45,6 +45,7 @@ SubCmdAdvanced::SubCmdAdvanced(bool _isHidden, bool _isDepricated, bool _isPreli
   setIsPreliminary(_isPreliminary);
 
   m_commonOptions.add_options()
+    ("device,d", boost::program_options::value<decltype(m_device)>(&m_device), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest")
     ("help", boost::program_options::bool_switch(&m_help), "Help to use this sub-command")
   ;
 
@@ -78,7 +79,7 @@ SubCmdAdvanced::execute(const SubCmdOptions& _options) const
 
   // No suboption print help
   if (!optionOption) {
-    printHelp();
+    printHelp(false, "", XBU::get_device_class(m_device, true));
     return;
   }
 

--- a/src/runtime_src/core/tools/xbutil2/SubCmdAdvanced.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdAdvanced.h
@@ -17,6 +17,7 @@ class SubCmdAdvanced : public SubCmd {
 
   private:
     bool m_help;
+    std::string m_device;
 };
 
 #endif


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
1. Prints correct help options when using the command xrt-smi configure --pmode default --help
2. Print correct help when using the command xrt-smi advanced --help

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://jira.xilinx.com/browse/CR-1216849
https://jira.xilinx.com/browse/CR-1217061

#### How problem was solved, alternative solutions (if any) and why they were rejected
1. The problem was fixed by setting the global options to optionOptions object before execution, similar to how its done for other optionOptions.
2. The problem was fixed by setting the m_device field and using it to print the correct help

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Tested on kracken board
1. 
Before fix 
```
Y:\Repos\XRT-MCDM-FORK\XRT-MCDM\build\WRelease\xilinx\xrt>xrt-smi configure --pmode default --help

COMMAND: configure

DESCRIPTION: Modes: default, powersaver, balanced, performance, turbo

USAGE:  configure --pmode [--help] [-d arg]

OPTIONS:
  --pmode            - Modes: default, powersaver, balanced, performance, turbo
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest
  --help             - Help to use this sub-command


GLOBAL OPTIONS:
```
After Fix 
```
Y:\Repos\XRT-MCDM-FORK\XRT-MCDM\build\WRelease\xilinx\xrt>xrt-smi configure --pmode default --help

COMMAND: configure

DESCRIPTION: Modes: default, powersaver, balanced, performance, turbo

USAGE:  configure --pmode [--help] [-d arg]

OPTIONS:
  --pmode            - Modes: default, powersaver, balanced, performance, turbo
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest
  --help             - Help to use this sub-command


GLOBAL OPTIONS:
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
```
2. Before fix
```
Y:\Repos\XRT-MCDM-FORK\XRT-MCDM\build\WRelease\xilinx\xrt>xrt-smi advanced --help

COMMAND: advanced

DESCRIPTION: Low level command operations.

USAGE: xrt-smi advanced [ --read-mem | --write-mem | --report ] [--help]

OPTIONS:
 Common:
  --help             - Help to use this sub-command
 AIE:
  --report           - Hidden reports
 Alveo:
  --read-mem         - Read from the given memory address
  --write-mem        - Write to a given memory address


GLOBAL OPTIONS:
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
```
After fix 
```
Y:\Repos\XRT-MCDM-FORK\XRT-MCDM\build\WRelease\xilinx\xrt>xrt-smi advanced --help

COMMAND: advanced

DESCRIPTION: Low level command operations.

USAGE: xrt-smi advanced [ --report ] [--help] [-d arg]

OPTIONS:
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest
  --help             - Help to use this sub-command
  --report           - Hidden reports


GLOBAL OPTIONS:
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
```
#### Documentation impact (if any)
None
