### PR TITLE
Releasing the aie partition while destroying hwctx

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/edge/zocl_aie.c
+++ b/src/runtime_src/core/edge/drm/zocl/edge/zocl_aie.c
@@ -379,7 +379,7 @@ zocl_aie_slot_reset(struct drm_zocl_slot* slot)
 
 }
 
-static void
+void
 zocl_destroy_aie(struct drm_zocl_slot* slot)
 {
 	if (!slot->aie_information)
@@ -412,7 +412,7 @@ zocl_cleanup_aie(struct drm_zocl_slot *slot)
 	if (!slot)
 	{
 		DRM_ERROR("%s: Invalid slot", __func__);
-		return 0;
+		return -EINVAL;
 	}
 
 	int ret = 0;

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
@@ -267,6 +267,7 @@ void zocl_init_mem(struct drm_zocl_dev *zdev, struct drm_zocl_slot *slot);
 void zocl_clear_mem(struct drm_zocl_dev *zdev);
 void zocl_clear_mem_slot(struct drm_zocl_dev *zdev, u32 slot_idx);
 int zocl_cleanup_aie(struct drm_zocl_slot *slot);
+void zocl_destroy_aie(struct drm_zocl_slot *slot);
 int zocl_create_aie(struct drm_zocl_slot *slot, struct axlf *axlf, char __user *xclbin,
 		void *aie_res, uint8_t hw_gen, uint32_t partition_id);
 int zocl_init_aie(struct drm_zocl_slot* slot);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1238839
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
We dont used to release the aie partition after destroying the hwctx. We used to cleanup the aie before loading the aie only PDI which is causing issues while working with more than one AIE only PDIs in overlay usecases.
#### How problem was solved, alternative solutions (if any) and why they were rejected
Problem was solved by releasing the partition while destroying the hwctx.
#### Risks (if any) associated the changes in the commit
n/a
#### What has been tested and how, request additional testing if necessary
Tested the given testcase on the CR and also PL and AIE usecases on edge.
#### Documentation impact (if any)
n/a