### PR TITLE
ERT data structure for context health

### DIFF
--- a/src/runtime_src/core/include/xrt/detail/ert.h
+++ b/src/runtime_src/core/include/xrt/detail/ert.h
@@ -1201,15 +1201,14 @@ get_ert_regmap_size_bytes(struct ert_start_kernel_cmd* pkt)
 static inline struct ert_ctx_health_data*
 get_ert_ctx_health_data(struct ert_packet* pkt)
 {
-  struct ert_ctx_health_data* ctxHealthData = NULL;
   switch (pkt->opcode) {
   case ERT_START_NPU:
   case ERT_START_NPU_PREEMPT:
   case ERT_START_NPU_PREEMPT_ELF:
     if (pkt->state == ERT_CMD_STATE_TIMEOUT)
-      ctxHealthData = (struct ert_ctx_health_data*) pkt->data;
+      return (struct ert_ctx_health_data*) pkt->data;
   }
-  return ctxHealthData;
+  return NULL;
 }
 
 #ifdef __linux__


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Adding a data structure for returning context health information when there is a command timeout.
This structure is valid only if the ert packet state is ERT_CMD_STATE_TIMEOUT

#### Risks (if any) associated the changes in the commit
None
