### PR TITLE
[XDP] Support for X+ML Flow in trace plugin for all the flows

### DIFF
--- a/src/runtime_src/core/edge/user/plugin/xdp/aie_trace.h
+++ b/src/runtime_src/core/edge/user/plugin/xdp/aie_trace.h
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2020 Xilinx, Inc
+ * Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -17,9 +18,8 @@
 #ifndef XDP_AIE_TRACE_H
 #define XDP_AIE_TRACE_H
 
-namespace xdp {
-namespace aie {
-  void update_device(void* handle);
+namespace xdp::aie {
+  void update_device(void* handle, bool hw_context_flow);
   void flush_device(void* handle);
   void finish_flush_device(void* handle);
 
@@ -30,8 +30,7 @@ namespace trace {
   int  error_function();
 
 } // end namespace trace
-} // end namespace aie
-} // end namespace xdp
+} // end namespace xdp::aie
 
 #endif
 

--- a/src/runtime_src/core/edge/user/plugin/xdp/shim_callbacks.h
+++ b/src/runtime_src/core/edge/user/plugin/xdp/shim_callbacks.h
@@ -47,7 +47,7 @@ void update_device(void* handle, bool hw_context_flow)
 {
 #ifndef __HWEM__
   hal::update_device(handle); //PL device offload
-  aie::update_device(handle); //trace
+  aie::update_device(handle, hw_context_flow); //trace
   //aie::dbg::update_device(handle); //debug
 #else
   hal::hw_emu::update_device(handle); //PL device offload

--- a/src/runtime_src/core/pcie/linux/plugin/xdp/aie_trace.cpp
+++ b/src/runtime_src/core/pcie/linux/plugin/xdp/aie_trace.cpp
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2020 Xilinx, Inc
+ * Copyright (C) 2025 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -20,8 +21,7 @@
 #include "core/common/dlfcn.h"
 #include "core/common/config_reader.h"
 
-namespace xdp {
-namespace aie {
+namespace xdp::aie {
 namespace trace {
 
   void load()
@@ -32,24 +32,21 @@ namespace trace {
                                                         error_function);
   }
 
-  std::function<void (void*)> update_device_cb;
+  std::function<void (void*, bool)> update_device_cb;
   std::function<void (void*)> flush_device_cb;
   std::function<void (void*)> finish_flush_device_cb;
 
   void register_callbacks(void* handle)
   {
-    typedef void (*ftype)(void*) ;
-    update_device_cb = (ftype)(xrt_core::dlsym(handle, "updateAIEDevice")) ;
-    if (xrt_core::dlerror() != NULL) 
-      update_device_cb = nullptr ;
+    using utype = void (*)(void*, bool);
+    using ftype = void (*)(void*);
 
-    flush_device_cb = (ftype)(xrt_core::dlsym(handle, "flushAIEDevice")) ;
-    if (xrt_core::dlerror() != NULL) 
-      flush_device_cb = nullptr ;
-
-    finish_flush_device_cb = (ftype)(xrt_core::dlsym(handle, "finishFlushAIEDevice")) ;
-    if (xrt_core::dlerror() != NULL) 
-      finish_flush_device_cb = nullptr ;
+    update_device_cb =
+       reinterpret_cast<utype>(xrt_core::dlsym(handle, "updateAIEDevice"));
+    flush_device_cb =
+      reinterpret_cast<ftype>(xrt_core::dlsym(handle, "flushAIEDevice"));
+    finish_flush_device_cb =
+      reinterpret_cast<ftype>(xrt_core::dlsym(handle, "finishFlushAIEDevice"));
   }
 
   void warning_function()
@@ -63,10 +60,10 @@ namespace trace {
 
 } // end namespace trace
 
-  void update_device(void* handle)
+  void update_device(void* handle, bool hw_context_flow)
   {
     if (trace::update_device_cb != nullptr) {
-      trace::update_device_cb(handle) ;
+      trace::update_device_cb(handle, hw_context_flow) ;
     }
   }
 
@@ -83,6 +80,5 @@ namespace trace {
       trace::finish_flush_device_cb(handle) ;
     }
   }
-  
-} // end namespace aie
-} // end namespace xdp
+
+} // end namespace xdp::aie

