### PR TITLE
exception message for V1 context health data

### DIFF
--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -2714,6 +2714,7 @@ public:
     
     switch (opcode) {
     case ERT_START_NPU:
+    case ERT_START_DPU:
     case ERT_START_NPU_PREEMPT:
     case ERT_START_NPU_PREEMPT_ELF:
       throw xrt::run::aie_error(xrt::run(get_mutable_shared_ptr()), msg);
@@ -3342,6 +3343,7 @@ class runlist_impl
 
     switch (opcode) {
     case ERT_START_NPU:
+    case ERT_START_DPU:
     case ERT_START_NPU_PREEMPT:
     case ERT_START_NPU_PREEMPT_ELF:
       throw xrt::runlist::aie_error(run, state, "runlist failed execution");

--- a/src/runtime_src/core/include/xrt/detail/ert.h
+++ b/src/runtime_src/core/include/xrt/detail/ert.h
@@ -1349,6 +1349,7 @@ get_ert_ctx_health_data_v1(const struct ert_packet* pkt)
   switch (pkt->opcode) {
   case ERT_START_CU:
   case ERT_START_NPU:
+  case ERT_START_DPU:
   case ERT_START_NPU_PREEMPT:
   case ERT_START_NPU_PREEMPT_ELF:
     if (pkt->state == ERT_CMD_STATE_TIMEOUT)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Added API for printing exception message (V1) on the event of ERT_CMD_STATE_TIMEOUT for AIE2 and AIE4.
https://amd.atlassian.net/wiki/spaces/AIE/pages/913025822/Context+timeout+state+capture
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
