### PR TITLE
AIESW-27330 : Add different sinks for uc log buffer

### DIFF
--- a/src/runtime_src/core/common/api/xrt_hw_context.cpp
+++ b/src/runtime_src/core/common/api/xrt_hw_context.cpp
@@ -196,6 +196,7 @@ class hw_context_impl : public std::enable_shared_from_this<hw_context_impl>
       config.dump_buffer = std::move(bo);
       config.dump_bin_format = xrt_core::config::get_uc_log_bin_format();
       config.enable_dumper_thread = xrt_core::config::get_uc_log_dumper_thread();
+      config.uc_log_dump = xrt_core::config::get_uc_log_dump();
 
       return std::make_unique<xrt_core::buffer_dumper>(std::move(config));
     }

--- a/src/runtime_src/core/common/buffer_dumper.cpp
+++ b/src/runtime_src/core/common/buffer_dumper.cpp
@@ -93,20 +93,30 @@ void
 buffer_dumper::
 dump_chunk_data(size_t chunk_index, size_t start, size_t length, uint8_t* chunk)
 {
-  std::ofstream& fs = get_or_open_stream(chunk_index);
+  // Determine if we need to open a file stream based on the sink configuration
+  // Binary dump always writes to file
+  // Default behavior is to write parsed logs to file
+  const bool use_file_sink = m_config.dump_bin_format
+                             || m_config.uc_log_dump == "file"
+                             || m_config.uc_log_dump.empty();
 
-  // Check if stream is in good state before writing
-  if (!fs.good()) {
-    throw std::runtime_error("File stream for chunk " + std::to_string(chunk_index) +
-                             " is in bad state before write");
+  // Open a file stream only when the sink requires it
+  std::ofstream* fs_ptr = nullptr;
+  if (use_file_sink) {
+    std::ofstream& fs = get_or_open_stream(chunk_index);
+    if (!fs.good())
+      throw std::runtime_error("File stream for chunk " + std::to_string(chunk_index) +
+                               " is in bad state before write");
+    fs_ptr = &fs;
   }
 
   // Calculate start offset and bytes to end for circular buffer wrapping
   const size_t start_offset = (start % m_data_size) + m_config.metadata_size;
   const size_t bytes_to_end = m_config.chunk_size - start_offset;
 
-  // UC log dump in binary format
+  // uC log dump in binary format (always uses file regardless of uc_log_dump setting)
   if (m_config.dump_bin_format) {
+    std::ofstream& fs = *fs_ptr;
     // Always write/update metadata since this function is called when there's new data
     // and metadata(count) gets updated when there is new data
     // Seek to beginning and write/update metadata
@@ -222,12 +232,29 @@ dump_chunk_data(size_t chunk_index, size_t start, size_t length, uint8_t* chunk)
     // log entries may have been lost at the boundary before the next read.
     parsed_stream << "[0.000000000] [CERT] [Dumper]--------------[Separator]--------------\n";
 
-    // Append parsed output to file
-    fs.seekp(0, std::ios::end);
-    fs << parsed_stream.str();
-
-    if (!fs)
-      throw std::runtime_error("Failed to write parsed UC log for chunk " + std::to_string(chunk_index));
+    // Dispatch parsed output to the configured sink
+    const std::string& sink = m_config.uc_log_dump;
+    if (sink == "file" || sink.empty()) {
+      // Write to file
+      fs_ptr->seekp(0, std::ios::end);
+      *fs_ptr << parsed_stream.str();
+      if (!*fs_ptr)
+        throw std::runtime_error("Failed to write parsed UC log for chunk " + std::to_string(chunk_index));
+    }
+    else if (sink != "null") {
+      // syslog or console: send each line as a separate message so the sink can
+      // format/route it correctly
+      std::istringstream lines(parsed_stream.str());
+      std::string line;
+      while (std::getline(lines, line)) {
+        if (!line.empty())
+          // TODO: Pass decoded severity from uC log entry. For now all entries
+          // are sent with info severity. Also may be pass uC index in tag for better traceability.
+          xrt_core::message::send_uc_log(sink, xrt_core::message::severity_level::info,
+                                         "xrt_uc_log", line.c_str());
+      }
+    }
+    // sink == "null": discard
   }
   catch (const std::exception& e) {
     // Log parsing error, log warning and continue
@@ -235,9 +262,11 @@ dump_chunk_data(size_t chunk_index, size_t start, size_t length, uint8_t* chunk)
                             std::string{"UC log parsing failed: "} + e.what());
   }
 
-  fs.flush();
-  if (!fs)
-    throw std::runtime_error("Failed to flush chunk " + std::to_string(chunk_index));
+  if (fs_ptr) {
+    fs_ptr->flush();
+    if (!*fs_ptr)
+      throw std::runtime_error("Failed to flush chunk " + std::to_string(chunk_index));
+  }
 }
 
 void

