### PR TITLE
hip: core: memory: throw error for hipHostAllocWriteCombined flag

### DIFF
--- a/src/runtime_src/hip/core/memory.cpp
+++ b/src/runtime_src/hip/core/memory.cpp
@@ -56,12 +56,7 @@ namespace xrt::core::hip
         break;
       }
       case hipHostMallocWriteCombined: {
-        // This is a workaround to create a buffer with cacheable flag if WriteComined flag is provided.
-        // This gets used to create instruction buffer on NPU
-        // TODO This would go away once xrt::elf flow is enabled
-        auto xrt_device = m_device->get_xrt_device();
-        m_bo = xrt::bo(xrt_device, m_size, xrt::bo::flags::cacheable, 1);
-        break;
+        throw xrt_core::system_error(hipErrorInvalidValue, "XRT bo creation doesn't support WriteCombined flag.");
       }
       default:
         break;


### PR DESCRIPTION
As XRT APIs doesn't support users to specify to allocate WriteCombined memory, throw error if user request to allocate memory with hipHostAllocWriteCombined flag.

e.g.
When calls:
  hipHostMalloc(&buf_ptr, size, hipHostMallocWriteCombined);

it will thow:
EXE: xrt-hip-app
[XRT] ERROR: XRT bo creation doesn't support WriteCombined flag.: Operation not permitted terminate called after throwing an instance of 'HIPError'
  what():  : hipErrorInvalidValue (hipErrorInvalidValue): Operation not permitted

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
