### PR TITLE
Modified strcture data element from fixed size to flexible array.

### DIFF
--- a/src/runtime_src/core/common/drv/cu_hls.c
+++ b/src/runtime_src/core/common/drv/cu_hls.c
@@ -110,7 +110,7 @@ static void cu_hls_xgq_start(struct xrt_cu_hls *cu_hls, u32 *data)
 	u32 i = 0;
 
 	num_reg = (cmd->hdr.count - (sizeof(struct xgq_cmd_start_cuidx)
-				     - sizeof(cmd->hdr) - sizeof(cmd->data)))/sizeof(u32);
+				     - sizeof(cmd->hdr)))/sizeof(u32);
 	for (i = 0; i < num_reg; ++i) {
 		cu_write32(cu_hls, ARGS + i * 4, cmd->data[i]);
 	}
@@ -123,7 +123,7 @@ static void cu_hls_xgq_start_kv(struct xrt_cu_hls *cu_hls, u32 *data)
 	u32 i = 0;
 
 	num_reg = (cmd->hdr.count - (sizeof(struct xgq_cmd_start_cuidx_kv)
-				     - sizeof(cmd->hdr) - sizeof(cmd->data)))/sizeof(u32);
+				     - sizeof(cmd->hdr)))/sizeof(u32);
 	/* data is a {offset : value} pairs list
 	 * cmd->data[i] -> offset
 	 * cmd->data[i+1] -> value

--- a/src/runtime_src/core/edge/drm/zocl/edge/zocl_edge_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/edge/zocl_edge_xclbin.c
@@ -131,7 +131,7 @@ zocl_xclbin_read_axlf(struct drm_zocl_dev *zdev, struct drm_zocl_axlf *axlf_obj,
 
 	/* Get full axlf header */
 	size_of_header = sizeof(struct axlf_section_header);
-	num_of_sections = axlf_head.m_header.m_numSections - 1;
+	num_of_sections = axlf_head.m_header.m_numSections;
 	axlf_size = sizeof(struct axlf) + size_of_header * num_of_sections;
 	axlf = vmalloc(axlf_size);
 	if (!axlf) {

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_util.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_util.h
@@ -37,7 +37,7 @@
 ({ \
 	size_t ret; \
 	size_t data_size; \
-	data_size = sect->m_count * sizeof(typeof(sect->data)); \
+	data_size = sect->m_count * sizeof(*(sect->data)); \
 	ret = (sect) ? offsetof(typeof(*sect), data) + data_size : 0; \
 	(ret); \
 })

--- a/src/runtime_src/core/edge/drm/zocl/zert/cu_scu.c
+++ b/src/runtime_src/core/edge/drm/zocl/zert/cu_scu.c
@@ -87,7 +87,7 @@ static void scu_xgq_start(struct xrt_cu_scu *scu, u32 *data)
 	u32 *cu_regfile = scu->vaddr;
 
 	scu->num_reg = (cmd->hdr.count - (sizeof(struct xgq_cmd_start_cuidx)
-				     - sizeof(cmd->hdr) - sizeof(cmd->data)))/sizeof(u32);
+				     - sizeof(cmd->hdr)))/sizeof(u32);
 	for (i = 0; i < scu->num_reg; ++i) {
 		cu_regfile[i+1] = cmd->data[i];
 	}

--- a/src/runtime_src/core/include/ert.h
+++ b/src/runtime_src/core/include/ert.h
@@ -108,7 +108,11 @@ struct ert_packet {
     };
     uint32_t header;
   };
+#if defined(__linux__) && defined(__KERNEL__)
+  uint32_t data[];   /* count number of words */
+#else
   uint32_t data[1];   /* count number of words */
+#endif
 };
 
 /**
@@ -144,10 +148,13 @@ struct ert_start_kernel_cmd {
     };
     uint32_t header;
   };
-
   /* payload */
   uint32_t cu_mask;              /* mandatory cu mask */
-  uint32_t data[1];              /* count-1 number of words */
+  #if defined(__linux__) && defined(__KERNEL__)
+  uint32_t data[];   /* flexible array member*/
+#else
+  uint32_t data[1];   /* count -1 number of words */
+#endif
 };
 
 /**
@@ -327,7 +334,11 @@ struct ert_init_kernel_cmd {
 
   /* payload */
   uint32_t cu_mask;          /* mandatory cu mask */
+ #if defined(__linux__) && defined(__KERNEL__)
+  uint32_t data[];   /* Flexible array member */
+#else
   uint32_t data[1];          /* count-9 number of words */
+#endif
 };
 
 #define KDMA_BLOCK_SIZE 64   /* Limited by KDMA CU */
@@ -411,7 +422,11 @@ struct ert_configure_cmd {
   uint32_t dsa52:1;
 
   /* cu address map size is num_cus */
+#if defined(__linux__) && defined(__KERNEL__)
+  uint32_t data[];  /* Flexible array member */
+#else
   uint32_t data[1];
+#endif
 };
 
 /*

--- a/src/runtime_src/core/include/xclbin.h
+++ b/src/runtime_src/core/include/xclbin.h
@@ -262,9 +262,12 @@ extern "C" {
         unsigned char m_keyBlock[256];              /* Signature for validation of binary */
         uint64_t m_uniqueId;                        /* axlf's uniqueId, use it to skip redownload etc */
         struct axlf_header m_header;                /* Inline header */
