### PR TITLE
[XDP] Added offloaderManager for AIE trace plugin to support PLIO and GMIO offload

### DIFF
--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -1070,6 +1070,20 @@ get_aie_trace_settings_enable_system_timeline()
   return value;
 }
 
+inline bool
+get_aie_trace_offload_plio_enabled()
+{
+  static bool value = detail::get_bool_value("AIE_trace_settings.enable_offload_plio", true);
+  return value;
+}
+
+inline bool
+get_aie_trace_offload_gmio_enabled()
+{
+  static bool value = detail::get_bool_value("AIE_trace_settings.enable_offload_gmio", true);
+  return value;
+}
+
 inline std::string
 get_dtrace_lib_path()
 {

--- a/src/runtime_src/xdp/profile/database/dynamic_event_database.cpp
+++ b/src/runtime_src/xdp/profile/database/dynamic_event_database.cpp
@@ -243,17 +243,19 @@ namespace xdp {
                                           uint64_t strmIndex,
                                           void* buffer,
                                           uint64_t bufferSz,
-                                          bool copy)
+                                          bool copy,
+                                          io_type offloadType)
   {
     auto device_db = getDeviceDB(deviceId);
     device_db->addAIETraceData(strmIndex, buffer, bufferSz, copy,
-                               db->getStaticInfo().getNumAIETraceStream(deviceId));
+                               db->getStaticInfo().getNumAIETraceStream(deviceId, offloadType),
+                               offloadType);
   }
 
