### PR TITLE
Revert "Made aie resources 0 for hw_gen greater than 1 (#8626)"

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/edge/zocl_aie.c
+++ b/src/runtime_src/core/edge/drm/zocl/edge/zocl_aie.c
@@ -524,12 +524,12 @@ zocl_create_aie(struct drm_zocl_slot *slot, struct axlf *axlf, char __user *xclb
 		}
 	}
 
-	/* TODO figure out the uid from xclbin or PDI */
+	/* TODO figure out the partition id and uid from xclbin or PDI */
 	req.partition_id = partition_id;
 	req.uid = 0;
 	req.meta_data = 0;
 
-	if (hw_gen == 1)
+	if (aie_res)
 		req.meta_data = (u64)aie_res;
 
 	if (slot->aie->aie_dev) {


### PR DESCRIPTION
Signed-off-by: bisingha <bikash.singha@amd.com>
(cherry picked from commit 715c7e79d49ebbf95126ad431151bcb9346e880c)

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
AIE engine driver team revoked the statement "pass NULL or 0 to req.meta_data for hw_gen > 1 while requesting for aie partition". Reverting the commit as the changes are not required.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
None.
#### How problem was solved, alternative solutions (if any) and why they were rejected
Based on the AIE engine driver team we published the changes. Since the statement made by them is not valid reverting the changes
#### Risks (if any) associated the changes in the commit
None
#### What has been tested and how, request additional testing if necessary
Tested on vck190 and vek280 board with simple AIE only testcase.
#### Documentation impact (if any)
None