### PR TITLE
[XDP] Add safe access check for tile stream ids

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_profile/edge/aie_profile.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/edge/aie_profile.cpp
@@ -456,7 +456,7 @@ namespace xdp {
           std::string counterName = "AIE Counter " + std::to_string(counterId);
           (db->getStaticInfo()).addAIECounter(deviceId, counterId, col, row, i,
                 phyStartEvent, phyEndEvent, resetEvent, payload, metadata->getClockFreqMhz(), 
-                metadata->getModuleName(module), counterName, tile.stream_ids[0]);
+                metadata->getModuleName(module), counterName, (tile.stream_ids.empty() ? 0 : tile.stream_ids[0]));
           counterId++;
           numCounters++;
         } // numFreeCtr

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/util/aie_profile_config.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/util/aie_profile_config.cpp
@@ -181,9 +181,9 @@ namespace xdp::aie::profile {
       auto pc = configInterfaceLatency(aieDevInst, aieDevice, metadata, xaieModule, xaieModType, xdpModType, 
                                        metricSet, startEvent, endEvent, resetEvent, pcIndex, threshold, 
                                        retCounterEvent, tile, isSourceTile, bcResourcesLatency, adfAPIBroadcastEventsMap);
-      std::string srcDestPairKey = metadata->getSrcDestPairKey(tile.col, tile.row, tile.stream_ids[0]);
+      std::string srcDestPairKey = metadata->getSrcDestPairKey(tile.col, tile.row, (tile.stream_ids.empty() ? 0 : tile.stream_ids[0]));
       if (isSourceTile) {
-        std::string srcDestPairKey = metadata->getSrcDestPairKey(tile.col, tile.row, tile.stream_ids[0]);
+        std::string srcDestPairKey = metadata->getSrcDestPairKey(tile.col, tile.row, (tile.stream_ids.empty() ? 0 : tile.stream_ids[0]));
         adfAPIResourceInfoMap[aie::profile::adfAPI::INTF_TILE_LATENCY][srcDestPairKey].isSourceTile = true; 
         adfAPIResourceInfoMap[aie::profile::adfAPI::INTF_TILE_LATENCY][srcDestPairKey].srcPcIdx = counterIndex;
       }
@@ -397,7 +397,7 @@ namespace xdp::aie::profile {
     
     metadata->getSrcTile(currTileLoc, srcTile);
     metadata->getDestTile(currTileLoc, destTile);
-    std::string srcDestTileKey = metadata->getSrcDestPairKey(srcTile.col, srcTile.row, srcTile.stream_ids[0]);
+    std::string srcDestTileKey = metadata->getSrcDestPairKey(srcTile.col, srcTile.row, (srcTile.stream_ids.empty() ? 0 : srcTile.stream_ids[0]));
     
     if (adfAPIBroadcastEventsMap.find(srcDestTileKey) == adfAPIBroadcastEventsMap.end()) {
       auto bcPair = getShimBroadcastChannel(aieDevice, srcTile, destTile, metadata, bcResourcesLatency);
@@ -420,7 +420,7 @@ namespace xdp::aie::profile {
                         std::map<std::string, std::pair<int, XAie_Events>>& adfAPIBroadcastEventsMap)
   {
     tile_type srcTile = currTileLoc;
-    std::string srcDestTileKey = metadata->getSrcDestPairKey(srcTile.col, srcTile.row, srcTile.stream_ids[0]);
+    std::string srcDestTileKey = metadata->getSrcDestPairKey(srcTile.col, srcTile.row, (srcTile.stream_ids.empty() ? 0 : srcTile.stream_ids[0]));
     
     if (adfAPIBroadcastEventsMap.find(srcDestTileKey) == adfAPIBroadcastEventsMap.end()) {
       return {-1, XAIE_EVENT_NONE_CORE};

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/ve2/aie_profile.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/ve2/aie_profile.cpp
@@ -474,7 +474,7 @@ namespace xdp {
           std::string counterName = "AIE Counter " + std::to_string(counterId);
           (db->getStaticInfo()).addAIECounter(deviceId, counterId, col, row, i,
                 phyStartEvent, phyEndEvent, resetEvent, payload, metadata->getClockFreqMhz(), 
-                metadata->getModuleName(module), counterName, tile.stream_ids[0]);
+                metadata->getModuleName(module), counterName, (tile.stream_ids.empty() ? 0 : tile.stream_ids[0]));
           counterId++;
           numCounters++;
         } // numFreeCtr

--- a/src/runtime_src/xdp/profile/writer/aie_profile/aie_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/aie_profile/aie_writer.cpp
@@ -82,7 +82,7 @@ namespace xdp {
         else if (i == module_type::shim && elm.second == METRIC_LATENCY) {
           if(validConfig.latencyConfigMap.find(create_tileKey(elm.first)) != validConfig.latencyConfigMap.end())
             metrics.back() += "," + std::to_string(+validConfig.latencyConfigMap.at(create_tileKey(elm.first)).tranx_no) +
-                              "," + std::to_string(+elm.first.stream_ids[0]);
+                      "," + (elm.first.stream_ids.size() > 0 ? std::to_string(+elm.first.stream_ids[0]) : "0");
         }
       }
       filteredConfig[static_cast<module_type>(i)] = metrics;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
stream_ids may or may not be populated for each tile type (ie core/mem) unlike shim tiles which leads to crash. This resolves this issue.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
(PR #8798)

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added safe check before accessing.
#### Risks (if any) associated the changes in the commit
Low
#### What has been tested and how, request additional testing if necessary
Verified on edge.

#### Documentation impact (if any)
