### PR TITLE
Update xrt-smi to handle new runner report format for iterations

### DIFF
--- a/src/runtime_src/core/common/runner/runner.cpp
+++ b/src/runtime_src/core/common/runner/runner.cpp
@@ -2178,6 +2178,7 @@ class profile
         m_report["cpu"]["throughput"] = throughput;
 
       if (m_verbose) {
+        std::cout << "Execution profile: " << m_name << "\n";
         std::cout << "Elapsed time (us): " << elapsed << "\n";
         if (m_legacy || m_mode == mode::latency)
           std::cout << "Average Latency (us): " << latency << "\n";

--- a/src/runtime_src/core/tools/common/tests/TestAIEReconfigOverhead.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestAIEReconfigOverhead.cpp
@@ -44,7 +44,7 @@ TestAIEReconfigOverhead::run(const std::shared_ptr<xrt_core::device>& dev)
     report = json::parse(runner.get_report());
     auto elapsed_nop = report["cpu"]["elapsed"].get<double>();
 
-    auto iterations = report["cpu"]["iterations"].get<double>(); 
+    auto iterations = report["iterations"].get<double>(); 
     double overhead = (elapsed - elapsed_nop) / (iterations * 1000); //NOLINT conversion to ms 
 
     XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Array reconfiguration overhead: %.1f ms") % overhead));

--- a/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.cpp
@@ -38,7 +38,7 @@ TestDF_bandwidth::run(const std::shared_ptr<xrt_core::device>& dev)
 
     auto report = json::parse(runner.get_report());
     auto elapsed_us = report["cpu"]["elapsed"].get<double>();
-    auto iterations = report["cpu"]["iterations"].get<int>();
+    auto iterations = report["iterations"].get<int>();
 
     // Used buffer in runner is 1GB in size, thus reporting in GB/s
     double bandwidth = (2 * iterations ) / (elapsed_us / 1000000); // NOLINT: Runner reports in microseconds, so conversion is required until request supports timescales


### PR DESCRIPTION
#### Problem solved by the commit
Accommodate minor runner report format changes.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
The report iterations element was moved out of the cpu node to the execution block in #9226.
