### PR TITLE
Unified interface for reporting system time

### DIFF
--- a/src/runtime_src/core/common/detail/linux/systime.h
+++ b/src/runtime_src/core/common/detail/linux/systime.h
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#include "core/common/time.h"
+#include <chrono>
+#include <cstdint>
+#include <cstring>
+#include <tuple>
+
+#include <sys/resource.h>
+
+namespace xrt_core {
+
+class systime_impl
+{
+  using timepoint = xrt_core::systime::timepoint;
+
+  timeval m_kernel_time, m_user_time;
+  uint64_t m_start_time;
+
+  static uint64_t
+  to_nsec(const timeval& tv)
+  {
+    return tv.tv_sec * 1e9 + tv.tv_usec * 1e3;
+  }
+
+public:
+  systime_impl()
+  {
+    start();
+  }
+
+  void
+  start()
+  {
+    struct rusage usage {};
+    getrusage(RUSAGE_SELF, &usage);
+    std::memcpy(&m_user_time, &usage.ru_utime, sizeof(timeval));
+    std::memcpy(&m_kernel_time, &usage.ru_stime, sizeof(timeval));
+    m_start_time = xrt_core::time_ns();
+  }
+
+  std::tuple<timepoint, timepoint, timepoint>
+  get_rusage()
+  {
+    struct rusage usage {};
+    getrusage(RUSAGE_SELF, &usage);
+    return {
+      xrt_core::time_ns() - m_start_time,
+      to_nsec(usage.ru_utime) - to_nsec(m_user_time),
+      to_nsec(usage.ru_stime) - to_nsec(m_kernel_time)
+    };
+  }
+};
+
+} // xrt_core
+
+
+

--- a/src/runtime_src/core/common/detail/systime.h
+++ b/src/runtime_src/core/common/detail/systime.h
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#ifndef core_common_detail_systime_h
+#define core_common_detail_systime_h
+
+#ifdef _WIN32
+# include "core/common/detail/windows/systime.h"
+#else
+# include "core/common/detail/linux/systime.h"
+#endif
+
+
+#endif

--- a/src/runtime_src/core/common/detail/windows/systime.h
+++ b/src/runtime_src/core/common/detail/windows/systime.h
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#include "core/common/time.h"
+#include <chrono>
+#include <tuple>
+#include <windows.h>
+
+namespace xrt_core {
+
+class systime_impl
+{
+  using timepoint = xrt_core::systime::timepoint;
+
+  FILETIME m_kernel_time, m_user_time;
+  uint64_t m_start_time;
+
+  static uint64_t
+  to_uint64(const FILETIME& ft)
+  {
+    ULARGE_INTEGER uli;
+    uli.LowPart = ft.dwLowDateTime;
+    uli.HighPart = ft.dwHighDateTime;
+    return uli.QuadPart;
+  }
+
+public:
+  systime_impl()
+  {
+    start();
+  }
+
+  void
+  start()
+  {
+    FILETIME dummy1, dummy2;
+    GetProcessTimes(GetCurrentProcess(), &dummy1, &dummy2, &m_kernel_time, &m_user_time);
+    m_start_time = xrt_core::time_ns();
+  }
+
+  std::tuple<timepoint, timepoint, timepoint>
+  get_rusage()
+  {
+    FILETIME dummy1, dummy2;
+    FILETIME kernel_time, user_time;
+    GetProcessTimes(GetCurrentProcess(), &dummy1, &dummy2, &kernel_time, &user_time);
+    return {
+      xrt_core::time_ns() - m_start_time,
+      to_uint64(user_time) - to_uint64(m_user_time),
+      to_uint64(kernel_time) - to_uint64(m_kernel_time)
+    };
+  }
+};
+
+} // xrt_core
+
+
+

--- a/src/runtime_src/core/common/time.cpp
+++ b/src/runtime_src/core/common/time.cpp
@@ -1,21 +1,9 @@
-/**
- * Copyright (C) 2016-2017 Xilinx, Inc
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2016-2017 Xilinx, Inc. All rights reserved.
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
 #define XRT_CORE_COMMON_SOURCE
 #include "time.h"
+#include "detail/systime.h" // after time.h, order matters
 
 #include <chrono>
 #include <cstring>
@@ -73,6 +61,35 @@ timestamp(uint64_t epoch)
   time_t rawtime = epoch;
   std::string tmp(ctime(&rawtime));
   return tmp.substr( 0, tmp.length() -1).append(" GMT");
+}
+
+////////////////////////////////////////////////////////////////
+// systime implementation
+// Implmentation is platform specific, the pimpl is inline
+// included from detail/time.h
+////////////////////////////////////////////////////////////////
+systime::
+systime()
+  : m_impl{std::make_unique<systime_impl>()}
+{}
+
+systime::
+~systime() = default;
+
+void
+systime::
+restart()
+{
+  m_impl->start();
+}
+
+// real, user, sys
+using timepoint = systime::timepoint;
+std::tuple<timepoint, timepoint, timepoint>
+systime::
+get_rusage()
+{
+  return m_impl->get_rusage();
 }
 
 } // xrt_core

--- a/src/runtime_src/core/common/time.h
+++ b/src/runtime_src/core/common/time.h
@@ -1,25 +1,14 @@
-/**
- * Copyright (C) 2016-2017 Xilinx, Inc
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2016-2017 Xilinx, Inc. All rights reserved.
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
 #ifndef xrtcore_util_time_h_
 #define xrtcore_util_time_h_
 
 #include "core/common/config.h"
 #include <cstdint>
+#include <memory>
 #include <string>
+#include <tuple>
 
 namespace xrt_core {
 
@@ -63,6 +52,54 @@ public:
     tally += time_ns() - zero;
   }
 };
+
+
+class systime_impl;
+class systime
+{
+  std::unique_ptr<systime_impl> m_impl;
+public:
+  class timepoint
+  {
+    uint64_t m_nanoseconds;
+
+  public:
+    timepoint(uint64_t nsec)
+      : m_nanoseconds{nsec}
+    {}
+
+    double
+    to_nsec() const { return static_cast<double>(m_nanoseconds); }
+
+    double
+    to_usec() const { return static_cast<double>(m_nanoseconds) / 1e3; }
+
+    double
+    to_msec() const { return static_cast<double>(m_nanoseconds) / 1e6; }
+
+    double
+    to_sec() const { return static_cast<double>(m_nanoseconds) / 1e9; }
+  };
+
+  using real_time = timepoint;
+  using user_time = timepoint;
+  using system_time = timepoint;
+
+  XRT_CORE_COMMON_EXPORT
+  systime();
+
+  XRT_CORE_COMMON_EXPORT
+  ~systime();
+
+  XRT_CORE_COMMON_EXPORT
+  void
+  restart();
+
+  // real, user, sys
+  XRT_CORE_COMMON_EXPORT
+  std::tuple<real_time, user_time, system_time>
+  get_rusage();
+}; // class systime
 
 } // xrt_core
 


### PR DESCRIPTION
#### Problem solved by the commit
GetProcessTimes() on Windows and getrusage() on Linux.  Integrate into xrt-runner.exe report.

#### What has been tested and how, request additional testing if necessary
Windows has been tested, Linux not so.

#### Documentation impact (if any)
