### PR TITLE
platform_path() also needs to handle directory path

### DIFF
--- a/src/runtime_src/core/common/module_loader.cpp
+++ b/src/runtime_src/core/common/module_loader.cpp
@@ -156,7 +156,7 @@ static sfs::path
 platform_path(const std::string& file_name)
 {
   sfs::path xpath{file_name};
-  if (sfs::exists(xpath) && sfs::is_regular_file(xpath))
+  if (sfs::exists(xpath))
     return xpath;
 
   if (!xpath.is_absolute())


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
When input is absolute directory path, platform_path() fails. However, absolute directory path is a valid use case.
#### What has been tested and how, request additional testing if necessary
Tested on STX HALO with modified xdna-driver pkg which can pass absolute directory path to platform_path().
