### PR TITLE
hip: implement memory prefetch async as synchronous instead

### DIFF
--- a/src/runtime_src/hip/core/event.cpp
+++ b/src/runtime_src/hip/core/event.cpp
@@ -314,28 +314,6 @@ bool memory_pool_command::wait()
   return true;
 }
 
-bool mem_prefetch_command::submit()
-{
-  auto hip_mem_and_off = memory_database::instance().get_hip_mem_from_addr(m_dev_ptr);
-  auto hip_mem = hip_mem_and_off.first;
-  size_t hip_mem_off = hip_mem_and_off.second;
-  throw_invalid_value_if(!hip_mem, "Invalid prefetch buf address.");
-  throw_invalid_value_if((hip_mem->get_size() < (hip_mem_off + m_size)),
-                         "Invalid prefetch buf address or size.");
-
-  // The under xrt::bo::sync() behaves the same for both TO_DEVICE or FROM_DEVICE direction.
-  // we pick xclBOSyncDirection::XCL_BO_SYNC_BO_TO_DEVICE as input argument here.
-  hip_mem->sync(xclBOSyncDirection::XCL_BO_SYNC_BO_TO_DEVICE, m_size, hip_mem_off);
-  set_state(state::completed);
-  return true;
-}
-
-bool mem_prefetch_command::wait()
-{
-  // completed in submit()
-  return true;
-}
-
 // Global map of commands
 xrt_core::handle_map<command_handle, std::shared_ptr<command>> command_cache;
 

--- a/src/runtime_src/hip/core/event.h
+++ b/src/runtime_src/hip/core/event.h
@@ -42,7 +42,6 @@ public:
     kernel_start,
     mem_cpy,
     mem_pool_op,
-    mem_prefetch
   };
 
 protected:
@@ -208,21 +207,6 @@ private:
   void* m_ptr;
   size_t m_size;
   std::future<void> m_handle;
-};
-
-class mem_prefetch_command : public command
-{
-public:
-  // sync() always happens in submit()
-  mem_prefetch_command(std::shared_ptr<stream> s, const void* dev_ptr, size_t size)
-    : command(command::type::mem_prefetch, std::move(s)), m_dev_ptr(dev_ptr), m_size(size)
-  {}
-  bool submit() override;
-  bool wait() override;
-
-private:
-  const void* m_dev_ptr;
-  size_t m_size;
 };
 
 // Global map of commands


