### PR TITLE
Misc APIs: hipDeviceGetName, hipKernelNameRef.

### DIFF
--- a/src/runtime_src/hip/api/hip_device.cpp
+++ b/src/runtime_src/hip/api/hip_device.cpp
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
 #include "core/include/xrt/experimental/xrt_system.h"
-#include"core/common/device.h"
-#include"core/common/query_requests.h"
+#include "core/common/device.h"
+#include "core/common/query_requests.h"
 
 #include "hip/core/common.h"
 #include "hip/core/device.h"

--- a/src/runtime_src/hip/api/hip_device.cpp
+++ b/src/runtime_src/hip/api/hip_device.cpp
@@ -1,10 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
 #include "core/include/xrt/experimental/xrt_system.h"
+#include"core/common/device.h"
+#include"core/common/query_requests.h"
 
 #include "hip/core/common.h"
 #include "hip/core/device.h"
 #include "hip/core/memory_pool.h"
+#include "hip/core/module.h"
 
 #include <cstring>
 #include <mutex>
@@ -99,7 +102,7 @@ hip_device_get_name(hipDevice_t device)
 {
   throw_invalid_device_if(check(device), "device requested is not available");
 
-  throw std::runtime_error("Not implemented");
+  return (xrt_core::device_query<xrt_core::query::rom_vbnv>((device_cache.get_or_error(device))->get_xrt_device().get_handle()));
 }
 
 static hipDeviceProp_t
@@ -133,6 +136,12 @@ hip_set_device(int dev_id)
 {
   throw_invalid_device_if(check(dev_id), "device to set is not available");
   tls_objs.dev_hdl = static_cast<device_handle>(dev_id);
+}
+
+const char*
+hip_kernel_name_ref(const hipFunction_t f)
+{
+  return (reinterpret_cast<function*>(f))->get_func_name().c_str();
 }
 } // xrt::core::hip
 
@@ -310,4 +319,22 @@ hipSetDevice(int device)
     xrt_core::send_exception_message(std::string(__func__) + " - " + ex.what());
   }
   return hipErrorUnknown;
+}
+
+const char *
+hipKernelNameRef(const hipFunction_t f)
+{
+  try {
+    throw_invalid_value_if(!f, "arg passed is nullptr");
+
+    return xrt::core::hip::hip_kernel_name_ref(f);
+  }
+  catch (const xrt_core::system_error& ex) {
+    xrt_core::send_exception_message(std::string(__func__) +  " - " + ex.what());
+    return nullptr;
+  }
+  catch (const std::exception& ex) {
+    xrt_core::send_exception_message(ex.what());
+  }
+  return nullptr;
 }

--- a/src/runtime_src/hip/core/module.h
+++ b/src/runtime_src/hip/core/module.h
@@ -148,6 +148,12 @@ public:
     std::scoped_lock lock(m_runs_mutex);
     m_runs_cache.push_back(std::move(run));
   }
+
+  const std::string&
+  get_func_name() const
+  {
+    return m_func_name;
+  }
 };
 
 extern xrt_core::handle_map<module_handle, std::shared_ptr<module>> module_cache;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Implementing hip miscellaneous functions - hipDeviceGetName, hipKernelNameRef.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
None
#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit
Low
#### What has been tested and how, request additional testing if necessary
Tested on Linux Strix machine 
device name is printed as NPU Strix.
kernel name is printed as DPU
used rom_vbnv for printing device name

#### Documentation impact (if any)
NA