### PR TITLE
fixed the issue with file writing; enable tranform-pdi on Windows

### DIFF
--- a/src/runtime_src/tools/xclbinutil/XclBinUtilMain.cxx
+++ b/src/runtime_src/tools/xclbinutil/XclBinUtilMain.cxx
@@ -534,14 +534,8 @@ int main_(int argc, const char** argv) {
 
   // add support for transform-pdi
   // transform the PDIs in AIE_PARTITION sections before writing out the output xclbin
-  if (bTransformPdi) {
-#ifndef _WIN32
+  if (bTransformPdi)
     XUtil::transformAiePartitionPDIs(xclBin);
-#else
-    std::string errMsg = "ERROR: --transform-pdi is only valid on Linux.";
-    throw std::runtime_error(errMsg);
-#endif
-  }
 
   // -- Remove Keys --
   for (const auto &key : keysToRemove)

--- a/src/runtime_src/tools/xclbinutil/XclBinUtilities.cxx
+++ b/src/runtime_src/tools/xclbinutil/XclBinUtilities.cxx
@@ -1041,8 +1041,6 @@ XclBinUtilities::createMemoryBankGrouping(XclBin & xclbin)
   }
 }
 
-// Note: --transform-pdi is currently only supported on Linux, so the following
-//   API is not called on Windows
 // pdi_transform is defined in libtransformcdo.a
 extern "C" int pdi_transform(char* pdi_file, char* pdi_file_out, const char* out_file);
 

--- a/src/runtime_src/tools/xclbinutil/aie-pdi-transform/src/pdi-transform.c
+++ b/src/runtime_src/tools/xclbinutil/aie-pdi-transform/src/pdi-transform.c
@@ -121,7 +121,8 @@ char* XPdi_Parse_Cmd(XCdoCmd* Cmd, uint32_t* prevId,
 
 uint32_t XPdi_Cmd_Parse(char* pdi_buf, uint32_t BufLen, const uint32_t *Buf)
 {
-  // pdi_buf points to the beginning address of the cdo image
+  // pdi_buf points to the beginning address of the cdo image in the new pdi
+  // Buf points to the beginning the cdo image in the input (original) pdi
   uint32_t const * Orignal_Buf = Buf;
   char* cur_pdi_buf = pdi_buf;
   static uint32_t prevId = -1;
@@ -252,7 +253,7 @@ void XPdi_Export(const XPdiLoad* PdiLoad, const char* pdi_file_out)
   const char* pdi_file = pdi_file_out;
   char* Buf = (char *)PdiLoad->PdiPtr;
   uint32_t len = PdiLoad->PdiLen;
-  FILE * fp = fopen (pdi_file,"w");
+  FILE * fp = fopen (pdi_file,"wb");
   //int fd = open(pdi_file, O_WRONLY | O_CREAT | O_TRUNC);
   if (fp == NULL)
   {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Enable --transform-pdi on Windows

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Fixed an issue with file writing

#### How problem was solved, alternative solutions (if any) and why they were rejected
On Windows, open() API writes the file in text mode by default, which leads to extra `0x0d` byte written to the output file. Changed the mode to binary

#### Risks (if any) associated the changes in the commit
No

#### What has been tested and how, request additional testing if necessary
Unittest, manual test

#### Documentation impact (if any)
N/A