### PR TITLE
AIESW-28041 Use env variable for is_advanced API

### DIFF
--- a/src/runtime_src/core/common/detail/linux/sysinfo.h
+++ b/src/runtime_src/core/common/detail/linux/sysinfo.h
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
 
 // 3rd Party Library - Include Files
+#include <boost/algorithm/string/predicate.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/format.hpp>
 #include <boost/property_tree/ini_parser.hpp>
 
 // System - Include Files
+#include <cstdlib>
 #include <gnu/libc-version.h>
 #include <sys/utsname.h>
 #include <thread>
@@ -130,7 +132,8 @@ get_os_info(boost::property_tree::ptree &pt)
 bool
 is_advanced()
 {
-  return true; //TODO: implement Linux side
+  const char* v = std::getenv("XRTSMIAdvanced");
+  return v && boost::iequals(v, "1");
 }
 
 } //xrt_core::sysinfo

--- a/src/runtime_src/core/common/detail/linux/sysinfo.h
+++ b/src/runtime_src/core/common/detail/linux/sysinfo.h
@@ -127,4 +127,10 @@ get_os_info(boost::property_tree::ptree &pt)
   pt.put("processor", processor_name());
 }
 
+bool
+is_advanced()
+{
+  return false; //TODO: remove once Windows side is removed
+}
+
 } //xrt_core::sysinfo

--- a/src/runtime_src/core/common/detail/linux/sysinfo.h
+++ b/src/runtime_src/core/common/detail/linux/sysinfo.h
@@ -2,13 +2,11 @@
 // Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
 
 // 3rd Party Library - Include Files
-#include <boost/algorithm/string/predicate.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/format.hpp>
 #include <boost/property_tree/ini_parser.hpp>
 
 // System - Include Files
-#include <cstdlib>
 #include <gnu/libc-version.h>
 #include <sys/utsname.h>
 #include <thread>
@@ -127,13 +125,6 @@ get_os_info(boost::property_tree::ptree &pt)
   pt.put("hostname", hn);
 
   pt.put("processor", processor_name());
-}
-
-bool
-is_advanced()
-{
-  const char* v = std::getenv("XRTSMIAdvanced");
-  return v && boost::iequals(v, "1");
 }
 
 } //xrt_core::sysinfo

--- a/src/runtime_src/core/common/detail/windows/sysinfo.h
+++ b/src/runtime_src/core/common/detail/windows/sysinfo.h
@@ -11,7 +11,6 @@
 #include <array>
 
 // 3rd Party Library - Include Files
-#include <boost/algorithm/string/predicate.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/format.hpp>
 
@@ -175,28 +174,6 @@ get_os_info(boost::property_tree::ptree &pt)
   BufferSize = sizeof value;
   RegGetValueA(HKEY_LOCAL_MACHINE, "HARDWARE\\DESCRIPTION\\System\\CentralProcessor\\0", "ProcessorNameString", RRF_RT_ANY, NULL, (PVOID)&value, &BufferSize);
   pt.put("processor", value);
-}
-
-bool
-is_advanced()
-{
-  DWORD value = 0;
-  DWORD valueSize = sizeof(value);
-  DWORD valueType;
-  LONG result = RegGetValueA(HKEY_LOCAL_MACHINE, "SYSTEM\\ControlSet001\\Services\\IpuMcdmDriver", "XRTSMIAdvanced", RRF_RT_REG_DWORD, &valueType, &value, &valueSize);
-  if ((result == ERROR_SUCCESS) && (valueType == REG_DWORD) && (value == 1))
-    return true;
-
-  result = RegGetValueA(HKEY_LOCAL_MACHINE, "SYSTEM\\ControlSet001\\Services\\Npu2McdmDriver", "XRTSMIAdvanced", RRF_RT_REG_DWORD, &valueType, &value, &valueSize);
-  if ((result == ERROR_SUCCESS) && (valueType == REG_DWORD) && (value == 1))
-    return true;
-
-  char buf[16] = {};
-  const DWORD n = GetEnvironmentVariableA("XRTSMIAdvanced", buf, static_cast<DWORD>(sizeof(buf)));
-  if (n > 0 && n < sizeof(buf) && boost::iequals(buf, "1"))
-    return true;
-
-  return false;
 }
 
 } //xrt_core::sysinfo

