### PR TITLE
[XRT-SMI] Archive migration xrt-smi tests AIESW-10132

### DIFF
--- a/src/runtime_src/core/tools/common/TestRunner.cpp
+++ b/src/runtime_src/core/tools/common/TestRunner.cpp
@@ -8,6 +8,7 @@
 #include "core/common/error.h"
 #include "core/common/module_loader.h"
 #include "core/common/archive.h"
+#include "core/common/runner/runner.h"
 #include "core/tools/common/Process.h"
 #include "tools/common/BusyBar.h"
 #include "tools/common/XBUtilities.h"
@@ -279,4 +280,26 @@ TestRunner::get_test_header()
     ptree.put("xclbin", m_xclbin);
     ptree.put("explicit", m_explicit);
     return ptree;
+}
+
+xrt_core::runner::artifacts_repository 
+TestRunner::extract_artifacts_from_archive(const xrt_core::archive* archive, 
+                                           const std::vector<std::string>& artifact_names,
+                                           boost::property_tree::ptree& ptree)
+{
+  xrt_core::runner::artifacts_repository artifacts_repo;
+  
+  for (const auto& artifact_name : artifact_names) {
+    try {
+      std::string artifact_data = archive->data(artifact_name);
+      // Convert string to vector<char> for artifacts_repository
+      std::vector<char> artifact_binary(artifact_data.begin(), artifact_data.end());
+      artifacts_repo[artifact_name] = std::move(artifact_binary);
+    }
+    catch (const std::exception&) {
+      XBValidateUtils::logger(ptree, "Error", boost::str(boost::format("Required artifact not found: %s") % artifact_name));
+    }
+  }
+  
+  return artifacts_repo;
 }

--- a/src/runtime_src/core/tools/common/TestRunner.h
+++ b/src/runtime_src/core/tools/common/TestRunner.h
@@ -6,6 +6,7 @@
 
 // Local - Include Files
 #include "core/common/query_requests.h"
+#include "core/common/runner/runner.h"
 #include "JSONConfigurable.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_bo.h"
@@ -21,9 +22,12 @@
 #include <filesystem>
 #include <string>
 #include <vector>
+#include <map>
 
 // Forward declarations
