### PR TITLE
Make capture and replay thread aware

### DIFF
--- a/src/runtime_src/core/common/runner/capture.cpp
+++ b/src/runtime_src/core/common/runner/capture.cpp
@@ -541,9 +541,9 @@ class frames
   std::map<const xrt::runlist_impl*, runlist> m_runlists;
 
   // A frame is either an execution of a single run object or a
-  // execution of a runlist with multiple run objects. A frame
-  // is a pointer to an object stored in a std::map, vector can
-  // resize by pointers remain valid.
+  // execution of a runlist with multiple run objects.
+  // Vector capacity is reserved in constructor to prevent reallocation
+  // which would invalidate frame pointers in m_hdl2frame and m_tid2last_frame.
   std::vector<frame> m_frames;
 
   // Mapping from run_impl or runlist_impl handle to the frame
@@ -566,7 +566,11 @@ class frames
 
   frames()
     : m_artifacts{xrt_core::config::get_capture_dir()}
-  {}
+  {
+    // Reserve capacity to prevent vector reallocation which would
+    // invalidate frame pointers stored in m_hdl2frame and m_tid2last_frame
+    m_frames.reserve(xrt_core::config::get_capture_frames());
+  }
 
   ~frames()
   {

--- a/src/runtime_src/core/common/runner/capture.cpp
+++ b/src/runtime_src/core/common/runner/capture.cpp
@@ -32,6 +32,7 @@
 #include <mutex>
 #include <set>
 #include <string>
+#include <thread>
 #include <variant>
 #include <vector>
 
@@ -371,6 +372,7 @@ class frames
     std::vector<std::string> m_waits;
 
     uint64_t m_id;
+    std::thread::id m_tid;  // thread that started this frame
 
     static uint64_t
     get_uid()
@@ -456,6 +458,7 @@ class frames
     frame(FrameType ft, artifacts& repo)
       : m_frame(std::move(ft))
       , m_id(get_uid())
+      , m_tid(std::this_thread::get_id())
     {
       capture_frame_start_data(ft, repo);
     }
@@ -514,6 +517,12 @@ class frames
     {
       return m_waits;
     }
+
+    std::thread::id
+    get_thread_id() const
+    {
+      return m_tid;
+    }
   };
 
   // Track xrt::run and xrt::runlist objects created by application
@@ -533,6 +542,11 @@ class frames
   // application run.wait() or runlist.wait to frame that should
   // waited on.
   std::map<const void*, frame*> m_hdl2frame;
+
+  // Mapping from thread ID to the last frame started by that thread.
+  // Used to find the active frame for the current thread when
+  // capturing wait() calls.
+  std::map<std::thread::id, frame*> m_tid2last_frame;
 
   // ELFIO cannot be dumped post creation, so capture as created
   // along with the data used to create ELF
@@ -1031,11 +1045,12 @@ public:
     std::lock_guard lk(m_mutex);
     auto& frame = m_frames.emplace_back(&m_runs.at(hdl), m_artifacts);
     m_hdl2frame.emplace(hdl, &frame);
+    m_tid2last_frame[std::this_thread::get_id()] = &frame;
   }
 
   // wait() - capture xrt::run::wait() or xrt::runlist::wait()
-  // 
-  // Waits are attributed for the current active frame, and during
+  //
+  // Waits are attributed to the current thread's active frame, and during
   // replay, are executed after the active frame has been started
   template <typename HandleType>
   void
@@ -1045,6 +1060,14 @@ public:
     if (m_frames.empty())
       throw std::runtime_error("No active frame, cannot wait");
 
+    // Find the current thread's active frame
+    auto tid = std::this_thread::get_id();
+    auto tid_itr = m_tid2last_frame.find(tid);
+    if (tid_itr == m_tid2last_frame.end())
+      throw std::runtime_error("No active frame for current thread, cannot wait");
+
+    frame* active_frame = tid_itr->second;
+
     // Find last frame starting from m_frames.end() that is
     // created from hdl, this is the frame to wait on.
     auto itr = std::find_if(m_frames.rbegin(), m_frames.rend(),
@@ -1052,8 +1075,8 @@ public:
     if (itr == m_frames.rend())
       throw std::runtime_error("No frame to wait on");
 
-    // Add wait to current active frame 
-    m_frames.back().add_wait((*itr).get_name());
+    // Add wait to current thread's active frame
+    active_frame->add_wait((*itr).get_name());
   }
 
   // start() - capture xrt::runlist::start()
