### PR TITLE
Resetting AWS clocking module using AWS API

### DIFF
--- a/src/runtime_src/core/pcie/tools/cloud-daemon/aws/aws_dev.h
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/aws/aws_dev.h
@@ -27,6 +27,7 @@
 #ifndef INTERNAL_TESTING_FOR_AWS
 #include "fpga_pci.h"
 #include "fpga_mgmt.h"
+#include "fpga_clkgen.h"
 #include "hal/fpga_common.h"
 #endif
 
@@ -115,6 +116,7 @@ private:
 #else
     int sleepUntilLoaded( const std::string &afi, fpga_mgmt_image_info* new_afi );
     char* get_afi_from_axlf(const axlf * buffer);
+    const clock_freq_topology* get_clock_freq_from_axlf(const axlf *buffer);
     int index;
 #endif
 };


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
AWS clocking module registers are moved to PF1 and hence resetting clocking module
from XRT using clkgen API.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
AWS clocking module registers are moved to PF1 and hence resetting clocking module
from XRT using clkgen API.
#### How problem was solved, alternative solutions (if any) and why they were rejected
AWS clocking module registers are moved to PF1 and hence resetting clocking module
from XRT using clkgen API.
#### Risks (if any) associated the changes in the commit
None 
#### What has been tested and how, request additional testing if necessary
Tested the clock module registers are successfully reset during image load
#### Documentation impact (if any)
None 