### PR TITLE
Implementation for device query for validate/report names usage

### DIFF
--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -569,7 +569,7 @@ struct xrt_smi_lists : request
   static const char* name() { return "xrt_smi_lists"; }
 
   virtual std::any
-  get(const device*) const override = 0;
+  get(const device*, const std::any& req_type) const override = 0;
 
   // formatting of individual items for the vector
   static std::string

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -56,6 +56,7 @@ enum class key_type
   edge_vendor,
   device_class,
   xrt_smi_config,
+  xrt_smi_lists,
   xclbin_name,
   sequence_name,
   elf_name,
@@ -555,6 +556,27 @@ struct xrt_smi_config : request
 
   virtual std::any
   get(const device*, const std::any& req_type) const override = 0;
+};
+
+struct xrt_smi_lists : request
+{
+  enum class type {
+    validate_tests,
+    examine_reports
+  };
+  using result_type = std::vector<std::tuple<std::string, std::string, std::string>>;
+  static const key_type key = key_type::xrt_smi_lists;
+  static const char* name() { return "xrt_smi_lists"; }
+
+  virtual std::any
+  get(const device*) const override = 0;
+
+  // formatting of individual items for the vector
+  static std::string
+  to_string(const std::string& value)
+  {
+    return value;
+  }
 };
 
 /**

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -558,6 +558,12 @@ struct xrt_smi_config : request
   get(const device*, const std::any& req_type) const override = 0;
 };
 
+/* Used to retrieve the list of validate tests and examine reports along with 
+   their description and visibility tags. This returns the same list which is
+   used by help printing to maintain concurrency between what is printed and 
+   what is run by xrt-smi. This can be extended to other list assuming the 
+   structure is kept the same as validate_tests and examine reports
+*/
 struct xrt_smi_lists : request
 {
   enum class type {

--- a/src/runtime_src/core/common/smi.cpp
+++ b/src/runtime_src/core/common/smi.cpp
@@ -42,44 +42,24 @@ to_ptree() const
   return pt;
 }
 
-const tuple_vector& 
 smi_base::
-get_validate_test_desc() const 
+smi_base()
 {
-  static const tuple_vector validate_test_desc = {};
-  return validate_test_desc;
-}
 
-const tuple_vector& 
-smi_base::
-get_examine_report_desc() const 
-{
-  static const tuple_vector examine_report_desc = {
+  examine_report_desc = {
     {"host", "Host information", "common"}
   };
-  return examine_report_desc;
 }
 
 std::vector<basic_option> 
 smi_base::
-construct_run_option_description() const 
+construct_option_description(const tuple_vector& vec) const
 {
-  std::vector<basic_option> run_option_descriptions;
-  for (const auto& [name, description, type] : get_validate_test_desc()) {
-    run_option_descriptions.push_back({name, description, type});
+  std::vector<basic_option> option_descriptions;
+  for (const auto& [name, description, type] : vec) {
+    option_descriptions.push_back({name, description, type});
   }
-  return run_option_descriptions;
-}
-
-std::vector<basic_option> 
-smi_base::
-construct_report_option_description() const 
-{
-  std::vector<basic_option> report_option_descriptions;
-  for (const auto& [name, description, type] : get_examine_report_desc()) {
-    report_option_descriptions.push_back({name, description, type});
-  }
-  return report_option_descriptions;
+  return option_descriptions;
 }
 
 ptree 
@@ -98,7 +78,7 @@ construct_validate_subcommand() const
                     "\tJSON-2020.2 - JSON 2020.2 schema", "common", "JSON", "string"},
     {"output", "o", "Direct the output to the given file", "common", "", "string"},
     {"help", "h", "Help to use this sub-command", "common", "", "none"},
-    {"run", "r", "Run a subset of the test suite. Valid options are:\n",  "common", "",  "array", construct_run_option_description()},
+    {"run", "r", "Run a subset of the test suite. Valid options are:\n",  "common", "",  "array", construct_option_description(validate_test_desc)},
     {"path", "p", "Path to the directory containing validate xclbins", "hidden", "", "string"},
     {"param", "", "Extended parameter for a given test. Format: <test-name>:<key>:<value>", "hidden", "", "string"},
     {"pmode", "", "Specify which power mode to run the benchmarks in. Note: Some tests might be unavailable for some modes", "hidden", "", "string"}
@@ -129,7 +109,7 @@ construct_examine_subcommand() const
                     "\tJSON-2020.2 - JSON 2020.2 schema", "common", "", "string"},
     {"output", "o", "Direct the output to the given file", "common", "", "string"},
     {"help", "h", "Help to use this sub-command", "common", "", "none"},
-    {"report", "r", "The type of report to be produced. Reports currently available are:\n", "common", "", "array", construct_report_option_description()},
+    {"report", "r", "The type of report to be produced. Reports currently available are:\n", "common", "", "array", construct_option_description(examine_report_desc)},
     {"element", "e", "Filters individual elements(s) from the report. Format: '/<key>/<key>/...'", "hidden", "", "array"}
   };
 
