### PR TITLE
Reusing device reset function for resetting device functionality. It …

### DIFF
--- a/src/runtime_src/core/common/api/device_int.h
+++ b/src/runtime_src/core/common/api/device_int.h
@@ -4,6 +4,7 @@
 #define _XRT_COMMON_DEVICE_INT_H_
 
 // This file defines implementation extensions to the XRT Device APIs.
+#include "core/common/config.h"
 #include "core/include/xrt/xrt_device.h"
 #include <chrono>
 #include <condition_variable>
@@ -23,6 +24,11 @@ get_xcl_device_handle(xrtDeviceHandle dhdl);
 // otherwise times out.
 std::cv_status
 exec_wait(const xrt::device& device, const std::chrono::milliseconds& timeout_ms);
+
+// This API is used by xocl for resetting the shared pointer.
+XRT_CORE_COMMON_EXPORT
+void
+reset(const xrt::device& device);
 
 }} // device_int, xrt_core
 

--- a/src/runtime_src/core/common/api/xrt_device.cpp
+++ b/src/runtime_src/core/common/api/xrt_device.cpp
@@ -222,6 +222,12 @@ exec_wait(const xrt::device& device, const std::chrono::milliseconds& timeout_ms
   return xrt_core::hw_queue::exec_wait(device.get_handle().get(), timeout_ms);
 }
 
+void
+reset(const xrt::device& device)
+{
+  device.get_handle().reset();
+}
+
 } // xrt_core::device_int
 
 namespace xrt {
@@ -315,7 +321,7 @@ device::
 reset()
 {
   return xdp::native::profiling_wrapper("xrt::device::reset", [this]{
-    handle.reset();
+    handle->reset();
   });
 }
 

--- a/src/runtime_src/core/common/device.h
+++ b/src/runtime_src/core/common/device.h
@@ -408,6 +408,10 @@ public:
   std::pair<size_t, size_t>
   get_ert_slots(const uuid& xclbin_id = uuid()) const;
 
+  /**
+   * reset() - resets the device
+   */
+  virtual void reset() const {}
   // Move all these 'pt' functions out the class interface
   virtual void get_info(boost::property_tree::ptree&) const {}
   /**

--- a/src/runtime_src/xrt/device/hal2.cpp
+++ b/src/runtime_src/xrt/device/hal2.cpp
@@ -4,6 +4,7 @@
 #include "hal2.h"
 
 #include "core/common/api/bo.h"
+#include "core/common/api/device_int.h"
 #include "core/common/device.h"
 #include "core/common/error.h"
 #include "core/common/query_requests.h"
@@ -101,7 +102,7 @@ device::
 close_nolock()
 {
   if (m_handle)
-    m_handle.reset();
+    xrt_core::device_int::reset(m_handle);
 }
 
 void


### PR DESCRIPTION
…was resetting the shared pointer earlier (#9111)

* reusing reset function for device reset purpose

* fix windows build

---------


(cherry picked from commit 44c9ceb9f8b6b29d5bdf3a50f92b8cbde8b57f2d)

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
