### PR TITLE
[XDP] Adjustments to Byte count metric

### DIFF
--- a/build/petalinux.build
+++ b/build/petalinux.build
@@ -1,3 +1,5 @@
 # When updating Petalinux build please file a SH ticket to retain the build
 # https://jira.xilinx.com/secure/CreateIssue!default.jspa
-PETALINUX=/proj/petalinux/2024.2/petalinux-v2024.2_10241236/tool/petalinux-v2024.2-final
+#PETALINUX=/proj/petalinux/2024.2/petalinux-v2024.2_10241236/tool/petalinux-v2024.2-final
+#PETALINUX=/proj/petalinux/2024.2/petalinux-v2024.2_11051541/tool/petalinux-v2024.2-final
+PETALINUX=/proj/petalinux/2024.2/petalinux-v2024.2_11062026/tool/petalinux-v2024.2-final

--- a/build/petalinux.build
+++ b/build/petalinux.build
@@ -1,5 +1,3 @@
 # When updating Petalinux build please file a SH ticket to retain the build
 # https://jira.xilinx.com/secure/CreateIssue!default.jspa
-#PETALINUX=/proj/petalinux/2024.2/petalinux-v2024.2_10241236/tool/petalinux-v2024.2-final
-#PETALINUX=/proj/petalinux/2024.2/petalinux-v2024.2_11051541/tool/petalinux-v2024.2-final
-PETALINUX=/proj/petalinux/2024.2/petalinux-v2024.2_11062026/tool/petalinux-v2024.2-final
+PETALINUX=/proj/petalinux/2024.2/petalinux-v2024.2_10241236/tool/petalinux-v2024.2-final

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/edge/aie_profile.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/edge/aie_profile.cpp
@@ -1061,6 +1061,9 @@ namespace xdp {
     XAie_Events counterEvent;
     pc->getCounterEvent(mod, counterEvent);
 
+    if (pc->start() != XAIE_OK)
+      return false;
+
     // performance counter event to use it later for broadcasting
     retCounterEvent = counterEvent;
     return true;

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/edge/aie_profile.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/edge/aie_profile.cpp
@@ -623,6 +623,9 @@ namespace xdp {
           // Generate user_event_1 for byte count metric set after configuration
           if ((metricSet == METRIC_BYTE_COUNT) && (i == 1) && !graphItrBroadcastConfigDone) {
             XAie_LocType tileloc = XAie_TileLoc(tile.col, tile.row);
+            //Note: For BYTE_COUNT metric, user_event_1 is used twice as eventA & eventB to
+            //      to transition the FSM from Idle->State0->State1.
+            //      eventC = Port Running and eventD = stop event (counter event).
             XAie_EventGenerate(aieDevInst, tileloc, mod, XAIE_EVENT_USER_EVENT_1_PL);
             XAie_EventGenerate(aieDevInst, tileloc, mod, XAIE_EVENT_USER_EVENT_1_PL);
           }

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/edge/aie_profile.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/edge/aie_profile.cpp
@@ -624,6 +624,7 @@ namespace xdp {
           if ((metricSet == METRIC_BYTE_COUNT) && (i == 1) && !graphItrBroadcastConfigDone) {
             XAie_LocType tileloc = XAie_TileLoc(tile.col, tile.row);
             XAie_EventGenerate(aieDevInst, tileloc, mod, XAIE_EVENT_USER_EVENT_1_PL);
+            XAie_EventGenerate(aieDevInst, tileloc, mod, XAIE_EVENT_USER_EVENT_1_PL);
           }
 
           // Convert enums to physical event IDs for reporting purposes
@@ -901,7 +902,7 @@ namespace xdp {
 
     // Set up the combo event with FSM type using 4 events state machine
     XAie_Events eventA = (resetEvent != XAIE_EVENT_NONE_CORE) ? resetEvent : XAIE_EVENT_USER_EVENT_1_PL;
-    XAie_Events eventB = startEvent;
+    XAie_Events eventB = XAIE_EVENT_USER_EVENT_1_PL;
     XAie_Events eventC = startEvent;
     XAie_Events eventD = endEvent;
 

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/util/aie_profile_util.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/util/aie_profile_util.cpp
@@ -521,11 +521,7 @@ namespace xdp::aie::profile {
     uint32_t streamWidth = aie::getStreamWidth(hw_gen);
     uint32_t total_beats = static_cast<uint32_t>(std::ceil(1.0 * bytes / streamWidth));
 
-    // Note: As per run experiments on board, combo 3 FSM checks stop event in
-    // every 4 clock cycles. We make sure stop event is in sync with FSM oddity
-    // by rounding up total beats to nearest multiple of 4.
-    uint32_t max_beats = 4 * ((total_beats + 3) / 4);
-    return max_beats; 
+    return total_beats;
   }
 
 } // namespace xdp::aie


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
This Resolves the following
Byte count metric settings required a beats to be in multiples of 4 clock cycles.
Graph iterator start was not getting acknowledged.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Enhancement & feature test.

#### How problem was solved, alternative solutions (if any) and why they were rejected
It uses user events to transition from Idle to State A & State A to state B.
These user events are generated one after another for FSM.

#### Risks (if any) associated the changes in the commit
Low
#### What has been tested and how, request additional testing if necessary
VCK190.
#### Documentation impact (if any)
