### PR TITLE
Change default ml timeline buffer size to 192K

### DIFF
--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -250,7 +250,7 @@ get_ml_timeline()
 inline std::string
 get_ml_timeline_buffer_size()
 {
-  static std::string value = detail::get_string_value("Debug.ml_timeline_buffer_size", "128K");
+  static std::string value = detail::get_string_value("Debug.ml_timeline_buffer_size", "192K");
   return value;
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Since the size of cycle value in record_timer_ts.json is changed from from 32bit to 64bit, which will cause the alignment issue when the buffer is overwritten. This commit could resolve this alignment issue.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
PR8416 introduces this bug. In the test case, generated record_timer_ts.json contains the wrong records.
#### How problem was solved, alternative solutions (if any) and why they were rejected
Set size value of a multiple of 12K would make the buffer is aligned when it's full. In this case, the issue disappears.
#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Run test and make sure the buffer is overwritten, then the alignment caused wrong result in record_timer_ts.json has gone.  It means that this commit resolve this issue.
#### Documentation impact (if any)
