### PR TITLE
XDP VE2: Resetting timer for all the tiles used in partition and change of core tile trace end event

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info/aie_util.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info/aie_util.cpp
@@ -198,6 +198,17 @@ namespace xdp::aie {
     return config;
   }
 
+  uint8_t
+  getNumRows(const boost::property_tree::ptree& aie_meta,
+            const std::string& location)
+  {
+    static std::optional<uint8_t> numRows;
+    if (!numRows.has_value()) {
+      numRows = aie_meta.get_child(location).get_value<uint8_t>();
+    }
+    return *numRows;
+  }
+
   /****************************************************************************
    * Get first row offset of AIE tiles in array
    ***************************************************************************/

--- a/src/runtime_src/xdp/profile/database/static_info/aie_util.h
+++ b/src/runtime_src/xdp/profile/database/static_info/aie_util.h
@@ -66,6 +66,11 @@ namespace xdp::aie {
   
   XDP_CORE_EXPORT
   uint8_t
+  getNumRows(const boost::property_tree::ptree& aie_meta,
+            const std::string& location);
+
+  XDP_CORE_EXPORT
+  uint8_t
   getAIETileRowOffset(const boost::property_tree::ptree& aie_meta,
                       const std::string& location);
   

--- a/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_control_config_filetype.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_control_config_filetype.cpp
@@ -71,6 +71,12 @@ AIEControlConfigFiletype::getAIECompilerOptions() const
     return aiecompiler_options;
 }
 
