### PR TITLE
Fix help handling with different number of devices

### DIFF
--- a/src/runtime_src/core/common/smi.cpp
+++ b/src/runtime_src/core/common/smi.cpp
@@ -46,30 +46,7 @@ const tuple_vector&
 smi_base::
 get_validate_test_desc() const 
 {
-  static const tuple_vector validate_test_desc = {
-    {"aie-reconfig-overhead", "Run end-to-end array reconfiguration overhead through shim DMA", "hidden"},
-    {"all", "All applicable validate tests will be executed (default)", "common"},
-    {"cmd-chain-latency", "Run end-to-end latency test using command chaining", "common"},
-    {"cmd-chain-throughput", "Run end-to-end throughput test using command chaining", "common"},
-    {"df-bw", "Run bandwidth test on data fabric", "common"},
-    {"gemm", "Measure the TOPS value of GEMM operations", "common"},
-    {"latency", "Run end-to-end latency test", "common"},
-    {"quick", "Run a subset of four tests: \n1. latency \n2. throughput \n3. cmd-chain-latency \n4. cmd-chain-throughput", "common"},
-    {"spatial-sharing-overhead", "Run Spatial Sharing Overhead Test", "hidden"},
-    {"tct-all-col", "Measure average TCT processing time for all columns", "common"},
-    {"tct-one-col", "Measure average TCT processing time for one column", "common"},
-    {"temporal-sharing-overhead", "Run Temporal Sharing Overhead Test", "hidden"},
-    {"throughput", "Run end-to-end throughput test", "common"},
-    {"aux-connection", "Check if auxiliary power is connected", "common"},
-    {"dma", "Run dma test", "common"},
-    {"thostmem-bw", "Run 'bandwidth kernel' when host memory is enabled", "common"},
-    {"m2m", "Run M2M test", "common"},
-    {"mem-bw", "Run 'bandwidth kernel' and check the throughput", "common"},
-    {"p2p", "Run P2P test", "common"},
-    {"pcie-link", "Check if PCIE link is active", "common"},
-    {"sc-version","Check if SC firmware is up-to-date", "common"},
-    {"verify", "Run 'Hello World' kernel test", "common"}
-  };
+  static const tuple_vector validate_test_desc = {};
   return validate_test_desc;
 }
 
@@ -78,24 +55,7 @@ smi_base::
 get_examine_report_desc() const 
 {
   static const tuple_vector examine_report_desc = {
-    {"aie-partitions", "AIE partition information", "common"},
-    {"host", "Host information", "common"},
-    {"platform", "Platforms flashed on the device", "common"},
-    {"telemetry", "Telemetry data for the device", "common"},
-    {"aie", "AIE metadata in xclbin", "common"},
-    {"aiemem", "AIE memory tile information", "common"},
-    {"aieshim", "AIE shim tile status", "common"},
-    {"debug-ip-status", "Status of Debug IPs present in xclbin loaded on device", "common"},
-    {"dynamic-regions", "Information about the xclbin and the compute units", "common"},
-    {"electrical", "Electrical and power sensors present on the device", "common"},
-    {"error", "Asyncronus Error present on the device", "common"},
-    {"firewall", "Firewall status", "common"},
-    {"mailbox", "Mailbox metrics of the device", "common"},
-    {"mechanical", "Mechanical sensors on and surrounding the device", "common"},
-    {"memory", "Memory information present on the device", "common"},
-    {"pcie-info", "Pcie information of the device", "common"},
-    {"qspi-status", "QSPI write protection status", "common"},
-    {"thermal", "Thermal sensors present on the device", "common"}
+    {"host", "Host information", "common"}
   };
   return examine_report_desc;
 }

