### PR TITLE
AIESW-26493 - uc log parser enhancement

### DIFF
--- a/src/runtime_src/core/common/api/xrt_hw_context.cpp
+++ b/src/runtime_src/core/common/api/xrt_hw_context.cpp
@@ -116,6 +116,7 @@ class hw_context_impl : public std::enable_shared_from_this<hw_context_impl>
       config.dump_interval_ms = dump_interval_ms;
       config.dump_file_prefix = "uc_log_" + std::to_string(ctx_hdl->get_slotidx());
       config.dump_buffer = std::move(bo);
+      config.dump_bin_format = xrt_core::config::get_uc_log_bin_format();
 
       return std::make_unique<xrt_core::buffer_dumper>(std::move(config));
     }

--- a/src/runtime_src/core/common/api/xrt_hw_context.cpp
+++ b/src/runtime_src/core/common/api/xrt_hw_context.cpp
@@ -82,7 +82,7 @@ class hw_context_impl : public std::enable_shared_from_this<hw_context_impl>
       // tweak dump interval, size_per_uc based on experiments
       constexpr size_t size_per_uc = 2_mb;
       constexpr size_t dump_interval_ms = 50;
-      constexpr size_t metadata_size = 32;
+      constexpr size_t metadata_size = sizeof(xrt_core::buffer_dumper::log_entry);
       constexpr size_t count_offset = 0;
       constexpr size_t count_size = 8;
 

--- a/src/runtime_src/core/common/buffer_dumper.cpp
+++ b/src/runtime_src/core/common/buffer_dumper.cpp
@@ -205,6 +205,10 @@ dump_chunk_data(size_t chunk_index, size_t start, size_t length, uint8_t* chunk)
       parsed_bytes += m_config.metadata_size;
     }
 
+    // Separator between dumper reads; the separator marks read boundaries and indicates
+    // log entries may have been lost at the boundary before the next read.
+    parsed_stream << "[0.000000000] [CERT] [Dumper]--------------[Separator]--------------\n";
+
     // Append parsed output to file
     fs.seekp(0, std::ios::end);
     fs << parsed_stream.str();
@@ -243,9 +247,9 @@ process_chunks_no_lock()
     size_t logged_wrap = logged_count / m_data_size;
     size_t dumped_wrap = dumped_count / m_data_size;
 
+    // Overwrite detected; catch up and resume dumping from current position.
     if (logged_count > dumped_count && logged_wrap > dumped_wrap)
-      throw std::runtime_error("Overwrite detected in chunk: " + std::to_string(i) +
-                               ", dump buffer corrupted.");
+      dumped_count = logged_count;
 
     if (dumped_count != logged_count) {
       size_t to_dump = logged_count - dumped_count;

--- a/src/runtime_src/core/common/buffer_dumper.cpp
+++ b/src/runtime_src/core/common/buffer_dumper.cpp
@@ -41,7 +41,7 @@ get_or_open_stream(size_t chunk_index)
 
   std::string filename = m_config.dump_file_prefix + "_" + m_session_timestamp + "_" +
                          std::to_string(xrt_core::utils::get_pid()) + "_" +
-                         std::to_string(chunk_index) + ".txt";
+                         std::to_string(chunk_index) + (m_config.dump_bin_format ? ".bin" : ".txt");
 
   fs.open(filename, std::ios::out | std::ios::binary);
   if (!fs.is_open())
@@ -88,12 +88,62 @@ dump_chunk_data(size_t chunk_index, size_t start, size_t length, uint8_t* chunk)
                              " is in bad state before write");
   }
 
