### PR TITLE
CR-1224774 "xbutil examine -r aie" command does not work for AIE partitions

### DIFF
--- a/src/runtime_src/core/common/info_aie.cpp
+++ b/src/runtime_src/core/common/info_aie.cpp
@@ -707,7 +707,7 @@ is_duplicate_core(const boost::property_tree::ptree& tile_array, boost::property
 void
 populate_buffer_only_cores(const boost::property_tree::ptree& pt,
 			   const boost::property_tree::ptree& core_info, int gr_id,
-			   boost::property_tree::ptree& tile_array)
+			   boost::property_tree::ptree& tile_array, int start_col)
 {
   const boost::property_tree::ptree empty_pt;
 
@@ -719,7 +719,7 @@ populate_buffer_only_cores(const boost::property_tree::ptree& pt,
     auto dma_row_it = g_node.second.get_child("dma_rows", empty_pt).begin();
     for (const auto& node : g_node.second.get_child("dma_columns", empty_pt)) {
       boost::property_tree::ptree tile;
-      tile.put("column", node.second.data());
+      tile.put("column", (std::stoul(node.second.data()) +  start_col));
       tile.put("row", dma_row_it->second.data());
       if (dma_row_it != g_node.second.end())
         dma_row_it++;
@@ -872,7 +872,7 @@ populate_aie_from_metadata(const xrt_core::device* device, boost::property_tree:
       tile_array.push_back({"", tile});
     }
 
-    populate_buffer_only_cores(pt_aie, core_info, gr_id, tile_array);
+    populate_buffer_only_cores(pt_aie, core_info, gr_id, tile_array, start_col);
 
     boost::property_tree::ptree plkernel_array;
     // Get the name of the kernls available for this graph

--- a/src/runtime_src/core/edge/user/device_linux.cpp
+++ b/src/runtime_src/core/edge/user/device_linux.cpp
@@ -15,9 +15,11 @@
 #include "core/edge/user/aie/aie_buffer_object.h"
 #endif
 #include "core/edge/user/aie/profile_object.h"
+#include <filesystem>
 #include <map>
 #include <memory>
 #include <poll.h>
+#include <regex>
 #include <string>
 
 #include <fcntl.h>
@@ -216,14 +218,30 @@ struct aie_core_info_sysfs
   {
     boost::property_tree::ptree ptarray;
     aie_metadata_info aie_meta = get_aie_metadata_info(device);
-    const std::string aiepart = std::to_string(aie_meta.shim_row) + "_" + std::to_string(aie_meta.num_cols);
-    const aie_sys_parser asp(aiepart);
+    auto base_path = "/sys/class/aie/";
+    std::regex pattern(R"(aiepart_(\d+)_(\d+))");
 
-    /* Loop each all aie core tiles and collect core, dma, events, errors, locks status. */
-    for (int i = 0; i < aie_meta.num_cols; ++i)
-      for (int j = 0; j < (aie_meta.num_rows-1); ++j)
-        ptarray.push_back(std::make_pair(std::to_string(i) + "_" + std::to_string(j),
-                          asp.aie_sys_read(i,(j + aie_meta.core_row))));
+    for (const auto& entry : std::filesystem::directory_iterator(base_path)) {
+        if (!entry.is_directory())
+            continue;
+
+        std::string dir_name = entry.path().filename().string();
+        std::smatch matches;
+
+        if (!std::regex_match(dir_name, matches, pattern))
+            continue;
+
+        auto start_col = std::stoi(matches[1].str());
+        auto num_col = std::stoi(matches[2].str());
+        auto aiepart = std::to_string(start_col) + "_" + std::to_string(num_col);
+        const aie_sys_parser asp(aiepart);
+
+        /* Loop each all aie core tiles and collect core, dma, events, errors, locks status. */
+        for (int i = start_col; i < (start_col + num_col); ++i)
+          for (int j = 0; j < (aie_meta.num_rows - 1); ++j)
+            ptarray.push_back(std::make_pair(std::to_string(i) + "_" + std::to_string(j),
+                              asp.aie_sys_read(i,(j + aie_meta.core_row))));
+    }
 
     boost::property_tree::ptree pt;
     pt.add_child("aie_core",ptarray);


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1224774   We are getting a 'node is not present' exception when we run "xrt-smi examine -r aie " command.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
We are trying to read the whole AIE partition array (0_50) even when the directory itself is not present, which is not correct when multiple partitions are created with hw_ctx.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Hardcoded the AIE paritions path and read all the AIE partitions present in that directory, which helps to read all the partitions when multiple AIE xclbins are present.

#### Risks (if any) associated the changes in the commit
low
#### What has been tested and how, request additional testing if necessary
Tested on vck190 with both device specific implementation(which uses whole array) and  hw_ctx (which uses partition of an array) implementation.

#### Documentation impact (if any)
NA
