### PR TITLE
Remove xbmgmt bash completion from setup scripts

### DIFF
--- a/src/runtime_src/tools/scripts/setup.csh
+++ b/src/runtime_src/tools/scripts/setup.csh
@@ -74,9 +74,8 @@ else
     setenv PYTHONPATH $XILINX_XRT/python:$PYTHONPATH
 endif
 
-# Enable autocompletion for the xbutil and xbmgmt commands
+# Enable autocompletion for xrt-smi commands
 source $XILINX_XRT/share/completions/xbutil-csh-completion-wrapper
-source $XILINX_XRT/share/completions/xbmgmt-csh-completion-wrapper
 
 # To use the newest version of the XRT tools, either uncomment or set 
 # the following environment variable in your profile:

--- a/src/runtime_src/tools/scripts/setup.sh
+++ b/src/runtime_src/tools/scripts/setup.sh
@@ -58,10 +58,9 @@ COMP_FILE="/usr/share/bash-completion/bash_completion"
 # correctly or setup on other shells.
 # 3. Make sure the bash completion file exists
 if [[ $- != *e* ]] && [[ "$BASH" == *"/bash" ]] && [ -f "${COMP_FILE}" ]; then
-    # Enable autocompletion for the xbutil and xbmgmt commands
+    # Enable autocompletion for xrt-smi commands
     source $COMP_FILE
     source $XILINX_XRT/share/completions/xbutil-bash-completion
-    source $XILINX_XRT/share/completions/xbmgmt-bash-completion
 else
     echo Autocomplete not enabled for XRT tools
 fi


### PR DESCRIPTION
#### Problem solved by the commit
Recent testing when sourcing setup script on Linux would show warning about missing xbmgmt script before running xrt-smi normally.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Recent cleanup of xbutil/xbmgmt mentions in code may have caused this, discovered in personal testing
#### How problem was solved, alternative solutions (if any) and why they were rejected
Removed the relevant xbmgmt script sourcing from the setup script.
#### Risks (if any) associated the changes in the commit
N/A
#### What has been tested and how, request additional testing if necessary
Tested on STX xdna, sourcing works normally again without the extra message.
#### Documentation impact (if any)
N/A