### PR TITLE
AIESW-1706 xrt-smi : add APU information to examine report

### DIFF
--- a/src/runtime_src/core/common/detail/linux/sysinfo.h
+++ b/src/runtime_src/core/common/detail/linux/sysinfo.h
@@ -56,7 +56,7 @@ processor_name()
       if (line.rfind("model name", 0) != 0)  // Check if line starts with "model name"
         continue;
 
-      if (auto colon_pos = line.find(":"); colon_pos != std::string::npos) {
+      if (auto colon_pos = line.find(": "); colon_pos != std::string::npos) {
         model_name = line.substr(colon_pos + 2); // Extract substring after ": "
         break;
       }

--- a/src/runtime_src/core/common/detail/linux/sysinfo.h
+++ b/src/runtime_src/core/common/detail/linux/sysinfo.h
@@ -53,11 +53,10 @@ processor_name()
 
   if (cpuinfo.is_open()) {
     while (std::getline(cpuinfo, line)) {
-      if (line.rfind("model name", 0) != 0) { // Check if line starts with "model name"
+      if (line.rfind("model name", 0) != 0)  // Check if line starts with "model name"
         continue;
-      }
-      size_t colon_pos = line.find(":");
-      if (colon_pos != std::string::npos) {
+
+      if (auto colon_pos = line.find(":"); colon_pos != std::string::npos) {
         model_name = line.substr(colon_pos + 2); // Extract substring after ": "
         break;
       }
@@ -116,9 +115,9 @@ get_os_info(boost::property_tree::ptree &pt)
   pt.put("model", machine_info());
   pt.put("cores", std::thread::hardware_concurrency());
   pt.put("memory_bytes", (boost::format("0x%lx") % (sysconf(_SC_PHYS_PAGES) * sysconf(_SC_PAGE_SIZE))).str());
-  boost::property_tree::ptree ptLibInfo;
-  ptLibInfo.push_back( {"", glibc_info()} );
-  pt.put_child("libraries", ptLibInfo);
+  boost::property_tree::ptree pt_lib_info;
+  pt_lib_info.push_back( {"", glibc_info()} );
+  pt.put_child("libraries", pt_lib_info);
 
   char hostname[256] = {0};
   gethostname(hostname, 256);

--- a/src/runtime_src/core/common/detail/linux/sysinfo.h
+++ b/src/runtime_src/core/common/detail/linux/sysinfo.h
@@ -103,6 +103,26 @@ get_os_info(boost::property_tree::ptree &pt)
   gethostname(hostname, 256);
   std::string hn(hostname);
   pt.put("hostname", hn);
+
+  //processor name
+  std::ifstream cpuinfo("/proc/cpuinfo");
+  std::string line;
+  std::string modelName = "Unknown";
+
+  if (cpuinfo.is_open()) {
+    while (std::getline(cpuinfo, line)) {
+      if (line.rfind("model name", 0) == 0) { // Check if line starts with "model name"
+        size_t colonPos = line.find(":");
+        if (colonPos != std::string::npos) {
+          modelName = line.substr(colonPos + 2); // Extract substring after ": "
+          break;
+        }
+      }
+    }
+    cpuinfo.close();
+  }
+
+  pt.put("processor", modelName);
 }
 
 } //xrt_core::sysinfo

--- a/src/runtime_src/core/common/detail/linux/sysinfo.h
+++ b/src/runtime_src/core/common/detail/linux/sysinfo.h
@@ -53,15 +53,15 @@ processor_name()
 
   if (cpuinfo.is_open()) {
     while (std::getline(cpuinfo, line)) {
-      if (line.rfind("model name", 0) == 0) { // Check if line starts with "model name"
-        size_t colon_pos = line.find(":");
-        if (colon_pos != std::string::npos) {
-          model_name = line.substr(colon_pos + 2); // Extract substring after ": "
-          break;
-        }
+      if (line.rfind("model name", 0) != 0) { // Check if line starts with "model name"
+        continue;
+      }
+      size_t colon_pos = line.find(":");
+      if (colon_pos != std::string::npos) {
+        model_name = line.substr(colon_pos + 2); // Extract substring after ": "
+        break;
       }
     }
-    cpuinfo.close();
   }
   return model_name;
 }

--- a/src/runtime_src/core/common/detail/windows/sysinfo.h
+++ b/src/runtime_src/core/common/detail/windows/sysinfo.h
@@ -224,6 +224,11 @@ get_os_info(boost::property_tree::ptree &pt)
   BufferSize = sizeof value;
   RegGetValueA(HKEY_LOCAL_MACHINE, "HARDWARE\\DESCRIPTION\\System\\BIOS", "BIOSVersion", RRF_RT_ANY, NULL, (PVOID)&value, &BufferSize);
   pt.put("bios_version", value);
+
+  //processor name
+  BufferSize = sizeof value;
+  RegGetValueA(HKEY_LOCAL_MACHINE, "HARDWARE\\DESCRIPTION\\System\\CentralProcessor\\0", "ProcessorNameString", RRF_RT_ANY, NULL, (PVOID)&value, &BufferSize);
+  pt.put("processor", value);
 }
 
 } //xrt_core::sysinfo

--- a/src/runtime_src/core/tools/common/reports/ReportHost.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportHost.cpp
@@ -129,6 +129,7 @@ ReportHost::writeReport(const xrt_core::device* /*_pDevice*/,
     _output << boost::format("  %-20s : %s\n") % "Model" % _pt.get<std::string>("host.os.model");
     _output << boost::format("  %-20s : %s\n") % "BIOS Vendor" % _pt.get<std::string>("host.os.bios_vendor");
     _output << boost::format("  %-20s : %s\n") % "BIOS Version" % _pt.get<std::string>("host.os.bios_version");
+    _output << boost::format("  %-20s : %s\n") % "Processor" % _pt.get<std::string>("host.os.processor");
     _output << std::endl;
     _output << "XRT\n";
     std::stringstream xrt_version_ss;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
[AIESW-1706](https://jira.xilinx.com/browse/AIESW-1706) xrt-smi : add APU information to examine report

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
New addition

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added processor name to the host report. This provides the APU information

#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
Tested on linux and windows

```
>xrt-smi examine
System Configuration
...
  BIOS Vendor          : AMD
  BIOS Version         : WXC4A30N
  Processor            : AMD Ryzen AI 7 350 w/ Radeon 860M

XRT
  Version              : 2.20.0
...
```

```
System Configuration
...
  BIOS Vendor          : American Megatrends Inc.
  BIOS Version         : 1.0a
  Processor            : Intel(R) Xeon(R) Silver 4110 CPU @ 2.10GHz

XRT
  Version              : 2.20.0
...
```


#### Documentation impact (if any)
N/A