### PR TITLE
Add timestamp to dtrace output file

### DIFF
--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -5,6 +5,7 @@
 #define XRT_CORE_COMMON_SOURCE // in same dll as core_common
 #include "core/common/config_reader.h"
 #include "core/common/message.h"
+#include "core/common/time.h"
 #include "xrt/experimental/xrt_module.h"
 #include "xrt/experimental/xrt_aie.h"
 #include "xrt/experimental/xrt_elf.h"
@@ -2827,7 +2828,11 @@ public:
     try {
       // dtrace output is dumped into current working directory
       // output is a python file
-      auto result_file_path = std::filesystem::current_path().string() + "/dtrace_dump_" + std::to_string(get_id()) + ".py";
+      std::string result_file_path = std::filesystem::current_path().string()
+                                   + "/dtrace_dump_"
+                                   + xrt_core::get_timestamp_for_filename()
+                                   + "_" + std::to_string(get_id()) + ".py";
+
       get_dtrace_result_file(result_file_path.c_str());
 
       xrt_core::message::send(xrt_core::message::severity_level::debug, "xrt_module",


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Added timestamp to dtrace dump o/p python file to not have file content overwritten.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
In command chain case probes are fired for each sub command and with current implementation result of only last command is saved. So adding timestamp in file name will create different files for different sub commands.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Adding timestamp to filename creates different dtrace files for each sub command

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
Tested build and it passes

#### Documentation impact (if any)
NA