### PR TITLE
hip: replay assert with throw error

### DIFF
--- a/src/runtime_src/hip/api/hip_memory.cpp
+++ b/src/runtime_src/hip/api/hip_memory.cpp
@@ -21,11 +21,11 @@ namespace xrt::core::hip
   static void
   hip_malloc(void** ptr, size_t size)
   {
-    assert(ptr);
-    assert(size > 0);
+    throw_invalid_value_if(!ptr, "empty ptr for hip malloc.");
+    throw_invalid_value_if(size <= 0, "invalid size for hip malloc.");
 
     auto dev = get_current_device();
-    assert(dev);
+    throw_invalid_device_if(!dev, "empty device for hip malloc.");
 
     *ptr = nullptr;
     auto hip_mem = std::make_shared<xrt::core::hip::memory>(dev, size);
@@ -40,11 +40,11 @@ namespace xrt::core::hip
   static void
   hip_host_malloc(void** ptr, size_t size, unsigned int flags)
   {
-    assert(ptr);
-    assert(size > 0);
+    throw_invalid_value_if(!ptr, "empty ptr for hip malloc.");
+    throw_invalid_value_if(size <= 0, "invalid size for hip malloc.");
 
     auto dev = get_current_device();
-    assert(dev);
+    throw_invalid_device_if(!dev, "empty device for hip malloc.");
 
     *ptr = nullptr;
     auto hip_mem = std::make_shared<xrt::core::hip::memory>(dev, size, flags);
@@ -60,8 +60,8 @@ namespace xrt::core::hip
   hip_host_register(void* host_ptr, size_t size, unsigned int flags)
   {
     auto dev = get_current_device();
-    assert(dev);
-    assert(host_ptr);
+    throw_invalid_device_if(!dev, "empty device for hip malloc.");
+    throw_invalid_value_if(!host_ptr, "empty host memory pointer for host memory registration.");
 
     auto hip_mem = std::make_shared<xrt::core::hip::memory>(dev, size, host_ptr, flags);
     auto host_addr = hip_mem->get_address();
@@ -74,7 +74,7 @@ namespace xrt::core::hip
   static void
   hip_host_get_device_pointer(void** device_ptr, void* host_ptr, unsigned int flags)
   {
-    assert(device_ptr);
+    throw_invalid_value_if(!device_ptr, "empty device memory pointer handle to get device pointer.");
 
     auto hip_mem = memory_database::instance().get_hip_mem_from_addr(host_ptr).first;
     throw_invalid_value_if(!hip_mem, "Error getting device pointer from host pointer.");
@@ -224,7 +224,8 @@ namespace xrt::core::hip
     auto hip_mem_info = memory_database::instance().get_hip_mem_from_addr(dst);
     auto hip_mem_dst = hip_mem_info.first;
     auto offset = hip_mem_info.second;
-    assert(hip_mem_dst->get_type() != xrt::core::hip::memory_type::invalid);
+    throw_invalid_value_if(hip_mem_dst->get_type() == xrt::core::hip::memory_type::invalid,
+                           "memory type is invalid for memset.");
     throw_invalid_value_if(offset + size > hip_mem_dst->get_size(), "dst out of bound.");
 
     auto host_src = xrt_core::aligned_alloc(xrt_core::getpagesize(), size);
@@ -285,8 +286,8 @@ namespace xrt::core::hip
   hip_mem_pool_create(hipMemPool_t* mem_pool, const hipMemPoolProps* pool_props)
   {
     auto dev = get_current_device();
-    assert(dev);
-    assert(mem_pool);
+    throw_invalid_device_if(!dev, "empty device for memory pool creation.");
+    throw_invalid_device_if(!mem_pool, "empty mem pool handle  for memory pool creation.");
 
     auto pool = std::make_shared<memory_pool>(dev, MAX_MEMORY_POOL_SIZE_NPU, MEMORY_POOL_BLOCK_SIZE_NPU);
     auto pool_hdl = insert_in_map(mem_pool_cache, pool);

--- a/src/runtime_src/hip/core/memory.cpp
+++ b/src/runtime_src/hip/core/memory.cpp
@@ -23,7 +23,7 @@ namespace xrt::core::hip
 	m_type(memory_type::device),
 	m_flags(0)
   {
-    assert(m_device);
+    throw_invalid_device_if(!m_device, "failed to create hip memory, empty device.");
 
     // TODO: support non-npu device that may require delayed xrt::bo allocation until xrt kernel is created
     init_xrt_bo();
@@ -32,7 +32,7 @@ namespace xrt::core::hip
   memory::memory(device* dev, size_t sz, void *host_mem, unsigned int flags)
       : m_device(dev), m_size(sz), m_type(memory_type::registered), m_flags(flags)
   {
-    assert(m_device);
+    throw_invalid_device_if(!m_device, "failed to create hip memory, empty device.");
 
     // TODO: useptr is not supported in NPU.
     auto xrt_device = m_device->get_xrt_device();
@@ -45,7 +45,7 @@ namespace xrt::core::hip
 	m_type(memory_type::host),
 	m_flags(flags)
   {
-    assert(m_device);
+    throw_invalid_device_if(!m_device, "failed to create hip memory, empty device.");
 
     switch (m_flags) {
       // TODO Need to create locked memory for Default and Portable flags. Creating a regular BO for now
@@ -97,7 +97,9 @@ namespace xrt::core::hip
     auto src_hip_mem = memory_database::instance().get_hip_mem_from_addr(src).first;
     if (src_hip_mem && src_hip_mem->get_type() == memory_type::host) {
         // pinned hip mem
-        assert(src_hip_mem->get_flags() == hipHostMallocDefault || src_hip_mem->get_flags() == hipHostMallocPortable);
+        throw_invalid_value_if((src_hip_mem->get_flags() != hipHostMallocDefault) &&
+                               (src_hip_mem->get_flags() != hipHostMallocPortable),
+                               "invalid src memory flag to write from host source memory.");
     }
     // host memory
     auto src_ptr = reinterpret_cast<const unsigned char*>(src);
@@ -112,7 +114,9 @@ namespace xrt::core::hip
     auto dst_hip_mem = memory_database::instance().get_hip_mem_from_addr(dst).first;
     if (dst_hip_mem != nullptr && dst_hip_mem->get_type() == memory_type::host) {
         // pinned hip mem
-        assert(dst_hip_mem->get_flags() == hipHostMallocDefault || dst_hip_mem->get_flags() == hipHostMallocPortable);
+        throw_invalid_value_if((dst_hip_mem->get_flags() != hipHostMallocDefault) &&
+                               (dst_hip_mem->get_flags() != hipHostMallocPortable),
+                               "invalid dst memory flag to read to host source memory.");
     }
     auto dst_ptr = reinterpret_cast<unsigned char *>(dst);
     dst_ptr += dst_offset;
@@ -125,7 +129,7 @@ namespace xrt::core::hip
   void
   memory::sync(xclBOSyncDirection direction)
   {
-    assert(m_bo);
+    throw_invalid_value_if(!m_bo, "empty bo to sync.");
     m_bo.sync(direction);
   }
 

--- a/src/runtime_src/hip/core/memory_pool.cpp
+++ b/src/runtime_src/hip/core/memory_pool.cpp
@@ -237,7 +237,7 @@ namespace xrt::core::hip
     if (m_list.size() == 0)
       init();
 
-    assert(ptr);
+    throw_invalid_value_if(!ptr, "empty sub memory handle for pool malloc.");
     auto sub_mem = memory_database::instance().get_sub_mem_from_handle(reinterpret_cast<memory_handle>(ptr));
     if (!sub_mem) {
       throw std::runtime_error("Invlid sub_memory handle");


### PR DESCRIPTION
assert() is to identify and diagnose program bugs during development. In release build when NDEBUG macro is defined, asser macros are completely removed from the compiled code.
In HIP XRT implementation, we want to check parameters and throw errors when check fails. handle_hip_memory_error() will catch the error and return error code.

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
