### PR TITLE
Fix default ctrl code id when sub kernel name is not passed

### DIFF
--- a/src/runtime_src/core/common/api/module_int.h
+++ b/src/runtime_src/core/common/api/module_int.h
@@ -47,6 +47,12 @@ struct kernel_info {
 xrt::module
 create_run_module(const xrt::module& parent, const xrt::hw_context& hwctx, const std::string& ctrl_code_id);
 
+// ELF can have multiple ctrl codes and when user doesn't provide
+// id while running the kernel then by default 1st ctrl code is run
+// This function returns the 1st available ctrl code id
+std::string
+get_default_ctrl_id(const xrt::module& module);
+
 // Fill in ERT command payload in ELF flow. The payload is after extra_cu_mask
 // and before CU arguments.
 uint32_t*

--- a/src/runtime_src/core/common/api/module_int.h
+++ b/src/runtime_src/core/common/api/module_int.h
@@ -47,9 +47,9 @@ struct kernel_info {
 xrt::module
 create_run_module(const xrt::module& parent, const xrt::hw_context& hwctx, const std::string& ctrl_code_id);
 
-// ELF can have multiple ctrl codes and when user doesn't provide
-// id while running the kernel then by default 1st ctrl code is run
-// This function returns the 1st available ctrl code id
+// If the user does not specify a sub-kernel ID,
+// select it automatically only if exactly one sub-kernel exists.
+// Otherwise, throw an exception
 std::string
 get_default_ctrl_id(const xrt::module& module);
 

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -1323,7 +1323,7 @@ private:
   size_t num_cumasks = 1;              // Required number of command cu masks
   control_type protocol = control_type::none; // Default opcode
   uint32_t uid;                        // Internal unique id for debug
-  std::string m_ctrl_code_id = "";     // ID to identify which ctrl code to load from elf
+  std::string m_ctrl_code_id;          // ID to identify which ctrl code to load from elf
   std::shared_ptr<xrt_core::usage_metrics::base_logger> m_usage_logger =
       xrt_core::usage_metrics::get_usage_metrics_logger();
 
@@ -1513,11 +1513,11 @@ private:
   }
 
   std::string
-  get_ctrlcode_id(const std::string& name)
+  get_ctrlcode_id(const std::string& id)
   {
     // kernel name will be of format - <kernel_name>:<ctrl code index>
-    if (auto i = name.find(":"); i != std::string::npos)
-      return name.substr(i + 1);
+    if (auto i = id.find(":"); i != std::string::npos)
+      return id.substr(i + 1);
 
     return xrt_core::module_int::get_default_ctrl_id(m_module);
   }

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -1323,7 +1323,7 @@ private:
   size_t num_cumasks = 1;              // Required number of command cu masks
   control_type protocol = control_type::none; // Default opcode
   uint32_t uid;                        // Internal unique id for debug
-  std::string m_ctrl_code_id;          // ID to identify which ctrl code to load from elf
+  std::string m_ctrl_code_id = "";     // ID to identify which ctrl code to load from elf
   std::shared_ptr<xrt_core::usage_metrics::base_logger> m_usage_logger =
       xrt_core::usage_metrics::get_usage_metrics_logger();
 
@@ -1512,14 +1512,14 @@ private:
     return data;  // no skipping
   }
 
-  static std::string
+  std::string
   get_ctrlcode_id(const std::string& name)
   {
     // kernel name will be of format - <kernel_name>:<ctrl code index>
     if (auto i = name.find(":"); i != std::string::npos)
       return name.substr(i + 1);
 
-    return ""; // default case
+    return xrt_core::module_int::get_default_ctrl_id(m_module);
   }
 
   static uint32_t


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
This PR fix the issue to pick proper sub kernel when it is not passed explicitly by appplication.
It will pick the sub kernel available if its the only sub kernel available. If multiple sub kernels are available and user doesnt pass any sub kernel name then an exception is thrown

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
#### How problem was solved, alternative solutions (if any) and why they were rejected
While parsing ELF we store all control codes in a map with key as sub kernel name (ctrl code id) and value as control code buffer, added a module_int function that returns the first entry of this map if its the only available sub kernel, otherwise an exception is thrown while creating xrt::ext::kernel object.

#### Risks (if any) associated the changes in the commit
Low as this doesn't affect the original flow and it only comes into picture in xclbin2elf flow

#### What has been tested and how, request additional testing if necessary
Tested using SNL baremetal flow on strix and test works as expected.

#### Documentation impact (if any)
NA