### PR TITLE
SWSPLAT-30716 xclbinutil fix integer overflow and bounds check issues in DTC.cxx

### DIFF
--- a/src/runtime_src/tools/xclbinutil/DTC.cxx
+++ b/src/runtime_src/tools/xclbinutil/DTC.cxx
@@ -109,12 +109,12 @@ DTC::marshalFromDTCImage(const char* _pBuffer,
   }
 
   // -- Get and validate the strings offset --
-  if (ntohl(pHdr->off_dt_strings) > _size) {
+  if (ntohl(pHdr->off_dt_strings) >= _size) {
     auto errMsg = boost::format("ERROR: The string block offset (0x%x) exceeds then image size (0x%x)") % ntohl(pHdr->off_dt_strings) % _size;
     throw std::runtime_error(errMsg.str());
   }
 
-  if ((ntohl(pHdr->off_dt_strings) + ntohl(pHdr->size_dt_strings)) > _size) {
+  if ((static_cast<uint64_t>(ntohl(pHdr->off_dt_strings)) + ntohl(pHdr->size_dt_strings)) > _size) {
     auto errMsg = boost::format("ERROR: The string block offset and size (0x%x) exceeds then image size (0x%x)") % (ntohl(pHdr->off_dt_strings) + ntohl(pHdr->size_dt_strings)) % _size;
     throw std::runtime_error(errMsg.str());
   }
@@ -125,12 +125,12 @@ DTC::marshalFromDTCImage(const char* _pBuffer,
   m_DTCStringsBlock.parseDTCStringsBlock(pStringBuffer, stringBufferSize);
 
   // -- Get the validate the structure nodes offset --
-  if (ntohl(pHdr->off_dt_struct) > _size) {
+  if (ntohl(pHdr->off_dt_struct) >= _size) {
     auto errMsg = boost::format("ERROR: The structure block offset (0x%x) exceeds then image size (0x%x)") % ntohl(pHdr->off_dt_struct) % _size;
     throw std::runtime_error(errMsg.str());
   }
 
-  if ((ntohl(pHdr->off_dt_struct) + ntohl(pHdr->size_dt_struct)) > _size) {
+  if ((static_cast<uint64_t>(ntohl(pHdr->off_dt_struct)) + ntohl(pHdr->size_dt_struct)) > _size) {
     auto errMsg = boost::format("ERROR: The structure block offset and size (0x%x) exceeds then image size (0x%x)") % (ntohl(pHdr->off_dt_struct) + ntohl(pHdr->size_dt_struct)) % _size;
     throw std::runtime_error(errMsg.str());
   }
@@ -180,8 +180,12 @@ DTC::marshalToDTC(std::ostringstream& _buf) const
     throw std::runtime_error("ERROR: There are no structure nodes in this design.");
   }
 
-  // Note roll over is checked at the end of this method
   uint64_t runningOffset = 0;
+
+  auto check_overflow = [](uint64_t offset, const char* ctx) {
+    if (offset >= UINT32_MAX)
+      throw std::runtime_error(std::string("ERROR: DTC block exceeds 4 GBytes at ") + ctx);
+  };
 
   // -- Create header --
   fdt_header header = { 0 };
@@ -198,7 +202,8 @@ DTC::marshalToDTC(std::ostringstream& _buf) const
     memoryBlock.write(&emptyByte, sizeof(char));
   }
   std::string sMemoryBlock = memoryBlock.str();
-  header.off_mem_rsvmap = htonl((uint32_t)runningOffset);
+  check_overflow(runningOffset, "memory reservation block offset");
+  header.off_mem_rsvmap = htonl(static_cast<uint32_t>(runningOffset));
   runningOffset += sMemoryBlock.size();
 
   // -- Create structure node image --
@@ -207,29 +212,29 @@ DTC::marshalToDTC(std::ostringstream& _buf) const
   m_pTopFDTNode->marshalToDTC(stringsBlock, structureNodesBuf);
   XUtil::write_htonl(structureNodesBuf, FDT_END);
   std::string sStructureNodes = structureNodesBuf.str();
-  header.off_dt_struct = htonl((uint32_t)runningOffset);
-  header.size_dt_struct = htonl((uint32_t)sStructureNodes.size());
+  check_overflow(runningOffset, "structure block offset");
+  check_overflow(sStructureNodes.size(), "structure block size");
+  header.off_dt_struct = htonl(static_cast<uint32_t>(runningOffset));
+  header.size_dt_struct = htonl(static_cast<uint32_t>(sStructureNodes.size()));
   runningOffset += sStructureNodes.size();
 
   // -- Create strings block --
   std::ostringstream stringBlock;
   stringsBlock.marshalToDTC(stringBlock);
   std::string sStringBlock = stringBlock.str();
-  header.off_dt_strings = htonl((uint32_t)runningOffset);
-  header.size_dt_strings = htonl((uint32_t)sStringBlock.size());
+  check_overflow(runningOffset, "strings block offset");
+  check_overflow(sStringBlock.size(), "strings block size");
+  header.off_dt_strings = htonl(static_cast<uint32_t>(runningOffset));
+  header.size_dt_strings = htonl(static_cast<uint32_t>(sStringBlock.size()));
   runningOffset += sStringBlock.size();
 
   // Complete the header
-  header.totalsize = htonl((uint32_t)runningOffset);
+  check_overflow(runningOffset, "total size");
+  header.totalsize = htonl(static_cast<uint32_t>(runningOffset));
 
   // -- Put it all together --
   _buf.write((char*)&header, sizeof(fdt_header));
   _buf.write(sMemoryBlock.c_str(), sMemoryBlock.size());
   _buf.write(sStructureNodes.c_str(), sStructureNodes.size());
   _buf.write(sStringBlock.c_str(), sStringBlock.size());
-
-  // -- Integrity check --
-  if (runningOffset >= UINT32_MAX) {
-    throw std::runtime_error("ERROR: DTC block exceeds 4 GBytes (uint32_t max size)");
-  }
 }


### PR DESCRIPTION
#### Problem solved by the commit

Four security vulnerabilities in the DTC (Device Tree Compiler) binary parser and serialiser allowed crafted input to bypass bounds checks or produce silently truncated output:

1. Off-by-one in offset validation: `off_dt_strings` and `off_dt_struct` were checked with `> _size` instead of `>= _size`, allowing an offset equal to the buffer size to pass validation and produce an out-of-bounds pointer.

2. Integer overflow in sum-based bounds checks: the expressions `ntohl(off_dt_strings) + ntohl(size_dt_strings)` and the equivalent for the struct block were computed in `uint32_t`, wrapping to a small value that falsely passed the `> _size` check. A crafted binary could map a section outside the buffer with no error thrown.

3. Silent truncation in marshalToDTC: all `htonl((uint32_t)runningOffset)` casts silently truncated the 64-bit running offset before the single overflow guard at the end of the function fired. Header fields `off_mem_rsvmap`, `off_dt_struct`, `size_dt_struct`, `off_dt_strings`, `size_dt_strings`, and `totalsize` could all be written with wrong values from oversized inputs.

4. Overflow check too late in marshalToDTC: the `UINT32_MAX` guard ran after all header fields were already written, making it ineffective.

#### How problem was solved

- Off-by-one (issues 1): changed `> _size` to `>= _size` for the two offset-only checks.
- Integer overflow (issue 2): widened one operand of each sum to `uint64_t` via `static_cast<uint64_t>` before the addition, ensuring the comparison is done in 64-bit arithmetic.
- Silent truncation and late guard (issues 3 & 4): replaced the single end-of-function overflow check with a `check_overflow` lambda that throws before each `static_cast<uint32_t>` cast. The old post-write guard is removed.

#### Risks

Low. All changes are purely defensive — they add early throws for inputs that were previously either silently mishandled or produced incorrect output. Valid, well-formed DTC blobs are unaffected.

#### What has been tested

Code review and manual inspection of all affected paths. Existing xclbinutil tests cover the nominal DTC parse/serialise round-trip. Additional fuzzing of malformed DTC headers is recommended.

