### PR TITLE
[XDP] Fix ExternalBuffers identification and storage

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_control_config_filetype.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_control_config_filetype.cpp
@@ -192,7 +192,7 @@ AIEControlConfigFiletype::getPLIOs() const
         plio.channelNum = 0;
         plio.burstLength = 0;
 
-        std::string plioKey = xdp::getGraphUniqueId(plio.name, plio.shimColumn, plio.channelNum, plio.streamId);
+        std::string plioKey = xdp::getGraphUniqueId(plio.shimColumn, plio.channelNum, plio.streamId);
         plios[plioKey] = plio;
     }
 
@@ -246,7 +246,7 @@ AIEControlConfigFiletype::getChildGMIOs( const std::string& childStr) const
         gmio.streamId = gmio_node.second.get<uint8_t>("stream_id");
         gmio.burstLength = gmio_node.second.get<uint8_t>("burst_length_in_16byte");
 
-        std::string gmioKey = xdp::getGraphUniqueId(gmio.name, gmio.shimColumn, gmio.channelNum, gmio.streamId);
+        std::string gmioKey = xdp::getGraphUniqueId(gmio.shimColumn, gmio.channelNum, gmio.streamId);
         gmios[gmioKey] = gmio;
     }
 

--- a/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_control_config_filetype.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_control_config_filetype.cpp
@@ -22,6 +22,7 @@
 
 #include "aie_control_config_filetype.h"
 #include "core/common/message.h"
+#include "xdp/profile/plugin/vp_base/utility.h"
 #include "xdp/profile/database/static_info/aie_util.h"
 #include "xdp/profile/plugin/aie_profile/aie_profile_defs.h"
 
@@ -191,7 +192,8 @@ AIEControlConfigFiletype::getPLIOs() const
         plio.channelNum = 0;
         plio.burstLength = 0;
 
-        plios[plio.name] = plio;
+        std::string plioKey = xdp::getGraphUniqueId(plio.name, plio.shimColumn, plio.channelNum, plio.streamId);
+        plios[plioKey] = plio;
     }
 
     return plios;
@@ -244,7 +246,8 @@ AIEControlConfigFiletype::getChildGMIOs( const std::string& childStr) const
         gmio.streamId = gmio_node.second.get<uint8_t>("stream_id");
         gmio.burstLength = gmio_node.second.get<uint8_t>("burst_length_in_16byte");
 
-        gmios[gmio.name] = gmio;
+        std::string gmioKey = xdp::getGraphUniqueId(gmio.name, gmio.shimColumn, gmio.channelNum, gmio.streamId);
+        gmios[gmioKey] = gmio;
     }
 
     return gmios;

--- a/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_trace_config_filetype.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_trace_config_filetype.cpp
@@ -100,7 +100,8 @@ AIETraceConfigFiletype::getExternalBuffers() const
         gmio.streamId = buf_node.second.get<uint8_t>("stream_id");
         gmio.burstLength = 8;
 
-        gmios[gmio.name] = gmio;
+        std::string gmioKey = xdp::getGraphUniqueId(gmio.name, gmio.shimColumn, gmio.channelNum, gmio.streamId);
+        gmios[gmioKey] = gmio;
     }
 
     return gmios;

--- a/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_trace_config_filetype.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_trace_config_filetype.cpp
@@ -100,7 +100,7 @@ AIETraceConfigFiletype::getExternalBuffers() const
         gmio.streamId = buf_node.second.get<uint8_t>("stream_id");
         gmio.burstLength = 8;
 
-        std::string gmioKey = xdp::getGraphUniqueId(gmio.name, gmio.shimColumn, gmio.channelNum, gmio.streamId);
+        std::string gmioKey = xdp::getGraphUniqueId(gmio.shimColumn, gmio.channelNum, gmio.streamId);
         gmios[gmioKey] = gmio;
     }
 

--- a/src/runtime_src/xdp/profile/plugin/vp_base/utility.cpp
+++ b/src/runtime_src/xdp/profile/plugin/vp_base/utility.cpp
@@ -197,4 +197,11 @@ namespace xdp {
     return mode ;
   }
 
