### PR TITLE
VAI-8052 Windows compile with /MT and link using Hybrid CRT

### DIFF
--- a/build/build-win22.sh
+++ b/build/build-win22.sh
@@ -11,8 +11,8 @@ CORE=`grep -c ^processor /proc/cpuinfo`
 
 CMAKE="/mnt/c/Program Files/CMake/bin/cmake.exe"
 XRT=/mnt/c/Xilinx/xrt
-BOOST=$XRT/ext
-KHRONOS=$XRT/ext
+BOOST=$XRT/ext.new
+KHRONOS=$XRT/ext.new
 
 BOOST=$(sed -e 's|/mnt/\([A-Za-z]\)/\(.*\)|\1:/\2|' -e 's|/|\\|g' <<< $BOOST)
 KHRONOS=$(sed -e 's|/mnt/\([A-Za-z]\)/\(.*\)|\1:/\2|' -e 's|/|\\|g' <<< $KHRONOS)

--- a/build/build22.bat
+++ b/build/build22.bat
@@ -7,7 +7,7 @@ set BUILDDIR=%SCRIPTDIR%
 
 set DEBUG=1
 set RELEASE=1
-set EXT_DIR=C:/Xilinx/XRT/ext
+set EXT_DIR=C:/Xilinx/XRT/ext.new
 set CREATE_PACKAGE=0
 set CMAKEFLAGS=
 set NOCMAKE=0

--- a/src/CMake/nativeWin.cmake
+++ b/src/CMake/nativeWin.cmake
@@ -51,18 +51,24 @@ add_compile_definitions("BOOST_BIND_GLOBAL_PLACEHOLDERS")
 add_compile_definitions("_SILENCE_CXX17_ALLOCATOR_VOID_DEPRECATION_WARNING")
 
 if (MSVC)
-    add_compile_options(
-        /Zc:__cplusplus
-        /Zi           # generate pdb files even in release mode
-	/sdl          # enable security checks
-        /Qspectre     # compile with the Spectre mitigations switch
-        /ZH:SHA_256   # enable secure source code hashing
-        /guard:cf     # enable compiler control guard feature (CFG) to prevent attackers from redirecting execution to unsafe locations
+  # Static linking with the CRT
+  set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+
+  add_compile_options(
+    /MT$<$<CONFIG:Debug>:d>  # static linking with the CRT
+    /Zc:__cplusplus
+    /Zi           # generate pdb files even in release mode
+    /sdl          # enable security checks
+    /Qspectre     # compile with the Spectre mitigations switch
+    /ZH:SHA_256   # enable secure source code hashing
+    /guard:cf     # enable compiler control guard feature (CFG) to prevent attackers from redirecting execution to unsafe locations
     )
-    add_link_options(
-        /DEBUG      # instruct linker to create debugging info
-        /guard:cf   # enable linker control guard feature (CFG) to prevent attackers from redirecting execution to unsafe locations
-        /CETCOMPAT  # enable Control-flow Enforcement Technology (CET) Shadow Stack mitigation
+  add_link_options(
+    /NODEFAULTLIB:libucrt$<$<CONFIG:Debug>:d>.lib  # Hybrid CRT
+    /DEFAULTLIB:ucrt$<$<CONFIG:Debug>:d>.lib       # Hybrid CRT
+    /DEBUG      # instruct linker to create debugging info
+    /guard:cf   # enable linker control guard feature (CFG) to prevent attackers from redirecting execution to unsafe locations
+    /CETCOMPAT  # enable Control-flow Enforcement Technology (CET) Shadow Stack mitigation
     )
 endif()
 


### PR DESCRIPTION
#### Problem solved by the commit
This changes how XRT links on windows and it switches the external dependency folder to c:/Xilinx/XRT/ext.new with corresponding build changes to Boost.

All developers who build on windows must update their external dependencies by downloading pre-built artifacts
from our internal artifactory.  Please check with @stsoe for a link.  The ext.zip file must be extracted into either the
default location (`c:\Xilinx\XRT\ext.new`)  or to a location of your choice provided you invoke `build.sh -ext <path> ...` with the path to where the extracted folder exists.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Per request

#### How problem was solved, alternative solutions (if any) and why they were rejected
Add new compile switch to link Visual studio and link options for Hybrid CRT.

#### Risks (if any) associated the changes in the commit
Many.   Each DLL has its own copy of runtime.  RTTI unlikely to work.  Exceptions are questionable.

#### What has been tested and how, request additional testing if necessary
Nothing yet.

#### Documentation impact (if any)
Mabe
