### PR TITLE
Added enable()function to the wait_ip_interrupt(timeout)

### DIFF
--- a/src/runtime_src/core/common/api/xrt_ip.cpp
+++ b/src/runtime_src/core/common/api/xrt_ip.cpp
@@ -116,10 +116,13 @@ public:
   }
 
   [[nodiscard]] std::cv_status
-  wait(const std::chrono::milliseconds& timeout) const
+  wait(const std::chrono::milliseconds& timeout)
   {
     // Waits for interrupt, or return on timeout
-    return device->wait_ip_interrupt(handle, static_cast<int32_t>(timeout.count()));
+    auto status = device->wait_ip_interrupt(handle, static_cast<int32_t>(timeout.count()));
+    if (status == std::cv_status::no_timeout)
+      enable(); //re-enable interrupts
+    return status;
   }
 };
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1221077 In wait_ip_interrupt(timeout) once interrupt is received we are not re-enabling in this function.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added enable()function to the wait_ip_interrupt(timeout)
#### Risks (if any) associated the changes in the commit
low
#### What has been tested and how, request additional testing if necessary
Tested on vck190.
#### Documentation impact (if any)
