### PR TITLE
adding error notification on all edge devices

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/edge/zocl_aie.c
+++ b/src/runtime_src/core/edge/drm/zocl/edge/zocl_aie.c
@@ -558,11 +558,8 @@ zocl_create_aie(struct drm_zocl_slot *slot, struct axlf *axlf, char __user *xclb
 	}
 
 	/* Register AIE error call back function. */
-	/* only aie-1 supports error management*/
-	if (hw_gen == 1) {
-		rval = aie_register_error_notification(slot->aie->aie_dev,
-		zocl_aie_error_cb, slot);
-	}
+	rval = aie_register_error_notification(slot->aie->aie_dev,
+					       zocl_aie_error_cb, slot);
 	mutex_unlock(&slot->aie_lock);
 
 	zocl_init_aie(slot);


### PR DESCRIPTION
Problem solved by the commit
Adding error notification on all AIE class of devices.

Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
This issue is there from begining.

How problem was solved, alternative solutions (if any) and why they were rejected
Removed the hw_gen check from driver

Risks (if any) associated the changes in the commit
None

What has been tested and how, request additional testing if necessary
Verified a simple example with error callback API messages

Documentation impact (if any)
None