### PR TITLE
Update documentation of xrt:: objects to reflect shallow copy

### DIFF
--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -3809,7 +3809,7 @@ add_callback(ert_cmd_state state,
 {
   XRT_DEBUGF("run::add_callback run(%d)\n", handle->get_uid());
   if (state != ERT_CMD_STATE_COMPLETED)
-    throw xrt_core::error(-EINVAL, "xrtRunSetCallback state may only be ERT_CMD_STATE_COMPLETED");
+    throw xrt_core::error(-EINVAL, "Cannot add callback, run state may only be ERT_CMD_STATE_COMPLETED");
   // The function callback is passed a key that uniquely identifies
   // run objects referring to the same implmentation.  This allows
   // upstream to associate key with some run object that represents
@@ -3969,6 +3969,9 @@ void
 runlist::
 add(const xrt::run& run)
 {
+  if (!handle)
+    throw xrt_core::error("cannot add run object to uninitialized runlist");
+
   handle->add(run);
 }
 

--- a/src/runtime_src/core/include/experimental/xrt_kernel.h
+++ b/src/runtime_src/core/include/experimental/xrt_kernel.h
@@ -77,6 +77,9 @@ public:
    * runlist() - Construct empty runlist object
    *
    * Can be used as lvalue in assignment.
+   *
+   * It is undefined behavior to use a default constructed runlist
+   * for anything but assignment.
    */
   runlist() = default;
 

--- a/src/runtime_src/core/include/xrt/xrt_bo.h
+++ b/src/runtime_src/core/include/xrt/xrt_bo.h
@@ -438,11 +438,15 @@ public:
 
   /**
    * bo() - Copy ctor
+   *
+   * Performs shallow copy, sharing data with the source
    */
   bo(const bo& rhs) = default;
 
   /**
    * operator= () - Copy assignment
+   *
+   * Performs shallow copy, sharing data with the source
    */
   bo&
   operator=(const bo& rhs) = default;

--- a/src/runtime_src/core/include/xrt/xrt_device.h
+++ b/src/runtime_src/core/include/xrt/xrt_device.h
@@ -143,6 +143,9 @@ class device
 public:
   /**
    * device() - Constructor for empty device
+   *
+   * It is undefined behavior to use a default constructed device
+   * for anything but assignment, unless otherwise noted.
    */
   device() = default;
 
@@ -223,11 +226,15 @@ public:
 
   /**
    * device() - Copy ctor
+   *
+   * Performs shallow copy, sharing data with the source
    */
   device(const device& rhs) = default;
 
   /**
-   * operator= () - Move assignment
+   * operator= () - Copy assignment
+   *
+   * Performs shallow copy, sharing data with the source
    */
   device&
   operator=(const device& rhs) = default;

--- a/src/runtime_src/core/include/xrt/xrt_hw_context.h
+++ b/src/runtime_src/core/include/xrt/xrt_hw_context.h
@@ -73,6 +73,9 @@ public:
 public:
   /**
    * hw_context() - Constructor for empty context
+   *
+   * It is undefined behavior to use a default constructed hw_context
+   * for anything but assignment.
    */
   hw_context() = default;
 
@@ -122,6 +125,8 @@ public:
 
   /**
    * hw_context() - Copy ctor
+   *
+   * Performs shallow copy, sharing data with the source
    */
   hw_context(const hw_context&) = default;
 
@@ -138,6 +143,8 @@ public:
 
   /**
    * operator= () - Copy assignment
+   *
+   * Performs shallow copy, sharing data with the source
    */
   hw_context&
   operator=(const hw_context&) = default;

--- a/src/runtime_src/core/include/xrt/xrt_kernel.h
+++ b/src/runtime_src/core/include/xrt/xrt_kernel.h
@@ -127,6 +127,9 @@ public:
    * run() - Construct empty run object
    *
    * Can be used as lvalue in assignment.
+   *
+   * It is undefined behavior to use a default constructed run object
+   * for anything but assignment.
    */
   run() = default;
 
@@ -141,6 +144,8 @@ public:
 
   /**
    * run() - Copy ctor
+   *
+   * Performs shallow copy, sharing data with the source
    */
   run(const run&) = default;
 
@@ -157,6 +162,8 @@ public:
 
   /**
    * operator= () - Copy assignment
+   *
+   * Performs shallow copy assignment, sharing data with the source
    */
   run&
   operator=(const run&) = default;
@@ -394,6 +401,12 @@ public:
    * by multiple xrt::run objects.
    *
    * Any number of callbacks are supported.
+   *
+   * Execution a run object with callback functions is referred to as
+   * managed execution.  Managed execution is supported on Alveo style
+   * platforms only. If targeted platform does not supported managed
+   * execution, then an exception is thrown when the run object is
+   * submitted for execution.
    */
   XCL_DRIVER_DLLESPEC
   void
@@ -695,6 +708,9 @@ public:
 
   /**
    * kernel() - Construct for empty kernel
+   *
+   * It is undefined behavior to use a default constructed kernel object
+   * for anything but assignment.
    */
   kernel() = default;
 
@@ -745,6 +761,8 @@ public:
 
   /**
    * kernel() - Copy ctor
+   *
+   * Performs shallow copy, sharing data with the source
    */
   kernel(const kernel&) = default;
 
@@ -761,6 +779,8 @@ public:
 
   /**
    * operator= () - Copy assignment
+   *
+   * Performs shallow copy assignment, sharing data with the source
    */
   kernel&
   operator=(const kernel&) = default;


### PR DESCRIPTION
#### Problem solved by the commit
#### How problem was solved, alternative solutions (if any) and why they were rejected
It is undefined behavior to use a default constructed first class xrt object for anything but assignment, unless otherwise noted.

Copy and assignment performs shallow copy unless otherwise noted.

Update comment in xrt::kernel to reflect that managed execution (adding callbacks) is only supported on select platforms.
