### PR TITLE
zocl: Fix CU aperture binding for multi-slot xclbins with shared IP a…

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/common/zocl_drv.c
+++ b/src/runtime_src/core/edge/drm/zocl/common/zocl_drv.c
@@ -415,6 +415,31 @@ int get_apt_index_by_addr(struct drm_zocl_dev *zdev, phys_addr_t addr)
 }
 
 /**
+ * Get the aperture index matching both a physical address and slot index.
+ * Used when multiple slots may contain IPs at the same address.
+ *
+ * @param	zdev:     zocl device struct
+ * @param	addr:     physical address of the aperture
+ * @param	slot_idx: slot index to match
+ *
+ * Returns the index if aperture was found, -EINVAL if not found.
+ */
+int get_apt_index_by_addr_and_slot(struct drm_zocl_dev *zdev,
+				   phys_addr_t addr, int slot_idx)
+{
+	struct addr_aperture *apts = zdev->cu_subdev.apertures;
+	int i;
+
+	mutex_lock(&zdev->cu_subdev.lock);
+	for (i = 0; i < zdev->cu_subdev.num_apts; ++i)
+		if (apts[i].addr == addr && apts[i].slot_idx == slot_idx)
+			break;
+	mutex_unlock(&zdev->cu_subdev.lock);
+
+	return (i == zdev->cu_subdev.num_apts) ? -EINVAL : i;
+}
+
+/**
  * Get the index of the geiven phys address,
  *		   if it is the start of an aperture
  *

--- a/src/runtime_src/core/edge/drm/zocl/common/zocl_ioctl.c
+++ b/src/runtime_src/core/edge/drm/zocl/common/zocl_ioctl.c
@@ -343,6 +343,12 @@ zocl_info_cu_ioctl(struct drm_device *ddev, void *data, struct drm_file *filp)
 		cu_idx = apts[apt_idx].cu_idx;
 
 out:
+	if (apt_idx < 0 || apt_idx >= zdev->cu_subdev.num_apts) {
+		DRM_ERROR("%s: invalid apt_idx=%d for cu_idx=%d (num_apts=%d)",
+			__func__, apt_idx, cu_idx, zdev->cu_subdev.num_apts);
+		return -EINVAL;
+	}
+
 	args->paddr = addr;
 	args->apt_idx = apt_idx;
 	args->cu_idx = cu_idx;

--- a/src/runtime_src/core/edge/drm/zocl/common/zocl_kds.c
+++ b/src/runtime_src/core/edge/drm/zocl/common/zocl_kds.c
@@ -441,7 +441,8 @@ int zocl_kds_update(struct drm_zocl_dev *zdev, struct drm_zocl_slot *slot,
 		if (!xcu)
 			continue;
 
-		apt_idx = get_apt_index_by_addr(zdev, xcu->info.addr);
+		apt_idx = get_apt_index_by_addr_and_slot(zdev, xcu->info.addr,
+			xcu->info.slot_idx);
 		if (apt_idx < 0) {
 			DRM_ERROR("CU address %llx is not found in XCLBIN\n",
 			    xcu->info.addr);

--- a/src/runtime_src/core/edge/drm/zocl/common/zocl_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/common/zocl_xclbin.c
@@ -332,6 +332,8 @@ zocl_update_apertures(struct drm_zocl_dev *zdev, struct drm_zocl_slot *slot)
 	if (slot->ip) {
 		for (i = 0; i < slot->ip->m_count; ++i) {
 			ip = &slot->ip->m_ip_data[i];
+			if (ip->m_base_address == EMPTY_APT_VALUE)
+				continue;
 			apt_idx = get_next_free_apt_index(zdev);
 			if (apt_idx < 0) {
 				DRM_ERROR("No more free apertures\n");

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
@@ -358,6 +358,7 @@ zocl_get_zdev(void)
 	return platform_get_drvdata(pdev);
 }
 int get_apt_index_by_addr(struct drm_zocl_dev *zdev, phys_addr_t addr);
+int get_apt_index_by_addr_and_slot(struct drm_zocl_dev *zdev, phys_addr_t addr, int slot_idx);
 int get_apt_index_by_cu_idx(struct drm_zocl_dev *zdev, int cu_idx);
 void update_cu_idx_in_apt(struct drm_zocl_dev *zdev, int apt_idx, int cu_idx);
 


### PR DESCRIPTION
…ddresses

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
VSS reset IP register write fails with "xclRegRW: can't map CU: 0" when PL and AIE xclbins are loaded into separate slots (slot 0 and slot 1) and both xclbins contain the same ap_none_rst:vss_aie_rst IP at the same physical address (0xa4000000). The CU aperture mapping for the slot 0 CU gets silently overwritten during slot 1 xclbin load, making the CU unreachable for register access.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Fixes: https://jira.xilinx.com/browse/CR-1253753

The bugs are latent in the multi-slot aperture management code and were exposed by the VSS reset flow where PL and AIE xclbins share an IP at the same address across different slots. Discovered via test failure of the VSS reset host application of edge class of devices.
#### How problem was solved, alternative solutions (if any) and why they were rejected
1. Skip IPs with m_base_address == EMPTY_APT_VALUE in
   zocl_update_apertures. These are metadata-only placeholders (e.g.
   ai_engine) that don't need aperture entries.
2. Add a new slot-aware lookup function get_apt_index_by_addr_and_slot
   and use it in zocl_kds_update so each CU only binds to the aperture
   in its own slot.
3. Add bounds validation for apt_idx in zocl_info_cu_ioctl to prevent
   out-of-bounds array access when aperture resolution fails.

#### Risks (if any) associated the changes in the commit
low

#### What has been tested and how, request additional testing if necessary
Tested the given vss reset test based on edge class of device.

#### Documentation impact (if any)
None