### PR TITLE
[VITIS-14796] Modified setup scripts to support both bash and dash

### DIFF
--- a/src/runtime_src/core/tools/xbmgmt2/xbmgmt
+++ b/src/runtime_src/core/tools/xbmgmt2/xbmgmt
@@ -1,13 +1,14 @@
-#!/bin/bash
+#!/bin/sh
 
 #
 # SPDX-License-Identifier: Apache-2.0
 #
 # Copyright (C) 2020-2022 Xilinx, Inc.
+# Copyright (C) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
 #
 
 # -- Detect a Windows environment and automatically switch to the .bat file
-if [[ "`uname`" == windows32* ]] || [[ "`uname`" == CYGWIN* ]] ; then
+if [ "$(uname | grep -E '^(windows32|CYGWIN)')" ]; then
     trap "" INT
     "$0.bat" "$@"
     exit $?
@@ -18,7 +19,6 @@ XRT_PROG=xbmgmt2
 
 # Examine the options and look for -new/--new
 XRTWARP_PROG_ARGS_size=0
-XRTWRAP_PROG_ARGS=()
 while [ $# -gt 0 ]; do
     case "$1" in
     # Indicates that the legacy was specified
@@ -34,18 +34,18 @@ while [ $# -gt 0 ]; do
        reported via the --help option."
         echo "----------------------------------------------------------------------"
         exit 1
-	    ;;
-	# Copy the options the remaining options
-	*)
-	    XRTWRAP_PROG_ARGS[$XRTWARP_PROG_ARGS_size]="$1"
-	    XRTWARP_PROG_ARGS_size=$(($XRTWARP_PROG_ARGS_size + 1))
-	    shift
-	    ;;
+        ;;
+    # Copy the options the remaining options
+    *)
+        eval "XRTWRAP_PROG_ARG_$XRTWARP_PROG_ARGS_size=\"\$1\""
+        XRTWARP_PROG_ARGS_size=$((XRTWARP_PROG_ARGS_size + 1))
+        shift
+        ;;
     esac
 done
 
 # -- Find and call the loader
-XRT_LOADER="`dirname \"$0\"`/unwrapped/loader"
+XRT_LOADER="$(dirname "$0")/unwrapped/loader"
 
 if [ ! -f "$XRT_LOADER" ]; then
     echo "ERROR: Could not find 64-bit loader executable."
@@ -53,4 +53,12 @@ if [ ! -f "$XRT_LOADER" ]; then
     exit 1
 fi
 
-"${XRT_LOADER}" -exec ${XRT_PROG} "${XRTWRAP_PROG_ARGS[@]}"
+# Build arguments dynamically for final call
+i=0
+while [ $i -lt $XRTWARP_PROG_ARGS_size ]; do
+    eval "arg=\$XRTWRAP_PROG_ARG_$i"
+    set -- "$@" "$arg"
+    i=$((i + 1))
+done
+
+"${XRT_LOADER}" -exec ${XRT_PROG} "$@"

--- a/src/runtime_src/core/tools/xbutil2/xrt-smi
+++ b/src/runtime_src/core/tools/xbutil2/xrt-smi
@@ -1,13 +1,13 @@
-#!/bin/bash
+#!/bin/sh
 
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-# Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2055 Advanced Micro Devices, Inc. All rights reserved.
 #
 
 # -- Detect a Windows environment and automatically switch to the .bat file
-if [[ "`uname`" == windows32* ]] || [[ "`uname`" == CYGWIN* ]] ; then
+if [ "$(uname | grep -E '^(windows32|CYGWIN)')" ]; then
     trap "" INT
     "$0.bat" "$@"
     exit $?
@@ -18,27 +18,35 @@ XRT_PROG=xrt-smi
 
 # -- Examine the options
 XRTWARP_PROG_ARGS_size=0
-XRTWRAP_PROG_ARGS=()
 while [ $# -gt 0 ]; do
     case "$1" in
-	# Copy the options the remaining options
-	*)
-	    XRTWRAP_PROG_ARGS[$XRTWARP_PROG_ARGS_size]="$1"
-	    XRTWARP_PROG_ARGS_size=$(($XRTWARP_PROG_ARGS_size + 1))
-	    shift
-	    ;;
+    # Copy the options the remaining options
+    *)
+        eval "XRTWRAP_PROG_ARG_$XRTWARP_PROG_ARGS_size=\"\$1\""
+        XRTWARP_PROG_ARGS_size=$((XRTWARP_PROG_ARGS_size + 1))
+        shift
+        ;;
     esac
 done
 
 # -- Find loader directory
