### PR TITLE
core: common: xrt_error: fix error string boost format

### DIFF
--- a/src/runtime_src/core/common/api/xrt_error.cpp
+++ b/src/runtime_src/core/common/api/xrt_error.cpp
@@ -267,7 +267,7 @@ public:
 
     auto fmt = boost::format
       ("%s\n"
-       "Timestamp: %s")
+       "Timestamp: %s: %s")
       % error_code_to_string(m_errcode)
       % error_time_to_string(m_timestamp)
       % m_ex_error_str;


### PR DESCRIPTION
Add missing %s to the boost format of the error string to fix the boost runtime error:
boost::too_many_args: format-string referred to fewer arguments than were passed

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
