### PR TITLE
Disable Git meta data for upstream builds

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -59,6 +59,7 @@ usage()
     echo "[-hip]                      Enable hip bindings"
     echo "[-disable-werror]           Disable compilation with warnings as error"
     echo "[-nocmake]                  Skip CMake call"
+    echo "[-cmake-flags <flags>]      Extra flags to pass to CMake"
     echo "[-noert]                    Do not treat missing ERT FW as a build error"
     echo "[-noinit]                   Do not initialize Git submodules"
     echo "[-noctest]                  Skip unit tests"
@@ -180,6 +181,11 @@ while [ $# -gt 0 ]; do
         -opt)
             dbg=0
             opt=1
+            shift
+            ;;
+        -cmake-flags)
+            shift
+            cmake_flags+=" $1"
             shift
             ;;
         -nocmake)

--- a/src/CMake/version.cmake
+++ b/src/CMake/version.cmake
@@ -14,9 +14,11 @@ set(XRT_VERSION_CMAKE_INCLUDED TRUE CACHE INTERNAL "XRT version cmake included")
 # repository.  The build cannot query git for git metadata.  The
 # promotion build has explicitly overwritten config/version.h.in and
 # config/version.json.in with pre-generated ones.
-if (DEFINED ENV{DK_ROOT})
+if (DEFINED ENV{DK_ROOT} OR XRT_UPSTREAM)
 
-message("-- Skipping Git metadata")
+  message("-- Skipping Git metadata")
+  set (XRT_HEAD_COMMITS 0)
+  set (XRT_BRANCH_COMMITS 0)
 
 else (DEFINED ENV{DK_ROOT})
 
@@ -79,17 +81,20 @@ execute_process(
 )
 string(REPLACE "\n" "," XRT_MODIFIED_FILES "${XRT_MODIFIED_FILES}")
 
-endif(DEFINED ENV{DK_ROOT})
+endif(DEFINED ENV{DK_ROOT} OR XRT_UPSTREAM)
 
-# Get the build date RFC format
-execute_process(
-  COMMAND date -R
-  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-  OUTPUT_VARIABLE XRT_DATE_RFC
-  OUTPUT_STRIP_TRAILING_WHITESPACE
-)
+# Upstream builds must be reproducilble.
+if (NOT XRT_UPSTREAM)
+  # Get the build date RFC format
+  execute_process(
+    COMMAND date -R
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+    OUTPUT_VARIABLE XRT_DATE_RFC
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
 
-string(TIMESTAMP XRT_DATE "%Y-%m-%d %H:%M:%S")
+  string(TIMESTAMP XRT_DATE "%Y-%m-%d %H:%M:%S")
+endif()
 
 configure_file(
   ${XRT_SOURCE_DIR}/CMake/config/version-slim.h.in

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -758,9 +758,15 @@ fill_xrt_versions(const boost::property_tree::ptree& pt_xrt,
 {
   boost::property_tree::ptree empty_ptree;
   output << boost::format("  %-20s : %s\n") % "Version" % pt_xrt.get<std::string>("version", "N/A");
-  output << boost::format("  %-20s : %s\n") % "Branch" % pt_xrt.get<std::string>("branch", "N/A");
-  output << boost::format("  %-20s : %s\n") % "Hash" % pt_xrt.get<std::string>("hash", "N/A");
-  output << boost::format("  %-20s : %s\n") % "Hash Date" % pt_xrt.get<std::string>("build_date", "N/A");
+  auto branch = pt_xrt.get<std::string>("branch", "N/A");
+  auto hash = pt_xrt.get<std::string>("hash", "N/A");
+  auto build_date = pt_xrt.get<std::string>("build_date", "N/A");
+  if (!branch.empty() && !boost::iequals(branch, "N/A"))
+    output << boost::format("  %-20s : %s\n") % "Branch" % branch;
+  if (!hash.empty() && !boost::iequals(hash, "N/A"))
+    output << boost::format("  %-20s : %s\n") % "Hash" % hash;
+  if (!build_date.empty() && !boost::iequals(build_date, "N/A"))
+    output << boost::format("  %-20s : %s\n") % "Hash Date" % build_date;
   const boost::property_tree::ptree& available_drivers = pt_xrt.get_child("drivers", empty_ptree);
   for(auto& drv : available_drivers) {
     const boost::property_tree::ptree& driver = drv.second;
@@ -769,7 +775,8 @@ fill_xrt_versions(const boost::property_tree::ptree& pt_xrt,
     if (!boost::iequals(drv_hash, "N/A")) {
       output << boost::format("  %-20s : %s, %s\n") % drv_name
           % driver.get<std::string>("version", "N/A") % driver.get<std::string>("hash", "N/A");
-    } else {
+    }
+    else {
       std::string drv_version = boost::iequals(drv_name, "N/A") ? drv_name : drv_name.append(" Version");
       output << boost::format("  %-20s : %s\n") % drv_version % driver.get<std::string>("version", "N/A");
     }
@@ -785,13 +792,13 @@ fill_xrt_versions(const boost::property_tree::ptree& pt_xrt,
       if (fw_ver != "N/A")
         output << boost::format("  %-20s : %s\n") % "NPU Firmware Version" % fw_ver;
 
-      const std::string uc_fw_version = dev.get<std::string>("uc_firmware.version", "N/A");
-      const std::string build_date    = dev.get<std::string>("uc_firmware.build_date", "N/A");
+      auto uc_fw_version = dev.get<std::string>("uc_firmware.version", "N/A");
+      auto uc_fw_build_date    = dev.get<std::string>("uc_firmware.build_date", "N/A");
 
       if (uc_fw_version != "N/A")
         output << boost::format("  %-20s : %s\n") % "UC Firmware Version" % uc_fw_version;
       if (build_date != "N/A")
-        output << boost::format("  %-20s : %s\n") % "UC Build Date" % build_date;
+        output << boost::format("  %-20s : %s\n") % "UC Build Date" % uc_fw_build_date;
     }
     else
       output << boost::format("  %-20s : %s\n") % "Firmware Version" % fw_ver;


### PR DESCRIPTION
Adjust xrt-smi XRT info to handle unavailable meta data.

