### PR TITLE
Rename xilinx.icd to amdxrt.icd for XRT upstream builds

### DIFF
--- a/src/CMake/icd.cmake
+++ b/src/CMake/icd.cmake
@@ -1,12 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2019-2021 Xilinx, Inc. All rights reserved.
 # Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
-SET (ICD_FILE_NAME "xilinx.icd")
+if (XRT_UPSTREAM)
+  set(ICD_FILE_NAME "amdxrt.icd")
+else()
+  set(ICD_FILE_NAME "xilinx.icd")
+endif()
 
 message("-- Preparing OpenCL ICD ${ICD_FILE_NAME}")
 
 configure_file (
-  "${XRT_SOURCE_DIR}/CMake/config/${ICD_FILE_NAME}.in"
+  "${XRT_SOURCE_DIR}/CMake/config/xilinx.icd.in"
   ${ICD_FILE_NAME}
   )
 


### PR DESCRIPTION
#### Problem solved by the commit
Avoid package conflict when installing internal XRT packages (/opt/xilinx) with upstream packages (/usr).

#### How problem was solved, alternative solutions (if any) and why they were rejected
The OpenCL ICD loader `/etc/OpenCL/vendors/xilinx.icd` is installed by internally built xrt-base package, which otherwise installs content to `/opt/xilinx/xrt`.   For upstream packages, the ICD loader must be named differently in order to co-exist with internal installs.
