### PR TITLE
Modified the aie-rt function APIs and updated the datatype of its parameter from u8 to u16

### DIFF
--- a/build/petalinux.build
+++ b/build/petalinux.build
@@ -1,3 +1,3 @@
 # When updating Petalinux build please file a SH ticket to retain the build
 # https://jira.xilinx.com/secure/CreateIssue!default.jspa
-PETALINUX=/proj/petalinux/2025.1/petalinux-v2025.1_12231101/tool/petalinux-v2025.1-final
+PETALINUX=/proj/petalinux/2025.1/petalinux-v2025.1_01061007/tool/petalinux-v2025.1-final

--- a/src/runtime_src/core/edge/ps_kernels/profiling/aie2_profile_config/aie2_profile_config.cpp
+++ b/src/runtime_src/core/edge/ps_kernels/profiling/aie2_profile_config/aie2_profile_config.cpp
@@ -408,10 +408,10 @@ namespace {
           mPerfCounters.push_back(perfCounter);
 
           // Convert enums to physical event IDs for reporting purposes
-          uint8_t tmpStart;
-          uint8_t tmpEnd;
-          XAie_EventLogicalToPhysicalConv(aieDevInst, loc, mod, startEvent, &tmpStart);
-          XAie_EventLogicalToPhysicalConv(aieDevInst, loc, mod, endEvent, &tmpEnd);
+          uint16_t tmpStart;
+          uint16_t tmpEnd;
+          XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, mod, startEvent, &tmpStart);
+          XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, mod, endEvent, &tmpEnd);
           uint16_t phyStartEvent = tmpStart + config.mCounterBases[type];
           uint16_t phyEndEvent = tmpEnd + config.mCounterBases[type];
 

--- a/src/runtime_src/core/edge/ps_kernels/profiling/aie2_trace_config/aie2_trace_config.cpp
+++ b/src/runtime_src/core/edge/ps_kernels/profiling/aie2_trace_config/aie2_trace_config.cpp
@@ -391,13 +391,13 @@ namespace {
           numCoreCounters++;
 
           // Update config file
-          uint8_t phyEvent = 0;
+          uint16_t phyEvent = 0;
           auto& cfg = cfgTile.core_trace_config.pc[idx];
-          XAie_EventLogicalToPhysicalConv(aieDevInst, loc, mod, config.coreCounterStartEvents[i], &phyEvent);
+          XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, mod, config.coreCounterStartEvents[i], &phyEvent);
           cfg.start_event = phyEvent;
-          XAie_EventLogicalToPhysicalConv(aieDevInst, loc, mod, config.coreCounterEndEvents[i], &phyEvent);
+          XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, mod, config.coreCounterEndEvents[i], &phyEvent);
           cfg.stop_event = phyEvent;
-          XAie_EventLogicalToPhysicalConv(aieDevInst, loc, mod, counterEvent, &phyEvent);
+          XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, mod, counterEvent, &phyEvent);
           cfg.reset_event = phyEvent;
           cfg.event_value = config.coreCounterEventValues[i];
         }
@@ -433,13 +433,13 @@ namespace {
           numMemoryCounters++;
 
           // Update config file
-          uint8_t phyEvent = 0;
+          uint16_t phyEvent = 0;
           auto& cfg = cfgTile.memory_trace_config.pc[idx];
-          XAie_EventLogicalToPhysicalConv(aieDevInst, loc, mod, config.memoryCounterStartEvents[i], &phyEvent);
+          XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, mod, config.memoryCounterStartEvents[i], &phyEvent);
           cfg.start_event = phyEvent;
-          XAie_EventLogicalToPhysicalConv(aieDevInst, loc, mod, config.memoryCounterEndEvents[i], &phyEvent);
+          XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, mod, config.memoryCounterEndEvents[i], &phyEvent);
           cfg.stop_event = phyEvent;
-          XAie_EventLogicalToPhysicalConv(aieDevInst, loc, mod, counterEvent, &phyEvent);
+          XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, mod, counterEvent, &phyEvent);
           cfg.reset_event = phyEvent;
           cfg.event_value = config.memoryCounterEventValues[i];
         }
@@ -461,7 +461,7 @@ namespace {
       //
       if (type == xdp::module_type::core) {
         XAie_ModuleType mod = XAIE_CORE_MOD;
-        uint8_t phyEvent = 0;
+        uint16_t phyEvent = 0;
         auto coreTrace = core.traceControl();
 
         // Delay cycles and user control are not compatible with each other
@@ -495,13 +495,13 @@ namespace {
           numCoreTraceEvents++;
 
           // Update config file
-          XAie_EventLogicalToPhysicalConv(aieDevInst, loc, mod, coreEvents[i], &phyEvent);
+          XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, mod, coreEvents[i], &phyEvent);
           cfgTile.core_trace_config.traced_events[slot] = phyEvent;
         }
         // Update config file
-        XAie_EventLogicalToPhysicalConv(aieDevInst, loc, mod, config.coreTraceStartEvent, &phyEvent);
+        XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, mod, config.coreTraceStartEvent, &phyEvent);
         cfgTile.core_trace_config.start_event = phyEvent;
-        XAie_EventLogicalToPhysicalConv(aieDevInst, loc, mod, config.coreTraceEndEvent, &phyEvent);
+        XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, mod, config.coreTraceEndEvent, &phyEvent);
         cfgTile.core_trace_config.stop_event = phyEvent;
 
         coreEvents.clear();
@@ -589,8 +589,8 @@ namespace {
           XAie_ModuleType M;
           TraceE->getRscId(L, M, S);
 
-          uint8_t phyEvent = 0;
-          XAie_EventLogicalToPhysicalConv(aieDevInst, loc, XAIE_CORE_MOD, memoryCrossEvents[i], &phyEvent);
+          uint16_t phyEvent = 0;
+          XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, XAIE_CORE_MOD, memoryCrossEvents[i], &phyEvent);
 
           if (type == xdp::module_type::mem_tile) {
             cfgTile.memory_tile_trace_config.traced_events[S] = phyEvent;
@@ -618,8 +618,8 @@ namespace {
           TraceE->getRscId(L, M, S);
           // Get Physical event
 
-          uint8_t phyEvent = 0;
-          XAie_EventLogicalToPhysicalConv(aieDevInst, loc, XAIE_MEM_MOD, memoryEvents[i], &phyEvent);
+          uint16_t phyEvent = 0;
+          XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, XAIE_MEM_MOD, memoryEvents[i], &phyEvent);
           // cfgTile.memory_trace_config.traced_events[S] = phyEvent;
 
           if (type == xdp::module_type::mem_tile)
@@ -634,14 +634,14 @@ namespace {
           uint32_t bcBit = 0x1;
           auto bcId = memoryTrace->getStartBc();
           coreToMemBcMask |= (bcBit << bcId);
-          uint8_t phyEvent = 0;
+          uint16_t phyEvent = 0;
 
           if (type == xdp::module_type::mem_tile) {
-            XAie_EventLogicalToPhysicalConv(aieDevInst, loc, XAIE_MEM_MOD, traceStartEvent, &phyEvent);
+            XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, XAIE_MEM_MOD, traceStartEvent, &phyEvent);
             cfgTile.memory_tile_trace_config.start_event = phyEvent;
 
           } else {
-            XAie_EventLogicalToPhysicalConv(aieDevInst, loc, XAIE_CORE_MOD, traceStartEvent, &phyEvent);
+            XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, XAIE_CORE_MOD, traceStartEvent, &phyEvent);
             cfgTile.memory_trace_config.start_event = bcIdToEvent(bcId);
             cfgTile.core_trace_config.internal_events_broadcast[bcId] = phyEvent;
           }
