### PR TITLE
[XDP] Modified Stream width bytes to suppport AIE2PS aie_profiling api

### DIFF
--- a/src/runtime_src/core/edge/user/aie/common_layer/adf_profiling_api.cpp
+++ b/src/runtime_src/core/edge/user/aie/common_layer/adf_profiling_api.cpp
@@ -154,7 +154,9 @@ err_code profiling::profile_stream_start_to_transfer_complete_cycles(XAie_DevIns
         << " row " << (int)tileLoc.Row << " , event port id " << (int)eventPortId << ", slave or master " << (int)slaveOrMaster
         << ", port interface SOUTH, stream switch port id " << (int)streamPortId).str());
 
-    uint8_t streamWidthInBytes=4;
+    // AIE2PS Edge devices have an 8-byte stream width that differs from AIE1/AIE2 devices.
+    // NOTE: AIE2P devices also have 8-byte stream width but APIs are not supported for client devices.
+    uint8_t streamWidthInBytes = 4;
     if (dev->DevProp.DevGen == XAIE_DEV_GEN_AIE2PS)
         streamWidthInBytes = 8;
     driverStatus |= XAie_PerfCounterEventValueSet(dev, tileLoc, XAIE_PL_MOD, (u8)counterId1, (u32)(numBytes / streamWidthInBytes));

--- a/src/runtime_src/core/edge/user/aie/common_layer/adf_profiling_api.cpp
+++ b/src/runtime_src/core/edge/user/aie/common_layer/adf_profiling_api.cpp
@@ -154,9 +154,12 @@ err_code profiling::profile_stream_start_to_transfer_complete_cycles(XAie_DevIns
         << " row " << (int)tileLoc.Row << " , event port id " << (int)eventPortId << ", slave or master " << (int)slaveOrMaster
         << ", port interface SOUTH, stream switch port id " << (int)streamPortId).str());
 
-    driverStatus |= XAie_PerfCounterEventValueSet(dev, tileLoc, XAIE_PL_MOD, (u8)counterId1, (u32)(numBytes / 4));
+    uint8_t streamWidthInBytes=4;
+    if (dev->DevProp.DevGen == XAIE_DEV_GEN_AIE2PS)
+        streamWidthInBytes = 8;
+    driverStatus |= XAie_PerfCounterEventValueSet(dev, tileLoc, XAIE_PL_MOD, (u8)counterId1, (u32)(numBytes / streamWidthInBytes));
     debugMsg(static_cast<std::stringstream &&>(std::stringstream() << "XAie_PerfCounterEventValueSet: col " << (int)tileLoc.Col
-        << " row " << (int)tileLoc.Row << ", module XAIE_PL_MOD, counter id " << (int)counterId1 << ", perf counter event value " << (unsigned int)(numBytes / 4)).str());
+        << " row " << (int)tileLoc.Row << ", module XAIE_PL_MOD, counter id " << (int)counterId1 << ", perf counter event value " << (unsigned int)(numBytes / streamWidthInBytes)).str());
 
     driverStatus |= XAie_PerfCounterControlSet(dev, tileLoc, XAIE_PL_MOD, (u8)counterId0, COMMON_XAIETILE_EVENT_SHIM_PORT_RUNNING[eventPortId], XAIE_EVENT_PERF_CNT_1_PL);
     debugMsg(static_cast<std::stringstream &&>(std::stringstream() << "XAie_PerfCounterControlSet: col " << (int)tileLoc.Col


### PR DESCRIPTION
#### Problem solved by the commit
Incorrect Stream width when profiling api's were being executed in aie2ps

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
N/A

#### How problem was solved, alternative solutions (if any) and why they were rejected
Earlier default stream width was considered to be 4 bytes. Problem was solved by adding an if block which checked for the hardware generation, verified if it is aie2ps and accordingly set the stream width to 8bytes.

#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
This has been tested on the aie2ps board on hw.

#### Documentation impact (if any)
N/A
