### PR TITLE
CR-1219118 fix : Order of validate tests and reports should be same as shown in help

### DIFF
--- a/src/runtime_src/core/tools/common/SubCmdExamineInternal.cpp
+++ b/src/runtime_src/core/tools/common/SubCmdExamineInternal.cpp
@@ -249,15 +249,15 @@ SubCmdExamineInternal::getReportsList(const xrt_core::smi::tuple_vector& reports
   // Vector to store the matched reports
   std::vector<std::shared_ptr<Report>> matchedReports;
 
-  for (const auto& report : fullReportCollection) {
-    auto it = std::find_if(reports.begin(), reports.end(),
-      [&report](const std::tuple<std::string, std::string, std::string>& rep) {
-        return (std::get<0>(rep) == report->getReportName() && 
-                (std::get<2>(rep) != "hidden" || XBU::getShowHidden()));
-      });
+  for (const auto& rep : reports) {
+    auto it = std::find_if(fullReportCollection.begin(), fullReportCollection.end(),
+              [&rep](const std::shared_ptr<Report>& report) {
+                return std::get<0>(rep) == report->getReportName() &&
+                       (std::get<2>(rep) != "hidden" || XBU::getShowHidden());
+              });
 
-    if (it != reports.end()) {
-      matchedReports.push_back(report);
+    if (it != fullReportCollection.end()) {
+      matchedReports.push_back(*it);
     }
   }
 

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -715,15 +715,15 @@ SubCmdValidate::getTestList(const xrt_core::smi::tuple_vector& tests) const
   // Vector to store the matched tests
   std::vector<std::shared_ptr<TestRunner>> matchedTests;
 
-  for (const auto& runner : testSuite) {
-    auto it = std::find_if(tests.begin(), tests.end(),
-      [&runner](const std::tuple<std::string, std::string, std::string>& test) {
-        return (std::get<0>(test) == runner->getConfigName() && 
-                (std::get<2>(test) != "hidden" || XBU::getShowHidden()));
-      });
+  for (const auto& test : tests) {
+    auto it = std::find_if(testSuite.begin(), testSuite.end(),
+              [&test](const std::shared_ptr<TestRunner>& runner) {
+                return std::get<0>(test) == runner->getConfigName() &&
+                       (std::get<2>(test) != "hidden" || XBU::getShowHidden());
+              });
 
-    if (it != tests.end()) {
-      matchedTests.push_back(runner);
+    if (it != testSuite.end()) {
+      matchedTests.push_back(*it);
     }
   }
   return matchedTests;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Handles order of validate test run and report generation based on the order of list provided by each shim.
Note the host report still gets printed first when doing xrt-smi examine --report all since that was how the logic is kept.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://jira.xilinx.com/browse/CR-1219113
https://jira.xilinx.com/browse/CR-1219118

#### How problem was solved, alternative solutions (if any) and why they were rejected
The problem was solved using the lists queried from him

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Tested in Windows platform

#### Documentation impact (if any)
None
