### PR TITLE
xrt::bo flags for for carveout memory

### DIFF
--- a/src/runtime_src/core/include/xrt/xrt_bo.h
+++ b/src/runtime_src/core/include/xrt/xrt_bo.h
@@ -117,12 +117,13 @@ public:
    */
   enum class flags : uint32_t
   {
-    normal      = 0,
-    cacheable   = XRT_BO_FLAGS_CACHEABLE,
-    device_only = XRT_BO_FLAGS_DEV_ONLY,
-    host_only   = XRT_BO_FLAGS_HOST_ONLY,
-    p2p         = XRT_BO_FLAGS_P2P,
-    svm         = XRT_BO_FLAGS_SVM,
+    normal        = 0,
+    cacheable     = XRT_BO_FLAGS_CACHEABLE,
+    device_only   = XRT_BO_FLAGS_DEV_ONLY,
+    host_only     = XRT_BO_FLAGS_HOST_ONLY,
+    p2p           = XRT_BO_FLAGS_P2P,
+    svm           = XRT_BO_FLAGS_SVM,
+    device_memory = XRT_BO_FLAGS_CARVEOUT,
   };
 
 #ifdef _WIN32

--- a/src/runtime_src/core/include/xrt/xrt_bo.h
+++ b/src/runtime_src/core/include/xrt/xrt_bo.h
@@ -112,7 +112,8 @@ public:
    * @var svm
    *  Create a BO for SVM (supported on specific platforms only)
    * @var device_memory
-   *  Create a BO with a carveout memory buffer. It is an extra separate pool of memory that is assigned for NPU use. 
+   *  Create a BO from device memory, which is a separate pool of
+   *  memory that is supported on specific platforms only.
    * 
    * The flags used by xrt::bo are compatible with XCL style
    * flags as define in ``xrt_mem.h``

--- a/src/runtime_src/core/include/xrt/xrt_bo.h
+++ b/src/runtime_src/core/include/xrt/xrt_bo.h
@@ -112,8 +112,9 @@ public:
    * @var svm
    *  Create a BO for SVM (supported on specific platforms only)
    * @var carveout
-   *  Create a BO from a special memory pool dedicated to the device.
-   *  For AMD Ryzen NPU this memory is allocated from the host memory carveout pool.
+   *  Create a BO from a reserved memory pool. Supported for specific
+   *  platforms only. For AMD Ryzen NPU this memory is allocated from
+   *  a host memory carveout pool.
    * 
    * The flags used by xrt::bo are compatible with XCL style
    * flags as define in ``xrt_mem.h``

--- a/src/runtime_src/core/include/xrt/xrt_bo.h
+++ b/src/runtime_src/core/include/xrt/xrt_bo.h
@@ -111,22 +111,22 @@ public:
    *  Create a BO for peer-to-peer use
    * @var svm
    *  Create a BO for SVM (supported on specific platforms only)
-   * @var device_memory
-   *  Create a BO from device memory, which is a separate pool of
-   *  memory that is supported on specific platforms only.
+   * @var carveout
+   *  Create a BO from a special memory pool dedicated to the device.
+   *  For AMD Ryzen NPU this memory is allocated from the host memory carveout pool.
    * 
    * The flags used by xrt::bo are compatible with XCL style
    * flags as define in ``xrt_mem.h``
    */
   enum class flags : uint32_t
   {
-    normal        = 0,
-    cacheable     = XRT_BO_FLAGS_CACHEABLE,
-    device_only   = XRT_BO_FLAGS_DEV_ONLY,
-    host_only     = XRT_BO_FLAGS_HOST_ONLY,
-    p2p           = XRT_BO_FLAGS_P2P,
-    svm           = XRT_BO_FLAGS_SVM,
-    device_memory = XRT_BO_FLAGS_CARVEOUT,
+    normal       = 0,
+    cacheable    = XRT_BO_FLAGS_CACHEABLE,
+    device_only  = XRT_BO_FLAGS_DEV_ONLY,
+    host_only    = XRT_BO_FLAGS_HOST_ONLY,
+    p2p          = XRT_BO_FLAGS_P2P,
+    svm          = XRT_BO_FLAGS_SVM,
+    carveout     = XRT_BO_FLAGS_CARVEOUT,
   };
 
 #ifdef _WIN32

