### PR TITLE
[XRT-SMI] Event trace update for header footer addition

### DIFF
--- a/src/runtime_src/core/tools/xbutil2/EventTracing/EventTraceStrix.h
+++ b/src/runtime_src/core/tools/xbutil2/EventTracing/EventTraceStrix.h
@@ -108,6 +108,26 @@ public:
   }
 
   /**
+   * @brief Get the entry header size
+   * @return Entry header size in bytes
+   */
+  size_t 
+  get_entry_header_size() const 
+  { 
+    return m_entry_header_size; 
+  }
+
+  /**
+   * @brief Get the entry footer size
+   * @return Entry footer size in bytes
+   */
+  size_t 
+  get_entry_footer_size() const 
+  { 
+    return m_entry_footer_size; 
+  }
+
+  /**
    * @brief Parse single event from buffer at runtime using config sizes
    * @param buffer_ptr Pointer to event data in buffer
    */
@@ -129,7 +149,13 @@ private:
   uint32_t 
   parse_payload_bits();
 
-
+  /**
+   * @brief Parse structure size from JSON structures section
+   * @param struct_name Name of structure to get size for
+   * @return Size in bytes, or 0 if not found
+   */
+  size_t
+  parse_structure_size(const std::string& struct_name);
 
   /**
    * @brief Parse arg_sets section from JSON (optional)
@@ -226,6 +252,8 @@ private:
   uint32_t m_payload_bits;                                   // Payload bit width
   std::map<std::string, std::vector<event_arg_strix>> m_arg_templates;  // Argument set definitions
   std::map<uint16_t, event_info_strix> m_event_map;               // Event ID -> info
+  size_t m_entry_header_size;                                // Entry header size in bytes
+  size_t m_entry_footer_size;                                // Entry footer size in bytes
 };
 
 /**


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
This PR updates the event trace logging to parse the new header and footer payloads added with each message by firmware in the latest release. This PR simply parses the newly added structures to read the size of header and footers and uses the size to parse each message by skipping header and footer bits. The current implementation does not use the header and footer which contains sequence number and magic number which are designed to achieve robust corruption detection in userspace. This will come as a future change commonly for both strix and npu3

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://jira.xilinx.com/browse/AIESW-18935

#### How problem was solved, alternative solutions (if any) and why they were rejected
Solved via handling based on latest firmware release

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Tested on Linux with a local build bundled with latest firmware release. Note, both windows and linux drivers are not yet released with latest firmwares and they should update to this XRT commit once the firmware is updated.
Output on linux : 
```
59606326536          PROCESS_APP_MSG_DONE      MAILBOX|NPU_SCHEDULING    context_id=15, msg_opcode=IPU_MSG_EXEC_NPU_CMD_CHAIN, virt_ctx=0
59606923784          PROCESS_APP_MSG_START     MAILBOX|NPU_SCHEDULING    context_id=15, msg_opcode=IPU_MSG_EXEC_NPU_CMD_CHAIN, virt_ctx=0
59642104313          PROCESS_APP_MSG_DONE      MAILBOX|NPU_SCHEDULING    context_id=15, msg_opcode=IPU_MSG_EXEC_NPU_CMD_CHAIN, virt_ctx=0
59642778519          PROCESS_APP_MSG_START     MAILBOX|NPU_SCHEDULING    context_id=15, msg_opcode=IPU_MSG_EXEC_NPU_CMD_CHAIN, virt_ctx=0
59678903128          PROCESS_APP_MSG_DONE      MAILBOX|NPU_SCHEDULING    context_id=15, msg_opcode=IPU_MSG_EXEC_NPU_CMD_CHAIN, virt_ctx=0
59679774458          PROCESS_APP_MSG_START     MAILBOX|NPU_SCHEDULING    context_id=15, msg_opcode=IPU_MSG_EXEC_NPU_CMD_CHAIN, virt_ctx=0
59716206607          PROCESS_APP_MSG_DONE      MAILBOX|NPU_SCHEDULING    context_id=15, msg_opcode=IPU_MSG_EXEC_NPU_CMD_CHAIN, virt_ctx=0
59717153520          PROCESS_APP_MSG_START     MAILBOX|NPU_SCHEDULING    context_id=15, msg_opcode=IPU_MSG_EXEC_NPU_CMD_CHAIN, virt_ctx=0
59752366383          PROCESS_APP_MSG_DONE      MAILBOX|NPU_SCHEDULING    context_id=15, msg_opcode=IPU_MSG_EXEC_NPU_CMD_CHAIN, virt_ctx=0
59753422295          PROCESS_APP_MSG_START     MAILBOX|NPU_SCHEDULING    context_id=15, msg_opcode=IPU_MSG_EXEC_NPU_CMD_CHAIN, virt_ctx=0
59788813282          PROCESS_APP_MSG_DONE      MAILBOX|NPU_SCHEDULING    context_id=15, msg_opcode=IPU_MSG_EXEC_NPU_CMD_CHAIN, virt_ctx=0
59789758528          PROCESS_APP_MSG_START     MAILBOX|NPU_SCHEDULING    context_id=15, msg_opcode=IPU_MSG_EXEC_NPU_CMD_CHAIN, virt_ctx=0
59825697763          PROCESS_APP_MSG_DONE      MAILBOX|NPU_SCHEDULING    context_id=15, msg_opcode=IPU_MSG_EXEC_NPU_CMD_CHAIN, virt_ctx=0
59826516468          PROCESS_MGMT_MSG_START    MAILBOX                   msg_opcode=IPU_MSG_DELETE_CONTEXT
59826563176          DELETE_CONTEXT            MAILBOX|NPU_SCHEDULING    context_id=15, status=0, virt_ctx=0
59826565134          PROCESS_MGMT_MSG_DONE     MAILBOX                   msg_opcode=IPU_MSG_DELETE_CONTEXT
```

#### Documentation impact (if any)
None
