### PR TITLE
hip: api: generalize error handling

### DIFF
--- a/src/runtime_src/hip/api/hip_context.cpp
+++ b/src/runtime_src/hip/api/hip_context.cpp
@@ -129,109 +129,55 @@ hip_device_primary_ctx_retain(device_handle dev)
 hipError_t
 hipCtxCreate(hipCtx_t* ctx, unsigned int flags, hipDevice_t device)
 {
-  try {
+  return handle_hip_func_error(__func__, hipErrorUnknown, [&] {
     throw_invalid_value_if(!ctx, "ctx passed is nullptr");
 
     auto handle = xrt::core::hip::hip_ctx_create(flags, device);
     *ctx = reinterpret_cast<hipCtx_t>(handle);
-    return hipSuccess;
-  }
-  catch (const xrt_core::system_error& ex) {
-    xrt_core::send_exception_message(std::string(__func__) +  " - " + ex.what());
-    return static_cast<hipError_t>(ex.value());
-  }
-  catch (const std::exception& ex) {
-    xrt_core::send_exception_message(ex.what());
-  }
-  return hipErrorUnknown;
+  });
 }
 
 hipError_t
 hipCtxDestroy(hipCtx_t ctx)
 {
-  try {
+  return handle_hip_func_error(__func__, hipErrorUnknown, [&] {
     xrt::core::hip::hip_ctx_destroy(ctx);
-    return hipSuccess;
-  }
-  catch (const xrt_core::system_error& ex) {
-    xrt_core::send_exception_message(std::string(__func__) +  " - " + ex.what());
-    return static_cast<hipError_t>(ex.value());
-  }
-  catch (const std::exception& ex) {
-    xrt_core::send_exception_message(ex.what());
-  }
-  return hipErrorUnknown;
+  });
 }
 
 hipError_t
 hipCtxGetDevice(hipDevice_t* device)
 {
-  try {
+  return handle_hip_func_error(__func__, hipErrorUnknown, [&] {
     throw_invalid_value_if(!device, "device passed is nullptr");
 
     *device = static_cast<int>(xrt::core::hip::hip_ctx_get_device());
-    return hipSuccess;
-  }
-  catch (const xrt_core::system_error& ex) {
-    xrt_core::send_exception_message(std::string(__func__) +  " - " + ex.what());
-    return static_cast<hipError_t>(ex.value());
-  }
-  catch (const std::exception& ex) {
-    xrt_core::send_exception_message(ex.what());
-  }
-  return hipErrorUnknown;
+  });
 }
 
 hipError_t
 hipCtxSetCurrent(hipCtx_t ctx)
 {
-  try {
+  return handle_hip_func_error(__func__, hipErrorUnknown, [&] {
     xrt::core::hip::hip_ctx_set_current(ctx);
-    return hipSuccess;
-  }
-  catch (const xrt_core::system_error& ex) {
-    xrt_core::send_exception_message(std::string(__func__) +  " - " + ex.what());
-    return static_cast<hipError_t>(ex.value());
-  }
-  catch (const std::exception& ex) {
-    xrt_core::send_exception_message(ex.what());
-  }
-  return hipErrorUnknown;
+  });
 }
 
 hipError_t
 hipDevicePrimaryCtxRetain(hipCtx_t* pctx, hipDevice_t dev)
 {
-  try {
+  return handle_hip_func_error(__func__, hipErrorUnknown, [&] {
     throw_invalid_value_if(!pctx, "nullptr passed");
 
     auto handle = xrt::core::hip::hip_device_primary_ctx_retain(dev);
     *pctx = reinterpret_cast<hipCtx_t>(handle);
-    return hipSuccess;
-  }
-  catch (const xrt_core::system_error& ex) {
-    xrt_core::send_exception_message(std::string(__func__) +  " - " + ex.what());
-    return static_cast<hipError_t>(ex.value());
-  }
-  catch (const std::exception& ex) {
-    xrt_core::send_exception_message(ex.what());
-  }
-  return hipErrorUnknown;
+  });
 }
 
 hipError_t
 hipDevicePrimaryCtxRelease(hipDevice_t dev)
 {
-  try {
+  return handle_hip_func_error(__func__, hipErrorUnknown, [&] {
     xrt::core::hip::hip_device_primary_ctx_release(dev);
-    return hipSuccess;
-  }
-  catch (const xrt_core::system_error& ex) {
-    xrt_core::send_exception_message(std::string(__func__) +  " - " + ex.what());
-    return static_cast<hipError_t>(ex.value());
-  }
-  catch (const std::exception& ex) {
-    xrt_core::send_exception_message(ex.what());
-  }
-  return hipErrorUnknown;
+  });
 }

