### PR TITLE
Fix Compiler Warnings for GCC 14 Compatibility

### DIFF
--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -674,7 +674,7 @@ struct clk_scaling_info
     std::vector<std::string> stat;
     boost::split(stat, keyValue, boost::is_any_of(":"));
     if (stat.size() != 2) {
-      const auto& errMsg = boost::format("Error: KeyValue pair doesn't meet expected format '<key>:<value>': '%s'") % keyValue;
+      const auto errMsg = boost::format("Error: KeyValue pair doesn't meet expected format '<key>:<value>': '%s'") % keyValue;
       throw std::runtime_error(errMsg.str());
     }
     return std::stoi(std::string(stat.at(1)));

--- a/src/runtime_src/core/tools/xbtracer/src/lib/logger.h
+++ b/src/runtime_src/core/tools/xbtracer/src/lib/logger.h
@@ -267,15 +267,15 @@ template <typename... Args>
 std::string concat_args(const Args&... args)
 {
   std::ostringstream oss;
-  bool first = true;
-
-  // Folding expression with type check for membuf
-  ((oss << (first ? "" : ", ")
-    << (std::is_same_v<membuf, std::decay_t<Args>>
-    ? mb_stringify(args)
-    : stringify_args(args)),
-    first = false), ...);
-
+  if constexpr (sizeof...(args) > 0) {
+    bool first = true;
+    // Folding expression with type check for membuf
+    ((oss << (first ? "" : ", ")
+      << (std::is_same_v<membuf, std::decay_t<Args>>
+      ? mb_stringify(args)
+      : stringify_args(args)),
+      first = false), ...);
+  }
   return oss.str();
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
This commit addresses two compiler errors that arise with GCC 14's stricter warning settings:

1. A dangling reference warning when using `Boost::format`
2. An unused variable warning in the `concat_args` template function when instantiated with an empty argument list

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
The issues were discovered during compilation with GCC 14 which has enhanced warning detection compared to previous GCC versions. These aren't new bugs but rather existing code patterns that GCC 14 now identifies as potentially problematic. These issues were discovered while compiling on 

- MINISFOURM AI370 mini PC (Ryzen™ AI 9 HX 370)
- OS: Ubuntu 25.04 with kernel 6.14.0-13.
- Compiler: GCC 14.2.0 (Ubuntu 14.2.0-19ubuntu2)

Error messages:

1. `error: possibly dangling reference to a temporary [-Werror=dangling-reference]`
2. `error: variable 'first' set but not used [-Werror=unused-but-set-variable]`

#### How problem was solved, alternative solutions (if any) and why they were rejected

1. For the dangling reference issue:

    - Changed const auto& `errMsg` to const auto `errMsg` to avoid referencing a temporary `Boost::format object`.
    - Alternative: Convert to string immediately with `.str()`, but this was rejected as unnecessary when simply removing the reference solves the issue more cleanly.

 2. For the unused variable issue:
     - Added `if constexpr (sizeof...(args) > 0)` condition to only declare and use the first variable when arguments are present.
     - Alternative: Create a template specialization for empty arguments, but this would duplicate more code than necessary (?).

#### Risks (if any) associated the changes in the commit

1. Dangling reference fix: No risks? as this corrects a potential undefined behavior.
2. Unused variable fix: No risks? as the function behavior with empty arguments remains the same.

#### What has been tested and how, request additional testing if necessary
- Compiled with GCC 14 with `-Werror=dangling-reference` and `-Werror=unused-but-set-variable` flags enabled.
- Verified that both issues no longer trigger compiler errors.
- Functionality remains unchanged as these are correctness fixes rather than behavioral changes.

#### Documentation impact (if any)
None. These are compiler warning fixes that don't change API behavior or usage.
