### PR TITLE
Cherry-pick : Fix seg fault when xrt::device is created in a loop in pcie hw_emu flow (#8832)

### DIFF
--- a/src/runtime_src/core/pcie/emulation/hw_emu/alveo_shim/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_emu/alveo_shim/shim.cxx
@@ -2675,7 +2675,10 @@ namespace xclhwemhal2 {
     // Shim object creation doesn't follow xclOpen/xclClose.
     // The core device must correspond to open and close, so
     // create here rather than in constructor
-    mCoreDevice = xrt_core::hwemu::get_userpf_device(this, mDeviceIndex);
+    // Also create it only for the first time as in further
+    // iterations device is cached and returned
+    if (!mCoreDevice)
+      mCoreDevice = xrt_core::hwemu::get_userpf_device(this, mDeviceIndex);
 
     device_handles::add(this);
   }


### PR DESCRIPTION
Signed-off-by: rbramand <rbramand@amd.com>
Co-authored-by: rbramand <rbramand@amd.com>
(cherry picked from commit e2cdce8647e98b9acec2bddb66c92c954a953b65)
