### PR TITLE
AIESW-32006: Fix temperature display scaling in data-driven thermal path

### DIFF
--- a/src/runtime_src/core/common/sensor.cpp
+++ b/src/runtime_src/core/common/sensor.cpp
@@ -242,7 +242,7 @@ read_data_driven_thermals(const std::vector<xq::sdm_sensor_info::data_type>& out
     ptree_type pt;
     pt.put("location_id", tmp.label);
     pt.put("description", tmp.label);
-    pt.put("temp_C", tmp.input);
+    pt.put("temp_C", xrt_core::utils::format_base10_shiftdown(tmp.input, tmp.unitm, 2));
     pt.put("is_present", "true");
     thermal_array.push_back({"", pt});
   }

--- a/src/runtime_src/core/tools/common/reports/platform/ReportRyzenPlatform.cpp
+++ b/src/runtime_src/core/tools/common/reports/platform/ReportRyzenPlatform.cpp
@@ -70,8 +70,7 @@ ReportRyzenPlatform::writeReport(const xrt_core::device* _pDevice,
         const boost::property_tree::ptree& pt_temp = kv.second;
         if (!pt_temp.get<bool>("is_present", false))
           continue;
-        auto temp_val = pt_temp.get<uint64_t>("temp_C", 0);
-        temp_c = std::to_string(temp_val);
+        temp_c = pt_temp.get<std::string>("temp_C", "N/A");
         break;
       }
     }


### PR DESCRIPTION
Issue
The data-driven thermal path in read_data_driven_thermals() was storing the raw sensor value directly into the "temp_C" property tree node without applying the unit modifier (unitm). On NPU Medusa (MDS), the KMD reports temperature in centi-Celsius (unitm = -2), so a raw value of 3668 was being displayed as "3668" instead of the correct "36.68" degrees Celsius.


All other sensor types (voltage, current, power) in the data-driven path correctly apply xrt_core::utils::format_base10_shiftdown() using the unitm field from the sensor data. Temperature was the only sensor type that skipped this conversion, storing the raw integer directly.

Fix:
1. sensor.cpp: Apply format_base10_shiftdown(input, unitm, 2) when storing temp_C in the property tree, consistent with how voltage, current and power are handled. Precision of 2 decimal places is used to preserve meaningful sub-degree resolution from sensors reporting in centi-Celsius.

2. ReportRyzenPlatform.cpp: Read temp_C as std::string instead of uint64_t since format_base10_shiftdown returns a formatted decimal string. The unitm field is not propagated into the property tree, so the conversion must happen in sensor.cpp where both input and unitm are available.

Impact:
Before: Temperature (C) : 3668
After:  Temperature (C) : 36.68

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Temperature reported by `xrt-smi examine -r platform` was displaying
the raw centi-Celsius sensor value (e.g. 3668) instead of the correct
scaled value in degrees Celsius (e.g. 36.68) on NPU Medusa (MDS) devices.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Discovered by running `xrt-smi examine -r platform` on an NPU Medusa
device under load and observing `Temperature (C) : 3668` which is
clearly not a valid temperature in Celsius.

#### How problem was solved, alternative solutions (if any) and why they were rejected
The data-driven thermal path in `read_data_driven_thermals()` was
storing `tmp.input` directly without applying the unit modifier (unitm),
unlike voltage, current and power which correctly use
`format_base10_shiftdown()`. Applied the same conversion for temperature
with precision 2 to preserve sub-degree resolution.

Updated `ReportRyzenPlatform.cpp` to read `temp_C` as `std::string`
since `format_base10_shiftdown` returns a formatted decimal string.

Alternative: Apply scaling in `ReportRyzenPlatform.cpp` — rejected
because `unitm` is not propagated into the property tree, so the
conversion must happen in `sensor.cpp` where both `input` and `unitm`
are available.

Alternative: Store as whole integer degrees (precision 0) — rejected
because it loses sub-degree resolution that the hardware provides
(unitm=-2, centi-Celsius).

#### Risks (if any) associated the changes in the commit
Low. Change is isolated to `read_data_driven_thermals()`. The legacy
path (`populate_temp`) used by PCIe platforms is unchanged. All
consumers of `temp_C` already read it as `std::string`.

#### What has been tested and how, request additional testing if necessary
Verified on NPU Medusa (MDS1 B0):
  Before: `Temperature (C) : 3668`
  After:  `Temperature (C) : 36.68`

Request testing on PCIe platforms (Alveo/Versal) using the data-driven
sensor path to confirm no regression.

#### Documentation impact (if any)
None.