-XRT_LOADER_DIR="`dirname \"$0\"`"
+XRT_LOADER_DIR="$(dirname "$0")"
 
 # For edge platforms loader is not required as tools are in standard location(/usr).
 # So calling unwrapped tool from this script itself.
-if [[ $XRT_LOADER_DIR =~ ^(/usr|/bin) ]]; then
-    "${XRT_LOADER_DIR}/unwrapped/${XRT_PROG}" "${XRTWRAP_PROG_ARGS[@]}"
-    exit 0
-fi
+case "$XRT_LOADER_DIR" in
+    /usr*|/bin*)
+        # Build arguments dynamically
+        i=0
+        while [ $i -lt $XRTWARP_PROG_ARGS_size ]; do
+            eval "arg=\$XRTWRAP_PROG_ARG_$i"
+            set -- "$@" "$arg"
+            i=$((i + 1))
+        done
+        "${XRT_LOADER_DIR}/unwrapped/${XRT_PROG}" "$@"
+        exit 0
+        ;;
+esac
 
 # Call loader for dc platforms
 XRT_LOADER="${XRT_LOADER_DIR}/unwrapped/loader"
@@ -48,4 +56,12 @@ if [ ! -f "$XRT_LOADER" ]; then
     exit 1
 fi
 
-"${XRT_LOADER}" -exec ${XRT_PROG} "${XRTWRAP_PROG_ARGS[@]}"
+# Build arguments dynamically for final call
+i=0
+while [ $i -lt $XRTWARP_PROG_ARGS_size ]; do
+    eval "arg=\$XRTWRAP_PROG_ARG_$i"
+    set -- "$@" "$arg"
+    i=$((i + 1))
+done
+
+"${XRT_LOADER}" -exec ${XRT_PROG} "$@"

--- a/src/runtime_src/tools/scripts/loader
+++ b/src/runtime_src/tools/scripts/loader
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2019-2021 Xilinx, Inc. All rights reserved.
@@ -6,23 +6,20 @@
 
 # Working Variables 
 XRT_EXEC=""
+XRT_LOADER_ARGS=""
 
 # -- Examine the options 
-XRT_LOADER_ARGS_size=0
-XRT_LOADER_ARGS=()
 while [ $# -gt 0 ]; do
   case "$1" in
     # Get the executable program name
-      -exec|--exec)
+    -exec|--exec)
       shift
       XRT_EXEC="$1"
       shift
       ;;
-
-    # Copy the remaining unknown options for they are associated with the executable program
+    # Collect remaining arguments
     *)
-      XRT_LOADER_ARGS[$XRT_LOADER_ARGS_size]="$1"
-      XRT_LOADER_ARGS_size=$(($XRT_LOADER_ARGS_size + 1))
+      XRT_LOADER_ARGS="$XRT_LOADER_ARGS \"$1\""
       shift
       ;;
   esac
@@ -50,13 +47,18 @@ if [ ! -f "$XRT_SETUP_SCRIPT" ]; then
   exit 1
 fi
 
-. "${XRT_SETUP_SCRIPT}" > /dev/null
+. "${XRT_SETUP_SCRIPT}" >/dev/null
 
-# XRT uses system librairies whereas Vitis and Vivado ship there own.
-# when XRT tools are invoked from Vitis/Vivado the LD_LIBRARY_PATH will be set to use libraries shipped with Vitis/vivado
-# so we reset the LD_LIBRARY_PATH to make XRT tool select the correct libraries.
+case "$XILINX_XRT" in
+  */bin/unwrapped)
+    XILINX_XRT=$(dirname "$(dirname "$XILINX_XRT")")
+    export XILINX_XRT
+    ;;
+esac
+
+# Reset LD_LIBRARY_PATH to avoid Vitis/Vivado libs
 LD_LIBRARY_PATH=$XILINX_XRT/lib:$(echo $LD_LIBRARY_PATH | tr ':' '\n' | grep -E -v "/(Vitis|Vivado).*/(lnx|lin)" | tr '\n' ':')
 
 # -- Execute the wrapped program
-"${XRT_PROG_UNWRAPPED}" "${XRT_LOADER_ARGS[@]}"
-
+# Use "eval" since we collected args as a string
+eval "\"$XRT_PROG_UNWRAPPED\" $XRT_LOADER_ARGS"

