### PR TITLE
Update linker options to meet binskim requirements

### DIFF
--- a/src/CMake/nativeWin.cmake
+++ b/src/CMake/nativeWin.cmake
@@ -50,6 +50,10 @@ if (MSVC)
     /DEFAULTLIB:ucrt$<$<CONFIG:Debug>:d>.lib       # Hybrid CRT
     /DEBUG      # instruct linker to create debugging info
     /guard:cf   # enable linker control guard feature (CFG) to prevent attackers from redirecting execution to unsafe locations
+    /LTCG       # perform whole-program optimization
+    /OPT:REF    # eliminates functions and data that are never referenced
+    /OPT:ICF    # enable COMDAT folding
+    /LTCG       # enable Link time code generation
     )
   if (NOT ${CMAKE_CXX_COMPILER} MATCHES "(arm64|ARM64)")
     add_link_options(


### PR DESCRIPTION
The following linkers options are required for binskim
  /LTCG       # perform whole-program optimization
  /OPT:REF    # eliminates functions and data that are never referenced
  /OPT:ICF    # enable COMDAT folding
  /LTCG       # enable Link time generation

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Binskim scan reported missing flags

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
binskim scan 

#### How problem was solved, alternative solutions (if any) and why they were rejected
Add the following linker options
  /LTCG       # perform whole-program optimization
  /OPT:REF    # eliminates functions and data that are never referenced
  /OPT:ICF    # enable COMDAT folding
  /LTCG       # enable Link time generation

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
run binskim on xrt dlls

#### Documentation impact (if any)
