### PR TITLE
Support move of xrt::run into xrt::runlist

### DIFF
--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -4068,6 +4068,16 @@ add(const xrt::run& run)
   handle->add(run);
 }
 
+void
+runlist::
+add(xrt::run&& run)
+{
+  if (!handle)
+    throw xrt_core::error("cannot add run object to uninitialized runlist");
+
+  handle->add(std::move(run));
+}
+
 
 void
 runlist::

--- a/src/runtime_src/core/include/xrt/experimental/xrt_kernel.h
+++ b/src/runtime_src/core/include/xrt/experimental/xrt_kernel.h
@@ -143,6 +143,15 @@ public:
   add(const xrt::run& run);
 
   /**
+   * add() - Move a run object into the list
+   *
+   * Same behavior as copy add()
+   */
+  XRT_API_EXPORT
+  void
+  add(xrt::run&& run);
+
+  /**
    * execute() - Execute the runlist
    *
    * The runlist is submitted for execution. The run objects in the


### PR DESCRIPTION
#### Problem solved by the commit
Add xrt::runlist::add(xrt::run&&).
