### PR TITLE
HIP events synchronization implementation update

### DIFF
--- a/src/runtime_src/hip/api/hip_stream.cpp
+++ b/src/runtime_src/hip/api/hip_stream.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
 
 #include "hip/core/common.h"
 #include "hip/core/event.h"
@@ -92,24 +92,18 @@ hip_stream_wait_event(hipStream_t stream, hipEvent_t ev, unsigned int flags)
   throw_invalid_resource_if(!hip_event_cmd, "event is invalid");
 
   throw_if(!hip_event_cmd->is_recorded(), hipErrorStreamCaptureIsolation, "Event passed is not recorded");
-  auto hip_event_stream = hip_event_cmd->get_stream();
 
   // check stream on which wait is called is same as stream in which event is enqueued
-  if (hip_wait_stream == hip_event_stream) {
-    hip_wait_stream->record_top_event(hip_event_cmd.get());
+  if (hip_event_cmd->is_recorded_stream(hip_wait_stream.get())) {
+    hip_wait_stream->record_top_event(std::move(hip_event_cmd));
   }
   else {
-    auto wait_stream = hip_wait_stream.get();
+    //auto wait_stream = hip_wait_stream.get();
     // create dummy event and add the event to be waited in its dep list
     auto dummy_event_hdl = static_cast<event*>(
         insert_in_map(command_cache,
                       std::make_shared<event>()));
-    dummy_event_hdl->record(std::move(hip_wait_stream));
-    dummy_event_hdl->add_dependency(hip_event_cmd);
-
-    // enqueue dummy event into wait stream
-    wait_stream->enqueue(command_cache.get(dummy_event_hdl));
-    wait_stream->record_top_event(dummy_event_hdl);
+    dummy_event_hdl->init_wait_event(hip_wait_stream, hip_event_cmd);
   }
 }
 } // // xrt::core::hip

--- a/src/runtime_src/hip/core/event.h
+++ b/src/runtime_src/hip/core/event.h
@@ -111,17 +111,21 @@ private:
 public:
   event();
   void record(std::shared_ptr<stream> s);
+  void init_wait_event(const std::shared_ptr<stream>& s, const std::shared_ptr<event>& e);
   bool submit() override;
   bool wait() override;
   bool synchronize();
   bool query();
-  std::shared_ptr<stream> get_stream();
+  // check if the stream is used to record this event;
+  bool is_recorded_stream(const stream* s) noexcept;
   void add_to_chain(std::shared_ptr<command> cmd);
   void add_dependency(std::shared_ptr<command> cmd);
   [[nodiscard]] bool is_recorded();
 
 private:
   [[nodiscard]] bool is_recorded_no_lock() const;
+  void launch_chain_of_commands();
+  bool check_dependencies_update_state(bool wait_for_dependencies);
 };
 
 class kernel_start : public command

--- a/src/runtime_src/hip/core/stream.cpp
+++ b/src/runtime_src/hip/core/stream.cpp
@@ -168,10 +168,16 @@ synchronize()
 
 void
 stream::
-record_top_event(event* ev)
+record_top_event(std::shared_ptr<event> ev)
 {
   std::lock_guard<std::mutex> lk(m_cmd_lock);
-  m_top_event = ev;
+
+  // previous top event is added as a dependency to the new top event
+  if (m_top_event) {
+    ev->add_dependency(std::move(m_top_event));
+  }
+
+  m_top_event = std::move(ev);
 }
 
 std::shared_ptr<stream>

--- a/src/runtime_src/hip/core/stream.h
+++ b/src/runtime_src/hip/core/stream.h
@@ -21,7 +21,7 @@ class stream
 
   std::list<std::shared_ptr<command>> m_cmd_queue;
   std::mutex m_cmd_lock;
-  event* m_top_event{nullptr};
+  std::shared_ptr<event> m_top_event;
 
 public:
   stream() = default;
@@ -69,7 +69,7 @@ public:
   synchronize();
 
   void
-  record_top_event(event* ev);
+  record_top_event(std::shared_ptr<event> ev);
 };
 
 // Global map of streams


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
There are a couple findings when testing the HIP events synchronization APIs.
* There is not lock to protect event state change in `hipEventRecord()` implementation, and it doesn't erase the event from the old hip stream, when trying to record the event with a new stream, instead, it erased the event from the stream it is trying to record.
* When calling `hipEventSynchronize()`, when the event dependencies are complete, it only starts the commands if they are on the same stream as where the event is recorded. It the commands depends on the event is on a different stream, it will not start.
* When calling `hipStreamWaitEvent()`, a dummy event is created as the waiting point on the stream, but only the event to wait is added as dependencies to this waiting point, if stream has another wait point before, it is it added to this wait point's dependencies. e.g. `stream1: wait_on_ev1 -> do_cmd1 - wait_on_ev2 -> do_cmd2`.  `do_cmd2` should not start until ev1 and ev2 completes, however, today, the implementation waits on ev1, ev2 and cmd1 to complete before doing `do_cmd2`.

This patch set are to
* add lock protection when updating the HIP event state when trying to record hip event, and erase the event from previous stream when recording to the new one.
* Update even synchronization implementation so that when the event is complete, not just the dependent commands on the same stream can start, but also those on a different stream but depends on this event can try to start. And enable the event to wait on previous waiting point on the same stream and the new wait event.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Tests to sync launches on the same stream and on different streams with hip events: https://gitenterprise.xilinx.com/XRT/testcases-v2/pull/6

#### Documentation impact (if any)
