### PR TITLE
Compile XDP AIE Profile libraries for both xdna and zocl on VE2 in one build

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_profile/CMakeLists.txt
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/CMakeLists.txt
@@ -7,23 +7,11 @@
 # on Edge, x86, Client, and VE2 platforms that support AIE.
 # ====================================================================
 
-if (XDP_VE2_BUILD_CMAKE STREQUAL "yes")
-  set(IMPL_DIR "${PROFILE_DIR}/plugin/aie_profile/ve2")
-elseif (XDP_CLIENT_BUILD_CMAKE STREQUAL "yes")
-  set(IMPL_DIR "${PROFILE_DIR}/plugin/aie_profile/client")
-elseif (${XRT_NATIVE_BUILD} STREQUAL "yes")
-  set(IMPL_DIR "${PROFILE_DIR}/plugin/aie_profile/x86")
-elseif (DEFINED XRT_AIE_BUILD AND ${XRT_NATIVE_BUILD} STREQUAL "no")
-  set(IMPL_DIR "${PROFILE_DIR}/plugin/aie_profile/edge")
-endif()
-
 file(GLOB AIE_PROFILE_PLUGIN_FILES
   "${PROFILE_DIR}/plugin/aie_profile/*.h"
   "${PROFILE_DIR}/plugin/aie_profile/*.cpp"
   "${PROFILE_DIR}/writer/aie_profile/*.h"
   "${PROFILE_DIR}/writer/aie_profile/*.cpp"
-  "${IMPL_DIR}/*.h"
-  "${IMPL_DIR}/*.cpp"
 )
 file(GLOB AIE_PROFILE_UTIL_FILES
   "${PROFILE_DIR}/plugin/aie_profile/util/aie_profile_util.h"
@@ -38,20 +26,14 @@ file(GLOB AIE_DRIVER_COMMON_UTIL_FILES
   "${PROFILE_DIR}/device/common/*.cpp"
 )
 
-if (XDP_VE2_BUILD_CMAKE STREQUAL "yes")
-  add_library(xdp_aie_profile_plugin MODULE ${AIE_PROFILE_PLUGIN_FILES} ${AIE_PROFILE_UTIL_FILES} ${AIE_PROFILE_CONFIG_FILES})
-  add_dependencies(xdp_aie_profile_plugin xdp_core xrt_coreutil)
-  target_link_libraries(xdp_aie_profile_plugin PRIVATE xdp_core xrt_coreutil xaiengine)
-  target_compile_definitions(xdp_aie_profile_plugin PRIVATE XDP_VE2_BUILD=1 FAL_LINUX="on")
-  target_include_directories(xdp_aie_profile_plugin PRIVATE ${CMAKE_SOURCE_DIR}/src)
-  set_target_properties(xdp_aie_profile_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
+if (XDP_CLIENT_BUILD_CMAKE STREQUAL "yes")
+  set(IMPL_DIR "${PROFILE_DIR}/plugin/aie_profile/client")
 
-  install (TARGETS xdp_aie_profile_plugin
-    LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT}
+  file(GLOB AIE_PROFILE_IMPL_FILES
+    "${IMPL_DIR}/*.h"
+    "${IMPL_DIR}/*.cpp"
   )
-
-elseif (XDP_CLIENT_BUILD_CMAKE STREQUAL "yes")
-  add_library(xdp_aie_profile_plugin MODULE ${AIE_PROFILE_PLUGIN_FILES} ${AIE_DRIVER_COMMON_UTIL_FILES} ${AIE_PROFILE_UTIL_FILES})
+  add_library(xdp_aie_profile_plugin MODULE ${AIE_PROFILE_PLUGIN_FILES} ${AIE_PROFILE_IMPL_FILES} ${AIE_DRIVER_COMMON_UTIL_FILES} ${AIE_PROFILE_UTIL_FILES})
   add_dependencies(xdp_aie_profile_plugin xdp_core xrt_coreutil)
   target_link_libraries(xdp_aie_profile_plugin PRIVATE xdp_core xrt_coreutil xaiengine)
   target_compile_definitions(xdp_aie_profile_plugin PRIVATE XDP_CLIENT_BUILD=1 -DXAIE_FEATURE_MSVC)
@@ -63,7 +45,13 @@ elseif (XDP_CLIENT_BUILD_CMAKE STREQUAL "yes")
   )
 
 elseif (DEFINED XRT_AIE_BUILD AND ${XRT_NATIVE_BUILD} STREQUAL "yes")
-  add_library(xdp_aie_profile_plugin MODULE ${AIE_PROFILE_PLUGIN_FILES})
+  set(IMPL_DIR "${PROFILE_DIR}/plugin/aie_profile/x86")
+
+  file(GLOB AIE_PROFILE_IMPL_FILES
+    "${IMPL_DIR}/*.h"
+    "${IMPL_DIR}/*.cpp"
+  )
+  add_library(xdp_aie_profile_plugin MODULE ${AIE_PROFILE_PLUGIN_FILES} ${AIE_PROFILE_IMPL_FILES})
   add_dependencies(xdp_aie_profile_plugin xdp_core xrt_coreutil)
   target_link_libraries(xdp_aie_profile_plugin PRIVATE xdp_core xrt_coreutil)
   target_compile_definitions(xdp_aie_profile_plugin PRIVATE XRT_X86_BUILD=1)
@@ -74,16 +62,44 @@ elseif (DEFINED XRT_AIE_BUILD AND ${XRT_NATIVE_BUILD} STREQUAL "yes")
     LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT}
   )
 
