### PR TITLE
AIESW-35018 Fix failure token for xrt-smi preemption overhead test

### DIFF
--- a/src/runtime_src/core/tools/common/tests/TestPreeemptionOverhead.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestPreeemptionOverhead.cpp
@@ -89,13 +89,16 @@ run_strix(const std::shared_ptr<xrt_core::device>& dev, const xrt_core::archive*
   catch(const std::exception& e) {
     XBValidateUtils::logger(ptree, "Error", e.what());
     ptree.put("status", XBValidateUtils::test_token_failed);
+
+    // Restore the original preemption state
+    xrt_core::device_update<xq::preemption>(dev.get(), static_cast<uint32_t>(layer_boundary));
+    return;
   }
 
   // Restore the original preemption state
   xrt_core::device_update<xq::preemption>(dev.get(), static_cast<uint32_t>(layer_boundary));
 
-  if (ptree.get<std::string>("status", "") != XBU::test_token_failed)
-    ptree.put("status", XBU::test_token_passed);
+  ptree.put("status", XBU::test_token_passed);
 }
 
 void static
@@ -117,13 +120,16 @@ run_npu3(const std::shared_ptr<xrt_core::device>& dev, const xrt_core::archive* 
   catch(const std::exception& e) {
     XBValidateUtils::logger(ptree, "Error", e.what());
     ptree.put("status", XBValidateUtils::test_token_failed);
+
+    // Restore the original preemption state
+    xrt_core::device_update<xq::preemption>(dev.get(), static_cast<uint32_t>(layer_boundary));
+    return;
   }
 
   // Restore the original preemption state
   xrt_core::device_update<xq::preemption>(dev.get(), static_cast<uint32_t>(layer_boundary));
 
-  if (ptree.get<std::string>("status", "") != XBU::test_token_failed)
-    ptree.put("status", XBU::test_token_passed);
+  ptree.put("status", XBU::test_token_passed);
 }
 
 TestPreemptionOverhead::TestPreemptionOverhead()

--- a/src/runtime_src/core/tools/common/tests/TestPreeemptionOverhead.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestPreeemptionOverhead.cpp
@@ -94,7 +94,8 @@ run_strix(const std::shared_ptr<xrt_core::device>& dev, const xrt_core::archive*
   // Restore the original preemption state
   xrt_core::device_update<xq::preemption>(dev.get(), static_cast<uint32_t>(layer_boundary));
 
-  ptree.put("status", XBU::test_token_passed);
+  if (ptree.get<std::string>("status", "") != XBU::test_token_failed)
+    ptree.put("status", XBU::test_token_passed);
 }
 
 void static
@@ -121,7 +122,8 @@ run_npu3(const std::shared_ptr<xrt_core::device>& dev, const xrt_core::archive* 
   // Restore the original preemption state
   xrt_core::device_update<xq::preemption>(dev.get(), static_cast<uint32_t>(layer_boundary));
 
-  ptree.put("status", XBU::test_token_passed);
+  if (ptree.get<std::string>("status", "") != XBU::test_token_failed)
+    ptree.put("status", XBU::test_token_passed);
 }
 
 TestPreemptionOverhead::TestPreemptionOverhead()


### PR DESCRIPTION
#### Problem solved by the commit
https://jira.xilinx.com/browse/AIESW-35018
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Discovered in internal testing
#### How problem was solved, alternative solutions (if any) and why they were rejected
Test was always passing even after failures due to test_token_passed being set after cleanup. Now, we check for any failures before setting to passed after cleanup.
#### Risks (if any) associated the changes in the commit
N/A
#### What has been tested and how, request additional testing if necessary
Testing on GPT.
#### Documentation impact (if any)
N/A