### PR TITLE
Changing the building of XDP modules to shared libraries for versioning

### DIFF
--- a/src/runtime_src/core/common/module_loader.h
+++ b/src/runtime_src/core/common/module_loader.h
@@ -49,6 +49,20 @@ public:
 };
 
 /**
+ * This class is responsible for loading a plugin module on Windows
+ * from the SDK install directory, separate from the XRT installation.
+ */
+class sdk_loader
+{
+public:
+  XRT_CORE_COMMON_EXPORT
+  sdk_loader(const std::string& plugin_name,
+             std::function<void (void*)> registration_function,
+             std::function<void ()> warning_function,
+             std::function<int ()> error_function = nullptr);
+};
+
+/**
  * Load XRT core library at runtime
  */
 class shim_loader

--- a/src/runtime_src/core/common/xdp/profile.cpp
+++ b/src/runtime_src/core/common/xdp/profile.cpp
@@ -87,9 +87,16 @@ register_callbacks(void* handle)
 void 
 load()
 {
+#if defined(XDP_CLIENT_BUILD) && defined(_WIN32)
+  // On Windows client, load AIE profiling from the SDK location
+  static xrt_core::sdk_loader xdp_aie_loader("xdp_aie_profile_plugin",
+                                             register_callbacks,
+                                             warning_callbacks_empty);
+#else
   static xrt_core::module_loader xdp_aie_loader("xdp_aie_profile_plugin",
                                                 register_callbacks,
                                                 warning_callbacks_empty);
+#endif
 }
 
 void
@@ -359,9 +366,16 @@ register_callbacks(void* handle)
 void 
 load()
 {
+#if defined(XDP_CLIENT_BUILD) && defined(_WIN32)
+  // On Windows client, load AIE trace from the SDK location
+  static xrt_core::sdk_loader xdp_aie_trace_loader("xdp_aie_trace_plugin",
+                                                   register_callbacks,
+                                                   warning_callbacks_empty);
+#else
   static xrt_core::module_loader xdp_aie_trace_loader("xdp_aie_trace_plugin",
                                                 register_callbacks,
                                                 warning_callbacks_empty);
+#endif
 }
 
 void 
@@ -410,9 +424,16 @@ register_callbacks(void* handle)
 void
 load()
 {
+#if defined(XDP_CLIENT_BUILD) && defined(_WIN32)
+  // On Windows client, load AIE Halt from the SDK location
+  static xrt_core::sdk_loader xdp_aie_halt_loader("xdp_aie_halt_plugin",
+                                                  register_callbacks,
+                                                  warning_callbacks_empty);
+#else
   static xrt_core::module_loader xdp_aie_halt_loader("xdp_aie_halt_plugin",
                                                      register_callbacks,
                                                      warning_callbacks_empty);
+#endif
 }
 
 void

--- a/src/runtime_src/xdp/appdebug/CMakeLists.txt
+++ b/src/runtime_src/xdp/appdebug/CMakeLists.txt
@@ -23,7 +23,7 @@ file(GLOB APPDEBUG_FILES
 # away and are visible to gdb.
 set_source_files_properties (${APPDEBUG_FILES} PROPERTIES COMPILE_FLAGS -g)
 
-add_library(xdp_appdebug_plugin MODULE ${APPDEBUG_FILES})
+add_library(xdp_appdebug_plugin SHARED ${APPDEBUG_FILES})
 
 # The application debug plugin is specific to OpenCL applications, so
 # we have a dependency to xilinxopencl
@@ -33,7 +33,7 @@ target_link_libraries(xdp_appdebug_plugin PRIVATE xrt_coreutil xilinxopencl)
 set_target_properties(xdp_appdebug_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
 
 install (TARGETS xdp_appdebug_plugin
-         LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR})
+         LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} NAMELINK_SKIP)
 
 # We also need to copy the python scripts that contain the gdb connection.
 # Only install these files for PCIe device for now, which is native build

--- a/src/runtime_src/xdp/debug/CMakeLists.txt
+++ b/src/runtime_src/xdp/debug/CMakeLists.txt
@@ -21,7 +21,7 @@ file(GLOB DEBUG_FILES
   "${DEBUG_DIR}/*.cpp"
   )
 
-add_library(xdp_debug_plugin MODULE ${DEBUG_FILES})
+add_library(xdp_debug_plugin SHARED ${DEBUG_FILES})
 
 add_dependencies(xdp_debug_plugin xrt_coreutil xilinxopencl)
 target_link_libraries(xdp_debug_plugin PRIVATE xrt_coreutil xilinxopencl)
@@ -29,6 +29,6 @@ target_link_libraries(xdp_debug_plugin PRIVATE xrt_coreutil xilinxopencl)
 set_target_properties(xdp_debug_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
 
 install (TARGETS xdp_debug_plugin
-         LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR})
+         LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} NAMELINK_SKIP)
 
 endif()

--- a/src/runtime_src/xdp/profile/plugin/aie_debug/CMakeLists.txt
+++ b/src/runtime_src/xdp/profile/plugin/aie_debug/CMakeLists.txt
@@ -32,18 +32,18 @@ file(GLOB AIE_DRIVER_COMMON_UTIL_FILES
 )
 
 if (XDP_VE2_BUILD_CMAKE STREQUAL "yes")
