### PR TITLE
[XRT-SMI] [AIESW-8381] Firmware logging updates for E2E testing

### DIFF
--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -4206,7 +4206,7 @@ struct firmware_log_version : request
 // Firmware log data query - following telemetry pattern
 struct firmware_log_data : request
 {
-  using result_type = firmware_debug_buffer;
+  using result_type = bool;
   static const key_type key = key_type::firmware_log_data;
 
   std::any

--- a/src/runtime_src/core/tools/common/SmiWatchMode.h
+++ b/src/runtime_src/core/tools/common/SmiWatchMode.h
@@ -19,7 +19,7 @@ struct firmware_debug_buffer;
 }
 
 //This is arbitrary for the moment. We can change this once we do real testing with firmware data
-constexpr size_t debug_buffer_size = static_cast<size_t>(4) * 1024 * 1024; // 4MB // NOLINT(readability-magic-numbers)
+constexpr size_t debug_buffer_size = static_cast<size_t>(8) * 1024; // 8KB // NOLINT(readability-magic-numbers)
 
 /**
  * @brief RAII wrapper for firmware debug buffer management
@@ -42,6 +42,24 @@ public:
   get_log_buffer() 
   { 
     return log_buffer; 
+  }
+
+  uint64_t 
+  get_size() const
+  {
+    return log_buffer.size;
+  }
+
+  void*
+  get_data() const
+  {
+    return log_buffer.data;
+  }
+
+  uint64_t
+  get_offset() const
+  {
+    return log_buffer.abs_offset;
   }
 };
 

--- a/src/runtime_src/core/tools/xbutil2/FirmwareLogConfig.cpp
+++ b/src/runtime_src/core/tools/xbutil2/FirmwareLogConfig.cpp
@@ -80,6 +80,16 @@ get_enumerator_value(const std::string& name) const {
   return it != enumerator_to_value.end() ? it->second : 0;
 }
 
+const firmware_log_config::structure_info& 
+firmware_log_config::
+get_log_header() const {
+  auto it = structures.find("ipu_log_message_header");
+  if (it == structures.end()) {
+    throw std::runtime_error("ipu_log_message_header structure not found in config");
+  }
+  return it->second;
+}
+
 size_t 
 firmware_log_config::
 calculate_header_size(const std::map<std::string, structure_info>& structures) {

--- a/src/runtime_src/core/tools/xbutil2/FirmwareLogConfig.h
+++ b/src/runtime_src/core/tools/xbutil2/FirmwareLogConfig.h
@@ -125,6 +125,14 @@ public:
     return header_size; 
   }
 
+  /**
+   * @brief Get the log message header structure
+   * @return Reference to the ipu_log_message_header structure info
+   * @throws std::runtime_error if header structure not found
+   */
+  const structure_info& 
+  get_log_header() const;
+
 private:
   /**
    * @brief Parse the root JSON object

--- a/src/runtime_src/core/tools/xbutil2/ReportEventTrace.cpp
+++ b/src/runtime_src/core/tools/xbutil2/ReportEventTrace.cpp
@@ -118,20 +118,20 @@ generate_raw_logs(const xrt_core::device* dev,
   // Always use real device data for raw logs
   xrt_core::device_query<xrt_core::query::event_trace_data>(dev, debug_buf.get_log_buffer());
   
-  watch_mode_offset = debug_buf.get_log_buffer().abs_offset;
+  watch_mode_offset = debug_buf.get_offset();
   
   ss << boost::format("Event Trace Report (Raw) - %s\n") 
         % xrt_core::timestamp();
   ss << "=======================================================\n";
   ss << "\n";
 
-  if (!debug_buf.get_log_buffer().data || debug_buf.get_log_buffer().size == 0) {
+  if (!debug_buf.get_data() || debug_buf.get_size() == 0) {
     ss << "No event trace data available\n";
     return ss.str();
   }
 
   // Simply print the raw payload data
-  ss.write(static_cast<const char*>(debug_buf.get_log_buffer().data), static_cast<std::streamsize>(debug_buf.get_log_buffer().size));
+  ss.write(static_cast<const char*>(debug_buf.get_data()), static_cast<std::streamsize>(debug_buf.get_size()));
   
   return ss.str();
 }
@@ -159,25 +159,25 @@ generate_event_trace_report(const xrt_core::device* dev,
     {
       xrt_core::device_query<xrt_core::query::event_trace_data>(dev, debug_buf.get_log_buffer());
     }
-    watch_mode_offset = debug_buf.get_log_buffer().abs_offset;
+    watch_mode_offset = debug_buf.get_offset();
     
     ss << boost::format("Event Trace Report (Buffer: %d bytes) - %s\n") 
-          % debug_buf.get_log_buffer().size % xrt_core::timestamp();
+          % debug_buf.get_size() % xrt_core::timestamp();
     ss << "=======================================================\n";
 
     ss << "\n";
 
-    if (!debug_buf.get_log_buffer().data || debug_buf.get_log_buffer().size == 0) {
+    if (!debug_buf.get_data() || debug_buf.get_size() == 0) {
       ss << "No event trace data available\n";
       return ss.str();
     }
 
     // Parse trace events from buffer
-    size_t event_count = debug_buf.get_log_buffer().size / sizeof(trace_event);
-    auto events = static_cast<trace_event*>(debug_buf.get_log_buffer().data);
+    size_t event_count = debug_buf.get_size() / sizeof(trace_event);
+    auto events = static_cast<trace_event*>(debug_buf.get_data());
 
     ss << boost::format("Total Events: %d\n") % event_count;
-    ss << boost::format("Buffer Offset: %d\n\n") % debug_buf.get_log_buffer().abs_offset;
+    ss << boost::format("Buffer Offset: %d\n\n") % debug_buf.get_offset();
 
     // Create Table2D with headers (enhanced with parsed args)
     const std::vector<Table2D::HeaderData> table_headers = {
@@ -259,9 +259,9 @@ getPropertyTree20202(const xrt_core::device* dev, bpt& pt) const
     xrt_core::device_query<xrt_core::query::event_trace_data>(dev, debug_buf.get_log_buffer());
 
     // Parse trace events from buffer
-    if (debug_buf.get_log_buffer().data && debug_buf.get_log_buffer().size > 0) {
-      size_t event_count = debug_buf.get_log_buffer().size / sizeof(smi::trace_event);
-      auto events = static_cast<smi::trace_event*>(debug_buf.get_log_buffer().data);
+    if (debug_buf.get_data() && debug_buf.get_size() > 0) {
+      size_t event_count = debug_buf.get_size() / sizeof(smi::trace_event);
+      auto events = static_cast<smi::trace_event*>(debug_buf.get_data());
 
       bpt events_array{};
       for (size_t i = 0; i < event_count; ++i) {
@@ -299,8 +299,8 @@ getPropertyTree20202(const xrt_core::device* dev, bpt& pt) const
       }
       event_trace_pt.add_child("events", events_array);
       event_trace_pt.put("event_count", event_count);
-      event_trace_pt.put("buffer_offset", debug_buf.get_log_buffer().abs_offset);
-      event_trace_pt.put("buffer_size", debug_buf.get_log_buffer().size);
+      event_trace_pt.put("buffer_offset", debug_buf.get_offset());
+      event_trace_pt.put("buffer_size", debug_buf.get_size());
     } else {
       event_trace_pt.put("event_count", 0);
       event_trace_pt.put("buffer_offset", 0);

--- a/src/runtime_src/core/tools/xbutil2/ReportFirmwareLog.h
+++ b/src/runtime_src/core/tools/xbutil2/ReportFirmwareLog.h
@@ -6,6 +6,148 @@
 
 #include "tools/common/Report.h"
 #include "FirmwareLogConfig.h" // Include the header file for firmware_log_config
+#include "tools/common/Table2D.h"
+#include <vector>
+#include <string>
+#include <memory>
+#include <unordered_map>
+
+namespace xrt_core::tools::xrt_smi {
+
+// Forward declarations
+class firmware_log_config;
+
+/**
+ * @brief Firmware log parser for XRT devices
+ * 
+ * This class provides an interface for parsing firmware log data.
+ * It encapsulates all parsing logic. The parser is configured with a firmware_log_config object
+ * that defines the structure and format of the log entries.
+ */
+class firmware_log_parser {
+public:
+  /**
+   * @brief Construct a new firmware log parser
+   * 
+   * @param config Firmware log configuration object containing structure definitions,
+   *               field layouts, and enumeration mappings
+   */
+  explicit 
+  firmware_log_parser(const firmware_log_config& config);
+
+  /**
+   * @brief Parse firmware log buffer and generate formatted table
+   * 
+   * @param data_ptr Pointer to the firmware log data buffer
+   * @param buf_size Total size of the data buffer in bytes
+   * @return Table2D Formatted table containing parsed log entries
+   * 
+   * This method processes the entire firmware log buffer, parsing each entry
+   * according to the configured structure.
+   */
+  Table2D 
+  parse(const uint8_t* data_ptr, size_t buf_size) const;
+
+private:
+  /**
+   * @brief Extract field value from bit-packed firmware log header
+   * 
+   * @param data_ptr Pointer to raw data buffer
+   * @param byte_offset Starting byte offset
+   * @param bit_offset Starting bit offset
+   * @param bit_width Number of bits to extract
+   * @return uint64_t Extracted field value
+   */
+  uint64_t 
+  extract_value(const uint8_t* data_ptr, 
+                size_t byte_offset, 
+                size_t bit_offset, 
+                size_t bit_width) const;
+
+  /**
+   * @brief Format field value with enum resolution if applicable
+   * 
+   * @param field Field information containing name and enumeration
+   * @param value Raw field value
+   * @return std::string Formatted field value with enum name if applicable
+   */
+  std::string 
+  format_value(const firmware_log_config::field_info& field, 
+               uint64_t value) const;
+
+  /**
+   * @brief Parse message data from log entry payload
+   * 
+   * @param data_ptr Pointer to the raw data buffer
+   * @param msg_offset Offset where message data begins
+   * @param argc Argument count field value (unused but kept for compatibility)
+   * @param buf_size Total buffer size for bounds checking
+   * @return std::string Parsed message with trailing newlines removed
+   * 
+   * This method extracts null-terminated string messages from log entries,
+   * with newline cleanup.
+   */
+  std::string 
+  parse_message(const uint8_t* data_ptr, 
+                size_t msg_offset, 
+                size_t buf_size) const;
+
+  /**
+   * @brief Parse a complete log entry (header + message)
+   * 
+   * @param data_ptr Pointer to the raw data buffer
+   * @param offset Offset where log entry begins
+   * @param buf_size Total buffer size for bounds checking
+   * @return std::vector<std::string> Vector of parsed field values and message
+   * 
+   * This method parses a complete log entry by:
+   * 1. Extracting all header fields according to structure definition
+   * 2. Parsing the message payload
+   * 3. Returning organized field data for table display
+   */
+  std::vector<std::string> 
+  parse_entry(const uint8_t* data_ptr, size_t offset, 
+                  size_t buf_size) const;
+
+  /**
+   * @brief Generate table headers based on log structure configuration
+   * 
+   * @return std::vector<Table2D::HeaderData> Vector of table headers with justification
+   * 
+   */
+  std::vector<Table2D::HeaderData> 
+  get_table_headers() const;
+
+  /**
+   * @brief Calculate entry size for buffer traversal
+   * 
+   * @param argc Argument count field value
+   * @param format Log format field value (full vs concise)
+   * @return uint32_t Total size of log entry in bytes
+   * 
+   */
+  uint32_t 
+  calculate_entry_size(uint32_t argc, uint32_t format) const;
+
+private:
+  const firmware_log_config m_config;  
+  const firmware_log_config::structure_info m_header; 
+  uint32_t m_header_size; // Size of log entry header in bytes
+  
+  // Field indices computed from config
+  const std::unordered_map<std::string, size_t> m_field_indices;
+
+  // Column headers mapping for display
+  const std::unordered_map<std::string, std::string> m_columns;
+
+  /**
+   * @brief Create field indices map from config
+   */
+  static std::unordered_map<std::string, size_t> 
+  create_field_indices(const firmware_log_config& config);
+};
+
+} // namespace xrt_core::tools::xrt_smi
 
 /**
  * @brief Report for firmware log information
@@ -91,28 +233,7 @@ public:
               const std::vector<std::string>& elements_filter,
               std::ostream& output) const override;
 
-public:
-  /**
-   * @brief Parse a single firmware log entry
-   *
-   * @param data_ptr Pointer to the firmware log data buffer
-   * @param offset Offset within the buffer to start parsing
-   * @param buf_size Total size of the data buffer
-   * @param config Firmware log configuration object
-   *
-   * @return Vector of strings containing parsed log entry data
-   *
-   * This static method parses a single firmware log entry from the data buffer
-   * and returns the extracted information as a vector of strings. The parsing
-   * is based on the provided configuration object, which defines the structure
-   * of the log entry.
-   */
-  static 
-  std::vector<std::string> 
-  parse_log_entry(const uint8_t* data_ptr, 
-                  size_t offset, 
-                  size_t buf_size, 
-                  const xrt_core::tools::xrt_smi::firmware_log_config& config);
+
 };
 
 #endif // REPORT_FIRMWARE_LOG_H


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
This PR updates the firmware logging report to have a cleaner parsing class to encapsulate all firmware log parsing related APIs and structures. This PR is an effort towards enabling firmware logging in xrt-smi on real data after the merge of windows side support for it through : 
https://gitenterprise.xilinx.com/XRT/XRT-MCDM/pull/2012

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://jira.xilinx.com/browse/AIESW-8381
AIESW-8381

