### PR TITLE
cmake/boostUtil: Don't look for boost system stub library.

### DIFF
--- a/src/CMake/boostUtil.cmake
+++ b/src/CMake/boostUtil.cmake
@@ -5,29 +5,17 @@
 # In particular the script runtime_src/tools/script/boost.sh downloads
 # and builds static Boost libraries compiled with fPIC so that they
 # can be used to resolve symbols in XRT dynamic libraries.
-
-# Note: Boost.System became header-only in Boost 1.69, so we only need
-# filesystem and program_options as compiled components for newer Boost versions
-set(BOOST_REQUIRED_COMPONENTS filesystem program_options)
-
 if (DEFINED ENV{XRT_BOOST_INSTALL})
   set(XRT_BOOST_INSTALL $ENV{XRT_BOOST_INSTALL})
   set(Boost_USE_STATIC_LIBS ON)
   if(CMAKE_VERSION VERSION_GREATER "3.29")
-    # First try to find Boost to get version
-    find_package(Boost CONFIG
-      HINTS $ENV{XRT_BOOST_INSTALL})
-    # For older Boost (< 1.69), also include system component
-    if(Boost_FOUND AND Boost_VERSION_STRING VERSION_LESS "1.69.0")
-      set(BOOST_REQUIRED_COMPONENTS system ${BOOST_REQUIRED_COMPONENTS})
-    endif()
     find_package(Boost CONFIG
       HINTS $ENV{XRT_BOOST_INSTALL}
-      REQUIRED COMPONENTS ${BOOST_REQUIRED_COMPONENTS})
+      REQUIRED COMPONENTS filesystem program_options)
   else(CMAKE_VERSION VERSION_GREATER "3.29")
     find_package(Boost
       HINTS $ENV{XRT_BOOST_INSTALL}
-      REQUIRED COMPONENTS system filesystem program_options)
+      REQUIRED COMPONENTS filesystem program_options)
   endif(CMAKE_VERSION VERSION_GREATER "3.29")
 
   # A bug in FindBoost maybe?  Doesn't set Boost_LIBRARY_DIRS when
@@ -41,17 +29,11 @@ if (DEFINED ENV{XRT_BOOST_INSTALL})
 
 else()
   if(CMAKE_VERSION VERSION_GREATER "3.29")
-    # First try to find Boost to get version
-    find_package(Boost CONFIG)
-    # For older Boost (< 1.69), also include system component
-    if(Boost_FOUND AND Boost_VERSION_STRING VERSION_LESS "1.69.0")
-      set(BOOST_REQUIRED_COMPONENTS system ${BOOST_REQUIRED_COMPONENTS})
-    endif()
     find_package(Boost CONFIG
-      REQUIRED COMPONENTS ${BOOST_REQUIRED_COMPONENTS})
+    REQUIRED COMPONENTS filesystem program_options)
   else(CMAKE_VERSION VERSION_GREATER "3.29")
     find_package(Boost
-      REQUIRED COMPONENTS system filesystem program_options)
+      REQUIRED COMPONENTS filesystem program_options)
   endif(CMAKE_VERSION VERSION_GREATER "3.29")
 endif()
 set(Boost_USE_MULTITHREADED ON)             # Multi-threaded libraries

--- a/src/runtime_src/core/tools/xbflash2/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbflash2/CMakeLists.txt
@@ -4,7 +4,7 @@
 #
 
 find_package(Boost
-  REQUIRED COMPONENTS system program_options)
+  REQUIRED COMPONENTS program_options)
 
 include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}
@@ -38,7 +38,6 @@ add_executable(${XBFLASH_NAME} ${XBFLASH_QSPI_SRC})
 set(Boost_USE_STATIC_LIBS ON)
 target_link_libraries(${XBFLASH_NAME}
       PRIVATE
-      boost_system
       boost_program_options
       )
 


### PR DESCRIPTION
Boost system has been header only since 1.69 (from 2018) and the stub library has been dropped in 1.89, resulting in CMake errors when being looked for.

This patch drops the redundant find_package component to boost_system, which was only a stub library since boost version 1.69 from 2018.

See https://github.com/boostorg/system/blob/1061db7dcd534bf93ea10558165115382fe3b87c/doc/system/changes.adoc#changes-in-boost-189

This fixes the following CMake error when bulding with boost 1.89 or later:
```
CMake Error at /usr/lib/cmake/Boost-1.89.0/BoostConfig.cmake:141 (find_package):
  Could not find a package configuration file provided by "boost_system"
  (requested version 1.89.0) with any of the following names:

    boost_systemConfig.cmake
    boost_system-config.cmake

  Add the installation prefix of "boost_system" to CMAKE_PREFIX_PATH or set
  "boost_system_DIR" to a directory containing one of the above files.  If
  "boost_system" provides a separate development package or SDK, be sure it
  has been installed.
```

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

Redundancy in the build system and build breakage in the current boost release.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

Following boost recommendation: Removing the redundant library.

#### Risks (if any) associated the changes in the commit

This assumes that XRT is only built with versions 1.69 of boost or higher. If versions below 1.69 must be supported, the find command will need to list system as optional dependency (As seen in the official documentation).

#### What has been tested and how, request additional testing if necessary

Tested building with boost 1.89. It should still build with all boost version since 2018, but the CI should maybe test it.

#### Documentation impact (if any)
