### PR TITLE
[XDP] Fix for order of configuration for multiple plugins

### DIFF
--- a/src/runtime_src/core/common/xdp/profile.cpp
+++ b/src/runtime_src/core/common/xdp/profile.cpp
@@ -584,6 +584,14 @@ update_device(void* handle, bool hw_context_flow)
            "Failed to load PL Deadlock Detection library. Caught exception ",  
            "Failed to setup for PL Deadlock Detection library. Caught exception ",  
            handle);  
+  
+  load_once_and_update(xrt_core::config::get_aie_profile,
+           xrt_core::xdp::aie::profile::load,
+           xrt_core::xdp::aie::profile::update_device,
+           "Failed to load AIE Profile library. Caught exception ",
+           "Failed to setup for AIE Profile. Caught exception ",
+           handle,
+           hw_context_flow);
 
   load_once_and_update(xrt_core::config::get_aie_trace,  
            xrt_core::xdp::aie::trace::load,
@@ -593,13 +601,6 @@ update_device(void* handle, bool hw_context_flow)
            handle,
            hw_context_flow);
 
-  load_once_and_update(xrt_core::config::get_aie_profile,
-           xrt_core::xdp::aie::profile::load,
-           xrt_core::xdp::aie::profile::update_device,
-           "Failed to load AIE Profile library. Caught exception ",
-           "Failed to setup for AIE Profile. Caught exception ",
-           handle,
-           hw_context_flow);
 
   // Avoid warning until we've added support in all plugins
   (void)(hw_context_flow);

--- a/src/runtime_src/core/common/xdp/profile.cpp
+++ b/src/runtime_src/core/common/xdp/profile.cpp
@@ -584,20 +584,20 @@ update_device(void* handle, bool hw_context_flow)
            "Failed to load PL Deadlock Detection library. Caught exception ",  
            "Failed to setup for PL Deadlock Detection library. Caught exception ",  
            handle);  
-  
-  load_once_and_update(xrt_core::config::get_aie_profile,
-           xrt_core::xdp::aie::profile::load,
-           xrt_core::xdp::aie::profile::update_device,
-           "Failed to load AIE Profile library. Caught exception ",
-           "Failed to setup for AIE Profile. Caught exception ",
-           handle,
-           hw_context_flow);
 
   load_once_and_update(xrt_core::config::get_aie_trace,  
            xrt_core::xdp::aie::trace::load,
            xrt_core::xdp::aie::trace::update_device,
            "Failed to load AIE Trace library. Caught exception ",  
            "Failed to setup for AIE Trace. Caught exception ",
+           handle,
+           hw_context_flow);
+
+  load_once_and_update(xrt_core::config::get_aie_profile,
+           xrt_core::xdp::aie::profile::load,
+           xrt_core::xdp::aie::profile::update_device,
+           "Failed to load AIE Profile library. Caught exception ",
+           "Failed to setup for AIE Profile. Caught exception ",
            handle,
            hw_context_flow);
 

--- a/src/runtime_src/core/common/xdp/profile.cpp
+++ b/src/runtime_src/core/common/xdp/profile.cpp
@@ -601,7 +601,6 @@ update_device(void* handle, bool hw_context_flow)
            handle,
            hw_context_flow);
 
-
   // Avoid warning until we've added support in all plugins
   (void)(hw_context_flow);
 #endif

--- a/src/runtime_src/xdp/profile/database/static_info_database.h
+++ b/src/runtime_src/xdp/profile/database/static_info_database.h
@@ -122,7 +122,7 @@ namespace xdp {
     void setAppStyle(AppStyle style);
 
     // When loading a new xclbin, should we reset our internal data structures?
-    bool resetDeviceInfo(uint64_t deviceId, xdp::Device* xdpDevice, xrt_core::uuid new_xclbin_uuid);
+    bool resetDeviceInfoAndCreatePlDeviceIfRequired(uint64_t deviceId, std::unique_ptr<xdp::Device>& xdpDevice, xrt_core::uuid new_xclbin_uuid, std::shared_ptr<xrt_core::device> device);
 
     // Functions that create the overall structure of the Xclbin's PL region
     void createComputeUnits(XclbinInfo*, const ip_layout*,const char*,size_t);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Changing the order of configuration for multiple plugins was generating incomplete data.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Bug was discovered when we changed the order of configuration for adding support for hw_context flow on Edge
#### How problem was solved, alternative solutions (if any) and why they were rejected
When trace plugin was coming after profile, we were resetting the static db info though it was same xclbin instead of just creating the PL Device. Now we are just creating the PL device if xclbin is same, which doesn't reset the older plugin data.
#### Risks (if any) associated the changes in the commit
NA
#### What has been tested and how, request additional testing if necessary
Tested AIE Trace + AIE Profile + Pl trace combination with different order of configuration.
#### Documentation impact (if any)
Na