### PR TITLE
CR-1229935 Fix validate return status on exception

### DIFF
--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -318,6 +318,7 @@ run_test_suite_device( const std::shared_ptr<xrt_core::device>& device,
       ptTest = testPtr->get_test_header();
       XBValidateUtils::logger(ptTest, "Error", "The test timed out");
       ptTest.put("status", test_token_failed);
+      status = test_status::failed;
     }
     ptDeviceTestSuite.push_back( std::make_pair("", ptTest) );
 


### PR DESCRIPTION
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1229935
xrt-smi validate return code was 0 even after gemm test failed.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Discovered while internally testing xrt-smi on STX.
#### How problem was solved, alternative solutions (if any) and why they were rejected
Test status was not set to failed in event of execution exception (e.g. timeout)
#### Risks (if any) associated the changes in the commit
N/A
#### What has been tested and how, request additional testing if necessary
Still need to test on machine for final confirmation, starting pipeline first...
#### Documentation impact (if any)
N/A