### PR TITLE
docs: fix grammatical error in Buffer Map API documentation

### DIFF
--- a/Buffer Map API"
+++ b/Buffer Map API"
@@ -1,0 +1,1 @@
+The API xrt::bo::map() allows mapping the host-side buffer backing to a user pointer.


### PR DESCRIPTION
Remove redundant word 'pointer' in xrt::bo::map() description.

Fixes #8796

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
