### PR TITLE
[XRT-SMI] Changing info to error for case when archive is not found

### DIFF
--- a/src/runtime_src/core/tools/common/tests/TestAIEReconfigOverhead.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestAIEReconfigOverhead.cpp
@@ -27,7 +27,8 @@ TestAIEReconfigOverhead::run(const std::shared_ptr<xrt_core::device>& dev, const
 {
   boost::property_tree::ptree ptree = get_test_header();
   if (archive == nullptr) {
-    XBValidateUtils::logger(ptree, "Info", "No archive found, skipping test");
+    ptree.put("status", XBValidateUtils::test_token_failed);
+    XBValidateUtils::logger(ptree, "Error", "No archive found, skipping test");
     return ptree;
   }
 

--- a/src/runtime_src/core/tools/common/tests/TestCmdChainLatency.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestCmdChainLatency.cpp
@@ -32,7 +32,8 @@ TestCmdChainLatency::run(const std::shared_ptr<xrt_core::device>& dev, const xrt
   boost::property_tree::ptree ptree = get_test_header();
 
   if (archive == nullptr) {
-    XBValidateUtils::logger(ptree, "Info", "No archive found, skipping test");
+    ptree.put("status", XBValidateUtils::test_token_failed);
+    XBValidateUtils::logger(ptree, "Error", "No archive found, skipping test");
     return ptree;
   }
   

--- a/src/runtime_src/core/tools/common/tests/TestCmdChainThroughput.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestCmdChainThroughput.cpp
@@ -30,7 +30,8 @@ TestCmdChainThroughput::run(const std::shared_ptr<xrt_core::device>& dev, const 
   boost::property_tree::ptree ptree = get_test_header();
 
   if (archive == nullptr) {
-    XBValidateUtils::logger(ptree, "Info", "No archive found, skipping test");
+    ptree.put("status", XBValidateUtils::test_token_failed);
+    XBValidateUtils::logger(ptree, "Error", "No archive found, skipping test");
     return ptree;
   }
 

--- a/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestDF_bandwidth.cpp
@@ -33,7 +33,8 @@ TestDF_bandwidth::run(const std::shared_ptr<xrt_core::device>& dev, const xrt_co
   boost::property_tree::ptree ptree = get_test_header();
 
   if (archive == nullptr) {
-    XBValidateUtils::logger(ptree, "Info", "No archive found, skipping test");
+    ptree.put("status", XBValidateUtils::test_token_failed);
+    XBValidateUtils::logger(ptree, "Error", "No archive found, skipping test");
     return ptree;
   }
   

--- a/src/runtime_src/core/tools/common/tests/TestGemm.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestGemm.cpp
@@ -36,7 +36,8 @@ TestGemm::run(const std::shared_ptr<xrt_core::device>& dev, const xrt_core::arch
   boost::property_tree::ptree ptree = get_test_header();
   
   if (archive == nullptr) {
-    XBValidateUtils::logger(ptree, "Info", "No archive provided, skipping test");
+    ptree.put("status", XBValidateUtils::test_token_failed);
+    XBValidateUtils::logger(ptree, "Error", "No archive provided, skipping test");
     return ptree;
   }
   

--- a/src/runtime_src/core/tools/common/tests/TestNPULatency.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestNPULatency.cpp
@@ -34,7 +34,8 @@ TestNPULatency::run(const std::shared_ptr<xrt_core::device>& dev, const xrt_core
   boost::property_tree::ptree ptree = get_test_header();
   
   if (archive == nullptr) {
-    XBValidateUtils::logger(ptree, "Info", "No archive found, skipping test");
+    ptree.put("status", XBValidateUtils::test_token_failed);
+    XBValidateUtils::logger(ptree, "Error", "No archive found, skipping test");
     return ptree;
   }
   

--- a/src/runtime_src/core/tools/common/tests/TestNPUThroughput.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestNPUThroughput.cpp
@@ -33,7 +33,8 @@ TestNPUThroughput::run(const std::shared_ptr<xrt_core::device>& dev, const xrt_c
   boost::property_tree::ptree ptree = get_test_header();
 
   if (archive == nullptr) {
-    XBValidateUtils::logger(ptree, "Info", "No archive found, skipping test");
+    ptree.put("status", XBValidateUtils::test_token_failed);
+    XBValidateUtils::logger(ptree, "Error", "No archive found, skipping test");
     return ptree;
   }
   

--- a/src/runtime_src/core/tools/common/tests/TestPreeemptionOverhead.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestPreeemptionOverhead.cpp
@@ -78,11 +78,10 @@ TestPreemptionOverhead::run(const std::shared_ptr<xrt_core::device>& dev, const 
   }
 
   if (archive == nullptr) {
-    XBU::logger(ptree, "Info", "No archive found, skipping test");
-    ptree.put("status", XBU::test_token_skipped);
+    ptree.put("status", XBValidateUtils::test_token_failed);
+    XBValidateUtils::logger(ptree, "Error", "No archive found, skipping test");
     return ptree;
   }
-  
   const auto layer_boundary = xrt_core::device_query_default<xq::preemption>(dev.get(), 0);
 
   try {

--- a/src/runtime_src/core/tools/common/tests/TestTCTAllColumn.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestTCTAllColumn.cpp
@@ -47,7 +47,8 @@ TestTCTAllColumn::run(const std::shared_ptr<xrt_core::device>& dev, const xrt_co
   boost::property_tree::ptree ptree = get_test_header();
 
   if (archive == nullptr) {
-    XBValidateUtils::logger(ptree, "Info", "No archive found, skipping test");
+    ptree.put("status", XBValidateUtils::test_token_failed);
+    XBValidateUtils::logger(ptree, "Error", "No archive found, skipping test");
     return ptree;
   }
   

--- a/src/runtime_src/core/tools/common/tests/TestTCTOneColumn.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestTCTOneColumn.cpp
@@ -44,7 +44,8 @@ TestTCTOneColumn::run(const std::shared_ptr<xrt_core::device>& dev, const xrt_co
 {
   boost::property_tree::ptree ptree = get_test_header();
   if (archive == nullptr) {
-    XBValidateUtils::logger(ptree, "Info", "No archive found, skipping test");
+    ptree.put("status", XBValidateUtils::test_token_failed);
+    XBValidateUtils::logger(ptree, "Error", "No archive found, skipping test");
     return ptree;
   }
   


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
This PR changes the info to error for case when archive is not present. 

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
None

#### How problem was solved, alternative solutions (if any) and why they were rejected
Changed by handling as test_token_skipped

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Tested on Linux with archive not present

#### Documentation impact (if any)
None