--- a/src/runtime_src/tools/scripts/setup.sh
+++ b/src/runtime_src/tools/scripts/setup.sh
@@ -1,73 +1,63 @@
-#!/bin/bash
+#!/bin/sh
 
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2019-2021 Xilinx, Inc. All rights reserved.
-# Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Script to setup environment for XRT
 # This script is installed in xrt install location, e.g. /opt/xilinx/xrt and must
 # be sourced from that location
 
 # Check OS version requirement
-OSDIST=`cat /etc/os-release | grep -i "^ID=" | awk -F= '{print $2}'`
-if [[ $OSDIST == "centos" ]]; then
-    OSREL=`cat /etc/redhat-release | awk '{print $4}' | tr -d '"' | awk -F. '{print $1*100+$2}'`
+OSDIST=$(awk -F= '/^ID=/{print $2}' /etc/os-release)
+if [ "$OSDIST" = "centos" ]; then
+    OSREL=$(awk '{print $4}' /etc/redhat-release | tr -d '"' | awk -F. '{print $1*100+$2}')
 else
-    OSREL=`cat /etc/os-release | grep -i "^VERSION_ID=" | awk -F= '{print $2}' | tr -d '"' | awk -F. '{print $1*100+$2}'`
+    OSREL=$(awk -F= '/^VERSION_ID=/{print $2}' /etc/os-release | tr -d '"' | awk -F. '{print $1*100+$2}')
 fi
 
-if [[ $OSDIST == "ubuntu" ]]; then
-    if (( $OSREL < 1604 )); then
-        echo "ERROR: Ubuntu release version must be 16.04 or later"
-        return 1
-    fi
-fi
-
-if [[ $OSDIST == "centos" ]] || [[ $OSDIST == "rhel"* ]]; then
-    if (( $OSREL < 704 )); then
-        echo "ERROR: Centos or RHEL release version must be 7.4 or later"
-        return 1
-    fi
-fi
-
-
-if [ -n "$BASH_VERSION" ]; then
-    XILINX_XRT=$(readlink -f $(dirname ${BASH_SOURCE[0]:-${(%):-%x}}))
-elif [ -n "$ZSH_VERSION" ]; then
-    XILINX_XRT=$(readlink -f $(dirname ${(%):-%N}))
-else
-    echo "ERROR: Unsupported shell. Only bash and zsh are supported"
+if [ "$OSDIST" = "ubuntu" ] && [ "$OSREL" -lt 1604 ]; then
+    echo "ERROR: Ubuntu release version must be 16.04 or later"
     return 1
 fi
 
+case "$OSDIST" in
+    centos|rhel*)
+        if [ "$OSREL" -lt 704 ]; then
+            echo "ERROR: Centos or RHEL release version must be 7.4 or later"
+            return 1
+        fi
+        ;;
+esac
+
+if [ -n "$BASH_VERSION" ]; then
+    XILINX_XRT=$(readlink -f "$(dirname "${BASH_SOURCE[0]}")")
+elif [ -n "$ZSH_VERSION" ]; then
+    XILINX_XRT=$(readlink -f "$(dirname "${(%):-%N}")")
+else
+    if [ ! -f "./setup.sh" ]; then
+       echo "ERROR: When sourcing in dash, please 'cd' to the script's directory first."
+       return 1
+    fi
+    XILINX_XRT=$(dirname "$(readlink -f "$0")")
+fi
+
 # Poor test to ensure we are in an install location
-if [[ ! -f $XILINX_XRT/version.json ]]; then
+if [ ! -f "$XILINX_XRT/version.json" ]; then
     echo "Invalid location: $XILINX_XRT"
     echo "This script must be sourced from XRT install directory"
     return 1
 fi
 
 COMP_FILE="/usr/share/bash-completion/bash_completion"
-# 1. This is a workaround for set -e
-# The issue is chaining conditionals with actual commands
-# The issue is caused when sourcing the ${COMP_FILE}.
-# Specifically ${COMP_FILE}::_sysvdirs. Each check in that function
-# will fail the script due to the issues.
-# If set -e is removed from the pipeline then check can be removed
-# 2. Make sure that the shell is bash! The completion may not function
-# correctly or setup on other shells.
-# 3. Make sure the bash completion file exists
-if [[ $- != *e* ]] && [[ "$BASH" == *"/bash" ]] && [ -f "${COMP_FILE}" ]; then
-    # Enable autocompletion for xrt-smi commands
-    source $COMP_FILE
-    source $XILINX_XRT/share/completions/xbutil-bash-completion
+if [ -n "$BASH_VERSION" ] && [ -f "$COMP_FILE" ]; then
+    # Enable autocompletion for the xbutil and xbmgmt commands
+    . "$COMP_FILE"
+    . "$XILINX_XRT/share/completions/xbutil-bash-completion"
+    . "$XILINX_XRT/share/completions/xbmgmt-bash-completion"
 else
