### PR TITLE
Update aiebu submodule and print opcode information in context health report on ERT_CMD_STATE_TIMEOUT (for AIE4 and AIE2PS)

### DIFF
--- a/src/runtime_src/core/common/CMakeLists.txt
+++ b/src/runtime_src/core/common/CMakeLists.txt
@@ -112,8 +112,8 @@ endif()
 # INSTALL_INTERFACE is for external targets that link XRT::xrt_coreutil
 # Link aiebu dtrace library when aiebu is built
 if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.18.0")
-  target_link_libraries(xrt_coreutil PRIVATE cert_dtrace_static)
-  target_link_libraries(xrt_coreutil_static PRIVATE cert_dtrace_static)
+  target_link_libraries(xrt_coreutil PRIVATE cert_dtrace_static aiebu_static)
+  target_link_libraries(xrt_coreutil_static PRIVATE cert_dtrace_static aiebu_static)
 endif()
 
 target_include_directories(xrt_coreutil

--- a/src/runtime_src/core/common/api/CMakeLists.txt
+++ b/src/runtime_src/core/common/api/CMakeLists.txt
@@ -28,5 +28,4 @@ target_include_directories(core_common_api_library_objects
   PRIVATE
   ${XRT_SOURCE_DIR}/runtime_src
   ${XRT_SOURCE_DIR}/runtime_src/core/common/elf
-  ${XRT_SOURCE_DIR}/runtime_src/core/common/aiebu/src/cpp/include
   )

--- a/src/runtime_src/core/common/api/CMakeLists.txt
+++ b/src/runtime_src/core/common/api/CMakeLists.txt
@@ -29,5 +29,4 @@ target_include_directories(core_common_api_library_objects
   ${XRT_SOURCE_DIR}/runtime_src
   ${XRT_SOURCE_DIR}/runtime_src/core/common/elf
   ${XRT_SOURCE_DIR}/runtime_src/core/common/aiebu/src/cpp/include
-  ${XRT_SOURCE_DIR}/runtime_src/core/common/aiebu/src/cpp
   )

--- a/src/runtime_src/core/common/api/CMakeLists.txt
+++ b/src/runtime_src/core/common/api/CMakeLists.txt
@@ -28,4 +28,5 @@ target_include_directories(core_common_api_library_objects
   PRIVATE
   ${XRT_SOURCE_DIR}/runtime_src
   ${XRT_SOURCE_DIR}/runtime_src/core/common/elf
+  ${XRT_SOURCE_DIR}/runtime_src/core/common/aiebu/src/cpp/include
   )

--- a/src/runtime_src/core/common/api/CMakeLists.txt
+++ b/src/runtime_src/core/common/api/CMakeLists.txt
@@ -29,4 +29,5 @@ target_include_directories(core_common_api_library_objects
   ${XRT_SOURCE_DIR}/runtime_src
   ${XRT_SOURCE_DIR}/runtime_src/core/common/elf
   ${XRT_SOURCE_DIR}/runtime_src/core/common/aiebu/src/cpp/include
+  ${XRT_SOURCE_DIR}/runtime_src/core/common/aiebu/src/cpp
   )

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -2732,6 +2732,7 @@ public:
   {
     if (!m_module)
       return {};
+      
     return xrt_core::module_int::get_elf_handle(m_module).get();
   }
 

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -2727,6 +2727,19 @@ public:
     return m_module;
   }
 
+  std::shared_ptr<xrt::elf_impl>
+  get_elf_handle() const
+  {
+    if (!m_module)
+      return {};
+    try {
+      return xrt_core::module_int::get_elf_handle(m_module);
+    }
+    catch (const std::exception&) {
+      return {};
+    }
+  }
+
   kernel_command*
   get_cmd() const
   {
@@ -5163,12 +5176,11 @@ get_elf_identity_from_run(const xrt::run& run)
   if (!impl)
     return {};
 
-  const auto& mod = impl->get_module();
-  if (!mod)
+  auto elf_handle = impl->get_elf_handle();
+  if (!elf_handle)
     return {};
 
   try {
-    auto elf_handle = xrt_core::module_int::get_elf_handle(mod);
     return {xrt_core::elf_int::get_filename(elf_handle.get()),
             impl->get_kernel()->get_full_name(),
             elf_handle->get_cfg_uuid().to_string()};
@@ -5190,15 +5202,8 @@ amend_aie_error_message(const xrt::run& run, const std::string& msg)
     auto [elf_filename, kernel_instance, elf_uuid] = get_elf_identity_from_run(run);
     // Retrieve parsed ELF for efficient binary decode (no re-parsing overhead)
     std::shared_ptr<xrt::elf_impl> elf_handle;
-    try {
-      auto impl = run.get_handle();
-      if (impl) {
-        const auto& mod = impl->get_module();
-        if (mod)
-          elf_handle = xrt_core::module_int::get_elf_handle(mod);
-      }
-    }
-    catch (const std::exception&) {}
+    if (auto impl = run.get_handle())
+      elf_handle = impl->get_elf_handle();
     return aie_error_message_v1(epkt, msg, elf_filename, kernel_instance, elf_uuid,
                                 elf_handle.get());
   }

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -53,7 +53,7 @@
 #include "core/common/runner/capture.h"
 #include "core/common/xdp/profile.h"
 
-#include "aiebu/aiebu_debug.h"
+#include "core/common/aiebu/src/cpp/include/aiebu/aiebu_debug.h"
 
 #include <boost/format.hpp>
 

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -2727,17 +2727,12 @@ public:
     return m_module;
   }
 
