### PR TITLE
Hardware context reset configure option

### DIFF
--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -332,6 +332,7 @@ enum class key_type
   firmware_log_state,
   firmware_log_config,
   archive_path,
+  hardware_context_reset,
   frame_boundary_preemption,
   debug_ip_layout_path,
   debug_ip_layout,
@@ -4112,10 +4113,21 @@ struct archive_path : request
   get(const device*) const override = 0;
 };
 
+/* Enable (1) or disable (0) hardware-context reset policy (shim ioctl; KMD optional). */
+struct hardware_context_reset : request
+{
+  using value_type = uint32_t;
+
+  static const key_type key = key_type::hardware_context_reset;
+
+  void
+  put(const device*, const std::any&) const override = 0;
+};
+
 /*
  * this request force enables or disables frame boundary pre-emption globally
  * 1: enable; 0: disable
-*/
+ */
 struct frame_boundary_preemption : request
 {
   using result_type = uint32_t;  // get value type

--- a/src/runtime_src/core/common/smi/smi_ryzen.cpp
+++ b/src/runtime_src/core/common/smi/smi_ryzen.cpp
@@ -100,6 +100,7 @@ config_gen_ryzen::create_configure_subcommand()
   configure_suboptions.emplace("force-preemption", std::make_shared<option>("force-preemption", "", "Force enable|disable and see status of preemption", "hidden", "", "string", true));
   configure_suboptions.emplace("event-trace", std::make_shared<option>("event-trace", "", "Enable|disable event tracing", "hidden", "", "string", true));
   configure_suboptions.emplace("firmware-log", std::make_shared<option>("firmware-log", "", "Enable|disable firmware logging", "hidden", "", "string", true));
+  configure_suboptions.emplace("hardware-context", std::make_shared<option>("hardware-context", "", "Enable|disable hardware context reset recovery", "hidden", "", "string", true));
 
   return {"configure", "Device and host configuration", "common", std::move(configure_suboptions)};
 }

