### PR TITLE
New API to provide unique identifier for device abstraction in XDP

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info_database.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info_database.cpp
@@ -1616,7 +1616,7 @@ namespace xdp {
     return it->second;
   }
 
-  uint64_t VPStaticDatabase::getXDPUniqueId(void* handle)
+  uint64_t VPStaticDatabase::getDeviceContextUniqueId(void* handle)
   {
     auto style = getAppStyle();
     if (AppStyle::LOAD_XCLBIN_STYLE == style) {

--- a/src/runtime_src/xdp/profile/database/static_info_database.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info_database.cpp
@@ -1622,7 +1622,7 @@ namespace xdp {
     if (AppStyle::LOAD_XCLBIN_STYLE == style) {
       // handle is an xclDeviceHandle in this style
       // Use sysfs path based unique device identifier in XDP
-      return addDevice(util::getDebugIpLayoutPath(handle));
+      return db->addDevice(util::getDebugIpLayoutPath(handle));
     }
     // For REGISTER_XCLBIN_STYLE and APP_STYLE_NOT_SET
     // handle is an HW Ctx Impl pointer

--- a/src/runtime_src/xdp/profile/database/static_info_database.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info_database.cpp
@@ -35,6 +35,7 @@
 #include "xdp/profile/database/static_info/xclbin_info.h"
 #include "xdp/profile/database/static_info_database.h"
 #include "xdp/profile/device/pl_device_intf.h"
+#include "xdp/profile/device/utility.h"
 #include "xdp/profile/plugin/vp_base/utility.h"
 #include "xdp/profile/writer/vp_base/vp_run_summary.h"
 
@@ -1613,6 +1614,19 @@ namespace xdp {
       return uid;
     }
     return it->second;
+  }
+
+  uint64_t VPStaticDatabase::getXDPUniqueId(void* handle)
+  {
+    auto style = getAppStyle();
+    if (AppStyle::LOAD_XCLBIN_STYLE == style) {
+      // handle is an xclDeviceHandle in this style
+      // Use sysfs path based unique device identifier in XDP
+      return addDevice(util::getDebugIpLayoutPath(handle));
+    }
+    // For REGISTER_XCLBIN_STYLE and APP_STYLE_NOT_SET
+    // handle is an HW Ctx Impl pointer
+    return getHwCtxImplUid(handle);
   }
 
   // Return true if we should reset the device information.

--- a/src/runtime_src/xdp/profile/database/static_info_database.h
+++ b/src/runtime_src/xdp/profile/database/static_info_database.h
@@ -314,7 +314,7 @@ namespace xdp {
     XDP_CORE_EXPORT
     uint64_t getHwCtxImplUid(void* hwCtxImpl);
 
-    /* API to assign unique id for HW Context/Device abstraction in XDP
+    /* API to assign unique id for Device abstraction/HW Context in XDP
      * For traditional App style using Load Xclbin, this API receives 
      * Device Handle and uses corresponding sysfs path to identify and
      * assign unique identifier.
@@ -322,7 +322,7 @@ namespace xdp {
      * API receieves HW Ctx Impl as argument and assigns unique identifier.
      */
     XDP_CORE_EXPORT
-    uint64_t getXDPUniqueId(void*);
+    uint64_t getDeviceContextUniqueId(void*);
 
     // *********************************************************
     // ***** Functions related to trace_processor tool *****

--- a/src/runtime_src/xdp/profile/database/static_info_database.h
+++ b/src/runtime_src/xdp/profile/database/static_info_database.h
@@ -314,6 +314,16 @@ namespace xdp {
     XDP_CORE_EXPORT
     uint64_t getHwCtxImplUid(void* hwCtxImpl);
 
+    /* API to assign unique id for HW Context/Device abstraction in XDP
+     * For traditional App style using Load Xclbin, this API receives 
+     * Device Handle and uses corresponding sysfs path to identify and
+     * assign unique identifier.
+     * For new App style using register xclbin and HW Ctx invocation, this
+     * API receieves HW Ctx Impl as argument and assigns unique identifier.
+     */
+    XDP_CORE_EXPORT
+    uint64_t getXDPUniqueId(void*);
+
     // *********************************************************
     // ***** Functions related to trace_processor tool *****
     // ***** which creates events from raw PL trace    *****


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
XDP now supports application styles using either LoadXclbin, RegisterXclbin-HWCtxt. This new API getDeviceContextUniqueId identifies the app style and calls applicable internal API to provide unique ID for both the styles.
This API should be used in all the XDP Plugins for multiple partition support.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Enhancement

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Used in multipartition tests to ensure unique ids are generated correctly.

#### Documentation impact (if any)
