### PR TITLE
VITIS-13627 [Preemption] Add preemption telemetry report

### DIFF
--- a/src/runtime_src/core/common/info_telemetry.cpp
+++ b/src/runtime_src/core/common/info_telemetry.cpp
@@ -39,6 +39,28 @@ add_rtos_tasks(const xrt_core::device* device, boost::property_tree::ptree& pt)
   pt.add_child("rtos_tasks", pt_rtos_array);
 }
 
+static boost::property_tree::ptree
+aie2_preemption_info(const xrt_core::device* device)
+{
+  const auto data = xrt_core::device_query<xrt_core::query::rtos_telemetry>(device);
+  boost::property_tree::ptree pt_rtos_array;
+  for (const auto& kp : data) {
+  boost::property_tree::ptree pt_preempt;
+
+  //add a check for not supported
+  if(static_cast<int>(kp.preemption_data.preemption_flag_set) == -1) 
+    return pt_rtos_array; //not supported
+  pt_preempt.put("slot_index", kp.preemption_data.slot_index);
+  pt_preempt.put("preemption_flag_set", kp.preemption_data.preemption_flag_set);
+  pt_preempt.put("preemption_flag_unset", kp.preemption_data.preemption_flag_unset);
+  pt_preempt.put("preemption_checkpoint_event", kp.preemption_data.preemption_checkpoint_event);
+  pt_preempt.put("preemption_frame_boundary_events", kp.preemption_data.preemption_frame_boundary_events);
+
+  pt_rtos_array.push_back({"", pt_preempt});
+  }
+  return pt_rtos_array;
+}
+
 static void
 add_opcode_info(const xrt_core::device* device, boost::property_tree::ptree& pt)
 {
@@ -128,6 +150,23 @@ telemetry_info(const xrt_core::device* device)
   case xrt_core::query::device_class::type::ryzen:
   {
     telemetry_pt.add_child("telemetry", aie2_telemetry_info(device));
+    return telemetry_pt;
+  }
+  }
+  return telemetry_pt;
+}
+
+boost::property_tree::ptree
+preemption_telemetry_info(const xrt_core::device* device)
+{
+  boost::property_tree::ptree telemetry_pt;
+  const auto device_class = xrt_core::device_query_default<xrt_core::query::device_class>(device, xrt_core::query::device_class::type::alveo);
+  switch (device_class) {
+  case xrt_core::query::device_class::type::alveo: // No telemetry for alveo devices
+    return telemetry_pt;
+  case xrt_core::query::device_class::type::ryzen:
+  {
+    telemetry_pt.add_child("telemetry", aie2_preemption_info(device));
     return telemetry_pt;
   }
   }

--- a/src/runtime_src/core/common/info_telemetry.h
+++ b/src/runtime_src/core/common/info_telemetry.h
@@ -16,6 +16,10 @@ XRT_CORE_COMMON_EXPORT
 boost::property_tree::ptree
 telemetry_info(const xrt_core::device* device);
 
+XRT_CORE_COMMON_EXPORT
+boost::property_tree::ptree
+preemption_telemetry_info(const xrt_core::device* device);
+
 }} // telemetry, xrt_core
 
 #endif

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -1779,8 +1779,6 @@ struct misc_telemetry : request
 {
   struct data {
     uint64_t l1_interrupts;
-    uint64_t preemption_flag_set;
-    uint64_t preemption_flag_unset;
   };
 
   using result_type = data;
@@ -1815,6 +1813,14 @@ struct rtos_telemetry : request
     uint64_t misses;
   };
 
+  struct preempt_data {
+    uint64_t slot_index;
+    uint64_t preemption_flag_set;
+    uint64_t preemption_flag_unset;
+    uint64_t preemption_checkpoint_event;
+    uint64_t preemption_frame_boundary_events;
+  };
+
   struct data {
     uint64_t context_starts;
     uint64_t schedules;
@@ -1822,6 +1828,7 @@ struct rtos_telemetry : request
     uint64_t dma_access;
     uint64_t resource_acquisition;
     std::vector<dtlb_data> dtlbs;
+    preempt_data preemption_data;
   };
 
   using result_type = std::vector<data>;

--- a/src/runtime_src/core/tools/common/reports/ReportTelemetry.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportTelemetry.cpp
@@ -33,7 +33,7 @@ generate_rtos_dtlb_string(const boost::property_tree::ptree& pt)
   std::stringstream ss;
 
   boost::property_tree::ptree rtos_tasks = pt.get_child("rtos_tasks", empty_ptree);
-  boost::property_tree::ptree rtos_dtlb_data = pt.get_child("rtos_tasks..dtlb_data", empty_ptree);
+  boost::property_tree::ptree rtos_dtlb_data = pt.get_child("rtos_tasks.dtlb_data", empty_ptree);
   if(rtos_tasks.empty() && rtos_dtlb_data.empty())
     return ss.str();
 

--- a/src/runtime_src/core/tools/xbutil2/OO_Reports.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_Reports.cpp
@@ -11,8 +11,6 @@
 #include "core/common/info_telemetry.h"
 #include "tools/common/Table2D.h"
 
-#include <boost/property_tree/json_parser.hpp>
-
 // 3rd Party Library - Include Files
 #include <boost/program_options.hpp>
 #include <boost/algorithm/string.hpp>
@@ -24,7 +22,6 @@ static void
 print_preemption_telemetry(const xrt_core::device* device)
 {
   boost::property_tree::ptree telemetry_pt = xrt_core::telemetry::preemption_telemetry_info(device);
-  boost::property_tree::json_parser::write_json( std::cout , telemetry_pt);
   if (telemetry_pt.empty()) {
     std::cout << "  No telemetry information available\n\n";
     return;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
[VITIS-13627](https://jira.xilinx.com/browse/VITIS-13627) [Preemption] Add preemption telemetry report

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
N/A

#### How problem was solved, alternative solutions (if any) and why they were rejected
New report was added to 
`xrt-smi advanced --report preemption`

#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
Tested with private fw build and unmerged driver changes on stx/mcdm

```
>xrt-smi advanced --report preemption
Premption Telemetry Data
  |User Task  ||Ctx ID  ||Set Hints  ||Unset Hints  ||Checkpoint Events  ||Frame Boundary Events  |
  |-----------||--------||-----------||-------------||-------------------||-----------------------|
  |0          ||0       ||1          ||2            ||3                  ||4                      |
  |1          ||0       ||1          ||2            ||3                  ||4                      |
  |2          ||0       ||1          ||2            ||3                  ||4                      |
  |3          ||0       ||1          ||2            ||3                  ||4                      |
  |4          ||0       ||1          ||2            ||3                  ||4                      |
  |5          ||0       ||1          ||2            ||3                  ||4                      |
  |6          ||0       ||1          ||2            ||3                  ||4                      |
  |7          ||0       ||1          ||2            ||3                  ||4                      |
  |8          ||0       ||1          ||2            ||3                  ||4                      |
  |9          ||0       ||1          ||2            ||3                  ||4                      |
  |10         ||0       ||1          ||2            ||3                  ||4                      |
  |11         ||0       ||1          ||2            ||3                  ||4                      |
  |12         ||0       ||1          ||2            ||3                  ||4                      |
  |13         ||0       ||1          ||2            ||3                  ||4                      |
  |14         ||0       ||1          ||2            ||3                  ||4                      |
  |15         ||0       ||1          ||2            ||3                  ||4                      |
```
#### Documentation impact (if any)
N/A
