### PR TITLE
[AIESW-3128][xrt-smi] Fix Variability in TCT Test Numbers

### DIFF
--- a/src/runtime_src/core/tools/common/tests/TestTCTAllColumn.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestTCTAllColumn.cpp
@@ -146,8 +146,8 @@ TestTCTAllColumn::run(std::shared_ptr<xrt_core::device> dev)
     XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("No. of iterations: %f") % itr_count));
   }
 
-  double avg_latency = 0.0;
-  double avg_throughput = 0.0;
+  double latency = 0.0;
+  double throughput = 0.0;
   for (int run_num = 0; run_num < run_count; run_num++) {
     auto start = std::chrono::high_resolution_clock::now();
     try {
@@ -181,17 +181,13 @@ TestTCTAllColumn::run(std::shared_ptr<xrt_core::device> dev)
 
     //Calculate throughput
     auto elapsedSecs = std::chrono::duration_cast<std::chrono::duration<double>>(end-start).count();
-    double throughput = itr_count / elapsedSecs;
-    double latency = (elapsedSecs / itr_count) * 1000000; //convert s to us
-    avg_latency += latency;
-    avg_throughput += throughput;
+    throughput = itr_count / elapsedSecs;
+    latency = (elapsedSecs / itr_count) * 1000000; //convert s to us
   }
 
-  avg_latency = avg_latency / run_count;
-  avg_throughput = avg_throughput / run_count;
   if(XBU::getVerbose())
-    XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Average time for TCT: %.1f us") % avg_latency));
-  XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Average TCT throughput: %.1f TCT/s") % avg_throughput));
+    XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Average time for TCT: %.1f us") % latency));
+  XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Average TCT throughput: %.1f TCT/s") % throughput));
   ptree.put("status", XBValidateUtils::test_token_passed);
 
   return ptree;

--- a/src/runtime_src/core/tools/common/tests/TestTCTAllColumn.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestTCTAllColumn.cpp
@@ -3,7 +3,7 @@
 
 // ------ I N C L U D E   F I L E S -------------------------------------------
 // Local - Include Files
-#include "TestTCTAllColumn.h"
+#include "TestTCTOneColumn.h"
 #include "TestValidateUtilities.h"
 #include "tools/common/XBUtilities.h"
 #include "xrt/xrt_bo.h"
@@ -17,15 +17,16 @@ namespace XBU = XBUtilities;
 
 static constexpr size_t buffer_size = 4;
 static constexpr size_t word_count = buffer_size/4;
-static constexpr int itr_count = 20000;
+static constexpr int itr_count = 10000;
+static constexpr int run_count = 100;
 
 // ----- C L A S S   M E T H O D S -------------------------------------------
-TestTCTAllColumn::TestTCTAllColumn()
-  : TestRunner("tct-all-col", "Measure average TCT processing time for all columns")
+TestTCTOneColumn::TestTCTOneColumn()
+  : TestRunner("tct-one-col", "Measure average TCT processing time for one column")
 {}
 
 boost::property_tree::ptree
-TestTCTAllColumn::run(std::shared_ptr<xrt_core::device> dev)
+TestTCTOneColumn::run(std::shared_ptr<xrt_core::device> dev)
 {
   boost::property_tree::ptree ptree = get_test_header();
   ptree.erase("xclbin");
@@ -69,7 +70,7 @@ TestTCTAllColumn::run(std::shared_ptr<xrt_core::device> dev)
 
   xrt::hw_context hwctx;
   xrt::kernel kernel;
-
+  
   if (!elf) { // DPU
     try {
       hwctx = xrt::hw_context(working_dev, xclbin.get_uuid());
@@ -81,7 +82,6 @@ TestTCTAllColumn::run(std::shared_ptr<xrt_core::device> dev)
       ptree.put("status", XBValidateUtils::test_token_failed);
       return ptree;
     }
-
     const auto seq_name = xrt_core::device_query<xrt_core::query::sequence_name>(dev, xrt_core::query::sequence_name::type::tct_one_column);
     dpu_instr = XBValidateUtils::findPlatformFile(seq_name, ptree);
     if (!std::filesystem::exists(dpu_instr))
@@ -97,7 +97,7 @@ TestTCTAllColumn::run(std::shared_ptr<xrt_core::device> dev)
     }
   }
   else { // ELF
-    const auto elf_name = xrt_core::device_query<xrt_core::query::elf_name>(dev, xrt_core::query::elf_name::type::tct_all_column);
+    const auto elf_name = xrt_core::device_query<xrt_core::query::elf_name>(dev, xrt_core::query::elf_name::type::tct_one_column);
     auto elf_path = XBValidateUtils::findPlatformFile(elf_name, ptree);
     
     if (!std::filesystem::exists(elf_path))
@@ -127,7 +127,7 @@ TestTCTAllColumn::run(std::shared_ptr<xrt_core::device> dev)
     bo_ifm = xrt::ext::bo{working_dev, buffer_size};
     bo_ofm = xrt::ext::bo{working_dev, buffer_size};
   }
-
+  
   // map input buffer
   auto ifm_mapped = bo_ifm.map<int*>();
 	for (size_t i = 0; i < word_count; i++)
@@ -138,51 +138,57 @@ TestTCTAllColumn::run(std::shared_ptr<xrt_core::device> dev)
   if (!elf) { 
     bo_instr.sync(XCL_BO_SYNC_BO_TO_DEVICE); 
   }
-
   //Log
   if(XBU::getVerbose()) {
     XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Buffer size: %f bytes") % buffer_size));
     XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("No. of iterations: %f") % itr_count));
   }
