### PR TITLE
[XDP] Enable shim tiles matching using both channelId and streamId.

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_control_config_filetype.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_control_config_filetype.cpp
@@ -331,10 +331,15 @@ AIEControlConfigFiletype::getInterfaceTiles(const std::string& graphName,
             continue;
 
         // Make sure stream/channel number is as specified
-        // NOTE: For GMIO, we use DMA channel number; for PLIO, we use the SOUTH location
-        uint8_t idToCheck = (type == io_type::GMIO) ? channelNum : streamId;
-        if ((specifiedId >= 0) && (specifiedId != idToCheck))
+        // NOTE1: For PLIO, we use the SOUTH location only
+        // NOTE2: For GMIO, we use DMA channel number or south location
+        if (specifiedId >= 0) {
+          if ((type == io_type::PLIO) && (specifiedId != streamId))
             continue;
+          if ((type == io_type::GMIO) && (specifiedId != channelNum)
+              && (specifiedId != streamId))
+            continue;
+        }
 
         tile_type tile;
         tile.col = shimCol;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
[CR-1218875] - streamIDs are shown in Vitis analyzer for Shim GMIO interface channels. However, by default only support profiling of channel0 or channel1 (Master/Slave)
In this defect, it tries to profile for particular stream ID instead of channel ID.
`tile_based_interface_tile_metrics=all:mm2s_throughputs:7`

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
[CR-1218875]

#### How problem was solved, alternative solutions (if any) and why they were rejected
For such case of GMIOs, code now checks for matching channelID and streamID.
This implicit understanding of channel/streamId is currently overloaded and will be  streamlined with json settings using separate keys.

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
vck190 DUT

#### Documentation impact (if any)
