### PR TITLE
Add changes to dump UC log buffer

### DIFF
--- a/src/runtime_src/core/common/api/bo_int.h
+++ b/src/runtime_src/core/common/api/bo_int.h
@@ -35,19 +35,21 @@ enum class use_type {
 
 // create_bo() - Create a buffer object within a device for specific use case
 //
-// Allocates a buffer object in the given device. All the public xrt::bo constructors
-// doesnt use 64 bit flags. So this function acts as an extension to create buffer
-// with specific use flag (debug/dtrace/log). This API is useful for creating buffers
-// that outlive hw context.
+// Allocates a buffer object in the given device. All the public
+// xrt::bo constructors doesnt use 64 bit flags. So this function acts
+// as an extension to create buffer with specific use flag
+// (debug/dtrace/log). This API is useful for creating buffers that
+// outlive hw context.
 XRT_CORE_COMMON_EXPORT
 xrt::bo
 create_bo(const std::shared_ptr<xrt_core::device>& m_core_device, size_t sz, use_type type);
 
 // create_bo() - Create a buffer object within a hwctx for specific use case
 //
-// Allocates a buffer object within a hwctx. All the public xrt::bo constructors
-// doesnt use 64 bit flags. So this function acts as an extension to create buffer
-// with specific use flag (debug/dtrace/log).
+// Allocates a buffer object within a hwctx. All the public xrt::bo
+// constructors doesnt use 64 bit flags. So this function acts as an
+// extension to create buffer with specific use flag
+// (debug/dtrace/log).
 XRT_CORE_COMMON_EXPORT
 xrt::bo
 create_bo(const xrt::hw_context& hwctx, size_t sz, use_type type);
@@ -55,11 +57,12 @@ create_bo(const xrt::hw_context& hwctx, size_t sz, use_type type);
 // config_bo() - Configure the buffer object for the given use case (based on
 // the flag passed)
 //
-// Configure the buffer object to be used for debug, dtrace, log, debug queue
-// purpose based on buffer type. The buffer object is tied to a slot using
-// the hw ctx passed to this call. If the hwctx passed in null then hwctx that is
-// used to create the bo is used. A map of uc or column index and
-// buffer size is used to split the buffer among the columns in the partition/slot.
+// Configure the buffer object to be used for debug, dtrace, log,
+// debug queue purpose based on buffer type. The buffer object is tied
+// to a slot using the hw ctx passed to this call. If the hwctx passed
+// in null then hwctx that is used to create the bo is used. A map of
+// uc or column index and buffer size is used to split the buffer
+// among the columns in the partition/slot.
 XRT_CORE_COMMON_EXPORT
 void
 config_bo(const xrt::bo& bo, const std::map<uint32_t, size_t>& buf_sizes,
@@ -67,11 +70,11 @@ config_bo(const xrt::bo& bo, const std::map<uint32_t, size_t>& buf_sizes,
 
 // unconfig_bo() - Unconfigure the buffer object configured earlier
 //
-// XRT Userspace can use this function to explicitly unconfigure the bo. It gives
-// more control on when to unconfigure the bo instead of relying on buffer handle
-// destruction
-// NOTE: The caller must ensure that the same buffer object and context handle
-// used in the corresponding config_bo() call are passed to this function.
+// XRT Userspace can use this function to explicitly unconfigure the
+// bo. It gives more control on when to unconfigure the bo instead of
+// relying on buffer handle destruction NOTE: The caller must ensure
+// that the same buffer object and context handle used in the
+// corresponding config_bo() call are passed to this function.
 XRT_CORE_COMMON_EXPORT
 void
 unconfig_bo(const xrt::bo& bo, const xrt_core::hwctx_handle* ctx_handle = nullptr);

--- a/src/runtime_src/core/common/api/bo_int.h
+++ b/src/runtime_src/core/common/api/bo_int.h
@@ -33,6 +33,16 @@ enum class use_type {
   uc_debug = XRT_BO_USE_UC_DEBUG // For microblaze debug data
 };
 
+// create_bo() - Create a buffer object within a device for specific use case
+//
+// Allocates a buffer object in the given device. All the public xrt::bo constructors
+// doesnt use 64 bit flags. So this function acts as an extension to create buffer
+// with specific use flag (debug/dtrace/log). This API is useful for creating buffers
+// that outlive hw context.
+XRT_CORE_COMMON_EXPORT
+xrt::bo
+create_bo(std::shared_ptr<xrt_core::device> m_core_device, size_t sz, use_type type);
+
 // create_bo() - Create a buffer object within a hwctx for specific use case
 //
 // Allocates a buffer object within a hwctx. All the public xrt::bo constructors
@@ -47,11 +57,13 @@ create_bo(const xrt::hw_context& hwctx, size_t sz, use_type type);
 //
 // Configure the buffer object to be used for debug, dtrace, log, debug queue
 // purpose based on buffer type. The buffer object is tied to a slot using
-// the hw ctx that is used to create the bo. A map of uc or column index and
+// the hw ctx passed to this call. If the hwctx passed in null then hwctx that is
+// used to create the bo is used. A map of uc or column index and
 // buffer size is used to split the buffer among the columns in the partition/slot.
 XRT_CORE_COMMON_EXPORT
 void
-config_bo(const xrt::bo& bo, const std::map<uint32_t, size_t>& buf_sizes);
+config_bo(const xrt::bo& bo, const std::map<uint32_t, size_t>& buf_sizes,
+          const xrt_core::hwctx_handle* ctx_handle = nullptr);
 
 // unconfig_bo() - Unconfigure the buffer object configured earlier
 //
@@ -60,7 +72,7 @@ config_bo(const xrt::bo& bo, const std::map<uint32_t, size_t>& buf_sizes);
 // destruction
 XRT_CORE_COMMON_EXPORT
 void
-unconfig_bo(const xrt::bo& bo);
+unconfig_bo(const xrt::bo& bo, const xrt_core::hwctx_handle* ctx_handle = nullptr);
 
 } // bo_int, xrt_core
 

--- a/src/runtime_src/core/common/api/bo_int.h
+++ b/src/runtime_src/core/common/api/bo_int.h
@@ -41,7 +41,7 @@ enum class use_type {
 // that outlive hw context.
 XRT_CORE_COMMON_EXPORT
 xrt::bo
-create_bo(std::shared_ptr<xrt_core::device> m_core_device, size_t sz, use_type type);
+create_bo(const std::shared_ptr<xrt_core::device>& m_core_device, size_t sz, use_type type);
 
 // create_bo() - Create a buffer object within a hwctx for specific use case
 //
@@ -70,6 +70,8 @@ config_bo(const xrt::bo& bo, const std::map<uint32_t, size_t>& buf_sizes,
 // XRT Userspace can use this function to explicitly unconfigure the bo. It gives
 // more control on when to unconfigure the bo instead of relying on buffer handle
 // destruction
+// NOTE: The caller must ensure that the same buffer object and context handle
+// used in the corresponding config_bo() call are passed to this function.
 XRT_CORE_COMMON_EXPORT
 void
 unconfig_bo(const xrt::bo& bo, const xrt_core::hwctx_handle* ctx_handle = nullptr);

--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -1698,8 +1698,8 @@ get_offset(const xrt::bo& bo)
   return handle->get_offset();
 }
 
-xrt::bo
-create_bo(const std::shared_ptr<xrt_core::device>& device, size_t sz, use_type type)
+static xrtBufferFlags
+compose_internal_bo_flags(use_type type)
 {
   xcl_bo_flags flags {0};  // see xrt_mem.h
   flags.flags = XRT_BO_FLAGS_CACHEABLE;
@@ -1707,27 +1707,27 @@ create_bo(const std::shared_ptr<xrt_core::device>& device, size_t sz, use_type t
   flags.dir = XRT_BO_ACCESS_READ_WRITE;
   flags.use = static_cast<uint32_t>(type);
 
+  return flags.all;
+}
+
+xrt::bo
+create_bo(const std::shared_ptr<xrt_core::device>& device, size_t sz, use_type type)
+{
   // While the memory group should be ignored (inferred) for
   // debug / trace / log buffers, it is still passed in as a default
   // group 1 with no implied correlation to xclbin connectivity
   // or memory group.
-  return xrt::bo{alloc(device_type{device}, sz, flags.all, 1)};
+  return xrt::bo{alloc(device_type{device}, sz, compose_internal_bo_flags(type), 1)};
 }
 
 xrt::bo
 create_bo(const xrt::hw_context& hwctx, size_t sz, use_type type)
 {
-  xcl_bo_flags flags {0};  // see xrt_mem.h
-  flags.flags = XRT_BO_FLAGS_CACHEABLE;
-  flags.access = XRT_BO_ACCESS_LOCAL;
-  flags.dir = XRT_BO_ACCESS_READ_WRITE;
-  flags.use = static_cast<uint32_t>(type);
-
   // While the memory group should be ignored (inferred) for
   // debug / trace buffers, it is still passed in as a default
   // group 1 with no implied correlation to xclbin connectivity
   // or memory group.
-  return xrt::bo{alloc(device_type{hwctx}, sz, flags.all, 1)};
+  return xrt::bo{alloc(device_type{hwctx}, sz, compose_internal_bo_flags(type), 1)};
 }
 
 void

--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -1699,7 +1699,7 @@ get_offset(const xrt::bo& bo)
 }
 
 xrt::bo
-create_bo(std::shared_ptr<xrt_core::device> m_core_device, size_t sz, use_type type)
+create_bo(const std::shared_ptr<xrt_core::device>& device, size_t sz, use_type type)
 {
   xcl_bo_flags flags {0};  // see xrt_mem.h
   flags.flags = XRT_BO_FLAGS_CACHEABLE;
@@ -1711,7 +1711,7 @@ create_bo(std::shared_ptr<xrt_core::device> m_core_device, size_t sz, use_type t
   // debug / trace / log buffers, it is still passed in as a default
   // group 1 with no implied correlation to xclbin connectivity
   // or memory group.
-  return xrt::bo{alloc(device_type{m_core_device}, sz, flags.all, 1)};
+  return xrt::bo{alloc(device_type{device}, sz, flags.all, 1)};
 }
 
 xrt::bo
@@ -1737,16 +1737,18 @@ config_bo(const xrt::bo& bo, const std::map<uint32_t, size_t>& buf_sizes,
   auto bo_impl = bo.get_handle();
   // use the ctx handle passed to this call
   // else use ctx handle used to create this buffer object
-  ctx_handle ? bo_impl->get_handle()->config(ctx_handle, buf_sizes)
-             : bo_impl->get_handle()->config(bo_impl->get_hwctx_handle(), buf_sizes);
+  ctx_handle
+    ? bo_impl->get_handle()->config(ctx_handle, buf_sizes)
+    : bo_impl->get_handle()->config(bo_impl->get_hwctx_handle(), buf_sizes);
 }
 
 void
 unconfig_bo(const xrt::bo& bo, const xrt_core::hwctx_handle* ctx_handle)
 {
   auto bo_impl = bo.get_handle();
-  ctx_handle ? bo_impl->get_handle()->unconfig(ctx_handle)
-             : bo_impl->get_handle()->unconfig(bo_impl->get_hwctx_handle());
+  ctx_handle
+    ? bo_impl->get_handle()->unconfig(ctx_handle)
+    : bo_impl->get_handle()->unconfig(bo_impl->get_hwctx_handle());
 }
 
 } // xrt_core::bo_int

--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -1699,6 +1699,22 @@ get_offset(const xrt::bo& bo)
 }
 
 xrt::bo
+create_bo(std::shared_ptr<xrt_core::device> m_core_device, size_t sz, use_type type)
+{
+  xcl_bo_flags flags {0};  // see xrt_mem.h
+  flags.flags = XRT_BO_FLAGS_CACHEABLE;
+  flags.access = XRT_BO_ACCESS_LOCAL;
+  flags.dir = XRT_BO_ACCESS_READ_WRITE;
+  flags.use = static_cast<uint32_t>(type);
+
+  // While the memory group should be ignored (inferred) for
+  // debug / trace / log buffers, it is still passed in as a default
+  // group 1 with no implied correlation to xclbin connectivity
+  // or memory group.
+  return xrt::bo{alloc(device_type{m_core_device}, sz, flags.all, 1)};
+}
+
+xrt::bo
 create_bo(const xrt::hw_context& hwctx, size_t sz, use_type type)
 {
   xcl_bo_flags flags {0};  // see xrt_mem.h
@@ -1715,19 +1731,22 @@ create_bo(const xrt::hw_context& hwctx, size_t sz, use_type type)
 }
 
 void
-config_bo(const xrt::bo& bo, const std::map<uint32_t, size_t>& buf_sizes)
+config_bo(const xrt::bo& bo, const std::map<uint32_t, size_t>& buf_sizes,
+          const xrt_core::hwctx_handle* ctx_handle)
 {
   auto bo_impl = bo.get_handle();
-  auto ctx = bo_impl->get_hwctx_handle();
-  bo_impl->get_handle()->config(ctx, buf_sizes);
+  // use the ctx handle passed to this call
+  // else use ctx handle used to create this buffer object
+  ctx_handle ? bo_impl->get_handle()->config(ctx_handle, buf_sizes)
+             : bo_impl->get_handle()->config(bo_impl->get_hwctx_handle(), buf_sizes);
 }
 
 void
-unconfig_bo(const xrt::bo& bo)
+unconfig_bo(const xrt::bo& bo, const xrt_core::hwctx_handle* ctx_handle)
 {
   auto bo_impl = bo.get_handle();
-  auto ctx = bo_impl->get_hwctx_handle();
-  bo_impl->get_handle()->unconfig(ctx);
+  ctx_handle ? bo_impl->get_handle()->unconfig(ctx_handle)
+             : bo_impl->get_handle()->unconfig(bo_impl->get_hwctx_handle());
 }
 
 } // xrt_core::bo_int

--- a/src/runtime_src/core/common/api/xrt_hw_context.cpp
+++ b/src/runtime_src/core/common/api/xrt_hw_context.cpp
@@ -56,8 +56,8 @@ class hw_context_impl : public std::enable_shared_from_this<hw_context_impl>
     size_t m_size_per_uc;
     xrt::bo m_uc_log_bo; // log buffer used for uc logging
 
-    static void
-    dump_bo(xrt::bo& bo, const std::string& filename, size_t offset, size_t size)
+    void
+    dump_bo(const std::string& filename, size_t offset, size_t size)
     {
       std::ofstream ofs(filename, std::ios::out | std::ios::binary);
       if (!ofs.is_open()) {
@@ -66,7 +66,7 @@ class hw_context_impl : public std::enable_shared_from_this<hw_context_impl>
         return;
       }
 
-      auto buf = bo.map<char*>() + offset;
+      auto buf = m_uc_log_bo.map<char*>() + offset;
       ofs.write(buf, static_cast<std::streamsize>(size));
 
       std::stringstream ss;
@@ -75,14 +75,13 @@ class hw_context_impl : public std::enable_shared_from_this<hw_context_impl>
     }
 
     static xrt::bo
-    init_and_get_uc_log_bo(std::shared_ptr<xrt_core::device> device,
+    init_and_get_uc_log_bo(const std::shared_ptr<xrt_core::device>& device,
                            xrt_core::hwctx_handle* ctx_hdl,
                            size_t size_per_uc,
                            size_t num_uc)
     {
-      auto bo = xrt_core::bo_int::create_bo(std::move(device),
-                                            (size_per_uc * num_uc),
-                                            xrt_core::bo_int::use_type::log);
+      auto bo = xrt_core::bo_int::
+        create_bo(device, (size_per_uc * num_uc), xrt_core::bo_int::use_type::log);
 
       // create map with uc index and log buffer size
       std::map<uint32_t, size_t> uc_buf_map;
@@ -98,7 +97,7 @@ class hw_context_impl : public std::enable_shared_from_this<hw_context_impl>
     }
 
     // may throw
-    uc_log_buffer(std::shared_ptr<xrt_core::device> device,
+    uc_log_buffer(const std::shared_ptr<xrt_core::device>& device,
                   xrt_core::hwctx_handle* ctx_hdl,
                   size_t size)
       : m_num_uc(ctx_hdl->get_num_uc())
@@ -127,7 +126,7 @@ class hw_context_impl : public std::enable_shared_from_this<hw_context_impl>
         for (size_t i = 0; i < m_num_uc; i++) {
           auto file_name = "uc_log_" + std::to_string(xrt_core::utils::get_pid()) + "_"
               + time_stamp.str() + "_" + std::to_string(m_slot_idx) + "_" + std::to_string(i) + ".bin";
-          dump_bo(m_uc_log_bo, file_name, (i * m_size_per_uc), m_size_per_uc);
+          dump_bo(file_name, (i * m_size_per_uc), m_size_per_uc);
         }
       }
       catch (const std::exception& e) {
@@ -169,20 +168,21 @@ class hw_context_impl : public std::enable_shared_from_this<hw_context_impl>
   // Initializes uc log buffer, configures it by splitting the buffer
   // equally among available columns
   static std::unique_ptr<uc_log_buffer>
-  init_uc_log_buf(std::shared_ptr<xrt_core::device> device, xrt_core::hwctx_handle* ctx_hdl)
+  init_uc_log_buf(const std::shared_ptr<xrt_core::device>& device, xrt_core::hwctx_handle* ctx_hdl)
   {
     // Create uc log buffer only if ini option is enabled
+    // If enabled, but not supported then this function returns nullptr
     static auto uc_log_buf_size = xrt_core::config::get_log_buffer_size_per_uc();
     if (!uc_log_buf_size || !ctx_hdl)
       return nullptr;
 
-    // We get size of single uc but we create one buffer for all uc's and split it
-    // uc needs buffer that is 32 Byte aligned
+    // We get size of single uc but we create one buffer for all uc's
+    // and split it uc needs buffer that is 32 Byte aligned
     constexpr std::size_t alignment = 32;
     // round up size to be 32 Byte aligned
     size_t uc_aligned_size = (uc_log_buf_size + alignment - 1) & ~(alignment - 1);
     try {
-      return std::make_unique<uc_log_buffer>(std::move(device), ctx_hdl, uc_aligned_size);
+      return std::make_unique<uc_log_buffer>(device, ctx_hdl, uc_aligned_size);
     }
     catch (const std::exception& e) {
       xrt_core::message::send(xrt_core::message::severity_level::debug, "xrt_hw_context",
@@ -199,8 +199,7 @@ public:
     , m_mode(xrt::hw_context::access_mode::shared)
     , m_hdl{m_core_device->create_hw_context(xclbin_id, m_cfg_param, m_mode)}
     , m_uc_log_buf(init_uc_log_buf(m_core_device, m_hdl.get()))
-  {
-  }
+  {}
 
   hw_context_impl(std::shared_ptr<xrt_core::device> device, const xrt::uuid& xclbin_id, access_mode mode)
     : m_core_device{std::move(device)}

--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -1092,6 +1092,12 @@ get_run_buffer_pool_memory_mb()
   return value;
 }
 
+get_uc_log_buffer_size()
+{
+  static unsigned int value = detail::get_uint_value("Debug.uc_log_buf_size", 0);
+  return value;
+}
+
 }} // config,xrt_core
 
 #endif

--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -1092,9 +1092,10 @@ get_run_buffer_pool_memory_mb()
   return value;
 }
 
-get_uc_log_buffer_size()
+inline unsigned int
+get_log_buffer_size_per_uc()
 {
-  static unsigned int value = detail::get_uint_value("Debug.uc_log_buf_size", 0);
+  static unsigned int value = detail::get_uint_value("Debug.log_buf_size_per_uc", 0);
   return value;
 }
 

--- a/src/runtime_src/core/common/shim/buffer_handle.h
+++ b/src/runtime_src/core/common/shim/buffer_handle.h
@@ -116,7 +116,7 @@ public:
   // the flag that is used to create this bo. This call creates metadata
   // using map of column/uc index and buffer sizes and passes the info to driver.
   virtual void
-  config(xrt_core::hwctx_handle* /*ctx*/, const std::map<uint32_t, size_t>& /*buf_sizes*/)
+  config(const xrt_core::hwctx_handle* /*ctx*/, const std::map<uint32_t, size_t>& /*buf_sizes*/)
   {
     throw xrt_core::error(std::errc::not_supported, __func__);
   }
@@ -125,7 +125,7 @@ public:
   // If this call is not made explicitly the derived buffer_handle class
   // destoryer should handle the unconfiguring part.
   virtual void
-  unconfig(xrt_core::hwctx_handle*)
+  unconfig(const xrt_core::hwctx_handle*)
   {
     throw xrt_core::error(std::errc::not_supported, __func__);
   }

--- a/src/runtime_src/core/common/shim/hwctx_handle.h
+++ b/src/runtime_src/core/common/shim/hwctx_handle.h
@@ -55,6 +55,13 @@ public:
   virtual slot_id
   get_slotidx() const = 0;
 
+  // Get number of UCs in the hardware context created
+  virtual size_t
+  get_num_uc() const
+  {
+    throw xrt_core::error(std::errc::not_supported, __func__);
+  }
+
   // Get a hardware queue for this context.  The return value is
   // allowed to be nullptr if the shim does not support hardware
   // queues.  The returned hwqueue is owned by the hwctx, it is


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Added changes to dump firmware (uC) log buffer when ini option is enabled.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
#### How problem was solved, alternative solutions (if any) and why they were rejected
In hw ctx constructor, log buffer is created and initialized if ini option for firmware logging is enabled and the buffer is dumped in hw ctx destructor. We are dumping each uC log in separate file so that it is easy for user to understand the log. To identify between hwctx's its slotidx is used in file name.

#### Risks (if any) associated the changes in the commit
Low as it doesn't impact regular flow

#### What has been tested and how, request additional testing if necessary
Tested uC log buffer dumping in Telluride by implementing required virtual functions in Telluride shim

#### Documentation impact (if any)
May be we need to document about the new ini option.