### PR TITLE
CR-1232068: Throwing error if available BDs are empty

### DIFF
--- a/src/runtime_src/core/edge/user/aie/common_layer/adf_runtime_api.cpp
+++ b/src/runtime_src/core/edge/user/aie/common_layer/adf_runtime_api.cpp
@@ -672,20 +672,21 @@ err_code gmio_api::enqueueBD(XAie_MemInst *memInst, uint64_t offset, size_t size
 
     int driverStatus = XAIE_OK; //0
 
-    //wait for available BD
-    while (availableBDs.empty())
-    {
-        u8 numPendingBDs = 0;
-        driverStatus |= XAie_DmaGetPendingBdCount(config->get_dev(), gmioTileLoc, pGMIOConfig->channelNum, (pGMIOConfig->type == gmio_config::gm2aie ? DMA_MM2S : DMA_S2MM), &numPendingBDs);
+    //get available BDs first
+    u8 numPendingBDs = 0;
+    driverStatus |= XAie_DmaGetPendingBdCount(config->get_dev(), gmioTileLoc, pGMIOConfig->channelNum, (pGMIOConfig->type == gmio_config::gm2aie ? DMA_MM2S : DMA_S2MM), &numPendingBDs);
 
-        int numBDCompleted = dmaStartQMaxSize - numPendingBDs;
-        //move completed BDs from enqueuedBDs to availableBDs
-        for (int i = 0; i < numBDCompleted; i++)
-        {
-            uint16_t bdNumber = frontAndPop(enqueuedBDs);
-            availableBDs.push(bdNumber);
-        }
+    int numBDCompleted = dmaStartQMaxSize - numPendingBDs;
+    //move completed BDs from enqueuedBDs to availableBDs
+    for (int i = 0; i < numBDCompleted; i++)
+    {
+        uint16_t bdNum = frontAndPop(enqueuedBDs);
+        availableBDs.push(bdNum);
     }
+
+    //first check if we have atleast one availabe BD to proceed
+    if (availableBDs.empty())
+        return errorMsg(err_code::internal_error, "ERROR: adf::gmio_api::enqueueBD: available BDs are empty.");
 
     //get an available BD
     uint16_t bdNumber = frontAndPop(availableBDs);

--- a/src/runtime_src/core/edge/user/aie/common_layer/adf_runtime_api.cpp
+++ b/src/runtime_src/core/edge/user/aie/common_layer/adf_runtime_api.cpp
@@ -678,7 +678,7 @@ err_code gmio_api::enqueueBD(XAie_MemInst *memInst, uint64_t offset, size_t size
 
     int numBDCompleted = dmaStartQMaxSize - numPendingBDs;
     //move completed BDs from enqueuedBDs to availableBDs
-    for (int i = 0; i < numBDCompleted; i++)
+    for (int i = 0; i < numBDCompleted && !enqueuedBDs.empty(); i++)
     {
         uint16_t bdNum = frontAndPop(enqueuedBDs);
         availableBDs.push(bdNum);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1232068
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
When we call too many async() calls with either xrt::aie::bo or xrt::aie::buffer, the XAie API XAie_DmaGetPendingBdCount() does not behave as expected and the availableBDs queue is not getting updated and we're just in the infinite while loop.
#### How problem was solved, alternative solutions (if any) and why they were rejected
By removing the while loop and calling XAie_DmaGetPendingBdCount() only once to update the availableBDs queue.
#### Risks (if any) associated the changes in the commit
n/a
#### What has been tested and how, request additional testing if necessary
Tested on the given testcase available in the bugcase area. Also tested by calling too many async() from both xrt::aie::bo and xrt::aie::buffer as well as by calling only single or 2 or 4 async() calls to check the pass case.
#### Documentation impact (if any)
n/a