@@ -650,10 +650,10 @@ namespace {
           bcId = memoryTrace->getStopBc();
           coreToMemBcMask |= (bcBit << bcId);
           if (type == xdp::module_type::mem_tile) {
-            XAie_EventLogicalToPhysicalConv(aieDevInst, loc, XAIE_MEM_MOD, traceEndEvent, &phyEvent);
+            XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, XAIE_MEM_MOD, traceEndEvent, &phyEvent);
             cfgTile.memory_tile_trace_config.stop_event = bcIdToEvent(bcId);
           } else {
-            XAie_EventLogicalToPhysicalConv(aieDevInst, loc, XAIE_CORE_MOD, traceEndEvent, &phyEvent);
+            XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, XAIE_CORE_MOD, traceEndEvent, &phyEvent);
             cfgTile.memory_trace_config.stop_event = bcIdToEvent(bcId);
             cfgTile.core_trace_config.internal_events_broadcast[bcId] = phyEvent;
 

--- a/src/runtime_src/core/edge/ps_kernels/profiling/aie_profile_config/aie_profile_config.cpp
+++ b/src/runtime_src/core/edge/ps_kernels/profiling/aie_profile_config/aie_profile_config.cpp
@@ -315,10 +315,10 @@ namespace {
           mPerfCounters.push_back(perfCounter);
 
           // Convert enums to physical event IDs for reporting purposes
-          uint8_t tmpStart;
-          uint8_t tmpEnd;
-          XAie_EventLogicalToPhysicalConv(aieDevInst, loc, mod, startEvent, &tmpStart);
-          XAie_EventLogicalToPhysicalConv(aieDevInst, loc, mod,   endEvent, &tmpEnd);
+          uint16_t tmpStart;
+          uint16_t tmpEnd;
+          XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, mod, startEvent, &tmpStart);
+          XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, mod,   endEvent, &tmpEnd);
           uint16_t phyStartEvent = tmpStart + config.mCounterBases[type];
           uint16_t phyEndEvent   = tmpEnd + config.mCounterBases[type];
 

--- a/src/runtime_src/core/edge/ps_kernels/profiling/aie_trace_config/aie_trace_config.cpp
+++ b/src/runtime_src/core/edge/ps_kernels/profiling/aie_trace_config/aie_trace_config.cpp
@@ -343,13 +343,13 @@ namespace {
           numCoreCounters++;
 
           // Update config file
-          uint8_t phyEvent = 0;
+          uint16_t phyEvent = 0;
           auto& cfg = cfgTile.core_trace_config.pc[idx];
-          XAie_EventLogicalToPhysicalConv(aieDevInst, loc, mod, config.coreCounterStartEvents[i], &phyEvent);
+          XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, mod, config.coreCounterStartEvents[i], &phyEvent);
           cfg.start_event = phyEvent;
-          XAie_EventLogicalToPhysicalConv(aieDevInst, loc, mod, config.coreCounterEndEvents[i], &phyEvent);
+          XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, mod, config.coreCounterEndEvents[i], &phyEvent);
           cfg.stop_event = phyEvent;
-          XAie_EventLogicalToPhysicalConv(aieDevInst, loc, mod, counterEvent, &phyEvent);
+          XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, mod, counterEvent, &phyEvent);
           cfg.reset_event = phyEvent;
           cfg.event_value = config.coreCounterEventValues[i];
         }
@@ -386,13 +386,13 @@ namespace {
           numMemoryCounters++;
 
           // Update config file
-          uint8_t phyEvent = 0;
+          uint16_t phyEvent = 0;
           auto& cfg = cfgTile.memory_trace_config.pc[idx];
-          XAie_EventLogicalToPhysicalConv(aieDevInst, loc, mod, config.memoryCounterStartEvents[i], &phyEvent);
+          XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, mod, config.memoryCounterStartEvents[i], &phyEvent);
           cfg.start_event = phyEvent;
-          XAie_EventLogicalToPhysicalConv(aieDevInst, loc, mod, config.memoryCounterEndEvents[i], &phyEvent);
+          XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, mod, config.memoryCounterEndEvents[i], &phyEvent);
           cfg.stop_event = phyEvent;
-          XAie_EventLogicalToPhysicalConv(aieDevInst, loc, mod, counterEvent, &phyEvent);
+          XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, mod, counterEvent, &phyEvent);
           cfg.reset_event = phyEvent;
           cfg.event_value = config.memoryCounterEventValues[i];
         }
@@ -414,7 +414,7 @@ namespace {
       //
       {
         XAie_ModuleType mod = XAIE_CORE_MOD;
-        uint8_t phyEvent = 0;
+        uint16_t phyEvent = 0;
         auto coreTrace = core.traceControl();
 
         // Delay cycles and user control are not compatible with each other
@@ -449,13 +449,13 @@ namespace {
           numTraceEvents++;
 
           // Update config file
-          XAie_EventLogicalToPhysicalConv(aieDevInst, loc, mod, coreEvents[i], &phyEvent);
+          XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, mod, coreEvents[i], &phyEvent);
           cfgTile.core_trace_config.traced_events[slot] = phyEvent;
         }
         // Update config file
-        XAie_EventLogicalToPhysicalConv(aieDevInst, loc, mod, config.coreTraceStartEvent, &phyEvent);
+        XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, mod, config.coreTraceStartEvent, &phyEvent);
         cfgTile.core_trace_config.start_event = phyEvent;
-        XAie_EventLogicalToPhysicalConv(aieDevInst, loc, mod, config.coreTraceEndEvent, &phyEvent);
+        XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, mod, config.coreTraceEndEvent, &phyEvent);
         cfgTile.core_trace_config.stop_event = phyEvent;
 
         coreEvents.clear();
