### PR TITLE
[XRT-SMi] AIESW-16302 Update context health report to use v1 struct

### DIFF
--- a/src/runtime_src/core/tools/common/reports/ReportContextHealth.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportContextHealth.cpp
@@ -55,12 +55,12 @@ getPropertyTree20202(const xrt_core::device* dev, bpt& pt) const
       for (const auto& context : contexts) {
         bpt context_pt;
         context_pt.put("ctx_id"                     ,context.ctx_id);
-        context_pt.put("txn_op_idx"                 ,context.health_data.txn_op_idx);
-        context_pt.put("ctx_pc"                     ,context.health_data.ctx_pc);
-        context_pt.put("fatal_error_type"           ,context.health_data.fatal_error_type);
-        context_pt.put("fatal_error_exception_type" ,context.health_data.fatal_error_exception_type);
-        context_pt.put("fatal_error_exception_pc"   ,context.health_data.fatal_error_exception_pc);
-        context_pt.put("fatal_error_app_module"     ,context.health_data.fatal_error_app_module);
+        context_pt.put("txn_op_idx"                 ,context.health_data_v1.aie2.txn_op_idx);
+        context_pt.put("ctx_pc"                     ,context.health_data_v1.aie2.ctx_pc);
+        context_pt.put("fatal_error_type"           ,context.health_data_v1.aie2.fatal_error_type);
+        context_pt.put("fatal_error_exception_type" ,context.health_data_v1.aie2.fatal_error_exception_type);
+        context_pt.put("fatal_error_exception_pc"   ,context.health_data_v1.aie2.fatal_error_exception_pc);
+        context_pt.put("fatal_error_app_module"     ,context.health_data_v1.aie2.fatal_error_app_module);
         contexts_array.push_back(std::make_pair("", context_pt));
       }
       pid_pt.add_child("contexts", contexts_array);
@@ -207,12 +207,12 @@ generate_context_health_report(const xrt_core::device* dev,
       for (const auto& context : contexts) {
         const std::vector<std::string> entry_data = {
           (boost::format("%d")   % context.ctx_id).str(),
-          (boost::format("0x%x") % context.health_data.txn_op_idx).str(),
-          (boost::format("0x%x") % context.health_data.ctx_pc).str(),
-          (boost::format("0x%x") % context.health_data.fatal_error_type).str(),
-          (boost::format("0x%x") % context.health_data.fatal_error_exception_type).str(),
-          (boost::format("0x%x") % context.health_data.fatal_error_exception_pc).str(),
-          (boost::format("0x%x") % context.health_data.fatal_error_app_module).str()
+          (boost::format("0x%x") % context.health_data_v1.aie2.txn_op_idx).str(),
+          (boost::format("0x%x") % context.health_data_v1.aie2.ctx_pc).str(),
+          (boost::format("0x%x") % context.health_data_v1.aie2.fatal_error_type).str(),
+          (boost::format("0x%x") % context.health_data_v1.aie2.fatal_error_exception_type).str(),
+          (boost::format("0x%x") % context.health_data_v1.aie2.fatal_error_exception_pc).str(),
+          (boost::format("0x%x") % context.health_data_v1.aie2.fatal_error_app_module).str()
         };
         context_table.addEntry(entry_data);
       }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Updates the xrt-smi context health report to use v1 struct. The v1 struct is a superset of v0 which contains details for both aie2 and aie4 platform. This PR uses the aie2 part to print the correct context health info on strix.
This will be followed by a new PR which should detect the hardware type and generate the correct report based on hardware type. 

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://jira.xilinx.com/browse/AIESW-16302

#### How problem was solved, alternative solutions (if any) and why they were rejected
Solved by updating the context health report to use v1 struct

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Tested on linux platform 
```
(Press Ctrl+C to exit watch mode | Last update: Mon Oct 27 18:18:50 2025 GMT)
  Context Health Information (PID: 1102637):
    |Ctx Id  |Txn Op Idx  |Ctx PC      |Fatal Err Type  |Fatal Err Ex Type  |Fatal Err Ex PC  |Fatal App Module  |
    |--------|------------|------------|----------------|-------------------|-----------------|------------------|
    |9       |0xffffffff  |0x28b04659  |0x0             |0x0                |0x0              |0x0               |


(Press Ctrl+C to exit watch mode | Last update: Mon Oct 27 18:18:50 2025 GMT)
  Context Health Information (PID: 0):
    |Ctx Id  |Txn Op Idx  |Ctx PC  |Fatal Err Type  |Fatal Err Ex Type  |Fatal Err Ex PC  |Fatal App Module  |
    |--------|------------|--------|----------------|-------------------|-----------------|------------------|
    |0       |0x0         |0x0     |0x0             |0x0                |0x0              |0x0               |

```

#### Documentation impact (if any)
None
