### PR TITLE
Run constructor Run wait and run start hook for temporal sharing usecase

### DIFF
--- a/src/runtime_src/core/common/api/CMakeLists.txt
+++ b/src/runtime_src/core/common/api/CMakeLists.txt
@@ -29,11 +29,3 @@ target_include_directories(core_common_api_library_objects
   ${XRT_SOURCE_DIR}/runtime_src
   ${XRT_SOURCE_DIR}/runtime_src/core/common/elf
   )
-
-# Compile definitions for VE2 XDNA builds to enable run hooks
-if (XDP_VE2_BUILD_CMAKE STREQUAL "yes")
-  target_compile_definitions(core_common_api_library_objects
-    PRIVATE
-    XDP_VE2_BUILD=1
-    )
-endif()

--- a/src/runtime_src/core/common/api/CMakeLists.txt
+++ b/src/runtime_src/core/common/api/CMakeLists.txt
@@ -29,3 +29,11 @@ target_include_directories(core_common_api_library_objects
   ${XRT_SOURCE_DIR}/runtime_src
   ${XRT_SOURCE_DIR}/runtime_src/core/common/elf
   )
+
+# Compile definitions for VE2 XDNA builds to enable run hooks
+if (XDP_VE2_BUILD_CMAKE STREQUAL "yes")
+  target_compile_definitions(core_common_api_library_objects
+    PRIVATE
+    XDP_VE2_BUILD=1
+    )
+endif()

--- a/src/runtime_src/core/common/api/kernel_int.h
+++ b/src/runtime_src/core/common/api/kernel_int.h
@@ -24,6 +24,10 @@
 #include <string>
 #include <vector>
 
+namespace xrt_core::xdp {
+struct xrt_kernel_data;
+}
+
 namespace xrt_core { namespace kernel_int {
 
 // Provide access to kdma command based BO copy Used by xrt::bo::copy.
@@ -97,26 +101,10 @@ get_hw_ctx(const xrt::kernel& kernel);
 xrt::kernel
 create_kernel_from_implementation(const xrt::kernel_impl* kernel_impl);
 
-// Run-level accessors for XDP dtrace hooks
+// Fill XDP kernel data from a run object for profiling hooks
 XRT_CORE_COMMON_EXPORT
-uint32_t
-get_run_uid(const xrt::run& run);
-
-XRT_CORE_COMMON_EXPORT
-xrt::hw_context
-get_run_hwctx(const xrt::run& run);
-
-XRT_CORE_COMMON_EXPORT
-std::string
-get_run_kernel_name(const xrt::run& run);
-
-XRT_CORE_COMMON_EXPORT
-xrt::module
-get_run_module(const xrt::run& run);
-
-XRT_CORE_COMMON_EXPORT
-ert_cmd_state
-get_run_state(const xrt::run& run);
+void
+get_xdp_kernel_data(const xrt::run& run, xrt_core::xdp::xrt_kernel_data* data);
 
 }} // kernel_int, xrt_core
 

--- a/src/runtime_src/core/common/api/kernel_int.h
+++ b/src/runtime_src/core/common/api/kernel_int.h
@@ -106,6 +106,12 @@ XRT_CORE_COMMON_EXPORT
 void
 get_xdp_kernel_data(const xrt::run& run, xrt_core::xdp::xrt_kernel_data* data);
 
+// Set dtrace control file on a run_impl handle
+// This is used by XDP profiling to set the CT file without requiring xrt::run
+XRT_CORE_COMMON_EXPORT
+void
+set_dtrace_control_file(xrt::run_impl* run_impl, const std::string& path);
+
 }} // kernel_int, xrt_core
 
 #endif

--- a/src/runtime_src/core/common/api/kernel_int.h
+++ b/src/runtime_src/core/common/api/kernel_int.h
@@ -9,15 +9,11 @@
 
 // This file defines implementation extensions to the XRT Kernel APIs.
 #include "core/include/xrt/experimental/xrt_kernel.h"
-#include "core/include/xrt/experimental/xrt_module.h"
 #include "core/include/xrt/experimental/xrt_xclbin.h"
-#include "core/include/xrt/xrt_hw_context.h"
 
 #include "core/common/config.h"
 #include "core/common/xclbin_parser.h"
 #include "core/common/shim/buffer_handle.h"
-
-#include "ert.h"
 
 #include <bitset>
 #include <cstdint>

--- a/src/runtime_src/core/common/api/kernel_int.h
+++ b/src/runtime_src/core/common/api/kernel_int.h
@@ -101,10 +101,10 @@ get_hw_ctx(const xrt::kernel& kernel);
 xrt::kernel
 create_kernel_from_implementation(const xrt::kernel_impl* kernel_impl);
 
-// Fill XDP kernel data from a run object for profiling hooks
+// Fill XDP kernel data from a run_impl pointer for profiling hooks
 XRT_CORE_COMMON_EXPORT
 void
-get_xdp_kernel_data(const xrt::run& run, xrt_core::xdp::xrt_kernel_data* data);
+get_xdp_kernel_data(const xrt::run_impl* run_impl, xrt_core::xdp::xrt_kernel_data* data);
 
 // Set dtrace control file on a run_impl handle
 // This is used by XDP profiling to set the CT file without requiring xrt::run

--- a/src/runtime_src/core/common/api/kernel_int.h
+++ b/src/runtime_src/core/common/api/kernel_int.h
@@ -9,14 +9,19 @@
 
 // This file defines implementation extensions to the XRT Kernel APIs.
 #include "core/include/xrt/experimental/xrt_kernel.h"
+#include "core/include/xrt/experimental/xrt_module.h"
 #include "core/include/xrt/experimental/xrt_xclbin.h"
+#include "core/include/xrt/xrt_hw_context.h"
 
 #include "core/common/config.h"
 #include "core/common/xclbin_parser.h"
 #include "core/common/shim/buffer_handle.h"
 
+#include "ert.h"
+
 #include <bitset>
 #include <cstdint>
+#include <string>
 #include <vector>
 
 namespace xrt_core { namespace kernel_int {
@@ -91,6 +96,27 @@ get_hw_ctx(const xrt::kernel& kernel);
 // This is used for logging usage mertrics
 xrt::kernel
 create_kernel_from_implementation(const xrt::kernel_impl* kernel_impl);
+
+// Run-level accessors for XDP dtrace hooks
+XRT_CORE_COMMON_EXPORT
+uint32_t
+get_run_uid(const xrt::run& run);
+
+XRT_CORE_COMMON_EXPORT
+xrt::hw_context
+get_run_hwctx(const xrt::run& run);
+
+XRT_CORE_COMMON_EXPORT
+std::string
+get_run_kernel_name(const xrt::run& run);
+
+XRT_CORE_COMMON_EXPORT
+xrt::module
+get_run_module(const xrt::run& run);
+
+XRT_CORE_COMMON_EXPORT
+ert_cmd_state
+get_run_state(const xrt::run& run);
 
 }} // kernel_int, xrt_core
 

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -2480,7 +2480,7 @@ public:
     XRT_DEBUGF("run_impl::run_impl(%d)\n" , uid);
 
     // XDP run_constructor hook
-    xrt_core::xdp::run_constructor(this, get_xdp_kernel_data());
+    xrt_core::xdp::run_constructor(this);
   }
 
   // Clones a run impl, so that the clone can be executed concurrently
@@ -2794,7 +2794,7 @@ public:
     prep_start();
 
     // XDP profiling hook - called immediately before run is submitted
-    xrt_core::xdp::run_start(get_xdp_kernel_data());
+    xrt_core::xdp::run_start(this);
 
     // log kernel start info
     // This is in critical path, we need to reduce log overhead
@@ -2898,9 +2898,7 @@ public:
     }
 
     // XDP profiling hook - called after wait completes
-    auto xdp_data = get_xdp_kernel_data();
-    xdp_data.ert_state = static_cast<int>(state);
-    xrt_core::xdp::run_wait(xdp_data);
+    xrt_core::xdp::run_wait(this);
 
     dump_logs(true); // dump required logs
 
@@ -2955,9 +2953,7 @@ public:
     }
 
     // XDP profiling hook - called after wait completes
-    auto xdp_data = get_xdp_kernel_data();
-    xdp_data.ert_state = static_cast<int>(state);
-    xrt_core::xdp::run_wait(xdp_data);
+    xrt_core::xdp::run_wait(this);
 
     // dump required logs
     dump_logs(true);
@@ -4238,19 +4234,20 @@ create_kernel_from_implementation(const xrt::kernel_impl* kernel_impl)
 }
 
 void
-get_xdp_kernel_data(const xrt::run& run, xrt_core::xdp::xrt_kernel_data* data)
+get_xdp_kernel_data(const xrt::run_impl* run_impl, xrt_core::xdp::xrt_kernel_data* data)
 {
-  auto run_handle = run.get_handle();
-  auto kernel = run_handle->get_kernel();
-  data->uid = run_handle->get_uid();
+  auto kernel = run_impl->get_kernel();
+  data->uid = run_impl->get_uid();
   data->name = kernel->get_name();
   data->hwctx = kernel->get_hw_context();
   data->mod = kernel->get_module();
+  data->ert_state = static_cast<int>(run_impl->state());
 }
 
 void
 set_dtrace_control_file(xrt::run_impl* run_impl, const std::string& path)
 {
+  XRT_TRACE_POINT_SCOPE(set_dtrace_control_file); 
   run_impl->set_dtrace_control_file(path);
 }
 

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -47,6 +47,7 @@
 #include "core/common/trace.h"
 #include "core/common/usage_metrics.h"
 #include "core/common/xclbin_parser.h"
+#include "core/common/xdp/profile.h"
 
 #include <boost/format.hpp>
 
@@ -4226,7 +4227,10 @@ run::
 run(const kernel& krnl)
   : handle(xdp::native::profiling_wrapper
            ("xrt::run::run", alloc_run, krnl.get_handle()))
-{}
+{
+  auto hwctx = krnl.get_handle()->get_hw_context();
+  xrt_core::xdp::run_constructor(this, hwctx.get_handle().get());
+}
 
 void
 run::

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -4217,24 +4217,6 @@ create_kernel_from_implementation(const xrt::kernel_impl* kernel_impl)
 
 } // xrt_core::kernel_int
 
-namespace {
-
-inline xrt_core::xdp::run_info
-make_run_info(void* run, void* hwctx_handle, uint32_t run_uid,
-              const char* kernel_name, void* elf_handle = nullptr, int ert_cmd_state = 0)
-{
-  xrt_core::xdp::run_info info;
-  info.run = run;
-  info.hwctx_handle = hwctx_handle;
-  info.run_uid = run_uid;
-  info.kernel_name = kernel_name;
-  info.elf_handle = elf_handle;
-  info.ert_cmd_state = ert_cmd_state;
-  return info;
-}
-
-} // anonymous namespace
-
 ////////////////////////////////////////////////////////////////
 // xrt_kernel C++ API implmentations (xrt_kernel.h)
 ////////////////////////////////////////////////////////////////
