### PR TITLE
EDGEML-13998:Disable UC log buffers for unsupported platforms

### DIFF
--- a/src/runtime_src/core/common/api/xrt_hw_context.cpp
+++ b/src/runtime_src/core/common/api/xrt_hw_context.cpp
@@ -53,6 +53,9 @@ constexpr double
 operator""_mhz(long double v) { return static_cast<double>(v) * 1'000'000.0; }
 // NOLINTEND(cppcoreguidelines-avoid-magic-numbers)
 
+static constexpr uint16_t PHOENIX_DEVICE_ID = 0x1502;
+static constexpr uint16_t STRIX_DEVICE_ID   = 0x17f0;
+
 template <typename T>
 using span = xrt::detail::span<T>;
 
@@ -283,15 +286,26 @@ class hw_context_impl : public std::enable_shared_from_this<hw_context_impl>
     return cfg;
   }
 
+  // Skip UC logs for unsupported devices (Phoenix, Strix)
+  static bool
+  skip_uc_log(const std::shared_ptr<xrt_core::device>& device)
+  {
+    try {
+      const auto pcie_id = xrt_core::device_query<xrt_core::query::pcie_id>(device.get());
+      return pcie_id.device_id == PHOENIX_DEVICE_ID || pcie_id.device_id == STRIX_DEVICE_ID;
+    }
+    catch (const std::exception&) {
+      return false;
+    }
+  }
+
   // Initializes uc log buffer
-  // Creates log buffer and starts a thread to dump the log buffer contents
-  // periodically per column to a file
   static std::unique_ptr<uc_log_buffer>
   init_uc_log_buf(const std::shared_ptr<xrt_core::device>& device, xrt_core::hwctx_handle* ctx_hdl)
   {
     // If uc log buffer is not supported then this function returns nullptr
     static auto uc_log_enabled = xrt_core::config::get_uc_log();
-    if (!ctx_hdl || !uc_log_enabled)
+    if (!ctx_hdl || !uc_log_enabled || skip_uc_log(device))
       return nullptr;
 
     try {

--- a/src/runtime_src/core/common/api/xrt_hw_context.cpp
+++ b/src/runtime_src/core/common/api/xrt_hw_context.cpp
@@ -53,9 +53,6 @@ constexpr double
 operator""_mhz(long double v) { return static_cast<double>(v) * 1'000'000.0; }
 // NOLINTEND(cppcoreguidelines-avoid-magic-numbers)
 
-static constexpr uint16_t PHOENIX_DEVICE_ID = 0x1502;
-static constexpr uint16_t STRIX_DEVICE_ID   = 0x17f0;
-
 template <typename T>
 using span = xrt::detail::span<T>;
 
@@ -290,9 +287,12 @@ class hw_context_impl : public std::enable_shared_from_this<hw_context_impl>
   static bool
   skip_uc_log(const std::shared_ptr<xrt_core::device>& device)
   {
+    constexpr uint16_t phoenix_device_id = 0x1502;
+    constexpr uint16_t strix_device_id   = 0x17f0;
+
     try {
       const auto pcie_id = xrt_core::device_query<xrt_core::query::pcie_id>(device.get());
-      return pcie_id.device_id == PHOENIX_DEVICE_ID || pcie_id.device_id == STRIX_DEVICE_ID;
+      return pcie_id.device_id == phoenix_device_id || pcie_id.device_id == strix_device_id;
     }
     catch (const std::exception&) {
       return false;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Phoenix and Strix platforms were triggering kernel IOCTL errors when
attempting to create UC log buffers.
Added early device ID check to skip UC log creation for Phoenix (0x1502)
and Strix (0x17f0), preventing misleading kernel errors.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://amd.atlassian.net/browse/EDGEML-13998
https://github.com/Xilinx/XRT/pull/9752 Introduced the issue when uc logs were enabled by default.
#### How problem was solved, alternative solutions (if any) and why they were rejected
Added platform check in init_uc_log_buf() to skip UC log buffer creation for
unsupported devices.
#### Risks (if any) associated the changes in the commit
Low
#### What has been tested and how, request additional testing if necessary
Tested on Linux Strix board with xrt-smi validate.
There are no errors in dmesg
#### Documentation impact (if any)
NA