### PR TITLE
Added enable()function to the wait_ip_interrupt(timeout) 

### DIFF
--- a/src/runtime_src/core/common/api/xrt_ip.cpp
+++ b/src/runtime_src/core/common/api/xrt_ip.cpp
@@ -116,10 +116,13 @@ public:
   }
 
   [[nodiscard]] std::cv_status
-  wait(const std::chrono::milliseconds& timeout) const
+  wait(const std::chrono::milliseconds& timeout)
   {
     // Waits for interrupt, or return on timeout
-    return device->wait_ip_interrupt(handle, static_cast<int32_t>(timeout.count()));
+    auto status = device->wait_ip_interrupt(handle, static_cast<int32_t>(timeout.count()));
+    if (status == std::cv_status::no_timeout)
+      enable(); //re-enable interrupts
+    return status;
   }
 };
 

--- a/src/runtime_src/core/edge/user/device_linux.cpp
+++ b/src/runtime_src/core/edge/user/device_linux.cpp
@@ -17,6 +17,7 @@
 #include "core/edge/user/aie/profile_object.h"
 #include <map>
 #include <memory>
+#include <poll.h>
 #include <string>
 
 #include <fcntl.h>
@@ -1291,6 +1292,28 @@ wait_ip_interrupt(xclInterruptNotifyHandle handle)
   int pending = 0;
   if (::read(handle, &pending, sizeof(pending)) == -1)
     throw error(errno, "wait_ip_interrupt failed POSIX read");
+}
+
+std::cv_status
+device_linux::
+wait_ip_interrupt(xclInterruptNotifyHandle handle, int32_t timeout)
+{
+  struct pollfd pfd = {.fd=handle, .events=POLLIN};
+  int32_t ret = 0;
+
+  //Checking for only one fd; Only of one CU
+  //Timeout value in milli seconds
+  ret = ::poll(&pfd, 1, timeout);
+  if (ret < 0)
+    throw error(errno, "wait_timeout: failed POSIX poll");
+
+  if (ret == 0) //Timeout occured
+    return std::cv_status::timeout;
+
+  if (pfd.revents & POLLIN) //Interrupt received
+    return std::cv_status::no_timeout;
+
+  throw error(-EINVAL, boost::str(boost::format("wait_timeout: POSIX poll unexpected event: %d")  % pfd.revents));
 }
 
 } // xrt_core

--- a/src/runtime_src/core/edge/user/device_linux.h
+++ b/src/runtime_src/core/edge/user/device_linux.h
@@ -26,8 +26,8 @@ public:
   // query functions
   virtual void read_dma_stats(boost::property_tree::ptree& pt) const;
 
-  virtual void read(uint64_t addr, void* buf, uint64_t len) const;
-  virtual void write(uint64_t addr, const void* buf, uint64_t len) const;
+  virtual void read(uint64_t addr, void* buf, uint64_t len) const override;
+  virtual void write(uint64_t addr, const void* buf, uint64_t len) const override;
   virtual void reset(const query::reset_type) const;
 
   ////////////////////////////////////////////////////////////////
@@ -70,29 +70,29 @@ public:
   // Custom ip interrupt handling
   // Redefined from xrt_core::ishim
   ////////////////////////////////////////////////////////////////
-  virtual xclInterruptNotifyHandle
-  open_ip_interrupt_notify(unsigned int ip_index)
+  xclInterruptNotifyHandle
+  open_ip_interrupt_notify(unsigned int ip_index) override
   {
     return xclOpenIPInterruptNotify(get_device_handle(), ip_index, 0);
   }
 
-  virtual void
-  close_ip_interrupt_notify(xclInterruptNotifyHandle handle)
+  void
+  close_ip_interrupt_notify(xclInterruptNotifyHandle handle) override
   {
     xclCloseIPInterruptNotify(get_device_handle(), handle);
   }
 
-  virtual void
-  enable_ip_interrupt(xclInterruptNotifyHandle);
+  void
+  enable_ip_interrupt(xclInterruptNotifyHandle) override;
 
-  virtual void
-  disable_ip_interrupt(xclInterruptNotifyHandle);
+  void
+  disable_ip_interrupt(xclInterruptNotifyHandle) override;
 
-  virtual void
-  wait_ip_interrupt(xclInterruptNotifyHandle);
+  void
+  wait_ip_interrupt(xclInterruptNotifyHandle) override;
 
-  virtual std::cv_status
-  wait_ip_interrupt(xclInterruptNotifyHandle, int32_t timeout);
+  std::cv_status
+  wait_ip_interrupt(xclInterruptNotifyHandle, int32_t timeout) override;
 
   virtual std::unique_ptr<hwctx_handle>
   create_hw_context(const xrt::uuid& xclbin_uuid,

--- a/src/runtime_src/core/edge/user/device_linux.h
+++ b/src/runtime_src/core/edge/user/device_linux.h
@@ -91,6 +91,9 @@ public:
   virtual void
   wait_ip_interrupt(xclInterruptNotifyHandle);
 
+  virtual std::cv_status
+  wait_ip_interrupt(xclInterruptNotifyHandle, int32_t timeout);
+
   virtual std::unique_ptr<hwctx_handle>
   create_hw_context(const xrt::uuid& xclbin_uuid,
                     const xrt::hw_context::cfg_param_type& cfg_param,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Added enable()function to the wait_ip_interrupt(timeout) 
Please refer to this PR: [PR-8611](https://github.com/Xilinx/XRT/pull/8611) and [PR-8627](https://github.com/Xilinx/XRT/pull/8627)

