### PR TITLE
[RFC] hip: add hipSetDevice to set thread default device

### DIFF
--- a/src/runtime_src/hip/api/hip_device.cpp
+++ b/src/runtime_src/hip/api/hip_device.cpp
@@ -128,6 +128,15 @@ hip_device_get_attribute(hipDeviceAttribute_t attr, int device)
 
   throw std::runtime_error("Not implemented");
 }
+
+// Sets thread default device
+// Throws on error
+static void
+hip_set_device(int dev_id)
+{
+  throw_invalid_device_if(check(dev_id), "device to set is not available");
+  tls_objs.dev_hdl = static_cast<device_handle>(dev_id);
+}
 } // xrt::core::hip
 
 // =========================================================================
@@ -285,6 +294,23 @@ hipDeviceGetAttribute(int* pi, hipDeviceAttribute_t attr, int device)
   }
   catch (const std::exception& ex) {
     xrt_core::send_exception_message(ex.what());
+  }
+  return hipErrorUnknown;
+}
+
+hipError_t
+hipSetDevice(int device)
+{
+  try {
+    xrt::core::hip::hip_set_device(device);
+    return hipSuccess;
+  }
+  catch (const xrt_core::system_error& ex) {
+    xrt_core::send_exception_message(std::string(__func__) +  " - " + ex.what());
+    return static_cast<hipError_t>(ex.value());
+  }
+  catch (const std::exception& ex) {
+    xrt_core::send_exception_message(std::string(__func__) + " - " + ex.what());
   }
   return hipErrorUnknown;
 }

--- a/src/runtime_src/hip/xrt_hip.def
+++ b/src/runtime_src/hip/xrt_hip.def
@@ -16,6 +16,7 @@ EXPORTS
   hipGetDevicePropertiesR0600
   hipDeviceGetUuid
   hipDeviceGetAttribute
+  hipSetDevice
   hipDrvGetErrorName
   hipDrvGetErrorString
   hipGetErrorString


### PR DESCRIPTION
Implement HIP API to set default device of a thread. default device is local to a thread. Currently, the default device local to a thread is max uint32_t. It is initialized to 0 to the main thread in global initialization. For local thread, we will need to change to default value to 0 instetad of max uint32_t or let the user to call hipSetDevice() to change it, this patch enables user to call hipSetDevice() to change default device.

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Tried to launch kernel in a child thread:
```
void worker(int id)
{
HipDevice hdevice(dindex);
hipModule_t hmodule;
hipModuleLoad(&hmodule, xclbinFileName)
...
}

int main()
{
  std::vector<std::thread> threads;
    constexpr uint32_t num_threads = 2;
    for (uint32_t i = 0; i < num_threads; i++) {
      struct worker_arg arg = {i, function};
      threads.emplace_back(worker, arg);
    }
    for (std::thread& t : threads) {
      t.join();
    }
}
```
`hipModuleLoad()` failed due to invalid device. It turns out that `dev_hdl` of local thread variable `tls_objs` is by default set to max uint32_t.
In the main thread, when app starts, global initialization will initialize it to 0.
For the child thread, either we change the default value to 0 or call hipSetDevice() to explicitly set it to 0.
That is either we do:
```
struct hip_tls_objs {
  device_handle dev_hdl{0};
}
```
or
let user explicitly call `hipSetDevice()` to set the default device.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