@@ -517,8 +517,8 @@ namespace {
           TraceE->getRscId(L, M, S);
           cfgTile.memory_trace_config.traced_events[S] = bcIdToEvent(bcId);
           auto mod = XAIE_CORE_MOD;
-          uint8_t phyEvent = 0;
-          XAie_EventLogicalToPhysicalConv(aieDevInst, loc, mod, memoryCrossEvents[i], &phyEvent);
+          uint16_t phyEvent = 0;
+          XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, mod, memoryCrossEvents[i], &phyEvent);
           cfgTile.core_trace_config.internal_events_broadcast[bcId] = phyEvent;
         }
 
@@ -540,8 +540,8 @@ namespace {
           TraceE->getRscId(L, M, S);
           // Get Physical event
           auto mod = XAIE_MEM_MOD;
-          uint8_t phyEvent = 0;
-          XAie_EventLogicalToPhysicalConv(aieDevInst, loc, mod, memoryEvents[i], &phyEvent);
+          uint16_t phyEvent = 0;
+          XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, mod, memoryEvents[i], &phyEvent);
           cfgTile.memory_trace_config.traced_events[S] = phyEvent;
         }
 
@@ -552,15 +552,15 @@ namespace {
           auto bcId = memoryTrace->getStartBc();
           coreToMemBcMask |= (bcBit << bcId);
           auto mod = XAIE_CORE_MOD;
-          uint8_t phyEvent = 0;
-          XAie_EventLogicalToPhysicalConv(aieDevInst, loc, mod, config.coreTraceStartEvent, &phyEvent);
+          uint16_t phyEvent = 0;
+          XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, mod, config.coreTraceStartEvent, &phyEvent);
           cfgTile.memory_trace_config.start_event = bcIdToEvent(bcId);
           cfgTile.core_trace_config.internal_events_broadcast[bcId] = phyEvent;
 
           bcBit = 0x1;
           bcId = memoryTrace->getStopBc();
           coreToMemBcMask |= (bcBit << bcId);
-          XAie_EventLogicalToPhysicalConv(aieDevInst, loc, mod, config.coreTraceEndEvent, &phyEvent);
+          XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, mod, config.coreTraceEndEvent, &phyEvent);
           cfgTile.memory_trace_config.stop_event = bcIdToEvent(bcId);
           cfgTile.core_trace_config.internal_events_broadcast[bcId] = phyEvent;
         }

--- a/src/runtime_src/core/edge/ps_kernels/profiling/aie_trace_gmio/gmio_config_kernel.cpp
+++ b/src/runtime_src/core/edge/ps_kernels/profiling/aie_trace_gmio/gmio_config_kernel.cpp
@@ -92,12 +92,12 @@ namespace {
       XAie_DmaEnableBd(&(gmioDMAInsts[i].shimDmaInst));
 
       // For trace, use bd# 0 for S2MM0, use bd# 4 for S2MM1
-      int bdNum = channelNumber * 4;
+      uint16_t bdNum = channelNumber * 4;
 
       // Write to shim DMA BD AxiMM registers
-      XAie_DmaWriteBd(aieDevInst, &(gmioDMAInsts[i].shimDmaInst), gmioDMAInsts[i].gmioTileLoc, bdNum);
+      XAie_DmaWriteBd_16(aieDevInst, &(gmioDMAInsts[i].shimDmaInst), gmioDMAInsts[i].gmioTileLoc, bdNum);
       // Enqueue BD
-      XAie_DmaChannelPushBdToQueue(aieDevInst, gmioDMAInsts[i].gmioTileLoc, channelNumber, dir, bdNum);
+      XAie_DmaChannelPushBdToQueue_16(aieDevInst, gmioDMAInsts[i].gmioTileLoc, channelNumber, dir, bdNum);
     }
     
     return 0;

--- a/src/runtime_src/core/edge/user/aie/aie.cpp
+++ b/src/runtime_src/core/edge/user/aie/aie.cpp
@@ -231,11 +231,11 @@ sync_external_buffer(std::vector<xrt::bo>& bos, adf::external_buffer_config& con
     int start_bd = -1;
     for (const auto& shim_bd_info : port_config.shim_bd_infos) {
       auto buf_idx = shim_bd_info.buf_idx;
-      dma_api_obj.updateBDAddressLin(&bds[buf_idx].mem_inst, port_config.shim_column, 0, static_cast<uint8_t>(shim_bd_info.bd_id), shim_bd_info.offset * 4);
+      dma_api_obj.updateBDAddressLin(&bds[buf_idx].mem_inst, port_config.shim_column, 0, static_cast<uint16_t>(shim_bd_info.bd_id), shim_bd_info.offset * 4);
       if (start_bd < 0)
         start_bd = shim_bd_info.bd_id;
     }
-    dma_api_obj.enqueueTask(1, port_config.shim_column, 0, port_config.direction, port_config.channel_number, port_config.task_repetition, port_config.enable_task_complete_token, static_cast<uint8_t>(start_bd));
+    dma_api_obj.enqueueTask(1, port_config.shim_column, 0, port_config.direction, port_config.channel_number, port_config.task_repetition, port_config.enable_task_complete_token, static_cast<uint16_t>(start_bd));
   }
 
   for (auto& bd :bds) {

--- a/src/runtime_src/core/edge/user/aie/common_layer/adf_aie_control_api.h
+++ b/src/runtime_src/core/edge/user/aie/common_layer/adf_aie_control_api.h
@@ -89,15 +89,15 @@ public:
     /// Lock acquire value (signed). acq_ge if less than 0. acq_eq if larger than or equal to 0.
     int8_t lock_acq_value = 0;
     /// Lock id to acquire
-    uint8_t lock_acq_id = 0;
+    uint16_t lock_acq_id = 0;
     /// Lock release value (signed). 0: do not release a lock.
     int8_t lock_rel_value = 0;
     /// Lock id to release
-    uint8_t lock_rel_id = 0;
+    uint16_t lock_rel_id = 0;
     /// Continue with next BD
     bool use_next_bd = false;
     /// Next BD ID
-    uint8_t next_bd = 0;
+    uint16_t next_bd = 0;
     /// AXI burst length. Shim tile only. In binary format 00: BLEN = 4 (64B), 01: BLEN = 8 (128B), 10: BLEN = 16 (256B), 11: Undefined
     uint8_t burst_length = 4;
   };
@@ -107,14 +107,14 @@ public:
   /// @param column AIE array column
   /// @param row AIE array row relative to tileType
   /// @param dir 0 (XAie_DmaDirection::DMA_S2MM), 1 (XAie_DmaDirection::DMA_MM2S)
