### PR TITLE
Fix for CR-1250185: Crash in Alveo hardware emulation

### DIFF
--- a/src/runtime_src/core/common/xdp/profile.cpp
+++ b/src/runtime_src/core/common/xdp/profile.cpp
@@ -54,13 +54,15 @@ namespace {
       }
     }
   }
-  
+
+#if !defined(XDP_CLIENT_BUILD) && !defined (XDP_VE2_BUILD)
   static bool is_hw_emulation()
   {
     static auto xem = std::getenv("XCL_EMULATION_MODE");
     static bool hwem = xem ? (std::strcmp(xem, "hw_emu") == 0) : false;
     return hwem;
   }
+#endif
   
 } // end anonymous namespace
 
@@ -676,7 +678,7 @@ update_device(void* handle, bool hw_context_flow)
            handle,
            hw_context_flow);
 
-  if (!::is_hw_emulation()) {
+  if (!is_hw_emulation()) {
     load_once_and_update(
              []() {
               return ((xrt_core::config::get_device_trace() != "off") ||
@@ -689,7 +691,6 @@ update_device(void* handle, bool hw_context_flow)
              handle,
              hw_context_flow);
   }
-
 
   // Avoid warning until we've added support in all plugins
   (void)(hw_context_flow);


### PR DESCRIPTION
#### Problem solved by the commit
PL profiling has two different device offload plugins that get loaded dynamically, one for hardware and one for hardware emulation.  Each of these pulls in the corresponding shim and are not meant to both be loaded simultaneously.

On Alveo hardware emulation, our hooks we added in the hw_context implementation constructors are getting hit and loading the hardware PL device offload plugin.  Per spec, we do not support hw_context with hardware emulation yet so this hook should not have been hit in this case.

For host code that still uses the load_xclbin flow, we correctly load the hardware emulation device offload plugin, but then the hw_context hook is hit and we erroneously load the hardware plugin as well causing the crash.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
This pull request restricts the loading of the PL device offload plugin via hw_context hook to hardware flows only which prevents the crash.  This was discovered through Alveo hardware emulation regression testing.

#### How problem was solved, alternative solutions (if any) and why they were rejected
A check is now added to make sure we do not load the hardware plugin when running in hardware emulation.

#### Risks (if any) associated the changes in the commit
Low risk as this only disables the loading of a hardware plugin when running hardware emulation.

#### What has been tested and how, request additional testing if necessary
The original failing Alveo test case has been verified.

#### Documentation impact (if any)
No documentation impact.