### PR TITLE
SWSPLAT-30706 fix sz+seek/offset integer overflow bypasses bounds check

### DIFF
--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -357,8 +357,9 @@ public:
   virtual void
   write(const void* src, size_t sz, size_t seek)
   {
-    if (sz + seek > size)
+    if (seek > size || sz > size - seek)
       throw xrt_core::error(-EINVAL,"attempting to write past buffer size");
+    
     auto hbuf = static_cast<char*>(get_hbuf_or_error()) + seek;
     std::memcpy(hbuf, src, sz);
   }
@@ -366,8 +367,9 @@ public:
   virtual void
   read(void* dst, size_t sz, size_t skip)
   {
-    if (sz + skip > size)
+    if (skip > size || sz > size - skip)
       throw xrt_core::error(-EINVAL,"attempting to read past buffer size");
+    
     auto hbuf = static_cast<char*>(get_hbuf_or_error()) + skip;
     std::memcpy(dst, hbuf, sz);
   }
@@ -378,9 +380,11 @@ public:
     // Check size and offset of dst and src
     if (!sz)
       throw xrt_core::system_error(EINVAL, "size must be a positive number");
-    if (sz + dst_offset > size)
+
+    if (dst_offset > size || sz > size - dst_offset)
       throw xrt_core::system_error(EINVAL, "copying past destination buffer size");
-    if (src->get_size() < sz + src_offset)
+
+    if (src_offset > src->get_size() || sz > src->get_size() - src_offset)
       throw xrt_core::system_error(EINVAL, "copying past source buffer size");
 
     if (get_device() != src->get_device()) {
@@ -836,16 +840,18 @@ public:
   void
   read(void* dst, size_t sz, size_t skip) override
   {
-    if (sz + skip > size)
+    if (skip > size || sz > size - skip)
       throw xrt_core::error(-EINVAL,"attempting to read past buffer size");
+    
     device->unmgd_pread(dst, sz, get_address() + skip);
   }
 
   void
   write(const void* src, size_t sz, size_t seek) override
   {
-    if (sz + seek > size)
+    if (seek > size || sz > size - seek)
       throw xrt_core::error(-EINVAL,"attempting to write past buffer size");
+    
     device->unmgd_pwrite(src, sz, get_address() + seek);
   }
 };
@@ -860,7 +866,8 @@ class buffer_nodma : public bo_impl
   {
     if (!sz)
       throw xrt_core::system_error(EINVAL, "size must be a positive number");
-    if (sz + offset > size)
+    
+    if (offset > size || sz > size - offset)
       throw xrt_core::system_error(EINVAL, "offset exceeds buffer size");
   }
 
@@ -923,7 +930,7 @@ public:
     , m_offset(off)
     , m_hbuf(static_cast<char*>(m_parent->get_hbuf()) + m_offset)
   {
-    if (size + m_offset > m_parent->get_size())
+    if (m_offset > m_parent->get_size() || size > m_parent->get_size() - m_offset)
       throw xrt_core::error(-EINVAL, "sub buffer size and offset");
   }
 
@@ -954,8 +961,11 @@ public:
   void
   sync(xclBOSyncDirection dir, size_t sz, size_t offset) override
   {
+    if (offset > m_parent->get_size() || m_offset > m_parent->get_size() - offset)
+      throw xrt_core::error(-EINVAL, "Invalid offset and size when syncing sub buffer");
+    
     size_t off = offset + m_offset;
-    if (off + sz > m_parent->get_size())
+    if (sz > m_parent->get_size() - off)
       throw xrt_core::error(-EINVAL, "Invalid offset and size when syncing sub buffer");
 
     // sync through parent buffer, which handles nodma case also


### PR DESCRIPTION
#### Problem solved by the commit
bo_impl::write(), read(), and copy(), and their overrides in buffer_unmgd, buffer_nodma, and buffer_sub, all validated bounds with expressions of the form `sz + seek > size`. Both operands are size_t (unsigned), so an attacker passing seek=SIZE_MAX-0x50 causes the sum to wrap to a small value that passes the check. The subsequent memcpy/pread/pwrite then writes or reads past the mapped BO into adjacent heap memory (CWE-190/787, CVSS 7.3).

The same pattern appears in the buffer_sub constructor (size + offset > parent_size) and in buffer_sub::sync (offset + m_offset, then off + sz), both of which are reachable from the sub-buffer constructor path where the BO is a shared host/NPU DMA buffer.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
SWSPLAT-30706. Identified by Mythos AI security audit (MYTHOS-RyzenAI-XRT-H1). Parent finding: SWSPLAT-30703.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Rewrote all nine `a + b > limit` checks to the overflow-safe form `a > limit || b > limit - a`. The semantics are identical for valid inputs, but the overflow case now throws rather than silently passing.

Affected sites:
- bo_impl::write         seek > size || sz > size - seek
- bo_impl::read          skip > size || sz > size - skip
- bo_impl::copy          dst/src offset and sz each checked separately
- buffer_unmgd::write    seek > size || sz > size - seek
- buffer_unmgd::read     skip > size || sz > size - skip
- buffer_nodma::valid_or_error  offset > size || sz > size - offset
- buffer_sub constructor off > parent_size || size > parent_size - off
- buffer_sub::sync       split into two guards: offset+m_offset overflow,
                         then off+sz overflow

#### Risks (if any) associated the changes in the commit
Low. The rewritten checks are logically equivalent for all valid inputs. Inputs that previously caused silent heap corruption now throw xrt_core::error(-EINVAL). No change in nominal behaviour.

#### What has been tested and how, request additional testing if necessary
Code review against the SWSPLAT-30706 finding. The AFL++/LibFuzzer harness from the ticket (feed sz/seek as size_t to bo.write) is recommended to confirm the wrap-around is closed.
