### PR TITLE
[XDP] Add warning if periodic trace is used for non hanging design on Client Devices

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_metadata.cpp
@@ -60,7 +60,7 @@ namespace xdp {
     continuousTrace = xrt_core::config::get_aie_trace_settings_periodic_offload();
     // AIE trace is now supported for HW only
 #ifdef XDP_CLIENT_BUILD
-    // Default periodic offload is flipped on client to off. But if user passes it explicity in xrt.ini,
+    // Default periodic offload is flipped on client to off. But if user passes it explicitly in xrt.ini,
     // we read that and turn on periodic offload as user might be passing to get trace for hung design.
     bool isPeriodicOffloadPresent = false;
     auto tree1 = xrt_core::config::detail::get_ptree_value("AIE_trace_settings");

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_metadata.cpp
@@ -65,6 +65,10 @@ namespace xdp {
     auto tree1 = xrt_core::config::detail::get_ptree_value("AIE_trace_settings");
     for (pt::ptree::iterator pos = tree1.begin(); pos != tree1.end(); pos++) {
       if (pos->first == "periodic_offload") {
+        std::stringstream msg;
+        msg << "Periodic offload on Client Devices is supported only for hanging design."
+            << " Periodic offload shouldn't be used for non hanging design.";
+        xrt_core::message::send(severity_level::warning, "XRT", msg.str());
         isPeriodicOffloadPresent = true;
         break;
       }

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_metadata.cpp
@@ -60,7 +60,8 @@ namespace xdp {
     continuousTrace = xrt_core::config::get_aie_trace_settings_periodic_offload();
     // AIE trace is now supported for HW only
 #ifdef XDP_CLIENT_BUILD
-    // Default return is flipped on client
+    // Default periodic offload is flipped on client to off. But if user passes it explicity in xrt.ini,
+    // we read that and turn on periodic offload as user might be passing to get trace for hung design.
     bool isPeriodicOffloadPresent = false;
     auto tree1 = xrt_core::config::detail::get_ptree_value("AIE_trace_settings");
     for (pt::ptree::iterator pos = tree1.begin(); pos != tree1.end(); pos++) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Added warning if periodic trace is used for non hanging design on client devices.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
NA
#### Risks (if any) associated the changes in the commit
Low
#### What has been tested and how, request additional testing if necessary
Tested windows compilation