### PR TITLE
Fix in ML Timeline, AIE PC plugin for Linux Client

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_pc/clientDev/aie_pc.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_pc/clientDev/aie_pc.cpp
@@ -64,6 +64,9 @@ namespace xdp {
   {
   }
 
+  AIEPCClientDevImpl::~AIEPCClientDevImpl()
+  {}
+
   void AIEPCClientDevImpl::updateDevice(void* hwCtxImpl)
   {
     (void)hwCtxImpl;

--- a/src/runtime_src/xdp/profile/plugin/aie_pc/clientDev/aie_pc.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_pc/clientDev/aie_pc.h
@@ -43,7 +43,7 @@ namespace xdp {
     public :
       AIEPCClientDevImpl(VPDatabase* dB);
 
-      ~AIEPCClientDevImpl() = default;
+      ~AIEPCClientDevImpl();
 
       virtual void updateDevice(void* hwCtxImpl);
       virtual void finishflushDevice(void* hwCtxImpl);

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.cpp
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.cpp
@@ -67,6 +67,12 @@ namespace xdp {
               "Created ML Timeline Plugin for Client Device.");
   }
 
+  MLTimelineClientDevImpl::~MLTimelineClientDevImpl()
+  {
+    xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT", 
+              "In destructor for ML Timeline Plugin for Client Device.");
+  }
+
   void MLTimelineClientDevImpl::updateDevice(void* hwCtxImpl)
   {
     xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT", 

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.h
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.h
@@ -29,7 +29,7 @@ namespace xdp {
     public :
       MLTimelineClientDevImpl(VPDatabase* dB);
 
-      ~MLTimelineClientDevImpl() = default;
+      ~MLTimelineClientDevImpl();
 
       virtual void updateDevice(void* hwCtxImpl);
       virtual void finishflushDevice(void* hwCtxImpl, uint64_t implId = 0);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
When ML Timeline and AIE PC Plugins are compiled for Linux Client, there is error caused by use of default destructor without defining the type of unique pointer member.
Windows does not give any such error.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
ML Timeline : https://github.com/Xilinx/XRT/pull/8512
PC Plugin : https://github.com/Xilinx/XRT/pull/8439
@parthash0804 discovered the issue while enabling these plugins for Linux Client locally.

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Unit tests
#### Documentation impact (if any)
