### PR TITLE
Fix coverity warnings

### DIFF
--- a/src/runtime_src/core/tools/xbtracer/src/capture/xbtracer.cpp
+++ b/src/runtime_src/core/tools/xbtracer/src/capture/xbtracer.cpp
@@ -60,7 +60,7 @@ parse_args(struct tracer_arg &args, int argc, const char* argv[])
       got_app = true;
     }
     else {
-      args.target_app.push_back(arg_str);
+      args.target_app.push_back(std::move(arg_str));
     }
   }
 

--- a/src/runtime_src/core/tools/xbtracer/src/common/trace_logger.h
+++ b/src/runtime_src/core/tools/xbtracer/src/common/trace_logger.h
@@ -71,19 +71,19 @@ public:
     if (l > plevel)
       return;
 
-    std::string level_str;
+    std::string prefix;
     if (l == level::CRITICAL)
-      level_str = "CRITICAL";
+      prefix = "CRITICAL";
     else if (l == level::ERR)
-      level_str = "ERROR";
+      prefix = "ERROR";
     else if (l == level::WARNING)
-      level_str = "WARNING";
+      prefix = "WARNING";
     else if (l == level::INFO)
-      level_str = "INFO";
+      prefix = "INFO";
     else
-      level_str = "DEBUG";
+      prefix = "DEBUG";
 
-    std::string prefix = std::string(level_str) + ": [" + lname + "]: ";
+    prefix.append(": [" + lname + "]: ");
     print_one(std::cout, prefix);
     print_all(std::cout, std::forward<Args>(args)...);
     std::cout << std::endl;

--- a/src/runtime_src/core/tools/xbtracer/src/common/trace_logger.h
+++ b/src/runtime_src/core/tools/xbtracer/src/common/trace_logger.h
@@ -92,8 +92,6 @@ public:
       print_all(ofile, std::forward<Args>(args)...);
       ofile << std::endl;
     }
-    if (l == level::CRITICAL)
-      throw std::runtime_error(lname + "hit critical error.");
   }
 
 private:
@@ -112,6 +110,7 @@ xbtracer_pcritical(const Args&... args)
 {
   xrt::tools::xbtracer::logger::get_instance().print(xrt::tools::xbtracer::logger::level::CRITICAL,
                                                      args...);
+  throw std::runtime_error("Critical error.");
 }
 
 template<typename... Args>

--- a/src/runtime_src/core/tools/xbtracer/src/common/trace_logger.h
+++ b/src/runtime_src/core/tools/xbtracer/src/common/trace_logger.h
@@ -22,19 +22,21 @@ namespace xrt::tools::xbtracer
 // Helper to print a single argument
 template<typename T>
 void
-print_one(std::ostream& os, T& arg)
+print_one(std::ostream& os, const T& arg)
 {
-  os << std::forward<T>(arg);
+  std::cout << arg;
+  if (&os != &std::cout)
+    os << arg;
 }
 
 // Recursive variadic template to print all arguments
 template<typename T, typename... Args>
 void
-print_all(std::ostream& os, T& first, Args&... args)
+print_all(std::ostream& os, T& first, const Args&... args)
 {
-  print_one(os, std::forward<T>(first));
+  print_one(os, first);
   if constexpr (sizeof...(args) > 0)
-    print_all(os, std::forward<Args>(args)...);
+    print_all(os, args...);
 }
 
 class logger
@@ -66,7 +68,7 @@ public:
 
   template<typename... Args>
   void
-  print(level l, Args&... args)
+  print(level l, const Args&... args)
   {
     if (l > plevel)
       return;
@@ -84,13 +86,15 @@ public:
       prefix = "DEBUG";
 
     prefix.append(": [" + lname + "]: ");
-    print_one(std::cout, prefix);
-    print_all(std::cout, std::forward<Args>(args)...);
-    std::cout << std::endl;
     if (ofile.is_open()) {
       print_one(ofile, prefix);
-      print_all(ofile, std::forward<Args>(args)...);
-      ofile << std::endl;
+      print_all(ofile, args...);
+      print_one(ofile, "\n");
+    }
+    else {
+      print_one(std::cout, prefix);
+      print_all(std::cout, args...);
+      print_one(std::cout, "\n");
     }
   }
 

