### PR TITLE
Release version.json in base component

### DIFF
--- a/src/CMake/version.cmake
+++ b/src/CMake/version.cmake
@@ -101,7 +101,7 @@ install(FILES ${PROJECT_BINARY_DIR}/gen/version.h
 if (${XRT_NATIVE_BUILD} STREQUAL "yes")
   install(FILES ${PROJECT_BINARY_DIR}/gen/version.json
     DESTINATION ${XRT_INSTALL_DIR}
-    COMPONENT ${XRT_BASE_DEV_COMPONENT})
+    COMPONENT ${XRT_BASE_COMPONENT})
 endif()
 
 # This is not required on MPSoC platform. To avoid yocto error, do NOT intall


### PR DESCRIPTION
Fix incorrect release of version.json so that it now releases in xrt-base component.
