### PR TITLE
Slot reuse

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/common/zocl_drv.c
+++ b/src/runtime_src/core/edge/drm/zocl/common/zocl_drv.c
@@ -149,6 +149,7 @@ static int zocl_pr_slot_init(struct drm_zocl_dev *zdev,
 		zocl_slot->partial_overlay_id = -1;
 		zocl_slot->slot_idx = i;
 		zocl_slot->slot_type = ZOCL_SLOT_TYPE_PHY;
+		zocl_slot->hwctx_ref_cnt = 0;
 
 		zdev->pr_slot[i] = zocl_slot;
 	}

--- a/src/runtime_src/core/edge/drm/zocl/common/zocl_ioctl.c
+++ b/src/runtime_src/core/edge/drm/zocl/common/zocl_ioctl.c
@@ -116,7 +116,7 @@ get_free_slot(struct drm_zocl_dev *zdev, struct axlf *axlf, int* slot_id)
 	if (s_id > 0) {
 		slot = zdev->pr_slot[s_id];
 		if (!slot) {
-			DRM_ERROR("%s: slot: %d doesn't exists or invaid slot", __func__, s_id);
+			DRM_ERROR("%s: slot %d doesn't exists or invalid", __func__, s_id);
 			return -EINVAL;
 		}
 		DRM_INFO("Found a free slot %d for XCLBIN %pUb", s_id, &axlf->m_header.uuid);
@@ -245,23 +245,8 @@ int zocl_destroy_hw_ctx_ioctl(struct drm_device *dev, void *data, struct drm_fil
 {
 	struct drm_zocl_dev *zdev = ZOCL_GET_ZDEV(dev);
 	struct drm_zocl_destroy_hw_ctx *drm_hw_ctx = (struct drm_zocl_destroy_hw_ctx *)data;
-	int ret = 0;
-	int slot_id = -1;
-	struct kds_client_hw_ctx *kds_hw_ctx = NULL;
-	struct kds_client *client = filp->driver_priv;
-	mutex_lock(&client->lock);
-	kds_hw_ctx = kds_get_hw_ctx_by_id(client, drm_hw_ctx->hw_context);
-	if (!kds_hw_ctx) {
-		DRM_ERROR("%s: No valid hw context is open", __func__);
-		mutex_unlock(&client->lock);
-		return -EINVAL;
-	}
-	slot_id = kds_hw_ctx->slot_idx;
-	mutex_unlock(&client->lock);
-	ret = zocl_destroy_hw_ctx(zdev, drm_hw_ctx, filp);
-	//TODO do it under lock
-	zdev->slot_mask &= ~(1 << slot_id);
-	return ret;
+
+	return zocl_destroy_hw_ctx(zdev, drm_hw_ctx, filp);
 }
 
 /*

--- a/src/runtime_src/core/edge/drm/zocl/edge/zocl_hwctx.c
+++ b/src/runtime_src/core/edge/drm/zocl/edge/zocl_hwctx.c
@@ -57,6 +57,7 @@ int zocl_destroy_hw_ctx(struct drm_zocl_dev *zdev, struct drm_zocl_destroy_hw_ct
     struct drm_zocl_slot *slot = NULL;
     struct kds_client *client = filp->driver_priv;
     int ret = 0;
+    u32 s_id = -1;
 
     if (!client) {
         DRM_ERROR("%s: Invalid client", __func__);
@@ -78,10 +79,12 @@ int zocl_destroy_hw_ctx(struct drm_zocl_dev *zdev, struct drm_zocl_destroy_hw_ct
         mutex_unlock(&client->lock);
         return -EINVAL;
     }
+
+    s_id = kds_hw_ctx->slot_idx;
     ret = kds_free_hw_ctx(client, kds_hw_ctx);
     if (--slot->hwctx_ref_cnt == 0) {
-        zdev->slot_mask &= ~(1 << kds_hw_ctx->slot_idx);
-        DRM_INFO("++ Released the slot %d", kds_hw_ctx->slot_idx);
+        zdev->slot_mask &= ~(1 << s_id);
+        DRM_DEBUG("Released the slot %d", s_id);
     }
 
     mutex_unlock(&client->lock);

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_util.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_util.h
@@ -147,6 +147,7 @@ struct drm_zocl_slot {
 	struct mutex		 aie_lock;
 	struct aie_info		*aie_information;
 	struct zocl_aie		*aie;
+	u32			hwctx_ref_cnt;
 };
 
 struct zocl_cu_subdev {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Slot-reuse
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Each hwctx creation used to use a new slot even if same xclbin is already loaded to a different slot
#### How problem was solved, alternative solutions (if any) and why they were rejected
Slot reuse. Added checks to check if the incoming xclbin is already loaded any of the xclbin. And using hwctx ref count to track if any hwctx is alive on a given slot. The destruction of last hwctx active on a particular slot will release the slot
#### Risks (if any) associated the changes in the commit
low
#### What has been tested and how, request additional testing if necessary
Tested case 5 and 6 from this confluence page https://confluence.amd.com/pages/viewpage.action?pageId=1600332938
#### Documentation impact (if any)
n/a