### PR TITLE
running authorize job on - [self-hosted, Ubuntu-22.04]

### DIFF
--- a/.github/workflows/xrt_ci.yml
+++ b/.github/workflows/xrt_ci.yml
@@ -15,7 +15,7 @@ concurrency:
   
 jobs:
   authorize:
-    runs-on: Ubuntu-22.04
+    runs-on: [self-hosted, Ubuntu-22.04]
     steps:
       - name: Checkout private repository      
         uses: actions/checkout@v4   


### PR DESCRIPTION
 - job is landing on cloud runners hence using [self-hosted, Ubuntu-22.04]
 - https://jira.xilinx.com/browse/SR-960180
 