### PR TITLE
hip: CMake: propagate XRT include header directory to user

### DIFF
--- a/src/runtime_src/hip/CMakeLists.txt
+++ b/src/runtime_src/hip/CMakeLists.txt
@@ -31,8 +31,9 @@ else()
 endif()
 
 target_include_directories(xrt_hip
-  PRIVATE
-  ${XRT_SOURCE_DIR}/runtime_src
+  PUBLIC
+  $<BUILD_INTERFACE:${XRT_SOURCE_DIR}/runtime_src>
+  $<INSTALL_INTERFACE:${XRT_INSTALL_INCLUDE_DIR}>
 )
 
 target_link_libraries(xrt_hip


### PR DESCRIPTION
XRT HIP extension header will be installed in XRT include header directory, propagate the XRT include header directory to user, such that when user depends on XRT::xrt_hip, the XRT header directory will be added by CMake to the include system directories path.

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
