### PR TITLE
Add API in xrt::run to get control scratchpad memory

### DIFF
--- a/src/runtime_src/core/common/api/module_int.h
+++ b/src/runtime_src/core/common/api/module_int.h
@@ -77,6 +77,15 @@ get_kernel_info(const xrt::module& module);
 void
 dump_dtrace_buffer(const xrt::module& module);
 
+// Below APIS are used to Read/Write data from/to control scratchpad
+// memory. This memory is created using ELF associated with run object.
+// Throws if ELF doesn't contain control scratchpad memory.
+std::vector<char>
+read_ctrl_scratchpad(const xrt::module& module, uint32_t offset, size_t size);
+
+void
+write_ctrl_scratchpad(const xrt::module& module, uint32_t offset, const std::vector<char>& data);
+
 } // xrt_core::module_int
 
 #endif

--- a/src/runtime_src/core/common/api/module_int.h
+++ b/src/runtime_src/core/common/api/module_int.h
@@ -77,14 +77,11 @@ get_kernel_info(const xrt::module& module);
 void
 dump_dtrace_buffer(const xrt::module& module);
 
-// Below APIS are used to Read/Write data from/to control scratchpad
-// memory. This memory is created using ELF associated with run object.
-// Throws if ELF doesn't contain control scratchpad memory.
-std::vector<char>
-read_ctrl_scratchpad(const xrt::module& module, uint32_t offset, size_t size);
-
-void
-write_ctrl_scratchpad(const xrt::module& module, uint32_t offset, const std::vector<char>& data);
+// Returns buffer object associated with control scratchpad memory.
+// This memory is created using ELF associated with run object.
+// Throws if ELF doesn't contain scratchpad memory
+xrt::bo
+get_ctrl_scratchpad_bo(const xrt::module& module);
 
 } // xrt_core::module_int
 

--- a/src/runtime_src/core/common/api/xrt_elf.cpp
+++ b/src/runtime_src/core/common/api/xrt_elf.cpp
@@ -30,12 +30,12 @@ class elf_impl
   struct symbol_info
   {
     std::string name;
-    ELFIO::Elf64_Addr value;
-    ELFIO::Elf_Xword size;
-    unsigned char bind;
-    unsigned char type;
-    ELFIO::Elf_Half section_index;
-    unsigned char other;
+    ELFIO::Elf64_Addr value{};
+    ELFIO::Elf_Xword size{};
+    unsigned char bind{};
+    unsigned char type{};
+    ELFIO::Elf_Half section_index{};
+    unsigned char other{};
   };
 
 public:
@@ -107,9 +107,9 @@ public:
   }
 
   symbol_info
