### PR TITLE
Added status support for gmio and ext buffers (#8903)

### DIFF
--- a/src/runtime_src/core/common/api/aie/xrt_graph.cpp
+++ b/src/runtime_src/core/common/api/aie/xrt_graph.cpp
@@ -212,6 +212,12 @@ public:
     m_buffer_handle->async(bos, dir, size, offset);
   }
 
+  device::buffer_state
+  async_status() const
+  {
+    return m_buffer_handle->async_status();
+  }
+
   void
   wait() const
   {
@@ -508,6 +514,13 @@ async(xrt::bo ping, xrt::bo pong, xclBOSyncDirection dir, size_t size, size_t of
 {
   std::vector<xrt::bo> bos {std::move(ping),std::move(pong)};
   return get_handle()->async(bos, dir, size, offset);
+}
+
+device::buffer_state
+buffer::
+async_status() const
+{
+  return get_handle()->async_status();
 }
 
 void

--- a/src/runtime_src/core/common/shim/aie_buffer_handle.h
+++ b/src/runtime_src/core/common/shim/aie_buffer_handle.h
@@ -4,32 +4,52 @@
 #ifndef XRT_CORE_AIE_BUFFER_HANDLE_H
 #define XRT_CORE_AIE_BUFFER_HANDLE_H
 #include <vector>
+#include <system_error>
 #include "xrt.h"
 #include "xrt/xrt_bo.h"
+#include "core/common/error.h"
+#include "xrt/xrt_aie.h"
+
 namespace xrt_core {
+
+// class aie_buffer_handle - shim base class for aie buffer objects
+//
+// shim level implementation derives off this class to support aie buffer objects
 class aie_buffer_handle
 {
 public:
+  // Destruction must destroy the underlying aie buffer object
   virtual ~aie_buffer_handle() {}
 
+  // Get the port name of this aie buffer object
   virtual std::string
   get_name() const
   {
     throw xrt_core::error(std::errc::not_supported, __func__);
   }
 
+  // Sync a buffer from AIE_to_GMIO or GMIO_to_AIE
   virtual void
   sync(std::vector<xrt::bo>&, xclBOSyncDirection, size_t, size_t) const
   {
     throw xrt_core::error(std::errc::not_supported, __func__);
   }
 
+  // Async a buffer from AIE_to_GMIO or GMIO_to_AIE
   virtual void
   async(std::vector<xrt::bo>&, xclBOSyncDirection, size_t, size_t)
   {
     throw xrt_core::error(std::errc::not_supported, __func__);
   }
 
+  // Get the state of this aie buffer object
+  virtual xrt::aie::device::buffer_state
+  async_status()
+  {
+    throw xrt_core::error(std::errc::not_supported, __func__);
+  }
+
+  // Wait for the async execution to complete
   virtual void
   wait()
   {

--- a/src/runtime_src/core/edge/user/aie/aie.h
+++ b/src/runtime_src/core/edge/user/aie/aie.h
@@ -108,14 +108,20 @@ public:
   void
   sync_external_buffer(std::vector<xrt::bo>& bo, adf::external_buffer_config& ebuf_config, enum xclBOSyncDirection dir, size_t size, size_t offset);
 
+  bool
+  status_external_buffer(adf::external_buffer_config& ebuf_config);
+
   void
   wait_external_buffer(adf::external_buffer_config& ebuf_config);
 
   void
   sync_bo(std::vector<xrt::bo>& bos, const char *dmaID, enum xclBOSyncDirection dir, size_t size, size_t offset);
 
-  void
+  std::pair<size_t, size_t>
   sync_bo_nb(std::vector<xrt::bo>& bos, const char *gmioName, enum xclBOSyncDirection dir, size_t size, size_t offset);
+
+  bool
+  async_status(const std::string& gmioName, uint16_t bdNum, uint32_t bdInstance);
 
   void
   wait_gmio(const std::string& gmioName);
@@ -168,7 +174,7 @@ private:
   std::vector<event_record> event_records;
   std::shared_ptr<adf::config_manager> m_config;
 
-  void
+  std::pair<size_t, size_t>
   submit_sync_bo(xrt::bo& bo, std::shared_ptr<adf::gmio_api>& gmio, adf::gmio_config& gmio_config, enum xclBOSyncDirection dir, size_t size, size_t offset);
 
   adf::shim_config

--- a/src/runtime_src/core/edge/user/aie/aie_buffer_object.h
+++ b/src/runtime_src/core/edge/user/aie/aie_buffer_object.h
@@ -22,22 +22,26 @@ namespace zynqaie {
     std::string name;
     std::shared_ptr<aie_array> m_aie_array;
     std::mutex mtx;
-    bool async_started = false;
+    xrt::aie::device::buffer_state m_state = xrt::aie::device::buffer_state::idle;
+    std::pair<uint16_t, uint64_t> bd_info;
 
   public:
     aie_buffer_object(xrt_core::device* device, const xrt::uuid uuid, const char* name, zynqaie::hwctx_object* hwctx=nullptr);
 
     void
-    sync(std::vector<xrt::bo>& bos, xclBOSyncDirection dir, size_t size, size_t offset) const;
+    sync(std::vector<xrt::bo>& bos, xclBOSyncDirection dir, size_t size, size_t offset) const override;
 
     void
-    async(std::vector<xrt::bo>& bos, xclBOSyncDirection dir, size_t size, size_t offset);
+    async(std::vector<xrt::bo>& bos, xclBOSyncDirection dir, size_t size, size_t offset) override;
+
+    xrt::aie::device::buffer_state
+    async_status() override;
 
     void
-    wait();
+    wait() override;
 
     std::string
-    get_name() const;
+    get_name() const override;
 
   }; // aie_buffer_object
 }

--- a/src/runtime_src/core/edge/user/aie/common_layer/adf_aie_control_api.h
+++ b/src/runtime_src/core/edge/user/aie/common_layer/adf_aie_control_api.h
@@ -112,6 +112,7 @@ public:
   err_code configureBD(int tileType, uint8_t column, uint8_t row, uint16_t bdId, const dma_api::buffer_descriptor& bdParam);
   err_code enqueueTask(int tileType, uint8_t column, uint8_t row, int dir, uint8_t channel, uint32_t repeatCount, bool enableTaskCompleteToken, uint16_t startBdId);
   err_code waitDMAChannelTaskQueue(int tileType, uint8_t column, uint8_t row, int dir, uint8_t channel);
+  bool statusDMAChannelDone(int tileType, uint8_t column, uint8_t row, int dir, uint8_t channel);
   err_code waitDMAChannelDone(int tileType, uint8_t column, uint8_t row, int dir, uint8_t channel);
   err_code updateBDAddress(int tileType, uint8_t column, uint8_t row, uint16_t bdId, uint64_t address);
   err_code updateBDAddressLin(XAie_MemInst* memInst , uint8_t column, uint8_t row, uint16_t bdId, uint64_t offset);

--- a/src/runtime_src/core/edge/user/aie/common_layer/adf_runtime_api.h
+++ b/src/runtime_src/core/edge/user/aie/common_layer/adf_runtime_api.h
@@ -68,7 +68,9 @@ public:
   virtual ~gmio_api() {}
 
   err_code configure();
-  err_code enqueueBD(XAie_MemInst *memInst, uint64_t offset, size_t size);
+  void getAvailableBDs();
+  std::pair<size_t, size_t> enqueueBD(XAie_MemInst *memInst, uint64_t offset, size_t size);
+  bool gmio_status(uint16_t bdNum, uint32_t bdInstance);
   err_code wait();
   err_code enqueueTask(std::vector<dma_api::buffer_descriptor> bdParams, uint32_t repeatCount, bool enableTaskCompleteToken);
   std::shared_ptr<config_manager>
@@ -88,6 +90,7 @@ private:
   uint8_t dmaStartQMaxSize;
   std::queue<size_t> enqueuedBDs;
   std::queue<size_t> availableBDs;
+  std::unordered_map<size_t, size_t> statusBDs;
   std::shared_ptr<config_manager> config;
 };
 

--- a/src/runtime_src/core/include/xrt/xrt_aie.h
+++ b/src/runtime_src/core/include/xrt/xrt_aie.h
@@ -60,6 +60,20 @@ public:
   using access_mode = xrt::aie::access_mode;
 
   /**
+   * @enum buffer_state - aie buffer object state
+   *
+   * @var idle
+   *   Newly created aie buffer object. Ready to perform an asynchronous operation. Not allowed
+   *   to access the status of the aie buffer object at this state.
+   * @var running
+   *   An asynchronous operation is already initiated. Not allowed to initiate another asynchronous
+   *   operation.
+   * @var completed
+   *   The initiated asynchronous operation is completed.
+   */
+  enum class buffer_state { idle, running, completed };
+
+  /**
    * device() - Construct device with specified access mode
    *
    * @param args
@@ -494,6 +508,11 @@ public:
    * This configures the required BDs , enqueues the task
    */
   void async(xrt::bo ping, xrt::bo pong, xclBOSyncDirection dir, size_t size, size_t offset) const;
+
+  /**
+   * async_status() - This function gets the status of the previously initiated async operation
+   */
+  device::buffer_state async_status() const;
 
   /**
    * wait() - This function waits for the previously initiated async operation


### PR DESCRIPTION
* Added status support for gmio and ext buffers


(cherry picked from commit 7c3edf3ca9e45f32d249003c08126197fdc962b8)

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1210116
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
