### PR TITLE
AIESW-16751 XRT umd and user mode library to support windows versioning

### DIFF
--- a/build/build-win22.sh
+++ b/build/build-win22.sh
@@ -175,7 +175,7 @@ if [ $dbg == 1 ]; then
         echo "${cmake_flags[@]}"
         "$CMAKE" -G "Visual Studio 17 2022" -B $BUILDDIR_DOS/WDebug $cmake_flags $BUILDDIR_DOS/../src
     fi
-    "$CMAKE" --build $BUILDDIR_DOS/WDebug --verbose --config Debug
+    "$CMAKE" --build $BUILDDIR_DOS/WDebug --verbose --config Debug --parallel $jcore
     "$CMAKE" --install $BUILDDIR_DOS/WDebug --config Debug --prefix $BUILDDIR_DOS/WDebug/xilinx/xrt
 fi
 
@@ -190,7 +190,7 @@ if [ $release == 1 ]; then
         echo "${cmake_flags[@]}"
         "$CMAKE" -G "Visual Studio 17 2022" -B $BUILDDIR_DOS/WRelease $cmake_flags $BUILDDIR_DOS/../src
     fi
-    "$CMAKE" --build $BUILDDIR_DOS/WRelease --verbose --config Release
+    "$CMAKE" --build $BUILDDIR_DOS/WRelease --verbose --config Release --parallel $jcore
     "$CMAKE" --install $BUILDDIR_DOS/WRelease --verbose --config Release --prefix $BUILDDIR_DOS/WRelease/xilinx/xrt
 
     if [[ $sdk == 1 && $npu_build == 1 ]]; then

--- a/src/CMake/config/version.rc.in
+++ b/src/CMake/config/version.rc.in
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+// version.rc.in - Windows VERSIONINFO resource template for CMake
+#include <winver.h>
+
+VS_VERSION_INFO VERSIONINFO
+ FILEVERSION @XRT_VERSION_MAJOR@,@XRT_VERSION_MINOR@,@XRT_VERSION_PATCH@,0
+ PRODUCTVERSION @XRT_VERSION_MAJOR@,@XRT_VERSION_MINOR@,@XRT_VERSION_PATCH@,0
+ FILEFLAGSMASK 0x3fL
+#ifdef _DEBUG
+ FILEFLAGS 0x1L
+#else
+ FILEFLAGS 0x0L
+#endif
+ FILEOS 0x4L
+ FILETYPE @XRT_RC_FILETYPE@
+ FILESUBTYPE 0x0L
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904b0"
+        BEGIN
+            VALUE "CompanyName", "AMD"
+            VALUE "FileDescription", "XRT User Mode Binary"
+            VALUE "FileVersion", "@XRT_VERSION_MAJOR@,@XRT_VERSION_MINOR@,@XRT_VERSION_PATCH@,0"
+            VALUE "InternalName", "XRT"
+            VALUE "LegalCopyright", "Copyright (C) 2025"
+            VALUE "OriginalFilename", "XRT"
+            VALUE "ProductName", "AMD PRODUCT"
+            VALUE "ProductVersion", "@XRT_VERSION_MAJOR@,@XRT_VERSION_MINOR@,@XRT_VERSION_PATCH@,0"
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x0409, 1200
+    END
+END

--- a/src/CMake/version.cmake
+++ b/src/CMake/version.cmake
@@ -98,6 +98,26 @@ configure_file(
   ${PROJECT_BINARY_DIR}/gen/version.json
 )
 
