### PR TITLE
[XDP] Support same tile graph/port latency 

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info/aie_constructs.h
+++ b/src/runtime_src/xdp/profile/database/static_info/aie_constructs.h
@@ -24,6 +24,7 @@
 #include <vector>
 #include "xdp/profile/device/tracedefs.h"
 #include <iostream>
+#include <sstream>
 
 namespace xdp::aie {
   struct aiecompiler_options
@@ -86,6 +87,33 @@ namespace xdp {
       if (row != tile.row) return row < tile.row;
       return subtype < tile.subtype;
     }
+
+     // Function to get the first stream_id
+    uint8_t getFirstStreamId() const {
+      return stream_ids.empty() ? 0 : stream_ids[0];
+    }
+
+    // Function to get the first is_master value
+    uint8_t getFirstIsMaster() const {
+      return is_master_vec.empty() ? 0 : is_master_vec[0];
+    }
+
+    // For debugging function to print tile_type all fields stream_ids, is_master_vec using stringstream 
+    friend std::ostream& operator<<(std::ostream& os, const tile_type& tile) {
+      std::stringstream ss;
+      ss << "!!! Tile: " << +tile.col << "," << +tile.row << " Subtype: " << +tile.subtype;
+      ss << " Stream IDs: ";
+      for (auto id : tile.stream_ids) {
+      ss << +id << " ";
+      }
+      ss << " Master: ";
+      for (auto master : tile.is_master_vec) {
+      ss << +master << " ";
+      }
+      os << ss.str();
+      return os;
+    }
+
   };
 
   struct compareTileByLoc {
@@ -155,11 +183,12 @@ namespace xdp {
     double clockFreqMhz;
     std::string module;
     std::string name;
+    uint8_t streamId;
 
     AIECounter(uint32_t i, uint8_t col, uint8_t r, uint8_t num, 
                uint16_t start, uint16_t end, uint8_t reset,
                uint64_t load, double freq, const std::string& mod, 
-               const std::string& aieName)
+               const std::string& aieName, uint8_t id=0)
       : id(i)
       , column(col)
       , row(r)
@@ -171,6 +200,7 @@ namespace xdp {
       , clockFreqMhz(freq)
       , module(mod)
       , name(aieName)
+      , streamId(id)
     {}
   };
 
@@ -343,6 +373,58 @@ namespace xdp {
     aie_cfg_tile(uint32_t c, uint32_t r, module_type t) : column(c), row(r), type(t) {}
   };
 
+  // Flattened key structure for tile_type or graph:port pair
+  struct tileKey {
+    uint8_t row;
+    uint8_t col;
+    uint8_t stream_id;
+    uint8_t is_master;
+    uint64_t itr_mem_addr;
+    bool active_core;
+    bool active_memory;
+    bool is_trigger;
+    io_type subtype;
+
+    bool operator<(const tileKey& other) const {
+      return std::tie(row, col, stream_id, is_master, itr_mem_addr, active_core, 
+              active_memory, is_trigger, subtype) <
+         std::tie(other.row, other.col, other.stream_id, other.is_master, 
+              other.itr_mem_addr, other.active_core, other.active_memory, 
+              other.is_trigger, other.subtype);
+    }
+
+    bool operator==(const tileKey& other) const {
+      return (row == other.row) && (col == other.col) && 
+             (stream_id == other.stream_id) && (is_master == other.is_master) &&
+             (itr_mem_addr == other.itr_mem_addr) && (active_core == other.active_core) &&
+             (active_memory == other.active_memory) && (is_trigger == other.is_trigger) &&
+             (subtype == other.subtype);
+    }
+
+    // Debug method to print the tileKey
+    friend std::ostream& operator<<(std::ostream& os, const tileKey& key) {
+      os << "TileKey: (" << +key.col << ", " << +key.row << ", " << +key.stream_id << ", " << +key.is_master
+       << ", " << +key.itr_mem_addr << ", " << key.active_core << ", " << key.active_memory << ", " << key.is_trigger
+       << ", " << (int)key.subtype << ")";
+      return os;
+    }
+  };
+
+  // Function to create a tileKey from a tile_type
+  inline tileKey create_tileKey(const tile_type& tile) {
+    return tileKey{
+      tile.row,
+      tile.col,
+      tile.getFirstStreamId(),
+      tile.getFirstIsMaster(),
+      tile.itr_mem_addr,
+      tile.active_core,
+      tile.active_memory,
+      tile.is_trigger,
+      tile.subtype
+    };
+  }
+
   struct GraphPortPair {
     std::string srcGraphName;
     std::string srcGraphPort;
@@ -365,7 +447,6 @@ namespace xdp {
       std::string metricSet;
       uint32_t tranx_no;
       bool isSource;
-      uint8_t portId;
       GraphPortPair graphPortPair;
 
       LatencyConfig() = default;
@@ -373,7 +454,6 @@ namespace xdp {
                     std::string g1, std::string p1, std::string g2, std::string p2) :
                     src(s), dest(d), metricSet(m), tranx_no(t), isSource(i),
                     graphPortPair(g1, p1, g2, p2) {}
-      void updatePortId(uint8_t& id) { portId=id; }
   };
 
   struct LatencyCache
@@ -391,7 +471,7 @@ namespace xdp {
     using tile_vec     = std::vector<std::map<tile_type, std::string>>;
     using tile_channel = std::map<tile_type, uint8_t>;
     using tile_bytes   = std::map<tile_type, uint32_t>;
-    using tile_latencyMap = std::map<tile_type, LatencyConfig>;
+    using tile_latencyMap = std::map<tileKey, LatencyConfig>;
 
     tile_vec configMetrics;
     tile_channel configChannel0;
@@ -408,6 +488,26 @@ namespace xdp {
                           configChannel1(cc1), tileRowOffset(offset),
                           bytesTransferConfigMap(byteMap), latencyConfigMap(latencyMap) {}
   };
+
+  // Structure to hold the graph/port pair for latency
+  struct latency_payload {
+    uint8_t col1;
+    uint8_t row1;
+    uint8_t portID1;
+    uint8_t col2;
+    uint8_t row2;
+    uint8_t portID2;
+
+    // print using << operator
+    friend std::ostream& operator<<(std::ostream& os, const latency_payload& payload) {
+      os << "col1: " << +payload.col1 << ", row1: " << +payload.row1
+        << ", portID1: " << +payload.portID1 << ", col2: " << +payload.col2
+        << ", row2: " << +payload.row2 << ", portID2: " << +payload.portID2;
+      return os;
+    }
+  };
+
+
 
 } // end namespace xdp
 

--- a/src/runtime_src/xdp/profile/database/static_info/aie_constructs.h
+++ b/src/runtime_src/xdp/profile/database/static_info/aie_constructs.h
@@ -101,7 +101,7 @@ namespace xdp {
     // For debugging function to print tile_type all fields stream_ids, is_master_vec using stringstream 
     friend std::ostream& operator<<(std::ostream& os, const tile_type& tile) {
       std::stringstream ss;
-      ss << "!!! Tile: " << +tile.col << "," << +tile.row << " Subtype: " << +tile.subtype;
+      ss << "Tile: " << +tile.col << "," << +tile.row << " Subtype: " << +tile.subtype;
       ss << " Stream IDs: ";
       for (auto id : tile.stream_ids) {
       ss << +id << " ";

--- a/src/runtime_src/xdp/profile/database/static_info/device_info.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info/device_info.cpp
@@ -326,14 +326,14 @@ namespace xdp {
                                  uint8_t num, uint16_t start, uint16_t end,
                                  uint8_t reset, uint64_t load, double freq,
                                  const std::string& mod,
-                                 const std::string& aieName)
+                                 const std::string& aieName, uint8_t streamId)
   {
     ConfigInfo* config = currentConfig() ;
     if (!config || config->currentXclbins.empty())
       return ;
 
     config->addAIECounter(i, col, row, num, start, end,
-                          reset, load, freq, mod, aieName) ;
+                          reset, load, freq, mod, aieName, streamId) ;
   }
 
   void DeviceInfo::addAIECounterResources(uint32_t numCounters,

--- a/src/runtime_src/xdp/profile/database/static_info/device_info.h
+++ b/src/runtime_src/xdp/profile/database/static_info/device_info.h
@@ -144,7 +144,7 @@ namespace xdp {
     void addAIECounter(uint32_t i, uint8_t col, uint8_t row, uint8_t num,
                        uint16_t start, uint16_t end, uint8_t reset,
                        uint64_t load, double freq, const std::string& mod,
-                       const std::string& aieName) ;
+                       const std::string& aieName, uint8_t streamId=0) ;
     XDP_CORE_EXPORT
     void addAIECounterResources(uint32_t numCounters, uint32_t numTiles,
                                 uint8_t moduleType) ;

--- a/src/runtime_src/xdp/profile/database/static_info/xclbin_info.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info/xclbin_info.cpp
@@ -573,14 +573,15 @@ namespace xdp {
                                    uint8_t num, uint16_t start, uint16_t end,
                                    uint8_t reset, uint64_t load, double freq,
                                    const std::string& mod,
-                                   const std::string& aieName)
+                                   const std::string& aieName, uint8_t streamId)
     {
       for (auto xclbin : currentXclbins)
       {
         if (xclbin->aie.valid)
         {
           xclbin->aie.aieList.push_back(new AIECounter(i, col, r, num, start, end,
-                                                    reset, load, freq, mod, aieName)) ;
+                                                       reset, load, freq, mod,
+                                                       aieName,streamId)) ;
           return ;
         }
       }

--- a/src/runtime_src/xdp/profile/database/static_info/xclbin_info.h
+++ b/src/runtime_src/xdp/profile/database/static_info/xclbin_info.h
@@ -247,7 +247,7 @@ namespace xdp {
                                  uint8_t num, uint16_t start, uint16_t end,
                                  uint8_t reset, uint64_t load, double freq,
                                  const std::string& mod,
-                                 const std::string& aieName) ;
+                                 const std::string& aieName, uint8_t streamId=0) ;
     void addAIECounterResources(uint32_t numCounters,
                                             uint32_t numTiles,
                                             uint8_t moduleType) ;

--- a/src/runtime_src/xdp/profile/database/static_info_database.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info_database.cpp
@@ -1075,14 +1075,14 @@ namespace xdp {
                                        uint16_t start, uint16_t end,
                                        uint8_t reset, uint64_t load,
                                        double freq, const std::string& mod,
-                                       const std::string& aieName)
+                                       const std::string& aieName, uint8_t streamId)
   {
     std::lock_guard<std::mutex> lock(deviceLock) ;
 
     if (deviceInfo.find(deviceId) == deviceInfo.end())
       return ;
     deviceInfo[deviceId]->addAIECounter(i, col, row, num, start, end, reset,
-                                        load, freq, mod, aieName) ;
+                                        load, freq, mod, aieName, streamId) ;
   }
 
   void VPStaticDatabase::addAIECounterResources(uint64_t deviceId,

--- a/src/runtime_src/xdp/profile/database/static_info_database.h
+++ b/src/runtime_src/xdp/profile/database/static_info_database.h
@@ -331,7 +331,7 @@ namespace xdp {
                                   uint8_t row, uint8_t num, uint16_t start,
                                   uint16_t end, uint8_t reset, uint64_t load,
                                   double freq, const std::string& mod,
-                                  const std::string& aieName) ;
+                                  const std::string& aieName, uint8_t streamId=0) ;
     XDP_CORE_EXPORT void addAIECounterResources(uint64_t deviceId,
                                            uint32_t numCounters,
                                            uint32_t numTiles,

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_metadata.cpp
@@ -1433,7 +1433,6 @@ namespace xdp {
       }
     }
   
