### PR TITLE
Apply Fedora patches

### DIFF
--- a/src/CMake/settings.cmake
+++ b/src/CMake/settings.cmake
@@ -14,6 +14,13 @@ message("-- CMake version: ${CMAKE_VERSION}")
 message("-- Host system processor is ${CMAKE_HOST_SYSTEM_PROCESSOR}")
 message("-- Target system processor is ${CMAKE_SYSTEM_PROCESSOR}")
 
+# Move to options.cmake
+# Option to enable/disable adding static libraries to xrt-target.cmake
+option(XRT_INSTALL_STATIC_LIBRARY "Enable CMake static library targets" ON)
+if (XRT_YOCTO)
+  set(XRT_INSTALL_STATIC_LIBRARY OFF)
+endif()                       
+
 # Indicate that we are building XRT
 add_compile_definitions("XRT_BUILD")
 

--- a/src/runtime_src/core/common/CMakeLists.txt
+++ b/src/runtime_src/core/common/CMakeLists.txt
@@ -15,6 +15,7 @@ else()
   set(AIEBU_COMPONENT ${XRT_BASE_COMPONENT})
   set(AIEBU_DEV_COMPONENT ${XRT_BASE_DEV_COMPONENT})
   set(AIEBU_UPSTREAM ${XRT_UPSTREAM})
+  set(AIEBU_INSTALL_STATIC_LIBRARY ${XRT_INSTALL_STATIC_LIBRARY})
 
   # AIEBU should use XRT's version of ELFIO
   set(AIEBU_ELFIO_SRC_DIR ${XRT_SOURCE_DIR}/runtime_src/core/common/elf)
@@ -157,12 +158,8 @@ install(TARGETS xrt_coreutil
   LIBRARY DESTINATION ${XRT_INSTALL_LIB_DIR} COMPONENT ${XRT_BASE_COMPONENT} NAMELINK_COMPONENT ${XRT_BASE_DEV_COMPONENT}
   ARCHIVE DESTINATION ${XRT_INSTALL_LIB_DIR} COMPONENT ${XRT_BASE_DEV_COMPONENT})
 
-# Install static library - exclude from xrt-targets export in yocto builds
-# to avoid find_package(XRT) failures when static libs are not in sysroot
-if(XRT_YOCTO)
-  install(TARGETS xrt_coreutil_static
-    ARCHIVE DESTINATION ${XRT_INSTALL_LIB_DIR} COMPONENT ${XRT_BASE_DEV_COMPONENT})
-else()
+# Enable install of static library iff requested
+if(XRT_INSTALL_STATIC_LIBRARY)
   install(TARGETS xrt_coreutil_static
     EXPORT xrt-targets
     ARCHIVE DESTINATION ${XRT_INSTALL_LIB_DIR} COMPONENT ${XRT_BASE_DEV_COMPONENT})

--- a/src/runtime_src/core/include/xrt/deprecated/xclerr.h
+++ b/src/runtime_src/core/include/xrt/deprecated/xclerr.h
@@ -1,34 +1,8 @@
-/*
- * Copyright (C) 2017 Xilinx, Inc
- * Author: Umang Parekh
- *
- * This file is dual licensed.  It may be redistributed and/or modified
- * under the terms of the Apache 2.0 License OR version 2 of the GNU
- * General Public License.
- *
- * Apache License Verbiage
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- *
- * GPL license Verbiage:
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by the Free Software Foundation;
- * either version 2 of the License, or (at your option) any later version.
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
- * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- * See the GNU General Public License for more details.
- * You should have received a copy of the GNU General Public License along with this program;
- * if not, write to the Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: GPL-2.0
+ * Copyright (C) 2017 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
  */
 
 /**

--- a/src/runtime_src/core/include/xrt/detail/ert.h
+++ b/src/runtime_src/core/include/xrt/detail/ert.h
@@ -1,38 +1,8 @@
-/*
- *  Copyright (C) 2019-2022, Xilinx Inc
- *
- *  This file is dual licensed.  It may be redistributed and/or modified
- *  under the terms of the Apache 2.0 License OR version 2 of the GNU
- *  General Public License.
- *
- *  Apache License Verbiage
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
- *  GPL license Verbiage:
- *
- *  This program is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU General Public License as
- *  published by the Free Software Foundation; either version 2 of the
- *  License, or (at your option) any later version.  This program is
- *  distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or
- *  FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
- *  License for more details.  You should have received a copy of the
- *  GNU General Public License along with this program; if not, write
- *  to the Free Software Foundation, Inc., 59 Temple Place, Suite 330,
- *  Boston, MA 02111-1307 USA
- *
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: GPL-2.0
+ * Copyright (C) 2019-2022 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2022-2026 Advanced Micro Devices, Inc. All rights reserved.
  */
 
 /**

--- a/src/runtime_src/core/include/xrt/detail/xclbin.h
+++ b/src/runtime_src/core/include/xrt/detail/xclbin.h
@@ -1,39 +1,8 @@
 /**
- *  Copyright (C) 2015-2024, Advanced Micro Devices, Inc. All rights Reserved.
- *
- *  This file is dual licensed.  It may be redistributed and/or modified
- *  under the terms of the Apache 2.0 License OR version 2 of the GNU
- *  General Public License.
- *
- *  Apache License Verbiage
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
- *  GPL license Verbiage:
- *
- *  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation, either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License
- *  along with this program.  If not, write to the Free Software Foundation,
- *  Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: GPL-2.0
+ * Copyright (C) 2015-2022 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2022-2026 Advanced Micro Devices, Inc. All rights reserved.
  */
 #ifndef INCLUDE_XRT_DETAIL_XCLBIN_H_
 #define INCLUDE_XRT_DETAIL_XCLBIN_H_