--- a/src/runtime_src/core/pcie/linux/plugin/xdp/aie_trace.h
+++ b/src/runtime_src/core/pcie/linux/plugin/xdp/aie_trace.h
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2020 Xilinx, Inc
+ * Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -17,9 +18,8 @@
 #ifndef XDP_AIE_TRACE_H
 #define XDP_AIE_TRACE_H
 
-namespace xdp {
-namespace aie {
-  void update_device(void* handle);
+namespace xdp::aie {
+  void update_device(void* handle, bool hw_context_flow);
   void flush_device(void* handle);
   void finish_flush_device(void* handle);
 
@@ -30,8 +30,7 @@ namespace trace {
   int  error_function();
 
 } // end namespace trace
-} // end namespace aie
-} // end namespace xdp
+} // end namespace xdp::aie
 
 #endif
 

--- a/src/runtime_src/core/pcie/linux/plugin/xdp/shim_callbacks.h
+++ b/src/runtime_src/core/pcie/linux/plugin/xdp/shim_callbacks.h
@@ -38,7 +38,7 @@ inline
 void update_device(void* handle, bool hw_context_flow)
 {
   hal::update_device(handle);
-  aie::update_device(handle);
+  aie::update_device(handle, hw_context_flow); //trace
   aie::ctr::update_device(handle, hw_context_flow); //profile
 }
 

