### PR TITLE
Hip:Graph:Adding support for event record & wait nodes.

### DIFF
--- a/src/runtime_src/hip/core/event.cpp
+++ b/src/runtime_src/hip/core/event.cpp
@@ -420,6 +420,41 @@ submit()
   return true;
 }
 
+bool event_record_command::submit()
+{
+  throw_invalid_value_if(!m_event, "event is nullptr");
+
+  auto s = m_stream.lock();
+  throw_invalid_value_if(!s, "stream is not set or has been destroyed for event record command");
+
+  // Record the event in the stream
+  m_event->record(s);
+  set_state(state::completed);
+  return true;
+}
+
+bool event_wait_command::submit()
+{
+  throw_invalid_value_if(!m_event, "event is nullptr");
+
+  auto s = m_stream.lock();
+  throw_invalid_value_if(!s, "stream is not set or has been destroyed for event wait command");
+
+  // check stream on which wait is called is same as stream in which event is enqueued
+  if (m_event->is_recorded_stream(s.get()))
+    s->record_top_event(m_event);
+
+  // Wait for the event to complete
+  m_event->wait();
+
+  // Clear the top event after wait completes (if it was set for this stream)
+  if (m_event->is_recorded_stream(s.get()))
+    s->clear_top_event();
+
+  set_state(state::completed);
+  return true;
+}
+
 // Global map of commands
 xrt_core::handle_map<command_handle, std::shared_ptr<command>> command_cache;
 

--- a/src/runtime_src/hip/core/event.h
+++ b/src/runtime_src/hip/core/event.h
@@ -42,8 +42,9 @@ public:
     kernel_start,
     mem_cpy,
     kernel_list_start,
-    graph_exec,
-    empty
+    empty,
+    event_record,
+    event_wait
   };
 
 protected:
@@ -249,6 +250,60 @@ public:
   get_hw_ctx() const
   {
     return m_hw_ctx;
+  }
+};
+
+// Command for recording an event in a graph node
+class event_record_command : public command
+{
+private:
+  std::shared_ptr<event> m_event;
+  std::weak_ptr<stream> m_stream;
+
+public:
+  explicit event_record_command(std::shared_ptr<event> ev)
+    : command(type::event_record)
+    , m_event(std::move(ev))
+  {}
+
+  void set_stream(std::shared_ptr<stream> s)
+  {
+    m_stream = s;
+  }
+
+  bool submit() override;
+
+  bool
+  wait() override
+  {
+    return true;
+  }
+};
+
+// Command for waiting on an event in a graph node
+class event_wait_command : public command
+{
+private:
+  std::shared_ptr<event> m_event;
+  std::weak_ptr<stream> m_stream;
+
+public:
+  explicit event_wait_command(std::shared_ptr<event> ev)
+    : command(type::event_wait)
+    , m_event(std::move(ev))
+  {}
+
+  void set_stream(std::shared_ptr<stream> s)
+  {
+    m_stream = s;
+  }
+
+  bool submit() override;
+
+  bool
+  wait() override
+  {
+    return true;
   }
 };
 

--- a/src/runtime_src/hip/core/graph.h
+++ b/src/runtime_src/hip/core/graph.h
@@ -6,6 +6,7 @@
 
 #include "event.h"
 #include "module.h"
+#include "stream.h"
 
 namespace xrt::core::hip {
 
@@ -14,6 +15,9 @@ using node_handle = void*;
 
 // graph_handle - opaque graph handle
 using graph_handle = void*;
+
+// graph_exec_handle - opaque graph_exec handle
+using graph_exec_handle = void*;
 
 // Represents a node in the HIP graph, wrapping a command.
 class graph_node : public std::enable_shared_from_this<graph_node>
@@ -99,22 +103,23 @@ private:
 };
 
 // Represents an executable instance of a HIP graph.
-class graph_exec : public command
+class graph_exec
 {
 private:
   std::vector<std::shared_ptr<graph_node>> m_node_exec_list;
-  std::future<void> m_exec_future;
 
 public:
   graph_exec() = default;
   explicit graph_exec(const std::shared_ptr<graph>& graph);
 
-  bool submit() override;
-  bool wait() override;
+  void execute(std::shared_ptr<stream> s);
 };
 
 // Global map of graph
 extern xrt_core::handle_map<graph_handle, std::shared_ptr<graph>> graph_cache;
+
+// Global map of graph_exec
+extern xrt_core::handle_map<graph_exec_handle, std::shared_ptr<graph_exec>> graph_exec_cache;
 } // xrt::core::hip
 
 #endif

--- a/src/runtime_src/hip/core/stream.cpp
+++ b/src/runtime_src/hip/core/stream.cpp
@@ -154,6 +154,9 @@ synchronize()
   // synchronize among streams in this ctx
   synchronize_streams();
 
+  if (m_graph_exec_future.valid())
+    m_graph_exec_future.wait();
+
   // complete commands in this stream
   await_completion();
 }
@@ -170,6 +173,21 @@ record_top_event(std::shared_ptr<event> ev)
   }
 
   m_top_event = std::move(ev);
+}
+
+void
+stream::
+set_graph_exec_future(std::future<void> future)
+{
+  m_graph_exec_future = std::move(future);
+}
+
+void
+stream::
+clear_top_event()
+{
+  std::lock_guard<std::mutex> lk(m_cmd_lock);
+  m_top_event = nullptr;
 }
 
 std::shared_ptr<stream>

--- a/src/runtime_src/hip/core/stream.h
+++ b/src/runtime_src/hip/core/stream.h
@@ -6,6 +6,7 @@
 #include "context.h"
 
 #include <list>
+#include <future>
 
 namespace xrt::core::hip {
 
@@ -22,6 +23,7 @@ class stream
   std::list<std::shared_ptr<command>> m_cmd_queue;
   std::mutex m_cmd_lock;
   std::shared_ptr<event> m_top_event;
+  std::future<void> m_graph_exec_future;
 
 public:
   stream() = default;
@@ -70,6 +72,12 @@ public:
 
   void
   record_top_event(std::shared_ptr<event> ev);
+
+  void
+  clear_top_event();
+
+  void
+  set_graph_exec_future(std::future<void> future);
 };
 
 // Global map of streams

--- a/src/runtime_src/hip/xrt_hip.def
+++ b/src/runtime_src/hip/xrt_hip.def
@@ -56,6 +56,8 @@ EXPORTS
   hipGraphAddEmptyNode
   hipGraphAddMemsetNode
   hipGraphAddMemcpyNode1D
+  hipGraphAddEventRecordNode
+  hipGraphAddEventWaitNode
   hipGraphInstantiate
   hipGraphLaunch
   hipGraphExecDestroy


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
- Added support for hipGraphAddEventRecordNode, hipGraphAddEventWaitNode.
- Removed graph_exec class inheritance from command.
- Enqueuing the commands into stream instead of direct submission.
- Resetting top event in stream after event wait is completed.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
None
#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit
Low
#### What has been tested and how, request additional testing if necessary
Tested on Windows Strix machine.
#### Documentation impact (if any)
NA