### PR TITLE
Notify shim when an execbo is recycled

### DIFF
--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -721,6 +721,11 @@ public:
   ~kernel_command() override
   {
     XRT_DEBUGF("kernel_command::~kernel_command(%d)\n", m_uid);
+
+    // Notify shim that any BOs bound to this kernel command are no
+    // longer used by the command.
+    get_exec_bo()->reset();
+    
     // This is problematic, bo_cache should return managed BOs
     m_device->exec_buffer_cache.release(std::move(m_execbuf));
   }

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -924,7 +924,7 @@ public:
   }
 
   xrt_core::buffer_handle*
-  get_exec_bo() const override
+  get_exec_bo() const final
   {
     return m_execbuf.first.get();
   }

--- a/src/runtime_src/core/common/shim/buffer_handle.h
+++ b/src/runtime_src/core/common/shim/buffer_handle.h
@@ -83,14 +83,20 @@ public:
     return XRT_NULL_BO;
   }
 
-  // Indicates to SHIM/driver that bh is going to be used by this BO. With
-  // offset and zie, it can also support using portion of bh (sub-BO).
-  // For now, this is only used when set_arg() is called upon an exec buf
-  // BO where pos is the arg index.
+  // Indicates to SHIM/driver that bh is going to be used by this
+  // BO. With offset and size, it can also support using portion of bh
+  // (sub-BO).  For now, this is only used when set_arg() is called
+  // upon an exec buf BO where pos is the arg index.
   virtual void
   bind_at(size_t /*pos*/, const buffer_handle* /*bh*/, size_t /*offset*/, size_t /*size*/)
-  {
-  }
+  {}
+
+  // Reverse of bind_at, this function indiciates to shim that the execbo
+  // (on which the function is called) is no longer using the BOs that were
+  // bound to it.
+  virtual void
+  reset()
+  {}
 
   virtual void
   sync_aie_bo(xrt::bo&, const char *, bo_direction, size_t, size_t)


### PR DESCRIPTION
#### Problem solved by the commit
Add xrt_core::buffer_handle::reset() callback so that shim can be notified when an execbo is recycled.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Exec BOs are cached in XRT coreutil and reused when creating new xrt::run objects.  When `xrt::run::set_arg(idx, bo)` is called, shim is notified through `xrt::buffer_handle::bind()` that the command (execbo) associated with the run is using the `bo`.  Shim is unaware of execbo reuse and may keep stale BO bindings if a BO is kept alive for use with some other command.

#### How problem was solved, alternative solutions (if any) and why they were rejected
This commit essentially adds the reverse of `bind()`, letting shim know that even as the execbo is not destroyed through shim (it is recycled for later use), the BOs bound to the execbo are no longer in use by this execbo.