@@ -154,9 +134,9 @@ construct_configure_subcommand() const
   std::vector<option> options = {
     {"device", "d", "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest", "common", "", "string"},
     {"help", "h", "Help to use this sub-command", "common", "", "none"},
-    {"daemon", "", "Update the device daemon configuration", "common", "", "none"},
+    {"daemon", "", "Update the device daemon configuration", "hidden", "", "none"},
     {"purge", "", "Remove the daemon configuration file", "hidden", "", "string"},
-    {"host", "", "IP or hostname for device peer", "common", "", "string"},
+    {"host", "", "IP or hostname for device peer", "hidden", "", "string"},
     {"security", "", "Update the security level for the device", "hidden", "", "string"},
     {"clk_throttle", "", "Enable/disable the device clock throttling", "hidden", "", "string"},
     {"ct_threshold_power_override", "", "Update the power threshold in watts", "hidden", "", "string"},

--- a/src/runtime_src/core/common/smi.h
+++ b/src/runtime_src/core/common/smi.h
@@ -52,19 +52,11 @@ struct option : public basic_option {
 class smi_base {
 protected:
 
-  XRT_CORE_COMMON_EXPORT
-  virtual const tuple_vector& 
-  get_validate_test_desc() const;
-
-  XRT_CORE_COMMON_EXPORT
-  virtual const tuple_vector& 
-  get_examine_report_desc() const;
+  tuple_vector validate_test_desc;
+  tuple_vector examine_report_desc;
 
   std::vector<basic_option> 
-  construct_run_option_description() const;
-
-  std::vector<basic_option> 
-  construct_report_option_description() const;
+  construct_option_description(const tuple_vector&) const;
 
   boost::property_tree::ptree 
   construct_validate_subcommand() const;
@@ -77,7 +69,21 @@ protected:
 
 public:
   XRT_CORE_COMMON_EXPORT
-  std::string get_smi_config() const;
+  std::string
+  get_smi_config() const;
+
+  XRT_CORE_COMMON_EXPORT
+  const tuple_vector&
+  get_validate_tests() const
+  { return validate_test_desc; }
+
+  XRT_CORE_COMMON_EXPORT
+  const tuple_vector&
+  get_examine_reports() const
+  { return examine_report_desc; }
+
+  XRT_CORE_COMMON_EXPORT
+  smi_base();
 };
 
 XRT_CORE_COMMON_EXPORT

--- a/src/runtime_src/core/edge/user/device_linux.cpp
+++ b/src/runtime_src/core/edge/user/device_linux.cpp
@@ -708,15 +708,15 @@ struct xrt_smi_lists
   using result_type = std::any;
 
   static result_type
-  user(const xrt_core::device* /*device*/, xrt_key_type key)
+  get(const xrt_core::device* /*device*/, key_type key)
   {
     throw xrt_core::query::no_such_key(key, "Not implemented");
   }
 
   static result_type
-  user(const xrt_core::device* /*device*/, xrt_key_type key, const std::any& reqType)
+  get(const xrt_core::device* /*device*/, key_type key, const std::any& reqType)
   {
-    if (key != xrt_key_type::xrt_smi_lists)
+    if (key != key_type::xrt_smi_lists)
       throw xrt_core::query::no_such_key(key, "Not implemented");
 
     const auto xrt_smi_lists_type = std::any_cast<xrt_core::query::xrt_smi_lists::type>(reqType);

--- a/src/runtime_src/core/edge/user/device_linux.cpp
+++ b/src/runtime_src/core/edge/user/device_linux.cpp
@@ -703,6 +703,34 @@ struct xrt_smi_config
   }
 };
 
+struct xrt_smi_lists
+{
+  using result_type = std::any;
+
+  static result_type
+  user(const xrt_core::device* /*device*/, xrt_key_type key)
+  {
+    throw xrt_core::query::no_such_key(key, "Not implemented");
+  }
+
+  static result_type
+  user(const xrt_core::device* /*device*/, xrt_key_type key, const std::any& reqType)
+  {
+    if (key != xrt_key_type::xrt_smi_lists)
+      throw xrt_core::query::no_such_key(key, "Not implemented");
+
+    const auto xrt_smi_lists_type = std::any_cast<xrt_core::query::xrt_smi_lists::type>(reqType);
+    switch (xrt_smi_lists_type) {
+    case xrt_core::query::xrt_smi_lists::type::validate_tests:
+      return shim_edge::smi::get_validate_tests();
+    case xrt_core::query::xrt_smi_lists::type::examine_reports:
+      return shim_edge::smi::get_examine_reports();
+    default:
+      throw xrt_core::query::no_such_key(key, "Not implemented");
+    }
+  }
+};
+
 struct asm_counter
 {
   using result_type = query::asm_counter::result_type;
@@ -1084,6 +1112,7 @@ initialize_query_table()
   emplace_func4_request<query::am_counter,              am_counter>();
   emplace_func4_request<query::asm_counter,             asm_counter>();
   emplace_func4_request<query::xrt_smi_config,          xrt_smi_config>();
+  emplace_func4_request<query::xrt_smi_lists,           xrt_smi_lists>();
   emplace_func4_request<query::lapc_status,             lapc_status>();
   emplace_func4_request<query::spc_status,              spc_status>();
   emplace_func4_request<query::accel_deadlock_status,   accel_deadlock_status>();

--- a/src/runtime_src/core/edge/user/smi.cpp
+++ b/src/runtime_src/core/edge/user/smi.cpp
@@ -4,11 +4,10 @@
 
 namespace shim_edge::smi {
 
-const std::vector<std::tuple<std::string, std::string, std::string>>& 
 smi_edge::
-get_validate_test_desc() const 
+smi_edge() : smi_base()
 {
-  static const std::vector<std::tuple<std::string, std::string, std::string>> validate_test_desc = {
+  validate_test_desc = {
     {"aux-connection", "Check if auxiliary power is connected", "common"},
     {"dma", "Run dma test", "common"},
     {"thostmem-bw", "Run 'bandwidth kernel' when host memory is enabled", "common"},
@@ -19,14 +18,8 @@ get_validate_test_desc() const
     {"sc-version","Check if SC firmware is up-to-date", "common"},
     {"verify", "Run 'Hello World' kernel test", "common"}
   };
-  return validate_test_desc;
-}
 
-const std::vector<std::tuple<std::string, std::string, std::string>>& 
-smi_edge::
-get_examine_report_desc() const 
-{
-  static const std::vector<std::tuple<std::string, std::string, std::string>> examine_report_desc = {
+  examine_report_desc = {
     {"aie", "AIE metadata in xclbin", "common"},
     {"aiemem", "AIE memory tile information", "common"},
     {"aieshim", "AIE shim tile status", "common"},
@@ -42,7 +35,6 @@ get_examine_report_desc() const
     {"qspi-status", "QSPI write protection status", "common"},
     {"thermal", "Thermal sensors present on the device", "common"}
   };
-  return examine_report_desc;
 }
 
 std::string
@@ -54,4 +46,25 @@ get_smi_config()
   // Call the get_smi_config method
   return smi_instance.get_smi_config();
 }
+
+std::vector<std::string>
+get_validate_tests()
+{
+  // Create an instance of the derived class
+  shim_edge::smi::smi_edge smi_instance;
+
+  // Call the get_validate_tests method
+  return smi_instance.get_validate_tests();
+}
+
+std::vector<std::string>
+get_examine_reports()
+{
+  // Create an instance of the derived class
+  shim_edge::smi::smi_edg smi_instance;
+
+  // Call the get_examine_reports method
+  return smi_instance.get_examine_reports();
+}
+
 } // namespace shim_edge::smi

--- a/src/runtime_src/core/edge/user/smi.cpp
+++ b/src/runtime_src/core/edge/user/smi.cpp
@@ -28,10 +28,12 @@ smi_edge() : smi_base()
     {"electrical", "Electrical and power sensors present on the device", "common"},
     {"error", "Asyncronus Error present on the device", "common"},
     {"firewall", "Firewall status", "common"},
+    {"host", "Host information", "common"},
     {"mailbox", "Mailbox metrics of the device", "common"},
     {"mechanical", "Mechanical sensors on and surrounding the device", "common"},
     {"memory", "Memory information present on the device", "common"},
     {"pcie-info", "Pcie information of the device", "common"},
+    {"platform", "Platforms flashed on the device", "common"},
     {"qspi-status", "QSPI write protection status", "common"},
     {"thermal", "Thermal sensors present on the device", "common"}
   };

--- a/src/runtime_src/core/edge/user/smi.cpp
+++ b/src/runtime_src/core/edge/user/smi.cpp
@@ -37,32 +37,26 @@ smi_edge() : smi_base()
   };
 }
 
