### PR TITLE
Fixing the bo sync logic in zocl

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/common/zocl_bo.c
+++ b/src/runtime_src/core/edge/drm/zocl/common/zocl_bo.c
@@ -763,7 +763,7 @@ int zocl_sync_bo_ioctl(struct drm_device *dev,
 	}
 
 	bo = to_zocl_bo(gem_obj);
-	if (bo->flags & ZOCL_BO_FLAGS_COHERENT) {
+	if (bo->flags & ZOCL_BO_FLAGS_COHERENT && !(bo->flags & ZOCL_BO_FLAGS_CMA)) {
 		/* The CMA buf is coherent, we don't need to do anything */
 		rc = 0;
 		goto out;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/AIESW-3316
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
For CMA we do not used to perform flushing. But its required to do so.
#### How problem was solved, alternative solutions (if any) and why they were rejected
Problem was solved by flushing even for CMA memories.
#### Risks (if any) associated the changes in the commit
n/a
#### What has been tested and how, request additional testing if necessary
Tested the provided testcase on the bugcase area.
Also tested some testcases based on vck190 and vek280 by creating all cma, all ddr, all lpddr BOs.
#### Documentation impact (if any)
