### PR TITLE
dynamic tracing compiler json result support

### DIFF
--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -709,13 +709,6 @@ class module_run_aie_gen2_plus : public module_run
   // Dynamic tracing utility structure
   struct dtrace_util
   {
-    // Configuration for dtrace handle creation
-    dtrace_config_t dtrace_config = {
-      nullptr, // ctrl_file_path
-      nullptr, // map_data
-      0U,      // log_level (error)
-      0U       // output_fmt (python)
-    };
     // Function pointer for dtrace destroy handle
     using dtrace_destroy_handle = void (*)(dtrace_handle_t);
 
@@ -727,9 +720,17 @@ class module_run_aie_gen2_plus : public module_run
 
     dtrace_util(const std::string& ctrl_file_path, const std::string& map_data,
                 uint32_t log_level, uint32_t output_fmt)
-      : dtrace_config{ctrl_file_path.c_str(), map_data.c_str(), log_level, output_fmt}
-      , dtrace_handle(create_dtrace_handle(&dtrace_config), destroy_dtrace_handle)
+      : dtrace_handle(nullptr, destroy_dtrace_handle)
     {
+      // Configuration for dtrace handle creation
+      const dtrace_config_t dtrace_config
+      {
+        ctrl_file_path.c_str(),
+        map_data.c_str(),
+        log_level,
+        output_fmt
+      };
+      dtrace_handle.reset(create_dtrace_handle(&dtrace_config));
     }
   };
   dtrace_util m_dtrace;
@@ -1148,7 +1149,7 @@ public:
 
     try {
       // dtrace output is dumped into current working directory
-      // output is a python file
+      // output is a python/json file
       std::string result_file_path = std::filesystem::current_path().string()
                                    + "/dtrace_dump"
                                    + postfix

--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -709,6 +709,13 @@ class module_run_aie_gen2_plus : public module_run
   // Dynamic tracing utility structure
   struct dtrace_util
   {
+    // Configuration for dtrace handle creation
+    dtrace_config_t dtrace_config = {
+      nullptr, // ctrl_file_path
+      nullptr, // map_data
+      0U,      // log_level (error)
+      0U       // output_fmt (python)
+    };
     // Function pointer for dtrace destroy handle
     using dtrace_destroy_handle = void (*)(dtrace_handle_t);
 
@@ -719,9 +726,11 @@ class module_run_aie_gen2_plus : public module_run
     dtrace_util() : dtrace_handle(nullptr, destroy_dtrace_handle) {}
 
     dtrace_util(const std::string& ctrl_file_path, const std::string& map_data,
-                uint32_t log_level)
-      : dtrace_handle(create_dtrace_handle(ctrl_file_path.c_str(), map_data.c_str(), log_level),
-                      destroy_dtrace_handle) {}
+                uint32_t log_level, uint32_t output_fmt)
+      : dtrace_config{ctrl_file_path.c_str(), map_data.c_str(), log_level, output_fmt}
+      , dtrace_handle(create_dtrace_handle(&dtrace_config), destroy_dtrace_handle)
+    {
+    }
   };
   dtrace_util m_dtrace;
 
@@ -749,10 +758,14 @@ class module_run_aie_gen2_plus : public module_run
       return false;
     }
 
+    // log level 0: error, 1: warning, 2: info
     auto log_level = static_cast<uint32_t>(xrt_core::config::get_dtrace_log_level());
-    log_level = (log_level > 3) ? 3U : (log_level < 1) ? 1U : log_level;
+    log_level = (log_level > 2) ? 2U : log_level;
 
-    m_dtrace = dtrace_util(path, m_config.dump_buf.to_string(), log_level);
+    // output format 0: python, 1: json
+    uint32_t output_fmt = xrt_core::config::get_dtrace_output_json_format() ? 1U : 0U;
+
+    m_dtrace = dtrace_util(path, m_config.dump_buf.to_string(), log_level, output_fmt);
     if (!m_dtrace.dtrace_handle.get()) {
       xrt_core::message::send(xrt_core::message::severity_level::debug, "xrt_module",
         "[dtrace] : Failed to get dtrace handle");
@@ -1139,7 +1152,7 @@ public:
       std::string result_file_path = std::filesystem::current_path().string()
                                    + "/dtrace_dump"
                                    + postfix
-                                   + ".py";
+                                   + (xrt_core::config::get_dtrace_output_json_format() ? ".json" : ".py");
 
       get_dtrace_result_file(m_dtrace.dtrace_handle.get(), result_file_path.c_str());
 

--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -1162,7 +1162,14 @@ get_dtrace_control_file_path()
 inline unsigned int
 get_dtrace_log_level()
 {
-  static unsigned int value = detail::get_uint_value("Debug.dtrace_log_level", 1);
+  static unsigned int value = detail::get_uint_value("Debug.dtrace_log_level", 0);
+  return value;
+}
+
+inline bool
+get_dtrace_output_json_format()
+{
+  static bool value = detail::get_bool_value("Debug.dtrace_output_json_format", false);
   return value;
 }
 

--- a/src/runtime_src/core/common/uc_log_schema.h
+++ b/src/runtime_src/core/common/uc_log_schema.h
@@ -140,7 +140,7 @@ uc_log_schema = {
     {85, "Page-in last elf to slot %u\n"},
     {86, "load elf skip\n"},
     {87, "load elf ...\n"},
-    {88, "fw_state: 0x%x\n"},
+    {88, "fw_state before hang is detected: 0x%x\n"},
     {89, "qh: 0x%x ql: 0x%x\n"},
     {90, "mpnpu base time: high 0x%x low 0x%x\n"},
     {91, "shim dma mm2s status: addr 0x%x value 0x%x\n"},


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

Pull in https://github.com/Xilinx/aiebu/pull/278 - dynamic tracing compiler refactor for json output support
Added `dtrace_output_json_format` (bool, default: false) to control the output format of tracing results.
When set to false (default), results are written to a Python file. When set to true, results are written in JSON format.
Updated the `dtrace_log_level` default from 1 to 0 and narrow the effective range to 0–2
Updated uc log schema to the latest version

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

Added flexibility to dump tracing result in json format while tracing/profiling

#### How problem was solved, alternative solutions (if any) and why they were rejected

This is a feature enhancement over existing dynamic tracing

#### Risks (if any) associated the changes in the commit

Low, this applies only when dynamic tracing is enabled

#### What has been tested and how, request additional testing if necessary

Tested by dumping tracing json result on windows medusa board and the feature works as expected

#### Documentation impact (if any)

NA
