### PR TITLE
Fixing telluride xdna compilation error

### DIFF
--- a/src/runtime_src/core/common/smi.h
+++ b/src/runtime_src/core/common/smi.h
@@ -49,6 +49,7 @@ struct option : public basic_option {
 // custom behavior for xrt-smi as required. This gives us the flexibility
 // to add device/platform specific xrt-smi behavior.
 class smi_base {
+protected:
   tuple_vector validate_test_desc;
   tuple_vector examine_report_desc;
   std::vector<option> configure_suboptions_desc;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

Fixing Telluride xdna compilation errors

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

N/A

#### How problem was solved, alternative solutions (if any) and why they were rejected

Replaced newly changed function name and "protected" access specifier added back from "private"

#### Risks (if any) associated the changes in the commit

N/A

#### What has been tested and how, request additional testing if necessary

N/A

#### Documentation impact (if any)

N/A