### PR TITLE
Fix for CR-1219106: Handling unrecognized commands for all utilities

### DIFF
--- a/src/runtime_src/core/tools/common/XBMain.cpp
+++ b/src/runtime_src/core/tools/common/XBMain.cpp
@@ -81,9 +81,17 @@ void  main_(int argc, char** argv,
   // Parse the command line arguments
   po::variables_map vm;
   po::command_line_parser parser(argc, argv);
-  SubCmd::SubCmdOptions subcmd_options;
+  SubCmd::SubCmdOptions unrecognized_options;
   try {
-    subcmd_options = XBU::process_arguments(vm, parser, allOptions, positionalCommand, false);
+    unrecognized_options = XBU::process_arguments(vm, parser, allOptions, positionalCommand, false);
+    if (!unrecognized_options.empty())
+    {
+      std::string error_str;
+      error_str.append("Unrecognized arguments:\n");
+      for (const auto& option : unrecognized_options)
+        error_str.append(boost::str(boost::format("  %s\n") % option));
+      throw boost::program_options::error(error_str);
+    }
   } catch (po::error& ex) {
     std::cerr << ex.what() << std::endl;
   }
@@ -168,8 +176,7 @@ void  main_(int argc, char** argv,
     return;
   }
 
-  // -- Prepare the data
-  subcmd_options.erase(subcmd_options.begin());
+  SubCmd::SubCmdOptions subcmd_options;
 
   if (bHelp)
     subcmd_options.push_back("--help");


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Added unrecognized arguments handling at xrt-smi level. This change also affects all other utilities like xbmgmt and xbflash. 

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://jira.xilinx.com/browse/CR-1219106

#### How problem was solved, alternative solutions (if any) and why they were rejected
The problem was solved by handling unrecognized arguments correctly.

#### Risks (if any) associated the changes in the commit
This change might alter the current behaviors for all utilities. There is a possibility that the user might be using the utilities with unrecognized options and tool might start erroring out in those cases

#### What has been tested and how, request additional testing if necessary
Tested on windows platform.

#### Documentation impact (if any)
None
