### PR TITLE
Add new config_bo API for sending metadata of bo to driver

### DIFF
--- a/src/runtime_src/core/common/api/bo_int.h
+++ b/src/runtime_src/core/common/api/bo_int.h
@@ -21,6 +21,16 @@ get_buffer_handle(const xrt::bo& bo);
 size_t
 get_offset(const xrt::bo& bo);
 
+// enum for different buffer use flags
+enum class use_type {
+  normal = XRT_BO_USE_NORMAL,
+  debug = XRT_BO_USE_DEBUG,
+  kmd = XRT_BO_USE_KMD,
+  dtrace = XRT_BO_USE_DTRACE,
+  log = XRT_BO_USE_LOG,
+  debug_queue = XRT_BO_USE_DEBUG_QUEUE
+};
+
 // create_bo_helper() - Create a buffer object within a hwctx for specific
 // use case
 //
@@ -28,42 +38,18 @@ get_offset(const xrt::bo& bo);
 // doesnt use 64 bit flags. So this function acts as an extension to create buffer
 // with specific use flag (debug/dtrace/log).
 xrt::bo
-create_bo_helper(const xrt::hw_context& hwctx, size_t sz, uint32_t use_flag);
-
-// TODO : cleanup below create_debug_bo and create_dtrace_bo APIs after metadata
-// bo design changes are checked in.
-
-// create_debug_bo() - Create a debug buffer object within a hwctx
-//  
-// Allocates a debug buffer object within a hwctx. The debug BO
-// is for sharing of driver / firmware data with user space XRT.
-// The shim allocation is through hwctx_handle::alloc_bo with
-// the XRT_BO_USE_DEBUG flag captured in extension flags.
-XRT_CORE_COMMON_EXPORT
-xrt::bo
-create_debug_bo(const xrt::hw_context& hwctx, size_t sz);
-
-// create_dtrace_bo() - Create a trace buffer object within a hwctx
-//
-// Allocates a buffer object within a hwctx used for dynamic tracing.
-// The BO is used by driver / firmware to fill dynamic tracing data
-// and is shared with user space XRT.
-// The shim allocation is through hwctx_handle::alloc_bo with
-// the XRT_BO_USE_DTRACE flag captured in extension flags.
-XRT_CORE_COMMON_EXPORT
-xrt::bo
-create_dtrace_bo(const xrt::hw_context& hwctx, size_t sz);
+create_bo(const xrt::hw_context& hwctx, size_t sz, use_type type);
 
 // config_bo() - Configure the buffer object for the given use case (based on
 // the flag passed)
 //
 // Configure the buffer object to be used for debug, dtrace, log, debug queue
-// purpose based on the flag passed. The buffer object is tied to a slot using
+// purpose based on buffer type. The buffer object is tied to a slot using
 // the hw ctx that is used to create the bo. A map of uc or column index and
 // buffer size is used to split the buffer among the columns in the partition/slot.
 XRT_CORE_COMMON_EXPORT
 void
-config_bo(const xrt::bo& bo, uint32_t flag, const std::map<uint32_t, size_t>& buf_sizes);
+config_bo(const xrt::bo& bo, const std::map<uint32_t, size_t>& buf_sizes);
 
 // unconfig_bo() - Unconfigure the buffer object configured earlier
 //

--- a/src/runtime_src/core/common/api/bo_int.h
+++ b/src/runtime_src/core/common/api/bo_int.h
@@ -22,21 +22,22 @@ size_t
 get_offset(const xrt::bo& bo);
 
 // enum for different buffer use flags
+// This is for internal use only
 enum class use_type {
-  normal = XRT_BO_USE_NORMAL,
-  debug = XRT_BO_USE_DEBUG,
-  kmd = XRT_BO_USE_KMD,
-  dtrace = XRT_BO_USE_DTRACE,
-  log = XRT_BO_USE_LOG,
-  debug_queue = XRT_BO_USE_DEBUG_QUEUE
+  normal = XRT_BO_USE_NORMAL, // Normal usage
+  debug = XRT_BO_USE_DEBUG, // For debug data
+  kmd = XRT_BO_USE_KMD, // Shared with kernel mode driver
+  dtrace = XRT_BO_USE_DTRACE, // For dynamic trace data
+  log = XRT_BO_USE_LOG, // For logging info
+  debug_queue = XRT_BO_USE_DEBUG_QUEUE // For debug queue data
 };
 
