### PR TITLE
CR-1229258 seeing "[XRT] ERROR: Can't Reset AIE: AIE is not initializ…

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/edge/zocl_edge_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/edge/zocl_edge_xclbin.c
@@ -163,6 +163,11 @@ zocl_xclbin_read_axlf(struct drm_zocl_dev *zdev, struct drm_zocl_axlf *axlf_obj,
 			// We come here if user sets force_xclbin_program
 			// option "true" in xrt.ini under [Runtime] section
 			DRM_WARN("%s Force xclbin download", __func__);
+
+		} else if((slot->aie) && (slot->aie->aie_reset == true)) { 
+			//since AIE reset happened load xclbin again
+			DRM_WARN("%s After AIE reset, loading xclbin again", __func__);
+
 		} else if (!is_aie_only(axlf)) {
 			DRM_INFO("xclbin already downloaded to slot=%d", slot_id);
 			vfree(axlf);

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -1991,6 +1991,13 @@ registerAieArray()
   aied = std::make_unique<zynqaie::aied>(mCoreDevice.get());
 }
 
+void
+shim::
+reset_aie_array()
+{
+  m_aie_array.reset();
+}
+
 bool
 shim::
 isAieRegistered()
@@ -2009,7 +2016,9 @@ int
 shim::
 resetAIEArray(drm_zocl_aie_reset &reset)
 {
-  return ioctl(mKernelFD, DRM_IOCTL_ZOCL_AIE_RESET, &reset) ? -errno : 0;
+  auto ret = ioctl(mKernelFD, DRM_IOCTL_ZOCL_AIE_RESET, &reset) ? -errno : 0;
+  reset_aie_array();
+  return ret;
 }
 
 int

--- a/src/runtime_src/core/edge/user/shim.h
+++ b/src/runtime_src/core/edge/user/shim.h
@@ -346,6 +346,7 @@ public:
   zynqaie::aied* getAied();
   int getBOInfo(drm_zocl_info_bo &info);
   void registerAieArray();
+  void reset_aie_array();
   bool isAieRegistered();
   int getPartitionFd(drm_zocl_aie_fd &aiefd);
   int resetAIEArray(drm_zocl_aie_reset &reset);


### PR DESCRIPTION
…ed" error

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

Properly resetting aie array upon resetAieArray() is called , so that for next loadXclbin, aie Array can be initialized properly

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

N/A

#### How problem was solved, alternative solutions (if any) and why they were rejected

Resetting aie array shared pointer

#### Risks (if any) associated the changes in the commit

N/A

#### What has been tested and how, request additional testing if necessary

simple_graph

#### Documentation impact (if any)

N/A
