### PR TITLE
Enable arm64 build on Windows

### DIFF
--- a/src/CMake/nativeWin.cmake
+++ b/src/CMake/nativeWin.cmake
@@ -59,8 +59,12 @@ if (MSVC)
     /DEFAULTLIB:ucrt$<$<CONFIG:Debug>:d>.lib       # Hybrid CRT
     /DEBUG      # instruct linker to create debugging info
     /guard:cf   # enable linker control guard feature (CFG) to prevent attackers from redirecting execution to unsafe locations
-    /CETCOMPAT  # enable Control-flow Enforcement Technology (CET) Shadow Stack mitigation
     )
+  if (NOT ${CMAKE_CXX_COMPILER} MATCHES "(arm64|ARM64)")
+    add_link_options(
+      /CETCOMPAT  # enable Control-flow Enforcement Technology (CET) Shadow Stack mitigation
+      )
+  endif()
 endif()
 
 
@@ -86,7 +90,9 @@ add_subdirectory(runtime_src)
 include(CMake/findpackage.cmake)
 
 # --- Python bindings ---
-xrt_add_subdirectory(python)
+if (NOT ${CMAKE_CXX_COMPILER} MATCHES "(arm64|ARM64)")
+  xrt_add_subdirectory(python)
+endif()
 
 # -- CPack windows SDK if base component
 if (${XRT_BASE_DEV_COMPONENT} STREQUAL "base_dev")

--- a/src/runtime_src/core/common/CMakeLists.txt
+++ b/src/runtime_src/core/common/CMakeLists.txt
@@ -11,6 +11,8 @@ add_subdirectory(runner)
 
 if(CMAKE_VERSION VERSION_LESS "3.18.0")
   message(WARNING "CMake version is less than 3.18.0, build of submodule aiebu disabled")
+elseif (${CMAKE_CXX_COMPILER} MATCHES "(arm64|ARM64)")
+  message(WARNING "Compiling for ARM64, build of submodule aiebu disabled")
 elseif (${XRT_NATIVE_BUILD} STREQUAL "yes")
   set(AIEBU_FULL OFF)
   set(AIEBU_SUBMODULE ON)


### PR DESCRIPTION
- remove /CETCOMPAT for ARM build
- update cmake to ignore building aiebu and python directories when building on ARM

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Update cmake to support Windows on ARM64 build

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
New request to support Windows on ARM64 build

#### How problem was solved, alternative solutions (if any) and why they were rejected
Update CMAKE complier/linker flag
disable python and aiebu when using ARM64 compiler

#### Risks (if any) associated the changes in the commit
No impact to existing build configuration

#### What has been tested and how, request additional testing if necessary
Test build for on x64(release/debug) and arm64 (release/debug)

#### Documentation impact (if any)
N/A