### PR TITLE
TCT tests conversion to elf and runner format

### DIFF
--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -59,7 +59,6 @@ enum class key_type
   xrt_smi_lists,
   xclbin_name,
   runner,
-  sequence_name,
   elf_name,
   mobilenet,
 
@@ -622,7 +621,13 @@ struct runner : request
     cmd_chain_latency_path,
     cmd_chain_throughput_recipe,
     cmd_chain_throughput_profile,
-    cmd_chain_throughput_path
+    cmd_chain_throughput_path,
+    tct_one_column_recipe,
+    tct_one_column_profile,
+    tct_one_column_path,
+    tct_all_column_recipe,
+    tct_all_column_profile,
+    tct_all_column_path
   };
 
   using result_type = std::string;
@@ -688,45 +693,6 @@ struct xclbin_name : request
 };
 
 /**
- * Used to retrieve the path to the dpu sequence file required for the
- * current device assuming a valid sequence "type" is passed. The shim
- * decides the appropriate path and name to return, absolving XRT of
- * needing to know where to look.
- */
-struct sequence_name : request
-{
-  enum class type {
-    df_bandwidth,
-    tct_one_column,
-    tct_all_column,
-    gemm_int8
-  };
-
-  static std::string
-  enum_to_str(const type& type)
-  {
-    switch (type) {
-      case type::df_bandwidth:
-        return "df_bandwidth";
-      case type::tct_one_column:
-        return "tct_one_column";
-      case type::tct_all_column:
-        return "tct_all_column";
-      case type::gemm_int8:
-        return "gemm_int8";
-    }
-    return "unknown";
-  }
-
-  using result_type = std::string;
-  static const key_type key = key_type::sequence_name;
-  static const char* name() { return "sequence_name"; }
-
-  virtual std::any
-  get(const device*, const std::any& req_type) const override = 0;
-};
-
-/**
  * Used to retrieve the path to the elf file required for the
  * current device assuming a valid elf "type" is passed. The shim
  * decides the appropriate path and name to return, absolving XRT of
@@ -735,11 +701,6 @@ struct sequence_name : request
 struct elf_name : request
 {
   enum class type {
-    df_bandwidth, 
-    tct_one_column, 
-    tct_all_column, 
-    aie_reconfig_overhead,
-    gemm_int8, 
     nop,
     preemption_noop_4x4,
     preemption_noop_4x8,
@@ -752,16 +713,6 @@ struct elf_name : request
   enum_to_str(const type& type)
   {
     switch (type) {
-      case type::df_bandwidth:
-        return "df_bandwidth";
-      case type::tct_one_column:
-        return "tct_one_column";
-      case type::tct_all_column:
-        return "tct_all_column";
-      case type::aie_reconfig_overhead:
-        return "aie_reconfig_overhead";
-      case type::gemm_int8:
-        return "gemm_int8";
       case type::nop:
         return "nop";
       case type::preemption_noop_4x4:

--- a/src/runtime_src/core/tools/common/tests/TestAIEReconfigOverhead.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestAIEReconfigOverhead.cpp
@@ -36,7 +36,7 @@ TestAIEReconfigOverhead::run(std::shared_ptr<xrt_core::device> dev)
     auto report = json::parse(runner.get_report());
     auto elapsed = report["cpu"]["elapsed"].get<double>();
 
-    runner = xrt_core::runner(xrt::device(dev), recipe_noop_path, profile_path);
+    runner = xrt_core::runner(xrt::device(dev), recipe_noop_path, profile_path, std::filesystem::path(test_path));
 
     //Run 2
     runner.execute();

--- a/src/runtime_src/core/tools/common/tests/TestTCTAllColumn.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestTCTAllColumn.cpp
@@ -6,18 +6,16 @@
 #include "TestTCTAllColumn.h"
 #include "TestValidateUtilities.h"
 #include "tools/common/XBUtilities.h"
-#include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
-#include "xrt/xrt_kernel.h"
-namespace XBU = XBUtilities;
+#include "core/common/runner/runner.h"
+#include "core/common/json/nlohmann/json.hpp"
 
 // System - Include Files
-#include <fstream>
 #include <filesystem>
 
-static constexpr size_t buffer_size = 4;
-static constexpr size_t word_count = buffer_size/4;
-static constexpr int itr_count = 20000;
+using json = nlohmann::json;
+namespace XBU = XBUtilities;
+
 static constexpr int run_count = 100;
 
 // ----- C L A S S   M E T H O D S -------------------------------------------
@@ -29,166 +27,39 @@ boost::property_tree::ptree
 TestTCTAllColumn::run(std::shared_ptr<xrt_core::device> dev)
 {
   boost::property_tree::ptree ptree = get_test_header();
-  ptree.erase("xclbin");
+  std::string recipe = xrt_core::device_query<xrt_core::query::runner>(dev, xrt_core::query::runner::type::tct_all_column_recipe);
+  std::string profile = xrt_core::device_query<xrt_core::query::runner>(dev, xrt_core::query::runner::type::tct_all_column_profile);
+  std::string test = xrt_core::device_query<xrt_core::query::runner>(dev, xrt_core::query::runner::type::tct_all_column_path);
+  auto recipe_path = XBValidateUtils::findPlatformFile(recipe, ptree);
+  auto profile_path = XBValidateUtils::findPlatformFile(profile, ptree);
+  auto test_path = XBValidateUtils::findPlatformFile(test, ptree);
 
-  auto elf = XBValidateUtils::get_elf();
-  std::string xclbin_path; 
-  
-  if (!elf) {
-    xclbin_path = XBValidateUtils::get_xclbin_path(dev, xrt_core::query::xclbin_name::type::validate, ptree);
-    if (XBU::getVerbose())
-      XBValidateUtils::logger(ptree, "Details", "Using DPU Sequence");
-  } else {
-    xclbin_path = XBValidateUtils::get_xclbin_path(dev, xrt_core::query::xclbin_name::type::validate_elf, ptree);
-    if (XBU::getVerbose())
-      XBValidateUtils::logger(ptree, "Details", "Using ELF");
-  }
-
-  if (!std::filesystem::exists(xclbin_path)){
-    XBValidateUtils::logger(ptree, "Details", "The test is not supported on this device.");
-    return ptree;
-  }
-
-  xrt::xclbin xclbin;
-  try {
-    xclbin = xrt::xclbin(xclbin_path);
-  }
-  catch (const std::runtime_error& ex) {
-    XBValidateUtils::logger(ptree, "Error", ex.what());
-    ptree.put("status", XBValidateUtils::test_token_failed);
-    return ptree;
-  }
-
-  // Determine The DPU Kernel Name
-  auto kernelName = XBValidateUtils::get_kernel_name(xclbin, ptree);
-
-  auto working_dev = xrt::device(dev);
-  working_dev.register_xclbin(xclbin);
-
-  size_t instr_size = 0;
-  std::string dpu_instr;
-
-  xrt::hw_context hwctx;
-  xrt::kernel kernel;
-
-  if (!elf) { // DPU
-    try {
-      hwctx = xrt::hw_context(working_dev, xclbin.get_uuid());
-      kernel = xrt::kernel(hwctx, kernelName);
-    }
-    catch (const std::exception& )
-    {
-      XBValidateUtils::logger (ptree, "Error", "Not enough columns available. Please make sure no other workload is running on the device.");
-      ptree.put("status", XBValidateUtils::test_token_failed);
-      return ptree;
-    }
-
-    const auto seq_name = xrt_core::device_query<xrt_core::query::sequence_name>(dev, xrt_core::query::sequence_name::type::tct_one_column);
-    dpu_instr = XBValidateUtils::findPlatformFile(seq_name, ptree);
-    if (!std::filesystem::exists(dpu_instr))
-      return ptree;
-
-    try {
-      instr_size = XBValidateUtils::get_instr_size(dpu_instr); 
-    }
-    catch(const std::exception& ex) {
-      XBValidateUtils::logger(ptree, "Error", ex.what());
-      ptree.put("status", XBValidateUtils::test_token_failed);
-      return ptree;
-    }
-  }
-  else { // ELF
-    const auto elf_name = xrt_core::device_query<xrt_core::query::elf_name>(dev, xrt_core::query::elf_name::type::tct_all_column);
-    auto elf_path = XBValidateUtils::findPlatformFile(elf_name, ptree);
+  try
+  {
+    // Create runner once 
+    xrt_core::runner runner(xrt::device(dev), recipe_path, profile_path, std::filesystem::path(test_path));
     
-    if (!std::filesystem::exists(elf_path))
-      return ptree;
-  
-    try {
-      hwctx = xrt::hw_context(working_dev, xclbin.get_uuid());
-      kernel = get_kernel(hwctx, kernelName, elf_path);
-    } 
-    catch (const std::exception& )
-    {
-      XBValidateUtils::logger (ptree, "Error", "Not enough columns available. Please make sure no other workload is running on the device.");
-      ptree.put("status", XBValidateUtils::test_token_failed);
-      return ptree;
-    }
-  }
-
-  //Create BOs
-  xrt::bo bo_ifm, bo_ofm, bo_instr; 
-  if (!elf) {
-    bo_ifm = xrt::bo(working_dev, buffer_size, XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(1));
-    bo_ofm = xrt::bo(working_dev, 4*buffer_size, XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(3));
-    bo_instr = xrt::bo(working_dev, instr_size*sizeof(int), XCL_BO_FLAGS_CACHEABLE, kernel.group_id(5));
-    XBValidateUtils::init_instr_buf(bo_instr, dpu_instr);
-  }
-  else {
-    bo_ifm = xrt::ext::bo{working_dev, buffer_size};
-    bo_ofm = xrt::ext::bo{working_dev, buffer_size};
-  }
-
-  // map input buffer
-  auto ifm_mapped = bo_ifm.map<int*>();
-	for (size_t i = 0; i < word_count; i++)
-		ifm_mapped[i] = rand() % 4096;
-
-  //Sync BOs
-  bo_ifm.sync(XCL_BO_SYNC_BO_TO_DEVICE);
-  if (!elf) { 
-    bo_instr.sync(XCL_BO_SYNC_BO_TO_DEVICE); 
-  }
-
-  //Log
-  if(XBU::getVerbose()) {
-    XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Buffer size: %f bytes") % buffer_size));
-    XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("No. of iterations: %f") % itr_count));
-  }
-
-  double latency = 0.0;
-  double throughput = 0.0;
-  for (int run_num = 0; run_num < run_count; run_num++) {
-    auto start = std::chrono::high_resolution_clock::now();
-    try {
-      xrt::run run;
-      if (!elf) {
-        run = kernel(XBValidateUtils::get_opcode(), bo_ifm, NULL, bo_ofm, NULL, bo_instr, instr_size, NULL);
-      } else {
-        run = kernel(XBValidateUtils::get_opcode(), 0, 0, bo_ifm, 0, bo_ofm, 0, 0);
-      }
-      
-      // Wait for kernel to be done
-      run.wait2();
-    }
-    catch (const std::exception& ex) {
-      XBValidateUtils::logger(ptree, "Error", ex.what());
-      ptree.put("status", XBValidateUtils::test_token_failed);
-      return ptree;
-    }
-    auto end = std::chrono::high_resolution_clock::now();
-
-    //map ouput buffer
-    bo_ofm.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
-    auto ofm_mapped = bo_ofm.map<int*>();
-    for (size_t i = 0; i < word_count; i++) {
-      if (ofm_mapped[i] != ifm_mapped[i]) {
-        auto msg = boost::str(boost::format("Data mismatch at out buffer[%d]") % i);
-        XBValidateUtils::logger(ptree, "Error", msg);
-        return ptree;
-      }
+    // Run the execution run_count times 
+    for (int run_num = 0; run_num < run_count; run_num++) {
+      runner.execute();
+      runner.wait();
     }
 
-    //Calculate throughput
-    auto elapsedSecs = std::chrono::duration_cast<std::chrono::duration<double>>(end-start).count();
-    throughput = itr_count / elapsedSecs;
-    latency = (elapsedSecs / itr_count) * 1000000; // NOLINT convert s to us
+    // Get final metrics from the last run 
+    auto report = json::parse(runner.get_report());
+    double latency = report["cpu"]["latency"].get<double>(); // Should be in microseconds
+    double throughput = report["cpu"]["throughput"].get<double>(); // Should be in operations/second
+
+    if(XBU::getVerbose())
+      XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Average time for TCT (all columns): %.1f us") % latency));
+    
+    XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Average TCT throughput (all columns): %.1f TCT/s") % throughput));
+    ptree.put("status", XBValidateUtils::test_token_passed);
   }
-
-  if(XBU::getVerbose())
-    XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Average time for TCT: %.1f us") % latency));
-  XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Average TCT throughput: %.1f TCT/s") % throughput));
-  ptree.put("status", XBValidateUtils::test_token_passed);
-
+  catch(const std::exception& e)
+  {
+    XBValidateUtils::logger(ptree, "Error", e.what());
+    ptree.put("status", XBValidateUtils::test_token_failed);
+  }
   return ptree;
 }

--- a/src/runtime_src/core/tools/common/tests/TestTCTAllColumn.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestTCTAllColumn.cpp
@@ -26,7 +26,7 @@ namespace XBU = XBUtilities;
 
 //Number of Sample Tokens to measure the throughtput. 
 //This is an assumption coming from elf code running on the device.
-static constexpr int samples = 10000;
+static constexpr int samples = 20000;
 
 // ----- C L A S S   M E T H O D S -------------------------------------------
 TestTCTAllColumn::TestTCTAllColumn()

--- a/src/runtime_src/core/tools/common/tests/TestTCTOneColumn.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestTCTOneColumn.cpp
@@ -6,18 +6,16 @@
 #include "TestTCTOneColumn.h"
 #include "TestValidateUtilities.h"
 #include "tools/common/XBUtilities.h"
-#include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
-#include "xrt/xrt_kernel.h"
-namespace XBU = XBUtilities;
+#include "core/common/runner/runner.h"
+#include "core/common/json/nlohmann/json.hpp"
 
 // System - Include Files
-#include <fstream>
 #include <filesystem>
 
-static constexpr size_t buffer_size = 4;
-static constexpr size_t word_count = buffer_size/4;
-static constexpr int itr_count = 10000;
+using json = nlohmann::json;
+namespace XBU = XBUtilities;
+
 static constexpr int run_count = 100;
 
 // ----- C L A S S   M E T H O D S -------------------------------------------
@@ -29,163 +27,40 @@ boost::property_tree::ptree
 TestTCTOneColumn::run(std::shared_ptr<xrt_core::device> dev)
 {
   boost::property_tree::ptree ptree = get_test_header();
-  ptree.erase("xclbin");
+  std::string recipe = xrt_core::device_query<xrt_core::query::runner>(dev, xrt_core::query::runner::type::tct_one_column_recipe);
+  std::string profile = xrt_core::device_query<xrt_core::query::runner>(dev, xrt_core::query::runner::type::tct_one_column_profile);
+  std::string test = xrt_core::device_query<xrt_core::query::runner>(dev, xrt_core::query::runner::type::tct_one_column_path);
+  auto recipe_path = XBValidateUtils::findPlatformFile(recipe, ptree);
+  auto profile_path = XBValidateUtils::findPlatformFile(profile, ptree);
+  auto test_path = XBValidateUtils::findPlatformFile(test, ptree);
 
-  auto elf = XBValidateUtils::get_elf();
-  std::string xclbin_path; 
-  
-  if (!elf) {
-    xclbin_path = XBValidateUtils::get_xclbin_path(dev, xrt_core::query::xclbin_name::type::validate, ptree);
-    if (XBU::getVerbose())
-      XBValidateUtils::logger(ptree, "Details", "Using DPU Sequence");
-  } else {
-    xclbin_path = XBValidateUtils::get_xclbin_path(dev, xrt_core::query::xclbin_name::type::validate_elf, ptree);
-    if (XBU::getVerbose())
-      XBValidateUtils::logger(ptree, "Details", "Using ELF");
-  }
-
-  if (!std::filesystem::exists(xclbin_path)){
-    XBValidateUtils::logger(ptree, "Details", "The test is not supported on this device.");
-    return ptree;
-  }
-
-  xrt::xclbin xclbin;
-  try {
-    xclbin = xrt::xclbin(xclbin_path);
-  }
-  catch (const std::runtime_error& ex) {
-    XBValidateUtils::logger(ptree, "Error", ex.what());
-    ptree.put("status", XBValidateUtils::test_token_failed);
-    return ptree;
-  }
-
-  // Determine The DPU Kernel Name
-  auto kernelName = XBValidateUtils::get_kernel_name(xclbin, ptree);
-
-  auto working_dev = xrt::device(dev);
-  working_dev.register_xclbin(xclbin);
-
-  size_t instr_size = 0;
-  std::string dpu_instr;
-
-  xrt::hw_context hwctx;
-  xrt::kernel kernel;
-  
-  if (!elf) { // DPU
-    try {
-      hwctx = xrt::hw_context(working_dev, xclbin.get_uuid());
-      kernel = xrt::kernel(hwctx, kernelName);
-    }
-    catch (const std::exception& )
-    {
-      XBValidateUtils::logger (ptree, "Error", "Not enough columns available. Please make sure no other workload is running on the device.");
-      ptree.put("status", XBValidateUtils::test_token_failed);
-      return ptree;
-    }
-    const auto seq_name = xrt_core::device_query<xrt_core::query::sequence_name>(dev, xrt_core::query::sequence_name::type::tct_one_column);
-    dpu_instr = XBValidateUtils::findPlatformFile(seq_name, ptree);
-    if (!std::filesystem::exists(dpu_instr))
-      return ptree;
-
-    try {
-      instr_size = XBValidateUtils::get_instr_size(dpu_instr); 
-    }
-    catch(const std::exception& ex) {
-      XBValidateUtils::logger(ptree, "Error", ex.what());
-      ptree.put("status", XBValidateUtils::test_token_failed);
-      return ptree;
-    }
-  }
-  else { // ELF
-    const auto elf_name = xrt_core::device_query<xrt_core::query::elf_name>(dev, xrt_core::query::elf_name::type::tct_one_column);
-    auto elf_path = XBValidateUtils::findPlatformFile(elf_name, ptree);
+  try
+  {
+    // Create runner once 
+    xrt_core::runner runner(xrt::device(dev), recipe_path, profile_path, std::filesystem::path(test_path));
     
-    if (!std::filesystem::exists(elf_path))
-      return ptree;
-  
-    try {
-      hwctx = xrt::hw_context(working_dev, xclbin.get_uuid());
-      kernel = get_kernel(hwctx, kernelName, elf_path);
-    } 
-    catch (const std::exception& )
-    {
-      XBValidateUtils::logger (ptree, "Error", "Not enough columns available. Please make sure no other workload is running on the device.");
-      ptree.put("status", XBValidateUtils::test_token_failed);
-      return ptree;
-    }
-  }
-
-  //Create BOs
-  xrt::bo bo_ifm, bo_ofm, bo_instr; 
-  if (!elf) {
-    bo_ifm = xrt::bo(working_dev, buffer_size, XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(1));
-    bo_ofm = xrt::bo(working_dev, 4*buffer_size, XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(3));
-    bo_instr = xrt::bo(working_dev, instr_size*sizeof(int), XCL_BO_FLAGS_CACHEABLE, kernel.group_id(5));
-    XBValidateUtils::init_instr_buf(bo_instr, dpu_instr);
-  }
-  else {
-    bo_ifm = xrt::ext::bo{working_dev, buffer_size};
-    bo_ofm = xrt::ext::bo{working_dev, buffer_size};
-  }
-  
-  // map input buffer
-  auto ifm_mapped = bo_ifm.map<int*>();
-	for (size_t i = 0; i < word_count; i++)
-		ifm_mapped[i] = rand() % 4096;
-
-  //Sync BOs
-  bo_ifm.sync(XCL_BO_SYNC_BO_TO_DEVICE);
-  if (!elf) { 
-    bo_instr.sync(XCL_BO_SYNC_BO_TO_DEVICE); 
-  }
-  //Log
-  if(XBU::getVerbose()) {
-    XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Buffer size: %f bytes") % buffer_size));
-    XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("No. of iterations: %f") % itr_count));
-  }
-  double latency = 0.0;
-  double throughput = 0.0;
-  for (int run_num = 0; run_num < run_count; run_num++) {
-    auto start = std::chrono::high_resolution_clock::now();
-    try {
-      xrt::run run;
-      if (!elf) {
-        run = kernel(XBValidateUtils::get_opcode(), bo_ifm, NULL, bo_ofm, NULL, bo_instr, instr_size, NULL);
-      } else {
-        run = kernel(XBValidateUtils::get_opcode(), 0, 0, bo_ifm, 0, bo_ofm, 0, 0);
-      }
-      
-      // Wait for kernel to be done
-      run.wait2();
-    }
-    catch (const std::exception& ex) {
-      XBValidateUtils::logger(ptree, "Error", ex.what());
-      ptree.put("status", XBValidateUtils::test_token_failed);
-      return ptree;
-    }
-    auto end = std::chrono::high_resolution_clock::now();
-
-    //map ouput buffer
-    bo_ofm.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
-    auto ofm_mapped = bo_ofm.map<int*>();
-    for (size_t i = 0; i < word_count; i++) {
-      if (ofm_mapped[i] != ifm_mapped[i]) {
-        auto msg = boost::str(boost::format("Data mismatch at out buffer[%d]") % i);
-        XBValidateUtils::logger(ptree, "Error", msg);
-        return ptree;
-      }
+    // Run the execution run_count times 
+    for (int run_num = 0; run_num < run_count; run_num++) {
+      runner.execute();
+      runner.wait();
     }
 
-    //Calculate throughput
-    auto elapsedSecs = std::chrono::duration_cast<std::chrono::duration<double>>(end-start).count();
-    throughput = itr_count / elapsedSecs;
-    latency = (elapsedSecs / itr_count) * 1000000; // NOLINT convert s to us
-  }
+    // Get final metrics from the last run 
+    auto report = json::parse(runner.get_report());
+    double latency = report["cpu"]["latency"].get<double>(); // Should be in microseconds
+    double throughput = report["cpu"]["throughput"].get<double>(); // Should be in operations/second
 
-  if(XBU::getVerbose())
-    XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Average time for TCT: %.1f us") % latency));
-  XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Average TCT throughput: %.1f TCT/s") % throughput));
-  ptree.put("status", XBValidateUtils::test_token_passed);
+    if(XBU::getVerbose())
+      XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Average time for TCT: %.1f us") % latency));
+    
+    XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Average TCT throughput: %.1f TCT/s") % throughput));
+    ptree.put("status", XBValidateUtils::test_token_passed);
+  }
+  catch(const std::exception& e)
+  {
+    XBValidateUtils::logger(ptree, "Error", e.what());
+    ptree.put("status", XBValidateUtils::test_token_failed);
+  }
 
   return ptree;
 }

--- a/src/runtime_src/core/tools/common/tests/TestTCTOneColumn.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestTCTOneColumn.cpp
@@ -16,7 +16,16 @@
 using json = nlohmann::json;
 namespace XBU = XBUtilities;
 
-static constexpr int run_count = 100;
+/* This host application measures the average TCT latency and TCT throughput 
+ * for one columns tests.
+ * The ELF code loopbacks the small chunk of input data from DDR through 
+ * a AIE MM2S Shim DMA channel back to DDR through a S2MM Shim DMA channel.
+ * TCT is used for dma transfer completion. Host app measures the time for
+ * predefined number of Tokens and calculate the latency and throughput.
+ */
+
+//This is an assumption coming from elf code running on the device.
+static constexpr int samples = 10000;
 
 // ----- C L A S S   M E T H O D S -------------------------------------------
 TestTCTOneColumn::TestTCTOneColumn()
