### PR TITLE
CR-1244418: Fixing xrt::aie::bo synchronization issue

### DIFF
--- a/src/runtime_src/core/edge/user/aie/aie.cpp
+++ b/src/runtime_src/core/edge/user/aie/aie.cpp
@@ -310,6 +310,7 @@ sync_bo(std::vector<xrt::bo>& bos, const char *port_name, enum xclBOSyncDirectio
 
   submit_sync_bo(bo, gmio_itr->second, gmio_config_itr->second, dir, size, offset);
   gmio_itr->second->wait();
+  bo.sync(dir);
 }
 
 std::pair<size_t, size_t>
@@ -342,7 +343,10 @@ sync_bo_nb(std::vector<xrt::bo>& bos, const char *port_name, enum xclBOSyncDirec
   if (gmio_config_itr == gmio_configs.end())
     throw xrt_core::error(-EINVAL, "Can't sync BO: GMIO name not found");
 
-  return submit_sync_bo(bos[0], gmio_itr->second, gmio_config_itr->second, dir, size, offset);
+  std::pair<size_t, size_t> bd_info = submit_sync_bo(bos[0], gmio_itr->second, gmio_config_itr->second, dir, size, offset);
+  gmio_itr->second->set_bo_dir(bd_info.first, bos[0], dir);
+
+  return bd_info;
 }
 
 bool

--- a/src/runtime_src/core/edge/user/aie/common_layer/adf_runtime_api.cpp
+++ b/src/runtime_src/core/edge/user/aie/common_layer/adf_runtime_api.cpp
@@ -685,6 +685,10 @@ void gmio_api::getAvailableBDs()
         uint16_t bdNumber = frontAndPop(enqueuedBDs);
         statusBDs[bdNumber]++;
         availableBDs.push(bdNumber);
+        if (BOs.find(bdNumber) != BOs.end()) {
+            BOs[bdNumber].first.sync(BOs[bdNumber].second);
+            BOs.erase(bdNumber);
+        }
     }
 }
 
@@ -764,6 +768,10 @@ err_code gmio_api::wait()
         size_t bdNumber = frontAndPop(enqueuedBDs);
         statusBDs[bdNumber]++;
         availableBDs.push(bdNumber);
+        if (BOs.find(bdNumber) != BOs.end()) {
+            BOs[bdNumber].first.sync(BOs[bdNumber].second);
+            BOs.erase(bdNumber);
+        }
     }
 
     return err_code::ok;

--- a/src/runtime_src/core/edge/user/aie/common_layer/adf_runtime_api.h
+++ b/src/runtime_src/core/edge/user/aie/common_layer/adf_runtime_api.h
@@ -19,6 +19,7 @@
 #include "adf_api_config.h"
 #include "adf_api_message.h"
 #include "adf_aie_control_api.h"
+#include "xrt/xrt_bo.h"
 
 #include <queue>
 #include <vector>
@@ -78,6 +79,10 @@ public:
   {
     return config;
   }
+  void set_bo_dir(uint16_t bdNum, xrt::bo& bo, xclBOSyncDirection dir)
+  {
+    BOs[bdNum] = {bo, dir};
+  }
 private:
   // GMIO shim DMA physical configuration compiled by the AIE compiler
   const gmio_config* pGMIOConfig;
@@ -91,6 +96,7 @@ private:
   std::queue<size_t> enqueuedBDs;
   std::queue<size_t> availableBDs;
   std::unordered_map<size_t, size_t> statusBDs;
+  std::unordered_map<size_t, std::pair<xrt::bo, xclBOSyncDirection>> BOs;
   std::shared_ptr<config_manager> config;
 };
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1244418
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
with xrt::aie::bo::sync() / xrt::aie::bo::async(), there were no guarantee that buffer will be synchronized (flushed in case of cma buffer) instantly just after GMIO_TO_AIE or AIE_TO_GMIO sync/async().
#### How problem was solved, alternative solutions (if any) and why they were rejected
Problem was solved by calling bo.sync(direction) explicitly from the xrt::aie::bo::sync() and xrt::aie::bo::async(). 
Please note: 
1. In case of xrt::aie::bo::sync(), bo.sync() gets called instantly after the wait() on the GMIO_TO_AIE / AIE_TO_GMIO. 
2. In case of xrt::aie::bo::async(), bo.sync() won't get triggered automatically, unless you call wait() with the handle returned by the xrt::aie::bo::async(). Or, if we ran out of the BDs while updating the availableBDs queue, bo.sync() gets called for the respective BD.
#### Risks (if any) associated the changes in the commit
n/a
#### What has been tested and how, request additional testing if necessary
<html xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:dt="uuid:C2F41010-65B3-11d1-A29F-00AA00C14882"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=OneNote.File>
<meta name=Generator content="Microsoft OneNote 15">
</head>

<body lang=en-US style='font-family:Calibri;font-size:11.0pt'>
<!--StartFragment-->

<div style='direction:ltr'>


Testcase | AIE1 | Remarks
-- | -- | --
Given testcase on   the CR | PASSED | Tested by having   xrt::aie::bo::sync() and    by having   xrt::aie::bo::async()
GMIO testcase by   pushing too many    xrt::aie::buffer::async()   calls | PASSED | -
bikash_aie_sync_issue-hw-xilinx_vck190_base_202520_1 | Running   *will update   shortly | The test used to   fail on regression, so testing on the regression



</div>

<!--EndFragment-->
</body>

</html>

#### Documentation impact (if any)
n/a