### PR TITLE
Updating the petalinux to its latest version

### DIFF
--- a/build/petalinux.build
+++ b/build/petalinux.build
@@ -1,3 +1,3 @@
 # When updating Petalinux build please file a SH ticket to retain the build
 # https://jira.xilinx.com/secure/CreateIssue!default.jspa
-PETALINUX=/proj/petalinux/2024.2/petalinux-v2024.2_10101427/tool/petalinux-v2024.2-final
+PETALINUX=/proj/petalinux/2024.2/petalinux-v2024.2_10241236/tool/petalinux-v2024.2-final


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Updating Petalinux built to Latest (petalinux-v2024.2_10241236). SH https://jira.xilinx.com/browse/SH-2571 to retain the petalinux build.
This petalinux build has the "invalid start col/ number col error" fix from the xilinx-aie-engine
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
None
#### How problem was solved, alternative solutions (if any) and why they were rejected
Updating Petalinux built to Latest
#### Risks (if any) associated the changes in the commit
None
#### What has been tested and how, request additional testing if necessary
Verified zynqmp/versal builds
#### Documentation impact (if any)
None