### PR TITLE
Add changes to send only opcode kernel arg size in ert pkt payload data

### DIFF
--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -2106,8 +2106,13 @@ class run_impl
         kcmd->opcode == ERT_START_NPU_PREEMPT_ELF) {
       auto payload_past_dpu = initialize_dpu(payload);
 
-      // adjust count to include the prepended ert_dpu_data structures
-      kcmd->count += payload_past_dpu - payload;
+      // Adjust count to include the prepended ert_dpu_data structures
+      // Also, for ELF flow we dont need kernel args info in cmd payload
+      // as args are patched at host side, only the first arg(opcode)
+      // info is sent in this case.
+      // opcode is uint64_t so (2 * uint32_t) is the size in payload
+      kcmd->count += payload_past_dpu - payload - kernel->get_regmap_size()
+          + sizeof(uint64_t) / sizeof(uint32_t); // size of arg opcode
       payload = payload_past_dpu;
     }
     return payload;

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -2109,8 +2109,11 @@ class run_impl
       // Adjust count to include the prepended ert_dpu_data structures
       // Also, for ELF flow we dont need kernel args info in cmd payload
       // as args are patched at host side, only the first arg(opcode)
-      // info is sent in this case.
-      // opcode is uint64_t so (2 * uint32_t) is the size in payload
+      // info is sent in this case and it is written into the command register
+      // map at offset 0x0.   The command count is initialized earlier to 
+      // the size the command register map plus cu masks.
+      // opcode is uint64_t so (2 * uint32_t) is the size in payload so
+      // subtract register map size and add 2.
       kcmd->count += payload_past_dpu - payload - kernel->get_regmap_size()
           + sizeof(uint64_t) / sizeof(uint32_t); // size of arg opcode
       payload = payload_past_dpu;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Added changes to send only info about first arg (opcode) in payload data of ert packet for which size of payload is updated.
This is done as elf patching is done at host side and we need not send all args info in ert packet in ELF based flows.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
#### How problem was solved, alternative solutions (if any) and why they were rejected
Adjusted the count in header to send only size of first arg in payload

#### Risks (if any) associated the changes in the commit
Moderate need to test ELF flow on all the devices that support the flow

#### What has been tested and how, request additional testing if necessary
Tested on Strix Linux
Additional testing needs to be on Strix windows, Telluride
Marking the PR with do not merge label till this testing is done.

#### Documentation impact (if any)
NA