### PR TITLE
Undo AIE-only xclbin message

### DIFF
--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -1772,9 +1772,11 @@ public:
         xrt_core::hw_context_int::set_exclusive(hwctx);
     }
 
+#if 0
     // AIE-only xclbins now have IP_LAYOUT; reject early with a clear message
     if (auto axlf = xclbin.get_axlf(); axlf && xrt_core::xclbin::is_aie_only(axlf))
       throw xrt_core::error(ENOTSUP, "xrt::kernel cannot be opened for AIE-only xclbins.");
+#endif
 
     // Compare the matching CUs against the CU sort order to create cumask
     const auto& kernel_cus = xkernel.get_cus(nm);  // xrt::xclbin::ip objects for matching nm


### PR DESCRIPTION
#### Problem solved by the commit
Revert #9640 exception in kernel construction.
Blocks xclbins used by model-tests.

