### PR TITLE
[XRT-SMI] Gbr support for xrt-smi

### DIFF
--- a/src/runtime_src/core/common/smi/smi.cpp
+++ b/src/runtime_src/core/common/smi/smi.cpp
@@ -165,10 +165,11 @@ smi_hardware_config()
     {{0x17f0, 0x11}, hardware_type::stxH},
     {{0x17f0, 0x20}, hardware_type::krk1},
     {{0x17f1, 0x00}, hardware_type::npu3_f0}, //deprecated
-    {{0x17f1, 0x12}, hardware_type::npu3_f4},
     {{0x17f1, 0x10}, hardware_type::npu3_f1}, 
     {{0x17f2, 0x10}, hardware_type::npu3_f2}, 
     {{0x17f3, 0x10}, hardware_type::npu3_f3},
+    {{0x17f1, 0x12}, hardware_type::npu3_f4},
+    {{0x17f1, 0x13}, hardware_type::npu3_f5},
     {{0x1B0A, 0x00}, hardware_type::npu3_B01},
     {{0x1B0B, 0x00}, hardware_type::npu3_B02},
     {{0x1B0C, 0x00}, hardware_type::npu3_B03},

--- a/src/runtime_src/core/common/smi/smi.cpp
+++ b/src/runtime_src/core/common/smi/smi.cpp
@@ -165,6 +165,7 @@ smi_hardware_config()
     {{0x17f0, 0x11}, hardware_type::stxH},
     {{0x17f0, 0x20}, hardware_type::krk1},
     {{0x17f1, 0x00}, hardware_type::npu3_f0}, //deprecated
+    {{0x17f1, 0x12}, hardware_type::npu3_f4}, //deprecated
     {{0x17f1, 0x10}, hardware_type::npu3_f1}, 
     {{0x17f2, 0x10}, hardware_type::npu3_f2}, 
     {{0x17f3, 0x10}, hardware_type::npu3_f3},

--- a/src/runtime_src/core/common/smi/smi.cpp
+++ b/src/runtime_src/core/common/smi/smi.cpp
@@ -165,7 +165,7 @@ smi_hardware_config()
     {{0x17f0, 0x11}, hardware_type::stxH},
     {{0x17f0, 0x20}, hardware_type::krk1},
     {{0x17f1, 0x00}, hardware_type::npu3_f0}, //deprecated
-    {{0x17f1, 0x12}, hardware_type::npu3_f4}, //deprecated
+    {{0x17f1, 0x12}, hardware_type::npu3_f4},
     {{0x17f1, 0x10}, hardware_type::npu3_f1}, 
     {{0x17f2, 0x10}, hardware_type::npu3_f2}, 
     {{0x17f3, 0x10}, hardware_type::npu3_f3},

--- a/src/runtime_src/core/common/smi/smi.h
+++ b/src/runtime_src/core/common/smi/smi.h
@@ -222,7 +222,7 @@ public:
     stxH, // Strix Halo
     krk1, // Krackan
     npu3_f0, // deprecated
-    npu3_f4, // deprecated
+    npu3_f4, // XXXXX 
     npu3_f1, // XXXXX
     npu3_f2, // XXXXX
     npu3_f3, // XXXXX

--- a/src/runtime_src/core/common/smi/smi.h
+++ b/src/runtime_src/core/common/smi/smi.h
@@ -222,10 +222,11 @@ public:
     stxH, // Strix Halo
     krk1, // Krackan
     npu3_f0, // deprecated
-    npu3_f4, // XXXXX 
     npu3_f1, // XXXXX
     npu3_f2, // XXXXX
     npu3_f3, // XXXXX
+    npu3_f4, // XXXXX
+    npu3_f5, // XXXXX
     npu3_B01, // XXXXX
     npu3_B02, // XXXXX
     npu3_B03, // XXXXX

--- a/src/runtime_src/core/common/smi/smi.h
+++ b/src/runtime_src/core/common/smi/smi.h
@@ -222,6 +222,7 @@ public:
     stxH, // Strix Halo
     krk1, // Krackan
     npu3_f0, // deprecated
