### PR TITLE
Relative Path Enforcement for Profiling Directory Plugin 

### DIFF
--- a/src/runtime_src/xdp/profile/writer/vp_base/vp_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/vp_writer.cpp
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2016-2020 Xilinx, Inc
- * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -94,7 +94,7 @@ namespace xdp {
 
     // The directory was specified.  Try to create it (regardless of if
     // it exists already or not).
-    constexpr mode_t rwx_all = 777;
+    constexpr mode_t rwx_all = 0777;
     int result = mkdir(directory.c_str(), rwx_all);
 
     try {

--- a/src/runtime_src/xdp/profile/writer/vp_base/vp_writer.h
+++ b/src/runtime_src/xdp/profile/writer/vp_base/vp_writer.h
@@ -68,7 +68,6 @@ namespace xdp {
     inline const char* getRawBasename() { return basename.c_str() ; } 
     XDP_CORE_EXPORT virtual void switchFiles() ;
     XDP_CORE_EXPORT virtual void refreshFile() ;
-
   public:
     XDP_CORE_EXPORT VPWriter(const char* filename) ;
     XDP_CORE_EXPORT VPWriter(const char* filename, VPDatabase* inst,
@@ -87,7 +86,6 @@ namespace xdp {
     virtual bool isSameDevice(void* /*handle*/) { return false ; }
 
     virtual std::string getDirectory() { return directory ; }
-
   } ;
 
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Enforcing relative path for the profiling directory plugin. No absolute paths will be allowed to ensure Vitis Analyzer will work smoothly.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
User specified paths must start with './' or be the name of a folder that can be created within the current directory. 

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Fix has been tested on the VCK190 to ensure that output files will not be written to an invalid directory that the user specified. 

#### Documentation impact (if any)
