### PR TITLE
CR-1221968 Fix invalid priority error throw for aie-partitions report

### DIFF
--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -1798,7 +1798,7 @@ struct aie_partition_info : request
       case 640: //0x280
         return "Low";
       default:
-        throw xrt_core::system_error(EINVAL, "Invalid priority status: " + std::to_string(prio_status));
+        return "N/A";
     }
   }
 };


### PR DESCRIPTION
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1221968 On Linux, xrt-smi throws priority error for the aie-partitions report.
#### How problem was solved, alternative solutions (if any) and why they were rejected
After discussion with Linux team, we want to handle the priority error gracefully by displaying "N/A".
#### Risks (if any) associated the changes in the commit
N/A
#### What has been tested and how, request additional testing if necessary
Tested on Linux STX. This change also verifies the fix for CR-1221397, as PID shows up in this output.
```
------------------------------
[0000:c5:00.1] : RyzenAI-npu4
------------------------------
AIE Partitions
  Partition Index: 0
    Columns: [0, 1, 2, 3]
    HW Contexts:
      |PID     |Ctx ID  |Status  |Instr BO  |Sub  |Compl  |Migr  |Err  |Prio  |GOPS  |EGOPS  |FPS  |Latency  |
      |--------|--------|--------|----------|-----|-------|------|-----|------|------|-------|-----|---------|
      |655166  |1       |Active  |0 Byte    |120  |119    |0     |0    |N/A   |0     |0      |0    |0        |
```
#### Documentation impact (if any)
N/A