--- a/src/runtime_src/hip/api/hip_device.cpp
+++ b/src/runtime_src/hip/api/hip_device.cpp
@@ -156,62 +156,32 @@ hip_kernel_name_ref(const hipFunction_t f)
 hipError_t
 hipInit(unsigned int flags)
 {
-  try {
-    xrt::core::hip::hip_init(flags);
-    return hipSuccess;
-  }
-  catch (const xrt_core::system_error& ex) {
-    xrt_core::send_exception_message(std::string(__func__) +  " - " + ex.what());
-    return static_cast<hipError_t>(ex.value());
-  }
-  catch (const std::exception& ex) {
-    xrt_core::send_exception_message(ex.what());
-  }
-  return hipErrorNotInitialized;
+  return handle_hip_func_error(__func__, hipErrorNotInitialized, [&] {
+    xrt::core::hip::hip_init(flags); });
 }
 
 hipError_t
 hipGetDeviceCount(size_t* count)
 {
-  try {
+  return handle_hip_func_error(__func__, hipErrorUnknown, [&] {
     throw_invalid_value_if(!count, "arg passed is nullptr");
-
     *count = xrt::core::hip::hip_get_device_count();
-    return hipSuccess;
-  }
-  catch (const xrt_core::system_error& ex) {
-    xrt_core::send_exception_message(std::string(__func__) +  " - " + ex.what());
-    return static_cast<hipError_t>(ex.value());
-  }
-  catch (const std::exception& ex) {
-    xrt_core::send_exception_message(ex.what());
-  }
-  return hipErrorUnknown;
+  });
 }
 
 hipError_t
 hipDeviceGet(hipDevice_t* device, int ordinal)
 {
-  try {
+  return handle_hip_func_error(__func__, hipErrorUnknown, [&] {
     throw_invalid_value_if(!device, "device is nullptr");
-
     *device = xrt::core::hip::hip_device_get(ordinal);
-    return hipSuccess;
-  }
-  catch (const xrt_core::system_error& ex) {
-    xrt_core::send_exception_message(std::string(__func__) +  " - " + ex.what());
-    return static_cast<hipError_t>(ex.value());
-  }
-  catch (const std::exception& ex) {
-    xrt_core::send_exception_message(ex.what());
-  }
-  return hipErrorUnknown;
+  });
 }
 
 hipError_t
 hipDeviceGetName(char* name, int len, hipDevice_t device)
 {
-  try {
+  return handle_hip_func_error(__func__, hipErrorUnknown, [&] {
     throw_invalid_value_if((!name || len <= 0), "invalid arg");
 
     auto name_str = xrt::core::hip::hip_device_get_name(device);
@@ -220,16 +190,7 @@ hipDeviceGetName(char* name, int len, hipDevice_t device)
     auto cpy_size = (static_cast<size_t>(len) <= (name_str.length() + 1) ? (len - 1) : name_str.length());
     std::memcpy(name, name_str.c_str(), cpy_size);
     name[cpy_size] = '\0';
-    return hipSuccess;
-  }
-  catch (const xrt_core::system_error& ex) {
-    xrt_core::send_exception_message(std::string(__func__) +  " - " + ex.what());
-    return static_cast<hipError_t>(ex.value());
-  }
-  catch (const std::exception& ex) {
-    xrt_core::send_exception_message(ex.what());
-  }
-  return hipErrorUnknown;
+  });
 }
 
 #if HIP_VERSION >= 60000000
