### PR TITLE
Update build of xdp_core to differentiate when building for client

### DIFF
--- a/src/runtime_src/xdp/profile/CMakeLists.txt
+++ b/src/runtime_src/xdp/profile/CMakeLists.txt
@@ -32,6 +32,11 @@ file(GLOB XDP_CORE_FILES
 
 add_library(xdp_core SHARED ${XDP_CORE_FILES})
 add_dependencies(xdp_core xrt_coreutil)
+
+if (XDP_CLIENT_BUILD_CMAKE STREQUAL "yes")
+  target_compile_definitions(xdp_core PRIVATE XDP_CLIENT_BUILD=1)
+endif()
+
 target_link_libraries(xdp_core PRIVATE xrt_coreutil)
 
 set_target_properties(xdp_core PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})


### PR DESCRIPTION
#### Problem solved by the commit
Enable the utility function "isClient" in the profiling core library.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Issue was discovered when testing new changes in the profiling code that require the isClient() function.

#### How problem was solved, alternative solutions (if any) and why they were rejected
The need for the isClient() function is due to some query_device functionality not being implemented on certain devices.  In the future the XRT APIs we're calling must be implemented in multiple targets.

#### Risks (if any) associated the changes in the commit
Low risk as the compile time guard being defined is only used in a single utility function in the profiling core library.

#### Documentation impact (if any)
No documentation change necessary.