### PR TITLE
AIESW-35158:Dump data before updating count on overflow

### DIFF
--- a/src/runtime_src/core/common/buffer_dumper.cpp
+++ b/src/runtime_src/core/common/buffer_dumper.cpp
@@ -299,13 +299,13 @@ process_chunks_no_lock()
     size_t logged_wrap = logged_count / m_data_size;
     size_t dumped_wrap = dumped_count / m_data_size;
 
-    // Overwrite detected: dump entire buffer and catch up and resume dumping from current position.
+    // Overflow detected: reposition to dump the most recent full buffer's worth of data.
     if (logged_count > dumped_count && logged_wrap > dumped_wrap) {
-      m_config.dump_buffer.sync(XCL_BO_SYNC_BO_FROM_DEVICE, m_data_size,
-                                chunk_offset + m_config.metadata_size);
-      dump_chunk_data(i, logged_count - m_data_size, m_data_size, chunk);
-      dumped_count = logged_count;
-      continue;
+      xrt_core::message::send(xrt_core::message::severity_level::warning, "buffer_dumper",
+                              "UC log overrun on chunk " + std::to_string(i) + ": " +
+                              std::to_string(logged_count - dumped_count - m_data_size) +
+                              " bytes lost, recovering from oldest surviving position.");
+      dumped_count = logged_count - m_data_size;
     }
 
     if (dumped_count != logged_count) {

--- a/src/runtime_src/core/common/buffer_dumper.cpp
+++ b/src/runtime_src/core/common/buffer_dumper.cpp
@@ -299,9 +299,14 @@ process_chunks_no_lock()
     size_t logged_wrap = logged_count / m_data_size;
     size_t dumped_wrap = dumped_count / m_data_size;
 
-    // Overwrite detected; catch up and resume dumping from current position.
-    if (logged_count > dumped_count && logged_wrap > dumped_wrap)
+    // Overwrite detected: dump entire buffer and catch up and resume dumping from current position.
+    if (logged_count > dumped_count && logged_wrap > dumped_wrap) {
+      m_config.dump_buffer.sync(XCL_BO_SYNC_BO_FROM_DEVICE, m_data_size,
+                                chunk_offset + m_config.metadata_size);
+      dump_chunk_data(i, logged_count - m_data_size, m_data_size, chunk);
       dumped_count = logged_count;
+      continue;
+    }
 
     if (dumped_count != logged_count) {
       size_t to_dump = logged_count - dumped_count;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
When the UC log ring buffer overflowed, the code updated the dumped counter before actually saving any data, causing the dump check to become false and all logs to be lost. The fix syncs and dumps the buffer contents before updating the counter, so overflow now saves the latest available logs instead of discarding everything.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
[AIESW-35158](https://jira.xilinx.com/browse/AIESW-35158)
#### How problem was solved, alternative solutions (if any) and why they were rejected
On overflow detection, sync the data buffer from device and call dump_chunk_data() to save the contents before updating dumped_count. This preserves the latest logs in the buffer.
#### Risks (if any) associated the changes in the commit
Low
#### What has been tested and how, request additional testing if necessary
Tested on Windows medusa board with debug cert firmware using xrt-smi validate. Able to reproduce the issue with xrt-smi validate and verified with the fix. 
#### Documentation impact (if any)
NA