### PR TITLE
Mark xcu status done in CU XGQ check

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/cu_xgq.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/cu_xgq.c
@@ -58,6 +58,8 @@ static void cu_xgq_check(void *core, struct xcu_status *status, bool force)
 	uint32_t cu_status = CU_AP_IDLE;
 
 	status->num_ready = 1;
+	status->num_done = 1;
+
 	while (!xocl_xgq_check_response(cu_xgq->xgq, cu_xgq->xgq_client_id, &cu_status));
 	status->new_status = (cu_status == KDS_SKCRASHED) ? CU_AP_CRASHED : CU_AP_IDLE;
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Mark xcu status done in CU XGQ check.
This change is made to mark the done status of xcu xgq command to avoid calling down_timeout() on semaphore twice.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
The entry in xgq completion list may not have been added by the time the cu interrupt thread polls and calls down_timout()
on semaphore. If the command done status is not set, the down_timeout() is called twice resulting in CU_TIMER timeout and causing unnecessary delay. 
#### How problem was solved, alternative solutions (if any) and why they were rejected
Mark command status done so that the down_timeout() is called only once.

#### Risks (if any) associated the changes in the commit
None 
#### What has been tested and how, request additional testing if necessary
Ran the filter2d application multiple times and verified the no CU_TIMER delay is encountered.
#### Documentation impact (if any)
None