### PR TITLE
Fix for AIESW-29256, AIESW-26642 and AIESW-29277

### DIFF
--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -3940,15 +3940,15 @@ struct performance_mode : request
   {
     switch(status) {
       case 0:
-        return "Default";
+        return "default";
       case 1:
-        return "Powersaver";
+        return "powersaver";
       case 2:
-        return "Balanced";
+        return "balanced";
       case 3:
-        return "Performance";
+        return "performance";
       case 4:
-        return "Turbo";
+        return "turbo";
       default:
         throw xrt_core::system_error(EINVAL, "Invalid performance status: " + std::to_string(status));
     }

--- a/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
@@ -89,9 +89,9 @@ SubCmdExamine::SubCmdExamine(bool _isHidden, bool _isDepricated, bool _isPrelimi
 
   // OptionOptions collection for examine-specific interactive functionality
   m_optionOptionsCollection = {
-    {std::make_shared<OO_FirmwareLogExamine>("firmware-log")}, //hidden
-    {std::make_shared<OO_EventTraceExamine>("event-trace")}, //hidden
-    {std::make_shared<OO_ContextHealth>("context-health")} //hidden
+    {std::make_shared<OO_FirmwareLogExamine>("firmware-log", true)}, //hidden
+    {std::make_shared<OO_EventTraceExamine>("event-trace", true)}, //hidden
+    {std::make_shared<OO_ContextHealth>("context-health", true)} //hidden
   };
 
   for (const auto& option : m_optionOptionsCollection){
@@ -147,7 +147,6 @@ SubCmdExamine::getReportsList(const xrt_core::smi::tuple_vector& reports) const
 std::shared_ptr<OptionOptions>
 SubCmdExamine::checkForSubOption(const po::variables_map& vm) const
 {
-  // Check if any of the option options are present
   for (const auto& option : m_optionOptionsCollection) {
     if (vm.count(option->getConfigName()) > 0) {
       return option;
@@ -155,27 +154,6 @@ SubCmdExamine::checkForSubOption(const po::variables_map& vm) const
   }
   
   return nullptr;
-}
-
-std::vector<std::shared_ptr<OptionOptions>>
-SubCmdExamine::getOptionOptions(const xrt_core::smi::tuple_vector& options) const
-{
-  // Vector to store the matched option options
-  std::vector<std::shared_ptr<OptionOptions>> matchedOptionOptions;
-
-  for (const auto& opt : options) {
-    auto it = std::find_if(m_optionOptionsCollection.begin(), m_optionOptionsCollection.end(),
-              [&opt](const std::shared_ptr<OptionOptions>& optionOption) {
-                return std::get<0>(opt) == optionOption->getConfigName() &&
-                       (std::get<2>(opt) != "hidden" || XBU::getAdvance());
-              });
-
-    if (it != m_optionOptionsCollection.end()) {
-      matchedOptionOptions.push_back(*it);
-    }
-  }
-
-  return matchedOptionOptions;
 }
 
 void
@@ -187,7 +165,11 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
   po::variables_map vm;
   SubCmdExamineOptions options;
   try{
-    const auto unrecognized_options = process_arguments(vm, _options, false);
+    // All JSON "hidden" options require --advanced to be accepted on the command line.
+    po::options_description empty_hidden;
+    const po::options_description& hidden_for_parse = XBU::getAdvance() ? m_hiddenOptions : empty_hidden;
+    const auto unrecognized_options = process_arguments(vm, _options, m_commonOptions, hidden_for_parse,
+                                                        m_positionals, m_subOptionOptions, false);
     fill_option_values(vm, options);
 
     // Check for OptionOptions first

--- a/src/runtime_src/core/tools/xbutil2/SubCmdExamine.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdExamine.h
@@ -34,7 +34,6 @@ class SubCmdExamine : public SubCmd {
   void fill_option_values(const boost::program_options::variables_map& vm, SubCmdExamineOptions& options) const;
   std::vector<std::shared_ptr<Report>> getReportsList(const xrt_core::smi::tuple_vector&) const;
   std::shared_ptr<OptionOptions> checkForSubOption(const boost::program_options::variables_map& vm) const;
-  std::vector<std::shared_ptr<OptionOptions>> getOptionOptions(const xrt_core::smi::tuple_vector& options) const;
 
  public:
   SubCmdExamine(bool _isHidden, bool _isDepricated, bool _isPreliminary);

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -216,8 +216,6 @@ print_status(test_status status, std::ostream & _ostream)
     _ostream << "Validation completed";
   if (status == test_status::warning)
     _ostream << ", but with warnings";
-  if (!XBU::getVerbose())
-    _ostream << ". Please run the command '--verbose' option for more details";
   _ostream << std::endl;
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
This PR adds the fixes for below mentioned CRs.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://jira.xilinx.com/browse/AIESW-29277
https://jira.xilinx.com/browse/AIESW-26642
https://jira.xilinx.com/browse/AIESW-29256

#### How problem was solved, alternative solutions (if any) and why they were rejected
Solved via making the printed power-mode in platform report as all lowercase and removing --verbose warning printing.

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Tested on Linux : 
```
aktondak@xsjstrix45:/proj/rdi/staff/aktondak/xdna/xdna-driver/xrt/build$ xrt-smi validate
Validate Device           : [0000:c5:00.1]
    Platform              : NPU Strix
    Power Mode            : performance
-------------------------------------------------------------------------------
Test 1 [0000:c5:00.1]     : gemm 
    Details               : TOPS: 51.0                                          
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Test 2 [0000:c5:00.1]     : latency 
    Details               : Average latency: 51.0 us                            
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Test 3 [0000:c5:00.1]     : throughput 
    Details               : Average throughput: 77639.0 op/s                    
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Validation completed
```

```
root@xsjstrix45:/proj/xsjhdstaff3/aktondak/xdna/xdna-driver/xrt/build# xrt-smi examine -r platform

---------------------------
[0000:c5:00.1] : NPU Strix
---------------------------
Platform
  Name                   : NPU Strix 
  Power Mode             : performance 
  Total Columns          : 8 

Estimated Power          : N/A
```

#### Documentation impact (if any)
None