### PR TITLE
AIESW-26391:Fix eff_net hip testcase failure.

### DIFF
--- a/src/runtime_src/hip/core/event.cpp
+++ b/src/runtime_src/hip/core/event.cpp
@@ -255,14 +255,29 @@ kernel_start::kernel_start(std::shared_ptr<function> f, void** args)
         break;
 
       case karg::argtype::global: {
+        // Handle both base buffer addresses and computed addresses (base + offset).
+        // If offset is non-zero, carve out a sub-buffer and pass it as BO arg.
         void **bufptr = static_cast<void **>(args[idx]);
-        auto hip_mem = memory_database::instance().get_hip_mem_from_addr(*bufptr).first;
+        auto hip_mem_info = memory_database::instance().get_hip_mem_from_addr(*bufptr);
+        auto hip_mem = hip_mem_info.first;
         if (!hip_mem) {
-            std::string err_msg = "failed to get memory from arg at index - " + std::to_string(idx);
-	    throw_hip_error(hipErrorInvalidValue, err_msg.c_str());
-	}
+          std::string err_msg = "failed to get memory from arg at index - " + std::to_string(idx);
+          throw_hip_error(hipErrorInvalidValue, err_msg.c_str());
+        }
 
-        r.set_arg(arg->index, hip_mem->get_xrt_bo());
+        if (!hip_mem_info.second) {
+          r.set_arg(static_cast<int>(arg->index), hip_mem->get_xrt_bo());
+        }
+        else {
+          auto parent_size = hip_mem->get_size();
+          auto sub_offset = hip_mem_info.second;
+          throw_invalid_value_if(sub_offset >= parent_size,
+                                 "kernel arg pointer offset out of range.");
+
+          auto sub_size = parent_size - sub_offset;
+          r.set_arg(static_cast<int>(arg->index), xrt::bo{hip_mem->get_xrt_bo(), sub_size, sub_offset});
+        }
+
         break;
       }
       case karg::argtype::constant :


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
HIP kernels using pointer arithmetic for sub-buffer addresses (e.g., address + offset) fail because extracting the buffer object returns only the base address, losing the offset calculation. All computed addresses collapse to the same base value, causing kernels to access wrong memory.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
[AIESW-26391](https://jira.xilinx.com/browse/AIESW-26391)
HIP global arguments using pointer arithmetic (base + offset) incorrectly receive only the base address, causing kernels to access wrong memory locations.
#### How problem was solved, alternative solutions (if any) and why they were rejected
Use get_hip_mem_from_addr() to extract both the base buffer object and offset. When offset is non-zero (pointer arithmetic detected), pass the raw pointer to preserve the exact computed address. When offset is zero (base buffer), pass the buffer object with proper binding for memory management.
#### Risks (if any) associated the changes in the commit
Low
#### What has been tested and how, request additional testing if necessary
tested with test case added in
https://gitenterprise.xilinx.com/XRT/Telluride/pull/743
#### Documentation impact (if any)
NA