### PR TITLE
Hip: graph: Fix Coverity warnings

### DIFF
--- a/src/runtime_src/hip/core/event.cpp
+++ b/src/runtime_src/hip/core/event.cpp
@@ -428,7 +428,7 @@ bool event_record_command::submit()
   throw_invalid_value_if(!s, "stream is not set or has been destroyed for event record command");
 
   // Record the event in the stream
-  m_event->record(s);
+  m_event->record(std::move(s));
   set_state(state::completed);
   return true;
 }

--- a/src/runtime_src/hip/core/graph.cpp
+++ b/src/runtime_src/hip/core/graph.cpp
@@ -143,12 +143,12 @@ execute(std::shared_ptr<stream> s)
   // Set stream on event_record_command and event_wait_command nodes before enqueuing
   for (auto& node : m_node_exec_list) {
     auto cmd = node->get_cmd();
-    if (cmd && cmd->get_type() == command::type::event_record) {
+    if (cmd->get_type() == command::type::event_record) {
       auto event_record_cmd = std::dynamic_pointer_cast<event_record_command>(cmd);
       if (event_record_cmd)
         event_record_cmd->set_stream(s);
     }
-    else if (cmd && cmd->get_type() == command::type::event_wait) {
+    else if (cmd->get_type() == command::type::event_wait) {
       auto event_wait_cmd = std::dynamic_pointer_cast<event_wait_command>(cmd);
       if (event_wait_cmd)
         event_wait_cmd->set_stream(s);
@@ -164,11 +164,11 @@ execute(std::shared_ptr<stream> s)
 
       // Enqueue the command to the stream instead of submitting directly
       auto cmd = node->get_cmd();
-      if (cmd && (cmd->get_type() == command::type::event_record ||
-                  cmd->get_type() == command::type::event_wait))
+      if (cmd->get_type() == command::type::event_record ||
+          cmd->get_type() == command::type::event_wait)
         cmd->submit();
       else
-        s->enqueue(cmd);
+        s->enqueue(std::move(cmd));
     }
   });
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Fix Coverity warnings:
- performance inefficiency in passing shared pointer
- Null pointer dereferences
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
None
#### How problem was solved, alternative solutions (if any) and why they were rejected
Removed cmd null check as it was done during init() during graph instantiation.
#### Risks (if any) associated the changes in the commit
Low
#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
NA