### PR TITLE
Use record_timer entry size aligned segment size 

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.cpp
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.cpp
@@ -74,7 +74,7 @@ namespace xdp {
               "In destructor for ML Timeline Plugin for Client Device.");
   }
 
-  void MLTimelineClientDevImpl::updateDevice(void* hwCtxImpl)
+  void MLTimelineClientDevImpl::updateDevice(void* hwCtxImpl, uint64_t /* devId */)
   {
     xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT", 
               "In MLTimelineClientDevImpl::updateDevice");

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.h
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.h
@@ -31,7 +31,7 @@ namespace xdp {
 
       ~MLTimelineClientDevImpl();
 
-      virtual void updateDevice(void* hwCtxImpl, uint64_t deviceId = 0);
+      virtual void updateDevice(void* hwCtxImpl, uint64_t devId = 0);
       virtual void finishflushDevice(void* hwCtxImpl, uint64_t implId = 0);
   };
 

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.h
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/clientDev/ml_timeline.h
@@ -31,7 +31,7 @@ namespace xdp {
 
       ~MLTimelineClientDevImpl();
 
-      virtual void updateDevice(void* hwCtxImpl);
+      virtual void updateDevice(void* hwCtxImpl, uint64_t deviceId = 0);
       virtual void finishflushDevice(void* hwCtxImpl, uint64_t implId = 0);
   };
 

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_impl.h
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_impl.h
@@ -42,7 +42,7 @@ namespace xdp {
 
       virtual ~MLTimelineImpl() {}
 
-      virtual void updateDevice(void*) = 0;
+      virtual void updateDevice(void*, uint64_t) = 0;
       virtual void finishflushDevice(void*, uint64_t) = 0;
   };
 

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_plugin.cpp
@@ -122,7 +122,7 @@ namespace xdp {
     xrt::hw_context hwContext = xrt_core::hw_context_int::create_hw_context_from_implementation(hwCtxImpl);
     std::shared_ptr<xrt_core::device> coreDevice = xrt_core::hw_context_int::get_core_device(hwContext);
 
-    //uint64_t deviceId = getHwCtxImplUid(hwCtxImpl); // TODO
+    //uint64_t deviceId = (db->getStaticInfo()).getHwCtxImplUid(hwCtxImpl); // TODO
     uint64_t implId   = mMultiImpl.size();  // to match ML Timeline output file naming convention
 
     std::string winDeviceName = "win_device" + std::to_string(implId);
@@ -153,7 +153,7 @@ namespace xdp {
       return;
     }
 
-    uint64_t deviceId = getHwCtxImplUid(hwCtxImpl);
+    uint64_t deviceId = (db->getStaticInfo()).getHwCtxImplUid(hwCtxImpl);
     uint64_t implId = mMultiImpl.size();  // to match ML Timeline output file naming convention
 
     std::string deviceName = util::getDeviceName(hwCtxImpl, true);

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_plugin.cpp
@@ -122,7 +122,8 @@ namespace xdp {
     xrt::hw_context hwContext = xrt_core::hw_context_int::create_hw_context_from_implementation(hwCtxImpl);
     std::shared_ptr<xrt_core::device> coreDevice = xrt_core::hw_context_int::get_core_device(hwContext);
 
-    uint64_t implId = mMultiImpl.size();
+    //uint64_t deviceId = getHwCtxImplUid(hwCtxImpl); // TODO
+    uint64_t implId   = mMultiImpl.size();  // to match ML Timeline output file naming convention
 
     std::string winDeviceName = "win_device" + std::to_string(implId);
     uint64_t deviceId = db->addDevice(winDeviceName);
@@ -131,7 +132,7 @@ namespace xdp {
 
     mMultiImpl[hwCtxImpl] = std::make_pair(implId, std::make_unique<MLTimelineClientDevImpl>(db, mBufSz));
     auto mlImpl = mMultiImpl[hwCtxImpl].second.get();
-    mlImpl->updateDevice(hwCtxImpl);
+    mlImpl->updateDevice(hwCtxImpl, deviceId);
 
 #elif defined (XDP_VE2_BUILD)
 
@@ -153,8 +154,7 @@ namespace xdp {
     }
 
     uint64_t deviceId = getHwCtxImplUid(hwCtxImpl);
-
-    uint64_t implId = mMultiImpl.size();
+    uint64_t implId = mMultiImpl.size();  // to match ML Timeline output file naming convention
 
     std::string deviceName = util::getDeviceName(hwCtxImpl, true);
 

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_plugin.cpp
@@ -105,8 +105,9 @@ namespace xdp {
 
   void MLTimelinePlugin::updateDevice(void* hwCtxImpl)
   {
-      xrt_core::message::send(xrt_core::message::severity_level::info, "XRT",
+    xrt_core::message::send(xrt_core::message::severity_level::info, "XRT",
           "In ML Timeline Plugin : updateDevice.");
+          
       
 #ifdef XDP_CLIENT_BUILD
 
@@ -151,16 +152,18 @@ namespace xdp {
       return;
     }
 
+    uint64_t deviceId = getHwCtxImplUid(hwCtxImpl);
+
     uint64_t implId = mMultiImpl.size();
 
-    std::string deviceName = "ve2_device" + std::to_string(implId);
-    uint64_t deviceId = db->addDevice(deviceName);
+    std::string deviceName = util::getDeviceName(hwCtxImpl, true);
+
     (db->getStaticInfo()).updateDeviceFromCoreDevice(deviceId, coreDevice);
     (db->getStaticInfo()).setDeviceName(deviceId, deviceName);
 
     mMultiImpl[hwCtxImpl] = std::make_pair(implId, std::make_unique<MLTimelineVE2Impl>(db, mBufSz));
     auto mlImpl = mMultiImpl[hwCtxImpl].second.get();
-    mlImpl->updateDevice(hwCtxImpl);
+    mlImpl->updateDevice(hwCtxImpl, deviceId);
     
   #endif
 
@@ -178,7 +181,7 @@ namespace xdp {
       return;   
     }
     std::map<void* /*hwCtxImpl*/,
-             std::pair<uint64_t /* deviceId */, std::unique_ptr<MLTimelineImpl>>>::iterator itr;
+             std::pair<uint64_t /* implId */, std::unique_ptr<MLTimelineImpl>>>::iterator itr;
 
     itr = mMultiImpl.find(hwCtxImpl);
     if (itr == mMultiImpl.end()) {

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_plugin.h
@@ -45,7 +45,7 @@ namespace xdp {
 
     uint32_t mBufSz;
     std::map<void* /*hwCtxImpl*/,
-             std::pair<uint64_t /* deviceId */, std::unique_ptr<MLTimelineImpl>>> mMultiImpl;
+             std::pair<uint64_t /* implId */, std::unique_ptr<MLTimelineImpl>>> mMultiImpl;
   };
 
 } // end namespace xdp

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/ve2/ml_timeline.cpp
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/ve2/ml_timeline.cpp
@@ -92,6 +92,11 @@ namespace xdp {
       * For now, each buffer segment is equal sized.
       */
       uint32_t segmentSzInBytes = mBufSz / mNumBufSegments;
+      uint32_t remBytes = segmentSzInBytes % RECORD_TIMER_ENTRY_SZ_IN_BYTES;
+      if (0 != remBytes) {
+        // Each segment needs to be aligned at RECORD_TIMER_ENTRY_SZ_IN_BYTES
+        segmentSzInBytes -= remBytes;
+      }
 
       std::map<uint32_t, size_t> activeUCsegmentMap;
       for (auto const &e : activeUCs) {

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/ve2/ml_timeline.cpp
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/ve2/ml_timeline.cpp
@@ -64,7 +64,7 @@ namespace xdp {
               "In destructor for ML Timeline Plugin for VE2 Device.");
   }
 
-  void MLTimelineVE2Impl::updateDevice(void* hwCtxImpl)
+  void MLTimelineVE2Impl::updateDevice(void* hwCtxImpl, uint64_t devId)
   {
     xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT", 
               "In MLTimelineVE2Impl::updateDevice");
@@ -84,7 +84,7 @@ namespace xdp {
     xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT", 
               "Allocated buffer In MLTimelineVE2Impl::updateDevice");
 
-    auto metadataReader = (db->getStaticInfo()).getAIEmetadataReader();
+    auto metadataReader = (db->getStaticInfo()).getAIEmetadataReader(devId);
     if (metadataReader) {
       auto activeUCs = metadataReader->getActiveMicroControllers();
       mNumBufSegments = activeUCs.size();

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/ve2/ml_timeline.h
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/ve2/ml_timeline.h
@@ -32,7 +32,7 @@ namespace xdp {
 
       ~MLTimelineVE2Impl();
 
-      virtual void updateDevice(void* devH);
+      virtual void updateDevice(void* devH, uint64_t devId = 0);
       virtual void finishflushDevice(void* hwCtxImpl, uint64_t implId = 0);
   };
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
On VE2, if there are multiple active uCs the debug buffer is split into segments. Each segment needs to be aligned at size of record_timer entry. This is a requirement in cert implementation. It is needed even if there is no buffer (at segment) overflow.
Also, use HW Ctx Impl based device id.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