--- a/src/runtime_src/core/tools/common/XBMain.cpp
+++ b/src/runtime_src/core/tools/common/XBMain.cpp
@@ -188,7 +188,7 @@ void  main_(int argc, char** argv,
   if (available_devices.empty()) //no device
     config = xrt_core::smi::get_smi_config();
   else if (available_devices.size() == 1 || !sDevice.empty()) { //1 device
-    auto device = XBU::get_device(boost::algorithm::to_lower_copy(sDevice), isUserDomain);//to-do
+    auto device = XBU::get_device(boost::algorithm::to_lower_copy(sDevice), isUserDomain);
     config = xrt_core::device_query<xrt_core::query::xrt_smi_config>(device, xrt_core::query::xrt_smi_config::type::options_config);
   }
   else { //multiple devices
@@ -198,7 +198,7 @@ void  main_(int argc, char** argv,
       dev = devpt.get<std::string>("bdf");
     }
     std::cout <<  (boost::format("NOTE: Multiple devices found. Showing help for %s device\n\n") % dev).str();
-    auto device = XBU::get_device(boost::algorithm::to_lower_copy(dev), isUserDomain);//to-do
+    auto device = XBU::get_device(boost::algorithm::to_lower_copy(dev), isUserDomain);
     config = xrt_core::device_query<xrt_core::query::xrt_smi_config>(device, xrt_core::query::xrt_smi_config::type::options_config);
   }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Currently, 0 and multiple device help print is treated as the same scenario. 

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Internal testing

#### How problem was solved, alternative solutions (if any) and why they were rejected
0 devices -> print bare minimum help, i.e., no tests and only host report under examine
1 device -> prints help custom for that device
2 devices -> gives a NOTE and prints custom help for one of the devices

This fix is limited to subcommand helps. The next iteration of change will reflect it at xrt-smi level

#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
0 device (win):
```
xrt-smi examine --help

COMMAND: examine

DESCRIPTION: This command will 'examine' the state of the system/device and will generate a report of interest
               in a text or JSON format.

USAGE: xrt-smi examine [-h] [-d arg] [-f arg] [-o arg] [-r arg]

OPTIONS:
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest
  -f, --format       - Report output format. Valid values are:
                        JSON        - Latest JSON schema
                        JSON-2020.2 - JSON 2020.2 schema
  -h, --help         - Help to use this sub-command
  -o, --output       - Direct the output to the given file
  -r, --report       - The type of report to be produced. Reports currently available are:
                         host - Host information


GLOBAL OPTIONS:
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
```

1 device (win):
```
xrt-smi examine --help

COMMAND: examine

DESCRIPTION: This command will 'examine' the state of the system/device and will generate a report of interest
               in a text or JSON format.

USAGE: xrt-smi examine [-h] [-d arg] [-f arg] [-o arg] [-r arg]

OPTIONS:
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest
  -f, --format       - Report output format. Valid values are:
                        JSON        - Latest JSON schema
                        JSON-2020.2 - JSON 2020.2 schema
  -h, --help         - Help to use this sub-command
  -o, --output       - Direct the output to the given file
  -r, --report       - The type of report to be produced. Reports currently available are:
                         aie-partitions - AIE partition information
                         host           - Host information
                         platform       - Platforms flashed on the device
                         telemetry      - Telemetry data for the device


GLOBAL OPTIONS:
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
```

2 devices (linux):
```
xrt-smi examine --help 
NOTE: Multiple devices found. Showing help for 0000:18:00.1 device


COMMAND: examine

DESCRIPTION: This command will 'examine' the state of the system/device and will generate a report of interest
               in a text or JSON format.

USAGE: xrt-smi examine [-h] [-d arg] [-f arg] [-o arg] [-r arg]

OPTIONS:
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest
  -f, --format       - Report output format. Valid values are:
                        JSON        - Latest JSON schema
                        JSON-2020.2 - JSON 2020.2 schema
  -h, --help         - Help to use this sub-command
  -o, --output       - Direct the output to the given file
  -r, --report       - The type of report to be produced. Reports currently available are:
                         aie             - AIE metadata in xclbin
                         aiemem          - AIE memory tile information
                         aieshim         - AIE shim tile status
                         debug-ip-status - Status of Debug IPs present in xclbin loaded on device
                         dynamic-regions - Information about the xclbin and the compute units
                         electrical      - Electrical and power sensors present on the device
                         error           - Asyncronus Error present on the device
                         firewall        - Firewall status
                         mailbox         - Mailbox metrics of the device
                         mechanical      - Mechanical sensors on and surrounding the device
                         memory          - Memory information present on the device
                         pcie-info       - Pcie information of the device
                         qspi-status     - QSPI write protection status
                         thermal         - Thermal sensors present on the device


GLOBAL OPTIONS:
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
```

#### Documentation impact (if any)
N/A
