### PR TITLE
[XDP] Fix AIE Debug on Client

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_debug/aie_debug_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_debug/aie_debug_plugin.cpp
@@ -182,7 +182,7 @@ namespace xdp {
 #ifdef _WIN32
     std::tm tm{};
     localtime_s(&tm, &time);
-    std::string deviceName = "win_device";
+    std::string deviceName = "aie_debug_win_device";
 #else
     auto tm = *std::localtime(&time);
     std::string deviceName = util::getDeviceName(handle);

--- a/src/runtime_src/xdp/profile/plugin/aie_debug/aie_debug_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_debug/aie_debug_plugin.cpp
@@ -193,11 +193,9 @@ namespace xdp {
     std::string timestamp = timeOss.str();
 
     std::string outputFile = "aie_debug_" + deviceName + timestamp + ".csv";
-    VPWriter* writer = new AIEDebugWriter(outputFile.c_str(), deviceName.c_str(), mIndex);
+    VPWriter* writer = new AIEDebugWriter(outputFile.c_str(), deviceName.c_str(), deviceID);
     writers.push_back(writer);
     db->getStaticInfo().addOpenedFile(writer->getcurrentFileName(), "AIE_DEBUG");
-
-    mIndex++;
   }
 
   /****************************************************************************

--- a/src/runtime_src/xdp/profile/plugin/aie_debug/aie_debug_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_debug/aie_debug_plugin.h
@@ -43,7 +43,6 @@ namespace xdp {
   private:
     static bool live;
     bool mPollRegisters = true;
-    uint32_t mIndex = 0;
 
     // This struct and handleToAIEData map is created to provision multiple AIEs
     // on the same machine, each denoted by its own handle

--- a/src/runtime_src/xdp/profile/plugin/aie_debug/client/aie_debug.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_debug/client/aie_debug.cpp
@@ -162,7 +162,7 @@ namespace xdp {
       // Traverse all active tiles for this module type
       for (auto& tileMetric : configMetrics) {
         auto tile        = tileMetric.first;
-        auto tileOffset  = XAie_GetTileAddr(&aieDevInst, tile.row, tile.col);
+        auto tileOffset = (tile.col << 25) + (tile.row << 20);
 
         for (int i = 0; i < Regs.size(); i++) {
           op_debug_data.emplace_back(register_data_t{Regs[i] + tileOffset});


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
On Client, AIE Debug was running into issues after recent re-architecture of the plugin. This also marks the completion of testing of re-architecture of the aie-debug on client.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
- register read was not working
- trace_config/profile_config was not working
- AIE Debug summary report was not getting generated.

#### How problem was solved, alternative solutions (if any) and why they were rejected
- Offset of the tile was including AIE Base address which is not needed in LX controllers.
- DeviceID for plugin and its writer wasn't matching.
- DeviceID for plugin was also matching with AIE Profile plugin if used in parallel.

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
MCDM: Verified on Client

#### Documentation impact (if any)
Known issues: If trace_config contains huge list of registers, currently transactions to read it fails. That is being debugged.