### PR TITLE
hip: event: correct event completion timestamping

### DIFF
--- a/src/runtime_src/hip/core/event.h
+++ b/src/runtime_src/hip/core/event.h
@@ -121,8 +121,7 @@ public:
 
 private:
   [[nodiscard]] bool is_recorded_no_lock() const;
-  void launch_chain_of_commands();
-  bool check_dependencies_update_state(bool wait_for_dependencies);
+  bool check_and_launch_chain(bool wait_for_dependencies);
 };
 
 class kernel_start : public command


### PR DESCRIPTION
Before, event always timestamp before it launches its chain of commands, which causes some issues:
* whenevery event synchronization is called, the event will timestamp even it has completed before.

This patch also make the following change:
* reorganizes the event sync() and submit() due to they almost the same except that submit() will not wait for dependencies to complete. Doing this change is because, the timestamp will be updated in these two functions
* event query() function checks state only instead of checking each depedencies as event completion will be check in sync() and submit().

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
