### PR TITLE
Update Yocto manifest to 2026.2 stable and SPDX LICENSE for bbappend QA

### DIFF
--- a/build/build_yocto.sh
+++ b/build/build_yocto.sh
@@ -77,7 +77,7 @@ install_recipes()
         echo 'EXTERNALSRC_BUILD = "${WORKDIR}/build"' >> $XRT_BB
 	echo 'DEPENDS += " systemtap"' >> $XRT_BB
         echo 'PACKAGE_CLASSES = "package_rpm"' >> $XRT_BB
-        echo 'LICENSE = "GPLv2 & Apache-2.0"' >> $XRT_BB
+        echo 'LICENSE = "GPL-2.0-or-later & Apache-2.0"' >> $XRT_BB
         echo 'LIC_FILES_CHKSUM = "file://../LICENSE;md5=de2c993ac479f02575bcbfb14ef9b485 \' >> $XRT_BB
         echo '                    file://runtime_src/core/edge/drm/zocl/LICENSE;md5=7d040f51aae6ac6208de74e88a3795f8 "' >> $XRT_BB
     fi
@@ -88,7 +88,7 @@ install_recipes()
         echo "EXTERNALSRC = \"$XRT_REPO_DIR/src/runtime_src/core/edge/drm/zocl\"" >> $ZOCL_BB
         echo "EXTERNALSRC_BUILD = \"$XRT_REPO_DIR/src/runtime_src/core/edge/drm/zocl\"" >> $ZOCL_BB
         echo 'PACKAGE_CLASSES = "package_rpm"' >> $ZOCL_BB
-        echo 'LICENSE = "GPLv2 & Apache-2.0"' >> $ZOCL_BB
+        echo 'LICENSE = "GPL-2.0-or-later & Apache-2.0"' >> $ZOCL_BB
         echo 'LIC_FILES_CHKSUM = "file://LICENSE;md5=7d040f51aae6ac6208de74e88a3795f8"' >> $ZOCL_BB
         if [[ ! -z $XRT_VERSION_PATCH ]]; then
             echo "EXTRA_OEMAKE += \"XRT_VERSION_PATCH=$XRT_VERSION_PATCH\"" >> $ZOCL_BB

--- a/build/yocto.build
+++ b/build/yocto.build
@@ -1,4 +1,4 @@
 REPO_URL=https://gitenterprise.xilinx.com/ssw-devops/yocto-tagged-manifest.git
 BRANCH=master
-MANIFEST_PATH=/proj/yocto/edf/2026.1/stable/Yocto_edf_2026.1_04162105
-MANIFEST_FILE=default_04162105.xml
+MANIFEST_PATH=/proj/yocto/edf/2026.2/stable/Yocto_edf_2026.2_06121253
+MANIFEST_FILE=default_06121253.xml


### PR DESCRIPTION


<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Point XRT Yocto builds at the resolved 2026.2 stable tree and use SPDX license strings so do_package_qa passes on current OE. Update yocto to the recent stable version: Yocto_edf_2026.1_04162105
SH ticket: https://jira.xilinx.com/browse/SH-3007

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Updated the yocto version

#### Risks (if any) associated the changes in the commit
low

#### What has been tested and how, request additional testing if necessary
Tested by building the xrt rpms using yocto script

#### Documentation impact (if any)
low