### PR TITLE
CR-1266460: Fix CU context flags and error handling in edge shim (#9757)

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/edge/zocl_hwctx.c
+++ b/src/runtime_src/core/edge/drm/zocl/edge/zocl_hwctx.c
@@ -137,9 +137,9 @@ static int zocl_cu_ctx_to_info(struct drm_zocl_dev *zdev, struct drm_zocl_open_c
 done:
     kds_cu_info->ctx = (void *)kds_hw_ctx;
     if (drm_cu_ctx->flags == ZOCL_CTX_EXCLUSIVE)
-        kds_cu_info->flags = ZOCL_CTX_EXCLUSIVE;
+        kds_cu_info->flags = CU_CTX_EXCLUSIVE;
     else
-        kds_cu_info->flags = ZOCL_CTX_SHARED;
+        kds_cu_info->flags = CU_CTX_SHARED;
     return 0;
 }
 
@@ -179,7 +179,7 @@ int zocl_open_cu_ctx(struct drm_zocl_dev *zdev, struct drm_zocl_open_cu_ctx *drm
     }
 
     kds_cu_ctx = kds_alloc_cu_hw_ctx(client, kds_hw_ctx, &kds_cu_info);
-    if (ret) {
+    if (!kds_cu_ctx) {
         DRM_ERROR("%s: Allocation of CU context failed", __func__);
         ret = -EINVAL;
         goto out;

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -1142,10 +1142,10 @@ open_cu_context(const xrt_core::hwctx_handle* hwctx_hdl, const std::string& cuna
     drm_zocl_open_cu_ctx  cu_ctx = {};
     cu_ctx.flags = flags;
     cu_ctx.hw_context = hwctx_hdl->get_slotidx();
-    std:strncpy(cu_ctx.cu_name, cuname.c_str(), sizeof(cu_ctx.cu_name));
+    std::strncpy(cu_ctx.cu_name, cuname.c_str(), sizeof(cu_ctx.cu_name));
     cu_ctx.cu_name[sizeof(cu_ctx.cu_name) - 1] = 0;
     if (ioctl(mKernelFD, DRM_IOCTL_ZOCL_OPEN_CU_CTX, &cu_ctx))
-      throw xrt_core::error("Failed to open cu context");
+      throw xrt_core::system_error(errno, "Failed to open cu context");
 
     return xrt_core::cuidx_type{cu_ctx.cu_index};
   }


### PR DESCRIPTION
(cherry picked from commit bb927f7ea6d946dc9a6720e7c0ca35400a078da3)

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
CR-1266460, AIESW-31262
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
