### PR TITLE
support pl ip patching schema pl_ddr_64 

### DIFF
--- a/src/runtime_src/core/common/api/elf_patcher.cpp
+++ b/src/runtime_src/core/common/api/elf_patcher.cpp
@@ -157,6 +157,17 @@ patch_ctrl57_aie4(uint32_t* bd_data_ptr, uint64_t patch)
 
 void
 symbol_patcher::
+patch_pl_ddr64(uint32_t* bd_data_ptr, uint64_t patch)
+{
+  // PL kernel wts_params block: words [8] and [9] hold a plain 64-bit DDR address
+  uint64_t base_address = (static_cast<uint64_t>(bd_data_ptr[9]) << 32) | bd_data_ptr[8]; // NOLINT
+  base_address += patch;
+  bd_data_ptr[8] = static_cast<uint32_t>(base_address & 0xFFFFFFFF);                      // NOLINT
+  bd_data_ptr[9] = static_cast<uint32_t>((base_address >> 32) & 0xFFFFFFFF);              // NOLINT
+}
+
+void
+symbol_patcher::
 patch_symbol(xrt::bo bo, uint64_t value, bool first, bool is_arg)
 {
   if (!m_config)
@@ -267,6 +278,14 @@ patch_symbol(xrt::bo bo, uint64_t value, bool first, bool is_arg)
         sync(3 * sizeof(uint32_t));    // NOLINT
       }
       break;
+    case symbol_type::pl_ddr_64:
+      // value is a bo address; patch words [8]+[9] of wts_params block
+      patch_pl_ddr64(bd_data_ptr, value + config.offset_to_base_bo_addr);
+      if (!first) {
+        // sync words [8] and [9] (2 words starting at offset + 8*sizeof(uint32_t))
+        bo.sync(XCL_BO_SYNC_BO_TO_DEVICE, 2 * sizeof(uint32_t), offset + 8 * sizeof(uint32_t)); // NOLINT
+      }
+      break;
     default:
       throw std::runtime_error("Unsupported symbol type");
     }
@@ -306,6 +325,9 @@ patch_symbol_raw(uint8_t* base, uint64_t value, const patcher_config& config)
       break;
     case symbol_type::control_packet_57_aie4:
       patch_ctrl57_aie4(bd_data_ptr, value + cfg.offset_to_base_bo_addr);
+      break;
+    case symbol_type::pl_ddr_64:
+      patch_pl_ddr64(bd_data_ptr, value + cfg.offset_to_base_bo_addr);
       break;
     default:
       throw std::runtime_error("Unsupported symbol type");

--- a/src/runtime_src/core/common/api/elf_patcher.h
+++ b/src/runtime_src/core/common/api/elf_patcher.h
@@ -82,7 +82,8 @@ enum class symbol_type {
   control_packet_57 = 7,                   // patching scheme needed by firmware to patch control packet for aie2ps
   address_64 = 8,                          // patching scheme needed to patch pdi address
   control_packet_57_aie4 = 9,              // patching scheme needed by firmware to patch control packet for aie4
-  unknown_symbol_kind = 10
+  pl_ddr_64 = 10,                          // patching scheme for PL kernel wts_params block (words 8+9 hold 64-bit DDR address)
+  unknown_symbol_kind = 11
 };
 
 // Maximum BD data words - AIE2P uses 8, AIE4/AIE2PS uses 9
@@ -177,6 +178,9 @@ private:
 
   static void
   patch_ctrl57_aie4(uint32_t* bd_data_ptr, uint64_t patch);
+
+  static void
+  patch_pl_ddr64(uint32_t* bd_data_ptr, uint64_t patch);
 };
 
 } // namespace xrt_core::elf_patcher


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
support pl ip patching schema "pl_ddr_64"

https://amd.atlassian.net/wiki/spaces/AIE/pages/1744115100/Weight+Prefetch+via+PL+IP+and+PLIO+Feature+Specification
XRT patches words 8+9 of wts_params with the physical weight buffer address via APPLY_OFFSET_PL at BO bind time.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
