### PR TITLE
Changes required to show aiarm driver version in the xrt-smi examine

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/Makefile
+++ b/src/runtime_src/core/edge/drm/zocl/Makefile
@@ -32,8 +32,8 @@ endif
 
 ccflags-y += -Wall
 
-# Version adjusted to 2.19 for 2025.1
-XRT_DRIVER_VERSION ?= 2.19.0
+# Version adjusted to 2.20 for master
+XRT_DRIVER_VERSION ?= 2.20.0
 
 # Add patch number in version if 'XRT_VERSION_PATCH' env variable is defined
 ifneq ($(XRT_VERSION_PATCH),)

--- a/src/runtime_src/core/edge/drm/zocl/common/zocl_drv.c
+++ b/src/runtime_src/core/edge/drm/zocl/common/zocl_drv.c
@@ -1418,7 +1418,7 @@ static void __exit zocl_exit(void)
 }
 module_exit(zocl_exit);
 
-MODULE_VERSION(XRT_DRIVER_VERSION);
+MODULE_VERSION(XRT_HASH);
 
 MODULE_DESCRIPTION(ZOCL_DRIVER_DESC);
 MODULE_AUTHOR("Sonal Santan <sonal.santan@xilinx.com>");

--- a/src/runtime_src/core/edge/user/drv.h
+++ b/src/runtime_src/core/edge/user/drv.h
@@ -14,6 +14,9 @@ class dev;
 class drv  //Base class for edge type of drivers
 {
 public:
+   virtual std::string
+   name() const = 0;
+
    virtual void
    scan_devices(std::vector<std::shared_ptr<dev>>& dev_list) = 0;
 

--- a/src/runtime_src/core/edge/user/drv_zocl.h
+++ b/src/runtime_src/core/edge/user/drv_zocl.h
@@ -14,6 +14,8 @@ namespace xrt_core::edge {
 class drv_zocl : public drv
 {
 public:
+   std::string
+   name() const override { return "zocl"; }
    void
    scan_devices(std::vector<std::shared_ptr<dev>>& dev_list) override;
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Changes required to show aiarm driver version in the xrt-smi examine. Removed Hardcoded driver name in the edge side.
Storing git_hash as the module version() instead of XRT_DRIVER_VERSION. This will be helpful to find the version when we build and load the driver independetly.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added name() function to the edge_drv class and removed the hardcoded check.

#### Risks (if any) associated the changes in the commit
low

#### What has been tested and how, request additional testing if necessary
Tested by building edge cases in both petalinux flow and ecternal_src flow.

#### Documentation impact (if any)
NA