### PR TITLE
XRT build error fix

### DIFF
--- a/src/CMake/version.cmake
+++ b/src/CMake/version.cmake
@@ -2,6 +2,31 @@
 # Copyright (C) 2019-2021 Xilinx, Inc. All rights reserved.
 # Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
 
+if (WIN32 AND XRT_RC_VERSION)
+  function(xrt_configure_version_file target_name type)
+    message(STATUS "-- Generating version file for target: ${target_name} of type: ${type}")
+    if (type STREQUAL "SHARED")
+      set(OriginalFilename ${target_name}.dll)
+      set(FileType VFT_DLL)
+    elseif(type STREQUAL "APP")
+      set(OriginalFilename ${target_name}.exe)
+      set(FileType VFT_APP)
+    else()
+      message(FATAL_ERROR "Unknown file type ${type} for version file configuration")
+    endif()
+
+    configure_file(
+      ${XRT_SOURCE_DIR}/CMake/config/version.rc.in
+      ${CMAKE_CURRENT_BINARY_DIR}/${target_name}-version.rc
+      @ONLY
+      )
+  endfunction()
+else()
+  function(xrt_configure_version_file target_name type)
+    file(TOUCH ${CMAKE_CURRENT_BINARY_DIR}/${target_name}-version.rc)
+  endfunction()
+endif()
+
 # The version.cmake should only be include once in a project
 # otherwise configured files may be overwritten.  This may
 # not be a problem but is better to avoid it.
@@ -124,29 +149,6 @@ if (WIN32 AND XRT_RC_VERSION)
   set(XRT_RC_MINOR ${XRT_RC_MINOR} CACHE STRING "Minor version for RC file")
   set(XRT_RC_BUILD ${XRT_RC_BUILD} CACHE STRING "Build version for RC file")
   set(XRT_RC_PATCH ${XRT_RC_PATCH} CACHE STRING "Patch version for RC file")
-
-  function(xrt_configure_version_file target_name type)
-    message(STATUS "-- Generating version file for target: ${target_name} of type: ${type}")
-    if (type STREQUAL "SHARED")
-      set(OriginalFilename ${target_name}.dll)
-      set(FileType VFT_DLL)
-    elseif(type STREQUAL "APP")
-      set(OriginalFilename ${target_name}.exe)
-      set(FileType VFT_APP)
-    else()
-      message(FATAL_ERROR "Unknown file type ${type} for version file configuration")
-    endif()
-
-    configure_file(
-      ${XRT_SOURCE_DIR}/CMake/config/version.rc.in
-      ${CMAKE_CURRENT_BINARY_DIR}/${target_name}-version.rc
-      @ONLY
-      )
-  endfunction()
-else()
-  function(xrt_configure_version_file target_name type)
-    file(TOUCH ${CMAKE_CURRENT_BINARY_DIR}/${target_name}-version.rc)
-  endfunction()
 endif()  
 
 # xrt component install


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
This PR fixes the XRT build failure that was introduced with PR https://github.com/Xilinx/XRT/pull/9395
The build failure comes from non-clean builds (where cmake's caching kicks in) for xrt and depending projects (xdna). Build error : 
```
-- add_subdirectory(doc)
-- add_subdirectory(xdp)
CMake Error at runtime_src/xdp/profile/CMakeLists.txt:33 (xrt_configure_version_file):
  Unknown CMake command "xrt_configure_version_file".
```
The reason is that the cmake function xrt_configure_version_file is not defined on subsequent builds when cmake caching is triggered.
This build failure is blocking the xdna submodule update : https://github.com/amd/xdna-driver/pull/844

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
None

#### How problem was solved, alternative solutions (if any) and why they were rejected
Solved via moving the cmake definition of the problematic function out of cache guard so that the function is defined in each build.

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Tested on linux. Builds fine for both xrt and xdna

#### Documentation impact (if any)
None
