### PR TITLE
[XDP] Fix to report tile master/slave using metricSet used for that tile

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_profile/edge/aie_profile.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/edge/aie_profile.cpp
@@ -160,8 +160,7 @@ namespace xdp {
           0 : static_cast<uint8_t>(tile.stream_ids.at(portnum));
       uint8_t idToReport = (tile.subtype == io_type::GMIO) ? channel : streamPortId;
       uint8_t isChannel  = (tile.subtype == io_type::GMIO) ? 1 : 0;
-      uint8_t isMaster   = (portnum >= tile.is_master_vec.size()) ?
-          0 : static_cast<uint8_t>(tile.is_master_vec.at(portnum));
+      uint8_t isMaster = aie::isInputSet(type, metricSet) ? 0 : 1;
 
       return ((isMaster << PAYLOAD_IS_MASTER_SHIFT)
              | (isChannel << PAYLOAD_IS_CHANNEL_SHIFT) | idToReport);

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/ve2/aie_profile.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/ve2/aie_profile.cpp
@@ -163,8 +163,7 @@ namespace xdp {
           0 : static_cast<uint8_t>(tile.stream_ids.at(portnum));
       uint8_t idToReport = (tile.subtype == io_type::GMIO) ? channel : streamPortId;
       uint8_t isChannel  = (tile.subtype == io_type::GMIO) ? 1 : 0;
-      uint8_t isMaster   = (portnum >= tile.is_master_vec.size()) ?
-          0 : static_cast<uint8_t>(tile.is_master_vec.at(portnum));
+      uint8_t isMaster = aie::isInputSet(type, metricSet)  ? 0 : 1;
 
       return ((isMaster << PAYLOAD_IS_MASTER_SHIFT)
              | (isChannel << PAYLOAD_IS_CHANNEL_SHIFT) | idToReport);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
CR-1239634 - Shim tile profiling table was not displayed.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1239634

#### How problem was solved, alternative solutions (if any) and why they were rejected
Tiles are profiled for input/output category of metric sets as Master & slave. This information is derived using metric set used.
This is also already been used for AIE/Memory tiles.

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
VCK190

#### Documentation impact (if any)
