### PR TITLE
Fix compile error for NPU

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_profile/util/aie_profile_util.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/util/aie_profile_util.cpp
@@ -794,12 +794,12 @@ namespace xdp::aie::profile {
     std::vector<bool> overflows;
     uint32_t numCounters = UC_NUM_EVENT_COUNTERS + UC_NUM_LATENCY_COUNTERS;
     for (uint32_t c=0; c < numCounters; ++c) {
-      uint32_t val;
-      XAie_Read32(aieDevInst, tileOffset + UC_MDM_PCSR, &val);
-      bool overflow = (((val >> UC_MDM_PCSR_OVERFLOW_BIT) & 0x1) == 1);
+      uint32_t val1;
+      XAie_Read32(aieDevInst, tileOffset + UC_MDM_PCSR, &val1);
+      bool overflow = (((val1 >> UC_MDM_PCSR_OVERFLOW_BIT) & 0x1) == 1);
       overflows.push_back(overflow);
 
-      if ((val >> UC_MDM_PCSR_FULL_BIT) & 0x1) {
+      if ((val1 >> UC_MDM_PCSR_FULL_BIT) & 0x1) {
         std::cout << "Full bit of tile " << col << "," << row << " microcontroller counter " 
                   << c << " is high" << std::endl;
       }
@@ -810,9 +810,9 @@ namespace xdp::aie::profile {
 
     // 5. Read values of event counters
     for (uint32_t c=0; c < UC_NUM_EVENT_COUNTERS; ++c) {
-      uint32_t val;
-      XAie_Read32(aieDevInst, tileOffset + UC_MDM_PCDRR, &val);
-      uint64_t val2 = (overflows.at(c)) ? (val + OVERFLOW_32BIT) : val;
+      uint32_t val1;
+      XAie_Read32(aieDevInst, tileOffset + UC_MDM_PCDRR, &val1);
+      uint64_t val2 = (overflows.at(c)) ? (val1 + OVERFLOW_32BIT) : val1;
       values.push_back(val2);
     }
 
@@ -824,9 +824,9 @@ namespace xdp::aie::profile {
     //             15:0  Maximum measured latency, 16 bits
     std::vector<uint64_t> latencyValues;
     for (uint32_t c=0; c < UC_MDM_PCDRR_LATENCY_READS; ++c) {
-      uint32_t val;
-      XAie_Read32(aieDevInst, tileOffset + UC_MDM_PCDRR, &val);
-      uint64_t val2 = (overflows.at(UC_NUM_EVENT_COUNTERS)) ? (val + OVERFLOW_32BIT) : val;
+      uint32_t val1;
+      XAie_Read32(aieDevInst, tileOffset + UC_MDM_PCDRR, &val1);
+      uint64_t val2 = (overflows.at(UC_NUM_EVENT_COUNTERS)) ? (val1 + OVERFLOW_32BIT) : val1;
       latencyValues.push_back(val2);
     }
 


### PR DESCRIPTION
#### Problem solved by the commit
Amend #8757

```
aie_profile_util.cpp(797,16): warning C4456: declaration of 'val' hides previous local declaration
aie_profile_util.cpp(797,16): error C2220: the following warning is treated as an error
```

