### PR TITLE
On Linux, xrt-runner should use MAP_SHARED for readonly memory mapped…

### DIFF
--- a/src/runtime_src/core/common/runner/detail/linux/mmap.h
+++ b/src/runtime_src/core/common/runner/detail/linux/mmap.h
@@ -97,7 +97,7 @@ private:
   static void*
   map_region(int fd, std::size_t size)
   {
-    void* ptr = mmap(nullptr, size, PROT_READ, MAP_PRIVATE, fd, 0);
+    void* ptr = mmap(nullptr, size, PROT_READ, MAP_SHARED, fd, 0);
     if (ptr == MAP_FAILED)
     {
       close(fd);

--- a/src/runtime_src/core/include/xrt/xrt_bo.h
+++ b/src/runtime_src/core/include/xrt/xrt_bo.h
@@ -160,7 +160,10 @@ public:
    * @param device
    *  The device on which to allocate this buffer
    * @param userptr
-   *  Pointer to aligned user memory
+   *  Pointer to 4K aligned user memory allocated using OS provided aligned
+   *  allocator.
+   *  A readonly pointer may be obtained via a readonly mmap of a file
+   *  opened in readonly mode.
    * @param sz
    *  Size of buffer
    * @param flags
@@ -181,7 +184,10 @@ public:
    * @param device
    *  The device on which to allocate this buffer
    * @param userptr
-   *  Pointer to aligned user memory
+   *  Pointer to 4K aligned user memory allocated using OS provided aligned
+   *  allocator.
+   *  A readonly pointer may be obtained via a readonly mmap of a file
+   *  opened in readonly mode.
    * @param sz
    *  Size of buffer
    * @param grp
@@ -272,7 +278,10 @@ public:
    * @param hwctx
    *  The hardware context in which to allocate this buffer
    * @param userptr
-   *  Pointer to aligned user memory
+   *  Pointer to 4K aligned user memory allocated using OS provided aligned
+   *  allocator.
+   *  A readonly pointer may be obtained via a readonly mmap of
+   *  a file opened in readonly mode.
    * @param sz
    *  Size of buffer
    * @param flags
@@ -293,7 +302,10 @@ public:
    * @param hwctx
    *  The hardware context in which to allocate this buffer
    * @param userptr
-   *  Pointer to aligned user memory
+   *  Pointer to 4K aligned user memory allocated using OS provided aligned
+   *  allocator.
+   *  A readonly pointer may be obtained via a readonly mmap of a file
+   *  opened in readonly mode.
    * @param sz
    *  Size of buffer
    * @param grp


### PR DESCRIPTION
… artifacts or else amdxdna returns EFAULT error code when creating BO

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
On Linux, xrt-runner was failing when creating BO from mmap of weights on the disk. This is because amdxdna driver has added additional checks on the pages backing a user ptr. The fix is for mmap to use MAP_SHARED instead of MAP_PRIVATE.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
model-tests failures

#### How problem was solved, alternative solutions (if any) and why they were rejected
Update mmap mode flag.

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Validated change with model-tests.

#### Documentation impact (if any)
NA