### PR TITLE
There are many compile warning which enabled by linux newer kernel build with -Werror

### DIFF
--- a/src/runtime_src/core/common/drv/xrt_cu.c
+++ b/src/runtime_src/core/common/drv/xrt_cu.c
@@ -555,7 +555,7 @@ int xrt_cu_process_queues(struct xrt_cu *xcu)
 	return XCU_IDLE;
 }
 
-int xrt_cu_intr_thread(void *data)
+static int xrt_cu_intr_thread(void *data)
 {
 	struct xrt_cu *xcu = (struct xrt_cu *)data;
 	int ret = 0;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libxdma.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libxdma.c
@@ -2265,7 +2265,7 @@ fail:
  */
 
 #ifndef arch_msi_check_device
-int arch_msi_check_device(struct pci_dev *dev, int nvec, int type)
+static int arch_msi_check_device(struct pci_dev *dev, int nvec, int type)
 {
 	return 0;
 }
@@ -4311,7 +4311,8 @@ int xdma_get_bypassio(void *dev_hndl, u64 *len, u32 *bar_idx)
 	return (0);
 }
 
-struct scatterlist *sglist_index(struct sg_table *sgt, unsigned int idx)
+/*
+static struct scatterlist *sglist_index(struct sg_table *sgt, unsigned int idx)
 {
 	struct scatterlist *sg = sgt->sgl;
 	int i;
@@ -4327,6 +4328,7 @@ struct scatterlist *sglist_index(struct sg_table *sgt, unsigned int idx)
 
 	return sg;
 }
+*/
 
 /* ********************* static function definitions ************************ */
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/Makefile
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/Makefile
@@ -54,7 +54,6 @@ xclmgmt-y := \
 	../subdev/ps.o \
 	../subdev/firewall.o \
 	../subdev/xvc.o \
-	../subdev/nifd.o \
 	../subdev/xiic.o \
 	../subdev/mailbox.o \
 	../subdev/icap.o \
@@ -81,6 +80,7 @@ xclmgmt-y := \
 	../subdev/version_ctrl.o \
 	../subdev/pcie_firewall.o \
 	../subdev/hwmon_sdm.o \
+	../subdev/nifd.o \
 	$(drv_common-y) \
 	mgmt-core.o \
 	mgmt-cw.o \

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
@@ -422,7 +422,8 @@ static int destroy_sg_char(struct xclmgmt_char *lro_char)
 	return 0;
 }
 
-struct pci_dev *find_user_node(const struct pci_dev *pdev)
+#if 0
+static struct pci_dev *find_user_node(const struct pci_dev *pdev)
 {
 	struct xclmgmt_dev *lro;
 	unsigned int slot = PCI_SLOT(pdev->devfn);
@@ -448,6 +449,7 @@ struct pci_dev *find_user_node(const struct pci_dev *pdev)
 
 	return user_dev;
 }
+#endif
 
 inline void check_temp_within_range(struct xclmgmt_dev *lro, u32 temp)
 {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/accel_deadlock_detector.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/accel_deadlock_detector.c
@@ -165,7 +165,7 @@ static int accel_deadlock_detector_close(struct inode *inode, struct file *file)
     return 0;
 }
 
-long accel_deadlock_detector_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
+static long accel_deadlock_detector_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
 {
     struct xocl_accel_deadlock_detector *accel_deadlock_detector = NULL;
     void __user *data = NULL;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/aim.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/aim.c
@@ -341,7 +341,7 @@ static int aim_close(struct inode *inode, struct file *file)
 	return 0;
 }
 
-long aim_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
+static long aim_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
 {
 	struct xocl_aim *aim;
 	void __user *data;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/am.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/am.c
@@ -327,7 +327,7 @@ static int am_close(struct inode *inode, struct file *file)
 	return 0;
 }
 
-long am_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
+static long am_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
 {
 	struct xocl_am *am;
 	void __user *data;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/asm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/asm.c
@@ -267,7 +267,7 @@ static int asm_close(struct inode *inode, struct file *file)
 	return 0;
 }
 
