### PR TITLE
[XDP] Fixing run_summary generation 

### DIFF
--- a/src/runtime_src/xdp/profile/writer/vp_base/vp_run_summary.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/vp_run_summary.cpp
@@ -179,9 +179,9 @@ namespace xdp {
       boost::property_tree::ptree ptSystemDiagrams;
       for (const auto& s : systemDiagrams) {
 	boost::property_tree::ptree ptSystemDiagram;
-	ptSystemDiagram.put("hardware_context", s.contextId);
+	ptSystemDiagram.put("hw_context", s.contextId);
 	ptSystemDiagram.put("payload_16bitEnd", s.systemDiagram.c_str());
-	ptSystemDiagrams.add_child("system_diagram", ptSystemDiagram);
+	ptSystemDiagrams.push_back(std::make_pair("", ptSystemDiagram));
       }
       ptRunSummary.add_child("system_diagrams", ptSystemDiagrams);
     }


### PR DESCRIPTION
#### Problem solved by the commit
Updating the xrt.run_summary JSON file generated by profiling to conform to the specification needed by visualization tools.  This changes the system_diagrams section to be a list even in the case of a single entry.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Bug was found in testing of new features.

#### Documentation impact (if any)
No documentation impact.