### PR TITLE
Amend #9074 fix include paths

### DIFF
--- a/src/runtime_src/core/include/shim_int.h
+++ b/src/runtime_src/core/include/shim_int.h
@@ -4,7 +4,7 @@
 #ifndef SHIM_INT_H_
 #define SHIM_INT_H_
 
-#include "core/include/xrt.h"
+#include "core/include/xrt/deprecated/xrt.h"
 #include "core/include/xrt_hwqueue.h"
 #include "core/include/xrt/xrt_hw_context.h"
 #include "core/common/cuidx_type.h"

--- a/src/runtime_src/core/include/xclerr_int.h
+++ b/src/runtime_src/core/include/xclerr_int.h
@@ -41,7 +41,12 @@
 #ifndef XCLERR_INT_H_
 #define XCLERR_INT_H_
 
-#include "xrt/detail/xrt_error_code.h"
+// The kernel DKMS release copies headers flat to driver/include
+#if defined(__linux__) && defined(__KERNEL__)
+# include "xrt_error_code.h"
+#else
+# include "xrt/detail/xrt_error_code.h"
+#endif
 
 #define	XCL_ERROR_CAPACITY	32
 

--- a/src/runtime_src/core/include/xclerr_int.h
+++ b/src/runtime_src/core/include/xclerr_int.h
@@ -1,5 +1,6 @@
 /**
- *  Copyright (C) 2015-2021, Xilinx Inc
+ *  Copyright (C) 2015-2021, Xilinx, Inc.  All rights reserved.
+ *  Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  *  This file is dual licensed.  It may be redistributed and/or modified
  *  under the terms of the Apache 2.0 License OR version 2 of the GNU
@@ -40,7 +41,7 @@
 #ifndef XCLERR_INT_H_
 #define XCLERR_INT_H_
 
-#include "xrt_error_code.h"
+#include "xrt/detail/xrt_error_code.h"
 
 #define	XCL_ERROR_CAPACITY	32
 

--- a/src/runtime_src/core/include/xclhal2.h
+++ b/src/runtime_src/core/include/xclhal2.h
@@ -1,29 +1,15 @@
-/*
- * Copyright (C) 2019, Xilinx Inc - All rights reserved
- * Xilinx Runtime (XRT) Experimental APIs
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
-
-#ifndef _XCL_HAL2_H_
-#define _XCL_HAL2_H_
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2019 Xilinx, Inc. All rights reserved.
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#ifndef XCL_HAL2_H_
+#define XCL_HAL2_H_
 
 /*
  * XRT API definitions have moved to xrt.h. This file provides wrapper for
  * compatibility with legacy code.
  */
 
-#include "xrt.h"
+#include "xrt/deprecated/xrt.h"
 #include "xrt/experimental/xrt-next.h"
 
 #endif

--- a/src/runtime_src/core/include/xclhal2_mem.h
+++ b/src/runtime_src/core/include/xclhal2_mem.h
@@ -1,23 +1,9 @@
-/*
- * Copyright (C) 2019, Xilinx Inc - All rights reserved.
- * Xilinx Runtime (XRT) APIs
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2019 Xilinx, Inc.  All rights reserved.
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#ifndef XCLHAL2_MEM_H_
+#define XCLHAL2_MEM_H_
 
-#ifndef _XCLHAL2_MEM_H_
-#define _XCLHAL2_MEM_H_
-
-#include "xrt_mem.h"
+#include "xrt/detail/xrt_mem.h"
 
 #endif

--- a/src/runtime_src/core/include/xrt/experimental/xclbin_util.h
+++ b/src/runtime_src/core/include/xrt/experimental/xclbin_util.h
@@ -1,18 +1,6 @@
-/**
- * Copyright (C) 2020 Xilinx, Inc
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2020 Xilinx, Inc. All rights reserved.
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
 
 /**
  * This file contains publically exported xclbin utilities.
@@ -22,6 +10,8 @@
 #define xclbin_util_h_
 
 #include "xrt/detail/xclbin.h"
+#include <cerrno>
+#include <cstring>
 
 static inline const axlf*
 xclbin_axlf_handle(const void *xclbin)

--- a/src/runtime_src/core/include/xrt/experimental/xrt_error.h
+++ b/src/runtime_src/core/include/xrt/experimental/xrt_error.h
@@ -1,23 +1,10 @@
-/**
- * Copyright (C) 2020 Xilinx, Inc
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2020 Xilinx, Inc.  All rights reserved.
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
 #ifndef xrt_error_h_
 #define xrt_error_h_
 
-#include "xrt.h"
+#include "xrt/deprecated/xrt.h"
 #include "xrt_device.h"
 #include "xrt/detail/xrt_error_code.h"
 

--- a/src/runtime_src/core/include/xrt/experimental/xrt_ini.h
+++ b/src/runtime_src/core/include/xrt/experimental/xrt_ini.h
@@ -1,11 +1,10 @@
-/*
- * Copyright (C) 2021-2022 Xilinx, Inc
- * SPDX-License-Identifier: Apache-2.0
- */
-#ifndef _XRT_INI_H_
-#define _XRT_INI_H_
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2021-2022 Xilinx, Inc.  All rights reserved.
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#ifndef XRT_INI_H_
+#define XRT_INI_H_
 
