### PR TITLE
Made aie resources 0 for hw_gen greater than 1

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/edge/zocl_aie.c
+++ b/src/runtime_src/core/edge/drm/zocl/edge/zocl_aie.c
@@ -524,12 +524,12 @@ zocl_create_aie(struct drm_zocl_slot *slot, struct axlf *axlf, char __user *xclb
 		}
 	}
 
-	/* TODO figure out the partition id and uid from xclbin or PDI */
+	/* TODO figure out the uid from xclbin or PDI */
 	req.partition_id = partition_id;
 	req.uid = 0;
 	req.meta_data = 0;
 
-	if (aie_res)
+	if (hw_gen == 1)
 		req.meta_data = (u64)aie_res;
 
 	if (slot->aie->aie_dev) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
While requesting for AIE partition the meta_data of aie_partition_req should be "zero" for hw_gen greater than 1 since AIE resource loading only supported on hw_gen 1 (AIE1). Confirmed with the AIE driver team.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Customer faced issue with 2023.2 XRT (https://jira.xilinx.com/browse/CR-1220658). To avoid future similar issues fixing it on XRT master. 
#### How problem was solved, alternative solutions (if any) and why they were rejected
making meta_data of aie_partition_req "zero" for hw_gen greater than 1.
#### Risks (if any) associated the changes in the commit
None
#### What has been tested and how, request additional testing if necessary
Tested on vck190(AIE1) and vek280(AIE2)
#### Documentation impact (if any)
None