### PR TITLE
Event trace report and parse changes

### DIFF
--- a/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
@@ -53,6 +53,8 @@ file(GLOB XBUTIL_V2_SUBCMD_FILES
   "OO_Preemption.cpp"
   "OO_EventTrace.cpp"
   "OO_FirmwareLog.cpp"
+  "ReportEventTrace.cpp"
+  "EventTraceConfig.cpp"
 )
 
 # Merge the files into one collection
@@ -96,12 +98,17 @@ if (XRT_STATIC_BUILD)
     RUNTIME DESTINATION ${XRT_INSTALL_UNWRAPPED_DIR} COMPONENT ${XRT_BASE_COMPONENT})
 endif()
 
+# YAML-CPP - Required for event trace configuration (xbutil2 only)
+find_package(yaml-cpp REQUIRED)
+set(YAML_CPP_LIBRARY yaml-cpp)
+
 target_link_libraries(${XBUTIL2_NAME}
   PRIVATE
   xrt_coreutil
   ${Boost_FILESYSTEM_LIBRARY}
   ${Boost_SYSTEM_LIBRARY}
   ${Boost_PROGRAM_OPTIONS_LIBRARY}
+  ${YAML_CPP_LIBRARY}
   )
 
 if (NOT WIN32)

--- a/src/runtime_src/core/tools/xbutil2/EventTraceConfig.cpp
+++ b/src/runtime_src/core/tools/xbutil2/EventTraceConfig.cpp
@@ -1,0 +1,553 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+
+#include "EventTraceConfig.h"
+
+#include <algorithm>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <regex>
+#include <set>
+#include <sstream>
+#include <yaml-cpp/yaml.h>
+
+#include "core/common/query_requests.h"
+#include "core/common/device.h"
+
+event_trace_config::
+event_trace_config(const std::string& yaml_file_path) 
+  : event_bits(16), payload_bits(48), 
+    file_major(0), file_minor(0), config_valid(false) {
+
+  load_from_yaml(yaml_file_path);
+}
+
+bool
+event_trace_config::
+load_from_yaml(const std::string& yaml_file_path) {
+  try {
+    YAML::Node config = load_yaml_file(yaml_file_path);
+    
+    parse_version(config);
+    parse_data_format(config);
+    parse_lookups(config);
+    parse_categories(config);
+    parse_arg_sets(config);
+    parse_events(config);
+    
+    config_valid = true;
+    return true;
+    
+  } catch (const YAML::Exception& e) {
+    std::cerr << "YAML parsing error: " << e.what() << std::endl;
+    return false;
+  } catch (const std::exception& e) {
+    std::cerr << "Configuration error: " << e.what() << std::endl;
+    return false;
+  } 
+}
+
+YAML::Node
+event_trace_config::
+load_yaml_file(const std::string& yaml_file_path) {
+  if (yaml_file_path.empty()) {
+    throw std::runtime_error("YAML file path cannot be empty");
+  }
+  
+  std::ifstream file(yaml_file_path);
+  if (!file.is_open()) {
+    throw std::runtime_error("Cannot open YAML file: " + yaml_file_path);
+  }
+  
+  return YAML::LoadFile(yaml_file_path);
+}
+
+void
+event_trace_config::
+parse_data_format(const YAML::Node& config) {
+  if (!config["data_format"]) {
+    throw std::runtime_error("Missing required 'data_format' section in YAML");
+  }
+  
+  const auto& data_format = config["data_format"];
+  
+  if (!data_format["event_bits"]) {
+    throw std::runtime_error("Missing 'event_bits' in data_format section");
+  }
+  if (!data_format["payload_bits"]) {
+    throw std::runtime_error("Missing 'payload_bits' in data_format section");
+  }
+  
+  event_bits = data_format["event_bits"].as<uint32_t>();
+  payload_bits = data_format["payload_bits"].as<uint32_t>();
+  
+  if (event_bits == 0 || payload_bits == 0) {
+    throw std::runtime_error("Event bits and payload bits must be greater than 0");
+  }
+}
+
+void
+event_trace_config::
+parse_version(const YAML::Node& config) {
+  // Version is optional, default to 0.0 if not present
+  if (config["version"]) {
+    const auto& version = config["version"];
+    
+    if (version["major"]) {
+      file_major = version["major"].as<uint16_t>();
+    }
+    if (version["minor"]) {
+      file_minor = version["minor"].as<uint16_t>();
+    }
+  }
+}
+void
+event_trace_config::
+parse_lookups(const YAML::Node& config) {
+  if (!config["lookups"]) {
+    // Lookups are optional
+    return;
+  }
+  
+  for (const auto& lookup_pair : config["lookups"]) {
+    std::string lookup_name = lookup_pair.first.as<std::string>();
+    std::map<uint32_t, std::string> lookup_map;
+    
+    for (const auto& entry_pair : lookup_pair.second) {
+      uint32_t key = entry_pair.first.as<uint32_t>();
+      std::string value = entry_pair.second.as<std::string>();
+      lookup_map[key] = value;
+    }
+    
+    code_tables[lookup_name] = lookup_map;
+  }
+}
+
+void
+event_trace_config::
+parse_categories(const YAML::Node& config) {
+  if (!config["categories"]) {
+    throw std::runtime_error("Missing required 'categories' section in YAML");
+  }
+  
+  std::set<std::string> name_check;
+  std::set<uint32_t> forced_id_categories;
+  
+  // First pass: collect forced IDs and validate names
+  for (const auto& category : config["categories"]) {
+    if (!category["name"]) {
+      throw std::runtime_error("Category missing required 'name' field");
+    }
+    
+    std::string name = category["name"].as<std::string>();
+    if (name_check.count(name)) {
+      throw std::runtime_error("Duplicate category name: " + name);
+    }
+    name_check.insert(name);
+    
+    category_info cat_info = create_category_info(category, forced_id_categories);
+    category_map[name] = cat_info;
+  }
+  
+  // Second pass: assign IDs to non-forced categories
+  assign_category_ids(forced_id_categories);
+}
+
+event_trace_config::category_info
+event_trace_config::
+create_category_info(const YAML::Node& category, std::set<uint32_t>& forced_id_categories) {
+  
+  category_info cat_info;
+  cat_info.name = category["name"].as<std::string>();
+  cat_info.description = category["description"] ? category["description"].as<std::string>() : "";
+  cat_info.forced_id = false;
+  
+  if (category["id"]) {
+    uint32_t id = category["id"].as<uint32_t>();
+    if (forced_id_categories.count(id)) {
+      throw std::runtime_error("Duplicate category ID " + std::to_string(id) + 
+                              " for category " + cat_info.name);
+    }
+    forced_id_categories.insert(id);
+    cat_info.id = id;
+    cat_info.forced_id = true;
+  }
+  
+  return cat_info;
+}
+
+void
+event_trace_config::
+assign_category_ids(const std::set<uint32_t>& forced_id_categories) {
+  uint32_t next_id = 0;
+  for (auto& cat_pair : category_map) {
+    if (!cat_pair.second.forced_id) {
+      while (forced_id_categories.count(next_id)) {
+        next_id++;
+      }
+      cat_pair.second.id = next_id++;
+    }
+  }
+}
+void
+event_trace_config::
+parse_arg_sets(const YAML::Node& config) {
+  if (!config["arg_sets"]) {
+    // Arg sets are optional
+    return;
+  }
+  
+  for (const auto& arg_set_pair : config["arg_sets"]) {
+    std::string arg_name = arg_set_pair.first.as<std::string>();
+    std::vector<event_arg> args = parse_argument_list(arg_set_pair.second, arg_name);
+    arg_templates[arg_name] = args;
+  }
+}
+
+std::vector<event_trace_config::event_arg>
+event_trace_config::
+parse_argument_list(const YAML::Node& arg_list, const std::string& arg_set_name) {
+  
+  std::vector<event_arg> args;
+  uint32_t start_position = 0;
+  
+  for (const auto& arg_data : arg_list) {
+    event_arg arg = create_event_arg(arg_data, start_position, arg_set_name);
+    start_position += arg.width;
+    
+    if (start_position > payload_bits) {
+      throw std::runtime_error("Argument '" + arg.name + "' in arg_set '" + 
+                              arg_set_name + "' exceeds payload bits (" + 
+                              std::to_string(payload_bits) + ")");
+    }
+    
+    args.push_back(arg);
+  }
+  
+  return args;
+}
+
+event_trace_config::event_arg
+event_trace_config::
+create_event_arg(const YAML::Node& arg_data, uint32_t start_position, const std::string& arg_set_name) {
+  
+  if (!arg_data["name"]) {
+    throw std::runtime_error("Argument in arg_set '" + arg_set_name + "' missing 'name' field");
+  }
+  if (!arg_data["width"]) {
+    throw std::runtime_error("Argument in arg_set '" + arg_set_name + "' missing 'width' field");
+  }
+  
+  event_arg arg;
+  arg.name = arg_data["name"].as<std::string>();
+  arg.width = arg_data["width"].as<uint32_t>();
+  arg.start = start_position;
+  arg.format = arg_data["format"] ? arg_data["format"].as<std::string>() : "";
+  arg.description = arg_data["description"] ? arg_data["description"].as<std::string>() : "";
+  arg.lookup = arg_data["lookup"] ? arg_data["lookup"].as<std::string>() : "";
+  arg.signed_field = arg_data["signed"] ? arg_data["signed"].as<bool>() : false;
+  
+  if (arg.width == 0) {
+    throw std::runtime_error("Argument '" + arg.name + "' width cannot be zero");
+  }
+  
+  return arg;
+}
+
+void
+event_trace_config::
+parse_events(const YAML::Node& config) {
+  std::set<std::string> name_check;
+  std::map<uint16_t, event_info> events_with_forced_id;
+  std::vector<event_info> events_without_id;
+  
+  // Parse all events and separate forced/non-forced IDs
+  for (const auto& event_pair : config["events"]) {
+    const YAML::Node& event_data = event_pair.second;
+    event_info event = create_event_info(event_data, name_check);
+    
+    if (event.forced_id) {
+      if (events_with_forced_id.count(event.id)) {
+        throw std::runtime_error("Duplicate event ID " + std::to_string(event.id) + 
+                                " for event " + event.name);
+      }
+      events_with_forced_id[event.id] = event;
+    } else {
+      events_without_id.push_back(event);
+    }
+  }
+  
+  // Assign IDs to events without forced IDs
+  assign_event_ids(events_with_forced_id, events_without_id);
+  
+  // Process event type pairs (START/DONE matching)
+  process_event_pairs(events_with_forced_id);
+  
+  event_map = events_with_forced_id;
+}
+
+event_trace_config::event_info
+event_trace_config::
+create_event_info(const YAML::Node& event_data, std::set<std::string>& name_check) {
+  
+  event_info event;
+  event.name = event_data["name"].as<std::string>();
+  
+  if (name_check.count(event.name)) {
+    throw std::runtime_error("Duplicate event name: " + event.name);
+  }
+  name_check.insert(event.name);
+  
+  event.description = event_data["description"] ? event_data["description"].as<std::string>() : "";
+  event.type = "null";
+  event.pair_id = -1;
+  
+  // Parse categories and validate references
+  parse_event_categories(event_data, event);
+  
+  // Parse arguments
+  parse_event_arguments(event_data, event);
+  
+  // Handle event ID assignment
+  if (event_data["id"]) {
+    event.id = static_cast<uint16_t>(event_data["id"].as<uint32_t>());
+    event.forced_id = true;
+  } else {
+    event.forced_id = false;
+  }
+  
+  return event;
+}
+
+void
+event_trace_config::
+parse_event_categories(const YAML::Node& event_data, event_info& event) {
+  
+  uint32_t category_mask = 0;
+  for (const auto& cat_name_node : event_data["categories"]) {
+    std::string cat_name = cat_name_node.as<std::string>();
+    event.categories.push_back(cat_name);
+    
+    auto cat_it = category_map.find(cat_name);
+    if (cat_it == category_map.end()) {
+      throw std::runtime_error("Event '" + event.name + "' references unknown category: " + cat_name);
+    }
+    
+    const auto& cat_info = cat_it->second;
+    category_mask |= (1U << cat_info.id);
+  }
+  
+  event.category_mask = category_mask;
+}
+
+void
+event_trace_config::
+parse_event_arguments(const YAML::Node& event_data, event_info& event) {
+  event.args_name = event_data["args_name"] ? event_data["args_name"].as<std::string>() : "";
+  
+  if (!event.args_name.empty()) {
+    auto arg_it = arg_templates.find(event.args_name);
+    if (arg_it == arg_templates.end()) {
+      throw std::runtime_error("Event '" + event.name + "' references unknown arg_set: " + event.args_name);
+    }
+    event.args = arg_it->second;
+  }
+}
+
+void
+event_trace_config::
+assign_event_ids(std::map<uint16_t, event_info>& events_with_forced_id,
+                std::vector<event_info>& events_without_id) {
+  
+  uint16_t next_id = 0;
+  for (auto& event : events_without_id) {
+    while (events_with_forced_id.count(next_id)) {
+      next_id++;
+    }
+    event.id = next_id;
+    events_with_forced_id[next_id] = event;
+    next_id++;
+  }
+}
+
+void
+event_trace_config::
+process_event_pairs(std::map<uint16_t, event_info>& events_map) {
+  std::map<std::string, std::map<std::string, uint16_t>> pairs;
+  std::regex start_re(R"(^(.*)_START$)");
+  std::regex done_re(R"(^(.*)_DONE$)");
+  
+  // Find START/DONE event pairs
+  for (auto& event_pair : events_map) {
+    event_info& event = event_pair.second;
+    
+    std::smatch match;
+    if (std::regex_match(event.name, match, start_re)) {
+      std::string stub = match[1].str();
+      pairs[stub]["start"] = event.id;
+      event.type = "start";
+    } else if (std::regex_match(event.name, match, done_re)) {
+      std::string stub = match[1].str();
+      pairs[stub]["done"] = event.id;
+      event.type = "done";
+    }
+  }
+  
+  // Cross-link pairs
+  for (const auto& pair : pairs) {
+    const auto& pair_map = pair.second;
+    if (pair_map.count("start") && pair_map.count("done")) {
+      uint16_t start_id = pair_map.at("start");
+      uint16_t done_id = pair_map.at("done");
+      events_map[start_id].pair_id = done_id;
+      events_map[done_id].pair_id = start_id;
+    }
+  }
+}
+
+event_trace_config::parsed_event
+event_trace_config::
+parse_event(uint64_t timestamp, uint16_t event_id, uint64_t payload) const {
+  parsed_event parsed;
+  parsed.timestamp = timestamp;
+  parsed.event_id = event_id;
+  parsed.raw_payload = payload;
+  
+  auto event_it = event_map.find(event_id);
+  if (event_it != event_map.end()) {
+    const event_info& event = event_it->second;
+    parsed.name = event.name;
+    parsed.description = event.description;
+    parsed.categories = event.categories;
+    
+    // Parse arguments from payload
+    for (const auto& arg : event.args) {
+      try {
+        std::string value = extract_arg_value(payload, arg);
+        parsed.args[arg.name] = value;
+      } catch (const std::exception& e) {
+        parsed.args[arg.name] = "ERROR: " + std::string(e.what());
+      }
+    }
+  } else {
+    parsed.name = "UNKNOWN";
+    parsed.description = "Unknown event ID: " + std::to_string(event_id);
+    parsed.categories = {"UNKNOWN"};
+  }
+  
+  return parsed;
+}
+
+std::string
+event_trace_config::
+get_event_name(uint16_t event_id) const {
+  auto it = event_map.find(event_id);
+  return it != event_map.end() ? it->second.name : "UNKNOWN";
+}
+
+std::vector<std::string>
+event_trace_config::
+get_event_categories(uint16_t event_id) const {
+  auto it = event_map.find(event_id);
+  return it != event_map.end() ? it->second.categories : std::vector<std::string>{"UNKNOWN"};
+}
+
+std::string
+event_trace_config::
+extract_arg_value(uint64_t payload, const event_arg& arg) const {
+  if (arg.width == 0 || arg.width > 64) {
+    throw std::runtime_error("Invalid argument width: " + std::to_string(arg.width));
+  }
+  
+  if (arg.start + arg.width > 64) {
+    throw std::runtime_error("Argument extends beyond payload: start=" + 
+                            std::to_string(arg.start) + ", width=" + std::to_string(arg.width));
+  }
+  
+  // Extract bits from payload
+  uint64_t mask = (1ULL << arg.width) - 1;
+  uint64_t value = (payload >> arg.start) & mask;
+  
+  // Handle signed values
+  if (arg.signed_field && (value & (1ULL << (arg.width - 1)))) {
+    // Sign extend
+    value |= (~mask);
+  }
+  
+  // Apply lookup if specified
+  if (!arg.lookup.empty()) {
+    auto lookup_it = code_tables.find(arg.lookup);
+    if (lookup_it != code_tables.end()) {
+      auto value_it = lookup_it->second.find(static_cast<uint32_t>(value));
+      if (value_it != lookup_it->second.end()) {
+        return value_it->second;
+      }
+    }
+    // If lookup specified but not found, show both raw and lookup name
+    return format_value(value, arg.format) + " [lookup:" + arg.lookup + "]";
+  }
+  
+  // Format value
+  return format_value(value, arg.format);
+}
+
+std::string
+event_trace_config::
+format_value(uint64_t value, const std::string& format) const {
+  if (format.empty() || format == "d") {
+    return std::to_string(value);
+  }
+  
+  std::ostringstream oss;
+  if (format.find('x') != std::string::npos) {
+    // Parse hexadecimal format (e.g., "08x", "4x")
+    std::string width_str;
+    for (char c : format) {
+      if (std::isdigit(c)) {
+        width_str += c;
+      }
+    }
+    
+    if (!width_str.empty()) {
+      int width = std::stoi(width_str);
+      oss << "0x" << std::hex << std::setw(width) << std::setfill('0') << value;
+    } else {
+      oss << "0x" << std::hex << value;
+    }
+  } else {
+    // Default to decimal
+    oss << value;
+  }
+  
+  return oss.str();
+}
+
+bool
+event_trace_config::
+validate_version_compatibility(const xrt_core::device* device) const {
+  if (!device) {
+    std::cerr << "Warning: Cannot validate event trace version - no device provided" << std::endl;
+    return false;
+  }
+
+  try {
+    // Query event trace version from device using specific query struct (like telemetry)
+    auto shim_version = xrt_core::device_query<xrt_core::query::event_trace_version>(device);
+
+    // Compare versions
+    if (file_major != shim_version.major || file_minor != shim_version.minor) {
+      std::cerr << "Warning: Event trace version mismatch!" << std::endl;
+      std::cerr << "  YAML file version: " << file_major << "." << file_minor << std::endl;
+      std::cerr << "  Device/Shim version: " << shim_version.major << "." << shim_version.minor << std::endl;
+      std::cerr << "  Event parsing may be incorrect or incomplete." << std::endl;
+      return false;
+    }
+
+    return true;
+
+  } catch (const std::exception& e) {
+    std::cerr << "Warning: Failed to validate event trace version: " << e.what() << std::endl;
+    return false;
+  }
+}

