### PR TITLE
Fix for CR-1251818

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_profile/edge/aie_profile.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/edge/aie_profile.h
@@ -82,6 +82,18 @@ namespace xdp {
 
       std::vector<std::shared_ptr<xaiefal::XAieBroadcast>> bcResourcesBytesTx;
       std::vector<std::shared_ptr<xaiefal::XAieBroadcast>> bcResourcesLatency;
+
+      uint8_t m_startColShift = 0;
+
+      // Helper: convert relative column to XAIE column
+      inline uint8_t getXAIECol(uint8_t relCol) const {
+        auto absCol = relCol + m_startColShift;
+        // For loadxclbin flow currently XRT creates partition of whole device from 0th column.
+        // Hence absolute and relative columns are same.
+        // TODO: For loadxclbin flow XRT will start creating partition of the specified columns,
+        //       hence we should stop adding partition shift to col for passing to XAIE Apis
+        return (db->getStaticInfo().getAppStyle() == xdp::AppStyle::LOAD_XCLBIN_STYLE) ? absCol : relCol;
+      }
   };
 }   
 

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/util/aie_profile_config.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/util/aie_profile_config.cpp
@@ -7,6 +7,7 @@
 #include "xdp/profile/plugin/aie_profile/util/aie_profile_util.h"
 #include "xdp/profile/plugin/aie_base/aie_base_util.h"
 #include "xdp/profile/database/static_info/aie_util.h"
+#include "xdp/profile/database/database.h"
 
 #include <cmath>
 #include <cstring>
@@ -171,7 +172,7 @@ namespace xdp::aie::profile {
   {
     if (xdpModType != module_type::shim)
       return nullptr;
-
+    
     if ((metricSet == METRIC_LATENCY) && (pcIndex == 0)) {
       bool isSourceTile = true;
       auto pc = configInterfaceLatency(aieDevInst, aieDevice, metadata, xaieModule, xaieModType, xdpModType, 
@@ -464,7 +465,15 @@ namespace xdp::aie::profile {
     if (ret != XAIE_OK)
       return nullptr;
 
-    XAie_LocType tileloc = XAie_TileLoc(tile.col, tile.row);
+    uint8_t startColShift = metadata->getPartitionOverlayStartCols().front();
+    auto absCol = tile.col + startColShift;
+    auto relCol = tile.col;
+    // For loadxclbin flow currently XRT creates partition of whole device from 0th column.
+    // Hence absolute and relative columns are same.
+    // TODO: For loadxclbin flow XRT will start creating partition of the specified columns,
+    //       hence we should stop adding partition shift to col for passing to XAIE Apis
+    auto xaieCol = (xdp::VPDatabase::Instance()->getStaticInfo().getAppStyle() == xdp::AppStyle::LOAD_XCLBIN_STYLE) ? absCol : relCol; 
+    XAie_LocType tileloc = XAie_TileLoc(xaieCol, tile.row);
 
     // uint8_t status = -1;
     // uint8_t broadcastId  = 10;
@@ -511,11 +520,18 @@ namespace xdp::aie::profile {
       }
 
       // Use the first available core tile to configure the broadcasting
-      uint8_t col = aieCoreTilesVec.begin()->col;
+      uint8_t startColShift = metadata->getPartitionOverlayStartCols().front();
+      uint8_t relCol = aieCoreTilesVec.begin()->col; 
+      auto absCol    = aieCoreTilesVec.begin()->col + startColShift;
+      // For loadxclbin flow currently XRT creates partition of whole device from 0th column.
+      // Hence absolute and relative columns are same.
+      // TODO: For loadxclbin flow XRT will start creating partition of the specified columns,
+      //       hence we should stop adding partition shift to col for passing to XAIE Apis
+      auto xaieCol   = (xdp::VPDatabase::Instance()->getStaticInfo().getAppStyle() == xdp::AppStyle::LOAD_XCLBIN_STYLE) ? absCol : relCol; 
       uint8_t row = aieCoreTilesVec.begin()->row;
-      auto& xaieTile = aieDevice->tile(col, row);
+      auto& xaieTile = aieDevice->tile(xaieCol, row);
       core = xaieTile.core();
-      loc = XAie_TileLoc(col, row);
+      loc = XAie_TileLoc(xaieCol, row);
     }
 
     auto iterCount = metadata->getIterationCount();
@@ -588,7 +604,15 @@ namespace xdp::aie::profile {
       return;
 
     for (auto &tile : allIntfTiles) {
-      vL.push_back(XAie_TileLoc(tile.col, tile.row));
+      uint8_t startColShift = metadata->getPartitionOverlayStartCols().front();
+      auto absCol = tile.col + startColShift;
+      auto relCol = tile.col;
+      // For loadxclbin flow currently XRT creates partition of whole device from 0th column.
+      // Hence absolute and relative columns are same.
+      // TODO: For loadxclbin flow XRT will start creating partition of the specified columns,
+      //       hence we should stop adding partition shift to col for passing to XAIE Apis
+      auto xaieCol = (xdp::VPDatabase::Instance()->getStaticInfo().getAppStyle() == xdp::AppStyle::LOAD_XCLBIN_STYLE) ? absCol : relCol; 
+      vL.push_back(XAie_TileLoc(xaieCol, tile.row));
     }
 
     auto BC = aieDevice->broadcast(vL, XAIE_PL_MOD, XAIE_PL_MOD);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
[CR-1251818](https://jira.xilinx.com/browse/CR-1251818)

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
The XAIE API used in getCounterPayload expects a relative column (relCol) rather than the absolute column (col). Passing the absolute column resulted in accessing gated tiles during profiling setup and produced repeated XAie_LinuxIO_Read32 gated tile errors

#### How problem was solved, alternative solutions (if any) and why they were rejected
Calculate the correct column required for XAIE API cols

#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
Tested on VCK190

#### Documentation impact (if any)
N/A