### PR TITLE
XDP: skip run-lifecycle hooks for XDP_KERNEL* internal runs

### DIFF
--- a/src/runtime_src/core/common/xdp/profile.cpp
+++ b/src/runtime_src/core/common/xdp/profile.cpp
@@ -14,6 +14,7 @@
 #include <cstring>
 #include <functional>
 #include <sstream>
+#include <string_view>
 #include <cstdlib>
 
 #ifdef _WIN32
@@ -949,9 +950,24 @@ finish_flush_device(void* handle)
 #endif
 }
 
+// XDP plugins that submit their own ELF name the xrt::ext::kernel
+// "XDP_KERNEL" or "XDP_KERNEL_<suffix>" so the run-lifecycle hooks
+// can skip self-instrumentation of those internal runs.
+static bool
+is_xdp_internal_kernel(const xrt::run_impl* run_impl)
+{
+  xrt_kernel_data data{};
+  xrt_core::kernel_int::get_xdp_kernel_data(run_impl, &data);
+  constexpr std::string_view prefix{"XDP_KERNEL"};
+  return data.name.compare(0, prefix.size(), prefix.data(), prefix.size()) == 0;
+}
+
 void
 run_constructor(xrt::run_impl* run_impl)
 {
+  if (is_xdp_internal_kernel(run_impl))
+    return;
+
   if (!xrt_core::config::get_aie_dtrace())
     return;
 
@@ -961,6 +977,9 @@ run_constructor(xrt::run_impl* run_impl)
 void
 run_start(const xrt::run_impl* run_impl)
 {
+  if (is_xdp_internal_kernel(run_impl))
+    return;
+
   if (!xrt_core::config::get_aie_dtrace())
     return;
 
@@ -970,6 +989,9 @@ run_start(const xrt::run_impl* run_impl)
 void
 run_wait(const xrt::run_impl* run_impl)
 {
+  if (is_xdp_internal_kernel(run_impl))
+    return;
+
   if (!xrt_core::config::get_aie_dtrace())
     return;
 


### PR DESCRIPTION
XDP plugins that submit their own ELF (e.g. aie_halt/ve2, aie_nop_util, and future plugin configurations) create an xrt::run with the kernel name "XDP_KERNEL:{IPUV1CNN}". The run-lifecycle XDP hooks (run_constructor / run_start / run_wait) would then attempt to instrument these internal runs through whatever plugin currently registers the callbacks (today aie_dtrace), which is incorrect and order-dependent on plugin load.

Add a tiny file-local is_xdp_internal_kernel() helper that does a prefix match on the (already colon-stripped) kernel name, and skip the dispatch at the top of each of the three top-level xrt_core::xdp run dispatchers. The check runs first so any future XDP plugin consumer added below the config gate inherits the same skip rule.

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
XDP run-lifecycle hooks (run_constructor / run_start / run_wait) fire on every xrt::run, including those created inside XDP plugins themselves (e.g. aie_halt/ve2 and aie_nop_util use xrt::ext::kernel{..., "XDP_KERNEL:{IPUV1CNN}"} to submit control-code ELFs). This makes XDP self-instrument its own internal runs. Skip the hooks for any run whose kernel name starts with XDP_KERNEL.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
PR [#9721](https://github.com/Xilinx/XRT/pull/9721) (commit 751273f609) added the three run-lifecycle XDP hooks but did not filter out XDP-internal runs. Today the issue is masked by load order — aie_trace::updateAIEDevice calls submitNopElf before aie_dtrace is loaded, so the callback is still null. We caught the latent bug while planning to extend the ELF-submission pattern to all XDP plugin configurations, and confirmed it by temporarily calling submitNopElf at the end of AieDtracePlugin::updateAIEDtraceDevice (after dtrace is registered): without the fix, dtrace's hook fires on the nop ELF.
#### How problem was solved, alternative solutions (if any) and why they were rejected
Added a file-local is_xdp_internal_kernel() helper in [src/runtime_src/core/common/xdp/profile.cpp](vscode-file://vscode-app/c:/Users/jyothees/AppData/Local/Programs/cursor/resources/app/out/vs/code/electron-sandbox/workbench/src/runtime_src/core/common/xdp/profile.cpp) that prefix-matches the kernel name against "XDP_KERNEL", called as the first check in each top-level dispatcher (run_constructor / run_start / run_wait). One file, one helper, three early-returns.

##### Alternatives rejected:

- Per-plugin guard in each *_cb.cpp — every present and future plugin would have to remember to repeat the check.
- Filter in the XDPPlugin base class via virtual *Impl overrides — structurally cleanest but a larger refactor than necessary.
- Filter at the run_impl call sites in xrt_kernel.cpp — touches XRT core API for an XDP-only concern and spreads the same logic across three sites.
- Refactor aie::dtrace::run_* to take a prepared xrt_kernel_data to avoid a duplicate fetch — micro-optimization not worth the signature churn.
#### Risks (if any) associated the changes in the commit
No
#### What has been tested and how, request additional testing if necessary
Tested a vaiml design
