### PR TITLE
Hip Memory API interface checking improvement

### DIFF
--- a/src/runtime_src/hip/api/hip_memory.cpp
+++ b/src/runtime_src/hip/api/hip_memory.cpp
@@ -435,6 +435,7 @@ namespace xrt::core::hip
   static void
   hip_malloc_from_pool_async(void** dev_ptr, size_t size, hipMemPool_t mem_pool, hipStream_t stream)
   {
+    throw_invalid_value_if(!dev_ptr, "Invalid dev_ptr.");
     auto hip_stream = get_stream(stream);
     throw_invalid_value_if(!hip_stream, "Invalid stream handle.");
 

--- a/src/runtime_src/hip/api/hip_memory.cpp
+++ b/src/runtime_src/hip/api/hip_memory.cpp
@@ -232,9 +232,11 @@ namespace xrt::core::hip
   static void
   hip_memset(void* dst, int value, size_t size)
   {
+    throw_invalid_value_if(!dst, "dst is nullptr.");
     auto hip_mem_info = memory_database::instance().get_hip_mem_from_addr(dst);
     auto hip_mem_dst = hip_mem_info.first;
     auto offset = hip_mem_info.second;
+    throw_invalid_value_if(!hip_mem_dst, "Invalid destination handle.");
     throw_invalid_value_if(hip_mem_dst->get_type() == xrt::core::hip::memory_type::invalid,
                            "memory type is invalid for memset.");
     throw_invalid_value_if(offset + size > hip_mem_dst->get_size(), "dst out of bound.");
@@ -270,9 +272,11 @@ namespace xrt::core::hip
   template<typename T> static void
   hip_memset_async(void* dst, T value, size_t size, hipStream_t stream)
   {
+    throw_invalid_value_if(!dst, "dst is nullptr.");
     auto hip_mem_info = memory_database::instance().get_hip_mem_from_addr(dst);
     auto hip_mem_dst = hip_mem_info.first;
     auto offset = hip_mem_info.second;
+    throw_invalid_value_if(!hip_mem_dst, "Invalid destination handle.");
     throw_invalid_value_if(offset + size > hip_mem_dst->get_size(), "dst out of bound.");
 
     auto element_size = sizeof(T);

--- a/src/runtime_src/hip/core/event.cpp
+++ b/src/runtime_src/hip/core/event.cpp
@@ -293,9 +293,11 @@ bool memory_pool_command::submit()
   {
   case alloc:
     m_mem_pool->malloc(m_ptr, m_size);
+    set_state(state::completed);
     break;
   case free:
     m_mem_pool->free(m_ptr);
+    set_state(state::completed);
     break;
 
   default:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
* Add input arguments checking for hip memory APIs
* Set command state to complete if HIP malloc from pool async command submit() runs successfully.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
