### PR TITLE
Add minimal version info header to help compiler cache

### DIFF
--- a/src/CMake/config/version-slim.h.in
+++ b/src/CMake/config/version-slim.h.in
@@ -1,0 +1,13 @@
+#ifndef _XRT_VERSION_SLIM_H_
+#define _XRT_VERSION_SLIM_H_
+
+/*
+ * This header contains minimal version info needed for xrt/detail/abi.h header
+ */
+
+#define XRT_SLIM_VERSION(major, minor) ((major << 16) + (minor))
+#define XRT_SLIM_VERSION_CODE XRT_SLIM_VERSION(@XRT_VERSION_MAJOR@, @XRT_VERSION_MINOR@)
+#define XRT_SLIM_MAJOR(code) ((code >> 16))
+#define XRT_SLIM_MINOR(code) (code - ((code >> 16) << 16))
+
+#endif

--- a/src/CMake/version.cmake
+++ b/src/CMake/version.cmake
@@ -89,12 +89,17 @@ configure_file(
 )
 
 configure_file(
+  ${XRT_SOURCE_DIR}/CMake/config/version-slim.h.in
+  ${PROJECT_BINARY_DIR}/gen/xrt/detail/version-slim.h
+)
+
+configure_file(
   ${XRT_SOURCE_DIR}/CMake/config/version.json.in
   ${PROJECT_BINARY_DIR}/gen/version.json
 )
 
 # xrt component install
-install(FILES ${PROJECT_BINARY_DIR}/gen/version.h
+install(FILES ${PROJECT_BINARY_DIR}/gen/version.h ${PROJECT_BINARY_DIR}/gen/xrt/detail/version-slim.h
   DESTINATION ${XRT_INSTALL_INCLUDE_DIR}/xrt/detail
   COMPONENT ${XRT_BASE_DEV_COMPONENT})
 

--- a/src/runtime_src/core/include/xrt/detail/abi.h
+++ b/src/runtime_src/core/include/xrt/detail/abi.h
@@ -4,12 +4,9 @@
 #ifndef XRT_DETAIL_ABI_H
 #define XRT_DETAIL_ABI_H
 
-// Generated version.h file is installed into include/xrt/detail/version.h
-// but at build time it is picked up from compile include search path
-#if defined(XRT_BUILD) && !defined(DISABLE_ABI_CHECK)
-# include "version.h"
-#elif !defined(XRT_BUILD)
-# include "xrt/detail/version.h"
+// Use slim version header without datetime fields
+#ifndef DISABLE_ABI_CHECK
+# include "xrt/detail/version-slim.h"
 #endif
 
 #ifdef __cplusplus
@@ -27,9 +24,9 @@ namespace xrt { namespace detail {
 // version of XRT and new version.
 struct abi {
 #ifndef DISABLE_ABI_CHECK
-  const unsigned int major {XRT_MAJOR(XRT_VERSION_CODE)};
-  const unsigned int minor {XRT_MINOR(XRT_VERSION_CODE)};
-  const unsigned int code  {XRT_VERSION_CODE};
+  const unsigned int major {XRT_SLIM_MAJOR(XRT_SLIM_VERSION_CODE)};
+  const unsigned int minor {XRT_SLIM_MINOR(XRT_SLIM_VERSION_CODE)};
+  const unsigned int code  {XRT_SLIM_VERSION_CODE};
 #else
   const unsigned int major {0};
   const unsigned int minor {0};


### PR DESCRIPTION
xrt/detail/abi.h includes autogenerated version.h that contains timestamp but use only major/minor version macros. Using smaller header enables use of compiler caches (like ccache).

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Make it possible to use ccache (or other compiler cache) at buildhosts

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Slim version header is added that contains only necessary info. Old version.h is left unchanged but it is possible to include slim one there to reduce code duplication

Why this solution is better then -DXRT_CCACHE?

XRT_CCACHE uses global define -DDISABLE_ABI_CHECK so technicaly compilation result is different and some errors can not be detected (redefinition of variables/macros from version.h for example).

This patch fixes root cause why -DDISABLE_ABI_CHECK was introduced and same code base with same flags can be compiled with or without ccache.

#### Risks (if any) associated the changes in the commit
Code that uses version macros without including version.h will break
 
#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
