### PR TITLE
trace: make sys/sdt.h include optional

### DIFF
--- a/src/runtime_src/CMakeLists.txt
+++ b/src/runtime_src/CMakeLists.txt
@@ -12,6 +12,7 @@ endif()
 
 option(XOCL_VERBOSE "Enable xocl verbosity" OFF)
 option(XRT_VERBOSE "Enable xrt verbosity" OFF)
+option(XRT_ENABLE_USDT "Enable SystemTap USDT tracepoints" ON)
 
 if (XOCL_VERBOSE)
   add_compile_options("-DXOCL_VERBOSE")
@@ -19,6 +20,18 @@ endif()
 
 if(XRT_VERBOSE)
   add_compile_options("-DXRT_VERBOSE")
+endif()
+
+if (XRT_ENABLE_USDT)
+  include(CheckIncludeFileCXX)
+  check_include_file_cxx("sys/sdt.h" XRT_HAVE_SYS_SDT_H)
+  if (NOT XRT_HAVE_SYS_SDT_H)
+    message(FATAL_ERROR
+      "sys/sdt.h not found. Install systemtap-sdt-dev "
+      "(or systemtap-sdt-devel), or configure with "
+      "-DXRT_ENABLE_USDT=OFF.")
+  endif()
+  add_compile_definitions(XRT_ENABLE_USDT)
 endif()
 
 add_compile_options("-fPIC")

--- a/src/runtime_src/core/common/detail/linux/trace.h
+++ b/src/runtime_src/core/common/detail/linux/trace.h
@@ -2,8 +2,15 @@
 // Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
 #include "core/common/trace.h"
 
-#define SDT_USE_VARIADIC
-#include <sys/sdt.h>
+#ifdef XRT_ENABLE_USDT
+# define SDT_USE_VARIADIC
+# include <sys/sdt.h>
+#else
+# define STAP_PROBEV(provider, name, ...) do {} while (0)
+# define DTRACE_PROBE(provider, name)      do {} while (0)
+# define DTRACE_PROBE1(provider, name, a)  do {} while (0)
+# define DTRACE_PROBE2(p, n, a, b)         do {} while (0)
+#endif
 
 #define XRT_DETAIL_TRACE_POINT_LOG(probe, ...) \
   STAP_PROBEV(xrt, probe##_log, ##__VA_ARGS__)


### PR DESCRIPTION
sys/sdt.h (SystemTap USDT) is not present in all Linux build environments, notably cross-compilation toolchains and embedded distributions that do not ship systemtap-sdt-dev.  The unconditional include causes a build failure in those environments.

Use __has_include to make the inclusion conditional.  When sys/sdt.h is unavailable, define no-op stubs for the four USDT macros used by XRT (STAP_PROBEV, DTRACE_PROBE, DTRACE_PROBE1, DTRACE_PROBE2) so that the tracing call sites compile without change.

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Compilation errors in environments without sys/sdt.h

#### How problem was solved, alternative solutions (if any) and why they were rejected
Define no-op stubs for the four USDT macros used by XRT (STAP_PROBEV, DTRACE_PROBE, DTRACE_PROBE1, DTRACE_PROBE2).

#### What has been tested and how, request additional testing if necessary
Successfully compiled on Ubuntu 24.04 with and without systemtap-sdt-dev installed.

#### Documentation impact (if any)