@@ -4249,8 +4231,8 @@ run(const kernel& krnl)
     auto hwctx = krnl.get_handle()->get_hw_context();
     const auto& mod = krnl.get_handle()->get_module();
     auto elf_hdl = mod ? xrt_core::module_int::get_elf_handle(mod) : nullptr;
-    auto info = make_run_info(this, hwctx.get_handle().get(), handle->get_uid(),
-                              krnl.get_handle()->get_name().c_str(), elf_hdl.get());
+    auto info = xrt_core::xdp::make_run_info(this, hwctx.get_handle().get(), handle->get_uid(),
+                                             krnl.get_handle()->get_name().c_str(), elf_hdl.get());
     xrt_core::xdp::run_constructor(info);
   }
 }
@@ -4269,8 +4251,8 @@ start()
   XRT_TRACE_POINT_SCOPE(xrt_run_start);
   if (xrt_core::config::get_aie_dtrace()) {
     auto hwctx = handle->get_kernel()->get_hw_context();
-    auto info = make_run_info(this, hwctx.get_handle().get(), handle->get_uid(),
-                              handle->get_kernel()->get_name().c_str());
+    auto info = xrt_core::xdp::make_run_info(this, hwctx.get_handle().get(), handle->get_uid(),
+                                             handle->get_kernel()->get_name().c_str());
     xrt_core::xdp::run_start(info);
   }
   xdp::native::profiling_wrapper
@@ -4311,9 +4293,9 @@ wait(const std::chrono::milliseconds& timeout_ms) const
     });
   if (xrt_core::config::get_aie_dtrace()) {
     auto hwctx = handle->get_kernel()->get_hw_context();
-    auto info = make_run_info(const_cast<xrt::run*>(this), hwctx.get_handle().get(),
-                              handle->get_uid(), handle->get_kernel()->get_name().c_str(),
-                              nullptr, static_cast<int>(state));
+    auto info = xrt_core::xdp::make_run_info(const_cast<xrt::run*>(this), hwctx.get_handle().get(),
+                                             handle->get_uid(), handle->get_kernel()->get_name().c_str(),
+                                             nullptr, static_cast<int>(state));
     xrt_core::xdp::run_wait(info);
   }
   return state;
@@ -4330,9 +4312,9 @@ wait2(const std::chrono::milliseconds& timeout_ms) const
     });
   if (xrt_core::config::get_aie_dtrace()) {
     auto hwctx = handle->get_kernel()->get_hw_context();
-    auto info = make_run_info(const_cast<xrt::run*>(this), hwctx.get_handle().get(),
-                              handle->get_uid(), handle->get_kernel()->get_name().c_str(),
-                              nullptr, static_cast<int>(handle->state()));
+    auto info = xrt_core::xdp::make_run_info(const_cast<xrt::run*>(this), hwctx.get_handle().get(),
+                                             handle->get_uid(), handle->get_kernel()->get_name().c_str(),
+                                             nullptr, static_cast<int>(handle->state()));
     xrt_core::xdp::run_wait(info);
   }
   return cvst;

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -4229,7 +4229,11 @@ run(const kernel& krnl)
            ("xrt::run::run", alloc_run, krnl.get_handle()))
 {
   auto hwctx = krnl.get_handle()->get_hw_context();
-  xrt_core::xdp::run_constructor(this, hwctx.get_handle().get(), handle->get_uid());
+  const auto& mod = krnl.get_handle()->get_module();
+  auto elf_hdl = mod ? xrt_core::module_int::get_elf_handle(mod) : nullptr;
+  xrt_core::xdp::run_constructor(this, hwctx.get_handle().get(), handle->get_uid(),
+                                 krnl.get_handle()->get_name().c_str(),
+                                 elf_hdl.get());
 }
 
 void

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -2402,12 +2402,6 @@ class run_impl : public std::enable_shared_from_this<run_impl>
   // Run-level dtrace result file postfix
   std::string m_dtrace_result_file_postfix;
 
-  xrt_core::xdp::xrt_kernel_data
-  get_xdp_kernel_data() const
-  {
-    return {uid, kernel->get_name(), kernel->get_hw_context(), m_module};
-  }
-
 public:
   uint32_t
   get_uid() const
@@ -4276,7 +4270,6 @@ run::
 start()
 {
   XRT_TRACE_POINT_SCOPE(xrt_run_start);
-  // XDP run_start hook is called in run_impl::start()
   xdp::native::profiling_wrapper
     ("xrt::run::start", [this] {
       handle->start();

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -4215,6 +4215,36 @@ create_kernel_from_implementation(const xrt::kernel_impl* kernel_impl)
   return xrt::kernel(const_cast<xrt::kernel_impl*>(kernel_impl)->get_shared_ptr()); // NOLINT
 }
 
+uint32_t
+get_run_uid(const xrt::run& run)
+{
+  return run.get_handle()->get_uid();
+}
+
+xrt::hw_context
+get_run_hwctx(const xrt::run& run)
+{
+  return run.get_handle()->get_kernel()->get_hw_context();
+}
+
+std::string
+get_run_kernel_name(const xrt::run& run)
+{
+  return run.get_handle()->get_kernel()->get_name();
+}
+
+xrt::module
+get_run_module(const xrt::run& run)
+{
+  return run.get_handle()->get_kernel()->get_module();
+}
+
+ert_cmd_state
+get_run_state(const xrt::run& run)
+{
+  return run.get_handle()->state();
+}
+
 } // xrt_core::kernel_int
 
 ////////////////////////////////////////////////////////////////
@@ -4227,14 +4257,7 @@ run(const kernel& krnl)
   : handle(xdp::native::profiling_wrapper
            ("xrt::run::run", alloc_run, krnl.get_handle()))
 {
-  if (xrt_core::config::get_aie_dtrace()) {
-    auto hwctx = krnl.get_handle()->get_hw_context();
-    const auto& mod = krnl.get_handle()->get_module();
-    auto elf_hdl = mod ? xrt_core::module_int::get_elf_handle(mod) : nullptr;
-    auto info = xrt_core::xdp::make_run_info(this, hwctx.get_handle().get(), handle->get_uid(),
-                                             krnl.get_handle()->get_name().c_str(), elf_hdl.get());
-    xrt_core::xdp::run_constructor(info);
-  }
+  xrt_core::xdp::run_constructor(*this);
 }
 
 void
@@ -4249,12 +4272,7 @@ run::
 start()
 {
   XRT_TRACE_POINT_SCOPE(xrt_run_start);
-  if (xrt_core::config::get_aie_dtrace()) {
-    auto hwctx = handle->get_kernel()->get_hw_context();
-    auto info = xrt_core::xdp::make_run_info(this, hwctx.get_handle().get(), handle->get_uid(),
-                                             handle->get_kernel()->get_name().c_str());
-    xrt_core::xdp::run_start(info);
-  }
+  xrt_core::xdp::run_start(*this);
   xdp::native::profiling_wrapper
     ("xrt::run::start", [this] {
       handle->start();
@@ -4291,13 +4309,7 @@ wait(const std::chrono::milliseconds& timeout_ms) const
     [this, &timeout_ms] {
       return handle->wait(timeout_ms);
     });
-  if (xrt_core::config::get_aie_dtrace()) {
-    auto hwctx = handle->get_kernel()->get_hw_context();
-    auto info = xrt_core::xdp::make_run_info(const_cast<xrt::run*>(this), hwctx.get_handle().get(),
-                                             handle->get_uid(), handle->get_kernel()->get_name().c_str(),
-                                             nullptr, static_cast<int>(state));
-    xrt_core::xdp::run_wait(info);
-  }
+  xrt_core::xdp::run_wait(*this);
   return state;
 }
 
@@ -4310,13 +4322,7 @@ wait2(const std::chrono::milliseconds& timeout_ms) const
     [this, &timeout_ms] {
       return handle->wait_throw_on_error(timeout_ms);
     });
-  if (xrt_core::config::get_aie_dtrace()) {
-    auto hwctx = handle->get_kernel()->get_hw_context();
-    auto info = xrt_core::xdp::make_run_info(const_cast<xrt::run*>(this), hwctx.get_handle().get(),
-                                             handle->get_uid(), handle->get_kernel()->get_name().c_str(),
-                                             nullptr, static_cast<int>(handle->state()));
-    xrt_core::xdp::run_wait(info);
-  }
+  xrt_core::xdp::run_wait(*this);
   return cvst;
 }
 

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -4229,7 +4229,7 @@ run(const kernel& krnl)
            ("xrt::run::run", alloc_run, krnl.get_handle()))
 {
   auto hwctx = krnl.get_handle()->get_hw_context();
-  xrt_core::xdp::run_constructor(this, hwctx.get_handle().get());
+  xrt_core::xdp::run_constructor(this, hwctx.get_handle().get(), handle->get_uid());
 }
 
 void

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -4217,6 +4217,23 @@ create_kernel_from_implementation(const xrt::kernel_impl* kernel_impl)
 
 } // xrt_core::kernel_int
 
+namespace {
+
+inline xrt_core::xdp::run_info
+make_run_info(void* run, void* hwctx_handle, uint32_t run_uid,
+              const char* kernel_name, void* elf_handle = nullptr, int ert_cmd_state = 0)
+{
+  xrt_core::xdp::run_info info;
+  info.run = run;
+  info.hwctx_handle = hwctx_handle;
+  info.run_uid = run_uid;
+  info.kernel_name = kernel_name;
+  info.elf_handle = elf_handle;
+  info.ert_cmd_state = ert_cmd_state;
+  return info;
+}
+
+} // anonymous namespace
 
 ////////////////////////////////////////////////////////////////
 // xrt_kernel C++ API implmentations (xrt_kernel.h)
@@ -4228,14 +4245,14 @@ run(const kernel& krnl)
   : handle(xdp::native::profiling_wrapper
            ("xrt::run::run", alloc_run, krnl.get_handle()))
 {
-#ifdef XDP_VE2_BUILD
-  auto hwctx = krnl.get_handle()->get_hw_context();
-  const auto& mod = krnl.get_handle()->get_module();
-  auto elf_hdl = mod ? xrt_core::module_int::get_elf_handle(mod) : nullptr;
-  xrt_core::xdp::run_constructor(this, hwctx.get_handle().get(), handle->get_uid(),
-                                 krnl.get_handle()->get_name().c_str(),
-                                 elf_hdl.get());
-#endif
+  if (xrt_core::config::get_aie_dtrace()) {
+    auto hwctx = krnl.get_handle()->get_hw_context();
+    const auto& mod = krnl.get_handle()->get_module();
+    auto elf_hdl = mod ? xrt_core::module_int::get_elf_handle(mod) : nullptr;
+    auto info = make_run_info(this, hwctx.get_handle().get(), handle->get_uid(),
+                              krnl.get_handle()->get_name().c_str(), elf_hdl.get());
+    xrt_core::xdp::run_constructor(info);
+  }
 }
 
 void
