### PR TITLE
[XDP] Load aie_profile plugin library based on device type for VE2

### DIFF
--- a/src/runtime_src/core/common/xdp/profile.cpp
+++ b/src/runtime_src/core/common/xdp/profile.cpp
@@ -626,39 +626,45 @@ update_device(void* handle, bool hw_context_flow)
   if (xrt_core::config::get_aie_profile()) {
     if (xrt_core::config::get_xdp_mode() == "xdna") {
       xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT",
-        "VE2 XDNA is set. Profiling will be available only for XDNA device.");
+        "xdp_mode config is set to XDNA. Hence, profiling will be available only for XDNA device.");
 
       try {
         xrt_core::xdp::aie::profile::load_xdna();
-        try {
-          xrt_core::xdp::aie::profile::update_device(handle, hw_context_flow);
-        }
-        catch (...) {
-          xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT",
-              "Update device for AIE Profile VE2 XDNA failed.");
-        }
       }
-      catch (...) {
-        xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT",
-            "Failed to load AIE Profile library for VE2 XDNA.");
+      catch (const std::exception &e) {
+        std::stringstream msg;
+        msg << "Failed to load AIE Profile library for XDNA device. Caught exception " << e.what();
+        xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT", msg.str());
+      }
+
+      try {
+        xrt_core::xdp::aie::profile::update_device(handle, hw_context_flow);
+      }
+      catch (const std::exception &e) {
+        std::stringstream msg;
+        msg << "Update device for AIE Profile VE2 XDNA failed. Caught exception " << e.what();
+        xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT", msg.str());
       }
     }
     else {
       xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT",
-        "VE2 XDNA is NOT set. Profiling will be available only for ZOCL device.");
+        "xdp_mode config is set to ZOCL. Hence, profiling will be available only for ZOCL device.");
       try {
         xrt_core::xdp::aie::profile::load();
-        try {
-          xrt_core::xdp::aie::profile::update_device(handle, hw_context_flow);
-        }
-        catch (...) {
-          xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT",
-              "Update device for AIE Profile VE2 Non-XDNA failed.");
-        }
       }
-      catch (...) {
-        xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT",
-            "Failed to load AIE Profile library for VE2 Non-XDNA.");
+      catch (const std::exception &e) {
+        std::stringstream msg;
+        msg << "Failed to load AIE Profile library for ZOCL device. Caught exception " << e.what();
+        xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT", msg.str());
+      }
+
+      try {
+        xrt_core::xdp::aie::profile::update_device(handle, hw_context_flow);
+      }
+      catch (const std::exception &e) {
+        std::stringstream msg;
+        msg << "Update device for AIE Profile VE2 ZOCL failed. Caught exception " << e.what();
+        xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT", msg.str());
       }
     }
   }

--- a/src/runtime_src/core/common/xdp/profile.cpp
+++ b/src/runtime_src/core/common/xdp/profile.cpp
@@ -633,7 +633,7 @@ update_device(void* handle, bool hw_context_flow)
       }
       catch (const std::exception &e) {
         std::stringstream msg;
-        msg << "Failed to load AIE Profile library for XDNA device. Caught exception " << e.what();
+        msg << "Failed to load AIE Profile library for XDNA mode. Caught exception " << e.what();
         xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT", msg.str());
       }
 
@@ -654,7 +654,7 @@ update_device(void* handle, bool hw_context_flow)
       }
       catch (const std::exception &e) {
         std::stringstream msg;
-        msg << "Failed to load AIE Profile library for ZOCL device. Caught exception " << e.what();
+        msg << "Failed to load AIE Profile library for ZOCL mode. Caught exception " << e.what();
         xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT", msg.str());
       }
 

--- a/src/runtime_src/core/common/xdp/profile.cpp
+++ b/src/runtime_src/core/common/xdp/profile.cpp
@@ -642,7 +642,7 @@ update_device(void* handle, bool hw_context_flow)
       }
       catch (const std::exception &e) {
         std::stringstream msg;
-        msg << "Update device for AIE Profile VE2 XDNA failed. Caught exception " << e.what();
+        msg << "Failed to setup for AIE Profile XDNA failed. Caught exception " << e.what();
         xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT", msg.str());
       }
     }