+  std::string getGraphUniqueId(std::string graphName, uint8_t col,
+                                uint8_t channelNum, uint8_t streamId)
+  {
+    return graphName + "_" + std::to_string(col) + "_" +
+           std::to_string(channelNum) + "_" + std::to_string(streamId);
+  }
+
 } // end namespace xdp

--- a/src/runtime_src/xdp/profile/plugin/vp_base/utility.cpp
+++ b/src/runtime_src/xdp/profile/plugin/vp_base/utility.cpp
@@ -197,11 +197,13 @@ namespace xdp {
     return mode ;
   }
 
-  std::string getGraphUniqueId(std::string graphName, uint8_t col,
-                                uint8_t channelNum, uint8_t streamId)
+  std::string getGraphUniqueId(const std::string& graphName, uint8_t col,
+                               uint8_t channelNum, uint8_t streamId)
   {
-    return graphName + "_" + std::to_string(col) + "_" +
-           std::to_string(channelNum) + "_" + std::to_string(streamId);
+    std::ostringstream uniqueId;
+    uniqueId << graphName << "_" << static_cast<int>(col) << "_"
+             << static_cast<int>(channelNum) << "_" << static_cast<int>(streamId);
+    return uniqueId.str();
   }
 
 } // end namespace xdp

--- a/src/runtime_src/xdp/profile/plugin/vp_base/utility.cpp
+++ b/src/runtime_src/xdp/profile/plugin/vp_base/utility.cpp
@@ -197,12 +197,11 @@ namespace xdp {
     return mode ;
   }
 
-  std::string getGraphUniqueId(const std::string& graphName, uint8_t col,
-                               uint8_t channelNum, uint8_t streamId)
+  std::string getGraphUniqueId(uint8_t col, uint8_t channelNum, uint8_t streamId)
   {
     std::ostringstream uniqueId;
-    uniqueId << graphName << "_" << static_cast<int>(col) << "_"
-             << static_cast<int>(channelNum) << "_" << static_cast<int>(streamId);
+    uniqueId << static_cast<int>(col) << "_" << static_cast<int>(channelNum)
+             << "_" << static_cast<int>(streamId);
     return uniqueId.str();
   }
 

--- a/src/runtime_src/xdp/profile/plugin/vp_base/utility.h
+++ b/src/runtime_src/xdp/profile/plugin/vp_base/utility.h
@@ -57,8 +57,8 @@ namespace xdp {
   }
 
   XDP_CORE_EXPORT Flow getFlowMode();
-  XDP_CORE_EXPORT std::string getGraphUniqueId(const std::string& graphName, uint8_t col,
-                                               uint8_t channelNum, uint8_t streamId);
+  XDP_CORE_EXPORT std::string getGraphUniqueId(uint8_t col, uint8_t channelNum,
+                                               uint8_t streamId);
 
 } // end namespace xdp
 

--- a/src/runtime_src/xdp/profile/plugin/vp_base/utility.h
+++ b/src/runtime_src/xdp/profile/plugin/vp_base/utility.h
@@ -57,8 +57,8 @@ namespace xdp {
   }
 
   XDP_CORE_EXPORT Flow getFlowMode();
-  XDP_CORE_EXPORT std::string getGraphUniqueId(std::string graphName, uint8_t col,
-                                                uint8_t channelNum, uint8_t streamId);
+  XDP_CORE_EXPORT std::string getGraphUniqueId(const std::string& graphName, uint8_t col,
+                                               uint8_t channelNum, uint8_t streamId);
 
 } // end namespace xdp
 

--- a/src/runtime_src/xdp/profile/plugin/vp_base/utility.h
+++ b/src/runtime_src/xdp/profile/plugin/vp_base/utility.h
@@ -57,6 +57,8 @@ namespace xdp {
   }
 
   XDP_CORE_EXPORT Flow getFlowMode();
+  XDP_CORE_EXPORT std::string getGraphUniqueId(std::string graphName, uint8_t col,
+                                                uint8_t channelNum, uint8_t streamId);
 
 } // end namespace xdp
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Observed in two stamped designs on Client
Not all shim tiles were getting configured for metric sets 
Same Port Names are mapped to different shim tiles, this was causing Key collision in internal data structure storage.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Each port name is uniquely identified and stored in associated map.

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
Verified on Client, original Test now passes.

#### Documentation impact (if any)
