### PR TITLE
[CR-1130483] Replace OpenSSL calls to EVP Digest calls

### DIFF
--- a/src/runtime_src/core/pcie/tools/cloud-daemon/container/container.cpp
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/container/container.cpp
@@ -23,9 +23,8 @@
 #include <iomanip>
 #include <fstream>
 #include <uuid/uuid.h>
-#define OPENSSL_SUPPRESS_DEPRECATED
 #include <openssl/md5.h>
-#undef OPENSSL_SUPPRESS_DEPRECATED
+#include <openssl/evp.h>
 #include "xrt/detail/xclbin.h"
 #include "container.h"
 
@@ -223,10 +222,10 @@ int Container::retrieve_xclbin(const xclBin *&orig, std::vector<char> &real_xclb
 std::string Container::calculate_md5(char *buf, size_t len)
 {
     unsigned char s[16];
-    MD5_CTX context;
-    MD5_Init(&context);
-    MD5_Update(&context, buf, len);
-    MD5_Final(s, &context);
+    EVP_MD_CTX *context = EVP_MD_CTX_new();
+    EVP_DigestInit(context, EVP_md5());
+    EVP_DigestUpdate(context, buf, len);
+    EVP_DigestFinal(context, s, NULL);
 
     std::stringstream md5;
     md5 << std::hex << std::setfill('0');
@@ -235,6 +234,7 @@ std::string Container::calculate_md5(char *buf, size_t len)
         md5 << std::setw(2) << (int)byte;
     }
 
+    EVP_MD_CTX_free(context);    
     return md5.str();
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1130483 OpenSSL apis used for cloud daemons in XRT are deprecated

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
OpenSSL apis used for cloud daemons code in XRT like SHA256_init, MD5_init etc are deprecated

#### How problem was solved, alternative solutions (if any) and why they were rejected
Removed the added macros and modified the calls from OpenSSL to EVP_DIGEST calls.

#### Risks (if any) associated the changes in the commit
low
#### What has been tested and how, request additional testing if necessary
Tested by building and installing XRT on 22.04 host. Ran xbutil examine on u250

#### Documentation impact (if any)
