### PR TITLE
Build xrt drivers on Linux 6.12-rc3

### DIFF
--- a/src/runtime_src/core/common/drv/include/xrt_cu.h
+++ b/src/runtime_src/core/common/drv/include/xrt_cu.h
@@ -413,19 +413,19 @@ static inline char *prot2str(enum CU_PROTOCOL prot)
 	}
 }
 
-static void inline xrt_cu_enable_intr(struct xrt_cu *xcu, u32 intr_type)
+static inline void xrt_cu_enable_intr(struct xrt_cu *xcu, u32 intr_type)
 {
 	if (xcu->funcs)
 		xcu->funcs->enable_intr(xcu->core, intr_type);
 }
 
-static void inline xrt_cu_disable_intr(struct xrt_cu *xcu, u32 intr_type)
+static inline void xrt_cu_disable_intr(struct xrt_cu *xcu, u32 intr_type)
 {
 	if (xcu->funcs)
 		xcu->funcs->disable_intr(xcu->core, intr_type);
 }
 
-static u32 inline xrt_cu_clear_intr(struct xrt_cu *xcu)
+static inline u32 xrt_cu_clear_intr(struct xrt_cu *xcu)
 {
 	return xcu->funcs ? xcu->funcs->clear_intr(xcu->core) : 0;
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/accel_deadlock_detector.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/accel_deadlock_detector.c
@@ -61,7 +61,7 @@ static struct attribute_group accel_deadlock_detector_attr_group = {
     .attrs = accel_deadlock_detector_attrs,
 };
 
-static int accel_deadlock_detector_remove(struct platform_device *pdev)
+static int __accel_deadlock_detector_remove(struct platform_device *pdev)
 {
     struct xocl_accel_deadlock_detector *accel_deadlock_detector = NULL;
     void *hdl = NULL;
@@ -86,6 +86,15 @@ static int accel_deadlock_detector_remove(struct platform_device *pdev)
 
     return 0;
 }
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+static void accel_deadlock_detector_remove(struct platform_device *pdev)
+{
+    __accel_deadlock_detector_remove(pdev);
+}
+#else
+#define accel_deadlock_detector_remove __accel_deadlock_detector_remove
+#endif
 
 static int accel_deadlock_detector_probe(struct platform_device *pdev)
 {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/address_translator.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/address_translator.c
@@ -391,7 +391,7 @@ failed:
 }
 
 
-static int addr_translator_remove(struct platform_device *pdev)
+static int __addr_translator_remove(struct platform_device *pdev)
 {
 	struct addr_translator *addr_translator = platform_get_drvdata(pdev);
 
@@ -410,6 +410,15 @@ static int addr_translator_remove(struct platform_device *pdev)
 
 	return 0;
 }
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+static void addr_translator_remove(struct platform_device *pdev)
+{
+	__addr_translator_remove(pdev);
+}
+#else
+#define addr_translator_remove __addr_translator_remove
+#endif
 
 struct xocl_drv_private addr_translator_priv = {
 	.ops = &addr_translator_ops,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/aim.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/aim.c
@@ -244,7 +244,7 @@ static struct attribute_group aim_attr_group = {
 			   .attrs = aim_attrs,
 };
 
-static int aim_remove(struct platform_device *pdev)
+static int __aim_remove(struct platform_device *pdev)
 {
 	struct xocl_aim *aim;
 	void *hdl;
@@ -268,6 +268,15 @@ static int aim_remove(struct platform_device *pdev)
 
 	return 0;
 }
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+static void aim_remove(struct platform_device *pdev)
+{
+	__aim_remove(pdev);
+}
+#else
+#define aim_remove __aim_remove
+#endif
 
 static int aim_probe(struct platform_device *pdev)
 {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/am.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/am.c
@@ -230,7 +230,7 @@ static struct attribute_group am_attr_group = {
 			   .attrs = am_attrs,
 };
 
-static int am_remove(struct platform_device *pdev)
+static int __am_remove(struct platform_device *pdev)
 {
 	struct xocl_am *am;
 	void *hdl;
@@ -254,6 +254,15 @@ static int am_remove(struct platform_device *pdev)
 
 	return 0;
 }
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+static void am_remove(struct platform_device *pdev)
+{
+	__am_remove(pdev);
+}
+#else
+#define am_remove __am_remove
+#endif
 
 static int am_probe(struct platform_device *pdev)
 {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/asm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/asm.c
@@ -170,7 +170,7 @@ static struct attribute_group asm_attr_group = {
 			   .attrs = asm_attrs,
 };
 
-static int asm_remove(struct platform_device *pdev)
+static int __asm_remove(struct platform_device *pdev)
 {
 	struct xocl_asm *xocl_asm;
 	void *hdl;
@@ -194,6 +194,15 @@ static int asm_remove(struct platform_device *pdev)
 
 	return 0;
 }
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+static void asm_remove(struct platform_device *pdev)
+{
+	__asm_remove(pdev);
+}
+#else
+#define asm_remove __asm_remove
+#endif
 
 static int asm_probe(struct platform_device *pdev)
 {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/axigate.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/axigate.c
@@ -148,7 +148,7 @@ static struct xocl_axigate_funcs axigate_ops = {
 	.get_status = axigate_status,
 };
 
-static int axigate_remove(struct platform_device *pdev)
+static int __axigate_remove(struct platform_device *pdev)
 {
 	struct axi_gate *gate;
 
@@ -169,6 +169,15 @@ static int axigate_remove(struct platform_device *pdev)
 
 	return 0;
 }
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+static void axigate_remove(struct platform_device *pdev)
+{
+	__axigate_remove(pdev);
+}
+#else
+#define axigate_remove __axigate_remove
+#endif
 
 static int axigate_probe(struct platform_device *pdev)
 {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/calib_storage.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/calib_storage.c
@@ -173,7 +173,7 @@ static int calib_storage_probe(struct platform_device *pdev)
 }
 
 
-static int calib_storage_remove(struct platform_device *pdev)
+static int __calib_storage_remove(struct platform_device *pdev)
 {
 	struct calib_storage *calib_storage = platform_get_drvdata(pdev);
 
@@ -189,6 +189,15 @@ static int calib_storage_remove(struct platform_device *pdev)
 
 	return 0;
 }
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+static void calib_storage_remove(struct platform_device *pdev)
+{
+	__calib_storage_remove(pdev);
+}
+#else
+#define calib_storage_remove __calib_storage_remove
+#endif
 
 struct xocl_drv_private calib_storage_priv = {
 	.ops = &calib_storage_ops,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/cfg_gpio.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/cfg_gpio.c
@@ -102,7 +102,7 @@ static int32_t gpio_cfg(struct platform_device *pdev, enum ert_gpio_cfg type)
 	mutex_unlock(&cfg_gpio->lock);
 	return ret;
 }
-static int config_gpio_remove(struct platform_device *pdev)
+static int __config_gpio_remove(struct platform_device *pdev)
 {
 	struct config_gpio *config_gpio;
 	void *hdl;
@@ -121,6 +121,15 @@ static int config_gpio_remove(struct platform_device *pdev)
 
 	return 0;
 }
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+static void config_gpio_remove(struct platform_device *pdev)
+{
+	__config_gpio_remove(pdev);
+}
+#else
+#define config_gpio_remove __config_gpio_remove
+#endif
 
 static int config_gpio_probe(struct platform_device *pdev)
 {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/clock_counter.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/clock_counter.c
@@ -267,7 +267,7 @@ static struct xocl_clock_counter_funcs clock_counter_ops = {
 	.get_freq_counter = clock_counter_get_freq,
 };
 
-static int clock_counter_remove(struct platform_device *pdev)
+static int __clock_counter_remove(struct platform_device *pdev)
 {
 	struct clock_counter *clock_c;
 
@@ -287,6 +287,15 @@ static int clock_counter_remove(struct platform_device *pdev)
 
 	return 0;
 }
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+static void clock_counter_remove(struct platform_device *pdev)
+{
+	__clock_counter_remove(pdev);
+}
+#else
+#define clock_counter_remove __clock_counter_remove
+#endif
 
 static int clock_counter_probe(struct platform_device *pdev)
 {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/clock_wiz.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/clock_wiz.c
@@ -1245,7 +1245,7 @@ static struct xocl_clock_wiz_funcs clock_wiz_ops = {
 	.get_data = clock_wiz_get_data,
 };
 
-static int clock_wiz_remove(struct platform_device *pdev)
+static int __clock_wiz_remove(struct platform_device *pdev)
 {
 	struct clock_wiz *clock_w;
 
@@ -1265,6 +1265,15 @@ static int clock_wiz_remove(struct platform_device *pdev)
 
 	return 0;
 }
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+static void clock_wiz_remove(struct platform_device *pdev)
+{
+	__clock_wiz_remove(pdev);
+}
+#else
+#define clock_wiz_remove __clock_wiz_remove
+#endif
 
 static int clock_wiz_probe(struct platform_device *pdev)
 {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/command_queue.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/command_queue.c
@@ -626,7 +626,7 @@ static struct xrt_ert_queue_funcs command_queue_func = {
 	.intc_config = command_queue_intc_config,
 };
 
-static int command_queue_remove(struct platform_device *pdev)
+static int __command_queue_remove(struct platform_device *pdev)
 {
 	struct xrt_ert *command_queue;
 	xdev_handle_t xdev = xocl_get_xdev(pdev);
@@ -650,6 +650,15 @@ static int command_queue_remove(struct platform_device *pdev)
 
 	return 0;
 }
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+static void command_queue_remove(struct platform_device *pdev)
+{
+	__command_queue_remove(pdev);
+}
+#else
+#define command_queue_remove __command_queue_remove
+#endif
 
 static int command_queue_probe(struct platform_device *pdev)
 {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/cu.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/cu.c
@@ -518,7 +518,7 @@ err:
 	return err;
 }
 
-static int cu_remove(struct platform_device *pdev)
+static int __cu_remove(struct platform_device *pdev)
 {
 	xdev_handle_t xdev = xocl_get_xdev(pdev);
 	struct xrt_cu_info *info;
@@ -562,6 +562,15 @@ static int cu_remove(struct platform_device *pdev)
 
 	return 0;
 }
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+static void cu_remove(struct platform_device *pdev)
+{
+	__cu_remove(pdev);
+}
+#else
+#define cu_remove __cu_remove
+#endif
 
 static struct platform_device_id cu_id_table[] = {
 	{ XOCL_DEVNAME(XOCL_CU), 0 },

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ddr_srsr.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ddr_srsr.c
@@ -312,7 +312,7 @@ failed:
 }
 
 
-static int xocl_ddr_srsr_remove(struct platform_device *pdev)
+static int __xocl_ddr_srsr_remove(struct platform_device *pdev)
 {
 	struct xocl_ddr_srsr *xocl_ddr_srsr = platform_get_drvdata(pdev);
 
@@ -332,6 +332,15 @@ static int xocl_ddr_srsr_remove(struct platform_device *pdev)
 
 	return 0;
 }
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+static void xocl_ddr_srsr_remove(struct platform_device *pdev)
+{
+	__xocl_ddr_srsr_remove(pdev);
+}
+#else
+#define xocl_ddr_srsr_remove __xocl_ddr_srsr_remove
+#endif
 
 struct xocl_drv_private srsr_priv = {
 	.ops = &srsr_ops,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/dna.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/dna.c
@@ -463,7 +463,7 @@ failed:
 }
 
 
-static int xlnx_dna_remove(struct platform_device *pdev)
+static int __xlnx_dna_remove(struct platform_device *pdev)
 {
 	struct xocl_xlnx_dna	*xlnx_dna;
 
@@ -483,6 +483,15 @@ static int xlnx_dna_remove(struct platform_device *pdev)
 
 	return 0;
 }
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+static void xlnx_dna_remove(struct platform_device *pdev)
+{
+	__xlnx_dna_remove(pdev);
+}
+#else
+#define xlnx_dna_remove __xlnx_dna_remove
+#endif
 
 struct xocl_drv_private dna_priv = {
 	.ops = &dna_ops,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert.c
@@ -361,7 +361,7 @@ static struct xocl_mb_funcs ert_ops = {
 	.stop			= stop_ert,
 };
 
-static int ert_remove(struct platform_device *pdev)
+static int __ert_remove(struct platform_device *pdev)
 {
 	struct xocl_ert *ert;
 	void *hdl;
@@ -395,6 +395,15 @@ static int ert_remove(struct platform_device *pdev)
 	xocl_drvinst_free(hdl);
 	return 0;
 }
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+static void ert_remove(struct platform_device *pdev)
+{
+	__ert_remove(pdev);
+}
+#else
+#define ert_remove __ert_remove
+#endif
 
 static int ert_probe(struct platform_device *pdev)
 {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_ctrl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_ctrl.c
@@ -880,7 +880,7 @@ static int ert_ctrl_cq_init(struct platform_device *pdev)
 	return 0;
 }
 
-static int ert_ctrl_remove(struct platform_device *pdev)
+static int __ert_ctrl_remove(struct platform_device *pdev)
 {
 	struct ert_ctrl	*ec = NULL;
 	xdev_handle_t xdev = xocl_get_xdev(pdev);
@@ -911,6 +911,15 @@ static int ert_ctrl_remove(struct platform_device *pdev)
 
 	return 0;
 }
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+static void ert_ctrl_remove(struct platform_device *pdev)
+{
+	__ert_ctrl_remove(pdev);
+}
+#else
+#define ert_ctrl_remove __ert_ctrl_remove
+#endif
 
 static int ert_ctrl_probe(struct platform_device *pdev)
 {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_user.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_user.c
@@ -1464,7 +1464,7 @@ add_event:
 }
 
 
-static int ert_user_remove(struct platform_device *pdev)
+static int __ert_user_remove(struct platform_device *pdev)
 {
 	struct xocl_ert_user *ert_user;
 	void *hdl;
@@ -1491,6 +1491,15 @@ static int ert_user_remove(struct platform_device *pdev)
 
 	return 0;
 }
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+static void ert_user_remove(struct platform_device *pdev)
+{
+	__ert_user_remove(pdev);
+}
+#else
+#define ert_user_remove __ert_user_remove
+#endif
 
 static int ert_user_probe(struct platform_device *pdev)
 {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/feature_rom.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/feature_rom.c
@@ -869,7 +869,7 @@ failed:
 	return ret;
 }
 
-static int feature_rom_remove(struct platform_device *pdev)
+static int __feature_rom_remove(struct platform_device *pdev)
 {
 	struct feature_rom *rom;
 
@@ -888,6 +888,15 @@ static int feature_rom_remove(struct platform_device *pdev)
 	devm_kfree(&pdev->dev, rom);
 	return 0;
 }
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+static void feature_rom_remove(struct platform_device *pdev)
+{
+	__feature_rom_remove(pdev);
+}
+#else
+#define feature_rom_remove __feature_rom_remove
+#endif
 
 struct xocl_drv_private rom_priv = {
 	.ops = &rom_ops,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/firewall.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/firewall.c
@@ -589,7 +589,7 @@ static struct xocl_firewall_funcs fw_ops = {
 	.get_data = af_get_data,
 };
 
-static int firewall_remove(struct platform_device *pdev)
+static int __firewall_remove(struct platform_device *pdev)
 {
 	struct firewall *fw;
 	int     i;
@@ -610,6 +610,15 @@ static int firewall_remove(struct platform_device *pdev)
 	devm_kfree(&pdev->dev, fw);
 	return 0;
 }
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+static void firewall_remove(struct platform_device *pdev)
+{
+	__firewall_remove(pdev);
+}
+#else
+#define firewall_remove __firewall_remove
+#endif
 
 static void get_fw_ep_name(const char *res_name, char *result)
 {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/flash.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/flash.c
@@ -1397,7 +1397,7 @@ static void sysfs_destroy_flash(struct xocl_flash *flash)
 		sysfs_remove_group(&flash->pdev->dev.kobj, &flash_attr_group);
 }
 
-static int flash_remove(struct platform_device *pdev)
+static int __flash_remove(struct platform_device *pdev)
 {
 	struct xocl_flash *flash;
 	void *hdl;
@@ -1421,6 +1421,15 @@ static int flash_remove(struct platform_device *pdev)
 	xocl_drvinst_free(hdl);
 	return 0;
 }
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+static void flash_remove(struct platform_device *pdev)
+{
+	__flash_remove(pdev);
+}
+#else
+#define flash_remove __flash_remove
+#endif
 
 static int flash_probe(struct platform_device *pdev)
 {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/fmgr.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/fmgr.c
@@ -195,7 +195,7 @@ static int fmgr_probe(struct platform_device *pdev)
 	return ret;
 }
 
-static int fmgr_remove(struct platform_device *pdev)
+static int __fmgr_remove(struct platform_device *pdev)
 {
 #if defined(FPGA_MGR_SUPPORT)
 	struct fpga_manager *mgr = platform_get_drvdata(pdev);
@@ -219,6 +219,15 @@ static int fmgr_remove(struct platform_device *pdev)
 	kfree(obj);
 	return 0;
 }
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+static void fmgr_remove(struct platform_device *pdev)
+{
+	__fmgr_remove(pdev);
+}
+#else
+#define fmgr_remove __fmgr_remove
+#endif
 
 static struct platform_driver	fmgr_driver = {
 	.probe		= fmgr_probe,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/hwmon_sdm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/hwmon_sdm.c
@@ -1229,7 +1229,7 @@ failed:
 	return err;
 }
 
-static int hwmon_sdm_remove(struct platform_device *pdev)
+static int __hwmon_sdm_remove(struct platform_device *pdev)
 {
 	struct xocl_hwmon_sdm *sdm;
 	void *hdl;
@@ -1251,6 +1251,15 @@ static int hwmon_sdm_remove(struct platform_device *pdev)
 
 	return 0;
 }
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+static void hwmon_sdm_remove(struct platform_device *pdev)
+{
+	__hwmon_sdm_remove(pdev);
+}
+#else
+#define hwmon_sdm_remove __hwmon_sdm_remove
+#endif
 
 static ssize_t
 bd_name_show(struct device *dev, struct device_attribute *attr, char *buf)

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -4304,7 +4304,7 @@ static struct attribute_group icap_attr_group = {
 	.bin_attrs = icap_bin_attrs,
 };
 
-static int icap_remove(struct platform_device *pdev)
+static int __icap_remove(struct platform_device *pdev)
 {
 	struct icap *icap = platform_get_drvdata(pdev);
 	xdev_handle_t xdev = xocl_get_xdev(pdev);
@@ -4339,6 +4339,15 @@ static int icap_remove(struct platform_device *pdev)
 	xocl_drvinst_free(hdl);
 	return 0;
 }
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+static void icap_remove(struct platform_device *pdev)
+{
+	__icap_remove(pdev);
+}
+#else
+#define icap_remove __icap_remove
+#endif
 
 /*
  * Run the following sequence of canned commands to obtain IDCODE of the FPGA

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap_cntrl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap_cntrl.c
@@ -166,7 +166,7 @@ static int icap_cntrl_sysfs_create(struct icap_cntrl *ic)
 	return 0;
 }
 
-static int icap_cntrl_remove(struct platform_device *pdev)
+static int __icap_cntrl_remove(struct platform_device *pdev)
 {
 	struct icap_cntrl *icap_cntrl;
 	void *hdl;
@@ -189,6 +189,15 @@ static int icap_cntrl_remove(struct platform_device *pdev)
 
 	return 0;
 }
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+static void icap_cntrl_remove(struct platform_device *pdev)
+{
+	__icap_cntrl_remove(pdev);
+}
+#else
+#define icap_cntrl_remove __icap_cntrl_remove
+#endif
 
 static int icap_cntrl_probe(struct platform_device *pdev)
 {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/intc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/intc.c
@@ -652,7 +652,7 @@ err:
 	return ret;
 }
 
-static int intc_remove(struct platform_device *pdev)
+static int __intc_remove(struct platform_device *pdev)
 {
 	struct xocl_intc *intc = platform_get_drvdata(pdev);
 	xdev_handle_t xdev = xocl_get_xdev(pdev);
@@ -671,6 +671,15 @@ static int intc_remove(struct platform_device *pdev)
 	xocl_drvinst_free(hdl);
 	return 0;
 }
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+static void intc_remove(struct platform_device *pdev)
+{
+	__intc_remove(pdev);
+}
+#else
+#define intc_remove __intc_remove
+#endif
 
 static struct xocl_intc_funcs intc_ops = {
 	.request_intr	= request_intr,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/iores.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/iores.c
@@ -83,7 +83,7 @@ static struct xocl_iores_funcs iores_ops = {
 	.get_offset = get_offset,
 };
 
-static int iores_remove(struct platform_device *pdev)
+static int __iores_remove(struct platform_device *pdev)
 {
 	struct iores *iores;
 	int i;
@@ -103,6 +103,15 @@ static int iores_remove(struct platform_device *pdev)
 
 	return 0;
 }
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+static void iores_remove(struct platform_device *pdev)
+{
+	__iores_remove(pdev);
+}
+#else
+#define iores_remove __iores_remove
+#endif
 
 static int iores_probe(struct platform_device *pdev)
 {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/lapc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/lapc.c
@@ -93,7 +93,7 @@ static struct attribute_group lapc_attr_group = {
 			   .attrs = lapc_attrs,
 };
 
-static int lapc_remove(struct platform_device *pdev)
+static int __lapc_remove(struct platform_device *pdev)
 {
 	struct xocl_lapc *lapc;
 	void *hdl;
@@ -117,6 +117,15 @@ static int lapc_remove(struct platform_device *pdev)
 
 	return 0;
 }
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+static void lapc_remove(struct platform_device *pdev)
+{
+	__lapc_remove(pdev);
+}
+#else
+#define lapc_remove __lapc_remove
+#endif
 
 static int lapc_probe(struct platform_device *pdev)
 {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/m2m.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/m2m.c
@@ -217,7 +217,7 @@ struct platform_device_id m2m_id_table[] = {
 	{ },
 };
 
-static int m2m_remove(struct platform_device *pdev)
+static int __m2m_remove(struct platform_device *pdev)
 {
 	struct xocl_dev *xdev = xocl_get_xdev(pdev);
 	struct xocl_m2m	*m2m;
@@ -252,6 +252,15 @@ static int m2m_remove(struct platform_device *pdev)
 	devm_kfree(&pdev->dev, m2m);
 	return 0;
 }
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+static void m2m_remove(struct platform_device *pdev)
+{
+	__m2m_remove(pdev);
+}
+#else
+#define m2m_remove __m2m_remove
+#endif
 
 static int m2m_probe(struct platform_device *pdev)
 {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mailbox.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mailbox.c
@@ -3101,7 +3101,7 @@ static const struct file_operations mailbox_fops = {
 };
 
 /* Tearing down driver in the exact reverse order as driver setting up. */
-static int mailbox_remove(struct platform_device *pdev)
+static int __mailbox_remove(struct platform_device *pdev)
 {
 	struct mailbox *mbx = platform_get_drvdata(pdev);
 	void *hdl;
@@ -3122,6 +3122,15 @@ static int mailbox_remove(struct platform_device *pdev)
 	xocl_drvinst_free(hdl);
 	return 0;
 }
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+static void mailbox_remove(struct platform_device *pdev)
+{
+	__mailbox_remove(pdev);
+}
+#else
+#define mailbox_remove __mailbox_remove
+#endif
 
 static int mailbox_probe(struct platform_device *pdev)
 {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mailbox_versal.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mailbox_versal.c
@@ -240,7 +240,7 @@ static struct xocl_mailbox_versal_funcs mailbox_versal_ops = {
 	.free_intr      = mailbox_versal_free_intr,
 };
 
-static int mailbox_versal_remove(struct platform_device *pdev)
+static int __mailbox_versal_remove(struct platform_device *pdev)
 {
 	struct mailbox_versal *mbv = platform_get_drvdata(pdev);
 
@@ -251,6 +251,15 @@ static int mailbox_versal_remove(struct platform_device *pdev)
 
 	return 0;
 }
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+static void mailbox_versal_remove(struct platform_device *pdev)
+{
+	__mailbox_versal_remove(pdev);
+}
+#else
+#define mailbox_versal_remove __mailbox_versal_remove
+#endif
 
 static int mailbox_versal_probe(struct platform_device *pdev)
 {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/memory_hbm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/memory_hbm.c
@@ -580,7 +580,7 @@ static int mem_hbm_probe(struct platform_device *pdev)
 	return 0;
 }
 
-static int mem_hbm_remove(struct platform_device *pdev)
+static int __mem_hbm_remove(struct platform_device *pdev)
 {
 	struct xocl_mem_hbm	*mem_hbm;
 
@@ -599,6 +599,15 @@ static int mem_hbm_remove(struct platform_device *pdev)
 
 	return 0;
 }
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+static void mem_hbm_remove(struct platform_device *pdev)
+{
+	__mem_hbm_remove(pdev);
+}
+#else
+#define mem_hbm_remove __mem_hbm_remove
+#endif
 
 struct xocl_drv_private mem_hbm_priv = {
 	.ops = &mem_hbm_ops,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mgmt_msix.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mgmt_msix.c
@@ -322,7 +322,7 @@ failed:
 	return ret;
 }
 
-static int mgmt_msix_remove(struct platform_device *pdev)
+static int __mgmt_msix_remove(struct platform_device *pdev)
 {
 	xdev_handle_t xdev;
 	struct xocl_mgmt_msix *mgmt_msix;
@@ -354,6 +354,15 @@ static int mgmt_msix_remove(struct platform_device *pdev)
 
 	return 0;
 }
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+static void mgmt_msix_remove(struct platform_device *pdev)
+{
+	__mgmt_msix_remove(pdev);
+}
+#else
+#define mgmt_msix_remove __mgmt_msix_remove
+#endif
 
 struct xocl_drv_private mgmt_msix_priv = {
 	.ops = &mgmt_msix_ops,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/microblaze.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/microblaze.c
@@ -612,7 +612,7 @@ static struct xocl_mb_funcs mb_ops = {
 
 
 
-static int mb_remove(struct platform_device *pdev)
+static int __mb_remove(struct platform_device *pdev)
 {
 	struct xocl_mb *mb;
 	int	i;
@@ -647,6 +647,15 @@ static int mb_remove(struct platform_device *pdev)
 
 	return 0;
 }
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+static void mb_remove(struct platform_device *pdev)
+{
+	__mb_remove(pdev);
+}
+#else
+#define mb_remove __mb_remove
+#endif
 
 static int mb_probe(struct platform_device *pdev)
 {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mig.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mig.c
@@ -498,7 +498,7 @@ static int mig_probe(struct platform_device *pdev)
 	return 0;
 }
 
-static int mig_remove(struct platform_device *pdev)
+static int __mig_remove(struct platform_device *pdev)
 {
 	struct xocl_mig	*mig;
 
@@ -516,6 +516,15 @@ static int mig_remove(struct platform_device *pdev)
 
 	return 0;
 }
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+static void mig_remove(struct platform_device *pdev)
+{
+	__mig_remove(pdev);
+}
+#else
+#define mig_remove __mig_remove
+#endif
 
 struct xocl_drv_private mig_priv = {
 	.ops = &mig_ops,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/msix_xdma.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/msix_xdma.c
@@ -256,7 +256,7 @@ failed:
 	return ret;
 }
 
-static int msix_xdma_remove(struct platform_device *pdev)
+static int __msix_xdma_remove(struct platform_device *pdev)
 {
 	xdev_handle_t xdev;
 	struct xocl_msix_xdma *msix_xdma;
@@ -293,6 +293,15 @@ static int msix_xdma_remove(struct platform_device *pdev)
 
 	return 0;
 }
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+static void msix_xdma_remove(struct platform_device *pdev)
+{
+	__msix_xdma_remove(pdev);
+}
+#else
+#define msix_xdma_remove __msix_xdma_remove
+#endif
 
 struct xocl_drv_private msix_xdma_priv = {
 	.ops = &msix_xdma_ops,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/nifd.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/nifd.c
@@ -629,7 +629,7 @@ failed:
     return err;
 }
 
-static int nifd_remove(struct platform_device *pdev)
+static int __nifd_remove(struct platform_device *pdev)
 {
     struct xocl_nifd *nifd;
     struct xocl_dev_core *core;
@@ -653,6 +653,15 @@ static int nifd_remove(struct platform_device *pdev)
 
     return 0;
 }
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+static void nifd_remove(struct platform_device *pdev)
+{
+    __nifd_remove(pdev);
+}
+#else
+#define nifd_remove __nifd_remove
+#endif
 
 struct xocl_drv_private nifd_priv = {
 	.ops = NULL,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ospi_versal.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ospi_versal.c
@@ -403,7 +403,7 @@ static int xfer_versal_close(struct inode *inode, struct file *file)
 	return 0;
 }
 
-static int xfer_versal_remove(struct platform_device *pdev)
+static int __xfer_versal_remove(struct platform_device *pdev)
 {
 	struct xfer_versal *xv = platform_get_drvdata(pdev);
 	void *hdl;
@@ -424,6 +424,15 @@ static int xfer_versal_remove(struct platform_device *pdev)
 	XV_INFO(xv, "return: %d", ret);
 	return ret;
 }
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+static void xfer_versal_remove(struct platform_device *pdev)
+{
+	__xfer_versal_remove(pdev);
+}
+#else
+#define xfer_versal_remove __xfer_versal_remove
+#endif
 
 static int xfer_versal_probe(struct platform_device *pdev)
 {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/p2p.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/p2p.c
@@ -1470,7 +1470,7 @@ static int p2p_sysfs_create(struct p2p *p2p)
 	return 0;
 }
 
-static int p2p_remove(struct platform_device *pdev)
+static int __p2p_remove(struct platform_device *pdev)
 {
 	struct p2p *p2p;
 	struct pci_dev *pcidev;
@@ -1502,6 +1502,15 @@ static int p2p_remove(struct platform_device *pdev)
 
 	return 0;
 }
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+static void p2p_remove(struct platform_device *pdev)
+{
+	__p2p_remove(pdev);
+}
+#else
+#define p2p_remove __p2p_remove
+#endif
 
 static int p2p_probe(struct platform_device *pdev)
 {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/pcie_firewall.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/pcie_firewall.c
@@ -79,7 +79,7 @@ static struct xocl_pcie_firewall_funcs firewall_ops = {
 	.unblock = firewall_unblock,
 };
 
-static int firewall_remove(struct platform_device *pdev)
+static int __firewall_remove(struct platform_device *pdev)
 {
 	struct firewall *firewall;
 	void *hdl;
@@ -100,6 +100,15 @@ static int firewall_remove(struct platform_device *pdev)
 
 	return 0;
 }
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+static void firewall_remove(struct platform_device *pdev)
+{
+	__firewall_remove(pdev);
+}
+#else
+#define firewall_remove __firewall_remove
+#endif
 
 static int firewall_probe(struct platform_device *pdev)
 {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/pmc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/pmc.c
@@ -138,7 +138,7 @@ static struct xocl_pmc_funcs pmc_ops = {
 	.enable_reset = pmc_enable_reset,
 };
 
-static int pmc_remove(struct platform_device *pdev)
+static int __pmc_remove(struct platform_device *pdev)
 {
 	struct pmc *pmc;
 
@@ -157,6 +157,15 @@ static int pmc_remove(struct platform_device *pdev)
 	PMC_INFO(pmc, "successfully removed pmc subdev");
 	return 0;
 }
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+static void pmc_remove(struct platform_device *pdev)
+{
+	__pmc_remove(pdev);
+}
+#else
+#define pmc_remove __pmc_remove
+#endif
 
 static int pmc_probe(struct platform_device *pdev)
 {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ps.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ps.c
@@ -345,7 +345,7 @@ static int ps_sysfs_create(struct xocl_ps *ps)
 	return 0;
 }
 
-static int ps_remove(struct platform_device *pdev)
+static int __ps_remove(struct platform_device *pdev)
 {
 	struct xocl_ps *ps;
 
@@ -363,7 +363,16 @@ static int ps_remove(struct platform_device *pdev)
 	mutex_destroy(&ps->ps_lock);
 
 	return 0;
-};
+}
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+static void ps_remove(struct platform_device *pdev)
+{
+	__ps_remove(pdev);
+}
+#else
+#define ps_remove __ps_remove
+#endif
 
 struct xocl_drv_private ps_priv = {
 	.ops = &ps_ops,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/qdma.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/qdma.c
@@ -893,7 +893,7 @@ failed:
 	return ret;
 }
 
-static int qdma_remove(struct platform_device *pdev)
+static int __qdma_remove(struct platform_device *pdev)
 {
 	struct xocl_qdma *qdma= platform_get_drvdata(pdev);
 	xdev_handle_t xdev;
@@ -934,6 +934,15 @@ static int qdma_remove(struct platform_device *pdev)
 
 	return 0;
 }
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+static void qdma_remove(struct platform_device *pdev)
+{
+	__qdma_remove(pdev);
+}
+#else
+#define qdma_remove __qdma_remove
+#endif
 
 struct xocl_drv_private qdma_priv = {
 	.ops = &qdma_ops,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/scu.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/scu.c
@@ -325,7 +325,7 @@ err:
 	return err;
 }
 
-static int scu_remove(struct platform_device *pdev)
+static int __scu_remove(struct platform_device *pdev)
 {
 	xdev_handle_t xdev = xocl_get_xdev(pdev);
 	struct xrt_cu_info *info = NULL;
@@ -350,6 +350,15 @@ static int scu_remove(struct platform_device *pdev)
 
 	return 0;
 }
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+static void scu_remove(struct platform_device *pdev)
+{
+	__scu_remove(pdev);
+}
+#else
+#define scu_remove __scu_remove
+#endif
 
 static struct platform_device_id scu_id_table[] = {
 	{ XOCL_DEVNAME(XOCL_SCU), 0 },

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/spc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/spc.c
@@ -74,7 +74,7 @@ static struct attribute_group spc_attr_group = {
 			   .attrs = spc_attrs,
 };
 
-static int spc_remove(struct platform_device *pdev)
+static int __spc_remove(struct platform_device *pdev)
 {
 	struct xocl_spc *spc;
 	void *hdl;
@@ -98,6 +98,15 @@ static int spc_remove(struct platform_device *pdev)
 
 	return 0;
 }
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+static void spc_remove(struct platform_device *pdev)
+{
+	__spc_remove(pdev);
+}
+#else
+#define spc_remove __spc_remove
+#endif
 
 static int spc_probe(struct platform_device *pdev)
 {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/sysmon.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/sysmon.c
@@ -363,7 +363,7 @@ failed:
 }
 
 
-static int sysmon_remove(struct platform_device *pdev)
+static int __sysmon_remove(struct platform_device *pdev)
 {
 	struct xocl_sysmon	*sysmon;
 
@@ -383,6 +383,15 @@ static int sysmon_remove(struct platform_device *pdev)
 
 	return 0;
 }
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+static void sysmon_remove(struct platform_device *pdev)
+{
+	__sysmon_remove(pdev);
+}
+#else
+#define sysmon_remove __sysmon_remove
+#endif
 
 struct xocl_drv_private sysmon_priv = {
 	.ops = &sysmon_ops,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/trace_fifo_full.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/trace_fifo_full.c
@@ -22,7 +22,7 @@ struct trace_fifo_full {
 	struct mutex 		lock;
 };
 
-static int trace_fifo_full_remove(struct platform_device *pdev)
+static int __trace_fifo_full_remove(struct platform_device *pdev)
 {
 	struct trace_fifo_full *trace_fifo_full;
 	void *hdl;
@@ -41,6 +41,15 @@ static int trace_fifo_full_remove(struct platform_device *pdev)
 
 	return 0;
 }
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+static void trace_fifo_full_remove(struct platform_device *pdev)
+{
+	__trace_fifo_full_remove(pdev);
+}
+#else
+#define trace_fifo_full_remove __trace_fifo_full_remove
+#endif
 
 static int trace_fifo_full_probe(struct platform_device *pdev)
 {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/trace_fifo_lite.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/trace_fifo_lite.c
@@ -61,7 +61,7 @@ static long get_numbytes(struct trace_fifo_lite *fifo, void __user *arg)
 	return 0;
 }
 
-static int trace_fifo_lite_remove(struct platform_device *pdev)
+static int __trace_fifo_lite_remove(struct platform_device *pdev)
 {
 	struct trace_fifo_lite *trace_fifo_lite;
 	void *hdl;
@@ -83,6 +83,15 @@ static int trace_fifo_lite_remove(struct platform_device *pdev)
 
 	return 0;
 }
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+static void trace_fifo_lite_remove(struct platform_device *pdev)
+{
+	__trace_fifo_lite_remove(pdev);
+}
+#else
+#define trace_fifo_lite_remove __trace_fifo_lite_remove
+#endif
 
 static int trace_fifo_lite_probe(struct platform_device *pdev)
 {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/trace_funnel.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/trace_funnel.c
@@ -64,7 +64,7 @@ static long train_clock(struct trace_funnel *trace_funnel, void __user *arg)
 	return 0;
 }
 
-static int trace_funnel_remove(struct platform_device *pdev)
+static int __trace_funnel_remove(struct platform_device *pdev)
 {
 	struct trace_funnel *trace_funnel;
 	void *hdl;
@@ -86,6 +86,15 @@ static int trace_funnel_remove(struct platform_device *pdev)
 
 	return 0;
 }
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+static void trace_funnel_remove(struct platform_device *pdev)
+{
+	__trace_funnel_remove(pdev);
+}
+#else
+#define trace_funnel_remove __trace_funnel_remove
+#endif
 
 static int trace_funnel_probe(struct platform_device *pdev)
 {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/trace_s2mm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/trace_s2mm.c
@@ -123,7 +123,7 @@ static long get_wordcount(struct xocl_trace_s2mm *trace_s2mm, void __user *arg)
 	return 0;
 }
 
-static int trace_s2mm_remove(struct platform_device *pdev)
+static int __trace_s2mm_remove(struct platform_device *pdev)
 {
 	struct xocl_trace_s2mm *trace_s2mm;
 	void *hdl;
@@ -145,6 +145,15 @@ static int trace_s2mm_remove(struct platform_device *pdev)
 
 	return 0;
 }
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+static void trace_s2mm_remove(struct platform_device *pdev)
+{
+	__trace_s2mm_remove(pdev);
+}
+#else
+#define trace_s2mm_remove __trace_s2mm_remove
+#endif
 
 static int trace_s2mm_probe(struct platform_device *pdev)
 {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ulite.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ulite.c
@@ -564,7 +564,7 @@ done:
  * `return`.
  * https://elixir.bootlin.com/linux/latest/source/include/linux/platform_device.h#L211
  */
-static int ulite_remove(struct platform_device *pdev)
+static int __ulite_remove(struct platform_device *pdev)
 {
 	struct uart_port *port = platform_get_drvdata(pdev);
 	struct uartlite_data *pdata;
@@ -588,6 +588,15 @@ static int ulite_remove(struct platform_device *pdev)
 
 	return 0;
 }
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+static void ulite_remove(struct platform_device *pdev)
+{
+	__ulite_remove(pdev);
+}
+#else
+#define ulite_remove __ulite_remove
+#endif
 
 struct xocl_drv_private ulite_priv = {
 	.ops = NULL,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ulite.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ulite.c
@@ -186,9 +186,51 @@ static int ulite_receive(struct uart_port *port, int stat)
 	return 1;
 }
 
+/* commit 1788cf6a91d9 ("tty: serial: switch from circ_buf to kfifo") */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0)
+static inline bool ulite_uart_is_empty(struct uart_port *p)
+{
+	return uart_circ_empty(&p->state->xmit);
+}
+static inline unsigned ulite_uart_pending(struct uart_port *p)
+{
+	return uart_circ_chars_pending(&p->state->xmit);
+}
+static inline int ulite_uart_pop_char(struct uart_port *port)
+{
+	struct circ_buf *xmit = &port->state->xmit;
+	u8 ret = xmit->buf[xmit->tail];
+
+	/*
+	 * When the tail of the circular buffer is reached, the next
+	 * byte is transferred to the beginning of the buffer.
+	 */
+	xmit->tail = (xmit->tail + 1) & (UART_XMIT_SIZE-1);
+	return ret;
+}
+#else
+static inline bool ulite_uart_is_empty(struct uart_port *p)
+{
+	return kfifo_is_empty(&p->state->port.xmit_fifo);
+}
+static inline unsigned ulite_uart_pending(struct uart_port *p)
+{
+	return kfifo_len(&p->state->port.xmit_fifo);
+}
+static inline int ulite_uart_pop_char(struct uart_port *port)
+{
+	struct tty_port *tport = &port->state->port;
+	u8 ret;
+
+	if (!kfifo_get(&tport->xmit_fifo, &ret))
+		return -1;
+	return ret;
+}
+#endif
+
 static int ulite_transmit(struct uart_port *port, int stat)
 {
-	struct circ_buf *xmit  = &port->state->xmit;
+	int ch;
 
 	if (stat & ULITE_STATUS_TXFULL)
 		return 0;
@@ -200,15 +242,17 @@ static int ulite_transmit(struct uart_port *port, int stat)
 		return 1;
 	}
 
-	if (uart_circ_empty(xmit) || uart_tx_stopped(port))
+	if (ulite_uart_is_empty(port) || uart_tx_stopped(port))
 		return 0;
 
-	uart_out32(xmit->buf[xmit->tail], ULITE_TX, port);
-	xmit->tail = (xmit->tail + 1) & (UART_XMIT_SIZE-1);
+	ch = ulite_uart_pop_char(port);
+	if (ch <= 0)
+		return 0;
+	uart_out32((char)ch, ULITE_TX, port);
 	port->icount.tx++;
 
 	/* wake up */
-	if (uart_circ_chars_pending(xmit) < WAKEUP_CHARS)
+	if (ulite_uart_pending(port) < WAKEUP_CHARS)
 		uart_write_wakeup(port);
 
 	return 1;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/version_ctrl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/version_ctrl.c
@@ -119,7 +119,7 @@ static int version_ctrl_sysfs_create(struct version_ctrl *vc)
 	return 0;
 }
 
-static int version_ctrl_remove(struct platform_device *pdev)
+static int __version_ctrl_remove(struct platform_device *pdev)
 {
 	struct version_ctrl *version_ctrl;
 	void *hdl;
@@ -141,6 +141,15 @@ static int version_ctrl_remove(struct platform_device *pdev)
 
 	return 0;
 }
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+static void version_ctrl_remove(struct platform_device *pdev)
+{
+	__version_ctrl_remove(pdev);
+}
+#else
+#define version_ctrl_remove __version_ctrl_remove
+#endif
 
 static struct xocl_version_ctrl_funcs vc_ops = {
 	.flat_shell_check = flat_shell_check,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xdma.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xdma.c
@@ -538,7 +538,7 @@ failed:
 	return ret;
 }
 
-static int xdma_remove(struct platform_device *pdev)
+static int __xdma_remove(struct platform_device *pdev)
 {
 	struct xocl_xdma *xdma = platform_get_drvdata(pdev);
 	xdev_handle_t xdev;
@@ -584,6 +584,15 @@ static int xdma_remove(struct platform_device *pdev)
 
 	return 0;
 }
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+static void xdma_remove(struct platform_device *pdev)
+{
+	__xdma_remove(pdev);
+}
+#else
+#define xdma_remove __xdma_remove
+#endif
 
 struct xocl_drv_private xdma_priv = {
 	.ops = &xdma_ops,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
@@ -3351,7 +3351,7 @@ static int xgq_ospi_close(struct inode *inode, struct file *file)
 	return 0;
 }
 
-static int xgq_vmr_remove(struct platform_device *pdev)
+static int __xgq_vmr_remove(struct platform_device *pdev)
 {
 	xdev_handle_t xdev = xocl_get_xdev(pdev);
 	struct xocl_xgq_vmr	*xgq;
@@ -3390,6 +3390,16 @@ static int xgq_vmr_remove(struct platform_device *pdev)
 	XGQ_INFO(xgq, "successfully removed xgq subdev");
 	return 0;
 }
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+static void xgq_vmr_remove(struct platform_device *pdev)
+{
+	__xgq_vmr_remove(pdev);
+}
+#else
+#define xgq_vmr_remove __xgq_vmr_remove
+#endif
+
 /* Function to query VMR and return the appropriate
  * SC status.
  */ 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xiic.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xiic.c
@@ -1030,7 +1030,7 @@ failed:
 	return ret;
 }
 
-static int xiic_remove(struct platform_device *pdev)
+static int __xiic_remove(struct platform_device *pdev)
 {
 	struct xiic_i2c *i2c;
 
@@ -1053,6 +1053,15 @@ static int xiic_remove(struct platform_device *pdev)
 
 	return 0;
 }
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+static void xiic_remove(struct platform_device *pdev)
+{
+	__xiic_remove(pdev);
+}
+#else
+#define xiic_remove __xiic_remove
+#endif
 
 struct platform_device_id xiic_id_table[] = {
 	{ XOCL_DEVNAME(XOCL_XIIC), 0 },

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xiic.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xiic.c
@@ -861,7 +861,11 @@ static const struct i2c_algorithm xiic_algorithm = {
 
 static struct i2c_adapter xiic_adapter = {
 	.owner = THIS_MODULE,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0)
+	.class = I2C_CLASS_HWMON,
+#else
 	.class = I2C_CLASS_HWMON | I2C_CLASS_SPD,
+#endif
 	.algo = &xiic_algorithm,
 };
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
@@ -3931,7 +3931,7 @@ static void xmc_unload_board_info(struct xocl_xmc *xmc)
 	xmc->bdinfo_raw = NULL;
 }
 
-static int xmc_remove(struct platform_device *pdev)
+static int __xmc_remove(struct platform_device *pdev)
 {
 	struct xocl_xmc *xmc;
 	void *hdl;
@@ -3976,6 +3976,15 @@ end:
 	xocl_drvinst_free(hdl);
 	return 0;
 }
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+static void xmc_remove(struct platform_device *pdev)
+{
+	__xmc_remove(pdev);
+}
+#else
+#define xmc_remove __xmc_remove
+#endif
 
 static const char *xmc_get_board_info(uint32_t *bdinfo_raw,
 	uint32_t bdinfo_raw_sz, enum board_info_key key, size_t *len)

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc_u2.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc_u2.c
@@ -3673,7 +3673,7 @@ static void xmc_unload_board_info(struct xocl_xmc *xmc)
 	xmc->bdinfo_raw = NULL;
 }
 
-static int xmc_remove(struct platform_device *pdev)
+static int __xmc_remove(struct platform_device *pdev)
 {
 	struct xocl_xmc *xmc;
 	void *hdl;
@@ -3718,6 +3718,15 @@ end:
 	xocl_drvinst_free(hdl);
 	return 0;
 }
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+static void xmc_remove(struct platform_device *pdev)
+{
+	__xmc_remove(pdev);
+}
+#else
+#define xmc_remove __xmc_remove
+#endif
 
 static const char *xmc_get_board_info(uint32_t *bdinfo_raw,
 	uint32_t bdinfo_raw_sz, enum board_info_key key, size_t *len)

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xvc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xvc.c
@@ -386,7 +386,7 @@ failed:
 }
 
 
-static int xvc_remove(struct platform_device *pdev)
+static int __xvc_remove(struct platform_device *pdev)
 {
 	struct xocl_xvc	*xvc;
 	void *hdl;
@@ -405,6 +405,15 @@ static int xvc_remove(struct platform_device *pdev)
 
 	return 0;
 }
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+static void xvc_remove(struct platform_device *pdev)
+{
+	__xvc_remove(pdev);
+}
+#else
+#define xvc_remove __xvc_remove
+#endif
 
 struct xocl_drv_private xvc_pub = {
 	.ops = NULL,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_debug.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_debug.c
@@ -145,7 +145,9 @@ static const struct file_operations trace_fops = {
 	.open = trace_open,
 	.release = trace_release,
 	.read = trace_read,
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
 	.llseek = no_llseek,
+#endif
 };
 
 static ssize_t trace_mod_read(struct file *file, char __user *buf,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -43,6 +43,7 @@
 #include <linux/types.h>
 #include <linux/moduleparam.h>
 #include <linux/cdev.h>
+#include <linux/vmalloc.h>
 
 #include "xocl_types.h"
 #include "xclbin.h"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
xrt doesn't build on linux kernels newer than v6.10

#### How problem was solved, alternative solutions (if any) and why they were rejected
Add more ifdefs, one patch generated with Сoccinelle.

#### What has been tested and how, request additional testing if necessary
So far, I only build tested on v6.12-rc3.
And local sources yet use 2023.1 release, so it might not fix all build issues (though, the biggest diff I generated on the latest master).

#### Risks (if any) associated the changes in the commit
For older kernels this should be no-op as guarded by ifdefs.
