### PR TITLE
AIESW-29024:CERT log buffer improvements

### DIFF
--- a/src/runtime_src/core/common/api/xrt_hw_context.cpp
+++ b/src/runtime_src/core/common/api/xrt_hw_context.cpp
@@ -42,10 +42,11 @@
 #endif
 
 namespace {
-static constexpr double hz_per_mhz = 1'000'000.0;
-
 constexpr std::size_t
-operator""_mb(unsigned long long v) { return 1024u * 1024u * v; }
+operator""_kb(unsigned long long v) { return 1024U * v; } // NOLINT(cppcoreguidelines-avoid-magic-numbers)
+
+constexpr double
+operator""_mhz(long double v) { return static_cast<double>(v) * 1'000'000.0; } // NOLINT(cppcoreguidelines-avoid-magic-numbers)
 
 // Dumps the content into a file with given size from given offset
 static void
@@ -123,12 +124,13 @@ class hw_context_impl : public std::enable_shared_from_this<hw_context_impl>
                           size_t num_uc)
     {
       // parameters for uc log buffer dumper
-      // tweak dump interval, size_per_uc based on experiments
-      constexpr size_t size_per_uc = 2_mb;
       constexpr size_t dump_interval_ms = 50;
       constexpr size_t metadata_size = sizeof(xrt_core::buffer_dumper::log_entry);
       constexpr size_t count_offset = 0;
       constexpr size_t count_size = 8;
+
+      // Get per-uC cert log size from xrt.ini.
+      const auto size_per_uc = xrt_core::config::get_uc_log_size_per_uc_kb() * 1_kb;
 
       auto bo = xrt_core::bo_int::create_bo(
           ctx_hdl, device, (size_per_uc * num_uc), xrt_core::bo_int::use_type::log);
@@ -161,6 +163,7 @@ class hw_context_impl : public std::enable_shared_from_this<hw_context_impl>
       config.dump_file_prefix = "uc_log_" + std::to_string(ctx_hdl->get_slotidx());
       config.dump_buffer = std::move(bo);
       config.dump_bin_format = xrt_core::config::get_uc_log_bin_format();
+      config.enable_dumper_thread = xrt_core::config::get_uc_log_dumper_thread();
 
       return std::make_unique<xrt_core::buffer_dumper>(std::move(config));
     }
