### PR TITLE
hip: module: only try load module with full elf if file is ELF

### DIFF
--- a/src/runtime_src/hip/api/hip_module.cpp
+++ b/src/runtime_src/hip/api/hip_module.cpp
@@ -279,12 +279,11 @@ hipModuleLoad(hipModule_t* module, const char* fname)
     // try creating full ELF module
     // if it throws fallback to xclbin + ELF flow
     xrt::core::hip::module_handle handle;
-    try {
+    if (xrt::core::hip::hip_module_file_is_elf(fname)) {
       handle = xrt::core::hip::create_full_elf_module(std::string{fname});
       *module = reinterpret_cast<hipModule_t>(handle);
       return;
     }
-    catch (...) { /*do nothing*/ }
 
     handle = xrt::core::hip::create_xclbin_module(std::string{fname});
     *module = reinterpret_cast<hipModule_t>(handle);


### PR DESCRIPTION
hipModuleLoad() only try loading module with full elf if the specified file is an ELF file. This is to avoid showing XCLBIN error for full elf loading failure.

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
