### PR TITLE
Porting pull request 8927 to 2024.2 branch: Fix Alveo HW Emulation seg fault

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info_database.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info_database.cpp
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2016-2022 Xilinx, Inc
- * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2025 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -396,6 +396,23 @@ namespace xdp {
       return nullptr ;
 
     return config->plDeviceIntf ;
+  }
+
+  // Should only be called from Alveo hardware emulation
+  // because the device interface must be destroyed while the
+  // simulation is still open and we cannot wait until the end of execution.
+  void VPStaticDatabase::removeDeviceIntf(uint64_t deviceId)
+  {
+    std::lock_guard<std::mutex> lock(deviceLock);
+
+    if (deviceInfo.find(deviceId) == deviceInfo.end())
+      return;
+    ConfigInfo* config = deviceInfo[deviceId]->currentConfig();
+    if (!config)
+      return;
+
+    delete config->plDeviceIntf;
+    config->plDeviceIntf = nullptr;
   }
 
   // This function will create a PL Device Interface if an xdp::Device is

--- a/src/runtime_src/xdp/profile/database/static_info_database.h
+++ b/src/runtime_src/xdp/profile/database/static_info_database.h
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2016-2021 Xilinx, Inc
- * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2025 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -267,6 +267,7 @@ namespace xdp {
     XDP_CORE_EXPORT void setDeviceName(uint64_t deviceId, const std::string& name) ;
     XDP_CORE_EXPORT std::string getDeviceName(uint64_t deviceId) ;
     XDP_CORE_EXPORT PLDeviceIntf* getDeviceIntf(uint64_t deviceId) ;
+    XDP_CORE_EXPORT void removeDeviceIntf(uint64_t deviceId);
     XDP_CORE_EXPORT void createPLDeviceIntf(uint64_t deviceId, std::unique_ptr<xdp::Device> xdpDevice, XclbinInfoType xclbinType);
     XDP_CORE_EXPORT uint64_t getKDMACount(uint64_t deviceId) ;
     XDP_CORE_EXPORT void setHostMaxReadBW(uint64_t deviceId, double bw) ;

--- a/src/runtime_src/xdp/profile/plugin/device_offload/hw_emu/hw_emu_device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/hw_emu/hw_emu_device_offload_plugin.cpp
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2022 Xilinx, Inc
- * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2022-2025 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -52,6 +52,14 @@ namespace xdp {
       readTrace() ;
       readCounters() ;
       XDPPlugin::endWrite() ;
+
+      // On Alveo hardware emulation (where there is only one device)
+      // we have to remove the device interface at this point
+      if (!isEdge()) {
+	for (auto deviceId : devicesSeen) {
+	  db->getStaticInfo().removeDeviceIntf(deviceId);
+	}
+      }
       db->unregisterPlugin(this) ;
     }
 


### PR DESCRIPTION
#### Problem solved by the commit
In Alveo HE-Emulation profiling must destroy its device interface while simulation is still live as the shared_ptr<xrt::device> used requires a live simulation when it is reclaimed.  This was fixed in the master branch with pull request 8937.  This is the fix for CR-1240697.

#### Risks (if any) associated the changes in the commit
Low risk, as this is focused only on Alveo hardware emulation.

#### What has been tested and how, request additional testing if necessary
The original failing emulation tests have been verified.

#### Documentation impact (if any)
No documentation impact.