### PR TITLE
CR-1228350 fix : Virtualizing configure options for alveo/pcie 

### DIFF
--- a/src/runtime_src/core/common/smi.cpp
+++ b/src/runtime_src/core/common/smi.cpp
@@ -49,6 +49,20 @@ smi_base()
   examine_report_desc = {
     {"host", "Host information", "common"}
   };
+
+  configure_options = {
+    {"device", "d", "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest", "common", "", "string"},
+    {"help", "h", "Help to use this sub-command", "common", "", "none"},
+    {"daemon", "", "Update the device daemon configuration", "hidden", "", "none"},
+    {"purge", "", "Remove the daemon configuration file", "hidden", "", "string"},
+    {"host", "", "IP or hostname for device peer", "hidden", "", "string"},
+    {"security", "", "Update the security level for the device", "hidden", "", "string"},
+    {"clk_throttle", "", "Enable/disable the device clock throttling", "hidden", "", "string"},
+    {"ct_threshold_power_override", "", "Update the power threshold in watts", "hidden", "", "string"},
+    {"ct_threshold_temp_override", "", "Update the temperature threshold in celsius", "hidden", "", "string"},
+    {"ct_reset", "", "Reset all throttling options", "hidden", "", "string"},
+    {"showx", "", "Display the device configuration settings", "hidden", "", "string"}
+  };
 }
 
 std::vector<basic_option> 
@@ -131,22 +145,8 @@ construct_configure_subcommand() const
   subcommand.put("type", "common");
   subcommand.put("description", "Device and host configuration");
 
-  std::vector<option> options = {
-    {"device", "d", "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest", "common", "", "string"},
-    {"help", "h", "Help to use this sub-command", "common", "", "none"},
-    {"daemon", "", "Update the device daemon configuration", "hidden", "", "none"},
-    {"purge", "", "Remove the daemon configuration file", "hidden", "", "string"},
-    {"host", "", "IP or hostname for device peer", "hidden", "", "string"},
-    {"security", "", "Update the security level for the device", "hidden", "", "string"},
-    {"clk_throttle", "", "Enable/disable the device clock throttling", "hidden", "", "string"},
-    {"ct_threshold_power_override", "", "Update the power threshold in watts", "hidden", "", "string"},
-    {"ct_threshold_temp_override", "", "Update the temperature threshold in celsius", "hidden", "", "string"},
-    {"ct_reset", "", "Reset all throttling options", "hidden", "", "string"},
-    {"showx", "", "Display the device configuration settings", "hidden", "", "string"}
-  };
-
   ptree options_ptree;
-  for (const auto& option : options) {
+  for (const auto& option : configure_options) {
     options_ptree.push_back(std::make_pair("", option.to_ptree()));
   }
 

--- a/src/runtime_src/core/common/smi.cpp
+++ b/src/runtime_src/core/common/smi.cpp
@@ -43,18 +43,15 @@ to_ptree() const
 }
 
 smi_base::
-smi_base()
-{
-
-  examine_report_desc = {
+smi_base() : 
+  examine_report_desc {
     {"host", "Host information", "common"}
-  };
-
-  configure_options = {
+  },
+  configure_options {
     {"device", "d", "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest", "common", "", "string"},
     {"help", "h", "Help to use this sub-command", "common", "", "none"}
-  };
-}
+  }
+{}
 
 std::vector<basic_option> 
 smi_base::

--- a/src/runtime_src/core/common/smi.cpp
+++ b/src/runtime_src/core/common/smi.cpp
@@ -52,16 +52,7 @@ smi_base()
 
   configure_options = {
     {"device", "d", "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest", "common", "", "string"},
-    {"help", "h", "Help to use this sub-command", "common", "", "none"},
-    {"daemon", "", "Update the device daemon configuration", "hidden", "", "none"},
-    {"purge", "", "Remove the daemon configuration file", "hidden", "", "string"},
-    {"host", "", "IP or hostname for device peer", "hidden", "", "string"},
-    {"security", "", "Update the security level for the device", "hidden", "", "string"},
-    {"clk_throttle", "", "Enable/disable the device clock throttling", "hidden", "", "string"},
-    {"ct_threshold_power_override", "", "Update the power threshold in watts", "hidden", "", "string"},
-    {"ct_threshold_temp_override", "", "Update the temperature threshold in celsius", "hidden", "", "string"},
-    {"ct_reset", "", "Reset all throttling options", "hidden", "", "string"},
-    {"showx", "", "Display the device configuration settings", "hidden", "", "string"}
+    {"help", "h", "Help to use this sub-command", "common", "", "none"}
   };
 }
 

