### PR TITLE
Using Combo Event 0 to start trace module for VE2

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_trace/util/aie_trace_config.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/util/aie_trace_config.cpp
@@ -524,7 +524,7 @@ namespace xdp::aie::trace {
     uint8_t broadcastId2 = traceStartBroadcastCh2->getBc();
 
     //build broadcast network
-    aie::trace::build2ChannelBroadcastNetwork(aieDevInst, metadata, broadcastId1, broadcastId2, XAIE_EVENT_USER_EVENT_0_PL, startCol, numCols);
+    aie::trace::build2ChannelBroadcastNetwork(aieDevInst, metadata, broadcastId1, broadcastId2, XAIE_EVENT_COMBO_EVENT_0_PL, startCol, numCols);
 
     //set timer control register
     for (auto& tileMetric : metadata->getConfigMetrics()) {
@@ -538,7 +538,7 @@ namespace xdp::aie::trace {
         XAie_Events resetEvent = (XAie_Events)(XAIE_EVENT_BROADCAST_A_0_PL + broadcastId2);
         if(col == startCol)
         {
-          resetEvent = XAIE_EVENT_USER_EVENT_0_PL;
+          resetEvent = XAIE_EVENT_COMBO_EVENT_0_PL;
         }
 
         XAie_SetTimerResetEvent(aieDevInst, loc, XAIE_PL_MOD, resetEvent, XAIE_RESETDISABLE);
@@ -556,7 +556,7 @@ namespace xdp::aie::trace {
     }
 
     //Generate the event to trigger broadcast network to reset timer
-    XAie_EventGenerate(aieDevInst, XAie_TileLoc(startCol, 0), XAIE_PL_MOD, XAIE_EVENT_USER_EVENT_0_PL);
+    XAie_EventGenerate(aieDevInst, XAie_TileLoc(startCol, 0), XAIE_PL_MOD, XAIE_EVENT_COMBO_EVENT_0_PL);
 
     //reset timer control register so that timer are not reset after this point
     for (auto& tileMetric : metadata->getConfigMetrics()) {

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/ve2/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/ve2/aie_trace.cpp
@@ -337,7 +337,7 @@ namespace xdp {
         traceStartBroadcastCh1->reserve();
         traceStartBroadcastCh2 = aieDevice->broadcast(vL, XAIE_PL_MOD, XAIE_CORE_MOD);
         traceStartBroadcastCh2->reserve();
-        aie::trace::build2ChannelBroadcastNetwork(aieDevInst, metadata, traceStartBroadcastCh1->getBc(), traceStartBroadcastCh2->getBc(), XAIE_EVENT_USER_EVENT_0_PL, startCol, numCols);
+        aie::trace::build2ChannelBroadcastNetwork(aieDevInst, metadata, traceStartBroadcastCh1->getBc(), traceStartBroadcastCh2->getBc(), XAIE_EVENT_COMBO_EVENT_0_PL, startCol, numCols);
 
         coreTraceStartEvent = (XAie_Events) (XAIE_EVENT_BROADCAST_0_CORE + traceStartBroadcastCh1->getBc());
         memoryTileTraceStartEvent = (XAie_Events) (XAIE_EVENT_BROADCAST_0_MEM_TILE + traceStartBroadcastCh1->getBc());
@@ -869,7 +869,7 @@ namespace xdp {
 
         if(col == startCol && compilerOptions.enable_multi_layer && xrt_core::config::get_aie_trace_settings_trace_start_broadcast())
         {
-          if (shimTrace->setCntrEvent(XAIE_EVENT_USER_EVENT_0_PL, interfaceTileTraceEndEvent) != XAIE_OK)
+          if (shimTrace->setCntrEvent(XAIE_EVENT_COMBO_EVENT_0_PL, interfaceTileTraceEndEvent) != XAIE_OK)
             break;
         }
         else


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
As of now we were generating USER_EVENT_0 in CDO to start the trace module for VE2 which was interfering with two of the profiling metric sets.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
After discussion with @pgschuey and @vipangul we decided to use combo_event_0 which is not being used currently and won't interfere with trace.

#### Risks (if any) associated the changes in the commit
Changes needs to be done in AIECompiler to start generating COMBO_EVENT_0 in cdo instead of USER_EVENT_0. Once this PR is merged @jyothees99 will submit the changes on compiler side. Once the compiler changes are in TA we can update the XRT submodule in VE2 to point to this commit.

#### What has been tested and how, request additional testing if necessary
Tested trace on eff_net design on both hardware and QEMU.
#### Documentation impact (if any)
NA