### PR TITLE
Break profile_impl and runner_impl, use interface base class

### DIFF
--- a/src/runtime_src/core/common/runner/profile.md
+++ b/src/runtime_src/core/common/runner/profile.md
@@ -55,11 +55,11 @@ the buffer is initialized from the content of the file.
   ],
 ```
 
-The "bind" key specifies if the buffer should be re-bound to run
+The `bind` key specifies if the buffer should be re-bound to run
 recipe in each iteration of the recipe (more about this in the
 execution section).
 
-If no file is specified, the size of the buffer must be instead be
+If no `file` is specified, the `size` of the buffer must be instead be
 present in the binding element.  Normally the size will appear along
 with an element that specifies how the buffer should be initialized.
 For example, here the binding is initialized with 1024 bytes of random
@@ -76,7 +76,21 @@ data:
     },
 ```
 
-The initialization can be a fixed pattern as well:
+It is also possible to specify the `size` even when a `file` is provided.
+In this case the specified size take precendence over the size of the file, 
+and the buffer created and bound to the recipe will be of specified
+size.  The data copied into the buffer and the minimum of the specified size
+or the size of the file.
+
+```
+    {
+      "name": "ifm",
+      "size": 4096,
+      "bind": true
+    },
+```
+
+The initialization can be a fixed `pattern` as well:
 
 ```
       "init": {
@@ -85,7 +99,7 @@ The initialization can be a fixed pattern as well:
 ```
 
 After executon, a buffer can be validated against golden data. This is
-specifed using a "validate" element for the binding.
+specifed using a `validate` element for the binding.
 
 ```
     {
@@ -131,15 +145,15 @@ iteration and before next iteration.
 ```
 
 The iteration element specifies what should happen before after each
-iteration of the run recipe.  
+iteration of the run recipe.
 
-- "bind" indicates if buffers should be re-bound to the
+- `bind` indicates if buffers should be re-bound to the
 recipe before an iteration.
-- "init" indicates if buffer should be initialized per what is
+- `init` indicates if buffer should be initialized per what is
 specified in the binding element.
-- "wait" says that execution should wait for completion between
+- `wait` says that execution should wait for completion between
 iterations and after last iteration.
-- "validate" means buffer validation per what is specified in
+- `validate` means buffer validation per what is specified in
 the binding element.
 
 # Instatiating an xrt::runner with a profile

--- a/src/runtime_src/core/common/runner/recipe.md
+++ b/src/runtime_src/core/common/runner/recipe.md
@@ -157,11 +157,12 @@ compiler (VAIML).
 
 External buffers (input and output) are created by the framework /
 application outside of the runner and bound to the recipe during
-execution.  The runner itself does not create `xrt::bo` objects for
-external buffers, but does rely on the framework to bind these buffers
-to runner object created from the recipe.   The external buffers must
-still be listed in the resources section and specify a name that can 
-be used when execution sets kernel arguments.
+execution.  If the recipe buffer element doesn't specify a buffer size, 
+then the runner does not create `xrt::bo` objects for
+external buffers, but instead relies on the framework
+to bind these buffers to runner object created from the recipe.  The
+external buffers must still be listed in the resources section and
+specify a name that can be used when execution sets kernel arguments.
 
 ```
   "resources": {
@@ -182,16 +183,24 @@ be used when execution sets kernel arguments.
   }
 
 ``` 
+If a buffer `size` is specified as in:
+
+```
+      {
+        "name": "ofm",
+        "type": "output",
+        "size": 8196
+      }
+```
+then the runner will create an `xrt::bo` internally for the specified
+buffer, even as the buffer is specified as "output" it is treated as
+internal by the runner.  The application framework can still bind an
+external buffer the runner object created from the recipe, but doesn't
+have to.
 
 The `name` of the buffers in the resources section must be unique.
 The name is used in the `execution` section to refer to kernel or cpu
 buffer arguments.
-
-<!-- The `src` of the buffers is meant to refer to a tensor name in the
-graph, but the use of this field is TBD as it does not appear to be
-required.  The `name` itself is enough to identify the buffer, both
-within the recipe and for external frame works to bind external
-created buffers to the graph. -->
 
 #### Internal buffers
 