@@ -1063,6 +1086,7 @@ public:
     std::lock_guard lk(m_mutex);
     auto& frame = m_frames.emplace_back(&m_runlists.at(hdl), m_artifacts);
     m_hdl2frame.emplace(hdl, &frame);
+    m_tid2last_frame[std::this_thread::get_id()] = &frame;
   }
 
   // capture_elf() - capture xrt::elf constructor

--- a/src/runtime_src/core/common/runner/capture.cpp
+++ b/src/runtime_src/core/common/runner/capture.cpp
@@ -31,6 +31,7 @@
 #include <map>
 #include <mutex>
 #include <set>
+#include <sstream>
 #include <string>
 #include <thread>
 #include <variant>
@@ -73,6 +74,14 @@ static std::string
 to_string(const void* v)
 {
   return std::to_string(reinterpret_cast<uintptr_t>(v));
+}
+
+static std::string
+to_string(std::thread::id tid)
+{
+  std::ostringstream oss;
+  oss << tid;
+  return oss.str();
 }
 
 } // namespace
@@ -943,6 +952,7 @@ class frames
   //
   // {
   //   "name":  unique identifer for this frame
+  //   "tid":   thread identifier that started this frame
   //   "runs":  [array of frame run objects]
   //   "waits": [array of frame wait]
   // }
@@ -959,6 +969,7 @@ class frames
   {
     json j = json::object();
     j["name"] = frame.get_name();
+    j["tid"] = to_string(frame.get_thread_id());
     j["runs"] = replay_execution_frame_runs(frame);
     j["waits"] = replay_execution_frame_waits(frame);
     return j;
@@ -975,15 +986,35 @@ class frames
     return j;
   }
 
+  // replay_execution_threads() - array of unique thread identifiers
+  //
+  // Returns an array of thread ID strings representing all unique
+  // threads that started frames during capture.
+  json
+  replay_execution_threads() const
+  {
+    std::set<std::thread::id> unique_tids;
+    for (const auto& frame : m_frames)
+      unique_tids.insert(frame.get_thread_id());
+
+    json j = json::array();
+    for (const auto& tid : unique_tids)
+      j.push_back(to_string(tid));
+
+    return j;
+  }
+
   // replay_execution() - execution object
   //
   //  "execution:" {
+  //      "threads": [array of unique thread identifiers]
   //      "frames": [array of frame objects]
   //  }
   json
   replay_execution() const
   {
     json execution = json::object();
+    insert_json_object(execution["execution"]["threads"], replay_execution_threads());
     insert_json_object(execution["execution"]["frames"], replay_execution_frames());
     return execution;
   }

--- a/src/runtime_src/core/common/runner/replay.md
+++ b/src/runtime_src/core/common/runner/replay.md
@@ -14,6 +14,7 @@ The captured data includes:
 - Kernel objects and control code
 - Run objects with their arguments
 - Frame execution sequence and synchronization points
+- Application thread context for each frame
 
 ## Capturing an Application
 
@@ -150,9 +151,18 @@ The capture system uses a smart invalidation mechanism:
 ### Wait Synchronization
 
 The capture system records all `xrt::run::wait()` and `xrt::runlist::wait()` calls:
-- Waits are associated with the current active frame
+- Waits are associated with the calling thread's active frame
 - Replay executes waits in the same order as captured
 - Handles asynchronous execution correctly
+- Cross-thread waits are preserved (Thread A can wait on a frame started by Thread B)
+
+### Multi-threaded Capture
+
+The capture system is thread-aware:
+- Each frame records the thread ID that executed `start()` or `execute()`
+- Waits are attributed to the calling thread's active frame
+- Multiple threads can execute frames concurrently
+- Frame execution order is preserved per-thread during replay
 
 ## Replay JSON Schema
 
