### PR TITLE
CR-1221398 Remove unknown xocl and xclmgmt from xrt-smi examine

### DIFF
--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -752,6 +752,9 @@ fill_xrt_versions(const boost::property_tree::ptree& pt_xrt,
     const boost::property_tree::ptree& driver = drv.second;
     std::string drv_name = driver.get<std::string>("name", "N/A");
     std::string drv_hash = driver.get<std::string>("hash", "N/A");
+    if ((boost::iequals(drv_name, "xclmgmt") || boost::iequals(drv_name, "xocl")) && (boost::iequals(driver.get<std::string>("version", "N/A"), "unknown"))) {
+      continue; // Do not display unknown Alveo driver info.
+    }
     if (!boost::iequals(drv_hash, "N/A")) {
       output << boost::format("  %-20s : %s, %s\n") % drv_name
           % driver.get<std::string>("version", "N/A") % driver.get<std::string>("hash", "N/A");
@@ -759,8 +762,6 @@ fill_xrt_versions(const boost::property_tree::ptree& pt_xrt,
       std::string drv_version = boost::iequals(drv_name, "N/A") ? drv_name : drv_name.append(" Version");
       output << boost::format("  %-20s : %s\n") % drv_version % driver.get<std::string>("version", "N/A");
     }
-    if (boost::iequals(drv_name, "xclmgmt") && boost::iequals(driver.get<std::string>("version", "N/A"), "unknown"))
-      output << "WARNING: xclmgmt version is unknown. Is xclmgmt driver loaded? Or is MSD/MPD running?" << std::endl;
   }
 
   try {

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -752,9 +752,6 @@ fill_xrt_versions(const boost::property_tree::ptree& pt_xrt,
     const boost::property_tree::ptree& driver = drv.second;
     std::string drv_name = driver.get<std::string>("name", "N/A");
     std::string drv_hash = driver.get<std::string>("hash", "N/A");
-    if ((boost::iequals(drv_name, "xclmgmt") || boost::iequals(drv_name, "xocl")) && (boost::iequals(driver.get<std::string>("version", "N/A"), "unknown"))) {
-      continue; // Do not display unknown Alveo driver info.
-    }
     if (!boost::iequals(drv_hash, "N/A")) {
       output << boost::format("  %-20s : %s, %s\n") % drv_name
           % driver.get<std::string>("version", "N/A") % driver.get<std::string>("hash", "N/A");


### PR DESCRIPTION
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1221398 xocl and xclmgmt showing as unknown in xrt-smi examine on Linux amdxdna
#### How problem was solved, alternative solutions (if any) and why they were rejected
After discussion with others, removed xocl and xclmgmt from ptree and host report if they are not present/unknown. There is more work to be done in re-architecture to separate legacy Alveo code from XRT, but this will cover things on user-facing side for the time being. This also removes the "xclmgmt is unknown" warning.
#### Risks (if any) associated the changes in the commit
N/A
#### What has been tested and how, request additional testing if necessary
Tested on STX Linux machine and Alveo Linux machine (xocl/xclmgmt still show up on the latter machine, as expected).
```
xrt-smi examine
System Configuration
  OS Name              : Linux
  Release              : 6.10.0-rc3-20240612t132459.0dd5d5f
  Machine              : x86_64
  CPU Cores            : 24
  Memory               : 31451 MB
  Distribution         : Ubuntu 22.04 LTS
  GLIBC                : 2.35
  Model                : BIRMANPLUS
  BIOS Vendor          : AMD
  BIOS Version         : TXB0090dB

XRT
  Version              : 2.19.0
  Branch               : HEAD
  Hash                 : 2eeedb2f504b7c6392c1c10a1a1f0c83a87b0e07
  Hash Date            : 2024-12-16 11:28:29
  amdxdna              : 2.19.320_20241213, a87b4f7c1f7bc9a7e15e9be0387b5efc14797ca5
  NPU Firmware Version : 1.0.0.63

Device(s) Present
|BDF             |Name          |
|----------------|--------------|
|[0000:c5:00.1]  |RyzenAI-npu4  |
```
Driver Section of JSON only contains amdxdna driver, as desired.
```
"xrt": {
                "version": "2.19.0",
                "branch": "HEAD",
                "hash": "2eeedb2f504b7c6392c1c10a1a1f0c83a87b0e07",
                "build_date": "2024-12-16 11:28:29",
                "drivers": [
                    {
                        "name": "amdxdna",
                        "version": "2.19.320_20241213",
                        "hash": "a87b4f7c1f7bc9a7e15e9be0387b5efc14797ca5"
                    }
                ]
            },
```
#### Documentation impact (if any)
N/A