-#include "xrt.h"
+#include "xrt/deprecated/xrt.h"
 
 #ifdef __cplusplus
 # include <string>

--- a/src/runtime_src/core/include/xrt/experimental/xrt_ip.h
+++ b/src/runtime_src/core/include/xrt/experimental/xrt_ip.h
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2021-2022 Xilinx, Inc. All rights reserved.
-// Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
 #ifndef XRT_IP_H_
 #define XRT_IP_H_
 
-#include "xrt.h"
+#include "xrt/deprecated/xrt.h"
 #include "xrt/xrt_uuid.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_hw_context.h"

--- a/src/runtime_src/core/include/xrt/experimental/xrt_mailbox.h
+++ b/src/runtime_src/core/include/xrt/experimental/xrt_mailbox.h
@@ -1,11 +1,10 @@
-/*
- * Copyright (C) 2021-2022 Xilinx, Inc
- * SPDX-License-Identifier: Apache-2.0
- */
-#ifndef _XRT_MAILBOX_H_
-#define _XRT_MAILBOX_H_
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2021-2022 Xilinx, Inc.  All rights reserved.
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#ifndef XRT_MAILBOX_H_
+#define XRT_MAILBOX_H_
 
-#include "xrt.h"
+#include "xrt/deprecated/xrt.h"
 #include "xrt/xrt_kernel.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/detail/pimpl.h"

--- a/src/runtime_src/core/include/xrt/experimental/xrt_message.h
+++ b/src/runtime_src/core/include/xrt/experimental/xrt_message.h
@@ -1,12 +1,10 @@
-/*
- * Copyright (C) 2021-2022 Xilinx, Inc
- * SPDX-License-Identifier: Apache-2.0
- */
-
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2021-2022 Xilinx, Inc.  All rights reserved.
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
 #ifndef xrt_message_h_
 #define xrt_message_h_
 
-#include "xrt.h"
+#include "xrt/deprecated/xrt.h"
 
 #ifdef __cplusplus
 # include <string>

--- a/src/runtime_src/core/include/xrt/experimental/xrt_profile.h
+++ b/src/runtime_src/core/include/xrt/experimental/xrt_profile.h
@@ -1,24 +1,10 @@
-/*
- * Copyright (C) 2020-2022, Xilinx Inc - All rights reserved
- * Xilinx Runtime (XRT) Experimental APIs
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2020-2022 Xilinx, Inc.  All rights reserved.
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#ifndef XRT_PROFILE_H_
+#define XRT_PROFILE_H_
 
-#ifndef _XRT_PROFILE_H_
-#define _XRT_PROFILE_H_
-
-#include "xrt.h"
+#include "xrt/deprecated/xrt.h"
 
 #ifdef __cplusplus
 

--- a/src/runtime_src/core/include/xrt/experimental/xrt_system.h
+++ b/src/runtime_src/core/include/xrt/experimental/xrt_system.h
@@ -1,12 +1,10 @@
-/*
- * Copyright (C) 2021-2022 Xilinx, Inc
- * SPDX-License-Identifier: Apache-2.0
- */
-
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2021-2022 Xilinx, Inc.  All rights reserved.
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
 #ifndef xrt_system_h_
 #define xrt_system_h_
 
-#include "xrt.h"
+#include "xrt/deprecated/xrt.h"
 
 #ifdef __cplusplus
 

