### PR TITLE
Fix xrt-smi throughput tests to measure throughput

### DIFF
--- a/src/runtime_src/core/tools/common/tests/TestNPUThroughput.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestNPUThroughput.cpp
@@ -112,15 +112,21 @@ TestNPUThroughput::run(std::shared_ptr<xrt_core::device> dev)
 
   try {
     auto start = std::chrono::high_resolution_clock::now();
-    //enqueue 9 commnds
-    for(int i = 0; i < run_buffer; i++) {
+
+    // enqueue 9 commnds
+    for (int i = 0; i < run_buffer; i++)
       run_handles[i%run_buffer].start();
-    }
-    //wait for each command to finish and add them to the queue
-    for(int i = 0; i < (itr_count_throughput-run_buffer); i++) {
+
+    // wait for each command to finish, then start immediately
+    for (int i = 0; i < (itr_count_throughput - run_buffer); i++) {
       run_handles[i%run_buffer].wait2();
       run_handles[i%run_buffer].start();
     }
+
+    // wait for the last 9 commands to finish
+    for (int i = 0; i < run_buffer; i++)
+      run_handles[i%run_buffer].wait2();
+
     auto end = std::chrono::high_resolution_clock::now();
     elapsedSecs = std::chrono::duration_cast<std::chrono::duration<double>>(end-start).count();
   }


### PR DESCRIPTION
#### Problem solved by the commit
Fix throughput tests for xrt-smi to actually measure throughput.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
NPU test for chained command throughput was measuring latency but computing throughput.   Additionally the test failed to hide the ramp-up clock scaling cost because iteration count was too low.

NPU test for individual command throughput was missing wait on last batch of commands submitted.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Fix chained command throughput to ensure NPU is always busy while measuring throughput.  This was done by using two xrt::runlists.

Additional problem for chained command throughput test was the iteration count, which was too small to hide the ramp-up cost of clock scaling, so the test was fixed to increase the iteration count and lowering the runlist command count.

Added wait on last batch of submitted commands in NPU throughput test for individual commands.

#### What has been tested and how, request additional testing if necessary
xrt-smi validate
