### PR TITLE
Added XRT support for RHEL/Rocky/AlmaLinux - 10.0

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
@@ -497,6 +497,9 @@ static const struct file_operations xocl_driver_fops = {
 	.read		= drm_read,
 	.unlocked_ioctl = xocl_drm_ioctl,
 	.release	= drm_release,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
+        .fop_flags      = FOP_UNSIGNED_OFFSET,
+#endif
 };
 
 static const struct vm_operations_struct xocl_vm_ops = {

--- a/src/runtime_src/tools/scripts/xrtdeps.sh
+++ b/src/runtime_src/tools/scripts/xrtdeps.sh
@@ -62,7 +62,6 @@ rh_package_list()
      boost-program-options \
      boost-static \
      cmake \
-     cppcheck \
      curl \
      dkms \
      elfutils-devel \
@@ -72,7 +71,6 @@ rh_package_list()
      gdb \
      git \
      glibc-static \
-     gnuplot \
      gnutls-devel \
      gtest-devel \
      json-glib-devel \
@@ -107,6 +105,12 @@ rh_package_list()
      zlib-static \
     )
 
+    if  [ "$MAJOR" -lt 10 ]; then
+        RH_LIST+=(\
+	cppcheck \
+	gnuplot\
+        )
+    fi
     if [ $FLAVOR == "amzn" ]; then
         RH_LIST+=(\
         system-lsb-core \
@@ -538,6 +542,19 @@ prep_rhel9()
     subscription-manager repos --enable "codeready-builder-for-rhel-9-x86_64-rpms"
 }
 
+prep_rhel10()
+{
+    echo "Enabling EPEL repository..."
+    rpm -q --quiet epel-release
+    if [ $? != 0 ]; then
+        yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm
+        yum check-update
+    fi
+
+    echo "Enabling CodeReady-Builder repository..."
+    subscription-manager repos --enable "codeready-builder-for-rhel-10-x86_64-rpms"
+}
+
 prep_centos8()
 {
     echo "Enabling EPEL repository..."
@@ -576,8 +593,10 @@ prep_centos()
 
 prep_rhel()
 {
-    if [ $MAJOR -ge 9 ]; then
-        prep_rhel9
+    if [ $MAJOR -ge 10 ]; then
+        prep_rhel10
+    elif [ $MAJOR == 9 ]; then
+	prep_rhel9
     else
         if [ $MAJOR == 8 ]; then
              prep_rhel8
@@ -645,10 +664,22 @@ prep_alma9()
     dnf config-manager --set-enabled crb
 }
 
+prep_alma10()
+{
+    echo "Enabling EPEL repository..."
+    yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm
+    yum check-update
+
+    echo "Enabling CodeReady-Builder repository..."
+    dnf config-manager --set-enabled crb
+}
+
 prep_alma()
 {
-    if [ $MAJOR -ge 9 ]; then
-        prep_alma9
+    if [ $MAJOR -ge 10 ]; then
+        prep_alma10
+    elif [ $MAJOR == 9 ]; then
+	prep_alma9
     elif [ $MAJOR == 8 ]; then
         prep_alma8
     fi

--- a/src/runtime_src/tools/scripts/xrtdeps.sh
+++ b/src/runtime_src/tools/scripts/xrtdeps.sh
@@ -107,8 +107,8 @@ rh_package_list()
 
     if  [ "$MAJOR" -lt 10 ]; then
         RH_LIST+=(\
-	cppcheck \
-	gnuplot\
+	    cppcheck \
+	    gnuplot\
         )
     fi
     if [ $FLAVOR == "amzn" ]; then
@@ -596,7 +596,7 @@ prep_rhel()
     if [ $MAJOR -ge 10 ]; then
         prep_rhel10
     elif [ $MAJOR == 9 ]; then
-	prep_rhel9
+	    prep_rhel9
     else
         if [ $MAJOR == 8 ]; then
              prep_rhel8
@@ -679,7 +679,7 @@ prep_alma()
     if [ $MAJOR -ge 10 ]; then
         prep_alma10
     elif [ $MAJOR == 9 ]; then
-	prep_alma9
+	    prep_alma9
     elif [ $MAJOR == 8 ]; then
         prep_alma8
     fi


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/VITIS-14802. Added XRT support for RHEL/Rocky/AlmaLinux 10.0.

RHEL 10 doesn't include the cppcheck and gnuplot packages, so I’ve excluded them for now. I’ll remove the exclusion once the packages are available in the EPEL repository.

We have a dependency on this: https://jira.xilinx.com/browse/CR-1247916. Once the PR is merged, I’ll update the dma_ip_drivers submodule.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit
low
#### What has been tested and how, request additional testing if necessary
Tested on RHEL, Rocky, and AlmaLinux 10 VMs by building, installing, and running the xrt-smi validate command.

#### Documentation impact (if any)
Yes. I will update the document.