@@ -256,91 +217,49 @@ hipError_t
 hipGetDeviceProperties(hipDeviceProp_t* props, hipDevice_t device)
 #endif
 {
-  try {
+  return handle_hip_func_error(__func__, hipErrorUnknown, [&] {
     throw_invalid_value_if(!props, "arg passed is nullptr");
-
     *props = xrt::core::hip::hip_get_device_properties(device);
-    return hipSuccess;
-  }
-  catch (const xrt_core::system_error& ex) {
-    xrt_core::send_exception_message(std::string(__func__) +  " - " + ex.what());
-    return static_cast<hipError_t>(ex.value());
-  }
-  catch (const std::exception& ex) {
-    xrt_core::send_exception_message(ex.what());
-  }
-  return hipErrorUnknown;
+  });
 }
 
 hipError_t
 hipDeviceGetUuid(hipUUID* uuid, hipDevice_t device)
 {
-  try {
+  return handle_hip_func_error(__func__, hipErrorUnknown, [&] {
     throw_invalid_value_if(!uuid, "arg passed is nullptr");
-
     *uuid = xrt::core::hip::hip_device_get_uuid(device);
-    return hipSuccess;
-  }
-  catch (const xrt_core::system_error& ex) {
-    xrt_core::send_exception_message(std::string(__func__) +  " - " + ex.what());
-    return static_cast<hipError_t>(ex.value());
-  }
-  catch (const std::exception& ex) {
-    xrt_core::send_exception_message(ex.what());
-  }
-  return hipErrorUnknown;
+  });
 }
 
 hipError_t
 hipDeviceGetAttribute(int* pi, hipDeviceAttribute_t attr, int device)
 {
-  try {
+  return handle_hip_func_error(__func__, hipErrorUnknown, [&] {
     throw_invalid_value_if(!pi, "arg passed is nullptr");
-
     *pi = xrt::core::hip::hip_device_get_attribute(attr, device);
-    return hipSuccess;
-  }
-  catch (const xrt_core::system_error& ex) {
-    xrt_core::send_exception_message(std::string(__func__) +  " - " + ex.what());
-    return static_cast<hipError_t>(ex.value());
-  }
-  catch (const std::exception& ex) {
-    xrt_core::send_exception_message(ex.what());
-  }
-  return hipErrorUnknown;
+  });
 }
 
 hipError_t
 hipSetDevice(int device)
 {
-  try {
+  return handle_hip_func_error(__func__, hipErrorUnknown, [&] {
     xrt::core::hip::hip_set_device(device);
-    return hipSuccess;
-  }
-  catch (const xrt_core::system_error& ex) {
-    xrt_core::send_exception_message(std::string(__func__) +  " - " + ex.what());
-    return static_cast<hipError_t>(ex.value());
-  }
-  catch (const std::exception& ex) {
-    xrt_core::send_exception_message(std::string(__func__) + " - " + ex.what());
-  }
-  return hipErrorUnknown;
+  });
 }
 
 const char *
 hipKernelNameRef(const hipFunction_t f)
 {
-  try {
+  const char* kname_ref = nullptr;
+  hipError_t err = handle_hip_func_error(__func__, hipErrorInvalidValue, [&] {
     throw_invalid_value_if(!f, "arg passed is nullptr");
+    kname_ref = xrt::core::hip::hip_kernel_name_ref(f);
+  });
 
-    return xrt::core::hip::hip_kernel_name_ref(f);
-  }
-  catch (const xrt_core::system_error& ex) {
-    xrt_core::send_exception_message(std::string(__func__) +  " - " + ex.what());
+  if (err != hipSuccess)
     return nullptr;
-  }
-  catch (const std::exception& ex) {
-    xrt_core::send_exception_message(ex.what());
-  }
-  return nullptr;
+
+  return kname_ref;
 }

--- a/src/runtime_src/hip/api/hip_device.cpp
+++ b/src/runtime_src/hip/api/hip_device.cpp
@@ -105,9 +105,10 @@ hip_device_get_name(hipDevice_t device)
   return (xrt_core::device_query<xrt_core::query::rom_vbnv>((device_cache.get_or_error(device))->get_xrt_device().get_handle()));
 }
 
-static hipDeviceProp_t
-hip_get_device_properties(hipDevice_t device)
+static void
+hip_get_device_properties(hipDeviceProp_t* props, hipDevice_t device)
 {
+  throw_invalid_value_if(!props, "arg passed is nullptr");
   throw_invalid_device_if(check(device), "device requested is not available");
 
   throw std::runtime_error("Not implemented");
@@ -127,9 +128,10 @@ hip_device_get_uuid(hipDevice_t device)
   return uid;
 }
 