+uint8_t
+AIEControlConfigFiletype::getNumRows() const
+{
+    return xdp::aie::getNumRows(aie_meta, "aie_metadata.driver_config.num_rows");
+}
+
 uint8_t 
 AIEControlConfigFiletype::getAIETileRowOffset() const {
     return xdp::aie::getAIETileRowOffset(aie_meta, "aie_metadata.driver_config.aie_tile_row_start");

--- a/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_control_config_filetype.h
+++ b/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_control_config_filetype.h
@@ -42,6 +42,8 @@ class AIEControlConfigFiletype : public xdp::aie::BaseFiletypeImpl {
 
         uint8_t getAIETileRowOffset() const override;
 
+        uint8_t getNumRows() const override;
+
         std::vector<uint8_t>
         getPartitionOverlayStartCols() const override;
 

--- a/src/runtime_src/xdp/profile/database/static_info/filetypes/base_filetype_impl.h
+++ b/src/runtime_src/xdp/profile/database/static_info/filetypes/base_filetype_impl.h
@@ -41,6 +41,8 @@ class BaseFiletypeImpl {
         virtual aiecompiler_options
         getAIECompilerOptions() const = 0;
         
+        virtual uint8_t getNumRows() const = 0;
+
         virtual uint8_t getAIETileRowOffset() const = 0;
 
         virtual std::vector<uint8_t>

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/util/aie_trace_config.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/util/aie_trace_config.cpp
@@ -511,7 +511,9 @@ namespace xdp::aie::trace {
   /****************************************************************************
    * Reset timer for the specified tile range
    ***************************************************************************/
-  void timerSyncronization(XAie_DevInst* aieDevInst, xaiefal::XAieDev* aieDevice, std::shared_ptr<AieTraceMetadata> metadata, uint8_t startCol, uint8_t numCols)
+  void timerSyncronization(XAie_DevInst* aieDevInst, xaiefal::XAieDev* aieDevice,
+                          std::shared_ptr<AieTraceMetadata> metadata, uint8_t startCol,
+                          uint8_t numCols, uint8_t numRows)
   {
     std::shared_ptr<xaiefal::XAieBroadcast> traceStartBroadcastCh1 = nullptr, traceStartBroadcastCh2 = nullptr;
     std::vector<XAie_LocType> vL;
@@ -524,34 +526,34 @@ namespace xdp::aie::trace {
     uint8_t broadcastId2 = traceStartBroadcastCh2->getBc();
 
     //build broadcast network
-    aie::trace::build2ChannelBroadcastNetwork(aieDevInst, metadata, broadcastId1, broadcastId2, XAIE_EVENT_COMBO_EVENT_0_PL, startCol, numCols);
+    aie::trace::build2ChannelBroadcastNetwork(aieDevInst, metadata, broadcastId1, broadcastId2,
+                                              XAIE_EVENT_COMBO_EVENT_0_PL, startCol, numCols, numRows);
 
     //set timer control register
-    for (auto& tileMetric : metadata->getConfigMetrics()) {
-      auto tile       = tileMetric.first;
-      auto col        = tile.col + startCol; 
-      auto row        = tile.row;
-      auto type       = aie::getModuleType(row, metadata->getRowOffset());
-      auto loc        = XAie_TileLoc(col, row);
+    for(uint8_t col = startCol; col < startCol + numCols; col++) {
+      for(uint8_t row = 0; row < numRows; row++) {
+        auto type       = aie::getModuleType(row, metadata->getRowOffset());
+        auto loc        = XAie_TileLoc(col, row);
 
-      if(type == module_type::shim) {
-        XAie_Events resetEvent = (XAie_Events)(XAIE_EVENT_BROADCAST_A_0_PL + broadcastId2);
-        if(col == startCol)
-        {
-          resetEvent = XAIE_EVENT_COMBO_EVENT_0_PL;
+        if(type == module_type::shim) {
+          XAie_Events resetEvent = (XAie_Events)(XAIE_EVENT_BROADCAST_A_0_PL + broadcastId2);
+          if(col == startCol)
+          {
+            resetEvent = XAIE_EVENT_COMBO_EVENT_0_PL;
+          }
+
+          XAie_SetTimerResetEvent(aieDevInst, loc, XAIE_PL_MOD, resetEvent, XAIE_RESETDISABLE);
         }
-
-        XAie_SetTimerResetEvent(aieDevInst, loc, XAIE_PL_MOD, resetEvent, XAIE_RESETDISABLE);
-      }
-      else if(type == module_type::mem_tile) {
-        XAie_Events resetEvent = (XAie_Events) (XAIE_EVENT_BROADCAST_0_MEM_TILE + broadcastId1);
-        XAie_SetTimerResetEvent(aieDevInst, loc, XAIE_MEM_MOD, resetEvent, XAIE_RESETDISABLE);
-      }
-      else {
-        XAie_Events resetEvent = (XAie_Events) (XAIE_EVENT_BROADCAST_0_CORE + broadcastId1);
-        XAie_SetTimerResetEvent(aieDevInst, loc, XAIE_CORE_MOD, resetEvent, XAIE_RESETDISABLE);
-        resetEvent = (XAie_Events) (XAIE_EVENT_BROADCAST_0_MEM + broadcastId1);
-        XAie_SetTimerResetEvent(aieDevInst, loc, XAIE_MEM_MOD, resetEvent, XAIE_RESETDISABLE);
+        else if(type == module_type::mem_tile) {
+          XAie_Events resetEvent = (XAie_Events) (XAIE_EVENT_BROADCAST_0_MEM_TILE + broadcastId1);
+          XAie_SetTimerResetEvent(aieDevInst, loc, XAIE_MEM_MOD, resetEvent, XAIE_RESETDISABLE);
+        }
+        else {
+          XAie_Events resetEvent = (XAie_Events) (XAIE_EVENT_BROADCAST_0_CORE + broadcastId1);
+          XAie_SetTimerResetEvent(aieDevInst, loc, XAIE_CORE_MOD, resetEvent, XAIE_RESETDISABLE);
+          resetEvent = (XAie_Events) (XAIE_EVENT_BROADCAST_0_MEM + broadcastId1);
+          XAie_SetTimerResetEvent(aieDevInst, loc, XAIE_MEM_MOD, resetEvent, XAIE_RESETDISABLE);
+        }
       }
     }
 
@@ -559,31 +561,31 @@ namespace xdp::aie::trace {
     XAie_EventGenerate(aieDevInst, XAie_TileLoc(startCol, 0), XAIE_PL_MOD, XAIE_EVENT_COMBO_EVENT_0_PL);
 
     //reset timer control register so that timer are not reset after this point
-    for (auto& tileMetric : metadata->getConfigMetrics()) {
-      auto tile       = tileMetric.first;
-      auto col        = tile.col + startCol;
-      auto row        = tile.row;
-      auto type       = aie::getModuleType(row, metadata->getRowOffset());
-      auto loc        = XAie_TileLoc(col, row);
+    for(uint8_t col = startCol; col < startCol + numCols; col++) {
+      for(uint8_t row = 0; row < numRows; row++) {
+        auto type       = aie::getModuleType(row, metadata->getRowOffset());
+        auto loc        = XAie_TileLoc(col, row);
 
-      if(type == module_type::shim) {
-        XAie_Events resetEvent = XAIE_EVENT_NONE_PL ;
-        XAie_SetTimerResetEvent(aieDevInst, loc, XAIE_PL_MOD, resetEvent, XAIE_RESETDISABLE);
-      }
-      else if(type == module_type::mem_tile) {
-        XAie_Events resetEvent = XAIE_EVENT_NONE_MEM_TILE;
-        XAie_SetTimerResetEvent(aieDevInst, loc, XAIE_MEM_MOD, resetEvent, XAIE_RESETDISABLE);
-      }
-      else {
-        XAie_Events resetEvent = XAIE_EVENT_NONE_CORE;
-        XAie_SetTimerResetEvent(aieDevInst, loc, XAIE_CORE_MOD, resetEvent, XAIE_RESETDISABLE);
-        resetEvent = XAIE_EVENT_NONE_MEM;
-        XAie_SetTimerResetEvent(aieDevInst, loc, XAIE_MEM_MOD, resetEvent, XAIE_RESETDISABLE);
+        if(type == module_type::shim) {
+          XAie_Events resetEvent = XAIE_EVENT_NONE_PL ;
+          XAie_SetTimerResetEvent(aieDevInst, loc, XAIE_PL_MOD, resetEvent, XAIE_RESETDISABLE);
+        }
+        else if(type == module_type::mem_tile) {
+          XAie_Events resetEvent = XAIE_EVENT_NONE_MEM_TILE;
+          XAie_SetTimerResetEvent(aieDevInst, loc, XAIE_MEM_MOD, resetEvent, XAIE_RESETDISABLE);
+        }
+        else {
+          XAie_Events resetEvent = XAIE_EVENT_NONE_CORE;
+          XAie_SetTimerResetEvent(aieDevInst, loc, XAIE_CORE_MOD, resetEvent, XAIE_RESETDISABLE);
+          resetEvent = XAIE_EVENT_NONE_MEM;
+          XAie_SetTimerResetEvent(aieDevInst, loc, XAIE_MEM_MOD, resetEvent, XAIE_RESETDISABLE);
+        }
       }
     }
 
     //reset broadcast network
-    reset2ChannelBroadcastNetwork(aieDevInst, metadata, broadcastId1, broadcastId2, startCol, numCols);
+    reset2ChannelBroadcastNetwork(aieDevInst, metadata, broadcastId1, broadcastId2, startCol,
+                                 numCols, numRows);
 
     //release the channels used for timer sync
     traceStartBroadcastCh1->release();

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/util/aie_trace_config.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/util/aie_trace_config.h
@@ -135,10 +135,11 @@ namespace xdp::aie::trace {
    * @param metadata       Trace Metadata
    * @param startCol       Start column of the partition
    * @param numCols        Num of columns in the partition
+   * @param numRows        Num of Rows
    */
   void timerSyncronization(XAie_DevInst* aieDevInst, xaiefal::XAieDev* aieDevice,
                            std::shared_ptr<AieTraceMetadata> metadata, uint8_t startCol, 
-                           uint8_t numCols);
+                           uint8_t numCols, uint8_t numRows);
 }  // namespace xdp::aie::trace
 
 #endif

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/util/aie_trace_util.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/util/aie_trace_util.cpp
@@ -709,21 +709,15 @@ namespace xdp::aie::trace {
   /****************************************************************************
    * Set up broadcast network 
    ***************************************************************************/
-  void build2ChannelBroadcastNetwork(XAie_DevInst* aieDevInst, std::shared_ptr<AieTraceMetadata> metadata, uint8_t broadcastId1, uint8_t broadcastId2, XAie_Events event, uint8_t startCol, uint8_t numCols) 
+  void build2ChannelBroadcastNetwork(XAie_DevInst* aieDevInst, std::shared_ptr<AieTraceMetadata> metadata,
+                                    uint8_t broadcastId1, uint8_t broadcastId2, XAie_Events event,
+                                    uint8_t startCol, uint8_t numCols, uint8_t numRows)
   {
-    std::vector<uint8_t> maxRowAtCol(startCol + numCols, 0);
-    for (auto& tileMetric : metadata->getConfigMetrics()) {
-      auto tile       = tileMetric.first;
-      auto col        = tile.col;
-      auto row        = tile.row;
-      maxRowAtCol[startCol + col] = std::max(maxRowAtCol[col], (uint8_t)row);
-    }
-
     XAie_Events bcastEvent2_PL =  (XAie_Events) (XAIE_EVENT_BROADCAST_A_0_PL + broadcastId2);
     XAie_EventBroadcast(aieDevInst, XAie_TileLoc(startCol, 0), XAIE_PL_MOD, broadcastId2, event);
 
     for(uint8_t col = startCol; col < startCol + numCols; col++) {
-      for(uint8_t row = 0; row <= maxRowAtCol[col]; row++) {
+      for(uint8_t row = 0; row < numRows; row++) {
         module_type tileType = aie::getModuleType(row, metadata->getRowOffset());
         auto loc = XAie_TileLoc(col, row);
 
@@ -735,7 +729,7 @@ namespace xdp::aie::trace {
           else {
             XAie_EventBroadcast(aieDevInst, loc, XAIE_PL_MOD, broadcastId1, bcastEvent2_PL);
           }
-          if(maxRowAtCol[col] != row) {
+          if(row != numRows-1) {
             XAie_EventBroadcastBlockDir(aieDevInst, loc, XAIE_PL_MOD, XAIE_EVENT_SWITCH_A, broadcastId1, XAIE_EVENT_BROADCAST_SOUTH | XAIE_EVENT_BROADCAST_WEST | XAIE_EVENT_BROADCAST_EAST);
           }
           else {
@@ -753,7 +747,7 @@ namespace xdp::aie::trace {
           }
         }
         else if(tileType == module_type::mem_tile) {
-          if(maxRowAtCol[col] != row) {
+          if(row != numRows-1) {
             XAie_EventBroadcastBlockDir(aieDevInst, loc, XAIE_MEM_MOD, XAIE_EVENT_SWITCH_A, broadcastId1, XAIE_EVENT_BROADCAST_SOUTH | XAIE_EVENT_BROADCAST_WEST | XAIE_EVENT_BROADCAST_EAST);
           }
           else {
@@ -761,7 +755,7 @@ namespace xdp::aie::trace {
           }
         }
         else { //core tile
-          if(maxRowAtCol[col] != row) {
+          if(row != numRows-1) {
             XAie_EventBroadcastBlockDir(aieDevInst, loc, XAIE_CORE_MOD, XAIE_EVENT_SWITCH_A, broadcastId1, XAIE_EVENT_BROADCAST_SOUTH | XAIE_EVENT_BROADCAST_WEST);
           }
           else {
@@ -776,19 +770,14 @@ namespace xdp::aie::trace {
   /****************************************************************************
    * Reset broadcast network
    ***************************************************************************/
-  void reset2ChannelBroadcastNetwork(XAie_DevInst* aieDevInst, std::shared_ptr<AieTraceMetadata> metadata, uint8_t broadcastId1, uint8_t broadcastId2, uint8_t startCol, uint8_t numCols) {
-    std::vector<uint8_t> maxRowAtCol(startCol + numCols, 0);
-    for (auto& tileMetric : metadata->getConfigMetrics()) {
-      auto tile       = tileMetric.first;
-      auto col        = tile.col;
-      auto row        = tile.row;
-      maxRowAtCol[startCol + col] = std::max(maxRowAtCol[col], (uint8_t)row);
-    }
+  void reset2ChannelBroadcastNetwork(XAie_DevInst* aieDevInst, std::shared_ptr<AieTraceMetadata> metadata,
+                                    uint8_t broadcastId1, uint8_t broadcastId2, uint8_t startCol,
+                                    uint8_t numCols, uint8_t numRows) {
 
     XAie_EventBroadcastReset(aieDevInst, XAie_TileLoc(startCol, 0), XAIE_PL_MOD, broadcastId2);
 
     for(uint8_t col = startCol; col < startCol + numCols; col++) {
-      for(uint8_t row = 0; row <= maxRowAtCol[col]; row++) {
+      for(uint8_t row = 0; row < numRows; row++) {
         module_type tileType = aie::getModuleType(row, metadata->getRowOffset());
         auto loc = XAie_TileLoc(col, row);
 

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/util/aie_trace_util.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/util/aie_trace_util.h
@@ -185,8 +185,11 @@ namespace xdp::aie::trace {
    * @param event          Event to trigger broadcast network
    * @param startCol       Start column of the partition
    * @param numCols        Num of columns in the partition
+   * @param numRows        Num of Rows
    */
-  void build2ChannelBroadcastNetwork(XAie_DevInst* aieDevInst, std::shared_ptr<AieTraceMetadata> metadata, uint8_t broadcastId1, uint8_t broadcastId2, XAie_Events event, uint8_t startCol, uint8_t numCols);
+  void build2ChannelBroadcastNetwork(XAie_DevInst* aieDevInst, std::shared_ptr<AieTraceMetadata> metadata,
+                                    uint8_t broadcastId1, uint8_t broadcastId2, XAie_Events event,
+                                    uint8_t startCol, uint8_t numCols, uint8_t numRows);
 
   /**
    * @brief Reset 2-channel broadcast network for specified tile range
@@ -196,8 +199,11 @@ namespace xdp::aie::trace {
    * @param broadcastId2   Broadcast channel 2
    * @param startCol       Start column of the partition
    * @param numCols        Num of columns in the partition
+   * @param numRows        Num of Rows
    */
-  void reset2ChannelBroadcastNetwork(XAie_DevInst* aieDevInst, std::shared_ptr<AieTraceMetadata> metadata, uint8_t broadcastId1, uint8_t broadcastId2, uint8_t startCol, uint8_t numCols);
+  void reset2ChannelBroadcastNetwork(XAie_DevInst* aieDevInst, std::shared_ptr<AieTraceMetadata> metadata,
+                                    uint8_t broadcastId1, uint8_t broadcastId2, uint8_t startCol,
+                                    uint8_t numCols, uint8_t numRows);
 }  // namespace xdp::aie::trace
 
 #endif

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/ve2/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/ve2/aie_trace.cpp
@@ -97,7 +97,7 @@ namespace xdp {
 
     // Core trace start/end: these are also broadcast to memory module
     coreTraceStartEvent = XAIE_EVENT_ACTIVE_CORE;
-    coreTraceEndEvent = XAIE_EVENT_DISABLED_CORE;
+    coreTraceEndEvent = XAIE_EVENT_USER_EVENT_3_CORE;
 
     // Memory/interface tile trace is flushed at end of run
     memoryTileTraceStartEvent = XAIE_EVENT_TRUE_MEM_TILE;
@@ -322,10 +322,11 @@ namespace xdp {
     }
 
     auto compilerOptions = metadataReader->getAIECompilerOptions();
+    uint8_t numRows = metadataReader->getNumRows();
     std::shared_ptr<xaiefal::XAieBroadcast> traceStartBroadcastCh1 = nullptr, traceStartBroadcastCh2 = nullptr;
     if(compilerOptions.enable_multi_layer) {
 
-      aie::trace::timerSyncronization(aieDevInst,aieDevice, metadata, startCol, numCols);
+      aie::trace::timerSyncronization(aieDevInst,aieDevice, metadata, startCol, numCols, numRows);
       if(xrt_core::config::get_aie_trace_settings_trace_start_broadcast()) 
       {
         std::vector<XAie_LocType> vL;
@@ -333,7 +334,9 @@ namespace xdp {
         traceStartBroadcastCh1->reserve();
         traceStartBroadcastCh2 = aieDevice->broadcast(vL, XAIE_PL_MOD, XAIE_CORE_MOD);
         traceStartBroadcastCh2->reserve();
-        aie::trace::build2ChannelBroadcastNetwork(aieDevInst, metadata, traceStartBroadcastCh1->getBc(), traceStartBroadcastCh2->getBc(), XAIE_EVENT_COMBO_EVENT_0_PL, startCol, numCols);
+        aie::trace::build2ChannelBroadcastNetwork(aieDevInst, metadata, traceStartBroadcastCh1->getBc(),
+                                                  traceStartBroadcastCh2->getBc(), XAIE_EVENT_COMBO_EVENT_0_PL,
+                                                  startCol, numCols, numRows);
 
         coreTraceStartEvent = (XAie_Events) (XAIE_EVENT_BROADCAST_0_CORE + traceStartBroadcastCh1->getBc());
         memoryTileTraceStartEvent = (XAie_Events) (XAIE_EVENT_BROADCAST_0_MEM_TILE + traceStartBroadcastCh1->getBc());
@@ -347,7 +350,6 @@ namespace xdp {
     
     if (metadata->getUseUserControl())
       coreTraceStartEvent = XAIE_EVENT_INSTR_EVENT_0_CORE;
-    coreTraceEndEvent = XAIE_EVENT_INSTR_EVENT_1_CORE;
 
     // Iterate over all used/specified tiles
     // NOTE: rows are stored as absolute as required by resource manager


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
1. Timer of the tiles that were not the part of trace graph were not being reset, which was causing issue with ML Timeline.
2. Some design use Instruction event and XDP was using that to stop trace module due to which incomplete trace was generated.
#### How problem was solved, alternative solutions (if any) and why they were rejected
Resetting timers of all the tiles used in partition.
Changed the Core tile trace end event from Instruction event to User event 3
#### Risks (if any) associated the changes in the commit
NA
#### What has been tested and how, request additional testing if necessary
Tested trace and ml timeline for Restnet50 ML ADF design for which the issue was seen.
#### Documentation impact (if any)
NA