### PR TITLE
Enhance profile file initialization of recipe resource buffers

### DIFF
--- a/src/runtime_src/core/common/runner/recipe.md
+++ b/src/runtime_src/core/common/runner/recipe.md
@@ -193,7 +193,7 @@ If a buffer `size` is specified as in:
       }
 ```
 then the runner will create an `xrt::bo` internally for the specified
-buffer, even as the buffer is specified as "output" it is treated as
+buffer, even if the buffer is specified as "output" it is treated as
 internal by the runner.  The application framework can still bind an
 external buffer the runner object created from the recipe, but doesn't
 have to.


### PR DESCRIPTION
#### Problem solved by the commit
Initialization of a resource buffer from a file, fills all the bytes of the buffer with data from file.  It wraps around the file if necessary to fill the bo.

The function supports initializing the buffer between iterations, copying from the file from an offset corresponding to where previous iteration initialization reached.

