### PR TITLE
xrt-runner support immediate job execution when running a script

### DIFF
--- a/src/runtime_src/core/common/runner/README.md
+++ b/src/runtime_src/core/common/runner/README.md
@@ -66,9 +66,8 @@ pair, (2) multi-threaded execution of multiple recipe and profile
 pairs.
 
 To use locally built xrt-runner.exe, it is important that KMD and UMD
-is in sync with what xrt-runner.exe is built from.
+are in sync with what xrt-runner.exe is built from.
 ```
-% xrt-runner.exe --help
 usage: xrt-runner.exe [options]
  [--recipe <recipe.json>] recipe file to run
  [--profile <profile.json>] execution profile
@@ -77,7 +76,8 @@ usage: xrt-runner.exe [options]
  [--threads <number>] number of threads to use when running script (default: #jobs)
  [--dir <path>] directory containing artifacts (default: current dir)
  [--progress] show progress
- [--report] print runner metrics
+ [--asap] process jobs immediately (default: wait for all jobs to initialize)
+ [--report [<file>]] output runner metrics to <file> or use stdout for no <file> or '-'
 
 % xrt-runner.exe --recipe recipe.json --profile profile.json [--iterations <num>] [--dir <path>]
 % xrt-runner.exe --script runner.json [--threads <num>] [--iterations <num>] [--dir <path>]
@@ -127,6 +127,10 @@ recipe/profile pair, then the script value takes precedence over the
 command line switch.
 
 Each recipe/profile pair results in the creation of an xrt::runner
-object.  All xrt::runner objects are created and inserted into a work
-queue before execution starts.  Each thread executes work items
+object.  The runner objects are inserted into a work
+queue, and each thread executes work items
 (xrt::runner) from the work queue until the queue is empty.
+By default each thread blocks until the queue has been populated with 
+all initialized jobs.  If `[--asap]` 
+is specified when invoking xrt-runner.exe, jobs are executed as soon as
+possible.

--- a/src/runtime_src/core/common/runner/main.cpp
+++ b/src/runtime_src/core/common/runner/main.cpp
@@ -265,7 +265,7 @@ public:
   close()
   {
     std::lock_guard lk{m_mutex};
-    XRT_DEBUGF("job_queue::close() m_jobs.size(%d)\n", m_jobs.size())
+    XRT_DEBUGF("job_queue::close() m_jobs.size(%d)\n", m_jobs.size());
     m_stop = true;
     m_work_cv.notify_all();
   }
@@ -335,7 +335,7 @@ struct script_runner
           if (!job)
             break;
 
-          XRT_DEBUGF("script_runner::worker::run_by_value() running job(%s)\n", job->get_id().c_str());
+          XRT_DEBUGF("script_runner::worker::run_by_value() running job(%s)\n", job.get_id().c_str());
           job.run();
           job.wait();
           report.add(job);

--- a/src/runtime_src/core/common/runner/runner.cpp
+++ b/src/runtime_src/core/common/runner/runner.cpp
@@ -2616,7 +2616,7 @@ wait()
 
 std::string
 runner::
-get_report()
+get_report() const
 {
   return handle->get_report();
 }

--- a/src/runtime_src/core/common/runner/runner.h
+++ b/src/runtime_src/core/common/runner/runner.h
@@ -159,7 +159,7 @@ public:
   // The schema of the report is TBD
   XRT_API_EXPORT
   std::string
-  get_report();
+  get_report() const;
 
   // map_buffer() - Get raw buffer data as a span of bytes
   // The buffer is synced from device as part of this call.


### PR DESCRIPTION
#### Problem solved by the commit
Add `--asap` switch to supporting processing jobs immediately.

#### How problem was solved, alternative solutions (if any) and why they were rejected
The script job queue is disabled until it is explicitly enabled.  This allows for all jobs to be initialized before any one job is returned to a worker.  If enabled up-front jobs are returned as soon as a worker requests a job and one is available.

```
% xrt-runner --help
usage: xrt-runner.exe [options]
 [--recipe <recipe.json>] recipe file to run
 [--profile <profile.json>] execution profile
 [--iterations <number>] override all profile iterations
 [--script <script>] runner script, enables multi-threaded execution
 [--threads <number>] number of threads to use when running script (default: #jobs)
 [--dir <path>] directory containing artifacts (default: current dir)
 [--progress] show progress
 [--asap] process jobs immediately (default: wait for all jobs to initialize)
 [--report [<file>]] output runner metrics to <file> or use stdout for no <file> or '-'

% xrt-runner.exe --recipe recipe.json --profile profile.json [--iterations <num>] [--dir <path>]
% xrt-runner.exe --script runner.json [--threads <num>] [--iterations <num>] [--dir <path>]

Note, [--threads <number>] overrides the default number, where default is the number of
jobs in the runner script.

Note, [--iterations <num>] overrides iterations in profile.json, but not in runner script.
If the runner script specifies iterations for a recipe/profile pair, then this value is
sticky for that recipe/profile pair.
```
