### PR TITLE
Remove _static suffix from static libraries on Linux 

### DIFF
--- a/src/python/pybind11/CMakeLists.txt
+++ b/src/python/pybind11/CMakeLists.txt
@@ -30,6 +30,7 @@ else()
   if (Python3_FOUND)
     message("-- Python libs version: ${Python3_VERSION}")
     message("-- PYTHON_INCLUDE_PATH ${Python3_INCLUDE_DIRS}")
+    message("-- Python3_SITEARCH ${Python3_SITEARCH}")
     set(PYTHONLIBS_VERSION_MAJOR ${Python3_VERSION_MAJOR})
     set(PYTHONLIBS_VERSION_MINOR ${Python3_VERSION_MINOR})
   endif(Python3_FOUND)
@@ -50,6 +51,11 @@ if (pybind11_FOUND)
   INCLUDE_DIRECTORIES(${PYTHON_INCLUDE_PATH})
   pybind11_add_module(pyxrt src/pyxrt.cpp)
   target_link_libraries(pyxrt PRIVATE xrt_coreutil uuid pthread)
+
+  if (CMAKE_INSTALL_PREFIX STREQUAL "/usr"
+      OR CMAKE_INSTALL_PREFIX STREQUAL "/usr/local")
+    set (XRT_INSTALL_PYTHON_DIR ${Python3_SITEARCH})
+  endif()
 
   install(TARGETS pyxrt
     EXPORT xrt-targets

--- a/src/runtime_src/core/common/CMakeLists.txt
+++ b/src/runtime_src/core/common/CMakeLists.txt
@@ -91,6 +91,11 @@ set_target_properties(xrt_coreutil PROPERTIES
   SOVERSION ${XRT_SOVERSION}
   )
 
+if (NOT WIN32)
+  # On linux use xrt_coreutil.a
+  set_target_properties(xrt_coreutil_static PROPERTIES OUTPUT_NAME "xrt_coreutil")
+endif()
+
 ################################################################
 # Define include directories and definitions needed by any target that
 # links with xrt_coreutil

--- a/src/runtime_src/core/pcie/emulation/hw_emu/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/emulation/hw_emu/CMakeLists.txt
@@ -42,6 +42,9 @@ add_library(xrt_hwemu_static STATIC ${CURR_SOURCE}
 set_target_properties(xrt_hwemu PROPERTIES VERSION ${XRT_VERSION_STRING}
   SOVERSION ${XRT_SOVERSION})
 
+# On linux use xrt_hwemu.a
+set_target_properties(xrt_hwemu_static PROPERTIES OUTPUT_NAME "xrt_hwemu")
+
 target_link_libraries(xrt_hwemu
   PRIVATE
   ${Boost_SYSTEM_LIBRARY}

--- a/src/runtime_src/core/pcie/emulation/sw_emu/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/emulation/sw_emu/CMakeLists.txt
@@ -38,6 +38,9 @@ add_library(xrt_swemu_static STATIC ${CURR_SOURCE}
 set_target_properties(xrt_swemu PROPERTIES VERSION ${XRT_VERSION_STRING}
   SOVERSION ${XRT_SOVERSION})
 
+# On linux use xrt_swemu.a
+set_target_properties(xrt_swemu_static PROPERTIES OUTPUT_NAME "xrt_swemu")
+
 target_link_libraries(xrt_swemu
   PRIVATE
   ${PROTOBUF_LIBRARY}

--- a/src/runtime_src/core/pcie/linux/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/linux/CMakeLists.txt
@@ -75,6 +75,11 @@ target_link_libraries(xrt_core_static
   pthread
   )
 
+if (NOT WIN32)
+  # On linux use xrt_core.a
+  set_target_properties(xrt_core_static PROPERTIES OUTPUT_NAME "xrt_core")
+endif()
+
 # Shim for Linux is installed in the base component as it is
 # used by both Alveo and NPU components.   
 install(TARGETS xrt_core xrt_core_static

--- a/src/runtime_src/tools/xclbinutil/CMakeLists.txt
+++ b/src/runtime_src/tools/xclbinutil/CMakeLists.txt
@@ -160,12 +160,14 @@ if(NOT WIN32 AND NOT XRT_SYSTEM_INSTALL)
 
   # -- Test Signing of the xclbin image using a DER formatted certificate
   xrt_add_test("signing-xclbin_DER" "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/unittests/signXclbinDER.py")
- 
-  # The xclbin image must contain atleast one section and platformVBNV information to meet
-  # the expectations of Linux file command utility
-  # -- Test --file-check option on valid and invalid xclbin images for Linux file command 
-  set(TEST_OPTIONS " --resource-dir ${CMAKE_CURRENT_SOURCE_DIR}/unittests/FileCheck")
-  xrt_add_test("file-check" "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/unittests/FileCheck/FileCheck.py ${TEST_OPTIONS}")
+
+  if (NOT XRT_NPU)
+    # The xclbin image must contain atleast one section and platformVBNV information to meet
+    # the expectations of Linux file command utility
+    # -- Test --file-check option on valid and invalid xclbin images for Linux file command 
+    set(TEST_OPTIONS " --resource-dir ${CMAKE_CURRENT_SOURCE_DIR}/unittests/FileCheck")
+    xrt_add_test("file-check" "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/unittests/FileCheck/FileCheck.py ${TEST_OPTIONS}")
+  endif()
   
   # -- Test SmartNic
   # Test: SmartNic Syntax

--- a/src/runtime_src/xocl/CMakeLists.txt
+++ b/src/runtime_src/xocl/CMakeLists.txt
@@ -88,6 +88,9 @@ target_link_libraries(xilinxopencl
   rt
   )
 
+  # On linux use xrt_coreutil.a
+  set_target_properties(xilinxopencl_static PROPERTIES OUTPUT_NAME "xilinxopencl")
+
 endif ()
 
 install(TARGETS xilinxopencl xilinxopencl_static

--- a/src/runtime_src/xrt/CMakeLists.txt
+++ b/src/runtime_src/xrt/CMakeLists.txt
@@ -60,6 +60,11 @@ target_link_libraries(xrt++
 set_target_properties(xrt++ PROPERTIES VERSION ${XRT_VERSION_STRING}
   SOVERSION ${XRT_SOVERSION})
 
+if (NOT WIN32)
+  # On linux use xrt++
+  set_target_properties(xrt++_static PROPERTIES OUTPUT_NAME "xrt++")
+endif()
+
 install(TARGETS xrt++ xrt++_static
   EXPORT xrt-targets
   RUNTIME DESTINATION ${XRT_INSTALL_BIN_DIR} COMPONENT ${XRT_BASE_COMPONENT}


### PR DESCRIPTION
#### Problem solved by the commit
Static libraries are named same as shared libraries.  CMake targets
are unchanged to distinguish linking with static vs shared, but refer
to the renamed static library.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Upstreaming package should not have libfoo_static.a  

#### How problem was solved, alternative solutions (if any) and why they were rejected
Sample CMakeLists.txt change:
```
if (NOT WIN32)
  # On linux use xrt_coreutil.a
  set_target_properties(xrt_coreutil_static PROPERTIES OUTPUT_NAME "xrt_coreutil")
endif()
```
Both the build and install version of the static libraries are changed, but
internal build targets that link against static libraries continue to refer
to e.g. `xrt_coreutil_static`. Under the hood CMake is aware of the renaming.

AIEBU submodule updated as well to fix naming of libaiebu.a
