### PR TITLE
[XDP] Support for X+ML Flow in aie_status plugin for Edge & VE2 flows

### DIFF
--- a/src/runtime_src/core/common/xdp/profile.cpp
+++ b/src/runtime_src/core/common/xdp/profile.cpp
@@ -136,7 +136,7 @@ std::function<void (void*)> end_status_cb;
 void
 register_callbacks(void* handle)
 {
-  #if defined(XDP_CLIENT_BUILD) || defined(XDP_VE2_BUILD)
+  #if defined(XDP_VE2_BUILD)
     using ftype = void (*)(void*);
     using utype = void (*)(void*, bool);
     

--- a/src/runtime_src/core/common/xdp/profile.cpp
+++ b/src/runtime_src/core/common/xdp/profile.cpp
@@ -130,17 +130,18 @@ end_debug(void* handle)
 
 namespace xrt_core::xdp::aie::status {
 
-std::function<void (void*)> update_device_cb;
+std::function<void (void*, bool)> update_device_cb;
 std::function<void (void*)> end_status_cb;
 
 void
 register_callbacks(void* handle)
 {
-  #if defined(XDP_VE2_BUILD)
+  #if defined(XDP_CLIENT_BUILD) || defined(XDP_VE2_BUILD)
     using ftype = void (*)(void*);
-
+    using utype = void (*)(void*, bool);
+    
+    update_device_cb = reinterpret_cast<utype>(xrt_core::dlsym(handle, "updateAIEStatusDevice"));
     end_status_cb = reinterpret_cast<ftype>(xrt_core::dlsym(handle, "endAIEStatusPoll"));
-    update_device_cb = reinterpret_cast<ftype>(xrt_core::dlsym(handle, "updateAIEStatusDevice"));
   #else
     (void)handle;
   #endif
@@ -157,10 +158,10 @@ load()
 
 // Make connections
 void
-update_device(void* handle)
+update_device(void* handle, bool hw_context_flow)
 {
   if (update_device_cb)
-    update_device_cb(handle);
+    update_device_cb(handle, hw_context_flow);
 }
 
 void
@@ -531,7 +532,7 @@ update_device(void* handle, bool hw_context_flow)
       xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT",
         "Failed to load AIE Status library.");
     }
-    xrt_core::xdp::aie::status::update_device(handle);
+    xrt_core::xdp::aie::status::update_device(handle, hw_context_flow);
   }
 
   if (xrt_core::config::get_ml_timeline()) {

--- a/src/runtime_src/core/edge/user/plugin/xdp/aie_status.cpp
+++ b/src/runtime_src/core/edge/user/plugin/xdp/aie_status.cpp
@@ -34,21 +34,17 @@ namespace status {
   }
 
   // Callback from shim to load device information and start polling
-  std::function<void (void*)> update_device_cb;
+  std::function<void (void*, bool)> update_device_cb;
   // Callback from shim to end poll for a device when xclbin changes
   std::function<void (void*)> end_poll_cb;
 
   void register_callbacks(void* handle)
   {
-    using ftype = void (*)(void*); // Device handle
+    using utype = void (*)(void*, bool);
+    using ftype = void (*)(void*);
 
-    update_device_cb = reinterpret_cast<ftype>(xrt_core::dlsym(handle, "updateAIEStatusDevice"));
-    if (xrt_core::dlerror() != nullptr)
-      update_device_cb = nullptr;
-
+    update_device_cb = reinterpret_cast<utype>(xrt_core::dlsym(handle, "updateAIEStatusDevice"));
     end_poll_cb = reinterpret_cast<ftype>(xrt_core::dlsym(handle, "endAIEStatusPoll"));
-    if (xrt_core::dlerror() != nullptr)
-      end_poll_cb = nullptr;
   }
 
   void warning_callbacks()
@@ -59,10 +55,10 @@ namespace status {
 } // end namespace status
 
 namespace sts {
-  void update_device(void* handle)
+  void update_device(void* handle, bool hw_context_flow)
   {
     if (status::update_device_cb != nullptr)
-      status::update_device_cb(handle);
+      status::update_device_cb(handle, hw_context_flow);
   }
 
   void end_poll(void* handle)

--- a/src/runtime_src/core/edge/user/plugin/xdp/aie_status.h
+++ b/src/runtime_src/core/edge/user/plugin/xdp/aie_status.h
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2021 Xilinx, Inc
+ * Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -27,7 +28,7 @@ namespace status {
 } // end namespace status
 
 namespace sts {
-  void update_device(void* handle);
+  void update_device(void* handle, bool hw_context_flow);
   void end_poll(void* handle);
 } // end namespace sts
 

--- a/src/runtime_src/core/edge/user/plugin/xdp/shim_callbacks.h
+++ b/src/runtime_src/core/edge/user/plugin/xdp/shim_callbacks.h
@@ -57,7 +57,7 @@ void update_device(void* handle, bool hw_context_flow)
 #endif
   aie::dbg::update_device(handle); //debug
   aie::ctr::update_device(handle, hw_context_flow); //counters=profiling
-  aie::sts::update_device(handle); //status
+  aie::sts::update_device(handle, hw_context_flow); //status
 }
 
 // The flush_device callback should be called just before a new xclbin
@@ -92,6 +92,7 @@ void finish_flush_device(void* handle)
 #endif
   aie::ctr::end_poll(handle);
   aie::dbg::end_poll(handle);
+  aie::sts::end_poll(handle);
 }
 
 } // end namespace xdp