--- a/src/runtime_src/core/tools/xbutil2/EventTraceConfig.h
+++ b/src/runtime_src/core/tools/xbutil2/EventTraceConfig.h
@@ -1,0 +1,340 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+
+#pragma once
+
+#include <cstdint>
+#include <map>
+#include <set>
+#include <string>
+#include <vector>
+
+// Forward declaration to avoid full yaml-cpp include in header
+namespace YAML { class Node; }
+
+// Forward declaration for device
+namespace xrt_core { class device; }
+
+/**
+ * @brief Configuration loader for firmware event trace data
+ * 
+ * This class reads event trace configuration from trace_events.yaml
+ * using yaml-cpp library and provides methods to parse and interpret 
+ * firmware trace events.
+ */
+class event_trace_config {
+public:
+  /**
+   * @brief Individual argument definition for an event
+   */
+  struct event_arg {
+    std::string name;           // Argument name (e.g., "context_id")
+    uint32_t width;             // Bit width of the argument
+    uint32_t start;             // Starting bit position in payload (calculated)
+    std::string format;         // Display format (e.g., "08x", "d")
+    std::string lookup;         // Lookup table name (if any)
+    bool signed_field;          // Whether the field is signed
+    std::string description;    // Human-readable description
+  };
+
+  /**
+   * @brief Category definition from YAML configuration
+   */
+  struct category_info {
+    std::string name;           // Category name
+    std::string description;    // Category description
+    uint32_t id;               // Category bit ID
+    bool forced_id;            // Whether ID was explicitly set
+  };
+
+  /**
+   * @brief Event definition from YAML configuration
+   */
+  struct event_info {
+    uint16_t id;                           // Event ID (index in events array)
+    std::string name;                      // Event name (e.g., "FRAME_START")
+    std::string description;               // Event description
+    std::vector<std::string> categories;   // Event category names
+    uint32_t category_mask;                // Category bitmask
+    std::string args_name;                 // Argument set name (from arg_sets)
+    std::vector<event_arg> args;           // Resolved event arguments
+    std::string type;                      // Event type (start/done/null)
+    int pair_id;                          // Paired event ID (for start/done pairs)
+    bool forced_id;                       // Whether ID was explicitly set
+  };
+
+  /**
+   * @brief Parsed event data from firmware buffer
+   */
+  struct parsed_event {
+    uint64_t timestamp;                    // Event timestamp
+    uint16_t event_id;                     // Event ID
+    std::string name;                      // Event name
+    std::string description;               // Event description
+    std::vector<std::string> categories;   // Event categories
+    std::map<std::string, std::string> args; // Parsed arguments (name -> formatted value)
+    uint64_t raw_payload;                  // Raw payload data
+  };
+
+public:
+  /**
+   * @brief Constructor - loads configuration from YAML file
+   * @param yaml_file_path Path to trace_events.yaml file
+   * 
+   * After construction, call validate_version_compatibility() with a device
+   * to check if the YAML file version matches the device/shim version.
+   */
+  explicit
+  event_trace_config(const std::string& yaml_file_path = "trace_events.yaml");
+
+  /**
+   * @brief Parse a single trace event from raw data
+   * @param timestamp Event timestamp
+   * @param event_id Event ID 
+   * @param payload Raw payload data
+   * @return Parsed event structure
+   */
+  parsed_event
+  parse_event(uint64_t timestamp, uint16_t event_id, uint64_t payload) const;
+
+  /**
+   * @brief Get event name by ID
+   * @param event_id Event ID to look up
+   * @return Event name or "UNKNOWN" if not found
+   */
+  std::string
+  get_event_name(uint16_t event_id) const;
+
+  /**
+   * @brief Get event categories by ID
+   * @param event_id Event ID to look up
+   * @return Vector of category names
+   */
+  std::vector<std::string>
+  get_event_categories(uint16_t event_id) const;
+
+  /**
+   * @brief Check if configuration is valid (loaded successfully)
+   * @return true if valid, false otherwise
+   */
+  bool
+  is_valid() const { return config_valid; }
+
+  /**
+   * @brief Get last error message
+   * @return Error message string
+   */
+  const std::string&
+  get_error() const { return last_error; }
+
+  /**
+   * @brief Get data format information
+   * @return pair of (event_bits, payload_bits)
+   */
+  std::pair<uint32_t, uint32_t>
+  get_data_format() const { 
+    return {event_bits, payload_bits}; 
+  }
+
+  /**
+   * @brief Get YAML file version
+   * @return pair of (major, minor) version from YAML file
+   */
+  std::pair<uint16_t, uint16_t>
+  get_file_version() const {
+    return {file_major, file_minor};
+  }
+
+  /**
+   * @brief Validate version compatibility with device
+   * @param device Pointer to device for querying shim version
+   * @return true if versions match, false with warning if mismatch
+   */
+  bool
+  validate_version_compatibility(const xrt_core::device* device) const;
+
+private:
+  /**
+   * @brief Load configuration from YAML file using yaml-cpp
+   * @param yaml_file_path Path to YAML file
+   * @return true on success, false on failure
+   */
+  bool
+  load_from_yaml(const std::string& yaml_file_path);
+
+  /**
+   * @brief Load and validate YAML file
+   * @param yaml_file_path Path to YAML file
+   * @return YAML node for the loaded file
+   * @throws std::runtime_error if file cannot be loaded
+   */
+  YAML::Node
+  load_yaml_file(const std::string& yaml_file_path);
+
+  /**
+   * @brief Parse data_format section from YAML
+   * @param config Root YAML node
+   * @throws std::runtime_error if parsing fails
+   */
+  void
+  parse_data_format(const YAML::Node& config);
+
+  /**
+   * @brief Parse version information from YAML
+   * @param config Root YAML node
+   * @throws std::runtime_error if version parsing fails
+   */
+  void
+  parse_version(const YAML::Node& config);
+
+  /**
+   * @brief Parse lookups section from YAML (optional)
+   * @param config Root YAML node
+   */
+  void
+  parse_lookups(const YAML::Node& config);
+
+  /**
+   * @brief Parse categories section from YAML
+   * @param config Root YAML node
+   * @throws std::runtime_error if parsing fails
+   */
+  void
+  parse_categories(const YAML::Node& config);
+
+  /**
+   * @brief Create category info from YAML node
+   * @param category YAML node for single category
+   * @param forced_id_categories Set of already used forced IDs
+   * @return category_info structure
+   * @throws std::runtime_error if validation fails
+   */
+  category_info
+  create_category_info(const YAML::Node& category, 
+                      std::set<uint32_t>& forced_id_categories);
+
+  /**
+   * @brief Assign IDs to categories without forced IDs
+   * @param forced_id_categories Set of forced category IDs to avoid
+   */
+  void
+  assign_category_ids(const std::set<uint32_t>& forced_id_categories);
+
+  /**
+   * @brief Parse arg_sets section from YAML (optional)
+   * @param config Root YAML node
+   * @throws std::runtime_error if parsing fails
+   */
+  void
+  parse_arg_sets(const YAML::Node& config);
+
+  /**
+   * @brief Parse a list of arguments for an arg_set
+   * @param arg_list YAML node containing argument array
+   * @param arg_set_name Name of the arg_set for error reporting
+   * @return Vector of parsed event_arg structures
+   * @throws std::runtime_error if validation fails
+   */
+  std::vector<event_arg>
+  parse_argument_list(const YAML::Node& arg_list, 
+                     const std::string& arg_set_name);
+
+  /**
+   * @brief Create event_arg from YAML node
+   * @param arg_data YAML node for single argument
+   * @param start_position Starting bit position for this argument
+   * @param arg_set_name Name of containing arg_set for error reporting
+   * @return event_arg structure
+   * @throws std::runtime_error if validation fails
+   */
+  event_arg
+  create_event_arg(const YAML::Node& arg_data, uint32_t start_position,
+                  const std::string& arg_set_name);
+
+  /**
+   * @brief Parse events section from YAML
+   * @param config Root YAML node
+   * @throws std::runtime_error if parsing fails
+   */
+  void
+  parse_events(const YAML::Node& config);
+
+  /**
+   * @brief Create event_info from YAML node
+   * @param event_data YAML node for single event
+   * @param name_check Set of used event names for duplicate detection
+   * @return event_info structure
+   * @throws std::runtime_error if validation fails
+   */
+  event_info
+  create_event_info(const YAML::Node& event_data, 
+                   std::set<std::string>& name_check);
+
+  /**
+   * @brief Parse and validate event categories
+   * @param event_data YAML node for event
+   * @param event Event info to populate
+   * @throws std::runtime_error if category references are invalid
+   */
+  void
+  parse_event_categories(const YAML::Node& event_data, event_info& event);
+
+  /**
+   * @brief Parse event arguments reference
+   * @param event_data YAML node for event
+   * @param event Event info to populate
+   * @throws std::runtime_error if arg_set reference is invalid
+   */
+  void
+  parse_event_arguments(const YAML::Node& event_data, event_info& event);
+
+  /**
+   * @brief Assign IDs to events without forced IDs
+   * @param events_with_forced_id Map of events with forced IDs
+   * @param events_without_id Vector of events needing ID assignment
+   */
+  void
+  assign_event_ids(std::map<uint16_t, event_info>& events_with_forced_id,
+                  std::vector<event_info>& events_without_id);
+
+  /**
+   * @brief Process START/DONE event pairs and link them
+   * @param events_map Map of all events to process
+   */
+  void
+  process_event_pairs(std::map<uint16_t, event_info>& events_map);
+
+  /**
+   * @brief Extract argument value from payload
+   * @param payload Raw payload data
+   * @param arg Argument definition
+   * @return Formatted argument value
+   * @throws std::runtime_error if extraction fails
+   */
+  std::string
+  extract_arg_value(uint64_t payload, const event_arg& arg) const;
+
+  /**
+   * @brief Format value according to format specification
+   * @param value Raw value
+   * @param format Format string
+   * @return Formatted string
+   */
+  std::string
+  format_value(uint64_t value, const std::string& format) const;
+
+private:
+  // Configuration data
+  uint32_t event_bits;                                     // Event ID bit width
+  uint32_t payload_bits;                                   // Payload bit width
+  uint16_t file_major;                                     // YAML file major version
+  uint16_t file_minor;                                     // YAML file minor version
+  std::map<std::string, std::map<uint32_t, std::string>> code_tables;  // Numeric code to string lookup tables
+  std::map<std::string, category_info> category_map;      // Category name -> info
+  std::map<std::string, std::vector<event_arg>> arg_templates;  // Argument set definitions
+  std::map<uint16_t, event_info> event_map;               // Event ID -> info
+  
+  // Status
+  bool config_valid;             // Whether configuration is valid
+  std::string last_error;        // Last error message
+};

