### PR TITLE
CR-1228185, CR-1228210 and CR-1228177

### DIFF
--- a/src/runtime_src/core/tools/common/SubCmdExamineInternal.cpp
+++ b/src/runtime_src/core/tools/common/SubCmdExamineInternal.cpp
@@ -114,7 +114,7 @@ SubCmdExamineInternal::execute(const SubCmdOptions& _options) const
       throw xrt_core::error("Please specify an output file to redirect the json to");
 
     if (!options.m_output.empty() && std::filesystem::exists(options.m_output) && !XBU::getForce())
-      throw xrt_core::error((boost::format("The output file '%s' already exists.  Please either remove it or execute this command again with the '--force' option to overwrite it") % options.m_output).str());
+      throw xrt_core::error((boost::format("The output file '%s' already exists. Please either remove it or execute this command again with the '--force' option to overwrite it") % options.m_output).str());
 
   } catch (const xrt_core::error& e) {
     // Catch only the exceptions that we have generated earlier

--- a/src/runtime_src/core/tools/common/SubCmdExamineInternal.cpp
+++ b/src/runtime_src/core/tools/common/SubCmdExamineInternal.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
 
 // ------ I N C L U D E   F I L E S -------------------------------------------
 // Local - Include Files

--- a/src/runtime_src/core/tools/common/XBHelpMenus.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenus.cpp
@@ -228,7 +228,7 @@ XBUtilities::collect_and_validate_reports( const ReportCollection &allReportsAva
     // Examine each report name for a match 
     for (const auto & reportName : reportNamesToAdd) {
       auto iter = std::find_if(allReportsAvailable.begin(), allReportsAvailable.end(), 
-                               [&reportName](const std::shared_ptr<Report>& obj) {return obj->getReportName() == reportName;});
+                               [&reportName](const std::shared_ptr<Report>& obj) {return obj->getReportName() == boost::algorithm::to_lower_copy(reportName);});
       if (iter != allReportsAvailable.end()) 
         reportsToUse.push_back(*iter);
       else {

--- a/src/runtime_src/core/tools/common/XBHelpMenus.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenus.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2020-2022 Xilinx, Inc
-// Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
 
 // ------ I N C L U D E   F I L E S -------------------------------------------
 // Local - Include Files

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -214,20 +214,24 @@ bdf2index(const std::string& bdfstr, bool _inUserDomain)
 
   std::reverse(std::begin(tokens), std::end(tokens));
 
-  //check if func was specified. func is optional
-  auto pos_of_func = tokens[0].find('.');
-  if (pos_of_func != std::string::npos) {
-    dev = static_cast<uint16_t>(std::stoi(std::string(tokens[0].substr(0, pos_of_func)), nullptr, radix));
-    func = static_cast<uint16_t>(std::stoi(std::string(tokens[0].substr(pos_of_func+1)), nullptr, radix));
+try {
+    //check if func was specified. func is optional
+    auto pos_of_func = tokens[0].find('.');
+    if (pos_of_func != std::string::npos) {
+      dev = static_cast<uint16_t>(std::stoi(std::string(tokens[0].substr(0, pos_of_func)), nullptr, radix));
+      func = static_cast<uint16_t>(std::stoi(std::string(tokens[0].substr(pos_of_func+1)), nullptr, radix));
+    }
+    else
+      dev = static_cast<uint16_t>(std::stoi(std::string(tokens[0]), nullptr, radix));
+
+    bus = static_cast<uint16_t>(std::stoi(std::string(tokens[1]), nullptr, radix));
+
+    // domain is not mandatory if it is "0000"
+    if(tokens.size() > 2)
+      domain = static_cast<uint16_t>(std::stoi(std::string(tokens[2]), nullptr, radix));
+  } catch (const std::invalid_argument&) {
+    //ignore
   }
-  else
-    dev = static_cast<uint16_t>(std::stoi(std::string(tokens[0]), nullptr, radix));
-
-  bus = static_cast<uint16_t>(std::stoi(std::string(tokens[1]), nullptr, radix));
-
-  // domain is not mandatory if it is "0000"
-  if(tokens.size() > 2)
-    domain = static_cast<uint16_t>(std::stoi(std::string(tokens[2]), nullptr, radix));
 
   // Iterate through the available devices to find a BDF match
   // This must not open any devices! Doing do would slow down the software

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2019-2022 Xilinx, Inc
-// Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
 
 // ------ I N C L U D E   F I L E S -------------------------------------------
 #include "XBUtilities.h"
@@ -230,7 +230,7 @@ try {
     if(tokens.size() > 2)
       domain = static_cast<uint16_t>(std::stoi(std::string(tokens[2]), nullptr, radix));
   } catch (const std::invalid_argument&) {
-    //ignore
+    throw std::runtime_error(boost::str(boost::format("Invalid BDF '%s'") % bdfstr) + XBUtilities::str_available_devs(_inUserDomain));
   }
 
   // Iterate through the available devices to find a BDF match

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2019-2022 Xilinx, Inc
-// Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
 
 // ------ I N C L U D E   F I L E S -------------------------------------------
 // Local - Include Files

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -458,7 +458,8 @@ SubCmdValidate::handle_errors_and_validate_tests(const boost::program_options::v
     throw xrt_core::error("Please specify an output file to redirect the json to");
 
   if (!options.m_output.empty() && !XBU::getForce() && std::filesystem::exists(options.m_output))
-    throw xrt_core::error((boost::format("Output file already exists: '%s'") % options.m_output).str());
+    throw xrt_core::error((boost::format("The output file '%s' already exists. Please either remove it or execute this command again with the '--force' option to overwrite it") % options.m_output).str());
+
 
   if (options.m_tests_to_run.empty())
     throw xrt_core::error("No test given to validate against.");


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
- [CR-1228185](https://jira.xilinx.com/browse/CR-1228185) stoi() error when invalid argument supplied to xrt-smi examine -d
- [CR-1228210](https://jira.xilinx.com/browse/CR-1228210) xrt-smi validate -r accept upper case but seems xrt-smi examine -r does not
- [CR-1228177](https://jira.xilinx.com/browse/CR-1228177) Error Message Lacking --force

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
DSV bash testing

#### How problem was solved, alternative solutions (if any) and why they were rejected
- added try/catch to handle stoi error
- added boost::lower_to_copy to mimic examine behavior
- Updated message

#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
tested on linux

#### Documentation impact (if any)
N/A
