### PR TITLE
AIESW-3158 fix

### DIFF
--- a/src/runtime_src/core/tools/common/XBMain.cpp
+++ b/src/runtime_src/core/tools/common/XBMain.cpp
@@ -89,6 +89,16 @@ void  main_(int argc, char** argv,
     std::cerr << ex.what() << std::endl;
   }
 
+  if (sCmd.empty() && !subcmd_options.empty())
+  {
+    std::string error_str;
+    error_str.append("Unrecognized arguments:\n");
+    for (const auto& option : subcmd_options)
+      error_str.append(boost::str(boost::format("  %s\n") % option));
+    throw boost::program_options::error(error_str);
+  }
+
+
   if(bVersion) {
     std::cout << XBU::get_xrt_pretty_version();
     return;

--- a/src/runtime_src/core/tools/common/XBMain.cpp
+++ b/src/runtime_src/core/tools/common/XBMain.cpp
@@ -85,19 +85,19 @@ void  main_(int argc, char** argv,
   SubCmd::SubCmdOptions subcmd_options;
   try {
     subcmd_options = XBU::process_arguments(vm, parser, allOptions, positionalCommand, false);
+    if (sCmd.empty() && !subcmd_options.empty())
+    {
+      std::string error_str;
+      error_str.append("Unrecognized arguments:\n");
+      for (const auto& option : subcmd_options)
+        error_str.append(boost::str(boost::format("  %s\n") % option));
+      throw boost::program_options::error(error_str);
+    }
   } catch (po::error& ex) {
     std::cerr << ex.what() << std::endl;
+    XBU::report_commands_help( _executable, _description, globalOptions, hiddenOptions, _subCmds);
+    throw xrt_core::error(std::errc::operation_canceled);
   }
-
-  if (sCmd.empty() && !subcmd_options.empty())
-  {
-    std::string error_str;
-    error_str.append("Unrecognized arguments:\n");
-    for (const auto& option : subcmd_options)
-      error_str.append(boost::str(boost::format("  %s\n") % option));
-    throw boost::program_options::error(error_str);
-  }
-
 
   if(bVersion) {
     std::cout << XBU::get_xrt_pretty_version();


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Adds error handling for invalid arguments at xrt-smi global level

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://jira.xilinx.com/browse/AIESW-3158
Discovered through internal testing

#### How problem was solved, alternative solutions (if any) and why they were rejected
Solved by handling the case where unrecognized arguments were present without any subcommand specified

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Tested on Windows platform :
```
W:\Repos\XRT-MCDM-FORK\XRT-MCDM\build\WRelease\xilinx\xrt>xrt-smi --version --v
Unrecognized arguments:
  --v


DESCRIPTION: The XRT - System Management Interface (xrt-smi) is a standalone command-line utility
             that is included with the XRT runtime package. It includes multiple commands to
             configure, examine, and validate supported device(s).

             The reports produced by xrt-smi may be used for device administration, monitoring, and
             troubleshooting application behavior.

USAGE: xrt-smi [--help] [--version] [--verbose] [--batch] [--force] [command [commandArgs]]

AVAILABLE COMMANDS:
  configure  - Device and host configuration
  examine    - Status of the system and device
  program    - Download the acceleration program to a given device
  reset      - Resets the given device
  validate   - Validates the basic device acceleration functionality

OPTIONS:
  --help             - Help to use this application
  --version          - Report the version of XRT and its drivers
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
```

#### Documentation impact (if any)
none
