### PR TITLE
Clean-up xrt-smi report output

### DIFF
--- a/src/runtime_src/core/common/sensor.cpp
+++ b/src/runtime_src/core/common/sensor.cpp
@@ -215,7 +215,7 @@ read_data_driven_electrical(const std::vector<xq::sdm_sensor_info::data_type>& c
   // iterate over power data, store to ptree by converting to watts.
   for (const auto& tmp : power) {
     if (boost::iequals(tmp.label, "Total Power")) {
-      if (tmp.input != std::numeric_limits<decltype(xq::sdm_sensor_info::data_type::input)>::max())
+      if ((tmp.input != std::numeric_limits<decltype(xq::sdm_sensor_info::data_type::input)>::max()) && (tmp.input != 0))
         bd_power = xrt_core::utils::format_base10_shiftdown(tmp.input, tmp.unitm, 3);
       bd_max_power = xrt_core::utils::format_base10_shiftdown(tmp.max, tmp.unitm, 3);
     }

--- a/src/runtime_src/core/tools/common/reports/ReportAiePartitions.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportAiePartitions.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
 
 // ------ I N C L U D E   F I L E S -------------------------------------------
 // Local - Include Files

--- a/src/runtime_src/core/tools/common/reports/ReportAiePartitions.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportAiePartitions.cpp
@@ -34,7 +34,7 @@ populate_aie_partition(const xrt_core::device* device)
     pt_entry.put("pid", entry.pid);
     pt_entry.put("context_id", entry.metadata.id);
     pt_entry.put("status", entry.is_suspended ? "Idle" : "Active");
-    pt_entry.put("instr_bo_mem", entry.instruction_mem);
+    pt_entry.put("instr_bo_mem", entry.instruction_mem ? xrt_core::utils::unit_convert(entry.instruction_mem) : "N/A");
     pt_entry.put("command_submissions", entry.command_submissions);
     pt_entry.put("command_completions", entry.command_completions);
     pt_entry.put("migrations", entry.migrations);
@@ -136,7 +136,7 @@ writeReport(const xrt_core::device* /*_pDevice*/,
         hw_context.get<std::string>("pid"),
         hw_context.get<std::string>("context_id"),
         hw_context.get<std::string>("status"),
-        xrt_core::utils::unit_convert(hw_context.get<uint64_t>("instr_bo_mem")),
+        hw_context.get<std::string>("instr_bo_mem"),
         hw_context.get<std::string>("command_submissions"),
         hw_context.get<std::string>("command_completions"),
         hw_context.get<std::string>("migrations"),

--- a/src/runtime_src/core/tools/common/reports/ReportPreemption.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportPreemption.cpp
@@ -65,7 +65,7 @@ ReportPreemption::writeReport(const xrt_core::device* ,
 {
   const bpt empty_ptree;
   bpt telemetry_array = pt.get_child("telemetry", empty_ptree);
-  _output << "Premption Telemetry Data\n";
+  _output << "Preemption Telemetry Data\n";
   _output << generate_preemption_string(telemetry_array);
   _output << std::endl;
 }

--- a/src/runtime_src/core/tools/common/tests/TestAIEReconfigOverhead.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestAIEReconfigOverhead.cpp
@@ -38,10 +38,12 @@ TestAIEReconfigOverhead::run(std::shared_ptr<xrt_core::device> dev)
   
   if (!elf) {
     xclbin_path = XBValidateUtils::get_xclbin_path(dev, xrt_core::query::xclbin_name::type::validate, ptree);
-    XBValidateUtils::logger(ptree, "Details", "Using DPU Sequence");
+    if (XBU::getVerbose())
+      XBValidateUtils::logger(ptree, "Details", "Using DPU Sequence");
   } else {
     xclbin_path = XBValidateUtils::get_xclbin_path(dev, xrt_core::query::xclbin_name::type::validate_elf, ptree);
-    XBValidateUtils::logger(ptree, "Details", "Using ELF");
+    if (XBU::getVerbose())
+      XBValidateUtils::logger(ptree, "Details", "Using ELF");
   }
 
   if (!std::filesystem::exists(xclbin_path)){

--- a/src/runtime_src/core/tools/common/tests/TestCmdChainLatency.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestCmdChainLatency.cpp
@@ -36,10 +36,12 @@ TestCmdChainLatency::run(std::shared_ptr<xrt_core::device> dev)
   
   if (!elf) {
     xclbin_path = XBValidateUtils::get_xclbin_path(dev, xrt_core::query::xclbin_name::type::validate, ptree);
-    XBValidateUtils::logger(ptree, "Details", "Using DPU Sequence");
+    if (XBU::getVerbose())
+      XBValidateUtils::logger(ptree, "Details", "Using DPU Sequence");
   } else {
     xclbin_path = XBValidateUtils::get_xclbin_path(dev, xrt_core::query::xclbin_name::type::validate_elf, ptree);
-    XBValidateUtils::logger(ptree, "Details", "Using ELF");
+    if (XBU::getVerbose())
+      XBValidateUtils::logger(ptree, "Details", "Using ELF");
   }
 
   if (!std::filesystem::exists(xclbin_path)){

--- a/src/runtime_src/core/tools/common/tests/TestCmdChainThroughput.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestCmdChainThroughput.cpp
@@ -39,10 +39,12 @@ TestCmdChainThroughput::run(std::shared_ptr<xrt_core::device> dev)
   
   if (!elf) {
     xclbin_path = XBValidateUtils::get_xclbin_path(dev, xrt_core::query::xclbin_name::type::validate, ptree);
-    XBValidateUtils::logger(ptree, "Details", "Using DPU Sequence");
+    if (XBU::getVerbose())
+      XBValidateUtils::logger(ptree, "Details", "Using DPU Sequence");
   } else {
     xclbin_path = XBValidateUtils::get_xclbin_path(dev, xrt_core::query::xclbin_name::type::validate_elf, ptree);
-    XBValidateUtils::logger(ptree, "Details", "Using ELF");
+    if (XBU::getVerbose())
+      XBValidateUtils::logger(ptree, "Details", "Using ELF");
   }
 
   if (!std::filesystem::exists(xclbin_path)){

--- a/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.cpp
@@ -40,10 +40,12 @@ TestDF_bandwidth::run(std::shared_ptr<xrt_core::device> dev)
   
   if (!elf) {
     xclbin_path = XBValidateUtils::get_xclbin_path(dev, xrt_core::query::xclbin_name::type::validate, ptree);
-    XBValidateUtils::logger(ptree, "Details", "Using DPU Sequence");
+    if (XBU::getVerbose())
+      XBValidateUtils::logger(ptree, "Details", "Using DPU Sequence");
   } else {
     xclbin_path = XBValidateUtils::get_xclbin_path(dev, xrt_core::query::xclbin_name::type::validate_elf, ptree);
-    XBValidateUtils::logger(ptree, "Details", "Using ELF");
+    if (XBU::getVerbose())
+      XBValidateUtils::logger(ptree, "Details", "Using ELF");
   }
 
   if (!std::filesystem::exists(xclbin_path)){

--- a/src/runtime_src/core/tools/common/tests/TestGemm.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestGemm.cpp
@@ -43,10 +43,12 @@ TestGemm::run(std::shared_ptr<xrt_core::device> dev)
 
   if (!elf) {
     xclbin_path = XBValidateUtils::get_xclbin_path(dev, xrt_core::query::xclbin_name::type::gemm, ptree);
-    XBValidateUtils::logger(ptree, "Details", "Using DPU Sequence");
+    if (XBU::getVerbose())
+      XBValidateUtils::logger(ptree, "Details", "Using DPU Sequence");
   } else {
     xclbin_path = XBValidateUtils::get_xclbin_path(dev, xrt_core::query::xclbin_name::type::gemm_elf, ptree);
-    XBValidateUtils::logger(ptree, "Details", "Using ELF");
+    if (XBU::getVerbose())
+      XBValidateUtils::logger(ptree, "Details", "Using ELF");
   }
 
   if (!std::filesystem::exists(xclbin_path)){

--- a/src/runtime_src/core/tools/common/tests/TestNPULatency.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestNPULatency.cpp
@@ -35,10 +35,12 @@ TestNPULatency::run(std::shared_ptr<xrt_core::device> dev)
   
   if (!elf) {
     xclbin_path = XBValidateUtils::get_xclbin_path(dev, xrt_core::query::xclbin_name::type::validate, ptree);
-    XBValidateUtils::logger(ptree, "Details", "Using DPU Sequence");
+    if (XBU::getVerbose())
+      XBValidateUtils::logger(ptree, "Details", "Using DPU Sequence");
   } else {
     xclbin_path = XBValidateUtils::get_xclbin_path(dev, xrt_core::query::xclbin_name::type::validate_elf, ptree);
-    XBValidateUtils::logger(ptree, "Details", "Using ELF");
+    if (XBU::getVerbose())
+      XBValidateUtils::logger(ptree, "Details", "Using ELF");
   }
 
   if (!std::filesystem::exists(xclbin_path)){

--- a/src/runtime_src/core/tools/common/tests/TestNPUThroughput.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestNPUThroughput.cpp
@@ -36,10 +36,12 @@ TestNPUThroughput::run(std::shared_ptr<xrt_core::device> dev)
   
   if (!elf) {
     xclbin_path = XBValidateUtils::get_xclbin_path(dev, xrt_core::query::xclbin_name::type::validate, ptree);
-    XBValidateUtils::logger(ptree, "Details", "Using DPU Sequence");
+    if (XBU::getVerbose())
+      XBValidateUtils::logger(ptree, "Details", "Using DPU Sequence");
   } else {
     xclbin_path = XBValidateUtils::get_xclbin_path(dev, xrt_core::query::xclbin_name::type::validate_elf, ptree);
-    XBValidateUtils::logger(ptree, "Details", "Using ELF");
+    if (XBU::getVerbose())
+      XBValidateUtils::logger(ptree, "Details", "Using ELF");
   }
 
   if (!std::filesystem::exists(xclbin_path)){

--- a/src/runtime_src/core/tools/common/tests/TestTCTAllColumn.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestTCTAllColumn.cpp
@@ -35,10 +35,12 @@ TestTCTAllColumn::run(std::shared_ptr<xrt_core::device> dev)
   
   if (!elf) {
     xclbin_path = XBValidateUtils::get_xclbin_path(dev, xrt_core::query::xclbin_name::type::validate, ptree);
-    XBValidateUtils::logger(ptree, "Details", "Using DPU Sequence");
+    if (XBU::getVerbose())
+      XBValidateUtils::logger(ptree, "Details", "Using DPU Sequence");
   } else {
     xclbin_path = XBValidateUtils::get_xclbin_path(dev, xrt_core::query::xclbin_name::type::validate_elf, ptree);
-    XBValidateUtils::logger(ptree, "Details", "Using ELF");
+    if (XBU::getVerbose())
+      XBValidateUtils::logger(ptree, "Details", "Using ELF");
   }
 
   if (!std::filesystem::exists(xclbin_path)){

--- a/src/runtime_src/core/tools/common/tests/TestTCTOneColumn.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestTCTOneColumn.cpp
@@ -35,10 +35,12 @@ TestTCTOneColumn::run(std::shared_ptr<xrt_core::device> dev)
   
   if (!elf) {
     xclbin_path = XBValidateUtils::get_xclbin_path(dev, xrt_core::query::xclbin_name::type::validate, ptree);
-    XBValidateUtils::logger(ptree, "Details", "Using DPU Sequence");
+    if (XBU::getVerbose())
+      XBValidateUtils::logger(ptree, "Details", "Using DPU Sequence");
   } else {
     xclbin_path = XBValidateUtils::get_xclbin_path(dev, xrt_core::query::xclbin_name::type::validate_elf, ptree);
-    XBValidateUtils::logger(ptree, "Details", "Using ELF");
+    if (XBU::getVerbose())
+      XBValidateUtils::logger(ptree, "Details", "Using ELF");
   }
 
   if (!std::filesystem::exists(xclbin_path)){


### PR DESCRIPTION
#### Problem solved by the commit
Fix typo in preemption report and add placeholder in aie-partitions report. Request to display "N/A" when power reading is 0 in platform report. Move details logging usage of dpu or elf to verbose for xrt-smi validate.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Typo seen in internal testing, noticed missing placeholder for xdna aie-partitions report. 
#### How problem was solved, alternative solutions (if any) and why they were rejected
Fixed typo, added "N/A" check for aie-partitions and platform reports. Moved details logging usage of dpu or elf to verbose for xrt-smi validate.
#### Risks (if any) associated the changes in the commit
N/A
#### What has been tested and how, request additional testing if necessary
Tested on MCDM and STX xdna.
Sample output for aie-partitions report for STX xdna:
```
---------------------------
[0000:c5:00.1] : NPU Strix
---------------------------
AIE Partitions
  Partition Index: 0
    Columns: [0, 1, 2, 3, 4, 5, 6, 7]
    HW Contexts:
      |PID     |Ctx ID  |Status  |Instr BO  |Sub  |Compl  |Migr  |Err  |Prio  |GOPS  |EGOPS  |FPS  |Latency  |
      |--------|--------|--------|----------|-----|-------|------|-----|------|------|-------|-----|---------|
      |263792  |1       |Active  |N/A       |105  |104    |0     |0    |Low   |N/A   |N/A    |N/A  |N/A      |
```
#### Documentation impact (if any)
N/A