### PR TITLE
Report average latency and throughput in xrt::runner w. profile

### DIFF
--- a/src/runtime_src/core/common/debug.cpp
+++ b/src/runtime_src/core/common/debug.cpp
@@ -32,7 +32,7 @@ debugf(const char* format,...)
   debug_lock lk;
   va_list args;
   va_start(args,format);
-  printf("%lu: ",time_ns());
+  printf("%llu: ",time_ns());
   vprintf(format,args);
   va_end(args);
 }

--- a/src/runtime_src/core/common/runner/runner.cpp
+++ b/src/runtime_src/core/common/runner/runner.cpp
@@ -9,7 +9,7 @@
 
 // If runlist contains more than XRT_RUNLIST_THRESHOLD runs then
 // switch to xrt::runlist
-#define XRT_RUNLIST_THRESHOLD 6
+//#define USE_XRT_RUNLIST
 
 #ifdef _DEBUG
 # define XRT_VERBOSE
@@ -22,6 +22,7 @@
 #include "core/common/dlfcn.h"
 #include "core/common/error.h"
 #include "core/common/module_loader.h"
+#include "core/common/time.h"
 #include "core/include/xrt/xrt_bo.h"
 #include "core/include/xrt/xrt_device.h"
 #include "core/include/xrt/xrt_hw_context.h"
@@ -37,6 +38,7 @@
 
 #include <algorithm>
 #include <fstream>
+#include <iostream>
 #include <istream>
 #include <map>
 #include <memory>
@@ -904,7 +906,7 @@ class recipe
     {
       virtual ~runlist() = default;
       virtual void add(const run& run) = 0;
-      virtual void execute() = 0;
+      virtual void execute(size_t) = 0;
       virtual void wait() {}
     };
 
@@ -919,8 +921,9 @@ class recipe
       }
       
       void
-      execute() override
+      execute(size_t) override
       {
+        // CPU runs are synchronous, nothing to wait on
         for (auto& run : m_runs)
           run.execute();
       }
@@ -942,9 +945,13 @@ class recipe
       }
 
       void
-      execute() override
+      execute(size_t iteration) override
       {
-        m_runlist.execute();
+        // Wait until previous iteration is done
+        if (iteration > 0)
+          m_runlist.wait();
+
+        m_runlst.execute();
       }
 
       void
@@ -968,10 +975,21 @@ class recipe
       }
 
       void
-      execute() override
+      execute(size_t iteration) override
       {
-        for (auto& run : m_runlist)
+        // First iteration, just start all runs
+        if (iteration == 0) {
+          for (auto& run : m_runlist)
+            run.start();
+
+          return;
+        }
+
+        // Wait until previous iteration run is done
+        for (auto& run : m_runlist) {
+          run.wait();
           run.start();
+        }
       }
 
       void
@@ -987,10 +1005,10 @@ class recipe
 
     std::vector<run> m_runs;
     xrt::queue m_queue;        // Queue that executes the runlists in sequence
-    xrt::queue::event m_event; // Event that signals the completion of the last runlist
     std::exception_ptr m_eptr;
 
     std::vector<std::unique_ptr<runlist>> m_runlists;
+    std::vector<xrt::queue::event> m_events;  // Events that signal complettion of a runlist
 
     static std::vector<std::unique_ptr<runlist>>
     create_runlists(const resources& resources, const std::vector<run>& runs)
@@ -1072,6 +1090,12 @@ class recipe
       , m_runlists{create_runlists(resources, m_runs)}
     {}
 
+    size_t
+    num_runs() const
+    {
+      return m_runs.size();
+    }
+
     void
     bind(const std::string& name, const xrt::bo& bo)
     {
@@ -1082,41 +1106,51 @@ class recipe
         run.bind(name, bo);
     }
 