-  get_symbol(const ELFIO::section* section, const std::string& symbol_name) const
+  get_symbol(ELFIO::section* section, const std::string& symbol_name) const
   {
-    const ELFIO::symbol_section_accessor symbols(m_elf, const_cast<ELFIO::section*>(section));
+    const ELFIO::symbol_section_accessor symbols(m_elf, section);
     for (unsigned int i = 0; i < symbols.get_symbols_num(); ++i) {
       symbol_info info;
       symbols.get_symbol(i, info.name, info.value, info.size, info.bind,

--- a/src/runtime_src/core/common/api/xrt_elf.cpp
+++ b/src/runtime_src/core/common/api/xrt_elf.cpp
@@ -25,6 +25,19 @@ class elf_impl
 {
   ELFIO::elfio m_elf;
 
+  // Structure to hold symbol information of an
+  // entry in .dynsym section
+  struct symbol_info
+  {
+    std::string name;
+    ELFIO::Elf64_Addr value;
+    ELFIO::Elf_Xword size;
+    unsigned char bind;
+    unsigned char type;
+    ELFIO::Elf_Half section_index;
+    unsigned char other;
+  };
+
 public:
   explicit
   elf_impl(const std::string& fnm)
@@ -86,11 +99,42 @@ public:
   uint32_t
   get_partition_size() const
   {
-    // Partition size is stored in as note 0 in .note.xrt.configuration section 
+    // Partition size is stored in as note 0 in .note.xrt.configuration section
     if (auto section = m_elf.sections[".note.xrt.configuration"])
       return std::stoul(get_note(section, 0));
 
-    throw std::runtime_error("ELF is missing xrt configuration info");  
+    throw std::runtime_error("ELF is missing xrt configuration info");
+  }
+
+  symbol_info
+  get_symbol(const ELFIO::section* section, const std::string& symbol_name) const
+  {
+    const ELFIO::symbol_section_accessor symbols(m_elf, const_cast<ELFIO::section*>(section));
+    for (unsigned int i = 0; i < symbols.get_symbols_num(); ++i) {
+      symbol_info info;
+      symbols.get_symbol(i, info.name, info.value, info.size, info.bind,
+          info.type, info.section_index, info.other);
+      if (info.name == symbol_name) {
+        return info;
+      }
+    }
+
+    throw std::runtime_error(symbol_name + " symbol not found in .dynsym");
+  }
+
+  size_t
+  get_ctrl_scratchpad_mem_size() const
+  {
+    // Symbol 'scratch-pad-ctrl' in .dynsym section represents
+    // control scratch pad memory, the symbol entry has the size info
+    static const char* section_name = ".dynsym";
+    static const char* symbol = "scratch-pad-ctrl";
+    auto section = m_elf.sections[section_name];
+    if (!section)
+      throw std::runtime_error(".dynsym section not found");
+
+    auto info = get_symbol(section, symbol); // throws if symbol not found
+    return info.size;
   }
 };
 
@@ -163,6 +207,13 @@ program::
 get_partition_size() const
 {
   return get_handle()->get_partition_size();
+}
+
+size_t
+program::
+get_ctrl_scratchpad_mem_size() const
+{
+  return get_handle()->get_ctrl_scratchpad_mem_size();
 }
 
 } // namespace xrt::aie

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -2593,6 +2593,24 @@ public:
   {
     return cmd->get_ert_packet();
   }
+
+  [[nodiscard]] std::vector<char>
+  read_ctrl_scratchpad(uint32_t offset, size_t size)
+  {
+    if (!m_module)
+      throw xrt_core::error("No module associated with run object");
+  
+    return xrt_core::module_int::read_ctrl_scratchpad(m_module, offset, size);
+  }
+
+  void
+  write_ctrl_scratchpad(uint32_t offset, const std::vector<char>& buf)
+  {
+    if (!m_module)
+      throw xrt_core::error("No module associated with run object");
+  
+    xrt_core::module_int::write_ctrl_scratchpad(m_module, offset, buf);
+  }
 };
 
 // class mailbox_impl - Extension of run_impl for mailbox support
@@ -3908,6 +3926,24 @@ submit_signal(const xrt::fence& fence)
   XRT_TRACE_POINT_SCOPE(xrt_submit_signal);
   return xdp::native::profiling_wrapper("xrt::run::submit_signal", [this, &fence]{
     handle->submit_signal(fence);
+  });
+}
+
+std::vector<char>
+run::
+read_ctrl_scratchpad(uint32_t offset, size_t size) const
+{
+  return xdp::native::profiling_wrapper("xrt::run::read_ctrl_scratchpad", [this, offset, size]{
+    return handle->read_ctrl_scratchpad(offset, size);
+  });
+}
+
+void
+run::
+write_ctrl_scratchpad(uint32_t offset, const std::vector<char>& data)
+{
+  return xdp::native::profiling_wrapper("xrt::run::write_ctrl_scratchpad", [this, offset, &data]{
+    handle->write_ctrl_scratchpad(offset, data);
   });
 }
 

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -2594,22 +2594,13 @@ public:
     return cmd->get_ert_packet();
   }
 
-  [[nodiscard]] std::vector<char>
-  read_ctrl_scratchpad(uint32_t offset, size_t size)
+  xrt::bo
+  get_ctrl_scratchpad_bo() const
   {
     if (!m_module)
       throw xrt_core::error("No module associated with run object");
   
-    return xrt_core::module_int::read_ctrl_scratchpad(m_module, offset, size);
-  }
-
-  void
-  write_ctrl_scratchpad(uint32_t offset, const std::vector<char>& buf)
-  {
-    if (!m_module)
-      throw xrt_core::error("No module associated with run object");
-  
-    xrt_core::module_int::write_ctrl_scratchpad(m_module, offset, buf);
+    return xrt_core::module_int::get_ctrl_scratchpad_bo(m_module);
   }
 };
 
@@ -3929,21 +3920,12 @@ submit_signal(const xrt::fence& fence)
   });
 }
 
-std::vector<char>
+xrt::bo
 run::
