### PR TITLE
Bug fix in patching ctrlpkt-pm symbol

### DIFF
--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -354,7 +354,7 @@ public:
     throw std::runtime_error("Not supported");
   }
 
-  [[nodiscard]] virtual const std::vector<std::string>&
+  [[nodiscard]] virtual const std::set<std::string>&
   get_ctrlpkt_pm_dynsyms() const
   {
     throw std::runtime_error("Not supported");
@@ -500,7 +500,7 @@ class module_elf : public module_impl
   bool m_restore_buf_exist = false;
   size_t m_scratch_pad_mem_size = 0;
 
-  std::vector<std::string> m_ctrlpkt_pm_dynsyms; // preemption dynsyms in elf
+  std::set<std::string> m_ctrlpkt_pm_dynsyms; // preemption dynsyms in elf
   std::map<std::string, buf> m_ctrlpkt_pm_bufs; // preemption buffers map
 
   // The ELF sections embed column and page information in their
@@ -723,7 +723,7 @@ class module_elf : public module_impl
         static constexpr const char* ctrlpkt_pm_dynsym = "ctrlpkt-pm";
         if (std::string(symname).find(ctrlpkt_pm_dynsym) != std::string::npos) {
           // store ctrlpkt preemption symbols which is later used for patching instr buf
-          m_ctrlpkt_pm_dynsyms.emplace_back(symname);
+          m_ctrlpkt_pm_dynsyms.emplace(symname);
         }
 
         // Get control code section referenced by the symbol, col, and page
@@ -950,7 +950,7 @@ public:
     return m_ctrl_packet;
   }
 
-  [[nodiscard]] const std::vector<std::string>&
+  [[nodiscard]] const std::set<std::string>&
   get_ctrlpkt_pm_dynsyms() const override
   {
     return m_ctrlpkt_pm_dynsyms;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Fixed a bug while patching ctrlpkt-pm symbol in ELF

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
In PR - https://github.com/Xilinx/XRT/pull/8593  changes were made to patch ctrlpkt-pm symbols, these symbols were stored when ELF is parsed in a vector which created duplicate entries for same symbol when multiple entries of same where present in .rela.dyn section.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Changed the logic to store the symbols in std::set to avoid duplicate entries.

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
Tested with failing application on strix simnow and patching happens as expected

#### Documentation impact (if any)
NA
