### PR TITLE
[XDP] Enable PL and HAL trace plugins for VEK385

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/CMakeLists.txt
+++ b/src/runtime_src/xdp/profile/plugin/CMakeLists.txt
@@ -12,6 +12,9 @@ if (XDP_VE2_BUILD_CMAKE STREQUAL "yes")
   add_subdirectory(native)
   add_subdirectory(user)
   add_subdirectory(device_offload/hal)
+  add_subdirectory(device_offload/opencl)
+  add_subdirectory(hal)
+
 
 elseif (XDP_CLIENT_BUILD_CMAKE STREQUAL "yes")
 

--- a/src/runtime_src/xdp/profile/plugin/CMakeLists.txt
+++ b/src/runtime_src/xdp/profile/plugin/CMakeLists.txt
@@ -11,6 +11,7 @@ if (XDP_VE2_BUILD_CMAKE STREQUAL "yes")
   add_subdirectory(aie_halt)
   add_subdirectory(native)
   add_subdirectory(user)
+  add_subdirectory(device_offload/hal)
 
 elseif (XDP_CLIENT_BUILD_CMAKE STREQUAL "yes")
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
CR-1237400 - Enable PL Trace and HAL host trace plugins.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
New Platform Feature enablement.

#### How problem was solved, alternative solutions (if any) and why they were rejected
- Enabled plugins compilations
- V++ Linker connects to all memory banks for CMA platform like VEK385.

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
Verified Two designs on VEK385.

#### Documentation impact (if any)