--- a/src/runtime_src/core/tools/xbutil2/ReportEventTrace.cpp
+++ b/src/runtime_src/core/tools/xbutil2/ReportEventTrace.cpp
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+
+// ------ I N C L U D E   F I L E S -------------------------------------------
+// Local - Include Files
+#include "core/common/query_requests.h"
+#include "core/common/time.h"
+#include "core/common/module_loader.h"
+#include "tools/common/SmiWatchMode.h"
+#include "tools/common/Table2D.h"
+#include "EventTraceConfig.h"
+#include "ReportEventTrace.h"
+
+// 3rd Party Library - Include Files
+#include <algorithm>
+#include <boost/format.hpp>
+#include <filesystem>
+#include <iomanip>
+#include <map>
+#include <sstream>
+#include <vector>
+#include <cstring>
+
+using bpt = boost::property_tree::ptree;
+
+// Event trace data structure (must match device.cpp implementation)
+struct trace_event {
+  uint64_t timestamp;    // Simulated timestamp
+  uint16_t event_id;     // Event ID from trace_events.h
+  uint64_t payload;      // Event payload/arguments
+};
+
+// Global event trace configuration instance
+static event_trace_config* get_event_trace_config(const xrt_core::device* dev) {
+
+  boost::property_tree::ptree ptree;
+  std::string config  = xrt_core::device_query<xrt_core::query::event_trace_config>(dev);
+
+  static event_trace_config config_obj(config);
+  return &config_obj;
+}
+
+void
+ReportEventTrace::
+getPropertyTreeInternal(const xrt_core::device* dev, bpt& pt) const
+{
+  // Defer to the 20202 format.  If we ever need to update JSON data,
+  // Then update this method to do so.
+  getPropertyTree20202(dev, pt);
+}
+
+void
+ReportEventTrace::
+getPropertyTree20202(const xrt_core::device* dev, bpt& pt) const
+{
+  bpt event_trace_pt{};
+
+  try {
+    // Get the event trace configuration
+    auto config = get_event_trace_config(dev);
+    
+    // Query version information from device using specific query struct (like telemetry)
+    auto version_info = xrt_core::device_query<xrt_core::query::event_trace_version>(dev);
+    
+    event_trace_pt.put("device_version_major", version_info.major);
+    event_trace_pt.put("device_version_minor", version_info.minor);
+    
+    // Query event trace data from device using specific query struct (like telemetry)
+    auto log_buffer = xrt_core::device_query<xrt_core::query::event_trace_data>(dev);
+
+    // Parse trace events from buffer
+    if (log_buffer.data && log_buffer.size > 0) {
+      size_t event_count = log_buffer.size / sizeof(trace_event);
+      trace_event* events = static_cast<trace_event*>(log_buffer.data);
+      
+      bpt events_array{};
+      for (size_t i = 0; i < event_count; ++i) {
+        // Parse event using yaml-cpp based configuration
+        auto parsed_event = config->parse_event(events[i].timestamp, 
+                                               events[i].event_id, 
+                                               events[i].payload);
+        
+        bpt event_pt;
+        event_pt.put("timestamp", parsed_event.timestamp);
+        event_pt.put("event_id", parsed_event.event_id);
+        event_pt.put("event_name", parsed_event.name);
+        
+        // Join categories with pipe separator for backward compatibility
+        std::string categories_str;
+        for (size_t j = 0; j < parsed_event.categories.size(); ++j) {
+          if (j > 0) categories_str += "|";
+          categories_str += parsed_event.categories[j];
+        }
+        event_pt.put("category", categories_str);
+        
+        event_pt.put("payload", parsed_event.raw_payload);
+        
+        // Add parsed arguments
+        bpt args_pt;
+        for (const auto& arg_pair : parsed_event.args) {
+          args_pt.put(arg_pair.first, arg_pair.second);
+        }
+        if (!parsed_event.args.empty()) {
+          event_pt.add_child("args", args_pt);
+        }
+        
+        // Extract context_id from payload if not already parsed
+        if (parsed_event.args.find("context_id") == parsed_event.args.end()) {
+          uint32_t context_id = parsed_event.raw_payload & 0xF;
+          event_pt.put("context_id", context_id);
+        }
+        
+        events_array.push_back(std::make_pair("", event_pt));
+      }
+      event_trace_pt.add_child("events", events_array);
+      event_trace_pt.put("event_count", event_count);
+      event_trace_pt.put("buffer_offset", log_buffer.abs_offset);
+      event_trace_pt.put("buffer_size", log_buffer.size);
+      event_trace_pt.put("config_valid", config->is_valid());
+    } else {
+      event_trace_pt.put("event_count", 0);
+      event_trace_pt.put("buffer_offset", 0);
+      event_trace_pt.put("buffer_size", 0);
+      event_trace_pt.put("config_valid", config->is_valid());
+    }
+  } 
+  catch (const std::exception& e) {
+    event_trace_pt.put("event_count", 0);
+    event_trace_pt.put("error", e.what());
+  }
+
+  // There can only be 1 root node
+  pt.add_child("event_trace", event_trace_pt);
+}
+
+static std::string
+generate_event_trace_report(const xrt_core::device* dev,
+                           const std::vector<std::string>& elements_filter)
+{
+  std::stringstream ss;
+  
+  try {
+    // Get the event trace configuration
+    auto config = get_event_trace_config(dev);
+    
+    // Query event trace data from device using specific query struct 
+    auto log_buffer = xrt_core::device_query<xrt_core::query::event_trace_data>(dev);
+    
+    ss << boost::format("Event Trace Report (Buffer: %d bytes) - %s\n") 
+          % log_buffer.size % xrt_core::timestamp();
+    ss << "=======================================================\n";
+    
+    if (!config->is_valid()) {
+      ss << "Warning: YAML file is invalid\n";
+    }
+    ss << "\n";
+
+    if (!log_buffer.data || log_buffer.size == 0) {
+      ss << "No event trace data available\n";
+      return ss.str();
+    }
+
+    // Parse trace events from buffer
+    size_t event_count = log_buffer.size / sizeof(trace_event);
+    trace_event* events = static_cast<trace_event*>(log_buffer.data);
+
+    ss << boost::format("Total Events: %d\n") % event_count;
+    ss << boost::format("Buffer Offset: %d\n\n") % log_buffer.abs_offset;
+
+    // Create Table2D with headers (enhanced with parsed args)
+    const std::vector<Table2D::HeaderData> table_headers = {
+      {"Timestamp",         Table2D::Justification::right},
+      {"Event ID",          Table2D::Justification::left},
+      {"Event Name",        Table2D::Justification::left},
+      {"Category",          Table2D::Justification::left},
+      {"Payload",           Table2D::Justification::left},
+      {"Parsed Args",       Table2D::Justification::left}
+    };
+    Table2D event_table(table_headers);
+    
+    // Add data rows
+    for (size_t i = 0; i < event_count; ++i) {
+      // Parse event using YAML-based configuration
+      auto parsed_event = config->parse_event(events[i].timestamp, 
+                                              events[i].event_id, 
+                                              events[i].payload);
+      
+      // Join categories with pipe separator for backward compatibility
+      std::string categories_str;
+      for (size_t j = 0; j < parsed_event.categories.size(); ++j) {
+        if (j > 0) categories_str += "|";
+        categories_str += parsed_event.categories[j];
+      }
+      
+      // Format parsed arguments
+      std::string args_str;
+      for (const auto& arg_pair : parsed_event.args) {
+        if (!args_str.empty()) args_str += ", ";
+        args_str += arg_pair.first + "=" + arg_pair.second;
+      }
+      
+      const std::vector<std::string> entry_data = {
+        std::to_string(parsed_event.timestamp),
+        (boost::format("0x%04x") % parsed_event.event_id).str(),
+        parsed_event.name,
+        categories_str,
+        (boost::format("0x%x") % parsed_event.raw_payload).str(),
+        args_str
+      };
+      event_table.addEntry(entry_data);
+    }
+
+    ss << "  Event Trace Information:\n";
+    ss << event_table.toString("    ");
+
+  } 
+  catch (const std::exception& e) {
+    ss << "Error retrieving event trace data: " << e.what() << "\n";
+  }
+
+  return ss.str();
+}
+
+void
+ReportEventTrace::
+writeReport(const xrt_core::device* device,
+            const bpt& /*pt*/,
+            const std::vector<std::string>& elements_filter,
+            std::ostream& output) const
+{
+  // Check for watch mode
+  if (smi_watch_mode::parse_watch_mode_options(elements_filter)) {
+    // Create report generator lambda for watch mode
+    auto report_generator = [](const xrt_core::device* dev, const std::vector<std::string>& filters) -> std::string {
+      return generate_event_trace_report(dev, filters); 
+    };
+
+    smi_watch_mode::run_watch_mode(device, elements_filter, output,
+                                  report_generator, "Event Trace");
+    return;
+  }
+  output << "Event Trace Report\n";
+  output << "==================\n\n";
+  output << generate_event_trace_report(device, elements_filter);
+  output << std::endl;
+}

