### PR TITLE
Added read() call to consume the interrput when interrput is occured

### DIFF
--- a/src/runtime_src/core/edge/user/device_linux.cpp
+++ b/src/runtime_src/core/edge/user/device_linux.cpp
@@ -1382,9 +1382,14 @@ wait_ip_interrupt(xclInterruptNotifyHandle handle, int32_t timeout)
 
   if (ret == 0) //Timeout occured
     return std::cv_status::timeout;
+  //Interrupt received
+  if (pfd.revents & POLLIN) {
+    int pending = 0;
+    if (::read(handle, &pending, sizeof(pending)) == -1)
+      throw error(errno, "Interrupt received but read failed");
 
-  if (pfd.revents & POLLIN) //Interrupt received
     return std::cv_status::no_timeout;
+  }
 
   throw error(-EINVAL, boost::str(boost::format("wait_timeout: POSIX poll unexpected event: %d")  % pfd.revents));
 }


### PR DESCRIPTION
(cherry picked from commit a4bcd34e1feb517538630436e49f7eebf010e5ce)

This commit was cherry-picked from this [PR-9070](https://github.com/Xilinx/XRT/pull/9070)
