### PR TITLE
fix in get shared buffer function

### DIFF
--- a/src/runtime_src/core/edge/common/aie_parser.cpp
+++ b/src/runtime_src/core/edge/common/aie_parser.cpp
@@ -390,11 +390,6 @@ std::unordered_map<std::string, adf::shared_buffer_config>
 get_shared_buffers(const pt::ptree& aie_meta, int graph_id, const zynqaie::hwctx_object* hwctx)
 {
   auto start_col = get_start_col(aie_meta, hwctx);
-  std::vector<size_t> addresses;
-  std::vector<int> producer_locks;
-  std::vector<int> consumer_locks;
-
-
   std::unordered_map<std::string, adf::shared_buffer_config> shared_buffer_configs;
 
   auto sbuf_tree = aie_meta.get_child_optional("aie_metadata.SharedBufferConfigs");
@@ -417,19 +412,16 @@ get_shared_buffers(const pt::ptree& aie_meta, int graph_id, const zynqaie::hwctx
     shared_buffer_config.initialized = shared_buffer_node.second.get<bool>("initialized");
 
     for (auto& item : shared_buffer_node.second.get_child("address")) {
-      addresses.push_back(item.second.get_value<size_t>());
+      shared_buffer_config.addr.push_back(item.second.get_value<size_t>());
     }
-    shared_buffer_config.addr = addresses;
 
     for (auto& item : shared_buffer_node.second.get_child("producer_lock_ids")) {
-      producer_locks.push_back(item.second.get_value<size_t>());
+      shared_buffer_config.producerLocks.push_back(item.second.get_value<size_t>());
     }
-    shared_buffer_config.producerLocks = producer_locks;
 
     for (auto& item : shared_buffer_node.second.get_child("consumer_lock_ids")) {
-      consumer_locks.push_back(item.second.get_value<size_t>());
+      shared_buffer_config.consumerLocks.push_back(item.second.get_value<size_t>());
     }
-    shared_buffer_config.consumerLocks = consumer_locks;
 
     shared_buffer_configs[shared_buffer_config.name] = shared_buffer_config;
   }


### PR DESCRIPTION
Problem solved by the commit
Removed shallow copy of shared buffer config which is passing the wrong parameters to update api

Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Removed shallow copy of shared buffer config which is passing the wrong parameters to update api

How problem was solved, alternative solutions (if any) and why they were rejected
Removed shallow copy of shared buffer config which is passing the wrong parameters to update api

Risks (if any) associated the changes in the commit
None

What has been tested and how, request additional testing if necessary
Tested the application with common tile for r/w and read only shared buffer.

Documentation impact (if any)
NA