### PR TITLE
xdna migration of userspace in submodule xrt

### DIFF
--- a/src/runtime_src/core/edge/user/system_linux.cpp
+++ b/src/runtime_src/core/edge/user/system_linux.cpp
@@ -36,11 +36,9 @@
   #define MACHINE_NODE_PATH ""
 #endif
 
-#ifdef EDGE_VE2
-#include "shim/device.h"
-#endif
-
-#ifdef EDGE_VE2_XDNA
+#ifdef XDNA_VE2
+#include "shim_ve2/xdna_device.h"
+#elif defined(EDGE_VE2_XDNA)
 #include "shim/xdna_device.h"
 #endif
 

--- a/src/runtime_src/xdp/profile/device/aie_trace/ve2/aie_trace_offload_ve2.cpp
+++ b/src/runtime_src/xdp/profile/device/aie_trace/ve2/aie_trace_offload_ve2.cpp
@@ -25,8 +25,13 @@
 #include "core/common/shim/hwctx_handle.h"
 #include "core/include/xrt/xrt_hw_context.h"
 #include "core/common/api/hw_context_int.h"
+#ifdef XDNA_VE2
+#include "shim_ve2/xdna_hwctx.h"
+#include "shim_ve2/xdna_aie_array.h"
+#else
 #include "shim/xdna_hwctx.h"
 #include "shim/xdna_aie_array.h"
+#endif
 #include "xdp/profile/database/database.h"
 #include "xdp/profile/database/static_info/aie_constructs.h"
 #include "xdp/profile/device/aie_trace/ve2/aie_trace_logger_ve2.h"

--- a/src/runtime_src/xdp/profile/plugin/aie_debug/ve2/aie_debug.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_debug/ve2/aie_debug.cpp
@@ -38,7 +38,11 @@
 #include "core/include/experimental/xrt-next.h"
 #include "core/common/shim/hwctx_handle.h"
 #include "core/common/api/hw_context_int.h"
+#ifdef XDNA_VE2
+#include "shim_ve2/xdna_hwctx.h"
+#else
 #include "shim/xdna_hwctx.h"
+#endif
  
 
 #include "xdp/profile/database/static_info/aie_util.h"

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/ve2/aie_profile.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/ve2/aie_profile.cpp
@@ -35,7 +35,11 @@
 #include "core/include/xrt/xrt_kernel.h"
 #include "core/common/shim/hwctx_handle.h"
 #include "core/common/api/hw_context_int.h"
+#ifdef XDNA_VE2
+#include "shim_ve2/xdna_hwctx.h"
+#else
 #include "shim/xdna_hwctx.h"
+#endif
 #include "xdp/profile/database/database.h"
 #include "xdp/profile/database/static_info/aie_constructs.h"
 #include "xdp/profile/database/static_info/pl_constructs.h"

--- a/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.cpp
@@ -39,7 +39,11 @@
 #ifdef XDP_VE2_BUILD
 #include "core/common/shim/hwctx_handle.h"
 #include "core/common/api/hw_context_int.h"
+#ifdef XDNA_VE2
+#include "shim_ve2/xdna_hwctx.h"
+#else
 #include "shim/xdna_hwctx.h"
+#endif
 #else
 #include "core/edge/user/shim.h"
 #endif

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -39,7 +39,11 @@
 #include "ve2/aie_trace.h"
 #include "xdp/profile/device/hal_device/xdp_hal_device.h"
 #include "core/common/shim/hwctx_handle.h"
+#ifdef XDNA_VE2
+#include "shim_ve2/xdna_hwctx.h"
+#else
 #include "shim/xdna_hwctx.h"
+#endif
 #else
 #include "edge/aie_trace.h"
 #include "xdp/profile/device/hal_device/xdp_hal_device.h"

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/ve2/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/ve2/aie_trace.cpp
@@ -33,7 +33,11 @@
 #include "core/include/xrt/xrt_kernel.h"
 #include "core/common/shim/hwctx_handle.h"
 #include "core/common/api/hw_context_int.h"
+#ifdef XDNA_VE2
+#include "shim_ve2/xdna_hwctx.h"
+#else
 #include "shim/xdna_hwctx.h"
+#endif
 #include "xdp/profile/database/database.h"
 #include "xdp/profile/database/events/creator/aie_trace_data_logger.h"
 #include "xdp/profile/database/static_info/aie_constructs.h"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

As part of "XDNA migration of userspace" (moving Telluride VE2 shim under XDNA repo, added changes which should be part of xrt (submodule of XDNA repo) , these are partial changes , full changes will be enabled when complete changes are raised in Telluride , XDNA repo's

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

N/A

#### How problem was solved, alternative solutions (if any) and why they were rejected

We can maintain single public repo of "XDNA" for the development of Telluride set of devices rather than maintaining different repo's.

#### Risks (if any) associated the changes in the commit

N/A

#### What has been tested and how, request additional testing if necessary

bo_sharing import-export import-export-across-process mem_ops multi-layer multi_partition multi_runs runlist simple_int8 vadd

#### Documentation impact (if any)

N/A