### PR TITLE
For Lin Client rename XRT package to npu

### DIFF
--- a/src/CMake/cpackLin.cmake
+++ b/src/CMake/cpackLin.cmake
@@ -19,10 +19,6 @@ SET(CPACK_ARCHIVE_COMPONENT_INSTALL ON)
 SET(CPACK_DEB_COMPONENT_INSTALL ON)
 SET(CPACK_RPM_COMPONENT_INSTALL ON)
 
-if (DEFINED NPU)
-  SET(CPACK_PACKAGE_NAME "npu")
-endif()
-
 # When the rpmbuild occurs for packaging, it uses a default version of
 # python to perform a python byte compilation.  For the CentOS 7.x OS, this
 # is python2.  Being that the XRT python code is for python3, this results in
@@ -80,7 +76,7 @@ if (${LINUX_FLAVOR} MATCHES "^(ubuntu|debian)")
   SET(CPACK_DEBIAN_AWS_PACKAGE_DEPENDS "xrt (>= ${XRT_VERSION_MAJOR}.${XRT_VERSION_MINOR}.${XRT_VERSION_PATCH})")
   SET(CPACK_DEBIAN_XRT_PACKAGE_DEPENDS "ocl-icd-libopencl1 (>= 2.2.0), dkms (>= 2.2.0), udev, python3")
 
-  if (${XRT_DEV_COMPONENT} STREQUAL "xrt")
+  if ((${XRT_DEV_COMPONENT} STREQUAL "xrt") OR (${XRT_DEV_COMPONENT} STREQUAL "npu"))
     # applications link with -luuid
     SET(CPACK_DEBIAN_XRT_PACKAGE_DEPENDS
       "${CPACK_DEBIAN_XRT_PACKAGE_DEPENDS},  \
@@ -161,7 +157,7 @@ elseif (${LINUX_FLAVOR} MATCHES "^(rhel|centos|amzn|fedora|sles|mariner|almalinu
     SET(CPACK_RPM_XRT_PACKAGE_REQUIRES "ocl-icd >= 2.2, dkms >= 2.5.0, python3 >= 3.6")
   endif()
 
-  if (${XRT_DEV_COMPONENT} STREQUAL "xrt")
+  if ((${XRT_DEV_COMPONENT} STREQUAL "xrt") OR (${XRT_DEV_COMPONENT} STREQUAL "npu"))
     # xrt is also development package
     SET(CPACK_RPM_XRT_PACKAGE_REQUIRES "${CPACK_RPM_XRT_PACKAGE_REQUIRES}, ocl-icd-devel >= 2.2, libuuid-devel >= 2.23.2")
   else()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,12 +27,18 @@ include(CMake/settings.cmake)
 # set to something different then a development component will be created with
 # link libraries and header which are then excluded from runtime component
 set (CMAKE_INSTALL_DEFAULT_COMPONENT_NAME "xrt")
+if (DEFINED NPU)
+  set (CMAKE_INSTALL_DEFAULT_COMPONENT_NAME "npu")
+endif()
 
 # Enable development package by specifying development component name
 # If XRT_DEV_COMPONENT is same DEFAULT_COMPONENT then only that package
 # is created with both development and run-time content.
 #set (XRT_DEV_COMPONENT "xrt-dev")
 set (XRT_DEV_COMPONENT "xrt")
+if (DEFINED NPU)
+  set (XRT_DEV_COMPONENT "npu")
+endif()
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${XRT_SOURCE_DIR}/CMake/")
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
xrt package component on Linux Client, built with "-npu", contains runtime and XDP support for NPU. So, rename the xrt package to "npu". As other packages like xbflash, azure doe snot contain npu specific XDP code, their name should keep "xrt" prefix

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Only "xrt" component has npu specific support under -npu switch. So, no other packages should start with "npu". Renaming all packages for Lin Client was added in https://github.com/Xilinx/XRT/pull/8568

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit
With this change, user needs to first remove "xrt" package if already installed, and then install the new npu package.

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
