### PR TITLE
[CR-1248279] Add CL directory to /usr/include/xrt on EDGE side

### DIFF
--- a/src/runtime_src/xocl/CMakeLists.txt
+++ b/src/runtime_src/xocl/CMakeLists.txt
@@ -100,21 +100,25 @@ install(TARGETS xilinxopencl xilinxopencl_static
   ARCHIVE DESTINATION ${XRT_INSTALL_LIB_DIR} COMPONENT ${XRT_BASE_DEV_COMPONENT}
 )
 
+set(CL_DEST_DIR ${XRT_INSTALL_INCLUDE_DIR}/)
+if(XRT_EDGE)
+  set(CL_DEST_DIR ${XRT_INSTALL_INCLUDE_DIR}/xrt/)
+endif()
+
 # Release OpenCL extension headers
 install (FILES
   ${XRT_SOURCE_DIR}/include/1_2/CL/cl_ext_xilinx.h
-  DESTINATION ${XRT_INSTALL_INCLUDE_DIR}/CL
+  DESTINATION ${CL_DEST_DIR}/CL
   COMPONENT ${XRT_BASE_DEV_COMPONENT}
 )
 
 # Preserve legacy behavior in legacy XRT package. The component
 # setup will have defined XRT_BASE_DEV_COMPONENT to XRT
-if (XRT_XRT)
+if (XRT_XRT OR XRT_EDGE)
   install (FILES
     ${XRT_SOURCE_DIR}/include/1_2/CL/cl_ext.h
     ${XRT_SOURCE_DIR}/include/1_2/CL/cl2xrt.hpp
-    DESTINATION ${XRT_INSTALL_INCLUDE_DIR}/CL
+    DESTINATION ${CL_DEST_DIR}/CL
     COMPONENT ${XRT_BASE_DEV_COMPONENT}
     )
-endif (XRT_XRT)
-  
+endif (XRT_XRT) 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1248279 Testcases from Versal platforms in the software pipeline were failing due to a CL header files are not found in /usr/include/xrt dir
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
All CL based applications are failing on vck190.
http://xoah/historydata?user=xbuild&suiteName=SSW_EMBEDDED_XILINX_VCK190_BASE_202520_1&suiteRunName=2025.2_0901_2219_304_1_SSW_embedded&superSuiteName=XRT_EMBEDDED&testName=emb_vadd-hw-xilinx_vck190_base_202520_1&relBranch=2025.2&platform=LNX64&taskName=build

#### How problem was solved, alternative solutions (if any) and why they were rejected
Moved CL/ to /usr/include/xrt for backward compatibility.

#### Risks (if any) associated the changes in the commit
low

#### What has been tested and how, request additional testing if necessary
Tested by compiling a CL-based vck190 application using the generated sysroot.

#### Documentation impact (if any)
