### PR TITLE
Setting this macro XDNA_VE2 to enable validate commands for Telluride

### DIFF
--- a/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
@@ -73,7 +73,7 @@ endif()
 add_executable(${XBUTIL2_NAME} ${XBUTIL_V2_SRCS})
 
 # Determine what functionality should be added
-if (NOT XRT_EDGE)
+if (NOT XRT_EDGE OR DEFINED XDNA_VE2)
   target_compile_definitions(${XBUTIL2_NAME} PRIVATE ENABLE_NATIVE_SUBCMDS_AND_REPORTS)
 else()
   target_compile_definitions(${XBUTIL2_NAME} PRIVATE ENABLE_DEFAULT_ONE_DEVICE_OPTION)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Setting this macro XDNA_VE2 to enable validate commands for Telluride. By defualt for edge cases validate commands are disabled. For telluride build we need this validate commands(xrt-smi validate) to be enabled
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit
low

#### What has been tested and how, request additional testing if necessary
Tested by building and running validate commands on Telluride
#### Documentation impact (if any)
NA