### PR TITLE
AWS: Clean up DRM FDs before PCI rescan post axlf load

### DIFF
--- a/src/runtime_src/core/common/drv/include/kds_core.h
+++ b/src/runtime_src/core/common/drv/include/kds_core.h
@@ -196,6 +196,7 @@ void kds_reset(struct kds_sched *kds);
 int kds_cfg_update(struct kds_sched *kds);
 void kds_cus_irq_enable(struct kds_sched *kds, bool enable);
 int is_bad_state(struct kds_sched *kds);
+u32 kds_get_open_clients(struct kds_sched *kds, pid_t **plist);
 u32 kds_live_clients(struct kds_sched *kds, pid_t **plist);
 u32 kds_live_clients_nolock(struct kds_sched *kds, pid_t **plist);
 int kds_add_cu(struct kds_sched *kds, struct xrt_cu *xcu);

--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -1810,6 +1810,37 @@ int is_bad_state(struct kds_sched *kds)
 	return kds->bad_state;
 }
 
+u32 kds_get_open_clients(struct kds_sched *kds, pid_t **plist)
+{
+	const struct list_head *ptr;
+        struct kds_client *client;
+        pid_t *pl = NULL;
+        u32 count = kds->num_client;
+        u32 i = 0;
+	printk("karthik kds core count=%d", count);
+	if (count == 0 || plist == NULL)
+                return 0;
+
+        mutex_lock(&kds->lock);
+	/* Collect list of PIDs of active client */
+        pl = (pid_t *)vmalloc(sizeof(pid_t) * count);
+        if (pl == NULL)
+		return 0;
+
+	/* Get Open clients */
+	list_for_each(ptr, &kds->clients) {
+		client = list_entry(ptr, struct kds_client, link);
+		pl[i] = pid_nr(client->pid);
+		i++;
+	}
+
+	*plist = pl;
+        mutex_unlock(&kds->lock);
+
+        return count;
+}
+
+
 u32 kds_live_clients(struct kds_sched *kds, pid_t **plist)
 {
 	u32 count = 0;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/common.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/common.h
@@ -252,6 +252,7 @@ int xocl_kds_reconfig(struct xocl_dev *xdev);
 int xocl_cu_map_addr(struct xocl_dev *xdev, u32 cu_idx,
 		     struct drm_file *filp, unsigned long size, u32 *addrp);
 u32 xocl_kds_live_clients(struct xocl_dev *xdev, pid_t **plist);
+u32 xocl_kds_get_open_clients(struct xocl_dev *xdev, pid_t **plist);
 int xocl_kds_update(struct xocl_dev *xdev, struct drm_xocl_kds kds_cfg);
 void xocl_kds_cus_enable(struct xocl_dev *xdev);
 void xocl_kds_cus_disable(struct xocl_dev *xdev);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -1098,6 +1098,11 @@ u32 xocl_kds_live_clients(struct xocl_dev *xdev, pid_t **plist)
 	return kds_live_clients(&XDEV(xdev)->kds, plist);
 }
 
+u32 xocl_kds_get_open_clients(struct xocl_dev *xdev, pid_t **plist)
+{
+        return kds_get_open_clients(&XDEV(xdev)->kds, plist);
+}
+
 static int xocl_kds_get_mem_idx(struct xocl_dev *xdev, int ip_index,
 		uint32_t slot_id)
 {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
AWS performs a pci rescan to change the PCI device ID during the first image load.
If there are any references to DRM render files which are not closed during the pci rescan,
XRT driver hangs waiting for ever to get the driver instance closed which usually happens if the DRM FDs are closed.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
XRT hangs indefinity in AWS environment during the PCI rescan after axlf load.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Fix is to close all the opened DRM render FDs below the PCI rescan is issued.

#### Risks (if any) associated the changes in the commit
This is AWS specific change, would not impact other cards.

#### What has been tested and how, request additional testing if necessary
Ran RTL kernel APP to see the all the FDs are closed before PCI rescan, no hang observed.
#### Documentation impact (if any)
NA