### PR TITLE
Refactor xrt::elf platform values as per latest spec

### DIFF
--- a/src/runtime_src/core/common/api/xrt_elf.cpp
+++ b/src/runtime_src/core/common/api/xrt_elf.cpp
@@ -1484,7 +1484,7 @@ create_elf_impl(ELFIO::elfio&& elfio, const std::string& path = {})
   case xrt::elf::platform::aie2p:
     return std::make_shared<xrt::elf_aie_gen2>(std::move(elfio), platform, path);
   case xrt::elf::platform::aie2ps:
-  case xrt::elf::platform::aie2ps_group:
+  case xrt::elf::platform::aie2ps_legacy:
   case xrt::elf::platform::aie4:
   case xrt::elf::platform::aie4a:
   case xrt::elf::platform::aie4z:

--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -1207,7 +1207,7 @@ create_module_run(const xrt::elf& elf, const xrt::hw_context& hwctx,
     // pre created ctrlpkt bo is used only in aie2p platform
     return xrt::module{std::make_shared<xrt::module_run_aie_gen2>(elf, hwctx, ctrl_code_id, ctrlpkt_bo)};
   case xrt::elf::platform::aie2ps:
-  case xrt::elf::platform::aie2ps_group:
+  case xrt::elf::platform::aie2ps_legacy:
   case xrt::elf::platform::aie4:
   case xrt::elf::platform::aie4a:
   case xrt::elf::platform::aie4z:
@@ -1317,7 +1317,7 @@ get_patch_buf_size(const xrt::module& module, xrt_core::elf_patcher::buf_type ty
         throw std::runtime_error("Unknown buffer type passed");
     }
   }
-  else if (platform == xrt::elf::platform::aie2ps || platform == xrt::elf::platform::aie2ps_group ||
+  else if (platform == xrt::elf::platform::aie2ps || platform == xrt::elf::platform::aie2ps_legacy ||
           platform == xrt::elf::platform::aie4 || platform == xrt::elf::platform::aie4a ||
           platform == xrt::elf::platform::aie4z) {
     auto module_config =
@@ -1368,7 +1368,7 @@ patch(const xrt::module& module, uint8_t* ibuf, size_t sz,
         throw std::runtime_error("Unknown buffer type passed");
     }
   }
-  else if (platform == xrt::elf::platform::aie2ps || platform == xrt::elf::platform::aie2ps_group ||
+  else if (platform == xrt::elf::platform::aie2ps || platform == xrt::elf::platform::aie2ps_legacy ||
            platform == xrt::elf::platform::aie4 || platform == xrt::elf::platform::aie4a ||
            platform == xrt::elf::platform::aie4z) {
     auto module_config =

--- a/src/runtime_src/core/include/xrt/experimental/xrt_elf.h
+++ b/src/runtime_src/core/include/xrt/experimental/xrt_elf.h
@@ -230,13 +230,13 @@ public:
    * These values correspond to the ELF header e_ident[EI_OSABI] field
    * and identify which AIE architecture the ELF was compiled for.
    */
-   enum class platform : uint8_t {
-    aie2ps       = 64,   // AIE2PS architecture
-    aie2p        = 69,   // AIE2P architecture
-    aie2ps_group = 70,   // AIE2PS group variant
-    aie4         = 75,   // AIE4 architecture
-    aie4a        = 86,   // AIE4 variant
-    aie4z        = 105   // AIE4 variant
+  enum class platform : uint8_t {
+    aie2p           = 69,   // AIE2P architecture
+    aie2ps_legacy   = 70,   // AIE2PS architecture with older ELF version (0x02, 0x03)
+    aie2ps          = 64,   // AIE2PS architecture with newer ELF version ( >= 0x20)
+    aie4            = 75,   // AIE4 architecture
+    aie4a           = 86,   // AIE4 variant
+    aie4z           = 105   // AIE4 variant
   };
 
   /**


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Refactored xrt::elf os abi values and names as per latest spec - https://amd.atlassian.net/wiki/spaces/AIE/pages/832142269/AIEBU+User+Manual#Target-to-ELF-ABI-and-OS_ABI-version-Mapping

#### What has been tested and how, request additional testing if necessary
Tested by running testcases from Telluride repo on hw and things work as expected

#### Documentation impact (if any)
Added appropriate comments in header.