### PR TITLE
Fix runner regression from #9325

### DIFF
--- a/src/runtime_src/core/common/runner/main.cpp
+++ b/src/runtime_src/core/common/runner/main.cpp
@@ -124,8 +124,10 @@ filter_mode(json& profile, const std::string& mode)
 static void
 touchup_iterations(json& profile, uint32_t iterations)
 {
-  if (iterations)
-    profile["execution"]["iterations"] = iterations;
+  if (!iterations)
+    return;
+
+  profile["execution"]["iterations"] = iterations;
 
   for (auto& exec : profile["executions"])
     exec["iterations"] = iterations;

--- a/src/runtime_src/core/common/runner/profile.md
+++ b/src/runtime_src/core/common/runner/profile.md
@@ -272,7 +272,7 @@ This section is optional.  If not present, the recipe will execute
 one iteration.
 
 - `iterations` (default: `1`) specifies how many times the recipe
-  should execute.
+  should execute. The specified value must be greater than 0.
 - `verbose` (default: `true`) controls printing of metrics post all
   iterations. By default the profile execution will display to stdout
   elapsed, throughput, and latency computed from running the recipe

--- a/src/runtime_src/core/common/runner/runner.cpp
+++ b/src/runtime_src/core/common/runner/runner.cpp
@@ -2128,6 +2128,15 @@ class profile
       return 1;
     }
 
+    static size_t
+    get_iterations(const json& j)
+    {
+      if (auto value = j.value("iterations", 1))
+        return value;
+
+      throw profile_error("bad iterations value in profile, must be greater than 0");
+    }
+
     void
     execute_iteration(size_t iteration)
     {
@@ -2165,7 +2174,7 @@ class profile
       , m_depth(get_depth(m_mode, j))
       , m_recipe_runs(rr->num_runs())
       , m_executor{m_profile, rr, m_depth}
-      , m_iterations(j.value("iterations", 1))
+      , m_iterations{get_iterations(j)}
       , m_iteration(get_iteration_node(m_mode, j))
       , m_verbose(j.value("verbose", true))
       , m_validate(j.value("validate", false))


### PR DESCRIPTION
#### Problem solved by the commit
The runner can override profile iterations but the override accidentally defaulted the value to 0 causing a hang.  This was a regression in #9325 .

Two fixes in this PR.  (1) fix the accidental override, (2) throw if profile.json specifies iterations less than `1`.