@@ -4250,13 +4267,12 @@ run::
 start()
 {
   XRT_TRACE_POINT_SCOPE(xrt_run_start);
-#ifdef XDP_VE2_BUILD
-  {
+  if (xrt_core::config::get_aie_dtrace()) {
     auto hwctx = handle->get_kernel()->get_hw_context();
-    xrt_core::xdp::run_start(this, hwctx.get_handle().get(), handle->get_uid(),
-                             handle->get_kernel()->get_name().c_str());
+    auto info = make_run_info(this, hwctx.get_handle().get(), handle->get_uid(),
+                              handle->get_kernel()->get_name().c_str());
+    xrt_core::xdp::run_start(info);
   }
-#endif
   xdp::native::profiling_wrapper
     ("xrt::run::start", [this] {
       handle->start();
@@ -4293,14 +4309,13 @@ wait(const std::chrono::milliseconds& timeout_ms) const
     [this, &timeout_ms] {
       return handle->wait(timeout_ms);
     });
-#ifdef XDP_VE2_BUILD
-  {
+  if (xrt_core::config::get_aie_dtrace()) {
     auto hwctx = handle->get_kernel()->get_hw_context();
-    xrt_core::xdp::run_wait(const_cast<xrt::run*>(this), hwctx.get_handle().get(),
-                            handle->get_uid(),
-                            handle->get_kernel()->get_name().c_str(), static_cast<int>(state));
+    auto info = make_run_info(const_cast<xrt::run*>(this), hwctx.get_handle().get(),
+                              handle->get_uid(), handle->get_kernel()->get_name().c_str(),
+                              nullptr, static_cast<int>(state));
+    xrt_core::xdp::run_wait(info);
   }
-#endif
   return state;
 }
 
@@ -4313,15 +4328,13 @@ wait2(const std::chrono::milliseconds& timeout_ms) const
     [this, &timeout_ms] {
       return handle->wait_throw_on_error(timeout_ms);
     });
-#ifdef XDP_VE2_BUILD
-  {
+  if (xrt_core::config::get_aie_dtrace()) {
     auto hwctx = handle->get_kernel()->get_hw_context();
-    xrt_core::xdp::run_wait(const_cast<xrt::run*>(this), hwctx.get_handle().get(),
-                            handle->get_uid(),
-                            handle->get_kernel()->get_name().c_str(),
-                            static_cast<int>(handle->state()));
+    auto info = make_run_info(const_cast<xrt::run*>(this), hwctx.get_handle().get(),
+                              handle->get_uid(), handle->get_kernel()->get_name().c_str(),
+                              nullptr, static_cast<int>(handle->state()));
+    xrt_core::xdp::run_wait(info);
   }
-#endif
   return cvst;
 }
 

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -4228,12 +4228,14 @@ run(const kernel& krnl)
   : handle(xdp::native::profiling_wrapper
            ("xrt::run::run", alloc_run, krnl.get_handle()))
 {
+#ifdef XDP_VE2_BUILD
   auto hwctx = krnl.get_handle()->get_hw_context();
   const auto& mod = krnl.get_handle()->get_module();
   auto elf_hdl = mod ? xrt_core::module_int::get_elf_handle(mod) : nullptr;
   xrt_core::xdp::run_constructor(this, hwctx.get_handle().get(), handle->get_uid(),
                                  krnl.get_handle()->get_name().c_str(),
                                  elf_hdl.get());
+#endif
 }
 
 void
@@ -4248,11 +4250,13 @@ run::
 start()
 {
   XRT_TRACE_POINT_SCOPE(xrt_run_start);
+#ifdef XDP_VE2_BUILD
   {
     auto hwctx = handle->get_kernel()->get_hw_context();
     xrt_core::xdp::run_start(this, hwctx.get_handle().get(), handle->get_uid(),
                              handle->get_kernel()->get_name().c_str());
   }
+#endif
   xdp::native::profiling_wrapper
     ("xrt::run::start", [this] {
       handle->start();
@@ -4289,12 +4293,14 @@ wait(const std::chrono::milliseconds& timeout_ms) const
     [this, &timeout_ms] {
       return handle->wait(timeout_ms);
     });
+#ifdef XDP_VE2_BUILD
   {
     auto hwctx = handle->get_kernel()->get_hw_context();
     xrt_core::xdp::run_wait(const_cast<xrt::run*>(this), hwctx.get_handle().get(),
                             handle->get_uid(),
                             handle->get_kernel()->get_name().c_str(), static_cast<int>(state));
   }
+#endif
   return state;
 }
 
@@ -4307,6 +4313,7 @@ wait2(const std::chrono::milliseconds& timeout_ms) const
     [this, &timeout_ms] {
       return handle->wait_throw_on_error(timeout_ms);
     });
+#ifdef XDP_VE2_BUILD
   {
     auto hwctx = handle->get_kernel()->get_hw_context();
     xrt_core::xdp::run_wait(const_cast<xrt::run*>(this), hwctx.get_handle().get(),
@@ -4314,6 +4321,7 @@ wait2(const std::chrono::milliseconds& timeout_ms) const
                             handle->get_kernel()->get_name().c_str(),
                             static_cast<int>(handle->state()));
   }
+#endif
   return cvst;
 }
 

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -4241,7 +4241,6 @@ get_xdp_kernel_data(const xrt::run_impl* run_impl, xrt_core::xdp::xrt_kernel_dat
 void
 set_dtrace_control_file(xrt::run_impl* run_impl, const std::string& path)
 {
-  XRT_TRACE_POINT_SCOPE(set_dtrace_control_file); 
   run_impl->set_dtrace_control_file(path);
 }
 

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -2402,6 +2402,12 @@ class run_impl : public std::enable_shared_from_this<run_impl>
   // Run-level dtrace result file postfix
   std::string m_dtrace_result_file_postfix;
 
+  xrt_core::xdp::xrt_kernel_data
+  get_xdp_kernel_data() const
+  {
+    return {uid, kernel->get_name(), kernel->get_hw_context(), m_module};
+  }
+
 public:
   uint32_t
   get_uid() const
@@ -2784,6 +2790,9 @@ public:
 
     prep_start();
 
+    // XDP profiling hook - called immediately before run is submitted
+    xrt_core::xdp::run_start(get_xdp_kernel_data());
+
     // log kernel start info
     // This is in critical path, we need to reduce log overhead
     // as much as possible, passing kernel impl pointer instead of
@@ -2885,6 +2894,11 @@ public:
       state = cmd->wait();
     }
 
+    // XDP profiling hook - called after wait completes
+    auto xdp_data = get_xdp_kernel_data();
+    xdp_data.ert_state = static_cast<int>(state);
+    xrt_core::xdp::run_wait(xdp_data);
+
     dump_logs(true); // dump required logs
 
     return state;
@@ -2936,6 +2950,11 @@ public:
     else {
       state = cmd->wait();
     }
+
+    // XDP profiling hook - called after wait completes
+    auto xdp_data = get_xdp_kernel_data();
+    xdp_data.ert_state = static_cast<int>(state);
+    xrt_core::xdp::run_wait(xdp_data);
 
     // dump required logs
     dump_logs(true);
@@ -4215,34 +4234,15 @@ create_kernel_from_implementation(const xrt::kernel_impl* kernel_impl)
   return xrt::kernel(const_cast<xrt::kernel_impl*>(kernel_impl)->get_shared_ptr()); // NOLINT
 }
 
-uint32_t
-get_run_uid(const xrt::run& run)
+void
+get_xdp_kernel_data(const xrt::run& run, xrt_core::xdp::xrt_kernel_data* data)
 {
-  return run.get_handle()->get_uid();
-}
-
-xrt::hw_context
-get_run_hwctx(const xrt::run& run)
-{
-  return run.get_handle()->get_kernel()->get_hw_context();
-}
-
-std::string
-get_run_kernel_name(const xrt::run& run)
-{
-  return run.get_handle()->get_kernel()->get_name();
-}
-
-xrt::module
-get_run_module(const xrt::run& run)
-{
-  return run.get_handle()->get_kernel()->get_module();
-}
-
-ert_cmd_state
-get_run_state(const xrt::run& run)
-{
-  return run.get_handle()->state();
+  auto run_handle = run.get_handle();
+  auto kernel = run_handle->get_kernel();
+  data->uid = run_handle->get_uid();
+  data->name = kernel->get_name();
+  data->hwctx = kernel->get_hw_context();
+  data->mod = kernel->get_module();
 }
 
 } // xrt_core::kernel_int
@@ -4257,6 +4257,7 @@ run(const kernel& krnl)
   : handle(xdp::native::profiling_wrapper
            ("xrt::run::run", alloc_run, krnl.get_handle()))
 {
+  // XDP run_constructor hook called here where xrt::run object is available
   xrt_core::xdp::run_constructor(*this);
 }
 
