### PR TITLE
[RFC] hip: hip_device: remove setting default device for main thread in global initialization

### DIFF
--- a/src/runtime_src/hip/api/hip_device.cpp
+++ b/src/runtime_src/hip/api/hip_device.cpp
@@ -53,9 +53,6 @@ device_init()
     current_memory_pool_db[i] = default_mem_pool;
     insert_in_map(mem_pool_cache, default_mem_pool);
   }
-  // make first device as default device
-  if (dev_count > 0)
-    tls_objs.dev_hdl = static_cast<device_handle>(0);
 }
 
 static void


### PR DESCRIPTION
The default device per-thread handle tls_objs.dev_hdl is set to max uint32_t
by default, for child threads, it needs to call hipSetDevice() to set it to
valid device before calling HIP APIs as many HIP APIs needs to use default
device, such as hipMalloc(), hipHostMalloc(), hipModuleLoad(), and so on. In
order to make the HIP execution flow the same for all threads, remove the main
thread default device from global initialization.

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Due to per-thread current device is by default set to max uint32_t, to run HIP APIs, we will need to set it to valid device first as many HIP APIs uses current device. Today, child thread needs to call `hipSetDevice()` to set it to 0, however, since global initialization of the application set it to 0 for main thread, and thus, main thread doesn't need to call it. But this introduce APIs execution requirements difference between child threads and main thread. In order to make the HIP APIs execution requirements the same for both, this patch remove the main thread current device setting from global initialization.

Alternatively, can consider setting the default per thread device to device 0 by default.
I would prefer enforcing user to call `hipSetDevice()` for both local and main threads. Please comment.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
