### PR TITLE
[XRT-SMI] Archive migration for firmware debuggability configurations AIESW-14046

### DIFF
--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -4146,10 +4146,7 @@ struct firmware_debug_buffer {
 
 struct event_trace_version : request 
 {
-  struct result_type {
-    uint16_t major;
-    uint16_t minor;
-  };
+  using result_type = uint32_t;
 
   static const key_type key = key_type::event_trace_version;
 

--- a/src/runtime_src/core/tools/common/TestRunner.cpp
+++ b/src/runtime_src/core/tools/common/TestRunner.cpp
@@ -281,27 +281,3 @@ TestRunner::get_test_header()
     ptree.put("explicit", m_explicit);
     return ptree;
 }
-
-xrt_core::runner::artifacts_repository 
-TestRunner::extract_artifacts_from_archive(const xrt_core::archive* archive, 
-                                           const std::vector<std::string>& artifact_names,
-                                           boost::property_tree::ptree& ptree)
-{
-  xrt_core::runner::artifacts_repository artifacts_repo;
-  
-  for (const auto& artifact_name : artifact_names) {
-    try {
-      std::string artifact_data = archive->data(artifact_name);
-      // Convert string to vector<char> for artifacts_repository
-      std::vector<char> artifact_binary(artifact_data.begin(), artifact_data.end());
-      artifacts_repo[artifact_name] = std::move(artifact_binary);
-    }
-    catch (const std::exception&) {
-      if (XBUtilities::getVerbose()) {
-        XBValidateUtils::logger(ptree, "Warning", boost::str(boost::format("Artifact not found: %s") % artifact_name));
-      }
-    }
-  }
-  
-  return artifacts_repo;
-}

--- a/src/runtime_src/core/tools/common/TestRunner.h
+++ b/src/runtime_src/core/tools/common/TestRunner.h
@@ -66,12 +66,6 @@ class TestRunner : public JSONConfigurable {
     xrt::kernel get_kernel(const xrt::hw_context& hwctx, const std::string& kernel_name, 
       const std::string& elf_path); 
 
-    // Archive helper method for extracting artifacts
-    xrt_core::runner::artifacts_repository 
-    extract_artifacts_from_archive(const xrt_core::archive* archive, 
-                                   const std::vector<std::string>& artifact_names,
-                                   boost::property_tree::ptree& ptree);
-
     std::string m_xclbin;
  
   //variables

--- a/src/runtime_src/core/tools/common/XBUtilities.h
+++ b/src/runtime_src/core/tools/common/XBUtilities.h
@@ -9,6 +9,8 @@
 // Please keep these to the bare minimum
 #include "core/common/device.h"
 #include "core/common/query_requests.h"
+#include "core/common/archive.h"
+#include "core/common/runner/runner.h"
 
 #include <chrono>
 #include <iostream>
@@ -126,6 +128,19 @@ namespace XBUtilities {
     */
     return (x != 0) && ((x & (x - 1)) == 0);
   }
+
+  /**
+   * Extract artifacts from archive
+   */
+  xrt_core::runner::artifacts_repository 
+  extract_artifacts_from_archive(const xrt_core::archive* archive, 
+                                 const std::vector<std::string>& artifact_names);
+
+  /**
+   * Open archive from device
+   */
+  std::unique_ptr<xrt_core::archive> 
+  open_archive(const xrt_core::device* device);
 
  /*
   * xclbin locking

--- a/src/runtime_src/core/tools/common/tests/TestAIEReconfigOverhead.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestAIEReconfigOverhead.cpp
@@ -32,11 +32,11 @@ TestAIEReconfigOverhead::run(const std::shared_ptr<xrt_core::device>& dev, const
     std::string recipe_noop_data = archive->data("recipe_aie_reconfig_nop.json");
     std::string profile_data = archive->data("profile_aie_reconfig.json"); 
     
-    auto artifacts_repo = extract_artifacts_from_archive(archive, {
+    auto artifacts_repo = XBU::extract_artifacts_from_archive(archive, {
       "aie_reconfig.xclbin", 
       "aie_reconfig.elf",
       "nop.elf" 
-    }, ptree);
+    });
     
     // Create runner with recipe, profile, and artifacts repository - Run 1
     xrt_core::runner runner(xrt::device(dev), recipe_data, profile_data, artifacts_repo);

--- a/src/runtime_src/core/tools/common/tests/TestCmdChainLatency.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestCmdChainLatency.cpp
@@ -36,12 +36,10 @@ TestCmdChainLatency::run(const std::shared_ptr<xrt_core::device>& dev, const xrt
     std::string profile_data = archive->data("profile_cmd_chain_latency.json"); 
     
     // Extract artifacts using helper method
-    auto artifacts_repo = extract_artifacts_from_archive(archive, {
+    auto artifacts_repo = XBU::extract_artifacts_from_archive(archive, {
       "validate.xclbin", 
-      "nop.elf" 
-    }, ptree);
-    
-    // Create runner with recipe, profile, and artifacts repository
+      "nop.elf"
+    });    // Create runner with recipe, profile, and artifacts repository
     xrt_core::runner runner(xrt::device(dev), recipe_data, profile_data, artifacts_repo);
     runner.execute();
     runner.wait();

--- a/src/runtime_src/core/tools/common/tests/TestCmdChainThroughput.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestCmdChainThroughput.cpp
@@ -34,12 +34,10 @@ TestCmdChainThroughput::run(const std::shared_ptr<xrt_core::device>& dev, const 
     std::string profile_data = archive->data("profile_cmd_chain_throughput.json"); 
     
     // Extract artifacts using helper method
-    auto artifacts_repo = extract_artifacts_from_archive(archive, {
+    auto artifacts_repo = XBU::extract_artifacts_from_archive(archive, {
       "validate.xclbin", 
       "nop.elf" 
-    }, ptree);
-    
-    // Create runner with recipe, profile, and artifacts repository
+    });    // Create runner with recipe, profile, and artifacts repository
     xrt_core::runner runner(xrt::device(dev), recipe_data, profile_data, artifacts_repo);
     runner.execute();
     runner.wait();

--- a/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.cpp
@@ -37,10 +37,10 @@ TestDF_bandwidth::run(const std::shared_ptr<xrt_core::device>& dev, const xrt_co
     std::string profile_data = archive->data("profile_df_bandwidth.json"); 
     
     // Extract artifacts using helper method
-    auto artifacts_repo = extract_artifacts_from_archive(archive, {
+    auto artifacts_repo = XBUtilities::extract_artifacts_from_archive(archive, {
       "validate_df_bandwidth.xclbin", 
       "df_bw.elf" 
-    }, ptree);
+    });
     
     // Create runner with recipe, profile, and artifacts repository
     xrt_core::runner runner(xrt::device(dev), recipe_data, profile_data, artifacts_repo);

--- a/src/runtime_src/core/tools/common/tests/TestGemm.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestGemm.cpp
@@ -45,10 +45,10 @@ TestGemm::run(const std::shared_ptr<xrt_core::device>& dev, const xrt_core::arch
     std::string profile_data = archive->data("profile_gemm.json"); 
     
     // Extract artifacts using helper method
-    auto artifacts_repo = extract_artifacts_from_archive(archive, {
+    auto artifacts_repo = XBU::extract_artifacts_from_archive(archive, {
       "gemm.xclbin", 
       "gemm.elf" 
-    }, ptree);
+    });
     
     // Create runner with recipe, profile, and artifacts repository
     xrt_core::runner runner(xrt::device(dev), recipe_data, profile_data, artifacts_repo);

--- a/src/runtime_src/core/tools/common/tests/TestNPULatency.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestNPULatency.cpp
@@ -5,6 +5,7 @@
 // Local - Include Files
 #include "TestNPULatency.h"
 #include "TestValidateUtilities.h"
+#include "tools/common/XBUtilities.h"
 #include "xrt/xrt_device.h"
 #include "core/common/runner/runner.h"
 #include "core/common/json/nlohmann/json.hpp"
@@ -41,10 +42,10 @@ TestNPULatency::run(const std::shared_ptr<xrt_core::device>& dev, const xrt_core
     std::string recipe_data = archive->data("recipe_latency.json");
     std::string profile_data = archive->data("profile_latency.json"); 
     
-    auto artifacts_repo = extract_artifacts_from_archive(archive, {
+    auto artifacts_repo = XBUtilities::extract_artifacts_from_archive(archive, {
       "validate.xclbin", 
       "nop.elf" 
-    }, ptree);
+    });
     
     // Create runner with recipe, profile, and artifacts repository
     xrt_core::runner runner(xrt::device(dev), recipe_data, profile_data, artifacts_repo);

--- a/src/runtime_src/core/tools/common/tests/TestNPUThroughput.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestNPUThroughput.cpp
@@ -5,6 +5,7 @@
 // Local - Include Files
 #include "TestNPUThroughput.h"
 #include "TestValidateUtilities.h"
+#include "tools/common/XBUtilities.h"
 #include "core/common/runner/runner.h"
 #include "xrt/xrt_device.h"
 #include "core/common/json/nlohmann/json.hpp"
@@ -35,10 +36,10 @@ TestNPUThroughput::run(const std::shared_ptr<xrt_core::device>& dev, const xrt_c
     std::string recipe_data = archive->data("recipe_throughput.json");
     std::string profile_data = archive->data("profile_throughput.json"); 
     
-    auto artifacts_repo = extract_artifacts_from_archive(archive, {
+    auto artifacts_repo = XBUtilities::extract_artifacts_from_archive(archive, {
       "validate.xclbin", 
       "nop.elf" 
-    }, ptree);
+    });
     
     // Create runner with recipe, profile, and artifacts repository
     xrt_core::runner runner(xrt::device(dev), recipe_data, profile_data, artifacts_repo);

--- a/src/runtime_src/core/tools/common/tests/TestTCTAllColumn.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestTCTAllColumn.cpp
@@ -51,10 +51,10 @@ TestTCTAllColumn::run(const std::shared_ptr<xrt_core::device>& dev, const xrt_co
     std::string profile_data = archive->data("profile_tct_all_column.json"); 
     
     // Extract artifacts using helper method
-    auto artifacts_repo = extract_artifacts_from_archive(archive, {
+    auto artifacts_repo = XBU::extract_artifacts_from_archive(archive, {
       "tct_all_col.xclbin", 
       "tct_4col.elf" 
-    }, ptree);
+    });
     
     // Create runner with archive data
     xrt_core::runner runner(xrt::device(dev), recipe_data, profile_data, artifacts_repo);

--- a/src/runtime_src/core/tools/common/tests/TestTCTOneColumn.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestTCTOneColumn.cpp
@@ -49,10 +49,10 @@ TestTCTOneColumn::run(const std::shared_ptr<xrt_core::device>& dev, const xrt_co
     std::string profile_data = archive->data("profile_tct_one_column.json"); 
     
     // Extract artifacts using helper method
-    auto artifacts_repo = extract_artifacts_from_archive(archive, {
+    auto artifacts_repo = XBU::extract_artifacts_from_archive(archive, {
       "tct_one_col.xclbin", 
       "tct_1col.elf" 
-    }, ptree);
+    });
     
     // Create runner with recipe, profile, and artifacts repository
     xrt_core::runner runner(xrt::device(dev), recipe_data, profile_data, artifacts_repo);

--- a/src/runtime_src/core/tools/xbutil2/EventTraceConfig.cpp
+++ b/src/runtime_src/core/tools/xbutil2/EventTraceConfig.cpp
@@ -18,27 +18,12 @@ namespace {
 constexpr uint32_t event_bits_default = 16;
 constexpr uint32_t payload_bits_default = 48;
 
-static nlohmann::json 
-load_json_file(const std::string& json_file_path) 
-{
-  if (json_file_path.empty()) {
-    throw std::runtime_error("JSON file path cannot be empty");
-  }
-  std::ifstream file(json_file_path);
-  if (!file.is_open()) {
-    throw std::runtime_error("Cannot open JSON file: " + json_file_path);
-  }
-  nlohmann::json j;
-  file >> j;
-  return j;
-}
-
 } // End of unnamed namespace
 namespace xrt_core::tools::xrt_smi{
 
 event_trace_config::
-event_trace_config(const std::string& json_file_path)
-  : config(load_json_file(json_file_path)),
+event_trace_config(const nlohmann::json& json_config)
+  : config(json_config),
     event_bits(parse_event_bits(config)),
     payload_bits(parse_payload_bits(config)),
     file_major(parse_major_version(config)),

--- a/src/runtime_src/core/tools/xbutil2/EventTraceConfig.h
+++ b/src/runtime_src/core/tools/xbutil2/EventTraceConfig.h
@@ -92,7 +92,7 @@ public:
    * to check if the JSON file version matches the device/shim version.
    */
   explicit
-  event_trace_config(const std::string& json_file_path = "trace_events.json");
+  event_trace_config(const nlohmann::json& json_config);
 
   /**
    * @brief Parse a single trace event from raw data

--- a/src/runtime_src/core/tools/xbutil2/FirmwareLogConfig.cpp
+++ b/src/runtime_src/core/tools/xbutil2/FirmwareLogConfig.cpp
@@ -6,23 +6,9 @@
 
 namespace xrt_core::tools::xrt_smi {
 
-static nlohmann::json 
-load_json_config(const std::string& json_file_path) {
-  if (json_file_path.empty()) {
-    throw std::runtime_error("JSON file path cannot be empty");
-  }
-  std::ifstream file(json_file_path);
-  if (!file.is_open()) {
-    throw std::runtime_error("Cannot open JSON file: " + json_file_path);
-  }
-  nlohmann::json j;
-  file >> j;
-  return j;
-}
-
 firmware_log_config::
-firmware_log_config(const std::string& json_file_path)
-  : config(load_json_config(json_file_path)),
+firmware_log_config(const nlohmann::json& json_config)
+  : config(json_config),
     enums(parse_enums(config)),
     structures(parse_structures(config)),
     header_size(calculate_header_size(structures))

--- a/src/runtime_src/core/tools/xbutil2/FirmwareLogConfig.h
+++ b/src/runtime_src/core/tools/xbutil2/FirmwareLogConfig.h
@@ -79,14 +79,13 @@ public:
 
 public:
   /**
-   * @brief Constructor - loads configuration from JSON file
-   * @param json_file_path Path to firmware_log.json file
+   * @brief Constructor - loads configuration from JSON content
+   * @param json_content JSON content as string
    *
-   * Loads and parses the JSON file, populating enums and structures.
-   * Sets valid_ to true if successful, false otherwise.
+   * Parses the JSON content directly, populating enums and structures.
    */
     explicit
-    firmware_log_config(const std::string& json_file_path); // Initializes using static parse APIs
+    firmware_log_config(const nlohmann::json& json_config); // Initializes using static parse APIs
 
   /**
    * @brief Get parsed enumerations

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -299,21 +299,7 @@ run_test_suite_device( const std::shared_ptr<xrt_core::device>& device,
   if (testObjectsToRun.empty())
     throw std::runtime_error("No test given to validate against.");
 
-  // Get archive path from device query and create archive object
-  std::unique_ptr<xrt_core::archive> test_archive;
-  try {
-    std::string archive_path = xrt_core::device_query<xrt_core::query::archive_path>(device.get());
-    auto archive = XBValidateUtils::findPlatformFile(archive_path, ptDevCollectionTestSuite);
-    if (!archive.empty() && std::filesystem::exists(archive)) {
-      test_archive = std::make_unique<xrt_core::archive>(archive);
-      XBU::verbose("Loaded test archive: " + archive);
-    } else {
-      XBU::verbose("Archive path not found or does not exist: " + archive);
-    }
-  } catch (const std::exception& e) {
-    XBU::verbose("Archive not available: " + std::string(e.what()));
-    // Continue without archive - this is not a fatal error
-  }
+  auto test_archive = XBU::open_archive(device.get());
 
   get_platform_info(device, ptDeviceInfo, schemaVersion, std::cout);
   std::cout << "-------------------------------------------------------------------------------" << std::endl;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
From cleanliness perspective, we have decided to move all xrt-smi related artifact files (json, binaries etc) under a platform specific archive. The archives will be a part of the [VTD repository](https://github.com/Xilinx/VTD) under the folder archive. This migration was done through some of the previous PRs.
This PR adds the firmware debuggability configurations to the strx specific archive and moves around some APIs for ease of use.
This PR also changes the event_trace and firmware_log reports to query from this archive and makes cosmetic code changes within the report code.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://jira.xilinx.com/browse/AIESW-14046

#### How problem was solved, alternative solutions (if any) and why they were rejected
Solved via creating generic APIs : 
1. open_archive
2. extract_artifacts_from_archive
and adding them to xrt-smi utility APIs to be used freely within the tool. With this, the xrt-smi validate tests and examine reports now open and extract from archive with correct artifact names instead of opening a file from path. The API will ignore without erroring out in-case the artifact is not present.

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Tested the 2 reports with dummy data on linux with configuration queried from archive as opposed to shim previously: 
```
---------------------------
[0000:c5:00.1] : NPU Strix
---------------------------
Firmware Log Report
===================

  Firmware Log Information:
    |Timestamp   |Format  |Log Level    |Application Number  |Argument Count  |Line Number  |Module ID  |Message                         |
    |------------|--------|-------------|--------------------|----------------|-------------|-----------|--------------------------------|
    |1000010000  |1       |1:err        |2                   |0               |2            |2          |System initialization complete  |
    |1000010100  |0       |2:wrn        |3                   |0               |3            |5          |DMA transfer started            |
    |1000010200  |1       |3:inf        |4                   |0               |4            |8          |Command queue overflow warning  |
    |1000010300  |0       |4:dbg        |5                   |0               |5            |11         |Temperature threshold exceeded  |
    |1000010400  |1       |5:<unknown>  |6                   |0               |6            |14         |Memory allocation failed        |
```
Configuration is queried and parses messages correctly.

#### Documentation impact (if any)
None