### PR TITLE
hip: device: return hipErrorNotSupported for invalid attr for hipDevice

### DIFF
--- a/src/runtime_src/hip/api/hip_device.cpp
+++ b/src/runtime_src/hip/api/hip_device.cpp
@@ -180,7 +180,7 @@ hip_device_get_attribute(int* pi, hipDeviceAttribute_t attr, int device)
       *pi = prop.pciDomainID;
       break;
     default:
-      throw std::runtime_error("unsupported attribute type");
+      throw_hip_error(hipErrorInvalidValue,"unsupported attribute type");
   }
 }
 


### PR DESCRIPTION
Return hipErrorNotSupported instread of std::runtime_error if user specify not supported attribute for hipDeviceGetAttribute().

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
