### PR TITLE
HIP: fix coverity

### DIFF
--- a/src/runtime_src/hip/api/hip_event.cpp
+++ b/src/runtime_src/hip/api/hip_event.cpp
@@ -30,6 +30,7 @@ static void hip_event_record(hipEvent_t eve, hipStream_t stream)
   throw_invalid_value_if(!stream, "stream passed is nullptr");
   auto hip_stream = get_stream(stream);
   auto hip_ev = std::dynamic_pointer_cast<event>(command_cache.get(eve));
+  throw_invalid_value_if(!hip_ev, "dynamic_pointer_cast failed");
   hip_ev->record(std::move(hip_stream));
 }
 

--- a/src/runtime_src/hip/api/hip_event.cpp
+++ b/src/runtime_src/hip/api/hip_event.cpp
@@ -30,7 +30,7 @@ static void hip_event_record(hipEvent_t eve, hipStream_t stream)
   throw_invalid_value_if(!stream, "stream passed is nullptr");
   auto hip_stream = get_stream(stream);
   auto hip_ev = std::dynamic_pointer_cast<event>(command_cache.get(eve));
-  hip_ev->record(hip_stream);
+  hip_ev->record(std::move(hip_stream));
 }
 
 static void hip_event_synchronize(hipEvent_t eve)

--- a/src/runtime_src/hip/api/hip_memory.cpp
+++ b/src/runtime_src/hip/api/hip_memory.cpp
@@ -32,7 +32,7 @@ namespace xrt::core::hip
     auto address = hip_mem->get_address();
     throw_if(!address, hipErrorOutOfMemory, "Error allocating memory using hipMalloc!");
       
-    memory_database::instance().insert(reinterpret_cast<uint64_t>(address), size, hip_mem);
+    memory_database::instance().insert(reinterpret_cast<uint64_t>(address), size, std::move(hip_mem));
     *ptr = reinterpret_cast<void* >(address);
   }
 
@@ -51,7 +51,7 @@ namespace xrt::core::hip
     auto address = hip_mem->get_address();
     throw_if(!address, hipErrorOutOfMemory, "Error allocating memory using hipHostMalloc!");
       
-    memory_database::instance().insert(reinterpret_cast<uint64_t>(address), size, hip_mem);
+    memory_database::instance().insert(reinterpret_cast<uint64_t>(address), size, std::move(hip_mem));
     *ptr = address;
   }
   
@@ -67,7 +67,7 @@ namespace xrt::core::hip
     auto host_addr = hip_mem->get_address();
     throw_if(!host_addr, hipErrorOutOfMemory, "Error registering the host memory using hipHostRegister!");
 
-    memory_database::instance().insert(reinterpret_cast<uint64_t>(host_addr), size, hip_mem);
+    memory_database::instance().insert(reinterpret_cast<uint64_t>(host_addr), size, std::move(hip_mem));
   }
   
   // Get Device pointer from Host Pointer allocated through hipHostMalloc().
@@ -292,7 +292,7 @@ namespace xrt::core::hip
     auto pool = std::make_shared<memory_pool>(dev, MAX_MEMORY_POOL_SIZE_NPU, MEMORY_POOL_BLOCK_SIZE_NPU);
     auto pool_hdl = insert_in_map(mem_pool_cache, pool);
     *mem_pool = reinterpret_cast<hipMemPool_t>(pool_hdl);
-    memory_pool_db[dev->get_device_id()].push_back(pool);
+    memory_pool_db[dev->get_device_id()].push_back(std::move(pool));
   }
   
   static void
@@ -324,7 +324,7 @@ namespace xrt::core::hip
     throw_invalid_value_if(!dev, "Invalid device index.");
 
     auto default_mem_pool = memory_pool_db[device].front();
-    *mem_pool = get_mem_pool_handle(default_mem_pool);
+    *mem_pool = get_mem_pool_handle(std::move(default_mem_pool));
   }
 
   // Gets the current memory pool for the specified device.
@@ -336,7 +336,7 @@ namespace xrt::core::hip
     throw_invalid_value_if(!dev, "Invalid device index.");
 
     auto curr_mem_pool = current_memory_pool_db[device];
-    *mem_pool = get_mem_pool_handle(curr_mem_pool);
+    *mem_pool = get_mem_pool_handle(std::move(curr_mem_pool));
   }
 
   static void

--- a/src/runtime_src/hip/api/hip_memory.cpp
+++ b/src/runtime_src/hip/api/hip_memory.cpp
@@ -78,6 +78,7 @@ namespace xrt::core::hip
 
     auto hip_mem = memory_database::instance().get_hip_mem_from_addr(host_ptr).first;
     throw_invalid_value_if(!hip_mem, "Error getting device pointer from host pointer.");
+    // coverity[REVERSE_INULL] , preivous function already checks for nullptr
     throw_invalid_value_if(hip_mem->get_flags() != hipHostMallocMapped, "Getting device pointer is valid only for memories created with hipHostMallocMapped flag!");
 
     *device_ptr = nullptr;

