### PR TITLE
check if aied is enabled before thread creation

### DIFF
--- a/src/runtime_src/core/edge/user/aie/aied.cpp
+++ b/src/runtime_src/core/edge/user/aie/aied.cpp
@@ -32,6 +32,10 @@ namespace zynqaie {
 
 aied::aied(xrt_core::device* device): m_device(device)
 {
+  m_is_enable = xrt_core::config::get_enable_aied();
+
+  if(!m_is_enable)
+    return;
   done = false;
   pthread_create(&ptid, NULL, &aied::poll_aie, this);
   pthread_setname_np(ptid, "Graph Status");
@@ -39,6 +43,8 @@ aied::aied(xrt_core::device* device): m_device(device)
 
 aied::~aied()
 {
+  if(!m_is_enable)
+    return;
   done = true;
   pthread_kill(ptid, SIGUSR1);
   pthread_join(ptid, NULL);
@@ -55,9 +61,6 @@ aied::poll_aie(void* arg)
   xclAIECmd cmd;
 
   signal(SIGUSR1, signal_handler);
-
-  if (!xrt_core::config::get_enable_aied())
-    return NULL;
 
   /* Ever running thread */
   while (1) {

--- a/src/runtime_src/core/edge/user/aie/aied.h
+++ b/src/runtime_src/core/edge/user/aie/aied.h
@@ -42,6 +42,7 @@ public:
 
 private:
   bool done;
+  bool m_is_enable;
   static void* poll_aie(void *arg);
   xrt_core::device *m_device;
   std::vector<const graph_object*> m_graphs;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
AIED thread running in the background cause performance hit during reads/writes running with <lock_guard> even with enable_aied set to false.

fix is to create thread only when get_enable_aied() is true.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
NA
#### How problem was solved, alternative solutions (if any) and why they were rejected
create thread only when get_enable_aied() is true.
#### Risks (if any) associated the changes in the commit
None
#### What has been tested and how, request additional testing if necessary
performance tests of reads and writes
#### Documentation impact (if any)
NA