### PR TITLE
[XDP] API to get hwCtxImpl UID

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info_database.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info_database.cpp
@@ -1599,6 +1599,22 @@ namespace xdp {
     updateDevice(deviceId, xrtXclbin, std::move(xdpDevice), isClient(), readAIEMetadata);
   }
 
+  uint64_t VPStaticDatabase::getHwCtxImplUid(void* hwCtxImpl)
+  {
+    std::lock_guard<std::mutex> lock(hwCtxImplUIDMapLock);
+    // NOTE: XDP plugins checks for validity of the hwContex Implementation handle
+    // before calling this function. So, we don't need to check for validity here.
+
+    auto it  = hwCtxImplUIDMap.find(hwCtxImpl);
+    if (it == hwCtxImplUIDMap.end()) {
+      // Assign a new UID
+      uint64_t uid = static_cast<uint64_t>(hwCtxImplUIDMap.size());
+      hwCtxImplUIDMap[hwCtxImpl] = uid;
+      return uid;
+    }
+    return it->second;
+  }
+
   // Return true if we should reset the device information.
   // Return false if we should not reset device information
   bool VPStaticDatabase::resetDeviceInfo(uint64_t deviceId, xdp::Device* xdpDevice, xrt_core::uuid new_xclbin_uuid)

--- a/src/runtime_src/xdp/profile/database/static_info_database.h
+++ b/src/runtime_src/xdp/profile/database/static_info_database.h
@@ -97,6 +97,9 @@ namespace xdp {
     // Device Specific Information mapped to the Unique Device Id
     std::map<uint64_t, std::unique_ptr<DeviceInfo>> deviceInfo;
 
+    // Map of hwCtxImpl Handle to unique ID to form device UID.
+    std::map<void*, uint64_t> hwCtxImplUIDMap;
+
     // Static info can be accessed via any host thread, so we have
     //  fine grained locks on each of the types of data.
     std::mutex summaryLock ;
@@ -104,6 +107,7 @@ namespace xdp {
     std::mutex deviceLock ;
     std::mutex aieLock ;
     std::mutex appStyleLock;
+    std::mutex hwCtxImplUIDMapLock;
 
     // AIE device (Supported devices only)
     void* aieDevInst = nullptr ; // XAie_DevInst
@@ -306,6 +310,9 @@ namespace xdp {
                                     std::shared_ptr<xrt_core::device> device,
                                     bool readAIEMetadata = true,
                                     std::unique_ptr<xdp::Device> xdpDevice = nullptr);
+
+    XDP_CORE_EXPORT
+    uint64_t getHwCtxImplUid(void* hwCtxImpl);
 
     // *********************************************************
     // ***** Functions related to trace_processor tool *****


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
XDP plugins need an API to uniquely identify each hwCtxImpl in different flows ( X or ML) & across repetitive calls
Next Steps:
 This API is planned to be used by each plugin to determine unique device ID.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
NA

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary


#### Documentation impact (if any)
