### PR TITLE
Fix build scripts for MSVC to honor custom ext path

### DIFF
--- a/build/build-win22.sh
+++ b/build/build-win22.sh
@@ -10,12 +10,9 @@ BUILDDIR=$(readlink -f $(dirname ${BASH_SOURCE[0]}))
 CORE=`grep -c ^processor /proc/cpuinfo`
 
 CMAKE="/mnt/c/Program Files/CMake/bin/cmake.exe"
-XRT=/mnt/c/Xilinx/xrt
-BOOST=$XRT/ext.new
-KHRONOS=$XRT/ext.new
-
-BOOST=$(sed -e 's|/mnt/\([A-Za-z]\)/\(.*\)|\1:/\2|' -e 's|/|\\|g' <<< $BOOST)
-KHRONOS=$(sed -e 's|/mnt/\([A-Za-z]\)/\(.*\)|\1:/\2|' -e 's|/|\\|g' <<< $KHRONOS)
+EXT_DIR=/mnt/c/Xilinx/xrt/ext.new
+BOOST=$EXT_DIR
+KHRONOS=$EXT_DIR
 
 usage()
 {
@@ -24,7 +21,7 @@ usage()
     echo "[-help]                    List this help"
     echo "[clean|-clean]             Remove build directories"
     echo "[-cmake]                   CMAKE executable (default: $CMAKE)"
-    echo "[-xrt]                     XRT root directory (default: $XRT)"
+    echo "[-ext]                     Location of link dependencies (default: $EXT_DIR)"
     echo "[-boost]                   BOOST libaries root directory (default: $BOOST)"
     echo "[-nocmake]                 Do not rerun cmake generation, just build"
     echo "[-noabi]                   Do compile with ABI version check"
@@ -56,9 +53,11 @@ while [ $# -gt 0 ]; do
 	    CMAKE="$1"
 	    shift
 	    ;;
-	-xrt)
+	-ext)
 	    shift
-	    XRT="$1"
+	    EXT_DIR="$1"
+            BOOST=$EXT_DIR
+            KHRONOS=$EXT_DIR
 	    shift
 	    ;;
         -dbg)
@@ -99,6 +98,9 @@ while [ $# -gt 0 ]; do
             ;;
     esac
 done
+
+BOOST=$(sed -e 's|/mnt/\([A-Za-z]\)/\(.*\)|\1:/\2|' -e 's|/|\\|g' <<< $BOOST)
+KHRONOS=$(sed -e 's|/mnt/\([A-Za-z]\)/\(.*\)|\1:/\2|' -e 's|/|\\|g' <<< $KHRONOS)
 
 here=$PWD
 cd $BUILDDIR

--- a/build/build22.bat
+++ b/build/build22.bat
@@ -34,7 +34,7 @@ IF DEFINED MSVC_PARALLEL_JOBS ( SET LOCAL_MSVC_PARALLEL_JOBS=%MSVC_PARALLEL_JOBS
   ) else (
   if [%1] == [-ext] (
     shift
-    set EXT_DIR=%1
+    set EXT_DIR=%2
   ) else (
   if [%1] == [-opt] (
     set DEBUG=0


### PR DESCRIPTION
#### Problem solved by the commit
Fix bug in build22.bat when `-ext` is specified.
Add `-ext` option to build-win22.sh.

With #8551 the default external dependency location for windows has moved to `c:\Xilinx\XRT\ext.new`.  Use the `-ext` option to override the location if desired.
