### PR TITLE
VITIS-14539 Add xrt-smi option to disable frame boundary preemption

### DIFF
--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -321,6 +321,7 @@ enum class key_type
   xgq_scaling_temp_override,
   performance_mode,
   preemption,
+  frame_boundary_preemption,
   debug_ip_layout_path,
   debug_ip_layout,
   num_live_processes,
@@ -3965,7 +3966,7 @@ struct performance_mode : request
 };
 
 /*
- * this request force enables or disables pre-emption globally
+ * this request force enables or disables layer boundary pre-emption globally
  * 1: enable; 0: disable
 */
 struct preemption : request
@@ -3974,6 +3975,25 @@ struct preemption : request
   using value_type = uint32_t;   // put value type
 
   static const key_type key = key_type::preemption;
+
+  virtual std::any
+  get(const device*) const override = 0;
+
+  virtual void
+  put(const device*, const std::any&) const override = 0;
+
+};
+
+/*
+ * this request force enables or disables frame boundary pre-emption globally
+ * 1: enable; 0: disable
+*/
+struct frame_boundary_preemption : request
+{
+  using result_type = uint32_t;  // get value type
+  using value_type = uint32_t;   // put value type
+
+  static const key_type key = key_type::frame_boundary_preemption;
 
   virtual std::any
   get(const device*) const override = 0;

--- a/src/runtime_src/core/tools/xbutil2/OO_Preemption.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_Preemption.cpp
@@ -115,7 +115,7 @@ OO_Preemption::execute(const SubCmdOptions& _options) const
 
   if(boost::iequals(m_action, "status")) {
     const auto layer_boundary = xrt_core::device_query_default<xrt_core::query::preemption>(device.get(), 0);
-    const auto frame_boundary = xrt_core::device_query_default<xrt_core::query::preemption>(device.get(), 0);
+    const auto frame_boundary = xrt_core::device_query_default<xrt_core::query::frame_boundary_preemption>(device.get(), 0);
     std::cout << (boost::format("Layer boundary force preemption is %s") % int_to_status(layer_boundary)) << std::endl;
     std::cout << (boost::format("Frame boundary force preemption is %s\n") % int_to_status(frame_boundary)) << std::endl;
     return;
@@ -133,7 +133,7 @@ OO_Preemption::execute(const SubCmdOptions& _options) const
 
   try {
     if (boost::iequals(m_type, "frame-boundary")) {
-      xrt_core::device_update<xrt_core::query::preemption>(device.get(), action_to_int(m_action));
+      xrt_core::device_update<xrt_core::query::frame_boundary_preemption>(device.get(), action_to_int(m_action));
     }
     else {
       xrt_core::device_update<xrt_core::query::preemption>(device.get(), action_to_int(m_action));

--- a/src/runtime_src/core/tools/xbutil2/OO_Preemption.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_Preemption.cpp
@@ -16,23 +16,47 @@ namespace po = boost::program_options;
 // ----- C L A S S   M E T H O D S -------------------------------------------
 
 OO_Preemption::OO_Preemption( const std::string &_longName, bool _isHidden )
-    : OptionOptions(_longName, _isHidden, "Force enable|disable pre-emption")
+    : OptionOptions(_longName, _isHidden, "Force enable|disable and see status of preemption")
     , m_device("")
     , m_action("")
+    , m_type("")
     , m_help(false)
 {
   m_optionsDescription.add_options()
     ("device,d", boost::program_options::value<decltype(m_device)>(&m_device), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest")
     ("help", boost::program_options::bool_switch(&m_help), "Help to use this sub-command")
+    ("type,t", boost::program_options::value<decltype(m_type)>(&m_type), "The type of reset to perform. Types resets available:\n"
+                                    "  layer-boundary         - Layer boundary force preeemption\n"
+                                    "  frame-boundary         - Frame boundary force preeemption\n")
   ;
 
   m_optionsHidden.add_options()
-    ("mode", boost::program_options::value<decltype(m_action)>(&m_action)->required(), "Action to perform: enable, disable")
+    ("action", boost::program_options::value<decltype(m_action)>(&m_action), "Action to perform: enable, disable, status");
   ;
 
   m_positionalOptions.
-    add("mode", 1 /* max_count */)
+    add("action", 1 /* max_count */)
   ;
+}
+
+void
+OO_Preemption::validate_args() const {
+  if(m_action.empty())
+    throw xrt_core::error(std::errc::operation_canceled, "Please specify a action 'enable', 'disable' or 'status'");
+  std::vector<std::string> vec_action { "enable", "disable", "status" };
+  if (std::find(vec_action.begin(), vec_action.end(), m_action) == vec_action.end()) {
+    throw xrt_core::error(std::errc::operation_canceled, boost::str(boost::format("\n'%s' is not a valid action for force-preemption\n") % m_action));
+  }
+
+  if(boost::iequals(m_action, "status"))
+    return;
+
+  if(m_type.empty())
+    throw xrt_core::error(std::errc::operation_canceled, "Please specify a type using --type");
+  std::vector<std::string> vec_type { "layer-boundary", "frame-boundary" };
+  if (std::find(vec_type.begin(), vec_type.end(), m_type) == vec_type.end()) {
+    throw xrt_core::error(std::errc::operation_canceled, boost::str(boost::format("\n'%s' is not a valid type of force-preemption\n") % m_type));
+  }
 }
 
 void
@@ -59,17 +83,18 @@ OO_Preemption::execute(const SubCmdOptions& _options) const
     all_options.add(m_optionsHidden);
     po::command_line_parser parser(_options);
     XBUtilities::process_arguments(vm, parser, all_options, m_positionalOptions, true);
+
+    //validate required arguments
+    validate_args(); 
   } catch(boost::program_options::error&) {
-      if(m_help) {
-        printHelp();
-        throw xrt_core::error(std::errc::operation_canceled);
-      }
-      // Exit if neither action or device specified
-      if(m_action.empty()) {
-        std::cerr << boost::format("ERROR: the required argument for option '--force-preemption' is missing\n");
-        printHelp();
-        throw xrt_core::error(std::errc::operation_canceled);
-      }
+    if(m_help) {
+      printHelp();
+      throw xrt_core::error(std::errc::operation_canceled);
+    }
+  } catch(xrt_core::error& err) {
+    std::cout << err.what() << std::endl;
+    printHelp();
+    throw xrt_core::error(err.get_code());
   }
 
   // Find device of interest
@@ -83,19 +108,37 @@ OO_Preemption::execute(const SubCmdOptions& _options) const
     throw xrt_core::error(std::errc::operation_canceled);
   }
 
+  //show status
+  auto int_to_status = [](uint32_t state) -> std::string {
+    return state == 0 ? "disabled" : "enabled";
+  };
+
+  if(boost::iequals(m_action, "status")) {
+    const auto layer_boundary = xrt_core::device_query_default<xrt_core::query::preemption>(device.get(), 0);
+    const auto frame_boundary = xrt_core::device_query_default<xrt_core::query::preemption>(device.get(), 0);
+    std::cout << (boost::format("Layer boundary force preemption is %s") % int_to_status(layer_boundary)) << std::endl;
+    std::cout << (boost::format("Frame boundary force preemption is %s\n") % int_to_status(frame_boundary)) << std::endl;
+    return;
+  }
+
   XBUtilities::sudo_or_throw("Force-preemption requires admin privileges");
 
+  auto action_to_int = [](const std::string& action) -> uint32_t {
+    return action == "enable" ? 1 : 0;
+  };
+
+  auto pretty_print = [](const std::string& type) -> std::string {
+    return (boost::iequals(type, "frame-boundary")) ? "Frame boundary" : "Layer boundary";
+  };
+
   try {
-    if (boost::iequals(m_action, "enable")) {
-      xrt_core::device_update<xrt_core::query::preemption>(device.get(), static_cast<uint32_t>(1)); // default
-    }
-    else if (boost::iequals(m_action, "disable")) {
-      xrt_core::device_update<xrt_core::query::preemption>(device.get(), static_cast<uint32_t>(0));
+    if (boost::iequals(m_type, "frame-boundary")) {
+      xrt_core::device_update<xrt_core::query::preemption>(device.get(), action_to_int(m_action));
     }
     else {
-      throw xrt_core::error(boost::str(boost::format("Invalid force-preemption value: '%s'\n") % m_action));
+      xrt_core::device_update<xrt_core::query::preemption>(device.get(), action_to_int(m_action));
     }
-    std::cout << boost::format("\nPreemption has been %sd \n") % (boost::algorithm::to_lower_copy(m_action));
+    std::cout << boost::format("\n%s preemption has been %sd \n") % pretty_print(m_type) % (boost::algorithm::to_lower_copy(m_action));
   }
   catch(const xrt_core::error& e) {
     std::cerr << boost::format("\nERROR: %s\n") % e.what();

--- a/src/runtime_src/core/tools/xbutil2/OO_Preemption.h
+++ b/src/runtime_src/core/tools/xbutil2/OO_Preemption.h
@@ -9,6 +9,7 @@
 class OO_Preemption : public OptionOptions {
  public:
   virtual void execute( const SubCmdOptions &_options ) const;
+  void validate_args() const;
 
  public:
   OO_Preemption( const std::string &_longName, bool _isHidden = true);
@@ -16,6 +17,7 @@ class OO_Preemption : public OptionOptions {
  private:
   std::string m_device;
   std::string m_action;
+  std::string m_type;
   bool m_help;
 };
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
[VITIS-14539](https://jira.xilinx.com/browse/VITIS-14539) Add xrt-smi option to disable frame boundary preemption

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
New feature

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added a new option "--type" to handle different types of force preemption
Added another option to see the status of force preemptions

#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
Tested on windows/MCDM; requires additional driver changes 

#### Documentation impact (if any)
Internal doc needs to be updated