--- a/src/runtime_src/core/common/detail/windows/sysinfo.h
+++ b/src/runtime_src/core/common/detail/windows/sysinfo.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
 
 // Local - Include files
 #include "core/common/error.h"
@@ -11,6 +11,7 @@
 #include <array>
 
 // 3rd Party Library - Include Files
+#include <boost/algorithm/string/predicate.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/format.hpp>
 
@@ -188,6 +189,11 @@ is_advanced()
 
   result = RegGetValueA(HKEY_LOCAL_MACHINE, "SYSTEM\\ControlSet001\\Services\\Npu2McdmDriver", "XRTSMIAdvanced", RRF_RT_REG_DWORD, &valueType, &value, &valueSize);
   if ((result == ERROR_SUCCESS) && (valueType == REG_DWORD) && (value == 1))
+    return true;
+
+  char buf[16] = {};
+  const DWORD n = GetEnvironmentVariableA("XRTSMIAdvanced", buf, static_cast<DWORD>(sizeof(buf)));
+  if (n > 0 && n < sizeof(buf) && boost::iequals(buf, "1"))
     return true;
 
   return false;

--- a/src/runtime_src/core/common/detail/windows/sysinfo.h
+++ b/src/runtime_src/core/common/detail/windows/sysinfo.h
@@ -176,4 +176,21 @@ get_os_info(boost::property_tree::ptree &pt)
   pt.put("processor", value);
 }
 
+bool
+is_advanced()
+{
+  DWORD value = 0;
+  DWORD valueSize = sizeof(value);
+  DWORD valueType;
+  LONG result = RegGetValueA(HKEY_LOCAL_MACHINE, "SYSTEM\\ControlSet001\\Services\\IpuMcdmDriver", "XRTSMIAdvanced", RRF_RT_REG_DWORD, &valueType, &value, &valueSize);
+  if ((result == ERROR_SUCCESS) && (valueType == REG_DWORD) && (value == 1))
+    return true;
+
+  result = RegGetValueA(HKEY_LOCAL_MACHINE, "SYSTEM\\ControlSet001\\Services\\Npu2McdmDriver", "XRTSMIAdvanced", RRF_RT_REG_DWORD, &valueType, &value, &valueSize);
+  if ((result == ERROR_SUCCESS) && (valueType == REG_DWORD) && (value == 1))
+    return true;
+
+  return false;
+}
+
 } //xrt_core::sysinfo

--- a/src/runtime_src/core/common/sysinfo.cpp
+++ b/src/runtime_src/core/common/sysinfo.cpp
@@ -7,8 +7,6 @@
 
 #include "xrt/detail/version-git.h"
 
