### PR TITLE
xrt::runner - support validate from file with skip of bytes

### DIFF
--- a/src/runtime_src/core/common/runner/profile.md
+++ b/src/runtime_src/core/common/runner/profile.md
@@ -203,6 +203,7 @@ specified using a `validate` element for the binding.
     {
       "validate": {
         "file": "ofm.bin"
+        "skip": bytes // skip number of bytes in file
       }
     }
 ```

--- a/src/runtime_src/core/common/runner/runner.cpp
+++ b/src/runtime_src/core/common/runner/runner.cpp
@@ -1500,6 +1500,12 @@ class profile
       else {
         // validate against content of a file
         golden_data = repo->get(node.at("file").get<std::string>());
+        auto skip = node.value<size_t>("skip", 0);
+        if (skip > golden_data.size())
+          throw std::runtime_error("skip bytes large than file");
+
+        // Adjust the view, skipping skip bytes
+        golden_data = std::string_view{golden_data.data() + skip, golden_data.size() - skip};
       }
 
       // here we could extract offset and size of region to validate
@@ -1622,7 +1628,7 @@ class profile
       else if (node.value<bool>("random", false))
         init_buffer_random(bo, node);
       else
-        throw profile_error("Unsupported initialziation node in profile");
+        throw profile_error("Unsupported initialization node in profile");
 
       if (node.value<bool>("debug", false)) {
         static uint64_t count = 0;


### PR DESCRIPTION
#### Problem solved by the commit
```
    {
      "validate": {
        "file": "ofm.bin",
        "skip": bytes     // skip number of bytes in file
      }
    }
```
