### PR TITLE
CR-1224365 Fix xrt-smi examine alveo platform error

### DIFF
--- a/src/runtime_src/core/tools/common/reports/platform/ReportAlveoPlatform.cpp
+++ b/src/runtime_src/core/tools/common/reports/platform/ReportAlveoPlatform.cpp
@@ -70,7 +70,7 @@ ReportAlveoPlatform::writeReport(const xrt_core::device* /*_pDevice*/,
     if (!pt_config.empty())
       _output << boost::format("  %-23s: %s\n") % "P2P IO space required" % pt_config.get<std::string>("exp_bar"); // Units appended when ptree is created
 
-    const boost::property_tree::ptree& clocks = pt_platform.get_child("clocks", empty_ptree);
+    const boost::property_tree::ptree& clocks = pt_platform.get_child("clocks.clocks", empty_ptree);
     if (!clocks.empty()) {
       _output << std::endl << "Clocks" << std::endl;
       for (const auto& kc : clocks) {


### PR DESCRIPTION
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1224365 On certain alveo cards, `xrt-smi examine -r platform` fails
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Fixed ptree access issue after clocks ptree was changed previously, discovered during regression testing.
#### How problem was solved, alternative solutions (if any) and why they were rejected
Fixed ptree access to properly obtain clock subtree.
#### Risks (if any) associated the changes in the commit
N/A
#### What has been tested and how, request additional testing if necessary
Tested on u55.
```
xrt-smi examine -d e2:00 -r platform
WARNING: Unexpected xocl version (2.19.57) was found. Expected 2.19.0, to match XRT tools.

-------------------------------------------------
[0000:e2:00.1] : xilinx_u55c_gen3x16_xdma_base_3
-------------------------------------------------
Platform
  XSA Name               : xilinx_u55c_gen3x16_xdma_base_3 
  Logic UUID             : 97088961-FEAE-DA91-52A2-1D9DFD63CCEF 
  FPGA Name              :  
  JTAG ID Code           : 0x14b7d093 
  DDR Size               : 0 Bytes
  DDR Count              : 0 
  Mig Calibrated         : true 
  P2P Status             : disabled 
  P2P IO space required  : 32 GB

Clocks
  DATA_CLK (Data)        : 300 MHz
  KERNEL_CLK (Kernel)    : 500 MHz
  hbm_aclk (System)      : 450 MHz

Mac Addresses            : 00:0A:35:0D:F9:F8
                         : 00:0A:35:0D:F9:F9
                         : 00:0A:35:0D:F9:FA
                         : 00:0A:35:0D:F9:FB
                         : 00:0A:35:0D:F9:FC
                         : 00:0A:35:0D:F9:FD
                         : 00:0A:35:0D:F9:FE
                         : 00:0A:35:0D:F9:FF

```
#### Documentation impact (if any)
N/A