### PR TITLE
Fixing the runner label for authorize in 2024.2

### DIFF
--- a/.github/workflows/xrt_ci.yml
+++ b/.github/workflows/xrt_ci.yml
@@ -15,7 +15,7 @@ concurrency:
   
 jobs:
   authorize:
-    runs-on: Ubuntu-22.04
+    runs-on: [self-hosted, Ubuntu-22.04]
     steps:
       - name: Checkout private repository      
         uses: actions/checkout@v4   


### PR DESCRIPTION
Adding the self-hosted to runner label to get around the issue observed in https://github.com/Xilinx/XRT/actions/runs/15418023974/job/43487125724?pr=8997 