-// create_bo_helper() - Create a buffer object within a hwctx for specific
-// use case
+// create_bo() - Create a buffer object within a hwctx for specific use case
 //
 // Allocates a buffer object within a hwctx. All the public xrt::bo constructors
 // doesnt use 64 bit flags. So this function acts as an extension to create buffer
 // with specific use flag (debug/dtrace/log).
+XRT_CORE_COMMON_EXPORT
 xrt::bo
 create_bo(const xrt::hw_context& hwctx, size_t sz, use_type type);
 

--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -1690,13 +1690,13 @@ get_offset(const xrt::bo& bo)
 }
 
 xrt::bo
-create_bo_helper(const xrt::hw_context& hwctx, size_t sz, uint32_t use_flag)
+create_bo(const xrt::hw_context& hwctx, size_t sz, use_type type)
 {
   xcl_bo_flags flags {0};  // see xrt_mem.h
   flags.flags = XRT_BO_FLAGS_CACHEABLE;
   flags.access = XRT_BO_ACCESS_LOCAL;
   flags.dir = XRT_BO_ACCESS_READ_WRITE;
-  flags.use = use_flag;
+  flags.use = static_cast<uint32_t>(type);
 
   // While the memory group should be ignored (inferred) for
   // debug / trace buffers, it is still passed in as a default
@@ -1705,24 +1705,12 @@ create_bo_helper(const xrt::hw_context& hwctx, size_t sz, uint32_t use_flag)
   return xrt::bo{alloc(device_type{hwctx}, sz, flags.all, 1)};
 }
 
-xrt::bo
-create_debug_bo(const xrt::hw_context& hwctx, size_t sz)
-{
-  return create_bo_helper(hwctx, sz, XRT_BO_USE_DEBUG);
-}
-
-xrt::bo
-create_dtrace_bo(const xrt::hw_context& hwctx, size_t sz)
-{
-  return create_bo_helper(hwctx, sz, XRT_BO_USE_DTRACE);
-}
-
 void
-config_bo(const xrt::bo& bo, uint32_t flag, const std::map<uint32_t, size_t>& buf_sizes)
+config_bo(const xrt::bo& bo, const std::map<uint32_t, size_t>& buf_sizes)
 {
   auto bo_impl = bo.get_handle();
   auto ctx = bo_impl->get_hwctx_handle();
-  bo_impl->get_handle()->config(ctx, flag, buf_sizes);
+  bo_impl->get_handle()->config(ctx, buf_sizes);
 }
 
 void

--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -1689,7 +1689,7 @@ get_offset(const xrt::bo& bo)
   return handle->get_offset();
 }
 
-static xrt::bo
+xrt::bo
 create_bo_helper(const xrt::hw_context& hwctx, size_t sz, uint32_t use_flag)
 {
   xcl_bo_flags flags {0};  // see xrt_mem.h
@@ -1715,6 +1715,22 @@ xrt::bo
 create_dtrace_bo(const xrt::hw_context& hwctx, size_t sz)
 {
   return create_bo_helper(hwctx, sz, XRT_BO_USE_DTRACE);
+}
+
+void
+config_bo(const xrt::bo& bo, uint32_t flag, const std::map<uint32_t, size_t>& buf_sizes)
+{
+  auto bo_impl = bo.get_handle();
+  auto ctx = bo_impl->get_hwctx_handle();
+  bo_impl->get_handle()->config(ctx, flag, buf_sizes);
+}
+
+void
+unconfig_bo(const xrt::bo& bo)
+{
+  auto bo_impl = bo.get_handle();
+  auto ctx = bo_impl->get_hwctx_handle();
+  bo_impl->get_handle()->unconfig(ctx);
 }
 
 } // xrt_core::bo_int

