### PR TITLE
cppcheck - various fixes

### DIFF
--- a/src/runtime_src/core/common/api/hw_queue.h
+++ b/src/runtime_src/core/common/api/hw_queue.h
@@ -38,11 +38,13 @@ public:
   hw_queue() = default;
 
   // Construct from hwctx
+  explicit
   hw_queue(const xrt::hw_context& hwctx);
 
   // Legacy construction for internal support of command execution
   // that is not tied to kernel execution, .e.g for copy_bo_with_kdma
   XRT_CORE_COMMON_EXPORT
+  explicit
   hw_queue(const xrt_core::device* device);
 
   // Start a command and manage its execution by monitoring

--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -324,6 +324,15 @@ public:
     return device.get_hwctx_handle();
   }
 
+  void*
+  get_hbuf_or_error() const
+  {
+    if (auto hbuf = get_hbuf())
+      return hbuf;
+
+    throw xrt_core::error("buffer is not mapped");
+  }
+
   export_handle
   export_buffer() const
   {
@@ -338,7 +347,7 @@ public:
   {
     if (sz + seek > size)
       throw xrt_core::error(-EINVAL,"attempting to write past buffer size");
-    auto hbuf = static_cast<char*>(get_hbuf()) + seek;
+    auto hbuf = static_cast<char*>(get_hbuf_or_error()) + seek;
     std::memcpy(hbuf, src, sz);
   }
 
@@ -347,7 +356,7 @@ public:
   {
     if (sz + skip > size)
       throw xrt_core::error(-EINVAL,"attempting to read past buffer size");
-    auto hbuf = static_cast<char*>(get_hbuf()) + skip;
+    auto hbuf = static_cast<char*>(get_hbuf_or_error()) + skip;
     std::memcpy(dst, hbuf, sz);
   }
 

--- a/src/runtime_src/core/common/device.cpp
+++ b/src/runtime_src/core/common/device.cpp
@@ -241,10 +241,9 @@ update_cu_info()
     // It assumes that m_xclbin is the single xclbin and that
     // there is only one default slot with number 0.
     auto ip_layout = get_axlf_section<const ::ip_layout*>(IP_LAYOUT);
-    auto& cu2idx = m_cu2idx[0u]; // default slot 0
     if (ip_layout != nullptr) {
       m_cus = xclbin::get_cus(ip_layout);
-      cu2idx = xclbin::get_cu_indices(ip_layout);
+      m_cu2idx[0u] = xclbin::get_cu_indices(ip_layout); // default slot 0
     }
   }
 }

--- a/src/runtime_src/core/common/ishim.h
+++ b/src/runtime_src/core/common/ishim.h
@@ -44,6 +44,7 @@ struct ishim
   class not_supported_error : public xrt_core::error
   {
   public:
+    explicit
     not_supported_error(const std::string& msg)
       : xrt_core::error{std::errc::not_supported, msg}
     {}
@@ -253,6 +254,7 @@ template <typename DeviceType>
 struct shim : public DeviceType
 {
   template <typename ...Args>
+  explicit
   shim(Args&&... args)
     : DeviceType(std::forward<Args>(args)...)
   {}
@@ -410,6 +412,7 @@ template <typename DeviceType>
 struct noshim : public DeviceType
 {
   template <typename ...Args>
+  explicit
   noshim(Args&&... args)
     : DeviceType(std::forward<Args>(args)...)
   {}

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -338,7 +338,7 @@ struct pcie_vendor : request
   static const char* name() { return "vendor"; }
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type val)
@@ -354,7 +354,7 @@ struct pcie_device : request
   static const char* name() { return "device"; }
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
 
   static std::string
@@ -371,7 +371,7 @@ struct pcie_subsystem_vendor : request
   static const char* name() { return "subsystem_vendor"; }
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type val)
@@ -387,7 +387,7 @@ struct pcie_subsystem_id : request
   static const char* name() { return "subsystem_id"; }
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type val)
@@ -403,7 +403,7 @@ struct pcie_link_speed : request
   static const char* name() { return "link_speed"; }
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type val)
@@ -419,7 +419,7 @@ struct pcie_link_speed_max : request
   static const char* name() { return "link_speed_max"; }
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type val)
@@ -435,7 +435,7 @@ struct pcie_express_lane_width : request
   static const char* name() { return "width"; }
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type val)
@@ -451,7 +451,7 @@ struct pcie_express_lane_width_max : request
   static const char* name() { return "width_max"; }
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type val)
@@ -467,7 +467,7 @@ struct pcie_bdf : request
   static const char* name() { return "bdf"; }
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(const result_type& value)
@@ -493,7 +493,7 @@ struct pcie_id : request
   static const char* name() { return "pcie_id"; }
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   device_to_string(const result_type& value)
@@ -516,7 +516,7 @@ struct edge_vendor : request
   static const char* name() { return "vendor"; }
 
   virtual std::any
-    get(const device*) const = 0;
+    get(const device*) const override = 0;
 
   static std::string
     to_string(result_type val)
@@ -555,7 +555,7 @@ struct xclbin_name : request
   static const char* name() { return "xclbin_name"; }
 
   virtual std::any
