### PR TITLE
hip: stream: throw invalid value error for invalid flags for stream wait event

### DIFF
--- a/src/runtime_src/hip/api/hip_stream.cpp
+++ b/src/runtime_src/hip/api/hip_stream.cpp
@@ -82,7 +82,7 @@ hip_stream_synchronize(hipStream_t stream)
 static void
 hip_stream_wait_event(hipStream_t stream, hipEvent_t ev, unsigned int flags)
 {
-  throw_invalid_handle_if(flags != 0, "flags should be 0");
+  throw_invalid_value_if(flags != 0, "flags should be 0");
 
   auto hip_wait_stream = get_stream(stream);
   throw_invalid_resource_if(!hip_wait_stream, "stream is invalid");


### PR DESCRIPTION
hip: stream: throw invalid value error for invalid flags for stream wait event

In hipStreamWaitEvent() API, throw hipErrorInvalidValue for invalid flags input argument instead of invalid handle error.

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
