### PR TITLE
Add build timestamp to CMake configure phase for CI diagnostics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,10 @@
 # Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
 cmake_minimum_required(VERSION 3.5...4.0)
 
+# Print build timestamp for diagnostics
+execute_process(COMMAND date OUTPUT_VARIABLE BUILD_TIMESTAMP OUTPUT_STRIP_TRAILING_WHITESPACE)
+message("-- Build timestamp: ${BUILD_TIMESTAMP}")
+
 message("-- CMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}")
 
 # Enable testing for this directory and below.  This command should be


### PR DESCRIPTION
## Summary
Add `execute_process(COMMAND date)` to CMakeLists.txt to print a build timestamp during the configure phase. This helps with CI debugging by providing a clear time reference in build logs.

## Changes
- Added `execute_process(COMMAND date ...)` after `cmake_minimum_required`
- Timestamp is printed as `-- Build timestamp: <date output>` alongside other CMake messages

## Testing
- Tested locally with `cmake -B build`, timestamp is printed without affecting build configuration