### PR TITLE
[XRT-SMI]Watch mode flag propagation to driver

### DIFF
--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -4158,7 +4158,7 @@ struct event_trace_data : request
   static const key_type key = key_type::event_trace_data;
 
   std::any
-  get(const device*) const override = 0;
+  get(const device*, const std::any&) const override = 0;
 
 };
 
@@ -4205,7 +4205,7 @@ struct firmware_log_data : request
   static const key_type key = key_type::firmware_log_data;
 
   std::any
-  get(const device*) const override = 0;
+  get(const device*, const std::any&) const override = 0;
 };
 
 struct firmware_log_state : request

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -4158,6 +4158,9 @@ struct event_trace_data : request
   static const key_type key = key_type::event_trace_data;
 
   std::any
+  get(const device*) const override = 0;
+
+  std::any
   get(const device*, const std::any&) const override = 0;
 
 };
@@ -4203,6 +4206,9 @@ struct firmware_log_data : request
 {
   using result_type = firmware_debug_buffer;
   static const key_type key = key_type::firmware_log_data;
+
+  std::any
+  get(const device*) const override = 0;
 
   std::any
   get(const device*, const std::any&) const override = 0;

--- a/src/runtime_src/core/tools/common/SmiWatchMode.cpp
+++ b/src/runtime_src/core/tools/common/SmiWatchMode.cpp
@@ -102,10 +102,9 @@ parse_watch_mode_options(const std::vector<std::string>& elements_filter)
 void 
 smi_watch_mode::
 run_watch_mode(const xrt_core::device* device,
-                               const std::vector<std::string>& elements_filter,
-                               std::ostream& output,
-                               const ReportGenerator& report_generator,
-                               const std::string& report_title)
+               std::ostream& output,
+               const ReportGenerator& report_generator,
+               const std::string& report_title)
 {
   if (!device || !report_generator) {
     output << "Error: Invalid device or report generator provided to watch mode\n";
@@ -123,13 +122,10 @@ run_watch_mode(const xrt_core::device* device,
   signal_handler::reset_interrupt();
   std::string last_report;
   
-  // Filter out watch-specific options for the report generator
-  auto filtered_elements = filter_out_watch_options(elements_filter);
-  
   while (signal_handler::active()) {
     try {
       // Generate current report
-      std::string current_report = report_generator(device, filtered_elements);
+      std::string current_report = report_generator(device);
       
       // Only update display if content has changed
       if (current_report != last_report) {
@@ -157,20 +153,3 @@ run_watch_mode(const xrt_core::device* device,
   // Restore original signal handler
   signal_handler::restore();
 }
-
-std::vector<std::string> 
-smi_watch_mode::
-filter_out_watch_options(const std::vector<std::string>& elements_filter)
-{
-  std::vector<std::string> filtered;
-  filtered.reserve(elements_filter.size());
-  
-  std::copy_if(elements_filter.begin(), elements_filter.end(),
-               std::back_inserter(filtered),
-               [](const std::string& filter) {
-                 return !(filter == "watch" || filter.find("watch=") == 0);
-               });
-  
-  return filtered;
-}
-

--- a/src/runtime_src/core/tools/common/SmiWatchMode.h
+++ b/src/runtime_src/core/tools/common/SmiWatchMode.h
@@ -49,7 +49,7 @@ public:
    * - Return formatted string ready for display
    * - Handle any exceptions internally (return error message if needed)
    */
-  using ReportGenerator = std::function<std::string(const xrt_core::device*, const std::vector<std::string>&)>;
+  using ReportGenerator = std::function<std::string(const xrt_core::device*)>;
 
   /**
    * @brief Parse watch mode options from element filters
@@ -92,27 +92,7 @@ public:
    */
   static void 
   run_watch_mode(const xrt_core::device* device,
-                            const std::vector<std::string>& elements_filter,
-                            std::ostream& output,
-                            const ReportGenerator& report_generator,
-                            const std::string& report_title = "Report");
-
-  /**
-   * @brief Filter out watch-specific options from element filters
-   * 
-   * @param elements_filter Input element filters that may contain watch options
-   * @return New vector with watch-specific options removed
-   * 
-   * Removes the following patterns:
-   * - "watch" - Simple watch mode activation
-   * - "watch=<value>" - Watch mode with custom options (future extension)
-   * 
-   * This allows the filtered list to be passed to report generators
-   * without them needing to handle watch-specific syntax.
-   * 
-   * @note The returned vector may be smaller than the input
-   * @note Original vector is not modified (returns new vector)
-   */
-  static std::vector<std::string> 
-  filter_out_watch_options(const std::vector<std::string>& elements_filter);
+                 std::ostream& output,
+                 const ReportGenerator& report_generator,
+                 const std::string& report_title = "Report");
 };

--- a/src/runtime_src/core/tools/xbutil2/ReportEventTrace.cpp
+++ b/src/runtime_src/core/tools/xbutil2/ReportEventTrace.cpp
@@ -243,12 +243,11 @@ writeReport(const xrt_core::device* device,
   // Check for watch mode
   if (smi_watch_mode::parse_watch_mode_options(elements_filter)) {
     // Create report generator lambda for watch mode
-    auto report_generator = [](const xrt_core::device* dev, const std::vector<std::string>& filters) -> std::string {
+    auto report_generator = [](const xrt_core::device* dev) -> std::string {
       return generate_event_trace_report(dev, true); 
     };
 
-    smi_watch_mode::run_watch_mode(device, elements_filter, output,
-                                  report_generator, "Event Trace");
+    smi_watch_mode::run_watch_mode(device, output, report_generator, "Event Trace");
     return;
   }
   output << "Event Trace Report\n";

--- a/src/runtime_src/core/tools/xbutil2/ReportEventTrace.cpp
+++ b/src/runtime_src/core/tools/xbutil2/ReportEventTrace.cpp
@@ -148,7 +148,7 @@ validate_version_compatibility(const std::pair<uint16_t, uint16_t>& version,
 
 static std::string
 generate_event_trace_report(const xrt_core::device* dev,
-                            const std::vector<std::string>& /*elements_filter*/)
+                            bool is_watch)
 {
   std::stringstream ss{};
   
@@ -160,7 +160,7 @@ generate_event_trace_report(const xrt_core::device* dev,
     validate_version_compatibility(version, dev);
 
     // Query event trace data from device using specific query struct
-    auto log_buffer = xrt_core::device_query<xrt_core::query::event_trace_data>(dev);
+    auto log_buffer = xrt_core::device_query<xrt_core::query::event_trace_data>(dev, is_watch);
     
     ss << boost::format("Event Trace Report (Buffer: %d bytes) - %s\n") 
           % log_buffer.size % xrt_core::timestamp();
@@ -244,7 +244,7 @@ writeReport(const xrt_core::device* device,
   if (smi_watch_mode::parse_watch_mode_options(elements_filter)) {
     // Create report generator lambda for watch mode
     auto report_generator = [](const xrt_core::device* dev, const std::vector<std::string>& filters) -> std::string {
-      return generate_event_trace_report(dev, filters); 
+      return generate_event_trace_report(dev, true); 
     };
 
     smi_watch_mode::run_watch_mode(device, elements_filter, output,
@@ -253,6 +253,6 @@ writeReport(const xrt_core::device* device,
   }
   output << "Event Trace Report\n";
   output << "==================\n\n";
-  output << generate_event_trace_report(device, elements_filter);
+  output << generate_event_trace_report(device, false);
   output << std::endl;
 }

--- a/src/runtime_src/core/tools/xbutil2/ReportFirmwareLog.cpp
+++ b/src/runtime_src/core/tools/xbutil2/ReportFirmwareLog.cpp
@@ -113,14 +113,14 @@ parse_log_entry(const uint8_t* data_ptr,
 
 static std::string
 generate_firmware_log_report(const xrt_core::device* dev,
-                             const std::vector<std::string>& /*elements_filter*/)
+                             bool is_watch)
 {
   std::stringstream ss;
 
   // Load config once (could be cached in a real implementation)
   std::string config_path;
   try {
-    config_path = xrt_core::device_query<xrt_core::query::firmware_log_config>(dev);
+    config_path = xrt_core::device_query<xrt_core::query::firmware_log_config>(dev, is_watch);
   } catch (const std::exception& e) {
     ss << "Error retrieving firmware log config path: " << e.what() << "\n";
     return ss.str();
@@ -192,7 +192,7 @@ writeReport(const xrt_core::device* device,
   // Check for watch mode
   if (smi_watch_mode::parse_watch_mode_options(elements_filter)) {
     auto report_generator = [](const xrt_core::device* dev, const std::vector<std::string>& filters) -> std::string {
-      return xrt_core::tools::xrt_smi::generate_firmware_log_report(dev, filters);
+      return xrt_core::tools::xrt_smi::generate_firmware_log_report(dev, true);
     };
     smi_watch_mode::run_watch_mode(device, elements_filter, output,
                                    report_generator, "Firmware Log");
@@ -202,7 +202,7 @@ writeReport(const xrt_core::device* device,
   // Non-watch mode
   output << "Firmware Log Report\n";
   output << "===================\n\n";
-  output << xrt_core::tools::xrt_smi::generate_firmware_log_report(device, elements_filter);
+  output << xrt_core::tools::xrt_smi::generate_firmware_log_report(device, false);
   output << std::endl;
 }
 

--- a/src/runtime_src/core/tools/xbutil2/ReportFirmwareLog.cpp
+++ b/src/runtime_src/core/tools/xbutil2/ReportFirmwareLog.cpp
@@ -191,11 +191,10 @@ writeReport(const xrt_core::device* device,
 {
   // Check for watch mode
   if (smi_watch_mode::parse_watch_mode_options(elements_filter)) {
-    auto report_generator = [](const xrt_core::device* dev, const std::vector<std::string>& filters) -> std::string {
+    auto report_generator = [](const xrt_core::device* dev) -> std::string {
       return xrt_core::tools::xrt_smi::generate_firmware_log_report(dev, true);
     };
-    smi_watch_mode::run_watch_mode(device, elements_filter, output,
-                                   report_generator, "Firmware Log");
+    smi_watch_mode::run_watch_mode(device, output, report_generator, "Firmware Log");
     return;
   }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
The driver needs to be aware of whether xrt-smi examine is running in watch mode or not. The driver will wait if there are no events to be logged by the firmware in watch mode.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
None

#### How problem was solved, alternative solutions (if any) and why they were rejected
Changing the interface to pass down watch mode flag from query. This flag will be consumed by driver IOCTL

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Not tested. Still in development 

#### Documentation impact (if any)
None
