### PR TITLE
[XRT-SMI] AIESW-29548 Code cleanup and re-architecture for further alveo decoupling

### DIFF
--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -605,6 +605,7 @@ struct xrt_smi_lists : request
     validate_tests,
     examine_reports,
     configure_option_options,
+    subcommands,
   };
   using result_type = std::vector<std::tuple<std::string, std::string, std::string>>;
   static const key_type key = key_type::xrt_smi_lists;

--- a/src/runtime_src/core/common/smi/smi.cpp
+++ b/src/runtime_src/core/common/smi/smi.cpp
@@ -187,6 +187,19 @@ get_hardware_type(const xq::pcie_id::data& dev) const
 }
 
 tuple_vector
+smi::
+get_subcommands_list() const 
+{
+  std::lock_guard<std::mutex> lock(m_mutex);
+  tuple_vector out;
+  out.reserve(m_subcommands.size());
+  for (const auto& [name, subcmd] : m_subcommands) {
+    out.emplace_back(std::make_tuple(name, subcmd.get_description(), subcmd.get_type()));
+  }
+  return out;
+}
+
+tuple_vector
 get_list(const std::string& subcommand, const std::string& suboption) 
 {
   return instance()->get_list(subcommand, suboption);
@@ -196,6 +209,12 @@ tuple_vector
 get_option_options(const std::string& subcommand) 
 {
   return instance()->get_option_options(subcommand);
+}
+
+tuple_vector
+get_subcommands_list() 
+{
+  return instance()->get_subcommands_list();
 }
 
 } // namespace xrt_core::smi

--- a/src/runtime_src/core/common/smi/smi.h
+++ b/src/runtime_src/core/common/smi/smi.h
@@ -116,6 +116,18 @@ public:
   boost::property_tree::ptree 
   construct_subcommand_json() const;
 
+  const std::string&
+  get_name() const
+  { return m_name; }
+
+  const std::string&
+  get_description() const
+  { return m_description; }
+
+  const std::string&
+  get_type() const
+  { return m_type; }
+
   subcommand(std::string name, 
              std::string description, 
              std::string type, 
@@ -152,6 +164,17 @@ public:
   XRT_CORE_COMMON_EXPORT
   tuple_vector
   get_option_options(const std::string& subcommand) const;
+
+  bool
+  empty() const
+  {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return m_subcommands.empty();
+  }
+
+  XRT_CORE_COMMON_EXPORT
+  tuple_vector
+  get_subcommands_list() const;
 
 };
 
@@ -243,5 +266,10 @@ get_list(const std::string& subcommand, const std::string& suboption);
 XRT_CORE_COMMON_EXPORT
 tuple_vector
 get_option_options(const std::string& subcommand);
+
+// Top-level xrt-smi subcommand names (and metadata) for the current smi singleton state.
+XRT_CORE_COMMON_EXPORT
+tuple_vector
+get_subcommands_list();
 
 } // namespace xrt_core::smi

--- a/src/runtime_src/core/common/smi/smi_alveo.cpp
+++ b/src/runtime_src/core/common/smi/smi_alveo.cpp
@@ -100,14 +100,61 @@ create_configure_subcommand()
   return {"configure", "Device and host configuration", "common", std::move(configure_suboptions)};
 }
 
