### PR TITLE
run recipe migration

### DIFF
--- a/src/runtime_src/core/common/module_loader.cpp
+++ b/src/runtime_src/core/common/module_loader.cpp
@@ -138,11 +138,11 @@ platform_repo_path(const std::string& file)
 {
   for (const auto& path : platform_repo_paths()) {
     auto xpath = path / file;
-    if (sfs::exists(xpath) && sfs::is_regular_file(xpath))
+    if (sfs::exists(xpath))
       return xpath;
   }
 
-  throw std::runtime_error("No such file '" + file + "'");
+  throw std::runtime_error("No such file or directory '" + file + "'");
 }
 
 /**

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -58,6 +58,7 @@ enum class key_type
   xrt_smi_config,
   xrt_smi_lists,
   xclbin_name,
+  runner,
   sequence_name,
   elf_name,
   mobilenet,
@@ -591,6 +592,26 @@ struct xrt_smi_lists : request
   // formatting of individual items for the vector
   static std::string
   to_string(const std::string& value)
+  {
+    return value;
+  }
+};
+
+struct runner : request
+{
+  enum class type {
+    throughput,
+  };
+
+  using result_type = std::string;
+  static const key_type key = key_type::runner;
+  static const char* name() { return "runner"; }
+
+  virtual std::any
+  get(const device*, const std::any& req_type) const override = 0;
+
+  static std::string
+  to_string(const result_type& value)
   {
     return value;
   }

--- a/src/runtime_src/core/common/runner/runner.cpp
+++ b/src/runtime_src/core/common/runner/runner.cpp
@@ -76,6 +76,8 @@ load_json(const std::string& input)
   try {
     if (std::ifstream f{input})
       return json::parse(f);
+    else
+      throw json_error("Failed to open file: " + input);
   }
   catch (const std::exception& ex) {
     throw json_error(ex.what());

--- a/src/runtime_src/core/tools/common/tests/TestNPUThroughput.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestNPUThroughput.cpp
@@ -5,19 +5,15 @@
 // Local - Include Files
 #include "TestNPUThroughput.h"
 #include "TestValidateUtilities.h"
-#include "tools/common/XBUtilities.h"
-#include "xrt/xrt_bo.h"
+#include "core/common/runner/runner.h"
 #include "xrt/xrt_device.h"
-#include "xrt/xrt_hw_context.h"
-#include "xrt/xrt_kernel.h"
-#include "xrt/experimental/xrt_kernel.h"
-namespace XBU = XBUtilities;
+#include "core/common/json/nlohmann/json.hpp"
 
+using json = nlohmann::json;
 #include <filesystem>
 
-static constexpr size_t buffer_size = 20;
-static constexpr int run_buffer = 9;
-static constexpr int itr_count_throughput = 2502;
+static constexpr std::string_view recipe_file = "recipe_throughput.json";
+static constexpr std::string_view profile_file = "profile_throughput.json";
 
 // ----- C L A S S   M E T H O D S -------------------------------------------
 TestNPUThroughput::TestNPUThroughput()
@@ -28,181 +24,27 @@ boost::property_tree::ptree
 TestNPUThroughput::run(std::shared_ptr<xrt_core::device> dev)
 {
   boost::property_tree::ptree ptree = get_test_header();
-  ptree.erase("xclbin");
-
-  // Check Whether Use ELF or DPU Sequence
-  auto elf = XBValidateUtils::get_elf();
-  std::string xclbin_path;
-  
-  if (!elf) {
-    xclbin_path = XBValidateUtils::get_xclbin_path(dev, xrt_core::query::xclbin_name::type::validate, ptree);
-    if (XBU::getVerbose())
-      XBValidateUtils::logger(ptree, "Details", "Using DPU Sequence");
-  } else {
-    xclbin_path = XBValidateUtils::get_xclbin_path(dev, xrt_core::query::xclbin_name::type::validate_elf, ptree);
-    if (XBU::getVerbose())
-      XBValidateUtils::logger(ptree, "Details", "Using ELF");
-  }
-
-  if (!std::filesystem::exists(xclbin_path)){
-    XBValidateUtils::logger(ptree, "Details", "The test is not supported on this device.");
-    return ptree;
-  }
-
-  xrt::xclbin xclbin;
-  try {
-    xclbin = xrt::xclbin(xclbin_path);
-  }
-  catch (const std::runtime_error& ex) {
-    XBValidateUtils::logger(ptree, "Error", ex.what());
-    ptree.put("status", XBValidateUtils::test_token_failed);
-    return ptree;
-  }
-
-  // Determine The DPU Kernel Name
-  auto kernelName = XBValidateUtils::get_kernel_name(xclbin, ptree);
-
-  auto working_dev = xrt::device(dev);
-  working_dev.register_xclbin(xclbin);
-
-  xrt::hw_context hwctx;
-  xrt::kernel kernel;
-
-  if (!elf) { // DPU
-    try {
-      hwctx = xrt::hw_context(working_dev, xclbin.get_uuid());
-      kernel = xrt::kernel(hwctx, kernelName);
-    } 
-    catch (const std::exception& )
-    {
-      XBValidateUtils::logger (ptree, "Error", "Not enough columns available. Please make sure no other workload is running on the device.");
-      ptree.put("status", XBValidateUtils::test_token_failed);
-      return ptree;
-    }
-  }
-  else { // ELF
-    const auto elf_name = xrt_core::device_query<xrt_core::query::elf_name>(dev, xrt_core::query::elf_name::type::nop);
-    auto elf_path = XBValidateUtils::findPlatformFile(elf_name, ptree);
-
-    if (!std::filesystem::exists(elf_path))
-      return ptree;
-    
-    try {
-      hwctx = xrt::hw_context(working_dev, xclbin.get_uuid());
-      kernel = get_kernel(hwctx, kernelName, elf_path);
-    } 
-    catch (const std::exception& )
-    {
-      XBValidateUtils::logger (ptree, "Error", "Not enough columns available. Please make sure no other workload is running on the device.");
-      ptree.put("status", XBValidateUtils::test_token_failed);ptree.put("status", XBValidateUtils::test_token_failed);
-      return ptree;
-    }
-  }
-
-  xrt::xclbin::ip cu;
-  for (const auto& ip : xclbin.get_ips()) {
-    if (ip.get_type() != xrt::xclbin::ip::ip_type::ps)
-      continue;
-    cu = ip;
-    break;
-  }
-
-  // create specified number of runs and populate with arguments
-  std::vector<xrt::bo> global_args;
-  std::vector<xrt::run> run_handles;
-  if (!elf) {
-    for (int i = 0; i < run_buffer; ++i) {
-      auto run = xrt::run(kernel);
-      for (const auto& arg : cu.get_args()) {
-        auto arg_idx = static_cast<int>(arg.get_index());
-        if (arg.get_host_type() == "uint64_t")
-          run.set_arg(arg_idx, static_cast<uint64_t>(XBValidateUtils::get_opcode()));
-        else if (arg.get_host_type() == "uint32_t")
-          run.set_arg(arg_idx, static_cast<uint32_t>(1));
-        else if (arg.get_host_type().find('*') != std::string::npos) {
-          xrt::bo bo;
-
-          if (arg.get_name() == "instruct") {
-            bo = xrt::bo(hwctx, arg.get_size(), xrt::bo::flags::cacheable, kernel.group_id(arg_idx));
-            auto bo_mapped = bo.map<int*>();
-            for (size_t idx = 0; idx < arg.get_size(); idx++)
-              bo_mapped[idx] = 0;
-          } else {
-            bo = xrt::bo(working_dev, arg.get_size(), xrt::bo::flags::host_only, kernel.group_id(arg_idx));
-          }
-
-          bo.sync(XCL_BO_SYNC_BO_TO_DEVICE);
-          global_args.push_back(bo);
-          run.set_arg(arg_idx, bo);
-        }
-      }
-      run_handles.push_back(std::move(run));
-    }
-  }
-  else {
-    for (int i=0; i < run_buffer; ++i) {
-      auto run = xrt::run(kernel);
-      for (const auto& arg : cu.get_args()) {
-        auto arg_idx = static_cast<int>(arg.get_index());
-        if (arg.get_host_type() == "uint64_t") // opcode
-          run.set_arg(arg_idx, static_cast<uint64_t>(XBValidateUtils::get_opcode()));
-        else if (arg.get_host_type() == "uint32_t") // nistruct
-          run.set_arg(arg_idx, static_cast<uint32_t>(0));
-        else if (arg.get_host_type().find('*') != std::string::npos) {
-          if (arg.get_name() == "instruct")
-            run.set_arg(arg_idx, 0);
-          else {
-            xrt::bo bo = xrt::ext::bo{working_dev, buffer_size};
-            bo.sync(XCL_BO_SYNC_BO_TO_DEVICE);
-            global_args.push_back(bo);
-            run.set_arg(arg_idx, bo);
-          }
-        }
-      }
-      run_handles.push_back(std::move(run));
-    }
-  }
-
-  //Log
-  if (XBU::getVerbose()) {
-    XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Instruction size: %f bytes") % buffer_size));
-    XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("No. of iterations: %f") % itr_count_throughput));
-  }
-
-  // Run the test to compute throughput where we saturate NPU with jobs and then wait for all
-  // completions at the end
-  double elapsedSecs = 0.0;
-
-  try {
+  std::string repo_path = xrt_core::device_query<xrt_core::query::runner>(dev, xrt_core::query::runner::type::throughput);
+  repo_path = XBValidateUtils::findPlatformFile(repo_path, ptree);
+  std::string recipe = repo_path + std::string(recipe_file);
+  std::string profile = repo_path + std::string(profile_file);
+  try
+  {
+    xrt_core::runner runner(xrt::device(dev), recipe, profile, std::filesystem::path(repo_path));
     auto start = std::chrono::high_resolution_clock::now();
+    runner.execute();
+    runner.wait();
 
-    // enqueue 9 commnds
-    for (int i = 0; i < run_buffer; i++)
-      run_handles[i%run_buffer].start();
-
-    // wait for each command to finish, then start immediately
-    for (int i = 0; i < (itr_count_throughput - run_buffer); i++) {
-      run_handles[i%run_buffer].wait2();
-      run_handles[i%run_buffer].start();
-    }
-
-    // wait for the last 9 commands to finish
-    for (int i = 0; i < run_buffer; i++)
-      run_handles[i%run_buffer].wait2();
-
-    auto end = std::chrono::high_resolution_clock::now();
-    elapsedSecs = std::chrono::duration_cast<std::chrono::duration<double>>(end-start).count();
+    auto report = json::parse(runner.get_report());
+    XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Average throughput: %.1f ops") % report["cpu"]["throughput"].get<double>()));
+    ptree.put("status", XBValidateUtils::test_token_passed);
+    return ptree;
   }
-  catch (const std::exception& ex) {
-    XBValidateUtils::logger(ptree, "Error", ex.what());
+  catch(const std::exception& e)
+  {
+    XBValidateUtils::logger(ptree, "Error", e.what());
     ptree.put("status", XBValidateUtils::test_token_failed);
     return ptree;
   }
-
-  // Compute the throughput
-  const double throughput = (elapsedSecs != 0.0) ? itr_count_throughput / elapsedSecs : 0.0;
-
-  XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Average throughput: %.1f ops") % throughput));
-  ptree.put("status", XBValidateUtils::test_token_passed);
   return ptree;
 }


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
This PR migrates the NPU throughput test within xrt-smi to the newly added XRT runner format. This is the first in subsequent PRs that are geared towards migrating xrt-smi tests to runner format. 
This will be followed by shim side changes in MCDM and XDNA drivers to support runner based test

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
The problem was solved by adding the static files required by this test in runner format to MCDM shim and querying the paths to them through shim.
Then creating runner object using static files and executing the run recipe.
The throughput metric was then queried directly from runner instead of calculating it locally for reporting.
The findPlatformFile() API was also enhanced to query valid paths instead of just files within platform. 
Output on kracken
```
Z:\Repos\XRT-MCDM-FORK\XRT-MCDM\build\WRelease\xilinx\xrt>xrt-smi validate -r throughput --verbose
Verbose: Enabling Verbosity
Verbose: Setting power mode to `performance`

Validate Device           : [00c5:00:01.1]
    Platform              : NPU Krackan
    Power Mode            : Performance
-------------------------------------------------------------------------------
Test 1 [00c5:00:01.1]     : throughput
    Description           : Run end-to-end throughput test
    Details               : Average throughput: 60971.0 ops
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Validation completed
```

#### Risks (if any) associated the changes in the commit
This migration should be tested on all platforms

#### What has been tested and how, request additional testing if necessary
Tested in windows kracken platform

#### Documentation impact (if any)
None
