### PR TITLE
Adding configure support to enable/disable event-tracing and firmware…

### DIFF
--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -323,6 +323,8 @@ enum class key_type
   xgq_scaling_temp_override,
   performance_mode,
   preemption,
+  event_trace,
+  firmware_log,
   frame_boundary_preemption,
   debug_ip_layout_path,
   debug_ip_layout,
@@ -4073,6 +4075,34 @@ struct preemption : request
   virtual void
   put(const device*, const std::any&) const override = 0;
 
+};
+
+struct event_trace : request 
+{
+  using result_type = uint32_t;  // get value type
+  using value_type = uint32_t;   // put value type
+
+  static const key_type key = key_type::event_trace;
+
+  virtual std::any
+  get(const device*) const override = 0;
+
+  virtual void
+  put(const device*, const std::any&) const override = 0;
+};
+
+struct firmware_log : request
+{  
+  using result_type = uint32_t;  // get value type
+  using value_type = uint32_t;   // put value type
+
+  static const key_type key = key_type::firmware_log;
+
+  virtual std::any
+  get(const device*) const override = 0;
+
+  virtual void
+  put(const device*, const std::any&) const override = 0;
 };
 
 /*

--- a/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
@@ -50,6 +50,8 @@ file(GLOB XBUTIL_V2_SUBCMD_FILES
   "OO_HostMem.cpp"
   "OO_Performance.cpp"
   "OO_Preemption.cpp"
+  "OO_EventTrace.cpp"
+  "OO_FirmwareLog.cpp"
 )
 
 # Merge the files into one collection

--- a/src/runtime_src/core/tools/xbutil2/OO_EventTrace.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_EventTrace.cpp
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+
+// ------ I N C L U D E   F I L E S -------------------------------------------
+// Local - Include Files
+#include "OO_EventTrace.h"
+#include "tools/common/XBUtilitiesCore.h"
+#include "tools/common/XBUtilities.h"
+#include "tools/common/XBHelpMenusCore.h"
+
+// 3rd Party Library - Include Files
+#include <boost/program_options.hpp>
+#include <boost/algorithm/string.hpp>
+namespace po = boost::program_options;
+
+// ----- C L A S S   M E T H O D S -------------------------------------------
+
+OO_EventTrace::OO_EventTrace( const std::string &_longName, bool _isHidden )
+    : OptionOptions(_longName, _isHidden, "Enable|disable event trace")
+    , m_device("")
+    , m_action("")
+    , m_help(false)
+{
+  m_optionsDescription.add_options()
+    ("device,d", boost::program_options::value<decltype(m_device)>(&m_device), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest")
+    ("help", boost::program_options::bool_switch(&m_help), "Help to use this sub-command")
+  ;
+
+  m_optionsHidden.add_options()
+    ("action", boost::program_options::value<decltype(m_action)>(&m_action), "Action to perform: enable, disable, status");
+  ;
+
+  m_positionalOptions.
+    add("action", 1 /* max_count */)
+  ;
+}
+
+void
+OO_EventTrace::validate_args() const {
+  if(m_action.empty() && !m_help)
+    throw xrt_core::error(std::errc::operation_canceled, "Please specify a action 'enable', 'disable' or 'status'");
+  std::vector<std::string> vec_action { "enable", "disable", "status" };
+  if (!m_action.empty() && std::find(vec_action.begin(), vec_action.end(), m_action) == vec_action.end()) {
+    throw xrt_core::error(std::errc::operation_canceled, boost::str(boost::format("\n'%s' is not a valid action for event trace\n") % m_action));
+  }
+}
+
+void
+OO_EventTrace::execute(const SubCmdOptions& _options) const
+{
+  XBUtilities::verbose("SubCommand option: Event Trace");
+
+  XBUtilities::verbose("Option(s):");
+  for (auto & aString : _options)
+    XBUtilities::verbose(std::string(" ") + aString);
+
+  // Parse sub-command ...
+  po::variables_map vm;
+
+  try {
+    po::options_description all_options("All Options");
+    all_options.add(m_optionsDescription);
+    all_options.add(m_optionsHidden);
+    po::command_line_parser parser(_options);
+    XBUtilities::process_arguments(vm, parser, all_options, m_positionalOptions, true);
+  } catch(boost::program_options::error& ex) {
+    std::cout << ex.what() << std::endl;
+    printHelp();
+    throw xrt_core::error(std::errc::operation_canceled);
+  } 
+
+  if (m_help) {
+    printHelp();
+    return;
+  }
+
+  try {
+    //validate required arguments
+    validate_args(); 
+  } catch(xrt_core::error& err) {
+    std::cout << err.what() << std::endl;
+    printHelp();
+    throw xrt_core::error(err.get_code());
+  }
+
+  // Find device of interest
+  std::shared_ptr<xrt_core::device> device;
+  
+  try {
+    device = XBUtilities::get_device(boost::algorithm::to_lower_copy(m_device), true /*inUserDomain*/);
+  } catch (const std::runtime_error& e) {
+    // Catch only the exceptions that we have generated earlier
+    std::cerr << boost::format("ERROR: %s\n") % e.what();
+    throw xrt_core::error(std::errc::operation_canceled);
+  }
+
+  XBUtilities::sudo_or_throw("Event trace configuration requires admin privileges");
+
+  auto action_to_int = [](const std::string& action) -> uint32_t {
+    return action == "enable" ? 1 : 0;
+  };
+
+  try {
+    xrt_core::device_update<xrt_core::query::event_trace>(device.get(), action_to_int(m_action));
+  }
+  catch(const xrt_core::error& e) {
+    std::cerr << boost::format("\nERROR: %s\n") % e.what();
+    printHelp();
+    throw xrt_core::error(std::errc::operation_canceled);
+  }
+}

