### PR TITLE
Amend xrt::elf with constructor from string literal

### DIFF
--- a/src/runtime_src/core/include/xrt/experimental/xrt_elf.h
+++ b/src/runtime_src/core/include/xrt/experimental/xrt_elf.h
@@ -33,6 +33,9 @@ class elf : public detail::pimpl<elf_impl>
 public:
   elf() = default;
 
+  /**
+   * elf() - Constructor from ELF file
+   */
   XRT_API_EXPORT
   explicit
   elf(const std::string& fnm);
@@ -49,6 +52,16 @@ public:
   XRT_API_EXPORT
   explicit
   elf(const std::string_view& data);
+
+  /**
+   * elf() - Constructor from ELF file
+   *
+   * Avoid ambiguity between std::string and std::string_view.
+   */
+  explicit
+  elf(const char* fnm)
+    : elf(std::string(fnm))
+  {}
 
   /**
    * elf() - Constructor from raw ELF data stream


### PR DESCRIPTION
#### Problem solved by the commit
This resolves ambiguity between std::string and std::string_view contructor.
