### PR TITLE
Updating the default polling interval used in the EA system timeline feature 

### DIFF
--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -1059,7 +1059,7 @@ get_aie_trace_settings_file_dump_interval_s()
 inline unsigned int
 get_aie_trace_settings_poll_timers_interval_us()
 {
-  static unsigned int value = detail::get_uint_value("AIE_trace_settings.poll_timers_interval_us", 100);
+  static unsigned int value = detail::get_uint_value("AIE_trace_settings.poll_timers_interval_us", 50);
   return value;
 }
 


### PR DESCRIPTION
#### Problem solved by the commit
System timeline aligns the AIE event trace with host and PL trace by sampling timestamps from AIE.  This pull request changes the default time between samples and results in a better alignment on key designs used to test this EA feature.

#### Risks (if any) associated the changes in the commit
Low risk as this feature is not enabled by default and the only change would be a larger timestamp file generated.

#### Documentation impact (if any)
No documentation impact.