--- a/src/runtime_src/core/include/xrt/experimental/xrt_xclbin.h
+++ b/src/runtime_src/core/include/xrt/experimental/xrt_xclbin.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (C) 2020-2022 Xilinx, Inc. All rights reserved.
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2020-2022 Xilinx, Inc.  All rights reserved.
+// Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
 #ifndef XRT_XCLBIN_H_
 #define XRT_XCLBIN_H_
 

--- a/src/runtime_src/core/include/xrt/xrt_aie.h
+++ b/src/runtime_src/core/include/xrt/xrt_aie.h
@@ -1,25 +1,10 @@
-/**
- * Copyright (C) 2020-2021 Xilinx, Inc
- * Author(s): Larry Liu
- * ZNYQ XRT Library layered on top of ZYNQ zocl kernel driver
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2020-2021 Xilinx, Inc. All rights reserved.
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
 #ifndef XRT_AIE_H_
 #define XRT_AIE_H_
 
-#include "xrt.h"
+#include "xrt/deprecated/xrt.h"
 #include "xrt/xrt_uuid.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"

--- a/src/runtime_src/core/include/xrt/xrt_bo.h
+++ b/src/runtime_src/core/include/xrt/xrt_bo.h
@@ -4,7 +4,7 @@
 #ifndef XRT_BO_H_
 #define XRT_BO_H_
 
-#include "xrt.h"
+#include "xrt/deprecated/xrt.h"
 #include "xrt/detail/xrt_mem.h"
 #include "xrt/detail/pimpl.h"
 

--- a/src/runtime_src/core/include/xrt/xrt_device.h
+++ b/src/runtime_src/core/include/xrt/xrt_device.h
@@ -4,7 +4,7 @@
 #ifndef XRT_DEVICE_H_
 #define XRT_DEVICE_H_
 
-#include "xrt.h"
+#include "xrt/deprecated/xrt.h"
 #include "xrt/xrt_uuid.h"
 #include "xrt/detail/config.h"
 #include "xrt/experimental/xrt_exception.h"

--- a/src/runtime_src/core/include/xrt/xrt_graph.h
+++ b/src/runtime_src/core/include/xrt/xrt_graph.h
@@ -1,25 +1,10 @@
-/**
- * Copyright (C) 2020-2021 Xilinx, Inc
- * Author(s): Larry Liu
- * ZNYQ XRT Library layered on top of ZYNQ zocl kernel driver
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2020-2021 Xilinx, Inc.  All rights reserved.
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
 #ifndef XRT_GRAPH_H_
 #define XRT_GRAPH_H_
 
-#include "xrt.h"
+#include "xrt/deprecated/xrt.h"
 #include "xrt/xrt_uuid.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"

--- a/src/runtime_src/core/include/xrt/xrt_hw_context.h
+++ b/src/runtime_src/core/include/xrt/xrt_hw_context.h
@@ -9,7 +9,7 @@
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_uuid.h"
 
-#include "experimental/xrt_elf.h"
+#include "xrt/experimental/xrt_elf.h"
 
 #ifdef __cplusplus
 

--- a/tests/xrt/100_ert_ncu/xrt.cpp
+++ b/tests/xrt/100_ert_ncu/xrt.cpp
@@ -1,25 +1,14 @@
-/**
- * Copyright (C) 2020 Xilinx, Inc
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2020 Xilinx, Inc.  All rights reserved.
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
 
 #include "xaddone_hw_64.h"
 
 // driver includes
-#include "ert.h"
-#include "xrt.h"
-#include "xclbin.h"
+#include "xrt/detail/ert.h"
+#include "xrt/detail/xclbin.h"
+#include "xrt/detail/xrt_mem.h"
+#include "xrt/deprecated/xrt.h"
 
 #include <fstream>
 #include <list>

--- a/tests/xrt/100_ert_ncu/xrtx.cpp
+++ b/tests/xrt/100_ert_ncu/xrtx.cpp
@@ -1,25 +1,13 @@
-/**
- * Copyright (C) 2020 Xilinx, Inc
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2020 Xilinx, Inc. All rights reserved.
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
 
 // driver includes
-#include "xrt.h"
-#include "xrt/xrt_kernel.h"
-#include "experimental/xrt_xclbin.h"
 #include "xrt/xrt_device.h"
-#include "xclbin.h"
+#include "xrt/xrt_kernel.h"
+#include "xrt/deprecated/xrt.h"
+#include "xrt/detail/xclbin.h"
+#include "xrt/experimental/xrt_xclbin.h"
 
 #include <fstream>
 #include <list>

--- a/tests/xrt/100_ert_ncu/xrtxx-ip.cpp
+++ b/tests/xrt/100_ert_ncu/xrtxx-ip.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2021-2022 Xilinx, Inc. All rights reserved.
-// Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
 
 ////////////////////////////////////////////////////////////////
 // This test uses xrt::ip for manual control of kernel compute
@@ -12,12 +12,12 @@
 // executes in its own thread.
 ////////////////////////////////////////////////////////////////
 
-#include "xrt.h"
-#include "xclbin.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include "experimental/xrt_ip.h"
+#include "xrt/deprecated/xrt.h"
+#include "xrt/detail/xclbin.h"
+#include "xrt/experimental/xrt_ip.h"
 
 #include <atomic>
 #include <cstdlib>

--- a/tests/xrt/100_ert_ncu/xrtxx-mt.cpp
+++ b/tests/xrt/100_ert_ncu/xrtxx-mt.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2021-2022 Xilinx, Inc. All rights reserved.
-// Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
 
 ////////////////////////////////////////////////////////////////
 // This test uses push scheduling on multiple threads threads that
@@ -9,8 +9,8 @@
 // xrt::run::wait()) is thread safe without missing kernel completions
 ////////////////////////////////////////////////////////////////
 
-#include "xrt.h"
-#include "xclbin.h"
+#include "xrt/deprecated/xrt.h"
+#include "xrt/detail/xclbin.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"

--- a/tests/xrt/100_ert_ncu/xrtxx-um.cpp
+++ b/tests/xrt/100_ert_ncu/xrtxx-um.cpp
@@ -1,7 +1,6 @@
-/**
- * SPDX-License-Identifier: Apache-2.0
- * Copyright (C) 2020-2021 Xilinx, Inc. All rights reserved.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2020-2021 Xilinx, Inc. All rights reserved.
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
 
 // This test uses unmanaged execution of kernel, where each run object
 // is reused after it completes.  The test is internal and uses a non
@@ -18,13 +17,15 @@
 //
 // % g++ -g -std=c++17 -I${XILINX_XRT}/include -L${XILINX_XRT}/lib -o xrtxx-um.exe xrtxx-um.cpp -lxrt_coreutil -pthread -luuid
 
+#include <future>
 #include <iostream>
 #include <iomanip>
 #include <vector>
 #include <chrono>
+#include <thread>
 #include <tuple>
 
-#include "ert.h"
+#include "xrt/detail/ert.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_kernel.h"

--- a/tests/xrt/100_ert_ncu/xrtxx.cpp
+++ b/tests/xrt/100_ert_ncu/xrtxx.cpp
@@ -1,25 +1,12 @@
-/**
- * Copyright (C) 2020 Xilinx, Inc
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2020 Xilinx, Inc.  All rights reserved.
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
 
 // driver includes
-#include "xrt.h"
 #include "xrt/xrt_kernel.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
-#include "xclbin.h"
+#include "xrt/detail/xclbin.h"
 
 #include <fstream>
 #include <list>

--- a/tests/xrt/56_xclbin/main.cpp
+++ b/tests/xrt/56_xclbin/main.cpp
@@ -1,26 +1,13 @@
-/**
- * Copyright (C) 2021-2022 Xilinx, Inc
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2021-2022 Xilinx, Inc. All rights reserved.
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
 #include <iostream>
 #include <stdexcept>
 #include <string>
 #include <cstring>
 
 // XRT includes
-#include "experimental/xrt_xclbin.h"
+#include "xrt/experimental/xrt_xclbin.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
 #include "xrt/xrt_bo.h"

--- a/tests/xrt/56_xclbin/xrt.ini
+++ b/tests/xrt/56_xclbin/xrt.ini
@@ -1,0 +1,2 @@
+[Runtime]
+xclbin_repo_path = /home/soeren/tmp:/proj/xsjhdstaff3/soeren/tmp


### PR DESCRIPTION
#### Problem solved by the commit
Fix include paths of exported headers to refer directly to unwrapped headers from `include/xrt/...`

Amends #9074

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Exported XRT headers were incorrectly referring to wrapper headers that are no longer released.  This resulted in application compile errors.

