### PR TITLE
Enhance options to xrt-runner.exe

### DIFF
--- a/src/runtime_src/core/common/runner/README.md
+++ b/src/runtime_src/core/common/runner/README.md
@@ -56,3 +56,51 @@ The schema will change before it is finalized and versioned.
   }
 }
 ```
+
+## xrt_runner.exe
+As part of building XRT, the runner infrastructure builds a runner executable that
+can be used to execute recipe and profile pairs.
+
+The executable has two modes, (1) execution of a single recipe/profile
+pair, (2) multi-threaded execution of multiple recipe and profile
+pairs.
+
+To use locally built xrt-runner.exe, it is important that KMD and UMD
+is in sync with what xrt-runner.exe is built from.
+```
+xrt-runner.exe --help
+usage: xrt-runner.exe [options]
+ [--recipe <recipe.json>] recipe file to run
+ [--profile <profile.json>] execution profile
+ [--script <script>] runner script, enables multi-threaded execution
+ [--dir <path>] directory containing artifacts (default: current dir)
+ [--report] print metrics
+
+% xrt-runner.exe --recipe recipe.json --profile profile.json [--dir <path>] [--report]
+% xrt-runner.exe --script runner.json [--dir <path>] [--report]
+```
+
+### runner.json
+Multi-threaded execution of the applcation is controlled by a separate json file that lists 
+what recipe and profile pairs to execute and on how many threads.
+
+```
+{
+  "threads": <number>
+  jobs: [
+    {
+      "id": "custom string",
+      "recipe": "<path>/recipe.json",
+      "profile": "<path>/profile.json",
+      "dir": "<path> artifacts referenced by recipe and profile"
+    },
+    ...
+  ]
+}
+```
+
+Each recipe/profile pair results in the creation of an xrt::runner
+object.  All xrt::runner objects are created and inserted into a work
+queue before execution starts.  Each thread executes work items
+(xrt::runner) from the work queue until the queue is empty.
+

--- a/src/runtime_src/core/common/runner/runner.cpp
+++ b/src/runtime_src/core/common/runner/runner.cpp
@@ -1393,6 +1393,7 @@ class recipe
       report rpt;
       rpt.add(report::section_type::resources, {{"runs", num_runs()}});
       rpt.add(report::section_type::resources, {{"runlist_threshold", m_runlist_threshold}});
+      rpt.add(report::section_type::resources, {{"runlist", num_runs() >= m_runlist_threshold}});
       return rpt;
     }
   }; // class recipe::execution


### PR DESCRIPTION
#### Problem solved by the commit
Add option for specifying number of threads to use.
Add option for overriding profile.json:execution/iterations
add option for showing progress

#### How problem was solved, alternative solutions (if any) and why they were rejected
```
% xrt-runner.exe --help
usage: xrt-runner.exe [options]
 [--recipe <recipe.json>] recipe file to run
 [--profile <profile.json>] execution profile
 [--iterations <number>] override all profile iterations
 [--script <script>] runner script, enables multi-threaded execution
 [--threads <number>] number of threads to use when running script
 [--dir <path>] directory containing artifacts (default: current dir)
 [--progress] show progress
 [--report] print runner metrics

% xrt-runner.exe --recipe recipe.json --profile profile.json [--iterations <num>] [--dir <path>]
% xrt-runner.exe --script runner.json [--threads <num>] [--iterations <num>] [--dir <path>]

Note, [--iterations <num>] overrides iterations in profile.json, but not in runner script.
If the runner script specifies iterations for a recipe/profile pair, then this value is
sticky for that recipe/profile pair.
```
