### PR TITLE
hip: device: expose hipGetDevicePropertiesR0600 API

### DIFF
--- a/src/runtime_src/hip/api/hip_device.cpp
+++ b/src/runtime_src/hip/api/hip_device.cpp
@@ -256,8 +256,8 @@ hipGetDevicePropertiesR0600(hipDeviceProp_tR0600* props, int device)
 #else
 using hipDeviceProp_tR0600 = hipDeviceProp_t;
 
-hipError_t
-hipGetDevicePropertiesR0600(hipDeviceProp_tR0600* props, int device)
+extern "C" hipError_t
+hipGetDevicePropertiesR0600(hipDeviceProp_tR0600 *props, int device)
 {
   return hipErrorNotSupported;
 }


### PR DESCRIPTION
We will need to add extern "C" to expose hipGetDevicePropertiesR0600() API, By default ubuntu 24.04 AMD HIP bundle is of version 5.7. If we compiled the XRT HIP on a host with 5.7 HIP installed, and then runtime, the application runs with newer version of HIP, the compilation will fail with undefined `hipGetDevicePropertiesR0600` as it is not exposed to user from xrt_hip library if the library is compiled with HIP headers of a version less than 6.x.

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
