### PR TITLE
VITIS-15145: allocating cma mem from zocl-tagged reserved mem

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/common/zocl_bo.c
+++ b/src/runtime_src/core/edge/drm/zocl/common/zocl_bo.c
@@ -35,6 +35,13 @@
 #include "xclbin.h"
 #include "zocl_bo.h"
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+static struct drm_gem_dma_object *
+#else
+static struct drm_gem_cma_object *
+#endif
+zocl_cma_create(struct drm_device *dev, size_t size);
+
 static inline void __user *to_user_ptr(u64 address)
 {
 	return (void __user *)(uintptr_t)address;
@@ -172,62 +179,11 @@ void zocl_free_userptr_bo(struct drm_gem_object *gem_obj)
 	kfree(&zocl_bo->cma_base);
 }
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
-static struct drm_gem_dma_object *
-#else
-static struct drm_gem_cma_object *
-#endif
-zocl_cma_create(struct drm_device *dev, size_t size)
-{
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
-	struct drm_gem_dma_object *cma_obj;
-#else
-	struct drm_gem_cma_object *cma_obj;
-#endif
-	struct drm_gem_object *gem_obj;
-	int ret;
-
-	gem_obj = kzalloc(sizeof(struct drm_zocl_bo), GFP_KERNEL);
-	if (!gem_obj) {
-		DRM_ERROR("cma_create: alloc failed\n");
-		return ERR_PTR(-ENOMEM);
-	}
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
-	cma_obj = container_of(gem_obj, struct drm_gem_dma_object, base);
-#else
-	cma_obj = container_of(gem_obj, struct drm_gem_cma_object, base);
-#endif
-
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 11, 0)
-	gem_obj->funcs = &zocl_cma_default_funcs;
-#endif
-
-	ret = drm_gem_object_init(dev, gem_obj, size);
-	if (ret) {
-		DRM_ERROR("cma_create: gem_obj_init failed\n");
-		goto error;
-	}
-
-	ret = drm_gem_create_mmap_offset(gem_obj);
-	if (ret) {
-		DRM_ERROR("cma_create: gem_mmap_offset failed\n");
-		drm_gem_object_release(gem_obj);
-		goto error;
-	}
-
-	return cma_obj;
-
-error:
-	memset(&cma_obj->base, 0, sizeof(cma_obj->base));
-	kfree(gem_obj);
-	return ERR_PTR(ret);
-}
-
-
 static struct drm_zocl_bo *
 zocl_create_cma_mem(struct drm_device *dev, size_t size)
 {
 	struct drm_zocl_dev *zdev = dev->dev_private;
+	int num_regions = zdev->num_regions;
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
 	struct drm_gem_dma_object *cma_obj;
 #else
@@ -237,10 +193,7 @@ zocl_create_cma_mem(struct drm_device *dev, size_t size)
 	struct drm_zocl_bo *bo;
 	dma_addr_t phys = 0;
 	void* vaddr = NULL;
-	int num_regions = of_count_phandle_with_args(dev->dev->of_node, "memory-region",
-		NULL);
 	int mem_region = -1;
-	int ret;
 
 	cma_obj = zocl_cma_create(dev, size);
 	if (IS_ERR(cma_obj))
@@ -1128,6 +1081,56 @@ int zocl_pread_bo_ioctl(struct drm_device *dev, void *data,
 	return (zocl_bo_rdwr_ioctl(dev, data, filp, true));
 }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+static struct drm_gem_dma_object *
+#else
+static struct drm_gem_cma_object *
+#endif
+zocl_cma_create(struct drm_device *dev, size_t size)
+{
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+	struct drm_gem_dma_object *cma_obj;
+#else
+	struct drm_gem_cma_object *cma_obj;
+#endif
+	struct drm_gem_object *gem_obj;
+	int ret;
+
+	gem_obj = kzalloc(sizeof(struct drm_zocl_bo), GFP_KERNEL);
+	if (!gem_obj) {
+		DRM_ERROR("cma_create: alloc failed\n");
+		return ERR_PTR(-ENOMEM);
+	}
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+	cma_obj = container_of(gem_obj, struct drm_gem_dma_object, base);
+#else
+	cma_obj = container_of(gem_obj, struct drm_gem_cma_object, base);
+#endif
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 11, 0)
+	gem_obj->funcs = &zocl_cma_default_funcs;
+#endif
+
+	ret = drm_gem_object_init(dev, gem_obj, size);
+	if (ret) {
+		DRM_ERROR("cma_create: gem_obj_init failed\n");
+		goto error;
+	}
+
+	ret = drm_gem_create_mmap_offset(gem_obj);
+	if (ret) {
+		DRM_ERROR("cma_create: gem_mmap_offset failed\n");
+		drm_gem_object_release(gem_obj);
+		goto error;
+	}
+
+	return cma_obj;
+
+error:
+	memset(&cma_obj->base, 0, sizeof(cma_obj->base));
+	kfree(gem_obj);
+	return ERR_PTR(ret);
+}
 
 int zocl_get_hbo_ioctl(struct drm_device *dev, void *data,
 		       struct drm_file *filp)

