### PR TITLE
pcie: linux: support non-PCI device discovery and sysfs access

### DIFF
--- a/src/runtime_src/core/pcie/linux/pcidev.cpp
+++ b/src/runtime_src/core/pcie/linux/pcidev.cpp
@@ -9,6 +9,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <charconv>
 #include <cstring>
 #include <dirent.h>
 #include <filesystem>
@@ -29,6 +30,34 @@
 namespace {
 
 namespace sfs = std::filesystem;
+
+// Parse a PCI sysfs name of the form "domain:bus:dev.func" (all hex),
+// e.g. "0000:01:00.0". Returns true only on a well-formed BDF.
+static bool
+parse_bdf(const std::string& name, uint16_t& domain, uint16_t& bus,
+          uint16_t& dev, uint16_t& func)
+{
+  constexpr int hex_base = 16;
+  const char* p = name.c_str();
+  const char* end = p + name.size();
+
+  auto field = [&](uint16_t& out, char sep) {
+    auto [ptr, ec] = std::from_chars(p, end, out, hex_base);
+    if (ec != std::errc{})
+      return false;
+    if (sep != '\0') {
+      if (ptr == end || *ptr != sep)
+        return false;
+      ++ptr;
+    }
+    p = ptr;
+    return true;
+  };
+
+  // Require the whole string to be a BDF and nothing else.
+  return field(domain, ':') && field(bus, ':')
+      && field(dev, '.') && field(func, '\0') && p == end;
+}
 
 static std::string
 get_name(const std::string& dir, const std::string& subdir)
@@ -158,19 +187,22 @@ namespace sysfs {
 static constexpr const char* dev_root = "/sys/bus/pci/devices/";
 
 static std::string
+get_dev_path(const std::string& name)
+{
+  if (!name.empty() && name.front() == '/')
+    return name;
+  return dev_root + name;
+}
+
+static std::string
 get_path(const std::string& name, const std::string& subdev, const std::string& entry)
 {
+  auto base = get_dev_path(name);
   std::string subdir;
-  if (get_subdev_dir_name(dev_root + name, subdev, subdir) != 0)
+  if (get_subdev_dir_name(base, subdev, subdir) != 0)
     return "";
 
-  std::string path = dev_root;
-  path += name;
-  path += "/";
-  path += subdir;
-  path += "/";
-  path += entry;
-  return path;
+  return base + "/" + subdir + "/" + entry;
 }
 
 static std::fstream
@@ -206,7 +238,7 @@ open(const std::string& name,
   if (path.empty()) {
     std::stringstream ss;
     ss << "Failed to find subdirectory for " << subdev
-       << " under " << dev_root + name << std::endl;
+       << " under " << get_dev_path(name) << std::endl;
     err = ss.str();
   } else {
     fs = open_path(path, err, write, binary);
@@ -458,24 +490,37 @@ dev(std::shared_ptr<const drv> driver, std::string sysfs)
   , m_driver(std::move(driver))
 {
   std::string err;
+  std::string sysfs_path = sysfs::get_dev_path(m_sysfs_name);
 
-  if(sscanf(m_sysfs_name.c_str(), "%hx:%hx:%hx.%hx", &m_domain, &m_bus, &m_dev, &m_func) < 4)
-    throw std::invalid_argument(m_sysfs_name + " is not valid BDF");
+  // A PCI device's sysfs name is a BDF (domain:bus:dev.func); anything
+  // else (rpmsg/platform canonical path) is non-PCI. Parsing the name
+  // both detects the bus type and fills in the BDF fields.
+  bool is_pci = parse_bdf(m_sysfs_name, m_domain, m_bus, m_dev, m_func);
 
-  m_is_mgmt = !m_driver->is_user();
+  // mgmt-vs-user PF is a PCI-only (Alveo dual-PF) concept; non-PCI
+  // devices are always user devices.
+  m_is_mgmt = is_pci && !m_driver->is_user();
 
-  if (m_is_mgmt) {
+  if (m_is_mgmt)
     sysfs_get("", "instance", err, m_instance, static_cast<uint32_t>(INVALID_ID));
-  }
-  else {
+  else
     m_instance = get_render_value(
-      sysfs::dev_root + m_sysfs_name + "/" + m_driver->sysfs_dev_node_dir(),
+      sysfs_path + "/" + m_driver->sysfs_dev_node_dir(),
       m_driver->dev_node_prefix());
+
+  if (is_pci) {
+    // BAR-mapped register access used by xclRead/Write (pcieBarRead/Write).
+    sysfs_get<int>("", "userbar", err, m_user_bar, 0);
+    m_user_bar_size = bar_size(sysfs_path, m_user_bar);
+    sysfs_get<bool>("", "ready", err, m_is_ready, false);
+  } else {
+    // Non-PCI devices have no BAR; mark it invalid so BAR access fails
+    // cleanly instead of mmap()'ing a zero-length region.
+    m_user_bar = -1;
+    m_user_bar_size = 0;
+    m_is_ready = true;
   }
 
-  sysfs_get<int>("", "userbar", err, m_user_bar, 0);
-  m_user_bar_size = bar_size(sysfs::dev_root + m_sysfs_name, m_user_bar);
-  sysfs_get<bool>("", "ready", err, m_is_ready, false);
   m_user_bar_map = reinterpret_cast<char *>(MAP_FAILED);
 }
 
@@ -494,6 +539,10 @@ map_usr_bar() const
 
   if (m_user_bar_map != MAP_FAILED)
     return 0;
+
+  // No BAR to map (e.g. non-PCI device).
+  if (m_user_bar_size == 0)
+    return -ENODEV;
 
   int dev_handle = open("", O_RDWR);
   if (dev_handle < 0)

--- a/src/runtime_src/core/pcie/linux/pcidrv.cpp
+++ b/src/runtime_src/core/pcie/linux/pcidrv.cpp
@@ -2,6 +2,7 @@
 // Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
 
 #include "pcidrv.h"
+#include <array>
 #include <filesystem>
 
 namespace xrt_core { namespace pci {
@@ -12,45 +13,76 @@ scan_devices(std::vector<std::shared_ptr<dev>>& ready_list,
              std::vector<std::shared_ptr<dev>>& nonready_list) const
 {
   namespace sfs = std::filesystem;
-  const std::string drv_root = "/sys/bus/pci/drivers/";
-  const std::string drvpath = drv_root + name();
 
-  if (!sfs::exists(drvpath))
-    return;
+  // Each driver-bus root the device may be bound to, paired with whether
+  // that bus is PCI. The bus type is authoritative here, so it is passed
+  // down rather than re-derived from the device name later.
+  struct bus_root {
+    const char* path;
+    bool is_pci;
+  };
+  static constexpr std::array<bus_root, 3> bus_roots = {{
+    { "/sys/bus/pci/drivers/",      true  },
+    { "/sys/bus/rpmsg/drivers/",    false },
+    { "/sys/bus/platform/drivers/", false },
+  }};
 
-  // Gather all sysfs directory and sort
-  // Use try/catch to handle permission errors (e.g. in a confined snap
-  // without the hardware-observe interface connected).
-  std::vector<sfs::path> vec;
-  try {
-    vec.assign(sfs::directory_iterator(drvpath), sfs::directory_iterator());
-  }
-  catch (const sfs::filesystem_error&) {
-    return;
-  }
-  std::sort(vec.begin(), vec.end());
+  const std::string drv_name = name();
 
-  for (auto& path : vec) {
+  for (const auto& [bus_path, is_pci] : bus_roots) {
+    const std::string drvpath = bus_path + drv_name;
+
+    if (!sfs::exists(drvpath))
+      continue;
+
+    std::vector<sfs::path> vec;
     try {
-      auto pf = create_pcidev(path.filename().string());
-
-      if (!pf)
-	      continue;
-
-      // In docker, all host sysfs nodes are available. So, we need to check
-      // devnode to make sure the device is really assigned to docker.
-      if (!sfs::exists(pf->get_subdev_path("", -1)))
-        continue;
-
-      // Insert detected device into proper list.
-      if (pf->m_is_ready)
-        ready_list.push_back(std::move(pf));
-      else
-        nonready_list.push_back(std::move(pf));
+      vec.assign(sfs::directory_iterator(drvpath), sfs::directory_iterator());
     }
-    catch (const std::invalid_argument& ex) {
+    catch (const sfs::filesystem_error&) {
       continue;
     }
+    std::sort(vec.begin(), vec.end());
+
+    for (auto& path : vec) {
+      try {
+        if (!sfs::is_symlink(path))
+          continue;
+
+        // Device entries are symlinks into /sys/devices/; skip
+        // standard driver attributes (module, bind, unbind, etc.)
+        auto real = sfs::canonical(path);
+        if (real.string().rfind("/sys/devices/", 0) != 0)
+          continue;
+
+        // PCI: pass BDF filename (e.g. "0000:01:00.0")
+        // rpmsg/platform: pass canonical device sysfs path
+        std::string dev_sysfs = is_pci ? path.filename().string() : real.string();
+
+        auto pf = create_pcidev(dev_sysfs);
+
+        if (!pf)
+          continue;
+
+        // In docker, all host sysfs nodes are available. So, we need to check
+        // devnode to make sure the device is really assigned to docker.
+        if (!sfs::exists(pf->get_subdev_path("", -1)))
+          continue;
+
+        if (pf->m_is_ready)
+          ready_list.push_back(std::move(pf));
+        else
+          nonready_list.push_back(std::move(pf));
+      }
+      catch (const std::exception& ex) {
+        continue;
+      }
+    }
+
+    // A driver binds on a single bus type (PCI, rpmsg or platform), so
+    // once a root yields devices there is no need to scan the others.
+    if (!ready_list.empty() || !nonready_list.empty())
+      return;
   }
 }
 


### PR DESCRIPTION
Extend pcidrv scan_devices() to search rpmsg and platform bus roots in addition to PCI, enabling discovery of non-PCI accel devices such as RPMsg-based NPU endpoints.

In pcidev constructor, detect non-PCI devices by checking if the sysfs name parses as a BDF. For non-PCI devices, skip PCI-specific sysfs reads (userbar, ready) and mark the device as always ready.

In pcidev sysfs helpers, use get_dev_path() to resolve sysfs paths correctly for both PCI (relative BDF) and non-PCI (absolute path) device names.


<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