--- a/src/runtime_src/core/tools/xbtracer/src/replay/xbreplay_replayer.cpp
+++ b/src/runtime_src/core/tools/xbtracer/src/replay/xbreplay_replayer.cpp
@@ -292,7 +292,7 @@ add_xclbin_kernel(uint64_t impl, std::string name, const xrt::xclbin::kernel& ke
     }
   }
   std::tuple<uint64_t, std::string, xrt::xclbin::kernel> t(impl, name, kernel);
-  xclbin_kernels.push_back(t);
+  xclbin_kernels.push_back(std::move(t));
   return;
 }
 

--- a/src/runtime_src/core/tools/xbtracer/src/replay/xbreplay_xrt_bo.cpp
+++ b/src/runtime_src/core/tools/xbtracer/src/replay/xbreplay_xrt_bo.cpp
@@ -62,9 +62,6 @@ register_bo_func()
                    ", group: ", (uint32_t)grp, ".");
     std::shared_ptr<xrt::bo> bo_sh = std::make_shared<xrt::bo>((xclDeviceHandle)(*dev_sh), size,
                                                                flags, grp);
-    if (!bo_sh) {
-      xbtracer_pcritical(entry_msg->name(), "failed to create bo with id.");
-    }
     track(bo_sh, impl);
     return 0;
   };

--- a/src/runtime_src/core/tools/xbtracer/src/replay/xbreplay_xrt_device.cpp
+++ b/src/runtime_src/core/tools/xbtracer/src/replay/xbreplay_xrt_device.cpp
@@ -43,9 +43,6 @@ register_device_func()
     xbtracer_pinfo("Replaying: ", entry_msg->name(), ", ", reinterpret_cast<void*>(impl),
                    ", id: ", id, ".");
     std::shared_ptr<xrt::device> dev_sh = std::make_shared<xrt::device>(id);
-    if (!dev_sh) {
-      xbtracer_pcritical(entry_msg->name(), "failed to create device with id: ", id, ".");
-    }
     track(dev_sh, impl);
     return 0;
   };

--- a/src/runtime_src/core/tools/xbtracer/src/replay/xbreplay_xrt_hw_context.cpp
+++ b/src/runtime_src/core/tools/xbtracer/src/replay/xbreplay_xrt_hw_context.cpp
@@ -59,9 +59,6 @@ register_hw_context_func()
     xbtracer_pinfo("Replaying: ", entry_msg->name(), ", ", std::hex, impl, ", dev: ", std::hex, dev_impl,
                    ", uuid: ", uuid_str, ", access_mode: ", std::hex, (uint32_t)mode, ".");
     std::shared_ptr<xrt::hw_context> hw_context_sh = std::make_shared<xrt::hw_context>(*dev_sh, xclbin_uuid, mode);
-    if (!hw_context_sh) {
-      xbtracer_pcritical(entry_msg->name(), "failed to create hw_context.");
-    }
     track(hw_context_sh, impl);
     return 0;
   };

--- a/src/runtime_src/core/tools/xbtracer/src/replay/xbreplay_xrt_kernel.cpp
+++ b/src/runtime_src/core/tools/xbtracer/src/replay/xbreplay_xrt_kernel.cpp
@@ -53,9 +53,6 @@ register_kernel_func()
                    name_str, ".");
     std::shared_ptr<xrt::kernel> kernel_sh = std::make_shared<xrt::kernel>(*hw_context_sh,
                                                                            name_str);
-    if (!hw_context_sh) {
-      xbtracer_pcritical(entry_msg->name(), "failed to create hw_context.");
-    }
     track(kernel_sh, impl);
     return 0;
   };

--- a/src/runtime_src/core/tools/xbtracer/src/replay/xbreplay_xrt_run.cpp
+++ b/src/runtime_src/core/tools/xbtracer/src/replay/xbreplay_xrt_run.cpp
@@ -49,9 +49,6 @@ register_run_func()
     xbtracer_pinfo("Replaying: ", entry_msg->name(), ", ", reinterpret_cast<const void*>(impl),
                    ", with kernel: ", reinterpret_cast<const void*>(kernel_impl), ".");
     std::shared_ptr<xrt::run> run_sh = std::make_shared<xrt::run>(*kernel_sh);
