### PR TITLE
porting AWS F2 work around changes to 2024.1 

### DIFF
--- a/src/runtime_src/core/pcie/driver/aws/kernel/mgmt/mgmt-core.c
+++ b/src/runtime_src/core/pcie/driver/aws/kernel/mgmt/mgmt-core.c
@@ -853,10 +853,10 @@ static int __init awsmgmt_init(void)
 
 	printk(KERN_INFO DRV_NAME " init()\n");
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0)
-	xrt_class = class_create(THIS_MODULE, DRV_NAME);
+	awsmgmt_class = class_create(THIS_MODULE, DRV_NAME);
 #else
 	awsmgmt_class = class_create(DRV_NAME);
-#endif	
+#endif
 	if (IS_ERR(awsmgmt_class))
 		return PTR_ERR(awsmgmt_class);
 	res = alloc_chrdev_region(&awsmgmt_devnode, AWSMGMT_MINOR_BASE,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
@@ -19,6 +19,7 @@
 #include <linux/version.h>
 #include <linux/eventfd.h>
 #include <linux/uuid.h>
+#include <linux/delay.h>
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 7, 0)
 #include <linux/hashtable.h>
 #endif
@@ -538,6 +539,32 @@ done:
 	return ret;
 }
 
+/* This is a Workaround function for AWS F2 to reset the clock registers.
+ * This function also incurs a delay of 10seconds to work around AWS ocl timeout issue.
+ * These changes will be removed once the issue is addressed in AWS F2 instance.
+ */
+void aws_reset_clock_registers(xdev_handle_t xdev)
+{
+	struct xocl_dev_core *core = XDEV(xdev);
+	resource_size_t bar0_clk1, bar0_clk2;
+	void __iomem *vbar0_clk1, *vbar0_clk2;
+
+	userpf_info(xdev, "AWS F2 WA, waiting to reset clock registers after Load ");
+	msleep(10000);
+
+	bar0_clk1 = pci_resource_start(core->pdev, 0) + 0x4058014;
+	bar0_clk2 = pci_resource_start(core->pdev, 0) + 0x4058010;
+	vbar0_clk1 = ioremap_nocache(bar0_clk1, 32);
+	vbar0_clk2 = ioremap_nocache(bar0_clk2, 32);
+
+	iowrite32(0, vbar0_clk1);
+	iowrite32(0, vbar0_clk2);
+
+	iounmap(vbar0_clk1);
+	iounmap(vbar0_clk2);
+	return;
+}
+
 int
 xocl_read_axlf_helper(struct xocl_drm *drm_p, struct drm_xocl_axlf *axlf_ptr,
 	       uint32_t qos, uint32_t *slot)
@@ -555,6 +582,7 @@ xocl_read_axlf_helper(struct xocl_drm *drm_p, struct drm_xocl_axlf *axlf_ptr,
 	void *ulp_blob;
 	void *kernels;
 	int rc = 0;
+	struct xocl_dev_core *core = XDEV(drm_p->xdev);
 
 	if (!xocl_is_unified(xdev)) {
 		userpf_err(xdev, "XOCL: not unified Shell\n");
@@ -766,8 +794,14 @@ done:
 
 		userpf_err(xdev, "Failed to download xclbin, err: %ld\n", err);
 	}
-	else
+	else {
 		userpf_info(xdev, "Loaded xclbin %pUb", &bin_obj.m_header.uuid);
+		/* Work around added for AWS F2 Instance to perform delay and reset clock registers */
+		if(core->pdev->device == 0xf010)
+		{
+			aws_reset_clock_registers(xdev);
+		}
+	}
 
 out_done:
 	/* Update the slot */


### PR DESCRIPTION
Problem solved by the commit
On AWS F2 Instance, ocl timeout occurs when onfi image is loaded followed by a rescan.
AWS Team is working real fix.
Added work around to incur delay of 10secs after pci device id changed. This fixes the ocl timeout issue until
AWS has the real fix.

Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Added work around to incur delay of 10secs after pci device id changed. This fixes the ocl timeout issue until
AWS has the real fix.

How problem was solved, alternative solutions (if any) and why they were rejected
Added work around to incur delay of 10secs after pci device id changed. This fixes the ocl timeout issue until
AWS has the real fix.

Risks (if any) associated the changes in the commit
NA

What has been tested and how, request additional testing if necessary
Load onfi image on AWS F2 instance.

Documentation impact (if any)
NA