### PR TITLE
Expose `xrt::run::get_ctrl_scratchpad_bo` in Python PyXRT bindings

### DIFF
--- a/src/python/pybind11/src/pyxrt.cpp
+++ b/src/python/pybind11/src/pyxrt.cpp
@@ -445,7 +445,9 @@ PYBIND11_MODULE(pyxrt, m) {
                             return r.wait2(timeout);
                     }, "Wait for the specified milliseconds for the run to complete")
         .def("state", &xrt::run::state, "Return the current execution state of the run.")
-        .def("add_callback", &xrt::run::add_callback, "Register a callback to be invoked when the run reaches the requested state.");
+        .def("add_callback", &xrt::run::add_callback, "Register a callback to be invoked when the run reaches the requested state.")
+        .def("get_ctrl_scratchpad_bo", &xrt::run::get_ctrl_scratchpad_bo,
+             "Get the control scratchpad buffer object associated with this run");
 
     py::class_<xrt::kernel> pyker(m, "kernel", "Represents a set of instances matching a specified name");
 


### PR DESCRIPTION
We'd like to use the scratchpad feature in MLIR-AIE/IRON from Python.

Note: Max advised I should submit the PR to `main`. The old backport PR to the `XRT-2.21` branch is at #9813. We'd like to get this into whatever version of XRT that xdna-driver pulls.
