### PR TITLE
Reverting aie err cb workaround part of CR-1235776

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/edge/zocl_aie.c
+++ b/src/runtime_src/core/edge/drm/zocl/edge/zocl_aie.c
@@ -120,9 +120,6 @@ zocl_aie_error_cb(void *arg)
 	struct aie_errors *errors;
 	int i;
 
-	DRM_WARN("%s: Received AIE_ERR callback, ignoring it\n", __func__);
-	return;
-
 	if (!slot) {
 		DRM_ERROR("%s: slot is not initialized\n", __func__);
 		return;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Workaround for aie err cb part of https://jira.xilinx.com/browse/CR-1235776
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://jira.xilinx.com/browse/CR-1235776
#### How problem was solved, alternative solutions (if any) and why they were rejected
AIE driver fixed the issue. 
#### Risks (if any) associated the changes in the commit
low
#### What has been tested and how, request additional testing if necessary
Tested by manually injecting error while running the application, aie driver is handling the hw errors properly now. And by reverting the changes now ZOCl is also handling properly since aie driver is triggering the callback with correct error inputs.
#### Documentation impact (if any)
n/a