### PR TITLE
[XRT-SMI] Firmware logging report addition

### DIFF
--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -4200,7 +4200,7 @@ struct firmware_log_state : request
     uint32_t action;
     uint32_t log_level;
   };
-  using result_type = uint32_t;  // get value type
+  using result_type = value_type;  // get value type
 
   static const key_type key = key_type::firmware_log_state;
   std::any

--- a/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
@@ -55,6 +55,8 @@ file(GLOB XBUTIL_V2_SUBCMD_FILES
   "OO_FirmwareLog.cpp"
   "ReportEventTrace.cpp"
   "EventTraceConfig.cpp"
+  "ReportFirmwareLog.cpp"
+  "FirmwareLogConfig.cpp"
 )
 
 # Merge the files into one collection

--- a/src/runtime_src/core/tools/xbutil2/FirmwareLogConfig.cpp
+++ b/src/runtime_src/core/tools/xbutil2/FirmwareLogConfig.cpp
@@ -4,8 +4,10 @@
 #include <fstream>
 #include "FirmwareLogConfig.h"
 
-namespace {
-static nlohmann::json load_json_config(const std::string& json_file_path) {
+namespace xrt_core::tools::xrt_smi {
+
+static nlohmann::json 
+load_json_config(const std::string& json_file_path) {
   if (json_file_path.empty()) {
     throw std::runtime_error("JSON file path cannot be empty");
   }
@@ -17,9 +19,6 @@ static nlohmann::json load_json_config(const std::string& json_file_path) {
   file >> j;
   return j;
 }
-} // namespace
-
-namespace xrt_core::tools::xrt_smi {
 
 firmware_log_config::
 firmware_log_config(const std::string& json_file_path)
@@ -106,7 +105,7 @@ calculate_header_size(const std::map<std::string, structure_info>& structures) {
   for (const auto& field : it->second.fields) {
     size += field.width;
   }
-  return (size + 7) / 8; // Convert bit width to byte size
+  return (size + byte_alignment) / bits_per_byte; // Convert bit width to byte size
 }
 
 } // namespace xrt_core::tools::xrt_smi

--- a/src/runtime_src/core/tools/xbutil2/FirmwareLogConfig.cpp
+++ b/src/runtime_src/core/tools/xbutil2/FirmwareLogConfig.cpp
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+
+#include <fstream>
+#include "FirmwareLogConfig.h"
+
+namespace {
+static nlohmann::json load_json_config(const std::string& json_file_path) {
+  if (json_file_path.empty()) {
+    throw std::runtime_error("JSON file path cannot be empty");
+  }
+  std::ifstream file(json_file_path);
+  if (!file.is_open()) {
+    throw std::runtime_error("Cannot open JSON file: " + json_file_path);
+  }
+  nlohmann::json j;
+  file >> j;
+  return j;
+}
+} // namespace
+
+namespace xrt_core::tools::xrt_smi {
+
+firmware_log_config::
+firmware_log_config(const std::string& json_file_path)
+  : config(load_json_config(json_file_path)),
+    enums(parse_enums(config)),
+    structures(parse_structures(config)),
+    header_size(calculate_header_size(structures))
+{}
+
+
+std::map<std::string, firmware_log_config::enum_info>
+firmware_log_config::
+parse_enums(const nlohmann::json& config)
+{
+  std::map<std::string, enum_info> enums_map;
+  if (!config.contains("enumerations")) {
+    return enums_map;
+  }
+  const auto& enums_json = config["enumerations"];
+  for (auto it = enums_json.begin(); it != enums_json.end(); ++it) {
+    enum_info enum_info;
+    enum_info.m_name = it.key();
+    if (it.value().contains("enumerators")) {
+      for (const auto& [name, value] : it.value()["enumerators"].items()) {
+        enum_info.enumerator_to_value[name] = value;
+        enum_info.value_to_enumerator[value] = name;
+      }
+    }
+    enums_map[enum_info.m_name] = enum_info;
+  }
+  return enums_map;
+}
+
+std::map<std::string, firmware_log_config::structure_info>
+firmware_log_config::
+parse_structures(const nlohmann::json& config)
+{
+  std::map<std::string, structure_info> structs_map;
+  if (!config.contains("structures")) {
+    return structs_map;
+  }
+  const auto& structs_json = config["structures"];
+  for (auto it = structs_json.begin(); it != structs_json.end(); ++it) {
+    structure_info struct_info;
+    struct_info.name = it.key();
+    if (it.value().contains("fields")) {
+      for (const auto& field : it.value()["fields"]) {
+        field_info field_info;
+        field_info.name = field.value("name", "");
+        field_info.type = field.value("type", "");
+        field_info.width = field.value("width", 0);
+        field_info.format = field.value("format", "");
+        field_info.enumeration = field.value("enumeration", "");
+        struct_info.fields.push_back(field_info);
+      }
+    }
+    structs_map[struct_info.name] = struct_info;
+  }
+  return structs_map;
+}
+
+std::string 
+firmware_log_config::enum_info::
+get_enumerator_name(uint32_t value) const {
+  auto it = value_to_enumerator.find(value);
+  return it != value_to_enumerator.end() ? it->second : "<unknown>";
+}
+
+uint32_t 
+firmware_log_config::enum_info::
+get_enumerator_value(const std::string& name) const {
+  auto it = enumerator_to_value.find(name);
+  return it != enumerator_to_value.end() ? it->second : 0;
+}
+
+size_t 
+firmware_log_config::
+calculate_header_size(const std::map<std::string, structure_info>& structures) {
+  auto it = structures.find("ipu_log_message_header");
+  if (it == structures.end()) {
+    throw std::runtime_error("Config missing ipu_log_message_header structure");
+  }
+  size_t size = 0;
+  for (const auto& field : it->second.fields) {
+    size += field.width;
+  }
+  return (size + 7) / 8; // Convert bit width to byte size
+}
+
+} // namespace xrt_core::tools::xrt_smi

--- a/src/runtime_src/core/tools/xbutil2/FirmwareLogConfig.h
+++ b/src/runtime_src/core/tools/xbutil2/FirmwareLogConfig.h
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+
+#ifndef FIRMWARE_LOG_CONFIG_H
+#define FIRMWARE_LOG_CONFIG_H
+
+#include <cstdint>
+#include <map>
+#include <string>
+#include <vector>
+#include "core/common/json/nlohmann/json.hpp"
+
+namespace xrt_core::tools::xrt_smi {
+/**
+ * @brief Parser for firmware_log.json configuration
+ *
+ * Loads enumerations and structures for firmware log message parsing.
+ */
+
+/**
+ * @brief FirmwareLogConfig parses firmware_log.json for log message formats
+ *
+ * Loads enumerations and structures for firmware log message parsing.
+ */
+class firmware_log_config 
+{
+public:
+  /**
+   * @brief EnumInfo holds enumeration name and value mappings
+   *
+   * name: Name of the enumeration
+   * name_to_value: Map from enumerator name to value
+   * value_to_name: Map from value to enumerator name
+   */
+  struct enum_info {
+    std::string m_name;
+    std::map<std::string, uint32_t> enumerator_to_value;
+    std::map<uint32_t, std::string> value_to_enumerator;
+
+    // Helper to get enumerator name from value
+    std::string get_enumerator_name(uint32_t value) const;
+    // Helper to get value from enumerator name
+    uint32_t get_enumerator_value(const std::string& name) const;
+  };
+
+  /**
+   * @brief FieldInfo describes a field in a structure
+   *
+   * name: Field name
+   * type: Field type (e.g., uint32_t)
+   * width: Bit width of the field
+   * format: Format string for display
+   * enumeration: Associated enumeration name (if any)
+   */
+  struct field_info {
+    std::string name;
+    std::string type;
+    uint32_t width;
+    std::string format;
+    std::string enumeration;
+  };
+
+  /**
+   * @brief StructureInfo describes a structure and its fields
+   *
+   * name: Structure name
+   * fields: List of FieldInfo for each field
+   */
+  struct structure_info {
+    std::string name;
+    std::vector<field_info> fields;
+  };
+
+public:
+  /**
+   * @brief Constructor - loads configuration from JSON file
+   * @param json_file_path Path to firmware_log.json file
+   *
+   * Loads and parses the JSON file, populating enums and structures.
+   * Sets valid_ to true if successful, false otherwise.
+   */
+    explicit
+    firmware_log_config(const std::string& json_file_path); // Initializes using static parse APIs
+
+  /**
+   * @brief Get parsed enumerations
+   * @return Map of enumeration name to EnumInfo
+   */
+  const std::map<std::string, enum_info>& 
+  get_enums() const 
+  { 
+    return enums;  
+  }
+
+  /**
+   * @brief Get parsed structures
+   * @return Map of structure name to StructureInfo
+   */
+  const std::map<std::string, structure_info>& 
+  get_structures() const 
+  { 
+    return structures; 
+  }
+
+  /**
+   * @brief Calculate the header size based on the ipu_log_message_header structure
+   * @param structures Map of structure name to StructureInfo
+   * @return Calculated header size in bytes
+   */
+  static size_t calculate_header_size(const std::map<std::string, structure_info>& structures);
+
+  /**
+   * @brief Get the calculated header size
+   * @return Header size in bytes
+   */
+  size_t 
+  get_header_size() const 
+  { 
+    return header_size; 
+  }
+
+private:
+  /**
+   * @brief Parse the root JSON object
+   * @param  nlohmann::json object
+   */
+  void parse_json(const nlohmann::json&);
+
+  /**
+   * @brief Parse enumerations section from JSON
+   * @param enums_json JSON object for enumerations
+   */
+  static std::map<std::string, enum_info> parse_enums(const nlohmann::json& config);
+
+  /**
+   * @brief Parse structures section from JSON
+   * @param structs_json JSON object for structures
+   */
+  static std::map<std::string, structure_info> parse_structures(const nlohmann::json& config);
+
+private:
+  nlohmann::json config; ///< Raw JSON configuration
+  std::map<std::string, enum_info> enums; ///< Parsed enumerations
+  std::map<std::string, structure_info> structures; ///< Parsed structures
+  size_t header_size; // Stores the calculated header size
+};
+
+} // namespace xrt_core::tools::xrt_smi
+
+#endif // FIRMWARE_LOG_CONFIG_H

--- a/src/runtime_src/core/tools/xbutil2/FirmwareLogConfig.h
+++ b/src/runtime_src/core/tools/xbutil2/FirmwareLogConfig.h
@@ -11,6 +11,12 @@
 #include "core/common/json/nlohmann/json.hpp"
 
 namespace xrt_core::tools::xrt_smi {
+
+constexpr size_t bits_per_byte = 8;
+constexpr size_t byte_alignment = 7;
+constexpr size_t bits_per_uint64 = 64;
+constexpr size_t hex_width_64 = 16;
+
 /**
  * @brief Parser for firmware_log.json configuration
  *
@@ -107,7 +113,8 @@ public:
    * @param structures Map of structure name to StructureInfo
    * @return Calculated header size in bytes
    */
-  static size_t calculate_header_size(const std::map<std::string, structure_info>& structures);
+  static size_t 
+  calculate_header_size(const std::map<std::string, structure_info>& structures);
 
   /**
    * @brief Get the calculated header size
@@ -124,19 +131,22 @@ private:
    * @brief Parse the root JSON object
    * @param  nlohmann::json object
    */
-  void parse_json(const nlohmann::json&);
+  static void 
+  parse_json(const nlohmann::json&);
 
   /**
    * @brief Parse enumerations section from JSON
    * @param enums_json JSON object for enumerations
    */
-  static std::map<std::string, enum_info> parse_enums(const nlohmann::json& config);
+  static std::map<std::string, enum_info> 
+  parse_enums(const nlohmann::json& config);
 
   /**
    * @brief Parse structures section from JSON
    * @param structs_json JSON object for structures
    */
-  static std::map<std::string, structure_info> parse_structures(const nlohmann::json& config);
+  static std::map<std::string, structure_info> 
+  parse_structures(const nlohmann::json& config);
 
 private:
   nlohmann::json config; ///< Raw JSON configuration

--- a/src/runtime_src/core/tools/xbutil2/OO_EventTrace.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_EventTrace.cpp
@@ -94,6 +94,14 @@ OO_EventTrace::execute(const SubCmdOptions& _options) const
     throw xrt_core::error(std::errc::operation_canceled);
   }
 
+  if (boost::iequals(m_action, "status")) {
+    // Get the current event trace state
+    const auto event_trace_state = xrt_core::device_query<xrt_core::query::event_trace_state>(device.get());
+    std::cout << "Event Trace Status:\n";
+    std::cout << "  Action: " << (event_trace_state == 1 ? "enabled" : "disabled") << "\n";
+    return;
+  }
+
   XBUtilities::sudo_or_throw("Event trace configuration requires admin privileges");
 
   auto action_to_int = [](const std::string& action) -> uint32_t {

--- a/src/runtime_src/core/tools/xbutil2/OO_FirmwareLog.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_FirmwareLog.cpp
@@ -97,6 +97,15 @@ OO_FirmwareLog::execute(const SubCmdOptions& _options) const
     throw xrt_core::error(std::errc::operation_canceled);
   }
 
+  if (boost::iequals(m_action, "status")) {
+    // Get the current firmware log state
+    const auto log_state = xrt_core::device_query<xrt_core::query::firmware_log_state>(device.get());
+    std::cout << "Firmware Log Status:\n";
+    std::cout << "  Action: " << (log_state.action == 1 ? "enabled" : "disabled") << "\n";
+    std::cout << "  Log Level: " << log_state.log_level << "\n";
+    return;
+  }
+
   XBUtilities::sudo_or_throw("Firmware log configuration requires admin privileges");
 
   auto action_to_int = [](const std::string& action) -> uint32_t {

--- a/src/runtime_src/core/tools/xbutil2/ReportFirmwareLog.cpp
+++ b/src/runtime_src/core/tools/xbutil2/ReportFirmwareLog.cpp
@@ -97,7 +97,7 @@ parse_log_entry(const uint8_t* data_ptr,
       field_context ctx{data_ptr, offset, bit_offset, bit_width, std::make_shared<firmware_log_config::field_info>(field)};
       std::string field_value = parse_field(ctx, config);
       if (field.name == "argc") {
-        argc = static_cast<uint32_t>(std::stoul(field_value, nullptr, 16));
+        argc = static_cast<uint32_t>(std::stoul(field_value, nullptr, hex_width_64));
       }
       entry_data.emplace_back(field_value);
     } else {

--- a/src/runtime_src/core/tools/xbutil2/ReportFirmwareLog.cpp
+++ b/src/runtime_src/core/tools/xbutil2/ReportFirmwareLog.cpp
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+
+#include "ReportFirmwareLog.h"
+#include "FirmwareLogConfig.h"
+#include "core/common/query_requests.h"
+#include "core/common/time.h"
+#include "tools/common/SmiWatchMode.h"
+#include "tools/common/Table2D.h"
+
+#include <algorithm>
+#include <boost/format.hpp>
+#include <iomanip>
+#include <sstream>
+#include <vector>
+
+using bpt = boost::property_tree::ptree;
+
+namespace {
+
+struct field_context {
+  const uint8_t* data_ptr;
+  size_t offset;
+  size_t bit_offset;
+  size_t bit_width;
+  const xrt_core::tools::xrt_smi::firmware_log_config::field_info& field;
+};
+
+constexpr size_t bits_per_byte = 8;
+constexpr size_t byte_alignment = 7;
+constexpr size_t bits_per_uint64 = 64;
+constexpr size_t hex_width_64 = 16;
+
+std::string
+parse_field(const field_context& ctx,
+            const xrt_core::tools::xrt_smi::firmware_log_config& config)
+{
+  size_t byte_offset = ctx.offset + (ctx.bit_offset / bits_per_byte);
+  size_t end_bit = ctx.bit_offset + ctx.bit_width;
+  size_t end_byte = ctx.offset + ((end_bit + byte_alignment) / bits_per_byte);
+  uint64_t raw = 0;
+  size_t bytes_to_read = end_byte - byte_offset;
+  std::memcpy(&raw, ctx.data_ptr + byte_offset, bytes_to_read);
+  size_t lsb = ctx.bit_offset % bits_per_byte;
+  uint64_t mask = (ctx.bit_width == bits_per_uint64) ? ~0ULL : ((1ULL << ctx.bit_width) - 1);
+  uint64_t value = (raw >> lsb) & mask;
+
+  if (ctx.field.format.find("x") != std::string::npos) {
+    return (ctx.bit_width == bits_per_uint64) ? boost::str(boost::format("0x%0" + std::to_string(hex_width_64) + "X") % value) : boost::str(boost::format("0x%08X") % value);
+  } 
+  else if (ctx.field.name == "level") {
+    const auto& enums = config.get_enums();
+    auto itr = enums.find(ctx.field.enumeration);
+    if (itr != enums.end()) {
+      return std::to_string(value) + ":" + itr->second.get_enumerator_name(static_cast<uint32_t>(value));
+    }
+  }
+  return std::to_string(value);
+}
+
+std::string
+parse_message(const uint8_t* data_ptr,
+              size_t msg_offset,
+              size_t argc,
+              size_t buf_size)
+{
+  size_t msg_size = argc * sizeof(uint32_t);
+  if (msg_size > 0 && msg_offset + msg_size <= buf_size) {
+    std::ostringstream oss;
+    for (size_t i = 0; i < argc; ++i) {
+      uint32_t msg_val = 0;
+      std::memcpy(&msg_val, data_ptr + msg_offset + i * 4, 4);
+      oss << boost::str(boost::format("0x%08X ") % msg_val);
+    }
+    return oss.str();
+  }
+  return "";
+}
+
+} // anonymous namespace
+
+void
+ReportFirmwareLog::
+getPropertyTreeInternal(const xrt_core::device* dev, bpt& pt) const
+{
+  getPropertyTree20202(dev, pt);
+}
+
+void
+ReportFirmwareLog::
+getPropertyTree20202(const xrt_core::device* /*dev*/, bpt& /*pt*/) const // Stubbing out for now till we decide on whether to add json dump support
+{}
+
+std::vector<std::string> 
+ReportFirmwareLog::
+parse_log_entry(const uint8_t* data_ptr,
+                size_t offset,
+                size_t buf_size,
+                const xrt_core::tools::xrt_smi::firmware_log_config& config)
+{
+  uint32_t argc = 0;
+  size_t header_size = config.get_header_size();
+  const auto& structures = config.get_structures();
+  auto it = structures.find("ipu_log_message_header");
+  if (it == structures.end()) 
+  {
+    return {}; // Handle error: structure not found
+  }
+
+  std::vector<std::string> entry_data;
+  size_t bit_offset = 0;
+  for (const auto& field : it->second.fields) 
+  {
+    size_t bit_width = field.width;
+    size_t end_bit = bit_offset + bit_width;
+    if (offset + ((end_bit + byte_alignment) / bits_per_byte) <= offset + header_size) {
+      field_context ctx{data_ptr, offset, bit_offset, bit_width, field};
+      std::string field_value = parse_field(ctx, config);
+      if (field.name == "argc") {
+        argc = static_cast<uint32_t>(std::stoul(field_value, nullptr, 16));
+      }
+      entry_data.emplace_back(field_value);
+    } else {
+      entry_data.emplace_back("-");
+    }
+    bit_offset += bit_width;
+  }
+
+  size_t msg_offset = offset + header_size;
+  entry_data.emplace_back(parse_message(data_ptr, msg_offset, argc, buf_size));
+  return entry_data;
+}
+
+static std::string
+generate_firmware_log_report(const xrt_core::device* dev,
+                             const std::vector<std::string>& /*elements_filter*/)
+{
+  std::stringstream ss;
+
+  // Load config once (could be cached in a real implementation)
+  std::string config_path;
+  try {
+    config_path = xrt_core::device_query<xrt_core::query::firmware_log_config>(dev);
+  } catch (const std::exception& e) {
+    ss << "Error retrieving firmware log config path: " << e.what() << "\n";
+    return ss.str();
+  }
+
+  xrt_core::tools::xrt_smi::firmware_log_config config(config_path);
+
+  try {
+    // Get raw buffer from device
+    xrt_core::query::firmware_debug_buffer log_buffer = xrt_core::device_query<xrt_core::query::firmware_log_data>(dev);
+    if (!log_buffer.data) {
+      ss << "No firmware log data available\n";
+      return ss.str();
+    }
+
+    const auto& structures = config.get_structures();
+    auto it = structures.find("ipu_log_message_header");
+
+    const auto* data_ptr = static_cast<const uint8_t*>(log_buffer.data);
+    size_t buf_size = log_buffer.size;
+    size_t offset = 0;
+
+    std::vector<Table2D::HeaderData> table_headers;
+    for (const auto& field : it->second.fields)
+      table_headers.push_back({field.name, Table2D::Justification::left});
+    table_headers.push_back({"message", Table2D::Justification::left});
+    Table2D log_table(table_headers);
+
+    size_t header_size = config.get_header_size();
+
+    while (offset + header_size <= buf_size) {
+      auto entry_data = ReportFirmwareLog::parse_log_entry(data_ptr, offset, buf_size, config);
+      log_table.addEntry(entry_data);
+      size_t msg_size = entry_data.back().size() * sizeof(uint32_t); // Approximate message size
+      size_t aligned_msg_size = ((msg_size + 3) / 4) * 4; // 4-byte alignment
+      offset += header_size + aligned_msg_size;
+    }
+    ss << "  Firmware Log Information:\n";
+    ss << log_table.toString("    ");
+  }
+  catch (const std::exception& e) {
+    ss << "Error retrieving firmware log data: " << e.what() << "\n";
+  }
+
+  return ss.str();
+}
+
+void
+ReportFirmwareLog::
+writeReport(const xrt_core::device* device,
+            const bpt& /*pt*/,
+            const std::vector<std::string>& elements_filter,
+            std::ostream& output) const
+{
+  // Check for watch mode
+  if (smi_watch_mode::parse_watch_mode_options(elements_filter)) {
+    auto report_generator = [](const xrt_core::device* dev, const std::vector<std::string>& filters) -> std::string {
+      return generate_firmware_log_report(dev, filters);
+    };
+    smi_watch_mode::run_watch_mode(device, elements_filter, output,
+                                   report_generator, "Firmware Log");
+    return;
+  }
+
+  // Non-watch mode
+  output << "Firmware Log Report\n";
+  output << "===================\n\n";
+  output << generate_firmware_log_report(device, elements_filter);
+  output << std::endl;
+}
+
+

--- a/src/runtime_src/core/tools/xbutil2/ReportFirmwareLog.h
+++ b/src/runtime_src/core/tools/xbutil2/ReportFirmwareLog.h
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+
+#ifndef REPORT_FIRMWARE_LOG_H
+#define REPORT_FIRMWARE_LOG_H
+
+#include "tools/common/Report.h"
+#include "FirmwareLogConfig.h" // Include the header file for firmware_log_config
+
+/**
+ * @brief Report for firmware log information
+ * 
+ * This report provides information about firmware logs on XRT devices.
+ * It displays:
+ * - Timestamp
+ * - Log Level
+ * - Message
+ *
+ * Usage Examples:
+ * @code
+ * # Basic firmware log report
+ * xrt-smi examine --report firmware-log
+ *
+ * @endcode
+ */
+class ReportFirmwareLog : public Report {
+public:
+  ReportFirmwareLog() 
+    : Report("firmware-log", "Log to console firmware log information", true /*deviceRequired*/) { };
+
+  // Child methods that need to be implemented from Report base class
+public:
+  /**
+   * @brief Get property tree representation of firmware log data
+   *
+   * @param dev XRT device to query for firmware log information
+   * @param pt Property tree to populate with firmware log data
+   *
+   * This method implements the standard XRT report interface for
+   * property tree generation. It queries the device using XRT's
+   * device query system and populates the property tree with
+   * structured firmware log information.
+   *
+   * Property tree structure:
+   * - firmware_log
+   *   - log_count: Total number of log entries
+   *   - logs: Array of log objects
+   *     - timestamp: Log timestamp
+   *     - level: Log level
+   *     - message: Log message
+   *
+   * @note Handles exceptions internally and reports errors in property tree
+   * @note Compatible with JSON serialization for xrt-smi --format JSON
+   */
+  void getPropertyTreeInternal(const xrt_core::device* dev, boost::property_tree::ptree& pt) const override;
+
+  /**
+   * @brief Get property tree representation for XRT 2020.2+ compatibility
+   *
+   * @param dev XRT device to query for firmware log information
+   * @param pt Property tree to populate with firmware log data
+   *
+   * @note May have slightly different property tree structure for compatibility
+   * @note Falls back to getPropertyTreeInternal implementation if no differences
+   */
+  void getPropertyTree20202(const xrt_core::device* dev, boost::property_tree::ptree& pt) const override;
+
+  /**
+   * @brief Write formatted firmware log report to output stream
+   *
+   * @param device XRT device to query for current firmware log data
+   * @param pt Property tree containing firmware log data (may be unused for direct queries)
+   * @param elements_filter Vector of element filter strings for customization
+   * @param output Output stream to write the formatted report
+   *
+   * This method generates the human-readable formatted output for firmware logs.
+   * It supports:
+   *
+   * Element Filters:
+   * - "log_level=<level>" - Filter to show only specific log level
+   * - "watch" - Enable real-time watch mode with 1-second updates
+   *
+   * @note Integrates with smi_watch_mode for real-time monitoring
+   * @note Thread-safe implementation for watch mode usage
+   */
+  void writeReport(const xrt_core::device* device,
+                   const boost::property_tree::ptree& pt,
+                   const std::vector<std::string>& elements_filter,
+                   std::ostream& output) const override;
+
+public:
+  /**
+   * @brief Parse a single firmware log entry
+   *
+   * @param data_ptr Pointer to the firmware log data buffer
+   * @param offset Offset within the buffer to start parsing
+   * @param buf_size Total size of the data buffer
+   * @param config Firmware log configuration object
+   *
+   * @return Vector of strings containing parsed log entry data
+   *
+   * This static method parses a single firmware log entry from the data buffer
+   * and returns the extracted information as a vector of strings. The parsing
+   * is based on the provided configuration object, which defines the structure
+   * of the log entry.
+   */
+  static std::vector<std::string> parse_log_entry(const uint8_t* data_ptr, 
+                                                  size_t offset, 
+                                                  size_t buf_size, 
+                                                  const xrt_core::tools::xrt_smi::firmware_log_config& config);
+};
+
+#endif // REPORT_FIRMWARE_LOG_H

--- a/src/runtime_src/core/tools/xbutil2/ReportFirmwareLog.h
+++ b/src/runtime_src/core/tools/xbutil2/ReportFirmwareLog.h
@@ -52,7 +52,8 @@ public:
    * @note Handles exceptions internally and reports errors in property tree
    * @note Compatible with JSON serialization for xrt-smi --format JSON
    */
-  void getPropertyTreeInternal(const xrt_core::device* dev, boost::property_tree::ptree& pt) const override;
+  void 
+  getPropertyTreeInternal(const xrt_core::device* dev, boost::property_tree::ptree& pt) const override;
 
   /**
    * @brief Get property tree representation for XRT 2020.2+ compatibility
@@ -63,7 +64,8 @@ public:
    * @note May have slightly different property tree structure for compatibility
    * @note Falls back to getPropertyTreeInternal implementation if no differences
    */
-  void getPropertyTree20202(const xrt_core::device* dev, boost::property_tree::ptree& pt) const override;
+  void 
+  getPropertyTree20202(const xrt_core::device* dev, boost::property_tree::ptree& pt) const override;
 
   /**
    * @brief Write formatted firmware log report to output stream
@@ -83,10 +85,11 @@ public:
    * @note Integrates with smi_watch_mode for real-time monitoring
    * @note Thread-safe implementation for watch mode usage
    */
-  void writeReport(const xrt_core::device* device,
-                   const boost::property_tree::ptree& pt,
-                   const std::vector<std::string>& elements_filter,
-                   std::ostream& output) const override;
+  void 
+  writeReport(const xrt_core::device* device,
+              const boost::property_tree::ptree& pt,
+              const std::vector<std::string>& elements_filter,
+              std::ostream& output) const override;
 
 public:
   /**
@@ -104,10 +107,12 @@ public:
    * is based on the provided configuration object, which defines the structure
    * of the log entry.
    */
-  static std::vector<std::string> parse_log_entry(const uint8_t* data_ptr, 
-                                                  size_t offset, 
-                                                  size_t buf_size, 
-                                                  const xrt_core::tools::xrt_smi::firmware_log_config& config);
+  static 
+  std::vector<std::string> 
+  parse_log_entry(const uint8_t* data_ptr, 
+                  size_t offset, 
+                  size_t buf_size, 
+                  const xrt_core::tools::xrt_smi::firmware_log_config& config);
 };
 
 #endif // REPORT_FIRMWARE_LOG_H

--- a/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
@@ -38,6 +38,7 @@
 #include "tools/common/reports/ReportQspiStatus.h"
 #include "tools/common/reports/ReportTelemetry.h"
 #include "tools/common/reports/ReportThermal.h"
+#include "tools/xbutil2/ReportFirmwareLog.h"
 
 #include <filesystem>
 #include <fstream>
@@ -73,6 +74,7 @@ SubCmdExamine::SubCmdExamine(bool _isHidden, bool _isDepricated, bool _isPrelimi
     std::make_shared<ReportPlatforms>(),
     std::make_shared<ReportPreemption>(),
     std::make_shared<ReportPsKernels>(),
+    std::make_shared<ReportFirmwareLog>(),
   // Native only reports
   #ifdef ENABLE_NATIVE_SUBCMDS_AND_REPORTS
     std::make_shared<ReportElectrical>(),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
This PR adds the implementation for Firmware logging report and a parser for firmware_log.json (one to one mapped from firmware_protocol.yaml that is shipped by the firmware in the latest strix firmware release).

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://jira.xilinx.com/browse/AIESW-5508

#### How problem was solved, alternative solutions (if any) and why they were rejected
Solved by using nlohmann::json for json parsing and using the parsed configs and payload configuration to print firmware log data in the report.

What is missing in this patch: 

1. This implementation misses handling of missed events since actual firmware data is not used to test this. This will be added once driver plumbing is in place to retrieve real firmware data.
2. This implementation also assumes the JSON configuration will be shipped with driver build and loaded at run time through a valid path retrieved from driver (similar to other artifact loading in xrt-smi like runner artifacts).

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
This is not tested on actual data yet since the driver has not implemented the ioctl changes to retrieve actual firmware data. This PR has been tested using a dummy data generated in the shim and using it to print a table from parsed configuration.
Dummy data used :
```
     struct ipu_log_message_header {
        uint64_t timestamp;
        uint32_t format : 1;
        uint32_t reserved_1 : 7;
        uint32_t level : 3;
        uint32_t reserved_11 : 5;
        uint32_t appn : 8;
        uint32_t argc : 8;
        uint32_t line : 16;
        uint32_t module : 16;
      };

      struct firmware_log_data {
        ipu_log_message_header header;
        uint32_t message[2]; // argc = 2 for dummy data
      };

      static firmware_log_data dummy_log = {
        {0x123456789ABCDEF0, 1, 0, 3, 0, 42, 2, 100, 200}, // header
        {0xDEADBEEF, 0xFEEDC0DE} // message
      };
```
Report generated : 
<img width="1198" height="98" alt="image" src="https://github.com/user-attachments/assets/7d174c64-1f05-4bb6-8fff-0d59dee7f153" />


#### Documentation impact (if any)
None
