### PR TITLE
Add xrt::runner::json_error for consistency

### DIFF
--- a/src/runtime_src/core/common/runner/runner.cpp
+++ b/src/runtime_src/core/common/runner/runner.cpp
@@ -63,6 +63,7 @@ const json empty_json;
 static json
 load_json(const std::string& input)
 {
+  using json_error = xrt_core::runner::json_error;
   try {
     // Try parse as in-memory json
     return json::parse(input);
@@ -72,10 +73,15 @@ load_json(const std::string& input)
     // Not a valid JSON - treat input as a file path
   }
 
-  if (std::ifstream f{input})
-    return json::parse(f);
+  try {
+    if (std::ifstream f{input})
+      return json::parse(f);
+  }
+  catch (const std::exception& ex) {
+    throw json_error(ex.what());
+  }
 
-  throw std::runtime_error("Failed to open JSON file: " + input);
+  throw std::runtime_error("Failed to load json, unknown error");
 }
 
 // Lifted from xrt_kernel.cpp

--- a/src/runtime_src/core/common/runner/runner.h
+++ b/src/runtime_src/core/common/runner/runner.h
@@ -42,6 +42,11 @@ public:
     what() const noexcept override;
   };
 
+  class json_error : public error
+  {
+    using error::error;
+  };
+
   class recipe_error : public error
   {
     using error::error;


### PR DESCRIPTION
#### Problem solved by the commit
Json parsing errors, while throwing json::exception, the runner will catch and re-throw as xrt::runner::json_error.