-        struct axlf_section_header m_sections[1];   /* One or more section headers follow */
+#if defined(__linux__) && defined(__KERNEL__)
+	struct axlf_section_header m_sections[];   // One or more section headers follow. Flexible array size suitable for kernel space.
+#else
+	struct axlf_section_header m_sections[1];   /* One or more section headers follow */
+#endif
     };
-    XCLBIN_STATIC_ASSERT(sizeof(struct axlf) == 496, "axlf structure no longer is 496 bytes in size");
 
     typedef struct axlf xclBin;
 
@@ -297,10 +300,12 @@ extern "C" {
 
     struct mem_topology {
         int32_t m_count; //Number of mem_data
+#if defined(__linux__) && defined(__KERNEL__)
+        struct mem_data m_mem_data[]; //Should be sorted on mem_type. Flexible array size suitable for kernel space. Flexible array size suitable for kernel space.
+#else
         struct mem_data m_mem_data[1]; //Should be sorted on mem_type
+#endif
     };
-    XCLBIN_STATIC_ASSERT(sizeof(struct mem_topology) == 48, "mem_topology structure no longer is 48 bytes in size");
-
 
     /****   CONNECTIVITY SECTION ****/
     /* Connectivity of each argument of Kernel. It will be in terms of argument
@@ -390,9 +395,12 @@ extern "C" {
 
     struct ip_layout {
         int32_t m_count;
+#if defined(__linux__) && defined(__KERNEL__)
+        struct ip_data m_ip_data[]; //All the ip_data needs to be sorted by m_base_address. Flexible array size suitable for kernel space.
+#else
         struct ip_data m_ip_data[1]; //All the ip_data needs to be sorted by m_base_address.
+#endif
     };
-    XCLBIN_STATIC_ASSERT(sizeof(struct ip_layout) == 88, "ip_layout structure no longer is 88 bytes in size");
 
     /*** Debug IP section layout ****/
     enum DEBUG_IP_TYPE {
@@ -451,9 +459,12 @@ extern "C" {
 
     struct clock_freq_topology {           /* Clock frequency section */
         int16_t m_count;                   /* Number of entries */
-        struct clock_freq m_clock_freq[1]; /* Clock array */
+#if defined(__linux__) && defined(__KERNEL__)
+        struct clock_freq m_clock_freq[]; // Clock array. Flexible array size suitable for kernel space.
+#else
+	struct clock_freq m_clock_freq[1]; /* Clock array */
+#endif
     };
-    XCLBIN_STATIC_ASSERT(sizeof(struct clock_freq_topology) == 138, "clock_freq_topology structure no longer is 138 bytes in size");
 
     enum MCS_TYPE {                        /* Supported MCS file types */
         MCS_UNKNOWN = 0,                   /* Initialized value */

--- a/src/runtime_src/core/include/xgq_cmd_ert.h
+++ b/src/runtime_src/core/include/xgq_cmd_ert.h
@@ -55,7 +55,11 @@
  */
 struct xgq_cmd_start_cuidx {
 	struct xgq_cmd_sq_hdr hdr;
+#if defined(__linux__) && defined(__KERNEL__)
+	uint32_t data[]; // NOLINT
+#else
 	uint32_t data[1]; // NOLINT
+#endif
 };
 
 /**

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
@@ -562,6 +562,7 @@ void xocl_close_drm_render_fds(pid_t pid)
         if (file && file->f_path.dentry) {
             const char *path = file->f_path.dentry->d_name.name;
             if (strstr(path, "renderD") != NULL) {
+		get_file(file);
                 filp_close(file, task->files);
             }
         }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -300,7 +300,7 @@ static inline void xocl_memcpy_toio(void *iomem, void *buf, u32 size)
 ({ \
 	size_t ret; \
 	size_t data_size; \
-	data_size = (sect) ? sect->m_count * sizeof(typeof(sect->data)) : 0; \
+	data_size = (sect) ? (sect->m_count * sizeof(*(sect->data))) : 0; \
 	ret = (sect) ? offsetof(typeof(*sect), data) + data_size : 0; \
 	(ret); \
 })


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
This PR is cherry-picked from https://github.com/Xilinx/XRT/pull/8669 and https://github.com/Xilinx/XRT/pull/8746

https://jira.xilinx.com/browse/CR-1214907 We are getting UBSAN: array-index-out-of-bounds call trace while compiling xocl xclmgmt drivers in ubuntu 24.04

Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Reference: https://www.kernel.org/doc/html/latest/process/deprecated.html#zero-length-and-one-element-arrays

How problem was solved, alternative solutions (if any) and why they were rejected
Added macros to pick flexible arrays when comipiling kernel code.

Risks (if any) associated the changes in the commit
Modifications are in common files and will affect all platforms.
#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
