### PR TITLE
[XDP] Core/Memory module trace for the tiles in same column

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_debug/aie_debug_metadata.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_debug/aie_debug_metadata.h
@@ -278,6 +278,10 @@ public:
     core_addresses.emplace(aie1::cm_event_broadcast13);
     core_addresses.emplace(aie1::cm_event_broadcast14);
     core_addresses.emplace(aie1::cm_event_broadcast15);
+    core_addresses.emplace(aie1::cm_event_broadcast_block_south_value);
+    core_addresses.emplace(aie1::cm_event_broadcast_block_west_value);
+    core_addresses.emplace(aie1::cm_event_broadcast_block_north_value);
+    core_addresses.emplace(aie1::cm_event_broadcast_block_east_value);
     core_addresses.emplace(aie1::cm_timer_trig_event_low_value);
     core_addresses.emplace(aie1::cm_timer_trig_event_high_value);
     core_addresses.emplace(aie1::cm_timer_low);
@@ -1650,6 +1654,10 @@ public:
     core_addresses.emplace(aie2::cm_event_broadcast13);
     core_addresses.emplace(aie2::cm_event_broadcast14);
     core_addresses.emplace(aie2::cm_event_broadcast15);
+    core_addresses.emplace(aie2::cm_event_broadcast_block_south_value);
+    core_addresses.emplace(aie2::cm_event_broadcast_block_west_value);
+    core_addresses.emplace(aie2::cm_event_broadcast_block_north_value);
+    core_addresses.emplace(aie2::cm_event_broadcast_block_east_value);
     core_addresses.emplace(aie2::cm_timer_trig_event_low_value);
     core_addresses.emplace(aie2::cm_timer_trig_event_high_value);
     core_addresses.emplace(aie2::cm_timer_low);
@@ -4627,6 +4635,10 @@ public:
     core_addresses.emplace(aie2ps::cm_event_broadcast13);
     core_addresses.emplace(aie2ps::cm_event_broadcast14);
     core_addresses.emplace(aie2ps::cm_event_broadcast15);
