### PR TITLE
hip: device: correct hipGetDeviceCount() argument

### DIFF
--- a/src/runtime_src/hip/api/hip_device.cpp
+++ b/src/runtime_src/hip/api/hip_device.cpp
@@ -70,7 +70,7 @@ hip_init(unsigned int flags)
   std::call_once(device_init_flag, xrt::core::hip::device_init);
 }
 
-static size_t
+static int
 hip_get_device_count()
 {
   // Get device count
@@ -78,7 +78,7 @@ hip_get_device_count()
 
   throw_if(count < 1, hipErrorNoDevice, "No valid device available");
 
-  return count;
+  return static_cast<int>(count);
 }
 
 inline bool
@@ -163,7 +163,7 @@ hipInit(unsigned int flags)
 }
 
 hipError_t
-hipGetDeviceCount(size_t* count)
+hipGetDeviceCount(int* count)
 {
   return handle_hip_func_error(__func__, hipErrorUnknown, [&] {
     throw_invalid_value_if(!count, "arg passed is nullptr");


### PR DESCRIPTION
hipGetDeviceCount() arguement should be int* instead of size_t*

Fix to match the ROCM HIP API declaration. Tested with ROCM HIP 6.2.0 on both Linux/Windows, and check with latest ROCM HIP head, it is also `int*`

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
