### PR TITLE
fixing yocto build script to generate embedded RPMs (#9112)

### DIFF
--- a/build/build_yocto.sh
+++ b/build/build_yocto.sh
@@ -53,7 +53,7 @@ install_recipes()
     if [ $? != 0 ]; then
         echo "inherit externalsrc" > $XRT_BB
         echo "EXTERNALSRC = \"$XRT_REPO_DIR/src\"" >> $XRT_BB
-        echo "EXTRA_OECMAKE += \"-DMY_VITIS=$XILINX_VITIS\"" >> $XRT_BB
+        echo "EXTRA_OECMAKE += \"-DMY_VITIS=$XILINX_VITIS -DXRT_EDGE=1 -DCMAKE_INSTALL_PREFIX=/usr\"" >> $XRT_BB
         echo 'EXTERNALSRC_BUILD = "${WORKDIR}/build"' >> $XRT_BB
 	echo 'DEPENDS += " systemtap"' >> $XRT_BB
         echo 'PACKAGE_CLASSES = "package_rpm"' >> $XRT_BB

--- a/build/yocto.build
+++ b/build/yocto.build
@@ -1,4 +1,4 @@
 REPO_URL=https://gitenterprise.xilinx.com/ssw-devops/yocto-tagged-manifest.git
 BRANCH=master
-MANIFEST_PATH=/proj/yocto/edf/2025.1/stable/Yocto_edf_2025.1_06190408
-MANIFEST_FILE=default_06190408.xml
+MANIFEST_PATH=/proj/yocto/edf/2025.1/stable/Yocto_edf_2025.1_07160403/
+MANIFEST_FILE=default_07160403.xml


### PR DESCRIPTION
* fixing yocto build script

* adding CMAKE_INSTALL_PREFIX=/usr flag aswell

---------


(cherry picked from commit 041da5df3026b3ab05706c591cb4072290899491)

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