@@ -206,9 +216,11 @@ The generated `replay.json` follows this structure:
     ]
   },
   "execution": {
+    "threads": ["<thread_id_1>", "<thread_id_2>"],
     "frames": [
       {
         "name": "<frame_id>",
+        "tid": "<thread_id>",
         "runs": [
           {
             "run": "<run_id>",
@@ -238,7 +250,9 @@ The generated `replay.json` follows this structure:
 
 #### Execution Section
 
+- **threads**: Array of unique thread identifiers from capture
 - **frames**: Ordered list of frame executions
+  - **tid**: Thread identifier that executed this frame
   - **runs**: Which run objects are executed in this frame
   - **arguments**: Which buffer data files to load for each run
   - **waits**: Which frames must complete before next frame can start
@@ -286,6 +300,20 @@ Capture complex multi-layered applications (VAIML, PyTorch, etc.) and analyze:
 % # Analyze captured kernels, buffers, execution patterns
 ```
 
+### Multi-threaded Application Testing
+
+Capture and replay multi-threaded applications with preserved threading patterns:
+
+```bash
+% # Capture multi-threaded application
+% xrt-capture --frames 100 -- ./multithreaded_app
+
+% # Replay with same thread count and execution pattern
+% xrt-replay --replay /tmp/xrt_capture/replay.json --dir /tmp/xrt_capture --iter 10
+```
+
+The replay will create the same number of threads as the captured application and execute frames in their original thread context.
+
 ## Limitations
 
 ### Current Limitations
@@ -331,6 +359,82 @@ Enable XRT debug messages:
 % export XRT_VERBOSITY=6
 % xrt-replay --replay replay.json --dir capture
 ```
+
+## Thread-Aware Replay
+
+### Overview
+
+Starting with the thread-aware capture/replay feature, XRT preserves and recreates the application's threading pattern during replay. This ensures:
+- Accurate performance measurement for multi-threaded applications
+- Correct reproduction of thread-dependent behavior
+- Realistic workload characterization
+
+### How It Works
+
+**During Capture:**
+1. Each `xrt::run::start()` or `xrt::runlist::execute()` records the calling thread's ID
+2. Each `xrt::run::wait()` or `xrt::runlist::wait()` is associated with the calling thread's active frame
+3. Thread IDs are exported to `replay.json` in the execution section
+
+**During Replay:**
+1. Worker threads are created based on unique thread IDs from capture
+2. Frames are grouped and assigned to their corresponding worker threads
+3. Each worker thread executes its frames in the original capture order
+4. Cross-thread waits are handled through XRT's synchronization primitives
+
+### Threading Model
+
+**Resources (shared across threads):**
+- Buffer objects (`xrt::bo`)
+- Hardware contexts (`xrt::hw_context`)
+- Kernel objects (`xrt::kernel`)
+- Run objects (`xrt::run`)
+- Runlist objects (`xrt::runlist`)
+
+**Execution (thread-specific):**
+- `xrt::run::start()` - Executed in the thread that called it during capture
+- `xrt::runlist::execute()` - Executed in the thread that called it during capture
+- `xrt::run::wait()` - Executed in the thread's context, can wait on any frame
+- `xrt::runlist::wait()` - Executed in the thread's context, can wait on any frame
+
+### Example
+
+Consider a two-threaded application:
+
+**Thread 1:**
+```cpp
+run1.start();     // Frame 0, Thread 1
+run1.wait();
+run3.start();     // Frame 2, Thread 1
+run3.wait();
+```
+
+**Thread 2:**
+```cpp
+run2.start();     // Frame 1, Thread 2
+run2.wait();
+```
+
+**Captured JSON:**
+```json
+{
+  "execution": {
+    "threads": ["140123456789", "140123456790"],
+    "frames": [
+      {"name": "frame_0", "tid": "140123456789", "waits": ["frame_0"]},
+      {"name": "frame_1", "tid": "140123456790", "waits": ["frame_1"]},
+      {"name": "frame_2", "tid": "140123456789", "waits": ["frame_2"]}
+    ]
+  }
+}
+```
+
+**During Replay:**
+- Two worker threads are created
+- Thread 1 executes frame_0, then frame_2
+- Thread 2 executes frame_1
+- Execution order within each thread is preserved
+- Threads run concurrently
 
 ## Advanced Topics
 

--- a/src/runtime_src/core/common/runner/xrt-replay.cpp
+++ b/src/runtime_src/core/common/runner/xrt-replay.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//#define XRT_VERBOSE
 #include "repo.h"
 #include "detail/module_cache.h"
 #include "detail/streambuf.h"
@@ -35,12 +36,15 @@
 #include "core/include/xrt/experimental/xrt_module.h"
 #include "core/include/xrt/experimental/xrt_xclbin.h"
 
+#include <condition_variable>
 #include <cstdint>
 #include <fstream>
 #include <iostream>
 #include <map>
+#include <mutex>
 #include <stdexcept>
 #include <string>
+#include <thread>
 #include <vector>
 
 #ifdef _WIN32
@@ -497,9 +501,11 @@ struct replayer
       };
 
       const repo_type* m_repo;              // repository with bo file data
+      std::string m_name;
       std::unique_ptr<executor> m_executor; // executor for run objects
       initializer m_init;                   // run object initializer
       std::vector<std::string> m_waits;     // wait frames prior to next frame
+      std::string m_tid;                    // thread id from replay.json
 
       /// I think frame will have to record all run objects in a vector
       /// and then call set_arg for each of the bo in initializer.
@@ -554,6 +560,7 @@ struct replayer
     public:
       frame(const resources& resources, const json& frame_object, const repo_type& repo)
         : m_repo(&repo)
+        , m_name(frame_object.at("name").get<std::string>())
         , m_executor{create_executor(resources, frame_object.at("runs"))}
         , m_init{create_initializer(resources, frame_object.at("runs"))}
 #ifdef _WIN32
@@ -562,6 +569,7 @@ struct replayer
 #else
         , m_waits(frame_object.at("waits"))
 #endif
+        , m_tid(frame_object.at("tid").get<std::string>())
       {}
 
       const std::vector<std::string>&
@@ -570,9 +578,16 @@ struct replayer
         return m_waits;
       }
 
+      const std::string&
+      get_tid() const
+      {
+        return m_tid;
+      }
+
       void
       execute()
       {
+        XRT_DEBUGF("Execute frame %s\n", m_name.c_str());
         m_init.init(m_repo);
         m_executor->execute();
       }
@@ -580,12 +595,53 @@ struct replayer
       void
       wait()
       {
+        XRT_DEBUGF("Waiting on frame %s\n", m_name.c_str());
         m_executor->wait();
       }
       
     }; //class frame
 
-    std::map<std::string, frame> m_frames;
+    // Thread coordination
+    std::mutex m_mutex;
+    std::condition_variable m_ready;
+    size_t m_iterations = 0;
+
+    // These maps are ordered by frame name, which correspond to the
+    // execution order in capture.  It is safe to iterate these maps
+    // and assume that the iteration order is the execution order.
+    std::map<std::string, frame>                m_frames;
+    std::map<std::string, std::vector<frame*>>  m_frames_thread_groups;
+    std::vector<std::thread>                    m_threads;
+
+    void
+    executor(std::string tid)
+    {
+      {
+        std::unique_lock lk(m_mutex);
+        m_ready.wait(lk, [this] { return m_iterations; });
+      }
+
+      auto& frames = m_frames_thread_groups.at(tid);
+
+      auto execute_iteration = [this, &frames] () {
+        for (auto frame : frames) {
+          frame->execute();
+
+          for (auto& frame_name : frame->get_waits())
+            m_frames.at(frame_name).wait();
+        }
+      };
+
+      auto wait_iteration = [&frames] () {
+        for (auto frame : frames)
+          frame->wait();
+      };
+        
+      for (size_t i = 0; i < m_iterations; ++i) {
+        execute_iteration();
+        wait_iteration();
+      }
+    }
 
     static std::map<std::string, frame>
     create_frames(const resources& resources, const json& frames_array, const repo_type& repo)
@@ -597,28 +653,73 @@ struct replayer
       return frames;
     }
 
+    static std::map<std::string, std::vector<frame*>>
+    group_frames(std::map<std::string, frame>& frames)
+    {
+      std::map<std::string, std::vector<frame*>> groups;
+      for (auto& [nm, frame] : frames)
+        groups[frame.get_tid()].push_back(&frame);
+
+      return groups;
+    }
+
+    std::vector<std::thread>
+    create_threads(const json& threads_array)
+    {
+      std::vector<std::thread> threads;
+      threads.reserve(threads_array.size());
+      for (const auto& tid_object : threads_array) {
+        auto tid = tid_object.get<std::string>();
+        threads.push_back(std::thread(&execution::executor, this, tid));
+      }
+      return threads;
+    }
+
   public:
     execution(const resources& resources, const json& exec_object, const repo_type& repo)
       : m_frames{create_frames(resources, exec_object.at("frames"), repo)}
+      , m_frames_thread_groups{group_frames(m_frames)}
+      , m_threads{create_threads(exec_object.at("threads"))}
     {}
 
-    void
-    run()
+    ~execution()
     {
-      for (auto& [nm, frame] : m_frames) {
-        frame.execute();
+      // Ensure that all threads have been executed and joined.
+      // This seems overly protective given that xrt-replay does
+      // call run() exactly once.
+      if (m_iterations)
+        return; // run() has been called
+      
+      try {
+        run(1); // should never be executed
+      }
+      catch (const std::exception& ex) {
+        xrt_core::send_exception_message(ex.what());
+      }
+    }
 
-        // Consider translating wait names to frames in frame ctor
-        for (auto& frame_name : frame.get_waits())
-          m_frames.at(frame_name).wait();
+    // run() - Run execution section specified number of iterations
+    // This function must and can be called once only
+    void
+    run(size_t iterations)
+    {
+      if (m_iterations)
+        throw std::runtime_error("execution::run() can only be called once");
+
+      {
+        std::lock_guard lk(m_mutex);
+        m_iterations = iterations;
+        m_ready.notify_all();
       }
 
-      // Capture has no chance to capture waits after last frame at
-      // frame capture limit. Make sure wait is called on all frames.
-      // The capture frames cannot be destroy nor iterated unless they
-      // have been waited on.
-      for (auto& [nm, frame] : m_frames)
-        frame.wait();
+      // Ideally join should be in dtor, but we need to join here or
+      // find some other way of ensuring that all threads have
+      // completed their iterations before returning.  This is
+      // necessary because outer call is timing this call.  Timing may
+      // be off depending on how expensive it is to join.
+      for (auto& thread : m_threads)
+        if (thread.joinable())
+          thread.join();
     }
 
     size_t
@@ -627,6 +728,11 @@ struct replayer
       return m_frames.size();
     }
 
+    size_t
+    num_threads() const
+    {
+      return m_threads.size();
+    }
   }; // class execution
 
 
