### PR TITLE
fix Linux kernel version check condition

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ulite.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ulite.c
@@ -286,7 +286,7 @@ static int ulite_thread(void *data)
 
 	while (atomic_read(&pdata->console_opened) && !kthread_should_stop()) {
 		ulite_worker(port);
-		/* 115200bps / 9bits * 2 sampling rate 
+		/* 115200bps / 9bits * 2 sampling rate
 		 * 25600Hz, we should sleep less than 40us
 		 */
 		usleep_range(30, 40);
@@ -382,7 +382,7 @@ static void ulite_shutdown(struct uart_port *port)
 	mutex_unlock(&pdata->lock);
 }
 
-#if (LINUX_VERSION_CODE > KERNEL_VERSION(6, 1, 0)) || defined(RHEL_9_2_GE)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)) || defined(RHEL_9_2_GE)
 static void ulite_set_termios(struct uart_port *port, struct ktermios *termios,
 			      const struct ktermios *old)
 #else
@@ -549,7 +549,7 @@ static int ulite_probe(struct platform_device *pdev)
 	for (id = 0; id < ULITE_NR_UARTS; id++)
 		if (ulite_ports[id].mapbase == 0)
 			break;
-	
+
 	if (id >= ULITE_NR_UARTS) {
 		dev_err(&pdev->dev, "%s%i too large\n", ULITE_NAME, id);
 		ret = -EINVAL;


### PR DESCRIPTION
1. set Linux kernel version check condition to greater or equal, instead of greater only, thus fixing compile error when building against Linux-6.1.0, and
2. remove trailing space

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
