### PR TITLE
hip: core: event: remove buffer sync from kernel start

### DIFF
--- a/src/runtime_src/hip/core/event.cpp
+++ b/src/runtime_src/hip/core/event.cpp
@@ -158,9 +158,6 @@ kernel_start::kernel_start(std::shared_ptr<stream> s, std::shared_ptr<function> 
         if (!hip_mem)
           throw std::runtime_error("failed to get memory from arg at index - " + std::to_string(idx));
 
-        // NPU device is not coherent. We need to sync the buffer objects before launching kernel
-        if (hip_mem->get_type() != memory_type::device)
-          hip_mem->sync(xclBOSyncDirection::XCL_BO_SYNC_BO_TO_DEVICE);
         r.set_arg(arg->index, hip_mem->get_xrt_bo());
         break;
       }


### PR DESCRIPTION
Remove buffer sync from kernel start.
User will explicitly call hipMemPrefechAsync() to sync buffer before launching kernel and after kernel execution.

With this patch, please make sure application using XRT HIP will need to add `hipMemPrefetchAsync()` to sync buffers which is supposed will be read by NPU before launching kernels
e.g.
```
hipMemPrefetchAsync(buf_dev_ptr, size, 0, stream);
hipModuleLaunchKernel(...);
```

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
