### PR TITLE
Update recipe.json schema with new kernel attribute

### DIFF
--- a/src/runtime_src/core/common/runner/recipe.md
+++ b/src/runtime_src/core/common/runner/recipe.md
@@ -99,6 +99,7 @@ with the control code.
         "name": "k1",
         "instance": "DPU",
         "ctrlcode": "no-ctrl-packet.elf"
+        "numargs": number
       }
     ]
   },
@@ -113,6 +114,15 @@ control code, then only one such kernel instance needs to be listed in
 the resources section.  Listing multiple kernel instances referring to
 the same kernel and using the same control code is not error,
 but is not necessary.
+
+The `numargs` is unused by the xrt::runner class, but is added to
+support using the recipe to create application code invoking a kernel
+with free formed args. For example, `hipLaunchKernel` takes a void**
+array of args, where the length of the array is supposed to exactly
+match the number of arguments to the kernel.  The recipe `runs`
+section itself may not specify all arguments, but a `hip` application
+created from the recipe.json must create an array of all expected
+arguments, where missing args will be populated with a default value.
 
 ### CPU functions
 

--- a/src/runtime_src/core/common/runner/schema/recipe.schema.json
+++ b/src/runtime_src/core/common/runner/schema/recipe.schema.json
@@ -32,6 +32,11 @@
       "type": "integer",
       "minimum": 0
     },
+    "index": {
+      "$comment": "index value",
+      "type": "integer",
+      "minimum": 0
+    },
     "size": {
       "$comment": "size or offset of a buffer",
       "type": "integer",
@@ -88,7 +93,8 @@
             "properties": {
               "name": { "$ref": "#/$defs/key" },
               "instance": { "type": "string" },
-              "ctrlcode": { "$ref": "#/$defs/path" }
+              "ctrlcode": { "$ref": "#/$defs/path" },
+              "numargs": { "$ref": "#/$defs/index" }
             },
             "additionalProperties": false
           }


### PR DESCRIPTION
#### Problem solved by the commit
Add recipe kernel attribute to list the number of expected kernel arguments.

#### How problem was solved, alternative solutions (if any) and why they were rejected
```
  "resources": {
    "kernels": [
      {
        ...
        "numargs": number
      }
    ]
  },
```
The `numargs` is unused by the xrt::runner class, but is added to support using the recipe to create application code invoking a kernel with free formed args. For example, `hipLaunchKernel` takes a void** array of args, where the length of the array is supposed to exactly match the number of arguments to the kernel.  The recipe `runs` section itself may not specify all arguments, but a `hip` application created from the recipe.json must create an array of all expected arguments, where missing args will be populated with a default value.
