### PR TITLE
AIESW-6055 [XRT-RUNNER] Enhance runner recipe with debug buffers

### DIFF
--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -1530,6 +1530,15 @@ map()
   });
 }
 
+const void*
+bo::
+map() const
+{
+  return xdp::native::profiling_wrapper("xrt::bo::map", [this]{
+    return handle->get_hbuf();
+  });
+}
+
 void
 bo::
 write(const void* src, size_t size, size_t seek)

--- a/src/runtime_src/core/include/xrt/xrt_bo.h
+++ b/src/runtime_src/core/include/xrt/xrt_bo.h
@@ -1,7 +1,6 @@
-/*
- * Copyright (C) 2020-2022 Xilinx, Inc
- * SPDX-License-Identifier: Apache-2.0
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2020-2022 Xilinx, Inc. All rights reserved.
+// Copyright (C) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
 #ifndef XRT_BO_H_
 #define XRT_BO_H_
 
@@ -11,6 +10,7 @@
 
 #ifdef __cplusplus
 # include <memory>
+# include <type_traits>
 #endif
 
 /**
@@ -622,6 +622,15 @@ public:
   map();
 
   /**
+   * map() - Const variant of map
+   *
+   * Constness is enforce through return type
+   */
+  XCL_DRIVER_DLLESPEC
+  const void*
+  map() const;
+
+  /**
    * map() - Map the host side buffer info application
    *
    * @tparam MapType
@@ -633,6 +642,22 @@ public:
   MapType
   map()
   {
+    return reinterpret_cast<MapType>(map());
+  }
+
+  /**
+   * map() - Const variant of map
+   *
+   * Constness is enforce through return type
+   */
+  template<typename MapType>
+  MapType
+  map() const
+  {
+    static_assert(std::is_pointer<MapType>::value &&
+                  std::is_const<std::remove_pointer_t<MapType>>::value,
+                  "MapType must be a pointer and const-qualified type");
+
     return reinterpret_cast<MapType>(map());
   }
 


### PR DESCRIPTION
#### Problem solved by the commit
Add support for debug buffers in recipe::resources::buffers by introducing a new buffer type `debug`.

Enhance the runner API to extract raw buffer data as a span of bytes.

#### How problem was solved, alternative solutions (if any) and why they were rejected
The `debug` type buffer is created specific to a hw context (as opposed to device) and cannot be used as kernel argument.  Its use is specific to XRT tools.

The raw data returned through runner API can be used with any resource buffer. The interpretation and validity of the data is at the discretion of the application that instantiates and uses the runner.

The recipe json is enhanced to accept debug buffers as shown here:

```
  "resources": {
    "buffers": [
      {
        "name": "tops",   // you pick a desired name
        "size": 53591040,
        "type": "debug"
      },
```

The runner API is amended with two methods to map resource data and return the data as a span.  The xrt::detail::span is because C++17 does not have support for std::span, and because at least GCC in C++20 does not have stable ABI for std::span.

```
  // map_buffer() - Get raw buffer data as a span of bytes
  // The buffer is synced from device as part of this call.
  // The returned data cannot be written to.
  XRT_API_EXPORT
  xrt::detail::span<const std::byte>
  map_buffer(const std::string& name) const;

  // map_buffer() - Get raw buffer data as a span of type
  // The buffer is synced from device as part of this call.
  // The returned data cannot be written to.
  template <typename MapType>
  xrt::detail::span<MapType>
  map_buffer(const std::string& name) const
  {
    static_assert(std::is_pointer<MapType>::value &&
                  std::is_const<std::remove_pointer_t<MapType>>::value,
                  "MapType must be a pointer and const-qualified type");

    auto span = map_buffer(name);
    return {reinterpret_cast<MapType*>(span.data()), span.size() / sizeof(MapType)};
  }
```

