### PR TITLE
Removing stray include in profiling

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -36,7 +36,6 @@
 #include "x86/aie_trace.h"
 #include "xdp/profile/device/hal_device/xdp_hal_device.h"
 #else
-#include "core/edge/user/shim.h"
 #include "edge/aie_trace.h"
 #include "xdp/profile/device/hal_device/xdp_hal_device.h"
 #endif


### PR DESCRIPTION
#### Problem solved by the commit
The XDP profiling code that is built only dependent on xrt_coreutil was accidentally including a file from xrt_core.  None of the objects or APIs were used, but for clarity this pull request removes the include.

#### What has been tested and how, request additional testing if necessary
Building has been tested.  No other impact expected.

#### Documentation impact (if any)
None.