### PR TITLE
CR-1232385 : Fix seg fault when xrt::device is created in a loop in pcie hw_emu flow

### DIFF
--- a/src/runtime_src/core/pcie/emulation/hw_emu/alveo_shim/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_emu/alveo_shim/shim.cxx
@@ -2675,7 +2675,10 @@ namespace xclhwemhal2 {
     // Shim object creation doesn't follow xclOpen/xclClose.
     // The core device must correspond to open and close, so
     // create here rather than in constructor
-    mCoreDevice = xrt_core::hwemu::get_userpf_device(this, mDeviceIndex);
+    // Also create it only for the first time as in further
+    // iterations device is cached and returned
+    if (!mCoreDevice)
+      mCoreDevice = xrt_core::hwemu::get_userpf_device(this, mDeviceIndex);
 
     device_handles::add(this);
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Fixed seg fault when xrt::device is created in a loop
The seg fault happens in second run as core device held by shim is recreated and existing one is destroyed and underlying handles are cleaned but in the recreation only cached object ptr is returned which is a dangling ptr.
This issue is only in pcie hw_emu flow.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
#### How problem was solved, alternative solutions (if any) and why they were rejected
Creating core device in shim xclOpen call only when it is null (first time)

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
Tested with test case attached in CR (https://github.com/Xilinx/Vitis_Accel_Examples/tree/main/performance/axi_burst_performance) and it passes

#### Documentation impact (if any)
NA