### PR TITLE
Added hw_context reset array support

### DIFF
--- a/src/runtime_src/core/common/api/xrt_hw_context.cpp
+++ b/src/runtime_src/core/common/api/xrt_hw_context.cpp
@@ -264,3 +264,17 @@ hw_context::
 {}
 
 } // xrt
+
+////////////////////////////////////////////////////////////////
+// xrt_aie_hw_context C++ API implmentations (xrt_aie.h)
+////////////////////////////////////////////////////////////////
+namespace xrt::aie {
+
+void
+hw_context::
+reset_array()
+{
+  auto core_handle = get_handle()->get_hwctx_handle();
+  core_handle->reset_array();
+}
+} //xrt::aie

--- a/src/runtime_src/core/common/shim/hwctx_handle.h
+++ b/src/runtime_src/core/common/shim/hwctx_handle.h
@@ -113,6 +113,12 @@ public:
   {
     throw xrt_core::error(std::errc::not_supported, __func__);
   }
+
+  virtual void
+  reset_array() const
+  {
+    throw xrt_core::error(std::errc::not_supported, __func__);
+  }
 };
 
 } // xrt_core

--- a/src/runtime_src/core/edge/drm/zocl/common/zocl_drv.c
+++ b/src/runtime_src/core/edge/drm/zocl/common/zocl_drv.c
@@ -193,7 +193,7 @@ static void zocl_pr_slot_fini(struct drm_zocl_dev *zdev)
 		zocl_slot = zdev->pr_slot[i];
 		if (zocl_slot) {
 			zocl_free_sections(zdev, zocl_slot);
-			zocl_destroy_aie(zocl_slot);
+			zocl_cleanup_aie(zocl_slot);
 			mutex_destroy(&zocl_slot->slot_xclbin_lock);
 			mutex_destroy(&zocl_slot->aie_lock);
 			zocl_xclbin_fini(zdev, zocl_slot);

--- a/src/runtime_src/core/edge/drm/zocl/edge/zocl_aie.c
+++ b/src/runtime_src/core/edge/drm/zocl/edge/zocl_aie.c
@@ -199,6 +199,7 @@ get_slot(struct drm_zocl_dev * zdev, struct kds_client* client, int hw_ctx_id)
 	mutex_unlock(&client->lock);
 	return slot;
 }
+
 int
 zocl_aie_request_part_fd(struct drm_zocl_dev *zdev, void *data,  struct drm_file *filp)
 {
@@ -290,7 +291,7 @@ zocl_aie_reset_work(struct work_struct *aie_work)
 	slot->aie->fd_cnt = 0;
 }
 
-int
+static int
 zocl_aie_slot_reset(struct drm_zocl_slot* slot)
 {
 	if (!slot) {
@@ -362,6 +363,33 @@ zocl_aie_slot_reset(struct drm_zocl_slot* slot)
 	DRM_INFO("AIE Reset successfully finished.");
 	return 0;
 
+}
+
+static void
+zocl_destroy_aie(struct drm_zocl_slot* slot)
+{
+	if (!slot->aie_information)
+		return;
+
+	mutex_lock(&slot->aie_lock);
+	vfree(slot->aie_information);
+	slot->aie_information = NULL;
+
+	if (!slot->aie) {
+		mutex_unlock(&slot->aie_lock);
+		return;
+	}
+
+	if (slot->aie->aie_dev)
+		aie_partition_release(slot->aie->aie_dev);
+
+	if (slot->aie->wq)
+		destroy_workqueue(slot->aie->wq);
+
+	vfree(slot->aie->err.errors);
+	vfree(slot->aie);
+	slot->aie = NULL;
+	mutex_unlock(&slot->aie_lock);
 }
 
 int
@@ -537,32 +565,6 @@ done:
 	return rval;
 }
 
-void
-zocl_destroy_aie(struct drm_zocl_slot* slot)
-{
-	if (!slot->aie_information)
-		return;
-
-	mutex_lock(&slot->aie_lock);
-	vfree(slot->aie_information);
-	slot->aie_information = NULL;
-
-	if (!slot->aie) {
-		mutex_unlock(&slot->aie_lock);
-		return;
-	}
-
-	if (slot->aie->aie_dev)
-		aie_partition_release(slot->aie->aie_dev);
-
-	if (slot->aie->wq)
-		destroy_workqueue(slot->aie->wq);
-
-	vfree(slot->aie->err.errors);
-	vfree(slot->aie);
-	slot->aie = NULL;
-	mutex_unlock(&slot->aie_lock);
-}
 
 
 

