### PR TITLE
CI/CD: changing the master branch for 2024.2 to on push event - SR-959503

### DIFF
--- a/.github/workflows/xrt_master_2024.2.yml
+++ b/.github/workflows/xrt_master_2024.2.yml
@@ -1,4 +1,4 @@
-name: XRT Master (2024.2)
+name: XRT 2024.2
 
 env:  
   RELEASE: '2024.2'  
@@ -6,9 +6,10 @@ env:
   ENV: 'prod'
 
 on:
-  workflow_dispatch:
-  schedule:
-    - cron: '0 3 * * *' 
+  push:
+    branches:
+      - '2024.2'
+  workflow_dispatch: 
   
 jobs:
   build:


### PR DESCRIPTION
Creating a master pipeline for 2024.2 as the current master would be 2025.1 as per the request - SR-959503

Modifying the event for the workflow trigger for 2024.2 master pipeline from schedule job which runs every night to "on push" event so that packages are deployed to TA only when there's a push to 2024.2 branch