-#include <boost/algorithm/string/predicate.hpp>
-
 #include <cstdlib>
 
 namespace xrt_core::sysinfo {
@@ -49,8 +47,7 @@ get_os_info()
 bool
 is_advanced()
 {
-  const char* v = std::getenv("XRTSMIAdvanced"); // NOLINT(concurrency-mt-unsafe)
-  if (v && boost::iequals(v, "1"))
+  if (std::getenv("XRTSMIAdvanced") != nullptr) // NOLINT(concurrency-mt-unsafe)
     return true;
 
   return xrt_core::sysinfo::detail::is_advanced();

--- a/src/runtime_src/core/common/sysinfo.cpp
+++ b/src/runtime_src/core/common/sysinfo.cpp
@@ -7,6 +7,13 @@
 
 #include "xrt/detail/version-git.h"
 
+#include <boost/algorithm/string/predicate.hpp>
+
+#include <cstdlib>
+#ifdef _WIN32
+# include <windows.h>
+#endif
+
 namespace xrt_core::sysinfo {
 
 void
@@ -45,7 +52,25 @@ get_os_info()
 bool
 is_advanced()
 {
-  return xrt_core::sysinfo::detail::is_advanced();
+  const char* v = std::getenv("XRTSMIAdvanced"); // NOLINT(concurrency-mt-unsafe)
+  if (v && boost::iequals(v, "1"))
+    return true;
+
+  // TODO: Remove when phasing out reg check for Windows
+#ifdef _WIN32
+  DWORD value = 0;
+  DWORD valueSize = sizeof(value);
+  DWORD valueType;
+  LONG result = RegGetValueA(HKEY_LOCAL_MACHINE, "SYSTEM\\ControlSet001\\Services\\IpuMcdmDriver", "XRTSMIAdvanced", RRF_RT_REG_DWORD, &valueType, &value, &valueSize);
+  if ((result == ERROR_SUCCESS) && (valueType == REG_DWORD) && (value == 1))
+    return true;
+
+  result = RegGetValueA(HKEY_LOCAL_MACHINE, "SYSTEM\\ControlSet001\\Services\\Npu2McdmDriver", "XRTSMIAdvanced", RRF_RT_REG_DWORD, &valueType, &value, &valueSize);
+  if ((result == ERROR_SUCCESS) && (valueType == REG_DWORD) && (value == 1))
+    return true;
+#endif
+
+  return false;
 }
 
 } //xrt_core::sysinfo

--- a/src/runtime_src/core/common/sysinfo.cpp
+++ b/src/runtime_src/core/common/sysinfo.cpp
@@ -10,9 +10,6 @@
 #include <boost/algorithm/string/predicate.hpp>
 
 #include <cstdlib>
-#ifdef _WIN32
-# include <windows.h>
-#endif
 
 namespace xrt_core::sysinfo {
 
@@ -56,21 +53,7 @@ is_advanced()
   if (v && boost::iequals(v, "1"))
     return true;
 
-  // TODO: Remove when phasing out reg check for Windows
-#ifdef _WIN32
-  DWORD value = 0;
-  DWORD valueSize = sizeof(value);
-  DWORD valueType;
-  LONG result = RegGetValueA(HKEY_LOCAL_MACHINE, "SYSTEM\\ControlSet001\\Services\\IpuMcdmDriver", "XRTSMIAdvanced", RRF_RT_REG_DWORD, &valueType, &value, &valueSize);
-  if ((result == ERROR_SUCCESS) && (valueType == REG_DWORD) && (value == 1))
-    return true;
-
-  result = RegGetValueA(HKEY_LOCAL_MACHINE, "SYSTEM\\ControlSet001\\Services\\Npu2McdmDriver", "XRTSMIAdvanced", RRF_RT_REG_DWORD, &valueType, &value, &valueSize);
-  if ((result == ERROR_SUCCESS) && (valueType == REG_DWORD) && (value == 1))
-    return true;
-#endif
-
-  return false;
+  return xrt_core::sysinfo::detail::is_advanced();
 }
 
 } //xrt_core::sysinfo


### PR DESCRIPTION
#### Problem solved by the commit
https://jira.xilinx.com/browse/AIESW-28041
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Add env variable check for both Windows and Linux
#### How problem was solved, alternative solutions (if any) and why they were rejected
Initially wanted to do a sudo check on Linux, decided against during review. To be more platform agnostic, decided to make both Windows and Linux do an environment variable check for is_advanced and let further validation be done at the driver level.
#### Risks (if any) associated the changes in the commit
Will need to update Linux xdna pipeline, Windows still accepts old flow but will eventually need to update as well.
#### What has been tested and how, request additional testing if necessary
Tested on Linux and Windows, works as desired.
#### Documentation impact (if any)
Will update xrt-smi documentation.