### PR TITLE
CR-1235101 : Fix error when including xrt_device.h in C file

### DIFF
--- a/src/runtime_src/core/include/xrt/experimental/xrt_exception.h
+++ b/src/runtime_src/core/include/xrt/experimental/xrt_exception.h
@@ -27,7 +27,7 @@ class exception : public std::exception
 } // namespace xrt
 
 #else
-# error xrt_exception is only implemented for C++
+# pragma message("Warning: xrt_exception is only implemented for C++")
 #endif // __cplusplus
 
 #endif


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Fixed compilation error when including xrt_device.h file in .c file.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
#### How problem was solved, alternative solutions (if any) and why they were rejected
Moved inclusion of xrt_exception.h in xrt_device.h under __cplusplus gaurd

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
Tested vvas build flow and it passes after applying this fix

#### Documentation impact (if any)
NA