-  err_code configureBdWaitQueueEnqueueTask(int tileType, uint8_t column, uint8_t row, int dir, uint8_t channel, uint32_t repeatCount, bool enableTaskCompleteToken, std::vector<uint8_t> bdIds, std::vector<dma_api::buffer_descriptor> bdParams);
+  err_code configureBdWaitQueueEnqueueTask(int tileType, uint8_t column, uint8_t row, int dir, uint8_t channel, uint32_t repeatCount, bool enableTaskCompleteToken, std::vector<uint16_t> bdIds, std::vector<dma_api::buffer_descriptor> bdParams);
 
-  err_code configureBD(int tileType, uint8_t column, uint8_t row, uint8_t bdId, const dma_api::buffer_descriptor& bdParam);
-  err_code enqueueTask(int tileType, uint8_t column, uint8_t row, int dir, uint8_t channel, uint32_t repeatCount, bool enableTaskCompleteToken, uint8_t startBdId);
+  err_code configureBD(int tileType, uint8_t column, uint8_t row, uint16_t bdId, const dma_api::buffer_descriptor& bdParam);
+  err_code enqueueTask(int tileType, uint8_t column, uint8_t row, int dir, uint8_t channel, uint32_t repeatCount, bool enableTaskCompleteToken, uint16_t startBdId);
   err_code waitDMAChannelTaskQueue(int tileType, uint8_t column, uint8_t row, int dir, uint8_t channel);
   err_code waitDMAChannelDone(int tileType, uint8_t column, uint8_t row, int dir, uint8_t channel);
-  err_code updateBDAddress(int tileType, uint8_t column, uint8_t row, uint8_t bdId, uint64_t address);
-  err_code updateBDAddressLin(XAie_MemInst* memInst , uint8_t column, uint8_t row, uint8_t bdId, uint64_t offset);
+  err_code updateBDAddress(int tileType, uint8_t column, uint8_t row, uint16_t bdId, uint64_t address);
+  err_code updateBDAddressLin(XAie_MemInst* memInst , uint8_t column, uint8_t row, uint16_t bdId, uint64_t offset);
 
   std::shared_ptr<config_manager> get_config()
   {
@@ -134,9 +134,9 @@ public:
   /// @param tileType 0 (adf::tile_type::aie_tile), 1 (adf::tile_type::shim_tile), 2 (adf::tile_type::memory_tile)
   /// @param column AIE array column
   /// @param row AIE array row relative to tileType
-  err_code initializeLock(int tileType, uint8_t column, uint8_t row, unsigned short lockId, int8_t initVal);
-  err_code acquireLock(int tileType, uint8_t column, uint8_t row, unsigned short lockId, int8_t acqVal);
-  err_code releaseLock(int tileType, uint8_t column, uint8_t row, unsigned short lockId, int8_t relVal);
+  err_code initializeLock(int tileType, uint8_t column, uint8_t row, uint16_t lockId, int8_t initVal);
+  err_code acquireLock(int tileType, uint8_t column, uint8_t row, uint16_t lockId, int8_t acqVal);
+  err_code releaseLock(int tileType, uint8_t column, uint8_t row, uint16_t lockId, int8_t relVal);
   std::shared_ptr<config_manager> get_config()
   {
     return config;

--- a/src/runtime_src/core/edge/user/aie/common_layer/adf_api_config.h
+++ b/src/runtime_src/core/edge/user/aie/common_layer/adf_api_config.h
@@ -78,15 +78,15 @@ struct rtp_config
     short selectorColumn;
     short selectorRow;
     size_t selectorAddr;
-    unsigned short selectorLockId;
+    uint16_t selectorLockId;
     short pingColumn;
     short pingRow;
     size_t pingAddr;
-    unsigned short pingLockId;
+    uint16_t pingLockId;
     short pongColumn;
     short pongRow;
     size_t pongAddr;
-    unsigned short pongLockId;
+    uint16_t pongLockId;
     bool blocking;
 };
 

--- a/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.cpp
+++ b/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.cpp
@@ -228,12 +228,12 @@ bool AIETraceOffload::initReadTrace()
       XAie_DmaEnableBd(&(gmioDMAInsts[i].shimDmaInst));
 
       // For trace, use bd# 0 for S2MM0, use bd# 4 for S2MM1
-      int bdNum = channelNumber * 4;
+      uint16_t bdNum = channelNumber * 4;
       // Write to shim DMA BD AxiMM registers
-      XAie_DmaWriteBd(devInst, &(gmioDMAInsts[i].shimDmaInst), gmioDMAInsts[i].gmioTileLoc, bdNum);
+      XAie_DmaWriteBd_16(devInst, &(gmioDMAInsts[i].shimDmaInst), gmioDMAInsts[i].gmioTileLoc, bdNum);
 
       // Enqueue BD
-      XAie_DmaChannelPushBdToQueue(devInst, gmioDMAInsts[i].gmioTileLoc, channelNumber, dir, bdNum);
+      XAie_DmaChannelPushBdToQueue_16(devInst, gmioDMAInsts[i].gmioTileLoc, channelNumber, dir, bdNum);
 
 #endif
     }

