### PR TITLE
CR 1245247 - Incorrect assignment of interface tile channels for AIE profiling

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_metadata.cpp
@@ -930,11 +930,10 @@ namespace xdp {
           configMetrics[moduleIdx][t] = metrics[i][1];
           configChannel0[t] = channelId0;
           configChannel1[t] = channelId1;
-          std::cout << "!!!!!!!!!! Setting tile " << t.col << "," << t.row << " with set " 
-                    << metrics[i][1] << " using channel " << configChannel0[t] << std::endl;
         } else {
-          std::cout << "!!!!!!!!!! Keeping set " << configMetrics[moduleIdx][t] << " using channel " 
-                    << configChannel0[t] << " for tile " << t.col << "," << t.row << std::endl;
+          xrt_core::message::send(severity_level::warning, "XRT", "Tile " + std::to_string(t.col) + ","
+            + std::to_string(t.row) + " is already configured with metric set " + configMetrics[moduleIdx][t]
+            + ". Ignoring setting for set " + metrics[i][1] + ".");
         }
         if (metrics[i][1] == METRIC_BYTE_COUNT)
           setUserSpecifiedBytes(t, bytes);


### PR DESCRIPTION
#### Problem solved by the commit
* Channels were not getting recorded correctly when multiple sets were specified

#### How problem was solved, alternative solutions (if any) and why they were rejected
* Ignore second set/channel pair; first takes precedence
* Added warning message to inform user that second pair was ignored

#### Risks (if any) associated the changes in the commit
* Very low

#### What has been tested and how, request additional testing if necessary
* Tested on vck190 using beamformer

#### Documentation impact (if any)
* Let users know that when two "all" settings are specified, the first one takes precedence