-static int
-hip_device_get_attribute(hipDeviceAttribute_t attr, int device)
+static void
+hip_device_get_attribute(int* pi, hipDeviceAttribute_t attr, int device)
 {
+  throw_invalid_value_if(!pi, "arg passed is nullptr");
   throw_invalid_device_if(check(device), "device requested is not available");
 
   throw std::runtime_error("Not implemented");
@@ -218,8 +220,7 @@ hipGetDeviceProperties(hipDeviceProp_t* props, hipDevice_t device)
 #endif
 {
   return handle_hip_func_error(__func__, hipErrorUnknown, [&] {
-    throw_invalid_value_if(!props, "arg passed is nullptr");
-    *props = xrt::core::hip::hip_get_device_properties(device);
+    xrt::core::hip::hip_get_device_properties(props, device);
   });
 }
 
@@ -236,8 +237,7 @@ hipError_t
 hipDeviceGetAttribute(int* pi, hipDeviceAttribute_t attr, int device)
 {
   return handle_hip_func_error(__func__, hipErrorUnknown, [&] {
-    throw_invalid_value_if(!pi, "arg passed is nullptr");
-    *pi = xrt::core::hip::hip_device_get_attribute(attr, device);
+	xrt::core::hip::hip_device_get_attribute(pi, attr, device);
   });
 }
 

--- a/src/runtime_src/hip/api/hip_event.cpp
+++ b/src/runtime_src/hip/api/hip_event.cpp
@@ -69,117 +69,68 @@ static bool hip_event_query(hipEvent_t eve)
 // =========================================================================
 hipError_t hipEventCreate(hipEvent_t* event)
 {
-  try {
+  return handle_hip_func_error(__func__, hipErrorUnknown, [&] {
     throw_invalid_value_if(!event, "event passed is nullptr");
 
     auto handle = xrt::core::hip::hip_event_create();
     *event = reinterpret_cast<hipEvent_t>(handle);
-    return hipSuccess;
-  }
-  catch (const xrt_core::system_error& ex) {
-    xrt_core::send_exception_message(std::string(__func__) +  " - " + ex.what());
-    return static_cast<hipError_t>(ex.value());
-  }
-  catch (const std::exception& ex) {
-    xrt_core::send_exception_message(ex.what());
-  }
-  return hipErrorUnknown;
+  });
 }
 
 hipError_t hipEventDestroy(hipEvent_t event)
 {
-  try {
+  return handle_hip_func_error(__func__, hipErrorUnknown, [&] {
     throw_invalid_value_if(!event, "event passed is nullptr");
-    
+
     xrt::core::hip::hip_event_destroy(event);
-    return hipSuccess;
-  }
-  catch (const xrt_core::system_error& ex) {
-    xrt_core::send_exception_message(std::string(__func__) +  " - " + ex.what());
-    return static_cast<hipError_t>(ex.value());
-  }
-  catch (const std::exception& ex) {
-    xrt_core::send_exception_message(ex.what());
-  }
-  return hipErrorUnknown;
+  });
 }
 
 hipError_t hipEventSynchronize(hipEvent_t event)
 {
-  try {
+  return handle_hip_func_error(__func__, hipErrorUnknown, [&] {
     throw_invalid_value_if(!event, "event passed is nullptr");
 
     xrt::core::hip::hip_event_synchronize(event);
-    return hipSuccess;
-  }
-  catch (const xrt_core::system_error& ex) {
-    xrt_core::send_exception_message(std::string(__func__) +  " - " + ex.what());
-    return static_cast<hipError_t>(ex.value());
-  }
-  catch (const std::exception& ex) {
-    xrt_core::send_exception_message(ex.what());
-  }
-  return hipErrorUnknown;
+  });
 }
 
 hipError_t hipEventRecord(hipEvent_t event, hipStream_t stream)
 {
-  try {
+  return handle_hip_func_error(__func__, hipErrorUnknown, [&] {
     throw_invalid_value_if(!event, "event passed is nullptr");
     throw_invalid_value_if(!stream, "stream passed is nullptr");
 
     xrt::core::hip::hip_event_record(event, stream);
-    return hipSuccess;
-  }
-  catch (const xrt_core::system_error& ex) {
-    xrt_core::send_exception_message(std::string(__func__) +  " - " + ex.what());
-    return static_cast<hipError_t>(ex.value());
-  }
-  catch (const std::exception& ex) {
-    xrt_core::send_exception_message(ex.what());
-  }
-  return hipErrorUnknown;
+  });
 }
 
 hipError_t hipEventQuery (hipEvent_t event)
 {
-  try {
+  hipError_t err = hipErrorUnknown, ret = hipSuccess;
+  err = handle_hip_func_error(__func__, hipErrorUnknown, [&] {
     throw_invalid_value_if(!event, "event passed is nullptr");
 
     if (xrt::core::hip::hip_event_query(event)){
-      return hipSuccess;
+      ret = hipSuccess;
     }
     else {
-      return hipErrorNotReady;
+      ret = hipErrorNotReady;
     }
-  }
-  catch (const xrt_core::system_error& ex) {
-    xrt_core::send_exception_message(std::string(__func__) +  " - " + ex.what());
-    return static_cast<hipError_t>(ex.value());
-  }
-  catch (const std::exception& ex) {
-    xrt_core::send_exception_message(ex.what());
-  }
-  return hipErrorUnknown;
+  });
+  if (err != hipSuccess)
+    return err;
+  return ret;
 }
 
 hipError_t hipEventElapsedTime (float *ms, hipEvent_t start, hipEvent_t stop)
 {
-  try {
+  return handle_hip_func_error(__func__, hipErrorUnknown, [&] {
     throw_invalid_value_if(!start, "start event passed is nullptr");
     throw_invalid_value_if(!stop, "stop event passed is nullptr");
     throw_invalid_value_if(!ms, "the ms (elapsed time output) passed is nullptr");
 
     *ms = xrt::core::hip::hip_event_elapsed_time(start, stop);
-    return hipSuccess;
-  }
-  catch (const xrt_core::system_error& ex) {
-    xrt_core::send_exception_message(std::string(__func__) +  " - " + ex.what());
-    return static_cast<hipError_t>(ex.value());
-  }
-  catch (const std::exception& ex) {
-    xrt_core::send_exception_message(ex.what());
-  }
-  return hipErrorUnknown;
+  });
 }
 

--- a/src/runtime_src/hip/api/hip_module.cpp
+++ b/src/runtime_src/hip/api/hip_module.cpp
@@ -175,45 +175,27 @@ hipModuleLaunchKernel(hipFunction_t f, uint32_t gridDimX, uint32_t gridDimY,
                       uint32_t blockDimZ, uint32_t sharedMemBytes, hipStream_t hStream,
                       void** kernelParams, void** extra)
 {
-  try {
+  return handle_hip_func_error(__func__, hipErrorUnknown, [&] {
     xrt::core::hip::hip_module_launch_kernel(f, gridDimX, gridDimY, gridDimZ, blockDimX, blockDimY,
                                              blockDimZ, sharedMemBytes, hStream, kernelParams, extra);
-    return hipSuccess;
-  }
-  catch (const xrt_core::system_error& ex) {
-    xrt_core::send_exception_message(std::string(__func__) +  " - " + ex.what());
-    return static_cast<hipError_t>(ex.value());
-  }
-  catch (const std::exception& ex) {
-    xrt_core::send_exception_message(ex.what());
-  }
-  return hipErrorUnknown;
+  });
 }
 
 hipError_t
 hipModuleGetFunction(hipFunction_t* hfunc, hipModule_t hmod, const char* name)
 {
-  try {
+  return handle_hip_func_error(__func__, hipErrorUnknown, [&] {
     throw_invalid_handle_if(!hfunc, "function passed is nullptr");
 
     auto handle = xrt::core::hip::hip_module_get_function(hmod, name);
     *hfunc = reinterpret_cast<hipFunction_t>(handle);
-    return hipSuccess;
-  }
-  catch (const xrt_core::system_error& ex) {
-    xrt_core::send_exception_message(std::string(__func__) +  " - " + ex.what());
-    return static_cast<hipError_t>(ex.value());
-  }
-  catch (const std::exception& ex) {
-    xrt_core::send_exception_message(ex.what());
-  }
-  return hipErrorUnknown;
+  });
 }
 
 static hipError_t
 hip_module_load_data_helper(hipModule_t* module, const void* image)
 {
-  try {
+  return handle_hip_func_error(__func__, hipErrorUnknown, [&] {
     throw_invalid_resource_if(!module, "module is nullptr");
 
     // Treat pointer passed has data to full ELF and
@@ -224,7 +206,7 @@ hip_module_load_data_helper(hipModule_t* module, const void* image)
       auto estimated_size = xrt::core::hip::estimate_elf_size(image);
       handle = xrt::core::hip::create_full_elf_module(image, estimated_size);
       *module = reinterpret_cast<hipModule_t>(handle);
-      return hipSuccess;
+      return;
     }
     catch (...) { /*do nothing*/ }
 
@@ -232,16 +214,7 @@ hip_module_load_data_helper(hipModule_t* module, const void* image)
     auto config_data = static_cast<const hipModuleData*>(image);
     handle = xrt::core::hip::create_module(config_data);
     *module = reinterpret_cast<hipModule_t>(handle);
-    return hipSuccess;
-  }
-  catch (const xrt_core::system_error& ex) {
-    xrt_core::send_exception_message(std::string(__func__) +  " - " + ex.what());
-    return static_cast<hipError_t>(ex.value());
-  }
-  catch (const std::exception& ex) {
-    xrt_core::send_exception_message(ex.what());
-  }
-  return hipErrorUnknown;
+  });
 }
 
 hipError_t
