### PR TITLE
SWSPLAT-30723 fix device-supplied num_uc indexes uc_info[] with no size check

### DIFF
--- a/src/runtime_src/core/tools/xbutil2/ContextHealth/OO_ContextHealth.cpp
+++ b/src/runtime_src/core/tools/xbutil2/ContextHealth/OO_ContextHealth.cpp
@@ -243,7 +243,7 @@ generate_npu3_report(const xrt_core::device* dev,
         // Clamp num_uc to the entries that actually fit in the buffer to guard
         // against a compromised/buggy firmware returning an inflated count (SWSPLAT-30723).
         const auto* uc_start = reinterpret_cast<const uint8_t*>(aie4_data.uc_info);
-        const size_t uc_base_offset = static_cast<size_t>(uc_start - raw.data());
+        const auto  uc_base_offset = static_cast<size_t>(uc_start - reinterpret_cast<const uint8_t*>(raw.data()));
         const size_t avail_uc = (uc_base_offset < raw.size())
           ? (raw.size() - uc_base_offset) / sizeof(ert_uc_health_info)
           : 0;

--- a/src/runtime_src/core/tools/xbutil2/ContextHealth/OO_ContextHealth.cpp
+++ b/src/runtime_src/core/tools/xbutil2/ContextHealth/OO_ContextHealth.cpp
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
 
-// ------ I N C L U D E   F I L E S -------------------------------------------
-// Local - Include Files
 #include "OO_ContextHealth.h"
 #include "tools/common/XBUtilitiesCore.h"
 #include "tools/common/XBUtilities.h"
@@ -12,15 +10,16 @@
 #include "core/common/query_requests.h"
 #include "core/common/smi/smi.h"
 
-// 3rd Party Library - Include Files
 #include <boost/program_options.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/format.hpp>
+
 #include <algorithm>
-#include <sstream>
-#include <vector>
+#include <cstddef>
 #include <map>
 #include <memory>
+#include <sstream>
+#include <vector>
 
 namespace po = boost::program_options;
 using context_health_info = xrt_core::query::context_health_info;
@@ -59,9 +58,16 @@ parse_values(const std::string& input)
   std::string token;
   
   while (std::getline(ss, token, ',')) {
-    // Trim whitespace
-    token.erase(0, token.find_first_not_of(" \t"));
-    token.erase(token.find_last_not_of(" \t") + 1);
+    // Trim leading whitespace
+    auto first = token.find_first_not_of(" \t");
+    if (first == std::string::npos)
+      continue;
+
+    token.erase(0, first);
+    // Trim trailing whitespace
+    auto last = token.find_last_not_of(" \t");
+    if (last != std::string::npos)
+      token.erase(last + 1);
     
     if (!token.empty()) {
       try {
@@ -148,6 +154,9 @@ generate_strx_report(const xrt_core::device* dev,
 
       // Add data rows for this PID
       for (const auto& context : contexts) {
+        if (context.health_data_raw.size() < sizeof(ert_ctx_health_data_v1))
+          throw std::runtime_error("health_data_raw too small for ert_ctx_health_data_v1");
+        
         const auto* health = reinterpret_cast<const ert_ctx_health_data_v1*>(context.health_data_raw.data());
         const std::vector<std::string> entry_data = {
           (boost::format("%d")   % context.ctx_id).str(),
@@ -224,16 +233,30 @@ generate_npu3_report(const xrt_core::device* dev,
       // Add data rows for this PID - NPU3 specific fields using AIE4 structure
       for (const auto& context : contexts) {
         // NPU3 uses AIE4 structure which has per-microcontroller data
-        const auto* health = reinterpret_cast<const ert_ctx_health_data_v1*>(context.health_data_raw.data());
-        const auto& aie4_data = health->aie4;
+        const auto& raw = context.health_data_raw;
+        if (raw.size() < sizeof(ert_ctx_health_data_v1))
+          throw std::runtime_error("health_data_raw too small for ert_ctx_health_data_v1");
         
-        if (aie4_data.num_uc == 0) {
+        const auto* health = reinterpret_cast<const ert_ctx_health_data_v1*>(raw.data());
+        const auto& aie4_data = health->aie4;
+
+        // Clamp num_uc to the entries that actually fit in the buffer to guard
+        // against a compromised/buggy firmware returning an inflated count (SWSPLAT-30723).
+        const auto* uc_start = reinterpret_cast<const uint8_t*>(aie4_data.uc_info);
+        const size_t uc_base_offset = static_cast<size_t>(uc_start - raw.data());
+        const size_t avail_uc = (uc_base_offset < raw.size())
+          ? (raw.size() - uc_base_offset) / sizeof(ert_uc_health_info)
+          : 0;
+        const uint32_t num_uc = static_cast<uint32_t>(
+          std::min<size_t>(aie4_data.num_uc, avail_uc));
+
+        if (num_uc == 0) {
           // No microcontroller data available
           const std::vector<std::string> entry_data = {
             (boost::format("%d") % context.ctx_id).str(),
             "No uC data",
             "N/A",
-            "N/A", 
+            "N/A",
             "N/A",
             "N/A",
             (boost::format("0x%x") % aie4_data.ctx_state).str()
@@ -241,7 +264,7 @@ generate_npu3_report(const xrt_core::device* dev,
           context_table.addEntry(entry_data);
         } else {
           // Display data for each microcontroller
-          for (uint32_t i = 0; i < aie4_data.num_uc; ++i) {
+          for (uint32_t i = 0; i < num_uc; ++i) {
             const auto& uc = aie4_data.uc_info[i];
             const std::vector<std::string> entry_data = {
               (boost::format("%d.%d") % context.ctx_id % uc.uc_idx).str(),  // Context.uC format


### PR DESCRIPTION
#### Problem solved by the commit
health_data_raw is a raw byte vector returned by the NPU driver and is reinterpret_cast to ert_ctx_health_data_v1 with no size() >= sizeof(struct) check. The NPU3 path then iterates for (i = 0; i < aie4_data.num_uc; ++i) where num_uc comes from the same device blob. A compromised or buggy NPU firmware can set num_uc large, causing the host process to read adjacent heap memory and print it to stdout (info-leak) or crash (CWE-125).

Additional issues found during review:
- generate_strx_report(): same missing sizeof check before reinterpret_cast on the aie2 path.
- parse_values(): find_last_not_of(" \t") returning npos on an all-whitespace token caused npos+1 == 0, so erase(0) silently cleared the token rather than skipping it via the empty-string guard below.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered 
SWSPLAT-30723 (CWE-125, CVSS 5.1). Discovered by Mythos AI security audit (MYTHOS-RyzenAI-XRT-M4).

#### How problem was solved, alternative solutions (if any) and why they were rejected
- Both reinterpret_cast sites: throw if health_data_raw.size() < sizeof(ert_ctx_health_data_v1) before dereferencing; exception is caught by the surrounding try/catch and reported as an error string.
- num_uc clamp: compute avail_uc at runtime from the actual pointer distance (raw.data() → aie4_data.uc_info) divided by sizeof(ert_uc_health_info), which is correct regardless of union/flexible-array-member layout. Loop iterates over std::min(aie4_data.num_uc, avail_uc).
- parse_values(): check find_first_not_of for npos first (continue skips all-whitespace tokens); guard trailing trim with explicit npos check.

#### Risks (if any) associated the changes in the commit 
Low — the size guard throws inside an existing try/catch that already converts exceptions to error strings in the output. Behavior for valid firmware data is unchanged.

#### What has been tested and how, request additional testing if necessary 
Code inspection. Recommend testing with a mock health_data_raw buffer shorter than sizeof(ert_ctx_health_data_v1) and with num_uc set larger than entries that fit in the buffer.
