### PR TITLE
Minor include tweeks to hip extension

### DIFF
--- a/src/runtime_src/hip/CMakeLists.txt
+++ b/src/runtime_src/hip/CMakeLists.txt
@@ -53,7 +53,7 @@ install(TARGETS xrt_hip
 )
 
 # Release headers
-install (FILES config.h xrt_hip.h
-  DESTINATION ${XRT_INSTALL_INCLUDE_DIR}/hip
+install (FILES xrt_hip.h
+  DESTINATION ${XRT_INSTALL_INCLUDE_DIR}/xrt
   COMPONENT ${XRT_BASE_DEV_COMPONENT}
 )

--- a/src/runtime_src/hip/api/hip_device.cpp
+++ b/src/runtime_src/hip/api/hip_device.cpp
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
-
-#include "core/include/experimental/xrt_system.h"
+// Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
+#include "core/include/xrt/experimental/xrt_system.h"
 
 #include "hip/core/common.h"
 #include "hip/core/device.h"

--- a/src/runtime_src/hip/core/memory.h
+++ b/src/runtime_src/hip/core/memory.h
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2024-2025 Advanced Micro Devices, Inc. All rights reserved.
 #ifndef xrthip_memory_h
 #define xrthip_memory_h
 
 #include "core/common/device.h"
 #include "core/common/unistd.h"
 #include "device.h"
-#include "experimental/xrt_bo.h"
-#include "experimental/xrt_ext.h"
+#include "core/include/xrt/xrt_bo.h"
+#include "core/include/xrt/experimental/xrt_ext.h"
 
 namespace xrt::core::hip
 {

--- a/src/runtime_src/hip/core/memory_pool.h
+++ b/src/runtime_src/hip/core/memory_pool.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2024-2025 Advanced Micro Devices, Inc. All rights reserved.
 #ifndef xrthip_memory_POOL_h
 #define xrthip_memory_POOL_h
 
@@ -9,8 +9,8 @@
 #include <mutex>
 
 #include "core/common/device.h"
-#include "experimental/xrt_bo.h"
-#include "experimental/xrt_ext.h"
+#include "core/include/xrt/xrt_bo.h"
+#include "core/include/xrt/experimental/xrt_ext.h"
 
 #include "device.h"
 #include "memory.h"

--- a/src/runtime_src/hip/core/module.h
+++ b/src/runtime_src/hip/core/module.h
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2024-2025 Advanced Micro Devices, Inc. All rights reserved.
 #ifndef xrthip_module_h
 #define xrthip_module_h
 
 #include "common.h"
 #include "context.h"
-#include "experimental/xrt_ext.h"
-#include "xrt/xrt_hw_context.h"
-#include "xrt/xrt_kernel.h"
+#include "core/include/xrt/experimental/xrt_ext.h"
+#include "core/include/xrt/xrt_hw_context.h"
+#include "core/include/xrt/xrt_kernel.h"
 
 namespace xrt::core::hip {
 

--- a/src/runtime_src/hip/hip_config.cmake
+++ b/src/runtime_src/hip/hip_config.cmake
@@ -12,7 +12,7 @@ else ()
   # HIP SDK installs hip files to C:/Program Files/AMD/ROCm in windows
   # Latest version installed (6.1, 5.7 or whatever available) will be picked
   # Users can set HIP_DIR to location of HIP installation or default path is used
-  set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} $ENV{HIP_DIR} "C:/Program Files/AMD/ROCm/6.1/lib/cmake/hip" "C:/Program Files/AMD/ROCm/5.7/lib/cmake/hip")
+  set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} $ENV{HIP_DIR} "C:/Program Files/AMD/ROCm/6.2/lib/cmake/hip" "C:/Program Files/AMD/ROCm/6.1/lib/cmake/hip" "C:/Program Files/AMD/ROCm/5.7/lib/cmake/hip")
 endif ()
 
 include(hip-config)


### PR DESCRIPTION
#### Problem solved by the commit
Fix include search paths per #8648.
Add conig support for ROCm 6.2
Remove release of unused config.h
