### PR TITLE
Remove linking with -lcrypt

### DIFF
--- a/src/runtime_src/core/edge/common_em/CMakeLists.txt
+++ b/src/runtime_src/core/edge/common_em/CMakeLists.txt
@@ -45,7 +45,5 @@ target_link_libraries(common_em
   xrt_coreutil
   dl
   pthread
-  crypt
-  rt
   )
 

--- a/src/runtime_src/core/edge/ps_kernels/profiling/aie2_profile_config/CMakeLists.txt
+++ b/src/runtime_src/core/edge/ps_kernels/profiling/aie2_profile_config/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2018-2022 Xilinx, Inc. All rights reserved.
-# Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
 set(PS_KERNEL_INSTALL_DIR "${XRT_INSTALL_LIB_DIR}/ps_kernels_lib")
 
 include_directories(
@@ -28,10 +28,7 @@ target_link_libraries(aie2_profile_config
     xrt_core
     xilinxopencl
     pthread
-    rt
     dl
-    crypt
-    stdc++
     xaiengine
 )
 

--- a/src/runtime_src/core/edge/ps_kernels/profiling/aie2_trace_config/CMakeLists.txt
+++ b/src/runtime_src/core/edge/ps_kernels/profiling/aie2_trace_config/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2018-2022 Xilinx, Inc. All rights reserved.
-# Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
 set(PS_KERNEL_INSTALL_DIR "${XRT_INSTALL_LIB_DIR}/ps_kernels_lib")
 
 include_directories(
@@ -28,10 +28,7 @@ target_link_libraries(aie2_trace_config
     xrt_core
     xilinxopencl
     pthread
-    rt
     dl
-    crypt
-    stdc++
     xaiengine
 )
 

--- a/src/runtime_src/core/edge/ps_kernels/profiling/aie_profile_config/CMakeLists.txt
+++ b/src/runtime_src/core/edge/ps_kernels/profiling/aie_profile_config/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2018-2022 Xilinx, Inc. All rights reserved.
-# Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
 set(PS_KERNEL_INSTALL_DIR "${XRT_INSTALL_LIB_DIR}/ps_kernels_lib")
 
 include_directories(
@@ -28,10 +28,7 @@ target_link_libraries(aie_profile_config
     xrt_core
     xilinxopencl
     pthread
-    rt
     dl
-    crypt
-    stdc++
     xaiengine
 )
 

--- a/src/runtime_src/core/edge/ps_kernels/profiling/aie_trace_config/CMakeLists.txt
+++ b/src/runtime_src/core/edge/ps_kernels/profiling/aie_trace_config/CMakeLists.txt
@@ -28,10 +28,7 @@ target_link_libraries(aie_trace_config
     xrt_core
     xilinxopencl
     pthread
-    rt
     dl
-    crypt
-    stdc++
     xaiengine
 )
 

--- a/src/runtime_src/core/edge/ps_kernels/profiling/aie_trace_gmio/CMakeLists.txt
+++ b/src/runtime_src/core/edge/ps_kernels/profiling/aie_trace_gmio/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2018-2022 Xilinx, Inc. All rights reserved.
-# Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
 set(PS_KERNEL_INSTALL_DIR "${XRT_INSTALL_LIB_DIR}/ps_kernels_lib")
 
 include_directories(
@@ -28,10 +28,7 @@ target_link_libraries(aie_trace_gmio
     xrt_core
     xilinxopencl
     pthread
-    rt
     dl
-    crypt
-    stdc++
     xaiengine
 )
 

--- a/src/runtime_src/core/pcie/emulation/common_em/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/emulation/common_em/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2019-2021 Xilinx, Inc. All rights reserved.
-#
+# Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
 SET (Protobuf_DEBUG)
 INCLUDE(FindProtobuf)
 FIND_PACKAGE(Protobuf REQUIRED)
@@ -44,7 +44,5 @@ target_link_libraries(common_em
   xrt_coreutil
   dl
   pthread
-  crypt
-  rt
   )
 

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/azure/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/azure/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2019-2021 Xilinx, Inc. All rights reserved.
-#
+# Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
 if (NOT ${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm")
 
 include_directories(
@@ -32,7 +32,6 @@ target_link_libraries(azure_mpd_plugin
   xrt_coreutil_static
   uuid
   pthread
-  rt
   dl
   curl
   crypto

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/container/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/container/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2019-2021 Xilinx, Inc. All rights reserved.
-#
+# Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
 if (NOT ${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm")
 
 include_directories(
@@ -26,7 +26,6 @@ target_link_libraries(container_mpd_plugin
   xrt_coreutil_static
   uuid
   pthread
-  rt
   crypto
   )
 

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/container/container.cpp
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/container/container.cpp
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2019 Xilinx, Inc
-// Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
-
+// Copyright (C) 2019 Xilinx, Inc. All rights reserved
+// Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
 #include <errno.h>
 
 #include <sys/types.h>

--- a/src/runtime_src/xocl/CMakeLists.txt
+++ b/src/runtime_src/xocl/CMakeLists.txt
@@ -83,9 +83,7 @@ target_link_libraries(xilinxopencl
   xrt_coreutil
   dl
   pthread
-  crypt
   uuid
-  rt
   )
 
   # On linux use xrt_coreutil.a


### PR DESCRIPTION
#### Problem solved by the commit
Remove linking with `-lcrypt` which is not used.   Remove few other link also.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1102454
