### PR TITLE
Catch throwing destructor

### DIFF
--- a/src/runtime_src/core/common/bo_cache.h
+++ b/src/runtime_src/core/common/bo_cache.h
@@ -54,9 +54,13 @@ public:
 
   ~bo_cache_t()
   {
-    std::lock_guard<std::mutex> lock(m_mutex);
-    for (auto& bo : m_cmd_bo_cache)
-      destroy(bo);
+    try {
+      std::lock_guard<std::mutex> lock(m_mutex);
+      for (auto& bo : m_cmd_bo_cache)
+        destroy(bo);
+    }
+    catch (...) {
+    }
   }
 
   template<typename T>


### PR DESCRIPTION
#### Problem solved by the commit
Destructors cannot throw.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
The bo_cache_t destructor triggered an abnormal termination after bo destuctions failed on MCDM, likely as driver was already unloaded or disabled.

#### How problem was solved, alternative solutions (if any) and why they were rejected
While it's TBD to root cause the bo destruction failure, the destructor must not fail ever.

