### PR TITLE
Update AIEBU for submodule reuse

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,9 +24,6 @@ include(CMake/settings.cmake)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${XRT_SOURCE_DIR}/CMake/")
 
-# This makes aiebu submodule use ELFIO from XRT
-set(AIEBU_ELFIO_SRC_DIR "${XRT_SOURCE_DIR}/runtime_src/core/common/elf")
-
 if (NOT XRT_EDGE)
   # Enable testing for this directory and below.  This command should be
   # in the source directory root because ctest expects to find a test

--- a/src/runtime_src/CMakeLists.txt
+++ b/src/runtime_src/CMakeLists.txt
@@ -77,14 +77,15 @@ else()
   endif()
 
   if (XRT_NPU)
+    # Used by xdp for include search path
     set(AIERT_DIR ${CMAKE_CURRENT_BINARY_DIR}/aie-rt/driver/src)
     set(XAIENGINE_BUILD_SHARED OFF)
     xrt_add_subdirectory_disable_install_target(aie-rt/driver/src)
-    # This enables aiebu submodule use aie-rt from higher level
-    set(AIEBU_AIE_RT_BIN_DIR ${AIERT_DIR})
-    set(AIEBU_AIE_RT_HEADER_DIR ${AIERT_DIR}/include)
-    message("-- Exporting AIEBU_AIE_RT_BIN_DIR=${AIEBU_AIE_RT_BIN_DIR}")
-    message("-- Exporting AIEBU_AIE_RT_HEADER_DIR=${AIEBU_AIE_RT_HEADER_DIR}")
+
+    # This enables aiebu submodule use aie-rt binaries built
+    # by XRT from above
+    set(AIEBU_AIE-RT_BIN_DIR ${AIERT_DIR})
+    set(AIEBU_AIE-RT_HEADER_DIR ${AIERT_DIR}/include)
   endif()
 
   # Build Subdirectories

--- a/src/runtime_src/core/common/CMakeLists.txt
+++ b/src/runtime_src/core/common/CMakeLists.txt
@@ -17,6 +17,16 @@ elseif (NOT XRT_EDGE)
   set(AIEBU_COMPONENT ${XRT_BASE_COMPONENT})
   set(AIEBU_DEV_COMPONENT ${XRT_BASE_DEV_COMPONENT})
   set(AIEBU_UPSTREAM ${XRT_UPSTREAM})
+
+  # AIEBU should use XRT's version of ELFIO
+  set(AIEBU_ELFIO_SRC_DIR ${XRT_SOURCE_DIR}/runtime_src/core/common/elf)
+
+  # AIEBU should build XRT's version of aie-rt, unless XRT is sharing its
+  # build of aie-rt
+  if (NOT DEFINED AIEBU_AIE-RT_BIN_DIR)
+    set(AIEBU_AIE-RT_SRC_DIR ${XRT_SOURCE_DIR}/runtime_src/aie-rt)
+  endif()
+
   xrt_add_subdirectory(aiebu)
 else()
   message(WARNING "Edge device, build of submodule aiebu disabled")


### PR DESCRIPTION
#### Problem solved by the commit
Pull in https://github.com/Xilinx/aiebu/pull/146

Update CMake configuration to direct AIEBU to use XRT's aie-rt and ELFIO submodules.
