### PR TITLE
Enforcing relative path for profiling directory plugin

### DIFF
--- a/src/runtime_src/xdp/profile/writer/vp_base/vp_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/vp_writer.cpp
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2016-2020 Xilinx, Inc
- * Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -66,10 +66,29 @@ namespace xdp {
 #else
     directory = xrt_core::config::get_profiling_directory() ;
 
-    if (!useDir || directory == "") {
-      // If no directory was specified, just use the file in
+    if (!useDir || directory == "" ) {
+      // If no directory was specified just use the file in
       //  the working directory
       fout.open(filename);
+      return;
+    }
+
+    // If the path is neither a relative path nor the name of a folder we can create
+    // just put the file in the current directory
+    size_t start = directory.find_first_not_of(" \t\n\r");
+    if (start != std::string::npos) directory = directory.substr(start);
+    if (!(std::isalpha(directory[0]) || (directory.size() > 1 && directory[0] == '.' && directory[1] == '/'))) {
+      fout.open(filename);
+      try {
+        std::string msg =
+          "The user specified profiling directory is not valid. Please provide a relative path or the name of a folder that can be created.";
+        xrt_core::message::send(xrt_core::message::severity_level::info,
+                                "XRT", msg);
+      }
+      catch (...) {
+        // The message sending could throw a boost::property_tree exception.
+        // If we catch it, just ignore it and move on.
+      }
       return;
     }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Enforcing relative path for the profiling directory plugin. No absolute paths will be allowed to ensure Vitis Analyzer will work smoothly.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
User specified paths must start with './' or be the name of a folder that can be created within the current directory.

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Fix has been tested on the VCK190 to ensure that output files will not be written to an invalid directory that the user specified.

#### Documentation impact (if any)
