### PR TITLE
hip: add get control scrachpad bo support

### DIFF
--- a/src/runtime_src/hip/api/hip_module.cpp
+++ b/src/runtime_src/hip/api/hip_module.cpp
@@ -15,7 +15,7 @@ static void
 hip_module_launch_kernel(hipFunction_t f, uint32_t /*gridDimX*/, uint32_t /*gridDimY*/,
                          uint32_t /*gridDimZ*/, uint32_t /*blockDimX*/, uint32_t /*blockDimY*/,
                          uint32_t /*blockDimZ*/, uint32_t sharedMemBytes, hipStream_t hStream,
-                         void** kernelParams, void** /*extra*/)
+                         void** kernelParams, void** extra)
 {
   throw_invalid_resource_if(!f, "function is nullptr");
 
@@ -34,7 +34,7 @@ hip_module_launch_kernel(hipFunction_t f, uint32_t /*gridDimX*/, uint32_t /*grid
   auto cmd_hdl = insert_in_map(command_cache,
                                std::make_shared<kernel_start>(hip_stream,
                                                               hip_func,
-                                                              kernelParams));
+                                                              kernelParams, extra));
   s_hdl->enqueue(command_cache.get(cmd_hdl));
 }
 

--- a/src/runtime_src/hip/core/event.h
+++ b/src/runtime_src/hip/core/event.h
@@ -123,9 +123,12 @@ class kernel_start : public command
 {
 private:
   std::shared_ptr<function> func;
+  xrt::bo m_ctrl_scratchpad_bo;
+  bool m_ctrl_scratchpad_bo_sync_rd;
   xrt::run r;
 
 public:
+  kernel_start(std::shared_ptr<stream> s, std::shared_ptr<function> f, void** args, void** extra);
   kernel_start(std::shared_ptr<stream> s, std::shared_ptr<function> f, void** args);
   ~kernel_start() override
   {

--- a/src/runtime_src/hip/xrt_hip.h
+++ b/src/runtime_src/hip/xrt_hip.h
@@ -5,6 +5,14 @@
 
 #include "hip/hip_runtime_api.h"
 
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+// NOLINTBEGIN(modernize-use-using, cppcoreguidelines-pro-type-member-init)
+
+#include <stdint.h>
+
 enum hipModuleDataType {
   hipModuleDataFilePath = 0,
   hipModuleDataBuffer
@@ -18,8 +26,49 @@ struct hipModuleData
                            // parent is null for xclbin creation, parent will point
                            // to xclbin module for elf creation
   void* data;              // pointer to file path or buffer based on type
-  size_t size;             // size of data buffer passed 
+  size_t size;             // size of data buffer passed
 };
+
+// HIP XRT extension
+enum hipXrtExtraInfoId {
+  hipXrtExtraInfoCtrlScratchPad,
+  hipXrtExtraInfoMax,
+};
+
+typedef struct hipXrtInfoExtraHead {
+  uint32_t extraId; // id of the extra info structure
+  uint32_t size; // size of the extra info structure including this header
+  void* info; // pointer to the details of the information
+} hipXrtInfoExtraHead_t;
+
+typedef struct hipXrtInfoCtrlScratchPad {
+  uint64_t ctrlScratchPadHostPtr; // Control scratchpad buffer host pointer,
+                                  // User pass control scratchpad bo initial
+                                  // content to XRT HIP for kernel launch.
+                                  // XRT HIP allocate control scratchpad bo
+                                  // for a run, and returns the host mapping pointer
+                                  // back to user with this field.
+  uint32_t ctrlScratchPadSize; // Control scratchpad buffer size.
+                              // Specified by user to tell the initial control
+                              // scratchpad content length. XRT HIP returns the
+                              // actual control scratchpad bo size back to user.
+  uint32_t syncAfterRun; // Pass by user to tell XRT HIP whether it needs to sync
+                         // after the XRT run is complete.
+} hipXrtInfoCtrlScratchPad_t;
+
+typedef struct hipXrtInfoExtraArray {
+  uint32_t numExtras; // number of extra information elements in the array
+  struct hipXrtInfoExtraHead extras[1]; // extra information elements array
+                                        // use length 1 here to avoid
+                                        // Zero-Sized Array as a Nonstandard Extension warning
+                                        // actual length depends on the @numExtras
+} hipXrtInfoExtraArray_t;
+
+// NOLINTEND(modernize-use-using, cppcoreguidelines-pro-type-member-init)
+
+#if defined(__cplusplus)
+} // extern "C"
+#endif
 
 #endif
 


### PR DESCRIPTION
Adding control scrachpad bo support to allow user to pass control scratchpad buffer information to kernel launch and enable users to get the allocated control scratchpad buffer from XRT.

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
XRT supports user to pass initial state information to AIE execution through control scratchpad buffer and allows users to access the control scratchpad buffer.

As control scratchpad is not a kernel argument and it is located in IPU SRAM, there is no existing HIP APIs to pass control scratchpad buffer between host control application and the NPU runtime library/driver. This patch set adds an extension to define extran arguments format to allow user to pass this information through kernel launch API. And host control application can get the buffer information returned from XRT HIP API through the same in/out argument.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Test case: https://gitenterprise.xilinx.com/wendlian/testcases-v2/blob/hip-utests/unittests/hip/src/test-basic.cpp#L110
[test-control-strachpad.cpp.txt](https://github.com/user-attachments/files/22505183/test-control-strachpad.cpp.txt)


#### Documentation impact (if any)
