### PR TITLE
VITIS-14240 Driver Version Detection via APIs

### DIFF
--- a/src/runtime_src/core/common/info_platform.cpp
+++ b/src/runtime_src/core/common/info_platform.cpp
@@ -209,6 +209,8 @@ add_status_info(const xrt_core::device* device, ptree_type& pt)
   case xrt_core::query::device_class::type::ryzen:
   {
     add_performance_info(device, pt_status);
+    const auto total_cols = xrt_core::device_query_default<xq::total_cols>(device, 0);
+    pt.add("total_columns", total_cols);
     break;
   }
   }

--- a/src/runtime_src/core/common/info_platform.cpp
+++ b/src/runtime_src/core/common/info_platform.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2021-2022 Xilinx, Inc
-// Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
 #define XRT_CORE_COMMON_SOURCE
 #include "info_platform.h"
 #include "query_requests.h"

--- a/src/runtime_src/core/common/info_platform.cpp
+++ b/src/runtime_src/core/common/info_platform.cpp
@@ -61,6 +61,8 @@ add_static_region_info(const xrt_core::device* device, ptree_type& pt)
   case xrt_core::query::device_class::type::ryzen:
   {
     static_region.add("name", xrt_core::device_query<xq::rom_vbnv>(device));
+    const auto total_cols = xrt_core::device_query_default<xq::total_cols>(device, 0);
+    pt.add("total_columns", total_cols);
     break;
   }
   }
@@ -209,8 +211,6 @@ add_status_info(const xrt_core::device* device, ptree_type& pt)
   case xrt_core::query::device_class::type::ryzen:
   {
     add_performance_info(device, pt_status);
-    const auto total_cols = xrt_core::device_query_default<xq::total_cols>(device, 0);
-    pt.add("total_columns", total_cols);
     break;
   }
   }

--- a/src/runtime_src/core/include/xrt/xrt_device.h
+++ b/src/runtime_src/core/include/xrt/xrt_device.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2020-2022 Xilinx, Inc.  All rights reserved.
-// Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
 #ifndef _XRT_DEVICE_H_
 #define _XRT_DEVICE_H_
 

