### PR TITLE
[XDP] Update PLIO multipartition warning to be CRITICAL

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -227,7 +227,7 @@ void AieTracePluginUnified::updateAIEDevice(void *handle, bool hw_context_flow) 
   // This is applicable only for register xclbin flow.
   if ((db->getStaticInfo()).getAppStyle() == xdp::AppStyle::REGISTER_XCLBIN_STYLE &&
           isPLIO && !isGMIO && configuredOnePlioPartition) {
-    xrt_core::message::send(severity_level::warning, "XRT",
+    xrt_core::message::send(severity_level::critical, "XRT",
       "AIE Trace: PLIO offload is not supported on multiple partitions at once. "
       "A previous PLIO partition has already been configured. "
       "Skipping current PLIO partition.");


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
CR-1254183

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
In a PLIO multipartition design where both partitions are configured for PLIO trace, offloading trace for only the first partition is supported. Updated this warning message to be CRITICAL

#### How problem was solved, alternative solutions (if any) and why they were rejected
Change message severity level to critical

#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
VCK190

#### Documentation impact (if any)
N/A