### PR TITLE
[XDP] Better handle partition shifts in VE2

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_trace/client/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/client/aie_trace.cpp
@@ -966,6 +966,7 @@ namespace xdp {
       auto& metricSet = tileMetric.second;
       auto tile       = tileMetric.first;
       auto col        = tile.col;
+      auto colReport  = col + startCol;
       auto row        = tile.row;
       auto subtype    = tile.subtype;
       auto type       = getTileType(row);
@@ -999,7 +1000,7 @@ namespace xdp {
       }
 
       // AIE config object for this tile
-      auto cfgTile = std::make_unique<aie_cfg_tile>(col+startCol, row, type);
+      auto cfgTile = std::make_unique<aie_cfg_tile>(colReport, row, type);
       cfgTile->type = type;
       cfgTile->trace_metric_set = metricSet;
       cfgTile->active_core = tile.active_core;

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/ve2/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/ve2/aie_trace.cpp
@@ -862,18 +862,11 @@ namespace xdp {
         }
 
         auto shimTrace = shim.traceControl();
-
-        if ((col == 0) && compilerOptions.enable_multi_layer 
-            && xrt_core::config::get_aie_trace_settings_trace_start_broadcast())
-        {
-          if (shimTrace->setCntrEvent(XAIE_EVENT_COMBO_EVENT_0_PL, interfaceTileTraceEndEvent) != XAIE_OK)
-            break;
-        }
-        else
-        {
-          if (shimTrace->setCntrEvent(interfaceTileTraceStartEvent, interfaceTileTraceEndEvent) != XAIE_OK)
-            break;
-        }
+        XAie_Events shimStart = ((col == 0) && compilerOptions.enable_multi_layer 
+                                 && xrt_core::config::get_aie_trace_settings_trace_start_broadcast())
+                              ? XAIE_EVENT_COMBO_EVENT_0_PL : interfaceTileTraceStartEvent;
+        if (shimTrace->setCntrEvent(shimStart, interfaceTileTraceEndEvent) != XAIE_OK)
+          break;
 
         auto ret = shimTrace->reserve();
         if (ret != XAIE_OK) {


### PR DESCRIPTION
#### Problem solved by the commit
Columns in shifted partitions are not reported correctly, hence, trace display is incorrect

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
None

#### How problem was solved, alternative solutions (if any) and why they were rejected
Use relative columns with driver but shifted columns when reporting

#### Risks (if any) associated the changes in the commit
Differences still exist between zocl and HW context flows; need to be worked out in future PR

#### What has been tested and how, request additional testing if necessary
Tested on VE2 board

#### Documentation impact (if any)
Tile locations will be reported at shifted locations