### PR TITLE
Advertise HIP support in XRT if HIP bindings have been enabled

### DIFF
--- a/src/CMake/config/xrt.fp.in
+++ b/src/CMake/config/xrt.fp.in
@@ -9,6 +9,7 @@
 # This module sets the following variables in your project::
 #
 #   @PROJECT_NAME@_FOUND              - true if @PROJECT_NAME@ and all required components found on the system
+#   @PROJECT_NAME@_HIP_FOUND          - true if @PROJECT_NAME@ was compiled with HIP support
 #   @PROJECT_NAME@_VERSION            - VERSION of this package in x.y.z format
 #   @PROJECT_NAME@_CMAKE_DIR          - Directory where this cmake module was found
 #   @PROJECT_NAME@_INCLUDE_DIRS       - Directory where @PROJECT_NAME@ headers are located.
@@ -16,6 +17,7 @@
 #   @PROJECT_NAME@_CORE_LIBRARIES     - libraries to link against.
 #   @PROJECT_NAME@_COREUTIL_LIBRARIES - libraries to link against.
 #   @PROJECT_NAME@_OPENCL_LIBRARIES   - libraries to link against.
+#   @PROJECT_NAME@_HIP_LIBRARIES      - libraries to link against.
 #   @PROJECT_NAME@_SWEMU_LIBRARIES    - libraries to link against.
 #   @PROJECT_NAME@_HWEMU_LIBRARIES    - libraries to link against.
 @PACKAGE_INIT@
@@ -40,6 +42,11 @@ set(@PROJECT_NAME@_COREUTIL_LIBRARIES @PROJECT_NAME@::xrt_coreutil)
 set(@PROJECT_NAME@_OPENCL_LIBRARIES @PROJECT_NAME@::xilinxopencl @PROJECT_NAME@::xrt++)
 set(@PROJECT_NAME@_SWEMU_LIBRARIES @PROJECT_NAME@::xrt_swemu)
 set(@PROJECT_NAME@_HWEMU_LIBRARIES @PROJECT_NAME@::xrt_hwemu)
+
+if (XRT_ENABLE_HIP)
+ set(@PROJECT_NAME@_HIP_LIBRARIES @PROJECT_NAME@::xrt_hip)
+ set(@PROJECT_NAME@_HIP_FOUND True)
+endif()
 
 set(@PROJECT_NAME@_FOUND True)
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
XRT install should advertise HIP support if XRT was compiled with HIP bindings.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
NA

#### How problem was solved, alternative solutions (if any) and why they were rejected
Updated **xrt-config.cmake** generated by XRT build to export variables `XRT_HIP_LIBRARIES` and `XRT_HIP_FOUND`.

#### Risks (if any) associated the changes in the commit
None, the exported CMake flags are for use by XRT HIP applications and not used otherwise.

#### What has been tested and how, request additional testing if necessary
Will update model-tests to start using this feature

#### Documentation impact (if any)
The flags are self documenting via CMake.