### PR TITLE
Propagate XRT include and compile defintions in CMake target

### DIFF
--- a/src/runtime_src/core/common/CMakeLists.txt
+++ b/src/runtime_src/core/common/CMakeLists.txt
@@ -80,6 +80,38 @@ set_target_properties(xrt_coreutil PROPERTIES
   SOVERSION ${XRT_SOVERSION}
   )
 
+################################################################
+# Define include directories and definitions needed by any target that
+# links with xrt_coreutil
+# BUILD_INTERFACE is for targets within XRT that link with xrt_coreutil
+# INSTALL_INTERFACE is for external targets that link XRT::xrt_coreutil
+target_include_directories(xrt_coreutil
+  PUBLIC
+  $<BUILD_INTERFACE:${XRT_SOURCE_DIR}/runtime_src>
+  $<INSTALL_INTERFACE:${XRT_INSTALL_INCLUDE_DIR}>
+  )
+  
+target_include_directories(xrt_coreutil_static
+  PUBLIC
+  $<BUILD_INTERFACE:${XRT_SOURCE_DIR}/runtime_src>
+  $<INSTALL_INTERFACE:${XRT_INSTALL_INCLUDE_DIR}>
+  )
+
+target_compile_definitions(xrt_coreutil_static
+  PUBLIC
+  $<BUILD_INTERFACE:XRT_STATIC_BUILD>
+  $<INSTALL_INTERFACE:XRT_STATIC_BUILD>
+  )
+
+# Linking with xrt_coreutil_static requires that applications link
+# with the same runtime library as xrt_coreutil_static
+if (WIN32)
+  target_compile_options(xrt_coreutil_static
+    PUBLIC
+    $<INSTALL_INTERFACE:/MT$<$<CONFIG:Debug>:d>>
+    )
+endif()
+
 if (NOT WIN32)
   # Additional link dependencies for xrt_coreutil
   # xrt_uuid.h depends on uuid
@@ -89,6 +121,7 @@ if (NOT WIN32)
   # system libraries
   target_link_libraries(xrt_coreutil_static INTERFACE uuid dl rt pthread)
 endif()
+################################################################
 
 install(TARGETS xrt_coreutil
   EXPORT xrt-targets


### PR DESCRIPTION
#### Problem solved by the commit
This PR modifies #8027 to decorate targets `xrt_coreutil` and `xrt_coreutil_static` with include and compile defintions.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Below make snippet is all that is needed to compile a target that includes header files from XRT and links statically with `xrt_coreutil_static`.

```
find_package(XRT REQUIRED HINTS ${XILINX_XRT})
add_executable(verify verify.cpp)
target_link_libraries(verify XRT::xrt_coreutil_static)
```

The include search path is automatically amended with directory specified in INSTALL_INTERFACE in the CMakeLists.txt file that defines the xrt_coreutil* targets.

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Local test programs linking with xrt_coreutil and xrt_coreutil_static on both Linux and Windows

Thanks to @wilderfield for the suggestion.  This closes #8027.
