### PR TITLE
xbmgmt2: use XBMGMT2_NAME in XRT_EDGE target_compile_definitions

### DIFF
--- a/src/runtime_src/core/tools/xbmgmt2/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbmgmt2/CMakeLists.txt
@@ -65,7 +65,7 @@ add_executable(${XBMGMT2_NAME} ${XBMGMT_V2_SRCS})
 if (NOT XRT_EDGE)
   target_compile_definitions(${XBMGMT2_NAME} PRIVATE ENABLE_NATIVE_SUBCMDS_AND_REPORTS)
 else()
-  target_compile_definitions(${XBUTIL2_NAME} PRIVATE ENABLE_DEFAULT_ONE_DEVICE_OPTION)
+  target_compile_definitions(${XBMGMT2_NAME} PRIVATE ENABLE_DEFAULT_ONE_DEVICE_OPTION)
 endif()
 
 # Static build is a Linux / Ubuntu option only


### PR DESCRIPTION
Fixes #9829.

## Summary

`src/runtime_src/core/tools/xbmgmt2/CMakeLists.txt` references `${XBUTIL2_NAME}` in its `XRT_EDGE` branch when calling `target_compile_definitions`. `XBUTIL2_NAME` is defined in the sibling `xbutil2/CMakeLists.txt` and is not visible in this directory scope, so it expands to an empty string. CMake then parses the call as `target_compile_definitions(PRIVATE ENABLE_DEFAULT_ONE_DEVICE_OPTION)` and aborts configure with:

```
CMake Error at src/runtime_src/core/tools/xbmgmt2/CMakeLists.txt:68 (target_compile_definitions):
  Cannot specify compile definitions for target "PRIVATE" which is not built
  by this project.
```

The non-edge branch above already uses the correct `${XBMGMT2_NAME}`. This change makes the edge branch consistent.

## Reproduction (before this PR)

```
cmake -S src -B build -DXRT_EDGE=ON -DXRT_AIE_BUILD=ON
```

Configure fails as above. With this patch, configure proceeds past xbmgmt2.

## Impact

- Configure fails for any build that sets `-DXRT_EDGE=ON` (arm64 / edge / Zynq).
- Native PCIe builds (`-DXRT_EDGE` unset or `OFF`) are unaffected — the else-branch is never entered.

## Notes

- One-line cmake fix, no behavioural change for the non-edge path.
- DCO sign-off added in commit.