@@ -263,7 +236,7 @@ hipModuleLoadData(hipModule_t* module, const void* image)
 hipError_t
 hipModuleLoad(hipModule_t* module, const char* fname)
 {
-  try {
+  return handle_hip_func_error(__func__, hipErrorUnknown, [&] {
     throw_invalid_resource_if(!module, "module is nullptr");
 
     // Treat fname passed is filepath to full ELF and
@@ -273,55 +246,28 @@ hipModuleLoad(hipModule_t* module, const char* fname)
     try {
       handle = xrt::core::hip::create_full_elf_module(std::string{fname});
       *module = reinterpret_cast<hipModule_t>(handle);
-      return hipSuccess;
+      return;
     }
     catch (...) { /*do nothing*/ }
 
     handle = xrt::core::hip::create_xclbin_module(std::string{fname});
     *module = reinterpret_cast<hipModule_t>(handle);
-    return hipSuccess;
-  }
-  catch (const xrt_core::system_error& ex) {
-    xrt_core::send_exception_message(std::string(__func__) +  " - " + ex.what());
-    return static_cast<hipError_t>(ex.value());
-  }
-  catch (const std::exception& ex) {
-    xrt_core::send_exception_message(ex.what());
-  }
-  return hipErrorUnknown;
+  });
 }
 
 hipError_t
 hipModuleUnload(hipModule_t hmod)
 {
-  try {
+  return handle_hip_func_error(__func__, hipErrorUnknown, [&] {
     xrt::core::hip::hip_module_unload(hmod);
-    return hipSuccess;
-  }
-  catch (const xrt_core::system_error& ex) {
-    xrt_core::send_exception_message(std::string(__func__) +  " - " + ex.what());
-    return static_cast<hipError_t>(ex.value());
-  }
-  catch (const std::exception& ex) {
-    xrt_core::send_exception_message(ex.what());
-  }
-  return hipErrorUnknown;
+  });
 }
 
 hipError_t
 hipFuncSetAttribute(const void* func, hipFuncAttribute attr, int value)
 {
-  try {
+  return handle_hip_func_error(__func__, hipErrorUnknown, [&] {
     xrt::core::hip::hip_func_set_attribute(func, attr, value);
-    return hipSuccess;
-  }
-  catch (const xrt_core::system_error& ex) {
-    xrt_core::send_exception_message(std::string(__func__) +  " - " + ex.what());
-    return static_cast<hipError_t>(ex.value());
-  }
-  catch (const std::exception& ex) {
-    xrt_core::send_exception_message(ex.what());
-  }
-  return hipErrorUnknown;
+  });
 }
 

