### PR TITLE
Fix use-after-free in message::send during process teardown

### DIFF
--- a/src/runtime_src/core/common/message.cpp
+++ b/src/runtime_src/core/common/message.cpp
@@ -193,7 +193,11 @@ send(severity_level l, const char* tag, const char* msg)
   int lev = static_cast<int>(l);
 
   if(ver >= lev) {
-    static auto dispatcher = message_dispatch::make_dispatcher(logger);
+    // Intentionally leaked for process lifetime so late exit paths (~shim,
+    // XDP trace flush) can still log after static teardown begins. Do not
+    // store as unique_ptr; that reintroduces use-after-free at process exit.
+    static message_dispatch* const dispatcher =
+      message_dispatch::make_dispatcher(logger).release();
     dispatcher->send(l, tag, msg);
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
[CR-1273207](https://jira.xilinx.com/browse/CR-1273207) 

With regression xrt.ini enabled (XDP profiling: aie_trace, device_trace, host_trace, etc.), host.exe passes data validation but crashes with SIGSEGV (RC=139) during teardown. A use-after-free in xrt_core::message::send() when logging is invoked from late process-exit paths (~shim(), XDP trace flush, static plugin destructors).

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
static std::unique_ptr<message_dispatch> in message::send() is destroyed during C++ static teardown at process exit. Late callers (shim::~shim() xdp::finish_flush_device(), ~AieTracePluginUnified(), trace writers) can still invoke message::send(), dereferencing an already-destroyed dispatcher ->use-after-free -> segfault.

Introduced by: PR #9837 

#### How problem was solved, alternative solutions (if any) and why they were rejected
make_dispatcher() still returns unique_ptr (unchanged API from #9837). and .release() transfers ownership to a raw pointer that is not destroyed during static teardown

#### Risks (if any) associated the changes in the commit
low

#### What has been tested and how, request additional testing if necessary
tested on vck190

#### Documentation impact (if any)
Not required