### PR TITLE
Added extra gaurd to run bash completion scripts in the non posix bash

### DIFF
--- a/src/runtime_src/tools/scripts/setup.sh
+++ b/src/runtime_src/tools/scripts/setup.sh
@@ -50,7 +50,7 @@ if [ ! -f "$XILINX_XRT/version.json" ]; then
 fi
 
 COMP_FILE="/usr/share/bash-completion/bash_completion"
-if [ -n "$BASH_VERSION" ] && [ -f "$COMP_FILE" ]; then
+if [ "${BASH##*/}" = bash ] && [ -n "$BASH_VERSION" ] && [ -f "$COMP_FILE" ]; then
     # Enable autocompletion for xrt-smi commands
     . "$COMP_FILE"
     . "$XILINX_XRT/share/completions/xbutil-bash-completion"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1251600 Sourcing setup.sh triggers bash-completion loading under bash running in POSIX (sh) mode. In that mode function names containing hyphens are rejected, so /etc/bash_completion.d/apport_completion fails with: /etc/bash_completion.d/apport_completion: line 107: `_apport-bug': not a valid identifier

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added extra gaurd to run bash completion scripts in the non posix bash

#### Risks (if any) associated the changes in the commit
low

#### What has been tested and how, request additional testing if necessary
Tested on ubuntu 22.04 on both bash and dash

#### Documentation impact (if any)
NA