### PR TITLE
Fix bug in multi ctrlpkt flow

### DIFF
--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -2159,7 +2159,12 @@ class module_sram : public module_impl
     // patch it in instruction buffer
     for (const auto& [name, ctrlpktbo] : m_ctrlpkt_bos) {
       // symbol name will be same as section name without the grp idx
-      auto sym_name = name.substr(0, name.rfind('.'));
+      // if sec name is .ctrlpkt-57.grp_idx then sym name is .ctrlpkt-57
+      auto dot_pos = name.rfind('.');
+      auto sym_name = (dot_pos != std::string::npos && dot_pos > 0)
+                    ? name.substr(0, dot_pos)
+                    : name;
+
       if (patch_instr_value(m_buffer, sym_name, std::numeric_limits<size_t>::max(), ctrlpktbo.address(),
                             xrt_core::patcher::buf_type::ctrltext, m_ctrl_code_id))
         m_patched_args.insert(sym_name);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Fixed a bug when running ELF with multi ctrlpkt sections (xclbin + elf flow)

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
It was discovered in internal testing

#### How problem was solved, alternative solutions (if any) and why they were rejected
patching symbol name is obtained by removing grp id in section name but in old flow (xclbin + elf) there is no group index so with the previous logic we get empty string and symbol is not patched.
Added changes to handle both old and new flows

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
Tested aie2ps xclbin + elf ctrlpkt test case

#### Documentation impact (if any)
NA