### PR TITLE
Indexed based CMA allocation changes with cacheable/non-cacheable support

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/common/zocl_drv.c
+++ b/src/runtime_src/core/edge/drm/zocl/common/zocl_drv.c
@@ -624,10 +624,16 @@ void zocl_free_cma_bo(struct drm_gem_object *obj)
 		mem_dev = zdev->mem_regions[zocl_obj->mem_region].dev;
 	else
 		mem_dev = zdev->ddev->dev;
+
 	if (zocl_obj->vaddr && mem_dev) {
-		dma_free_coherent(mem_dev, zocl_obj->size, zocl_obj->vaddr, zocl_obj->phys);
+		if (zocl_obj->flags & ZOCL_BO_FLAGS_CACHEABLE)
+			dma_free_wc(mem_dev, zocl_obj->size, zocl_obj->vaddr, zocl_obj->phys);
+		else
+			dma_free_coherent(mem_dev, zocl_obj->size, zocl_obj->vaddr, zocl_obj->phys);
+
 		zocl_obj->vaddr = NULL;
 	}
+
 	drm_gem_object_release(obj);
 	kfree(zocl_obj);
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
1. Indexed based CMA bo allocation.
2. cacheable/non-cacheable CMA bo allocation
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
It's not a Bug but a new feature to allocate CMA buffer object from a specific CMA memory region of cacheable/non-cacheable support.
#### How problem was solved, alternative solutions (if any) and why they were rejected
Problem was solved by allocating memory from a specific CMA memory region. If user provides invalid cma memory region, the driver will allocate bo from the default CMA.
For CMA bo, if user doesn't specify about the type by default non-cacheable CMA buffer object will be created.
#### Risks (if any) associated the changes in the commit
n/a
#### What has been tested and how, request additional testing if necessary
Tested on some edge testcases.
Also tested:
1. allocation from specific cma regions by index by updating the dtb
2. bo allocation from specific cma region with cacheable/non-cacheable type
#### Documentation impact (if any)
n/a