### PR TITLE
SWSPLAT-30702 validate library_name to prevent path traversal

### DIFF
--- a/src/runtime_src/core/common/module_loader.cpp
+++ b/src/runtime_src/core/common/module_loader.cpp
@@ -322,6 +322,26 @@ xilinx_xrt()
 }
 
 sfs::path
+xrt_path_or_error(const std::string& file)
+{
+  if (file.empty())
+    throw std::runtime_error("Invalid empty file name");
+
+  std::filesystem::path path {file};
+
+  // No absolute path
+  if (path.is_absolute())
+    throw std::runtime_error("Invalid path '" + path.string() + "' cannot be absolute");
+
+  // May not contain any ".." to escape xilinx_xrt
+  auto normalize = path.lexically_normal();
+  if (normalize.string().find("..") != std::string::npos)
+    throw std::runtime_error("Invalid path '" + normalize.string() + "' escapes xrt");
+
+  return xilinx_xrt() / normalize;
+}
+
+sfs::path
 platform_path(const std::string& file_name)
 {
   return ::platform_path(file_name);

--- a/src/runtime_src/core/common/module_loader.h
+++ b/src/runtime_src/core/common/module_loader.h
@@ -127,6 +127,25 @@ std::filesystem::path
 platform_path(const std::string& file_name);
 
 /**
+ * xrt_path() - Get XRT path to specified file
+ *
+ * @param file
+ *   Relative path to a file
+ * Return:
+ *   Path of file rooted at xilinx_xrt() or error
+ *
+ * This function can be used to limit on demand loading to
+ * files that are rooted at xilinx_xrt().
+ *
+ * Throws if file is an absolute path or if resulting path
+ * escapes xilinx_xrt().   Here escape simply implies that
+ * the resulting path contains any ".." element.
+ */
+XRT_CORE_COMMON_EXPORT
+std::filesystem::path
+xrt_path_or_error(const std::string& file);
+
+/**
  * platform_repo_paths() - Get paths to the platform repositories
  *
  * Return: All full paths to available platform repositories

--- a/src/runtime_src/core/common/runner/runner.cpp
+++ b/src/runtime_src/core/common/runner/runner.cpp
@@ -508,8 +508,8 @@ class recipe
       create_cpu(const json& j)
       {
         auto name = j.at("name").get<std::string>(); // required
-        auto library_path = xrt_core::environment::xilinx_xrt()
-          / j.at("library_name").get<std::string>(); // required
+        auto libname = j.at("library_name").get<std::string>(); // required
+        auto library_path = xrt_core::environment::xrt_path_or_error(libname);
         return cpu{std::move(name), library_path.string()};
       }
 


### PR DESCRIPTION
#### Problem solved by the commit
Limit library loading to libraries rooted at xilinx_xrt()

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
SWSPLAT-30702

#### How problem was solved, alternative solutions (if any) and why they were rejected
Add xrt_path_or_error() to xrt_core::environment that enforces three guards before constructing a path for dlopen:

  1. Reject empty strings.
  2. Reject absolute paths (catches a leading '/' or Windows drive/UNC).
  3. Normalize the relative path with lexically_normal() and reject any result that still contains '..', preventing traversal outside the XRT installation root.

The runner's create_cpu() now calls xrt_path_or_error(libname) instead of blindly joining library_name from the recipe JSON to xilinx_xrt(). Any recipe-supplied value that escapes the XRT root throws at parse time rather than silently loading an arbitrary shared library.

#### What has been tested and how, request additional testing if necessary
The particular code path is currently unused, but the function `xrt_path_or_error(libname)` has been unit tested
