### PR TITLE
Saturating contexts to run kernels in parallel

### DIFF
--- a/src/runtime_src/core/tools/common/tests/TestTemporalSharingOvd.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestTemporalSharingOvd.cpp
@@ -14,7 +14,8 @@
 
 namespace XBU = XBUtilities;
 
-static constexpr size_t num_kernel_iterations = 1000;
+static constexpr size_t num_kernel_iterations = 20;
+static constexpr size_t queue_len = 40;
 
 // Method to run the test
 // Parameters:
@@ -101,7 +102,7 @@ boost::property_tree::ptree TestTemporalSharingOvd::run(std::shared_ptr<xrt_core
   std::vector<TestCase> testcases;
 
   // Create two test cases and add them to the vector
-  TestParams params(xclbin, working_dev, kernelName, elf_path, ifm_file, param_file, buffer_sizes_file, 1, num_kernel_iterations);
+  TestParams params(xclbin, working_dev, kernelName, elf_path, ifm_file, param_file, buffer_sizes_file, queue_len, num_kernel_iterations);
   testcases.emplace_back(params);
   testcases.emplace_back(params);
 
@@ -157,8 +158,8 @@ boost::property_tree::ptree TestTemporalSharingOvd::run(std::shared_ptr<xrt_core
     XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Single context latency: %.1f us") % (latencySingle)));
     XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Temporally shared multiple context latency: %.1f us") % (latencyShared)));
   }
-  auto overhead =  (latencyShared - (2 * latencySingle))/ num_kernel_iterations;
-  XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Overhead: %.1f us") % overhead));
+  auto overhead =  (latencyShared - (2 * latencySingle))/ (num_kernel_iterations * queue_len);
+  XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Overhead: %.1f us") % (overhead > 0.0 ? overhead : 0.0)));
   ptree.put("status", XBValidateUtils::test_token_passed);
 
   return ptree;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
This PR tweaks the parameters in temporal sharing overhead test to saturate hardware context with queue_len number of parallel kernel runs.
In case the overhead comes out to be negative, we report 0 overhead

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://jira.xilinx.com/browse/AIESW-3131

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
tested on strix and kracken machines. The latest numbers are :
strix : 
```
Test 1 [00c5:00:01.1]     : temporal-sharing-overhead
    Description           : Run Temporal Sharing Overhead Test
    Details               : Single context latency: 1843018.0 us
                            Temporally shared multiple context latency: 3688130.6 us
                            Overhead: 2.6 us
    Test Status           : [PASSED]
```
krck
```
Test 1 [00c5:00:01.1]     : temporal-sharing-overhead
    Description           : Run Temporal Sharing Overhead Test
    Details               : Single context latency: 1779994.8 us
                            Temporally shared multiple context latency: 3600556.9 us
                            Overhead: 50.7 us
    Test Status           : [PASSED]
```

#### Documentation impact (if any)
None
