### PR TITLE
Fix for CR-1240697: Remove device interface in Alveo hardware emulation when switching xclbins

### DIFF
--- a/src/runtime_src/core/pcie/emulation/hw_emu/alveo_shim/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_emu/alveo_shim/shim.cxx
@@ -75,6 +75,7 @@ namespace xclhwemhal2 {
   std::map<int, std::tuple<std::string,int,void*, unsigned int> > HwEmShim::mFdToFileNameMap;
   std::ofstream HwEmShim::mDebugLogStream;
   bool HwEmShim::mFirstBinary = true;
+  unsigned int HwEmShim::binaryCounter = 0;
   unsigned int HwEmShim::mBufferCount = 0;
   const int xclhwemhal2::HwEmShim::SPIR_ADDRSPACE_PRIVATE   = 0;
   const int xclhwemhal2::HwEmShim::SPIR_ADDRSPACE_GLOBAL    = 1;
@@ -2241,7 +2242,6 @@ namespace xclhwemhal2 {
 
     buf = nullptr;
     buf_size = 0;
-    binaryCounter = 0;
     host_sptag_idx = -1;
     sock = nullptr;
     mCURangeMap.clear();

--- a/src/runtime_src/core/pcie/emulation/hw_emu/alveo_shim/shim.h
+++ b/src/runtime_src/core/pcie/emulation/hw_emu/alveo_shim/shim.h
@@ -564,7 +564,7 @@ using addr_type = uint64_t;
       std::ofstream mGlobalOutMemStream;
       static std::ofstream mDebugLogStream;
       static bool mFirstBinary;
-      unsigned int binaryCounter;
+      static unsigned int binaryCounter;
 
       std::shared_ptr<unix_socket> sock;
       std::string deviceName;

--- a/src/runtime_src/xdp/profile/plugin/device_offload/hw_emu/hw_emu_device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/hw_emu/hw_emu_device_offload_plugin.cpp
@@ -90,7 +90,20 @@ namespace xdp {
     }
     readCounters();
 
-    clearOffloader(deviceId) ;
+    clearOffloader(deviceId);
+
+    // On Alveo hardware emulation (where there is only one device)
+    // we have to remove the device interface at this point.  This
+    // is because of the use case where xclbins get swapped out and
+    // replaced with a different xclbin.  Additionally, Alveo hardware
+    // emulation only calls flush device when the object is being closed.
+    if (!isEdge() &&
+	db->getStaticInfo().getAppStyle() == xdp::AppStyle::LOAD_XCLBIN_STYLE) {
+      for (auto deviceId : devicesSeen) {
+	db->getStaticInfo().removeDeviceIntf(deviceId);
+      }
+      devicesSeen.clear();
+    }
   }
 
   void HWEmuDeviceOffloadPlugin::updateDevice(void* userHandle)


### PR DESCRIPTION
#### Problem solved by the commit
In Alveo hardware emulation, when xlcbins are swapped profiling needs to flush profiling information off of the device and close the PL device interface we constructed at that point.  This is because the PL device interface keeps an xrt::device object, and if we keep it past the point where simulation shuts down the destruction of the xrt::device object causes a crash when it queries the non-existent simulation.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
This pull request fixes two issues in Alveo hardware emulation, one in profiling and one in the emulation shim.  In profiling, we clean out our information and destroy our objects while the simulation is still active before it is shut down.  In the emulation shim, the binary counter used to keep track of multiple xclbins loaded on the same device was not unique across different binaries, leading to the simulation model reusing the same binary directory and causing problems with overwriting files.

#### Risks (if any) associated the changes in the commit
Low risk as this is focused exclusively on Alveo hardware emulation and applications that run multiple xclbins.

#### What has been tested and how, request additional testing if necessary
The original failing tutorials (axi_burst_performance and rtl_streaming_free_running_k2k) have been verified

#### Documentation impact (if any)
No documentation impact