### PR TITLE
Deprecate messages added for kernel, IP and buffer constructors

### DIFF
--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -4417,6 +4417,12 @@ kernel(const xrt::device& xdev, const xrt::uuid& xclbin_id, const std::string& n
 {}
 
 kernel::
+kernel(const xrt::device& xdev, const xrt::uuid& xclbin_id, const std::string& name, bool ex)
+  : handle(xdp::native::profiling_wrapper("xrt::kernel::kernel",
+      alloc_kernel, get_device(xdev), xclbin_id, name, ex ? cu_access_mode::exclusive : cu_access_mode::shared))
+{}
+
+kernel::
 kernel(xclDeviceHandle dhdl, const xrt::uuid& xclbin_id, const std::string& name, cu_access_mode mode)
   : handle(xdp::native::profiling_wrapper("xrt::kernel::kernel",
       alloc_kernel, get_device(xrt_core::get_userpf_device(dhdl)), xclbin_id, name, mode))

--- a/src/runtime_src/core/include/xrt/experimental/xrt_ip.h
+++ b/src/runtime_src/core/include/xrt/experimental/xrt_ip.h
@@ -138,6 +138,7 @@ public:
    *
    * Constructor throws on error.
    */
+  [[deprecated("deprecated, please use ip(hw_context, name) instead")]]
   XCL_DRIVER_DLLESPEC
   ip(const xrt::device& device, const xrt::uuid& xclbin_id, const std::string& name);
 

--- a/src/runtime_src/core/include/xrt/xrt_aie.h
+++ b/src/runtime_src/core/include/xrt/xrt_aie.h
@@ -385,6 +385,7 @@ public:
    *  The device on which the profiling should start
    *
    */
+  [[deprecated("deprecated, please use profiling(hw_context) instead")]]
   explicit
   profiling(const xrt::device& device);
 

--- a/src/runtime_src/core/include/xrt/xrt_kernel.h
+++ b/src/runtime_src/core/include/xrt/xrt_kernel.h
@@ -795,6 +795,7 @@ public:
    * other kernels and other process will have shared access to same
    * compute units.
    */
+  [[deprecated("deprecated, please use kernel(hw_context, name) instead")]]
   XRT_API_EXPORT
   kernel(const xrt::device& device, const xrt::uuid& xclbin_id, const std::string& name,
          cu_access_mode mode = cu_access_mode::shared);
@@ -807,14 +808,13 @@ public:
   /// @endcond
 
   /// @cond
-  /// Deprecated construtor for exclusive access
-  kernel(const xrt::device& device, const xrt::uuid& xclbin_id, const std::string& name, bool ex)
-    : kernel(device, xclbin_id, name, ex ? cu_access_mode::exclusive : cu_access_mode::shared)
-  {}
+  /// Deprecated constructor for exclusive access
+  kernel(const xrt::device& device, const xrt::uuid& xclbin_id, const std::string& name, bool ex);
 
   /**
    * Obsoleted construction from xclDeviceHandle
    */
+  [[deprecated("deprecated, please use kernel(hw_context, name) instead")]]
   XRT_API_EXPORT
   kernel(xclDeviceHandle dhdl, const xrt::uuid& xclbin_id, const std::string& name,
          cu_access_mode mode = cu_access_mode::shared);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Mark legacy XRT entry points as deprecated in favor of hw_context-based APIs where a replacement exists (xrt::kernel, xrt::ip, xrt::aie::buffer, xrt::aie::profiling, 
and the xclDeviceHandle kernel overload).
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
old APIs are not getting depricate warnings.
#### How problem was solved, alternative solutions (if any) and why they were rejected
Mark legacy XRT entry points as deprecated in favor of hw_context-based APIs where a replacement exists (xrt::kernel, xrt::ip, xrt::aie::buffer, xrt::aie::profiling, 
and the xclDeviceHandle kernel overload).
#### Risks (if any) associated the changes in the commit
None 
#### What has been tested and how, request additional testing if necessary
build a sample application that uses these ctors and verify the warning is logged
#### Documentation impact (if any)
None 