+static xrt_core::smi::subcommand
+create_advanced_subcommand()
+{
+  std::map<std::string, std::shared_ptr<xrt_core::smi::option>> advanced_suboptions;
+  advanced_suboptions.emplace("device", std::make_shared<xrt_core::smi::option>("device", "d", "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest", "common", "", "string"));
+  advanced_suboptions.emplace("help", std::make_shared<xrt_core::smi::option>("help", "h", "Help to use this sub-command", "common", "", "none"));
+  advanced_suboptions.emplace("read-mem", std::make_shared<xrt_core::smi::option>("read-mem", "", "Read from the given memory address", "hidden", "", "string", true));
+  advanced_suboptions.emplace("write-mem", std::make_shared<xrt_core::smi::option>("write-mem", "", "Write to a given memory address", "hidden", "", "string", true));
+
+  return {"advanced", "Low level command operations", "hidden", std::move(advanced_suboptions)};
+}
+
+static xrt_core::smi::subcommand
+create_program_subcommand()
+{
+  std::map<std::string, std::shared_ptr<xrt_core::smi::option>> o;
+  o.emplace("device", std::make_shared<xrt_core::smi::option>("device", "d", "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest", "common", "", "string"));
+  o.emplace("help", std::make_shared<xrt_core::smi::option>("help", "h", "Help to use this sub-command", "common", "", "none"));
+  return {"program", "Download the acceleration program to a given device", "common", std::move(o)};
+}
+
+static xrt_core::smi::subcommand
+create_reset_subcommand()
+{
+  std::map<std::string, std::shared_ptr<xrt_core::smi::option>> o;
+  o.emplace("device", std::make_shared<xrt_core::smi::option>("device", "d", "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest", "common", "", "string"));
+  o.emplace("help", std::make_shared<xrt_core::smi::option>("help", "h", "Help to use this sub-command", "common", "", "none"));
+  return {"reset", "Resets the given device", "common", std::move(o)};
+}
+
+void
+populate_smi_instance(xrt_core::smi::smi* smi_instance)
+{
+  smi_instance->add_subcommand("validate", create_validate_subcommand());
+  smi_instance->add_subcommand("examine", create_examine_subcommand());
+  smi_instance->add_subcommand("configure", create_configure_subcommand());
+  smi_instance->add_subcommand("advanced", create_advanced_subcommand());
+  smi_instance->add_subcommand("program", create_program_subcommand());
+  smi_instance->add_subcommand("reset", create_reset_subcommand());
+}
+
 std::string
 get_smi_config()
 {
   auto smi_instance = xrt_core::smi::instance();
-  smi_instance->add_subcommand("validate", create_validate_subcommand());
-  smi_instance->add_subcommand("examine", create_examine_subcommand());
-  smi_instance->add_subcommand("configure", create_configure_subcommand());
+  populate_smi_instance(smi_instance);
   return smi_instance->build_json();
+}
+
+xrt_core::smi::tuple_vector
+get_subcommands_list()
+{
+  auto smi_instance = xrt_core::smi::instance();
+  populate_smi_instance(smi_instance);
+  return smi_instance->get_subcommands_list();
 }
 
 } // namespace xrt_core::smi::alveo

--- a/src/runtime_src/core/common/smi/smi_alveo.h
+++ b/src/runtime_src/core/common/smi/smi_alveo.h
@@ -2,12 +2,19 @@
 // Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
 #pragma once
 
+#include "core/common/smi/smi.h"
+
 #include <string>
 
 namespace xrt_core::smi::alveo {
 
-// xrt-smi JSON for Alveo-class shims (PCIe Linux and edge user device_linux).
+void
+populate_smi_instance(xrt_core::smi::smi* smi_instance);
+
 std::string
 get_smi_config();
+
+xrt_core::smi::tuple_vector
+get_subcommands_list();
 
 } // namespace xrt_core::smi::alveo

--- a/src/runtime_src/core/common/smi/smi_ryzen.cpp
+++ b/src/runtime_src/core/common/smi/smi_ryzen.cpp
@@ -107,6 +107,19 @@ config_gen_ryzen::create_configure_subcommand()
   return {"configure", "Device and host configuration", "common", std::move(configure_suboptions)};
 }
 
