### PR TITLE
Apply Fedora patch to disable emulation libraries

### DIFF
--- a/src/CMake/settings.cmake
+++ b/src/CMake/settings.cmake
@@ -19,7 +19,10 @@ message("-- Target system processor is ${CMAKE_SYSTEM_PROCESSOR}")
 option(XRT_INSTALL_STATIC_LIBRARY "Enable CMake static library targets" ON)
 if (XRT_YOCTO)
   set(XRT_INSTALL_STATIC_LIBRARY OFF)
-endif()                       
+endif()
+
+# Option to enable/disable emulation libraries
+option(XRT_ENABLE_EMULATION "Enable Alveo emulation" ON)
 
 # Indicate that we are building XRT
 add_compile_definitions("XRT_BUILD")

--- a/src/runtime_src/core/pcie/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/CMakeLists.txt
@@ -10,7 +10,7 @@ xrt_add_subdirectory(common)
 if(NOT WIN32)
   xrt_add_subdirectory(tools)
   xrt_add_subdirectory(linux)
-  if (${CMAKE_SYSTEM_PROCESSOR} STREQUAL "x86_64")
+  if (${CMAKE_SYSTEM_PROCESSOR} STREQUAL "x86_64" AND XRT_ENABLE_EMULATION)
     # Emulation flow only works on x86_64
     xrt_add_subdirectory(emulation)
     xrt_add_subdirectory(noop)

--- a/src/runtime_src/ert/scheduler/CMakeLists.txt
+++ b/src/runtime_src/ert/scheduler/CMakeLists.txt
@@ -93,6 +93,7 @@ add_custom_target(scheduler
 
 endif(${ERT_BUILD_ALL} STREQUAL "yes")
 
+if (XRT_ENABLE_EMULATION)
 ################################################################
 # HW emulation libsched_em
 ################################################################
@@ -147,3 +148,4 @@ install(TARGETS sched_em_v30
   ARCHIVE DESTINATION ${XRT_INSTALL_LIB_DIR} COMPONENT ${XRT_DEV_COMPONENT}
   LIBRARY DESTINATION ${XRT_INSTALL_LIB_DIR} COMPONENT ${XRT_DEV_COMPONENT} ${XRT_NAMELINK_ONLY}
 )
+endif(XRT_ENABLE_EMULATION)


### PR DESCRIPTION
#### Problem solved by the commit
- `CMake/settings.cmake` option `XRT_ENABLE_EMULATION` default ON
- Check variable in makefiles that build emulation libraries

#### How problem was solved, alternative solutions (if any) and why they were rejected
Emulation is disabled in upstream (Fedora) builds under the assumption that emulation users will have Vitis installed with necessary components (libraries) for use during development.

