### PR TITLE
Handle exception in xbtop when no xclbin is loaded into card (and some cleanups)

### DIFF
--- a/src/runtime_src/core/tools/xbtop/_xbtop/ReportDynamicRegions.py
+++ b/src/runtime_src/core/tools/xbtop/_xbtop/ReportDynamicRegions.py
@@ -35,25 +35,21 @@ class ReportDynamicRegions:
     def _print_cu_info(self, term, lock, start_x, start_y, page):
         XBUtil.print_section_heading(term, lock, "Compute Usage", start_y)
         table_offset = 1
-        if self._df is None:
+        try:
+            uuid = self._df['dynamic_regions'][0]['xclbin_uuid']
+            cus = self._df['dynamic_regions'][0]['compute_units']
+        except:
             XBUtil.print_warning(term, lock, start_y + table_offset, "Data unavailable. Acceleration image not loaded")
             return table_offset + 1
 
         with lock:
             term.location(3, start_y+table_offset)
-            print("Xclbin UUID: %s" % self._df['dynamic_regions'][0]['xclbin_uuid'])
+            print("Xclbin UUID: %s" % uuid)
             table_offset += 2
 
         header = [     "", "Name", "Base Address", "Usage", "Status", "Type"]
         format = ["right", "left",        "right", "right", "center", "center"]
         data = []
-
-        cus = []
-        try:
-            cus = self._df['dynamic_regions'][0]['compute_units']
-        except:
-            XBUtil.print_warning(term, lock, start_y + table_offset, "Data unavailable. Acceleration image not loaded")
-            return table_offset + 1
 
         # Each page should display however many items a report page can hold
         for i in range(self.report_length):

--- a/src/runtime_src/core/tools/xbtop/_xbtop/XBUtil.py
+++ b/src/runtime_src/core/tools/xbtop/_xbtop/XBUtil.py
@@ -268,7 +268,7 @@ class _GetchUnix:
         fd = sys.stdin.fileno()
         old_settings = termios.tcgetattr(fd)
         try:
-            tty.setraw(sys.stdin.fileno())
+            tty.setcbreak(sys.stdin.fileno())
             ch = sys.stdin.read(1)
         finally:
             termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)

--- a/src/runtime_src/core/tools/xbtop/xbtop
+++ b/src/runtime_src/core/tools/xbtop/xbtop
@@ -1,26 +1,6 @@
-#!/bin/bash
-
-# -- Detect a Windows environment and automatically switch to the .bat file
-if [[ "`uname`" == windows32* ]] || [[ "`uname`" == CYGWIN* ]] ; then
-  trap "" INT
-  "$0.bat" "$@"
-  exit $?
-fi
+#!/bin/sh
 
 # Working variables
 XRT_PROG="`dirname \"$0\"`/../python/xbtop.py"
 
-# -- Examine the options 
-XRTWARP_PROG_ARGS_size=0
-XRTWRAP_PROG_ARGS=()
-while [ $# -gt 0 ]; do
-  case "$1" in
-    *)
-      XRTWRAP_PROG_ARGS[$XRTWARP_PROG_ARGS_size]="$1"
-      XRTWARP_PROG_ARGS_size=$(($XRTWARP_PROG_ARGS_size + 1))
-      shift
-      ;;
-  esac
-done
-
-"python3" "$XRT_PROG" "${XRTWRAP_PROG_ARGS[@]}"
+exec "python3" "$XRT_PROG" "$@"

--- a/src/runtime_src/core/tools/xbtop/xbtop.py
+++ b/src/runtime_src/core/tools/xbtop/xbtop.py
@@ -267,6 +267,9 @@ if __name__ == '__main__':
     try:
         main()
 
+    except KeyboardInterrupt:
+        pass
+
     except RuntimeError as r:
         print("ERROR: %s" % r)
         exit(1)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

xbtop fails to display dynamic region page for cards after reset (when there is no xclbin loaded).

Also xbtop is ignoring Ctrl-C due to strict 'raw' mode used for TTY.

Last patch removes bashisms so wrapper script is compatible with sh (dash or ash).

Feel free to drop any commits you don't like from this pull request

By the way, same cleanups can be applied to xrt-smi and xbmgmt wrappers - no arguments, cleaner win32 detection and exec, launcher script also uses args copy and thus 'eval' for launch

I can provide cleanup if you think this can be useful

#### What has been tested and how, request additional testing if necessary
It would be great if someone can check that calling `exec "$0".bat "$@"` is ok, maybe there is some windows magic that is incompatible with exec. However there is no .bat file for xbtop...