### PR TITLE
CR-1224549: fixing XRT profiling with hw context

### DIFF
--- a/src/runtime_src/core/edge/user/aie/common_layer/adf_profiling_api.cpp
+++ b/src/runtime_src/core/edge/user/aie/common_layer/adf_profiling_api.cpp
@@ -299,7 +299,7 @@ err_code profiling::profile_start_time_difference_btw_two_streams(XAie_DevInst* 
 
         std::vector< XAie_LocType > vLocs(numBcastShimColumns);
         for (int i = 0; i < numBcastShimColumns; i++)
-            vLocs[i] = XAie_TileLoc(shimColumn1 + i, 0); // Insert in order of broadcast direction: shimColumn1->shimColumn2
+            vLocs[i] = XAie_TileLoc(westShimColumn + i, 0);
 
         //reserve broadcast channel along the shim tiles
         auto pBroadcastRsc = fal_util::s_pXAieDev->broadcast(vLocs, XAIE_PL_MOD, XAIE_PL_MOD);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1224549 
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
XRT profiling issue with hw context. 
#### How problem was solved, alternative solutions (if any) and why they were rejected
For device specific we use the whole aie array as a single partition whereas for hw context specific tests we try to create a partition (based on the design) withing the aie array. And we need to pass the valid shim tile locations to set the broadcast, and these shim tile locations should not go beyond the created partition which was not the case. By making sure we are creating broadcast within the aie array fixes the issue.
#### Risks (if any) associated the changes in the commit
no risks
#### What has been tested and how, request additional testing if necessary
Tested PL+AIE testcase on vck190 with/without profiling and with device and hw context. Also tested with a single xclbin (PL+AIE merged) and with PL xclbin and AIE only xclbin.
<html xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:dt="uuid:C2F41010-65B3-11d1-A29F-00AA00C14882"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=OneNote.File>
<meta name=Generator content="Microsoft OneNote 15">
</head>

<body lang=en-US style='font-family:Calibri;font-size:11.0pt'>
<!--StartFragment-->

<div style='direction:ltr'>


with and without   profiling | with device and   with hw context | with single   xclbin(pl+aie merged) and with two xclbins(pl only xclbin and aie only   xclbin)
-- | -- | --




</div>

<!--EndFragment-->
</body>

</html>

#### Documentation impact (if any)
n/a