### PR TITLE
AIESW-29594 Long process names cause formatting issues in the AIE partition report

### DIFF
--- a/src/runtime_src/core/tools/common/Table2D.cpp
+++ b/src/runtime_src/core/tools/common/Table2D.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2022 Xilinx, Inc
-// Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2022-2026 Advanced Micro Devices, Inc. All rights reserved.
 
 // ------ I N C L U D E   F I L E S -------------------------------------------
 // Local - Include Files
@@ -15,6 +15,154 @@ Table2D::Table2D(const std::vector<HeaderData>& headers) : m_inter_entry_padding
 {
   for (auto& header : headers)
       addHeader(header);
+}
+
+Table2D::Table2D(size_t column_count, Justification justification)
+  : m_inter_entry_padding(2)
+  , m_stacked_mode(true)
+{
+  for (size_t i = 0; i < column_count; ++i) {
+    HeaderData header;
+    header.name = "";
+    header.justification = justification;
+    addHeader(header);
+  }
+}
+
+void
+Table2D::updateStackedColumnWidth(size_t column_index, const std::string& data)
+{
+  auto& column = m_table[column_index];
+  column.max_element_size = std::max(column.max_element_size, data.size());
+}
+
+void
+Table2D::validateStackedRow(const std::vector<std::string>& row, const char* context) const
+{
+  if (!m_stacked_mode)
+    throw std::runtime_error(boost::str(boost::format("Table2D - %s requires a stacked table.\n") % context));
+
+  if (row.size() < m_table.size())
+    throw std::runtime_error(boost::str(boost::format("Table2D - %s row is smaller than table. Row size: %d Table Size: %d\n")
+      % context % row.size() % m_table.size()));
+  if (row.size() > m_table.size())
+    throw std::runtime_error(boost::str(boost::format("Table2D - %s row is larger than table. Row size: %d Table Size: %d\n")
+      % context % row.size() % m_table.size()));
+}
+
+void
+Table2D::setStackedHeaders(const std::vector<std::vector<std::string>>& header_rows)
+{
+  if (!m_stacked_mode)
+    throw std::runtime_error("Table2D - setStackedHeaders requires a stacked table.\n");
+
+  if (header_rows.empty())
+    throw std::runtime_error("Table2D - setStackedHeaders requires at least one header row.\n");
+
+  m_stacked_header_rows.clear();
+  for (const auto& row : header_rows) {
+    validateStackedRow(row, "setStackedHeaders");
+    m_stacked_header_rows.push_back(row);
+    for (size_t col = 0; col < row.size(); ++col)
+      updateStackedColumnWidth(col, row[col]);
+  }
+}
+
+void
+Table2D::addStackedEntry(const std::vector<std::vector<std::string>>& entry_rows)
+{
+  if (entry_rows.empty())
+    throw std::runtime_error("Table2D - addStackedEntry requires at least one entry row.\n");
+
+  for (const auto& row : entry_rows) {
+    validateStackedRow(row, "addStackedEntry");
+    for (size_t col = 0; col < row.size(); ++col)
+      updateStackedColumnWidth(col, row[col]);
+  }
+
+  StackedBlock block;
+  block.kind = StackedBlockKind::entry;
+  block.rows = entry_rows;
+  m_stacked_blocks.push_back(std::move(block));
+}
+
+void
+Table2D::addStackedSeparator()
+{
+  if (!m_stacked_mode)
+    throw std::runtime_error("Table2D - addStackedSeparator requires a stacked table.\n");
+
+  StackedBlock block;
+  block.kind = StackedBlockKind::separator;
+  m_stacked_blocks.push_back(std::move(block));
+}
+
+void
+Table2D::formatDataRow(std::string& output_line, const std::string& prefix, const std::vector<std::string>& row) const
+{
+  const auto space_suffix = std::string(m_inter_entry_padding, ' ');
+  for (size_t col = 0; col < m_table.size(); ++col) {
+    std::string column_prefix;
+    if (col == 0)
+      column_prefix = prefix + '|';
+    appendToOutput(output_line, column_prefix, space_suffix, m_table[col], row[col]);
+  }
+  output_line.append("\n");
+}
+
+void
+Table2D::formatSeparatorRow(std::string& output_line, const std::string& prefix) const
+{
+  const auto dash_suffix = std::string(m_inter_entry_padding, '-');
+  for (size_t col = 0; col < m_table.size(); ++col) {
+    std::string column_prefix;
+    if (col == 0)
+      column_prefix = prefix + '|';
+    const auto& column = m_table[col];
+    appendToOutput(output_line, column_prefix, dash_suffix, column, std::string(column.max_element_size, '-'));
+  }
+  output_line.append("\n");
+}
+
+std::string
+Table2D::stackedToString(const std::string& prefix) const
+{
+  if (!m_stacked_mode)
+    throw std::runtime_error("Table2D - stackedToString requires a stacked table.\n");
+
+  std::stringstream os;
+  for (const auto& header_row : m_stacked_header_rows) {
+    std::string output_line;
+    formatDataRow(output_line, prefix, header_row);
+    os << output_line;
+  }
+
+  if (!m_stacked_header_rows.empty()) {
+    std::string separator_line;
+    formatSeparatorRow(separator_line, prefix);
+    os << separator_line;
+  }
+
+  for (const auto& block : m_stacked_blocks) {
+    switch (block.kind) {
+      case StackedBlockKind::entry:
+        for (const auto& row : block.rows) {
+          std::string output_line;
+          formatDataRow(output_line, prefix, row);
+          os << output_line;
+        }
+        break;
+      case StackedBlockKind::separator:
+        {
+          std::string separator_line;
+          formatSeparatorRow(separator_line, prefix);
+          os << separator_line;
+        }
+        break;
+    }
+  }
+
+  return os.str();
 }
 
 void

