### PR TITLE
AIESW-28663 : Add syslog equivalent message dispatcher for Windows

### DIFF
--- a/src/runtime_src/core/common/CMakeLists.txt
+++ b/src/runtime_src/core/common/CMakeLists.txt
@@ -141,10 +141,6 @@ if (WIN32)
     PUBLIC
     $<INSTALL_INTERFACE:/MT$<$<CONFIG:Debug>:d>>
     )
-
-  # Advapi32 is required for Windows Event Log API used in syslog_dispatch (message.cpp)
-  target_link_libraries(xrt_coreutil PRIVATE Advapi32)
-  target_link_libraries(xrt_coreutil_static INTERFACE Advapi32)
 endif()
 
 if (NOT WIN32)

--- a/src/runtime_src/core/common/CMakeLists.txt
+++ b/src/runtime_src/core/common/CMakeLists.txt
@@ -141,6 +141,10 @@ if (WIN32)
     PUBLIC
     $<INSTALL_INTERFACE:/MT$<$<CONFIG:Debug>:d>>
     )
+
+  # Advapi32 is required for Windows Event Log API used in syslog_dispatch (message.cpp)
+  target_link_libraries(xrt_coreutil PRIVATE Advapi32)
+  target_link_libraries(xrt_coreutil_static INTERFACE Advapi32)
 endif()
 
 if (NOT WIN32)

--- a/src/runtime_src/core/common/detail/linux/syslog.h
+++ b/src/runtime_src/core/common/detail/linux/syslog.h
@@ -8,7 +8,7 @@
 #include <map>
 #include <syslog.h>
 
-namespace xrt_core { namespace message {
+namespace xrt_core::message {
 
 class syslog_dispatch : public message_dispatch
 {
@@ -16,7 +16,12 @@ public:
   syslog_dispatch()
   { openlog("sdaccel", LOG_PID|LOG_CONS, LOG_USER); }
 
-  ~syslog_dispatch()
+  syslog_dispatch(const syslog_dispatch&) = delete;
+  syslog_dispatch& operator=(const syslog_dispatch&) = delete;
+  syslog_dispatch(syslog_dispatch&&) = delete;
+  syslog_dispatch& operator=(syslog_dispatch&&) = delete;
+
+  ~syslog_dispatch() override
   { closelog(); }
 
   void
@@ -36,4 +41,4 @@ private:
   };
 };
 
-}} // xrt_core::message
+} // xrt_core::message

--- a/src/runtime_src/core/common/detail/linux/syslog.h
+++ b/src/runtime_src/core/common/detail/linux/syslog.h
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+// POSIX syslog implementation of syslog_dispatch.
+
+#include "core/common/message.h"
+
+#include <map>
+#include <syslog.h>
+
+namespace xrt_core { namespace message {
+
+class syslog_dispatch : public message_dispatch
+{
+public:
+  syslog_dispatch()
+  { openlog("sdaccel", LOG_PID|LOG_CONS, LOG_USER); }
+
+  ~syslog_dispatch()
+  { closelog(); }
+
+  void
+  send(severity_level l, const char* tag, const char* msg) override
+  { syslog(m_severity_map[l], "%s", msg); }
+
+private:
+  std::map<severity_level, int> m_severity_map = {
+    { severity_level::emergency, LOG_EMERG   },
+    { severity_level::alert,     LOG_ALERT   },
+    { severity_level::critical,  LOG_CRIT    },
+    { severity_level::error,     LOG_ERR     },
+    { severity_level::warning,   LOG_WARNING },
+    { severity_level::notice,    LOG_NOTICE  },
+    { severity_level::info,      LOG_INFO    },
+    { severity_level::debug,     LOG_DEBUG   }
+  };
+};
+
+}} // xrt_core::message

--- a/src/runtime_src/core/common/detail/syslog.h
+++ b/src/runtime_src/core/common/detail/syslog.h
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#ifndef core_common_detail_syslog_h
+#define core_common_detail_syslog_h
+
+#ifdef _WIN32
+# include "core/common/detail/windows/syslog.h"
+#else
+# include "core/common/detail/linux/syslog.h"
+#endif
+
+#endif

--- a/src/runtime_src/core/common/detail/windows/syslog.h
+++ b/src/runtime_src/core/common/detail/windows/syslog.h
@@ -17,11 +17,12 @@
 
 #include "core/common/message.h"
 
+#include <array>
 #include <iostream>
 #include <string>
 #include <windows.h>
 
