### PR TITLE
Fix for handling CUs with undefined protocol

### DIFF
--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -1741,6 +1741,9 @@ static int kds_cfg_xgq_update(struct kds_sched *kds)
 		if (!xcu)
 			continue;
 
+		if (xcu->info.protocol == CTRL_NONE)
+			continue;
+
 		if (xrt_cu_intr_supported(xcu))
 			continue;
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -2333,6 +2333,9 @@ static int xocl_kds_update_xgq(struct xocl_dev *xdev, int slot_hdl,
 		struct xgq_cmd_resp_query_cu resp;
 		void *xgq;
 
+		if (cu_info[i].protocol == CTRL_NONE)
+		continue;
+
 		ret = xocl_kds_xgq_query_cu(xdev, cu_info[i].cu_idx, 0, &resp);
 		if (ret)
 			goto create_regular_cu;
@@ -2546,6 +2549,9 @@ int xocl_kds_unregister_cus(struct xocl_dev *xdev, int slot_hdl)
 	for (i = 0; i < MAX_CUS; i++) {
 		xcu = cu_mgmt->xcus[i];
 		if (!xcu)
+			continue;
+
+		if (xcu->info.protocol == CTRL_NONE)
 			continue;
 
 		/* Unregister the CUs as per slot order */


### PR DESCRIPTION
Problem solved by the commit
Fix for handling CUs with undefined protocol

Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Skip querying CUs with undefined protocol type.

How problem was solved, alternative solutions (if any) and why they were rejected
Skip querying CUs with undefined protocol type.

Risks (if any) associated the changes in the commit
Fixed make for PL Kernels, may need changes for PS kernels as well in future.

What has been tested and how, request additional testing if necessary
Loaded PL+AIE kernel to check if program has been succeeded.
Ran xbutil validate to verify the KDS functionality after programming.

Documentation impact (if any)
Changes are made for PL kernels only. may need to handle changes for PS kernels in future.