### PR TITLE
HIP: Fix kernel_start null-args handling.

### DIFF
--- a/src/runtime_src/hip/core/event.cpp
+++ b/src/runtime_src/hip/core/event.cpp
@@ -238,8 +238,15 @@ kernel_start::kernel_start(std::shared_ptr<function> f, void** args)
   r = xrt::run(k);
 
   using karg = xrt_core::xclbin::kernel_argument;
+  auto kernel_args = xrt_core::kernel_int::get_args(k);
+  if (!args) {
+    throw_invalid_value_if(!kernel_args.empty(),
+                           "kernel args pointer is null but kernel expects arguments");
+    return;
+  }
+
   int idx = 0;
-  for (const auto& arg : xrt_core::kernel_int::get_args(k)) {
+  for (const auto& arg : kernel_args) {
     // non index args are not supported, this condition will not hit in case of HIP
     throw_invalid_value_if(arg->index == karg::no_index, "function has invalid argument");
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Add validation in kernel_start constructor to handle null args safely:
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Fixed a null-args validation gap in HIP kernel launch setup: when kernelParams (args) was null, constructor logic could proceed into argument processing for kernels that actually require arguments, which could lead to invalid launch behavior.
#### How problem was solved, alternative solutions (if any) and why they were rejected
- If args is null and kernel expects arguments, throw invalid value 
- If args is null and kernel has zero arguments, return early 
#### Risks (if any) associated the changes in the commit
Low
#### What has been tested and how, request additional testing if necessary
Tested on Windows Strix machine with negative tests of unit tests in testcases-v2 repo.
#### Documentation impact (if any)
NA