### PR TITLE
XRT-SMI handling for Npu 3 (and other future devices/device families)

### DIFF
--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -493,6 +493,11 @@ struct pcie_id : request
   struct data {
     uint16_t device_id;
     uint8_t revision_id;
+
+    // Define the < operator for comparison
+    bool operator<(const data& other) const {
+      return std::tie(device_id, revision_id) < std::tie(other.device_id, other.revision_id);
+    }
   };
 
   using result_type = data;

--- a/src/runtime_src/core/common/smi.cpp
+++ b/src/runtime_src/core/common/smi.cpp
@@ -153,14 +153,14 @@ smi_hardware_config()
 {
   // Initialize the hardware map
   hardware_map = {
-    {{0x1502, 0x00}, hardware_type::PHX},
-    {{0x17f0, 0x00}, hardware_type::STXA0},
-    {{0x17f0, 0x10}, hardware_type::STXB0},
-    {{0x17f0, 0x11}, hardware_type::STXH},
-    {{0x17f0, 0x20}, hardware_type::KRK1},
-    {{0x17f1, 0x00}, hardware_type::NPU3_F1}, 
-    {{0x17f1, 0x01}, hardware_type::NPU3_F2},
-    {{0x17f1, 0x10}, hardware_type::NPU3_F3}
+    {{0x1502, 0x00}, hardware_type::phx},
+    {{0x17f0, 0x00}, hardware_type::stxA0},
+    {{0x17f0, 0x10}, hardware_type::stxB0},
+    {{0x17f0, 0x11}, hardware_type::stxH},
+    {{0x17f0, 0x20}, hardware_type::krk1},
+    {{0x17f1, 0x00}, hardware_type::npu3_f1}, 
+    {{0x17f1, 0x01}, hardware_type::npu3_f2},
+    {{0x17f1, 0x10}, hardware_type::npu3_f3}
   };
 }
 
@@ -169,7 +169,9 @@ smi_hardware_config::
 get_hardware_type(const xq::pcie_id::data& dev) const 
 {
   auto it = hardware_map.find(dev);
-  return (it != hardware_map.end()) ? it->second : hardware_type::UNKNOWN;
+  return (it != hardware_map.end()) 
+      ? it->second 
+      : hardware_type::unknown;
 }
 
 tuple_vector

--- a/src/runtime_src/core/common/smi.cpp
+++ b/src/runtime_src/core/common/smi.cpp
@@ -91,7 +91,7 @@ get_option_options() const
 
 std::string 
 smi::
-build_smi_config() const 
+build_json() const 
 {
   ptree config;
   ptree subcommands;
@@ -103,7 +103,7 @@ build_smi_config() const
   config.add_child("subcommands", subcommands);
 
   std::ostringstream oss;
-  boost::property_tree::write_json(oss, config, true); // Pretty print with true
+  boost::property_tree::write_json(oss, config, true); 
   return oss.str();
 }
 
@@ -146,6 +146,29 @@ instance()
 {
   static smi instance;
   return &instance;
+}
+
+smi_hardware_config::
+smi_hardware_config()
+{
+  // Initialize the hardware map
+  hardware_map = {
+    {"NPU Phoenix", hardware_type::PHX},
+    {"NPU Strix", hardware_type::STX},
+    {"NPU Strix Halo", hardware_type::STXH},
+    {"NPU Krackan", hardware_type::KRK1},
+    {"NPU Medusa", hardware_type::MDS},
+    {"NPU Medusa PF", hardware_type::MDS_PF},
+    {"NPU Medusa VF", hardware_type::MDS_VF}
+  };
+}
+
+smi_hardware_config::hardware_type
+smi_hardware_config::
+get_hardware_type(const std::string& device_name) const 
+{
+  auto it = hardware_map.find(device_name);
+  return (it != hardware_map.end()) ? it->second : hardware_type::UNKNOWN;
 }
 
 tuple_vector

