### PR TITLE
[Xbutil] Remove TOPS print for Ryzen because it's incorrect

### DIFF
--- a/src/runtime_src/core/tools/common/reports/platform/ReportRyzenPlatform.cpp
+++ b/src/runtime_src/core/tools/common/reports/platform/ReportRyzenPlatform.cpp
@@ -62,16 +62,6 @@ ReportRyzenPlatform::writeReport(const xrt_core::device* /*_pDevice*/,
       }
     }
 
-    const boost::property_tree::ptree& tops = pt_platform.get_child("tops", empty_ptree);
-    if (!tops.empty()) {
-      _output << "\nTOPs\n";
-      for (const auto& kt : tops) {
-        const boost::property_tree::ptree& pt_tops = kt.second;
-        std::string tops_name_type = pt_tops.get<std::string>("id");
-        _output << boost::format("  %-23s: %s Terabyte ops/second\n") % tops_name_type % pt_tops.get<std::string>("value");
-      }
-    }
-
     auto watts = pt_platform.get<std::string>("electrical.power_consumption_watts", "N/A");
     if (watts != "N/A")
       _output << std::endl << boost::format("%-23s  : %s Watts\n") % "Power" % watts;


### PR DESCRIPTION
#### Problem solved by the commit
Removal of incorrect print for Ryzen TOPS. For example, it prints 56 TOPS instead of 50

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
#8461 introduced it

#### How problem was solved, alternative solutions (if any) and why they were rejected
Removed the offending code as we would like to merge this ASAP

#### Risks (if any) associated the changes in the commit
None