### PR TITLE
supporting ubuntu 2404 builds for master pipeline

### DIFF
--- a/.github/workflows/xrt_master_2025.1.yml
+++ b/.github/workflows/xrt_master_2025.1.yml
@@ -32,7 +32,10 @@ jobs:
             os_ver: ubuntu_20.04      
           - os: hip      
             packageType: deb
-            os_ver: ubuntu_22.04 
+            os_ver: ubuntu_22.04
+          - os: ubuntu2404      
+            packageType: deb
+            os_ver: ubuntu_24.04  
           - os: npu      
             packageType: deb
             os_ver: ubuntu_22.04    


### PR DESCRIPTION
Support ubuntu 2404 builds for master pipeline as per the request of this SR-964568
