### PR TITLE
Add total columns to the right ptree

### DIFF
--- a/src/runtime_src/core/common/info_platform.cpp
+++ b/src/runtime_src/core/common/info_platform.cpp
@@ -62,7 +62,7 @@ add_static_region_info(const xrt_core::device* device, ptree_type& pt)
   {
     static_region.add("name", xrt_core::device_query<xq::rom_vbnv>(device));
     const auto total_cols = xrt_core::device_query_default<xq::total_cols>(device, 0);
-    pt.add("total_columns", total_cols);
+    static_region.add("total_columns", total_cols);
     break;
   }
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Currently, total_columns is added on the highest level in json, however, it needs to be part of static_region group. 

This is where platform report reads it from and without this change, platform report is broken on ryzen

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Internal testing

#### How problem was solved, alternative solutions (if any) and why they were rejected
-

#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
Tested on MCDM

#### Documentation impact (if any)
N/A
