### PR TITLE
[XRT-SMI] Context health update for ctx_id and pid handling

### DIFF
--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -1991,21 +1991,20 @@ struct aie_partition_info : request
 // This provides detailed health information for hardware contexts
 // including transaction operation indices, program counters, and error details
 // 
-// Can be called with optional context_ids parameter to filter specific contexts:
+// Can be called with optional filtering parameters:
 //   - No parameter: Returns all contexts
-//   - std::vector<uint32_t>: Returns only specified context IDs
+//   - std::vector<uint32_t>: Returns only specified context IDs (Win)
+//   - std::vector<std::pair<uint32_t, uint32_t>>: Returns contexts matching (context_id, pid) pairs (Linux)
 struct context_health_info : request
 {
   using result_type = std::vector<ert_ctx_health_data>;
   static const key_type key = key_type::context_health_info;
 
-  // Standard query interface - returns all contexts
   std::any
   get(const device* device) const override = 0;
 
-  // Parameterized query interface - supports context filtering
   std::any
-  get(const device* device, const std::any& context_ids) const override = 0;
+  get(const device* device, const std::any& context_info) const override = 0;
 };
 
 // Retrieves the AIE telemetry info for the device

--- a/src/runtime_src/core/tools/common/reports/ReportContextHealth.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportContextHealth.cpp
@@ -61,67 +61,104 @@ getPropertyTree20202(const xrt_core::device* dev, bpt& pt) const
   pt.add_child("context_health", context_health_pt);
 }
 
-// Helper function to parse context IDs from elements_filter
 static std::vector<uint32_t> 