-  add_library(xdp_aie_debug_plugin MODULE ${AIE_DEBUG_PLUGIN_FILES})
+  add_library(xdp_aie_debug_plugin SHARED ${AIE_DEBUG_PLUGIN_FILES})
   add_dependencies(xdp_aie_debug_plugin xdp_core xrt_coreutil)
   target_link_libraries(xdp_aie_debug_plugin PRIVATE xdp_core xrt_coreutil xaiengine)
   target_compile_definitions(xdp_aie_debug_plugin PRIVATE FAL_LINUX="on" XDP_VE2_BUILD=1)
   target_include_directories(xdp_aie_debug_plugin PRIVATE ${CMAKE_SOURCE_DIR}/src)
   
   install (TARGETS xdp_aie_debug_plugin
-    LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR}
+    LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} NAMELINK_SKIP
   )
 
 elseif (XDP_CLIENT_BUILD_CMAKE STREQUAL "yes")
-  add_library(xdp_aie_debug_plugin MODULE ${AIE_DEBUG_PLUGIN_FILES} ${AIE_DRIVER_COMMON_UTIL_FILES})
+  add_library(xdp_aie_debug_plugin SHARED ${AIE_DEBUG_PLUGIN_FILES} ${AIE_DRIVER_COMMON_UTIL_FILES})
   add_dependencies(xdp_aie_debug_plugin xdp_core xrt_coreutil)
   target_link_libraries(xdp_aie_debug_plugin PRIVATE xdp_core xrt_coreutil xaiengine)
   target_compile_definitions(xdp_aie_debug_plugin PRIVATE XDP_CLIENT_BUILD=1 -DXAIE_FEATURE_MSVC)
@@ -51,18 +51,18 @@ elseif (XDP_CLIENT_BUILD_CMAKE STREQUAL "yes")
   set_target_properties(xdp_aie_debug_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
 
   install (TARGETS xdp_aie_debug_plugin
-    LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT}
+    LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT} NAMELINK_SKIP
   )
 
 elseif (DEFINED XRT_AIE_BUILD AND XRT_EDGE)
-  add_library(xdp_aie_debug_plugin MODULE ${AIE_DEBUG_PLUGIN_FILES})
+  add_library(xdp_aie_debug_plugin SHARED ${AIE_DEBUG_PLUGIN_FILES})
   add_dependencies(xdp_aie_debug_plugin xdp_core xrt_coreutil)
   target_link_libraries(xdp_aie_debug_plugin PRIVATE xdp_core xrt_coreutil xaiengine)
   target_compile_definitions(xdp_aie_debug_plugin PRIVATE FAL_LINUX="on")
   set_target_properties(xdp_aie_debug_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
 
   install (TARGETS xdp_aie_debug_plugin
-    LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR}
+    LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} NAMELINK_SKIP
   )
 
 # Else, on edge-aarch64 don't build at all

--- a/src/runtime_src/xdp/profile/plugin/aie_halt/CMakeLists.txt
+++ b/src/runtime_src/xdp/profile/plugin/aie_halt/CMakeLists.txt
@@ -28,7 +28,7 @@ file(GLOB XDP_DEVICE_COMMON_FILES
 )
 
 if (XDP_CLIENT_BUILD_CMAKE STREQUAL "yes")
-  add_library(xdp_aie_halt_plugin MODULE ${XDP_AIE_HALT_PLUGIN_FILES} ${XDP_DEVICE_COMMON_FILES})
+  add_library(xdp_aie_halt_plugin SHARED ${XDP_AIE_HALT_PLUGIN_FILES} ${XDP_DEVICE_COMMON_FILES})
   add_dependencies(xdp_aie_halt_plugin xdp_core xrt_coreutil)
   target_link_libraries(xdp_aie_halt_plugin PRIVATE xdp_core xrt_coreutil xaiengine)
   target_compile_definitions(xdp_aie_halt_plugin PRIVATE XDP_CLIENT_BUILD=1 -DXAIE_FEATURE_MSVC)
@@ -36,11 +36,11 @@ if (XDP_CLIENT_BUILD_CMAKE STREQUAL "yes")
   set_target_properties(xdp_aie_halt_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
 
   install (TARGETS xdp_aie_halt_plugin
-    LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT}
+    LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT} NAMELINK_SKIP
   )
 
 elseif (XDP_VE2_BUILD_CMAKE STREQUAL "yes")
-  add_library(xdp_aie_halt_plugin MODULE ${XDP_AIE_HALT_PLUGIN_FILES})
+  add_library(xdp_aie_halt_plugin SHARED ${XDP_AIE_HALT_PLUGIN_FILES})
   add_dependencies(xdp_aie_halt_plugin xdp_core xrt_coreutil)
 
   #target_include_directories(xdp_aie_halt_plugin PRIVATE ${AIERT_DIR}/include)
@@ -51,7 +51,7 @@ elseif (XDP_VE2_BUILD_CMAKE STREQUAL "yes")
   set_target_properties(xdp_aie_halt_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
 
   install (TARGETS xdp_aie_halt_plugin
-    LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT}
+    LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT} NAMELINK_SKIP
   )
 
 # Else, on edge-aarch64 don't build at all

--- a/src/runtime_src/xdp/profile/plugin/aie_pc/CMakeLists.txt
+++ b/src/runtime_src/xdp/profile/plugin/aie_pc/CMakeLists.txt
@@ -26,7 +26,7 @@ file(GLOB XDP_DEVICE_COMMON_FILES
 )
 
 if (XDP_CLIENT_BUILD_CMAKE STREQUAL "yes")