-  get(const device*, const std::any& req_type) const = 0;
+  get(const device*, const std::any& req_type) const override = 0;
 };
 
 /**
@@ -597,7 +597,7 @@ struct sequence_name : request
   static const char* name() { return "sequence_name"; }
 
   virtual std::any
-  get(const device*, const std::any& req_type) const = 0;
+  get(const device*, const std::any& req_type) const override = 0;
 };
 
 /**
@@ -627,7 +627,7 @@ struct elf_name : request
   static const char* name() { return "elf_name"; }
 
   virtual std::any
-  get(const device*, const std::any& req_type) const = 0;
+  get(const device*, const std::any& req_type) const override = 0;
 };
 
 struct device_class : request
@@ -654,7 +654,7 @@ struct device_class : request
   static const char* name() { return "device_class"; }
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 struct dma_threads_raw : request
@@ -664,7 +664,7 @@ struct dma_threads_raw : request
   static const char* name() { return "dma_threads_raw"; }
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   // formatting of individual items for the vector
   static std::string
@@ -681,7 +681,7 @@ struct rom_vbnv : request
   static const char* name() { return "vbnv"; }
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(const result_type& value)
@@ -697,7 +697,7 @@ struct rom_ddr_bank_size_gb : request
   static const char* name() { return "ddr_size_bytes"; }
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type value)
@@ -713,7 +713,7 @@ struct rom_ddr_bank_count_max : request
   static const char* name() { return "widdr_countdth"; }
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type value)
@@ -729,7 +729,7 @@ struct rom_fpga_name : request
   static const char* name() { return "fpga_name"; }
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(const result_type& value)
@@ -744,7 +744,7 @@ struct rom_raw : request
   static const key_type key = key_type::rom_raw;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 struct rom_uuid : request
@@ -754,7 +754,7 @@ struct rom_uuid : request
   static const char* name() { return "uuid"; }
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static result_type
   to_string(const result_type& value)
@@ -770,7 +770,7 @@ struct rom_time_since_epoch : request
   static const char* name() { return "id"; }
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(const result_type& value)
@@ -786,7 +786,7 @@ struct interface_uuids : request
   static const char* name() { return "interface_uuids"; }
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   // formatting of individual items for the vector
   static std::string
@@ -832,7 +832,7 @@ struct logic_uuids : request
   static const char* name() { return "logic_uuids"; }
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   // formatting of individual items for the vector
   static std::string
@@ -848,7 +848,7 @@ struct xclbin_uuid : request
   static const key_type key = key_type::xclbin_uuid;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 // dtbo_path is unique path used by libdfx library to load bitstream and device tree
@@ -862,7 +862,7 @@ struct dtbo_path : request
   static const key_type key = key_type::dtbo_path;
 
   virtual std::any
-  get(const device*, const std::any& slot_id) const = 0;
+  get(const device*, const std::any& slot_id) const override = 0;
 };
 
 struct group_topology : request
@@ -871,7 +871,7 @@ struct group_topology : request
   static const key_type key = key_type::group_topology;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 struct temp_by_mem_topology : request
@@ -880,7 +880,7 @@ struct temp_by_mem_topology : request
   static const key_type key = key_type::temp_by_mem_topology;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 struct memstat : request
@@ -889,7 +889,7 @@ struct memstat : request
   static const key_type key = key_type::memstat;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 struct memstat_raw : request
@@ -898,7 +898,7 @@ struct memstat_raw : request
   static const key_type key = key_type::memstat_raw;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 struct dma_stream : request
@@ -907,10 +907,10 @@ struct dma_stream : request
   static const key_type key = key_type::dma_stream;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   virtual std::any
-  get(const device*, modifier, const std::string&) const = 0;
+  get(const device*, modifier, const std::string&) const override = 0;
 };
 
 struct mem_topology_raw : request
@@ -919,7 +919,7 @@ struct mem_topology_raw : request
   static const key_type key = key_type::mem_topology_raw;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 struct xclbin_full : request
@@ -928,7 +928,7 @@ struct xclbin_full : request
   static const key_type key = key_type::xclbin_full;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 struct ic_enable : request
@@ -938,10 +938,10 @@ struct ic_enable : request
   static const key_type key = key_type::ic_enable;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   virtual void
-  put(const device*, const std::any&) const = 0;
+  put(const device*, const std::any&) const override = 0;
 };
 
 struct ic_load_flash_address : request
@@ -951,10 +951,10 @@ struct ic_load_flash_address : request
   static const key_type key = key_type::ic_load_flash_address;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   virtual void
-  put(const device*, const std::any&) const = 0;
+  put(const device*, const std::any&) const override = 0;
 };
 
 struct aie_metadata : request
@@ -963,7 +963,7 @@ struct aie_metadata : request
   static const key_type key = key_type::aie_metadata;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 struct aie_reg_read : request
@@ -975,7 +975,7 @@ struct aie_reg_read : request
   static const key_type key = key_type::aie_reg_read;
 
   virtual std::any
-  get(const device*, const std::any& row, const std::any& col, const std::any& reg) const = 0;
+  get(const device*, const std::any& row, const std::any& col, const std::any& reg) const override = 0;
 };
 
 struct aie_get_freq : request
@@ -985,7 +985,7 @@ struct aie_get_freq : request
   static const key_type key = key_type::aie_get_freq;
 
   virtual std::any
-  get(const device*, const std::any& partition_id) const = 0;
+  get(const device*, const std::any& partition_id) const override = 0;
 };
 
 struct aie_set_freq : request
@@ -996,7 +996,7 @@ struct aie_set_freq : request
   static const key_type key = key_type::aie_set_freq;
 
   virtual std::any
-  get(const device*, const std::any& partition_id, const std::any& freq) const = 0;
+  get(const device*, const std::any& partition_id, const std::any& freq) const override = 0;
 };
 
 struct graph_status : request
@@ -1005,7 +1005,7 @@ struct graph_status : request
   static const key_type key = key_type::graph_status;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 struct ip_layout_raw : request
@@ -1014,7 +1014,7 @@ struct ip_layout_raw : request
   static const key_type key = key_type::ip_layout_raw;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 struct debug_ip_layout_raw : request
@@ -1023,7 +1023,7 @@ struct debug_ip_layout_raw : request
   static const key_type key = key_type::debug_ip_layout_raw;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 struct sdm_sensor_info : request
@@ -1070,7 +1070,7 @@ struct sdm_sensor_info : request
   static const key_type key = key_type::sdm_sensor_info;
 
   virtual std::any
-  get(const device*, const std::any& req_type) const = 0;
+  get(const device*, const std::any& req_type) const override = 0;
 };
 
 /**
@@ -1083,7 +1083,7 @@ struct device_status : request
   static const key_type key = key_type::device_status;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   parse_status(const result_type status)
@@ -1116,7 +1116,7 @@ struct kds_cu_info : request
   static const key_type key = key_type::kds_cu_info;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 struct ps_kernel : request
@@ -1125,7 +1125,7 @@ struct ps_kernel : request
   static const key_type key = key_type::ps_kernel;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 struct kds_scu_info : request
@@ -1142,7 +1142,7 @@ struct kds_scu_info : request
   static const key_type key = key_type::kds_scu_info;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 /**
@@ -1179,7 +1179,7 @@ struct hw_context_info : request
   static const key_type key = key_type::hw_context_info;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 /**
@@ -1205,7 +1205,7 @@ struct hw_context_memory_info : request
   static const key_type key = key_type::hw_context_memory_info;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 struct clock_freq_topology_raw : request
@@ -1214,7 +1214,7 @@ struct clock_freq_topology_raw : request
   static const key_type key = key_type::clock_freq_topology_raw;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 /**
@@ -1271,7 +1271,7 @@ struct xrt_resource_raw : request
   }
 
   virtual std::any
-  get(const device *) const = 0;
+  get(const device *) const override = 0;
 };
 
 struct xmc_version : request
@@ -1281,7 +1281,7 @@ struct xmc_version : request
   static const char* name() { return "xmc_version"; }
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static result_type
   to_string(const result_type& value)
@@ -1298,7 +1298,7 @@ struct instance : request
   static const char* name() { return "instance"; }
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(const result_type& value)
@@ -1315,7 +1315,7 @@ struct xmc_board_name : request
   static const char* name() { return "xmc_board_name"; }
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static result_type
   to_string(const result_type& value)
@@ -1331,7 +1331,7 @@ struct xmc_serial_num : request
   static const char* name() { return "serial_number"; }
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static result_type
   to_string(const result_type& value)
@@ -1347,7 +1347,7 @@ struct max_power_level : request
   static const char* name() { return "max_power_level"; }
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type value)
@@ -1363,7 +1363,7 @@ struct xmc_sc_presence : request
   static const char* name() { return "sc_presence"; }
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type value)
@@ -1378,7 +1378,7 @@ struct is_sc_fixed : request
   static const key_type key = key_type::is_sc_fixed;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type value)
@@ -1395,7 +1395,7 @@ struct xmc_sc_version : request
   static const char* name() { return "sc_version"; }
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(const result_type& value)
@@ -1411,7 +1411,7 @@ struct expected_sc_version : request
   static const char* name() { return "expected_sc_version"; }
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(const result_type& value)
@@ -1426,7 +1426,7 @@ struct xmc_status : request
   static const key_type key = key_type::xmc_status;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 struct xmc_reg_base : request
@@ -1435,7 +1435,7 @@ struct xmc_reg_base : request
   static const key_type key = key_type::xmc_reg_base;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 struct xmc_scaling_support : request
@@ -1444,7 +1444,7 @@ struct xmc_scaling_support : request
   static const key_type key = key_type::xmc_scaling_support;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 struct xmc_scaling_critical_temp_threshold : request
@@ -1453,7 +1453,7 @@ struct xmc_scaling_critical_temp_threshold : request
   static const key_type key = key_type::xmc_scaling_critical_temp_threshold;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 struct xmc_scaling_critical_pow_threshold : request
@@ -1462,7 +1462,7 @@ struct xmc_scaling_critical_pow_threshold : request
   static const key_type key = key_type::xmc_scaling_critical_pow_threshold;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 struct xmc_scaling_threshold_power_limit : request
@@ -1471,7 +1471,7 @@ struct xmc_scaling_threshold_power_limit : request
   static const key_type key = key_type::xmc_scaling_threshold_power_limit;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 struct xmc_scaling_threshold_temp_limit : request
@@ -1480,7 +1480,7 @@ struct xmc_scaling_threshold_temp_limit : request
   static const key_type key = key_type::xmc_scaling_threshold_temp_limit;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 struct xmc_scaling_power_override_enable : request
@@ -1489,7 +1489,7 @@ struct xmc_scaling_power_override_enable : request
   static const key_type key = key_type::xmc_scaling_power_override_enable;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 struct xmc_scaling_temp_override_enable : request
@@ -1498,7 +1498,7 @@ struct xmc_scaling_temp_override_enable : request
   static const key_type key = key_type::xmc_scaling_temp_override_enable;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 struct xmc_scaling_enabled : request
@@ -1508,10 +1508,10 @@ struct xmc_scaling_enabled : request
   static const key_type key = key_type::xmc_scaling_enabled;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   virtual void
-  put(const device*, const std::any&) const = 0;
+  put(const device*, const std::any&) const override = 0;
 };
 
 struct xmc_scaling_power_override: request
@@ -1521,10 +1521,10 @@ struct xmc_scaling_power_override: request
   static const key_type key = key_type::xmc_scaling_power_override;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   virtual void
-  put(const device*, const std::any&) const = 0;
+  put(const device*, const std::any&) const override = 0;
 
 };
 
@@ -1535,10 +1535,10 @@ struct xmc_scaling_temp_override: request
   static const key_type key = key_type::xmc_scaling_temp_override;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   virtual void
-  put(const device*, const std::any&) const = 0;
+  put(const device*, const std::any&) const override = 0;
 
 };
 
@@ -1548,7 +1548,7 @@ struct xmc_scaling_reset : request
   static const key_type key = key_type::xmc_scaling_reset;
 
   virtual void
-  put(const device*, const std::any&) const = 0;
+  put(const device*, const std::any&) const override = 0;
 };
 
 struct xmc_qspi_status : request
@@ -1558,7 +1558,7 @@ struct xmc_qspi_status : request
   static const key_type key = key_type::xmc_qspi_status;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 struct m2m : request
@@ -1567,7 +1567,7 @@ struct m2m : request
   static const key_type key = key_type::m2m;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static bool
   to_bool(const result_type& value)
@@ -1583,7 +1583,7 @@ struct nodma : request
   static const key_type key = key_type::nodma;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static bool
   to_bool(const result_type& value)
@@ -1600,7 +1600,7 @@ struct error : request
   static const key_type key = key_type::error;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   // Parse sysfs line and split into error code and timestamp
   static std::pair<uint64_t, uint64_t>
@@ -1620,7 +1620,7 @@ struct xocl_errors : request
   static const key_type key = key_type::xocl_errors;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   // Parse sysfs line and from class get error code and timestamp
   XRT_CORE_COMMON_EXPORT
@@ -1640,7 +1640,7 @@ struct dna_serial_num : request
   static const char* name() { return "dna"; }
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(const result_type& value)
@@ -1656,7 +1656,7 @@ struct aie_core_info_sysfs : request
   static const key_type key = key_type::aie_core_info_sysfs;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 // Used to retrive aie shim tile status information from sysfs
@@ -1666,7 +1666,7 @@ struct aie_shim_info_sysfs : request
   static const key_type key = key_type::aie_shim_info_sysfs;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 // Used to retrive aie mem tile status information from sysfs
@@ -1676,7 +1676,7 @@ struct aie_mem_info_sysfs : request
   static const key_type key = key_type::aie_mem_info_sysfs;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 // Retrieve total number of columns on device
@@ -1686,7 +1686,7 @@ struct total_cols : request
   static const key_type key = key_type::total_cols;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 // Retrive aie status version
@@ -1703,7 +1703,7 @@ struct aie_status_version : request
   static const key_type key = key_type::aie_status_version;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 // Retrive device specific Aie tiles(core, mem, shim) tiles info
@@ -1715,7 +1715,7 @@ struct aie_tiles_stats : request
   static const key_type key = key_type::aie_tiles_stats;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 // Used to retrive aie tiles status info
@@ -1742,7 +1742,7 @@ struct aie_tiles_status_info : request
   static const key_type key = key_type::aie_tiles_status_info;
 
   virtual std::any
-  get(const device* device, const std::any& param) const = 0;
+  get(const device* device, const std::any& param) const override = 0;
 };
 
 // Retrieves the aie partition info.
@@ -1783,7 +1783,7 @@ struct aie_partition_info : request
   static const key_type key = key_type::aie_partition_info;
 
   virtual std::any
-  get(const device* device) const = 0;
+  get(const device* device) const override = 0;
 
   static std::string
   parse_priority_status(const uint64_t prio_status)
@@ -1817,7 +1817,7 @@ struct aie_telemetry : request
   static const key_type key = key_type::aie_telemetry;
 
   virtual std::any
-  get(const device* device) const = 0;
+  get(const device* device) const override = 0;
 };
 
 // Retrieves the miscellaneous telemetry info for the device
@@ -1834,7 +1834,7 @@ struct misc_telemetry : request
   static const key_type key = key_type::misc_telemetry;
 
   virtual std::any
-  get(const device* device) const = 0;
+  get(const device* device) const override = 0;
 };
 
 // Retrieves the opcode telemetry info for the device
@@ -1850,7 +1850,7 @@ struct opcode_telemetry : request
   static const key_type key = key_type::opcode_telemetry;
 
   virtual std::any
-  get(const device* device) const = 0;
+  get(const device* device) const override = 0;
 };
 
 // Retrieves the rtos telemetry info for the device
@@ -1885,7 +1885,7 @@ struct rtos_telemetry : request
   static const key_type key = key_type::rtos_telemetry;
 
   virtual std::any
-  get(const device* device) const = 0;
+  get(const device* device) const override = 0;
 };
 
 // Retrieve the stream buffer telemetry from the device
@@ -1901,7 +1901,7 @@ struct stream_buffer_telemetry : request
   static const key_type key = key_type::stream_buffer_telemetry;
 
   virtual std::any
-  get(const device* device) const = 0;
+  get(const device* device) const override = 0;
 };
 
 // Retrieves the firmware version of the device.
@@ -1919,7 +1919,7 @@ struct firmware_version : request
   static const key_type key = key_type::firmware_version;
 
   virtual std::any
-  get(const device* device) const = 0;
+  get(const device* device) const override = 0;
 };
 
 struct clock_freqs_mhz : request
@@ -1929,7 +1929,7 @@ struct clock_freqs_mhz : request
   static const char* name() { return "clocks"; }
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   // formatting of individual items for the vector
   static std::string
@@ -1946,7 +1946,7 @@ struct idcode : request
   static const char* name() { return "idcode"; }
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(const result_type& value)
@@ -1963,10 +1963,10 @@ struct data_retention : request
   static const key_type key = key_type::data_retention;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   virtual void
-  put(const device*, const std::any&) const = 0;
+  put(const device*, const std::any&) const override = 0;
 
   static bool
   to_bool(const result_type& value)
@@ -1983,10 +1983,10 @@ struct sec_level : request
   static const key_type key = key_type::sec_level;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   virtual void
-  put(const device*, const std::any&) const = 0;
+  put(const device*, const std::any&) const override = 0;
 };
 
 struct max_shared_host_mem_aperture_bytes : request
@@ -1995,7 +1995,7 @@ struct max_shared_host_mem_aperture_bytes : request
   static const key_type key = key_type::max_shared_host_mem_aperture_bytes;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 struct status_mig_calibrated : request
@@ -2005,7 +2005,7 @@ struct status_mig_calibrated : request
   static const char* name() { return "mig_calibrated"; }
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type value)
@@ -2033,7 +2033,7 @@ struct p2p_config : request
   to_string(value_type value);
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   // formatting of individual items for the vector
   static std::string
@@ -2053,7 +2053,7 @@ struct temp_card_top_front : request
   static const key_type key = key_type::temp_card_top_front;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type value)
@@ -2068,7 +2068,7 @@ struct temp_card_top_rear : request
   static const key_type key = key_type::temp_card_top_rear;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type value)
@@ -2083,7 +2083,7 @@ struct temp_card_bottom_front : request
   static const key_type key = key_type::temp_card_bottom_front;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type value)
@@ -2098,7 +2098,7 @@ struct temp_fpga : request
   static const key_type key = key_type::temp_fpga;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type value)
@@ -2113,7 +2113,7 @@ struct fan_trigger_critical_temp : request
   static const key_type key = key_type::fan_trigger_critical_temp;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type value)
@@ -2128,10 +2128,10 @@ struct fan_fan_presence : request
   static const key_type key = key_type::fan_fan_presence;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
-  to_string(result_type value)
+  to_string(const result_type& value)
   {
     return value.compare("A") == 0 ? "true" : "false";
   }
@@ -2143,7 +2143,7 @@ struct fan_speed_rpm : request
   static const key_type key = key_type::fan_speed_rpm;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type value)
@@ -2158,7 +2158,7 @@ struct ddr_temp_0 : request
   static const key_type key = key_type::ddr_temp_0;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 struct ddr_temp_1 : request
@@ -2167,7 +2167,7 @@ struct ddr_temp_1 : request
   static const key_type key = key_type::ddr_temp_1;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 struct ddr_temp_2 : request
@@ -2176,7 +2176,7 @@ struct ddr_temp_2 : request
   static const key_type key = key_type::ddr_temp_2;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 struct ddr_temp_3 : request
@@ -2185,7 +2185,7 @@ struct ddr_temp_3 : request
   static const key_type key = key_type::ddr_temp_3;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 struct hbm_temp : request
@@ -2194,7 +2194,7 @@ struct hbm_temp : request
   static const key_type key = key_type::hbm_temp;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type value)
@@ -2209,7 +2209,7 @@ struct cage_temp_0 : request
   static const key_type key = key_type::cage_temp_0;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type value)
@@ -2224,7 +2224,7 @@ struct cage_temp_1 : request
   static const key_type key = key_type::cage_temp_1;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type value)
@@ -2239,7 +2239,7 @@ struct cage_temp_2 : request
   static const key_type key = key_type::cage_temp_2;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type value)
@@ -2254,7 +2254,7 @@ struct cage_temp_3 : request
   static const key_type key = key_type::cage_temp_3;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type value)
@@ -2269,7 +2269,7 @@ struct dimm_temp_0 : request
   static const key_type key = key_type::dimm_temp_0;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type value)
@@ -2284,7 +2284,7 @@ struct dimm_temp_1 : request
   static const key_type key = key_type::dimm_temp_1;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type value)
@@ -2299,7 +2299,7 @@ struct dimm_temp_2 : request
   static const key_type key = key_type::dimm_temp_2;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type value)
@@ -2314,7 +2314,7 @@ struct dimm_temp_3 : request
   static const key_type key = key_type::dimm_temp_3;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type value)
@@ -2329,7 +2329,7 @@ struct v12v_pex_millivolts : request
   static const key_type key = key_type::v12v_pex_millivolts;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type value)
@@ -2344,7 +2344,7 @@ struct v12v_pex_milliamps : request
   static const key_type key = key_type::v12v_pex_milliamps;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type value)
@@ -2359,7 +2359,7 @@ struct v12v_aux_millivolts : request
   static const key_type key = key_type::v12v_aux_millivolts;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type value)
@@ -2374,7 +2374,7 @@ struct v12v_aux_milliamps : request
   static const key_type key = key_type::v12v_aux_milliamps;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type value)
@@ -2389,7 +2389,7 @@ struct v3v3_pex_millivolts : request
   static const key_type key = key_type::v3v3_pex_millivolts;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type value)
@@ -2404,7 +2404,7 @@ struct v3v3_aux_millivolts : request
   static const key_type key = key_type::v3v3_aux_millivolts;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type value)
@@ -2419,7 +2419,7 @@ struct ddr_vpp_bottom_millivolts : request
   static const key_type key = key_type::ddr_vpp_bottom_millivolts;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type value)
@@ -2434,7 +2434,7 @@ struct ddr_vpp_top_millivolts : request
   static const key_type key = key_type::ddr_vpp_top_millivolts;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type value)
@@ -2449,7 +2449,7 @@ struct v5v5_system_millivolts : request
   static const key_type key = key_type::v5v5_system_millivolts;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type value)
@@ -2464,7 +2464,7 @@ struct v1v2_vcc_top_millivolts : request
   static const key_type key = key_type::v1v2_vcc_top_millivolts;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type value)
@@ -2479,7 +2479,7 @@ struct v1v2_vcc_bottom_millivolts : request
   static const key_type key = key_type::v1v2_vcc_bottom_millivolts;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type value)
@@ -2494,7 +2494,7 @@ struct v1v8_millivolts : request
   static const key_type key = key_type::v1v8_millivolts;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type value)
@@ -2509,7 +2509,7 @@ struct v0v85_millivolts : request
   static const key_type key = key_type::v0v85_millivolts;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type value)
@@ -2524,7 +2524,7 @@ struct v0v9_vcc_millivolts : request
   static const key_type key = key_type::v0v9_vcc_millivolts;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type value)
@@ -2539,7 +2539,7 @@ struct v12v_sw_millivolts : request
   static const key_type key = key_type::v12v_sw_millivolts;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type value)
@@ -2554,7 +2554,7 @@ struct mgt_vtt_millivolts : request
   static const key_type key = key_type::mgt_vtt_millivolts;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type value)
@@ -2569,7 +2569,7 @@ struct int_vcc_millivolts : request
   static const key_type key = key_type::int_vcc_millivolts;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type value)
@@ -2584,7 +2584,7 @@ struct int_vcc_milliamps : request
   static const key_type key = key_type::int_vcc_milliamps;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type value)
@@ -2599,7 +2599,7 @@ struct int_vcc_temp : request
   static const key_type key = key_type::int_vcc_temp;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type value)
@@ -2614,7 +2614,7 @@ struct v3v3_pex_milliamps : request
   static const key_type key = key_type::v3v3_pex_milliamps;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type value)
@@ -2629,7 +2629,7 @@ struct v3v3_aux_milliamps : request
   static const key_type key = key_type::v3v3_aux_milliamps;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type value)
@@ -2644,7 +2644,7 @@ struct int_vcc_io_milliamps : request
   static const key_type key = key_type::int_vcc_io_milliamps;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type value)
@@ -2659,7 +2659,7 @@ struct v3v3_vcc_millivolts : request
   static const key_type key = key_type::v3v3_vcc_millivolts;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type value)
@@ -2674,7 +2674,7 @@ struct hbm_1v2_millivolts : request
   static const key_type key = key_type::hbm_1v2_millivolts;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type value)
@@ -2689,7 +2689,7 @@ struct v2v5_vpp_millivolts : request
   static const key_type key = key_type::v2v5_vpp_millivolts;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type value)
@@ -2704,7 +2704,7 @@ struct v12_aux1_millivolts : request
   static const key_type key = key_type::v12_aux1_millivolts;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type value)
@@ -2719,7 +2719,7 @@ struct vcc1v2_i_milliamps : request
   static const key_type key = key_type::vcc1v2_i_milliamps;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type value)
@@ -2734,7 +2734,7 @@ struct v12_in_i_milliamps : request
   static const key_type key = key_type::v12_in_i_milliamps;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type value)
@@ -2749,7 +2749,7 @@ struct v12_in_aux0_i_milliamps : request
   static const key_type key = key_type::v12_in_aux0_i_milliamps;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type value)
@@ -2764,7 +2764,7 @@ struct v12_in_aux1_i_milliamps : request
   static const key_type key = key_type::v12_in_aux1_i_milliamps;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type value)
@@ -2779,7 +2779,7 @@ struct vcc_aux_millivolts : request
   static const key_type key = key_type::vcc_aux_millivolts;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type value)
@@ -2794,7 +2794,7 @@ struct vcc_aux_pmc_millivolts : request
   static const key_type key = key_type::vcc_aux_pmc_millivolts;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type value)
@@ -2809,7 +2809,7 @@ struct vcc_ram_millivolts : request
   static const key_type key = key_type::vcc_ram_millivolts;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type value)
@@ -2824,7 +2824,7 @@ struct int_vcc_io_millivolts : request
   static const key_type key = key_type::int_vcc_io_millivolts;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type value)
@@ -2839,7 +2839,7 @@ struct v0v9_int_vcc_vcu_millivolts : request
   static const key_type key = key_type::v0v9_int_vcc_vcu_millivolts;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type value)
@@ -2855,7 +2855,7 @@ struct mac_contiguous_num : request
   static const char* name() { return "mac_contiguous_num"; }
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 struct mac_addr_first : request
@@ -2865,7 +2865,7 @@ struct mac_addr_first : request
   static const char* name() { return "mac_addr_first"; }
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 struct mac_addr_list : request
@@ -2875,7 +2875,7 @@ struct mac_addr_list : request
   static const char* name() { return "mac_addr_list"; }
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 struct oem_id : request
@@ -2890,7 +2890,7 @@ struct oem_id : request
   parse(const result_type& value);
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 struct firewall_detect_level : request
@@ -2900,7 +2900,7 @@ struct firewall_detect_level : request
   static const char* name() { return "level"; }
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type value)
@@ -2916,7 +2916,7 @@ struct firewall_detect_level_name : request
   static const char* name() { return "level_name"; }
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
 };
 
@@ -2927,7 +2927,7 @@ struct firewall_status : request
   static const char* name() { return "status"; }
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type value)
@@ -2943,7 +2943,7 @@ struct firewall_time_sec : request
   static const char* name() { return "time_sec"; }
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type value)
@@ -2958,7 +2958,7 @@ struct power_microwatts : request
   static const key_type key = key_type::power_microwatts;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type value)
@@ -2973,7 +2973,7 @@ struct power_warning : request
   static const key_type key = key_type::power_warning;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type value)
@@ -2989,7 +2989,7 @@ struct host_mem_addr : request
   static const char* name() { return "host_mem_addr"; }
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type val)
@@ -3005,7 +3005,7 @@ struct host_mem_size : request
   static const char* name() { return "host_mem_size"; }
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type val)
@@ -3021,7 +3021,7 @@ struct kds_numcdmas : request
   static const char* name() { return "kds_numcdmas"; }
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type val)
@@ -3037,10 +3037,10 @@ struct mig_cache_update : request
   static const key_type key = key_type::mig_cache_update;
 
   virtual std::any
-  get(const device*, modifier m, const std::string&) const = 0;
+  get(const device*, modifier m, const std::string&) const override = 0;
 
   virtual void
-  put(const device*, const std::any&) const = 0;
+  put(const device*, const std::any&) const override = 0;
 };
 
 struct mig_ecc_enabled : request
@@ -3049,7 +3049,7 @@ struct mig_ecc_enabled : request
   static const key_type key = key_type::mig_ecc_enabled;
 
   virtual std::any
-  get(const device*, modifier, const std::string&) const = 0;
+  get(const device*, modifier, const std::string&) const override = 0;
 };
 
 struct mig_ecc_status : request
@@ -3058,7 +3058,7 @@ struct mig_ecc_status : request
   static const key_type key = key_type::mig_ecc_status;
 
   virtual std::any
-  get(const device*, modifier, const std::string&) const = 0;
+  get(const device*, modifier, const std::string&) const override = 0;
 };
 
 struct mig_ecc_ce_cnt : request
@@ -3067,7 +3067,7 @@ struct mig_ecc_ce_cnt : request
   static const key_type key = key_type::mig_ecc_ce_cnt;
 
   virtual std::any
-  get(const device*, modifier, const std::string&) const = 0;
+  get(const device*, modifier, const std::string&) const override = 0;
 };
 
 struct mig_ecc_ue_cnt : request
@@ -3076,7 +3076,7 @@ struct mig_ecc_ue_cnt : request
   static const key_type key = key_type::mig_ecc_ue_cnt;
 
   virtual std::any
-  get(const device*, modifier, const std::string&) const = 0;
+  get(const device*, modifier, const std::string&) const override = 0;
 };
 
 struct mig_ecc_ce_ffa : request
@@ -3085,7 +3085,7 @@ struct mig_ecc_ce_ffa : request
   static const key_type key = key_type::mig_ecc_ce_ffa;
 
   virtual std::any
-  get(const device*, modifier, const std::string&) const = 0;
+  get(const device*, modifier, const std::string&) const override = 0;
 };
 
 struct mig_ecc_ue_ffa : request
@@ -3094,7 +3094,7 @@ struct mig_ecc_ue_ffa : request
   static const key_type key = key_type::mig_ecc_ue_ffa;
 
   virtual std::any
-  get(const device*, modifier, const std::string&) const = 0;
+  get(const device*, modifier, const std::string&) const override = 0;
 };
 
 struct is_mfg : request
@@ -3103,7 +3103,7 @@ struct is_mfg : request
   static const key_type key = key_type::is_mfg;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 struct mfg_ver : request
@@ -3112,7 +3112,7 @@ struct mfg_ver : request
   static const key_type key = key_type::mfg_ver;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 struct is_recovery : request
@@ -3121,7 +3121,7 @@ struct is_recovery : request
   static const key_type key = key_type::is_recovery;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 
@@ -3135,7 +3135,7 @@ struct is_versal : request
   static const key_type key = key_type::is_versal;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 // struct is_ready - A boolean stating
@@ -3147,7 +3147,7 @@ struct is_ready : request
   static const key_type key = key_type::is_ready;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 // struct is_offline - check if device is offline (being reset)
@@ -3163,7 +3163,7 @@ struct is_offline : request
   static const key_type key = key_type::is_offline;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 struct f_flash_type : request
@@ -3172,7 +3172,7 @@ struct f_flash_type : request
   static const key_type key = key_type::f_flash_type;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 struct flash_type : request
@@ -3182,7 +3182,7 @@ struct flash_type : request
   static const char* name() { return "flash_type"; }
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type value)
@@ -3197,7 +3197,7 @@ struct flash_size : request
   static const key_type key = key_type::flash_size;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 struct board_name : request
@@ -3206,7 +3206,7 @@ struct board_name : request
   static const key_type key = key_type::board_name;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 struct flash_bar_offset : request
@@ -3215,7 +3215,7 @@ struct flash_bar_offset : request
   static const key_type key = key_type::flash_bar_offset;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 struct rp_program_status : request
@@ -3225,10 +3225,10 @@ struct rp_program_status : request
   static const key_type key = key_type::rp_program_status;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   virtual void
-  put(const device*, const std::any&) const = 0;
+  put(const device*, const std::any&) const override = 0;
 
   static bool
   to_bool(const result_type& value)
@@ -3243,7 +3243,7 @@ struct cpu_affinity : request
   static const key_type key = key_type::cpu_affinity;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 struct shared_host_mem : request
@@ -3252,7 +3252,7 @@ struct shared_host_mem : request
   static const key_type key = key_type::shared_host_mem;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 struct enabled_host_mem : request
@@ -3261,7 +3261,7 @@ struct enabled_host_mem : request
   static const key_type key = key_type::enabled_host_mem;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 struct clock_timestamp : request
@@ -3270,7 +3270,7 @@ struct clock_timestamp : request
   static const key_type key = key_type::clock_timestamp;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 struct mailbox_metrics : request
@@ -3279,7 +3279,7 @@ struct mailbox_metrics : request
   static const key_type key = key_type::mailbox_metrics;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   // formatting of individual items for the vector
   static std::string
@@ -3297,10 +3297,10 @@ struct config_mailbox_channel_disable : request
   static const key_type key = key_type::config_mailbox_channel_disable;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   virtual void
-  put(const device*, const std::any&) const = 0;
+  put(const device*, const std::any&) const override = 0;
 };
 
 struct config_mailbox_channel_switch : request
@@ -3311,10 +3311,10 @@ struct config_mailbox_channel_switch : request
   static const key_type key = key_type::config_mailbox_channel_switch;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   virtual void
-  put(const device*, const std::any&) const = 0;
+  put(const device*, const std::any&) const override = 0;
 };
 
 struct config_xclbin_change : request
@@ -3325,10 +3325,10 @@ struct config_xclbin_change : request
   static const key_type key = key_type::config_xclbin_change;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   virtual void
-  put(const device*, const std::any&) const = 0;
+  put(const device*, const std::any&) const override = 0;
 };
 
 struct cache_xclbin : request
@@ -3339,10 +3339,10 @@ struct cache_xclbin : request
   static const key_type key = key_type::cache_xclbin;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   virtual void
-  put(const device*, const std::any&) const = 0;
+  put(const device*, const std::any&) const override = 0;
 };
 
 struct ert_sleep : request
@@ -3353,10 +3353,10 @@ struct ert_sleep : request
   static const key_type key = key_type::ert_sleep;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   virtual void
-  put(const device*, const std::any&) const = 0;
+  put(const device*, const std::any&) const override = 0;
 
 };
 
@@ -3366,7 +3366,7 @@ struct ert_cq_read : request
   static const key_type key = key_type::ert_cq_read;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 struct ert_cq_write : request
@@ -3375,7 +3375,7 @@ struct ert_cq_write : request
   static const key_type key = key_type::ert_cq_write;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 struct ert_cu_read : request
@@ -3384,7 +3384,7 @@ struct ert_cu_read : request
   static const key_type key = key_type::ert_cu_read;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 struct ert_cu_write : request
@@ -3393,7 +3393,7 @@ struct ert_cu_write : request
   static const key_type key = key_type::ert_cu_write;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 
@@ -3403,7 +3403,7 @@ struct ert_data_integrity : request
   static const key_type key = key_type::ert_data_integrity;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type value)
@@ -3422,7 +3422,7 @@ struct ert_status : request
   static const key_type key = key_type::ert_status;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static ert_status_data
   to_ert_status(const result_type& strs);
@@ -3434,7 +3434,7 @@ struct noop : request
   static const key_type key = key_type::noop;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   static std::string
   to_string(result_type value)
@@ -3450,7 +3450,7 @@ struct heartbeat_err_time : request
   static const key_type key = key_type::heartbeat_err_time;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 struct heartbeat_err_code : request
@@ -3459,7 +3459,7 @@ struct heartbeat_err_code : request
   static const key_type key = key_type::heartbeat_err_code;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 struct heartbeat_count : request
@@ -3468,7 +3468,7 @@ struct heartbeat_count : request
   static const key_type key = key_type::heartbeat_count;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 struct heartbeat_stall : request
@@ -3477,7 +3477,7 @@ struct heartbeat_stall : request
   static const key_type key = key_type::heartbeat_stall;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 struct aim_counter : request
@@ -3487,7 +3487,7 @@ struct aim_counter : request
   static const key_type key = key_type::aim_counter;
 
   virtual std::any
-  get(const xrt_core::device* device, const std::any& dbg_ip_data) const = 0;
+  get(const xrt_core::device* device, const std::any& dbg_ip_data) const override = 0;
 };
 
 struct am_counter : request
@@ -3497,7 +3497,7 @@ struct am_counter : request
   static const key_type key = key_type::am_counter;
 
   virtual std::any
-  get(const xrt_core::device* device, const std::any& dbg_ip_data) const = 0;
+  get(const xrt_core::device* device, const std::any& dbg_ip_data) const override = 0;
 };
 
 struct asm_counter : request
@@ -3507,7 +3507,7 @@ struct asm_counter : request
   static const key_type key = key_type::asm_counter;
 
   virtual std::any
-  get(const xrt_core::device* device, const std::any& dbg_ip_data) const = 0;
+  get(const xrt_core::device* device, const std::any& dbg_ip_data) const override = 0;
 };
 
 struct lapc_status : request
@@ -3517,7 +3517,7 @@ struct lapc_status : request
   static const key_type key = key_type::lapc_status;
 
   virtual std::any
-  get(const xrt_core::device* device, const std::any& dbg_ip_data) const = 0;
+  get(const xrt_core::device* device, const std::any& dbg_ip_data) const override = 0;
 };
 
 struct spc_status : request
@@ -3527,7 +3527,7 @@ struct spc_status : request
   static const key_type key = key_type::spc_status;
 
   virtual std::any
-  get(const xrt_core::device* device, const std::any& dbg_ip_data) const = 0;
+  get(const xrt_core::device* device, const std::any& dbg_ip_data) const override = 0;
 };
 
 struct accel_deadlock_status : request
@@ -3537,7 +3537,7 @@ struct accel_deadlock_status : request
   static const key_type key = key_type::accel_deadlock_status;
 
   virtual std::any
-  get(const xrt_core::device* device, const std::any& dbg_ip_data) const = 0;
+  get(const xrt_core::device* device, const std::any& dbg_ip_data) const override = 0;
 };
 
 struct boot_partition : request
@@ -3549,10 +3549,10 @@ struct boot_partition : request
   static const key_type key = key_type::boot_partition;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   virtual void
-  put(const device*, const std::any&) const = 0;
+  put(const device*, const std::any&) const override = 0;
 };
 
 struct flush_default_only : request
@@ -3562,10 +3562,10 @@ struct flush_default_only : request
   static const key_type key = key_type::flush_default_only;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   virtual void
-  put(const device*, const std::any&) const = 0;
+  put(const device*, const std::any&) const override = 0;
 };
 
 struct program_sc : request
@@ -3575,10 +3575,10 @@ struct program_sc : request
   static const key_type key = key_type::program_sc;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   virtual void
-  put(const device*, const std::any&) const = 0;
+  put(const device*, const std::any&) const override = 0;
 };
 
 
@@ -3592,7 +3592,7 @@ struct vmr_status : request
   static const key_type key = key_type::vmr_status;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 struct extended_vmr_status : request
@@ -3601,7 +3601,7 @@ struct extended_vmr_status : request
   static const key_type key = key_type::extended_vmr_status;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 // Retrieve xclbin slot information.  This is a mapping
@@ -3623,7 +3623,7 @@ struct xclbin_slots : request
   to_map(const result_type& value);
 
   virtual std::any
-  get(const xrt_core::device* device) const = 0;
+  get(const xrt_core::device* device) const override = 0;
 };
 
 // Retrieve Board Serial number from xocl hwmon_sdm driver
@@ -3633,7 +3633,7 @@ struct hwmon_sdm_serial_num : request
   static const key_type key = key_type::hwmon_sdm_serial_num;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 // Retrieve OEM ID data from xocl hwmon_sdm driver
@@ -3643,7 +3643,7 @@ struct hwmon_sdm_oem_id : request
   static const key_type key = key_type::hwmon_sdm_oem_id;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 // Retrieve Board name from xocl hwmon_sdm driver
@@ -3653,7 +3653,7 @@ struct hwmon_sdm_board_name : request
   static const key_type key = key_type::hwmon_sdm_board_name;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 // Retrieve active SC version from xocl hwmon_sdm driver
@@ -3663,7 +3663,7 @@ struct hwmon_sdm_active_msp_ver : request
   static const key_type key = key_type::hwmon_sdm_active_msp_ver;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 // Retrieve expected SC version from xocl hwmon_sdm driver
@@ -3673,7 +3673,7 @@ struct hwmon_sdm_target_msp_ver : request
   static const key_type key = key_type::hwmon_sdm_target_msp_ver;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 // Retrieve MAC ADDR0 from xocl hwmon_sdm driver
@@ -3683,7 +3683,7 @@ struct hwmon_sdm_mac_addr0 : request
   static const key_type key = key_type::hwmon_sdm_mac_addr0;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 // Retrieve MAC ADDR1 from xocl hwmon_sdm driver
@@ -3693,7 +3693,7 @@ struct hwmon_sdm_mac_addr1 : request
   static const key_type key = key_type::hwmon_sdm_mac_addr1;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 // Retrieve Revision data from xocl hwmon_sdm driver
@@ -3703,7 +3703,7 @@ struct hwmon_sdm_revision : request
   static const key_type key = key_type::hwmon_sdm_revision;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 // Retrieve FAN presence status from xocl hwmon_sdm driver
@@ -3713,7 +3713,7 @@ struct hwmon_sdm_fan_presence : request
   static const key_type key = key_type::hwmon_sdm_fan_presence;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 // Retrieve board MFG date from xocl hwmon_sdm driver
@@ -3723,7 +3723,7 @@ struct hwmon_sdm_mfg_date : request
   static const key_type key = key_type::hwmon_sdm_mfg_date;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 struct hotplug_offline : request
@@ -3732,7 +3732,7 @@ struct hotplug_offline : request
   static const key_type key = key_type::hotplug_offline;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 struct cu_size : request
@@ -3741,7 +3741,7 @@ struct cu_size : request
   static const key_type key = key_type::cu_size;
 
   virtual std::any
-  get(const device*, modifier, const std::string&) const = 0;
+  get(const device*, modifier, const std::string&) const override = 0;
 };
 
 struct cu_read_range : request
@@ -3754,7 +3754,7 @@ struct cu_read_range : request
   static const key_type key = key_type::cu_read_range;
 
   virtual std::any
-  get(const device*, modifier, const std::string&) const = 0;
+  get(const device*, modifier, const std::string&) const override = 0;
 
   static range_data
   to_range(const std::string& str);
@@ -3779,7 +3779,7 @@ struct clk_scaling_info : request
   static const key_type key = key_type::clk_scaling_info;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 struct xgq_scaling_enabled : request
@@ -3789,10 +3789,10 @@ struct xgq_scaling_enabled : request
   static const key_type key = key_type::xgq_scaling_enabled;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   virtual void
-  put(const device*, const std::any&) const = 0;
+  put(const device*, const std::any&) const override = 0;
 };
 
 struct xgq_scaling_power_override : request
@@ -3802,10 +3802,10 @@ struct xgq_scaling_power_override : request
   static const key_type key = key_type::xgq_scaling_power_override;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   virtual void
-  put(const device*, const std::any&) const = 0;
+  put(const device*, const std::any&) const override = 0;
 };
 
 struct xgq_scaling_temp_override : request
@@ -3815,10 +3815,10 @@ struct xgq_scaling_temp_override : request
   static const key_type key = key_type::xgq_scaling_temp_override;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   virtual void
-  put(const device*, const std::any&) const = 0;
+  put(const device*, const std::any&) const override = 0;
 };
 
 struct performance_mode : request
@@ -3838,10 +3838,10 @@ struct performance_mode : request
   static const key_type key = key_type::performance_mode;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   virtual void
-  put(const device*, const std::any&) const = 0;
+  put(const device*, const std::any&) const override = 0;
 
   static std::string
   parse_status(const result_type status)
@@ -3875,10 +3875,10 @@ struct preemption : request
   static const key_type key = key_type::preemption;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 
   virtual void
-  put(const device*, const std::any&) const = 0;
+  put(const device*, const std::any&) const override = 0;
 
 };
 
@@ -3890,7 +3890,7 @@ struct debug_ip_layout_path : request
   static const key_type key = key_type::debug_ip_layout_path;
 
   virtual std::any
-  get(const device*, const std::any&) const = 0;
+  get(const device*, const std::any&) const override = 0;
 };
 
 struct debug_ip_layout : request
@@ -3900,7 +3900,7 @@ struct debug_ip_layout : request
   static const key_type key = key_type::debug_ip_layout;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 struct num_live_processes : request
@@ -3910,7 +3910,7 @@ struct num_live_processes : request
   static const key_type key = key_type::num_live_processes;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 struct device_clock_freq_mhz : request
@@ -3920,7 +3920,7 @@ struct device_clock_freq_mhz : request
   static const key_type key = key_type::device_clock_freq_mhz;
 
   virtual std::any
-  get(const device*) const = 0;
+  get(const device*) const override = 0;
 };
 
 struct trace_buffer_info : request
@@ -3934,7 +3934,7 @@ struct trace_buffer_info : request
   static const key_type key = key_type::trace_buffer_info;
 
   virtual std::any
-  get(const device*, const std::any&) const = 0;
+  get(const device*, const std::any&) const override = 0;
 };
 
 struct host_max_bandwidth_mbps : request
@@ -3944,7 +3944,7 @@ struct host_max_bandwidth_mbps : request
   static const key_type key = key_type::host_max_bandwidth_mbps;
 
   virtual std::any
-  get(const device*, const std::any&) const = 0;
+  get(const device*, const std::any&) const override = 0;
 };
 
 struct kernel_max_bandwidth_mbps : request
@@ -3954,7 +3954,7 @@ struct kernel_max_bandwidth_mbps : request
   static const key_type key = key_type::kernel_max_bandwidth_mbps;
 
   virtual std::any
-  get(const device*, const std::any&) const = 0;
+  get(const device*, const std::any&) const override = 0;
 };
 
 struct sub_device_path : request
@@ -3968,7 +3968,7 @@ struct sub_device_path : request
   static const key_type key = key_type::sub_device_path;
 
   virtual std::any
-  get(const device*, const std::any&) const = 0;
+  get(const device*, const std::any&) const override = 0;
 };
 
 struct read_trace_data : request
@@ -3984,7 +3984,7 @@ struct read_trace_data : request
   static const key_type key = key_type::read_trace_data;
 
   virtual std::any
-  get(const device*, const std::any&) const = 0;
+  get(const device*, const std::any&) const override = 0;
 };
 } // query
 

--- a/src/runtime_src/core/common/query_reset.h
+++ b/src/runtime_src/core/common/query_reset.h
@@ -49,9 +49,13 @@ class reset_type {
 
 public:
   reset_type(reset_key key, std::string name, std::string subdev, std::string entry, std::string warning, std::string value)
-    : mKey(key), mName(name), mSubdev(subdev), mEntry(entry), mWarning(warning), mValue(value)
-  {
-  }
+    : mKey(std::move(key))
+    , mName(std::move(name))
+    , mSubdev(std::move(subdev))
+    , mEntry(std::move(entry))
+    , mWarning(std::move(warning))
+    , mValue(std::move(value))
+  {}
 
   reset_key get_key() const {
     return mKey;
@@ -70,11 +74,11 @@ public:
   }
 
   void set_subdev(std::string str) {
-    mSubdev = str;
+    mSubdev = std::move(str);
   }
 
   void set_entry(std::string str) {
-    mEntry = str;
+    mEntry = std::move(str);
   }
 
   std::string get_warning() const {

--- a/src/runtime_src/core/include/experimental/xrt_queue.h
+++ b/src/runtime_src/core/include/experimental/xrt_queue.h
@@ -54,11 +54,12 @@ class queue
     {
       Callable m_held;
 
+      explicit
       task_holder(Callable&& t)
         : m_held(std::move(t))
       {}
 
-      void execute()
+      void execute() override
       {
         m_held();
       }
@@ -122,11 +123,12 @@ public:
     {
       std::shared_future<ValueType> m_held;
 
+      explicit
       event_holder(std::shared_future<ValueType>&& e)
         : m_held(std::move(e))
       {}
 
-      void wait() const
+      void wait() const override
       {
         m_held.wait();
       }

--- a/src/runtime_src/core/include/experimental/xrt_xclbin.h
+++ b/src/runtime_src/core/include/experimental/xrt_xclbin.h
@@ -880,7 +880,7 @@ public:
 
   public:
     /**
-     * iterator - Default constructor from implmentation
+     * iterator - Converting default constructor from implmentation
      */
     iterator(std::shared_ptr<iterator_impl> handle)
       : detail::pimpl<iterator_impl>(std::move(handle))

