### PR TITLE
pyxrt porting of runlist, ext, kernel

### DIFF
--- a/src/python/pybind11/src/pyxrt.cpp
+++ b/src/python/pybind11/src/pyxrt.cpp
@@ -394,7 +394,7 @@ PYBIND11_MODULE(pyxrt, m) {
     */
     py::module_ ext = m.def_submodule("ext", "Submodule for external");
 
-    py::class_<xrt::ext::bo, xrt::bo> pyextbo(ext, "bo", "Represents an external buffer object");
+    py::class_<xrt::ext::bo, xrt::bo> pyextbo(ext, "bo", "Represents an enhanced version of xrt::bo with support for access mode");
 
     py::enum_<xrt::ext::bo::access_mode>(pyextbo, "access_mode", "External buffer access mode")
         .value("none", xrt::ext::bo::access_mode::none)
@@ -486,6 +486,6 @@ PYBIND11_MODULE(pyxrt, m) {
         }), "Wait for all runs in the runlist to complete")
         .def("wait", ([](xrt::runlist &r, const std::chrono::milliseconds& timeout) {
             return r.wait(timeout);
-        }), "Another way to wait for all runs in hte runlist to complete");
+        }), "Wait for the specified timeout for the runlist to complete");
         
 }

--- a/src/python/pybind11/src/pyxrt.cpp
+++ b/src/python/pybind11/src/pyxrt.cpp
@@ -206,6 +206,12 @@ PYBIND11_MODULE(pyxrt, m) {
         .def("wait", ([](xrt::run& r, unsigned int timeout_ms)  {
                           return r.wait(timeout_ms);
                       }), "Wait for the specified milliseconds for the run to complete")
+        .def("wait2", [](xrt::run&r) { 
+                            return r.wait2();
+                    }, "Wait for the run to complete")
+        .def("wait2", [](xrt::run&r, const std::chrono::milliseconds& timeout) {
+                            return r.wait2(timeout);
+                    }, "Wait for the specified milliseconds for the run to complete")
         .def("state", &xrt::run::state, "Check the current state of a run object")
         .def("add_callback", &xrt::run::add_callback, "Add a callback function for run state");
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Porting new APIs: Runlist, Ext, Kernel from C++ to Python using Pybind11
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
NA
#### How problem was solved, alternative solutions (if any) and why they were rejected
Added pybind bindings for various new API methods in XRT
#### Risks (if any) associated the changes in the commit
NA
#### What has been tested and how, request additional testing if necessary
Tested on Linux strix45 NPU, on model-tests
#### Documentation impact (if any)
