### PR TITLE
Fix hardwired /opt/xilinx/xrt paths

### DIFF
--- a/src/runtime_src/core/common/CMakeLists.txt
+++ b/src/runtime_src/core/common/CMakeLists.txt
@@ -56,9 +56,9 @@ target_include_directories(core_common_library_objects
   ${XRT_SOURCE_DIR}/runtime_src
   )
 
-target_compile_definitions(core_common_library_objects
-  PRIVATE
+set_property(SOURCE module_loader.cpp APPEND PROPERTY COMPILE_DEFINITIONS
   XRT_VERSION_MAJOR="${XRT_VERSION_MAJOR}"
+  XRT_INSTALL_PREFIX="${CMAKE_INSTALL_PREFIX}"
   XRT_LIB_DIR="${CMAKE_INSTALL_LIBDIR}"
   )
 

--- a/src/runtime_src/core/common/detail/linux/xilinx_xrt.h
+++ b/src/runtime_src/core/common/detail/linux/xilinx_xrt.h
@@ -1,10 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
 
 #include <filesystem>
 #include <stdexcept>
 #include <string>
 #include <vector>
+
+#ifndef XRT_INSTALL_PREFIX
+# error "XRT_INSTALL_PREFIX is undefined"
+#endif
+
 namespace xrt_core::detail {
 
 namespace sfs = std::filesystem;
@@ -12,17 +17,18 @@ namespace sfs = std::filesystem;
 sfs::path
 xilinx_xrt()
 {
-#if defined (__aarch64__) || defined (__arm__)
-  return sfs::path("/usr");
-#else
-  return sfs::path("/opt/xilinx/xrt");
-#endif
+  // This returns CMAKE_INSTALL_PREFIX.  The internal default cmake
+  // install path is /opt/xilinx/xrt, for upstreaming most likely /usr.
+  return sfs::path(XRT_INSTALL_PREFIX);
 }
 
 std::vector<sfs::path>
 platform_repo_path()
 {
-  return {sfs::path("/lib/firmware/amdnpu"), sfs::path("/opt/xilinx/xrt/amdxdna")};
+  // If CMAKE_INSTALL_PREFIX is /usr, then /usr/amdxdna will be invalid,
+  // not sure if this matters or why the second path is even present?
+  // Regardless, default /opt/xilinx/xrt behavior remains unchanged.
+  return {sfs::path("/lib/firmware/amdnpu"), xilinx_xrt() / "amdxdna"};
 }
 
 } // xrt_core::detail

--- a/src/runtime_src/core/common/module_loader.cpp
+++ b/src/runtime_src/core/common/module_loader.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2016-2020 Xilinx, Inc
-// Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2024-2025 Advanced Micro Devices, Inc. All rights reserved.
 
 #define XRT_CORE_COMMON_SOURCE
 #include "core/common/module_loader.h"

--- a/src/runtime_src/xrt/CMakeLists.txt
+++ b/src/runtime_src/xrt/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2019-2021 Xilinx, Inc. All rights reserved.
-#
+# Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
 add_subdirectory(xrt++)
 
 include_directories(
@@ -36,6 +36,10 @@ add_compile_options("-DXRT_SOURCE")
 if (NOT WIN32)
 set_source_files_properties(${XRT_XRT_DEVICE_DIR}/hal_static.cpp PROPERTIES
   COMPILE_FLAGS -Wno-unused
+  COMPILE_DEFINITIONS XRT_LIB_DIR="${CMAKE_INSTALL_LIBDIR}"
+  )
+set_source_files_properties(${XRT_XRT_DEVICE_DIR}/hal.cpp PROPERTIES
+  COMPILE_DEFINITIONS XRT_LIB_DIR="${CMAKE_INSTALL_LIBDIR}"
   )
 endif()
 

--- a/src/runtime_src/xrt/device/hal.cpp
+++ b/src/runtime_src/xrt/device/hal.cpp
@@ -1,23 +1,11 @@
-/**
- * Copyright (C) 2016-2021 Xilinx, Inc
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2016-2021 Xilinx, Inc
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
 #include "hal.h"
 
 #include "core/common/dlfcn.h"
 #include "core/common/device.h"
+#include "core/common/module_loader.h"
 #include "core/include/xrt/experimental/xrt_system.h"
 
 #include <filesystem>
@@ -40,12 +28,6 @@ ends_with(const std::string& str, const std::string& sub)
   return (p==std::string::npos)
     ? false
     : (str.size() - p) == sub.size();
-}
-
-static const char*
-emptyOrValue(const char* cstr)
-{
-  return cstr ? cstr : "";
 }
 
 static void
@@ -80,7 +62,7 @@ dllpath(const std::filesystem::path& root, const std::string& libnm)
 #ifdef _WIN32
   return root / "bin" / (libnm + dllExt().string());
 #else
-  return root / "lib" / ("lib" + libnm + dllExt().string());
+  return root / XRT_LIB_DIR / ("lib" + libnm + dllExt().string());
 #endif
 }
 
@@ -147,7 +129,7 @@ loadDevices()
   hal::device_list devices;
 #ifndef XRT_STATIC_BUILD
   // xrt
-  sfs::path xrt(emptyOrValue(getenv("XILINX_XRT")));
+  auto xrt = xrt_core::environment::xilinx_xrt();
 
 #if defined (__aarch64__) || defined (__arm__)
   if (xrt.empty()) {


### PR DESCRIPTION
#### Problem solved by the commit
Use compile time macros for install and library path.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
When running XRT applications compiled from debian upstream artifacts, XRT runtime loaded libraries were picked up from non-existent /opt/xilinx/xrt path.