--- a/src/runtime_src/core/include/xrt/detail/xrt_error_code.h
+++ b/src/runtime_src/core/include/xrt/detail/xrt_error_code.h
@@ -1,38 +1,8 @@
-/*
- *  Copyright (C) 2020, Xilinx Inc
- *
- *  This file is dual licensed.  It may be redistributed and/or modified
- *  under the terms of the Apache 2.0 License OR version 2 of the GNU
- *  General Public License.
- *
- *  Apache License Verbiage
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
- *  GPL license Verbiage:
- *
- *  This program is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU General Public License as
- *  published by the Free Software Foundation; either version 2 of the
- *  License, or (at your option) any later version.  This program is
- *  distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or
- *  FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
- *  License for more details.  You should have received a copy of the
- *  GNU General Public License along with this program; if not, write
- *  to the Free Software Foundation, Inc., 59 Temple Place, Suite 330,
- *  Boston, MA 02111-1307 USA
- *
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: GPL-2.0
+ * Copyright (C) 2020-2022 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
  */
 #ifndef INCLUDE_XRT_DETAIL_XRT_ERROR_CODE_H_
 #define INCLUDE_XRT_DETAIL_XRT_ERROR_CODE_H_

--- a/src/runtime_src/core/include/xrt/detail/xrt_mem.h
+++ b/src/runtime_src/core/include/xrt/detail/xrt_mem.h
@@ -1,30 +1,9 @@
-/*
- * Copyright (C) 2019-2022, Xilinx Inc - All rights reserved.
- * Xilinx Runtime (XRT) APIs
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- *
- * GPL license Verbiage:
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by the Free Software Foundation;
- * either version 2 of the License, or (at your option) any later version.
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
- * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- * See the GNU General Public License for more details.
- * You should have received a copy of the GNU General Public License along with this program;
- * if not, write to the Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: GPL-2.0
+ * Copyright (C) 2019-2022 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2022-2026 Advanced Micro Devices, Inc. All rights reserved.
  */
-
 #ifndef INCLUDE_XRT_DETAIL_XRT_MEM_H_
 #define INCLUDE_XRT_DETAIL_XRT_MEM_H_
 

--- a/src/runtime_src/core/pcie/emulation/hw_emu/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/emulation/hw_emu/CMakeLists.txt
@@ -64,10 +64,16 @@ target_link_libraries(xrt_hwemu_static
   uuid
   )
 