-elseif (DEFINED XRT_AIE_BUILD AND ${XRT_NATIVE_BUILD} STREQUAL "no")
-  add_library(xdp_aie_profile_plugin MODULE ${AIE_PROFILE_PLUGIN_FILES} ${AIE_PROFILE_UTIL_FILES} ${AIE_PROFILE_CONFIG_FILES})
-  add_dependencies(xdp_aie_profile_plugin xdp_core xrt_coreutil)
-  target_link_libraries(xdp_aie_profile_plugin PRIVATE xdp_core xrt_coreutil xaiengine)
-  target_compile_definitions(xdp_aie_profile_plugin PRIVATE FAL_LINUX="on")
-  set_target_properties(xdp_aie_profile_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
+else()
 
-  install (TARGETS xdp_aie_profile_plugin
-    LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT}
-  )
+  if (XDP_VE2_BUILD_CMAKE STREQUAL "yes")
+    set(IMPL_DIR "${PROFILE_DIR}/plugin/aie_profile/ve2")
+
+    file(GLOB AIE_PROFILE_IMPL_FILES
+      "${IMPL_DIR}/*.h"
+      "${IMPL_DIR}/*.cpp"
+    )
+    add_library(xdp_aie_profile_plugin_xdna MODULE ${AIE_PROFILE_PLUGIN_FILES} ${AIE_PROFILE_IMPL_FILES} ${AIE_PROFILE_UTIL_FILES} ${AIE_PROFILE_CONFIG_FILES})
+    add_dependencies(xdp_aie_profile_plugin_xdna xdp_core xrt_coreutil)
+    target_link_libraries(xdp_aie_profile_plugin_xdna PRIVATE xdp_core xrt_coreutil xaiengine)
+    target_compile_definitions(xdp_aie_profile_plugin_xdna PRIVATE XDP_VE2_BUILD=1 FAL_LINUX="on")
+    target_include_directories(xdp_aie_profile_plugin_xdna PRIVATE ${CMAKE_SOURCE_DIR}/src)
+    set_target_properties(xdp_aie_profile_plugin_xdna PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
+
+    install (TARGETS xdp_aie_profile_plugin_xdna
+      LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT}
+    )
+  endif()
+
+  if (DEFINED XRT_AIE_BUILD AND ${XRT_NATIVE_BUILD} STREQUAL "no")
+    set(IMPL_DIR "${PROFILE_DIR}/plugin/aie_profile/edge")
+
+    file(GLOB AIE_PROFILE_IMPL_FILES
+      "${IMPL_DIR}/*.h"
+      "${IMPL_DIR}/*.cpp"
+    )
+    add_library(xdp_aie_profile_plugin MODULE ${AIE_PROFILE_PLUGIN_FILES} ${AIE_PROFILE_IMPL_FILES} ${AIE_PROFILE_UTIL_FILES} ${AIE_PROFILE_CONFIG_FILES})
+    add_dependencies(xdp_aie_profile_plugin xdp_core xrt_coreutil)
+    target_link_libraries(xdp_aie_profile_plugin PRIVATE xdp_core xrt_coreutil xaiengine)
+    target_compile_definitions(xdp_aie_profile_plugin PRIVATE FAL_LINUX="on")
+    set_target_properties(xdp_aie_profile_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
+
+    install (TARGETS xdp_aie_profile_plugin
+      LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT}
+    )
+  endif()
 
 # Else, on edge-aarch64 don't build at all
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
VE2 supports access via both xdna and zocl. However for now, XDP supports AIE Profile for one at a time. This PR adds support for compiling separate XDP AIE Profile libraries for each of the VE2 backends in one build.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
New support
#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Compilation on VE2, Edge, xdna client, Win Client
Run with AIE Profile xdna plugin on VE2
#### Documentation impact (if any)