-    if (!run_sh) {
-      xbtracer_pcritical(entry_msg->name(), "failed to create run with kernel.");
-    }
     track(run_sh, impl);
     return 0;
   };

--- a/src/runtime_src/core/tools/xbtracer/src/replay/xbreplay_xrt_xclbin.cpp
+++ b/src/runtime_src/core/tools/xbtracer/src/replay/xbreplay_xrt_xclbin.cpp
@@ -52,9 +52,6 @@ register_xclbin_func()
 
     xbtracer_pinfo("Replaying: ", entry_msg->name(), ", ", reinterpret_cast<void*>(impl), ".");
     std::shared_ptr<xrt::xclbin> xclbin_sh = std::make_shared<xrt::xclbin>(xclbin_file);
-    if (!xclbin_sh) {
-      xbtracer_pcritical(entry_msg->name(), "failed to create xclbin with: ", xclbin_file, ".");
-    }
     track(xclbin_sh, impl);
     return 0;
   };

--- a/src/runtime_src/core/tools/xbtracer/src/wrapper/hook_xrt_run.cpp
+++ b/src/runtime_src/core/tools/xbtracer/src/wrapper/hook_xrt_run.cpp
@@ -252,7 +252,7 @@ add_callback(ert_cmd_state state, std::function<void(const void*, ert_cmd_state,
   xbtracer_write_protobuf_msg(func_entry, need_trace);
   *ofunc_ptr = (void*)paddr_ptr;
 
-  (this->*ofunc)(state, callback, data);
+  (this->*ofunc)(state, std::move(callback), data);
 
   xbtracer_proto::Func func_exit;
   xbtracer_init_member_func_exit_handle(func_exit, need_trace, func_s);

--- a/src/runtime_src/core/tools/xbtracer/src/wrapper/tracer.h
+++ b/src/runtime_src/core/tools/xbtracer/src/wrapper/tracer.h
@@ -380,11 +380,15 @@ xbtracer_init_func_entry(PFUNC& func_msg, bool& need_trace, const char* func_s,
                          proc_addr_type& paddr_ptr)
 {
   const char* func_mname = get_func_mname_from_signature(func_s);
-  if (!func_mname)
-    xbtracer_pcritical("failed to get mangled name for function\"", std::string(func_s), "\".");
+  if (!func_mname) {
+    xbtracer_perror("failed to get mangled name for function\"", std::string(func_s), "\".");
+    return false;
+  }
   paddr_ptr = xbtracer_get_original_func_addr(func_mname);
-  if (!paddr_ptr)
-    xbtracer_pcritical("failed to get function\"", std::string(func_s), "\", \"", std::string(func_s), "\".");
+  if (!paddr_ptr) {
+    xbtracer_perror("failed to get function\"", std::string(func_s), "\", \"", std::string(func_s), "\".");
+    return false;
+  }
 
   if (!xbtracer_needs_trace_func()) {
     // if function doesn't need to be traced, do not initialize protobuf message


### PR DESCRIPTION
#### Problem solved by the commit
This patch set tried to coverity warnings/errors reported in: https://scan9.scan.coverity.com/#/project-view/63759/13446?selectedIssue=534826

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
The issues were found by running coverity with xrt repo.

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
I have ran coverity locally and, not seeing coverity. I setup the coverity configuration as following:
```
cov-build --dir cov_idir make -j20
cov-analyze --dir ./cov_idir --tu-pattern "file('.*xbtracer.*')" \
  --all --enable-fnptr --security \
  --aggressiveness-level low --enable USER_POINTER --enable BUFFER_SIZE \
  --enable SIZEOF_MISMATCH --enable STRING_NULL --enable RESOURCE_LEAK \
  --enable REVERSE_INULL --enable FORWARD_NULL \
  --enable COPY_INSTEAD_OF_MOVE --enable DEADCODE --enable UNCAUGHT_EXCEPT \
  --enable USE_AFTER_MOVE --enable CHECKED_RETURN
```
The options are based on the errors/warnings reported from: https://scan9.scan.coverity.com/#/project-view/63759/13446?

And also run xbtracer with xrt basic flow test described in https://github.com/Xilinx/XRT/pull/9065 on both Linux and Windows.

#### Documentation impact (if any)
