### PR TITLE
[XDP]: Fix for specific metric sets drops from configuration

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_metadata.cpp
@@ -520,7 +520,7 @@ namespace xdp {
       if ((minCol > maxCol) || (minRow > maxRow)) {
         std::stringstream msg;
         msg << "Tile range specification in tile_based_" << modName
-            << "_metrics is not valid format and hence skipped.";
+            << "_metrics is not a valid range ({col1,row1}<={col2,row2}) and hence skipped.";
         xrt_core::message::send(severity_level::warning, "XRT", msg.str());
         continue;
       }

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_metadata.cpp
@@ -494,9 +494,9 @@ namespace xdp {
         maxRow = aie::convertStringToUint8(maxTile[1]) + rowOffset;
       } catch (...) {
         std::stringstream msg;
-        msg << "Tile range specification in tile_based_" << tileName
-            << "_tile_metrics is not of valid format and hence skipped [1].";
-        xrt_core::message::send(severity_level::warning, "XRT", msg.str());
+        msg << "Valid Tile range specification in tile_based_" << tileName
+            << "_tile_metrics is not met, it will re-processed for single-tile specification.";
+        xrt_core::message::send(severity_level::info, "XRT", msg.str());
         continue;       
       }
 
@@ -505,8 +505,8 @@ namespace xdp {
       // Ensure range is valid 
       if ((minCol > maxCol) || (minRow > maxRow)) {
         std::stringstream msg;
-        msg << "Tile range specification in tile_based_" << tileName 
-            << "_tile_metrics is not of valid format and hence skipped [2].";
+        msg << "Tile range specification in tile_based_" << tileName
+            << "_tile_metrics is not of valid range ({col1,row1}<={col2,row2}) and hence skipped.";
         xrt_core::message::send(severity_level::warning, "XRT", msg.str());
         continue;
       }

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_metadata.cpp
@@ -474,7 +474,6 @@ namespace xdp {
       if ((processed.find(i) != processed.end()) || (metrics[i].size() < 3))
         continue;
       
-      processed.insert(i);
       uint8_t minCol = 0, minRow = 0;
       uint8_t maxCol = 0, maxRow = 0;
 
@@ -496,16 +495,18 @@ namespace xdp {
       } catch (...) {
         std::stringstream msg;
         msg << "Tile range specification in tile_based_" << tileName
-            << "_tile_metrics is not of valid format and hence skipped.";
+            << "_tile_metrics is not of valid format and hence skipped [1].";
         xrt_core::message::send(severity_level::warning, "XRT", msg.str());
         continue;       
       }
+
+      processed.insert(i);
 
       // Ensure range is valid 
       if ((minCol > maxCol) || (minRow > maxRow)) {
         std::stringstream msg;
         msg << "Tile range specification in tile_based_" << tileName 
-            << "_tile_metrics is not of valid format and hence skipped.";
+            << "_tile_metrics is not of valid format and hence skipped [2].";
         xrt_core::message::send(severity_level::warning, "XRT", msg.str());
         continue;
       }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Few of the metrics were dropped from configuration as those were marked as processed under range-based tile specification.
e.g. 
`{0,1}:s2mm_channels_stalls:0`

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
NA

#### How problem was solved, alternative solutions (if any) and why they were rejected
Code now marks it as processed only after passing certain initial error checks.

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
MCDM Build & Test on Client.

#### Documentation impact (if any)