-    void
-    execute()
+    
+    // execute_runlist() - execute a runlist synchronously
+    // The lambda function is executed asynchronously by an
+    // xrt::queue object. The wait is necessary for an NPU runlist,
+    // which must complete before next enqueue operation can be
+    // executed.  Execution of an NPU runlist is itself asynchronous.
+    static void
+    execute_runlist(size_t iteration, runlist* runlist, std::exception_ptr& eptr)
     {
-      XRT_DEBUGF("recipe::execution::execute()\n");
+      try {
+        runlist->execute(iteration);
+        runlist->wait(); // needed for NPU runlists, noop for CPU
+      }
+      catch (const xrt::runlist::command_error&) {
+        eptr = std::current_exception();
+      }
+      catch (const std::exception&) {
+        eptr = std::current_exception();
+      }
+    }
 
-      // execute_runlist() - execute a runlist synchronously
-      // The lambda function is executed asynchronously by an
-      // xrt::queue object. The wait is necessary for an NPU runlist,
-      // which must complete before next enqueue operation can be
-      // executed.  Execution of an NPU runlist is itself asynchronous.
-      static auto execute_runlist = [](runlist* runlist, std::exception_ptr& eptr) {
-        try {
-          runlist->execute();
-          runlist->wait(); // needed for NPU runlists, noop for CPU
-        }
-        catch (const xrt::runlist::command_error&) {
-          eptr = std::current_exception();
-        }
-        catch (const std::exception&) {
-          eptr = std::current_exception();
-        }
-      };
+    // Execute a run-recipe iteration
+    void
+    execute(size_t iteration)
+    {
+      XRT_DEBUGF("recipe::execution::execute(%d)\n", iteration);
 
       // If single runlist then avoid the overhead of xrt::queue
       if (m_runlists.size() == 1) {
-        m_runlists[0]->execute();
+        m_runlists[0]->execute(iteration);
         return;
       }
 
-      // A recipe can have multiple runlists. Each runlist can have
-      // multiple runs.  Runlists are executed sequentially, execution
-      // is orchestrated by xrt::queue which uses one thread to
-      // asynchronously (from called pov) execute all runlists
-      for (auto& runlist : m_runlists)
-        m_event = m_queue.enqueue([this, &runlist] { execute_runlist(runlist.get(), m_eptr); });
+      // The recipe has multiple runlists (a mix of NPU and CPU).
+      // Restart the recipes, but ensure that a runlist has completed
+      // its previous iteration before restarting it.
+      int count = 0;
+      for (auto& runlist : m_runlists) {
+        if (iteration > 0)
+          m_events[count].wait();
+
+        m_events[count++] = m_queue.enqueue([this, iteration, &runlist] {
+          execute_runlist(iteration, runlist.get(), m_eptr);
+        });
+      }
     }
 
     void
@@ -1133,9 +1167,9 @@ class recipe
 
       // Sufficient to wait for last runlist to finish since last list
       // must have waited for all previous lists to finish.
-      auto runlist = m_runlists.back().get();
-      if (runlist) 
-        m_event.wait();
+      const auto& event = m_events.back();
+      if (event)
+        event.wait();
 
       if (m_eptr)
         std::rethrow_exception(m_eptr);
@@ -1164,6 +1198,12 @@ public:
 
   recipe(const recipe&) = default;
 
+  size_t
+  num_runs() const
+  {
+    return m_execution.num_runs();
+  }
+
   void
   bind_input(const std::string& name, const xrt::bo& bo)
   {
@@ -1183,17 +1223,17 @@ public:
     m_execution.bind(name, bo);
   }
 
-  // The recipe can be executed with its currently bound
-  // input and output resources
+  void
+  execute(size_t iteration)
+  {
+    XRT_DEBUGF("recipe::execute(%d)\n", iteration);
+    m_execution.execute(iteration);
+  }
+
   void
   execute()
   {
-    XRT_DEBUGF("recipe::execute()\n");
-    // Verify that all required resources are bound
-    // ...
-
-    // Execute the runlist
-    m_execution.execute();
+    execute(0);
   }
 
   void
@@ -1502,7 +1542,7 @@ class profile
       if (m_iteration.value("init", false))
         m_profile->init();
       
