### PR TITLE
[CR-1246433] XRT_XRT flag is excluded during embedded builds

### DIFF
--- a/src/CMake/components.cmake
+++ b/src/CMake/components.cmake
@@ -5,7 +5,7 @@
 # by parent CMake: LINUX_FLAVOR
 
 # The default XRT build is legacy
-if (NOT XRT_BASE AND NOT XRT_NPU AND NOT XRT_ALVEO)
+if (NOT XRT_BASE AND NOT XRT_NPU AND NOT XRT_ALVEO AND NOT XRT_EDGE)
   message("-- Defaulting to legacy XRT build")
   set(XRT_XRT 1)
 endif()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1246433 The xrt-dev and opencl-headers-dev packages are both trying to install the same file (/usr/include/CL/cl_ext.h), which is causing the transaction to fail.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Modified if loop to exclude XRT_XRT flag durign embedded builds

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Tested by running vadd on Zynq MP in hw_emu after building and installing the XRT packages

#### Documentation impact (if any)
