### PR TITLE
Add CMAKE_INSTALL_PREFIX when building on WSL

### DIFF
--- a/build/build-win22.sh
+++ b/build/build-win22.sh
@@ -21,6 +21,7 @@ usage()
     echo
     echo "[-help]                    List this help"
     echo "[clean|-clean]             Remove build directories"
+    echo "[-prefix]                  CMAKE_INSTALL_PREFIX (default: $BUILDDIR/<WRelease|WDebug>/xilinx)"
     echo "[-cmake]                   CMAKE executable (default: $CMAKE)"
     echo "[-ext]                     Location of link dependencies (default: $EXT_DIR)"
     echo "[-boost]                   BOOST libaries root directory (default: $BOOST)"
@@ -35,6 +36,7 @@ usage()
 }
 
 clean=0
+prefix=
 jcore=$CORE
 nocmake=0
 noabi=0
@@ -52,6 +54,11 @@ while [ $# -gt 0 ]; do
             ;;
         clean|-clean)
             clean=1
+            shift
+            ;;
+        -prefix)
+            shift
+            prefix="$1"
             shift
             ;;
 	-cmake)
@@ -153,6 +160,12 @@ if [ $dbg == 1 ]; then
     mkdir -p WDebug
     cd WDebug
 
+    if [[ $prefix == "" ]]; then
+        cmake_flags+=" -DCMAKE_INSTALL_PREFIX=$BUILDDIR/WDebug/xilinx"
+    else
+        cmake_flags+=" -DCMAKE_INSTALL_PREFIX=$prefix"
+    fi
+
     if [ $nocmake == 0 ]; then
         echo "${cmake_flags[@]}"
         "$CMAKE" -G "Visual Studio 17 2022" $cmake_flags ../../src
@@ -165,6 +178,13 @@ if [ $release == 1 ]; then
     cmake_flags+=" -DCMAKE_BUILD_TYPE=Release"
     mkdir -p WRelease
     cd WRelease
+
+    if [[ $prefix == "" ]]; then
+        cmake_flags+=" -DCMAKE_INSTALL_PREFIX=$BUILDDIR/WRelease/xilinx"
+    else
+        cmake_flags+=" -DCMAKE_INSTALL_PREFIX=$prefix"
+    fi
+    
     if [ $nocmake == 0 ]; then
         echo "${cmake_flags[@]}"
         "$CMAKE" -G "Visual Studio 17 2022" $cmake_flags ../../src


### PR DESCRIPTION
#### Problem solved by the commit
Set CMAKE_INSTALL_PREFIX in build script to default or specified location.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
In #8758, the control of CMAKE_INSTALL_PREFIX was removed from nativeWin.cmake, but this results in default install prefix is `C:\Program Files` if not explicitly set by build script.

#### How problem was solved, alternative solutions (if any) and why they were rejected
In this PR, the WSL build script is amended to use default install prefix if none is specified.  The default behavior mirrors that of build22.bat.