### PR TITLE
Build fix on windows after https://github.com/Xilinx/XRT/pull/9651 merge

### DIFF
--- a/src/python/pybind11/src/pyxrt.cpp
+++ b/src/python/pybind11/src/pyxrt.cpp
@@ -31,6 +31,10 @@
 // C++11 includes
 #include <string>
 
+#ifdef _MSC_VER
+#pragma warning(disable: 4996)  // C4996: deprecated function; Python binding delegates to C++
+#endif
+
 namespace py = pybind11;
 
 PYBIND11_MAKE_OPAQUE(std::vector<xrt::xclbin::ip>);
@@ -493,4 +497,7 @@ PYBIND11_MODULE(pyxrt, m) {
         }), "Wait for the specified timeout for the runlist to complete");
         
 }
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 

--- a/src/python/pybind11/src/pyxrt.cpp
+++ b/src/python/pybind11/src/pyxrt.cpp
@@ -497,7 +497,3 @@ PYBIND11_MODULE(pyxrt, m) {
         }), "Wait for the specified timeout for the runlist to complete");
         
 }
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
-


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
This PR fixes a build failure we are seeing on windows MCDM build after the merge of https://github.com/Xilinx/XRT/pull/9651 : 
```
"C:\Users\AKTONDAK\Repos\XRT-MCDM-FORK\XRT-MCDM\build\x64\ALL_BUILD.vcxproj" (default target) (1) ->
"C:\Users\AKTONDAK\Repos\XRT-MCDM-FORK\XRT-MCDM\build\x64\src\xrt\src\python\pybind11\pyxrt.vcxproj" (default target) (31) ->
(ClCompile target) ->
  C:\Users\AKTONDAK\Repos\XRT-MCDM-FORK\XRT-MCDM\src\xrt\src\python\pybind11\src\pyxrt.cpp(138,42): error C4996: 'xrt::device::load_xclbin': deprecated, please use hw_context() instead [C:\Users\AKTONDAK\Repos\XRT-MCDM-F 
ORK\XRT-MCDM\build\x64\src\xrt\src\python\pybind11\pyxrt.vcxproj]
  C:\Users\AKTONDAK\Repos\XRT-MCDM-FORK\XRT-MCDM\src\xrt\src\python\pybind11\src\pyxrt.cpp(142,42): error C4996: 'xrt::device::load_xclbin': deprecated, please use hw_context() instead [C:\Users\AKTONDAK\Repos\XRT-MCDM-F 
ORK\XRT-MCDM\build\x64\src\xrt\src\python\pybind11\pyxrt.vcxproj]
```
The code change suppresses the error/warning and simply calls the deprecated XRT API for the calling python API to handle error logging correctly.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
None

#### How problem was solved, alternative solutions (if any) and why they were rejected

1. As an alternative, we can implement the python binding's load_xclbin API but since pyxrt is designed to be a 1to1 mapping for all C++ APIs, its better to deprecate python API as well. 
2. We could've also explored adding deprecation to the python binding itself but for uniformity, its better for the same C++ handling to trigger when used.

#### Risks (if any) associated the changes in the commit
Existing python users might start seeing this warning but this is expected.

#### What has been tested and how, request additional testing if necessary
Not tested as this is only suppressing the build warning and the original deprecation is already merged

#### Documentation impact (if any)
None
