### PR TITLE
[XDP] Added method to get PL device Interface for register Xclbin flow

### DIFF
--- a/build/petalinux.build
+++ b/build/petalinux.build
@@ -1,4 +1,3 @@
 # When updating Petalinux build please file a SH ticket to retain the build
 # https://jira.xilinx.com/secure/CreateIssue!default.jspa
-#PETALINUX=/proj/petalinux/2025.2/petalinux-v2025.2_05300031/tool/petalinux-v2025.2-final
-PETALINUX=/proj/petalinux/2025.1/petalinux-v2025.1_05180714/tool/petalinux-v2025.1-final
+PETALINUX=/proj/petalinux/2025.2/petalinux-v2025.2_05300031/tool/petalinux-v2025.2-final

--- a/build/petalinux.build
+++ b/build/petalinux.build
@@ -1,3 +1,4 @@
 # When updating Petalinux build please file a SH ticket to retain the build
 # https://jira.xilinx.com/secure/CreateIssue!default.jspa
-PETALINUX=/proj/petalinux/2025.2/petalinux-v2025.2_05300031/tool/petalinux-v2025.2-final
+#PETALINUX=/proj/petalinux/2025.2/petalinux-v2025.2_05300031/tool/petalinux-v2025.2-final
+PETALINUX=/proj/petalinux/2025.1/petalinux-v2025.1_05180714/tool/petalinux-v2025.1-final

--- a/src/runtime_src/xdp/profile/database/static_info_database.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info_database.cpp
@@ -433,7 +433,7 @@ namespace xdp {
     if (!config)
       return nullptr ;
 
-    return config->plDeviceIntf ;
+    return getPlDeviceIntf(config) ;
   }
 
   // Should only be called from Alveo hardware emulation
@@ -1627,6 +1627,24 @@ namespace xdp {
     // For REGISTER_XCLBIN_STYLE and APP_STYLE_NOT_SET
     // handle is an HW Ctx Impl pointer
     return getHwCtxImplUid(handle);
+  }
+
+  PLDeviceIntf* VPStaticDatabase::getPlDeviceIntf(const ConfigInfo* curConfig)
+  {
+    // In LOAD_XCLBIN_STYLE, the deviceId is the same as the plDeviceId
+    if (AppStyle::REGISTER_XCLBIN_STYLE != getAppStyle())
+      return curConfig->plDeviceIntf;
+
+    // In REGISTER_XCLBIN_STYLE, the PL Device Interface is always deviceId 0.
+    // This API is used to query the PL Device Interface by AIE_ONLY partitions's hw contexts.
+    uint64_t plDeviceId = 0;
+    if (deviceInfo.find(plDeviceId) == deviceInfo.end())
+      return nullptr;
+    ConfigInfo* config = deviceInfo[plDeviceId]->currentConfig() ;
+    if (!config)
+      return nullptr;
+
+    return config->plDeviceIntf;
   }
 
   // Return true if we should reset the device information.

--- a/src/runtime_src/xdp/profile/database/static_info_database.h
+++ b/src/runtime_src/xdp/profile/database/static_info_database.h
@@ -155,6 +155,12 @@ namespace xdp {
     double findClockRate(xrt::xclbin);
 
     XclbinInfoType getXclbinType(xrt::xclbin& xclbin);
+    // API to get the unique device id of stored PL Device Intf
+    // NOTE: In register xclbin flow, this API returns 0 as device Id to refer
+    // to PL Device Intf for aie only partitions.
+    // Otherwise, it returns same plDeviceId to find PL Device Intf
+    PLDeviceIntf* getPlDeviceIntf(const ConfigInfo* curConfig);
+
     // This common private updateDevice functionality takes an xdp::Device
     // pointer to handle any connection to the PL side as necessary.
     // Some plugins do not require any PL control and will pass in nullptr


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Required for hw contex register xclbin flow.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
NA

#### How problem was solved, alternative solutions (if any) and why they were rejected
Device ID 0 is reserved for PL Device Interface.

#### Risks (if any) associated the changes in the commit
Low
#### What has been tested and how, request additional testing if necessary
Verified on edge.
#### Documentation impact (if any)
