### PR TITLE
xbmgmt missing tests fix

### DIFF
--- a/src/runtime_src/core/edge/user/smi_edge.cpp
+++ b/src/runtime_src/core/edge/user/smi_edge.cpp
@@ -9,15 +9,22 @@ create_validate_subcommand()
 {
   std::vector<xrt_core::smi::basic_option> validate_test_desc = {
     {"all", "All applicable validate tests will be executed (default)", "common"},
+    {"aie", "Run AIE PL test", "common"},
     {"aux-connection", "Check if auxiliary power is connected", "common"},
+    {"bist", "Run built-in self test", "common"},
     {"dma", "Run dma test", "common"},
     {"hostmem-bw", "Run 'bandwidth kernel' when host memory is enabled", "common"},
+    {"iops", "Run Input/Output operations per second test", "common"},
     {"m2m", "Run M2M test", "common"},
     {"mem-bw", "Run 'bandwidth kernel' and check the throughput", "common"},
     {"p2p", "Run P2P test", "common"},
     {"pcie-link", "Check if PCIE link is active", "common"},
-    {"quick", "Only the first 4 tests will be executed", "common"},
+    {"ps-aie", "Run PS controlled AIE test", "common"},
+    {"ps-iops", "Run IOPS PS test", "common"},
+    {"ps-pl-verify", "Run PS controlled 'Hello World' PL kernel test", "common"},
+    {"ps-verify", "Run 'Hello World' PS kernel test", "common"},
     {"sc-version","Check if SC firmware is up-to-date", "common"},
+    {"vcu", "Run VCU test", "common"},
     {"verify", "Run 'Hello World' kernel test", "common"}
   };
 

--- a/src/runtime_src/core/pcie/linux/smi_pcie.cpp
+++ b/src/runtime_src/core/pcie/linux/smi_pcie.cpp
@@ -9,15 +9,23 @@ create_validate_subcommand()
 {
   std::vector<xrt_core::smi::basic_option> validate_test_desc = {
     {"all", "All applicable validate tests will be executed (default)", "common"},
+    {"aie", "Run AIE PL test", "common"},
     {"aux-connection", "Check if auxiliary power is connected", "common"},
+    {"bist", "Run built-in self test", "common"},
     {"dma", "Run dma test", "common"},
     {"hostmem-bw", "Run 'bandwidth kernel' when host memory is enabled", "common"},
+    {"iops", "Run Input/Output operations per second test", "common"},
     {"m2m", "Run M2M test", "common"},
     {"mem-bw", "Run 'bandwidth kernel' and check the throughput", "common"},
     {"p2p", "Run P2P test", "common"},
     {"pcie-link", "Check if PCIE link is active", "common"},
+    {"ps-aie", "Run PS controlled AIE test", "common"},
+    {"ps-iops", "Run IOPS PS test", "common"},
+    {"ps-pl-verify", "Run PS controlled 'Hello World' PL kernel test", "common"},
+    {"ps-verify", "Run 'Hello World' PS kernel test", "common"},
     {"quick", "Only the first 4 tests will be executed", "common"},
     {"sc-version","Check if SC firmware is up-to-date", "common"},
+    {"vcu", "Run VCU test", "common"},
     {"verify", "Run 'Hello World' kernel test", "common"}
   };
 

--- a/src/runtime_src/core/tools/common/tests/TestNPUThroughput.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestNPUThroughput.cpp
@@ -35,7 +35,7 @@ TestNPUThroughput::run(std::shared_ptr<xrt_core::device> dev)
     runner.wait();
 
     auto report = json::parse(runner.get_report());
-    XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Average throughput: %.1f ops") % report["cpu"]["throughput"].get<double>()));
+    XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Average throughput: %.1f op/s") % report["cpu"]["throughput"].get<double>()));
     ptree.put("status", XBValidateUtils::test_token_passed);
   }
   catch(const std::exception& e)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
This PR fixes an xrt-smi for alveo/edge issue. There were tests missing in the list of applicable tests to be run.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
N/A

#### How problem was solved, alternative solutions (if any) and why they were rejected
Resolved by adding the missing tests. We should have xrt-smi tests for all validate tests and examine reports added to XRT pipeline so that this can be avoided in future. We mostly only tests xrt-smi on Ryzen and this is difficult to catch since the xrt-smi executable is common between the two.

#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
Not tested yet. Will request a est board from @karthdmg-xilinx .

#### Documentation impact (if any)
NA
