### PR TITLE
Load ML Timeline on Client even if other XDP libraries are not available

### DIFF
--- a/src/runtime_src/core/common/xdp/profile.cpp
+++ b/src/runtime_src/core/common/xdp/profile.cpp
@@ -401,6 +401,16 @@ update_device(void* handle)
   }
   #endif
 
+  if (xrt_core::config::get_ml_timeline()) {
+    try {
+      xrt_core::xdp::ml_timeline::load();
+    }
+    catch (...) {
+      return;
+    }
+    xrt_core::xdp::ml_timeline::update_device(handle);
+  }
+
   if (xrt_core::config::get_aie_halt()) {
     try {
       xrt_core::xdp::aie::halt::load();
@@ -442,15 +452,7 @@ update_device(void* handle)
     xrt_core::xdp::aie::debug::update_device(handle);
   }
 
-  if (xrt_core::config::get_ml_timeline()) {
-    try {
-      xrt_core::xdp::ml_timeline::load();
-    }
-    catch (...) {
-      return;
-    }
-    xrt_core::xdp::ml_timeline::update_device(handle);
-  }
+
 
   if (xrt_core::config::get_aie_pc()) {
     try {
@@ -495,6 +497,8 @@ finish_flush_device(void* handle)
 
 #ifdef XDP_CLIENT_BUILD
 
+  if (xrt_core::config::get_ml_timeline())
+    xrt_core::xdp::ml_timeline::finish_flush_device(handle);
   if (xrt_core::config::get_aie_halt())
     xrt_core::xdp::aie::halt::finish_flush_device(handle);
   if (xrt_core::config::get_aie_profile())
@@ -503,8 +507,6 @@ finish_flush_device(void* handle)
     xrt_core::xdp::aie::trace::end_trace(handle);
   if (xrt_core::config::get_aie_debug())
     xrt_core::xdp::aie::debug::end_debug(handle);
-  if (xrt_core::config::get_ml_timeline())
-    xrt_core::xdp::ml_timeline::finish_flush_device(handle);
   if (xrt_core::config::get_aie_pc())
     xrt_core::xdp::aie_pc::finish_flush_device(handle);
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
If other non-production Client XDP features like AIE Trace/Profile are enabled are runtime but their libraries are not available, then production feature ML Timeline also does not load at runtime. This is fixed in this PR.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
ML Timeline should get loaded and attached before any other non-production libraries.

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Unit test on Client Windows

#### Documentation impact (if any)
