### PR TITLE
correct initialization of mem_index variable

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/common/zocl_bo.c
+++ b/src/runtime_src/core/edge/drm/zocl/common/zocl_bo.c
@@ -204,7 +204,7 @@ zocl_create_cma_mem(struct drm_device *dev, size_t size, u32 user_flags)
 #endif
 	struct device *mem_dev;
 	struct drm_zocl_bo *bo;
-	unsigned int mem_index;
+	int mem_index;
 	dma_addr_t phys = 0;
 	void* vaddr = NULL;
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
correct initialization of mem_index variable
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
correct initialization of mem_index variable
#### How problem was solved, alternative solutions (if any) and why they were rejected
correct initialization of mem_index variable
#### Risks (if any) associated the changes in the commit
None
#### What has been tested and how, request additional testing if necessary
This change was affecting NPU inference behavior, verified the NPU inference loaded successfully.
#### Documentation impact (if any)
None