### PR TITLE
Add APIs to get number of columns and uCs in HW Ctx

### DIFF
--- a/src/runtime_src/core/common/api/hw_context_int.h
+++ b/src/runtime_src/core/common/api/hw_context_int.h
@@ -53,8 +53,14 @@ get_elf(const xrt::hw_context& hwctx, const std::string& kname);
 
 // Get the partition size (number of columns).  May not be available
 // in xclbin mode.
+XRT_CORE_COMMON_EXPORT
 size_t
 get_partition_size(const xrt::hw_context&);
+
+// Get the number of controllers.
+XRT_CORE_COMMON_EXPORT
+size_t
+get_num_uc(const xrt::hw_context&);
 
 // get_elf_flow() - Returns true if hwctx was created with elf file/flow
 // Returns false everywhere else

--- a/src/runtime_src/core/common/api/xrt_hw_context.cpp
+++ b/src/runtime_src/core/common/api/xrt_hw_context.cpp
@@ -376,6 +376,15 @@ public:
     return m_partition_size;
   }
 
+  size_t
+  get_num_uc() const
+  {
+    if (!m_hdl) {
+      throw std::runtime_error("Hardware Context Handle is not yet created, so cannot get number of micro-controllers.");
+    }
+    return m_hdl->get_num_uc();
+  }
+
   xrt_core::hwctx_handle*
   get_hwctx_handle()
   {
@@ -556,6 +565,12 @@ size_t
 get_partition_size(const xrt::hw_context& ctx)
 {
   return ctx.get_handle()->get_partition_size();
+}
+
+size_t
+get_num_uc(const xrt::hw_context& ctx)
+{
+  return ctx.get_handle()->get_num_uc();
 }
 
 bool


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Add export APIs for Partition Size and Num of UCs in Hw Ctx. Currently XDP features use aie partition info and aie trace metadata, with some assumptions on order of hw ctx creation to get number of cols in a partition.
XDP features will use these APIs instead.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Currently XDP features use aie partition info and aie trace metadata, with some assumptions on order of hw ctx creation to get number of cols in a partition.
XDP features will use these APIs instead.

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Unit test
#### Documentation impact (if any)
