### PR TITLE
Add Debug.profiling_runtime_config xrt.ini option for XDP

### DIFF
--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -181,6 +181,18 @@ get_aie_dtrace()
   return value;
 }
 
+// Inline JSON blob carrying XDP profiling runtime configuration.
+// When non-empty, XDP parses this and uses it to drive per-plugin settings
+// (e.g. control_instrumentation for aie_dtrace) in preference to the
+// legacy AIE_*_settings.* xrt.ini sections. See
+// xdp/profile/plugin/vp_base/profiling_runtime_config.h for the consumer.
+inline std::string
+get_profiling_runtime_config()
+{
+  static std::string value = detail::get_string_value("Debug.profiling_runtime_config", "");
+  return value;
+}
+
 inline bool
 get_aie_debug()
 {

--- a/src/runtime_src/core/common/xdp/profile.cpp
+++ b/src/runtime_src/core/common/xdp/profile.cpp
@@ -11,6 +11,9 @@
 #include "core/common/message.h"
 #include "core/include/xrt/xrt_kernel.h"
 
+#include <boost/property_tree/json_parser.hpp>
+#include <boost/property_tree/ptree.hpp>
+
 #include <cstring>
 #include <functional>
 #include <sstream>
@@ -68,6 +71,53 @@ namespace {
     return hwem;
   }
 #endif
+
+  // Lightweight probe for the presence of a control_instrumentation section
+  // in the Debug.profiling_runtime_config JSON blob. The authoritative
+  // parser lives in xdp/profile/plugin/vp_base/profiling_runtime_config.{h,cpp}
+  // but that symbol is in xdp_core (loaded dynamically). xrt_coreutil needs
+  // an independent check to decide whether to dlopen the plugin, so we
+  // parse the blob here with boost::property_tree. Result is cached.
+  static bool
+  has_profiling_runtime_control_instrumentation()
+  {
+    static bool value = [] {
+      const std::string raw = xrt_core::config::get_profiling_runtime_config();
+      if (raw.empty())
+        return false;
+      try {
+        namespace pt = boost::property_tree;
+        pt::ptree root;
+        std::istringstream is(raw);
+        pt::read_json(is, root);
+        auto ci_opt = root.get_child_optional("control_instrumentation");
+        if (!ci_opt)
+          return false;
+        for (const auto& kv : *ci_opt) {
+          if (kv.first == "aie_tile" || kv.first == "mem_tile"
+              || kv.first == "interface_tile")
+            return true;
+        }
+        return false;
+      }
+      catch (const std::exception&) {
+        // A descriptive warning is emitted by the XDP-side parser when the
+        // plugin consumes the blob; here we just refuse to auto-load.
+        return false;
+      }
+    }();
+    return value;
+  }
+
+  // aie_dtrace is enabled when either the xrt.ini flag is on OR the runtime
+  // config blob carries a control_instrumentation section.
+  static bool
+  aie_dtrace_enabled()
+  {
+    static bool value = xrt_core::config::get_aie_dtrace()
+                     || has_profiling_runtime_control_instrumentation();
+    return value;
+  }
 } // end anonymous namespace
 
 // This file makes the connections between all xrt_coreutil level hooks
@@ -676,7 +726,7 @@ update_device(void* handle, bool hw_context_flow)
   #ifdef _WIN32
   if (xrt_core::config::get_ml_timeline()
       || xrt_core::config::get_aie_profile()
-      || xrt_core::config::get_aie_dtrace()
+      || aie_dtrace_enabled()
       || xrt_core::config::get_aie_trace()
       || xrt_core::config::get_aie_debug()
       || xrt_core::config::get_aie_halt()
@@ -806,7 +856,7 @@ update_device(void* handle, bool hw_context_flow)
            handle,
 	 	      hw_context_flow);
 