-      m_profile->execute_recipe();
+      m_profile->execute_recipe(idx);
 
       // Wait execution to complete if requested
       if (m_iteration.value("wait", false))
@@ -1528,10 +1568,21 @@ class profile
     void
     execute()
     {
-      for (size_t i = 0; i < m_iterations; ++i)
-        execute_iteration(i);
+      unsigned long long time_ns = 0;
+      {
+        xrt_core::time_guard tg(time_ns);
+        for (size_t i = 0; i < m_iterations; ++i)
+          execute_iteration(i);
+
+        m_profile->wait_recipe();
+      }
+
+      auto num_runs = m_profile->num_recipe_runs();
+      
+      std::cout << "Elapsed time (us): " << time_ns / 1000 << "\n";
+      std::cout << "Average Latency (us): " << time_ns / (1000 * m_iterations * num_runs) << "\n";
+      std::cout << "Average Throughput (op/s): " << (1000000000 * m_iterations * num_runs) / time_ns << "\n";
     }
-    
   }; // class profile::execution
   
 private:
@@ -1543,6 +1594,12 @@ private:
   recipe m_recipe;
   bindings m_bindings;
   execution m_execution;
+
+  size_t
+  num_recipe_runs() const
+  {
+    return m_recipe.num_runs();
+  }
 
   void
   bind()
@@ -1563,9 +1620,9 @@ private:
   }
 
   void
-  execute_recipe()
+  execute_recipe(size_t idx)
   {
-    m_recipe.execute();
+    m_recipe.execute(idx);
   }
 
   void

--- a/src/runtime_src/core/common/runner/runner.cpp
+++ b/src/runtime_src/core/common/runner/runner.cpp
@@ -1578,10 +1578,12 @@ class profile
       }
 
       auto num_runs = m_profile->num_recipe_runs();
-      
+
+      // NOLINTBEGIN
       std::cout << "Elapsed time (us): " << time_ns / 1000 << "\n";
       std::cout << "Average Latency (us): " << time_ns / (1000 * m_iterations * num_runs) << "\n";
       std::cout << "Average Throughput (op/s): " << (1000000000 * m_iterations * num_runs) / time_ns << "\n";
+      // NOLINTEND
     }
   }; // class profile::execution
   

--- a/src/runtime_src/core/common/task.h
+++ b/src/runtime_src/core/common/task.h
@@ -116,8 +116,8 @@ class mpmcqueue
   mutable std::mutex m_mutex;
   std::condition_variable m_work;
   bool m_stop = false;
-  unsigned long tp = 0;       // time point when last task consumed
-  unsigned long waittime = 0; // wait time from tp to next task avail
+  unsigned long long tp = 0;       // time point when last task consumed
+  unsigned long long waittime = 0; // wait time from tp to next task avail
   bool debug = false;
 public:
   mpmcqueue()
