### PR TITLE
AIESW-29276 Update xrt-smi help menu

### DIFF
--- a/src/runtime_src/core/tools/common/XBHelpMenusCore.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenusCore.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2020-2022 Xilinx, Inc
-// Copyright (C) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2022-2026 Advanced Micro Devices, Inc. All rights reserved.
 // ------ I N C L U D E   F I L E S -------------------------------------------
 // Local - Include Files
 #include "XBHelpMenusCore.h"
@@ -373,8 +373,15 @@ XBUtilities::report_commands_help( const std::string &_executable,
 
   report_option_help("OPTIONS", _optionDescription);
 
-  if (XBU::getAdvance())
-    report_option_help(std::string("OPTIONS ") + sHidden, _optionHidden);
+  if (XBU::getAdvance()) {
+    po::options_description hiddenForDisplay;
+    for (const auto& opt : _optionHidden.options()) {
+      if (opt && !boost::iequals(opt->long_name(), "subCmd"))
+        hiddenForDisplay.add(opt);
+    }
+    if (!hiddenForDisplay.options().empty())
+      report_option_help(std::string("OPTIONS ") + sHidden, hiddenForDisplay);
+  }
 }
 
 static std::string
@@ -400,7 +407,11 @@ create_option_format_name(const boost::program_options::option_description * _op
     optionDisplayName += removeLongOptDashes ? _option->long_name() : longName;
   }
 
-  if (_reportParameter && !_option->format_parameter().empty())
+  // Omit Boost's format_parameter() for subCmd; semantics stay in the description.
+  const std::string& longKey = _option->long_name();
+  if (_reportParameter && boost::iequals(longKey, "device"))
+    optionDisplayName += " <BDF>";
+  else if (_reportParameter && !boost::iequals(longKey, "subCmd") && !_option->format_parameter().empty())
     optionDisplayName += " " + _option->format_parameter();
 
   return optionDisplayName;

