### PR TITLE
CR-1268451 - Fix Segfault in libxrt_coreutil.so during dynamic xclbin…

### DIFF
--- a/src/runtime_src/xrt/device/hal2.cpp
+++ b/src/runtime_src/xrt/device/hal2.cpp
@@ -276,7 +276,8 @@ loadXclBin(const xclBin* xclbin)
 {
   auto xclbin_obj = xrt::xclbin(reinterpret_cast<const axlf*>(xclbin));
   auto uuid = m_handle.register_xclbin(xclbin_obj);
-  m_hw_contexts[uuid] = xrt::hw_context(m_handle, uuid);
+  m_hw_ctx = {}; // clear active hw context
+  m_hw_ctx = xrt::hw_context(m_handle, uuid);
 
   // refresh device info on successful load
   std::lock_guard<std::mutex> lk(m_mutex);

--- a/src/runtime_src/xrt/device/hal2.h
+++ b/src/runtime_src/xrt/device/hal2.h
@@ -25,6 +25,7 @@
 #include <map>
 #include <array>
 #include <mutex>
+#include <stdexcept>
 
 #include <boost/optional/optional.hpp>
 
@@ -70,11 +71,8 @@ class device : public xrt_xocl::hal::device
   xrt::device m_handle;
   mutable boost::optional<hal2::device_info> m_devinfo;
 
-  // In hwctx flow, we create hw contexts from xclbins on demand
-  // instead of explicitly loading the xclbins.  The hwctx are cached
-  // here and accessors are provided so that xclbin references can be
-  // converted into the hwctx that has loaded the xclbin.
-  std::map<xrt::uuid, xrt::hw_context> m_hw_contexts;
+  // Active xrt::hw_context for the HAL session.
+  xrt::hw_context m_hw_ctx;
 
   mutable std::mutex m_mutex;
 
@@ -201,7 +199,13 @@ public:
   xrt::hw_context
   get_xrt_hwctx(const uuid& uuid) const override
   {
-    return m_hw_contexts.at(uuid);
+    if (!m_hw_ctx)
+      throw std::runtime_error("no active hw context");
+
+    if (m_hw_ctx.get_xclbin_uuid() != uuid)
+      throw std::runtime_error(std::string("requested xclbin uuid does not match active hw context: ") + uuid.to_string() + "/" + m_hw_ctx.get_xclbin_uuid().to_string());
+
+    return m_hw_ctx;
   }
 
   std::shared_ptr<xrt_core::device>


### PR DESCRIPTION
Problem solved by the commit
caching hw contexts using std:map resulting in hw context alive even after coming out of scope in application.
this leads to failure when loading multiple xclbins from application.

replace with std:optional, pair so old hw context is destroyed when loading a new xclbin.

Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
destruct old hw context if present wen loading a new hw context.

How problem was solved, alternative solutions (if any) and why they were rejected
caching hw contexts using std:map resulting in hw context alive even after coming out of scope in application.
this leads to failure when loading multiple xclbins from application.

replace with std:optional, pair so old hw context is destroyed when loading a new xclbin.

Risks (if any) associated the changes in the commit
None

What has been tested and how, request additional testing if necessary
Tested regression suite

Documentation impact (if any)
NA