--- a/src/runtime_src/core/common/smi.cpp
+++ b/src/runtime_src/core/common/smi.cpp
@@ -153,21 +153,21 @@ smi_hardware_config()
 {
   // Initialize the hardware map
   hardware_map = {
-    {"NPU Phoenix", hardware_type::PHX},
-    {"NPU Strix", hardware_type::STX},
-    {"NPU Strix Halo", hardware_type::STXH},
-    {"NPU Krackan", hardware_type::KRK1},
-    {"NPU Medusa", hardware_type::MDS},
-    {"NPU Medusa PF", hardware_type::MDS_PF},
-    {"NPU Medusa VF", hardware_type::MDS_VF}
+    {{0x1502, 0x00}, hardware_type::PHX},
+    {{0x17f0, 0x00}, hardware_type::STX},
+    {{0x17f0, 0x11}, hardware_type::STXH},
+    {{0x17f0, 0x20}, hardware_type::KRK1},
+    {{0x17f1, 0x00}, hardware_type::NPU3_F1}, 
+    {{0x17f1, 0x01}, hardware_type::NPU3_F2},
+    {{0x17f1, 0x10}, hardware_type::NPU3_F3}
   };
 }
 
 smi_hardware_config::hardware_type
 smi_hardware_config::
-get_hardware_type(const std::string& device_name) const 
+get_hardware_type(const xq::pcie_id::data& dev) const 
 {
-  auto it = hardware_map.find(device_name);
+  auto it = hardware_map.find(dev);
   return (it != hardware_map.end()) ? it->second : hardware_type::UNKNOWN;
 }
 

--- a/src/runtime_src/core/common/smi.cpp
+++ b/src/runtime_src/core/common/smi.cpp
@@ -154,7 +154,8 @@ smi_hardware_config()
   // Initialize the hardware map
   hardware_map = {
     {{0x1502, 0x00}, hardware_type::PHX},
-    {{0x17f0, 0x00}, hardware_type::STX},
+    {{0x17f0, 0x00}, hardware_type::STXA0},
+    {{0x17f0, 0x10}, hardware_type::STXB0},
     {{0x17f0, 0x11}, hardware_type::STXH},
     {{0x17f0, 0x20}, hardware_type::KRK1},
     {{0x17f1, 0x00}, hardware_type::NPU3_F1}, 

--- a/src/runtime_src/core/common/smi.h
+++ b/src/runtime_src/core/common/smi.h
@@ -4,6 +4,7 @@
 #pragma once
 // Local include files
 #include "config.h"
+#include "device.h"
 
 // 3rd Party Library - Include Files
 #include <boost/property_tree/ptree.hpp>
@@ -136,7 +137,7 @@ public:
 
   XRT_CORE_COMMON_EXPORT
   std::string
-  build_smi_config() const;
+  build_json() const;
 
   XRT_CORE_COMMON_EXPORT
   tuple_vector
@@ -146,6 +147,48 @@ public:
   tuple_vector
   get_option_options(const std::string& subcommand) const;
 
+};
+
+class config_generator {
+public:
+  XRT_CORE_COMMON_EXPORT
+  virtual subcommand 
+  create_validate_subcommand() = 0;
+
+  XRT_CORE_COMMON_EXPORT
+  virtual subcommand 
+  create_examine_subcommand() = 0;
+
+  XRT_CORE_COMMON_EXPORT
+  virtual subcommand 
+  create_configure_subcommand() = 0; 
+};
+
+/* This class includes all the hardware specific logic. 
+   Each shim should inherit from this if they are to define
+   shim specific hardware specific behavior*/
+class smi_hardware_config {
+public:
+  enum class hardware_type {
+    PHX, // Phoenix
+    STX, // Strix
+    STXH, // Strix Halo
+    KRK1, // Krackan
+    MDS, // Medusa
+    MDS_PF, // Medusa PF
+    MDS_VF, // Medusa VF
+    UNKNOWN // Unknown hardware type
+  };
+
+  XRT_CORE_COMMON_EXPORT
+  smi_hardware_config();
+
+  XRT_CORE_COMMON_EXPORT
+  hardware_type 
+  get_hardware_type(const std::string&) const;
+
+private:
+  std::map<std::string, hardware_type> hardware_map;
 };
 
 XRT_CORE_COMMON_EXPORT

--- a/src/runtime_src/core/common/smi.h
+++ b/src/runtime_src/core/common/smi.h
@@ -5,6 +5,7 @@
 // Local include files
 #include "config.h"
 #include "device.h"