-  add_library(xdp_aie_pc_plugin MODULE ${XDP_AIE_PC_PLUGIN_FILES} ${XDP_DEVICE_COMMON_FILES})
+  add_library(xdp_aie_pc_plugin SHARED ${XDP_AIE_PC_PLUGIN_FILES} ${XDP_DEVICE_COMMON_FILES})
   add_dependencies(xdp_aie_pc_plugin xdp_core xrt_coreutil)
   target_link_libraries(xdp_aie_pc_plugin PRIVATE xdp_core xrt_coreutil xaiengine)
   target_compile_definitions(xdp_aie_pc_plugin PRIVATE XDP_CLIENT_BUILD=1 -DXAIE_FEATURE_MSVC)
@@ -34,7 +34,7 @@ if (XDP_CLIENT_BUILD_CMAKE STREQUAL "yes")
   set_target_properties(xdp_aie_pc_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
 
   install (TARGETS xdp_aie_pc_plugin
-    LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT}
+    LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT} NAMELINK_SKIP
   )
 
 # Else, on edge-aarch64 don't build at all

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/CMakeLists.txt
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/CMakeLists.txt
@@ -35,7 +35,7 @@ if (XDP_CLIENT_BUILD_CMAKE STREQUAL "yes")
     "${IMPL_DIR}/*.h"
     "${IMPL_DIR}/*.cpp"
   )
-  add_library(xdp_aie_profile_plugin MODULE ${AIE_PROFILE_PLUGIN_FILES} ${AIE_PROFILE_IMPL_FILES} ${AIE_DRIVER_COMMON_UTIL_FILES} ${AIE_PROFILE_UTIL_FILES})
+  add_library(xdp_aie_profile_plugin SHARED ${AIE_PROFILE_PLUGIN_FILES} ${AIE_PROFILE_IMPL_FILES} ${AIE_DRIVER_COMMON_UTIL_FILES} ${AIE_PROFILE_UTIL_FILES})
   add_dependencies(xdp_aie_profile_plugin xdp_core xrt_coreutil)
   target_link_libraries(xdp_aie_profile_plugin PRIVATE xdp_core xrt_coreutil xaiengine)
   target_compile_definitions(xdp_aie_profile_plugin PRIVATE XDP_CLIENT_BUILD=1 -DXAIE_FEATURE_MSVC)
@@ -43,7 +43,7 @@ if (XDP_CLIENT_BUILD_CMAKE STREQUAL "yes")
   set_target_properties(xdp_aie_profile_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
 
   install (TARGETS xdp_aie_profile_plugin
-    LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT}
+    LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT} NAMELINK_SKIP
   )
 
 elseif (DEFINED XRT_AIE_BUILD AND (NOT XRT_EDGE))
@@ -53,7 +53,7 @@ elseif (DEFINED XRT_AIE_BUILD AND (NOT XRT_EDGE))
     "${IMPL_DIR}/*.h"
     "${IMPL_DIR}/*.cpp"
   )
-  add_library(xdp_aie_profile_plugin MODULE ${AIE_PROFILE_PLUGIN_FILES} ${AIE_PROFILE_IMPL_FILES})
+  add_library(xdp_aie_profile_plugin SHARED ${AIE_PROFILE_PLUGIN_FILES} ${AIE_PROFILE_IMPL_FILES})
   add_dependencies(xdp_aie_profile_plugin xdp_core xrt_coreutil)
   target_link_libraries(xdp_aie_profile_plugin PRIVATE xdp_core xrt_coreutil)
   target_compile_definitions(xdp_aie_profile_plugin PRIVATE XRT_X86_BUILD=1)
@@ -61,7 +61,7 @@ elseif (DEFINED XRT_AIE_BUILD AND (NOT XRT_EDGE))
   set_target_properties(xdp_aie_profile_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
 
   install (TARGETS xdp_aie_profile_plugin
-    LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT}
+    LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT} NAMELINK_SKIP
   )
 
 else()
@@ -73,7 +73,7 @@ else()
       "${IMPL_DIR}/*.h"
       "${IMPL_DIR}/*.cpp"
     )
-    add_library(xdp_aie_profile_plugin_xdna MODULE ${AIE_PROFILE_PLUGIN_FILES} ${AIE_PROFILE_IMPL_FILES} ${AIE_PROFILE_UTIL_FILES} ${AIE_PROFILE_CONFIG_FILES})
+    add_library(xdp_aie_profile_plugin_xdna SHARED ${AIE_PROFILE_PLUGIN_FILES} ${AIE_PROFILE_IMPL_FILES} ${AIE_PROFILE_UTIL_FILES} ${AIE_PROFILE_CONFIG_FILES})
     add_dependencies(xdp_aie_profile_plugin_xdna xdp_core xrt_coreutil)
     target_link_libraries(xdp_aie_profile_plugin_xdna PRIVATE xdp_core xrt_coreutil xaiengine)
     target_compile_definitions(xdp_aie_profile_plugin_xdna PRIVATE XDP_VE2_BUILD=1 FAL_LINUX="on")
@@ -81,7 +81,7 @@ else()
     set_target_properties(xdp_aie_profile_plugin_xdna PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
 
     install (TARGETS xdp_aie_profile_plugin_xdna
-      LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT}
+      LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT} NAMELINK_SKIP
     )
   endif()
 
@@ -92,7 +92,7 @@ else()
       "${IMPL_DIR}/*.h"
       "${IMPL_DIR}/*.cpp"
     )
