### PR TITLE
[XDP] Bug fixes to parsing of graph-based xrt.ini settings

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_control_config_filetype.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_control_config_filetype.cpp
@@ -512,7 +512,10 @@ AIEControlConfigFiletype::getEventTiles(const std::string& graph_name,
     int startCount = 0;
 
     for (auto& graph : graphsMetadata.get()) {
-        // Only top-level graphs are listed, so search is reverse
+        // Make sure this is requested graph
+        // NOTE: Only top-level graphs are currently listed in metadata,
+        // so search is reversed to support sub-graph requests
+        // (e.g., "mygraph" is found in "mygraph.subgraph1")
         auto currGraph = graph.second.get<std::string>("name");
         if ((graph_name.find(currGraph) == std::string::npos)
             && (graph_name.compare("all") != 0))


### PR DESCRIPTION
#### Problem solved by the commit
Parsing of some profile/trace settings was not correct

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
A few bugs were found regarding parsing of graph names

#### How problem was solved, alternative solutions (if any) and why they were rejected
Subgraph support fixed for interface tiles, memory modules, and kernel = all

#### Risks (if any) associated the changes in the commit
Known issue: support is constrained by metadata. This needs to be updated to better support graphs/subgraphs, core- and DMA-only tiles, etc. 

#### What has been tested and how, request additional testing if necessary
Tested on vck190 and vek280

#### Documentation impact (if any)
When specifying subgraphs and kernel=all, users will get what they ask for, plus possibly more.