### PR TITLE
Enabling force program xclbin with LOAD_PDI action mask

### DIFF
--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -1181,7 +1181,7 @@ int shim::prepare_hw_axlf(const axlf *buffer, struct drm_zocl_axlf *axlf_obj)
 #ifndef __HWEM__
   auto is_pr_platform = (buffer->m_header.m_mode == XCLBIN_PR || buffer->m_header.m_actionMask & AM_LOAD_PDI);
   auto is_flat_enabled = xrt_core::config::get_enable_flat(); //default value is false
-  auto force_program = xrt_core::config::get_force_program_xclbin(); //default value is false
+  auto force_program = xrt_core::config::get_force_program_xclbin() || buffer->m_header.m_actionMask & AM_LOAD_PDI;
   auto overlay_header = xclbin::get_axlf_section(buffer, axlf_section_kind::OVERLAY);
 
   if (is_pr_platform)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Reloading AIE partitions
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
PDI used not reloaded for AIE only xclbins. 
#### How problem was solved, alternative solutions (if any) and why they were rejected
Enabling force reload if LOAD_PDI action mask is enabled on the AIE only xclbins to reload the partition
#### Risks (if any) associated the changes in the commit
n/a
#### What has been tested and how, request additional testing if necessary
Tested by Generating AIE only xclbin with the LOAD_PDI action mask to reload again and again. 
Tested by Generating PL only xclbin and AIE only xclbin with the LOAD_PDI action mask on the AIE only xclbin to reload the AIE partition again and again.
In both cases the test is passing.
#### Documentation impact (if any)
n/a