-read_ctrl_scratchpad(uint32_t offset, size_t size) const
+get_ctrl_scratchpad_bo() const
 {
-  return xdp::native::profiling_wrapper("xrt::run::read_ctrl_scratchpad", [this, offset, size]{
-    return handle->read_ctrl_scratchpad(offset, size);
-  });
-}
-
-void
-run::
-write_ctrl_scratchpad(uint32_t offset, const std::vector<char>& data)
-{
-  return xdp::native::profiling_wrapper("xrt::run::write_ctrl_scratchpad", [this, offset, &data]{
-    handle->write_ctrl_scratchpad(offset, data);
+  return xdp::native::profiling_wrapper("xrt::run::get_ctrl_scratchpad_bo", [this]{
+    return handle->get_ctrl_scratchpad_bo();
   });
 }
 

--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -69,10 +69,10 @@ static constexpr uint8_t Elf_Amd_Aie2p_config = 70;
 // using max bd words as 9 to cover all cases
 static constexpr size_t max_bd_words = 9;
 
-static const char* Scratch_Pad_Mem_Symbol = "scratch-pad-mem";
-static const char* Control_ScratchPad_Symbol = "scratch-pad-ctrl";
-static const char* Control_Packet_Symbol = "control-packet";
-static const char* Control_Code_Symbol = "control-code";
+static const char* const Scratch_Pad_Mem_Symbol = "scratch-pad-mem";
+static const char* const Control_ScratchPad_Symbol = "scratch-pad-ctrl";
+static const char* const Control_Packet_Symbol = "control-packet";
+static const char* const Control_Code_Symbol = "control-code";
 
 struct buf
 {
@@ -569,20 +569,6 @@ public:
   get_os_abi() const
   {
     throw std::runtime_error("Not supported");
-  }
-
-  // Patch ctrlcode buffer object for global argument
-  //
-  // @param bo_ctrlcode - bo containing ctrlcode
-  // @param symbol - symbol name
-  // @param index - argument index
-  // @param bo - global argument to patch into ctrlcode
-  // @param buf_type - whether it is control-code, control-packet, preempt-save or preempt-restore
-  // @param sec_index - index of section to be patched
-  virtual void
-  patch_instr(xrt::bo&, const std::string&, size_t, const xrt::bo&, patcher::buf_type, uint32_t)
-  {
-    throw std::runtime_error("Not supported ");
   }
 
   // Patch ctrlcode buffer object for global argument
@@ -1874,9 +1860,11 @@ class module_sram : public module_impl
     fill_instruction_buffer(data);
   }
 
+  // Patch the instruction buffer with global argument(xrt::bo)
+  // The symbol to be patched is identified using argnm/index
   void
   patch_instr(xrt::bo& bo_ctrlcode, const std::string& argnm, size_t index, const xrt::bo& bo,
-              patcher::buf_type type, uint32_t sec_idx) override
+              patcher::buf_type type, uint32_t sec_idx)
   {
     patch_instr_value(bo_ctrlcode, argnm, index, bo.address(), type, sec_idx);
   }

--- a/src/runtime_src/core/include/xrt/experimental/xrt_aie.h
+++ b/src/runtime_src/core/include/xrt/experimental/xrt_aie.h
@@ -77,19 +77,6 @@ public:
   XRT_API_EXPORT
   size_type
   get_partition_size() const;
-
-  /**
-   * get_ctrl_scratchpad_mem_size - Retrieves the size of the control
-   * scratchpad memory in bytes.
-   *
-   * The control scratchpad memory is utilized to store state data
-   * during the execution of the model. This function provides the
-   * size of this memory enabling users to determine the amount of
-   * data that can be read from or written to it.
-   */
-  XRT_API_EXPORT
-  size_t
-  get_ctrl_scratchpad_mem_size() const;
 };
 
 } // namespace xrt::aie

--- a/src/runtime_src/core/include/xrt/experimental/xrt_aie.h
+++ b/src/runtime_src/core/include/xrt/experimental/xrt_aie.h
@@ -77,8 +77,21 @@ public:
   XRT_API_EXPORT
   size_type
   get_partition_size() const;
+
+  /**
+   * get_ctrl_scratchpad_mem_size - Retrieves the size of the control
+   * scratchpad memory in bytes.
+   *
+   * The control scratchpad memory is utilized to store state data
+   * during the execution of the model. This function provides the
+   * size of this memory enabling users to determine the amount of
+   * data that can be read from or written to it.
+   */
+  XRT_API_EXPORT
+  size_t
+  get_ctrl_scratchpad_mem_size() const;
 };
