### PR TITLE
Fix Dtrace bug

### DIFF
--- a/src/runtime_src/core/common/api/xrt_hw_context.cpp
+++ b/src/runtime_src/core/common/api/xrt_hw_context.cpp
@@ -79,6 +79,13 @@ class hw_context_impl : public std::enable_shared_from_this<hw_context_impl>
       auto bo = xrt_core::bo_int::
         create_bo(device, (size_per_uc * num_uc), xrt_core::bo_int::use_type::log);
 
+      // Log buffers first 8 bytes are used for metadata
+      // So make sure it is initialized with zero's before configuring
+      constexpr size_t metadata_size = 8;
+      char* buf_map = bo.map<char*>();
+      std::memset(buf_map, 0, metadata_size);
+      bo.sync(XCL_BO_SYNC_BO_TO_DEVICE, metadata_size, 0);
+
       // create map with uc index and log buffer size
       std::map<uint32_t, size_t> uc_buf_map;
       for (uint32_t i = 0; i < num_uc; ++i)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
This PR fixes bug in dtrace code.
Dtrace library provided in ini option is opened using dlopen and is used to create, fill dtrace buffer and is later closed. When dlclose is called on the library all the variables stored in the library gets destroyed but while dumping the dtrace buffer we need some data in dtrace library which is lost. Added changes to extend the lifetime of library handle created by adding it as a member in module object.

This PR also adds changes to initialize log buffer initial 8 bytes that will be used for metadata to all zeros before configuring

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://github.com/Xilinx/XRT/pull/8721 introduced the bug. It was discovered while testing the feature on windows

#### How problem was solved, alternative solutions (if any) and why they were rejected
Extended the scope of library handle created using dlopen to the scope of module object by making it a member in it.

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
Tested dtrace function on Telluride and it works as expected.
Need to test on aie4 windows where the issue is reported
 
#### Documentation impact (if any)
NA