### PR TITLE
Use PACKAGE_NAME consistent with directory name in dkms.conf

### DIFF
--- a/src/CMake/config/dkms-awsmgmt/dkms.conf.in
+++ b/src/CMake/config/dkms-awsmgmt/dkms.conf.in
@@ -1,4 +1,4 @@
-PACKAGE_NAME="xrt-awsmgmt"
+PACKAGE_NAME="xrt-aws"
 PACKAGE_VERSION="@XRT_VERSION_STRING@"
 MAKE[0]="cd driver/aws; make KERNELDIR=${kernel_source_dir}; cd ../.."
 CLEAN="cd driver/aws; make clean KERNELDIR=${kernel_source_dir}; cd ../.."

--- a/src/CMake/config/dkms-xocl/dkms.conf.in
+++ b/src/CMake/config/dkms-xocl/dkms.conf.in
@@ -1,4 +1,4 @@
-PACKAGE_NAME="xrt-xocl"
+PACKAGE_NAME="xrt"
 PACKAGE_VERSION="@XRT_VERSION_STRING@"
 MAKE[0]="cd driver/xocl; make KERNEL_SRC=${kernel_source_dir}; cd ../.."
 CLEAN="cd driver/xocl; make clean KERNEL_SRC=${kernel_source_dir}; cd ../.."


### PR DESCRIPTION
Commandeer #9276 
Once merged this PR closes #9276 

#### Problem solved by the commit
DKMS documentation states that PACKAGE_NAME variable should be same as directory name:

  add [module/module-version | /path/to/source-tree | /path/to/tarball.tar]

  Adds a module/module-version combination to the tree for builds and installs.
  If module/module-version, -m module/module-version, or -m module -v
  module-version are passed as options, this command requires source in
  /usr/src/<module>-<module-version>/ as well as a properly formatted dkms.conf
  file.

  PACKAGE_NAME=

  This directive is used to give the name associated with the entire package of
  modules. This is the same name that is used with the -m option when
  building, adding, etc. and may not necessarily be the same as the MODULE_NAME.
  This directive must be present in every DKMS configuration file.