+#include "query_requests.h"
 
 // 3rd Party Library - Include Files
 #include <boost/property_tree/ptree.hpp>
@@ -14,6 +15,8 @@
 #include <vector>
 #include <memory>
 #include <map>
+
+namespace xq = xrt_core::query;
 
 namespace xrt_core::smi {
 
@@ -176,9 +179,9 @@ public:
     STX, // Strix
     STXH, // Strix Halo
     KRK1, // Krackan
-    MDS, // Medusa
-    MDS_PF, // Medusa PF
-    MDS_VF, // Medusa VF
+    NPU3_F1, // XXXXX
+    NPU3_F2, // XXXXX
+    NPU3_F3, // XXXXX
     UNKNOWN // Unknown hardware type
   };
 
@@ -187,10 +190,10 @@ public:
 
   XRT_CORE_COMMON_EXPORT
   hardware_type 
-  get_hardware_type(const std::string&) const;
+  get_hardware_type(const xq::pcie_id::data&) const;
 
 private:
-  std::map<std::string, hardware_type> hardware_map;
+  std::map<xq::pcie_id::data, hardware_type> hardware_map;
 };
 
 XRT_CORE_COMMON_EXPORT

--- a/src/runtime_src/core/common/smi.h
+++ b/src/runtime_src/core/common/smi.h
@@ -4,7 +4,6 @@
 #pragma once
 // Local include files
 #include "config.h"
-#include "device.h"
 #include "query_requests.h"
 
 // 3rd Party Library - Include Files
@@ -190,15 +189,15 @@ public:
 class smi_hardware_config {
 public:
   enum class hardware_type {
-    PHX, // Phoenix
-    STXA0, // StrixA0
-    STXB0, // Strix B0
-    STXH, // Strix Halo
-    KRK1, // Krackan
-    NPU3_F1, // XXXXX
-    NPU3_F2, // XXXXX
-    NPU3_F3, // XXXXX
-    UNKNOWN // Unknown hardware type
+    phx, // Phoenix
+    stxA0, // StrixA0
+    stxB0, // Strix B0
+    stxH, // Strix Halo
+    krk1, // Krackan
+    npu3_f1, // XXXXX
+    npu3_f2, // XXXXX
+    npu3_f3, // XXXXX
+    unknown // Unknown hardware type
   };
 
   XRT_CORE_COMMON_EXPORT

--- a/src/runtime_src/core/common/smi.h
+++ b/src/runtime_src/core/common/smi.h
@@ -151,6 +151,8 @@ public:
 
 class config_generator {
 public:
+  virtual ~config_generator() = default;
+
   XRT_CORE_COMMON_EXPORT
   virtual subcommand 
   create_validate_subcommand() = 0;

--- a/src/runtime_src/core/common/smi.h
+++ b/src/runtime_src/core/common/smi.h
@@ -152,31 +152,47 @@ public:
 
 };
 
+// class config_generator
+// This class is used to generate configuration objects for xrt-smi.
+// It provides methods to create subcommands for validating, examining, and configuring devices.
+// Derived classes should implement these methods to provide platform-specific and hardware-specific options.
+// It is designed to be extended for different hardware configurations, such as NPU1, NPU2 and NPU3 and
+// different platforms like linux, windows, etc.
+
 class config_generator {
 public:
   virtual ~config_generator() = default;
 
-  XRT_CORE_COMMON_EXPORT
+  // Creates the "validate" subcommand.
+  // This subcommand is used to validate the given device by executing the platform's validate executable.
+  // Derived classes must implement this method to define hardware-specific validation logic.
   virtual subcommand 
   create_validate_subcommand() = 0;
 
-  XRT_CORE_COMMON_EXPORT
+  // Creates the "examine" subcommand.
+  // This subcommand generates a report of interest in a text or JSON format.
+  // Derived classes must implement this method to define hardware-specific examination logic.
   virtual subcommand 
   create_examine_subcommand() = 0;
 
-  XRT_CORE_COMMON_EXPORT
+  // Creates the "configure" subcommand.
+  // This subcommand is used for device and host configuration.
+  // Derived classes must implement this method to define hardware-specific configuration logic.
   virtual subcommand 
   create_configure_subcommand() = 0; 
 };
 
-/* This class includes all the hardware specific logic. 
-   Each shim should inherit from this if they are to define
-   shim specific hardware specific behavior*/
+// class smi_hardware_config
+// This class is used to determine the hardware type based on the PCIe ID, Rev ID of the device.
+// It provides a mapping of known hardware types to their corresponding PCIe IDs.
+// This is required since xrt-smi needs to know the hardware type to provide appropriate runnable 
+// tests and reports for the combination of plarform and hardware. 
 class smi_hardware_config {
 public:
   enum class hardware_type {
     PHX, // Phoenix
-    STX, // Strix
+    STXA0, // StrixA0
+    STXB0, // Strix B0
     STXH, // Strix Halo
     KRK1, // Krackan
     NPU3_F1, // XXXXX
@@ -188,6 +204,7 @@ public:
   XRT_CORE_COMMON_EXPORT
   smi_hardware_config();
 
+  // Returns the hardware type based on the PCIe ID and Revision ID.
   XRT_CORE_COMMON_EXPORT
   hardware_type 
   get_hardware_type(const xq::pcie_id::data&) const;
@@ -196,14 +213,25 @@ private:
   std::map<xq::pcie_id::data, hardware_type> hardware_map;
 };
 
+// Function to get the singleton instance of type smi
+// This is to ensure that the smi instance is created only once
+// per xrt-smi execution. 
 XRT_CORE_COMMON_EXPORT
 smi*
 instance();
 
+// Function to get the list of applicable options for a given subcommand and suboption.
+// Example : xrt-smi validate --run=[test1, test2, test3]
+// This function returns a vector of tuples containing the name, description, and type 
+// of each option test1, test2 and test3.
 XRT_CORE_COMMON_EXPORT
 tuple_vector
 get_list(const std::string& subcommand, const std::string& suboption);
 
+// Function to get the options for a given subcommand.
+// Example : xrt-smi configure --pmode --device 1 
+// This function returns a vector of tuples containing the name, description, and type
+// of each option option once example of which is --pmode
 XRT_CORE_COMMON_EXPORT
 tuple_vector
 get_option_options(const std::string& subcommand);

--- a/src/runtime_src/core/edge/user/smi_edge.cpp
+++ b/src/runtime_src/core/edge/user/smi_edge.cpp
@@ -95,7 +95,7 @@ get_smi_config()
   smi_instance->add_subcommand("examine", create_examine_subcommand());
   smi_instance->add_subcommand("configure", create_configure_subcommand());
 
-  return smi_instance->build_smi_config();
+  return smi_instance->build_json();
 }
 
 } // namespace shim_edge::smi

