### PR TITLE
Support windows linking with xrt_coreutil_static without dllimport

### DIFF
--- a/src/runtime_src/core/common/config.h
+++ b/src/runtime_src/core/common/config.h
@@ -21,10 +21,12 @@
 //------------------Enable dynamic linking on windows-------------------------//
 
 #ifdef _WIN32
-# ifdef XRT_CORE_COMMON_SOURCE
-#  define XRT_CORE_COMMON_EXPORT __declspec(dllexport)
-# else
-#  define XRT_CORE_COMMON_EXPORT __declspec(dllimport)
+# ifndef XRT_STATIC_BUILD
+#  ifdef XRT_CORE_COMMON_SOURCE
+#   define XRT_CORE_COMMON_EXPORT __declspec(dllexport)
+#  else
+#   define XRT_CORE_COMMON_EXPORT __declspec(dllimport)
+#  endif
 # endif
 #endif
 #ifdef __linux__

--- a/src/runtime_src/core/include/deprecated/xrt.h
+++ b/src/runtime_src/core/include/deprecated/xrt.h
@@ -41,15 +41,23 @@
 #endif
 
 #if defined(_WIN32)
-#ifdef XCL_DRIVER_DLL_EXPORT
-#define XCL_DRIVER_DLLESPEC __declspec(dllexport)
-#else
-#define XCL_DRIVER_DLLESPEC __declspec(dllimport)
+# ifndef XRT_STATIC_BUILD
+#  ifdef XCL_DRIVER_DLL_EXPORT
+#   define XCL_DRIVER_DLLESPEC __declspec(dllexport)
+#  else
+#   define XCL_DRIVER_DLLESPEC __declspec(dllimport)
+#  endif
+# endif
+# define XCL_DRIVER_DLLHIDDEN
 #endif
-#define XCL_DRIVER_DLLHIDDEN
-#else
-#define XCL_DRIVER_DLLESPEC __attribute__((visibility("default")))
-#define XCL_DRIVER_DLLHIDDEN __attribute__((visibility("hidden")))
+
+#ifdef __linux__
+# define XCL_DRIVER_DLLESPEC __attribute__((visibility("default")))
+# define XCL_DRIVER_DLLHIDDEN __attribute__((visibility("hidden")))
+#endif
+
+#ifndef XCL_DRIVER_DLLESPEC
+# define XCL_DRIVER_DLLESPEC
 #endif
 
 #ifdef __cplusplus

--- a/src/runtime_src/core/include/xrt/detail/config.h
+++ b/src/runtime_src/core/include/xrt/detail/config.h
@@ -6,10 +6,12 @@
 //------------------Enable dynamic linking on windows-------------------------//
 
 #ifdef _WIN32
-# ifdef XRT_API_SOURCE
-#  define XRT_API_EXPORT __declspec(dllexport)
-# else
-#  define XRT_API_EXPORT __declspec(dllimport)
+# ifndef XRT_STATIC_BUILD
+#  ifdef XRT_API_SOURCE
+#   define XRT_API_EXPORT __declspec(dllexport)
+#  else
+#   define XRT_API_EXPORT __declspec(dllimport)
+#  endif
 # endif
 #endif
 #ifdef __linux__

--- a/src/runtime_src/xdp/config.h
+++ b/src/runtime_src/xdp/config.h
@@ -22,41 +22,43 @@
 //------------------Enable dynamic linking on windows-----------------------// 
 
 #ifdef _WIN32
-  #ifdef XDP_CORE_SOURCE
-    #define XDP_CORE_EXPORT __declspec(dllexport)
-  #else
-    #define XDP_CORE_EXPORT __declspec(dllimport)
-  #endif  
+# ifdef XDP_CORE_SOURCE
+#  define XDP_CORE_EXPORT __declspec(dllexport)
+# else
+#  define XDP_CORE_EXPORT __declspec(dllimport)
+# endif  
 #endif
+
 #ifdef __linux__
-  #ifdef XDP_CORE_SOURCE
-    #define XDP_CORE_EXPORT __attribute__ ((visibility("default")))
-  #else
-    #define XDP_CORE_EXPORT
-  #endif
+# ifdef XDP_CORE_SOURCE
+#  define XDP_CORE_EXPORT __attribute__ ((visibility("default")))
+# else
+# define XDP_CORE_EXPORT
+# endif
 #endif
 
 #ifndef XDP_CORE_EXPORT
-  #define XDP_CORE_EXPORT
+# define XDP_CORE_EXPORT
 #endif
 
 #ifdef _WIN32
-  #ifdef XDP_PLUGIN_SOURCE
-    #define XDP_PLUGIN_EXPORT __declspec(dllexport)
-  #else
-    #define XDP_PLUGIN_EXPORT __declspec(dllimport)
-  #endif  
+# ifdef XDP_PLUGIN_SOURCE
+#  define XDP_PLUGIN_EXPORT __declspec(dllexport)
+# else
+#  define XDP_PLUGIN_EXPORT __declspec(dllimport)
+# endif  
 #endif
+
 #ifdef __linux__
-  #ifdef XDP_PLUGIN_SOURCE
-    #define XDP_PLUGIN_EXPORT __attribute__ ((visibility("default")))
-  #else
-    #define XDP_PLUGIN_EXPORT
-  #endif
+# ifdef XDP_PLUGIN_SOURCE
+#  define XDP_PLUGIN_EXPORT __attribute__ ((visibility("default")))
+# else
+#  define XDP_PLUGIN_EXPORT
+# endif
 #endif
 
 #ifndef XDP_PLUGIN_EXPORT
-  #define XDP_PLUGIN_EXPORT
+# define XDP_PLUGIN_EXPORT
 #endif
 
 #endif


### PR DESCRIPTION
#### Problem solved by the commit
Add a preprocessor directive to turn off dllimport decoration of exported symbols when exported APIs are intended to be statically linked into some external target.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
On windows LNK4217 means that a symbol defined in one object (e.g., a static link library) is being imported by another object.  In order to avoid this situation, the `__declspec(dllimport)` modifier should be removed from the object that uses the symbol.

#### How problem was solved, alternative solutions (if any) and why they were rejected
This PR simply adds `XRT_STATIC_BUILD` preprocessor directive that can be used when compiling objects that use XRT symbols and link to static libraries from XRT.

#### Risks (if any) associated the changes in the commit
The changes in this PR are target for `xrt_coreutil_static` usage only, specifically for use in a user-mode-driver for DirectML.