@@ -556,7 +565,12 @@ A unit test for the cpu library and corresponding sample run recipe
 that references the cpu library is under `test/cpulib.cpp` and
 `test/main.cpp`
 
+# Recipe json validation against schema
 
-
-
-
+A schema for the recipe json is available in
+[schema](schema/recipe.schema.json).  A recipe can be validated
+against the schema by running [schema-validator.py](test/schema-validator.py):
+```
+% python3 schema-validator.py recipe.json schema\recipe.schema.json
+JSON is valid against the schema.
+```

--- a/src/runtime_src/core/common/runner/runner.cpp
+++ b/src/runtime_src/core/common/runner/runner.cpp
@@ -1015,7 +1015,7 @@ public:
   {}
 
   recipe(xrt::device device, const std::string& recipe, const artifacts::repo* repo)
-    : recipe{std::move(device), load_json(recipe), repo}
+    : recipe(std::move(device), load_json(recipe), repo)
   {}
 
   recipe(const recipe&) = default;

--- a/src/runtime_src/core/common/runner/runner.cpp
+++ b/src/runtime_src/core/common/runner/runner.cpp
@@ -27,9 +27,9 @@
 
 #include <algorithm>
 #include <fstream>
-#include <iostream>
 #include <istream>
 #include <map>
+#include <memory>
 #include <random>
 #include <string>
 #include <string_view>
