### PR TITLE
aie_coredump query arg change

### DIFF
--- a/src/runtime_src/core/common/api/xrt_hw_context.cpp
+++ b/src/runtime_src/core/common/api/xrt_hw_context.cpp
@@ -503,7 +503,7 @@ public:
     try {
       xrt_core::query::aie_coredump::args args{};
       args.pid = static_cast<uint64_t>(xrt_core::utils::get_pid());
-      args.context_id = m_hdl->get_slotidx();
+      args.context_id = static_cast<uint32_t>(m_hdl->get_slotidx());
       return xrt_core::device_query<xrt_core::query::aie_coredump>(m_core_device, args);
     }
     catch (const xrt_core::query::no_such_key&) {

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -4244,7 +4244,7 @@ struct aie_coredump : request
 {
   struct args {
     uint64_t  pid;
-    uint16_t  context_id;
+    uint32_t  context_id;
   };
 
   using result_type = std::vector<char>;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
aie_coredump query arg change
encapsulated individual 2 args to aie_coredump::args

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
