### PR TITLE
 Add AIO enable/disable support

### DIFF
--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -612,6 +612,18 @@ get_cmdbo_cache()
   return value;
 }
 
+/**
+ * Enable QDMA AIO (Asynchronous I/O) support.
+ * Default is false.
+ * Set to true in xrt.ini to enable AIO if needed.
+ */
+inline bool
+get_qdma_aio_enable()
+{
+  static bool value = detail::get_bool_value("Runtime.qdma_aio_enable", false);
+  return value;
+}
+
 inline std::string
 get_hw_em_driver()
 {


### PR DESCRIPTION
Problem solved by the commit
QDMA streaming make use of asynchronous AIO.
Linux kernel accomodates 65536 in total where xrt is making use of all starving other entities to make use of AIOs.
Provided an interface to user if configure AIO enablement as per requirement.

Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
discovered by customer

How problem was solved, alternative solutions (if any) and why they were rejected
QDMA streaming make use of asynchronous AIO.
Linux kernel accomodates 65536 in total where xrt is making use of all starving other entities to make use of AIOs.
Provided an interface to user if configure AIO enablement as per requirement.

Risks (if any) associated the changes in the commit
None

What has been tested and how, request additional testing if necessary
Ran NVMe stress test and don't see the resource unavailable error when AIO is disabled.

Documentation impact (if any)
NA