--- a/src/runtime_src/hip/api/hip_stream.cpp
+++ b/src/runtime_src/hip/api/hip_stream.cpp
@@ -104,7 +104,7 @@ hip_stream_wait_event(hipStream_t stream, hipEvent_t ev, unsigned int flags)
     auto dummy_event_hdl = static_cast<event*>(
         insert_in_map(command_cache,
                       std::make_shared<event>()));
-    dummy_event_hdl->record(hip_wait_stream);
+    dummy_event_hdl->record(std::move(hip_wait_stream));
     dummy_event_hdl->add_dependency(hip_event_cmd);
 
     // enqueue dummy event into wait stream

--- a/src/runtime_src/hip/core/memory_pool.cpp
+++ b/src/runtime_src/hip/core/memory_pool.cpp
@@ -59,7 +59,7 @@ namespace xrt::core::hip
   memory_pool_node::merge_free_slots(std::shared_ptr<memory_pool_slot> new_free_slot)
   {
     std::shared_ptr<memory_pool_slot> p0 = new_free_slot;
-    std::shared_ptr<memory_pool_slot> p1 = new_free_slot;
+    std::shared_ptr<memory_pool_slot> p1 = std::move(new_free_slot); // should not use new_free_slot onward
 
     while (p0 && p0->is_free()) {
       p1 = p0;
@@ -88,7 +88,7 @@ namespace xrt::core::hip
         dlinkedlist_delete(m_alloc_list, used_slot);
         dlinkedlist_insert(m_free_list, used_slot);
         used_slot->m_is_free = true;
-        merge_free_slots(used_slot);
+        merge_free_slots(std::move(used_slot));
         break;
       }
       used_slot = used_slot->m_next;
@@ -299,7 +299,7 @@ namespace xrt::core::hip
             else {
               // if the free slot found has exactly the same size as required aligned_size
               // there is no need to divide the slot, just remove the slot from m_free_list
-              alloc_slot = free_slot;
+              alloc_slot = std::move(free_slot);
               dlinkedlist_delete(mm->m_free_list, alloc_slot);
               alloc_slot->m_is_free = false;
             }

--- a/src/runtime_src/hip/core/memory_pool.cpp
+++ b/src/runtime_src/hip/core/memory_pool.cpp
@@ -386,10 +386,10 @@ namespace xrt::core::hip
   void
   memory_pool::trim_to(size_t min_bytes_to_hold)
   {
+    std::lock_guard lock(m_mutex);
+
     if (m_reserved_mem_current < min_bytes_to_hold)
       return;
-
-    std::lock_guard lock(m_mutex);
 
     bool node_deleted = false;
     do {

--- a/src/runtime_src/hip/core/stream.cpp
+++ b/src/runtime_src/hip/core/stream.cpp
@@ -31,12 +31,12 @@ enqueue(std::shared_ptr<command> cmd)
 {
   // if there is top event add command chain list of this event
   // else submit the command
+  std::lock_guard<std::mutex> lock(m_cmd_lock);
   if (m_top_event)
     m_top_event->add_to_chain(cmd);
   else
     cmd->submit();
 
-  std::lock_guard<std::mutex> lock(m_cmd_lock);
   m_cmd_queue.emplace_back(std::move(cmd));
 }
 


### PR DESCRIPTION
This patch set fixes HIP coverity reports. except this one:
```
** CID 535924:       Concurrent data access violations  (MISSING_LOCK)
/src/runtime_src/hip/core/event.h: 84           in xrt::core::hip::command::get_time()()


_____________________________________________________________________________________________
*** CID 535924:         Concurrent data access violations  (MISSING_LOCK)
/src/runtime_src/hip/core/event.h: 84             in xrt::core::hip::command::get_time()()
78         return cstate;
79       }
80     
81       std::chrono::time_point<std::chrono::system_clock>
82       get_time()
83       {
>>>     CID 535924:         Concurrent data access violations  (MISSING_LOCK)
>>>     Accessing "this->ctime" without holding lock "xrt::core::hip::event.m_mutex_rec_coms". Elsewhere, "xrt::core::hip::command.ctime" is written to with "event.m_mutex_rec_coms" held 1 out of 1 times.
84         return ctime;
85       }
86     
87       void
88       set_state(state newstate)
89       {

** CID 535923:       Uninitialized variables  (USE_AFTER_MOVE)
/src/runtime_src/core/common/aiebu/src/cpp/common/writer.h: 91           in aiebu::section_writer::add_symbols(std::vector<aiebu::symbol, std::allocator<aiebu::symbol>> &)()
```
Because the `get_time()` is implemented in `class command`, however, the `ctime` is set in `bool event::synchronize()` and `class event` inherits `class command`. and only `event` sets `ctime`, looks like it is better to move `ctime` from `class command` to `class event` ? or if we want to keep `ctime` in the event, how about make `command::get_time()` as virtual or return 0 and let child class does the actual implementation because it is better to keep set ctime and get ctime in the same class.
Hi @chvamshi-xilinx , could you comment on this? thanks

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