-namespace xrt_core { namespace message {
+namespace xrt_core::message {
 
 class syslog_dispatch : public message_dispatch
 {
@@ -41,7 +42,12 @@ public:
                 << "(error " << GetLastError() << "). Logging disabled.\n";
   }
 
-  ~syslog_dispatch()
+  syslog_dispatch(const syslog_dispatch&) = delete;
+  syslog_dispatch& operator=(const syslog_dispatch&) = delete;
+  syslog_dispatch(syslog_dispatch&&) = delete;
+  syslog_dispatch& operator=(syslog_dispatch&&) = delete;
+
+  ~syslog_dispatch() override
   {
     if (m_handle)
       DeregisterEventSource(m_handle);
@@ -54,37 +60,32 @@ public:
       return;
 
     std::string full_msg = std::string("[") + tag + "] : " + msg;
-    LPCSTR strings[] = {full_msg.c_str()};
+    std::array<LPCSTR, 1> strings = {full_msg.c_str()};
     // Event ID 1 matches the pass-through entry in EventCreate.exe's message
     // table (%1), so Event Viewer displays our text directly without a warning.
     // Severity filtering uses wType (Level column), not event ID.
     static constexpr DWORD event_id = 1;
     ReportEventA(m_handle, to_event_type(l), 0, event_id,
-                 nullptr, 1, 0, strings, nullptr);
+                 nullptr, 1, 0, strings.data(), nullptr);
   }
 
 private:
   HANDLE m_handle = nullptr;
 
   // Maps XRT severity to Windows event type (controls icon in Event Viewer):
-  //   EVENTLOG_ERROR_TYPE       -> red X
+  //   EVENTLOG_ERROR_TYPE       -> red X   (emergency/alert/critical/error)
   //   EVENTLOG_WARNING_TYPE     -> yellow triangle
-  //   EVENTLOG_INFORMATION_TYPE -> blue i
+  //   EVENTLOG_INFORMATION_TYPE -> blue i  (notice/info/debug)
   static WORD
   to_event_type(severity_level l)
   {
-    switch (l) {
-    case severity_level::emergency:
-    case severity_level::alert:
-    case severity_level::critical:
-    case severity_level::error:
-      return EVENTLOG_ERROR_TYPE;
-    case severity_level::warning:
+    if (l == severity_level::warning)
       return EVENTLOG_WARNING_TYPE;
-    default:
-      return EVENTLOG_INFORMATION_TYPE;
-    }
+    if (l == severity_level::emergency || l == severity_level::alert ||
+        l == severity_level::critical  || l == severity_level::error)
+      return EVENTLOG_ERROR_TYPE;
+    return EVENTLOG_INFORMATION_TYPE;
   }
 };
 
-}} // xrt_core::message
+} // xrt_core::message

--- a/src/runtime_src/core/common/detail/windows/syslog.h
+++ b/src/runtime_src/core/common/detail/windows/syslog.h
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+// Windows Event Log implementation of syslog_dispatch.
+// Routes XRT messages to the Application event log under source "AMD_XRT".
+//
+// Filter in Event Viewer:
+//   Windows Logs -> Application -> Source: AMD_XRT
+// Filter via PowerShell:
+//   Get-EventLog -LogName Application -Source "AMD_XRT"
+//   Get-EventLog -LogName Application -Source "AMD_XRT" -EntryType Error
+//   Get-EventLog -LogName Application -Source "AMD_XRT" -EntryType Error,Warning
+// Filter via cmd (Level: 2=Error, 3=Warning, 4=Information):
+//   wevtutil qe Application /q:"*[System[Provider[@Name='AMD_XRT']]]" /f:text
+//   wevtutil qe Application /q:"*[System[Provider[@Name='AMD_XRT'] and Level=2]]" /f:text
+//   wevtutil qe Application /q:"*[System[Provider[@Name='AMD_XRT'] and (Level=2 or Level=3)]]" /f:text
+
+#include "core/common/message.h"
+
+#include <iostream>
+#include <string>
+#include <windows.h>
+
+namespace xrt_core { namespace message {
+
+class syslog_dispatch : public message_dispatch
+{
+public:
+  syslog_dispatch()
+  {
+    // RegisterEventSourceA opens a handle to the Application event log and
+    // associates it with the source name "AMD_XRT".  Registry registration of
+    // "AMD_XRT" as a known source is done at driver install time via the INF
+    // AddReg directive.  This call does not require admin rights.
+    m_handle = RegisterEventSourceA(nullptr, "AMD_XRT");
+    // Do not throw on failure: this is constructed lazily on first
+    // xrt_core::message::send(), so a throw here would crash the application
+    // if the Windows Event Log service is unavailable.
+    if (!m_handle)
+      std::cerr << "XRT: Failed to open Windows Event Log source 'AMD_XRT' "
+                << "(error " << GetLastError() << "). Logging disabled.\n";
+  }
+
+  ~syslog_dispatch()
+  {
+    if (m_handle)
+      DeregisterEventSource(m_handle);
+  }
+
+  void
+  send(severity_level l, const char* tag, const char* msg) override
+  {
+    if (!m_handle)
+      return;
+
+    std::string full_msg = std::string("[") + tag + "] : " + msg;
+    LPCSTR strings[] = {full_msg.c_str()};
+    // Event ID 1 matches the pass-through entry in EventCreate.exe's message
+    // table (%1), so Event Viewer displays our text directly without a warning.
+    // Severity filtering uses wType (Level column), not event ID.
+    static constexpr DWORD event_id = 1;
+    ReportEventA(m_handle, to_event_type(l), 0, event_id,
+                 nullptr, 1, 0, strings, nullptr);
+  }
+
+private:
+  HANDLE m_handle = nullptr;
+
+  // Maps XRT severity to Windows event type (controls icon in Event Viewer):
+  //   EVENTLOG_ERROR_TYPE       -> red X
+  //   EVENTLOG_WARNING_TYPE     -> yellow triangle
+  //   EVENTLOG_INFORMATION_TYPE -> blue i
+  static WORD
+  to_event_type(severity_level l)
+  {
+    switch (l) {
+    case severity_level::emergency:
+    case severity_level::alert:
+    case severity_level::critical:
+    case severity_level::error:
+      return EVENTLOG_ERROR_TYPE;
+    case severity_level::warning:
+      return EVENTLOG_WARNING_TYPE;
+    default:
+      return EVENTLOG_INFORMATION_TYPE;
+    }
+  }
+};
+
+}} // xrt_core::message