--- a/src/runtime_src/core/edge/drm/zocl/edge/zocl_edge_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/edge/zocl_edge_xclbin.c
@@ -193,8 +193,8 @@ zocl_xclbin_read_axlf(struct drm_zocl_dev *zdev, struct drm_zocl_axlf *axlf_obj,
 	/* Free sections before load the new xclbin */
 	zocl_free_sections(zdev, slot);
 	
-	/* Destroy the aie information from slot and create new */
-	zocl_destroy_aie(slot);
+	/* Cleanup the aie information from slot and create new */
+	zocl_cleanup_aie(slot);
 
 
 #if KERNEL_VERSION(5, 4, 0) <= LINUX_VERSION_CODE

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
@@ -268,7 +268,6 @@ int zocl_cleanup_aie(struct drm_zocl_slot *slot);
 int zocl_create_aie(struct drm_zocl_slot *slot, struct axlf *axlf, char __user *xclbin,
 		void *aie_res, uint8_t hw_gen, uint32_t partition_id);
 int zocl_init_aie(struct drm_zocl_slot* slot);
-void zocl_destroy_aie(struct drm_zocl_slot *slot);
 int zocl_aie_request_part_fd(struct drm_zocl_dev *zdev, void *data,struct drm_file* filp );
 int zocl_aie_reset(struct drm_zocl_dev *zdev, void* data, struct drm_file* file);
 int zocl_aie_freqscale(struct drm_zocl_dev *zdev, void *data, struct drm_file* filp);

--- a/src/runtime_src/core/edge/user/aie/aie.cpp
+++ b/src/runtime_src/core/edge/user/aie/aie.cpp
@@ -403,7 +403,7 @@ clear_bd(aie_bd& bd)
 
 void
 aie_array::
-reset(const xrt_core::device* device)
+reset(const xrt_core::device* device, uint32_t hw_context_id, uint32_t partition_id)
 {
   if (!dev_inst)
     throw xrt_core::error(-EINVAL, "Can't Reset AIE: AIE is not initialized");
@@ -416,11 +416,7 @@ reset(const xrt_core::device* device)
 
   auto drv = ZYNQ::shim::handleCheck(device->get_device_handle());
 
-  /* TODO get partition id and uid from XCLBIN or PDI */
-  uint32_t partition_id = 1;
-
-  //TODO create similar function for hw_context
-  drm_zocl_aie_reset reset = { 0 , partition_id };
+  drm_zocl_aie_reset reset = { hw_context_id , partition_id };
   int ret = drv->resetAIEArray(reset);
   if (ret)
     throw xrt_core::error(ret, "Fail to reset AIE Array");

--- a/src/runtime_src/core/edge/user/aie/aie.h
+++ b/src/runtime_src/core/edge/user/aie/aie.h
@@ -121,7 +121,7 @@ public:
   wait_gmio(const std::string& gmioName);
 
   void
-  reset(const xrt_core::device* device);
+  reset(const xrt_core::device* device, uint32_t hw_context_id, uint32_t partition_id);
 
   int
   start_profiling(int option, const std::string& port1_name, const std::string& port2_name, uint32_t value);

--- a/src/runtime_src/core/edge/user/device_linux.cpp
+++ b/src/runtime_src/core/edge/user/device_linux.cpp
@@ -1235,7 +1235,7 @@ reset_aie()
   if (!aie_array->is_context_set())
     aie_array->open_context(this, xrt::aie::access_mode::primary);
 
-  aie_array->reset(this);
+  aie_array->reset(this, 0 /*hw_context_id*/, xrt_core::edge::aie::full_array_id);
 }
 
 void

--- a/src/runtime_src/core/edge/user/hwctx_object.cpp
+++ b/src/runtime_src/core/edge/user/hwctx_object.cpp
@@ -127,4 +127,17 @@ hwctx_object::open_aie_buffer_handle(const char* name)
 #endif
 }
 
+void
+hwctx_object::reset_array() const
+{
+  if (!m_aie_array)
+    throw xrt_core::error(-EINVAL, "No AIE present in hw_context to reset");
+
+  auto device{xrt_core::get_userpf_device(m_shim)};
+  if (!m_aie_array->is_context_set())
+    m_aie_array->open_context(device.get(), xrt::aie::access_mode::primary);
+
+  m_aie_array->reset(device.get(), m_slot_idx, m_info.partition_id);
+}
+
 }

--- a/src/runtime_src/core/edge/user/hwctx_object.h
+++ b/src/runtime_src/core/edge/user/hwctx_object.h
@@ -108,6 +108,9 @@ namespace zynqaie {
     std::unique_ptr<xrt_core::aie_buffer_handle>
     open_aie_buffer_handle(const char* name) override;
 
+    void
+    reset_array() const override;
+
 #ifdef XRT_ENABLE_AIE
     std::shared_ptr<aie_array>
     get_aie_array_shared();

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -1283,8 +1283,6 @@ int shim::prepare_hw_axlf(const axlf *buffer, struct drm_zocl_axlf *axlf_obj)
     }
     off += sizeof(kernel_info) + sizeof(argument_info) * kernel.args.size();
   }
-  
-  
   return 0;
 }
 

--- a/src/runtime_src/core/include/xrt/xrt_aie.h
+++ b/src/runtime_src/core/include/xrt/xrt_aie.h
@@ -255,6 +255,29 @@ public:
   }
 };
 
+class hw_context : public xrt::hw_context
+{
+public:
+
+  /**
+   * hw_context() - Constructor that is used for AIE hw_context.
+   *
+   * @param arg
+   *  Arguments to construct hw_context (xrt_hw_context.h).
+   */
+  template <typename ...Args>
+  hw_context(Args&&... args)
+    : xrt::hw_context(std::forward<Args>(args)...)
+  {}
+
+  /**
+   * reset_array() - reset the AIE Array used for this hw_context
+   *
+   */
+  void
+  reset_array();
+};
+
 class profiling_impl;
 class profiling : public detail::pimpl<profiling_impl>
 {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
We have enabled multi-partition support in edge in this release, There is one functionality missing in this support is to reset the partition instead of whole device. Added hw_context reset support now

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
None. This is new feature

#### How problem was solved, alternative solutions (if any) and why they were rejected
Enabled hw_context reset array support. Provided a public API on xrt::aie::hw_context class

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Verified hw_context reset support

#### Documentation impact (if any)
Yes. Updated the API Documentation. Need to add an example