### PR TITLE
[XRT-SMI] debug report addition

### DIFF
--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -4116,9 +4116,13 @@ struct archive_path : request
 
 struct auto_coredump : request
 {
+  using result_type = uint32_t;
   using value_type = uint32_t;
 
   static const key_type key = key_type::auto_coredump;
+
+  std::any
+  get(const device*) const override = 0;
 
   void
   put(const device*, const std::any&) const override = 0;

--- a/src/runtime_src/core/common/smi/smi_ryzen.cpp
+++ b/src/runtime_src/core/common/smi/smi_ryzen.cpp
@@ -21,7 +21,8 @@ config_gen_ryzen()
     {"platform", "Platforms flashed on the device", "common"},
     {"telemetry", "Telemetry data for the device", "hidden"},
     {"preemption", "Preemption telemetry data for the device", "hidden"},
-    {"clocks", "Clock frequency information", "hidden"}
+    {"clocks", "Clock frequency information", "hidden"},
+    {"debug", "Debug configuration settings for the device", "hidden"}
   };
 
   validate_test_desc = {
@@ -118,7 +119,8 @@ config_gen_npu3()
     {"platform", "Platforms flashed on the device", "common"},
     {"telemetry", "Telemetry data for the device", "common"},
     {"preemption", "Preemption telemetry data for the device", "common"},
-    {"clocks", "Clock frequency information", "hidden"}
+    {"clocks", "Clock frequency information", "hidden"},
+    {"debug", "Debug configuration settings for the device", "hidden"}
   };
 
   validate_test_desc = {

--- a/src/runtime_src/core/tools/common/reports/ReportDebug.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportDebug.cpp
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+#include "ReportDebug.h"
+
+#include "core/common/query_requests.h"
+
+#include <boost/format.hpp>
+#include <functional>
+
+namespace xq = xrt_core::query;
+
+namespace {
+
+std::string
+enabled_status(uint32_t value)
+{
+  return value == 1 ? "enabled" : "disabled";
+}
+
+std::string
+format_line(const boost::property_tree::ptree& setting)
+{
+  const auto status = setting.get<std::string>("status");
+  const auto detail = setting.get<std::string>("detail", "");
+  if (detail.empty())
+    return status;
+  return boost::str(boost::format("%s (%s)") % status % detail);
+}
+
+void
+add_setting(boost::property_tree::ptree& parent, const std::string& name,
+            const std::function<void(boost::property_tree::ptree&)>& populate)
+{
+  boost::property_tree::ptree node;
+  try {
+    populate(node);
+  }
+  catch (const std::exception&) {
+    node.put("status", "not supported");
+  }
+  parent.add_child(name, node);
+}
+
+void
+populate_debug(const xrt_core::device* dev, boost::property_tree::ptree& debug_pt)
+{
+  add_setting(debug_pt, "firmware_log", [&](boost::property_tree::ptree& node) {
+    const auto fw = xrt_core::device_query<xq::firmware_log_state>(dev);
+    node.put("status", enabled_status(fw.action));
+    if (fw.action == 1)
+      node.put("detail", boost::str(boost::format("log level %u") % fw.log_level));
+  });
+
+  add_setting(debug_pt, "event_trace", [&](boost::property_tree::ptree& node) {
+    const auto et = xrt_core::device_query<xq::event_trace_state>(dev);
+    node.put("status", enabled_status(et.action));
+    if (et.action == 1 && et.categories != 0)
+      node.put("detail", boost::str(boost::format("categories 0x%x") % et.categories));
+  });
+
+  add_setting(debug_pt, "auto_coredump", [&](boost::property_tree::ptree& node) {
+    const auto coredump = xrt_core::device_query<xq::auto_coredump>(dev);
+    node.put("status", enabled_status(coredump));
+  });
+}
+
+} // namespace
+
+void
+ReportDebug::getPropertyTreeInternal(const xrt_core::device* dev, boost::property_tree::ptree& pt) const
+{
+  getPropertyTree20202(dev, pt);
+}
+
+void
+ReportDebug::getPropertyTree20202(const xrt_core::device* dev, boost::property_tree::ptree& pt) const
+{
+  boost::property_tree::ptree debug_pt;
+  populate_debug(dev, debug_pt);
+  pt.add_child("debug", debug_pt);
+}
+
+void
+ReportDebug::writeReport(const xrt_core::device* /*dev*/, const boost::property_tree::ptree& pt,
+                         const std::vector<std::string>& /*elementsFilter*/,
+                         std::ostream& output) const
+{
+  const auto& debug_pt = pt.get_child("debug");
+
+  output << "Debug Configurations\n";
+  output << boost::format("  %-20s: %s\n") % "Firmware Log"
+           % format_line(debug_pt.get_child("firmware_log"));
+  output << boost::format("  %-20s: %s\n") % "Event Trace"
+           % format_line(debug_pt.get_child("event_trace"));
+  output << boost::format("  %-20s: %s\n") % "Auto Coredump"
+           % format_line(debug_pt.get_child("auto_coredump"));
+  output << "\n";
+}

--- a/src/runtime_src/core/tools/common/reports/ReportDebug.h
+++ b/src/runtime_src/core/tools/common/reports/ReportDebug.h
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 
-#ifndef __ReportDebug_h_
-#define __ReportDebug_h_
+#ifndef ReportDebug_h
+#define ReportDebug_h
 
 #include "tools/common/Report.h"
 

--- a/src/runtime_src/core/tools/common/reports/ReportDebug.h
+++ b/src/runtime_src/core/tools/common/reports/ReportDebug.h
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+#ifndef __ReportDebug_h_
+#define __ReportDebug_h_
+
+#include "tools/common/Report.h"
+
+class ReportDebug : public Report {
+ public:
+  ReportDebug()
+    : Report("debug", "Debug configuration settings for the device", true /*deviceRequired*/, true /*isHidden*/)
+  {}
+
+  void getPropertyTreeInternal(const xrt_core::device* dev, boost::property_tree::ptree& pt) const override;
+  void getPropertyTree20202(const xrt_core::device* dev, boost::property_tree::ptree& pt) const override;
+  void writeReport(const xrt_core::device* dev, const boost::property_tree::ptree& pt,
+                   const std::vector<std::string>& elementsFilter, std::ostream& output) const override;
+};
+
+#endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
@@ -31,6 +31,7 @@
 #include "tools/common/reports/ReportClocks.h"
 #include "tools/common/reports/ReportCmcStatus.h"
 #include "tools/common/reports/ReportDynamicRegion.h"
+#include "tools/common/reports/ReportDebug.h"
 #include "tools/common/reports/ReportDebugIpStatus.h"
 #include "tools/common/reports/ReportElectrical.h"
 #include "tools/common/reports/ReportFirewall.h"
@@ -71,6 +72,7 @@ SubCmdExamine::SubCmdExamine(bool _isHidden, bool _isDepricated, bool _isPrelimi
     std::make_shared<ReportAsyncError>(),
     std::make_shared<ReportBOStats>(),
     std::make_shared<ReportClocks>(),
+    std::make_shared<ReportDebug>(),
     std::make_shared<ReportDebugIpStatus>(),
     std::make_shared<ReportDynamicRegion>(),
     std::make_shared<ReportHost>(),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
This PR adds a new Debug report to xrt-smi examine --advanced. 
Currently this report prints 3 debug fields but this can be extended further in future if and when we need to capture states of driver/firmware. Example hysteresis.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://jira.xilinx.com/browse/AIESW-34703

#### How problem was solved, alternative solutions (if any) and why they were rejected
Solved via adding new report and adding device query for auto-coredump feature.

#### Risks (if any) associated the changes in the commit
None, new report

#### What has been tested and how, request additional testing if necessary
Tested on MDS platform. This is how the report looks like :
```
aktondak@xsjstrix45:/proj/rdi/staff/aktondak/xdna/xdna-driver/xrt/build$ xrt-smi examine --advanced -r debug
-------------------------------------------------------------------------
                    DISCLAIMER  (xrt-smi --advanced)                     
You are running a developer command that may change system configuration.
                Continue only if you understand the risks.               
-------------------------------------------------------------------------

---------------------------
[0000:c5:00.1] : NPU Strix
---------------------------
Debug Configurations
  Firmware Log        : enabled (log level 4)
  Event Trace         : disabled
  Auto Coredump       : not supported
```

#### Documentation impact (if any)
None