### PR TITLE
[XRT-SMI] Add new device and add logic to divide types into family of devices

### DIFF
--- a/src/runtime_src/core/common/smi/smi.cpp
+++ b/src/runtime_src/core/common/smi/smi.cpp
@@ -10,6 +10,7 @@
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
 
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -170,6 +171,7 @@ smi_hardware_config()
     {{0x17f3, 0x10}, hardware_type::npu3_f3},
     {{0x17f1, 0x12}, hardware_type::npu3_f4},
     {{0x17f1, 0x13}, hardware_type::npu3_f5},
+    {{0x17f1, 0x15}, hardware_type::npu3_f6},
     {{0x1B0A, 0x00}, hardware_type::npu3_B01},
     {{0x1B0B, 0x00}, hardware_type::npu3_B02},
     {{0x1B0C, 0x00}, hardware_type::npu3_B03},
@@ -186,6 +188,86 @@ get_hardware_type(const xq::pcie_id::data& dev) const
   return (it != hardware_map.end()) 
       ? it->second 
       : hardware_type::unknown;
+}
+
+smi_hardware_config::hardware_family
+smi_hardware_config::
+get_family(hardware_type hw)
+{
+  switch (hw) {
+  case hardware_type::phx:
+    return hardware_family::phoenix;
+  case hardware_type::stxA0:
+  case hardware_type::stxB0:
+  case hardware_type::stxH:
+  case hardware_type::krk1:
+    return hardware_family::strix;
+  case hardware_type::npu3_f0:
+  case hardware_type::npu3_f1:
+  case hardware_type::npu3_f2:
+  case hardware_type::npu3_f3:
+  case hardware_type::npu3_f4:
+  case hardware_type::npu3_f5:
+  case hardware_type::npu3_f6:
+  case hardware_type::npu3_B01:
+  case hardware_type::npu3_B02:
+  case hardware_type::npu3_B03:
+    return hardware_family::npu3;
+  case hardware_type::aie2ps:
+    return hardware_family::aie2ps;
+  case hardware_type::unknown:
+  default:
+    return hardware_family::unknown;
+  }
+}
+
+std::optional<std::string>
+smi_hardware_config::
+get_aie_architecture_version(hardware_type hw)
+{
+  switch (get_family(hw)) {
+  case hardware_family::phoenix:
+    return "aie2";
+  case hardware_family::strix:
+    return "aie2p";
+  case hardware_family::npu3:
+    return "aie4";
+  case hardware_family::aie2ps:
+    return "aie2ps";
+  default:
+    return std::nullopt;
+  }
+}
+
+bool
+smi_hardware_config::
+is_aie2_platform(hardware_type hw)
+{
+  switch (get_family(hw)) {
+  case hardware_family::phoenix:
+  case hardware_family::strix:
+    return true;
+  case hardware_family::npu3:
+    return false;
+  default:
+    throw std::runtime_error("Unsupported hardware type");
+  }
+}
+
+std::string
+smi_hardware_config::
+get_validate_archive_path(hardware_type hw)
+{
+  switch (get_family(hw)) {
+  case hardware_family::phoenix:
+    return "Runner/xrt_smi_phx.a";
+  case hardware_family::strix:
+    return "Runner/xrt_smi_strx.a";
+  case hardware_family::npu3:
+    return "Runner/xrt_smi_npu3.a";
+  default:
+    throw std::runtime_error("Unsupported hardware type");
+  }
 }
 
 tuple_vector

--- a/src/runtime_src/core/common/smi/smi.h
+++ b/src/runtime_src/core/common/smi/smi.h
@@ -12,6 +12,7 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <string>
 #include <tuple>
 #include <vector>
@@ -227,11 +228,21 @@ public:
     npu3_f3, // XXXXX
     npu3_f4, // XXXXX
     npu3_f5, // XXXXX
+    npu3_f6, // XXXXX 
     npu3_B01, // XXXXX
     npu3_B02, // XXXXX
     npu3_B03, // XXXXX
     aie2ps, // Telluride aie2ps
     unknown // Unknown hardware type
+  };
+
+  // Coarse hardware grouping used for xrt-smi config, AIE arch strings, and test routing.
+  enum class hardware_family {
+    phoenix, // AIE2 (PHX)
+    strix,   // AIE2P (STX, KRK)
+    npu3,    // AIE4
+    aie2ps,
+    unknown
   };
 
   XRT_CORE_COMMON_EXPORT
