### PR TITLE
HIP: Module: extend XRT HIP defined struct hipModuleLoadData{} to enable user to pass QoS related configuration parameters  

### DIFF
--- a/src/runtime_src/hip/core/module.cpp
+++ b/src/runtime_src/hip/core/module.cpp
@@ -39,6 +39,22 @@ module_xclbin(std::shared_ptr<context> ctx, void* data, size_t size)
   , m_xrt_hw_ctx{m_ctx->get_xrt_device(), register_xclbin(m_ctx, m_xrt_xclbin)}
 {}
 
+module_xclbin::
+module_xclbin(std::shared_ptr<context> ctx, const std::string& file_name,
+	      const xrt::hw_context::cfg_param_type& cfg_param)
+  : module{std::move(ctx)}
+  , m_xrt_xclbin{file_name}
+  , m_xrt_hw_ctx{m_ctx->get_xrt_device(), register_xclbin(m_ctx, m_xrt_xclbin), cfg_param}
+{}
+
+module_xclbin::
+module_xclbin(std::shared_ptr<context> ctx, void* data, size_t size,
+	      const xrt::hw_context::cfg_param_type& cfg_param)
+  : module{std::move(ctx)}
+  , m_xrt_xclbin{std::vector<char>{static_cast<char*>(data), static_cast<char*>(data) + size}}
+  , m_xrt_hw_ctx{m_ctx->get_xrt_device(), register_xclbin(m_ctx, m_xrt_xclbin), cfg_param}
+{}
+
 module_elf::
 module_elf(module_xclbin* xclbin_module, const std::string& file_name)
   : module{xclbin_module->get_context()}
@@ -69,6 +85,21 @@ module_full_elf(std::shared_ptr<context> ctx, const void* data, size_t size)
   , m_xrt_hw_ctx{m_ctx->get_xrt_device(), m_xrt_elf}
 {}
 
+module_full_elf::
+module_full_elf(std::shared_ptr<context> ctx, const std::string& file_name,
+                const xrt::hw_context::cfg_param_type& cfg_param)
+  : module{std::move(ctx)}
+  , m_xrt_elf{file_name}
+  , m_xrt_hw_ctx{m_ctx->get_xrt_device(), m_xrt_elf, cfg_param, xrt::hw_context::access_mode::shared}
+{}
+
+module_full_elf::
+module_full_elf(std::shared_ptr<context> ctx, void* data, size_t size,
+                const xrt::hw_context::cfg_param_type& cfg_param)
+  : module{std::move(ctx)}
+  , m_xrt_elf{data, size}
+  , m_xrt_hw_ctx{m_ctx->get_xrt_device(), m_xrt_elf, cfg_param, xrt::hw_context::access_mode::shared}
+{}
 function_handle
 module_elf::
 add_function(const std::string& name)

--- a/src/runtime_src/hip/core/module.h
+++ b/src/runtime_src/hip/core/module.h
@@ -73,6 +73,12 @@ public:
 
   module_xclbin(std::shared_ptr<context> ctx, void* data, size_t size);
 
