### PR TITLE
ML timeline buffer needs to be 12KB aligned now

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.cpp
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.cpp
@@ -60,8 +60,8 @@ namespace xdp {
       }
   };
 
-  MLTimelineClientDevImpl::MLTimelineClientDevImpl(VPDatabase*dB)
-    : MLTimelineImpl(dB)
+  MLTimelineClientDevImpl::MLTimelineClientDevImpl(VPDatabase*dB, uint32_t sz)
+    : MLTimelineImpl(dB, sz)
   {
     xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT", 
               "Created ML Timeline Plugin for Client Device.");
@@ -134,16 +134,16 @@ namespace xdp {
     // Record Timer TS in JSON
     // Assuming correct Stub has been called and Write Buffer contains valid data
     
-    uint32_t max_count = mBufSz / (3*sizeof(uint32_t));
+    uint32_t maxCount = mBufSz / RECORD_TIMER_ENTRY_SZ_IN_BYTES;
     // Each record timer entry has 32bit ID and 32bit AIE High Timer + 32bit AIE Low Timer value.
 
-    uint32_t numEntries = max_count;
+    uint32_t numEntries = maxCount;
     std::stringstream msg;
     msg << "A maximum of " << numEntries << " record can be accommodated in given buffer of bytes size 0x"
         << std::hex << mBufSz << std::dec << std::endl;
     xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT", msg.str());
 
-    if (numEntries <= max_count) {
+    if (numEntries <= maxCount) {
       for (uint32_t i = 0 ; i < numEntries; i++) {
         boost::property_tree::ptree ptIdTS;
         uint32_t id = *ptr;

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.h
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.h
@@ -27,7 +27,7 @@ namespace xdp {
   {
     std::unique_ptr<ResultBOContainer> mResultBOHolder;
     public :
-      MLTimelineClientDevImpl(VPDatabase* dB);
+      MLTimelineClientDevImpl(VPDatabase* dB, uint32_t sz);
 
       ~MLTimelineClientDevImpl();
 

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_impl.h
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_impl.h
@@ -21,6 +21,9 @@
 
 namespace xdp {
 
+  // Each record timer entry has 32bit ID and 32bit AIE High Timer + 32bit AIE Low Timer value.
+  constexpr uint32_t RECORD_TIMER_ENTRY_SZ_IN_BYTES = 3*sizeof(uint32_t);
+
   class VPDatabase;
 
   class MLTimelineImpl
@@ -30,8 +33,9 @@ namespace xdp {
       uint32_t mBufSz;
 
     public:
-      MLTimelineImpl(VPDatabase* dB)
-        : db(dB)
+      MLTimelineImpl(VPDatabase* dB, uint32_t sz)
+        : db(dB),
+          mBufSz(sz)
       {}
 
       MLTimelineImpl() = delete;
@@ -40,11 +44,6 @@ namespace xdp {
 
       virtual void updateDevice(void*) = 0;
       virtual void finishflushDevice(void*, uint64_t) = 0;
-
-      void setBufSize(uint32_t sz)
-      {
-        mBufSz = sz;
-      }
   };
 
 }

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_plugin.cpp
@@ -51,7 +51,9 @@ namespace xdp {
           bufSz = (uint32_t)std::stoull(subStr[1]) * uint_constants::one_mb;
         }
         if (0 != (bufSz % RECORD_TIMER_ENTRY_SZ_IN_BYTES)) {
-          /* Adjusting given ML Timeline Buffer Size for alignment */
+          /* Adjusting given ML Timeline Buffer Size for alignment to avoid incorrect reads when Host Buffer
+           * gets overwritten with excess record timer data.
+           */
           std::stringstream msg;
           msg << "Adjusting given ML Timeline Buffer Size (in bytes) 0x" << std::hex << bufSz << std::dec;
           bufSz = (bufSz / RECORD_TIMER_ENTRY_SZ_IN_BYTES) * RECORD_TIMER_ENTRY_SZ_IN_BYTES;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Each record timer entry now has 32 bit ID + 64bit AIE Timer(High+Low). So, the buffer should be 12KB aligned to avoid incorrect reads when buffer is overwritten with excess record timer data.
A fix was added earlier to use 192KB as the default host buffer size. This PR now adjusts the user specified buffer size to 12KB aligned.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://github.com/Xilinx/XRT/pull/8416 introduced the issue and it was discovered by DPU team

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Unit tests
#### Documentation impact (if any)
