### PR TITLE
Update gemm test to use current max clock instead of absolute max clock

### DIFF
--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -1222,7 +1222,8 @@ struct xrt_resource_raw : request
     npu_tops_max,  // Max TOPs, query returns double value
     npu_task_max,  // Max Tasks, query returns uint64 value
     npu_tops_curr, // Current TOPs, query returns double value
-    npu_task_curr  // Current Tasks, query returns uint64 value
+    npu_task_curr,  // Current Tasks, query returns uint64 value
+    npu_curr_clk_max
   };
 
   /**
@@ -1256,6 +1257,8 @@ struct xrt_resource_raw : request
       return "Current TOPs";
     case resource_type::npu_task_curr:
       return "Current Tasks";
+    case resource_type::npu_curr_clk_max:
+      return "Current Max H-Clocks";
     default:
       throw xrt_core::internal_error("enum value does not exists");
     }

--- a/src/runtime_src/core/tools/common/tests/TestGemm.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestGemm.cpp
@@ -35,7 +35,7 @@ get_clock(const std::shared_ptr<xrt_core::device>& dev)
   uint64_t npu_hclock = 0;
   auto res_info = xrt_core::device_query_default<xrt_core::query::xrt_resource_raw>(dev, {});
   for (auto &res : res_info) {
-    if (res.type != xrt_core::query::xrt_resource_raw::resource_type::npu_clk_max)
+    if (res.type != xrt_core::query::xrt_resource_raw::resource_type::npu_curr_clk_max)
       continue;
     npu_hclock = res.data_uint64;
   } 

--- a/src/runtime_src/core/tools/common/tests/TestPreeemptionOverhead.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestPreeemptionOverhead.cpp
@@ -111,7 +111,7 @@ run_npu3(const std::shared_ptr<xrt_core::device>& dev, const xrt_core::archive* 
     });
 
     auto overhead_memtile_4x3 = measure_preemption_overhead(dev, recipe_4x3_memtile_data, profile_data, artifacts_repo);
-    XBU::logger(ptree, "Details", boost::str(boost::format("Average %s preemption overhead for 4x%d is %.1f us") % "memtile" % 3 % overhead_memtile_4x3));
+    XBU::logger(ptree, "Details", boost::str(boost::format("Average %s preemption overhead is %.1f us") % "memtile" % overhead_memtile_4x3));
   }
   catch(const std::exception& e) {
     XBValidateUtils::logger(ptree, "Error", e.what());


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
This PR updates the Gemm test to use npu_curr_clk_max for caluculating TOPS. 
npu_curr_clk_max is added in the driver to propagate the max clock value for current DPM level set by the driver. 
Currently, only max clock was used which cased xrt-smi to repot only the max tops value, whatever the DPM level set.
With this change, we can set different performance mode which running gemm test and see different TOPS.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
(https://jira.xilinx.com/browse/AIESW-10440)

#### How problem was solved, alternative solutions (if any) and why they were rejected
Solved by adding the updated field which reports max clock for current DPM set

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Tested on Windows platform with driver changes in place 
<img width="970" height="418" alt="image" src="https://github.com/user-attachments/assets/1bd6c246-bc0e-4816-8810-449bcdc07e4d" />


#### Documentation impact (if any)
None