--- a/src/runtime_src/xdp/profile/device/aie_trace/client/aie_trace_offload_client.cpp
+++ b/src/runtime_src/xdp/profile/device/aie_trace/client/aie_trace_offload_client.cpp
@@ -123,7 +123,7 @@ namespace xdp {
       XAie_DmaDesc DmaDesc;
       loc = XAie_TileLoc(traceGMIO->shimColumn, 0);
       uint8_t s2mm_ch_id = traceGMIO->channelNumber;
-      uint8_t s2mm_bd_id = 15; /* for now use last bd */
+      uint16_t s2mm_bd_id = 15; /* for now use last bd */
 
       // S2MM BD
       RC = XAie_DmaDescInit(&aieDevInst, &DmaDesc, loc);
@@ -132,10 +132,10 @@ namespace xdp {
                            static_cast<uint32_t>(bufAllocSz));
       RC = XAie_DmaEnableBd(&DmaDesc);
       RC = XAie_DmaSetAxi(&DmaDesc, 0U, 8U, 0U, 0U, 0U);
-      RC = XAie_DmaWriteBd(&aieDevInst, &DmaDesc, loc, s2mm_bd_id);
+      RC = XAie_DmaWriteBd_16(&aieDevInst, &DmaDesc, loc, s2mm_bd_id);
 
       // printf("Enabling channels....\n");
-      RC = XAie_DmaChannelPushBdToQueue(&aieDevInst, loc, s2mm_ch_id, DMA_S2MM,
+      RC = XAie_DmaChannelPushBdToQueue_16(&aieDevInst, loc, s2mm_ch_id, DMA_S2MM,
                                         s2mm_bd_id);
       RC = XAie_DmaChannelEnable(&aieDevInst, loc, s2mm_ch_id, DMA_S2MM);
 

--- a/src/runtime_src/xdp/profile/device/aie_trace/ve2/aie_trace_offload_ve2.cpp
+++ b/src/runtime_src/xdp/profile/device/aie_trace/ve2/aie_trace_offload_ve2.cpp
@@ -215,12 +215,12 @@ bool AIETraceOffload::initReadTrace()
       XAie_DmaEnableBd(&(gmioDMAInsts[i].shimDmaInst));
 
       // For trace, use bd# 0 for S2MM0, use bd# 4 for S2MM1
-      int bdNum = channelNumber * 4;
+      uint16_t bdNum = channelNumber * 4;
       // Write to shim DMA BD AxiMM registers
-      XAie_DmaWriteBd(devInst, &(gmioDMAInsts[i].shimDmaInst), gmioDMAInsts[i].gmioTileLoc, bdNum);
+      XAie_DmaWriteBd_16(devInst, &(gmioDMAInsts[i].shimDmaInst), gmioDMAInsts[i].gmioTileLoc, bdNum);
 
       // Enqueue BD
-      XAie_DmaChannelPushBdToQueue(devInst, gmioDMAInsts[i].gmioTileLoc, channelNumber, dir, bdNum);
+      XAie_DmaChannelPushBdToQueue_16(devInst, gmioDMAInsts[i].gmioTileLoc, channelNumber, dir, bdNum);
     }
   }
   bufferInitialized = true;

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/client/aie_profile.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/client/aie_profile.cpp
@@ -196,8 +196,8 @@ namespace xdp {
           // Convert enums to physical event IDs for reporting purposes
           uint16_t tmpStart;
           uint16_t tmpEnd;
-          XAie_EventLogicalToPhysicalConv(&aieDevInst, loc, mod, startEvent, &tmpStart);
-          XAie_EventLogicalToPhysicalConv(&aieDevInst, loc, mod,   endEvent, &tmpEnd);
+          XAie_EventLogicalToPhysicalConv_16(&aieDevInst, loc, mod, startEvent, &tmpStart);
+          XAie_EventLogicalToPhysicalConv_16(&aieDevInst, loc, mod,   endEvent, &tmpEnd);
           uint16_t phyStartEvent = tmpStart + aie::profile::getCounterBase(type);
           uint16_t phyEndEvent   = tmpEnd   + aie::profile::getCounterBase(type);
           // auto payload = getCounterPayload(tileMetric.first, type, col, row, 

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/edge/aie_profile.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/edge/aie_profile.cpp
@@ -1150,10 +1150,10 @@ namespace xdp {
       return std::make_pair(eventId, eventId);
     }
 
-    uint8_t tmpStart;
-    uint8_t tmpEnd;
-    XAie_EventLogicalToPhysicalConv(aieDevInst, tileLoc, xaieModType, startEvent, &tmpStart);
-    XAie_EventLogicalToPhysicalConv(aieDevInst, tileLoc, xaieModType,   endEvent, &tmpEnd);
+    uint16_t tmpStart;
+    uint16_t tmpEnd;
+    XAie_EventLogicalToPhysicalConv_16(aieDevInst, tileLoc, xaieModType, startEvent, &tmpStart);
+    XAie_EventLogicalToPhysicalConv_16(aieDevInst, tileLoc, xaieModType,   endEvent, &tmpEnd);
     uint16_t phyStartEvent = tmpStart + aie::profile::getCounterBase(xdpModType);
     uint16_t phyEndEvent   = tmpEnd   + aie::profile::getCounterBase(xdpModType);
     return std::make_pair(phyStartEvent, phyEndEvent);

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/ve2/aie_profile.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/ve2/aie_profile.cpp
@@ -1150,10 +1150,10 @@ namespace xdp {
       return std::make_pair(eventId, eventId);
     }
 
-    uint8_t tmpStart;
-    uint8_t tmpEnd;
-    XAie_EventLogicalToPhysicalConv(aieDevInst, tileLoc, xaieModType, startEvent, &tmpStart);
-    XAie_EventLogicalToPhysicalConv(aieDevInst, tileLoc, xaieModType,   endEvent, &tmpEnd);
+    uint16_t tmpStart;
+    uint16_t tmpEnd;
+    XAie_EventLogicalToPhysicalConv_16(aieDevInst, tileLoc, xaieModType, startEvent, &tmpStart);
+    XAie_EventLogicalToPhysicalConv_16(aieDevInst, tileLoc, xaieModType,   endEvent, &tmpEnd);
     uint16_t phyStartEvent = tmpStart + aie::profile::getCounterBase(xdpModType);
     uint16_t phyEndEvent   = tmpEnd   + aie::profile::getCounterBase(xdpModType);
     return std::make_pair(phyStartEvent, phyEndEvent);

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/client/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/client/aie_trace.cpp
@@ -904,7 +904,7 @@ namespace xdp {
         config.combo_event_control[i] = 2;
       for (size_t i=0; i < events.size(); ++i) {
         uint16_t phyEvent = 0;
-        XAie_EventLogicalToPhysicalConv(&aieDevInst, loc, mod, events.at(i), &phyEvent);
+        XAie_EventLogicalToPhysicalConv_16(&aieDevInst, loc, mod, events.at(i), &phyEvent);
         config.combo_event_input[i] = phyEvent;
       }
 
@@ -1252,14 +1252,14 @@ namespace xdp {
           numCoreTraceEvents++;
 
           // Update config file
-          XAie_EventLogicalToPhysicalConv(&aieDevInst, loc, mod, coreEvents[i], &phyEvent);
+          XAie_EventLogicalToPhysicalConv_16(&aieDevInst, loc, mod, coreEvents[i], &phyEvent);
           cfgTile->core_trace_config.traced_events[slot] = phyEvent;
         }
 
         // Update config file
-        XAie_EventLogicalToPhysicalConv(&aieDevInst, loc, mod, coreTraceStartEvent, &phyEvent);
+        XAie_EventLogicalToPhysicalConv_16(&aieDevInst, loc, mod, coreTraceStartEvent, &phyEvent);
         cfgTile->core_trace_config.start_event = phyEvent;
-        XAie_EventLogicalToPhysicalConv(&aieDevInst, loc, mod, coreTraceEndEvent, &phyEvent);
+        XAie_EventLogicalToPhysicalConv_16(&aieDevInst, loc, mod, coreTraceEndEvent, &phyEvent);
         cfgTile->core_trace_config.stop_event = phyEvent;
 
         coreEvents.clear();
@@ -1319,10 +1319,10 @@ namespace xdp {
 
           uint16_t phyEvent = 0;
           if(!m_trace_start_broadcast) {
-            XAie_EventLogicalToPhysicalConv(&aieDevInst, loc, XAIE_CORE_MOD, traceStartEvent, &phyEvent);
+            XAie_EventLogicalToPhysicalConv_16(&aieDevInst, loc, XAIE_CORE_MOD, traceStartEvent, &phyEvent);
             cfgTile->core_trace_config.internal_events_broadcast[8] = phyEvent;
           }
-          XAie_EventLogicalToPhysicalConv(&aieDevInst, loc, XAIE_CORE_MOD, traceEndEvent, &phyEvent);
+          XAie_EventLogicalToPhysicalConv_16(&aieDevInst, loc, XAIE_CORE_MOD, traceEndEvent, &phyEvent);
           cfgTile->core_trace_config.internal_events_broadcast[9] = phyEvent;
 
           // Only enable Core -> MEM. Block everything else in both modules
@@ -1355,8 +1355,8 @@ namespace xdp {
         {
           uint16_t phyEvent1 = 0;
           uint16_t phyEvent2 = 0;
-          XAie_EventLogicalToPhysicalConv(&aieDevInst, loc, mod, traceStartEvent, &phyEvent1);
-          XAie_EventLogicalToPhysicalConv(&aieDevInst, loc, mod, traceEndEvent, &phyEvent2);
+          XAie_EventLogicalToPhysicalConv_16(&aieDevInst, loc, mod, traceStartEvent, &phyEvent1);
+          XAie_EventLogicalToPhysicalConv_16(&aieDevInst, loc, mod, traceEndEvent, &phyEvent2);
           if (type == module_type::core) {
             cfgTile->memory_trace_config.start_event = phyEvent1;
             cfgTile->memory_trace_config.stop_event = phyEvent2;
@@ -1438,7 +1438,7 @@ namespace xdp {
           // Update config file
           uint16_t phyEvent = 0;
           auto phyMod = isCoreEvent ? XAIE_CORE_MOD : XAIE_MEM_MOD;
-          XAie_EventLogicalToPhysicalConv(&aieDevInst, loc, phyMod, memoryEvents[i], &phyEvent);
+          XAie_EventLogicalToPhysicalConv_16(&aieDevInst, loc, phyMod, memoryEvents[i], &phyEvent);
 
           if (isCoreEvent) {
             cfgTile->core_trace_config.internal_events_broadcast[bcId] = phyEvent;
@@ -1536,7 +1536,7 @@ namespace xdp {
           // TraceE->getRscId(L, M, S);
           // Get Physical event
           uint16_t phyEvent = 0;
-          XAie_EventLogicalToPhysicalConv(&aieDevInst, loc, XAIE_PL_MOD, event, &phyEvent);
+          XAie_EventLogicalToPhysicalConv_16(&aieDevInst, loc, XAIE_PL_MOD, event, &phyEvent);
           cfgTile->interface_tile_trace_config.traced_events[i] = phyEvent;
         }
 
@@ -1545,10 +1545,10 @@ namespace xdp {
           // Add interface trace control events
           // Start
           uint16_t phyEvent = 0;
-          XAie_EventLogicalToPhysicalConv(&aieDevInst, loc, XAIE_PL_MOD, interfaceTileTraceStartEvent, &phyEvent);
+          XAie_EventLogicalToPhysicalConv_16(&aieDevInst, loc, XAIE_PL_MOD, interfaceTileTraceStartEvent, &phyEvent);
           cfgTile->interface_tile_trace_config.start_event = phyEvent;
           // Stop
-          XAie_EventLogicalToPhysicalConv(&aieDevInst, loc, XAIE_PL_MOD, interfaceTileTraceEndEvent, &phyEvent);
+          XAie_EventLogicalToPhysicalConv_16(&aieDevInst, loc, XAIE_PL_MOD, interfaceTileTraceEndEvent, &phyEvent);
           cfgTile->interface_tile_trace_config.stop_event = phyEvent;
         }
 

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/edge/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/edge/aie_trace.cpp
@@ -476,13 +476,13 @@ namespace xdp {
           numCoreCounters++;
 
           // Update config file
-          uint8_t phyEvent = 0;
+          uint16_t phyEvent = 0;
           auto& cfg = cfgTile->core_trace_config.pc[idx];
-          XAie_EventLogicalToPhysicalConv(aieDevInst, loc, mod, coreCounterStartEvents[i], &phyEvent);
+          XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, mod, coreCounterStartEvents[i], &phyEvent);
           cfg.start_event = phyEvent;
-          XAie_EventLogicalToPhysicalConv(aieDevInst, loc, mod, coreCounterStartEvents[i], &phyEvent);
+          XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, mod, coreCounterStartEvents[i], &phyEvent);
           cfg.stop_event = phyEvent;
-          XAie_EventLogicalToPhysicalConv(aieDevInst, loc, mod, counterEvent, &phyEvent);
+          XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, mod, counterEvent, &phyEvent);
           cfg.reset_event = phyEvent;
           cfg.event_value = coreCounterEventValues[i];
         }
@@ -525,13 +525,13 @@ namespace xdp {
           numMemoryCounters++;
 
           // Update config file
-          uint8_t phyEvent = 0;
+          uint16_t phyEvent = 0;
           auto& cfg = cfgTile->memory_trace_config.pc[idx];
-          XAie_EventLogicalToPhysicalConv(aieDevInst, loc, mod, memoryCounterStartEvents[i], &phyEvent);
+          XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, mod, memoryCounterStartEvents[i], &phyEvent);
           cfg.start_event = phyEvent;
-          XAie_EventLogicalToPhysicalConv(aieDevInst, loc, mod, memoryCounterEndEvents[i], &phyEvent);
+          XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, mod, memoryCounterEndEvents[i], &phyEvent);
           cfg.stop_event = phyEvent;
-          XAie_EventLogicalToPhysicalConv(aieDevInst, loc, mod, counterEvent, &phyEvent);
+          XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, mod, counterEvent, &phyEvent);
           cfg.reset_event = phyEvent;
           cfg.event_value = memoryCounterEventValues[i];
         }
@@ -563,7 +563,7 @@ namespace xdp {
         }
 
         XAie_ModuleType mod = XAIE_CORE_MOD;
-        uint8_t phyEvent = 0;
+        uint16_t phyEvent = 0;
         auto coreTrace = core.traceControl();
 
         // Delay cycles and user control are not compatible with each other
@@ -607,14 +607,14 @@ namespace xdp {
           numCoreTraceEvents++;
 
           // Update config file
-          XAie_EventLogicalToPhysicalConv(aieDevInst, loc, mod, coreEvents[i], &phyEvent);
+          XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, mod, coreEvents[i], &phyEvent);
           cfgTile->core_trace_config.traced_events[slot] = phyEvent;
         }
 
         // Update config file
-        XAie_EventLogicalToPhysicalConv(aieDevInst, loc, mod, coreTraceStartEvent, &phyEvent);
+        XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, mod, coreTraceStartEvent, &phyEvent);
         cfgTile->core_trace_config.start_event = phyEvent;