--- a/src/runtime_src/core/tools/common/XBHelpMenusCore.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenusCore.cpp
@@ -313,7 +313,7 @@ XBUtilities::report_commands_help( const std::string &_executable,
 
   for (auto& subCmdEntry : _subCmds) {
     // Filter out hidden subcommand
-    if (!XBU::getAdvance() && subCmdEntry->isHidden())
+    if (!XBU::getShowHidden() && subCmdEntry->isHidden())
       continue;
 
     // Depricated sub-command
@@ -373,15 +373,8 @@ XBUtilities::report_commands_help( const std::string &_executable,
 
   report_option_help("OPTIONS", _optionDescription);
 
-  if (XBU::getAdvance()) {
-    po::options_description hiddenForDisplay;
-    for (const auto& opt : _optionHidden.options()) {
-      if (opt && !boost::iequals(opt->long_name(), "subCmd"))
-        hiddenForDisplay.add(opt);
-    }
-    if (!hiddenForDisplay.options().empty())
-      report_option_help(std::string("OPTIONS ") + sHidden, hiddenForDisplay);
-  }
+  if (XBU::getShowHidden())
+    report_option_help(std::string("OPTIONS ") + sHidden, _optionHidden);
 }
 
 static std::string
@@ -407,11 +400,7 @@ create_option_format_name(const boost::program_options::option_description * _op
     optionDisplayName += removeLongOptDashes ? _option->long_name() : longName;
   }
 
-  // Omit Boost's format_parameter() for subCmd; semantics stay in the description.
-  const std::string& longKey = _option->long_name();
-  if (_reportParameter && boost::iequals(longKey, "device"))
-    optionDisplayName += " <BDF>";
-  else if (_reportParameter && !boost::iequals(longKey, "subCmd") && !_option->format_parameter().empty())
+  if (_reportParameter && !_option->format_parameter().empty())
     optionDisplayName += " " + _option->format_parameter();
 
   return optionDisplayName;

--- a/src/runtime_src/core/tools/common/XBMain.cpp
+++ b/src/runtime_src/core/tools/common/XBMain.cpp
@@ -120,29 +120,31 @@ void  main_(int argc, char** argv,
   XBU::setAdvance( bAdvance );
   XBU::setForce( bForce );
 
-  // Was device specified? If not, check for default device.
   const auto& device_var = vm["device"];
-  if (device_var.defaulted() && boost::iequals(sDevice, "default")) {
-    sDevice.clear();
-    boost::property_tree::ptree available_devices = XBU::get_available_devices(isUserDomain);
+  if (device_var.defaulted()) {
+    // Was default device requested?
+    if (boost::iequals(sDevice, "default")) {
+      sDevice.clear();
+      boost::property_tree::ptree available_devices = XBU::get_available_devices(isUserDomain);
 
-    // DRC: Are there any devices
-    if (available_devices.empty()) 
-      throw std::runtime_error("No devices found.");
+      // DRC: Are there any devices
+      if (available_devices.empty())
+        throw std::runtime_error("No devices found.");
 
-    // DRC: Are there multiple devices, if so then no default device can be found.
-    if (available_devices.size() > 1) {
-      std::cerr << "\nERROR: Multiple devices found. Please specify a single device using the --device option\n\n";
-      std::cerr << XBUtilities::str_available_devs(isUserDomain) << std::endl;
+      // DRC: Are there multiple devices, if so then no default device can be found.
+      if (available_devices.size() > 1) {
+        std::cerr << "\nERROR: Multiple devices found. Please specify a single device using the --device option\n\n";
+        std::cerr << XBUtilities::str_available_devs(isUserDomain) << std::endl;
 
-      std::cout << std::endl;
-      throw xrt_core::error(std::errc::operation_canceled);
-    }
+        std::cout << std::endl;
+        throw xrt_core::error(std::errc::operation_canceled);
+      }
 
-    // We have only 1 item in the array, get it
-    for (const auto &kd : available_devices) {
-      sDevice = kd.second.get<std::string>("bdf");
-      break; // Exit after the first item
+      // We have only 1 item in the array, get it
+      for (const auto &kd : available_devices) {
+        sDevice = kd.second.get<std::string>("bdf");
+        break; // Exit after the first item
+      }
     }
   }
   else if (sDevice.empty() || boost::iequals(sDevice, "default")) {

--- a/src/runtime_src/core/tools/common/XBMain.cpp
+++ b/src/runtime_src/core/tools/common/XBMain.cpp
@@ -120,29 +120,35 @@ void  main_(int argc, char** argv,
   XBU::setAdvance( bAdvance );
   XBU::setForce( bForce );
 
-  // Was device specified? If not, try to use default device.
-  {
-    const auto& device_var = vm["device"];
-    if (device_var.defaulted()) {
-      boost::property_tree::ptree available_devices = XBU::get_available_devices(isUserDomain);
-      if (available_devices.empty())
-        throw std::runtime_error("No devices found.");
-      if (available_devices.size() > 1) {
-        std::cerr << "\nERROR: Multiple devices found. Please specify a single device using the --device option\n\n";
-        std::cerr << XBUtilities::str_available_devs(isUserDomain) << std::endl;
-        std::cout << std::endl;
-        throw xrt_core::error(std::errc::operation_canceled);
-      }
-      for (const auto& kd : available_devices) {
-        sDevice = kd.second.get<std::string>("bdf");
-        break;
-      }
-    }
-    else if (sDevice.empty() || boost::algorithm::iequals(sDevice, "default")) {
-      std::cerr << "\nERROR: Option --device (-d) requires a BDF.\n";
+  // Was device specified? If not, check for default device.
+  const auto& device_var = vm["device"];
+  if (device_var.defaulted() && boost::iequals(sDevice, "default")) {
+    sDevice.clear();
+    boost::property_tree::ptree available_devices = XBU::get_available_devices(isUserDomain);
+
+    // DRC: Are there any devices
+    if (available_devices.empty()) 
+      throw std::runtime_error("No devices found.");
+
+    // DRC: Are there multiple devices, if so then no default device can be found.
+    if (available_devices.size() > 1) {
+      std::cerr << "\nERROR: Multiple devices found. Please specify a single device using the --device option\n\n";
       std::cerr << XBUtilities::str_available_devs(isUserDomain) << std::endl;
+
+      std::cout << std::endl;
       throw xrt_core::error(std::errc::operation_canceled);
     }
+
+    // We have only 1 item in the array, get it
+    for (const auto &kd : available_devices) {
+      sDevice = kd.second.get<std::string>("bdf");
+      break; // Exit after the first item
+    }
+  }
+  else if (sDevice.empty() || boost::iequals(sDevice, "default")) {
+    std::cerr << "\nERROR: Option --device (-d) requires a BDF.\n";
+    std::cerr << XBUtilities::str_available_devs(isUserDomain) << std::endl;
+    throw xrt_core::error(std::errc::operation_canceled);
   }
 
   // If there is a device value, parse for valid subcommands for this device.

--- a/src/runtime_src/core/tools/common/XBMain.cpp
+++ b/src/runtime_src/core/tools/common/XBMain.cpp
@@ -66,7 +66,7 @@ void  main_(int argc, char** argv,
   const std::string device_default = xrt_core::get_total_devices(isUserDomain).first == 1 ? "default" : "";
   po::options_description hiddenOptions("Hidden Options");
   hiddenOptions.add_options()
-    ("device,d",    boost::program_options::value<decltype(sDevice)>(&sDevice)->default_value(device_default)->implicit_value("default"), "If specified with no BDF value and there is only 1 device, that device will be automatically selected.\n")
+    ("device,d",    boost::program_options::value<decltype(sDevice)>(&sDevice)->default_value(device_default)->implicit_value("default"), "Specify a BDF. If the option is omitted and there is only 1 device, that device is used\n")
     ("trace",       boost::program_options::bool_switch(&bTrace), "Enables code flow tracing")
     ("subCmd",      po::value<decltype(sCmd)>(&sCmd), "Command to execute")
   ;
@@ -120,28 +120,29 @@ void  main_(int argc, char** argv,
   XBU::setAdvance( bAdvance );
   XBU::setForce( bForce );
 
-  // Was default device requested?
-  if (boost::iequals(sDevice, "default")) {
-    sDevice.clear();
-    boost::property_tree::ptree available_devices = XBU::get_available_devices(isUserDomain);
-
-    // DRC: Are there any devices
-    if (available_devices.empty()) 
-      throw std::runtime_error("No devices found.");
-
-    // DRC: Are there multiple devices, if so then no default device can be found.
-    if (available_devices.size() > 1) {
-      std::cerr << "\nERROR: Multiple devices found. Please specify a single device using the --device option\n\n";
+  // Was device specified? If not, try to use default device.
+  {
+    const auto& device_var = vm["device"];
+    if (device_var.defaulted()) {
+      boost::property_tree::ptree available_devices = XBU::get_available_devices(isUserDomain);
+      if (available_devices.empty())
+        throw std::runtime_error("No devices found.");
+      if (available_devices.size() > 1) {
+        std::cerr << "\nERROR: Multiple devices found. Please specify a single device using the --device option\n\n";
+        std::cerr << XBUtilities::str_available_devs(isUserDomain) << std::endl;
+        std::cout << std::endl;
+        throw xrt_core::error(std::errc::operation_canceled);
+      }
+      for (const auto& kd : available_devices) {
+        sDevice = kd.second.get<std::string>("bdf");
+        break;
+      }
+    }
+    else if (sDevice.empty() || boost::algorithm::iequals(sDevice, "default")) {
+      std::cerr << "\nERROR: Option --device (-d) requires a BDF.\n";
       std::cerr << XBUtilities::str_available_devs(isUserDomain) << std::endl;
-
-      std::cout << std::endl;
       throw xrt_core::error(std::errc::operation_canceled);
     }
-
-    // We have only 1 item in the array, get it
-    for (const auto &kd : available_devices) 
-      sDevice = kd.second.get<std::string>("bdf"); // Exit after the first item
-
   }
 
   // If there is a device value, parse for valid subcommands for this device.

--- a/src/runtime_src/core/tools/common/XBMain.cpp
+++ b/src/runtime_src/core/tools/common/XBMain.cpp
@@ -41,6 +41,7 @@ void  main_(int argc, char** argv,
   bool bTrace = false;
   bool bHelp = false;
   bool bBatchMode = false;
+  bool bShowHidden = false;
   bool bAdvance = false;
   bool bForce = false;
   bool bVersion = false;
@@ -68,12 +69,13 @@ void  main_(int argc, char** argv,
   hiddenOptions.add_options()
     ("device,d",    boost::program_options::value<decltype(sDevice)>(&sDevice)->default_value(device_default)->implicit_value("default"), "Specify a BDF. If the option is omitted and there is only 1 device, that device is used\n")
     ("trace",       boost::program_options::bool_switch(&bTrace), "Enables code flow tracing")
+    ("show-hidden", boost::program_options::bool_switch(&bShowHidden), "Shows hidden options and commands")
     ("subCmd",      po::value<decltype(sCmd)>(&sCmd), "Command to execute")
   ;
 
   if (xrt_core::sysinfo::is_advanced()) {
     hiddenOptions.add_options()
-      ("advanced", boost::program_options::bool_switch(&bAdvance), "Shows hidden options and commands")
+      ("advanced", boost::program_options::bool_switch(&bAdvance), "Shows advanced options and commands")
     ;
   }
 
@@ -117,6 +119,7 @@ void  main_(int argc, char** argv,
   XBU::disable_escape_codes( bBatchMode );
   XBU::setVerbose( bVerbose );
   XBU::setTrace( bTrace );
+  XBU::setShowHidden( bShowHidden );
   XBU::setAdvance( bAdvance );
   XBU::setForce( bForce );
 

--- a/src/runtime_src/core/tools/common/XBUtilitiesCore.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilitiesCore.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2019-2022 Xilinx, Inc
-// Copyright (C) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2022-2026 Advanced Micro Devices, Inc. All rights reserved.
 
 
 // ------ I N C L U D E   F I L E S -------------------------------------------
@@ -26,6 +26,7 @@ using namespace XBUtilities;
 static bool m_bVerbose = false;
 static bool m_bTrace = false;
 static bool m_disableEscapeCodes = false;
+static bool m_bShowHidden = false;
 static bool m_bAdvance = false;
 static bool m_bForce = false;
 static bool m_bElf = false; 
@@ -77,14 +78,30 @@ XBUtilities::setTrace(bool _bTrace)
   m_bTrace = _bTrace;
 }
 
+void
+XBUtilities::setShowHidden(bool _bShowHidden)
+{
+  if (_bShowHidden)
+    trace("Hidden commands and options will be shown.");
+  else
+    trace("Hidden commands and options will be hidden");
+
+  m_bShowHidden = _bShowHidden;
+}
+
+bool
+XBUtilities::getShowHidden()
+{
+  return m_bShowHidden;
+}
 
 void
 XBUtilities::setAdvance(bool _bAdvance)
 {
   if (_bAdvance)
-    trace("Hidden commands and options will be shown.");
+    trace("Advanced commands and options will be shown.");
   else
-    trace("Hidden commands and options will be hidden");
+    trace("Advanced commands and options will be hidden");
 
   m_bAdvance = _bAdvance;
 }

--- a/src/runtime_src/core/tools/common/XBUtilitiesCore.h
+++ b/src/runtime_src/core/tools/common/XBUtilitiesCore.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2019-2022 Xilinx, Inc
-// Copyright (C) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2022-2026 Advanced Micro Devices, Inc. All rights reserved.
 
 #ifndef __XBUtilitiesCore_h_
 #define __XBUtilitiesCore_h_
@@ -41,6 +41,9 @@ namespace XBUtilities {
   bool getElf();
 
   void setTrace(bool _bVerbose);
+
+  void setShowHidden(bool _bShowHidden);
+  bool getShowHidden();
 
   void setAdvance(bool _bAdvance);
   bool getAdvance();


### PR DESCRIPTION
#### Problem solved by the commit
https://jira.xilinx.com/browse/AIESW-29276
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Discovered during internal bash testing
#### How problem was solved, alternative solutions (if any) and why they were rejected
Updated help wording, separated show-hidden from advanced help, and specified -d requires BDF in error message
#### Risks (if any) associated the changes in the commit
May require Alveo users to specify BDF with -d/--device if they left -d/--device empty previously
#### What has been tested and how, request additional testing if necessary
Tested on KRK. Updated `device` description:
```
-d, --device <BDF> - Specify a BDF. If the option is omitted and there is only 1 device, that
                       device is used
```
#### Documentation impact (if any)
N/A