### PR TITLE
CR-1269998: Fix segfault in gmio_bank_id() for device-based graphs

### DIFF
--- a/src/runtime_src/core/common/api/aie/xrt_graph.cpp
+++ b/src/runtime_src/core/common/api/aie/xrt_graph.cpp
@@ -122,9 +122,11 @@ public:
   uint32_t
   gmio_bank_id(const std::string& gmio_name) const
   {
+    if (!hw_ctx)
+      throw std::runtime_error("gmio_bank_id: graph has no hw_context (create graph from hw_context)");
     auto xclbin = hw_ctx.get_xclbin();
     if (!xclbin)
-      throw std::runtime_error("gmio_bank_id: graph has no hw_context with xclbin (create graph from hw_context)");
+      throw std::runtime_error("gmio_bank_id: hw_context has no xclbin");
     int32_t mem_index = xclbin.get_gmio_mem_index(gmio_name);
     return static_cast<uint32_t>(mem_index);
   }


### PR DESCRIPTION
Add null guard for hw_context before dereferencing it in gmio_bank_id()

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
xrt::graph::gmio_bank_id() causes a segfault when called on a graph created via the deprecated device-based constructor (xrt::graph(device, uuid, name)).
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1269998 (https://jira.xilinx.com/browse/CR-1269998).
#### How problem was solved, alternative solutions (if any) and why they were rejected
Added an early if (!hw_ctx) check in graph_impl::gmio_bank_id() before calling hw_ctx.get_xclbin().
#### Risks (if any) associated the changes in the commit
None.
#### What has been tested and how, request additional testing if necessary
Tested on Versal board with both hw_context path -- passes as before and device path -- now throws a clear exception instead of segfault.
#### Documentation impact (if any)
None.