--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -2181,7 +2181,9 @@ class module_sram : public module_impl
     // required data, buffers are synced after data is filled.
     try {
       // below call creates dtrace xrt control buffer and informs driver / firmware with the buffer address
-      m_dtrace_ctrl_bo = xrt_core::bo_int::create_dtrace_bo(m_hwctx, ctrl_buf_size * sizeof(uint32_t));
+      m_dtrace_ctrl_bo = xrt_core::bo_int::create_bo(m_hwctx,
+                                                     ctrl_buf_size * sizeof(uint32_t),
+                                                     xrt_core::bo_int::use_type::dtrace);
       // also create dtrace mem buffer if size is non zero
       if (mem_buf_size) {
         m_dtrace_mem_bo = xrt::bo{ m_hwctx, mem_buf_size * sizeof(uint32_t), xrt::bo::flags::cacheable, 1 /* fix me */ };

--- a/src/runtime_src/core/common/shim/buffer_handle.h
+++ b/src/runtime_src/core/common/shim/buffer_handle.h
@@ -10,9 +10,11 @@
 
 #include <cstdint>
 #include <cstddef>
+#include <map>
 #include <memory>
 
 namespace xrt_core {
+class hwctx_handle; // forward declaration
 
 // class buffer_handle - shim base class for buffer objects
 //
@@ -106,6 +108,25 @@ public:
 
   virtual void
   sync_aie_bo_nb(xrt::bo&, const char *, bo_direction, size_t, size_t)
+  {
+    throw xrt_core::error(std::errc::not_supported, __func__);
+  }
+
+  // Configures the buffer to be used as debug/dtrace/log bo based
+  // on the flag passed. This call creates metadata using map of
+  // column/uc index and buffer sizes and passes the info to driver.
+  virtual void
+  config(xrt_core::hwctx_handle* /*ctx*/, uint32_t /*flag*/,
+         const std::map<uint32_t, size_t>& /*buf_sizes*/)
+  {
+    throw xrt_core::error(std::errc::not_supported, __func__);
+  }
+
+  // Unconfigure the buffer configured earlier
+  // If this call is not made explicitly the derived buffer_handle class
+  // destoryer should handle the unconfiguring part.
+  virtual void
+  unconfig(xrt_core::hwctx_handle*)
   {
     throw xrt_core::error(std::errc::not_supported, __func__);
   }

--- a/src/runtime_src/core/common/shim/buffer_handle.h
+++ b/src/runtime_src/core/common/shim/buffer_handle.h
@@ -112,12 +112,11 @@ public:
     throw xrt_core::error(std::errc::not_supported, __func__);
   }
 
-  // Configures the buffer to be used as debug/dtrace/log bo based
-  // on the flag passed. This call creates metadata using map of
-  // column/uc index and buffer sizes and passes the info to driver.
+  // Configures the buffer to be used as debug/dtrace/log bo using
+  // the flag that is used to create this bo. This call creates metadata
+  // using map of column/uc index and buffer sizes and passes the info to driver.
   virtual void
-  config(xrt_core::hwctx_handle* /*ctx*/, uint32_t /*flag*/,
-         const std::map<uint32_t, size_t>& /*buf_sizes*/)
+  config(xrt_core::hwctx_handle* /*ctx*/, const std::map<uint32_t, size_t>& /*buf_sizes*/)
   {
     throw xrt_core::error(std::errc::not_supported, __func__);
   }

--- a/src/runtime_src/core/include/xrt/detail/xrt_mem.h
+++ b/src/runtime_src/core/include/xrt/detail/xrt_mem.h
@@ -70,8 +70,8 @@ struct xcl_bo_flags
       // extension
       uint32_t access : 2;  // [33-32]
       uint32_t dir    : 2;  // [35-34]
-      uint32_t use    : 2;  // [37-36]
-      uint32_t unused : 26; // [63-38]
+      uint32_t use    : 3;  // [38-36]
+      uint32_t unused : 25; // [63-39]
     };
   };
 };
@@ -126,11 +126,25 @@ struct xcl_bo_flags
  * XRT_BO_USE_DTRACE indicates that the buffer will be used to
  * communicate dynamic trace data from driver / firmware back to
  * userspace. At present this type of usage is supported only on Telluride.
+ *
+ * XRT_BO_USE_LOG indicates that the buffer will be used for logging info
+ * from driver / firmware back to userspace.
+ *
+ * XRT_BO_USE_DEBUG_QUEUE indicates that the buffer will be used for
+ * holding debug queue data.
  */
