### PR TITLE
Change xbmgmt2 executable name to xbmgmt

### DIFF
--- a/src/CMake/nativeTests.cmake
+++ b/src/CMake/nativeTests.cmake
@@ -23,7 +23,7 @@ set_tests_properties(xrt-smi PROPERTIES ENVIRONMENT
 
 if (XRT_XRT OR XRT_ALVEO)
   add_test(NAME xbmgmt2
-    COMMAND ${XRT_BINARY_DIR}/runtime_src/core/tools/xbmgmt2/xbmgmt2 examine -r host
+    COMMAND ${XRT_BINARY_DIR}/runtime_src/core/tools/xbmgmt2/xbmgmt examine -r host
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
   set_tests_properties(xbmgmt2 PROPERTIES ENVIRONMENT

--- a/src/runtime_src/core/tools/xbmgmt2/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbmgmt2/CMakeLists.txt
@@ -52,11 +52,10 @@ file(GLOB XBMGMT_V2_SUBCMD_FILES
 set(XBMGMT_V2_SRCS ${XBMGMT_V2_BASE_FILES} ${XBMGMT_V2_SUBCMD_FILES})
 
 # Determine the name of the executable
+set(XBMGMT2_NAME "xbmgmt")
 if(WIN32)
-  set(XBMGMT2_NAME "xbmgmt")     # Yes, on windows the file name will be xbmgmt
   set(XRT_LOADER_SCRIPTS "xbmgmt" "xbmgmt.bat")
 else()
-  set(XBMGMT2_NAME "xbmgmt2")
   set(XRT_LOADER_SCRIPTS "xbmgmt")
 endif()
 

--- a/src/runtime_src/core/tools/xbmgmt2/xbmgmt
+++ b/src/runtime_src/core/tools/xbmgmt2/xbmgmt
@@ -15,7 +15,7 @@ if [ "$(uname | grep -E '^(windows32|CYGWIN)')" ]; then
 fi
 
 # Working variables
-XRT_PROG=xbmgmt2
+XRT_PROG=xbmgmt
 
 # Examine the options and look for -new/--new
 XRTWARP_PROG_ARGS_size=0


### PR DESCRIPTION
When installing to system path wrapper script is not used and 'xbmgmt' command is available under 'xbmgmt2' name.

Commandeer #9268
Once merged this PR closes #9268