### PR TITLE
Dynamic trace support in ve2

### DIFF
--- a/src/runtime_src/core/common/api/bo_int.h
+++ b/src/runtime_src/core/common/api/bo_int.h
@@ -28,6 +28,17 @@ XRT_CORE_COMMON_EXPORT
 xrt::bo
 create_debug_bo(const xrt::hw_context& hwctx, size_t sz);
 
+// create_dtrace_bo() - Create a trace buffer object within a hwctx
+//
+// Allocates a buffer object within a hwctx used for dynamic tracing.
+// The BO is used by driver / firmware to fill dynamic tracing data
+// and is shared with user space XRT.
+// The shim allocation is through hwctx_handle::alloc_bo with
+// the XRT_BO_USE_DTRACE flag captured in extension flags.
+XRT_CORE_COMMON_EXPORT
+xrt::bo
+create_dtrace_bo(const xrt::hw_context& hwctx, size_t sz);
+
 } // bo_int, xrt_core
 
 #endif

--- a/src/runtime_src/core/common/api/module_int.h
+++ b/src/runtime_src/core/common/api/module_int.h
@@ -75,6 +75,11 @@ get_kernel_info(const xrt::module& module);
 uint32_t
 get_partition_size(const xrt::module& module);
 
+// Dump dynamic trace buffer
+// Buffer is dumped after the kernel run is finished
+void
+dump_dtrace_buffer(const xrt::module& module);
+
 } // xrt_core::module_int
 
 #endif

--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -1689,19 +1689,32 @@ get_offset(const xrt::bo& bo)
   return handle->get_offset();
 }
 
-xrt::bo
-create_debug_bo(const xrt::hw_context& hwctx, size_t sz)
+static xrt::bo
+create_bo_helper(const xrt::hw_context& hwctx, size_t sz, uint32_t use_flag)
 {
   xcl_bo_flags flags {0};  // see xrt_mem.h
   flags.flags = XRT_BO_FLAGS_CACHEABLE;
   flags.access = XRT_BO_ACCESS_LOCAL;
   flags.dir = XRT_BO_ACCESS_READ_WRITE;
-  flags.use = XRT_BO_USE_DEBUG;
+  flags.use = use_flag;
 
-  // While the memory group should be ignored (inferred) for debug
-  // buffers, it is still passed in as a default group 1 with no
-  // implied correlation to xclbin connectivity or memory group.
+  // While the memory group should be ignored (inferred) for
+  // debug / trace buffers, it is still passed in as a default
+  // group 1 with no implied correlation to xclbin connectivity
+  // or memory group.
   return xrt::bo{alloc(device_type{hwctx}, sz, flags.all, 1)};
+}
+
+xrt::bo
+create_debug_bo(const xrt::hw_context& hwctx, size_t sz)
+{
+  return create_bo_helper(hwctx, sz, XRT_BO_USE_DEBUG);
+}
+
+xrt::bo
+create_dtrace_bo(const xrt::hw_context& hwctx, size_t sz)
+{
+  return create_bo_helper(hwctx, sz, XRT_BO_USE_DTRACE);
 }
 
 } // xrt_core::bo_int

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -2522,6 +2522,11 @@ public:
     static bool dump = xrt_core::config::get_feature_toggle("Debug.dump_scratchpad_mem");
     if (dump)
       xrt_core::module_int::dump_scratchpad_mem(m_module);
+    
+    // dump dtrace buffer if ini option is enabled
+    static auto dtrace_lib_path = xrt_core::config::get_dtrace_lib_path();
+    if (!dtrace_lib_path.empty())
+      xrt_core::module_int::dump_dtrace_buffer(m_module);
 
     return state;
   }
@@ -2545,6 +2550,12 @@ public:
     else {
       state = cmd->wait();
     }
+
+    // dump dtrace buffer if ini option is enabled
+    // here dtrace is dumped in both passing and timeout cases
+    static auto dtrace_lib_path = xrt_core::config::get_dtrace_lib_path();
+    if (!dtrace_lib_path.empty())
+      xrt_core::module_int::dump_dtrace_buffer(m_module);
 
     if (state == ERT_CMD_STATE_COMPLETED) {
       m_usage_logger->log_kernel_run_info(kernel.get(), this, state);

--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -1031,6 +1031,20 @@ get_aie_trace_settings_enable_system_timeline()
   return value;
 }
 
+inline std::string
+get_dtrace_lib_path()
+{
+  static std::string value = detail::get_string_value("Debug.dtrace_lib_path", "");
+  return value;
+}
+
+inline std::string
+get_dtrace_control_file_path()
+{
+  static std::string value = detail::get_string_value("Debug.dtrace_control_file_path", "");
+  return value;
+}
+
 }} // config,xrt_core
 
 #endif

--- a/src/runtime_src/core/include/xrt/detail/xrt_mem.h
+++ b/src/runtime_src/core/include/xrt/detail/xrt_mem.h
@@ -122,10 +122,15 @@ struct xcl_bo_flags
  * XRT_BO_USE_KMD indicates that the buffer content can be shared
  * with the kernel mode driver. This type of usage is supported on 
  * specific platforms only.
+ * 
+ * XRT_BO_USE_DTRACE indicates that the buffer will be used to
+ * communicate dynamic trace data from driver / firmware back to
+ * userspace. At present this type of usage is supported only on Telluride.
  */
 #define XRT_BO_USE_NORMAL 0
 #define XRT_BO_USE_DEBUG  1
-#define XRT_BO_USE_KMD    2 
+#define XRT_BO_USE_KMD    2
+#define XRT_BO_USE_DTRACE 3 
 
 /**
  * XRT Native BO flags


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Enabled support for dumping dynamic trace. This feature is supported in Telluride only for now.
Trace is dumped only when ini option is enabled.

Input is a control script based on which trace info will be filled. Spec for same can be found at - https://confluence.amd.com/pages/viewpage.action?pageId=1665323347

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
NA

#### How problem was solved, alternative solutions (if any) and why they were rejected
Trace is dumped into a file only when required ini options are enabled.

Also we are calling APIs from dtrace library and the library path is taken as an ini option, ideally the library code should be part of AIEBU repo but as Telluride based AIEBU is still not made public we are taking library path as ini option and calling dlopen / dlsym to use APIs from the library. This should go away once AIEBU has the APIs for dtrace integrated into it.

#### Risks (if any) associated the changes in the commit
Low as dtrace is dumped only when ini option is enabled.

#### What has been tested and how, request additional testing if necessary
Tested dtrace dump on Telluride qemu flow and the output was as expected.

#### Documentation impact (if any)
NA