### PR TITLE
Added 6.12 kernel support to the zocl

### DIFF
--- a/src/runtime_src/core/common/drv/include/kds_ert_table.h
+++ b/src/runtime_src/core/common/drv/include/kds_ert_table.h
@@ -16,7 +16,7 @@
 #include "ert.h"
 #include "kds_command.h"
 
-const static enum ert_cmd_state kds_ert_table[] = {
+static const enum ert_cmd_state kds_ert_table[] = {
   [KDS_NEW] = ERT_CMD_STATE_NEW,
   [KDS_QUEUED] = ERT_CMD_STATE_QUEUED,
   [KDS_RUNNING] = ERT_CMD_STATE_RUNNING,
@@ -28,7 +28,7 @@ const static enum ert_cmd_state kds_ert_table[] = {
   [KDS_STAT_MAX] = ERT_CMD_STATE_MAX,
 };
 
-const static enum kds_status ert_kds_table[] = {
+static const enum kds_status ert_kds_table[] = {
   [ERT_CMD_STATE_NEW] = KDS_NEW,
   [ERT_CMD_STATE_QUEUED] = KDS_QUEUED,
   [ERT_CMD_STATE_RUNNING] = KDS_RUNNING,

--- a/src/runtime_src/core/common/drv/include/xrt_cu.h
+++ b/src/runtime_src/core/common/drv/include/xrt_cu.h
@@ -413,19 +413,19 @@ static inline char *prot2str(enum CU_PROTOCOL prot)
 	}
 }
 
-static void inline xrt_cu_enable_intr(struct xrt_cu *xcu, u32 intr_type)
+static inline void xrt_cu_enable_intr(struct xrt_cu *xcu, u32 intr_type)
 {
 	if (xcu->funcs)
 		xcu->funcs->enable_intr(xcu->core, intr_type);
 }
 
-static void inline xrt_cu_disable_intr(struct xrt_cu *xcu, u32 intr_type)
+static inline void xrt_cu_disable_intr(struct xrt_cu *xcu, u32 intr_type)
 {
 	if (xcu->funcs)
 		xcu->funcs->disable_intr(xcu->core, intr_type);
 }
 
-static u32 inline xrt_cu_clear_intr(struct xrt_cu *xcu)
+static inline u32 xrt_cu_clear_intr(struct xrt_cu *xcu)
 {
 	return xcu->funcs ? xcu->funcs->clear_intr(xcu->core) : 0;
 }
@@ -548,6 +548,7 @@ void xrt_cu_hpq_submit(struct xrt_cu *xcu, struct kds_command *xcmd);
 void xrt_cu_abort(struct xrt_cu *xcu, struct kds_client *client);
 bool xrt_cu_abort_done(struct xrt_cu *xcu, struct kds_client *client);
 bool xrt_cu_intr_supported(struct xrt_cu *xcu);
+int xrt_cu_intr_thread(void *data);
 int xrt_cu_start_thread(struct xrt_cu *xcu);
 void xrt_cu_stop_thread(struct xrt_cu *xcu);
 int xrt_cu_cfg_update(struct xrt_cu *xcu, int intr);

--- a/src/runtime_src/core/edge/drm/zocl/common/cu.c
+++ b/src/runtime_src/core/edge/drm/zocl/common/cu.c
@@ -9,7 +9,6 @@
  * This file is dual-licensed; you may select either the GNU General Public
  * License version 2 or Apache License, Version 2.0.
  */
-
 #include "zocl_drv.h"
 #include "xrt_cu.h"
 #include "zocl_ert_intc.h"
@@ -445,8 +444,11 @@ err:
 	kfree(zcu);
 	return err;
 }
-
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
+static void cu_remove(struct platform_device *pdev)
+#else
 static int cu_remove(struct platform_device *pdev)
+#endif
 {
 	struct zocl_cu *zcu;
 	struct drm_zocl_dev *zdev;
@@ -454,9 +456,10 @@ static int cu_remove(struct platform_device *pdev)
 	struct platform_device *intc;
 
 	zcu = platform_get_drvdata(pdev);
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
 	if (!zcu)
 		return -EINVAL;
-
+#endif
 	info = &zcu->base.info;
 	switch (info->model) {
 	case XCU_HLS:
@@ -487,8 +490,9 @@ static int cu_remove(struct platform_device *pdev)
 	zocl_info(&pdev->dev, "CU[%d] removed", info->inst_idx);
 	kfree(zcu->irq_name);
 	kfree(zcu);
-
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
 	return 0;
+#endif
 }
 
 static struct platform_device_id cu_id_table[] = {

--- a/src/runtime_src/core/edge/drm/zocl/common/zocl_drv.c
+++ b/src/runtime_src/core/edge/drm/zocl/common/zocl_drv.c
@@ -1315,7 +1315,11 @@ err_apt:
  * @return       0 on success, Error code on failure.
  *
  */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
+static void zocl_drm_platform_remove(struct platform_device *pdev)
+#else
 static int zocl_drm_platform_remove(struct platform_device *pdev)
+#endif
 {
 	struct drm_zocl_dev *zdev = platform_get_drvdata(pdev);
 	struct drm_device *drm = zdev->ddev;
@@ -1350,7 +1354,9 @@ static int zocl_drm_platform_remove(struct platform_device *pdev)
 	drm_dev_unregister(drm);
 	ZOCL_DRM_DEV_PUT(drm);
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
 	return 0;
+#endif
 }
 
 static struct platform_driver zocl_drm_private_driver = {

--- a/src/runtime_src/core/edge/drm/zocl/common/zocl_sysfs.c
+++ b/src/runtime_src/core/edge/drm/zocl/common/zocl_sysfs.c
@@ -594,7 +594,6 @@ static ssize_t read_xclbin_full(struct file *filp, struct kobject *kobj,
 	size_t size = 0;
 	u32 nread = 0;
 	u32 f_nread = 0;
-	int i = 0;
 
 	zdev = dev_get_drvdata(container_of(kobj, struct device, kobj));
 	if (!zdev)

--- a/src/runtime_src/core/edge/drm/zocl/edge/zocl_cu.c
+++ b/src/runtime_src/core/edge/drm/zocl/edge/zocl_cu.c
@@ -15,7 +15,7 @@
 #include <drm/drm.h>
 #include <drm/drm_print.h>
 #include <linux/io.h>
-
+#include <linux/vmalloc.h>
 #include "zocl_cu.h"
 
 void

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_aie.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_aie.h
@@ -148,7 +148,7 @@ aie_free_errors(struct aie_errors *aie_errs)
 {
 }
 #endif
-
+int zocl_read_aieresbin(struct drm_zocl_slot *slot, struct axlf* axlf, char __user *xclbin);
 struct aie_info {
 	struct list_head	aie_cmd_list;
 	struct mutex		aie_lock;

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
@@ -23,6 +23,7 @@
 #include <drm/drm_gem.h>
 #include <drm/drm_mm.h>
 #include <linux/version.h>
+#include <linux/vmalloc.h>
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
 #include <drm/drm_gem_dma_helper.h>
 #else
@@ -257,6 +258,7 @@ void zocl_fini_sysfs(struct device *dev);
 void zocl_free_sections(struct drm_zocl_dev *dev, struct drm_zocl_slot *slot);
 void zocl_free_bo(struct drm_gem_object *obj);
 void zocl_drm_free_bo(struct drm_zocl_bo *bo);
+struct drm_gem_object *zocl_gem_create_object(struct drm_device *dev, size_t size);
 struct drm_zocl_bo *zocl_drm_create_bo(struct drm_device *dev,
 		uint64_t unaligned_size, unsigned user_flags);
 void zocl_update_mem_stat(struct drm_zocl_dev *zdev, u64 size,
@@ -288,7 +290,6 @@ int zocl_inject_error(struct drm_zocl_dev *zdev, void *data,
 int zocl_init_error(struct drm_zocl_dev *zdev);
 void zocl_fini_error(struct drm_zocl_dev *zdev);
 int zocl_insert_error_record(struct drm_zocl_dev *zdev, xrtErrorCode err_code);
-
 /* zocl_kds.c */
 int zocl_init_sched(struct drm_zocl_dev *zdev);
 void zocl_fini_sched(struct drm_zocl_dev *zdev);
@@ -319,6 +320,9 @@ int subdev_create_cu(struct device *dev, struct xrt_cu_info *info, struct platfo
 void subdev_destroy_cu(struct drm_zocl_dev *zdev);
 int subdev_create_scu(struct device *dev, struct xrt_cu_info *info, struct platform_device **pdevp);
 void subdev_destroy_scu(struct drm_zocl_dev *zdev);
+
+irqreturn_t cu_isr(int irq, void *arg);
+irqreturn_t ucu_isr(int irq, void *arg);
 /* Sub device driver */
 extern struct platform_driver zocl_cu_xgq_driver;
 extern struct platform_driver zocl_csr_intc_driver;

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_ert.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_ert.h
@@ -197,5 +197,5 @@ struct zocl_ert_info {
 	int			model;
 	struct zocl_ert_ops    *ops;
 };
-
+struct ert_packet *get_packet(struct ert_packet *packet, u32 idx, u32 size);
 #endif

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_ert_intc.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_ert_intc.h
@@ -17,6 +17,7 @@
 #include <linux/interrupt.h>
 #include <linux/slab.h>
 #include <linux/io.h>
+#include <linux/version.h>
 #include "zocl_lib.h"
 
 #define ERT_CSR_INTC_DEV_NAME		"ZOCL_CSR_INTC"

--- a/src/runtime_src/core/edge/drm/zocl/zert/scu.c
+++ b/src/runtime_src/core/edge/drm/zocl/zert/scu.c
@@ -263,8 +263,11 @@ err:
 	kfree(zcu);
 	return err;
 }
-
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
+static void scu_remove(struct platform_device *pdev)
+#else
 static int scu_remove(struct platform_device *pdev)
+#endif
 {
 	struct zocl_scu *zcu = platform_get_drvdata(pdev);
 	struct drm_zocl_dev *zdev = zocl_get_zdev();
@@ -285,8 +288,9 @@ static int scu_remove(struct platform_device *pdev)
 
 	zocl_info(&pdev->dev, "SCU[%d] removed", info->cu_idx);
 	kfree(zcu);
-
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
 	return 0;
+#endif
 }
 
 static struct platform_device_id scu_id_table[] = {

--- a/src/runtime_src/core/edge/drm/zocl/zert/zocl_csr_intc.c
+++ b/src/runtime_src/core/edge/drm/zocl/zert/zocl_csr_intc.c
@@ -131,12 +131,18 @@ static int zintc_probe(struct platform_device *pdev)
 	return 0;
 }
 
-static int zintc_remove(struct platform_device *pdev)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
+static void zintc_remove(struct platform_device *pdev) 
+#else
+static int zintc_remove(struct platform_device *pdev) 
+#endif
 {
 	struct zocl_csr_intc *zintc = platform_get_drvdata(pdev);
 
 	zintc_info(zintc, "Removing %s", ZINTC_NAME);
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
 	return 0;
+#endif
 }
 
 /*

--- a/src/runtime_src/core/edge/drm/zocl/zert/zocl_ctrl_ert.c
+++ b/src/runtime_src/core/edge/drm/zocl/zert/zocl_ctrl_ert.c
@@ -710,8 +710,11 @@ static int zert_probe(struct platform_device *pdev)
 
 	return ret;
 }
-
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
+static void zert_remove(struct platform_device *pdev)
+#else
 static int zert_remove(struct platform_device *pdev)
+#endif
 {
 	struct zocl_ctrl_ert *zert = platform_get_drvdata(pdev);
 
@@ -728,8 +731,9 @@ static int zert_remove(struct platform_device *pdev)
 	zert->zce_num_cu_xgqs = 0;
 	zocl_ert_destroy_intc(zert->zce_xgq_intc);
 	zocl_ert_destroy_intc(zert->zce_cu_intc);
-
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
 	return 0;
+#endif
 }
 
 struct platform_driver zocl_ctrl_ert_driver = {

--- a/src/runtime_src/core/edge/drm/zocl/zert/zocl_cu_xgq.c
+++ b/src/runtime_src/core/edge/drm/zocl/zert/zocl_cu_xgq.c
@@ -341,8 +341,11 @@ static int zcu_xgq_probe(struct platform_device *pdev)
 
 	return 0;
 }
-
+#if  LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
+static void zcu_xgq_remove(struct platform_device *pdev)
+#else
 static int zcu_xgq_remove(struct platform_device *pdev)
+#endif
 {
 	struct zocl_cu_xgq *zcu_xgq = platform_get_drvdata(pdev);
 
@@ -358,7 +361,9 @@ static int zcu_xgq_remove(struct platform_device *pdev)
 	if (zcu_xgq->zxc_client_hdl)
 		zocl_destroy_client(zcu_xgq->zxc_client_hdl);
 	zcu_xgq_fini_xgq(zcu_xgq);
+#if  LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
 	return 0;
+#endif
 }
 
 static const struct platform_device_id zocl_cu_xgq_id_match[] = {

--- a/src/runtime_src/core/edge/drm/zocl/zert/zocl_ert.c
+++ b/src/runtime_src/core/edge/drm/zocl/zert/zocl_ert.c
@@ -297,13 +297,16 @@ static int zocl_ert_probe(struct platform_device *pdev)
 	platform_set_drvdata(pdev, ert);
 	return 0;
 }
-
-static int zocl_ert_remove(struct platform_device *pdev)
-{
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
+static void zocl_ert_remove(struct platform_device *pdev) {
+	ert_dbg(pdev, "Release resource");
+}
+#else
+static int zocl_ert_remove(struct platform_device *pdev) {
 	ert_dbg(pdev, "Release resource");
 	return 0;
 }
-
+#endif
 struct platform_driver zocl_ert_driver = {
 	.driver = {
 		.name = ZOCL_ERT_NAME,

--- a/src/runtime_src/core/edge/drm/zocl/zert/zocl_ospi_versal.c
+++ b/src/runtime_src/core/edge/drm/zocl/zert/zocl_ospi_versal.c
@@ -497,8 +497,11 @@ static int zocl_ov_probe(struct platform_device  *pdev)
 
 	return 0;
 }
-
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
+static void zocl_ov_remove(struct platform_device *pdev)
+#else
 static int zocl_ov_remove(struct platform_device *pdev)
+#endif
 {
 	struct zocl_ov_dev *ov = platform_get_drvdata(pdev);
 
@@ -506,8 +509,9 @@ static int zocl_ov_remove(struct platform_device *pdev)
 
 	if (ov && ov->timer_task)
 		kthread_stop(ov->timer_task);
-
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
 	return 0;
+#endif
 }
 
 struct platform_driver zocl_ospi_versal_driver = {

--- a/src/runtime_src/core/edge/drm/zocl/zert/zocl_rpu_channel.c
+++ b/src/runtime_src/core/edge/drm/zocl/zert/zocl_rpu_channel.c
@@ -518,8 +518,11 @@ err_intc:
 	sysfs_remove_group(&pdev->dev.kobj, &zrpu_channel_attrgroup);
 	return -EINVAL;
 };
-
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
+static void zrpu_channel_remove(struct platform_device *pdev)
+#else
 static int zrpu_channel_remove(struct platform_device *pdev)
+#endif
 {
 	struct zocl_rpu_channel *chan = platform_get_drvdata(pdev);
 
@@ -527,7 +530,9 @@ static int zrpu_channel_remove(struct platform_device *pdev)
 		zxgq_fini(chan->xgq_hdl);
 	zocl_ert_destroy_intc(chan->intc_pdev);
 	sysfs_remove_group(&pdev->dev.kobj, &zrpu_channel_attrgroup);
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
 	return 0;
+#endif
 };
 
 struct platform_driver zocl_rpu_channel_driver = {

--- a/src/runtime_src/core/edge/drm/zocl/zert/zocl_sk.c
+++ b/src/runtime_src/core/edge/drm/zocl/zert/zocl_sk.c
@@ -73,10 +73,10 @@ zocl_sk_getcmd_ioctl(struct drm_device *dev, void *data, struct drm_file *filp)
 		}
 
 		if (slot_id == MAX_PR_SLOT_NUM) {
-			DRM_ERROR("PS Kernel UUID %lx not found!",cmd->sk_uuid);
+			DRM_ERROR("PS Kernel UUID %s not found!",cmd->sk_uuid);
 			return -EINVAL;
 		} else {
-			DRM_INFO("PS Kernel UUID %lx found at slot %d\n",cmd->sk_uuid, slot_id);
+			DRM_INFO("PS Kernel UUID %s found at slot %d\n",cmd->sk_uuid, slot_id);
 		}
 
 		if (sk->sk_meta_bohdl[slot_id] >= 0) {

--- a/src/runtime_src/core/edge/drm/zocl/zert/zocl_xgq_intc.c
+++ b/src/runtime_src/core/edge/drm/zocl/zert/zocl_xgq_intc.c
@@ -86,13 +86,18 @@ static int zintc_probe(struct platform_device *pdev)
 
 	return 0;
 }
-
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
+static void zintc_remove(struct platform_device *pdev)
+#else
 static int zintc_remove(struct platform_device *pdev)
+#endif
 {
 	struct zocl_irq_intc *zintc = platform_get_drvdata(pdev);
 
 	zintc_info(zintc, "Removing %s", ZINTC_DRV_NAME);
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
 	return 0;
+#endif
 }
 
 /*


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1222615 Added 6.12 kernel support to the zocl. In 6.12 kernel remove funciton pointer is changed from to void ([Reference](https://lxr.bootlin.com/linux/v6.12.4/source/include/linux/platform_device.h#L236)). Fixed compiler warnings.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
changed the function type by adding #if #endif directives.
#### Risks (if any) associated the changes in the commit
low
#### What has been tested and how, request additional testing if necessary
Tested by building with both 6.6 and 6.12 kernels
#### Documentation impact (if any)
