### PR TITLE
Fix HIP kernel argument extraction

### DIFF
--- a/src/runtime_src/hip/core/event.cpp
+++ b/src/runtime_src/hip/core/event.cpp
@@ -102,6 +102,35 @@ kernel_start::kernel_start(std::shared_ptr<stream> s, std::shared_ptr<function> 
 {
   auto k = func->get_kernel();
 
+  /*
+   * args (or kernelParams) is defined as the following by CUDA documentation:
+   *
+   * "Kernel parameters can be specified via kernelParams. If f has N
+   * parameters, then kernelParams needs to be an array of N pointers. Each of
+   * kernelParams[0] through kernelParams[N-1] must point to a region of memory
+   * from which the actual kernel parameter will be copied. The number of kernel
+   * parameters and their offsets and sizes do not need to be specified as that
+   * information is retrieved directly from the kernel's image."
+   *
+   * Essentially args is an array of void * where each element points to the
+   * "actual argument" which may be either a scalar or pointer to a buffer.
+   * See the following example:
+        uint64_t opcode = 3;
+        void *o0 = obj0.getDeviceView(); // pointer to device buffer
+        void *o1 = obj1.getDeviceView(); // pointer to device buffer
+        void *o2 = obj2.getDeviceView(); // pointer to device buffer
+        void *o4 = obj4.getDeviceView(); // pointer to device buffer
+        std::array<void *, 8> args = {
+        &opcode, // pointer to scalar
+        nullptr, // ctrlcode pointer
+        nullptr, // pointer to control code size
+        &o0, // pointer to pointer
+        &o1, // pointer to pointer
+        &o2, // pointer to pointer
+        nullptr, // ctrlpkt pointer
+        &o4}; // pointer to pointer
+   */
+
   // create run object and set args
   r = xrt::run(k);
 
@@ -112,15 +141,20 @@ kernel_start::kernel_start(std::shared_ptr<stream> s, std::shared_ptr<function> 
     if (arg->index == karg::no_index)
       throw std::runtime_error("function has invalid argument");
 
+    if (!args[idx]) {
+      // Skip nullptr which is used for ctrlcode, ctrlcode size and ctrlpkt
+      idx++;
+      continue;
+    }
+
     switch (arg->type) {
       case karg::argtype::scalar :
         xrt_core::kernel_int::set_arg_at_index(r, arg->index, args[idx], arg->size);
         break;
 
       case karg::argtype::global: {
-        if (!args[idx])
-          break;
-        auto hip_mem = memory_database::instance().get_hip_mem_from_addr(args[idx]).first;
+        void **bufptr = static_cast<void **>(args[idx]);
+        auto hip_mem = memory_database::instance().get_hip_mem_from_addr(*bufptr).first;
         if (!hip_mem)
           throw std::runtime_error("failed to get memory from arg at index - " + std::to_string(idx));
 
@@ -193,12 +227,12 @@ bool memory_pool_command::submit()
   case free:
     m_mem_pool->free(m_ptr);
     break;
-  
+
   default:
     throw std::runtime_error("Invalid memory pool operation type.");
     break;
   }
-  
+
   return true;
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Update the HIP kernel parameter walking/parsing code 

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
NA

#### How problem was solved, alternative solutions (if any) and why they were rejected
Clarified the semantics of parameters passed in `kernelParams` as part of `hipLaunchKernel`. Every element in the array
is a pointer to the _actual_ parameter. The actual parameter may be a scalar or a buffer. In the case of former we end 
up pointer to a scalar. In the case of latter we end up with pointer to pointer since the buffer is represented as pointer.

#### Risks (if any) associated the changes in the commit
Need to review all the existing HIP tests to ensure they are composing the `kernelParams` correctly.

#### What has been tested and how, request additional testing if necessary
Tested with model-tests testcase which was converted to HIP

#### Documentation impact (if any)
NA