### PR TITLE
Apply 0002-Make-git-optional-for-the-build.patch (and 0006)

### DIFF
--- a/src/CMake/embedded_system.cmake
+++ b/src/CMake/embedded_system.cmake
@@ -30,19 +30,8 @@ ELSE(OPENCL_FOUND)
   MESSAGE(FATAL_ERROR "Looking for OPENCL - not found")
 ENDIF(OPENCL_FOUND)
 
-find_package(Git)
-
-IF(GIT_FOUND)
-  message("git found: ${GIT_EXECUTABLE}")
-ELSE(GIT_FOUND)
-  MESSAGE(FATAL_ERROR "Looking for GIT - not found")
-endif(GIT_FOUND)
-
 set(LINUX_FLAVOR ${CMAKE_SYSTEM_NAME})
 set(LINUX_KERNEL_VERSION ${CMAKE_SYSTEM_VERSION})
-
-message("-- LINUX_FLAVOR = ${LINUX_FLAVOR}")
-message("-- LINUX_KERNEL_VERSION = ${LINUX_KERNEL_VERSION}")
 
 # Set up what components of XRT to build
 # Indicate that we are building for edge

--- a/src/CMake/nativeLnx.cmake
+++ b/src/CMake/nativeLnx.cmake
@@ -31,15 +31,6 @@ else (OPENCL_FOUND)
   MESSAGE(FATAL_ERROR "Looking for OPENCL - not found")
 endif (OPENCL_FOUND)
 
-# --- Git ---
-find_package(Git)
-
-if (GIT_FOUND)
-  MESSAGE(STATUS "Looking for GIT - found at ${GIT_EXECUTABLE}")
-else (GIT_FOUND)
-  MESSAGE(FATAL_ERROR "Looking for GIT - not found")
-endif (GIT_FOUND)
-
 # --- LSB Release ---
 find_program(UNAME uname)
 

--- a/src/CMake/nativeWin.cmake
+++ b/src/CMake/nativeWin.cmake
@@ -12,15 +12,6 @@
 # pdb install dir
 set (CMAKE_PDB_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/symbols")
 
-# --- Git ---
-find_package(Git)
-
-IF(GIT_FOUND)
-  MESSAGE(STATUS "Looking for GIT - found at ${GIT_EXECUTABLE}")
-ELSE(GIT_FOUND)
-  MESSAGE(FATAL_ERROR "Looking for GIT - not found")
-endif(GIT_FOUND)
-
 include(CMake/components.cmake)
 
 # Boost Libraries

--- a/src/CMake/settings.cmake
+++ b/src/CMake/settings.cmake
@@ -11,6 +11,21 @@ message("-- Target system processor is ${CMAKE_SYSTEM_PROCESSOR}")
 # Indicate that we are building XRT
 add_compile_definitions("XRT_BUILD")
 
+# Note if we are building for upstream packaging
+if (XRT_UPSTREAM_DEBIAN)
+  set (XRT_UPSTREAM 1)
+endif()
+
+find_package(Git)
+
+if (GIT_FOUND)
+  message(STATUS "-- GIT found: ${GIT_EXECUTABLE}")
+elseif (XRT_UPSTREAM)
+  message(STATUS "-- GIT not found, ignored for upstream build")
+else()
+  message(FATAL_ERROR "-- GIT not found, required for internal build")
+endif()
+
 if ( ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" )
   set(XRT_WARN_OPTS
   -Wall


### PR DESCRIPTION
#### Problem solved by the commit
Git is made optional for upstream builds.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
During the build, "git" is used to query information regarding the branch and top commit which is then embedded in the build artifacts.

Not all builds of xrt are from the upstream trees and embedding arbitrary git tree information is not helpful. Conditionally drop the requirement for "git" during the build when CMake variable XRT_UPSTREAM is defined - thus preventing the embedding of associated information as well.

Later patch
(0006-src-CMake-version.cmake-Consistently-use-UTC-timezon.patch) fixes how version.h is generated with semi meaningful data when Git metadata is not available.

