### PR TITLE
Fix AIE Event Trace for Client

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -165,27 +165,6 @@ void AieTracePluginUnified::updateAIEDevice(void *handle, bool hw_context_flow) 
     return;
   }
   AIEData.valid = true; // initialize struct
-  
-  // Check if trace streams are available TODO
-  AIEData.metadata->setNumStreamsPLIO(
-      (db->getStaticInfo()).getNumAIETraceStream(deviceID, io_type::PLIO));
-  AIEData.metadata->setNumStreamsGMIO(
-      (db->getStaticInfo()).getNumAIETraceStream(deviceID, io_type::GMIO));
-  
-  uint64_t numStreamsPLIO = AIEData.metadata->getNumStreamsPLIO();
-  uint64_t numStreamsGMIO = AIEData.metadata->getNumStreamsGMIO();
-  bool isPLIO = (numStreamsPLIO > 0) ? true : false;
-  bool isGMIO = (numStreamsGMIO > 0) ? true : false;
-  
-  // Check if we've already configured a PLIO partition and current partition also has PLIO
-  // If so, skip this entire partition. GMIO-only partitions are still allowed. This is applicable just for register xclbin flow.
-  if ((db->getStaticInfo()).getAppStyle() == xdp::AppStyle::REGISTER_XCLBIN_STYLE && isPLIO && configuredOnePlioPartition) {
-    xrt_core::message::send(severity_level::warning, "XRT",
-      "AIE Trace: PLIO offload is not supported on multiple partitions at once. "
-      "A previous PLIO partition has already been configured. Skipping current PLIO partition.");
-    AIEData.valid = false;
-    return;
-  }
 
   // If there are tiles configured for this xclbin, then we have configured the first matching xclbin and will not configure any upcoming ones
   if ((xrt_core::config::get_aie_trace_settings_config_one_partition()) && !(AIEData.metadata->configMetricsEmpty()))
@@ -230,6 +209,30 @@ void AieTracePluginUnified::updateAIEDevice(void *handle, bool hw_context_flow) 
     }
 
     (db->getStaticInfo()).setIsGMIORead(deviceID, true);
+  }
+
+  // Check if trace streams are available
+  AIEData.metadata->setNumStreamsPLIO(
+      (db->getStaticInfo()).getNumAIETraceStream(deviceID, io_type::PLIO));
+  AIEData.metadata->setNumStreamsGMIO(
+      (db->getStaticInfo()).getNumAIETraceStream(deviceID, io_type::GMIO));
+
+  uint64_t numStreamsPLIO = AIEData.metadata->getNumStreamsPLIO();
+  uint64_t numStreamsGMIO = AIEData.metadata->getNumStreamsGMIO();
+  bool isPLIO = (numStreamsPLIO > 0) ? true : false;
+  bool isGMIO = (numStreamsGMIO > 0) ? true : false;
+
+  // Check if we've already configured a PLIO partition and current partition also has PLIO
+  // If so, skip this entire partition. GMIO-only partitions are still allowed.
+  // This is applicable only for register xclbin flow.
+  if ((db->getStaticInfo()).getAppStyle() == xdp::AppStyle::REGISTER_XCLBIN_STYLE &&
+          isPLIO && !isGMIO && configuredOnePlioPartition) {
+    xrt_core::message::send(severity_level::warning, "XRT",
+      "AIE Trace: PLIO offload is not supported on multiple partitions at once. "
+      "A previous PLIO partition has already been configured. "
+      "Skipping current PLIO partition.");
+    AIEData.valid = false;
+    return;
   }
 
   if ((AIEData.metadata->getNumStreamsPLIO() == 0) && 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
For Client, number of GMIO streams are incorrectly reported as 0 and hence no trace is configured/available. 
Along with the above fix, this PR fixes incorrect skipping of trace configuration for AIE partitions using GMIO streams when other AIE Partitions using PLIO trace stream have already been configured.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://github.com/Xilinx/XRT/pull/9344

#### How problem was solved, alternative solutions (if any) and why they were rejected
For Client, we need to check the metadata explicitly to find the GMIO streams and add to the DB. So, check for number of GMIO streams should be done after this explicit check.

#### Risks (if any) associated the changes in the commit
Low
#### What has been tested and how, request additional testing if necessary
Unit test on Client
#### Documentation impact (if any)
