### PR TITLE
support dynamic tracing new api

### DIFF
--- a/src/runtime_src/core/common/api/bo_int.h
+++ b/src/runtime_src/core/common/api/bo_int.h
@@ -29,7 +29,8 @@ enum class use_type {
   kmd = XRT_BO_USE_KMD, // Shared with kernel mode driver
   dtrace = XRT_BO_USE_DTRACE, // For dynamic trace data
   log = XRT_BO_USE_LOG, // For logging info
-  debug_queue = XRT_BO_USE_DEBUG_QUEUE // For debug queue data
+  debug_queue = XRT_BO_USE_DEBUG_QUEUE, // For debug queue data
+  uc_debug = XRT_BO_USE_UC_DEBUG // For microblaze debug data
 };
 
 // create_bo() - Create a buffer object within a hwctx for specific use case

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -2520,13 +2520,13 @@ public:
   wait(const std::chrono::milliseconds& timeout_ms) const
   {
     // dump dtrace buffer if ini option is enabled
-    static auto dtrace_lib_path = xrt_core::config::get_dtrace_lib_path();
+    static bool dtrace = !xrt_core::config::get_dtrace_lib_path();
 
     ert_cmd_state state {ERT_CMD_STATE_NEW}; // initial value doesn't matter
     if (timeout_ms.count()) {
       auto [ert_state, cv_status] = cmd->wait(timeout_ms);
       if (cv_status == std::cv_status::timeout) {
-        if (!dtrace_lib_path.empty()) {
+        if (dtrace) {
           xrt_core::module_int::dump_dtrace_buffer(m_module);
 	}
         return ERT_CMD_STATE_TIMEOUT;
@@ -2543,7 +2543,7 @@ public:
     if (dump)
       xrt_core::module_int::dump_scratchpad_mem(m_module);
 
-    if (!dtrace_lib_path.empty())
+    if (dtrace)
       xrt_core::module_int::dump_dtrace_buffer(m_module);
 
     return state;

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -2522,8 +2522,10 @@ public:
     ert_cmd_state state {ERT_CMD_STATE_NEW}; // initial value doesn't matter
     if (timeout_ms.count()) {
       auto [ert_state, cv_status] = cmd->wait(timeout_ms);
-      if (cv_status == std::cv_status::timeout)
-        return ERT_CMD_STATE_TIMEOUT;
+      if (cv_status == std::cv_status::timeout) {
+        state = ERT_CMD_STATE_TIMEOUT;
+	goto done;
+      }
 
       state = ert_state;
     }
@@ -2535,7 +2537,8 @@ public:
     static bool dump = xrt_core::config::get_feature_toggle("Debug.dump_scratchpad_mem");
     if (dump)
       xrt_core::module_int::dump_scratchpad_mem(m_module);
-    
+
+done:  
     // dump dtrace buffer if ini option is enabled
     static auto dtrace_lib_path = xrt_core::config::get_dtrace_lib_path();
     if (!dtrace_lib_path.empty())

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -2520,7 +2520,7 @@ public:
   wait(const std::chrono::milliseconds& timeout_ms) const
   {
     // dump dtrace buffer if ini option is enabled
-    static bool dtrace = !xrt_core::config::get_dtrace_lib_path();
+    static bool dtrace = !xrt_core::config::get_dtrace_lib_path().empty();
 
     ert_cmd_state state {ERT_CMD_STATE_NEW}; // initial value doesn't matter
     if (timeout_ms.count()) {

--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -2202,7 +2202,7 @@ class module_sram : public module_impl
       m_dtrace_ctrl_bo = xrt_core::bo_int::create_bo(m_hwctx,
                                                      total_size * sizeof(uint32_t),
                                                      xrt_core::bo_int::use_type::dtrace);
-      // fill data by calling dtrace library API without mem buffer
+      // fill data by calling dtrace library API
       populate_dtrace_buffer(m_dtrace_ctrl_bo.map<uint32_t*>(), m_dtrace_ctrl_bo.address());
 
       // sync dtrace control buffer

--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -2191,12 +2191,12 @@ class module_sram : public module_impl
       std::map<uint32_t, size_t> buf_sizes;
       size_t total_size = 0;
 
-      const uint32_t MASK32 = 0xffffffff;
-      const uint32_t SHIFT32 = 32;
-      for (const auto& entry : buffers)
-      {//for each entry, lower 32 is the uc index, and upper 32 is the length in word for that uc
-        buf_sizes[static_cast<uint32_t>(entry & MASK32)] = static_cast<size_t>(entry >> SHIFT32);
-	total_size += static_cast<size_t>(entry >> SHIFT32);
+      constexpr uint32_t mask32 = 0xffffffff;
+      constexpr uint32_t shift32 = 32;
+      for (const auto& entry : buffers) {
+        //for each entry, lower 32 is the uc index, and upper 32 is the length in word for that uc
+        buf_sizes[static_cast<uint32_t>(entry & mask32)] = static_cast<size_t>(entry >> shift32);
+	total_size += static_cast<size_t>(entry >> shift32);
       }
       // below call creates dtrace xrt control buffer and informs driver / firmware with the buffer address
       m_dtrace_ctrl_bo = xrt_core::bo_int::create_bo(m_hwctx,

--- a/src/runtime_src/core/include/xrt/detail/xrt_mem.h
+++ b/src/runtime_src/core/include/xrt/detail/xrt_mem.h
@@ -132,6 +132,11 @@ struct xcl_bo_flags
  *
  * XRT_BO_USE_DEBUG_QUEUE indicates that the buffer will be used for
  * holding debug queue data.
+ *
+ * XRT_BO_USE_UC_DEBUG indicates that the buffer will be used to
+ * communicate debug data from microblaze back to user
+ * space. This type of usage is supported on platforms with
+ * microblaze only
  */
 
 // This file is used in driver as well, so using #define instead of
@@ -144,6 +149,7 @@ struct xcl_bo_flags
 #define XRT_BO_USE_DTRACE      3
 #define XRT_BO_USE_LOG         4
 #define XRT_BO_USE_DEBUG_QUEUE 5
+#define XRT_BO_USE_UC_DEBUG    6
 // NOLINTEND
 
 /**


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
1. when app hangs, the already collected dtrace data should still be dumped
2. change to support new dtrace lib ApIs
3. leverage new config_bo() api
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
1. when timeout happens, dump dtrace result first then return
2. use new APIs
#### Risks (if any) associated the changes in the commit
low
#### What has been tested and how, request additional testing if necessary
since driver change and/or fw change are not ready, so there is no e2e test done
but I test with some stub code.
#### Documentation impact (if any)