-
-  auto start = std::chrono::high_resolution_clock::now();
-  try {
-    xrt::run run;
-    if (!elf) {
-      run = kernel(XBValidateUtils::get_opcode(), bo_ifm, NULL, bo_ofm, NULL, bo_instr, instr_size, NULL);
-    } else {
-      run = kernel(XBValidateUtils::get_opcode(), 0, 0, bo_ifm, 0, bo_ofm, 0, 0);
+  double avg_latency = 0.0;
+  double avg_throughput = 0.0;
+  for (int run_num = 0; run_num < run_count; run_num++) {
+    auto start = std::chrono::high_resolution_clock::now();
+    try {
+      xrt::run run;
+      if (!elf) {
+        run = kernel(XBValidateUtils::get_opcode(), bo_ifm, NULL, bo_ofm, NULL, bo_instr, instr_size, NULL);
+      } else {
+        run = kernel(XBValidateUtils::get_opcode(), 0, 0, bo_ifm, 0, bo_ofm, 0, 0);
+      }
+      
+      // Wait for kernel to be done
+      run.wait2();
     }
-    
-    // Wait for kernel to be done
-    run.wait2();
-  }
-  catch (const std::exception& ex) {
-    XBValidateUtils::logger(ptree, "Error", ex.what());
-    ptree.put("status", XBValidateUtils::test_token_failed);
-    return ptree;
-  }
-  auto end = std::chrono::high_resolution_clock::now();
-
-  //map ouput buffer
-  bo_ofm.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
-  auto ofm_mapped = bo_ofm.map<int*>();
-  for (size_t i = 0; i < word_count; i++) {
-    if (ofm_mapped[i] != ifm_mapped[i]) {
-      auto msg = boost::str(boost::format("Data mismatch at out buffer[%d]") % i);
-      XBValidateUtils::logger(ptree, "Error", msg);
+    catch (const std::exception& ex) {
+      XBValidateUtils::logger(ptree, "Error", ex.what());
+      ptree.put("status", XBValidateUtils::test_token_failed);
       return ptree;
     }
+    auto end = std::chrono::high_resolution_clock::now();
+
+    //map ouput buffer
+    bo_ofm.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
+    auto ofm_mapped = bo_ofm.map<int*>();
+    for (size_t i = 0; i < word_count; i++) {
+      if (ofm_mapped[i] != ifm_mapped[i]) {
+        auto msg = boost::str(boost::format("Data mismatch at out buffer[%d]") % i);
+        XBValidateUtils::logger(ptree, "Error", msg);
+        return ptree;
+      }
+    }
+
+    //Calculate throughput
+    auto elapsedSecs = std::chrono::duration_cast<std::chrono::duration<double>>(end-start).count();
+    double throughput = itr_count / elapsedSecs;
+    double latency = (elapsedSecs / itr_count) * 1000000; //convert s to us
+    avg_latency += latency;
+    avg_throughput += throughput;
   }
 
-  //Calculate throughput
-  auto elapsedSecs = std::chrono::duration_cast<std::chrono::duration<double>>(end-start).count();
-  double throughput = itr_count / elapsedSecs;
-  double latency = (elapsedSecs / itr_count) * 1000000; //convert s to us
-
+  avg_latency = avg_latency / run_count;
+  avg_throughput = avg_throughput / run_count;
   if(XBU::getVerbose())
-    XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Average time for TCT: %.1f us") % latency));
-  XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Average TCT throughput: %.1f TCT/s") % throughput));
+    XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Average time for TCT: %.1f us") % avg_latency));
+  XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Average TCT throughput: %.1f TCT/s") % avg_throughput));
   ptree.put("status", XBValidateUtils::test_token_passed);
 
   return ptree;

--- a/src/runtime_src/core/tools/common/tests/TestTCTAllColumn.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestTCTAllColumn.cpp
@@ -182,7 +182,7 @@ TestTCTAllColumn::run(std::shared_ptr<xrt_core::device> dev)
     //Calculate throughput
     auto elapsedSecs = std::chrono::duration_cast<std::chrono::duration<double>>(end-start).count();
     throughput = itr_count / elapsedSecs;
-    latency = (elapsedSecs / itr_count) * 1000000; //convert s to us
+    latency = (elapsedSecs / itr_count) * 1000000; // NOLINT convert s to us
   }
 
   if(XBU::getVerbose())

--- a/src/runtime_src/core/tools/common/tests/TestTCTOneColumn.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestTCTOneColumn.cpp
@@ -143,8 +143,8 @@ TestTCTOneColumn::run(std::shared_ptr<xrt_core::device> dev)
     XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Buffer size: %f bytes") % buffer_size));
     XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("No. of iterations: %f") % itr_count));
   }
