### PR TITLE
AIESW-32028 Automatic core dump collection on xrt.ini key

### DIFF
--- a/src/runtime_src/core/common/api/xrt_hw_context.cpp
+++ b/src/runtime_src/core/common/api/xrt_hw_context.cpp
@@ -262,6 +262,27 @@ class hw_context_impl : public std::enable_shared_from_this<hw_context_impl>
     xrt_core::xdp::update_device(this, true);
   }
 
+  // Amend configuration parameters 
+  static cfg_storage
+  amend_cfg(cfg_storage cfg)
+  {
+    // Refactor if more to amend
+    if (xrt_core::config::get_aie_coredump_file().empty())
+      return cfg;
+
+    std::visit([](auto& v) {
+      using T = std::decay_t<decltype(v)>;
+      if constexpr (std::is_same_v<T, cfg_param_type>) {
+        v.emplace("aie_coredump", 1u);
+      }
+      else if constexpr (std::is_same_v<T, cfg_type>) {
+        v.emplace("aie_coredump", "1");
+      }
+    }, cfg);
+
+    return cfg;
+  }
+
   // Initializes uc log buffer
   // Creates log buffer and starts a thread to dump the log buffer contents
   // periodically per column to a file
@@ -309,7 +330,7 @@ public:
     : m_core_device(std::move(device))
     , m_xclbin(m_core_device->get_xclbin(xclbin_id))
     , m_partition_size(get_partition_size_from_xclbin(m_xclbin))
-    , m_cfg_storage{std::move(cfg)}
+    , m_cfg_storage{amend_cfg(std::move(cfg))}
     , m_mode(xrt::hw_context::access_mode::shared)
     , m_hdl{m_core_device->create_hw_context(xclbin_id, effective_cfg_param(m_cfg_storage), m_mode)}
     , m_uc_log_buf(init_uc_log_buf(m_core_device, m_hdl.get()))
@@ -319,7 +340,7 @@ public:
     : m_core_device{std::move(device)}
     , m_xclbin{m_core_device->get_xclbin(xclbin_id)}
     , m_partition_size(get_partition_size_from_xclbin(m_xclbin))
-    , m_cfg_storage{cfg_param_type{}}
+    , m_cfg_storage{amend_cfg(cfg_param_type{})}
     , m_mode{mode}
     , m_hdl{m_core_device->create_hw_context(xclbin_id, effective_cfg_param(m_cfg_storage), m_mode)}
     , m_uc_log_buf(init_uc_log_buf(m_core_device, m_hdl.get()))
@@ -327,7 +348,7 @@ public:
 
   hw_context_impl(std::shared_ptr<xrt_core::device> device, cfg_storage cfg, access_mode mode)
     : m_core_device{std::move(device)}
-    , m_cfg_storage{std::move(cfg)}
+    , m_cfg_storage{amend_cfg(std::move(cfg))}
     , m_mode{mode}
   {}
 
@@ -335,7 +356,7 @@ public:
                   cfg_storage cfg, access_mode mode)
     : m_core_device{std::move(device)}
     , m_partition_size{elf.get_partition_size()}
-    , m_cfg_storage{std::move(cfg)}
+    , m_cfg_storage{amend_cfg(std::move(cfg))}
     , m_mode{mode}
     , m_hdl{m_core_device->create_hw_context(elf, effective_cfg_param(m_cfg_storage), m_mode)}
     , m_uc_log_buf(init_uc_log_buf(m_core_device, m_hdl.get()))

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -2893,6 +2893,33 @@ public:
     return state;
   }
 
+  // abort_coredump_or_noop() - AIE coredump if enabled
+  // Dump core and abort, or do nothing.
+  void
+  abort_coredump_or_noop(ert_cmd_state state) const
+  {
+    if (state != ERT_CMD_STATE_TIMEOUT)
+      return;
+    
+    auto file = xrt_core::config::get_aie_coredump_file();
+    if (file.empty())
+      return;
+
+    try {
+      auto hwctx = kernel->get_hw_context();
+      auto core = hwctx.get_aie_coredump();  // may throw
+
+      std::ofstream ostr{file, std::ios::binary};
+      if (!ostr)
+        throw std::runtime_error("Could not open '" + file + "' for writing");
+      ostr.write(core.data(), static_cast<std::streamsize>(core.size()));
+      std::abort();
+    }
+    catch (const std::exception& ex) {
+      xrt_core::send_exception_message(std::string("Failed to create core dump: ") + ex.what());
+    }
+  }
+
   void
   throw_command_error(ert_cmd_state state) const
   {
@@ -2912,6 +2939,7 @@ public:
     case ERT_START_DPU:
     case ERT_START_NPU_PREEMPT:
     case ERT_START_NPU_PREEMPT_ELF:
+      abort_coredump_or_noop(state);
       throw xrt::run::aie_error(xrt::run(get_mutable_shared_ptr()), msg);
     default:
       throw xrt::run::command_error(state, msg);
@@ -3576,6 +3604,7 @@ class runlist_impl
     case ERT_START_DPU:
     case ERT_START_NPU_PREEMPT:
     case ERT_START_NPU_PREEMPT_ELF:
+      rhdl->abort_coredump_or_noop(state);
       throw xrt::runlist::aie_error(run, state, msg);
     default:
       throw xrt::runlist::command_error(run, state, msg);
@@ -4715,7 +4744,8 @@ aie_error_message_v1(const ert_packet* epkt, const std::string& msg)
       << "\nfatal_error_exception_pc = 0x" << std::setw(indent8) << ctx_health->aie2.fatal_error_exception_pc
       << "\nfatal_error_app_module = 0x" << std::setw(indent8) << ctx_health->aie2.fatal_error_app_module
       << "\n";
-  } else if ( ctx_health->npu_gen == NPU_GEN_AIE4) {
+  }
+  else if ( ctx_health->npu_gen == NPU_GEN_AIE4) {
     oss << std::uppercase << std::hex << std::setfill('0');
     oss << "ctx_state = 0x" << std::setw(indent8) << ctx_health->aie4.ctx_state
       << "\nctx_error_type = 0x" << std::setw(indent8) << ctx_health->aie4.ctx_error_type

--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -611,6 +611,13 @@ get_enable_aied()
   return value;
 }
 
+inline std::string
+get_aie_coredump_file()
+{
+  static std::string value = detail::get_string_value("Runtime.aie_coredump_file", "");
+  return value;
+}
+
 inline bool
 get_multiprocess()
 {


### PR DESCRIPTION
#### Problem solved by the commit
Add `Runtime.aie_coredump_file` xrt.ini key to enable AIE coredump.

#### How problem was solved, alternative solutions (if any) and why they were rejected
If specified in xrt.ini, then the hwctx is configured to enable aie coredump on command error (`ERT_CMD_STATE_TIMEOUT`).  The coredump, if succesfully generated, is dumped to specified file and process is aborted.

If UMD fails to generate a coredump (under xrt.ini condition) then error message is produced but standard error path is taken to throw an exception without aborting.

To configure the hwctx for coredump, XRT internally sets a configuration parameter (`aie_coredump = 1`) which is passed to UMD and then KMD.

