### PR TITLE
Secure DLL loading by restricting the DLL search path

### DIFF
--- a/src/runtime_src/core/common/dlfcn.h
+++ b/src/runtime_src/core/common/dlfcn.h
@@ -58,10 +58,20 @@ dlsym(void* handle, const char* symbol)
 #endif
 
 #ifdef _WIN32
+// Forward declaration
+void init_dll_search_paths();
+
 inline void*
 dlopen(const char* dllname, int)
 {
-  return ::LoadLibrary(dllname);
+  init_dll_search_paths();
+
+  DWORD flags = LOAD_LIBRARY_SEARCH_SYSTEM32 | LOAD_LIBRARY_SEARCH_DEFAULT_DIRS | LOAD_LIBRARY_SEARCH_USER_DIRS;
+  void* handle = ::LoadLibraryExA(dllname, NULL, flags);
+  if (!handle)
+    throw std::runtime_error("LoadLibrary of " + std::string(dllname ? dllname : "") + " failed");
+
+  return handle;
 }
 
 inline void

--- a/src/runtime_src/core/common/module_loader.cpp
+++ b/src/runtime_src/core/common/module_loader.cpp
@@ -246,6 +246,31 @@ load_library(const std::string& path)
 
 namespace xrt_core {
 
+#ifdef _WIN32
+// Initialize DLL search paths once at process startup
+void
+init_dll_search_paths()
+{
+  static bool initialized = false;
+  if (initialized)
+    return;
+  initialized = true;
+
+  sfs::path xrt(value_or_empty(getenv("XILINX_XRT")));
+  sfs::path sdk(value_or_empty(getenv("AMD_NPU_SDK_PATH")));
+
+  if (!xrt.empty()) {
+    std::wstring wide_xrt(xrt.string().begin(), xrt.string().end());
+    AddDllDirectory(wide_xrt.c_str());
+  }
+
+  if (!sdk.empty()) {
+    std::wstring wide_sdk(sdk.string().begin(), sdk.string().end());
+    AddDllDirectory(wide_sdk.c_str());
+  }
+}
+#endif
+
 module_loader::
 module_loader(const std::string& module_name,
               std::function<void (void*)> register_function,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
According to https://support.microsoft.com/en-us/topic/secure-loading-of-libraries-to-prevent-dll-preloading-attacks-d41303ec-0748-9211-f317-2edc819682e1, secure DLL loading on Windows is needed to prevent DLL hijacking attacks by restricting the DLL search path (e.g., remove CWD from the search path)

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
None

#### How problem was solved, alternative solutions (if any) and why they were rejected
 1. src/runtime_src/core/common/dlfcn.h
  - Modified `dlopen()` function to call `init_dll_search_paths()` before loading DLLs
  - Uses `LoadLibraryExA()` with secure flags: LOAD_LIBRARY_SEARCH_SYSTEM32 | LOAD_LIBRARY_SEARCH_DEFAULT_DIRS |
  LOAD_LIBRARY_SEARCH_USER_DIRS
  - These flags exclude the current working directory (CWD) from the search path
  - Added forward declaration for `init_dll_search_paths()`

  2. src/runtime_src/core/common/module_loader.cpp
  - Added `init_dll_search_paths()` helper function in xrt_core namespace
  - Runs once per process (static initialization guard; thread safe)
  - Calls `AddDllDirectory()` to add trusted paths from environment variables:
    - XILINX_XRT
    - AMD_NPU_SDK_PATH

#### Risks (if any) associated the changes in the commit
This change will prevent loading DLLs outside of System32, Driver Store, XILINX_XRT, AMD_NPU_SDK_PATH

#### What has been tested and how, request additional testing if necessary
Need to test local build, xrt-smi, and xrt tests

#### Documentation impact (if any)
None