### PR TITLE
AIESW-5531 Allow mmap shim error through xrt-smi examine

### DIFF
--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -365,7 +365,10 @@ XBUtilities::collect_devices( const std::set<std::string> &_deviceBDFs,
     for(xrt_core::device::id_type index = 0; index < total; ++index) {
       try {
         _deviceCollection.push_back(get_device_internal(index, _inUserDomain));
-      } catch (...) {
+      } catch (const std::runtime_error& e) {
+        if (boost::icontains(e.what(), "mmap"))
+          throw std::runtime_error(e.what());
+      }  catch (...) {
         /* If the device is not available, quietly ignore it
            Use case: when a device is being reset in parallel */
       }


### PR DESCRIPTION
#### Problem solved by the commit
https://jira.xilinx.com/browse/AIESW-5531
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Discovered while testing, noticed "No devices" when in actuality there was a memlock ulimit issue
#### How problem was solved, alternative solutions (if any) and why they were rejected
Allowed mmap error through previously caught exception.
#### Risks (if any) associated the changes in the commit
N/A
#### What has been tested and how, request additional testing if necessary
Tested on Linux STX:
```
> xrt-smi examine
XRT build version: 2.20.0
Build hash: 15429831f51c5b7b4cedcab7f46528aca1c90cc4
Build date: 2025-08-06 14:15:06
Git branch: HEAD
PID: 2749330
UID: ---
[Wed Aug  6 21:20:04 2025 GMT]
HOST: ---
EXE: /opt/xilinx/xrt/bin/unwrapped/xrt-smi
[xrt-smi] ERROR: mmap(addr=0x793258000000, len=67108864, prot=3, flags=8209, offset=4362100736) failed (err=-11): Resource temporarily unavailable
```
#### Documentation impact (if any)
N/A