+// Create an instance of the derived class
+static shim_edge::smi::smi_edge smi_instance;
+
 std::string
 get_smi_config()
 {
-  // Create an instance of the derived class
-  shim_edge::smi::smi_edge smi_instance;
-
   // Call the get_smi_config method
   return smi_instance.get_smi_config();
 }
 
-std::vector<std::string>
+const xrt_core::smi::tuple_vector&
 get_validate_tests()
 {
-  // Create an instance of the derived class
-  shim_edge::smi::smi_edge smi_instance;
-
   // Call the get_validate_tests method
   return smi_instance.get_validate_tests();
 }
 
-std::vector<std::string>
+const xrt_core::smi::tuple_vector&
 get_examine_reports()
 {
-  // Create an instance of the derived class
-  shim_edge::smi::smi_edg smi_instance;
-
   // Call the get_examine_reports method
   return smi_instance.get_examine_reports();
 }

--- a/src/runtime_src/core/edge/user/smi.h
+++ b/src/runtime_src/core/edge/user/smi.h
@@ -13,4 +13,10 @@ public:
 
 /* This API can be device specific since this is used by the shim*/
 std::string get_smi_config();
+
+const xrt_core::smi::tuple_vector&
+get_validate_tests();
+
+const xrt_core::smi::tuple_vector&
+get_examine_reports();
 } // namespace shim_edge::smi

