### PR TITLE
VITIS-14540 - [MCDM] Provide interface for xrt-smi to disable frame boundary preemption. 

### DIFF
--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -333,7 +333,8 @@ enum class key_type
   noop,
 
   xocl_errors_ex,
-  xocl_ex_error_code2string
+  xocl_ex_error_code2string,
+  frame_boundary_preemption
 };
 
 struct pcie_vendor : request
@@ -3980,6 +3981,25 @@ struct preemption : request
 
   virtual void
   put(const device*, const std::any&) const override = 0;
+
+};
+
+/*
+ * this request force enables or disables frame boundary pre-emption globally
+ * 1: enable; 0: disable
+*/
+struct frame_boundary_preemption : request
+{
+  using result_type = uint32_t;  // get value type
+  using value_type = uint32_t;   // put value type
+
+  static const key_type key = key_type::frame_boundary_preemption;
+
+  virtual std::any
+    get(const device*) const override = 0;
+
+  virtual void
+    put(const device*, const std::any&) const override = 0;
 
 };
 

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -3995,11 +3995,11 @@ struct frame_boundary_preemption : request
 
   static const key_type key = key_type::frame_boundary_preemption;
 
-  virtual std::any
-    get(const device*) const override = 0;
+  std::any
+  get(const device*) const override = 0;
 
-  virtual void
-    put(const device*, const std::any&) const override = 0;
+  void
+  put(const device*, const std::any&) const override = 0;
 
 };
 


### PR DESCRIPTION
Problem solved by the commit
Added the interface to enable/disable frame boundary preemption.

Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
xrt-smi need a interface to enable/disable frame boundary preemption..

How problem was solved, alternative solutions (if any) and why they were rejected
After this code change, a new escape code will be added to the NPU driver to enable/disable frame boundary preemption.

Risks (if any) associated the changes in the commit
N/A

What has been tested and how, request additional testing if necessary
Tested with the new escape code in NPU driver on Windows 11.

Documentation impact (if any)
N/A