### PR TITLE
[XRT-SMI] AIESW-28055 fix. xrt-smi examine --advanced should behave similar to xrt-smi examine

### DIFF
--- a/src/runtime_src/core/common/smi.cpp
+++ b/src/runtime_src/core/common/smi.cpp
@@ -93,6 +93,8 @@ std::string
 smi::
 build_json() const 
 {
+  std::lock_guard<std::mutex> lock(m_mutex);
+
   ptree config;
   ptree subcommands;
 
@@ -111,6 +113,8 @@ tuple_vector
 smi::
 get_list(const std::string& subcommand, const std::string& suboption) const 
 {
+  std::lock_guard<std::mutex> lock(m_mutex);
+
   const auto it = m_subcommands.find(subcommand);
   if (it == m_subcommands.end()) {
     throw std::runtime_error("Subcommand not found: " + subcommand);
@@ -131,6 +135,8 @@ tuple_vector
 smi::
 get_option_options(const std::string& subcommand) const 
 {
+  std::lock_guard<std::mutex> lock(m_mutex);
+
   const auto it = m_subcommands.find(subcommand);
   if (it == m_subcommands.end()) {
     throw std::runtime_error("Subcommand not found: " + subcommand);

--- a/src/runtime_src/core/common/smi.h
+++ b/src/runtime_src/core/common/smi.h
@@ -9,11 +9,12 @@
 // 3rd Party Library - Include Files
 #include <boost/property_tree/ptree.hpp>
 
+#include <map>
+#include <memory>
+#include <mutex>
 #include <string>
 #include <tuple>
 #include <vector>
-#include <memory>
-#include <map>
 
 namespace xq = xrt_core::query;
 
@@ -129,11 +130,14 @@ public:
 // Each shim (including smi_default) should create objects of smi class and populate
 // them with their custom fields. Currently, shims create singleton instanced of it. 
 class smi {
+  mutable std::mutex m_mutex;
   std::map<std::string, subcommand> m_subcommands;
 
 public:
   void
-  add_subcommand(std::string name, subcommand subcmd) {
+  add_subcommand(std::string name, subcommand subcmd)
+  {
+    std::lock_guard<std::mutex> lock(m_mutex);
     m_subcommands.emplace(std::move(name), std::move(subcmd));
   }
 

--- a/src/runtime_src/core/tools/common/SubCmdExamineInternal.cpp
+++ b/src/runtime_src/core/tools/common/SubCmdExamineInternal.cpp
@@ -155,13 +155,8 @@ SubCmdExamineInternal::execute(const SubCmdOptions& _options) const
   // Determine report level
   std::vector<std::string> reportsToRun(m_reportNames);
   if (reportsToRun.empty()) {
-    if (!XBU::getAdvance()) {
-      reportsToRun.push_back("host");
-    } 
-    else {
-      print_help_internal();
-      return;
-    }
+    // Default report with or without --advanced (advanced only unlocks hidden options/reports).
+    reportsToRun.push_back("host");
   }
 
   if ((std::find(reportsToRun.begin(), reportsToRun.end(), "all") != reportsToRun.end()) && (reportsToRun.size() > 1)) {

--- a/src/runtime_src/core/tools/common/SubCmdExamineInternal.cpp
+++ b/src/runtime_src/core/tools/common/SubCmdExamineInternal.cpp
@@ -156,7 +156,7 @@ SubCmdExamineInternal::execute(const SubCmdOptions& _options) const
   std::vector<std::string> reportsToRun(m_reportNames);
   if (reportsToRun.empty()) {
     // Default report with or without --advanced (advanced only unlocks hidden options/reports).
-    reportsToRun.push_back("host");
+    reportsToRun.emplace_back("host");
   }
 
   if ((std::find(reportsToRun.begin(), reportsToRun.end(), "all") != reportsToRun.end()) && (reportsToRun.size() > 1)) {

--- a/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
@@ -236,13 +236,8 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
   // Determine report level
   std::vector<std::string> reportsToRun(options.m_reportNames);
   if (reportsToRun.empty()) {
-    if (!XBU::getAdvance()) {
-      reportsToRun.emplace_back("host");
-    } 
-    else {
-      printHelp();
-      return;
-    }
+    // Default report with or without --advanced (advanced only unlocks hidden options/reports).
+    reportsToRun.emplace_back("host");
   }
 
   if ((std::find(reportsToRun.begin(), reportsToRun.end(), "all") != reportsToRun.end()) && (reportsToRun.size() > 1)) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
This PR fixes the behavior of xrt-smi examine --advanced command. Currently this command printed help as if the command usage was incorrect. This should be a valid command and should behave exactly how xrt-smi examine would behave.
This PR also fixes a speculative bug identified by claude where some smi APIs were changing the singleton object. This mutation of singleton objects should be under a lock guard so that no multiple threads can alter the singleton.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

1. https://jira.xilinx.com/browse/AIESW-29148
2. https://jira.xilinx.com/browse/AIESW-28055

#### How problem was solved, alternative solutions (if any) and why they were rejected
Solved via removing the unnecessary if guard for XBU::getAdvance() when running xrt-smi examine

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Tested on windows platform. 

#### Documentation impact (if any)
None
