### PR TITLE
hip: core: module: use proper xrt::elf() constructor

### DIFF
--- a/src/runtime_src/hip/core/module.cpp
+++ b/src/runtime_src/hip/core/module.cpp
@@ -12,9 +12,7 @@ namespace {
 static xrt::elf
 create_elf(void* data, size_t size)
 {
-  std::istringstream stream;
-  stream.rdbuf()->pubsetbuf(static_cast<char*>(data), size);
-  return xrt::elf{stream};
+  return xrt::elf{data, size};
 }
 
 static xrt::uuid


### PR DESCRIPTION
use xrt::elf(const void *data, size_t size) for create_elf(void* data, size_t size) instead of xrt::elf(std::istream& stream) as std::putsetbuf for istringstream() is not directly supported as a standard and portable feature according to
https://stackoverflow.com/questions/1494182/setting-the-internal-buffer-used-by-a-standard-stream-pubsetbuf and this leads to runtime invalid ELF error on Windows: EXEC : [XRT] error : not a valid ELF stream

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