### PR DESCRIPTION
Currently, hipMemoryPrefetchAsync() implement the fetch in an async fashion, Eventhough, it acts as synchronous most time. But caller can use it asynchronously with event, and the memory prefetch which is doing a memory sync can wait until dependent event is complete. However, this added overhead to create commands and push it to the command queue of a stream which is completed for simple cases. This patch change it to always do memory prefech synchronously instead, that is as long as it is called, it do memory sync all the time.

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Test with noop kernel firmware full elf with different number of kernel arguments as following:
```
uint64_t test_xrt_overhead_args(int num_iterations, int num_args, int num_non_null_args, size_t size, const std::string &elf_path, bool buf_sync)
{
  auto device = xrt::device(0);
  xrt::elf elf{elf_path};
  xrt::hw_context hwctx = xrt::hw_context(device, elf);
  xrt::ext::kernel kernel = xrt::ext::kernel(hwctx, "MLIR_AIE");
  xrt::bo args[num_args];
  for (int i = 0; i < num_non_null_args; i++) {
    args[i] = xrt::ext::bo{device, size};
  }
  auto elapsed_usec = get_time_elapsed_usec([&]() {
    for (int i = 0; i < num_iterations; i++) {
      auto runt = xrt::run(kernel);
      for (int j = 0; j < num_non_null_args; j++) {
        runt.set_arg(j, args[j]);
      }
      for (int j = num_non_null_args; j < num_args; j++) {
        runt.set_arg(j, nullptr);
      }
      if (buf_sync) {
        for (int j = 0; j < num_non_null_args; j++) {
          args[j].sync(XCL_BO_SYNC_BO_TO_DEVICE);
        }
      }
      runt.start();
      runt.wait2();
      if (buf_sync && (num_non_null_args == num_args)) {
        args[num_args - 1].sync(XCL_BO_SYNC_BO_FROM_DEVICE);
      }
    }
  });
  elapsed_usec /= num_iterations;
  std::cout << "XRT single module: args(" << num_args << "," << num_non_null_args << "): " << (buf_sync ? " with " : " without ") << "buf sync"
            << " Time elapsed: (" << num_iterations << ") iterations avg:" << elapsed_usec << "(us)" << std::endl;
  return elapsed_usec;
}

uint64_t test_hip_overhead_args(int num_iterations, int num_args, int num_non_null_args, size_t size, const std::string &elf_path, bool buf_sync)
{
  constexpr size_t num_bos = 1024;

  std::array<void *, num_bos> bo_host_ptrs;
  std::array<void *, num_bos> bo_dev_ptrs;
  for (int i = 0; i < num_bos; i++) {
    EXPECT_EQ(hipHostMalloc(&bo_host_ptrs[i], size, hipHostMallocMapped), hipSuccess);
    EXPECT_EQ(hipHostGetDevicePointer(&bo_dev_ptrs[i], bo_host_ptrs[i], hipHostMallocMapped), hipSuccess);
  }

  hipModule_t hmodule;
  EXPECT_EQ(hipModuleLoad(&hmodule, elf_path.c_str()), hipSuccess);
  hipFunction_t hfunction;
  EXPECT_EQ(hipModuleGetFunction(&hfunction, hmodule, "MLIR_AIE"), hipSuccess);
  void *args[num_args] = {};
  for (int i = 0; i < num_non_null_args; i++) {
    args[i] = &bo_dev_ptrs[i];
  }
  for (int i = num_non_null_args; i < num_args; i++) {
    args[i] = nullptr;
  }
  hipStream_t stream = nullptr;
  EXPECT_EQ(hipStreamCreateWithFlags(&stream, hipStreamNonBlocking), hipSuccess);

  auto elapsed_usec = get_time_elapsed_usec([&]() {
    for (int i = 0; i < num_iterations; i++) {
      if (buf_sync) {
        for (int j = 0; j < num_non_null_args; j++) {
          EXPECT_EQ(hipMemPrefetchAsync(bo_dev_ptrs[j], size, 0, stream), hipSuccess);
        }
      }
      EXPECT_EQ(hipModuleLaunchKernel(hfunction, 1, 1, 1, 1, 1, 1, 0, stream, args, nullptr), hipSuccess);
      EXPECT_EQ(hipStreamSynchronize(stream), hipSuccess);
      if (buf_sync && (num_non_null_args == num_args)) {
        EXPECT_EQ(hipMemPrefetchAsync(bo_dev_ptrs[3], size, 0, stream), hipSuccess);
      }
    }
  });
  elapsed_usec /= num_iterations;
  std::cout << "HIP stream single module: args(" << num_args << "," << num_non_null_args << "): " << (buf_sync ? " with " : " without ") << "buf sync"
            << " Time elapsed: (" << num_iterations << ") iterations avg:" << elapsed_usec << "(us)" << std::endl;
  for (int i = 0; i < num_bos; i++) {
    EXPECT_EQ(hipHostFree(bo_host_ptrs[i]), hipSuccess);
  }
  EXPECT_EQ(hipStreamDestroy(stream), hipSuccess);
  EXPECT_EQ(hipModuleUnload(hmodule), hipSuccess);
  return elapsed_usec;
}

TEST(HipXrtStreamEvent, HipXrtStreamOverhead)
{
  EXPECT_EQ(hipInit(0), hipSuccess);
  EXPECT_EQ(hipSetDevice(0), hipSuccess);

  constexpr int num_iterations = 1024 * 100;
  constexpr size_t size = KB(4);
  uint64_t hip_elapsed_us = 0;
  uint64_t xrt_elapsed_us = 0;

  xrt_elapsed_us = test_xrt_overhead_args(num_iterations, 2, 0, size, get_full_elf_path("noop-full.elf"), false);
  hip_elapsed_us = test_hip_overhead_args(num_iterations, 2, 0, size, get_full_elf_path("noop-full.elf"), false);
  ASSERT_LT(hip_elapsed_us < xrt_elapsed_us ? 0: (hip_elapsed_us - xrt_elapsed_us), 20);
  xrt_elapsed_us = test_xrt_overhead_args(num_iterations, 2, 2, size, get_full_elf_path("noop-full.elf"), false);
  hip_elapsed_us = test_hip_overhead_args(num_iterations, 2, 2, size, get_full_elf_path("noop-full.elf"), false);
  ASSERT_LT(hip_elapsed_us < xrt_elapsed_us ? 0: (hip_elapsed_us - xrt_elapsed_us), 20);
  xrt_elapsed_us = test_xrt_overhead_args(num_iterations, 2, 2, size, get_full_elf_path("noop-full.elf"), true);
  hip_elapsed_us = test_hip_overhead_args(num_iterations, 2, 2, size, get_full_elf_path("noop-full.elf"), true);
  ASSERT_LT(hip_elapsed_us < xrt_elapsed_us ? 0: (hip_elapsed_us - xrt_elapsed_us), 20);
  xrt_elapsed_us = test_xrt_overhead_args(num_iterations, 4, 0, size, get_full_elf_path("noop-4args-full.elf"), false);
  hip_elapsed_us = test_hip_overhead_args(num_iterations, 4, 0, size, get_full_elf_path("noop-4args-full.elf"), false);
  ASSERT_LT(hip_elapsed_us < xrt_elapsed_us ? 0: (hip_elapsed_us - xrt_elapsed_us), 20);
  xrt_elapsed_us = test_xrt_overhead_args(num_iterations, 4, 4, size, get_full_elf_path("noop-4args-full.elf"), false);
  hip_elapsed_us = test_hip_overhead_args(num_iterations, 4, 4, size, get_full_elf_path("noop-4args-full.elf"), false);
  ASSERT_LT(hip_elapsed_us < xrt_elapsed_us ? 0: (hip_elapsed_us - xrt_elapsed_us), 20);
  xrt_elapsed_us = test_xrt_overhead_args(num_iterations, 4, 4, size, get_full_elf_path("noop-4args-full.elf"), true);
  hip_elapsed_us = test_hip_overhead_args(num_iterations, 4, 4, size, get_full_elf_path("noop-4args-full.elf"), true);
  ASSERT_LT(hip_elapsed_us < xrt_elapsed_us ? 0: (hip_elapsed_us - xrt_elapsed_us), 20);
  xrt_elapsed_us = test_xrt_overhead_args(num_iterations, 8, 0, size, get_full_elf_path("noop-8args-full.elf"), false);
  hip_elapsed_us = test_hip_overhead_args(num_iterations, 8, 0, size, get_full_elf_path("noop-8args-full.elf"), false);
  ASSERT_LT(hip_elapsed_us < xrt_elapsed_us ? 0: (hip_elapsed_us - xrt_elapsed_us), 20);
  xrt_elapsed_us = test_xrt_overhead_args(num_iterations, 8, 8, size, get_full_elf_path("noop-8args-full.elf"), false);
  hip_elapsed_us = test_hip_overhead_args(num_iterations, 8, 8, size, get_full_elf_path("noop-8args-full.elf"), false);
   ASSERT_LT(hip_elapsed_us < xrt_elapsed_us ? 0: (hip_elapsed_us - xrt_elapsed_us), 20);
  xrt_elapsed_us = test_xrt_overhead_args(num_iterations, 8, 8, size, get_full_elf_path("noop-8args-full.elf"), true);
  hip_elapsed_us = test_hip_overhead_args(num_iterations, 8, 8, size, get_full_elf_path("noop-8args-full.elf"), true);
  ASSERT_LT(hip_elapsed_us < xrt_elapsed_us ? 0: (hip_elapsed_us - xrt_elapsed_us), 20);
  xrt_elapsed_us = test_xrt_overhead_args(num_iterations, 16, 0, size, get_full_elf_path("noop-16args-full.elf"), false);
  hip_elapsed_us = test_hip_overhead_args(num_iterations, 16, 0, size, get_full_elf_path("noop-16args-full.elf"), false);
  ASSERT_LT(hip_elapsed_us < xrt_elapsed_us ? 0: (hip_elapsed_us - xrt_elapsed_us), 20);
  xrt_elapsed_us = test_xrt_overhead_args(num_iterations, 16, 16, size, get_full_elf_path("noop-16args-full.elf"), false);
  hip_elapsed_us = test_hip_overhead_args(num_iterations, 16, 16, size, get_full_elf_path("noop-16args-full.elf"), false);
   ASSERT_LT(hip_elapsed_us < xrt_elapsed_us ? 0: (hip_elapsed_us - xrt_elapsed_us), 20);
  xrt_elapsed_us = test_xrt_overhead_args(num_iterations, 16, 16, size, get_full_elf_path("noop-16args-full.elf"), true);
  hip_elapsed_us = test_hip_overhead_args(num_iterations, 16, 16, size, get_full_elf_path("noop-16args-full.elf"), true);
  ASSERT_LT(hip_elapsed_us < xrt_elapsed_us ? 0: (hip_elapsed_us - xrt_elapsed_us), 20);
}
```

