### PR TITLE
fix for CR-1254182 destroying the aied threads before destroyin hwctx…

### DIFF
--- a/src/runtime_src/core/edge/user/hwctx_object.cpp
+++ b/src/runtime_src/core/edge/user/hwctx_object.cpp
@@ -43,6 +43,10 @@ hwctx_object::get_aied() const
 hwctx_object::
 ~hwctx_object()
 {
+#ifdef XRT_ENABLE_AIE
+  // explicitly destroy the aied before destroying the hw context
+  m_aied.reset();
+#endif
   try {
     m_shim->destroy_hw_context(m_slot_idx);
   }


### PR DESCRIPTION
… (#9372)

(cherry picked from commit d7e8b9226acbd071e2e9adbad7dc204c6fdb5b7b)

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
