### PR TITLE
query: context_health_info: support context health report v1

### DIFF
--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -2019,6 +2019,7 @@ struct context_health_info : request
     uint64_t ctx_id;
     uint64_t pid;
     ert_ctx_health_data health_data;
+    ert_ctx_health_data_v1 health_data_v1;
   };
   using result_type = std::vector<smi_context_health>;
   static const key_type key = key_type::context_health_info;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Supporting context health report v1 on aie2/aie4.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
In order to support context health report v1 on aie2/aie4, adding new ert_ctx_health_data_v1 entry in smi_context_health structure to enable backward compatibility as well as windows driver. Replacing ert_ctx_health_data with ert_ctx_health_data_v1 may disturb the functionality on windows platforms. So, once everyone move to v1 report, then we can remove v0 (ert_ctx_health_data) entry from context_health_info
#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
