### PR TITLE
fixing apu package build issue

### DIFF
--- a/src/runtime_src/core/common/drv/xrt_cu.c
+++ b/src/runtime_src/core/common/drv/xrt_cu.c
@@ -555,7 +555,7 @@ int xrt_cu_process_queues(struct xrt_cu *xcu)
 	return XCU_IDLE;
 }
 
-static int xrt_cu_intr_thread(void *data)
+int xrt_cu_intr_thread(void *data)
 {
 	struct xrt_cu *xcu = (struct xrt_cu *)data;
 	int ret = 0;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Somehow bad commit is merged to XRT which is causing apu package build to fail

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
There are two PRs merged which are in this file, somehow , both of them passed APU package build , but after merging both, build is failing.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Fixed the static declaration of function

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Verified the APU package build

#### Documentation impact (if any)
None