### PR TITLE
Added AIE flag to build XRT edge debian packages on ubuntu 24.04

### DIFF
--- a/build/debian/rules
+++ b/build/debian/rules
@@ -6,7 +6,7 @@
 override_dh_auto_configure:
 	set -ex; \
 	if [ "$$(dpkg-architecture -q DEB_TARGET_ARCH)" = arm64 ]; then \
-	    XRT_NATIVE_BUILD=no DKMS_FLOW=yes XRT_AIE_BUILD=true CXXFLAGS="-DXRT_ENABLE_AIE -DFAL_LINUX=on" dh_auto_configure; \
+	    XRT_NATIVE_BUILD=no DKMS_FLOW=yes CXXFLAGS="-DXRT_ENABLE_AIE -DFAL_LINUX=on" dh_auto_configure  -- -DXRT_AIE_BUILD=ON; \
 	else \
 	    dh_auto_configure; \
 	fi


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Added AIE flag to build XRT edge debian packages on ubuntu 24.04. Please refer to this [PR-8642](https://github.com/Xilinx/XRT/pull/8642)
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added XRT_AIE_BUILD flag to debian/rules file
#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Testd on kria kv260
#### Documentation impact (if any)