--- a/src/runtime_src/core/common/buffer_dumper.cpp
+++ b/src/runtime_src/core/common/buffer_dumper.cpp
@@ -91,72 +91,146 @@ read_logged_count(uint8_t* chunk)
 
 void
 buffer_dumper::
-dump_chunk_data(size_t chunk_index, size_t start, size_t length, uint8_t* chunk)
+dump_chunk_data_binary(size_t chunk_index, size_t start_offset, size_t bytes_to_end,
+                       size_t length, uint8_t* chunk)
 {
-  // Determine if we need to open a file stream based on the sink configuration
-  // Binary dump always writes to file
-  // Default behavior is to write parsed logs to file
-  const bool use_file_sink = m_config.dump_bin_format
-                             || m_config.uc_log_dump == "file"
-                             || m_config.uc_log_dump.empty();
+  std::ofstream& fs = get_or_open_stream(chunk_index);
+  if (!fs.good())
+    throw std::runtime_error("File stream for chunk " + std::to_string(chunk_index) +
+                             " is in bad state before write");
 
-  // Open a file stream only when the sink requires it
-  std::ofstream* fs_ptr = nullptr;
-  if (use_file_sink) {
+  // Rewrite metadata at the start on every call: the count field in the metadata
+  // is updated by the device each time new data is written, so we must keep it
+  // in sync with the appended payload.
+  fs.seekp(0);
+  fs.write(reinterpret_cast<const char*>(chunk),
+           static_cast<std::streamsize>(m_config.metadata_size));
+  if (!fs)
+    throw std::runtime_error("Failed to write metadata for chunk " + std::to_string(chunk_index));
+
+  // Append payload after existing file content
+  fs.seekp(0, std::ios::end);
+
+  if (length <= bytes_to_end) {
+    // Payload fits before the circular buffer wrap point; write in one shot
+    fs.write(reinterpret_cast<const char*>(chunk + start_offset),
+             static_cast<std::streamsize>(length));
+    if (!fs)
+      throw std::runtime_error("Failed to write " + std::to_string(length) +
+                               " bytes to chunk " + std::to_string(chunk_index));
+  }
+  else {
+    // Payload straddles the wrap point; write the two contiguous segments separately
+    fs.write(reinterpret_cast<const char*>(chunk + start_offset),
+             static_cast<std::streamsize>(bytes_to_end));
+    if (!fs)
+      throw std::runtime_error("Failed to write first part (" + std::to_string(bytes_to_end) +
+                               " bytes) to chunk " + std::to_string(chunk_index));
+
+    fs.write(reinterpret_cast<const char*>(chunk + m_config.metadata_size),
+             static_cast<std::streamsize>(length - bytes_to_end));
+    if (!fs)
+      throw std::runtime_error("Failed to write wrapped part (" +
+                               std::to_string(length - bytes_to_end) +
+                               " bytes) to chunk " + std::to_string(chunk_index));
+  }
+
+  fs.flush();
+  if (!fs)
+    throw std::runtime_error("Failed to flush chunk " + std::to_string(chunk_index));
+}
+
+std::string
+buffer_dumper::
+parse_log_entries(size_t start_offset, size_t bytes_to_end, size_t length,
+                  uint8_t* chunk)
+{
+  std::ostringstream out;
+  size_t parsed_bytes = 0;
+
+  while (parsed_bytes < length) {
+    // Resolve the byte offset of the current entry, accounting for circular buffer wrap
+    size_t entry_offset = (parsed_bytes < bytes_to_end)
+      ? start_offset + parsed_bytes
+      : m_config.metadata_size + (parsed_bytes - bytes_to_end);
+
+    log_entry log;
+    std::memcpy(&log, chunk + entry_offset, sizeof(log_entry));
+
+    // Look up format string in the schema; fall back to a generic placeholder
+    // when the log_id is unrecognized. The fallback is chosen by argument count
+    // (derived from entry length) so the output still shows available data.
+    constexpr std::array<const char*, 3> default_formats = {
+      "unknown !\n",
+      "unknown %d !!\n",
+      "unknown %d unknown %d !!!\n"
+    };
+
+    auto log_schema_it = uc_log_schema.logs.find(log.log_id);
+    const char* log_format = (log_schema_it != uc_log_schema.logs.end())
+      ? log_schema_it->second.c_str()
+      : default_formats[std::min(
+          static_cast<std::size_t>(
+              log.length - (offsetof(log_entry, argument1) / sizeof(uint32_t))),
+          default_formats.size() - 1)];
+
+    // Reconstruct 64-bit nanosecond timestamp from the two 32-bit halves
+    constexpr uint64_t ts_high_shift = 32;
+    uint64_t timestamp_ns =
+        (static_cast<uint64_t>(log.ts_high) << ts_high_shift) | log.ts_low;
+    out << "[" << xrt_core::get_timestamp_for_uc_log(timestamp_ns) << "] [CERT] ";
+
+    // Format the log message according to the number of arguments encoded in entry length
+    std::array<char, 1024> log_message{}; // NOLINT(cppcoreguidelines-avoid-magic-numbers)
+    if (log.length == (offsetof(log_entry, argument1) / sizeof(uint32_t))) {
+      out << log_format;
+    }
+    else if (log.length == (offsetof(log_entry, argument2) / sizeof(uint32_t))) {
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
+      static_cast<void>(std::snprintf(log_message.data(), log_message.size(),
+                                      log_format, log.argument1));
+      out << log_message.data();
+    }
+    else if (log.length == (sizeof(log_entry) / sizeof(uint32_t))) {
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
+      static_cast<void>(std::snprintf(log_message.data(), log_message.size(),
+                                      log_format, log.argument1, log.argument2));
+      out << log_message.data();
+    }
+    else {
+      xrt_core::message::send(xrt_core::message::severity_level::warning, "buffer_dumper",
+                              "Invalid UC log entry length: " + std::to_string(log.length));
+    }
+
+    parsed_bytes += m_config.metadata_size;
+  }
+
+  // Separator marks the read boundary; entries may have been lost before the next read
+  out << "[0.000000000] [CERT] [Dumper]--------------[Separator]--------------\n";
+  return out.str();
+}
+
+void
+buffer_dumper::
+dispatch_parsed_log(size_t chunk_index, const std::string& text)
+{
+  const std::string& sink = m_config.uc_log_dump;
+
+  // "null" sink: silently discard
+  if (sink == "null")
+    return;
+
+  if (sink == "file" || sink.empty()) {
+    // Append the entire text block to the per-chunk file
     std::ofstream& fs = get_or_open_stream(chunk_index);
     if (!fs.good())
       throw std::runtime_error("File stream for chunk " + std::to_string(chunk_index) +
                                " is in bad state before write");
-    fs_ptr = &fs;
-  }
-
-  // Calculate start offset and bytes to end for circular buffer wrapping
-  const size_t start_offset = (start % m_data_size) + m_config.metadata_size;
-  const size_t bytes_to_end = m_config.chunk_size - start_offset;
-
-  // uC log dump in binary format (always uses file regardless of uc_log_dump setting)
-  if (m_config.dump_bin_format) {
-    std::ofstream& fs = *fs_ptr;
-    // Always write/update metadata since this function is called when there's new data
-    // and metadata(count) gets updated when there is new data
-    // Seek to beginning and write/update metadata
-    fs.seekp(0);
-    fs.write(reinterpret_cast<const char*>(chunk),
-            static_cast<std::streamsize>(m_config.metadata_size));
-
-    if (!fs)
-      throw std::runtime_error("Failed to write metadata for chunk " + std::to_string(chunk_index));
-
-    // Seek to end to append actual data
     fs.seekp(0, std::ios::end);
-
-    if (length <= bytes_to_end) { // data doesn't wrap around
-      fs.write(reinterpret_cast<const char*>(chunk + start_offset),
-              static_cast<std::streamsize>(length));
-
-      if (!fs)
-        throw std::runtime_error("Failed to write " + std::to_string(length) +
-                                " bytes to chunk " + std::to_string(chunk_index));
-    }
-    else {
-      // data wraps around
-      // write the first part
-      fs.write(reinterpret_cast<const char*>(chunk + start_offset),
-              static_cast<std::streamsize>(bytes_to_end));
-
-      if (!fs)
-        throw std::runtime_error("Failed to write first part (" + std::to_string(bytes_to_end) +
-                                " bytes) to chunk " + std::to_string(chunk_index));
-
-      // write the wrapped part
-      fs.write(reinterpret_cast<const char*>(chunk + m_config.metadata_size),
-              static_cast<std::streamsize>(length - bytes_to_end));
-
-      if (!fs)
-        throw std::runtime_error("Failed to write wrapped part (" +
-                                std::to_string(length - bytes_to_end) +
-                                " bytes) to chunk " + std::to_string(chunk_index));
-    }
+    fs << text;
+    if (!fs)
+      throw std::runtime_error("Failed to write parsed UC log for chunk " +
+                               std::to_string(chunk_index));
 
     fs.flush();
     if (!fs)
@@ -165,107 +239,42 @@ dump_chunk_data(size_t chunk_index, size_t start, size_t length, uint8_t* chunk)
     return;
   }
 
-  // UC log parsing and writing log messages to file using log schema
+  // syslog or console: each line is dispatched as a discrete message so the
+  // sink can apply its own formatting and routing per entry
+  std::istringstream lines(text);
+  std::string line;
+  while (std::getline(lines, line)) {
+    if (!line.empty())
+      // TODO: Pass decoded severity from uC log entry.
+      // For now all entries are sent with info severity.
+      // Also may be pass uC index in tag for better traceability.
+      xrt_core::message::send_uc_log(sink,
+                                     xrt_core::message::severity_level::info,
+                                     "xrt_uc_log", line.c_str());
+  }
+}
+
+void
+buffer_dumper::
+dump_chunk_data(size_t chunk_index, size_t start, size_t length, uint8_t* chunk)
+{
+  const size_t start_offset = (start % m_data_size) + m_config.metadata_size;
+  const size_t bytes_to_end = m_config.chunk_size - start_offset;
+
+  if (m_config.dump_bin_format) {
+    dump_chunk_data_binary(chunk_index, start_offset, bytes_to_end, length, chunk);
+    return;
+  }
+
+  // Dump in parsed text format
+  // Parse log entries and route to the configured sink.
   try {
-    std::ostringstream parsed_stream;
-    size_t parsed_bytes = 0;
-    // Iterate and parse each log entry in dumped data
-    while (parsed_bytes < length) {
-      size_t entry_offset = 0;
-
-      // Handle circular buffer wrapping
-      if (parsed_bytes < bytes_to_end)
-        entry_offset = start_offset + parsed_bytes; // No wrap around
-      else
-        entry_offset = m_config.metadata_size + (parsed_bytes - bytes_to_end); // Wrapped around
-
-      // Current log entry in chunk
-      const uint8_t* entry = chunk + entry_offset;
-      // Extract log entry fields
-      log_entry log;
-      std::memcpy(&log, entry, sizeof(log_entry));
-
-      // Format log message using log schema
-      // If log_id is not found in log schema, use default format string
-      constexpr std::array<const char*, 3> default_formats = {
-        "unknown !\n",
-        "unknown %d !!\n",
-        "unknown %d unknown %d !!!\n"
-      };
-      auto log_schema_it = uc_log_schema.logs.find(log.log_id);
-      const char* log_format = (log_schema_it != uc_log_schema.logs.end())
-        ? log_schema_it->second.c_str()
-        : default_formats[std::min(static_cast<std::size_t>(log.length - (offsetof(log_entry, argument1) / sizeof(uint32_t))),
-                          (default_formats.size() - 1))];
-
-      // log marker [<seconds>.<nanoseconds>] [CERT]
-      uint64_t timestamp_ns = (static_cast<uint64_t>(log.ts_high) << 32) | log.ts_low; // NOLINT(cppcoreguidelines-avoid-magic-numbers)
-      parsed_stream << "[" << xrt_core::get_timestamp_for_uc_log(timestamp_ns) << "] [CERT] ";
-
-      std::array<char, 1024> log_message{}; // NOLINT(cppcoreguidelines-avoid-magic-numbers)
-      if (log.length == (offsetof(log_entry, argument1) / sizeof(uint32_t)))
-      { // Log message without arguments
-        parsed_stream << log_format;
-      }
-      else if (log.length == (offsetof(log_entry, argument2) / sizeof(uint32_t)))
-      { // Log message with one argument
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
-        static_cast<void>(std::snprintf(log_message.data(), log_message.size(), log_format, log.argument1));
-        parsed_stream << log_message.data();
-      }
-      else if (log.length == (sizeof(log_entry) / sizeof(uint32_t)))
-      { // Log message with two arguments
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
-        static_cast<void>(std::snprintf(log_message.data(), log_message.size(), log_format, log.argument1, log.argument2));
-        parsed_stream << log_message.data();
-      }
-      else
-      { // Unexpected entry length
-        xrt_core::message::send(xrt_core::message::severity_level::warning, "buffer_dumper",
-                                "Invalid UC log entry length: " + std::to_string(log.length));
-      }
-
-      parsed_bytes += m_config.metadata_size;
-    }
-
-    // Separator between dumper reads; the separator marks read boundaries and indicates
-    // log entries may have been lost at the boundary before the next read.
-    parsed_stream << "[0.000000000] [CERT] [Dumper]--------------[Separator]--------------\n";
-
-    // Dispatch parsed output to the configured sink
-    const std::string& sink = m_config.uc_log_dump;
-    if (sink == "file" || sink.empty()) {
-      // Write to file
-      fs_ptr->seekp(0, std::ios::end);
-      *fs_ptr << parsed_stream.str();
-      if (!*fs_ptr)
-        throw std::runtime_error("Failed to write parsed UC log for chunk " + std::to_string(chunk_index));
-    }
-    else if (sink != "null") {
-      // syslog or console: send each line as a separate message so the sink can
-      // format/route it correctly
-      std::istringstream lines(parsed_stream.str());
-      std::string line;
-      while (std::getline(lines, line)) {
-        if (!line.empty())
-          // TODO: Pass decoded severity from uC log entry. For now all entries
-          // are sent with info severity. Also may be pass uC index in tag for better traceability.
-          xrt_core::message::send_uc_log(sink, xrt_core::message::severity_level::info,
-                                         "xrt_uc_log", line.c_str());
-      }
-    }
-    // sink == "null": discard
+    const std::string text = parse_log_entries(start_offset, bytes_to_end, length, chunk);
+    dispatch_parsed_log(chunk_index, text);
   }
   catch (const std::exception& e) {
-    // Log parsing error, log warning and continue
     xrt_core::message::send(xrt_core::message::severity_level::warning, "buffer_dumper",
                             std::string{"UC log parsing failed: "} + e.what());
-  }
-
-  if (fs_ptr) {
-    fs_ptr->flush();
-    if (!*fs_ptr)
-      throw std::runtime_error("Failed to flush chunk " + std::to_string(chunk_index));
   }
 }
 

--- a/src/runtime_src/core/common/buffer_dumper.cpp
+++ b/src/runtime_src/core/common/buffer_dumper.cpp
@@ -21,7 +21,7 @@ buffer_dumper(config cfg)
   : m_config(std::move(cfg))
   , m_data_size(m_config.chunk_size - m_config.metadata_size)
   , m_dumped_counts(m_config.num_chunks, 0)
-  , m_file_streams(m_config.num_chunks)
+  , m_file_streams(needs_file_streams() ? m_config.num_chunks : 0)
 {
   // Files are opened lazily in get_or_open_stream() when first data is available
   // start background dumping only when enabled
@@ -245,6 +245,7 @@ dispatch_parsed_log(size_t chunk_index, const std::string& text)
   std::string line;
   while (std::getline(lines, line)) {
     if (!line.empty())
+      // Sink argument sent is cached and dispatcher is created inf first call.
       // TODO: Pass decoded severity from uC log entry.
       // For now all entries are sent with info severity.
       // Also may be pass uC index in tag for better traceability.

--- a/src/runtime_src/core/common/buffer_dumper.h
+++ b/src/runtime_src/core/common/buffer_dumper.h
@@ -48,6 +48,10 @@ public:
     xrt::bo dump_buffer;              // xrt buffer object to dump
     bool dump_bin_format = false;     // Dump in binary format when enabled
     bool enable_dumper_thread = false; // Enable background dumper thread
+    // Sink for parsed uC log text output:
+    // "file" (default), "syslog", "console", or "null"
+    // Ignored when dump_bin_format=true (binary always writes to file)
+    std::string uc_log_dump = "file";
   };
 
   // Log entry layout: shared definition in uc_log.h

--- a/src/runtime_src/core/common/buffer_dumper.h
+++ b/src/runtime_src/core/common/buffer_dumper.h
@@ -79,7 +79,20 @@ private:
   size_t
   read_logged_count(uint8_t* chunk);
 
-  // Write chunk data to file (metadata header + new data payload)
+  // Write raw binary data (metadata + payload) to file
+  void
+  dump_chunk_data_binary(size_t chunk_index, size_t start_offset, size_t bytes_to_end,
+                         size_t length, uint8_t* chunk);
+
+  // Parse log entries from chunk data into a formatted string
+  std::string
+  parse_log_entries(size_t start_offset, size_t bytes_to_end, size_t length, uint8_t* chunk);
+
+  // Route parsed log text to the configured sink (file, syslog, console, or null)
+  void
+  dispatch_parsed_log(size_t chunk_index, const std::string& text);
+
+  // Coordinate binary or parsed log dump for a chunk
   void
   dump_chunk_data(size_t chunk_index, size_t start, size_t length, uint8_t* chunk);
 

--- a/src/runtime_src/core/common/buffer_dumper.h
+++ b/src/runtime_src/core/common/buffer_dumper.h
@@ -71,6 +71,10 @@ private:
   std::vector<std::ofstream> m_file_streams;
   std::string m_session_timestamp;  // Set on first file open for consistent naming
 
+  bool
+  needs_file_streams() const
+  { return m_config.dump_bin_format || m_config.uc_log_dump == "file" || m_config.uc_log_dump.empty(); }
+
   // Open file for chunk lazily when first data is available; returns stream
   std::ofstream&
   get_or_open_stream(size_t chunk_index);

--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -1256,6 +1256,19 @@ get_uc_log_size_per_uc_kb()
   return value;
 }
 
+inline std::string
+get_uc_log_dump()
+{
+  // Sink for parsed uC log output: "file" (default), "syslog", "console", or "null"
+  // "file"    -> write to timestamped per-chunk files
+  // "syslog"  -> route to OS system log (Linux syslog / Windows Event Log under AMD_XRT)
+  // "console" -> write to stderr
+  // "null"    -> discard
+  // Note: uc_log_bin_format=true always writes raw binary to 'file' regardless of this setting.
+  static std::string value = detail::get_string_value("Debug.uc_log_dump", "file");
+  return value;
+}
+
 }} // config,xrt_core
 
 #endif