@@ -241,6 +252,33 @@ public:
   XRT_CORE_COMMON_EXPORT
   hardware_type 
   get_hardware_type(const xq::pcie_id::data&) const;
+
+  // Maps a specific hardware_type to its family. All per-device case logic lives here.
+  XRT_CORE_COMMON_EXPORT
+  static hardware_family
+  get_family(hardware_type hw);
+
+  XRT_CORE_COMMON_EXPORT
+  hardware_family
+  get_family(const xq::pcie_id::data& dev) const
+  {
+    return get_family(get_hardware_type(dev));
+  }
+
+  // AIE architecture version string for examine JSON; nullopt when unknown.
+  XRT_CORE_COMMON_EXPORT
+  static std::optional<std::string>
+  get_aie_architecture_version(hardware_type hw);
+
+  // True for PHX and STX/KRK (AIE2/AIE2P); false for NPU3 (AIE4).
+  XRT_CORE_COMMON_EXPORT
+  static bool
+  is_aie2_platform(hardware_type hw);
+
+  // Validate-runner archive path relative to the platform archive root.
+  XRT_CORE_COMMON_EXPORT
+  static std::string
+  get_validate_archive_path(hardware_type hw);
 
 private:
   std::map<xq::pcie_id::data, hardware_type> hardware_map;

--- a/src/runtime_src/core/common/smi/smi_ryzen.cpp
+++ b/src/runtime_src/core/common/smi/smi_ryzen.cpp
@@ -137,50 +137,32 @@ config_gen_npu3()
   };
 }
 
