### PR TITLE
Added uc_firmware_version query to print the cert version

### DIFF
--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -2106,7 +2106,7 @@ struct firmware_version : request
   using result_type = data;
   static const key_type key = key_type::firmware_version;
 
-  virtual std::any
+  std::any
   get(const device* device, const std::any& req_type) const override = 0;
 };
 

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -2089,19 +2089,25 @@ struct stream_buffer_telemetry : request
 // Retrieves the firmware version of the device.
 struct firmware_version : request
 {
+  enum class firmware_type {
+    npu_firmware,
+    uc_firmware
+  };
   struct data
   {
     uint32_t major;
     uint32_t minor;
     uint32_t patch;
     uint32_t build;
+    std::string git_hash;
+    std::string date;
   };
 
   using result_type = data;
   static const key_type key = key_type::firmware_version;
 
   virtual std::any
-  get(const device* device) const override = 0;
+  get(const device* device, const std::any& req_type) const override = 0;
 };
 
 struct clock_freqs_mhz : request


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Added a uc_firmware_version query to print the CERT version. The xrt-smi examine command currently does not show the CERT version. Since the CERT version comes from the driver, I added another query to fetch and display the CERT version and git hash.

Required [PR](https://github.com/amd/xdna-driver/pull/559) is merged in the xdna driver. 
https://gitenterprise.xilinx.com/XRT/Telluride/compare/xdna...mtakasi:Telluride_public:cert_version
```XRT
  Version              : 2.20.0
  Branch               : HEAD
  Hash                 : 23cd4296402fe746448ba210cc42b90628ad91c5
  Hash Date            : 2025-05-29 13:24:27
  zocl                 : 2.20.0, f245499d37b446efe9764d615ce13bb338629fcc
  Firmware Version     : 0.9, b7be35c176f439511dd8949fb93da255f4465b49
  Firmware Build Date  : 2025-04-28
 
Device(s) Present
|BDF             |Name       |
|----------------|-----------|
|[0000:00:00.0]  |Telluride  |
 
 
root@versal:/mnt# 
```

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added uc_firmware_version query. Included an if-else condition to print the certification version only if it is available.

#### Risks (if any) associated the changes in the commit
low

#### What has been tested and how, request additional testing if necessary
Tested on Telluride.

#### Documentation impact (if any)
