### PR TITLE
AIESW-3806XRT API to report memory usage

### DIFF
--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -1981,6 +1981,8 @@ struct aie_partition_info : request
     uint64_t    pasid = 0;
     qos_info    qos {};
     uint64_t    suspensions;    // Suspensions by context switching and idle detection
+    std::string process_name;
+    size_t      memory_usage;   //bytes
   };
 
   using result_type = std::vector<struct data>;

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -144,6 +144,7 @@ enum class key_type
   rtos_telemetry,
   stream_buffer_telemetry,
 
+  total_mem_usage,
 
   firmware_version,
 
@@ -2105,6 +2106,15 @@ struct stream_buffer_telemetry : request
 
   using result_type = std::vector<data>;
   static const key_type key = key_type::stream_buffer_telemetry;
+
+  virtual std::any
+  get(const device* device) const override = 0;
+};
+
+struct total_mem_usage : request
+{
+  using result_type = uint64_t; // get value type
+  static const key_type key = key_type::total_mem_usage;
 
   virtual std::any
   get(const device* device) const override = 0;

--- a/src/runtime_src/core/tools/common/reports/ReportAiePartitions.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportAiePartitions.cpp
@@ -138,7 +138,7 @@ writeReport(const xrt_core::device* /*_pDevice*/,
       const auto& hw_context = pt_hw_context.second;
 
       std::vector<boost::format> row_data;
-      row_data.push_back(boost::format("      |%-20s|%-9s|%-12s|%-12s|%-5s|%-9s|")
+      row_data.emplace_back(boost::format("      |%-20s|%-9s|%-12s|%-12s|%-5s|%-9s|")
                    % hw_context.get<int>("pid")
                    % hw_context.get<std::string>("context_id")
                    % hw_context.get<uint64_t>("command_submissions")
@@ -146,22 +146,22 @@ writeReport(const xrt_core::device* /*_pDevice*/,
                    % hw_context.get<uint64_t>("errors")
                    % hw_context.get<std::string>("priority"));
 
-      row_data.push_back(boost::format("      |%-20s|%-9s|%-12s|%-12s|     |%-9s|")
+      row_data.emplace_back(boost::format("      |%-20s|%-9s|%-12s|%-12s|     |%-9s|")
                    % hw_context.get<std::string>("process_name")
                    % hw_context.get<std::string>("status")
                    % hw_context.get<uint64_t>("command_completions")
                    % hw_context.get<uint64_t>("suspensions")
                    % hw_context.get<std::string>("gops"));
 
-      row_data.push_back(boost::format("      |%-20s|%-9s|            |            |     |%-9s|")
+      row_data.emplace_back(boost::format("      |%-20s|%-9s|            |            |     |%-9s|")
                    % hw_context.get<std::string>("memory_usage")
                    % hw_context.get<std::string>("instr_bo_mem")
                    % hw_context.get<std::string>("fps"));
 
-      row_data.push_back(boost::format("      |               |         |            |            |     |%-9s|")
+      row_data.emplace_back(boost::format("      |               |         |            |            |     |%-9s|")
                    % hw_context.get<std::string>("latency"));
 
-      row_data.push_back(boost::format("      |--------------------|---------|------------|------------|-----|---------|"));
+      row_data.emplace_back(boost::format("      |--------------------|---------|------------|------------|-----|---------|"));
 
       for (const auto& row : row_data) {
         _output << row << "\n";

--- a/src/runtime_src/core/tools/common/reports/ReportAiePartitions.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportAiePartitions.cpp
@@ -83,6 +83,7 @@ getPropertyTree20202(const xrt_core::device* _pDevice,
 {
   boost::property_tree::ptree pt;
   pt.put("description", "AIE Partition Information");
+  pt.put("total_memory_usage", xrt_core::utils::unit_convert(xrt_core::device_query_default<xrt_core::query::total_mem_usage>(_pDevice, 0)));
   pt.add_child("partitions", populate_aie_partition(_pDevice));
   _pt.add_child("aie_partitions", pt);
 }
@@ -102,7 +103,7 @@ writeReport(const xrt_core::device* /*_pDevice*/,
     return;
   }
 
-  _output << boost::str(boost::format("  Total Memory Usage: %s\n") % "20 MB"); // Placeholder for total memory usage
+  _output << boost::str(boost::format("  Total Memory Usage: %s\n") % _pt.get<std::string>("aie_partitions.total_memory_usage"));
 
   for (const auto& pt_partition : pt_partitions) {
     const auto& partition = pt_partition.second;
@@ -121,11 +122,11 @@ writeReport(const xrt_core::device* /*_pDevice*/,
     _output << "    HW Contexts:\n";
 
     const std::vector<std::string> headers = {
-      "      |PID            |Ctx ID   |Submissions |Migrations  |Err  |Priority |",
-      "      |Process Name   |Status   |Completions |Suspensions |     |GOPS     |",
-      "      |Memory Usage   |Instr BO |            |            |     |FPS      |",
-      "      |               |         |            |            |     |Latency  |",
-      "      |===============|=========|============|============|=====|=========|"
+      "      |PID                 |Ctx ID   |Submissions |Migrations  |Err  |Priority |",
+      "      |Process Name        |Status   |Completions |Suspensions |     |GOPS     |",
+      "      |Memory Usage        |Instr BO |            |            |     |FPS      |",
+      "      |                    |         |            |            |     |Latency  |",
+      "      |====================|=========|============|============|=====|=========|"
     };
 
     for (const auto& header : headers) {
@@ -137,7 +138,7 @@ writeReport(const xrt_core::device* /*_pDevice*/,
       const auto& hw_context = pt_hw_context.second;
 
       std::vector<boost::format> row_data;
-      row_data.push_back(boost::format("      |%-15s|%-9s|%-12s|%-12s|%-5s|%-9s|")
+      row_data.push_back(boost::format("      |%-20s|%-9s|%-12s|%-12s|%-5s|%-9s|")
                    % hw_context.get<int>("pid")
                    % hw_context.get<std::string>("context_id")
                    % hw_context.get<uint64_t>("command_submissions")
@@ -145,14 +146,14 @@ writeReport(const xrt_core::device* /*_pDevice*/,
                    % hw_context.get<uint64_t>("errors")
                    % hw_context.get<std::string>("priority"));
 
-      row_data.push_back(boost::format("      |%-15s|%-9s|%-12s|%-12s|     |%-9s|")
+      row_data.push_back(boost::format("      |%-20s|%-9s|%-12s|%-12s|     |%-9s|")
                    % hw_context.get<std::string>("process_name")
                    % hw_context.get<std::string>("status")
                    % hw_context.get<uint64_t>("command_completions")
                    % hw_context.get<uint64_t>("suspensions")
                    % hw_context.get<std::string>("gops"));
 
-      row_data.push_back(boost::format("      |%-15s|%-9s|            |            |     |%-9s|")
+      row_data.push_back(boost::format("      |%-20s|%-9s|            |            |     |%-9s|")
                    % hw_context.get<std::string>("memory_usage")
                    % hw_context.get<std::string>("instr_bo_mem")
                    % hw_context.get<std::string>("fps"));
@@ -160,7 +161,7 @@ writeReport(const xrt_core::device* /*_pDevice*/,
       row_data.push_back(boost::format("      |               |         |            |            |     |%-9s|")
                    % hw_context.get<std::string>("latency"));
 
-      row_data.push_back(boost::format("      |---------------|---------|------------|------------|-----|---------|"));
+      row_data.push_back(boost::format("      |--------------------|---------|------------|------------|-----|---------|"));
 
       for (const auto& row : row_data) {
         _output << row << "\n";


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
XRT API to report memory usage

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
New feature

#### How problem was solved, alternative solutions (if any) and why they were rejected
- Created multi-level table to add more info to aie-partitions report
- Added total memory usage, process name and memory usage per ctx to the report


#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
Tested on windows/MCDM
xrt-smi examine -r aie-partitions
```
-----------------------------
[00c5:00:01.1] : NPU Krackan
-----------------------------
AIE Partitions
  Total Memory Usage: 20 MB
  Partition Index   : 0
    Columns: [0, 1, 2, 3, 4, 5, 6, 7]
    HW Contexts:
      |PID            |Ctx ID   |Submissions |Migrations  |Err  |Priority |
      |Process Name   |Status   |Completions |Suspensions |     |GOPS     |
      |Memory Usage   |Instr BO |            |            |     |FPS      |
      |               |         |            |            |     |Latency  |
      |===============|=========|============|============|=====|=========|
      |11644          |2        |0           |0           |0    |Normal   |
      |xrt-smi.exe    |Active   |0           |0           |     |N/A      |
      |1953 KB        |64 KB    |            |            |     |N/A      |
      |               |         |            |            |     |N/A      |
      |---------------|---------|------------|------------|-----|---------|
```

#### Documentation impact (if any)
Internal doc needs to be updated
