### PR TITLE
[XDP] Fix for CR-1239514

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_metadata.cpp
@@ -440,8 +440,8 @@ namespace xdp {
      */
 
     std::vector<std::vector<std::string>> metrics(metricsSettings.size());
-    bool isAll = false;
-    bool isRange = false;
+    std::vector<bool> isAll(metricsSettings.size());
+    std::vector<bool> isRange(metricsSettings.size());
 
     // Pass 1 : process only "all" metric setting
     for (size_t i = 0; i < metricsSettings.size(); ++i) {
@@ -451,7 +451,7 @@ namespace xdp {
       if ((metrics[i][0].compare("all") != 0) || (metrics[i].size() < 2))
         continue;
 
-      isAll = true;
+      isAll[i] = true;
 
       auto tiles = metadataReader->getTiles(metrics[i][0], mod, "all");
       for (auto& e : tiles) {
@@ -499,7 +499,7 @@ namespace xdp {
         continue;
       }
 
-      isRange = true;
+      isRange[i] = true;
 
       uint8_t minRow = 0, minCol = 0;
       uint8_t maxRow = 0, maxCol = 0;
@@ -595,7 +595,7 @@ namespace xdp {
     // Pass 3 : process only single tile metric setting
     for (size_t i = 0; i < metricsSettings.size(); ++i) {
       // Check if already processed
-      if (isAll || isRange)
+      if (isAll[i] || isRange[i])
         continue;
 
       uint8_t col = 0;

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_metadata.cpp
@@ -494,11 +494,9 @@ namespace xdp {
       if ((metrics[i].size() != 3) && (metrics[i].size() != 4))
         continue;
 
-      if (metrics[i].size() == 3) {
-        if (metrics[i][1].find('{') == std::string::npos) { 
-          // not found
-          continue;
-        } 
+      if ((metrics[i].size() == 3) && (metrics[i][1].find('{') == std::string::npos)) {
+        // the second string in this metric set does not contain a '{', which means it does not describe a range of tiles
+        continue;
       }
 
       isRange = true;
@@ -518,7 +516,7 @@ namespace xdp {
         std::vector<std::string> maxTile;
         boost::split(maxTile, metrics[i][1], boost::is_any_of(","));
         
-        if (minTile.size() != 2 || maxTile.size() != 2) {
+        if ((minTile.size() != 2) || (maxTile.size() != 2)) {
           std::stringstream msg;
           msg << "Tile range specification in tile_based_" << modName
               << "_metrics is not a valid format and hence skipped. Should be {<mincolumn,<minrow>}:{<maxcolumn>,<maxrow>}";

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_metadata.cpp
@@ -440,6 +440,8 @@ namespace xdp {
      */
 
     std::vector<std::vector<std::string>> metrics(metricsSettings.size());
+    bool isAll = false;
+    bool isRange = false;
 
     // Pass 1 : process only "all" metric setting
     for (size_t i = 0; i < metricsSettings.size(); ++i) {
@@ -448,6 +450,8 @@ namespace xdp {
 
       if ((metrics[i][0].compare("all") != 0) || (metrics[i].size() < 2))
         continue;
+
+      isAll = true;
 
       auto tiles = metadataReader->getTiles(metrics[i][0], mod, "all");
       for (auto& e : tiles) {
@@ -487,8 +491,17 @@ namespace xdp {
 
     // Pass 2 : process only range of tiles metric setting
     for (size_t i = 0; i < metricsSettings.size(); ++i) {
-      if ((metrics[i].size() != 3) && (metrics[i].size() != 5))
+      if ((metrics[i].size() != 3) && (metrics[i].size() != 4))
         continue;
+
+      if (metrics[i].size() == 3) {
+        if (metrics[i][1].find('{') == std::string::npos) { 
+          // not found
+          continue;
+        } 
+      }
+
+      isRange = true;
 
       uint8_t minRow = 0, minCol = 0;
       uint8_t maxRow = 0, maxCol = 0;
@@ -584,8 +597,7 @@ namespace xdp {
     // Pass 3 : process only single tile metric setting
     for (size_t i = 0; i < metricsSettings.size(); ++i) {
       // Check if already processed
-      if ((metrics[i][0].compare("all") == 0) || (metrics[i].size() == 3) 
-          || (metrics[i].size() == 5))
+      if (isAll || isRange)
         continue;
 
       uint8_t col = 0;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
This commit fixes the way the type of tile (all/range/single) was detected. Metric size was used to distinguish between single tile and range-based tile type, but this approach was flawed since both types can have the same metric sizes based on the settings provided.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Fixes [CR-1239514](https://jira.xilinx.com/browse/CR-1239514)

#### How problem was solved, alternative solutions (if any) and why they were rejected
1. Added two bool vectors isAll and isRange to keep track of the tile type
2. Changed logic to check for presence of `{` in the second string to identify range-based type
3. Instead of checking metric size, used isAll and isRange vectors to determine whether to go ahead with single tile type flow or not

#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
1. Tested on vek280
2. Tested on hw_emu with the following tests: 
- original test (single tile metric for memory_tile)
- single tile metric for aie_tile
- multiple options separated by `;` (eg: `tile_based_memory_tile_metrics={18,0}:mm2s_channels_details:1 ; {19,0}:mm2s_channels_details:1`)

#### Documentation impact (if any)
N/A