### PR TITLE
CMake option to disable DKMS

### DIFF
--- a/src/CMake/nativeLnx.cmake
+++ b/src/CMake/nativeLnx.cmake
@@ -12,6 +12,10 @@
 # --- PkgConfig ---
 INCLUDE (FindPkgConfig)
 
+# By default DKMS is enabled, but can be disabled at
+# configuation time with -DXRT_ENABLE_DKMS=OFF
+option(XRT_ENABLE_DKMS "Enable DKMS by default" ON)
+
 # --- DRM ---
 pkg_check_modules(DRM REQUIRED libdrm)
 IF(DRM_FOUND)
@@ -154,7 +158,7 @@ if (NOT XRT_UPSTREAM)
    include (CMake/cpackLin.cmake)
 endif() 
 
-if (XRT_ALVEO)
+if (XRT_ALVEO AND XRT_ENABLE_DKMS)
   message("-- XRT Alveo drivers will be bundled with the XRT package")
   set (XRT_DKMS_DRIVER_SRC_BASE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/runtime_src/core")
   include (CMake/dkms.cmake)

--- a/src/CMake/version.cmake
+++ b/src/CMake/version.cmake
@@ -173,7 +173,7 @@ if (NOT XRT_EDGE)
 endif()
 
 # This is not required on MPSoC platform. To avoid yocto error, do NOT intall
-if (XRT_ALVEO AND (NOT XRT_EDGE) AND (NOT WIN32))
+if (XRT_ALVEO AND (NOT XRT_EDGE) AND (NOT WIN32) AND XRT_ENABLE_DKMS)
   # Copied over from dkms.cmake. TODO: cleanup
   set (XRT_DKMS_INSTALL_DIR "/usr/src/xrt-${XRT_VERSION_STRING}")
   install(FILES


### PR DESCRIPTION
#### Problem solved by the commit
Apply Fedora patch to disable DKMS.

Kernel modules are not allowed in the fedora repo, this includes dkms.

