### PR TITLE
Fix for CR-1254841 (2025.2 branch)

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -261,7 +261,7 @@ void AieTracePluginUnified::updateAIEDevice(void *handle, bool hw_context_flow) 
   uint64_t aieTraceBufSize = GetTS2MMBufSize(true /*isAIETrace*/);
   // uint64_t aieTraceBufSizePLIO = aieTraceBufSize;
   // uint64_t aieTraceBufSizeGMIO = aieTraceBufSize;
-  if (isPLIO) {
+  if (isPLIO && !configuredOnePlioPartition) {
 
     XAie_DevInst* devInst = static_cast<XAie_DevInst*>(AIEData.implementation->setAieDeviceInst(handle, deviceID));
     if(!devInst) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
CR-1254841

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
PLIO trace files are incorrectly mapped in hw_context designs containing multiple independent partitions with different trace configurations (PLIO in first partition, GMIO in second partition)

#### How problem was solved, alternative solutions (if any) and why they were rejected
Prevent configuration of any upcoming PLIO partitions after the first PLIO partition is configured. This ensures trace file mappings remain consistent across partitions

#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
Tested on VCK190

#### Documentation impact (if any)
N/A