### PR TITLE
fix: Remove boost system dependencies 

### DIFF
--- a/src/runtime_src/core/pcie/emulation/hw_emu/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/emulation/hw_emu/CMakeLists.txt
@@ -47,7 +47,6 @@ set_target_properties(xrt_hwemu_static PROPERTIES OUTPUT_NAME "xrt_hwemu")
 
 target_link_libraries(xrt_hwemu
   PRIVATE
-  ${Boost_SYSTEM_LIBRARY}
   ${PROTOBUF_LIBRARY}
   xrt_coreutil
   common_em
@@ -57,7 +56,6 @@ target_link_libraries(xrt_hwemu
 
 target_link_libraries(xrt_hwemu_static
   INTERFACE
-  boost_system
   ${PROTOBUF_LIBRARY}
   xrt_coreutil_static
   rt

--- a/src/runtime_src/core/tools/xbmgmt2/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbmgmt2/CMakeLists.txt
@@ -74,11 +74,10 @@ if (XRT_STATIC_BUILD)
   target_link_options(${XBMGMT2_NAME}_static PRIVATE "-static" "-L${Boost_LIBRARY_DIRS}")
   target_compile_definitions(${XBMGMT2_NAME}_static PRIVATE ENABLE_NATIVE_SUBCMDS_AND_REPORTS)
   # Bypass FindBoost versions and just link explicitly with boost libraries
-  # The -static link option will pick the static libraries. 
+  # The -static link option will pick the static libraries.
   target_link_libraries(${XBMGMT2_NAME}_static
     PRIVATE
     xrt_coreutil_static
-    boost_system
     boost_program_options
     -Wl,--whole-archive rt pthread -Wl,--no-whole-archive
     uuid
@@ -93,10 +92,9 @@ target_link_libraries(${XBMGMT2_NAME}
   PRIVATE
   xrt_coreutil
   ${Boost_FILESYSTEM_LIBRARY}
-  ${Boost_SYSTEM_LIBRARY}
   ${Boost_PROGRAM_OPTIONS_LIBRARY}
   )
-  
+
 # Add the supporting libraries
 if(WIN32)
   target_link_libraries(${XBMGMT2_NAME} PRIVATE ws2_32)

--- a/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
@@ -59,7 +59,7 @@ add_subdirectory(FirmwareLogging)
 # Merge the files into one collection
 set(XBUTIL_V2_SRCS ${XBUTIL_V2_BASE_FILES} ${XBUTIL_V2_SUBCMD_FILES})
 
-set(XBUTIL2_NAME "xrt-smi") 
+set(XBUTIL2_NAME "xrt-smi")
 # Determine any helper scripts
 if(WIN32)
   set(XRT_HELPER_SCRIPTS "xrt-smi" "xrt-smi.bat")
@@ -87,7 +87,6 @@ if (XRT_STATIC_BUILD)
   target_link_libraries(${XBUTIL2_NAME}_static
     PRIVATE
     xrt_coreutil_static
-    boost_system
     boost_program_options
     -Wl,--whole-archive rt pthread -Wl,--no-whole-archive
     uuid
@@ -102,7 +101,6 @@ target_link_libraries(${XBUTIL2_NAME}
   PRIVATE
   xrt_coreutil
   ${Boost_FILESYSTEM_LIBRARY}
-  ${Boost_SYSTEM_LIBRARY}
   ${Boost_PROGRAM_OPTIONS_LIBRARY}
   )
 


### PR DESCRIPTION
Since it's a deprecated empty shim that was removed in newer boost packaging.

#### Problem solved by the commit
Current master doesn't build on Arch linux and latest kernel because of the Boost System dependency package in CMake.
Boost system is an empty package, there's no sources or headers in it and it's only present for a small period so it doesn't break legacy code depending on it. Many rolling release distributions have removed it so it doesn't build if you rely on it.  

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
I haven't created an issue for it, but will do if required.

#### How problem was solved, alternative solutions (if any) and why they were rejected
I've remove the dependency since it was useless anyway.

#### Risks (if any) associated the changes in the commit
On very very old system, where Boost System was not empty, this could break. However, it's unlikely such system would build the current driver due to their aging kernel.

#### What has been tested and how, request additional testing if necessary
It fixes a build issue, no actual code was modified, so it's unlikely to break the driver features

#### Documentation impact (if any)
