### PR TITLE
Switch to use public ccache rahter than RDI ccache

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -90,7 +90,6 @@ usage()
 }
 
 clean=0
-ccache=0
 ci=0
 docs=0
 verbose=""
@@ -190,8 +189,8 @@ while [ $# -gt 0 ]; do
             shift
             ;;
         -ccache)
-            cmake_flags+=" -DRDI_CCACHE=1"
-            ccache=1
+            export CCACHE_DIR=${CCACHE_DIR:-/scratch/ccache/$USER}
+            cmake_flags+=" -DXRT_CCACHE=1"
             shift
             ;;
         -cppstd)
@@ -275,19 +274,6 @@ if [[ $clean == 1 ]]; then
     echo "/bin/rm -rf $debug_dir $release_dir $edge_dir"
     /bin/rm -rf $debug_dir $release_dir $edge_dir
     exit 0
-fi
-
-if [[ $ccache == 1 ]]; then
-    SRCROOT=`readlink -f $BUILDDIR/../src`
-    export RDI_ROOT=$SRCROOT
-    export RDI_BUILDROOT=$SRCROOT
-    export RDI_CCACHEROOT=/scratch/ccache/$USER
-    mkdir -p $RDI_CCACHEROOT
-    # Run cleanup script once a day
-    # Clean cache dir for stale files older than 30 days
-    if [[ -e /proj/rdi/env/HEAD/hierdesign/ccache/cleanup.pl ]]; then
-        /proj/rdi/env/HEAD/hierdesign/ccache/cleanup.pl 1 30 $RDI_CCACHEROOT
-    fi
 fi
 
 if [[ ! -z $ertbsp ]]; then

--- a/src/CMake/ccache.cmake
+++ b/src/CMake/ccache.cmake
@@ -1,27 +1,19 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2019-2021 Xilinx, Inc. All rights reserved.
-#
-if (RDI_CCACHE)
+# Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+if (XRT_CCACHE)
+  
+  find_program(CCACHE_PROGRAM ccache)
 
-  find_program(gccwrap /tools/batonroot/rodin/devkits/lnx64/ccwrap/gccwrap)
-  find_program(gccarwrap /tools/batonroot/rodin/devkits/lnx64/ccwrap/gccarwrap)
+  if(CCACHE_PROGRAM)
+    set(CMAKE_C_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
+    set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
 
-  if (gccwrap)
-    message ("-- Using compile cache wrapper ${gccwrap} with cache in $ENV{RDI_CCACHEROOT}")
-    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${gccwrap} --with-cache-rw")
-  endif ()
-
-  if (gccarwrap)
-    set(CMAKE_CXX_ARCHIVE_CREATE "<CMAKE_AR> -qc -o <TARGET> <LINK_FLAGS> <OBJECTS>")
-    set(CMAKE_C_ARCHIVE_CREATE "<CMAKE_AR> -qc -o <TARGET> <LINK_FLAGS> <OBJECTS>")
-    set(CMAKE_CXX_ARCHIVE_FINISH)
-    set(CMAKE_C_ARCHIVE_FINISH)
-    message ("-- Using link cache wrapper ${gccarwrap} with cache in $ENV{RDI_CCACHEROOT}")
-    set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK "${gccarwrap} --with-cache-rw")
-  endif ()
-
-  # Disable abi compile time checks which renders ccache close to useless
-  message ("***** CCACHE: DISABLING ABI VERSION CHECK ******")
-  add_compile_options("-DDISABLE_ABI_CHECK")
+    # Disable abi compile time checks which renders ccache close to useless
+    message ("***** CCACHE: DISABLING ABI VERSION CHECK ******")
+    add_compile_options("-DDISABLE_ABI_CHECK")
+  else()
+    message ("***** ccache program not found, ignoring -ccache")
+  endif()
 
 endif()


### PR DESCRIPTION
#### Problem solved by the commit
Use public ccache when building XRT (`build.sh -ccache`)

#### How problem was solved, alternative solutions (if any) and why they were rejected
While not as efficient as rdi ccache, the public version can be used by everyone.

Requires that ccache is installed on system.
