### PR TITLE
Add support for user to enter xdp_mode (zocl or xdna) via xrt.ini file

### DIFF
--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -160,6 +160,13 @@ get_power_profile_interval_ms()
   return value ;
 }
 
+inline std::string
+get_xdp_mode()
+{
+  static std::string value = detail::get_string_value("Debug.xdp_mode", "zocl");
+  return value;
+}
+
 inline bool
 get_aie_profile()
 {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Added initial support to enter xdp_mode (zocl or xdna) via xrt.ini file

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
This allows device type to be checked in the xdp plugins

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
NA