### PR TITLE
[XDP] Handle incorrect range of tiles usage for memory tiles settings

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info/aie_util.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info/aie_util.cpp
@@ -385,7 +385,11 @@ namespace xdp::aie {
    ***************************************************************************/
   uint8_t
   convertStringToUint8(const std::string& input) {
-    return static_cast<uint8_t>(std::stoi(input));
+    try {
+      return static_cast<uint8_t>(std::stoi(input));
+    } catch (const std::exception&) {
+      throw;
+    }
   }
 
   std::string


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
[CR-1222763] Incorrect usage of range of memory tiles was resulting into segmentation faults.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1222763 - UG1076 has documentation error and needs an update for  tile based settings of memory tiles.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Parsing of user settings are in try-catch block. However, this was skipped as invalid string to int conversion was not thrown and re-caught.

#### Risks (if any) associated the changes in the commit
Low.

#### What has been tested and how, request additional testing if necessary
Verified on VEK280.
Verified that user now doesn't see crash and appropriate warning is emitted.
Verified that correct usage of memory tile settings are parsed correctly by plugin.

#### Documentation impact (if any)
Yes. UG1076 needs an update.