-  std::shared_ptr<xrt::elf_impl>
+  const xrt::elf_impl*
   get_elf_handle() const
   {
     if (!m_module)
       return {};
-    try {
-      return xrt_core::module_int::get_elf_handle(m_module);
-    }
-    catch (const std::exception&) {
-      return {};
-    }
+    return xrt_core::module_int::get_elf_handle(m_module).get();
   }
 
   kernel_command*
@@ -5176,12 +5171,12 @@ get_elf_identity_from_run(const xrt::run& run)
   if (!impl)
     return {};
 
-  auto elf_handle = impl->get_elf_handle();
+  const auto* elf_handle = impl->get_elf_handle();
   if (!elf_handle)
     return {};
 
   try {
-    return {xrt_core::elf_int::get_filename(elf_handle.get()),
+    return {xrt_core::elf_int::get_filename(elf_handle),
             impl->get_kernel()->get_full_name(),
             elf_handle->get_cfg_uuid().to_string()};
   }
@@ -5201,11 +5196,9 @@ amend_aie_error_message(const xrt::run& run, const std::string& msg)
   if (epkt->data[0] == ERT_CTX_HEALTH_DATA_V1) {
     auto [elf_filename, kernel_instance, elf_uuid] = get_elf_identity_from_run(run);
     // Retrieve parsed ELF for efficient binary decode (no re-parsing overhead)
-    std::shared_ptr<xrt::elf_impl> elf_handle;
-    if (auto impl = run.get_handle())
-      elf_handle = impl->get_elf_handle();
+    auto impl = run.get_handle();
     return aie_error_message_v1(epkt, msg, elf_filename, kernel_instance, elf_uuid,
-                                elf_handle.get());
+                                impl->get_elf_handle());
   }
   else if (epkt->data[0] !=  ERT_CTX_HEALTH_DATA_V0)
     return msg;

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -53,6 +53,8 @@
 #include "core/common/runner/capture.h"
 #include "core/common/xdp/profile.h"
 
+#include "aiebu/aiebu_debug.h"
+
 #include <boost/format.hpp>
 
 #include <algorithm>
@@ -5047,7 +5049,7 @@ what() const noexcept
 static std::string
 aie_error_message_v1(const ert_packet* epkt, const std::string& msg,
                      const std::string& elf_filename, const std::string& kernel_instance,
-                     const std::string& elf_uuid)
+                     const std::string& elf_uuid, const xrt::elf_impl* elf_impl_ptr = nullptr)
 {
   constexpr auto indent8 = 8;
   auto ctx_health = get_ert_ctx_health_data_v1(epkt);
@@ -5118,6 +5120,29 @@ aie_error_message_v1(const ert_packet* epkt, const std::string& msg,
           << "\nuc_esr=0x" << std::setw(indent8)
           << ctx_health->aie4.uc_info[i].uc_esr
           << "\n";
+
+      // Decode the opcode at (uc_idx, page_idx, offset) directly from the ELF binary
+      if (elf_impl_ptr) {
+        aiebu::AIEDebug dbg(elf_impl_ptr->get_elfio());
+        auto info = dbg.get_opcode_information(
+          kernel_instance,
+          ctx_health->aie4.uc_info[i].uc_idx,
+          ctx_health->aie4.uc_info[i].page_idx,
+          ctx_health->aie4.uc_info[i].offset);
+        if (info.found) {
+          oss << "\nOpcode:         " << info.opcode_name;
+          if (!info.args_str.empty())
+            oss << "  " << info.args_str;
+          oss << "\nOpcode Size:    0x" << std::hex << info.opcode_size;
+          if (info.line > 0)
+            oss << "\nLine:           " << std::dec << info.line;
+          if (!info.source_file.empty())
+            oss << "\nFile:           " << info.source_file;
+          oss << "\n";
+        }
+        if (!info.diag_info.empty())
+          oss << "Opcode diag_info: " << info.diag_info << "\n";
+      }
     }
   }
   return oss.str();
