### PR TITLE
Configure ML Timeline buffer segments 

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_trace_config_filetype.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info/filetypes/aie_trace_config_filetype.cpp
@@ -249,7 +249,7 @@ AIETraceConfigFiletype::getTiles(const std::string& graph_name,
 std::vector<UCInfo>
 AIETraceConfigFiletype::getActiveMicroControllers() const
 {
-    if (getHardwareGeneration() != 5)
+    if (getHardwareGeneration() < 5)
       return {};
 
     auto activeUCInfo = aie_meta.get_child_optional("Microcontrollers");

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_impl.h
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_impl.h
@@ -1,18 +1,5 @@
-/**
- * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. - All rights reserved
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved
 
 #ifndef XDP_PLUGIN_ML_TIMELINE_IMPL_H
 #define XDP_PLUGIN_ML_TIMELINE_IMPL_H
@@ -31,11 +18,13 @@ namespace xdp {
     protected :
       VPDatabase* db = nullptr;
       uint32_t mBufSz;
+      uint32_t mNumBufSegments;
 
     public:
       MLTimelineImpl(VPDatabase* dB, uint32_t sz)
         : db(dB),
-          mBufSz(sz)
+          mBufSz(sz),
+          mNumBufSegments(1)
       {}
 
       MLTimelineImpl() = delete;

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_plugin.cpp
@@ -106,8 +106,7 @@ namespace xdp {
   void MLTimelinePlugin::updateDevice(void* hwCtxImpl)
   {
     xrt_core::message::send(xrt_core::message::severity_level::info, "XRT",
-          "In ML Timeline Plugin : updateDevice.");
-          
+          "In ML Timeline Plugin : updateDevice.");          
       
 #ifdef XDP_CLIENT_BUILD
 
@@ -122,13 +121,13 @@ namespace xdp {
     xrt::hw_context hwContext = xrt_core::hw_context_int::create_hw_context_from_implementation(hwCtxImpl);
     std::shared_ptr<xrt_core::device> coreDevice = xrt_core::hw_context_int::get_core_device(hwContext);
 
-    //uint64_t deviceId = (db->getStaticInfo()).getHwCtxImplUid(hwCtxImpl); // TODO
+    uint64_t deviceId = (db->getStaticInfo()).getHwCtxImplUid(hwCtxImpl);
     uint64_t implId   = mMultiImpl.size();  // to match ML Timeline output file naming convention
 
-    std::string winDeviceName = "win_device" + std::to_string(implId);
-    uint64_t deviceId = db->addDevice(winDeviceName);
-    (db->getStaticInfo()).updateDeviceFromCoreDevice(deviceId, coreDevice, false);
-    (db->getStaticInfo()).setDeviceName(deviceId, winDeviceName);
+    std::string deviceName = util::getDeviceName(hwCtxImpl, true);
+
+    (db->getStaticInfo()).updateDeviceFromCoreDevice(deviceId, coreDevice);
+    (db->getStaticInfo()).setDeviceName(deviceId, deviceName);
 
     mMultiImpl[hwCtxImpl] = std::make_pair(implId, std::make_unique<MLTimelineClientDevImpl>(db, mBufSz));
     auto mlImpl = mMultiImpl[hwCtxImpl].second.get();

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/ml_timeline_plugin.h
@@ -1,18 +1,5 @@
-/**
- * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. - All rights reserved
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved
 
 #ifndef XDP_ML_TIMELINE_PLUGIN_H
 #define XDP_ML_TIMELINE_PLUGIN_H

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/ve2/ml_timeline.cpp
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/ve2/ml_timeline.cpp
@@ -51,8 +51,7 @@ namespace xdp {
   };
 
   MLTimelineVE2Impl::MLTimelineVE2Impl(VPDatabase*dB, uint32_t sz)
-    : MLTimelineImpl(dB, sz),
-      mNumBufSegments(0)
+    : MLTimelineImpl(dB, sz)
   {
     xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT", 
               "Created ML Timeline Plugin for VE2 Device.");

--- a/src/runtime_src/xdp/profile/plugin/ml_timeline/ve2/ml_timeline.h
+++ b/src/runtime_src/xdp/profile/plugin/ml_timeline/ve2/ml_timeline.h
@@ -1,18 +1,5 @@
-/**
- * Copyright (C) 2025 Advanced Micro Devices, Inc. - All rights reserved
- *        
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */ 
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved
 
 #ifndef XDP_PLUGIN_ML_TIMELINE_VE2_IMPL_H
 #define XDP_PLUGIN_ML_TIMELINE_VE2_IMPL_H
@@ -25,7 +12,6 @@ namespace xdp {
   class ResultBOContainer;
   class MLTimelineVE2Impl : public MLTimelineImpl
   {
-    uint32_t mNumBufSegments;
     std::unique_ptr<ResultBOContainer> mResultBOHolder;
     public :
       MLTimelineVE2Impl(VPDatabase* dB, uint32_t sz);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
For new Client devices, ML Timeline buffer needs to be configured for separate segments for separate controllers

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Start reading aie metadata to determine the device gen and number of controllers used.

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Unit test on client

#### Documentation impact (if any)
