### PR TITLE
Added mapping bw xclbin mem configuration and cma mem regions

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_util.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_util.h
@@ -164,6 +164,8 @@ struct zocl_cu_subdev {
 struct zocl_mem_region {
 	struct device 		*dev;
 	bool 			initialized;
+	phys_addr_t		base;        /* Cached CMA base address */
+	resource_size_t		size;        /* Cached CMA size */
 };
 
 struct drm_zocl_dev {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Mapping of cma regions with the xclbin's memory configuration.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Its not a bug but a new feature. now if there is multiple cma regions the host can allocate bo in a particular cma memory region.
#### How problem was solved, alternative solutions (if any) and why they were rejected
it was solved by mapping cma regions into xclbin's memory configuration at the time of loading the xclbin. Earlier if the index of cma mem region and xclbin's mem region are not same then it used to allocate BO from the default CMA even though the memroy is same. This mapping pr solves this problem.
#### Risks (if any) associated the changes in the commit
n/a
#### What has been tested and how, request additional testing if necessary
Tested by targetting different different cma mem regions. Assume xclbin is loaded:
Default usecase:
1. no tagging of cma mem regions into the zocl node in the DTB. -> it will allocate from the default CMA region. Backward compatible

New usecase, multiple cma regions are tagged into zocl node:
3. host can allocate a bo into particular CMA regions. it can target a memory based on xclbin's memory configuration. If its no map then bo will be allocated as usual.
4. host passes invalid mem index. by default bo will be allocated in default cma region

Note no changes in the range allocator. So, BOs will be allocated as usual. Only changes are into the CMA allocation. 

Find few scenarios of mappings:
- Mapping1: CMA contained within xclbin mem region
xclbin: 0x800000000, 2GB → range [0x800000000, 0x880000000]
CMA: 0x840000000, 512MB → range [0x840000000, 0x860000000]
Result: BO will be allocated on this cma region

- Mapping2: CMA outside xclbin mem range
xclbin: 0x50000000000, 1GB → range [0x50000000000, 0x50040000000]
CMA: 0x60000000000, 4GB → range [0x60000000000, 0x60100000000]
Result: Bo will be allocated from the default CMA

- Mapping3: CMA equals with xclbin mem range
xclbin: 0x50000000000, 1GB → range [0x50000000000, 0x50040000000]
CMA: 0x50000000000, 1GB → range [0x50000000000, 0x50040000000]
Result: BO will be allocated on this cma region.

- Mapping4: CMA is not within the xclbin mem region
xclbin: 0x50000000000, 1GB → range [0x50000000000, 0x50040000000]
CMA: 0x50000000000, 4GB → range [0x50000000000, 0x50100000000]
Result: Bo will be allocated from the default CMA

This mapping assumes a CMA region's base and size will be always within the memory region of that particular mem region of the xclbin

#### Documentation impact (if any)
n/a