### PR TITLE
Fix for CR-1255414

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/device_offload/hal/hal_device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/hal/hal_device_offload_plugin.cpp
@@ -190,8 +190,7 @@ namespace xdp {
     // Update the static database with all the information that
     // will be needed later
     if(hw_context_flow)
-      // TODO: should we use updateDeviceFromCoreDeviceHwCtxFlow or updateDeviceFromCoreDevice
-      db->getStaticInfo().updateDeviceFromCoreDevice(deviceId, device, true, std::make_unique<HalDevice>(device->get_device_handle()));
+      db->getStaticInfo().updateDeviceFromCoreDeviceHwCtxFlow(deviceId, device, userHandle, hw_context_flow, true, std::make_unique<HalDevice>(device->get_device_handle()));
     else
       db->getStaticInfo().updateDeviceFromHandle(deviceId, std::make_unique<HalDevice>(ownedHandle), userHandle) ;
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
CR-1255414

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
In a run with multiple hosts running consecutively, getting device_trace for one of the later runs was causing a segmentation fault. The root cause was traced to incorrect UUID retrieval logic that used .back() on the xclbin_slots query result. In multipartition designs where the first xclbin contains PL components and the second contains AIE components, the .back() method would incorrectly reference the AIE xclbin. Consequently, the AIE xclbin was passed to the PL-side device_trace path, leading to the crash instead of using the intended PL xclbin.

#### How problem was solved, alternative solutions (if any) and why they were rejected
The problem was solved by using the hw_ctx_impl to retrieve UUID for hw_ctx style runs. This approach ensures that we obtain the correct xclbin regardless of the partition ordering.

#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
VCK190

#### Documentation impact (if any)
N/A