### PR TITLE
Fix older non group Elf flow on aie2ps

### DIFF
--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -1569,12 +1569,15 @@ class module_elf_aie2ps : public module_elf
       for (auto sec_idx : sec_ids) {
         const auto& sec = m_elfio.sections[sec_idx];
         auto name = sec->get_name();
-        auto [col, page] = get_column_and_page(name);
 
-        if (name.find(patcher::to_string(xrt_core::patcher::buf_type::ctrltext)) != std::string::npos)
+        if (name.find(patcher::to_string(xrt_core::patcher::buf_type::ctrltext)) != std::string::npos) {
+          auto [col, page] = get_column_and_page(name);
           ctrl_map[id][col][page].ctrltext = sec;
-        else if (name.find(patcher::to_string(xrt_core::patcher::buf_type::ctrldata)) != std::string::npos)
+        }
+        else if (name.find(patcher::to_string(xrt_core::patcher::buf_type::ctrldata)) != std::string::npos) {
+          auto [col, page] = get_column_and_page(name);
           ctrl_map[id][col][page].ctrldata = sec;
+        }
       }
     }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Fix bug in older non group ELF flow (xclbin + elf) on aie2ps.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
PR - https://github.com/Xilinx/XRT/pull/9058 introduced the bug and it was discovered in local testing

#### How problem was solved, alternative solutions (if any) and why they were rejected
When creating map for section to group index for older Elf's all the sections are grouped together into a default group and in one of the function all sections are iterated and we call get_column_and_page function which throws exception for sections like .rela.dyn thinking data after '.' is column number.
Added check so that only intended .ctrltext and .ctrldata sections are used with function get_column_and_page

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
Tested using Telluride (aie2ps) test case suite and all tests passed with this change

#### Documentation impact (if any)
NA
