### PR TITLE
[XDP] CR-1230509: No profiling data or eventIDs when using only s2mm_throughputs for memory module metric set

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_debug/aie_debug_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_debug/aie_debug_plugin.cpp
@@ -58,6 +58,7 @@ namespace xdp {
     AieDebugPlugin::live = true;
 
     db->registerPlugin(this);
+    db->registerInfo(info::aie_debug);
     db->getStaticInfo().setAieApplication();
   }
 
@@ -68,6 +69,7 @@ namespace xdp {
   {
     xrt_core::message::send(severity_level::info, "XRT", "Calling ~AieDebugPlugin destructor.");
 
+    AieDebugPlugin::live = false;
     for (const auto& kv : handleToAIEData)
       endPollforDevice(kv.first);
 
@@ -78,9 +80,8 @@ namespace xdp {
       for (auto w : writers) {
         w->write(false);
       }
-      db->unregisterPlugin(this);}
-
-    AieDebugPlugin::live = false;
+      db->unregisterPlugin(this);
+    }
   }
 
   /****************************************************************************
@@ -221,7 +222,7 @@ namespace xdp {
   void AieDebugPlugin::endPollforDevice(void* handle)
   {
     xrt_core::message::send(severity_level::info, "XRT", "AIE Debug endPollforDevice");
-    if (handleToAIEData.empty())
+    if (handleToAIEData.find(handle) == handleToAIEData.end())
       return;
 
     auto& AIEData = handleToAIEData[handle];

--- a/src/runtime_src/xdp/profile/plugin/aie_debug/aie_debug_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_debug/aie_debug_plugin.cpp
@@ -97,7 +97,7 @@ namespace xdp {
    ***************************************************************************/
   uint64_t AieDebugPlugin::getDeviceIDFromHandle(void* handle)
   {
-    xrt_core::message::send(severity_level::info, "XRT", "Calling AIE DEBUG AieDebugPlugin::getDeviceIDFromHandle.");
+    xrt_core::message::send(severity_level::info, "XRT", "Calling AIE DEBUG getDeviceIDFromHandle.");
     auto itr = handleToAIEData.find(handle);
     if (itr != handleToAIEData.end())
       return itr->second.deviceID;
@@ -105,8 +105,7 @@ namespace xdp {
 #ifdef XDP_CLIENT_BUILD
     return db->addDevice("win_device");
 #else
-    //return db->addDevice(util::getDebugIpLayoutPath(handle));
-    return db->addDevice("temp_edge_device");
+    return db->addDevice(util::getDebugIpLayoutPath(handle)); // Get the unique device Id
 #endif
   }
 

--- a/src/runtime_src/xdp/profile/plugin/vp_base/info.h
+++ b/src/runtime_src/xdp/profile/plugin/vp_base/info.h
@@ -40,6 +40,7 @@ namespace info {
   const uint64_t ml_timeline     = 0x04000 ;
   const uint64_t aie_halt        = 0x08000 ;
   const uint64_t aie_pc          = 0x10000 ;
+  const uint64_t aie_debug       = 0x20000 ;
 
 } // end namespace info
 } // end namespace xdp ;


### PR DESCRIPTION
#### Problem solved by the commit
Turning on AIE debug plugin created errors in other plugins (e.g., AIE profiling)

#### How problem was solved, alternative solutions (if any) and why they were rejected
Use consistent device string when adding device to database

#### Risks (if any) associated the changes in the commit
Very low

#### What has been tested and how, request additional testing if necessary
Tested on vek280

#### Documentation impact (if any)
None