--- a/src/runtime_src/core/include/xrt/xrt_device.h
+++ b/src/runtime_src/core/include/xrt/xrt_device.h
@@ -40,45 +40,45 @@ namespace info {
  * device.  The type of the device properties is compile time defined
  * with param traits.
  *
- * @var bdf
+ * @var bdf (deprecated)
  *  BDF for device (std::string)
- * @var interface_uuid
+ * @var interface_uuid (deprecated)
  *  Interface UUID when device is programmed with 2RP shell (`xrt::uuid`)
- * @var kdma
+ * @var kdma (deprecated)
  *  Number of KDMA engines (std::uint32_t)
- * @var max_clock_frequency_mhz
+ * @var max_clock_frequency_mhz (deprecated)
  *  Max clock frequency (unsigned long)
- * @var m2m
+ * @var m2m (deprecated)
  *  True if device contains m2m (bool)
- * @var name
+ * @var name (deprecated)
  *  Name (VBNV) of device (std::string)
- * @var nodma
+ * @var nodma (deprecated)
  *  True if device is a NoDMA device (bool)
- * @var offline
+ * @var offline (deprecated)
  *  True if device is offline and in process of being reset (bool)
- * @var electrical
+ * @var electrical (deprecated)
  *  Electrical and power sensors present on the device (std::string)
- * @var thermal
+ * @var thermal (deprecated)
  *  Thermal sensors present on the device (std::string)
- * @var mechanical
+ * @var mechanical (deprecated)
  *  Mechanical sensors on and surrounding the device (std::string)
- * @var memory
+ * @var memory (deprecated)
  *  Memory information present on the device (std::string)
  * @var platform
  *  Platforms flashed on the device (std::string)
- * @var pcie_info
+ * @var pcie_info (deprecated)
  *  Pcie information of the device (std::string)
  * @var host
  *  Host information (std::string)
- * @var aie
+ * @var aie (deprecated)
  *  AIE core information of the device (std::string)
- * @var aie_shim
+ * @var aie_shim (deprecated)
  *  AIE shim information of the device (std::string)
- * @var dynamic_regions
+ * @var dynamic_regions (deprecated)
  *  Information about xclbin on the device (std::string)
- * @var vmr
+ * @var vmr (deprecated)
  *  Information about vmr on the device (std::string)
- * @var aie_mem
+ * @var aie_mem (deprecated)
  *  AIE memory information of the device (std::string)
  */
 enum class device : unsigned int {

--- a/src/runtime_src/core/tools/common/reports/platform/ReportRyzenPlatform.cpp
+++ b/src/runtime_src/core/tools/common/reports/platform/ReportRyzenPlatform.cpp
@@ -51,7 +51,7 @@ ReportRyzenPlatform::writeReport(const xrt_core::device* /*_pDevice*/,
 
     const boost::property_tree::ptree& pt_status = pt_platform.get_child("status");
     _output << boost::format("  %-23s: %s \n") % "Power Mode" % pt_status.get<std::string>("power_mode");
-    _output << boost::format("  %-23s: %s \n") % "Total Columns" % pt_status.get<std::string>("total_columns");
+    _output << boost::format("  %-23s: %s \n") % "Total Columns" % pt_static_region.get<std::string>("total_columns");
 
 
     auto watts = pt_platform.get<std::string>("electrical.power_consumption_watts", "N/A");

--- a/src/runtime_src/core/tools/common/reports/platform/ReportRyzenPlatform.cpp
+++ b/src/runtime_src/core/tools/common/reports/platform/ReportRyzenPlatform.cpp
@@ -51,16 +51,8 @@ ReportRyzenPlatform::writeReport(const xrt_core::device* /*_pDevice*/,
 
     const boost::property_tree::ptree& pt_status = pt_platform.get_child("status");
     _output << boost::format("  %-23s: %s \n") % "Power Mode" % pt_status.get<std::string>("power_mode");
+    _output << boost::format("  %-23s: %s \n") % "Total Columns" % pt_status.get<std::string>("total_columns");
 
-    const boost::property_tree::ptree& clocks = pt_platform.get_child("clocks", empty_ptree);
-    if (!clocks.empty()) {
-      _output << std::endl << "Clocks" << std::endl;
-      for (const auto& kc : clocks) {
-        const boost::property_tree::ptree& pt_clock = kc.second;
-        std::string clock_name_type = pt_clock.get<std::string>("id");
-        _output << boost::format("  %-23s: %3s MHz\n") % clock_name_type % pt_clock.get<std::string>("freq_mhz");
-      }
-    }
 
     auto watts = pt_platform.get<std::string>("electrical.power_consumption_watts", "N/A");
     if (watts != "N/A")

--- a/src/runtime_src/core/tools/common/reports/platform/ReportRyzenPlatform.cpp
+++ b/src/runtime_src/core/tools/common/reports/platform/ReportRyzenPlatform.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
 
 // ------ I N C L U D E   F I L E S -------------------------------------------
 // System - Include Files

--- a/tests/xrt/query/main.cpp
+++ b/tests/xrt/query/main.cpp
@@ -17,7 +17,7 @@ usage()
 {
     std::cout << "usage: %s [options]\n\n";
     std::cout << "  -d <bdf | device_index>\n";
-    std::cout << "  [-j all] # dump all json queries\n";
+    std::cout << "  [-j] # dump all json queries\n";
     std::cout << "  -h\n\n";
     std::cout << "";
 }
@@ -25,7 +25,7 @@ usage()
 static int
 run(int argc, char** argv)
 {
-  if (argc < 3) {
+  if (argc < 2) {
     usage();
     return 1;
   }
@@ -52,7 +52,7 @@ run(int argc, char** argv)
     }
 
     // Switch arguments
-    else if (cur == "-d")
+    if (cur == "-d")
       device_index = arg;
     else
       throw std::runtime_error("Unknown option value " + cur + " " + arg);

--- a/tests/xrt/query/main.cpp
+++ b/tests/xrt/query/main.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2021 Xilinx, Inc. All rights reserved.
-// Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2021-2022 Xilinx, Inc.  All rights reserved.
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
 #include <iostream>
 #include <stdexcept>
 #include <string>
@@ -15,13 +15,11 @@
 static void
 usage()
 {
-    std::cout << "usage: %s [options] -k <bitstream>\n\n";
-    std::cout << "  -k <bitstream>\n";
+    std::cout << "usage: %s [options]\n\n";
     std::cout << "  -d <bdf | device_index>\n";
     std::cout << "  [-j all] # dump all json queries\n";
     std::cout << "  -h\n\n";
     std::cout << "";
-    std::cout << "* Bitstream is required\n";
 }
 
 static int
@@ -32,7 +30,6 @@ run(int argc, char** argv)
     return 1;
   }
 
-  std::string xclbin_fnm;
   std::string device_index = "0";
   bool json_queries = false;
 
@@ -55,49 +52,19 @@ run(int argc, char** argv)
     }
 
     // Switch arguments
-    if (cur == "-k")
-      xclbin_fnm = arg;
     else if (cur == "-d")
       device_index = arg;
     else
       throw std::runtime_error("Unknown option value " + cur + " " + arg);
   }
 
-  if (xclbin_fnm.empty())
-    throw std::runtime_error("No xclbin specified");
-
   auto device = xrt::device(device_index);
-  auto xclbin = xrt::xclbin{xclbin_fnm};
-  auto uuid = device.load_xclbin(xclbin);
-
-  if (uuid != xclbin.get_uuid())
-    throw std::runtime_error("Unexpected uuid error");
-
-  std::cout << "device name:           " << device.get_info<xrt::info::device::name>() << "\n";
-  std::cout << "device bdf:            " << device.get_info<xrt::info::device::bdf>() << "\n";
-  std::cout << "device kdma:           " << device.get_info<xrt::info::device::kdma>() << "\n";
-  std::cout << "device max freq:       " << device.get_info<xrt::info::device::max_clock_frequency_mhz>() << "\n";
-  std::cout << "device m2m:            " << std::boolalpha << device.get_info<xrt::info::device::m2m>() << std::dec << "\n";
-  std::cout << "device nodma:          " << std::boolalpha << device.get_info<xrt::info::device::nodma>() << std::dec << "\n";
-  std::cout << "device interface uuid: " << device.get_info<xrt::info::device::interface_uuid>().to_string() << "\n";
 
   if (json_queries) {
-    std::cout << "device electrical json info ====================================\n";
-    std::cout << device.get_info<xrt::info::device::electrical>();
-    std::cout << "device thermal json info =======================================\n";
-    std::cout << device.get_info<xrt::info::device::thermal>();
-    std::cout << "device mechanical json info ====================================\n";
-    std::cout << device.get_info<xrt::info::device::mechanical>();
-    std::cout << "device memory json info ========================================\n";
-    std::cout << device.get_info<xrt::info::device::memory>();
-    std::cout << "device platform json info ======================================\n";
-    std::cout << device.get_info<xrt::info::device::platform>();
-    std::cout << "device pcie json info ==========================================\n";
-    std::cout << device.get_info<xrt::info::device::pcie_info>();
-    std::cout << "device dynamic regions json info ===============================\n";
-    std::cout << device.get_info<xrt::info::device::dynamic_regions>();
     std::cout << "device host json info ==========================================\n";
     std::cout << device.get_info<xrt::info::device::host>();
+    std::cout << "device platform json info ==========================================\n";
+    std::cout << device.get_info<xrt::info::device::platform>();
   }
 
   // Equality implemented in 2.14


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
[VITIS-13522](https://jira.xilinx.com/browse/VITIS-13522) Add API to query system configuration which is a story under [VITIS-14240](https://jira.xilinx.com/browse/VITIS-14240) Driver Version Detection via APIs

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
This is a requested feature

#### How problem was solved, alternative solutions (if any) and why they were rejected
enhanced the existing API and marked some device properties as deprecated

#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
tested on linux and windows setup

xdna output:
```
$ ./query.exe -j
device host json info ==========================================
{
    "version": "2.19.0",
    "branch": "master",
    "hash": "4e8c32a9e5a2e51a8bdfa672885d213cbad6df5a",
    "build_date": "2025-01-15 11:39:37",
    "drivers": [
        {
            "name": "amdxdna",
            "version": "2.19.0_20250122",
            "hash": "..."
        }
    ]
}
device platform json info ==========================================
{
    "platforms": [
        {
            "static_region": {
                "name": "RyzenAI-npu4", # will be full name on MCDM
                "total_columns": "8"
            },
            "status": {
                "power_mode": "Default"
            },
            "electrical": {
                "power_consumption_watts": "1.234"
            }
        }
    ]
}
PASSED TEST
```

#### Documentation impact (if any)