-    add_library(xdp_aie_profile_plugin MODULE ${AIE_PROFILE_PLUGIN_FILES} ${AIE_PROFILE_IMPL_FILES} ${AIE_PROFILE_UTIL_FILES} ${AIE_PROFILE_CONFIG_FILES})
+    add_library(xdp_aie_profile_plugin SHARED ${AIE_PROFILE_PLUGIN_FILES} ${AIE_PROFILE_IMPL_FILES} ${AIE_PROFILE_UTIL_FILES} ${AIE_PROFILE_CONFIG_FILES})
     add_dependencies(xdp_aie_profile_plugin xdp_core xrt_coreutil)
     target_link_libraries(xdp_aie_profile_plugin PRIVATE xdp_core xrt_coreutil xaiengine)
     if (XDP_VE2_BUILD_CMAKE STREQUAL "yes")
@@ -103,7 +103,7 @@ else()
     set_target_properties(xdp_aie_profile_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
 
     install (TARGETS xdp_aie_profile_plugin
-      LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT}
+      LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT} NAMELINK_SKIP
     )
   endif()
 

--- a/src/runtime_src/xdp/profile/plugin/aie_status/CMakeLists.txt
+++ b/src/runtime_src/xdp/profile/plugin/aie_status/CMakeLists.txt
@@ -15,7 +15,7 @@ file(GLOB AIE_STATUS_PLUGIN_FILES
 )
 
 if (XDP_VE2_BUILD_CMAKE STREQUAL "yes")
-  add_library(xdp_aie_status_plugin MODULE ${AIE_STATUS_PLUGIN_FILES})
+  add_library(xdp_aie_status_plugin SHARED ${AIE_STATUS_PLUGIN_FILES})
   add_dependencies(xdp_aie_status_plugin xdp_core)
   target_link_libraries(xdp_aie_status_plugin PRIVATE xdp_core xaiengine)
   target_compile_definitions(xdp_aie_status_plugin PRIVATE XDP_VE2_BUILD=1 FAL_LINUX="on")
@@ -23,11 +23,11 @@ if (XDP_VE2_BUILD_CMAKE STREQUAL "yes")
   set_target_properties(xdp_aie_status_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
 
   install (TARGETS xdp_aie_status_plugin
-    LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT}
+    LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT} NAMELINK_SKIP
   )
 
 elseif (DEFINED XRT_AIE_BUILD AND XRT_EDGE)
-  add_library(xdp_aie_status_plugin MODULE ${AIE_STATUS_PLUGIN_FILES})
+  add_library(xdp_aie_status_plugin SHARED ${AIE_STATUS_PLUGIN_FILES})
   add_dependencies(xdp_aie_status_plugin xdp_core)
   target_link_libraries(xdp_aie_status_plugin PRIVATE xdp_core xaiengine)
   target_compile_definitions(xdp_aie_status_plugin PRIVATE FAL_LINUX="on")
@@ -35,7 +35,7 @@ elseif (DEFINED XRT_AIE_BUILD AND XRT_EDGE)
   set_target_properties(xdp_aie_status_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
 
   install (TARGETS xdp_aie_status_plugin
-    LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT}
+    LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT} NAMELINK_SKIP
   )
 
 endif()

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/CMakeLists.txt
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/CMakeLists.txt
@@ -44,7 +44,7 @@ if (XDP_CLIENT_BUILD_CMAKE STREQUAL "yes")
     "${IMPL_DIR}/*.cpp"
   )
 
-  add_library(xdp_aie_trace_plugin MODULE ${AIE_TRACE_PLUGIN_FILES} ${AIE_TRACE_COMPONENT_FILES} ${AIE_TRACE_UTIL_FILES} ${AIE_DRIVER_COMMON_UTIL_FILES})
+  add_library(xdp_aie_trace_plugin SHARED ${AIE_TRACE_PLUGIN_FILES} ${AIE_TRACE_COMPONENT_FILES} ${AIE_TRACE_UTIL_FILES} ${AIE_DRIVER_COMMON_UTIL_FILES})
   add_dependencies(xdp_aie_trace_plugin xdp_core xrt_coreutil)
   target_link_libraries(xdp_aie_trace_plugin PRIVATE xdp_core xrt_coreutil xaiengine)
   target_compile_definitions(xdp_aie_trace_plugin PRIVATE XDP_CLIENT_BUILD=1 -DXAIE_FEATURE_MSVC)
@@ -52,7 +52,7 @@ if (XDP_CLIENT_BUILD_CMAKE STREQUAL "yes")
   set_target_properties(xdp_aie_trace_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
 
   install (TARGETS xdp_aie_trace_plugin
-    LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT}
+    LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT} NAMELINK_SKIP
   )
 
 elseif (DEFINED XRT_AIE_BUILD AND (NOT XRT_EDGE))
@@ -69,14 +69,14 @@ elseif (DEFINED XRT_AIE_BUILD AND (NOT XRT_EDGE))
     "${IMPL_DIR}/*.cpp"
   )
 
-  add_library(xdp_aie_trace_plugin MODULE ${AIE_TRACE_PLUGIN_FILES} ${AIE_TRACE_COMPONENT_FILES})
+  add_library(xdp_aie_trace_plugin SHARED ${AIE_TRACE_PLUGIN_FILES} ${AIE_TRACE_COMPONENT_FILES})
   add_dependencies(xdp_aie_trace_plugin xdp_core xrt_coreutil)
   target_link_libraries(xdp_aie_trace_plugin PRIVATE xdp_core xrt_coreutil)
   target_compile_definitions(xdp_aie_trace_plugin PRIVATE XRT_X86_BUILD=1)
   set_target_properties(xdp_aie_trace_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
 
   install (TARGETS xdp_aie_trace_plugin
-    LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT}
+    LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT} NAMELINK_SKIP
   )  
 
 else()
