### PR TITLE
VITIS-13627 and CR-1216853

### DIFF
--- a/src/runtime_src/core/common/info_telemetry.cpp
+++ b/src/runtime_src/core/common/info_telemetry.cpp
@@ -47,14 +47,19 @@ aie2_preemption_info(const xrt_core::device* device)
   for (const auto& kp : data) {
   boost::property_tree::ptree pt_preempt;
 
-  //add a check for not supported
-  if(static_cast<int>(kp.preemption_data.preemption_flag_set) == -1) 
-    return pt_rtos_array; //not supported
-  pt_preempt.put("slot_index", kp.preemption_data.slot_index);
-  pt_preempt.put("preemption_flag_set", kp.preemption_data.preemption_flag_set);
-  pt_preempt.put("preemption_flag_unset", kp.preemption_data.preemption_flag_unset);
-  pt_preempt.put("preemption_checkpoint_event", kp.preemption_data.preemption_checkpoint_event);
-  pt_preempt.put("preemption_frame_boundary_events", kp.preemption_data.preemption_frame_boundary_events);
+    auto populate_value = [](uint64_t value) {
+      return (value == static_cast<uint64_t>(-1) || value == UINT64_MAX) ? "N/A" : std::to_string(value);
+    };
+
+  //add check if a workload is running
+  if(static_cast<int>(kp.preemption_data.slot_index) == -1) 
+    continue;
+  pt_preempt.put("user_task", populate_value(kp.user_task));
+  pt_preempt.put("slot_index", populate_value(kp.preemption_data.slot_index));
+  pt_preempt.put("preemption_flag_set", populate_value(kp.preemption_data.preemption_flag_set));
+  pt_preempt.put("preemption_flag_unset", populate_value(kp.preemption_data.preemption_flag_unset));
+  pt_preempt.put("preemption_checkpoint_event", populate_value(kp.preemption_data.preemption_checkpoint_event));
+  pt_preempt.put("preemption_frame_boundary_events", populate_value(kp.preemption_data.preemption_frame_boundary_events));
 
   pt_rtos_array.push_back({"", pt_preempt});
   }

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -1752,6 +1752,23 @@ struct aie_partition_info : request
 
   virtual std::any
   get(const device* device) const = 0;
+
+  static std::string
+  parse_priority_status(const uint64_t prio_status)
+  {
+    switch(prio_status) {
+      case 256: //0x100
+        return "Realtime";
+      case 384: //0x180
+        return "High";
+      case 512: //0x200
+        return "Normal";
+      case 640: //0x280
+        return "Low";
+      default:
+        throw xrt_core::system_error(EINVAL, "Invalid priority status: " + std::to_string(prio_status));
+    }
+  }
 };
 
 // Retrieves the AIE telemetry info for the device
@@ -1822,6 +1839,7 @@ struct rtos_telemetry : request
   };
 
   struct data {
+    uint64_t user_task;
     uint64_t context_starts;
     uint64_t schedules;
     uint64_t syscalls;

--- a/src/runtime_src/core/tools/common/reports/ReportAiePartitions.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportAiePartitions.cpp
@@ -44,7 +44,7 @@ populate_aie_partition(const xrt_core::device* device)
     pt_entry.put("egops", qos.egops);
     pt_entry.put("fps", qos.fps);
     pt_entry.put("latency", qos.latency);
-    pt_entry.put("priority", qos.priority);
+    pt_entry.put("priority", xrt_core::query::aie_partition_info::parse_priority_status(qos.priority));
 
     partition.first->second.push_back(std::make_pair("", pt_entry));
   }
@@ -170,7 +170,7 @@ writeReport(const xrt_core::device* /*_pDevice*/,
         hw_context.get<std::string>("command_completions"),
         hw_context.get<std::string>("migrations"),
         std::to_string(hw_context.get<uint64_t>("errors")),
-        std::to_string(hw_context.get<uint64_t>("priority")),
+        hw_context.get<std::string>("priority"),
         std::to_string(hw_context.get<uint64_t>("gops")),
         std::to_string(hw_context.get<uint64_t>("egops")),
         std::to_string(hw_context.get<uint64_t>("fps")),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
- [CR-1216853](https://jira.xilinx.com/browse/CR-1216853) [xrt-smi] Display priority as string low/normal/high/real-time in xrt-smi examine report
- [VITIS-13627](https://jira.xilinx.com/browse/VITIS-13627) [Preemption] Add preemption telemetry report

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
- Currently we display priority as a a number. We want to parse it to a more human readable format
- Fix the reports to handle no context running scenario better

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
Sample outputs:
```
>xrt-smi advanced --report preemption
Premption Telemetry Data
  |User Task  ||Ctx ID  ||Set Hints  ||Unset Hints  ||Checkpoint Events  ||Frame Boundary Events  |
  |-----------||--------||-----------||-------------||-------------------||-----------------------|
  |16         ||10      ||N/A        ||N/A          ||N/A                ||N/A                    |
```

```
>xrt-smi advanced --report preemption
Premption Telemetry Data
 No hardware contexts running on device
```

```
>xrt-smi examine -r aie-partitions

---------------------
[00c5:00:01.1] : NPU
---------------------
AIE Partitions
Total Column Utilization: 0%
  Partition Index: 0
    Columns: [0, 1, 2, 3]
    HW Contexts:
      |PID     ||Ctx ID  ||Instr BO  ||Sub  ||Compl  ||Migr  ||Err  ||Prio    ||GOPS  ||EGOPS  ||FPS  ||Latency  |
      |--------||--------||----------||-----||-------||------||-----||--------||------||-------||-----||---------|
      |121892  ||14      ||0 Byte    ||0    ||0      ||0     ||0    ||Normal  ||0     ||0      ||0    ||0        |
```

#### Documentation impact (if any)
N/A
