### PR TITLE
Fix Gcc warnings

### DIFF
--- a/src/python/pybind11/src/pyxrt.cpp
+++ b/src/python/pybind11/src/pyxrt.cpp
@@ -1,4 +1,5 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2019-2026 Xilinx, Inc. All rights reserved
 
 /**
  * Pybind11 module for XRT C++ APIs
@@ -434,12 +435,12 @@ PYBIND11_MODULE(pyxrt, m) {
                                  try {
                                      r.set_arg(i, item.cast<xrt::bo>());
                                  }
-                                 catch (std::exception e) {  }
+                                 catch (const std::exception&) {  }
 
                                  try {
                                      r.set_arg<int>(i, item.cast<int>());
                                  }
-                                 catch (std::exception e) {  }
+                                 catch (const std::exception&) {  }
 
                                  i++;
                              }

--- a/src/runtime_src/core/common/info_memory.cpp
+++ b/src/runtime_src/core/common/info_memory.cpp
@@ -3,10 +3,9 @@
 // Copyright (C) 2023-2026 Advanced Micro Devices, Inc. - All rights reserved
 #define XRT_CORE_COMMON_SOURCE
 #include "info_memory.h"
-
-#include "ps_kernel.h"
 #include "query_requests.h"
 #include "utils.h"
+#include "core/include/ps_kernel.h"
 #include "xrt/detail/xclbin.h"
 
 #include <boost/property_tree/ptree.hpp>
@@ -456,6 +455,12 @@ scheduler_update_stat(const xrt_core::device* device)
   }
 }
 
+#if defined(__GNUC__) && (__GNUC__ == 15)
+// Known GCC 15 false positive around std::any_cast<std::vector<char>>
+// + vector copy/destruction at high optimization levels.
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wfree-nonheap-object"
+#endif
 std::vector<ps_kernel_data> 
 get_ps_kernels(const xrt_core::device* device)
 {
@@ -464,19 +469,33 @@ get_ps_kernels(const xrt_core::device* device)
     std::vector<char> buf = xrt_core::device_query<xq::ps_kernel>(device);
     if (buf.empty())
       return ps_kernels;
-    const ps_kernel_node *map = reinterpret_cast<ps_kernel_node *>(buf.data());
+
+    if (buf.size() < sizeof(ps_kernel_node))
+      throw xrt_core::error("'ps_kernel' invalid. Buffer too small.");
+
+    auto map = reinterpret_cast<const ps_kernel_node*>(buf.data());
     if(map->pkn_count == 0)
       throw xrt_core::error("'ps_kernel' invalid. Has the PS kernel been loaded? See 'xrt-smi program'.");
 
-    for (unsigned int i = 0; i < map->pkn_count; i++)
-      ps_kernels.emplace_back(map->pkn_data[i]);
+    auto needed = sizeof(ps_kernel_node) * map->pkn_count * sizeof(ps_kernel_data);
+    if (buf.size() < needed)
+      throw xrt_core::error("'ps_kernel' invalid. Truncated buffer.");
+
+    ps_kernels.reserve(map->pkn_count);
+    for (unsigned int i = 0; i < map->pkn_count; i++) {
+      ps_kernel_data kd {};
+      std::memcpy(&kd, &map->pkn_data[i], sizeof(kd));
+      ps_kernels.emplace_back(kd);
+    }
   }
   catch (const xq::no_such_key&) {
     // Ignoring if not available: Edge Case
   }
-
   return ps_kernels;
 }
+#if defined(__GNUC__) && (__GNUC__ == 15)
+# pragma GCC diagnostic pop
+#endif
 
 ptree_type
 populate_cus(const xrt_core::device* device, const std::vector<xq::kds_cu_info::data_type>& cu_stats, const std::vector<xq::kds_scu_info::data_type>& scu_stats)

--- a/src/runtime_src/core/include/ps_kernel.h
+++ b/src/runtime_src/core/include/ps_kernel.h
@@ -7,6 +7,11 @@
 #ifndef PS_KERNEL_H_
 #define PS_KERNEL_H_
 
+#ifdef _WIN32
+# pragma warning( push )
+# pragma warning( disable : 4200 )
+#endif
+
 /*
  * This header file contains data structure for xrt PS kernel metadata. This
  * file is included in user space utilities and kernel drivers. The data
@@ -26,5 +31,9 @@ struct ps_kernel_node {
 	uint32_t		pkn_count;
 	struct ps_kernel_data	pkn_data[];
 };
+
+#ifdef _WIN32
+# pragma warning( pop )
+#endif
 
 #endif /* _PS_KERNEL_H_ */

--- a/src/runtime_src/core/include/ps_kernel.h
+++ b/src/runtime_src/core/include/ps_kernel.h
@@ -1,21 +1,11 @@
-/*
- * Copyright (C) 2021 Xilinx, Inc
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *		 http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: GPL-2.0
+ * Copyright (C) 2021 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
  */
-
-#ifndef _PS_KERNEL_H_
-#define _PS_KERNEL_H_
+#ifndef PS_KERNEL_H_
+#define PS_KERNEL_H_
 
 /*
  * This header file contains data structure for xrt PS kernel metadata. This
@@ -34,7 +24,7 @@ struct ps_kernel_data {
 
 struct ps_kernel_node {
 	uint32_t		pkn_count;
-	struct ps_kernel_data	pkn_data[1];
+	struct ps_kernel_data	pkn_data[];
 };
 
 #endif /* _PS_KERNEL_H_ */

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -1,6 +1,6 @@
 /**
  *  Copyright (C) 2017-2022 Xilinx, Inc. All rights reserved.
- *  Copyright (C) 2022 Advanced Micro Devices, Inc.
+ *  Copyright (C) 2022-2026 Advanced Micro Devices, Inc.
  *  Author: Sonal Santan
  *  Code copied verbatim from SDAccel xcldma kernel mode driver
  *
@@ -3020,7 +3020,7 @@ static int icap_cache_ps_kernel_axlf_section(const struct axlf *xclbin,
 		return -EINVAL;
 
 	*data = vzalloc(sizeof(struct ps_kernel_node) +
-	    sizeof(struct ps_kernel_data) * (count - 1));
+			sizeof(struct ps_kernel_data) * count);
 	if (*data == NULL)
 		return -ENOMEM;
 
@@ -3906,8 +3906,8 @@ static ssize_t icap_read_ps_kernel(struct file *filp, struct kobject *kobj,
 		if (err)
 			return f_nread;
 
-		size = sizeof(struct ps_kernel_node) + sizeof(struct ps_kernel_data) *
-			(islot->ps_kernel->pkn_count - 1);
+		size = sizeof(struct ps_kernel_node)
+			+ sizeof(struct ps_kernel_data) * islot->ps_kernel->pkn_count;
 		if (offset >= size) {
 			icap_xclbin_rd_unlock(icap, st);
 			return f_nread;


### PR DESCRIPTION
#### Problem solved by the commit
Avoid GCC15 warnings and adjust improper code

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
- Known GCC 15 false positive around std::any_cast<std::vector<char>> and vector copy/destruction at high optimization levels.
- Don't catch by value (pyxrt)

#### How problem was solved, alternative solutions (if any) and why they were rejected
Adjust function in info_memory.cpp to be more pendatic in how it
checks data received from query request.   Adjust the size of
ps_kernel_node to use true flexible array.
