### PR TITLE
Fix error when build base component

### DIFF
--- a/src/CMake/components.cmake
+++ b/src/CMake/components.cmake
@@ -72,6 +72,11 @@ if (XRT_BASE)
   set (CMAKE_INSTALL_DEFAULT_COMPONENT_NAME "base")
   set (XRT_BASE_COMPONENT "base")
   set (XRT_BASE_DEV_COMPONENT "base-${XRT_DEV_COMPONENT_SUFFIX}")
+
+  # Tempoary fix for cpackLin conditionally adding dependencies for
+  # legacy XRT when XRT_DEV_COMPONENT equals "xrt".  We don't want the
+  # dependencies in case of base package.
+  set (XRT_DEV_COMPONENT "dummy")
 endif(XRT_BASE)  
 
 # NPU builds one NPU package for both deployment and development

--- a/src/runtime_src/core/pcie/linux/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/linux/CMakeLists.txt
@@ -1,6 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2019-2022 Xilinx, Inc. All rights reserved.
-# Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
+
+# Linux shim is part of the base component.  It is used by both
+# Alveo and NPU components.
+if (NOT XRT_BASE)
+  return()
+endif()
+
 add_subdirectory(plugin/xdp)
 
 add_library(core_pcielinux_objects OBJECT


### PR DESCRIPTION
#### Problem solved by the commit
Amend #8706. Use dummy value or XRT_DEV_COMPONENT when building only base component.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
#### How problem was solved, alternative solutions (if any) and why they were rejected
Tempoary fix for cpackLin conditionally adding dependencies for legacy XRT when XRT_DEV_COMPONENT equals "xrt".  We don't want the dependencies in case of base package so use dummy value to by-pass.

Also, ensure that pcie/linux shim is built only when XRT_BASE is active.  Linux shim is shared between npu and alveo, hence should be in base component only.

