### PR TITLE
[XDP] Support for X or ML flow in AIE Trace Plugin

### DIFF
--- a/src/runtime_src/core/common/xdp/profile.cpp
+++ b/src/runtime_src/core/common/xdp/profile.cpp
@@ -31,7 +31,6 @@ namespace {
 // modules.
 
 namespace xrt_core::xdp::core {
-
   void
   load_core()
   {
@@ -345,6 +344,14 @@ load()
                                                 warning_callbacks_empty);
 }
 
+void 
+load_xdna()
+{
+  static xrt_core::module_loader xdp_aie_trace_loader("xdp_aie_trace_plugin_xdna",
+                                                register_callbacks,
+                                                warning_callbacks_empty);
+}
+
 // Make connections
 void 
 update_device(void* handle, bool hw_context_flow)
@@ -573,19 +580,48 @@ update_device(void* handle, bool hw_context_flow)
   }
 
   if (xrt_core::config::get_aie_trace()) {
-    try {
-      xrt_core::xdp::aie::trace::load();
-    } catch (const std::exception &e) {
-      std::stringstream msg;
-      msg << "Failed to load AIE Trace library. Caught exception " << e.what();
-      xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT", msg.str());
+    if (xrt_core::config::get_xdp_mode() == "xdna") {
+      xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT",
+        "xdp_mode config is set to XDNA. Hence, Event Trace will be available only for XDNA device.");
+
+      try {
+        xrt_core::xdp::aie::trace::load_xdna();
+      }
+      catch (const std::exception &e) {
+        std::stringstream msg;
+        msg << "Failed to load AIE Trace library for XDNA mode. Caught exception " << e.what();
+        xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT", msg.str());
+      }
+
+      try {
+        xrt_core::xdp::aie::trace::update_device(handle, hw_context_flow);
+      }
+      catch (const std::exception &e) {
+        std::stringstream msg;
+        msg << "Failed to setup for AIE Trace XDNA. Caught exception " << e.what();
+        xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT", msg.str());
+      }
     }
-    try {
-      xrt_core::xdp::aie::trace::update_device(handle, hw_context_flow);
-    } catch (const std::exception &e) {
-      std::stringstream msg;
-      msg << "Failed to setup for AIE Trace. Caught exception " << e.what();
-      xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT", msg.str());
+    else {
+      xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT",
+        "xdp_mode config is set to ZOCL. Hence, Event Trace will be available only for ZOCL device.");
+      try {
+        xrt_core::xdp::aie::trace::load();
+      }
+      catch (const std::exception &e) {
+        std::stringstream msg;
+        msg << "Failed to load AIE Trace library for ZOCL mode. Caught exception " << e.what();
+        xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT", msg.str());
+      }
+
+      try {
+        xrt_core::xdp::aie::trace::update_device(handle, hw_context_flow);
+      }
+      catch (const std::exception &e) {
+        std::stringstream msg;
+        msg << "Failed to setup for AIE Trace ZOCL. Caught exception " << e.what();
+        xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT", msg.str());
+      }
     }
   }
 
@@ -642,7 +678,7 @@ update_device(void* handle, bool hw_context_flow)
       }
       catch (const std::exception &e) {
         std::stringstream msg;
-        msg << "Failed to setup for AIE Profile XDNA failed. Caught exception " << e.what();
+        msg << "Failed to setup for AIE Profile XDNA. Caught exception " << e.what();
         xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT", msg.str());
       }
     }
@@ -663,7 +699,7 @@ update_device(void* handle, bool hw_context_flow)
       }
       catch (const std::exception &e) {
         std::stringstream msg;
-        msg << "Failed to setup for AIE Profile ZOCL failed. Caught exception " << e.what();
+        msg << "Failed to setup for AIE Profile ZOCL. Caught exception " << e.what();
         xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT", msg.str());
       }
     }

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_plugin.cpp
@@ -41,12 +41,8 @@
 #elif defined(XRT_X86_BUILD)
 #include "x86/aie_profile.h"
 #elif XDP_VE2_BUILD
-#include "core/common/query_requests.h"
-#include "core/common/api/xclbin_int.h"
 #include "ve2/aie_profile.h"
 #else
