### PR TITLE
[2025.1] VITIS-15145: allocating cma mem from zocl-tagged reserved mem (#9077)

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/common/zocl_bo.c
+++ b/src/runtime_src/core/edge/drm/zocl/common/zocl_bo.c
@@ -16,6 +16,7 @@
 
 #include <linux/pagemap.h>
 #include <linux/of_address.h>
+#include <linux/of_reserved_mem.h>
 #include <linux/dma-buf.h>
 #include <linux/iommu.h>
 #include <linux/version.h>
@@ -33,6 +34,13 @@
 #include "zocl_drv.h"
 #include "xclbin.h"
 #include "zocl_bo.h"
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+static struct drm_gem_dma_object *
+#else
+static struct drm_gem_cma_object *
+#endif
+zocl_cma_create(struct drm_device *dev, size_t size);
 
 static inline void __user *to_user_ptr(u64 address)
 {
@@ -174,25 +182,62 @@ void zocl_free_userptr_bo(struct drm_gem_object *gem_obj)
 static struct drm_zocl_bo *
 zocl_create_cma_mem(struct drm_device *dev, size_t size)
 {
+	struct drm_zocl_dev *zdev = dev->dev_private;
+	int num_regions = zdev->num_regions;
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
 	struct drm_gem_dma_object *cma_obj;
 #else
 	struct drm_gem_cma_object *cma_obj;
 #endif
+	struct device *mem_dev;
 	struct drm_zocl_bo *bo;
+	dma_addr_t phys = 0;
+	void* vaddr = NULL;
+	int mem_region = -1;
 
-	/* Allocate from CMA buffer */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
-	cma_obj = drm_gem_dma_create(dev, size);
-#else
-	cma_obj = drm_gem_cma_create(dev, size);
-#endif
+	cma_obj = zocl_cma_create(dev, size);
 	if (IS_ERR(cma_obj))
 		return ERR_PTR(-ENOMEM);
 
-	bo = to_zocl_bo(&cma_obj->base);
+	while ((!vaddr || !phys) && ++mem_region < num_regions) {
+		mem_dev = zdev->mem_regions[mem_region].dev;
+		if (!mem_dev)
+			continue;
+		vaddr = dma_alloc_coherent(mem_dev, size, &phys, GFP_KERNEL | __GFP_NOWARN);
+		if (!vaddr)
+			DRM_DEBUG("Failed to allocate from zocl attached memory region %d \n",
+				mem_region);
+	}
 
+	//allocate from default cma if we failed to allocate from zocl attached memory regions
+	if(!phys || !vaddr) {
+		DRM_WARN("Allocating BO from default CMA for invalid or no zocl attached memory regions");
+		mem_region = -1;
+		vaddr = dma_alloc_coherent(dev->dev, size, &phys, GFP_KERNEL | __GFP_NOWARN);
+	}
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+	cma_obj->dma_addr = phys;
+#else
+	cma_obj->paddr = phys;
+#endif
+	cma_obj->vaddr = vaddr;
+	if (!cma_obj->vaddr) {
+		DRM_ERROR("Failed to allocate buffer with size %zu\n", size);
+		goto error_free_gem;
+	}
+	bo = to_zocl_bo(&cma_obj->base);
+	bo->vaddr = vaddr;
+	bo->phys = phys;
+	bo->size = size;
+	bo->mem_region = mem_region;
 	return bo;
+
+error_free_gem:
+	drm_gem_object_release(&cma_obj->base);
+	kfree(to_zocl_bo(&cma_obj->base));
+	memset(&cma_obj->base, 0, sizeof(cma_obj->base));
+	return ERR_PTR(-ENOMEM);
 }
 
 /*
@@ -380,6 +425,8 @@ zocl_create_bo(struct drm_device *dev, uint64_t unaligned_size, u32 user_flags)
 
 		bo = zocl_create_range_mem(dev, size, mem);
 	}
+	if (IS_ERR(bo))
+		return ERR_PTR(-ENOMEM);
 
 	if (user_flags & ZOCL_BO_FLAGS_EXECBUF) {
 		bo->flags = ZOCL_BO_FLAGS_EXECBUF;
@@ -1080,7 +1127,8 @@ zocl_cma_create(struct drm_device *dev, size_t size)
 	return cma_obj;
 
 error:
-	kfree(cma_obj);
+	memset(&cma_obj->base, 0, sizeof(cma_obj->base));
+	kfree(gem_obj);
 	return ERR_PTR(ret);
 }
 

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
@@ -24,6 +24,7 @@
 #include <drm/drm_mm.h>
 #include <linux/version.h>
 #include <linux/vmalloc.h>
+#include <linux/of_reserved_mem.h>
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
 #include <drm/drm_gem_dma_helper.h>
 #else
@@ -149,6 +150,10 @@ struct drm_zocl_bo {
 	unsigned int                   mem_index;
 	uint32_t                       flags;
 	unsigned int                   user_flags;
+	void				*vaddr;
+	dma_addr_t			phys;
+	size_t				size;
+	int				mem_region;
 };
 
 struct drm_zocl_copy_bo {

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_util.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_util.h
@@ -22,6 +22,7 @@
 #define _8KB	0x2000
 #define _64KB	0x10000
 
+#define ZOCL_MAX_MEM_REGIONS 5
 #define MAX_PR_SLOT_NUM	32
 #define MAX_CU_NUM     128
 /* Apertures contains both ip and debug ip information */
@@ -159,6 +160,11 @@ struct zocl_cu_subdev {
 	struct mutex		 lock;
 };
 
+struct zocl_mem_region {
+	struct device *dev;
+	bool initialized;
+};
+
 struct drm_zocl_dev {
 	struct drm_device       *ddev;
 	struct fpga_manager     *fpga_mgr;
@@ -200,6 +206,8 @@ struct drm_zocl_dev {
 	int			 full_overlay_id;
 	struct drm_zocl_slot	*pr_slot[MAX_PR_SLOT_NUM];
 	u32                     slot_mask;
+	int						num_regions;
+	struct zocl_mem_region	mem_regions[ZOCL_MAX_MEM_REGIONS];
 };
 
 int zocl_kds_update(struct drm_zocl_dev *zdev, struct drm_zocl_slot *slot,


### PR DESCRIPTION
* allocate from multiple cma

* VITIS-15042: allocating cma mem from zocl-tagged reserved mem



* Making backward compatible



* Added num_regions to zocl dev and adjusted prev commits



---------




(cherry picked from commit cd235bd7246b13916a072bfc95ef32d097841b97)

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