--- a/src/runtime_src/core/edge/user/smi.h
+++ b/src/runtime_src/core/edge/user/smi.h
@@ -7,13 +7,8 @@
 namespace shim_edge::smi {
 
 class smi_edge : public xrt_core::smi::smi_base {
-protected:
-  const std::vector<std::tuple<std::string, std::string, std::string>>& 
-  get_validate_test_desc() const override;
-
-  const std::vector<std::tuple<std::string, std::string, std::string>>& 
-  get_examine_report_desc() const override;
-
+public:
+  smi_edge();
 };
 
 /* This API can be device specific since this is used by the shim*/

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -931,6 +931,34 @@ struct xrt_smi_config
   }
 };
 
+struct xrt_smi_lists
+{
+  using result_type = std::any;
+
+  static result_type
+  user(const xrt_core::device* /*device*/, xrt_key_type key)
+  {
+    throw xrt_core::query::no_such_key(key, "Not implemented");
+  }
+
+  static result_type
+  user(const xrt_core::device* /*device*/, xrt_key_type key, const std::any& reqType)
+  {
+    if (key != xrt_key_type::xrt_smi_lists)
+      throw xrt_core::query::no_such_key(key, "Not implemented");
+
+    const auto xrt_smi_lists_type = std::any_cast<xrt_core::query::xrt_smi_lists::type>(reqType);
+    switch (xrt_smi_lists_type) {
+    case xrt_core::query::xrt_smi_lists::type::validate_tests:
+      return shim_pcie::smi::get_validate_tests();
+    case xrt_core::query::xrt_smi_lists::type::examine_reports:
+      return shim_pcie::smi::get_examine_reports();
+    default:
+      throw xrt_core::query::no_such_key(key, "Not implemented");
+    }
+  }
+};
+
 
 
 /* ASM counter values
@@ -1484,6 +1512,7 @@ initialize_query_table()
   emplace_func4_request<query::am_counter,                     am_counter>();
   emplace_func4_request<query::asm_counter,                    asm_counter>();
   emplace_func4_request<query::xrt_smi_config,                 xrt_smi_config>();
+  emplace_func4_request<query::xrt_smi_lists,                  xrt_smi_lists>();
   emplace_func4_request<query::lapc_status,                    lapc_status>();
   emplace_func4_request<query::spc_status,                     spc_status>();
   emplace_func4_request<query::accel_deadlock_status,          accel_deadlock_status>();

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -936,15 +936,15 @@ struct xrt_smi_lists
   using result_type = std::any;
 
   static result_type
-  user(const xrt_core::device* /*device*/, xrt_key_type key)
+  get(const xrt_core::device* /*device*/, key_type key)
   {
     throw xrt_core::query::no_such_key(key, "Not implemented");
   }
 
   static result_type
