### PR TITLE
Edits to interface

### DIFF
--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -325,10 +325,14 @@ enum class key_type
   xgq_scaling_temp_override,
   performance_mode,
   preemption,
-  event_trace,
+  event_trace_data,
   event_trace_version,
-  firmware_log,
+  event_trace_state,
+  event_trace_config,
+  firmware_log_data,
   firmware_log_version,
+  firmware_log_state,
+  firmware_log_config,
   frame_boundary_preemption,
   debug_ip_layout_path,
   debug_ip_layout,
@@ -4121,55 +4125,95 @@ struct firmware_debug_buffer {
     bool b_wait;
 };
 
-struct event_trace : request 
+struct event_trace_version : request 
 {
-  // Version struct for event trace
-  struct event_trace_version {
+  struct result_type {
     uint16_t major;
     uint16_t minor;
   };
 
-  using result_type = firmware_debug_buffer;  // Default result type for backward compatibility
-  using value_type = uint32_t;                // put value type
+  static const key_type key = key_type::event_trace_version;
 
-  static const key_type key = key_type::event_trace;
-
-  // Parameterized get method based on key_type passed via std::any
-  // Returns event_trace_version if key is event_trace_version
-  // Returns firmware_debug_buffer if key is event_trace
   std::any
-  get(const device*, const std::any& key) const override = 0;
+  get(const device*) const override = 0;
+};
+
+struct event_trace_data : request
+{
+  using result_type = firmware_debug_buffer;
+  static const key_type key = key_type::event_trace_data;
+
+  std::any
+  get(const device*) const override = 0;
+
+};
+
+struct event_trace_state : request
+{
+  static const key_type key = key_type::event_trace_state;
+
+  std::any
+  get(const device*) const override = 0;
 
   void
   put(const device*, const std::any&) const override = 0;
 };
 
-struct firmware_log : request
-{  
-  // Version struct for firmware log
-  struct firmware_log_version {
+struct event_trace_config : request
+{
+  static const key_type key = key_type::event_trace_config;
+  using result_type = std::string;
+
+  std::any
+  get(const device*) const override = 0;
+};
+
+// Firmware log version query - following telemetry pattern
+struct firmware_log_version : request 
+{
+  struct result_type {
     uint16_t major;
     uint16_t minor;
   };
 
-  using result_type = firmware_debug_buffer;  // Default result type for backward compatibility
-  
-  // Structure to hold both action and log_level parameters
-  struct value_type {
+  static const key_type key = key_type::firmware_log_version;
+
+  std::any
+  get(const device*) const override = 0;
+};
+
+// Firmware log data query - following telemetry pattern
+struct firmware_log_data : request
+{
+  using result_type = firmware_debug_buffer;
+  static const key_type key = key_type::firmware_log_data;
+
+  std::any
+  get(const device*) const override = 0;
+};
+
+struct firmware_log_state : request
+{
+  struct value_type{
     uint32_t action;
     uint32_t log_level;
   };
 
-  static const key_type key = key_type::firmware_log;
-
-  // Parameterized get method based on key_type passed via std::any
-  // Returns firmware_log_version if key is firmware_log_version
-  // Returns firmware_debug_buffer if key is firmware_log
+  static const key_type key = key_type::firmware_log_state;
   std::any
-  get(const device*, const std::any& key) const override = 0;
+  get(const device*) const override = 0;
 
   void
   put(const device*, const std::any&) const override = 0;
+};
+
+struct firmware_log_config : request
+{
+  static const key_type key = key_type::firmware_log_config;
+  using result_type = std::string;
+
+  std::any
+  get(const device*) const override = 0;
 };
 
 /*

--- a/src/runtime_src/core/tools/xbutil2/OO_EventTrace.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_EventTrace.cpp
@@ -101,7 +101,7 @@ OO_EventTrace::execute(const SubCmdOptions& _options) const
   };
 
   try {
-    xrt_core::device_update<xrt_core::query::event_trace>(device.get(), action_to_int(m_action));
+    xrt_core::device_update<xrt_core::query::event_trace_state>(device.get(), action_to_int(m_action));
   }
   catch(const xrt_core::error& e) {
     std::cerr << boost::format("\nERROR: %s\n") % e.what();

--- a/src/runtime_src/core/tools/xbutil2/OO_FirmwareLog.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_FirmwareLog.cpp
@@ -104,8 +104,8 @@ OO_FirmwareLog::execute(const SubCmdOptions& _options) const
   };
 
   try {
-    xrt_core::query::firmware_log::value_type params{action_to_int(m_action), m_log_level};
-    xrt_core::device_update<xrt_core::query::firmware_log>(device.get(), params);
+    xrt_core::query::firmware_log_state::value_type params{action_to_int(m_action), m_log_level};
+    xrt_core::device_update<xrt_core::query::firmware_log_state>(device.get(), params);
   }
   catch(const xrt_core::error& e) {
     std::cerr << boost::format("\nERROR: %s\n") % e.what();


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
This PR updates the interface for event tracing and firmware logging to a cleaner approach.
Now there are 4 structs for different types of data we want to send and receive : 

1. event_trace_data --> Get the data buffer from driver (result type firmware_log_buffer).
2. event_trace_state -->Get and Put (enable and disable) event trace feature in firmware.
3. event_trace_version --> Get the version of event tracing from firmware.
4. event_trace_config --> Get the event trace yaml file path from driver .

Now the driver code can now have only one event_trace struct mapped to all 4 with each get and put API implemented in a key_type basis. 

Similar convention is followed for firmware logging.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
None

#### How problem was solved, alternative solutions (if any) and why they were rejected
The problem was solved by analyzing how telemetry querying and following a similar pattern which was cleaner.

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Tested with event trace feature on linux with a dummy input 

#### Documentation impact (if any)
None
