### PR TITLE
fixing aie_only xclbin issue

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/edge/zocl_edge_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/edge/zocl_edge_xclbin.c
@@ -163,7 +163,7 @@ zocl_xclbin_read_axlf(struct drm_zocl_dev *zdev, struct drm_zocl_axlf *axlf_obj,
 			// We come here if user sets force_xclbin_program
 			// option "true" in xrt.ini under [Runtime] section
 			DRM_WARN("%s Force xclbin download", __func__);
-		} else {
+		} else if (!is_aie_only(axlf)) {
 			DRM_INFO("xclbin already downloaded to slot=%d", slot_id);
 			vfree(axlf);
 			mutex_unlock(&slot->slot_xclbin_lock);
@@ -214,7 +214,6 @@ zocl_xclbin_read_axlf(struct drm_zocl_dev *zdev, struct drm_zocl_axlf *axlf_obj,
 	} else
 #endif
 	if (is_aie_only(axlf)) {
-		zocl_cleanup_aie(slot);
 
 		ret = zocl_load_aie_only_pdi(zdev, slot, axlf, xclbin, client);
 		if (ret)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Fixed AIE only xclbin issue. We need to load the xclbin always if xclbin is AIE only.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
NA

#### How problem was solved, alternative solutions (if any) and why they were rejected
Reloading the AIE only PDI if xclbin is aie only xclbin

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Verified AIE only xclbins

#### Documentation impact (if any)
None