@@ -648,8 +754,7 @@ struct replayer
     unsigned long long time_ns = 0;
     {
       xrt_core::time_guard tg(time_ns);
-      for (size_t i = 0; i < iterations; ++i)
-        m_execution.run();
+      m_execution.run(iterations);
     }
 
     // NOLINTBEGIN
@@ -661,6 +766,7 @@ struct replayer
     m_report["cpu"]["elapsed_us"] = elapsed;
     m_report["iterations"] = iterations;
     m_report["frames"] = m_execution.num_frames();
+    m_report["threads"] = m_execution.num_threads();
   }
 
   json

--- a/src/runtime_src/core/common/runner/xrt-replay.cpp
+++ b/src/runtime_src/core/common/runner/xrt-replay.cpp
@@ -670,7 +670,7 @@ struct replayer
       threads.reserve(threads_array.size());
       for (const auto& tid_object : threads_array) {
         auto tid = tid_object.get<std::string>();
-        threads.push_back(std::thread(&execution::executor, this, tid));
+        threads.emplace_back(std::thread(&execution::executor, this, tid));
       }
       return threads;
     }


### PR DESCRIPTION
#### Problem solved by the commit
Applications may execute runs and runlists from multiple threads concurrently. To accurately replay captured workloads and measure realistic performance, replay must recreate the same threading pattern used by the application during capture.

