### PR TITLE
Remove improper set of CMAKE_INSTALL_PREFIX

### DIFF
--- a/src/CMake/nativeWin.cmake
+++ b/src/CMake/nativeWin.cmake
@@ -9,9 +9,6 @@
 # XRT_VERSION_MINOR
 # XRT_VERSION_PATCH
 
-# install under c:/xrt
-set (CMAKE_INSTALL_PREFIX "${PROJECT_BINARY_DIR}/xilinx")
-
 # pdb install dir
 set (CMAKE_PDB_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/symbols")
 


### PR DESCRIPTION
#### How problem was solved, alternative solutions (if any) and why they were rejectedCMAKE_INSTALL_PREFIX is controlled by caller and shouldn't be changed.

The override in nativeWin.cmake has not effect anyway because it wasn't forced, but regardless it was confusing for debug prints.
