### PR TITLE
Fix for c compiler warning. 

### DIFF
--- a/src/runtime_src/core/include/xrt/experimental/xrt_exception.h
+++ b/src/runtime_src/core/include/xrt/experimental/xrt_exception.h
@@ -26,8 +26,6 @@ class exception : public std::exception
 
 } // namespace xrt
 
-#else
-# pragma message("Warning: xrt_exception is only implemented for C++")
 #endif // __cplusplus
 
 #endif


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Fix for c compiler warning in xrt_device.h.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
c compiler is throwing warning for including xrt_exception.h in xrt_device.h.
#### How problem was solved, alternative solutions (if any) and why they were rejected
 Removing the warning from xrt_exception.h.
#### Risks (if any) associated the changes in the commit
Low
#### What has been tested and how, request additional testing if necessary
Compiled simple application just including xrt_device.h using gcc compiler in windows. 
#### Documentation impact (if any)
NA