### PR TITLE
[XDP] Removing unused parameters to avoid Windows warning treated as error

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info_database.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info_database.cpp
@@ -2397,7 +2397,7 @@ namespace xdp {
     setDeviceNameFromXclbin(deviceId, xrtXclbin);
     if (readAIEdata) {
       readAIEMetadata(xrtXclbin, clientBuild);
-      setAIEGeneration(deviceId, xrtXclbin);
+      setAIEGeneration(deviceId);
     }
 
     /* Configure AMs if context monitoring is supported
@@ -2416,7 +2416,7 @@ namespace xdp {
 
     // Following functions require configInfo to be created first.
     if (readAIEdata)
-      setAIEClockRateMHz(deviceId, xrtXclbin);
+      setAIEClockRateMHz(deviceId);
     initializeProfileMonitors(devInfo, std::move(xrtXclbin));
 
     devInfo->isReady = true;
@@ -2503,7 +2503,7 @@ namespace xdp {
     return metadataReader.get();
   }
 
-  void VPStaticDatabase::setAIEGeneration(uint64_t deviceId, xrt::xclbin xrtXclbin) {
+  void VPStaticDatabase::setAIEGeneration(uint64_t deviceId) {
     std::lock_guard<std::mutex> lock(deviceLock) ;
     if (deviceInfo.find(deviceId) == deviceInfo.end())
       return;
@@ -2519,7 +2519,7 @@ namespace xdp {
     }
   }
 
-  void VPStaticDatabase::setAIEClockRateMHz(uint64_t deviceId, xrt::xclbin xrtXclbin) {
+  void VPStaticDatabase::setAIEClockRateMHz(uint64_t deviceId) {
     std::lock_guard<std::mutex> lock(deviceLock) ;
 
     if (deviceInfo.find(deviceId) == deviceInfo.end())

--- a/src/runtime_src/xdp/profile/database/static_info_database.h
+++ b/src/runtime_src/xdp/profile/database/static_info_database.h
@@ -148,8 +148,8 @@ namespace xdp {
     void initializeFIFO(DeviceInfo* devInfo) ;
 
     void setDeviceNameFromXclbin(uint64_t deviceId, xrt::xclbin xrtXclbin);
-    void setAIEGeneration(uint64_t deviceId, xrt::xclbin xrtXclbin) ;
-    void setAIEClockRateMHz(uint64_t deviceId, xrt::xclbin xrtXclbin) ;
+    void setAIEGeneration(uint64_t deviceId);
+    void setAIEClockRateMHz(uint64_t deviceId);
     bool initializeStructure(XclbinInfo*, xrt::xclbin);
     bool initializeProfileMonitors(DeviceInfo*, xrt::xclbin);
     double findClockRate(xrt::xclbin);


### PR DESCRIPTION
#### Problem solved by the commit
A few functions in the profiling library had unused parameters, which end up causing warnings on Windows builds and these warnings are treated as errors in some builds.  This pull request removes the unused parameters.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Removes unused parameters from internal utility functions.

#### Risks (if any) associated the changes in the commit
Low risk as these functions were not called from outside of the object.

#### Documentation impact (if any)
No documentation impact.