+  module_xclbin(std::shared_ptr<context> ctx, const std::string& file_name,
+                const xrt::hw_context::cfg_param_type& cfg_param);
+
+  module_xclbin(std::shared_ptr<context> ctx, void* data, size_t size,
+                const xrt::hw_context::cfg_param_type& cfg_param);
+
   const xrt::hw_context&
   get_hw_context() const
   {
@@ -116,6 +122,12 @@ public:
   module_full_elf(std::shared_ptr<context> ctx, const std::string& file_name);
 
   module_full_elf(std::shared_ptr<context> ctx, const void* data, size_t size);
+
+  module_full_elf(std::shared_ptr<context> ctx, const std::string& file_name,
+                  const xrt::hw_context::cfg_param_type& cfg_param);
+
+  module_full_elf(std::shared_ptr<context> ctx, void* data, size_t size,
+                  const xrt::hw_context::cfg_param_type& cfg_param);
 
   const xrt::hw_context&
   get_hw_context() const

--- a/src/runtime_src/hip/hip_xrt.h
+++ b/src/runtime_src/hip/hip_xrt.h
@@ -18,6 +18,13 @@ enum hipModuleDataType {
   hipModuleDataBuffer
 };
 
+// Hip XRT module configuration parameters which will be passed to XRT hardware
+// context creation
+typedef struct hipXrtModuleCfgParam {
+  const char *name; // name of configuration parameter
+  uint32_t data; // data of configuration parameter
+} hipXrtModuleCfgParam_t;
+
 // structure that represents the config data passed to hipModuleLoadData
 struct hipModuleData
 {
@@ -27,6 +34,9 @@ struct hipModuleData
                            // to xclbin module for elf creation
   void* data;              // pointer to file path or buffer based on type
   size_t size;             // size of data buffer passed
+  uint32_t numCfgParams; // number of HIP XRT configuration parameters which
+                           // will be passed to XRT hardware context creation
+  const hipXrtModuleCfgParam_t *cfgParams; // HIP XRT configuration parameters array
 };
 
 // HIP XRT extension


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
To pass AIE hardware context QoS parameters to hardware context, we need to tell XRT these parameters when we are creating AIe hardware context.
`hipModuleLoad()` and `hipModuleLoadData()` are the APIs we used to create XRT HIP module which will create hardware context underline.
`hipModuleLoad()` requires user to pass xclbin or full elf path and no extra information can be passed with this API.

However, we have already defined `struct hipModuleData{}` for `hipModuleLoadData()` to pass extra information for partial ELF flow. This PR extends `struct hipModuleData{}` used by `hipModuleLoadData()` API to enable user to pass QoS information.

The following are added to `struct hipModuleData` in `hip_xrt.h`:
```
struct hipModuleData
{
  ...
  uint32_t numCfgParams; // number of HIP XRT configuration parameters which
                           // will be passed to XRT hardware context creation
  const hipXrtModuleCfgParam_t *cfgParams; // HIP XRT configuration parameters array
};
```

Extending `struct hipModuleData` so that we can avoid introducing new XRT specific APIs.

Here are some examples:
* Partial ELF flow:
```
  hipXrtModuleCfgParam_t config_param = {"priority", 0x100};
  std::string xclbin_path = get_xclbin_file_path("memcpy.xclbin");
  void *xclbin_data = xclbin_path.data();
  size_t xclbin_size = xclbin_path.size();
  config_data = {};
  config_data.type = hipModuleDataFilePath;
  config_data.parent = nullptr;
  config_data.data = xclbin_data;
  config_data.size = xclbin_size;
  config_data.numCfgParams = 1;
  config_data.cfgParams = &config_param;
  hipModuleLoadData(&hmodule_parent, &config_data);
  elf = get_txn_elf_data("ctrl-memcpy.elf");
  config_data = {};
  config_data.type = hipModuleDataBuffer;
  config_data.parent = hmodule_parent;
  config_data.data = elf.data();
  config_data.size = elf.size();
 hipModuleLoadData(&hmodule, &config_data)
```
* Full ELF flow:
```
  hipXrtModuleCfgParam_t config_param = {"priority", 0x100};
  std::string elf_path = get_full_elf_path("memcpy-full.elf");
  char* elf_data = elf_path.data();
  size_t elf_size = elf_path.size();
  hipModuleData config_data = {};
  config_data.type = hipModuleDataFilePath;
  config_data.parent = nullptr;
  config_data.data = elf_data;
  config_data.size = elf_size;
  config_data.numCfgParams = 1;
  config_data.cfgParams = &config_param;
  hipModuleLoadData(&hmodule, &config_data);
```

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Test: 
* XRT HIP unit test: https://gitenterprise.xilinx.com/wendlian/testcases-v2/blob/hip-utests/unittests/hip/src/test-module.cpp#L326
* updated XRT model test: https://gitenterprise.xilinx.com/wendlian/model-tests/blob/hip/strix/sentence_transformers_paraphrase_multilingual_MiniLM_L12_v2/hip/main.cpp#L31

#### Documentation impact (if any)
