### PR TITLE
CR-1219148 Fix --pmode in xrt-smi configure help menu

### DIFF
--- a/src/runtime_src/core/tools/common/XBHelpMenusCore.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenusCore.cpp
@@ -549,7 +549,7 @@ display_subcommand_options(const std::string& executable,
   if (usageSuboption.empty())
     std::cout << boost::format(fh.fgc_header + "\nUSAGE: " + fh.fgc_usageBody + "%s %s %s\n" + fh.fgc_reset) % executable % subcommand % usage;
   else
-    std::cout << boost::format(fh.fgc_header + "\nUSAGE: " + fh.fgc_usageBody + "%s %s [ %s ] %s\n" + fh.fgc_reset) % executable % subcommand % usageSuboption % usage;
+    std::cout << boost::format(fh.fgc_header + "\nUSAGE: " + fh.fgc_usageBody + "%s %s %s %s\n" + fh.fgc_reset) % executable % subcommand % usageSuboption % usage;
 
   std::map<std::string, std::vector<std::shared_ptr<JSONConfigurable>>> commonJsonOptions;
   if (commandConfig.empty())

--- a/src/runtime_src/core/tools/common/XBHelpMenusCore.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenusCore.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2020-2022 Xilinx, Inc
-// Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
 // ------ I N C L U D E   F I L E S -------------------------------------------
 // Local - Include Files
 #include "XBHelpMenusCore.h"


### PR DESCRIPTION
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1219148
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
During internal testing, found [--pmode] option in brackets for xrt-smi configure help menu was misleading, as it is a required option.
#### How problem was solved, alternative solutions (if any) and why they were rejected
Removed the square brackets from formatting string.
#### Risks (if any) associated the changes in the commit
N/A
#### What has been tested and how, request additional testing if necessary
Tested on Linux and STX/MCDM, verified that help menus for examine and validate were not broken in the process.
```
C:\Users\rchane\Desktop\xrt>xrt-smi configure --help

COMMAND: configure

DESCRIPTION: Device and host configuration.

USAGE: xrt-smi configure --pmode [-h] [-d arg]

OPTIONS:
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest
  -h, --help         - Help to use this sub-command
  --pmode            - Modes: default, powersaver, balanced, performance, turbo


GLOBAL OPTIONS:
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
```
#### Documentation impact (if any)
N/A