### PR TITLE
CR-1247943: Fix seg fault at end of execution in hardware emulation caused by profiling

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info_database.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info_database.cpp
@@ -57,6 +57,12 @@ namespace xdp {
 #else
     pid = static_cast<int>(getpid()) ;
 #endif
+
+    // During initialization, call the utility function isEdge()
+    // just to initialize static variables, so later other functions
+    // will not have to call the xrt::system_linux queries when
+    // they might have been destroyed
+    (void)(isEdge()); 
   }
 
   VPStaticDatabase::~VPStaticDatabase()


### PR DESCRIPTION
#### Problem solved by the commit
On some edge boards and runs, profiling was crashing when dumping the summary file.  This was due to a query for device information, which should not be called during static object destruction.

#### How problem was solved, alternative solutions (if any) and why they were rejected
The issue was resolved by fetching the information profiling needs from XRT during profiling initialization and caching it, so we do not call the device query during static object destruction.

#### Risks (if any) associated the changes in the commit
Low risk as this function call is normally called in all flows and the additional call is done at a safe spot.  Additionally, this only affects hardware emulation designs as the original call that caused the crash is blocked by a guard and only executed in hardware emulation designs.

#### What has been tested and how, request additional testing if necessary
The original failing hardware emulation test has been verified to work.

#### Documentation impact (if any)
No documentation impact.