### PR TITLE
reporting correct bo size

### DIFF
--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -1075,8 +1075,10 @@ alloc_kbuf(const device_type& device, size_t sz, xrtBufferFlags flags, xrtMemory
 {
   XRT_TRACE_POINT_SCOPE(xrt_bo_alloc_kbuf);
   auto handle = alloc_bo(device, sz, flags, grp);
-  auto boh = std::make_shared<xrt::buffer_kbuf>(device, std::move(handle), sz);
-  boh->get_usage_logger()->log_buffer_info_construct(device->get_device_id(), sz, device.get_hwctx_handle());
+  // Query actual allocated size from driver (bo size may be rounded up)
+  auto actual_sz = handle->get_properties().size;
+  auto boh = std::make_shared<xrt::buffer_kbuf>(device, std::move(handle), actual_sz);
+  boh->get_usage_logger()->log_buffer_info_construct(device->get_device_id(), actual_sz, device.get_hwctx_handle());
   return boh;
 }
 

--- a/src/runtime_src/core/edge/drm/zocl/common/zocl_bo.c
+++ b/src/runtime_src/core/edge/drm/zocl/common/zocl_bo.c
@@ -666,6 +666,7 @@ zocl_create_bo_ioctl(struct drm_device *dev, void *data, struct drm_file *filp)
 	 *       actual size allocated.
 	 */
 	zocl_update_mem_stat(zdev, bo->gem_base.size, 1, bo->mem_index);
+	args->size = bo->size;
 
 	return ret;
 }

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -293,7 +293,7 @@ xclAllocBO(size_t size, unsigned flags, xrt_core::hwctx_handle* hwctx_hdl)
   if (result)
     throw std::bad_alloc();
 
-  xclLog(XRT_DEBUG, "%s: size %ld, flags 0x%x", __func__, size, flags);
+  xclLog(XRT_DEBUG, "%s: size %lld, flags 0x%x", __func__, info.size, flags);
   xclLog(XRT_INFO, "%s: ioctl return %d, bo handle %d", __func__, result, info.handle);
 
   return std::make_unique<buffer_object>(this, info.handle, hwctx_hdl);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
reporting correct bo size
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
The bug was if driver rounds up the bo size, userspace used to report the cached original requested bo size when host application requests with xrt::bo::size()
#### How problem was solved, alternative solutions (if any) and why they were rejected
Problem was solved by updating the cached bo size with the actual bo size. Extra call is being made to get the actual size.
#### Risks (if any) associated the changes in the commit
n/a
#### What has been tested and how, request additional testing if necessary
Tested by allocating a bo with less size and driver rounds up it 8K and checked if xrt::bo::size() reports the updated bo size. with this pr xrt::bo:;size() reports correct bo size.
#### Documentation impact (if any)
n/a