### PR TITLE
Added wait_ip_interrupt(timeout) functionality on edge side

### DIFF
--- a/src/runtime_src/core/edge/user/device_linux.cpp
+++ b/src/runtime_src/core/edge/user/device_linux.cpp
@@ -17,6 +17,7 @@
 #include "core/edge/user/aie/profile_object.h"
 #include <map>
 #include <memory>
+#include <poll.h>
 #include <string>
 
 #include <fcntl.h>
@@ -1291,6 +1292,28 @@ wait_ip_interrupt(xclInterruptNotifyHandle handle)
   int pending = 0;
   if (::read(handle, &pending, sizeof(pending)) == -1)
     throw error(errno, "wait_ip_interrupt failed POSIX read");
+}
+
+std::cv_status
+device_linux::
+wait_ip_interrupt(xclInterruptNotifyHandle handle, int32_t timeout)
+{
+  struct pollfd pfd = {.fd=handle, .events=POLLIN};
+  int32_t ret = 0;
+
+  //Checking for only one fd; Only of one CU
+  //Timeout value in milli seconds
+  ret = ::poll(&pfd, 1, timeout);
+  if (ret < 0)
+    throw error(errno, "wait_timeout: failed POSIX poll");
+
+  if (ret == 0) //Timeout occured
+    return std::cv_status::timeout;
+
+  if (pfd.revents & POLLIN) //Interrupt received
+    return std::cv_status::no_timeout;
+
+  throw error(-EINVAL, boost::str(boost::format("wait_timeout: POSIX poll unexpected event: %d")  % pfd.revents));
 }
 
 } // xrt_core

--- a/src/runtime_src/core/edge/user/device_linux.h
+++ b/src/runtime_src/core/edge/user/device_linux.h
@@ -91,6 +91,9 @@ public:
   virtual void
   wait_ip_interrupt(xclInterruptNotifyHandle);
 
+  virtual std::cv_status
+  wait_ip_interrupt(xclInterruptNotifyHandle, int32_t timeout);
+
   virtual std::unique_ptr<hwctx_handle>
   create_hw_context(const xrt::uuid& xclbin_uuid,
                     const xrt::hw_context::cfg_param_type& cfg_param,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
[CR-1221077](https://jira.xilinx.com/browse/CR-1221077) Added wait_ip_interrupt(timeout) API on edge side

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added wait_ip_interrupt(timeout) functionality on edge side by using existing kernel features.

#### Risks (if any) associated the changes in the commit
low

#### What has been tested and how, request additional testing if necessary
Tested on vck190 hw_emu

#### Documentation impact (if any)
