### PR TITLE
Added aie, aiemem, aieshim reports to the ryzen class of devices

### DIFF
--- a/src/runtime_src/core/tools/xbutil2/xbutil.cpp
+++ b/src/runtime_src/core/tools/xbutil2/xbutil.cpp
@@ -56,7 +56,7 @@ R"(
 },{
   "aie": [{
     "examine": [{
-      "report": ["host", "platform", "aie-partitions", "telemetry"]
+      "report": ["aie", "aiemem", "aieshim", "host", "platform", "aie-partitions", "telemetry"]
     }]
   },{
     "configure": [{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Added aie, aiemem, aieshim reports to the ryzen class of devices

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
We are using ryzen device type on the Telluride side, and it is essential to enable these reports in order to get the status of AIE.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added requied reports on the Ryzen device in order to generate them.

#### Risks (if any) associated the changes in the commit
low

#### What has been tested and how, request additional testing if necessary
Tested by building and running multi-layer, vadd, eff_net test cases on the  telluride.

#### Documentation impact (if any)
