### PR TITLE
Fix bug to remove circular dependency

### DIFF
--- a/src/runtime_src/core/common/api/bo_int.h
+++ b/src/runtime_src/core/common/api/bo_int.h
@@ -24,18 +24,19 @@ get_offset(const xrt::bo& bo);
 // enum for different buffer use flags
 // This is for internal use only
 enum class use_type {
-  debug       = XRT_BO_USE_DEBUG,       // debug data
-  kmd         = XRT_BO_USE_KMD,         // shared with kernel mode driver
-  dtrace      = XRT_BO_USE_DTRACE,      // dynamic trace data
-  log         = XRT_BO_USE_LOG,         // logging info
-  debug_queue = XRT_BO_USE_DEBUG_QUEUE, // debug queue data
-  uc_debug    = XRT_BO_USE_UC_DEBUG,    // microblaze debug data
-  host_only   = XRT_BO_USE_HOST_ONLY,   // system memory buffer
-  instruction = XRT_BO_USE_INSTRUCTION, // instruction (instructon buffer)
-  preemption  = XRT_BO_USE_PREEMPTION,  // preemption data
-  scratch_pad = XRT_BO_USE_SCRATCH_PAD, // scratch pad data
-  pdi         = XRT_BO_USE_PDI,         // PDI data
-  ctrlpkt     = XRT_BO_USE_CTRLPKT      // control packet
+  debug            = XRT_BO_USE_DEBUG,            // debug data
+  kmd              = XRT_BO_USE_KMD,              // shared with kernel mode driver
+  dtrace           = XRT_BO_USE_DTRACE,           // dynamic trace data
+  log              = XRT_BO_USE_LOG,              // logging info
+  debug_queue      = XRT_BO_USE_DEBUG_QUEUE,      // debug queue data
+  uc_debug         = XRT_BO_USE_UC_DEBUG,         // microblaze debug data
+  host_only        = XRT_BO_USE_HOST_ONLY,        // system memory buffer
+  instruction      = XRT_BO_USE_INSTRUCTION,      // instruction (instructon buffer)
+  preemption       = XRT_BO_USE_PREEMPTION,       // preemption data
+  scratch_pad      = XRT_BO_USE_SCRATCH_PAD,      // scratch pad data
+  ctrl_scratch_pad = XRT_BO_USE_CTRL_SCRATCH_PAD, // ctrl scratchpad data
+  pdi              = XRT_BO_USE_PDI,              // PDI data
+  ctrlpkt          = XRT_BO_USE_CTRLPKT           // control packet
 };
 
 // create_bo() - Create a buffer object within a device for specific use case

--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -1711,7 +1711,7 @@ compose_internal_bo_flags(use_type type)
   case use_type::instruction:
   case use_type::preemption:
   case use_type::pdi:
-  case use_type::scratch_pad:
+  case use_type::ctrl_scratch_pad:
     // client use case, create buffer in sram
     flags.flags = XRT_BO_FLAGS_CACHEABLE;
     break;
@@ -1720,6 +1720,7 @@ compose_internal_bo_flags(use_type type)
   case use_type::host_only:
   case use_type::uc_debug:
   case use_type::log:
+  case use_type::scratch_pad:
     flags.flags = XRT_BO_FLAGS_HOST_ONLY;
     break;
   default:

