### PR TITLE
[XDP] Support subgraphs profiling graphs and kernel and new metadata handling

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info/aie_constructs.h
+++ b/src/runtime_src/xdp/profile/database/static_info/aie_constructs.h
@@ -515,7 +515,6 @@ namespace xdp {
     {}
   };
 
-
 } // end namespace xdp
 
 #endif

--- a/src/runtime_src/xdp/profile/database/static_info/aie_constructs.h
+++ b/src/runtime_src/xdp/profile/database/static_info/aie_constructs.h
@@ -515,6 +515,7 @@ namespace xdp {
     {}
   };
 
+
 } // end namespace xdp
 
 #endif

--- a/src/runtime_src/xdp/profile/database/static_info/aie_util.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info/aie_util.cpp
@@ -214,23 +214,6 @@ namespace xdp::aie {
   }
 
   /****************************************************************************
-   * Get all valid graph names from metadata
-   * NOTE: This is applicable only for aie_trace_config.json format till major v2.
-   *       Use latest version of AIETraceConfigFiletype for v3 and later.
-   ***************************************************************************/
-  std::vector<std::string>
-  getValidGraphs(const boost::property_tree::ptree& aie_meta,
-                const std::string& root)
-  {
-    std::vector<std::string> graphs;
-    for (auto& graph : aie_meta.get_child(root)) {
-      std::string graphName = graph.second.get<std::string>("name");
-      graphs.push_back(graphName);
-    }
-    return graphs;
-  }
-
-  /****************************************************************************
    * Read AIE metadata from axlf section
    ***************************************************************************/
   std::unique_ptr<xdp::aie::BaseFiletypeImpl>

--- a/src/runtime_src/xdp/profile/database/static_info/aie_util.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info/aie_util.cpp
@@ -12,6 +12,7 @@
 #include "core/common/query_requests.h"
 #include "filetypes/aie_control_config_filetype.h"
 #include "filetypes/aie_trace_config_filetype.h"
+#include "filetypes/aie_trace_config_v3_filetype.h"
 
 #include "core/common/api/xclbin_int.h"
 #include "core/include/xrt/detail/xclbin.h"
