### PR TITLE
runtime_src: fix unreferenced parameter compilation warning

### DIFF
--- a/src/runtime_src/core/tools/common/TestRunner.h
+++ b/src/runtime_src/core/tools/common/TestRunner.h
@@ -25,7 +25,7 @@ class TestRunner : public JSONConfigurable {
   public:
     virtual boost::property_tree::ptree run(std::shared_ptr<xrt_core::device> dev) = 0;
     boost::property_tree::ptree startTest(std::shared_ptr<xrt_core::device> dev);
-    virtual void set_param(const std::string key, const std::string value){}
+    virtual void set_param(const std::string, const std::string) {}
     bool is_explicit() const { return m_explicit; };
     virtual bool getConfigHidden() const { return is_explicit(); };
     const void set_xclbin_path(std::string path) { m_xclbin = path; };


### PR DESCRIPTION
There are some files have unreferenced input arguments. MSVC compiler can reports `C4100: unreferenced parameter` warning as errors. This patch is to mark those function arguments as (void) in the function body.

Here is an example of the warning:
C:\Users\wendlian\src\XRT-MCDM\src\xrt\src\runtime_src\core\tools\common\TestRunner.h(28,69): error C2220: the following warning is treated as an error [C:\Users\wendlian\src\XRT-MCDM\build\WRelease\src\xrt\src\runtime_src\core\tools\xbutil2\xrt-smi.vcxproj]
  (compiling source file '../../../../../../../../../src/xrt/src/runtime_src/core/tools/common/tests/TestAIEReconfigOverhead.cpp')

C:\Users\wendlian\src\XRT-MCDM\src\xrt\src\runtime_src\core\tools\common\TestRunner.h(28,69): warning C4100: 'value': unreferenced parameter [C:\Users\wendlian\src\XRT-MCDM\build\WRelease\src\xrt\src\runtime_src\core\tools\xbutil2\xrt-smi.vcxproj]
  (compiling source file '../../../../../../../../../src/xrt/src/runtime_src/core/tools/common/tests/TestAIEReconfigOverhead.cpp')

C:\Users\wendlian\src\XRT-MCDM\src\xrt\src\runtime_src\core\tools\common\TestRunner.h(28,46): warning C4100: 'key': unreferenced parameter [C:\Users\wendlian\src\XRT-MCDM\build\WRelease\src\xrt\src\runtime_src\core\tools\xbutil2\xrt-smi.vcxproj]
  (compiling source file '../../../../../../../../../src/xrt/src/runtime_src/core/tools/common/tests/TestAIEReconfigOverhead.cpp')

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
