### PR TITLE
Remove live ctx requirement for preemption report

### DIFF
--- a/src/runtime_src/core/common/info_telemetry.cpp
+++ b/src/runtime_src/core/common/info_telemetry.cpp
@@ -55,10 +55,6 @@ aie2_preemption_info(const xrt_core::device* device)
   for (const auto& kp : data) {
   boost::property_tree::ptree pt_preempt;
 
-  // if no hw ctx is running, don't populate
-  if(is_value_na(kp.preemption_data.slot_index))
-    continue;
-
   auto populate_value = [](uint64_t value) {
     return is_value_na(value) ? "N/A" : std::to_string(value);
   };

--- a/src/runtime_src/core/tools/common/reports/ReportPreemption.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportPreemption.cpp
@@ -66,11 +66,6 @@ ReportPreemption::writeReport(const xrt_core::device* ,
   const bpt empty_ptree;
   bpt telemetry_array = pt.get_child("telemetry", empty_ptree);
   _output << "Premption Telemetry Data\n";
-  if (telemetry_array.empty()) {
-    _output << " No hardware contexts running on device\n\n";
-    return;
-  }
-
   _output << generate_preemption_string(telemetry_array);
   _output << std::endl;
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Remove live ctx requirement for preemption report

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
DSV testing. Since preemption is persistent data, they need to run this report before running a model to get a baseline and then figure out the preemption points. 

#### How problem was solved, alternative solutions (if any) and why they were rejected
remove array empty check

#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
Tested on MCDM

#### Documentation impact (if any)
N/A
