### PR TITLE
Temporal sharing overhead test enhancement

### DIFF
--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -60,6 +60,7 @@ enum class key_type
   xclbin_name,
   sequence_name,
   elf_name,
+  binary_name,
 
   dma_threads_raw,
 
@@ -598,7 +599,8 @@ struct xclbin_name : request
 {
   enum class type {
     validate,
-    gemm
+    gemm,
+    mobilenet
   };
 
   static std::string
@@ -609,6 +611,8 @@ struct xclbin_name : request
         return "validate";
       case type::gemm:
         return "gemm";
+      case type::mobilenet:
+        return "mobilenet";
     }
     return "unknown";
   }
@@ -688,6 +692,36 @@ struct elf_name : request
   using result_type = std::string;
   static const key_type key = key_type::elf_name;
   static const char* name() { return "elf_name"; }
+
+  virtual std::any
+  get(const device*, const std::any& req_type) const override = 0;
+};
+
+struct binary_name : request 
+{
+  enum class type {
+    ifm_mobilenet,
+    param_mobilenet,
+    DPU_instr_mobilenet
+  };
+
+  static std::string
+  enum_to_str(const type& type)
+  {
+    switch (type) {
+      case type::ifm_mobilenet:
+        return "ifm_mobilenet";
+      case type::param_mobilenet:
+        return "param_mobilenet";
+      case type::DPU_instr_mobilenet:
+        return "DPU_instr_mobilenet";
+    }
+    return "unknown";
+  }
+
+  using result_type = std::string;
+  static const key_type key = key_type::binary_name;
+  static const char* name() { return "binary_name"; }
 
   virtual std::any
   get(const device*, const std::any& req_type) const override = 0;

--- a/src/runtime_src/core/tools/common/tests/TestSpatialSharingOvd.h
+++ b/src/runtime_src/core/tools/common/tests/TestSpatialSharingOvd.h
@@ -36,7 +36,10 @@ public:
 
   // Constructor to initialize the test runner with a name and description
   TestSpatialSharingOvd()
-    : TestRunner("spatial-sharing-overhead", "Run Spatial Sharing Overhead Test"), ptree(get_test_header()){}
+  //For the time, the driver mandates even 4 column hardware contexts to 
+  //Occupy all 8 columns. Thus the logic for spatial sharing is implementing temporal sharing.
+  //This should be renamed back once the MCDM driver switches to spatial sharing.
+    : TestRunner("temporal-sharing-overhead", "Run Spatial Sharing Overhead Test"), ptree(get_test_header()){}
 };
 
 #endif

--- a/src/runtime_src/core/tools/common/tests/TestValidateUtilities.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestValidateUtilities.cpp
@@ -16,31 +16,32 @@
 #include "TestValidateUtilities.h"
 namespace xq = xrt_core::query;
 
-static constexpr size_t param_size = 0x100;
-static constexpr size_t inter_size = 0x100;
-static constexpr size_t mc_size = 0x100;
+// Buffer sizes for Mobilenet test
+static constexpr size_t ifm_size = 201736;
+static constexpr size_t param_size = 7233612;
+static constexpr size_t inter_size = 7192640;
+static constexpr size_t mc_size = 16;
+static constexpr size_t ofm_size = 8224;
+static constexpr size_t instr_word_size = 122575;
+static constexpr size_t instr_size = instr_word_size * sizeof(int);
 
 // Constructor for BO_set
 // BO_set is a collection of all the buffer objects so that the operations on all buffers can be done from a single object
 // Parameters:
 // - device: Reference to the xrt::device object
 // - kernel: Reference to the xrt::kernel object
-BO_set::BO_set(const xrt::device& device, const xrt::kernel& kernel, const std::string& dpu_instr, size_t buffer_size) 
-  : buffer_size(buffer_size), 
-    bo_ifm   (device, buffer_size, XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(1)),
+BO_set::BO_set(const xrt::device& device, const xrt::kernel& kernel, const std::string& dpu_instr, const std::string& ifm_file, const std::string& param_file) 
+  : bo_ifm   (device, ifm_size, XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(1)),
     bo_param (device, param_size, XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(2)),
-    bo_ofm   (device, buffer_size, XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(3)),
+    bo_ofm   (device, ofm_size, XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(3)),
     bo_inter (device, inter_size, XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(4)),