+subcommand
+config_gen_ryzen::create_advanced_subcommand()
+{
+  std::map<std::string, std::shared_ptr<option>> advanced_suboptions;
+  advanced_suboptions.emplace("device", std::make_shared<option>("device", "d", "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest", "common", "", "string"));
+  advanced_suboptions.emplace("help", std::make_shared<option>("help", "h", "Help to use this sub-command", "common", "", "none"));
+  advanced_suboptions.emplace("read-aie-reg", std::make_shared<option>("read-aie-reg", "", "Read given aie register from given row and column", "hidden", "", "string", true));
+  advanced_suboptions.emplace("aie-clock", std::make_shared<option>("aie-clock", "", "AIE clock frequency operations", "hidden", "", "string", true));
+  advanced_suboptions.emplace("report", std::make_shared<option>("report", "", "Advanced report output", "hidden", "", "string", true));
+
+  return {"advanced", "Low level command operations", "hidden", std::move(advanced_suboptions)};
+}
+
 config_gen_npu3::
 config_gen_npu3()
 {
@@ -142,7 +155,7 @@ populate_smi_instance(xrt_core::smi::smi* smi_instance, const xrt_core::device* 
   const auto pcie_id = xrt_core::device_query<xrt_core::query::pcie_id>(device);
   auto hardware_type = smi_hrdw.get_hardware_type(pcie_id);
 
-  std::shared_ptr<config_generator> generator;
+  std::shared_ptr<config_gen_ryzen> generator;
 
   switch (hardware_type) {
   case smi_hardware_config::hardware_type::phx:
@@ -178,6 +191,7 @@ populate_smi_instance(xrt_core::smi::smi* smi_instance, const xrt_core::device* 
     smi_instance->add_subcommand("validate",  generator->create_validate_subcommand());
     smi_instance->add_subcommand("examine",  generator->create_examine_subcommand());
     smi_instance->add_subcommand("configure",  generator->create_configure_subcommand());
+    smi_instance->add_subcommand("advanced",  generator->create_advanced_subcommand());
   }
 }
 
@@ -189,6 +203,14 @@ get_smi_config(const xrt_core::device* device)
   populate_smi_instance(smi_instance, device);
 
   return smi_instance->build_json();
+}
+
+xrt_core::smi::tuple_vector
+get_subcommands_list(const xrt_core::device* device)
+{
+  auto smi_instance = xrt_core::smi::instance();
+  populate_smi_instance(smi_instance, device);
+  return smi_instance->get_subcommands_list();
 }
 
 } // namespace xrt_core::smi::ryzen

--- a/src/runtime_src/core/common/smi/smi_ryzen.h
+++ b/src/runtime_src/core/common/smi/smi_ryzen.h
@@ -39,6 +39,9 @@ public:
 
   xrt_core::smi::subcommand
   create_configure_subcommand() override;
+
+  xrt_core::smi::subcommand
+  create_advanced_subcommand();
 };
 
 class config_gen_phoenix : public config_gen_ryzen {
@@ -83,5 +86,9 @@ populate_smi_instance(xrt_core::smi::smi* smi_instance, const xrt_core::device* 
 XRT_CORE_COMMON_EXPORT
 std::string
 get_smi_config(const xrt_core::device* device);
+
+XRT_CORE_COMMON_EXPORT
+xrt_core::smi::tuple_vector
+get_subcommands_list(const xrt_core::device* device);
 
 } // namespace xrt_core::smi::ryzen

--- a/src/runtime_src/core/edge/user/device_linux.cpp
+++ b/src/runtime_src/core/edge/user/device_linux.cpp
@@ -789,6 +789,8 @@ struct xrt_smi_lists
       return xrt_core::smi::get_list("examine", "report");
     case xrt_core::query::xrt_smi_lists::type::configure_option_options:
       return xrt_core::smi::get_option_options("configure");
+    case xrt_core::query::xrt_smi_lists::type::subcommands:
+      return xrt_core::smi::alveo::get_subcommands_list();
     default:
       throw xrt_core::query::no_such_key(key, "Not implemented");
     }

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -956,6 +956,8 @@ struct xrt_smi_lists
       return xrt_core::smi::get_list("examine", "report");
     case xrt_core::query::xrt_smi_lists::type::configure_option_options:
       return xrt_core::smi::get_option_options("configure");
+    case xrt_core::query::xrt_smi_lists::type::subcommands:
+      return xrt_core::smi::alveo::get_subcommands_list();
     default:
       throw xrt_core::query::no_such_key(key, "Not implemented");
     }

--- a/src/runtime_src/core/tools/common/XBMain.cpp
+++ b/src/runtime_src/core/tools/common/XBMain.cpp
@@ -6,7 +6,7 @@
 // Local - Include Files
 #include "core/common/system.h"
 #include "core/common/sysinfo.h"
-#include "core/common/smi/smi.h"
+#include "core/common/query_requests.h"
 #include "SmiDefault.h"
 #include "SubCmd.h"
 #include "XBHelpMenusCore.h"
@@ -21,6 +21,8 @@ namespace XBU = XBUtilities;
 #include <boost/program_options.hpp>
 #include <boost/property_tree/json_parser.hpp>
 
