### PR TITLE
Explicitly sync debug buffer for ML Timeline on VE2 HW

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_plugin.cpp
@@ -156,13 +156,6 @@ namespace xdp {
     xrt::hw_context hwContext = xrt_core::hw_context_int::create_hw_context_from_implementation(hwCtxImpl);
     std::shared_ptr<xrt_core::device> coreDevice = xrt_core::hw_context_int::get_core_device(hwContext);
 
-    xclDeviceHandle h = coreDevice->get_device_handle();
-    if (nullptr == h) {
-      xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT",
-          "In ML Timeline Plugin for VE2 Device : Devicehandle is NULL");
-      return;
-    } 
-
     uint64_t implId = mMultiImpl.size();
 
     std::string deviceName = "ve2_device" + std::to_string(implId);
@@ -172,7 +165,7 @@ namespace xdp {
 
     mMultiImpl[hwCtxImpl] = std::make_pair(implId, std::make_unique<MLTimelineVE2Impl>(db, mBufSz));
     auto mlImpl = mMultiImpl[hwCtxImpl].second.get();
-    mlImpl->updateDevice(h);
+    mlImpl->updateDevice(hwCtxImpl);
     
   #endif
 

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/ve2/ml_timeline.cpp
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/ve2/ml_timeline.cpp
@@ -75,7 +75,7 @@ namespace xdp {
               "In destructor for ML Timeline Plugin for VE2 Device.");
   }
 
-  void MLTimelineVE2Impl::updateDevice(void* devH)
+  void MLTimelineVE2Impl::updateDevice(void* hwCtxImpl)
   {
     xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT", 
               "In MLTimelineVE2Impl::updateDevice");

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/ve2/ml_timeline.cpp
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/ve2/ml_timeline.cpp
@@ -25,6 +25,8 @@
 
 #include "shim/shim.h"
 
+#include "core/common/api/bo_int.h"
+#include "core/common/api/hw_context_int.h"
 #include "core/common/device.h"
 #include "core/common/message.h"
 
@@ -36,48 +38,28 @@
 
 namespace xdp {
 
-  class VE2ResultBO
+  class ResultBOContainer
   {
-    private:
-      aiarm::shim* mDev;
-      std::unique_ptr<xrt_core::buffer_handle> mBufHandle;
-      uint32_t *mBOptr = nullptr;
-      bool mNoUnmap = false;
-
-      uint32_t* mapAndChk()
-      {
-        mBOptr = reinterpret_cast<uint32_t *>(mBufHandle->map(xrt_core::buffer_handle::map_type::write));
-        if (!mBOptr)
-          throw std::runtime_error("Failed mapping bo of " + std::to_string(size()) + "bytes.");
-        return mBOptr;
-      }
-
     public:
-      VE2ResultBO(aiarm::shim* devHandle, size_t size)
-        : mDev(devHandle)
+      xrt::bo  mBO;
+      ResultBOContainer(void* hwCtxImpl, uint32_t sz)
       {
-        xcl_bo_flags flags {0};
-        flags.flags = XRT_BO_FLAGS_CACHEABLE;
-        flags.access = XRT_BO_ACCESS_LOCAL;
-        flags.dir = XRT_BO_ACCESS_READ_WRITE;
-        flags.use = XRT_BO_USE_DEBUG;
-        mBufHandle  = mDev->xclAllocBO(size, flags.all);
-        mapAndChk();
+        mBO = xrt_core::bo_int::create_debug_bo(
+                xrt_core::hw_context_int::create_hw_context_from_implementation(hwCtxImpl),
+                sz);
       }
+      ~ResultBOContainer() {}
 
-      ~VE2ResultBO()
+      void 
+      syncFromDevice()
       {
-        if (!mNoUnmap)
-          mBufHandle->unmap(mBOptr);
+        mBO.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
       }
-
-      xrt_core::buffer_handle* get() { return mBufHandle.get(); }
-
-      uint32_t *map() { return mBOptr; }
-
-      void set_no_unmap() { mNoUnmap = true; }
-
-      size_t size() { return mBufHandle->get_properties().size; }
+      uint32_t*
+      map()
+      {
+        return mBO.map<uint32_t*>();
+      }
   };
 
   MLTimelineVE2Impl::MLTimelineVE2Impl(VPDatabase*dB, uint32_t sz)
@@ -98,7 +80,7 @@ namespace xdp {
     xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT", 
               "In MLTimelineVE2Impl::updateDevice");
     try {
-      mResultBOHolder = std::make_unique<xdp::VE2ResultBO>(reinterpret_cast<aiarm::shim*>(devH), mBufSz);
+      mResultBOHolder = std::make_unique<xdp::ResultBOContainer>(hwCtxImpl, mBufSz);
       memset(mResultBOHolder->map(), 0, mBufSz);
 
     } catch (std::exception& e) {
@@ -123,9 +105,9 @@ namespace xdp {
       return;
   
     xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT", 
-              "Using Allocated buffer In MLTimelineVE2Impl::finishflushDevice");
+              "Syncing Allocated buffer In MLTimelineVE2Impl::finishflushDevice");
               
-//    mResultBOHolder->syncFromDevice();    
+    mResultBOHolder->syncFromDevice();    
     uint32_t* ptr = mResultBOHolder->map();
       
     boost::property_tree::ptree ptTop;

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/ve2/ml_timeline.h
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/ve2/ml_timeline.h
@@ -22,10 +22,10 @@
 
 namespace xdp {
 
-  class VE2ResultBO;
+  class ResultBOContainer;
   class MLTimelineVE2Impl : public MLTimelineImpl
   {
-    std::unique_ptr<VE2ResultBO> mResultBOHolder;
+    std::unique_ptr<ResultBOContainer> mResultBOHolder;
     public :
       MLTimelineVE2Impl(VPDatabase* dB, uint32_t sz);
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
VE2 HW will need explicit sync from device for debug buffer. Also, xrt::bo,hw_ctx and create_debug_bo now works for VE2

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Unit vadd test on QEMU + AIARM
#### Documentation impact (if any)
