### PR TITLE
hip: core: stream: clear m_top_event when stream completes

### DIFF
--- a/src/runtime_src/hip/core/stream.cpp
+++ b/src/runtime_src/hip/core/stream.cpp
@@ -121,6 +121,8 @@ await_completion()
       command_cache.remove(cmd.get());
     m_cmd_queue.pop_front();
   }
+  // reset m_top_event as stream completed
+  m_top_event = nullptr;
 }
 
 void


### PR DESCRIPTION
If a stream is set to wait for an event, all the commands enqueued to the stream, after setting the stream waiting on the event will be added to the commands chain to the event so that when an event is completed, all those dependent commands will execute. When the stream which depends on an event completed, we should reset the event on which the stream depends on, otherwise, the commands enqueued to the stream later will added to the event commands chain. Since the event has completed, it will not signal again, and thus, those commands will not run again, even we want to rerun the stream.

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
