### PR TITLE
CR-1219475 and CR-1220306

### DIFF
--- a/src/runtime_src/core/tools/common/tests/TestTemporalSharingOvd.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestTemporalSharingOvd.cpp
@@ -120,11 +120,11 @@ TestTemporalSharingOvd::run(std::shared_ptr<xrt_core::device> dev) {
   // End of Run 2 
 
   if(XBU::getVerbose()){
-    XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Spatially shared contexts latency: '%.1f' ms") % (latencySpatial * 1000)));
-    XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Temporally shared contexts latency: '%.1f' ms") % (latencyTemporal * 1000)));
+    XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Spatially shared contexts latency: %.1f ms") % (latencySpatial * 1000)));
+    XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Temporally shared contexts latency: %.1f ms") % (latencyTemporal * 1000)));
   }
   auto overhead = (latencyTemporal - latencySpatial); 
-  XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Overhead: '%.1f' ms") % (overhead * 1000)));
+  XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Overhead: %.1f ms") % (overhead * 1000)));
 
   // Set the test status to passed
   ptree.put("status", XBValidateUtils::test_token_passed);

--- a/src/runtime_src/core/tools/xbutil2/OO_Performance.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_Performance.cpp
@@ -27,7 +27,7 @@ OO_Performance::OO_Performance( const std::string &_longName, bool _isHidden )
   ;
 
   m_optionsHidden.add_options()
-    ("mode", boost::program_options::value<decltype(m_action)>(&m_action)->required(), "Action to perform: default, powersaver, balanced, performance, turbo")
+    ("mode", boost::program_options::value<decltype(m_action)>(&m_action)->required(), "Action to perform: default, powersaver, balanced, performance") //to-do: add turbo mode back to help!
   ;
 
   m_positionalOptions.
@@ -38,12 +38,6 @@ OO_Performance::OO_Performance( const std::string &_longName, bool _isHidden )
 void
 OO_Performance::execute(const SubCmdOptions& _options) const
 {
-  XBUtilities::verbose("SubCommand option: Power Mode");
-
-  XBUtilities::verbose("Option(s):");
-  for (auto & aString : _options)
-    XBUtilities::verbose(std::string(" ") + aString);
-
   // Honor help option first
   if (std::find(_options.begin(), _options.end(), "--help") != _options.end()) {
     printHelp();


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
- [CR-1220306](https://jira.xilinx.com/browse/CR-1220306) xrt-smi validate output json file has inconsistent format for temporal-sharing-overhead
- [CR-1219475](https://jira.xilinx.com/browse/CR-1219475) xrt-smi configure --pmode performance --verbose prints unnecessary informations
- remove turbo mode from --pmode help as it is not a public option

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
- Removed quotes around the numbers for consistency
- remove verbose messages from --pmode

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
Tested on strix

#### Documentation impact (if any)
N/A