### PR TITLE
Updated driver_version function to read the version and hash from the same file

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/Makefile
+++ b/src/runtime_src/core/edge/drm/zocl/Makefile
@@ -32,8 +32,8 @@ endif
 
 ccflags-y += -Wall
 
-# Version adjusted to 2.20 for master
-XRT_DRIVER_VERSION ?= 2.20.0
+# Version adjusted to 2.21 for master
+XRT_DRIVER_VERSION ?= 2.21.0
 
 # Add patch number in version if 'XRT_VERSION_PATCH' env variable is defined
 ifneq ($(XRT_VERSION_PATCH),)

--- a/src/runtime_src/core/edge/drm/zocl/common/zocl_drv.c
+++ b/src/runtime_src/core/edge/drm/zocl/common/zocl_drv.c
@@ -1614,7 +1614,7 @@ static void __exit zocl_exit(void)
 }
 module_exit(zocl_exit);
 
-MODULE_VERSION(XRT_HASH);
+MODULE_VERSION(XRT_DRIVER_VERSION","XRT_HASH);
 
 MODULE_DESCRIPTION(ZOCL_DRIVER_DESC);
 MODULE_AUTHOR("Sonal Santan <sonal.santan@xilinx.com>");

--- a/src/runtime_src/core/edge/user/system_linux.cpp
+++ b/src/runtime_src/core/edge/user/system_linux.cpp
@@ -95,17 +95,15 @@ driver_version(const std::string& driver)
   std::string path("/sys/module/");
   path += driver;
   path += "/version";
-  //dkms flow is not available for zocl
-  //so version.h file is not available at zocl build time
-#if defined(XRT_DRIVER_VERSION)
-  std::string zocl_driver_ver = XRT_DRIVER_VERSION;
-  std::stringstream ss(zocl_driver_ver);
-  getline(ss, ver, ',');
-#endif
+ 
   std::ifstream stream(path);
-  if (stream.is_open())
-     getline(stream, hash);
-  
+  if (stream.is_open()) {
+    std::string line;
+    getline(stream, line);
+    std::stringstream ss(line);
+    getline(ss, ver, ',');
+    getline(ss, hash, ',');
+  }
   _pt.put("name", driver);
   _pt.put("version", ver);
   _pt.put("hash", hash);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
The ZOCL driver version is not fetched from the module version sysnode, instead, we are trying to retrieve it from the XRT_DRIVER_VERSION macro, which is unavailable while building the Telluride repository. This results in an “unknown” error in the xrt-smi examine report.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Updated driver_version function to read the version and hash from the same file

#### Risks (if any) associated the changes in the commit
low

#### What has been tested and how, request additional testing if necessary
Tested on Telluride by running xrt-smi examine
```
XRT
  Version              : 2.21.0
  Branch               : HEAD
  Hash                 : 042a967bd865c7d932ccf5808827a3b98dc7a308
  Hash Date            : 2025-11-12 19:13:36
  amdxdna              : 2.21.0_20251112, e56379dd493ebdc3b74228fa8404439ce0395263
  zocl                 : 2.21.0, 042a967bd865c7d932ccf5808827a3b98dc7a308
  UC Firmware Version  : 0.17, c76d3a76981106a614e3eeda6b268059fc75957d
  UC Build Date        : 2025-10-25

Device(s) Present
|BDF             |Shell  |Logic UUID  |Device ID     |Device Ready*  |
|----------------|-------|------------|--------------|---------------|
|[0000:00:00.1]  |edge   |0x0         |user(inst=0)  |Yes            |


* Devices that are not ready will have reduced functionality when using XRT tools
|BDF             |Name       |
|----------------|-----------|
|[0000:00:00.0]  |Telluride  |


amd-edf:/home/amd-edf# 
```
#### Documentation impact (if any)