-  aie::TraceDataType* VPDynamicDatabase::getAIETraceData(uint64_t deviceId, uint64_t strmIndex)
+  aie::TraceDataType* VPDynamicDatabase::getAIETraceData(uint64_t deviceId, uint64_t strmIndex, io_type offloadType)
   {
     auto device_db = getDeviceDB(deviceId);
-    return device_db->getAIETraceData(strmIndex);
+    return device_db->getAIETraceData(strmIndex, offloadType);
   }
 
   void VPDynamicDatabase::addPowerSample(uint64_t deviceId, double timestamp,

--- a/src/runtime_src/xdp/profile/database/dynamic_event_database.h
+++ b/src/runtime_src/xdp/profile/database/dynamic_event_database.h
@@ -35,6 +35,7 @@
 #include "xdp/profile/database/dynamic_info/string_table.h"
 #include "xdp/profile/database/dynamic_info/types.h"
 #include "xdp/profile/database/events/vtf_event.h"
+#include "xdp/profile/database/static_info/aie_constructs.h"
 
 namespace xdp {
 
@@ -164,8 +165,8 @@ namespace xdp {
     XDP_CORE_EXPORT std::map<uint64_t, std::vector<uint64_t>> getDependencyMap() ;
 
     // Add and get AIE Trace Data Buffer
-    XDP_CORE_EXPORT void addAIETraceData(uint64_t deviceId, uint64_t strmIndex, void* buffer, uint64_t bufferSz, bool copy);
-    XDP_CORE_EXPORT aie::TraceDataType* getAIETraceData(uint64_t deviceId, uint64_t strmIndex);
+    XDP_CORE_EXPORT void addAIETraceData(uint64_t deviceId, uint64_t strmIndex, void* buffer, uint64_t bufferSz, bool copy, io_type offloadType);
+    XDP_CORE_EXPORT aie::TraceDataType* getAIETraceData(uint64_t deviceId, uint64_t strmIndex, io_type offloadType);
 
     // Functions that are used by counter-based plugins
     XDP_CORE_EXPORT void addPowerSample(uint64_t deviceId, double timestamp,

--- a/src/runtime_src/xdp/profile/database/dynamic_info/aie_db.h
+++ b/src/runtime_src/xdp/profile/database/dynamic_info/aie_db.h
@@ -25,6 +25,7 @@
 #include "xdp/config.h"
 #include "xdp/profile/database/dynamic_info/samples.h"
 #include "xdp/profile/database/dynamic_info/types.h"
+#include "xdp/profile/database/static_info/aie_constructs.h"
 
 namespace xdp {
 
@@ -33,7 +34,8 @@ namespace xdp {
   class AIEDB
   {
   private:
-    aie::TraceDataVector traceData;
+    // aie::TraceDataVector traceData;
+    std::map<io_type, aie::TraceDataVector> traceDataMap;
 
     SampleContainer samples;
     DoubleSampleContainer timerSamples;
@@ -49,8 +51,8 @@ namespace xdp {
     XDP_CORE_EXPORT ~AIEDB();
 
     void addAIETraceData(uint64_t strmIndex, void* buffer, uint64_t bufferSz,
-                         bool copy, uint64_t numTraceStreams);
-    aie::TraceDataType* getAIETraceData(uint64_t strmIndex);
+                         bool copy, uint64_t numTraceStreams, io_type offloadType);
+    aie::TraceDataType* getAIETraceData(uint64_t strmIndex, io_type offloadType);
 
     void addAIESample(double timestamp, const std::vector<uint64_t>& values);
 

--- a/src/runtime_src/xdp/profile/database/dynamic_info/device_db.h
+++ b/src/runtime_src/xdp/profile/database/dynamic_info/device_db.h
@@ -28,6 +28,7 @@
 #include "xdp/profile/database/dynamic_info/aie_db.h"
 #include "xdp/profile/database/dynamic_info/pl_db.h"
 #include "xdp/profile/database/dynamic_info/types.h"
+#include "xdp/profile/database/static_info/aie_constructs.h"
 
 namespace xdp {
 
@@ -97,11 +98,11 @@ namespace xdp {
 
     inline void addAIETraceData(uint64_t strmIndex, void* buffer,
                                 uint64_t bufferSz, bool copy,
-                                uint64_t numStreams)
-    { aie_db.addAIETraceData(strmIndex, buffer, bufferSz, copy, numStreams); }
+                                uint64_t numStreams, io_type offloadType)
+    { aie_db.addAIETraceData(strmIndex, buffer, bufferSz, copy, numStreams, offloadType); }
 
-    inline aie::TraceDataType* getAIETraceData(uint64_t strmIndex)
-    { return aie_db.getAIETraceData(strmIndex); }
+    inline aie::TraceDataType* getAIETraceData(uint64_t strmIndex, io_type offloadType)
+    { return aie_db.getAIETraceData(strmIndex, offloadType);  }
 
     inline
     void addAIESample(double timestamp, const std::vector<uint64_t>& values)

--- a/src/runtime_src/xdp/profile/database/events/creator/aie_trace_data_logger.cpp
+++ b/src/runtime_src/xdp/profile/database/events/creator/aie_trace_data_logger.cpp
@@ -21,9 +21,10 @@
 
 namespace xdp {
 
-AIETraceDataLogger::AIETraceDataLogger(uint64_t devId)
+AIETraceDataLogger::AIETraceDataLogger(uint64_t devId, io_type oType)
            : AIETraceLogger(),
              deviceId(devId),
+             offloadType(oType),
              db(VPDatabase::Instance())
 {
 }
@@ -37,7 +38,7 @@ void AIETraceDataLogger::addAIETraceData(uint64_t strmIndex, void* buffer, uint6
   if(!VPDatabase::alive()) {
     return;
   }
-  db->getDynamicInfo().addAIETraceData(deviceId, strmIndex, buffer, bufferSz, copy);
+  db->getDynamicInfo().addAIETraceData(deviceId, strmIndex, buffer, bufferSz, copy, offloadType);
 }
 
 }

--- a/src/runtime_src/xdp/profile/database/events/creator/aie_trace_data_logger.h
+++ b/src/runtime_src/xdp/profile/database/events/creator/aie_trace_data_logger.h
@@ -27,12 +27,13 @@ namespace xdp {
 class AIETraceDataLogger : public AIETraceLogger
 {
   uint64_t deviceId = 0;
+  io_type offloadType = io_type::PLIO;
   VPDatabase* db = nullptr;
 
 public:
 
   XDP_CORE_EXPORT
-  AIETraceDataLogger(uint64_t devId);
+  AIETraceDataLogger(uint64_t devId, io_type oType);
   XDP_CORE_EXPORT
   virtual ~AIETraceDataLogger();
 

--- a/src/runtime_src/xdp/profile/database/static_info_database.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info_database.cpp
@@ -1257,28 +1257,44 @@ namespace xdp {
 
   uint64_t VPStaticDatabase::getNumAIETraceStream(uint64_t deviceId)
   {
-    uint64_t numAIETraceStream = getNumTracePLIO(deviceId) ;
-    if (numAIETraceStream)
-      return numAIETraceStream ;
-    {
-      // NumTracePLIO also locks the database, so put this lock in its own
-      //  scope after numTracePLIO has returned.
-      std::lock_guard<std::mutex> lock(deviceLock) ;
+    uint64_t numAIETraceStreamPLIO = getNumTracePLIO(deviceId) ;
+    uint64_t numAIETraceStreamGMIO = getNumTraceGMIO(deviceId) ;
+    std::cout << "getNumAIETraceStream: deviceId=" << deviceId
+              << " PLIO=" << numAIETraceStreamPLIO
+              << " GMIO=" << numAIETraceStreamGMIO
+              << " Total=" << (numAIETraceStreamPLIO + numAIETraceStreamGMIO)
+              << std::endl ;
+    return numAIETraceStreamPLIO + numAIETraceStreamGMIO ;
+    // if (numAIETraceStream)
+    //   return numAIETraceStream ;
+    // {
+    //   // NumTracePLIO also locks the database, so put this lock in its own
+    //   //  scope after numTracePLIO has returned.
+    //   std::lock_guard<std::mutex> lock(deviceLock) ;
 
-      if (deviceInfo.find(deviceId) == deviceInfo.end())
-        return 0 ;
+    //   if (deviceInfo.find(deviceId) == deviceInfo.end())
+    //     return 0 ;
 
-      ConfigInfo* config = deviceInfo[deviceId]->currentConfig() ;
-      if (!config)
-        return 0 ;
+    //   ConfigInfo* config = deviceInfo[deviceId]->currentConfig() ;
+    //   if (!config)
+    //     return 0 ;
 
-      XclbinInfo* xclbin = config->getAieXclbin();
-      if (!xclbin)
-        return 0;
+    //   XclbinInfo* xclbin = config->getAieXclbin();
+    //   if (!xclbin)
+    //     return 0;
 
-      auto rc = xclbin->aie.gmioList.size() ;
-      return rc;
-    }
+    //   auto rc = xclbin->aie.gmioList.size() ;
+    //   return rc;
+    // }
+  }
+
+  uint64_t VPStaticDatabase::getNumAIETraceStream(uint64_t deviceId, io_type ioType)
+  {
+    if (ioType == io_type::PLIO)
+      return getNumTracePLIO(deviceId);
+    // else if (ioType == io_type::GMIO)
+    else
+      return getNumTraceGMIO(deviceId);
   }
 
   void* VPStaticDatabase::getAieDevInst(std::function<void* (void*)> fetch,

--- a/src/runtime_src/xdp/profile/database/static_info_database.h
+++ b/src/runtime_src/xdp/profile/database/static_info_database.h
@@ -396,6 +396,7 @@ namespace xdp {
                                   std::unique_ptr<aie_cfg_tile>& tile) ;
     XDP_CORE_EXPORT uint64_t getNumTracePLIO(uint64_t deviceId) ;
     XDP_CORE_EXPORT uint64_t getNumAIETraceStream(uint64_t deviceId) ;
+    XDP_CORE_EXPORT uint64_t getNumAIETraceStream(uint64_t deviceId, io_type ioType);
     XDP_CORE_EXPORT void* getAieDevInst(std::function<void* (void*)> fetch,
                                    void* devHandle, uint64_t deviceID=0) ;
     XDP_CORE_EXPORT void* getAieDevice(std::function<void* (void*)> allocate,

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_metadata.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_metadata.h
@@ -84,7 +84,9 @@ class AieTraceMetadata {
     std::string getCounterScheme(){return counterScheme;}
 
     uint32_t getIterationCount(){return iterationCount;}
-    uint64_t getNumStreams() {return numAIETraceOutput;}
+    // uint64_t getNumStreams() {return numAIETraceOutput;}
+    uint64_t getNumStreamsPLIO() {return numAIETraceOutputPLIO;}
+    uint64_t getNumStreamsGMIO() {return numAIETraceOutputGMIO;}
     uint64_t getContinuousTrace() {return continuousTrace;}
     void resetContinuousTrace() {continuousTrace = false;}
     uint64_t getOffloadIntervalUs() {return offloadIntervalUs;}
@@ -99,7 +101,8 @@ class AieTraceMetadata {
     std::map<tile_type, uint8_t> getConfigChannel0() {return configChannel0;}
     std::map<tile_type, uint8_t> getConfigChannel1() {return configChannel1;}
 
-    void setNumStreams(uint64_t newNumTraceStreams) {numAIETraceOutput = newNumTraceStreams;}
+    void setNumStreamsPLIO(uint64_t newNumTraceStreams) {numAIETraceOutputPLIO = newNumTraceStreams;}
+    void setNumStreamsGMIO(uint64_t newNumTraceStreams) {numAIETraceOutputGMIO = newNumTraceStreams;}
     void setDelayCycles(uint64_t newDelayCycles) {delayCycles = newDelayCycles;}
     void setRuntimeMetrics(bool metrics) {runtimeMetrics = metrics;}
     uint64_t getDelay() {return ((useDelay) ? delayCycles : 0);}
@@ -132,7 +135,8 @@ class AieTraceMetadata {
     uint32_t iterationCount = 0;
     uint64_t delayCycles = 0;
     uint64_t deviceID;
-    uint64_t numAIETraceOutput = 0;
+    uint64_t numAIETraceOutputPLIO = 0;
+    uint64_t numAIETraceOutputGMIO = 0;
     uint64_t offloadIntervalUs = 0;
     unsigned int aie_trace_file_dump_int_s;
     

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_offload_manager.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_offload_manager.cpp
@@ -1,0 +1,265 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved
+#define XDP_PLUGIN_SOURCE
+#include "xdp/profile/plugin/aie_trace/aie_trace_offload_manager.h"
+
+namespace xdp {
+  using severity_level = xrt_core::message::severity_level;
+
+  void AIETraceOffloadManager::startPLIOOffload(bool continuousTrace, uint64_t offloadIntervalUs) {
+    // std::cout << "!!! AIETraceOffloadManager::startPLIOOffload called." << std::endl;
+    if (plio.offloader && continuousTrace) {
+      plio.offloader->setContinuousTrace();
+      plio.offloader->setOffloadIntervalUs(offloadIntervalUs);
+    }
+    if (plio.offloader)
+      plio.offloader->startOffload();
+  }
+
+  void AIETraceOffloadManager::startGMIOOffload(bool continuousTrace, uint64_t offloadIntervalUs) {
+    // std::cout << "!!! AIETraceOffloadManager::startGMIOOffload called." << std::endl;
+    if (gmio.offloader && continuousTrace) {
+      gmio.offloader->setContinuousTrace(); // GMIO trace offload does not support continuous trace
+      gmio.offloader->setOffloadIntervalUs(offloadIntervalUs);
+    }
+    if (gmio.offloader)
+      gmio.offloader->startOffload();
+  }
+
+uint64_t AIETraceOffloadManager::checkAndCapToBankSize(VPDatabase* db,
+                                 uint64_t device_id,
+                                 uint8_t memIndex,
+                                 uint64_t desired)
+{
+  auto* memory = db->getStaticInfo().getMemory(device_id, memIndex);
+  if (!memory)
+    return desired;
+
+  const uint64_t fullBankSize = static_cast<uint64_t>(memory->size) * 1024ULL;
+  if ((fullBankSize > 0) && (desired > fullBankSize)) {
+    xrt_core::message::send(severity_level::warning, "XRT",
+      "Requested AIE trace buffer is too big for memory resource. Limiting to "
+      + std::to_string(fullBankSize) + ".");
+    return fullBankSize;
+  }
+  return desired;
+}
+
+  AIETraceOffloadManager::AIETraceOffloadManager(uint64_t device_id, VPDatabase* database, AieTraceImpl* impl)
+    : deviceID{device_id},
+      db{database},
+      aieTraceImpl{impl},
+      offloadEnabledPLIO(xrt_core::config::get_aie_trace_offload_plio_enabled()),
+      offloadEnabledGMIO(xrt_core::config::get_aie_trace_offload_gmio_enabled())
+  {}
+
+  void AIETraceOffloadManager::initPLIO(uint64_t device_id, void* handle, PLDeviceIntf* deviceIntf, uint64_t bufSize, uint64_t numStreams, XAie_DevInst* devInst) {
+    offloadEnabledPLIO = xrt_core::config::get_aie_trace_offload_plio_enabled();
+    if (!offloadEnabledPLIO) {
+      // std::cout << "!!! AIETraceOffloadManager::initPLIO: PLIO offload disabled by config, skipping.." << std::endl;
+      return;
+    }
+
+    plio.logger = std::make_unique<AIETraceDataLogger>(device_id, io_type::PLIO);
+#ifndef XDP_CLIENT_BUILD
+    plio.offloader = std::make_unique<AIETraceOffload>(handle, device_id, deviceIntf, plio.logger.get(), true, bufSize, numStreams, devInst);
+#else
+    // Suppress unused parameter warnings in client build
+    (void)handle;
+    (void)deviceIntf;
+    (void)bufSize;
+    (void)numStreams;
+    (void)devInst;
+#endif
+    plio.valid = true;
+    // std::cout << "!!! AIETraceOffloadManager::initPLIO called. numStreams: " << numStreams << std::endl;
+  }
+
+  // TODO: Use const references for parameters where applicable
+  #ifdef XDP_CLIENT_BUILD
+  void AIETraceOffloadManager::initGMIO(
+              uint64_t device_id, void* handle, PLDeviceIntf* deviceIntf,
+              uint64_t bufSize, uint64_t numStreams, xrt::hw_context context, std::shared_ptr<AieTraceMetadata> metadata)
+  {
+    offloadEnabledGMIO = xrt_core::config::get_aie_trace_offload_gmio_enabled();
+    if (!offloadEnabledGMIO) {
+      // std::cout << "!!! AIETraceOffloadManager::initGMIO: GMIO offload disabled by config, skipping..." << std::endl;
+      return;
+    }
+
+    gmio.logger = std::make_unique<AIETraceDataLogger>(device_id, io_type::GMIO);
+    // Use the client-specific AIETraceOffload constructor
+    gmio.offloader = std::make_unique<AIETraceOffload>(
+        handle, device_id, deviceIntf, gmio.logger.get(), false, // isPLIO = false
+        bufSize, numStreams, context, metadata);
+    gmio.valid = true;
+  }
+#else
+  void AIETraceOffloadManager::initGMIO(uint64_t device_id, void* handle, PLDeviceIntf* deviceIntf, uint64_t bufSize, uint64_t numStreams, XAie_DevInst* devInst) {
+    offloadEnabledGMIO = xrt_core::config::get_aie_trace_offload_gmio_enabled();
+    if (!offloadEnabledGMIO) {
+      // std::cout << "!!! AIETraceOffloadManager::initGMIO: GMIO offload disabled by config, skipping" << std::endl;
+      return;
+    }
+
+    gmio.logger = std::make_unique<AIETraceDataLogger>(device_id, io_type::GMIO);
+    gmio.offloader = std::make_unique<AIETraceOffload>(handle, device_id, deviceIntf, gmio.logger.get(), false, bufSize, numStreams, devInst);
+    gmio.valid = true;
+    // std::cout << "!!! AIETraceOffloadManager::initGMIO called. numStreams: " << numStreams << std::endl;
+  }
+#endif
+
+  void AIETraceOffloadManager::startOffload(bool continuousTrace, uint64_t offloadIntervalUs){
+    if (!offloadEnabledPLIO && !offloadEnabledGMIO) {
+      // std::cout << "!!! AIETraceOffloadManager::startOffload: Both PLIO and GMIO offload disabled by config." << std::endl;
+      return;
+    }
+    if (offloadEnabledPLIO)
+      startPLIOOffload(continuousTrace, offloadIntervalUs);
+    if (offloadEnabledGMIO)
+      startGMIOOffload(continuousTrace, offloadIntervalUs);
+  }
+
+  bool AIETraceOffloadManager::initReadTraces() {
+    bool readStatus = true;
+
+    if (offloadEnabledPLIO && plio.offloader) {
+      // std::cout << "!!! AIETraceOffloadManager::initReadTraces: Initializing PLIO trace read." << std::endl;
+      readStatus &= plio.offloader->initReadTrace();
+    }
+    if (offloadEnabledGMIO && gmio.offloader) {
+      // std::cout << "!!! AIETraceOffloadManager::initReadTraces: Initializing GMIO trace read." << std::endl;
+      readStatus &= gmio.offloader->initReadTrace();
+    }
+    return readStatus;
+  }
+
+  void AIETraceOffloadManager::flushAll(bool warn) {
+    if (offloadEnabledPLIO && plio.offloader) {
+      // std::cout << "!!! AIETraceOffloadManager::flushAll: Flushing PLIO traces." << std::endl;
+      flushOffloader(plio.offloader, warn);
+    }
+    if (offloadEnabledGMIO && gmio.offloader) {
+      // std::cout << "!!! AIETraceOffloadManager::flushAll: Flushing GMIO traces." << std::endl;
+      flushOffloader(gmio.offloader, warn);
+    }
+  }
+
+  void AIETraceOffloadManager::flushOffloader(const std::unique_ptr<AIETraceOffload>& offloader, bool warn) {
+    // std::cout << "!!! AIETraceOffloadManager::flushOffloader called." << std::endl;
+    if (offloader->continuousTrace()) {
+      offloader->stopOffload();
+      while (offloader->getOffloadStatus() != AIEOffloadThreadStatus::STOPPED) {}
+    } else {
+      offloader->readTrace(true);
+      offloader->endReadTrace();
+    }
+    if (warn && offloader->isTraceBufferFull()) {
+      xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", AIE_TS2MM_WARN_MSG_BUF_FULL);
+    }
+  }
+
+  void AIETraceOffloadManager::createTraceWriters(uint64_t device_id, uint64_t numStreamsPLIO, uint64_t numStreamsGMIO, std::vector<VPWriter*>& writers) {
+    if (offloadEnabledPLIO) {
+      // Add writer for every PLIO stream
+      for (uint64_t n = 0; n < numStreamsPLIO; ++n) {
+        std::string fileName = "aie_trace_plio_" + std::to_string(device_id) + "_" +
+                              std::to_string(n) + ".txt";
+        VPWriter *writer = new AIETraceWriter(
+          fileName.c_str(),
+          device_id,
+          n,  // stream id
+          "", // version
+          "", // creation time
+          "", // xrt version
+          "",  // tool version
+          io_type::PLIO // offload type
+        );
+        writers.push_back(writer);
+        db->getStaticInfo().addOpenedFile(writer->getcurrentFileName(),
+                                          "AIE_EVENT_TRACE");
+
+        std::stringstream msg;
+        msg << "Creating AIE trace file " << fileName << " for device " << device_id;
+        xrt_core::message::send(severity_level::info, "XRT", msg.str());
+      }
+    }
+
+    if (offloadEnabledGMIO) {
+      // Add writer for every GMIO stream
+      for (uint64_t n = 0; n < numStreamsGMIO; ++n) {
+        std::string fileName = "aie_trace_gmio_" + std::to_string(device_id) + "_" +
+                              std::to_string(n) + ".txt";
+        VPWriter *writer = new AIETraceWriter(
+          fileName.c_str(),
+          device_id,
+          n,  // stream id
+          "", // version
+          "", // creation time
+          "", // xrt version
+          "",  // tool version
+          io_type::GMIO // offload type
+        );
+        writers.push_back(writer);
+        db->getStaticInfo().addOpenedFile(writer->getcurrentFileName(),
+                                          "AIE_EVENT_TRACE");
+
+        std::stringstream msg;
+        msg << "Creating AIE trace file " << fileName << " for device " << device_id;
+        xrt_core::message::send(severity_level::info, "XRT", msg.str());
+      }
+    }
+  }
+
+
+bool AIETraceOffloadManager::configureAndInitPLIO(
+  uint64_t device_id, void* handle, PLDeviceIntf* deviceIntf,
+  uint64_t desiredBufSize, uint64_t numStreamsPLIO, XAie_DevInst* devInst)
+{
+  uint64_t sz = aieTraceImpl ? aieTraceImpl->checkTraceBufSize(desiredBufSize) : desiredBufSize;
+
+  uint8_t memIndex = 0;
+  if (deviceIntf)
+    memIndex = deviceIntf->getAIETs2mmMemIndex(0);
+
+  desiredBufSize = checkAndCapToBankSize(db, device_id, memIndex, desiredBufSize);
+  desiredBufSize = aieTraceImpl->checkTraceBufSize(desiredBufSize);
+
+  if (!devInst) {
+    xrt_core::message::send(severity_level::warning, "XRT",
+      "Unable to get AIE device instance. AIE event trace will not be available.");
+    return false;
+  }
+
+  initPLIO(device_id, handle, deviceIntf, sz, numStreamsPLIO, devInst);
+  return true;
+}
+
+bool AIETraceOffloadManager::configureAndInitGMIO(
+  uint64_t device_id, void* handle, PLDeviceIntf* deviceIntf,
+  uint64_t desiredBufSize, uint64_t numStreamsGMIO
+#ifdef XDP_CLIENT_BUILD
+  , const xrt::hw_context& hwctx, const std::shared_ptr<AieTraceMetadata>& md
+#else
+  , XAie_DevInst* devInst
+#endif
+  )
+{
+  desiredBufSize = checkAndCapToBankSize(db, device_id, /*bank 0*/ 0, desiredBufSize);
+  desiredBufSize = aieTraceImpl->checkTraceBufSize(desiredBufSize);
+
+#ifdef XDP_CLIENT_BUILD
+  initGMIO(device_id, handle, deviceIntf, desiredBufSize, numStreamsGMIO, hwctx, md);
+  return true;
+#else
+  if (!devInst) {
+    xrt_core::message::send(severity_level::warning, "XRT",
+      "Unable to get AIE device instance. AIE event trace will not be available.");
+    return false;
+  }
+  initGMIO(device_id, handle, deviceIntf, desiredBufSize, numStreamsGMIO, devInst);
+  return true;
+#endif
+}
+
+} // namespace xdp

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_offload_manager.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_offload_manager.h
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved
+#ifndef AIE_TRACE_OFFLOAD_MANAGER_H
+#define AIE_TRACE_OFFLOAD_MANAGER_H
+#include <iostream>
+#include <sstream>
+#include <functional>
+#include <vector>
+#include <string>
+#include <memory>
+#include "core/common/message.h"
+#include "xdp/profile/database/events/creator/aie_trace_data_logger.h"
+#include "xdp/profile/writer/aie_trace/aie_trace_writer.h"
+#include "xdp/profile/plugin/aie_trace/aie_trace_impl.h"
+#include "xdp/profile/device/pl_device_intf.h"
+#include "xdp/profile/database/static_info/pl_constructs.h"
+#include "xdp/profile/database/database.h"
+
+// #include "xdp/profile/device/aie_trace/aie_trace_offload.h"
+#ifdef XDP_CLIENT_BUILD
+#include "xdp/profile/device/aie_trace/client/aie_trace_offload_client.h"
+#elif XDP_VE2_BUILD
+#include "xdp/profile/device/aie_trace/ve2/aie_trace_offload_ve2.h"
+#else
+#include "xdp/profile/device/aie_trace/aie_trace_offload.h"
+#endif
+
+extern "C" {
+#include <xaiengine.h>
+#include <xaiengine/xaiegbl_params.h>
+}
+
+
+namespace xdp {
+
+  struct AIETraceOffloadData {
+    bool valid = false;
+    std::unique_ptr<AIETraceLogger> logger;
+    std::unique_ptr<AIETraceOffload> offloader;
+  };
+
+class AIETraceOffloadManager {
+  private:
+    void startPLIOOffload(bool continuousTrace, uint64_t offloadIntervalUs);
+    void startGMIOOffload(bool continuousTrace, uint64_t offloadIntervalUs);
+    uint64_t checkAndCapToBankSize(VPDatabase* db, uint64_t device_id, uint8_t memIndex, uint64_t desired);
+
+    uint64_t deviceID;
+    VPDatabase* db;
+    AieTraceImpl* aieTraceImpl = nullptr;
+    AIETraceOffloadData plio;
+    AIETraceOffloadData gmio;
+    bool offloadEnabledPLIO = false;
+    bool offloadEnabledGMIO = false;
+
+  public:
+    AIETraceOffloadManager(uint64_t device_id, VPDatabase* database, AieTraceImpl* impl=nullptr);
+    void initPLIO(uint64_t device_id, void* handle, PLDeviceIntf* deviceIntf, uint64_t bufSize, uint64_t numStreams, XAie_DevInst* devInst);
+
+    // TODO: Use const references for parameters where applicable
+  #ifdef XDP_CLIENT_BUILD
+    void initGMIO(uint64_t device_id, void* handle, PLDeviceIntf* deviceIntf,
+                  uint64_t bufSize, uint64_t numStreams, xrt::hw_context context,
+                  std::shared_ptr<AieTraceMetadata> metadata);
+  #else
+    void initGMIO(uint64_t device_id, void* handle, PLDeviceIntf* deviceIntf, uint64_t bufSize, uint64_t numStreams, XAie_DevInst* devInst);
+  #endif
+
+    void startOffload(bool continuousTrace, uint64_t offloadIntervalUs);
+    bool initReadTraces();
+    void flushAll(bool warn);
+    void flushOffloader(const std::unique_ptr<AIETraceOffload>& offloader, bool warn);
+    void createTraceWriters(uint64_t device_id, uint64_t numStreamsPLIO, uint64_t numStreamsGMIO,
+                            std::vector<VPWriter*>& writers);
+    bool configureAndInitPLIO(uint64_t device_id, void* handle, PLDeviceIntf* deviceIntf,
+                              uint64_t desiredBufSize, uint64_t numStreamsPLIO, XAie_DevInst* devInst);
+    bool configureAndInitGMIO(uint64_t device_id, void* handle, PLDeviceIntf* deviceIntf,
+                              uint64_t desiredBufSize, uint64_t numStreamsGMIO
+  #ifdef XDP_CLIENT_BUILD
+                              , const xrt::hw_context& hwctx, const std::shared_ptr<AieTraceMetadata>& md
+  #else
+                              , XAie_DevInst* devInst
+  #endif
+                              );
+
+}; // class AIETraceOffloadManager
+
+} //namespace xdp
+
+#endif // AIE_TRACE_OFFLOAD_MANAGER_H

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -28,7 +28,8 @@
 #include "xdp/profile/plugin/vp_base/info.h"
 #include "xdp/profile/writer/aie_trace/aie_trace_config_writer.h"
 #include "xdp/profile/writer/aie_trace/aie_trace_timestamps_writer.h"
-#include "xdp/profile/writer/aie_trace/aie_trace_writer.h"
+// #include "xdp/profile/writer/aie_trace/aie_trace_writer.h"
+#include "aie_trace_offload_manager.h"
 
 #ifdef XDP_CLIENT_BUILD
 #include "client/aie_trace.h"
@@ -94,7 +95,7 @@ uint64_t AieTracePluginUnified::getDeviceIDFromHandle(void *handle) {
 
 void AieTracePluginUnified::updateAIEDevice(void *handle, bool hw_context_flow) {
   xrt_core::message::send(severity_level::info, "XRT",
-                          "Calling AIE Trace updateAIEDevice.");
+                          "!!! Calling AIE Trace updateAIEDevice.");
 
   if (!handle)
     return;
@@ -198,10 +199,13 @@ void AieTracePluginUnified::updateAIEDevice(void *handle, bool hw_context_flow) 
   }
 
   // Check if trace streams are available TODO
-  AIEData.metadata->setNumStreams(
-      (db->getStaticInfo()).getNumAIETraceStream(deviceID));
+  AIEData.metadata->setNumStreamsPLIO(
+      (db->getStaticInfo()).getNumAIETraceStream(deviceID, io_type::PLIO));
+  AIEData.metadata->setNumStreamsGMIO(
+      (db->getStaticInfo()).getNumAIETraceStream(deviceID, io_type::GMIO));
 
-  if (AIEData.metadata->getNumStreams() == 0) {
+  if ((AIEData.metadata->getNumStreamsPLIO() == 0) && 
+      (AIEData.metadata->getNumStreamsGMIO() == 0)) {
     AIEData.valid = false;
     xrt_core::message::send(severity_level::warning, "XRT",
                             AIE_TRACE_UNAVAILABLE);
@@ -217,74 +221,209 @@ void AieTracePluginUnified::updateAIEDevice(void *handle, bool hw_context_flow) 
                        "AIE_EVENT_RUNTIME_CONFIG");
   }
 
-  // Add writer for every stream
-  for (uint64_t n = 0; n < AIEData.metadata->getNumStreams(); ++n) {
-    std::string fileName = "aie_trace_" + std::to_string(deviceID) + "_" +
-                           std::to_string(n) + ".txt";
-    VPWriter *writer = new AIETraceWriter(
-      fileName.c_str(),
-      deviceID,
-      n,  // stream id
-      "", // version
-      "", // creation time
-      "", // xrt version
-      ""  // tool version
-    );
-    writers.push_back(writer);
-    db->getStaticInfo().addOpenedFile(writer->getcurrentFileName(),
-                                      "AIE_EVENT_TRACE");
+  if (!AIEData.offloadManager)
+    AIEData.offloadManager = std::make_unique<AIETraceOffloadManager>(deviceID, db, AIEData.implementation.get());
 
-    std::stringstream msg;
-    msg << "Creating AIE trace file " << fileName << " for device " << deviceID;
-    xrt_core::message::send(severity_level::info, "XRT", msg.str());
-  }
+  uint64_t numStreamsPLIO = AIEData.metadata->getNumStreamsPLIO();
+  uint64_t numStreamsGMIO = AIEData.metadata->getNumStreamsGMIO();
+  bool isPLIO = (numStreamsPLIO > 0) ? true : false;
+  bool isGMIO = (numStreamsGMIO > 0) ? true : false;
+  // bool isPLIOGMIO = isPLIO && isGMIO;
+  AIEData.offloadManager->createTraceWriters(deviceID, numStreamsPLIO,
+                                             numStreamsGMIO, writers);
+
+
+  // // Add writer for every PLIO stream
+  // for (uint64_t n = 0; n < AIEData.metadata->getNumStreamsPLIO(); ++n) {
+  //   std::string fileName = "aie_trace_plio_" + std::to_string(deviceID) + "_" +
+  //                          std::to_string(n) + ".txt";
+  //   VPWriter *writer = new AIETraceWriter(
+  //     fileName.c_str(),
+  //     deviceID,
+  //     n,  // stream id
+  //     "", // version
+  //     "", // creation time
+  //     "", // xrt version
+  //     "",  // tool version
+  //     io_type::PLIO // offload type
+  //   );
+  //   writers.push_back(writer);
+  //   db->getStaticInfo().addOpenedFile(writer->getcurrentFileName(),
+  //                                     "AIE_EVENT_TRACE");
+
+  //   std::stringstream msg;
+  //   msg << "Creating AIE trace file " << fileName << " for device " << deviceID;
+  //   xrt_core::message::send(severity_level::info, "XRT", msg.str());
+  // }
+
+  //   // Add writer for every GMIO stream
+  // for (uint64_t n = 0; n < AIEData.metadata->getNumStreamsGMIO(); ++n) {
+  //   std::string fileName = "aie_trace_gmio_" + std::to_string(deviceID) + "_" +
+  //                          std::to_string(n) + ".txt";
+  //   VPWriter *writer = new AIETraceWriter(
+  //     fileName.c_str(),
+  //     deviceID,
+  //     n,  // stream id
+  //     "", // version
+  //     "", // creation time
+  //     "", // xrt version
+  //     "",  // tool version
+  //     io_type::GMIO // offload type
+  //   );
+  //   writers.push_back(writer);
+  //   db->getStaticInfo().addOpenedFile(writer->getcurrentFileName(),
+  //                                     "AIE_EVENT_TRACE");
+
+  //   std::stringstream msg;
+  //   msg << "Creating AIE trace file " << fileName << " for device " << deviceID;
+  //   xrt_core::message::send(severity_level::info, "XRT", msg.str());
+  // }
 
   // Ensure trace buffer size is appropriate
   uint64_t aieTraceBufSize = GetTS2MMBufSize(true /*isAIETrace*/);
-  bool isPLIO = (db->getStaticInfo()).getNumTracePLIO(deviceID) ? true : false;
+  // uint64_t aieTraceBufSizePLIO = aieTraceBufSize;
+  // uint64_t aieTraceBufSizeGMIO = aieTraceBufSize;
+  if (isPLIO) {
 
-  if (AIEData.metadata->getContinuousTrace())
-    XDPPlugin::startWriteThread(AIEData.metadata->getFileDumpIntS(),
-                                "AIE_EVENT_TRACE", false);
-
-  // First, check against memory bank size
-  // NOTE: Check first buffer for PLIO; assume bank 0 for GMIO
-  uint8_t memIndex = 0;
-  if (isPLIO && (deviceIntf != nullptr))
-    memIndex = deviceIntf->getAIETs2mmMemIndex(0);
-
-  Memory *memory = (db->getStaticInfo()).getMemory(deviceID, memIndex);
-
-  if (memory != nullptr) {
-    uint64_t fullBankSize = memory->size * 1024;
-
-    if ((fullBankSize > 0) && (aieTraceBufSize > fullBankSize)) {
-      aieTraceBufSize = fullBankSize;
-      std::string msg = "Requested AIE trace buffer is too big for memory "
-                        "resource. Limiting to " +
-                        std::to_string(fullBankSize) + ".";
-      xrt_core::message::send(severity_level::warning, "XRT", msg);
+    XAie_DevInst* devInst = static_cast<XAie_DevInst*>(AIEData.implementation->setAieDeviceInst(handle, deviceID));
+    if(!devInst) {
+      xrt_core::message::send(severity_level::warning, "XRT",
+        "Unable to get AIE device instance. AIE event trace will not be available.");
+      return;
     }
+    AIEData.offloadManager->configureAndInitPLIO(deviceID, handle, deviceIntf, 
+        aieTraceBufSize, AIEData.metadata->getNumStreamsPLIO(), devInst);
+  }
+  if (isGMIO) {
+#ifdef XDP_CLIENT_BUILD
+  if (!AIEData.offloadManager->configureAndInitGMIO(
+        deviceID, handle, deviceIntf, aieTraceBufSize,
+        AIEData.metadata->getNumStreamsGMIO(),
+        AIEData.metadata->getHwContext(), AIEData.metadata))
+    return;
+#else
+  XAie_DevInst* devInst =
+    static_cast<XAie_DevInst*>(AIEData.implementation->setAieDeviceInst(handle, deviceID));
+  if (!AIEData.offloadManager->configureAndInitGMIO(
+        deviceID, handle, deviceIntf, aieTraceBufSize,
+        AIEData.metadata->getNumStreamsGMIO(), devInst))
+    return;
+#endif
   }
 
-  // Ensures Contiguous Memory Allocation specific for linux/edge.
-  aieTraceBufSize = AIEData.implementation->checkTraceBufSize(aieTraceBufSize);
+  // if (isPLIO) {
+  //   // First, check against memory bank size
+  //   // NOTE: Check first buffer for PLIO; assume bank 0 for GMIO
+  //   uint8_t memIndex = 0;
+  //   if (isPLIO && (deviceIntf != nullptr))
+  //     memIndex = deviceIntf->getAIETs2mmMemIndex(0);
+    
+  //   Memory *memory = (db->getStaticInfo()).getMemory(deviceID, memIndex);
+  //   if (memory != nullptr) {
+  //     uint64_t fullBankSize = memory->size * 1024;
 
-  // Create AIE Trace Offloader
-  AIEData.logger = std::make_unique<AIETraceDataLogger>(deviceID);
+  //     if ((fullBankSize > 0) && (aieTraceBufSizePLIO > fullBankSize)) {
+  //       aieTraceBufSizePLIO = fullBankSize;
+  //       std::string msg = "Requested AIE trace buffer is too big for memory "
+  //                         "resource. Limiting to " +
+  //                         std::to_string(fullBankSize) + ".";
+  //       xrt_core::message::send(severity_level::warning, "XRT", msg);
+  //     }
+  //   }
 
-  if (xrt_core::config::get_verbosity() >=
-      static_cast<uint32_t>(severity_level::debug)) {
-    std::string flowType = (isPLIO) ? "PLIO" : "GMIO";
-    std::stringstream msg;
-    msg << "Total size of " << std::fixed << std::setprecision(3)
-        << (aieTraceBufSize / (1024.0 * 1024.0))
-        << " MB is used for AIE trace buffer for "
-        << std::to_string(AIEData.metadata->getNumStreams()) << " " << flowType
-        << " streams.";
-    xrt_core::message::send(severity_level::debug, "XRT", msg.str());
-  }
+  //   // Ensures Contiguous Memory Allocation specific for linux/edge.
+  //   aieTraceBufSizePLIO = AIEData.implementation->checkTraceBufSize(aieTraceBufSizePLIO);
 
+  //   XAie_DevInst* devInst = static_cast<XAie_DevInst*>(AIEData.implementation->setAieDeviceInst(handle, deviceID));
+  //   if(!devInst) {
+  //     xrt_core::message::send(severity_level::warning, "XRT",
+  //       "Unable to get AIE device instance. AIE event trace will not be available.");
+  //     return;
+  //   }
+
+  //   AIEData.offloadManager->initPLIO(deviceID, handle, deviceIntf, aieTraceBufSizePLIO, AIEData.metadata->getNumStreamsPLIO(), devInst);
+  //   // AIEData.offloadManager->startPLIOOffload(AIEData.metadata->getOffloadIntervalUs(), AIEData.metadata->getContinuousTrace());
+  // }
+
+//   if (isGMIO) {
+//     // First, check against memory bank size
+//     // NOTE: Assume bank 0 for GMIO
+//     uint8_t memIndex = 0;
+//     Memory *memory = (db->getStaticInfo()).getMemory(deviceID, memIndex);
+//     if (memory != nullptr) {
+//       uint64_t fullBankSize = memory->size * 1024;
+
+//       if ((fullBankSize > 0) && (aieTraceBufSizeGMIO > fullBankSize)) {
+//         aieTraceBufSizeGMIO = fullBankSize;
+//         std::string msg = "Requested AIE trace buffer is too big for memory "
+//                           "resource. Limiting to " +
+//                           std::to_string(fullBankSize) + ".";
+//         xrt_core::message::send(severity_level::warning, "XRT", msg);
+//       }
+//     }
+
+//     // Ensures Contiguous Memory Allocation specific for linux/edge.
+//     aieTraceBufSizeGMIO = AIEData.implementation->checkTraceBufSize(aieTraceBufSizeGMIO);
+
+// #ifdef XDP_CLIENT_BUILD
+//     AIEData.offloadManager->initGMIO(deviceID, handle, deviceIntf, aieTraceBufSizeGMIO, AIEData.metadata->getNumStreamsGMIO(), AIEData.metadata->getHwContext(), AIEData.metadata);
+// #else
+//   XAie_DevInst* devInst = static_cast<XAie_DevInst*>(AIEData.implementation->setAieDeviceInst(handle, deviceID));
+//   if(!devInst) {
+//     xrt_core::message::send(severity_level::warning, "XRT",
+//       "Unable to get AIE device instance. AIE event trace will not be available.");
+//     return;
+//   }
+//   AIEData.offloadManager->initGMIO(deviceID, handle, deviceIntf, aieTraceBufSizeGMIO, AIEData.metadata->getNumStreamsGMIO(), devInst);
+// #endif
+
+//     // AIEData.offloadManager->startGMIOOffload(AIEData.metadata->getOffloadIntervalUs(), AIEData.metadata->getContinuousTrace());
+//   }
+
+  // if (AIEData.metadata->getContinuousTrace())
+  //   XDPPlugin::startWriteThread(AIEData.metadata->getFileDumpIntS(),
+  //                                 "AIE_EVENT_TRACE", false);
+
+  // // First, check against memory bank size
+  // // NOTE: Check first buffer for PLIO; assume bank 0 for GMIO
+  // uint8_t memIndex = 0;
+  // if (isPLIO && (deviceIntf != nullptr))
+  //   memIndex = deviceIntf->getAIETs2mmMemIndex(0);
+
+  // Memory *memory = (db->getStaticInfo()).getMemory(deviceID, memIndex);
+
+  // if (memory != nullptr) {
+  //   uint64_t fullBankSize = memory->size * 1024;
+
+  //   if ((fullBankSize > 0) && (aieTraceBufSize > fullBankSize)) {
+  //     aieTraceBufSize = fullBankSize;
+  //     std::string msg = "Requested AIE trace buffer is too big for memory "
+  //                       "resource. Limiting to " +
+  //                       std::to_string(fullBankSize) + ".";
+  //     xrt_core::message::send(severity_level::warning, "XRT", msg);
+  //   }
+  // }
+
+  // // Ensures Contiguous Memory Allocation specific for linux/edge.
+  // aieTraceBufSize = AIEData.implementation->checkTraceBufSize(aieTraceBufSize);
+
+  // // Create AIE Trace Offloader
+  // AIEData.logger = std::make_unique<AIETraceDataLogger>(deviceID);
+
+  // if (xrt_core::config::get_verbosity() >=
+  //     static_cast<uint32_t>(severity_level::debug)) {
+  //   std::string flowType = (isPLIO) ? "PLIO" : "GMIO";
+  //   std::stringstream msg;
+  //   msg << "Total size of " << std::fixed << std::setprecision(3)
+  //       << (aieTraceBufSize / (1024.0 * 1024.0))
+  //       << " MB is used for AIE trace buffer for "
+  //       << std::to_string(AIEData.metadata->getNumStreams()) << " " << flowType
+  //       << " streams.";
+  //   xrt_core::message::send(severity_level::debug, "XRT", msg.str());
+  // }
+
+/*
+// This is moved to offload manager
 #ifdef XDP_CLIENT_BUILD
   AIEData.offloader = std::make_unique<AIETraceOffload>(
       handle, deviceID, deviceIntf, AIEData.logger.get(), isPLIO // isPLIO?
@@ -322,17 +461,20 @@ void AieTracePluginUnified::updateAIEDevice(void *handle, bool hw_context_flow) 
       ,
       AIEData.metadata->getNumStreams(), devInst);
 #endif
+*/
 
-  auto &offloader = AIEData.offloader;
+  // auto &offloaderPLIO = AIEData.offloadManager.plio.offloader;
+  // auto &offloaderGMIO = AIEData.offloadManager.gmio.offloader;
+  auto &offloaderManager = AIEData.offloadManager;
 
-  // Can't call init without setting important details in offloader
-  if (AIEData.metadata->getContinuousTrace()) {
-    offloader->setContinuousTrace();
-    offloader->setOffloadIntervalUs(AIEData.metadata->getOffloadIntervalUs());
-  }
+  // // Can't call init without setting important details in offloader
+  // if ((!isPLIOGMIO) && (AIEData.metadata->getContinuousTrace())) {
+  //   offloaderPLIO->setContinuousTrace();
+  //   offloaderPLIO->setOffloadIntervalUs(AIEData.metadata->getOffloadIntervalUs());
+  // }
 
   try {
-    if (!offloader->initReadTrace()) {
+    if (!offloaderManager->initReadTraces()) {
       xrt_core::message::send(severity_level::warning, "XRT",
                               AIE_TRACE_BUF_ALLOC_FAIL);
       AIEData.valid = false;
@@ -363,12 +505,12 @@ void AieTracePluginUnified::updateAIEDevice(void *handle, bool hw_context_flow) 
 
     // Start the AIE trace timestamps thread
     // NOTE: we purposely start polling before configuring trace events
-    AIEData.threadCtrlBool = true;
+    AIEData.pollAIETimerThreadCtrlBool = true;
     auto device_thread = std::thread(&AieTracePluginUnified::pollAIETimers,
                                      this, deviceID, handle);
-    AIEData.thread = std::move(device_thread);
+    AIEData.pollAIETimerThread = std::move(device_thread);
   } else {
-    AIEData.threadCtrlBool = false;
+    AIEData.pollAIETimerThreadCtrlBool = false;
   }
 
   // Sets up and calls the PS kernel on x86 implementation
@@ -380,7 +522,8 @@ void AieTracePluginUnified::updateAIEDevice(void *handle, bool hw_context_flow) 
 
   // Continuous Trace Offload is supported only for PLIO flow
   if (AIEData.metadata->getContinuousTrace())
-    offloader->startOffload();
+    offloaderManager->startOffload(AIEData.metadata->getContinuousTrace(),
+                                  AIEData.metadata->getOffloadIntervalUs());
   xrt_core::message::send(severity_level::info, "XRT",
                           "Finished AIE Trace updateAIEDevice.");
 }
@@ -391,30 +534,13 @@ void AieTracePluginUnified::pollAIETimers(uint64_t index, void *handle) {
   if (it == handleToAIEData.end())
     return;
 
-  auto &should_continue = it->second.threadCtrlBool;
+  auto &should_continue = it->second.pollAIETimerThreadCtrlBool;
 
   while (should_continue) {
     handleToAIEData[handle].implementation->pollTimers(index, handle);
     std::this_thread::sleep_for(std::chrono::microseconds(
         handleToAIEData[handle].metadata->getPollingIntervalVal()));
   }
-}
-
-void AieTracePluginUnified::flushOffloader(
-    const std::unique_ptr<AIETraceOffload> &offloader, bool warn) {
-  if (offloader->continuousTrace()) {
-    offloader->stopOffload();
-
-    while (offloader->getOffloadStatus() != AIEOffloadThreadStatus::STOPPED)
-      ;
-  } else {
-    offloader->readTrace(true);
-    offloader->endReadTrace();
-  }
-
-  if (warn && offloader->isTraceBufferFull())
-    xrt_core::message::send(severity_level::warning, "XRT",
-                            AIE_TS2MM_WARN_MSG_BUF_FULL);
 }
 
 void AieTracePluginUnified::flushAIEDevice(void *handle) {
@@ -433,7 +559,8 @@ void AieTracePluginUnified::flushAIEDevice(void *handle) {
 
   // Flush AIE then datamovers
   AIEData.implementation->flushTraceModules();
-  flushOffloader(AIEData.offloader, false);
+  if (AIEData.offloadManager)
+    AIEData.offloadManager->flushAll(false);
 }
 
 void AieTracePluginUnified::finishFlushAIEDevice(void *handle) {
@@ -462,7 +589,10 @@ void AieTracePluginUnified::finishFlushAIEDevice(void *handle) {
 
   // Flush AIE then datamovers
   AIEData.implementation->flushTraceModules();
-  flushOffloader(AIEData.offloader, true);
+  if (AIEData.offloadManager)
+    AIEData.offloadManager->flushAll(true);
+
+
   XDPPlugin::endWrite();
 
   handleToAIEData.erase(itr);
@@ -481,7 +611,8 @@ void AieTracePluginUnified::writeAll(bool openNewFiles) {
 
     if (AIEData.valid) {
       AIEData.implementation->flushTraceModules();
-      flushOffloader(AIEData.offloader, true);
+      if (AIEData.offloadManager)
+        AIEData.offloadManager->flushAll(true);
     }
   }
 
@@ -499,13 +630,13 @@ void AieTracePluginUnified::endPollforDevice(void *handle) {
 
   auto &AIEData = itr->second;
 
-  if (!AIEData.valid || !AIEData.threadCtrlBool)
+  if (!AIEData.valid || !AIEData.pollAIETimerThreadCtrlBool)
     return;
 
-  AIEData.threadCtrlBool = false;
+  AIEData.pollAIETimerThreadCtrlBool = false;
 
-  if (AIEData.thread.joinable())
-    AIEData.thread.join();
+  if (AIEData.pollAIETimerThread.joinable())
+    AIEData.pollAIETimerThread.join();
 
   if (AIEData.implementation)
     AIEData.implementation->freeResources();
@@ -515,11 +646,11 @@ void AieTracePluginUnified::endPoll() {
   // Ask all threads to end
   for (auto &p : handleToAIEData) {
     auto& data = p.second;
-    if (data.threadCtrlBool) {
-      data.threadCtrlBool = false;
+    if (data.pollAIETimerThreadCtrlBool) {
+      data.pollAIETimerThreadCtrlBool = false;
 
-      if (data.thread.joinable())
-        data.thread.join();
+      if (data.pollAIETimerThread.joinable())
+        data.pollAIETimerThread.join();
       if (data.implementation)
         data.implementation->freeResources();
     }

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.h
@@ -20,6 +20,7 @@
 #include <cstdint>
 
 #include "aie_trace_metadata.h"
+#include "aie_trace_offload_manager.h"
 #include "xdp/profile/database/events/creator/aie_trace_data_logger.h"
 #include "xdp/profile/plugin/aie_trace/aie_trace_impl.h"
 #include "xdp/profile/plugin/vp_base/vp_base_plugin.h"
@@ -48,22 +49,20 @@ public:
 private:
   uint64_t getDeviceIDFromHandle(void *handle);
   void pollAIETimers(uint64_t index, void *handle);
-  void flushOffloader(const std::unique_ptr<AIETraceOffload> &offloader,
-                      bool warn);
+  // void flushOffloader(const std::unique_ptr<AIETraceOffload> &offloader,
+  //                     bool warn);
   void endPoll();
 
 private:
   static bool live;
   struct AIEData {
     uint64_t deviceID;
-    bool valid;
-
-    std::unique_ptr<AIETraceOffload> offloader;
-    std::unique_ptr<AIETraceLogger> logger;
+    bool valid = false;
+    std::atomic<bool> pollAIETimerThreadCtrlBool;
+    std::thread pollAIETimerThread;
+    std::unique_ptr<AIETraceOffloadManager> offloadManager;
     std::unique_ptr<AieTraceImpl> implementation;
     std::shared_ptr<AieTraceMetadata> metadata;
-    std::atomic<bool> threadCtrlBool;
-    std::thread thread;
   };
   std::map<void *, AIEData> handleToAIEData;
 };

--- a/src/runtime_src/xdp/profile/writer/aie_trace/aie_trace_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/aie_trace/aie_trace_writer.cpp
@@ -30,10 +30,12 @@ namespace xdp {
                                  const std::string& version, 
                                  const std::string& creationTime, 
                                  const std::string& /*xrtV*/, 
-                                 const std::string& /*toolV*/)
+                                 const std::string& /*toolV*/,
+                                 io_type oType)
     : VPTraceWriter(filename, version, creationTime, 6 /* us */),
       deviceId(devId),
-      traceStreamId(trStrmId)
+      traceStreamId(trStrmId),
+      offloadType(oType)
 #if 0
       xrtVersion(xrtV),
       toolVersion(toolV)
@@ -73,7 +75,7 @@ namespace xdp {
   void AIETraceWriter::writeTraceEvents()
   {
     // write the entire buffer
-    aie::TraceDataType* traceData = (db->getDynamicInfo()).getAIETraceData(deviceId, traceStreamId);
+    aie::TraceDataType* traceData = (db->getDynamicInfo()).getAIETraceData(deviceId, traceStreamId, offloadType);
     if (nullptr == traceData) {
       return;
     }

--- a/src/runtime_src/xdp/profile/writer/aie_trace/aie_trace_writer.h
+++ b/src/runtime_src/xdp/profile/writer/aie_trace/aie_trace_writer.h
@@ -40,6 +40,7 @@ namespace xdp {
 
    uint64_t deviceId;
    uint64_t traceStreamId;
+   io_type  offloadType;
 
   protected:
     virtual void writeHeader();
@@ -53,7 +54,8 @@ namespace xdp {
                    const std::string& version, 
 		   const std::string& creationTime, 
 		   const std::string& xrtV,
-		   const std::string& toolV);
+		   const std::string& toolV,
+       io_type oType);
     ~AIETraceWriter();
 
     virtual bool write(bool openNewFile);


### PR DESCRIPTION
Signed-off-by: Vinod Pangul <146476973+vipangul@users.noreply.github.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
 CR-1242247 - support of PLIO and GMIO trace offload for independently compiled work dir
 
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
 CR-1242247

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added a offload manager which takes care of managing both types of offloaders for particular deviceID.

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
Verified AIE Trace on Versal Edge, VE2 XDNA and Client Strix Designs.

#### Documentation impact (if any)
