### PR TITLE
fix double free irq issue

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/zert/zocl_xgq_intc.c
+++ b/src/runtime_src/core/edge/drm/zocl/zert/zocl_xgq_intc.c
@@ -149,10 +149,14 @@ static void zocl_irq_intc_remove(struct platform_device *pdev, u32 id)
 	h = &zintc->zei_handler[id];
 	spin_lock_irqsave(&zintc->zei_lock, irqflags);
 
+	/* Free irq only if its not already freed */
+       if (h->zeih_enabled == true)
+               free_irq(h->zeih_irq, h);
+
+
 	h->zeih_cb = NULL;
 	h->zeih_arg = NULL;
 	h->zeih_enabled = false;
-	free_irq(h->zeih_irq, h);
 
 	spin_unlock_irqrestore(&zintc->zei_lock, irqflags);
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
When user manage interrupt tries to register, it removes any handler that was previously registered.
If no interrupt was registered earlier, then free irq is being called in such case.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
double free irq issue

#### How problem was solved, alternative solutions (if any) and why they were rejected
Check if the handler exists before freeing interrupt.

#### Risks (if any) associated the changes in the commit
None
#### What has been tested and how, request additional testing if necessary
Tested the NPU IP inference and observed no crash in dmesg logs.

#### Documentation impact (if any)
None