### PR TITLE
Explicitly load xdp_core for xdp_user_plugin on Windows

### DIFF
--- a/src/runtime_src/core/common/api/xrt_profile.cpp
+++ b/src/runtime_src/core/common/api/xrt_profile.cpp
@@ -124,6 +124,9 @@ register_user_functions(void* handle)
     reinterpret_cast<nsType>(xrt_core::dlsym(handle, "user_event_time_ns_cb"));
 }
 
+#ifdef __linux__
+__attribute__((unused))
+#endif
 static void
 register_callbacks_empty(void*)
 {

--- a/src/runtime_src/core/common/api/xrt_profile.cpp
+++ b/src/runtime_src/core/common/api/xrt_profile.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2020-2022, Xilinx Inc - All rights reserved
- * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2025 Advanced Micro Devices, Inc. - All rights reserved
  * Xilinx Runtime (XRT) Experimental APIs
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
@@ -125,11 +125,28 @@ register_user_functions(void* handle)
 }
 
 static void
+register_callbacks_empty(void*)
+{
+}
+
+static void
+warning_callbacks_empty()
+{
+}
+
+static void
 load_user_profiling_plugin()
 {
+
+#ifdef _WIN32
+  static xrt_core::module_loader xdp_core_loader("xdp_core",
+                                                register_callbacks_empty,
+                                                warning_callbacks_empty);
+#endif
+
   static xrt_core::module_loader user_event_loader("xdp_user_plugin",
                                                    register_user_functions,
-                                                   nullptr);
+                                                   warning_callbacks_empty);
 }
 
 } // end anonymous


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Windows STX fails to open XDP User Plugin dll in some cases. Loading the dependent xdp_core library explicitly resolves the issue.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Issue can be reproduced while running tests on Windows Powershell. Surprisingly, XOAH runs on Win STX does not hit the issue.
#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Win STX
Verified compilation for Linux STX

#### Documentation impact (if any)