@@ -5163,7 +5188,19 @@ amend_aie_error_message(const xrt::run& run, const std::string& msg)
 
   if (epkt->data[0] == ERT_CTX_HEALTH_DATA_V1) {
     auto [elf_filename, kernel_instance, elf_uuid] = get_elf_identity_from_run(run);
-    return aie_error_message_v1(epkt, msg, elf_filename, kernel_instance, elf_uuid);
+    // Retrieve parsed ELF for efficient binary decode (no re-parsing overhead)
+    std::shared_ptr<xrt::elf_impl> elf_handle;
+    try {
+      auto impl = run.get_handle();
+      if (impl) {
+        const auto& mod = impl->get_module();
+        if (mod)
+          elf_handle = xrt_core::module_int::get_elf_handle(mod);
+      }
+    }
+    catch (const std::exception&) {}
+    return aie_error_message_v1(epkt, msg, elf_filename, kernel_instance, elf_uuid,
+                                elf_handle.get());
   }
   else if (epkt->data[0] !=  ERT_CTX_HEALTH_DATA_V0)
     return msg;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Print opcode information in context health report on ERT_CMD_STATE_TIMEOUT (for AIE4 and AIE2PS)#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
A new API is added in AIEBU which decodes an opcode from ucindex, page_index and offset.  
As part of this PR, updated aiebu submodule of XRT to get the newly added API and added code in XRT to link to aiebu so that XRT calls this new API and prints decoded opcode in the event ERT_CMD_STATE_TIMEOUT 
#### Risks (if any) associated the changes in the commit
None
#### What has been tested and how, request additional testing if necessary
runlist failed execution (ERT_CMD_STATE_TIMEOUT)
Kernel Instance: mladfmatmulbias_mladf_aie4_v1_abfp16wbfp16acc16f_128_2560_2048_128
ELF File: C:\Users\sayyanna\Downloads\mcdm_stack_05_01\mcdm_stack/../data_bin/diff_pm/mladfmatmulbias_mladf_aie4_v1_abfp16wbfp16acc16f_128_2560_2048_128.elf
ELF UUID: 784303af-f0c5-aa13-fb02-2bf0ef0ff038
ctx_state = 0x00000001 (CTX_STATUS_ERROR)
ctx_error_type = 0x00000005 (NPU_ASYNC_EVENT_CTX_ERR_UC_CRITICAL_ERROR)
number of uC reported = 6
uc_info[0]:
uc_idx=0x00000000
uc_idle_status=0x00000000 (NONE)
misc_status=0x00000002 (CTRL_HANG)
fw_state=0x00000019 (FW_STATE_CTRL_CODE_HANG)
page_idx=0x00000002
offset=0x00000084
restore_page=0x00000000
restore_offset=0x00000000
uc_ear=0x00000000
uc_esr=0x00000000

**Opcode: mask_poll_32 0x2119630, 1, 1
Opcode Size: 0x10
Opcode diag: section=.ctrltext.0.2.0 size=256 pos=132**

uc_info[1]:
uc_idx=0x00000001
uc_idle_status=0x00000000 (NONE)
misc_status=0x00000000 (NONE)
fw_state=0x00002001 (FW_STATE_WORKER_PRE_WORK_BARRIER)
page_idx=0x00000000
offset=0x00000000
restore_page=0x00000000
restore_offset=0x00000000
uc_ear=0x00000000
uc_esr=0x00000000

Opcode decode failed
Opcode diag: section not found: .ctrltext.1.0.0

**From .dump section:**
runlist failed execution (ERT_CMD_STATE_TIMEOUT)
Kernel Instance: mladfmatmulbias_mladf_aie4_v1_abfp16wbfp16acc16f_128_2560_2048_128
ELF File: C:\Users\sayyanna\Downloads\mcdm_stack_05_01\mcdm_stack/../data_bin/diff_pm/mladfmatmulbias_mladf_aie4_v1_abfp16wbfp16acc16f_128_2560_2048_128.elf
ELF UUID: 784303af-f0c5-aa13-fb02-2bf0ef0ff038
ctx_state = 0x00000001 (CTX_STATUS_ERROR)
ctx_error_type = 0x00000005 (NPU_ASYNC_EVENT_CTX_ERR_UC_CRITICAL_ERROR)
number of uC reported = 6
uc_info[0]:
uc_idx=0x00000000
uc_idle_status=0x00000000 (NONE)
misc_status=0x00000002 (CTRL_HANG)
fw_state=0x00000019 (FW_STATE_CTRL_CODE_HANG)
page_idx=0x00000002
offset=0x00000084
restore_page=0x00000000
restore_offset=0x00000000
uc_ear=0x00000000
uc_esr=0x00000000

**Opcode: MASK_POLL_32 0x2119630, 0x1, 0x1
Opcode Size: 0x10
Line: 28
File: ../ml_asm/aie_runtime_control.asm**

uc_info[1]:
uc_idx=0x00000001
uc_idle_status=0x00000000 (NONE)
misc_status=0x00000000 (NONE)
fw_state=0x00002001 (FW_STATE_WORKER_PRE_WORK_BARRIER)
page_idx=0x00000000
offset=0x00000000
restore_page=0x00000000
restore_offset=0x00000000
uc_ear=0x00000000
uc_esr=0x00000000

Opcode decode failed
Opcode diag: section not found: .ctrltext.1.0.0
#### Documentation impact (if any)
