### PR TITLE
Adding ryzen.cpp to core_common_smi_objects

### DIFF
--- a/src/runtime_src/core/common/smi/CMakeLists.txt
+++ b/src/runtime_src/core/common/smi/CMakeLists.txt
@@ -3,11 +3,10 @@
 #
 # OBJECT libraries linked into xrt_coreutil, xrt_core (Alveo/edge), and xrt_driver_xdna / other shims.
 
-add_library(core_common_smi_objects OBJECT smi.cpp)
+add_library(core_common_smi_objects OBJECT smi.cpp smi_ryzen.cpp)
 target_include_directories(core_common_smi_objects
   PRIVATE
   ${XRT_SOURCE_DIR}/runtime_src
   )
 
 add_library(core_smi_alveo_objects OBJECT smi_alveo.cpp)
-add_library(core_smi_ryzen_objects OBJECT smi_ryzen.cpp)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
This PR moves the ryzen.cpp to core_common_smi_objects (which is already linked with xrt_coreutil.so) so that we do not need to couple shim to XRT sources and ryzen.cpp can export symbols via xrt_coreutils.so itself.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
None

#### How problem was solved, alternative solutions (if any) and why they were rejected
Rejected the original solution which was coupling XRT sources to shim

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Tested on Linux

#### Documentation impact (if any)
None
