### PR TITLE
[xrt-smi] Add power check for amdxdna

### DIFF
--- a/src/runtime_src/core/common/sensor.cpp
+++ b/src/runtime_src/core/common/sensor.cpp
@@ -215,7 +215,7 @@ read_data_driven_electrical(const std::vector<xq::sdm_sensor_info::data_type>& c
   // iterate over power data, store to ptree by converting to watts.
   for (const auto& tmp : power) {
     if (boost::iequals(tmp.label, "Total Power")) {
-      if (tmp.input != UINT32_MAX)
+      if (tmp.input != std::numeric_limits<decltype(xq::sdm_sensor_info::data_type::input)>::max())
         bd_power = xrt_core::utils::format_base10_shiftdown(tmp.input, tmp.unitm, 3);
       bd_max_power = xrt_core::utils::format_base10_shiftdown(tmp.max, tmp.unitm, 3);
     }

--- a/src/runtime_src/core/common/sensor.cpp
+++ b/src/runtime_src/core/common/sensor.cpp
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2018-2022 Xilinx, Inc
+ * Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -214,7 +215,8 @@ read_data_driven_electrical(const std::vector<xq::sdm_sensor_info::data_type>& c
   // iterate over power data, store to ptree by converting to watts.
   for (const auto& tmp : power) {
     if (boost::iequals(tmp.label, "Total Power")) {
-      bd_power = xrt_core::utils::format_base10_shiftdown(tmp.input, tmp.unitm, 3);
+      if (tmp.input != UINT32_MAX)
+        bd_power = xrt_core::utils::format_base10_shiftdown(tmp.input, tmp.unitm, 3);
       bd_max_power = xrt_core::utils::format_base10_shiftdown(tmp.max, tmp.unitm, 3);
     }
   }


### PR DESCRIPTION
#### Problem solved by the commit
We need to display "N/A" for xrt-smi platform report power reading for amdxdna for the time being.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Noticed during internal testing.
#### How problem was solved, alternative solutions (if any) and why they were rejected
amdxdna will return max integer value for now until we get a real value. If reading is max, we will not add to ptree.
#### Risks (if any) associated the changes in the commit
N/A
#### What has been tested and how, request additional testing if necessary
Tested on STX amdxdna.
#### Documentation impact (if any)
N/A