+  // Calculate start offset and bytes to end for circular buffer wrapping
+  const size_t start_offset = (start % m_data_size) + m_config.metadata_size;
+  const size_t bytes_to_end = m_config.chunk_size - start_offset;
+
+  // UC log dump in binary format
+  if (m_config.dump_bin_format) {
+    // Always write/update metadata since this function is called when there's new data
+    // and metadata(count) gets updated when there is new data
+    // Seek to beginning and write/update metadata
+    fs.seekp(0);
+    fs.write(reinterpret_cast<const char*>(chunk),
+            static_cast<std::streamsize>(m_config.metadata_size));
+
+    if (!fs)
+      throw std::runtime_error("Failed to write metadata for chunk " + std::to_string(chunk_index));
+
+    // Seek to end to append actual data
+    fs.seekp(0, std::ios::end);
+
+    if (length <= bytes_to_end) { // data doesn't wrap around
+      fs.write(reinterpret_cast<const char*>(chunk + start_offset),
+              static_cast<std::streamsize>(length));
+
+      if (!fs)
+        throw std::runtime_error("Failed to write " + std::to_string(length) +
+                                " bytes to chunk " + std::to_string(chunk_index));
+    }
+    else {
+      // data wraps around
+      // write the first part
+      fs.write(reinterpret_cast<const char*>(chunk + start_offset),
+              static_cast<std::streamsize>(bytes_to_end));
+
+      if (!fs)
+        throw std::runtime_error("Failed to write first part (" + std::to_string(bytes_to_end) +
+                                " bytes) to chunk " + std::to_string(chunk_index));
+
+      // write the wrapped part
+      fs.write(reinterpret_cast<const char*>(chunk + m_config.metadata_size),
+              static_cast<std::streamsize>(length - bytes_to_end));
+
+      if (!fs)
+        throw std::runtime_error("Failed to write wrapped part (" +
+                                std::to_string(length - bytes_to_end) +
+                                " bytes) to chunk " + std::to_string(chunk_index));
+    }
+
+    fs.flush();
+    if (!fs)
+      throw std::runtime_error("Failed to flush chunk " + std::to_string(chunk_index));
+
+    return;
+  }
+
   // UC log parsing and writing log messages to file using log schema
   try {
-    // Parse log entries from the chunk using log schema
-    const size_t start_offset = (start % m_data_size) + m_config.metadata_size;
-    const size_t bytes_to_end = m_config.chunk_size - start_offset;
-
     std::ostringstream parsed_stream;
     size_t parsed_bytes = 0;
     // Iterate and parse each log entry in dumped data

--- a/src/runtime_src/core/common/buffer_dumper.cpp
+++ b/src/runtime_src/core/common/buffer_dumper.cpp
@@ -115,9 +115,9 @@ dump_chunk_data(size_t chunk_index, size_t start, size_t length, uint8_t* chunk)
       // Format log message using log schema
       // If log_id is not found in log schema, use default format string
       constexpr std::array<const char*, 3> default_formats = {
-        "unknown !",
-        "unknown %d !!",
-        "unknown %d unknown %d !!!"
+        "unknown !\n",
+        "unknown %d !!\n",
+        "unknown %d unknown %d !!!\n"
       };
       auto log_schema_it = uc_log_schema.logs.find(log.log_id);
       const char* log_format = (log_schema_it != uc_log_schema.logs.end())

--- a/src/runtime_src/core/common/buffer_dumper.cpp
+++ b/src/runtime_src/core/common/buffer_dumper.cpp
@@ -175,7 +175,10 @@ dump_chunk_data(size_t chunk_index, size_t start, size_t length, uint8_t* chunk)
         : default_formats[std::min(static_cast<std::size_t>(log.length - (offsetof(log_entry, argument1) / sizeof(uint32_t))),
                           (default_formats.size() - 1))];
 
-      parsed_stream << "[CERT] ";
+      // log marker [<seconds>.<nanoseconds>] [CERT]
+      uint64_t timestamp_ns = (static_cast<uint64_t>(log.ts_high) << 32) | log.ts_low; // NOLINT(cppcoreguidelines-avoid-magic-numbers)
+      parsed_stream << "[" << xrt_core::get_timestamp_for_uc_log(timestamp_ns) << "] [CERT] ";
+
       std::array<char, 1024> log_message{}; // NOLINT(cppcoreguidelines-avoid-magic-numbers)
       if (log.length == (offsetof(log_entry, argument1) / sizeof(uint32_t)))
       { // Log message without arguments

--- a/src/runtime_src/core/common/buffer_dumper.h
+++ b/src/runtime_src/core/common/buffer_dumper.h
@@ -44,6 +44,7 @@ public:
     size_t dump_interval_ms = 0;      // Polling interval in ms
     std::string dump_file_prefix;     // Output file prefix
     xrt::bo dump_buffer;              // xrt buffer object to dump
+    bool dump_bin_format = false;     // Dump in binary format when enabled
   };
 
   // Log entry struct for uc log binary format

--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -1152,6 +1152,13 @@ get_uc_log()
   return value;
 }
 
