### PR TITLE
CMake: Win: use find_package(Boost CONFIG) lastest cmake

### DIFF
--- a/src/CMake/boostUtil.cmake
+++ b/src/CMake/boostUtil.cmake
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
 
 # Support building XRT or its components with local build of Boost libraries. 
 # In particular the script runtime_src/tools/script/boost.sh downloads
@@ -8,9 +8,15 @@
 if (DEFINED ENV{XRT_BOOST_INSTALL})
   set(XRT_BOOST_INSTALL $ENV{XRT_BOOST_INSTALL})
   set(Boost_USE_STATIC_LIBS ON)
-  find_package(Boost
-    HINTS $ENV{XRT_BOOST_INSTALL}
-    REQUIRED COMPONENTS system filesystem program_options)
+  if(CMAKE_VERSION VERSION_GREATER "3.29")
+    find_package(Boost CONFIG
+      HINTS $ENV{XRT_BOOST_INSTALL}
+      REQUIRED COMPONENTS system filesystem program_options)
+  else(CMAKE_VERSION VERSION_GREATER "3.29")
+    find_package(Boost
+      HINTS $ENV{XRT_BOOST_INSTALL}
+      REQUIRED COMPONENTS system filesystem program_options)
+  endif(CMAKE_VERSION VERSION_GREATER "3.29")
 
   # A bug in FindBoost maybe?  Doesn't set Boost_LIBRARY_DIRS when
   # Boost install has only static libraries. For static tool linking
@@ -22,8 +28,13 @@ if (DEFINED ENV{XRT_BOOST_INSTALL})
   endif()
 
 else()
-  find_package(Boost
+  if(CMAKE_VERSION VERSION_GREATER "3.29")
+    find_package(Boost CONFIG
     REQUIRED COMPONENTS system filesystem program_options)
+  else(CMAKE_VERSION VERSION_GREATER "3.29")
+    find_package(Boost
+      REQUIRED COMPONENTS system filesystem program_options)
+  endif(CMAKE_VERSION VERSION_GREATER "3.29")
 endif()
 set(Boost_USE_MULTITHREADED ON)             # Multi-threaded libraries
 

--- a/src/CMake/nativeWin.cmake
+++ b/src/CMake/nativeWin.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2019-2022 Xilinx, Inc. All rights reserved.
-# Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
 #
 # This cmake file is for native build. Host and target processor are the same.
 # Custom variables imported by this CMake stub which should be defined by parent CMake:
@@ -23,14 +23,9 @@ endif(GIT_FOUND)
 
 include(CMake/components.cmake)
 
-include(FindBoost)
-set(Boost_USE_MULTITHREADED ON)
-set(Boost_USE_STATIC_LIBS ON)
-find_package(Boost
-  REQUIRED COMPONENTS system filesystem program_options)
-
-# Boost_VERSION_STRING is not working properly, use our own macro
-set(XRT_BOOST_VERSION ${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION}.${Boost_SUBMINOR_VERSION})
+# Boost Libraries
+set(ENV{XRT_BOOST_INSTALL} "${BOOST_ROOT}")
+include (CMake/boostUtil.cmake)
 
 include_directories(${Boost_INCLUDE_DIRS})
 add_compile_definitions("BOOST_LOCALE_HIDE_AUTO_PTR")

--- a/tests/CMake/utils.cmake
+++ b/tests/CMake/utils.cmake
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (C) 2022 Xilinx, Inc. All rights reserved.
+# Copyright (C) 2025 Xilinx, Inc. All rights reserved.
 #
 
 set(CMAKE_CXX_STANDARD 17)
@@ -48,7 +48,11 @@ if (NOT WIN32)
   endif()
 else()
     set(BOOST_ROOT C:/Xilinx/XRT/ext)
-    find_package(Boost)
+    if(CMAKE_VERSION VERSION_GREATER "3.29")
+      find_package(Boost CONFIG)
+    else (CMAKE_VERSION VERSION_GREATER "3.29")
+      find_package(Boost)
+    endif (CMAKE_VERSION VERSION_GREATER "3.29")
     include_directories(${Boost_INCLUDE_DIRS})
 endif(NOT WIN32)
 


### PR DESCRIPTION
Since > CMake 3.29, FindBoost module is removed, it looks for BoostConfig.cmake instead. And thus, we need to change our CMakefile to find boost with find_package to search for BoostConfig.cmake instead. For details, please see https://cmake.org/cmake/help/latest/policy/CMP0167.html

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
This patch is to support CMake 3.30 and above to find Boost package.
`FindBoost` module is removed from CMake 3.30 and above. I installed CMake 4.0 on my Windows11 system, it complains:
```
CMake Warning (dev) at src/xrt/src/CMake/nativeWin.cmake:29 (find_package):
  Policy CMP0167 is not set: The FindBoost module is removed.
```
We need to change CMakeFil to use `find_package(Boost CONFIG)` instead of 
```
include(FindBoost)
find_package(Boost)
```
to find Boost package.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Installed CMake 4.0 on Windows11 when this issue was discovered.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Check if the CMake version is > `3.29`, if yes, use `find_package(Boost CONFIG)` instead of `find_package(Boost)` and removed `include(FindBoost)`.
If you just removed `include(FindBoost)`, CMake can find the Boost module, however, it will reports this warning:
```
CMake Warning (dev) at src/xrt/src/CMake/boostUtil.cmake:25 (find_package):
  Policy CMP0167 is not set: The FindBoost module is removed.  Run "cmake
  --help-policy CMP0167" for policy details.  Use the cmake_policy command to
  set the policy and suppress this warning.
```
To remove the above warning, will need to change to use `find_package(Boost CONFIG)`.

Alternatives, make our project to only support CMake < = 3.29.

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Built on Windows11 with CMake 4.0 installed. requires additional testing with older CMake version which CI is supposed to be used.

#### Documentation impact (if any)