-install (TARGETS xrt_hwemu xrt_hwemu_static
+install (TARGETS xrt_hwemu
   EXPORT xrt-targets
   RUNTIME DESTINATION ${XRT_INSTALL_BIN_DIR} COMPONENT ${XRT_COMPONENT}
   LIBRARY DESTINATION ${XRT_INSTALL_LIB_DIR} COMPONENT ${XRT_COMPONENT} NAMELINK_COMPONENT ${XRT_DEV_COMPONENT}
   ARCHIVE DESTINATION ${XRT_INSTALL_LIB_DIR} COMPONENT ${XRT_DEV_COMPONENT}
 )
 
+# Enable install of static library iff requested
+if(XRT_INSTALL_STATIC_LIBRARY)
+  install(TARGETS xrt_hwemu_static
+    EXPORT xrt-targets
+    ARCHIVE DESTINATION ${XRT_INSTALL_LIB_DIR} COMPONENT ${XRT_DEV_COMPONENT})
+endif()

--- a/src/runtime_src/core/pcie/emulation/sw_emu/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/emulation/sw_emu/CMakeLists.txt
@@ -58,9 +58,16 @@ target_link_libraries(xrt_swemu_static
   uuid
   )
 
-install (TARGETS xrt_swemu xrt_swemu_static
+install (TARGETS xrt_swemu
   EXPORT xrt-targets
   RUNTIME DESTINATION ${XRT_INSTALL_BIN_DIR} COMPONENT ${XRT_COMPONENT}
   LIBRARY DESTINATION ${XRT_INSTALL_LIB_DIR} COMPONENT ${XRT_COMPONENT} NAMELINK_COMPONENT ${XRT_DEV_COMPONENT}
   ARCHIVE DESTINATION ${XRT_INSTALL_LIB_DIR} COMPONENT ${XRT_DEV_COMPONENT}
 )
+
+# Enable install of static library iff requested
+if(XRT_INSTALL_STATIC_LIBRARY)
+  install(TARGETS xrt_swemu_static
+    EXPORT xrt-targets
+    ARCHIVE DESTINATION ${XRT_INSTALL_LIB_DIR} COMPONENT ${XRT_DEV_COMPONENT})
+endif()

--- a/src/runtime_src/core/pcie/linux/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/linux/CMakeLists.txt
@@ -82,9 +82,16 @@ endif()
 
 # Shim for Linux is installed in the base component as it is
 # used by both Alveo and NPU components.   
-install(TARGETS xrt_core xrt_core_static
+install(TARGETS xrt_core
   EXPORT xrt-targets
   RUNTIME DESTINATION ${XRT_INSTALL_BIN_DIR} COMPONENT ${XRT_BASE_COMPONENT}
   LIBRARY DESTINATION ${XRT_INSTALL_LIB_DIR} COMPONENT ${XRT_BASE_COMPONENT} NAMELINK_COMPONENT ${XRT_BASE_DEV_COMPONENT}
   ARCHIVE DESTINATION ${XRT_INSTALL_LIB_DIR} COMPONENT ${XRT_BASE_DEV_COMPONENT}
 )
+
+# Enable install of static library iff requested
+if(XRT_INSTALL_STATIC_LIBRARY)
+  install(TARGETS xrt_core_static
+    EXPORT xrt-targets
+    ARCHIVE DESTINATION ${XRT_INSTALL_LIB_DIR} COMPONENT ${XRT_BASE_DEV_COMPONENT})
+endif()

--- a/src/runtime_src/xocl/CMakeLists.txt
+++ b/src/runtime_src/xocl/CMakeLists.txt
@@ -101,12 +101,8 @@ install(TARGETS xilinxopencl
   ARCHIVE DESTINATION ${XRT_INSTALL_LIB_DIR} COMPONENT ${XRT_BASE_DEV_COMPONENT}
 )
 
-# Install static library - exclude from xrt-targets export in yocto builds
-# to avoid find_package(XRT) failures when static libs are not in sysroot
-if(XRT_YOCTO)
-  install(TARGETS xilinxopencl_static
-    ARCHIVE DESTINATION ${XRT_INSTALL_LIB_DIR} COMPONENT ${XRT_BASE_DEV_COMPONENT})
-else()
+# Enable install of static library iff requested
+if(XRT_INSTALL_STATIC_LIBRARY)
   install(TARGETS xilinxopencl_static
     EXPORT xrt-targets
     ARCHIVE DESTINATION ${XRT_INSTALL_LIB_DIR} COMPONENT ${XRT_BASE_DEV_COMPONENT})

--- a/src/runtime_src/xrt/CMakeLists.txt
+++ b/src/runtime_src/xrt/CMakeLists.txt
@@ -74,12 +74,8 @@ install(TARGETS xrt++
   ARCHIVE DESTINATION ${XRT_INSTALL_LIB_DIR} COMPONENT ${XRT_BASE_DEV_COMPONENT}
 )
 
-# Install static library - exclude from xrt-targets export in yocto builds
-# to avoid find_package(XRT) failures when static libs are not in sysroot
-if(XRT_YOCTO)
-  install(TARGETS xrt++_static
-    ARCHIVE DESTINATION ${XRT_INSTALL_LIB_DIR} COMPONENT ${XRT_BASE_DEV_COMPONENT})
-else()
+# Enable install of static library iff requested
+if(XRT_INSTALL_STATIC_LIBRARY)
   install(TARGETS xrt++_static
     EXPORT xrt-targets
     ARCHIVE DESTINATION ${XRT_INSTALL_LIB_DIR} COMPONENT ${XRT_BASE_DEV_COMPONENT})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
- Provide CMake option to disable install of static libraries.
- Replace improper GPL license preamble with SPDX (flagged by `rpmlint`)

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Fedora does not allow static libraries in `-devel` packages and strongly discourages dependencies on package static libraries.

- https://docs.fedoraproject.org/en-US/packaging-guidelines/#packaging-static-libraries

#### How problem was solved, alternative solutions (if any) and why they were rejected
The PR implements support for `-DXRT_INSTALL_STATIC_LIBRARY=OFF` to prevent static libraries from being installed by CMake.  The option is inferred by XRT_YOCTO, which also must prevent static libraries from being installed.

The one little difference between earlier YOCTO behavior and this PR, is that when option is now defined, no static libraries are installed, where as earlier they used to be installed but excluded from xrt-targets.   It makes no sense to provide the static libraries in the install tree for XRT internal builds when linking cannot be facilitated through standard CMake find_package.

