### PR TITLE
Add custom kernel name demangler

### DIFF
--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -476,8 +476,13 @@ demangle(const std::string& mangled)
   idx += len;
   std::vector<std::string> args;
 
+  // Parse the argument types from the mangled name
+  // Each argument can have multiple 'P' prefixes indicating pointer depth
+  // followed by a single character representing the base type
   while (idx < mangled.size()) {
     int pointer_depth = 0;
+    // Count pointer depth (number of 'P' characters indicating pointer levels)
+    // For example: "P" = 1 level (char*), "PP" = 2 levels (char**), etc.
     while (idx < mangled.size() && mangled[idx] == 'P') {
       ++pointer_depth;
       ++idx;


### PR DESCRIPTION
#### Problem solved by the commit
XRT was separate demangler APIs for Linux (GCC API) and Windows (UnDecorateSymbolName) while AIEBU has mangling implementation similar to the one on Linux.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
N/A

#### How problem was solved, alternative solutions (if any) and why they were rejected
1. Add custom demangler in XRT common for both Linux and Windows platforms which matches the mangler in AIEBU.
2. Currently, it supports only argument types char, void and int like AIEBU.
3. The demangler is similar to the Itanium ABI style: `_Z<length><name><types>`
 
> -   length : number of characters in the name string.
> -   name : kernel name in string
> -   types : kernel argument data type as below.
>      -  'c' represents the arg is a char.
>      -  'v' represents the arg is a void.
>      -  'i' represents the arg is an int.
>      -  'P' represents the arg is a pointer. Hence, "Pc" = char*, "Pv" = void*,  "Pi" = int*

5. Will be adding support for uint32_t and uint64_t later.

#### Risks (if any) associated the changes in the commit
1. Break existing demangling on Linux

#### What has been tested and how, request additional testing if necessary
1> Successfully ran End to end test on aie4 on Windows and Linux as given below. (It also prints the mangled and demangled name)

**1. Test on aie4 Windows with 3 args-**

> starting vadd thread number: 0
====== 0: vadd started =====
15820: Closing adapter 00000000400000405983770: -> mcdm::device::device(0x40000000)
6805810: hw_type is 5, is_iommu_disabled = 0
6840330: <- mcdm::device::device() this(0x23006370860) handle(0x40000080) adapter(0x40000000)
...
Mangled  name: _Z3DPUPcPcPc
Demangled kname: DPU(char*, char*, char*)
...
19298676990: <- mcdm::device::device()
====== 0: vadd passed  =====


**2. Test onaie4 Linux with 3 args**

> root@qemuvm:~# ./advanaik/bins/bin/xrt_test 0
====== 0: npu3 xrt vadd started =====
837: PID(982): Created pcidev (0000:02:00.4)
...
mangled kname :_Z3DPUPcPcPc
demangled kname :DPU(char*, char*, char*)
...
19087159717: PID(982): Closed 3
====== 0: npu3 xrt vadd PASSED  =====


**3. Test onaie4 Linux with no arg**

> ====== 1: npu3 xrt move memtiles started =====
688: PID(989): Created pcidev (0000:02:00.4)
...
mangled kname :_Z3DPU
demangled kname :DPU()
...
7751058106: PID(989): Closed 3
====== 1: npu3 xrt move memtiles PASSED  =====

**4. Test on aie2p Windows** 

> [INFO] Host test code is created device object
> [INFO] ===== Thread 0 Start =====
> Host test will create kernel: DPU:dpu
> Host code is creating hw_context...
> ----------- mangled name: _Z3DPUPcPcPcPcPc
> ----------- Demangled name: DPU(char*, char*, char*, char*, char*)
> ...
> Thread 0, Iteration 0 Finished
> ===== Thread 0 Finished  =====

**5. Test on aie2p Linux**

> _Z3DPUPcPcPcPcPc
> DPU(char*, char*, char*, char*, char*)


#### Documentation impact (if any)
N/A