### PR TITLE
Check version before printing ctx health exception message

### DIFF
--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -4423,6 +4423,8 @@ amend_aie_error_message(const ert_packet* epkt, const std::string& msg)
   std::ostringstream oss;
   oss << msg << "\n";
   auto ctx_health = get_ert_ctx_health_data(epkt);
+  if (ctx_health->version != 0) return oss.str();
+
   oss << std::uppercase << std::hex << std::setfill('0');
   oss << "txn_op_idx = 0x" << std::setw(8) << ctx_health->txn_op_idx
     << "\nctx_pc = 0x"<< std::setw(8) << ctx_health->ctx_pc

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -4423,7 +4423,8 @@ amend_aie_error_message(const ert_packet* epkt, const std::string& msg)
   std::ostringstream oss;
   oss << msg << "\n";
   auto ctx_health = get_ert_ctx_health_data(epkt);
-  if (ctx_health->version != 0) return oss.str();
+  if (ctx_health->version != 0) 
+    return oss.str();
 
   oss << std::uppercase << std::hex << std::setfill('0');
   oss << "txn_op_idx = 0x" << std::setw(8) << ctx_health->txn_op_idx


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Added version check before printing ctx health exception message. At present ctx health data structure only supports version 0. 
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