+inline bool
+get_uc_log_bin_format()
+{
+  static bool value = detail::get_bool_value("Debug.uc_log_bin_format", false);
+  return value;
+}
+
 }} // config,xrt_core
 
 #endif

--- a/src/runtime_src/core/common/time.cpp
+++ b/src/runtime_src/core/common/time.cpp
@@ -97,6 +97,22 @@ get_timestamp_for_filename()
   return time_stamp.str();
 }
 
+// returns uc log formatted timestamp "seconds.nanoseconds"
+std::string
+get_timestamp_for_uc_log(uint64_t epoch)
+{
+  constexpr uint64_t nanoseconds_per_second = 1000000000;
+  constexpr int nanoseconds_width = 9;
+
+  uint64_t seconds = epoch / nanoseconds_per_second;
+  uint64_t nanoseconds = epoch % nanoseconds_per_second;
+
+  std::stringstream time_stamp;
+  time_stamp << seconds << '.'
+             << std::setfill('0') << std::setw(nanoseconds_width) << nanoseconds;
+  return time_stamp.str();
+}
+
 ////////////////////////////////////////////////////////////////
 // systime implementation
 // Implmentation is platform specific, the pimpl is inline

--- a/src/runtime_src/core/common/time.cpp
+++ b/src/runtime_src/core/common/time.cpp
@@ -99,13 +99,13 @@ get_timestamp_for_filename()
 
 // returns uc log formatted timestamp "seconds.nanoseconds"
 std::string
