### PR TITLE
build.sh: Don't use -Werror as default.

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -57,7 +57,7 @@ usage()
     echo "[-opt]                      Build optimized library only (default)"
     echo "[-edge]                     Build edge of x64.  Turns off opt and dbg"
     echo "[-hip]                      Enable hip bindings"
-    echo "[-disable-werror]           Disable compilation with warnings as error"
+    echo "[-enable-werror]            Enable compilation with warnings as error"
     echo "[-nocmake]                  Skip CMake call"
     echo "[-noert]                    Do not treat missing ERT FW as a build error"
     echo "[-noinit]                   Do not initialize Git submodules"
@@ -111,7 +111,7 @@ noert=0
 static_boost=""
 ertbsp=""
 ertfw=""
-werror=1
+werror=0
 alveo_build=0
 npu_build=0
 base_build=0
@@ -194,8 +194,8 @@ while [ $# -gt 0 ]; do
             noctest=1
             shift
             ;;
-        -disable-werror|--disable-werror)
-            werror=0
+        -enable-werror|--enable-werror)
+            werror=1
             shift
             ;;
         -j)
@@ -274,9 +274,9 @@ fi
 debug_dir=${DEBUG_DIR:-Debug}
 release_dir=${REL_DIR:-Release}
 
-# By default compile with warnings as errors.
+# By default compile without warnings as errors.
 # Update every time CMake is generating makefiles.
-# Disable with '-disable-werror' option.
+# Enable with '-enable-werror' option.
 cmake_flags+=" -DXRT_ENABLE_WERROR=$werror"
 
 # set CMAKE_INSTALL_PREFIX


### PR DESCRIPTION
While being a good practice to use during development, enabling `-Werror` by default for deployment and user builds is a guarantee for failed builds.

It is not feasible for development to keep up with all warnings in all compiler versions, especially ones from the future.

To avoid the build being broken, this patch sets `-Werror` being disabled as default behavior. This mimics the behavior of CMake being invoked directly without the build.sh script.

While a zero warning policy is good, and `-Werror` should also be enabled by default on the CI, it is a bad practice for deployment.

https://embeddedartistry.com/blog/2017/05/22/werror-is-not-your-friend/

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Project fails building on newer compiler versions.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Providing a saner default.

#### Risks (if any) associated the changes in the commit
The project will more likely build on newer compiler versions.

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
