### PR TITLE
[CR-1241855] graph.wait(cycles) doesn't trigger any exception

### DIFF
--- a/src/runtime_src/core/edge/user/aie/graph_object.cpp
+++ b/src/runtime_src/core/edge/user/aie/graph_object.cpp
@@ -214,6 +214,7 @@ graph_object::wait_graph(uint64_t cycle)
 
     graph_api_obj->wait(cycle);
     state = graph_state::suspend;
+    throw xrt_core::error(-ETIME, "Wait graph '" + name + "' timeout");
   }
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
[CR-1241855] graph.wait(cycles) doesn't catch the timeout exception but will force the graph to end
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Add throw at the right function
#### Risks (if any) associated the changes in the commit
low
#### What has been tested and how, request additional testing if necessary
Tested on both vck190 hw and hw_emu
#### Documentation impact (if any)
