### PR TITLE
Update XRT release version

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -414,8 +414,8 @@ if [[ $opt == 1 ]]; then
   if [[ $driver == 1 ]]; then
     unset CC
     unset CXX
-    echo "make -C usr/src/xrt-2.25.0/driver/xocl"
-    make -C usr/src/xrt-2.25.0/driver/xocl
+    echo "make -C usr/src/xrt-2.26.0/driver/xocl"
+    make -C usr/src/xrt-2.26.0/driver/xocl
     if [[ $CPU == "aarch64" ]]; then
 	# I know this is dirty as it messes up the source directory with build artifacts but this is the
 	# quickest way to enable native zocl build in Travis CI environment for aarch64

--- a/src/CMake/settings.cmake
+++ b/src/CMake/settings.cmake
@@ -71,10 +71,11 @@ endif (NOT CMAKE_BUILD_TYPE)
 # vai-6.1 branched at 2.22
 # 2026.1 is 2.23
 # vai_6.2 is 2.24
-# Version adjusted to 2.25 for 2026.2
+# XRT-2.25 is branched at 2.25
+# Version adjusted to 2.26 for 2026.2
 set(XRT_VERSION_RELEASE 202620)
 set(XRT_VERSION_MAJOR 2)
-set(XRT_VERSION_MINOR 25)
+set(XRT_VERSION_MINOR 26)
 
 # Upstream builds cannot set XRT_VERSION_PATCH directory as it is
 # reset by project(xrt).  Instead upstream builds sets


### PR DESCRIPTION
- XRT was branched XRT-2.25 to track RAI1.8
- Update running XRT version to 2.26.x