@@ -4272,7 +4273,7 @@ run::
 start()
 {
   XRT_TRACE_POINT_SCOPE(xrt_run_start);
-  xrt_core::xdp::run_start(*this);
+  // XDP run_start hook is called in run_impl::start()
   xdp::native::profiling_wrapper
     ("xrt::run::start", [this] {
       handle->start();
@@ -4305,12 +4306,10 @@ run::
 wait(const std::chrono::milliseconds& timeout_ms) const
 {
   XRT_TRACE_POINT_SCOPE(xrt_run_wait);
-  auto state = xdp::native::profiling_wrapper("xrt::run::wait",
+  return xdp::native::profiling_wrapper("xrt::run::wait",
     [this, &timeout_ms] {
       return handle->wait(timeout_ms);
     });
-  xrt_core::xdp::run_wait(*this);
-  return state;
 }
 
 std::cv_status
@@ -4318,12 +4317,10 @@ run::
 wait2(const std::chrono::milliseconds& timeout_ms) const
 {
   XRT_TRACE_POINT_SCOPE(xrt_run_wait2);
-  auto cvst = xdp::native::profiling_wrapper("xrt::run::wait",
+  return xdp::native::profiling_wrapper("xrt::run::wait",
     [this, &timeout_ms] {
       return handle->wait_throw_on_error(timeout_ms);
     });
-  xrt_core::xdp::run_wait(*this);
-  return cvst;
 }
 
 ert_cmd_state

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -2478,6 +2478,9 @@ public:
     , uid(create_uid())
   {
     XRT_DEBUGF("run_impl::run_impl(%d)\n" , uid);
+
+    // XDP run_constructor hook
+    xrt_core::xdp::run_constructor(this, get_xdp_kernel_data());
   }
 
   // Clones a run impl, so that the clone can be executed concurrently
@@ -4245,6 +4248,12 @@ get_xdp_kernel_data(const xrt::run& run, xrt_core::xdp::xrt_kernel_data* data)
   data->mod = kernel->get_module();
 }
 
+void
+set_dtrace_control_file(xrt::run_impl* run_impl, const std::string& path)
+{
+  run_impl->set_dtrace_control_file(path);
+}
+
 } // xrt_core::kernel_int
 
 ////////////////////////////////////////////////////////////////
@@ -4256,10 +4265,7 @@ run::
 run(const kernel& krnl)
   : handle(xdp::native::profiling_wrapper
            ("xrt::run::run", alloc_run, krnl.get_handle()))
-{
-  // XDP run_constructor hook called here where xrt::run object is available
-  xrt_core::xdp::run_constructor(*this);
-}
+{}
 
 void
 run::

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -4248,6 +4248,11 @@ run::
 start()
 {
   XRT_TRACE_POINT_SCOPE(xrt_run_start);
+  {
+    auto hwctx = handle->get_kernel()->get_hw_context();
+    xrt_core::xdp::run_start(this, hwctx.get_handle().get(), handle->get_uid(),
+                             handle->get_kernel()->get_name().c_str());
+  }
   xdp::native::profiling_wrapper
     ("xrt::run::start", [this] {
       handle->start();
@@ -4280,10 +4285,17 @@ run::
 wait(const std::chrono::milliseconds& timeout_ms) const
 {
   XRT_TRACE_POINT_SCOPE(xrt_run_wait);
-  return xdp::native::profiling_wrapper("xrt::run::wait",
+  auto state = xdp::native::profiling_wrapper("xrt::run::wait",
     [this, &timeout_ms] {
       return handle->wait(timeout_ms);
     });
+  {
+    auto hwctx = handle->get_kernel()->get_hw_context();
+    xrt_core::xdp::run_wait(const_cast<xrt::run*>(this), hwctx.get_handle().get(),
+                            handle->get_uid(),
+                            handle->get_kernel()->get_name().c_str(), static_cast<int>(state));
+  }
+  return state;
 }
 
 std::cv_status
@@ -4291,10 +4303,18 @@ run::
 wait2(const std::chrono::milliseconds& timeout_ms) const
 {
   XRT_TRACE_POINT_SCOPE(xrt_run_wait2);
-  return xdp::native::profiling_wrapper("xrt::run::wait",
+  auto cvst = xdp::native::profiling_wrapper("xrt::run::wait",
     [this, &timeout_ms] {
       return handle->wait_throw_on_error(timeout_ms);
     });
+  {
+    auto hwctx = handle->get_kernel()->get_hw_context();
+    xrt_core::xdp::run_wait(const_cast<xrt::run*>(this), hwctx.get_handle().get(),
+                            handle->get_uid(),
+                            handle->get_kernel()->get_name().c_str(),
+                            static_cast<int>(handle->state()));
+  }
+  return cvst;
 }
 
 ert_cmd_state

--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -175,6 +175,13 @@ get_aie_profile()
 }
 
 inline bool
+get_aie_dtrace()
+{
+  static bool value = detail::get_bool_value("Debug.aie_dtrace", false);
+  return value;
+}
+
+inline bool
 get_aie_debug()
 {
   static bool value = detail::get_bool_value("Debug.aie_debug",false);
@@ -969,6 +976,30 @@ inline bool
 get_aie_profile_settings_dtrace_debug()
 {
   static bool value = detail::get_bool_value("AIE_profile_settings.dtrace_debug", "false");
+  return value;
+}
+
+// Configurations under AIE_dtrace_settings (bandwidth / CT for Debug.aie_dtrace; no aie_profile CSV)
+inline unsigned int
+get_aie_dtrace_settings_interval_us()
+{
+  static unsigned int value = detail::get_uint_value("AIE_dtrace_settings.interval_us", 1000);
+  return value;
+}
+
+inline std::string
+get_aie_dtrace_settings_graph_based_interface_tile_metrics()
+{
+  static std::string value =
+      detail::get_string_value("AIE_dtrace_settings.graph_based_interface_tile_metrics", "");
+  return value;
+}
+
+inline std::string
+get_aie_dtrace_settings_tile_based_interface_tile_metrics()
+{
+  static std::string value =
+      detail::get_string_value("AIE_dtrace_settings.tile_based_interface_tile_metrics", "");
   return value;
 }
 

--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -972,13 +972,6 @@ get_aie_profile_settings_start_iteration()
   return value;
 }
 
-inline bool
-get_aie_profile_settings_dtrace_debug()
-{
-  static bool value = detail::get_bool_value("AIE_profile_settings.dtrace_debug", "false");
-  return value;
-}
-
 // Configurations under AIE_dtrace_settings (bandwidth / CT for Debug.aie_dtrace; no aie_profile CSV)
 inline unsigned int
 get_aie_dtrace_settings_interval_us()

--- a/src/runtime_src/core/common/xdp/CMakeLists.txt
+++ b/src/runtime_src/core/common/xdp/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(core_common_xdp_profile_objects OBJECT
 target_include_directories(core_common_xdp_profile_objects
   PRIVATE
   ${XRT_SOURCE_DIR}/runtime_src
+  ${XRT_SOURCE_DIR}/runtime_src/core/common/elf
   )
 
 # Compile defintions when building npu, alveo, or legacy xrt

--- a/src/runtime_src/core/common/xdp/profile.cpp
+++ b/src/runtime_src/core/common/xdp/profile.cpp
@@ -161,6 +161,8 @@ namespace xrt_core::xdp::aie::dtrace {
 std::function<void(void*, bool)> update_device_cb;
 std::function<void(void*)> end_poll_cb;
 std::function<void(void*, void*, uint32_t, const char*, void*)> run_constructor_cb;
+std::function<void(void*, void*, uint32_t, const char*)> run_start_cb;
+std::function<void(void*, void*, uint32_t, const char*, int)> run_wait_cb;
 
 void
 register_callbacks(void* handle)
@@ -168,10 +170,14 @@ register_callbacks(void* handle)
   using ftype = void (*)(void*);
   using utype = void (*)(void*, bool);
   using rctype = void (*)(void*, void*, uint32_t, const char*, void*);
+  using rsctype = void (*)(void*, void*, uint32_t, const char*);
+  using rwctype = void (*)(void*, void*, uint32_t, const char*, int);
 
   update_device_cb = reinterpret_cast<utype>(xrt_core::dlsym(handle, "updateAIEDtraceDevice"));
   end_poll_cb = reinterpret_cast<ftype>(xrt_core::dlsym(handle, "endAIEDtracePoll"));
   run_constructor_cb = reinterpret_cast<rctype>(xrt_core::dlsym(handle, "aieDtraceRunConstructor"));
+  run_start_cb = reinterpret_cast<rsctype>(xrt_core::dlsym(handle, "aieDtraceRunStart"));
+  run_wait_cb = reinterpret_cast<rwctype>(xrt_core::dlsym(handle, "aieDtraceRunWait"));
 }
 
 void
@@ -208,6 +214,20 @@ run_constructor(void* run, void* hwctx, uint32_t run_uid, const char* kernel_nam
 {
   if (run_constructor_cb)
     run_constructor_cb(run, hwctx, run_uid, kernel_name, elf_handle);
+}
+
+void
+run_start(void* run, void* hwctx, uint32_t run_uid, const char* kernel_name)
+{
+  if (run_start_cb)
+    run_start_cb(run, hwctx, run_uid, kernel_name);
+}
+
+void
+run_wait(void* run, void* hwctx, uint32_t run_uid, const char* kernel_name, int ert_cmd_state)
+{
+  if (run_wait_cb)
+    run_wait_cb(run, hwctx, run_uid, kernel_name, ert_cmd_state);
 }
 
 } // end namespace xrt_core::xdp::aie::dtrace
@@ -865,6 +885,21 @@ run_constructor(void* run, void* hwctx_handle, uint32_t run_uid, const char* ker
   if (xrt_core::config::get_aie_dtrace())
     xrt_core::xdp::aie::dtrace::run_constructor(run, hwctx_handle, run_uid, kernel_name,
                                                 elf_handle);
+}
+
+void
+run_start(void* run, void* hwctx_handle, uint32_t run_uid, const char* kernel_name)
+{
+  if (xrt_core::config::get_aie_dtrace())
+    xrt_core::xdp::aie::dtrace::run_start(run, hwctx_handle, run_uid, kernel_name);
+}
+
+void
+run_wait(void* run, void* hwctx_handle, uint32_t run_uid, const char* kernel_name,
+         int ert_cmd_state)
+{
+  if (xrt_core::config::get_aie_dtrace())
+    xrt_core::xdp::aie::dtrace::run_wait(run, hwctx_handle, run_uid, kernel_name, ert_cmd_state);
 }
 
 } // end namespace xrt_core::xdp

--- a/src/runtime_src/core/common/xdp/profile.cpp
+++ b/src/runtime_src/core/common/xdp/profile.cpp
@@ -869,12 +869,12 @@ run_constructor(xrt::run& run)
   if (!xrt_core::config::get_aie_dtrace())
     return;
 
-  auto hwctx = xrt_core::kernel_int::get_run_hwctx(run);
-  const auto& mod = xrt_core::kernel_int::get_run_module(run);
-  auto elf_hdl = mod ? xrt_core::module_int::get_elf_handle(mod) : nullptr;
-  xrt_core::xdp::aie::dtrace::run_constructor(&run, hwctx.get_handle().get(),
-                                              xrt_core::kernel_int::get_run_uid(run),
-                                              xrt_core::kernel_int::get_run_kernel_name(run).c_str(),
+  xrt_core::xdp::xrt_kernel_data data;
+  xrt_core::kernel_int::get_xdp_kernel_data(run, &data);
+  auto elf_hdl = data.mod ? xrt_core::module_int::get_elf_handle(data.mod) : nullptr;
+  xrt_core::xdp::aie::dtrace::run_constructor(&run, data.hwctx.get_handle().get(),
+                                              data.uid,
+                                              data.name.c_str(),
                                               elf_hdl.get());
 }
 
@@ -884,23 +884,34 @@ run_start(xrt::run& run)
   if (!xrt_core::config::get_aie_dtrace())
     return;
 
-  auto hwctx = xrt_core::kernel_int::get_run_hwctx(run);
-  xrt_core::xdp::aie::dtrace::run_start(&run, hwctx.get_handle().get(),
-                                        xrt_core::kernel_int::get_run_uid(run),
-                                        xrt_core::kernel_int::get_run_kernel_name(run).c_str());
+  xrt_core::xdp::xrt_kernel_data data;
+  xrt_core::kernel_int::get_xdp_kernel_data(run, &data);
+  xrt_core::xdp::aie::dtrace::run_start(&run, data.hwctx.get_handle().get(),
+                                        data.uid,
+                                        data.name.c_str());
 }
 
 void
-run_wait(const xrt::run& run)
+run_start(const xrt_kernel_data& data)
 {
   if (!xrt_core::config::get_aie_dtrace())
     return;
 
-  auto hwctx = xrt_core::kernel_int::get_run_hwctx(run);
-  xrt_core::xdp::aie::dtrace::run_wait(const_cast<xrt::run*>(&run), hwctx.get_handle().get(),
-                                       xrt_core::kernel_int::get_run_uid(run),
-                                       xrt_core::kernel_int::get_run_kernel_name(run).c_str(),
-                                       static_cast<int>(xrt_core::kernel_int::get_run_state(run)));
+  xrt_core::xdp::aie::dtrace::run_start(nullptr, data.hwctx.get_handle().get(),
+                                        data.uid,
+                                        data.name.c_str());
+}
+
+void
+run_wait(const xrt_kernel_data& data)
+{
+  if (!xrt_core::config::get_aie_dtrace())
+    return;
+
+  xrt_core::xdp::aie::dtrace::run_wait(nullptr, data.hwctx.get_handle().get(),
+                                       data.uid,
+                                       data.name.c_str(),
+                                       data.ert_state);
 }
 
 } // end namespace xrt_core::xdp

--- a/src/runtime_src/core/common/xdp/profile.cpp
+++ b/src/runtime_src/core/common/xdp/profile.cpp
@@ -145,7 +145,6 @@ end_poll(void* handle)
 
 } // end namespace xrt_core::xdp::aie::profile
 
-#ifdef XDP_VE2_BUILD
 namespace xrt_core::xdp::aie::dtrace {
 
 std::function<void(void*, bool)> update_device_cb;
@@ -199,29 +198,27 @@ end_poll(void* handle)
 }
 
 void
-run_constructor(void* run, void* hwctx, uint32_t run_uid, const char* kernel_name,
-                void* elf_handle)
+run_constructor(const run_info& info)
 {
   if (run_constructor_cb)
-    run_constructor_cb(run, hwctx, run_uid, kernel_name, elf_handle);
+    run_constructor_cb(info.run, info.hwctx_handle, info.run_uid, info.kernel_name, info.elf_handle);
 }
 
 void
-run_start(void* run, void* hwctx, uint32_t run_uid, const char* kernel_name)
+run_start(const run_info& info)
 {
   if (run_start_cb)
-    run_start_cb(run, hwctx, run_uid, kernel_name);
+    run_start_cb(info.run, info.hwctx_handle, info.run_uid, info.kernel_name);
 }
 
 void
-run_wait(void* run, void* hwctx, uint32_t run_uid, const char* kernel_name, int ert_cmd_state)
+run_wait(const run_info& info)
 {
   if (run_wait_cb)
-    run_wait_cb(run, hwctx, run_uid, kernel_name, ert_cmd_state);
+    run_wait_cb(info.run, info.hwctx_handle, info.run_uid, info.kernel_name, info.ert_cmd_state);
 }
 
 } // end namespace xrt_core::xdp::aie::dtrace
-#endif
 
 namespace xrt_core::xdp::aie::debug {
 
@@ -862,30 +859,25 @@ finish_flush_device(void* handle)
 #endif
 }
 
-#ifdef XDP_VE2_BUILD
 void
-run_constructor(void* run, void* hwctx_handle, uint32_t run_uid, const char* kernel_name,
-                void* elf_handle)
+run_constructor(const run_info& info)
 {
   if (xrt_core::config::get_aie_dtrace())
-    xrt_core::xdp::aie::dtrace::run_constructor(run, hwctx_handle, run_uid, kernel_name,
-                                                elf_handle);
+    xrt_core::xdp::aie::dtrace::run_constructor(info);
 }
 
 void
-run_start(void* run, void* hwctx_handle, uint32_t run_uid, const char* kernel_name)
+run_start(const run_info& info)
 {
   if (xrt_core::config::get_aie_dtrace())
-    xrt_core::xdp::aie::dtrace::run_start(run, hwctx_handle, run_uid, kernel_name);
+    xrt_core::xdp::aie::dtrace::run_start(info);
 }
 
 void
-run_wait(void* run, void* hwctx_handle, uint32_t run_uid, const char* kernel_name,
-         int ert_cmd_state)
+run_wait(const run_info& info)
 {
   if (xrt_core::config::get_aie_dtrace())
-    xrt_core::xdp::aie::dtrace::run_wait(run, hwctx_handle, run_uid, kernel_name, ert_cmd_state);
+    xrt_core::xdp::aie::dtrace::run_wait(info);
 }
-#endif
 
 } // end namespace xrt_core::xdp

--- a/src/runtime_src/core/common/xdp/profile.cpp
+++ b/src/runtime_src/core/common/xdp/profile.cpp
@@ -93,18 +93,15 @@ namespace xrt_core::xdp::aie::profile {
 
 std::function<void (void*, bool)> update_device_cb;
 std::function<void (void*)> end_poll_cb;
-std::function<void (void*, void*, uint32_t, const char*, void*)> run_constructor_cb;
 
 void 
 register_callbacks(void* handle)
 {  
     using ftype = void (*)(void*);
     using utype = void (*)(void*, bool);
-    using rctype = void (*)(void*, void*, uint32_t, const char*, void*);
 
     update_device_cb = reinterpret_cast<utype>(xrt_core::dlsym(handle, "updateAIECtrDevice"));
     end_poll_cb = reinterpret_cast<ftype>(xrt_core::dlsym(handle, "endAIECtrPoll"));
-    run_constructor_cb = reinterpret_cast<rctype>(xrt_core::dlsym(handle, "aieProfileRunConstructor"));
 }
 
 void 
@@ -144,14 +141,6 @@ end_poll(void* handle)
 {
   if (end_poll_cb)
     end_poll_cb(handle);
-}
-
-void
-run_constructor(void* run, void* hwctx, uint32_t run_uid, const char* kernel_name,
-                void* elf_handle)
-{
-  if (run_constructor_cb)
-    run_constructor_cb(run, hwctx, run_uid, kernel_name, elf_handle);
 }
 
 } // end namespace xrt_core::xdp::aie::profile
@@ -879,9 +868,6 @@ void
 run_constructor(void* run, void* hwctx_handle, uint32_t run_uid, const char* kernel_name,
                 void* elf_handle)
 {
-  if (xrt_core::config::get_aie_profile())
-    xrt_core::xdp::aie::profile::run_constructor(run, hwctx_handle, run_uid, kernel_name,
-                                                  elf_handle);
   if (xrt_core::config::get_aie_dtrace())
     xrt_core::xdp::aie::dtrace::run_constructor(run, hwctx_handle, run_uid, kernel_name,
                                                 elf_handle);

--- a/src/runtime_src/core/common/xdp/profile.cpp
+++ b/src/runtime_src/core/common/xdp/profile.cpp
@@ -202,24 +202,43 @@ end_poll(void* handle)
 }
 
 void
-run_constructor(void* run, void* hwctx_handle, uint32_t run_uid, const char* kernel_name, void* elf_handle)
+run_constructor(const xrt::run_impl* run_impl)
 {
-  if (run_constructor_cb)
-    run_constructor_cb(run, hwctx_handle, run_uid, kernel_name, elf_handle);
+  if (run_constructor_cb) {
+    xrt_kernel_data data{};
+    xrt_core::kernel_int::get_xdp_kernel_data(run_impl, &data);
+    auto elf_hdl = data.mod ? xrt_core::module_int::get_elf_handle(data.mod) : nullptr;
+    run_constructor_cb(const_cast<xrt::run_impl*>(run_impl),
+                       data.hwctx.get_handle().get(),
+                       data.uid,
+                       data.name.c_str(),
+                       elf_hdl.get());
+  }
 }
 
 void
-run_start(void* run, void* hwctx_handle, uint32_t run_uid, const char* kernel_name)
+run_start(const xrt::run_impl* run_impl)
 {
-  if (run_start_cb)
-    run_start_cb(run, hwctx_handle, run_uid, kernel_name);
+  if (run_start_cb) {
+    xrt_kernel_data data{};
+    xrt_core::kernel_int::get_xdp_kernel_data(run_impl, &data);
+    run_start_cb(nullptr, data.hwctx.get_handle().get(),
+                 data.uid,
+                 data.name.c_str());
+  }
 }
 
 void
-run_wait(void* run, void* hwctx_handle, uint32_t run_uid, const char* kernel_name, int ert_cmd_state)
+run_wait(const xrt::run_impl* run_impl)
 {
-  if (run_wait_cb)
-    run_wait_cb(run, hwctx_handle, run_uid, kernel_name, ert_cmd_state);
+  if (run_wait_cb) {
+    xrt_kernel_data data{};
+    xrt_core::kernel_int::get_xdp_kernel_data(run_impl, &data);
+    run_wait_cb(nullptr, data.hwctx.get_handle().get(),
+                data.uid,
+                data.name.c_str(),
+                data.ert_state);
+  }
 }
 
 } // end namespace xrt_core::xdp::aie::dtrace
@@ -864,39 +883,30 @@ finish_flush_device(void* handle)
 }
 
 void
