### PR TITLE
[XDP] Support XDP plugins on xdna branch for VE2

### DIFF
--- a/src/runtime_src/core/common/xdp/profile.cpp
+++ b/src/runtime_src/core/common/xdp/profile.cpp
@@ -516,17 +516,6 @@ update_device(void* handle)
 
 #elif defined(XDP_VE2_BUILD)
 
-  if (xrt_core::config::get_ml_timeline()) {
-    try {
-      xrt_core::xdp::ml_timeline::load();
-      xrt_core::xdp::ml_timeline::update_device(handle);
-    }
-    catch (...) {
-      xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT",
-        "Failed to load ML Timeline library.");
-    }
-  }
-
   if (xrt_core::config::get_aie_halt()) {
     try {
       xrt_core::xdp::aie::halt::load();
@@ -571,6 +560,17 @@ update_device(void* handle)
     }
   }
 
+  if (xrt_core::config::get_ml_timeline()) {
+    try {
+      xrt_core::xdp::ml_timeline::load();
+      xrt_core::xdp::ml_timeline::update_device(handle);
+    }
+    catch (...) {
+      xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT",
+        "Failed to load ML Timeline library.");
+    }
+  }
+  
   if (xrt_core::config::get_aie_profile()) {
     try {
       xrt_core::xdp::aie::profile::load();

--- a/src/runtime_src/xdp/profile/database/static_info_database.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info_database.cpp
@@ -1461,6 +1461,7 @@ namespace xdp {
     return true;
   }
 
+  
 void VPStaticDatabase::updateDeviceVE2(uint64_t deviceId, std::unique_ptr<xdp::Device> xdpDevice, void* devHandle)
 {
     xrt::hw_context context = xrt_core::hw_context_int::create_hw_context_from_implementation(devHandle);
@@ -1504,13 +1505,14 @@ void VPStaticDatabase::updateDeviceVE2(uint64_t deviceId, std::unique_ptr<xdp::D
       devInfo->isNoDMADevice = true;
 
 }
+
   // This function is called whenever a device is loaded with an
   //  xclbin.  It has to clear out any previous device information and
   //  reload our information.
   void VPStaticDatabase::updateDevice(uint64_t deviceId, std::unique_ptr<xdp::Device> xdpDevice, void* devHandle)
   {
-    std::shared_ptr<xrt_core::device> device =
-      xrt_core::get_userpf_device(devHandle);
+    std::shared_ptr<xrt_core::device> device = xrt_core::get_userpf_device(devHandle);
+
     if (nullptr == device)
       return;
 

--- a/src/runtime_src/xdp/profile/database/static_info_database.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info_database.cpp
@@ -1462,12 +1462,12 @@ namespace xdp {
   }
 
   
-void VPStaticDatabase::updateDeviceVE2(uint64_t deviceId, std::unique_ptr<xdp::Device> xdpDevice, void* devHandle)
-{
+  void VPStaticDatabase::updateDeviceVE2(uint64_t deviceId, std::unique_ptr<xdp::Device> xdpDevice, void* devHandle)
+  {
     xrt::hw_context context = xrt_core::hw_context_int::create_hw_context_from_implementation(devHandle);
-   auto device = xrt_core::hw_context_int::get_core_device(context);
+    auto device = xrt_core::hw_context_int::get_core_device(context);
 
-   if (nullptr == device)
+    if (nullptr == device)
       return;
 
     xrt::uuid new_xclbin_uuid;
@@ -1494,8 +1494,8 @@ void VPStaticDatabase::updateDeviceVE2(uint64_t deviceId, std::unique_ptr<xdp::D
     }
 
     /* If multiple plugins are enabled for the current run, the first plugin has already updated device information
-     * in the static data base. So, no need to read the xclbin information again.
-     */
+      * in the static data base. So, no need to read the xclbin information again.
+      */
     if (!resetDeviceInfo(deviceId, xdpDevice.get(), new_xclbin_uuid))
       return;
 
@@ -1503,8 +1503,7 @@ void VPStaticDatabase::updateDeviceVE2(uint64_t deviceId, std::unique_ptr<xdp::D
     DeviceInfo* devInfo   = updateDevice(deviceId, xrtXclbin, std::move(xdpDevice), false);
     if (device->is_nodma())
       devInfo->isNoDMADevice = true;
-
-}
+  }
 
   // This function is called whenever a device is loaded with an
   //  xclbin.  It has to clear out any previous device information and
@@ -2416,10 +2415,8 @@ void VPStaticDatabase::updateDeviceVE2(uint64_t deviceId, std::unique_ptr<xdp::D
     initializeProfileMonitors(devInfo, std::move(xrtXclbin));
 
     devInfo->isReady = true;
-
     if (xdpDevice != nullptr)
       createPLDeviceIntf(deviceId, std::move(xdpDevice), xclbinType);
-
     return devInfo;
   }
 

--- a/src/runtime_src/xdp/profile/database/static_info_database.h
+++ b/src/runtime_src/xdp/profile/database/static_info_database.h
@@ -283,6 +283,7 @@ namespace xdp {
     XDP_CORE_EXPORT Memory* getMemory(uint64_t deviceId, int32_t memId) ;
     // Reseting device information whenever a new xclbin is added
     XDP_CORE_EXPORT void updateDevice(uint64_t deviceId, std::unique_ptr<xdp::Device> xdpDevice, void* devHandle) ;
+    XDP_CORE_EXPORT void updateDeviceVE2(uint64_t deviceId, std::unique_ptr<xdp::Device> xdpDevice, void* devHandle);
     XDP_CORE_EXPORT void updateDeviceClient(uint64_t deviceId, std::shared_ptr<xrt_core::device> device, bool readAIEMetadata = true);
 
     // *********************************************************

--- a/src/runtime_src/xdp/profile/device/aie_trace/ve2/aie_trace_offload_ve2.h
+++ b/src/runtime_src/xdp/profile/device/aie_trace/ve2/aie_trace_offload_ve2.h
@@ -19,7 +19,6 @@
 #define XDP_PROFILE_AIE_TRACE_OFFLOAD_VE2_H_
 
 #include "xdp/profile/device/tracedefs.h"
-#include "xdp/profile/plugin/aie_trace/aie_trace_metadata.h"
 
 extern "C"
 {
@@ -77,8 +76,7 @@ class AIETraceOffload
                     bool     isPlio,
                     uint64_t totalSize,
                     uint64_t numStrm,
-					xrt::hw_context context,
-					std::shared_ptr<AieTraceMetadata> metadata
+                    XAie_DevInst* devInstance
                    );
 
     virtual ~AIETraceOffload();
@@ -106,9 +104,9 @@ private:
 
     void*           deviceHandle;
     uint64_t        deviceId;
-    PLDeviceIntf*     deviceIntf;
+    PLDeviceIntf*   deviceIntf;
     AIETraceLogger* traceLogger;
-    xrt::hw_context m_hwcontext;
+    XAie_DevInst*   devInst;
 
     bool isPLIO;
     uint64_t totalSz;

--- a/src/runtime_src/xdp/profile/device/aie_trace/ve2/aie_trace_offload_ve2.h
+++ b/src/runtime_src/xdp/profile/device/aie_trace/ve2/aie_trace_offload_ve2.h
@@ -19,8 +19,13 @@
 #define XDP_PROFILE_AIE_TRACE_OFFLOAD_VE2_H_
 
 #include "xdp/profile/device/tracedefs.h"
-#include "shim/aie/aie.h"
+#include "xdp/profile/plugin/aie_trace/aie_trace_metadata.h"
 
+extern "C"
+{
+  #include "xaiengine/xaiegbl.h"
+  #include <xaiengine.h>
+}
 
 namespace xdp {
 
@@ -71,7 +76,9 @@ class AIETraceOffload
                     PLDeviceIntf*, AIETraceLogger*,
                     bool     isPlio,
                     uint64_t totalSize,
-                    uint64_t numStrm
+                    uint64_t numStrm,
+					xrt::hw_context context,
+					std::shared_ptr<AieTraceMetadata> metadata
                    );
 
     virtual ~AIETraceOffload();
@@ -101,6 +108,7 @@ private:
     uint64_t        deviceId;
     PLDeviceIntf*     deviceIntf;
     AIETraceLogger* traceLogger;
+    xrt::hw_context m_hwcontext;
 
     bool isPLIO;
     uint64_t totalSz;

--- a/src/runtime_src/xdp/profile/device/utility.cpp
+++ b/src/runtime_src/xdp/profile/device/utility.cpp
@@ -20,6 +20,7 @@
 #include "core/common/system.h"
 #include "core/common/message.h"
 #include "core/common/query_requests.h"
+#include "core/common/api/hw_context_int.h"
 
 #include "xdp/profile/device/utility.h"
 #include "xdp/profile/plugin/vp_base/utility.h"
@@ -68,10 +69,18 @@ namespace xdp { namespace util {
     return path;
   }
 
-  std::string getDeviceName(void* deviceHandle)
+  std::string getDeviceName(void* deviceHandle, bool isVE2build)
   {
     std::string deviceName = "";
-    std::shared_ptr<xrt_core::device> coreDevice = xrt_core::get_userpf_device(deviceHandle);
+    std::shared_ptr<xrt_core::device> coreDevice;
+    if(isVE2build) {
+      xrt::hw_context context = xrt_core::hw_context_int::create_hw_context_from_implementation(deviceHandle);
+      coreDevice = xrt_core::hw_context_int::get_core_device(context);
+    }
+    else {
+      coreDevice = xrt_core::get_userpf_device(deviceHandle);
+    }
+
     if (!coreDevice) {
       return deviceName;
     }

--- a/src/runtime_src/xdp/profile/device/utility.h
+++ b/src/runtime_src/xdp/profile/device/utility.h
@@ -40,7 +40,7 @@ namespace xdp { namespace util {
   std::string getDebugIpLayoutPath(void* deviceHandle);
 
   XDP_CORE_EXPORT
-  std::string getDeviceName(void* deviceHandle);
+  std::string getDeviceName(void* deviceHandle, bool isVE2build = false);
 
 
   // At compile time, each monitor inserted in the PL region is given a set 

--- a/src/runtime_src/xdp/profile/plugin/aie_debug/aie_debug_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_debug/aie_debug_plugin.cpp
@@ -104,6 +104,8 @@ namespace xdp {
 
 #ifdef XDP_CLIENT_BUILD
     return db->addDevice("win_device");
+#elif XDP_VE2_BUILD
+    return db->addDevice("ve2_device");
 #else
     return db->addDevice(util::getDebugIpLayoutPath(handle)); // Get the unique device Id
 #endif
@@ -134,12 +136,15 @@ namespace xdp {
 #ifdef XDP_CLIENT_BUILD
       (db->getStaticInfo()).updateDeviceClient(deviceID, device);
       (db->getStaticInfo()).setDeviceName(deviceID, "win_device");
+#elif defined(XDP_VE2_BUILD)
+      (db->getStaticInfo()).updateDeviceVE2(deviceID, nullptr, handle);
+      std::string deviceName = util::getDeviceName(handle,true);
 #else
       (db->getStaticInfo()).updateDevice(deviceID, nullptr, handle);
       std::string deviceName = util::getDeviceName(handle);
-      if (deviceName != "")
-        (db->getStaticInfo()).setDeviceName(deviceID, deviceName);
 #endif
+      if (deviceName != "")
+      (db->getStaticInfo()).setDeviceName(deviceID, deviceName);
     }
 
     // Delete old data
@@ -185,7 +190,11 @@ namespace xdp {
     std::string deviceName = "aie_debug_win_device";
 #else
     auto tm = *std::localtime(&time);
-    std::string deviceName = util::getDeviceName(handle);
+    #ifdef XDP_VE2_BUILD
+      std::string deviceName = util::getDeviceName(handle,true);
+    #else
+      std::string deviceName = util::getDeviceName(handle);
+    #endif
 #endif
 
     std::ostringstream timeOss;

--- a/src/runtime_src/xdp/profile/plugin/aie_debug/aie_debug_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_debug/aie_debug_plugin.cpp
@@ -139,12 +139,14 @@ namespace xdp {
 #elif defined(XDP_VE2_BUILD)
       (db->getStaticInfo()).updateDeviceVE2(deviceID, nullptr, handle);
       std::string deviceName = util::getDeviceName(handle,true);
+      if (deviceName != "")
+        (db->getStaticInfo()).setDeviceName(deviceID, deviceName);
 #else
       (db->getStaticInfo()).updateDevice(deviceID, nullptr, handle);
       std::string deviceName = util::getDeviceName(handle);
-#endif
       if (deviceName != "")
-      (db->getStaticInfo()).setDeviceName(deviceID, deviceName);
+        (db->getStaticInfo()).setDeviceName(deviceID, deviceName);
+#endif
     }
 
     // Delete old data

--- a/src/runtime_src/xdp/profile/plugin/aie_debug/ve2/aie_debug.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_debug/ve2/aie_debug.cpp
@@ -29,7 +29,6 @@
 #include <boost/property_tree/json_parser.hpp>
 #include <string>
 
-#include "shim/shim.h"
 #include "core/common/message.h"
 #include "core/common/time.h"
 #include "core/include/xrt/xrt_kernel.h"
@@ -37,6 +36,10 @@
 //#include "core/common/api/hw_context_int.h"
 #include "core/common/config_reader.h"
 #include "core/include/experimental/xrt-next.h"
+#include "core/common/shim/hwctx_handle.h"
+#include "core/common/api/hw_context_int.h"
+#include "shim/xdna_hwctx.h"
+ 
 
 #include "xdp/profile/database/static_info/aie_util.h"
 #include "xdp/profile/database/database.h"
@@ -46,12 +49,10 @@
 namespace {
   static void* fetchAieDevInst(void* devHandle)
   {
-    auto drv = aiarm::shim::handleCheck(devHandle);
-    if (!drv)
-      return nullptr ;
-    auto aieArray = drv->get_aie_array();
-    if (!aieArray)
-      return nullptr;
+    xrt::hw_context context = xrt_core::hw_context_int::create_hw_context_from_implementation(devHandle);
+    auto hwctx_hdl = static_cast<xrt_core::hwctx_handle*>(context);
+    auto hwctx_obj = dynamic_cast<shim_xdna_edge::xdna_hwctx*>(hwctx_hdl);
+    auto aieArray = hwctx_obj->get_aie_array();
     return aieArray->get_dev();
   }
 

--- a/src/runtime_src/xdp/profile/plugin/aie_halt/aie_halt_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_halt/aie_halt_plugin.cpp
@@ -32,6 +32,7 @@
 #include "xdp/profile/plugin/aie_halt/clientDev/aie_halt.h"
 #elif defined (XDP_VE2_BUILD)
 #include "xdp/profile/plugin/aie_halt/ve2/aie_halt.h"
+#include "xdp/profile/device/xdp_base_device.h"
 #endif
 
 namespace xdp {
@@ -100,7 +101,7 @@ namespace xdp {
 
     // Only one device for VE2 Device flow
     uint64_t deviceId = db->addDevice("ve2_device");
-    (db->getStaticInfo()).updateDeviceClient(deviceId, coreDevice, false);
+    (db->getStaticInfo()).updateDeviceVE2(deviceId, nullptr, hwCtxImpl);
     (db->getStaticInfo()).setDeviceName(deviceId, "ve2_device");
 
     DeviceDataEntry.valid = true;

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_plugin.cpp
@@ -110,7 +110,7 @@ namespace xdp {
   /*
    * handle relates to hw context handle in case of Client XRT
    */
-    #ifdef XDP_CLIENT_BUILD
+  #if defined(XDP_CLIENT_BUILD) || defined(XDP_VE2_BUILD)
         xrt::hw_context context = xrt_core::hw_context_int::create_hw_context_from_implementation(handle);
         auto device = xrt_core::hw_context_int::get_core_device(context);
     #else

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_plugin.cpp
@@ -92,6 +92,8 @@ namespace xdp {
 
 #ifdef XDP_CLIENT_BUILD
     return db->addDevice("win_device");
+#elif XDP_VE2_BUILD
+    return db->addDevice("ve2_device");
 #else
     return db->addDevice(util::getDebugIpLayoutPath(handle));  // Get the unique device Id
 #endif

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_plugin.cpp
@@ -124,6 +124,8 @@ namespace xdp {
 #ifdef XDP_CLIENT_BUILD
       (db->getStaticInfo()).updateDeviceClient(deviceID, device);
       (db->getStaticInfo()).setDeviceName(deviceID, "win_device");
+#elif defined(XDP_VE2_BUILD)
+      (db->getStaticInfo()).updateDeviceVE2(deviceID, nullptr, handle);
 #else
       (db->getStaticInfo()).updateDevice(deviceID, nullptr, handle);
 #endif
@@ -181,7 +183,11 @@ auto time = std::time(nullptr);
     std::string deviceName = "win_device";
 #else
     auto tm = *std::localtime(&time);
-    std::string deviceName = util::getDeviceName(handle);
+    #ifdef XDP_VE2_BUILD
+      std::string deviceName = util::getDeviceName(handle,true);
+    #else
+      std::string deviceName = util::getDeviceName(handle);
+    #endif
 #endif
 
     std::ostringstream timeOss;

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/ve2/aie_profile.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/ve2/aie_profile.cpp
@@ -33,22 +33,22 @@
 #include "core/common/message.h"
 #include "core/common/time.h"
 #include "core/include/xrt/xrt_kernel.h"
+#include "core/common/shim/hwctx_handle.h"
+#include "core/common/api/hw_context_int.h"
+#include "shim/xdna_hwctx.h"
 #include "xdp/profile/database/database.h"
 #include "xdp/profile/database/static_info/aie_constructs.h"
 #include "xdp/profile/database/static_info/pl_constructs.h"
 #include "xdp/profile/plugin/aie_profile/aie_profile_defs.h"
 #include "xdp/profile/plugin/aie_profile/aie_profile_metadata.h"
-#include "shim/shim.h"
 
 namespace {
   static void* fetchAieDevInst(void* devHandle)
   {
-    auto drv = aiarm::shim::handleCheck(devHandle);
-    if (!drv)
-      return nullptr ;
-    auto aieArray = drv->get_aie_array() ;
-    if (!aieArray)
-      return nullptr ;
+    xrt::hw_context context = xrt_core::hw_context_int::create_hw_context_from_implementation(devHandle);
+    auto hwctx_hdl = static_cast<xrt_core::hwctx_handle*>(context);
+    auto hwctx_obj = dynamic_cast<shim_xdna_edge::xdna_hwctx*>(hwctx_hdl);
+    auto aieArray = hwctx_obj->get_aie_array();
     return aieArray->get_dev() ;
   }
 

--- a/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.cpp
@@ -36,9 +36,11 @@
 #include "core/common/config_reader.h"
 #include "core/include/experimental/xrt-next.h"
 
-#ifdef XDP_VE2_BUILD
-#include "shim/shim.h"
-#else
+#include "core/common/shim/hwctx_handle.h"
+#include "core/common/api/hw_context_int.h"
+#include "shim/xdna_hwctx.h"
+
+#ifndef XDP_VE2_BUILD
 #include "core/edge/user/shim.h"
 #endif
 
@@ -46,10 +48,10 @@ namespace {
   static void* fetchAieDevInst(void* devHandle)
   {
 #ifdef XDP_VE2_BUILD
-    auto drv = aiarm::shim::handleCheck(devHandle);
-    if (!drv)
-      return nullptr;
-    auto aieArray = drv->get_aie_array();
+    xrt::hw_context context = xrt_core::hw_context_int::create_hw_context_from_implementation(devHandle);
+    auto hwctx_hdl = static_cast<xrt_core::hwctx_handle*>(context);
+    auto hwctx_obj = dynamic_cast<shim_xdna_edge::xdna_hwctx*>(hwctx_hdl);
+    auto aieArray = hwctx_obj->get_aie_array();
 #else
     auto drv = ZYNQ::shim::handleCheck(devHandle);
     if (!drv)

--- a/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.cpp
@@ -36,13 +36,13 @@
 #include "core/common/config_reader.h"
 #include "core/include/experimental/xrt-next.h"
 
+#ifdef XDP_VE2_BUILD
 #include "core/common/shim/hwctx_handle.h"
 #include "core/common/api/hw_context_int.h"
 #include "shim/xdna_hwctx.h"
-
-#ifndef XDP_VE2_BUILD
-#include "core/edge/user/shim.h"
 #include "xdp/profile/device/xdp_base_device.h"
+#else
+#include "core/edge/user/shim.h"
 #endif
 
 namespace {

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -93,6 +93,8 @@ uint64_t AieTracePluginUnified::getDeviceIDFromHandle(void *handle) {
 
 #ifdef XDP_CLIENT_BUILD
   return db->addDevice("win_sysfspath");
+#elif XDP_VE2_BUILD
+  return db->addDevice("ve2_device");
 #else
   return db->addDevice(util::getDebugIpLayoutPath(handle)); // Get the unique device Id
 #endif

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.h
@@ -26,6 +26,8 @@
 
 #ifdef XDP_CLIENT_BUILD
 #include "xdp/profile/device/aie_trace/client/aie_trace_offload_client.h"
+#elif XDP_VE2_BUILD
+#include "xdp/profile/device/aie_trace/ve2/aie_trace_offload_ve2.h"
 #else
 #include "xdp/profile/device/aie_trace/aie_trace_offload.h"
 #endif

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/ve2/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/ve2/aie_trace.cpp
@@ -291,10 +291,7 @@ namespace xdp {
       return false;
     }
 
-    xrt::hw_context ctx = xrt_core::hw_context_int::create_hw_context_from_implementation(handle);
-    auto dev = xrt_core::hw_context_int::get_core_device(ctx);
-     // Get partition columns
-    boost::property_tree::ptree aiePartitionPt = xdp::aie::getAIEPartitionInfo(handle, false /* handle is not a hwCtxImpl*/);
+    boost::property_tree::ptree aiePartitionPt = xdp::aie::getAIEPartitionInfo(handle);
     // Currently, assuming only one Hw Context is alive at a time
     uint8_t startCol = static_cast<uint8_t>(aiePartitionPt.front().second.get<uint64_t>("start_col"));
     uint8_t numCols  = static_cast<uint8_t>(aiePartitionPt.front().second.get<uint64_t>("num_cols"));

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_plugin.cpp
@@ -32,6 +32,7 @@
 #include "xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.h"
 #elif defined (XDP_VE2_BUILD)
 #include "xdp/profile/plugin/ml_timeline/ve2/ml_timeline.h"
+#include "xdp/profile/device/xdp_base_device.h"
 #endif
 
 namespace xdp {
@@ -160,7 +161,7 @@ namespace xdp {
 
     std::string deviceName = "ve2_device" + std::to_string(implId);
     uint64_t deviceId = db->addDevice(deviceName);
-    (db->getStaticInfo()).updateDeviceClient(deviceId, coreDevice, false);
+    (db->getStaticInfo()).updateDeviceVE2(deviceId, nullptr, hwCtxImpl);
     (db->getStaticInfo()).setDeviceName(deviceId, deviceName);
 
     mMultiImpl[hwCtxImpl] = std::make_pair(implId, std::make_unique<MLTimelineVE2Impl>(db, mBufSz));


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Xdna branch on VE2 doesn't have shim layer, so Xdp hooks needs to use hw_context flow.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
NA
#### How problem was solved, alternative solutions (if any) and why they were rejected
1. Enabled all the plugins on VE2 using hw_context flow
2. Used hw_context hooks and got core device from hw_context_impl handle.
3. Used xclbin_slots query to get xclbin uuid as "get_xclbin_uuid" method is not available in xdna branch.
4. Stored XAie_DevInst in trace plugin which is used in the destructor of trace plugin as storing hw_context causes issues for multi partition designs.
#### Risks (if any) associated the changes in the commit
Halt and status plugin haven't been tested yet.
#### What has been tested and how, request additional testing if necessary
Tested Trace, Profile, Ml_timeline, Debug plugin on VE2 for a MLADF resent50 testcase.
Note : The plugins are tested with  XRT commit (1a60603b31421082c70ba124da2201d60f877036) referenced by the XDNA branch on VE2 repo. With latest XRT as a submodule on VE2 I see compilation issues.
#### Documentation impact (if any)
NA