### PR TITLE
[XRT-SMI]Interface buffer addition for firmware debuggability reports

### DIFF
--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -4112,14 +4112,11 @@ struct event_trace : request
 
   static const key_type key = key_type::event_trace;
 
-  std::any
-  get(const device*) const override = 0;
-
-  // Parameterized get method based on key_type
+  // Parameterized get method based on key_type passed via std::any
   // Returns event_trace_version if key is event_trace_version
   // Returns firmware_debug_buffer if key is event_trace
-  virtual std::any
-  get(const device*, const key_type&) const = 0;
+  std::any
+  get(const device*, const std::any& key) const override = 0;
 
   void
   put(const device*, const std::any&) const override = 0;
@@ -4143,14 +4140,11 @@ struct firmware_log : request
 
   static const key_type key = key_type::firmware_log;
 
-  std::any
-  get(const device*) const override = 0;
-
-  // Parameterized get method based on key_type
+  // Parameterized get method based on key_type passed via std::any
   // Returns firmware_log_version if key is firmware_log_version
   // Returns firmware_debug_buffer if key is firmware_log
-  virtual std::any
-  get(const device*, const key_type&) const = 0;
+  std::any
+  get(const device*, const std::any& key) const override = 0;
 
   void
   put(const device*, const std::any&) const override = 0;

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -324,7 +324,9 @@ enum class key_type
   performance_mode,
   preemption,
   event_trace,
+  event_trace_version,
   firmware_log,
+  firmware_log_version,
   frame_boundary_preemption,
   debug_ip_layout_path,
   debug_ip_layout,
@@ -4099,7 +4101,13 @@ struct firmware_debug_buffer {
 
 struct event_trace : request 
 {
-  using result_type = firmware_debug_buffer;  // get value type (shared buffer structure)
+  // Version struct for event trace
+  struct event_trace_version {
+    uint16_t major;
+    uint16_t minor;
+  };
+
+  using result_type = firmware_debug_buffer;  // Default result type for backward compatibility
   using value_type = uint32_t;                // put value type
 
   static const key_type key = key_type::event_trace;
@@ -4107,13 +4115,25 @@ struct event_trace : request
   std::any
   get(const device*) const override = 0;
 
+  // Parameterized get method based on key_type
+  // Returns event_trace_version if key is event_trace_version
+  // Returns firmware_debug_buffer if key is event_trace
+  virtual std::any
+  get(const device*, const key_type&) const = 0;
+
   void
   put(const device*, const std::any&) const override = 0;
 };
 
 struct firmware_log : request
 {  
-  using result_type = firmware_debug_buffer;  // get value type (shared buffer structure)
+  // Version struct for firmware log
+  struct firmware_log_version {
+    uint16_t major;
+    uint16_t minor;
+  };
+
+  using result_type = firmware_debug_buffer;  // Default result type for backward compatibility
   
   // Structure to hold both action and log_level parameters
   struct value_type {
@@ -4125,6 +4145,12 @@ struct firmware_log : request
 
   std::any
   get(const device*) const override = 0;
+
+  // Parameterized get method based on key_type
+  // Returns firmware_log_version if key is firmware_log_version
+  // Returns firmware_debug_buffer if key is firmware_log
+  virtual std::any
+  get(const device*, const key_type&) const = 0;
 
   void
   put(const device*, const std::any&) const override = 0;

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -4082,15 +4082,16 @@ struct preemption : request
  * supporting both polling and streaming modes of operation.
  * 
  * Fields:
- * - buffer_offset: Absolute index of last-read event. Updated by driver to new offset 
- *                  till the point where data is read from buffer.
+ * - abs_offset: Absolute index to begin loading the next chunk of data. To start with 0 in the very first read.
+                 Updated by driver to new offset from where the next read should start.
  * - data: Pointer to data buffer to be filled by driver with firmware log/trace data
- * - size: Size in bytes of the data buffer filled by driver
- * - b_wait: Directive for driver whether to wait for new events or return immediately.
- *           True = wait for new events. Always false for non-watch mode operations.
+ * - size: size of the buffer. When used from userspace->driver : size(in bytes) of the allocated buffer
+                               When used from driver->userspace : size(in bytes) of the filled buffer
+ * - b_wait: Directive for driver whether to wait for new events or return immediately 
+             in-case there is nothing to read.
  */
-struct firmware_log_buffer {
-    uint64_t buffer_offset;
+struct firmware_debug_buffer {
+    uint64_t abs_offset;
     void* data;
     uint64_t size;
     bool b_wait;
@@ -4098,7 +4099,7 @@ struct firmware_log_buffer {
 
 struct event_trace : request 
 {
-  using result_type = firmware_log_buffer;  // get value type (shared buffer structure)
+  using result_type = firmware_debug_buffer;  // get value type (shared buffer structure)
   using value_type = uint32_t;                // put value type
 
   static const key_type key = key_type::event_trace;
@@ -4112,7 +4113,7 @@ struct event_trace : request
 
 struct firmware_log : request
 {  
-  using result_type = firmware_log_buffer;  // get value type (shared buffer structure)
+  using result_type = firmware_debug_buffer;  // get value type (shared buffer structure)
   
   // Structure to hold both action and log_level parameters
   struct value_type {

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -4077,10 +4077,29 @@ struct preemption : request
 
 };
 
+/**
+ * This structure provides a common interface for accessing firmware debug data,
+ * supporting both polling and streaming modes of operation.
+ * 
+ * Fields:
+ * - buffer_offset: Absolute index of last-read event. Updated by driver to new offset 
+ *                  till the point where data is read from buffer.
+ * - data: Pointer to data buffer to be filled by driver with firmware log/trace data
+ * - size: Size in bytes of the data buffer filled by driver
+ * - b_wait: Directive for driver whether to wait for new events or return immediately.
+ *           True = wait for new events. Always false for non-watch mode operations.
+ */
+struct firmware_log_buffer {
+    uint64_t buffer_offset;
+    void* data;
+    uint64_t size;
+    bool b_wait;
+};
+
 struct event_trace : request 
 {
-  using result_type = uint32_t;  // get value type
-  using value_type = uint32_t;   // put value type
+  using result_type = firmware_log_buffer;  // get value type (shared buffer structure)
+  using value_type = uint32_t;                // put value type
 
   static const key_type key = key_type::event_trace;
 
@@ -4093,7 +4112,7 @@ struct event_trace : request
 
 struct firmware_log : request
 {  
-  using result_type = uint32_t;  // get value type
+  using result_type = firmware_log_buffer;  // get value type (shared buffer structure)
   
   // Structure to hold both action and log_level parameters
   struct value_type {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
This PR adds the buffer required for log streaming between Drivers and XRT-SMI. 

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
None

#### How problem was solved, alternative solutions (if any) and why they were rejected
The firmware_debug_buffer will be used as buffer type for payload streaming to xrt-smi. Both XDNA and MCDM will use this buffer to fill up trace events and firmware logs. 

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Will be tested once firmware events are logged onto the buffer.

#### Documentation impact (if any)
NA