@@ -94,7 +94,7 @@ else()
       "${IMPL_DIR}/*.cpp"
     )
 
-    add_library(xdp_aie_trace_plugin_xdna MODULE ${AIE_TRACE_PLUGIN_FILES} ${AIE_TRACE_COMPONENT_FILES} ${AIE_TRACE_UTIL_FILES} ${AIE_TRACE_CONFIG_FILES})
+    add_library(xdp_aie_trace_plugin_xdna SHARED ${AIE_TRACE_PLUGIN_FILES} ${AIE_TRACE_COMPONENT_FILES} ${AIE_TRACE_UTIL_FILES} ${AIE_TRACE_CONFIG_FILES})
     add_dependencies(xdp_aie_trace_plugin_xdna xdp_core xrt_coreutil)
     target_link_libraries(xdp_aie_trace_plugin_xdna PRIVATE xdp_core xrt_coreutil xaiengine)
     target_compile_definitions(xdp_aie_trace_plugin_xdna PRIVATE XDP_VE2_BUILD=1 FAL_LINUX="on")
@@ -102,7 +102,7 @@ else()
     set_target_properties(xdp_aie_trace_plugin_xdna PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
 
     install (TARGETS xdp_aie_trace_plugin_xdna
-      LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT}
+      LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT} NAMELINK_SKIP
     )
   endif()
     
@@ -120,7 +120,7 @@ else()
       "${IMPL_DIR}/*.cpp"
     )
 
-    add_library(xdp_aie_trace_plugin MODULE ${AIE_TRACE_PLUGIN_FILES} ${AIE_TRACE_COMPONENT_FILES} ${AIE_TRACE_UTIL_FILES} ${AIE_TRACE_CONFIG_FILES})
+    add_library(xdp_aie_trace_plugin SHARED ${AIE_TRACE_PLUGIN_FILES} ${AIE_TRACE_COMPONENT_FILES} ${AIE_TRACE_UTIL_FILES} ${AIE_TRACE_CONFIG_FILES})
     add_dependencies(xdp_aie_trace_plugin xdp_core xrt_coreutil)
     target_link_libraries(xdp_aie_trace_plugin PRIVATE xdp_core xrt_coreutil xaiengine)
     if (XDP_VE2_BUILD_CMAKE STREQUAL "yes")
@@ -131,7 +131,7 @@ else()
     set_target_properties(xdp_aie_trace_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
 
     install (TARGETS xdp_aie_trace_plugin
-      LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT}
+      LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT} NAMELINK_SKIP
     )
   endif()
 

--- a/src/runtime_src/xdp/profile/plugin/device_offload/hal/CMakeLists.txt
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/hal/CMakeLists.txt
@@ -19,12 +19,12 @@ file(GLOB HAL_DEVICE_OFFLOAD_PLUGIN_FILES
   "${PROFILE_DIR}/writer/device_trace/*.cpp"
 )
 
-add_library(xdp_hal_device_offload_plugin MODULE ${HAL_DEVICE_OFFLOAD_PLUGIN_FILES})
+add_library(xdp_hal_device_offload_plugin SHARED ${HAL_DEVICE_OFFLOAD_PLUGIN_FILES})
 add_dependencies(xdp_hal_device_offload_plugin xdp_core xrt_core xrt_coreutil)
 target_link_libraries(xdp_hal_device_offload_plugin PRIVATE xdp_core xrt_core xrt_coreutil)
 
 set_target_properties(xdp_hal_device_offload_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
 
 install (TARGETS xdp_hal_device_offload_plugin
-  LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT}
+  LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT} NAMELINK_SKIP
 )

--- a/src/runtime_src/xdp/profile/plugin/device_offload/hw_emu/CMakeLists.txt
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/hw_emu/CMakeLists.txt
@@ -20,7 +20,7 @@ file(GLOB HW_EMU_DEVICE_OFFLOAD_PLUGIN_FILES
   "${PROFILE_DIR}/writer/device_trace/*.cpp"
 )
 
-add_library(xdp_hw_emu_device_offload_plugin MODULE ${HW_EMU_DEVICE_OFFLOAD_PLUGIN_FILES})
+add_library(xdp_hw_emu_device_offload_plugin SHARED ${HW_EMU_DEVICE_OFFLOAD_PLUGIN_FILES})
 add_dependencies(xdp_hw_emu_device_offload_plugin xdp_core xrt_coreutil xrt_hwemu)
 target_link_libraries(xdp_hw_emu_device_offload_plugin PRIVATE xdp_core xrt_coreutil xrt_hwemu)
 target_compile_definitions(xdp_hw_emu_device_offload_plugin PRIVATE XDP_HWEMU_USING_HAL_BUILD=1)
@@ -28,5 +28,5 @@ target_compile_definitions(xdp_hw_emu_device_offload_plugin PRIVATE XDP_HWEMU_US
 set_target_properties(xdp_hw_emu_device_offload_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
 
 install (TARGETS xdp_hw_emu_device_offload_plugin
-  LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT}
+  LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT} NAMELINK_SKIP
 )