-        XAie_EventLogicalToPhysicalConv(aieDevInst, loc, mod, coreTraceEndEvent, &phyEvent);
+        XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, mod, coreTraceEndEvent, &phyEvent);
         cfgTile->core_trace_config.stop_event = phyEvent;
 
         // Record allocated trace events
@@ -728,8 +728,8 @@ namespace xdp {
           TraceE->getRscId(L, M, S);
 
           // Get physical event
-          uint8_t phyEvent = 0;
-          XAie_EventLogicalToPhysicalConv(aieDevInst, loc, mod, memoryEvents[i], &phyEvent);
+          uint16_t phyEvent = 0;
+          XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, mod, memoryEvents[i], &phyEvent);
 
           if (isCoreEvent) {
             auto bcId = TraceE->getBc();
@@ -746,19 +746,19 @@ namespace xdp {
 
         // Add trace control events to config file
         {
-          uint8_t phyEvent = 0;
+          uint16_t phyEvent = 0;
 
           // Start
           if (aie::trace::isCoreModuleEvent(traceStartEvent)) {
             auto bcId = memoryTrace->getStartBc();
             coreToMemBcMask |= (1 << bcId);
 
-            XAie_EventLogicalToPhysicalConv(aieDevInst, loc, XAIE_CORE_MOD, traceStartEvent, &phyEvent);
+            XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, XAIE_CORE_MOD, traceStartEvent, &phyEvent);
             cfgTile->core_trace_config.internal_events_broadcast[bcId] = phyEvent;
             cfgTile->memory_trace_config.start_event = aie::bcIdToEvent(bcId);
           }
           else {
-            XAie_EventLogicalToPhysicalConv(aieDevInst, loc, XAIE_MEM_MOD, traceStartEvent, &phyEvent);
+            XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, XAIE_MEM_MOD, traceStartEvent, &phyEvent);
             if (type == module_type::mem_tile)
               cfgTile->memory_tile_trace_config.start_event = phyEvent;
             else
@@ -770,7 +770,7 @@ namespace xdp {
             auto bcId = memoryTrace->getStopBc();
             coreToMemBcMask |= (1 << bcId);
           
-            XAie_EventLogicalToPhysicalConv(aieDevInst, loc, XAIE_CORE_MOD, traceEndEvent, &phyEvent);
+            XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, XAIE_CORE_MOD, traceEndEvent, &phyEvent);
             cfgTile->core_trace_config.internal_events_broadcast[bcId] = phyEvent;
             cfgTile->memory_trace_config.stop_event = aie::bcIdToEvent(bcId);
 
@@ -781,7 +781,7 @@ namespace xdp {
               cfgTile->core_trace_config.broadcast_mask_west = coreToMemBcMask;
           }
           else {
-            XAie_EventLogicalToPhysicalConv(aieDevInst, loc, XAIE_MEM_MOD, traceEndEvent, &phyEvent);
+            XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, XAIE_MEM_MOD, traceEndEvent, &phyEvent);
             if (type == module_type::mem_tile)
               cfgTile->memory_tile_trace_config.stop_event = phyEvent;
             else
@@ -868,8 +868,8 @@ namespace xdp {
           XAie_ModuleType M;
           TraceE->getRscId(L, M, S);
           // Get Physical event
-          uint8_t phyEvent = 0;
-          XAie_EventLogicalToPhysicalConv(aieDevInst, loc, XAIE_PL_MOD, event, &phyEvent);
+          uint16_t phyEvent = 0;
+          XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, XAIE_PL_MOD, event, &phyEvent);
           cfgTile->interface_tile_trace_config.traced_events[S] = phyEvent;
         }
 
@@ -877,11 +877,11 @@ namespace xdp {
         {
           // Add interface trace control events
           // Start
-          uint8_t phyEvent = 0;
-          XAie_EventLogicalToPhysicalConv(aieDevInst, loc, XAIE_PL_MOD, interfaceTileTraceStartEvent, &phyEvent);
+          uint16_t phyEvent = 0;
+          XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, XAIE_PL_MOD, interfaceTileTraceStartEvent, &phyEvent);
           cfgTile->interface_tile_trace_config.start_event = phyEvent;
           // Stop
-          XAie_EventLogicalToPhysicalConv(aieDevInst, loc, XAIE_PL_MOD, interfaceTileTraceEndEvent, &phyEvent);
+          XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, XAIE_PL_MOD, interfaceTileTraceEndEvent, &phyEvent);
           cfgTile->interface_tile_trace_config.stop_event = phyEvent;
         }
 

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/util/aie_trace_config.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/util/aie_trace_config.cpp
@@ -187,8 +187,8 @@ namespace xdp::aie::trace {
       for (int i=0; i < NUM_COMBO_EVENT_CONTROL; ++i)
         config.combo_event_control[i] = 2;
       for (int i=0; i < events.size(); ++i) {
-        uint8_t phyEvent = 0;
-        XAie_EventLogicalToPhysicalConv(aieDevInst, loc, mod, events.at(i), &phyEvent);
+        uint16_t phyEvent = 0;
+        XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, mod, events.at(i), &phyEvent);
         config.combo_event_input[i] = phyEvent;
       }
 

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/ve2/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/ve2/aie_trace.cpp
@@ -476,13 +476,13 @@ namespace xdp {
           numCoreCounters++;
 
           // Update config file
-          uint8_t phyEvent = 0;
+          uint16_t phyEvent = 0;
           auto& cfg = cfgTile->core_trace_config.pc[idx];
-          XAie_EventLogicalToPhysicalConv(aieDevInst, loc, mod, coreCounterStartEvents[i], &phyEvent);
+          XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, mod, coreCounterStartEvents[i], &phyEvent);
           cfg.start_event = phyEvent;
