### PR TITLE
fix for CR-1254182 destroying the aied before destroying hwctx

### DIFF
--- a/src/runtime_src/core/edge/user/hwctx_object.cpp
+++ b/src/runtime_src/core/edge/user/hwctx_object.cpp
@@ -43,6 +43,10 @@ hwctx_object::get_aied() const
 hwctx_object::
 ~hwctx_object()
 {
+#ifdef XRT_ENABLE_AIE
+  // explicitly destroy the aied before destroying the hw context
+  m_aied.reset();
+#endif
   try {
     m_shim->destroy_hw_context(m_slot_idx);
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1254182
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
The bug was hw context used to destroy earlier than the aied and it causes crash.
#### How problem was solved, alternative solutions (if any) and why they were rejected
Problem was solved by destroying the aied before hw context which guarantees to stop the thread running. it avoids thread to access illegal memory or any dangling pointers.
#### Risks (if any) associated the changes in the commit
n/a
#### What has been tested and how, request additional testing if necessary
Tested the given testcase in the mentioned CR.
#### Documentation impact (if any)
n/a