--- a/src/runtime_src/hip/api/hip_stream.cpp
+++ b/src/runtime_src/hip/api/hip_stream.cpp
@@ -119,71 +119,31 @@ hip_stream_wait_event(hipStream_t stream, hipEvent_t ev, unsigned int flags)
 hipError_t
 hipStreamCreateWithFlags(hipStream_t* stream, unsigned int flags)
 {
-  try {
+  return handle_hip_func_error(__func__, hipErrorUnknown, [&] {
     throw_invalid_value_if(!stream, "stream passed is nullptr");
-
     auto handle = xrt::core::hip::hip_stream_create_with_flags(flags);
     *stream = reinterpret_cast<hipStream_t>(handle);
-    return hipSuccess;
-  }
-  catch (const xrt_core::system_error& ex) {
-    xrt_core::send_exception_message(std::string(__func__) +  " - " + ex.what());
-    return static_cast<hipError_t>(ex.value());
-  }
-  catch (const std::exception& ex) {
-    xrt_core::send_exception_message(ex.what());
-  }
-  return hipErrorUnknown;
+  });
 }
 
 hipError_t
 hipStreamDestroy(hipStream_t stream)
 {
-  try {
-    xrt::core::hip::hip_stream_destroy(stream);
-    return hipSuccess;
-  }
-  catch (const xrt_core::system_error& ex) {
-    xrt_core::send_exception_message(std::string(__func__) +  " - " + ex.what());
-    return static_cast<hipError_t>(ex.value());
-  }
-  catch (const std::exception& ex) {
-    xrt_core::send_exception_message(ex.what());
-  }
-  return hipErrorUnknown;
+  return handle_hip_func_error(__func__, hipErrorUnknown, [&] {
+    xrt::core::hip::hip_stream_destroy(stream); });
 }
 
 hipError_t
 hipStreamSynchronize(hipStream_t stream)
 {
-  try {
-    xrt::core::hip::hip_stream_synchronize(stream);
-    return hipSuccess;
-  }
-  catch (const xrt_core::system_error& ex) {
-    xrt_core::send_exception_message(std::string(__func__) +  " - " + ex.what());
-    return static_cast<hipError_t>(ex.value());
-  }
-  catch (const std::exception& ex) {
-    xrt_core::send_exception_message(ex.what());
-  }
-  return hipErrorUnknown;
+  return handle_hip_func_error(__func__, hipErrorUnknown, [&] {
+    xrt::core::hip::hip_stream_synchronize(stream); });
 }
 
 hipError_t
 hipStreamWaitEvent(hipStream_t stream, hipEvent_t event, unsigned int flags)
 {
-  try {
-    xrt::core::hip::hip_stream_wait_event(stream, event, flags);
-    return hipSuccess;
-  }
-  catch (const xrt_core::system_error& ex) {
-    xrt_core::send_exception_message(std::string(__func__) +  " - " + ex.what());
-    return static_cast<hipError_t>(ex.value());
-  }
-  catch (const std::exception& ex) {
-    xrt_core::send_exception_message(ex.what());
-  }
-  return hipErrorUnknown;
+  return handle_hip_func_error(__func__, hipErrorUnknown, [&] {
+    xrt::core::hip::hip_stream_wait_event(stream, event, flags); });
 }
 

--- a/src/runtime_src/hip/core/common.h
+++ b/src/runtime_src/hip/core/common.h
@@ -45,6 +45,23 @@ insert_in_map(map& m, value&& v)
 } // xrt::core::hip
 
 namespace {
+template<typename F> hipError_t
+handle_hip_func_error(const char* func_name, hipError_t default_err, F && f)
+{
+  try {
+    std::forward<F>(f)();
+    return hipSuccess;
+  }
+  catch (const xrt_core::system_error &ex) {
+    xrt_core::send_exception_message(std::string(func_name) + " - " + ex.what());
+    return static_cast<hipError_t>(ex.value());
+  }
+  catch (const std::exception &ex) {
+    xrt_core::send_exception_message(std::string(func_name) + " - " + ex.what());
+  }
+  return default_err;
+}
+
 // common functions for throwing hip errors
 inline void
 throw_if(bool check, hipError_t err, const char* err_msg)


### PR DESCRIPTION
Generalize error handling for XRT hip external APIs. This modification doesn't change the return error values or how it capture errors. Instead, it generalizes the code to handle error and return error, which reduces code duplication and makes it easier for future error capturing change and error code update.

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
