### PR TITLE
Revert "Add io_uring changes to ads_runtime_api.cpp files (#9708)"

### DIFF
--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -684,17 +684,6 @@ get_qdma_aio_enable()
   return value;
 }
 
-/**
- * When true, batched io_uring submits (DmaWriteBdAsync / PushBdToQueueAsync + one wait).
- * When false (default), synchronous AIE DMA APIs are used throughout.
- */
-inline bool
-get_io_uring()
-{
-  static bool value = detail::get_bool_value("Runtime.io_uring", false);
-  return value;
-}
-
 inline std::string
 get_hw_em_driver()
 {

--- a/src/runtime_src/core/edge/user/aie/aie.cpp
+++ b/src/runtime_src/core/edge/user/aie/aie.cpp
@@ -17,7 +17,6 @@
  */
 
 #include "aie.h"
-#include "core/common/config_reader.h"
 #include "core/common/error.h"
 #include "common_layer/fal_util.h"
 #include "core/common/message.h"
@@ -71,8 +70,7 @@ aie_array(const std::shared_ptr<xrt_core::device>& device)
   dev_inst = &dev_inst_obj;
 
   adf::aiecompiler_options aiecompiler_options = xrt_core::edge::aie::get_aiecompiler_options(device.get());
-  m_config = std::make_shared<adf::config_manager>(dev_inst, driver_config.mem_num_rows, aiecompiler_options.broadcast_enable_core,
-                                                     xrt_core::config::get_io_uring());
+  m_config = std::make_shared<adf::config_manager>(dev_inst, driver_config.mem_num_rows, aiecompiler_options.broadcast_enable_core);
 
   fal_util::initialize(dev_inst); //resource manager initialization
 
@@ -146,8 +144,7 @@ aie_array(const std::shared_ptr<xrt_core::device>& device, const zynqaie::hwctx_
   dev_inst = &dev_inst_obj;
 
   adf::aiecompiler_options aiecompiler_options = xrt_core::edge::aie::get_aiecompiler_options(device.get(), hwctx_obj);
-  m_config = std::make_shared<adf::config_manager>(dev_inst, driver_config.mem_num_rows, aiecompiler_options.broadcast_enable_core,
-                                                     xrt_core::config::get_io_uring());
+  m_config = std::make_shared<adf::config_manager>(dev_inst, driver_config.mem_num_rows, aiecompiler_options.broadcast_enable_core);
 
   fal_util::initialize(dev_inst); //resource manager initialization
   

--- a/src/runtime_src/core/edge/user/aie/common_layer/adf_aie_control_api.h
+++ b/src/runtime_src/core/edge/user/aie/common_layer/adf_aie_control_api.h
@@ -26,8 +26,7 @@ namespace adf
 class config_manager
 {
 public:
-  config_manager(XAie_DevInst* dev_inst, size_t num_reserved_rows, bool broadcast_enable_core,
-                 bool io_uring = false);
+  config_manager(XAie_DevInst* dev_inst, size_t num_reserved_rows, bool broadcast_enable_core);
   XAie_DevInst*
   get_dev()
   {
@@ -46,17 +45,10 @@ public:
     return m_broadcast_enable_core;
   }
 
-  bool
-  get_io_uring() const
-  {
-    return m_io_uring;
-  }
-
 private:
   XAie_DevInst* m_aie_dev;
   size_t m_num_reserved_rows;
   bool m_broadcast_enable_core;
-  bool m_io_uring;
 };
 
 class dma_api

--- a/src/runtime_src/core/edge/user/aie/common_layer/adf_runtime_api.cpp
+++ b/src/runtime_src/core/edge/user/aie/common_layer/adf_runtime_api.cpp
@@ -26,23 +26,10 @@
 extern "C"
 {
 #include "xaiengine.h"
-#include <xaiengine/xaie_helper.h>
 }
 
 namespace adf
 {
-
-namespace {
-void
-aie_async_wait_nr_throw(XAie_DevInst* dev, int nr)
-{
-  if (nr <= 0)
-    return;
-  AieRC w = XAie_AsyncWaitNr(dev, static_cast<u32>(nr));
-  if (w != XAIE_OK)
-    throw xrt_core::error(-EIO, "XAie_AsyncWaitNr failed: " + std::to_string(w));
-}
-} // namespace
 
 /********************************* Statics & Constants *********************************/
 
@@ -61,12 +48,10 @@ static constexpr unsigned LOCK_TIMEOUT = 0x7FFFFFFF;
 /********************************* config_manager *************************************/
 
 config_manager::
-config_manager(XAie_DevInst* dev_inst, size_t num_reserved_rows, bool broadcast_enable_core,
-               bool io_uring)
+config_manager(XAie_DevInst* dev_inst, size_t num_reserved_rows, bool broadcast_enable_core)
   : m_aie_dev(dev_inst)
   , m_num_reserved_rows(num_reserved_rows)
   , m_broadcast_enable_core(broadcast_enable_core)
-  , m_io_uring(io_uring)
 {}
 
 /************************************ graph_api ************************************/
@@ -799,55 +784,21 @@ std::pair<size_t, size_t> gmio_api::enqueueBD(XAie_MemInst *memInst, uint64_t of
     //get an available BD
     uint16_t bdNumber = frontAndPop(availableBDs);
 
-    if (config->get_io_uring()) {
-      driverStatus |= XAie_DmaSetAddrOffsetLen(&shimDmaInst, memInst, offset, static_cast<u32>(size));
+    //set up BD
+    driverStatus |= XAie_DmaSetAddrOffsetLen(&shimDmaInst, memInst, offset, (u32)size);
 
-      XAie_AsyncRes ares[2]{};
-      int n = 0;
-
-      if (config->get_dev()->DevProp.DevGen == XAIE_DEV_GEN_AIEML || config->get_dev()->DevProp.DevGen == XAIE_DEV_GEN_AIE2PS)
+    if (config->get_dev()->DevProp.DevGen == XAIE_DEV_GEN_AIEML || config->get_dev()->DevProp.DevGen == XAIE_DEV_GEN_AIE2PS) // AIEML (note AIE1 XAIE_LOCK_WITH_NO_VALUE is -1, which does not work for AIEML)
         driverStatus |= XAie_DmaSetLock(&shimDmaInst, XAie_LockInit(bdNumber, 0), XAie_LockInit(bdNumber, 0));
-      else
+    else
         driverStatus |= XAie_DmaSetLock(&shimDmaInst, XAie_LockInit(bdNumber, XAIE_LOCK_WITH_NO_VALUE), XAie_LockInit(bdNumber, XAIE_LOCK_WITH_NO_VALUE));
 
-      driverStatus |= XAie_DmaEnableBd(&shimDmaInst);
+    driverStatus |= XAie_DmaEnableBd(&shimDmaInst);
 
-      int r = XAie_DmaWriteBdAsync(config->get_dev(), &shimDmaInst, gmioTileLoc, bdNumber, &ares[0]);
-      if (r == 0) {
-        aie_async_wait_nr_throw(config->get_dev(), n);
-        throw xrt_core::error(ares[0].res ? ares[0].res : -EIO, "XAie_DmaWriteBdAsync submit failed");
-      }
-      n += r;
+    //write BD
+    driverStatus |= XAie_DmaWriteBd(config->get_dev(), &shimDmaInst, gmioTileLoc, bdNumber);
 
-      r = XAie_DmaChannelPushBdToQueueAsync(config->get_dev(), gmioTileLoc, pGMIOConfig->channelNum,
-          (pGMIOConfig->type == gmio_config::gm2aie ? DMA_MM2S : DMA_S2MM), bdNumber, &ares[1]);
-      if (r == 0) {
-        aie_async_wait_nr_throw(config->get_dev(), n);
-        throw xrt_core::error(ares[1].res ? ares[1].res : -EIO, "XAie_DmaChannelPushBdToQueueAsync submit failed");
-      }
-      n += r;
-
-      aie_async_wait_nr_throw(config->get_dev(), n);
-      for (int i = 0; i < 2; ++i) {
-        if (ares[i].res < 0){
-          throw xrt_core::error(ares[i].res, "GMIO enqueueBD async completion failed");
-	}
-      }
-    }
-    else {
-      driverStatus |= XAie_DmaSetAddrOffsetLen(&shimDmaInst, memInst, offset, static_cast<u32>(size));
-
-      if (config->get_dev()->DevProp.DevGen == XAIE_DEV_GEN_AIEML || config->get_dev()->DevProp.DevGen == XAIE_DEV_GEN_AIE2PS)
-        driverStatus |= XAie_DmaSetLock(&shimDmaInst, XAie_LockInit(bdNumber, 0), XAie_LockInit(bdNumber, 0));
-      else
-        driverStatus |= XAie_DmaSetLock(&shimDmaInst, XAie_LockInit(bdNumber, XAIE_LOCK_WITH_NO_VALUE), XAie_LockInit(bdNumber, XAIE_LOCK_WITH_NO_VALUE));
-
-      driverStatus |= XAie_DmaEnableBd(&shimDmaInst);
-      driverStatus |= XAie_DmaWriteBd(config->get_dev(), &shimDmaInst, gmioTileLoc, bdNumber);
-      driverStatus |= XAie_DmaChannelPushBdToQueue(config->get_dev(), gmioTileLoc, pGMIOConfig->channelNum,
-          (pGMIOConfig->type == gmio_config::gm2aie ? DMA_MM2S : DMA_S2MM), bdNumber);
-    }
-
+    //enqueue BD
+    driverStatus |= XAie_DmaChannelPushBdToQueue(config->get_dev(), gmioTileLoc, pGMIOConfig->channelNum, (pGMIOConfig->type == gmio_config::gm2aie ? DMA_MM2S : DMA_S2MM), bdNumber);
     enqueuedBDs.push(bdNumber);
 
     /* Commenting out as this is increasing overhead of the performance */
@@ -1016,6 +967,7 @@ err_code dma_api::configureBD(int tileType, uint8_t column, uint8_t row, uint16_
     //valid bd
     driverStatus |= XAie_DmaEnableBd(&dmaInst);
 
+    //write bd
     driverStatus |= XAie_DmaWriteBd(config->get_dev(), &dmaInst, tileLoc, bdId);
     debugMsg(static_cast<std::stringstream &&>(std::stringstream() << "XAie_DmaWriteBd " << (uint16_t)bdId << std::endl).str());
 


### PR DESCRIPTION
This reverts commit 5f886c3b05aab02b3ab8d6be586f6a3667dff304.

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Revert "Add io_uring changes to ads_runtime_api.cpp files (#9708)"
Reverting this io_uring changes as Vitis-AI-Telluride uses 6.12 kernel and these changes are not supported on this kernel.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
