### PR TITLE
[XDP] CR-1209911: When 2 PLIOs profiling are requesting on a same interface tile, only one is profiled and no warning are generating

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_profile/util/aie_profile_config.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/util/aie_profile_config.cpp
@@ -155,6 +155,14 @@ namespace xdp::aie::profile {
       }
     }
 
+    if ((type == module_type::shim) && (tile.subtype == io_type::PLIO) &&
+        (switchPortMap.size() < tile.stream_ids.size())) {
+      std::string msg = "Interface tile " + std::to_string(tile.col) + " has more "
+                      + "PLIO than can be monitored by metric set " + metricSet + ". Please "
+                      + "run again with different profile settings or choose a different set.";
+      xrt_core::message::send(severity_level::warning, "XRT", msg);
+    }
+
     switchPortMap.clear();
   }
 

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/util/aie_trace_config.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/util/aie_trace_config.cpp
@@ -194,8 +194,8 @@ namespace xdp::aie::trace {
     if ((type == module_type::shim) && (tile.subtype == io_type::PLIO) &&
         (switchPortMap.size() < tile.stream_ids.size())) {
       std::string msg = "Interface tile " + std::to_string(tile.col) + " has more "
-                      + "PLIO than can be monitored by metric set " + metricSet + "."
-                      + "Please run again with different settings or choose a different set.";
+                      + "PLIO than can be monitored by metric set " + metricSet + ". Please "
+                      + "run again with different trace settings or choose a different set.";
       xrt_core::message::send(severity_level::warning, "XRT", msg);
     }
 


### PR DESCRIPTION
#### Problem solved by the commit
Warning message was not issued in AIE profiling when not all PLIO could be monitored in a given interface tile

#### How problem was solved, alternative solutions (if any) and why they were rejected
Copy warning message from trace to profiling

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Tested on vek280

#### Documentation impact (if any)
Update list of potential warning messages