### PR TITLE
fixing an issue in edge flow where multiple reserved memory region exists in DTB

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/common/zocl_bo.c
+++ b/src/runtime_src/core/edge/drm/zocl/common/zocl_bo.c
@@ -1290,12 +1290,14 @@ static bool check_for_reserved_memory(uint64_t start_addr, size_t size)
 	struct resource res_mem;
 	int err;
 
-	mem_np = of_find_node_by_name(NULL, "reserved-memory");
+	mem_np = of_find_node_by_path("/reserved-memory");
 	if(!mem_np)
 		return false;
 
 	/* Traverse through all the child nodes */
 	for (np_it = NULL; (np_it = of_get_next_child(mem_np, np_it)) != NULL;) {
+                if (!of_property_read_bool(np_it, "no-map"))
+                        continue;
 		err = of_address_to_resource(np_it, 0, &res_mem);
 		if (!err) {
 			/* Check the given address and size fall


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
fixing an issue in edge flow where multiple reserved memory region exists in DTB

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Recently DT added multiple reserved nodes which introduced this issue

#### How problem was solved, alternative solutions (if any) and why they were rejected
Checking reserved-memory from top node

#### Risks (if any) associated the changes in the commit
None. If there are any platforms which has reserved-node not in top node would fail after this change

#### What has been tested and how, request additional testing if necessary
Verified multiple platforms

#### Documentation impact (if any)
None