### PR TITLE
[XRT-SMI] Cmd-chain test rename

### DIFF
--- a/src/runtime_src/core/tools/common/tests/TestRunlistLatency.h
+++ b/src/runtime_src/core/tools/common/tests/TestRunlistLatency.h
@@ -1,19 +1,19 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2024-2025 Advanced Micro Devices, Inc. All rights reserved.
 
-#ifndef TestCmdChainLatency_h_
-#define TestCmdChainLatency_h_
+#ifndef TestRunlistLatency_h_
+#define TestRunlistLatency_h_
 
 #include "tools/common/TestRunner.h"
 #include "xrt/xrt_device.h"
 
-class TestCmdChainLatency : public TestRunner {
+class TestRunlistLatency : public TestRunner {
   public:
     boost::property_tree::ptree run(const std::shared_ptr<xrt_core::device>&) override;
     boost::property_tree::ptree run(const std::shared_ptr<xrt_core::device>&, const xrt_core::archive*) override;
 
   public:
-    TestCmdChainLatency();
+    TestRunlistLatency();
 };
 
 #endif

--- a/src/runtime_src/core/tools/common/tests/TestRunlistThroughput.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestRunlistThroughput.cpp
@@ -3,7 +3,7 @@
 
 // ------ I N C L U D E   F I L E S -------------------------------------------
 // Local - Include Files
-#include "TestCmdChainLatency.h"
+#include "TestRunlistThroughput.h"
 #include "TestValidateUtilities.h"
 #include "tools/common/XBUtilities.h"
 #include "xrt/xrt_device.h"
@@ -12,22 +12,20 @@
 #include "core/common/archive.h"
 namespace XBU = XBUtilities;
 
-#include <filesystem>
-
 // ----- C L A S S   M E T H O D S -------------------------------------------
-TestCmdChainLatency::TestCmdChainLatency()
-  : TestRunner("cmd-chain-latency", "Run end-to-end latency test using command chaining")
+TestRunlistThroughput::TestRunlistThroughput()
+  : TestRunner("runlist-throughput", "Run end-to-end throughput test using runlist")
 {}
 
 boost::property_tree::ptree
-TestCmdChainLatency::run(const std::shared_ptr<xrt_core::device>&)
+TestRunlistThroughput::run(const std::shared_ptr<xrt_core::device>&)
 {
   boost::property_tree::ptree ptree = get_test_header();
   return ptree;
 }
 
 boost::property_tree::ptree
-TestCmdChainLatency::run(const std::shared_ptr<xrt_core::device>& dev, const xrt_core::archive* archive)
+TestRunlistThroughput::run(const std::shared_ptr<xrt_core::device>& dev, const xrt_core::archive* archive)
 {
   boost::property_tree::ptree ptree = get_test_header();
 
@@ -36,24 +34,24 @@ TestCmdChainLatency::run(const std::shared_ptr<xrt_core::device>& dev, const xrt
     XBValidateUtils::logger(ptree, "Error", "No archive found, skipping test");
     return ptree;
   }
-  
+
   try {
-    std::string recipe_data = archive->data("recipe_cmd_chain_latency.json");
-    std::string profile_data = archive->data("profile_cmd_chain_latency.json"); 
+    std::string recipe_data = archive->data("recipe_cmd_chain_throughput.json");
+    std::string profile_data = archive->data("profile_cmd_chain_throughput.json"); 
     
     // Extract artifacts using helper method
     auto artifacts_repo = XBU::extract_artifacts_from_archive(archive, {
       "validate.xclbin", 
-      "nop.elf"
+      "nop.elf" 
     });    // Create runner with recipe, profile, and artifacts repository
     xrt_core::runner runner(xrt::device(dev), recipe_data, profile_data, artifacts_repo);
     runner.execute();
     runner.wait();
 
     auto report = nlohmann::json::parse(runner.get_report());
-    auto latency = report["cpu"]["latency"].get<double>();
+    auto throughput = report["cpu"]["throughput"].get<double>();
 
-    XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Average latency: %.1f us") % latency));
+    XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Average throughput: %.1f ops/s") % throughput));
     ptree.put("status", XBValidateUtils::test_token_passed);
   }
   catch (const std::exception& ex) {

--- a/src/runtime_src/core/tools/common/tests/TestRunlistThroughput.h
+++ b/src/runtime_src/core/tools/common/tests/TestRunlistThroughput.h
@@ -1,19 +1,19 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2024-2025 Advanced Micro Devices, Inc. All rights reserved.
 
-#ifndef TestCmdChainThroughput_h_
-#define TestCmdChainThroughput_h_
+#ifndef TestRunlistThroughput_h_
+#define TestRunlistThroughput_h_
 
 #include "tools/common/TestRunner.h"
 #include "xrt/xrt_device.h"
 
-class TestCmdChainThroughput : public TestRunner {
+class TestRunlistThroughput : public TestRunner {
   public:
     boost::property_tree::ptree run(const std::shared_ptr<xrt_core::device>&) override;
     boost::property_tree::ptree run(const std::shared_ptr<xrt_core::device>&, const xrt_core::archive*) override;
 
   public:
-    TestCmdChainThroughput();
+    TestRunlistThroughput();
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -36,8 +36,8 @@
 #include "tools/common/tests/TestGemm.h"
 #include "tools/common/tests/TestNPUThroughput.h"
 #include "tools/common/tests/TestNPULatency.h"
-#include "tools/common/tests/TestCmdChainLatency.h"
-#include "tools/common/tests/TestCmdChainThroughput.h"
+#include "tools/common/tests/TestRunlistLatency.h"
+#include "tools/common/tests/TestRunlistThroughput.h"
 #include "tools/common/tests/TestAIEReconfigOverhead.h"
 #include "tools/common/tests/TestTemporalSharingOvd.h"
 #include "tools/common/tests/TestPreemptionOverhead.h"
@@ -114,8 +114,8 @@ std::vector<std::shared_ptr<TestRunner>> testSuite = {
   std::make_shared<TestGemm>(),
   std::make_shared<TestNPUThroughput>(),
   std::make_shared<TestNPULatency>(),
-  std::make_shared<TestCmdChainLatency>(),
-  std::make_shared<TestCmdChainThroughput>(),
+  std::make_shared<TestRunlistLatency>(),
+  std::make_shared<TestRunlistThroughput>(),
   std::make_shared<TestAIEReconfigOverhead>(),
   std::make_shared<TestTemporalSharingOvd>(),
   std::make_shared<TestPreemptionOverhead>(),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
This test renames the command chain latency test to runlist latency and throughput since that more accurately describes what is being tested

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
None

#### How problem was solved, alternative solutions (if any) and why they were rejected
Solved via renaming. This will require name changes in the driver code as well when the xrt submodule is updated

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
None

#### Documentation impact (if any)
None
