### PR TITLE
Patch nativeLnx.cmake to use pkg-config for libdrm not found

### DIFF
--- a/src/CMake/nativeLnx.cmake
+++ b/src/CMake/nativeLnx.cmake
@@ -10,6 +10,8 @@
 
 
 # --- PkgConfig ---
+# Force use of system pkg-config to avoid version compatibility issues
+set(PKG_CONFIG_EXECUTABLE "/usr/bin/pkg-config" CACHE FILEPATH "Path to pkg-config executable")
 INCLUDE (FindPkgConfig)
 
 # --- DRM ---


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

I was running into errors in the XRT build step towards building xdna-driver. I could not find the package libdrm even though it was installed on the system. This patch helps cmake look in the right place. 

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

Package not found libdrm 

#### How problem was solved, alternative solutions (if any) and why they were rejected

Use pkg-config from system to avoid version compatibility 

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

This was tested on a system with Ubuntu 24.04 and Linux 6.14 building [xdna-driver@1.6](https://github.com/amd/xdna-driver/tree/1.6) and [xrt@0212043](https://github.com/Xilinx/XRT/tree/021204355eeaa034ff69aae407ace2265adf047a)

#### Documentation impact (if any)
