### PR TITLE
Deterministic build for xrt-smi and xrt libaries

### DIFF
--- a/src/runtime_src/CMakeLists.txt
+++ b/src/runtime_src/CMakeLists.txt
@@ -70,7 +70,6 @@ else()
       string(CONCAT MP_OPTION "/MP" ${MSVC_PARALLEL_JOBS})
       add_compile_options(${MP_OPTION})
     endif()
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /experimental:deterministic")
   else()
     # lots of warnings and all warnings as errors
     # add_compile_options(-Wall -Wextra -pedantic -Werror)


### PR DESCRIPTION
#### Problem solved by the commit
xrt-smi.exe is reported to be not deterministic builds at link time.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
To fix this issue, we need to add a linker flag to configure for deterministic builds.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Add /experimental:deterministic linker flag if MSVC. It will normalize variables such as order of input files, timestamps, et cetera.

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Verified on Strix device by running fc /b <xrt-smi-1.exe> <xrt-smi-2.exe> command and returned no differences encountered

#### Documentation impact (if any)
None