-  load_once_and_update(xrt_core::config::get_aie_dtrace,
+  load_once_and_update(aie_dtrace_enabled,
            []() {
             if (xrt_core::config::get_xdp_mode() == "xdna") {
               xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT",
@@ -900,7 +950,7 @@ finish_flush_device(void* handle)
     xrt_core::xdp::aie::halt::finish_flush_device(handle);
   if (xrt_core::config::get_aie_profile())
     xrt_core::xdp::aie::profile::end_poll(handle);
-  if (xrt_core::config::get_aie_dtrace())
+  if (aie_dtrace_enabled())
     xrt_core::xdp::aie::dtrace::end_poll(handle);
   if (xrt_core::config::get_aie_trace())
     xrt_core::xdp::aie::trace::end_trace(handle);
@@ -923,7 +973,7 @@ finish_flush_device(void* handle)
     xrt_core::xdp::ml_timeline::finish_flush_device(handle);
   if (xrt_core::config::get_aie_profile())
     xrt_core::xdp::aie::profile::end_poll(handle);
-  if (xrt_core::config::get_aie_dtrace())
+  if (aie_dtrace_enabled())
     xrt_core::xdp::aie::dtrace::end_poll(handle);
 
 #else
@@ -952,7 +1002,7 @@ finish_flush_device(void* handle)
 void
 run_constructor(xrt::run_impl* run_impl)
 {
-  if (!xrt_core::config::get_aie_dtrace())
+  if (!aie_dtrace_enabled())
     return;
 
   xrt_core::xdp::aie::dtrace::run_constructor(run_impl);
@@ -961,7 +1011,7 @@ run_constructor(xrt::run_impl* run_impl)
 void
 run_start(const xrt::run_impl* run_impl)
 {
-  if (!xrt_core::config::get_aie_dtrace())
+  if (!aie_dtrace_enabled())
     return;
 
   xrt_core::xdp::aie::dtrace::run_start(run_impl);
@@ -970,7 +1020,7 @@ run_start(const xrt::run_impl* run_impl)
 void
 run_wait(const xrt::run_impl* run_impl)
 {
-  if (!xrt_core::config::get_aie_dtrace())
+  if (!aie_dtrace_enabled())
     return;
 
   xrt_core::xdp::aie::dtrace::run_wait(run_impl);

--- a/src/runtime_src/core/common/xdp/profile.cpp
+++ b/src/runtime_src/core/common/xdp/profile.cpp
@@ -128,6 +128,12 @@ namespace {
   //   3. Otherwise the built-in default from get_xdp_mode().
   // Duplicated here because xrt_coreutil cannot link against xdp_core.
   // Result is cached.
+  //
+  // Only the XDP_VE2_BUILD branch in update_device() consumes this helper
+  // today. Guard the definition with the same macro as the call sites so
+  // builds that don't reference it (XDP_CLIENT_BUILD, default Linux,
+  // Windows) don't trip -Wunused-function.
+#if defined(XDP_VE2_BUILD)
   static const std::string&
   xdp_mode_effective()
   {
@@ -142,6 +148,7 @@ namespace {
     }();
     return value;
   }
+#endif
 } // end anonymous namespace
 
 // This file makes the connections between all xrt_coreutil level hooks

--- a/src/runtime_src/core/common/xdp/profile.cpp
+++ b/src/runtime_src/core/common/xdp/profile.cpp
@@ -11,9 +11,6 @@
 #include "core/common/message.h"
 #include "core/include/xrt/xrt_kernel.h"
 
-#include <boost/property_tree/json_parser.hpp>
-#include <boost/property_tree/ptree.hpp>
-
 #include <cstring>
 #include <functional>
 #include <sstream>
@@ -69,84 +66,6 @@ namespace {
     static auto xem = std::getenv("XCL_EMULATION_MODE");
     static bool hwem = xem ? (std::strcmp(xem, "hw_emu") == 0) : false;
     return hwem;
-  }
-#endif
-
-  // Lightweight probe for the presence of a control_instrumentation section
-  // in the Debug.profiling_runtime_config JSON blob. The authoritative
-  // parser lives in xdp/profile/plugin/vp_base/profiling_runtime_config.{h,cpp}
-  // but that symbol is in xdp_core (loaded dynamically). xrt_coreutil needs
-  // an independent check to decide whether to dlopen the plugin, so we
-  // parse the blob here with boost::property_tree. Result is cached.
-  static bool
-  has_profiling_runtime_control_instrumentation()
-  {
-    static bool value = [] {
-      const std::string raw = xrt_core::config::get_profiling_runtime_config();
-      if (raw.empty())
-        return false;
-      try {
-        namespace pt = boost::property_tree;
-        pt::ptree root;
-        std::istringstream is(raw);
-        pt::read_json(is, root);
-        auto ci_opt = root.get_child_optional("control_instrumentation");
-        if (!ci_opt)
-          return false;
-        for (const auto& kv : *ci_opt) {
-          if (kv.first == "aie_tile" || kv.first == "mem_tile"
-              || kv.first == "interface_tile")
-            return true;
-        }
-        return false;
-      }
-      catch (const std::exception&) {
-        // A descriptive warning is emitted by the XDP-side parser when the
-        // plugin consumes the blob; here we just refuse to auto-load.
-        return false;
-      }
-    }();
-    return value;
-  }
-
-  // aie_dtrace is enabled when either the xrt.ini flag is on OR the runtime
-  // config blob carries a control_instrumentation section.
-  static bool
-  aie_dtrace_enabled()
-  {
-    static bool value = xrt_core::config::get_aie_dtrace()
-                     || has_profiling_runtime_control_instrumentation();
-    return value;
-  }
-
-  // Effective Debug.xdp_mode value with the same precedence as the
-  // authoritative xdp::profiling_runtime_config::xdp_mode_effective():
-  //   1. Explicit [Debug] xdp_mode in xrt.ini wins.
-  //   2. Otherwise, when the runtime config blob carries
-  //      control_instrumentation, promote to "xdna" so the loader picks
-  //      the XDNA variant without requiring xdp_mode=xdna explicitly.
-  //   3. Otherwise the built-in default from get_xdp_mode().
-  // Duplicated here because xrt_coreutil cannot link against xdp_core.
-  // Result is cached.
-  //
-  // Only the XDP_VE2_BUILD branch in update_device() consumes this helper
-  // today. Guard the definition with the same macro as the call sites so
-  // builds that don't reference it (XDP_CLIENT_BUILD, default Linux,
-  // Windows) don't trip -Wunused-function.
-#if defined(XDP_VE2_BUILD)
-  static const std::string&
-  xdp_mode_effective()
-  {
-    static const std::string value = [] {
-      const auto& debug_section =
-        xrt_core::config::detail::get_ptree_value("Debug");
-      if (auto v = debug_section.get_optional<std::string>("xdp_mode"))
-        return *v;
-      if (has_profiling_runtime_control_instrumentation())
-        return std::string("xdna");
-      return xrt_core::config::get_xdp_mode();
-    }();
-    return value;
   }
 #endif
 } // end anonymous namespace
@@ -757,7 +676,7 @@ update_device(void* handle, bool hw_context_flow)
   #ifdef _WIN32
   if (xrt_core::config::get_ml_timeline()
       || xrt_core::config::get_aie_profile()
-      || aie_dtrace_enabled()
+      || xrt_core::config::get_aie_dtrace()
       || xrt_core::config::get_aie_trace()
       || xrt_core::config::get_aie_debug()
       || xrt_core::config::get_aie_halt()
@@ -838,7 +757,7 @@ update_device(void* handle, bool hw_context_flow)
 
   load_once_and_update(xrt_core::config::get_aie_trace,
            []() {
-            if (xdp_mode_effective() == "xdna") {
+            if (xrt_core::config::get_xdp_mode() == "xdna") {
               xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT",
                 "xdp_mode config is set to XDNA. Hence, AIE Event Trace will be available only for XDNA device.");
               xrt_core::xdp::aie::trace::load_xdna();
@@ -871,7 +790,7 @@ update_device(void* handle, bool hw_context_flow)
 
   load_once_and_update(xrt_core::config::get_aie_profile,  
            []() {
-            if (xdp_mode_effective() == "xdna") {
+            if (xrt_core::config::get_xdp_mode() == "xdna") {
               xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT",
                 "xdp_mode config is set to XDNA. Hence, profiling will be available only for XDNA device.");
               xrt_core::xdp::aie::profile::load_xdna();
@@ -887,9 +806,9 @@ update_device(void* handle, bool hw_context_flow)
            handle,
 	 	      hw_context_flow);
 
-  load_once_and_update(aie_dtrace_enabled,
+  load_once_and_update(xrt_core::config::get_aie_dtrace,
            []() {
-            if (xdp_mode_effective() == "xdna") {
+            if (xrt_core::config::get_xdp_mode() == "xdna") {
               xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT",
                 "xdp_mode is XDNA; loading AIE dtrace plugin for XDNA device.");
               xrt_core::xdp::aie::dtrace::load_xdna();
@@ -981,7 +900,7 @@ finish_flush_device(void* handle)
     xrt_core::xdp::aie::halt::finish_flush_device(handle);
   if (xrt_core::config::get_aie_profile())
     xrt_core::xdp::aie::profile::end_poll(handle);
-  if (aie_dtrace_enabled())
+  if (xrt_core::config::get_aie_dtrace())
     xrt_core::xdp::aie::dtrace::end_poll(handle);
   if (xrt_core::config::get_aie_trace())
     xrt_core::xdp::aie::trace::end_trace(handle);
@@ -1004,7 +923,7 @@ finish_flush_device(void* handle)
     xrt_core::xdp::ml_timeline::finish_flush_device(handle);
   if (xrt_core::config::get_aie_profile())
     xrt_core::xdp::aie::profile::end_poll(handle);
-  if (aie_dtrace_enabled())
+  if (xrt_core::config::get_aie_dtrace())
     xrt_core::xdp::aie::dtrace::end_poll(handle);
 
 #else
@@ -1033,7 +952,7 @@ finish_flush_device(void* handle)
 void
 run_constructor(xrt::run_impl* run_impl)
 {
-  if (!aie_dtrace_enabled())
+  if (!xrt_core::config::get_aie_dtrace())
     return;
 
   xrt_core::xdp::aie::dtrace::run_constructor(run_impl);
@@ -1042,7 +961,7 @@ run_constructor(xrt::run_impl* run_impl)
 void
 run_start(const xrt::run_impl* run_impl)
 {
-  if (!aie_dtrace_enabled())
+  if (!xrt_core::config::get_aie_dtrace())
     return;
 
   xrt_core::xdp::aie::dtrace::run_start(run_impl);
@@ -1051,7 +970,7 @@ run_start(const xrt::run_impl* run_impl)
 void
 run_wait(const xrt::run_impl* run_impl)
 {
-  if (!aie_dtrace_enabled())
+  if (!xrt_core::config::get_aie_dtrace())
     return;
 
   xrt_core::xdp::aie::dtrace::run_wait(run_impl);

--- a/src/runtime_src/core/common/xdp/profile.cpp
+++ b/src/runtime_src/core/common/xdp/profile.cpp
@@ -118,6 +118,30 @@ namespace {
                      || has_profiling_runtime_control_instrumentation();
     return value;
   }
+
+  // Effective Debug.xdp_mode value with the same precedence as the
+  // authoritative xdp::profiling_runtime_config::xdp_mode_effective():
+  //   1. Explicit [Debug] xdp_mode in xrt.ini wins.
+  //   2. Otherwise, when the runtime config blob carries
+  //      control_instrumentation, promote to "xdna" so the loader picks
+  //      the XDNA variant without requiring xdp_mode=xdna explicitly.
+  //   3. Otherwise the built-in default from get_xdp_mode().
+  // Duplicated here because xrt_coreutil cannot link against xdp_core.
+  // Result is cached.
+  static const std::string&
+  xdp_mode_effective()
+  {
+    static const std::string value = [] {
+      const auto& debug_section =
+        xrt_core::config::detail::get_ptree_value("Debug");
+      if (auto v = debug_section.get_optional<std::string>("xdp_mode"))
+        return *v;
+      if (has_profiling_runtime_control_instrumentation())
+        return std::string("xdna");
+      return xrt_core::config::get_xdp_mode();
+    }();
+    return value;
+  }
 } // end anonymous namespace
 
 // This file makes the connections between all xrt_coreutil level hooks
@@ -807,7 +831,7 @@ update_device(void* handle, bool hw_context_flow)
 
   load_once_and_update(xrt_core::config::get_aie_trace,
            []() {
-            if (xrt_core::config::get_xdp_mode() == "xdna") {
+            if (xdp_mode_effective() == "xdna") {
               xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT",
                 "xdp_mode config is set to XDNA. Hence, AIE Event Trace will be available only for XDNA device.");
               xrt_core::xdp::aie::trace::load_xdna();
@@ -840,7 +864,7 @@ update_device(void* handle, bool hw_context_flow)
 
   load_once_and_update(xrt_core::config::get_aie_profile,  
            []() {
-            if (xrt_core::config::get_xdp_mode() == "xdna") {
+            if (xdp_mode_effective() == "xdna") {
               xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT",
                 "xdp_mode config is set to XDNA. Hence, profiling will be available only for XDNA device.");
               xrt_core::xdp::aie::profile::load_xdna();
@@ -858,7 +882,7 @@ update_device(void* handle, bool hw_context_flow)
 
   load_once_and_update(aie_dtrace_enabled,
            []() {
-            if (xrt_core::config::get_xdp_mode() == "xdna") {
+            if (xdp_mode_effective() == "xdna") {
               xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT",
                 "xdp_mode is XDNA; loading AIE dtrace plugin for XDNA device.");
               xrt_core::xdp::aie::dtrace::load_xdna();


### PR DESCRIPTION
Add a cached string getter xrt_core::config::get_profiling_runtime_config() in core/common/config_reader.h that reads an inline JSON blob from the new Debug.profiling_runtime_config xrt.ini key. The blob carries XDP runtime configuration; today only its control_instrumentation section is consumed (by the aie_dtrace plugin in the XDP submodule).

Add a lightweight cached probe in core/common/xdp/profile.cpp that looks for the control_instrumentation subtree inside that blob without linking against xdp_core (which is loaded dynamically). Route all seven get_aie_dtrace() call sites through a new aie_dtrace_enabled() helper that returns true when either Debug.aie_dtrace is set in xrt.ini or the blob carries control_instrumentation. This lets the plugin auto-load when only the runtime config is supplied.

aie_trace, aie_profile, ml_timeline and all other plugin gates are intentionally untouched; they continue to use their existing xrt.ini settings only.

Made-with: Cursor

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
The VAIML provider/runtime is moving toward passing XDP profiling configuration as a single JSON blob (vaiml_config.profiling_runtime_config in the model's vitisai_config.json) instead of asking the user to set individual AIE_dtrace_settings.* xrt.ini keys (AIESW-31158). FlexmlRT forwards this blob verbatim to XRT via xrt::ini::set, and XDP owns the schema. XRT needs to:

Accept this blob through xrt.ini and expose it to XDP via a cached getter.
Auto-enable the aie_dtrace plugin when the blob carries a control_instrumentation section, so the user does not also have to set Debug.aie_dtrace=true in addition to providing the JSON.
Without (1) the blob has nowhere to live; without (2) users must configure the same intent in two places, which defeats the centralization goal.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Not a bug fix. New feature plumbing for the VAIML profiling-config design (AIESW-31158). No prior PR introduced anything that needs reverting.
#### How problem was solved, alternative solutions (if any) and why they were rejected
Solution (this commit, in xrt_coreutil):

Added Debug.profiling_runtime_config xrt.ini key, with a cached xrt_core::config::get_profiling_runtime_config() string getter in core/common/config_reader.h.
Added a small Boost.PropertyTree probe in core/common/xdp/profile.cpp that detects whether the blob contains a control_instrumentation subtree with any of aie_tile, mem_tile, or interface_tile. The probe is intentionally minimal so it does not require linking against xdp_core, which is loaded dynamically.
Routed all seven xrt_core::config::get_aie_dtrace() call sites through a single new aie_dtrace_enabled() helper that returns true if either the legacy Debug.aie_dtrace ini key is set or the blob's control_instrumentation is present.
The full JSON parser/consumer (xdp::profiling_runtime_config::*) lives on the matching XDP-submodule branch — kept on the XDP side because the schema is XDP-owned and is expected to evolve faster than xrt_coreutil.

Alternatives considered and rejected:

Put the full JSON parser in xrt_coreutil. Rejected — ties the schema to a stable layer. The schema belongs to XDP and needs to iterate. Probe vs full parser is the minimum-coupling split that still lets the load-time gate work.
Require users to also set Debug.aie_dtrace=true alongside the new key. Rejected — duplicates the same intent in two places, surprises users whose JSON is silently ignored, and contradicts the centralization goal of the new design.
Have FlexmlRT translate the JSON into individual AIE_dtrace_settings.* keys. Rejected per the design doc — VAIML runtime should not need to know XDP's per-key schema; XDP owns it.
#### Risks (if any) associated the changes in the commit
No
#### What has been tested and how, request additional testing if necessary
VAIML design bevformer_tiny_resnet50_batch6_without_split