--- a/src/runtime_src/core/tools/xbutil2/OO_EventTrace.h
+++ b/src/runtime_src/core/tools/xbutil2/OO_EventTrace.h
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+
+#pragma once
+
+#include "tools/common/OptionOptions.h"
+
+class OO_EventTrace : public OptionOptions {
+public:
+  virtual void execute( const SubCmdOptions &_options ) const;
+  void validate_args() const;
+
+public:
+  OO_EventTrace(const std::string &_longName, bool _isHidden = false);
+
+private:
+  std::string m_device;
+  std::string m_action;
+  bool m_help;
+};

--- a/src/runtime_src/core/tools/xbutil2/OO_FirmwareLog.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_FirmwareLog.cpp
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+
+// ------ I N C L U D E   F I L E S -------------------------------------------
+// Local - Include Files
+#include "OO_FirmwareLog.h"
+#include "tools/common/XBUtilitiesCore.h"
+#include "tools/common/XBUtilities.h"
+#include "tools/common/XBHelpMenusCore.h"
+
+// 3rd Party Library - Include Files
+#include <boost/program_options.hpp>
+#include <boost/algorithm/string.hpp>
+namespace po = boost::program_options;
+
+// ----- C L A S S   M E T H O D S -------------------------------------------
+
+OO_FirmwareLog::OO_FirmwareLog( const std::string &_longName, bool _isHidden )
+    : OptionOptions(_longName, _isHidden, "Enable|disable firmware log")
+    , m_device("")
+    , m_action("")
+    , m_help(false)
+    , m_log_level(0)
+{
+  m_optionsDescription.add_options()
+    ("device,d", boost::program_options::value<decltype(m_device)>(&m_device), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest")
+    ("help,h", boost::program_options::bool_switch(&m_help), "Help to use this sub-command")
+    ("log-level", boost::program_options::value<decltype(m_log_level)>(&m_log_level), "Log level ranging from 0 to 5")
+  ;
+
+  m_optionsHidden.add_options()
+    ("action", boost::program_options::value<decltype(m_action)>(&m_action), "Action to perform: enable, disable, status");
+  ;
+
+  m_positionalOptions.
+    add("action", 1 /* max_count */)
+  ;
+}
+
+void
+OO_FirmwareLog::validate_args() const {
+  if(m_action.empty() && !m_help)
+    throw xrt_core::error(std::errc::operation_canceled, "Please specify a action 'enable' or 'disable'");
+  std::vector<std::string> vec_action { "enable", "disable" };
+  if (!m_action.empty() && std::find(vec_action.begin(), vec_action.end(), m_action) == vec_action.end()) {
+    throw xrt_core::error(std::errc::operation_canceled, boost::str(boost::format("\n'%s' is not a valid action for firmware log\n") % m_action));
+  }
+}
+
+void
+OO_FirmwareLog::execute(const SubCmdOptions& _options) const
+{
+  XBUtilities::verbose("SubCommand option: Firmware Log");
+
+  XBUtilities::verbose("Option(s):");
+  for (auto & aString : _options)
+    XBUtilities::verbose(std::string(" ") + aString);
+
+  // Parse sub-command ...
+  po::variables_map vm;
+
+  try {
+    po::options_description all_options("All Options");
+    all_options.add(m_optionsDescription);
+    all_options.add(m_optionsHidden);
+    po::command_line_parser parser(_options);
+    XBUtilities::process_arguments(vm, parser, all_options, m_positionalOptions, true);
+  } catch(boost::program_options::error& ex) {
+    std::cout << ex.what() << std::endl;
+    printHelp();
+    throw xrt_core::error(std::errc::operation_canceled);
+  } 
+
+  if (m_help)
+  {
+    printHelp();
+    return;
+  }
+
+  try {
+    //validate required arguments
+    validate_args(); 
+  } catch(xrt_core::error& err) {
+    std::cout << err.what() << std::endl;
+    printHelp();
+    throw xrt_core::error(err.get_code());
+  }
+
+  // Find device of interest
+  std::shared_ptr<xrt_core::device> device;
+  
+  try {
+    device = XBUtilities::get_device(boost::algorithm::to_lower_copy(m_device), true /*inUserDomain*/);
+  } catch (const std::runtime_error& e) {
+    // Catch only the exceptions that we have generated earlier
+    std::cerr << boost::format("ERROR: %s\n") % e.what();
+    throw xrt_core::error(std::errc::operation_canceled);
+  }
+
+  XBUtilities::sudo_or_throw("Firmware log configuration requires admin privileges");
+
+  auto action_to_int = [](const std::string& action) -> uint32_t {
+    return action == "enable" ? 1 : 0;
+  };
+
+  try {
+    xrt_core::device_update<xrt_core::query::firmware_log>(device.get(), action_to_int(m_action));
+  }
+  catch(const xrt_core::error& e) {
+    std::cerr << boost::format("\nERROR: %s\n") % e.what();
+    printHelp();
+    throw xrt_core::error(std::errc::operation_canceled);
+  }
+}

--- a/src/runtime_src/core/tools/xbutil2/OO_FirmwareLog.h
+++ b/src/runtime_src/core/tools/xbutil2/OO_FirmwareLog.h
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+
+#pragma once
+
+#include "tools/common/OptionOptions.h"
+
+class OO_FirmwareLog : public OptionOptions {
+public:
+  virtual void execute( const SubCmdOptions &_options ) const;
+  void validate_args() const;
+
+public:
+  OO_FirmwareLog(const std::string &_longName, bool _isHidden = false);
+
+private:
+  std::string m_device;
+  std::string m_action;
+  bool m_help;
+  int m_log_level;
+};

--- a/src/runtime_src/core/tools/xbutil2/SubCmdConfigure.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdConfigure.cpp
@@ -10,6 +10,8 @@
 #include "OO_P2P.h"
 #include "OO_Performance.h"
 #include "OO_Preemption.h"
+#include "OO_EventTrace.h"
+#include "OO_FirmwareLog.h"
 #include "common/device.h"
 #include "tools/common/XBUtilities.h"
 
@@ -30,7 +32,10 @@ SubCmdConfigure::SubCmdConfigure(bool _isHidden, bool _isDepricated, bool _isPre
     {std::make_shared<OO_HostMem>("host-mem")},
     {std::make_shared<OO_P2P>("p2p")},
     {std::make_shared<OO_Performance>("pmode")},
-    {std::make_shared<OO_Preemption>("force-preemption")} //hidden
+    {std::make_shared<OO_Preemption>("force-preemption")}, //hidden
+    {std::make_shared<OO_EventTrace>("event-trace")}, //hidden
+    {std::make_shared<OO_FirmwareLog>("firmware-log")} //hidden
+
   };
 
   for (const auto& option : m_optionOptionsCollection){


### PR DESCRIPTION
… logging

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
This PR adds new xrt-smi configure sub-options to enable and disable event tracing and firmware logging. These sub-options will be enabled from xdna and mcdm shims when the support is there in the driver.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://jira.xilinx.com/browse/AIESW-4326
https://jira.xilinx.com/browse/AIESW-5344

#### How problem was solved, alternative solutions (if any) and why they were rejected
Solved by adding required handling as a new xrt-smi configure command

#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
Will be tested when it is enabled from shim

#### Documentation impact (if any)
NA