--- a/src/runtime_src/core/include/xrt/xrt_hw_context.h
+++ b/src/runtime_src/core/include/xrt/xrt_hw_context.h
@@ -114,7 +114,7 @@ public:
   /// @endcond
 
   ///@cond
-  // Undocumented construction using impl only
+  // Undocumented converting constructor using impl only
   hw_context(std::shared_ptr<hw_context_impl> impl)
     : detail::pimpl<hw_context_impl>(std::move(impl))
   {}

--- a/src/runtime_src/core/include/xrt/xrt_uuid.h
+++ b/src/runtime_src/core/include/xrt/xrt_uuid.h
@@ -54,7 +54,7 @@ public:
   }
 
   /**
-   * uuid() - Construct uuid from a basic bare uuid
+   * uuid() - Converting construct uuid from a basic bare uuid
    *
    * @param val
    *  The basic uuid to construct this object from
@@ -75,7 +75,8 @@ public:
    *
    * A uuid string is 36 bytes with '-' at 8, 13, 18, and 23
    */
-  explicit uuid(const std::string& uuid_str)
+  explicit
+  uuid(const std::string& uuid_str)
   {
     if (uuid_str.empty()) {
       uuid_clear(m_uuid);
@@ -112,6 +113,21 @@ public:
   {
     uuid source(rhs);
     std::swap(*this,source);
+    return *this;
+  }
+
+  /**
+   * operator=() - assignment
+   *
+   * @param val
+   *   Value to be assigned from
+   * @return 
+   *   Reference to this
+   */
+  uuid&
+  operator=(const xuid_t val)
+  {
+    uuid_copy(m_uuid,val);
     return *this;
   }
 


### PR DESCRIPTION
#### Problem solved by the commit
Fix few cppcheck warnings

#### How problem was solved, alternative solutions (if any) and why they were rejected
Add nullptr check; not that this will ever trigger, but sure, cppcheck is correct about missing nullptr check.

Use override on virtual function overrides, but leave virtual if the override makes the function pure virtual for additional derived classes.

Use explicit to avoid converting constructors, but allow converting constructors for classes that act more or less as alias for type.
