### PR TITLE
Add -npu switch to compile for Lin Client. 

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -53,12 +53,12 @@ usage()
     echo "[-opt]                      Build optimized library only (default)"
     echo "[-edge]                     Build edge of x64.  Turns off opt and dbg"
     echo "[-hip]                      Enable hip bindings"
-    echo "[-noalveo]                  Disable bundling of Alveo Linux drivers"
     echo "[-disable-werror]           Disable compilation with warnings as error"
     echo "[-nocmake]                  Skip CMake call"
     echo "[-noert]                    Do not treat missing ERT FW as a build error"
     echo "[-noinit]                   Do not initialize Git submodules"
     echo "[-noctest]                  Skip unit tests"
+    echo "[-npu]                      Build for NPU only. Disable bundling of Alveo Linux drivers. Do not treat missing ERT FW as a build error. Compile XDP plugins for NPU."
     echo "[-with-static-boost <boost> Build binaries using static linking of boost from specified boost install"
     echo "[-clangtidy]                Run clang-tidy as part of build"
     echo "[-pskernel]                 Enable building of POC ps kernel"
@@ -156,9 +156,12 @@ while [ $# -gt 0 ]; do
             shift
             cmake_flags+=" -DXRT_ENABLE_HIP=ON"
             ;;
-	-noalveo)
+	-npu)
             shift
 	    alveo=0
+	    noert=1
+	    cmake_flags+=" -DXDP_CLIENT_BUILD_CMAKE=yes"
+	    cmake_flags+=" -DNPU=1"
             ;;
         -opt)
             dbg=0

--- a/src/CMake/cpackLin.cmake
+++ b/src/CMake/cpackLin.cmake
@@ -19,6 +19,10 @@ SET(CPACK_ARCHIVE_COMPONENT_INSTALL ON)
 SET(CPACK_DEB_COMPONENT_INSTALL ON)
 SET(CPACK_RPM_COMPONENT_INSTALL ON)
 
+if (DEFINED NPU)
+  SET(CPACK_PACKAGE_NAME "npu")
+endif()
+
 # When the rpmbuild occurs for packaging, it uses a default version of
 # python to perform a python byte compilation.  For the CentOS 7.x OS, this
 # is python2.  Being that the XRT python code is for python3, this results in


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Compiling with -npu will build xrt package named "npu*" targeted for Linux Client. The Alveo drivers will be disabled and ERT is not included. This will include XDP Plugins targeted only for Client devices. Only host side profiling plugins are included for now. Other features like ML Timeline, AIE profile/trace will be enabled in later PRs.
 
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
We need to update compilation instructions in amd-xdna repo with this change.