### PR TITLE
[XDP] Fix to handle V3 metadata unique case

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_trace_config_v3_filetype.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_trace_config_v3_filetype.cpp
@@ -182,9 +182,8 @@ AIETraceConfigV3Filetype::getTiles(const std::string& graph_name,
     for (const auto& pair : tileMap) {
         const tile_type& tile = pair.second;
 
-        if ((type == module_type::core) && tile.active_core) {
-            tiles.push_back(tile);
-        } else if ((type == module_type::dma) && tile.active_memory) {
+        if (((type == module_type::core) && tile.active_core) ||
+            ((type == module_type::dma) && tile.active_memory)) {
             tiles.push_back(tile);
         }
     }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
[CR-1251582] - multikernel design has dmaChannels spreaded across different tiles. Such metadata needed to be handled.
 
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
[CR-1251582] - Feature test.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Code parsing check for dma channels associated tiles to be available from earlier core tiles map.

#### Risks (if any) associated the changes in the commit
low

#### What has been tested and how, request additional testing if necessary
Verified on original AIE test.

#### Documentation impact (if any)