-  double avg_latency = 0.0;
-  double avg_throughput = 0.0;
+  double latency = 0.0;
+  double throughput = 0.0;
   for (int run_num = 0; run_num < run_count; run_num++) {
     auto start = std::chrono::high_resolution_clock::now();
     try {
@@ -178,17 +178,13 @@ TestTCTOneColumn::run(std::shared_ptr<xrt_core::device> dev)
 
     //Calculate throughput
     auto elapsedSecs = std::chrono::duration_cast<std::chrono::duration<double>>(end-start).count();
-    double throughput = itr_count / elapsedSecs;
-    double latency = (elapsedSecs / itr_count) * 1000000; //convert s to us
-    avg_latency += latency;
-    avg_throughput += throughput;
+    throughput = itr_count / elapsedSecs;
+    latency = (elapsedSecs / itr_count) * 1000000; //convert s to us
   }
 
-  avg_latency = avg_latency / run_count;
-  avg_throughput = avg_throughput / run_count;
   if(XBU::getVerbose())
-    XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Average time for TCT: %.1f us") % avg_latency));
-  XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Average TCT throughput: %.1f TCT/s") % avg_throughput));
+    XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Average time for TCT: %.1f us") % latency));
+  XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Average TCT throughput: %.1f TCT/s") % throughput));
   ptree.put("status", XBValidateUtils::test_token_passed);
 
   return ptree;

--- a/src/runtime_src/core/tools/common/tests/TestTCTOneColumn.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestTCTOneColumn.cpp
@@ -179,7 +179,7 @@ TestTCTOneColumn::run(std::shared_ptr<xrt_core::device> dev)
     //Calculate throughput
     auto elapsedSecs = std::chrono::duration_cast<std::chrono::duration<double>>(end-start).count();
     throughput = itr_count / elapsedSecs;
-    latency = (elapsedSecs / itr_count) * 1000000; //convert s to us
+    latency = (elapsedSecs / itr_count) * 1000000; // NOLINT convert s to us
   }
 
   if(XBU::getVerbose())


### PR DESCRIPTION
#### Problem solved by the commit
https://jira.xilinx.com/browse/AIESW-3128
Some variability has been noticed in the two TCT test numbers in xrt-smi for both DPU and ELF flows.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Discovered during internal testing.
#### How problem was solved, alternative solutions (if any) and why they were rejected
Update: After group discussion and follow-up with Min, decided to use ramp-up approach by taking iterating the kernel run and then taking the next result. Numbers were about the same as when averaging as described below. We should get this merged before Runner migration.

Attempted to increase the number of kernel runs and average the result as suggested by Sri Latha. 
We have tested running the tests individually and within the "-r all" suite.
Before implementing the fix, testing with STX amdxdna showed some large jumps in reported numbers that were also below the expected values (e.g. ~150k for a one-col run, ~400k for an all-col run). There were times that the numbers seemed more stable between successive runs before seemingly randomly having another large jump.
Testing with MCDM also had some variability while reaching target numbers, though not as much as on xdna (though this is with limited testing runs, usually within 100k above or below). 
We attempted to set all CPU clocks to performance as well before running the tests, but variability remained. It wasn't until using this averaging approach that the numbers jumped up to target values and became more stable on STX amdxdna. Using --elf with the averaging approach on xdna yielded even larger numbers (~470k and ~1100k); I am not sure if this is even supposed to be possible. The reason as to why the numbers jumped up and the variability decreased should be investigated further. I am also not sure if the machines have anything to do with it, though I tried to ensure that I was the sole user, no other NPU workloads were running, and that the NPU was set to performance mode with xrt-smi configure.
#### Risks (if any) associated the changes in the commit
N/A
#### What has been tested and how, request additional testing if necessary
Tested on STX machine with amdxdna. Tested on MCDM.
Currently seeing ~450k and ~900k on DPU run for xdna, which is slightly higher than expected.
#### Documentation impact (if any)
Possibly (Numbers in user guide)