### PR TITLE
CR-1216478 xrt-smi still prints 'operation canceled'

### DIFF
--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -495,7 +495,7 @@ XBUtilities::print_exception(const std::system_error& e)
     // Remove the type of error from the message.
     const std::string msg = std::regex_replace(e.what(), std::regex(std::string(": ") + e.code().message()), "");
 
-    if (!msg.empty())
+    if ((!msg.empty()) && (!boost::icontains(msg, "operation canceled")))
       std::cerr << boost::format("ERROR: %s\n") % msg;
   }
   catch (const std::exception&)


### PR DESCRIPTION
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1216478
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
"operation canceled" error still prints on MCDM, discovered in DSV testing
#### How problem was solved, alternative solutions (if any) and why they were rejected
Removed "operation canceled" from possible error printouts, as we handle detailed argument error previously and also include help menus.
#### Risks (if any) associated the changes in the commit
N/A
#### What has been tested and how, request additional testing if necessary
Tested on Linux/MCDM. 
```
xrt-smi examine test
ERROR: Unrecognized arguments:
  test
COMMAND: examine

DESCRIPTION: This command will 'examine' the state of the system/device and will generate a report of interest in a text or JSON format.

USAGE: xrt-smi examine [--help] [-d arg] [-f arg] [-o arg] [-r arg]

OPTIONS:
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest
  -f, --format       - Report output format. Valid values are:
                         JSON        - Latest JSON schema
                         JSON-2020.2 - JSON 2020.2 schema
  -o, --output       - Direct the output to the given file
  --help             - Help to use this sub-command
  -r, --report       - The type of report to be produced.

Reports currently available are:
                         aie-partitions - AIE partition information
                         all            - All known reports are produced
                         host           - Host information
                         platform       - Platforms flashed on the device
                         telemetry      - Telemetry data for the device
GLOBAL OPTIONS:
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
```
#### Documentation impact (if any)
N/A