### PR TITLE
SWSPLAT-30730 XclBinUtilities::exec() require boost::process

### DIFF
--- a/src/runtime_src/tools/xclbinutil/XclBinUtilities.cxx
+++ b/src/runtime_src/tools/xclbinutil/XclBinUtilities.cxx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2018, 2020-2023 Xilinx, Inc. All rights reserved.
-// Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
 
 #include "XclBinUtilities.h"
 
@@ -15,33 +15,30 @@
 #include <future>
 #include <set>
 
-#if (BOOST_VERSION >= 106400)
+#ifdef _WIN32
+# define _WIN32_WINNT 0x0501
+# pragma warning (disable : 4244) // Addresses Boost conversion Windows build warnings
+#endif
 
-# ifdef _WIN32
-#  define _WIN32_WINNT 0x0501
-#  pragma warning (disable : 4244) // Addresses Boost conversion Windows build warnings
-# endif
-
-# include <boost/asio/io_context.hpp>
-# if (BOOST_VERSION < 108600)
-#  include <boost/process.hpp>
-#  include <boost/process/child.hpp>
-#  include <boost/process/env.hpp>
-#  include <boost/process/search_path.hpp>
-# else
-#  include <boost/process/v1/args.hpp>
-#  include <boost/process/v1/async.hpp>
-#  include <boost/process/v1/child.hpp>
-#  include <boost/process/v1/env.hpp>
-#  include <boost/process/v1/io.hpp>
-#  include <boost/process/v1/search_path.hpp>
-# endif
+#include <boost/asio/io_context.hpp>
+#if (BOOST_VERSION < 108600)
+# include <boost/process.hpp>
+# include <boost/process/child.hpp>
+# include <boost/process/env.hpp>
+# include <boost/process/search_path.hpp>
+#else
+# include <boost/process/v1/args.hpp>
+# include <boost/process/v1/async.hpp>
+# include <boost/process/v1/child.hpp>
+# include <boost/process/v1/env.hpp>
+# include <boost/process/v1/io.hpp>
+# include <boost/process/v1/search_path.hpp>
 #endif
 
 #ifdef _WIN32
-  #include <winsock2.h>
+# include <winsock2.h>
 #else
-  #include <arpa/inet.h>
+# include <arpa/inet.h>
 #endif
 
 namespace XUtil = XclBinUtilities;


### PR DESCRIPTION
#### Problem solved by the commit
Remove `XclBinUtilities::exec()` fallback — `popen()` with concatenated unescaped args

The non-boost::process fallback builds `cmdLine = cmd + " " + join(args," ")` and passes it to `popen()` (= /bin/sh -c). `ElfUtilities::data_mine_PS_kernels()` places the user-supplied `--add-pskernel <path>` directly into args. If xclbinutil is wrapped by a higher-privilege build service that only intends to pass a filename, a path containing `;` or `$()` executes arbitrary commands. (Default builds use boost::process and are unaffected.)

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
SWSPLAT-30730.  Identified by Mythos AI security audit (MYTHOS-RyzenAI-XRT-H1). Parent finding: SWSPLAT-30703.

#### How problem was solved, alternative solutions (if any) and why they were rejected
While boost::process should not be used, the easiest fix here is for xclbinutil to require boost::process removing the `popen()` fallback entirely.

#### Risks (if any) associated the changes in the commit
None, all supported platforms already used boost::process.  The fix in this PR just makes that explicit.
