### PR TITLE
CR-1269998: Fix segfault in gmio_bank_id() for device-based graphs (#…

### DIFF
--- a/src/runtime_src/core/common/api/aie/xrt_graph.cpp
+++ b/src/runtime_src/core/common/api/aie/xrt_graph.cpp
@@ -122,9 +122,11 @@ public:
   uint32_t
   gmio_bank_id(const std::string& gmio_name) const
   {
+    if (!hw_ctx)
+      throw std::runtime_error("gmio_bank_id: graph has no hw_context (create graph from hw_context)");
     auto xclbin = hw_ctx.get_xclbin();
     if (!xclbin)
-      throw std::runtime_error("gmio_bank_id: graph has no hw_context with xclbin (create graph from hw_context)");
+      throw std::runtime_error("gmio_bank_id: hw_context has no xclbin");
     int32_t mem_index = xclbin.get_gmio_mem_index(gmio_name);
     return static_cast<uint32_t>(mem_index);
   }


### PR DESCRIPTION
…9799)

Add null guard for hw_context before dereferencing it in gmio_bank_id()


(cherry picked from commit d5642328f9780b900b3ce37a92e1b73e2f817849)

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
