### PR TITLE
VITIS-13807 : Use opencl icd dispatcher instead of ocl icd for embedded flows

### DIFF
--- a/src/runtime_src/xocl/api/icd/ocl_icd_bindings.cpp
+++ b/src/runtime_src/xocl/api/icd/ocl_icd_bindings.cpp
@@ -22,7 +22,7 @@
 // populated, trailing 0s don't matter.
 //static_assert(sizeof(_cl_icd_dispatch)==178*sizeof(void*),"Fix dispatch table");
 
-const _cl_icd_dispatch cl_icd_dispatch = {
+const cl_icd_dispatch cl_icd_dispatch_obj = {
   clGetPlatformIDs,
   clGetPlatformInfo,
   clGetDeviceIDs,
@@ -170,6 +170,11 @@ const _cl_icd_dispatch cl_icd_dispatch = {
   0, //clSetProgramReleaseCallback,
   0, //clSetProgramSpecializationConstant,
 #ifndef _WIN32
+#if (defined (__aarch64__) || defined (__arm__)) && defined (OPENCL_ICD_LOADER)
+  0, //clCreateBufferWithProperties
+  0, //clCreateImageWithProperties
+  0, //clSetContextDestructorCallback
+#else
   0,
   0,
   0,
@@ -202,5 +207,6 @@ const _cl_icd_dispatch cl_icd_dispatch = {
   0,
   0,
   0
+#endif
 #endif
 };

--- a/src/runtime_src/xocl/api/icd/ocl_icd_bindings.h
+++ b/src/runtime_src/xocl/api/icd/ocl_icd_bindings.h
@@ -33,7 +33,7 @@ using cl_icd_dispatch = KHRicdVendorDispatchRec;
 #else
 // All x86 linux distros doesn't have opencl icd dispatcher
 // support so using ocl icd dispatcher for x86 flows.
-# include "ocl_icd.h"
+# include <ocl_icd.h>
 using cl_icd_dispatch = _cl_icd_dispatch;
 #endif
 #endif

--- a/src/runtime_src/xocl/api/icd/ocl_icd_bindings.h
+++ b/src/runtime_src/xocl/api/icd/ocl_icd_bindings.h
@@ -23,10 +23,20 @@
 #ifdef _WIN32
 # define NOMINMAX
 # include "windows/icd_dispatch.h"
-using _cl_icd_dispatch = KHRicdVendorDispatchRec;
+using cl_icd_dispatch = KHRicdVendorDispatchRec;
 #else
-# include <ocl_icd.h>
+#if (defined (__aarch64__) || defined (__arm__)) && defined (OPENCL_ICD_LOADER)
+// In Yocto ocl icd dispatcher is deprecated and
+// opencl icd dispatcher is the recommended one.
+// Using opencl icd dispatcher for embedded flows.
+# include <CL/cl_icd.h>
+#else
+// All x86 linux distros doesn't have opencl icd dispatcher
+// support so using ocl icd dispatcher for x86 flows.
+# include "ocl_icd.h"
+using cl_icd_dispatch = _cl_icd_dispatch;
 #endif
-extern const _cl_icd_dispatch cl_icd_dispatch;
+#endif
+extern const cl_icd_dispatch cl_icd_dispatch_obj;
 
 #endif

--- a/src/runtime_src/xocl/core/object.h
+++ b/src/runtime_src/xocl/core/object.h
@@ -32,13 +32,14 @@ class stream_mem;
 template <typename XOCLTYPE, typename CLTYPE>
 class object
 {
-  const _cl_icd_dispatch* m_dispatch;
+  const cl_icd_dispatch* m_dispatch;
+
 
 public:
   typedef XOCLTYPE xocl_type;
   typedef CLTYPE   cl_type;
 
-  object() : m_dispatch(&cl_icd_dispatch) {}
+  object() : m_dispatch(&cl_icd_dispatch_obj) {}
 };
 
 namespace detail {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Moved to Opencl icd dispatcher from ocl icd dispatcher for embedded platforms as yocto is deprecating the use of ocl icd flows.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Yocto team filed story VITIS-13807

#### How problem was solved, alternative solutions (if any) and why they were rejected
The best fix is to move all the flows to opencl icd way but the problem is all the linux distributions (RHEL, CentOS) doesn't ship packages to support opencl icd flow, so only made changes to embedded flow.
Also this change is made under temporary flag OPENCL_ICD_LOADER so that XRT builds doesn't break till changes in XRT recipe related to opencl icd loader in yocto/petalinux get into TA. This flag will be removed soon.

#### Risks (if any) associated the changes in the commit
Low as both ocl icd and opencl icd are almost similar and the only change is structure cl_icd_dispatch members differ a little which we already dont use (we already fill zeros as those APIs are not supported in our flow).

#### What has been tested and how, request additional testing if necessary
Tested Embedded flows build and OpenCL test cases.
Tested x86 build.

#### Documentation impact (if any)
Most likely no as user doesn't need to understand about the dispatcher we use.