--- a/src/runtime_src/core/common/api/xrt_hw_context.cpp
+++ b/src/runtime_src/core/common/api/xrt_hw_context.cpp
@@ -77,8 +77,8 @@ class hw_context_impl : public std::enable_shared_from_this<hw_context_impl>
                            size_t size_per_uc,
                            size_t num_uc)
     {
-      auto bo = xrt_core::bo_int::
-        create_bo(device, (size_per_uc * num_uc), xrt_core::bo_int::use_type::log);
+      auto bo = xrt_core::bo_int::create_bo(
+          device, (size_per_uc * num_uc), xrt_core::bo_int::use_type::log);
 
       // Log buffers first 8 bytes are used for metadata
       // So make sure for each uC metadata bytes are initialized with
@@ -465,8 +465,9 @@ public:
     std::call_once(m_scratchpad_init_flag, [this, size_per_col] () {
       try {
         // create scratchpad memory buffer using this context
-        m_scratchpad_buf = xrt::ext::bo{xrt::hw_context(get_shared_ptr()),
-                                        size_per_col * m_partition_size};
+        auto buf_size = size_per_col * m_partition_size;
+        m_scratchpad_buf = xrt_core::bo_int::create_bo(
+            m_core_device, buf_size, xrt_core::bo_int::use_type::scratch_pad);
       }
       catch (...) { /*do nothing*/ }
     });

--- a/src/runtime_src/core/include/xrt/detail/xrt_mem.h
+++ b/src/runtime_src/core/include/xrt/detail/xrt_mem.h
@@ -148,7 +148,10 @@ struct xcl_bo_flags
  * hold instructions for firmware.
  *
  * XRT_BO_USE_SCRATCH_PAD indicates that the buffer will be used as
- * scratch pad memory for firmware.
+ * scratch pad memory to store L2 memory at time of preemption.
+ * 
+ * XRT_BO_USE_CTRL_SCRATCH_PAD indicates that the buffer will be used
+ * to store/retrieve control state information during model execution.
  *
  * XRT_BO_USE_PDI indicates that the buffer will be used to hold
  * PDI data for firmware.
@@ -161,19 +164,20 @@ struct xcl_bo_flags
 // constexpr and using NOLINT block to supress clng-tidy warnings
 
 // NOLINTBEGIN
-#define XRT_BO_USE_UNUSED      0
-#define XRT_BO_USE_DEBUG       1
-#define XRT_BO_USE_KMD         2
-#define XRT_BO_USE_DTRACE      3
-#define XRT_BO_USE_LOG         4
-#define XRT_BO_USE_DEBUG_QUEUE 5
-#define XRT_BO_USE_UC_DEBUG    6
-#define XRT_BO_USE_PREEMPTION  7
-#define XRT_BO_USE_HOST_ONLY   8
-#define XRT_BO_USE_INSTRUCTION 9
-#define XRT_BO_USE_SCRATCH_PAD 10
-#define XRT_BO_USE_PDI         11
-#define XRT_BO_USE_CTRLPKT     12
+#define XRT_BO_USE_UNUSED           0
+#define XRT_BO_USE_DEBUG            1
+#define XRT_BO_USE_KMD              2
+#define XRT_BO_USE_DTRACE           3
+#define XRT_BO_USE_LOG              4
+#define XRT_BO_USE_DEBUG_QUEUE      5
+#define XRT_BO_USE_UC_DEBUG         6
+#define XRT_BO_USE_PREEMPTION       7
+#define XRT_BO_USE_HOST_ONLY        8
+#define XRT_BO_USE_INSTRUCTION      9
+#define XRT_BO_USE_SCRATCH_PAD      10
+#define XRT_BO_USE_CTRL_SCRATCH_PAD 11
+#define XRT_BO_USE_PDI              12
+#define XRT_BO_USE_CTRLPKT          13
 // NOLINTEND
 
 /**


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Removed circular dependency b/w xrt::hw_context and xrt::bo (scratchpad mem buf).
Also made changes to use common API (xrt_core::bo_int::create_bo) for internal bo creations

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Scratchpad buffer is needed one per hw ctx, so moved scratchpad xrt::bo to xrt::hw_context level which added circular dependency as bo stores hw ctx that is used to create it

#### How problem was solved, alternative solutions (if any) and why they were rejected
scratchpad buffer is now created with device which removes circular dependency and as this bo is member of ctx its lifetime is tied to ctx.

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
Tested with testcase that has L2 preemption (test that use scratchpad memory) and the test works as expected. Hw ctx also destroyed properly

#### Documentation impact (if any)
NA