### PR TITLE
Fix minor bug in log buffer dumping

### DIFF
--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -1702,7 +1702,7 @@ static xrtBufferFlags
 compose_internal_bo_flags(use_type type)
 {
   xcl_bo_flags flags {0};  // see xrt_mem.h
-  flags.flags = XRT_BO_FLAGS_CACHEABLE;
+  flags.flags = XRT_BO_FLAGS_HOST_ONLY;
   flags.access = XRT_BO_ACCESS_LOCAL;
   flags.dir = XRT_BO_ACCESS_READ_WRITE;
   flags.use = static_cast<uint32_t>(type);

--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -1702,7 +1702,14 @@ static xrtBufferFlags
 compose_internal_bo_flags(use_type type)
 {
   xcl_bo_flags flags {0};  // see xrt_mem.h
-  flags.flags = XRT_BO_FLAGS_HOST_ONLY;
+
+  if (type == use_type::debug) {
+    // client use case, create buffer in sram
+    flags.flags = XRT_BO_FLAGS_CACHEABLE;
+  }
+  else
+    flags.flags = XRT_BO_FLAGS_HOST_ONLY;
+
   flags.access = XRT_BO_ACCESS_LOCAL;
   flags.dir = XRT_BO_ACCESS_READ_WRITE;
   flags.use = static_cast<uint32_t>(type);

--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -1703,12 +1703,22 @@ compose_internal_bo_flags(use_type type)
 {
   xcl_bo_flags flags {0};  // see xrt_mem.h
 
-  if (type == use_type::debug) {
+  // This function is used to create internal buffers
+  // for debug/trace/log use cases.
+  // Sanity check the use_type
+  switch (type) {
+  case use_type::debug :
     // client use case, create buffer in sram
     flags.flags = XRT_BO_FLAGS_CACHEABLE;
-  }
-  else
+    break;
+  case use_type::dtrace :
+  case use_type::uc_debug :
+  case use_type::log :
     flags.flags = XRT_BO_FLAGS_HOST_ONLY;
+    break;
+  default:
+    throw std::runtime_error("create_bo is called with invalid buffer type\n");
+  }
 
   flags.access = XRT_BO_ACCESS_LOCAL;
   flags.dir = XRT_BO_ACCESS_READ_WRITE;

--- a/src/runtime_src/core/common/api/xrt_hw_context.cpp
+++ b/src/runtime_src/core/common/api/xrt_hw_context.cpp
@@ -238,6 +238,9 @@ public:
     // This trace point measures the time to tear down a hw context on the device
     XRT_TRACE_POINT_SCOPE(xrt_hw_context_dtor);
 
+    // dump uC log buffer before shim hwctx handle is destroyed
+    m_uc_log_buf.reset();
+
     try {
       // finish_flush_device should only be called when the underlying 
       // hw_context_impl is destroyed. The xdp::update_device cannot exist

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/ve2/ml_timeline.cpp
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/ve2/ml_timeline.cpp
@@ -34,7 +34,7 @@ namespace xdp {
         mBO = xrt_core::bo_int::create_bo(
                 xrt_core::hw_context_int::create_hw_context_from_implementation(hwCtxImpl),
                 sz,
-                xrt_core::bo_int::use_type::debug);
+                xrt_core::bo_int::use_type::uc_debug);
       }
       ~ResultBOContainer() {}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Fixed a minor bug where shim hwctx handle is destroyed before log buffer is destroyed, this happens because we call explicit destruction of shim hwctx handle in hw_context_impl destructor.
Also creating host only buffer instead of cacheable buffer for all these special buffers.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
It was caught when testing the feature on aie4

#### How problem was solved, alternative solutions (if any) and why they were rejected
Calling destruction of log buffer before shim hw ctx handle destruction in hw_context_impl class

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
Tested the feature on aie4 on both Linux and windows and things work as expected

#### Documentation impact (if any)
NA