--- a/src/runtime_src/core/tools/common/Table2D.cpp
+++ b/src/runtime_src/core/tools/common/Table2D.cpp
@@ -30,14 +30,14 @@ Table2D::Table2D(size_t column_count, Justification justification)
 }
 
 void
-Table2D::updateStackedColumnWidth(size_t column_index, const std::string& data)
+Table2D::update_stacked_column_width(size_t column_index, const std::string& data)
 {
   auto& column = m_table[column_index];
   column.max_element_size = std::max(column.max_element_size, data.size());
 }
 
 void
-Table2D::validateStackedRow(const std::vector<std::string>& row, const char* context) const
+Table2D::validate_stacked_row(const std::vector<std::string>& row, const char* context) const
 {
   if (!m_stacked_mode)
     throw std::runtime_error(boost::str(boost::format("Table2D - %s requires a stacked table.\n") % context));
@@ -51,33 +51,33 @@ Table2D::validateStackedRow(const std::vector<std::string>& row, const char* con
 }
 
 void
-Table2D::setStackedHeaders(const std::vector<std::vector<std::string>>& header_rows)
+Table2D::set_stacked_headers(const std::vector<std::vector<std::string>>& header_rows)
 {
   if (!m_stacked_mode)
-    throw std::runtime_error("Table2D - setStackedHeaders requires a stacked table.\n");
+    throw std::runtime_error("Table2D - set_stacked_headers requires a stacked table.\n");
 
   if (header_rows.empty())
-    throw std::runtime_error("Table2D - setStackedHeaders requires at least one header row.\n");
+    throw std::runtime_error("Table2D - set_stacked_headers requires at least one header row.\n");
 
   m_stacked_header_rows.clear();
   for (const auto& row : header_rows) {
-    validateStackedRow(row, "setStackedHeaders");
+    validate_stacked_row(row, "set_stacked_headers");
     m_stacked_header_rows.push_back(row);
     for (size_t col = 0; col < row.size(); ++col)
-      updateStackedColumnWidth(col, row[col]);
+      update_stacked_column_width(col, row[col]);
   }
 }
 
 void
-Table2D::addStackedEntry(const std::vector<std::vector<std::string>>& entry_rows)
+Table2D::add_stacked_entry(const std::vector<std::vector<std::string>>& entry_rows)
 {
   if (entry_rows.empty())
-    throw std::runtime_error("Table2D - addStackedEntry requires at least one entry row.\n");
+    throw std::runtime_error("Table2D - add_stacked_entry requires at least one entry row.\n");
 
   for (const auto& row : entry_rows) {
-    validateStackedRow(row, "addStackedEntry");
+    validate_stacked_row(row, "add_stacked_entry");
     for (size_t col = 0; col < row.size(); ++col)
-      updateStackedColumnWidth(col, row[col]);
+      update_stacked_column_width(col, row[col]);
   }
 
   StackedBlock block;
@@ -87,10 +87,10 @@ Table2D::addStackedEntry(const std::vector<std::vector<std::string>>& entry_rows
 }
 
 void
-Table2D::addStackedSeparator()
+Table2D::add_stacked_separator()
 {
   if (!m_stacked_mode)
-    throw std::runtime_error("Table2D - addStackedSeparator requires a stacked table.\n");
+    throw std::runtime_error("Table2D - add_stacked_separator requires a stacked table.\n");
 
   StackedBlock block;
   block.kind = StackedBlockKind::separator;
@@ -98,7 +98,7 @@ Table2D::addStackedSeparator()
 }
 
 void
-Table2D::formatDataRow(std::string& output_line, const std::string& prefix, const std::vector<std::string>& row) const
+Table2D::format_data_row(std::string& output_line, const std::string& prefix, const std::vector<std::string>& row) const
 {
   const auto space_suffix = std::string(m_inter_entry_padding, ' ');
   for (size_t col = 0; col < m_table.size(); ++col) {
@@ -111,7 +111,7 @@ Table2D::formatDataRow(std::string& output_line, const std::string& prefix, cons
 }
 
 void
-Table2D::formatSeparatorRow(std::string& output_line, const std::string& prefix) const
+Table2D::format_separator_row(std::string& output_line, const std::string& prefix) const
 {
   const auto dash_suffix = std::string(m_inter_entry_padding, '-');
   for (size_t col = 0; col < m_table.size(); ++col) {
@@ -125,21 +125,21 @@ Table2D::formatSeparatorRow(std::string& output_line, const std::string& prefix)
 }
 
 std::string
-Table2D::stackedToString(const std::string& prefix) const
+Table2D::stacked_to_string(const std::string& prefix) const
 {
   if (!m_stacked_mode)
-    throw std::runtime_error("Table2D - stackedToString requires a stacked table.\n");
+    throw std::runtime_error("Table2D - stacked_to_string requires a stacked table.\n");
 
   std::stringstream os;
   for (const auto& header_row : m_stacked_header_rows) {
     std::string output_line;
-    formatDataRow(output_line, prefix, header_row);
+    format_data_row(output_line, prefix, header_row);
     os << output_line;
   }
 
   if (!m_stacked_header_rows.empty()) {
     std::string separator_line;
-    formatSeparatorRow(separator_line, prefix);
+    format_separator_row(separator_line, prefix);
     os << separator_line;
   }
 
@@ -148,14 +148,14 @@ Table2D::stackedToString(const std::string& prefix) const
       case StackedBlockKind::entry:
         for (const auto& row : block.rows) {
           std::string output_line;
-          formatDataRow(output_line, prefix, row);
+          format_data_row(output_line, prefix, row);
           os << output_line;
         }
         break;
       case StackedBlockKind::separator:
         {
           std::string separator_line;
-          formatSeparatorRow(separator_line, prefix);
+          format_separator_row(separator_line, prefix);
           os << separator_line;
         }
         break;

--- a/src/runtime_src/core/tools/common/Table2D.h
+++ b/src/runtime_src/core/tools/common/Table2D.h
@@ -32,8 +32,8 @@ class Table2D {
     /**
      * @brief Construct a table for stacked (multi-row) headers and entries.
      *
-     * Each logical row of the table has one string per column. Use setStackedHeaders(),
-     * addStackedEntry(), addStackedSeparator(), and stackedToString() for this layout.
+     * Each logical row of the table has one string per column. Use set_stacked_headers(),
+     * add_stacked_entry(), add_stacked_separator(), and stacked_to_string() for this layout.
      *
      * @param column_count Number of columns in the table
      * @param justification Column alignment for all columns
@@ -48,7 +48,7 @@ class Table2D {
      *
      * @param header_rows Stacked header rows, one vector of cell values per row
      */
-    void setStackedHeaders(const std::vector<std::vector<std::string>>& header_rows);
+    void set_stacked_headers(const std::vector<std::vector<std::string>>& header_rows);
 
     /**
      * @brief Add a stacked entry (multiple table rows sharing the same column widths).
@@ -58,24 +58,24 @@ class Table2D {
      *
      * @param entry_rows Stacked data rows for this entry
      */
-    void addStackedEntry(const std::vector<std::vector<std::string>>& entry_rows);
+    void add_stacked_entry(const std::vector<std::vector<std::string>>& entry_rows);
 
     /**
      * @brief Insert a separator line after the most recently added stacked entry.
      */
-    void addStackedSeparator();
+    void add_stacked_separator();
 
     /**
      * @brief Format a stacked table (headers, entries, and separators) as a string.
      *
      * @param prefix Leading whitespace before the first column delimiter on each row
      */
-    std::string stackedToString(const std::string& prefix = "") const;
+    std::string stacked_to_string(const std::string& prefix = "") const;
 
     /**
      * @return Number of columns in the table
      */
-    size_t columnCount() const
+    size_t column_count() const
     {
       return m_table.size();
     }
@@ -83,7 +83,7 @@ class Table2D {
     /**
      * @return true if the stacked table has no entries (headers may still be set)
      */
-    bool stackedEmpty() const
+    bool stacked_empty() const
     {
       return m_stacked_blocks.empty();
     }
@@ -140,10 +140,10 @@ class Table2D {
     void getBlankSizes(ColumnData col_data, size_t string_size, size_t& left_blanks, size_t& right_blanks) const;
     void addHeader(const HeaderData& header);
     void appendToOutput(std::string& output, const std::string& prefix, const std::string& suffix, const ColumnData& column, const std::string& data) const;
-    void updateStackedColumnWidth(size_t column_index, const std::string& data);
-    void validateStackedRow(const std::vector<std::string>& row, const char* context) const;
-    void formatDataRow(std::string& output_line, const std::string& prefix, const std::vector<std::string>& row) const;
-    void formatSeparatorRow(std::string& output_line, const std::string& prefix) const;
+    void update_stacked_column_width(size_t column_index, const std::string& data);
+    void validate_stacked_row(const std::vector<std::string>& row, const char* context) const;
+    void format_data_row(std::string& output_line, const std::string& prefix, const std::vector<std::string>& row) const;
+    void format_separator_row(std::string& output_line, const std::string& prefix) const;
 
  public:
     friend std::ostream&

--- a/src/runtime_src/core/tools/common/Table2D.h
+++ b/src/runtime_src/core/tools/common/Table2D.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2022 Xilinx, Inc
-// Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2022-2026 Advanced Micro Devices, Inc. All rights reserved.
 
 #ifndef __Table2D_h_
 #define __Table2D_h_
@@ -30,6 +30,65 @@ class Table2D {
     Table2D(const std::vector<HeaderData>& headers);
 
     /**
+     * @brief Construct a table for stacked (multi-row) headers and entries.
+     *
+     * Each logical row of the table has one string per column. Use setStackedHeaders(),
+     * addStackedEntry(), addStackedSeparator(), and stackedToString() for this layout.
+     *
+     * @param column_count Number of columns in the table
+     * @param justification Column alignment for all columns
+     */
+    explicit Table2D(size_t column_count, Justification justification = Justification::left);
+
+    /**
+     * @brief Set multi-row column headers for a stacked table.
+     *
+     * Each inner vector is one header row and must contain exactly column_count() strings.
+     * Column widths are updated from every non-empty cell across all header rows.
+     *
+     * @param header_rows Stacked header rows, one vector of cell values per row
+     */
+    void setStackedHeaders(const std::vector<std::vector<std::string>>& header_rows);
+
+    /**
+     * @brief Add a stacked entry (multiple table rows sharing the same column widths).
+     *
+     * Each inner vector is one row and must contain exactly column_count() strings.
+     * Empty strings may be used for cells that are unused on that row.
+     *
+     * @param entry_rows Stacked data rows for this entry
+     */
+    void addStackedEntry(const std::vector<std::vector<std::string>>& entry_rows);
+
+    /**
+     * @brief Insert a separator line after the most recently added stacked entry.
+     */
+    void addStackedSeparator();
+
+    /**
+     * @brief Format a stacked table (headers, entries, and separators) as a string.
+     *
+     * @param prefix Leading whitespace before the first column delimiter on each row
+     */
+    std::string stackedToString(const std::string& prefix = "") const;
+
+    /**
+     * @return Number of columns in the table
+     */
+    size_t columnCount() const
+    {
+      return m_table.size();
+    }
+
+    /**
+     * @return true if the stacked table has no entries (headers may still be set)
+     */
+    bool stackedEmpty() const
+    {
+      return m_stacked_blocks.empty();
+    }
+
+    /**
      * @brief Add an entry to the table. The entry must contain data for each header in the table.
      * 
      * @param entry_data A list of data elements that correspond the headers
@@ -54,6 +113,16 @@ class Table2D {
     }
 
  private:
+    enum class StackedBlockKind {
+        entry,
+        separator
+    };
+
+    struct StackedBlock {
+        StackedBlockKind kind;
+        std::vector<std::vector<std::string>> rows;
+    };
+
     typedef struct ColumnData {
         HeaderData header;
         std::vector<std::string> data;
@@ -62,12 +131,19 @@ class Table2D {
 
     std::vector<ColumnData> m_table;
     size_t m_inter_entry_padding;
+    bool m_stacked_mode = false;
+    std::vector<std::vector<std::string>> m_stacked_header_rows;
+    std::vector<StackedBlock> m_stacked_blocks;
 
     std::ostream& print(std::ostream& os) const;
 
     void getBlankSizes(ColumnData col_data, size_t string_size, size_t& left_blanks, size_t& right_blanks) const;
     void addHeader(const HeaderData& header);
     void appendToOutput(std::string& output, const std::string& prefix, const std::string& suffix, const ColumnData& column, const std::string& data) const;
+    void updateStackedColumnWidth(size_t column_index, const std::string& data);
+    void validateStackedRow(const std::vector<std::string>& row, const char* context) const;
+    void formatDataRow(std::string& output_line, const std::string& prefix, const std::vector<std::string>& row) const;
+    void formatSeparatorRow(std::string& output_line, const std::string& prefix) const;
 
  public:
     friend std::ostream&

--- a/src/runtime_src/core/tools/common/reports/ReportAiePartitions.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportAiePartitions.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
 
 // ------ I N C L U D E   F I L E S -------------------------------------------
 // Local - Include Files
@@ -11,6 +11,7 @@
 #include "tools/common/XBUtilitiesCore.h"
 
 #include <map>
+#include <string>
 #include <vector>
 
 // Populate the AIE Mem tile information from the input XRT device
@@ -128,54 +129,52 @@ writeReport(const xrt_core::device* /*_pDevice*/,
     _output << boost::str(boost::format("    Columns: [%s]\n") % column_string);
     _output << "    HW Contexts:\n";
 
-    const std::vector<std::string> headers = {
-      "      |PID                 |Ctx ID     |Submissions |Migrations  |Frame Evts  |Err  |Priority |",
-      "      |Process Name        |Status     |Completions |Suspensions |Layer Evts  |     |GOPS     |",
-      "      |Memory Usage        |Instr BO   |            |            |            |     |FPS      |",
-      "      |                    |           |            |            |            |     |Latency  |",
-      "      |====================|===========|============|============|============|=====|=========|"
-    };
+    // NOLINTNEXTLINE(readability-magic-numbers,cppcoreguidelines-avoid-magic-numbers)
+    Table2D hw_table(7);
+    hw_table.setStackedHeaders({
+      {"PID", "Ctx ID", "Submissions", "Migrations", "Frame Evts", "Err", "Priority"},
+      {"Process Name", "Status", "Completions", "Suspensions", "Layer Evts", "", "GOPS"},
+      {"Memory Usage", "Instr BO", "", "", "", "", "FPS"},
+      {"", "", "", "", "", "", "Latency"},
+    });
 
-    for (const auto& header : headers) {
-      _output << header << "\n";
-    }
-
-    std::vector<uint64_t> errors;
     for (const auto& pt_hw_context : partition.get_child("hw_contexts", empty_ptree)) {
       const auto& hw_context = pt_hw_context.second;
 
-      std::vector<boost::format> row_data;
-      row_data.emplace_back(boost::format("      |%-20s|%-11s|%-12s|%-12s|%-12s|%-5s|%-9s|")
-                   % hw_context.get<int>("pid")
-                   % hw_context.get<std::string>("context_id")
-                   % hw_context.get<uint64_t>("command_submissions")
-                   % hw_context.get<uint64_t>("migrations")
-                   % hw_context.get<uint64_t>("preemption_frame_event")
-                   % hw_context.get<uint64_t>("errors")
-                   % hw_context.get<std::string>("priority"));
-
-      row_data.emplace_back(boost::format("      |%-20s|%-11s|%-12s|%-12s|%-12s|     |%-9s|")
-                   % hw_context.get<std::string>("process_name")
-                   % hw_context.get<std::string>("status")
-                   % hw_context.get<uint64_t>("command_completions")
-                   % hw_context.get<uint64_t>("suspensions")
-                   % hw_context.get<uint64_t>("preemption_layer_event")
-                   % hw_context.get<std::string>("gops"));
-
-      row_data.emplace_back(boost::format("      |%-20s|%-11s|            |            |            |     |%-9s|")
-                   % hw_context.get<std::string>("memory_usage")
-                   % hw_context.get<std::string>("instr_bo_mem")
-                   % hw_context.get<std::string>("fps"));
-
-      row_data.emplace_back(boost::format("      |                    |           |            |            |            |     |%-9s|")
-                   % hw_context.get<std::string>("latency"));
-
-      row_data.emplace_back(boost::format("      |--------------------|-----------|------------|------------|------------|-----|---------|"));
-
-      for (const auto& row : row_data) {
-        _output << row << "\n";
-      }
+      hw_table.addStackedEntry({
+        {
+          std::to_string(hw_context.get<int>("pid")),
+          hw_context.get<std::string>("context_id"),
+          std::to_string(hw_context.get<uint64_t>("command_submissions")),
+          std::to_string(hw_context.get<uint64_t>("migrations")),
+          std::to_string(hw_context.get<uint64_t>("preemption_frame_event")),
+          std::to_string(hw_context.get<uint64_t>("errors")),
+          hw_context.get<std::string>("priority"),
+        },
+        {
+          hw_context.get<std::string>("process_name"),
+          hw_context.get<std::string>("status"),
+          std::to_string(hw_context.get<uint64_t>("command_completions")),
+          std::to_string(hw_context.get<uint64_t>("suspensions")),
+          std::to_string(hw_context.get<uint64_t>("preemption_layer_event")),
+          "",
+          hw_context.get<std::string>("gops"),
+        },
+        {
+          hw_context.get<std::string>("memory_usage"),
+          hw_context.get<std::string>("instr_bo_mem"),
+          "", "", "", "",
+          hw_context.get<std::string>("fps"),
+        },
+        {
+          "", "", "", "", "", "",
+          hw_context.get<std::string>("latency"),
+        },
+      });
+      hw_table.addStackedSeparator();
     }
+
+    _output << hw_table.stackedToString("      ");
   }
 
   if (XBUtilities::getVerbose()) {

--- a/src/runtime_src/core/tools/common/reports/ReportAiePartitions.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportAiePartitions.cpp
@@ -131,7 +131,7 @@ writeReport(const xrt_core::device* /*_pDevice*/,
 
     // NOLINTNEXTLINE(readability-magic-numbers,cppcoreguidelines-avoid-magic-numbers)
     Table2D hw_table(7);
-    hw_table.setStackedHeaders({
+    hw_table.set_stacked_headers({
       {"PID", "Ctx ID", "Submissions", "Migrations", "Frame Evts", "Err", "Priority"},
       {"Process Name", "Status", "Completions", "Suspensions", "Layer Evts", "", "GOPS"},
       {"Memory Usage", "Instr BO", "", "", "", "", "FPS"},
@@ -141,7 +141,7 @@ writeReport(const xrt_core::device* /*_pDevice*/,
     for (const auto& pt_hw_context : partition.get_child("hw_contexts", empty_ptree)) {
       const auto& hw_context = pt_hw_context.second;
 
-      hw_table.addStackedEntry({
+      hw_table.add_stacked_entry({
         {
           std::to_string(hw_context.get<int>("pid")),
           hw_context.get<std::string>("context_id"),
@@ -171,10 +171,10 @@ writeReport(const xrt_core::device* /*_pDevice*/,
           hw_context.get<std::string>("latency"),
         },
       });
-      hw_table.addStackedSeparator();
+      hw_table.add_stacked_separator();
     }
 
-    _output << hw_table.stackedToString("      ");
+    _output << hw_table.stacked_to_string("      ");
   }
 
   if (XBUtilities::getVerbose()) {


### PR DESCRIPTION
#### Problem solved by the commit
https://jira.xilinx.com/browse/AIESW-29594
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Too long process name was right-shifting table output, discovered during internal testing. This problem was due to some hardcoded header lengths that were introduced when first changing aie-partitions report table output.
#### How problem was solved, alternative solutions (if any) and why they were rejected
Introduce stacked functionality to Table2D, which uses some pre-existing Table2D methods to pre-calculate column width (and expand length to the longest element) before printing to output
#### Risks (if any) associated the changes in the commit
N/A, does not affect pre-existing Table2D construction
#### What has been tested and how, request additional testing if necessary
```
AIE Partitions
  Total Memory Usage: 1088 MB
  Partition Index   : 0
    Columns: [0, 1, 2, 3, 4, 5, 6, 7]
    HW Contexts:
      |PID                             |Ctx ID    |Submissions  |Migrations   |Frame Evts  |Err  |Priority  |
      |Process Name                    |Status    |Completions  |Suspensions  |Layer Evts  |     |GOPS      |
      |Memory Usage                    |Instr BO  |             |             |            |     |FPS       |
      |                                |          |             |             |            |     |Latency   |
      |--------------------------------|----------|-------------|-------------|------------|-----|----------|
      |10800                           |1         |26           |0            |0           |0    |Normal    |
      |xrt-smi-testing-validation.exe  |Active    |25           |0            |0           |     |N/A       |
      |1088 MB                         |64 KB     |             |             |            |     |N/A       |
      |                                |          |             |             |            |     |N/A       |
      |--------------------------------|----------|-------------|-------------|------------|-----|----------|
```
#### Documentation impact (if any)
N/A