@@ -62,7 +63,9 @@ namespace xdp::aie {
     // aie_trace_config.json format
     try {
       int majorVersion = aie_project.get("schema_version.major", 1);
-      if (majorVersion == 2)
+      if (majorVersion == 3)
+        return std::make_unique<xdp::aie::AIETraceConfigV3Filetype>(aie_project);
+      else if (majorVersion == 2)
         return std::make_unique<xdp::aie::AIETraceConfigFiletype>(aie_project);
     }
     catch(...) {
@@ -212,6 +215,8 @@ namespace xdp::aie {
 
   /****************************************************************************
    * Get all valid graph names from metadata
+   * NOTE: This is applicable only for aie_trace_config.json format till major v2.
+   *       Use latest version of AIETraceConfigFiletype for v3 and later.
    ***************************************************************************/
   std::vector<std::string>
   getValidGraphs(const boost::property_tree::ptree& aie_meta,

--- a/src/runtime_src/xdp/profile/database/static_info/aie_util.h
+++ b/src/runtime_src/xdp/profile/database/static_info/aie_util.h
@@ -62,11 +62,6 @@ namespace xdp::aie {
                       const std::string& location);
   
   XDP_CORE_EXPORT
-  std::vector<std::string>
-  getValidGraphs(const boost::property_tree::ptree& aie_meta,
-                 const std::string& root);
-
-  XDP_CORE_EXPORT
   bool isInfoVerbosity();
 
   XDP_CORE_EXPORT

--- a/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_control_config_filetype.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_control_config_filetype.cpp
@@ -80,7 +80,7 @@ AIEControlConfigFiletype::getValidGraphs() const
 {
     std::vector<std::string> graphs;
     for (auto& graph : aie_meta.get_child("aie_metadata.graphs")) {
-        std::string graphName = graph.second.get<std::string>("name");
+        auto graphName = graph.second.get<std::string>("name");
         graphs.push_back(graphName);
     }
     return graphs;

--- a/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_control_config_filetype.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_control_config_filetype.cpp
@@ -78,7 +78,12 @@ AIEControlConfigFiletype::getPartitionOverlayStartCols() const {
 std::vector<std::string>
 AIEControlConfigFiletype::getValidGraphs() const
 {
-    return xdp::aie::getValidGraphs(aie_meta, "aie_metadata.graphs");
+    std::vector<std::string> graphs;
+    for (auto& graph : aie_meta.get_child("aie_metadata.graphs")) {
+        std::string graphName = graph.second.get<std::string>("name");
+        graphs.push_back(graphName);
+    }
+    return graphs;
 }
 
 std::vector<std::string>

--- a/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_trace_config_v3_filetype.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_trace_config_v3_filetype.cpp
@@ -36,7 +36,7 @@ AIETraceConfigV3Filetype::getValidKernels() const
     std::set<std::string> uniqueKernels; // Use set to avoid duplicates
 
     for (auto const &mapping : kernelToTileMapping.get()) {
-        std::string functionStr = mapping.second.get<std::string>("function");
+        auto functionStr = mapping.second.get<std::string>("function");
         if (functionStr.empty())
             continue;
 
@@ -74,7 +74,7 @@ AIETraceConfigV3Filetype::getValidGraphs() const
     std::set<std::string> uniqueGraphs; // Use set to avoid duplicates
 
     for (auto const &mapping : kernelToTileMapping.get()) {
-        std::string graphStr = mapping.second.get<std::string>("graph");
+        auto graphStr = mapping.second.get<std::string>("graph");
         if (graphStr.empty())
             continue;
 
@@ -120,8 +120,8 @@ AIETraceConfigV3Filetype::getTiles(const std::string& graph_name,
 
     // Parse all kernel mappings
     for (auto const &mapping : kernelToTileMapping.get()) {
-        std::string graphStr = mapping.second.get<std::string>("graph", "");
-        std::string functionStr = mapping.second.get<std::string>("function", "");
+        auto graphStr = mapping.second.get<std::string>("graph", "");
+        auto functionStr = mapping.second.get<std::string>("function", "");
         
         if (graphStr.empty() || functionStr.empty())
             continue;
@@ -153,8 +153,8 @@ AIETraceConfigV3Filetype::getTiles(const std::string& graph_name,
             
             // Always add DMA-only tiles at different coordinates (for both core and dma module types)
             if (dmaChannelsTree) {
-                uint8_t coreCol = mapping.second.get<uint8_t>("column");
-                uint8_t coreRow = mapping.second.get<uint8_t>("row") + rowOffset;
+                auto coreCol = mapping.second.get<uint8_t>("column");
+                auto coreRow = mapping.second.get<uint8_t>("row") + rowOffset;
                 
                 for (auto const &channel : dmaChannelsTree.get()) {
                     uint8_t dmaCol = xdp::aie::convertStringToUint8(channel.second.get<std::string>("column"));
@@ -226,21 +226,21 @@ bool AIETraceConfigV3Filetype::matchesKernelPattern(const std::string& function,
 // =================================================================
 
 std::vector<tile_type>
-AIETraceConfigV3Filetype::getAIETiles(const std::string& graphName) const
+AIETraceConfigV3Filetype::getAIETiles(const std::string&) const
 {
     throw std::runtime_error("getAIETiles() is not supported in V3 metadata format. "
                              "Use getTiles() with module_type::core instead.");
 }
 
 std::vector<tile_type>
-AIETraceConfigV3Filetype::getAllAIETiles(const std::string& graphName) const
+AIETraceConfigV3Filetype::getAllAIETiles(const std::string&) const
 {
     throw std::runtime_error("getAllAIETiles() is not supported in V3 metadata format. "
                              "Use getTiles() with module_type::core instead.");
 }
 
 std::vector<tile_type>
-AIETraceConfigV3Filetype::getEventTiles(const std::string& graph_name, module_type type) const
+AIETraceConfigV3Filetype::getEventTiles(const std::string&, module_type) const
 {
     throw std::runtime_error("getEventTiles() is not supported in V3 metadata format. "
                              "Use getTiles() with the appropriate module_type instead.");

--- a/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_trace_config_v3_filetype.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_trace_config_v3_filetype.cpp
@@ -221,4 +221,29 @@ bool AIETraceConfigV3Filetype::matchesKernelPattern(const std::string& function,
     return false;
 }
 
+// =================================================================
+// UNSUPPORTED METHODS - Throw runtime exceptions for V3 format
+// =================================================================
+
+std::vector<tile_type>
+AIETraceConfigV3Filetype::getAIETiles(const std::string& graphName) const
+{
+    throw std::runtime_error("getAIETiles() is not supported in V3 metadata format. "
+                             "Use getTiles() with module_type::core instead.");
+}
+
+std::vector<tile_type>
+AIETraceConfigV3Filetype::getAllAIETiles(const std::string& graphName) const
+{
+    throw std::runtime_error("getAllAIETiles() is not supported in V3 metadata format. "
+                             "Use getTiles() with module_type::core instead.");
+}
+
+std::vector<tile_type>
+AIETraceConfigV3Filetype::getEventTiles(const std::string& graph_name, module_type type) const
+{
+    throw std::runtime_error("getEventTiles() is not supported in V3 metadata format. "
+                             "Use getTiles() with the appropriate module_type instead.");
+}
+
 } // namespace xdp::aie

--- a/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_trace_config_v3_filetype.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_trace_config_v3_filetype.cpp
@@ -136,8 +136,8 @@ AIETraceConfigV3Filetype::getTiles(const std::string& graph_name,
             continue;
 
         // Get core tile location
-        uint8_t coreCol = mapping.second.get<uint8_t>("column");
-        uint8_t coreRow = mapping.second.get<uint8_t>("row") + rowOffset;
+        auto coreCol = mapping.second.get<uint8_t>("column");
+        auto coreRow = mapping.second.get<uint8_t>("row") + rowOffset;
 
         // Create or get existing core tile
         auto coreKey = std::make_pair(coreCol, coreRow);

--- a/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_trace_config_v3_filetype.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_trace_config_v3_filetype.cpp
@@ -1,0 +1,421 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved
+
+#define XDP_CORE_SOURCE
+
+#include "aie_trace_config_v3_filetype.h"
+#include "core/common/message.h"
+#include "xdp/profile/database/static_info/aie_util.h"
+#include "xdp/profile/plugin/vp_base/utility.h"
+
+#include <boost/algorithm/string.hpp>
+#include <boost/property_tree/json_parser.hpp>
+#include <boost/property_tree/ptree.hpp>
+#include <set>
+#include <algorithm>
+
+namespace xdp::aie {
+namespace pt = boost::property_tree;
+using severity_level = xrt_core::message::severity_level;
+
+AIETraceConfigV3Filetype::AIETraceConfigV3Filetype(boost::property_tree::ptree& aie_project)
+: AIETraceConfigFiletype(aie_project) {}
+
+std::vector<std::string>
+AIETraceConfigV3Filetype::getValidKernels() const
+{
+    std::vector<std::string> kernels;
+
+    // Grab all kernel to tile mappings
+    auto kernelToTileMapping = aie_meta.get_child_optional("aie_metadata.TileMapping.AIEKernelToTileMapping");
+    if (!kernelToTileMapping) {
+        xrt_core::message::send(severity_level::info, "XRT", getMessage("TileMapping.AIEKernelToTileMapping"));
+        return {};
+    }
+
+    std::set<std::string> uniqueKernels; // Use set to avoid duplicates
+
+    for (auto const &mapping : kernelToTileMapping.get()) {
+        std::string functionStr = mapping.second.get<std::string>("function");
+        if (functionStr.empty())
+            continue; // Skip empty function names
+
+        // Extract kernel names from function string
+        std::vector<std::string> names;
+        boost::split(names, functionStr, boost::is_any_of("."));
+        
+        // Add individual kernel components
+        for (const auto& name : names) {
+            if (!name.empty()) {
+                uniqueKernels.insert(name);
+            }
+        }
+
+        // Also store the complete function name
+        uniqueKernels.insert(functionStr);
+    }
+    
+    // Convert set to vector
+    kernels.assign(uniqueKernels.begin(), uniqueKernels.end());
+    return kernels;
+}
+
+std::vector<std::string>
+AIETraceConfigV3Filetype::getValidGraphs() const
+{
+    std::vector<std::string> graphs;
+
+    // Grab all kernel to tile mappings
+    auto kernelToTileMapping = aie_meta.get_child_optional("aie_metadata.TileMapping.AIEKernelToTileMapping");
+    if (!kernelToTileMapping) {
+        xrt_core::message::send(severity_level::info, "XRT", getMessage("TileMapping.AIEKernelToTileMapping"));
+        return {};
+    }
+
+    std::set<std::string> uniqueGraphs; // Use set to avoid duplicates
+
+    for (auto const &mapping : kernelToTileMapping.get()) {
+        std::string graphStr = mapping.second.get<std::string>("graph");
+        if (graphStr.empty())
+            continue; // Skip empty graph names
+
+        // Extract subgraph names from complete graph string
+        std::vector<std::string> names;
+        boost::split(names, graphStr, boost::is_any_of("."));
+        
+        // Add individual subgraph components
+        for (const auto& name : names) {
+            if (!name.empty()) {
+                uniqueGraphs.insert(name);
+            }
+        }
+
+        // Add the complete graph name
+        uniqueGraphs.insert(graphStr);
+    }
+    
+    // Convert set to vector
+    graphs.assign(uniqueGraphs.begin(), uniqueGraphs.end());
+    return graphs;
+}
+
+// Find all AIE or memory tiles associated with a graph and kernel/buffer
+//   kernel_name = all      : all tiles in graph
+//   kernel_name = <kernel> : only tiles used by that specific kernel
+std::vector<tile_type>
+AIETraceConfigV3Filetype::getTiles(const std::string& graph_name,
+                                 module_type type,
+                                 const std::string& kernel_name) const
+{
+    if (type == module_type::mem_tile)
+        return getMemoryTiles(graph_name, kernel_name);
+    
+    // For DMA type, we want tiles that have DMA channels (both core tiles and DMA-only)
+    if (type == module_type::dma) {
+        if (kernel_name == "all")
+            return getEventTiles(graph_name, type);
+        // For specific kernel, we need special logic to include DMA-only tiles
+        // Fall through to handle this case below
+    }
+    
+    // For core type or default, get tiles that use cores
+    if (type == module_type::core && kernel_name == "all")
+        return getAllAIETiles(graph_name);
+    
+    // Now search by graph-kernel pairs for specific kernel
+    auto kernelToTileMapping = aie_meta.get_child_optional("aie_metadata.TileMapping.AIEKernelToTileMapping");
+    if (!kernelToTileMapping) {
+        xrt_core::message::send(severity_level::info, "XRT", getMessage("TileMapping.AIEKernelToTileMapping"));
+        return {};
+    }
+
+    std::set<tile_type> uniqueTiles; // Use set to handle DMA-only tile uniqueness
+    auto rowOffset = getAIETileRowOffset();
+
+    // Parse all kernel mappings
+    for (auto const &mapping : kernelToTileMapping.get()) {
+        std::string graphStr = mapping.second.get<std::string>("graph", "");
+        std::string functionStr = mapping.second.get<std::string>("function", "");
+        
+        if (graphStr.empty() || functionStr.empty())
+            continue;
+
+        // Check if graph matches
+        bool foundGraph = (graph_name == "all") || (graphStr.find(graph_name) != std::string::npos);
+        if (!foundGraph)
+            continue;
+
+        // Check if kernel/function matches using precise pattern matching
+        bool foundKernel = (kernel_name == "all") || matchesKernelPattern(functionStr, kernel_name);
+
+        // Add tile if it matches the criteria
+        if (foundGraph && foundKernel) {
+            // Compute tile properties from metadata
+            std::string tileType = mapping.second.get<std::string>("tile", "");
+            bool isCoreUsed = (tileType == "aie");
+            
+            auto dmaChannelsTree = mapping.second.get_child_optional("dmaChannels");
+            bool isDMAUsed = (dmaChannelsTree && !dmaChannelsTree.get().empty());
+            
+            // Add core tile if it matches the requested module type
+            if ((type == module_type::core && isCoreUsed) || 
+                (type == module_type::dma && isDMAUsed)) {
+                tile_type tile;
+                tile.col = mapping.second.get<uint8_t>("column");
+                tile.row = mapping.second.get<uint8_t>("row") + rowOffset;
+                tile.active_core = isCoreUsed;
+                tile.active_memory = isDMAUsed;
+                uniqueTiles.insert(tile);
+            }
+            
+            // For DMA module type, also add DMA-only tiles at different coordinates
+            if (type == module_type::dma && dmaChannelsTree) {
+                uint8_t coreCol = mapping.second.get<uint8_t>("column");
+                uint8_t coreRow = mapping.second.get<uint8_t>("row") + rowOffset;
+                
+                for (auto const &channel : dmaChannelsTree.get()) {
+                    uint8_t dmaCol = xdp::aie::convertStringToUint8(channel.second.get<std::string>("column"));
+                    uint8_t dmaRow = xdp::aie::convertStringToUint8(channel.second.get<std::string>("row")) + rowOffset;
+
+                    // Check if this DMA channel is at a different location than the core
+                    if (dmaCol != coreCol || dmaRow != coreRow) {
+                        tile_type dmaTile;
+                        dmaTile.col = dmaCol;
+                        dmaTile.row = dmaRow;
+                        dmaTile.active_core = false;
+                        dmaTile.active_memory = true;
+                        uniqueTiles.insert(dmaTile);
+                    }
+                }
+            }
+        }
+    }
+    
+    // Convert set back to vector
+    return std::vector<tile_type>(uniqueTiles.begin(), uniqueTiles.end());
+}
+
+// Find all AIE tiles in a graph that use core and/or memories (kernel_name = all)
+std::vector<tile_type>
+AIETraceConfigV3Filetype::getAllAIETiles(const std::string& graph_name) const
+{
+    auto kernelToTileMapping = aie_meta.get_child_optional("aie_metadata.TileMapping.AIEKernelToTileMapping");
+    if (!kernelToTileMapping) {
+        xrt_core::message::send(severity_level::info, "XRT", getMessage("TileMapping.AIEKernelToTileMapping"));
+        return {};
+    }
+
+    std::set<tile_type> uniqueTiles;
+    auto rowOffset = getAIETileRowOffset();
+
+    for (auto const &mapping : kernelToTileMapping.get()) {
+        std::string graphStr = mapping.second.get<std::string>("graph");
+        if (graphStr.empty())
+            continue; // Skip empty graph names
+        
+        if ((graphStr.find(graph_name) == std::string::npos) && (graph_name.compare("all")) != 0)
+            continue; // Skip graphs/subgraphs that do not match the requested graph name
+
+        // Add core tile
+        tile_type coreTile;
+        coreTile.col = xdp::aie::convertStringToUint8(mapping.second.get<std::string>("column"));
+        coreTile.row = xdp::aie::convertStringToUint8(mapping.second.get<std::string>("row")) + rowOffset;
+        
+        // Compute tile properties from metadata
+        std::string tileType = mapping.second.get<std::string>("tile", "");
+        coreTile.active_core = (tileType == "aie");
+        
+        auto dmaChannelsTree = mapping.second.get_child_optional("dmaChannels");
+        coreTile.active_memory = (dmaChannelsTree && !dmaChannelsTree.get().empty());
+        
+        uniqueTiles.insert(coreTile);
+
+        // Add DMA-only tiles from dmaChannels that are at different coordinates than core tiles
+        if (dmaChannelsTree) {
+            for (auto const &channel : dmaChannelsTree.get()) {
+                uint8_t dmaCol = xdp::aie::convertStringToUint8(channel.second.get<std::string>("column"));
+                uint8_t dmaRow = xdp::aie::convertStringToUint8(channel.second.get<std::string>("row")) + rowOffset;
+
+                // Check if this DMA channel is at a different location than the core
+                if (dmaCol != coreTile.col || dmaRow != coreTile.row) {
+                    tile_type dmaTile;
+                    dmaTile.col = dmaCol;
+                    dmaTile.row = dmaRow;
+                    dmaTile.active_core = false;
+                    dmaTile.active_memory = true;
+                    uniqueTiles.insert(dmaTile); // Set automatically handles uniqueness
+                }
+            }
+        }
+    }
+ 
+    // Convert set back to vector
+    return std::vector<tile_type>(uniqueTiles.begin(), uniqueTiles.end());
+}
+
+// Find all AIE tiles in a graph that use the core (kernel_name = all)
+std::vector<tile_type> 
+AIETraceConfigV3Filetype::getAIETiles(const std::string& graph_name) const
+{   
+    auto kernelToTileMapping = aie_meta.get_child_optional("aie_metadata.TileMapping.AIEKernelToTileMapping");
+    if (!kernelToTileMapping) {
+        xrt_core::message::send(severity_level::info, "XRT", getMessage("TileMapping.AIEKernelToTileMapping"));
+        return {};
+    }
+
+    std::vector<tile_type> tiles;
+    auto rowOffset = getAIETileRowOffset();
+
+    for (auto const &mapping : kernelToTileMapping.get()) {
+        std::string graphStr = mapping.second.get<std::string>("graph", "");
+        if (graphStr.empty())
+            continue; // Skip empty graph names
+        
+        if ((graphStr.find(graph_name) == std::string::npos) && (graph_name.compare("all") != 0))
+            continue; // Skip graphs/subgraphs that do not match the requested graph name
+
+        // Compute isCoreUsed: true if tile type is "aie"
+        std::string tileType = mapping.second.get<std::string>("tile", "");
+        bool isCoreUsed = (tileType == "aie");
+        
+        // Skip tiles that do not use the core
+        if (!isCoreUsed)
+            continue;
+
+        tile_type tile;
+        tile.col = mapping.second.get<uint8_t>("column");
+        tile.row = mapping.second.get<uint8_t>("row") + rowOffset;
+        tile.active_core = isCoreUsed;
+        
+        // Compute isDMAUsed: true if tile has non-empty dmaChannels
+        auto dmaChannelsTree = mapping.second.get_child_optional("dmaChannels");
+        tile.active_memory = (dmaChannelsTree && !dmaChannelsTree.get().empty());
+        
+        tiles.push_back(tile);
+    }
+ 
+    return tiles;
+}
+
+// Find all AIE tiles in a graph that use the core or memory module (kernels = all)
+std::vector<tile_type>
+AIETraceConfigV3Filetype::getEventTiles(const std::string& graph_name,
+                                        module_type type) const
+{
+    if ((type == module_type::shim) || (type == module_type::mem_tile))
+        return {};
+
+    auto kernelToTileMapping = aie_meta.get_child_optional("aie_metadata.TileMapping.AIEKernelToTileMapping");
+    if (!kernelToTileMapping) {
+        xrt_core::message::send(severity_level::info, "XRT", getMessage("TileMapping.AIEKernelToTileMapping"));
+        return {};
+    }
+
+    // Use set to handle uniqueness, especially important for DMA tiles
+    std::set<tile_type> uniqueTiles;
+    auto rowOffset = getAIETileRowOffset();
+
+    for (auto const &mapping : kernelToTileMapping.get()) {
+        std::string graphStr = mapping.second.get<std::string>("graph", "");
+        if (graphStr.empty())
+            continue; // Skip empty graph names
+        
+        if ((graphStr.find(graph_name) == std::string::npos) && (graph_name.compare("all") != 0))
+            continue; // Skip graphs/subgraphs that do not match the requested graph name
+
+        // Compute isCoreUsed: true if tile type is "aie"
+        std::string tileType = mapping.second.get<std::string>("tile", "");
+        bool isCoreUsed = (tileType == "aie");
+        
+        // Compute isDMAUsed: true if tile has non-empty dmaChannels
+        auto dmaChannelsTree = mapping.second.get_child_optional("dmaChannels");
+        bool isDMAUsed = (dmaChannelsTree && !dmaChannelsTree.get().empty());
+        
+        // Filter based on the requested module type
+        bool includesTile = false;
+        if (type == module_type::core) {
+            includesTile = isCoreUsed;
+        } else if (type == module_type::dma) {
+            includesTile = isDMAUsed;
+        }
+        
+        // Skip tiles that do not match the requested module type
+        if (!includesTile)
+            continue;
+
+        // Add the core/mapped tile
+        tile_type tile;
+        tile.col = mapping.second.get<uint8_t>("column");
+        tile.row = mapping.second.get<uint8_t>("row") + rowOffset;
+        tile.active_core = isCoreUsed;
+        tile.active_memory = isDMAUsed;
+        uniqueTiles.insert(tile);
+
+        // For DMA module type, also add DMA-only tiles at different coordinates
+        if (type == module_type::dma && dmaChannelsTree) {
+            for (auto const &channel : dmaChannelsTree.get()) {
+                uint8_t dmaCol = xdp::aie::convertStringToUint8(channel.second.get<std::string>("column"));
+                uint8_t dmaRow = xdp::aie::convertStringToUint8(channel.second.get<std::string>("row")) + rowOffset;
+
+                // Check if this DMA channel is at a different location than the core
+                if (dmaCol != tile.col || dmaRow != tile.row) {
+                    tile_type dmaTile;
+                    dmaTile.col = dmaCol;
+                    dmaTile.row = dmaRow;
+                    dmaTile.active_core = false;
+                    dmaTile.active_memory = true;
+                    uniqueTiles.insert(dmaTile); // Set automatically handles uniqueness
+                }
+            }
+        }
+    }
+ 
+    // Convert set back to vector
+    return std::vector<tile_type>(uniqueTiles.begin(), uniqueTiles.end());
+}
+
+// Helper method to match kernel patterns with ordered substring matching
+bool AIETraceConfigV3Filetype::matchesKernelPattern(const std::string& function, const std::string& kernel_name) const
+{
+    if (kernel_name == "all" || kernel_name.empty()) {
+        return true;
+    }
+    
+    // Split function and kernel pattern by dots
+    std::vector<std::string> functionParts;
+    boost::split(functionParts, function, boost::is_any_of("."));
+    
+    std::vector<std::string> kernelParts;
+    boost::split(kernelParts, kernel_name, boost::is_any_of("."));
+    
+    // Remove empty parts
+    functionParts.erase(std::remove_if(functionParts.begin(), functionParts.end(), 
+                                      [](const std::string& s) { return s.empty(); }), 
+                       functionParts.end());
+    kernelParts.erase(std::remove_if(kernelParts.begin(), kernelParts.end(), 
+                                    [](const std::string& s) { return s.empty(); }), 
+                     kernelParts.end());
+    
+    // If kernel has more parts than function, it can't match
+    if (kernelParts.size() > functionParts.size()) {
+        return false;
+    }
+    
+    // Look for contiguous subsequence of kernel parts in function parts
+    for (size_t i = 0; i <= functionParts.size() - kernelParts.size(); ++i) {
+        bool matches = true;
+        for (size_t j = 0; j < kernelParts.size(); ++j) {
+            if (functionParts[i + j] != kernelParts[j]) {
+                matches = false;
+                break;
+            }
+        }
+        if (matches) {
+            return true;
+        }
+    }
+    
+    return false;
+}
+
+} // namespace xdp::aie

--- a/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_trace_config_v3_filetype.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_trace_config_v3_filetype.cpp
@@ -137,7 +137,7 @@ AIETraceConfigV3Filetype::getTiles(const std::string& graph_name,
 
         // Get core tile location
         auto coreCol = mapping.second.get<uint8_t>("column");
-        auto coreRow = mapping.second.get<uint8_t>("row") + rowOffset;
+        auto coreRow = static_cast<uint8_t>(mapping.second.get<uint8_t>("row") + rowOffset);
 
         // Create or get existing core tile
         auto coreKey = std::make_pair(coreCol, coreRow);
@@ -155,7 +155,7 @@ AIETraceConfigV3Filetype::getTiles(const std::string& graph_name,
         if (dmaChannelsTree) {
             for (auto const &channel : dmaChannelsTree.get()) {
                 uint8_t dmaCol = xdp::aie::convertStringToUint8(channel.second.get<std::string>("column"));
-                uint8_t dmaRow = xdp::aie::convertStringToUint8(channel.second.get<std::string>("row")) + rowOffset;
+                uint8_t dmaRow = static_cast<uint8_t>(xdp::aie::convertStringToUint8(channel.second.get<std::string>("row")) + rowOffset);
 
                 // If channel matches core tile location, add to core tile
                 if (dmaCol == coreCol && dmaRow == coreRow) {

--- a/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_trace_config_v3_filetype.h
+++ b/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_trace_config_v3_filetype.h
@@ -17,6 +17,11 @@ class AIETraceConfigV3Filetype : public AIETraceConfigFiletype {
         explicit AIETraceConfigV3Filetype(boost::property_tree::ptree& aie_project);
         ~AIETraceConfigV3Filetype() noexcept {}
 
+        AIETraceConfigV3Filetype(const AIETraceConfigV3Filetype&) = default;
+        AIETraceConfigV3Filetype& operator=(const AIETraceConfigV3Filetype&) = default;
+        AIETraceConfigV3Filetype(AIETraceConfigV3Filetype&&) = default;
+        AIETraceConfigV3Filetype& operator=(AIETraceConfigV3Filetype&&) = default;
+
         std::vector<std::string>
         getValidKernels() const override;
 

--- a/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_trace_config_v3_filetype.h
+++ b/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_trace_config_v3_filetype.h
@@ -15,7 +15,7 @@ namespace xdp::aie {
 class AIETraceConfigV3Filetype : public AIETraceConfigFiletype {
     public:
         explicit AIETraceConfigV3Filetype(boost::property_tree::ptree& aie_project);
-        ~AIETraceConfigV3Filetype() override = default;
+        ~AIETraceConfigV3Filetype() noexcept {}
 
         std::vector<std::string>
         getValidKernels() const override;

--- a/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_trace_config_v3_filetype.h
+++ b/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_trace_config_v3_filetype.h
@@ -28,8 +28,6 @@ class AIETraceConfigV3Filetype : public AIETraceConfigFiletype {
                  module_type type, 
                  const std::string& kernel_name = "all") const override;
         
-        std::vector<tile_type> 
-        getAIETiles(const std::string& graph_name) const override;
 
     private:
         // Helper method to match kernel patterns with ordered substring matching

--- a/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_trace_config_v3_filetype.h
+++ b/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_trace_config_v3_filetype.h
@@ -47,6 +47,9 @@ class AIETraceConfigV3Filetype : public AIETraceConfigFiletype {
     private:
         // Helper method to match kernel patterns with ordered substring matching
         bool matchesKernelPattern(const std::string& function, const std::string& kernel_name) const;
+
+        // Helper method to populate DMA channel names from metadata
+        void populateDMAChannelNames(tile_type& tile, const boost::property_tree::ptree& dmaChannels) const;
 };
 
 } // namespace xdp::aie

--- a/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_trace_config_v3_filetype.h
+++ b/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_trace_config_v3_filetype.h
@@ -27,7 +27,22 @@ class AIETraceConfigV3Filetype : public AIETraceConfigFiletype {
         getTiles(const std::string& graph_name,
                  module_type type, 
                  const std::string& kernel_name = "all") const override;
+
+        // =================================================================
+        // UNSUPPORTED METHODS - Not applicable to V3 metadata format
+        // =================================================================
+        // These methods are inherited from base classes but are not compatible
+        // with the V3 metadata structure. Use getTiles() with appropriate 
+        // module_type instead. They throw runtime exceptions if called.
         
+        std::vector<tile_type>
+        getAIETiles(const std::string& graphName) const override;
+
+        std::vector<tile_type>
+        getAllAIETiles(const std::string& graphName) const override;
+
+        std::vector<tile_type>
+        getEventTiles(const std::string& graph_name, module_type type) const override;
 
     private:
         // Helper method to match kernel patterns with ordered substring matching

--- a/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_trace_config_v3_filetype.h
+++ b/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_trace_config_v3_filetype.h
@@ -15,7 +15,7 @@ namespace xdp::aie {
 class AIETraceConfigV3Filetype : public AIETraceConfigFiletype {
     public:
         explicit AIETraceConfigV3Filetype(boost::property_tree::ptree& aie_project);
-        ~AIETraceConfigV3Filetype() noexcept {}
+        ~AIETraceConfigV3Filetype() noexcept override = default;
 
         AIETraceConfigV3Filetype(const AIETraceConfigV3Filetype&) = default;
         AIETraceConfigV3Filetype& operator=(const AIETraceConfigV3Filetype&) = default;

--- a/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_trace_config_v3_filetype.h
+++ b/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_trace_config_v3_filetype.h
@@ -28,14 +28,8 @@ class AIETraceConfigV3Filetype : public AIETraceConfigFiletype {
                  module_type type, 
                  const std::string& kernel_name = "all") const override;
         
-        std::vector<tile_type>
-        getAllAIETiles(const std::string& graph_name) const override;
-
         std::vector<tile_type> 
         getAIETiles(const std::string& graph_name) const override;
-        
-        std::vector<tile_type>
-        getEventTiles(const std::string& graph_name, module_type type) const override;
 
     private:
         // Helper method to match kernel patterns with ordered substring matching

--- a/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_trace_config_v3_filetype.h
+++ b/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_trace_config_v3_filetype.h
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved
+
+#ifndef AIE_TRACE_CONFIG_V3_FILETYPE_DOT_H
+#define AIE_TRACE_CONFIG_V3_FILETYPE_DOT_H
+
+#include "aie_trace_config_filetype.h"
+#include <boost/property_tree/ptree.hpp>
+
+// ***************************************************************
+// The implementation for major version 3 of aie_trace_config.json file
+// ***************************************************************
+namespace xdp::aie {
+
+class AIETraceConfigV3Filetype : public AIETraceConfigFiletype {
+    public:
+        AIETraceConfigV3Filetype(boost::property_tree::ptree& aie_project);
+        ~AIETraceConfigV3Filetype() = default;
+
+        std::vector<std::string>
+        getValidKernels() const override;
+
+        std::vector<std::string>
+        getValidGraphs() const override;
+
+        std::vector<tile_type>
+        getTiles(const std::string& graph_name,
+                 module_type type, 
+                 const std::string& kernel_name = "all") const override;
+        
+        std::vector<tile_type>
+        getAllAIETiles(const std::string& graph_name) const override;
+
+        std::vector<tile_type> 
+        getAIETiles(const std::string& graph_name) const override;
+        
+        std::vector<tile_type>
+        getEventTiles(const std::string& graph_name, module_type type) const override;
+
+    private:
+        // Helper method to match kernel patterns with ordered substring matching
+        bool matchesKernelPattern(const std::string& function, const std::string& kernel_name) const;
+};
+
+} // namespace xdp::aie
+
+#endif

--- a/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_trace_config_v3_filetype.h
+++ b/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_trace_config_v3_filetype.h
@@ -14,8 +14,8 @@ namespace xdp::aie {
 
 class AIETraceConfigV3Filetype : public AIETraceConfigFiletype {
     public:
-        AIETraceConfigV3Filetype(boost::property_tree::ptree& aie_project);
-        ~AIETraceConfigV3Filetype() = default;
+        explicit AIETraceConfigV3Filetype(boost::property_tree::ptree& aie_project);
+        ~AIETraceConfigV3Filetype() override = default;
 
         std::vector<std::string>
         getValidKernels() const override;

--- a/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_trace_config_v3_filetype.h
+++ b/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_trace_config_v3_filetype.h
@@ -36,13 +36,13 @@ class AIETraceConfigV3Filetype : public AIETraceConfigFiletype {
         // module_type instead. They throw runtime exceptions if called.
         
         std::vector<tile_type>
-        getAIETiles(const std::string& graphName) const override;
+        getAIETiles(const std::string&) const override;
 
         std::vector<tile_type>
-        getAllAIETiles(const std::string& graphName) const override;
+        getAllAIETiles(const std::string&) const override;
 
         std::vector<tile_type>
-        getEventTiles(const std::string& graph_name, module_type type) const override;
+        getEventTiles(const std::string&, module_type) const override;
 
     private:
         // Helper method to match kernel patterns with ordered substring matching

--- a/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_status/aie_status_plugin.cpp
@@ -124,7 +124,7 @@ namespace xdp {
     // Note: in the future, we could support user-defined tile sets
     auto graphs = metadataReader->getValidGraphs();
     for (auto& graph : graphs) {
-      mGraphCoreTilesMap[graph] = metadataReader->getEventTiles(graph, module_type::core);
+      mGraphCoreTilesMap[graph] = metadataReader->getTiles(graph, module_type::core, "all");
     }
 
    // NOTE: AIE Status is not released product on client. Whenever client support is needed,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
CR-1230523 - various subgraphs and kernel profiling settings expected.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
New feature.

#### How problem was solved, alternative solutions (if any) and why they were rejected
To support this completely, it takes following changes in account - 
XRT changes:
- New metadata parser using new major version 3. Please note major version 2 is not deprecated & it will handle for aie-compiler version which creates older metadata.
- Metadata changes were needed to make AIE kernel tile mapping section self-sufficient to fetch AIE tiles, added dmaChannels
- It now fetches graphs from the AIE kernel mapping section
- It supports substring way of finding Graph and kernel names for profiling

Metadata changes:
- major version is updated to 3
- Earlier major version 2 is still supported

#### Risks (if any) associated the changes in the commit
Low
Please Note:
- AIEcompiler will make default major version 3 only after this XRT commit makes it to TA & XRT & XRT_MCDM pipeline for Xoah tests.
- Meanwhile  Xoah tests can enable new metadata for applicable tests using AIE compiler switch and locally built latest XRT rpms

#### What has been tested and how, request additional testing if necessary
Verified original test on AIE1 & AIE2.

#### Documentation impact (if any)
