### PR TITLE
Preemption report header name changes

### DIFF
--- a/src/runtime_src/core/common/info_telemetry.cpp
+++ b/src/runtime_src/core/common/info_telemetry.cpp
@@ -59,10 +59,10 @@ aie2_preemption_info(const xrt_core::device* device)
     return is_value_na(value) ? "N/A" : std::to_string(value);
   };
 
-  pt_preempt.put("user_task", user_task++);
-  pt_preempt.put("slot_index", populate_value(kp.preemption_data.slot_index));
-  pt_preempt.put("preemption_layer_boundary_events", populate_value(kp.preemption_data.preemption_checkpoint_event));
-  pt_preempt.put("preemption_frame_boundary_events", populate_value(kp.preemption_data.preemption_frame_boundary_events));
+  pt_preempt.put("fw_tid", user_task++);
+  pt_preempt.put("ctx_index", populate_value(kp.preemption_data.slot_index));
+  pt_preempt.put("layer_events", populate_value(kp.preemption_data.preemption_checkpoint_event));
+  pt_preempt.put("frame_events", populate_value(kp.preemption_data.preemption_frame_boundary_events));
 
   pt_rtos_array.push_back({"", pt_preempt});
   }

--- a/src/runtime_src/core/tools/common/XBMain.cpp
+++ b/src/runtime_src/core/tools/common/XBMain.cpp
@@ -66,7 +66,7 @@ void  main_(int argc, char** argv,
   hiddenOptions.add_options()
     ("device,d",    boost::program_options::value<decltype(sDevice)>(&sDevice)->default_value(device_default)->implicit_value("default"), "If specified with no BDF value and there is only 1 device, that device will be automatically selected.\n")
     ("trace",       boost::program_options::bool_switch(&bTrace), "Enables code flow tracing")
-    ("advance", boost::program_options::bool_switch(&bAdvance), "Shows hidden options and commands")
+    ("advanced", boost::program_options::bool_switch(&bAdvance), "Shows hidden options and commands")
     ("subCmd",      po::value<decltype(sCmd)>(&sCmd), "Command to execute")
   ;
 

--- a/src/runtime_src/core/tools/common/reports/ReportPreemption.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportPreemption.cpp
@@ -35,19 +35,19 @@ generate_preemption_string(const bpt& pt)
   std::stringstream ss;
 
   std::vector<Table2D::HeaderData> preempt_headers = {
-    {"User Task", Table2D::Justification::left},
+    {"FW TID", Table2D::Justification::left},
     {"Ctx ID", Table2D::Justification::left},
-    {"Layer Boundary Events", Table2D::Justification::left},
-    {"Frame Boundary Events", Table2D::Justification::left},
+    {"Layer Events", Table2D::Justification::left},
+    {"Frame Events", Table2D::Justification::left},
   };
   Table2D preemption_table(preempt_headers);
 
   for (const auto& [name, user_task] : pt) {
     const std::vector<std::string> rtos_data = {
-      user_task.get<std::string>("user_task"),
-      user_task.get<std::string>("slot_index"),
-      user_task.get<std::string>("preemption_layer_boundary_events"),
-      user_task.get<std::string>("preemption_frame_boundary_events"),
+      user_task.get<std::string>("fw_tid"),
+      user_task.get<std::string>("ctx_index"),
+      user_task.get<std::string>("layer_events"),
+      user_task.get<std::string>("frame_events"),
     };
     preemption_table.addEntry(rtos_data);
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Rename some of the fields in preemption report
rename a global option from --advance to --advanced

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Internal discussion

#### How problem was solved, alternative solutions (if any) and why they were rejected
N/A

#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
N/A

#### Documentation impact (if any)
Update internal user guide