### PR TITLE
Drop redundant assignment operator for xrt::uuid

### DIFF
--- a/src/runtime_src/core/include/xrt/xrt_uuid.h
+++ b/src/runtime_src/core/include/xrt/xrt_uuid.h
@@ -1,19 +1,6 @@
-/**
- * Copyright (C) 2016-2021 Xilinx, Inc
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2020-2022 Xilinx, Inc. All rights reserved.
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
 #ifndef xrt_uuid_h_
 #define xrt_uuid_h_
 
@@ -113,21 +100,6 @@ public:
   {
     uuid source(rhs);
     std::swap(*this,source);
-    return *this;
-  }
-
-  /**
-   * operator=() - assignment
-   *
-   * @param val
-   *   Value to be assigned from
-   * @return 
-   *   Reference to this
-   */
-  uuid&
-  operator=(const xuid_t val)
-  {
-    uuid_copy(m_uuid,val);
     return *this;
   }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Code that resets uuid variable using value assigment `uuid_variable = {};` is broken after #8622 

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Drop redundant assignment operator.
xrt::uuid already has non-explicit constructor from xuid_t that enables assignment from xuid_t.

Removed operator is choosen by compiler in value assignment `uuid_variable = {};` that leads to call with null pointer and segmentation fault.

Minimal example that demonstrates bug: https://godbolt.org/z/GvExv98j8 (line 52)
Minimal code that uses xrt/xrt_uuid.h header (compile with `g++ -ouuid uuid.cc -luuid`):

```
#include <xrt/xrt_uuid.h>

int main()
{
	xrt::uuid uuid = {};
	uuid = {};
}
```

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
