### PR TITLE
Update AIEBU for release artifacts fix

### DIFF
--- a/src/runtime_src/tools/scripts/xrtdeps.sh
+++ b/src/runtime_src/tools/scripts/xrtdeps.sh
@@ -178,6 +178,7 @@ ub_package_list()
      cppcheck \
      curl \
      dkms \
+     elfutils \
      file \
      g++ \
      gcc \
@@ -325,6 +326,7 @@ suse_package_list()
      curl \
      dkms \
      dmidecode \
+     elfutils \
      gcc \
      gcc-c++ \
      gdb \


### PR DESCRIPTION
#### Problem solved by the commit
Pull in https://github.com/Xilinx/aiebu/pull/259
Stop release of cert_dtrace shared objects.

Part of AIESW-29818