### PR TITLE
Update Coverity workflow for new version of upload-artifacts

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -54,7 +54,7 @@ jobs:
         SHA: ${{ github.sha }}
     - name: Upload Coverity imed
       if: steps.cache-sha.outputs.cache-hit != 'true'
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: cov-int-file
         path: xrt.tgz


### PR DESCRIPTION
#### Problem solved by the commit
On December 14, 2023, GitHub Actions released [v4 of the actions to upload and download artifacts](https://github.blog/2024-02-12-get-started-with-v4-of-github-actions-artifacts/). This version improves upload/download speeds by up to 98%, addresses long-standing customer feedback requests, and represents the future of artifacts in GitHub Actions.