### PR TITLE
Adding OOB checks in the xclbin_parser

### DIFF
--- a/src/runtime_src/core/tools/common/xball
+++ b/src/runtime_src/core/tools/common/xball
@@ -148,6 +148,8 @@ exit $python_exit_code
 import json
 import os
 import re
+import subprocess
+import shlex
 import sys
 
 temp_python_status = sys.argv[1]
@@ -198,11 +200,17 @@ for device in working_devices:
   print("\n")
   print("=====================================================================")
   print("%d / %d [%s] : %s" % (device_count, len(working_devices), device["bdf"], device["vbnv"]))
-  cmd = xrt_bin_dir + "/" + xrt_app + " --device " + device["bdf"] + " " + prog_args
+  cmd_list = [os.path.join(xrt_bin_dir, xrt_app), "--device", device["bdf"]]
+  if prog_args:
+    cmd_list.extend(shlex.split(prog_args))
   print("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
-  print("Command: %s\n" % cmd)
-  exit_code = os.system(cmd)
-
+  print("Command: %s\n" % " ".join(shlex.quote(a) for a in cmd_list))
+  try:
+    exit_code = subprocess.run(cmd_list).returncode
+  except OSError as e:
+    print("Error: %s" % e)
+    exit_code = 1
+ 
   if exit_code == 0:
     print("\nCommand Return Value: 0 [Operation successful]");
     passed_devices += 1


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://amd.atlassian.net/wiki/spaces/~saifuddi/pages/1407497203/XRT+UserSpace+Bug+Bounty
SWSPLAT-9168: OOB read in xclbin SOFT_KERNEL parsing via unvalidated mpo_* offsets, crafted xclbins could cause crash or info leak.
SWSPLAT-9114 / 9170 / 9154: OOB read and integer overflow in AIE_PARTITION parsing (get_aie_partition), file-controlled offsets/sizes used without bounds checks, leading to crash or metadata corruption.

SWSPLAT-9150: Use-after-free and OOB read in xclbinutil SectionAIEResourcesBin (init, copyBufferUpdateMetadata, writeObjImage, writeMetadata) when processing malformed AIE_RESOURCES_BIN sections.

SWSPLAT-9110: Command injection in xball via prog_args concatenated into a shell command passed to os.system().

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added section bounds checks and overflow checks and use strnlen for all string fields from section data.
Added offset/size validation and bounded string reads and store subsection names by value to avoid UAF
Run command via subprocess.run(cmd_list) with shlex.split(prog_args) instead of os.system(cmd).

#### Risks (if any) associated the changes in the commit
low

#### What has been tested and how, request additional testing if necessary
Tested by building XRT package on ubuntu 22.04

#### Documentation impact (if any)