-#define XRT_BO_USE_NORMAL 0
-#define XRT_BO_USE_DEBUG  1
-#define XRT_BO_USE_KMD    2
-#define XRT_BO_USE_DTRACE 3 
+
+// This file is used in driver as well, so using #define instead of
+// constexpr and using NOLINT block to supress clng-tidy warnings
+
+// NOLINTBEGIN
+#define XRT_BO_USE_NORMAL      0
+#define XRT_BO_USE_DEBUG       1
+#define XRT_BO_USE_KMD         2
+#define XRT_BO_USE_DTRACE      3
+#define XRT_BO_USE_LOG         4
+#define XRT_BO_USE_DEBUG_QUEUE 5
+// NOLINTEND
 
 /**
  * XRT Native BO flags

--- a/src/runtime_src/core/tools/common/tests/TestGemm.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestGemm.cpp
@@ -135,7 +135,7 @@ TestGemm::run(std::shared_ptr<xrt_core::device> dev)
   }
 
   // Create 128KB Debug BO to capture TOPS data
-  xrt::bo bo_result = xrt_core::bo_int::create_debug_bo(hwctx, 0x20000);
+  xrt::bo bo_result = xrt_core::bo_int::create_bo(hwctx, 0x20000, xrt_core::bo_int::use_type::debug);
 
   try {
     xrt::run run;

--- a/src/runtime_src/xdp/profile/plugin/aie_debug/client/aie_debug.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_debug/client/aie_debug.cpp
@@ -63,7 +63,7 @@ namespace xdp {
     xrt::bo resultBO;
     uint32_t* output = nullptr;
     try {
-      resultBO = xrt_core::bo_int::create_debug_bo(hwContext, 0x20000);
+      resultBO = xrt_core::bo_int::create_bo(hwContext, 0x20000, xrt_core::bo_int::use_type::debug);
       output = resultBO.map<uint32_t*>();
       memset(output, 0, 0x20000);
     } catch (std::exception& e) {

--- a/src/runtime_src/xdp/profile/plugin/aie_pc/clientDev/aie_pc.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_pc/clientDev/aie_pc.cpp
@@ -334,7 +334,7 @@ namespace xdp {
 
     xrt::bo resultBO;
     try {
-      resultBO = xrt_core::bo_int::create_debug_bo(mHwContext, 0x20000);
+      resultBO = xrt_core::bo_int::create_bo(mHwContext, 0x20000, xrt_core::bo_int::use_type::debug);
     } catch (std::exception& e) {
       std::stringstream msg;
       msg << "Unable to create 128KB buffer for AIE PC Profile results. Cannot get AIE PC Profile info. " << e.what() << std::endl;

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/client/aie_profile.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/client/aie_profile.cpp
@@ -320,7 +320,7 @@ namespace xdp {
     xrt::bo resultBO;
     uint32_t* output = nullptr;
     try {
-      resultBO = xrt_core::bo_int::create_debug_bo(context, 0x20000);
+      resultBO = xrt_core::bo_int::create_bo(context, 0x20000, xrt_core::bo_int::use_type::debug);
       output = resultBO.map<uint32_t*>();
       memset(output, 0, 0x20000);
     } catch (std::exception& e) {

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.cpp
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.cpp
@@ -42,9 +42,10 @@ namespace xdp {
       xrt::bo  mBO;
       ResultBOContainer(void* hwCtxImpl, uint32_t sz)
       {
-        mBO = xrt_core::bo_int::create_debug_bo(
+        mBO = xrt_core::bo_int::create_bo(
                 xrt_core::hw_context_int::create_hw_context_from_implementation(hwCtxImpl),
-                sz);
+                sz,
+                xrt_core::bo_int::use_type::debug);
       }
       ~ResultBOContainer() {}
 

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/ve2/ml_timeline.cpp
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/ve2/ml_timeline.cpp
@@ -43,9 +43,10 @@ namespace xdp {
       xrt::bo  mBO;
       ResultBOContainer(void* hwCtxImpl, uint32_t sz)
       {
-        mBO = xrt_core::bo_int::create_debug_bo(
+        mBO = xrt_core::bo_int::create_bo(
                 xrt_core::hw_context_int::create_hw_context_from_implementation(hwCtxImpl),
-                sz);
+                sz,
+                xrt_core::bo_int::use_type::debug);
       }
       ~ResultBOContainer() {}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Implemented according to design in confluence page - https://amd.atlassian.net/wiki/spaces/~rbramand/pages/870149964/Debug+Dtrace+and+Log+Buffer+Design+in+XRT+for+AIE2PS+AIE4
A new internal config_bo api is added which configures the given buffer to be used as debug / dtrace / log or debug queue buffer based on the flag passed. This buffer is tied to partition/slot based on hwctx used to create the buffer and the buffer is divided among columns of partition based on the map of column/uc index, sizes.
This PR just provides the virtual functions in base buffer_handle class and different shims should implement this function accordingly.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
#### How problem was solved, alternative solutions (if any) and why they were rejected
Provided a new internal config_bo API which can be called after the xrt::bo object is created with required size to configure it for specific use case.

#### Risks (if any) associated the changes in the commit
Provided just template functions so no effect

#### What has been tested and how, request additional testing if necessary
Tested build flow

#### Documentation impact (if any)
NA