--- a/src/runtime_src/xdp/profile/plugin/device_offload/opencl/CMakeLists.txt
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/opencl/CMakeLists.txt
@@ -17,12 +17,12 @@ file(GLOB OPENCL_DEVICE_OFFLOAD_PLUGIN_FILES
   "${PROFILE_DIR}/writer/device_trace/*.cpp"
 )
 
-add_library(xdp_device_offload_plugin MODULE ${OPENCL_DEVICE_OFFLOAD_PLUGIN_FILES})
+add_library(xdp_device_offload_plugin SHARED ${OPENCL_DEVICE_OFFLOAD_PLUGIN_FILES})
 add_dependencies(xdp_device_offload_plugin xdp_core xilinxopencl xrt_coreutil)
 target_link_libraries(xdp_device_offload_plugin PRIVATE xdp_core xilinxopencl xrt_coreutil)
 
 set_target_properties(xdp_device_offload_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
 
 install (TARGETS xdp_device_offload_plugin
-  LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT}
+  LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT} NAMELINK_SKIP
 )

--- a/src/runtime_src/xdp/profile/plugin/hal/CMakeLists.txt
+++ b/src/runtime_src/xdp/profile/plugin/hal/CMakeLists.txt
@@ -14,12 +14,12 @@ file(GLOB HAL_PLUGIN_FILES
   "${PROFILE_DIR}/writer/hal/*.cpp"
 )
 
-add_library(xdp_hal_plugin MODULE ${HAL_PLUGIN_FILES})
+add_library(xdp_hal_plugin SHARED ${HAL_PLUGIN_FILES})
 add_dependencies(xdp_hal_plugin xdp_core xrt_coreutil)
 target_link_libraries(xdp_hal_plugin PRIVATE xdp_core xrt_coreutil)
 
 set_target_properties(xdp_hal_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
 
 install (TARGETS xdp_hal_plugin
-  LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT}
+  LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT} NAMELINK_SKIP
 )

--- a/src/runtime_src/xdp/profile/plugin/hal_api_interface/CMakeLists.txt
+++ b/src/runtime_src/xdp/profile/plugin/hal_api_interface/CMakeLists.txt
@@ -16,11 +16,11 @@ file(GLOB HAL_API_PLUGIN_FILES
   "${PROFILE_DIR}/plugin/hal_api_interface/*.cpp"
 )
 
-add_library(xdp_hal_api_interface_plugin MODULE ${HAL_API_PLUGIN_FILES})
+add_library(xdp_hal_api_interface_plugin SHARED ${HAL_API_PLUGIN_FILES})
 add_dependencies(xdp_hal_api_interface_plugin xdp_core xrt_core xrt_coreutil)
 target_link_libraries(xdp_hal_api_interface_plugin PRIVATE xdp_core xrt_core xrt_coreutil)
 
 set_target_properties(xdp_hal_api_interface_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
 
 install (TARGETS xdp_hal_api_interface_plugin
-  LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT})
+  LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT} NAMELINK_SKIP)

--- a/src/runtime_src/xdp/profile/plugin/lop/CMakeLists.txt
+++ b/src/runtime_src/xdp/profile/plugin/lop/CMakeLists.txt
@@ -14,10 +14,10 @@ file(GLOB LOP_PLUGIN_FILES
   "${PROFILE_DIR}/writer/lop/*.cpp"
 )
 
-add_library(xdp_lop_plugin MODULE ${LOP_PLUGIN_FILES})
+add_library(xdp_lop_plugin SHARED ${LOP_PLUGIN_FILES})
 add_dependencies(xdp_lop_plugin xdp_core xrt_coreutil)
 target_link_libraries(xdp_lop_plugin PRIVATE xdp_core xrt_coreutil)
 
 set_target_properties(xdp_lop_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
 
-install (TARGETS xdp_lop_plugin LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT})
+install (TARGETS xdp_lop_plugin LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT} NAMELINK_SKIP)

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/CMakeLists.txt
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/CMakeLists.txt
@@ -23,7 +23,7 @@ file(GLOB ML_TIMELINE_PLUGIN_FILES
 )
 
 if (XDP_CLIENT_BUILD_CMAKE STREQUAL "yes")
-  add_library(xdp_ml_timeline_plugin MODULE ${ML_TIMELINE_PLUGIN_FILES})
+  add_library(xdp_ml_timeline_plugin SHARED ${ML_TIMELINE_PLUGIN_FILES})
   add_dependencies(xdp_ml_timeline_plugin xdp_core xrt_coreutil)
 
   target_link_libraries(xdp_ml_timeline_plugin PRIVATE xdp_core xrt_coreutil)
@@ -33,12 +33,12 @@ if (XDP_CLIENT_BUILD_CMAKE STREQUAL "yes")
   set_target_properties(xdp_ml_timeline_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
 
   install (TARGETS xdp_ml_timeline_plugin
-    LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT}
+    LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT} NAMELINK_SKIP
   )
 
 elseif (XDP_VE2_BUILD_CMAKE STREQUAL "yes")
 
-add_library(xdp_ml_timeline_plugin MODULE ${ML_TIMELINE_PLUGIN_FILES})
+add_library(xdp_ml_timeline_plugin SHARED ${ML_TIMELINE_PLUGIN_FILES})
 add_dependencies(xdp_ml_timeline_plugin xdp_core xrt_coreutil)
 
 target_link_libraries(xdp_ml_timeline_plugin PRIVATE xdp_core xrt_coreutil)
