### PR TITLE
AIESW-34220 Secure DLL loading

### DIFF
--- a/src/runtime_src/core/common/dlfcn.h
+++ b/src/runtime_src/core/common/dlfcn.h
@@ -1,28 +1,19 @@
-/**
- * Copyright (C) 2019 Xilinx, Inc
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2019 Xilinx, Inc. All rights reserved.
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 #ifndef core_common_dlopen_h_
 #define core_common_dlopen_h_
 
 #ifndef _WIN32
 # include <dlfcn.h>
 #else
+# include <filesystem>
 # include <stdexcept>
 # include <string>
 # include <windows.h>
+# ifndef LOAD_LIBRARY_SEARCH_SYSTEM32
+#  define LOAD_LIBRARY_SEARCH_SYSTEM32 0x00000800
+# endif
 # define RTLD_LAZY 0
 # define RTLD_GLOBAL 0
 # define RTLD_NOW 0
@@ -54,14 +45,43 @@ dlsym(void* handle, const char* symbol)
 {
   return ::dlsym(handle,symbol);
 }
-
 #endif
 
 #ifdef _WIN32
+// dlopen(const char* dllname, int) -
+// We follow Microsoft DLL search-order guidance for all runtime
+// loads; separately, SDK plugin discovery via environment variable is
+// an explicit trust boundary and is not protected by that guidance.
+// Specifically, the environment can define XILINX_XRT or
+// AMD_NPU_SDK_PATH, both of which are considered user trusted
+// boundaries from where DLLs can be loaded if needed.
 inline void*
 dlopen(const char* dllname, int)
 {
-  return ::LoadLibrary(dllname);
+  namespace sfs = std::filesystem;
+
+  if (!dllname || !*dllname)
+    throw std::runtime_error("Empty DLL path");
+
+  sfs::path path{dllname};
+  uint32_t flags = 0;
+  if (path.has_parent_path() && !path.parent_path().empty()) {
+    if (!path.is_absolute())
+      path = sfs::absolute(path);
+
+    // Make sure any dependencies are satisfied first from same
+    // directory as the dll being loaded.  Even when the main DLL
+    // comes from a trusted absolute path, a missing or ambiguous
+    // dependency could otherwise be satisfied from CWD. This flag
+    // makes “same directory as the plugin” win first.
+    flags = LOAD_WITH_ALTERED_SEARCH_PATH;
+  }
+  else {
+    // Bare filename: restrict search to System32 (never CWD or PATH).
+    flags = LOAD_LIBRARY_SEARCH_SYSTEM32;
+  }
+
+  return ::LoadLibraryExA(path.string().c_str(), nullptr, flags);
 }
 
 inline void


### PR DESCRIPTION
#### Problem solved by the commit
Change Windows LoadLibrary to use LoadLibraryEx and use explicit flags to meet Microsoft DLL search-order guidance.

#### How problem was solved, alternative solutions (if any) and why they were rejected
- Bare files (no absolute path) are loaded from system32 only.
- Relative paths are converted to full paths rooted at CWD forcing dependencies to be searched as described for the full path case.
- Full paths are loaded from specified location and dependencies are satisfied first from same location before consulting default search order.

We follow Microsoft DLL search-order guidance for all runtime loads; separately, SDK plugin discovery via environment variable is an explicit trust boundary and is not protected by that guidance. Specifically, the environment can define XILINX_XRT or AMD_NPU_SDK_PATH, both of which are considered user trusted boundaries from where DLLs can be loaded if needed.