--- a/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
@@ -55,6 +55,7 @@ file(GLOB XBUTIL_V2_SUBCMD_FILES
 
 add_subdirectory(EventTracing)
 add_subdirectory(FirmwareLogging)
+add_subdirectory(HardwareContext)
 add_subdirectory(ContextHealth)
 
 # Merge the files into one collection

--- a/src/runtime_src/core/tools/xbutil2/HardwareContext/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbutil2/HardwareContext/CMakeLists.txt
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+file(GLOB HARDWARE_CONTEXT_FILES
+  "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp"
+)
+
+list(APPEND XBUTIL_V2_SUBCMD_FILES ${HARDWARE_CONTEXT_FILES})
+set(XBUTIL_V2_SUBCMD_FILES ${XBUTIL_V2_SUBCMD_FILES} PARENT_SCOPE)

--- a/src/runtime_src/core/tools/xbutil2/HardwareContext/OO_HardwareContextReset.cpp
+++ b/src/runtime_src/core/tools/xbutil2/HardwareContext/OO_HardwareContextReset.cpp
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+#include "OO_HardwareContextReset.h"
+#include "tools/common/XBUtilitiesCore.h"
+#include "tools/common/XBUtilities.h"
+#include "tools/common/XBHelpMenusCore.h"
+#include "core/common/query_requests.h"
+
+#include <boost/algorithm/string.hpp>
+#include <boost/format.hpp>
+#include <boost/program_options.hpp>
+#include <any>
+#include <iostream>
+
+namespace po = boost::program_options;
+
+OO_HardwareContextReset::OO_HardwareContextReset(const std::string& _longName, bool _isHidden)
+  : OptionOptions(_longName, _isHidden, "Hardware context reset recovery (enable|disable)")
+  , m_device("")
+  , m_reset("")
+  , m_help(false)
+{
+  m_optionsDescription.add_options()
+    ("device,d", boost::program_options::value<decltype(m_device)>(&m_device), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest")
+    ("help,h", boost::program_options::bool_switch(&m_help), "Help to use this sub-command")
+    ("reset", boost::program_options::value<decltype(m_reset)>(&m_reset), "enable or disable hardware context reset recovery")
+  ;
+}
+
+void
+OO_HardwareContextReset::validate_args() const
+{
+  if (m_reset.empty() && !m_help)
+    throw xrt_core::error(std::errc::operation_canceled, "Please specify --reset with enable or disable");
+
+  if (!m_reset.empty() && !boost::iequals(m_reset, "enable") && !boost::iequals(m_reset, "disable"))
+    throw xrt_core::error(std::errc::operation_canceled, "Invalid --reset value (use enable or disable)");
+}
+
+void
+OO_HardwareContextReset::execute(const SubCmdOptions& _options) const
+{
+  XBUtilities::verbose("SubCommand option: hardware-context reset");
+  XBUtilities::sudo_or_throw("Hardware context reset policy requires admin privileges");
+
+  XBUtilities::verbose("Option(s):");
+  for (auto& aString : _options)
+    XBUtilities::verbose(std::string(" ") + aString);
+
+  po::variables_map vm;
+
+  try {
+    po::options_description all_options("All Options");
+    all_options.add(m_optionsDescription);
+    all_options.add(m_optionsHidden);
+    po::command_line_parser parser(_options);
+    XBUtilities::process_arguments(vm, parser, all_options, m_positionalOptions, true);
+  } catch (boost::program_options::error& ex) {
+    std::cout << ex.what() << std::endl;
+    printHelp();
+    throw xrt_core::error(std::errc::operation_canceled);
+  }
+
+  if (m_help) {
+    printHelp();
+    return;
+  }
+
+  try {
+    validate_args();
+  } catch (xrt_core::error& err) {
+    std::cout << err.what() << std::endl;
+    printHelp();
+    throw xrt_core::error(err.get_code());
+  }
+
+  std::shared_ptr<xrt_core::device> device;
+
+  try {
+    device = XBUtilities::get_device(boost::algorithm::to_lower_copy(m_device), true /*inUserDomain*/);
+  } catch (const std::runtime_error& e) {
+    std::cerr << boost::format("ERROR: %s\n") % e.what();
+    throw xrt_core::error(std::errc::operation_canceled);
+  }
+
+  const uint32_t enable = boost::iequals(m_reset, "enable") ? 1U : 0U;
+  const std::string action_name = enable ? "enabled" : "disabled";
+
+  try {
+    xrt_core::device_update<xrt_core::query::hardware_context_reset>(device.get(), std::any(enable));
+    std::cout << "Hardware context reset recovery " << action_name << std::endl;
+  } catch (const xrt_core::error& e) {
+    std::cerr << boost::format("\nERROR: %s\n") % e.what();
+    printHelp();
+    throw xrt_core::error(std::errc::operation_canceled);
+  }
+}

--- a/src/runtime_src/core/tools/xbutil2/HardwareContext/OO_HardwareContextReset.cpp
+++ b/src/runtime_src/core/tools/xbutil2/HardwareContext/OO_HardwareContextReset.cpp
@@ -18,24 +18,24 @@ namespace po = boost::program_options;
 OO_HardwareContextReset::OO_HardwareContextReset(const std::string& _longName, bool _isHidden)
   : OptionOptions(_longName, _isHidden, "Hardware context reset recovery (enable|disable)")
   , m_device("")
-  , m_reset("")
+  , m_reset_on_error("")
   , m_help(false)
 {
   m_optionsDescription.add_options()
     ("device,d", boost::program_options::value<decltype(m_device)>(&m_device), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest")
     ("help,h", boost::program_options::bool_switch(&m_help), "Help to use this sub-command")
-    ("reset", boost::program_options::value<decltype(m_reset)>(&m_reset), "enable or disable hardware context reset recovery")
+    ("reset-on-error", boost::program_options::value<decltype(m_reset_on_error)>(&m_reset_on_error), "enable or disable hardware context reset recovery")
   ;
 }
 
 void
 OO_HardwareContextReset::validate_args() const
 {
-  if (m_reset.empty() && !m_help)
-    throw xrt_core::error(std::errc::operation_canceled, "Please specify --reset with enable or disable");
+  if (m_reset_on_error.empty() && !m_help)
+    throw xrt_core::error(std::errc::operation_canceled, "Please specify --reset-on-error with enable or disable");
 
-  if (!m_reset.empty() && !boost::iequals(m_reset, "enable") && !boost::iequals(m_reset, "disable"))
-    throw xrt_core::error(std::errc::operation_canceled, "Invalid --reset value (use enable or disable)");
+  if (!m_reset_on_error.empty() && !boost::iequals(m_reset_on_error, "enable") && !boost::iequals(m_reset_on_error, "disable"))
+    throw xrt_core::error(std::errc::operation_canceled, "Invalid --reset-on-error value (use enable or disable)");
 }
 
 void
@@ -84,7 +84,7 @@ OO_HardwareContextReset::execute(const SubCmdOptions& _options) const
     throw xrt_core::error(std::errc::operation_canceled);
   }
 
-  const uint32_t enable = boost::iequals(m_reset, "enable") ? 1U : 0U;
+  const uint32_t enable = boost::iequals(m_reset_on_error, "enable") ? 1U : 0U;
   const std::string action_name = enable ? "enabled" : "disabled";
 
   try {

--- a/src/runtime_src/core/tools/xbutil2/HardwareContext/OO_HardwareContextReset.h
+++ b/src/runtime_src/core/tools/xbutil2/HardwareContext/OO_HardwareContextReset.h
@@ -14,6 +14,6 @@ public:
 
 private:
   std::string m_device;
-  std::string m_reset;
+  std::string m_reset_on_error;
   bool m_help;
 };

--- a/src/runtime_src/core/tools/xbutil2/HardwareContext/OO_HardwareContextReset.h
+++ b/src/runtime_src/core/tools/xbutil2/HardwareContext/OO_HardwareContextReset.h
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+#pragma once
+
+#include "tools/common/OptionOptions.h"
+
+class OO_HardwareContextReset : public OptionOptions {
+public:
+  void execute(const SubCmdOptions& _options) const override;
+  void validate_args() const;
+
+  explicit OO_HardwareContextReset(const std::string& _longName, bool _isHidden = false);
+
+private:
+  std::string m_device;
+  std::string m_reset;
+  bool m_help;
+};

--- a/src/runtime_src/core/tools/xbutil2/SubCmdConfigure.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdConfigure.cpp
@@ -12,6 +12,7 @@
 #include "OO_Preemption.h"
 #include "EventTracing/OO_EventTrace.h"
 #include "FirmwareLogging/OO_FirmwareLog.h"
+#include "HardwareContext/OO_HardwareContextReset.h"
 #include "common/device.h"
 #include "tools/common/XBUtilities.h"
 
@@ -34,7 +35,8 @@ SubCmdConfigure::SubCmdConfigure(bool _isHidden, bool _isDepricated, bool _isPre
     {std::make_shared<OO_Performance>("pmode")},
     {std::make_shared<OO_Preemption>("force-preemption")}, //hidden
     {std::make_shared<OO_EventTrace>("event-trace")}, //hidden
-    {std::make_shared<OO_FirmwareLog>("firmware-log")} //hidden
+    {std::make_shared<OO_FirmwareLog>("firmware-log")}, //hidden
+    {std::make_shared<OO_HardwareContextReset>("hardware-context", true)} // hidden
 
   };
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
This PR adds an advanced xrt-smi configure option for hardware-context reset policy (--hardware-context --reset enable|disable), wired through a new device query (hardware_context_reset).

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://jira.xilinx.com/browse/AIESW-32024 

#### How problem was solved, alternative solutions (if any) and why they were rejected
New HardwareContext/ xbutil2 sources + OO_HardwareContextReset
query_requests.h adds hardware_context_reset; shim registers it and performs ioctl; configure option list is extended in device.cpp so advanced configure discovers hardware-context without depending on a missing/duplicate SMI source path.

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Tested on linux with local changes

#### Documentation impact (if any)
None