@@ -48,7 +48,7 @@ target_compile_definitions(xdp_ml_timeline_plugin PRIVATE XDP_VE2_BUILD=1)
 set_target_properties(xdp_ml_timeline_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
 
 install (TARGETS xdp_ml_timeline_plugin
-  LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT}
+  LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT} NAMELINK_SKIP
 )
 
 endif()

--- a/src/runtime_src/xdp/profile/plugin/native/CMakeLists.txt
+++ b/src/runtime_src/xdp/profile/plugin/native/CMakeLists.txt
@@ -14,12 +14,12 @@ file(GLOB NATIVE_PLUGIN_FILES
   "${PROFILE_DIR}/writer/native/*.cpp"
 )
 
-add_library(xdp_native_plugin MODULE ${NATIVE_PLUGIN_FILES})
+add_library(xdp_native_plugin SHARED ${NATIVE_PLUGIN_FILES})
 add_dependencies(xdp_native_plugin xdp_core xrt_coreutil)
 target_link_libraries(xdp_native_plugin PRIVATE xdp_core xrt_coreutil)
 
 set_target_properties(xdp_native_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
 
 install (TARGETS xdp_native_plugin
-  LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT}
+  LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT} NAMELINK_SKIP
 )

--- a/src/runtime_src/xdp/profile/plugin/noc/CMakeLists.txt
+++ b/src/runtime_src/xdp/profile/plugin/noc/CMakeLists.txt
@@ -14,12 +14,12 @@ file(GLOB NOC_PLUGIN_FILES
   "${PROFILE_DIR}/writer/noc/*.cpp"
 )
 
-add_library(xdp_noc_plugin MODULE ${NOC_PLUGIN_FILES})
+add_library(xdp_noc_plugin SHARED ${NOC_PLUGIN_FILES})
 add_dependencies(xdp_noc_plugin xdp_core xrt_core)
 target_link_libraries(xdp_noc_plugin PRIVATE xdp_core xrt_core)
 
 set_target_properties(xdp_noc_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
 
 install (TARGETS xdp_noc_plugin
-  LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT}
+  LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT} NAMELINK_SKIP
 )

--- a/src/runtime_src/xdp/profile/plugin/opencl/counters/CMakeLists.txt
+++ b/src/runtime_src/xdp/profile/plugin/opencl/counters/CMakeLists.txt
@@ -12,12 +12,12 @@ file(GLOB OPENCL_COUNTERS_PLUGIN_FILES
   "${PROFILE_DIR}/plugin/opencl/counters/*.cpp"
 )
 
-add_library(xdp_opencl_counters_plugin MODULE ${OPENCL_COUNTERS_PLUGIN_FILES})
+add_library(xdp_opencl_counters_plugin SHARED ${OPENCL_COUNTERS_PLUGIN_FILES})
 add_dependencies(xdp_opencl_counters_plugin xdp_core xrt_coreutil xilinxopencl)
 target_link_libraries(xdp_opencl_counters_plugin PRIVATE xdp_core xrt_coreutil xilinxopencl)
 
 set_target_properties(xdp_opencl_counters_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
 
 install (TARGETS xdp_opencl_counters_plugin
-  LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT}
+  LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT} NAMELINK_SKIP
 )

--- a/src/runtime_src/xdp/profile/plugin/opencl/trace/CMakeLists.txt
+++ b/src/runtime_src/xdp/profile/plugin/opencl/trace/CMakeLists.txt
@@ -14,12 +14,12 @@ file(GLOB OPENCL_TRACE_PLUGIN_FILES
   "${PROFILE_DIR}/writer/opencl/*.cpp"
 )
 
-add_library(xdp_opencl_trace_plugin MODULE ${OPENCL_TRACE_PLUGIN_FILES})
+add_library(xdp_opencl_trace_plugin SHARED ${OPENCL_TRACE_PLUGIN_FILES})
 add_dependencies(xdp_opencl_trace_plugin xdp_core xrt_coreutil)
 target_link_libraries(xdp_opencl_trace_plugin PRIVATE xdp_core xrt_coreutil)
 
 set_target_properties(xdp_opencl_trace_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
 
 install (TARGETS xdp_opencl_trace_plugin
-  LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT}
+  LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT} NAMELINK_SKIP
 )

--- a/src/runtime_src/xdp/profile/plugin/pl_deadlock/CMakeLists.txt
+++ b/src/runtime_src/xdp/profile/plugin/pl_deadlock/CMakeLists.txt
@@ -18,14 +18,14 @@ file(GLOB PL_DEADLOCK_PLUGIN_FILES
   "${PROFILE_DIR}/writer/pl_deadlock/*.cpp"
 )
 
-add_library(xdp_pl_deadlock_plugin MODULE ${PL_DEADLOCK_PLUGIN_FILES})
+add_library(xdp_pl_deadlock_plugin SHARED ${PL_DEADLOCK_PLUGIN_FILES})
 add_dependencies(xdp_pl_deadlock_plugin xdp_core xrt_core xrt_coreutil)
 target_link_libraries(xdp_pl_deadlock_plugin PRIVATE xdp_core xrt_core xrt_coreutil)
 
 set_target_properties(xdp_pl_deadlock_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
 
 install (TARGETS xdp_pl_deadlock_plugin
-  LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT}
+  LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT} NAMELINK_SKIP
 )
 
 if (NOT WIN32)
