### PR TITLE
Backporting fix to Alveo hardware emulation crash with profiling to 2025.1 branch

### DIFF
--- a/src/runtime_src/core/pcie/emulation/hw_emu/alveo_shim/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_emu/alveo_shim/shim.cxx
@@ -75,6 +75,7 @@ namespace xclhwemhal2 {
   std::map<int, std::tuple<std::string,int,void*, unsigned int> > HwEmShim::mFdToFileNameMap;
   std::ofstream HwEmShim::mDebugLogStream;
   bool HwEmShim::mFirstBinary = true;
+  unsigned int HwEmShim::binaryCounter = 0;
   unsigned int HwEmShim::mBufferCount = 0;
   const int xclhwemhal2::HwEmShim::SPIR_ADDRSPACE_PRIVATE   = 0;
   const int xclhwemhal2::HwEmShim::SPIR_ADDRSPACE_GLOBAL    = 1;
@@ -2241,7 +2242,6 @@ namespace xclhwemhal2 {
 
     buf = nullptr;
     buf_size = 0;
-    binaryCounter = 0;
     host_sptag_idx = -1;
     sock = nullptr;
     mCURangeMap.clear();

--- a/src/runtime_src/core/pcie/emulation/hw_emu/alveo_shim/shim.h
+++ b/src/runtime_src/core/pcie/emulation/hw_emu/alveo_shim/shim.h
@@ -564,7 +564,7 @@ using addr_type = uint64_t;
       std::ofstream mGlobalOutMemStream;
       static std::ofstream mDebugLogStream;
       static bool mFirstBinary;
-      unsigned int binaryCounter;
+      static unsigned int binaryCounter;
 
       std::shared_ptr<unix_socket> sock;
       std::string deviceName;

--- a/src/runtime_src/xdp/profile/plugin/device_offload/hw_emu/hw_emu_device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/hw_emu/hw_emu_device_offload_plugin.cpp
@@ -89,7 +89,19 @@ namespace xdp {
     }
     readCounters();
 
-    clearOffloader(deviceId) ;
+    clearOffloader(deviceId);
+
+    // On Alveo hardware emulation (where there is only one device)
+    // we have to remove the device interface at this point.  This
+    // is because of the use case where xclbins get swapped out and
+    // replaced with a different xclbin.  Additionally, Alveo hardware
+    // emulation only calls flush device when the object is being closed.
+    if (!isEdge()) {
+      for (auto deviceId : devicesSeen) {
+        db->getStaticInfo().removeDeviceIntf(deviceId);
+      }
+      devicesSeen.clear();
+    }
   }
 
   void HWEmuDeviceOffloadPlugin::updateDevice(void* userHandle)


### PR DESCRIPTION
#### Problem solved by the commit
Backporting a fix in Alveo hardware emulation profiling to 2025.1.  This addresses an issue with two of the tutorial/sample designs in hardware emulation and was fixed in master on July 30th with pull request 9105.

#### Risks (if any) associated the changes in the commit
Low risk as this is specifically targeted to Alveo hardware emulation designs that have multiple xclbins swapped at runtime.

#### What has been tested and how, request additional testing if necessary
The two failing test cases have been verified to no longer crash and the other sample designs continue to work in hardware emulation.

#### Documentation impact (if any)
No documentation impact.