### PR TITLE
[XDP] remove deprecated metric sets reference.

### DIFF
--- a/src/runtime_src/xdp/profile/device/tracedefs.h
+++ b/src/runtime_src/xdp/profile/device/tracedefs.h
@@ -90,7 +90,7 @@ Please increase trace_buffer_size and trace_buffer_offload_interval together or 
 
 #define AIE_TRACE_BUF_REUSE_WARN              "AIE reuse_buffer may cause overrun. \
 Recommended settings: \
-buffer_size/stream: functions >= 8M functions_partial_stalls >= 16M functions_all_stalls >= 32M, \
+buffer_size/stream: functions >= 8M partial_stalls >= 16M all_stalls >= 32M, \
 trace streams <= 4, buffer_offload_interval_us <= 100. \
 For large tile count, use granular trace. "
 

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_metadata.cpp
@@ -648,24 +648,6 @@ namespace xdp {
         }
         tileMetric.second = defaultSet;
       }
-
-      // Check for deprecated metric set names
-      if (tileMetric.second == "functions_partial_stalls") {
-        if (showWarning2) {
-          xrt_core::message::send(severity_level::warning, "XRT", 
-              "The metric set functions_partial_stalls is being renamed to partial_stalls. "
-              "Please use the new set name starting in 2024.2.");
-          showWarning2 = false;
-        }
-      }
-      if (tileMetric.second == "functions_all_stalls") {
-        if (showWarning3) {
-          xrt_core::message::send(severity_level::warning, "XRT", 
-              "The metric set functions_all_stalls is being renamed to all_stalls. "
-              "Please use the new set name starting in 2024.2.");
-          showWarning3 = false;
-        }
-      }
     }
 
     // Remove all the "off" tiles

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_metadata.cpp
@@ -617,8 +617,6 @@ namespace xdp {
 
     // Set default, check validity, and remove "off" tiles
     bool showWarning = true;
-    bool showWarning2 = true;
-    bool showWarning3 = true;
     std::vector<tile_type> offTiles;
     auto defaultSet = defaultSets[type];
     auto coreSets = metricSets[module_type::core];

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_metadata.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_metadata.h
@@ -151,8 +151,7 @@ class AieTraceMetadata {
     };
 
     std::map <module_type, std::vector<std::string>> metricSets {
-      { module_type::core,     {"functions", "functions_partial_stalls", 
-                                "functions_all_stalls", "partial_stalls",
+      { module_type::core,     {"functions", "partial_stalls",
                                 "all_stalls", "all_dma", "all_stalls_dma",
                                 "all_stalls_s2mm", "all_stalls_mm2s",
                                 "s2mm_channels", "mm2s_channels",

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/util/aie_trace_util.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/util/aie_trace_util.cpp
@@ -69,9 +69,6 @@ namespace xdp::aie::trace {
       eventSets["mm2s_channels_stalls"]   = eventSets["functions"];
     }
 
-    // Deprecated after 2024.1
-    eventSets["functions_partial_stalls"] = eventSets["partial_stalls"];
-    eventSets["functions_all_stalls"]     = eventSets["all_stalls"];
     return eventSets;
   }
 
@@ -138,9 +135,6 @@ namespace xdp::aie::trace {
     eventSets["mm2s_channels"]   = eventSets["s2mm_channels"];
     eventSets["all_stalls_mm2s"] = eventSets["all_stalls_s2mm"];
 
-    // Deprecated after 2024.1
-    eventSets["functions_partial_stalls"] = eventSets["partial_stalls"];
-    eventSets["functions_all_stalls"]     = eventSets["all_stalls"];
     return eventSets;
   }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
[CR-1204442] Remove old metric sets support in 2025.1

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
[CR-1204442]

#### How problem was solved, alternative solutions (if any) and why they were rejected
Removed code surrounding it.

#### Risks (if any) associated the changes in the commit
low

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
