### PR TITLE
HIP changes to support full ELF flow

### DIFF
--- a/src/runtime_src/hip/api/CMakeLists.txt
+++ b/src/runtime_src/hip/api/CMakeLists.txt
@@ -14,4 +14,5 @@ target_include_directories(hip_api_library_objects
   PRIVATE
   ${XRT_SOURCE_DIR}/runtime_src
   ${HIP_INCLUDE_DIRS}
+  ${XRT_SOURCE_DIR}/runtime_src/core/common/elf
   )

--- a/src/runtime_src/hip/api/hip_module.cpp
+++ b/src/runtime_src/hip/api/hip_module.cpp
@@ -7,6 +7,8 @@
 #include "hip/core/stream.h"
 #include "hip/xrt_hip.h"
 
+#include <elfio/elfio.hpp>
+
 namespace xrt::core::hip {
 
 static void
@@ -21,12 +23,21 @@ hip_module_launch_kernel(hipFunction_t f, uint32_t /*gridDimX*/, uint32_t /*grid
   auto hip_mod = module_cache.get(static_cast<function*>(func_hdl)->get_module());
   throw_invalid_resource_if(!hip_mod, "module associated with function is unloaded");
 
-  // function store module handle of xclbin
-  auto hip_xclbin_mod = std::dynamic_pointer_cast<module_xclbin>(hip_mod);
-  throw_invalid_resource_if(!hip_xclbin_mod, "getting hip module using dynamic pointer cast failed");
+  std::shared_ptr<function> hip_func;
+  if (hip_mod->is_full_elf_module()) {
+    auto hip_elf_mod = std::dynamic_pointer_cast<module_full_elf>(hip_mod);
+    throw_invalid_resource_if(!hip_elf_mod, "getting hip module using dynamic pointer cast failed");
 
-  auto hip_func = hip_xclbin_mod->get_function(func_hdl);
-  throw_invalid_resource_if(!hip_func, "invalid function passed");
+    hip_func = hip_elf_mod->get_function(func_hdl);
+    throw_invalid_resource_if(!hip_func, "invalid function passed");
+  }
+  else {
+    auto hip_xclbin_mod = std::dynamic_pointer_cast<module_xclbin>(hip_mod);
+    throw_invalid_resource_if(!hip_xclbin_mod, "getting hip module using dynamic pointer cast failed");
+
+    hip_func = hip_xclbin_mod->get_function(func_hdl);
+    throw_invalid_resource_if(!hip_func, "invalid function passed");
+  }
 
   // All the RyzenAI kernels run only once, so ignoring grid and block dimensions
   // Revisit if we need to launch multiple times
@@ -49,18 +60,30 @@ hip_module_get_function(hipModule_t hmod, const char* name)
   auto mod_hdl = reinterpret_cast<module_handle>(hmod);
   auto hip_mod = module_cache.get(mod_hdl);
   throw_invalid_resource_if(!hip_mod, "module not available");
-  // module handle passed should be elf module handle
-  throw_invalid_resource_if(hip_mod->is_xclbin_module(), "invalid module handle passed");
 
-  auto hip_elf_mod = std::dynamic_pointer_cast<module_elf>(hip_mod);
-  throw_invalid_resource_if(!hip_elf_mod, "getting hip module using dynamic pointer cast failed");
+  if (hip_mod->is_full_elf_module()) {
+    // module handle passed is created with full ELF
+    auto hip_elf_mod = std::dynamic_pointer_cast<module_full_elf>(hip_mod);
+    throw_invalid_resource_if(!hip_elf_mod, "getting hip module using dynamic pointer cast failed");
+    throw_invalid_resource_if(!module_cache.count(hip_elf_mod.get()), "module not available");
 
-  // Get xclbin module corresponding to this elf module
-  auto module_xclbin = hip_elf_mod->get_xclbin_module();
-  throw_invalid_resource_if(!module_cache.count(module_xclbin), "module not available");
+    // create function obj and store in map maintained by fill elf module
+    return hip_elf_mod->add_function(std::make_shared<function>(hip_elf_mod.get(), std::string(name)));
+  }
+  else {
+    // module handle should not be xclbin module
+    throw_invalid_resource_if(hip_mod->is_xclbin_module(), "invalid module handle passed");
 
-  // create function obj and store in map maintained by xclbin module
-  return module_xclbin->add_function(std::make_shared<function>(module_xclbin, hip_elf_mod->get_xrt_module(), std::string(name)));
+    auto hip_elf_mod = std::dynamic_pointer_cast<module_elf>(hip_mod);
+    throw_invalid_resource_if(!hip_elf_mod, "getting hip module using dynamic pointer cast failed");
+
+    // Get xclbin module corresponding to this elf module
+    auto module_xclbin = hip_elf_mod->get_xclbin_module();
+    throw_invalid_resource_if(!module_cache.count(module_xclbin), "module not available");
+
+    // create function obj and store in map maintained by xclbin module
+    return module_xclbin->add_function(std::make_shared<function>(module_xclbin, hip_elf_mod->get_xrt_module(), std::string(name)));
+  }
 }
 
 static module_handle
@@ -107,6 +130,49 @@ create_module(const hipModuleData* config)
     return insert_in_map(module_cache, std::make_shared<module_elf>(hip_xclbin_mod.get(), config->data, config->size));
   }
   throw xrt_core::system_error(hipErrorInvalidValue, "invalid module data type passed");
+}
+
+
+// Function that estimates ELF size from header
+static size_t
+estimate_elf_size(const void* data)
+{
+  auto bytes = static_cast<const unsigned char*>(data);
+  if (bytes[0] != 0x7f || bytes[1] != 'E' || bytes[2] != 'L' || bytes[3] != 'F')
+    throw std::runtime_error("Invalid ELF magic number");
+
+  if (bytes[4] == ELFIO::ELFCLASS32) {
+    // 32 bit ELF
+    auto header = static_cast<const ELFIO::Elf32_Ehdr*>(data);
+    return std::max(header->e_shoff + header->e_shentsize * header->e_shnum,
+                    header->e_phoff + header->e_phentsize * header->e_phnum);
+  }
+  else if (bytes[4] == ELFIO::ELFCLASS64) {
+    // 64 bit ELF
+    auto header = static_cast<const ELFIO::Elf64_Ehdr*>(data);
+    return std::max(header->e_shoff + header->e_shentsize * header->e_shnum,
+                    header->e_phoff + header->e_phentsize * header->e_phnum);
+  }
+
+  throw std::runtime_error("Unable to calculate ELF size");
+}
+
+static module_handle
+create_full_elf_module(const std::string& fname)
+{
+  auto ctx = get_current_context();
+  throw_context_destroyed_if(!ctx, "context is destroyed, no active context");
+  // create module and store it in module map
+  return insert_in_map(module_cache, std::make_shared<module_full_elf>(ctx, fname));
+}
+
+static module_handle
+create_full_elf_module(const void* image, size_t size)
+{
+  auto ctx = get_current_context();
+  throw_context_destroyed_if(!ctx, "context is destroyed, no active context");
+  // create module and store it in module map
+  return insert_in_map(module_cache, std::make_shared<module_full_elf>(ctx, image, size));
 }
 
 static module_handle
@@ -183,10 +249,22 @@ hip_module_load_data_helper(hipModule_t* module, const void* image)
   try {
     throw_invalid_resource_if(!module, "module is nullptr");
 
+    // Treat pointer passed has data to full ELF and
+    // try creating full ELF module
+    // if it throws fallback to xclbin + ELF flow
+    xrt::core::hip::module_handle handle;
+    try {
+      auto estimated_size = xrt::core::hip::estimate_elf_size(image);
+      handle = xrt::core::hip::create_full_elf_module(image, estimated_size);
+      *module = reinterpret_cast<hipModule_t>(handle);
+      return hipSuccess;
+    }
+    catch (...) { /*do nothing*/ }
+
     // image passed to this call is structure hipModuleData object pointer
     auto config_data = static_cast<const hipModuleData*>(image);
-    auto mod = xrt::core::hip::create_module(config_data);
-    *module = reinterpret_cast<hipModule_t>(mod);
+    handle = xrt::core::hip::create_module(config_data);
+    *module = reinterpret_cast<hipModule_t>(handle);
     return hipSuccess;
   }
   catch (const xrt_core::system_error& ex) {
@@ -221,7 +299,18 @@ hipModuleLoad(hipModule_t* module, const char* fname)
   try {
     throw_invalid_resource_if(!module, "module is nullptr");
 
-    auto handle = xrt::core::hip::create_xclbin_module(std::string{fname});
+    // Treat fname passed is filepath to full ELF and
+    // try creating full ELF module
+    // if it throws fallback to xclbin + ELF flow
+    xrt::core::hip::module_handle handle;
+    try {
+      handle = xrt::core::hip::create_full_elf_module(std::string{fname});
+      *module = reinterpret_cast<hipModule_t>(handle);
+      return hipSuccess;
+    }
+    catch (...) { /*do nothing*/ }
+
+    handle = xrt::core::hip::create_xclbin_module(std::string{fname});
     *module = reinterpret_cast<hipModule_t>(handle);
     return hipSuccess;
   }

--- a/src/runtime_src/hip/core/module.cpp
+++ b/src/runtime_src/hip/core/module.cpp
@@ -27,21 +27,21 @@ namespace xrt::core::hip {
 
 module_xclbin::
 module_xclbin(std::shared_ptr<context> ctx, const std::string& file_name)
-  : module{std::move(ctx), true}
+  : module{std::move(ctx)}
   , m_xrt_xclbin{file_name}
   , m_xrt_hw_ctx{m_ctx->get_xrt_device(), register_xclbin(m_ctx, m_xrt_xclbin)}
 {}
 
 module_xclbin::
 module_xclbin(std::shared_ptr<context> ctx, void* data, size_t size)
-  : module{std::move(ctx), true}
+  : module{std::move(ctx)}
   , m_xrt_xclbin{std::vector<char>{static_cast<char*>(data), static_cast<char*>(data) + size}}
   , m_xrt_hw_ctx{m_ctx->get_xrt_device(), register_xclbin(m_ctx, m_xrt_xclbin)}
 {}
 
 module_elf::
 module_elf(module_xclbin* xclbin_module, const std::string& file_name)
-  : module{xclbin_module->get_context(), false}
+  : module{xclbin_module->get_context()}
   , m_xclbin_module{xclbin_module}
   , m_xrt_elf{file_name}
   , m_xrt_module{m_xrt_elf}
@@ -49,7 +49,7 @@ module_elf(module_xclbin* xclbin_module, const std::string& file_name)
 
 module_elf::
 module_elf(module_xclbin* xclbin_module, void* data, size_t size)
-  : module{xclbin_module->get_context(), false}
+  : module{xclbin_module->get_context()}
   , m_xclbin_module{xclbin_module}
   , m_xrt_elf{create_elf(data, size)}
   , m_xrt_module{m_xrt_elf}
@@ -57,23 +57,50 @@ module_elf(module_xclbin* xclbin_module, void* data, size_t size)
 
 module_full_elf::
 module_full_elf(std::shared_ptr<context> ctx, const std::string& file_name)
-  : module{std::move(ctx), false, true}
+  : module{std::move(ctx)}
   , m_xrt_elf{file_name}
   , m_xrt_hw_ctx{m_ctx->get_xrt_device(), m_xrt_elf}
 {}
 
 module_full_elf::
 module_full_elf(std::shared_ptr<context> ctx, const void* data, size_t size)
-  : module{std::move(ctx), false, true}
+  : module{std::move(ctx)}
   , m_xrt_elf{data, size}
   , m_xrt_hw_ctx{m_ctx->get_xrt_device(), m_xrt_elf}
 {}
 
+function_handle
+module_elf::
+add_function(const std::string& name)
+{
+  return insert_in_map(function_cache,
+                       std::make_shared<function>(this, m_xrt_module, name));
+}
+
+function_handle
+module_full_elf::
+add_function(const std::string& name)
+{
+  return insert_in_map(function_cache,
+                       std::make_shared<function>(this, name));
+}
+
+static xrt::kernel
+create_kernel(module_elf* elf_mod, const xrt::module& xrt_mod, const std::string& name)
+{
+  auto xclbin_mod = elf_mod->get_xclbin_module();
+  if (!xclbin_mod)
+    throw_invalid_resource_if(!module_cache.count(xclbin_mod),
+			      "corresponding xclbin module of elf module is not available");
+
+  return xrt::ext::kernel{xclbin_mod->get_hw_context(), xrt_mod, name};
+}
+
 function::
-function(module_xclbin* xclbin_mod_hdl, const xrt::module& xrt_module, const std::string& name)
-  : m_xclbin_module{xclbin_mod_hdl}
+function(module_elf* elf_mod_hdl, const xrt::module& xrt_module, const std::string& name)
+  : m_elf_module{elf_mod_hdl}
   , m_func_name{name}
-  , m_xrt_kernel{xrt::ext::kernel{m_xclbin_module->get_hw_context(), xrt_module, name}}
+  , m_xrt_kernel{create_kernel(m_elf_module, xrt_module, name)}
 {}
 
 function::

--- a/src/runtime_src/hip/core/module.cpp
+++ b/src/runtime_src/hip/core/module.cpp
@@ -55,11 +55,32 @@ module_elf(module_xclbin* xclbin_module, void* data, size_t size)
   , m_xrt_module{m_xrt_elf}
 {}
 
+module_full_elf::
+module_full_elf(std::shared_ptr<context> ctx, const std::string& file_name)
+  : module{std::move(ctx), false, true}
+  , m_xrt_elf{file_name}
+  , m_xrt_hw_ctx{m_ctx->get_xrt_device(), m_xrt_elf}
+{}
+
+module_full_elf::
+module_full_elf(std::shared_ptr<context> ctx, const void* data, size_t size)
+  : module{std::move(ctx), false, true}
+  , m_xrt_elf{data, size}
+  , m_xrt_hw_ctx{m_ctx->get_xrt_device(), m_xrt_elf}
+{}
+
 function::
 function(module_xclbin* xclbin_mod_hdl, const xrt::module& xrt_module, const std::string& name)
   : m_xclbin_module{xclbin_mod_hdl}
   , m_func_name{name}
   , m_xrt_kernel{xrt::ext::kernel{m_xclbin_module->get_hw_context(), xrt_module, name}}
+{}
+
+function::
+function(module_full_elf* full_elf_mod_hdl, const std::string& name)
+  : m_full_elf_module{full_elf_mod_hdl}
+  , m_func_name{name}
+  , m_xrt_kernel{xrt::ext::kernel{m_full_elf_module->get_hw_context(), name}}
 {}
 
 // Global map of modules

--- a/src/runtime_src/hip/core/module.h
+++ b/src/runtime_src/hip/core/module.h
@@ -33,33 +33,34 @@ class module
 protected:
   // NOLINTBEGIN
   std::shared_ptr<context> m_ctx;
-  bool m_is_xclbin;
-  bool m_is_full_elf;
+  xrt_core::handle_map<function_handle, std::shared_ptr<function>> function_cache;
   // NOLINTEND
 
 public:
-  module(std::shared_ptr<context> ctx, bool is_xclbin, bool is_full_elf = false)
+  explicit module(std::shared_ptr<context> ctx)
     : m_ctx{std::move(ctx)}
-    , m_is_xclbin{is_xclbin}
-    , m_is_full_elf{is_full_elf}
   {}
-
-  bool
-  is_xclbin_module() const
-  {
-    return m_is_xclbin;
-  }
-
-  bool
-  is_full_elf_module() const
-  {
-    return m_is_full_elf;
-  }
 
   std::shared_ptr<context>
   get_context() const
   {
     return m_ctx;
+  }
+
+  virtual function_handle
+  add_function(const std::string& name)
+  {
+    // should be called from derived class
+    throw_invalid_resource_if(true, "invalid module handle passed");
+    return nullptr; // to avoid compiler warning
+  }
+
+  virtual std::shared_ptr<function>
+  get_function(function_handle handle) const
+  {
+    // should be called from derived class
+    throw_invalid_resource_if(true, "invalid module handle passed");
+    return nullptr; // to avoid compiler warning
   }
 
   virtual
@@ -70,24 +71,11 @@ class module_xclbin : public module
 {
   xrt::xclbin m_xrt_xclbin;
   xrt::hw_context m_xrt_hw_ctx;
-  xrt_core::handle_map<function_handle, std::shared_ptr<function>> function_cache;
 
 public:
   module_xclbin(std::shared_ptr<context> ctx, const std::string& file_name);
 
   module_xclbin(std::shared_ptr<context> ctx, void* data, size_t size);
-
-  function_handle
-  add_function(std::shared_ptr<function> f)
-  {
-    return insert_in_map(function_cache, f);
-  }
-
-  std::shared_ptr<function>
-  get_function(function_handle handle) const
-  {
-    return function_cache.get(handle);
-  }
 
   const xrt::hw_context&
   get_hw_context() const
@@ -112,41 +100,46 @@ public:
 
   const xrt::module&
   get_xrt_module() const { return m_xrt_module; }
+
+  function_handle
+  add_function(const std::string& name) override;
+
+  std::shared_ptr<function>
+  get_function(function_handle handle) const override
+  {
+    return function_cache.get(handle);
+  }
 };
 
 class module_full_elf : public module
 {
   xrt::elf m_xrt_elf;
   xrt::hw_context m_xrt_hw_ctx;
-  xrt_core::handle_map<function_handle, std::shared_ptr<function>> function_cache;
 
 public:
   module_full_elf(std::shared_ptr<context> ctx, const std::string& file_name);
 
   module_full_elf(std::shared_ptr<context> ctx, const void* data, size_t size);
 
-  function_handle
-  add_function(std::shared_ptr<function> f)
-  {
-    return insert_in_map(function_cache, f);
-  }
-
-  std::shared_ptr<function>
-  get_function(function_handle handle) const
-  {
-    return function_cache.get(handle);
-  }
-
   const xrt::hw_context&
   get_hw_context() const
   {
     return m_xrt_hw_ctx;
   }
+
+  function_handle
+  add_function(const std::string& name) override;
+
+  std::shared_ptr<function>
+  get_function(function_handle handle) const override
+  {
+    return function_cache.get(handle);
+  }
 };
 
 class function
 {
-  module_xclbin* m_xclbin_module = nullptr;
+  module_elf* m_elf_module = nullptr;
   module_full_elf* m_full_elf_module = nullptr;
   std::vector<xrt::run> m_runs_cache; // cache for the runs to this function
   std::mutex m_runs_mutex; // lock to m_runs_cache
@@ -155,20 +148,8 @@ class function
 
 public:
   function() = default;
-  function(module_xclbin* mod_hdl, const xrt::module& xrt_module, const std::string& name);
+  function(module_elf* mod_hdl, const xrt::module& xrt_module, const std::string& name);
   function(module_full_elf* mod_hdl, const std::string& name);
-
-  module_xclbin*
-  get_xclbin_module() const
-  {
-    return m_xclbin_module;
-  }
-
-  module_full_elf*
-  get_full_elf_module() const
-  {
-    return m_full_elf_module;
-  }
 
   module*
   get_module() const
@@ -176,7 +157,7 @@ public:
     if (m_full_elf_module)
       return m_full_elf_module;
 
-    return m_xclbin_module;
+    return m_elf_module;
   }
 
   const xrt::kernel&

--- a/src/runtime_src/hip/core/module.h
+++ b/src/runtime_src/hip/core/module.h
@@ -31,9 +31,11 @@ class function;
 class module
 {
 protected:
+  // NOLINTBEGIN
   std::shared_ptr<context> m_ctx;
   bool m_is_xclbin;
   bool m_is_full_elf;
+  // NOLINTEND
 
 public:
   module(std::shared_ptr<context> ctx, bool is_xclbin, bool is_full_elf = false)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Added changes in hip module APIs to load full ELF

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
#### How problem was solved, alternative solutions (if any) and why they were rejected
Hip module load calls are modified to try to load full ELF and when exception is caught fallback to load xclbin + elf 
Ideal way is to modify hip module calls to load full ELFs but as our compilers at present doesn't generate full ELFs and we need to support xclbin + elf flow for some time the changes are made this way.

Also hipModuleLoadData API only takes void* pointer as input but to create elfio object we need data pointer and size, so added a function to calculate size of elf from elf header.

#### Risks (if any) associated the changes in the commit
Low as it impacts only HIP flows

#### What has been tested and how, request additional testing if necessary
Tested existing model test expoi (xclbin + elf) test on strix Linux and it works as expected
Also converted expoi full elf c++ application to HIP based application and tested it on strix Linux, test passes

#### Documentation impact (if any)
Need to document the usage when HIP documentation is made available