#### How problem was solved, alternative solutions (if any) and why they were rejected
- Phase 1: Thread-aware capture (capture.cpp)
1. Track thread ID (std::thread::id) in each captured frame
2. Maintain per-thread "active frame" mapping (tid -> last started frame)
3. Change capture_wait() to attribute waits to the calling thread's active frame instead of the global last frame

- Phase 2: Export thread info to JSON (capture.cpp)
1. Each frame in JSON now includes "tid" field with thread ID string
2. Execution section now includes "threads" array with all unique  thread IDs that participated in frame execution

- Phase 3: Thread-aware replay (xrt-replay.cpp) 
1. Constructor: Parse frames, group by tid, create worker threads (waiting)
2. run(iterations): Wake threads, they execute N iterations, exit
3. Destructor: Join threads if not already joined (safety)

#### Risks (if any) associated the changes in the commit
Threading overhead in measuring metrics

#### What has been tested and how, request additional testing if necessary
Use xrt-runner to capture existing model tests.

```
% xrt-capture --frames 10 --output-dir /tmp/capture -- xrt-runner --recipe resnet50/recipe/recipe.json --profile resnet50/recipe/profile.json --dir resnet50 --mode validate
% xrt-replay --replay /tmp/capture/replay.json --dir /tmp/capture -i 10 --report
```

```
% xrt-capture --frames 10 --output-dir /tmp/capture -- xrt-runner --script runner/concurrency/3-models.json --mode validate
% xrt-replay --replay /tmp/capture/replay.json --dir /tmp/capture -i 10 --report
```