-run_constructor(xrt::run_impl* run_impl, const xrt_kernel_data& data)
+run_constructor(const xrt::run_impl* run_impl)
 {
   if (!xrt_core::config::get_aie_dtrace())
     return;
 
-  auto elf_hdl = data.mod ? xrt_core::module_int::get_elf_handle(data.mod) : nullptr;
-  xrt_core::xdp::aie::dtrace::run_constructor(run_impl, data.hwctx.get_handle().get(),
-                                              data.uid,
-                                              data.name.c_str(),
-                                              elf_hdl.get());
+  xrt_core::xdp::aie::dtrace::run_constructor(run_impl);
 }
 
 void
-run_start(const xrt_kernel_data& data)
+run_start(const xrt::run_impl* run_impl)
 {
   if (!xrt_core::config::get_aie_dtrace())
     return;
 
-  xrt_core::xdp::aie::dtrace::run_start(nullptr, data.hwctx.get_handle().get(),
-                                        data.uid,
-                                        data.name.c_str());
+  xrt_core::xdp::aie::dtrace::run_start(run_impl);
 }
 
 void
-run_wait(const xrt_kernel_data& data)
+run_wait(const xrt::run_impl* run_impl)
 {
   if (!xrt_core::config::get_aie_dtrace())
     return;
 
-  xrt_core::xdp::aie::dtrace::run_wait(nullptr, data.hwctx.get_handle().get(),
-                                       data.uid,
-                                       data.name.c_str(),
-                                       data.ert_state);
+  xrt_core::xdp::aie::dtrace::run_wait(run_impl);
 }
 
 } // end namespace xrt_core::xdp

--- a/src/runtime_src/core/common/xdp/profile.cpp
+++ b/src/runtime_src/core/common/xdp/profile.cpp
@@ -156,6 +156,62 @@ run_constructor(void* run, void* hwctx, uint32_t run_uid, const char* kernel_nam
 
 } // end namespace xrt_core::xdp::aie::profile
 