--- a/src/runtime_src/core/include/xrt/xrt_bo.h
+++ b/src/runtime_src/core/include/xrt/xrt_bo.h
@@ -111,7 +111,9 @@ public:
    *  Create a BO for peer-to-peer use
    * @var svm
    *  Create a BO for SVM (supported on specific platforms only)
-   *
+   * @var device_memory
+   *  Create a BO with a carveout memory buffer. It is an extra separate pool of memory that is assigned for NPU use. 
+   * 
    * The flags used by xrt::bo are compatible with XCL style
    * flags as define in ``xrt_mem.h``
    */

--- a/src/runtime_src/core/include/xrt_mem.h
+++ b/src/runtime_src/core/include/xrt_mem.h
@@ -112,13 +112,16 @@ struct xcl_bo_flags
 /**
  * Shim level BO Flags to distinguish use of BO
  *
- * The use flag is for internal use only. A debug BO
- * is supported only on some platforms to communicate
- * data from driver / firmware back to user space.
- * The flag `XRT_BO_USE_KMD`  indicates that the buffer 
- * content can be shared with the kernel mode driver.
- * This flag controls how the shim level constructs the 
- * allocation for the buffer.
+ * The use flag is for internal use only. 
+ *
+ * XRT_BO_USE_DEBUG indicates that the buffer will be used to
+ * communicate debug data from driver / firmware back to user
+ * space. This type of usage is supported on specific
+ * platforms only.
+
+ * XRT_BO_USE_KMD indicates that the buffer content can be shared
+ * with the kernel mode driver. This type of usage is supported on 
+ * specific platforms only.
  */
 #define XRT_BO_USE_NORMAL 0
 #define XRT_BO_USE_DEBUG  1

--- a/src/runtime_src/core/include/xrt_mem.h
+++ b/src/runtime_src/core/include/xrt_mem.h
@@ -70,8 +70,8 @@ struct xcl_bo_flags
       // extension
       uint32_t access : 2;  // [33-32]
       uint32_t dir    : 2;  // [35-34]
-      uint32_t use    : 1;  // [36]
-      uint32_t unused : 27; // [63-35]
+      uint32_t use    : 2;  // [37-36]
+      uint32_t unused : 26; // [63-38]
     };
   };
 };
@@ -118,6 +118,7 @@ struct xcl_bo_flags
  */
 #define XRT_BO_USE_NORMAL 0
 #define XRT_BO_USE_DEBUG  1
+#define XRT_BO_USE_KMD    2
 
 /**
  * XRT Native BO flags
@@ -130,6 +131,7 @@ struct xcl_bo_flags
 #define XRT_BO_FLAGS_HOST_ONLY XCL_BO_FLAGS_HOST_ONLY
 #define XRT_BO_FLAGS_P2P       XCL_BO_FLAGS_P2P
 #define XRT_BO_FLAGS_SVM       XCL_BO_FLAGS_SVM
+#define XRT_BO_FLAGS_CARVEOUT  XCL_BO_FLAGS_KERNBUF
 
 /**
  * This is the legacy usage of XCL DDR Flags.

--- a/src/runtime_src/core/include/xrt_mem.h
+++ b/src/runtime_src/core/include/xrt_mem.h
@@ -115,10 +115,14 @@ struct xcl_bo_flags
  * The use flag is for internal use only. A debug BO
  * is supported only on some platforms to communicate
  * data from driver / firmware back to user space.
+ * The flag `XRT_BO_USE_KMD`  indicates that the buffer 
+ * content can be shared with the kernel mode driver.
+ * This flag controls how the shim level constructs the 
+ * allocation for the buffer.
  */
 #define XRT_BO_USE_NORMAL 0
 #define XRT_BO_USE_DEBUG  1
-#define XRT_BO_USE_KMD    2
+#define XRT_BO_USE_KMD    2 
 
 /**
  * XRT Native BO flags


### PR DESCRIPTION
Created the xrt::bo flags for carveout memory

Problem solved by the commit
xrt::bo for carveout memory

Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

How problem was solved, alternative solutions (if any) and why they were rejected
I reused one of the flags which already been defined and only used in xocl files in linux. xocl driver is not used on npu platform, hence I could reuse one of them for both windows and linux.

Risks (if any) associated the changes in the commit
None.

What has been tested and how, request additional testing if necessary

Documentation impact (if any)
None.