### PR TITLE
[XRT-SMI] firmware log buffer allocation in xrt-smi

### DIFF
--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -4159,7 +4159,7 @@ struct event_trace_version : request
 
 struct event_trace_data : request
 {
-  using result_type = firmware_debug_buffer;
+  using result_type = bool;
   static const key_type key = key_type::event_trace_data;
 
   std::any

--- a/src/runtime_src/core/tools/common/SmiWatchMode.cpp
+++ b/src/runtime_src/core/tools/common/SmiWatchMode.cpp
@@ -116,7 +116,6 @@ run_watch_mode(const xrt_core::device* device,
   signal_handler::setup();
   
   output << "Starting " << report_title << " Watch Mode (Press Ctrl+C to exit)\n";
-  output << "Update interval: 1 second\n";
   output << "=======================================================\n\n";
   output.flush();
   
@@ -144,9 +143,6 @@ run_watch_mode(const xrt_core::device* device,
       output << "Error generating report: " << e.what() << "\n";
       output.flush();
     }
-    
-    // Sleep for 1 second
-    std::this_thread::sleep_for(std::chrono::seconds(1));
   }
   
   output << "\n\nWatch mode interrupted by user.\n";

--- a/src/runtime_src/core/tools/common/SmiWatchMode.cpp
+++ b/src/runtime_src/core/tools/common/SmiWatchMode.cpp
@@ -155,16 +155,11 @@ run_watch_mode(const xrt_core::device* device,
   signal_handler::restore();
 }
 
-void
-smi_watch_mode::
-setup_debug_buffer(std::vector<char>& buffer,
-                   xrt_core::query::firmware_debug_buffer& log_buffer,
-                   uint64_t abs_offset,
-                   bool b_wait)
-{
-  buffer.resize(debug_buffer_size);
+smi_debug_buffer::
+smi_debug_buffer(uint64_t abs_offset, bool b_wait, size_t size)
+  : buffer(size) {
   log_buffer.abs_offset = abs_offset;
   log_buffer.data = buffer.data();
-  log_buffer.size = debug_buffer_size;
+  log_buffer.size = size;
   log_buffer.b_wait = b_wait;
 }

--- a/src/runtime_src/core/tools/common/SmiWatchMode.cpp
+++ b/src/runtime_src/core/tools/common/SmiWatchMode.cpp
@@ -155,17 +155,16 @@ run_watch_mode(const xrt_core::device* device,
   signal_handler::restore();
 }
 
-std::unique_ptr<std::vector<char>>
+void
 smi_watch_mode::
-allocate_debug_buffer(xrt_core::query::firmware_debug_buffer& log_buffer,
-                      uint64_t abs_offset,
-                      bool b_wait)
+setup_debug_buffer(std::vector<char>& buffer,
+                   xrt_core::query::firmware_debug_buffer& log_buffer,
+                   uint64_t abs_offset,
+                   bool b_wait)
 {
-  auto buffer = std::make_unique<std::vector<char>>(debug_buffer_size);
+  buffer.resize(debug_buffer_size);
   log_buffer.abs_offset = abs_offset;
-  log_buffer.data = buffer->data();
+  log_buffer.data = buffer.data();
   log_buffer.size = debug_buffer_size;
   log_buffer.b_wait = b_wait;
-  
-  return buffer;
 }

--- a/src/runtime_src/core/tools/common/SmiWatchMode.cpp
+++ b/src/runtime_src/core/tools/common/SmiWatchMode.cpp
@@ -4,6 +4,7 @@
 // ------ I N C L U D E   F I L E S -------------------------------------------
 // Local - Include Files
 #include "SmiWatchMode.h"
+#include "core/common/query_requests.h"
 #include "core/common/time.h"
 
 // 3rd Party Library - Include Files
@@ -152,4 +153,19 @@ run_watch_mode(const xrt_core::device* device,
   
   // Restore original signal handler
   signal_handler::restore();
+}
+
+std::unique_ptr<std::vector<char>>
+smi_watch_mode::
+allocate_debug_buffer(xrt_core::query::firmware_debug_buffer& log_buffer,
+                      uint64_t abs_offset,
+                      bool b_wait)
+{
+  auto buffer = std::make_unique<std::vector<char>>(debug_buffer_size);
+  log_buffer.abs_offset = abs_offset;
+  log_buffer.data = buffer->data();
+  log_buffer.size = debug_buffer_size;
+  log_buffer.b_wait = b_wait;
+  
+  return buffer;
 }

--- a/src/runtime_src/core/tools/common/SmiWatchMode.cpp
+++ b/src/runtime_src/core/tools/common/SmiWatchMode.cpp
@@ -157,9 +157,6 @@ run_watch_mode(const xrt_core::device* device,
 
 smi_debug_buffer::
 smi_debug_buffer(uint64_t abs_offset, bool b_wait, size_t size)
-  : buffer(size) {
-  log_buffer.abs_offset = abs_offset;
-  log_buffer.data = buffer.data();
-  log_buffer.size = size;
-  log_buffer.b_wait = b_wait;
-}
+  : buffer(size),
+    log_buffer{abs_offset, buffer.data(), size, b_wait}
+{}

--- a/src/runtime_src/core/tools/common/SmiWatchMode.h
+++ b/src/runtime_src/core/tools/common/SmiWatchMode.h
@@ -17,8 +17,8 @@ struct firmware_debug_buffer;
 }
 }
 
-// Standard debug buffer size used for both event trace and firmware log data
-constexpr size_t debug_buffer_size = 64 * 1024 * 1024; // 64MB
+//This is arbitrary for the moment. We can change this once we do real testing with firmware data
+constexpr size_t debug_buffer_size = 64 * 1024 * 1024; // 64MB // NOLINT(readability-magic-numbers)
 
 /**
  * @brief Generic watch mode utility for XRT-SMI reports
@@ -104,28 +104,28 @@ public:
                  const std::string& report_title = "Report");
 
   /**
-   * @brief Allocate and initialize a debug buffer for firmware log/trace data
+   * @brief Setup and initialize a debug buffer for firmware log/trace data
    * 
+   * @param buffer Reference to vector that will be resized to debug_buffer_size
    * @param log_buffer Reference to firmware_debug_buffer structure to initialize
    * @param abs_offset Initial absolute offset for the buffer
    * @param b_wait Whether the driver should wait for new events
-   * @return std::unique_ptr<std::vector<char>> Managed buffer that keeps data alive
    * 
-   * This utility function provides consistent buffer allocation and initialization
+   * This utility function provides consistent buffer setup and initialization
    * for both event trace and firmware log reports. Uses the standard debug_buffer_size
-   * constant. The returned unique_ptr ensures automatic memory management and should 
-   * be kept alive while using log_buffer.
+   * constant. The buffer and log_buffer are passed by reference and configured in-place.
    * 
    * Usage Example:
    * @code
+   * std::vector<char> buffer;
    * xrt_core::query::firmware_debug_buffer log_buffer;
-   * auto buffer = smi_watch_mode::allocate_debug_buffer(log_buffer, 0, false);
+   * smi_watch_mode::setup_debug_buffer(buffer, log_buffer, 0, false);
    * // Use log_buffer for device queries...
-   * // buffer automatically cleaned up when going out of scope
    * @endcode
    */
-  static std::unique_ptr<std::vector<char>>
-  allocate_debug_buffer(xrt_core::query::firmware_debug_buffer& log_buffer,
-                        uint64_t abs_offset,
-                        bool b_wait);
+  static void
+  setup_debug_buffer(std::vector<char>& buffer,
+                     xrt_core::query::firmware_debug_buffer& log_buffer,
+                     uint64_t abs_offset,
+                     bool b_wait);
 };

