### PR TITLE
Remove EXPORT target for internal library

### DIFF
--- a/src/runtime_src/xdp/profile/CMakeLists.txt
+++ b/src/runtime_src/xdp/profile/CMakeLists.txt
@@ -36,9 +36,9 @@ target_link_libraries(xdp_core PRIVATE xrt_coreutil)
 
 set_target_properties(xdp_core PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
 
-# xdp_cre is not an end-user link library, so skip the name link
+# xdp_core is not an end-user link library, so skip the name link
+# and do not add to xrt-targets.
 install(TARGETS xdp_core
-  EXPORT xrt-targets
   RUNTIME DESTINATION ${XRT_INSTALL_BIN_DIR} COMPONENT ${XRT_COMPONENT}
   LIBRARY DESTINATION ${XRT_INSTALL_LIB_DIR} COMPONENT ${XRT_COMPONENT} NAMELINK_SKIP)
 


### PR DESCRIPTION
#### Problem solved by the commit
xdp_core is an internal library, it should have no namelink and it should not be added to the exported targets.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
The library was incorrectly showing up in the xrt-target-release.cmake used by find_package.

