### PR TITLE
Returning proper device index in edgecase instead of hardcoding

### DIFF
--- a/src/runtime_src/core/edge/CMakeLists.txt
+++ b/src/runtime_src/core/edge/CMakeLists.txt
@@ -1,15 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2019-2022 Xilinx, Inc. All rights reserved.
 #
-add_subdirectory(include)
-add_subdirectory(common)
-add_subdirectory(user)
-add_subdirectory(common_em)
-add_subdirectory(hw_emu)
+xrt_add_subdirectory(include)
+xrt_add_subdirectory(common)
+xrt_add_subdirectory(user)
+xrt_add_subdirectory(common_em)
+xrt_add_subdirectory(hw_emu)
 # We dont need PS Kernel compilation in non-versal devices.
 # Using XRT_AIE_BUILD flag as it is enabled for all the versal devices.
 if (DEFINED XRT_AIE_BUILD)
-        add_subdirectory(ps_kernels)
+        xrt_add_subdirectory(ps_kernels)
 endif()
-add_subdirectory(sw_emu)
-add_subdirectory(skd)
+xrt_add_subdirectory(sw_emu)
+xrt_add_subdirectory(skd)

--- a/src/runtime_src/core/edge/user/device_linux.cpp
+++ b/src/runtime_src/core/edge/user/device_linux.cpp
@@ -85,7 +85,7 @@ struct bdf
   static result_type
   get(const xrt_core::device* device, key_type)
   {
-    return std::make_tuple(0,0,0,0);
+    return std::make_tuple(0,0,0,device->get_device_id());
   }
 
 };

--- a/src/runtime_src/core/edge/user/system_linux.cpp
+++ b/src/runtime_src/core/edge/user/system_linux.cpp
@@ -170,6 +170,18 @@ get_total_devices(bool is_user) const
   return std::make_pair(num, num);
 }
 
+std::tuple<uint16_t, uint16_t, uint16_t, uint16_t>
+system_linux::
+get_bdf_info(device::id_type id, bool is_user) const
+{
+    if (id < dev_list.size()) {
+      auto device = get_userpf_device(id);
+      return std::make_tuple(0, 0, 0, device->get_device_id());
+    }
+
+    throw std::runtime_error(" No such device with index '"+ std::to_string(id) + "'");
+}
+
 void
 system_linux::
 scan_devices(bool /*verbose*/, bool /*json*/) const

--- a/src/runtime_src/core/edge/user/system_linux.h
+++ b/src/runtime_src/core/edge/user/system_linux.h
@@ -42,7 +42,7 @@ public:
   get_total_devices(bool is_user) const;
 
   std::tuple<uint16_t, uint16_t, uint16_t, uint16_t>
-  get_bdf_info(device::id_type id, bool is_user) const;
+  get_bdf_info(device::id_type id, bool is_user) const override;
 
   void
   scan_devices(bool verbose, bool json) const;

--- a/src/runtime_src/core/edge/user/system_linux.h
+++ b/src/runtime_src/core/edge/user/system_linux.h
@@ -41,6 +41,9 @@ public:
   std::pair<device::id_type, device::id_type>
   get_total_devices(bool is_user) const;
 
+  std::tuple<uint16_t, uint16_t, uint16_t, uint16_t>
+  get_bdf_info(device::id_type id, bool is_user) const;
+
   void
   scan_devices(bool verbose, bool json) const;
 

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -181,15 +181,6 @@ XBUtilities::get_available_devices(bool inUserDomain)
   return pt;
 }
 
-/*
- * currently edge supports only one device
- */
-static uint16_t
-deviceId2index()
-{
-  return 0;
-}
-
 std::string
 XBUtilities::str_available_devs(bool _inUserDomain)
 {
@@ -319,8 +310,8 @@ str2index(const std::string& str, bool _inUserDomain)
 
     auto bdf = xrt_core::device_query<xrt_core::query::pcie_bdf>(device);
     // if the bdf is zero, we are dealing with an edge device
-    if (std::get<0>(bdf) == 0 && std::get<1>(bdf) == 0 && std::get<2>(bdf) == 0 && std::get<3>(bdf) == 0)
-      return deviceId2index();
+    if (std::get<0>(bdf) == 0 && std::get<1>(bdf) == 0 && std::get<2>(bdf) == 0)
+      return std::get<3>(bdf);
   } catch (...) {
     /* not an edge device so safe to ignore this error */
   }

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -309,7 +309,6 @@ str2index(const std::string& str, bool _inUserDomain)
     auto device = get_device_internal(idx, _inUserDomain);
 
     auto bdf = xrt_core::device_query<xrt_core::query::pcie_bdf>(device);
-    // if the bdf is zero, we are dealing with an edge device
     if (std::get<0>(bdf) == 0 && std::get<1>(bdf) == 0 && std::get<2>(bdf) == 0)
       return std::get<3>(bdf);
   } catch (...) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
In Telluride, we have two devices running simultaneously on the edge side. Currently, both devices are showing the same BDF: 0000:00:00.0.
To resolve this, we modified the BDF function to use the device ID, which now returns distinct BDFs for each device.
we updated the str2index() function to return device index properly. This change ensures compatibility with the legacy flow where devices are accessed using an index, such as in the command:
xrt-smi examine -r aie -d 0.


#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added get_bdf_info() function to return the proper bdf in the edge side aswell.
Added xrt_add_subdirectory instead of add_subdirectory

#### Risks (if any) associated the changes in the commit
low.

#### What has been tested and how, request additional testing if necessary
Tested by building and running vadd testcase on vek385

#### Documentation impact (if any)
