### PR TITLE
CR-1217444 Callback on xrt::run causes "kds monitor died" and hang

### DIFF
--- a/src/runtime_src/core/common/api/hw_queue.cpp
+++ b/src/runtime_src/core/common/api/hw_queue.cpp
@@ -398,7 +398,7 @@ public:
 
   // Managed start uses command manager for monitoring command
   // completion
-  void
+  virtual void
   managed_start(xrt_core::command* cmd)
   {
     get_cmd_manager()->launch(cmd);
@@ -425,6 +425,16 @@ public:
     : m_hwctx(std::move(hwctx))
     , m_qhdl(qhdl)
   {}
+
+  // Managed start is invoked when application has added a callback
+  // function for notification of command completion. This is not
+  // supported for platforms that implement hwqueue_handle (see
+  // details in wait(size_t) comments.
+  void
+  managed_start(xrt_core::command*) override
+  {
+    throw std::runtime_error("Managed execution is not supported for this device");
+  }
 
   std::cv_status
   wait(size_t /*timeout_ms*/) override


### PR DESCRIPTION
#### Problem solved by the commit
Trap unsupported managed execution earlier.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
We don't plan on supporting callbacks for xrt::run objects for RyzenAI.  This would kill performance.  Callbacks are used under the hood in the OpenCL implementation and are indeed supported for XRT native APIs on Alveo, but not for RyzenAI

#### How problem was solved, alternative solutions (if any) and why they were rejected
This PR changes code such that an exception is thrown when an xrt::run object is started after adding a callback on the run object.