-  user(const xrt_core::device* /*device*/, xrt_key_type key, const std::any& reqType)
+  get(const xrt_core::device* /*device*/, key_type key, const std::any& reqType)
   {
-    if (key != xrt_key_type::xrt_smi_lists)
+    if (key != key_type::xrt_smi_lists)
       throw xrt_core::query::no_such_key(key, "Not implemented");
 
     const auto xrt_smi_lists_type = std::any_cast<xrt_core::query::xrt_smi_lists::type>(reqType);

--- a/src/runtime_src/core/pcie/linux/smi.cpp
+++ b/src/runtime_src/core/pcie/linux/smi.cpp
@@ -4,9 +4,10 @@
 
 namespace shim_pcie::smi {
 
-const std::vector<std::tuple<std::string, std::string, std::string>>& 
-smi_pcie::get_validate_test_desc() const {
-  static const std::vector<std::tuple<std::string, std::string, std::string>> validate_test_desc = {
+smi_pcie::
+smi_pcie() : smi_base()
+{
+  validate_test_desc = {
     {"aux-connection", "Check if auxiliary power is connected", "common"},
     {"dma", "Run dma test", "common"},
     {"thostmem-bw", "Run 'bandwidth kernel' when host memory is enabled", "common"},
@@ -17,12 +18,8 @@ smi_pcie::get_validate_test_desc() const {
     {"sc-version","Check if SC firmware is up-to-date", "common"},
     {"verify", "Run 'Hello World' kernel test", "common"}
   };
-  return validate_test_desc;
-}
 
-const std::vector<std::tuple<std::string, std::string, std::string>>& 
-smi_pcie::get_examine_report_desc() const {
-  static const std::vector<std::tuple<std::string, std::string, std::string>> examine_report_desc = {
+  examine_report_desc = {
     {"aie", "AIE metadata in xclbin", "common"},
     {"aiemem", "AIE memory tile information", "common"},
     {"aieshim", "AIE shim tile status", "common"},
@@ -38,7 +35,6 @@ smi_pcie::get_examine_report_desc() const {
     {"qspi-status", "QSPI write protection status", "common"},
     {"thermal", "Thermal sensors present on the device", "common"}
   };
-  return examine_report_desc;
 }
 
 std::string
@@ -49,4 +45,25 @@ get_smi_config(){
   // Call the get_smi_config method
   return smi_instance.get_smi_config();
 }
+
+std::vector<std::string>
+get_validate_tests()
+{
+  // Create an instance of the derived class
+  shim_pcie::smi::smi_pcie smi_instance;
+
+  // Call the get_validate_tests method
+  return smi_instance.get_validate_tests();
+}
+
+std::vector<std::string>
+get_examine_reports()
+{
+  // Create an instance of the derived class
+  shim_pcie::smi::smi_pcie smi_instance;
+
+  // Call the get_examine_reports method
+  return smi_instance.get_examine_reports();
+}
+
 } // namespace shim_pcie::smi

--- a/src/runtime_src/core/pcie/linux/smi.cpp
+++ b/src/runtime_src/core/pcie/linux/smi.cpp
@@ -28,10 +28,12 @@ smi_pcie() : smi_base()
     {"electrical", "Electrical and power sensors present on the device", "common"},
     {"error", "Asyncronus Error present on the device", "common"},
     {"firewall", "Firewall status", "common"},
+    {"host", "Host information", "common"},
     {"mailbox", "Mailbox metrics of the device", "common"},
     {"mechanical", "Mechanical sensors on and surrounding the device", "common"},
     {"memory", "Memory information present on the device", "common"},
     {"pcie-info", "Pcie information of the device", "common"},
+    {"platform", "Platforms flashed on the device", "common"},
     {"qspi-status", "QSPI write protection status", "common"},
     {"thermal", "Thermal sensors present on the device", "common"}
   };

--- a/src/runtime_src/core/pcie/linux/smi.cpp
+++ b/src/runtime_src/core/pcie/linux/smi.cpp
@@ -37,31 +37,25 @@ smi_pcie() : smi_base()
   };
 }
 
+// Create an instance of the derived class
+static shim_pcie::smi::smi_pcie smi_instance;
+
 std::string
 get_smi_config(){
-  // Create an instance of the derived class
-  shim_pcie::smi::smi_pcie smi_instance;
-
   // Call the get_smi_config method
   return smi_instance.get_smi_config();
 }
 
-std::vector<std::string>
+const xrt_core::smi::tuple_vector&
 get_validate_tests()
 {
-  // Create an instance of the derived class
-  shim_pcie::smi::smi_pcie smi_instance;
-
   // Call the get_validate_tests method
   return smi_instance.get_validate_tests();
 }
 
-std::vector<std::string>
+const xrt_core::smi::tuple_vector&
 get_examine_reports()
 {
-  // Create an instance of the derived class
-  shim_pcie::smi::smi_pcie smi_instance;
-
   // Call the get_examine_reports method
   return smi_instance.get_examine_reports();
 }

--- a/src/runtime_src/core/pcie/linux/smi.h
+++ b/src/runtime_src/core/pcie/linux/smi.h
@@ -15,9 +15,9 @@ public:
 std::string
 get_smi_config();
 
-std::vector<std::string>
+const xrt_core::smi::tuple_vector&
 get_validate_tests();
 
-std::vector<std::string>
+const xrt_core::smi::tuple_vector&
 get_examine_reports();
 } // namespace shim_pcie::smi

--- a/src/runtime_src/core/pcie/linux/smi.h
+++ b/src/runtime_src/core/pcie/linux/smi.h
@@ -7,11 +7,17 @@
 namespace shim_pcie::smi {
 
 class smi_pcie : public xrt_core::smi::smi_base {
-protected:
-  const std::vector<std::tuple<std::string, std::string, std::string>>& get_validate_test_desc() const override;
-  const std::vector<std::tuple<std::string, std::string, std::string>>& get_examine_report_desc() const override;
+public:
+  smi_pcie();
 };
 
 /* This API can be device specific since this is used by the shim*/
-std::string get_smi_config();
+std::string
+get_smi_config();
+
+std::vector<std::string>
+get_validate_tests();
+
+std::vector<std::string>
+get_examine_reports();
 } // namespace shim_pcie::smi

--- a/src/runtime_src/core/tools/common/SubCmdExamineInternal.cpp
+++ b/src/runtime_src/core/tools/common/SubCmdExamineInternal.cpp
@@ -134,7 +134,6 @@ SubCmdExamineInternal::execute(const SubCmdOptions& _options) const
 
   // Filter out reports that are not compatible for the device
   const std::string deviceClass = XBU::get_device_class(options.m_device, m_isUserDomain);
-  // ReportCollection runnableReports = validateConfigurables<Report>(deviceClass, std::string("report"), fullReportCollection);
 
  // Find device of interest
   std::shared_ptr<xrt_core::device> device;

--- a/src/runtime_src/core/tools/common/SubCmdExamineInternal.cpp
+++ b/src/runtime_src/core/tools/common/SubCmdExamineInternal.cpp
@@ -134,18 +134,9 @@ SubCmdExamineInternal::execute(const SubCmdOptions& _options) const
 
   // Filter out reports that are not compatible for the device
   const std::string deviceClass = XBU::get_device_class(options.m_device, m_isUserDomain);
-  ReportCollection runnableReports = validateConfigurables<Report>(deviceClass, std::string("report"), fullReportCollection);
+  // ReportCollection runnableReports = validateConfigurables<Report>(deviceClass, std::string("report"), fullReportCollection);
 
-  // Collect the reports to be processed
-  try {
-    XBU::collect_and_validate_reports(runnableReports, reportsToRun, reportsToProcess);
-  } catch (const xrt_core::error& e) {
-    std::cerr << boost::format("ERROR: %s\n") % e.what();
-    print_help_internal(options);
-    return;
-  }
-
-  // Find device of interest
+ // Find device of interest
   std::shared_ptr<xrt_core::device> device;
   
   try {
@@ -156,6 +147,25 @@ SubCmdExamineInternal::execute(const SubCmdOptions& _options) const
     std::cerr << boost::format("ERROR: %s\n") % e.what();
     throw xrt_core::error(std::errc::operation_canceled);
   }
+
+  ReportCollection runnableReports;
+  if (device){
+    const xrt_core::smi::tuple_vector& reportList = xrt_core::device_query<xrt_core::query::xrt_smi_lists>(device, xrt_core::query::xrt_smi_lists::type::examine_reports);
+    runnableReports = getReportsList(reportList);
+  } else 
+  {
+    runnableReports = validateConfigurables<Report>(deviceClass, std::string("report"), fullReportCollection);
+  }
+  // Collect the reports to be processed
+  try {
+    XBU::collect_and_validate_reports(runnableReports, reportsToRun, reportsToProcess);
+  } catch (const xrt_core::error& e) {
+    std::cerr << boost::format("ERROR: %s\n") % e.what();
+    print_help_internal(options);
+    return;
+  }
+
+ 
 
   bool is_report_output_valid = true;
   // DRC check on devices and reports
@@ -232,4 +242,25 @@ SubCmdExamineInternal::setOptionConfig(const boost::property_tree::ptree &config
   catch (const std::exception& e) {
     std::cerr << "Error: " << e.what() << std::endl;
   }
+}
+
+std::vector<std::shared_ptr<Report>>
+SubCmdExamineInternal::getReportsList(const xrt_core::smi::tuple_vector& reports) const
+{
+  // Vector to store the matched reports
+  std::vector<std::shared_ptr<Report>> matchedReports;
+
+  for (const auto& report : fullReportCollection) {
+    auto it = std::find_if(reports.begin(), reports.end(),
+      [&report](const std::tuple<std::string, std::string, std::string>& rep) {
+        return (std::get<0>(rep) == report->getReportName() && 
+                (std::get<2>(rep) != "hidden" || XBU::getShowHidden()));
+      });
+
+    if (it != reports.end()) {
+      matchedReports.push_back(report);
+    }
+  }
+
+  return matchedReports;
 }

--- a/src/runtime_src/core/tools/common/SubCmdExamineInternal.h
+++ b/src/runtime_src/core/tools/common/SubCmdExamineInternal.h
@@ -6,6 +6,7 @@
 
 #include "tools/common/Report.h"
 #include "tools/common/SubCmd.h"
+#include "core/common/smi.h"
 
 struct SubCmdExamineOptions {
   std::string               m_device;
@@ -32,6 +33,7 @@ class SubCmdExamineInternal : public SubCmd {
   void print_help_internal(const SubCmdExamineOptions&) const;
 
   bool                      m_isUserDomain;
+  std::vector<std::shared_ptr<Report>> getReportsList(const xrt_core::smi::tuple_vector&) const;
 };
 
 #endif

--- a/src/runtime_src/core/tools/common/SubCmdJsonObjects.cpp
+++ b/src/runtime_src/core/tools/common/SubCmdJsonObjects.cpp
@@ -72,7 +72,7 @@ SubCommandOption::addProgramOption(po::options_description& options, const std::
   if (!m_description_array.empty()) {
     std::vector<std::pair<std::string, std::string>> temp;
     for (const auto& desc : m_description_array) {
-      if (desc.getType() == const_hidden_literal) continue;
+      if (desc.getType() == const_hidden_literal && !XBUtilities::getShowHidden()) continue;
       temp.emplace_back(std::make_pair<std::string, std::string>(desc.getName(), desc.getDescription()));
     }
     description += XBUtilities::create_suboption_list_string(temp);

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -727,5 +727,5 @@ SubCmdValidate::getTestList(const xrt_core::smi::tuple_vector& tests) const
     }
   }
 
-  return std::move(matchedTests);
+  return matchedTests;
 }

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -726,6 +726,5 @@ SubCmdValidate::getTestList(const xrt_core::smi::tuple_vector& tests) const
       matchedTests.push_back(runner);
     }
   }
