### PR TITLE
SWSPLAT-30712 xrt_xclbin.cpp fix heap OOB read and related validation issues

### DIFF
--- a/src/runtime_src/core/common/api/xrt_xclbin.cpp
+++ b/src/runtime_src/core/common/api/xrt_xclbin.cpp
@@ -96,6 +96,12 @@ read_xclbin(const std::string& fnm)
 static std::vector<char>
 copy_axlf(const axlf* top)
 {
+  if (!top)
+    throw std::runtime_error("xclbin: null axlf pointer");
+  
+  if (top->m_header.m_length < sizeof(axlf))
+    throw std::runtime_error("xclbin: m_length smaller than axlf header");
+  
   auto size = top->m_header.m_length;
   std::vector<char> header(size);
   auto data = reinterpret_cast<const char*>(top);
@@ -822,6 +828,10 @@ class xclbin_full : public xclbin_impl
   void
   emplace_section(const axlf_section_header* hdr, axlf_section_kind kind)
   {
+    auto total = m_axlf.size();
+    if (hdr->m_sectionOffset > total || hdr->m_sectionSize > total - hdr->m_sectionOffset)
+      throw std::runtime_error("xclbin: section header out of range");
+    
     auto section_data = reinterpret_cast<const char*>(m_top) + hdr->m_sectionOffset;
     std::vector<char> data{section_data, section_data + hdr->m_sectionSize};
     m_axlf_sections.emplace(kind , std::move(data));
@@ -839,9 +849,26 @@ class xclbin_full : public xclbin_impl
   void
   init_axlf()
   {
+    if (m_axlf.size() < sizeof(axlf))
+      throw std::runtime_error("xclbin: buffer too small to contain header");
+
     const axlf* tmp = reinterpret_cast<const axlf*>(m_axlf.data());
     if (strncmp(tmp->m_magic, "xclbin2", strlen("xclbin2")) != 0) // Future: Do not hardcode "xclbin2"
       throw std::runtime_error("Invalid xclbin");
+
+    // m_length must match the actual buffer size we loaded
+    if (tmp->m_header.m_length != m_axlf.size())
+      throw std::runtime_error("xclbin: m_length does not match buffer size");
+
+    // Ensure the section header array fits within the buffer before iterating
+    static const uint64_t max_sections_allowed = 10000;
+    if (tmp->m_header.m_numSections > max_sections_allowed)
+      throw std::runtime_error("xclbin: unreasonable m_numSections value");
+
+    auto hdr_array_size = static_cast<uint64_t>(tmp->m_header.m_numSections) * sizeof(axlf_section_header);
+    if (hdr_array_size > m_axlf.size() - sizeof(axlf))
+      throw std::runtime_error("xclbin: section header array exceeds buffer");
+
     m_top = tmp;
 
     m_uuid = uuid(m_top->m_header.uuid);
@@ -910,7 +937,8 @@ public:
   std::string
   get_xsa_name() const override
   {
-    return reinterpret_cast<const char*>(m_top->m_header.m_platformVBNV);
+    const auto* p = reinterpret_cast<const char*>(m_top->m_header.m_platformVBNV);
+    return std::string(p, strnlen(p, sizeof(m_top->m_header.m_platformVBNV)));
   }
 
   xclbin::target_type
@@ -1720,6 +1748,9 @@ xrtXclbinAllocRawData(const char* data, int size)
 {
   try {
     return xdp::native::profiling_wrapper(__func__, [data, size]{
+      if (size <= 0)
+        throw std::runtime_error("xrtXclbinAllocRawData: invalid size");
+
       std::vector<char> raw_data(data, data + size);
       auto xclbin = std::make_shared<xrt::xclbin_full>(raw_data);
       auto handle = xclbin.get();
@@ -1771,7 +1802,11 @@ xrtXclbinGetXSAName(xrtXclbinHandle handle, char* name, int size, int* ret_size)
       
       // populate name if memory is allocated
       if (name) {
-        auto cp_len = std::min<size_t>(size - 1, xsaname.size());
+        if (size <= 0)
+          throw std::runtime_error("xrtXclbinGetXSAName: invalid size");
+
+        // Prevent underflow, cast size before decrement
+        auto cp_len = std::min(static_cast<size_t>(size) - 1, xsaname.size());
         std::memcpy(name, xsaname.c_str(), cp_len);
         name[cp_len] = 0;
       }
@@ -1865,10 +1900,14 @@ xrtXclbinGetData(xrtXclbinHandle handle, char* data, int size, int* ret_size)
       // populate ret_size if memory is allocated
       if (ret_size)
         *ret_size = result_size;
+      
       // populate data if memory is allocated
       if (data) {
-        auto size_tmp = std::min(size,result_size);
-        std::memcpy(data, result.data(), size_tmp);
+        if (size <= 0)
+          throw std::runtime_error("xrtXclbinGetData: invalid size");
+        
+        auto size_tmp = std::min(size, result_size);
+        std::memcpy(data, result.data(), static_cast<size_t>(size_tmp));
       }
       return 0;
     });


### PR DESCRIPTION
#### Problem solved by the commit
Five security defects allowed crafted xclbin binaries or negative integer arguments from the C API to cause heap out-of-bounds reads, large spurious allocations, or unterminated-string reads:

1. emplace_section() (CWE-125, CVSS 6.9): m_sectionOffset and m_sectionSize from each axlf section header were used directly to slice the raw buffer with no check that the range fits within it. A crafted xclbin with offset=0x80000000 and size=0x1000 causes the std::vector range constructor to read 4KB+ past the end of the heap allocation, enabling process heap disclosure and potential DoS.

2. init_axlf() trusts m_numSections and m_length without validation: An unreasonably large m_numSections causes the section-header iteration loop to walk past the end of the buffer. m_length is also used by copy_axlf() as an allocation size with no check that it matches the actual loaded data.

3. copy_axlf(): m_length from the caller-supplied axlf pointer is used as allocation and copy size with no null check and no check that m_length >= sizeof(axlf).

4. get_xsa_name(): m_platformVBNV is a fixed-size char array in the binary; constructing a std::string from a bare pointer without bounding on sizeof(m_platformVBNV) reads past the array if the field is not null-terminated.

5. C API size arguments: xrtXclbinAllocRawData(), xrtXclbinGetXSAName(), and xrtXclbinGetData() accept int size parameters that can be zero or negative. A negative value silently converts to a huge size_t in vector/memcpy operations.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
SWSPLAT-30712. Identified by Mythos AI security audit. Parent finding: SWSPLAT-30799.

#### How problem was solved, alternative solutions (if any) and why they were rejected
- emplace_section(): added an overflow-safe bounds check (offset > total || size > total - offset) that throws before the vector range constructor runs.

- init_axlf(): added four sequential guards before assigning m_top: (a) buffer >= sizeof(axlf), (b) m_length == buffer size, (c) m_numSections <= 10000 sanity cap, (d) section header array fits within buffer - sizeof(axlf).

- copy_axlf(): added null check and m_length >= sizeof(axlf) guard.

- get_xsa_name(): replaced bare reinterpret_cast<const char*> implicit string construction with strnlen bounded to sizeof(m_platformVBNV).

- C API size guards: reject size <= 0 before use; cast to size_t only after validation.

#### Risks (if any) associated the changes in the commit
Low. All changes are defensive early-throws on inputs that were previously either mishandled or produced incorrect behavior. Valid, well-formed xclbin files and non-negative C API size arguments are unaffected.

#### What has been tested and how, request additional testing if necessary
Code review against the SWSPLAT-30712 finding and manual inspection of all affected paths. Existing xclbin API unit tests cover the nominal load/parse round-trip. Fuzzing with the AFL++ harness from the ticket (extern "C" int LLVMFuzzerTestOneInput) is recommended to confirm the OOB is closed.
