### PR TITLE
Added daemon suboption as default configure subcommand

### DIFF
--- a/src/runtime_src/core/tools/common/SmiDefault.cpp
+++ b/src/runtime_src/core/tools/common/SmiDefault.cpp
@@ -56,6 +56,7 @@ create_configure_subcommand()
   std::map<std::string, std::shared_ptr<xrt_core::smi::option>> configure_suboptions;
   configure_suboptions.emplace("device", std::make_shared<xrt_core::smi::option>("device", "d", "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest", "common", "", "string"));
   configure_suboptions.emplace("help", std::make_shared<xrt_core::smi::option>("help", "h", "Help to use this sub-command", "common", "", "none"));
+  configure_suboptions.emplace("daemon", std::make_shared<xrt_core::smi::option>("daemon", "", "Update the device daemon configuration", "hidden", "", "none"));
 
   return {"configure", "Device and host configuration", "common", std::move(configure_suboptions)};
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1240855 The --daemon suboption was being reported as an unrecognized command when installing the latest XRT package without a device present. This issue does not occur when a device is available.

![image-2025-05-15-13-26-16-295](https://github.com/user-attachments/assets/7bf6e99b-0c5b-4c75-be94-980bfd026bc4)

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
The issue arises because SmiDefault.cpp is used when no device is detected. This file does not include  --daemon command leading to the observed error.

#### How problem was solved, alternative solutions (if any) and why they were rejected
The fix ensures that the --daemon suboption is recognized even when no device is present.

#### Risks (if any) associated the changes in the commit
low

#### What has been tested and how, request additional testing if necessary
Tested by building and running xbmgmt configure --daemon command with and without device.

#### Documentation impact (if any)
NA