### PR TITLE
[XDP] fixed compile bug in MDM latency calculation

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_profile/util/aie_profile_util.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/util/aie_profile_util.cpp
@@ -761,7 +761,7 @@ namespace xdp::aie::profile {
     //    Read 3 - The sum of each event latency squared
     //    Read 4 - 31:16 Minimum measured latency, 16 bits
     //             15:0  Maximum measured latency, 16 bits
-    std::vector<uint32_t> latencyValues;
+    std::vector<uint64_t> latencyValues;
     for (uint32_t c=0; c < UC_MDM_PCDRR_LATENCY_READS; ++c) {
       uint32_t val;
       XAie_Read32(aieDevInst, tileOffset + UC_MDM_PCDRR, &val);
@@ -771,8 +771,8 @@ namespace xdp::aie::profile {
 
     // 6. Calculate average latency
     // NOTE: for now, only report average (we also have min and max; see above)
-    uint32_t numValues = latencyValues.at(0);
-    uint32_t totalLatency = latencyValues.at(1);
+    auto numValues = latencyValues.at(0);
+    auto totalLatency = latencyValues.at(1);
     uint64_t avgLatency = (numValues == 0) ? 0 : (totalLatency / numValues);
     values.push_back(avgLatency);
   }


### PR DESCRIPTION
#### Problem solved by the commit
Due to potential overflows, latency values from MDM need to be 64 bits

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Compilation bug on clients introduced in PR-8702

#### How problem was solved, alternative solutions (if any) and why they were rejected
Make latency values use 64 bits

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Compiling on clients

#### Documentation impact (if any)
None