### PR TITLE
print ctx heath exception message in non-elf flow

### DIFF
--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -2571,6 +2571,7 @@ public:
     std::string msg = "Command failed to complete successfully (" + cmd_state_to_string(state) + ")";
     
     switch (epkt->opcode) {
+    case ERT_START_CU:
     case ERT_START_NPU:
     case ERT_START_NPU_PREEMPT:
     case ERT_START_NPU_PREEMPT_ELF:
@@ -3190,6 +3191,7 @@ class runlist_impl
   {
     auto epkt = run.get_ert_packet();
     switch (epkt->opcode) {
+    case ERT_START_CU:
     case ERT_START_NPU:
     case ERT_START_NPU_PREEMPT:
     case ERT_START_NPU_PREEMPT_ELF:

--- a/src/runtime_src/core/include/xrt/detail/ert.h
+++ b/src/runtime_src/core/include/xrt/detail/ert.h
@@ -1207,6 +1207,7 @@ static inline struct ert_ctx_health_data*
 get_ert_ctx_health_data(const struct ert_packet* pkt)
 {
   switch (pkt->opcode) {
+  case ERT_START_CU:
   case ERT_START_NPU:
   case ERT_START_NPU_PREEMPT:
   case ERT_START_NPU_PREEMPT_ELF:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Exception message is not getting printed in case of ERT_CMD_STATE_TIMEOUT with TXN flow
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Exception message is not getting printed in case of ERT_CMD_STATE_TIMEOUT with TXN flow
#### How problem was solved, alternative solutions (if any) and why they were rejected
Added case for TXN flow.
#### Risks (if any) associated the changes in the commit
None
#### What has been tested and how, request additional testing if necessary
Tested with TXN binary 
#### Documentation impact (if any)
No