### PR TITLE
[XDP] Fix for AIESW-13835: Add check for AIE_TRACE_METADATA in determining xclbin type

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info_database.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info_database.cpp
@@ -2427,7 +2427,9 @@ namespace xdp {
     bool is_aie_available = false;
     bool is_pl_available  = false;
 
-    auto data = xrt_core::xclbin_int::get_axlf_section(xclbin, AIE_METADATA);
+    auto data = xrt_core::xclbin_int::get_axlf_section(xclbin, AIE_TRACE_METADATA);
+    if (!data.first || !data.second)
+      data = xrt_core::xclbin_int::get_axlf_section(xclbin, AIE_METADATA);
     if (data.first && data.second)
         is_aie_available = true;
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
[AIESW-13835](https://jira.xilinx.com/browse/AIESW-13835)

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
The bug was discovered when XDP couldn't detect GMIO trace streams in VAIML style VE2 designs despite having proper trace configuration. The issue occurs because XDP was reading only AIE_METADATA section to determine if the xclbin had an AIE section or not, but VAIML style designs only have AIE_TRACE_METADATA section

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added check for AIE_TRACE_METADATA in determining xclbin type

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Tested on ve2 with VAIML design

#### Documentation impact (if any)
N/A