--- a/src/runtime_src/core/tools/common/SmiWatchMode.h
+++ b/src/runtime_src/core/tools/common/SmiWatchMode.h
@@ -19,7 +19,7 @@ struct firmware_debug_buffer;
 }
 
 //This is arbitrary for the moment. We can change this once we do real testing with firmware data
-constexpr size_t debug_buffer_size = static_cast<size_t>(64) * 1024; // 64KB // NOLINT(readability-magic-numbers)
+constexpr size_t debug_buffer_size = static_cast<size_t>(4) * 1024 * 1024; // 4MB // NOLINT(readability-magic-numbers)
 
 /**
  * @brief RAII wrapper for firmware debug buffer management
@@ -90,10 +90,7 @@ public:
    * @return true if watch mode is requested, false otherwise
    * 
    * Supported formats:
-   * - "watch" - Enable watch mode with default 1 second interval
-   * 
-   * Future extensions could support:
-   * - "watch=<seconds>" - Custom interval (not implemented yet)
+   * - "watch" - Enable watch mode
    * 
    * @note This function only checks for watch mode presence, 
    *       it does not validate or parse other filter options

--- a/src/runtime_src/core/tools/common/SmiWatchMode.h
+++ b/src/runtime_src/core/tools/common/SmiWatchMode.h
@@ -6,12 +6,19 @@
 // Please keep external include file dependencies to a minimum
 #include <functional>
 #include <iostream>
+#include <memory>
 #include <string>
 #include <vector>
 
 namespace xrt_core {
 class device;
+namespace query {
+struct firmware_debug_buffer;
 }
+}
+
+// Standard debug buffer size used for both event trace and firmware log data
+constexpr size_t debug_buffer_size = 64 * 1024 * 1024; // 64MB
 
 /**
  * @brief Generic watch mode utility for XRT-SMI reports
@@ -95,4 +102,30 @@ public:
                  std::ostream& output,
                  const ReportGenerator& report_generator,
                  const std::string& report_title = "Report");
+
+  /**
+   * @brief Allocate and initialize a debug buffer for firmware log/trace data
+   * 
+   * @param log_buffer Reference to firmware_debug_buffer structure to initialize
+   * @param abs_offset Initial absolute offset for the buffer
+   * @param b_wait Whether the driver should wait for new events
+   * @return std::unique_ptr<std::vector<char>> Managed buffer that keeps data alive
+   * 
+   * This utility function provides consistent buffer allocation and initialization
+   * for both event trace and firmware log reports. Uses the standard debug_buffer_size
+   * constant. The returned unique_ptr ensures automatic memory management and should 
+   * be kept alive while using log_buffer.
+   * 
+   * Usage Example:
+   * @code
+   * xrt_core::query::firmware_debug_buffer log_buffer;
+   * auto buffer = smi_watch_mode::allocate_debug_buffer(log_buffer, 0, false);
+   * // Use log_buffer for device queries...
+   * // buffer automatically cleaned up when going out of scope
+   * @endcode
+   */
+  static std::unique_ptr<std::vector<char>>
+  allocate_debug_buffer(xrt_core::query::firmware_debug_buffer& log_buffer,
+                        uint64_t abs_offset,
+                        bool b_wait);
 };

