### PR TITLE
Addition of query for xrt_smi_configuration.json

### DIFF
--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -55,6 +55,7 @@ enum class key_type
   instance,
   edge_vendor,
   device_class,
+  xrt_smi_config,
   xclbin_name,
   sequence_name,
   elf_name,
@@ -523,6 +524,37 @@ struct edge_vendor : request
   {
     return boost::str(boost::format("0x%x") % val);
   }
+};
+
+/**
+ * Used to retieve the path to a configuration file required for the 
+ * current device assuming a valid instance "type" is passed. The shim
+ * decides the appropriate path and name to return, absolving XRT of
+ * needing to know where to look.
+ * This structure can be extended to provide other configurations supporting xrt-smi
+ */
+
+struct xrt_smi_config : request 
+{
+  enum class type {
+    options_config
+  };
+
+  static std::string
+  enum_to_str(const type& type)
+  {
+    switch (type) {
+      case type::options_config:
+        return "options_config";
+    }
+    return "unknown";
+  }
+  using result_type = std::string;
+  static const key_type key = key_type::xrt_smi_config;
+  static const char* name() { return "xrt_smi_config"; }
+
+  virtual std::any
+  get(const device*, const std::any& req_type) const override = 0;
 };
 
 /**


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
This change adds a new query object to shim layer for drivers to provide the path for xrt_smi_configuration.json.
This structure can/should be augmented for future jsons we plan to add.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://jira.xilinx.com/browse/VITIS-14245

#### How problem was solved, alternative solutions (if any) and why they were rejected
The problem was solved by adding a new structure to query objects

#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
Tested on Linux xdna

#### Documentation impact (if any)
N/A
