### PR TITLE
Fix bug in handling older non group ELF

### DIFF
--- a/src/runtime_src/core/common/api/module_int.h
+++ b/src/runtime_src/core/common/api/module_int.h
@@ -73,7 +73,7 @@ patch(const xrt::module&, const std::string& argnm, size_t index, const xrt::bo&
 XRT_CORE_COMMON_EXPORT
 XRT_CORE_UNUSED
 size_t
-get_patch_buf_size(const xrt::module&, xrt_core::patcher::buf_type, uint32_t id = UINT32_MAX);
+get_patch_buf_size(const xrt::module&, xrt_core::patcher::buf_type, uint32_t id = no_ctrl_code_id);
 
 // Extract control code buffer and patch it with addresses from all arguments.
 // This API may be useful for developing unit test case at SHIM level where
@@ -87,7 +87,7 @@ XRT_CORE_COMMON_EXPORT
 XRT_CORE_UNUSED
 void
 patch(const xrt::module&, uint8_t*, size_t, const std::vector<std::pair<std::string, uint64_t>>*,
-      xrt_core::patcher::buf_type, uint32_t id = UINT32_MAX);
+      xrt_core::patcher::buf_type, uint32_t id = no_ctrl_code_id);
 
 // Patch scalar into control code at given argument
 XRT_CORE_COMMON_EXPORT

--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -1019,14 +1019,7 @@ public:
       constexpr const char* kname = "";
       std::vector<uint32_t> sec_ids;
       for (const auto& sec : m_elfio.sections) {
-        auto name = sec->get_name();
-        // insert only the sections that can be grouped
-        if ((name.find(patcher::to_string(xrt_core::patcher::buf_type::ctrltext)) == std::string::npos)
-            && (name.find(patcher::to_string(xrt_core::patcher::buf_type::ctrldata)) == std::string::npos)
-            && (name.find(patcher::to_string(xrt_core::patcher::buf_type::pad)) == std::string::npos)
-            && (name.find(patcher::to_string(xrt_core::patcher::buf_type::dump)) == std::string::npos))
-          continue;
-
+        // insert all the sections into a common group
         sec_ids.push_back(sec->get_index());
         // fill the sec_to_grp_map for lookup later
         // for this kind of ELF we fill UINT32_MAX as there is no group section


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Fixed bug in handling older ELF which has no group sections
Removed condition for grouping as there can be 1 group for all the sections in older ELF's

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
PR - https://github.com/Xilinx/XRT/pull/9030 introduced the bug and it was discovered while running shim tests of xdna-driver repo. 
Shim test was trying to scratchpad symbol in preempt save/restore section in older ELF and as preempt save/restore sections are not grouped test was failing, fixed it

#### How problem was solved, alternative solutions (if any) and why they were rejected
Adding all the available sections into default group in older ELF's

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
Tested the failing test case and it passes after applying the fix

#### Documentation impact (if any)
NA