--- a/src/runtime_src/core/tools/xbutil2/ReportEventTrace.h
+++ b/src/runtime_src/core/tools/xbutil2/ReportEventTrace.h
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+
+#pragma once
+
+#include "tools/common/Report.h"
+
+/**
+ * @brief Report for firmware event trace information
+ * 
+ * This report provides comprehensive information about firmware event traces
+ * captured from the device. It displays chronological trace events with:
+ * 
+ * Event Trace Information:
+ * - Timestamp: When the event occurred (in nanoseconds)
+ * - Event ID: Unique identifier for the event type
+ * - Event Name: Human-readable name for the event
+ * - Category: Event category (NPU Scheduling, Mailbox, etc.)
+ * - Payload: Event-specific data and arguments
+ * - Context ID: Associated hardware context (if applicable)
+ * 
+ * Event Categories Include:
+ * - NPU Scheduling: Frame start/done, preemption events
+ * - Mailbox: Message processing, context management
+ * - Clock/Power: Power gating, clock management
+ * - Errors: Async errors, fatal errors
+ * - PDI Load: Program download and initialization
+ * - L2 Memory: Save/restore operations
+ * 
+ */
+class ReportEventTrace : public Report {
+public:
+  /**
+   * @brief Constructor for event trace report
+   * 
+   * Initializes the report with:
+   * - Report name: "event-trace"
+   * - Description: "Log to console firmware event trace information"
+   */
+  ReportEventTrace() : Report("event-trace", "Log to console firmware event trace information", true /*deviceRequired*/) { /*empty*/ };
+
+  /**
+   * @brief Generate property tree representation of event trace data
+   * 
+   * Creates a structured property tree containing event trace information
+   * suitable for JSON serialization and programmatic access.
+   * 
+   * @param device Target device to query
+   * @param pt Property tree to populate with event data
+   */
+  void
+  getPropertyTreeInternal(const xrt_core::device* device,
+                         boost::property_tree::ptree& pt) const override;
+
+  /**
+   * @brief Generate property tree in 20202 format for compatibility
+   * 
+   * @param device Target device to query  
+   * @param pt Property tree to populate
+   */
+  void
+  getPropertyTree20202(const xrt_core::device* device,
+                      boost::property_tree::ptree& pt) const override;
+
+  /**
+   * @brief Generate human-readable event trace report
+   * 
+   * Outputs formatted event trace information to the specified stream.
+   * 
+   * @param device Target device to query
+   * @param pt Property tree data (unused for this report)
+   * @param elements_filter Filter options (reserved for future use)
+   * @param output Output stream for report text
+   */
+  void
+  writeReport(const xrt_core::device* device,
+             const boost::property_tree::ptree& pt,
+             const std::vector<std::string>& elements_filter,
+             std::ostream& output) const override;
+};

