### PR TITLE
Add owning pointer annotation

### DIFF
--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -27,10 +27,12 @@
 #include <algorithm>
 #include <atomic>
 #include <cstdint>
+#include <cstdlib>
 #include <cstring>
 #include <filesystem>
 #include <numeric>
 #include <map>
+#include <memory>
 #include <regex>
 #include <set>
 #include <string>
@@ -370,14 +372,13 @@ demangle(const std::string& mangled_name)
     throw std::runtime_error("Error demangling kernel signature");
 #else
   int status = 0;
-  char* demangled_name = abi::__cxa_demangle(mangled_name.c_str(), nullptr, nullptr,  &status);
+  std::unique_ptr<char, decltype(&std::free)> demangled_name
+    (abi::__cxa_demangle(mangled_name.c_str(), nullptr, nullptr, &status), std::free);
 
   if (status)
     throw std::runtime_error("Error demangling kernel signature");
 
-  std::string result {demangled_name};
-  std::free(demangled_name); // Free the allocated memory by api
-  return result;
+  return demangled_name.get();
 #endif
 }
 

--- a/src/runtime_src/core/common/scheduler.cpp
+++ b/src/runtime_src/core/common/scheduler.cpp
@@ -1,19 +1,6 @@
-/**
- * Copyright (C) 2019-2021 Xilinx, Inc
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2019-2021 Xilinx, Inc
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
 #include "scheduler.h"
 #include "system.h"
 #include "device.h"
@@ -28,6 +15,7 @@
 #include <stdexcept>
 #include <cstring>
 #include <iostream>
+#include <gsl/pointers>
 
 #ifdef __linux__
 #include <sys/mman.h>
@@ -72,7 +60,7 @@ using buffer = std::shared_ptr<buffer_object>;
 static buffer
 create_exec_bo(xclDeviceHandle handle, size_t sz)
 {
-  auto delBO = [](buffer_object* bo) {
+  auto delBO = [](gsl::owner<buffer_object*> bo) {
     xclUnmapBO(bo->dev, bo->bo, bo->data);
     xclFreeBO(bo->dev,bo->bo);
     delete bo;


### PR DESCRIPTION
Experimental use of gsl::owner<T*> to silence scan issues. Fix owning pointer issue in xrt_module.cpp

