### PR TITLE
set FOP_UNSIGNED_OFFSET flag to handle file offset correctly

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/common/zocl_drv.c
+++ b/src/runtime_src/core/edge/drm/zocl/common/zocl_drv.c
@@ -1009,6 +1009,9 @@ static const struct file_operations zocl_driver_fops = {
 	.read           = drm_read,
 	.unlocked_ioctl = drm_ioctl,
 	.release        = drm_release,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
+        .fop_flags      = FOP_UNSIGNED_OFFSET,
+#endif
 };
 
 static struct drm_driver zocl_driver = {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1227677 drm_open call is faling if we are not setting this flag

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://gitenterprise.xilinx.com/Linux/linux-xlnx/blob/2a6854d26575157bd8d2fdfc885637e66337b591/drivers/gpu/drm/drm_file.c#L312  - If this flag is not set drm_open_helper funciton will return EINVAL. 

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added the flag on fops structure in the zocl driver.

#### Risks (if any) associated the changes in the commit
low
#### What has been tested and how, request additional testing if necessary
Tested vadd test case on vck190 

#### Documentation impact (if any)
NA