### PR TITLE
[XDP] fixed recent compile issue on client

### DIFF
--- a/src/runtime_src/xdp/profile/device/aie_trace/client/aie_trace_offload_client.cpp
+++ b/src/runtime_src/xdp/profile/device/aie_trace/client/aie_trace_offload_client.cpp
@@ -132,10 +132,10 @@ namespace xdp {
                            static_cast<uint32_t>(bufAllocSz));
       RC = XAie_DmaEnableBd(&DmaDesc);
       RC = XAie_DmaSetAxi(&DmaDesc, 0U, 8U, 0U, 0U, 0U);
-      RC = XAie_DmaWriteBd_16(&aieDevInst, &DmaDesc, loc, s2mm_bd_id);
+      RC = XAie_DmaWriteBd(&aieDevInst, &DmaDesc, loc, s2mm_bd_id);
 
       // printf("Enabling channels....\n");
-      RC = XAie_DmaChannelPushBdToQueue_16(&aieDevInst, loc, s2mm_ch_id, DMA_S2MM,
+      RC = XAie_DmaChannelPushBdToQueue(&aieDevInst, loc, s2mm_ch_id, DMA_S2MM,
                                         s2mm_bd_id);
       RC = XAie_DmaChannelEnable(&aieDevInst, loc, s2mm_ch_id, DMA_S2MM);
 

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/client/aie_profile.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/client/aie_profile.cpp
@@ -195,8 +195,8 @@ namespace xdp {
           // Convert enums to physical event IDs for reporting purposes
           uint16_t tmpStart;
           uint16_t tmpEnd;
-          XAie_EventLogicalToPhysicalConv_16(&aieDevInst, loc, mod, startEvent, &tmpStart);
-          XAie_EventLogicalToPhysicalConv_16(&aieDevInst, loc, mod,   endEvent, &tmpEnd);
+          XAie_EventLogicalToPhysicalConv(&aieDevInst, loc, mod, startEvent, &tmpStart);
+          XAie_EventLogicalToPhysicalConv(&aieDevInst, loc, mod,   endEvent, &tmpEnd);
           uint16_t phyStartEvent = tmpStart + aie::profile::getCounterBase(type);
           uint16_t phyEndEvent   = tmpEnd   + aie::profile::getCounterBase(type);
           // auto payload = getCounterPayload(tileMetric.first, type, col, row, 

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/client/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/client/aie_trace.cpp
@@ -767,7 +767,7 @@ namespace xdp {
         config.combo_event_control[i] = 2;
       for (size_t i=0; i < events.size(); ++i) {
         uint16_t phyEvent = 0;
-        XAie_EventLogicalToPhysicalConv_16(&aieDevInst, loc, mod, events.at(i), &phyEvent);
+        XAie_EventLogicalToPhysicalConv(&aieDevInst, loc, mod, events.at(i), &phyEvent);
         config.combo_event_input[i] = phyEvent;
       }
 
@@ -1114,14 +1114,14 @@ namespace xdp {
           numCoreTraceEvents++;
 
           // Update config file
-          XAie_EventLogicalToPhysicalConv_16(&aieDevInst, loc, mod, coreEvents[i], &phyEvent);
+          XAie_EventLogicalToPhysicalConv(&aieDevInst, loc, mod, coreEvents[i], &phyEvent);
           cfgTile->core_trace_config.traced_events[slot] = phyEvent;
         }
 
         // Update config file
-        XAie_EventLogicalToPhysicalConv_16(&aieDevInst, loc, mod, coreTraceStartEvent, &phyEvent);
+        XAie_EventLogicalToPhysicalConv(&aieDevInst, loc, mod, coreTraceStartEvent, &phyEvent);
         cfgTile->core_trace_config.start_event = phyEvent;
-        XAie_EventLogicalToPhysicalConv_16(&aieDevInst, loc, mod, coreTraceEndEvent, &phyEvent);
+        XAie_EventLogicalToPhysicalConv(&aieDevInst, loc, mod, coreTraceEndEvent, &phyEvent);
         cfgTile->core_trace_config.stop_event = phyEvent;
 
         coreEvents.clear();
@@ -1181,10 +1181,10 @@ namespace xdp {
 
           uint16_t phyEvent = 0;
           if(!m_trace_start_broadcast) {
-            XAie_EventLogicalToPhysicalConv_16(&aieDevInst, loc, XAIE_CORE_MOD, traceStartEvent, &phyEvent);
+            XAie_EventLogicalToPhysicalConv(&aieDevInst, loc, XAIE_CORE_MOD, traceStartEvent, &phyEvent);
             cfgTile->core_trace_config.internal_events_broadcast[8] = phyEvent;
           }
-          XAie_EventLogicalToPhysicalConv_16(&aieDevInst, loc, XAIE_CORE_MOD, traceEndEvent, &phyEvent);
+          XAie_EventLogicalToPhysicalConv(&aieDevInst, loc, XAIE_CORE_MOD, traceEndEvent, &phyEvent);
           cfgTile->core_trace_config.internal_events_broadcast[9] = phyEvent;
 
           // Only enable Core -> MEM. Block everything else in both modules
@@ -1217,8 +1217,8 @@ namespace xdp {
         {
           uint16_t phyEvent1 = 0;
           uint16_t phyEvent2 = 0;
-          XAie_EventLogicalToPhysicalConv_16(&aieDevInst, loc, mod, traceStartEvent, &phyEvent1);
-          XAie_EventLogicalToPhysicalConv_16(&aieDevInst, loc, mod, traceEndEvent, &phyEvent2);
+          XAie_EventLogicalToPhysicalConv(&aieDevInst, loc, mod, traceStartEvent, &phyEvent1);
+          XAie_EventLogicalToPhysicalConv(&aieDevInst, loc, mod, traceEndEvent, &phyEvent2);
           if (type == module_type::core) {
             cfgTile->memory_trace_config.start_event = phyEvent1;
             cfgTile->memory_trace_config.stop_event = phyEvent2;
@@ -1300,7 +1300,7 @@ namespace xdp {
           // Update config file
           uint16_t phyEvent = 0;
           auto phyMod = isCoreEvent ? XAIE_CORE_MOD : XAIE_MEM_MOD;
-          XAie_EventLogicalToPhysicalConv_16(&aieDevInst, loc, phyMod, memoryEvents[i], &phyEvent);
+          XAie_EventLogicalToPhysicalConv(&aieDevInst, loc, phyMod, memoryEvents[i], &phyEvent);
 
           if (isCoreEvent) {
             cfgTile->core_trace_config.internal_events_broadcast[bcId] = phyEvent;
@@ -1398,7 +1398,7 @@ namespace xdp {
           // TraceE->getRscId(L, M, S);
           // Get Physical event
           uint16_t phyEvent = 0;
-          XAie_EventLogicalToPhysicalConv_16(&aieDevInst, loc, XAIE_PL_MOD, event, &phyEvent);
+          XAie_EventLogicalToPhysicalConv(&aieDevInst, loc, XAIE_PL_MOD, event, &phyEvent);
           cfgTile->interface_tile_trace_config.traced_events[i] = phyEvent;
         }
 
@@ -1407,10 +1407,10 @@ namespace xdp {
           // Add interface trace control events
           // Start
           uint16_t phyEvent = 0;
-          XAie_EventLogicalToPhysicalConv_16(&aieDevInst, loc, XAIE_PL_MOD, interfaceTileTraceStartEvent, &phyEvent);
+          XAie_EventLogicalToPhysicalConv(&aieDevInst, loc, XAIE_PL_MOD, interfaceTileTraceStartEvent, &phyEvent);
           cfgTile->interface_tile_trace_config.start_event = phyEvent;
           // Stop
-          XAie_EventLogicalToPhysicalConv_16(&aieDevInst, loc, XAIE_PL_MOD, interfaceTileTraceEndEvent, &phyEvent);
+          XAie_EventLogicalToPhysicalConv(&aieDevInst, loc, XAIE_PL_MOD, interfaceTileTraceEndEvent, &phyEvent);
           cfgTile->interface_tile_trace_config.stop_event = phyEvent;
         }
 


### PR DESCRIPTION
#### Problem solved by the commit
Client build broke after PR-8689

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Recent usage of "_16" APIs were not reverted correctly in PR-8689

#### How problem was solved, alternative solutions (if any) and why they were rejected
Revert previous usage of _16 APIs as they are not needed on client

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Client builds

#### Documentation impact (if any)
None