### PR TITLE
Add simple archive extraction utility to XRT

### DIFF
--- a/src/runtime_src/core/common/CMakeLists.txt
+++ b/src/runtime_src/core/common/CMakeLists.txt
@@ -23,6 +23,7 @@ else()
 endif()
 
 add_library(core_common_library_objects OBJECT
+  archive.cpp
   config_reader.cpp
   debug.cpp
   debug_ip.cpp
@@ -54,6 +55,7 @@ add_library(core_common_library_objects OBJECT
 target_include_directories(core_common_library_objects
   PRIVATE
   ${XRT_SOURCE_DIR}/runtime_src
+  ${XRT_SOURCE_DIR}/runtime_src/core/common/elf
   )
 
 set_property(SOURCE module_loader.cpp APPEND PROPERTY COMPILE_DEFINITIONS

--- a/src/runtime_src/core/common/archive.cpp
+++ b/src/runtime_src/core/common/archive.cpp
@@ -11,7 +11,16 @@
 # pragma warning(disable : 4389 4458)
 #endif
 
+#ifdef __GNUC__
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wsign-compare"
+#endif
+
 #include <ario/ario.hpp>
+
+#ifdef __GNUC__
+# pragma GCC diagnostic pop
+#endif
 
 #ifdef _WIN32
 # pragma warning( pop )

--- a/src/runtime_src/core/common/archive.cpp
+++ b/src/runtime_src/core/common/archive.cpp
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#define XCL_DRIVER_DLL_EXPORT  // in same dll as exported xrt apis
+#define XRT_API_SOURCE         // in same dll as coreutil
+#define XRT_CORE_COMMON_SOURCE // in same dll as coreutil
+
+#include "archive.h"
+
+#ifdef _WIN32
+# pragma warning( push )
+# pragma warning(disable : 4389 4458)
+#endif
+
+#include <ario/ario.hpp>
+
+#ifdef _WIN32
+# pragma warning( pop )
+#endif
+
+namespace xrt_core {
+
+class archive_impl
+{
+  ARIO::ario m_archive;
+
+public:
+  archive_impl(const std::string& archive_filename)
+  {
+    m_archive.load(archive_filename);
+  }
+
+  std::string
+  data(const std::string& archive_member) const
+  {
+    return m_archive.members[archive_member].data();
+  }
+}; // class archive_impl
+
+////////////////////////////////////////////////////////////////
+// Public API
+////////////////////////////////////////////////////////////////
+archive::
+archive(const std::string& archive_filename)
+  : xrt::detail::pimpl<archive_impl>(std::make_shared<archive_impl>(archive_filename))
+{}
+  
+std::string
+archive::
+data(const std::string& archive_member) const
+{
+  return handle->data(archive_member);
+}
+
+} // xrt_core

--- a/src/runtime_src/core/common/archive.h
+++ b/src/runtime_src/core/common/archive.h
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#ifndef xrtcore_archive_h_
+#define xrtcore_archive_h_
+
+#include "core/include/xrt/detail/config.h"
+#include "core/include/xrt/detail/pimpl.h"
+#include <string>
+
+namespace xrt_core {
+
+// class archive - Simple API to extract archive member
+//
+// The archive (.a) must be a UNIX archive.  The archive
+// is read using ARIO from the ELFIO project repository.
+//
+// The implementation is insulated to for minimal header
+// file inclusion by clients.
+class archive_impl;
+class archive : public xrt::detail::pimpl<archive_impl>
+{
+public:
+  // archive() - Create an archive object from a archive filename
+  XRT_API_EXPORT
+  explicit
+  archive(const std::string& archive_filename);
+
+  // data() - Get the data of an archive member as a string
+  XRT_API_EXPORT
+  std::string
+  data(const std::string& archive_member) const;
+};
+  
+}
+
+#endif

--- a/src/runtime_src/core/common/test/CMakeLists.txt
+++ b/src/runtime_src/core/common/test/CMakeLists.txt
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+CMAKE_MINIMUM_REQUIRED(VERSION 3.18.0)
+PROJECT(common-test)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED OFF)
+set(CMAKE_VERBOSE_MAKEFILE ON)
+set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+
+if (MSVC)
+  add_compile_options(/Zc:__cplusplus)
+
+  add_compile_options(
+    /MT$<$<CONFIG:Debug>:d>  # static linking with the CRT
+    /Zc:__cplusplus
+    /Zi           # generate pdb files even in release mode
+    /sdl          # enable security checks
+    /Qspectre     # compile with the Spectre mitigations switch
+    /ZH:SHA_256   # enable secure source code hashing
+    /guard:cf     # enable compiler control guard feature (CFG) to prevent attackers from redirecting execution to unsafe locations
+    )
+  add_link_options(
+    /NODEFAULTLIB:libucrt$<$<CONFIG:Debug>:d>.lib  # Hybrid CRT
+    /DEFAULTLIB:ucrt$<$<CONFIG:Debug>:d>.lib       # Hybrid CRT
+    /DEBUG      # instruct linker to create debugging info
+    /guard:cf   # enable linker control guard feature (CFG) to prevent attackers from redirecting execution to unsafe locations
+    )
+endif()
+
+find_package(XRT REQUIRED HINTS ${XILINX_XRT}/share/cmake/XRT)
+message("-- XRT_INCLUDE_DIRS=${XRT_INCLUDE_DIRS}")
+
+add_executable(archive archive.cpp)
+target_include_directories(archive PRIVATE
+  ${XRT_INCLUDE_DIRS}
+  # path to runtime_src
+  ${CMAKE_CURRENT_SOURCE_DIR}/../../..)
+target_link_libraries(archive PRIVATE XRT::xrt_coreutil)
+
+if (NOT MSVC)
+  target_link_libraries(archive PRIVATE pthread uuid dl)
+endif()
+
+install(TARGETS archive)
+

--- a/src/runtime_src/core/common/test/archive.cpp
+++ b/src/runtime_src/core/common/test/archive.cpp
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+
+// Unit test for archive extraction
+//
+// % cmake -B build -DXILINX_XRT=<path>
+// % cmake --build build --config <Release|Debug>
+//
+// % ar q myarchive.a file1 file2 ...
+// % <path>/archive -a myarchive.a -m file2 -g file2
+
+#include "core/common/archive.h"
+
+#include <fstream>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+static void
+usage()
+{}
+
+void
+run(int argc, char* argv[])
+{
+  std::vector<std::string> args(argv+1,argv+argc);
+  std::string cur;
+  std::string archive_filename;
+  std::string archive_member;
+  std::string golden_filename;
+  for (auto& arg : args) {
+    if (arg == "-h") {
+      usage();
+      return;
+    }
+
+    if (arg[0] == '-') {
+      cur = arg;
+      continue;
+    }
+
+    if (cur == "--archive" || cur == "-a") {
+      archive_filename = arg;
+    }
+    else if (cur == "--member" || cur == "-m") {
+      archive_member = arg;
+    }
+    else if (cur == "--golden" || cur == "-g") {
+      golden_filename = arg;
+    }
+    else
+      throw std::runtime_error("Unknown option value " + cur + " " + arg);
+  }
+
+  if (archive_filename.empty())
+    throw std::runtime_error("--archive must be specified");
+
+  if (archive_member.empty())
+    throw std::runtime_error("--member must be specified");
+
+  // Open archive
+  xrt_core::archive archive(archive_filename);
+
+  // Extract archive member
+  auto data = archive.data(archive_member);
+
+  if (golden_filename.empty())
+    return;
+
+  // Compare data agaist golden
+  std::ifstream ifs(golden_filename, std::ios::binary);
+  if (!ifs)
+    throw std::runtime_error("Failed to open file: " + golden_filename);
+
+  std::string golden((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
+
+  if (data.size() != golden.size())
+    throw std::runtime_error
+      ("archive member data size (" + std::to_string(data.size())
+       + ") mismatch (" + std::to_string(golden.size()) + ")");
+
+  if (!std::equal(golden.data(), golden.data() + golden.size(), data.data()))
+    throw std::runtime_error("archive member data mismatch");
+}
+
+int main(int argc, char* argv[])
+{
+  try {
+    run(argc, argv);
+    return 0;
+  }
+  catch (const std::exception& ex) {
+    std::cout << "Exception caught: " << ex.what() << '\n';
+  }
+  catch (...) {
+    std::cout << "Unknown exception\n";
+  }
+  return 1;
+}


### PR DESCRIPTION
#### Problem solved by the commit
Use ARIO (part of ELFIO) as an archive extraction utility.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Idea is that xrt-smi will read validation data from an archive installed at build time.  The archive creation can be static and checked into VTD, or we can enhance build of XRT-MCDM and amdxdna to create the archive from VTD artifacts at build time.

Update ELFIO for archive support in newly added ARIO module.