+static std::shared_ptr<config_gen_ryzen>
+create_config_generator(smi_hardware_config::hardware_family family)
+{
+  switch (family) {
+  case smi_hardware_config::hardware_family::phoenix:
+    return std::make_shared<config_gen_phoenix>();
+  case smi_hardware_config::hardware_family::strix:
+    return std::make_shared<config_gen_strix>();
+  case smi_hardware_config::hardware_family::npu3:
+    return std::make_shared<config_gen_npu3>();
+  default:
+    return std::make_shared<config_gen_strix>();
+  }
+}
+
 void
 populate_smi_instance(xrt_core::smi::smi* smi_instance, const xrt_core::device* device)
 {
   smi_hardware_config smi_hrdw;
   const auto pcie_id = xrt_core::device_query<xrt_core::query::pcie_id>(device);
-  auto hardware_type = smi_hrdw.get_hardware_type(pcie_id);
+  const auto family = smi_hrdw.get_family(pcie_id);
+  const auto generator = create_config_generator(family);
 
-  std::shared_ptr<config_gen_ryzen> generator;
-
-  switch (hardware_type) {
-  case smi_hardware_config::hardware_type::phx:
-  {
-    generator = std::make_shared<config_gen_phoenix>();
-    break;
-  }
-  case smi_hardware_config::hardware_type::stxA0:
-  case smi_hardware_config::hardware_type::stxB0:
-  case smi_hardware_config::hardware_type::stxH:
-  case smi_hardware_config::hardware_type::krk1:
-  {
-    generator = std::make_shared<config_gen_strix>();
-    break;
-  }
-  case smi_hardware_config::hardware_type::npu3_f0:
-  case smi_hardware_config::hardware_type::npu3_f1:
-  case smi_hardware_config::hardware_type::npu3_f2:
-  case smi_hardware_config::hardware_type::npu3_f3:
-  case smi_hardware_config::hardware_type::npu3_B01:
-  case smi_hardware_config::hardware_type::npu3_B02:
-  case smi_hardware_config::hardware_type::npu3_B03:
-  {
-    generator = std::make_shared<config_gen_npu3>();
-    break;
-  }
-  default:
-    generator = std::make_shared<config_gen_strix>();
-    break;
-  }
-
-  if (generator) {
-    smi_instance->add_subcommand("validate",  generator->create_validate_subcommand());
-    smi_instance->add_subcommand("examine",  generator->create_examine_subcommand());
-    smi_instance->add_subcommand("configure",  generator->create_configure_subcommand());
-  }
+  smi_instance->add_subcommand("validate",  generator->create_validate_subcommand());
+  smi_instance->add_subcommand("examine",  generator->create_examine_subcommand());
+  smi_instance->add_subcommand("configure",  generator->create_configure_subcommand());
 }
 
 std::string

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -216,39 +216,11 @@ XBUtilities::get_available_devices(bool inUserDomain)
       }
 
       try {
-        // Map hardware type to AIE architecture version string
         const auto& pcie_id = xrt_core::device_query<xrt_core::query::pcie_id>(device);
         xrt_core::smi::smi_hardware_config smi_hrdw;
-        auto hardware_type = smi_hrdw.get_hardware_type(pcie_id);
-
-        switch (hardware_type) {
-        case xrt_core::smi::smi_hardware_config::hardware_type::phx:
-          pt_dev.put("aie_architecture_version", "aie2");
-          break;
-        case xrt_core::smi::smi_hardware_config::hardware_type::stxA0:
-        case xrt_core::smi::smi_hardware_config::hardware_type::stxB0:
-        case xrt_core::smi::smi_hardware_config::hardware_type::stxH:
-        case xrt_core::smi::smi_hardware_config::hardware_type::krk1:
-          pt_dev.put("aie_architecture_version", "aie2p");
-          break;
-        case xrt_core::smi::smi_hardware_config::hardware_type::npu3_f0:
-        case xrt_core::smi::smi_hardware_config::hardware_type::npu3_f1:
-        case xrt_core::smi::smi_hardware_config::hardware_type::npu3_f2:
-        case xrt_core::smi::smi_hardware_config::hardware_type::npu3_f3:
-        case xrt_core::smi::smi_hardware_config::hardware_type::npu3_f4:
-        case xrt_core::smi::smi_hardware_config::hardware_type::npu3_f5:
-        case xrt_core::smi::smi_hardware_config::hardware_type::npu3_B01:
-        case xrt_core::smi::smi_hardware_config::hardware_type::npu3_B02:
-        case xrt_core::smi::smi_hardware_config::hardware_type::npu3_B03:
-          pt_dev.put("aie_architecture_version", "aie4");
-          break;
-        case xrt_core::smi::smi_hardware_config::hardware_type::aie2ps:
-          pt_dev.put("aie_architecture_version", "aie2ps");
-          break;
-        default:
-          pt_dev.put("aie_architecture_version", "N/A");
-          break;
-        }
+        const auto hardware_type = smi_hrdw.get_hardware_type(pcie_id);
+        const auto aie_arch = xrt_core::smi::smi_hardware_config::get_aie_architecture_version(hardware_type);
+        pt_dev.put("aie_architecture_version", aie_arch.value_or("N/A"));
       }
       catch (...) {
         // AIE architecture version wasn't added
@@ -1029,26 +1001,7 @@ bool
 XBUtilities::
 is_strix_hardware(xrt_core::smi::smi_hardware_config::hardware_type hw_type)
 {
-  switch (hw_type) {
-    case xrt_core::smi::smi_hardware_config::hardware_type::stxA0:
-    case xrt_core::smi::smi_hardware_config::hardware_type::stxB0:
-    case xrt_core::smi::smi_hardware_config::hardware_type::stxH:
-    case xrt_core::smi::smi_hardware_config::hardware_type::krk1:
-    case xrt_core::smi::smi_hardware_config::hardware_type::phx:
-      return true;
-    case xrt_core::smi::smi_hardware_config::hardware_type::npu3_f0:
-    case xrt_core::smi::smi_hardware_config::hardware_type::npu3_f1:
-    case xrt_core::smi::smi_hardware_config::hardware_type::npu3_f2:
-    case xrt_core::smi::smi_hardware_config::hardware_type::npu3_f3:
-    case xrt_core::smi::smi_hardware_config::hardware_type::npu3_f4:
-    case xrt_core::smi::smi_hardware_config::hardware_type::npu3_f5:
-    case xrt_core::smi::smi_hardware_config::hardware_type::npu3_B01:
-    case xrt_core::smi::smi_hardware_config::hardware_type::npu3_B02:
-    case xrt_core::smi::smi_hardware_config::hardware_type::npu3_B03:
-      return false;
-    default:
-      throw std::runtime_error("Unsupported hardware type");
-  }
+  return xrt_core::smi::smi_hardware_config::is_aie2_platform(hw_type);
 }
 
 std::string


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
This PR adds the device configuration for npu3 (2) family. This PR also cleans up the code to maintain device families for a logical combination of artifacts and types and avoiding replication of case statements wherever the distinction is required.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://jira.xilinx.com/browse/AIESW-33742

#### How problem was solved, alternative solutions (if any) and why they were rejected
Solved via adding the new device type to the list of devices supported

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Tested on an npu3 board

#### Documentation impact (if any)
None
