### PR TITLE
Added check to verify if XILINX_VITIS varible is set in build_yocto.sh

### DIFF
--- a/build/build_yocto.sh
+++ b/build/build_yocto.sh
@@ -108,6 +108,11 @@ if [ -f $SETTINGS_FILE  ]; then
     source $SETTINGS_FILE
 fi
 
+if [[ -z ${XILINX_VITIS:+x} ]] || [[ ! -d ${XILINX_VITIS} ]]; then
+   echo "XILINX_VITIS is not available. Please source Vitis"
+   exit 1
+fi
+
 #Check if repo is installed and get its version
 if ! command -v repo &> /dev/null; then
     echo "Repo command not found. Installing repo..."


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
XILINX_VITIS must be set to get the xclbinutil executable which is required to generate the XRT rpms

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered


#### How problem was solved, alternative solutions (if any) and why they were rejected
Added check to verify if XILINX_VITIS varible is set in build_yocto.sh

#### Risks (if any) associated the changes in the commit
low

#### What has been tested and how, request additional testing if necessary
Verified by running the script

#### Documentation impact (if any)
NA