### PR TITLE
Fix for CR-1235776 and CR-1236948

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/edge/zocl_aie.c
+++ b/src/runtime_src/core/edge/drm/zocl/edge/zocl_aie.c
@@ -120,6 +120,9 @@ zocl_aie_error_cb(void *arg)
 	struct aie_errors *errors;
 	int i;
 
+	DRM_WARN("%s: Received AIE_ERR callback, ignoring it\n", __func__);
+	return;
+
 	if (!slot) {
 		DRM_ERROR("%s: slot is not initialized\n", __func__);
 		return;

--- a/src/runtime_src/core/edge/user/system_linux.cpp
+++ b/src/runtime_src/core/edge/user/system_linux.cpp
@@ -76,6 +76,10 @@ enumerate_accel_devices(unsigned int& device_count)
   std::string accel_dev_name;
 
   try {
+    if (!fs::exists(base_path)) {
+      throw std::runtime_error("Device search path: " + base_path + " doesn't exist\n");
+    }
+
     for (const auto& entry : fs::directory_iterator(base_path)) {
       if (fs::is_directory(entry) && std::regex_match(entry.path().filename().string(), accel_regex)) {
         const std::string accel_file_path = entry.path().string() + of_node_path;
@@ -104,7 +108,7 @@ enumerate_accel_devices(unsigned int& device_count)
       dev_map[device_count++] = dev_type::aiarm_xdna;
   }
   catch (const std::exception& e) {
-    std::string msg = "Error while searching for AIARM accel device: " + std::string(e.what());
+    std::string msg = "AIARM accel device not found : " + std::string(e.what());
     xrt_core::message::send(xrt_core::message::severity_level::info, "XRT", msg);
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1235776
https://jira.xilinx.com/browse/CR-1236948
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1236948: We dont used to validate the path before accessing it. 
CR-1235776: We used to register err callback for AIE. Somehow there is an error callback is coming for passing case also. For now, we're just ignoring the errors coming from hw.
#### How problem was solved, alternative solutions (if any) and why they were rejected
CR-1236948: Added a proper check before accessing the path for the accel device. And printing proper message.
CR-1235776: As a temporary fix we're just ignoring the errors coming from the hw.
#### Risks (if any) associated the changes in the commit
low
#### What has been tested and how, request additional testing if necessary
Tested on vck190 and vek280 with some testcases.
#### Documentation impact (if any)
n/a