### PR TITLE
AIESW-13862: Fix group_id crash for scalar kernel arguments

### DIFF
--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -696,6 +696,13 @@ class ip_context
     int32_t
     get_arg_memidx(size_t argidx) const
     {
+      // Calling group_id() on a scalar argument crashes with std::out_of_range
+      // because default_connection is only populated for arguments with memory
+      // connections. When a scalar argument appears after all pointer arguments,
+      // its index falls outside the vector bounds. The bounds check below
+      // intercepts this and returns no_memidx for such arguments.
+      if (argidx >= default_connection.size())
+        return no_memidx;
       return default_connection.at(argidx);
     }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Calling xrt::kernel::group_id() on a scalar argument crashes
with std::out_of_range because connectivity::default_connection is only
populated for arguments with memory connections. When a scalar argument
appears after all pointer arguments, its index falls outside the vector
bounds causing the crash.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
[AIESW-13862](https://jira.xilinx.com/browse/AIESW-13862)
#### How problem was solved, alternative solutions (if any) and why they were rejected
Added a bounds check in connectivity::get_arg_memidx() to return
no_memidx when argidx falls outside default_connection.
#### Risks (if any) associated the changes in the commit
Low
#### What has been tested and how, request additional testing if necessary
Tested on telluride board.
#### Documentation impact (if any)
NA