### PR TITLE
Update petalinux version to v2025.1_12141504

### DIFF
--- a/build/petalinux.build
+++ b/build/petalinux.build
@@ -1,3 +1,3 @@
 # When updating Petalinux build please file a SH ticket to retain the build
 # https://jira.xilinx.com/secure/CreateIssue!default.jspa
-PETALINUX=/proj/petalinux/2024.2/petalinux-v2024.2_11062026/tool/petalinux-v2024.2-final
+PETALINUX=/proj/petalinux/2025.1/petalinux-v2025.1_12141504/tool/petalinux-v2025.1-final

--- a/src/runtime_src/core/edge/ps_kernels/profiling/aie2_trace_config/aie2_trace_config.cpp
+++ b/src/runtime_src/core/edge/ps_kernels/profiling/aie2_trace_config/aie2_trace_config.cpp
@@ -257,7 +257,7 @@ namespace {
                           xdp::built_in::TraceOutputConfiguration* tilecfg, xdp::built_in::MessageConfiguration* msgcfg,
                           std::vector<XAie_LocType>& traceFlushLocs, std::vector<XAie_LocType>& memTileTraceFlushLocs)
   {
-    xaiefal::Logger::get().setLogLevel(xaiefal::LogLevel::DEBUG);
+    xaiefal::Logger::get().setLogLevel(xaiefal::LogLevel::FAL_DEBUG);
 
     // Keep track of number of events reserved per tile
     int numTileCoreTraceEvents[params->NUM_CORE_TRACE_EVENTS + 1] = {0};

--- a/src/runtime_src/core/edge/ps_kernels/profiling/aie_trace_config/aie_trace_config.cpp
+++ b/src/runtime_src/core/edge/ps_kernels/profiling/aie_trace_config/aie_trace_config.cpp
@@ -239,7 +239,7 @@ namespace {
                           xdp::built_in::TraceOutputConfiguration* tilecfg, xdp::built_in::MessageConfiguration* msgcfg,
                           std::vector<XAie_LocType>& traceFlushLocs)
   {
-    xaiefal::Logger::get().setLogLevel(xaiefal::LogLevel::DEBUG);
+    xaiefal::Logger::get().setLogLevel(xaiefal::LogLevel::FAL_DEBUG);
 
     // Keep track of number of events reserved per tile
     int numTileCoreTraceEvents[params->NUM_CORE_TRACE_EVENTS + 1] = {0};


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
SH tikcet to retain the build: https://jira.xilinx.com/browse/SH-2606. Updated petalinux to latest version - v2025.1_12141504

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
aiefal::logging enums are updated in the latest verison.
 
#### How problem was solved, alternative solutions (if any) and why they were rejected
Added FAL prefix to logging enums

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
tested by building the xrt on both versal and aarch64
#### Documentation impact (if any)