-          XAie_EventLogicalToPhysicalConv(aieDevInst, loc, mod, coreCounterStartEvents[i], &phyEvent);
+          XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, mod, coreCounterStartEvents[i], &phyEvent);
           cfg.stop_event = phyEvent;
-          XAie_EventLogicalToPhysicalConv(aieDevInst, loc, mod, counterEvent, &phyEvent);
+          XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, mod, counterEvent, &phyEvent);
           cfg.reset_event = phyEvent;
           cfg.event_value = coreCounterEventValues[i];
         }
@@ -525,13 +525,13 @@ namespace xdp {
           numMemoryCounters++;
 
           // Update config file
-          uint8_t phyEvent = 0;
+          uint16_t phyEvent = 0;
           auto& cfg = cfgTile->memory_trace_config.pc[idx];
-          XAie_EventLogicalToPhysicalConv(aieDevInst, loc, mod, memoryCounterStartEvents[i], &phyEvent);
+          XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, mod, memoryCounterStartEvents[i], &phyEvent);
           cfg.start_event = phyEvent;
-          XAie_EventLogicalToPhysicalConv(aieDevInst, loc, mod, memoryCounterEndEvents[i], &phyEvent);
+          XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, mod, memoryCounterEndEvents[i], &phyEvent);
           cfg.stop_event = phyEvent;
