### PR TITLE
Update ROM VBNV name by reading shell version from AWS interface

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
@@ -888,6 +888,10 @@ int xocl_refresh_subdevs(struct xocl_dev *xdev)
 		if (ret)
 			goto failed;
 
+        /* Update AWS shell version (vbnv name of rom subdev) as peer communication is established */
+        if (xocl_is_aws(xdev))
+            xocl_rom_set_vbnv_name(xdev);
+
 		if (!offset)
 			checksum = resp->checksum;
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -710,6 +710,7 @@ struct xocl_rom_funcs {
 		size_t *fw_size);
 	bool (*passthrough_virtualization_on)(struct platform_device *pdev);
 	char *(*get_uuid)(struct platform_device *pdev);
+	void (*set_vbnv_name)(struct platform_device *pdev);
 };
 
 #define ROM_DEV(xdev)	\
@@ -755,6 +756,8 @@ struct xocl_rom_funcs {
 	ROM_OPS(xdev)->passthrough_virtualization_on(ROM_DEV(xdev)) : false)
 #define xocl_rom_get_uuid(xdev)				\
 	(ROM_CB(xdev, get_uuid) ? ROM_OPS(xdev)->get_uuid(ROM_DEV(xdev)) : NULL)
+#define xocl_rom_set_vbnv_name(xdev)                   \
+	(ROM_CB(xdev, set_vbnv_name) ? ROM_OPS(xdev)->set_vbnv_name(ROM_DEV(xdev)) : NULL)
 
 /* version_ctrl callbacks */
 struct xocl_version_ctrl_funcs {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
The version strings for AWS are currently static.
AWS request is to show the rom vbnv name with version loaded that can change in future for F2 instance.
 Added code to query the aws shell version from aws api and update rom vbnv name accordingly.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
The version strings for AWS are currently static.
AWS request is to show the rom vbnv name with version loaded that can change in future for F2 instance.
 Added code to query the aws shell version from aws api and update rom vbnv name accordingly.
#### How problem was solved, alternative solutions (if any) and why they were rejected
 Added code to query the aws shell version from aws api and update rom vbnv name accordingly.
#### Risks (if any) associated the changes in the commit
None
#### What has been tested and how, request additional testing if necessary
Verified the shell version from aws api is included as part of vbnv name.
#### Documentation impact (if any)
None