### PR TITLE
HIP:Add HIP_VERSION guard for hipMemcpyHtoDAsync.

### DIFF
--- a/src/runtime_src/hip/api/hip_memory.cpp
+++ b/src/runtime_src/hip/api/hip_memory.cpp
@@ -546,7 +546,11 @@ hipMemset(void* dst, int value, size_t size)
 }
 
 hipError_t
+#if HIP_VERSION >= 70000000
 hipMemcpyHtoDAsync(hipDeviceptr_t dst, const void* src, size_t size, hipStream_t stream)
+#else
+hipMemcpyHtoDAsync(hipDeviceptr_t dst, void* src, size_t size, hipStream_t stream)
+#endif
 {
   return handle_hip_func_error(__func__, hipErrorRuntimeMemory, [&] {
     xrt::core::hip::hip_memcpy_host2device_async(dst, src, size, stream);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
hipMemcpyHtoDAsync had signature mismatch across HIP versions because the src parameter type changed (void* in older HIP vs const void* in newer HIP)
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Issue discovered during compilation of testcses_v2 repo using old version of hip headers. 
#### How problem was solved, alternative solutions (if any) and why they were rejected
Add a HIP version conditional for hipMemcpyHtoDAsync so the public API signature matches the expected ABI across releases:
HIP >= 70000000: use const void* src
HIP < 70000000: use void* src
Keep internal host-to-device async copy helper unchanged with const source, since older-ABI void* callers are safely convertible to const void*. This preserves compatibility while maintaining const-correct internal behavior.
#### Risks (if any) associated the changes in the commit
Low
#### What has been tested and how, request additional testing if necessary
Tested with testcses_v2 repo with xrt hip build different versions of hip. 
#### Documentation impact (if any)
