### PR TITLE
Adding user profiling and native XRT profiling to VE2 build

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/CMakeLists.txt
+++ b/src/runtime_src/xdp/profile/plugin/CMakeLists.txt
@@ -7,6 +7,8 @@ if(XDP_VE2_BUILD_CMAKE STREQUAL "yes")
   add_subdirectory(aie_trace)
   add_subdirectory(aie_debug)
   add_subdirectory(ml_timeline)
+  add_subdirectory(native)
+  add_subdirectory(user)
 
 elseif (XDP_CLIENT_BUILD_CMAKE STREQUAL "yes")
 


### PR DESCRIPTION
#### Problem solved by the commit
The profiling plugins for tracing user level events and tracing native XRT APIs were not built for VE2 devices so they were not available.

#### Risks (if any) associated the changes in the commit
Low risk as this only builds the plugins, they still need to be enabled by the user on VE2.

#### What has been tested and how, request additional testing if necessary
Integration with other applications that use user-level events must be tested on VE2 after this is built.

#### Documentation impact (if any)
No documentation impact.