### PR TITLE
Add missing library destination for capture library

### DIFF
--- a/src/runtime_src/core/tools/xbtracer/src/lib/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbtracer/src/lib/CMakeLists.txt
@@ -22,4 +22,5 @@ endif()
 # it does not have a library or namelink component
 install(TARGETS xrt_capture
   RUNTIME DESTINATION ${XRT_INSTALL_BIN_DIR} COMPONENT ${XRT_BASE_COMPONENT}
+  LIBRARY DESTINATION ${XRT_INSTALL_LIB_DIR} COMPONENT ${XRT_BASE_COMPONENT}
 )


### PR DESCRIPTION
#### Problem solved by the commit
The libxrt_capture.so is plug-in runtime loaded library it must be released to library destination on Linux and runtime destination on windows.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Noticed stray libxrt_capture.so under CMAKE_INSTALL_PREFIX because of the missing library destinaton for the install target.

