### PR TITLE
[VITIS-14334] Review and cleanup GOPS, EGOPS, FPS, Latency in aie-partitions report

### DIFF
--- a/src/runtime_src/core/tools/common/reports/ReportAiePartitions.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportAiePartitions.cpp
@@ -41,10 +41,10 @@ populate_aie_partition(const xrt_core::device* device)
     pt_entry.put("errors", entry.errors);
 
     xrt_core::query::aie_partition_info::qos_info qos = entry.qos;
-    pt_entry.put("gops", qos.gops);
-    pt_entry.put("egops", qos.egops);
-    pt_entry.put("fps", qos.fps);
-    pt_entry.put("latency", qos.latency);
+    pt_entry.put("gops", qos.gops ? std::to_string(qos.gops) : "N/A");
+    pt_entry.put("egops", qos.egops ? std::to_string(qos.egops) : "N/A");
+    pt_entry.put("fps", qos.fps ? std::to_string(qos.fps) : "N/A");
+    pt_entry.put("latency", qos.latency ? std::to_string(qos.latency) : "N/A");
     pt_entry.put("priority", xrt_core::query::aie_partition_info::parse_priority_status(qos.priority));
 
     partition.first->second.push_back(std::make_pair("", pt_entry));
@@ -142,10 +142,10 @@ writeReport(const xrt_core::device* /*_pDevice*/,
         hw_context.get<std::string>("migrations"),
         std::to_string(hw_context.get<uint64_t>("errors")),
         hw_context.get<std::string>("priority"),
-        std::to_string(hw_context.get<uint64_t>("gops")),
-        std::to_string(hw_context.get<uint64_t>("egops")),
-        std::to_string(hw_context.get<uint64_t>("fps")),
-        std::to_string(hw_context.get<uint64_t>("latency"))
+        hw_context.get<std::string>("gops"),
+        hw_context.get<std::string>("egops"),
+        hw_context.get<std::string>("fps"),
+        hw_context.get<std::string>("latency")
       };
       context_table.addEntry(entry_data);
     }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Solves https://jira.xilinx.com/browse/VITIS-14334 to show appropriate value for GOPS, EGOPS, FPS, and Latency in aie-partition report.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Currently if GOPS, EGOPS, FPS, and Latency are not configured, the air-partition report shows 0, which may confuse users.

#### How problem was solved, alternative solutions (if any) and why they were rejected
QOS values will show up as N/A if not configured.

#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
tested on windows

output of 
xrt-smi examine -r aie-partitions

<img width="522" alt="aie-partition-qos" src="https://github.com/user-attachments/assets/c9f45b88-ac43-462b-a7d4-4d61a63f0d41" />



#### Documentation impact (if any)
