### PR TITLE
fix patch() API for shim level testing

### DIFF
--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -2434,9 +2434,35 @@ patch(const xrt::module& module, uint8_t* ibuf, size_t sz, const std::vector<std
   auto os_abi = hdl->get_os_abi();
 
   if (os_abi == Elf_Amd_Aie2p || os_abi == Elf_Amd_Aie2p_config) {
-    auto buf_info = hdl->get_instr(idx);
-    patch_index = buf_info.first;
-    inst = &(buf_info.second);
+    switch (type) {
+    case xrt_core::patcher::buf_type::ctrltext : {
+      auto buf_info = hdl->get_instr(idx);
+      patch_index = buf_info.first;
+      inst = &(buf_info.second);
+      break;
+    }
+    case xrt_core::patcher::buf_type::ctrldata : {
+      auto buf_info = hdl->get_ctrlpkt(idx);
+      patch_index = buf_info.first;
+      inst = &(buf_info.second);
+      break;
+    }
+    case xrt_core::patcher::buf_type::preempt_save : {
+      auto buf_info = hdl->get_preempt_save();
+      patch_index = buf_info.first;
+      inst = &(buf_info.second);
+      break;
+    }
+    case xrt_core::patcher::buf_type::preempt_restore : {
+      auto buf_info = hdl->get_preempt_restore();
+      patch_index = buf_info.first;
+      inst = &(buf_info.second);
+      break;
+    }
+    default :
+      throw std::runtime_error("Unknown buffer type passed");
+      break;
+    }
   }
   else if(os_abi == Elf_Amd_Aie2ps) {
     const auto& instr_buf = hdl->get_data();


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
The existing patch() API does not patch save and restore instruction buffer correctly. This PR fixes it.
#### Risks (if any) associated the changes in the commit
Low risk since this API is not called in normal XRT flow.
#### What has been tested and how, request additional testing if necessary
Tested with the shim level test which is also pending to be checked in.