### PR TITLE
[XDP] Read metadata from xclbin for VE2

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info_database.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info_database.cpp
@@ -1516,7 +1516,7 @@ namespace xdp {
                              std::unique_ptr<xdp::Device> xdpDevice)
   {
     xrt::uuid new_xclbin_uuid;
-    //TODO:: Getting xclbin_uuid should be unified for both Client and Telluride.
+    //TODO:: Getting xclbin_uuid should be unified for both Client and VE2.
     if(isClient()) {
       new_xclbin_uuid = device->get_xclbin_uuid();
     }
@@ -1542,7 +1542,7 @@ namespace xdp {
     if (!resetDeviceInfo(deviceId, xdpDevice.get(), new_xclbin_uuid))
       return;
     xrt::xclbin xrtXclbin = device->get_xclbin(new_xclbin_uuid);
-    updateDevice(deviceId, xrtXclbin, std::move(xdpDevice), true, readAIEMetadata);
+    updateDevice(deviceId, xrtXclbin, std::move(xdpDevice), isClient(), readAIEMetadata);
   }
 
   // Return true if we should reset the device information.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
For VE2, metadata was being read from disk instead of xclbin.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://github.com/Xilinx/XRT/commit/46a8ea282ce54c396d55c1b3c1bfcbcbcc90490e
#### How problem was solved, alternative solutions (if any) and why they were rejected
Check whether it is a client build or VE2 build and based on that read from xclbin if it is VE2 build.
#### Risks (if any) associated the changes in the commit
Low risk as the change has already been submitted to master branch.
#### What has been tested and how, request additional testing if necessary
Tested a VE2 design.
#### Documentation impact (if any)
NA