### PR TITLE
[SH-3009] build: bump Petalinux to petalinux-v2026.2_06161249

### DIFF
--- a/build/petalinux.build
+++ b/build/petalinux.build
@@ -1,3 +1,3 @@
 # When updating Petalinux build please file a SH ticket to retain the build
 # https://jira.xilinx.com/secure/CreateIssue!default.jspa
-PETALINUX=/proj/petalinux/2026.1/petalinux-v2026.1_05081655/tool/petalinux-v2026.1-final
+PETALINUX=/proj/petalinux/2026.2/petalinux-v2026.2_06161249/tool/petalinux-v2026.2-final


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
[SH-3009] build: bump Petalinux to petalinux-v2026.2_06161249
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Point PETALINUX at 2026.2 toolchain; validated with build_edge.sh -aarch versal.
#### Documentation impact (if any)
