### PR TITLE
Remove legacy release of windows detail header files

### DIFF
--- a/src/runtime_src/core/include/xrt/detail/windows/CMakeLists.txt
+++ b/src/runtime_src/core/include/xrt/detail/windows/CMakeLists.txt
@@ -8,11 +8,6 @@ set(XRT_WINDOWS_HEADER_SRC
   types.h
   uuid.h)
 
-# Legacy deprecated install
-install (FILES ${XRT_WINDOWS_HEADER_SRC}
-  DESTINATION ${XRT_INSTALL_INCLUDE_DIR}/windows
-  COMPONENT ${XRT_BASE_DEV_COMPONENT})
-
 # base component install
 install (FILES ${XRT_WINDOWS_HEADER_SRC}
   DESTINATION ${XRT_INSTALL_INCLUDE_DIR}/xrt/detail/windows


### PR DESCRIPTION
#### Problem solved by the commit
The SDK include dir should have only xrt/ and aiebu/ sub-folders
