### PR TITLE
Add workflow that builds deb package using debian/rules

### DIFF
--- a/.github/workflows/debian-validate.yml
+++ b/.github/workflows/debian-validate.yml
@@ -1,0 +1,52 @@
+name: Validate Debian build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-24.04]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        submodules: recursive
+    - uses: actions/cache@v4
+      with:
+        path: |
+          /home/runner/.ccache
+          /home/runner/.cache/ccache
+        key: debian-validate:${{ matrix.os }}:${{ github.sha }}
+        restore-keys: 'debian-validate:${{ matrix.os }}:'
+    - name: disable man-db trigger # See https://github.com/actions/runner-images/issues/10977
+      run: |
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
+    - name: install deps
+      run: |
+        ln -s build/debian debian
+        sudo apt update
+        sudo apt remove --yes libpython3*-dev # By default github images have python3-dev packages installed, drop them
+        sudo apt install --yes build-essential ccache
+        sudo apt satisfy --yes --no-install-recommends "`perl ./debian/print-build-deps.pl`"
+    - name: build
+      env:
+        CMAKE_CXX_COMPILER_LAUNCHER: ccache
+        CMAKE_C_COMPILER_LAUNCHER: ccache
+      run: dpkg-buildpackage --no-sign -b -j4
+    - name: test
+      continue-on-error: true
+      run: |
+        set -x
+        test ! -f /opt/xilinix/xrt/bin/xclbinutil
+        if pkg-config --exists xrt; then echo "XRT pkg-config file installed: `pkg-config --modversion xrt`"; false; else true; fi
+        sudo dpkg -i ../xrt_*.deb
+        test -f /opt/xilinx/xrt/bin/xclbinutil
+        pkg-config --exists xrt
+        mkdir build-test
+        cd build-test
+        c++ -ohello `pkg-config --cflags --libs xrt` -Wall ../tests/xrt/00_hello/main.cpp
+
+# vim: sts=2 sw=2 et

--- a/build/debian/print-build-deps.pl
+++ b/build/debian/print-build-deps.pl
@@ -1,0 +1,16 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use Dpkg::Control::Info;
+use Dpkg::Deps;
+
+my $fields = Dpkg::Control::Info->new()->get_source();
+my %options = (reduce_restrictions => 1);
+
+print(deps_concat(
+	deps_parse($fields->{'Build-Depends'}, %options),
+	deps_parse($fields->{'Build-Depends-Arch'} || '', %options) || undef,
+	deps_parse($fields->{'Build-Depends-Indep'} || '', %options) || undef,
+))

--- a/build/debian/xrt.install
+++ b/build/debian/xrt.install
@@ -1,3 +1,3 @@
 etc/OpenCL/
 opt/xilinx/
-usr/lib/pkgconfig/
+#usr/lib/*/pkgconfig/

--- a/src/CMake/config/version-slim.h.in
+++ b/src/CMake/config/version-slim.h.in
@@ -1,0 +1,13 @@
+#ifndef _XRT_VERSION_SLIM_H_
+#define _XRT_VERSION_SLIM_H_
+
+/*
+ * This header contains minimal version info needed for xrt/detail/abi.h header
+ */
+
+#define XRT_SLIM_VERSION(major, minor) ((major << 16) + (minor))
+#define XRT_SLIM_VERSION_CODE XRT_SLIM_VERSION(@XRT_VERSION_MAJOR@, @XRT_VERSION_MINOR@)
+#define XRT_SLIM_MAJOR(code) ((code >> 16))
+#define XRT_SLIM_MINOR(code) (code - ((code >> 16) << 16))
+
+#endif

--- a/src/CMake/version.cmake
+++ b/src/CMake/version.cmake
@@ -89,12 +89,17 @@ configure_file(
 )
 
 configure_file(
+  ${XRT_SOURCE_DIR}/CMake/config/version-slim.h.in
+  ${PROJECT_BINARY_DIR}/gen/xrt/detail/version-slim.h
+)
+
+configure_file(
   ${XRT_SOURCE_DIR}/CMake/config/version.json.in
   ${PROJECT_BINARY_DIR}/gen/version.json
 )
 
 # xrt component install
-install(FILES ${PROJECT_BINARY_DIR}/gen/version.h
+install(FILES ${PROJECT_BINARY_DIR}/gen/version.h ${PROJECT_BINARY_DIR}/gen/xrt/detail/version-slim.h
   DESTINATION ${XRT_INSTALL_INCLUDE_DIR}/xrt/detail
   COMPONENT ${XRT_BASE_DEV_COMPONENT})
 

--- a/src/runtime_src/core/include/xrt/detail/abi.h
+++ b/src/runtime_src/core/include/xrt/detail/abi.h
@@ -4,12 +4,9 @@
 #ifndef XRT_DETAIL_ABI_H
 #define XRT_DETAIL_ABI_H
 
-// Generated version.h file is installed into include/xrt/detail/version.h
-// but at build time it is picked up from compile include search path
-#if defined(XRT_BUILD) && !defined(DISABLE_ABI_CHECK)
-# include "version.h"
-#elif !defined(XRT_BUILD)
-# include "xrt/detail/version.h"
+// Use slim version header without datetime fields
+#ifndef DISABLE_ABI_CHECK
+# include "xrt/detail/version-slim.h"
 #endif
 
 #ifdef __cplusplus
@@ -27,9 +24,9 @@ namespace xrt { namespace detail {
 // version of XRT and new version.
 struct abi {
 #ifndef DISABLE_ABI_CHECK
-  const unsigned int major {XRT_MAJOR(XRT_VERSION_CODE)};
-  const unsigned int minor {XRT_MINOR(XRT_VERSION_CODE)};
-  const unsigned int code  {XRT_VERSION_CODE};
+  const unsigned int major {XRT_SLIM_MAJOR(XRT_SLIM_VERSION_CODE)};
+  const unsigned int minor {XRT_SLIM_MINOR(XRT_SLIM_VERSION_CODE)};
+  const unsigned int code  {XRT_SLIM_VERSION_CODE};
 #else
   const unsigned int major {0};
   const unsigned int minor {0};


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Debian build rules are not used in regular builds and break from time to time.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

Workflow uses dependencies list extracted from debian/control with simple perl script to make sure they are valid.

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)

This is draft until some issues are clarified and resolved:

- [ ] It looks like packaging is gradually shifting from /opt/xilinx/xrt to /usr (see f47d3cd5 for example). Is it true?
- [ ] What is minimal amount of tests that should be performed on installed package? Calling xclbinutil and compiling xrt/00_hello tests is enought?
- [ ] This pull request uses ccache (that greatly reduces compilation time) that depends on #9231 (if it is not merged then using ccache does not make sense).
- [ ] Also there are files installed (but not packaged) in /usr/src/xrt-aws-2.20.0 (dkms files reports that this is xrt-awsmgmt driver). Should it be packaged into xrt-aws-dkms package?