--- a/src/runtime_src/core/tools/common/SmiWatchMode.h
+++ b/src/runtime_src/core/tools/common/SmiWatchMode.h
@@ -3,7 +3,8 @@
 
 #pragma once
 
-// Please keep external include file dependencies to a minimum
+#include "core/common/query_requests.h"
+
 #include <functional>
 #include <iostream>
 #include <memory>
@@ -18,7 +19,31 @@ struct firmware_debug_buffer;
 }
 
 //This is arbitrary for the moment. We can change this once we do real testing with firmware data
-constexpr size_t debug_buffer_size = static_cast<size_t>(64) * 1024 * 1024; // 64MB // NOLINT(readability-magic-numbers)
+constexpr size_t debug_buffer_size = static_cast<size_t>(64) * 1024; // 64KB // NOLINT(readability-magic-numbers)
+
+/**
+ * @brief RAII wrapper for firmware debug buffer management
+ * 
+ * Encapsulates buffer allocation and firmware_debug_buffer configuration
+ * with automatic memory management and proper RAII semantics.
+ */
+class smi_debug_buffer {
+private:
+  std::vector<char> buffer;
+  xrt_core::query::firmware_debug_buffer log_buffer;
+
+public:
+  explicit 
+  smi_debug_buffer(uint64_t abs_offset = 0, 
+                   bool b_wait = false, 
+                   size_t size = debug_buffer_size);
+
+  xrt_core::query::firmware_debug_buffer& 
+  get_log_buffer() 
+  { 
+    return log_buffer; 
+  }
+};
 
 /**
  * @brief Generic watch mode utility for XRT-SMI reports
@@ -102,30 +127,4 @@ public:
                  std::ostream& output,
                  const ReportGenerator& report_generator,
                  const std::string& report_title = "Report");
-
-  /**
-   * @brief Setup and initialize a debug buffer for firmware log/trace data
-   * 
-   * @param buffer Reference to vector that will be resized to debug_buffer_size
-   * @param log_buffer Reference to firmware_debug_buffer structure to initialize
-   * @param abs_offset Initial absolute offset for the buffer
-   * @param b_wait Whether the driver should wait for new events
-   * 
-   * This utility function provides consistent buffer setup and initialization
-   * for both event trace and firmware log reports. Uses the standard debug_buffer_size
-   * constant. The buffer and log_buffer are passed by reference and configured in-place.
-   * 
-   * Usage Example:
-   * @code
-   * std::vector<char> buffer;
-   * xrt_core::query::firmware_debug_buffer log_buffer;
-   * smi_watch_mode::setup_debug_buffer(buffer, log_buffer, 0, false);
-   * // Use log_buffer for device queries...
-   * @endcode
-   */
-  static void
-  setup_debug_buffer(std::vector<char>& buffer,
-                     xrt_core::query::firmware_debug_buffer& log_buffer,
-                     uint64_t abs_offset,
-                     bool b_wait);
 };

