### PR TITLE
Trace/Profile support using runlist

### DIFF
--- a/src/runtime_src/core/common/api/hw_context_int.h
+++ b/src/runtime_src/core/common/api/hw_context_int.h
@@ -8,6 +8,7 @@
 // This file defines implementation extensions to the XRT XCLBIN APIs.
 #include "core/include/xrt/xrt_hw_context.h"
 #include "core/include/xrt/experimental/xrt_module.h"
+#include "core/include/xrt/xrt_kernel.h"
 
 #include <cstdint>
 
@@ -69,6 +70,23 @@ get_scratchpad_mem_buf(const xrt::hw_context& hwctx, size_t size_per_col);
 // Dump scratch pad mem buffer contents into a file when ini option is enabled
 void
 dump_scratchpad_mem(const xrt::hw_context& hwctx);
+
+// APIs used by XDP to register init and exit runs
+// These runs will be used to initialize AI array and collect profile/trace data
+// These runs are added to runlist at the beginning and end respectively
+XRT_CORE_COMMON_EXPORT
+void
+register_xdp_init_run(const xrt::hw_context& ctx, const xrt::run& run);
+
+XRT_CORE_COMMON_EXPORT
+void
+register_xdp_exit_run(const xrt::hw_context& ctx, const xrt::run& run);
+
+const std::vector<xrt::run>&
+get_xdp_init_runs(const xrt::hw_context& ctx);
+
+const std::vector<xrt::run>&
+get_xdp_exit_runs(const xrt::hw_context& ctx);
 
 }} // hw_context_int, xrt_core
 

--- a/src/runtime_src/core/common/api/xrt_hw_context.cpp
+++ b/src/runtime_src/core/common/api/xrt_hw_context.cpp
@@ -12,6 +12,7 @@
 #include "core/common/time.h"
 #include "core/common/utils.h"
 #include "core/include/xrt/xrt_hw_context.h"
+#include "core/include/xrt/xrt_kernel.h"
 #include "core/include/xrt/experimental/xrt_ext.h"
 #include "core/include/xrt/experimental/xrt_module.h"
 #include "bo_int.h"
@@ -141,6 +142,11 @@ class hw_context_impl : public std::enable_shared_from_this<hw_context_impl>
   // are saved to a scratchpad memory allocated specifically for that context.
   std::once_flag m_scratchpad_init_flag; // used for thread safe lazy init of scratchpad
   xrt::bo m_scratchpad_buf;
+  // Vector of XDP runs to be added at beginning and end of runlist
+  // These runs initializes/configures AI array and collects the profile/trace data
+  std::vector<xrt::run> m_xdp_init_runs;
+  std::vector<xrt::run> m_xdp_exit_runs;
+
   std::shared_ptr<xrt_core::usage_metrics::base_logger> m_usage_logger =
       xrt_core::usage_metrics::get_usage_metrics_logger();
   bool m_elf_flow = false;
@@ -454,6 +460,33 @@ public:
     msg.append(dump_file_name);
     xrt_core::message::send(xrt_core::message::severity_level::debug, "xrt_hw_context", msg);
   }
+
+  // Callback Functions for XDP to register init and exit runs
+  // that are added to xrt::runlist at start and end respectively
+  void
+  register_xdp_init_run(const xrt::run& run)
+  {
+    m_xdp_init_runs.push_back(run);
+  }
+
+  void
+  register_xdp_exit_run(const xrt::run& run)
+  {
+    m_xdp_exit_runs.push_back(run);
+  }
+
+  // Functions to get XDP init and exit run vectors
+  const std::vector<xrt::run>&
+  get_xdp_init_runs() const
+  {
+    return m_xdp_init_runs;
+  }
+
+  const std::vector<xrt::run>&
+  get_xdp_exit_runs() const
+  {
+    return m_xdp_exit_runs;
+  }
 };
 
 } // xrt
@@ -519,6 +552,31 @@ void
 dump_scratchpad_mem(const xrt::hw_context& hwctx)
 {
   return hwctx.get_handle()->dump_scratchpad_mem();
+}
+
+void
+register_xdp_init_run(const xrt::hw_context& ctx, const xrt::run& run)
+{
+  ctx.get_handle()->register_xdp_init_run(run);
+}
+
+XRT_CORE_COMMON_EXPORT
+void
+register_xdp_exit_run(const xrt::hw_context& ctx, const xrt::run& run)
+{
+  ctx.get_handle()->register_xdp_exit_run(run);
+}
+
+const std::vector<xrt::run>&
+get_xdp_init_runs(const xrt::hw_context& ctx)
+{
+  return ctx.get_handle()->get_xdp_init_runs();
+}
+
+const std::vector<xrt::run>&
+get_xdp_exit_runs(const xrt::hw_context& ctx)
+{
+  return ctx.get_handle()->get_xdp_exit_runs();
 }
 
 } // xrt_core::hw_context_int


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Added trace/profile support using runlist.
Earlier XDP hooks were in xrt::hw_context constructor and destructor but now because of recent optimizations we have to move them to xrt::runlist.
Spec for this change is captured in confluence page - https://amd.atlassian.net/wiki/spaces/~rbramand/pages/1117815036/Trace+Profile+flow+proposal+using+runlist

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
#### How problem was solved, alternative solutions (if any) and why they were rejected
While the solution has its own limitations it can act as workaround to collect XDP data

#### Risks (if any) associated the changes in the commit
Low as the feature works only when ini options related to xdp are enabled

#### What has been tested and how, request additional testing if necessary
Tested using runlist test case on strix linux and xdp init and exit runs are properly added and removed as expected

#### Documentation impact (if any)
May be we need to update about limitations on when Profile/Trace data can be captured.