### PR TITLE
XDP: Fixed compilation issue for VE2 and new uC metric set for trace

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_debug/CMakeLists.txt
+++ b/src/runtime_src/xdp/profile/plugin/aie_debug/CMakeLists.txt
@@ -36,7 +36,7 @@ if (XDP_VE2_BUILD_CMAKE STREQUAL "yes")
   add_dependencies(xdp_aie_debug_plugin xdp_core xrt_coreutil)
   target_link_libraries(xdp_aie_debug_plugin PRIVATE xdp_core xrt_coreutil xaiengine)
   target_compile_definitions(xdp_aie_debug_plugin PRIVATE FAL_LINUX="on" XDP_VE2_BUILD=1)
-
+  target_include_directories(xdp_aie_debug_plugin PRIVATE ${CMAKE_SOURCE_DIR}/src)
   install (TARGETS xdp_aie_debug_plugin
     LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR}
   )

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/util/aie_trace_util.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/util/aie_trace_util.cpp
@@ -263,6 +263,10 @@ namespace xdp::aie::trace {
       eventSets["uc_axis"] = {};
       eventSets["uc_program_flow"] = {};
 #else
+      eventSets["uc_dma"] = {
+          XAIE_EVENT_DMA_DM2MM_START_TASK_UC,              XAIE_EVENT_DMA_DM2MM_FINISHED_BD_UC,
+          XAIE_EVENT_DMA_DM2MM_FINISHED_TASK_UC,           XAIE_EVENT_DMA_MM2DM_START_TASK_UC,
+          XAIE_EVENT_DMA_MM2DM_FINISHED_BD_UC,             XAIE_EVENT_DMA_MM2DM_FINISHED_TASK_UC};
       eventSets["uc_dma_dm2mm"] = {
           XAIE_EVENT_DMA_DM2MM_START_TASK_UC,              XAIE_EVENT_DMA_DM2MM_FINISHED_BD_UC,
           XAIE_EVENT_DMA_DM2MM_FINISHED_TASK_UC,           XAIE_EVENT_DMA_DM2MM_LOCAL_MEMORY_STARVATION_UC,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
1. Fixed compilation issue for VE2.
2. Added "uc_dma" metric set for trace. Suggested by @pgschuey.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://github.com/Xilinx/XRT/pull/8701
#### How problem was solved, alternative solutions (if any) and why they were rejected
Included the required files in CMake. 
#### Risks (if any) associated the changes in the commit
Low risk.
#### What has been tested and how, request additional testing if necessary
Tested compilation of VE2. 
#### Documentation impact (if any)
NA