--- a/src/runtime_src/core/edge/drm/zocl/common/zocl_drv.c
+++ b/src/runtime_src/core/edge/drm/zocl/common/zocl_drv.c
@@ -554,6 +554,11 @@ void zocl_free_bo(struct drm_gem_object *obj)
 {
 	struct drm_zocl_bo *zocl_obj;
 	struct drm_zocl_dev *zdev;
+#if 0
+        struct drm_gem_dma_object* cma_obj;
+        dma_addr_t dma_handle;
+        void* vaddr;
+#endif
 	int npages;
 
 	if (IS_ERR(obj) || !obj)
@@ -579,7 +584,15 @@ void zocl_free_bo(struct drm_gem_object *obj)
 #else
 			drm_gem_cma_free_object(obj);
 #endif
-
+#if 0
+                        // Need to verify and cleanup below code 
+	                cma_obj = to_drm_gem_dma_obj(obj);
+                        if(cma_obj){
+	                        dma_handle = cma_obj->dma_addr;
+                                vaddr = cma_obj->vaddr;
+                                dma_free_coherent(obj->dev->dev, obj->size, vaddr, dma_handle);
+                        }
+#endif
 		} else {
 			if (zocl_obj->mm_node) {
 				mutex_lock(&zdev->mm_lock);

--- a/src/runtime_src/core/edge/drm/zocl/common/zocl_drv.c
+++ b/src/runtime_src/core/edge/drm/zocl/common/zocl_drv.c
@@ -15,7 +15,7 @@
  * This file is dual-licensed; you may select either the GNU General Public
  * License version 2 or Apache License, Version 2.0.
  */
-
+#include <linux/kernel.h>
 #include <linux/delay.h>
 #include <linux/dma-buf.h>
 #include <linux/module.h>
@@ -80,6 +80,55 @@ match_name(struct device *dev, void *data)
 	 * the dev_name is like: 20300030000.ert_hw
 	 */
 	return strstr(dev_name(dev), name) != NULL;
+}
+
+// put description
+static int zocl_cma_mem_region_init(struct drm_zocl_dev *zdev, struct platform_device *pdev)
+{
+	int num_regions = of_count_phandle_with_args(pdev->dev.of_node, "memory-region", NULL);
+	int ret = 0;
+	int i;
+
+	//remove this print later
+	printk("[bs]: probing the cma mem regions\n");
+	for (i = 0; i < num_regions && i < ZOCL_MAX_MEM_REGIONS; i++) {
+		struct device *child_dev;
+		child_dev = devm_kzalloc(&pdev->dev, sizeof(struct device), GFP_KERNEL);
+		if (!child_dev)
+			return -ENOMEM;
+
+		child_dev->parent = &pdev->dev;
+		child_dev->of_node = pdev->dev.of_node;
+		child_dev->coherent_dma_mask = DMA_BIT_MASK(64);
+
+		ret = dev_set_name(child_dev, "zocl-mem%d", i);
+		if (ret) {
+			DRM_WARN("Failed to set name for mem region %d\n", i);
+			continue;
+		}
+
+		ret = of_reserved_mem_device_init_by_idx(child_dev, pdev->dev.of_node, i);
+		if (ret) {
+			DRM_WARN("Failed to init reserved mem region %d\n", i);
+			continue;
+		}
+
+		zdev->mem_regions[i].dev = child_dev;
+		zdev->mem_regions[i].initialized = true;
+	}
+	platform_set_drvdata(pdev, zdev);
+	return ret;
+}
+
+// put description
+static void zocl_cma_mem_region_remove(struct drm_zocl_dev *zdev)
+{
+	int i;
+	printk("[bs]: removing the cma mem regions\n");
+	for (i = 0; i < ZOCL_MAX_MEM_REGIONS; i++) {
+		if (zdev->mem_regions[i].initialized)
+			of_reserved_mem_device_release(zdev->mem_regions[i].dev);
+	}
 }
 
 /**
@@ -554,19 +603,22 @@ void zocl_free_bo(struct drm_gem_object *obj)
 {
 	struct drm_zocl_bo *zocl_obj;
 	struct drm_zocl_dev *zdev;
+	struct drm_device *dev;
+	struct device *mem_dev;
 #if 0
         struct drm_gem_dma_object* cma_obj;
         dma_addr_t dma_handle;
         void* vaddr;
 #endif
 	int npages;
-
+	printk("[bs]: %s: freeing the bo\n", __func__);
 	if (IS_ERR(obj) || !obj)
 		return;
 
 	DRM_DEBUG("Freeing BO\n");
 	zocl_obj = to_zocl_bo(obj);
 	zdev = obj->dev->dev_private;
+	dev = obj->dev;
 
 	if (!zdev->domain) {
 		zocl_describe(zocl_obj);
@@ -580,7 +632,20 @@ void zocl_free_bo(struct drm_gem_object *obj)
 			    zocl_obj->mem_index);
 			/* free resources associated with a CMA GEM object */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
-			drm_gem_dma_object_free(obj);
+			if (zocl_obj->mem_region >= 0) {
+				// have a check before assigning dev to mem_dev;
+				mem_dev = zdev->mem_regions[zocl_obj->mem_region].dev;
+			}
+			else
+				mem_dev = dev->dev;
+			if (zocl_obj->vaddr) {
+				printk("[bs]: %s: calling dma_free_coherent()\n", __func__);
+				dma_free_coherent(mem_dev, zocl_obj->size, zocl_obj->vaddr, zocl_obj->phys);
+				zocl_obj->vaddr = NULL;
+			}
+
+			drm_gem_object_release(obj);
+			kfree(zocl_obj);
 #else
 			drm_gem_cma_free_object(obj);
 #endif
@@ -1238,6 +1303,11 @@ static int zocl_drm_platform_probe(struct platform_device *pdev)
 		}
 	}
 
