### PR TITLE
fixing uninitialized variable related crash

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/edge/zocl_aie.c
+++ b/src/runtime_src/core/edge/drm/zocl/edge/zocl_aie.c
@@ -302,6 +302,8 @@ zocl_create_aie(struct drm_zocl_dev *zdev, struct axlf *axlf, void *aie_res, uin
 	/* only aie-1 supports resources */
 	if (hw_gen == 1)
 		req.meta_data = (u64)aie_res;
+	else
+		req.meta_data = 0;
 
 	if (zdev->aie->aie_dev) {
 		DRM_INFO("Partition %d already requested\n",


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
While requesting a partition, we need to initilize the request variable to "zero"s without that, AIE driver is crashing

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
This issue is there from beginning. Customer faced issue at their end

#### How problem was solved, alternative solutions (if any) and why they were rejected
Initialized variable to "zero"

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Verified customer case

#### Documentation impact (if any)
None