### PR TITLE
Enable ML Timeline Plugin in XDP for Linux Client

### DIFF
--- a/src/runtime_src/CMakeLists.txt
+++ b/src/runtime_src/CMakeLists.txt
@@ -4,18 +4,6 @@
 
 # Note: Add Windows compilation directives at the END of this file
 
-if (XDP_CLIENT_BUILD_CMAKE STREQUAL "yes")
-  set(AIERT_DIR ${CMAKE_CURRENT_BINARY_DIR}/aie-rt)
-  set(XAIENGINE_BUILD_SHARED OFF)
-  xrt_add_subdirectory(aie-rt/driver/src aie-rt)
-  # This enables aiebu submodule use aie-rt from higher level
-  set(AIEBU_AIE_RT_BIN_DIR ${AIERT_DIR})
-  set(AIEBU_AIE_RT_HEADER_DIR ${AIERT_DIR}/include)
-  message("-- Exporting AIEBU_AIE_RT_BIN_DIR=${AIEBU_AIE_RT_BIN_DIR}")
-  message("-- Exporting AIEBU_AIE_RT_HEADER_DIR=${AIEBU_AIE_RT_HEADER_DIR}")
-endif()
-
-
 if( NOT WIN32)
 
 if(${CMAKE_BUILD_TYPE} STREQUAL "Release" AND ${XRT_NATIVE_BUILD} STREQUAL "yes")
@@ -85,6 +73,17 @@ else()
     # lots of warnings and all warnings as errors
     # add_compile_options(-Wall -Wextra -pedantic -Werror)
     add_compile_options( ${XRT_WARN_OPTS} )
+  endif()
+
+  if (XDP_CLIENT_BUILD_CMAKE STREQUAL "yes")
+    set(AIERT_DIR ${CMAKE_CURRENT_BINARY_DIR}/aie-rt)
+    set(XAIENGINE_BUILD_SHARED OFF)
+    xrt_add_subdirectory(aie-rt/driver/src aie-rt)
+    # This enables aiebu submodule use aie-rt from higher level
+    set(AIEBU_AIE_RT_BIN_DIR ${AIERT_DIR})
+    set(AIEBU_AIE_RT_HEADER_DIR ${AIERT_DIR}/include)
+    message("-- Exporting AIEBU_AIE_RT_BIN_DIR=${AIEBU_AIE_RT_BIN_DIR}")
+    message("-- Exporting AIEBU_AIE_RT_HEADER_DIR=${AIEBU_AIE_RT_HEADER_DIR}")
   endif()
 
   # Build Subdirectories

--- a/src/runtime_src/CMakeLists.txt
+++ b/src/runtime_src/CMakeLists.txt
@@ -4,6 +4,18 @@
 
 # Note: Add Windows compilation directives at the END of this file
 
+if (XDP_CLIENT_BUILD_CMAKE STREQUAL "yes")
+  set(AIERT_DIR ${CMAKE_CURRENT_BINARY_DIR}/aie-rt)
+  set(XAIENGINE_BUILD_SHARED OFF)
+  xrt_add_subdirectory(aie-rt/driver/src aie-rt)
+  # This enables aiebu submodule use aie-rt from higher level
+  set(AIEBU_AIE_RT_BIN_DIR ${AIERT_DIR})
+  set(AIEBU_AIE_RT_HEADER_DIR ${AIERT_DIR}/include)
+  message("-- Exporting AIEBU_AIE_RT_BIN_DIR=${AIEBU_AIE_RT_BIN_DIR}")
+  message("-- Exporting AIEBU_AIE_RT_HEADER_DIR=${AIEBU_AIE_RT_HEADER_DIR}")
+endif()
+
+
 if( NOT WIN32)
 
 if(${CMAKE_BUILD_TYPE} STREQUAL "Release" AND ${XRT_NATIVE_BUILD} STREQUAL "yes")
