### PR TITLE
[XDP] Enhancement to fix PL device Interface for register Xclbin AppStyle

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info/device_info.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info/device_info.cpp
@@ -138,6 +138,13 @@ namespace xdp {
     loadedConfigInfos.push_back(std::move(config));
   }
 
+  void DeviceInfo::createEmptyConfig()
+  {
+    // Create a new empty config
+    std::unique_ptr<ConfigInfo> config = std::make_unique<ConfigInfo>();
+    loadedConfigInfos.push_back(std::move(config));
+  }
+
   bool DeviceInfo::hasFloatingAIMWithTrace(XclbinInfo* xclbin) const
   {
     for (const auto& cfg : getLoadedConfigs()) {

--- a/src/runtime_src/xdp/profile/database/static_info/device_info.h
+++ b/src/runtime_src/xdp/profile/database/static_info/device_info.h
@@ -89,6 +89,7 @@ namespace xdp {
     // ****** Functions for Device ConfigInfo ******
     XDP_CORE_EXPORT XclbinInfo* createXclbinFromLastConfig(XclbinInfoType xclbinQueryType) ;
     XDP_CORE_EXPORT void createConfig(XclbinInfo* xclbin) ;
+    XDP_CORE_EXPORT void createEmptyConfig() ;
     
     // ****** Functions for information on the device ******
     XDP_CORE_EXPORT std::string getUniqueDeviceName() const ;

--- a/src/runtime_src/xdp/profile/database/static_info/xclbin_types.h
+++ b/src/runtime_src/xdp/profile/database/static_info/xclbin_types.h
@@ -30,7 +30,8 @@ namespace xdp {
     CONFIG_PL_ONLY,
     CONFIG_AIE_ONLY,
     CONFIG_AIE_PL,
-    CONFIG_AIE_PL_FORMED
+    CONFIG_AIE_PL_FORMED,
+    CONFIG_PL_DEVICE_INTF_ONLY
   } ;
 
 } // end namespace xdp

--- a/src/runtime_src/xdp/profile/database/static_info_database.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info_database.cpp
@@ -520,7 +520,6 @@ namespace xdp {
 
       if ((!config->plDeviceIntf) && (getAppStyle() == AppStyle::REGISTER_XCLBIN_STYLE)) {
           // If AIE_ONLY xclbin loaded first, dummy PLDeviceIntf is created
-          //       with PL is loaded on to the device later.
           if (deviceInfo.find(DEFAULT_PL_DEVICE_ID) == deviceInfo.end()) {
             deviceInfo[DEFAULT_PL_DEVICE_ID] = std::make_unique<DeviceInfo>();
             deviceInfo[DEFAULT_PL_DEVICE_ID]->createEmptyConfig();

--- a/src/runtime_src/xdp/profile/database/static_info_database.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info_database.cpp
@@ -2530,24 +2530,19 @@ namespace xdp {
     } else {
       // This is a previously used device being reloaded with a new xclbin
       devInfo = itr->second.get();
-
-      // Do not clean config if new xclbin is AIE type as it could be for mix xclbins run.
-      // It is expected to have AIE type xclbin loaded after PL type.
-      devInfo->cleanCurrentConfig(xclbinType);
-    }
-
-    if ((getAppStyle() == AppStyle::REGISTER_XCLBIN_STYLE) && ((xclbinType == XCLBIN_PL_ONLY) || (xclbinType == XCLBIN_AIE_PL)))
-    {
-      if (deviceInfo.find(DEFAULT_PL_DEVICE_ID) != deviceInfo.end()) {
-        ConfigInfo* defaultConfig = deviceInfo[DEFAULT_PL_DEVICE_ID]->currentConfig();
-        if (defaultConfig && (defaultConfig->type == CONFIG_PL_DEVICE_INTF_ONLY)) {
+      ConfigInfo *config = devInfo->currentConfig();
+      if (config && (config->type == CONFIG_PL_DEVICE_INTF_ONLY) &&
+          (xclbinType == XCLBIN_PL_ONLY || xclbinType == XCLBIN_AIE_PL)) {
           std::stringstream errMsg;
           errMsg << "Debug and Profiling features are not supported if PL xclbin hw_context is created after AIE only xclbin hw_context for device. ";
           errMsg << "Please update host code to create PL xclbin hw_context before AIE only xclbin hw_context.";
           xrt_core::message::send(xrt_core::message::severity_level::error, "XRT", errMsg.str());
           std::abort();
-        }
       }
+
+      // Do not clean config if new xclbin is AIE type as it could be for mix xclbins run.
+      // It is expected to have AIE type xclbin loaded after PL type.
+      devInfo->cleanCurrentConfig(xclbinType);
     }
 
     XclbinInfo* currentXclbin = new XclbinInfo(xclbinType) ;

--- a/src/runtime_src/xdp/profile/database/static_info_database.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info_database.cpp
@@ -483,7 +483,11 @@ namespace xdp {
     // Check if new xclbin has new PL metadata
     if ((newXclbinType == XCLBIN_AIE_PL) || (newXclbinType == XCLBIN_PL_ONLY))
     {
-      // Delete previous dummy plDeviceIntf if available and re-create using xclbin with PL
+      /* Delete previous dummy plDeviceIntf if available and re-create using xclbin with PL.
+      * For now, if HW Ctx for PL xclbin is created after a dummy PL Device Interface has been created for AIE only xclbin (for aie_trace), 
+      * XDP errors out and aborts while processing the new PL xclbin. 
+      * So the following deletion of dummy PL Device Intf is unreachable.
+      */
       if ((config->plDeviceIntf != nullptr) && (config->type == CONFIG_PL_DEVICE_INTF_ONLY))
         delete config->plDeviceIntf;
 

--- a/src/runtime_src/xdp/profile/database/static_info_database.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info_database.cpp
@@ -520,7 +520,6 @@ namespace xdp {
 
       if ((!config->plDeviceIntf) && (getAppStyle() == AppStyle::REGISTER_XCLBIN_STYLE)) {
           // If AIE_ONLY xclbin loaded first, dummy PLDeviceIntf is created
-          // NOTE: PLDeviceIntf will be overwritten with a new PLDevice Intf if xclbin
           //       with PL is loaded on to the device later.
           if (deviceInfo.find(DEFAULT_PL_DEVICE_ID) == deviceInfo.end()) {
             deviceInfo[DEFAULT_PL_DEVICE_ID] = std::make_unique<DeviceInfo>();

--- a/src/runtime_src/xdp/profile/database/static_info_database.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info_database.cpp
@@ -2541,7 +2541,10 @@ namespace xdp {
       if (deviceInfo.find(DEFAULT_PL_DEVICE_ID) != deviceInfo.end()) {
         ConfigInfo* defaultConfig = deviceInfo[DEFAULT_PL_DEVICE_ID]->currentConfig();
         if (defaultConfig && (defaultConfig->type == CONFIG_PL_DEVICE_INTF_ONLY)) {
-          xrt_core::message::send(xrt_core::message::severity_level::error, "XRT", XDP_ERROR_PL_XCLBIN_AFTER_AIE_ONLY_XCLBIN);
+          std::stringstream errMsg;
+          errMsg << "Debug and Profiling features are not supported if PL xclbin hw_context is created after AIE only xclbin hw_context for device. ";
+          errMsg << "Please update host code to create PL xclbin hw_context before AIE only xclbin hw_context.";
+          xrt_core::message::send(xrt_core::message::severity_level::error, "XRT", errMsg.str());
           std::abort();
         }
       }

--- a/src/runtime_src/xdp/profile/database/static_info_database.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info_database.cpp
@@ -2536,7 +2536,7 @@ namespace xdp {
       if (config && (config->type == CONFIG_PL_DEVICE_INTF_ONLY) &&
           (xclbinType == XCLBIN_PL_ONLY || xclbinType == XCLBIN_AIE_PL)) {
           std::stringstream errMsg;
-          errMsg << "Debug and Profiling features are not supported if PL xclbin hw_context is created after AIE only xclbin hw_context for device. ";
+          errMsg << "AIE Trace is not supported if PL xclbin hw_context is created after AIE only xclbin hw_context for device. ";
           errMsg << "Please update host code to create PL xclbin hw_context before AIE only xclbin hw_context.";
           xrt_core::message::send(xrt_core::message::severity_level::error, "XRT", errMsg.str());
           std::abort();

--- a/src/runtime_src/xdp/profile/database/static_info_database.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info_database.cpp
@@ -2516,7 +2516,7 @@ namespace xdp {
     //  create a new PL interface if necessary
     if (deviceInfo.find(deviceId) != deviceInfo.end()) {
       ConfigInfo* config = deviceInfo[deviceId]->currentConfig() ;
-      if (config) {
+      if (config && (config->type != CONFIG_PL_DEVICE_INTF_ONLY)) {
         xrt_core::message::send(xrt_core::message::severity_level::info, "XRT", "Marking the end of last config xclbin");
         db->getDynamicInfo().markXclbinEnd(deviceId) ;
 

--- a/src/runtime_src/xdp/profile/database/static_info_database.h
+++ b/src/runtime_src/xdp/profile/database/static_info_database.h
@@ -25,6 +25,8 @@
 #include "xdp/config.h"
 
 namespace xdp {
+  // Device ID for PL-only and AIE+PL xclbins in Register Xclbin style.
+  constexpr uint64_t DEFAULT_PL_DEVICE_ID = 0;
 
   // Forward declarations of general XDP constructs
   class VPDatabase;
@@ -155,6 +157,8 @@ namespace xdp {
     double findClockRate(xrt::xclbin);
 
     XclbinInfoType getXclbinType(xrt::xclbin& xclbin);
+    xrt::uuid getXclbinUuidOnDevice(std::shared_ptr<xrt_core::device> device);
+
     // This common private updateDevice functionality takes an xdp::Device
     // pointer to handle any connection to the PL side as necessary.
     // Some plugins do not require any PL control and will pass in nullptr

--- a/src/runtime_src/xdp/profile/device/tracedefs.h
+++ b/src/runtime_src/xdp/profile/device/tracedefs.h
@@ -87,6 +87,8 @@ Please increase trace_buffer_size and trace_buffer_offload_interval together or 
 #define AIE_TS2MM_WARN_MSG_BUF_FULL           "AIE Trace Buffer is full. Device trace could be incomplete."
 #define AIE_TS2MM_WARN_MSG_CIRC_BUF_OVERWRITE "Circular buffer overwrite was detected in device trace. AIE trace could be incomplete."
 #define AIE_TRACE_TILES_UNAVAILABLE           "No valid tiles found for the provided configuration and design. So, AIE event trace will not be available."
+#define XDP_ERROR_PL_XCLBIN_AFTER_AIE_ONLY_XCLBIN "Debug and Profiling features not supported if PL xclbin hw_context is created after AIE only xclbin hw_context for device. \
+Please update host code to create PL xclbin hw_context before AIE only xclbin hw_context."
 
 #define AIE_TRACE_BUF_REUSE_WARN              "AIE reuse_buffer may cause overrun. \
 Recommended settings: \

--- a/src/runtime_src/xdp/profile/device/tracedefs.h
+++ b/src/runtime_src/xdp/profile/device/tracedefs.h
@@ -87,8 +87,6 @@ Please increase trace_buffer_size and trace_buffer_offload_interval together or 
 #define AIE_TS2MM_WARN_MSG_BUF_FULL           "AIE Trace Buffer is full. Device trace could be incomplete."
 #define AIE_TS2MM_WARN_MSG_CIRC_BUF_OVERWRITE "Circular buffer overwrite was detected in device trace. AIE trace could be incomplete."
 #define AIE_TRACE_TILES_UNAVAILABLE           "No valid tiles found for the provided configuration and design. So, AIE event trace will not be available."
-#define XDP_ERROR_PL_XCLBIN_AFTER_AIE_ONLY_XCLBIN "Debug and Profiling features not supported if PL xclbin hw_context is created after AIE only xclbin hw_context for device. \
-Please update host code to create PL xclbin hw_context before AIE only xclbin hw_context."
 
 #define AIE_TRACE_BUF_REUSE_WARN              "AIE reuse_buffer may cause overrun. \
 Recommended settings: \


### PR DESCRIPTION
Problem solved by the commit
New Feature - Support PL Device Interface at DeviceID 0 in register xclbin flow.

Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
NA, New feature.

How problem was solved, alternative solutions (if any) and why they were rejected
Device ID 0 is reserved for PL Device Interface.
In register xclbin flow, all references to PL DeviceIntf will now refer to Device ID 0.

Risks (if any) associated the changes in the commit
Medium

What has been tested and how, request additional testing if necessary
Verified on edge with multi partition DUT.

Documentation impact (if any)
NA