### PR TITLE
Force sync, reading of ML Timeline debug buffer before AIE Trace Offload

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_trace/client/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/client/aie_trace.cpp
@@ -33,6 +33,7 @@
 #include "xdp/profile/device/tracedefs.h"
 #include "xdp/profile/plugin/aie_trace/aie_trace_metadata.h"
 #include "xdp/profile/plugin/aie_trace/util/aie_trace_util.h"
+#include "xdp/profile/plugin/vp_base/info.h"
 
 namespace xdp {
   using severity_level = xrt_core::message::severity_level;
@@ -344,6 +345,11 @@ namespace xdp {
 
   void AieTrace_WinImpl::flushTraceModules()
   {
+    if (db->infoAvailable(xdp::info::ml_timeline)) {
+      db->broadcast(VPDatabase::MessageType::READ_RECORD_TIMESTAMPS, nullptr);
+      xrt_core::message::send(severity_level::debug, "XRT", "Done reading recorded timestamps.");
+    }
+
     if (traceFlushLocs.empty() && memoryTileTraceFlushLocs.empty() 
         && interfaceTileTraceFlushLocs.empty())
       return;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
When a large amount of AIE Event Trace is generated and offloaded by AIE Event Trace Plugin causing a delay, ML Timeline debug buffer sometimes fails to sync the recorded data to host side. This occurs very rarely. To avoid this issue, this PR forces offload of ML Timeline data before AIE Trace.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Test using ML Timeline and AIE Event Trace on Win Client
#### Documentation impact (if any)
