### PR TITLE
Add HIP cross compilation support

### DIFF
--- a/src/runtime_src/hip/hip_config.cmake
+++ b/src/runtime_src/hip/hip_config.cmake
@@ -2,15 +2,15 @@
 # Copyright (C) 2024 - 2025 Advanced Micro Devices, Inc. All rights reserved.
 
 message("-- Looking for HIP include files...")
-if(NOT WIN32)
+if (NOT WIN32)
   # Determine library architecture for Debian/Ubuntu multiarch systems
   # (x86_64-linux-gnu, aarch64-linux-gnu)
   # CMAKE_LIBRARY_ARCHITECTURE is automatically set by CMake on Debian/Ubuntu
   # For other distros or incomplete toolchains, provide a reasonable fallback
-  if(NOT CMAKE_LIBRARY_ARCHITECTURE)
-    if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64|ARM64")
+  if (NOT CMAKE_LIBRARY_ARCHITECTURE)
+    if (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64|ARM64")
       set(CMAKE_LIBRARY_ARCHITECTURE "aarch64-linux-gnu")
-    elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "arm")
+    elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "arm")
       set(CMAKE_LIBRARY_ARCHITECTURE "arm-linux-gnueabihf")
     else()
       set(CMAKE_LIBRARY_ARCHITECTURE "x86_64-linux-gnu")
@@ -90,6 +90,13 @@ else()
     "C:/Program Files/AMD/ROCm/6.2/lib/cmake/hip"
     "C:/Program Files/AMD/ROCm/6.1/lib/cmake/hip"
     "C:/Program Files/AMD/ROCm/5.7/lib/cmake/hip"
+  )
+  # hip-config itself requires these other directories to find its dependencies
+  list(APPEND CMAKE_PREFIX_PATH
+    $ENV{HIP_DIR}
+    "C:/Program Files/AMD/ROCm/6.2"
+    "C:/Program Files/AMD/ROCm/6.1"
+    "C:/Program Files/AMD/ROCm/5.7"
   )
 endif()
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Added HIP cross compilation support, this is done as part of making HIP work on Telluride

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
This is an enhancement

#### How problem was solved, alternative solutions (if any) and why they were rejected
When CMAKE_CROSSCOMPILING flag is set, HIP config files are searched inside sysroot rather than host directories

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
Tested the build for Telluride by copying hip related files into telluride sysroot as HIP support is not available on arm and things work as expected. Able to successfully generate  libxrt_hip.so for arm

#### Documentation impact (if any)
NA