--- a/src/runtime_src/core/common/detail/windows/syslog.h
+++ b/src/runtime_src/core/common/detail/windows/syslog.h
@@ -22,6 +22,8 @@
 #include <string>
 #include <windows.h>
 
+#pragma comment(lib, "Advapi32.lib") // for Windows Event Log APIs
+
 namespace xrt_core::message {
 
 class syslog_dispatch : public message_dispatch

--- a/src/runtime_src/core/common/message.cpp
+++ b/src/runtime_src/core/common/message.cpp
@@ -166,25 +166,23 @@ send(severity_level l, const char* tag, const char* msg)
 
 namespace xrt_core { namespace message {
 
-message_dispatch*
+std::unique_ptr<message_dispatch>
 message_dispatch::
 make_dispatcher(const std::string& choice)
 {
   if ((choice == "null") || (choice == ""))
-    return new null_dispatch;
-  else if (choice == "console")
-    return new console_dispatch;
-  else if (choice == "syslog")
-    return new syslog_dispatch;
-  else {
-    if (choice.front() == '"') {
-      std::string file = choice;
-      file.erase(0, 1);
-      file.erase(file.size()-1);
-      return new file_dispatch(file);
-    }
-    return new file_dispatch(choice);
+    return std::make_unique<null_dispatch>();
+  if (choice == "console")
+    return std::make_unique<console_dispatch>();
+  if (choice == "syslog")
+    return std::make_unique<syslog_dispatch>();
+
+  std::string file = choice;
+  if (file.front() == '"') {
+    file.erase(0, 1);
+    file.erase(file.size()-1);
   }
+  return std::make_unique<file_dispatch>(file);
 }
 
 void
@@ -195,7 +193,7 @@ send(severity_level l, const char* tag, const char* msg)
   int lev = static_cast<int>(l);
 
   if(ver >= lev) {
-    static message_dispatch* dispatcher = message_dispatch::make_dispatcher(logger);
+    static auto dispatcher = message_dispatch::make_dispatcher(logger);
     dispatcher->send(l, tag, msg);
   }
 }

--- a/src/runtime_src/core/common/message.cpp
+++ b/src/runtime_src/core/common/message.cpp
@@ -26,6 +26,8 @@
 #endif
 #ifdef _WIN32
 # include <winsock.h>
+// Windows Event Log API - required for syslog_dispatch
+# include <windows.h>
 #endif
 
 namespace {
@@ -82,6 +84,7 @@ public:
   console_dispatch();
   virtual ~console_dispatch() {}
   virtual void send(severity_level l, const char* tag, const char* msg) override;
+
 private:
   std::map<severity_level, const char*> severityMap = {
     { severity_level::emergency, "EMERGENCY: "},
@@ -95,8 +98,88 @@ private:
   };
 };
 
-//--
-#ifndef _WIN32
+// syslog_dispatch: routes to the OS-level centralized log on each platform.
+// Linux   -> POSIX syslog (/var/log/syslog)
+//
+// Windows -> Windows Application Event Log under source "AMD_XRT"
+// Filter in Event Viewer:
+//   Windows Logs -> Application -> Source: AMD_XRT
+// Filter via PowerShell:
+//   Get-EventLog -LogName Application -Source "AMD_XRT"                        -- all
+//   Get-EventLog -LogName Application -Source "AMD_XRT" -EntryType Error       -- errors only
+//   Get-EventLog -LogName Application -Source "AMD_XRT" -EntryType Error,Warning
+// Filter via cmd line (Level: 2=Error, 3=Warning, 4=Information):
+//   wevtutil qe Application /q:"*[System[Provider[@Name='AMD_XRT']]]" /f:text
+//   wevtutil qe Application /q:"*[System[Provider[@Name='AMD_XRT'] and Level=2]]" /f:text
+//   wevtutil qe Application /q:"*[System[Provider[@Name='AMD_XRT'] and (Level=2 or Level=3)]]" /f:text
+#ifdef _WIN32
+class syslog_dispatch : public message_dispatch
+{
+public:
+  syslog_dispatch()
+  {
+    // RegisterEventSourceA opens a handle to the Application event log and
+    // associates it with the source name "AMD_XRT". This handle is used in
+    // every subsequent ReportEventA call to stamp events with that source name.
+    // First arg (nullptr) means the local machine; a UNC server name can be
+    // passed to write to a remote machine's event log.
+    // This call does NOT require admin rights and does NOT touch the registry —
+    // it only opens a write channel. Registry registration of "AMD_XRT" as a
+    // known source is done separately at driver install time via the INF AddReg
+    // directive
+    m_handle = RegisterEventSourceA(nullptr, "AMD_XRT");
+    if (!m_handle)
+      throw std::runtime_error("Failed to register Windows event source 'AMD_XRT'");
+  }
+
+  virtual ~syslog_dispatch()
+  {
+    if (m_handle)
+      DeregisterEventSource(m_handle);
+  }
+
+  virtual void
+  send(severity_level l, const char* tag, const char* msg) override
+  {
+    if (!m_handle)
+      return;
+    // Combine tag and message so Event Viewer shows "[xrt_elf] : some message"
+    std::string full_msg = std::string("[") + tag + "] : " + msg;
+    LPCSTR strings[] = {full_msg.c_str()};
+    // Event ID 1 matches the pass-through entry in EventCreate.exe's message table
+    // (%1 format string), so Event Viewer displays our message text directly
+    // without the warning.
+    // Severity filtering in Event Viewer uses wType (Level column), not event ID.
+    static constexpr DWORD event_id = 1;
+    ReportEventA(m_handle, to_event_type(l), 0, event_id,
+                 nullptr, 1, 0, strings, nullptr);
+  }
+
+private:
+  HANDLE m_handle = nullptr;
+
+  // Maps XRT severity to Windows event type (controls icon in Event Viewer):
+  //   EVENTLOG_ERROR_TYPE       -> red X
+  //   EVENTLOG_WARNING_TYPE     -> yellow triangle
+  //   EVENTLOG_INFORMATION_TYPE -> blue i
+  static WORD
+  to_event_type(severity_level l)
+  {
+    switch (l) {
+    case severity_level::emergency:
+    case severity_level::alert:
+    case severity_level::critical:
+    case severity_level::error:
+      return EVENTLOG_ERROR_TYPE;
+    case severity_level::warning:
+      return EVENTLOG_WARNING_TYPE;
+    default:
+      return EVENTLOG_INFORMATION_TYPE;
+    }
+  }
+
+};
+#else
 class syslog_dispatch : public message_dispatch
 {
 public:
@@ -106,10 +189,12 @@ public:
   virtual ~syslog_dispatch()
   { closelog(); }
 
-  virtual void send(severity_level l, const char* tag, const char* msg) override
+  virtual void
+  send(severity_level l, const char* tag, const char* msg) override
   { syslog(severityMap[l], "%s", msg); }
 
 private:
+  // Maps XRT severity to POSIX syslog priority
   std::map<severity_level, int> severityMap = {
     { severity_level::emergency, LOG_EMERG},
     { severity_level::alert,     LOG_ALERT},
@@ -154,13 +239,8 @@ make_dispatcher(const std::string& choice)
     return new null_dispatch;
   else if(choice == "console")
     return new console_dispatch;
-  else if(choice == "syslog") {
-#ifndef _WIN32
+  else if(choice == "syslog")
     return new syslog_dispatch;
-#else
-    throw std::runtime_error("syslog not supported on windows");
-#endif
-  }
   else {
     if(choice.front() == '"') {
       std::string file = choice;

--- a/src/runtime_src/core/common/message.cpp
+++ b/src/runtime_src/core/common/message.cpp
@@ -7,6 +7,8 @@
 #include "config_reader.h"
 #include "utils.h"
 
+#include "detail/syslog.h"  // for syslog_dispatch
+
 #include "xrt/detail/version-git.h"
 
 #include <algorithm>
@@ -19,15 +21,9 @@
 #include <mutex>
 #include <thread>
 #ifdef __linux__
-# include <syslog.h>
 # include <linux/limits.h>
 # include <sys/stat.h>
 # include <sys/types.h>
-#endif
-#ifdef _WIN32
-# include <winsock.h>
-// Windows Event Log API - required for syslog_dispatch
-# include <windows.h>
 #endif
 
 namespace {
@@ -56,17 +52,7 @@ get_exe_path()
 
 
 using severity_level = xrt_core::message::severity_level;
-
-//--
-class message_dispatch
-{
-public:
-  message_dispatch() {}
-  virtual ~message_dispatch() {}
-  static message_dispatch* make_dispatcher(const std::string& choice);
-public:
-  virtual void send(severity_level l, const char* tag, const char* msg) = 0;
-};
+using message_dispatch = xrt_core::message::message_dispatch;
 
 //--
 class null_dispatch : public message_dispatch
@@ -98,122 +84,6 @@ private:
   };
 };
 
-// syslog_dispatch: routes to the OS-level centralized log on each platform.
-// Linux   -> POSIX syslog
-//
-// Windows -> Windows Application Event Log under source "AMD_XRT"
-// Filter in Event Viewer:
-//   Windows Logs -> Application -> Source: AMD_XRT
-// Filter via PowerShell:
-//   Get-EventLog -LogName Application -Source "AMD_XRT"                        -- all
-//   Get-EventLog -LogName Application -Source "AMD_XRT" -EntryType Error       -- errors only
-//   Get-EventLog -LogName Application -Source "AMD_XRT" -EntryType Error,Warning
-// Filter via cmd line (Level: 2=Error, 3=Warning, 4=Information):
-//   wevtutil qe Application /q:"*[System[Provider[@Name='AMD_XRT']]]" /f:text
-//   wevtutil qe Application /q:"*[System[Provider[@Name='AMD_XRT'] and Level=2]]" /f:text
-//   wevtutil qe Application /q:"*[System[Provider[@Name='AMD_XRT'] and (Level=2 or Level=3)]]" /f:text
-#ifdef _WIN32
-class syslog_dispatch : public message_dispatch
-{
-public:
-  syslog_dispatch()
-  {
-    // RegisterEventSourceA opens a handle to the Application event log and
-    // associates it with the source name "AMD_XRT". This handle is used in
-    // every subsequent ReportEventA call to stamp events with that source name.
-    // First arg (nullptr) means the local machine; a UNC server name can be
-    // passed to write to a remote machine's event log.
-    // This call does NOT require admin rights and does NOT touch the registry —
-    // it only opens a write channel. Registry registration of "AMD_XRT" as a
-    // known source is done separately at driver install time via the INF AddReg
-    // directive
-    m_handle = RegisterEventSourceA(nullptr, "AMD_XRT");
-    // Do not throw on failure — syslog_dispatch is constructed lazily on the
-    // first call to xrt_core::message::send(), so a throw here would crash the
-    // application during normal logging if the Windows Event Log service is
-    // unavailable.
-    if (!m_handle)
-      std::cerr << "XRT: Failed to open Windows Event Log source 'AMD_XRT' "
-                << "(error " << GetLastError() << "). Logging disabled.\n";
-  }
-
-  virtual ~syslog_dispatch()
-  {
-    if (m_handle)
-      DeregisterEventSource(m_handle);
-  }
-
-  void
-  send(severity_level l, const char* tag, const char* msg) override
-  {
-    if (!m_handle)
-      return; // Logging is unavailable if we failed to open the event source
-
-    // Combine tag and message so Event Viewer shows "[xrt_elf] : some message"
-    std::string full_msg = std::string("[") + tag + "] : " + msg;
-    LPCSTR strings[] = {full_msg.c_str()};
-    // Event ID 1 matches the pass-through entry in EventCreate.exe's message table
-    // (%1 format string), so Event Viewer displays our message text directly
-    // without the warning.
-    // Severity filtering in Event Viewer uses wType (Level column), not event ID.
-    static constexpr DWORD event_id = 1;
-    ReportEventA(m_handle, to_event_type(l), 0, event_id,
-                 nullptr, 1, 0, strings, nullptr);
-  }
-
-private:
-  HANDLE m_handle = nullptr;
-
-  // Maps XRT severity to Windows event type (controls icon in Event Viewer):
-  //   EVENTLOG_ERROR_TYPE       -> red X
-  //   EVENTLOG_WARNING_TYPE     -> yellow triangle
-  //   EVENTLOG_INFORMATION_TYPE -> blue i
-  static WORD
-  to_event_type(severity_level l)
-  {
-    switch (l) {
-    case severity_level::emergency:
-    case severity_level::alert:
-    case severity_level::critical:
-    case severity_level::error:
-      return EVENTLOG_ERROR_TYPE;
-    case severity_level::warning:
-      return EVENTLOG_WARNING_TYPE;
-    default:
-      return EVENTLOG_INFORMATION_TYPE;
-    }
-  }
-
-};
-#else
-class syslog_dispatch : public message_dispatch
-{
-public:
-  syslog_dispatch()
-  { openlog("sdaccel", LOG_PID|LOG_CONS, LOG_USER); }
-
-  virtual ~syslog_dispatch()
-  { closelog(); }
-
-  void
-  send(severity_level l, const char* tag, const char* msg) override
-  { syslog(severityMap[l], "%s", msg); }
-
-private:
-  // Maps XRT severity to POSIX syslog priority
-  std::map<severity_level, int> severityMap = {
-    { severity_level::emergency, LOG_EMERG},
-    { severity_level::alert,     LOG_ALERT},
-    { severity_level::critical,  LOG_CRIT},
-    { severity_level::error,     LOG_ERR},
-    { severity_level::warning,   LOG_WARNING},
-    { severity_level::notice,    LOG_NOTICE},
-    { severity_level::info,      LOG_INFO},
-    { severity_level::debug,     LOG_DEBUG}
-  };
-};
-#endif
-
 //--
 class file_dispatch : public message_dispatch
 {
@@ -235,29 +105,6 @@ private:
     { severity_level::debug,     "DEBUG: "}
   };
 };
-
-//-------
-message_dispatch*
-message_dispatch::
-make_dispatcher(const std::string& choice)
-{
-  if( (choice == "null") || (choice == ""))
-    return new null_dispatch;
-  else if(choice == "console")
-    return new console_dispatch;
-  else if(choice == "syslog")
-    return new syslog_dispatch;
-  else {
-    if(choice.front() == '"') {
-      std::string file = choice;
-      file.erase(0, 1);
-      file.erase(file.size()-1);
-      return new file_dispatch(file);
-    }
-    else
-      return new file_dispatch(choice);
-  }
-}
 
 //file ops
 file_dispatch::
@@ -318,6 +165,27 @@ send(severity_level l, const char* tag, const char* msg)
 } //end unnamed namespace
 
 namespace xrt_core { namespace message {
+
+message_dispatch*
+message_dispatch::
+make_dispatcher(const std::string& choice)
+{
+  if ((choice == "null") || (choice == ""))
+    return new null_dispatch;
+  else if (choice == "console")
+    return new console_dispatch;
+  else if (choice == "syslog")
+    return new syslog_dispatch;
+  else {
+    if (choice.front() == '"') {
+      std::string file = choice;
+      file.erase(0, 1);
+      file.erase(file.size()-1);
+      return new file_dispatch(file);
+    }
+    return new file_dispatch(choice);
+  }
+}
 
 void
 send(severity_level l, const char* tag, const char* msg)

--- a/src/runtime_src/core/common/message.cpp
+++ b/src/runtime_src/core/common/message.cpp
@@ -99,7 +99,7 @@ private:
 };
 
 // syslog_dispatch: routes to the OS-level centralized log on each platform.
-// Linux   -> POSIX syslog (/var/log/syslog)
+// Linux   -> POSIX syslog
 //
 // Windows -> Windows Application Event Log under source "AMD_XRT"
 // Filter in Event Viewer:
@@ -128,8 +128,13 @@ public:
     // known source is done separately at driver install time via the INF AddReg
     // directive
     m_handle = RegisterEventSourceA(nullptr, "AMD_XRT");
+    // Do not throw on failure — syslog_dispatch is constructed lazily on the
+    // first call to xrt_core::message::send(), so a throw here would crash the
+    // application during normal logging if the Windows Event Log service is
+    // unavailable.
     if (!m_handle)
-      throw std::runtime_error("Failed to register Windows event source 'AMD_XRT'");
+      std::cerr << "XRT: Failed to open Windows Event Log source 'AMD_XRT' "
+                << "(error " << GetLastError() << "). Logging disabled.\n";
   }
 
   virtual ~syslog_dispatch()
@@ -138,11 +143,12 @@ public:
       DeregisterEventSource(m_handle);
   }
 
-  virtual void
+  void
   send(severity_level l, const char* tag, const char* msg) override
   {
     if (!m_handle)
-      return;
+      return; // Logging is unavailable if we failed to open the event source
+
     // Combine tag and message so Event Viewer shows "[xrt_elf] : some message"
     std::string full_msg = std::string("[") + tag + "] : " + msg;
     LPCSTR strings[] = {full_msg.c_str()};
@@ -189,7 +195,7 @@ public:
   virtual ~syslog_dispatch()
   { closelog(); }
 
-  virtual void
+  void
   send(severity_level l, const char* tag, const char* msg) override
   { syslog(severityMap[l], "%s", msg); }
 

--- a/src/runtime_src/core/common/message.h
+++ b/src/runtime_src/core/common/message.h
@@ -1,18 +1,6 @@
-/**
- * Copyright (C) 2016-2021 Xilinx, Inc
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2016-2022 Xilinx, Inc. All rights reserved.
+// Copyright (C) 2022-2026 Advanced Micro Devices, Inc. All rights reserved.
 
 #ifndef xrtcore_message_h_
 #define xrtcore_message_h_
@@ -27,6 +15,14 @@
 namespace xrt_core { namespace message {
 
 using severity_level = xrt::message::level;
+
+class message_dispatch
+{
+public:
+  virtual ~message_dispatch() = default;
+  static message_dispatch* make_dispatcher(const std::string& choice);
+  virtual void send(severity_level l, const char* tag, const char* msg) = 0;
+};
 
 XRT_CORE_COMMON_EXPORT
 void

--- a/src/runtime_src/core/common/message.h
+++ b/src/runtime_src/core/common/message.h
@@ -8,6 +8,7 @@
 #include "core/common/config_reader.h"
 #include "core/include/xrt.h"
 #include "core/include/xrt/experimental/xrt_message.h"
+#include <memory>
 #include <string>
 #include <cstdio>
 #include <vector>
@@ -19,9 +20,18 @@ using severity_level = xrt::message::level;
 class message_dispatch
 {
 public:
+  message_dispatch() = default;
+  message_dispatch(const message_dispatch&) = delete;
+  message_dispatch& operator=(const message_dispatch&) = delete;
+  message_dispatch(message_dispatch&&) = delete;
+  message_dispatch& operator=(message_dispatch&&) = delete;
   virtual ~message_dispatch() = default;
-  static message_dispatch* make_dispatcher(const std::string& choice);
-  virtual void send(severity_level l, const char* tag, const char* msg) = 0;
+
+  static std::unique_ptr<message_dispatch>
+  make_dispatcher(const std::string& choice);
+
+  virtual void
+  send(severity_level l, const char* tag, const char* msg) = 0;
 };
 
 XRT_CORE_COMMON_EXPORT

--- a/src/runtime_src/core/include/xrt/experimental/xrt_message.h
+++ b/src/runtime_src/core/include/xrt/experimental/xrt_message.h
@@ -21,9 +21,17 @@
  *
  * @details
  * XRT internally uses a message system that supports dispatching of
- * messages to null, console, file, or syslog under different verbosity
- * levels.  The sink and verbosity level is controlled statically
- * through ``xrt.ini`` or at run-time using ``xrt::ini``.
+ * messages to different sinks under configurable verbosity levels.
+ * The sink and verbosity level is controlled statically through
+ * ``xrt.ini`` or at run-time using ``xrt::ini``.
+ *
+ * Supported sinks (``Runtime.runtime_log`` in xrt.ini):
+ *   - ``null``    : discard all messages
+ *   - ``console`` : writes to console (default)
+ *   - ``syslog``  : route to OS-level centralized log (all platforms):
+ *                   Linux uses POSIX syslog; Windows uses the Windows
+ *                   Application Event Log under source "AMD_XRT"
+ *   - ``<path>``  : write to a file at the given path (all platforms)
  *
  * The APIs in this file allow host application to use the same
  * message dispatch mechanism as XRT is configured to use.

--- a/src/runtime_src/doc/toc/xrt_ini.rst
+++ b/src/runtime_src/doc/toc/xrt_ini.rst
@@ -82,7 +82,7 @@ The ``runtime_log`` key controls where XRT message output is sent. The following
    * - ``syslog``
      - All
      - Routes to the OS-level centralized log on each platform:
-       Linux uses the POSIX syslog (``/var/log/syslog``);
+       Linux uses the system syslog/journald depending on distro.
        Windows uses the Windows Application Event Log under source ``AMD_XRT``.
        Using ``syslog`` in ``xrt.ini`` works on both platforms without change.
 

--- a/src/runtime_src/doc/toc/xrt_ini.rst
+++ b/src/runtime_src/doc/toc/xrt_ini.rst
@@ -48,7 +48,7 @@ The following is a simple example that turns on profile timeline trace and sends
    timeline_trace = true
 
 
-**API Support**: From 2020.2 release the runtime configuration options can also be provided through Native XRT APIs. 
+**API Support**: From 2020.2 release the runtime configuration options can also be provided through Native XRT APIs.
 
 
     - ``xrt::ini::set``
@@ -59,6 +59,71 @@ Example
 
     xrt::ini::set("Runtime.runtime_log", "console");
     xrt::ini::set("Runtime.verbosity", 5);
+
+
+Runtime Log Sinks (``runtime_log``)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``runtime_log`` key controls where XRT message output is sent. The following values are supported:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 15 65
+
+   * - Value
+     - Platform
+     - Description
+   * - ``null`` or empty
+     - All
+     - Discard all messages (silent mode)
+   * - ``console``
+     - All
+     - Writes messages to console (default)
+   * - ``syslog``
+     - All
+     - Routes to the OS-level centralized log on each platform:
+       Linux uses the POSIX syslog (``/var/log/syslog``);
+       Windows uses the Windows Application Event Log under source ``AMD_XRT``.
+       Using ``syslog`` in ``xrt.ini`` works on both platforms without change.
+
+       On Windows, messages can be filtered in Event Viewer
+       (**Windows Logs → Application → Filter Current Log → Source: AMD_XRT**)
+       or from the command line by source and/or severity level
+       (Level: ``2`` = Error, ``3`` = Warning, ``4`` = Information):
+
+       .. code-block:: powershell
+
+          # PowerShell - all XRT events
+          Get-EventLog -LogName Application -Source "AMD_XRT"
+
+          # PowerShell - errors only
+          Get-EventLog -LogName Application -Source "AMD_XRT" -EntryType Error
+
+          # PowerShell - errors and warnings
+          Get-EventLog -LogName Application -Source "AMD_XRT" -EntryType Error,Warning
+
+       .. code-block:: bat
+
+          :: Command prompt - all XRT events
+          wevtutil qe Application /q:"*[System[Provider[@Name='AMD_XRT']]]" /f:text
+
+          :: Command prompt - errors only (Level=2)
+          wevtutil qe Application /q:"*[System[Provider[@Name='AMD_XRT'] and Level=2]]" /f:text
+
+          :: Command prompt - errors and warnings (Level=2 or Level=3)
+          wevtutil qe Application /q:"*[System[Provider[@Name='AMD_XRT'] and (Level=2 or Level=3)]]" /f:text
+
+   * - ``<filename>``
+     - All
+     - Write messages to the specified file path (e.g., ``runtime_log = xrt_run.log``)
+
+Example — redirect XRT logs to the OS system log on both Linux and Windows:
+
+.. code-block:: ini
+
+   [Runtime]
+   runtime_log = syslog
+   verbosity = 7
 
 
 For a complete list of currently supported xrt.ini keys, default value, and valid key values please refer `Vitis Application Acceleration Development Flow Documentation <https://docs.amd.com/r/en-US/ug1702-vitis-accelerated-reference/xrt.ini-File>`_


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
XRT's syslog message dispatcher was Linux-only — on Windows it used to throw an exception ("syslog not supported on windows").
This PR adds changes to dispatch messages to Event log on Windows using same xrt ini option **runtime_log = syslog**

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
 This is a new feature addition. The gap was identified when working on ticket - https://jira.xilinx.com/browse/AIESW-27330

#### How problem was solved, alternative solutions (if any) and why they were rejected
The syslog_dispatch class is split into two platform-specific definitions under a single #ifdef _WIN32 / #else / #endif block, both sharing the same class name and interface:

**Linux**: unchanged — uses POSIX openlog / syslog / closelog
**Windows:** new implementation using the Windows Event Log API (RegisterEventSourceA / ReportEventA / DeregisterEventSource) writing under source name AMD_XRT in the Application log
The syslog config value now works transparently on both platforms — no xrt.ini change needed when moving between Linux and Windows.

**INF change dependency:**  The Event Viewer filter UI (Source: AMD_XRT) only works if the driver INF file is changed to add new registry key.
Note: Events are still written correctly without the INF change — only the filter dropdown is affected.
cc : @arpitxilinx , @satishra-xilinx 

The following inf file changes are needed for filtering of xrt messages -
```
[Npu2McdmDriver.NT]
FeatureScore=FB
AddReg = IpuMcdmDriver.AddReg
AddReg = XRT_EventLog.AddReg
CopyFiles = Npu2McdmDriver.Miniport, IpuMcdmDriver.UserMode, IpuMcdmDriver.UserModeAMD

[XRT_EventLog.AddReg]
; Register AMD_XRT as a known source under the Windows Application event log.
; This allows filtering by source in Event Viewer: Windows Logs -> Application -> Filter -> Source: AMD_XRT
; EventMessageFile points to EventCreate.exe which has a pass-through message entry (ID=1, format="%1")
; so Event Viewer displays XRT message text directly without a "description cannot be found" warning.
; This key persists after uninstall which is acceptable - reinstall simply overwrites with same values.
HKLM,"SYSTEM\CurrentControlSet\Services\EventLog\Application\AMD_XRT","TypesSupported",%REG_DWORD%,7
HKLM,"SYSTEM\CurrentControlSet\Services\EventLog\Application\AMD_XRT","EventMessageFile",%REG_EXPAND_SZ%,"%%SystemRoot%%\System32\EventCreate.exe"
```
#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary

- Verified on Windows that setting runtime_log = syslog in xrt.ini routes XRT messages to the Windows Application Event Log under source AMD_XRT.
- Verified events appear in Event Viewer with correct Level icons.
- Verified source filter works in Event Viewer after driver INF installation applies the XRT_EventLog.AddReg registry entries.

#### Documentation impact (if any)
src/runtime_src/doc/toc/xrt_ini.rst:  Added a new Runtime Log Sinks section documenting all runtime_log values, their platform availability, and Windows-specific filtering commands (Event Viewer, PowerShell, wevtutil).