#### How problem was solved, alternative solutions (if any) and why they were rejected
Introduces a new class firmware_log_parser to encapsulate all parsing related logic. This class stores the firmware logging configuration as a member and uses the configuration to parse raw buffer passed to users-pace by shim. 
This PR also removes the dummy data generation since now we have an e2e test running. 

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Tested on windows platform  : 
```
W:\Repos\XRT-MCDM-FORK\XRT-MCDM\build\x64\Release\xilinx\xrt>xrt-smi examine --advanced -r firmware-log --element dummy

-----------------------------
[00c5:00:01.1] : NPU Krackan
-----------------------------
Firmware Log Report
===================

  Firmware Log Information:
    |Timestamp  |Log-Level    |App Number   |Line Number  |Module ID  |Message                                                                     |
    |-----------|-------------|-------------|-------------|-----------|----------------------------------------------------------------------------|
    |2988513    |3:inf        |255          |1041         |9985       |[AIE2P] [POWER_COLUMNS] [enable_ONO_0] IPU_DLDOREG_ONO_0_STATE=0x00000200   |
    |2990122    |3:inf        |255          |817          |8448       |xaie_reset_init()                                                           |
    |2992140    |3:inf        |255          |1583         |8198       | [MGT] Event...0x4                                                          |
    |2993186    |4:dbg        |255          |1655         |8198       | [MGT] mailbox                                                              |
    |2993436    |4:dbg        |255          |3087         |8200       |Message received - msg id = 0x1D039608, msg opcode = 0x101, msg size = 0x4  |
    |2993641    |3:inf        |255          |1702         |8198       |[MGT] start ipu_prepare_suspend MPIPU_PMFW_SUSP_RDY: 0x0                    |
    |2993772    |3:inf        |255          |1371         |9985       |[AIE] [POWER_OFF] [WARM]                                                    |
    |2993873    |3:inf        |255          |1605         |9985       |soc_try_ips0_to_ips1()                                                      |
    |2993973    |3:inf        |255          |924          |9985       |soc_are_columns_off()                                                       |
    |2994127    |3:inf        |255          |927          |9985       |cntrl0.val=0xE00002F                                                        |
    |2994220    |3:inf        |255          |1091         |9985       |disable_ONO_0()                                                             |
    |2994340    |3:inf        |255          |122          |9985       |[AIE2P][DLDO][ONO] ONO0 SHIMs/NoC/AXISDP                                    |
    |2994451    |3:inf        |255          |924          |9985       |soc_are_columns_off()                                                       |
    |2994600    |3:inf        |255          |927          |9985       |cntrl0.val=0xE00002F                                                        |
    |2994799    |4:dbg        |255          |108          |8204       |switching to logging destination 0 (entering low-power mode)                |
    |192896     |3:inf        |255          |1767         |8198       |[MGT] finish ipu_prepare_resume MPIPU_PMFW_SUSP_RDY: 0x0                    |
    |193306     |3:inf        |255          |308          |8194       |H Clock override disabled                                                   |
    |194299     |3:inf        |255          |1575         |8198       | [MGT] Yielding...                                                          |
    |195277     |3:inf        |255          |1605         |9985       |soc_try_ips0_to_ips1()                                                      |
    |196263     |3:inf        |255          |924          |9985       |soc_are_columns_off()                                                       |
    |197248     |3:inf        |255          |927          |9985       |cntrl0.val=0xE00002F                                                        |
    |198227     |3:inf        |255          |1091         |9985       |disable_ONO_0()                                                             |
    |199231     |3:inf        |255          |122          |9985       |[AIE2P][DLDO][ONO] ONO0 SHIMs/NoC/AXISDP                                    |
    |200379     |3:inf        |255          |924          |9985       |soc_are_columns_off()                                                       |
    |201356     |3:inf        |255          |927          |9985       |cntrl0.val=0xE00002F                                                        |
    |202411     |4:dbg        |255          |108          |8204       |switching to logging destination 0 (entering low-power mode)                |
    |674555     |3:inf        |255          |1041         |9985       |[AIE2P] [POWER_COLUMNS] [enable_ONO_0] IPU_DLDOREG_ONO_0_STATE=0x00000200   |
    |676166     |3:inf        |255          |817          |8448       |xaie_reset_init()                                                           |
    |678184     |3:inf        |255          |1583         |8198       | [MGT] Event...0x4                                                          |
    |679229     |4:dbg        |255          |1655         |8198       | [MGT] mailbox                                                              |
    |679479     |4:dbg        |255          |3087         |8200       |Message received - msg id = 0x1D039808, msg opcode = 0x108, msg size = 0x4  |
    |679726     |3:inf        |255          |308          |8194       |H Clock override disabled                                                   |
    |680717     |3:inf        |255          |1575         |8198       | [MGT] Yielding...                                                          |
    |681695     |3:inf        |255          |1605         |9985       |soc_try_ips0_to_ips1()                                                      |
    |682682     |3:inf        |255          |924          |9985       |soc_are_columns_off()                                                       |
```

#### Documentation impact (if any)
None
