### PR TITLE
Add changes for missing symbol in windows dll

### DIFF
--- a/src/runtime_src/core/include/xrt/xrt_kernel.h
+++ b/src/runtime_src/core/include/xrt/xrt_kernel.h
@@ -626,6 +626,7 @@ public:
    * Throws if control scratchpad section is not absent in ELF or
    * if any error occurs while retrieving the bo
    */
+  XCL_DRIVER_DLLESPEC
   xrt::bo
   get_ctrl_scratchpad_bo() const;
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Added missing dllexport to get_ctrl_scratchpad_bo function of xrt::run

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
#### How problem was solved, alternative solutions (if any) and why they were rejected
Marked the function with XCL_DRIVER_DLLESPEC

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
Tested the dll generated and intended symbol is found after adding the changes

#### Documentation impact (if any)
NA