### PR TITLE
[XRT-SMI] exporting get api for windows build

### DIFF
--- a/src/runtime_src/core/common/smi/smi_ryzen.cpp
+++ b/src/runtime_src/core/common/smi/smi_ryzen.cpp
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
 
+#define XRT_CORE_COMMON_SOURCE
+
 #include "core/common/smi/smi_ryzen.h"
 
 #include "core/common/query_requests.h"

--- a/src/runtime_src/core/common/smi/smi_ryzen.h
+++ b/src/runtime_src/core/common/smi/smi_ryzen.h
@@ -80,6 +80,7 @@ public:
 void
 populate_smi_instance(xrt_core::smi::smi* smi_instance, const xrt_core::device* device);
 
+XRT_CORE_COMMON_EXPORT
 std::string
 get_smi_config(const xrt_core::device* device);
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
This PR exports the get_config api which is a requirement for windows MCDM shim to build 

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
None

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
