### PR TITLE
CR-1217846: In trace and profiling provide a better name than "Edge" on edge platforms

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_plugin.cpp
@@ -124,10 +124,6 @@ namespace xdp {
       (db->getStaticInfo()).setDeviceName(deviceID, "win_device");
 #else
       (db->getStaticInfo()).updateDevice(deviceID, nullptr, handle);
-      std::string deviceName = util::getDeviceName(handle);
-      if (deviceName != "") {
-        (db->getStaticInfo()).setDeviceName(deviceID, deviceName);
-      }
 #endif
     }
 

--- a/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.cpp
@@ -429,12 +429,6 @@ namespace xdp {
     if (!(db->getStaticInfo()).isDeviceReady(deviceID)) {
       // Update the static database with information from xclbin
       (db->getStaticInfo()).updateDevice(deviceID, nullptr, handle);
-      {
-        std::string deviceName = util::getDeviceName(handle);
-        if(deviceName != "") {
-          (db->getStaticInfo()).setDeviceName(deviceID, deviceName);
-        }
-      }
     }
 
     // Grab AIE metadata

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -127,10 +127,6 @@ void AieTracePluginUnified::updateAIEDevice(void *handle) {
 #else
   // Update the static database with information from xclbin
   (db->getStaticInfo()).updateDevice(deviceID, std::move(std::make_unique<HalDevice>(handle)), handle);
-  std::string deviceName = util::getDeviceName(handle);
-  if (deviceName != "")
-    (db->getStaticInfo()).setDeviceName(deviceID, deviceName);
-
 #endif
 
   // Metadata depends on static information from the database

--- a/src/runtime_src/xdp/profile/plugin/device_offload/hal/hal_device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/hal/hal_device_offload_plugin.cpp
@@ -146,11 +146,6 @@ namespace xdp {
     // Update the static database with all the information that
     //  will be needed later
     db->getStaticInfo().updateDevice(deviceId, std::move(std::make_unique<HalDevice>(ownedHandle)), userHandle) ;
-    {
-      std::string deviceName = util::getDeviceName(userHandle);
-      if (deviceName != "")
-        (db->getStaticInfo()).setDeviceName(deviceId, deviceName);
-    }
 
     // For the HAL level, we must create a device interface using 
     //  the xdp::HalDevice to communicate with the physical device

--- a/src/runtime_src/xdp/profile/plugin/device_offload/hw_emu/hw_emu_device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/hw_emu/hw_emu_device_offload_plugin.cpp
@@ -115,12 +115,6 @@ namespace xdp {
     // Update the static database with all the information that
     //  will be needed later
     db->getStaticInfo().updateDevice(deviceId, std::move(std::make_unique<HalDevice>(userHandle)), userHandle) ;
-    {
-      std::string deviceName = util::getDeviceName(userHandle);
-      if (deviceName != "") {
-        (db->getStaticInfo()).setDeviceName(deviceId, deviceName);
-      }
-    }
 
     // For the HAL level, we must create a device interface using
     //  the xdp::HalDevice to communicate with the physical device

--- a/src/runtime_src/xdp/profile/plugin/pl_deadlock/pl_deadlock_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/pl_deadlock/pl_deadlock_plugin.cpp
@@ -197,12 +197,6 @@ namespace xdp {
     if (!(db->getStaticInfo()).isDeviceReady(deviceId)) {
       // Update the static database with information from xclbin
       (db->getStaticInfo()).updateDevice(deviceId,std::move(std::make_unique<HalDevice>(handle)), handle);
-      {
-        std::string deviceName = util::getDeviceName(handle);
-        if(deviceName != "") {
-          (db->getStaticInfo()).setDeviceName(deviceId, deviceName);
-        }
-      }
     }
 
     PLDeviceIntf* deviceIntf = (db->getStaticInfo()).getDeviceIntf(deviceId);


### PR DESCRIPTION
#### Problem solved by the commit
Profiling was incorrectly ignoring metadata regarding each platform's name and using the nondescriptive term "edge" for all boards PL sections.  The name of the platform was successfully read from the metadata from the profiling library, but then it was overwritten with the generic term "edge."

#### How problem was solved, alternative solutions (if any) and why they were rejected
This pull request removes the extraneous setting of the platform name in the plugin objects and leaves the correct name as determined by the centralized database which parses the metadata.

#### Risks (if any) associated the changes in the commit
Automated scripts that look for the generic name "edge" will now find a different name for the PL portion of trace.

#### What has been tested and how, request additional testing if necessary
A hardware and hardware emulation design that generates PL trace.

#### Documentation impact (if any)
Any Vitis documentation that references the trace PL section as "edge."