### PR TITLE
[XDP] Support for zocl multi partition for AIE Trace Plugin

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info_database.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info_database.cpp
@@ -1286,8 +1286,6 @@ namespace xdp {
                                         void* devHandle)
   {
     std::lock_guard<std::mutex> lock(aieLock) ;
-    if (aieDevInst)
-      return aieDevInst ;
 
     aieDevInst = fetch(devHandle) ;
     return aieDevInst ;
@@ -1298,10 +1296,6 @@ namespace xdp {
                                        void* devHandle)
   {
     std::lock_guard<std::mutex> lock(aieLock) ;
-    if (aieDevice)
-      return aieDevice;
-    if (!aieDevInst)
-      return nullptr ;
 
     deallocateAieDevice = deallocate ;
     aieDevice = allocate(devHandle) ;

--- a/src/runtime_src/xdp/profile/database/static_info_database.h
+++ b/src/runtime_src/xdp/profile/database/static_info_database.h
@@ -112,9 +112,10 @@ namespace xdp {
     std::mutex hwCtxImplUIDMapLock;
 
     // AIE device (Supported devices only)
-    void* aieDevInst = nullptr ; // XAie_DevInst
-    void* aieDevice = nullptr ; // xaiefal::XAieDev
     std::function<void (void*)> deallocateAieDevice = nullptr ;
+    // AIE device instances mapped to unique device id.
+    std::map<uint64_t, void*> aieDeviceInstances;
+    std::map<uint64_t, void*> aieDevices; // xaiefal::XAieDev
     boost::property_tree::ptree aieMetadata;
     std::unique_ptr<aie::BaseFiletypeImpl> metadataReader = nullptr;
 
@@ -396,10 +397,10 @@ namespace xdp {
     XDP_CORE_EXPORT uint64_t getNumTracePLIO(uint64_t deviceId) ;
     XDP_CORE_EXPORT uint64_t getNumAIETraceStream(uint64_t deviceId) ;
     XDP_CORE_EXPORT void* getAieDevInst(std::function<void* (void*)> fetch,
-                                   void* devHandle) ;
+                                   void* devHandle, uint64_t deviceID=0) ;
     XDP_CORE_EXPORT void* getAieDevice(std::function<void* (void*)> allocate,
                                   std::function<void (void*)> deallocate,
-                                  void* devHandle) ;
+                                  void* devHandle, uint64_t deviceID=0) ;
 
     XDP_CORE_EXPORT void readAIEMetadata(xrt::xclbin xrtXclbin, bool checkDisk);
     XDP_CORE_EXPORT const aie::BaseFiletypeImpl* getAIEmetadataReader() const;

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_impl.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_impl.h
@@ -87,7 +87,7 @@ namespace xdp {
      * @param handle Pointer to device handle
      * @return Pointer to AIE device instance
      */
-    virtual void* setAieDeviceInst(void* handle) = 0;
+    virtual void* setAieDeviceInst(void* handle, uint64_t deviceID) = 0;
   };
 
 } // namespace xdp

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -187,7 +187,7 @@ void AieTracePluginUnified::updateAIEDevice(void *handle, bool hw_context_flow) 
         // For loadxclbin flow currently XRT creates partition of whole device from 0th column.
         // Hence absolute and relative columns are same.
         // TODO: For loadxclbin flow XRT will start creating partition of the specified columns,
-        //       hence we should stop adding partition shift to col for passing to XAIE Apis (CR-1244525).
+        //       hence we should stop adding partition shift to col for passing to XAIE Apis.
         uint8_t relCol = ((db->getStaticInfo()).getAppStyle() == xdp::AppStyle::LOAD_XCLBIN_STYLE) ? gmio.shimColumn + startColShift : gmio.shimColumn;
         (db->getStaticInfo()).addTraceGMIO(deviceID, gmio.id, relCol, gmio.channelNum,
                                             gmio.streamId, gmio.burstLength);

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -209,7 +209,7 @@ void AieTracePluginUnified::updateAIEDevice(void *handle, bool hw_context_flow) 
   }
 
   if (AIEData.metadata->getRuntimeMetrics()) {
-    std::string configFile = "aie_event_runtime_config.json";
+    std::string configFile = "aie_event_runtime_config_" + std::to_string(deviceID) + ".json";
     VPWriter *writer = new AieTraceConfigWriter(configFile.c_str(), deviceID);
     writers.push_back(writer);
     (db->getStaticInfo())
@@ -294,7 +294,7 @@ void AieTracePluginUnified::updateAIEDevice(void *handle, bool hw_context_flow) 
       AIEData.metadata->getNumStreams(), AIEData.metadata->getHwContext(),
       AIEData.metadata);
 #elif XDP_VE2_BUILD
