### PR TITLE
CR-1219123 and CR-1219106 fix

### DIFF
--- a/src/runtime_src/core/tools/common/XBHelpMenusCore.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenusCore.cpp
@@ -11,6 +11,7 @@ namespace XBU = XBUtilities;
 
 // 3rd Party Library - Include Files
 #include <boost/property_tree/json_parser.hpp>
+#include <boost/program_options/cmdline.hpp>
 #include <boost/format.hpp>
 namespace po = boost::program_options;
 
@@ -640,7 +641,11 @@ XBUtilities::process_arguments( po::variables_map& vm,
   all_positionals.add("__unreg", -1);
 
   // Parse the given options and hold onto the results
-  auto parsed_options = parser.options(all_options).positional(all_positionals).allow_unregistered().run();
+  auto parsed_options = parser.options(all_options)
+                        .positional(all_positionals)
+                        .allow_unregistered()
+                        .style(~po::command_line_style::allow_guessing)
+                        .run();
 
   if (validate_arguments) {
     // This variables holds options denoted with a '-' or '--' that were not registered


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
This fixes CR-1219123 and CR-1219106 : Incorrect behavior when guessing is enabled in program options within xrt-smi

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://jira.xilinx.com/browse/CR-1219106
https://jira.xilinx.com/browse/CR-1219123

#### How problem was solved, alternative solutions (if any) and why they were rejected
The problem was solved by disabling option guessing in program options. This makes using sub-command like --verb for --verbose as invalid and throw out correct consistant error

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Tested on kracken board
Behavior before fix 
```
C:\Windows\System32\AMD>xrt-smi validate --p
ERROR: option '--p' is ambiguous and matches '--param', '--path', and '--pmode'

COMMAND: validate

DESCRIPTION: Validates the given device by executing the platform's validate executable.

USAGE: xrt-smi validate [--help] [-d arg] [-f arg] [-o arg] [-r arg]

OPTIONS:
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest
  -f, --format       - Report output format. Valid values are:
                         JSON        - Latest JSON schema
                         JSON-2020.2 - JSON 2020.2 schema
  -o, --output       - Direct the output to the given file
  --help             - Help to use this sub-command
  -r, --run          - Run a subset of the test suite. Valid options are:
                       Common:
                         all                       - All applicable validate tests will be
                                                     executed (default)
                         quick                     - Run a subset of four tests:
                                                     1. latency
                                                     2. throughput
                                                     3. cmd-chain-latency
                                                     4. cmd-chain-throughput
                       AIE:
                         aie-reconfig-overhead     - Run end-to-end array reconfiguration overhead
                                                     through shim DMA
                         cmd-chain-latency         - Run end-to-end latency test using command
                                                     chaining
                         cmd-chain-throughput      - Run end-to-end throughput test using command
                                                     chaining
                         df-bw                     - Run bandwidth test on data fabric
                         gemm                      - Measure the TOPS value of GEMM operations
                         latency                   - Run end-to-end latency test
                         spatial-sharing-overhead  - Run Spatial Sharing Overhead Test
                         tct-all-col               - Measure average TCT processing time for all
                                                     columns
                         tct-one-col               - Measure average TCT processing time for one
                                                     column
                         temporal-sharing-overhead - Run Temporal Sharing Overhead Test
                         throughput                - Run end-to-end throughput test
                       Alveo:
                         aie                       - Run AIE PL test
                         aux-connection            - Check if auxiliary power is connected
                         dma                       - Run dma test
                         hostmem-bw                - Run 'bandwidth kernel' when host memory is
                                                     enabled
                         iops                      - Run scheduler performance measure test
                         m2m                       - Run M2M test
                         mem-bw                    - Run 'bandwidth kernel' and check the
                                                     throughput
                         p2p                       - Run P2P test
                         pcie-link                 - Check if PCIE link is active
                         sc-version                - Check if SC firmware is up-to-date
                         vcu                       - Run decoder test
                         verify                    - Run 'Hello World' kernel test


GLOBAL OPTIONS:
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
ERROR: operation canceled
```
After fix :
```
Y:\Repos\XRT-MCDM-FORK\XRT-MCDM\build\WRelease\xilinx\xrt>xrt-smi validate --p
ERROR: Unrecognized arguments:
  --p


COMMAND: validate

DESCRIPTION: Validates the given device by executing the platform's validate executable.

USAGE: xrt-smi validate [--help] [-d arg] [-f arg] [-o arg] [-r arg]

OPTIONS:
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest
  -f, --format       - Report output format. Valid values are:
                         JSON        - Latest JSON schema
                         JSON-2020.2 - JSON 2020.2 schema
  -o, --output       - Direct the output to the given file
  --help             - Help to use this sub-command
  -r, --run          - Run a subset of the test suite. Valid options are:
                         aie-reconfig-overhead     - Run end-to-end array reconfiguration overhead
                                                     through shim DMA
                         all                       - All applicable validate tests will be
                                                     executed (default)
                         cmd-chain-latency         - Run end-to-end latency test using command
                                                     chaining
                         cmd-chain-throughput      - Run end-to-end throughput test using command
                                                     chaining
                         df-bw                     - Run bandwidth test on data fabric
                         gemm                      - Measure the TOPS value of GEMM operations
                         latency                   - Run end-to-end latency test
                         quick                     - Run a subset of four tests:
                                                     1. latency
                                                     2. throughput
                                                     3. cmd-chain-latency
                                                     4. cmd-chain-throughput
                         spatial-sharing-overhead  - Run Spatial Sharing Overhead Test
                         tct-all-col               - Measure average TCT processing time for all
                                                     columns
                         tct-one-col               - Measure average TCT processing time for one
                                                     column
                         temporal-sharing-overhead - Run Temporal Sharing Overhead Test
                         throughput                - Run end-to-end throughput test


GLOBAL OPTIONS:
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
ERROR: operation canceled
```

#### Documentation impact (if any)
N/A