### PR TITLE
Name change of the structure "struct uc_health_info" to fix windows compilation errors

### DIFF
--- a/src/runtime_src/core/include/xrt/detail/ert.h
+++ b/src/runtime_src/core/include/xrt/detail/ert.h
@@ -657,7 +657,7 @@ struct ert_ctx_health_data_aie2 {
 };
 
 /**
- * struct uc_health_info: Health data for each cert
+ * struct ert_uc_health_info: Health data for each cert
  *
  * @uc_idx:            uC index in this context, 0 is the lead
  * @uc_idle_status:    valid when CERT is CTX_IDEL, represent the reason CERT is idle
@@ -677,7 +677,7 @@ struct ert_ctx_health_data_aie2 {
  * @uc_esr:            in case of uC crash, the exception status of uC
  * @uc_pc:             in case of uC crash, the PC of the current uC
  */
-struct uc_health_info {
+struct ert_uc_health_info {
   uint32_t uc_idx;
   uint32_t uc_idle_status;
   uint32_t misc_status;
@@ -706,7 +706,7 @@ struct uc_health_info {
 struct ert_ctx_health_data_aie4 {
   uint32_t ctx_state;
   uint32_t num_uc;
-  struct uc_health_info uc_info[];
+  struct ert_uc_health_info uc_info[];
 };
 
 /**


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
struct uc_health_info is defined in both ert.h and firmware headers.
"struct uc_health_info" is causing conflicts since a lot of files in mcdm driver code include both firmware and XRT core headers
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Added ert_ prefix to the struct name in ert.h
#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