+    npu3_f4, // deprecated
     npu3_f1, // XXXXX
     npu3_f2, // XXXXX
     npu3_f3, // XXXXX

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -235,6 +235,8 @@ XBUtilities::get_available_devices(bool inUserDomain)
         case xrt_core::smi::smi_hardware_config::hardware_type::npu3_f1:
         case xrt_core::smi::smi_hardware_config::hardware_type::npu3_f2:
         case xrt_core::smi::smi_hardware_config::hardware_type::npu3_f3:
+        case xrt_core::smi::smi_hardware_config::hardware_type::npu3_f4:
+        case xrt_core::smi::smi_hardware_config::hardware_type::npu3_f5:
         case xrt_core::smi::smi_hardware_config::hardware_type::npu3_B01:
         case xrt_core::smi::smi_hardware_config::hardware_type::npu3_B02:
         case xrt_core::smi::smi_hardware_config::hardware_type::npu3_B03:

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -1038,6 +1038,7 @@ is_strix_hardware(xrt_core::smi::smi_hardware_config::hardware_type hw_type)
     case xrt_core::smi::smi_hardware_config::hardware_type::npu3_f1:
     case xrt_core::smi::smi_hardware_config::hardware_type::npu3_f2:
     case xrt_core::smi::smi_hardware_config::hardware_type::npu3_f3:
+    case xrt_core::smi::smi_hardware_config::hardware_type::npu3_f4:
     case xrt_core::smi::smi_hardware_config::hardware_type::npu3_B01:
     case xrt_core::smi::smi_hardware_config::hardware_type::npu3_B02:
     case xrt_core::smi::smi_hardware_config::hardware_type::npu3_B03:

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -1041,6 +1041,7 @@ is_strix_hardware(xrt_core::smi::smi_hardware_config::hardware_type hw_type)
     case xrt_core::smi::smi_hardware_config::hardware_type::npu3_f2:
     case xrt_core::smi::smi_hardware_config::hardware_type::npu3_f3:
     case xrt_core::smi::smi_hardware_config::hardware_type::npu3_f4:
+    case xrt_core::smi::smi_hardware_config::hardware_type::npu3_f5:
     case xrt_core::smi::smi_hardware_config::hardware_type::npu3_B01:
     case xrt_core::smi::smi_hardware_config::hardware_type::npu3_B02:
     case xrt_core::smi::smi_hardware_config::hardware_type::npu3_B03:

--- a/src/runtime_src/core/tools/common/tests/TestGemm.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestGemm.cpp
@@ -54,9 +54,11 @@ static void
 log_gemm_results(boost::property_tree::ptree& ptree,
                  double tops,
                  double avg_cycle_count,
+                 uint64_t clock_mhz,
                  double period_ns)
 {
   if (XBU::getVerbose()) {
+    XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Clock Frequency: %d MHz") % clock_mhz));
     XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Total Duration (avg): %.1f ns") % (period_ns * avg_cycle_count)));
     XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Average cycle count: %.1f") % avg_cycle_count));
   }
@@ -106,7 +108,7 @@ run_strix(const std::shared_ptr<xrt_core::device>& dev, const xrt_core::archive*
     double TOPS = run_TOPS;
     double avg_cycle_count = run_total_cycle_count / num_of_cores_strix;
 
-    log_gemm_results(ptree, TOPS, avg_cycle_count, period_ns);
+    log_gemm_results(ptree, TOPS, avg_cycle_count, clock_mhz, period_ns);
     ptree.put("status", XBValidateUtils::test_token_passed);
   }
   catch(const std::exception& e) {
@@ -168,7 +170,7 @@ run_npu3(const std::shared_ptr<xrt_core::device>& dev, const xrt_core::archive* 
     double aie4_tops_all_cores = tops_per_core * num_of_cores_npu3;
     double avg_cycle_count = total_cycle_count / num_of_cores_npu3;
 
-    log_gemm_results(ptree, aie4_tops_all_cores, avg_cycle_count, period_ns);
+    log_gemm_results(ptree, aie4_tops_all_cores, avg_cycle_count, clock_mhz, period_ns);
     ptree.put("status", XBValidateUtils::test_token_passed);
   }
   catch(const std::exception& e) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
This PR extends the device type to GBR and B0 based on the device's dev_id + rev_id
Also added additional debug prints for verbose prints.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
None

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Tested in bringup environment via different team

#### Documentation impact (if any)
None
