### PR TITLE
Removed hardcoded num_cols for VE2 in XDP

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_trace/ve2/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/ve2/aie_trace.cpp
@@ -297,10 +297,6 @@ namespace xdp {
     uint8_t startCol = static_cast<uint8_t>(aiePartitionPt.front().second.get<uint64_t>("start_col"));
     uint8_t numCols  = static_cast<uint8_t>(aiePartitionPt.front().second.get<uint64_t>("num_cols"));
     
-    //TODO: Remove below 2 lines once aie_partition_info from XRT returns correct values
-    const char* envNumCols = std::getenv("NUM_COLS");
-    numCols = envNumCols ? static_cast<uint8_t>(std::stoi(envNumCols)) : 4 ;
-    
     // Get channel configurations (memory and interface tiles)
     auto configChannel0 = metadata->getConfigChannel0();
     auto configChannel1 = metadata->getConfigChannel1();


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Removed hardcoded num_cols which was done because aie_partition query was giving incorrect values. It has been fixed by XRT now.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
NA
#### How problem was solved, alternative solutions (if any) and why they were rejected
Removing the hardcoding of num_cols and started using aie_partition query to provide num_cols.
#### Risks (if any) associated the changes in the commit
NA
#### What has been tested and how, request additional testing if necessary
Tested trace for eff_net design on VE2
#### Documentation impact (if any)
NA