### PR TITLE
Fix for CR-1224994 and CR-1226988

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/edge/zocl_edge_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/edge/zocl_edge_xclbin.c
@@ -131,7 +131,7 @@ zocl_xclbin_read_axlf(struct drm_zocl_dev *zdev, struct drm_zocl_axlf *axlf_obj,
 
 	/* Get full axlf header */
 	size_of_header = sizeof(struct axlf_section_header);
-	num_of_sections = axlf_head.m_header.m_numSections - 1;
+	num_of_sections = axlf_head.m_header.m_numSections;
 	axlf_size = sizeof(struct axlf) + size_of_header * num_of_sections;
 	axlf = vmalloc(axlf_size);
 	if (!axlf) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Kernel Crash reported in https://jira.xilinx.com/browse/CR-1224994 and hang with trace enabled reported in https://jira.xilinx.com/browse/CR-1226988
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
#8669  The bug was calculating the size for the axlf buffer in ZOCL. The ZOCL used to calculate the size for axlf with (header_size * number_of_sections). And the number of sections we used to calculate (total_sections_in_xclbin-1). And after supporting flexible arrays this calculation was not valid. And the size of the axlf buffer was coming incorrect and ZOCL was failing to copy the whole axlf buffer from the userspace. And due to this the issues we saw reported on the mentioned CRs.
#### How problem was solved, alternative solutions (if any) and why they were rejected
Problem was solved by correcting the logic to calculate the size for the axlf buffer in ZOCL.
#### Risks (if any) associated the changes in the commit
n/a
#### What has been tested and how, request additional testing if necessary
Tested on multikernel_sharedmem_access testcase based on VCK190 BASE and k2kstrm_II_mismatch_fifo test based on VCK190 DFX
#### Documentation impact (if any)
n/a