+set(XRT_RESOURCE_SHARED "")
+set(XRT_RESOURCE_EXEC "")
+if (WIN32)
+  set(XRT_RC_FILETYPE VFT_DLL)
+  configure_file(
+    ${XRT_SOURCE_DIR}/CMake/config/version.rc.in
+    ${PROJECT_BINARY_DIR}/gen/xrt/detail/version-dll.rc
+    @ONLY
+  )
+  set(XRT_RESOURCE_SHARED ${PROJECT_BINARY_DIR}/gen/xrt/detail/version-dll.rc)
+  
+  set(XRT_RC_FILETYPE VFT_APP)
+  configure_file(
+    ${XRT_SOURCE_DIR}/CMake/config/version.rc.in
+    ${PROJECT_BINARY_DIR}/gen/xrt/detail/version-app.rc
+    @ONLY
+  )
+  set(XRT_RESOURCE_EXEC ${PROJECT_BINARY_DIR}/gen/xrt/detail/version-app.rc)
+endif(WIN32)
+
 # xrt component install
 install(FILES
   ${PROJECT_BINARY_DIR}/gen/xrt/detail/version.h

--- a/src/runtime_src/core/common/CMakeLists.txt
+++ b/src/runtime_src/core/common/CMakeLists.txt
@@ -85,6 +85,7 @@ target_include_directories(core_common_objects
   )
 
 add_library(xrt_coreutil SHARED
+  ${XRT_RESOURCE_SHARED}
   $<TARGET_OBJECTS:core_common_library_objects>
   $<TARGET_OBJECTS:core_common_runner_objects>
   $<TARGET_OBJECTS:core_common_api_library_objects>

--- a/src/runtime_src/core/common/runner/CMakeLists.txt
+++ b/src/runtime_src/core/common/runner/CMakeLists.txt
@@ -10,7 +10,7 @@ target_include_directories(core_common_runner_objects
   ${XRT_SOURCE_DIR}/runtime_src
   )
 
-add_executable(xrt-runner main.cpp)
+add_executable(xrt-runner ${XRT_RESOURCE_EXEC} main.cpp)
 target_link_libraries(xrt-runner PRIVATE xrt_coreutil)
 
 if (NOT WIN32)

--- a/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
@@ -70,7 +70,7 @@ else()
   set(XRT_HELPER_SCRIPTS "xrt-smi")
 endif()
 
-add_executable(${XBUTIL2_NAME} ${XBUTIL_V2_SRCS})
+add_executable(${XBUTIL2_NAME} ${XRT_RESOURCE_EXEC} ${XBUTIL_V2_SRCS})
 
 # Determine what functionality should be added
 if (NOT XRT_EDGE OR DEFINED XDNA_VE2)
@@ -81,7 +81,7 @@ endif()
 
 # Static build is a Linux / Ubuntu option only
 if (XRT_STATIC_BUILD)
-  add_executable(${XBUTIL2_NAME}_static ${XBUTIL_V2_SRCS})
+  add_executable(${XBUTIL2_NAME}_static ${XRT_RESOURCE_EXEC} ${XBUTIL_V2_SRCS})
   target_compile_definitions(${XBUTIL2_NAME}_static PRIVATE ENABLE_NATIVE_SUBCMDS_AND_REPORTS)
   target_link_options(${XBUTIL2_NAME}_static PRIVATE "-static" "-L${Boost_LIBRARY_DIRS}")
   # Bypass FindBoost versions and just link explicitly with boost libraries

--- a/src/runtime_src/tools/xclbinutil/CMakeLists.txt
+++ b/src/runtime_src/tools/xclbinutil/CMakeLists.txt
@@ -101,7 +101,7 @@ file(GLOB XCLBINUTIL_MAIN_FILE
 )
 set(XCLBINUTIL_SRCS ${XCLBINUTIL_MAIN_FILE} ${XCLBINUTIL_FILES_SRCS})
 
-add_executable(${XCLBINUTIL_NAME} ${XCLBINUTIL_SRCS})
+add_executable(${XCLBINUTIL_NAME} ${XRT_RESOURCE_EXEC} ${XCLBINUTIL_SRCS})
 
 # Signing xclbin images currently is not support on windows
 if(NOT WIN32)

--- a/src/runtime_src/xocl/CMakeLists.txt
+++ b/src/runtime_src/xocl/CMakeLists.txt
@@ -48,6 +48,7 @@ include_directories(
   )
 
 add_library(xilinxopencl SHARED
+  ${XRT_RESOURCE_SHARED}
   $<TARGET_OBJECTS:xocl>
   ${XRT_XOCL_API_DIR}/icd/windows/xilinxopencl.def
   )

--- a/src/runtime_src/xrt/CMakeLists.txt
+++ b/src/runtime_src/xrt/CMakeLists.txt
@@ -44,6 +44,7 @@ set_source_files_properties(${XRT_XRT_DEVICE_DIR}/hal.cpp PROPERTIES
 endif()
 
 add_library(xrt++ SHARED
+  ${XRT_RESOURCE_SHARED}
   ${XRT_XRT_ALL_SRC_SHARED}
   )
 


### PR DESCRIPTION
#### Problem solved by the commit
Add versioninfo resource to DLLs and APPs in XRT.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Configure a `version-dll.rc` and `version-app.rc` at CMake configure time. The config file is copied from ticket where it is pre-confgured with required fields.

The generated file is include in CMake targets.  For now only a small subset of targets (those that are distributed) include the versioninfo.

Subject to change.

<img width="394" height="498" alt="image" src="https://github.com/user-attachments/assets/a3daf13f-e41e-49f1-b492-3a14da8bd6f2" />




