### PR TITLE
Fix force-preemption CLI

### DIFF
--- a/src/runtime_src/core/tools/xbutil2/OO_Preemption.h
+++ b/src/runtime_src/core/tools/xbutil2/OO_Preemption.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2024-2025 Advanced Micro Devices, Inc. All rights reserved.
 
 #ifndef __OO_Preemption_h_
 #define __OO_Preemption_h_
@@ -17,7 +17,6 @@ class OO_Preemption : public OptionOptions {
  private:
   std::string m_device;
   std::string m_action;
-  std::string m_type;
   bool m_help;
 };
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
There is only 1 ioctl that controls the whole force-preemption. There was a misunderstanding and the other ioctl which is used to set "frame force-preemption", actually sets the normal frame preemption.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Internal testing

#### How problem was solved, alternative solutions (if any) and why they were rejected
Removed option "--type" and the force preemption now supports enable/disable and status. I will introduce a new command which supports toggling frame-boundary preemption for npu4/5/6. 

#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
Tested on MCDM

#### Documentation impact (if any)
Will update the main document once this is merged