--- a/src/runtime_src/core/tools/common/SmiWatchMode.h
+++ b/src/runtime_src/core/tools/common/SmiWatchMode.h
@@ -18,7 +18,7 @@ struct firmware_debug_buffer;
 }
 
 //This is arbitrary for the moment. We can change this once we do real testing with firmware data
-constexpr size_t debug_buffer_size = 64 * 1024 * 1024; // 64MB // NOLINT(readability-magic-numbers)
+constexpr size_t debug_buffer_size = static_cast<size_t>(64) * 1024 * 1024; // 64MB // NOLINT(readability-magic-numbers)
 
 /**
  * @brief Generic watch mode utility for XRT-SMI reports

--- a/src/runtime_src/core/tools/xbutil2/ReportFirmwareLog.cpp
+++ b/src/runtime_src/core/tools/xbutil2/ReportFirmwareLog.cpp
@@ -64,14 +64,14 @@ static void generate_dummy_firmware_log_data(xrt_core::query::firmware_debug_buf
     uint32_t argc = 0;
     
     // Pack all bit fields into a single 64-bit value
-    uint64_t packed = (static_cast<uint64_t>(format) << 0) | 
-                      (static_cast<uint64_t>(0x60) << 1) | 
-                      (static_cast<uint64_t>(level) << 8) | 
-                      (static_cast<uint64_t>(0) << 11) | 
-                      (static_cast<uint64_t>(appn) << 16) | 
-                      (static_cast<uint64_t>(argc) << 24) |
-                      (static_cast<uint64_t>(line) << 32) |
-                      (static_cast<uint64_t>(module) << 48); // NOLINT(readability-magic-numbers,cppcoreguidelines-avoid-magic-numbers) - dummy data for pretty printing
+    uint64_t packed = (static_cast<uint64_t>(format) << 0) | // NOLINT(cppcoreguidelines-avoid-magic-numbers) - dummy data for pretty printing
+                      (static_cast<uint64_t>(0x60) << 1) | // NOLINT(cppcoreguidelines-avoid-magic-numbers) - dummy data for pretty printing
+                      (static_cast<uint64_t>(level) << 8) | // NOLINT(cppcoreguidelines-avoid-magic-numbers) - dummy data for pretty printing
+                      (static_cast<uint64_t>(0) << 11) | // NOLINT(cppcoreguidelines-avoid-magic-numbers) - dummy data for pretty printing
+                      (static_cast<uint64_t>(appn) << 16) | // NOLINT(cppcoreguidelines-avoid-magic-numbers) - dummy data for pretty printing
+                      (static_cast<uint64_t>(argc) << 24) |// NOLINT(cppcoreguidelines-avoid-magic-numbers) - dummy data for pretty printing
+                      (static_cast<uint64_t>(line) << 32) |// NOLINT(cppcoreguidelines-avoid-magic-numbers) - dummy data for pretty printing
+                      (static_cast<uint64_t>(module) << 48); // NOLINT(cppcoreguidelines-avoid-magic-numbers) - dummy data for pretty printing
     
     // Write header (16 bytes total)
     memcpy(data_ptr + total_size, &timestamp, 8); // NOLINT(readability-magic-numbers,cppcoreguidelines-avoid-magic-numbers) - dummy data for pretty printing
@@ -143,7 +143,7 @@ parse_message(const uint8_t* data_ptr,
       str_len++;
     }
     if (str_len > 0) {
-      return std::string(str_ptr, str_len);
+      return {str_ptr, str_len};
     }
   }
   return "";

--- a/src/runtime_src/core/tools/xbutil2/ReportFirmwareLog.cpp
+++ b/src/runtime_src/core/tools/xbutil2/ReportFirmwareLog.cpp
@@ -19,26 +19,74 @@ using bpt = boost::property_tree::ptree;
 
 namespace xrt_core::tools::xrt_smi {
 
-// Function to generate simple dummy firmware log data for testing
+// Function to generate structured dummy firmware log data matching ipu_log_message_header format
 static void generate_dummy_firmware_log_data(xrt_core::query::firmware_debug_buffer& log_buffer) {
   static uint64_t counter = 0;  // Ever-increasing counter
   counter++;
   
-  auto data_ptr = static_cast<char*>(log_buffer.data);
+  auto data_ptr = static_cast<uint8_t*>(log_buffer.data);
   size_t total_size = 0;
   
-  // Create simple log messages with counter
-  std::vector<std::string> dummy_messages = {
-    (boost::format("INFO: System init complete (cycle %d)\n") % counter).str(),
-    (boost::format("DEBUG: Command 0x%04X processed (iter %d)\n") % (0x1234 + counter) % counter).str(),
-    (boost::format("WARN: Temperature check %d\n") % counter).str(),
-  };
+  // Generate 5 entries for testing
+  size_t num_entries = 5; // NOLINT(cppcoreguidelines-avoid-magic-numbers) - dummy data for pretty printing
   
-  for (const auto& msg : dummy_messages) {
-    size_t msg_len = msg.length();
-    if (total_size + msg_len < debug_buffer_size) {
-      memcpy(data_ptr + total_size, msg.c_str(), msg_len);
-      total_size += msg_len;
+  for (size_t entry = 0; entry < num_entries; ++entry) {
+    // Random timestamp with some ordering
+    uint64_t timestamp = 1000000000ULL + counter * 10000 + entry * 100; // NOLINT(cppcoreguidelines-avoid-magic-numbers) - dummy data for pretty printing
+    
+    // Random format (0 or 1)
+    uint32_t format = (counter + entry) % 2; // NOLINT(cppcoreguidelines-avoid-magic-numbers) - dummy data for pretty printing
+    
+    // Random log level (0-7)
+    uint32_t level = (counter + entry) % 8; // NOLINT(cppcoreguidelines-avoid-magic-numbers) - dummy data for pretty printing
+    
+    // Random application number (1-8)
+    uint32_t appn = 1 + ((counter + entry) % 8); // NOLINT(cppcoreguidelines-avoid-magic-numbers) - dummy data for pretty printing
+    
+    // Random line number (1-8)
+    uint32_t line = 1 + ((counter + entry) % 8); // NOLINT(cppcoreguidelines-avoid-magic-numbers) - dummy data for pretty printing
+    
+    // Random module ID (1-15)
+    uint32_t module = 1 + ((counter + entry * 3) % 15); // NOLINT(cppcoreguidelines-avoid-magic-numbers) - dummy data for pretty printing
+    
+    // Generate string messages instead of hex payloads
+    std::vector<std::string> dummy_messages = {
+      "System initialization complete",
+      "DMA transfer started",
+      "Command queue overflow warning", 
+      "Temperature threshold exceeded",
+      "Memory allocation failed"
+    };
+    
+    std::string message = dummy_messages[entry % dummy_messages.size()]; // NOLINT(readability-magic-numbers) - dummy data for pretty printing
+    
+    // Set argc to 0 since we're using string messages, not hex arguments
+    uint32_t argc = 0;
+    
+    // Pack all bit fields into a single 64-bit value
+    uint64_t packed = (static_cast<uint64_t>(format) << 0) | 
+                      (static_cast<uint64_t>(0x60) << 1) | 
+                      (static_cast<uint64_t>(level) << 8) | 
+                      (static_cast<uint64_t>(0) << 11) | 
+                      (static_cast<uint64_t>(appn) << 16) | 
+                      (static_cast<uint64_t>(argc) << 24) |
+                      (static_cast<uint64_t>(line) << 32) |
+                      (static_cast<uint64_t>(module) << 48); // NOLINT(readability-magic-numbers,cppcoreguidelines-avoid-magic-numbers) - dummy data for pretty printing
+    
+    // Write header (16 bytes total)
+    memcpy(data_ptr + total_size, &timestamp, 8); // NOLINT(readability-magic-numbers,cppcoreguidelines-avoid-magic-numbers) - dummy data for pretty printing
+    total_size += 8; // NOLINT(readability-magic-numbers,cppcoreguidelines-avoid-magic-numbers) - dummy data for pretty printing
+    memcpy(data_ptr + total_size, &packed, 8); // NOLINT(readability-magic-numbers,cppcoreguidelines-avoid-magic-numbers) - dummy data for pretty printing
+    total_size += 8; // NOLINT(readability-magic-numbers,cppcoreguidelines-avoid-magic-numbers) - dummy data for pretty printing
+    
+    // Write string message as null-terminated string
+    size_t msg_len = message.length() + 1; // +1 for null terminator
+    memcpy(data_ptr + total_size, message.c_str(), msg_len);
+    total_size += msg_len;
+    
+    // Align to 4-byte boundary
+    while (total_size % 4 != 0) { // NOLINT(readability-magic-numbers,cppcoreguidelines-avoid-magic-numbers) - dummy data for pretty printing
+      data_ptr[total_size++] = 0;
     }
   }
   
@@ -68,10 +116,8 @@ parse_field(const field_context& ctx,
   uint64_t mask = (ctx.bit_width == bits_per_uint64) ? ~0ULL : ((1ULL << ctx.bit_width) - 1);
   uint64_t value = (raw >> lsb) & mask;
 
-  if (ctx.field && ctx.field->format.find("x") != std::string::npos) {
-    return (ctx.bit_width == bits_per_uint64) ? boost::str(boost::format("0x%0" + std::to_string(hex_width_64) + "X") % value) : boost::str(boost::format("0x%08X") % value);
-  } 
-  else if (ctx.field && ctx.field->name == "level") {
+  // For dummy data, display decimal values instead of hex
+  if (ctx.field && ctx.field->name == "level") {
     const auto& enums = config.get_enums();
     auto itr = enums.find(ctx.field->enumeration);
     if (itr != enums.end()) {
@@ -87,15 +133,18 @@ parse_message(const uint8_t* data_ptr,
               size_t argc,
               size_t buf_size)
 {
-  size_t msg_size = argc * sizeof(uint32_t);
-  if (msg_size > 0 && msg_offset + msg_size <= buf_size) {
-    std::ostringstream oss;
-    for (size_t i = 0; i < argc; ++i) {
-      uint32_t msg_val = 0;
-      std::memcpy(&msg_val, data_ptr + msg_offset + i * 4, 4);
-      oss << boost::str(boost::format("0x%08X ") % msg_val);
+  // Always try to read as null-terminated string
+  if (msg_offset < buf_size) {
+    const char* str_ptr = reinterpret_cast<const char*>(data_ptr + msg_offset);
+    // Find the end of the string or buffer boundary
+    size_t max_len = buf_size - msg_offset;
+    size_t str_len = 0;
+    while (str_len < max_len && str_ptr[str_len] != '\0') {
+      str_len++;
     }
-    return oss.str();
+    if (str_len > 0) {
+      return std::string(str_ptr, str_len);
+    }
   }
   return "";
 }
@@ -127,9 +176,16 @@ parse_log_entry(const uint8_t* data_ptr,
       if (field.name == "argc") {
         argc = static_cast<uint32_t>(std::stoul(field_value, nullptr, hex_width_64));
       }
-      entry_data.emplace_back(field_value);
+      
+      // Skip reserved fields when adding to entry data
+      if (field.name.find("reserved") == std::string::npos) {
+        entry_data.emplace_back(field_value);
+      }
     } else {
-      entry_data.emplace_back("-");
+      // Skip reserved fields when adding error placeholder
+      if (field.name.find("reserved") == std::string::npos) {
+        entry_data.emplace_back("-");
+      }
     }
     bit_offset += bit_width;
   }
@@ -144,12 +200,13 @@ generate_raw_logs(const xrt_core::device* dev,
                   bool is_watch,
                   uint64_t& watch_mode_offset)
 {
-  std::stringstream ss;
+  std::stringstream ss{};
 
   try {
-    // Create and allocate buffer for firmware log data
-    xrt_core::query::firmware_debug_buffer log_buffer;
-    auto buffer = smi_watch_mode::allocate_debug_buffer(log_buffer, watch_mode_offset, is_watch);
+    // Create and setup buffer for firmware log data
+    std::vector<char> buffer;
+    xrt_core::query::firmware_debug_buffer log_buffer{};
+    smi_watch_mode::setup_debug_buffer(buffer, log_buffer, watch_mode_offset, is_watch);
 
     // Get raw buffer from device for raw dump
     xrt_core::device_query<xrt_core::query::firmware_log_data>(dev, log_buffer);
@@ -178,18 +235,19 @@ generate_firmware_log_report(const xrt_core::device* dev,
                              bool is_watch,
                              bool use_dummy = false)
 {
-  std::stringstream ss;
+  std::stringstream ss{};
   static uint64_t watch_mode_offset = 0;
 
   try {
     // Load config once (could be cached in a real implementation)
-    std::string config_path;
+    std::string config_path{};
     config_path = xrt_core::device_query<xrt_core::query::firmware_log_config>(dev);
     firmware_log_config config(config_path);
 
-    // Create and allocate buffer for firmware log data
-    xrt_core::query::firmware_debug_buffer log_buffer;
-    auto buffer = smi_watch_mode::allocate_debug_buffer(log_buffer, watch_mode_offset, is_watch);
+    // Create and setup buffer for firmware log data
+    std::vector<char> buffer;
+    xrt_core::query::firmware_debug_buffer log_buffer{};
+    smi_watch_mode::setup_debug_buffer(buffer, log_buffer, watch_mode_offset, is_watch);
 
     if (use_dummy) 
     {
@@ -216,9 +274,52 @@ generate_firmware_log_report(const xrt_core::device* dev,
     size_t offset = 0;
 
     std::vector<Table2D::HeaderData> table_headers;
-    for (const auto& field : it->second.fields)
-      table_headers.push_back({field.name, Table2D::Justification::left});
-    table_headers.push_back({"message", Table2D::Justification::left});
+    
+    // Create meaningful column headers based on ipu_log_message_header structure
+    // Skip reserved fields and use descriptive names
+    for (const auto& field : it->second.fields) {
+      // Skip reserved fields
+      if (field.name.find("reserved") != std::string::npos) {
+        continue;
+      }
+      
+      // Map field names to more descriptive column headers
+      std::string header_name;
+      if (field.name == "timestamp") 
+      {
+        header_name = "Timestamp";
+      } 
+      else if (field.name == "format") 
+      {
+        header_name = "Format";
+      } 
+      else if (field.name == "level") 
+      {
+        header_name = "Log Level";
+      } 
+      else if (field.name == "appn") 
+      {
+        header_name = "Application Number";
+      } 
+      else if (field.name == "argc") 
+      {
+        header_name = "Argument Count";
+      } 
+      else if (field.name == "line") 
+      {
+        header_name = "Line Number";
+      } 
+      else if (field.name == "module") 
+      {
+        header_name = "Module ID";
+      } 
+      else {
+        header_name = field.name; // Fallback to original name
+      }
+      
+      table_headers.push_back({header_name, Table2D::Justification::left});
+    }
+    table_headers.push_back({"Message", Table2D::Justification::left});
     Table2D log_table(table_headers);
 
     size_t header_size = config.get_header_size();
@@ -226,7 +327,8 @@ generate_firmware_log_report(const xrt_core::device* dev,
     while (offset + header_size <= buf_size) {
       auto entry_data = parse_log_entry(data_ptr, offset, buf_size, config);
       log_table.addEntry(entry_data);
-      size_t msg_size = entry_data.back().size() * sizeof(uint32_t); // Approximate message size
+      
+      size_t msg_size = entry_data.back().size() + 1; // +1 for null terminator
       size_t aligned_msg_size = ((msg_size + 3) / 4) * 4; // 4-byte alignment
       offset += header_size + aligned_msg_size;
     }

--- a/src/runtime_src/core/tools/xbutil2/ReportFirmwareLog.cpp
+++ b/src/runtime_src/core/tools/xbutil2/ReportFirmwareLog.cpp
@@ -12,6 +12,7 @@
 #include <boost/format.hpp>
 #include <iomanip>
 #include <sstream>
+#include <unordered_map>
 #include <vector>
 #include <cstring>
 
@@ -284,38 +285,18 @@ generate_firmware_log_report(const xrt_core::device* dev,
       }
       
       // Map field names to more descriptive column headers
-      std::string header_name;
-      if (field.name == "timestamp") 
-      {
-        header_name = "Timestamp";
-      } 
-      else if (field.name == "format") 
-      {
-        header_name = "Format";
-      } 
-      else if (field.name == "level") 
-      {
-        header_name = "Log Level";
-      } 
-      else if (field.name == "appn") 
-      {
-        header_name = "Application Number";
-      } 
-      else if (field.name == "argc") 
-      {
-        header_name = "Argument Count";
-      } 
-      else if (field.name == "line") 
-      {
-        header_name = "Line Number";
-      } 
-      else if (field.name == "module") 
-      {
-        header_name = "Module ID";
-      } 
-      else {
-        header_name = field.name; // Fallback to original name
-      }
+      static const std::unordered_map<std::string, std::string> field_name_map = {
+        {"timestamp", "Timestamp"},
+        {"format", "Format"},
+        {"level", "Log Level"},
+        {"appn", "Application Number"},
+        {"argc", "Argument Count"},
+        {"line", "Line Number"},
+        {"module", "Module ID"}
+      };
+      
+      auto it_map = field_name_map.find(field.name);
+      std::string header_name = (it_map != field_name_map.end()) ? it_map->second : field.name;
       
       table_headers.push_back({header_name, Table2D::Justification::left});
     }

--- a/src/runtime_src/core/tools/xbutil2/ReportFirmwareLog.cpp
+++ b/src/runtime_src/core/tools/xbutil2/ReportFirmwareLog.cpp
@@ -131,7 +131,7 @@ parse_field(const field_context& ctx,
 static std::string
 parse_message(const uint8_t* data_ptr,
               size_t msg_offset,
-              size_t argc,
+              size_t /*argc*/,
               size_t buf_size)
 {
   // Always try to read as null-terminated string


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
1. This PR adds the firmware log buffer allocation to xrt-smi. 
2. This PR adds a dummy data generation API to report generation till the time drivers are ready. This is for demoing purpose.
3. This PR adds the ability to dump raw logs in case the configuration is not present (CIP : npu3/4). Required for bring up.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://jira.xilinx.com/browse/AIESW-5345
AIESW-5345

#### How problem was solved, alternative solutions (if any) and why they were rejected
Solved through adding the allocation API and using it to allocate and pass the buffer to shim wherever required

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Tested on Linux : 
Firmware log : 
```
---------------------------
[0000:c5:00.1] : NPU Strix
---------------------------
Firmware Log Report
===================

  Firmware Log Information:
    |Timestamp   |Format  |Log Level    |Application Number  |Argument Count  |Line Number  |Module ID  |Message                         |
    |------------|--------|-------------|--------------------|----------------|-------------|-----------|--------------------------------|
    |1000010000  |1       |1:err        |2                   |0               |2            |2          |System initialization complete  |
    |1000010100  |0       |2:wrn        |3                   |0               |3            |5          |DMA transfer started            |
    |1000010200  |1       |3:inf        |4                   |0               |4            |8          |Command queue overflow warning  |
    |1000010300  |0       |4:dbg        |5                   |0               |5            |11         |Temperature threshold exceeded  |
    |1000010400  |1       |5:<unknown>  |6                   |0               |6            |14         |Memory allocation failed        |
```
Event trace : 
```
---------------------------
[0000:c5:00.1] : NPU Strix
---------------------------
Event Trace Report
==================

[Using dummy test data]

Event Trace Report (Buffer: 120 bytes) - Wed Sep 17 05:16:43 2025 GMT
=======================================================

Total Events: 5
Buffer Offset: 120

  Event Trace Information:
    | Timestamp  |Event ID  |Event Name             |Category                |Payload  |Parsed Args                                                 |
    |------------|----------|-----------------------|------------------------|---------|------------------------------------------------------------|
    |1000010000  |0x0000    |PROCESS_APP_MSG_START  |MAILBOX|NPU_SCHEDULING  |0x161    |context_id=1, msg_opcode=IPU_MSG_APP_RELEASE_PARTITION      |
    |1000010100  |0x0002    |CREATE_CONTEXT         |MAILBOX|NPU_SCHEDULING  |0x151    |context_id=1, context_priority=21, num_cols=0, start_col=0  |
    |1000010200  |0x000a    |GATE_AIE2_CLKS         |CLKPWRGATING            |0x500    |num_cols=5, start_col=0                                     |
    |1000010300  |0x000e    |SUSPEND                |SUSPEND_RESUME          |0x100    |                                                            |
    |1000010400  |0x0001    |PROCESS_APP_MSG_DONE   |MAILBOX|NPU_SCHEDULING  |0x161    |context_id=1, msg_opcode=IPU_MSG_APP_RELEASE_PARTITION      |
```

#### Documentation impact (if any)
None