### PR TITLE
[XRT-SMI] AIESW-14189 XRT to provide a static library for firmware log config and data parsing

### DIFF
--- a/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
@@ -134,3 +134,24 @@ if (NOT XRT_INSTALL_BIN_DIR STREQUAL XRT_INSTALL_UNWRAPPED_DIR)
     DESTINATION ${XRT_INSTALL_BIN_DIR} COMPONENT ${XRT_BASE_COMPONENT})
 endif()
 
+# FirmwareLog Static Library
+# Create a separate static library for FirmwareLog classes
+set(FIRMWARE_LOG_LIB_NAME "xrt_firmware_log")
+add_library(${FIRMWARE_LOG_LIB_NAME} STATIC FirmwareLog.cpp)
+
+set_target_properties(${FIRMWARE_LOG_LIB_NAME} PROPERTIES
+  CXX_STANDARD 17
+  CXX_STANDARD_REQUIRED ON
+)
+
+# Install firmware log library
+install(TARGETS ${FIRMWARE_LOG_LIB_NAME}
+  EXPORT xrt-targets
+  ARCHIVE DESTINATION ${XRT_INSTALL_LIB_DIR} COMPONENT ${XRT_BASE_DEV_COMPONENT})
+
+# Install header to experimental location with renamed filename
+install(FILES FirmwareLog.h
+  DESTINATION ${XRT_INSTALL_INCLUDE_DIR}/xrt/experimental
+  RENAME xrt_firmware_log.h
+  COMPONENT ${XRT_BASE_DEV_COMPONENT})
+


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
This PR creates and installs the xrt_firmware_log.lib/xrt_firmware_log.a libraries to XRT installation and xrt_firmware_log.h to xrt/experimental install path. These are required for WinDbg for log parsing.
This static library uses the same implementation used by xrt-smi to parse the runtime config and runtime logs for firmware-log report

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
[AIESW-14189](https://jira.xilinx.com/browse/AIESW-14189)

#### How problem was solved, alternative solutions (if any) and why they were rejected
The problem was solved via creating and installing above library through CMake in XRT.

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Not tested. Will work with WinDbg to test out.

#### Documentation impact (if any)
None.
