### PR TITLE
Make control code id or kernel instance as string in ELF flow

### DIFF
--- a/src/runtime_src/core/common/api/module_int.h
+++ b/src/runtime_src/core/common/api/module_int.h
@@ -39,6 +39,14 @@ struct kernel_info {
   xrt_core::xclbin::kernel_properties props;
 };
 
+// create module object that will be used with run object
+// The object created holds buffers for instruction/control-pkt
+// These buffers are patched and sent to driver/firmware for execution
+// If module has multiple control codes, ctrl_code_id is used to
+// identify the control code that needs to be run.
+xrt::module
+create_run_module(const xrt::module& parent, const xrt::hw_context& hwctx, std::string ctrl_code_id);
+
 // Fill in ERT command payload in ELF flow. The payload is after extra_cu_mask
 // and before CU arguments.
 uint32_t*

--- a/src/runtime_src/core/common/api/module_int.h
+++ b/src/runtime_src/core/common/api/module_int.h
@@ -45,7 +45,7 @@ struct kernel_info {
 // If module has multiple control codes, ctrl_code_id is used to
 // identify the control code that needs to be run.
 xrt::module
-create_run_module(const xrt::module& parent, const xrt::hw_context& hwctx, std::string ctrl_code_id);
+create_run_module(const xrt::module& parent, const xrt::hw_context& hwctx, const std::string& ctrl_code_id);
 
 // Fill in ERT command payload in ELF flow. The payload is after extra_cu_mask
 // and before CU arguments.

--- a/src/runtime_src/core/common/api/module_int.h
+++ b/src/runtime_src/core/common/api/module_int.h
@@ -52,11 +52,11 @@ patch(const xrt::module&, const std::string& argnm, size_t index, const xrt::bo&
 // Returns patch buffer size of the given module based on buffer type passed
 // This API may be useful for developing unit test case at SHIM level
 // New ELfs pack multiple control codes info in it, to identify which control code
-// to run we use index
+// to run we use ctrl code id
 XRT_CORE_COMMON_EXPORT
 XRT_CORE_UNUSED
 size_t
-get_patch_buf_size(const xrt::module&, xrt_core::patcher::buf_type, uint32_t index = 0);
+get_patch_buf_size(const xrt::module&, xrt_core::patcher::buf_type, const std::string& id = "");
 
 // Extract control code buffer and patch it with addresses from all arguments.
 // This API may be useful for developing unit test case at SHIM level where
@@ -65,12 +65,12 @@ get_patch_buf_size(const xrt::module&, xrt_core::patcher::buf_type, uint32_t ind
 // This API expects buffer type that needs to be patched to identify which buffer
 // to patch (control code, control pkt, save/restore buffer etc)
 // New ELfs pack multiple control codes info in it, to identify which control code
-// to run we use index
+// to run we use ctrl code id
 XRT_CORE_COMMON_EXPORT
 XRT_CORE_UNUSED
 void
 patch(const xrt::module&, uint8_t*, size_t, const std::vector<std::pair<std::string, uint64_t>>*,
-      xrt_core::patcher::buf_type, uint32_t index = 0);
+      xrt_core::patcher::buf_type, const std::string& id = "");
 
 // Patch scalar into control code at given argument
 XRT_CORE_COMMON_EXPORT

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -1991,7 +1991,7 @@ class run_impl
     if (!module)
       return {};
 
-    return {module, hwctx, ctrl_code_id};
+    return xrt_core::module_int::create_run_module(module, hwctx, ctrl_code_id);
   }
 
   virtual std::unique_ptr<arg_setter>

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -1517,7 +1517,7 @@ private:
   {
     // kernel name will be of format - <kernel_name>:<ctrl code index>
     if (auto i = name.find(":"); i != std::string::npos)
-      return name.substr(i+1, name.size()-i-1);
+      return name.substr(i + 1);
 
     return ""; // default case
   }

--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -2372,7 +2372,7 @@ public:
 namespace xrt_core::module_int {
 
 xrt::module
-create_run_module(const xrt::module& parent, const xrt::hw_context& hwctx, std::string ctrl_code_id)
+create_run_module(const xrt::module& parent, const xrt::hw_context& hwctx, const std::string& ctrl_code_id)
 {
   return xrt::module{std::make_shared<xrt::module_sram>(parent.get_handle(), hwctx, ctrl_code_id)};
 }

--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -2371,6 +2371,12 @@ public:
 ////////////////////////////////////////////////////////////////
 namespace xrt_core::module_int {
 
+xrt::module
+create_run_module(const xrt::module& parent, const xrt::hw_context& hwctx, std::string ctrl_code_id)
+{
+  return xrt::module{std::make_shared<xrt::module_sram>(parent.get_handle(), hwctx, ctrl_code_id)};
+}
+
 uint32_t*
 fill_ert_dpu_data(const xrt::module& module, uint32_t* payload)
 {
@@ -2581,11 +2587,6 @@ module(void* userptr, size_t sz, const xrt::uuid& uuid)
 module::
 module(const xrt::module& parent, const xrt::hw_context& hwctx)
 : detail::pimpl<module_impl>{ std::make_shared<module_sram>(parent.handle, hwctx) }
-{}
-
-module::
-module(const xrt::module& parent, const xrt::hw_context& hwctx, std::string ctrl_code_id)
-: detail::pimpl<module_impl>{ std::make_shared<module_sram>(parent.handle, hwctx, ctrl_code_id) }
 {}
 
 xrt::uuid

--- a/src/runtime_src/core/include/xrt/experimental/xrt_module.h
+++ b/src/runtime_src/core/include/xrt/experimental/xrt_module.h
@@ -95,25 +95,13 @@ public:
   XRT_API_EXPORT
   module(const xrt::module& parent, const xrt::hw_context& hwctx);
 
-  /**
-   * module() - Constructor associate module with hardware context
-   *
-   * @param parent
-   *   Parent module with instruction buffer to move into hwctx
-   * @param hwctx
-   *   Hardware context to associate with module
-   * @param ctrl_code_idx
-   *   index of control code inside the parent module
-   *
-   * Copy content of existing module into an allocation associated
-   * with the specified hardware context.
-   * If module has multiple control codes, ctrl code id is used to
-   * identify the control code that needs to be run.
-   *
-   * Throws if module is not compatible with hardware context
-   */
-  XRT_API_EXPORT
-  module(const xrt::module& parent, const xrt::hw_context& hwctx, std::string ctrl_code_id);
+  ///@cond
+  // Undocumented converting constructor using impl only
+  explicit
+  module(std::shared_ptr<module_impl> impl)
+    : detail::pimpl<module_impl>(std::move(impl))
+  {}
+  /// @endcond
 
   /**
    * get_cfg_uuid() - Get the uuid of the hardware configuration

--- a/src/runtime_src/core/include/xrt/experimental/xrt_module.h
+++ b/src/runtime_src/core/include/xrt/experimental/xrt_module.h
@@ -107,13 +107,13 @@ public:
    *
    * Copy content of existing module into an allocation associated
    * with the specified hardware context.
-   * If module has multiple control codes, index is used to identify
-   * the control code that needs to be run.
+   * If module has multiple control codes, ctrl code id is used to
+   * identify the control code that needs to be run.
    *
    * Throws if module is not compatible with hardware context
    */
   XRT_API_EXPORT
-  module(const xrt::module& parent, const xrt::hw_context& hwctx, uint32_t ctrl_code_idx);
+  module(const xrt::module& parent, const xrt::hw_context& hwctx, std::string ctrl_code_id);
 
   /**
    * get_cfg_uuid() - Get the uuid of the hardware configuration


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Made kernel instance or control code id as string instead of uint32_t in ELF flow.
This is done in accordance with change in ELF spec where a kernel like DPU can have instance name as "abc" instead of just having id numbers.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
#### How problem was solved, alternative solutions (if any) and why they were rejected
#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
Tested with new ELF flow on SNL flow and txn cp test case on strix linux hw

#### Documentation impact (if any)
NA