### PR TITLE
Do not fail when LINUX_VERSION variable is empty

### DIFF
--- a/src/CMake/cpackLin.cmake
+++ b/src/CMake/cpackLin.cmake
@@ -58,7 +58,7 @@ set(CPACK_COMPONENT_XRT-DEV_DEPENDS xrt)
 SET(CPACK_RPM_SPEC_MORE_DEFINE "%define __python python3")
 
 if (DEFINED CROSS_COMPILE)
-  set(CPACK_REL_VER ${LINUX_VERSION})
+  set(CPACK_REL_VER "${LINUX_VERSION}")
 elseif (${LINUX_FLAVOR} MATCHES "^centos")
   execute_process(
     COMMAND awk "{print $4}" /etc/redhat-release
@@ -141,7 +141,7 @@ if (${LINUX_FLAVOR} MATCHES "^(ubuntu|debian|linuxmint)")
       dkms (>= 2.2.0), udev")
   endif()
 
-  if ((${LINUX_FLAVOR} MATCHES "^(ubuntu)") AND (${LINUX_VERSION} STREQUAL "23.10"))
+  if ((${LINUX_FLAVOR} MATCHES "^(ubuntu)") AND ("${LINUX_VERSION}" STREQUAL "23.10"))
     # Workaround for the following class of cpack build failure on Ubuntu 23.10
     # CMake Error at /usr/share/cmake-3.27/Modules/Internal/CPack/CPackDeb.cmake:348 (message):
     #   CPackDeb: dpkg-shlibdeps: 'dpkg-shlibdeps: error: no dependency information


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Running build/build.sh on debain/testing fail due to missing version tag.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Debian testing and unstable do not have version number so LINUX_VERSION variable is empty. CMake is not happy with unquoted use of empty variables.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Use quotes around ${LINUX_VERSION}. Alternative is to get VERSION_CODENAME if ID is missing.

Also looks like there is code duplication in src/CMake/nativeLnx.cmake:
```
if (${LINUX_FLAVOR} MATCHES "^centos")
  execute_process(
    COMMAND awk "{print $4}" /etc/redhat-release
    COMMAND tr -d "\""
    OUTPUT_VARIABLE LINUX_VERSION
    OUTPUT_STRIP_TRAILING_WHITESPACE
  )
else()
  execute_process(
    COMMAND awk -F= "$1==\"VERSION_ID\" {print $2}" /etc/os-release
    COMMAND tr -d "\""
    OUTPUT_VARIABLE LINUX_VERSION
    OUTPUT_STRIP_TRAILING_WHITESPACE
)
endif()
```
and src/CMake/cpackLin.cmake:
```
if (DEFINED CROSS_COMPILE)
  set(CPACK_REL_VER ${LINUX_VERSION})
elseif (${LINUX_FLAVOR} MATCHES "^centos")
  execute_process(
    COMMAND awk "{print $4}" /etc/redhat-release
    COMMAND tr -d "\""
    OUTPUT_VARIABLE CPACK_REL_VER
    OUTPUT_STRIP_TRAILING_WHITESPACE
  )
else()
  execute_process(
      COMMAND awk -F= "$1==\"VERSION_ID\" {print $2}" /etc/os-release
      COMMAND tr -d "\""
      OUTPUT_VARIABLE CPACK_REL_VER
      OUTPUT_STRIP_TRAILING_WHITESPACE
)
endif()
```
Maybe it can be replaced by simple `set(CPACK_REL_VER "${LINUX_VERSION}")`?
#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
