### PR TITLE
VITIS-13605: Introduce user task ID parameter to aie-partition info query

### DIFF
--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -1159,11 +1159,11 @@ struct hw_context_info : request
    * A structure to represent a single hardware context on any device type. This
    * structure must contain all data that makes up a hardware context across
    * all device types.
-   * 
+   *
    * The only field that must be populated is the xclbin uuid.
    * All other fields can be populated as required by the appropriate device.
    * As new compute types are created they must be accounted for here
-   * 
+   *
    * For example:
    *  Alveo -> populate only the PL compute units
    *  Versal -> populate PL and PS compute units
@@ -1189,7 +1189,7 @@ struct hw_context_memory_info : request
 {
   /**
    * A structure to represent a single hardware context's memory contents on
-   * any device type. This structure contains all data that makes up a 
+   * any device type. This structure contains all data that makes up a
    * hardware context memory structure across all device types.
    */
   struct data {
@@ -1768,6 +1768,7 @@ struct aie_partition_info : request
     uint64_t    start_col;
     uint64_t    num_cols;
     int         pid;
+    uint32_t    user_tid;
     bool        is_suspended;
     uint64_t    instruction_mem;
     uint64_t    command_submissions;


### PR DESCRIPTION
Added a user task ID parameter to the AIE-partition info query. This enhancement will be used by xrt-smi to map a context ID to a user task ID while parsing the NPU telemetry buffer.

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Added a user task ID parameter to the AIE-partition info query

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
None

#### How problem was solved, alternative solutions (if any) and why they were rejected
None

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Verified on Strix silicon

#### Documentation impact (if any)
None