+namespace xrt_core::xdp::aie::dtrace {
+
+std::function<void(void*, bool)> update_device_cb;
+std::function<void(void*)> end_poll_cb;
+std::function<void(void*, void*, uint32_t, const char*, void*)> run_constructor_cb;
+
+void
+register_callbacks(void* handle)
+{
+  using ftype = void (*)(void*);
+  using utype = void (*)(void*, bool);
+  using rctype = void (*)(void*, void*, uint32_t, const char*, void*);
+
+  update_device_cb = reinterpret_cast<utype>(xrt_core::dlsym(handle, "updateAIEDtraceDevice"));
+  end_poll_cb = reinterpret_cast<ftype>(xrt_core::dlsym(handle, "endAIEDtracePoll"));
+  run_constructor_cb = reinterpret_cast<rctype>(xrt_core::dlsym(handle, "aieDtraceRunConstructor"));
+}
+
+void
+load_xdna()
+{
+  static xrt_core::module_loader xdp_aie_dtrace_loader("xdp_aie_dtrace_plugin_xdna",
+                                                       register_callbacks,
+                                                       warning_callbacks_empty);
+}
+
+void
+load()
+{
+  load_xdna();
+}
+
+void
+update_device(void* handle, bool hw_context_flow)
+{
+  if (update_device_cb)
+    update_device_cb(handle, hw_context_flow);
+}
+
+void
+end_poll(void* handle)
+{
+  if (end_poll_cb)
+    end_poll_cb(handle);
+}
+
+void
+run_constructor(void* run, void* hwctx, uint32_t run_uid, const char* kernel_name,
+                void* elf_handle)
+{
+  if (run_constructor_cb)
+    run_constructor_cb(run, hwctx, run_uid, kernel_name, elf_handle);
+}
+
+} // end namespace xrt_core::xdp::aie::dtrace
+
 namespace xrt_core::xdp::aie::debug {
 
 std::function<void (void*)> update_device_cb;
@@ -548,6 +604,7 @@ update_device(void* handle, bool hw_context_flow)
   #ifdef _WIN32
   if (xrt_core::config::get_ml_timeline()
       || xrt_core::config::get_aie_profile()
+      || xrt_core::config::get_aie_dtrace()
       || xrt_core::config::get_aie_trace()
       || xrt_core::config::get_aie_debug()
       || xrt_core::config::get_aie_halt()
@@ -677,6 +734,24 @@ update_device(void* handle, bool hw_context_flow)
            handle,
 	 	      hw_context_flow);
 
+  load_once_and_update(xrt_core::config::get_aie_dtrace,
+           []() {
+            if (xrt_core::config::get_xdp_mode() == "xdna") {
+              xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT",
+                "xdp_mode is XDNA; loading AIE dtrace plugin for XDNA device.");
+              xrt_core::xdp::aie::dtrace::load_xdna();
+            } else {
+              xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT",
+                "xdp_mode is ZOCL; loading AIE dtrace plugin for ZOCL device.");
+              xrt_core::xdp::aie::dtrace::load();
+            }
+           },
+           xrt_core::xdp::aie::dtrace::update_device,
+           "Failed to load AIE dtrace library. Caught exception ",
+           "Failed to setup for AIE dtrace. Caught exception ",
+           handle,
+           hw_context_flow);
+
 #else
 
   load_once_and_update(  
@@ -737,6 +812,8 @@ finish_flush_device(void* handle)
     xrt_core::xdp::aie::halt::finish_flush_device(handle);
   if (xrt_core::config::get_aie_profile())
     xrt_core::xdp::aie::profile::end_poll(handle);
+  if (xrt_core::config::get_aie_dtrace())
+    xrt_core::xdp::aie::dtrace::end_poll(handle);
   if (xrt_core::config::get_aie_trace())
     xrt_core::xdp::aie::trace::end_trace(handle);
   if (xrt_core::config::get_aie_debug())
@@ -758,6 +835,8 @@ finish_flush_device(void* handle)
     xrt_core::xdp::ml_timeline::finish_flush_device(handle);
   if (xrt_core::config::get_aie_profile())
     xrt_core::xdp::aie::profile::end_poll(handle);
+  if (xrt_core::config::get_aie_dtrace())
+    xrt_core::xdp::aie::dtrace::end_poll(handle);
 
 #else
 
@@ -783,6 +862,9 @@ run_constructor(void* run, void* hwctx_handle, uint32_t run_uid, const char* ker
   if (xrt_core::config::get_aie_profile())
     xrt_core::xdp::aie::profile::run_constructor(run, hwctx_handle, run_uid, kernel_name,
                                                   elf_handle);
+  if (xrt_core::config::get_aie_dtrace())
+    xrt_core::xdp::aie::dtrace::run_constructor(run, hwctx_handle, run_uid, kernel_name,
+                                                elf_handle);
 }
 
 } // end namespace xrt_core::xdp

--- a/src/runtime_src/core/common/xdp/profile.cpp
+++ b/src/runtime_src/core/common/xdp/profile.cpp
@@ -93,14 +93,14 @@ namespace xrt_core::xdp::aie::profile {
 
 std::function<void (void*, bool)> update_device_cb;
 std::function<void (void*)> end_poll_cb;
-std::function<void (void*, void*)> run_constructor_cb;
+std::function<void (void*, void*, uint32_t)> run_constructor_cb;
 
 void 
 register_callbacks(void* handle)
 {  
     using ftype = void (*)(void*);
     using utype = void (*)(void*, bool);
-    using rctype = void (*)(void*, void*);
+    using rctype = void (*)(void*, void*, uint32_t);
 
     update_device_cb = reinterpret_cast<utype>(xrt_core::dlsym(handle, "updateAIECtrDevice"));
     end_poll_cb = reinterpret_cast<ftype>(xrt_core::dlsym(handle, "endAIECtrPoll"));
@@ -147,10 +147,10 @@ end_poll(void* handle)
 }
 
 void
-run_constructor(void* run, void* hwctx)
+run_constructor(void* run, void* hwctx, uint32_t run_uid)
 {
   if (run_constructor_cb)
-    run_constructor_cb(run, hwctx);
+    run_constructor_cb(run, hwctx, run_uid);
 }
 
 } // end namespace xrt_core::xdp::aie::profile
@@ -776,10 +776,10 @@ finish_flush_device(void* handle)
 }
 
 void
-run_constructor(void* run, void* hwctx_handle)
+run_constructor(void* run, void* hwctx_handle, uint32_t run_uid)
 {
   if (xrt_core::config::get_aie_profile())
-    xrt_core::xdp::aie::profile::run_constructor(run, hwctx_handle);
+    xrt_core::xdp::aie::profile::run_constructor(run, hwctx_handle, run_uid);
 }
 
 } // end namespace xrt_core::xdp

--- a/src/runtime_src/core/common/xdp/profile.cpp
+++ b/src/runtime_src/core/common/xdp/profile.cpp
@@ -864,31 +864,16 @@ finish_flush_device(void* handle)
 }
 
 void
-run_constructor(xrt::run& run)
+run_constructor(xrt::run_impl* run_impl, const xrt_kernel_data& data)
 {
   if (!xrt_core::config::get_aie_dtrace())
     return;
 
-  xrt_core::xdp::xrt_kernel_data data;
-  xrt_core::kernel_int::get_xdp_kernel_data(run, &data);
   auto elf_hdl = data.mod ? xrt_core::module_int::get_elf_handle(data.mod) : nullptr;
-  xrt_core::xdp::aie::dtrace::run_constructor(&run, data.hwctx.get_handle().get(),
+  xrt_core::xdp::aie::dtrace::run_constructor(run_impl, data.hwctx.get_handle().get(),
                                               data.uid,
                                               data.name.c_str(),
                                               elf_hdl.get());
-}
-
-void
-run_start(xrt::run& run)
-{
-  if (!xrt_core::config::get_aie_dtrace())
-    return;
-
-  xrt_core::xdp::xrt_kernel_data data;
-  xrt_core::kernel_int::get_xdp_kernel_data(run, &data);
-  xrt_core::xdp::aie::dtrace::run_start(&run, data.hwctx.get_handle().get(),
-                                        data.uid,
-                                        data.name.c_str());
 }
 
 void

--- a/src/runtime_src/core/common/xdp/profile.cpp
+++ b/src/runtime_src/core/common/xdp/profile.cpp
@@ -3,10 +3,14 @@
 #define XRT_CORE_COMMON_SOURCE
 #include "core/common/xdp/profile.h"
 
+#include "core/common/api/kernel_int.h"
+#include "core/common/api/module_int.h"
 #include "core/common/config_reader.h"
 #include "core/common/dlfcn.h"
 #include "core/common/module_loader.h"
 #include "core/common/message.h"
+#include "core/include/xrt/xrt_kernel.h"
+
 #include <cstring>
 #include <functional>
 #include <sstream>
@@ -198,24 +202,24 @@ end_poll(void* handle)
 }
 
 void
-run_constructor(const run_info& info)
+run_constructor(void* run, void* hwctx_handle, uint32_t run_uid, const char* kernel_name, void* elf_handle)
 {
   if (run_constructor_cb)
-    run_constructor_cb(info.run, info.hwctx_handle, info.run_uid, info.kernel_name, info.elf_handle);
+    run_constructor_cb(run, hwctx_handle, run_uid, kernel_name, elf_handle);
 }
 
 void
-run_start(const run_info& info)
+run_start(void* run, void* hwctx_handle, uint32_t run_uid, const char* kernel_name)
 {
   if (run_start_cb)
-    run_start_cb(info.run, info.hwctx_handle, info.run_uid, info.kernel_name);
+    run_start_cb(run, hwctx_handle, run_uid, kernel_name);
 }
 
 void
-run_wait(const run_info& info)
+run_wait(void* run, void* hwctx_handle, uint32_t run_uid, const char* kernel_name, int ert_cmd_state)
 {
   if (run_wait_cb)
-    run_wait_cb(info.run, info.hwctx_handle, info.run_uid, info.kernel_name, info.ert_cmd_state);
+    run_wait_cb(run, hwctx_handle, run_uid, kernel_name, ert_cmd_state);
 }
 
 } // end namespace xrt_core::xdp::aie::dtrace
@@ -860,24 +864,43 @@ finish_flush_device(void* handle)
 }
 
 void
-run_constructor(const run_info& info)
+run_constructor(xrt::run& run)
 {
-  if (xrt_core::config::get_aie_dtrace())
-    xrt_core::xdp::aie::dtrace::run_constructor(info);
+  if (!xrt_core::config::get_aie_dtrace())
+    return;
+
+  auto hwctx = xrt_core::kernel_int::get_run_hwctx(run);
+  const auto& mod = xrt_core::kernel_int::get_run_module(run);
+  auto elf_hdl = mod ? xrt_core::module_int::get_elf_handle(mod) : nullptr;
+  xrt_core::xdp::aie::dtrace::run_constructor(&run, hwctx.get_handle().get(),
+                                              xrt_core::kernel_int::get_run_uid(run),
+                                              xrt_core::kernel_int::get_run_kernel_name(run).c_str(),
+                                              elf_hdl.get());
 }
 
 void
-run_start(const run_info& info)
+run_start(xrt::run& run)
 {
-  if (xrt_core::config::get_aie_dtrace())
-    xrt_core::xdp::aie::dtrace::run_start(info);
+  if (!xrt_core::config::get_aie_dtrace())
+    return;
+
+  auto hwctx = xrt_core::kernel_int::get_run_hwctx(run);
+  xrt_core::xdp::aie::dtrace::run_start(&run, hwctx.get_handle().get(),
+                                        xrt_core::kernel_int::get_run_uid(run),
+                                        xrt_core::kernel_int::get_run_kernel_name(run).c_str());
 }
 
 void
