### PR TITLE
Adding error notification on all edge devices

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/edge/zocl_aie.c
+++ b/src/runtime_src/core/edge/drm/zocl/edge/zocl_aie.c
@@ -366,11 +366,8 @@ zocl_create_aie(struct drm_zocl_dev *zdev, struct axlf *axlf, char __user *xclbi
 	zdev->aie->uid = req.uid;
 
 	/* Register AIE error call back function. */
-	/* only aie-1 supports error management*/
-	if (hw_gen == 1) {
-		rval = aie_register_error_notification(zdev->aie->aie_dev,
-		zocl_aie_error_cb, zdev);
-	}
+	rval = aie_register_error_notification(zdev->aie->aie_dev,
+					       zocl_aie_error_cb, zdev);
 	mutex_unlock(&zdev->aie_lock);
 
 	zocl_init_aie(zdev);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Adding error notification on all edge devices as this is supported for all edge devices now

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
This issue is there from begining

#### How problem was solved, alternative solutions (if any) and why they were rejected
Removed the aie_gen check in driver

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Verified simple error notify test

#### Documentation impact (if any)
None