### PR TITLE
VITIS-13806 Fix helper scripts and return codes for xrt-smi

### DIFF
--- a/src/runtime_src/core/tools/xbutil2/xbutil
+++ b/src/runtime_src/core/tools/xbutil2/xbutil
@@ -43,7 +43,7 @@ XRT_LOADER_DIR="`dirname \"$0\"`"
 
 # For edge platforms loader is not required as tools are in standard location(/usr).
 # So calling unwrapped tool from this script itself.
-if [[ $XRT_LOADER_DIR =~ "/usr" || $XRT_LOADER_DIR =~ "/bin" ]]; then
+if [[ $XRT_LOADER_DIR =~ ^(/usr|/bin) ]]; then
     "${XRT_LOADER_DIR}/unwrapped/${XRT_PROG}" "${XRTWRAP_PROG_ARGS[@]}"
     exit 0
 fi

--- a/src/runtime_src/core/tools/xbutil2/xrt-smi
+++ b/src/runtime_src/core/tools/xbutil2/xrt-smi
@@ -35,7 +35,7 @@ XRT_LOADER_DIR="`dirname \"$0\"`"
 
 # For edge platforms loader is not required as tools are in standard location(/usr).
 # So calling unwrapped tool from this script itself.
-if [[ $XRT_LOADER_DIR =~ "/usr" || $XRT_LOADER_DIR =~ "/bin" ]]; then
+if [[ $XRT_LOADER_DIR =~ ^(/usr|/bin) ]]; then
     "${XRT_LOADER_DIR}/unwrapped/${XRT_PROG}" "${XRTWRAP_PROG_ARGS[@]}"
     exit 0
 fi


### PR DESCRIPTION
#### Problem solved by the commit
https://jira.xilinx.com/browse/VITIS-13806
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
The xrt-smi and xbutil helper scripts weren't trying to get the loader and returned 0 due to a faulty if check.
(e.g. `bin` is still in the path on Windows MCDM and Linux amdxdna, so we should still be finding the loader)
#### How problem was solved, alternative solutions (if any) and why they were rejected
Fixed the if check. This should also preserve the original return behavior for edge platforms.
#### Risks (if any) associated the changes in the commit
N/A
#### What has been tested and how, request additional testing if necessary
Tested/built on amdxdna and MCDM.
```
$ xrt-smi configure --pmode performance
ERROR: Please specify a device using --device option
 Available devices:

$ echo $?
1
```
#### Documentation impact (if any)
N/A