@@ -44,7 +44,7 @@
 namespace {
 
 using json = nlohmann::json;
-const json default_json;
+const json empty_json;
 
 // load_json() - Load a JSON from in-memory string or file
 static json
@@ -510,7 +510,7 @@ class recipe
       , m_hwctx{m_device, m_device.register_xclbin(xclbin)}
       , m_buffers{create_buffers(m_device, recipe.at("buffers"))}
       , m_kernels{create_kernels(m_device, m_hwctx, recipe.at("kernels"), repo)}
-      , m_cpus{create_cpus(recipe.value("cpus", default_json))} // optional
+      , m_cpus{create_cpus(recipe.value("cpus", empty_json))} // optional
     {}
 
     resources(const resources& other)
@@ -520,6 +520,12 @@ class recipe
       , m_kernels{other.m_kernels}                           // share kernels
       , m_cpus{other.m_cpus}                                 // share cpus
     {}
+
+    xrt::device
+    get_device() const
+    {
+      return m_device;
+    }
 
     xrt::hw_context
     get_xrt_hwctx() const
@@ -561,6 +567,14 @@ class recipe
   {
     class run
     {
+      // class argument - represents a execution::run argument
+      //
+      // The argument refers to a recipe resource buffer.
+      //
+      // Note, that resource buffers manage their own xrt::bo objects
+      // either created as internal xrt::bo or bound from external
+      // xrt::bo.  If an argument is copied, then the xrt::bo with the
+      // resource buffer is also be copy created.
       struct argument
       {
         resources::buffer m_buffer;
@@ -569,10 +583,10 @@ class recipe
         // if the argument is sliced or it can be null bo if the
         // argument is unbound.
         size_t m_offset;
-        size_t m_size;   // 0 indicates the entire buffer
+        size_t m_size;      // 0 indicates the entire buffer
         int m_argidx;
 
-        xrt::bo m_xrt_bo;
+        xrt::bo m_xrt_bo;   // sub-buffer if m_size > 0
 
         static xrt::bo
         create_xrt_bo(const resources::buffer& buffer, size_t offset, size_t size)
@@ -595,7 +609,22 @@ class recipe
           , m_argidx{j.at("argidx").get<int>()}
           , m_xrt_bo{create_xrt_bo(m_buffer, m_offset, m_size)}
         {
-            XRT_DEBUGF("recipe::execution::run::argument(%s, %lu, %lu, %d) bound(%s)\n",
+            XRT_DEBUGF("recipe::execution::run::argument(json) (%s, %lu, %lu, %d) bound(%s)\n",
+                     m_buffer.get_name().c_str(), m_offset, m_size, m_argidx,
+                     m_xrt_bo ? "true" : "false");
+        }
+
+        // Copy constructor.  Allocates new resources::buffer and new
+        // XRT buffer object.
+        argument(const resources& resources, const argument& other)
+          : m_buffer{resources::buffer::create_buffer           // new resources:buffer
+                     (resources.get_device(), other.m_buffer)}  // (see earlier comment)
+          , m_offset{other.m_offset}                            // same offset
+          , m_size{other.m_size}                                // same size
+          , m_argidx{other.m_argidx}                            // same argidx
+          , m_xrt_bo{create_xrt_bo(m_buffer, m_offset, m_size)} // new xrt::bo, maybe null
+        {
+            XRT_DEBUGF("recipe::execution::run::argument(other) (%s, %lu, %lu, %d) bound(%s)\n",
                      m_buffer.get_name().c_str(), m_offset, m_size, m_argidx,
                      m_xrt_bo ? "true" : "false");
         }
@@ -603,7 +632,10 @@ class recipe
         void
         bind(const xrt::bo& bo)
         {
+          // The full bo is bound to the resource buffer.
           m_buffer.bind(bo);
+          // The argument specific bo may be a sub-buffer per
+          // specified offset and size
           m_xrt_bo = create_xrt_bo(m_buffer, m_offset, m_size);
         }
 
@@ -648,6 +680,21 @@ class recipe
             std::visit(set_arg_visitor{arg.m_argidx, std::move(bo)}, run);
 
           args.emplace(node.at("name").get<std::string>(), std::move(arg));
+        }
+        return args;
+      }
+
+      static std::map<std::string, argument>
+      create_and_set_args(const resources& resources, run_type run,
+                          const std::map<std::string, argument>& other_args)
+      {
+        std::map<std::string, argument> args;
+        for (const auto& [name, other_arg] : other_args) {
+          argument arg{resources, other_arg};
+          if (auto bo = arg.get_xrt_bo())
+            std::visit(set_arg_visitor{arg.m_argidx, std::move(bo)}, run);
+
+          args.emplace(name, std::move(arg));
         }
         return args;
       }
@@ -709,12 +756,15 @@ class recipe
           set_constant_args(m_run, j.at("constants"));
       }
 
-      // Create a run from another run but using argument resources
+      // Create a run from another run using argument resources
       // The ctor creates a new xrt::run or cpu::run from other, these
-      // runs refer to resources per argument resources
+      // runs refer to resources per argument resources.  Arguments
+      // to the runs are copied, so this run along with the argument
+      // other run are independent in regards to argument data.
       run(const resources& resources, const run& other)
         : m_name{other.m_name}
         , m_run{create_run(resources, other)}
+        , m_args{create_and_set_args(resources, m_run, other.m_args)}
       {}
 
       bool
@@ -950,18 +1000,22 @@ class recipe
 
   xrt::device m_device;
 
-  json m_recipe;
+  json m_recipe_json;
   header m_header;
   resources m_resources;
   execution m_execution;
 
 public:
-  recipe(xrt::device device, const std::string& recipe, const artifacts::repo* repo)
+  recipe(xrt::device device, json recipe, const artifacts::repo* repo)
     : m_device{std::move(device)}
-    , m_recipe{load_json(recipe)}
-    , m_header{m_recipe.at("header"), repo}
-    , m_resources{m_device, m_header.get_xclbin(), m_recipe.at("resources"), repo}
-    , m_execution{m_resources, m_recipe.at("execution")}
+    , m_recipe_json(std::move(recipe)) // paren required, else initialized as array
+    , m_header{m_recipe_json.at("header"), repo}
+    , m_resources{m_device, m_header.get_xclbin(), m_recipe_json.at("resources"), repo}
+    , m_execution{m_resources, m_recipe_json.at("execution")}
+  {}
+
+  recipe(xrt::device device, const std::string& recipe, const artifacts::repo* repo)
+    : recipe{std::move(device), load_json(recipe), repo}
   {}
 
   recipe(const recipe&) = default;
@@ -1195,11 +1249,11 @@ class profile
 
     // Bind resources to the recipe per json
     void
-    bind(recipe* rr)
+    bind(recipe& rr)
     {
       for (auto& [name, node] : m_bindings) {
         if (node.value<bool>("bind", false))
-          rr->bind(name, m_xrt_bos.at(name));
+          rr.bind(name, m_xrt_bos.at(name));
       }
     }
   }; // class profile::bindings
@@ -1283,9 +1337,10 @@ class profile
 private:
   friend class bindings;  // embedded class
   friend class execution; // embedded class
-  json m_profile;
+  json m_profile_json;
   std::shared_ptr<artifacts::repo> m_repo;
-  recipe* m_recipe = nullptr;
+
+  recipe m_recipe;
   bindings m_bindings;
   execution m_execution;
 
@@ -1310,15 +1365,14 @@ private:
   void
   execute_recipe()
   {
-    m_recipe->execute();
+    m_recipe.execute();
   }
 
   void
   wait_recipe()
   {
-    m_recipe->wait();
+    m_recipe.wait();
   }
-  
 
 public:
   // profile - constructor
@@ -1326,14 +1380,22 @@ public:
   // Reads json, creates xrt::bo bindings to recipe and initializes
   // execution. The respository is used for looking up artifacts.
   // The recipe is what the profile binds to and what it executes.
-  profile(const xrt::device& device, recipe* rr, const std::string& profile,
+  profile(const xrt::device& device,
+          const std::string& recipe,
+          const std::string& profile,
           std::shared_ptr<artifacts::repo> repo)
-    : m_profile{load_json(profile)}
+    : m_profile_json{load_json(profile)}
     , m_repo{std::move(repo)}
-    , m_recipe{rr}
-    , m_bindings{device, m_profile.at("bindings"), m_repo.get()}
-    , m_execution(this, m_profile.at("execution"))
+    , m_recipe{device, load_json(recipe), m_repo.get()}
+    , m_bindings{device, m_profile_json.at("bindings"), m_repo.get()}
+    , m_execution(this, m_profile_json.at("execution"))
   {}
+
+  void
+  bind(const std::string& name, const xrt::bo& bo)
+  {
+    m_recipe.bind(name, bo);
+  }
 
   void
   execute()
@@ -1353,65 +1415,76 @@ public:
 
 namespace xrt_core {
 
-// class runner_impl - Insulated implementation of xrt::runner
-//
-// Manages a run recipe and an execution profile.
-//
-// The recipe defines the resources and how to run a model.
-//
-// The profile controls how resources are bound to the recipe and how
-// the recipe is executed, e.g. number of times, debug info,
-// validation, etc.
+// class runner_impl - Base class API for implementations of
+// xrt::runner
 class runner_impl
+{
+public:
+  virtual ~runner_impl() = default;
+
+  void
+  bind_input(const std::string& name, const xrt::bo& bo)
+  {
+    bind(name, bo);
+  }
+
+  void
+  bind_output(const std::string& name, const xrt::bo& bo)
+  {
+    bind(name, bo);
+  }
+
+  virtual void
+  bind(const std::string& name, const xrt::bo& bo) = 0;
+
+  virtual void
+  execute() = 0;
+
+  virtual void
+  wait() = 0;
+};
+
+// class recipe_impl - Insulated implementation of xrt::runner
+//
+// Manages a run recipe.
+//
+// The recipe defines resources and how to run a model.
+class recipe_impl : public runner_impl
 {
   recipe m_recipe;
 
-protected:
-  recipe*
-  get_recipe()
-  {
-    return &m_recipe;
-  }
-
 public:
-  runner_impl(const xrt::device& device, const std::string& recipe,
+  recipe_impl(const xrt::device& device, const std::string& recipe,
               const std::shared_ptr<artifacts::repo>& repo)
     : m_recipe{device, recipe, repo.get()}
   {}
 
-  virtual ~runner_impl() = default;
-
-  virtual void
-  bind_input(const std::string& name, const xrt::bo& bo)
+  void
+  bind(const std::string& name, const xrt::bo& bo) override
   {
     m_recipe.bind(name, bo);
   }
 
-  virtual void
-  bind_output(const std::string& name, const xrt::bo& bo)
-  {
-    m_recipe.bind(name, bo);
-  }
-
-  virtual void
-  bind(const std::string& name, const xrt::bo& bo)
-  {
-    m_recipe.bind(name, bo);
-  }
-
-  virtual void
-  execute()
+  void
+  execute() override
   {
     m_recipe.execute();
   }
 
-  virtual void
-  wait()
+  void
+  wait() override
   {
     m_recipe.wait();
   }
 }; // class runner_impl
 
+// class profile_impl - Insulated implementaton of xrt::runner
+//
+// Manages a profile for how to run a recipe.
+//
+// The profile controls how resources are bound to a recipe and how
+// the recipe is executed, e.g. number of times, debug info,
+// validation, etc.
 class profile_impl : public runner_impl
 {
   profile m_profile;
@@ -1420,9 +1493,14 @@ public:
   profile_impl(const xrt::device& device,
                const std::string& recipe, const std::string& profile,
                const std::shared_ptr<artifacts::repo>& repo)
-    : runner_impl{device, recipe, repo}
-    , m_profile{device, get_recipe(), profile, repo}
+    : m_profile{device, recipe, profile, repo}
   {}
+
+  void
+  bind(const std::string& name, const xrt::bo& bo) override
+  {
+    m_profile.bind(name, bo);
+  }
 
   void
   execute() override
@@ -1443,7 +1521,7 @@ public:
 runner::
 runner(const xrt::device& device,
        const std::string& recipe)
-  : m_impl{std::make_unique<runner_impl>
+  : m_impl{std::make_unique<recipe_impl>
            (device, recipe, std::make_shared<artifacts::file_repo>())}
 {} 
   
@@ -1451,7 +1529,7 @@ runner::
 runner(const xrt::device& device,
        const std::string& recipe,
        const std::filesystem::path& dir)
-  : m_impl{std::make_unique<runner_impl>
+  : m_impl{std::make_unique<recipe_impl>
            (device, recipe, std::make_shared<artifacts::file_repo>(dir))}
 {} 
 
@@ -1459,7 +1537,7 @@ runner::
 runner(const xrt::device& device,
        const std::string& recipe,
        const artifacts_repository& repo)
-  : m_impl{std::make_unique<runner_impl>
+  : m_impl{std::make_unique<recipe_impl>
            (device, recipe, std::make_shared<artifacts::ram_repo>(repo))}
 {}
 

--- a/src/runtime_src/core/common/runner/runner.cpp
+++ b/src/runtime_src/core/common/runner/runner.cpp
@@ -1014,8 +1014,8 @@ public:
     , m_execution{m_resources, m_recipe_json.at("execution")}
   {}
 
-  recipe(xrt::device device, const std::string& recipe, const artifacts::repo* repo)
-    : recipe(std::move(device), load_json(recipe), repo)
+  recipe(xrt::device device, const std::string& rr, const artifacts::repo* repo)
+    : recipe(std::move(device), load_json(rr), repo)
   {}
 
   recipe(const recipe&) = default;

--- a/src/runtime_src/core/common/runner/runner.cpp
+++ b/src/runtime_src/core/common/runner/runner.cpp
@@ -975,6 +975,12 @@ class recipe
         }
       };
 
+      // If single runlist then avoid the overhead of xrt::queue
+      if (m_runlists.size() == 1) {
+        m_runlists[0]->execute();
+        return;
+      }
+
       // A recipe can have multiple runlists. Each runlist can have
       // multiple runs.  Runlists are executed sequentially, execution
       // is orchestrated by xrt::queue which uses one thread to
@@ -987,6 +993,14 @@ class recipe
     wait()
     {
       XRT_DEBUGF("recipe::execution::wait()\n");
+
+      // If single runlist then it was submitted explicitly, so
+      // wait explicitly
+      if (m_runlists.size() == 1) {
+        m_runlists[0]->wait();
+        return;
+      }
+
       // Sufficient to wait for last runlist to finish since last list
       // must have waited for all previous lists to finish.
       auto runlist = m_runlists.back().get();

--- a/src/runtime_src/core/common/runner/schema/recipe.schema.json
+++ b/src/runtime_src/core/common/runner/schema/recipe.schema.json
@@ -148,7 +148,7 @@
                 "items": {
                   "type": "object",
                   "properties": {
-                    "value": { "type": ["string", "integer" },
+                    "value": { "type": ["string", "integer"] },
                     "type": { "enum": ["int", "string"] },
                     "argidx": { "$ref": "#/$defs/argidx" }
                   }


### PR DESCRIPTION
#### Problem solved by the commit
Break inheritance of profile_impl from runner_impl, which caused strange depdendencies.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Keep runner_impl as an interface base class, derive recipe_impl and profile_impl. Class recipe_impl manages a `recipe` and class profile_impl manages a `profile`, which in turn is tied to a recipe.
