### PR TITLE
Support strided initialization of a buffer

### DIFF
--- a/src/runtime_src/core/common/runner/profile.md
+++ b/src/runtime_src/core/common/runner/profile.md
@@ -90,11 +90,28 @@ or the size of the file.
     },
 ```
 
-The initialization can be a fixed `pattern` as well:
+As shown above, the initialization can be `random`, but a buffer can
+also be initialized with a fixed pattern at every `stride` byte.  This 
+is referred to as strided buffer initialization:
 
 ```
       "init": {
-        "pattern": "A"
+        "stride": 1,
+        "value": 239,
+        "begin": 0,
+        "end": 524288
+      }
+```
+Here the buffer range specified by `begin` and `end` is written with
+the byte value `239` at every byte (`stride` is 1). The value can be
+any uint64_t value, but must be a decimal value in order to be valid 
+json.  To initalize a buffer with with 0xdeadbeef, convert to decimal 
+and write:
+
+```
+      "init": {
+        "stride": 4,
+        "value": 3735928559
       }
 ```
 

--- a/src/runtime_src/core/common/runner/runner.cpp
+++ b/src/runtime_src/core/common/runner/runner.cpp
@@ -4,6 +4,13 @@
 #define XRT_CORE_COMMON_SOURCE // in same dll as coreutil
 #define XRT_API_SOURCE         // in same dll as coreutil
 
+// AIESW-2326 The runner currently disables the use of xrt::runlist
+// #define USE_XRT_RUNLIST
+
+// If runlist contains more than XRT_RUNLIST_THRESHOLD runs then
+// switch to xrt::runlist
+#define XRT_RUNLIST_THRESHOLD 6
+
 #define XRT_VERBOSE
 #include "runner.h"
 #include "cpu.h"
@@ -64,6 +71,62 @@ load_json(const std::string& input)
 
   throw std::runtime_error("Failed to open JSON file: " + input);
 }
+
+// Lifted from xrt_kernel.cpp
+// Helper for converting an arbitrary sequence of bytes into
+// a range that be iterated byte-by-byte (or by ValueType)
+// Used during profile initialziation of a buffer.
+template <typename ValueType>
+class arg_range
+{
+  const ValueType* uval;
+  size_t words;
+
+  // Number of bytes must multiple of sizeof(ValueType)
+  size_t
+  validate_bytes(size_t bytes)
+  {
+    if (bytes % sizeof(ValueType))
+      throw std::runtime_error("arg_range unaligned bytes");
+    return bytes;
+  }
+
+public:
+  arg_range(const void* value, size_t bytes)
+    : uval(reinterpret_cast<const ValueType*>(value))
+    , words(validate_bytes(bytes) / sizeof(ValueType))
+  {}
+
+  const ValueType*
+  begin() const
+  {
+    return uval;
+  }
+
+  const ValueType*
+  end() const
+  {
+    return uval + words;
+  }
+
+  size_t
+  size() const
+  {
+    return words;
+  }
+
+  size_t
+  bytes() const
+  {
+    return words * sizeof(ValueType);
+  }
+
+  const ValueType*
+  data() const
+  {
+    return uval;
+  }
+};
 
 // struct streambuf - wrap a std::streambuf around an external buffer
 //
@@ -837,6 +900,7 @@ class recipe
     struct runlist
     {
       virtual ~runlist() = default;
+      virtual void add(const run& run) = 0;
       virtual void execute() = 0;
       virtual void wait() {}
     };
@@ -844,6 +908,12 @@ class recipe
     struct cpu_runlist : runlist
     {
       std::vector<xrt_core::cpu::run> m_runs;
+
+      void
+      add(const run& run) override
+      {
+        m_runs.push_back(run.get_cpu_run());
+      }
       
       void
       execute() override
@@ -853,6 +923,7 @@ class recipe
       }
     };
 
+#ifdef USE_XRT_RUNLIST
     struct npu_runlist : runlist
     {
       xrt::runlist m_runlist;
@@ -860,6 +931,12 @@ class recipe
       explicit npu_runlist(const xrt::hw_context& hwctx)
         : m_runlist{hwctx}
       {}
+
+      void
+      add(const run& run) override
+      {
+        m_runlist.add(run.get_xrt_run());
+      }
 
       void
       execute() override
@@ -873,7 +950,37 @@ class recipe
         m_runlist.wait();
       }
     };
+#else
+    struct npu_runlist : runlist
+    {
+      std::vector<xrt::run> m_runlist;
 
+      explicit npu_runlist(const xrt::hw_context&)
+      {}
+
+      void
+      add(const run& run) override
+      {
+        m_runlist.push_back(run.get_xrt_run());
+      }
+
+      void
+      execute() override
+      {
+        for (auto& run : m_runlist)
+          run.start();
+      }
+
+      void
+      wait() override
+      {
+        // While waiting for last to complete is enough, all runs
+        // must be marked completed
+        for (auto itr = m_runlist.rbegin(); itr != m_runlist.rend(); ++itr)
+          (*itr).wait2();
+      }
+    };
+#endif
 
     std::vector<run> m_runs;
     xrt::queue m_queue;        // Queue that executes the runlists in sequence
@@ -904,7 +1011,7 @@ class recipe
             runlists.push_back(std::move(rl));
           }
 
-          nrl->m_runlist.add(run.get_xrt_run());
+          nrl->add(run);
         }
         else if (run.is_cpu_run()) {
           if (nrl) 
@@ -916,7 +1023,7 @@ class recipe
             runlists.push_back(std::move(rl));
           }
 
-          crl->m_runs.push_back(run.get_cpu_run());
+          crl->add(run);
         }
       }
       return runlists;
@@ -1225,24 +1332,59 @@ class profile
       }
     }
 
-    // Initialize a resource buffer per the binding json node
+    // init_buffer_stride() - Initialize bo with value at stride
+    // "init": {
+    //   "stride": 1,   // write the value repeatedly at this stride
+    //   "value": 239,  // the value to write
+    //   "begin": 0,    // offset to start writing at
+    //   "end": 524288, // offset to end writing at
+    //   "debug": true  // undefined 
+    // }
+    static void
+    init_buffer_stride(xrt::bo& bo, const init_node& node)
+    {
+      auto bo_data = bo.map<uint8_t*>();
+      auto stride = node.at("stride").get<size_t>();
+      auto value = node.at("value").get<uint64_t>();
+      auto begin = node.value("begin", 0);
+      auto end = node.value("end", bo.size());
+      arg_range<uint8_t> vr{&value, sizeof(value)};
+      for (size_t offset = begin; offset < end; offset += stride) 
+        std::copy_n(vr.begin(), std::min<size_t>(bo.size() - offset, vr.size()), bo_data + offset);
+    }
+
+    static void
+    init_buffer_random(xrt::bo& bo, const init_node&)
+    {
+      auto bo_data = bo.map<uint8_t*>();
+      static std::random_device rd;
+      std::generate(bo_data, bo_data + bo.size(), [&]() { return static_cast<uint8_t>(rd()); });
+    }
+
+    // init_buffer() - Initialize a resource buffer per the binding json node
+    // "init": {
+    //   // "stride" stride initialization
+    //   // "random" random initialization
+    // }
+    // The buffer is synced to device after iniitialization
     static void
     init_buffer(xrt::bo& bo, const init_node& node)
     {
       // Fill the resource buffer with data
       auto bo_data = bo.map<uint8_t*>();
 
-      if (node.value<bool>("random", false)) {
-        static std::random_device rd;
-        std::generate(bo_data, bo_data + bo.size(), [&]() { return static_cast<uint8_t>(rd()); });
-      }
-      else {
-        // Get the pattern, which must be one character
-        auto pattern = node.at("pattern").get<std::string>();
-        if (pattern.size() != 1)
-          throw std::runtime_error("pattern size must be 1");
-      
-        std::fill(bo_data, bo_data + bo.size(), pattern[0]);
+      // stride initialization with specified value
+      if (node.contains("stride"))
+        init_buffer_stride(bo, node);
+      else if (node.value<bool>("random", false))
+        init_buffer_random(bo, node);
+      else
+        throw std::runtime_error("Unsupported initialziation node in profile");
+
+      if (node.value<bool>("debug", false)) {
+        static uint64_t count = 0;
+        std::ofstream ostrm("profile.debug.init[" + std::to_string(count++) + "].bin", std::ios::binary);
+        ostrm.write(reinterpret_cast<char*>(bo_data), bo.size());
       }
 
       bo.sync(XCL_BO_SYNC_BO_TO_DEVICE);


### PR DESCRIPTION
#### Problem solved by the commit
Extend profile json to support strided buffer initialization.

#### How problem was solved, alternative solutions (if any) and why they were rejected

```
      "init": {
        "stride": 1,
        "value": 239,
        "begin": 0,
        "end": 524288
      }
```
Here the buffer range specified by `begin` and `end` is written with the byte value `239` at every byte (`stride` is 1). The value can be any uint64_t value, but must be a decimal value in order to be valid json.  To initalize a buffer with with 0xdeadbeef, convert to decimal and write:

```
      "init": {
        "stride": 4,
        "value": 3735928559
      }
```
