### PR TITLE
Create poll thread for AIE Profile in device specific implementation

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_impl.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_impl.h
@@ -1,21 +1,10 @@
-/**
- * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2022-2025 Advanced Micro Devices, Inc. All rights reserved
 
 #ifndef AIE_PROFILE_IMPL_H
 #define AIE_PROFILE_IMPL_H
+
+#include <thread>
 
 #include "aie_profile_metadata.h"
 #include "xdp/profile/plugin/vp_base/vp_base_plugin.h"
@@ -33,16 +22,27 @@ namespace xdp {
   protected:
     VPDatabase* db = nullptr;
     std::shared_ptr<AieProfileMetadata> metadata;
+    std::atomic<bool> threadCtrl;
+    std::unique_ptr<std::thread> thread;
 
   public:
     AieProfileImpl(VPDatabase* database, std::shared_ptr<AieProfileMetadata> metadata)
-      :db(database), metadata(metadata) {}
+      : db(database),
+        metadata(metadata),
+        threadCtrl(false),
+        thread(nullptr)
+    {}
 
     AieProfileImpl() = delete;
     virtual ~AieProfileImpl() {};
 
     virtual void updateDevice() = 0;
-    virtual void poll(const uint32_t index, void* handle) = 0;
+
+    virtual void startPoll(const uint32_t index) = 0;
+    virtual void continuePoll(const uint32_t index) = 0;
+    virtual void poll(const uint32_t index) = 0;
+    virtual void endPoll() = 0;
+
     virtual void freeResources() = 0;
   };
 

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_plugin.h
@@ -1,18 +1,5 @@
-/**
- * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. - All rights reserved
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2022-2025 Advanced Micro Devices, Inc. All rights reserved
 
 #ifndef XDP_AIE_PLUGIN_DOT_H
 #define XDP_AIE_PLUGIN_DOT_H
@@ -37,7 +24,6 @@ namespace xdp {
   private:
     virtual void writeAll(bool openNewFiles) override;
     uint64_t getDeviceIDFromHandle(void* handle, bool hw_context_flow);
-    void pollAIECounters(const uint32_t index, void* handle);
     void endPoll();
 
   private:
@@ -49,9 +35,6 @@ namespace xdp {
       bool valid;
       std::unique_ptr<AieProfileImpl> implementation;
       std::shared_ptr<AieProfileMetadata> metadata;
-      std::atomic<bool> threadCtrlBool;
-      std::thread thread;
-
     };
     std::map<void*, AIEData>  handleToAIEData;
 

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/client/aie_profile.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/client/aie_profile.cpp
@@ -294,7 +294,7 @@ namespace xdp {
   }
 
   void
-  AieProfile_WinImpl::poll(const uint32_t index, void* handle)
+  AieProfile_WinImpl::poll(const uint32_t index)
   {
     if (finishedPoll)
       return;
@@ -318,7 +318,6 @@ namespace xdp {
       return;
     }
 
-    (void)handle;
     double timestamp = xrt_core::time_ns() / 1.0e6;
 
     XAie_StartTransaction(&aieDevInst, XAIE_TRANSACTION_DISABLE_AUTO_FLUSH);

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/client/aie_profile.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/client/aie_profile.h
@@ -25,7 +25,12 @@ namespace xdp {
     ~AieProfile_WinImpl() = default;
 
     void updateDevice();
-    void poll(const uint32_t index, void* handle);
+
+    void startPoll(const uint32_t /*index*/) override {}
+    void continuePoll(const uint32_t /*index*/) override {}
+    void poll(const uint32_t index) override;
+    void endPoll() override {}
+
     void freeResources();
     bool setMetricsSettings(const uint64_t deviceId);
     void configStreamSwitchPorts(

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/edge/aie_profile.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/edge/aie_profile.h
@@ -25,7 +25,12 @@ namespace xdp {
       ~AieProfile_EdgeImpl() = default;
 
       void updateDevice();
-      void poll(const uint32_t index, void* handle);
+
+      void startPoll(const uint32_t index) override;
+      void continuePoll(const uint32_t index) override;
+      void poll(const uint32_t index) override;
+      void endPoll() override;
+
       void freeResources();
       bool checkAieDevice(const uint64_t deviceId, void* handle);
 

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/ve2/aie_profile.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/ve2/aie_profile.h
@@ -28,7 +28,12 @@ namespace xdp {
       ~AieProfile_VE2Impl() = default;
 
       void updateDevice();
-      void poll(const uint32_t index, void* handle);
+
+      void startPoll(const uint32_t index) override;
+      void continuePoll(const uint32_t index) override;
+      void poll(const uint32_t index) override;
+      void endPoll() override;
+
       void freeResources();
       bool checkAieDevice(const uint64_t deviceId, void* handle);
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
For AIE Profile, XDP used to create polling thread for reading counter values from device in the unified AIE Profile Plugin itself. This  works for single partition. For multiple partition support, each partition needs to have its own polling thread. This adds requirement for ensuring thread safety while reading/writing to shared data structures. 
This PR creates and manages polling thread for each partition in its own implementation backend and avoids shared data structures. Each polling thread can now execute safely.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
New enhancement required for multiple partition support

#### How problem was solved, alternative solutions (if any) and why they were rejected
Alternative solution would be to employ mutexes around read/write of shared data structures. That would impact performance negatively.

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
AIE Profiling for single partition test. Snigdha used these changes in multi partition support.

#### Documentation impact (if any)