+#include <sstream>
+
 namespace po = boost::program_options;
 
 // System - Include Files
@@ -31,8 +33,7 @@ namespace po = boost::program_options;
 void  main_(int argc, char** argv, 
             const std::string & _executable,
             const std::string & _description,
-            const SubCmdsCollection &_subCmds,
-            const boost::property_tree::ptree& configurations) 
+            const SubCmdsCollection &_subCmds) 
 {
   bool isUserDomain = boost::iequals(_executable, "xrt-smi"); 
 
@@ -74,7 +75,7 @@ void  main_(int argc, char** argv,
   ;
 
   if (xrt_core::sysinfo::is_advanced()) {
-    hiddenOptions.add_options()
+    globalOptions.add_options()
       ("advanced", boost::program_options::bool_switch(&bAdvance), "Shows advanced options and commands")
     ;
   }
@@ -87,12 +88,16 @@ void  main_(int argc, char** argv,
   po::positional_options_description positionalCommand;
   positionalCommand.add("subCmd", 1 /* max_count */);
 
-  // Parse the command line arguments
+  SubCmdsCollection parsedSubCmds = _subCmds;
   po::variables_map vm;
   po::command_line_parser parser(argc, argv);
   SubCmd::SubCmdOptions subcmd_options;
   try {
     subcmd_options = XBU::process_arguments(vm, parser, allOptions, positionalCommand, false);
+    XBU::resolve_device(isUserDomain, vm, sDevice);
+    const auto filtered = XBU::filter_subcmds(isUserDomain, sDevice, _subCmds);
+    if (!filtered.empty())
+      parsedSubCmds = filtered;
     if (sCmd.empty() && !subcmd_options.empty())
     {
       std::string error_str;
@@ -103,7 +108,7 @@ void  main_(int argc, char** argv,
     }
   } catch (po::error& ex) {
     std::cerr << ex.what() << std::endl;
-    XBU::report_commands_help( _executable, _description, globalOptions, hiddenOptions, _subCmds);
+    XBU::report_commands_help( _executable, _description, globalOptions, hiddenOptions, parsedSubCmds);
     throw xrt_core::error(std::errc::operation_canceled);
   }
 
@@ -122,60 +127,6 @@ void  main_(int argc, char** argv,
   XBU::setShowHidden( bShowHidden );
   XBU::setAdvance( bAdvance );
   XBU::setForce( bForce );
-
-  const auto& device_var = vm["device"];
-  if (device_var.defaulted()) {
-    // Was default device requested?
-    if (boost::iequals(sDevice, "default")) {
-      sDevice.clear();
-      boost::property_tree::ptree available_devices = XBU::get_available_devices(isUserDomain);
-
-      // DRC: Are there any devices
-      if (available_devices.empty())
-        throw std::runtime_error("No devices found.");
-
-      // DRC: Are there multiple devices, if so then no default device can be found.
-      if (available_devices.size() > 1) {
-        std::cerr << "\nERROR: Multiple devices found. Please specify a single device using the --device option\n\n";
-        std::cerr << XBUtilities::str_available_devs(isUserDomain) << std::endl;
-
-        std::cout << std::endl;
-        throw xrt_core::error(std::errc::operation_canceled);
-      }
-
-      // We have exactly one device. Get it
-      const auto kd = available_devices.begin();
-      sDevice = kd->second.get<std::string>("bdf");
-    }
-  }
-  else if (sDevice.empty() || boost::iequals(sDevice, "default")) {
-    std::cerr << "\nERROR: Option --device (-d) requires a BDF.\n";
-    std::cerr << XBUtilities::str_available_devs(isUserDomain) << std::endl;
-    throw xrt_core::error(std::errc::operation_canceled);
-  }
-
-  // If there is a device value, parse for valid subcommands for this device.
-  SubCmdsCollection devSubCmds;
-  if (!sDevice.empty()) {
-    std::string deviceClass;
-    try {
-      deviceClass = XBU::get_device_class(sDevice, isUserDomain); //can throw
-    } catch (const std::runtime_error& e) {
-      // Catch only the exceptions that we have generated earlier
-      std::cerr << boost::format("ERROR: %s\n") % e.what();
-      throw xrt_core::error(std::errc::operation_canceled);
-    }
-    const auto& configs = JSONConfigurable::parse_configuration_tree(configurations);
-    for (auto & subCmdEntry : _subCmds) {
-      auto it = configs.find(subCmdEntry->getName());
-      for (const auto& [device_name, device_config] : it->second) {
-        if (device_name.compare(deviceClass) == 0)
-          devSubCmds.emplace_back(subCmdEntry);
-      }
-    }
-  }
-
-  const SubCmdsCollection parsedSubCmds = sDevice.empty() ? _subCmds : devSubCmds;
 
   // Search for the subcommand (case sensitive)
   std::shared_ptr<SubCmd> subCommand;

--- a/src/runtime_src/core/tools/common/XBMain.h
+++ b/src/runtime_src/core/tools/common/XBMain.h
@@ -28,6 +28,5 @@
 void main_(int argc, char** argv, 
            const std::string & _executable,
            const std::string & _description,
-           const SubCmdsCollection & _SubCmds,
-           const boost::property_tree::ptree& configurations);
+           const SubCmdsCollection & _SubCmds);
 #endif

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -24,10 +24,12 @@
 #include <boost/tokenizer.hpp>
 
 // System - Include Files
+#include <algorithm>
+#include <filesystem>
 #include <iostream>
 #include <map>
 #include <regex>
-#include <filesystem>
+#include <stdexcept>
 
 
 #ifdef _WIN32
@@ -228,6 +230,66 @@ XBUtilities::get_available_devices(bool inUserDomain)
     pt.push_back(std::make_pair("", pt_dev));
   }
   return pt;
+}
+
+void
+XBUtilities::resolve_device(bool is_user_domain,
+                            const boost::program_options::variables_map& vm,
+                            std::string& device_bdf)
+{
+  const auto& device_var = vm["device"];
+  if (device_var.defaulted()) {
+    if (boost::iequals(device_bdf, "default")) {
+      device_bdf.clear();
+      boost::property_tree::ptree available_devices = get_available_devices(is_user_domain);
+      if (available_devices.empty())
+        throw std::runtime_error("No devices found.");
+      if (available_devices.size() > 1) {
+        std::cerr << "\nERROR: Multiple devices found. Please specify a single device using the --device option\n\n";
+        std::cerr << str_available_devs(is_user_domain) << std::endl;
+        std::cout << std::endl;
+        throw xrt_core::error(std::errc::operation_canceled);
+      }
+      const auto kd = available_devices.begin();
+      device_bdf = kd->second.get<std::string>("bdf");
+    }
+  }
+  else if (device_bdf.empty() || boost::iequals(device_bdf, "default")) {
+    std::cerr << "\nERROR: Option --device (-d) requires a BDF.\n";
+    std::cerr << str_available_devs(is_user_domain) << std::endl;
+    throw xrt_core::error(std::errc::operation_canceled);
+  }
+}
+
+std::vector<std::shared_ptr<SubCmd>>
+XBUtilities::filter_subcmds(bool is_user_domain,
+                            const std::string& device_bdf,
+                            const std::vector<std::shared_ptr<SubCmd>>& all_subcmds)
+{
+  if (!is_user_domain || device_bdf.empty())
+    return {};
+
+  try {
+    auto device = get_device(boost::algorithm::to_lower_copy(device_bdf), is_user_domain);
+    const auto rows = xrt_core::device_query<xrt_core::query::xrt_smi_lists>(
+      device, xrt_core::query::xrt_smi_lists::type::subcommands);
+
+    std::vector<std::shared_ptr<SubCmd>> out;
+    for (const auto& cmd : all_subcmds) {
+      const std::string& name = cmd->getName();
+      for (const auto& row : rows) {
+        const std::string& n = std::get<0>(row);
+        if (!n.empty() && n == name) {
+          out.emplace_back(cmd);
+          break;
+        }
+      }
+    }
+    return out;
+  }
+  catch (const std::exception&) {
+    return {};
+  }
 }
 
 std::string

--- a/src/runtime_src/core/tools/common/XBUtilities.h
+++ b/src/runtime_src/core/tools/common/XBUtilities.h
@@ -13,6 +13,8 @@
 #include "core/common/runner/runner.h"
 #include "core/common/smi/smi.h"
 
+#include "SubCmd.h"
+
 #include <chrono>
 #include <iostream>
 #include <map>
@@ -67,7 +69,17 @@ namespace XBUtilities {
   std::string
   str_available_devs(bool _inUserDomain);
 
-   /**
+  void
+  resolve_device(bool is_user_domain,
+                 const boost::program_options::variables_map& vm,
+                 std::string& device_bdf);
+
+  std::vector<std::shared_ptr<SubCmd>>
+  filter_subcmds(bool is_user_domain,
+                 const std::string& device_bdf,
+                 const std::vector<std::shared_ptr<SubCmd>>& all_subcmds);
+
+  /**
    * get_axlf_section() - Get section from the file passed in
    *
    * filename: file containing the axlf section

--- a/src/runtime_src/core/tools/xbmgmt2/xbmgmt.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/xbmgmt.cpp
@@ -86,7 +86,7 @@ int main( int argc, char** argv )
 
   // -- Ready to execute the code
   try {
-    main_( argc, argv, executable, description, subCommands, configTree);
+    main_( argc, argv, executable, description, subCommands);
     return 0;
   } catch (const xrt_core::error& e) {
     // Clean exception exit

--- a/src/runtime_src/core/tools/xbutil2/SubCmdAdvanced.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdAdvanced.cpp
@@ -32,7 +32,7 @@ namespace po = boost::program_options;
 
 // ----- C L A S S   M E T H O D S -------------------------------------------
 
-SubCmdAdvanced::SubCmdAdvanced(bool _isHidden, bool _isDepricated, bool _isPreliminary, const boost::property_tree::ptree& configurations)
+SubCmdAdvanced::SubCmdAdvanced(bool _isHidden, bool _isDepricated, bool _isPreliminary)
     : SubCmd("advanced", 
              "Low level command operations"),
       m_device("")
@@ -48,8 +48,6 @@ SubCmdAdvanced::SubCmdAdvanced(bool _isHidden, bool _isDepricated, bool _isPreli
     ("device,d", boost::program_options::value<decltype(m_device)>(&m_device), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest")
     ("help", boost::program_options::bool_switch(&m_help), "Help to use this sub-command")
   ;
-
-  m_commandConfig = configurations;
 
   addSubOption(std::make_shared<OO_MemRead>("read-mem"));
   addSubOption(std::make_shared<OO_MemWrite>("write-mem"));

--- a/src/runtime_src/core/tools/xbutil2/SubCmdAdvanced.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdAdvanced.h
@@ -12,7 +12,7 @@ class SubCmdAdvanced : public SubCmd {
   virtual void execute(const SubCmdOptions &_options) const;
 
  public:
-  SubCmdAdvanced(bool _isHidden, bool _isDepricated, bool _isPreliminary, const boost::property_tree::ptree& configurations);
+  SubCmdAdvanced(bool _isHidden, bool _isDepricated, bool _isPreliminary);
   virtual ~SubCmdAdvanced() {};
 
   private:

--- a/src/runtime_src/core/tools/xbutil2/xbutil.cpp
+++ b/src/runtime_src/core/tools/xbutil2/xbutil.cpp
@@ -17,7 +17,6 @@
 #include "tools/common/SubCmdJSON.h"
 #include "tools/common/XBMain.h"
 #include "tools/common/XBUtilities.h"
-#include "tools/common/JSONConfigurable.h"
 #include "core/common/module_loader.h"
 
 // System include files
@@ -26,52 +25,12 @@
 #include <iostream>
 #include <string>
 
-#include <boost/property_tree/json_parser.hpp>
-#include <boost/property_tree/ptree.hpp>
-
-const std::string& command_config = 
-R"(
-[{
-  "alveo": [{
-    "examine": [{}]
-  },{
-    "configure": [{}]
-  },{
-    "advanced":[{
-      "suboption": ["read-mem", "write-mem"]
-    }]
-  },{
-    "validate": [{}]
-  },{
-    "reset": [{}]
-  },{
-    "program": [{}]
-  }]
-},{
-  "aie": [{
-    "examine": [{}]
-  },{
-    "configure": [{}]
-  },{
-    "advanced":[{
-      "suboption": ["read-aie-reg", "aie-clock", "report"]
-    }]
-  },{
-    "validate": [{}]
-  }]
-}]
-)";
-
 // Program entry
 int main( int argc, char** argv )
 {
   // -- Build the supported subcommands
   SubCmdsCollection subCommands;
   const std::string executable = "xrt-smi";
-
-  boost::property_tree::ptree configTree;
-  std::istringstream command_config_stream(command_config);
-  boost::property_tree::read_json(command_config_stream, configTree);
 
   {
     // Syntax: SubCmdClass( IsHidden, IsDepricated, IsPreliminary)
@@ -87,7 +46,7 @@ int main( int argc, char** argv )
     subCommands.emplace_back(std::make_shared< SubCmdValidate >(false,  false, false));
 #endif
 
-    subCommands.emplace_back(std::make_shared< SubCmdAdvanced >(true, false, true, configTree));
+    subCommands.emplace_back(std::make_shared< SubCmdAdvanced >(true, false, true));
   }
 
   for (auto & subCommand : subCommands) {
@@ -104,7 +63,7 @@ int main( int argc, char** argv )
 
   // -- Ready to execute the code
   try {
-    main_( argc, argv, executable, description, subCommands, configTree);
+    main_( argc, argv, executable, description, subCommands);
     return 0;
   } catch (const xrt_core::error& e) {
     // Clean exception exit


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
xrt-smi listed every registered subcommand even when a device/platform only supported some of them for global xrt-smi help menus. This was because the device was not resolved by the time we printed help menus on xrt-smi global options. This was  largely due was due to the fact that we were using old flow of xrt-smi option setting and it required a first principles approach to fix.

This PR fixes that by resolving the device BDF early, querying xrt_smi_lists::subcommands from the shim, and keeping only subcommands whose names appear in that list. This code cleans up device resolution and subcommand filtering into a dedicated resolve_device and filter_subcmd for cleaner XBMain.cpp. xbutil main_ stays small and drops the unused configurations argument. With this change, we get rid of the embedded json configuration altogether and move to the shim based configuration flow. Now the shim is the real source of truth. 

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://jira.xilinx.com/browse/AIESW-29548

#### How problem was solved, alternative solutions (if any) and why they were rejected
Solved via obsoleting the old cumbersome flow of maintaining embedded json and moving to the new flow fully.

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Tested on linux with corresponding shim changes. Works as expected : 
```
aktondak@xsjstrix45:/proj/rdi/staff/aktondak/xdna/xdna-driver/xrt/build$ xrt-smi --mode
Unrecognized arguments:
  --mode


DESCRIPTION: The XRT - System Management Interface (xrt-smi) is a standalone command-line utility
             that is included with the XRT runtime package. It includes multiple commands to
             configure, examine, and validate supported device(s).
             
             The reports produced by xrt-smi may be used for device administration, monitoring, and
             troubleshooting application behavior.

USAGE: xrt-smi [--help] [--version] [--verbose] [--batch] [--force] [--advanced] [command [commandArgs]]

AVAILABLE COMMANDS:
  configure  - Device and host configuration
  examine    - Status of the system and device
  validate   - Validates the basic device acceleration functionality

OPTIONS:
  --help             - Help to use this application
  --version          - Report the version of XRT and its drivers
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
  --advanced         - Shows advanced options and commands
```

Earlier behavior : 
```
xrt-smi --mode
Unrecognized arguments:
--mode

DESCRIPTION: The XRT - System Management Interface (xrt-smi) is a standalone command-line utility
that is included with the XRT runtime package. It includes multiple commands to
configure, examine, and validate supported device(s).

The reports produced by xrt-smi may be used for device administration, monitoring, and
troubleshooting application behavior.

USAGE: xrt-smi [--help] [--version] [--verbose] [--batch] [--force] [command [commandArgs]]

AVAILABLE COMMANDS:
configure - Device and host configuration
examine - Status of the system and device
program - Download the acceleration program to a given device
reset - Resets the given device
validate - Validates the basic device acceleration functionality

OPTIONS:
--help - Help to use this application
--version - Report the version of XRT and its drivers
--verbose - Turn on verbosity
--batch - Enable batch mode (disables escape characters)
--force - When possible, force an operation
```

#### Documentation impact (if any)
None