### PR TITLE
CR-1243454: Skip destroying aie for pl-aie merged xclbin usecases

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/edge/zocl_hwctx.c
+++ b/src/runtime_src/core/edge/drm/zocl/edge/zocl_hwctx.c
@@ -82,7 +82,8 @@ int zocl_destroy_hw_ctx(struct drm_zocl_dev *zdev, struct drm_zocl_destroy_hw_ct
     s_id = kds_hw_ctx->slot_idx;
     ret = kds_free_hw_ctx(client, kds_hw_ctx);
     if (--slot->hwctx_ref_cnt == 0) {
-        zocl_destroy_aie(slot);
+        if (s_id != 0)
+            zocl_destroy_aie(slot);
         zdev->slot_mask &= ~(1 << s_id);
         DRM_DEBUG("Released the slot %d", s_id);
     }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1243454
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
It was a bug. It was discovered by reloading the PL+AIE (merged xclbin) again. Earlier we used to destroy the aie for all the usecases while destroying the hw context. For merged xclbin (PL + AIE) usecases, we do not clean the slot-0 fully (special case for slot-0 and PL). On the second time if we try to run again after destroying the first hw context on the second hw context we do not create the aie again for this usecase.
#### How problem was solved, alternative solutions (if any) and why they were rejected
The problem was solved by not destroying the aie while destroying the hw context for usecases like this.
#### Risks (if any) associated the changes in the commit
n/a
#### What has been tested and how, request additional testing if necessary
Tested the provided usecase on the CR.
#### Documentation impact (if any)
n/a