### PR TITLE
[RFC] hip: use hipMemPrefetchAsync() to sync buffer in HIP flow

### DIFF
--- a/src/runtime_src/hip/core/event.cpp
+++ b/src/runtime_src/hip/core/event.cpp
@@ -242,6 +242,28 @@ bool memory_pool_command::wait()
   return true;
 }
 
+bool mem_prefetch_command::submit()
+{
+  auto hip_mem_and_off = memory_database::instance().get_hip_mem_from_addr(m_dev_ptr);
+  auto hip_mem = hip_mem_and_off.first;
+  size_t hip_mem_off = hip_mem_and_off.second;
+  throw_invalid_value_if(!hip_mem, "Invalid prefetch buf address.");
+  throw_invalid_value_if((hip_mem->get_size() < (hip_mem_off + m_size)),
+                         "Invalid prefetch buf address or size.");
+
+  // The under xrt::bo::sync() behaves the same for both TO_DEVICE or FROM_DEVICE direction.
+  // we pick xclBOSyncDirection::XCL_BO_SYNC_BO_TO_DEVICE as input argument here.
+  hip_mem->sync(xclBOSyncDirection::XCL_BO_SYNC_BO_TO_DEVICE, m_size, hip_mem_off);
+  set_state(state::completed);
+  return true;
+}
+
+bool mem_prefetch_command::wait()
+{
+  // completed in submit()
+  return true;
+}
+
 // Global map of commands
 xrt_core::handle_map<command_handle, std::shared_ptr<command>> command_cache;
 

--- a/src/runtime_src/hip/core/event.h
+++ b/src/runtime_src/hip/core/event.h
@@ -41,7 +41,8 @@ public:
     event,
     kernel_start,
     mem_cpy,
-    mem_pool_op
+    mem_pool_op,
+    mem_prefetch
   };
 
 protected:
@@ -204,6 +205,21 @@ private:
   void* m_ptr;
   size_t m_size;
   std::future<void> m_handle;
+};
+
+class mem_prefetch_command : public command
+{
+public:
+  // sync() always happens in submit()
+  mem_prefetch_command(std::shared_ptr<stream> s, const void* dev_ptr, size_t size)
+    : command(command::type::mem_prefetch, std::move(s)), m_dev_ptr(dev_ptr), m_size(size)
+  {}
+  bool submit() override;
+  bool wait() override;
+
+private:
+  const void* m_dev_ptr;
+  size_t m_size;
 };
 
 // Global map of commands

--- a/src/runtime_src/hip/core/memory.cpp
+++ b/src/runtime_src/hip/core/memory.cpp
@@ -130,6 +130,13 @@ namespace xrt::core::hip
   }
 
   void
+  memory::sync(xclBOSyncDirection direction, size_t sz, size_t offset)
+  {
+    throw_invalid_value_if(!m_bo, "memory sync, empty bo.");
+    m_bo.sync(direction, sz, offset);
+  }
+
+  void
   memory::copy(const memory& src, size_t sz, size_t src_offset, size_t dst_offset)
   {
     m_bo.copy(src.get_xrt_bo(), sz, src_offset, dst_offset);

--- a/src/runtime_src/hip/core/memory.h
+++ b/src/runtime_src/hip/core/memory.h
@@ -66,6 +66,9 @@ namespace xrt::core::hip
     sync(xclBOSyncDirection);
 
     void
+    sync(xclBOSyncDirection dir, size_t sz, size_t offset);
+
+    void
     copy(const memory& src, size_t sz, size_t src_offset = 0, size_t dst_offset = 0);
 
     const xrt::bo&


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
This Patch sets solve two HIP XRT APIs issues:
* Some NPUs only support non-coherent memory, and thus, we need to sync data to memory before AIE kernel execution, and we will need to sync data after kernel execution to make sure CPU gets the right data. This patch set use `hipMemPrefetchAsync()` to sync data before kernel launch and after kernel execution.

Here is the example to use the API:
```
uint32_t* ibuf0, ibuf1, ibuf2, obuf;
uint32_t* ibuf0_dev, ibuf1_dev, ibuf2_dev, obuf_dev;
hipHostMalloc(&ibuf0, size, FLAG);
hipHostMalloc(&ibuf1, size, FLAG);
hipHostMalloc(&ibuf2, size, FLAG);
hipHostMalloc(&obuf, size, FLAG);
hipHostGetDevicePointer(&ibuf0_dev, ibuf0, 0);
hipHostGetDevicePointer(&ibuf1_dev, ibuf1, 0);
hipHostGetDevicePointer(&ibuf2_dev, ibuf2, 0);
hipHostGetDevicePointer(&obuf_dev, obuf, 0);
uint64_t opcode = 3;
std::array<void *, 8> args = {
      &opcode,
      nullptr,
      nullptr,
      &ibuf0_dev,
      &ibuf1_dev,
      &ibuf2_dev, nullptr, &obuf_dev};
hipMemPrefetchAsync(ibuf0_dev, size, 0, stream);
hipMemPrefetchAsync(ibuf1_dev, size, 0, stream);
hipMemPrefetchAsync(ibuf2_dev, size, 0, stream);
hipMemPrefetchAsync(obuf_dev, size, 0, stream); // sometimes, obuf, may also want to sync before kernel starts
hipModuleLaunchKernel(function, gridDimX, gridDimY, gridDimZ,
                      blockDimX, blockDimY, blockDimZ,
                      sharedMemBytes, stream,
                      args.data(), nullptr);
hipStreamSynchronize(stream);
hipMemPrefetchAsync(obuf_dev, size, 0, stream); // sync() will be completed in cmd submit()
hipStreamSynchronize(stream); // can be optional as it will clear the completed sync() command from the queue
```

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Tested with `expoi-v1-fp32-256x256-1x_GroupConv__coeffs_up2_conv_conv2_conv_kernel_2_Conv` model on strix

#### Documentation impact (if any)
