### PR TITLE
[XDP] Fixed runtime summary payload key name

### DIFF
--- a/src/runtime_src/xdp/profile/writer/vp_base/vp_run_summary.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/vp_run_summary.cpp
@@ -180,7 +180,7 @@ namespace xdp {
       for (const auto& s : systemDiagrams) {
 	boost::property_tree::ptree ptSystemDiagram;
 	ptSystemDiagram.put("hw_context", s.contextId);
-	ptSystemDiagram.put("payload_16bitEnd", s.systemDiagram.c_str());
+	ptSystemDiagram.put("payload_16bitEnc", s.systemDiagram.c_str());
 	ptSystemDiagrams.push_back(std::make_pair("", ptSystemDiagram));
       }
       ptRunSummary.add_child("system_diagrams", ptSystemDiagrams);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
This is double commit of https://github.com/Xilinx/XRT/pull/9425 
For Vitis designs, generated runtime summary wasn't generating payload keyname as expected.

Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Generated vitis designs summary had a field named payload_16bitEnd instead of payload_16bitEnc.

How problem was solved, alternative solutions (if any) and why they were rejected
Fixed a typo in expected payload keyname to payload_16bitEnc

Risks (if any) associated the changes in the commit
Low

What has been tested and how, request additional testing if necessary
It has been already verified that original test works with the updated key field name.

Documentation impact (if any)