-run_wait(const run_info& info)
+run_wait(const xrt::run& run)
 {
-  if (xrt_core::config::get_aie_dtrace())
-    xrt_core::xdp::aie::dtrace::run_wait(info);
+  if (!xrt_core::config::get_aie_dtrace())
+    return;
+
+  auto hwctx = xrt_core::kernel_int::get_run_hwctx(run);
+  xrt_core::xdp::aie::dtrace::run_wait(const_cast<xrt::run*>(&run), hwctx.get_handle().get(),
+                                       xrt_core::kernel_int::get_run_uid(run),
+                                       xrt_core::kernel_int::get_run_kernel_name(run).c_str(),
+                                       static_cast<int>(xrt_core::kernel_int::get_run_state(run)));
 }
 
 } // end namespace xrt_core::xdp

--- a/src/runtime_src/core/common/xdp/profile.cpp
+++ b/src/runtime_src/core/common/xdp/profile.cpp
@@ -145,6 +145,7 @@ end_poll(void* handle)
 
 } // end namespace xrt_core::xdp::aie::profile
 
+#ifdef XDP_VE2_BUILD
 namespace xrt_core::xdp::aie::dtrace {
 
 std::function<void(void*, bool)> update_device_cb;
@@ -220,6 +221,7 @@ run_wait(void* run, void* hwctx, uint32_t run_uid, const char* kernel_name, int 
 }
 
 } // end namespace xrt_core::xdp::aie::dtrace
+#endif
 
 namespace xrt_core::xdp::aie::debug {
 
@@ -749,10 +751,6 @@ update_device(void* handle, bool hw_context_flow)
               xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT",
                 "xdp_mode is XDNA; loading AIE dtrace plugin for XDNA device.");
               xrt_core::xdp::aie::dtrace::load_xdna();
-            } else {
-              xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT",
-                "xdp_mode is ZOCL; loading AIE dtrace plugin for ZOCL device.");
-              xrt_core::xdp::aie::dtrace::load();
             }
            },
            xrt_core::xdp::aie::dtrace::update_device,
@@ -864,6 +862,7 @@ finish_flush_device(void* handle)
 #endif
 }
 
+#ifdef XDP_VE2_BUILD
 void
 run_constructor(void* run, void* hwctx_handle, uint32_t run_uid, const char* kernel_name,
                 void* elf_handle)
@@ -887,5 +886,6 @@ run_wait(void* run, void* hwctx_handle, uint32_t run_uid, const char* kernel_nam
   if (xrt_core::config::get_aie_dtrace())
     xrt_core::xdp::aie::dtrace::run_wait(run, hwctx_handle, run_uid, kernel_name, ert_cmd_state);
 }
+#endif
 
 } // end namespace xrt_core::xdp

--- a/src/runtime_src/core/common/xdp/profile.cpp
+++ b/src/runtime_src/core/common/xdp/profile.cpp
@@ -93,14 +93,14 @@ namespace xrt_core::xdp::aie::profile {
 
 std::function<void (void*, bool)> update_device_cb;
 std::function<void (void*)> end_poll_cb;
-std::function<void (void*, void*, uint32_t)> run_constructor_cb;
+std::function<void (void*, void*, uint32_t, const char*, void*)> run_constructor_cb;
 
 void 
 register_callbacks(void* handle)
 {  
     using ftype = void (*)(void*);
     using utype = void (*)(void*, bool);
-    using rctype = void (*)(void*, void*, uint32_t);
+    using rctype = void (*)(void*, void*, uint32_t, const char*, void*);
 
     update_device_cb = reinterpret_cast<utype>(xrt_core::dlsym(handle, "updateAIECtrDevice"));
     end_poll_cb = reinterpret_cast<ftype>(xrt_core::dlsym(handle, "endAIECtrPoll"));
@@ -147,10 +147,11 @@ end_poll(void* handle)
 }
 
 void
-run_constructor(void* run, void* hwctx, uint32_t run_uid)
+run_constructor(void* run, void* hwctx, uint32_t run_uid, const char* kernel_name,
+                void* elf_handle)
 {
   if (run_constructor_cb)
-    run_constructor_cb(run, hwctx, run_uid);
+    run_constructor_cb(run, hwctx, run_uid, kernel_name, elf_handle);
 }
 
 } // end namespace xrt_core::xdp::aie::profile
@@ -776,10 +777,12 @@ finish_flush_device(void* handle)
 }
 
 void
-run_constructor(void* run, void* hwctx_handle, uint32_t run_uid)
+run_constructor(void* run, void* hwctx_handle, uint32_t run_uid, const char* kernel_name,
+                void* elf_handle)
 {
   if (xrt_core::config::get_aie_profile())
-    xrt_core::xdp::aie::profile::run_constructor(run, hwctx_handle, run_uid);
+    xrt_core::xdp::aie::profile::run_constructor(run, hwctx_handle, run_uid, kernel_name,
+                                                  elf_handle);
 }
 
 } // end namespace xrt_core::xdp

--- a/src/runtime_src/core/common/xdp/profile.cpp
+++ b/src/runtime_src/core/common/xdp/profile.cpp
@@ -202,13 +202,13 @@ end_poll(void* handle)
 }
 
 void
-run_constructor(const xrt::run_impl* run_impl)
+run_constructor(xrt::run_impl* run_impl)
 {
   if (run_constructor_cb) {
     xrt_kernel_data data{};
     xrt_core::kernel_int::get_xdp_kernel_data(run_impl, &data);
     auto elf_hdl = data.mod ? xrt_core::module_int::get_elf_handle(data.mod) : nullptr;
-    run_constructor_cb(const_cast<xrt::run_impl*>(run_impl),
+    run_constructor_cb(run_impl,
                        data.hwctx.get_handle().get(),
                        data.uid,
                        data.name.c_str(),
@@ -883,7 +883,7 @@ finish_flush_device(void* handle)
 }
 
 void
-run_constructor(const xrt::run_impl* run_impl)
+run_constructor(xrt::run_impl* run_impl)
 {
   if (!xrt_core::config::get_aie_dtrace())
     return;

--- a/src/runtime_src/core/common/xdp/profile.cpp
+++ b/src/runtime_src/core/common/xdp/profile.cpp
@@ -93,15 +93,18 @@ namespace xrt_core::xdp::aie::profile {
 
 std::function<void (void*, bool)> update_device_cb;
 std::function<void (void*)> end_poll_cb;
+std::function<void (void*, void*)> run_constructor_cb;
 
 void 
 register_callbacks(void* handle)
 {  
     using ftype = void (*)(void*);
     using utype = void (*)(void*, bool);
+    using rctype = void (*)(void*, void*);
 
     update_device_cb = reinterpret_cast<utype>(xrt_core::dlsym(handle, "updateAIECtrDevice"));
     end_poll_cb = reinterpret_cast<ftype>(xrt_core::dlsym(handle, "endAIECtrPoll"));
+    run_constructor_cb = reinterpret_cast<rctype>(xrt_core::dlsym(handle, "aieProfileRunConstructor"));
 }
 
 void 
@@ -141,6 +144,13 @@ end_poll(void* handle)
 {
   if (end_poll_cb)
     end_poll_cb(handle);
+}
+
+void
+run_constructor(void* run, void* hwctx)
+{
+  if (run_constructor_cb)
+    run_constructor_cb(run, hwctx);
 }
 
 } // end namespace xrt_core::xdp::aie::profile
@@ -763,6 +773,13 @@ finish_flush_device(void* handle)
     xrt_core::xdp::hal::device_offload::finish_flush_device(handle) ;
 
 #endif
+}
+
+void
+run_constructor(void* run, void* hwctx_handle)
+{
+  if (xrt_core::config::get_aie_profile())
+    xrt_core::xdp::aie::profile::run_constructor(run, hwctx_handle);
 }
 
 } // end namespace xrt_core::xdp

--- a/src/runtime_src/core/common/xdp/profile.h
+++ b/src/runtime_src/core/common/xdp/profile.h
@@ -52,8 +52,9 @@ finish_flush_device(void* handle);
 // This hook allows XDP plugins to attach per-run resources (e.g.,
 // a CT file for dtrace) before the run is started.
 // Called from run_impl constructor with the raw handle.
+// Non-const because the callback may modify run_impl (e.g., set_dtrace_control_file).
 void
-run_constructor(const xrt::run_impl* run_impl);
+run_constructor(xrt::run_impl* run_impl);
 
 // run_start should be called immediately before a run is submitted to the device.
 // Extracts kernel data internally from the run_impl.

--- a/src/runtime_src/core/common/xdp/profile.h
+++ b/src/runtime_src/core/common/xdp/profile.h
@@ -22,6 +22,12 @@ update_device(void* handle, bool hw_context_flow);
 void 
 finish_flush_device(void* handle);
 
+// run_constructor should be called when an xrt::run is constructed.
+// This hook allows XDP plugins to attach per-run resources (e.g.,
+// a CT file for dtrace) before the run is started.
+void
+run_constructor(void* run, void* hwctx_handle);
+
 } // end namespace xrt_core::xdp
 
 #endif

--- a/src/runtime_src/core/common/xdp/profile.h
+++ b/src/runtime_src/core/common/xdp/profile.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023-2025 Advanced Micro Devices, Inc. - All rights reserved
+// Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
 #ifndef CORE_COMMON_PROFILE_DOT_H
 #define CORE_COMMON_PROFILE_DOT_H
 

--- a/src/runtime_src/core/common/xdp/profile.h
+++ b/src/runtime_src/core/common/xdp/profile.h
@@ -35,6 +35,21 @@ struct run_info
   int ert_cmd_state;  // used by run_wait, passed as int for stable C plugin ABI
 };
 
+// Helper to construct run_info for XDP hooks
+inline run_info
+make_run_info(void* run, void* hwctx_handle, uint32_t run_uid,
+              const char* kernel_name, void* elf_handle = nullptr, int ert_cmd_state = 0)
+{
+  run_info info;
+  info.run = run;
+  info.hwctx_handle = hwctx_handle;
+  info.run_uid = run_uid;
+  info.kernel_name = kernel_name;
+  info.elf_handle = elf_handle;
+  info.ert_cmd_state = ert_cmd_state;
+  return info;
+}
+
 // run_constructor should be called when an xrt::run is constructed.
 // This hook allows XDP plugins to attach per-run resources (e.g.,
 // a CT file for dtrace) before the run is started.

--- a/src/runtime_src/core/common/xdp/profile.h
+++ b/src/runtime_src/core/common/xdp/profile.h
@@ -10,7 +10,7 @@
 #include <string>
 
 namespace xrt {
-class run;
+class run_impl;
 }
 
 // Data structure for XDP kernel profiling hooks.
@@ -48,20 +48,15 @@ update_device(void* handle, bool hw_context_flow);
 void 
 finish_flush_device(void* handle);
 
-// run_constructor should be called when an xrt::run is constructed.
+// run_constructor should be called when a run_impl is constructed.
 // This hook allows XDP plugins to attach per-run resources (e.g.,
 // a CT file for dtrace) before the run is started.
-// Note: This hook requires xrt::run& because the XDP plugin needs to call
-// methods on the run object (e.g., set_dtrace_control_file).
+// Called from run_impl constructor with the raw handle.
 void
-run_constructor(xrt::run& run);
+run_constructor(xrt::run_impl* run_impl, const xrt_kernel_data& data);
 
 // run_start should be called immediately before a run is submitted to the device.
