### PR TITLE
AIESW-32262: skip connectivity check for imported buffer objects (#9782)

### DIFF
--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -2290,8 +2290,10 @@ class run_impl : public std::enable_shared_from_this<run_impl>
   xrt::bo
   validate_bo_at_index(size_t index, const xrt::bo& bo)
   {
-    // ELF flow doesn't have arg connectivity, so skip validation
-    if (!kernel->get_xclbin())
+    // ELF flow doesn't have arg connectivity, so skip validation.
+    // Imported BOs have fixed physical backing from another device
+    // and bank re-mapping is not applicable.
+    if (!kernel->get_xclbin() || xrt_core::bo::is_imported(bo))
       return bo;
 
     // Check if connectivity validation should be skipped via INI option


### PR DESCRIPTION
Imported BOs have pre-allocated physical backing from another device and cannot be re-mapped to a different memory bank. Skip the connectivity validation in validate_bo_at_index() for imported BOs to allow cross-device zero-copy buffer sharing (e.g., xDNA to PL) without triggering a spurious bank mismatch clone



(cherry picked from commit 6db73d416eb707ca0446a2ffd26c6c400ca49caa)

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
