### PR TITLE
[XDP] VE2 xdna build fix by using correct function name from metadataReader

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_trace/ve2/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/ve2/aie_trace.cpp
@@ -291,7 +291,7 @@ namespace xdp {
 
     auto compilerOptions = metadataReader->getAIECompilerOptions();
     uint8_t numRows = metadataReader->getNumRows();
-    int hwGen = metadataReader->getHardwareGen();
+    int hwGen = metadataReader->getHardwareGeneration();
     std::shared_ptr<xaiefal::XAieBroadcast> traceStartBroadcastCh1 = nullptr, traceStartBroadcastCh2 = nullptr;
     if(compilerOptions.enable_multi_layer) {
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
VE2 XDNA build was failing, getHardwareGen() is only applicable to plugin metadata. 

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
(https://github.com/Xilinx/XRT/pull/9159)

#### How problem was solved, alternative solutions (if any) and why they were rejected
Used correct method.


#### Risks (if any) associated the changes in the commit
low

#### What has been tested and how, request additional testing if necessary
VE2 build has been verified.

#### Documentation impact (if any)