-  XAie_DevInst* devInst = static_cast<XAie_DevInst*>(AIEData.implementation->setAieDeviceInst(handle));
+  XAie_DevInst* devInst = static_cast<XAie_DevInst*>(AIEData.implementation->setAieDeviceInst(handle, deviceID));
   if(!devInst) {
     xrt_core::message::send(severity_level::warning, "XRT",
       "Unable to get AIE device instance. AIE event trace will not be available.");
@@ -308,7 +308,7 @@ void AieTracePluginUnified::updateAIEDevice(void *handle, bool hw_context_flow) 
       ,
       AIEData.metadata->getNumStreams(), devInst);
 #else
-  XAie_DevInst* devInst = static_cast<XAie_DevInst*>(AIEData.implementation->setAieDeviceInst(handle));
+  XAie_DevInst* devInst = static_cast<XAie_DevInst*>(AIEData.implementation->setAieDeviceInst(handle, deviceID));
   if(!devInst) {
     xrt_core::message::send(severity_level::warning, "XRT",
       "Unable to get AIE device instance. AIE event trace will not be available.");

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -169,7 +169,7 @@ void AieTracePluginUnified::updateAIEDevice(void *handle, bool hw_context_flow) 
 #endif
 
   // Check for device interface
-  PLDeviceIntf *deviceIntf = (db->getStaticInfo()).getDeviceIntf(0);
+  PLDeviceIntf *deviceIntf = (db->getStaticInfo()).getDeviceIntf(deviceID);
 
   // Create gmio metadata
   if (!(db->getStaticInfo()).isGMIORead(deviceID)) {

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -83,7 +83,7 @@ AieTracePluginUnified::~AieTracePluginUnified() {
   AieTracePluginUnified::live = false;
 }
 
-uint64_t AieTracePluginUnified::getDeviceIDFromHandle(void *handle, bool hw_context_flow) {
+uint64_t AieTracePluginUnified::getDeviceIDFromHandle(void *handle) {
   auto itr = handleToAIEData.find(handle);
 
   if (itr != handleToAIEData.end())
@@ -122,7 +122,7 @@ void AieTracePluginUnified::updateAIEDevice(void *handle, bool hw_context_flow) 
   if (handleToAIEData.find(handle) != handleToAIEData.end())
     handleToAIEData.erase(handle);
 
-  auto deviceID = getDeviceIDFromHandle(handle, hw_context_flow);
+  auto deviceID = getDeviceIDFromHandle(handle);
 
   // Setting up struct
   auto &AIEData = handleToAIEData[handle];
@@ -134,7 +134,7 @@ void AieTracePluginUnified::updateAIEDevice(void *handle, bool hw_context_flow) 
   (db->getStaticInfo()).updateDeviceFromCoreDevice(deviceID, device);
   (db->getStaticInfo()).setDeviceName(deviceID, "win_device");  
 #else
-    if(hw_context_flow)
+    if((db->getStaticInfo()).getAppStyle() == xdp::AppStyle::REGISTER_XCLBIN_STYLE)
       (db->getStaticInfo()).updateDeviceFromCoreDevice(deviceID, device, true, std::move(std::make_unique<HalDevice>(device->get_device_handle())));
     else
       (db->getStaticInfo()).updateDeviceFromHandle(deviceID, std::move(std::make_unique<HalDevice>(handle)), handle);
@@ -188,7 +188,7 @@ void AieTracePluginUnified::updateAIEDevice(void *handle, bool hw_context_flow) 
         // Hence absolute and relative columns are same.
         // TODO: For loadxclbin flow XRT will start creating partition of the specified columns,
         //       hence we should stop adding partition shift to col for passing to XAIE Apis (CR-1244525).
-        uint8_t relCol = (! hw_context_flow) ? gmio.shimColumn + startColShift : gmio.shimColumn;
+        uint8_t relCol = ((db->getStaticInfo()).getAppStyle() == xdp::AppStyle::LOAD_XCLBIN_STYLE) ? gmio.shimColumn + startColShift : gmio.shimColumn;
         (db->getStaticInfo()).addTraceGMIO(deviceID, gmio.id, relCol, gmio.channelNum,
                                             gmio.streamId, gmio.burstLength);
       }

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.h
@@ -46,7 +46,7 @@ public:
   static bool alive();
 
 private:
-  uint64_t getDeviceIDFromHandle(void *handle, bool hw_context_flow);
+  uint64_t getDeviceIDFromHandle(void *handle);
   void pollAIETimers(uint64_t index, void *handle);
   void flushOffloader(const std::unique_ptr<AIETraceOffload> &offloader,
                       bool warn);

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/client/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/client/aie_trace.cpp
@@ -1286,6 +1286,6 @@ namespace xdp {
    /****************************************************************************
    * Set AIE Device Instance (Currently unused in Windows implementation)
    ***************************************************************************/
-  void* AieTrace_WinImpl::setAieDeviceInst(void* /*handle*/) {  return nullptr;}
+  void* AieTrace_WinImpl::setAieDeviceInst(void*, uint64_t) {  return nullptr;}
 
 }  // namespace xdp

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/client/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/client/aie_trace.cpp
@@ -1286,10 +1286,6 @@ namespace xdp {
    /****************************************************************************
    * Set AIE Device Instance (Currently unused in Windows implementation)
    ***************************************************************************/
-  void* AieTrace_WinImpl::setAieDeviceInst(void* handle)
-  {
-    (void)handle;
-    return nullptr;
-  }
+  void* AieTrace_WinImpl::setAieDeviceInst(void* /*handle*/) {  return nullptr;}
 
 }  // namespace xdp

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/client/aie_trace.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/client/aie_trace.h
@@ -26,7 +26,7 @@ namespace xdp {
       void freeResources() override;
       void pollTimers(uint64_t index, void* handle) override;
       uint64_t checkTraceBufSize(uint64_t size) override;
-      void* setAieDeviceInst(void* /*handle*/) override;
+      void* setAieDeviceInst(void*, uint64_t) override;
 
       void modifyEvents(module_type type, io_type subtype, 
                         const std::string metricSet, uint8_t channel, 

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/client/aie_trace.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/client/aie_trace.h
@@ -26,7 +26,7 @@ namespace xdp {
       void freeResources() override;
       void pollTimers(uint64_t index, void* handle) override;
       uint64_t checkTraceBufSize(uint64_t size) override;
-      void* setAieDeviceInst(void* handle) override;
+      void* setAieDeviceInst(void* /*handle*/) override;
 
       void modifyEvents(module_type type, io_type subtype, 
                         const std::string metricSet, uint8_t channel, 

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/edge/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/edge/aie_trace.cpp
@@ -312,7 +312,7 @@ namespace xdp {
       // For loadxclbin flow currently XRT creates partition of whole device from 0th column.
       // Hence absolute and relative columns are same.
       // TODO: For loadxclbin flow XRT will start creating partition of the specified columns,
-      //       hence we should stop adding partition shift to col for passing to XAIE Apis (CR-1244525).
+      //       hence we should stop adding partition shift to col for passing to XAIE Apis.
       auto relCol     = (db->getStaticInfo().getAppStyle() == xdp::AppStyle::LOAD_XCLBIN_STYLE)
                         ? col /* startColShift already added */ : tile.col;
       auto& xaieTile  = aieDevice->tile(relCol, row);

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/edge/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/edge/aie_trace.cpp
@@ -313,8 +313,8 @@ namespace xdp {
       // Hence absolute and relative columns are same.
       // TODO: For loadxclbin flow XRT will start creating partition of the specified columns,
       //       hence we should stop adding partition shift to col for passing to XAIE Apis (CR-1244525).
-      auto relCol     = (xdp::VPDatabase::Instance()->getStaticInfo().getAppStyle() ==
-                                xdp::AppStyle::LOAD_XCLBIN_STYLE) ? col /* startColShift already added */ : tile.col;
+      auto relCol     = (db->getStaticInfo().getAppStyle() == xdp::AppStyle::LOAD_XCLBIN_STYLE)
+                        ? col /* startColShift already added */ : tile.col;
       auto& xaieTile  = aieDevice->tile(relCol, row);
       auto loc        = XAie_TileLoc(relCol, row);
 

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/edge/aie_trace.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/edge/aie_trace.h
@@ -27,7 +27,6 @@ namespace xdp {
     uint64_t checkTraceBufSize(uint64_t size) override;
     bool tileHasFreeRsc(xaiefal::XAieDev* aieDevice, XAie_LocType& loc, 
                         const module_type type, const std::string& metricSet);
-    bool checkAieDeviceAndRuntimeMetrics(uint64_t deviceId, void* handle);
     bool setMetricsSettings(uint64_t deviceId, void* handle);
 
   private:

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/edge/aie_trace.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/edge/aie_trace.h
@@ -21,7 +21,7 @@ namespace xdp {
     void flushTraceModules() override;
     void pollTimers(uint64_t index, void* handle) override;
     void freeResources() override;
-    void* setAieDeviceInst(void* handle) override;
+    void* setAieDeviceInst(void* handle, uint64_t deviceID) override;
 
   private:
     uint64_t checkTraceBufSize(uint64_t size) override;

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/ve2/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/ve2/aie_trace.cpp
@@ -1052,7 +1052,7 @@ namespace xdp {
   {
     aieDevInst = static_cast<XAie_DevInst*>(db->getStaticInfo().getAieDevInst(fetchAieDevInst, handle, deviceID));
     aieDevice = static_cast<xaiefal::XAieDev*>(db->getStaticInfo().getAieDevice(allocateAieDevice, deallocateAieDevice, handle, deviceID));
-    return aieDevInst
+    return aieDevInst;
   }
 
 }  // namespace xdp

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/ve2/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/ve2/aie_trace.cpp
@@ -233,24 +233,12 @@ namespace xdp {
   }
 
   /****************************************************************************
-   * Validate AIE device and runtime metrics
-   ***************************************************************************/
-  bool AieTrace_VE2Impl::checkAieDeviceAndRuntimeMetrics(uint64_t deviceId, void* handle)
-  {
-    // Make sure compiler trace option is available as runtime
-    if (!metadata->getRuntimeMetrics()) {
-      return false;
-    }
-
-    return true;
-  }
-
-  /****************************************************************************
    * Update device (e.g., after loading xclbin)
    ***************************************************************************/
   void AieTrace_VE2Impl::updateDevice()
   {
-    if (!checkAieDeviceAndRuntimeMetrics(metadata->getDeviceID(), metadata->getHandle()))
+    // If runtime metrics are not enabled, do not configure trace
+    if(!metadata->getRuntimeMetrics())
       return;
 
     // Set metrics for counters and trace events
@@ -985,7 +973,7 @@ namespace xdp {
       std::stringstream msg;
       msg << "AIE device instance is not available. AIE Trace might be empty/incomplete as "
           << "flushing won't be performed.";
-      xrt_core::message::send(severity_level::warning, "XRT", msg.str());
+      xrt_core::message::send(severity_level::debug, "XRT", msg.str());
       return;
     }
 

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/ve2/aie_trace.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/ve2/aie_trace.h
@@ -27,7 +27,6 @@ namespace xdp {
     uint64_t checkTraceBufSize(uint64_t size) override;
     bool tileHasFreeRsc(xaiefal::XAieDev* aieDevice, XAie_LocType& loc, 
                         const module_type type, const std::string& metricSet);
-    bool checkAieDeviceAndRuntimeMetrics(uint64_t deviceId, void* handle);
     bool setMetricsSettings(uint64_t deviceId, void* handle);
 
   private:

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/ve2/aie_trace.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/ve2/aie_trace.h
@@ -21,7 +21,7 @@ namespace xdp {
     void flushTraceModules() override;
     void pollTimers(uint64_t index, void* handle) override;
     void freeResources() override;
-    void* setAieDeviceInst(void* handle) override;
+    void* setAieDeviceInst(void* handle, uint64_t deviceID) override;
 
   private:
     uint64_t checkTraceBufSize(uint64_t size) override;

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/x86/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/x86/aie_trace.cpp
@@ -86,7 +86,7 @@ void AieTrace_x86Impl::updateDevice() {
 // No CMA checks on x86
 uint64_t AieTrace_x86Impl::checkTraceBufSize(uint64_t size) { return size; }
 
-void* AieTrace_x86Impl::setAieDeviceInst(void* /*handle*/) { return nullptr; }
+void* AieTrace_x86Impl::setAieDeviceInst(void*, uint64_t) { return nullptr; }
 
 module_type AieTrace_x86Impl::getTileType(uint16_t absRow) {
   if (absRow == 0)

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/x86/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/x86/aie_trace.cpp
@@ -86,10 +86,7 @@ void AieTrace_x86Impl::updateDevice() {
 // No CMA checks on x86
 uint64_t AieTrace_x86Impl::checkTraceBufSize(uint64_t size) { return size; }
 
-void* AieTrace_x86Impl::setAieDeviceInst(void* handle) {
-  (void)handle; // Unused in x86 implementation
-  return nullptr;
-}
+void* AieTrace_x86Impl::setAieDeviceInst(void* /*handle*/) { return nullptr; }
 
 module_type AieTrace_x86Impl::getTileType(uint16_t absRow) {
   if (absRow == 0)

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/x86/aie_trace.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/x86/aie_trace.h
@@ -35,7 +35,7 @@ namespace xdp {
       uint64_t checkTraceBufSize(uint64_t size) override;
       void pollTimers(uint64_t index, void* handle) override;
       void freeResources() override;
-      void* setAieDeviceInst(void* handle) override;
+      void* setAieDeviceInst(void* /*handle*/) override;
 
       bool setMetricsSettings(uint64_t deviceId, void* handle);
       void parseMessages(uint8_t* messages);

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/x86/aie_trace.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/x86/aie_trace.h
@@ -35,7 +35,7 @@ namespace xdp {
       uint64_t checkTraceBufSize(uint64_t size) override;
       void pollTimers(uint64_t index, void* handle) override;
       void freeResources() override;
-      void* setAieDeviceInst(void* /*handle*/) override;
+      void* setAieDeviceInst(void*, uint64_t) override;
 
       bool setMetricsSettings(uint64_t deviceId, void* handle);
       void parseMessages(uint8_t* messages);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Added support for zocl multipartition for AIE Trace Plugin.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
NA
#### How problem was solved, alternative solutions (if any) and why they were rejected
1. Using unique device ID for each partition. 
2. Storing XAieDev Instance corresponding to each partition in static DB.
3. Generating seperate trace reports for each parition.
#### Risks (if any) associated the changes in the commit
Needs more thorough testing for various flow.
#### What has been tested and how, request additional testing if necessary
Tested ZOCL Multipartition design on VCK190
Tested single parition design on vck190 with register xclbin and load xclbin flow.
Tested independent compilation design for both PLIO and GMIO offload on VCK190.
Tested ML Design on VE2.
Tested Single parition design on Strix
#### Documentation impact (if any)
NA