### PR TITLE
Enable strong volatile ordering

### DIFF
--- a/src/CMake/nativeWin.cmake
+++ b/src/CMake/nativeWin.cmake
@@ -45,6 +45,7 @@ if (MSVC)
     /ZH:SHA_256   # enable secure source code hashing
     /guard:cf     # enable compiler control guard feature (CFG) to prevent attackers from redirecting execution to unsafe locations
     $<$<NOT:$<CONFIG:Debug>>:/GL>  # enable whole program optimization
+    /volatile:ms  # strong volatile ordering
     )
   add_link_options(
     /NODEFAULTLIB:libucrt$<$<CONFIG:Debug>:d>.lib  # Hybrid CRT


### PR DESCRIPTION
#### Problem solved by the commit
Enable strong volatile ordering

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
`/volatile:ms` switch enables Microsoft extended volatile semantics that guarantee strong ordering

#### How problem was solved, alternative solutions (if any) and why they were rejected
Could add as AdditionalOptions in vcxproj files

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Confirmed that the compile option is successfully set by building locally

#### Documentation impact (if any)
None