### PR TITLE
[XDP] Fix input ports names for trace runtime config

### DIFF
--- a/build/petalinux.build
+++ b/build/petalinux.build
@@ -1,4 +1,3 @@
 # When updating Petalinux build please file a SH ticket to retain the build
 # https://jira.xilinx.com/secure/CreateIssue!default.jspa
-#PETALINUX=/proj/petalinux/2025.2/petalinux-v2025.2_08291050/tool/petalinux-v2025.2-final
-PETALINUX=/proj/petalinux/2025.2/petalinux-v2025.2_10211539/tool/petalinux-v2025.2-final
+PETALINUX=/proj/petalinux/2025.2/petalinux-v2025.2_08291050/tool/petalinux-v2025.2-final

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/client/aie_trace.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/client/aie_trace.cpp
@@ -494,13 +494,8 @@ namespace xdp {
           // Record for runtime config file
           config.port_trace_ids[portnum] = channelNum;
           config.port_trace_is_master[portnum] = (tile.is_master_vec.at(portnum) != 0);
-          if (streamPortId < tile.port_names.size()) {
+          if (streamPortId < tile.port_names.size())
             config.port_trace_names[portnum] = tile.port_names.at(streamPortId);
-            std::string msg = "Interface tile port assignment: portnum=" + std::to_string(portnum) + 
-                            ", streamId=" + std::to_string(streamPortId) + 
-                            ", name=" + tile.port_names.at(streamPortId);
-            xrt_core::message::send(severity_level::debug, "XRT", msg);
-          }
           
           if (tile.is_master_vec.at(portnum) == 0) {
             config.mm2s_channels[channelNum] = channel; // Slave or Input Port

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/util/aie_trace_config.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/util/aie_trace_config.cpp
@@ -148,13 +148,8 @@ namespace xdp::aie::trace {
           // Record for runtime config file
           config.port_trace_ids[portnum] = (tile.subtype == io_type::PLIO) ? portnum : channel;
           config.port_trace_is_master[portnum] = (tile.is_master_vec.at(portnum) != 0);
-          if (streamPortId < tile.port_names.size()) {
+          if (streamPortId < tile.port_names.size())
             config.port_trace_names[portnum] = tile.port_names.at(streamPortId);
-            std::string msg = "!!! Interface tile port assignment: portnum=" + std::to_string(portnum) + 
-                            ", streamId=" + std::to_string(streamPortId) + 
-                            ", name=" + tile.port_names.at(streamPortId);
-            xrt_core::message::send(severity_level::debug, "XRT", msg);
-          }
 
           if (tile.is_master_vec.at(portnum) == 0)
             config.mm2s_channels[channelNum] = channel;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
AIESW-16493 - Input ports names were not getting populated correctly and always marked `unused`.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Port names feature enhancements.

#### How problem was solved, alternative solutions (if any) and why they were rejected
- This is a common issue for all platforms and is because of port number is used to index the names instead of stream IDs.
- Also added bound checks for memory tiles buffer names.

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
Verified on AIE1 and AIE2 designs.

#### Documentation impact (if any)