@@ -663,7 +663,7 @@ update_device(void* handle, bool hw_context_flow)
       }
       catch (const std::exception &e) {
         std::stringstream msg;
-        msg << "Update device for AIE Profile VE2 ZOCL failed. Caught exception " << e.what();
+        msg << "Failed to setup for AIE Profile ZOCL failed. Caught exception " << e.what();
         xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT", msg.str());
       }
     }

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_plugin.cpp
@@ -111,7 +111,7 @@ namespace xdp {
       return;
 
     auto device = util::convertToCoreDevice(handle, hw_context_flow);
-
+#ifdef XDP_VE2_BUILD
     if (1 == device->get_device_id() && xrt_core::config::get_xdp_mode() == "xdna") {  // Device 0 for xdna(ML) and device 1 for zocl(PL)
       xrt_core::message::send(severity_level::warning, "XRT", "Got Non-XDNA device when VE2 XDNA flow is set. AIE Profiling is not yet supported for this combination.");
       return;
@@ -120,6 +120,7 @@ namespace xdp {
       xrt_core::message::send(severity_level::warning, "XRT", "Got XDNA device when VE2 XDNA flow is not set. AIE Profiling is not yet supported for this combination.");
       return;
     }
+#endif
 
     auto deviceID = getDeviceIDFromHandle(handle, hw_context_flow);
     // Update the static database with information from xclbin

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_plugin.cpp
@@ -113,11 +113,11 @@ namespace xdp {
     auto device = util::convertToCoreDevice(handle, hw_context_flow);
 #ifdef XDP_VE2_BUILD
     if (1 == device->get_device_id() && xrt_core::config::get_xdp_mode() == "xdna") {  // Device 0 for xdna(ML) and device 1 for zocl(PL)
-      xrt_core::message::send(severity_level::warning, "XRT", "Got Non-XDNA device when VE2 XDNA flow is set. AIE Profiling is not yet supported for this combination.");
+      xrt_core::message::send(severity_level::warning, "XRT", "Got ZOCL device when xdp_config mode is set to XDNA. AIE Profiling is not yet supported for this combination.");
       return;
     }
     else if(0 == device->get_device_id() && xrt_core::config::get_xdp_mode() == "zocl") {
-      xrt_core::message::send(severity_level::warning, "XRT", "Got XDNA device when VE2 XDNA flow is not set. AIE Profiling is not yet supported for this combination.");
+      xrt_core::message::send(severity_level::warning, "XRT", "Got XDNA device when xdp_config mode is set to ZOCL. AIE Profiling is not yet supported for this combination.");
       return;
     }
 #endif

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_plugin.cpp
@@ -91,6 +91,7 @@ namespace xdp {
       return itr->second.deviceID;
 
 #ifdef XDP_CLIENT_BUILD
+    (void)(hw_context_flow);
     return db->addDevice("win_device");
 #else
     if (hw_context_flow)
@@ -111,7 +112,7 @@ namespace xdp {
       return;
 
     auto device = util::convertToCoreDevice(handle, hw_context_flow);
-#ifdef XDP_VE2_BUILD
+#if ! defined (XRT_X86_BUILD) && ! defined (XDP_CLIENT_BUILD)
     if (1 == device->get_device_id() && xrt_core::config::get_xdp_mode() == "xdna") {  // Device 0 for xdna(ML) and device 1 for zocl(PL)
       xrt_core::message::send(severity_level::warning, "XRT", "Got ZOCL device when xdp_config mode is set to XDNA. AIE Profiling is not yet supported for this combination.");
       return;

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_plugin.h
@@ -36,7 +36,7 @@ namespace xdp {
 
   private:
     virtual void writeAll(bool openNewFiles) override;
-    uint64_t getDeviceIDFromHandle(void* handle);
+    uint64_t getDeviceIDFromHandle(void* handle, bool hw_context_flow);
     void pollAIECounters(const uint32_t index, void* handle);
     void endPoll();
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Load AIE Profile plugin library based on device type (zocl or xdna) provided by the user in xrt.ini fir VE2.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
NA
#### How problem was solved, alternative solutions (if any) and why they were rejected
Check which application is running and based on the information provided in xrt.ini by the user load the appropriate library.
#### Risks (if any) associated the changes in the commit
Low risk.
#### What has been tested and how, request additional testing if necessary
Tested profile plugin on VEK280 board for Edge.
Tested profile plugin on Resnet18 Design for client.
Tested profile plugin for Pl_ml testcase for VE2 where it has AIE used for xdna application but not for zocl application.
Tested profile plugin for a VE2 design where our hooks are being hit from shim layer.
#### Documentation impact (if any)
NA