### PR TITLE
Updated ML timeline to report correct VE2 clock frequency 

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/ve2/ml_timeline.cpp
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/ve2/ml_timeline.cpp
@@ -158,7 +158,7 @@ namespace xdp {
     ptSchema.put("patch", "0");
     ptHeader.add_child("schema_version", ptSchema);
     ptHeader.put("device", "VE2");
-    ptHeader.put("clock_freq_MHz", 1000);
+    ptHeader.put("clock_freq_MHz", 1250);
     ptHeader.put("id_size", sizeof(uint32_t));
     ptHeader.put("cycle_size", 2*sizeof(uint32_t));
     ptHeader.put("buffer_size", mBufSz);


### PR DESCRIPTION
#### Problem solved by the commit
Updating the reported value of the VE2 clock frequency in ML timeline from 1 GHz to 1.25 GHz.  This is output in the record_timer_ts.json file and consumed by later tools.

#### Risks (if any) associated the changes in the commit
Low risk as this corrects an output not used by other tools.

#### Documentation impact (if any)
No documentation impact.