### PR TITLE
Fix base_dev package include mess

### DIFF
--- a/src/runtime_src/core/include/CMakeLists.txt
+++ b/src/runtime_src/core/include/CMakeLists.txt
@@ -1,31 +1,36 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2024-2025 Advanced Micro Devices, Inc. All rights reserved.
 
-# These headers must be installed to legacy include dir for legacy xrt
-# package as well as under xrt/ for base package and also xrt legacy
-# The includes simply refer into include/xrt
-set(XRT_CORE_HEADER_SRC
-  ert.h
-  xrt.h
-  xclbin.h
-  xclerr.h
-  xrt_error_code.h
-  xrt_mem.h
+# Legacy header wrappers are no longer released to base package.  Only
+# xrt/* are released and applications must include from include/xrt
+#
+# The legacy headers are simple wrappers that
+# refer to include/xrt.  These wrapper headers have included a pragma
+# warning for quite a while that have asked applications to include from
+# corresponding header files under include/xrt.
 
-  # unknown where used
-  xgq_cmd_common.h
-  xgq_cmd_ert.h
-  xgq_impl.h
-  xgq_resp_parser.h)
+# Preserve legacy behavior in legacy XRT package. The component
+# setup will have defined XRT_BASE_DEV_COMPONENT to XRT
+if (XRT_XRT)
 
+  set(XRT_CORE_HEADER_SRC
+    ert.h
+    xrt.h
+    xclbin.h
+    xclerr.h
+    xrt_error_code.h
+    xrt_mem.h
+  )
 
-# Legacy deprecated install
-install (FILES ${XRT_CORE_HEADER_SRC}
-  DESTINATION ${XRT_INSTALL_INCLUDE_DIR}
-  COMPONENT ${XRT_BASE_DEV_COMPONENT})
+  # Legacy deprecated install
+  install (FILES ${XRT_CORE_HEADER_SRC}
+    DESTINATION ${XRT_INSTALL_INCLUDE_DIR}
+    COMPONENT ${XRT_BASE_DEV_COMPONENT})
 
-# Legacy experimental
-add_subdirectory(experimental)
+  # Legacy experimental
+  add_subdirectory(experimental)
+
+endif (XRT_XRT)
 
 # Exported includes
 add_subdirectory(xrt)

--- a/src/runtime_src/xocl/CMakeLists.txt
+++ b/src/runtime_src/xocl/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2019-2021 Xilinx, Inc. All rights reserved.
-#
+# Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
 include_directories(
   ${Boost_INCLUDE_DIRS}
   ${XRT_SOURCE_DIR}/include/1_2
@@ -100,8 +100,18 @@ install(TARGETS xilinxopencl xilinxopencl_static
 # Release OpenCL extension headers
 install (FILES
   ${XRT_SOURCE_DIR}/include/1_2/CL/cl_ext_xilinx.h
-  ${XRT_SOURCE_DIR}/include/1_2/CL/cl_ext.h
-  ${XRT_SOURCE_DIR}/include/1_2/CL/cl2xrt.hpp
   DESTINATION ${XRT_INSTALL_INCLUDE_DIR}/CL
   COMPONENT ${XRT_BASE_DEV_COMPONENT}
 )
+
+# Preserve legacy behavior in legacy XRT package. The component
+# setup will have defined XRT_BASE_DEV_COMPONENT to XRT
+if (XRT_XRT)
+  install (FILES
+    ${XRT_SOURCE_DIR}/include/1_2/CL/cl_ext.h
+    ${XRT_SOURCE_DIR}/include/1_2/CL/cl2xrt.hpp
+    DESTINATION ${XRT_INSTALL_INCLUDE_DIR}/CL
+    COMPONENT ${XRT_BASE_DEV_COMPONENT}
+    )
+endif (XRT_XRT)
+  

--- a/src/runtime_src/xrt/xrt++/CMakeLists.txt
+++ b/src/runtime_src/xrt/xrt++/CMakeLists.txt
@@ -1,14 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2019-2021 Xilinx, Inc. All rights reserved.
-#
-set(XRT_XRT_CPP_HEADER_SRC
-  xrt++.hpp
-  xrtexec.hpp)
+# Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
 
-install (FILES ${XRT_XRT_CPP_HEADER_SRC}
-  DESTINATION ${XRT_INSTALL_INCLUDE_DIR}/experimental COMPONENT ${XRT_BASE_DEV_COMPONENT})
+# Preserve legacy behavior in legacy XRT package. The component
+# setup will have defined XRT_BASE_DEV_COMPONENT to XRT
+if (XRT_XRT)
+  set(XRT_XRT_CPP_HEADER_SRC
+    xrt++.hpp
+    xrtexec.hpp)
 
-message("-- XRT xrt++ header files")
-foreach (header ${XRT_XRT_CPP_HEADER_SRC})
-  message("-- ${header}")
-endforeach()
+  install (FILES ${XRT_XRT_CPP_HEADER_SRC}
+    DESTINATION ${XRT_INSTALL_INCLUDE_DIR}/experimental COMPONENT ${XRT_BASE_DEV_COMPONENT})
+endif (XRT_XRT)


### PR DESCRIPTION
#### Problem solved by the commit
All includes in base development packages must be rooted at `include/xrt/`.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Stop releasing wrapper header files.  These header files were referencing include/xrt and have had a pragma warning directing application to fix code to include from proper location.

Stop releasing a few xgq_*.h header files that are not supposed to be include by application code.

Preserve legacy XRT behavior, e.g. no changes for legacy `-xrt.{deb,rpm}` packages.

Only NPU (`build.sh -npu ...`), Alveo, and Edge builds are affected by this change.  In particular NPU and Edge builds an upstream base-dev package and cannot have stray header files directly under `include/`.

