### PR TITLE
CR-1210116: Fixed gmio async status logic

### DIFF
--- a/src/runtime_src/core/edge/user/aie/common_layer/adf_runtime_api.cpp
+++ b/src/runtime_src/core/edge/user/aie/common_layer/adf_runtime_api.cpp
@@ -678,7 +678,7 @@ void gmio_api::getAvailableBDs()
     if (driverStatus != AieRC::XAIE_OK)
         throw xrt_core::error(-EIO, "ERROR: adf::gmio_api::getAvailableBDs: AIE driver error.");
 
-    numBDCompleted = dmaStartQMaxSize - numPendingBDs;
+    numBDCompleted = dmaStartQMaxSize - availableBDs.size() - numPendingBDs;
 
     for (int i = 0; i < numBDCompleted && !enqueuedBDs.empty(); i++)
     {
@@ -762,6 +762,7 @@ err_code gmio_api::wait()
     while (!enqueuedBDs.empty())
     {
         size_t bdNumber = frontAndPop(enqueuedBDs);
+        statusBDs[bdNumber]++;
         availableBDs.push(bdNumber);
     }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Fixed the GMIO async status logic. The logic of checking completed BDs is not proper.
Here is an example: There are 4 channels & 4 BDs corresponds to those channels are available. Here is how we need to calculate completed BDs.
Number of submitted BDs = TotalChannels-free_bds 
Number of Completed BDs = Number of Submitted BDs - pending BDs.  

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
New Feature

#### How problem was solved, alternative solutions (if any) and why they were rejected
Internal testing

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Verified multiple async status cases

#### Documentation impact (if any)
None