-          XAie_EventLogicalToPhysicalConv(aieDevInst, loc, mod, counterEvent, &phyEvent);
+          XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, mod, counterEvent, &phyEvent);
           cfg.reset_event = phyEvent;
           cfg.event_value = memoryCounterEventValues[i];
         }
@@ -563,7 +563,7 @@ namespace xdp {
         }
 
         XAie_ModuleType mod = XAIE_CORE_MOD;
-        uint8_t phyEvent = 0;
+        uint16_t phyEvent = 0;
         auto coreTrace = core.traceControl();
 
         // Delay cycles and user control are not compatible with each other
@@ -607,14 +607,14 @@ namespace xdp {
           numCoreTraceEvents++;
 
           // Update config file
-          XAie_EventLogicalToPhysicalConv(aieDevInst, loc, mod, coreEvents[i], &phyEvent);
+          XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, mod, coreEvents[i], &phyEvent);
           cfgTile->core_trace_config.traced_events[slot] = phyEvent;
         }
 
         // Update config file
-        XAie_EventLogicalToPhysicalConv(aieDevInst, loc, mod, coreTraceStartEvent, &phyEvent);
+        XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, mod, coreTraceStartEvent, &phyEvent);
         cfgTile->core_trace_config.start_event = phyEvent;
-        XAie_EventLogicalToPhysicalConv(aieDevInst, loc, mod, coreTraceEndEvent, &phyEvent);
+        XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, mod, coreTraceEndEvent, &phyEvent);
         cfgTile->core_trace_config.stop_event = phyEvent;
 
         // Record allocated trace events
@@ -728,8 +728,8 @@ namespace xdp {
           TraceE->getRscId(L, M, S);
 
           // Get physical event
-          uint8_t phyEvent = 0;
-          XAie_EventLogicalToPhysicalConv(aieDevInst, loc, mod, memoryEvents[i], &phyEvent);
+          uint16_t phyEvent = 0;
+          XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, mod, memoryEvents[i], &phyEvent);
 
           if (isCoreEvent) {
             auto bcId = TraceE->getBc();
@@ -746,19 +746,19 @@ namespace xdp {
 
         // Add trace control events to config file
         {
-          uint8_t phyEvent = 0;
+          uint16_t phyEvent = 0;
 
           // Start
           if (aie::trace::isCoreModuleEvent(traceStartEvent)) {
             auto bcId = memoryTrace->getStartBc();
             coreToMemBcMask |= (1 << bcId);
 
-            XAie_EventLogicalToPhysicalConv(aieDevInst, loc, XAIE_CORE_MOD, traceStartEvent, &phyEvent);
+            XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, XAIE_CORE_MOD, traceStartEvent, &phyEvent);
             cfgTile->core_trace_config.internal_events_broadcast[bcId] = phyEvent;
             cfgTile->memory_trace_config.start_event = aie::bcIdToEvent(bcId);
           }
           else {
-            XAie_EventLogicalToPhysicalConv(aieDevInst, loc, XAIE_MEM_MOD, traceStartEvent, &phyEvent);
+            XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, XAIE_MEM_MOD, traceStartEvent, &phyEvent);
             if (type == module_type::mem_tile)
               cfgTile->memory_tile_trace_config.start_event = phyEvent;
             else
@@ -770,7 +770,7 @@ namespace xdp {
             auto bcId = memoryTrace->getStopBc();
             coreToMemBcMask |= (1 << bcId);
           
-            XAie_EventLogicalToPhysicalConv(aieDevInst, loc, XAIE_CORE_MOD, traceEndEvent, &phyEvent);
+            XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, XAIE_CORE_MOD, traceEndEvent, &phyEvent);
             cfgTile->core_trace_config.internal_events_broadcast[bcId] = phyEvent;
             cfgTile->memory_trace_config.stop_event = aie::bcIdToEvent(bcId);
 
@@ -781,7 +781,7 @@ namespace xdp {
               cfgTile->core_trace_config.broadcast_mask_west = coreToMemBcMask;
           }
           else {
-            XAie_EventLogicalToPhysicalConv(aieDevInst, loc, XAIE_MEM_MOD, traceEndEvent, &phyEvent);
+            XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, XAIE_MEM_MOD, traceEndEvent, &phyEvent);
             if (type == module_type::mem_tile)
               cfgTile->memory_tile_trace_config.stop_event = phyEvent;
             else
@@ -868,8 +868,8 @@ namespace xdp {
           XAie_ModuleType M;
           TraceE->getRscId(L, M, S);
           // Get Physical event
-          uint8_t phyEvent = 0;
-          XAie_EventLogicalToPhysicalConv(aieDevInst, loc, XAIE_PL_MOD, event, &phyEvent);
+          uint16_t phyEvent = 0;
+          XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, XAIE_PL_MOD, event, &phyEvent);
           cfgTile->interface_tile_trace_config.traced_events[S] = phyEvent;
         }
 
@@ -877,11 +877,11 @@ namespace xdp {
         {
           // Add interface trace control events
           // Start
-          uint8_t phyEvent = 0;
-          XAie_EventLogicalToPhysicalConv(aieDevInst, loc, XAIE_PL_MOD, interfaceTileTraceStartEvent, &phyEvent);
+          uint16_t phyEvent = 0;
+          XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, XAIE_PL_MOD, interfaceTileTraceStartEvent, &phyEvent);
           cfgTile->interface_tile_trace_config.start_event = phyEvent;
           // Stop
-          XAie_EventLogicalToPhysicalConv(aieDevInst, loc, XAIE_PL_MOD, interfaceTileTraceEndEvent, &phyEvent);
+          XAie_EventLogicalToPhysicalConv_16(aieDevInst, loc, XAIE_PL_MOD, interfaceTileTraceEndEvent, &phyEvent);
           cfgTile->interface_tile_trace_config.stop_event = phyEvent;
         }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
[confluence page to modified APIs](https://confluence.amd.com/pages/viewpage.action?spaceKey=~gvaradar&title=aie-rt+API+changes+for+AIG+group+and+aie4+device). A few APIs have been updated in the aie-rt branch. [SH ticket ](https://jira.xilinx.com/browse/SH-2618) to retain the petalinux build.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
No funtionlaity changes.

#### How problem was solved, alternative solutions (if any) and why they were rejected
By modifying the mentioned APIs and its parameter from u8 to u16.

#### Risks (if any) associated the changes in the commit
low.

#### What has been tested and how, request additional testing if necessary
Ran graph test case by building and installing xrt,czocl, aiefal, libaiengine packages on vck190. 

#### Documentation impact (if any)
