### PR TITLE
 Add AIO enable/disable support

### DIFF
--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -639,6 +639,18 @@ get_cmdbo_cache()
   return value;
 }
 
+/**
+ * Enable QDMA AIO (Asynchronous I/O) support.
+ * Default is false.
+ * Set to true in xrt.ini to enable AIO if needed.
+ */
+inline bool
+get_qdma_aio_enable()
+{
+  static bool value = detail::get_bool_value("Runtime.qdma_aio_enable", false);
+  return value;
+}
+
 inline std::string
 get_hw_em_driver()
 {

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -805,7 +805,20 @@ int shim::dev_init()
 
     mStreamHandle = mDev->open("dma.qdma", O_RDWR | O_SYNC);
     memset(&mAioContext, 0, sizeof(mAioContext));
-    mAioEnabled = (io_setup(SHIM_QDMA_AIO_EVT_MAX, &mAioContext) == 0);
+
+    // Enable AIO only if configured in xrt.ini (Runtime.qdma_aio_enable = true)
+    // Default is false as QDMA streaming services are used now
+    if (xrt_core::config::get_qdma_aio_enable()) {
+        mAioEnabled = (io_setup(SHIM_QDMA_AIO_EVT_MAX, &mAioContext) == 0);
+        if (mAioEnabled) {
+            xrt_logmsg(XRT_INFO, "%s: QDMA AIO enabled (context: %lu, max events: %d)",
+                    __func__, static_cast<unsigned long>(mAioContext), SHIM_QDMA_AIO_EVT_MAX);
+        } else {
+            xrt_logmsg(XRT_WARNING, "%s: Failed to enable QDMA AIO", __func__);
+        }
+    } else {
+        mAioEnabled = false;
+    }
 
     return 0;
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
QDMA streaming make use of asynchronous AIO. 
Linux kernel accomodates 65536 in total where xrt is making use of all starving other entities to make use of AIOs.
Provided an interface to user if configure AIO enablement as per requirement.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
discovered by customer
#### How problem was solved, alternative solutions (if any) and why they were rejected
QDMA streaming make use of asynchronous AIO. 
Linux kernel accomodates 65536 in total where xrt is making use of all starving other entities to make use of AIOs.
Provided an interface to user if configure AIO enablement as per requirement.
#### Risks (if any) associated the changes in the commit
None
#### What has been tested and how, request additional testing if necessary
Ran NVMe stress test and don't see the resource unavailable error when AIO is disabled.
#### Documentation impact (if any)
NA