### PR TITLE
CR-1235726 Fix BO initialization for throughput and latency tests

### DIFF
--- a/src/runtime_src/core/tools/common/tests/TestNPULatency.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestNPULatency.cpp
@@ -120,10 +120,14 @@ TestNPULatency::run(std::shared_ptr<xrt_core::device> dev)
       else if (arg.get_host_type().find('*') != std::string::npos) {
         xrt::bo bo;
 
-        if (arg.get_name() == "instruct")
+        if (arg.get_name() == "instruct") {
           bo = xrt::bo(hwctx, arg.get_size(), xrt::bo::flags::cacheable, kernel.group_id(arg_idx));
-        else 
+          auto bo_mapped = bo.map<int*>();
+            for (size_t idx = 0; idx < arg.get_size(); idx++)
+              bo_mapped[idx] = 0;
+        } else {
           bo = xrt::bo(working_dev, arg.get_size(), xrt::bo::flags::host_only, kernel.group_id(arg_idx));
+        }
 
         bo.sync(XCL_BO_SYNC_BO_TO_DEVICE);
         global_args.push_back(bo);


### PR DESCRIPTION
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1235726 Throughput test failed with gemm test using dpu w/ xdna
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Discovered while trying to enable gemm test on xdna
#### How problem was solved, alternative solutions (if any) and why they were rejected
Initialized Instruct BO to zeros for the no-op tests (NPULatency and NPUThroughput).
#### Risks (if any) associated the changes in the commit
N/A
#### What has been tested and how, request additional testing if necessary
Tested on STX xdna and MCDM. All tests run correctly as desired.
#### Documentation impact (if any)
N/A