-    // If no match is found, return an empty key
     return key;
   }
 

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_metadata.cpp
@@ -1259,22 +1259,19 @@ namespace xdp {
       auto tileDest =  metadataReader->getInterfaceTiles(g2, p2, metricName);
 
       if (tileSrc.empty() || tileDest.empty()) {
+        xrt_core::message::send(severity_level::info, "XRT", "No valid tiles found for the graph ports " 
+          + g1 + ":" + p1 + " or " + g2 + ":" + p2 + ", skipping this setting. Please confirm if these are valid graph ports.");
         continue;
       }
-      if ((tileSrc[0].col == tileDest[0].col) && (tileSrc[0].row == tileDest[0].row)) {
-        xrt_core::message::send(severity_level::warning, "XRT", "The ports " + g1 + ":" + p1
-            + " and " + g2 + ":" + p2 + " were mapped to the same interface tile."
-            + " Latency measurement of these ports is not supported in 2024.2.");
-        continue;
-      }
+
       std::string tranx_no = tileMetrics[i].size() <= 4 ? "0" : tileMetrics[i].back();
       if (!aie::isDigitString(tranx_no) || std::numeric_limits<uint32_t>::max() < std::stoul(tranx_no)) {
         return;
       }
 
       // Update the latencyConfigMap to store the complete config.
-      latencyConfigMap[tileSrc[0]]  = std::move(LatencyConfig(tileSrc[0], tileDest[0], metricName, std::stoul(tranx_no), true, g1, p1, g2, p2));
-      latencyConfigMap[tileDest[0]] = std::move(LatencyConfig(tileSrc[0], tileDest[0], metricName, std::stoul(tranx_no), false, g1, p1, g2, p2));
+      latencyConfigMap[create_tileKey(tileSrc[0])]  = std::move(LatencyConfig(tileSrc[0], tileDest[0], metricName, std::stoul(tranx_no), true, g1, p1, g2, p2));
+      latencyConfigMap[create_tileKey(tileDest[0])] = std::move(LatencyConfig(tileSrc[0], tileDest[0], metricName, std::stoul(tranx_no), false, g1, p1, g2, p2));
 
       // Also update the common configMetrics 
       configMetrics[moduleIdx][tileSrc[0]]  = metricName;
@@ -1363,11 +1360,11 @@ namespace xdp {
       }
     }
     else if(metricSet == METRIC_LATENCY) {
-      if (latencyConfigMap.find(tile) == latencyConfigMap.end()) {
+      if (latencyConfigMap.find(create_tileKey(tile)) == latencyConfigMap.end()) {
         return 0;
       }
       else{
-        return latencyConfigMap.at(tile).tranx_no;
+        return latencyConfigMap.at(create_tileKey(tile)).tranx_no;
       }
     }
     return 0;
@@ -1383,39 +1380,50 @@ namespace xdp {
     if (!isValidLatencyTile(tile))
       return false;
     
-    return latencyConfigMap.at(tile).isSource;
+    return latencyConfigMap.at(create_tileKey(tile)).isSource;
   }
 
-  bool AieProfileMetadata::getSourceTile(const tile_type& pairTyle, tile_type& sourceTile) const
+  bool AieProfileMetadata::getSourceTile(const tile_type& pairTile, tile_type& sourceTile) const
   {
-    if (!isValidLatencyTile(pairTyle))
+    if (!isValidLatencyTile(pairTile))
       return false;
 
-    sourceTile = latencyConfigMap.at(pairTyle).src;
+    auto tile_key = create_tileKey(pairTile);
+    sourceTile = latencyConfigMap.at(create_tileKey(pairTile)).src;
     return true;
   }
 
-  bool AieProfileMetadata::getDestTile(const tile_type& pairTyle, tile_type& destTile) const
+  bool AieProfileMetadata::getDestTile(const tile_type& pairTile, tile_type& destTile) const
   {
-    if (!isValidLatencyTile(pairTyle))
+    if (!isValidLatencyTile(pairTile))
       return false;
 
-    destTile = latencyConfigMap.at(pairTyle).dest;
+    destTile = latencyConfigMap.at(create_tileKey(pairTile)).dest;
     return true;
   }
 
-  std::string AieProfileMetadata::getSrcDestPairKey(uint8_t col, uint8_t row)
+  bool AieProfileMetadata::getSrcTile(const tile_type& pairTile, tile_type& srcTile) const
   {
-    std::string key = "";
+    if (!isValidLatencyTile(pairTile))
+      return false;
 
-    std::string cacheKey = "fetch_" + aie::uint8ToStr(col) + "," + aie::uint8ToStr(row);
-    if(keysCache.find(cacheKey) != keysCache.end())
+    srcTile = latencyConfigMap.at(create_tileKey(pairTile)).src;
+    return true;
+  }
+
+  std::string AieProfileMetadata::getSrcDestPairKey(uint8_t col, uint8_t row, uint8_t streamId)
+  {
+    std::string cacheKey = "fetch_" + aie::uint8ToStr(col) + "," + aie::uint8ToStr(row) + "," + aie::uint8ToStr(streamId);
+    if(keysCache.find(cacheKey) != keysCache.end()) {
       return keysCache.at(cacheKey).srcDestKey;
+    }
 
-    for(const auto &config : latencyConfigMap) {
-      if(config.first.col == col && config.first.row == row) {
-        key = "src_"  + aie::uint8ToStr(config.second.src.col)  + "," + aie::uint8ToStr(config.second.src.row)+
-              "dest_" + aie::uint8ToStr(config.second.dest.col) + "," + aie::uint8ToStr(config.second.dest.row);
+    std::string key = "";
+    // Iterate through the latencyConfigMap to find the matching key
+    for (const auto &config : latencyConfigMap) {
+      if (config.first.col == col && config.first.row == row && config.first.stream_id == streamId) {
+        key = "src_"  + aie::uint8ToStr(config.second.src.col)  + "," + aie::uint8ToStr(config.second.src.row)  + "," + aie::uint8ToStr(config.second.src.stream_ids.at(0)) + ":" +
+              "dest_" + aie::uint8ToStr(config.second.dest.col) + "," + aie::uint8ToStr(config.second.dest.row) + "," + aie::uint8ToStr(config.second.dest.stream_ids.at(0));
         keysCache[cacheKey] = LatencyCache(key,
                                            config.second.graphPortPair.srcGraphName,
                                            config.second.graphPortPair.srcGraphPort,
@@ -1424,6 +1432,8 @@ namespace xdp {
         return key;
       }
     }
+  
+    // If no match is found, return an empty key
     return key;
   }
 
@@ -1441,7 +1451,7 @@ namespace xdp {
 
   bool AieProfileMetadata::isValidLatencyTile(const tile_type& tile) const
   {
-    return latencyConfigMap.find(tile) != latencyConfigMap.end();
+    return latencyConfigMap.find(create_tileKey(tile)) != latencyConfigMap.end();
   }
 
   uint64_t AieProfileMetadata::getIntfLatencyPayload(const tile_type& tile)
@@ -1449,9 +1459,9 @@ namespace xdp {
     if (!isValidLatencyTile(tile))
       return 0;
 
-    LatencyConfig latencyCfg = latencyConfigMap.at(tile);
+    LatencyConfig latencyCfg = latencyConfigMap.at(create_tileKey(tile));
     return createPayload(latencyCfg.src.col, latencyCfg.src.row, latencyCfg.src.stream_ids.at(0),
-                        latencyCfg.dest.col, latencyCfg.dest.row, latencyCfg.dest.stream_ids.at(0));
+                         latencyCfg.dest.col, latencyCfg.dest.row, latencyCfg.dest.stream_ids.at(0));
   }
 
  std::vector<tile_type>
@@ -1473,5 +1483,18 @@ namespace xdp {
                        (static_cast<uint64_t>(portID2) << 0);
     return payload;
   }
+  
+// Function to extract values from the payload
+latency_payload extractPayloadValues(uint64_t payload) {
+  latency_payload values;
+  values.col1    = (payload >> 40) & 0xFF;
+  values.row1    = (payload >> 32) & 0xFF;
+  values.portID1 = (payload >> 24) & 0xFF;
+  values.col2    = (payload >> 16) & 0xFF;
+  values.row2    = (payload >> 8) & 0xFF;
+  values.portID2 = payload & 0xFF;
+  return values;
+}
+
 
 }  // namespace xdp

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_metadata.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_metadata.h
@@ -108,10 +108,12 @@ class AieProfileMetadata {
     std::map<tile_type, std::string> pairConfigMetrics;
     std::map<tile_type, uint8_t> configChannel0;
     std::map<tile_type, uint8_t> configChannel1;
-    std::map<tile_type, LatencyConfig> latencyConfigMap;
+
+    std::map<tileKey, LatencyConfig> latencyConfigMap;
     std::vector<std::pair<tile_type, std::string>> configMetricLatencyVec; // configuration order vector
-    std::map<tile_type, uint32_t> bytesTransferConfigMap;
     std::map<std::string, LatencyCache> keysCache;
+
+    std::map<tile_type, uint32_t> bytesTransferConfigMap;
     uint32_t defaultTransferBytes = 1;
 
     const aie::BaseFiletypeImpl* metadataReader = nullptr;
@@ -189,7 +191,8 @@ class AieProfileMetadata {
                          uint8_t col2, uint8_t row2, uint8_t portID2);
     bool getSourceTile(const tile_type& pairTyle, tile_type& sourceTile) const;
     bool getDestTile(const tile_type& pairTyle, tile_type& destTile) const;
-    std::string getSrcDestPairKey(uint8_t col, uint8_t row);
+    bool getSrcTile(const tile_type& pairTyle, tile_type& srcTile) const;
+    std::string getSrcDestPairKey(uint8_t col, uint8_t row, uint8_t streamId);
     GraphPortPair getSrcDestGraphPair(const std::string& srcDestKey) const;
 
     std::vector<tile_type>

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/edge/aie_profile.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/edge/aie_profile.cpp
@@ -415,7 +415,7 @@ namespace xdp {
             XAie_Events retCounterEvent = XAIE_EVENT_NONE_CORE;
             perfCounter = aie::profile::configProfileAPICounters(aieDevInst, aieDevice, metadata, xaieModule, 
                             mod, type, metricSet, startEvent, endEvent, resetEvent, i, perfCounters.size(),
-                            threshold, retCounterEvent, tile, bcResourcesLatency, adfAPIResourceInfoMap);
+                            threshold, retCounterEvent, tile, bcResourcesLatency, adfAPIResourceInfoMap, adfAPIBroadcastEventsMap);
           }
           else {
             // Request counter from resource manager
@@ -456,7 +456,7 @@ namespace xdp {
           std::string counterName = "AIE Counter " + std::to_string(counterId);
           (db->getStaticInfo()).addAIECounter(deviceId, counterId, col, row, i,
                 phyStartEvent, phyEndEvent, resetEvent, payload, metadata->getClockFreqMhz(), 
-                metadata->getModuleName(module), counterName);
+                metadata->getModuleName(module), counterName, tile.stream_ids[0]);
           counterId++;
           numCounters++;
         } // numFreeCtr
@@ -529,7 +529,7 @@ namespace xdp {
           uint32_t srcCounterValue = 0;
           uint32_t destCounterValue = 0;
           try {
-            std::string srcDestPairKey = metadata->getSrcDestPairKey(aie->column, aie->row);
+            std::string srcDestPairKey = metadata->getSrcDestPairKey(aie->column, aie->row, aie->streamId);
             uint8_t srcPcIdx = adfAPIResourceInfoMap.at(aie::profile::adfAPI::INTF_TILE_LATENCY).at(srcDestPairKey).srcPcIdx;
             uint8_t destPcIdx = adfAPIResourceInfoMap.at(aie::profile::adfAPI::INTF_TILE_LATENCY).at(srcDestPairKey).destPcIdx;
             auto srcPerfCount = perfCounters.at(srcPcIdx);

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/edge/aie_profile.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/edge/aie_profile.h
@@ -85,6 +85,8 @@ namespace xdp {
       XAie_Events latencyUserBrodcastChannelEvent = XAIE_EVENT_NONE_CORE;
 
       std::map<aie::profile::adfAPI, std::map<std::string, aie::profile::adfAPIResourceInfo>> adfAPIResourceInfoMap;
+      // This stores the map of location of tile and configured broadcast channel event
+      std::map<std::string, std::pair<int, XAie_Events>> adfAPIBroadcastEventsMap;
 
       std::vector<std::shared_ptr<xaiefal::XAieBroadcast>> bcResourcesBytesTx;
       std::vector<std::shared_ptr<xaiefal::XAieBroadcast>> bcResourcesLatency;

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/util/aie_profile_config.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/util/aie_profile_config.h
@@ -82,7 +82,8 @@ namespace xdp::aie::profile {
                            XAie_Events resetEvent, int pcIndex, size_t counterIndex, 
                            size_t threshold, XAie_Events& retCounterEvent, const tile_type& tile,
                            std::vector<std::shared_ptr<xaiefal::XAieBroadcast>>& bcResourcesLatency,
-                           std::map<adfAPI, std::map<std::string, adfAPIResourceInfo>>& adfAPIResourceInfoMap);
+                           std::map<adfAPI, std::map<std::string, adfAPIResourceInfo>>& adfAPIResourceInfoMap,
+                           std::map<std::string, std::pair<int, XAie_Events>>& adfAPIBroadcastEventsMap);
 
    /**
    * @brief Start a performance counter
@@ -124,9 +125,10 @@ namespace xdp::aie::profile {
    * @return channel and event
    */
   std::pair<int, XAie_Events>
-  getPLBroadcastChannel(xaiefal::XAieDev* aieDevice, const tile_type& srcTile, 
-                        std::shared_ptr<AieProfileMetadata> metadata,
-                        std::vector<std::shared_ptr<xaiefal::XAieBroadcast>>& bcResourcesLatency);
+  getShimBroadcastChannel(xaiefal::XAieDev* aieDevice, const tile_type& srcTile, const tile_type& destTile,
+                          std::shared_ptr<AieProfileMetadata> metadata,
+                          std::vector<std::shared_ptr<xaiefal::XAieBroadcast>>& bcResourcesLatency,
+                          std::map<std::string, std::pair<int, XAie_Events>>& adfAPIBroadcastEventsMap);
 
   /**
    * @brief Setup broadcast channel
@@ -139,7 +141,14 @@ namespace xdp::aie::profile {
   std::pair<int, XAie_Events>
   setupBroadcastChannel(xaiefal::XAieDev* aieDevice, const tile_type& currTileLoc, 
                         std::shared_ptr<AieProfileMetadata> metadata,
-                        std::vector<std::shared_ptr<xaiefal::XAieBroadcast>>& bcResourcesLatency);
+                        std::vector<std::shared_ptr<xaiefal::XAieBroadcast>>& bcResourcesLatency,
+                        std::map<std::string, std::pair<int, XAie_Events>>& adfAPIBroadcastEventsMap);
+  
+   std::pair<int, XAie_Events>
+   getSetBroadcastChannel(xaiefal::XAieDev* aieDevice, const tile_type& currTileLoc, 
+                          std::shared_ptr<AieProfileMetadata> metadata,
+                          std::vector<std::shared_ptr<xaiefal::XAieBroadcast>>& bcResourcesLatency,
+                          std::map<std::string, std::pair<int, XAie_Events>>& adfAPIBroadcastEventsMap);
 
   /**
    * @brief Configure interface tile counter for latency
@@ -169,7 +178,8 @@ namespace xdp::aie::profile {
                          XAie_Events startEvent, XAie_Events endEvent, XAie_Events resetEvent, 
                          int pcIndex, size_t threshold, XAie_Events& retCounterEvent,
                          const tile_type& tile, bool& isSource,
-                         std::vector<std::shared_ptr<xaiefal::XAieBroadcast>>& bcResourcesLatency);
+                         std::vector<std::shared_ptr<xaiefal::XAieBroadcast>>& bcResourcesLatency,
+                         std::map<std::string, std::pair<int, XAie_Events>>& adfAPIBroadcastEventsMap);
 
    /**
    * @brief Configure individual AIE events for metric sets related to Profile APIs

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/ve2/aie_profile.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/ve2/aie_profile.cpp
@@ -474,7 +474,7 @@ namespace xdp {
           std::string counterName = "AIE Counter " + std::to_string(counterId);
           (db->getStaticInfo()).addAIECounter(deviceId, counterId, col, row, i,
                 phyStartEvent, phyEndEvent, resetEvent, payload, metadata->getClockFreqMhz(), 
-                metadata->getModuleName(module), counterName);
+                metadata->getModuleName(module), counterName, tile.stream_ids[0]);
           counterId++;
           numCounters++;
         } // numFreeCtr
@@ -548,7 +548,7 @@ namespace xdp {
           uint32_t srcCounterValue = 0;
           uint32_t destCounterValue = 0;
           try {
-            std::string srcDestPairKey = metadata->getSrcDestPairKey(aie->column, aie->row);
+            std::string srcDestPairKey = metadata->getSrcDestPairKey(aie->column, aie->row, aie->streamId);
             uint8_t srcPcIdx = adfAPIResourceInfoMap.at(aie::profile::adfAPI::INTF_TILE_LATENCY).at(srcDestPairKey).srcPcIdx;
             uint8_t destPcIdx = adfAPIResourceInfoMap.at(aie::profile::adfAPI::INTF_TILE_LATENCY).at(srcDestPairKey).destPcIdx;
             auto srcPerfCount = perfCounters.at(srcPcIdx);

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/ve2/aie_profile.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/ve2/aie_profile.cpp
@@ -433,7 +433,7 @@ namespace xdp {
             XAie_Events retCounterEvent = XAIE_EVENT_NONE_CORE;
             perfCounter = aie::profile::configProfileAPICounters(aieDevInst, aieDevice, metadata, xaieModule, 
                             mod, type, metricSet, startEvent, endEvent, resetEvent, i, perfCounters.size(),
-                            threshold, retCounterEvent, tile, bcResourcesLatency, adfAPIResourceInfoMap);
+                            threshold, retCounterEvent, tile, bcResourcesLatency, adfAPIResourceInfoMap, adfAPIBroadcastEventsMap);
           }
           else {
             // Request counter from resource manager

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/ve2/aie_profile.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/ve2/aie_profile.h
@@ -124,7 +124,6 @@ namespace xdp {
 
       std::vector<std::shared_ptr<xaiefal::XAieBroadcast>> bcResourcesBytesTx;
       std::vector<std::shared_ptr<xaiefal::XAieBroadcast>> bcResourcesLatency;
-
   };
 }   
 

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/ve2/aie_profile.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/ve2/aie_profile.h
@@ -87,7 +87,7 @@ namespace xdp {
       }
 
       std::pair<int, XAie_Events>
-      getPLBroadcastChannel(const tile_type& srcTile);
+      getShimBroadcastChannel(const tile_type& srcTile);
 
       void
       displayAdfAPIResults();
@@ -120,10 +120,11 @@ namespace xdp {
       std::map<aie::profile::adfAPI, std::map<std::string, aie::profile::adfAPIResourceInfo>> adfAPIResourceInfoMap;
       
       // This stores the map of location of tile and configured broadcast channel event
-      std::map<tile_type, std::pair<int, XAie_Events>> adfAPIBroadcastEventsMap;
+      std::map<std::string, std::pair<int, XAie_Events>> adfAPIBroadcastEventsMap;
 
       std::vector<std::shared_ptr<xaiefal::XAieBroadcast>> bcResourcesBytesTx;
       std::vector<std::shared_ptr<xaiefal::XAieBroadcast>> bcResourcesLatency;
+
   };
 }   
 

--- a/src/runtime_src/xdp/profile/writer/aie_profile/aie_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/aie_profile/aie_writer.cpp
@@ -35,8 +35,9 @@ namespace xdp {
 
   void AIEProfilingWriter::writeHeader()
   {
-    // Updated offsets for AIE mem, shim and mem_tile to 1000, 2000, 3000 respectively.
-    float fileVersion = 1.1f;
+    // 1.1 Updated offsets for AIE mem, shim and mem_tile to 1000, 2000, 3000 respectively.
+    // 1.2 Added stream_id in metric sets reporting 
+    float fileVersion = 1.2f;
 
     // Report HW generation to inform analysis how to interpret event IDs
     auto aieGeneration = (db->getStaticInfo()).getAIEGeneration(mDeviceIndex);
@@ -79,8 +80,9 @@ namespace xdp {
             metrics.back() += "," + std::to_string(+validConfig.bytesTransferConfigMap.at(elm.first));
         }
         else if (i == module_type::shim && elm.second == METRIC_LATENCY) {
-          if(validConfig.latencyConfigMap.find(elm.first) != validConfig.latencyConfigMap.end())
-            metrics.back() += "," + std::to_string(+validConfig.latencyConfigMap.at(elm.first).tranx_no);
+          if(validConfig.latencyConfigMap.find(create_tileKey(elm.first)) != validConfig.latencyConfigMap.end())
+            metrics.back() += "," + std::to_string(+validConfig.latencyConfigMap.at(create_tileKey(elm.first)).tranx_no) +
+                              "," + std::to_string(+elm.first.stream_ids[0]);
         }
       }
       filteredConfig[static_cast<module_type>(i)] = metrics;


### PR DESCRIPTION
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
[VITIS-13360][CR-1217230][CR-1216938] - Support same tile graph/port latency measurements.

#### How problem was solved, alternative solutions (if any) and why they were rejected
- Unrolling out the tile_type to form unique keys.

#### Risks (if any) associated the changes in the commit
Low.
#### What has been tested and how, request additional testing if necessary
Verified on Edge with different usecases.

To be tested:
Build on VE2/MCDM - In progress
#### Documentation impact (if any)
