### PR TITLE
[XDP] Fix for AIE Status hang on VEK385 Vitis flow 

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.cpp
@@ -223,14 +223,12 @@ namespace xdp {
       return;
 
     // AIE core register offsets
-#ifdef XDP_VE2_BUILD
-    constexpr uint64_t AIE_OFFSET_CORE_STATUS = 0x38004;
-#else
-    constexpr uint64_t AIE_OFFSET_CORE_STATUS = 0x32004;
-#endif
+    auto hwGen = metadataReader->getHardwareGeneration();
+    uint64_t AIE_OFFSET_CORE_STATUS = 0x32004;
+    if (hwGen == 5)
+      AIE_OFFSET_CORE_STATUS = 0x38004; // AIE2PS
 
     auto offset = metadataReader->getAIETileRowOffset();
-    auto hwGen = metadataReader->getHardwareGeneration();
 
     // This mask check for following states
     // ECC_Scrubbing_Stall


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
AIE Status plugin was causing hang on the board for vek385 vitis flow designs.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Code flow was not reading the correct core status register.
Changed the code to use hw gen from metadata to differentiate the platform and deferred build make variables.
 
#### Risks (if any) associated the changes in the commit
low

#### What has been tested and how, request additional testing if necessary
verified on vek385. Hang is not observed anymore.

#### Documentation impact (if any)