--- a/src/runtime_src/core/pcie/linux/smi_pcie.cpp
+++ b/src/runtime_src/core/pcie/linux/smi_pcie.cpp
@@ -96,7 +96,7 @@ get_smi_config()
   smi_instance->add_subcommand("examine", create_examine_subcommand());
   smi_instance->add_subcommand("configure", create_configure_subcommand());
 
-  return smi_instance->build_smi_config();
+  return smi_instance->build_json();
 }
 
 } // namespace shim_pcie::smi

--- a/src/runtime_src/core/tools/common/SmiDefault.cpp
+++ b/src/runtime_src/core/tools/common/SmiDefault.cpp
@@ -68,6 +68,6 @@ get_default_smi_config()
   smi_instance->add_subcommand("examine", create_examine_subcommand());
   smi_instance->add_subcommand("configure", create_configure_subcommand());
 
-  return smi_instance->build_smi_config();
+  return smi_instance->build_json();
 }
 } // namespace xrt_smi_default


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
This PR adds the basic implementation for handling device specific intelligence within xrt-smi.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://jira.xilinx.com/browse/AIESW-1690
Discovered through internal enhancement efforts

#### How problem was solved, alternative solutions (if any) and why they were rejected
The problem is solved by introducing a new hardware type related class which maps the hardware types to correct config generators.
XRT-SMI architecture : https://amd.atlassian.net/wiki/spaces/AIE/pages/871761228/XRT-SMI+Architecture+overview

#### Risks (if any) associated the changes in the commit
None.

#### What has been tested and how, request additional testing if necessary
Not tested yet since all behavior is Strix specific. Will test further when new devic types are added

#### Documentation impact (if any)
None.
