### PR TITLE
Add trace points in functions that depends on user input

### DIFF
--- a/src/runtime_src/core/common/api/xrt_elf.cpp
+++ b/src/runtime_src/core/common/api/xrt_elf.cpp
@@ -12,6 +12,7 @@
 #include "core/common/config_reader.h"
 #include "core/common/error.h"
 #include "core/common/message.h"
+#include "core/common/trace.h"
 #include "core/common/xclbin_parser.h"
 
 #include <boost/interprocess/streams/bufferstream.hpp>
@@ -917,6 +918,7 @@ public:
   elf_aie_gen2(ELFIO::elfio&& elfio, elf::platform platform, std::string path)
     : elf_impl{std::move(elfio), platform, std::move(path)}
   {
+    XRT_TRACE_POINT_SCOPE(xrt_elf_aie_gen2);
     // Parse ELF sections to populate kernel and section maps
     parse_sections();
     // Initialize all section buffer maps
@@ -1362,6 +1364,7 @@ public:
   elf_aie_gen2_plus(ELFIO::elfio&& elfio, elf::platform platform, std::string path)
     : elf_impl{std::move(elfio), platform, std::move(path)}
   {
+    XRT_TRACE_POINT_SCOPE(xrt_elf_aie_gen2_plus);
     // Parse ELF sections to populate kernel and section maps
     parse_sections();
     // Initialize all section buffer maps

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -289,7 +289,7 @@ ctx_error_type_to_string(uint32_t ctx_error_type)
 
   if (ctx_error_type >= ctx_error_type_names.size())
     return "UNKNOWN";
-  
+
   return ctx_error_type_names[ctx_error_type];
 }
 
@@ -299,7 +299,7 @@ flags_to_string(uint32_t value, const std::array<std::pair<uint32_t, const char*
 {
   if (value == 0)
     return "NONE";
-  
+
   std::string result;
   uint32_t unknown = value;
   for (const auto& entry : flags) {
@@ -320,7 +320,7 @@ flags_to_string(uint32_t value, const std::array<std::pair<uint32_t, const char*
   }
   return result;
 }
-  
+
 // misc_status is a bit mask (ert_uc_health_info); OR known flags and report unknown bits.
 static std::string
 uc_misc_status_flags_to_string(uint32_t misc_status)
@@ -2584,6 +2584,7 @@ public:
   void
   set_dtrace_control_file(const std::string& path)
   {
+    XRT_TRACE_POINT_SCOPE(xrt_run_set_dtrace_control_file);
     std::lock_guard<std::mutex> lock(m_mutex);
     if (!m_module) {
       throw xrt_core::error(
@@ -2597,12 +2598,13 @@ public:
           "Cannot set dtrace control file: run has already been started and is "
           "still in progress");
 
+    xrt_core::module_int::set_dtrace_control_file(m_module, path);
+    if (m_dpu_payload)
+      xrt_core::module_int::fill_ert_dpu_data(m_module, m_dpu_payload);
+
+    // Store only after module and command payload are updated
+    // clone inherits this
     m_dtrace_control_file = path;
-    if (m_module) {
-      xrt_core::module_int::set_dtrace_control_file(m_module, path);
-      if (m_dpu_payload)
-        xrt_core::module_int::fill_ert_dpu_data(m_module, m_dpu_payload);
-    }
   }
 
   // run_type() - constructor
@@ -3067,7 +3069,7 @@ public:
   {
     if (state != ERT_CMD_STATE_TIMEOUT)
       return;
-    
+
     auto file = xrt_core::config::get_aie_coredump_file();
     if (file.empty())
       return;
@@ -4908,10 +4910,10 @@ aie_error_message_v1(const ert_packet* epkt, const std::string& msg,
   // (e.g. ELF loaded from a buffer rather than a file path).
   if (!kernel_instance.empty())
     oss << "Kernel Instance: " << kernel_instance;
-  
+
   if (!elf_filename.empty())
     oss << "\nELF File:        " << elf_filename;
-  
+
   if (!elf_uuid.empty())
     oss << "\nELF UUID:        " << elf_uuid;
 

--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -5,6 +5,8 @@
 #define XRT_CORE_COMMON_SOURCE // in same dll as core_common
 #include "core/common/config_reader.h"
 #include "core/common/message.h"
+#include "core/common/trace.h"
+
 #include "xrt/experimental/xrt_module.h"
 #include "xrt/experimental/xrt_aie.h"
 #include "xrt/experimental/xrt_elf.h"
@@ -555,6 +557,7 @@ public:
     : module_run(elf, hw_context, id)
     , m_config(std::get<xrt::module_config_aie_gen2>(m_elf_impl->get_module_config(id)))
   {
+    XRT_TRACE_POINT_SCOPE(xrt_module_run_aie_gen2);
     create_ctrlpkt_buf(ctrlpkt_bo);
     create_ctrlpkt_pm_bufs();
     create_instruction_buf();
@@ -1026,6 +1029,7 @@ public:
     : module_run(elf, hw_context, id)
     , m_config(std::get<xrt::module_config_aie_gen2_plus>(m_elf_impl->get_module_config(id)))
   {
+    XRT_TRACE_POINT_SCOPE(xrt_module_run_aie_gen2_plus);
     initialize_dtrace_buf("");  // use config path by default
     create_ctrlpkt_bufs();
     create_instruction_buffer();


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Added new trace points in xrt classes that depend on user input
During earlier debugs we identified bottlenecks while creating objects like xrt::run, xrt::elf etc, so added trace points at such places

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
#### How problem was solved, alternative solutions (if any) and why they were rejected
Added new trace points
Using tools like perf we can capture trace data and analyze bottlenecks

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
Tested trace data captured by running test on Telluride and things work as expected

#### Documentation impact (if any)
NA