### PR TITLE
[XDP] Update header path for VE2 as the directory structure is changed by XRT in xdna-driver repo

### DIFF
--- a/src/runtime_src/xdp/profile/device/aie_trace/ve2/aie_trace_offload_ve2.cpp
+++ b/src/runtime_src/xdp/profile/device/aie_trace/ve2/aie_trace_offload_ve2.cpp
@@ -25,7 +25,7 @@
 #include "core/common/shim/hwctx_handle.h"
 #include "core/include/xrt/xrt_hw_context.h"
 #include "core/common/api/hw_context_int.h"
-#include "shim/xdna_hwctx.h"
+#include "shim_ve2/xdna_hwctx.h"
 #include "shim/xdna_aie_array.h"
 #include "xdp/profile/database/database.h"
 #include "xdp/profile/database/static_info/aie_constructs.h"

--- a/src/runtime_src/xdp/profile/device/aie_trace/ve2/aie_trace_offload_ve2.cpp
+++ b/src/runtime_src/xdp/profile/device/aie_trace/ve2/aie_trace_offload_ve2.cpp
@@ -26,7 +26,7 @@
 #include "core/include/xrt/xrt_hw_context.h"
 #include "core/common/api/hw_context_int.h"
 #include "shim_ve2/xdna_hwctx.h"
-#include "shim/xdna_aie_array.h"
+#include "shim_ve2/xdna_aie_array.h"
 #include "xdp/profile/database/database.h"
 #include "xdp/profile/database/static_info/aie_constructs.h"
 #include "xdp/profile/device/aie_trace/ve2/aie_trace_logger_ve2.h"

--- a/src/runtime_src/xdp/profile/plugin/aie_debug/ve2/aie_debug.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_debug/ve2/aie_debug.cpp
@@ -36,7 +36,7 @@
 #include "core/common/config_reader.h"
 #include "core/common/shim/hwctx_handle.h"
 #include "core/common/api/hw_context_int.h"
-#include "shim/xdna_hwctx.h"
+#include "shim_ve2/xdna_hwctx.h"
  
 
 #include "xdp/profile/database/static_info/aie_util.h"

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/ve2/aie_profile.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/ve2/aie_profile.cpp
@@ -35,7 +35,7 @@
 #include "core/include/xrt/xrt_kernel.h"
 #include "core/common/shim/hwctx_handle.h"
 #include "core/common/api/hw_context_int.h"
-#include "shim/xdna_hwctx.h"
+#include "shim_ve2/xdna_hwctx.h"
 #include "xdp/profile/database/database.h"
 #include "xdp/profile/database/static_info/aie_constructs.h"
 #include "xdp/profile/database/static_info/pl_constructs.h"

--- a/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.cpp
@@ -39,7 +39,7 @@
 #ifdef XDP_VE2_BUILD
 #include "core/common/shim/hwctx_handle.h"
 #include "core/common/api/hw_context_int.h"
-#include "shim/xdna_hwctx.h"
+#include "shim_ve2/xdna_hwctx.h"
 #else
 #include "core/edge/user/shim.h"
 #endif

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -39,7 +39,7 @@
 #include "ve2/aie_trace.h"
 #include "xdp/profile/device/hal_device/xdp_hal_device.h"
 #include "core/common/shim/hwctx_handle.h"
-#include "shim/xdna_hwctx.h"
+#include "shim_ve2/xdna_hwctx.h"
 #else
 #include "edge/aie_trace.h"
 #include "xdp/profile/device/hal_device/xdp_hal_device.h"

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/ve2/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/ve2/aie_trace.cpp
@@ -33,7 +33,7 @@
 #include "core/include/xrt/xrt_kernel.h"
 #include "core/common/shim/hwctx_handle.h"
 #include "core/common/api/hw_context_int.h"
-#include "shim/xdna_hwctx.h"
+#include "shim_ve2/xdna_hwctx.h"
 #include "xdp/profile/database/database.h"
 #include "xdp/profile/database/events/creator/aie_trace_data_logger.h"
 #include "xdp/profile/database/static_info/aie_constructs.h"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
XRT will be updating the directory structure for VE2 xdna-driver repo with the following PR https://github.com/amd/xdna-driver/pull/573. So to keep XDP compatible and working XDP need to update the header path in all the files wherever used.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
NA
#### How problem was solved, alternative solutions (if any) and why they were rejected
Updated the header path in XDP.
#### Risks (if any) associated the changes in the commit
XRT submodule commit in VE2 repo should be updated only when @SravanKumarAllu-xilinx PR is merged and XDNA submodule is updated.
#### What has been tested and how, request additional testing if necessary
Tested Trace, Profile, Debug, Halt, ML Timeline plugin on VE2 along with Sravan's PR.
#### Documentation impact (if any)
NA