### PR TITLE
Runner + Partial Elf migration update on file structure 

### DIFF
--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -600,13 +600,28 @@ struct xrt_smi_lists : request
 struct runner : request
 {
   enum class type {
-    throughput,
-    latency,
-    df_bandwidth,
-    gemm,
-    aie_reconfig_overhead,
-    cmd_chain_latency,
-    cmd_chain_throughput
+    throughput_recipe,
+    throughput_profile,
+    throughput_path,
+    latency_recipe,
+    latency_profile,
+    latency_path,
+    df_bandwidth_recipe,
+    df_bandwidth_profile,
+    df_bandwidth_path,
+    gemm_recipe,
+    gemm_profile,
+    gemm_path,
+    aie_reconfig_overhead_recipe,
+    aie_reconfig_overhead_nop_recipe,
+    aie_reconfig_overhead_profile,
+    aie_reconfig_overhead_path,
+    cmd_chain_latency_recipe,
+    cmd_chain_latency_profile,
+    cmd_chain_latency_path,
+    cmd_chain_throughput_recipe,
+    cmd_chain_throughput_profile,
+    cmd_chain_throughput_path
   };
 
   using result_type = std::string;

--- a/src/runtime_src/core/tools/common/tests/TestAIEReconfigOverhead.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestAIEReconfigOverhead.cpp
@@ -22,12 +22,14 @@ TestAIEReconfigOverhead::run(std::shared_ptr<xrt_core::device> dev)
   std::string recipe = xrt_core::device_query<xrt_core::query::runner>(dev, xrt_core::query::runner::type::aie_reconfig_overhead_recipe);
   std::string recipe_noop = xrt_core::device_query<xrt_core::query::runner>(dev, xrt_core::query::runner::type::aie_reconfig_overhead_nop_recipe);
   std::string profile = xrt_core::device_query<xrt_core::query::runner>(dev, xrt_core::query::runner::type::aie_reconfig_overhead_profile);
+  std::string test = xrt_core::device_query<xrt_core::query::runner>(dev, xrt_core::query::runner::type::aie_reconfig_overhead_path); 
   auto recipe_path = XBValidateUtils::findPlatformFile(recipe, ptree);
   auto recipe_noop_path = XBValidateUtils::findPlatformFile(recipe_noop, ptree);
   auto profile_path = XBValidateUtils::findPlatformFile(profile, ptree);
+  auto test_path =  XBValidateUtils::findPlatformFile(test, ptree); 
   try
   {
-    xrt_core::runner runner(xrt::device(dev), recipe_path, profile_path);
+    xrt_core::runner runner(xrt::device(dev), recipe_path, profile_path, std::filesystem::path(test_path));
 
     //Run 1
     runner.execute();

--- a/src/runtime_src/core/tools/common/tests/TestCmdChainLatency.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestCmdChainLatency.cpp
@@ -11,8 +11,8 @@
 #include "core/common/json/nlohmann/json.hpp"
 namespace XBU = XBUtilities;
 
-static constexpr std::string_view recipe_file = "recipe_cmd_chain_latency.json";
-static constexpr std::string_view profile_file = "profile_cmd_chain_latency.json";
+#include <filesystem>
+
 // ----- C L A S S   M E T H O D S -------------------------------------------
 TestCmdChainLatency::TestCmdChainLatency()
   : TestRunner("cmd-chain-latency", "Run end-to-end latency test using command chaining")
@@ -22,13 +22,16 @@ boost::property_tree::ptree
 TestCmdChainLatency::run(std::shared_ptr<xrt_core::device> dev)
 {
   boost::property_tree::ptree ptree = get_test_header();
-  std::string repo_path = xrt_core::device_query<xrt_core::query::runner>(dev, xrt_core::query::runner::type::cmd_chain_latency);
-  repo_path = XBValidateUtils::findPlatformFile(repo_path, ptree);
-  std::string recipe = repo_path + std::string(recipe_file);
-  std::string profile = repo_path + std::string(profile_file);
+  std::string recipe = xrt_core::device_query<xrt_core::query::runner>(dev, xrt_core::query::runner::type::cmd_chain_latency_recipe);
+  std::string profile = xrt_core::device_query<xrt_core::query::runner>(dev, xrt_core::query::runner::type::cmd_chain_latency_profile);
+  std::string test = xrt_core::device_query<xrt_core::query::runner>(dev, xrt_core::query::runner::type::cmd_chain_latency_path); 
+  auto recipe_path = XBValidateUtils::findPlatformFile(recipe, ptree);
+  auto profile_path = XBValidateUtils::findPlatformFile(profile, ptree);
+  auto test_path = XBValidateUtils::findPlatformFile(test, ptree); 
+   
   try
   {
-    xrt_core::runner runner(xrt::device(dev), recipe, profile, std::filesystem::path(repo_path));
+    xrt_core::runner runner(xrt::device(dev), recipe_path, profile_path, std::filesystem::path(test_path));
     runner.execute();
     runner.wait();
 

--- a/src/runtime_src/core/tools/common/tests/TestCmdChainThroughput.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestCmdChainThroughput.cpp
@@ -11,8 +11,6 @@
 #include "core/common/json/nlohmann/json.hpp"
 namespace XBU = XBUtilities;
 
-static constexpr std::string_view recipe_file = "recipe_cmd_chain_throughput.json";
-static constexpr std::string_view profile_file = "profile_cmd_chain_throughput.json";
 // ----- C L A S S   M E T H O D S -------------------------------------------
 TestCmdChainThroughput::TestCmdChainThroughput()
   : TestRunner("cmd-chain-throughput", "Run end-to-end throughput test using command chaining")
@@ -22,13 +20,15 @@ boost::property_tree::ptree
 TestCmdChainThroughput::run(std::shared_ptr<xrt_core::device> dev)
 {
   boost::property_tree::ptree ptree = get_test_header();
-  std::string repo_path = xrt_core::device_query<xrt_core::query::runner>(dev, xrt_core::query::runner::type::cmd_chain_throughput);
-  repo_path = XBValidateUtils::findPlatformFile(repo_path, ptree);
-  std::string recipe = repo_path + std::string(recipe_file);
-  std::string profile = repo_path + std::string(profile_file);
+  std::string recipe = xrt_core::device_query<xrt_core::query::runner>(dev, xrt_core::query::runner::type::cmd_chain_throughput_recipe);
+  std::string profile = xrt_core::device_query<xrt_core::query::runner>(dev, xrt_core::query::runner::type::cmd_chain_throughput_profile);
+  std::string test = xrt_core::device_query<xrt_core::query::runner>(dev, xrt_core::query::runner::type::cmd_chain_throughput_path);
+  auto recipe_path = XBValidateUtils::findPlatformFile(recipe, ptree);
+  auto profile_path = XBValidateUtils::findPlatformFile(profile, ptree);
+  auto test_path = XBValidateUtils::findPlatformFile(test, ptree);
   try
   {
-    xrt_core::runner runner(xrt::device(dev), recipe, profile, std::filesystem::path(repo_path));
+    xrt_core::runner runner(xrt::device(dev), recipe_path, profile_path, std::filesystem::path(test_path));
     runner.execute();
     runner.wait();
 

--- a/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.cpp
@@ -14,9 +14,6 @@
 using json = nlohmann::json;
 #include <filesystem>
 
-static constexpr std::string_view recipe_file = "recipe_df_bandwidth.json";
-static constexpr std::string_view profile_file = "profile_df_bandwidth.json";
-
 // ----- C L A S S   M E T H O D S -------------------------------------------
 TestDF_bandwidth::TestDF_bandwidth()
   : TestRunner("df-bw", "Run bandwidth test on data fabric")
@@ -26,13 +23,16 @@ boost::property_tree::ptree
 TestDF_bandwidth::run(std::shared_ptr<xrt_core::device> dev)
 {
   boost::property_tree::ptree ptree = get_test_header();
-  std::string repo_path = xrt_core::device_query<xrt_core::query::runner>(dev, xrt_core::query::runner::type::df_bandwidth);
-  repo_path = XBValidateUtils::findPlatformFile(repo_path, ptree);
-  std::string recipe = repo_path + std::string(recipe_file);
-  std::string profile = repo_path + std::string(profile_file);
+  std::string recipe = xrt_core::device_query<xrt_core::query::runner>(dev, xrt_core::query::runner::type::df_bandwidth_recipe);
+  std::string profile = xrt_core::device_query<xrt_core::query::runner>(dev, xrt_core::query::runner::type::df_bandwidth_profile);
+  std::string test = xrt_core::device_query<xrt_core::query::runner>(dev, xrt_core::query::runner::type::df_bandwidth_path);
+  auto recipe_path = XBValidateUtils::findPlatformFile(recipe, ptree);
+  auto profile_path = XBValidateUtils::findPlatformFile(profile, ptree);
+  auto test_path = XBValidateUtils::findPlatformFile(test, ptree);
+
   try
   {
-    xrt_core::runner runner(xrt::device(dev), recipe, profile, std::filesystem::path(repo_path));
+    xrt_core::runner runner(xrt::device(dev), recipe_path, profile_path, std::filesystem::path(test_path));
     runner.execute();
     runner.wait();
 

--- a/src/runtime_src/core/tools/common/tests/TestGemm.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestGemm.cpp
@@ -12,8 +12,6 @@
 namespace XBU = XBUtilities;
 
 static constexpr uint32_t num_of_cores = 32;
-static constexpr std::string_view recipe_file = "recipe_gemm.json";
-static constexpr std::string_view profile_file = "profile_gemm.json";
 /*
 * Total OPs= = 196K OPs.
 */
@@ -28,13 +26,15 @@ boost::property_tree::ptree
 TestGemm::run(std::shared_ptr<xrt_core::device> dev)
 {
   boost::property_tree::ptree ptree = get_test_header();
-  std::string repo_path = xrt_core::device_query<xrt_core::query::runner>(dev, xrt_core::query::runner::type::gemm);
-  repo_path = XBValidateUtils::findPlatformFile(repo_path, ptree);
-  std::string recipe = repo_path + std::string(recipe_file);
-  std::string profile = repo_path + std::string(profile_file);
+  std::string recipe = xrt_core::device_query<xrt_core::query::runner>(dev, xrt_core::query::runner::type::gemm_recipe);
+  std::string profile = xrt_core::device_query<xrt_core::query::runner>(dev, xrt_core::query::runner::type::gemm_profile);
+  std::string test = xrt_core::device_query<xrt_core::query::runner>(dev, xrt_core::query::runner::type::gemm_path);
+  auto recipe_path = XBValidateUtils::findPlatformFile(recipe, ptree);
+  auto profile_path = XBValidateUtils::findPlatformFile(profile, ptree);
+  auto test_path = XBValidateUtils::findPlatformFile(test, ptree);
   try
   {
-    xrt_core::runner runner(xrt::device(dev), recipe, profile, std::filesystem::path(repo_path));
+    xrt_core::runner runner(xrt::device(dev), recipe_path, profile_path, std::filesystem::path(test_path));
     runner.execute();
     runner.wait();
     const auto bo_result_map = runner.map_buffer("bo_result");

--- a/src/runtime_src/core/tools/common/tests/TestNPULatency.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestNPULatency.cpp
@@ -31,7 +31,7 @@ TestNPULatency::run(std::shared_ptr<xrt_core::device> dev)
   auto test_path = XBValidateUtils::findPlatformFile(test, ptree);
   try
   {
-    xrt_core::runner runner(xrt::device(dev), recipe_path, recipe_path, std::filesystem::path(test_path));
+    xrt_core::runner runner(xrt::device(dev), recipe_path, profile_path, std::filesystem::path(test_path));
     runner.execute();
     runner.wait();
 

--- a/src/runtime_src/core/tools/common/tests/TestNPULatency.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestNPULatency.cpp
@@ -13,10 +13,8 @@ using json = nlohmann::json;
 // System - Include Files
 #include <filesystem>
 
-static constexpr std::string_view recipe_file = "recipe_latency.json";
-static constexpr std::string_view profile_file = "profile_latency.json";
-
 // ----- C L A S S   M E T H O D S -------------------------------------------
+
 TestNPULatency::TestNPULatency()
    : TestRunner("latency", "Run end-to-end latency test")
 {}
@@ -25,13 +23,15 @@ boost::property_tree::ptree
 TestNPULatency::run(std::shared_ptr<xrt_core::device> dev)
 {
   boost::property_tree::ptree ptree = get_test_header();
-  std::string repo_path = xrt_core::device_query<xrt_core::query::runner>(dev, xrt_core::query::runner::type::latency);
-  repo_path = XBValidateUtils::findPlatformFile(repo_path, ptree);
-  std::string recipe = repo_path + std::string(recipe_file);
-  std::string profile = repo_path + std::string(profile_file);
+  std::string recipe = xrt_core::device_query<xrt_core::query::runner>(dev, xrt_core::query::runner::type::latency_recipe);
+  std::string profile = xrt_core::device_query<xrt_core::query::runner>(dev, xrt_core::query::runner::type::latency_profile);
+  std::string test = xrt_core::device_query<xrt_core::query::runner>(dev, xrt_core::query::runner::type::latency_path); 
+  auto recipe_path = XBValidateUtils::findPlatformFile(recipe, ptree);
+  auto profile_path = XBValidateUtils::findPlatformFile(profile, ptree);
+  auto test_path = XBValidateUtils::findPlatformFile(test, ptree);
   try
   {
-    xrt_core::runner runner(xrt::device(dev), recipe, profile, std::filesystem::path(repo_path));
+    xrt_core::runner runner(xrt::device(dev), recipe_path, recipe_path, std::filesystem::path(test_path));
     runner.execute();
     runner.wait();
 

--- a/src/runtime_src/core/tools/common/tests/TestNPUThroughput.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestNPUThroughput.cpp
@@ -12,8 +12,6 @@
 using json = nlohmann::json;
 #include <filesystem>
 
-static constexpr std::string_view recipe_file = "recipe_throughput.json";
-static constexpr std::string_view profile_file = "profile_throughput.json";
 
 // ----- C L A S S   M E T H O D S -------------------------------------------
 TestNPUThroughput::TestNPUThroughput()
@@ -24,13 +22,15 @@ boost::property_tree::ptree
 TestNPUThroughput::run(std::shared_ptr<xrt_core::device> dev)
 {
   boost::property_tree::ptree ptree = get_test_header();
-  std::string repo_path = xrt_core::device_query<xrt_core::query::runner>(dev, xrt_core::query::runner::type::throughput);
-  repo_path = XBValidateUtils::findPlatformFile(repo_path, ptree);
-  std::string recipe = repo_path + std::string(recipe_file);
-  std::string profile = repo_path + std::string(profile_file);
+  std::string recipe = xrt_core::device_query<xrt_core::query::runner>(dev, xrt_core::query::runner::type::throughput_recipe);
+  std::string profile = xrt_core::device_query<xrt_core::query::runner>(dev, xrt_core::query::runner::type::throughput_profile);
+  std::string test = xrt_core::device_query<xrt_core::query::runner>(dev, xrt_core::query::runner::type::throughput_path);
+  auto recipe_path = XBValidateUtils::findPlatformFile(recipe, ptree);
+  auto profile_path = XBValidateUtils::findPlatformFile(profile, ptree);
+  auto test_path = XBValidateUtils::findPlatformFile(test, ptree);
   try
   {
-    xrt_core::runner runner(xrt::device(dev), recipe, profile, std::filesystem::path(repo_path));
+    xrt_core::runner runner(xrt::device(dev), recipe_path, profile_path, std::filesystem::path(test_path));
     runner.execute();
     runner.wait();
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
This PR corrects the hardcoding of recipe and profile JSON file names in xrt-smi tests.
Today, the windows driver installation through INF doesn't allow multiple files with the same name which causes integration of these tests to windows driver painful since the file needs to be different for different devices (phx, strx, npu3 etc).

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
None

#### How problem was solved, alternative solutions (if any) and why they were rejected
This PR adds queries for each runner artifacts from driver and allows the driver to be flexible on what it wants to name these files. Now, the driver can store these files with _phx, _stx appended to the name and return device specific runner artifacts, instead of the file name being hard-coded to the test itself.

#### Risks (if any) associated the changes in the commit
NA

#### What has been tested and how, request additional testing if necessary
Tested on strx and phx platforms. 

#### Documentation impact (if any)
NA
