### PR TITLE
Fix preemption-overhead test status when not supported

### DIFF
--- a/src/runtime_src/core/tools/common/tests/TestPreeemptionOverhead.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestPreeemptionOverhead.cpp
@@ -145,11 +145,13 @@ TestPreemptionOverhead::run(std::shared_ptr<xrt_core::device> dev)
         noop_exec_time = run_preempt_test(dev, ptree, ncol, level);
       } 
       catch (const std::exception& ex) {
-        XBU::logger(ptree, "Error", ex.what());
-        if (boost::icontains(ex.what(), "not supported"))
+        if (boost::icontains(ex.what(), "not supported")) {
+          XBU::logger(ptree, "Details", "The test is not supported on this device.");
           ptree.put("status", XBU::test_token_skipped);
-        else
+        } else {
+          XBU::logger(ptree, "Error", ex.what());
           ptree.put("status", XBU::test_token_failed);
+        }
         return ptree;
       }
 
@@ -160,11 +162,13 @@ TestPreemptionOverhead::run(std::shared_ptr<xrt_core::device> dev)
         noop_preempt_exec_time = run_preempt_test(dev, ptree, ncol, level);
       } 
       catch (const std::exception& ex) {
-        XBU::logger(ptree, "Error", ex.what());
-        if (boost::icontains(ex.what(), "not supported"))
+        if (boost::icontains(ex.what(), "not supported")) {
+          XBU::logger(ptree, "Details", "The test is not supported on this device.");
           ptree.put("status", XBU::test_token_skipped);
-        else
+        } else {
+          XBU::logger(ptree, "Error", ex.what());
           ptree.put("status", XBU::test_token_failed);
+        }
         return ptree;
       }
 

--- a/src/runtime_src/core/tools/common/tests/TestPreeemptionOverhead.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestPreeemptionOverhead.cpp
@@ -142,11 +142,14 @@ TestPreemptionOverhead::run(std::shared_ptr<xrt_core::device> dev)
       xrt_core::device_update<xq::preemption>(dev.get(), static_cast<uint32_t>(0));
       double noop_exec_time = 0;
       try {
-      noop_exec_time = run_preempt_test(dev, ptree, ncol, level);
+        noop_exec_time = run_preempt_test(dev, ptree, ncol, level);
       } 
       catch (const std::exception& ex) {
         XBU::logger(ptree, "Error", ex.what());
-        ptree.put("status", XBU::test_token_failed);
+        if (boost::icontains(ex.what(), "not supported"))
+          ptree.put("status", XBU::test_token_skipped);
+        else
+          ptree.put("status", XBU::test_token_failed);
         return ptree;
       }
 
@@ -158,7 +161,10 @@ TestPreemptionOverhead::run(std::shared_ptr<xrt_core::device> dev)
       } 
       catch (const std::exception& ex) {
         XBU::logger(ptree, "Error", ex.what());
-        ptree.put("status", XBU::test_token_failed);
+        if (boost::icontains(ex.what(), "not supported"))
+          ptree.put("status", XBU::test_token_skipped);
+        else
+          ptree.put("status", XBU::test_token_failed);
         return ptree;
       }
 


### PR DESCRIPTION
#### Problem solved by the commit
Preemption test fails when not supported (xclbin not available)
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Discovered while testing preemption test for amdxdna
#### How problem was solved, alternative solutions (if any) and why they were rejected
Added a check to put skip token instead of fail token in not supported scenario
#### Risks (if any) associated the changes in the commit
N/A
#### What has been tested and how, request additional testing if necessary
Testing on Linux device.
#### Documentation impact (if any)
N/A