@@ -39,11 +48,8 @@ TestTCTOneColumn::run(std::shared_ptr<xrt_core::device> dev)
     // Create runner once 
     xrt_core::runner runner(xrt::device(dev), recipe_path, profile_path, std::filesystem::path(test_path));
     
-    // Run the execution run_count times 
-    for (int run_num = 0; run_num < run_count; run_num++) {
-      runner.execute();
-      runner.wait();
-    }
+    runner.execute();
+    runner.wait();
 
     // Get final metrics from the last run 
     auto report = json::parse(runner.get_report());
@@ -51,9 +57,9 @@ TestTCTOneColumn::run(std::shared_ptr<xrt_core::device> dev)
     double throughput = report["cpu"]["throughput"].get<double>(); // Should be in operations/second
 
     if(XBU::getVerbose())
-      XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Average time for TCT: %.1f us") % latency));
-    
-    XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Average TCT throughput: %.1f TCT/s") % throughput));
+      XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Average time for TCT: %.1f us") % (latency / samples)));
+
+    XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Average TCT throughput: %.1f TCT/s") % (samples * throughput)));
     ptree.put("status", XBValidateUtils::test_token_passed);
   }
   catch(const std::exception& e)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
This PR moved the TCT tests to elf/runner based flow and remove DPU sequence struct since its not used anymore.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
N/A

#### How problem was solved, alternative solutions (if any) and why they were rejected
Following are the updated TCT number after this change : 
```
Validate Device           : [0000:c5:00.1]
    Platform              : NPU Strix
    Power Mode            : Default
-------------------------------------------------------------------------------
Test 1 [0000:c5:00.1]     : tct-all-col                                         
    Details               : Average TCT throughput (all columns): 1160000.0 TCT/s
    Test Status           : [PASSED]
```

Before : 
```
Validate Device           : [0000:c5:00.1]
    Platform              : NPU Strix
    Power Mode            : Default
-------------------------------------------------------------------------------
Test 1 [0000:c5:00.1]     : tct-all-col                                         
    Details               : Average TCT throughput: 1121611.7 TCT/s
    Test Status           : [PASSED]
```
The updated code also removes the run_count hard-coding since that did not fix the high variability issue. This test should run kernels for multiple iteration, which will be controlled from profile section of the run recipe itself (controlled by the each driver) similar to how we do for latency and throughput tests.

#### Risks (if any) associated the changes in the commit
NA

#### What has been tested and how, request additional testing if necessary
Tested on Linux strix

#### Documentation impact (if any)
NA
