### PR TITLE
Remove pyxrt from CMake export set

### DIFF
--- a/src/python/pybind11/CMakeLists.txt
+++ b/src/python/pybind11/CMakeLists.txt
@@ -58,7 +58,6 @@ if (pybind11_FOUND)
   endif()
 
   install(TARGETS pyxrt
-    EXPORT xrt-targets
     LIBRARY DESTINATION ${XRT_INSTALL_PYTHON_DIR} COMPONENT ${XRT_BASE_COMPONENT}
     )
 
@@ -108,7 +107,6 @@ if (pybind11_FOUND)
   set_target_properties(pyxrt PROPERTIES SUFFIX ".pyd")
 
   install(TARGETS pyxrt
-    EXPORT xrt-targets
     LIBRARY DESTINATION ${XRT_INSTALL_PYTHON_DIR} COMPONENT ${XRT_BASE_COMPONENT}
     )
 


### PR DESCRIPTION
#### Problem solved by the commit
pyxrt.pyd is not required at build time and should not be in xrt-targets.cmake.