-#include "core/common/query_requests.h"
-#include "core/common/api/xclbin_int.h"
 #include "core/edge/user/shim.h"
 #include "edge/aie_profile.h"
 #endif

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/CMakeLists.txt
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/CMakeLists.txt
@@ -7,35 +7,12 @@
 # Edge-Versal systems, client and ve2 but not Edge-aarch64.  It also has a dependency
 # on the hardware shim
 # ====================================================================
-if (XDP_VE2_BUILD_CMAKE STREQUAL "yes")
-  set(IMPL_DIR "${PROFILE_DIR}/plugin/aie_trace/ve2")
-  set(OFFLOAD_DIR "${PROFILE_DIR}/device/aie_trace/ve2")
-  set(DEVICE_DIR "${PROFILE_DIR}/device/hal_device")
-elseif (XDP_CLIENT_BUILD_CMAKE STREQUAL "yes")
-  set(IMPL_DIR "${PROFILE_DIR}/plugin/aie_trace/client")
-  set(OFFLOAD_DIR "${PROFILE_DIR}/device/aie_trace/client")
-  set(DEVICE_DIR "${PROFILE_DIR}/device/client_device")
-elseif (${XRT_NATIVE_BUILD} STREQUAL "yes")
-  set(IMPL_DIR "${PROFILE_DIR}/plugin/aie_trace/x86")
-  set(OFFLOAD_DIR "${PROFILE_DIR}/device/aie_trace")
-  set(DEVICE_DIR "${PROFILE_DIR}/device/hal_device")
-elseif (DEFINED XRT_AIE_BUILD AND ${XRT_NATIVE_BUILD} STREQUAL "no")
-  set(IMPL_DIR "${PROFILE_DIR}/plugin/aie_trace/edge")
-  set(OFFLOAD_DIR "${PROFILE_DIR}/device/aie_trace")
-  set(DEVICE_DIR "${PROFILE_DIR}/device/hal_device")
-endif()
 
 file(GLOB AIE_TRACE_PLUGIN_FILES
-  "${OFFLOAD_DIR}/*.h"
-  "${OFFLOAD_DIR}/*.cpp"
-  "${DEVICE_DIR}/*.h"
-  "${DEVICE_DIR}/*.cpp"
   "${PROFILE_DIR}/plugin/aie_trace/*.h"
   "${PROFILE_DIR}/plugin/aie_trace/*.cpp"
   "${PROFILE_DIR}/writer/aie_trace/*.h"
   "${PROFILE_DIR}/writer/aie_trace/*.cpp"
-  "${IMPL_DIR}/*.h"
-  "${IMPL_DIR}/*.cpp"
 )
 file(GLOB AIE_TRACE_UTIL_FILES
   "${PROFILE_DIR}/plugin/aie_trace/util/aie_trace_util.h"
@@ -50,20 +27,21 @@ file(GLOB AIE_DRIVER_COMMON_UTIL_FILES
   "${PROFILE_DIR}/device/common/*.cpp"
 )
 
-if (XDP_VE2_BUILD_CMAKE STREQUAL "yes")
-  add_library(xdp_aie_trace_plugin MODULE ${AIE_TRACE_PLUGIN_FILES} ${AIE_TRACE_UTIL_FILES} ${AIE_TRACE_CONFIG_FILES})
-  add_dependencies(xdp_aie_trace_plugin xdp_core xrt_coreutil)
-  target_link_libraries(xdp_aie_trace_plugin PRIVATE xdp_core xrt_coreutil xaiengine)
-  target_compile_definitions(xdp_aie_trace_plugin PRIVATE XDP_VE2_BUILD=1 FAL_LINUX="on")
-  target_include_directories(xdp_aie_trace_plugin PRIVATE ${CMAKE_SOURCE_DIR}/src)
-  set_target_properties(xdp_aie_trace_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
+if (XDP_CLIENT_BUILD_CMAKE STREQUAL "yes")
+  set(IMPL_DIR "${PROFILE_DIR}/plugin/aie_trace/client")
+  set(OFFLOAD_DIR "${PROFILE_DIR}/device/aie_trace/client")
+  set(DEVICE_DIR "${PROFILE_DIR}/device/client_device")
 
-  install (TARGETS xdp_aie_trace_plugin
-    LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT}
+  file(GLOB AIE_TRACE_COMPONENT_FILES
+    "${OFFLOAD_DIR}/*.h"
+    "${OFFLOAD_DIR}/*.cpp"
+    "${DEVICE_DIR}/*.h"
+    "${DEVICE_DIR}/*.cpp"
+    "${IMPL_DIR}/*.h"
+    "${IMPL_DIR}/*.cpp"
   )
 
-elseif (XDP_CLIENT_BUILD_CMAKE STREQUAL "yes")
-  add_library(xdp_aie_trace_plugin MODULE ${AIE_TRACE_PLUGIN_FILES} ${AIE_TRACE_UTIL_FILES} ${AIE_DRIVER_COMMON_UTIL_FILES})
+  add_library(xdp_aie_trace_plugin MODULE ${AIE_TRACE_PLUGIN_FILES} ${AIE_TRACE_COMPONENT_FILES} ${AIE_TRACE_UTIL_FILES} ${AIE_DRIVER_COMMON_UTIL_FILES})
   add_dependencies(xdp_aie_trace_plugin xdp_core xrt_coreutil)
   target_link_libraries(xdp_aie_trace_plugin PRIVATE xdp_core xrt_coreutil xaiengine)
   target_compile_definitions(xdp_aie_trace_plugin PRIVATE XDP_CLIENT_BUILD=1 -DXAIE_FEATURE_MSVC)
@@ -75,7 +53,20 @@ elseif (XDP_CLIENT_BUILD_CMAKE STREQUAL "yes")
   )
 
 elseif (DEFINED XRT_AIE_BUILD AND ${XRT_NATIVE_BUILD} STREQUAL "yes")
-  add_library(xdp_aie_trace_plugin MODULE ${AIE_TRACE_PLUGIN_FILES})
+  set(IMPL_DIR "${PROFILE_DIR}/plugin/aie_trace/x86")
+  set(OFFLOAD_DIR "${PROFILE_DIR}/device/aie_trace")
+  set(DEVICE_DIR "${PROFILE_DIR}/device/hal_device")
+
+  file(GLOB AIE_TRACE_COMPONENT_FILES
+    "${OFFLOAD_DIR}/*.h"
+    "${OFFLOAD_DIR}/*.cpp"
+    "${DEVICE_DIR}/*.h"
+    "${DEVICE_DIR}/*.cpp"
+    "${IMPL_DIR}/*.h"
+    "${IMPL_DIR}/*.cpp"
+  )
+
+  add_library(xdp_aie_trace_plugin MODULE ${AIE_TRACE_PLUGIN_FILES} ${AIE_TRACE_COMPONENT_FILES})
   add_dependencies(xdp_aie_trace_plugin xdp_core xrt_coreutil)
   target_link_libraries(xdp_aie_trace_plugin PRIVATE xdp_core xrt_coreutil)
   target_compile_definitions(xdp_aie_trace_plugin PRIVATE XRT_X86_BUILD=1)
@@ -83,21 +74,64 @@ elseif (DEFINED XRT_AIE_BUILD AND ${XRT_NATIVE_BUILD} STREQUAL "yes")
 
   install (TARGETS xdp_aie_trace_plugin
     LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT}
-  )
+  )  
 