-long asm_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
+static long asm_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
 {
 	struct xocl_asm *xocl_asm;
 	void __user *data;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/cu.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/cu.c
@@ -295,7 +295,7 @@ static const struct attribute_group cu_attrgroup = {
 	.bin_attrs = cu_bin_attrs,
 };
 
-irqreturn_t cu_isr(int irq, void *arg)
+static irqreturn_t cu_isr(int irq, void *arg)
 {
 	struct xocl_cu *xcu = arg;
 
@@ -307,7 +307,7 @@ irqreturn_t cu_isr(int irq, void *arg)
 	return IRQ_HANDLED;
 }
 
-irqreturn_t ucu_isr(int irq, void *arg)
+static irqreturn_t ucu_isr(int irq, void *arg)
 {
 	struct xocl_cu *xcu = arg;
 	xdev_handle_t xdev = xocl_get_xdev(xcu->pdev);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_user.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_user.c
@@ -1263,7 +1263,7 @@ done:
 	mutex_unlock(&ert_user->ev_lock);
 }
 
-int ert_user_thread(void *data)
+static int ert_user_thread(void *data)
 {
 	struct xocl_ert_user *ert_user = (struct xocl_ert_user *)data;
 	int ret = 0;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/intc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/intc.c
@@ -250,7 +250,7 @@ static void intc_polling(struct intr_metadata *data, int max_try)
 /**
  * intc_isr()
  */
-irqreturn_t intc_isr(int irq, void *arg)
+static irqreturn_t intc_isr(int irq, void *arg)
 {
 	struct intr_metadata *data = arg;
 	u32 pending;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/lapc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/lapc.c
@@ -190,7 +190,7 @@ static int lapc_close(struct inode *inode, struct file *file)
 	return 0;
 }
 
-long lapc_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
+static long lapc_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
 {
 	struct xocl_lapc *lapc;
 	long result = 0;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mailbox.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mailbox.c
@@ -627,7 +627,7 @@ static void mailbox_dbg_collect(struct mailbox *mbx, int rec_type)
 	rec->mir_rx_poll_cnt = mbx->mbx_rx.polling_count;
 }
 
-irqreturn_t mailbox_isr(int irq, void *arg)
+static irqreturn_t mailbox_isr(int irq, void *arg)
 {
 	struct mailbox *mbx = (struct mailbox *)arg;
 	u32 is = mailbox_reg_rd(mbx, &mbx->mbx_regs->mbr_is);
@@ -768,7 +768,7 @@ static void cleanup_sw_ch(struct mailbox_channel *ch)
 }
 
 
-void timeout_msg(struct mailbox_channel *ch)
+static void timeout_msg(struct mailbox_channel *ch)
 {
 	struct mailbox *mbx = ch->mbc_parent;
 	struct mailbox_msg *msg = NULL;
@@ -2439,7 +2439,7 @@ int mailbox_post_notify(struct platform_device *pdev, void *buf, size_t len)
 /*
  * Response will be always posted, no waiting.
  */
-int mailbox_post_response(struct platform_device *pdev,
+static int mailbox_post_response(struct platform_device *pdev,
 	enum xcl_mailbox_request req, u64 reqid, void *buf, size_t len)
 {
 	int rv = 0;
@@ -2558,7 +2558,7 @@ static void mailbox_recv_request(struct work_struct *work)
 	mutex_unlock(&mbx->mbx_lock);
 }
 
-int mailbox_listen(struct platform_device *pdev,
+static int mailbox_listen(struct platform_device *pdev,
 	mailbox_msg_cb_t cb, void *cbarg)
 {
 	struct mailbox *mbx = platform_get_drvdata(pdev);
@@ -2702,7 +2702,7 @@ int mailbox_get(struct platform_device *pdev, enum mb_kind kind, u64 *data)
 }
 
 
-int mailbox_set(struct platform_device *pdev, enum mb_kind kind, u64 data)
+static int mailbox_set(struct platform_device *pdev, enum mb_kind kind, u64 data)
 {
 	struct mailbox *mbx = platform_get_drvdata(pdev);
 	int ret = 0;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mailbox_versal.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mailbox_versal.c
@@ -141,7 +141,7 @@ static void mailbox_versal_handle_pending(struct mailbox_versal *mbv)
 		mbv->mbv_irq_handler(mbv->mbv_irq_arg);
 }
 
-irqreturn_t mailbox_versal_isr(int irq, void *arg)
+static irqreturn_t mailbox_versal_isr(int irq, void *arg)
 {
 	struct mailbox_versal *mbv = (struct mailbox_versal *)arg;
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/spc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/spc.c
@@ -171,7 +171,7 @@ static int spc_close(struct inode *inode, struct file *file)
 	return 0;
 }
 
-long spc_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
+static long spc_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
 {
 	struct xocl_spc *spc;
 	long result = 0;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/sysmon.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/sysmon.c
@@ -58,7 +58,7 @@ struct xocl_sysmon {
  * Also, sysmon register will have all F's once mgmtpf bar goes offline
  * during card shutdown sequence, so ignoring all F's.
  */
-int32_t SYSMON_TO_MILLDEGREE(u32 val)
+static int32_t SYSMON_TO_MILLDEGREE(u32 val)
 {
 	if (val == 0xFFFFFFFF)
 		return 0;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/trace_fifo_full.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/trace_fifo_full.c
@@ -77,7 +77,7 @@ static int trace_fifo_full_close(struct inode *inode, struct file *file)
 	return 0;
 }
 
-long trace_fifo_full_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
+static long trace_fifo_full_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
 {
 	struct trace_fifo_full *trace_fifo_full;
 	long result = 0;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/trace_fifo_lite.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/trace_fifo_lite.c
@@ -146,7 +146,7 @@ static int trace_fifo_lite_close(struct inode *inode, struct file *file)
 	return 0;
 }
 
-long trace_fifo_lite_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
+static long trace_fifo_lite_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
 {
 	struct trace_fifo_lite *trace_fifo_lite;
 	void __user *data;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/trace_funnel.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/trace_funnel.c
@@ -149,7 +149,7 @@ static int trace_funnel_close(struct inode *inode, struct file *file)
 	return 0;
 }
 
-long trace_funnel_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
+static long trace_funnel_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
 {
 	struct trace_funnel *trace_funnel;
 	void __user *data;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/trace_s2mm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/trace_s2mm.c
@@ -208,7 +208,7 @@ static int trace_s2mm_close(struct inode *inode, struct file *file)
 	return 0;
 }
 
-long trace_s2mm_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
+static long trace_s2mm_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
 {
 	struct xocl_trace_s2mm *trace_s2mm;
 	void __user *data;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq_vmr.c
@@ -228,7 +228,7 @@ static void cmd_complete(struct xocl_xgq_vmr *xgq, struct xgq_com_queue_entry *c
 /*
  * Read completed cmd based on XGQ protocol.
  */
-void read_completion(struct xgq_com_queue_entry *ccmd, u64 addr)
+static void read_completion(struct xgq_com_queue_entry *ccmd, u64 addr)
 {
 	u32 i = 0;
 	u32 *buffer = (u32 *)ccmd;
@@ -467,7 +467,7 @@ static struct opcode_name {
 	{"PROGRAM VMR", XGQ_CMD_OP_PROGRAM_VMR},
 };
 
-const char *get_opcode_name(int opcode)
+static const char *get_opcode_name(int opcode)
 {
 	int i = 0;
 	const char *unknown = "UNKNOWN";
@@ -709,7 +709,7 @@ static enum xgq_cmd_opcode opcode[] = {
 	XGQ_CMD_OP_IDENTIFY,
 };
 
-bool vmr_xgq_basic_op(struct xocl_xgq_vmr_cmd *cmd)
+static bool vmr_xgq_basic_op(struct xocl_xgq_vmr_cmd *cmd)
 {
 	int i = 0;
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
@@ -73,7 +73,7 @@ static size_t xocl_bo_physical_addr(const struct drm_xocl_bo *xobj)
 	return paddr;
 }
 
-void xocl_describe(const struct drm_xocl_bo *xobj)
+static void xocl_describe(const struct drm_xocl_bo *xobj)
 {
 	size_t size_kb = xobj->base.size / 1024;
 	size_t physical_addr = xocl_bo_physical_addr(xobj);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
@@ -852,7 +852,7 @@ int xocl_mm_insert_node(struct xocl_drm *drm_p, unsigned memidx,
         return ret;
 }
 
-int xocl_check_slot_topology(struct xocl_drm *drm_p, uint32_t slot_id)
+static int xocl_check_slot_topology(struct xocl_drm *drm_p, uint32_t slot_id)
 {
 	struct xocl_mem_stat *curr_mem = NULL;
 	int err = 0;
@@ -920,7 +920,7 @@ done:
 	return 0;
 }
 
-int xocl_set_cma_bank(struct xocl_drm *drm_p, uint64_t base_addr, size_t ddr_bank_size)
+static int xocl_set_cma_bank(struct xocl_drm *drm_p, uint64_t base_addr, size_t ddr_bank_size)
 {
 	int ret = 0;
 	uint64_t *phys_addrs = 0;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
@@ -274,7 +274,7 @@ void xocl_reset_notify(struct pci_dev *pdev, bool prepare)
 	xdev->reset_ert_cus = true;
 }
 
-int xocl_program_shell(struct xocl_dev *xdev, bool force)
+static int xocl_program_shell(struct xocl_dev *xdev, bool force)
 {
 	int ret = 0, mbret = 0;
 	struct xcl_mailbox_req mbreq = { 0 };
@@ -761,7 +761,7 @@ static void xocl_mailbox_srv(void *arg, void *data, size_t len,
 	}
 }
 
-void store_pcie_link_info(struct xocl_dev *xdev)
+static void store_pcie_link_info(struct xocl_dev *xdev)
 {
 	u16 stat = 0;
 	long result;
@@ -1195,7 +1195,7 @@ static void xocl_cleanup_axlf_obj(struct xocl_dev *xdev)
 	mutex_unlock(&xdev->dev_lock);
 }
 
-void xocl_userpf_remove(struct pci_dev *pdev)
+static void xocl_userpf_remove(struct pci_dev *pdev)
 {
 	struct xocl_dev		*xdev;
 	void *hdl;
@@ -1691,7 +1691,7 @@ unlock:
 	return err;
 }
 
-int xocl_userpf_probe(struct pci_dev *pdev,
+static int xocl_userpf_probe(struct pci_dev *pdev,
 		const struct pci_device_id *ent)
 {
 	struct xocl_dev			*xdev;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
@@ -208,7 +208,7 @@ int xocl_user_intr_ioctl(struct drm_device *dev, void *data,
 	return ret;
 }
 
-char *kind_to_string(enum axlf_section_kind kind)
+static char *kind_to_string(enum axlf_section_kind kind)
 {
 	switch (kind) {
 	case 0:  return "BITSTREAM";
@@ -533,7 +533,7 @@ done:
  * This function also incurs a delay of 10seconds to work around AWS ocl timeout issue.
  * These changes will be removed once the issue is addressed in AWS F2 instance.
  */
-void aws_reset_clock_registers(xdev_handle_t xdev)
+static void aws_reset_clock_registers(xdev_handle_t xdev)
 {
 	struct xocl_dev_core *core = XDEV(xdev);
 	resource_size_t bar0_clk1, bar0_clk2;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -2823,6 +2823,9 @@ void xocl_fini_config_gpio(void);
 int __init xocl_init_xgq(void);
 void xocl_fini_xgq(void);
 
+int __init xocl_init_nifd(void);
+void xocl_fini_nifd(void);
+
 int __init xocl_init_hwmon_sdm(void);
 void xocl_fini_hwmon_sdm(void);
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

The Werror is somehow enabled as default [y] since kernel 6.9. We'd like to clean this up for xrt driver build.
[*] Compile the kernel with warnings as errors

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
fix most of the missing compile warrnings

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