+    core_addresses.emplace(aie2ps::cm_event_broadcast_block_south_value);
+    core_addresses.emplace(aie2ps::cm_event_broadcast_block_west_value);
+    core_addresses.emplace(aie2ps::cm_event_broadcast_block_north_value);
+    core_addresses.emplace(aie2ps::cm_event_broadcast_block_east_value);
     core_addresses.emplace(aie2ps::cm_timer_trig_event_low_value);
     core_addresses.emplace(aie2ps::cm_timer_trig_event_high_value);
     core_addresses.emplace(aie2ps::cm_timer_low);

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/client/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/client/aie_trace.cpp
@@ -1206,7 +1206,6 @@ namespace xdp {
           for (uint8_t i = 8; i < 16; i++)
             if (XAie_EventBroadcastUnblockDir(&aieDevInst, loc, XAIE_CORE_MOD, XAIE_EVENT_SWITCH_A, i, XAIE_EVENT_BROADCAST_EAST) != XAIE_OK)
               break;
-          xrt_core::message::send(severity_level::info, "XRT", "!!! Configured broadcast mask for core to memory events");
         }
 
         // Configure event ports on stream switch

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/client/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/client/aie_trace.cpp
@@ -1166,17 +1166,6 @@ namespace xdp {
         if (type == module_type::mem_tile)
           aieConfig = cfgTile->memory_tile_trace_config;
 
-        // Only enable Core -> MEM. Block everything else in both modules
-        if (XAie_EventBroadcastBlockMapDir(&aieDevInst, loc, XAIE_CORE_MOD, XAIE_EVENT_SWITCH_A, 0xFF00, XAIE_EVENT_BROADCAST_WEST | XAIE_EVENT_BROADCAST_NORTH | XAIE_EVENT_BROADCAST_SOUTH) != XAIE_OK)
-          break;
-        if (XAie_EventBroadcastBlockMapDir(&aieDevInst, loc, XAIE_MEM_MOD, XAIE_EVENT_SWITCH_A, 0xFF00, XAIE_EVENT_BROADCAST_EAST | XAIE_EVENT_BROADCAST_NORTH | XAIE_EVENT_BROADCAST_SOUTH) != XAIE_OK)
-          break;
-
-        for (uint8_t i = 8; i < 16; i++)
-          if (XAie_EventBroadcastUnblockDir(&aieDevInst, loc, XAIE_CORE_MOD, XAIE_EVENT_SWITCH_A, i, XAIE_EVENT_BROADCAST_EAST) != XAIE_OK)
-            break;
-        xrt_core::message::send(severity_level::info, "XRT", "!!! Configured Core/MemoryTile broadcasting.");
-
         // Configure combo events for metric sets that include DMA events        
         auto comboEvents = configComboEvents(loc, mod, type, metricSet, aieConfig);
         if (comboEvents.size() == 2) {
@@ -1199,6 +1188,15 @@ namespace xdp {
           XAie_EventLogicalToPhysicalConv(&aieDevInst, loc, XAIE_CORE_MOD, traceEndEvent, &phyEvent);
           cfgTile->core_trace_config.internal_events_broadcast[9] = phyEvent;
 
+          if(m_trace_start_broadcast)
+            traceStartEvent = (XAie_Events) (XAIE_EVENT_BROADCAST_0_MEM + traceStartBroadcastChId1);
+          else
+            traceStartEvent = XAIE_EVENT_BROADCAST_8_MEM;
+          traceEndEvent = XAIE_EVENT_BROADCAST_9_MEM;
+          firstBroadcastId = 10;
+        }
+
+        if (type == module_type::core) {
           // Only enable Core -> MEM. Block everything else in both modules
           if (XAie_EventBroadcastBlockMapDir(&aieDevInst, loc, XAIE_CORE_MOD, XAIE_EVENT_SWITCH_A, 0xFF00, XAIE_EVENT_BROADCAST_WEST | XAIE_EVENT_BROADCAST_NORTH | XAIE_EVENT_BROADCAST_SOUTH) != XAIE_OK)
             break;
@@ -1208,13 +1206,7 @@ namespace xdp {
           for (uint8_t i = 8; i < 16; i++)
             if (XAie_EventBroadcastUnblockDir(&aieDevInst, loc, XAIE_CORE_MOD, XAIE_EVENT_SWITCH_A, i, XAIE_EVENT_BROADCAST_EAST) != XAIE_OK)
               break;
-
-          if(m_trace_start_broadcast)
-            traceStartEvent = (XAie_Events) (XAIE_EVENT_BROADCAST_0_MEM + traceStartBroadcastChId1);
-          else
-            traceStartEvent = XAIE_EVENT_BROADCAST_8_MEM;
-          traceEndEvent = XAIE_EVENT_BROADCAST_9_MEM;
-          firstBroadcastId = 10;
+          xrt_core::message::send(severity_level::info, "XRT", "!!! Configured broadcast mask for core to memory events");
         }
 
         // Configure event ports on stream switch

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/client/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/client/aie_trace.cpp
@@ -1166,6 +1166,17 @@ namespace xdp {
         if (type == module_type::mem_tile)
           aieConfig = cfgTile->memory_tile_trace_config;
 
+        // Only enable Core -> MEM. Block everything else in both modules
+        if (XAie_EventBroadcastBlockMapDir(&aieDevInst, loc, XAIE_CORE_MOD, XAIE_EVENT_SWITCH_A, 0xFF00, XAIE_EVENT_BROADCAST_WEST | XAIE_EVENT_BROADCAST_NORTH | XAIE_EVENT_BROADCAST_SOUTH) != XAIE_OK)
+          break;
+        if (XAie_EventBroadcastBlockMapDir(&aieDevInst, loc, XAIE_MEM_MOD, XAIE_EVENT_SWITCH_A, 0xFF00, XAIE_EVENT_BROADCAST_EAST | XAIE_EVENT_BROADCAST_NORTH | XAIE_EVENT_BROADCAST_SOUTH) != XAIE_OK)
+          break;
+
+        for (uint8_t i = 8; i < 16; i++)
+          if (XAie_EventBroadcastUnblockDir(&aieDevInst, loc, XAIE_CORE_MOD, XAIE_EVENT_SWITCH_A, i, XAIE_EVENT_BROADCAST_EAST) != XAIE_OK)
+            break;
+        xrt_core::message::send(severity_level::info, "XRT", "!!! Configured Core/MemoryTile broadcasting.");
+
         // Configure combo events for metric sets that include DMA events        
         auto comboEvents = configComboEvents(loc, mod, type, metricSet, aieConfig);
         if (comboEvents.size() == 2) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
CR-1229145: As reported in this CR, core and memory module trace metric sets were not working in combination.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
It is observed that tiles in same column were causing broadcast event conflict because of missing broadcast masking.
This commit enables required masking for DMA metric sets as well.

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
MCDM build - Verified on Client

#### Documentation impact (if any)
