### PR TITLE
Support packaging for Linux Mint

### DIFF
--- a/src/CMake/cpackLin.cmake
+++ b/src/CMake/cpackLin.cmake
@@ -76,7 +76,7 @@ else()
 endif()
 
 SET(PACKAGE_KIND "TGZ")
-if (${LINUX_FLAVOR} MATCHES "^(ubuntu|debian)")
+if (${LINUX_FLAVOR} MATCHES "^(ubuntu|debian|linuxmint)")
   execute_process(
     COMMAND dpkg --print-architecture
     OUTPUT_VARIABLE CPACK_ARCH

--- a/src/runtime_src/tools/scripts/xrtdeps.sh
+++ b/src/runtime_src/tools/scripts/xrtdeps.sh
@@ -420,7 +420,7 @@ mariner_package_list()
 
 update_package_list()
 {
-    if [ $FLAVOR == "ubuntu" ] || [ $FLAVOR == "debian" ]; then
+    if [ $FLAVOR == "ubuntu" ] || [ $FLAVOR == "debian" ] || [ $FLAVOR == "linuxmint" ]; then
         ub_package_list
     elif [ $FLAVOR == "centos" ] || [ $FLAVOR == "rhel" ] || [ $FLAVOR == "amzn" ] || [ $FLAVOR == "almalinux" ] || [ $FLAVOR == "rocky" ]; then
         rh_package_list
@@ -438,7 +438,7 @@ update_package_list()
 
 validate()
 {
-    if [ $FLAVOR == "ubuntu" ] || [ $FLAVOR == "debian" ]; then
+    if [ $FLAVOR == "ubuntu" ] || [ $FLAVOR == "debian" ] || [ $FLAVOR == "linuxmint" ]; then
         #apt-get -qq list "${UB_LIST[@]}"
         dpkg -l "${UB_LIST[@]}" > /dev/null
         if [ $? == 0 ] ; then
@@ -661,6 +661,8 @@ install_pybind11()
         sudo dnf install -y pybind11-devel python3-pybind11
     elif [ $FLAVOR == "ubuntu" ] && [ $MAJOR -ge 23 ]; then
         apt-get install -y pybind11-dev
+    elif [ $FLAVOR == "linuxmint" ]; then
+        apt-get install -y pybind11-dev
     else
         # Install/upgrade pybind11 for building the XRT python bindings
         # We need 2.6.0 minimum version
@@ -707,7 +709,7 @@ install_hip()
 
 install()
 {
-    if [ $FLAVOR == "ubuntu" ] || [ $FLAVOR == "debian" ]; then
+    if [ $FLAVOR == "ubuntu" ] || [ $FLAVOR == "debian" ] || [ $FLAVOR == "linuxmint" ]; then
         prep_ubuntu
 
         echo "Installing packages..."


### PR DESCRIPTION
#### Problem solved by the commit
Update xrtdeps.sh and cpack for Linux Mint support. Now creates .deb packages for this variant of Ubuntu.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Addresses missing packages as described in #9141.
This doesn't necessarily mean full commitment to and support for Linux Mint.

#### What has been tested and how, request additional testing if necessary
Build XRT on linuxmintd/mint21.3-amd64 docker hub image.