### PR TITLE
Preemption overhead bug fix

### DIFF
--- a/src/runtime_src/core/tools/common/tests/TestPreeemptionOverhead.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestPreeemptionOverhead.cpp
@@ -131,6 +131,8 @@ TestPreemptionOverhead::run(std::shared_ptr<xrt_core::device> dev)
     return ptree;
   }
   
+  const auto layer_boundary = xrt_core::device_query_default<xq::preemption>(dev.get(), 0);
+
   if(XBUtilities::getVerbose())
     XBU::logger(ptree, "Details", "Using ELF");
 
@@ -177,5 +179,7 @@ TestPreemptionOverhead::run(std::shared_ptr<xrt_core::device> dev)
       ptree.put("status", XBU::test_token_passed);
     }
   }
+  // Restore the original preemption state
+  xrt_core::device_update<xq::preemption>(dev.get(), static_cast<uint32_t>(layer_boundary));
   return ptree;
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
This PR fixes the bug in preemption-overhead test. The test enabled layer boundary preemption for running the commands and kept it enabled which was incorrect.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Windows : https://jira.xilinx.com/browse/AIESW-4207

Linux: https://jira.xilinx.com/browse/AIESW-4275

#### How problem was solved, alternative solutions (if any) and why they were rejected
The problem was solved by caching the state of preemption before starting the test and resetting the state to it once test was done : 
Following are the results before and after the fix :
After fix : 
```
root@xsjstrix45:/opt/xilinx/xrt# xrt-smi validate -r latency 
Validate Device           : [0000:c5:00.1]
    Platform              : NPU Strix
    Power Mode            : Performance
-------------------------------------------------------------------------------
Test 1 [0000:c5:00.1]     : latency                                             
    Details               : Average latency: 51.6 us
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Validation completed. Please run the command '--verbose' option for more details
root@xsjstrix45:/opt/xilinx/xrt# xrt-smi validate -r preemption-overhead --advanced ; xrt-smi validate -r latency
Validate Device           : [0000:c5:00.1]
    Platform              : NPU Strix
    Power Mode            : Performance
-------------------------------------------------------------------------------
Test 1 [0000:c5:00.1]     : preemption-overhead                                 
    Details               : Average noop preemption overhead for 4x4 is 179.0 us
                            Average noop preemption overhead for 4x8 is 320.0 us
                            Average memtile preemption overhead for 4x4 is 372.0 us
                            Average memtile preemption overhead for 4x8 is 668.7 us
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Validation completed. Please run the command '--verbose' option for more details
Validate Device           : [0000:c5:00.1]
    Platform              : NPU Strix
    Power Mode            : Performance
-------------------------------------------------------------------------------
Test 1 [0000:c5:00.1]     : latency                                             
    Details               : Average latency: 51.1 us
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
```

Before fix:
```
root@xsjstrix45:/opt/xilinx/xrt# xrt-smi validate -r latency 
Validate Device           : [0000:c5:00.1]
    Platform              : NPU Strix
    Power Mode            : Performance
-------------------------------------------------------------------------------
Test 1 [0000:c5:00.1]     : latency                                             
    Details               : Average latency: 51.6 us
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Validation completed. Please run the command '--verbose' option for more details
root@xsjstrix45:/opt/xilinx/xrt# xrt-smi validate -r preemption-overhead --advanced ; xrt-smi validate -r latency
Validate Device           : [0000:c5:00.1]
    Platform              : NPU Strix
    Power Mode            : Performance
-------------------------------------------------------------------------------
Test 1 [0000:c5:00.1]     : preemption-overhead                                 
    Details               : Average noop preemption overhead for 4x4 is 179.0 us
                            Average noop preemption overhead for 4x8 is 320.0 us
                            Average memtile preemption overhead for 4x4 is 372.0 us
                            Average memtile preemption overhead for 4x8 is 668.7 us
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Validation completed. Please run the command '--verbose' option for more details
Validate Device           : [0000:c5:00.1]
    Platform              : NPU Strix
    Power Mode            : Performance
-------------------------------------------------------------------------------
Test 1 [0000:c5:00.1]     : latency                                             
    Details               : Average latency: 129.1 us
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
```

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Tested on Linux xsjstrix45

#### Documentation impact (if any)
None
