### PR TITLE
DF bandwidth test migration to run recipe format

### DIFF
--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -602,6 +602,7 @@ struct runner : request
   enum class type {
     throughput,
     latency,
+    df_bandwidth,
   };
 
   using result_type = std::string;

--- a/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.cpp
@@ -4,7 +4,6 @@
 // ------ I N C L U D E   F I L E S -------------------------------------------
 // Local - Include Files
 
-
 #include "TestDF_bandwidth.h"
 #include "TestValidateUtilities.h"
 #include "core/common/runner/runner.h"
@@ -14,7 +13,6 @@
 
 using json = nlohmann::json;
 #include <filesystem>
-
 
 static constexpr std::string_view recipe_file = "recipe_df_bandwidth.json";
 static constexpr std::string_view profile_file = "profile_df_bandwidth.json";
@@ -42,9 +40,8 @@ TestDF_bandwidth::run(std::shared_ptr<xrt_core::device> dev)
     auto elapsed_us = report["cpu"]["elapsed"].get<double>();
     auto iterations = report["cpu"]["iterations"].get<int>();
 
-    // NOLINTBEGIN
-    double bandwidth = (2 * iterations ) / (elapsed_us / 1000000);
-    // NOLINTEND
+    // Used buffer in runner is 1GB in size, thus reporting in GB/s
+    double bandwidth = (2 * iterations ) / (elapsed_us / 1000000); // NOLINT: Runner reports in microseconds, so conversion is required until request supports timescales
 
     if(XBUtilities::getVerbose())
       XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Total duration: %.1fs") % (elapsed_us / 1000000)));

--- a/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.cpp
@@ -3,25 +3,21 @@
 
 // ------ I N C L U D E   F I L E S -------------------------------------------
 // Local - Include Files
+
+
 #include "TestDF_bandwidth.h"
 #include "TestValidateUtilities.h"
-#include "tools/common/XBUtilities.h"
-#include "xrt/xrt_bo.h"
+#include "core/common/runner/runner.h"
 #include "xrt/xrt_device.h"
-#include "xrt/xrt_hw_context.h"
-#include "xrt/xrt_kernel.h"
-namespace XBU = XBUtilities;
+#include "core/common/json/nlohmann/json.hpp"
+#include "tools/common/XBUtilities.h"
 
-// 3rd Party Library - Include Files
-
-// System - Include Files
-#include <fstream>
+using json = nlohmann::json;
 #include <filesystem>
 
-static constexpr size_t buffer_size_gb = 1;
-static constexpr size_t buffer_size = buffer_size_gb * 1024 * 1024 * 1024; //1 GB
-static constexpr size_t word_count = buffer_size/4;
-static constexpr int itr_count = 600;
+
+static constexpr std::string_view recipe_file = "recipe_df_bandwidth.json";
+static constexpr std::string_view profile_file = "profile_df_bandwidth.json";
 
 // ----- C L A S S   M E T H O D S -------------------------------------------
 TestDF_bandwidth::TestDF_bandwidth()