+	/* Initialize the cma mem reserved nodes */
+	ret = zocl_cma_mem_region_init(zdev, pdev);
+	if (ret)
+		DRM_WARN("Failed to initialize the cma mem reserved nodes\n");
+
 	/* Initialize Aperture */
 	ret = zocl_aperture_init(zdev);
 	if (ret)
@@ -1355,6 +1425,7 @@ static int zocl_drm_platform_remove(struct platform_device *pdev)
 	if (zdev->fpga_mgr)
 		fpga_mgr_put(zdev->fpga_mgr);
 
+	zocl_cma_mem_region_remove(zdev);
 	zocl_clear_mem(zdev);
 	mutex_destroy(&zdev->mm_lock);
 	zocl_pr_slot_fini(zdev);

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
@@ -24,6 +24,7 @@
 #include <drm/drm_mm.h>
 #include <linux/version.h>
 #include <linux/vmalloc.h>
+#include <linux/of_reserved_mem.h>
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
 #include <drm/drm_gem_dma_helper.h>
 #else
@@ -149,6 +150,11 @@ struct drm_zocl_bo {
 	unsigned int                   mem_index;
 	uint32_t                       flags;
 	unsigned int                   user_flags;
+	// new members to track the memory region
+	void				*vaddr;
+	dma_addr_t			phys;
+	size_t				size;
+	int				mem_region;
 };
 
 struct drm_zocl_copy_bo {

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
@@ -150,7 +150,6 @@ struct drm_zocl_bo {
 	unsigned int                   mem_index;
 	uint32_t                       flags;
 	unsigned int                   user_flags;
-	// new members to track the memory region
 	void				*vaddr;
 	dma_addr_t			phys;
 	size_t				size;

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_util.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_util.h
@@ -22,6 +22,7 @@
 #define _8KB	0x2000
 #define _64KB	0x10000
 
+#define ZOCL_MAX_MEM_REGIONS 5
 #define MAX_PR_SLOT_NUM	32
 #define MAX_CU_NUM     128
 /* Apertures contains both ip and debug ip information */
@@ -159,6 +160,11 @@ struct zocl_cu_subdev {
 	struct mutex		 lock;
 };
 
+struct zocl_mem_region {
+	struct device *dev;
+	bool initialized;
+};
+
 struct drm_zocl_dev {
 	struct drm_device       *ddev;
 	struct fpga_manager     *fpga_mgr;
@@ -200,6 +206,7 @@ struct drm_zocl_dev {
 	int			 full_overlay_id;
 	struct drm_zocl_slot	*pr_slot[MAX_PR_SLOT_NUM];
 	u32                     slot_mask;
+	struct zocl_mem_region	mem_regions[ZOCL_MAX_MEM_REGIONS];
 };
 
 int zocl_kds_update(struct drm_zocl_dev *zdev, struct drm_zocl_slot *slot,

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_util.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_util.h
@@ -206,6 +206,7 @@ struct drm_zocl_dev {
 	int			 full_overlay_id;
 	struct drm_zocl_slot	*pr_slot[MAX_PR_SLOT_NUM];
 	u32                     slot_mask;
+	int						num_regions;
 	struct zocl_mem_region	mem_regions[ZOCL_MAX_MEM_REGIONS];
 };
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/VITIS-15145
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Not an issue but a new feature
#### How problem was solved, alternative solutions (if any) and why they were rejected
EDF/Vitis Common CED contains multiple DDR (or LPDDR) memory banks, this pr is to support DMA access to any of the memory banks. It was solved by probing the zocl tagged cma memory regions at the time of probing the driver and allocating bufffers from the zocl tagged cma memories and also from the default CMAs. 

Note: in next pr will support index based cma buffer allocation. User will be able to allocate from specific CMA memory. Currently by default it tries to allocate from the zocl tagged cma reserved memories if unavailable then fallbacks to the default CMA and allocates from the default CMA to support existing flow.
#### Risks (if any) associated the changes in the commit
n/a
#### What has been tested and how, request additional testing if necessary
Tested existing edge testcases. Here is the table of existing testcases:
<html xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:dt="uuid:C2F41010-65B3-11d1-A29F-00AA00C14882"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=OneNote.File>
<meta name=Generator content="Microsoft OneNote 15">
</head>

<body lang=en-US style='font-family:Calibri;font-size:11.0pt'>
<!--StartFragment-->

<div style='direction:ltr'>


Test | VCK190 | VEK280 | Overlay
-- | -- | -- | --
Simple vadd | PASSED | PASSED | No
Simple gmio | PASSED | PASSED | No
Simple rtp | PASSED | PASSED | No
Multi AIE only | PASSED | PASSED | Yes
AIE only | PASSED | PASSED | Yes
PL only + AIE only | PASSED | PASSED | Yes
PL only + AIE only   + AIE only | PASSED | PASSED | Yes



</div>

<!--EndFragment-->
</body>

</html>
Also tested a testcase by having zocl tagged cma reserved memories
<html xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:dt="uuid:C2F41010-65B3-11d1-A29F-00AA00C14882"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=OneNote.File>
<meta name=Generator content="Microsoft OneNote 15">
</head>

<body lang=en-US style='font-family:Calibri;font-size:11.0pt'>
<!--StartFragment-->

<div style='direction:ltr'>


Test | Status
-- | --
Simple vadd with   zocl tagged cma reserved memories | Able to create   buffer from zocl tagged cma reserved memories as well as from default CMA



</div>

<!--EndFragment-->
</body>

</html>

#### Documentation impact (if any)
n/a