### PR TITLE
Fix bug when using static ref and std::make_pair

### DIFF
--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -914,7 +914,7 @@ class module_elf_aie2p : public module_elf
       
       uint32_t index = get_section_name_index(name);
       buf.append_section_data(sec.get());
-      map.emplace(std::make_pair(index, std::make_pair(sec_index, buf)));
+      map.emplace(index, std::pair{sec_index, buf});
     }
   }
 
@@ -928,7 +928,7 @@ class module_elf_aie2p : public module_elf
       
       buf pdi_buf;
       pdi_buf.append_section_data(sec.get());
-      m_pdi_buf_map.emplace(std::make_pair(name, pdi_buf));
+      m_pdi_buf_map.emplace(name, pdi_buf);
     }
   }
 
@@ -1143,7 +1143,7 @@ public:
     auto it = m_instr_buf_map.find(index);
     if (it != m_instr_buf_map.end())
       return it->second;
-    return std::make_pair(UINT32_MAX, instr_buf::get_empty_buf());
+    return {UINT32_MAX, instr_buf::get_empty_buf()};
   }
 
   std::pair<uint32_t, const control_packet&>
@@ -1152,7 +1152,7 @@ public:
     auto it = m_ctrl_packet_map.find(index);
     if (it != m_ctrl_packet_map.end())
       return it->second;
-    return std::make_pair(UINT32_MAX, control_packet::get_empty_buf());
+    return {UINT32_MAX, control_packet::get_empty_buf()};
   }
 
   const std::set<std::string>&


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Fixed bug when using std::make_pair to return const reference to a static object.

std::make_pair doesn't work when either first or second is a reference, it makes a local copy of what the reference refers to and but as the local copy goes out of scope we get junk values

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
PR - https://github.com/Xilinx/XRT/pull/8581 introduced the bug and it was discovered when doing a local testing

#### How problem was solved, alternative solutions (if any) and why they were rejected
Using initializer list to create std::pair instead of std::make_pair

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
Tested the failing test case (elf_txn_no_cp) on phoenix hw and test passes after the fix

#### Documentation impact (if any)
NA