--- a/src/runtime_src/core/common/smi.h
+++ b/src/runtime_src/core/common/smi.h
@@ -54,6 +54,7 @@ protected:
 
   tuple_vector validate_test_desc;
   tuple_vector examine_report_desc;
+  std::vector<option> configure_options;
 
   std::vector<basic_option> 
   construct_option_description(const tuple_vector&) const;

--- a/src/runtime_src/core/edge/user/smi.cpp
+++ b/src/runtime_src/core/edge/user/smi.cpp
@@ -37,6 +37,20 @@ smi_edge() : smi_base()
     {"qspi-status", "QSPI write protection status", "common"},
     {"thermal", "Thermal sensors present on the device", "common"}
   };
+
+  configure_options = {
+    {"device", "d", "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest", "common", "", "string"},
+    {"help", "h", "Help to use this sub-command", "common", "", "none"},
+    {"daemon", "", "Update the device daemon configuration", "hidden", "", "none"},
+    {"purge", "", "Remove the daemon configuration file", "hidden", "", "string"},
+    {"host", "", "IP or hostname for device peer", "hidden", "", "string"},
+    {"security", "", "Update the security level for the device", "hidden", "", "string"},
+    {"clk_throttle", "", "Enable/disable the device clock throttling", "hidden", "", "string"},
+    {"ct_threshold_power_override", "", "Update the power threshold in watts", "hidden", "", "string"},
+    {"ct_threshold_temp_override", "", "Update the temperature threshold in celsius", "hidden", "", "string"},
+    {"ct_reset", "", "Reset all throttling options", "hidden", "", "string"},
+    {"showx", "", "Display the device configuration settings", "hidden", "", "string"}
+  };
 }
 
 // Create an instance of the derived class

--- a/src/runtime_src/core/pcie/linux/smi.cpp
+++ b/src/runtime_src/core/pcie/linux/smi.cpp
@@ -39,6 +39,20 @@ smi_pcie() : smi_base()
     {"qspi-status", "QSPI write protection status", "common"},
     {"thermal", "Thermal sensors present on the device", "common"}
   };
+
+  configure_options = {
+    {"device", "d", "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest", "common", "", "string"},
+    {"help", "h", "Help to use this sub-command", "common", "", "none"},
+    {"daemon", "", "Update the device daemon configuration", "hidden", "", "none"},
+    {"purge", "", "Remove the daemon configuration file", "hidden", "", "string"},
+    {"host", "", "IP or hostname for device peer", "hidden", "", "string"},
+    {"security", "", "Update the security level for the device", "hidden", "", "string"},
+    {"clk_throttle", "", "Enable/disable the device clock throttling", "hidden", "", "string"},
+    {"ct_threshold_power_override", "", "Update the power threshold in watts", "hidden", "", "string"},
+    {"ct_threshold_temp_override", "", "Update the temperature threshold in celsius", "hidden", "", "string"},
+    {"ct_reset", "", "Reset all throttling options", "hidden", "", "string"},
+    {"showx", "", "Display the device configuration settings", "hidden", "", "string"}
+  };
 }
 
 // Create an instance of the derived class


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
This PR changes the xrt-smi configure options for alveo/edge case vs MCDM/XDNA case. MCDM and XDNA will have a minimal list of configure options

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://jira.xilinx.com/browse/CR-1228350

#### How problem was solved, alternative solutions (if any) and why they were rejected
The problem was solved by creating a default structure configure options for the default, alveo and edge cases which consists of a list of all options. This structure will be overridden by MCDM and XDNA shims to only show a minimal list of configure options.

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Tested on windows platform

#### Documentation impact (if any)
None