-parse_context_ids(const std::vector<std::string>& elements_filter) 
+parse_values(const std::string& input) 
 {
-  std::vector<uint32_t> context_ids;
-  std::stringstream ctx_stream;
+  std::vector<uint32_t> result;
+  if (input.empty()) {
+    return result;
+  }
   
-  for (const auto& filter : elements_filter) {
-    if (filter.find("ctx_id=") == 0) {
-      std::string ctx_ids_str = filter.substr(7); // // NOLINT(cppcoreguidelines-avoid-magic-numbers) 
-      ctx_stream.str(ctx_ids_str);
-      ctx_stream.clear(); // Clear error flags
-      std::string ctx_id_token;
-      
-      // Parse comma-separated context IDs
-      while (std::getline(ctx_stream, ctx_id_token, ',')) {
-        try {
-          uint32_t ctx_id = std::stoul(ctx_id_token);
-          context_ids.push_back(ctx_id);
-        } 
-        catch (const std::exception&) {
-          // Invalid ctx_id format, skip this token
-        }
+  std::stringstream ss(input);
+  std::string token;
+  
+  while (std::getline(ss, token, ',')) {
+    // Trim whitespace
+    token.erase(0, token.find_first_not_of(" \t"));
+    token.erase(token.find_last_not_of(" \t") + 1);
+    
+    if (!token.empty()) {
+      try {
+        uint32_t value = std::stoul(token);
+        result.push_back(value);
+      } 
+      catch (const std::exception&) {
+        // Skip invalid entries
       }
-      break;
     }
   }
   
-  return context_ids;
+  return result;
+}
+
+// Helper function to parse context IDs and PIDs and create pairs
+// Usage: ctx_id=1,2,3 pid=100,200,300 creates pairs (1,100), (2,200), (3,300)
+static std::vector<std::pair<uint32_t, uint32_t>> 
+parse_context_pid_pairs(const std::vector<std::string>& elements_filter) 
+{
+  std::vector<uint32_t> context_ids;
+  std::vector<uint32_t> pids;
+  
+  // Parse both ctx_id and pid from filter
+  for (const auto& element : elements_filter) {
+    if (element.find("ctx_id=") == 0) {
+      std::string ctx_ids_str = element.substr(7); // Skip "ctx_id="
+      context_ids = parse_values(ctx_ids_str);
+    } 
+    else if (element.find("pid=") == 0) {
+      std::string pids_str = element.substr(4); // Skip "pid="
+      pids = parse_values(pids_str);
+    }
+  }
+  
+  // Create pairs - map 1:1, pad with 0 if lists are different lengths
+  std::vector<std::pair<uint32_t, uint32_t>> pairs;
+  size_t max_size = std::max(context_ids.size(), pids.size());
+  
+  for (size_t i = 0; i < max_size; ++i) {
+    uint32_t ctx_id = (i < context_ids.size()) ? context_ids[i] : 0;
+    uint32_t pid = (i < pids.size()) ? pids[i] : 0;
+    pairs.emplace_back(ctx_id, pid);
+  }
+  
+  return pairs;
+}
+
+static std::vector<uint32_t> 
+parse_context_ids(const std::vector<std::string>& elements_filter) 
+{
+  for (const auto& element : elements_filter) {
+    if (element.find("ctx_id=") == 0) {
+      std::string ctx_ids_str = element.substr(7); // Skip "ctx_id="
+      return parse_values(ctx_ids_str);
+    }
+  }
+  return {};
 }
 
 static std::string
 generate_context_health_report(const xrt_core::device* dev,
-                               const std::vector<std::string>& elements_filter,
-                               bool include_timestamp = true)
+                               const std::vector<std::string>& elements_filter)
 {
   std::stringstream ss;
-  
-  // Parse context IDs from elements_filter - collect for future use
+  // Parse context_id/pid pairs from elements_filter
+  std::vector<std::pair<uint32_t, uint32_t>> context_pid_pairs = parse_context_pid_pairs(elements_filter);
   std::vector<uint32_t> context_ids = parse_context_ids(elements_filter);
 
   try {
     std::vector<ert_ctx_health_data> context_health_data;
-    
-    // Query device with context_ids parameter if provided
-    if (context_ids.empty()) {
-      // No specific context IDs - get all contexts
-      context_health_data = xrt_core::device_query<xrt_core::query::context_health_info>(dev);
-    } else {
-      // Pass context_ids vector to device query
+
+    // If any pid is nonzero, pass pairs
+    bool has_nonzero_pid = std::any_of(context_pid_pairs.begin(), context_pid_pairs.end(), [](const auto& p){ return p.second != 0; });
+    if (!context_pid_pairs.empty() && has_nonzero_pid) {
+      context_health_data = xrt_core::device_query<xrt_core::query::context_health_info>(dev, context_pid_pairs);
+    } else if (!context_ids.empty()) {
       context_health_data = xrt_core::device_query<xrt_core::query::context_health_info>(dev, context_ids);
-    }
-    
-    auto context_count = context_health_data.size();
-    
-    if (include_timestamp) {
-      ss << boost::format("Context Health Report (Total: %d) - %s\n") % context_count % xrt_core::timestamp();
-      ss << "=======================================================\n\n";
     } else {
-      ss << boost::format("Total Contexts: %d\n\n") % context_count;
+      context_health_data = xrt_core::device_query<xrt_core::query::context_health_info>(dev);
     }
+
+    auto context_count = context_health_data.size();
 
     if (context_count == 0) {
       ss << "No context health data available\n";
@@ -138,16 +175,16 @@ generate_context_health_report(const xrt_core::device* dev,
       {"Fatal App Module",     Table2D::Justification::left}
     };
     Table2D context_table(table_headers);
-    
+
     // Add data rows
     for (const auto& context : context_health_data) {
       const std::vector<std::string> entry_data = {
         (boost::format("0x%x") % context.txn_op_idx).str(),
         (boost::format("0x%x") % context.ctx_pc).str(),
-        std::to_string(context.fatal_error_type),
-        std::to_string(context.fatal_error_exception_type),
+        (boost::format("0x%x") % context.fatal_error_type).str(),
+        (boost::format("0x%x") % context.fatal_error_exception_type).str(),
         (boost::format("0x%x") % context.fatal_error_exception_pc).str(),
-        std::to_string(context.fatal_error_app_module)
+        (boost::format("0x%x") % context.fatal_error_app_module).str()
       };
       context_table.addEntry(entry_data);
     }
@@ -174,7 +211,7 @@ writeReport(const xrt_core::device* device,
   if (smi_watch_mode::parse_watch_mode_options(elements_filter)) {
     // Create report generator lambda for watch mode
     auto report_generator = [](const xrt_core::device* dev, const std::vector<std::string>& filters) -> std::string {
-      return generate_context_health_report(dev, filters, true); // include timestamp for watch mode
+      return generate_context_health_report(dev, filters); 
     };
     
     smi_watch_mode::run_watch_mode(device, elements_filter, output, 
@@ -185,6 +222,6 @@ writeReport(const xrt_core::device* device,
   // Non-watch mode: use the same API but without timestamp
   output << "Context Health Report\n";
   output << "=====================\n\n";
-  output << generate_context_health_report(device, elements_filter, false); // no timestamp for non-watch mode
+  output << generate_context_health_report(device, elements_filter);
   output << std::endl;
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
This PR adds the option to take in PID to make <ctx_id,pid> pairs for accurate filtering of contexts in linux driver. 
The updated command usage on linux would now be :
```
xrt-smi examine --advanced -r context-health --element ctx_id=5 --element pid=1846378
```

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://jira.xilinx.com/browse/AIESW-8460

#### How problem was solved, alternative solutions (if any) and why they were rejected
Solved by adding a new --element filter to the command and passing the vector of pairs to shim for consumption

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Tested on Linux : 
<img width="1566" height="417" alt="image" src="https://github.com/user-attachments/assets/9f9cfe89-8f38-4a80-9e39-6f1bacd2b8fc" />


#### Documentation impact (if any)
None
