### PR TITLE
Added status support for gmio and ext buffers

### DIFF
--- a/src/runtime_src/core/common/api/aie/xrt_graph.cpp
+++ b/src/runtime_src/core/common/api/aie/xrt_graph.cpp
@@ -212,7 +212,7 @@ public:
     m_buffer_handle->async(bos, dir, size, offset);
   }
 
-  bool
+  aie_buffer_state
   async_status() const
   {
     return m_buffer_handle->async_status();
@@ -516,7 +516,7 @@ async(xrt::bo ping, xrt::bo pong, xclBOSyncDirection dir, size_t size, size_t of
   return get_handle()->async(bos, dir, size, offset);
 }
 
-bool
+aie_buffer_state
 buffer::
 async_status() const
 {

--- a/src/runtime_src/core/common/api/aie/xrt_graph.cpp
+++ b/src/runtime_src/core/common/api/aie/xrt_graph.cpp
@@ -212,6 +212,12 @@ public:
     m_buffer_handle->async(bos, dir, size, offset);
   }
 
+  bool
+  status() const
+  {
+    return m_buffer_handle->status();
+  }
+
   void
   wait() const
   {
@@ -508,6 +514,13 @@ async(xrt::bo ping, xrt::bo pong, xclBOSyncDirection dir, size_t size, size_t of
 {
   std::vector<xrt::bo> bos {std::move(ping),std::move(pong)};
   return get_handle()->async(bos, dir, size, offset);
+}
+
+bool
+buffer::
+status() const
+{
+  return get_handle()->status();
 }
 
 void

--- a/src/runtime_src/core/common/api/aie/xrt_graph.cpp
+++ b/src/runtime_src/core/common/api/aie/xrt_graph.cpp
@@ -213,9 +213,9 @@ public:
   }
 
   bool
-  status() const
+  async_status() const
   {
-    return m_buffer_handle->status();
+    return m_buffer_handle->async_status();
   }
 
   void
@@ -518,9 +518,9 @@ async(xrt::bo ping, xrt::bo pong, xclBOSyncDirection dir, size_t size, size_t of
 
 bool
 buffer::
-status() const
+async_status() const
 {
-  return get_handle()->status();
+  return get_handle()->async_status();
 }
 
 void

--- a/src/runtime_src/core/common/api/aie/xrt_graph.cpp
+++ b/src/runtime_src/core/common/api/aie/xrt_graph.cpp
@@ -212,7 +212,7 @@ public:
     m_buffer_handle->async(bos, dir, size, offset);
   }
 
-  aie_buffer_state
+  device::buffer_state
   async_status() const
   {
     return m_buffer_handle->async_status();
@@ -516,7 +516,7 @@ async(xrt::bo ping, xrt::bo pong, xclBOSyncDirection dir, size_t size, size_t of
   return get_handle()->async(bos, dir, size, offset);
 }
 
-aie_buffer_state
+device::buffer_state
 buffer::
 async_status() const
 {

--- a/src/runtime_src/core/common/shim/aie_buffer_handle.h
+++ b/src/runtime_src/core/common/shim/aie_buffer_handle.h
@@ -6,6 +6,7 @@
 #include <vector>
 #include "xrt.h"
 #include "xrt/xrt_bo.h"
+
 namespace xrt_core {
 class aie_buffer_handle
 {
@@ -26,6 +27,12 @@ public:
 
   virtual void
   async(std::vector<xrt::bo>&, xclBOSyncDirection, size_t, size_t)
+  {
+    throw xrt_core::error(std::errc::not_supported, __func__);
+  }
+
+  virtual bool
+  status()
   {
     throw xrt_core::error(std::errc::not_supported, __func__);
   }

--- a/src/runtime_src/core/common/shim/aie_buffer_handle.h
+++ b/src/runtime_src/core/common/shim/aie_buffer_handle.h
@@ -11,35 +11,45 @@
 #include "xrt/xrt_aie.h"
 
 namespace xrt_core {
+
+// class aie_buffer_handle - shim base class for aie buffer objects
+//
+// shim level implementation derives off this class to support aie buffer objects
 class aie_buffer_handle
 {
 public:
+  // Destruction must destroy the underlying aie buffer object
   virtual ~aie_buffer_handle() {}
 
+  // Get the port name of this aie buffer object
   virtual std::string
   get_name() const
   {
     throw xrt_core::error(std::errc::not_supported, __func__);
   }
 
+  // Sync a buffer from AIE_to_GMIO or GMIO_to_AIE
   virtual void
   sync(std::vector<xrt::bo>&, xclBOSyncDirection, size_t, size_t) const
   {
     throw xrt_core::error(std::errc::not_supported, __func__);
   }
 
+  // Async a buffer from AIE_to_GMIO or GMIO_to_AIE
   virtual void
   async(std::vector<xrt::bo>&, xclBOSyncDirection, size_t, size_t)
   {
     throw xrt_core::error(std::errc::not_supported, __func__);
   }
 
-  virtual xrt::aie::aie_buffer_state
+  // Get the state of this aie buffer object
+  virtual xrt::aie::device::buffer_state
   async_status()
   {
     throw xrt_core::error(std::errc::not_supported, __func__);
   }
 
+  // Wait for the async execution to complete
   virtual void
   wait()
   {

--- a/src/runtime_src/core/common/shim/aie_buffer_handle.h
+++ b/src/runtime_src/core/common/shim/aie_buffer_handle.h
@@ -4,8 +4,10 @@
 #ifndef XRT_CORE_AIE_BUFFER_HANDLE_H
 #define XRT_CORE_AIE_BUFFER_HANDLE_H
 #include <vector>
+#include <system_error>
 #include "xrt.h"
 #include "xrt/xrt_bo.h"
+#include "core/common/error.h"
 
 namespace xrt_core {
 class aie_buffer_handle
@@ -32,7 +34,7 @@ public:
   }
 
   virtual bool
-  status()
+  async_status()
   {
     throw xrt_core::error(std::errc::not_supported, __func__);
   }

--- a/src/runtime_src/core/common/shim/aie_buffer_handle.h
+++ b/src/runtime_src/core/common/shim/aie_buffer_handle.h
@@ -8,6 +8,7 @@
 #include "xrt.h"
 #include "xrt/xrt_bo.h"
 #include "core/common/error.h"
+#include "xrt/xrt_aie.h"
 
 namespace xrt_core {
 class aie_buffer_handle
@@ -33,7 +34,7 @@ public:
     throw xrt_core::error(std::errc::not_supported, __func__);
   }
 
-  virtual bool
+  virtual xrt::aie::aie_buffer_state
   async_status()
   {
     throw xrt_core::error(std::errc::not_supported, __func__);

--- a/src/runtime_src/core/edge/user/aie/aie.cpp
+++ b/src/runtime_src/core/edge/user/aie/aie.cpp
@@ -347,7 +347,7 @@ sync_bo_nb(std::vector<xrt::bo>& bos, const char *port_name, enum xclBOSyncDirec
 
 bool
 aie_array::
-status(const std::string& port_name, uint16_t bdNum, uint32_t bdInstance)
+async_status(const std::string& port_name, uint16_t bdNum, uint32_t bdInstance)
 {
   if (!dev_inst)
     throw xrt_core::error(-EINVAL, "Can't get status of GMIO: AIE is not initialized");
@@ -363,7 +363,7 @@ status(const std::string& port_name, uint16_t bdNum, uint32_t bdInstance)
   if (gmio_itr == gmio_apis.end())
     throw xrt_core::error(-EINVAL, "Can't get status of GMIO: GMIO name not found");
 
-  return gmio_itr->second->status(bdNum, bdInstance);
+  return gmio_itr->second->gmio_status(bdNum, bdInstance);
 }
 
 void

--- a/src/runtime_src/core/edge/user/aie/aie.cpp
+++ b/src/runtime_src/core/edge/user/aie/aie.cpp
@@ -243,6 +243,25 @@ sync_external_buffer(std::vector<xrt::bo>& bos, adf::external_buffer_config& con
   }
 }
 
+bool
+aie_array::
+status_external_buffer(adf::external_buffer_config& config)
+{
+  if (config.shim_port_configs.empty())
+    throw xrt_core::error(-EINVAL, "Can't get status of External Buffer: No shim port configs");
+
+  if (config.num_bufs == 2)
+    return true; // for ping pong buffers return true
+
+  adf::dma_api dma_api_obj(m_config);
+  for (auto& port_config : config.shim_port_configs) {
+    if (!dma_api_obj.statusDMAChannelDone(1 /*adf::tile_type::shim_tile*/, port_config.shim_column, 0/*shim row*/, port_config.direction, port_config.channel_number))
+      return false;
+  }
+
+  return true;
+}
+
 void
 aie_array::
 wait_external_buffer(adf::external_buffer_config& config)
@@ -293,7 +312,7 @@ sync_bo(std::vector<xrt::bo>& bos, const char *port_name, enum xclBOSyncDirectio
   gmio_itr->second->wait();
 }
 
-void
+std::pair<size_t, size_t>
 aie_array::
 sync_bo_nb(std::vector<xrt::bo>& bos, const char *port_name, enum xclBOSyncDirection dir, size_t size, size_t offset)
 {
@@ -309,7 +328,7 @@ sync_bo_nb(std::vector<xrt::bo>& bos, const char *port_name, enum xclBOSyncDirec
   auto ebuf_itr = external_buffer_configs.find(port_name);
   if (ebuf_itr != external_buffer_configs.end()) {
     sync_external_buffer(bos, ebuf_itr->second, dir, size, offset);
-    return;
+    return std::make_pair(-1,0); // status external buffer does not depend on the BD but port
   }
 
   if (bos.size() > 1)
@@ -323,7 +342,28 @@ sync_bo_nb(std::vector<xrt::bo>& bos, const char *port_name, enum xclBOSyncDirec
   if (gmio_config_itr == gmio_configs.end())
     throw xrt_core::error(-EINVAL, "Can't sync BO: GMIO name not found");
 
-  submit_sync_bo(bos[0], gmio_itr->second, gmio_config_itr->second, dir, size, offset);
+  return submit_sync_bo(bos[0], gmio_itr->second, gmio_config_itr->second, dir, size, offset);
+}
+
+bool
+aie_array::
+status(const std::string& port_name, uint16_t bdNum, uint32_t bdInstance)
+{
+  if (!dev_inst)
+    throw xrt_core::error(-EINVAL, "Can't get status of GMIO: AIE is not initialized");
+
+  if (access_mode == xrt::aie::access_mode::shared)
+    throw xrt_core::error(-EPERM, "Can't get status of GMIO: Shared AIE context");
+
+  auto ebuf_itr = external_buffer_configs.find(port_name);
+  if (ebuf_itr != external_buffer_configs.end())
+    return status_external_buffer(ebuf_itr->second);
+
+  auto gmio_itr = gmio_apis.find(port_name);
+  if (gmio_itr == gmio_apis.end())
+    throw xrt_core::error(-EINVAL, "Can't get status of GMIO: GMIO name not found");
+
+  return gmio_itr->second->status(bdNum, bdInstance);
 }
 
 void
@@ -349,7 +389,7 @@ wait_gmio(const std::string& port_name)
   gmio_itr->second->wait();
 }
 
-void
+std::pair<size_t, size_t>
 aie_array::
 submit_sync_bo(xrt::bo& bo, std::shared_ptr<adf::gmio_api>& gmio_api, adf::gmio_config& gmio_config, enum xclBOSyncDirection dir, size_t size, size_t offset)
 {
@@ -370,8 +410,10 @@ submit_sync_bo(xrt::bo& bo, std::shared_ptr<adf::gmio_api>& gmio_api, adf::gmio_
     throw xrt_core::error(-EINVAL, "Sync AIE Bo fails: size is not 32 bits aligned.");
   aie_bd bd;
   prepare_bd(bd, bo);
-  gmio_api->enqueueBD(&bd.mem_inst, offset, size);
+  std::pair<size_t, size_t> bd_info = gmio_api->enqueueBD(&bd.mem_inst, offset, size);
   clear_bd(bd);
+
+  return bd_info;
 }
 
 void

--- a/src/runtime_src/core/edge/user/aie/aie.h
+++ b/src/runtime_src/core/edge/user/aie/aie.h
@@ -121,7 +121,7 @@ public:
   sync_bo_nb(std::vector<xrt::bo>& bos, const char *gmioName, enum xclBOSyncDirection dir, size_t size, size_t offset);
 
   bool
-  status(const std::string& gmioName, uint16_t bdNum, uint32_t bdInstance);
+  async_status(const std::string& gmioName, uint16_t bdNum, uint32_t bdInstance);
 
   void
   wait_gmio(const std::string& gmioName);

--- a/src/runtime_src/core/edge/user/aie/aie.h
+++ b/src/runtime_src/core/edge/user/aie/aie.h
@@ -108,14 +108,20 @@ public:
   void
   sync_external_buffer(std::vector<xrt::bo>& bo, adf::external_buffer_config& ebuf_config, enum xclBOSyncDirection dir, size_t size, size_t offset);
 
+  bool
+  status_external_buffer(adf::external_buffer_config& ebuf_config);
+
   void
   wait_external_buffer(adf::external_buffer_config& ebuf_config);
 
   void
   sync_bo(std::vector<xrt::bo>& bos, const char *dmaID, enum xclBOSyncDirection dir, size_t size, size_t offset);
 
-  void
+  std::pair<size_t, size_t>
   sync_bo_nb(std::vector<xrt::bo>& bos, const char *gmioName, enum xclBOSyncDirection dir, size_t size, size_t offset);
+
+  bool
+  status(const std::string& gmioName, uint16_t bdNum, uint32_t bdInstance);
 
   void
   wait_gmio(const std::string& gmioName);
@@ -168,7 +174,7 @@ private:
   std::vector<event_record> event_records;
   std::shared_ptr<adf::config_manager> m_config;
 
-  void
+  std::pair<size_t, size_t>
   submit_sync_bo(xrt::bo& bo, std::shared_ptr<adf::gmio_api>& gmio, adf::gmio_config& gmio_config, enum xclBOSyncDirection dir, size_t size, size_t offset);
 
   adf::shim_config

--- a/src/runtime_src/core/edge/user/aie/aie_buffer_object.cpp
+++ b/src/runtime_src/core/edge/user/aie/aie_buffer_object.cpp
@@ -57,12 +57,12 @@ namespace zynqaie {
   }
 
   bool
-  aie_buffer_object::status()
+  aie_buffer_object::async_status()
   {
     if (!async_started)
       throw xrt_core::error(-EINVAL, "Asynchronous operation is not initiated.");
 
-    return m_aie_array->status(name, bd_info.first, bd_info.second);
+    return m_aie_array->async_status(name, bd_info.first, bd_info.second);
   }
 
   void

--- a/src/runtime_src/core/edge/user/aie/aie_buffer_object.cpp
+++ b/src/runtime_src/core/edge/user/aie/aie_buffer_object.cpp
@@ -59,6 +59,9 @@ namespace zynqaie {
   bool
   aie_buffer_object::status()
   {
+    if (!async_started)
+      throw xrt_core::error(-EINVAL, "Asynchronous operation is not initiated.");
+
     return m_aie_array->status(name, bd_info.first, bd_info.second);
   }
 

--- a/src/runtime_src/core/edge/user/aie/aie_buffer_object.cpp
+++ b/src/runtime_src/core/edge/user/aie/aie_buffer_object.cpp
@@ -8,6 +8,7 @@
 #include "core/edge/user/shim.h"
 
 namespace zynqaie {
+  using buffer_state = xrt::aie::device::buffer_state;
   aie_buffer_object::aie_buffer_object(xrt_core::device* device, const xrt::uuid uuid, const char* buffer_name, zynqaie::hwctx_object* hwctx)
     : name{buffer_name}
   {
@@ -49,21 +50,21 @@ namespace zynqaie {
   aie_buffer_object::async(std::vector<xrt::bo>& bos, xclBOSyncDirection dir, size_t size, size_t offset)
   {
     std::lock_guard<std::mutex> lock(mtx);
-    if (m_state == xrt::aie::aie_buffer_state::running)
+    if (m_state == buffer_state::running)
       throw xrt_core::error(-EINVAL, "Asynchronous operation is already initiated. Multiple 'async' calls are not supported");
 
     bd_info = m_aie_array->sync_bo_nb(bos, name.c_str(), dir, size, offset);
-    m_state = xrt::aie::aie_buffer_state::running;
+    m_state = buffer_state::running;
   }
 
-  xrt::aie::aie_buffer_state
+  buffer_state
   aie_buffer_object::async_status()
   {
-    if (m_state != xrt::aie::aie_buffer_state::running)
+    if (m_state != buffer_state::running)
       throw xrt_core::error(-EINVAL, "Asynchronous operation is not initiated.");
 
-    if (m_state != xrt::aie::aie_buffer_state::completed && m_aie_array->async_status(name, bd_info.first, bd_info.second))
-      m_state = xrt::aie::aie_buffer_state::completed;
+    if (m_state != buffer_state::completed && m_aie_array->async_status(name, bd_info.first, bd_info.second))
+      m_state = buffer_state::completed;
 
     return m_state;
   }
@@ -72,10 +73,10 @@ namespace zynqaie {
   aie_buffer_object::wait()
   {
     std::lock_guard<std::mutex> lock(mtx);
-    if (m_state != xrt::aie::aie_buffer_state::running)
+    if (m_state != buffer_state::running)
       throw xrt_core::error(-EINVAL, "Asynchronous operation is not initiated. Please call 'wait' after 'async' call");
 
     m_aie_array->wait_gmio(name);
-    m_state = xrt::aie::aie_buffer_state::completed;
+    m_state = buffer_state::completed;
   }
 }

--- a/src/runtime_src/core/edge/user/aie/aie_buffer_object.cpp
+++ b/src/runtime_src/core/edge/user/aie/aie_buffer_object.cpp
@@ -52,8 +52,14 @@ namespace zynqaie {
     if (async_started)
       throw xrt_core::error(-EINVAL, "Asynchronous operation is already initiated. Multiple 'async' calls are not supported");
 
-    m_aie_array->sync_bo_nb(bos, name.c_str(), dir, size, offset);
+    bd_info = m_aie_array->sync_bo_nb(bos, name.c_str(), dir, size, offset);
     async_started = true;
+  }
+
+  bool
+  aie_buffer_object::status()
+  {
+    return m_aie_array->status(name, bd_info.first, bd_info.second);
   }
 
   void

--- a/src/runtime_src/core/edge/user/aie/aie_buffer_object.cpp
+++ b/src/runtime_src/core/edge/user/aie/aie_buffer_object.cpp
@@ -49,30 +49,33 @@ namespace zynqaie {
   aie_buffer_object::async(std::vector<xrt::bo>& bos, xclBOSyncDirection dir, size_t size, size_t offset)
   {
     std::lock_guard<std::mutex> lock(mtx);
-    if (async_started)
+    if (m_state == xrt::aie::aie_buffer_state::running)
       throw xrt_core::error(-EINVAL, "Asynchronous operation is already initiated. Multiple 'async' calls are not supported");
 
     bd_info = m_aie_array->sync_bo_nb(bos, name.c_str(), dir, size, offset);
-    async_started = true;
+    m_state = xrt::aie::aie_buffer_state::running;
   }
 
-  bool
+  xrt::aie::aie_buffer_state
   aie_buffer_object::async_status()
   {
-    if (!async_started)
+    if (m_state != xrt::aie::aie_buffer_state::running)
       throw xrt_core::error(-EINVAL, "Asynchronous operation is not initiated.");
 
-    return m_aie_array->async_status(name, bd_info.first, bd_info.second);
+    if (m_state != xrt::aie::aie_buffer_state::completed && m_aie_array->async_status(name, bd_info.first, bd_info.second))
+      m_state = xrt::aie::aie_buffer_state::completed;
+
+    return m_state;
   }
 
   void
   aie_buffer_object::wait()
   {
     std::lock_guard<std::mutex> lock(mtx);
-    if (!async_started)
+    if (m_state != xrt::aie::aie_buffer_state::running)
       throw xrt_core::error(-EINVAL, "Asynchronous operation is not initiated. Please call 'wait' after 'async' call");
 
     m_aie_array->wait_gmio(name);
-    async_started = false;
+    m_state = xrt::aie::aie_buffer_state::completed;
   }
 }

--- a/src/runtime_src/core/edge/user/aie/aie_buffer_object.h
+++ b/src/runtime_src/core/edge/user/aie/aie_buffer_object.h
@@ -22,7 +22,7 @@ namespace zynqaie {
     std::string name;
     std::shared_ptr<aie_array> m_aie_array;
     std::mutex mtx;
-    bool async_started = false;
+    xrt::aie::aie_buffer_state m_state = xrt::aie::aie_buffer_state::idle;
     std::pair<uint16_t, uint64_t> bd_info;
 
   public:
@@ -34,7 +34,7 @@ namespace zynqaie {
     void
     async(std::vector<xrt::bo>& bos, xclBOSyncDirection dir, size_t size, size_t offset) override;
 
-    bool
+    xrt::aie::aie_buffer_state
     async_status() override;
 
     void

--- a/src/runtime_src/core/edge/user/aie/aie_buffer_object.h
+++ b/src/runtime_src/core/edge/user/aie/aie_buffer_object.h
@@ -22,7 +22,7 @@ namespace zynqaie {
     std::string name;
     std::shared_ptr<aie_array> m_aie_array;
     std::mutex mtx;
-    xrt::aie::aie_buffer_state m_state = xrt::aie::aie_buffer_state::idle;
+    xrt::aie::device::buffer_state m_state = xrt::aie::device::buffer_state::idle;
     std::pair<uint16_t, uint64_t> bd_info;
 
   public:
@@ -34,7 +34,7 @@ namespace zynqaie {
     void
     async(std::vector<xrt::bo>& bos, xclBOSyncDirection dir, size_t size, size_t offset) override;
 
-    xrt::aie::aie_buffer_state
+    xrt::aie::device::buffer_state
     async_status() override;
 
     void

--- a/src/runtime_src/core/edge/user/aie/aie_buffer_object.h
+++ b/src/runtime_src/core/edge/user/aie/aie_buffer_object.h
@@ -23,21 +23,25 @@ namespace zynqaie {
     std::shared_ptr<aie_array> m_aie_array;
     std::mutex mtx;
     bool async_started = false;
+    std::pair<uint16_t, uint64_t> bd_info;
 
   public:
     aie_buffer_object(xrt_core::device* device, const xrt::uuid uuid, const char* name, zynqaie::hwctx_object* hwctx=nullptr);
 
     void
-    sync(std::vector<xrt::bo>& bos, xclBOSyncDirection dir, size_t size, size_t offset) const;
+    sync(std::vector<xrt::bo>& bos, xclBOSyncDirection dir, size_t size, size_t offset) const override;
 
     void
-    async(std::vector<xrt::bo>& bos, xclBOSyncDirection dir, size_t size, size_t offset);
+    async(std::vector<xrt::bo>& bos, xclBOSyncDirection dir, size_t size, size_t offset) override;
+
+    bool
+    status() override;
 
     void
-    wait();
+    wait() override;
 
     std::string
-    get_name() const;
+    get_name() const override;
 
   }; // aie_buffer_object
 }

--- a/src/runtime_src/core/edge/user/aie/aie_buffer_object.h
+++ b/src/runtime_src/core/edge/user/aie/aie_buffer_object.h
@@ -35,7 +35,7 @@ namespace zynqaie {
     async(std::vector<xrt::bo>& bos, xclBOSyncDirection dir, size_t size, size_t offset) override;
 
     bool
-    status() override;
+    async_status() override;
 
     void
     wait() override;

--- a/src/runtime_src/core/edge/user/aie/common_layer/adf_aie_control_api.h
+++ b/src/runtime_src/core/edge/user/aie/common_layer/adf_aie_control_api.h
@@ -112,6 +112,7 @@ public:
   err_code configureBD(int tileType, uint8_t column, uint8_t row, uint16_t bdId, const dma_api::buffer_descriptor& bdParam);
   err_code enqueueTask(int tileType, uint8_t column, uint8_t row, int dir, uint8_t channel, uint32_t repeatCount, bool enableTaskCompleteToken, uint16_t startBdId);
   err_code waitDMAChannelTaskQueue(int tileType, uint8_t column, uint8_t row, int dir, uint8_t channel);
+  bool statusDMAChannelDone(int tileType, uint8_t column, uint8_t row, int dir, uint8_t channel);
   err_code waitDMAChannelDone(int tileType, uint8_t column, uint8_t row, int dir, uint8_t channel);
   err_code updateBDAddress(int tileType, uint8_t column, uint8_t row, uint16_t bdId, uint64_t address);
   err_code updateBDAddressLin(XAie_MemInst* memInst , uint8_t column, uint8_t row, uint16_t bdId, uint64_t offset);

--- a/src/runtime_src/core/edge/user/aie/common_layer/adf_runtime_api.cpp
+++ b/src/runtime_src/core/edge/user/aie/common_layer/adf_runtime_api.cpp
@@ -17,6 +17,8 @@
 #include "adf_runtime_api.h"
 #include "adf_api_message.h"
 
+#include "core/common/error.h"
+
 #include <algorithm>
 #include <sstream>
 #include <map>
@@ -649,6 +651,7 @@ err_code gmio_api::configure()
         {
             int bdNum = ((1 - pGMIOConfig->type) * 2 + pGMIOConfig->channelNum) * dmaStartQMaxSize + j;
             availableBDs.push(bdNum);
+            statusBDs[bdNum] = 0;
 
             //set AXI burst length, this won't change during runtime
             driverStatus |= XAie_DmaSetAxi(&shimDmaInst, 0 /*Smid*/, pGMIOConfig->burstLength /*BurstLen*/, 0 /*Qos*/, 0 /*Cache*/, 0 /*Secure*/);
@@ -665,27 +668,36 @@ err_code gmio_api::configure()
     return err_code::ok;
 }
 
-err_code gmio_api::enqueueBD(XAie_MemInst *memInst, uint64_t offset, size_t size)
+void gmio_api::getAvailableBDs()
+{
+    u8 numPendingBDs = 0;
+    int numBDCompleted = 0;
+    int driverStatus = XAIE_OK; //0
+
+    driverStatus |= XAie_DmaGetPendingBdCount(config->get_dev(), gmioTileLoc, pGMIOConfig->channelNum, (pGMIOConfig->type == gmio_config::gm2aie ? DMA_MM2S : DMA_S2MM), &numPendingBDs);
+    if (driverStatus != AieRC::XAIE_OK)
+        throw xrt_core::error(-EIO, "ERROR: adf::gmio_api::getAvailableBDs: AIE driver error.");
+
+    numBDCompleted = dmaStartQMaxSize - numPendingBDs;
+
+    for (int i = 0; i < numBDCompleted && !enqueuedBDs.empty(); i++)
+    {
+        uint16_t bdNumber = frontAndPop(enqueuedBDs);
+        statusBDs[bdNumber]++;
+        availableBDs.push(bdNumber);
+    }
+}
+
+std::pair<size_t, size_t> gmio_api::enqueueBD(XAie_MemInst *memInst, uint64_t offset, size_t size)
 {
     if (!isConfigured)
-        return errorMsg(err_code::internal_error, "ERROR: adf::gmio_api::enqueueBD: GMIO is not configured.");
+        throw xrt_core::error(-ENODEV, "ERROR: adf::gmio_api::enqueueBD: GMIO is not configured.");
 
     int driverStatus = XAIE_OK; //0
 
     //wait for available BD
     while (availableBDs.empty())
-    {
-        u8 numPendingBDs = 0;
-        driverStatus |= XAie_DmaGetPendingBdCount(config->get_dev(), gmioTileLoc, pGMIOConfig->channelNum, (pGMIOConfig->type == gmio_config::gm2aie ? DMA_MM2S : DMA_S2MM), &numPendingBDs);
-
-        int numBDCompleted = dmaStartQMaxSize - numPendingBDs;
-        //move completed BDs from enqueuedBDs to availableBDs
-        for (int i = 0; i < numBDCompleted; i++)
-        {
-            uint16_t bdNumber = frontAndPop(enqueuedBDs);
-            availableBDs.push(bdNumber);
-        }
-    }
+        getAvailableBDs();
 
     //get an available BD
     uint16_t bdNumber = frontAndPop(availableBDs);
@@ -716,9 +728,23 @@ err_code gmio_api::enqueueBD(XAie_MemInst *memInst, uint64_t offset, size_t size
 
     // Update status after using AIE driver
     if (driverStatus != AieRC::XAIE_OK)
-        return errorMsg(err_code::aie_driver_error, "ERROR: adf::gmio_api::enqueueBD: AIE driver error.");
+        throw xrt_core::error(-EIO, "ERROR: adf::gmio_api::enqueueBD: AIE driver error.");
 
-    return err_code::ok;
+    return std::make_pair(bdNumber, statusBDs[bdNumber]);;
+}
+
+bool gmio_api::status(uint16_t bdNum, uint32_t bdInstance)
+{
+    if (statusBDs.find(bdNum) == statusBDs.end())
+        throw xrt_core::error(-ENODEV, "ERROR: adf::gmio_api::status: Invalid BD.");
+
+    if (statusBDs[bdNum] > bdInstance)
+        return true;
+
+    //update the availableBDs queue
+    getAvailableBDs();
+
+    return statusBDs[bdNum] > bdInstance;
 }
 
 err_code gmio_api::wait()
@@ -901,6 +927,13 @@ err_code dma_api::waitDMAChannelTaskQueue(int tileType, uint8_t column, uint8_t 
         return errorMsg(err_code::aie_driver_error, "ERROR: adf::dma_api::waitDMAChannelTaskQueue: AIE driver error.");
 
     return err_code::ok;
+}
+
+bool dma_api::statusDMAChannelDone(int tileType, uint8_t column, uint8_t row, int dir, uint8_t channel)
+{
+    XAie_LocType tileLoc = XAie_TileLoc(column, relativeToAbsoluteRow(config, tileType, row));
+
+    return XAie_DmaWaitForDone(config->get_dev(), tileLoc, channel, (XAie_DmaDirection)dir, 0) == XAIE_OK;
 }
 
 err_code dma_api::waitDMAChannelDone(int tileType, uint8_t column, uint8_t row, int dir, uint8_t channel)

--- a/src/runtime_src/core/edge/user/aie/common_layer/adf_runtime_api.cpp
+++ b/src/runtime_src/core/edge/user/aie/common_layer/adf_runtime_api.cpp
@@ -733,7 +733,7 @@ std::pair<size_t, size_t> gmio_api::enqueueBD(XAie_MemInst *memInst, uint64_t of
     return std::make_pair(bdNumber, statusBDs[bdNumber]);;
 }
 
-bool gmio_api::status(uint16_t bdNum, uint32_t bdInstance)
+bool gmio_api::gmio_status(uint16_t bdNum, uint32_t bdInstance)
 {
     if (statusBDs.find(bdNum) == statusBDs.end())
         throw xrt_core::error(-ENODEV, "ERROR: adf::gmio_api::status: Invalid BD.");

--- a/src/runtime_src/core/edge/user/aie/common_layer/adf_runtime_api.h
+++ b/src/runtime_src/core/edge/user/aie/common_layer/adf_runtime_api.h
@@ -70,7 +70,7 @@ public:
   err_code configure();
   void getAvailableBDs();
   std::pair<size_t, size_t> enqueueBD(XAie_MemInst *memInst, uint64_t offset, size_t size);
-  bool status(uint16_t bdNum, uint32_t bdInstance);
+  bool gmio_status(uint16_t bdNum, uint32_t bdInstance);
   err_code wait();
   err_code enqueueTask(std::vector<dma_api::buffer_descriptor> bdParams, uint32_t repeatCount, bool enableTaskCompleteToken);
   std::shared_ptr<config_manager>

--- a/src/runtime_src/core/edge/user/aie/common_layer/adf_runtime_api.h
+++ b/src/runtime_src/core/edge/user/aie/common_layer/adf_runtime_api.h
@@ -68,7 +68,9 @@ public:
   virtual ~gmio_api() {}
 
   err_code configure();
-  err_code enqueueBD(XAie_MemInst *memInst, uint64_t offset, size_t size);
+  void getAvailableBDs();
+  std::pair<size_t, size_t> enqueueBD(XAie_MemInst *memInst, uint64_t offset, size_t size);
+  bool status(uint16_t bdNum, uint32_t bdInstance);
   err_code wait();
   err_code enqueueTask(std::vector<dma_api::buffer_descriptor> bdParams, uint32_t repeatCount, bool enableTaskCompleteToken);
   std::shared_ptr<config_manager>
@@ -88,6 +90,7 @@ private:
   uint8_t dmaStartQMaxSize;
   std::queue<size_t> enqueuedBDs;
   std::queue<size_t> availableBDs;
+  std::unordered_map<size_t, size_t> statusBDs;
   std::shared_ptr<config_manager> config;
 };
 

--- a/src/runtime_src/core/include/xrt/xrt_aie.h
+++ b/src/runtime_src/core/include/xrt/xrt_aie.h
@@ -54,24 +54,24 @@ namespace xrt { namespace aie {
  */
 enum class access_mode : uint8_t { exclusive = 0, primary = 1, shared = 2, none = 3 };
 
-/**
- * @enum aie_buffer_state - aie buffer object state
- *
- * @var idle
- *   Newly created aie buffer object. Ready to perform an asynchronous operation. Not allowed
- *   to access the status of the aie buffer object at this state.
- * @var running
- *   An asynchronous operation is already initiated. Not allowed to initiate another asynchronous
- *   operation.
- * @var completed
- *   The initiated asynchronous operation is completed.
- */
-enum class aie_buffer_state { idle, running, completed };
-
 class device : public xrt::device
 {
 public:
   using access_mode = xrt::aie::access_mode;
+
+  /**
+   * @enum buffer_state - aie buffer object state
+   *
+   * @var idle
+   *   Newly created aie buffer object. Ready to perform an asynchronous operation. Not allowed
+   *   to access the status of the aie buffer object at this state.
+   * @var running
+   *   An asynchronous operation is already initiated. Not allowed to initiate another asynchronous
+   *   operation.
+   * @var completed
+   *   The initiated asynchronous operation is completed.
+   */
+  enum class buffer_state { idle, running, completed };
 
   /**
    * device() - Construct device with specified access mode
@@ -512,7 +512,7 @@ public:
   /**
    * async_status() - This function gets the status of the previously initiated async operation
    */
-  aie_buffer_state async_status() const;
+  device::buffer_state async_status() const;
 
   /**
    * wait() - This function waits for the previously initiated async operation

--- a/src/runtime_src/core/include/xrt/xrt_aie.h
+++ b/src/runtime_src/core/include/xrt/xrt_aie.h
@@ -54,6 +54,20 @@ namespace xrt { namespace aie {
  */
 enum class access_mode : uint8_t { exclusive = 0, primary = 1, shared = 2, none = 3 };
 
+/**
+ * @enum aie_buffer_state - aie buffer object state
+ *
+ * @var idle
+ *   Newly created aie buffer object. Ready to perform an asynchronous operation. Not allowed
+ *   to access the status of the aie buffer object at this state.
+ * @var running
+ *   An asynchronous operation is already initiated. Not allowed to initiate another asynchronous
+ *   operation.
+ * @var completed
+ *   The initiated asynchronous operation is completed.
+ */
+enum class aie_buffer_state { idle, running, completed };
+
 class device : public xrt::device
 {
 public:
@@ -498,7 +512,7 @@ public:
   /**
    * async_status() - This function gets the status of the previously initiated async operation
    */
-  bool async_status() const;
+  aie_buffer_state async_status() const;
 
   /**
    * wait() - This function waits for the previously initiated async operation

--- a/src/runtime_src/core/include/xrt/xrt_aie.h
+++ b/src/runtime_src/core/include/xrt/xrt_aie.h
@@ -496,9 +496,9 @@ public:
   void async(xrt::bo ping, xrt::bo pong, xclBOSyncDirection dir, size_t size, size_t offset) const;
 
   /**
-   * status() - This function gets the status of the previously initiated async operation
+   * async_status() - This function gets the status of the previously initiated async operation
    */
-  bool status() const;
+  bool async_status() const;
 
   /**
    * wait() - This function waits for the previously initiated async operation

--- a/src/runtime_src/core/include/xrt/xrt_aie.h
+++ b/src/runtime_src/core/include/xrt/xrt_aie.h
@@ -496,6 +496,11 @@ public:
   void async(xrt::bo ping, xrt::bo pong, xclBOSyncDirection dir, size_t size, size_t offset) const;
 
   /**
+   * status() - This function gets the status of the previously initiated async operation
+   */
+  bool status() const;
+
+  /**
    * wait() - This function waits for the previously initiated async operation
    */
   void wait() const;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1210116. 
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Not a bug. It's a new feature for GMIO and external buffer usecases. It is a new member function of xrt::aie::buffer class which will get the status of the previously initiated async operation.
#### How problem was solved, alternative solutions (if any) and why they were rejected
By adding a new member function to xrt::aie::buffer class
#### Risks (if any) associated the changes in the commit
-
#### What has been tested and how, request additional testing if necessary
Tested on vck190 and vek280 with GMIO and external buffer testcases
#### Documentation impact (if any)
status() of xrt::aie::buffer needs to be documented