@@ -484,7 +487,8 @@ public:
   {
     try {
       auto freq_hz = m_hdl->get_aie_freq();
-      return static_cast<double>(freq_hz) / hz_per_mhz; // Convert Hz to MHz
+      // Convert Hz to MHz.
+      return static_cast<double>(freq_hz) / 1.0_mhz; // NOLINT(cppcoreguidelines-avoid-magic-numbers)
     }
     catch (const xrt_core::error& e) {
       if (e.code() == std::errc::not_supported)
@@ -501,7 +505,8 @@ public:
   set_aie_freq(double freq_mhz)
   {
     try {
-      auto freq_hz = static_cast<uint64_t>(freq_mhz * hz_per_mhz);
+      // Convert MHz to Hz.
+      auto freq_hz = static_cast<uint64_t>(freq_mhz * 1.0_mhz); // NOLINT(cppcoreguidelines-avoid-magic-numbers)
       m_hdl->set_aie_freq(freq_hz);
     }
     catch (const xrt_core::error& e) {

--- a/src/runtime_src/core/common/buffer_dumper.cpp
+++ b/src/runtime_src/core/common/buffer_dumper.cpp
@@ -24,9 +24,13 @@ buffer_dumper(config cfg)
   , m_file_streams(m_config.num_chunks)
 {
   // Files are opened lazily in get_or_open_stream() when first data is available
-  // start the background thread to dump the data
-  m_done_future = m_done_promise.get_future();
-  m_dump_thread = std::thread(&buffer_dumper::dumping_loop, this);
+  // start background dumping only when enabled
+  if (m_config.enable_dumper_thread) {
+    m_done_future = m_done_promise.get_future();
+    // start the background dump loop
+    m_dump_thread = std::thread(&buffer_dumper::dumping_loop, this);
+    m_thread_created = true;
+  }
 }
 
 std::ofstream&
@@ -57,12 +61,17 @@ buffer_dumper::
   // Flush the remaining data
   // catch exceptions to avoid throwing in destructor
   try {
-    m_stop_thread = true;
-    m_cv.notify_one();
-    // Wait for dump thread to finish before detaching.
-    m_done_future.wait();
-    // detach instead of join to avoid deadlock under DLL_PROCESS_DETACH
-    m_dump_thread.detach();
+    // clean up thread state only if the thread was created
+    if (m_thread_created) {
+      // signal the dump thread to stop
+      m_stop_thread = true;
+      m_cv.notify_one();
+      // Wait for dump thread to finish before detaching.
+      m_done_future.wait();
+      // Detach instead of join to avoid deadlock under DLL_PROCESS_DETACH
+      m_dump_thread.detach();
+    }
+
     flush();
   }
   catch (const std::exception& e) {

--- a/src/runtime_src/core/common/buffer_dumper.h
+++ b/src/runtime_src/core/common/buffer_dumper.h
@@ -47,6 +47,7 @@ public:
     std::string dump_file_prefix;     // Output file prefix
     xrt::bo dump_buffer;              // xrt buffer object to dump
     bool dump_bin_format = false;     // Dump in binary format when enabled
+    bool enable_dumper_thread = false; // Enable background dumper thread
   };
 
   // Log entry layout: shared definition in uc_log.h
@@ -60,6 +61,7 @@ private:
   std::promise<void> m_done_promise;
   std::future<void>  m_done_future;
   std::atomic<bool> m_stop_thread{false};
+  std::atomic<bool> m_thread_created{false};
   std::mutex m_dump_mutex;
   std::condition_variable m_cv;
   std::vector<std::ofstream> m_file_streams;

--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -1185,7 +1185,9 @@ get_run_buffer_pool_max_size()
 inline bool
 get_uc_log()
 {
-  static bool value = detail::get_bool_value("Debug.uc_log", false);
+  // Enabled by default for failure logs.
+  // This creates a per-uC log buffer (default 16KB per uC).
+  static bool value = detail::get_bool_value("Debug.uc_log", true);
   return value;
 }
 
@@ -1193,6 +1195,24 @@ inline bool
 get_uc_log_bin_format()
 {
   static bool value = detail::get_bool_value("Debug.uc_log_bin_format", false);
+  return value;
+}
+
+inline bool
+get_uc_log_dumper_thread()
+{
+  // Optional background dump thread; default false keeps dumping on-demand only.
+  static bool value = detail::get_bool_value("Debug.uc_log_dumper_thread", false);
+  return value;
+}
+
+inline unsigned int
+get_uc_log_size_per_uc_kb()
+{
+  // Per-uC log buffer size in KB. Default is 16KB per uC.
+  static constexpr unsigned int default_uc_log_size_per_uc_kb = 16U;
+  static unsigned int value =
+      detail::get_uint_value("Debug.uc_log_size_per_uc_kb", default_uc_log_size_per_uc_kb);
   return value;
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
- Enable uC log collection by default. No overhead on success case.
- Add configurable per-uC log buffer size via xrt.ini (Debug.uc_log_size_per_uc_kb). Default size 16kb.
- Make background dumper thread optional and configurable (Debug.uc_log_dumper_thread).
- Implement safe thread creation/cleanup when dumper thread is disabled.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
[AIESW-29024](https://jira.xilinx.com/browse/AIESW-29024)
#### How problem was solved, alternative solutions (if any) and why they were rejected
#### Risks (if any) associated the changes in the commit
Low
#### What has been tested and how, request additional testing if necessary
tested on telluride board with and without dumping thread. 
#### Documentation impact (if any)
NA