### PR TITLE
Extend runner to support config elf (program)

### DIFF
--- a/src/runtime_src/core/common/api/xrt_elf.cpp
+++ b/src/runtime_src/core/common/api/xrt_elf.cpp
@@ -16,6 +16,7 @@
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include <boost/interprocess/streams/bufferstream.hpp>
@@ -47,7 +48,8 @@ public:
       throw std::runtime_error("not a valid ELF stream");
   }
 
-  explicit elf_impl(const void *data, size_t size)
+  explicit
+  elf_impl(const void *data, size_t size)
   {
     // Uses the same approach as in aiebu reporter.cpp
     // ibufferstream allows reading from data without first copying over
@@ -151,7 +153,12 @@ elf(std::istream& stream)
 
 elf::
 elf(const void *data, size_t size)
-    : detail::pimpl<elf_impl>{std::make_shared<elf_impl>(data, size)}
+  : detail::pimpl<elf_impl>{std::make_shared<elf_impl>(data, size)}
+{}
+
+elf::
+elf(const std::string_view& sv)
+  : detail::pimpl<elf_impl>{std::make_shared<elf_impl>(sv.data(), sv.size())}
 {}
 
 xrt::uuid

--- a/src/runtime_src/core/common/runner/recipe.md
+++ b/src/runtime_src/core/common/runner/recipe.md
@@ -43,26 +43,32 @@ kernel arguments.
 
 ## Header
 
-For the time being, the header stores nothing but the path to the
-xclbin.  The xclbin contains the kernel meta data used by XRT when
-xrt::kernel objects are created.  The xclbin contains PDIs for each
-kernel, the PDIs are loaded by firmware prior to running a kernel.
+The header section identifies programs with PDIs and meta data used by
+XRT when xrt::kernel objects are created.
+
+The run recipe supports legacy xclbin and new program configuration
+ELF files.
 
 The header section can be amended with other meta data as needed.
+
+If both "xclbin" and "program" are specified, the behavior is
+undefined, one takes precedence over the other, but which one is
+undefined.
 
 ```
 {
   "header": {
-    "xclbin": "design.xclbin",
+    "xclbin": "design.xclbin"
+    "program": "config.elf"
   },
   
   ...
 }
 ```
 
-The runner will use the xclbin from the `header` section to create an
-xrt::hw_context, which is subsequently used to create xrt::kernel
-objects.
+The runner will use the xclbin or program from the `header` section to
+create an xrt::hw_context, which is subsequently used to create
+xrt::kernel objects.
 
 ## Resources
 
@@ -77,14 +83,14 @@ be listed in the resources section.
 
 Kernels listed in the resources section result in runner creating
 `xrt::kernel` objects.  In XRT, the kernel objects are identified by
-name, which must match a kernel instance name in the xclbin.
+name, which must match a kernel instance name in the xclbin or program.
 
 Kernels are constructed from the instance name and what control code
 the kernel should execute.  The hardware context associated with the
-kernel is created by the runner from the xclbin specified in the
-recipe `header` section, so kernels in the resources section must
-contain just the kernel instance name and the full path to an ELF with
-the control code.
+kernel is created by the runner from the xclbin or program specified
+in the recipe `header` section, so kernels in the resources section
+must contain just the kernel instance name and the full path to an ELF
+with the control code.
 
 ```
   "resources": {
@@ -105,7 +111,7 @@ to which instance should be executed.
 If a kernel is instantiated from the same instance kernel name and same
 control code, then only one such kernel instance needs to be listed in
 the resources section.  Listing multiple kernel instances referring to
-the same xclbin kernel and using the same control code is not error,
+the same kernel and using the same control code is not error,
 but is not necessary.
 
 ### CPU functions
@@ -357,7 +363,7 @@ each individual runlist will be executed in sequence, when the
 framework calls the runner API execute method.
 
 In addition to the buffer arguments referring to resource buffers, the
-xclbin kernels and cpu functions may have additional arguments that
+kernels and cpu functions may have additional arguments that
 need to be set. For example the current DPU kernel have 8 arguments
 and some of these must be set to some sentinel value.  Here the
 argument with index 0, represents the kernel opcode which specifies

--- a/src/runtime_src/core/common/runner/runner.cpp
+++ b/src/runtime_src/core/common/runner/runner.cpp
@@ -716,11 +716,11 @@ class recipe
     }
 
     static xrt::hw_context
-    create_hwctx(const xrt::device& device, const xrt::uuid& uuid,
+    create_hwctx(xrt::device device, const xrt::xclbin& xclbin,
                  const xrt::hw_context::qos_type& qos)
     {
       try {
-        return {device, uuid, qos};
+        return {device, device.register_xclbin(xclbin), qos};
       }
       catch (const std::exception& ex) {
         throw xrt_core::runner::hwctx_error{ex.what()};
@@ -744,7 +744,7 @@ class recipe
                  const xrt::hw_context::qos_type& qos)
     {
       if (auto xclbin = header.get_xclbin())
-        return create_hwctx(device, xclbin.get_uuid(), qos);
+        return create_hwctx(device, xclbin, qos);
 
       if (auto program = header.get_program())
         return create_hwctx(device, program, qos);

--- a/src/runtime_src/core/common/runner/runner.cpp
+++ b/src/runtime_src/core/common/runner/runner.cpp
@@ -22,6 +22,7 @@
 #include "core/include/xrt/xrt_hw_context.h"
 #include "core/include/xrt/xrt_kernel.h"
 #include "core/include/xrt/xrt_uuid.h"
+#include "core/include/xrt/experimental/xrt_aie.h"
 #include "core/include/xrt/experimental/xrt_elf.h"
 #include "core/include/xrt/experimental/xrt_ext.h"
 #include "core/include/xrt/experimental/xrt_kernel.h"
@@ -408,18 +409,34 @@ class recipe
   class header
   {
     xrt::xclbin m_xclbin;
+    xrt::aie::program m_program;
 
     static xrt::xclbin
     read_xclbin(const json& j, const artifacts::repo* repo)
     {
+      if (!j.contains("xclbin"))
+        return {};
+        
       auto path = j.at("xclbin").get<std::string>();
       auto data = repo->get(path);
       return xrt::xclbin{data};
     }
 
+    static xrt::aie::program
+    read_program(const json& j, const artifacts::repo* repo)
+    {
+      if (!j.contains("program"))
+        return {};
+
+      auto path = j.at("program").get<std::string>();
+      auto data = repo->get(path);
+      return xrt::aie::program{data};
+    }
+
   public:
     header(const json& j, const artifacts::repo* repo)
       : m_xclbin{read_xclbin(j, repo)}
+      , m_program{read_program(j, repo)}
     {
       XRT_DEBUGF("Loaded xclbin: %s\n", m_xclbin.get_uuid().to_string().c_str());
     }
@@ -430,6 +447,12 @@ class recipe
     get_xclbin() const
     {
       return m_xclbin;
+    }
+
+    xrt::aie::program
+    get_program() const
+    {
+      return m_program;
     }
 
     report
@@ -704,12 +727,37 @@ class recipe
       }
     }
 
+    static xrt::hw_context
+    create_hwctx(const xrt::device& device, const xrt::aie::program& program,
+                 const xrt::hw_context::qos_type& qos)
+    {
+      try {
+        return {device, program, qos, xrt::hw_context::access_mode::shared};
+      }
+      catch (const std::exception& ex) {
+        throw xrt_core::runner::hwctx_error{ex.what()};
+      }
+    }
+
+    static xrt::hw_context
+    create_hwctx(const xrt::device& device, const header& header, 
+                 const xrt::hw_context::qos_type& qos)
+    {
+      if (auto xclbin = header.get_xclbin())
+        return create_hwctx(device, xclbin.get_uuid(), qos);
+
+      if (auto program = header.get_program())
+        return create_hwctx(device, program, qos);
+
+      throw recipe_error("No program or xclbin specified");
+    }
+
   public:
-    resources(xrt::device device, const xrt::xclbin& xclbin,
+    resources(xrt::device device, const header& header,
               const xrt::hw_context::qos_type& qos,
               const json& recipe, const artifacts::repo* repo)
       : m_device{std::move(device)}
-      , m_hwctx{create_hwctx(m_device, m_device.register_xclbin(xclbin), qos)}
+      , m_hwctx{create_hwctx(m_device, header, qos)}
       , m_buffers{create_buffers(m_device, recipe.at("buffers"))}
       , m_kernels{create_kernels(m_device, m_hwctx, recipe.at("kernels"), repo)}
       , m_cpus{create_cpus(recipe.value("cpus", empty_json))} // optional
@@ -1412,7 +1460,7 @@ public:
     : m_device{std::move(device)}
     , m_recipe_json(std::move(recipe)) // paren required, else initialized as array
     , m_header{m_recipe_json.at("header"), repo}
-    , m_resources{m_device, m_header.get_xclbin(), qos, m_recipe_json.at("resources"), repo}
+    , m_resources{m_device, m_header, qos, m_recipe_json.at("resources"), repo}
     , m_execution{m_resources, m_recipe_json.at("execution"), runlist_threshold }
   {}
 

--- a/src/runtime_src/core/include/xrt/experimental/xrt_aie.h
+++ b/src/runtime_src/core/include/xrt/experimental/xrt_aie.h
@@ -40,6 +40,14 @@ public:
   using size_type = uint32_t;
 
   /**
+   * program() - Construct for empty program
+   *
+   * It is undefined behavior to use a default constructed program object
+   * for anything but assignment.
+   */
+  program() = default;
+
+  /**
    * program() - Create a program object using xrt::elf constructors.
    *
    * Construction fails if the ELF is not a valid AIE program.

--- a/src/runtime_src/core/include/xrt/experimental/xrt_elf.h
+++ b/src/runtime_src/core/include/xrt/experimental/xrt_elf.h
@@ -38,6 +38,19 @@ public:
   elf(const std::string& fnm);
 
   /**
+   * elf() - Constructor from raw data
+   *
+   * @param data
+   *  Raw data of elf
+   *
+   * The raw data of the elfcan be deleted after calling the
+   * constructor.
+   */
+  XRT_API_EXPORT
+  explicit
+  elf(const std::string_view& data);
+
+  /**
    * elf() - Constructor from raw ELF data stream
    *
    * @param stream


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Minor tweaks to create hwctx from recipe:header:program for configuration elf.

Add xrt::elf constructor from std::string_view to avoid copying.

