### PR TITLE
ml_timeline record json file add more info

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.cpp
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.cpp
@@ -121,11 +121,14 @@ namespace xdp {
 
     boost::property_tree::ptree ptSchema;
     ptSchema.put("major", "1");
-    ptSchema.put("minor", "0");
+    ptSchema.put("minor", "1");
     ptSchema.put("patch", "0");
     ptHeader.add_child("schema_version", ptSchema);
     ptHeader.put("device", "Client");
     ptHeader.put("clock_freq_MHz", 1000);
+    ptHeader.put("id_size", sizeof(uint32_t));
+    ptHeader.put("cycle_size", 2*sizeof(uint32_t));
+    ptHeader.put("buffer_size", mBufSz);
     ptTop.add_child("header", ptHeader);
 
     // Record Timer TS in JSON


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Because the size of cycle value in record_timer_ts.json is changed from from 32bit to 64bit, when try to parse it, just depends on the information provided by the header, it's not known that the cycle value is 64bit or 32bit, which means it's difficult to be compatible to the previous version. This commit resolves compatible problem. 
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Providing id/cycle size would make record_timer_ts.json parser easily distinguish the last version of previous version.
#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Run test and generate record_timer_ts.json, then check the header which would contain the id/cycle size information.
#### Documentation impact (if any)
