### PR TITLE
Build XDP depending on XRT component being built

### DIFF
--- a/build/build-win22.sh
+++ b/build/build-win22.sh
@@ -95,7 +95,6 @@ while [ $# -gt 0 ]; do
 	-npu)
             shift
 	    npu_build=1
-	    cmake_flags+=" -DXDP_CLIENT_BUILD_CMAKE=yes"
 	    cmake_flags+=" -DXRT_NPU=1"
             ;;
         -j)

--- a/build/build.sh
+++ b/build/build.sh
@@ -172,7 +172,6 @@ while [ $# -gt 0 ]; do
             shift
 	    npu_build=1
 	    noert=1
-	    cmake_flags+=" -DXDP_CLIENT_BUILD_CMAKE=yes"
 	    cmake_flags+=" -DXRT_NPU=1"
             ;;
         -opt)

--- a/src/CMake/embedded_system.cmake
+++ b/src/CMake/embedded_system.cmake
@@ -41,6 +41,9 @@ endif(GIT_FOUND)
 set(LINUX_FLAVOR ${CMAKE_SYSTEM_NAME})
 set(LINUX_KERNEL_VERSION ${CMAKE_SYSTEM_VERSION})
 
+# --- Set up what components of XRT to build ---
+include(CMake/components.cmake)
+
 # --- Boost Libraries ---
 include (CMake/boostUtil.cmake)
 

--- a/src/runtime_src/CMakeLists.txt
+++ b/src/runtime_src/CMakeLists.txt
@@ -76,7 +76,7 @@ else()
     add_compile_options( ${XRT_WARN_OPTS} )
   endif()
 
-  if (XDP_CLIENT_BUILD_CMAKE STREQUAL "yes")
+  if (XRT_NPU)
     set(AIERT_DIR ${CMAKE_CURRENT_BINARY_DIR}/aie-rt/driver/src)
     set(XAIENGINE_BUILD_SHARED OFF)
     xrt_add_subdirectory_disable_install_target(aie-rt/driver/src)

--- a/src/runtime_src/core/common/xdp/CMakeLists.txt
+++ b/src/runtime_src/core/common/xdp/CMakeLists.txt
@@ -9,15 +9,22 @@ target_include_directories(core_common_xdp_profile_objects
   ${XRT_SOURCE_DIR}/runtime_src
   )
 
-if (XDP_CLIENT_BUILD_CMAKE STREQUAL "yes")
+# Compile defintions when building npu, alveo, or legacy xrt
+# components
+if (XRT_NPU)
+  
   target_compile_definitions(core_common_xdp_profile_objects
     PRIVATE 
     XDP_CLIENT_BUILD=1
     )
-
+  
 elseif (XDP_VE2_BUILD_CMAKE STREQUAL "yes")
-    target_compile_definitions(core_common_xdp_profile_objects
-      PRIVATE
-      XDP_VE2_BUILD=1
-      )
+  
+  target_compile_definitions(core_common_xdp_profile_objects
+    PRIVATE
+    XDP_VE2_BUILD=1
+    )
+
 endif()
+  
+

--- a/src/runtime_src/xdp/CMakeLists.txt
+++ b/src/runtime_src/xdp/CMakeLists.txt
@@ -8,7 +8,6 @@
 # of the plugins and subdirectories.  Also, set the install
 # locations for the plugins on Linux and Windows
 # ================================================================
-
 if (NOT WIN32)
 
   include_directories(
@@ -29,13 +28,16 @@ else()
 
 endif()
 
-if (XDP_CLIENT_BUILD_CMAKE STREQUAL "yes")
+# Only include xdp in npu, alveo, or legacy xrt components
+# For npu, set up different flags used conditionally in
+# in subdirectories.
+if (XRT_NPU)
 
- add_compile_options("-DSKIP_IOCTL")
+  set(XDP_CLIENT_BUILD_CMAKE "yes")
+  add_compile_options("-DSKIP_IOCTL")
+  add_subdirectory(profile)
 
- add_subdirectory(profile)
-
-else()
+elseif(XRT_XRT OR XRT_ALVEO)
 
   add_subdirectory(appdebug)
   add_subdirectory(debug)

--- a/src/runtime_src/xdp/CMakeLists.txt
+++ b/src/runtime_src/xdp/CMakeLists.txt
@@ -37,7 +37,7 @@ if (XRT_NPU)
   add_compile_options("-DSKIP_IOCTL")
   add_subdirectory(profile)
 
-elseif(XRT_XRT OR XRT_ALVEO)
+elseif(XRT_ALVEO)
 
   add_subdirectory(appdebug)
   add_subdirectory(debug)


### PR DESCRIPTION
#### Problem solved by the commit
Change how XDP is built in XRT.  Infer XDP build options based on which component is being built.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
XDP is included in the npu and alveo components and the in the legacy xrt component, but it is being built differently depending on the component. XDP is excluded from XRT's base component.

#### How problem was solved, alternative solutions (if any) and why they were rejected
This PR builds on #8691.  It includes XDP in `npu`, `alveo`, and legacy `xrt` components, but excludes XDP from `base`. Compile flags for XDP are based on the component. XDP_CLIENT_BUILD_CMAKE is now an internal  configuration variable for XDP.

There are no visible changes in this PR.  However, anything invoking CMake with XDP_CLIENT_BUILD_CMAKE will be affected and must change to ensure that XRT is building the NPU component by adding `-DXRT_NPU` when invoking CMake.