### PR TITLE
VITIS-13786 Update aie partition report to show active and suspended contexts

### DIFF
--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -1768,6 +1768,7 @@ struct aie_partition_info : request
     uint64_t    start_col;
     uint64_t    num_cols;
     int         pid;
+    bool        is_suspended;
     uint64_t    instruction_mem;
     uint64_t    command_submissions;
     uint64_t    command_completions;

--- a/src/runtime_src/core/tools/common/Table2D.cpp
+++ b/src/runtime_src/core/tools/common/Table2D.cpp
@@ -37,7 +37,7 @@ void
 Table2D::appendToOutput(std::string& output, const std::string& prefix, const std::string& suffix, const ColumnData& column, const std::string& data) const
 {
   // Format for table data
-  boost::format fmt("%s|%s%s%s%s|");
+  boost::format fmt("%s%s%s%s%s");
   size_t left_blanks = 0;
   size_t right_blanks = 0;
   getBlankSizes(column, data.size(), left_blanks, right_blanks);

--- a/src/runtime_src/core/tools/common/Table2D.cpp
+++ b/src/runtime_src/core/tools/common/Table2D.cpp
@@ -37,7 +37,7 @@ void
 Table2D::appendToOutput(std::string& output, const std::string& prefix, const std::string& suffix, const ColumnData& column, const std::string& data) const
 {
   // Format for table data
-  boost::format fmt("%s%s%s%s%s");
+  boost::format fmt("%s%s%s%s%s|");
   size_t left_blanks = 0;
   size_t right_blanks = 0;
   getBlankSizes(column, data.size(), left_blanks, right_blanks);
@@ -57,7 +57,9 @@ Table2D::toString(const std::string& prefix) const
 
       // The first column must align with the user desires
       // All other columns should only use the previous lines space suffix
-      const std::string column_prefix = (col == 0) ? prefix : "";
+      std::string column_prefix = "";
+      if (col == 0)
+         column_prefix = prefix + '|';
 
       // For the first row add the headers
       const auto space_suffix = std::string(m_inter_entry_padding, ' ');

--- a/src/runtime_src/core/tools/common/reports/ReportAiePartitions.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportAiePartitions.cpp
@@ -33,7 +33,7 @@ populate_aie_partition(const xrt_core::device* device)
     boost::property_tree::ptree pt_entry;
     pt_entry.put("pid", entry.pid);
     pt_entry.put("context_id", entry.metadata.id);
-    pt_entry.put("status", entry.is_suspended ? "IDLE" : "ACTIVE");
+    pt_entry.put("status", entry.is_suspended ? "Idle" : "Active");
     pt_entry.put("instr_bo_mem", entry.instruction_mem);
     pt_entry.put("command_submissions", entry.command_submissions);
     pt_entry.put("command_completions", entry.command_completions);


### PR DESCRIPTION
#### Problem solved by the commit
https://jira.xilinx.com/browse/VITIS-13786
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Users had concerns over column occupancy/utilization
#### How problem was solved, alternative solutions (if any) and why they were rejected
We will revisit column occupancy in the future and have removed it for now. Removed the double dividers from various tables and made them single dividers as asked. Added status column ("Active" or "Idle") to each context.
#### Risks (if any) associated the changes in the commit
Double-check documentation for GA RAI_1.3 to ensure they don't expect column occupancy if this is backported.
#### What has been tested and how, request additional testing if necessary
Tested on STX/MCDM using Divyajyoti's changes in MCDM for status values. 
![Sample Output](https://github.com/user-attachments/assets/13d06a04-c892-433c-b49a-70d9fae08b1e)

#### Documentation impact (if any)
Possibly, see comment in risks