### PR TITLE
Amend #9231: Add minimal version info header to help compiler cache

### DIFF
--- a/src/CMake/ccache.cmake
+++ b/src/CMake/ccache.cmake
@@ -8,10 +8,6 @@ if (XRT_CCACHE)
   if(CCACHE_PROGRAM)
     set(CMAKE_C_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
     set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
-
-    # Disable abi compile time checks which renders ccache close to useless
-    message ("***** CCACHE: DISABLING ABI VERSION CHECK ******")
-    add_compile_options("-DDISABLE_ABI_CHECK")
   else()
     message ("***** ccache program not found, ignoring -ccache")
   endif()

--- a/src/CMake/config/version-slim.h.in
+++ b/src/CMake/config/version-slim.h.in
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#ifndef XRT_VERSION_SLIM_H_
+#define XRT_VERSION_SLIM_H_
+
+// This header contains minimal version info needed for xrt/detail/abi.h header
+
+#define XRT_VERSION(major, minor) ((major << 16) + (minor))
+#define XRT_VERSION_CODE XRT_VERSION(@XRT_VERSION_MAJOR@, @XRT_VERSION_MINOR@)
+#define XRT_MAJOR(code) ((code >> 16))
+#define XRT_MINOR(code) (code - ((code >> 16) << 16))
+
+#endif

--- a/src/CMake/config/version.h.in
+++ b/src/CMake/config/version.h.in
@@ -1,11 +1,8 @@
-/**
- * SPDX-License-Identifier: Apache-2.0
- * Copyright (C) 2019-2021 Xilinx, Inc. All rights reserved.
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
- */
-
-#ifndef _XRT_VERSION_H_
-#define _XRT_VERSION_H_
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2019-2021 Xilinx, Inc. All rights reserved.
+// Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
+#ifndef XRT_VERSION_H_
+#define XRT_VERSION_H_
 
 static const char xrt_build_version[] = "@XRT_VERSION_STRING@";
 
@@ -22,16 +19,13 @@ static const char xrt_build_version_date[] = "@XRT_DATE@";
 static const char xrt_modified_files[] = "@XRT_MODIFIED_FILES@";
 
 #define XRT_DRIVER_VERSION "@XRT_VERSION_STRING@,@XRT_HASH@"
-
-#define XRT_VERSION(major, minor) ((major << 16) + (minor))
-#define XRT_VERSION_CODE XRT_VERSION(@XRT_VERSION_MAJOR@, @XRT_VERSION_MINOR@)
-#define XRT_MAJOR(code) ((code >> 16))
-#define XRT_MINOR(code) (code - ((code >> 16) << 16))
 #define XRT_PATCH @XRT_VERSION_PATCH@
 #define XRT_HEAD_COMMITS @XRT_HEAD_COMMITS@
 #define XRT_BRANCH_COMMITS @XRT_BRANCH_COMMITS@
 
 #ifdef __cplusplus
+#include "xrt/detail/version-slim.h"
+
 #include <iostream>
 #include <string>
 

--- a/src/CMake/config/version.h.in
+++ b/src/CMake/config/version.h.in
@@ -23,9 +23,9 @@ static const char xrt_modified_files[] = "@XRT_MODIFIED_FILES@";
 #define XRT_HEAD_COMMITS @XRT_HEAD_COMMITS@
 #define XRT_BRANCH_COMMITS @XRT_BRANCH_COMMITS@
 
-#ifdef __cplusplus
 #include "xrt/detail/version-slim.h"
 
+#ifdef __cplusplus
 #include <iostream>
 #include <string>
 

--- a/src/CMake/settings.cmake
+++ b/src/CMake/settings.cmake
@@ -50,10 +50,6 @@ else()
   set(XRT_WARN_OPTS -Wall)
 endif()
 
-if (DISABLE_ABI_CHECK)
-  add_compile_options("-DDISABLE_ABI_CHECK")
-endif()
-
 if (NOT CMAKE_BUILD_TYPE)
   set (CMAKE_BUILD_TYPE RelWithDebInfo)
 endif (NOT CMAKE_BUILD_TYPE)

--- a/src/CMake/version.cmake
+++ b/src/CMake/version.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2019-2021 Xilinx, Inc. All rights reserved.
-# Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
 
 # AMD promotion build works from copied sources with no git
 # repository.  The build cannot query git for git metadata.  The
@@ -84,8 +84,13 @@ execute_process(
 string(TIMESTAMP XRT_DATE "%Y-%m-%d %H:%M:%S")
 
 configure_file(
+  ${XRT_SOURCE_DIR}/CMake/config/version-slim.h.in
+  ${PROJECT_BINARY_DIR}/gen/xrt/detail/version-slim.h
+)
+
+configure_file(
   ${XRT_SOURCE_DIR}/CMake/config/version.h.in
-  ${PROJECT_BINARY_DIR}/gen/version.h
+  ${PROJECT_BINARY_DIR}/gen/xrt/detail/version.h
 )
 
 configure_file(
@@ -94,7 +99,9 @@ configure_file(
 )
 
 # xrt component install
-install(FILES ${PROJECT_BINARY_DIR}/gen/version.h
+install(FILES
+  ${PROJECT_BINARY_DIR}/gen/xrt/detail/version.h
+  ${PROJECT_BINARY_DIR}/gen/xrt/detail/version-slim.h
   DESTINATION ${XRT_INSTALL_INCLUDE_DIR}/xrt/detail
   COMPONENT ${XRT_BASE_DEV_COMPONENT})
 
@@ -108,7 +115,9 @@ endif()
 if (XRT_ALVEO AND (NOT XRT_EDGE) AND (NOT WIN32))
   # Copied over from dkms.cmake. TODO: cleanup
   set (XRT_DKMS_INSTALL_DIR "/usr/src/xrt-${XRT_VERSION_STRING}")
-  install(FILES ${PROJECT_BINARY_DIR}/gen/version.h
+  install(FILES
+    ${PROJECT_BINARY_DIR}/gen/xrt/detail/version.h
+    ${PROJECT_BINARY_DIR}/gen/xrt/detail/version-slim.h
     DESTINATION ${XRT_DKMS_INSTALL_DIR}/driver/include
     COMPONENT ${XRT_DEV_COMPONENT})
 endif()

--- a/src/CMake/version.cmake
+++ b/src/CMake/version.cmake
@@ -120,4 +120,8 @@ if (XRT_ALVEO AND (NOT XRT_EDGE) AND (NOT WIN32))
     ${PROJECT_BINARY_DIR}/gen/xrt/detail/version-slim.h
     DESTINATION ${XRT_DKMS_INSTALL_DIR}/driver/include
     COMPONENT ${XRT_DEV_COMPONENT})
+  install(FILES
+    ${PROJECT_BINARY_DIR}/gen/xrt/detail/version-slim.h
+    DESTINATION ${XRT_DKMS_INSTALL_DIR}/driver/include/xrt/detail
+    COMPONENT ${XRT_DEV_COMPONENT})
 endif()

--- a/src/runtime_src/core/common/api/xrt_version.cpp
+++ b/src/runtime_src/core/common/api/xrt_version.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
 
 // This file implements XRT version APIs as declared in
 // core/include/experimental/xrt_version.h
 #define XRT_API_SOURCE         // exporting xrt_version.h
 #define XRT_CORE_COMMON_SOURCE // in same dll as core_common
 #include "core/include/xrt/experimental/xrt_version.h"
-#include "version.h"
+#include "xrt/detail/version.h"
 
 #ifdef major
 # undef major

--- a/src/runtime_src/core/common/message.cpp
+++ b/src/runtime_src/core/common/message.cpp
@@ -1,25 +1,13 @@
-/**
- * Copyright (C) 2016-2022 Xilinx, Inc
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2016-2022 Xilinx, Inc. All rights reserved.
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
 #define XRT_CORE_COMMON_SOURCE
 #include "message.h"
 #include "time.h"
-#include "gen/version.h"
 #include "config_reader.h"
 #include "utils.h"
+
+#include "xrt/detail/version.h"
 
 #include <map>
 #include <fstream>

--- a/src/runtime_src/core/common/sysinfo.cpp
+++ b/src/runtime_src/core/common/sysinfo.cpp
@@ -1,13 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
 #define XRT_CORE_COMMON_SOURCE
-// Local - Include files
 #include "sysinfo.h"
 #include "detail/sysinfo.h"
 #include "system.h"
 
-// System - Include Files
-#include "gen/version.h"
+#include "xrt/detail/version.h"
 
 namespace xrt_core::sysinfo {
 

--- a/src/runtime_src/core/common/system.cpp
+++ b/src/runtime_src/core/common/system.cpp
@@ -1,16 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2019 Xilinx, Inc
-// Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
 #define XRT_CORE_COMMON_SOURCE
-// Local - Include Files
 #include "system.h"
 #include "device.h"
 #include "module_loader.h"
 
-#include "gen/version.h"
-
-
-// System - Include Files
 #include <boost/property_tree/ptree.hpp>
 
 #include <map>

--- a/src/runtime_src/core/include/xrt/detail/abi.h
+++ b/src/runtime_src/core/include/xrt/detail/abi.h
@@ -1,16 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2021 Xilinx, Inc. All rights reserved.
-// Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2024-2025 Advanced Micro Devices, Inc. All rights reserved.
 #ifndef XRT_DETAIL_ABI_H
 #define XRT_DETAIL_ABI_H
 
-// Generated version.h file is installed into include/xrt/detail/version.h
-// but at build time it is picked up from compile include search path
-#if defined(XRT_BUILD) && !defined(DISABLE_ABI_CHECK)
-# include "version.h"
-#elif !defined(XRT_BUILD)
-# include "xrt/detail/version.h"
-#endif
+#include "xrt/detail/version-slim.h"
 
 #ifdef __cplusplus
 
@@ -26,15 +20,9 @@ namespace xrt { namespace detail {
 // The struct is used to guarantee schema compability between old
 // version of XRT and new version.
 struct abi {
-#ifndef DISABLE_ABI_CHECK
   const unsigned int major {XRT_MAJOR(XRT_VERSION_CODE)};
   const unsigned int minor {XRT_MINOR(XRT_VERSION_CODE)};
   const unsigned int code  {XRT_VERSION_CODE};
-#else
-  const unsigned int major {0};
-  const unsigned int minor {0};
-  const unsigned int code  {0};
-#endif
 };
 
 }} // detail, xrt

--- a/src/runtime_src/core/tools/xbtracer/src/wrapper/tracer.cpp
+++ b/src/runtime_src/core/tools/xbtracer/src/wrapper/tracer.cpp
@@ -11,15 +11,15 @@
 #include <iostream>
 #include <memory>
 #include <mutex>
-#include <version.h>
 
-#include <wrapper/tracer.h>
+#include "xrt/detail/version.h"
+#include "wrapper/tracer.h"
 #ifdef _WIN32
-#include <core/common/windows/win_utils.h>
+#include "core/common/windows/win_utils.h"
 #else
-#include <core/common/linux/linux_utils.h>
+#include "core/common/linux/linux_utils.h"
 #endif
-#include <common/trace_utils.h>
+#include "common/trace_utils.h"
 
 namespace xrt::tools::xbtracer
 {

--- a/src/runtime_src/tools/xclbinutil/FormattedOutput.cxx
+++ b/src/runtime_src/tools/xclbinutil/FormattedOutput.cxx
@@ -1,24 +1,10 @@
-/**
- * Copyright (C) 2020-2022 Xilinx, Inc. All rights reserved.
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
- * implied. See the License for the specific language governing 
- * permissions and limitations under the License. 
- */
-
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2020-2022 Xilinx, Inc. All rights reserved.
+// Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
 #include "FormattedOutput.h"
 #include "Section.h"
 #include "SectionBitstream.h"
-#include "version.h"
+#include "xrt/detail/version.h"
 #include "XclBinSignature.h"
 #include "XclBinUtilities.h"
 #include <boost/algorithm/string.hpp>

--- a/src/runtime_src/tools/xclbinutil/SectionBuildMetadata.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionBuildMetadata.cxx
@@ -1,23 +1,10 @@
-/**
- * Copyright (C) 2018, 2020, 2022-2023 Xilinx, Inc
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2018-2022 Xilinx, Inc. All rights reserved.
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
 #include "SectionBuildMetadata.h"
-
-#include "version.h" // Globally included from main
 #include "XclBinUtilities.h"
+#include "xrt/detail/version.h"
+
 #include <boost/functional/factory.hpp>
 #include <boost/property_tree/json_parser.hpp>
 

--- a/src/runtime_src/tools/xclbinutil/XclBinClass.cxx
+++ b/src/runtime_src/tools/xclbinutil/XclBinClass.cxx
@@ -1,20 +1,6 @@
-/**
- * Copyright (C) 2020-2022 Xilinx, Inc. All rights reserved.
- * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2020-2022 Xilinx, Inc. All rights reserved.
+// Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
 // ------ I N C L U D E   F I L E S -------------------------------------------
 #include "XclBinClass.h"
 
@@ -22,12 +8,12 @@
 #include "FormattedOutput.h"
 #include "KernelUtilities.h"
 #include "Section.h"
-#include "version.h"                             // Generated include files
 #include "XclBinUtilities.h"
+#include "xrt/detail/version.h"                  // Generated include files
 #include <boost/algorithm/string.hpp>            // boost::split, is_any_of
 #include <boost/property_tree/json_parser.hpp>
+#include <cstdlib>
 #include <random>                                // randomGen 
-#include <stdlib.h>
 
 // Constant data
 static const std::string mirroDataStart("XCLBIN_MIRROR_DATA_START");


### PR DESCRIPTION
#### Problem solved by the commit
Refactor the autogenerated version.h into two separately configured headers, one that doesn't use timestamp (version-slim.h) and one that does (version.h).

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
The XRT exported header files depend on ABI check that uses the XRT version only.  These headers can include version-slim.h and not be affected by a changing timestamp every time CMake is reconfigured. This in turn simplifies the logic for building with ccache.

#### How problem was solved, alternative solutions (if any) and why they were rejected
The two separate headers are generated under the build tree in a directory with same relatively location as where the corresponding headers will be installed.

Thank you @shramov for #9231, which seeded this PR.
Once merge, this PR closes #9231 