### PR TITLE
Slight change to runner and xrt_hw_context to support smi elf flow

### DIFF
--- a/src/runtime_src/core/common/api/hw_context_int.h
+++ b/src/runtime_src/core/common/api/hw_context_int.h
@@ -56,6 +56,12 @@ get_module(const xrt::hw_context& hwctx, const std::string& kname);
 size_t
 get_partition_size(const xrt::hw_context&);
 
+// get_elf_flow() - Returns true if hwctx was created with elf file/flow
+// Returns false everywhere else
+XRT_CORE_COMMON_EXPORT
+bool
+get_elf_flow(const xrt::hw_context& ctx);
+
 }} // hw_context_int, xrt_core
 
 #endif

--- a/src/runtime_src/core/common/api/xrt_hw_context.cpp
+++ b/src/runtime_src/core/common/api/xrt_hw_context.cpp
@@ -146,6 +146,7 @@ class hw_context_impl : public std::enable_shared_from_this<hw_context_impl>
   std::unique_ptr<uc_log_buffer> m_uc_log_buf;
   std::shared_ptr<xrt_core::usage_metrics::base_logger> m_usage_logger =
       xrt_core::usage_metrics::get_usage_metrics_logger();
+  bool m_elf_flow = false;
 
   void
   create_module_map(const xrt::elf& elf)
@@ -223,6 +224,7 @@ public:
     , m_mode{mode}
     , m_hdl{m_core_device->create_hw_context(elf, m_cfg_param, m_mode)}
     , m_uc_log_buf(init_uc_log_buf(m_core_device, m_hdl.get()))
+    , m_elf_flow{true}
   {
     create_module_map(elf);
   }
@@ -350,6 +352,12 @@ public:
     throw std::runtime_error("no module found with given kernel name in ctx");
   }
 
+  bool
+  get_elf_flow() const
+  {
+    return m_elf_flow;
+  }
+
   double
   get_aie_freq() const
   {
@@ -433,6 +441,12 @@ size_t
 get_partition_size(const xrt::hw_context& ctx)
 {
   return ctx.get_handle()->get_partition_size();
+}
+
+bool
+get_elf_flow(const xrt::hw_context& ctx)
+{
+  return ctx.get_handle()->get_elf_flow();
 }
 
 } // xrt_core::hw_context_int

--- a/src/runtime_src/core/common/runner/runner.cpp
+++ b/src/runtime_src/core/common/runner/runner.cpp
@@ -572,12 +572,12 @@ class recipe
         XRT_DEBUGF("recipe::resources::kernel(%s, %s)\n", m_name.c_str(), m_instance.c_str());
       }
 
-      // Legacy kernel (alveo)
+      // Legacy kernel (alveo) or elf file was used when the hwctx was constructed.
       kernel(const xrt::hw_context& ctx, std::string name, std::string xname)
         : m_name(std::move(name))
         , m_instance(std::move(xname))
         , m_xclbin_kernel{ctx.get_xclbin().get_kernel(m_instance)}
-        , m_xrt_kernel{xrt::kernel{ctx, m_instance}}
+        , m_xrt_kernel{xrt_core::hw_context_int::get_elf_flow(ctx) ? xrt::ext::kernel{ctx, m_instance} : xrt::kernel{ctx, m_instance}}
       {
         XRT_DEBUGF("recipe::resources::kernel(%s, %s)\n", m_name.c_str(), m_instance.c_str());
       }


### PR DESCRIPTION
#### Problem solved by the commit
Runner could not execute smi validate tests on npu3 with elf flow. 

#### How problem was solved
By looking at runner.cpp, I saw that xrt::kernel was being called for elf flow instead of correct xrt::ext::kernel.

#### What has been tested and how, request additional testing if necessary
Tested smi validate with elf flow on npu3, runner operated as intended. 
