### PR TITLE
[XDP][Cherry-pick] [AIE2PS] - AIE Status: Use hw gen instead of build flags (#9006)

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.cpp
@@ -223,9 +223,12 @@ namespace xdp {
       return;
 
     // AIE core register offsets
-    constexpr uint64_t AIE_OFFSET_CORE_STATUS = 0x32004;
-    auto offset = metadataReader->getAIETileRowOffset();
     auto hwGen = metadataReader->getHardwareGeneration();
+    uint64_t AIE_OFFSET_CORE_STATUS = 0x32004;
+    if (hwGen == 5)
+      AIE_OFFSET_CORE_STATUS = 0x38004; // AIE2PS
+
+    auto offset = metadataReader->getAIETileRowOffset();
 
     // This mask check for following states
     // ECC_Scrubbing_Stall

--- a/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.cpp
@@ -226,7 +226,7 @@ namespace xdp {
     auto hwGen = metadataReader->getHardwareGeneration();
     uint64_t AIE_OFFSET_CORE_STATUS = 0x32004;
     if (hwGen == 5)
-      AIE_OFFSET_CORE_STATUS = 0x38004; // AIE2PS
+      AIE_OFFSET_CORE_STATUS = 0x38004; //AIE2PS
 
     auto offset = metadataReader->getAIETileRowOffset();
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
CR-1240965 - Double commit of PR (#9006) to 2025.1.1.
