### PR TITLE
Limit maximum number of jobs in xrt-runner queue

### DIFF
--- a/src/runtime_src/core/common/runner/main.cpp
+++ b/src/runtime_src/core/common/runner/main.cpp
@@ -120,12 +120,19 @@ filter_mode(json& profile, const std::string& mode)
   if (mode == "all")
     return;
 
+  // Legacy profile nothing to filter
+  if (!profile.contains("executions"))
+    return;
+
   auto& execs = profile["executions"];
   execs.erase(std::remove_if(execs.begin(), execs.end(),
                              [mode](const json& exec) {
-                               return exec["mode"] != mode;
+                               return (!exec.contains("mode") || exec["mode"] != mode);
                              }),
               execs.end());
+
+  if (execs.empty())
+    throw std::runtime_error("No execution profile with mode '" + mode + "'");
 }
 
 // Touch up profile(s) with specified iterations
@@ -507,7 +514,7 @@ usage()
   std::cout << " [--script <script>] runner script, enables multi-threaded execution\n";
   std::cout << " [--threads <number>] number of threads to use when running script (default: #jobs)\n";
   std::cout << " [--dir <path>] directory containing artifacts (default: current dir)\n";
-  std::cout << " [--mode <latency|throughput>] execute only specified mode (default: all)\n";
+  std::cout << " [--mode <latency|throughput|validate>] execute only specified mode (default: all)\n";
   std::cout << " [--progress] show progress\n";
   std::cout << " [--asap] process jobs immediately (default: wait for all jobs to initialize)\n";
   std::cout << " [--max-queue-size <number>] maximum number of in-flight commands (default: #jobs)\n";
@@ -523,7 +530,7 @@ usage()
   std::cout << "Note, [--max-queue-size <num>] limits the number of in-flight jobs, implies --asap so\n";
   std::cout << "that jobs can be drained to make room for more jobs.  This option is useful in script\n";
   std::cout << "mode when memory puts a limit to how many jobs can be created simultanously.\n\n";
-  std::cout << "Note, [--mode <latency|throughput>] filters execution sections in profile.json such\n";
+  std::cout << "Note, [--mode <latency|throughput|validate>] filters execution sections in profile.json such\n";
   std::cout << "only specified modes are executed. If the runner script specifies a mode for a recipe/profile\n";
   std::cout << "pair, then this value is sticky for that recipe/profile pair.\n";
 }

--- a/src/runtime_src/core/common/runner/profile.md
+++ b/src/runtime_src/core/common/runner/profile.md
@@ -262,7 +262,7 @@ then the recipe will execute one iteration.
     "verbose": false,      // disable reporting of cpu time
     "validate": true,      // validate after all iterations
     "runlist_threshold": 1 // when to use xrt::runlist
-    "mode": mode           // latency or throughput
+    "mode": mode           // latency, throughput, or validate
     "depth": depth         // clone the recipe runlist
     "iteration" : {
     }
@@ -278,14 +278,16 @@ one iteration.
   elapsed, throughput, and latency computed from running the recipe
   specified number of iterations.
 - `validate` (default: `false`) enables validation per binding
-  elements upon completion of all iterations.
+  elements upon completion of all iterations. If mode is set to
+  validate then this element is implicitly `true` (see details
+  in mode section).
 - `runlist_threshold` (default: `6`) specifies when to
   xrt::runlist. xrt::runner controls when to use xrt::runlist versus a
   list of separate xrt::run objects. A value of `0` disables
   xrt::runlist completely, any other value is used to trigger when to
   use xrt::runlist based on corresponding number of recipe run objects.
 - `mode` (optional) runs the recipe in specified mode. The recipe can
-  be run in latency, or throughput mode (see details below).
+  be run in latency, throughput or validate mode (see details below).
 - `depth` (default: 1 or 2). Specifies how many times the recipe runs should
   be cloned. All `runs` specified in a [recipe](recipe.md#execution) are
   treated as a single runlist.  In `throughput` mode the recipe runlist
@@ -315,6 +317,9 @@ or `throughput`:
   significant to ensure that the hardware is kept busy, a `depth` of
   `1` is really measuring latency but still reported as throughput if
   `mode` is set to throughput.
+- `validate` mode. In validate mode, the runner at a minimum enables
+   validation per binding elements upon completion of specified or
+   default number of iterations.
 
 #### iteration
 The `iteration` sub-element is optional, but if present specifies what

--- a/src/runtime_src/core/common/runner/runner.cpp
+++ b/src/runtime_src/core/common/runner/runner.cpp
@@ -2062,7 +2062,7 @@ class profile
     }; // class profile::execution::executor
 
     // Mode of execution
-    enum class mode { none, latency, throughput };
+    enum class mode { none, latency, throughput, validate };
     
     profile* m_profile;
     std::string m_name;
@@ -2083,7 +2083,8 @@ class profile
       static const std::map<std::string, mode> mode_map{
         {"default", mode::none},
         {"latency", mode::latency},
-        {"throughput", mode::throughput}
+        {"throughput", mode::throughput},
+        {"validate", mode::validate}
       };
 
       if (auto itr = mode_map.find(mstr); itr != mode_map.end())
@@ -2098,7 +2099,8 @@ class profile
       static const std::map<mode, std::string> mode_map{
         {mode::none, "default"},
         {mode::latency, "latency"},
-        {mode::throughput, "throughput"}
+        {mode::throughput, "throughput"},
+        {mode::validate, "validate"}
       };
 
       if (auto itr = mode_map.find(m); itr != mode_map.end())
@@ -2110,10 +2112,10 @@ class profile
     static iteration_node
     get_iteration_node(mode m, const json& j)
     {
-      if (m == mode::none)
+      if (m == mode::none || m == mode::validate)
         return j.value("iteration", json::object());
 
-      // latency and throughput modes do not support iteration node
+      // validate and throughput do not support iteration node
       return json::object();
     }
 
@@ -2177,7 +2179,7 @@ class profile
       , m_iterations{get_iterations(j)}
       , m_iteration(get_iteration_node(m_mode, j))
       , m_verbose(j.value("verbose", true))
-      , m_validate(j.value("validate", false))
+      , m_validate(j.value("validate", (m_mode == mode::validate)))
       , m_legacy(legacy)
     {}
 


### PR DESCRIPTION
#### Problem solved by the commit
Scripted execution can specify any number of jobs, which can lead to out-of-memory when creating and adding the xrt::runner jobs to the queue.

Extend profile execution::mode with validate to allow easy filtering of profile executions to any one of the supported modes (validate, latency, throughput).

#### How problem was solved, alternative solutions (if any) and why they were rejected
This PR adds a new switch `--max-queue-size <num>` which causes `job_queue::add(...)` to wait if current number of jobs in the queue exceeds the specified max.  The option implies `--asap` so that jobs are processed as soon as possible rather than all created up-front.