### PR TITLE
[XDP] Fix for GMIO trace offload of independently compiled graphs

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -177,9 +177,12 @@ void AieTracePluginUnified::updateAIEDevice(void *handle) {
     if (device != nullptr) {
       for (auto &gmioEntry : AIEData.metadata->get_trace_gmios()) {
         auto gmio = gmioEntry.second;
-        (db->getStaticInfo())
-            .addTraceGMIO(deviceID, gmio.id, gmio.shimColumn, gmio.channelNum,
-                          gmio.streamId, gmio.burstLength);
+        // Get the column shift for partition
+        // NOTE: If partition is not used, this value is zero.
+        // This is later required for GMIO trace offload.
+        uint8_t startColShift = AIEData.metadata->getPartitionOverlayStartCols().front();
+        (db->getStaticInfo()).addTraceGMIO(deviceID, gmio.id, gmio.shimColumn+startColShift,
+                                           gmio.channelNum, gmio.streamId, gmio.burstLength);
       }
     }
 

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/edge/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/edge/aie_trace.cpp
@@ -295,6 +295,8 @@ namespace xdp {
     auto configChannel0 = metadata->getConfigChannel0();
     auto configChannel1 = metadata->getConfigChannel1();
 
+    // Get the column shift for partition
+    // NOTE: If partition is not used, this value is zero.
     uint8_t startColShift = metadata->getPartitionOverlayStartCols().front();
     aie::displayColShiftInfo(startColShift);
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
GMIO trace offload was not working for independent compiled design.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1201066

#### How problem was solved, alternative solutions (if any) and why they were rejected
Partition shift is now also considered for GMIO trace offload.

#### Risks (if any) associated the changes in the commit
Low.

#### What has been tested and how, request additional testing if necessary
Verified on vck190 and VEK280.

#### Documentation impact (if any)
