### PR TITLE
CR-1253753: Skip CU creation for AIE-only xclbin in zocl driver

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/edge/zocl_edge_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/edge/zocl_edge_xclbin.c
@@ -317,17 +317,20 @@ zocl_xclbin_read_axlf(struct drm_zocl_dev *zdev, struct drm_zocl_axlf *axlf_obj,
 
 	zocl_xclbin_set_uuid(zdev, slot, &axlf_head.m_header.uuid);
 
-	/* Destroy the CUs specific for this slot */
-	zocl_destroy_cu_slot(zdev, slot->slot_idx);
+	/* Skip creating CUs for AIE only xclbin */
+	if (!zocl_xclbin_is_aie_only(axlf)) {
+		/* Destroy the CUs specific for this slot */
+		zocl_destroy_cu_slot(zdev, slot->slot_idx);
 
-	/* Create the CUs for this slot */
-	ret = zocl_create_cu(zdev, slot);
-	if (ret)
-		goto out0;
+		/* Create the CUs for this slot */
+		ret = zocl_create_cu(zdev, slot);
+		if (ret)
+			goto out0;
 
-	ret = zocl_kds_update(zdev, slot, &axlf_obj->kds_cfg);
-	if (ret)
-		goto out0;
+		ret = zocl_kds_update(zdev, slot, &axlf_obj->kds_cfg);
+		if (ret)
+			goto out0;
+	}
 
 	DRM_INFO("xclbin %pUb successfully loaded to slot %d\n",
 			zocl_xclbin_get_uuid(slot), slot_id);


### PR DESCRIPTION
AIE-only xclbins may contain PL CU entries in their IP_LAYOUT section. During hw_context creation, the zocl driver probes these CUs and reads their control registers via ioread32. If the AXI bus is blocked (e.g. during VSS reset), this read hangs the kernel thread indefinitely.

Skip CU destroy/create/kds_update for AIE-only xclbins since PL CUs belong to slot 0 and should not be probed from AIE-only slots.

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Hard hang during second AIE hw_context creation after asserting VSS reset without releasing it on edge.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://jira.xilinx.com/browse/CR-1253753
It's not a bug but due to recent V++ change. AIE only xclbins can have PL kernels in its IP_LAYOUT section. On each xclbin load ZOCL driver probes all the CUs present on a xclbin and reads their valid control registers which is causing issue for VSS reset usecases. After asserting a VSS reset without releasing it if xclbin gets loaded the valid control register read gets blocked and causes a hard hang.
#### How problem was solved, alternative solutions (if any) and why they were rejected
Skip CU creation (destroy/create/kds_update) in zocl_xclbin_read_axlf
when the xclbin is AIE-only
#### Risks (if any) associated the changes in the commit
Low. No functional change for non-AIE only xclbins. Assumption is AIE only xclbin will not have any PL kernels and host application will not use the pl kernels present in the AIE only xclbins which is also not a correct usecase. 
#### What has been tested and how, request additional testing if necessary
Verified on an edge board with VSS reset usecases that previously hung. With this fix test now passes each and everytime without any hangs or errors.
#### Documentation impact (if any)
None