@@ -35,14 +35,14 @@ file(GLOB HW_EMU_PL_DEADLOCK_PLUGIN_FILES
   "${PROFILE_DIR}/plugin/pl_deadlock/hw_emu/*.cpp"
 )
 
-add_library(xdp_hw_emu_pl_deadlock_plugin MODULE ${HW_EMU_PL_DEADLOCK_PLUGIN_FILES})
+add_library(xdp_hw_emu_pl_deadlock_plugin SHARED ${HW_EMU_PL_DEADLOCK_PLUGIN_FILES})
 add_dependencies(xdp_hw_emu_pl_deadlock_plugin xdp_core xrt_coreutil xrt_hwemu)
 target_link_libraries(xdp_hw_emu_pl_deadlock_plugin PRIVATE xdp_core xrt_coreutil xrt_hwemu)
 
 set_target_properties(xdp_hw_emu_pl_deadlock_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
 
 install (TARGETS xdp_hw_emu_pl_deadlock_plugin
-  LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT}
+  LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT} NAMELINK_SKIP
 )
 
 endif()

--- a/src/runtime_src/xdp/profile/plugin/power/CMakeLists.txt
+++ b/src/runtime_src/xdp/profile/plugin/power/CMakeLists.txt
@@ -14,12 +14,12 @@ file(GLOB POWER_PLUGIN_FILES
   "${PROFILE_DIR}/writer/power/*.cpp"
 )
 
-add_library(xdp_power_plugin MODULE ${POWER_PLUGIN_FILES})
+add_library(xdp_power_plugin SHARED ${POWER_PLUGIN_FILES})
 add_dependencies(xdp_power_plugin xdp_core xrt_core)
 target_link_libraries(xdp_power_plugin PRIVATE xdp_core xrt_core)
 
 set_target_properties(xdp_power_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
 
 install (TARGETS xdp_power_plugin
-  LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT}
+  LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT} NAMELINK_SKIP
 )

--- a/src/runtime_src/xdp/profile/plugin/system_compiler/CMakeLists.txt
+++ b/src/runtime_src/xdp/profile/plugin/system_compiler/CMakeLists.txt
@@ -11,11 +11,11 @@ file(GLOB SYSTEM_COMPILER_PLUGIN_FILES
   "${PROFILE_DIR}/plugin/system_compiler/*.cpp"
 )
 
-add_library(xdp_system_compiler_plugin MODULE ${SYSTEM_COMPILER_PLUGIN_FILES})
+add_library(xdp_system_compiler_plugin SHARED ${SYSTEM_COMPILER_PLUGIN_FILES})
 add_dependencies(xdp_system_compiler_plugin xdp_core)
 target_link_libraries(xdp_system_compiler_plugin PRIVATE xdp_core)
 
 set_target_properties(xdp_system_compiler_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
 
 install (TARGETS xdp_system_compiler_plugin
-  LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT})
+  LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT} NAMELINK_SKIP)

--- a/src/runtime_src/xdp/profile/plugin/user/CMakeLists.txt
+++ b/src/runtime_src/xdp/profile/plugin/user/CMakeLists.txt
@@ -14,12 +14,12 @@ file(GLOB USER_PLUGIN_FILES
   "${PROFILE_DIR}/writer/user/*.cpp"
 )
 
-add_library(xdp_user_plugin MODULE ${USER_PLUGIN_FILES})
+add_library(xdp_user_plugin SHARED ${USER_PLUGIN_FILES})
 add_dependencies(xdp_user_plugin xdp_core xrt_coreutil)
 target_link_libraries(xdp_user_plugin PRIVATE xdp_core xrt_coreutil)
 
 set_target_properties(xdp_user_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
 
 install (TARGETS xdp_user_plugin
-  LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT}
+  LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT} NAMELINK_SKIP
 )

--- a/src/runtime_src/xdp/profile/plugin/vart/CMakeLists.txt
+++ b/src/runtime_src/xdp/profile/plugin/vart/CMakeLists.txt
@@ -13,11 +13,11 @@ file(GLOB VART_PLUGIN_FILES
   "${PROFILE_DIR}/plugin/vart/*.cpp"
 )
 
-add_library(xdp_vart_plugin MODULE ${VART_PLUGIN_FILES})
+add_library(xdp_vart_plugin SHARED ${VART_PLUGIN_FILES})
 add_dependencies(xdp_vart_plugin xdp_core)
 target_link_libraries(xdp_vart_plugin PRIVATE xdp_core)
 
 set_target_properties(xdp_vart_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
 
 install (TARGETS xdp_vart_plugin
-  LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT})
+  LIBRARY DESTINATION ${XDP_PLUGIN_INSTALL_DIR} COMPONENT ${XRT_COMPONENT} NAMELINK_SKIP)


### PR DESCRIPTION
#### Problem solved by the commit
The XDP plugin modules are currently built as modules, which do not incorporate the XRT major version in their name.  CMake explicitly does not add versioning to modules, but it is a necessary aspect of the XRT code base.  This changes the modules to shared libraries with the major number as part of the name and changes the loading to recognize the new name.

Additionally, this pull request adds the capability to load a few plugins from an SDK location separate from the XRT install on Client Windows machines.

#### Risks (if any) associated the changes in the commit
Low risk as the implementation remains the same, just the packaging and naming of the built .so files.

#### What has been tested and how, request additional testing if necessary
The loading of the newly created .so files has been tested on Edge and the loading of .dlls from the SDK install has been tested on Client Windows.

#### Documentation impact (if any)
No documentation impact.