### PR TITLE
Fix for CR-1236201

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_metadata.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_profile_metadata.cpp
@@ -356,11 +356,11 @@ namespace xdp {
       }
 
       // Grab channel numbers (if specified; memory tiles only)
-      if (graphMetrics[i].size() == 5) {
+      if (graphMetrics[i].size() > 3) {
         try {
           for (auto& e : tiles) {
             configChannel0[e] = aie::convertStringToUint8(graphMetrics[i][3]);
-            configChannel1[e] = aie::convertStringToUint8(graphMetrics[i][4]);
+            configChannel1[e] = aie::convertStringToUint8(graphMetrics[i].back());
           }
         }
         catch (...) {
@@ -398,11 +398,11 @@ namespace xdp {
       }
 
       // Grab channel numbers (if specified; memory tiles only)
-      if (graphMetrics[i].size() == 5) {
+      if (graphMetrics[i].size() > 3) {
         try {
           for (auto& e : tiles) {
             configChannel0[e] = aie::convertStringToUint8(graphMetrics[i][3]);
-            configChannel1[e] = aie::convertStringToUint8(graphMetrics[i][4]);
+            configChannel1[e] = aie::convertStringToUint8(graphMetrics[i].back());
           }
         }
         catch (...) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
CR-1236201

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
The AIE profile metadata parser only accepted configurations with exactly 5 tokens, rejecting/ignoring valid 4-token configurations (eg: all:all:s2mm_throughputs:1). This caused the channel parameter to be dropped, defaulting to channel 0

#### How problem was solved, alternative solutions (if any) and why they were rejected
Changed parsing condition from == 5 to > 3 to accept both 4-token and 5-token configurations. This aligns with the more flexible parsing already used in aie_trace_metadata.cpp and allows the channel parameter to be correctly parsed and applied.

#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
Tested on VEK280 with the xrt.ini specified in the CR. Also tested with both channels 0 and 1 individually and mixed to make sure it is working as expected

#### Documentation impact (if any)
N/A