### PR TITLE
Fix AIE Profile for VE2 DSP flow

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_profile/CMakeLists.txt
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/CMakeLists.txt
@@ -93,7 +93,11 @@ else()
     add_library(xdp_aie_profile_plugin MODULE ${AIE_PROFILE_PLUGIN_FILES} ${AIE_PROFILE_IMPL_FILES} ${AIE_PROFILE_UTIL_FILES} ${AIE_PROFILE_CONFIG_FILES})
     add_dependencies(xdp_aie_profile_plugin xdp_core xrt_coreutil)
     target_link_libraries(xdp_aie_profile_plugin PRIVATE xdp_core xrt_coreutil xaiengine)
-    target_compile_definitions(xdp_aie_profile_plugin PRIVATE FAL_LINUX="on")
+    if (XDP_VE2_BUILD_CMAKE STREQUAL "yes")
+      target_compile_definitions(xdp_aie_profile_plugin PRIVATE XDP_VE2_ZOCL_BUILD=1 FAL_LINUX="on")
+    else()
+      target_compile_definitions(xdp_aie_profile_plugin PRIVATE FAL_LINUX="on")
+    endif()
     set_target_properties(xdp_aie_profile_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
 
     install (TARGETS xdp_aie_profile_plugin

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_plugin.cpp
@@ -124,6 +124,13 @@ namespace xdp {
     //TODO: Stop using hw_gen for below check once XRT provides and API to get device type across all hw_gen.
     //      Also remove the relevant header files for both edge and VE2 (query_requests.h, xclbin_int.h). CR-1240834
     else if(0 == device->get_device_id() && xrt_core::config::get_xdp_mode() == "zocl") {
+  #ifdef XDP_VE2_ZOCL_BUILD
+      xrt_core::message::send(severity_level::warning, "XRT", "Got XDNA device when xdp_config mode is set to ZOCL. AIE Profiling is not yet supported for this combination.");
+      return;
+  #else
+      xrt_core::message::send(severity_level::warning, "XRT", "Got EDGE device when xdp_config mode is set to ZOCL. AIE Profiling should be available.");
+  #endif
+/*
       std::vector<xrt_core::query::xclbin_slots::slot_info> xclbin_slot_info;
       try {
         xclbin_slot_info = xrt_core::device_query<xrt_core::query::xclbin_slots>(device.get());
@@ -158,6 +165,7 @@ namespace xdp {
         xrt_core::message::send(severity_level::warning, "XRT", "Got XDNA device when xdp_config mode is set to ZOCL. AIE Profiling is not yet supported for this combination.");
         return;
       }
+*/
     }
 #endif
 

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_plugin.cpp
@@ -118,54 +118,16 @@ namespace xdp {
     auto device = util::convertToCoreDevice(handle, hw_context_flow);
 #if ! defined (XRT_X86_BUILD) && ! defined (XDP_CLIENT_BUILD)
     if (1 == device->get_device_id() && xrt_core::config::get_xdp_mode() == "xdna") {  // Device 0 for xdna(ML) and device 1 for zocl(PL)
-      xrt_core::message::send(severity_level::warning, "XRT", "Got ZOCL device when xdp_config mode is set to XDNA. AIE Profiling is not yet supported for this combination.");
+      xrt_core::message::send(severity_level::warning, "XRT", "Got ZOCL device when xdp_mode is set to XDNA. AIE Profiling is not yet supported for this combination.");
       return;
     }
-    //TODO: Stop using hw_gen for below check once XRT provides and API to get device type across all hw_gen.
-    //      Also remove the relevant header files for both edge and VE2 (query_requests.h, xclbin_int.h). CR-1240834
     else if(0 == device->get_device_id() && xrt_core::config::get_xdp_mode() == "zocl") {
   #ifdef XDP_VE2_ZOCL_BUILD
-      xrt_core::message::send(severity_level::warning, "XRT", "Got XDNA device when xdp_config mode is set to ZOCL. AIE Profiling is not yet supported for this combination.");
+      xrt_core::message::send(severity_level::warning, "XRT", "Got XDNA device when xdp_mode is set to ZOCL. AIE Profiling is not yet supported for this combination.");
       return;
   #else
-      xrt_core::message::send(severity_level::warning, "XRT", "Got EDGE device when xdp_config mode is set to ZOCL. AIE Profiling should be available.");
+      xrt_core::message::send(severity_level::debug, "XRT", "Got EDGE device when xdp_mode is set to ZOCL. AIE Profiling should be available.");
   #endif
-/*
-      std::vector<xrt_core::query::xclbin_slots::slot_info> xclbin_slot_info;
-      try {
-        xclbin_slot_info = xrt_core::device_query<xrt_core::query::xclbin_slots>(device.get());
-      }
-      catch (const std::exception& e) {
-        std::stringstream msg;
-        msg << "Exception occured while retrieving loaded xclbin info: " << e.what();
-        xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT", msg.str());
-      }
-
-      if (xclbin_slot_info.empty())
-        return;
-
-      auto new_xclbin_uuid = xrt::uuid(xclbin_slot_info.back().uuid);
-      xrt::xclbin xrtXclbin = device->get_xclbin(new_xclbin_uuid);
-      auto data = xrt_core::xclbin_int::get_axlf_section(xrtXclbin, AIE_METADATA);
-
-      std::unique_ptr<aie::BaseFiletypeImpl> metadataReader = nullptr;
-      boost::property_tree::ptree aieMetadata;
-      if (data.first && data.second) {
-        metadataReader =
-          aie::readAIEMetadata(data.first, data.second, aieMetadata);
-      }
-      if (!metadataReader)
-      {
-        xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT",
-                              "AIE metadata read failed. Hence, Profiling will not be available.");
-        return;
-      }
-      if(metadataReader->getHardwareGeneration() == 5)
-      {
-        xrt_core::message::send(severity_level::warning, "XRT", "Got XDNA device when xdp_config mode is set to ZOCL. AIE Profiling is not yet supported for this combination.");
-        return;
-      }
-*/
     }
 #endif
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Even for DSP flow on VE2, zocl devices attach to device 0, like older HW generations. As compilation for XDP libraries for DSP flow is still separate (from ML enabled flow) for VE2, AIE Profile library is now built to identify zocl device for zocl mode only. In ML/XDNA enabled compilation, AIE profile library identifies both xdna and zocl nodes and enables aie profiling if matching "xdp_mode" is set.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
 
#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Unit test on VE2
#### Documentation impact (if any)
