### PR TITLE
AIESW-32864: Fix temperature missing from platform JSON output

### DIFF
--- a/src/runtime_src/core/common/info_platform.cpp
+++ b/src/runtime_src/core/common/info_platform.cpp
@@ -350,12 +350,11 @@ add_thermal_info(const xrt_core::device* device, ptree_type& pt)
   try {
     ptree_type thermals_pt = xrt_core::sensor::read_thermals(device);
     const ptree_type& thermals = thermals_pt.get_child("thermals");
-    for (const auto& kv : thermals) {
-      const ptree_type& pt_temp = kv.second;
-      if (!pt_temp.get<bool>("is_present", false))
+    for (const auto& [key, child] : thermals) {
+      if (!child.get<bool>("is_present", false))
         continue;
       ptree_type thermal;
-      thermal.put("temp_C", pt_temp.get<std::string>("temp_C", "N/A"));
+      thermal.put("temp_C", child.get<std::string>("temp_C", "N/A"));
       pt.put_child("thermal", thermal);
       break;
     }

--- a/src/runtime_src/core/common/info_platform.cpp
+++ b/src/runtime_src/core/common/info_platform.cpp
@@ -345,6 +345,27 @@ add_electrical_info(const xrt_core::device* device, ptree_type& pt)
 }
 
 void
+add_thermal_info(const xrt_core::device* device, ptree_type& pt)
+{
+  try {
+    ptree_type thermals_pt = xrt_core::sensor::read_thermals(device);
+    const ptree_type& thermals = thermals_pt.get_child("thermals");
+    for (const auto& kv : thermals) {
+      const ptree_type& pt_temp = kv.second;
+      if (!pt_temp.get<bool>("is_present", false))
+        continue;
+      ptree_type thermal;
+      thermal.put("temp_C", pt_temp.get<std::string>("temp_C", "N/A"));
+      pt.put_child("thermal", thermal);
+      break;
+    }
+  }
+  catch (const xq::exception&) {
+    // ignoring if not available
+  }
+}
+
+void
 add_mac_info(const xrt_core::device* device, ptree_type& pt)
 {
   ptree_type pt_mac;
@@ -410,6 +431,7 @@ add_platform_info(const xrt_core::device* device, ptree_type& pt_platform_array)
   case xrt_core::query::device_class::type::ryzen:
   {
     add_electrical_info(device, pt_platform);
+    add_thermal_info(device, pt_platform);
     break;
   }
   default:

--- a/src/runtime_src/core/tools/common/reports/platform/ReportRyzenPlatform.cpp
+++ b/src/runtime_src/core/tools/common/reports/platform/ReportRyzenPlatform.cpp
@@ -8,7 +8,6 @@
 
 // Local - Include Files
 #include "ReportRyzenPlatform.h"
-#include "core/common/sensor.h"
 
 // 3rd Party Library - Include Files
 #include <boost/property_tree/json_parser.hpp>
@@ -36,8 +35,8 @@ ReportRyzenPlatform::getPropertyTree20202(const xrt_core::device* dev,
   pt = pt_platform;
 }
 
-void 
-ReportRyzenPlatform::writeReport(const xrt_core::device* _pDevice,
+void
+ReportRyzenPlatform::writeReport(const xrt_core::device* /*_pDevice*/,
                                  const boost::property_tree::ptree& _pt,
                                  const std::vector<std::string>& /*_elementsFilter*/,
                                  std::ostream& _output) const
@@ -55,27 +54,13 @@ ReportRyzenPlatform::writeReport(const xrt_core::device* _pDevice,
     _output << boost::format("  %-23s: %s \n") % "Power Mode" % pt_status.get<std::string>("power_mode");
     _output << boost::format("  %-23s: %s \n") % "Total Columns" % pt_static_region.get<std::string>("total_columns");
 
-
     auto watts = pt_platform.get<std::string>("electrical.power_consumption_watts", "N/A");
     if (watts != "N/A")
       _output << std::endl << boost::format("%-23s  : %s Watts\n") % "Estimated Power" % watts;
     else
       _output << std::endl << boost::format("%-23s  : %s\n") % "Estimated Power" % watts;
 
-    std::string temp_c = "N/A";
-    try {
-      boost::property_tree::ptree thermals_pt = xrt_core::sensor::read_thermals(_pDevice);
-      const boost::property_tree::ptree& thermals = thermals_pt.get_child("thermals", empty_ptree);
-      for (const auto& kv : thermals) {
-        const boost::property_tree::ptree& pt_temp = kv.second;
-        if (!pt_temp.get<bool>("is_present", false))
-          continue;
-        temp_c = pt_temp.get<std::string>("temp_C", "N/A");
-        break;
-      }
-    }
-    catch (const std::exception&) {
-    }
+    auto temp_c = pt_platform.get<std::string>("thermal.temp_C", "N/A");
     _output << boost::format("%-23s  : %s\n") % "Temperature (C)" % temp_c;
   }
 


### PR DESCRIPTION
AIESW-32864: Fix temperature missing from platform JSON output

Problem:
xrt-smi examine --report platform --format JSON produces a JSON file
with no temperature field, while the console output shows temperature
correctly.

Bug history:
Thermal data was never added to the platform property tree in
add_platform_info() for the ryzen case. The JSON output gap existed
since the initial implementation — temperature was only read inside
writeReport() for console display and was never included in the
property tree that gets serialized to JSON.

Root cause:
writeReport() called read_thermals() independently (console-only path).
The property tree built by platform_info() -> add_platform_info() had
no thermal data, so JSON serialization produced no temperature field.
Electrical power was already handled correctly via add_electrical_info()
in the ryzen case of add_platform_info().

Fix:
- info_platform.cpp: Add add_thermal_info() following the same pattern
  as add_electrical_info(). Call it in the ryzen case of
  add_platform_info() so thermal.temp_C is part of the canonical
  property tree used for both JSON and console output.
  Temperature decimal formatting is preserved as it applies inside
  sensor.cpp read_data_driven_thermals().

- ReportRyzenPlatform.cpp: Remove the direct read_thermals() call and
  sensor.h include. writeReport() now reads thermal.temp_C from the
  passed-in property tree, consistent with electrical.power_consumption_watts.

Alternative considered:
Inject thermal into the ptree inside getPropertyTree20202() in
ReportRyzenPlatform.cpp after calling device.get_info<platform>().
Rejected because info_platform.cpp is the architecturally correct
location — it is where all other platform data (electrical, clocks,
board info) is assembled, and fixes there automatically benefit all
callers of platform_info().

Risks:
Low. add_thermal_info() adds one additional read_thermals() driver
query per platform info call. If thermal sensors are unavailable,
xq::exception is caught and silently ignored — thermal is absent from
the output, same behavior as electrical when unavailable. No change
to existing data fields; thermal.temp_C is a new additive field.

Testing:
Validated on MDS hardware:
  xrt-smi examine --report platform --format JSON
  JSON output now includes "thermal": { "temp_C": "33.83" }
  Decimal formatting confirmed correct through new code path.

Documentation: None.
