### PR TITLE
Add checks while creating xrt::kernel to use proper ELF

### DIFF
--- a/src/runtime_src/core/common/api/module_int.h
+++ b/src/runtime_src/core/common/api/module_int.h
@@ -132,6 +132,10 @@ get_ctrl_scratchpad_bo(const xrt::module& module);
 std::vector<uint8_t>
 get_ctrlpkt_data(const xrt::module& module, uint32_t ctrl_code_id);
 
+// Function to check if the module is created from a full ELF
+bool
+is_full_elf_module(const xrt::module& module);
+
 } // xrt_core::module_int
 
 #endif

--- a/src/runtime_src/core/common/api/xrt_elf.cpp
+++ b/src/runtime_src/core/common/api/xrt_elf.cpp
@@ -110,6 +110,18 @@ public:
     std::memcpy(&value, data.data(), std::min(data.size(), sizeof(uint32_t)));
     return value;
   }
+
+  bool
+  is_full_elf() const
+  {
+    // A full ELF can be used as a replacement for xclbin, it contains
+    // all the information required to create a hardware context like
+    // partition size, kernel signatures, etc.
+    //
+    // So, if the ELF contains note sections like
+    // .note.xrt.configuration then it is a full ELF.
+    return m_elf.sections[".note.xrt.configuration"] != nullptr;
+  }
 };
 
 } // namespace xrt
@@ -170,6 +182,13 @@ elf::
 get_cfg_uuid() const
 {
   return handle->get_cfg_uuid();
+}
+
+bool
+elf::
+is_full_elf() const
+{
+  return handle->is_full_elf();
 }
 
 } // namespace xrt

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -1657,6 +1657,56 @@ private:
     return std::make_unique<buffer_cache>(ctx, std::move(ctrlpkt_data), max_pool_size, xbi::use_type::ctrlpkt);
   }
 
+  // Function that checks if hw ctx is created using xcbin/ELF
+  // If is_elf_flow is true, then it checks if hw ctx is created using ELF
+  // and returns the hw ctx
+  // If is_elf_flow is false, then it checks if hw ctx is created using XCLBIN
+  // and returns the hw ctx
+  // Throws exception in other cases
+  static xrt::hw_context
+  check_and_get_hw_context(const xrt::hw_context& ctx, bool is_full_elf_flow)
+  {
+    if (is_full_elf_flow) {
+      if (xrt_core::hw_context_int::get_elf_flow(ctx))
+        return ctx;
+
+      throw std::runtime_error("Invalid API called for xrt::kernel creation, "
+                               "xrt::hw_context passed is not created using full ELF");
+    }
+    else {
+      if (!xrt_core::hw_context_int::get_elf_flow(ctx))
+        return ctx;
+
+      throw std::runtime_error("Invalid API called for xrt::kernel creation, "
+                               "xrt::hw_context passed is not created using XCLBIN");
+    }
+  }
+
+  // Function that checks if the module is created using full ELF
+  // If is_full_elf_flow is true, then it checks if the module is created using full ELF
+  // and returns the module
+  // If is_full_elf_flow is false, then it checks if the module is created using XCLBIN
+  // and returns the module
+  // Throws exception in other cases
+  static xrt::module
+  check_and_get_module(const xrt::module& mod, bool is_full_elf_flow)
+  {
+    if (is_full_elf_flow) {
+      if (xrt_core::module_int::is_full_elf_module(mod))
+        return mod;
+
+      throw std::runtime_error("Invalid API called for xrt::kernel creation, "
+                               "xrt::module passed is not created using full ELF");
+    }
+    else {
+      if (!xrt_core::module_int::is_full_elf_module(mod))
+        return mod;
+
+      throw std::runtime_error("Invalid API called for xrt::kernel creation, "
+                               "xrt::module passed is created using full ELF");
+    }
+  }
+
 public:
   // kernel_type - constructor
   //
@@ -1671,9 +1721,9 @@ public:
     : name(nm.substr(0,nm.find(":")))                          // filter instance names
     , device(std::move(dev))                                   // share ownership
     , ctxmgr(xrt_core::context_mgr::create(device->core_device.get())) // owership tied to kernel_impl