-    echo Autocomplete not enabled for XRT tools
+    echo "Autocomplete not enabled for XRT tools"
 fi
-
-# To use the newest version of the XRT tools, either uncomment or set
-# the following environment variable in your profile:
-#   export XRT_TOOLS_NEXTGEN=true
 
 export XILINX_XRT
 export LD_LIBRARY_PATH=$XILINX_XRT/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}

--- a/src/runtime_src/tools/xclbinutil/xclbinutil
+++ b/src/runtime_src/tools/xclbinutil/xclbinutil
@@ -1,7 +1,9 @@
-#!/bin/bash
+#!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
 
 # -- Detect a Windows environment and automatically switch to the .bat file
-if [[ "`uname`" == windows32* ]] || [[ "`uname`" == CYGWIN* ]] ; then
+if [ "$(uname | grep -E '^(windows32|CYGWIN)')" ]; then
   trap "" INT
   "$0.bat" "$@"
   exit $?
@@ -12,7 +14,6 @@ XRT_PROG=xclbinutil
 
 # -- Examine the options 
 XRTWARP_PROG_ARGS_size=0
-XRTWRAP_PROG_ARGS=()
 while [ $# -gt 0 ]; do
   case "$1" in
     #  Future option example syntax
@@ -23,22 +24,31 @@ while [ $# -gt 0 ]; do
 
     # Copy the remaining options
     *)
-      XRTWRAP_PROG_ARGS[$XRTWARP_PROG_ARGS_size]="$1"
-      XRTWARP_PROG_ARGS_size=$(($XRTWARP_PROG_ARGS_size + 1))
+      eval "XRTWRAP_PROG_ARG_$XRTWARP_PROG_ARGS_size=\"\$1\""
+      XRTWARP_PROG_ARGS_size=$((XRTWARP_PROG_ARGS_size + 1))
       shift
       ;;
   esac
 done
 
 # -- Find loader directory
-XRT_LOADER_DIR="`dirname \"$0\"`"
+XRT_LOADER_DIR="$(dirname "$0")"
 
 # For edge platforms loader is not required as tools are in standard location(/usr).
 # So calling unwrapped tool from this script itself.
-if [[ $XRT_LOADER_DIR =~ "/usr" ]]; then
-    "${XRT_LOADER_DIR}/unwrapped/${XRT_PROG}" "${XRTWRAP_PROG_ARGS[@]}"
-    exit 0
-fi
+case "$XRT_LOADER_DIR" in
+    */usr*|/usr*)
+        # Build arguments dynamically
+        i=0
+        while [ $i -lt $XRTWARP_PROG_ARGS_size ]; do
+            eval "arg=\$XRTWRAP_PROG_ARG_$i"
+            set -- "$@" "$arg"
+            i=$((i + 1))
+        done
+        "${XRT_LOADER_DIR}/unwrapped/${XRT_PROG}" "$@"
+        exit 0
+        ;;
+esac
 
 # Call loader for dc platforms
 XRT_LOADER="${XRT_LOADER_DIR}/unwrapped/loader"
@@ -49,5 +59,12 @@ if [ ! -f "$XRT_LOADER" ]; then
   exit 1
 fi
 
-"${XRT_LOADER}" -exec $XRT_PROG "${XRTWRAP_PROG_ARGS[@]}"
+# Build arguments dynamically for final call
+i=0
+while [ $i -lt $XRTWARP_PROG_ARGS_size ]; do
+    eval "arg=\$XRTWRAP_PROG_ARG_$i"
+    set -- "$@" "$arg"
+    i=$((i + 1))
+done
 
+"${XRT_LOADER}" -exec $XRT_PROG "$@"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/VITIS-14796

Ubuntu removed the official way to configure the default shell from Dash to Bash. On Ubuntu, ls -l /bin/sh points to Dash by default. Our scripts were Bash-specific, so they were modified to support both Bash and Dash.Made 
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Removed arrays in the scripts, since Dash does not support them.
Dash does not provide the script path ($0) in the same way, so to make the script robust, it is recommended to source the script after running cd /opt/xilinx/xrt.

#### Risks (if any) associated the changes in the commit
low

#### What has been tested and how, request additional testing if necessary
Teseted on RHEL ubuntu with both bash and dash.

#### Documentation impact (if any)