-
   return matchedTests;
 }

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -15,7 +15,6 @@
 #include "tools/common/XBHelpMenusCore.h"
 #include "tools/common/XBUtilitiesCore.h"
 #include "tools/common/XBUtilities.h"
-#include "tools/common/TestRunner.h"
 #include "tools/common/tests/TestAuxConnection.h"
 #include "tools/common/tests/TestPcieLink.h"
 #include "tools/common/tests/TestSCVersion.h"
@@ -573,13 +572,8 @@ SubCmdValidate::execute(const SubCmdOptions& _options) const
     throw xrt_core::error(std::errc::operation_canceled);
   }
 
-  const auto& configs = JSONConfigurable::parse_configuration_tree(m_commandConfig);
-  auto testOptionsMap = JSONConfigurable::extract_subcmd_config<TestRunner, TestRunner>(testSuite, configs, getConfigName(), std::string("test"));
-  const std::string& deviceClass = XBU::get_device_class(options.m_device, true);
-  auto it = testOptionsMap.find(deviceClass);
-  if (it == testOptionsMap.end())
-    XBU::throw_cancel(boost::format("Invalid device class %s. Device: %s") % deviceClass % options.m_device);
-  std::vector<std::shared_ptr<TestRunner>>& testOptions = it->second;
+  const xrt_core::smi::tuple_vector& tests = xrt_core::device_query<xrt_core::query::xrt_smi_lists>(device, xrt_core::query::xrt_smi_lists::type::validate_tests);
+  std::vector<std::shared_ptr<TestRunner>> testOptions = getTestList(tests);
 
   // Collect all of the tests of interests
   std::vector<std::shared_ptr<TestRunner>> testObjectsToRun;