+    bo_instr (device, instr_size, XCL_BO_FLAGS_CACHEABLE, kernel.group_id(5)),
     bo_mc    (device, mc_size, XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(7))
 {
-  if (dpu_instr.empty()) {
-    // Create a no-op instruction if no instruction file is provided
-    std::memset(bo_instr.map<char*>(), (uint8_t)0, buffer_size);
-  } else {
-    size_t instr_size = XBValidateUtils::get_instr_size(dpu_instr); 
-    bo_instr = xrt::bo(device, instr_size * sizeof(int), XCL_BO_FLAGS_CACHEABLE, kernel.group_id(5));
-    XBValidateUtils::init_instr_buf(bo_instr, dpu_instr);
-  }
+  XBValidateUtils::init_buf_bin((int*)bo_ifm.map<int*>(), ifm_size, ifm_file);
+  XBValidateUtils::init_buf_bin((int*)bo_param.map<int*>(), param_size, param_file);
+  XBValidateUtils::init_buf_bin((int*)bo_instr.map<int*>(), instr_size, dpu_instr);
+  // XBValidateUtils::init_instr_buf(bo_instr, dpu_instr);
 }
 
 // Method to synchronize buffer objects to the device
@@ -74,7 +75,7 @@ TestCase::initialize()
   for (int j = 0; j < params.queue_len; j++) {
     xrt::kernel kernel;
     kernel = xrt::kernel(hw_ctx, params.kernel_name);
-    auto bos = BO_set(params.device, kernel, params.dpu_file, params.buffer_size);
+    auto bos = BO_set(params.device, kernel, params.dpu_file, params.ifm_file, params.param_file);
     bos.sync_bos_to_device();
     auto run = xrt::run(kernel);
     bos.set_kernel_args(run);
@@ -124,6 +125,17 @@ init_instr_buf(xrt::bo &bo_instr, const std::string& dpu_file) {
     ss >> std::hex >> word;
     *(instr++) = word;
   }
+}
+
+void init_buf_bin(int* buff, size_t bytesize, const std::string &filename) {
+
+  std::ifstream ifs(filename, std::ios::in | std::ios::binary);
+
+  if (!ifs.is_open()) {
+    std::cout << "Failure opening file " + filename + " for reading!!" << std::endl;
+    abort();
+  }
+  ifs.read((char *)buff, bytesize);
 }
 
 size_t 

--- a/src/runtime_src/core/tools/common/tests/TestValidateUtilities.h
+++ b/src/runtime_src/core/tools/common/tests/TestValidateUtilities.h
@@ -19,12 +19,19 @@ public:
   xrt::device device;              
   std::string kernel_name;
   std::string dpu_file;
+  std::string ifm_file;
+  std::string param_file;
   int queue_len;
-  size_t buffer_size;
   int itr_count;
   
-  TestParams(const xrt::xclbin& xclbin, xrt::device device, const std::string& kernel_name, const std::string& dpu_file, int queue_len, size_t buffer_size, int itr_count)
-    : xclbin(xclbin), device(device), kernel_name(kernel_name), dpu_file(dpu_file), queue_len(queue_len), buffer_size(buffer_size), itr_count(itr_count) {}
+  TestParams(const xrt::xclbin& xclbin, 
+             xrt::device device, 
+             const std::string& kernel_name, 
+             const std::string& dpu_file, 
+             const std::string& ifm_file, 
+             const std::string& param_file, 
+             int queue_len, int itr_count)
+    : xclbin(xclbin), device(device), kernel_name(kernel_name), dpu_file(dpu_file), queue_len(queue_len), ifm_file(ifm_file), param_file(param_file), itr_count(itr_count) {}
 };
 
 // Class representing a set of buffer objects (BOs)
@@ -39,7 +46,7 @@ class BO_set {
 
 public:
   // Constructor to initialize buffer objects
-  BO_set(const xrt::device&, const xrt::kernel&, const std::string&, size_t);
+  BO_set(const xrt::device&, const xrt::kernel&, const std::string&, const std::string&, const std::string&);
 
   // Method to set kernel arguments
   void set_kernel_args(xrt::run&) const;
@@ -74,6 +81,7 @@ constexpr std::string_view test_token_failed = "FAILED";
 constexpr std::string_view test_token_passed = "PASSED";
 
 void init_instr_buf(xrt::bo &bo_instr, const std::string& dpu_file);
+void init_buf_bin(int* buff, size_t bytesize, const std::string &filename);
 size_t get_instr_size(const std::string& dpu_file);
 void logger(boost::property_tree::ptree& , const std::string&, const std::string&);
 std::string findPlatformPath(const std::shared_ptr<xrt_core::device>& dev, boost::property_tree::ptree& ptTest);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
This change enhances the spatial/temporal sharing overhead tests (under --advance) to use the mobilenet test representing actual workload to calculate the overhead of temporally shared hardware contexts.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://jira.xilinx.com/browse/CR-1225327

#### How problem was solved, alternative solutions (if any) and why they were rejected
The problem was solved using input feature map, parameters and xclbin from a real test mobilenet. The mentioned 3 binaries are installed in the driver store under Binaries which are queried through a newly added device query. These are then used to run 1000 kernels to saturate the hardware and calculate the overhead of running 2 temporally shared hardware contexts

#### Risks (if any) associated the changes in the commit
None. Test is still under advance

#### What has been tested and how, request additional testing if necessary
Tested on windows kracken platform

#### Documentation impact (if any)
None
