### PR TITLE
Added read() call to consume the interrput when interrput is occured

### DIFF
--- a/src/runtime_src/core/edge/user/device_linux.cpp
+++ b/src/runtime_src/core/edge/user/device_linux.cpp
@@ -1388,9 +1388,14 @@ wait_ip_interrupt(xclInterruptNotifyHandle handle, int32_t timeout)
 
   if (ret == 0) //Timeout occured
     return std::cv_status::timeout;
+  //Interrupt received
+  if (pfd.revents & POLLIN) {
+    int pending = 0;
+    if (::read(handle, &pending, sizeof(pending)) == -1)
+      throw error(errno, "Interrupt received but read failed");
 
-  if (pfd.revents & POLLIN) //Interrupt received
     return std::cv_status::no_timeout;
+  }
 
   throw error(-EINVAL, boost::str(boost::format("wait_timeout: POSIX poll unexpected event: %d")  % pfd.revents));
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1221077 wait_ip_interrupt(timeout) is not working as expected, but wait_ip_interrupt(timeout) along with wait_ip_interrupt() is working properly.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
poll() is not consuming the interrupt; it only notifies when data is available. Because of this, future poll() calls behave incorrectly.
 
#### How problem was solved, alternative solutions (if any) and why they were rejected
A read() call was added to the function when the interrupt is triggered. This consumes and clears the interrupt properly.

#### Risks (if any) associated the changes in the commit
low
#### What has been tested and how, request additional testing if necessary
Tested by building and running Zebra application on VEK280.

#### Documentation impact (if any)
NA