### PR TITLE
Add timeout err msg

### DIFF
--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -316,6 +316,7 @@ run_test_suite_device( const std::shared_ptr<xrt_core::device>& device,
       ptTest = testPtr->startTest(device);
     } catch (const std::exception&) {
       ptTest = testPtr->get_test_header();
+      XBValidateUtils::logger(ptTest, "Error", "The test timed out");
       ptTest.put("status", test_token_failed);
     }
     ptDeviceTestSuite.push_back( std::make_pair("", ptTest) );


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
When a test times out, we exit without logging any error msg. This makes debugging in production env hard

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
During recent GeMM test failure when clocks don't reach the required freq

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added a log 

#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
On linux:
```
% xrt-smi validate -d 17:00 -r verify
Validate Device           : [0000:17:00.1]
    Platform              : xilinx_u30_gen3x4_base_2
    SC Version            : 6.3.9
    Platform ID           : 7F2A9619-6D07-9610-DEF6-0B81EC18DBAA
-------------------------------------------------------------------------------
Test 1 [0000:17:00.1]     : verify                                              
    Error(s)              : The test timed out
    Test Status           : [FAILED]
-------------------------------------------------------------------------------
Validation failed. Please run the command '--verbose' option for more details
```

#### Documentation impact (if any)
