### PR TITLE
CR-1227316 : Fix bug in calling native C xrt::kernel API

### DIFF
--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -3524,7 +3524,10 @@ xrtKernelOpen(xrtDeviceHandle dhdl, const xuid_t xclbin_uuid, const char *name, 
 {
   auto device = get_device(dhdl);
   auto mode = hwctx_access_mode(am);  // legacy access mode to hwctx qos
-  auto kernel = std::make_shared<xrt::kernel_impl>(device, xrt::hw_context{device->get_xrt_device(), xclbin_uuid, mode}, name);
+  auto kernel = std::make_shared<xrt::kernel_impl>(device,
+                                                   xrt::hw_context{device->get_xrt_device(), xclbin_uuid, mode},
+                                                   xrt::module{},
+                                                   name);
   auto handle = kernel.get();
   kernels.add(handle, std::move(kernel));
   return handle;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
When xrt::kernel is created using native C API XRT is throwing exception because of wrong constructor being called.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
PR - https://github.com/Xilinx/XRT/pull/8581 introduced the bug.
Discovered in regressions run on XOAH where application using native C API is run

#### How problem was solved, alternative solutions (if any) and why they were rejected
Passing empty xrt::module so that proper kernel impl constructor is called which fixes the issue.

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
Tested the failing case added in CR and it passes after this fix

#### Documentation impact (if any)
NA
