### PR TITLE
AIESW-31422:Fix use of deprecated kernel apis.

### DIFF
--- a/src/python/pybind11/src/pyxrt.cpp
+++ b/src/python/pybind11/src/pyxrt.cpp
@@ -33,10 +33,6 @@
 #include <stdexcept>
 #include <string>
 
-#ifdef _MSC_VER
-#pragma warning(disable: 4996)  // C4996: deprecated function; Python binding delegates to C++
-#endif
-
 namespace py = pybind11;
 
 //-----------------------------------------------------------------------------
@@ -83,6 +79,49 @@ warn_deprecated_load_xclbin()
                    "pyxrt.device.load_xclbin() is deprecated; use pyxrt.hw_context(device, xclbin) or pyxrt.hw_context(device, xclbin_path) instead",
                    1) == -1)
     throw py::error_already_set();
+}
+
+void
+warn_deprecated_kernel_device_constructor()
+{
+  if (PyErr_WarnEx(PyExc_DeprecationWarning,
+                   "kernel(device, uuid, name[, mode]) is deprecated; use kernel(hw_context, name) instead.",
+                   1) == -1)
+    throw py::error_already_set();
+}
+
+xrt::kernel
+kernel_device_compat(const xrt::device& device, const xrt::uuid& xclbin_id,
+                     const std::string& name, xrt::kernel::cu_access_mode mode)
+{
+  // Convert kernel cu_access_mode to hw_context access_mode
+  auto ctx_mode = (mode == xrt::kernel::cu_access_mode::exclusive)
+      ? xrt::hw_context::access_mode::exclusive
+      : xrt::hw_context::access_mode::shared;
+
+  xrt::hw_context ctx(device, xclbin_id, ctx_mode);
+  return {ctx, name};
+}
+
+void
+bind_kernel_device_compat(py::class_<xrt::kernel>& pyker)  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+{
+  pyker
+    .def(py::init([](const xrt::device& d, const xrt::uuid& u, const std::string& n,
+                     xrt::kernel::cu_access_mode m) {
+        warn_deprecated_kernel_device_constructor();
+        py::gil_scoped_release release;
+        return new xrt::kernel(kernel_device_compat(d, u, n, m));
+      }),
+      py::arg("device"), py::arg("uuid"), py::arg("name"), py::arg("mode"),
+      "Deprecated compatibility shim. Use kernel(hw_context, name) for new code")
+    .def(py::init([](const xrt::device& d, const xrt::uuid& u, const std::string& n) {
+        warn_deprecated_kernel_device_constructor();
+        py::gil_scoped_release release;
+        return new xrt::kernel(kernel_device_compat(d, u, n, xrt::kernel::cu_access_mode::shared));
+      }),
+      py::arg("device"), py::arg("uuid"), py::arg("name"),
+      "Deprecated compatibility shim. Use kernel(hw_context, name) for new code");
 }
 
 xrt::uuid
@@ -415,17 +454,15 @@ PYBIND11_MODULE(pyxrt, m) {
         .value("none", xrt::kernel::cu_access_mode::none)
         .export_values();
 
+    bind_kernel_device_compat(pyker);
 
-    pyker.def(py::init([](const xrt::device& d, const xrt::uuid& u, const std::string& n,
-                          xrt::kernel::cu_access_mode m) {
-                           return new xrt::kernel(d, u, n, m);
-                       }))
-  	    .def(py::init([](const xrt::device& d, const xrt::uuid& u, const std::string& n) {
-                               return new xrt::kernel(d, u, n);
-                       }))
+    pyker
         .def(py::init([](const xrt::hw_context& ctx, const std::string& n) {
-                               return new xrt::kernel(ctx, n);
-                       }))
+                           py::gil_scoped_release release;
+                           return new xrt::kernel(ctx, n);
+                       }),
+              py::arg("hw_context"), py::arg("name"),
+              "Create kernel from hardware context and name (recommended)")
         .def("__call__", [](xrt::kernel& k, py::args args) -> xrt::run {
                              int i = 0;
                              xrt::run r(k);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
The deprecated constructors kernel (device, uuid, name) and kernel (device, uuid, name, mode) were being called directly from Python bindings, causing compilation failures
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
[AIESW-31422](https://jira.xilinx.com/browse/AIESW-31422)
#### How problem was solved, alternative solutions (if any) and why they were rejected
Added compatibility shim for both kernel constructor overloads using modern hw_context API internally to eliminate C++ deprecation warnings while maintaining Python backward compatibility.
- kernel(device, uuid, name) → uses hw_context with shared mode
- kernel(device, uuid, name, mode) → uses hw_context with specified mode
- Issues Python DeprecationWarning at runtime
- Fixes the issue properly instead of suppressing warnings on Windows.
#### Risks (if any) associated the changes in the commit
Python.
#### What has been tested and how, request additional testing if necessary
Tested on windows with custom made test on Strix machine.
#### Documentation impact (if any)
None. Runtime warnings guide users to modern API.