-  
+
 } // namespace xrt::aie
 
 #endif // __cplusplus

--- a/src/runtime_src/core/include/xrt/xrt_kernel.h
+++ b/src/runtime_src/core/include/xrt/xrt_kernel.h
@@ -615,41 +615,19 @@ public:
   }
 
   /**
-   * read_ctrl_scratchpad() - Read control scratchpad memory
+   * get_ctrl_scratchpad_bo() - Get the ctrl scratchpad bo object
    * 
-   * @param offset
-   *  Offset in control scratchpad memory
-   * @param size
-   *  Number of bytes to read
-   * @return
-   *  Data read from control scratchpad memory
-   * 
-   * This API is valid only for run objects that are associated with an ELF.
-   * Use this API to read data from control scratchpad memory.
-   * This memory is created by XRT based on ELF used to create xrt::kernel.
-   * 
-   * This function throws if the read fails.
-   */
-  std::vector<char>
-  read_ctrl_scratchpad(uint32_t offset, size_t size) const;
-
-  /**
-   * write_ctrl_scratchpad() - Write data to control scratchpad memory
-   * 
-   * @param offset
-   *  Offset in control scratchpad memory to write to
-   * @param data
-   *  Data to write to control scratchpad memory
-   * 
-   * This API is valid only for run objects that are associated with an ELF.
-   * Use this API to write data to control scratchpad memory.
+   * NPU uses ctrl scratchpad memory to store control state data.
    * This memory is created by XRT based on ELF used to create xrt::kernel
-   * Size of data is calculated using vector of data passed
+   * The API returns the buffer object (bo) created by XRT allowing
+   * applications to read from or write to it.
+   * This API is only valid for run objects associated with an ELF.
    * 
-   * This function throws if the write fails.
+   * Throws if control scratchpad section is not absent in ELF or
+   * if any error occurs while retrieving the bo
    */
-  void
-  write_ctrl_scratchpad(uint32_t offset, const std::vector<char>& data);
+  xrt::bo
+  get_ctrl_scratchpad_bo() const;
 
 public:
   /// @cond

--- a/src/runtime_src/core/include/xrt/xrt_kernel.h
+++ b/src/runtime_src/core/include/xrt/xrt_kernel.h
@@ -614,6 +614,43 @@ public:
     start(count);
   }
 
+  /**
+   * read_ctrl_scratchpad() - Read control scratchpad memory
+   * 
+   * @param offset
+   *  Offset in control scratchpad memory
+   * @param size
+   *  Number of bytes to read
+   * @return
+   *  Data read from control scratchpad memory
+   * 
+   * This API is valid only for run objects that are associated with an ELF.
+   * Use this API to read data from control scratchpad memory.
+   * This memory is created by XRT based on ELF used to create xrt::kernel.
+   * 
+   * This function throws if the read fails.
+   */
+  std::vector<char>
+  read_ctrl_scratchpad(uint32_t offset, size_t size) const;
+
+  /**
+   * write_ctrl_scratchpad() - Write data to control scratchpad memory
+   * 
+   * @param offset
+   *  Offset in control scratchpad memory to write to
+   * @param data
+   *  Data to write to control scratchpad memory
+   * 
+   * This API is valid only for run objects that are associated with an ELF.
+   * Use this API to write data to control scratchpad memory.
+   * This memory is created by XRT based on ELF used to create xrt::kernel
+   * Size of data is calculated using vector of data passed
+   * 
+   * This function throws if the write fails.
+   */
+  void
+  write_ctrl_scratchpad(uint32_t offset, const std::vector<char>& data);
+
 public:
   /// @cond
   const std::shared_ptr<run_impl>&


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Added new API to get control scratchpad memory.
This memory is used by NPU to store control state information of a model. ELF is parsed to look for this section and a xrt::bo object is created corresponding to it.
This PR provides API  to get this buffer object so that users can read/write to this memory.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
#### How problem was solved, alternative solutions (if any) and why they were rejected
Provided required function with xrt::run class as each running instance of a model will have its own control scratchpad memory

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
Tested with Preemption application on strix linux and things work as expected

#### Documentation impact (if any)
Added comments with the API declaration.