### PR TITLE
ZOCL version adjusted to 2.19 for 2025.1

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/Makefile
+++ b/src/runtime_src/core/edge/drm/zocl/Makefile
@@ -32,8 +32,8 @@ endif
 
 ccflags-y += -Wall
 
-# Version adjusted to 2.18 for 2024.2
-XRT_DRIVER_VERSION ?= 2.18.0
+# Version adjusted to 2.19 for 2025.1
+XRT_DRIVER_VERSION ?= 2.19.0
 
 # Add patch number in version if 'XRT_VERSION_PATCH' env variable is defined
 ifneq ($(XRT_VERSION_PATCH),)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
updating zocl version to 2.19 for 2025.1
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
none
#### How problem was solved, alternative solutions (if any) and why they were rejected
updating zocl version to 2.19 for 2025.1
#### Risks (if any) associated the changes in the commit
none
#### What has been tested and how, request additional testing if necessary
Tested on versal (simple gmio testcase) and zynqmp (zcu102 hello world testcase)
#### Documentation impact (if any)
none