Result:
Before the change:
```
XRT single module: args(2,0):  without buf sync Time elapsed: (102400) iterations avg:61(us)
HIP stream single module: args(2,0):  without buf sync Time elapsed: (102400) iterations avg:61(us)
XRT single module: args(2,2):  without buf sync Time elapsed: (102400) iterations avg:61(us)
HIP stream single module: args(2,2):  without buf sync Time elapsed: (102400) iterations avg:62(us)
XRT single module: args(2,2):  with buf sync Time elapsed: (102400) iterations avg:62(us)
HIP stream single module: args(2,2):  with buf sync Time elapsed: (102400) iterations avg:63(us)
XRT single module: args(4,0):  without buf sync Time elapsed: (102400) iterations avg:61(us)
HIP stream single module: args(4,0):  without buf sync Time elapsed: (102400) iterations avg:62(us)
XRT single module: args(4,4):  without buf sync Time elapsed: (102400) iterations avg:63(us)
HIP stream single module: args(4,4):  without buf sync Time elapsed: (102400) iterations avg:63(us)
XRT single module: args(4,4):  with buf sync Time elapsed: (102400) iterations avg:63(us)
HIP stream single module: args(4,4):  with buf sync Time elapsed: (102400) iterations avg:65(us)
XRT single module: args(8,0):  without buf sync Time elapsed: (102400) iterations avg:62(us)
HIP stream single module: args(8,0):  without buf sync Time elapsed: (102400) iterations avg:62(us)
XRT single module: args(8,8):  without buf sync Time elapsed: (102400) iterations avg:64(us)
HIP stream single module: args(8,8):  without buf sync Time elapsed: (102400) iterations avg:65(us)
XRT single module: args(8,8):  with buf sync Time elapsed: (102400) iterations avg:65(us)
HIP stream single module: args(8,8):  with buf sync Time elapsed: (102400) iterations avg:68(us)
XRT single module: args(16,0):  without buf sync Time elapsed: (102400) iterations avg:63(us)
HIP stream single module: args(16,0):  without buf sync Time elapsed: (102400) iterations avg:63(us)
XRT single module: args(16,16):  without buf sync Time elapsed: (102400) iterations avg:67(us)
HIP stream single module: args(16,16):  without buf sync Time elapsed: (102400) iterations avg:68(us)
XRT single module: args(16,16):  with buf sync Time elapsed: (102400) iterations avg:67(us)
HIP stream single module: args(16,16):  with buf sync Time elapsed: (102400) iterations avg:74(us)
```
After the change:
```
XRT single module: args(2,0):  without buf sync Time elapsed: (102400) iterations avg:61(us)
HIP stream single module: args(2,0):  without buf sync Time elapsed: (102400) iterations avg:61(us)
XRT single module: args(2,2):  without buf sync Time elapsed: (102400) iterations avg:61(us)
HIP stream single module: args(2,2):  without buf sync Time elapsed: (102400) iterations avg:62(us)
XRT single module: args(2,2):  with buf sync Time elapsed: (102400) iterations avg:62(us)
HIP stream single module: args(2,2):  with buf sync Time elapsed: (102400) iterations avg:63(us)
XRT single module: args(4,0):  without buf sync Time elapsed: (102400) iterations avg:61(us)
HIP stream single module: args(4,0):  without buf sync Time elapsed: (102400) iterations avg:58(us)
XRT single module: args(4,4):  without buf sync Time elapsed: (102400) iterations avg:61(us)
HIP stream single module: args(4,4):  without buf sync Time elapsed: (102400) iterations avg:63(us)
XRT single module: args(4,4):  with buf sync Time elapsed: (102400) iterations avg:63(us)
HIP stream single module: args(4,4):  with buf sync Time elapsed: (102400) iterations avg:64(us)
XRT single module: args(8,0):  without buf sync Time elapsed: (102400) iterations avg:62(us)
HIP stream single module: args(8,0):  without buf sync Time elapsed: (102400) iterations avg:62(us)
XRT single module: args(8,8):  without buf sync Time elapsed: (102400) iterations avg:63(us)
HIP stream single module: args(8,8):  without buf sync Time elapsed: (102400) iterations avg:65(us)
XRT single module: args(8,8):  with buf sync Time elapsed: (102400) iterations avg:64(us)
HIP stream single module: args(8,8):  with buf sync Time elapsed: (102400) iterations avg:67(us)
XRT single module: args(16,0):  without buf sync Time elapsed: (102400) iterations avg:63(us)
HIP stream single module: args(16,0):  without buf sync Time elapsed: (102400) iterations avg:63(us)
XRT single module: args(16,16):  without buf sync Time elapsed: (102400) iterations avg:66(us)
HIP stream single module: args(16,16):  without buf sync Time elapsed: (102400) iterations avg:68(us)
XRT single module: args(16,16):  with buf sync Time elapsed: (102400) iterations avg:67(us)
HIP stream single module: args(16,16):  with buf sync Time elapsed: (102400) iterations avg:71(us)
```

The above result shows memory buffer sync time reduced after the change.

#### Documentation impact (if any)
