### PR TITLE
Fix for CR-1209896 (for 2025.2 branch)

### DIFF
--- a/src/runtime_src/xdp/profile/writer/vp_base/ini_parameters.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/ini_parameters.cpp
@@ -37,17 +37,18 @@ namespace xdp {
     addParameter("xrt_trace", xrt_core::config::get_xrt_trace(),
                  "Generation of hardware SHIM function trace");
     addParameter("device_trace",
-                 xrt_core::config::get_device_trace(),
+                 replaceCommas(xrt_core::config::get_device_trace()),
                  "Collection of data from PL monitors and added to summary and trace");
     addParameter("power_profile", xrt_core::config::get_power_profile(),
                  "Polling of power data during execution of application");
     addParameter("power_profile_interval_ms",
                  xrt_core::config::get_power_profile_interval_ms(),
                  "Interval for reading power data (in ms)");
-    addParameter("stall_trace", xrt_core::config::get_stall_trace(),
+    addParameter("stall_trace", 
+                 replaceCommas(xrt_core::config::get_stall_trace()),
                  "Enables hardware generation of stalls in compute units");
     addParameter("trace_buffer_size",
-                 xrt_core::config::get_trace_buffer_size(),
+                 replaceCommas(xrt_core::config::get_trace_buffer_size()),
                  "Size of buffer to allocate for trace (memory offload only)");
     addParameter("verbosity", xrt_core::config::get_verbosity(),
                  "Verbosity level");
@@ -74,6 +75,12 @@ namespace xdp {
                  "Interval for reading AI Engine debug/status registers (in us)");
     addParameter("vitis_ai_profile", xrt_core::config::get_vitis_ai_profile(),
                  "Generation of Vitis AI summary and trace (Vitis AI designs only)");
+    addParameter("profiling_directory", 
+                 replaceCommas(xrt_core::config::get_profiling_directory()),
+                 "Path to the directory where all debug/profiling data is saved");
+    addParameter("xdp_mode", 
+                 replaceCommas(xrt_core::config::get_xdp_mode()),
+                 "Mode in which design is running (zocl or xdna)");
 
     // AIE Profile
     addParameter("AIE_profile_settings.interval_us",
@@ -83,34 +90,34 @@ namespace xdp {
                  xrt_core::config::get_aie_profile_settings_config_one_partition(),
                  "Flag for enabling profiling for a specific partition");
     addParameter("AIE_profile_settings.graph_based_aie_metrics",
-                 xrt_core::config::get_aie_profile_settings_graph_based_aie_metrics(),
+                 replaceCommas(xrt_core::config::get_aie_profile_settings_graph_based_aie_metrics()),
                  "Metric set for profiling AI Engine processor modules per graph");
     addParameter("AIE_profile_settings.graph_based_aie_memory_metrics",
-                 xrt_core::config::get_aie_profile_settings_graph_based_aie_memory_metrics(),
+                 replaceCommas(xrt_core::config::get_aie_profile_settings_graph_based_aie_memory_metrics()),
                  "Metric set for profiling AI Engine memory modules per graph");
     addParameter("AIE_profile_settings.graph_based_memory_tile_metrics",
-                 xrt_core::config::get_aie_profile_settings_graph_based_memory_tile_metrics(),
+                 replaceCommas(xrt_core::config::get_aie_profile_settings_graph_based_memory_tile_metrics()),
                  "Metric set for profiling AI Engine memory tiles per graph");
     addParameter("AIE_profile_settings.graph_based_interface_tile_metrics",
-                 xrt_core::config::get_aie_profile_settings_graph_based_interface_tile_metrics(),
+                 replaceCommas(xrt_core::config::get_aie_profile_settings_graph_based_interface_tile_metrics()),
                  "Metric set for profiling AI Engine interface tiles per graph");
     addParameter("AIE_profile_settings.tile_based_aie_metrics",
-                 xrt_core::config::get_aie_profile_settings_tile_based_aie_metrics(),
+                 replaceCommas(xrt_core::config::get_aie_profile_settings_tile_based_aie_metrics()),
                  "Metric set for profiling AI Engine processor modules per tile");
     addParameter("AIE_profile_settings.tile_based_aie_memory_metrics",
-                 xrt_core::config::get_aie_profile_settings_tile_based_aie_memory_metrics(),
+                 replaceCommas(xrt_core::config::get_aie_profile_settings_tile_based_aie_memory_metrics()),
                  "Metric set for profiling AI Engine memory modules per tile");
     addParameter("AIE_profile_settings.tile_based_memory_tile_metrics",
-                 xrt_core::config::get_aie_profile_settings_tile_based_memory_tile_metrics(),
+                 replaceCommas(xrt_core::config::get_aie_profile_settings_tile_based_memory_tile_metrics()),
                  "Metric set for profiling AI Engine memory tiles per tile");
     addParameter("AIE_profile_settings.tile_based_interface_tile_metrics",
-                 xrt_core::config::get_aie_profile_settings_tile_based_interface_tile_metrics(),
+                 replaceCommas(xrt_core::config::get_aie_profile_settings_tile_based_interface_tile_metrics()),
                  "Metric set for profiling AI Engine interface tiles per tile");
    addParameter("AIE_profile_settings.interface_tile_latency",
-                 xrt_core::config::get_aie_profile_settings_interface_tile_latency_metrics(),
+                 replaceCommas(xrt_core::config::get_aie_profile_settings_interface_tile_latency_metrics()),
                  "Metric set for profiling AI Engine interface tiles latency between different graph ports");
     addParameter("AIE_profile_settings.start_type",
-                 xrt_core::config::get_aie_profile_settings_start_type(),
+                 replaceCommas(xrt_core::config::get_aie_profile_settings_start_type()),
                  "Type of delay to use in AI Engine Profiling");
     addParameter("AIE_profile_settings.start_iteration",
                  xrt_core::config::get_aie_profile_settings_start_iteration(),
@@ -118,10 +125,10 @@ namespace xdp {
 
     // AIE Trace
     addParameter("AIE_trace_settings.start_type",
-                 xrt_core::config::get_aie_trace_settings_start_type(),
+                 replaceCommas(xrt_core::config::get_aie_trace_settings_start_type()),
                  "Type of delay to use in AI Engine trace");
     addParameter("AIE_trace_settings.start_time",
-                 xrt_core::config::get_aie_trace_settings_start_time(),
+                 replaceCommas(xrt_core::config::get_aie_trace_settings_start_time()),
                  "Start delay for AI Engine trace");
     addParameter("AIE_trace_settings.start_iteration",
                  xrt_core::config::get_aie_trace_settings_start_iteration(),
@@ -133,25 +140,25 @@ namespace xdp {
                  xrt_core::config::get_aie_trace_settings_config_one_partition(),
                  "Flag for enabling trace for a specific partition");
     addParameter("AIE_trace_settings.graph_based_aie_tile_metrics",
-                 xrt_core::config::get_aie_trace_settings_graph_based_aie_tile_metrics(),
+                 replaceCommas(xrt_core::config::get_aie_trace_settings_graph_based_aie_tile_metrics()),
                  "Configuration level used for AI Engine trace per graph");
     addParameter("AIE_trace_settings.graph_based_memory_tile_metrics",
-                 xrt_core::config::get_aie_trace_settings_graph_based_memory_tile_metrics(),
+                 replaceCommas(xrt_core::config::get_aie_trace_settings_graph_based_memory_tile_metrics()),
                  "Configuration level used for memory tile trace per graph");
     addParameter("AIE_trace_settings.graph_based_interface_tile_metrics",
-                 xrt_core::config::get_aie_trace_settings_graph_based_interface_tile_metrics(),
+                 replaceCommas(xrt_core::config::get_aie_trace_settings_graph_based_interface_tile_metrics()),
                  "Configuration level used for interface tile trace per graph");
     addParameter("AIE_trace_settings.tile_based_aie_tile_metrics",
-                 xrt_core::config::get_aie_trace_settings_tile_based_aie_tile_metrics(),
+                 replaceCommas(xrt_core::config::get_aie_trace_settings_tile_based_aie_tile_metrics()),
                  "Configuration level used for AI Engine trace per tile");
     addParameter("AIE_trace_settings.tile_based_memory_tile_metrics",
-                 xrt_core::config::get_aie_trace_settings_tile_based_memory_tile_metrics(),
+                 replaceCommas(xrt_core::config::get_aie_trace_settings_tile_based_memory_tile_metrics()),
                  "Configuration level used for memory tile trace per tile");
     addParameter("AIE_trace_settings.tile_based_interface_tile_metrics",
-                 xrt_core::config::get_aie_trace_settings_tile_based_interface_tile_metrics(),
+                 replaceCommas(xrt_core::config::get_aie_trace_settings_tile_based_interface_tile_metrics()),
                  "Configuration level used for interface tile trace per tile");
     addParameter("AIE_trace_settings.buffer_size",
-                 xrt_core::config::get_aie_trace_settings_buffer_size(),
+                 replaceCommas(xrt_core::config::get_aie_trace_settings_buffer_size()),
                  "Size of buffer to allocate for AI Engine trace");
     addParameter("AIE_trace_settings.periodic_offload",
                  xrt_core::config::get_aie_trace_settings_periodic_offload(),

--- a/src/runtime_src/xdp/profile/writer/vp_base/ini_parameters.h
+++ b/src/runtime_src/xdp/profile/writer/vp_base/ini_parameters.h
@@ -22,6 +22,7 @@
 #include <string>
 #include <sstream>
 #include <fstream>
+#include <algorithm>
 
 namespace xdp {
 
@@ -42,6 +43,13 @@ namespace xdp {
     }
 
     void write(std::ofstream& fout);
+
+    // Helper function: replaces all commas with underscores
+    std::string replaceCommas(const std::string& input) {
+      std::string result = input;
+      std::replace(result.begin(), result.end(), ',', '_');
+      return result;
+    }
   } ;
 
 } // end namespace xdp


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
CR-1209896

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
When opening a profile or trace summary executed on hardware, some of the xrt.ini string values that contain commas were displayed incorrectly due to the way they were being parsed. This was because comma was being treated as a delimiter, causing the value to be split into multiple incorrect fragments. eg: tile_based_aie_memory_metrics={13,0}:{16,3}:conflicts was split into:
- {13
- 0}:{16
- 3}:conflicts
This caused it to be displayed incorrectly

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added a replaceCommas() function in the code that parses xrt.ini parameters to replace commas with underscores in the affected values, changing {13,0}:{16,3} to {13_0}:{16_3}.
User-facing xrt.ini files: Continue using the natural {13,0}:{16,3} syntax with commas
After parsing internally: Store as {13_0}:{16_3} to avoid delimiter conflicts

#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
Tested on VCK190

#### Documentation impact (if any)
N/A