--- a/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_cb.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_cb.cpp
@@ -24,10 +24,10 @@ namespace xdp {
 
   static AIEStatusPlugin aiePluginInstance;
 
-  static void updateAIEStatusDevice(void* handle)
+  static void updateAIEStatusDevice(void* handle, bool hw_context_flow)
   {
     if (AIEStatusPlugin::alive()) {
-      aiePluginInstance.updateAIEDevice(handle);
+      aiePluginInstance.updateAIEDevice(handle, hw_context_flow);
     }
   }
 
@@ -41,9 +41,9 @@ namespace xdp {
 } // end namespace xdp
 
 extern "C"
-void updateAIEStatusDevice(void* handle)
+void updateAIEStatusDevice(void* handle, bool hw_context_flow)
 {
-  xdp::updateAIEStatusDevice(handle);
+  xdp::updateAIEStatusDevice(handle, hw_context_flow);
 }
 
 extern "C"

--- a/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.cpp
@@ -457,7 +457,7 @@ namespace xdp {
     // Update the static database with information from xclbin
     {
       #ifdef XDP_VE2_BUILD
-        (db->getStaticInfo()).updateDeviceFromCoreDevice(deviceID, device);
+        (db->getStaticInfo()).updateDeviceFromCoreDevice(deviceID, mXrtCoreDevice);
       #else
         (db->getStaticInfo()).updateDeviceFromHandle(deviceID, nullptr, handle);
       #endif

--- a/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.cpp
@@ -422,7 +422,8 @@ namespace xdp {
     while (shouldContinue) {
       if (!(db->getStaticInfo().isDeviceReady(index)))
         continue;
-
+      
+      std::lock_guard<std::mutex> l(mtx_writer_thread);  
       aieWriter->write(false, handle);
       std::this_thread::sleep_for(std::chrono::microseconds(mPollingInterval));
     }
@@ -505,8 +506,9 @@ namespace xdp {
    ***************************************************************************/
   void AIEStatusPlugin::endPollforDevice(void* handle)
   {
-    // Last chance at writing status reports
-    for (auto w : writers)
+    // Last chance at writing status reports 
+    std::lock_guard<std::mutex> l(mtx_writer_thread);
+    for (auto w : writers) 
       w->write(false, handle);
 
     // When ending polling for a device, if we are on edge we must instead

--- a/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.cpp
@@ -423,8 +423,9 @@ namespace xdp {
       if (!(db->getStaticInfo().isDeviceReady(index)))
         continue;
       
-      std::lock_guard<std::mutex> l(mtx_writer_thread);  
+      mtx_writer_thread.lock();
       aieWriter->write(false, handle);
+      mtx_writer_thread.unlock();
       std::this_thread::sleep_for(std::chrono::microseconds(mPollingInterval));
     }
   }

--- a/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.cpp
@@ -428,6 +428,21 @@ namespace xdp {
     }
   }
 
+  uint64_t AIEStatusPlugin::getDeviceIDFromHandle(void* handle)
+  {
+    auto itr = handleToAIEData.find(handle);
+    if (itr != handleToAIEData.end())
+      return itr->second.deviceID;
+
+#ifdef XDP_CLIENT_BUILD
+    return db->addDevice("win_device");
+#elif XDP_VE2_BUILD
+    return db->addDevice("ve2_device");
+#else
+    return db->addDevice(util::getDebugIpLayoutPath(handle));  // Get the unique device Id
+#endif
+  }
+
   /****************************************************************************
    * Update AIE device
    ***************************************************************************/

--- a/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.cpp
@@ -423,9 +423,9 @@ namespace xdp {
       if (!(db->getStaticInfo().isDeviceReady(index)))
         continue;
       
-      mtx_writer_thread.lock();
+      mtxWriterThread.lock();
       aieWriter->write(false, handle);
-      mtx_writer_thread.unlock();
+      mtxWriterThread.unlock();
       std::this_thread::sleep_for(std::chrono::microseconds(mPollingInterval));
     }
   }
@@ -508,9 +508,11 @@ namespace xdp {
   void AIEStatusPlugin::endPollforDevice(void* handle)
   {
     // Last chance at writing status reports 
-    std::lock_guard<std::mutex> l(mtx_writer_thread);
-    for (auto w : writers) 
-      w->write(false, handle);
+    for (auto w : writers) {
+      mtxWriterThread.lock();
+      w->write(false, handle);      
+      mtxWriterThread.unlock();
+    }
 
     // When ending polling for a device, if we are on edge we must instead
     // shut down all of the threads and not just a single one in order

--- a/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.h
@@ -54,7 +54,7 @@ namespace xdp {
     void getTilesForStatus();
     void endPoll();
     std::string getCoreStatusString(uint32_t status);
-    uint64_t getDeviceIDFromHandle(void* handle);
+    uint64_t getDeviceIDFromHandle(void* handle, bool hw_context_flow);
     
     // Threads used by this plugin
     void pollDeadlock(uint64_t index, void* handle);

--- a/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.h
@@ -65,6 +65,7 @@ namespace xdp {
     uint32_t mPollingInterval;
     const aie::BaseFiletypeImpl* metadataReader = nullptr;
     std::shared_ptr<xrt_core::device> mXrtCoreDevice;
+    std::mutex mtx_writer_thread;
 
     // Thread control flags for each device handle
     std::map<void*,std::atomic<bool>> mThreadCtrlMap;

--- a/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.h
@@ -54,6 +54,7 @@ namespace xdp {
     void getTilesForStatus();
     void endPoll();
     std::string getCoreStatusString(uint32_t status);
+    uint64_t getDeviceIDFromHandle(void* handle);
     
     // Threads used by this plugin
     void pollDeadlock(uint64_t index, void* handle);

--- a/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.h
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2021 Xilinx, Inc
- * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2025 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -45,7 +45,7 @@ namespace xdp {
     AIEStatusPlugin();
     ~AIEStatusPlugin();
 
-    void updateAIEDevice(void* handle);
+    void updateAIEDevice(void* handle, bool hw_context_flow);
     void endPollforDevice(void* handle);
 
     static bool alive();

--- a/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.h
@@ -65,7 +65,7 @@ namespace xdp {
     uint32_t mPollingInterval;
     const aie::BaseFiletypeImpl* metadataReader = nullptr;
     std::shared_ptr<xrt_core::device> mXrtCoreDevice;
-    std::mutex mtx_writer_thread;
+    std::mutex mtxWriterThread;
 
     // Thread control flags for each device handle
     std::map<void*,std::atomic<bool>> mThreadCtrlMap;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
1. Added initial support for X+ML flow in aie_status plugin for Edge and VE2
2. Made writing to aie_status file thread-safe 

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
NA

#### How problem was solved, alternative solutions (if any) and why they were rejected
1. Started checking whether XDP hooks are called from hw_context using hw_context_flow variable.
2. Used hw_context hooks and got core device & deviceID from hw_context_impl handle.
3. Added a mutex lock when writing to file to make it thread-safe

#### Risks (if any) associated the changes in the commit
Low risk as the same changes are already done for profile & trace plugin

#### What has been tested and how, request additional testing if necessary
Tested status plugin on Edge

#### Documentation impact (if any)
NA