### PR TITLE
kds: Reduce CU abort wait time during client exit

### DIFF
--- a/src/runtime_src/core/common/drv/include/xrt_cu.h
+++ b/src/runtime_src/core/common/drv/include/xrt_cu.h
@@ -60,7 +60,7 @@
 /* A low frequence timer per CU to check if CU/command timeout */
 #define CU_TICKS_PER_SEC	2
 #define CU_TIMER		(HZ / CU_TICKS_PER_SEC) /* in jiffies */
-#define CU_EXEC_DEFAULT_TTL	(5UL * CU_TICKS_PER_SEC)
+#define CU_EXEC_DEFAULT_TTL	(1UL * CU_TICKS_PER_SEC)
 /* A customed frequency timer per CU to collect data */
 #define CU_STATS_TICKS_PER_SEC  20
 #define CU_STATS_TIMER          (HZ / CU_STATS_TICKS_PER_SEC) /* in jiffies */

--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -727,6 +727,8 @@ kds_del_cu_context(struct kds_sched *kds, struct kds_client *client,
 		goto skip;
 
 	if (kds->ert_disable || kds->xgq_enable) {
+		int timeout_ms = 2000;
+
 		wait_ms = 500;
 		xrt_cu_abort(cu_mgmt->xcus[cu_idx], client);
 
@@ -735,6 +737,7 @@ kds_del_cu_context(struct kds_sched *kds, struct kds_client *client,
 			kds_warn(client, "%ld outstanding command(s) on Domain(%d) CU(%d)",
 				 submitted - completed, domain, cu_idx);
 			msleep(wait_ms);
+			timeout_ms -= wait_ms;
 			if (domain == DOMAIN_PL) {
 				submitted = client_stat_read(client, hw_ctx, s_cnt[cu_idx]);
 				completed = client_stat_read(client, hw_ctx, c_cnt[cu_idx]);
@@ -742,7 +745,9 @@ kds_del_cu_context(struct kds_sched *kds, struct kds_client *client,
 				submitted = client_stat_read(client, hw_ctx, scu_s_cnt[cu_idx]);
 				completed = client_stat_read(client, hw_ctx, scu_c_cnt[cu_idx]);
 			}
-		} while (submitted != completed);
+			if (submitted == completed)
+				break;
+		} while (timeout_ms > 0);
 
 		bad_state = xrt_cu_abort_done(cu_mgmt->xcus[cu_idx], client);
 	} else if (!kds->ert->abort_sync) {


### PR DESCRIPTION
When a host application is terminated (e.g. ctrl+c, SIGKILL) while kernels are still running, kds_del_cu_context() waits for each CU's outstanding commands to be aborted before proceeding to the next CU. The CU thread waits CU_EXEC_DEFAULT_TTL (5 seconds) before attempting the abort, and this happens sequentially per CU. With 6 active outstanding CUs this results in ~34 seconds of exit time; with increasing in CU numbers it increases linearly.

Reduce CU_EXEC_DEFAULT_TTL from 5 seconds to 1 second. This grace period only applies when an abort event is pending during context teardown -- normal command execution is unaffected. The CU abort function (cu_hls_abort) retains its own 10-second hardware reset timeout, so hardware safety is preserved.

Add a 2-second timeout bound to the unbounded polling loop in the ert_disable/xgq_enable branch of kds_del_cu_context(), preventing an infinite hang if the abort never completes.

Impact:
- Exit time with 6 active oustanding CUs: ~9s (was ~34s)
- Normal application exit: unchanged
- No changes to CU thread logic (xrt_cu.c)

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

Host application takes excessively long to exit when terminated (ctrl+c/SIGKILL) while kernels are running. Exit time scales linearly with number of CUs -- ~34s for 6 outstanding CUs.

https://jira.xilinx.com/browse/CR-1269673

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

Not a regression. The CU abort path in kds_del_cu_context() has always waited CU_EXEC_DEFAULT_TTL (5s) per CU sequentially before attempting abort, and the polling loop was unbounded. 
#### How problem was solved, alternative solutions (if any) and why they were rejected

1. Reduced CU_EXEC_DEFAULT_TTL from 5s to 1s. This grace period only applies when an abort event is pending during context teardown. The CU abort function (cu_hls_abort) retains its own 10s hardware reset timeout, so hardware safety is preserved.
2. Added a 2-second timeout bound to the unbounded polling loop in the ert_disable/xgq_enable branch of kds_del_cu_context(), preventing infinite hang.

Alternatives rejected but we can target in nex Release:
- Skipping TTL entirely in __process_sq(): changes CU thread scheduling logic, higher regression risk.
- Parallelizing CU abort: requires architectural change to ev_entry (single list_head per client), too invasive for mid-release.

#### Risks (if any) associated the changes in the commit

Low. TTL is only checked on the abort path (abnormal exit). Normal command execution is unaffected. No logic changes to xrt_cu.c. The bad_state propagation is preserved exactly as before.

#### What has been tested and how, request additional testing if necessary

Tested on an edge platform (on hw) with 12 CUs (6 mm2s + 6 s2mm), with 6 CUs outstanding:
- Without fix: Ctrl+C exit ~34s (11 polls per CU at 500ms)
- With fix: Ctrl+C exit ~9.7s (3 polls per CU, timeout bound hit once at 4 polls)
- No bad_state set, clean exit confirmed via dmesg
- Normal exit path unaffected (submitted == completed skips abort entirely)

#### Documentation impact (if any)

None.