-    , hwctx(std::move(ctx))                                    // hw context
+    , hwctx(check_and_get_hw_context(ctx, false))              // hw context (not full ELF flow)
     , hwqueue(hwctx)                                           // hw queue
-    , m_module{std::move(mod)}                                 // module if any
+    , m_module(check_and_get_module(mod, false))               // module (not full ELF flow)
     , xclbin(hwctx.get_xclbin())                               // xclbin with kernel
     , xkernel(get_kernel_or_error(xclbin, name))               // kernel meta data managed by xclbin
     , properties(xrt_core::xclbin_int::get_properties(xkernel))// cache kernel properties
@@ -1720,7 +1770,7 @@ public:
   kernel_impl(std::shared_ptr<device_type> dev, xrt::hw_context ctx, const std::string& nm)
     : name(nm.substr(0, nm.find(":")))                                  // kernel name
     , device(std::move(dev))                                            // share ownership
-    , hwctx(std::move(ctx))                                             // hw context
+    , hwctx(check_and_get_hw_context(ctx, true))                        // hw context (full ELF flow)
     , hwqueue(hwctx)                                                    // hw queue
     , m_module(xrt_core::hw_context_int::get_module(hwctx, nm.substr(0, nm.find(":"))))
     , properties(get_kernel_info().props)

--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -812,6 +812,16 @@ public:
   {
     throw std::runtime_error("Not supported");
   }
+
+  // function to check if the module is created from a full ELF
+  virtual bool
+  is_full_elf_module() const
+  {
+    // This function is not applicable for child classes
+    // like module_userptr and module_sram
+    // So throwing exception here.
+    throw std::runtime_error("Not Applicable");
+  }
 };
 
 // class module_userptr - Opaque userptr provided by application
@@ -1214,6 +1224,12 @@ public:
 
     throw std::runtime_error(
         std::string{"Unable to get arg patcher for index: " + std::to_string(id)});
+  }
+
+  bool
+  is_full_elf_module() const override
+  {
+    return m_elf.is_full_elf();
   }
 };
 
@@ -3052,6 +3068,12 @@ get_ctrlpkt_data(const xrt::module& module, uint32_t ctrl_code_id)
   catch (...) {
     return {}; // returns empty buffer
   }
+}
+
+bool
+is_full_elf_module(const xrt::module& module)
+{
+  return module.get_handle()->is_full_elf_module();
 }
 
 } // xrt_core::module_int

--- a/src/runtime_src/core/include/xrt/experimental/xrt_elf.h
+++ b/src/runtime_src/core/include/xrt/experimental/xrt_elf.h
@@ -44,7 +44,7 @@ public:
    * elf() - Constructor from raw data
    *
    * @param data
-   *  Raw data of elf
+   *  Raw data of elf 
    *
    * The raw data of the elfcan be deleted after calling the
    * constructor.
@@ -95,6 +95,20 @@ public:
   XRT_API_EXPORT
   xrt::uuid
   get_cfg_uuid() const;
+
+  /**
+   * is_full_elf() - Check if the elf is a full ELF
+   * 
+   * A full ELF can be used as a replacement for xclbin, it contains
+   * all the information required to create a hardware context like
+   * partition size, kernel signatures, etc.
+   *
+   * @return
+   *  True if the elf is a full ELF, false otherwise
+   */
+  XRT_API_EXPORT
+  bool
+  is_full_elf() const;
 };
 
 } // namespace xrt


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
With the full ELF flow now enabled in XRT, users may inadvertently use incorrect APIs when creating xrt::kernel objects. This PRintroduces validation checks to detect and report improper API usage during xrt::kernel creation.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
This is an enhancement aimed at improving Ease of Use (EOU). 

#### How problem was solved, alternative solutions (if any) and why they were rejected
The correct usage of xrt::kernel creation APIs is as follows:
1. xrt::kernel(ctx, module, "kernel_name") — for xclbin + ELF flow
2. xrt::kernel(ctx, "kernel_name") — for full ELF flow

However, users might mistakenly pass an xrt::module created via the full ELF flow into the first API, or vice versa. This commit adds runtime checks to detect such misuse and throws appropriate exceptions to guide developers.

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
Did negative testing to verify that exceptions are correctly thrown when APIs are misused.

#### Documentation impact (if any)
NA