-void
-run_start(xrt::run& run);
-
-// Overload for implementation-level calls (e.g., from run_impl::start() or C API).
-// This version takes the kernel data directly without requiring an xrt::run object.
+// Takes the kernel data directly without requiring an xrt::run object.
 void
 run_start(const xrt_kernel_data& data);
 

--- a/src/runtime_src/core/common/xdp/profile.h
+++ b/src/runtime_src/core/common/xdp/profile.h
@@ -53,17 +53,17 @@ finish_flush_device(void* handle);
 // a CT file for dtrace) before the run is started.
 // Called from run_impl constructor with the raw handle.
 void
-run_constructor(xrt::run_impl* run_impl, const xrt_kernel_data& data);
+run_constructor(const xrt::run_impl* run_impl);
 
 // run_start should be called immediately before a run is submitted to the device.
-// Takes the kernel data directly without requiring an xrt::run object.
+// Extracts kernel data internally from the run_impl.
 void
-run_start(const xrt_kernel_data& data);
+run_start(const xrt::run_impl* run_impl);
 
 // run_wait should be called when a run wait completes (after the underlying wait returns).
-// The ert_state field in data should be set before calling this.
+// Extracts kernel data internally from the run_impl, including the ERT state.
 void
-run_wait(const xrt_kernel_data& data);
+run_wait(const xrt::run_impl* run_impl);
 
 } // end namespace xrt_core::xdp
 

--- a/src/runtime_src/core/common/xdp/profile.h
+++ b/src/runtime_src/core/common/xdp/profile.h
@@ -3,6 +3,8 @@
 #ifndef CORE_COMMON_PROFILE_DOT_H
 #define CORE_COMMON_PROFILE_DOT_H
 
+#include <cstdint>
+
 // The functions here are the general interfaces for the XDP hooks that are
 // called from the common coreutil library and not the specific shims.
 namespace xrt_core::xdp {
@@ -26,7 +28,7 @@ finish_flush_device(void* handle);
 // This hook allows XDP plugins to attach per-run resources (e.g.,
 // a CT file for dtrace) before the run is started.
 void
-run_constructor(void* run, void* hwctx_handle);
+run_constructor(void* run, void* hwctx_handle, uint32_t run_uid);
 
 } // end namespace xrt_core::xdp
 

--- a/src/runtime_src/core/common/xdp/profile.h
+++ b/src/runtime_src/core/common/xdp/profile.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
+// Copyright (C) 2023-2025 Advanced Micro Devices, Inc. - All rights reserved
 #ifndef CORE_COMMON_PROFILE_DOT_H
 #define CORE_COMMON_PROFILE_DOT_H
 
@@ -24,6 +24,7 @@ update_device(void* handle, bool hw_context_flow);
 void 
 finish_flush_device(void* handle);
 
+#ifdef XDP_VE2_BUILD
 // run_constructor should be called when an xrt::run is constructed.
 // This hook allows XDP plugins to attach per-run resources (e.g.,
 // a CT file for dtrace) before the run is started.
@@ -40,6 +41,7 @@ run_start(void* run, void* hwctx_handle, uint32_t run_uid, const char* kernel_na
 void
 run_wait(void* run, void* hwctx_handle, uint32_t run_uid, const char* kernel_name,
          int ert_cmd_state);
+#endif
 
 } // end namespace xrt_core::xdp
 

--- a/src/runtime_src/core/common/xdp/profile.h
+++ b/src/runtime_src/core/common/xdp/profile.h
@@ -3,11 +3,31 @@
 #ifndef CORE_COMMON_PROFILE_DOT_H
 #define CORE_COMMON_PROFILE_DOT_H
 
+#include "core/include/xrt/xrt_hw_context.h"
+#include "core/include/xrt/experimental/xrt_module.h"
+
 #include <cstdint>
+#include <string>
 
 namespace xrt {
 class run;
 }
+
+// Data structure for XDP kernel profiling hooks.
+// This struct is used to pass kernel/run information from xrt_kernel.cpp
+// to the XDP profiling infrastructure.
+namespace xrt_core::xdp {
+
+struct xrt_kernel_data
+{
+  uint32_t uid;
+  std::string name;
+  xrt::hw_context hwctx;
+  xrt::module mod;
+  int ert_state = 0;  // ERT command state, only meaningful for run_wait hook
+};
+
+} // end namespace xrt_core::xdp
 
 // The functions here are the general interfaces for the XDP hooks that are
 // called from the common coreutil library and not the specific shims.
@@ -31,6 +51,8 @@ finish_flush_device(void* handle);
 // run_constructor should be called when an xrt::run is constructed.
 // This hook allows XDP plugins to attach per-run resources (e.g.,
 // a CT file for dtrace) before the run is started.
+// Note: This hook requires xrt::run& because the XDP plugin needs to call
+// methods on the run object (e.g., set_dtrace_control_file).
 void
 run_constructor(xrt::run& run);
 
@@ -38,9 +60,15 @@ run_constructor(xrt::run& run);
 void
 run_start(xrt::run& run);
 
-// run_wait should be called when a run wait completes (after the underlying wait returns).
+// Overload for implementation-level calls (e.g., from run_impl::start() or C API).
+// This version takes the kernel data directly without requiring an xrt::run object.
 void
-run_wait(const xrt::run& run);
+run_start(const xrt_kernel_data& data);
+
+// run_wait should be called when a run wait completes (after the underlying wait returns).
+// The ert_state field in data should be set before calling this.
+void
+run_wait(const xrt_kernel_data& data);
 
 } // end namespace xrt_core::xdp
 

--- a/src/runtime_src/core/common/xdp/profile.h
+++ b/src/runtime_src/core/common/xdp/profile.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023 Advanced Micro Devices, Inc. - All rights reserved
+// Copyright (C) 2023-2025 Advanced Micro Devices, Inc. - All rights reserved
 #ifndef CORE_COMMON_PROFILE_DOT_H
 #define CORE_COMMON_PROFILE_DOT_H
 
@@ -24,24 +24,30 @@ update_device(void* handle, bool hw_context_flow);
 void 
 finish_flush_device(void* handle);
 
-#ifdef XDP_VE2_BUILD
+// Encapsulates all context needed for run-level XDP hooks
+struct run_info
+{
+  void* run;
+  void* hwctx_handle;
+  uint32_t run_uid;
+  const char* kernel_name;
+  void* elf_handle;
+  int ert_cmd_state;  // used by run_wait, passed as int for stable C plugin ABI
+};
+
 // run_constructor should be called when an xrt::run is constructed.
 // This hook allows XDP plugins to attach per-run resources (e.g.,
 // a CT file for dtrace) before the run is started.
 void
-run_constructor(void* run, void* hwctx_handle, uint32_t run_uid,
-                const char* kernel_name, void* elf_handle);
+run_constructor(const run_info& info);
 
 // run_start should be called immediately before a run is submitted to the device.
 void
-run_start(void* run, void* hwctx_handle, uint32_t run_uid, const char* kernel_name);
+run_start(const run_info& info);
 
 // run_wait should be called when a run wait completes (after the underlying wait returns).
-// ert_cmd_state is passed as int for a stable C plugin ABI.
 void
-run_wait(void* run, void* hwctx_handle, uint32_t run_uid, const char* kernel_name,
-         int ert_cmd_state);
-#endif
+run_wait(const run_info& info);
 
 } // end namespace xrt_core::xdp
 

--- a/src/runtime_src/core/common/xdp/profile.h
+++ b/src/runtime_src/core/common/xdp/profile.h
@@ -28,7 +28,8 @@ finish_flush_device(void* handle);
 // This hook allows XDP plugins to attach per-run resources (e.g.,
 // a CT file for dtrace) before the run is started.
 void
-run_constructor(void* run, void* hwctx_handle, uint32_t run_uid);
+run_constructor(void* run, void* hwctx_handle, uint32_t run_uid,
+                const char* kernel_name, void* elf_handle);
 
 } // end namespace xrt_core::xdp
 

--- a/src/runtime_src/core/common/xdp/profile.h
+++ b/src/runtime_src/core/common/xdp/profile.h
@@ -5,6 +5,10 @@
 
 #include <cstdint>
 
+namespace xrt {
+class run;
+}
+
 // The functions here are the general interfaces for the XDP hooks that are
 // called from the common coreutil library and not the specific shims.
 namespace xrt_core::xdp {
@@ -24,45 +28,19 @@ update_device(void* handle, bool hw_context_flow);
 void 
 finish_flush_device(void* handle);
 
-// Encapsulates all context needed for run-level XDP hooks
-struct run_info
-{
-  void* run;
-  void* hwctx_handle;
-  uint32_t run_uid;
-  const char* kernel_name;
-  void* elf_handle;
-  int ert_cmd_state;  // used by run_wait, passed as int for stable C plugin ABI
-};
-
-// Helper to construct run_info for XDP hooks
-inline run_info
-make_run_info(void* run, void* hwctx_handle, uint32_t run_uid,
-              const char* kernel_name, void* elf_handle = nullptr, int ert_cmd_state = 0)
-{
-  run_info info;
-  info.run = run;
-  info.hwctx_handle = hwctx_handle;
-  info.run_uid = run_uid;
-  info.kernel_name = kernel_name;
-  info.elf_handle = elf_handle;
-  info.ert_cmd_state = ert_cmd_state;
-  return info;
-}
-
 // run_constructor should be called when an xrt::run is constructed.
 // This hook allows XDP plugins to attach per-run resources (e.g.,
 // a CT file for dtrace) before the run is started.
 void
-run_constructor(const run_info& info);
+run_constructor(xrt::run& run);
 
 // run_start should be called immediately before a run is submitted to the device.
 void
-run_start(const run_info& info);
+run_start(xrt::run& run);
 
 // run_wait should be called when a run wait completes (after the underlying wait returns).
 void
-run_wait(const run_info& info);
+run_wait(const xrt::run& run);
 
 } // end namespace xrt_core::xdp
 

--- a/src/runtime_src/core/common/xdp/profile.h
+++ b/src/runtime_src/core/common/xdp/profile.h
@@ -31,6 +31,16 @@ void
 run_constructor(void* run, void* hwctx_handle, uint32_t run_uid,
                 const char* kernel_name, void* elf_handle);
 
+// run_start should be called immediately before a run is submitted to the device.
+void
+run_start(void* run, void* hwctx_handle, uint32_t run_uid, const char* kernel_name);
+
+// run_wait should be called when a run wait completes (after the underlying wait returns).
+// ert_cmd_state is passed as int for a stable C plugin ABI.
+void
+run_wait(void* run, void* hwctx_handle, uint32_t run_uid, const char* kernel_name,
+         int ert_cmd_state);
+
 } // end namespace xrt_core::xdp
 
 #endif


### PR DESCRIPTION
Fix : Added XDP dtrace plugin support for temporal sharing usecase.
- Added run constructor, run wait and run start hooks
- updated xdp submodule
- added dtrace plugin related settings in xrt.ini
- Use of aiebu api to get info from elf for dtrace

Testing: Verified few examples with and without XDP dtrace plugin. Verified temporal sharing example as well.