-get_timestamp_for_uc_log(uint64_t epoch)
+get_timestamp_for_uc_log(uint64_t epoch_ns)
 {
   constexpr uint64_t nanoseconds_per_second = 1000000000;
   constexpr int nanoseconds_width = 9;
 
-  uint64_t seconds = epoch / nanoseconds_per_second;
-  uint64_t nanoseconds = epoch % nanoseconds_per_second;
+  uint64_t seconds = epoch_ns / nanoseconds_per_second;
+  uint64_t nanoseconds = epoch_ns % nanoseconds_per_second;
 
   std::stringstream time_stamp;
   time_stamp << seconds << '.'

--- a/src/runtime_src/core/common/time.h
+++ b/src/runtime_src/core/common/time.h
@@ -43,6 +43,13 @@ std::string
 get_timestamp_for_filename();
 
 /**
+ * @return uc log formatted timestamp "seconds.nanoseconds"
+ */
+XRT_CORE_COMMON_EXPORT
+std::string
+get_timestamp_for_uc_log(uint64_t epoch);
+
+/**
  * Simple time guard to accumulate scoped time
  */
 class time_guard

--- a/src/runtime_src/core/common/time.h
+++ b/src/runtime_src/core/common/time.h
@@ -43,11 +43,14 @@ std::string
 get_timestamp_for_filename();
 
 /**
+ * @brief get uc log formatted timestamp
+ * The input is expected to be a timestamp in nanoseconds
+ *
  * @return uc log formatted timestamp "seconds.nanoseconds"
  */
 XRT_CORE_COMMON_EXPORT
 std::string
-get_timestamp_for_uc_log(uint64_t epoch);
+get_timestamp_for_uc_log(uint64_t epoch_ns);
 
 /**
  * Simple time guard to accumulate scoped time

--- a/src/runtime_src/core/common/uc_log_schema.h
+++ b/src/runtime_src/core/common/uc_log_schema.h
@@ -7,7 +7,7 @@
 #include <map>
 #include <string>
 
-// UC Log Schema Version 0.25
+// UC Log Schema Version 0.26
 // This file defines UC log schema mappings for parsing binary log messages
 // from the firmware. It includes mappings for file IDs to filenames and
 // log IDs to format strings.
@@ -75,7 +75,7 @@ uc_log_schema = {
     {20, "OPCODE entering barrier (id: %d slot: %d)\n"},
     {21, "LB %u check-in\n"},
     {22, "LB %u release\n"},
-    {23, "patch address (r%d r%d) "},
+    {23, "patch address (r%d r%d)\n"},
     {24, "0x%x : 0x%x\n"},
     {25, "collect trace info at offset %d\n"},
     {26, "invalid trace control body address: 0x%x\n"},
@@ -100,7 +100,7 @@ uc_log_schema = {
     {45, "Page-in to slot %u length 0x%x\n"},
     {46, "Page-in to slot %u length 0x%x cur_save_level %d\n"},
     {47, "Partition: [%u, %u], self = %u\n"},
-    {48, "Log buffer: [0x%x 0x%x] "},
+    {48, "Log buffer: [0x%x 0x%x]\n"},
     {49, "size = 0x%x, id: %d\n"},
     {50, "tct %x fsl %x\n"},
     {51, "tct %x tlast = %x\n"},
@@ -123,17 +123,17 @@ uc_log_schema = {
     {68, "handle dbg queue...\n"},
     {69, "DBG queue packet opcode: %u\n"},
     {70, "do_dbg_rw\n"},
-    {71, "Page-in to slot %u page offset 0x%x "},
+    {71, "Page-in to slot %u page offset 0x%x\n"},
     {72, "cur_save_level 0x%x\n"},
-    {73, "[TIMESTAMP][ID] %d "},
+    {73, "[TIMESTAMP][ID] %d\n"},
     {74, "[HIGH] %d [LOW] %d\n"},
-    {75, "    job: %d state: %d "},
+    {75, "    job: %d state: %d\n"},
     {76, "pc: 0x%x\n"},
-    {77, "Page-in to slot %u length 0x%x "},
+    {77, "Page-in to slot %u length 0x%x\n"},
     {78, "cur_save_level %d\n"},
-    {79, "Exception!!\n\tESR: 0x%x EAR: 0x%x "},
+    {79, "Exception!!\n\tESR: 0x%x EAR: 0x%x\n"},
     {80, "PC: 0x%x\n"},
-    {81, "Partition: [%u, %u], "},
+    {81, "Partition: [%u, %u]\n"},
     {82, "self = %u\n"},
     {83, "Waken up after preempted?\n"},
     {84, "prefetch load last elf: %d ...\n"},
@@ -179,7 +179,9 @@ uc_log_schema = {
     {124, "Trigger miscellaneous interrupt\n"},
     {125, "Trigger common interrupt\n"},
     {126, "Skip %d cmds in runlist\n"},
-    {127, "\n"}
+    {127, "Leaving barrier: conditional job\n"},
+    {128, "break early same page same job\n"},
+    {129, "\n"}
   }
 };
 

--- a/src/runtime_src/core/common/uc_log_schema.h
+++ b/src/runtime_src/core/common/uc_log_schema.h
@@ -174,7 +174,12 @@ uc_log_schema = {
     {119, "q new read index high %d : low %d\n"},
     {120, "q old write index high %d : low %d\n"},
     {121, "q old read index high %d : low %d\n"},
-    {122, "\n"}
+    {122, "Trigger completion interrupt\n"},
+    {123, "Trigger idle interrupt\n"},
+    {124, "Trigger miscellaneous interrupt\n"},
+    {125, "Trigger common interrupt\n"},
+    {126, "Skip %d cmds in runlist\n"},
+    {127, "\n"}
   }
 };
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

Added `uc_log_bin_format` (bool, default false) to control uc log dump format. When false, logs are written as parsed .txt (default). When true, logs are written as raw .bin for use with an external parser.
Added timestamp to the uc log stream and updated uc log schema to the latest version

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

Added missing flexibility to add more temporary logs to firmware while debugging

#### How problem was solved, alternative solutions (if any) and why they were rejected

This is a feature enhancement over existing log buffer parsing

#### Risks (if any) associated the changes in the commit

Low, this applies only when uc log dump is enabled

#### What has been tested and how, request additional testing if necessary

Tested by dumping uc log on windows medusa board and the feature works as expected

#### Documentation impact (if any)

NA