### PR TITLE
Avoid creating xrt::queue object unless needed, plus debug print changes

### DIFF
--- a/src/runtime_src/core/common/debug.cpp
+++ b/src/runtime_src/core/common/debug.cpp
@@ -17,6 +17,20 @@
 #include "debug.h"
 #include <cstdarg>
 #include <cstdio>
+#include <sstream>
+#include <thread>
+
+namespace {
+
+static std::string
+get_tid()
+{
+  std::ostringstream oss;
+  oss << std::this_thread::get_id();
+  return oss.str();
+}
+
+}
 
 namespace xrt_core {
 
@@ -32,7 +46,7 @@ debugf(const char* format,...)
   debug_lock lk;
   va_list args;
   va_start(args,format);
-  printf("%llu: ",time_ns());
+  printf("%llu (%s): ",time_ns(), get_tid().c_str());
   vprintf(format,args);
   va_end(args);
 }

--- a/src/runtime_src/core/common/runner/runner.cpp
+++ b/src/runtime_src/core/common/runner/runner.cpp
@@ -5,7 +5,7 @@
 #define XRT_API_SOURCE         // in same dll as coreutil
 
 #ifdef _DEBUG
-# define XRT_VERBOSE
+//# define XRT_VERBOSE
 #endif
 
 #include "runner.h"


### PR DESCRIPTION
#### Problem solved by the commit
The xrt::runner supports execution of multiple runlists by leveraging
an xrt::queue object.  But for all practical use-cases there is only
one runlist and the xrt::queue object should not be created.

Update XRT_PRINTF/DEBUGF to print thread id and add debug prints to runner.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
The xrt::queue object spawns a thread, this results in unnecessarily
many threads.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Condition creation of xrt::queue objects based on number of runlists.

