### PR TITLE
AIESW-35164 Remove placeholder JSON option

### DIFF
--- a/src/runtime_src/core/common/smi/smi_ryzen.cpp
+++ b/src/runtime_src/core/common/smi/smi_ryzen.cpp
@@ -61,8 +61,7 @@ config_gen_ryzen::create_validate_subcommand()
   std::map<std::string, std::shared_ptr<option>> validate_suboptions;
   validate_suboptions.emplace("device", std::make_shared<option>("device", "d", "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest", "common", "", "string"));
   validate_suboptions.emplace("format", std::make_shared<option>("format", "f", "Report output format. Valid values are:\n"
-                                "\tJSON        - Latest JSON schema\n"
-                                "\tJSON-2020.2 - JSON 2020.2 schema", "common", "JSON", "string"));
+                                "\tJSON - Latest JSON schema", "common", "JSON", "string"));
   validate_suboptions.emplace("output", std::make_shared<option>("output", "o", "Direct the output to the given file", "common", "", "string"));
   validate_suboptions.emplace("help", std::make_shared<option>("help", "h", "Help to use this sub-command", "common", "", "none"));
   validate_suboptions.emplace("run", std::make_shared<listable_description_option>("run", "r", "Run a subset of the test suite. Valid options are:\n",
@@ -80,8 +79,7 @@ config_gen_ryzen::create_examine_subcommand()
   std::map<std::string, std::shared_ptr<option>> examine_suboptions;
   examine_suboptions.emplace("device", std::make_shared<option>("device", "d", "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest", "common", "", "string"));
   examine_suboptions.emplace("format", std::make_shared<option>("format", "f", "Report output format. Valid values are:\n"
-                                "\tJSON        - Latest JSON schema\n"
-                                "\tJSON-2020.2 - JSON 2020.2 schema", "common", "JSON", "string"));
+                                "\tJSON - Latest JSON schema", "common", "JSON", "string"));
   examine_suboptions.emplace("output", std::make_shared<option>("output", "o", "Direct the output to the given file", "common", "", "string"));
   examine_suboptions.emplace("help", std::make_shared<option>("help", "h", "Help to use this sub-command", "common", "", "none"));
   examine_suboptions.emplace("watch", std::make_shared<option>("watch", "", "Refresh interval in seconds between examine updates. Exit with Ctrl+C.", "hidden", "0", "string"));

--- a/src/runtime_src/core/common/smi/smi_ryzen.cpp
+++ b/src/runtime_src/core/common/smi/smi_ryzen.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
 
 #define XRT_CORE_COMMON_SOURCE
 


### PR DESCRIPTION
#### Problem solved by the commit
https://jira.xilinx.com/browse/AIESW-35164
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Discovered during internal testing
#### How problem was solved, alternative solutions (if any) and why they were rejected
2020.2 was a placeholder value in Alveo time, both JSON and JSON 2020.2 outputs are currently identical. Removed it from the Ryzen help menu while leaving plumbing in case we decide to support JSON versioning in the future for Ryzen.
#### Risks (if any) associated the changes in the commit
N/A, functionality is the same for possible users and testcases-v2/documentation never mentioned JSON-2020.2 to begin with.
#### What has been tested and how, request additional testing if necessary
Tested on GPT
#### Documentation impact (if any)
N/A