### PR TITLE
Remove default arguments from xrt::hw_context constructor

### DIFF
--- a/src/runtime_src/core/common/api/elf_int.h
+++ b/src/runtime_src/core/common/api/elf_int.h
@@ -4,6 +4,7 @@
 #define _XRT_COMMON_ELF_INT_H_
 
 // This file defines implementation extensions to the XRT ELF APIs.
+#include "core/common/config.h"
 #include "core/include/xrt/experimental/xrt_elf.h"
 #include <cstdint>
 #include <string>
@@ -14,7 +15,7 @@ namespace ELFIO { class elfio; }
 // Provide access to xrt::elf data that is not directly exposed
 // to end users via xrt::elf.   These functions are used by
 // XRT core implementation.
-namespace xrt_core { namespace elf_int {
+namespace xrt_core::elf_int {
 
 // Extract section data from ELF file
 std::vector<uint8_t>
@@ -22,8 +23,14 @@ get_section(const xrt::elf& elf, const std::string& sname);
 
 const ELFIO::elfio&
 get_elfio(const xrt::elf& elf);
-    
 
-}} // xclbin_int, xrt_core
+// Extract number of columns for parititon
+// This API is not really and ELF property, so rather than
+// publically exposing it, we provide this internal accessor
+XRT_CORE_COMMON_EXPORT  
+uint32_t
+get_partition_size(const xrt::elf& elf);
+
+} // namespace xrt_core::elf_int
 
 #endif

--- a/src/runtime_src/core/common/api/module_int.h
+++ b/src/runtime_src/core/common/api/module_int.h
@@ -71,10 +71,6 @@ dump_scratchpad_mem(const xrt::module& module);
 const kernel_info&
 get_kernel_info(const xrt::module& module);
 
-// Get partition size if ELF has the info
-uint32_t
-get_partition_size(const xrt::module& module);
-
 // Dump dynamic trace buffer
 // Buffer is dumped after the kernel run is finished
 void

--- a/src/runtime_src/core/common/ishim.h
+++ b/src/runtime_src/core/common/ishim.h
@@ -8,20 +8,23 @@
 #include "xcl_graph.h"
 #include "xrt.h"
 
-#include "core/common/shim/hwctx_handle.h"
-#include "core/include/shim_int.h"
-#include "core/include/xdp/counters.h"
+#include "core/common/api/elf_int.h"
 #include "core/common/shim/aie_buffer_handle.h"
 #include "core/common/shim/graph_handle.h"
+#include "core/common/shim/hwctx_handle.h"
 #include "core/common/shim/profile_handle.h"
+#include "core/include/shim_int.h"
+#include "core/include/xdp/counters.h"
 
 #include "xrt/xrt_aie.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_graph.h"
 #include "xrt/xrt_hw_context.h"
 #include "xrt/xrt_uuid.h"
+#include "xrt/experimental/xrt_elf.h"
 #include "xrt/experimental/xrt_fence.h"
 #include "xrt/experimental/xrt-next.h"
+
 
 #include <stdexcept>
 #include <condition_variable>
@@ -157,7 +160,7 @@ struct ishim
                     const xrt::hw_context::cfg_param_type& /*cfg_params*/,
                     xrt::hw_context::access_mode /*mode*/) const = 0;
 
-  // creates hw context using partition size
+  // Create a hw context using partition size
   // Used in elf flow
   // This function is not supported by all platforms
   virtual std::unique_ptr<hwctx_handle>
@@ -165,6 +168,14 @@ struct ishim
                     const xrt::hw_context::cfg_param_type& /*cfg_params*/,
                     xrt::hw_context::access_mode /*mode*/) const
   { throw not_supported_error{__func__}; }
+
+  // Create a hw context from a configation elf
+  // This function is not supported by all platforms
+  virtual std::unique_ptr<hwctx_handle>
+  create_hw_context(const xrt::elf& elf,
+                    const xrt::hw_context::cfg_param_type& cfg,
+                    xrt::hw_context::access_mode mode) const
+  { return create_hw_context(elf_int::get_partition_size(elf), cfg, mode); }
 
   // Registers an xclbin with shim, but does not load it.
   // This is no-op for most platform shims

--- a/src/runtime_src/core/include/xrt/xrt_hw_context.h
+++ b/src/runtime_src/core/include/xrt/xrt_hw_context.h
@@ -106,7 +106,7 @@ public:
    * @param device
    *  Device where context is created
    * @param elf
-   *  XRT Elf object created from config Elf file
+   *  Elf configuration object
    * @param cfg_param
    *  Configuration Parameters (incl. Quality of Service)
    * @param mode
@@ -118,8 +118,21 @@ public:
    */
   XRT_API_EXPORT
   hw_context(const xrt::device& device, const xrt::elf& elf,
-             const cfg_param_type& cfg_param = cfg_param_type{},
-             access_mode mode = access_mode::shared);
+             const cfg_param_type& cfg_param, access_mode mode);
+
+  /**
+    * hw_context() - Constructor with Elf file with implied qos and mode
+    *
+    * @param device
+    *  Device where context is created
+    * @param elf
+    *  Elf configuration object
+    *
+    * This constructor defaults optional configuration parameters
+    * and creates a hw context with shared access mode.
+    */
+  XRT_API_EXPORT
+  hw_context(const xrt::device& device, const xrt::elf& elf);
 
   /**
    * add_config() - adds config Elf file to the context


### PR DESCRIPTION
#### Problem solved by the commit
The decision about the value of unused arguments is moved to the implementation code for ABI protection.

#### How problem was solved, alternative solutions (if any) and why they were rejected
This PR additionally add shim callback for creating a hwctx_handle from an elf.  The default implementation (if not overridden by shim) uses existing callback that takes the partition size.

xrt::elf was enhanced to extract the partition size from the elf without going through a module.

xrt::module is in dire need of a rewrite.

