### PR TITLE
tools: common: tests: AIE reconfigOverhead: add return to normal path

### DIFF
--- a/src/runtime_src/core/tools/common/tests/TestAIEReconfigOverhead.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestAIEReconfigOverhead.cpp
@@ -50,6 +50,7 @@ TestAIEReconfigOverhead::run(std::shared_ptr<xrt_core::device> dev)
 
     XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Array reconfiguration overhead: %.1f ms") % overhead));
     ptree.put("status", XBValidateUtils::test_token_passed);
+    return ptree;
   }
   catch(const std::exception& e)
   {


### PR DESCRIPTION
The test function TestAIEReconfigOverhead::run() requires return, add missing return to the normal path to fix compilation error.

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
