### PR TITLE
Enabling AIE Reconfig overhead test to only run in elf flow

### DIFF
--- a/src/runtime_src/core/tools/common/tests/TestAIEReconfigOverhead.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestAIEReconfigOverhead.cpp
@@ -32,19 +32,7 @@ TestAIEReconfigOverhead::run(std::shared_ptr<xrt_core::device> dev)
   boost::property_tree::ptree ptree = get_test_header();
   ptree.erase("xclbin");
 
-  // Check Whether Use ELF or DPU Sequence
-  auto elf = XBValidateUtils::get_elf();
-  std::string xclbin_path; 
-  
-  if (!elf) {
-    xclbin_path = XBValidateUtils::get_xclbin_path(dev, xrt_core::query::xclbin_name::type::validate, ptree);
-    if (XBU::getVerbose())
-      XBValidateUtils::logger(ptree, "Details", "Using DPU Sequence");
-  } else {
-    xclbin_path = XBValidateUtils::get_xclbin_path(dev, xrt_core::query::xclbin_name::type::validate_elf, ptree);
-    if (XBU::getVerbose())
-      XBValidateUtils::logger(ptree, "Details", "Using ELF");
-  }
+  std::string xclbin_path = XBValidateUtils::get_xclbin_path(dev, xrt_core::query::xclbin_name::type::validate_elf, ptree);
 
   if (!std::filesystem::exists(xclbin_path)){
     XBValidateUtils::logger(ptree, "Details", "The test is not supported on this device.");
@@ -67,81 +55,35 @@ TestAIEReconfigOverhead::run(std::shared_ptr<xrt_core::device> dev)
   auto working_dev = xrt::device(dev);
   working_dev.register_xclbin(xclbin);
 
-  size_t instr_size = 0;
-  std::string dpu_instr;
 
   xrt::hw_context hwctx;
   xrt::kernel kernel, kernel_no_op;
 
-  if (!elf) { // DPU
-    try {
-      hwctx = xrt::hw_context(working_dev, xclbin.get_uuid());
-      kernel = xrt::kernel(hwctx, kernelName);
-    } 
-    catch (const std::exception& )
-    {
-      XBValidateUtils::logger (ptree, "Error", "Not enough columns available. Please make sure no other workload is running on the device.");
-      ptree.put("status", XBValidateUtils::test_token_failed);
-      return ptree;
-    }
-
-    const auto seq_name = xrt_core::device_query<xrt_core::query::sequence_name>(dev, xrt_core::query::sequence_name::type::aie_reconfig_overhead);
-    dpu_instr = XBValidateUtils::findPlatformFile(seq_name, ptree);
-    if (!std::filesystem::exists(dpu_instr))
-      return ptree;
-
-    try {
-      instr_size = XBValidateUtils::get_instr_size(dpu_instr); 
-    }
-    catch(const std::exception& ex) {
-      XBValidateUtils::logger(ptree, "Error", ex.what());
-      ptree.put("status", XBValidateUtils::test_token_failed);
-      return ptree;
-    }
-  }
-  else { // ELF
-    const auto elf_name = xrt_core::device_query<xrt_core::query::elf_name>(dev, xrt_core::query::elf_name::type::aie_reconfig_overhead);
-    auto elf_path = XBValidateUtils::findPlatformFile(elf_name, ptree);
-    
-    if (!std::filesystem::exists(elf_path))
-      return ptree;
+  const auto elf_name = xrt_core::device_query<xrt_core::query::elf_name>(dev, xrt_core::query::elf_name::type::aie_reconfig_overhead);
+  auto elf_path = XBValidateUtils::findPlatformFile(elf_name, ptree);
   
-    try {
-      hwctx = xrt::hw_context(working_dev, xclbin.get_uuid());
-      kernel = get_kernel(hwctx, kernelName, elf_path);
-      kernel_no_op = get_kernel(hwctx, kernelName); 
-    } 
-    catch (const std::exception& )
-    {
-      XBValidateUtils::logger (ptree, "Error", "Not enough columns available. Please make sure no other workload is running on the device.");
-      ptree.put("status", XBValidateUtils::test_token_failed);
-      return ptree;
-    }
+  if (!std::filesystem::exists(elf_path))
+    return ptree;
+  
+  try {
+    hwctx = xrt::hw_context(working_dev, xclbin.get_uuid());
+    kernel = get_kernel(hwctx, kernelName, elf_path);
+    kernel_no_op = get_kernel(hwctx, kernelName); 
+  } 
+  catch (const std::exception& )
+  {
+    XBValidateUtils::logger (ptree, "Error", "Not enough columns available. Please make sure no other workload is running on the device.");
+    ptree.put("status", XBValidateUtils::test_token_failed);
+    return ptree;
   }
 
   //Create BOs
   xrt::bo bo_ifm, bo_ofm, bo_inter, bo_instr, bo_instr_no_op, bo_mc;
-  if (!elf) {
-    int argno = 1;
-    bo_ifm = xrt::bo(working_dev, buffer_size, XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(argno++));
-    argno++;
-    bo_ofm = xrt::bo(working_dev, buffer_size, XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(argno++));
-    bo_inter = xrt::bo(working_dev, inter_size, XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(argno++));
-    bo_instr = xrt::bo(working_dev, instr_size*sizeof(int), XCL_BO_FLAGS_CACHEABLE, kernel.group_id(argno));
-    bo_instr_no_op = xrt::bo(working_dev, instr_size*sizeof(int), XCL_BO_FLAGS_CACHEABLE, kernel.group_id(argno++));
-    argno++;
-    bo_mc = xrt::bo(working_dev, 16, XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(argno++));
   
-    XBValidateUtils::init_instr_buf(bo_instr, dpu_instr);
-    //Create ctrlcode with NOPs
-    std::memset(bo_instr_no_op.map<char*>(), 0, instr_size);
-  }
-  else {
-    bo_ifm = xrt::ext::bo{working_dev, buffer_size};
-    bo_ofm = xrt::ext::bo{working_dev, buffer_size};
-    bo_inter = xrt::ext::bo{working_dev, inter_size};
-    bo_mc = xrt::ext::bo{working_dev, 16};
-  }
+  bo_ifm = xrt::ext::bo{working_dev, buffer_size};
+  bo_ofm = xrt::ext::bo{working_dev, buffer_size};
+  bo_inter = xrt::ext::bo{working_dev, inter_size};
+  bo_mc = xrt::ext::bo{working_dev, 16};
 
   // map input buffer
   // Incremental byte pattern
@@ -151,10 +93,6 @@ TestAIEReconfigOverhead::run(std::shared_ptr<xrt_core::device> dev)
 
   //Sync BOs
   bo_ifm.sync(XCL_BO_SYNC_BO_TO_DEVICE);
-  if (!elf) { 
-    bo_instr.sync(XCL_BO_SYNC_BO_TO_DEVICE); 
-    bo_mc.sync(XCL_BO_SYNC_BO_TO_DEVICE);
-  }
 
   //Log
   if(XBU::getVerbose()) { 
@@ -166,11 +104,7 @@ TestAIEReconfigOverhead::run(std::shared_ptr<xrt_core::device> dev)
   for (int i = 0 ;i < itr_count ; i++){
     try{
       xrt::run run;
-      if (!elf) {
-        run = kernel(XBValidateUtils::get_opcode(), bo_ifm, NULL, bo_ofm, bo_inter, bo_instr_no_op, instr_size, bo_mc);
-      } else { 
-        run = kernel_no_op(XBValidateUtils::get_opcode(), 0, 0, bo_ifm, 0, bo_ofm, bo_inter, 0);
-      }
+      run = kernel_no_op(3, 0, 0, bo_ifm, 0, bo_ofm, bo_inter, 0);
 
       // Wait for kernel to be done
       run.wait2();
@@ -192,12 +126,7 @@ TestAIEReconfigOverhead::run(std::shared_ptr<xrt_core::device> dev)
   {
     try{
       xrt::run run;
-      if (!elf) {
-        run = kernel(XBValidateUtils::get_opcode(), bo_ifm, NULL, bo_ofm, bo_inter, bo_instr, instr_size, bo_mc);
-      }
-      else {
-        run = kernel(XBValidateUtils::get_opcode(), 0, 0, bo_ifm, 0, bo_ofm, bo_inter, 0);
-      }
+      run = kernel(3, 0, 0, bo_ifm, 0, bo_ofm, bo_inter, 0);
       // Wait for kernel to be done
       run.wait2();
     }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
This PR updates the aie-reconfig-overhead test to run in elf mode only for it to be automatically enabled on linux.
James has enabled this test in elf mode on linux already. Thus to migrate this test to linux for parity, we should enable it by default in elf mode for window<--> Linux compatibility.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://jira.xilinx.com/browse/VITIS-14542
Opened through linux windows parity work for xrt-smi

#### How problem was solved, alternative solutions (if any) and why they were rejected
Solved through enabling this test in elf mode only

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Tested on xsjstrix45 linux machine :
```
Test 1 [0000:c5:00.1]     : aie-reconfig-overhead                               
    Details               : Array reconfiguration overhead: 3.9 ms
    Test Status           : [PASSED]
```

#### Documentation impact (if any)
None
