### PR TITLE
[XDP] Prevent segfault by checking correct usage for range of tiles for aie_profile

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_metadata.cpp
@@ -501,11 +501,21 @@ namespace xdp {
 
         std::vector<std::string> minTile;
         boost::split(minTile, metrics[i][0], boost::is_any_of(","));
-        minCol = aie::convertStringToUint8(minTile[0]);
-        minRow = aie::convertStringToUint8(minTile[1]) + rowOffset;
 
         std::vector<std::string> maxTile;
         boost::split(maxTile, metrics[i][1], boost::is_any_of(","));
+        
+        if (minTile.size() != 2 || maxTile.size() != 2) {
+          std::stringstream msg;
+          msg << "Tile range specification in tile_based_" << modName
+              << "_metrics is not a valid format and hence skipped. Should be {<mincolumn,<minrow>}:{<maxcolumn>,<maxrow>}";
+          xrt_core::message::send(severity_level::warning, "XRT", msg.str());
+          continue;
+        }
+              
+        minCol = aie::convertStringToUint8(minTile[0]);
+        minRow = aie::convertStringToUint8(minTile[1]) + rowOffset;
+
         maxCol = aie::convertStringToUint8(maxTile[0]);
         maxRow = aie::convertStringToUint8(maxTile[1]) + rowOffset;
       }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
[CR-1223004](https://jira.xilinx.com/browse/CR-1223004) Using range of columns for memory tile causes segmentation fault

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
[UG-1076](https://docs.amd.com/r/en-US/ug1076-ai-engine-environment/XRT-Flow?tocId=UBk2qtIX2tunIJmjD4G4pw) has a documentation error which specifies the wrong format for range of tiles for tile-based settings of memory tiles.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Ensured that there were two parameters (col, row) entered. If they weren't, we skip it.

#### Risks (if any) associated the changes in the commit
Low.

#### What has been tested and how, request additional testing if necessary
Tested on VEK280. Verified that there is no segmentation fault and instead the user sees the appropriate warning message. Also ensured that for the correct format there is no crash.

#### Documentation impact (if any)
Yes - [UG-1076](https://docs.amd.com/r/en-US/ug1076-ai-engine-environment/XRT-Flow?tocId=UBk2qtIX2tunIJmjD4G4pw) needs to be updated to have the correct format for for range of tiles for tile-based settings of memory tiles.