### PR TITLE
Remove data retention flag for AWS F2 as this is not supported

### DIFF
--- a/src/runtime_src/core/pcie/tools/cloud-daemon/aws/aws_dev.cpp
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/aws/aws_dev.cpp
@@ -546,10 +546,12 @@ int AwsDev::awsLoadXclBin(const xclBin *buffer)
     fpga_mgmt_describe_local_image(mBoardNumber, &imageInfoOld, 0);
 
     int retVal = 0;
-    union fpga_mgmt_load_local_image_options opt;
+    union fpga_mgmt_load_local_image_options opt = {0};
     // force data retention option
     fpga_mgmt_init_load_local_image_options(&opt);
-    opt.flags = FPGA_CMD_DRAM_DATA_RETENTION;
+    /* Set the data retention mode only for AWS F1, this is not supported for AWS F2 */
+    if (imageInfoOld.spec.map[FPGA_APP_PF].device_id == 0x1042)
+        opt.flags = FPGA_CMD_DRAM_DATA_RETENTION;
     opt.afi_id = afi_id;
     opt.slot_id = mBoardNumber;
     retVal = fpga_mgmt_load_local_image_with_options(&opt);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Data retention support is removed for AWS F2, so made changes in the interface accordingly.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Data retention support is removed for AWS F2, so made changes in the interface accordingly.
#### How problem was solved, alternative solutions (if any) and why they were rejected
Data retention support is removed for AWS F2, so made changes in the interface accordingly.
#### Risks (if any) associated the changes in the commit
None
#### What has been tested and how, request additional testing if necessary
Ran hello world on AWS F2 instance and verified the behavior.
#### Documentation impact (if any)
None