### PR TITLE
CR 1245247 - Incorrect assignment of interface tile channels for AIE

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_metadata.cpp
@@ -930,7 +930,8 @@ namespace xdp {
           configMetrics[moduleIdx][t] = metrics[i][1];
           configChannel0[t] = channelId0;
           configChannel1[t] = channelId1;
-        } else {
+        }
+        else {
           xrt_core::message::send(severity_level::warning, "XRT", "Tile " + std::to_string(t.col) + ","
             + std::to_string(t.row) + " is already configured with metric set " + configMetrics[moduleIdx][t]
             + ". Ignoring setting for set " + metrics[i][1] + ".");


### PR DESCRIPTION
…profiling (#9321)

#### Problem solved by the commit
* Incorrectly replaced channels and metric sets

#### How problem was solved, alternative solutions (if any) and why they were rejected
* Allow first set/channel pair to take precedence

#### Risks (if any) associated the changes in the commit
* Very low

#### What has been tested and how, request additional testing if necessary
* Tested on vck190

#### Documentation impact (if any)
* Let users know of precedence