@@ -32,167 +28,35 @@ boost::property_tree::ptree
 TestDF_bandwidth::run(std::shared_ptr<xrt_core::device> dev)
 {
   boost::property_tree::ptree ptree = get_test_header();
-  ptree.erase("xclbin");
-  
-  // Check Whether Use ELF or DPU Sequence
-  auto elf = XBValidateUtils::get_elf();
-  std::string xclbin_path; 
-  
-  if (!elf) {
-    xclbin_path = XBValidateUtils::get_xclbin_path(dev, xrt_core::query::xclbin_name::type::validate, ptree);
-    if (XBU::getVerbose())
-      XBValidateUtils::logger(ptree, "Details", "Using DPU Sequence");
-  } else {
-    xclbin_path = XBValidateUtils::get_xclbin_path(dev, xrt_core::query::xclbin_name::type::validate_elf, ptree);
-    if (XBU::getVerbose())
-      XBValidateUtils::logger(ptree, "Details", "Using ELF");
-  }
+  std::string repo_path = xrt_core::device_query<xrt_core::query::runner>(dev, xrt_core::query::runner::type::df_bandwidth);
+  repo_path = XBValidateUtils::findPlatformFile(repo_path, ptree);
+  std::string recipe = repo_path + std::string(recipe_file);
+  std::string profile = repo_path + std::string(profile_file);
+  try
+  {
+    xrt_core::runner runner(xrt::device(dev), recipe, profile, std::filesystem::path(repo_path));
+    runner.execute();
+    runner.wait();
 
-  if (!std::filesystem::exists(xclbin_path)){
-    XBValidateUtils::logger(ptree, "Details", "The test is not supported on this device.");
-    return ptree;
-  }
+    auto report = json::parse(runner.get_report());
+    auto elapsed_us = report["cpu"]["elapsed"].get<double>();
+    auto iterations = report["cpu"]["iterations"].get<int>();
 
-  xrt::xclbin xclbin;
-  try {
-    xclbin = xrt::xclbin(xclbin_path);
+    // NOLINTBEGIN
+    double bandwidth = (2 * iterations ) / (elapsed_us / 1000000);
+    // NOLINTEND
+
+    if(XBUtilities::getVerbose())
+      XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Total duration: %.1fs") % (elapsed_us / 1000000)));
+
+    XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Average bandwidth per shim DMA: %.1f GB/s") % bandwidth));
+    ptree.put("status", XBValidateUtils::test_token_passed);
   }
-  catch (const std::runtime_error& ex) {
-    XBValidateUtils::logger(ptree, "Error", ex.what());
+  catch(const std::exception& e)
+  {
+    XBValidateUtils::logger(ptree, "Error", e.what());
     ptree.put("status", XBValidateUtils::test_token_failed);
     return ptree;
   }
-
-  // Determine The DPU Kernel Name
-  auto kernelName = XBValidateUtils::get_kernel_name(xclbin, ptree);
-
-  auto working_dev = xrt::device(dev);
-  working_dev.register_xclbin(xclbin);
-
-  size_t instr_size = 0;
-  std::string dpu_instr;
-
-  xrt::hw_context hwctx;
-  xrt::kernel kernel;
-
-  if (!elf) { // DPU
-    try {
-      hwctx = xrt::hw_context(working_dev, xclbin.get_uuid());
-      kernel = xrt::kernel(hwctx, kernelName);
-    } 
-    catch (const std::exception& )
-    {
-      XBValidateUtils::logger (ptree, "Error", "Not enough columns available. Please make sure no other workload is running on the device.");
-      ptree.put("status", XBValidateUtils::test_token_failed);
-      return ptree;
-    }
-
-    const auto seq_name = xrt_core::device_query<xrt_core::query::sequence_name>(dev, xrt_core::query::sequence_name::type::df_bandwidth);
-    dpu_instr = XBValidateUtils::findPlatformFile(seq_name, ptree);
-    if (!std::filesystem::exists(dpu_instr))
-      return ptree;
-
-    try {
-      instr_size = XBValidateUtils::get_instr_size(dpu_instr); 
-    }
-    catch(const std::exception& ex) {
-      XBValidateUtils::logger(ptree, "Error", ex.what());
-      ptree.put("status", XBValidateUtils::test_token_failed);
-      return ptree;
-    }
-  }
-  else { // ELF
-    const auto elf_name = xrt_core::device_query<xrt_core::query::elf_name>(dev, xrt_core::query::elf_name::type::df_bandwidth);
-    auto elf_path = XBValidateUtils::findPlatformFile(elf_name, ptree);
-
-    if (!std::filesystem::exists(elf_path))
-      return ptree;
-    
-    try {
-      hwctx = xrt::hw_context(working_dev, xclbin.get_uuid());
-      kernel = get_kernel(hwctx, kernelName, elf_path);
-    } 
-    catch (const std::exception& )
-    {
-      XBValidateUtils::logger (ptree, "Error", "Not enough columns available. Please make sure no other workload is running on the device.");
-      ptree.put("status", XBValidateUtils::test_token_failed);
-      return ptree;
-    }
-  }
-
-  //Create BOs
-  xrt::bo bo_ifm;
-  xrt::bo bo_ofm;
-  xrt::bo bo_instr;
-  if (!elf) { 
-    bo_ifm = xrt::bo(working_dev, buffer_size, XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(1));
-    bo_ofm = xrt::bo(working_dev, buffer_size, XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(3));
-    bo_instr = xrt::bo(working_dev, instr_size*sizeof(int), XCL_BO_FLAGS_CACHEABLE, kernel.group_id(5));
-    XBValidateUtils::init_instr_buf(bo_instr, dpu_instr);
-  } 
-  else {
-    bo_ifm = xrt::ext::bo{working_dev, buffer_size};
-    bo_ofm = xrt::ext::bo{working_dev, buffer_size};
-  }
-  
-  // map input buffer
-  auto ifm_mapped = bo_ifm.map<int*>();
-	for (size_t i = 0; i < word_count; i++)
-		ifm_mapped[i] = rand() % 4096;
-
-  //Sync BOs
-  bo_ifm.sync(XCL_BO_SYNC_BO_TO_DEVICE);
-  if (!elf) { 
-    bo_instr.sync(XCL_BO_SYNC_BO_TO_DEVICE);
-  }
-
-  //Log
-  if(XBU::getVerbose()) { 
-    XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Buffer size: %f GB") % buffer_size_gb));
-    XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("No. of iterations: %f") % itr_count));
-  }
-
-  auto start = std::chrono::high_resolution_clock::now();
-  for (int i = 0; i < itr_count; i++) {
-    try {
-      xrt::run run;
-      if (!elf) {
-        run = kernel(XBValidateUtils::get_opcode(), bo_ifm, NULL, bo_ofm, NULL, bo_instr, instr_size, NULL);
-      } else {
-        run = kernel(XBValidateUtils::get_opcode(), 0, 0, bo_ifm, 0, bo_ofm, 0, 0);
-      }
-      
-      // Wait for kernel to be done
-      run.wait2();
-    }
-    catch (const std::exception& ex) {
-      XBValidateUtils::logger(ptree, "Error", ex.what());
-      ptree.put("status", XBValidateUtils::test_token_failed);
-      return ptree;
-    }
-  }
-  auto end = std::chrono::high_resolution_clock::now();
-
-  //map ouput buffer
-  bo_ofm.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
-  auto ofm_mapped = bo_ofm.map<int*>();
-  for (size_t i = 0; i < word_count; i++) {
-    if (ofm_mapped[i] != ifm_mapped[i]) {
-      auto msg = boost::str(boost::format("Data mismatch at out buffer[%d]") % i);
-      XBValidateUtils::logger(ptree, "Error", msg);
-      return ptree;
-    }
-  }
-
-  //Calculate bandwidth
-  auto elapsedSecs = std::chrono::duration_cast<std::chrono::duration<double>>(end-start).count();
-  //Data is read and written in parallel hence x2
-  double bandwidth = (buffer_size_gb*itr_count*2) / elapsedSecs;
-
-  if(XBU::getVerbose())
-    XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Total duration: %.1fs") % elapsedSecs));
-  XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Average bandwidth per shim DMA: %.1f GB/s") % bandwidth));
-  ptree.put("status", XBValidateUtils::test_token_passed);
-
   return ptree;
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
This PR adds the XRT code for changing df-bandwidth test to run recipe format. 

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://jira.xilinx.com/browse/AIESW-1721

#### How problem was solved, alternative solutions (if any) and why they were rejected
The problem was solved through adding the the runner artifacts to linux and testing on the strix45 machine.

#### Risks (if any) associated the changes in the commit
Currently I'm seeing inconsistent behavior between elf and non-elf runs for the same test on linux strix45 without run recipe: 
Default without elf : 
```
aktondak@xsjstrix45:/proj/rdi/staff/aktondak/xdna/xdna-driver/build$ xrt-smi validate -r df-bw --advanced 
WARNING: User doesn't have admin permissions to set performance mode. Running validate in Default mode
Validate Device           : [0000:c5:00.1]
    Platform              : NPU Strix
    Power Mode            : Default
-------------------------------------------------------------------------------
Test 1 [0000:c5:00.1]     : df-bw                                               
    Details               : Average bandwidth per shim DMA: 39.2 GB/s
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
```

Default with elf 
```
aktondak@xsjstrix45:/proj/rdi/staff/aktondak/xdna/xdna-driver/xrt/build$ xrt-smi validate -r df-bw --advanced --elf
WARNING: User doesn't have admin permissions to set performance mode. Running validate in Default mode
Validate Device           : [0000:c5:00.1]
    Platform              : NPU Strix
    Power Mode            : Default
-------------------------------------------------------------------------------
Test 1 [0000:c5:00.1]     : df-bw                                               
    Details               : Average bandwidth per shim DMA: 58.8 GB/s
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
```

After run recipe migration(elf by default) : 
```
aktondak@xsjstrix45:/proj/rdi/staff/aktondak/xdna/xdna-driver/build$ xrt-smi validate -r df-bw --advanced 
WARNING: User doesn't have admin permissions to set performance mode. Running validate in Default mode
Validate Device           : [0000:c5:00.1]
    Platform              : NPU Strix
    Power Mode            : Default
-------------------------------------------------------------------------------
Test 1 [0000:c5:00.1]     : df-bw                                               
    Details               : Average bandwidth per shim DMA: 58.3 GB/s
    Test Status           : [PASSED]
```

#### What has been tested and how, request additional testing if necessary
Tested with above results on linux. Numbers with elf match between run recipe and default. 

#### Documentation impact (if any)
None