@@ -713,4 +707,25 @@ SubCmdValidate::setOptionConfig(const boost::property_tree::ptree &config)
   catch (const std::exception& e) {
     std::cerr << "Error: " << e.what() << std::endl;
   }
+}
+
+std::vector<std::shared_ptr<TestRunner>>
+SubCmdValidate::getTestList(const xrt_core::smi::tuple_vector& tests) const
+{
+  // Vector to store the matched tests
+  std::vector<std::shared_ptr<TestRunner>> matchedTests;
+
+  for (const auto& runner : testSuite) {
+    auto it = std::find_if(tests.begin(), tests.end(),
+      [&runner](const std::tuple<std::string, std::string, std::string>& test) {
+        return (std::get<0>(test) == runner->getConfigName() && 
+                (std::get<2>(test) != "hidden" || XBU::getShowHidden()));
+      });
+
+    if (it != tests.end()) {
+      matchedTests.push_back(runner);
+    }
+  }
+
+  return std::move(matchedTests);
 }

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.h
@@ -5,9 +5,13 @@
 #ifndef __SubCmdValidate_h_
 #define __SubCmdValidate_h_
 
+#include <memory>
+
 #include <boost/program_options.hpp>
 #include "tools/common/SubCmd.h"
 #include "tools/common/XBHelpMenus.h"
+#include "tools/common/TestRunner.h"
+#include "core/common/smi.h"
 
 struct SubCmdValidateOptions {
   std::string m_device;
@@ -37,6 +41,7 @@ class SubCmdValidate : public SubCmd {
                                         std::vector<std::string>&,
                                         std::vector<std::string>&) const;
   XBUtilities::VectorPairStrings getTestNameDescriptions(const SubCmdValidateOptions&, const bool addAdditionOptions) const;
+  std::vector<std::shared_ptr<TestRunner>> getTestList(const xrt_core::smi::tuple_vector&) const;
 };
 
 #endif


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
This PR implements new device queries for getting the list of validate test names and report names from each shim. This list is then used by xrt-smi to run appropriate validate tests and examine reports. The new query uses the same structures used by xrt-smi help printing to make xrt-smi behavior concurrent between help printing and running tests/reports. 

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://jira.xilinx.com/browse/VITIS-14366

#### How problem was solved, alternative solutions (if any) and why they were rejected
Discovered through internal testing. 

#### Risks (if any) associated the changes in the commits l
None

#### What has been tested and how, request additional testing if necessary
Tested on Linux and windows platforms

#### Documentation impact (if any)
None