-elseif (DEFINED XRT_AIE_BUILD AND ${XRT_NATIVE_BUILD} STREQUAL "no")
-  add_library(xdp_aie_trace_plugin MODULE ${AIE_TRACE_PLUGIN_FILES} ${AIE_TRACE_UTIL_FILES} ${AIE_TRACE_CONFIG_FILES})
-  add_dependencies(xdp_aie_trace_plugin xdp_core xrt_coreutil)
-  target_link_libraries(xdp_aie_trace_plugin PRIVATE xdp_core xrt_coreutil xaiengine)
-  target_compile_definitions(xdp_aie_trace_plugin PRIVATE FAL_LINUX="on")
-  set_target_properties(xdp_aie_trace_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
+else()
+  if (XDP_VE2_BUILD_CMAKE STREQUAL "yes")
+    set(IMPL_DIR "${PROFILE_DIR}/plugin/aie_trace/ve2")
+    set(OFFLOAD_DIR "${PROFILE_DIR}/device/aie_trace/ve2")
+    set(DEVICE_DIR "${PROFILE_DIR}/device/hal_device")
 
-  install (TARGETS xdp_aie_trace_plugin
-    LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT}
-  )
+    file(GLOB AIE_TRACE_COMPONENT_FILES
+      "${OFFLOAD_DIR}/*.h"
+      "${OFFLOAD_DIR}/*.cpp"
+      "${DEVICE_DIR}/*.h"
+      "${DEVICE_DIR}/*.cpp"
+      "${IMPL_DIR}/*.h"
+      "${IMPL_DIR}/*.cpp"
+    )
+
+    add_library(xdp_aie_trace_plugin_xdna MODULE ${AIE_TRACE_PLUGIN_FILES} ${AIE_TRACE_COMPONENT_FILES} ${AIE_TRACE_UTIL_FILES} ${AIE_TRACE_CONFIG_FILES})
+    add_dependencies(xdp_aie_trace_plugin_xdna xdp_core xrt_coreutil)
+    target_link_libraries(xdp_aie_trace_plugin_xdna PRIVATE xdp_core xrt_coreutil xaiengine)
+    target_compile_definitions(xdp_aie_trace_plugin_xdna PRIVATE XDP_VE2_BUILD=1 FAL_LINUX="on")
+    target_include_directories(xdp_aie_trace_plugin_xdna PRIVATE ${CMAKE_SOURCE_DIR}/src)
+    set_target_properties(xdp_aie_trace_plugin_xdna PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
+
+    install (TARGETS xdp_aie_trace_plugin_xdna
+      LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT}
+    )
+  endif()
+    
+  if (DEFINED XRT_AIE_BUILD AND ${XRT_NATIVE_BUILD} STREQUAL "no")
+    set(IMPL_DIR "${PROFILE_DIR}/plugin/aie_trace/edge")
+    set(OFFLOAD_DIR "${PROFILE_DIR}/device/aie_trace")
+    set(DEVICE_DIR "${PROFILE_DIR}/device/hal_device")
+
+    file(GLOB AIE_TRACE_COMPONENT_FILES
+      "${OFFLOAD_DIR}/*.h"
+      "${OFFLOAD_DIR}/*.cpp"
+      "${DEVICE_DIR}/*.h"
+      "${DEVICE_DIR}/*.cpp"
+      "${IMPL_DIR}/*.h"
+      "${IMPL_DIR}/*.cpp"
+    )
+
+    add_library(xdp_aie_trace_plugin MODULE ${AIE_TRACE_PLUGIN_FILES} ${AIE_TRACE_COMPONENT_FILES} ${AIE_TRACE_UTIL_FILES} ${AIE_TRACE_CONFIG_FILES})
+    add_dependencies(xdp_aie_trace_plugin xdp_core xrt_coreutil)
+    target_link_libraries(xdp_aie_trace_plugin PRIVATE xdp_core xrt_coreutil xaiengine)
+    if (XDP_VE2_BUILD_CMAKE STREQUAL "yes")
+      target_compile_definitions(xdp_aie_trace_plugin PRIVATE XDP_VE2_ZOCL_BUILD=1 FAL_LINUX="on")
+    else()
+      target_compile_definitions(xdp_aie_trace_plugin PRIVATE FAL_LINUX="on")
+    endif()
+    set_target_properties(xdp_aie_trace_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
+
+    install (TARGETS xdp_aie_trace_plugin
+      LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT}
+    )
+  endif()
 
 # Else, on edge-aarch64 don't build at all
 
 endif()
-
-

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.h
@@ -46,7 +46,7 @@ public:
   static bool alive();
 
 private:
-  uint64_t getDeviceIDFromHandle(void *handle);
+  uint64_t getDeviceIDFromHandle(void *handle, bool hw_context_flow);
   void pollAIETimers(uint64_t index, void *handle);
   void flushOffloader(const std::unique_ptr<AIETraceOffload> &offloader,
                       bool warn);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Added support for X or ML flow in AIE Trace Plugin
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Removed unused header from aie_profile_plugin.cpp
#### How problem was solved, alternative solutions (if any) and why they were rejected
Generated different library for xdna and zocl flow and based on the option provided in xrt.ini load appropriate library.
#### Risks (if any) associated the changes in the commit
Low
#### What has been tested and how, request additional testing if necessary
Tested trace on PL_ML testcase on VE2.
Tested trace on resnet_50 design on Client
Tested  trace on VEK280 design.
#### Documentation impact (if any)
NA