### PR TITLE
[2025.1] Updated free cma bo path if handle creation fails in ioctl (#9121)

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/common/zocl_bo.c
+++ b/src/runtime_src/core/edge/drm/zocl/common/zocl_bo.c
@@ -620,7 +620,7 @@ zocl_create_bo_ioctl(struct drm_device *dev, void *data, struct drm_file *filp)
 		    &args->handle);
 		if (ret) {
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
-			drm_gem_dma_object_free(&bo->cma_base.base);
+			zocl_free_cma_bo(&bo->cma_base.base);
 #else
 			drm_gem_cma_free_object(&bo->cma_base.base);
 #endif

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
@@ -261,6 +261,7 @@ int zocl_iommu_unmap_bo(struct drm_device *dev, struct drm_zocl_bo *bo);
 int zocl_init_sysfs(struct device *dev);
 void zocl_fini_sysfs(struct device *dev);
 void zocl_free_sections(struct drm_zocl_dev *dev, struct drm_zocl_slot *slot);
+void zocl_free_cma_bo(struct drm_gem_object *obj);
 void zocl_free_bo(struct drm_gem_object *obj);
 void zocl_drm_free_bo(struct drm_zocl_bo *bo);
 struct drm_gem_object *zocl_gem_create_object(struct drm_device *dev, size_t size);


### PR DESCRIPTION
(cherry picked from commit 664abf16c9033a5456b71d98fb3acf4f114ed820)

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
CMA bo free path if handle creation fails for CMA buffer objects
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