@@ -343,8 +343,8 @@ inline void
 worker_debug(queue& q,const std::string& id)
 {
   unsigned long loops = 0;
-  unsigned long worktime = 0;
-  unsigned long waittime = 0;
+  unsigned long long worktime = 0;
+  unsigned long long waittime = 0;
   while (true) {
     ++loops;
     auto timepoint = time_ns();

--- a/src/runtime_src/core/common/time.cpp
+++ b/src/runtime_src/core/common/time.cpp
@@ -42,13 +42,13 @@ namespace xrt_core {
  * @return
  *   nanoseconds since first call
  */
-unsigned long
+unsigned long long
 time_ns()
 {
   static auto zero = std::chrono::high_resolution_clock::now();
   auto now = std::chrono::high_resolution_clock::now();
   auto integral_duration = std::chrono::duration_cast<std::chrono::nanoseconds>(now-zero).count();
-  return static_cast<unsigned long>(integral_duration);
+  return static_cast<unsigned long long>(integral_duration);
 }
 
 /**

--- a/src/runtime_src/core/common/time.h
+++ b/src/runtime_src/core/common/time.h
@@ -28,7 +28,7 @@ namespace xrt_core {
  *   nanoseconds since first call
  */
 XRT_CORE_COMMON_EXPORT
-unsigned long
+unsigned long long
 time_ns();
 
 /**
@@ -50,11 +50,11 @@ timestamp(uint64_t epoch);
  */
 class time_guard
 {
-  unsigned long zero = 0;
-  unsigned long& tally;
+  unsigned long long zero = 0;
+  unsigned long long& tally;
 public:
   explicit
-  time_guard(unsigned long& t)
+  time_guard(unsigned long long& t)
     : zero(time_ns()), tally(t)
   {}
 

--- a/src/runtime_src/xdp/profile/plugin/hal/xdp_hal_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/hal/xdp_hal_plugin.cpp
@@ -35,7 +35,7 @@ namespace xdp {
 
   static void generic_log_function_start(const char* functionName, uint64_t id)
   {
-    auto timestamp = xrt_core::time_ns() ;
+    auto timestamp = static_cast<double>(xrt_core::time_ns());
     VPDatabase* db = halPluginInstance.getDatabase() ;
 
     // Update counters
@@ -52,7 +52,7 @@ namespace xdp {
 
   static void generic_log_function_end(const char* functionName, uint64_t id)
   {
-    auto timestamp = xrt_core::time_ns() ;
+    auto timestamp = static_cast<double>(xrt_core::time_ns());
     VPDatabase* db = halPluginInstance.getDatabase() ;
   
     // Update counters
@@ -74,7 +74,7 @@ namespace xdp {
     // Also create a buffer transfer event
     VPDatabase* db = halPluginInstance.getDatabase() ;
 
-    auto timestamp = xrt_core::time_ns();
+    auto timestamp = static_cast<double>(xrt_core::time_ns());
     VTFEvent* event = new BufferTransfer(0, timestamp, WRITE_BUFFER, size);
     (db->getDynamicInfo()).addEvent(event);
     (db->getDynamicInfo()).markStart(bufferId, event->getEventId());
@@ -85,7 +85,7 @@ namespace xdp {
     generic_log_function_end(name, id) ;
 
     // Add trace event for end of Buffer Transfer
-    auto timestamp = xrt_core::time_ns();
+    auto timestamp = static_cast<double>(xrt_core::time_ns());
     VPDatabase* db = halPluginInstance.getDatabase();
     VTFEvent* event =
       new BufferTransfer(db->getDynamicInfo().matchingStart(bufferId),
@@ -101,7 +101,7 @@ namespace xdp {
     // Also create a buffer transfer event
     VPDatabase* db = halPluginInstance.getDatabase() ;
 
-    auto timestamp = xrt_core::time_ns();
+    auto timestamp = static_cast<double>(xrt_core::time_ns());
     VTFEvent* event = new BufferTransfer(0, timestamp, READ_BUFFER, size);
     (db->getDynamicInfo()).addEvent(event);
     (db->getDynamicInfo()).markStart(bufferId, event->getEventId());
@@ -112,7 +112,7 @@ namespace xdp {
     generic_log_function_end(name, id) ;
 
     // Add trace event for end of Buffer Transfer
-    auto timestamp = xrt_core::time_ns();
+    auto timestamp = static_cast<double>(xrt_core::time_ns());
     VPDatabase* db = halPluginInstance.getDatabase();
     VTFEvent* event =
       new BufferTransfer(db->getDynamicInfo().matchingStart(bufferId),

--- a/src/runtime_src/xdp/profile/plugin/lop/lop_cb.cpp
+++ b/src/runtime_src/xdp/profile/plugin/lop/lop_cb.cpp
@@ -35,7 +35,7 @@ namespace xdp {
 
     // Since these are OpenCL level events, we must use the OpenCL
     //  level time functions to get the proper value of time zero.
-    double timestamp = xrt_xocl::time_ns() ;
+    auto timestamp = static_cast<double>(xrt_xocl::time_ns());
     VPDatabase* db = lopPluginInstance.getDatabase() ;
 
     if (queueAddress != 0) 
@@ -58,7 +58,7 @@ namespace xdp {
     if (!VPDatabase::alive() || !LowOverheadProfilingPlugin::alive())
       return ;
 
-    double timestamp = xrt_xocl::time_ns() ;
+    auto timestamp = static_cast<double>(xrt_xocl::time_ns());
     VPDatabase* db = lopPluginInstance.getDatabase() ;
 
     uint64_t start = (db->getDynamicInfo()).matchingStart(functionID) ;
@@ -77,7 +77,7 @@ namespace xdp {
     if (!VPDatabase::alive() || !LowOverheadProfilingPlugin::alive())
       return ;
 
-    double timestamp = xrt_xocl::time_ns() ;
+    auto timestamp = static_cast<double>(xrt_xocl::time_ns());
     VPDatabase* db = lopPluginInstance.getDatabase() ;
     
     uint64_t start = 0 ;
@@ -98,7 +98,7 @@ namespace xdp {
     if (!VPDatabase::alive() || !LowOverheadProfilingPlugin::alive())
       return ;
 
-    double timestamp = xrt_xocl::time_ns() ;
+    auto timestamp = static_cast<double>(xrt_xocl::time_ns());
     VPDatabase* db = lopPluginInstance.getDatabase() ;
 
     uint64_t start = 0 ;
@@ -118,7 +118,7 @@ namespace xdp {
     if (!VPDatabase::alive() || !LowOverheadProfilingPlugin::alive())
       return ;
 
-    double timestamp = xrt_xocl::time_ns() ;
+    auto timestamp = static_cast<double>(xrt_xocl::time_ns());
     VPDatabase* db = lopPluginInstance.getDatabase() ;
 
     uint64_t start = 0 ;

--- a/src/runtime_src/xdp/profile/plugin/opencl/counters/opencl_counters_cb.cpp
+++ b/src/runtime_src/xdp/profile/plugin/opencl/counters/opencl_counters_cb.cpp
@@ -38,7 +38,7 @@ namespace xdp {
       return;
 
     VPDatabase* db = openclCountersPluginInstance.getDatabase() ;
-    auto timestamp = xrt_core::time_ns() ;
+    auto timestamp = static_cast<double>(xrt_core::time_ns());
 
     (db->getStats()).logFunctionCallStart(functionName, timestamp) ;
     if (queueAddress != 0)
@@ -51,7 +51,7 @@ namespace xdp {
       return;
 
     VPDatabase* db = openclCountersPluginInstance.getDatabase() ;
-    auto timestamp = xrt_core::time_ns() ;
+    auto timestamp = static_cast<double>(xrt_core::time_ns());
 
     (db->getStats()).logFunctionCallEnd(functionName, timestamp) ;
   }

--- a/src/runtime_src/xdp/profile/plugin/opencl/trace/opencl_trace_cb.cpp
+++ b/src/runtime_src/xdp/profile/plugin/opencl/trace/opencl_trace_cb.cpp
@@ -34,7 +34,7 @@ namespace xdp {
     if (!VPDatabase::alive() || !OpenCLTracePlugin::alive())
       return;
 
-    double timestamp = xrt_core::time_ns() ;
+    auto timestamp = static_cast<double>(xrt_core::time_ns());
     VPDatabase* db = openclPluginInstance.getDatabase() ;
 
     if (queueAddress != 0) 
@@ -57,7 +57,7 @@ namespace xdp {
     if (!VPDatabase::alive() || !OpenCLTracePlugin::alive())
       return;
 
-    double timestamp = xrt_core::time_ns() ;
+    auto timestamp = static_cast<double>(xrt_core::time_ns());
     VPDatabase* db = openclPluginInstance.getDatabase() ;
 
     uint64_t start = (db->getDynamicInfo()).matchingStart(functionID) ;
@@ -90,7 +90,7 @@ namespace xdp {
     if (!VPDatabase::alive() || !OpenCLTracePlugin::alive())
       return;
 
-    double timestamp = xrt_core::time_ns() ;
+    auto timestamp = static_cast<double>(xrt_core::time_ns());
     VPDatabase* db = openclPluginInstance.getDatabase() ;
 
     uint64_t start = 0 ;
@@ -124,7 +124,7 @@ namespace xdp {
     if (!VPDatabase::alive() || !OpenCLTracePlugin::alive())
       return;
 
-    double timestamp = xrt_core::time_ns() ;
+    auto timestamp = static_cast<double>(xrt_core::time_ns());
     VPDatabase* db = openclPluginInstance.getDatabase() ;
 
     uint64_t start = 0 ;
@@ -166,7 +166,7 @@ namespace xdp {
     if (!VPDatabase::alive() || !OpenCLTracePlugin::alive())
       return;
 
-    double timestamp = xrt_core::time_ns() ;
+    auto timestamp = static_cast<double>(xrt_core::time_ns());
     VPDatabase* db = openclPluginInstance.getDatabase() ;
 
     uint64_t start = 0 ;
@@ -205,7 +205,7 @@ namespace xdp {
     if (!VPDatabase::alive() || !OpenCLTracePlugin::alive())
       return;
 
-    double timestamp = xrt_core::time_ns() ;
+    auto timestamp = static_cast<double>(xrt_core::time_ns());
     VPDatabase* db = openclPluginInstance.getDatabase() ;
 
     uint64_t start = 0 ;

--- a/src/runtime_src/xdp/profile/plugin/user/user_cb.cpp
+++ b/src/runtime_src/xdp/profile/plugin/user/user_cb.cpp
@@ -85,7 +85,7 @@ namespace xdp {
     if (!VPDatabase::alive() || !UserEventsPlugin::alive())
       return;
 
-    double timestamp = xrt_core::time_ns();
+    double timestamp = static_cast<double>(xrt_core::time_ns());
     VPDatabase* db = userEventsPluginInstance.getDatabase();
 
     uint64_t l = 0;

--- a/src/runtime_src/xdp/profile/plugin/user/user_cb.cpp
+++ b/src/runtime_src/xdp/profile/plugin/user/user_cb.cpp
@@ -85,7 +85,7 @@ namespace xdp {
     if (!VPDatabase::alive() || !UserEventsPlugin::alive())
       return;
 
-    double timestamp = static_cast<double>(xrt_core::time_ns());
+    auto timestamp = static_cast<double>(xrt_core::time_ns());
     VPDatabase* db = userEventsPluginInstance.getDatabase();
 
     uint64_t l = 0;

--- a/src/runtime_src/xocl/core/time.h
+++ b/src/runtime_src/xocl/core/time.h
@@ -25,7 +25,7 @@ namespace xocl {
  * @return
  *   nanoseconds since first call
  */
-inline unsigned long
+inline unsigned long long
 time_ns() 
 { 
   return xrt_xocl::time_ns(); 


### PR DESCRIPTION
#### Problem solved by the commit
Default report average latency and throughput when running a recipe with a profile.

#### How problem was solved, alternative solutions (if any) and why they were rejected
The runner implementation is fixed to handle iterations with minimum wait.  For example, when the runlist consists of individually managed xrt::run objects, then a iteration restarts all the xrt::run objects waiting on runs in FIFO manner and restarting ASAP.

Latency is measured as expired time divided by the product of number of runs in the runlist and number of iterations.

Throughput is measured as the product of number of runs in runlist and number of iterations divided by the expired time.

This is generic and optimal throughput and latency for current XRT execution.  The recipe can be modified to include as many runs as desired in order to keep the hardware busy.

There is no need to specify iteration wait in the profile json, in fact if wait is specified, the granularity of wait is at the recipe level, meaning that an recipe execution must complete before it be iterated.

#### Risks (if any) associated the changes in the commit
This commit also has changes to xrt_core:: timing which is changed to use `unsigned long long` for timers.

