### PR TITLE
[RFC] Update hip device2host/host2device APIs to do buffer sync without copying

### DIFF
--- a/src/runtime_src/hip/api/hip_memory.cpp
+++ b/src/runtime_src/hip/api/hip_memory.cpp
@@ -133,7 +133,10 @@ namespace xrt::core::hip
     throw_invalid_handle_if(!hip_mem_dev, "Invalid destination handle.");
     throw_invalid_value_if(offset + size > hip_mem_dev->get_size(), "dst out of bound.");
 
-    hip_mem_dev->write(src, size, 0, offset);
+    if (src && src != dst)
+        hip_mem_dev->write(src, size, 0, offset);
+    else
+        hip_mem_dev->sync(XCL_BO_SYNC_BO_TO_DEVICE);
   }
 
   static void
@@ -153,7 +156,10 @@ namespace xrt::core::hip
     throw_invalid_value_if(offset + size > hip_mem_dev->get_size(), "source out of bound.");
 
     // src is device address. Get device address
-    hip_mem_dev->read(dst, size, 0, offset);
+    if (dst && dst != src)
+        hip_mem_dev->read(dst, size, 0, offset);
+    else
+        hip_mem_dev->sync(XCL_BO_SYNC_BO_FROM_DEVICE);
   }
 
   static void

--- a/src/runtime_src/hip/core/event.cpp
+++ b/src/runtime_src/hip/core/event.cpp
@@ -158,9 +158,6 @@ kernel_start::kernel_start(std::shared_ptr<stream> s, std::shared_ptr<function> 
         if (!hip_mem)
           throw std::runtime_error("failed to get memory from arg at index - " + std::to_string(idx));
 
-        // NPU device is not coherent. We need to sync the buffer objects before launching kernel
-        if (hip_mem->get_type() != memory_type::device)
-          hip_mem->sync(xclBOSyncDirection::XCL_BO_SYNC_BO_TO_DEVICE);
         r.set_arg(arg->index, hip_mem->get_xrt_bo());
         break;
       }

--- a/src/runtime_src/hip/core/stream.cpp
+++ b/src/runtime_src/hip/core/stream.cpp
@@ -121,6 +121,8 @@ await_completion()
       command_cache.remove(cmd.get());
     m_cmd_queue.pop_front();
   }
+  // reset m_top_event as stream completed
+  m_top_event = nullptr;
 }
 
 void


### PR DESCRIPTION
AIE hardware can directly access host memory, in many cases, it is not
required to copy data to device or from device.
However, due to some AIE Hardwares only supports non-coherent memory,
for those Hardwares, we will need to make sure data flushed to the memory
before kernel starts and CPU gets the right data from memory after
kernel execution completes.
However, not all data will change every time a kernel
is executed, and thus, it is better to unbind buffers sync from kernel
execution.
Current HIP APIs doesn't have sync.  This patch set enables to use existing
`hipMemcpy()` APIs to do buffer sync without the need to copy.

Here is the test flow using `hipMemcpyAsync()`, we can implement `hipMemcpy()` synchronous APIs later:
```
    unsigned int index = 0;
    HipDevice hdevice(index);
    hipFunction_t function =hdevice.getFunctionExt(rebase_path("unified-4x4.xclbin"),
                               rebase_path("ctrl.elf"), "DPU");

    void* o0, o1, o2, o4;
    // coalesed_weights
    hipHostMalloc(&o0, 13924*4, hipHostMallocMapped)
    std::ifstream stm(rebase_path("wts32.bin"), std::ios::binary);
    stm.read(o0, 13924*4);
    stm.close();

    // compute_graph.ifm_ddr
    hipHostMalloc(&o1, 72, hipHostMallocMapped)
    std::fill(o1, (char*)o1 + 72), 0xdeadbeef);

    // compute_graph.ifm_ddr_1
    hipHostMalloc(&o2, 72, hipHostMallocMapped)
    std::fill(o2, (char*)o2 + 72), 0xdeadbeef);

    // compute_graph.spill_L3_Concat_Buffer_layer_3
    hipHostMalloc(&o4, 18432*4, hipHostMallocMapped)
    std::memset(o4), 0x0, 18432*4);
 
    hipStream_t in_buf_stream = nullptr;
    hipCheck(hipStreamCreateWithFlags(&in_buf_stream, hipStreamNonBlocking));
    hipEvent_t in_buf_event;
    hipCheck(hipEventCreate(&in_buf_event));
    void* o0_dev = nullptr;
    void* o1_dev = nullptr;
    void* o2_dev = nullptr;
    void* o4_dev = nullptr;
    hipCheck(hipHostGetDevicePointer(&o0_dev, o0, 0));
    hipCheck(hipHostGetDevicePointer(&o1_dev, o1, 0));
    hipCheck(hipHostGetDevicePointer(&o2_dev, o2, 0));
    hipCheck(hipHostGetDevicePointer(&o4_dev, o4, 0));
    hipCheck(hipMemcpyAsync(o0_dev, o0, 13924*4, hipMemcpyHostToDevice, in_buf_stream));
    hipCheck(hipMemcpyAsync(o1_dev, o1, 72, hipMemcpyHostToDevice, in_buf_stream));
    hipCheck(hipMemcpyAsync(o2_dev, o2, 72, hipMemcpyHostToDevice, in_buf_stream));
    hipCheck(hipMemcpyAsync(o4_dev, o4, 18432*4, hipMemcpyHostToDevice, in_buf_stream));
    hipCheck(hipEventRecord(in_buf_event, in_buf_stream));
    hipCheck(hipStreamSynchronize(in_buf_stream));

    hipStream_t stream = nullptr;
    hipCheck(hipStreamCreateWithFlags(&stream, hipStreamNonBlocking));
    hipCheck(hipStreamWaitEvent(stream, in_buf_event, 0));

    uint64_t opcode = 3;
    std::array<void *, 8> args = {
      &opcode,
      nullptr,
      nullptr,
      &o0_dev,
      &o1_dev,
      &o2_dev, nullptr, &o4_dev};

    run_kernel(function, stream, args.data());
    hipEvent_t kernel_event;
    hipCheck(hipEventCreate(&kernel_event));
    hipCheck(hipEventRecord(kernel_event, stream));
    hipCheck(hipStreamSynchronize(stream));

    hipStream_t out_buf_stream = nullptr;
    hipCheck(hipStreamCreateWithFlags(&out_buf_stream, hipStreamDefault));
    hipCheck(hipStreamWaitEvent(out_buf_stream, kernel_event, 0));
    hipCheck(hipMemcpyAsync(o4, o4_dev, 18432*4, hipMemcpyDeviceToHost, out_buf_stream));
    hipCheck(hipStreamSynchronize(out_buf_stream));
```

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
