### PR TITLE
[XDP] Revert order of configuration changes for multiple plugins

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info_database.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info_database.cpp
@@ -1586,7 +1586,7 @@ namespace xdp {
     /* If multiple plugins are enabled for the current run, the first plugin has already updated device information
      * in the static data base. So, no need to read the xclbin information again.
      */
-    if (!resetDeviceInfoAndCreatePlDeviceIfRequired(deviceId, xdpDevice, new_xclbin_uuid, device))
+    if (!resetDeviceInfo(deviceId, xdpDevice.get(), new_xclbin_uuid))
       return;
 
     xrt::xclbin xrtXclbin = device->get_xclbin(new_xclbin_uuid);
@@ -1626,7 +1626,7 @@ namespace xdp {
     /* If multiple plugins are enabled for the current run, the first plugin has already updated device information
      * in the static data base. So, no need to read the xclbin information again.
      */
-    if (!resetDeviceInfoAndCreatePlDeviceIfRequired(deviceId, xdpDevice, new_xclbin_uuid, device))
+    if (!resetDeviceInfo(deviceId, xdpDevice.get(), new_xclbin_uuid))
       return;
 
     xrt::xclbin xrtXclbin = device->get_xclbin(new_xclbin_uuid);
@@ -1706,31 +1706,24 @@ namespace xdp {
 
   // Return true if we should reset the device information.
   // Return false if we should not reset device information
-  bool VPStaticDatabase::resetDeviceInfoAndCreatePlDeviceIfRequired(uint64_t deviceId, std::unique_ptr<xdp::Device>& xdpDevice, xrt_core::uuid new_xclbin_uuid, std::shared_ptr<xrt_core::device> device)
+  bool VPStaticDatabase::resetDeviceInfo(uint64_t deviceId, xdp::Device* xdpDevice, xrt_core::uuid new_xclbin_uuid)
   {
-    DeviceInfo *devInfo = nullptr;
-    {
-      std::lock_guard<std::mutex> lock(deviceLock);
-      auto itr = deviceInfo.find(deviceId);
-      if (itr != deviceInfo.end()) {
-        devInfo = itr->second.get();
-      } else {
-        return true;
+    std::lock_guard<std::mutex> lock(deviceLock);
+
+    auto itr = deviceInfo.find(deviceId);
+    if(itr != deviceInfo.end()) {
+      DeviceInfo *devInfo = itr->second.get();
+      ConfigInfo* config = devInfo->currentConfig() ;
+
+      if (config != nullptr && config->containsXclbin(new_xclbin_uuid)) {
+        // Even if we're attempting to load the same xclbin, if we need to
+        // add a PL Device Interface, then we should reset the device info
+        if (config->plDeviceIntf == nullptr && xdpDevice != nullptr)
+          return true;
+
+        return false;
       }
     }
-
-    ConfigInfo* config = devInfo->currentConfig() ;
-    if (config != nullptr && config->containsXclbin(new_xclbin_uuid)) {
-      // Device info already exists and contains this xclbin, no reset needed
-      // But check if we need to create PLDeviceIntf for this plugin
-      if (config->plDeviceIntf == nullptr && xdpDevice != nullptr) {
-        xrt::xclbin xrtXclbin = device->get_xclbin(new_xclbin_uuid);
-        XclbinInfoType xclbinType = getXclbinType(xrtXclbin);
-        createPLDeviceIntf(deviceId, std::move(xdpDevice), xclbinType);
-      }
-      return false;
-    }
-
     return true;
   }
 

--- a/src/runtime_src/xdp/profile/database/static_info_database.h
+++ b/src/runtime_src/xdp/profile/database/static_info_database.h
@@ -124,7 +124,7 @@ namespace xdp {
     void setAppStyle(AppStyle style);
 
     // When loading a new xclbin, should we reset our internal data structures?
-    bool resetDeviceInfoAndCreatePlDeviceIfRequired(uint64_t deviceId, std::unique_ptr<xdp::Device>& xdpDevice, xrt_core::uuid new_xclbin_uuid, std::shared_ptr<xrt_core::device> device);
+    bool resetDeviceInfo(uint64_t deviceId, xdp::Device* xdpDevice, xrt_core::uuid new_xclbin_uuid);
 
     // Functions that create the overall structure of the Xclbin's PL region
     void createComputeUnits(XclbinInfo*, const ip_layout*,const char*,size_t);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Revert order of configuration changes for multiple plugins as on strix when ml_timeline + trace is ran together then trace is not available.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://github.com/Xilinx/XRT/pull/9076
#### How problem was solved, alternative solutions (if any) and why they were rejected
NA
#### Risks (if any) associated the changes in the commit
Low
#### What has been tested and how, request additional testing if necessary
Tested Client single partition design.
Tested VCK190 load_xclbin flow and register xclbin flow design.
Tested independent compilation design for both PLIO and GMIO offload on VCK190.
Tested VE2 compilation.
#### Documentation impact (if any)
NA