-namespace xrt_core { class archive; }
+namespace xrt_core { 
+  class archive; 
+}
 
 class TestRunner : public JSONConfigurable {
   public:
@@ -61,6 +65,12 @@ class TestRunner : public JSONConfigurable {
     xrt::kernel get_kernel(const xrt::hw_context& hwctx, const std::string& kernel_or_elf);
     xrt::kernel get_kernel(const xrt::hw_context& hwctx, const std::string& kernel_name, 
       const std::string& elf_path); 
+
+    // Archive helper method for extracting artifacts
+    xrt_core::runner::artifacts_repository 
+    extract_artifacts_from_archive(const xrt_core::archive* archive, 
+                                   const std::vector<std::string>& artifact_names,
+                                   boost::property_tree::ptree& ptree);
 
     std::string m_xclbin;
  

--- a/src/runtime_src/core/tools/common/tests/TestAIEReconfigOverhead.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestAIEReconfigOverhead.cpp
@@ -7,6 +7,7 @@
 #include "xrt/xrt_device.h"
 #include "core/common/runner/runner.h"
 #include "core/common/json/nlohmann/json.hpp"
+#include "core/common/archive.h"
 namespace XBU = XBUtilities;
 using json = nlohmann::json;
 
@@ -15,30 +16,37 @@ TestAIEReconfigOverhead::TestAIEReconfigOverhead()
 {}
 
 boost::property_tree::ptree
-TestAIEReconfigOverhead::run(const std::shared_ptr<xrt_core::device>& dev)
+TestAIEReconfigOverhead::run(const std::shared_ptr<xrt_core::device>&)
 {
   boost::property_tree::ptree ptree = get_test_header();
-  std::string recipe = xrt_core::device_query<xrt_core::query::runner>(dev, xrt_core::query::runner::type::aie_reconfig_overhead_recipe);
-  std::string recipe_noop = xrt_core::device_query<xrt_core::query::runner>(dev, xrt_core::query::runner::type::aie_reconfig_overhead_nop_recipe);
-  std::string profile = xrt_core::device_query<xrt_core::query::runner>(dev, xrt_core::query::runner::type::aie_reconfig_overhead_profile);
-  std::string test = xrt_core::device_query<xrt_core::query::runner>(dev, xrt_core::query::runner::type::aie_reconfig_overhead_path); 
-  auto recipe_path = XBValidateUtils::findPlatformFile(recipe, ptree);
-  auto recipe_noop_path = XBValidateUtils::findPlatformFile(recipe_noop, ptree);
-  auto profile_path = XBValidateUtils::findPlatformFile(profile, ptree);
-  auto test_path =  XBValidateUtils::findPlatformFile(test, ptree);
-  
-  try {
-    xrt_core::runner runner(xrt::device(dev), recipe_path, profile_path, std::filesystem::path(test_path));
+  return ptree;
+}
 
-    //Run 1
+boost::property_tree::ptree
+TestAIEReconfigOverhead::run(const std::shared_ptr<xrt_core::device>& dev, const xrt_core::archive* archive)
+{
+  boost::property_tree::ptree ptree = get_test_header();
+
+  try {
+    std::string recipe_data = archive->data("recipe_aie_reconfig.json");
+    std::string recipe_noop_data = archive->data("recipe_aie_reconfig_nop.json");
+    std::string profile_data = archive->data("profile_aie_reconfig.json"); 
+    
+    auto artifacts_repo = extract_artifacts_from_archive(archive, {
+      "aie_reconfig.xclbin", 
+      "aie_reconfig.elf",
+      "nop.elf" 
+    }, ptree);
+    
+    // Create runner with recipe, profile, and artifacts repository - Run 1
+    xrt_core::runner runner(xrt::device(dev), recipe_data, profile_data, artifacts_repo);
     runner.execute();
     runner.wait();
     auto report = json::parse(runner.get_report());
     auto elapsed = report["cpu"]["elapsed"].get<double>();
 
-    runner = xrt_core::runner(xrt::device(dev), recipe_noop_path, profile_path, std::filesystem::path(test_path));
-
-    //Run 2
+    // Run 2 with noop recipe
+    runner = xrt_core::runner(xrt::device(dev), recipe_noop_data, profile_data, artifacts_repo);
     runner.execute();
     runner.wait();
     report = json::parse(runner.get_report());

--- a/src/runtime_src/core/tools/common/tests/TestAIEReconfigOverhead.h
+++ b/src/runtime_src/core/tools/common/tests/TestAIEReconfigOverhead.h
@@ -7,9 +7,12 @@
 #include "tools/common/TestRunner.h"
 #include "xrt/xrt_device.h"
 
+namespace xrt_core { class archive; }
+
 class TestAIEReconfigOverhead : public TestRunner {
   public :
     boost::property_tree::ptree run(const std::shared_ptr<xrt_core::device>&) override;
+    boost::property_tree::ptree run(const std::shared_ptr<xrt_core::device>&, const xrt_core::archive*);
 
     TestAIEReconfigOverhead();
 };

--- a/src/runtime_src/core/tools/common/tests/TestCmdChainLatency.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestCmdChainLatency.cpp
@@ -9,6 +9,7 @@
 #include "xrt/xrt_device.h"
 #include "core/common/runner/runner.h"
 #include "core/common/json/nlohmann/json.hpp"
+#include "core/common/archive.h"
 namespace XBU = XBUtilities;
 
 #include <filesystem>
@@ -19,19 +20,31 @@ TestCmdChainLatency::TestCmdChainLatency()
 {}
 
 boost::property_tree::ptree
-TestCmdChainLatency::run(const std::shared_ptr<xrt_core::device>& dev)
+TestCmdChainLatency::run(const std::shared_ptr<xrt_core::device>&)
 {
   boost::property_tree::ptree ptree = get_test_header();
-  std::string recipe = xrt_core::device_query<xrt_core::query::runner>(dev, xrt_core::query::runner::type::cmd_chain_latency_recipe);
-  std::string profile = xrt_core::device_query<xrt_core::query::runner>(dev, xrt_core::query::runner::type::cmd_chain_latency_profile);
-  std::string test = xrt_core::device_query<xrt_core::query::runner>(dev, xrt_core::query::runner::type::cmd_chain_latency_path); 
-  auto recipe_path = XBValidateUtils::findPlatformFile(recipe, ptree);
-  auto profile_path = XBValidateUtils::findPlatformFile(profile, ptree);
-  auto test_path = XBValidateUtils::findPlatformFile(test, ptree); 
-   
-  try
-  {
-    xrt_core::runner runner(xrt::device(dev), recipe_path, profile_path, std::filesystem::path(test_path));
+  return ptree;
+}
+
+boost::property_tree::ptree
+TestCmdChainLatency::run(const std::shared_ptr<xrt_core::device>& dev, const xrt_core::archive* archive)
+{
+  boost::property_tree::ptree ptree = get_test_header();
+  
+  try {
+    std::string recipe_data = archive->data("recipe_cmd_chain_latency.json");
+    std::string profile_data = archive->data("profile_cmd_chain_latency.json"); 
+    
+    std::vector<std::string> artifact_names = {
+      "validate.xclbin", 
+      "nop.elf" 
+    };
+    
+    // Extract artifacts using helper method
+    auto artifacts_repo = extract_artifacts_from_archive(archive, artifact_names, ptree);
+    
+    // Create runner with recipe, profile, and artifacts repository
+    xrt_core::runner runner(xrt::device(dev), recipe_data, profile_data, artifacts_repo);
     runner.execute();
     runner.wait();
 
@@ -41,11 +54,9 @@ TestCmdChainLatency::run(const std::shared_ptr<xrt_core::device>& dev)
     XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Average latency: %.1f us") % latency));
     ptree.put("status", XBValidateUtils::test_token_passed);
   }
-  catch (const std::exception& ex)
-  {
+  catch (const std::exception& ex) {
     XBValidateUtils::logger(ptree, "Error", ex.what());
     ptree.put("status", XBValidateUtils::test_token_failed);
-    return ptree;
   }
 
   return ptree;

--- a/src/runtime_src/core/tools/common/tests/TestCmdChainLatency.h
+++ b/src/runtime_src/core/tools/common/tests/TestCmdChainLatency.h
@@ -7,9 +7,12 @@
 #include "tools/common/TestRunner.h"
 #include "xrt/xrt_device.h"
 
+namespace xrt_core { class archive; }
+
 class TestCmdChainLatency : public TestRunner {
   public:
     boost::property_tree::ptree run(const std::shared_ptr<xrt_core::device>&) override;
+    boost::property_tree::ptree run(const std::shared_ptr<xrt_core::device>&, const xrt_core::archive*);
 
   public:
     TestCmdChainLatency();

--- a/src/runtime_src/core/tools/common/tests/TestCmdChainThroughput.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestCmdChainThroughput.cpp
@@ -9,6 +9,7 @@
 #include "xrt/xrt_device.h"
 #include "core/common/runner/runner.h"
 #include "core/common/json/nlohmann/json.hpp"
+#include "core/common/archive.h"
 namespace XBU = XBUtilities;
 
 // ----- C L A S S   M E T H O D S -------------------------------------------
@@ -17,18 +18,31 @@ TestCmdChainThroughput::TestCmdChainThroughput()
 {}
 
 boost::property_tree::ptree
-TestCmdChainThroughput::run(const std::shared_ptr<xrt_core::device>& dev)
+TestCmdChainThroughput::run(const std::shared_ptr<xrt_core::device>&)
 {
   boost::property_tree::ptree ptree = get_test_header();
-  std::string recipe = xrt_core::device_query<xrt_core::query::runner>(dev, xrt_core::query::runner::type::cmd_chain_throughput_recipe);
-  std::string profile = xrt_core::device_query<xrt_core::query::runner>(dev, xrt_core::query::runner::type::cmd_chain_throughput_profile);
-  std::string test = xrt_core::device_query<xrt_core::query::runner>(dev, xrt_core::query::runner::type::cmd_chain_throughput_path);
-  auto recipe_path = XBValidateUtils::findPlatformFile(recipe, ptree);
-  auto profile_path = XBValidateUtils::findPlatformFile(profile, ptree);
-  auto test_path = XBValidateUtils::findPlatformFile(test, ptree);
-  try
-  {
-    xrt_core::runner runner(xrt::device(dev), recipe_path, profile_path, std::filesystem::path(test_path));
+  return ptree;
+}
+
+boost::property_tree::ptree
+TestCmdChainThroughput::run(const std::shared_ptr<xrt_core::device>& dev, const xrt_core::archive* archive)
+{
+  boost::property_tree::ptree ptree = get_test_header();
+
+  try {
+    std::string recipe_data = archive->data("recipe_cmd_chain_throughput.json");
+    std::string profile_data = archive->data("profile_cmd_chain_throughput.json"); 
+    
+    std::vector<std::string> artifact_names = {
+      "validate.xclbin", 
+      "nop.elf" 
+    };
+    
+    // Extract artifacts using helper method
+    auto artifacts_repo = extract_artifacts_from_archive(archive, artifact_names, ptree);
+    
+    // Create runner with recipe, profile, and artifacts repository
+    xrt_core::runner runner(xrt::device(dev), recipe_data, profile_data, artifacts_repo);
     runner.execute();
     runner.wait();
 
@@ -38,11 +52,9 @@ TestCmdChainThroughput::run(const std::shared_ptr<xrt_core::device>& dev)
     XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Average throughput: %.1f ops/s") % throughput));
     ptree.put("status", XBValidateUtils::test_token_passed);
   }
-  catch (const std::exception& ex)
-  {
+  catch (const std::exception& ex) {
     XBValidateUtils::logger(ptree, "Error", ex.what());
     ptree.put("status", XBValidateUtils::test_token_failed);
-    return ptree;
   }
 
   return ptree;

--- a/src/runtime_src/core/tools/common/tests/TestCmdChainThroughput.h
+++ b/src/runtime_src/core/tools/common/tests/TestCmdChainThroughput.h
@@ -7,9 +7,12 @@
 #include "tools/common/TestRunner.h"
 #include "xrt/xrt_device.h"
 
+namespace xrt_core { class archive; }
+
 class TestCmdChainThroughput : public TestRunner {
   public:
     boost::property_tree::ptree run(const std::shared_ptr<xrt_core::device>&) override;
+    boost::property_tree::ptree run(const std::shared_ptr<xrt_core::device>&, const xrt_core::archive*);
 
   public:
     TestCmdChainThroughput();

--- a/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.cpp
@@ -10,6 +10,7 @@
 #include "xrt/xrt_device.h"
 #include "core/common/json/nlohmann/json.hpp"
 #include "tools/common/XBUtilities.h"
+#include "core/common/archive.h"
 
 using json = nlohmann::json;
 #include <filesystem>
@@ -20,19 +21,31 @@ TestDF_bandwidth::TestDF_bandwidth()
 {}
 
 boost::property_tree::ptree
-TestDF_bandwidth::run(const std::shared_ptr<xrt_core::device>& dev)
+TestDF_bandwidth::run(const std::shared_ptr<xrt_core::device>&)
 {
   boost::property_tree::ptree ptree = get_test_header();
-  std::string recipe = xrt_core::device_query<xrt_core::query::runner>(dev, xrt_core::query::runner::type::df_bandwidth_recipe);
-  std::string profile = xrt_core::device_query<xrt_core::query::runner>(dev, xrt_core::query::runner::type::df_bandwidth_profile);
-  std::string test = xrt_core::device_query<xrt_core::query::runner>(dev, xrt_core::query::runner::type::df_bandwidth_path);
-  auto recipe_path = XBValidateUtils::findPlatformFile(recipe, ptree);
-  auto profile_path = XBValidateUtils::findPlatformFile(profile, ptree);
-  auto test_path = XBValidateUtils::findPlatformFile(test, ptree);
+  return ptree;
+}
 
-  try
-  {
-    xrt_core::runner runner(xrt::device(dev), recipe_path, profile_path, std::filesystem::path(test_path));
+boost::property_tree::ptree
+TestDF_bandwidth::run(const std::shared_ptr<xrt_core::device>& dev, const xrt_core::archive* archive)
+{
+  boost::property_tree::ptree ptree = get_test_header();
+  
+  try {
+    std::string recipe_data = archive->data("recipe_df_bandwidth.json");
+    std::string profile_data = archive->data("profile_df_bandwidth.json"); 
+    
+    std::vector<std::string> artifact_names = {
+      "validate_df_bandwidth.xclbin", 
+      "df_bw.elf" 
+    };
+    
+    // Extract artifacts using helper method
+    auto artifacts_repo = extract_artifacts_from_archive(archive, artifact_names, ptree);
+    
+    // Create runner with recipe, profile, and artifacts repository
+    xrt_core::runner runner(xrt::device(dev), recipe_data, profile_data, artifacts_repo);
     runner.execute();
     runner.wait();
 
@@ -49,11 +62,9 @@ TestDF_bandwidth::run(const std::shared_ptr<xrt_core::device>& dev)
     XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Average bandwidth per shim DMA: %.1f GB/s") % bandwidth));
     ptree.put("status", XBValidateUtils::test_token_passed);
   }
-  catch(const std::exception& e)
-  {
+  catch(const std::exception& e) {
     XBValidateUtils::logger(ptree, "Error", e.what());
     ptree.put("status", XBValidateUtils::test_token_failed);
-    return ptree;
   }
   return ptree;
 }

--- a/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.h
+++ b/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.h
@@ -7,9 +7,12 @@
 #include "tools/common/TestRunner.h"
 #include "xrt/xrt_device.h"
 
+namespace xrt_core { class archive; }
+
 class TestDF_bandwidth : public TestRunner {
   public:
     boost::property_tree::ptree run(const std::shared_ptr<xrt_core::device>&) override;
+    boost::property_tree::ptree run(const std::shared_ptr<xrt_core::device>&, const xrt_core::archive*);
 
   public:
     TestDF_bandwidth();

--- a/src/runtime_src/core/tools/common/tests/TestGemm.h
+++ b/src/runtime_src/core/tools/common/tests/TestGemm.h
@@ -7,9 +7,12 @@
 #include "tools/common/TestRunner.h"
 #include "xrt/xrt_device.h"
 
+namespace xrt_core { class archive; }
+
 class TestGemm : public TestRunner {
   public:
     boost::property_tree::ptree run(const std::shared_ptr<xrt_core::device>&) override;
+    boost::property_tree::ptree run(const std::shared_ptr<xrt_core::device>&, const xrt_core::archive*);
 
   public:
     TestGemm();

--- a/src/runtime_src/core/tools/common/tests/TestNPULatency.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestNPULatency.cpp
@@ -41,26 +41,10 @@ TestNPULatency::run(const std::shared_ptr<xrt_core::device>& dev, const xrt_core
     std::string recipe_data = archive->data("recipe_latency.json");
     std::string profile_data = archive->data("profile_latency.json"); 
     
-    xrt_core::runner::artifacts_repository artifacts_repo;
-    
-    std::vector<std::string> artifact_names = {
+    auto artifacts_repo = extract_artifacts_from_archive(archive, {
       "validate.xclbin", 
       "nop.elf" 
-    };
-    
-    // Extract available artifacts from archive into repository
-    for (const auto& artifact_name : artifact_names) {
-      try {
-        std::string artifact_data = archive->data(artifact_name);
-        
-        // Convert string to vector<char> for artifacts_repository
-        std::vector<char> artifact_binary(artifact_data.begin(), artifact_data.end());
-        artifacts_repo[artifact_name] = std::move(artifact_binary);
-      }
-      catch (const std::exception&) {
-        XBValidateUtils::logger(ptree, "Error", boost::str(boost::format("Required artifact not found: %s") % artifact_name));
-      }
-    }
+    }, ptree);
     
     // Create runner with recipe, profile, and artifacts repository
     xrt_core::runner runner(xrt::device(dev), recipe_data, profile_data, artifacts_repo);

--- a/src/runtime_src/core/tools/common/tests/TestNPUThroughput.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestNPUThroughput.cpp
@@ -8,6 +8,7 @@
 #include "core/common/runner/runner.h"
 #include "xrt/xrt_device.h"
 #include "core/common/json/nlohmann/json.hpp"
+#include "core/common/archive.h"
 
 using json = nlohmann::json;
 #include <filesystem>
@@ -22,15 +23,25 @@ boost::property_tree::ptree
 TestNPUThroughput::run(const std::shared_ptr<xrt_core::device>& dev)
 {
   boost::property_tree::ptree ptree = get_test_header();
-  std::string recipe = xrt_core::device_query<xrt_core::query::runner>(dev, xrt_core::query::runner::type::throughput_recipe);
-  std::string profile = xrt_core::device_query<xrt_core::query::runner>(dev, xrt_core::query::runner::type::throughput_profile);
-  std::string test = xrt_core::device_query<xrt_core::query::runner>(dev, xrt_core::query::runner::type::throughput_path);
-  auto recipe_path = XBValidateUtils::findPlatformFile(recipe, ptree);
-  auto profile_path = XBValidateUtils::findPlatformFile(profile, ptree);
-  auto test_path = XBValidateUtils::findPlatformFile(test, ptree);
-  try
-  {
-    xrt_core::runner runner(xrt::device(dev), recipe_path, profile_path, std::filesystem::path(test_path));
+  return ptree;
+}
+
+boost::property_tree::ptree
+TestNPUThroughput::run(const std::shared_ptr<xrt_core::device>& dev, const xrt_core::archive* archive)
+{
+  boost::property_tree::ptree ptree = get_test_header();
+  
+  try {
+    std::string recipe_data = archive->data("recipe_throughput.json");
+    std::string profile_data = archive->data("profile_throughput.json"); 
+    
+    auto artifacts_repo = extract_artifacts_from_archive(archive, {
+      "validate.xclbin", 
+      "nop.elf" 
+    }, ptree);
+    
+    // Create runner with recipe, profile, and artifacts repository
+    xrt_core::runner runner(xrt::device(dev), recipe_data, profile_data, artifacts_repo);
     runner.execute();
     runner.wait();
 
@@ -38,8 +49,7 @@ TestNPUThroughput::run(const std::shared_ptr<xrt_core::device>& dev)
     XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Average throughput: %.1f op/s") % report["cpu"]["throughput"].get<double>()));
     ptree.put("status", XBValidateUtils::test_token_passed);
   }
-  catch(const std::exception& e)
-  {
+  catch(const std::exception& e) {
     XBValidateUtils::logger(ptree, "Error", e.what());
     ptree.put("status", XBValidateUtils::test_token_failed);
     return ptree;

--- a/src/runtime_src/core/tools/common/tests/TestNPUThroughput.h
+++ b/src/runtime_src/core/tools/common/tests/TestNPUThroughput.h
@@ -7,9 +7,12 @@
 #include "tools/common/TestRunner.h"
 #include "xrt/xrt_device.h"
 
+namespace xrt_core { class archive; }
+
 class TestNPUThroughput : public TestRunner {
   public:
     boost::property_tree::ptree run(const std::shared_ptr<xrt_core::device>&) override;
+    boost::property_tree::ptree run(const std::shared_ptr<xrt_core::device>&, const xrt_core::archive*);
 
   public:
     TestNPUThroughput();

--- a/src/runtime_src/core/tools/common/tests/TestTCTAllColumn.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestTCTAllColumn.cpp
@@ -9,6 +9,7 @@
 #include "xrt/xrt_device.h"
 #include "core/common/runner/runner.h"
 #include "core/common/json/nlohmann/json.hpp"
+#include "core/common/archive.h"
 
 // System - Include Files
 #include <filesystem>
@@ -34,20 +35,31 @@ TestTCTAllColumn::TestTCTAllColumn()
 {}
 
 boost::property_tree::ptree
-TestTCTAllColumn::run(const std::shared_ptr<xrt_core::device>& dev)
+TestTCTAllColumn::run(const std::shared_ptr<xrt_core::device>&)
 {
   boost::property_tree::ptree ptree = get_test_header();
-  std::string recipe = xrt_core::device_query<xrt_core::query::runner>(dev, xrt_core::query::runner::type::tct_all_column_recipe);
-  std::string profile = xrt_core::device_query<xrt_core::query::runner>(dev, xrt_core::query::runner::type::tct_all_column_profile);
-  std::string test = xrt_core::device_query<xrt_core::query::runner>(dev, xrt_core::query::runner::type::tct_all_column_path);
-  auto recipe_path = XBValidateUtils::findPlatformFile(recipe, ptree);
-  auto profile_path = XBValidateUtils::findPlatformFile(profile, ptree);
-  auto test_path = XBValidateUtils::findPlatformFile(test, ptree);
+  return ptree;
+}
 
-  try
-  {
-    // Create runner once 
-    xrt_core::runner runner(xrt::device(dev), recipe_path, profile_path, std::filesystem::path(test_path));
+boost::property_tree::ptree
+TestTCTAllColumn::run(const std::shared_ptr<xrt_core::device>& dev, const xrt_core::archive* archive)
+{
+  boost::property_tree::ptree ptree = get_test_header();
+  
+  try {
+    std::string recipe_data = archive->data("recipe_tct_all_column.json");
+    std::string profile_data = archive->data("profile_tct_all_column.json"); 
+    
+    std::vector<std::string> artifact_names = {
+      "tct_all_col.xclbin", 
+      "tct_4col.elf" 
+    };
+    
+    // Extract artifacts using helper method
+    auto artifacts_repo = extract_artifacts_from_archive(archive, artifact_names, ptree);
+    
+    // Create runner with archive data
+    xrt_core::runner runner(xrt::device(dev), recipe_data, profile_data, artifacts_repo);
     
     runner.execute();
     runner.wait();
@@ -63,10 +75,10 @@ TestTCTAllColumn::run(const std::shared_ptr<xrt_core::device>& dev)
     XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Average TCT throughput (all columns): %.1f TCT/s") % (samples * throughput)));
     ptree.put("status", XBValidateUtils::test_token_passed);
   }
-  catch(const std::exception& e)
-  {
+  catch(const std::exception& e) {
     XBValidateUtils::logger(ptree, "Error", e.what());
     ptree.put("status", XBValidateUtils::test_token_failed);
   }
+  
   return ptree;
 }

--- a/src/runtime_src/core/tools/common/tests/TestTCTAllColumn.h
+++ b/src/runtime_src/core/tools/common/tests/TestTCTAllColumn.h
@@ -7,9 +7,12 @@
 #include "tools/common/TestRunner.h"
 #include "xrt/xrt_device.h"
 
+namespace xrt_core { class archive; }
+
 class TestTCTAllColumn : public TestRunner {
   public:
     boost::property_tree::ptree run(const std::shared_ptr<xrt_core::device>&) override;
+    boost::property_tree::ptree run(const std::shared_ptr<xrt_core::device>&, const xrt_core::archive*);
 
   public:
     TestTCTAllColumn();

--- a/src/runtime_src/core/tools/common/tests/TestTCTOneColumn.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestTCTOneColumn.cpp
@@ -7,8 +7,8 @@
 #include "TestValidateUtilities.h"
 #include "tools/common/XBUtilities.h"
 #include "xrt/xrt_device.h"
-#include "core/common/runner/runner.h"
 #include "core/common/json/nlohmann/json.hpp"
+#include "core/common/archive.h"
 
 // System - Include Files
 #include <filesystem>
@@ -33,21 +33,31 @@ TestTCTOneColumn::TestTCTOneColumn()
 {}
 
 boost::property_tree::ptree
-TestTCTOneColumn::run(const std::shared_ptr<xrt_core::device>& dev)
+TestTCTOneColumn::run(const std::shared_ptr<xrt_core::device>&)
 {
   boost::property_tree::ptree ptree = get_test_header();
-  std::string recipe = xrt_core::device_query<xrt_core::query::runner>(dev, xrt_core::query::runner::type::tct_one_column_recipe);
-  std::string profile = xrt_core::device_query<xrt_core::query::runner>(dev, xrt_core::query::runner::type::tct_one_column_profile);
-  std::string test = xrt_core::device_query<xrt_core::query::runner>(dev, xrt_core::query::runner::type::tct_one_column_path);
-  auto recipe_path = XBValidateUtils::findPlatformFile(recipe, ptree);
-  auto profile_path = XBValidateUtils::findPlatformFile(profile, ptree);
-  auto test_path = XBValidateUtils::findPlatformFile(test, ptree);
+  return ptree;
+}
 
-  try
-  {
-    // Create runner once 
-    xrt_core::runner runner(xrt::device(dev), recipe_path, profile_path, std::filesystem::path(test_path));
+boost::property_tree::ptree
+TestTCTOneColumn::run(const std::shared_ptr<xrt_core::device>& dev, const xrt_core::archive* archive)
+{
+  boost::property_tree::ptree ptree = get_test_header();
+  
+  try {
+    std::string recipe_data = archive->data("recipe_tct_one_column.json");
+    std::string profile_data = archive->data("profile_tct_one_column.json"); 
     
+    std::vector<std::string> artifact_names = {
+      "tct_one_col.xclbin", 
+      "tct_1col.elf" 
+    };
+    
+    // Extract artifacts using helper method
+    auto artifacts_repo = extract_artifacts_from_archive(archive, artifact_names, ptree);
+    
+    // Create runner with recipe, profile, and artifacts repository
+    xrt_core::runner runner(xrt::device(dev), recipe_data, profile_data, artifacts_repo);
     runner.execute();
     runner.wait();
 
@@ -62,8 +72,7 @@ TestTCTOneColumn::run(const std::shared_ptr<xrt_core::device>& dev)
     XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Average TCT throughput: %.1f TCT/s") % (samples * throughput)));
     ptree.put("status", XBValidateUtils::test_token_passed);
   }
-  catch(const std::exception& e)
-  {
+  catch(const std::exception& e) {
     XBValidateUtils::logger(ptree, "Error", e.what());
     ptree.put("status", XBValidateUtils::test_token_failed);
   }

--- a/src/runtime_src/core/tools/common/tests/TestTCTOneColumn.h
+++ b/src/runtime_src/core/tools/common/tests/TestTCTOneColumn.h
@@ -7,9 +7,12 @@
 #include "tools/common/TestRunner.h"
 #include "xrt/xrt_device.h"
 
+namespace xrt_core { class archive; }
+
 class TestTCTOneColumn : public TestRunner {
   public:
     boost::property_tree::ptree run(const std::shared_ptr<xrt_core::device>&) override;
+    boost::property_tree::ptree run(const std::shared_ptr<xrt_core::device>&, const xrt_core::archive*);
 
   public:
     TestTCTOneColumn();


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Migrated all xrt-smi tests to use archive added to VTD

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
AIESW-10132

#### How problem was solved, alternative solutions (if any) and why they were rejected
Solved through using the archive object passes through TestRunner

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Tested on Linux. Requires VTD submodule updates in both xdna and MCDM for this to take effect

#### Documentation impact (if any)
None