@@ -73,17 +85,6 @@ else()
     # lots of warnings and all warnings as errors
     # add_compile_options(-Wall -Wextra -pedantic -Werror)
     add_compile_options( ${XRT_WARN_OPTS} )
-  endif()
-
-  if (XDP_CLIENT_BUILD_CMAKE STREQUAL "yes")
-    set(AIERT_DIR ${CMAKE_CURRENT_BINARY_DIR}/aie-rt)
-    set(XAIENGINE_BUILD_SHARED OFF)
-    xrt_add_subdirectory(aie-rt/driver/src aie-rt)
-    # This enables aiebu submodule use aie-rt from higher level
-    set(AIEBU_AIE_RT_BIN_DIR ${AIERT_DIR})
-    set(AIEBU_AIE_RT_HEADER_DIR ${AIERT_DIR}/include)
-    message("-- Exporting AIEBU_AIE_RT_BIN_DIR=${AIEBU_AIE_RT_BIN_DIR}")
-    message("-- Exporting AIEBU_AIE_RT_HEADER_DIR=${AIEBU_AIE_RT_HEADER_DIR}")
   endif()
 
   # Build Subdirectories

--- a/src/runtime_src/core/common/xdp/profile.cpp
+++ b/src/runtime_src/core/common/xdp/profile.cpp
@@ -382,7 +382,7 @@ update_device(void* handle)
   /* Adding the macro guard as the static instances of the following plugins
    * get created unnecessarily when the configs are enabled on Edge.
    */
-
+  #ifdef _WIN32
   if (xrt_core::config::get_ml_timeline()
       || xrt_core::config::get_aie_profile()
       || xrt_core::config::get_aie_trace()
@@ -398,6 +398,7 @@ update_device(void* handle)
       return;
     }
   }
+  #endif
 
   if (xrt_core::config::get_aie_halt()) {
     try {

--- a/src/runtime_src/xdp/profile/plugin/CMakeLists.txt
+++ b/src/runtime_src/xdp/profile/plugin/CMakeLists.txt
@@ -6,13 +6,16 @@ if (XDP_CLIENT_BUILD_CMAKE STREQUAL "yes")
 
   add_subdirectory(native)
   add_subdirectory(user)
-  add_subdirectory(aie_profile)
-  add_subdirectory(aie_trace)
-  add_subdirectory(aie_debug)
-  add_subdirectory(aie_halt)
-  add_subdirectory(aie_pc)
   add_subdirectory(ml_timeline)
- 
+
+  if (WIN32)
+    add_subdirectory(aie_profile)
+    add_subdirectory(aie_trace)
+    add_subdirectory(aie_debug)
+    add_subdirectory(aie_halt)
+    add_subdirectory(aie_pc)
+  endif()
+   
 else()
 
 # =========================================================

--- a/src/runtime_src/xdp/profile/plugin/CMakeLists.txt
+++ b/src/runtime_src/xdp/profile/plugin/CMakeLists.txt
@@ -6,15 +6,13 @@ if (XDP_CLIENT_BUILD_CMAKE STREQUAL "yes")
 
   add_subdirectory(native)
   add_subdirectory(user)
-  
-  if (WIN32)
-    add_subdirectory(aie_profile)
-    add_subdirectory(aie_trace)
-    add_subdirectory(aie_debug)
-    add_subdirectory(aie_halt)
-    add_subdirectory(aie_pc)
-    add_subdirectory(ml_timeline)
-  endif()
+  add_subdirectory(aie_profile)
+  add_subdirectory(aie_trace)
+  add_subdirectory(aie_debug)
+  add_subdirectory(aie_halt)
+  add_subdirectory(aie_pc)
+  add_subdirectory(ml_timeline)
+ 
 else()
 
 # =========================================================


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Enabled ml timeline plugin to be used for linux client devices.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
NA

#### Risks (if any) associated the changes in the commit
NA

#### What has been tested and how, request additional testing if necessary
Tested ml timeline plugin on linux and the supported plugins on windows client.

#### Documentation impact (if any)
NA