### PR TITLE
Aligning bo size for cma allocation

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/common/zocl_bo.c
+++ b/src/runtime_src/core/edge/drm/zocl/common/zocl_bo.c
@@ -195,6 +195,13 @@ zocl_create_cma_mem(struct drm_device *dev, size_t size)
 	void* vaddr = NULL;
 	int mem_region = -1;
 
+	/* Roundng up the size to more than 4K
+	 * to ensure to allocate memory from CMA always */
+	if (size <= PAGE_SIZE)
+		size = round_up(size, 2 * PAGE_SIZE);
+	else
+		size = round_up(size, PAGE_SIZE);
+
 	cma_obj = zocl_cma_create(dev, size);
 	if (IS_ERR(cma_obj))
 		return ERR_PTR(-ENOMEM);

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_util.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_util.h
@@ -22,7 +22,7 @@
 #define _8KB	0x2000
 #define _64KB	0x10000
 
-#define ZOCL_MAX_MEM_REGIONS 5
+#define ZOCL_MAX_MEM_REGIONS 32
 #define MAX_PR_SLOT_NUM	32
 #define MAX_CU_NUM     128
 /* Apertures contains both ip and debug ip information */
@@ -161,8 +161,8 @@ struct zocl_cu_subdev {
 };
 
 struct zocl_mem_region {
-	struct device *dev;
-	bool initialized;
+	struct device 		*dev;
+	bool 			initialized;
 };
 
 struct drm_zocl_dev {
@@ -206,7 +206,7 @@ struct drm_zocl_dev {
 	int			 full_overlay_id;
 	struct drm_zocl_slot	*pr_slot[MAX_PR_SLOT_NUM];
 	u32                     slot_mask;
-	int						num_regions;
+	int			num_regions;
 	struct zocl_mem_region	mem_regions[ZOCL_MAX_MEM_REGIONS];
 };
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1245557
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
The issue was when we request Linux to allocate cma memory it used to allocate randomly from different different regions for smaller sizes. Which cause test failure for some PL tests in which PL kernel does not have connection or access to that memory region.
#### How problem was solved, alternative solutions (if any) and why they were rejected
Problem was solved by rounding up the size to 2*page_size if the size is smaller and for bigger size, we're just rounding up with the page size.
#### Risks (if any) associated the changes in the commit
n/a
#### What has been tested and how, request additional testing if necessary
Tested the given testcase from the CR. Also tested few edge cases:
1. Simple VADD, 
2. simple GMIO, 
3. too many async operations on a GMIO test)
#### Documentation impact (if any)
n/a