--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -1260,7 +1260,7 @@ inline std::string
 get_uc_log_dump()
 {
   // Sink for parsed uC log output: "file" (default), "syslog", "console", or "null"
-  // "file"    -> write to timestamped per-chunk files
+  // "file" or "" (default) -> write to timestamped per-chunk files
   // "syslog"  -> route to OS system log (Linux syslog / Windows Event Log under AMD_XRT)
   // "console" -> write to stderr
   // "null"    -> discard

--- a/src/runtime_src/core/common/detail/linux/syslog.h
+++ b/src/runtime_src/core/common/detail/linux/syslog.h
@@ -6,6 +6,7 @@
 #include "core/common/message.h"
 
 #include <map>
+#include <string>
 #include <syslog.h>
 
 namespace xrt_core::message {
@@ -14,7 +15,7 @@ class syslog_dispatch : public message_dispatch
 {
 public:
   syslog_dispatch()
-  { openlog("sdaccel", LOG_PID|LOG_CONS, LOG_USER); }
+  { openlog("XRT", LOG_PID|LOG_CONS, LOG_USER); }
 
   syslog_dispatch(const syslog_dispatch&) = delete;
   syslog_dispatch& operator=(const syslog_dispatch&) = delete;
@@ -26,7 +27,10 @@ public:
 
   void
   send(severity_level l, const char* tag, const char* msg) override
-  { syslog(m_severity_map[l], "%s", msg); }
+  {
+    std::string full_msg = std::string("[") + tag + "] : " + msg;
+    syslog(m_severity_map[l], "%s", full_msg.c_str());
+  }
 
 private:
   std::map<severity_level, int> m_severity_map = {

--- a/src/runtime_src/core/common/detail/linux/syslog.h
+++ b/src/runtime_src/core/common/detail/linux/syslog.h
@@ -6,7 +6,6 @@
 #include "core/common/message.h"
 
 #include <map>
-#include <string>
 #include <syslog.h>
 
 namespace xrt_core::message {
@@ -28,8 +27,7 @@ public:
   void
   send(severity_level l, const char* tag, const char* msg) override
   {
-    std::string full_msg = std::string("[") + tag + "] : " + msg;
-    syslog(m_severity_map[l], "%s", full_msg.c_str());
+    syslog(m_severity_map[l], "[%s] : %s", tag, msg);
   }
 
 private:

--- a/src/runtime_src/core/common/message.cpp
+++ b/src/runtime_src/core/common/message.cpp
@@ -223,4 +223,13 @@ sendv(severity_level l, const char* tag, const char* format, va_list args)
   send(l, tag, buf.data());
 }
 
+void
+send_uc_log(const std::string& sink, severity_level l, const char* tag, const char* msg)
+{
+  // Dedicated dispatcher for uC log output, driven by Debug.uc_log_dump (not runtime_log).
+  // No verbosity filtering — all uC log lines are forwarded unconditionally.
+  static auto dispatcher = message_dispatch::make_dispatcher(sink);
+  dispatcher->send(l, tag, msg);
+}
+
 }} // message,xrt

--- a/src/runtime_src/core/common/message.h
+++ b/src/runtime_src/core/common/message.h
@@ -38,6 +38,15 @@ XRT_CORE_COMMON_EXPORT
 void
 send(severity_level l, const char* tag, const char* msg);
 
+// Send a uC log line directly to the given sink ("syslog" or "console"),
+// bypassing runtime_log and verbosity filtering.
+// Used by buffer_dumper for uc_log_dump routing.
+// TODO: severity_level is currently always info; in future it can be decoded
+// from the uC log entry and passed by buffer_dumper for finer event classification.
+XRT_CORE_COMMON_EXPORT
+void
+send_uc_log(const std::string& sink, severity_level l, const char* tag, const char* msg);
+
 void
 sendv(severity_level l, const char* tag, const char* format, va_list args);
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
The uC log buffer dumper previously only supported writing parsed log entries to files. There was no way to route uC logs to the OS system log (syslog on Linux, Windows Event Log on Windows) or to console, making it difficult to correlate uC log output with other system-level logs in production environments or automated test pipelines where file-based output is inconvenient.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
 This is a new feature extending the existing buffer_dumper infrastructure to dump to new sinks (syslog or console)

#### How problem was solved, alternative solutions (if any) and why they were rejected
A new **Debug.uc_log_dump** key is added to xrt.ini supporting four values:

file or "" (default) — existing behavior, writes timestamped per-chunk files
syslog — routes parsed log lines through the OS system log: Linux syslog/journald via openlog("XRT", ...) / syslog(), Windows Application Event Log via RegisterEventSourceA("AMD_XRT") / ReportEventA()
console — writes to stderr
null  — silently discards all uC log output
A dedicated send_uc_log() function is added to message.cpp/message.h that creates its own dispatcher from the uc_log_dump ini value, completely independent of runtime_log.
Parsed log entries are split line-by-line before dispatch so each line becomes a discrete syslog/Event Log entry.

The file stream in dump_chunk_data() is now opened lazily only when the sink requires it (file or binary format), so no files are created when syslog, console, or null is configured.

TODO : At present log from uC is not tagged with message type like info, warning or error, we send all the uC log entries with level info to syslog. Need to get the correct tag from uC logs so that we can send the entries to syslog with proper severity level

#### Risks (if any) associated the changes in the commit
Low as it can be enabled only with ini option and default behavior is not changed.

#### What has been tested and how, request additional testing if necessary
Tested uC log dumping on Linux and windows and things work as expected

#### Documentation impact (if any)
Added comments where ever necessary to explain different sinks