### PR TITLE
Disable CPack when building for upstream

### DIFF
--- a/src/CMake/nativeLnx.cmake
+++ b/src/CMake/nativeLnx.cmake
@@ -147,8 +147,12 @@ xrt_add_subdirectory(python)
 
 message("-- XRT version: ${XRT_VERSION_STRING}")
 
-# -- CPack
-include (CMake/cpackLin.cmake)
+# CPack
+# Upstream builds do not use CPack, plus LINUX_VERSION which is
+# used by CPack may not be initialzed properly depending on host
+if (NOT XRT_UPSTREAM)
+   include (CMake/cpackLin.cmake)
+endif() 
 
 if (XRT_ALVEO)
   message("-- XRT Alveo drivers will be bundled with the XRT package")


### PR DESCRIPTION
#### Problem solved by the commit
At least Debian does not use CPack.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Some upstream build host failed build when cpackLin.cmake is included.  For some reason LINUX_VERSION is unset maybe because of missing VERISON_ID in /etc/os-release.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Safe not to include cpackLin.cmake.

