### PR TITLE
Use current HW Ctx number of columns for ML Timeline on VE2

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/ve2/ml_timeline.h
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/ve2/ml_timeline.h
@@ -25,6 +25,7 @@ namespace xdp {
   class ResultBOContainer;
   class MLTimelineVE2Impl : public MLTimelineImpl
   {
+    uint32_t mNumBufSegments;
     std::unique_ptr<ResultBOContainer> mResultBOHolder;
     public :
       MLTimelineVE2Impl(VPDatabase* dB, uint32_t sz);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
ML Timeline uses the number of columns in the current partition for number of segments in buffer on VE2. Earlier it was assuming only one partition is available. This PR uses correct HW Ctx.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Multipartition test on VE2, Multi uC test on VE2

#### Documentation impact (if any)