--- a/src/runtime_src/xdp/profile/database/static_info_database.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info_database.cpp
@@ -1517,8 +1517,10 @@ namespace xdp {
   {
     xrt::uuid new_xclbin_uuid;
     //TODO:: Getting xclbin_uuid should be unified for both Client and Telluride.
+    bool isClientBuild = false;
     if(isClient()) {
       new_xclbin_uuid = device->get_xclbin_uuid();
+      isClientBuild = true;
     }
     else {
       std::vector<xrt_core::query::xclbin_slots::slot_info> xclbin_slot_info;
@@ -1542,7 +1544,7 @@ namespace xdp {
     if (!resetDeviceInfo(deviceId, xdpDevice.get(), new_xclbin_uuid))
       return;
     xrt::xclbin xrtXclbin = device->get_xclbin(new_xclbin_uuid);
-    updateDevice(deviceId, xrtXclbin, std::move(xdpDevice), true, readAIEMetadata);
+    updateDevice(deviceId, xrtXclbin, std::move(xdpDevice), isClientBuild, readAIEMetadata);
   }
 
   // Return true if we should reset the device information.

--- a/src/runtime_src/xdp/profile/database/static_info_database.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info_database.cpp
@@ -1516,11 +1516,9 @@ namespace xdp {
                              std::unique_ptr<xdp::Device> xdpDevice)
   {
     xrt::uuid new_xclbin_uuid;
-    //TODO:: Getting xclbin_uuid should be unified for both Client and Telluride.
-    bool isClientBuild = false;
+    //TODO:: Getting xclbin_uuid should be unified for both Client and VE2.
     if(isClient()) {
       new_xclbin_uuid = device->get_xclbin_uuid();
-      isClientBuild = true;
     }
     else {
       std::vector<xrt_core::query::xclbin_slots::slot_info> xclbin_slot_info;
@@ -1544,7 +1542,7 @@ namespace xdp {
     if (!resetDeviceInfo(deviceId, xdpDevice.get(), new_xclbin_uuid))
       return;
     xrt::xclbin xrtXclbin = device->get_xclbin(new_xclbin_uuid);
-    updateDevice(deviceId, xrtXclbin, std::move(xdpDevice), isClientBuild, readAIEMetadata);
+    updateDevice(deviceId, xrtXclbin, std::move(xdpDevice), isClient(), readAIEMetadata);
   }
 
   // Return true if we should reset the device information.

--- a/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.cpp
@@ -132,7 +132,7 @@ namespace xdp {
 #ifdef XDP_VE2_BUILD
     boost::property_tree::ptree aiePartitionPt = xdp::aie::getAIEPartitionInfo(handle);
     uint8_t startColShift = static_cast<uint8_t>(aiePartitionPt.front().second.get<uint64_t>("start_col"));
-#elif
+#else
    uint8_t startColShift = metadataReader->getPartitionOverlayStartCols().front();
    aie::displayColShiftInfo(startColShift);
 #endif

--- a/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.cpp
@@ -129,13 +129,8 @@ namespace xdp {
 
    // NOTE: AIE Status is not released product on client. Whenever client support is needed,
    // required dynamic column start shift should come from XRT and not compiler metadata
-#ifdef XDP_VE2_BUILD
-    boost::property_tree::ptree aiePartitionPt = xdp::aie::getAIEPartitionInfo(handle);
-    uint8_t startColShift = static_cast<uint8_t>(aiePartitionPt.front().second.get<uint64_t>("start_col"));
-#else
    uint8_t startColShift = metadataReader->getPartitionOverlayStartCols().front();
    aie::displayColShiftInfo(startColShift);
-#endif
 
    if (startColShift > 0) {
     for(auto& [graph, tileVec] : mGraphCoreTilesMap) {

--- a/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.cpp
@@ -230,7 +230,7 @@ namespace xdp {
     // AIE core register offsets
 #ifdef XDP_VE2_BUILD
     constexpr uint64_t AIE_OFFSET_CORE_STATUS = 0x38004;
-#elif
+#else
     constexpr uint64_t AIE_OFFSET_CORE_STATUS = 0x32004;
 #endif
 

--- a/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.cpp
@@ -118,7 +118,7 @@ namespace xdp {
   /****************************************************************************
    * Gather list of tiles to check status
    ***************************************************************************/
-  void AIEStatusPlugin::getTilesForStatus()
+  void AIEStatusPlugin::getTilesForStatus(void* handle)
   {
     // Capture all tiles across all graphs
     // Note: in the future, we could support user-defined tile sets
@@ -129,8 +129,13 @@ namespace xdp {
 
    // NOTE: AIE Status is not released product on client. Whenever client support is needed,
    // required dynamic column start shift should come from XRT and not compiler metadata
+#ifdef XDP_VE2_BUILD
+    boost::property_tree::ptree aiePartitionPt = xdp::aie::getAIEPartitionInfo(handle);
+    uint8_t startColShift = static_cast<uint8_t>(aiePartitionPt.front().second.get<uint64_t>("start_col"));
+#elif
    uint8_t startColShift = metadataReader->getPartitionOverlayStartCols().front();
    aie::displayColShiftInfo(startColShift);
+#endif
 
    if (startColShift > 0) {
     for(auto& [graph, tileVec] : mGraphCoreTilesMap) {
@@ -223,7 +228,12 @@ namespace xdp {
       return;
 
     // AIE core register offsets
+#ifdef XDP_VE2_BUILD
+    constexpr uint64_t AIE_OFFSET_CORE_STATUS = 0x38004;
+#elif
     constexpr uint64_t AIE_OFFSET_CORE_STATUS = 0x32004;
+#endif
+
     auto offset = metadataReader->getAIETileRowOffset();
     auto hwGen = metadataReader->getHardwareGeneration();
 
@@ -462,7 +472,7 @@ namespace xdp {
     auto hwGen =  metadataReader->getHardwareGeneration();
 
     // Update list of tiles to debug
-    getTilesForStatus();
+    getTilesForStatus(handle);
 
     // Open the writer for this device
     #ifdef XDP_VE2_BUILD

--- a/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.h
@@ -51,7 +51,7 @@ namespace xdp {
     static bool alive();
 
   private:
-    void getTilesForStatus();
+    void getTilesForStatus(void* handle);
     void endPoll();
     std::string getCoreStatusString(uint32_t status);
     

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_cb.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_cb.cpp
@@ -26,10 +26,10 @@ namespace xdp {
 
   static AieTracePluginUnified aieTracePluginInstance;
 
-  static void updateAIEDevice(void* handle)
+  static void updateAIEDevice(void* handle, bool hw_context_flow)
   {
     if (AieTracePluginUnified::alive())
-      aieTracePluginInstance.updateAIEDevice(handle);
+      aieTracePluginInstance.updateAIEDevice(handle, hw_context_flow);
   }
 
   static void flushAIEDevice(void* handle)
@@ -47,9 +47,9 @@ namespace xdp {
 } // end namespace xdp
 
 extern "C" 
-void updateAIEDevice(void* handle)
+void updateAIEDevice(void* handle, bool hw_context_flow)
 {
-  xdp::updateAIEDevice(handle);
+  xdp::updateAIEDevice(handle, hw_context_flow);
 }
 
 extern "C" 

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_cb.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_cb.h
@@ -21,7 +21,7 @@
 
 extern "C" {
 
-  XDP_PLUGIN_EXPORT void updateAIEDevice(void* handle);
+  XDP_PLUGIN_EXPORT void updateAIEDevice(void* handle, bool hw_context_flow);
   XDP_PLUGIN_EXPORT void flushAIEDevice(void* handle);
   XDP_PLUGIN_EXPORT void finishFlushAIEDevice(void* handle);
 

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -100,20 +100,14 @@ uint64_t AieTracePluginUnified::getDeviceIDFromHandle(void *handle) {
 #endif
 }
 
-void AieTracePluginUnified::updateAIEDevice(void *handle) {
+void AieTracePluginUnified::updateAIEDevice(void *handle, bool hw_context_flow) {
   xrt_core::message::send(severity_level::info, "XRT",
                           "Calling AIE Trace updateAIEDevice.");
 
   if (!handle)
     return;
   
-  //handle relates to hw context handle in case of Client XRT
-#if defined(XDP_CLIENT_BUILD) || defined(XDP_VE2_BUILD)
-  xrt::hw_context context = xrt_core::hw_context_int::create_hw_context_from_implementation(handle);
-  auto device = xrt_core::hw_context_int::get_core_device(context);
-#else
-  auto device = xrt_core::get_userpf_device(handle);
-#endif
+  auto device = util::convertToCoreDevice(handle, hw_context_flow);
 
   // Clean out old data every time xclbin gets updated
   if (handleToAIEData.find(handle) != handleToAIEData.end())
@@ -153,6 +147,7 @@ void AieTracePluginUnified::updateAIEDevice(void *handle) {
   AIEData.valid = true; // initialize struct
 
 #ifdef XDP_CLIENT_BUILD
+  xrt::hw_context context = xrt_core::hw_context_int::create_hw_context_from_implementation(handle);
   AIEData.metadata->setHwContext(context);
   AIEData.implementation = std::make_unique<AieTrace_WinImpl>(db, AIEData.metadata);
 #elif defined(XRT_X86_BUILD)
@@ -283,6 +278,7 @@ void AieTracePluginUnified::updateAIEDevice(void *handle) {
       AIEData.metadata->getNumStreams(), AIEData.metadata->getHwContext(),
       AIEData.metadata);
 #elif XDP_VE2_BUILD
+  xrt::hw_context context = xrt_core::hw_context_int::create_hw_context_from_implementation(handle);
   auto hwctx_hdl = static_cast<xrt_core::hwctx_handle*>(context);
   auto hwctx_obj = dynamic_cast<shim_xdna_edge::xdna_hwctx*>(hwctx_hdl);
   auto aieObj = hwctx_obj->get_aie_array();
@@ -330,7 +326,7 @@ void AieTracePluginUnified::updateAIEDevice(void *handle) {
 #ifdef _WIN32
     std::string deviceName = "win_device";
 #else
-    std::string deviceName = util::getDeviceName(handle);
+    std::string deviceName = util::getDeviceName(handle, hw_context_flow);
 #endif
 
     // Writer for timestamp file

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.h
@@ -38,7 +38,7 @@ class AieTracePluginUnified : public XDPPlugin {
 public:
   AieTracePluginUnified();
   virtual ~AieTracePluginUnified();
-  void updateAIEDevice(void *handle);
+  void updateAIEDevice(void *handle, bool hw_context_flow);
   void flushAIEDevice(void *handle);
   void finishFlushAIEDevice(void *handle);
   virtual void writeAll(bool openNewFiles) override;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Added initial support for X+ML flow in trace plugin for Edge, Client and VE2
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
1. For VE2, AIE_TRACE_METADATA and AIE_METADATA should be read from xclbin which was not happening. The bug was introduced in this PR https://github.com/Xilinx/XRT/pull/8856
#### How problem was solved, alternative solutions (if any) and why they were rejected
Started checking whether XDP hooks are called from hw_context constructor using hw_context_flow variable.
#### Risks (if any) associated the changes in the commit
Low risk as the same changes are already done for profile plugin and current changes are tested for all the flows.
#### What has been tested and how, request additional testing if necessary
Tested Trace plugin on VE2 and client.
Tested Trace and status plugin on Edge.
#### Documentation impact (if any)
NA