### PR TITLE
Fix Binskim BA6004 Eliminate Duplicate Strings issue for debug builds

### DIFF
--- a/src/CMake/nativeWin.cmake
+++ b/src/CMake/nativeWin.cmake
@@ -44,10 +44,10 @@ if (MSVC)
     /Qspectre     # compile with the Spectre mitigations switch
     /ZH:SHA_256   # enable secure source code hashing
     /guard:cf     # enable compiler control guard feature (CFG) to prevent attackers from redirecting execution to unsafe locations
+    /GF           # eliminate duplicate strings
     $<$<NOT:$<CONFIG:Debug>>:/guard:cast> # enable cast guard to prevent type confusion
     $<$<NOT:$<CONFIG:Debug>>:/d2CastGuardFailureMode:fastfail> # fastfail mode for cast guard
     $<$<NOT:$<CONFIG:Debug>>:/GL>  # enable whole program optimization
-    $<$<NOT:$<CONFIG:Debug>>:/GF>  # eliminate duplicate strings
     )
   add_link_options(
     /NODEFAULTLIB:libucrt$<$<CONFIG:Debug>:d>.lib  # Hybrid CRT


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://amd.atlassian.net/browse/EDGEML-13495 and https://amd.atlassian.net/browse/EDGEML-13496 reported BA6002 (EliminateDuplicateStrings) warning in debug builds of cert_dtrace.dll, xrtcore and xdp dlls.,
#### How problem was solved, alternative solutions (if any) and why they were rejected
Added /GF flag for debug builds as it is safe and does not conflict with any Debug-only flags.

#### What has been tested and how, request additional testing if necessary
Build both Release and Debug xrt successfully without any warnings.