### PR TITLE
Fixed event profiling issues

### DIFF
--- a/build/petalinux.build
+++ b/build/petalinux.build
@@ -1,1 +1,3 @@
+# When updating Petalinux build please file a SH ticket to retain the build
+# https://jira.xilinx.com/secure/CreateIssue!default.jspa
 PETALINUX=/proj/petalinux/2025.1/petalinux-v2025.1_04122302/tool/petalinux-v2025.1-final

--- a/build/petalinux.build
+++ b/build/petalinux.build
@@ -1,3 +1,1 @@
-# When updating Petalinux build please file a SH ticket to retain the build
-# https://jira.xilinx.com/secure/CreateIssue!default.jspa
-PETALINUX=/proj/petalinux/2025.1/petalinux-v2025.1_04080742/tool/petalinux-v2025.1-final
+PETALINUX=/proj/petalinux/2025.1/petalinux-v2025.1_04122302/tool/petalinux-v2025.1-final

--- a/src/runtime_src/core/common/api/aie/xrt_graph.cpp
+++ b/src/runtime_src/core/common/api/aie/xrt_graph.cpp
@@ -126,7 +126,6 @@ class profiling_impl
 {
 private:
   std::unique_ptr<xrt_core::profile_handle> m_profile_handle{nullptr};
-  bool is_stopped{false};
 
 public:
   static constexpr int invalid_handle = -1;
@@ -171,10 +170,7 @@ public:
   void
   stop()
   {
-    if(is_stopped == false)
       m_profile_handle->stop();
-
-    is_stopped = true;
   }
 };
 

--- a/src/runtime_src/core/edge/user/aie/profile_object.cpp
+++ b/src/runtime_src/core/edge/user/aie/profile_object.cpp
@@ -35,6 +35,9 @@ uint64_t
 profile_object::
 read()
 {
+  if (m_profile_id == invalid_profile_id)
+    return 0; // dont throw any exception/error 
+ 
   auto device = xrt_core::get_userpf_device(m_shim);
 
   if (!m_aie_array->is_context_set()) {
@@ -47,12 +50,16 @@ void
 profile_object::
 stop()
 {
+  if (m_profile_id == invalid_profile_id)
+    return; // dont throw any exception/error 
+
   auto device = xrt_core::get_userpf_device(m_shim);
 
   if (!m_aie_array->is_context_set()) {
     m_aie_array->open_context(device.get(), xrt::aie::access_mode::primary);
   }
   m_aie_array->stop_profiling(m_profile_id);
+  m_profile_id = invalid_profile_id;
 }
 
 } //namespace zynqaie


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Earlier coreutil is used to call event::profiling stop based on some conditions which is causing issues. Moved that logic to shim handle

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Properly calling start/read/stop shim APIs from coreutil. let shim handle the error cases

#### How problem was solved, alternative solutions (if any) and why they were rejected
Fixed the start/read/stop logic in the shim. Removed logic from coreutil

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Verified multiple profiling cases

#### Documentation impact (if any)
None