--- a/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
@@ -25,6 +25,7 @@
 #include "tools/common/reports/ReportDynamicRegion.h"
 #include "tools/common/reports/ReportDebugIpStatus.h"
 #include "tools/common/reports/ReportElectrical.h"
+#include "tools/xbutil2/ReportEventTrace.h"
 #include "tools/common/reports/ReportFirewall.h"
 #include "tools/common/reports/ReportHost.h"
 #include "tools/common/reports/ReportMailbox.h"
@@ -65,6 +66,7 @@ SubCmdExamine::SubCmdExamine(bool _isHidden, bool _isDepricated, bool _isPrelimi
     std::make_shared<ReportContextHealth>(),
     std::make_shared<ReportDebugIpStatus>(),
     std::make_shared<ReportDynamicRegion>(),
+    std::make_shared<ReportEventTrace>(),
     std::make_shared<ReportHost>(),
     std::make_shared<ReportMemory>(),
     std::make_shared<ReportPcieInfo>(),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
This PR adds the implementation for Event Trace report and a parser for event_trace.yaml that is shipped by the firmware in tha latest stric firmware release.
The parser implementation is based on a python parses the firmware team uses for their debugging. 

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://jira.xilinx.com/browse/AIESW-5508

#### How problem was solved, alternative solutions (if any) and why they were rejected
The problem was solved by using an open source yaml parsing library yaml-cpp for yaml parsing and using the parsed configuration to formalize the event trace data in a readable table.

What is missing in this : 

1. This implementation misses handling of missed events since actual firmware data is not used to test this.
2. This implementation also assumes the yaml configuration will be stored in driver build and loaded at run time through a valid path retrieved from UMD. 

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
This is not tested on actual data yet since the driver has not implemented the ioctl changes to retrieve actual firmware data. This PR has been tested using a dummy data generated in the shim and using it to print a table from parsed configuration.
Dummy data used :
```
      std::vector<trace_event> dummy_events = {
        // NPU Scheduling events
        {1000000, 0x0000, 0x1},  // FRAME_START with context_id=1
        {1001000, 0x0001, 0x1},  // FRAME_DONE with context_id=1
        {1002000, 0x0002, 0x12}, // PREEMPTION_START with context_id=1, op_id=2
        {1003000, 0x0003, 0x12}, // PREEMPTION_DONE with context_id=1, op_id=2
        
        // Mailbox events
        {1004000, 0x0004, 0x10}, // PROCESS_MGMT_MSG_START with MSG_OPCODE=0x10
        {1005000, 0x0005, 0x10}, // PROCESS_MGMT_MSG_DONE with MSG_OPCODE=0x10
        {1006000, 0x0006, 0x01000110}, // CREATE_CONTEXT with priority=0x1, cols=1, start=1, ctx=1
        {1007000, 0x0007, 0x10001},     // DELETE_CONTEXT with context_id=1, status=1
        
        // Clock/Power events
        {1008000, 0x000a, 0x101}, // GATE_AIE2_CLKS with num_cols=1, start_col=1
        {1009000, 0x000b, 0x101}, // UNGATE_AIE2_CLKS with num_cols=1, start_col=1
        
        // Error events
        {1010000, 0x0010, 0x101}, // ASYNC_ERROR with num_cols=1, start_col=1
        
        // PDI Load events
        {1011000, 0x0012, 0x1000A001}, // PDI_LOAD_START with context_id=1, address=0xA000
        {1012000, 0x0013, 0x1000A001}, // PDI_LOAD_DONE with context_id=1, address=0xA000
      };
```
Report generated : 
```
<img width="1247" height="476" alt="image" src="https://github.com/user-attachments/assets/b423d0ba-3917-451c-9337-93e309680b59" />

```

#### Documentation impact (if any)
