### PR TITLE
fix the race condition between device::get_xclbin() and device::record_xclbin().

### DIFF
--- a/src/runtime_src/core/common/device.cpp
+++ b/src/runtime_src/core/common/device.cpp
@@ -189,9 +189,9 @@ get_xclbin(const uuid& xclbin_id) const
   // Allow access to xclbin in process of loading via device::load_xclbin
   if (xclbin_id && xclbin_id == m_xclbin.get_uuid())
     return m_xclbin;
-  if (xclbin_id) {
+
+  if (xclbin_id)
     return m_xclbins.get(xclbin_id);
-  }
 
   // Single xclbin case
   return m_xclbin;
@@ -221,18 +221,21 @@ update_xclbin_info()
   }
 }
 
+// Compute CU sort order, kernel driver zocl and xocl now assign and
+// control the sort order, which is accessible via a query request.
+// For emulation old xclbin_parser::get_cus is used.
 void
 device::
 update_cu_info()
 {
-  // Compute CU sort order, kernel driver zocl and xocl now assign and
-  // control the sort order, which is accessible via a query request.
-  // For emulation old xclbin_parser::get_cus is used.
-  std::lock_guard lk(m_mutex);
-  m_cus.clear();
-  m_cu2idx.clear();
-  m_scu2idx.clear();
   try {
+    // Lock is scoped to try block to ensure lock is released before
+    // reaching outer catch block, where get_axlf_section() cannot be
+    // called with lock held as it in turn calls get_xclbin(uuid).
+    std::lock_guard lk(m_mutex);
+    m_cus.clear();
+    m_cu2idx.clear();
+    m_scu2idx.clear();
     // Regular CUs
     auto cudata = xrt_core::device_query<xrt_core::query::kds_cu_info>(this);
 
@@ -262,6 +265,8 @@ update_cu_info()
     // there is only one default slot with number 0.
     auto ip_layout = get_axlf_section<const ::ip_layout*>(IP_LAYOUT);
     if (ip_layout != nullptr) {
+      // Aquire lock again before updating m_cus and m_cu2idx
+      std::lock_guard lk(m_mutex);
       m_cus = xclbin::get_cus(ip_layout);
       m_cu2idx[0u] = xclbin::get_cu_indices(ip_layout); // default slot 0
     }

--- a/src/runtime_src/core/common/device.cpp
+++ b/src/runtime_src/core/common/device.cpp
@@ -184,16 +184,13 @@ xrt::xclbin
 device::
 get_xclbin(const uuid& xclbin_id) const
 {
-  {
-    // do not lock m_mutex in case of Single xclbin
-    std::lock_guard lk(m_mutex);
+  std::lock_guard lk(m_mutex);
 
-    // Allow access to xclbin in process of loading via device::load_xclbin
-    if (xclbin_id && xclbin_id == m_xclbin.get_uuid())
-      return m_xclbin;
-    if (xclbin_id) {
-      return m_xclbins.get(xclbin_id);
-    }
+  // Allow access to xclbin in process of loading via device::load_xclbin
+  if (xclbin_id && xclbin_id == m_xclbin.get_uuid())
+    return m_xclbin;
+  if (xclbin_id) {
+    return m_xclbins.get(xclbin_id);
   }
 
   // Single xclbin case

--- a/src/runtime_src/core/common/device.cpp
+++ b/src/runtime_src/core/common/device.cpp
@@ -184,11 +184,12 @@ xrt::xclbin
 device::
 get_xclbin(const uuid& xclbin_id) const
 {
+  std::lock_guard lk(m_mutex);
+
   // Allow access to xclbin in process of loading via device::load_xclbin
   if (xclbin_id && xclbin_id == m_xclbin.get_uuid())
     return m_xclbin;
   if (xclbin_id) {
-    std::lock_guard lk(m_mutex);
     return m_xclbins.get(xclbin_id);
   }
 

--- a/src/runtime_src/core/common/device.cpp
+++ b/src/runtime_src/core/common/device.cpp
@@ -184,13 +184,16 @@ xrt::xclbin
 device::
 get_xclbin(const uuid& xclbin_id) const
 {
-  std::lock_guard lk(m_mutex);
+  {
+    // do not lock m_mutex in case of Single xclbin
+    std::lock_guard lk(m_mutex);
 
-  // Allow access to xclbin in process of loading via device::load_xclbin
-  if (xclbin_id && xclbin_id == m_xclbin.get_uuid())
-    return m_xclbin;
-  if (xclbin_id) {
-    return m_xclbins.get(xclbin_id);
+    // Allow access to xclbin in process of loading via device::load_xclbin
+    if (xclbin_id && xclbin_id == m_xclbin.get_uuid())
+      return m_xclbin;
+    if (xclbin_id) {
+      return m_xclbins.get(xclbin_id);
+    }
   }
 
   // Single xclbin case


### PR DESCRIPTION

Problem solved by the commit
Application crash because of the race condition between device::get_xclbin() and device::record_xclbin().

Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1233298 - Back-to-back hw context creation and deletion caused crash of application
https://jira.xilinx.com/browse/CR-1233298

How problem was solved, alternative solutions (if any) and why they were rejected
Move the lock in device::get_xclbin() to fix the race condition.

Risks (if any) associated the changes in the commit
Low.

What has been tested and how, request additional testing if necessary
Tested on RyzenAI+Windows.

Documentation impact (if any)
N/A
