### PR TITLE
Fix for Alveo hardware emulation device profiling/trace

### DIFF
--- a/src/runtime_src/core/pcie/emulation/hw_emu/alveo_shim/plugin/xdp/device_offload.cpp
+++ b/src/runtime_src/core/pcie/emulation/hw_emu/alveo_shim/plugin/xdp/device_offload.cpp
@@ -35,22 +35,19 @@ namespace device_offload {
                                 warning_callbacks) ;
   }
 
-  std::function<void (void*)> update_device_cb ;
+  std::function<void (void*, bool)> update_device_cb ;
   std::function<void (void*)> flush_device_cb ;
 
   void register_callbacks(void* handle)
   {
     using cb_type = void (*)(void*) ;
+    using ud_type = void (*)(void*, bool);
 
     update_device_cb =
-      reinterpret_cast<cb_type>(xrt_core::dlsym(handle, "updateDeviceHWEmu")) ;
-    if (xrt_core::dlerror() != nullptr)
-      update_device_cb = nullptr ;
+      reinterpret_cast<ud_type>(xrt_core::dlsym(handle, "updateDeviceHWEmu")) ;
 
     flush_device_cb =
       reinterpret_cast<cb_type>(xrt_core::dlsym(handle, "flushDeviceHWEmu")) ;
-    if (xrt_core::dlerror() != nullptr)
-      flush_device_cb = nullptr ;
   }
 
   void warning_callbacks()
@@ -63,7 +60,7 @@ namespace device_offload {
   void update_device(void* handle)
   {
     if (device_offload::update_device_cb != nullptr)
-      device_offload::update_device_cb(handle) ;
+      device_offload::update_device_cb(handle, false) ;
   }
 
   void flush_device(void* handle)

--- a/src/runtime_src/xdp/profile/plugin/device_offload/hw_emu/hw_emu_device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/hw_emu/hw_emu_device_offload_plugin.cpp
@@ -108,6 +108,9 @@ namespace xdp {
 
   void HWEmuDeviceOffloadPlugin::updateDevice(void* userHandle, bool hw_context_flow)
   {
+    if (!(db->getStaticInfo().continueXDPConfig(hw_context_flow)))
+      return;
+
     std::string path = ProcessHwEmuDebugIpLayoutPath(userHandle) ;
     if (path == "")
       return ;


### PR DESCRIPTION
#### Problem solved by the commit
Recent changes to profiling to add support for host code that uses hw_context missed applying those changes to Alveo hardware emulation.  The two changes in this pull request are to correctly connect the hook points with the XDP functions and to make sure we correctly identify load_xclbin versus register_xclbin styles of host code in hardware emulation.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
The bug was discovered through testing of other features.

#### Risks (if any) associated the changes in the commit
Low risk as this is specific to Alveo hardware emulation and restores the functionality of any of the currently running tests that use load_xclbin in their host code.

#### What has been tested and how, request additional testing if necessary
Tested on designs from the Vitis Accel Examples running hardware emulation.

#### Documentation impact (if any)
No documentation impact.